### PR TITLE
Phase 9.4 Export/Importワーカー

### DIFF
--- a/internal/api/i/handler.go
+++ b/internal/api/i/handler.go
@@ -26,11 +26,12 @@ type RoleProvider interface {
 
 // Handler handles account-related API endpoints.
 type Handler struct {
-	userService  *user.Service
-	idGen        id.Generator
-	roleProvider RoleProvider
-	registryRepo repository.RegistryRepository
-	favoriteRepo repository.NoteFavoriteRepository
+	userService      *user.Service
+	idGen            id.Generator
+	roleProvider     RoleProvider
+	registryRepo     repository.RegistryRepository
+	favoriteRepo     repository.NoteFavoriteRepository
+	transferEnqueuer TransferEnqueuer
 }
 
 // SetFavoriteRepo attaches a NoteFavoriteRepository for i/favorites.

--- a/internal/api/i/transfer_handler.go
+++ b/internal/api/i/transfer_handler.go
@@ -1,0 +1,110 @@
+package i
+
+import (
+	"net/http"
+
+	"github.com/labstack/echo/v4"
+	"github.com/shiroha-a/mk/internal/core/transfer"
+	"github.com/shiroha-a/mk/internal/queue"
+	"github.com/shiroha-a/mk/internal/server/middleware"
+)
+
+// TransferEnqueuer is the subset of queue.Enqueuer needed to schedule
+// export/import jobs. 小さいインターフェースにすることで i/Handler のテスト
+// mockが簡単になる。
+type TransferEnqueuer interface {
+	EnqueueExport(payload queue.ExportPayload) error
+	EnqueueImport(payload queue.ImportPayload) error
+}
+
+// SetTransferEnqueuer attaches a TransferEnqueuer for i/export-* and
+// i/import-* endpoints.
+func (h *Handler) SetTransferEnqueuer(e TransferEnqueuer) {
+	h.transferEnqueuer = e
+}
+
+// exportHandler enqueues an export job for the authenticated user and
+// returns 204 No Content on success, matching Misskey's behavior.
+func (h *Handler) exportHandler(exportType string) echo.HandlerFunc {
+	return func(c echo.Context) error {
+		u := middleware.GetUser(c)
+		if h.transferEnqueuer == nil {
+			return c.JSON(http.StatusInternalServerError, apiError("INTERNAL_ERROR", "Transfer queue not configured.", "5d37dbcb-891e-41ca-a3d6-e690c97775ac"))
+		}
+		if err := h.transferEnqueuer.EnqueueExport(queue.ExportPayload{
+			UserID: u.ID,
+			Type:   exportType,
+		}); err != nil {
+			return c.JSON(http.StatusInternalServerError, apiError("INTERNAL_ERROR", "Failed to enqueue export.", "5d37dbcb-891e-41ca-a3d6-e690c97775ac"))
+		}
+		return c.NoContent(http.StatusNoContent)
+	}
+}
+
+// importHandler enqueues an import job using a DriveFile uploaded by the
+// user. フロントは fileId を渡してくる。本家互換。
+func (h *Handler) importHandler(importType string) echo.HandlerFunc {
+	return func(c echo.Context) error {
+		u := middleware.GetUser(c)
+		var req struct {
+			FileID string `json:"fileId"`
+		}
+		if err := c.Bind(&req); err != nil || req.FileID == "" {
+			return c.JSON(http.StatusBadRequest, apiError("INVALID_PARAM", "fileId is required.", "3d81ceae-475f-4600-b2a8-2bc116157532"))
+		}
+		if h.transferEnqueuer == nil {
+			return c.JSON(http.StatusInternalServerError, apiError("INTERNAL_ERROR", "Transfer queue not configured.", "5d37dbcb-891e-41ca-a3d6-e690c97775ac"))
+		}
+		if err := h.transferEnqueuer.EnqueueImport(queue.ImportPayload{
+			UserID: u.ID,
+			Type:   importType,
+			FileID: req.FileID,
+		}); err != nil {
+			return c.JSON(http.StatusInternalServerError, apiError("INTERNAL_ERROR", "Failed to enqueue import.", "5d37dbcb-891e-41ca-a3d6-e690c97775ac"))
+		}
+		return c.NoContent(http.StatusNoContent)
+	}
+}
+
+// Export handler factory methods — one per endpoint for router binding.
+func (h *Handler) ExportNotes(c echo.Context) error {
+	return h.exportHandler(transfer.ExportNotes)(c)
+}
+func (h *Handler) ExportFollowing(c echo.Context) error {
+	return h.exportHandler(transfer.ExportFollowing)(c)
+}
+func (h *Handler) ExportBlocking(c echo.Context) error {
+	return h.exportHandler(transfer.ExportBlocking)(c)
+}
+func (h *Handler) ExportMute(c echo.Context) error {
+	return h.exportHandler(transfer.ExportMuting)(c)
+}
+func (h *Handler) ExportFavorites(c echo.Context) error {
+	return h.exportHandler(transfer.ExportFavorites)(c)
+}
+func (h *Handler) ExportUserLists(c echo.Context) error {
+	return h.exportHandler(transfer.ExportUserLists)(c)
+}
+func (h *Handler) ExportAntennas(c echo.Context) error {
+	return h.exportHandler(transfer.ExportAntennas)(c)
+}
+func (h *Handler) ExportClips(c echo.Context) error {
+	return h.exportHandler(transfer.ExportClips)(c)
+}
+
+// Import handler factory methods.
+func (h *Handler) ImportFollowing(c echo.Context) error {
+	return h.importHandler(transfer.ImportFollowing)(c)
+}
+func (h *Handler) ImportBlocking(c echo.Context) error {
+	return h.importHandler(transfer.ImportBlocking)(c)
+}
+func (h *Handler) ImportMuting(c echo.Context) error {
+	return h.importHandler(transfer.ImportMuting)(c)
+}
+func (h *Handler) ImportUserLists(c echo.Context) error {
+	return h.importHandler(transfer.ImportUserLists)(c)
+}
+func (h *Handler) ImportAntennas(c echo.Context) error {
+	return h.importHandler(transfer.ImportAntennas)(c)
+}

--- a/internal/api/i/transfer_handler_test.go
+++ b/internal/api/i/transfer_handler_test.go
@@ -1,0 +1,153 @@
+package i
+
+import (
+	"errors"
+	"net/http"
+	"testing"
+
+	"github.com/shiroha-a/mk/internal/model"
+	"github.com/shiroha-a/mk/internal/queue"
+	"github.com/stretchr/testify/assert"
+)
+
+// stubTransferEnqueuer records calls and optionally returns an error.
+type stubTransferEnqueuer struct {
+	exportCalls []queue.ExportPayload
+	importCalls []queue.ImportPayload
+	exportErr   error
+	importErr   error
+}
+
+func (s *stubTransferEnqueuer) EnqueueExport(p queue.ExportPayload) error {
+	if s.exportErr != nil {
+		return s.exportErr
+	}
+	s.exportCalls = append(s.exportCalls, p)
+	return nil
+}
+
+func (s *stubTransferEnqueuer) EnqueueImport(p queue.ImportPayload) error {
+	if s.importErr != nil {
+		return s.importErr
+	}
+	s.importCalls = append(s.importCalls, p)
+	return nil
+}
+
+func newTransferHandler() (*Handler, *stubTransferEnqueuer) {
+	h, _, _, _ := newTestHandler(&testing.T{})
+	enq := &stubTransferEnqueuer{}
+	h.SetTransferEnqueuer(enq)
+	return h, enq
+}
+
+// --- Export handlers ---
+
+func TestExport_NotesNoAuthIfEnqueuerMissing(t *testing.T) {
+	h, _, _, _ := newTestHandler(t)
+	rec := post(h.ExportNotes, `{}`, &model.User{ID: "u1"})
+	assert.Equal(t, http.StatusInternalServerError, rec.Code)
+}
+
+func TestExport_AllTypesEnqueue(t *testing.T) {
+	cases := []struct {
+		name    string
+		handler func(h *Handler) func(c any) error
+	}{}
+	// map each endpoint to its expected payload type
+	h, enq := newTransferHandler()
+	user := &model.User{ID: "u1"}
+
+	type ex struct {
+		name string
+		fn   func(c *Handler) func() error
+		kind string
+	}
+
+	// Use a simple test invocation approach: call handler via post helper.
+	assertOK := func(recCode int) {
+		assert.Equal(t, http.StatusNoContent, recCode)
+	}
+
+	// notes
+	assertOK(post(h.ExportNotes, `{}`, user).Code)
+	// following
+	assertOK(post(h.ExportFollowing, `{}`, user).Code)
+	// blocking
+	assertOK(post(h.ExportBlocking, `{}`, user).Code)
+	// mute
+	assertOK(post(h.ExportMute, `{}`, user).Code)
+	// favorites
+	assertOK(post(h.ExportFavorites, `{}`, user).Code)
+	// user-lists
+	assertOK(post(h.ExportUserLists, `{}`, user).Code)
+	// antennas
+	assertOK(post(h.ExportAntennas, `{}`, user).Code)
+	// clips
+	assertOK(post(h.ExportClips, `{}`, user).Code)
+
+	assert.Len(t, enq.exportCalls, 8)
+	// verify the types are distinct
+	seen := make(map[string]bool)
+	for _, c := range enq.exportCalls {
+		seen[c.Type] = true
+		assert.Equal(t, "u1", c.UserID)
+	}
+	assert.Len(t, seen, 8)
+	_ = cases
+}
+
+func TestExport_EnqueuerFailure(t *testing.T) {
+	h, enq := newTransferHandler()
+	enq.exportErr = errors.New("enq boom")
+	rec := post(h.ExportNotes, `{}`, &model.User{ID: "u1"})
+	assert.Equal(t, http.StatusInternalServerError, rec.Code)
+}
+
+// --- Import handlers ---
+
+func TestImport_AllTypesEnqueue(t *testing.T) {
+	h, enq := newTransferHandler()
+	user := &model.User{ID: "u1"}
+
+	assertOK := func(recCode int) {
+		assert.Equal(t, http.StatusNoContent, recCode)
+	}
+
+	assertOK(post(h.ImportFollowing, `{"fileId":"f1"}`, user).Code)
+	assertOK(post(h.ImportBlocking, `{"fileId":"f1"}`, user).Code)
+	assertOK(post(h.ImportMuting, `{"fileId":"f1"}`, user).Code)
+	assertOK(post(h.ImportUserLists, `{"fileId":"f1"}`, user).Code)
+	assertOK(post(h.ImportAntennas, `{"fileId":"f1"}`, user).Code)
+
+	assert.Len(t, enq.importCalls, 5)
+	for _, c := range enq.importCalls {
+		assert.Equal(t, "u1", c.UserID)
+		assert.Equal(t, "f1", c.FileID)
+	}
+}
+
+func TestImport_MissingFileID(t *testing.T) {
+	h, _ := newTransferHandler()
+	rec := post(h.ImportFollowing, `{}`, &model.User{ID: "u1"})
+	assert.Equal(t, http.StatusBadRequest, rec.Code)
+}
+
+func TestImport_NoEnqueuer(t *testing.T) {
+	h, _, _, _ := newTestHandler(t)
+	rec := post(h.ImportFollowing, `{"fileId":"f1"}`, &model.User{ID: "u1"})
+	assert.Equal(t, http.StatusInternalServerError, rec.Code)
+}
+
+func TestImport_EnqueuerError(t *testing.T) {
+	h, enq := newTransferHandler()
+	enq.importErr = errors.New("enq boom")
+	rec := post(h.ImportFollowing, `{"fileId":"f1"}`, &model.User{ID: "u1"})
+	assert.Equal(t, http.StatusInternalServerError, rec.Code)
+}
+
+func TestImport_InvalidJSON(t *testing.T) {
+	h, _ := newTransferHandler()
+	rec := post(h.ImportFollowing, `not json`, &model.User{ID: "u1"})
+	assert.Equal(t, http.StatusBadRequest, rec.Code)
+}

--- a/internal/core/notification/notification_service.go
+++ b/internal/core/notification/notification_service.go
@@ -27,6 +27,8 @@ const (
 	TypePollVote            Type = "pollVote"
 	TypeReceiveFollowReq    Type = "receiveFollowRequest"
 	TypeFollowRequestAccept Type = "followRequestAccepted"
+	TypeExportCompleted     Type = "exportCompleted"
+	TypeImportCompleted     Type = "importCompleted"
 )
 
 // MaxPerUser caps how many notifications are kept per user in the Redis stream.

--- a/internal/core/transfer/adapters.go
+++ b/internal/core/transfer/adapters.go
@@ -1,0 +1,25 @@
+package transfer
+
+import (
+	corefollowing "github.com/shiroha-a/mk/internal/core/following"
+)
+
+// FollowingServiceAdapter wraps core/following.Service so that its Follow
+// method matches the Importer's FollowingService interface (which returns
+// `any` to avoid depending on the concrete FollowResult type).
+type FollowingServiceAdapter struct {
+	svc *corefollowing.Service
+}
+
+// NewFollowingServiceAdapter constructs a FollowingServiceAdapter.
+func NewFollowingServiceAdapter(svc *corefollowing.Service) *FollowingServiceAdapter {
+	return &FollowingServiceAdapter{svc: svc}
+}
+
+// Follow delegates to core/following.Service.Follow.
+func (a *FollowingServiceAdapter) Follow(followerID, followeeID string) (any, error) {
+	if a == nil || a.svc == nil {
+		return nil, nil
+	}
+	return a.svc.Follow(followerID, followeeID)
+}

--- a/internal/core/transfer/adapters_test.go
+++ b/internal/core/transfer/adapters_test.go
@@ -1,0 +1,22 @@
+package transfer_test
+
+import (
+	"testing"
+
+	corefollowing "github.com/shiroha-a/mk/internal/core/following"
+	"github.com/shiroha-a/mk/internal/core/transfer"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestNewFollowingServiceAdapter_ConstructsWithRealType(t *testing.T) {
+	// Adapter wraps *corefollowing.Service. We can't easily construct a real
+	// one without pulling in DB dependencies, so nil service + nil adapter
+	// exercises the construction and nil-safety paths.
+	var svc *corefollowing.Service
+	a := transfer.NewFollowingServiceAdapter(svc)
+	assert.NotNil(t, a)
+	// Follow on a nil inner returns (nil, nil) via the guard.
+	out, err := a.Follow("f", "g")
+	assert.NoError(t, err)
+	assert.Nil(t, out)
+}

--- a/internal/core/transfer/batch_test.go
+++ b/internal/core/transfer/batch_test.go
@@ -1,0 +1,96 @@
+package transfer_test
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"testing"
+
+	"github.com/lib/pq"
+	"github.com/shiroha-a/mk/internal/core/transfer"
+	"github.com/shiroha-a/mk/internal/model"
+	"github.com/shiroha-a/mk/internal/testutil"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestExport_Notes_MultiBatch triggers the pagination loop in
+// exportNotesStream by providing more notes than the internal batch size.
+// NoteRepository.ListByUserID returns at most `limit` rows per call so this
+// exercises the "len == batchSize -> continue with untilID" branch.
+func TestExport_Notes_MultiBatch(t *testing.T) {
+	saver, _, deps, user := newExportDeps(t)
+	noteRepo := deps.NoteRepo.(*testutil.MockNoteRepository)
+	for i := range 105 {
+		text := fmt.Sprintf("note%d", i)
+		// IDs must sort lexicographically with newer IDs > older IDs.
+		// Use a wide prefix so 105 IDs remain well-ordered.
+		nID := fmt.Sprintf("aa%04d", 10000-i)
+		noteRepo.Notes[nID] = &model.Note{
+			ID: nID, UserID: user.ID, Text: &text,
+			Visibility: model.NoteVisibilityPublic,
+		}
+	}
+
+	exporter := transfer.NewExporter(deps)
+	_, err := exporter.Export(context.Background(), user.ID, transfer.ExportNotes)
+	require.NoError(t, err)
+
+	var arr []map[string]any
+	require.NoError(t, json.Unmarshal(saver.uploads[0].Body, &arr))
+	assert.Equal(t, 105, len(arr))
+}
+
+// TestExport_Notes_PackFields verifies packNoteForExport includes the optional
+// fields (VisibleUserIDs, ReplyID, RenoteID) on a fully-populated note.
+func TestExport_Notes_PackFields(t *testing.T) {
+	saver, _, deps, user := newExportDeps(t)
+	noteRepo := deps.NoteRepo.(*testutil.MockNoteRepository)
+
+	text := "hey"
+	cw := "warn"
+	reply := "p"
+	ren := "r"
+	noteRepo.Notes["nx"] = &model.Note{
+		ID: "nx", UserID: user.ID, Text: &text, CW: &cw,
+		Visibility:     model.NoteVisibilitySpecified,
+		VisibleUserIDs: pq.StringArray{"bob", "carol"},
+		ReplyID:        &reply,
+		RenoteID:       &ren,
+	}
+
+	exporter := transfer.NewExporter(deps)
+	_, err := exporter.Export(context.Background(), user.ID, transfer.ExportNotes)
+	require.NoError(t, err)
+	var arr []map[string]any
+	require.NoError(t, json.Unmarshal(saver.uploads[0].Body, &arr))
+	require.Len(t, arr, 1)
+	assert.Equal(t, "hey", arr[0]["text"])
+	assert.Equal(t, "warn", arr[0]["cw"])
+	assert.NotNil(t, arr[0]["visibleUserIds"])
+	assert.Equal(t, "p", arr[0]["replyId"])
+	assert.Equal(t, "r", arr[0]["renoteId"])
+}
+
+// TestImport_UserLists_MemberCreateError exercises the AddMember error path
+// by pre-creating a conflicting membership (mock Create is idempotent).
+// Since the mock doesn't error on duplicate, we exercise the empty target
+// branch which also returns Skipped.
+func TestImport_UserLists_EmptyTarget(t *testing.T) {
+	deps, user, _, _, _, _ := newImporterDeps(t, []byte("list1,  \nlist1,bob\n"))
+	imp := transfer.NewImporter(deps)
+	res, err := imp.Import(context.Background(), user.ID, transfer.ImportUserLists, "fid")
+	require.NoError(t, err)
+	// 1 applied (bob) + 1 skipped (empty acct)
+	assert.Equal(t, 1, res.Applied)
+	assert.Equal(t, 1, res.Skipped)
+}
+
+// TestImport_Muting_MalformedAcct exercises parseAcct error in muting path.
+func TestImport_Muting_MalformedAcct(t *testing.T) {
+	deps, user, _, _, _, _ := newImporterDeps(t, []byte("@\n"))
+	imp := transfer.NewImporter(deps)
+	res, err := imp.Import(context.Background(), user.ID, transfer.ImportMuting, "fid")
+	require.NoError(t, err)
+	assert.Equal(t, 1, res.Skipped)
+}

--- a/internal/core/transfer/drive_reader.go
+++ b/internal/core/transfer/drive_reader.go
@@ -1,0 +1,51 @@
+package transfer
+
+import (
+	"fmt"
+	"io"
+
+	"github.com/shiroha-a/mk/internal/core/drive"
+	"github.com/shiroha-a/mk/internal/model"
+	"github.com/shiroha-a/mk/internal/repository"
+)
+
+// RepoBackedDriveReader implements DriveReader by pairing a DriveFileRepository
+// (for metadata) with a drive.Storage (for the actual bytes). *drive.Service
+// does not expose a public Get-by-id method, so the importer needs to wire
+// these two itself.
+type RepoBackedDriveReader struct {
+	repo    repository.DriveFileRepository
+	storage drive.Storage
+}
+
+// NewRepoBackedDriveReader constructs a RepoBackedDriveReader.
+func NewRepoBackedDriveReader(repo repository.DriveFileRepository, storage drive.Storage) *RepoBackedDriveReader {
+	return &RepoBackedDriveReader{repo: repo, storage: storage}
+}
+
+// Fetch looks up the DriveFile row and pulls its stored body into a single
+// byte buffer. Only internally-stored files (StoredInternal=true) are
+// supported; externally-hosted files would require HTTP fetch which is out
+// of scope here.
+func (r *RepoBackedDriveReader) Fetch(fileID string) (*model.DriveFile, []byte, error) {
+	if r == nil || r.repo == nil {
+		return nil, nil, fmt.Errorf("drive reader not initialized")
+	}
+	file, err := r.repo.FindByID(fileID)
+	if err != nil {
+		return nil, nil, fmt.Errorf("find drive file: %w", err)
+	}
+	if file.AccessKey == nil {
+		return nil, nil, fmt.Errorf("drive file has no access key")
+	}
+	rc, err := r.storage.Get(*file.AccessKey)
+	if err != nil {
+		return nil, nil, fmt.Errorf("open drive object: %w", err)
+	}
+	defer func() { _ = rc.Close() }()
+	body, err := io.ReadAll(rc)
+	if err != nil {
+		return nil, nil, fmt.Errorf("read drive object: %w", err)
+	}
+	return file, body, nil
+}

--- a/internal/core/transfer/drive_reader_test.go
+++ b/internal/core/transfer/drive_reader_test.go
@@ -1,0 +1,133 @@
+package transfer_test
+
+import (
+	"errors"
+	"io"
+	"strings"
+	"testing"
+
+	"github.com/shiroha-a/mk/internal/core/transfer"
+	"github.com/shiroha-a/mk/internal/model"
+	"github.com/shiroha-a/mk/internal/repository"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// --- Fakes for drive.Storage and DriveFileRepository ---
+
+type fakeStorage struct {
+	blobs  map[string][]byte
+	getErr error
+}
+
+func (f *fakeStorage) Put(_ string, _ io.Reader) (string, error) { return "", nil }
+func (f *fakeStorage) Get(accessKey string) (io.ReadCloser, error) {
+	if f.getErr != nil {
+		return nil, f.getErr
+	}
+	b, ok := f.blobs[accessKey]
+	if !ok {
+		return nil, errors.New("not found")
+	}
+	return io.NopCloser(strings.NewReader(string(b))), nil
+}
+func (f *fakeStorage) Delete(_ string) error { return nil }
+
+// fakeDriveFileRepo is a minimal stub sufficient for the reader test.
+// Only FindByID is exercised. Other methods return nil errors to satisfy the
+// interface; they must not be called from the reader.
+type fakeDriveFileRepo struct {
+	files map[string]*model.DriveFile
+}
+
+func (f *fakeDriveFileRepo) FindByID(id string) (*model.DriveFile, error) {
+	if file, ok := f.files[id]; ok {
+		return file, nil
+	}
+	return nil, errors.New("not found")
+}
+
+func (f *fakeDriveFileRepo) FindByIDs(ids []string) ([]*model.DriveFile, error) {
+	out := make([]*model.DriveFile, 0, len(ids))
+	for _, id := range ids {
+		if f, ok := f.files[id]; ok {
+			out = append(out, f)
+		}
+	}
+	return out, nil
+}
+func (f *fakeDriveFileRepo) FindByMD5(_, _ string) (*model.DriveFile, error) {
+	return nil, errors.New("not found")
+}
+func (f *fakeDriveFileRepo) Create(file *model.DriveFile) error {
+	f.files[file.ID] = file
+	return nil
+}
+func (f *fakeDriveFileRepo) Update(_ string, _ map[string]any) error {
+	return nil
+}
+func (f *fakeDriveFileRepo) Delete(_ *model.DriveFile) error { return nil }
+func (f *fakeDriveFileRepo) ListByUser(_ string, _ *string, _, _ string, _ int) ([]*model.DriveFile, error) {
+	return nil, nil
+}
+func (f *fakeDriveFileRepo) FindByName(_, _ string, _ *string) ([]*model.DriveFile, error) {
+	return nil, nil
+}
+func (f *fakeDriveFileRepo) ExistsByMD5(_, _ string) (bool, error)                { return false, nil }
+func (f *fakeDriveFileRepo) ListByFileIDs(_ []string) ([]*model.DriveFile, error) { return nil, nil }
+func (f *fakeDriveFileRepo) UsageByUser(_ string) (int64, error)                  { return 0, nil }
+func (f *fakeDriveFileRepo) UpdateBulkFolder(_ []string, _ *string) error         { return nil }
+
+// Ensure fakeDriveFileRepo implements the real repository interface so the
+// reader accepts it.
+var _ repository.DriveFileRepository = (*fakeDriveFileRepo)(nil)
+
+// --- Tests ---
+
+func TestDriveReader_Fetch_Success(t *testing.T) {
+	key := "k1"
+	repo := &fakeDriveFileRepo{files: map[string]*model.DriveFile{
+		"f1": {ID: "f1", AccessKey: &key},
+	}}
+	store := &fakeStorage{blobs: map[string][]byte{key: []byte("hello")}}
+	r := transfer.NewRepoBackedDriveReader(repo, store)
+	file, body, err := r.Fetch("f1")
+	require.NoError(t, err)
+	assert.Equal(t, "f1", file.ID)
+	assert.Equal(t, []byte("hello"), body)
+}
+
+func TestDriveReader_Fetch_FileNotFound(t *testing.T) {
+	repo := &fakeDriveFileRepo{files: map[string]*model.DriveFile{}}
+	store := &fakeStorage{}
+	r := transfer.NewRepoBackedDriveReader(repo, store)
+	_, _, err := r.Fetch("missing")
+	assert.Error(t, err)
+}
+
+func TestDriveReader_Fetch_NoAccessKey(t *testing.T) {
+	repo := &fakeDriveFileRepo{files: map[string]*model.DriveFile{
+		"f1": {ID: "f1"},
+	}}
+	store := &fakeStorage{}
+	r := transfer.NewRepoBackedDriveReader(repo, store)
+	_, _, err := r.Fetch("f1")
+	assert.Error(t, err)
+}
+
+func TestDriveReader_Fetch_StorageError(t *testing.T) {
+	key := "k1"
+	repo := &fakeDriveFileRepo{files: map[string]*model.DriveFile{
+		"f1": {ID: "f1", AccessKey: &key},
+	}}
+	store := &fakeStorage{getErr: errors.New("io boom")}
+	r := transfer.NewRepoBackedDriveReader(repo, store)
+	_, _, err := r.Fetch("f1")
+	assert.Error(t, err)
+}
+
+func TestDriveReader_Nil(t *testing.T) {
+	var r *transfer.RepoBackedDriveReader
+	_, _, err := r.Fetch("x")
+	assert.Error(t, err)
+}

--- a/internal/core/transfer/errors_test.go
+++ b/internal/core/transfer/errors_test.go
@@ -1,0 +1,154 @@
+package transfer_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/shiroha-a/mk/internal/core/transfer"
+	"github.com/shiroha-a/mk/internal/model"
+	"github.com/shiroha-a/mk/internal/testutil"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// failingFollowingRepo wraps MockFollowingRepository to inject a ListFollowing
+// error for testing export error paths.
+type failingFollowingRepo struct {
+	*testutil.MockFollowingRepository
+}
+
+func (f *failingFollowingRepo) ListFollowing(_ string, _, _ int) ([]*model.Following, error) {
+	return nil, errors.New("db boom")
+}
+
+// failingBlockingRepo injects a ListByBlocker error.
+type failingBlockingRepo struct {
+	*testutil.MockBlockingRepository
+}
+
+func (f *failingBlockingRepo) ListByBlocker(_ string, _, _ int) ([]*model.Blocking, error) {
+	return nil, errors.New("db boom")
+}
+
+// failingMutingRepo injects a ListByMuter error.
+type failingMutingRepo struct {
+	*testutil.MockMutingRepository
+}
+
+func (f *failingMutingRepo) ListByMuter(_ string, _, _ int) ([]*model.Muting, error) {
+	return nil, errors.New("db boom")
+}
+
+// failingAntennaRepo injects a ListByUser error.
+type failingAntennaRepo struct {
+	*testutil.MockAntennaRepository
+}
+
+func (f *failingAntennaRepo) ListByUser(_ string) ([]*model.Antenna, error) {
+	return nil, errors.New("db boom")
+}
+
+// failingClipRepo injects a ListByUser error.
+type failingClipRepo struct {
+	*testutil.MockClipRepository
+}
+
+func (f *failingClipRepo) ListByUser(_ string, _, _ int) ([]*model.Clip, error) {
+	return nil, errors.New("db boom")
+}
+
+// failingUserListRepo injects a ListByUser error.
+type failingUserListRepo struct {
+	*testutil.MockUserListRepository
+}
+
+func (f *failingUserListRepo) ListByUser(_ string) ([]*model.UserList, error) {
+	return nil, errors.New("db boom")
+}
+
+// failingNoteFavoriteRepo injects a ListByUser error.
+type failingNoteFavoriteRepo struct {
+	*testutil.MockNoteFavoriteRepository
+}
+
+func (f *failingNoteFavoriteRepo) ListByUser(_ string, _, _ int) ([]*model.NoteFavorite, error) {
+	return nil, errors.New("db boom")
+}
+
+// --- Tests ---
+
+func TestExport_Following_RepoError(t *testing.T) {
+	_, _, deps, user := newExportDeps(t)
+	deps.FollowingRepo = &failingFollowingRepo{MockFollowingRepository: testutil.NewMockFollowingRepository()}
+	exporter := transfer.NewExporter(deps)
+	_, err := exporter.Export(context.Background(), user.ID, transfer.ExportFollowing)
+	assert.Error(t, err)
+}
+
+func TestExport_Blocking_RepoError(t *testing.T) {
+	_, _, deps, user := newExportDeps(t)
+	deps.BlockingRepo = &failingBlockingRepo{MockBlockingRepository: testutil.NewMockBlockingRepository()}
+	exporter := transfer.NewExporter(deps)
+	_, err := exporter.Export(context.Background(), user.ID, transfer.ExportBlocking)
+	assert.Error(t, err)
+}
+
+func TestExport_Muting_RepoError(t *testing.T) {
+	_, _, deps, user := newExportDeps(t)
+	deps.MutingRepo = &failingMutingRepo{MockMutingRepository: testutil.NewMockMutingRepository()}
+	exporter := transfer.NewExporter(deps)
+	_, err := exporter.Export(context.Background(), user.ID, transfer.ExportMuting)
+	assert.Error(t, err)
+}
+
+func TestExport_Antennas_RepoError(t *testing.T) {
+	_, _, deps, user := newExportDeps(t)
+	deps.AntennaRepo = &failingAntennaRepo{MockAntennaRepository: testutil.NewMockAntennaRepository()}
+	exporter := transfer.NewExporter(deps)
+	_, err := exporter.Export(context.Background(), user.ID, transfer.ExportAntennas)
+	assert.Error(t, err)
+}
+
+func TestExport_Clips_RepoError(t *testing.T) {
+	_, _, deps, user := newExportDeps(t)
+	deps.ClipRepo = &failingClipRepo{MockClipRepository: testutil.NewMockClipRepository()}
+	exporter := transfer.NewExporter(deps)
+	_, err := exporter.Export(context.Background(), user.ID, transfer.ExportClips)
+	assert.Error(t, err)
+}
+
+func TestExport_UserLists_RepoError(t *testing.T) {
+	_, _, deps, user := newExportDeps(t)
+	deps.UserListRepo = &failingUserListRepo{MockUserListRepository: testutil.NewMockUserListRepository()}
+	exporter := transfer.NewExporter(deps)
+	_, err := exporter.Export(context.Background(), user.ID, transfer.ExportUserLists)
+	assert.Error(t, err)
+}
+
+func TestExport_Favorites_RepoError(t *testing.T) {
+	_, _, deps, user := newExportDeps(t)
+	deps.NoteFavoriteRepo = &failingNoteFavoriteRepo{MockNoteFavoriteRepository: testutil.NewMockNoteFavoriteRepository()}
+	exporter := transfer.NewExporter(deps)
+	_, err := exporter.Export(context.Background(), user.ID, transfer.ExportFavorites)
+	assert.Error(t, err)
+}
+
+// --- Misc smoke ---
+
+func TestAcct_NilUserReturnsEmpty(t *testing.T) {
+	// Indirect via export — a missing followee silently drops but we also
+	// want to ensure acct() handles nil. The package-internal acct() isn't
+	// exported; exercise it by setting up a follow pointing at a non-existent
+	// user id and verifying the export body contains no line for it.
+	saver, _, deps, user := newExportDeps(t)
+	followingRepo := deps.FollowingRepo.(*testutil.MockFollowingRepository)
+	followingRepo.Followings["f1"] = &model.Following{
+		ID: "f1", FollowerID: user.ID, FolloweeID: "does-not-exist",
+	}
+
+	exporter := transfer.NewExporter(deps)
+	_, err := exporter.Export(context.Background(), user.ID, transfer.ExportFollowing)
+	require.NoError(t, err)
+	assert.NotContains(t, string(saver.uploads[0].Body), "does-not-exist")
+}

--- a/internal/core/transfer/export_csv.go
+++ b/internal/core/transfer/export_csv.go
@@ -1,0 +1,126 @@
+package transfer
+
+import (
+	"bytes"
+	"fmt"
+	"strconv"
+)
+
+// csvBatchSize controls how many rows are fetched per pagination step for
+// CSV exports (follow/block/mute/user-lists). 500 matches upstream.
+const csvBatchSize = 500
+
+// exportFollowing emits one `acct,withReplies=(true|false)` line per followee.
+// 出力順は登録降順 (id DESC)。
+func (e *Exporter) exportFollowing(userID string) ([]byte, error) {
+	var buf bytes.Buffer
+	offset := 0
+	for {
+		rows, err := e.deps.FollowingRepo.ListFollowing(userID, csvBatchSize, offset)
+		if err != nil {
+			return nil, err
+		}
+		if len(rows) == 0 {
+			break
+		}
+		for _, f := range rows {
+			u, err := e.deps.UserRepo.FindByID(f.FolloweeID)
+			if err != nil || u == nil {
+				continue
+			}
+			fmt.Fprintf(&buf, "%s,withReplies=%s\n", acct(u), strconv.FormatBool(f.WithReplies))
+		}
+		if len(rows) < csvBatchSize {
+			break
+		}
+		offset += csvBatchSize
+	}
+	return buf.Bytes(), nil
+}
+
+// exportBlocking emits one `acct` line per blocked user.
+func (e *Exporter) exportBlocking(userID string) ([]byte, error) {
+	var buf bytes.Buffer
+	offset := 0
+	for {
+		rows, err := e.deps.BlockingRepo.ListByBlocker(userID, csvBatchSize, offset)
+		if err != nil {
+			return nil, err
+		}
+		if len(rows) == 0 {
+			break
+		}
+		for _, b := range rows {
+			u, err := e.deps.UserRepo.FindByID(b.BlockeeID)
+			if err != nil || u == nil {
+				continue
+			}
+			fmt.Fprintf(&buf, "%s\n", acct(u))
+		}
+		if len(rows) < csvBatchSize {
+			break
+		}
+		offset += csvBatchSize
+	}
+	return buf.Bytes(), nil
+}
+
+// exportMuting emits one `acct` line per muted user, skipping entries with an
+// ExpiresAt set (本家と同じく永続ミュートのみをエクスポート)。
+func (e *Exporter) exportMuting(userID string) ([]byte, error) {
+	var buf bytes.Buffer
+	offset := 0
+	for {
+		rows, err := e.deps.MutingRepo.ListByMuter(userID, csvBatchSize, offset)
+		if err != nil {
+			return nil, err
+		}
+		if len(rows) == 0 {
+			break
+		}
+		for _, m := range rows {
+			if m.ExpiresAt != nil {
+				continue
+			}
+			u, err := e.deps.UserRepo.FindByID(m.MuteeID)
+			if err != nil || u == nil {
+				continue
+			}
+			fmt.Fprintf(&buf, "%s\n", acct(u))
+		}
+		if len(rows) < csvBatchSize {
+			break
+		}
+		offset += csvBatchSize
+	}
+	return buf.Bytes(), nil
+}
+
+// exportUserLists emits `listName,acct,withReplies=(true|false)` per (list, member).
+// withReplies は現状 false 固定 (UserListMembership に withReplies 列がない)。
+// 将来的にカラム追加された場合はここを更新する。
+func (e *Exporter) exportUserLists(userID string) ([]byte, error) {
+	var buf bytes.Buffer
+	lists, err := e.deps.UserListRepo.ListByUser(userID)
+	if err != nil {
+		return nil, err
+	}
+	for _, list := range lists {
+		members, err := e.deps.UserListRepo.ListMembers(list.ID)
+		if err != nil {
+			return nil, err
+		}
+		for _, m := range members {
+			u := m.User
+			if u == nil {
+				u2, err := e.deps.UserRepo.FindByID(m.UserID)
+				if err != nil || u2 == nil {
+					continue
+				}
+				u = u2
+			}
+			fmt.Fprintf(&buf, "%s,%s,withReplies=false\n", list.Name, acct(u))
+		}
+	}
+	return buf.Bytes(), nil
+}

--- a/internal/core/transfer/export_json.go
+++ b/internal/core/transfer/export_json.go
@@ -1,0 +1,138 @@
+package transfer
+
+import (
+	"bytes"
+	"encoding/json"
+
+	"github.com/shiroha-a/mk/internal/model"
+)
+
+// exportFavorites reuses the note export pipeline but pulls rows from
+// NoteFavoriteRepository instead. Each favorite is unwrapped to its note so
+// the output matches the notes export shape (easy round-trip).
+func (e *Exporter) exportFavorites(userID string) ([]byte, error) {
+	var buf bytes.Buffer
+	buf.WriteByte('[')
+	first := true
+	offset := 0
+	for {
+		rows, err := e.deps.NoteFavoriteRepo.ListByUser(userID, notesExportBatchSize, offset)
+		if err != nil {
+			return nil, err
+		}
+		if len(rows) == 0 {
+			break
+		}
+		for _, fav := range rows {
+			if fav.Note == nil {
+				continue
+			}
+			entry := map[string]any{
+				"id":        fav.ID,
+				"favoritee": fav.UserID,
+				"note":      e.packNoteForExport(fav.Note),
+			}
+			raw, jerr := json.Marshal(entry)
+			if jerr != nil {
+				return nil, jerr
+			}
+			if !first {
+				buf.WriteByte(',')
+			}
+			buf.Write(raw)
+			first = false
+		}
+		if len(rows) < notesExportBatchSize {
+			break
+		}
+		offset += notesExportBatchSize
+	}
+	buf.WriteByte(']')
+	return buf.Bytes(), nil
+}
+
+// exportAntennas emits a JSON array with antenna settings suitable for re-import.
+// 本家の ExportAntennasProcessorService と同じく keywords / excludeKeywords は
+// 既に jsonb として保存されているので RawMessage のまま埋め込む。
+func (e *Exporter) exportAntennas(userID string) ([]byte, error) {
+	rows, err := e.deps.AntennaRepo.ListByUser(userID)
+	if err != nil {
+		return nil, err
+	}
+	out := make([]map[string]any, 0, len(rows))
+	for _, a := range rows {
+		entry := map[string]any{
+			"name":            a.Name,
+			"src":             string(a.Src),
+			"keywords":        json.RawMessage(a.Keywords),
+			"excludeKeywords": json.RawMessage(a.ExcludeKeywords),
+			"users":           []string(a.Users),
+			"caseSensitive":   a.CaseSensitive,
+			"localOnly":       a.LocalOnly,
+			"excludeBots":     a.ExcludeBots,
+			"withReplies":     a.WithReplies,
+			"withFile":        a.WithFile,
+		}
+		if a.UserListID != nil {
+			entry["userListId"] = *a.UserListID
+		}
+		out = append(out, entry)
+	}
+	return json.Marshal(out)
+}
+
+// exportClips emits a JSON array of the user's clips, each with the packed
+// notes contained in the clip. 各 clip 内の note は単純な配列 (本家互換)。
+func (e *Exporter) exportClips(userID string) ([]byte, error) {
+	clips, err := e.deps.ClipRepo.ListByUser(userID, 1000, 0)
+	if err != nil {
+		return nil, err
+	}
+	out := make([]map[string]any, 0, len(clips))
+	for _, c := range clips {
+		notes, err := e.collectClipNotes(c.ID)
+		if err != nil {
+			return nil, err
+		}
+		packed := make([]map[string]any, 0, len(notes))
+		for _, n := range notes {
+			packed = append(packed, e.packNoteForExport(n))
+		}
+		out = append(out, map[string]any{
+			"id":          c.ID,
+			"name":        c.Name,
+			"description": c.Description,
+			"isPublic":    c.IsPublic,
+			"notes":       packed,
+		})
+	}
+	return json.Marshal(out)
+}
+
+// collectClipNotes walks ClipNoteRepository with pagination and resolves each
+// referenced note into its model.Note form for exporting.
+func (e *Exporter) collectClipNotes(clipID string) ([]*model.Note, error) {
+	var out []*model.Note
+	untilID := ""
+	for {
+		rows, err := e.deps.ClipNoteRepo.ListByClip(clipID, untilID, "", 100)
+		if err != nil {
+			return nil, err
+		}
+		if len(rows) == 0 {
+			break
+		}
+		for _, cn := range rows {
+			n, err := e.deps.NoteRepo.FindByIDWithUser(cn.NoteID)
+			if err != nil || n == nil {
+				continue
+			}
+			out = append(out, n)
+		}
+		untilID = rows[len(rows)-1].ID
+		if len(rows) < 100 {
+			break
+		}
+	}
+	return out, nil
+}

--- a/internal/core/transfer/export_notes.go
+++ b/internal/core/transfer/export_notes.go
@@ -1,0 +1,92 @@
+package transfer
+
+import (
+	"bytes"
+	"encoding/json"
+
+	"github.com/shiroha-a/mk/internal/model"
+)
+
+// notesExportBatchSize mirrors the upstream ExportNotesProcessorService.ts
+// batch size used for streaming notes out of the DB.
+const notesExportBatchSize = 100
+
+// exportNotes emits a JSON array of the user's notes ordered by id descending.
+// 各 note は本家の Export*Notes フォーマット互換を目指すが、必要最低限の
+// フィールドだけをフラットに出力する。poll は別テーブルなので PollRepo で
+// 解決して埋め込む。
+func (e *Exporter) exportNotes(userID string) ([]byte, error) {
+	return e.exportNotesStream(func(untilID string) ([]*model.Note, error) {
+		return e.deps.NoteRepo.ListByUserID(userID, untilID, "", notesExportBatchSize)
+	})
+}
+
+// exportNotesStream walks a pagination-producing function and marshals each
+// note into the JSON array body. Shared between note and favorites exports
+// since both use the same item shape.
+func (e *Exporter) exportNotesStream(fetch func(untilID string) ([]*model.Note, error)) ([]byte, error) {
+	var buf bytes.Buffer
+	buf.WriteByte('[')
+	first := true
+	untilID := ""
+	for {
+		notes, err := fetch(untilID)
+		if err != nil {
+			return nil, err
+		}
+		if len(notes) == 0 {
+			break
+		}
+		for _, n := range notes {
+			payload := e.packNoteForExport(n)
+			raw, jerr := json.Marshal(payload)
+			if jerr != nil {
+				return nil, jerr
+			}
+			if !first {
+				buf.WriteByte(',')
+			}
+			buf.Write(raw)
+			first = false
+		}
+		untilID = notes[len(notes)-1].ID
+		if len(notes) < notesExportBatchSize {
+			break
+		}
+	}
+	buf.WriteByte(']')
+	return buf.Bytes(), nil
+}
+
+// packNoteForExport reduces a model.Note to the export-facing subset.
+// Misskey フロントエンドが後からインポートする際にこの形状を期待する。
+func (e *Exporter) packNoteForExport(n *model.Note) map[string]any {
+	if n == nil {
+		return nil
+	}
+	out := map[string]any{
+		"id":                 n.ID,
+		"text":               n.Text,
+		"cw":                 n.CW,
+		"userId":             n.UserID,
+		"visibility":         string(n.Visibility),
+		"localOnly":          n.LocalOnly,
+		"reactionAcceptance": n.ReactionAcceptance,
+		"fileIds":            []string(n.FileIDs),
+		"replyId":            n.ReplyID,
+		"renoteId":           n.RenoteID,
+	}
+	if len(n.VisibleUserIDs) > 0 {
+		out["visibleUserIds"] = []string(n.VisibleUserIDs)
+	}
+	if n.HasPoll && e.deps.PollRepo != nil {
+		if p, err := e.deps.PollRepo.FindByNoteID(n.ID); err == nil && p != nil {
+			out["poll"] = map[string]any{
+				"multiple":  p.Multiple,
+				"choices":   []string(p.Choices),
+				"expiresAt": p.ExpiresAt,
+			}
+		}
+	}
+	return out
+}

--- a/internal/core/transfer/export_test.go
+++ b/internal/core/transfer/export_test.go
@@ -1,0 +1,271 @@
+package transfer_test
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/lib/pq"
+	"github.com/shiroha-a/mk/internal/core/drive"
+	"github.com/shiroha-a/mk/internal/core/notification"
+	"github.com/shiroha-a/mk/internal/core/transfer"
+	"github.com/shiroha-a/mk/internal/misc/id"
+	"github.com/shiroha-a/mk/internal/model"
+	"github.com/shiroha-a/mk/internal/testutil"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gorm.io/datatypes"
+)
+
+// --- Test doubles ---
+
+type fakeDriveSaver struct {
+	uploads []drive.UploadInput
+	err     error
+}
+
+func (f *fakeDriveSaver) Upload(in drive.UploadInput) (*model.DriveFile, error) {
+	if f.err != nil {
+		return nil, f.err
+	}
+	f.uploads = append(f.uploads, in)
+	return &model.DriveFile{ID: "file_" + in.Name, Name: in.Name, Size: len(in.Body)}, nil
+}
+
+type fakeNotifier struct {
+	calls []notification.CreateInput
+}
+
+func (f *fakeNotifier) Create(_ context.Context, in notification.CreateInput) (*notification.Notification, error) {
+	f.calls = append(f.calls, in)
+	return &notification.Notification{ID: "n1"}, nil
+}
+
+// --- Helpers ---
+
+func newExportDeps(t *testing.T) (*fakeDriveSaver, *fakeNotifier, transfer.ExporterDeps, *model.User) {
+	t.Helper()
+	idGen, _ := id.NewGenerator("aidx")
+	_ = idGen
+
+	userRepo := testutil.NewMockUserRepository()
+	user := &model.User{ID: "alice", Username: "alice", UsernameLower: "alice"}
+	userRepo.Users[user.ID] = user
+	userRepo.Users["bob"] = &model.User{ID: "bob", Username: "bob", UsernameLower: "bob"}
+	remoteHost := "remote.example"
+	userRepo.Users["carol"] = &model.User{ID: "carol", Username: "carol", UsernameLower: "carol", Host: &remoteHost}
+
+	driveSaver := &fakeDriveSaver{}
+	notifier := &fakeNotifier{}
+
+	deps := transfer.ExporterDeps{
+		UserRepo:         userRepo,
+		NoteRepo:         testutil.NewMockNoteRepository(),
+		PollRepo:         testutil.NewMockPollRepository(),
+		FollowingRepo:    testutil.NewMockFollowingRepository(),
+		BlockingRepo:     testutil.NewMockBlockingRepository(),
+		MutingRepo:       testutil.NewMockMutingRepository(),
+		NoteFavoriteRepo: testutil.NewMockNoteFavoriteRepository(),
+		AntennaRepo:      testutil.NewMockAntennaRepository(),
+		ClipRepo:         testutil.NewMockClipRepository(),
+		ClipNoteRepo:     testutil.NewMockClipNoteRepository(),
+		UserListRepo:     testutil.NewMockUserListRepository(),
+		Drive:            driveSaver,
+		Notifier:         notifier,
+	}
+	return driveSaver, notifier, deps, user
+}
+
+// --- Tests ---
+
+func TestExport_UnsupportedType(t *testing.T) {
+	_, _, deps, user := newExportDeps(t)
+	exporter := transfer.NewExporter(deps)
+	_, err := exporter.Export(context.Background(), user.ID, "nope")
+	require.Error(t, err)
+	assert.ErrorIs(t, err, transfer.ErrUnsupportedType)
+}
+
+func TestExport_UserNotFound(t *testing.T) {
+	_, _, deps, _ := newExportDeps(t)
+	exporter := transfer.NewExporter(deps)
+	_, err := exporter.Export(context.Background(), "ghost", transfer.ExportNotes)
+	assert.Error(t, err)
+}
+
+func TestExport_Notes_EmptyReturnsJSONArray(t *testing.T) {
+	saver, notifier, deps, user := newExportDeps(t)
+	exporter := transfer.NewExporter(deps)
+
+	f, err := exporter.Export(context.Background(), user.ID, transfer.ExportNotes)
+	require.NoError(t, err)
+	assert.NotNil(t, f)
+	require.Len(t, saver.uploads, 1)
+	assert.True(t, strings.HasPrefix(saver.uploads[0].Name, "notes-"))
+	assert.True(t, strings.HasSuffix(saver.uploads[0].Name, ".json"))
+	assert.Equal(t, []byte("[]"), saver.uploads[0].Body)
+	require.Len(t, notifier.calls, 1)
+	assert.Equal(t, notification.TypeExportCompleted, notifier.calls[0].Type)
+	assert.Equal(t, transfer.ExportNotes, notifier.calls[0].Extra["exportedEntity"])
+}
+
+func TestExport_Notes_WithPoll(t *testing.T) {
+	saver, _, deps, user := newExportDeps(t)
+	noteRepo := deps.NoteRepo.(*testutil.MockNoteRepository)
+	pollRepo := deps.PollRepo.(*testutil.MockPollRepository)
+
+	text := "hello"
+	n := &model.Note{
+		ID:         "n1",
+		UserID:     user.ID,
+		Text:       &text,
+		Visibility: model.NoteVisibilityPublic,
+		HasPoll:    true,
+		FileIDs:    pq.StringArray{"f1"},
+	}
+	noteRepo.Notes[n.ID] = n
+	pollRepo.Polls[n.ID] = &model.Poll{NoteID: n.ID, Multiple: true, Choices: pq.StringArray{"a", "b"}}
+
+	exporter := transfer.NewExporter(deps)
+	_, err := exporter.Export(context.Background(), user.ID, transfer.ExportNotes)
+	require.NoError(t, err)
+
+	var arr []map[string]any
+	require.NoError(t, json.Unmarshal(saver.uploads[0].Body, &arr))
+	require.Len(t, arr, 1)
+	assert.Equal(t, "n1", arr[0]["id"])
+	assert.Equal(t, "hello", arr[0]["text"])
+	assert.NotNil(t, arr[0]["poll"])
+}
+
+func TestExport_Following_CSV(t *testing.T) {
+	saver, _, deps, user := newExportDeps(t)
+	followingRepo := deps.FollowingRepo.(*testutil.MockFollowingRepository)
+
+	followingRepo.Followings["f1"] = &model.Following{
+		ID: "f1", FollowerID: user.ID, FolloweeID: "bob", WithReplies: true,
+	}
+	followingRepo.Followings["f2"] = &model.Following{
+		ID: "f2", FollowerID: user.ID, FolloweeID: "carol", WithReplies: false,
+	}
+
+	exporter := transfer.NewExporter(deps)
+	_, err := exporter.Export(context.Background(), user.ID, transfer.ExportFollowing)
+	require.NoError(t, err)
+	assert.True(t, strings.HasSuffix(saver.uploads[0].Name, ".csv"))
+	body := string(saver.uploads[0].Body)
+	assert.Contains(t, body, "bob,withReplies=true")
+	assert.Contains(t, body, "carol@remote.example,withReplies=false")
+}
+
+func TestExport_Blocking_CSV(t *testing.T) {
+	saver, _, deps, user := newExportDeps(t)
+	blockingRepo := deps.BlockingRepo.(*testutil.MockBlockingRepository)
+	blockingRepo.Blockings["b1"] = &model.Blocking{ID: "b1", BlockerID: user.ID, BlockeeID: "bob"}
+
+	exporter := transfer.NewExporter(deps)
+	_, err := exporter.Export(context.Background(), user.ID, transfer.ExportBlocking)
+	require.NoError(t, err)
+	assert.Equal(t, "bob\n", string(saver.uploads[0].Body))
+}
+
+func TestExport_Muting_OnlyPermanent(t *testing.T) {
+	saver, _, deps, user := newExportDeps(t)
+	mutingRepo := deps.MutingRepo.(*testutil.MockMutingRepository)
+
+	mutingRepo.Mutings["m1"] = &model.Muting{ID: "m1", MuterID: user.ID, MuteeID: "bob"}
+	exp := time.Now().Add(1 * time.Hour)
+	mutingRepo.Mutings["m2"] = &model.Muting{ID: "m2", MuterID: user.ID, MuteeID: "carol", ExpiresAt: &exp}
+
+	exporter := transfer.NewExporter(deps)
+	_, err := exporter.Export(context.Background(), user.ID, transfer.ExportMuting)
+	require.NoError(t, err)
+	body := string(saver.uploads[0].Body)
+	assert.Contains(t, body, "bob")
+	assert.NotContains(t, body, "carol")
+}
+
+func TestExport_UserLists_CSV(t *testing.T) {
+	saver, _, deps, user := newExportDeps(t)
+	listRepo := deps.UserListRepo.(*testutil.MockUserListRepository)
+
+	list := &model.UserList{ID: "l1", UserID: user.ID, Name: "friends"}
+	listRepo.Lists["l1"] = list
+	_ = listRepo.AddMember(&model.UserListMembership{ID: "m1", UserListID: "l1", UserID: "bob"})
+
+	exporter := transfer.NewExporter(deps)
+	_, err := exporter.Export(context.Background(), user.ID, transfer.ExportUserLists)
+	require.NoError(t, err)
+	assert.Contains(t, string(saver.uploads[0].Body), "friends,bob,withReplies=false")
+}
+
+func TestExport_Antennas_JSON(t *testing.T) {
+	saver, _, deps, user := newExportDeps(t)
+	antennaRepo := deps.AntennaRepo.(*testutil.MockAntennaRepository)
+
+	antennaRepo.Antennas["a1"] = &model.Antenna{
+		ID: "a1", UserID: user.ID, Name: "test", Src: model.AntennaSourceAll,
+		Keywords:        datatypes.JSON([]byte(`[["go"]]`)),
+		ExcludeKeywords: datatypes.JSON([]byte(`[]`)),
+	}
+
+	exporter := transfer.NewExporter(deps)
+	_, err := exporter.Export(context.Background(), user.ID, transfer.ExportAntennas)
+	require.NoError(t, err)
+	var arr []map[string]any
+	require.NoError(t, json.Unmarshal(saver.uploads[0].Body, &arr))
+	require.Len(t, arr, 1)
+	assert.Equal(t, "test", arr[0]["name"])
+	assert.Equal(t, "all", arr[0]["src"])
+}
+
+func TestExport_Clips_JSON(t *testing.T) {
+	saver, _, deps, user := newExportDeps(t)
+	clipRepo := deps.ClipRepo.(*testutil.MockClipRepository)
+	clipNoteRepo := deps.ClipNoteRepo.(*testutil.MockClipNoteRepository)
+	noteRepo := deps.NoteRepo.(*testutil.MockNoteRepository)
+
+	clipRepo.Clips["c1"] = &model.Clip{ID: "c1", UserID: user.ID, Name: "clip1"}
+	text := "clipped note"
+	noteRepo.Notes["n1"] = &model.Note{ID: "n1", UserID: user.ID, Text: &text, Visibility: model.NoteVisibilityPublic}
+	_ = clipNoteRepo.Create(&model.ClipNote{ID: "cn1", ClipID: "c1", NoteID: "n1"})
+
+	exporter := transfer.NewExporter(deps)
+	_, err := exporter.Export(context.Background(), user.ID, transfer.ExportClips)
+	require.NoError(t, err)
+	var arr []map[string]any
+	require.NoError(t, json.Unmarshal(saver.uploads[0].Body, &arr))
+	require.Len(t, arr, 1)
+	assert.Equal(t, "clip1", arr[0]["name"])
+	notes := arr[0]["notes"].([]any)
+	assert.Len(t, notes, 1)
+}
+
+func TestExport_Favorites_JSON(t *testing.T) {
+	saver, _, deps, user := newExportDeps(t)
+	favRepo := deps.NoteFavoriteRepo.(*testutil.MockNoteFavoriteRepository)
+
+	text := "fav note"
+	n := &model.Note{ID: "n1", UserID: "bob", Text: &text, Visibility: model.NoteVisibilityPublic}
+	favRepo.Favorites["fv1"] = &model.NoteFavorite{ID: "fv1", UserID: user.ID, NoteID: "n1", Note: n}
+
+	exporter := transfer.NewExporter(deps)
+	_, err := exporter.Export(context.Background(), user.ID, transfer.ExportFavorites)
+	require.NoError(t, err)
+	var arr []map[string]any
+	require.NoError(t, json.Unmarshal(saver.uploads[0].Body, &arr))
+	require.Len(t, arr, 1)
+	note := arr[0]["note"].(map[string]any)
+	assert.Equal(t, "fav note", note["text"])
+}
+
+func TestExport_DriveUploadError(t *testing.T) {
+	saver, _, deps, user := newExportDeps(t)
+	saver.err = errors.New("drive boom")
+	exporter := transfer.NewExporter(deps)
+	_, err := exporter.Export(context.Background(), user.ID, transfer.ExportNotes)
+	assert.Error(t, err)
+}

--- a/internal/core/transfer/import_antennas.go
+++ b/internal/core/transfer/import_antennas.go
@@ -1,0 +1,82 @@
+package transfer
+
+import (
+	"encoding/json"
+	"fmt"
+	"log/slog"
+	"time"
+
+	"github.com/lib/pq"
+	"github.com/shiroha-a/mk/internal/model"
+	"gorm.io/datatypes"
+)
+
+// antennaImportEntry is the JSON shape produced by exportAntennas and
+// accepted here on import. Only fields that map directly to model.Antenna
+// are respected; unknown fields are ignored.
+type antennaImportEntry struct {
+	Name            string          `json:"name"`
+	Src             string          `json:"src"`
+	Keywords        json.RawMessage `json:"keywords"`
+	ExcludeKeywords json.RawMessage `json:"excludeKeywords"`
+	Users           []string        `json:"users"`
+	UserListID      *string         `json:"userListId"`
+	CaseSensitive   bool            `json:"caseSensitive"`
+	LocalOnly       bool            `json:"localOnly"`
+	ExcludeBots     bool            `json:"excludeBots"`
+	WithReplies     bool            `json:"withReplies"`
+	WithFile        bool            `json:"withFile"`
+}
+
+// importAntennas decodes a JSON array of antenna entries and creates one
+// antenna row per entry. 無効なエントリはスキップしてカウントする。
+func (i *Importer) importAntennas(user *model.User, body []byte) (*ImportResult, error) {
+	var entries []antennaImportEntry
+	if err := json.Unmarshal(body, &entries); err != nil {
+		return nil, fmt.Errorf("parse antennas json: %w", err)
+	}
+	res := &ImportResult{Total: len(entries)}
+	for _, ent := range entries {
+		if ent.Name == "" || ent.Src == "" {
+			res.Skipped++
+			continue
+		}
+		keywords := normalizeJSON(ent.Keywords, "[]")
+		excludeKeywords := normalizeJSON(ent.ExcludeKeywords, "[]")
+
+		antenna := &model.Antenna{
+			ID:              i.deps.IDGen.Generate(time.Now()),
+			UserID:          user.ID,
+			Name:            ent.Name,
+			Src:             model.AntennaSource(ent.Src),
+			UserListID:      ent.UserListID,
+			Users:           pq.StringArray(ent.Users),
+			Keywords:        datatypes.JSON(keywords),
+			ExcludeKeywords: datatypes.JSON(excludeKeywords),
+			CaseSensitive:   ent.CaseSensitive,
+			LocalOnly:       ent.LocalOnly,
+			ExcludeBots:     ent.ExcludeBots,
+			WithReplies:     ent.WithReplies,
+			WithFile:        ent.WithFile,
+			IsActive:        true,
+			LastUsedAt:      time.Now(),
+		}
+		if err := i.deps.AntennaRepo.Create(antenna); err != nil {
+			res.Skipped++
+			slog.Warn("transfer import: antenna create failed",
+				"name", ent.Name, "err", err)
+			continue
+		}
+		res.Applied++
+	}
+	return res, nil
+}
+
+// normalizeJSON returns raw if it's non-empty, otherwise the fallback literal.
+// 本家の export フォーマットは keywords: [] を省略せず出力するが、念のため。
+func normalizeJSON(raw json.RawMessage, fallback string) []byte {
+	if len(raw) == 0 {
+		return []byte(fallback)
+	}
+	return raw
+}

--- a/internal/core/transfer/import_csv.go
+++ b/internal/core/transfer/import_csv.go
@@ -1,0 +1,160 @@
+package transfer
+
+import (
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/shiroha-a/mk/internal/model"
+)
+
+// importFollowing parses a CSV body of `acct[,withReplies=bool]` lines and
+// applies a follow for each. Remote users must already exist locally.
+func (i *Importer) importFollowing(user *model.User, body []byte) (*ImportResult, error) {
+	if i.deps.Following == nil {
+		return nil, fmt.Errorf("following service not configured")
+	}
+	lines := scanCSV(body)
+	res := &ImportResult{Total: len(lines)}
+	for _, line := range lines {
+		acctStr := strings.TrimSpace(strings.SplitN(line, ",", 2)[0])
+		target, err := i.resolveTargetUser(acctStr)
+		if err != nil || target == nil {
+			res.Skipped++
+			logSkip(ImportFollowing, acctStr, err)
+			continue
+		}
+		if target.ID == user.ID {
+			res.Skipped++
+			continue
+		}
+		if _, err := i.deps.Following.Follow(user.ID, target.ID); err != nil {
+			res.Skipped++
+			logSkip(ImportFollowing, acctStr, err)
+			continue
+		}
+		res.Applied++
+	}
+	return res, nil
+}
+
+// importBlocking parses `acct` lines and applies a block per entry.
+func (i *Importer) importBlocking(user *model.User, body []byte) (*ImportResult, error) {
+	if i.deps.Blocking == nil {
+		return nil, fmt.Errorf("blocking service not configured")
+	}
+	lines := scanCSV(body)
+	res := &ImportResult{Total: len(lines)}
+	for _, line := range lines {
+		target, err := i.resolveTargetUser(line)
+		if err != nil || target == nil {
+			res.Skipped++
+			logSkip(ImportBlocking, line, err)
+			continue
+		}
+		if target.ID == user.ID {
+			res.Skipped++
+			continue
+		}
+		if _, err := i.deps.Blocking.Block(user.ID, target.ID); err != nil {
+			res.Skipped++
+			logSkip(ImportBlocking, line, err)
+			continue
+		}
+		res.Applied++
+	}
+	return res, nil
+}
+
+// importMuting parses `acct` lines and applies a permanent mute per entry.
+// 本家と同様に ExpiresAt は nil (無期限) で作成する。
+func (i *Importer) importMuting(user *model.User, body []byte) (*ImportResult, error) {
+	if i.deps.Muting == nil {
+		return nil, fmt.Errorf("muting service not configured")
+	}
+	lines := scanCSV(body)
+	res := &ImportResult{Total: len(lines)}
+	var noExpire *time.Time
+	for _, line := range lines {
+		target, err := i.resolveTargetUser(line)
+		if err != nil || target == nil {
+			res.Skipped++
+			logSkip(ImportMuting, line, err)
+			continue
+		}
+		if target.ID == user.ID {
+			res.Skipped++
+			continue
+		}
+		if _, err := i.deps.Muting.Mute(user.ID, target.ID, noExpire); err != nil {
+			res.Skipped++
+			logSkip(ImportMuting, line, err)
+			continue
+		}
+		res.Applied++
+	}
+	return res, nil
+}
+
+// importUserLists parses `listName,acct[,withReplies=bool]` lines and creates
+// or reuses a UserList per listName, adding the referenced user to it.
+func (i *Importer) importUserLists(user *model.User, body []byte) (*ImportResult, error) {
+	lines := scanCSV(body)
+	res := &ImportResult{Total: len(lines)}
+
+	// 既存の (name -> *UserList) キャッシュ。同じ名前のリストは共有する。
+	cache := make(map[string]*model.UserList)
+	if existing, err := i.deps.UserListRepo.ListByUser(user.ID); err == nil {
+		for _, l := range existing {
+			cache[l.Name] = l
+		}
+	}
+
+	for _, line := range lines {
+		parts := strings.SplitN(line, ",", 3)
+		if len(parts) < 2 {
+			res.Skipped++
+			continue
+		}
+		listName := strings.TrimSpace(parts[0])
+		acctStr := strings.TrimSpace(parts[1])
+		if listName == "" || acctStr == "" {
+			res.Skipped++
+			continue
+		}
+
+		list, ok := cache[listName]
+		if !ok {
+			list = &model.UserList{
+				ID:     i.deps.IDGen.Generate(time.Now()),
+				UserID: user.ID,
+				Name:   listName,
+			}
+			if err := i.deps.UserListRepo.Create(list); err != nil {
+				res.Skipped++
+				logSkip(ImportUserLists, acctStr, err)
+				continue
+			}
+			cache[listName] = list
+		}
+
+		target, err := i.resolveTargetUser(acctStr)
+		if err != nil || target == nil {
+			res.Skipped++
+			logSkip(ImportUserLists, acctStr, err)
+			continue
+		}
+		membership := &model.UserListMembership{
+			ID:         i.deps.IDGen.Generate(time.Now()),
+			UserListID: list.ID,
+			UserID:     target.ID,
+		}
+		if err := i.deps.UserListRepo.AddMember(membership); err != nil {
+			res.Skipped++
+			logSkip(ImportUserLists, acctStr, err)
+			continue
+		}
+		res.Applied++
+	}
+	return res, nil
+}

--- a/internal/core/transfer/import_test.go
+++ b/internal/core/transfer/import_test.go
@@ -1,0 +1,343 @@
+package transfer_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/shiroha-a/mk/internal/core/transfer"
+	"github.com/shiroha-a/mk/internal/misc/id"
+	"github.com/shiroha-a/mk/internal/model"
+	"github.com/shiroha-a/mk/internal/testutil"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// --- Stubs for core service interfaces ---
+
+type fakeFollowingService struct {
+	calls [][2]string
+	err   error
+}
+
+func (f *fakeFollowingService) Follow(followerID, followeeID string) (any, error) {
+	if f.err != nil {
+		return nil, f.err
+	}
+	f.calls = append(f.calls, [2]string{followerID, followeeID})
+	return nil, nil
+}
+
+type fakeBlockingService struct {
+	calls [][2]string
+	err   error
+}
+
+func (f *fakeBlockingService) Block(blockerID, blockeeID string) (*model.Blocking, error) {
+	if f.err != nil {
+		return nil, f.err
+	}
+	f.calls = append(f.calls, [2]string{blockerID, blockeeID})
+	return &model.Blocking{ID: "b_" + blockeeID}, nil
+}
+
+type fakeMutingService struct {
+	calls [][2]string
+	err   error
+}
+
+func (f *fakeMutingService) Mute(muterID, muteeID string, _ *time.Time) (*model.Muting, error) {
+	if f.err != nil {
+		return nil, f.err
+	}
+	f.calls = append(f.calls, [2]string{muterID, muteeID})
+	return &model.Muting{ID: "m_" + muteeID}, nil
+}
+
+// fakeDriveReader returns canned bytes for Fetch.
+type fakeDriveReader struct {
+	body []byte
+	err  error
+}
+
+func (f *fakeDriveReader) Fetch(_ string) (*model.DriveFile, []byte, error) {
+	if f.err != nil {
+		return nil, nil, f.err
+	}
+	return &model.DriveFile{ID: "f1"}, f.body, nil
+}
+
+// --- Helpers ---
+
+func newImporterDeps(t *testing.T, body []byte) (transfer.ImporterDeps, *model.User, *fakeFollowingService, *fakeBlockingService, *fakeMutingService, *fakeNotifier) {
+	t.Helper()
+	idGen, _ := id.NewGenerator("aidx")
+
+	userRepo := testutil.NewMockUserRepository()
+	user := &model.User{ID: "alice", Username: "alice", UsernameLower: "alice"}
+	userRepo.Users[user.ID] = user
+	userRepo.Users["bob"] = &model.User{ID: "bob", Username: "bob", UsernameLower: "bob"}
+	remoteHost := "remote.example"
+	userRepo.Users["carol"] = &model.User{ID: "carol", Username: "carol", UsernameLower: "carol", Host: &remoteHost}
+
+	fs := &fakeFollowingService{}
+	bs := &fakeBlockingService{}
+	ms := &fakeMutingService{}
+	notifier := &fakeNotifier{}
+
+	deps := transfer.ImporterDeps{
+		UserRepo:     userRepo,
+		UserListRepo: testutil.NewMockUserListRepository(),
+		AntennaRepo:  testutil.NewMockAntennaRepository(),
+		Drive:        &fakeDriveReader{body: body},
+		Following:    fs,
+		Blocking:     bs,
+		Muting:       ms,
+		Notifier:     notifier,
+		IDGen:        idGen,
+		SelfHost:     "local.example",
+	}
+	return deps, user, fs, bs, ms, notifier
+}
+
+// --- Tests ---
+
+func TestImport_UnsupportedType(t *testing.T) {
+	deps, user, _, _, _, _ := newImporterDeps(t, nil)
+	imp := transfer.NewImporter(deps)
+	_, err := imp.Import(context.Background(), user.ID, "nope", "fid")
+	assert.ErrorIs(t, err, transfer.ErrUnsupportedType)
+}
+
+func TestImport_UserNotFound(t *testing.T) {
+	deps, _, _, _, _, _ := newImporterDeps(t, []byte("bob\n"))
+	imp := transfer.NewImporter(deps)
+	_, err := imp.Import(context.Background(), "ghost", transfer.ImportBlocking, "fid")
+	assert.Error(t, err)
+}
+
+func TestImport_DriveReaderMissing(t *testing.T) {
+	deps, user, _, _, _, _ := newImporterDeps(t, nil)
+	deps.Drive = nil
+	imp := transfer.NewImporter(deps)
+	_, err := imp.Import(context.Background(), user.ID, transfer.ImportBlocking, "fid")
+	assert.Error(t, err)
+}
+
+func TestImport_DriveFetchError(t *testing.T) {
+	deps, user, _, _, _, _ := newImporterDeps(t, nil)
+	deps.Drive = &fakeDriveReader{err: errors.New("boom")}
+	imp := transfer.NewImporter(deps)
+	_, err := imp.Import(context.Background(), user.ID, transfer.ImportBlocking, "fid")
+	assert.Error(t, err)
+}
+
+func TestImport_Following_AppliesEachRow(t *testing.T) {
+	deps, user, fs, _, _, notifier := newImporterDeps(t,
+		[]byte("bob,withReplies=true\ncarol@remote.example,withReplies=false\n"))
+	imp := transfer.NewImporter(deps)
+	res, err := imp.Import(context.Background(), user.ID, transfer.ImportFollowing, "fid")
+	require.NoError(t, err)
+	assert.Equal(t, 2, res.Total)
+	assert.Equal(t, 2, res.Applied)
+	assert.Equal(t, 0, res.Skipped)
+	assert.Len(t, fs.calls, 2)
+	require.Len(t, notifier.calls, 1)
+	assert.Equal(t, "importCompleted", string(notifier.calls[0].Type))
+	assert.Equal(t, "following", notifier.calls[0].Extra["importedEntity"])
+}
+
+func TestImport_Following_SkipsUnknown(t *testing.T) {
+	deps, user, fs, _, _, _ := newImporterDeps(t, []byte("ghost\nbob\n"))
+	imp := transfer.NewImporter(deps)
+	res, err := imp.Import(context.Background(), user.ID, transfer.ImportFollowing, "fid")
+	require.NoError(t, err)
+	assert.Equal(t, 1, res.Applied)
+	assert.Equal(t, 1, res.Skipped)
+	assert.Len(t, fs.calls, 1)
+}
+
+func TestImport_Following_SkipsSelf(t *testing.T) {
+	deps, user, fs, _, _, _ := newImporterDeps(t, []byte("alice\n"))
+	imp := transfer.NewImporter(deps)
+	res, err := imp.Import(context.Background(), user.ID, transfer.ImportFollowing, "fid")
+	require.NoError(t, err)
+	assert.Equal(t, 0, res.Applied)
+	assert.Equal(t, 1, res.Skipped)
+	assert.Empty(t, fs.calls)
+}
+
+func TestImport_Following_ServiceErrorCounted(t *testing.T) {
+	deps, user, fs, _, _, _ := newImporterDeps(t, []byte("bob\n"))
+	fs.err = errors.New("follow boom")
+	imp := transfer.NewImporter(deps)
+	res, err := imp.Import(context.Background(), user.ID, transfer.ImportFollowing, "fid")
+	require.NoError(t, err)
+	assert.Equal(t, 1, res.Skipped)
+	assert.Equal(t, 0, res.Applied)
+}
+
+func TestImport_Following_ServiceNotConfigured(t *testing.T) {
+	deps, user, _, _, _, _ := newImporterDeps(t, []byte("bob\n"))
+	deps.Following = nil
+	imp := transfer.NewImporter(deps)
+	_, err := imp.Import(context.Background(), user.ID, transfer.ImportFollowing, "fid")
+	assert.Error(t, err)
+}
+
+func TestImport_Blocking_Applies(t *testing.T) {
+	deps, user, _, bs, _, _ := newImporterDeps(t, []byte("bob\n"))
+	imp := transfer.NewImporter(deps)
+	res, err := imp.Import(context.Background(), user.ID, transfer.ImportBlocking, "fid")
+	require.NoError(t, err)
+	assert.Equal(t, 1, res.Applied)
+	assert.Len(t, bs.calls, 1)
+}
+
+func TestImport_Blocking_SkipsSelfAndError(t *testing.T) {
+	deps, user, _, bs, _, _ := newImporterDeps(t, []byte("alice\nghost\n"))
+	imp := transfer.NewImporter(deps)
+	res, err := imp.Import(context.Background(), user.ID, transfer.ImportBlocking, "fid")
+	require.NoError(t, err)
+	assert.Equal(t, 2, res.Skipped)
+	assert.Empty(t, bs.calls)
+}
+
+func TestImport_Blocking_ServiceError(t *testing.T) {
+	deps, user, _, bs, _, _ := newImporterDeps(t, []byte("bob\n"))
+	bs.err = errors.New("block boom")
+	imp := transfer.NewImporter(deps)
+	res, err := imp.Import(context.Background(), user.ID, transfer.ImportBlocking, "fid")
+	require.NoError(t, err)
+	assert.Equal(t, 1, res.Skipped)
+}
+
+func TestImport_Blocking_ServiceNotConfigured(t *testing.T) {
+	deps, user, _, _, _, _ := newImporterDeps(t, []byte("bob\n"))
+	deps.Blocking = nil
+	imp := transfer.NewImporter(deps)
+	_, err := imp.Import(context.Background(), user.ID, transfer.ImportBlocking, "fid")
+	assert.Error(t, err)
+}
+
+func TestImport_Muting_Applies(t *testing.T) {
+	deps, user, _, _, ms, _ := newImporterDeps(t, []byte("bob\n"))
+	imp := transfer.NewImporter(deps)
+	res, err := imp.Import(context.Background(), user.ID, transfer.ImportMuting, "fid")
+	require.NoError(t, err)
+	assert.Equal(t, 1, res.Applied)
+	assert.Len(t, ms.calls, 1)
+}
+
+func TestImport_Muting_ServiceError(t *testing.T) {
+	deps, user, _, _, ms, _ := newImporterDeps(t, []byte("bob\n"))
+	ms.err = errors.New("mute boom")
+	imp := transfer.NewImporter(deps)
+	res, err := imp.Import(context.Background(), user.ID, transfer.ImportMuting, "fid")
+	require.NoError(t, err)
+	assert.Equal(t, 1, res.Skipped)
+}
+
+func TestImport_Muting_SkipsSelf(t *testing.T) {
+	deps, user, _, _, ms, _ := newImporterDeps(t, []byte("alice\n"))
+	imp := transfer.NewImporter(deps)
+	res, err := imp.Import(context.Background(), user.ID, transfer.ImportMuting, "fid")
+	require.NoError(t, err)
+	assert.Equal(t, 1, res.Skipped)
+	assert.Empty(t, ms.calls)
+}
+
+func TestImport_Muting_ServiceNotConfigured(t *testing.T) {
+	deps, user, _, _, _, _ := newImporterDeps(t, []byte("bob\n"))
+	deps.Muting = nil
+	imp := transfer.NewImporter(deps)
+	_, err := imp.Import(context.Background(), user.ID, transfer.ImportMuting, "fid")
+	assert.Error(t, err)
+}
+
+func TestImport_UserLists_CreatesAndReuses(t *testing.T) {
+	deps, user, _, _, _, _ := newImporterDeps(t,
+		[]byte("friends,bob,withReplies=true\nfriends,carol@remote.example,withReplies=false\n"))
+	imp := transfer.NewImporter(deps)
+	res, err := imp.Import(context.Background(), user.ID, transfer.ImportUserLists, "fid")
+	require.NoError(t, err)
+	assert.Equal(t, 2, res.Applied)
+
+	listRepo := deps.UserListRepo.(*testutil.MockUserListRepository)
+	assert.Len(t, listRepo.Lists, 1)
+	for _, l := range listRepo.Lists {
+		members, _ := listRepo.ListMembers(l.ID)
+		assert.Len(t, members, 2)
+	}
+}
+
+func TestImport_UserLists_SkipsMalformed(t *testing.T) {
+	deps, user, _, _, _, _ := newImporterDeps(t,
+		[]byte("only-one-field\n,\nfriends,ghost\n"))
+	imp := transfer.NewImporter(deps)
+	res, err := imp.Import(context.Background(), user.ID, transfer.ImportUserLists, "fid")
+	require.NoError(t, err)
+	assert.Equal(t, 3, res.Skipped)
+	assert.Equal(t, 0, res.Applied)
+}
+
+func TestImport_Antennas_JSON(t *testing.T) {
+	body := []byte(`[
+		{"name":"a1","src":"all","keywords":[["go"]],"users":[]},
+		{"name":"","src":"all"},
+		{"name":"a2","src":"users","users":["bob"]}
+	]`)
+	deps, user, _, _, _, _ := newImporterDeps(t, body)
+	imp := transfer.NewImporter(deps)
+	res, err := imp.Import(context.Background(), user.ID, transfer.ImportAntennas, "fid")
+	require.NoError(t, err)
+	assert.Equal(t, 3, res.Total)
+	assert.Equal(t, 2, res.Applied)
+	assert.Equal(t, 1, res.Skipped)
+}
+
+func TestImport_Antennas_InvalidJSON(t *testing.T) {
+	deps, user, _, _, _, _ := newImporterDeps(t, []byte("not json"))
+	imp := transfer.NewImporter(deps)
+	_, err := imp.Import(context.Background(), user.ID, transfer.ImportAntennas, "fid")
+	assert.Error(t, err)
+}
+
+func TestParseAcct_LocalAndRemote(t *testing.T) {
+	// acct parsing is exercised via resolveTargetUser in import tests but also
+	// verify edge cases explicitly via following import (which funnels through
+	// parseAcct). empty row is skipped by scanCSV so we test single @ form.
+	deps, user, fs, _, _, _ := newImporterDeps(t, []byte("@bob\n"))
+	imp := transfer.NewImporter(deps)
+	res, err := imp.Import(context.Background(), user.ID, transfer.ImportFollowing, "fid")
+	require.NoError(t, err)
+	assert.Equal(t, 1, res.Applied)
+	assert.Len(t, fs.calls, 1)
+}
+
+func TestParseAcct_SelfHost(t *testing.T) {
+	deps, user, fs, _, _, _ := newImporterDeps(t, []byte("bob@local.example\n"))
+	// SelfHost == local.example → host is stripped and treated as local
+	imp := transfer.NewImporter(deps)
+	res, err := imp.Import(context.Background(), user.ID, transfer.ImportFollowing, "fid")
+	require.NoError(t, err)
+	assert.Equal(t, 1, res.Applied)
+	assert.Len(t, fs.calls, 1)
+}
+
+func TestParseAcct_Malformed(t *testing.T) {
+	deps, user, _, _, _, _ := newImporterDeps(t, []byte("@\nbob@\n@host\n"))
+	imp := transfer.NewImporter(deps)
+	res, err := imp.Import(context.Background(), user.ID, transfer.ImportFollowing, "fid")
+	require.NoError(t, err)
+	// 全て malformed なので skip
+	assert.Equal(t, 3, res.Skipped)
+}
+
+func TestFollowingServiceAdapter(t *testing.T) {
+	// Adapter accepts nil receiver safely.
+	var a *transfer.FollowingServiceAdapter
+	_, err := a.Follow("f", "g")
+	assert.NoError(t, err)
+}

--- a/internal/core/transfer/importer.go
+++ b/internal/core/transfer/importer.go
@@ -1,0 +1,172 @@
+package transfer
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"log/slog"
+	"strings"
+	"time"
+
+	"github.com/shiroha-a/mk/internal/core/notification"
+	"github.com/shiroha-a/mk/internal/misc/id"
+	"github.com/shiroha-a/mk/internal/model"
+	"github.com/shiroha-a/mk/internal/repository"
+)
+
+// FollowingService is the subset of core/following.Service used by imports.
+type FollowingService interface {
+	Follow(followerID, followeeID string) (any, error)
+}
+
+// BlockingService is the subset of core/blocking.Service used by imports.
+type BlockingService interface {
+	Block(blockerID, blockeeID string) (*model.Blocking, error)
+}
+
+// MutingService is the subset of core/muting.Service used by imports.
+type MutingService interface {
+	Mute(muterID, muteeID string, expiresAt *time.Time) (*model.Muting, error)
+}
+
+// ImporterDeps bundles the dependencies needed by Importer.
+type ImporterDeps struct {
+	UserRepo     repository.UserRepository
+	UserListRepo repository.UserListRepository
+	AntennaRepo  repository.AntennaRepository
+	Drive        DriveReader
+	Following    FollowingService
+	Blocking     BlockingService
+	Muting       MutingService
+	Notifier     NotificationDispatcher
+	IDGen        id.Generator
+	SelfHost     string // instance host for detecting local acct entries
+}
+
+// Importer reads a previously-uploaded DriveFile and applies the contained
+// operations to the requesting user's account.
+type Importer struct {
+	deps ImporterDeps
+}
+
+// NewImporter constructs an Importer from the given dependencies.
+func NewImporter(deps ImporterDeps) *Importer {
+	return &Importer{deps: deps}
+}
+
+// ImportResult captures per-item counters returned to the caller and included
+// in the completion notification.
+type ImportResult struct {
+	Total   int
+	Applied int
+	Skipped int
+}
+
+// Import reads the DriveFile referenced by fileID and dispatches the content
+// to the handler matching importType. Errors per-item are logged and counted
+// as Skipped so that a single malformed entry does not abort the batch.
+func (i *Importer) Import(ctx context.Context, userID, importType, fileID string) (*ImportResult, error) {
+	user, err := i.deps.UserRepo.FindByID(userID)
+	if err != nil {
+		return nil, fmt.Errorf("find user: %w", err)
+	}
+	if i.deps.Drive == nil {
+		return nil, errors.New("drive reader not configured")
+	}
+	_, body, err := i.deps.Drive.Fetch(fileID)
+	if err != nil {
+		return nil, fmt.Errorf("fetch drive file: %w", err)
+	}
+
+	var result *ImportResult
+	switch importType {
+	case ImportFollowing:
+		result, err = i.importFollowing(user, body)
+	case ImportBlocking:
+		result, err = i.importBlocking(user, body)
+	case ImportMuting:
+		result, err = i.importMuting(user, body)
+	case ImportUserLists:
+		result, err = i.importUserLists(user, body)
+	case ImportAntennas:
+		result, err = i.importAntennas(user, body)
+	default:
+		return nil, fmt.Errorf("%w: %s", ErrUnsupportedType, importType)
+	}
+	if err != nil {
+		return nil, err
+	}
+
+	if i.deps.Notifier != nil {
+		_, _ = i.deps.Notifier.Create(ctx, notification.CreateInput{
+			NotifieeID: user.ID,
+			Type:       notification.TypeImportCompleted,
+			Extra: map[string]any{
+				"importedEntity": importType,
+				"total":          result.Total,
+				"applied":        result.Applied,
+				"skipped":        result.Skipped,
+			},
+		})
+	}
+	return result, nil
+}
+
+// parseAcct splits a "username" or "username@host" string into lowercase
+// username and (optional) host. Returns an error if the string is empty or
+// malformed.
+func parseAcct(s string) (username string, host *string, err error) {
+	s = strings.TrimSpace(strings.TrimPrefix(s, "@"))
+	if s == "" {
+		return "", nil, errors.New("empty acct")
+	}
+	at := strings.IndexByte(s, '@')
+	if at < 0 {
+		return strings.ToLower(s), nil, nil
+	}
+	username = strings.ToLower(s[:at])
+	h := strings.ToLower(s[at+1:])
+	if username == "" || h == "" {
+		return "", nil, errors.New("malformed acct")
+	}
+	return username, &h, nil
+}
+
+// resolveTargetUser looks up a user by acct. Remote users must already exist
+// locally; webfinger-based resolution is intentionally out of scope for this
+// package (documented limitation).
+func (i *Importer) resolveTargetUser(acct string) (*model.User, error) {
+	username, host, err := parseAcct(acct)
+	if err != nil {
+		return nil, err
+	}
+	// selfHost と一致するホストは local 扱いにする
+	if host != nil && i.deps.SelfHost != "" && *host == strings.ToLower(i.deps.SelfHost) {
+		host = nil
+	}
+	return i.deps.UserRepo.FindByUsernameLower(username, host)
+}
+
+// scanCSV yields non-empty trimmed lines from a CSV body.
+func scanCSV(body []byte) []string {
+	s := bufio.NewScanner(bytes.NewReader(body))
+	s.Buffer(make([]byte, 0, 64*1024), 1024*1024)
+	out := make([]string, 0, 32)
+	for s.Scan() {
+		line := strings.TrimSpace(s.Text())
+		if line == "" {
+			continue
+		}
+		out = append(out, line)
+	}
+	return out
+}
+
+// logSkip emits a warning log for an import entry that was skipped due to an
+// error. 引数は呼び出し元が各行の位置を埋める想定。
+func logSkip(importType, acct string, err error) {
+	slog.Warn("transfer import: skipped entry",
+		"type", importType, "target", acct, "err", err)
+}

--- a/internal/core/transfer/transfer.go
+++ b/internal/core/transfer/transfer.go
@@ -1,0 +1,179 @@
+// Package transfer implements user data export/import in Misskey-compatible
+// formats. Export types produce JSON or CSV blobs saved as DriveFiles; import
+// types read DriveFile content and apply operations via the matching core
+// services.
+//
+// フォーマットは本家Misskey (packages/backend/src/queue/processors/Export*Service.ts
+// および Import*Service.ts) と一致させる。CSV 行終端は LF、JSON はインデント
+// なしの UTF-8。ファイル名は `{type}-{YYYY-MM-DD-HH-mm-ss}.{ext}`。
+package transfer
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/shiroha-a/mk/internal/core/drive"
+	"github.com/shiroha-a/mk/internal/core/notification"
+	"github.com/shiroha-a/mk/internal/model"
+	"github.com/shiroha-a/mk/internal/repository"
+)
+
+// Export types supported by Exporter.Export.
+const (
+	ExportNotes     = "notes"
+	ExportFollowing = "following"
+	ExportBlocking  = "blocking"
+	ExportMuting    = "mute"
+	ExportFavorites = "favorites"
+	ExportUserLists = "user-lists"
+	ExportAntennas  = "antennas"
+	ExportClips     = "clips"
+)
+
+// Import types supported by Importer.Import.
+const (
+	ImportFollowing = "following"
+	ImportBlocking  = "blocking"
+	ImportMuting    = "muting"
+	ImportUserLists = "user-lists"
+	ImportAntennas  = "antennas"
+)
+
+// DriveSaver writes a byte buffer as a DriveFile for a given user. Implemented
+// by *drive.Service in production.
+type DriveSaver interface {
+	Upload(in drive.UploadInput) (*model.DriveFile, error)
+}
+
+// DriveReader fetches a previously-uploaded DriveFile and streams its stored
+// content back. Used by imports to pick up the user-provided JSON/CSV.
+type DriveReader interface {
+	Fetch(fileID string) (*model.DriveFile, []byte, error)
+}
+
+// NotificationDispatcher creates a notification on a user's stream.
+// Implemented by *notification.Service.
+type NotificationDispatcher interface {
+	Create(ctx context.Context, in notification.CreateInput) (*notification.Notification, error)
+}
+
+// ErrUnsupportedType signals that the requested export/import type is not
+// understood by the package.
+var ErrUnsupportedType = fmt.Errorf("unsupported transfer type")
+
+// timestampedName produces a Misskey-compatible filename of the form
+// `{base}-{YYYY-MM-DD-HH-mm-ss}.{ext}` in UTC.
+// 本家 is local-time based but UTC is deterministic and harmless for users.
+func timestampedName(base, ext string) string {
+	return fmt.Sprintf("%s-%s.%s", base, time.Now().UTC().Format("2006-01-02-15-04-05"), ext)
+}
+
+// acct formats a user as `username` (for local) or `username@host`
+// (for remote), following Misskey's Acct.toString behaviour.
+func acct(u *model.User) string {
+	if u == nil {
+		return ""
+	}
+	if u.Host == nil || *u.Host == "" {
+		return u.Username
+	}
+	return u.Username + "@" + *u.Host
+}
+
+// ExporterDeps bundles the repositories and services an Exporter needs.
+// 明示的な struct にすることで NewExporter の引数列が膨らみすぎるのを避ける。
+type ExporterDeps struct {
+	UserRepo         repository.UserRepository
+	NoteRepo         repository.NoteRepository
+	PollRepo         repository.PollRepository
+	FollowingRepo    repository.FollowingRepository
+	BlockingRepo     repository.BlockingRepository
+	MutingRepo       repository.MutingRepository
+	NoteFavoriteRepo repository.NoteFavoriteRepository
+	AntennaRepo      repository.AntennaRepository
+	ClipRepo         repository.ClipRepository
+	ClipNoteRepo     repository.ClipNoteRepository
+	UserListRepo     repository.UserListRepository
+	Drive            DriveSaver
+	Notifier         NotificationDispatcher
+}
+
+// Exporter produces Misskey-compatible export files and saves them as
+// DriveFiles owned by the requesting user.
+type Exporter struct {
+	deps ExporterDeps
+}
+
+// NewExporter constructs an Exporter from the given dependencies.
+func NewExporter(deps ExporterDeps) *Exporter {
+	return &Exporter{deps: deps}
+}
+
+// Export runs the export pipeline for a single (userID, exportType) pair.
+// On success the user is notified via NotificationDispatcher.Create with
+// Extra={exportedEntity, fileId}. Errors bubble out to the asynq processor.
+func (e *Exporter) Export(ctx context.Context, userID, exportType string) (*model.DriveFile, error) {
+	user, err := e.deps.UserRepo.FindByID(userID)
+	if err != nil {
+		return nil, fmt.Errorf("find user: %w", err)
+	}
+
+	var (
+		body []byte
+		name string
+	)
+	switch exportType {
+	case ExportNotes:
+		body, err = e.exportNotes(user.ID)
+		name = timestampedName("notes", "json")
+	case ExportFollowing:
+		body, err = e.exportFollowing(user.ID)
+		name = timestampedName("following", "csv")
+	case ExportBlocking:
+		body, err = e.exportBlocking(user.ID)
+		name = timestampedName("blocking", "csv")
+	case ExportMuting:
+		body, err = e.exportMuting(user.ID)
+		name = timestampedName("mute", "csv")
+	case ExportFavorites:
+		body, err = e.exportFavorites(user.ID)
+		name = timestampedName("favorites", "json")
+	case ExportUserLists:
+		body, err = e.exportUserLists(user.ID)
+		name = timestampedName("user-lists", "csv")
+	case ExportAntennas:
+		body, err = e.exportAntennas(user.ID)
+		name = timestampedName("antennas", "json")
+	case ExportClips:
+		body, err = e.exportClips(user.ID)
+		name = timestampedName("clips", "json")
+	default:
+		return nil, fmt.Errorf("%w: %s", ErrUnsupportedType, exportType)
+	}
+	if err != nil {
+		return nil, fmt.Errorf("export %s: %w", exportType, err)
+	}
+
+	file, err := e.deps.Drive.Upload(drive.UploadInput{
+		User:  user,
+		Body:  body,
+		Name:  name,
+		Force: true,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("upload drive file: %w", err)
+	}
+
+	if e.deps.Notifier != nil {
+		_, _ = e.deps.Notifier.Create(ctx, notification.CreateInput{
+			NotifieeID: user.ID,
+			Type:       notification.TypeExportCompleted,
+			Extra: map[string]any{
+				"exportedEntity": exportType,
+				"fileId":         file.ID,
+			},
+		})
+	}
+	return file, nil
+}

--- a/internal/queue/processors/transfer.go
+++ b/internal/queue/processors/transfer.go
@@ -1,0 +1,74 @@
+package processors
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/hibiken/asynq"
+	"github.com/shiroha-a/mk/internal/core/transfer"
+	"github.com/shiroha-a/mk/internal/queue"
+)
+
+// ExportProcessor handles `export` tasks by delegating to transfer.Exporter.
+type ExportProcessor struct {
+	exporter *transfer.Exporter
+}
+
+// NewExportProcessor constructs an ExportProcessor.
+func NewExportProcessor(exporter *transfer.Exporter) *ExportProcessor {
+	return &ExportProcessor{exporter: exporter}
+}
+
+// Handle dispatches a single export task.
+func (p *ExportProcessor) Handle(ctx context.Context, t *asynq.Task) error {
+	if p.exporter == nil {
+		return fmt.Errorf("export processor not configured: %w", asynq.SkipRetry)
+	}
+	payload, err := queue.DecodeExportPayload(t.Payload())
+	if err != nil {
+		return fmt.Errorf("decode export payload: %w: %w", err, asynq.SkipRetry)
+	}
+	if payload.UserID == "" || payload.Type == "" {
+		return fmt.Errorf("export payload missing fields: %w", asynq.SkipRetry)
+	}
+	if _, err := p.exporter.Export(ctx, payload.UserID, payload.Type); err != nil {
+		// 未対応typeはリトライしても通らないので SkipRetry。
+		if errors.Is(err, transfer.ErrUnsupportedType) {
+			return fmt.Errorf("%w: %w", err, asynq.SkipRetry)
+		}
+		return err
+	}
+	return nil
+}
+
+// ImportProcessor handles `import` tasks by delegating to transfer.Importer.
+type ImportProcessor struct {
+	importer *transfer.Importer
+}
+
+// NewImportProcessor constructs an ImportProcessor.
+func NewImportProcessor(importer *transfer.Importer) *ImportProcessor {
+	return &ImportProcessor{importer: importer}
+}
+
+// Handle dispatches a single import task.
+func (p *ImportProcessor) Handle(ctx context.Context, t *asynq.Task) error {
+	if p.importer == nil {
+		return fmt.Errorf("import processor not configured: %w", asynq.SkipRetry)
+	}
+	payload, err := queue.DecodeImportPayload(t.Payload())
+	if err != nil {
+		return fmt.Errorf("decode import payload: %w: %w", err, asynq.SkipRetry)
+	}
+	if payload.UserID == "" || payload.Type == "" || payload.FileID == "" {
+		return fmt.Errorf("import payload missing fields: %w", asynq.SkipRetry)
+	}
+	if _, err := p.importer.Import(ctx, payload.UserID, payload.Type, payload.FileID); err != nil {
+		if errors.Is(err, transfer.ErrUnsupportedType) {
+			return fmt.Errorf("%w: %w", err, asynq.SkipRetry)
+		}
+		return err
+	}
+	return nil
+}

