### PR TITLE
docs: migration-from-ts.md を日本語版に差し替え

### DIFF
--- a/docs/migration-from-ts.md
+++ b/docs/migration-from-ts.md
@@ -1,16 +1,16 @@
-# Misskey-TS to Misskey-Go Migration Guide
+# Misskey-TSからMisskey-Goへの移行ガイド
 
-This guide explains how to set up Misskey-Go as a replacement backend for an existing Misskey-TS instance, sharing the same database, Redis, and frontend assets.
+本ガイドでは、既存のMisskey-TSインスタンスのバックエンドをMisskey-Goに置き換え、同じデータベース・Redis・フロントエンド資産を共有させる手順を説明する。
 
-## Prerequisites
+## 前提条件
 
 - Go 1.24+
-- PostgreSQL 15+ (existing Misskey-TS database)
+- PostgreSQL 15+ (既存のMisskey-TSデータベース)
 - Redis 7+
-- Misskey-TS source code (for frontend assets)
+- Misskey-TSのソースコード (フロントエンド資産のビルドに必要)
 - git
 
-## 1. Clone and Build
+## 1. クローンとビルド
 
 ```bash
 git clone https://github.com/shiroha-a/mk.git misskey-go
@@ -18,30 +18,30 @@ cd misskey-go
 go build -o built/misskey ./cmd/misskey
 ```
 
-## 2. Build Frontend Assets
+## 2. フロントエンド資産のビルド
 
-Misskey-Go uses the same frontend as Misskey-TS. You need the built frontend assets.
+Misskey-GoはMisskey-TSと同じフロントエンドを利用する。ビルド済みのフロントエンド資産を別途用意する必要がある。
 
 ```bash
-# Clone Misskey-TS (if not already present)
+# Misskey-TSのクローン (未取得なら)
 git clone https://github.com/misskey-dev/misskey.git ../misskey
 cd ../misskey
 
-# Install dependencies and build
+# 依存インストールとビルド
 pnpm install
 pnpm build
 
-# The build outputs are in:
-#   built/_frontend_vite_/  (JS/CSS bundles)
-#   built/_frontend_dist_/  (locales, fonts)
-#   packages/frontend/assets/  (game images, icons)
+# 成果物は以下に配置される:
+#   built/_frontend_vite_/  (JS/CSS バンドル)
+#   built/_frontend_dist_/  (locale・フォント)
+#   packages/frontend/assets/  (ゲーム画像・アイコン類)
 ```
 
-## 3. Configuration
+## 3. 設定
 
-### 3.1 Application Config
+### 3.1 アプリケーション設定
 
-Create `.config/default.yml`:
+`.config/default.yml` を作成する:
 
 ```yaml
 url: https://your-instance.example.com
@@ -50,7 +50,7 @@ port: 3000
 db:
   host: localhost
   port: 5432
-  db: misskey        # Your existing Misskey-TS database
+  db: misskey        # 既存のMisskey-TSデータベース
   user: misskey
   pass: your_password
 
@@ -58,68 +58,68 @@ redis:
   host: localhost
   port: 6379
 
-id: aidx             # Must match your Misskey-TS id generation method
+id: aidx             # Misskey-TS側のID生成方式と一致させること
 ```
 
-> **Important:** The `id` field must match the ID generation method used by your Misskey-TS instance. Check your Misskey-TS `.config/default.yml` for the correct value. Common values: `aidx`, `aid`, `meid`, `ulid`, `objectid`.
+> **重要:** `id` フィールドはMisskey-TSインスタンスで使われているID生成方式と必ず一致させること。Misskey-TS側の `.config/default.yml` を確認して正しい値を設定する。よく使われる値: `aidx`, `aid`, `meid`, `ulid`, `objectid`。
 
-### 3.2 Environment Variables
+### 3.2 環境変数
 
-Create `.env`:
+`.env` を作成する:
 
 ```bash
-# Path to built frontend assets (JS/CSS bundles)
+# ビルド済みフロントエンドのパス (JS/CSSバンドル)
 MISSKEY_FRONTEND_DIR=/path/to/misskey/built/_frontend_vite_
 
-# Path to frontend dist assets (locales, fonts)
+# フロントエンドdist資産のパス (locale・フォント)
 MISSKEY_FRONTEND_DIST_DIR=/path/to/misskey/built/_frontend_dist_
 
-# Path to twemoji SVG files
+# twemoji SVGファイルのパス
 MISSKEY_TWEMOJI_DIR=/path/to/misskey/node_modules/@discordapp/twemoji/dist/svg
 
-# Path to client assets (game images, etc.)
+# クライアント資産 (ゲーム画像等) のパス
 MISSKEY_CLIENT_ASSETS_DIR=/path/to/misskey/packages/frontend/assets
 
-# Path to static assets (favicon, splash, icons)
+# 静的資産 (favicon、splash、アイコン等) のパス
 # MISSKEY_STATIC_DIR=assets
 ```
 
