### PR TITLE
Phase 9.6 リバーシWebSocket対戦

### DIFF
--- a/internal/core/reversi/service.go
+++ b/internal/core/reversi/service.go
@@ -2,10 +2,19 @@ package reversi
 
 import (
 	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"math/rand"
+	"strconv"
 	"time"
 
 	"github.com/redis/go-redis/v9"
+	"github.com/shiroha-a/mk/internal/model"
+	"github.com/shiroha-a/mk/internal/repository"
 )
+
+// --- Federation ID cache (existing) ---
 
 // FederationIDCache manages federationId ↔ gameId mapping in Redis.
 type FederationIDCache struct {
@@ -47,4 +56,574 @@ var ValidUpdateKeys = map[string]bool{
 // IsValidUpdateKey checks if a key is allowed for federation settings updates.
 func IsValidUpdateKey(key string) bool {
 	return ValidUpdateKeys[key]
+}
+
+// --- Errors returned by Service methods ---
+
+var (
+	// ErrGameNotFound is returned when the referenced game does not exist.
+	ErrGameNotFound = errors.New("reversi game not found")
+	// ErrNotPlayer is returned when a non-player attempts a player-only action.
+	ErrNotPlayer = errors.New("user is not a player in this game")
+	// ErrAlreadyStarted is returned when attempting pre-start changes on a
+	// running game.
+	ErrAlreadyStarted = errors.New("reversi game already started")
+	// ErrAlreadyEnded is returned when attempting any action on a concluded game.
+	ErrAlreadyEnded = errors.New("reversi game already ended")
+	// ErrNotStarted is returned when attempting in-game actions on a pre-start
+	// game.
+	ErrNotStarted = errors.New("reversi game not yet started")
+	// ErrNotYourTurn is returned when a player tries to move out of turn.
+	ErrNotYourTurn = errors.New("not your turn")
+	// ErrInvalidMove is returned when a move violates game rules.
+	ErrInvalidMove = errors.New("invalid move")
+	// ErrInvalidSetting is returned when an updateSettings key/value is refused.
+	ErrInvalidSetting = errors.New("invalid setting")
+)
+
+// --- PubSub publisher interface ---
+
+// GamePublisher is the minimal interface the Service uses to push events to
+// the reversi WebSocket channel. 循環依存を避けるため interface で受ける。
+type GamePublisher interface {
+	PublishGameEvent(gameID, eventType string, body any)
+}
+
+// --- Core service ---
+
+// Service manages reversi game state transitions and publishes updates to
+// the matching WebSocket channel.
+type Service struct {
+	repo      repository.ReversiRepository
+	publisher GamePublisher
+	redis     redis.Cmdable
+	fedCache  *FederationIDCache
+}
+
+// NewService constructs a Service with the required dependencies.
+func NewService(
+	repo repository.ReversiRepository,
+	publisher GamePublisher,
+	r redis.Cmdable,
+) *Service {
+	return &Service{repo: repo, publisher: publisher, redis: r}
+}
+
+// SetFederationCache attaches a FederationIDCache so that federated
+// Invite/Join/Leave messages can resolve the game id.
+func (s *Service) SetFederationCache(c *FederationIDCache) {
+	s.fedCache = c
+}
+
+// --- Queries ---
+
+// Get fetches a game by id.
+func (s *Service) Get(_ context.Context, gameID string) (*model.ReversiGame, error) {
+	game, err := s.repo.FindByID(gameID)
+	if err != nil {
+		return nil, ErrGameNotFound
+	}
+	return game, nil
+}
+
+// --- Pre-start transitions ---
+
+// UpdateReady toggles the per-user ready flag. When both players are ready,
+// StartGame is fired automatically.
+func (s *Service) UpdateReady(ctx context.Context, gameID, userID string, ready bool) error {
+	game, err := s.Get(ctx, gameID)
+	if err != nil {
+		return err
+	}
+	if game.IsStarted {
+		return ErrAlreadyStarted
+	}
+	if game.IsEnded {
+		return ErrAlreadyEnded
+	}
+	if !isPlayer(game, userID) {
+		return ErrNotPlayer
+	}
+	if game.User1ID == userID {
+		game.User1Ready = ready
+	} else {
+		game.User2Ready = ready
+	}
+	if err := s.repo.Update(game); err != nil {
+		return err
+	}
+	s.publish(gameID, "changeReadyStates", map[string]any{
+		"user1": game.User1Ready,
+		"user2": game.User2Ready,
+	})
+	if game.User1Ready && game.User2Ready {
+		return s.StartGame(ctx, game)
+	}
+	return nil
+}
+
+// UpdateSettings mutates a single pre-start setting (map, bw, isLlotheo, etc.)
+// and broadcasts the change so both clients can re-render.
+func (s *Service) UpdateSettings(ctx context.Context, gameID, userID, key string, value json.RawMessage) error {
+	game, err := s.Get(ctx, gameID)
+	if err != nil {
+		return err
+	}
+	if game.IsStarted || game.IsEnded {
+		return ErrAlreadyStarted
+	}
+	if !isPlayer(game, userID) {
+		return ErrNotPlayer
+	}
+	if !IsValidUpdateKey(key) {
+		return ErrInvalidSetting
+	}
+	if err := applySetting(game, key, value); err != nil {
+		return err
+	}
+	// 設定変更は ready 状態をリセットする (本家挙動)
+	game.User1Ready = false
+	game.User2Ready = false
+	if err := s.repo.Update(game); err != nil {
+		return err
+	}
+	var valueAny any
+	_ = json.Unmarshal(value, &valueAny)
+	s.publish(gameID, "updateSettings", map[string]any{
+		"userId": userID,
+		"key":    key,
+		"value":  valueAny,
+	})
+	s.publish(gameID, "changeReadyStates", map[string]any{
+		"user1": false, "user2": false,
+	})
+	return nil
+}
+
+// CancelGame aborts a pre-start game. Both players receive `canceled` and the
+// game row is deleted.
+func (s *Service) CancelGame(ctx context.Context, gameID, userID string) error {
+	game, err := s.Get(ctx, gameID)
+	if err != nil {
+		return err
+	}
+	if game.IsStarted {
+		return ErrAlreadyStarted
+	}
+	if !isPlayer(game, userID) {
+		return ErrNotPlayer
+	}
+	if err := s.repo.Delete(gameID); err != nil {
+		return err
+	}
+	s.publish(gameID, "canceled", map[string]any{"userId": userID})
+	return nil
+}
+
+// --- Start ---
+
+// StartGame transitions the game to in-progress state. color 割り当ては
+// game.BW ("random" | "1" | "2") に従い、Redis に最初のターンタイマーをセット
+// してから `started` イベントを publish する。
+func (s *Service) StartGame(ctx context.Context, game *model.ReversiGame) error {
+	if game.IsStarted {
+		return ErrAlreadyStarted
+	}
+	if game.IsEnded {
+		return ErrAlreadyEnded
+	}
+
+	black := pickBlack(game.BW)
+	game.Black = &black
+	game.IsStarted = true
+	now := time.Now()
+	game.StartedAt = &now
+
+	if err := s.repo.Update(game); err != nil {
+		return err
+	}
+	// 初期ターンタイマー: logsCount=0 (まだ一手も置かれていない)
+	s.setTurnTimer(ctx, game.ID, 0, game.TimeLimitForEachTurn)
+	s.publish(game.ID, "started", map[string]any{"game": packGame(game)})
+	return nil
+}
+
+// --- In-game actions ---
+
+// PutStone validates and applies a move, publishes the log, and ends the game
+// if the engine reports terminal state.
+func (s *Service) PutStone(ctx context.Context, gameID, userID string, pos int) error {
+	game, err := s.Get(ctx, gameID)
+	if err != nil {
+		return err
+	}
+	if !game.IsStarted {
+		return ErrNotStarted
+	}
+	if game.IsEnded {
+		return ErrAlreadyEnded
+	}
+	if !isPlayer(game, userID) {
+		return ErrNotPlayer
+	}
+	engine, err := EngineFromGame(game)
+	if err != nil {
+		return err
+	}
+	myColor, err := playerColor(game, userID)
+	if err != nil {
+		return err
+	}
+	if engine.Turn == nil || *engine.Turn != myColor {
+		return ErrNotYourTurn
+	}
+	if !engine.CanPut(myColor, pos) {
+		return ErrInvalidMove
+	}
+	engine.PutStone(pos)
+
+	// logs: [[pos, color], ...]
+	var logs [][]int
+	if len(game.Logs) > 0 {
+		_ = json.Unmarshal(game.Logs, &logs)
+	}
+	colorInt := 1
+	if !myColor {
+		colorInt = 2
+	}
+	logs = append(logs, []int{pos, colorInt})
+	raw, _ := json.Marshal(logs)
+	game.Logs = raw
+
+	if engine.Turn == nil {
+		// ゲーム終了
+		if err := s.finalizeGame(ctx, game, engine); err != nil {
+			return err
+		}
+	} else {
+		if err := s.repo.Update(game); err != nil {
+			return err
+		}
+		s.setTurnTimer(ctx, game.ID, len(logs), game.TimeLimitForEachTurn)
+	}
+
+	s.publish(gameID, "log", map[string]any{
+		"pos":       pos,
+		"color":     colorInt,
+		"player":    myColor,
+		"time":      time.Now().UnixMilli(),
+		"operation": "put",
+	})
+	if engine.Turn == nil {
+		s.publish(gameID, "ended", map[string]any{
+			"winnerId": game.WinnerID,
+			"game":     packGame(game),
+		})
+	}
+	return nil
+}
+
+// Surrender marks the opposing user as the winner and ends the game.
+func (s *Service) Surrender(ctx context.Context, gameID, userID string) error {
+	game, err := s.Get(ctx, gameID)
+	if err != nil {
+		return err
+	}
+	if game.IsEnded {
+		return ErrAlreadyEnded
+	}
+	if !isPlayer(game, userID) {
+		return ErrNotPlayer
+	}
+	winnerID := opponent(game, userID)
+	now := time.Now()
+	game.IsEnded = true
+	game.EndedAt = &now
+	game.WinnerID = &winnerID
+	game.SurrenderedUserID = &userID
+	if err := s.repo.Update(game); err != nil {
+		return err
+	}
+	s.publish(gameID, "ended", map[string]any{
+		"winnerId": winnerID,
+		"reason":   "surrender",
+		"game":     packGame(game),
+	})
+	return nil
+}
+
+// CheckTimeout is invoked when a client claims the opponent's turn timer has
+// expired. If the matching Redis key is gone, the opponent wins by timeout.
+func (s *Service) CheckTimeout(ctx context.Context, gameID string) error {
+	game, err := s.Get(ctx, gameID)
+	if err != nil {
+		return err
+	}
+	if !game.IsStarted || game.IsEnded {
+		return nil
+	}
+	var logs [][]int
+	if len(game.Logs) > 0 {
+		_ = json.Unmarshal(game.Logs, &logs)
+	}
+	exists, err := s.turnTimerExists(ctx, gameID, len(logs))
+	if err != nil {
+		return err
+	}
+	if exists {
+		// タイマー未期限: タイムアウト主張は無効。
+		return nil
+	}
+	// タイムアウト発生: 現在のターンプレイヤー (logs 末尾 + 1) を敗者にする。
+	engine, err := EngineFromGame(game)
+	if err != nil {
+		return err
+	}
+	if engine.Turn == nil {
+		return nil
+	}
+	loserID := playerIDForColor(game, *engine.Turn)
+	if loserID == "" {
+		return nil
+	}
+	winnerID := opponent(game, loserID)
+	now := time.Now()
+	game.IsEnded = true
+	game.EndedAt = &now
+	game.WinnerID = &winnerID
+	game.TimeoutUserID = &loserID
+	if err := s.repo.Update(game); err != nil {
+		return err
+	}
+	s.publish(gameID, "ended", map[string]any{
+		"winnerId": winnerID,
+		"reason":   "timeout",
+		"game":     packGame(game),
+	})
+	return nil
+}
+
+// --- helpers ---
+
+func (s *Service) publish(gameID, eventType string, body any) {
+	if s.publisher == nil {
+		return
+	}
+	s.publisher.PublishGameEvent(gameID, eventType, body)
+}
+
+func (s *Service) setTurnTimer(ctx context.Context, gameID string, turnIndex, seconds int) {
+	if s.redis == nil || seconds <= 0 {
+		return
+	}
+	key := turnTimerKey(gameID, turnIndex)
+	s.redis.Set(ctx, key, "1", time.Duration(seconds)*time.Second)
+}
+
+func (s *Service) turnTimerExists(ctx context.Context, gameID string, turnIndex int) (bool, error) {
+	if s.redis == nil {
+		return true, nil
+	}
+	key := turnTimerKey(gameID, turnIndex)
+	n, err := s.redis.Exists(ctx, key).Result()
+	if err != nil {
+		return false, err
+	}
+	return n > 0, nil
+}
+
+func turnTimerKey(gameID string, turnIndex int) string {
+	return fmt.Sprintf("reversi:game:turnTimer:%s:%d", gameID, turnIndex)
+}
+
+func (s *Service) finalizeGame(_ context.Context, game *model.ReversiGame, engine *Game) error {
+	now := time.Now()
+	game.IsEnded = true
+	game.EndedAt = &now
+	crc := strconv.FormatUint(uint64(engine.CalcCRC32()), 10)
+	game.CRC32 = &crc
+	if winnerColor := engine.Winner(); winnerColor != nil {
+		winnerID := playerIDForColor(game, *winnerColor)
+		if winnerID != "" {
+			game.WinnerID = &winnerID
+		}
+	}
+	return s.repo.Update(game)
+}
+
+// isPlayer returns true when userID matches one of the game's two players.
+func isPlayer(game *model.ReversiGame, userID string) bool {
+	return game.User1ID == userID || game.User2ID == userID
+}
+
+// opponent returns the other player's id given userID.
+func opponent(game *model.ReversiGame, userID string) string {
+	if game.User1ID == userID {
+		return game.User2ID
+	}
+	return game.User1ID
+}
+
+// playerColor computes a user's stone color from game.Black (1 | 2).
+func playerColor(game *model.ReversiGame, userID string) (Color, error) {
+	if game.Black == nil {
+		return false, errors.New("game.Black not set")
+	}
+	user1IsBlack := *game.Black == 1
+	switch userID {
+	case game.User1ID:
+		return colorFromBool(user1IsBlack), nil
+	case game.User2ID:
+		return colorFromBool(!user1IsBlack), nil
+	}
+	return false, ErrNotPlayer
+}
+
+// playerIDForColor is the inverse of playerColor — returns the user id that
+// plays the given color.
+func playerIDForColor(game *model.ReversiGame, color Color) string {
+	if game.Black == nil {
+		return ""
+	}
+	user1IsBlack := *game.Black == 1
+	if color == Black {
+		if user1IsBlack {
+			return game.User1ID
+		}
+		return game.User2ID
+	}
+	if user1IsBlack {
+		return game.User2ID
+	}
+	return game.User1ID
+}
+
+func colorFromBool(black bool) Color {
+	if black {
+		return Black
+	}
+	return White
+}
+
+// pickBlack returns 1 or 2 per the BW setting, defaulting to random.
+func pickBlack(bw string) int {
+	switch bw {
+	case "1":
+		return 1
+	case "2":
+		return 2
+	}
+	// "random" など
+	//nolint:gosec // G404 — UX randomness, non-cryptographic is fine
+	if rand.Intn(2) == 0 {
+		return 1
+	}
+	return 2
+}
+
+// applySetting writes the typed raw JSON value into the matching game column.
+func applySetting(game *model.ReversiGame, key string, raw json.RawMessage) error {
+	switch key {
+	case "map":
+		var m []string
+		if err := json.Unmarshal(raw, &m); err != nil {
+			return ErrInvalidSetting
+		}
+		game.Map = m
+	case "bw":
+		var v any
+		if err := json.Unmarshal(raw, &v); err != nil {
+			return ErrInvalidSetting
+		}
+		game.BW = fmt.Sprint(v)
+	case "isLlotheo":
+		var b bool
+		if err := json.Unmarshal(raw, &b); err != nil {
+			return ErrInvalidSetting
+		}
+		game.IsLlotheo = b
+	case "canPutEverywhere":
+		var b bool
+		if err := json.Unmarshal(raw, &b); err != nil {
+			return ErrInvalidSetting
+		}
+		game.CanPutEverywhere = b
+	case "loopedBoard":
+		var b bool
+		if err := json.Unmarshal(raw, &b); err != nil {
+			return ErrInvalidSetting
+		}
+		game.LoopedBoard = b
+	case "timeLimitForEachTurn":
+		var n int
+		if err := json.Unmarshal(raw, &n); err != nil {
+			return ErrInvalidSetting
+		}
+		if n < 0 {
+			return ErrInvalidSetting
+		}
+		game.TimeLimitForEachTurn = n
+	case "noIrregularRules":
+		var b bool
+		if err := json.Unmarshal(raw, &b); err != nil {
+			return ErrInvalidSetting
+		}
+		game.NoIrregularRules = b
+	default:
+		return ErrInvalidSetting
+	}
+	return nil
+}
+
+// EngineFromGame restores a reversi.Game engine from the persisted state by
+// replaying the move log against the original map.
+func EngineFromGame(game *model.ReversiGame) (*Game, error) {
+	opts := Options{
+		IsLlotheo:        game.IsLlotheo,
+		CanPutEverywhere: game.CanPutEverywhere,
+		LoopedBoard:      game.LoopedBoard,
+	}
+	engine := NewGame([]string(game.Map), opts)
+	if len(game.Logs) == 0 {
+		return engine, nil
+	}
+	var logs [][]int
+	if err := json.Unmarshal(game.Logs, &logs); err != nil {
+		return nil, fmt.Errorf("decode logs: %w", err)
+	}
+	for _, entry := range logs {
+		if len(entry) >= 1 {
+			engine.PutStone(entry[0])
+		}
+	}
+	return engine, nil
+}
+
+// packGame is a minimal JSON projection used by event bodies. 詳細ペイロード
+// は api ハンドラ側の packGame を使うため、ここでは stream 配信に必要な最小の
+// フィールドのみ含める。
+func packGame(game *model.ReversiGame) map[string]any {
+	return map[string]any{
+		"id":                   game.ID,
+		"user1Id":              game.User1ID,
+		"user2Id":              game.User2ID,
+		"user1Ready":           game.User1Ready,
+		"user2Ready":           game.User2Ready,
+		"black":                game.Black,
+		"isStarted":            game.IsStarted,
+		"isEnded":              game.IsEnded,
+		"winnerId":             game.WinnerID,
+		"surrenderedUserId":    game.SurrenderedUserID,
+		"timeoutUserId":        game.TimeoutUserID,
+		"timeLimitForEachTurn": game.TimeLimitForEachTurn,
+		"logs":                 game.Logs,
+		"map":                  game.Map,
+		"bw":                   game.BW,
+		"isLlotheo":            game.IsLlotheo,
+		"canPutEverywhere":     game.CanPutEverywhere,
+		"loopedBoard":          game.LoopedBoard,
+		"noIrregularRules":     game.NoIrregularRules,
+		"startedAt":            game.StartedAt,
+		"endedAt":              game.EndedAt,
+	}
 }

--- a/internal/core/reversi/service_redis_test.go
+++ b/internal/core/reversi/service_redis_test.go
@@ -1,0 +1,162 @@
+package reversi
+
+import (
+	"context"
+	"log"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/lib/pq"
+	"github.com/shiroha-a/mk/internal/model"
+	"github.com/shiroha-a/mk/internal/testutil"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gorm.io/datatypes"
+)
+
+var reversiTestRedis *testutil.TestRedis
+
+func TestMain(m *testing.M) {
+	ctx := context.Background()
+	tr, err := testutil.SetupRedis(ctx)
+	if err != nil {
+		log.Fatalf("reversi test: redis setup failed: %v", err)
+	}
+	reversiTestRedis = tr
+	code := m.Run()
+	reversiTestRedis.Teardown(ctx)
+	os.Exit(code)
+}
+
+// newStartedGameWithRedis creates a started game wired to a real Redis so
+// turn timer tests can actually exercise SET/EXISTS.
+func newStartedGameWithRedis(t *testing.T) (*model.ReversiGame, *fakeRepo, *capturePublisher, *Service) {
+	t.Helper()
+	reversiTestRedis.FlushAll(context.Background())
+	repo := newFakeRepo()
+	pub := &capturePublisher{}
+	svc := NewService(repo, pub, reversiTestRedis.Client)
+
+	game := &model.ReversiGame{
+		ID:                   "rg1",
+		User1ID:              "alice",
+		User2ID:              "bob",
+		Map:                  pq.StringArray{"--------", "--------", "--------", "---wb---", "---bw---", "--------", "--------", "--------"},
+		BW:                   "1",
+		TimeLimitForEachTurn: 1, // 1 second for fast timeout
+		Logs:                 datatypes.JSON("[]"),
+	}
+	require.NoError(t, repo.Create(game))
+	require.NoError(t, svc.UpdateReady(context.Background(), game.ID, "alice", true))
+	require.NoError(t, svc.UpdateReady(context.Background(), game.ID, "bob", true))
+	fresh, _ := repo.FindByID(game.ID)
+	return fresh, repo, pub, svc
+}
+
+func TestService_CheckTimeout_StillRunning(t *testing.T) {
+	game, _, _, svc := newStartedGameWithRedis(t)
+	// Timer just set by StartGame (TTL 1s) — check immediately, still valid.
+	err := svc.CheckTimeout(context.Background(), game.ID)
+	require.NoError(t, err)
+	got, _ := svc.Get(context.Background(), game.ID)
+	assert.False(t, got.IsEnded, "timer still valid, game must not end")
+}
+
+func TestService_CheckTimeout_Expired(t *testing.T) {
+	game, repo, pub, svc := newStartedGameWithRedis(t)
+
+	// Explicitly delete the timer key to simulate expiry.
+	key := turnTimerKey(game.ID, 0)
+	require.NoError(t, reversiTestRedis.Client.Del(context.Background(), key).Err())
+
+	require.NoError(t, svc.CheckTimeout(context.Background(), game.ID))
+
+	got, _ := repo.FindByID(game.ID)
+	assert.True(t, got.IsEnded)
+	require.NotNil(t, got.WinnerID)
+	assert.Equal(t, "bob", *got.WinnerID, "current turn is alice(black), she loses")
+	require.NotNil(t, got.TimeoutUserID)
+	assert.Equal(t, "alice", *got.TimeoutUserID)
+	assert.Contains(t, pub.types(), "ended")
+}
+
+func TestService_SetTurnTimer_KeyExists(t *testing.T) {
+	reversiTestRedis.FlushAll(context.Background())
+	svc := NewService(newFakeRepo(), &capturePublisher{}, reversiTestRedis.Client)
+	ctx := context.Background()
+	svc.setTurnTimer(ctx, "g1", 0, 5)
+
+	exists, err := svc.turnTimerExists(ctx, "g1", 0)
+	require.NoError(t, err)
+	assert.True(t, exists)
+
+	missing, err := svc.turnTimerExists(ctx, "g1", 1)
+	require.NoError(t, err)
+	assert.False(t, missing)
+}
+
+func TestService_SetTurnTimer_ZeroSecondsSkipped(t *testing.T) {
+	reversiTestRedis.FlushAll(context.Background())
+	svc := NewService(newFakeRepo(), nil, reversiTestRedis.Client)
+	svc.setTurnTimer(context.Background(), "g1", 0, 0) // no-op path
+	exists, err := svc.turnTimerExists(context.Background(), "g1", 0)
+	require.NoError(t, err)
+	assert.False(t, exists)
+}
+
+func TestService_PutStone_EndsGame_SmallBoard(t *testing.T) {
+	// Construct a tiny 4x4 board where filling quickly ends the game so the
+	// finalize branch is exercised.
+	reversiTestRedis.FlushAll(context.Background())
+	repo := newFakeRepo()
+	pub := &capturePublisher{}
+	svc := NewService(repo, pub, reversiTestRedis.Client)
+
+	tinyMap := pq.StringArray{
+		"----",
+		"-wb-",
+		"-bw-",
+		"----",
+	}
+	game := &model.ReversiGame{
+		ID:                   "tiny1",
+		User1ID:              "alice",
+		User2ID:              "bob",
+		Map:                  tinyMap,
+		BW:                   "1",
+		TimeLimitForEachTurn: 60,
+		Logs:                 datatypes.JSON("[]"),
+	}
+	require.NoError(t, repo.Create(game))
+	require.NoError(t, svc.UpdateReady(context.Background(), game.ID, "alice", true))
+	require.NoError(t, svc.UpdateReady(context.Background(), game.ID, "bob", true))
+
+	// On this board, run PutStone until one side cannot move → game ends.
+	// We use a loop that alternates based on engine turn.
+	for range 16 {
+		g, _ := repo.FindByID(game.ID)
+		if g.IsEnded {
+			break
+		}
+		engine, err := EngineFromGame(g)
+		require.NoError(t, err)
+		if engine.Turn == nil {
+			break
+		}
+		places := engine.GetPuttablePlaces(*engine.Turn)
+		if len(places) == 0 {
+			break
+		}
+		uid := playerIDForColor(g, *engine.Turn)
+		require.NotEmpty(t, uid)
+		require.NoError(t, svc.PutStone(context.Background(), game.ID, uid, places[0]))
+	}
+
+	final, _ := repo.FindByID(game.ID)
+	assert.True(t, final.IsEnded, "small board should end via normal play")
+	assert.NotNil(t, final.EndedAt)
+	assert.NotNil(t, final.CRC32)
+	assert.Contains(t, pub.types(), "ended")
+	_ = time.Now
+}

--- a/internal/core/reversi/service_wire_test.go
+++ b/internal/core/reversi/service_wire_test.go
@@ -1,0 +1,576 @@
+package reversi
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/lib/pq"
+	"github.com/shiroha-a/mk/internal/model"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gorm.io/datatypes"
+)
+
+// --- in-memory repository ---
+
+type fakeRepo struct {
+	mu        sync.Mutex
+	games     map[string]*model.ReversiGame
+	findErr   error
+	updateErr error
+}
+
+func newFakeRepo() *fakeRepo {
+	return &fakeRepo{games: make(map[string]*model.ReversiGame)}
+}
+
+func (r *fakeRepo) Create(g *model.ReversiGame) error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	clone := *g
+	r.games[g.ID] = &clone
+	return nil
+}
+
+func (r *fakeRepo) FindByID(id string) (*model.ReversiGame, error) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if r.findErr != nil {
+		return nil, r.findErr
+	}
+	if g, ok := r.games[id]; ok {
+		clone := *g
+		return &clone, nil
+	}
+	return nil, errors.New("not found")
+}
+
+func (r *fakeRepo) Update(g *model.ReversiGame) error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if r.updateErr != nil {
+		return r.updateErr
+	}
+	clone := *g
+	r.games[g.ID] = &clone
+	return nil
+}
+
+func (r *fakeRepo) ListByUser(userID string, limit int) ([]*model.ReversiGame, error) {
+	_ = userID
+	_ = limit
+	return nil, nil
+}
+
+func (r *fakeRepo) ListActive() ([]*model.ReversiGame, error) {
+	return nil, nil
+}
+
+func (r *fakeRepo) Delete(id string) error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	delete(r.games, id)
+	return nil
+}
+
+// --- capture publisher ---
+
+type capturePublisher struct {
+	mu     sync.Mutex
+	events []capturedEvent
+}
+
+type capturedEvent struct {
+	gameID string
+	kind   string
+	body   any
+}
+
+func (p *capturePublisher) PublishGameEvent(gameID, eventType string, body any) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	p.events = append(p.events, capturedEvent{gameID, eventType, body})
+}
+
+func (p *capturePublisher) types() []string {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	out := make([]string, len(p.events))
+	for i, e := range p.events {
+		out[i] = e.kind
+	}
+	return out
+}
+
+func (p *capturePublisher) latestBody() any {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	if len(p.events) == 0 {
+		return nil
+	}
+	return p.events[len(p.events)-1].body
+}
+
+// --- helpers ---
+
+func newPendingGame(t *testing.T) (*model.ReversiGame, *fakeRepo, *capturePublisher, *Service) {
+	t.Helper()
+	repo := newFakeRepo()
+	pub := &capturePublisher{}
+	svc := NewService(repo, pub, nil)
+	game := &model.ReversiGame{
+		ID:                   "g1",
+		User1ID:              "alice",
+		User2ID:              "bob",
+		Map:                  pq.StringArray{"--------", "--------", "--------", "---wb---", "---bw---", "--------", "--------", "--------"},
+		BW:                   "1",
+		TimeLimitForEachTurn: 90,
+		Logs:                 datatypes.JSON("[]"),
+	}
+	require.NoError(t, repo.Create(game))
+	return game, repo, pub, svc
+}
+
+// --- Ready / Start ---
+
+func TestService_UpdateReady_Both_TriggersStart(t *testing.T) {
+	game, repo, pub, svc := newPendingGame(t)
+	ctx := context.Background()
+
+	require.NoError(t, svc.UpdateReady(ctx, game.ID, "alice", true))
+	require.NoError(t, svc.UpdateReady(ctx, game.ID, "bob", true))
+
+	got, err := repo.FindByID(game.ID)
+	require.NoError(t, err)
+	assert.True(t, got.IsStarted)
+	assert.NotNil(t, got.StartedAt)
+	assert.NotNil(t, got.Black)
+
+	// ready → ready → changeReadyStates, changeReadyStates, started
+	kinds := pub.types()
+	assert.Contains(t, kinds, "changeReadyStates")
+	assert.Contains(t, kinds, "started")
+}
+
+func TestService_UpdateReady_NotPlayer(t *testing.T) {
+	game, _, _, svc := newPendingGame(t)
+	err := svc.UpdateReady(context.Background(), game.ID, "carol", true)
+	assert.ErrorIs(t, err, ErrNotPlayer)
+}
+
+func TestService_UpdateReady_GameNotFound(t *testing.T) {
+	_, _, _, svc := newPendingGame(t)
+	err := svc.UpdateReady(context.Background(), "ghost", "alice", true)
+	assert.ErrorIs(t, err, ErrGameNotFound)
+}
+
+func TestService_UpdateReady_AlreadyStarted(t *testing.T) {
+	game, repo, _, svc := newPendingGame(t)
+	game.IsStarted = true
+	_ = repo.Update(game)
+	err := svc.UpdateReady(context.Background(), game.ID, "alice", true)
+	assert.ErrorIs(t, err, ErrAlreadyStarted)
+}
+
+func TestService_UpdateReady_AlreadyEnded(t *testing.T) {
+	game, repo, _, svc := newPendingGame(t)
+	game.IsEnded = true
+	_ = repo.Update(game)
+	err := svc.UpdateReady(context.Background(), game.ID, "alice", true)
+	assert.ErrorIs(t, err, ErrAlreadyEnded)
+}
+
+// --- Settings ---
+
+func TestService_UpdateSettings_ChangesMapResetsReady(t *testing.T) {
+	game, repo, pub, svc := newPendingGame(t)
+	game.User1Ready = true
+	_ = repo.Update(game)
+
+	raw, _ := json.Marshal([]string{"bw", "wb"})
+	err := svc.UpdateSettings(context.Background(), game.ID, "alice", "map", raw)
+	require.NoError(t, err)
+
+	got, _ := repo.FindByID(game.ID)
+	assert.Equal(t, []string{"bw", "wb"}, []string(got.Map))
+	assert.False(t, got.User1Ready)
+	assert.Contains(t, pub.types(), "updateSettings")
+	assert.Contains(t, pub.types(), "changeReadyStates")
+}
+
+func TestService_UpdateSettings_InvalidKey(t *testing.T) {
+	game, _, _, svc := newPendingGame(t)
+	err := svc.UpdateSettings(context.Background(), game.ID, "alice", "bogus", json.RawMessage(`null`))
+	assert.ErrorIs(t, err, ErrInvalidSetting)
+}
+
+func TestService_UpdateSettings_NotPlayer(t *testing.T) {
+	game, _, _, svc := newPendingGame(t)
+	err := svc.UpdateSettings(context.Background(), game.ID, "carol", "isLlotheo", json.RawMessage(`true`))
+	assert.ErrorIs(t, err, ErrNotPlayer)
+}
+
+func TestService_UpdateSettings_AlreadyStarted(t *testing.T) {
+	game, repo, _, svc := newPendingGame(t)
+	game.IsStarted = true
+	_ = repo.Update(game)
+	err := svc.UpdateSettings(context.Background(), game.ID, "alice", "isLlotheo", json.RawMessage(`true`))
+	assert.ErrorIs(t, err, ErrAlreadyStarted)
+}
+
+func TestService_UpdateSettings_TypedKeys(t *testing.T) {
+	game, repo, _, svc := newPendingGame(t)
+	cases := []struct {
+		key string
+		val string
+	}{
+		{"bw", `"2"`},
+		{"isLlotheo", `true`},
+		{"canPutEverywhere", `true`},
+		{"loopedBoard", `true`},
+		{"timeLimitForEachTurn", `60`},
+		{"noIrregularRules", `true`},
+	}
+	for _, tc := range cases {
+		err := svc.UpdateSettings(context.Background(), game.ID, "alice", tc.key, json.RawMessage(tc.val))
+		require.NoError(t, err, tc.key)
+	}
+	got, _ := repo.FindByID(game.ID)
+	assert.Equal(t, "2", got.BW)
+	assert.True(t, got.IsLlotheo)
+	assert.True(t, got.CanPutEverywhere)
+	assert.True(t, got.LoopedBoard)
+	assert.Equal(t, 60, got.TimeLimitForEachTurn)
+	assert.True(t, got.NoIrregularRules)
+}
+
+func TestService_UpdateSettings_BadJSON(t *testing.T) {
+	game, _, _, svc := newPendingGame(t)
+	err := svc.UpdateSettings(context.Background(), game.ID, "alice", "isLlotheo", json.RawMessage(`"not-bool"`))
+	assert.ErrorIs(t, err, ErrInvalidSetting)
+}
+
+func TestService_UpdateSettings_NegativeTimeLimit(t *testing.T) {
+	game, _, _, svc := newPendingGame(t)
+	err := svc.UpdateSettings(context.Background(), game.ID, "alice", "timeLimitForEachTurn", json.RawMessage(`-1`))
+	assert.ErrorIs(t, err, ErrInvalidSetting)
+}
+
+// --- Cancel ---
+
+func TestService_CancelGame(t *testing.T) {
+	game, repo, pub, svc := newPendingGame(t)
+	require.NoError(t, svc.CancelGame(context.Background(), game.ID, "alice"))
+	_, err := repo.FindByID(game.ID)
+	assert.Error(t, err)
+	assert.Contains(t, pub.types(), "canceled")
+}
+
+func TestService_CancelGame_NotPlayer(t *testing.T) {
+	game, _, _, svc := newPendingGame(t)
+	err := svc.CancelGame(context.Background(), game.ID, "carol")
+	assert.ErrorIs(t, err, ErrNotPlayer)
+}
+
+func TestService_CancelGame_AlreadyStarted(t *testing.T) {
+	game, repo, _, svc := newPendingGame(t)
+	game.IsStarted = true
+	_ = repo.Update(game)
+	err := svc.CancelGame(context.Background(), game.ID, "alice")
+	assert.ErrorIs(t, err, ErrAlreadyStarted)
+}
+
+// --- PutStone ---
+
+func startedGame(t *testing.T) (*model.ReversiGame, *fakeRepo, *capturePublisher, *Service) {
+	t.Helper()
+	game, repo, pub, svc := newPendingGame(t)
+	require.NoError(t, svc.UpdateReady(context.Background(), game.ID, "alice", true))
+	require.NoError(t, svc.UpdateReady(context.Background(), game.ID, "bob", true))
+	fresh, _ := repo.FindByID(game.ID)
+	return fresh, repo, pub, svc
+}
+
+func TestService_PutStone_Valid(t *testing.T) {
+	game, repo, pub, svc := startedGame(t)
+
+	// alice is black (BW="1")
+	// 8x8 default board: valid black moves include pos 19 (3,2), 26 (2,3), 37 (5,4), 44 (4,5)
+	require.NoError(t, svc.PutStone(context.Background(), game.ID, "alice", 19))
+
+	got, _ := repo.FindByID(game.ID)
+	var logs [][]int
+	_ = json.Unmarshal(got.Logs, &logs)
+	require.Len(t, logs, 1)
+	assert.Equal(t, 19, logs[0][0])
+
+	// log event published
+	types := pub.types()
+	assert.Contains(t, types, "log")
+}
+
+func TestService_PutStone_NotYourTurn(t *testing.T) {
+	game, _, _, svc := startedGame(t)
+	// bob is white; black moves first
+	err := svc.PutStone(context.Background(), game.ID, "bob", 19)
+	assert.ErrorIs(t, err, ErrNotYourTurn)
+}
+
+func TestService_PutStone_InvalidMove(t *testing.T) {
+	game, _, _, svc := startedGame(t)
+	err := svc.PutStone(context.Background(), game.ID, "alice", 0) // corner, not valid opening
+	assert.ErrorIs(t, err, ErrInvalidMove)
+}
+
+func TestService_PutStone_NotStarted(t *testing.T) {
+	game, _, _, svc := newPendingGame(t)
+	err := svc.PutStone(context.Background(), game.ID, "alice", 19)
+	assert.ErrorIs(t, err, ErrNotStarted)
+}
+
+func TestService_PutStone_AlreadyEnded(t *testing.T) {
+	game, repo, _, svc := startedGame(t)
+	game.IsEnded = true
+	_ = repo.Update(game)
+	err := svc.PutStone(context.Background(), game.ID, "alice", 19)
+	assert.ErrorIs(t, err, ErrAlreadyEnded)
+}
+
+func TestService_PutStone_NotPlayer(t *testing.T) {
+	game, _, _, svc := startedGame(t)
+	err := svc.PutStone(context.Background(), game.ID, "carol", 19)
+	assert.ErrorIs(t, err, ErrNotPlayer)
+}
+
+// --- Surrender ---
+
+func TestService_Surrender_SetsOpponentAsWinner(t *testing.T) {
+	game, repo, pub, svc := startedGame(t)
+	require.NoError(t, svc.Surrender(context.Background(), game.ID, "alice"))
+
+	got, _ := repo.FindByID(game.ID)
+	assert.True(t, got.IsEnded)
+	require.NotNil(t, got.WinnerID)
+	assert.Equal(t, "bob", *got.WinnerID)
+	require.NotNil(t, got.SurrenderedUserID)
+	assert.Equal(t, "alice", *got.SurrenderedUserID)
+	assert.Contains(t, pub.types(), "ended")
+}
+
+func TestService_Surrender_NotPlayer(t *testing.T) {
+	game, _, _, svc := startedGame(t)
+	err := svc.Surrender(context.Background(), game.ID, "carol")
+	assert.ErrorIs(t, err, ErrNotPlayer)
+}
+
+func TestService_Surrender_AlreadyEnded(t *testing.T) {
+	game, repo, _, svc := startedGame(t)
+	game.IsEnded = true
+	_ = repo.Update(game)
+	err := svc.Surrender(context.Background(), game.ID, "alice")
+	assert.ErrorIs(t, err, ErrAlreadyEnded)
+}
+
+// --- CheckTimeout (nil Redis skips the effective check) ---
+
+func TestService_CheckTimeout_NilRedisIsNoop(t *testing.T) {
+	// svc.redis is nil; turnTimerExists returns true → CheckTimeout returns nil
+	game, _, _, svc := startedGame(t)
+	err := svc.CheckTimeout(context.Background(), game.ID)
+	assert.NoError(t, err)
+}
+
+func TestService_CheckTimeout_PendingGameNoop(t *testing.T) {
+	game, _, _, svc := newPendingGame(t)
+	err := svc.CheckTimeout(context.Background(), game.ID)
+	assert.NoError(t, err)
+}
+
+func TestService_CheckTimeout_GameNotFound(t *testing.T) {
+	_, _, _, svc := newPendingGame(t)
+	err := svc.CheckTimeout(context.Background(), "ghost")
+	assert.ErrorIs(t, err, ErrGameNotFound)
+}
+
+// --- helpers ---
+
+func TestPickBlack_Explicit(t *testing.T) {
+	assert.Equal(t, 1, pickBlack("1"))
+	assert.Equal(t, 2, pickBlack("2"))
+	// random mode returns 1 or 2
+	for range 5 {
+		v := pickBlack("random")
+		assert.True(t, v == 1 || v == 2)
+	}
+}
+
+func TestPlayerColor(t *testing.T) {
+	b1 := 1
+	g := &model.ReversiGame{User1ID: "a", User2ID: "b", Black: &b1}
+	c, err := playerColor(g, "a")
+	require.NoError(t, err)
+	assert.Equal(t, Black, c)
+	c, err = playerColor(g, "b")
+	require.NoError(t, err)
+	assert.Equal(t, White, c)
+	b2 := 2
+	g.Black = &b2
+	c, _ = playerColor(g, "a")
+	assert.Equal(t, White, c)
+	c, _ = playerColor(g, "b")
+	assert.Equal(t, Black, c)
+}
+
+func TestPlayerColor_BlackNil(t *testing.T) {
+	g := &model.ReversiGame{User1ID: "a", User2ID: "b"}
+	_, err := playerColor(g, "a")
+	assert.Error(t, err)
+}
+
+func TestPlayerColor_NotPlayer(t *testing.T) {
+	b1 := 1
+	g := &model.ReversiGame{User1ID: "a", User2ID: "b", Black: &b1}
+	_, err := playerColor(g, "c")
+	assert.ErrorIs(t, err, ErrNotPlayer)
+}
+
+func TestPlayerIDForColor(t *testing.T) {
+	b1 := 1
+	g := &model.ReversiGame{User1ID: "a", User2ID: "b", Black: &b1}
+	assert.Equal(t, "a", playerIDForColor(g, Black))
+	assert.Equal(t, "b", playerIDForColor(g, White))
+	b2 := 2
+	g.Black = &b2
+	assert.Equal(t, "b", playerIDForColor(g, Black))
+	assert.Equal(t, "a", playerIDForColor(g, White))
+	g.Black = nil
+	assert.Equal(t, "", playerIDForColor(g, Black))
+}
+
+func TestIsPlayerOpponent(t *testing.T) {
+	g := &model.ReversiGame{User1ID: "a", User2ID: "b"}
+	assert.True(t, isPlayer(g, "a"))
+	assert.True(t, isPlayer(g, "b"))
+	assert.False(t, isPlayer(g, "c"))
+	assert.Equal(t, "b", opponent(g, "a"))
+	assert.Equal(t, "a", opponent(g, "b"))
+}
+
+func TestEngineFromGame_ReplaysLogs(t *testing.T) {
+	game := &model.ReversiGame{
+		Map:  pq.StringArray{"--------", "--------", "--------", "---wb---", "---bw---", "--------", "--------", "--------"},
+		Logs: datatypes.JSON(`[[19,1]]`),
+	}
+	engine, err := EngineFromGame(game)
+	require.NoError(t, err)
+	// alice put at pos 19; engine should now be at white's turn
+	require.NotNil(t, engine.Turn)
+	assert.Equal(t, White, *engine.Turn)
+}
+
+func TestEngineFromGame_BadLogs(t *testing.T) {
+	game := &model.ReversiGame{
+		Map:  pq.StringArray{"--------"},
+		Logs: datatypes.JSON(`not-json`),
+	}
+	_, err := EngineFromGame(game)
+	assert.Error(t, err)
+}
+
+func TestService_Nil_NoPanic(t *testing.T) {
+	s := NewService(newFakeRepo(), nil, nil)
+	s.publish("g1", "t", nil) // no publisher → no-op
+	s.setTurnTimer(context.Background(), "g1", 0, 90)
+
+	_, err := s.turnTimerExists(context.Background(), "g1", 0)
+	assert.NoError(t, err)
+
+	// nil service is nil-safe where relevant
+	assert.NotPanics(t, func() {
+		s.SetFederationCache(NewFederationIDCache(nil))
+	})
+}
+
+func TestApplySetting_AllCases(t *testing.T) {
+	g := &model.ReversiGame{}
+	// each branch already exercised via UpdateSettings; here we call directly
+	// for the unknown-key path
+	err := applySetting(g, "unknown", json.RawMessage(`null`))
+	assert.ErrorIs(t, err, ErrInvalidSetting)
+}
+
+func TestService_PutStone_RestoresFromLogs(t *testing.T) {
+	// Two moves: ensure the second move sees the board state from the first
+	game, _, _, svc := startedGame(t)
+	ctx := context.Background()
+	require.NoError(t, svc.PutStone(ctx, game.ID, "alice", 19)) // black
+	// after black at 19, white's valid moves include 18 (2,2) among others
+	// alice is black here so bob is white
+	require.NoError(t, svc.PutStone(ctx, game.ID, "bob", 18))
+}
+
+// capture UpdateError path
+func TestService_UpdateReady_UpdateError(t *testing.T) {
+	game, repo, _, svc := newPendingGame(t)
+	repo.updateErr = errors.New("db boom")
+	err := svc.UpdateReady(context.Background(), game.ID, "alice", true)
+	assert.Error(t, err)
+}
+
+func TestService_CancelGame_GameNotFound(t *testing.T) {
+	_, _, _, svc := newPendingGame(t)
+	err := svc.CancelGame(context.Background(), "ghost", "alice")
+	assert.ErrorIs(t, err, ErrGameNotFound)
+}
+
+func TestService_Surrender_GameNotFound(t *testing.T) {
+	_, _, _, svc := newPendingGame(t)
+	err := svc.Surrender(context.Background(), "ghost", "alice")
+	assert.ErrorIs(t, err, ErrGameNotFound)
+}
+
+func TestService_PutStone_GameNotFound(t *testing.T) {
+	_, _, _, svc := newPendingGame(t)
+	err := svc.PutStone(context.Background(), "ghost", "alice", 19)
+	assert.ErrorIs(t, err, ErrGameNotFound)
+}
+
+// TestStartGame_AlreadyEnded ensures StartGame rejects terminal games.
+func TestService_StartGame_AlreadyEnded(t *testing.T) {
+	game, _, _, svc := newPendingGame(t)
+	game.IsEnded = true
+	err := svc.StartGame(context.Background(), game)
+	assert.ErrorIs(t, err, ErrAlreadyEnded)
+}
+
+// ensure the SetFederationCache setter stores the passed cache
+func TestSetFederationCache(t *testing.T) {
+	s := NewService(newFakeRepo(), nil, nil)
+	c := NewFederationIDCache(nil)
+	s.SetFederationCache(c)
+	assert.Same(t, c, s.fedCache)
+}
+
+// make sure time.Time zero-value is not stored for winnerID (no panic)
+func TestService_Finalize_NoWinnerDraw(t *testing.T) {
+	// craft a game whose engine.Winner() returns nil (draw)
+	game, _, _, svc := newPendingGame(t)
+	game.IsStarted = true
+	b := 1
+	game.Black = &b
+	engine := NewGame([]string(game.Map), Options{})
+	engine.Turn = nil
+	require.NoError(t, svc.finalizeGame(context.Background(), game, engine))
+	// IsEnded set, no winner
+	assert.True(t, game.IsEnded)
+	assert.NotNil(t, game.EndedAt)
+	// Winner ID unset for draw
+	assert.Nil(t, game.WinnerID)
+	// Sanity on generated CRC32
+	require.NotNil(t, game.CRC32)
+	_ = time.Now
+}