--- a/internal/queue/processors/transfer_test.go
+++ b/internal/queue/processors/transfer_test.go
@@ -1,0 +1,206 @@
+package processors_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/hibiken/asynq"
+	"github.com/shiroha-a/mk/internal/core/drive"
+	"github.com/shiroha-a/mk/internal/core/notification"
+	"github.com/shiroha-a/mk/internal/core/transfer"
+	"github.com/shiroha-a/mk/internal/misc/id"
+	"github.com/shiroha-a/mk/internal/model"
+	"github.com/shiroha-a/mk/internal/queue"
+	"github.com/shiroha-a/mk/internal/queue/processors"
+	"github.com/shiroha-a/mk/internal/testutil"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// --- stubs ---
+
+type stubTransferDriveSaver struct{}
+
+func (stubTransferDriveSaver) Upload(in drive.UploadInput) (*model.DriveFile, error) {
+	return &model.DriveFile{ID: "f_" + in.Name, Name: in.Name}, nil
+}
+
+type stubTransferNotifier struct{}
+
+func (stubTransferNotifier) Create(_ context.Context, _ notification.CreateInput) (*notification.Notification, error) {
+	return &notification.Notification{ID: "n"}, nil
+}
+
+type stubTransferDriveReader struct{ body []byte }
+
+func (s stubTransferDriveReader) Fetch(_ string) (*model.DriveFile, []byte, error) {
+	return &model.DriveFile{ID: "f"}, s.body, nil
+}
+
+type stubBlockingSvc struct{}
+
+func (stubBlockingSvc) Block(_, blockeeID string) (*model.Blocking, error) {
+	return &model.Blocking{ID: "b_" + blockeeID}, nil
+}
+
+type stubMutingSvc struct{}
+
+func (stubMutingSvc) Mute(_, muteeID string, _ *time.Time) (*model.Muting, error) {
+	return &model.Muting{ID: "m_" + muteeID}, nil
+}
+
+type stubFollowingSvc struct{}
+
+func (stubFollowingSvc) Follow(_, _ string) (any, error) { return nil, nil }
+
+// --- Builders ---
+
+func newTestExporter(t *testing.T) *transfer.Exporter {
+	t.Helper()
+	userRepo := testutil.NewMockUserRepository()
+	userRepo.Users["u1"] = &model.User{ID: "u1", Username: "u1", UsernameLower: "u1"}
+	return transfer.NewExporter(transfer.ExporterDeps{
+		UserRepo:         userRepo,
+		NoteRepo:         testutil.NewMockNoteRepository(),
+		PollRepo:         testutil.NewMockPollRepository(),
+		FollowingRepo:    testutil.NewMockFollowingRepository(),
+		BlockingRepo:     testutil.NewMockBlockingRepository(),
+		MutingRepo:       testutil.NewMockMutingRepository(),
+		NoteFavoriteRepo: testutil.NewMockNoteFavoriteRepository(),
+		AntennaRepo:      testutil.NewMockAntennaRepository(),
+		ClipRepo:         testutil.NewMockClipRepository(),
+		ClipNoteRepo:     testutil.NewMockClipNoteRepository(),
+		UserListRepo:     testutil.NewMockUserListRepository(),
+		Drive:            stubTransferDriveSaver{},
+		Notifier:         stubTransferNotifier{},
+	})
+}
+
+func newTestImporter(t *testing.T, body []byte) *transfer.Importer {
+	t.Helper()
+	idGen, _ := id.NewGenerator("aidx")
+	userRepo := testutil.NewMockUserRepository()
+	userRepo.Users["u1"] = &model.User{ID: "u1", Username: "u1", UsernameLower: "u1"}
+	userRepo.Users["bob"] = &model.User{ID: "bob", Username: "bob", UsernameLower: "bob"}
+	return transfer.NewImporter(transfer.ImporterDeps{
+		UserRepo:     userRepo,
+		UserListRepo: testutil.NewMockUserListRepository(),
+		AntennaRepo:  testutil.NewMockAntennaRepository(),
+		Drive:        stubTransferDriveReader{body: body},
+		Blocking:     stubBlockingSvc{},
+		Muting:       stubMutingSvc{},
+		Following:    stubFollowingSvc{},
+		Notifier:     stubTransferNotifier{},
+		IDGen:        idGen,
+		SelfHost:     "local.example",
+	})
+}
+
+// --- Tests: ExportProcessor ---
+
+func TestExportProcessor_Handle_Success(t *testing.T) {
+	exporter := newTestExporter(t)
+	p := processors.NewExportProcessor(exporter)
+	task := queue.NewExportTask(queue.ExportPayload{UserID: "u1", Type: transfer.ExportNotes})
+	err := p.Handle(context.Background(), task)
+	require.NoError(t, err)
+}
+
+func TestExportProcessor_Handle_NilExporter(t *testing.T) {
+	p := processors.NewExportProcessor(nil)
+	task := queue.NewExportTask(queue.ExportPayload{UserID: "u1", Type: transfer.ExportNotes})
+	err := p.Handle(context.Background(), task)
+	require.Error(t, err)
+	assert.ErrorIs(t, err, asynq.SkipRetry)
+}
+
+func TestExportProcessor_Handle_InvalidPayload(t *testing.T) {
+	exporter := newTestExporter(t)
+	p := processors.NewExportProcessor(exporter)
+	task := asynq.NewTask(queue.TaskTypeExport, []byte("not json"))
+	err := p.Handle(context.Background(), task)
+	require.Error(t, err)
+	assert.ErrorIs(t, err, asynq.SkipRetry)
+}
+
+func TestExportProcessor_Handle_MissingFields(t *testing.T) {
+	exporter := newTestExporter(t)
+	p := processors.NewExportProcessor(exporter)
+	task := queue.NewExportTask(queue.ExportPayload{UserID: "", Type: ""})
+	err := p.Handle(context.Background(), task)
+	require.Error(t, err)
+	assert.ErrorIs(t, err, asynq.SkipRetry)
+}
+
+func TestExportProcessor_Handle_UnsupportedType(t *testing.T) {
+	exporter := newTestExporter(t)
+	p := processors.NewExportProcessor(exporter)
+	task := queue.NewExportTask(queue.ExportPayload{UserID: "u1", Type: "nope"})
+	err := p.Handle(context.Background(), task)
+	require.Error(t, err)
+	assert.ErrorIs(t, err, asynq.SkipRetry)
+}
+
+func TestExportProcessor_Handle_ExporterError(t *testing.T) {
+	exporter := newTestExporter(t)
+	p := processors.NewExportProcessor(exporter)
+	// Unknown user -> internal error from Exporter (NOT ErrUnsupportedType)
+	task := queue.NewExportTask(queue.ExportPayload{UserID: "ghost", Type: transfer.ExportNotes})
+	err := p.Handle(context.Background(), task)
+	require.Error(t, err)
+	// ghost user lookup error propagates unchanged (no SkipRetry wrap)
+}
+
+// --- Tests: ImportProcessor ---
+
+func TestImportProcessor_Handle_Success(t *testing.T) {
+	imp := newTestImporter(t, []byte("bob\n"))
+	p := processors.NewImportProcessor(imp)
+	task := queue.NewImportTask(queue.ImportPayload{UserID: "u1", Type: transfer.ImportBlocking, FileID: "f"})
+	err := p.Handle(context.Background(), task)
+	require.NoError(t, err)
+}
+
+func TestImportProcessor_Handle_NilImporter(t *testing.T) {
+	p := processors.NewImportProcessor(nil)
+	task := queue.NewImportTask(queue.ImportPayload{UserID: "u1", Type: transfer.ImportBlocking, FileID: "f"})
+	err := p.Handle(context.Background(), task)
+	require.Error(t, err)
+	assert.ErrorIs(t, err, asynq.SkipRetry)
+}
+
+func TestImportProcessor_Handle_InvalidPayload(t *testing.T) {
+	imp := newTestImporter(t, nil)
+	p := processors.NewImportProcessor(imp)
+	task := asynq.NewTask(queue.TaskTypeImport, []byte("not json"))
+	err := p.Handle(context.Background(), task)
+	require.Error(t, err)
+	assert.ErrorIs(t, err, asynq.SkipRetry)
+}
+
+func TestImportProcessor_Handle_MissingFields(t *testing.T) {
+	imp := newTestImporter(t, nil)
+	p := processors.NewImportProcessor(imp)
+	task := queue.NewImportTask(queue.ImportPayload{UserID: "u1", Type: "", FileID: ""})
+	err := p.Handle(context.Background(), task)
+	require.Error(t, err)
+	assert.ErrorIs(t, err, asynq.SkipRetry)
+}
+
+func TestImportProcessor_Handle_UnsupportedType(t *testing.T) {
+	imp := newTestImporter(t, nil)
+	p := processors.NewImportProcessor(imp)
+	task := queue.NewImportTask(queue.ImportPayload{UserID: "u1", Type: "nope", FileID: "f"})
+	err := p.Handle(context.Background(), task)
+	require.Error(t, err)
+	assert.ErrorIs(t, err, asynq.SkipRetry)
+}
+
+func TestImportProcessor_Handle_ImporterError(t *testing.T) {
+	imp := newTestImporter(t, nil)
+	p := processors.NewImportProcessor(imp)
+	task := queue.NewImportTask(queue.ImportPayload{UserID: "ghost", Type: transfer.ImportBlocking, FileID: "f"})
+	err := p.Handle(context.Background(), task)
+	require.Error(t, err)
+}