-## 4. Database Migration
+## 4. データベースマイグレーション
 
-Misskey-Go adds its own tables alongside the existing Misskey-TS tables. Existing data is preserved.
+Misskey-Goは既存のMisskey-TSテーブルには手を加えず、独自のテーブルを追加する形で共存する。既存データは保持される。
 
 ```bash
-# Apply Misskey-Go migrations
+# Misskey-Goのマイグレーションを適用
 go run ./cmd/migrate -direction up
 ```
 
-This creates additional tables required by Go-specific features (e.g., `app`, `auth_session`, `webhook`, `sw_subscription`, `chat_room`, `chat_message`, `bubble_game_record`, etc.).
+これによりGo側で必要な追加テーブル (`app`, `auth_session`, `webhook`, `sw_subscription`, `chat_room`, `chat_message`, `bubble_game_record` 等) が作成される。
 
-> **Note:** Misskey-Go migrations are additive and do not modify existing Misskey-TS tables. Both backends can coexist on the same database.
+> **補足:** Misskey-Goのマイグレーションは追加のみで、既存のMisskey-TSテーブルを変更しない。両バックエンドは同じデータベース上で共存できる。
 
-## 5. Stop Misskey-TS
+## 5. Misskey-TSの停止
 
 ```bash
-# Stop the existing Misskey-TS server
-# (method depends on your deployment: systemd, pm2, docker, etc.)
+# 既存のMisskey-TSサーバーを停止する
+# (停止方法はデプロイ手段による: systemd、pm2、docker 等)
 systemctl stop misskey
-# or
+# または
 pm2 stop misskey
-# or
+# または
 docker compose stop web
 ```
 
-## 6. Start Misskey-Go
+## 6. Misskey-Goの起動
 
 ```bash
-# Load environment variables
+# 環境変数を読み込む
 source .env
 
-# Start the server
+# サーバー起動
 ./built/misskey -config .config/default.yml
 ```
 
-Or with explicit environment variables:
+または環境変数を直接指定する場合:
 
 ```bash
 MISSKEY_FRONTEND_DIR=/path/to/misskey/built/_frontend_vite_ \
@@ -129,75 +129,82 @@ MISSKEY_CLIENT_ASSETS_DIR=/path/to/misskey/packages/frontend/assets \
 ./built/misskey -config .config/default.yml
 ```
 
-## 7. Verify
+## 7. 動作確認
 
-1. Open `http://localhost:3000` in your browser
-2. Check that the entrance page loads with proper styling
-3. Log in with your existing account
-4. Verify:
-   - Timeline displays your notes
-   - Profile page shows correctly
-   - Notifications work
-   - File uploads work
-   - Reactions work
+1. ブラウザで `http://localhost:3000` を開く
+2. エントランスページがスタイル付きで正しく表示されることを確認する
+3. 既存アカウントでログインする
+4. 以下を確認する:
+   - タイムラインに自分のノートが表示される
+   - プロフィールページが正しく表示される
+   - 通知が動作する
+   - ファイルアップロードが動作する
+   - リアクションが動作する
 
-## Docker Setup
+## Docker Compose で新規構築する場合
 
-Alternatively, use Docker Compose for a fresh instance:
+新しいインスタンスをDocker Composeで立ち上げる場合は以下で起動できる:
 
 ```bash
 docker compose up -d
 ```
 
-This starts Misskey-Go with PostgreSQL and Redis. See `docker-compose.yml` for details.
+Misskey-GoがPostgreSQLおよびRedisと共に起動する。詳細は `docker-compose.yml` を参照。
 
-## Rollback to Misskey-TS
+## Misskey-TSへのロールバック
 
-To switch back to Misskey-TS:
+Misskey-TSに戻す場合の手順:
 
-1. Stop Misskey-Go
-2. Start Misskey-TS as before
+1. Misskey-Goを停止する
+2. 従来通りMisskey-TSを起動する
 
-The database is fully compatible in both directions. Misskey-Go's additional tables are ignored by Misskey-TS.
+データベースは双方向に互換性があり、Misskey-Goが追加したテーブルはMisskey-TSからは無視される。
 
-## Known Limitations
+## 既知の制限
 
-### Stub Implementations
-The following features return valid responses but do not perform full processing:
+### スタブ実装
 
-- **2FA/WebAuthn** - Returns 204 (not yet implemented)
-- **Export/Import** - Jobs are queued but workers are not yet implemented
-- **Reversi** - Game listing works but real-time play is not yet implemented
-- **Federation (remote)** - Local ActivityPub works; remote object fetching is limited
+以下の機能は正常なレスポンスを返すものの、完全な処理は未実装:
 