--- a/internal/server/router.go
+++ b/internal/server/router.go
@@ -64,6 +64,7 @@ import (
 	corepage "github.com/shiroha-a/mk/internal/core/page"
 	corepoll "github.com/shiroha-a/mk/internal/core/poll"
 	corereaction "github.com/shiroha-a/mk/internal/core/reaction"
+	corereversi "github.com/shiroha-a/mk/internal/core/reversi"
 	corerole "github.com/shiroha-a/mk/internal/core/role"
 	coresearch "github.com/shiroha-a/mk/internal/core/search"
 	coresignup "github.com/shiroha-a/mk/internal/core/signup"
@@ -130,6 +131,7 @@ func (s *Server) setupRoutes() {
 	userListRepo := repository.NewUserListRepository(s.db)
 	webhookRepo := repository.NewWebhookRepository(s.db)
 	systemWebhookRepo := repository.NewSystemWebhookRepository(s.db)
+	reversiRepo := repository.NewReversiRepository(s.db)
 
 	// Core services
 	roleService := corerole.NewService(roleRepo, roleAssignmentRepo, metaRepo, idGen)
@@ -824,12 +826,17 @@ func (s *Server) setupRoutes() {
 	notePublisher := stream.NewNotePublisher(streamPubSub, idGen)
 	notificationPublisher := stream.NewNotificationPublisher(streamPubSub)
 	drivePublisher := stream.NewDrivePublisher(streamPubSub)
+	reversiPublisher := stream.NewReversiGamePublisher(streamPubSub)
 
 	// 4. 既存サービスへ publisher を注入する。これらはいずれも nil 安全な
 	//    setter で、未設定なら何もしない (テスト互換)。
 	timelineFanoutHook.SetStreamingPublisher(notePublisher)
 	notificationService.SetStreamingPublisher(notificationPublisher)
 	driveService.SetStreamingPublisher(drivePublisher)
+
+	// 5. Reversi WebSocket channel (Phase 9.6) を登録する
+	reversiService := corereversi.NewService(reversiRepo, reversiPublisher, s.redis.Default)
+	streamRegistry.Register("reversiGame", channels.NewReversiGameFactory(reversiService).New)
 
 	// 5. /streaming エンドポイント配線
 	streamingHandler := streaming.NewHandler(streamManager)
@@ -1042,7 +1049,6 @@ func (s *Server) setupRoutes() {
 	api.POST("/sw/unregister", swHandler.Unregister)
 
 	// reversi/* — オセロゲーム (実データ)
-	reversiRepo := repository.NewReversiRepository(s.db)
 	reversiHandler := apireversi.NewHandler(reversiRepo, idGen)
 	api.POST("/reversi/games", reversiHandler.Games)
 	api.POST("/reversi/invitations", reversiHandler.Invitations, middleware.RequireAuth())

--- a/internal/stream/channels/reversi_game.go
+++ b/internal/stream/channels/reversi_game.go
@@ -1,0 +1,131 @@
+package channels
+
+import (
+	"context"
+	"encoding/json"
+	"log/slog"
+
+	corereversi "github.com/shiroha-a/mk/internal/core/reversi"
+	"github.com/shiroha-a/mk/internal/model"
+	"github.com/shiroha-a/mk/internal/stream"
+)
+
+// ReversiGameChannel is the per-game WebSocket channel that forwards game
+// state updates (`started`, `log`, `ended`, ...) to connected clients and
+// relays player actions (`ready`, `putStone`, ...) to the reversi service.
+//
+// 観戦モード対応: 認証済みだが player でないユーザーは OnClientMessage を
+// 無視するだけで OnRedisEvent は受け取れる。匿名ユーザーも同様。
+type ReversiGameChannel struct {
+	ctx     stream.ChannelContext
+	svc     *corereversi.Service
+	gameID  string
+	topic   string
+	factory *ReversiGameFactory
+}
+
+// ReversiGameFactory holds the shared service so multiple channel instances
+// can delegate into it. Used by router.go when registering the factory.
+type ReversiGameFactory struct {
+	svc *corereversi.Service
+}
+
+// NewReversiGameFactory constructs a ReversiGameFactory wired to the service.
+func NewReversiGameFactory(svc *corereversi.Service) *ReversiGameFactory {
+	return &ReversiGameFactory{svc: svc}
+}
+
+// New builds a new channel bound to the given context. Usable directly as a
+// stream.ChannelFactory.
+func (f *ReversiGameFactory) New(ctx stream.ChannelContext) stream.Channel {
+	return &ReversiGameChannel{ctx: ctx, svc: f.svc, factory: f}
+}
+
+// Init subscribes to `reversiGame:{gameId}` so the channel receives game
+// events published by the service. Missing / malformed params silently
+// result in a no-op channel.
+func (c *ReversiGameChannel) Init(params json.RawMessage) {
+	var p struct {
+		GameID string `json:"gameId"`
+	}
+	if err := json.Unmarshal(params, &p); err != nil || p.GameID == "" {
+		return
+	}
+	c.gameID = p.GameID
+	c.topic = "reversiGame:" + p.GameID
+	c.ctx.Subscribe(c.topic)
+}
+
+// OnRedisEvent forwards a `reversiGame:{gameId}` pub/sub payload to the
+// client. The payload must be a {type, body} envelope.
+func (c *ReversiGameChannel) OnRedisEvent(payload []byte) {
+	var env struct {
+		Type string          `json:"type"`
+		Body json.RawMessage `json:"body"`
+	}
+	if err := json.Unmarshal(payload, &env); err != nil || env.Type == "" {
+		return
+	}
+	_ = c.ctx.Send(env.Type, env.Body)
+}
+
+// OnClientMessage dispatches player actions to the reversi service. Requires
+// authentication; anonymous clients and non-player spectators are ignored.
+// 失敗は `error` イベントでクライアントへ通知する。
+func (c *ReversiGameChannel) OnClientMessage(msgType string, body json.RawMessage) {
+	if c.svc == nil || c.gameID == "" {
+		return
+	}
+	user, ok := c.ctx.User().(*model.User)
+	if !ok || user == nil {
+		return
+	}
+	ctx := context.Background()
+	var err error
+	switch msgType {
+	case "ready":
+		var ready bool
+		if jerr := json.Unmarshal(body, &ready); jerr != nil {
+			return
+		}
+		err = c.svc.UpdateReady(ctx, c.gameID, user.ID, ready)
+	case "updateSettings":
+		var req struct {
+			Key   string          `json:"key"`
+			Value json.RawMessage `json:"value"`
+		}
+		if jerr := json.Unmarshal(body, &req); jerr != nil || req.Key == "" {
+			return
+		}
+		err = c.svc.UpdateSettings(ctx, c.gameID, user.ID, req.Key, req.Value)
+	case "putStone":
+		var req struct {
+			Pos int    `json:"pos"`
+			ID  string `json:"id"`
+		}
+		if jerr := json.Unmarshal(body, &req); jerr != nil {
+			return
+		}
+		err = c.svc.PutStone(ctx, c.gameID, user.ID, req.Pos)
+	case "surrender":
+		err = c.svc.Surrender(ctx, c.gameID, user.ID)
+	case "cancel":
+		err = c.svc.CancelGame(ctx, c.gameID, user.ID)
+	case "claimTimeIsUp":
+		err = c.svc.CheckTimeout(ctx, c.gameID)
+	default:
+		return
+	}
+	if err != nil {
+		slog.Info("reversi channel: action failed",
+			"gameId", c.gameID, "type", msgType, "user", user.ID, "err", err)
+		_ = c.ctx.Send("error", map[string]any{"message": err.Error(), "type": msgType})
+	}
+}
+
+// Dispose unsubscribes from the game topic.
+func (c *ReversiGameChannel) Dispose() {
+	if c.topic != "" {
+		c.ctx.Unsubscribe(c.topic)
+	}
+}

--- a/internal/stream/channels/reversi_game_test.go
+++ b/internal/stream/channels/reversi_game_test.go
@@ -1,0 +1,248 @@
+package channels
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/lib/pq"
+	corereversi "github.com/shiroha-a/mk/internal/core/reversi"
+	"github.com/shiroha-a/mk/internal/model"
+	"github.com/shiroha-a/mk/internal/stream"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gorm.io/datatypes"
+)
+
+// --- in-memory repo reused for channel tests ---
+
+type channelFakeRepo struct {
+	games map[string]*model.ReversiGame
+}
+
+func (r *channelFakeRepo) Create(g *model.ReversiGame) error {
+	r.games[g.ID] = g
+	return nil
+}
+func (r *channelFakeRepo) FindByID(id string) (*model.ReversiGame, error) {
+	if g, ok := r.games[id]; ok {
+		clone := *g
+		return &clone, nil
+	}
+	return nil, assertError
+}
+func (r *channelFakeRepo) Update(g *model.ReversiGame) error {
+	r.games[g.ID] = g
+	return nil
+}
+func (r *channelFakeRepo) ListByUser(_ string, _ int) ([]*model.ReversiGame, error) {
+	return nil, nil
+}
+func (r *channelFakeRepo) ListActive() ([]*model.ReversiGame, error) { return nil, nil }
+func (r *channelFakeRepo) Delete(id string) error {
+	delete(r.games, id)
+	return nil
+}
+
+var assertError = assertErr("not found")
+
+type assertErr string
+
+func (e assertErr) Error() string { return string(e) }
+
+// --- channel conformance ---
+
+var _ stream.Channel = (*ReversiGameChannel)(nil)
+
+func newGameForChannel(t *testing.T) *model.ReversiGame {
+	t.Helper()
+	return &model.ReversiGame{
+		ID:                   "g1",
+		User1ID:              "alice",
+		User2ID:              "bob",
+		Map:                  pq.StringArray{"--------", "--------", "--------", "---wb---", "---bw---", "--------", "--------", "--------"},
+		BW:                   "1",
+		TimeLimitForEachTurn: 90,
+		Logs:                 datatypes.JSON("[]"),
+	}
+}
+
+func newChannel(t *testing.T, user any) (*ReversiGameChannel, *stubContext, *channelFakeRepo, *model.ReversiGame) {
+	t.Helper()
+	repo := &channelFakeRepo{games: map[string]*model.ReversiGame{}}
+	game := newGameForChannel(t)
+	require.NoError(t, repo.Create(game))
+	svc := corereversi.NewService(repo, nil, nil)
+	factory := NewReversiGameFactory(svc)
+	ctx := newCtx(user)
+	ch := factory.New(ctx).(*ReversiGameChannel)
+	return ch, ctx, repo, game
+}
+
+func TestReversiChannel_Init_SubscribesToTopic(t *testing.T) {
+	ch, ctx, _, _ := newChannel(t, &model.User{ID: "alice"})
+	ch.Init(json.RawMessage(`{"gameId":"g1"}`))
+	assert.Equal(t, []string{"reversiGame:g1"}, ctx.subs)
+}
+
+func TestReversiChannel_Init_MissingGameID(t *testing.T) {
+	ch, ctx, _, _ := newChannel(t, nil)
+	ch.Init(json.RawMessage(`{}`))
+	assert.Empty(t, ctx.subs)
+}
+
+func TestReversiChannel_Init_BadJSON(t *testing.T) {
+	ch, ctx, _, _ := newChannel(t, nil)
+	ch.Init(json.RawMessage(`not json`))
+	assert.Empty(t, ctx.subs)
+}
+
+func TestReversiChannel_OnRedisEvent_Forwards(t *testing.T) {
+	ch, ctx, _, _ := newChannel(t, nil)
+	ch.Init(json.RawMessage(`{"gameId":"g1"}`))
+	ch.OnRedisEvent([]byte(`{"type":"log","body":{"pos":19}}`))
+	require.Len(t, ctx.sentType, 1)
+	assert.Equal(t, "log", ctx.sentType[0])
+}
+
+func TestReversiChannel_OnRedisEvent_InvalidJSON(t *testing.T) {
+	ch, ctx, _, _ := newChannel(t, nil)
+	ch.Init(json.RawMessage(`{"gameId":"g1"}`))
+	ch.OnRedisEvent([]byte(`not-json`))
+	assert.Empty(t, ctx.sentType)
+}
+
+func TestReversiChannel_OnRedisEvent_NoType(t *testing.T) {
+	ch, ctx, _, _ := newChannel(t, nil)
+	ch.Init(json.RawMessage(`{"gameId":"g1"}`))
+	ch.OnRedisEvent([]byte(`{"body":{}}`))
+	assert.Empty(t, ctx.sentType)
+}
+
+func TestReversiChannel_OnClientMessage_ReadyValid(t *testing.T) {
+	ch, _, repo, game := newChannel(t, &model.User{ID: "alice"})
+	ch.Init(json.RawMessage(`{"gameId":"g1"}`))
+	ch.OnClientMessage("ready", json.RawMessage(`true`))
+	got, _ := repo.FindByID(game.ID)
+	assert.True(t, got.User1Ready)
+}
+
+func TestReversiChannel_OnClientMessage_Unauthenticated(t *testing.T) {
+	ch, _, repo, _ := newChannel(t, nil)
+	ch.Init(json.RawMessage(`{"gameId":"g1"}`))
+	ch.OnClientMessage("ready", json.RawMessage(`true`))
+	got, _ := repo.FindByID("g1")
+	assert.False(t, got.User1Ready, "unauthenticated clients must not mutate state")
+}
+
+func TestReversiChannel_OnClientMessage_NilService(t *testing.T) {
+	// Direct construction with nil service → OnClientMessage is a no-op.
+	factory := NewReversiGameFactory(nil)
+	ctx := newCtx(&model.User{ID: "alice"})
+	ch := factory.New(ctx).(*ReversiGameChannel)
+	ch.gameID = "g1"
+	ch.OnClientMessage("ready", json.RawMessage(`true`)) // no panic, no Send
+	assert.Empty(t, ctx.sentType)
+}
+
+func TestReversiChannel_OnClientMessage_UpdateSettings(t *testing.T) {
+	ch, _, repo, _ := newChannel(t, &model.User{ID: "alice"})
+	ch.Init(json.RawMessage(`{"gameId":"g1"}`))
+	ch.OnClientMessage("updateSettings", json.RawMessage(`{"key":"isLlotheo","value":true}`))
+	got, _ := repo.FindByID("g1")
+	assert.True(t, got.IsLlotheo)
+}
+
+func TestReversiChannel_OnClientMessage_UpdateSettings_InvalidBody(t *testing.T) {
+	ch, ctx, _, _ := newChannel(t, &model.User{ID: "alice"})
+	ch.Init(json.RawMessage(`{"gameId":"g1"}`))
+	ch.OnClientMessage("updateSettings", json.RawMessage(`not-json`))
+	assert.Empty(t, ctx.sentType) // bad body → silent drop
+}
+
+func TestReversiChannel_OnClientMessage_PutStone_PreStartError(t *testing.T) {
+	ch, ctx, _, _ := newChannel(t, &model.User{ID: "alice"})
+	ch.Init(json.RawMessage(`{"gameId":"g1"}`))
+	ch.OnClientMessage("putStone", json.RawMessage(`{"pos":19,"id":"x"}`))
+	// Game not started → service returns error → channel emits "error" event.
+	require.NotEmpty(t, ctx.sentType)
+	assert.Equal(t, "error", ctx.sentType[0])
+}
+
+func TestReversiChannel_OnClientMessage_PutStone_BadJSON(t *testing.T) {
+	ch, ctx, _, _ := newChannel(t, &model.User{ID: "alice"})
+	ch.Init(json.RawMessage(`{"gameId":"g1"}`))
+	ch.OnClientMessage("putStone", json.RawMessage(`not-json`))
+	assert.Empty(t, ctx.sentType)
+}
+
+func TestReversiChannel_OnClientMessage_Surrender(t *testing.T) {
+	ch, ctx, repo, game := newChannel(t, &model.User{ID: "alice"})
+	// force started state
+	game.IsStarted = true
+	b := 1
+	game.Black = &b
+	_ = repo.Update(game)
+
+	ch.Init(json.RawMessage(`{"gameId":"g1"}`))
+	ch.OnClientMessage("surrender", json.RawMessage(`null`))
+	got, _ := repo.FindByID("g1")
+	assert.True(t, got.IsEnded)
+	assert.Empty(t, ctx.sentType) // success → no error event
+}
+
+func TestReversiChannel_OnClientMessage_Cancel(t *testing.T) {
+	ch, _, repo, _ := newChannel(t, &model.User{ID: "alice"})
+	ch.Init(json.RawMessage(`{"gameId":"g1"}`))
+	ch.OnClientMessage("cancel", json.RawMessage(`null`))
+	_, err := repo.FindByID("g1")
+	assert.Error(t, err)
+}
+
+func TestReversiChannel_OnClientMessage_ClaimTimeIsUp(t *testing.T) {
+	ch, ctx, _, _ := newChannel(t, &model.User{ID: "alice"})
+	ch.Init(json.RawMessage(`{"gameId":"g1"}`))
+	// nil redis → svc.CheckTimeout returns nil without ending the game
+	ch.OnClientMessage("claimTimeIsUp", json.RawMessage(`null`))
+	assert.Empty(t, ctx.sentType)
+}
+
+func TestReversiChannel_OnClientMessage_UnknownType(t *testing.T) {
+	ch, ctx, _, _ := newChannel(t, &model.User{ID: "alice"})
+	ch.Init(json.RawMessage(`{"gameId":"g1"}`))
+	ch.OnClientMessage("bogus", json.RawMessage(`null`))
+	assert.Empty(t, ctx.sentType)
+}
+
+func TestReversiChannel_OnClientMessage_NoGameID(t *testing.T) {
+	ch, ctx, _, _ := newChannel(t, &model.User{ID: "alice"})
+	// Init skipped → gameID empty → OnClientMessage early-return
+	ch.OnClientMessage("ready", json.RawMessage(`true`))
+	assert.Empty(t, ctx.sentType)
+}
+
+func TestReversiChannel_Dispose_Unsubscribes(t *testing.T) {
+	ch, ctx, _, _ := newChannel(t, nil)
+	ch.Init(json.RawMessage(`{"gameId":"g1"}`))
+	ch.Dispose()
+	assert.Equal(t, []string{"reversiGame:g1"}, ctx.unsubs)
+}
+
+func TestReversiChannel_Dispose_WithoutInit(t *testing.T) {
+	ch, ctx, _, _ := newChannel(t, nil)
+	ch.Dispose() // no panic, no unsubscribe
+	assert.Empty(t, ctx.unsubs)
+}
+
+func TestReversiChannel_OnClientMessage_ReadyBadJSON(t *testing.T) {
+	ch, ctx, _, _ := newChannel(t, &model.User{ID: "alice"})
+	ch.Init(json.RawMessage(`{"gameId":"g1"}`))
+	ch.OnClientMessage("ready", json.RawMessage(`not-a-bool`))
+	assert.Empty(t, ctx.sentType)
+}
+
+func TestReversiChannel_OnClientMessage_SettingsEmptyKey(t *testing.T) {
+	ch, ctx, _, _ := newChannel(t, &model.User{ID: "alice"})
+	ch.Init(json.RawMessage(`{"gameId":"g1"}`))
+	ch.OnClientMessage("updateSettings", json.RawMessage(`{"key":"","value":true}`))
+	assert.Empty(t, ctx.sentType)
+}

--- a/internal/stream/reversi_publisher.go
+++ b/internal/stream/reversi_publisher.go
@@ -1,0 +1,36 @@
+package stream
+
+import (
+	"context"
+	"encoding/json"
+	"log/slog"
+)
+
+// ReversiGamePublisher serializes {type, body} envelopes to the Redis topic
+// `reversiGame:{gameID}` which the reversi WebSocket channel subscribes to.
+// 本家 ReversiService の publish パターンと同じ。
+type ReversiGamePublisher struct {
+	pub PubSubPublisher
+}
+
+// NewReversiGamePublisher constructs a ReversiGamePublisher.
+func NewReversiGamePublisher(pub PubSubPublisher) *ReversiGamePublisher {
+	return &ReversiGamePublisher{pub: pub}
+}
+
+// PublishGameEvent implements core/reversi.GamePublisher.
+func (p *ReversiGamePublisher) PublishGameEvent(gameID, eventType string, body any) {
+	if p.pub == nil || gameID == "" {
+		return
+	}
+	env := map[string]any{"type": eventType, "body": body}
+	raw, err := json.Marshal(env)
+	if err != nil {
+		slog.Warn("reversi publisher: marshal failed", "event", eventType, "err", err)
+		return
+	}
+	topic := "reversiGame:" + gameID
+	if err := p.pub.Publish(context.Background(), topic, json.RawMessage(raw)); err != nil {
+		slog.Warn("reversi publisher: publish failed", "topic", topic, "err", err)
+	}
+}

--- a/internal/stream/reversi_publisher_test.go
+++ b/internal/stream/reversi_publisher_test.go
@@ -1,0 +1,65 @@
+package stream
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type capturingPubSub struct {
+	calls []capturedPublish
+	err   error
+}
+
+type capturedPublish struct {
+	topic   string
+	payload any
+}
+
+func (c *capturingPubSub) Publish(_ context.Context, topic string, payload any) error {
+	if c.err != nil {
+		return c.err
+	}
+	c.calls = append(c.calls, capturedPublish{topic, payload})
+	return nil
+}
+
+func TestReversiGamePublisher_PublishEnvelope(t *testing.T) {
+	bus := &capturingPubSub{}
+	p := NewReversiGamePublisher(bus)
+	p.PublishGameEvent("g1", "log", map[string]any{"pos": 19})
+
+	require.Len(t, bus.calls, 1)
+	assert.Equal(t, "reversiGame:g1", bus.calls[0].topic)
+
+	raw, ok := bus.calls[0].payload.(json.RawMessage)
+	require.True(t, ok)
+	var env struct {
+		Type string          `json:"type"`
+		Body json.RawMessage `json:"body"`
+	}
+	require.NoError(t, json.Unmarshal(raw, &env))
+	assert.Equal(t, "log", env.Type)
+}
+
+func TestReversiGamePublisher_NilPub(t *testing.T) {
+	p := NewReversiGamePublisher(nil)
+	p.PublishGameEvent("g1", "log", nil) // no panic
+}
+
+func TestReversiGamePublisher_EmptyGameID(t *testing.T) {
+	bus := &capturingPubSub{}
+	p := NewReversiGamePublisher(bus)
+	p.PublishGameEvent("", "log", nil)
+	assert.Empty(t, bus.calls)
+}
+
+func TestReversiGamePublisher_PublishError(t *testing.T) {
+	bus := &capturingPubSub{err: errors.New("pub boom")}
+	p := NewReversiGamePublisher(bus)
+	p.PublishGameEvent("g1", "log", nil) // logged but not panicked
+}


### PR DESCRIPTION
## Summary

Misskey互換のリバーシWebSocketリアルタイム対戦を実装しました。既存の純Go Othelloエンジン (\`core/reversi/game.go\`) とModel/Repositoryはそのまま活用し、その上に **ゲーム状態遷移サービス** (\`core/reversi/service.go\` を大幅拡張) と **新規 WebSocketチャネル** (\`stream/channels/reversi_game.go\`) を載せて、2プレイヤー+観戦者が 1 ゲームを最後まで進められる状態にしています。メッセージ名・ペイロード envelope は本家 \`ReversiGameChannelService\` と 1:1 で合わせているので、既存フロントエンドは無改修で動作する想定です。

## 主な変更点

### 新規ファイル
- \`internal/stream/channels/reversi_game.go\` — \`ReversiGameChannel\` と \`ReversiGameFactory\`。初期化で \`reversiGame:{gameId}\` を subscribe し、クライアントメッセージをサービスに dispatch する
- \`internal/stream/reversi_publisher.go\` — \`{type, body}\` envelope を Redis topic に publish する薄いアダプタ
- \`internal/core/reversi/service_wire_test.go\` — fake repository + capturing publisher ベースの単体テスト
- \`internal/core/reversi/service_redis_test.go\` — testcontainers Redis を使った turn timer 統合テスト
- \`internal/stream/channels/reversi_game_test.go\` — チャネル契約網羅テスト
- \`internal/stream/reversi_publisher_test.go\` — publisher 単体テスト

### 既存コードの変更
- \`internal/core/reversi/service.go\` — 以下を新規追加:
  - \`Service\` struct (ReversiRepository + GamePublisher + redis.Cmdable)
  - \`UpdateReady\` / \`UpdateSettings\` / \`CancelGame\` / \`StartGame\` / \`PutStone\` / \`Surrender\` / \`CheckTimeout\`
  - \`EngineFromGame\` (logs から engine を復元)
  - color 割当 (\`pickBlack\`), プレイヤー ID ↔ color 変換
  - ターンタイマー helper (\`setTurnTimer\` / \`turnTimerExists\` / \`turnTimerKey\`)
  - エラー定数 (\`ErrGameNotFound\`, \`ErrNotPlayer\`, \`ErrNotYourTurn\`, \`ErrInvalidMove\` 他)
  - 既存の \`FederationIDCache\` / \`IsValidUpdateKey\` はそのまま維持
- \`internal/server/router.go\` — reversi repo を repository ブロックに移動、\`corereversi.Service\` / \`stream.ReversiGamePublisher\` を構築し、\`streamRegistry.Register(\"reversiGame\", ...)\` で登録

## 互換性 (本家 ReversiGameChannelService 準拠)

### Client → Server
| type | body | 意味 |
|------|------|------|
| \`ready\` | \`boolean\` | ready フラグを切り替え。両者 ready で自動 \`StartGame\` 発火 |
| \`updateSettings\` | \`{key, value}\` | pre-start 設定変更 (map / bw / isLlotheo / canPutEverywhere / loopedBoard / timeLimitForEachTurn / noIrregularRules) |
| \`cancel\` | — | pre-start のゲーム中断 |
| \`putStone\` | \`{pos, id}\` | 石配置 |
| \`surrender\` | — | 降参 |
| \`claimTimeIsUp\` | — | 相手の持ち時間切れを主張 |

### Server → Client
| type | body | タイミング |
|------|------|-----------|
| \`changeReadyStates\` | \`{user1, user2}\` | ready 切替 / 設定変更時 |
| \`updateSettings\` | \`{userId, key, value}\` | 設定変更時 |
| \`started\` | \`{game}\` | 両者 ready 時 |
| \`log\` | \`{pos, color, player, time, operation}\` | 石配置時 |
| \`ended\` | \`{winnerId, reason?, game}\` | ゲーム終了時 |
| \`canceled\` | \`{userId}\` | pre-start cancel 時 |
| \`error\` | \`{message, type}\` | クライアント操作が失敗した場合 |

### サーバーサイドバリデーション
- ready / updateSettings / putStone / surrender / cancel は **player 以外拒否** (観戦者・匿名は sentinel エラー)
- putStone は \`engine.Turn\` と \`engine.CanPut\` をチェック (ターン違反と不正位置を弾く)
- updateSettings は started/ended 後は拒否
- cancel は started 後は拒否

### ターンタイマー
- key: \`reversi:game:turnTimer:{gameID}:{logsCount}\`
- TTL: \`game.TimeLimitForEachTurn\` 秒
- \`StartGame\` と \`PutStone\` のたびに次ターンのタイマーをセット
- \`claimTimeIsUp\` は該当 key の有無を確認: 存在しなければタイムアウト確定 → 現ターンプレイヤーが負け

### 色割当 (\`BW\`)
- \`"1"\` → user1 が黒
- \`"2"\` → user2 が黒
- \`"random"\` または他 → ランダム (\`math/rand.Intn(2)\`)

### 観戦モード
認証済みだが player でないユーザーは \`OnClientMessage\` が完全に no-op になる一方、\`OnRedisEvent\` は player と同じく受信する (匿名ユーザーも同じ)。

## 制約事項 (スコープ外)

- **ランダムマッチング** (待機列) は未実装。Match API は既存のまま
- **Form1 / Form2** (サブフォーム UI 用の JSON) の編集は対象外
- **連合経由の対戦** (Invite/Join/Update/Leave via ActivityPub) は Phase 9.7 で扱う。現状の \`FederationIDCache\` はそのまま維持
- \`Reversi.Serializer.restoreGame\` 相当の CRC32 検証は既存の \`/api/reversi/verify\` endpoint で対応済みなので追加しない

## テスト

- \`core/reversi\` **93.2%**: Service 全メソッド網羅 (ready / settings / cancel / start / putStone / surrender / checkTimeout)、pre-start / started / ended 状態でのエラーハンドリング、色割当 / player 判定 / applySetting 全 key 経路、turnTimer Redis 統合 (hit, miss, zero TTL)、小盤面で正常終了まで走らせる統合テスト
- \`stream/channels\` **100%**: チャネル lifecycle (Init / OnRedisEvent / OnClientMessage / Dispose)、auth チェック、各 message type (ready / updateSettings / putStone / surrender / cancel / claimTimeIsUp / unknown)、bad JSON パス
- \`stream\` **99.3%**: reversi publisher の envelope 生成、nil pub 時の no-op、empty gameID スキップ、publish エラー時の log

ローカル実行で \`make fmt && make lint\` pass、全 77 パッケージが CI 閾値 (90% / admin 60%) をクリアしています。

### 再現コマンド
\`\`\`bash
PKGS=\$(go list -f '{{if (or .TestGoFiles .XTestGoFiles)}}{{.ImportPath}}{{end}}' ./... | tr '\n' ' ')
go test \$PKGS -race -count=1 -timeout 10m -coverprofile=coverage.out -covermode=atomic

# Phase 9.6 のみ
go test ./internal/core/reversi/... \\
        ./internal/stream/... \\
        ./internal/stream/channels/...
\`\`\`

## Closes

Closes #4