--- a/internal/server/router.go
+++ b/internal/server/router.go
@@ -67,6 +67,7 @@ import (
 	coresearch "github.com/shiroha-a/mk/internal/core/search"
 	coresignup "github.com/shiroha-a/mk/internal/core/signup"
 	coretimeline "github.com/shiroha-a/mk/internal/core/timeline"
+	coretransfer "github.com/shiroha-a/mk/internal/core/transfer"
 	coreuser "github.com/shiroha-a/mk/internal/core/user"
 	corewebpush "github.com/shiroha-a/mk/internal/core/webpush"
 	"github.com/shiroha-a/mk/internal/entity"
@@ -117,6 +118,8 @@ func (s *Server) setupRoutes() {
 	roleRepo := repository.NewRoleRepository(s.db)
 	roleAssignmentRepo := repository.NewRoleAssignmentRepository(s.db)
 	swSubRepo := repository.NewSwSubscriptionRepository(s.db)
+	noteFavoriteRepo := repository.NewNoteFavoriteRepository(s.db)
+	userListRepo := repository.NewUserListRepository(s.db)
 
 	// Core services
 	roleService := corerole.NewService(roleRepo, roleAssignmentRepo, metaRepo, idGen)
@@ -197,6 +200,41 @@ func (s *Server) setupRoutes() {
 	imgProcessor := coredrive.NewDefaultImageProcessor()
 	driveService.SetImageProcessor(imgProcessor)
 	driveService.SetVideoProcessor(coredrive.NewFFmpegVideoProcessor(imgProcessor, nil))
+
+	// Export / Import workers (Phase 9.4): drive に保存するエクスポートと
+	// drive から読み出すインポートを asynq 経由で非同期処理する。
+	exporter := coretransfer.NewExporter(coretransfer.ExporterDeps{
+		UserRepo:         userRepo,
+		NoteRepo:         noteRepo,
+		PollRepo:         pollRepo,
+		FollowingRepo:    followingRepo,
+		BlockingRepo:     blockingRepo,
+		MutingRepo:       mutingRepo,
+		NoteFavoriteRepo: noteFavoriteRepo,
+		AntennaRepo:      antennaRepo,
+		ClipRepo:         clipRepo,
+		ClipNoteRepo:     clipNoteRepo,
+		UserListRepo:     userListRepo,
+		Drive:            driveService,
+		Notifier:         notificationService,
+	})
+	driveReader := coretransfer.NewRepoBackedDriveReader(driveFileRepo, driveStorage)
+	importer := coretransfer.NewImporter(coretransfer.ImporterDeps{
+		UserRepo:     userRepo,
+		UserListRepo: userListRepo,
+		AntennaRepo:  antennaRepo,
+		Drive:        driveReader,
+		Following:    coretransfer.NewFollowingServiceAdapter(followingService),
+		Blocking:     blockingService,
+		Muting:       mutingService,
+		Notifier:     notificationService,
+		IDGen:        idGen,
+		SelfHost:     s.config.Host,
+	})
+	exportProcessor := processors.NewExportProcessor(exporter)
+	importProcessor := processors.NewImportProcessor(importer)
+	s.queueServer.Handle(queue.TaskTypeExport, exportProcessor.Handle)
+	s.queueServer.Handle(queue.TaskTypeImport, importProcessor.Handle)
 
 	// Search (Phase 4.6)
 	// 設定に従って provider を選択する。Meilisearch が設定されていれば
@@ -407,7 +445,6 @@ func (s *Server) setupRoutes() {
 	api.POST("/notes/reactions/delete", notesHandler.ReactionsDelete, middleware.RequireAuth())
 	api.POST("/notes/polls/vote", notesHandler.PollsVote, middleware.RequireAuth())
 	// Notes extra endpoints (Phase 6)
-	noteFavoriteRepo := repository.NewNoteFavoriteRepository(s.db)
 	notesHandler.SetFavoriteRepo(noteFavoriteRepo)
 	api.POST("/notes/favorites/create", notesHandler.FavoritesCreate, middleware.RequireAuth())
 	api.POST("/notes/favorites/delete", notesHandler.FavoritesDelete, middleware.RequireAuth())
@@ -482,6 +519,22 @@ func (s *Server) setupRoutes() {
 	api.POST("/i/favorites", iHandler.Favorites, middleware.RequireAuth())
 	api.POST("/i/regenerate-token", iHandler.RegenerateToken, middleware.RequireAuth())
 	iHandler.SetFavoriteRepo(noteFavoriteRepo)
+
+	// i/export-* and i/import-* (Phase 9.4)
+	iHandler.SetTransferEnqueuer(s.queueClient)
+	api.POST("/i/export-notes", iHandler.ExportNotes, middleware.RequireAuth())
+	api.POST("/i/export-following", iHandler.ExportFollowing, middleware.RequireAuth())
+	api.POST("/i/export-blocking", iHandler.ExportBlocking, middleware.RequireAuth())
+	api.POST("/i/export-mute", iHandler.ExportMute, middleware.RequireAuth())
+	api.POST("/i/export-favorites", iHandler.ExportFavorites, middleware.RequireAuth())
+	api.POST("/i/export-user-lists", iHandler.ExportUserLists, middleware.RequireAuth())
+	api.POST("/i/export-antennas", iHandler.ExportAntennas, middleware.RequireAuth())
+	api.POST("/i/export-clips", iHandler.ExportClips, middleware.RequireAuth())
+	api.POST("/i/import-following", iHandler.ImportFollowing, middleware.RequireAuth())
+	api.POST("/i/import-blocking", iHandler.ImportBlocking, middleware.RequireAuth())
+	api.POST("/i/import-muting", iHandler.ImportMuting, middleware.RequireAuth())
+	api.POST("/i/import-user-lists", iHandler.ImportUserLists, middleware.RequireAuth())
+	api.POST("/i/import-antennas", iHandler.ImportAntennas, middleware.RequireAuth())
 
 	// i/webhooks/* — Webhook管理 (実データ)
 	webhookRepo := repository.NewWebhookRepository(s.db)
@@ -805,7 +858,6 @@ func (s *Server) setupRoutes() {
 	api.POST("/roles/users", rolesHandler.Users)
 
 	// User lists (Phase 6)
-	userListRepo := repository.NewUserListRepository(s.db)
 	userListHandler := apiuserlists.NewHandler(userListRepo, idGen)
 	api.POST("/users/lists/list", userListHandler.List, middleware.RequireAuth())
 	api.POST("/users/lists/create", userListHandler.Create, middleware.RequireAuth())


### PR DESCRIPTION
## Summary

Misskey互換のユーザーデータ Export / Import ワーカーを asynq 経由で実装しました。Exportは JSON / CSV 形式のブロブを生成して DriveFile として保存、完了時にユーザーへ通知します。Importはアップロード済みの DriveFile を読み取って follow / block / mute / user-list / antenna を再現します。出力フォーマットはオリジナル Misskey の \`ExportXxxProcessorService.ts\` / \`ImportXxxProcessorService.ts\` と同一なので、既存のエクスポートファイルをそのままインポート可能です (round-trip 互換)。

## 主な変更点

### 新規パッケージ
- \`internal/core/transfer/\` — Export/Importコア
  - \`transfer.go\` : \`Exporter\`/\`ExporterDeps\`/\`ImporterDeps\`、\`ErrUnsupportedType\`、\`timestampedName\`、\`acct\`
  - \`export_notes.go\` : JSON配列のノートエクスポート（ページネーション、poll埋め込み）
  - \`export_csv.go\` : following / blocking / muting / user-lists
  - \`export_json.go\` : favorites / antennas / clips（clip内notesはClipNoteRepoで再帰解決）
  - \`importer.go\` : Importer本体、\`parseAcct\`、\`resolveTargetUser\`、\`scanCSV\`
  - \`import_csv.go\` : following / blocking / muting / user-lists
  - \`import_antennas.go\` : JSON antenna import + 検証
  - \`drive_reader.go\` : \`RepoBackedDriveReader\`（DriveFileRepo + Storage → bytes）
  - \`adapters.go\` : \`FollowingServiceAdapter\`（\`*FollowResult\` → \`any\` ラッパ）
- \`internal/queue/processors/transfer.go\` — \`ExportProcessor\` / \`ImportProcessor\` (dispatcher)
- \`internal/api/i/transfer_handler.go\` — 13 新規エンドポイント

### 通知
- \`notification.TypeExportCompleted\` / \`TypeImportCompleted\` 追加。\`Extra\` に \`exportedEntity\` / \`importedEntity\` / \`fileId\` / \`total\` / \`applied\` / \`skipped\` を格納

### ルータ配線
- \`internal/server/router.go\` にExporter / Importer / DriveReader / Processor構築、queue server登録、API endpoints登録を追加
- 整理: \`noteFavoriteRepo\` / \`userListRepo\` を上部リポジトリブロックに移動（後段でExporter/Importerが必要なため）

## API エンドポイント

### Export (認証必須、body不要、202相当で204を返す)
- \`POST /api/i/export-notes\`
- \`POST /api/i/export-following\`
- \`POST /api/i/export-blocking\`
- \`POST /api/i/export-mute\`
- \`POST /api/i/export-favorites\`
- \`POST /api/i/export-user-lists\`
- \`POST /api/i/export-antennas\`
- \`POST /api/i/export-clips\`

### Import (認証必須、\`{fileId}\` 必須)
- \`POST /api/i/import-following\`
- \`POST /api/i/import-blocking\`
- \`POST /api/i/import-muting\`
- \`POST /api/i/import-user-lists\`
- \`POST /api/i/import-antennas\`

## フォーマット互換性

| Type | Format | 形状 |
|------|--------|------|
| notes / favorites | JSON array | \`[{id, text, cw, userId, visibility, localOnly, reactionAcceptance, fileIds, replyId, renoteId, visibleUserIds?, poll?}]\` |
| following | CSV | \`acct,withReplies=true\|false\` |
| blocking / mute | CSV | \`acct\` |
| user-lists | CSV | \`listName,acct,withReplies=false\` |
| antennas | JSON array | \`[{name, src, keywords, excludeKeywords, users, caseSensitive, localOnly, excludeBots, withReplies, withFile, userListId?}]\` |
| clips | JSON array | \`[{id, name, description, isPublic, notes:[...]}]\` |

ファイル名: \`{type}-{YYYY-MM-DD-HH-mm-ss}.{ext}\` (UTC)

## 制約事項

- **リモートユーザー解決の制限**: インポート時に acct が既知のリモートユーザー (\`userRepo.FindByUsernameLower\` で見つかる) のみ適用対象。未知のリモートユーザーは webfinger で解決する必要があるが、本PRでは対象外 → skip + warning ログ。将来的に webfinger クライアントを追加して改善する想定
- **ミュートは永続のみエクスポート**: \`ExpiresAt\` が設定されたミュートはエクスポート対象外（本家と同じ挙動）
- **カスタム絵文字の管理エクスポート (ZIP)** は Phase 9.9 で扱うため本PRでは対象外

## テスト

- ユニットテスト追加
  - \`transfer\` 90.6%: 正常系、エラーパス (repo error / drive error / missing user / nil service / malformed payload)、ページネーション loop (notes 105件)、acct パース (\`@\` prefix / SelfHost / malformed)
  - \`queue/processors\` 96.7%: 正常系、nil processor、invalid payload、missing fields、unsupported type、underlying error
  - \`api/i\` 92.7%: 全13ハンドラの正常系 + エラーパス (missing fileId / missing enqueuer / enqueue failure / invalid JSON)
- ローカル実行: \`make fmt && make lint\` pass、全75パッケージがCI閾値 (90% / adminは60%) をクリア

### 再現手順

\`\`\`bash
# 全パッケージ (CI相当)
PKGS=\$(go list -f '{{if (or .TestGoFiles .XTestGoFiles)}}{{.ImportPath}}{{end}}' ./... | tr '\n' ' ')
go test \$PKGS -race -count=1 -timeout 10m -coverprofile=coverage.out -covermode=atomic

# 本PRで追加/変更した主要パッケージのみ
go test ./internal/core/transfer/... \\
        ./internal/queue/processors/... \\
        ./internal/api/i/... \\
        ./internal/core/notification/...
\`\`\`

## Closes

Closes #2