-### Differences from Misskey-TS
+- **2FA/WebAuthn** — 204を返すのみ (未実装)
+- **Export/Import** — ジョブはキューに積まれるがワーカーが未実装
+- **Reversi** — ゲーム一覧は取得できるがリアルタイム対戦は未実装
+- **連合 (リモート)** — ローカルのActivityPubは動作するが、リモートオブジェクトの取得は限定的
 
-- **Timeline** - Falls back to DB query when Redis cache is empty (e.g., after server restart)
-- **Identicon** - Generated avatars have a slightly different visual style
-- **Notifications** - Not pushed via WebSocket in real-time; visible on page reload
+### Misskey-TSとの差異
 
-## Troubleshooting
+- **タイムライン** — Redisキャッシュが空の場合 (サーバー再起動直後等) はDBクエリにフォールバックする
+- **Identicon** — 生成される自動アバターの見た目が若干異なる
+- **通知** — WebSocketによるリアルタイム配信は未対応。ページ再読み込みで表示される
 
-### Page shows "Loading..." forever
-- Check that `MISSKEY_FRONTEND_DIR` points to a valid built frontend directory
-- Verify the frontend was built successfully (`ls $MISSKEY_FRONTEND_DIR/manifest.json`)
+## トラブルシューティング
 
-### Emojis not displaying
-- Check that `MISSKEY_TWEMOJI_DIR` points to the correct twemoji SVG directory
-- Verify: `ls $MISSKEY_TWEMOJI_DIR/1f44d.svg`
+### ページが「Loading...」のまま進まない
 
-### Game images not showing
-- Check that `MISSKEY_CLIENT_ASSETS_DIR` points to `packages/frontend/assets/`
-- Verify: `ls $MISSKEY_CLIENT_ASSETS_DIR/drop-and-fusion/`
+- `MISSKEY_FRONTEND_DIR` が正しいビルド済みフロントエンドディレクトリを指しているか確認する
+- フロントエンドが正常にビルドされているか確認する (`ls $MISSKEY_FRONTEND_DIR/manifest.json`)
 
-### CSS/styling broken
-- Ensure you're using the production build (not Vite dev mode)
-- Check that `MISSKEY_FRONTEND_DIST_DIR` is set (for locales/fonts)
+### 絵文字が表示されない
 
-### Timeline empty after restart
-- This is expected. New notes will appear in the timeline immediately.
-- Existing notes will show after the first DB fallback query.
+- `MISSKEY_TWEMOJI_DIR` が正しいtwemoji SVGディレクトリを指しているか確認する
+- 確認コマンド: `ls $MISSKEY_TWEMOJI_DIR/1f44d.svg`
 
-### File upload fails with CREDENTIAL_REQUIRED
-- Ensure the auth middleware is processing multipart/form-data requests correctly
-- Check server logs for authentication errors
+### ゲーム画像が表示されない
+
+- `MISSKEY_CLIENT_ASSETS_DIR` が `packages/frontend/assets/` を指しているか確認する
+- 確認コマンド: `ls $MISSKEY_CLIENT_ASSETS_DIR/drop-and-fusion/`
+
+### CSS/スタイルが崩れる
+
+- プロダクションビルドを使用していることを確認する (Viteのdevモードではない)
+- `MISSKEY_FRONTEND_DIST_DIR` が設定されているか確認する (locale・フォント用)
+
+### 再起動後にタイムラインが空になる
+
+- これは期待通りの挙動。新規ノートは即時にタイムラインへ反映される
+- 既存ノートは初回のDBフォールバッククエリ実行後に表示される
+
+### ファイルアップロードが `CREDENTIAL_REQUIRED` で失敗する
+
+- 認証ミドルウェアが `multipart/form-data` リクエストを正しく処理できているか確認する
+- サーバーログで認証エラーを確認する


### PR DESCRIPTION
## Summary

`docs/migration-from-ts.md` を英語から日本語へ全面的に差し替えた。プロジェクトの主な利用者層が日本語話者であることを踏まえ、参照コストを下げる目的。

## 主な変更点

- `docs/migration-from-ts.md` の本文を日本語に翻訳
- ファイル名・章立て・見出し階層は原文のまま保持 (既存リンクを壊さないため)
- コマンド例・環境変数名・パス・設定キー (`MISSKEY_FRONTEND_DIR` 等) は英語のまま保持
- CLAUDE.md 「日本語の書式」ルールに従い、日本語中の不要な半角スペースは入れない方針で統一
- 構成変更や追記は行わず、純粋な翻訳に限定

## 影響範囲

- 変更対象: `docs/migration-from-ts.md` 1ファイルのみ
- コード / ビルド / CI には一切影響しない

## テスト

- 純 docs 変更のため実行テストなし
- `make fmt` / `make lint` / `make test` の結果は変わらない想定

## その他

英語版が必要な場合は本 PR マージ後に別 issue で bilingual 化を検討できる構成。

Closes #12