### PR TITLE
Phase 9.8 チャット WebSocket 配信

### DIFF
--- a/internal/api/chat/handler.go
+++ b/internal/api/chat/handler.go
@@ -1,25 +1,52 @@
 package chat
 
 import (
+	"errors"
 	"net/http"
 	"time"
 
 	"github.com/labstack/echo/v4"
+	corechat "github.com/shiroha-a/mk/internal/core/chat"
 	"github.com/shiroha-a/mk/internal/misc/id"
 	"github.com/shiroha-a/mk/internal/model"
 	"github.com/shiroha-a/mk/internal/repository"
 	"github.com/shiroha-a/mk/internal/server/middleware"
 )
 
+// legacyNow is a tiny indirection so tests can override time in the handler's
+// legacy (non-service) path if needed. 現状は time.Now を直接返す。
+func legacyNow() time.Time { return time.Now() }
+
 // Handler handles chat/* endpoints.
 type Handler struct {
 	repo  repository.ChatRepository
 	idGen id.Generator
+	svc   *corechat.Service
 }
 
 // NewHandler creates a new chat handler.
 func NewHandler(repo repository.ChatRepository, idGen id.Generator) *Handler {
 	return &Handler{repo: repo, idGen: idGen}
+}
+
+// SetService wires a chat Service so that state-changing message endpoints
+// (create/update/delete/read) route through it and publish streaming events.
+// 未設定の場合は従来どおり repo 直操作にフォールバックする (既存テスト互換)。
+func (h *Handler) SetService(svc *corechat.Service) {
+	h.svc = svc
+}
+
+// mapChatErr maps a core/chat service error to an Echo response.
+func (h *Handler) mapChatErr(c echo.Context, err error) error {
+	switch {
+	case errors.Is(err, corechat.ErrNotFound):
+		return c.JSON(http.StatusNotFound, apiError("NO_SUCH_MESSAGE", "No such message.", "00000000-0000-0000-0000-000000000000"))
+	case errors.Is(err, corechat.ErrForbidden):
+		return c.JSON(http.StatusForbidden, apiError("ACCESS_DENIED", "Access denied.", "00000000-0000-0000-0000-000000000000"))
+	case errors.Is(err, corechat.ErrInvalidTarget):
+		return c.JSON(http.StatusBadRequest, apiError("INVALID_PARAM", "toUserId or toRoomId is required.", "ed1d7571-a3ac-4370-899c-0dbe5e230cc8"))
+	}
+	return c.JSON(http.StatusInternalServerError, apiError("INTERNAL_ERROR", "Internal error.", "5d37dbcb-891e-41ca-a3d6-e690c97775ac"))
 }
 
 func apiError(code, message, errID string) map[string]any {
@@ -230,6 +257,7 @@ func (h *Handler) RoomsTransferOwnership(c echo.Context) error {
 // --- Messages ---
 
 // MessagesCreate handles POST /api/chat/messages/create.
+// service が wire されていれば streaming 配信も同時に行う。
 func (h *Handler) MessagesCreate(c echo.Context) error {
 	user := middleware.GetUser(c)
 	var req struct {
@@ -241,10 +269,44 @@ func (h *Handler) MessagesCreate(c echo.Context) error {
 	if err := c.Bind(&req); err != nil {
 		return c.JSON(http.StatusBadRequest, apiError("INVALID_PARAM", "Invalid parameters.", "ed1d7571-a3ac-4370-899c-0dbe5e230cc8"))
 	}
+	if h.svc == nil {
+		// 未wire時のフォールバック (テスト互換)
+		return h.messagesCreateLegacy(c, user, req.Text, req.ToUserID, req.ToRoomID, req.FileID)
+	}
+	text := ""
+	if req.Text != nil {
+		text = *req.Text
+	}
+	fileID := ""
+	if req.FileID != nil {
+		fileID = *req.FileID
+	}
+	var (
+		msg *model.ChatMessage
+		err error
+	)
+	switch {
+	case req.ToRoomID != nil && *req.ToRoomID != "":
+		msg, err = h.svc.CreateMessageToRoom(c.Request().Context(), user.ID, *req.ToRoomID, text, fileID)
+	case req.ToUserID != nil && *req.ToUserID != "":
+		msg, err = h.svc.CreateMessageToUser(c.Request().Context(), user.ID, *req.ToUserID, text, fileID)
+	default:
+		return c.JSON(http.StatusBadRequest, apiError("INVALID_PARAM", "toUserId or toRoomId is required.", "ed1d7571-a3ac-4370-899c-0dbe5e230cc8"))
+	}
+	if err != nil {
+		return h.mapChatErr(c, err)
+	}
+	return c.JSON(http.StatusOK, packMessage(msg))
+}
+
+// messagesCreateLegacy preserves pre-Phase-9.8 behaviour for callers that
+// construct a Handler without wiring the service. 既存の chat handler テスト
+// はこちらを通る。
+func (h *Handler) messagesCreateLegacy(c echo.Context, user *model.User, text, toUserID, toRoomID, fileID *string) error {
 	msg := &model.ChatMessage{
-		ID: h.idGen.Generate(time.Now()), FromUserID: user.ID,
-		ToUserID: req.ToUserID, ToRoomID: req.ToRoomID,
-		Text: req.Text, FileID: req.FileID,
+		ID: h.idGen.Generate(legacyNow()), FromUserID: user.ID,
+		ToUserID: toUserID, ToRoomID: toRoomID,
+		Text: text, FileID: fileID,
 	}
 	if err := h.repo.CreateMessage(msg); err != nil {
 		return c.JSON(http.StatusInternalServerError, apiError("INTERNAL_ERROR", "Internal error.", "5d37dbcb-891e-41ca-a3d6-e690c97775ac"))
@@ -277,14 +339,25 @@ func (h *Handler) MessagesUpdate(c echo.Context) error {
 	if err := c.Bind(&req); err != nil || req.MessageID == "" {
 		return c.JSON(http.StatusBadRequest, apiError("INVALID_PARAM", "messageId is required.", "ed1d7571-a3ac-4370-899c-0dbe5e230cc8"))
 	}
-	msg, err := h.repo.FindMessageByID(req.MessageID)
-	if err != nil || msg.FromUserID != user.ID {
-		return c.JSON(http.StatusNotFound, apiError("NO_SUCH_MESSAGE", "No such message.", "00000000-0000-0000-0000-000000000000"))
+	if h.svc == nil {
+		// legacy fallback
+		msg, err := h.repo.FindMessageByID(req.MessageID)
+		if err != nil || msg.FromUserID != user.ID {
+			return c.JSON(http.StatusNotFound, apiError("NO_SUCH_MESSAGE", "No such message.", "00000000-0000-0000-0000-000000000000"))
+		}
+		if req.Text != nil {
+			msg.Text = req.Text
+			_ = h.repo.UpdateMessage(msg)
+		}
+		return c.NoContent(http.StatusNoContent)
 	}
+	text := ""
 	if req.Text != nil {
-		msg.Text = req.Text
+		text = *req.Text
 	}
-	// CreateMessageを使って更新 (Saveに相当)
+	if _, err := h.svc.UpdateMessage(c.Request().Context(), user.ID, req.MessageID, text); err != nil {
+		return h.mapChatErr(c, err)
+	}
 	return c.NoContent(http.StatusNoContent)
 }
 
@@ -297,11 +370,17 @@ func (h *Handler) MessagesDelete(c echo.Context) error {
 	if err := c.Bind(&req); err != nil || req.MessageID == "" {
 		return c.JSON(http.StatusBadRequest, apiError("INVALID_PARAM", "messageId is required.", "ed1d7571-a3ac-4370-899c-0dbe5e230cc8"))
 	}
-	msg, err := h.repo.FindMessageByID(req.MessageID)
-	if err != nil || msg.FromUserID != user.ID {
-		return c.JSON(http.StatusNotFound, apiError("NO_SUCH_MESSAGE", "No such message.", "00000000-0000-0000-0000-000000000000"))
+	if h.svc == nil {
+		msg, err := h.repo.FindMessageByID(req.MessageID)
+		if err != nil || msg.FromUserID != user.ID {
+			return c.JSON(http.StatusNotFound, apiError("NO_SUCH_MESSAGE", "No such message.", "00000000-0000-0000-0000-000000000000"))
+		}
+		_ = h.repo.DeleteMessage(req.MessageID)
+		return c.NoContent(http.StatusNoContent)
 	}
-	_ = h.repo.DeleteMessage(req.MessageID)
+	if err := h.svc.DeleteMessage(c.Request().Context(), user.ID, req.MessageID); err != nil {
+		return h.mapChatErr(c, err)
+	}
 	return c.NoContent(http.StatusNoContent)
 }
 
@@ -313,6 +392,12 @@ func (h *Handler) MessagesRead(c echo.Context) error {
 	}
 	if err := c.Bind(&req); err != nil || req.MessageID == "" {
 		return c.JSON(http.StatusBadRequest, apiError("INVALID_PARAM", "messageId is required.", "ed1d7571-a3ac-4370-899c-0dbe5e230cc8"))
+	}
+	if h.svc != nil {
+		if err := h.svc.MarkReadByMessageID(c.Request().Context(), user.ID, req.MessageID); err != nil {
+			return h.mapChatErr(c, err)
+		}
+		return c.NoContent(http.StatusNoContent)
 	}
 	_ = h.repo.MarkRead(user.ID, req.MessageID)
 	return c.NoContent(http.StatusNoContent)

--- a/internal/api/chat/handler_test.go
+++ b/internal/api/chat/handler_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/labstack/echo/v4"
 	"github.com/lib/pq"
+	corechat "github.com/shiroha-a/mk/internal/core/chat"
 	"github.com/shiroha-a/mk/internal/misc/id"
 	"github.com/shiroha-a/mk/internal/model"
 	"github.com/shiroha-a/mk/internal/server/middleware"
@@ -74,6 +75,10 @@ func (m *mockChatRepo) FindMessageByID(id string) (*model.ChatMessage, error) {
 		return msg, nil
 	}
 	return nil, errMock
+}
+func (m *mockChatRepo) UpdateMessage(msg *model.ChatMessage) error {
+	m.messages[msg.ID] = msg
+	return nil
 }
 func (m *mockChatRepo) DeleteMessage(id string) error { delete(m.messages, id); return nil }
 func (m *mockChatRepo) ListMessagesByRoom(_ string, _ int) ([]*model.ChatMessage, error) {
@@ -505,6 +510,112 @@ func TestMessages_List(t *testing.T) {
 	h, _ := newTestHandler()
 	rec := post(h.Messages, `{"roomId":"r1"}`, u1)
 	assert.Equal(t, http.StatusOK, rec.Code)
+}
+
+// --- Phase 9.8: service wiring tests ---
+
+func newHandlerWithService(t *testing.T) (*Handler, *mockChatRepo) {
+	t.Helper()
+	repo := newMock()
+	idGen, _ := id.NewGenerator("aidx")
+	h := NewHandler(repo, idGen)
+	svc := corechat.NewService(repo, idGen)
+	h.SetService(svc)
+	return h, repo
+}
+
+func TestMessagesCreate_Service_ToUser(t *testing.T) {
+	h, repo := newHandlerWithService(t)
+	rec := post(h.MessagesCreate, `{"text":"hi","toUserId":"u2"}`, u1)
+	assert.Equal(t, http.StatusOK, rec.Code)
+	assert.Len(t, repo.messages, 1)
+}
+
+func TestMessagesCreate_Service_ToRoom(t *testing.T) {
+	h, repo := newHandlerWithService(t)
+	repo.rooms["r1"] = &model.ChatRoom{ID: "r1", OwnerID: "u1"}
+	rec := post(h.MessagesCreate, `{"text":"hi","toRoomId":"r1"}`, u1)
+	assert.Equal(t, http.StatusOK, rec.Code)
+	assert.Len(t, repo.messages, 1)
+}
+
+func TestMessagesCreate_Service_NoTarget(t *testing.T) {
+	h, _ := newHandlerWithService(t)
+	rec := post(h.MessagesCreate, `{"text":"hi"}`, u1)
+	assert.Equal(t, http.StatusBadRequest, rec.Code)
+}
+
+func TestMessagesCreate_Service_RoomNotFound(t *testing.T) {
+	h, _ := newHandlerWithService(t)
+	rec := post(h.MessagesCreate, `{"text":"hi","toRoomId":"ghost"}`, u1)
+	assert.Equal(t, http.StatusNotFound, rec.Code)
+}
+
+func TestMessagesCreate_Service_RoomForbidden(t *testing.T) {
+	h, repo := newHandlerWithService(t)
+	repo.rooms["r1"] = &model.ChatRoom{ID: "r1", OwnerID: "otherUser"}
+	rec := post(h.MessagesCreate, `{"text":"hi","toRoomId":"r1"}`, u1)
+	assert.Equal(t, http.StatusForbidden, rec.Code)
+}
+
+func TestMessagesDelete_Service(t *testing.T) {
+	h, repo := newHandlerWithService(t)
+	toID := "u2"
+	repo.messages["m1"] = &model.ChatMessage{ID: "m1", FromUserID: "u1", ToUserID: &toID}
+	rec := post(h.MessagesDelete, `{"messageId":"m1"}`, u1)
+	assert.Equal(t, http.StatusNoContent, rec.Code)
+}
+
+func TestMessagesDelete_Service_NotFound(t *testing.T) {
+	h, _ := newHandlerWithService(t)
+	rec := post(h.MessagesDelete, `{"messageId":"ghost"}`, u1)
+	assert.Equal(t, http.StatusNotFound, rec.Code)
+}
+
+func TestMessagesDelete_Service_Forbidden(t *testing.T) {
+	h, repo := newHandlerWithService(t)
+	toID := "u1"
+	repo.messages["m1"] = &model.ChatMessage{ID: "m1", FromUserID: "u2", ToUserID: &toID}
+	rec := post(h.MessagesDelete, `{"messageId":"m1"}`, u1)
+	assert.Equal(t, http.StatusForbidden, rec.Code)
+}
+
+func TestMessagesUpdate_Service(t *testing.T) {
+	h, repo := newHandlerWithService(t)
+	toID := "u2"
+	orig := "old"
+	repo.messages["m1"] = &model.ChatMessage{ID: "m1", FromUserID: "u1", ToUserID: &toID, Text: &orig}
+	rec := post(h.MessagesUpdate, `{"messageId":"m1","text":"new"}`, u1)
+	assert.Equal(t, http.StatusNoContent, rec.Code)
+}
+
+func TestMessagesUpdate_Service_NotFound(t *testing.T) {
+	h, _ := newHandlerWithService(t)
+	rec := post(h.MessagesUpdate, `{"messageId":"ghost","text":"x"}`, u1)
+	assert.Equal(t, http.StatusNotFound, rec.Code)
+}
+
+func TestMessagesUpdate_Service_Forbidden(t *testing.T) {
+	h, repo := newHandlerWithService(t)
+	toID := "u1"
+	orig := "old"
+	repo.messages["m1"] = &model.ChatMessage{ID: "m1", FromUserID: "u2", ToUserID: &toID, Text: &orig}
+	rec := post(h.MessagesUpdate, `{"messageId":"m1","text":"new"}`, u1)
+	assert.Equal(t, http.StatusForbidden, rec.Code)
+}
+
+func TestMessagesRead_Service(t *testing.T) {
+	h, repo := newHandlerWithService(t)
+	toID := "u1"
+	repo.messages["m1"] = &model.ChatMessage{ID: "m1", FromUserID: "u2", ToUserID: &toID}
+	rec := post(h.MessagesRead, `{"messageId":"m1"}`, u1)
+	assert.Equal(t, http.StatusNoContent, rec.Code)
+}
+
+func TestMessagesRead_Service_NotFound(t *testing.T) {
+	h, _ := newHandlerWithService(t)
+	rec := post(h.MessagesRead, `{"messageId":"ghost"}`, u1)
+	assert.Equal(t, http.StatusNotFound, rec.Code)
 }
 
 type mockUserMsgRepo struct{ *mockChatRepo }

--- a/internal/core/chat/service.go
+++ b/internal/core/chat/service.go
@@ -1,0 +1,254 @@
+// Package chat provides a thin service layer over ChatRepository that
+// dispatches real-time delivery events to the matching WebSocket channel.
+//
+// Phase 9.8 — メッセージ送信 / 削除 / 編集 / 既読マークの各 API はこの service
+// を経由することで、(a) DB への永続化と (b) Redis pubsub 経由の WebSocket
+// 配信を同時に行う。本家 Misskey の ChatService.createMessageToUser /
+// createMessageToRoom / deleteMessage の挙動を移植している。
+package chat
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/shiroha-a/mk/internal/misc/id"
+	"github.com/shiroha-a/mk/internal/model"
+	"github.com/shiroha-a/mk/internal/repository"
+)
+
+// Errors returned by Service.
+var (
+	// ErrNotFound is returned when a referenced message or room does not exist.
+	ErrNotFound = errors.New("chat resource not found")
+	// ErrForbidden is returned when the acting user cannot modify the target
+	// resource (e.g. deleting someone else's message, posting to a room they
+	// are not a member of).
+	ErrForbidden = errors.New("chat action forbidden")
+	// ErrInvalidTarget is returned when neither toUserId nor toRoomId is
+	// provided to CreateMessage helpers.
+	ErrInvalidTarget = errors.New("chat target is required")
+)
+
+// StreamingPublisher is the Redis pub/sub dispatch interface the service uses
+// to broadcast chat events. Implementations live in internal/stream so the
+// concrete pub/sub bus can be injected without creating a cycle.
+//
+// 本家 Misskey の GlobalEventService.publishChatUserStream /
+// publishChatRoomStream に対応する。
+type StreamingPublisher interface {
+	PublishUserMessage(ctx context.Context, fromUserID, toUserID, eventType string, body any)
+	PublishRoomMessage(ctx context.Context, roomID, eventType string, body any)
+}
+
+// Event types mirrored by the WebSocket channel. 本家と同名。
+const (
+	EventMessage = "message"
+	EventDeleted = "deleted"
+	EventEdited  = "edited"
+	EventRead    = "read"
+)
+
+// Service implements chat message CRUD + streaming fan-out.
+type Service struct {
+	repo      repository.ChatRepository
+	idGen     id.Generator
+	publisher StreamingPublisher
+}
+
+// NewService constructs a chat Service.
+func NewService(repo repository.ChatRepository, idGen id.Generator) *Service {
+	return &Service{repo: repo, idGen: idGen}
+}
+
+// SetStreamingPublisher wires a StreamingPublisher so state-changing methods
+// can dispatch to the WebSocket channel. nil 渡しで配信は無効になる (既存の
+// DB 処理は変わらない)。
+func (s *Service) SetStreamingPublisher(p StreamingPublisher) {
+	s.publisher = p
+}
+
+// --- Message lifecycle ---
+
+// CreateMessageToUser persists a direct-message row and fires the
+// `message` event on both conversation directions so that either user's
+// connected WebSocket subscribers see the message immediately.
+func (s *Service) CreateMessageToUser(ctx context.Context, fromUserID, toUserID, text, fileID string) (*model.ChatMessage, error) {
+	if fromUserID == "" || toUserID == "" {
+		return nil, ErrInvalidTarget
+	}
+	msg := &model.ChatMessage{
+		ID:         s.idGen.Generate(time.Now()),
+		FromUserID: fromUserID,
+		ToUserID:   &toUserID,
+	}
+	if text != "" {
+		msg.Text = &text
+	}
+	if fileID != "" {
+		msg.FileID = &fileID
+	}
+	if err := s.repo.CreateMessage(msg); err != nil {
+		return nil, fmt.Errorf("create user message: %w", err)
+	}
+	if s.publisher != nil {
+		s.publisher.PublishUserMessage(ctx, fromUserID, toUserID, EventMessage, packMessage(msg))
+	}
+	return msg, nil
+}
+
+// CreateMessageToRoom persists a room-message row and fires the `message`
+// event on the room topic so every subscribed member receives it.
+func (s *Service) CreateMessageToRoom(ctx context.Context, fromUserID, roomID, text, fileID string) (*model.ChatMessage, error) {
+	if fromUserID == "" || roomID == "" {
+		return nil, ErrInvalidTarget
+	}
+	// ルームが存在し、送信者がメンバーであることを確認する。
+	if _, err := s.repo.FindRoomByID(roomID); err != nil {
+		return nil, ErrNotFound
+	}
+	isMember, err := s.IsRoomMember(fromUserID, roomID)
+	if err != nil {
+		return nil, err
+	}
+	if !isMember {
+		return nil, ErrForbidden
+	}
+	msg := &model.ChatMessage{
+		ID:         s.idGen.Generate(time.Now()),
+		FromUserID: fromUserID,
+		ToRoomID:   &roomID,
+	}
+	if text != "" {
+		msg.Text = &text
+	}
+	if fileID != "" {
+		msg.FileID = &fileID
+	}
+	if err := s.repo.CreateMessage(msg); err != nil {
+		return nil, fmt.Errorf("create room message: %w", err)
+	}
+	if s.publisher != nil {
+		s.publisher.PublishRoomMessage(ctx, roomID, EventMessage, packMessage(msg))
+	}
+	return msg, nil
+}
+
+// DeleteMessage removes a message and fans out a `deleted` event on the
+// appropriate topic (user DM or room). Only the author may delete.
+func (s *Service) DeleteMessage(ctx context.Context, userID, messageID string) error {
+	msg, err := s.repo.FindMessageByID(messageID)
+	if err != nil {
+		return ErrNotFound
+	}
+	if msg.FromUserID != userID {
+		return ErrForbidden
+	}
+	if err := s.repo.DeleteMessage(messageID); err != nil {
+		return fmt.Errorf("delete message: %w", err)
+	}
+	if s.publisher != nil {
+		body := map[string]any{"id": messageID}
+		if msg.ToRoomID != nil {
+			s.publisher.PublishRoomMessage(ctx, *msg.ToRoomID, EventDeleted, body)
+		} else if msg.ToUserID != nil {
+			s.publisher.PublishUserMessage(ctx, msg.FromUserID, *msg.ToUserID, EventDeleted, body)
+		}
+	}
+	return nil
+}
+
+// UpdateMessage edits a message text and fires `edited`. Author-only.
+func (s *Service) UpdateMessage(ctx context.Context, userID, messageID, text string) (*model.ChatMessage, error) {
+	msg, err := s.repo.FindMessageByID(messageID)
+	if err != nil {
+		return nil, ErrNotFound
+	}
+	if msg.FromUserID != userID {
+		return nil, ErrForbidden
+	}
+	msg.Text = &text
+	if err := s.repo.UpdateMessage(msg); err != nil {
+		return nil, fmt.Errorf("update message: %w", err)
+	}
+	if s.publisher != nil {
+		body := packMessage(msg)
+		if msg.ToRoomID != nil {
+			s.publisher.PublishRoomMessage(ctx, *msg.ToRoomID, EventEdited, body)
+		} else if msg.ToUserID != nil {
+			s.publisher.PublishUserMessage(ctx, msg.FromUserID, *msg.ToUserID, EventEdited, body)
+		}
+	}
+	return msg, nil
+}
+
+// MarkReadByMessageID records that userID has read messageID. Misskey 本家は
+// 既読を redis cache のみで持ち配信しないが、マルチ端末/タブ同期のため軽微な
+// 拡張として `read` イベントを発行する。
+func (s *Service) MarkReadByMessageID(ctx context.Context, userID, messageID string) error {
+	msg, err := s.repo.FindMessageByID(messageID)
+	if err != nil {
+		return ErrNotFound
+	}
+	if err := s.repo.MarkRead(userID, messageID); err != nil {
+		return fmt.Errorf("mark read: %w", err)
+	}
+	if s.publisher != nil {
+		body := map[string]any{"id": messageID, "userId": userID}
+		if msg.ToRoomID != nil {
+			s.publisher.PublishRoomMessage(ctx, *msg.ToRoomID, EventRead, body)
+		} else if msg.ToUserID != nil {
+			// DM の場合、両端末に既読状態を通知するため双方向へ送る。
+			s.publisher.PublishUserMessage(ctx, msg.FromUserID, *msg.ToUserID, EventRead, body)
+		}
+	}
+	return nil
+}
+
+// --- Queries used by the WebSocket channel for membership / auth checks ---
+
+// IsRoomMember reports whether userID is a member of roomID. The room owner
+// is implicitly a member even if no explicit chat_room_membership row exists.
+func (s *Service) IsRoomMember(userID, roomID string) (bool, error) {
+	room, err := s.repo.FindRoomByID(roomID)
+	if err == nil && room.OwnerID == userID {
+		return true, nil
+	}
+	if _, err := s.repo.FindMembership(userID, roomID); err == nil {
+		return true, nil
+	}
+	return false, nil
+}
+
+// packMessage produces a JSON-serializable projection of a ChatMessage for
+// outbound WebSocket events. フロント互換のため本家 ChatMessageLite と同じ
+// 主要フィールドを含める。
+func packMessage(msg *model.ChatMessage) map[string]any {
+	out := map[string]any{
+		"id":         msg.ID,
+		"fromUserId": msg.FromUserID,
+	}
+	if msg.Text != nil {
+		out["text"] = *msg.Text
+	}
+	if msg.ToUserID != nil {
+		out["toUserId"] = *msg.ToUserID
+	}
+	if msg.ToRoomID != nil {
+		out["toRoomId"] = *msg.ToRoomID
+	}
+	if msg.FileID != nil {
+		out["fileId"] = *msg.FileID
+	}
+	if msg.URI != nil {
+		out["uri"] = *msg.URI
+	}
+	if msg.Reads != nil {
+		out["reads"] = []string(msg.Reads)
+	}
+	if msg.Reactions != nil {
+		out["reactions"] = []string(msg.Reactions)
+	}
+	return out
+}

--- a/internal/core/chat/service_test.go
+++ b/internal/core/chat/service_test.go
@@ -1,0 +1,456 @@
+package chat_test
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"testing"
+
+	"github.com/lib/pq"
+	corechat "github.com/shiroha-a/mk/internal/core/chat"
+	"github.com/shiroha-a/mk/internal/misc/id"
+	"github.com/shiroha-a/mk/internal/model"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// --- fake repository ---
+
+type fakeChatRepo struct {
+	mu          sync.Mutex
+	rooms       map[string]*model.ChatRoom
+	messages    map[string]*model.ChatMessage
+	memberships map[string]*model.ChatRoomMembership // key: userID:roomID
+
+	createErr error
+	updateErr error
+	deleteErr error
+}
+
+func newFakeRepo() *fakeChatRepo {
+	return &fakeChatRepo{
+		rooms:       make(map[string]*model.ChatRoom),
+		messages:    make(map[string]*model.ChatMessage),
+		memberships: make(map[string]*model.ChatRoomMembership),
+	}
+}
+
+func (r *fakeChatRepo) CreateRoom(room *model.ChatRoom) error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.rooms[room.ID] = room
+	return nil
+}
+func (r *fakeChatRepo) FindRoomByID(id string) (*model.ChatRoom, error) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if room, ok := r.rooms[id]; ok {
+		return room, nil
+	}
+	return nil, errors.New("not found")
+}
+func (r *fakeChatRepo) UpdateRoom(_ *model.ChatRoom) error                   { return nil }
+func (r *fakeChatRepo) DeleteRoom(_ string) error                            { return nil }
+func (r *fakeChatRepo) ListRoomsByOwner(_ string) ([]*model.ChatRoom, error) { return nil, nil }
+func (r *fakeChatRepo) ListJoinedRooms(_ string) ([]*model.ChatRoom, error)  { return nil, nil }
+
+func (r *fakeChatRepo) CreateMessage(msg *model.ChatMessage) error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if r.createErr != nil {
+		return r.createErr
+	}
+	clone := *msg
+	r.messages[msg.ID] = &clone
+	return nil
+}
+func (r *fakeChatRepo) FindMessageByID(id string) (*model.ChatMessage, error) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if msg, ok := r.messages[id]; ok {
+		clone := *msg
+		return &clone, nil
+	}
+	return nil, errors.New("not found")
+}
+func (r *fakeChatRepo) UpdateMessage(msg *model.ChatMessage) error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if r.updateErr != nil {
+		return r.updateErr
+	}
+	clone := *msg
+	r.messages[msg.ID] = &clone
+	return nil
+}
+func (r *fakeChatRepo) DeleteMessage(id string) error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if r.deleteErr != nil {
+		return r.deleteErr
+	}
+	delete(r.messages, id)
+	return nil
+}
+func (r *fakeChatRepo) ListMessagesByRoom(_ string, _ int) ([]*model.ChatMessage, error) {
+	return nil, nil
+}
+func (r *fakeChatRepo) ListMessagesByUser(_, _ string, _ int) ([]*model.ChatMessage, error) {
+	return nil, nil
+}
+func (r *fakeChatRepo) SearchMessages(_, _ string, _ int) ([]*model.ChatMessage, error) {
+	return nil, nil
+}
+func (r *fakeChatRepo) CreateMembership(m *model.ChatRoomMembership) error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.memberships[m.UserID+":"+m.RoomID] = m
+	return nil
+}
+func (r *fakeChatRepo) FindMembership(userID, roomID string) (*model.ChatRoomMembership, error) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if m, ok := r.memberships[userID+":"+roomID]; ok {
+		return m, nil
+	}
+	return nil, errors.New("not found")
+}
+func (r *fakeChatRepo) UpdateMembership(_ *model.ChatRoomMembership) error { return nil }
+func (r *fakeChatRepo) DeleteMembership(_, _ string) error                 { return nil }
+func (r *fakeChatRepo) ListMembersByRoom(_ string) ([]*model.ChatRoomMembership, error) {
+	return nil, nil
+}
+func (r *fakeChatRepo) CreateInvitation(_ *model.ChatRoomInvitation) error { return nil }
+func (r *fakeChatRepo) DeleteInvitation(_ string) error                    { return nil }
+func (r *fakeChatRepo) FindInvitation(_, _ string) (*model.ChatRoomInvitation, error) {
+	return nil, errors.New("not found")
+}
+func (r *fakeChatRepo) CountUnread(_ string) (int64, error) { return 0, nil }
+func (r *fakeChatRepo) MarkRead(userID, messageID string) error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if msg, ok := r.messages[messageID]; ok {
+		msg.Reads = append(msg.Reads, userID)
+	}
+	return nil
+}
+
+// --- capture publisher ---
+
+type capturePublisher struct {
+	mu        sync.Mutex
+	userCalls []userCall
+	roomCalls []roomCall
+}
+
+type userCall struct {
+	from, to, eventType string
+	body                any
+}
+
+type roomCall struct {
+	roomID, eventType string
+	body              any
+}
+
+func (p *capturePublisher) PublishUserMessage(_ context.Context, from, to, t string, body any) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	p.userCalls = append(p.userCalls, userCall{from, to, t, body})
+}
+
+func (p *capturePublisher) PublishRoomMessage(_ context.Context, roomID, t string, body any) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	p.roomCalls = append(p.roomCalls, roomCall{roomID, t, body})
+}
+
+// --- helper ---
+
+func newSvc(t *testing.T) (*corechat.Service, *fakeChatRepo, *capturePublisher) {
+	t.Helper()
+	repo := newFakeRepo()
+	pub := &capturePublisher{}
+	idGen, _ := id.NewGenerator("aidx")
+	svc := corechat.NewService(repo, idGen)
+	svc.SetStreamingPublisher(pub)
+	return svc, repo, pub
+}
+
+// --- CreateMessageToUser ---
+
+func TestCreateMessageToUser_Success(t *testing.T) {
+	svc, _, pub := newSvc(t)
+	msg, err := svc.CreateMessageToUser(context.Background(), "alice", "bob", "hello", "")
+	require.NoError(t, err)
+	assert.NotEmpty(t, msg.ID)
+	require.NotNil(t, msg.Text)
+	assert.Equal(t, "hello", *msg.Text)
+	require.Len(t, pub.userCalls, 1)
+	assert.Equal(t, "alice", pub.userCalls[0].from)
+	assert.Equal(t, "bob", pub.userCalls[0].to)
+	assert.Equal(t, corechat.EventMessage, pub.userCalls[0].eventType)
+}
+
+func TestCreateMessageToUser_WithFile(t *testing.T) {
+	svc, _, _ := newSvc(t)
+	msg, err := svc.CreateMessageToUser(context.Background(), "alice", "bob", "", "file_x")
+	require.NoError(t, err)
+	require.NotNil(t, msg.FileID)
+	assert.Equal(t, "file_x", *msg.FileID)
+}
+
+func TestCreateMessageToUser_EmptySender(t *testing.T) {
+	svc, _, _ := newSvc(t)
+	_, err := svc.CreateMessageToUser(context.Background(), "", "bob", "hi", "")
+	assert.ErrorIs(t, err, corechat.ErrInvalidTarget)
+}
+
+func TestCreateMessageToUser_EmptyRecipient(t *testing.T) {
+	svc, _, _ := newSvc(t)
+	_, err := svc.CreateMessageToUser(context.Background(), "alice", "", "hi", "")
+	assert.ErrorIs(t, err, corechat.ErrInvalidTarget)
+}
+
+func TestCreateMessageToUser_RepoError(t *testing.T) {
+	svc, repo, pub := newSvc(t)
+	repo.createErr = errors.New("db boom")
+	_, err := svc.CreateMessageToUser(context.Background(), "alice", "bob", "hi", "")
+	assert.Error(t, err)
+	assert.Empty(t, pub.userCalls)
+}
+
+// --- CreateMessageToRoom ---
+
+func seedRoom(t *testing.T, repo *fakeChatRepo, id string, owner string, members ...string) {
+	t.Helper()
+	repo.rooms[id] = &model.ChatRoom{ID: id, Name: "test-room", OwnerID: owner}
+	for _, u := range members {
+		repo.memberships[u+":"+id] = &model.ChatRoomMembership{UserID: u, RoomID: id}
+	}
+}
+
+func TestCreateMessageToRoom_Success(t *testing.T) {
+	svc, repo, pub := newSvc(t)
+	seedRoom(t, repo, "r1", "alice", "bob")
+
+	msg, err := svc.CreateMessageToRoom(context.Background(), "bob", "r1", "hello room", "")
+	require.NoError(t, err)
+	require.NotNil(t, msg.ToRoomID)
+	assert.Equal(t, "r1", *msg.ToRoomID)
+	require.Len(t, pub.roomCalls, 1)
+	assert.Equal(t, "r1", pub.roomCalls[0].roomID)
+	assert.Equal(t, corechat.EventMessage, pub.roomCalls[0].eventType)
+}
+
+func TestCreateMessageToRoom_OwnerIsImplicitMember(t *testing.T) {
+	svc, repo, _ := newSvc(t)
+	seedRoom(t, repo, "r1", "alice") // bob not a member
+
+	_, err := svc.CreateMessageToRoom(context.Background(), "alice", "r1", "hi", "")
+	require.NoError(t, err)
+}
+
+func TestCreateMessageToRoom_NotMember(t *testing.T) {
+	svc, repo, _ := newSvc(t)
+	seedRoom(t, repo, "r1", "alice")
+
+	_, err := svc.CreateMessageToRoom(context.Background(), "carol", "r1", "hi", "")
+	assert.ErrorIs(t, err, corechat.ErrForbidden)
+}
+
+func TestCreateMessageToRoom_RoomNotFound(t *testing.T) {
+	svc, _, _ := newSvc(t)
+	_, err := svc.CreateMessageToRoom(context.Background(), "alice", "ghost", "hi", "")
+	assert.ErrorIs(t, err, corechat.ErrNotFound)
+}
+
+func TestCreateMessageToRoom_EmptyTarget(t *testing.T) {
+	svc, _, _ := newSvc(t)
+	_, err := svc.CreateMessageToRoom(context.Background(), "alice", "", "hi", "")
+	assert.ErrorIs(t, err, corechat.ErrInvalidTarget)
+}
+
+func TestCreateMessageToRoom_WithFile(t *testing.T) {
+	svc, repo, _ := newSvc(t)
+	seedRoom(t, repo, "r1", "alice")
+	msg, err := svc.CreateMessageToRoom(context.Background(), "alice", "r1", "", "file_y")
+	require.NoError(t, err)
+	require.NotNil(t, msg.FileID)
+}
+
+func TestCreateMessageToRoom_RepoError(t *testing.T) {
+	svc, repo, _ := newSvc(t)
+	seedRoom(t, repo, "r1", "alice")
+	repo.createErr = errors.New("db boom")
+	_, err := svc.CreateMessageToRoom(context.Background(), "alice", "r1", "hi", "")
+	assert.Error(t, err)
+}
+
+// --- DeleteMessage ---
+
+func TestDeleteMessage_UserDM(t *testing.T) {
+	svc, _, pub := newSvc(t)
+	msg, _ := svc.CreateMessageToUser(context.Background(), "alice", "bob", "hi", "")
+	pub.userCalls = nil // reset
+
+	require.NoError(t, svc.DeleteMessage(context.Background(), "alice", msg.ID))
+	require.Len(t, pub.userCalls, 1)
+	assert.Equal(t, corechat.EventDeleted, pub.userCalls[0].eventType)
+}
+
+func TestDeleteMessage_Room(t *testing.T) {
+	svc, repo, pub := newSvc(t)
+	seedRoom(t, repo, "r1", "alice")
+	msg, _ := svc.CreateMessageToRoom(context.Background(), "alice", "r1", "hi", "")
+	pub.roomCalls = nil
+
+	require.NoError(t, svc.DeleteMessage(context.Background(), "alice", msg.ID))
+	require.Len(t, pub.roomCalls, 1)
+	assert.Equal(t, corechat.EventDeleted, pub.roomCalls[0].eventType)
+}
+
+func TestDeleteMessage_NotFound(t *testing.T) {
+	svc, _, _ := newSvc(t)
+	err := svc.DeleteMessage(context.Background(), "alice", "ghost")
+	assert.ErrorIs(t, err, corechat.ErrNotFound)
+}
+
+func TestDeleteMessage_NotAuthor(t *testing.T) {
+	svc, _, _ := newSvc(t)
+	msg, _ := svc.CreateMessageToUser(context.Background(), "alice", "bob", "hi", "")
+	err := svc.DeleteMessage(context.Background(), "carol", msg.ID)
+	assert.ErrorIs(t, err, corechat.ErrForbidden)
+}
+
+func TestDeleteMessage_RepoError(t *testing.T) {
+	svc, repo, _ := newSvc(t)
+	msg, _ := svc.CreateMessageToUser(context.Background(), "alice", "bob", "hi", "")
+	repo.deleteErr = errors.New("db boom")
+	err := svc.DeleteMessage(context.Background(), "alice", msg.ID)
+	assert.Error(t, err)
+}
+
+// --- UpdateMessage ---
+
+func TestUpdateMessage_Success(t *testing.T) {
+	svc, _, pub := newSvc(t)
+	msg, _ := svc.CreateMessageToUser(context.Background(), "alice", "bob", "original", "")
+	pub.userCalls = nil
+
+	updated, err := svc.UpdateMessage(context.Background(), "alice", msg.ID, "edited")
+	require.NoError(t, err)
+	require.NotNil(t, updated.Text)
+	assert.Equal(t, "edited", *updated.Text)
+	require.Len(t, pub.userCalls, 1)
+	assert.Equal(t, corechat.EventEdited, pub.userCalls[0].eventType)
+}
+
+func TestUpdateMessage_Room(t *testing.T) {
+	svc, repo, pub := newSvc(t)
+	seedRoom(t, repo, "r1", "alice")
+	msg, _ := svc.CreateMessageToRoom(context.Background(), "alice", "r1", "original", "")
+	pub.roomCalls = nil
+
+	_, err := svc.UpdateMessage(context.Background(), "alice", msg.ID, "edited")
+	require.NoError(t, err)
+	require.Len(t, pub.roomCalls, 1)
+	assert.Equal(t, corechat.EventEdited, pub.roomCalls[0].eventType)
+}
+
+func TestUpdateMessage_NotFound(t *testing.T) {
+	svc, _, _ := newSvc(t)
+	_, err := svc.UpdateMessage(context.Background(), "alice", "ghost", "x")
+	assert.ErrorIs(t, err, corechat.ErrNotFound)
+}
+
+func TestUpdateMessage_NotAuthor(t *testing.T) {
+	svc, _, _ := newSvc(t)
+	msg, _ := svc.CreateMessageToUser(context.Background(), "alice", "bob", "hi", "")
+	_, err := svc.UpdateMessage(context.Background(), "carol", msg.ID, "edited")
+	assert.ErrorIs(t, err, corechat.ErrForbidden)
+}
+
+func TestUpdateMessage_RepoError(t *testing.T) {
+	svc, repo, _ := newSvc(t)
+	msg, _ := svc.CreateMessageToUser(context.Background(), "alice", "bob", "hi", "")
+	repo.updateErr = errors.New("db boom")
+	_, err := svc.UpdateMessage(context.Background(), "alice", msg.ID, "edited")
+	assert.Error(t, err)
+}
+
+// --- MarkReadByMessageID ---
+
+func TestMarkReadByMessageID_DM(t *testing.T) {
+	svc, _, pub := newSvc(t)
+	msg, _ := svc.CreateMessageToUser(context.Background(), "alice", "bob", "hi", "")
+	pub.userCalls = nil
+
+	require.NoError(t, svc.MarkReadByMessageID(context.Background(), "bob", msg.ID))
+	require.Len(t, pub.userCalls, 1)
+	assert.Equal(t, corechat.EventRead, pub.userCalls[0].eventType)
+}
+
+func TestMarkReadByMessageID_Room(t *testing.T) {
+	svc, repo, pub := newSvc(t)
+	seedRoom(t, repo, "r1", "alice", "bob")
+	msg, _ := svc.CreateMessageToRoom(context.Background(), "alice", "r1", "hi", "")
+	pub.roomCalls = nil
+
+	require.NoError(t, svc.MarkReadByMessageID(context.Background(), "bob", msg.ID))
+	require.Len(t, pub.roomCalls, 1)
+	assert.Equal(t, corechat.EventRead, pub.roomCalls[0].eventType)
+}
+
+func TestMarkReadByMessageID_NotFound(t *testing.T) {
+	svc, _, _ := newSvc(t)
+	err := svc.MarkReadByMessageID(context.Background(), "bob", "ghost")
+	assert.ErrorIs(t, err, corechat.ErrNotFound)
+}
+
+// --- IsRoomMember ---
+
+func TestIsRoomMember_Member(t *testing.T) {
+	svc, repo, _ := newSvc(t)
+	seedRoom(t, repo, "r1", "alice", "bob")
+	ok, err := svc.IsRoomMember("bob", "r1")
+	require.NoError(t, err)
+	assert.True(t, ok)
+}
+
+func TestIsRoomMember_Owner(t *testing.T) {
+	svc, repo, _ := newSvc(t)
+	seedRoom(t, repo, "r1", "alice") // alice is owner, no explicit membership
+	ok, err := svc.IsRoomMember("alice", "r1")
+	require.NoError(t, err)
+	assert.True(t, ok, "owner should implicitly be a member")
+}
+
+func TestIsRoomMember_NonMember(t *testing.T) {
+	svc, repo, _ := newSvc(t)
+	seedRoom(t, repo, "r1", "alice")
+	ok, err := svc.IsRoomMember("carol", "r1")
+	require.NoError(t, err)
+	assert.False(t, ok)
+}
+
+// --- nil publisher fallback ---
+
+func TestService_NilPublisherStillWorks(t *testing.T) {
+	idGen, _ := id.NewGenerator("aidx")
+	svc := corechat.NewService(newFakeRepo(), idGen)
+	// No publisher set; operations should still succeed (no panic)
+	_, err := svc.CreateMessageToUser(context.Background(), "alice", "bob", "hi", "")
+	assert.NoError(t, err)
+}
+
+// --- sanity: reads array mutation round-trip ---
+
+func TestMarkRead_AppendsToReads(t *testing.T) {
+	svc, repo, _ := newSvc(t)
+	msg, _ := svc.CreateMessageToUser(context.Background(), "alice", "bob", "hi", "")
+	require.NoError(t, svc.MarkReadByMessageID(context.Background(), "bob", msg.ID))
+	stored := repo.messages[msg.ID]
+	require.NotNil(t, stored)
+	assert.Equal(t, pq.StringArray{"bob"}, stored.Reads)
+}

--- a/internal/repository/chat.go
+++ b/internal/repository/chat.go
@@ -18,6 +18,7 @@ type ChatRepository interface {
 	// Message operations
 	CreateMessage(msg *model.ChatMessage) error
 	FindMessageByID(id string) (*model.ChatMessage, error)
+	UpdateMessage(msg *model.ChatMessage) error
 	DeleteMessage(id string) error
 	ListMessagesByRoom(roomID string, limit int) ([]*model.ChatMessage, error)
 	ListMessagesByUser(userID, otherUserID string, limit int) ([]*model.ChatMessage, error)
@@ -99,6 +100,10 @@ func (r *chatRepository) FindMessageByID(id string) (*model.ChatMessage, error) 
 		return nil, err
 	}
 	return &msg, nil
+}
+
+func (r *chatRepository) UpdateMessage(msg *model.ChatMessage) error {
+	return r.db.Save(msg).Error
 }
 
 func (r *chatRepository) DeleteMessage(id string) error {

--- a/internal/server/router.go
+++ b/internal/server/router.go
@@ -52,6 +52,7 @@ import (
 	corechannel "github.com/shiroha-a/mk/internal/core/channel"
 	"github.com/shiroha-a/mk/internal/core/chart"
 	"github.com/shiroha-a/mk/internal/core/chart/charthook"
+	corechat "github.com/shiroha-a/mk/internal/core/chat"
 	coreclip "github.com/shiroha-a/mk/internal/core/clip"
 	coredrive "github.com/shiroha-a/mk/internal/core/drive"
 	"github.com/shiroha-a/mk/internal/core/event"
@@ -133,6 +134,7 @@ func (s *Server) setupRoutes() {
 	webhookRepo := repository.NewWebhookRepository(s.db)
 	systemWebhookRepo := repository.NewSystemWebhookRepository(s.db)
 	reversiRepo := repository.NewReversiRepository(s.db)
+	chatRepo := repository.NewChatRepository(s.db)
 
 	// Core services
 	roleService := corerole.NewService(roleRepo, roleAssignmentRepo, metaRepo, idGen)
@@ -847,6 +849,13 @@ func (s *Server) setupRoutes() {
 	// 5. Reversi WebSocket channel (Phase 9.6) を登録する
 	reversiService := corereversi.NewService(reversiRepo, reversiPublisher, s.redis.Default)
 	streamRegistry.Register("reversiGame", channels.NewReversiGameFactory(reversiService).New)
+
+	// 6. Chat WebSocket channels (Phase 9.8): chatRoom と chatUser を登録する
+	chatPublisher := stream.NewChatPublisher(streamPubSub)
+	chatService := corechat.NewService(chatRepo, idGen)
+	chatService.SetStreamingPublisher(chatPublisher)
+	streamRegistry.Register("chatRoom", channels.NewChatRoomFactory(chatService).New)
+	streamRegistry.Register("chatUser", channels.NewChatUserFactory(chatService).New)
 	// Phase 9.7: federation processor / reversi handler に reversi 依存を注入。
 	// FederationIDCache は本家 Misskey DB スキーマ互換のため DB カラムを持たず
 	// Redis のみで session↔gameID の双方向 mapping を保持する。api handler と
@@ -1082,8 +1091,8 @@ func (s *Server) setupRoutes() {
 	api.POST("/bubble-game/ranking", bubbleGameHandler.Ranking)
 
 	// chat/* — Misskey v2026 チャット機能 (実データ)
-	chatRepo := repository.NewChatRepository(s.db)
 	chatHandler := apichat.NewHandler(chatRepo, idGen)
+	chatHandler.SetService(chatService)
 	api.POST("/chat/rooms/create", chatHandler.RoomsCreate, middleware.RequireAuth())
 	api.POST("/chat/rooms/show", chatHandler.RoomsShow, middleware.RequireAuth())
 	api.POST("/chat/rooms/update", chatHandler.RoomsUpdate, middleware.RequireAuth())

--- a/internal/stream/channels/chat_room.go
+++ b/internal/stream/channels/chat_room.go
@@ -1,0 +1,109 @@
+package channels
+
+import (
+	"context"
+	"encoding/json"
+	"log/slog"
+
+	corechat "github.com/shiroha-a/mk/internal/core/chat"
+	"github.com/shiroha-a/mk/internal/model"
+	"github.com/shiroha-a/mk/internal/stream"
+)
+
+// ChatRoomChannel forwards chat room events (message / edited / deleted /
+// read) to any connected client that is a member of the target room.
+// Init に失敗 (未参加、room 不明) した場合は topic を subscribe せず沈黙する
+// — 本家 Misskey ChatRoomChannel と同じ挙動。
+type ChatRoomChannel struct {
+	ctx    stream.ChannelContext
+	svc    *corechat.Service
+	roomID string
+	topic  string
+}
+
+// ChatRoomFactory holds the shared chat service so the registry can build
+// channel instances per connection.
+type ChatRoomFactory struct {
+	svc *corechat.Service
+}
+
+// NewChatRoomFactory constructs a ChatRoomFactory.
+func NewChatRoomFactory(svc *corechat.Service) *ChatRoomFactory {
+	return &ChatRoomFactory{svc: svc}
+}
+
+// New builds a new channel bound to ctx, usable directly as stream.ChannelFactory.
+func (f *ChatRoomFactory) New(ctx stream.ChannelContext) stream.Channel {
+	return &ChatRoomChannel{ctx: ctx, svc: f.svc}
+}
+
+// Init parses `roomId` from params, verifies the connected user is a member
+// of the room, then subscribes to the shared Redis topic.
+func (c *ChatRoomChannel) Init(params json.RawMessage) {
+	var p struct {
+		RoomID string `json:"roomId"`
+	}
+	if err := json.Unmarshal(params, &p); err != nil || p.RoomID == "" {
+		return
+	}
+	user, ok := c.ctx.User().(*model.User)
+	if !ok || user == nil {
+		return
+	}
+	if c.svc != nil {
+		member, err := c.svc.IsRoomMember(user.ID, p.RoomID)
+		if err != nil || !member {
+			return
+		}
+	}
+	c.roomID = p.RoomID
+	c.topic = "chatRoomStream:" + p.RoomID
+	c.ctx.Subscribe(c.topic)
+}
+
+// OnRedisEvent decodes a {type, body} envelope and forwards the body to the
+// client with the matching event type.
+func (c *ChatRoomChannel) OnRedisEvent(payload []byte) {
+	var env struct {
+		Type string          `json:"type"`
+		Body json.RawMessage `json:"body"`
+	}
+	if err := json.Unmarshal(payload, &env); err != nil || env.Type == "" {
+		return
+	}
+	_ = c.ctx.Send(env.Type, env.Body)
+}
+
+// OnClientMessage handles the single supported client-side action: "read".
+// Clients send `{type: "read", body: {id: messageID}}` to mark a message as
+// read, which propagates to the service layer. Other message types are
+// silently ignored.
+func (c *ChatRoomChannel) OnClientMessage(msgType string, body json.RawMessage) {
+	if c.svc == nil || c.roomID == "" {
+		return
+	}
+	user, ok := c.ctx.User().(*model.User)
+	if !ok || user == nil {
+		return
+	}
+	switch msgType {
+	case "read":
+		var req struct {
+			ID string `json:"id"`
+		}
+		if err := json.Unmarshal(body, &req); err != nil || req.ID == "" {
+			return
+		}
+		if err := c.svc.MarkReadByMessageID(context.Background(), user.ID, req.ID); err != nil {
+			slog.Info("chat room channel: read failed",
+				"user", user.ID, "room", c.roomID, "err", err)
+		}
+	}
+}
+
+// Dispose unsubscribes from the room topic.
+func (c *ChatRoomChannel) Dispose() {
+	if c.topic != "" {
+		c.ctx.Unsubscribe(c.topic)
+	}
+}

--- a/internal/stream/channels/chat_room_test.go
+++ b/internal/stream/channels/chat_room_test.go
@@ -1,0 +1,276 @@
+package channels
+
+import (
+	"encoding/json"
+	"errors"
+	"sync"
+	"testing"
+
+	corechat "github.com/shiroha-a/mk/internal/core/chat"
+	"github.com/shiroha-a/mk/internal/misc/id"
+	"github.com/shiroha-a/mk/internal/model"
+	"github.com/shiroha-a/mk/internal/stream"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// --- minimal in-memory chat repo for channel wiring ---
+
+type chatFakeRepo struct {
+	mu          sync.Mutex
+	rooms       map[string]*model.ChatRoom
+	messages    map[string]*model.ChatMessage
+	memberships map[string]*model.ChatRoomMembership
+}
+
+func newChatFakeRepo() *chatFakeRepo {
+	return &chatFakeRepo{
+		rooms:       make(map[string]*model.ChatRoom),
+		messages:    make(map[string]*model.ChatMessage),
+		memberships: make(map[string]*model.ChatRoomMembership),
+	}
+}
+
+func (r *chatFakeRepo) CreateRoom(rm *model.ChatRoom) error { r.rooms[rm.ID] = rm; return nil }
+func (r *chatFakeRepo) FindRoomByID(id string) (*model.ChatRoom, error) {
+	if rm, ok := r.rooms[id]; ok {
+		return rm, nil
+	}
+	return nil, errors.New("not found")
+}
+func (r *chatFakeRepo) UpdateRoom(_ *model.ChatRoom) error                   { return nil }
+func (r *chatFakeRepo) DeleteRoom(_ string) error                            { return nil }
+func (r *chatFakeRepo) ListRoomsByOwner(_ string) ([]*model.ChatRoom, error) { return nil, nil }
+func (r *chatFakeRepo) ListJoinedRooms(_ string) ([]*model.ChatRoom, error)  { return nil, nil }
+func (r *chatFakeRepo) CreateMessage(msg *model.ChatMessage) error {
+	r.messages[msg.ID] = msg
+	return nil
+}
+func (r *chatFakeRepo) FindMessageByID(id string) (*model.ChatMessage, error) {
+	if m, ok := r.messages[id]; ok {
+		return m, nil
+	}
+	return nil, errors.New("not found")
+}
+func (r *chatFakeRepo) UpdateMessage(_ *model.ChatMessage) error { return nil }
+func (r *chatFakeRepo) DeleteMessage(_ string) error             { return nil }
+func (r *chatFakeRepo) ListMessagesByRoom(_ string, _ int) ([]*model.ChatMessage, error) {
+	return nil, nil
+}
+func (r *chatFakeRepo) ListMessagesByUser(_, _ string, _ int) ([]*model.ChatMessage, error) {
+	return nil, nil
+}
+func (r *chatFakeRepo) SearchMessages(_, _ string, _ int) ([]*model.ChatMessage, error) {
+	return nil, nil
+}
+func (r *chatFakeRepo) CreateMembership(m *model.ChatRoomMembership) error {
+	r.memberships[m.UserID+":"+m.RoomID] = m
+	return nil
+}
+func (r *chatFakeRepo) FindMembership(userID, roomID string) (*model.ChatRoomMembership, error) {
+	if m, ok := r.memberships[userID+":"+roomID]; ok {
+		return m, nil
+	}
+	return nil, errors.New("not found")
+}
+func (r *chatFakeRepo) UpdateMembership(_ *model.ChatRoomMembership) error { return nil }
+func (r *chatFakeRepo) DeleteMembership(_, _ string) error                 { return nil }
+func (r *chatFakeRepo) ListMembersByRoom(_ string) ([]*model.ChatRoomMembership, error) {
+	return nil, nil
+}
+func (r *chatFakeRepo) CreateInvitation(_ *model.ChatRoomInvitation) error { return nil }
+func (r *chatFakeRepo) DeleteInvitation(_ string) error                    { return nil }
+func (r *chatFakeRepo) FindInvitation(_, _ string) (*model.ChatRoomInvitation, error) {
+	return nil, errors.New("not found")
+}
+func (r *chatFakeRepo) CountUnread(_ string) (int64, error) { return 0, nil }
+func (r *chatFakeRepo) MarkRead(_, _ string) error          { return nil }
+
+// --- test helpers ---
+
+func newChatSvc(t *testing.T) (*corechat.Service, *chatFakeRepo) {
+	t.Helper()
+	repo := newChatFakeRepo()
+	idGen, _ := id.NewGenerator("aidx")
+	return corechat.NewService(repo, idGen), repo
+}
+
+// --- conformance ---
+
+var _ stream.Channel = (*ChatRoomChannel)(nil)
+var _ stream.Channel = (*ChatUserChannel)(nil)
+
+// --- ChatRoom channel tests ---
+
+func TestChatRoomChannel_Init_Member(t *testing.T) {
+	svc, repo := newChatSvc(t)
+	repo.rooms["r1"] = &model.ChatRoom{ID: "r1", OwnerID: "alice"}
+	repo.memberships["bob:r1"] = &model.ChatRoomMembership{UserID: "bob", RoomID: "r1"}
+
+	ctx := newCtx(&model.User{ID: "bob"})
+	ch := NewChatRoomFactory(svc).New(ctx)
+	ch.Init(json.RawMessage(`{"roomId":"r1"}`))
+
+	assert.Equal(t, []string{"chatRoomStream:r1"}, ctx.subs)
+}
+
+func TestChatRoomChannel_Init_OwnerImplicitMember(t *testing.T) {
+	svc, repo := newChatSvc(t)
+	repo.rooms["r1"] = &model.ChatRoom{ID: "r1", OwnerID: "alice"}
+
+	ctx := newCtx(&model.User{ID: "alice"})
+	ch := NewChatRoomFactory(svc).New(ctx)
+	ch.Init(json.RawMessage(`{"roomId":"r1"}`))
+
+	assert.Equal(t, []string{"chatRoomStream:r1"}, ctx.subs)
+}
+
+func TestChatRoomChannel_Init_NotMember(t *testing.T) {
+	svc, repo := newChatSvc(t)
+	repo.rooms["r1"] = &model.ChatRoom{ID: "r1", OwnerID: "alice"}
+
+	ctx := newCtx(&model.User{ID: "carol"})
+	ch := NewChatRoomFactory(svc).New(ctx)
+	ch.Init(json.RawMessage(`{"roomId":"r1"}`))
+
+	assert.Empty(t, ctx.subs, "non-member should not subscribe")
+}
+
+func TestChatRoomChannel_Init_Unauthenticated(t *testing.T) {
+	svc, _ := newChatSvc(t)
+	ctx := newCtx(nil)
+	ch := NewChatRoomFactory(svc).New(ctx)
+	ch.Init(json.RawMessage(`{"roomId":"r1"}`))
+	assert.Empty(t, ctx.subs)
+}
+
+func TestChatRoomChannel_Init_MissingRoomID(t *testing.T) {
+	svc, _ := newChatSvc(t)
+	ctx := newCtx(&model.User{ID: "alice"})
+	ch := NewChatRoomFactory(svc).New(ctx)
+	ch.Init(json.RawMessage(`{}`))
+	assert.Empty(t, ctx.subs)
+}
+
+func TestChatRoomChannel_Init_BadJSON(t *testing.T) {
+	svc, _ := newChatSvc(t)
+	ctx := newCtx(&model.User{ID: "alice"})
+	ch := NewChatRoomFactory(svc).New(ctx)
+	ch.Init(json.RawMessage(`not-json`))
+	assert.Empty(t, ctx.subs)
+}
+
+func TestChatRoomChannel_OnRedisEvent_Forwards(t *testing.T) {
+	svc, repo := newChatSvc(t)
+	repo.rooms["r1"] = &model.ChatRoom{ID: "r1", OwnerID: "alice"}
+	ctx := newCtx(&model.User{ID: "alice"})
+	ch := NewChatRoomFactory(svc).New(ctx)
+	ch.Init(json.RawMessage(`{"roomId":"r1"}`))
+	ch.OnRedisEvent([]byte(`{"type":"message","body":{"id":"m1"}}`))
+	require.Len(t, ctx.sentType, 1)
+	assert.Equal(t, "message", ctx.sentType[0])
+}
+
+func TestChatRoomChannel_OnRedisEvent_Invalid(t *testing.T) {
+	svc, repo := newChatSvc(t)
+	repo.rooms["r1"] = &model.ChatRoom{ID: "r1", OwnerID: "alice"}
+	ctx := newCtx(&model.User{ID: "alice"})
+	ch := NewChatRoomFactory(svc).New(ctx)
+	ch.Init(json.RawMessage(`{"roomId":"r1"}`))
+	ch.OnRedisEvent([]byte(`not-json`))
+	assert.Empty(t, ctx.sentType)
+}
+
+func TestChatRoomChannel_OnRedisEvent_NoType(t *testing.T) {
+	svc, repo := newChatSvc(t)
+	repo.rooms["r1"] = &model.ChatRoom{ID: "r1", OwnerID: "alice"}
+	ctx := newCtx(&model.User{ID: "alice"})
+	ch := NewChatRoomFactory(svc).New(ctx)
+	ch.Init(json.RawMessage(`{"roomId":"r1"}`))
+	ch.OnRedisEvent([]byte(`{"body":{}}`))
+	assert.Empty(t, ctx.sentType)
+}
+
+func TestChatRoomChannel_OnClientMessage_Read(t *testing.T) {
+	svc, repo := newChatSvc(t)
+	repo.rooms["r1"] = &model.ChatRoom{ID: "r1", OwnerID: "alice"}
+	textStr := "hi"
+	repo.messages["m1"] = &model.ChatMessage{
+		ID: "m1", FromUserID: "alice", ToRoomID: strPtr("r1"), Text: &textStr,
+	}
+	ctx := newCtx(&model.User{ID: "alice"})
+	ch := NewChatRoomFactory(svc).New(ctx)
+	ch.Init(json.RawMessage(`{"roomId":"r1"}`))
+	ch.OnClientMessage("read", json.RawMessage(`{"id":"m1"}`))
+	// should not panic; we don't verify the side effect here (covered in service tests)
+}
+
+func TestChatRoomChannel_OnClientMessage_UnknownType(t *testing.T) {
+	svc, repo := newChatSvc(t)
+	repo.rooms["r1"] = &model.ChatRoom{ID: "r1", OwnerID: "alice"}
+	ctx := newCtx(&model.User{ID: "alice"})
+	ch := NewChatRoomFactory(svc).New(ctx)
+	ch.Init(json.RawMessage(`{"roomId":"r1"}`))
+	ch.OnClientMessage("bogus", json.RawMessage(`{}`))
+	// silently ignored
+}
+
+func TestChatRoomChannel_OnClientMessage_ReadEmptyID(t *testing.T) {
+	svc, repo := newChatSvc(t)
+	repo.rooms["r1"] = &model.ChatRoom{ID: "r1", OwnerID: "alice"}
+	ctx := newCtx(&model.User{ID: "alice"})
+	ch := NewChatRoomFactory(svc).New(ctx)
+	ch.Init(json.RawMessage(`{"roomId":"r1"}`))
+	ch.OnClientMessage("read", json.RawMessage(`{"id":""}`))
+}
+
+func TestChatRoomChannel_OnClientMessage_ReadBadJSON(t *testing.T) {
+	svc, repo := newChatSvc(t)
+	repo.rooms["r1"] = &model.ChatRoom{ID: "r1", OwnerID: "alice"}
+	ctx := newCtx(&model.User{ID: "alice"})
+	ch := NewChatRoomFactory(svc).New(ctx)
+	ch.Init(json.RawMessage(`{"roomId":"r1"}`))
+	ch.OnClientMessage("read", json.RawMessage(`not-json`))
+}
+
+func TestChatRoomChannel_OnClientMessage_Unauthenticated(t *testing.T) {
+	svc, _ := newChatSvc(t)
+	ctx := newCtx(nil)
+	ch := &ChatRoomChannel{ctx: ctx, svc: svc, roomID: "r1"}
+	ch.OnClientMessage("read", json.RawMessage(`{"id":"m1"}`))
+}
+
+func TestChatRoomChannel_OnClientMessage_NilService(t *testing.T) {
+	ctx := newCtx(&model.User{ID: "alice"})
+	ch := &ChatRoomChannel{ctx: ctx, svc: nil, roomID: "r1"}
+	ch.OnClientMessage("read", json.RawMessage(`{"id":"m1"}`))
+}
+
+func TestChatRoomChannel_OnClientMessage_ReadServiceError(t *testing.T) {
+	svc, _ := newChatSvc(t)
+	// message doesn't exist in repo → MarkReadByMessageID returns ErrNotFound
+	ctx := newCtx(&model.User{ID: "alice"})
+	ch := &ChatRoomChannel{ctx: ctx, svc: svc, roomID: "r1"}
+	ch.OnClientMessage("read", json.RawMessage(`{"id":"ghost"}`))
+}
+
+func TestChatRoomChannel_Dispose(t *testing.T) {
+	svc, repo := newChatSvc(t)
+	repo.rooms["r1"] = &model.ChatRoom{ID: "r1", OwnerID: "alice"}
+	ctx := newCtx(&model.User{ID: "alice"})
+	ch := NewChatRoomFactory(svc).New(ctx)
+	ch.Init(json.RawMessage(`{"roomId":"r1"}`))
+	ch.Dispose()
+	assert.Equal(t, []string{"chatRoomStream:r1"}, ctx.unsubs)
+}
+
+func TestChatRoomChannel_Dispose_WithoutInit(t *testing.T) {
+	svc, _ := newChatSvc(t)
+	ctx := newCtx(nil)
+	ch := NewChatRoomFactory(svc).New(ctx)
+	ch.Dispose() // no panic
+	assert.Empty(t, ctx.unsubs)
+}
+
+// helper
+func strPtr(s string) *string { return &s }

--- a/internal/stream/channels/chat_user.go
+++ b/internal/stream/channels/chat_user.go
@@ -1,0 +1,101 @@
+package channels
+
+import (
+	"context"
+	"encoding/json"
+	"log/slog"
+
+	corechat "github.com/shiroha-a/mk/internal/core/chat"
+	"github.com/shiroha-a/mk/internal/model"
+	"github.com/shiroha-a/mk/internal/stream"
+)
+
+// ChatUserChannel forwards direct-message events for a specific conversation
+// pair (me ↔ other). Param: `otherId`.
+// 本家 Misskey ChatUserChannel 相当。subscribe するトピックは
+// `chatUserStream:{myId}-{otherId}` (自分のビュー)。
+type ChatUserChannel struct {
+	ctx     stream.ChannelContext
+	svc     *corechat.Service
+	otherID string
+	topic   string
+}
+
+// ChatUserFactory holds the shared service for per-connection factory calls.
+type ChatUserFactory struct {
+	svc *corechat.Service
+}
+
+// NewChatUserFactory constructs a ChatUserFactory.
+func NewChatUserFactory(svc *corechat.Service) *ChatUserFactory {
+	return &ChatUserFactory{svc: svc}
+}
+
+// New builds a new channel bound to ctx, usable directly as stream.ChannelFactory.
+func (f *ChatUserFactory) New(ctx stream.ChannelContext) stream.Channel {
+	return &ChatUserChannel{ctx: ctx, svc: f.svc}
+}
+
+// Init parses `otherId` and subscribes to the user's own conversation view.
+func (c *ChatUserChannel) Init(params json.RawMessage) {
+	var p struct {
+		OtherID string `json:"otherId"`
+	}
+	if err := json.Unmarshal(params, &p); err != nil || p.OtherID == "" {
+		return
+	}
+	user, ok := c.ctx.User().(*model.User)
+	if !ok || user == nil {
+		return
+	}
+	// 自分と同じ id を other に指定するのは無効。
+	if p.OtherID == user.ID {
+		return
+	}
+	c.otherID = p.OtherID
+	c.topic = "chatUserStream:" + user.ID + "-" + p.OtherID
+	c.ctx.Subscribe(c.topic)
+}
+
+// OnRedisEvent decodes a {type, body} envelope and forwards to the client.
+func (c *ChatUserChannel) OnRedisEvent(payload []byte) {
+	var env struct {
+		Type string          `json:"type"`
+		Body json.RawMessage `json:"body"`
+	}
+	if err := json.Unmarshal(payload, &env); err != nil || env.Type == "" {
+		return
+	}
+	_ = c.ctx.Send(env.Type, env.Body)
+}
+
+// OnClientMessage handles "read" to mark a DM as read. Other types ignored.
+func (c *ChatUserChannel) OnClientMessage(msgType string, body json.RawMessage) {
+	if c.svc == nil || c.otherID == "" {
+		return
+	}
+	user, ok := c.ctx.User().(*model.User)
+	if !ok || user == nil {
+		return
+	}
+	switch msgType {
+	case "read":
+		var req struct {
+			ID string `json:"id"`
+		}
+		if err := json.Unmarshal(body, &req); err != nil || req.ID == "" {
+			return
+		}
+		if err := c.svc.MarkReadByMessageID(context.Background(), user.ID, req.ID); err != nil {
+			slog.Info("chat user channel: read failed",
+				"user", user.ID, "other", c.otherID, "err", err)
+		}
+	}
+}
+
+// Dispose unsubscribes from the user's conversation topic.
+func (c *ChatUserChannel) Dispose() {
+	if c.topic != "" {
+		c.ctx.Unsubscribe(c.topic)
+	}
+}

--- a/internal/stream/channels/chat_user_test.go
+++ b/internal/stream/channels/chat_user_test.go
@@ -1,0 +1,159 @@
+package channels
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/shiroha-a/mk/internal/model"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestChatUserChannel_Init_SubscribesMyDirection(t *testing.T) {
+	svc, _ := newChatSvc(t)
+	ctx := newCtx(&model.User{ID: "alice"})
+	ch := NewChatUserFactory(svc).New(ctx)
+	ch.Init(json.RawMessage(`{"otherId":"bob"}`))
+	assert.Equal(t, []string{"chatUserStream:alice-bob"}, ctx.subs)
+}
+
+func TestChatUserChannel_Init_MissingOtherID(t *testing.T) {
+	svc, _ := newChatSvc(t)
+	ctx := newCtx(&model.User{ID: "alice"})
+	ch := NewChatUserFactory(svc).New(ctx)
+	ch.Init(json.RawMessage(`{}`))
+	assert.Empty(t, ctx.subs)
+}
+
+func TestChatUserChannel_Init_BadJSON(t *testing.T) {
+	svc, _ := newChatSvc(t)
+	ctx := newCtx(&model.User{ID: "alice"})
+	ch := NewChatUserFactory(svc).New(ctx)
+	ch.Init(json.RawMessage(`not-json`))
+	assert.Empty(t, ctx.subs)
+}
+
+func TestChatUserChannel_Init_Unauthenticated(t *testing.T) {
+	svc, _ := newChatSvc(t)
+	ctx := newCtx(nil)
+	ch := NewChatUserFactory(svc).New(ctx)
+	ch.Init(json.RawMessage(`{"otherId":"bob"}`))
+	assert.Empty(t, ctx.subs)
+}
+
+func TestChatUserChannel_Init_SelfIsInvalid(t *testing.T) {
+	svc, _ := newChatSvc(t)
+	ctx := newCtx(&model.User{ID: "alice"})
+	ch := NewChatUserFactory(svc).New(ctx)
+	ch.Init(json.RawMessage(`{"otherId":"alice"}`))
+	assert.Empty(t, ctx.subs)
+}
+
+func TestChatUserChannel_OnRedisEvent_Forwards(t *testing.T) {
+	svc, _ := newChatSvc(t)
+	ctx := newCtx(&model.User{ID: "alice"})
+	ch := NewChatUserFactory(svc).New(ctx)
+	ch.Init(json.RawMessage(`{"otherId":"bob"}`))
+	ch.OnRedisEvent([]byte(`{"type":"message","body":{"id":"m1"}}`))
+	require.Len(t, ctx.sentType, 1)
+	assert.Equal(t, "message", ctx.sentType[0])
+}
+
+func TestChatUserChannel_OnRedisEvent_Invalid(t *testing.T) {
+	svc, _ := newChatSvc(t)
+	ctx := newCtx(&model.User{ID: "alice"})
+	ch := NewChatUserFactory(svc).New(ctx)
+	ch.Init(json.RawMessage(`{"otherId":"bob"}`))
+	ch.OnRedisEvent([]byte(`not-json`))
+	assert.Empty(t, ctx.sentType)
+}
+
+func TestChatUserChannel_OnRedisEvent_NoType(t *testing.T) {
+	svc, _ := newChatSvc(t)
+	ctx := newCtx(&model.User{ID: "alice"})
+	ch := NewChatUserFactory(svc).New(ctx)
+	ch.Init(json.RawMessage(`{"otherId":"bob"}`))
+	ch.OnRedisEvent([]byte(`{"body":{}}`))
+	assert.Empty(t, ctx.sentType)
+}
+
+func TestChatUserChannel_OnClientMessage_Read(t *testing.T) {
+	svc, repo := newChatSvc(t)
+	text := "hi"
+	toID := "alice"
+	repo.messages["m1"] = &model.ChatMessage{
+		ID: "m1", FromUserID: "bob", ToUserID: &toID, Text: &text,
+	}
+	ctx := newCtx(&model.User{ID: "alice"})
+	ch := NewChatUserFactory(svc).New(ctx)
+	ch.Init(json.RawMessage(`{"otherId":"bob"}`))
+	ch.OnClientMessage("read", json.RawMessage(`{"id":"m1"}`))
+}
+
+func TestChatUserChannel_OnClientMessage_UnknownType(t *testing.T) {
+	svc, _ := newChatSvc(t)
+	ctx := newCtx(&model.User{ID: "alice"})
+	ch := NewChatUserFactory(svc).New(ctx)
+	ch.Init(json.RawMessage(`{"otherId":"bob"}`))
+	ch.OnClientMessage("bogus", json.RawMessage(`{}`))
+}
+
+func TestChatUserChannel_OnClientMessage_ReadEmptyID(t *testing.T) {
+	svc, _ := newChatSvc(t)
+	ctx := newCtx(&model.User{ID: "alice"})
+	ch := NewChatUserFactory(svc).New(ctx)
+	ch.Init(json.RawMessage(`{"otherId":"bob"}`))
+	ch.OnClientMessage("read", json.RawMessage(`{"id":""}`))
+}
+
+func TestChatUserChannel_OnClientMessage_ReadBadJSON(t *testing.T) {
+	svc, _ := newChatSvc(t)
+	ctx := newCtx(&model.User{ID: "alice"})
+	ch := NewChatUserFactory(svc).New(ctx)
+	ch.Init(json.RawMessage(`{"otherId":"bob"}`))
+	ch.OnClientMessage("read", json.RawMessage(`not-json`))
+}
+
+func TestChatUserChannel_OnClientMessage_NoOther(t *testing.T) {
+	svc, _ := newChatSvc(t)
+	ctx := newCtx(&model.User{ID: "alice"})
+	ch := &ChatUserChannel{ctx: ctx, svc: svc} // no Init → otherID empty
+	ch.OnClientMessage("read", json.RawMessage(`{"id":"m1"}`))
+}
+
+func TestChatUserChannel_OnClientMessage_Unauthenticated(t *testing.T) {
+	svc, _ := newChatSvc(t)
+	ctx := newCtx(nil)
+	ch := &ChatUserChannel{ctx: ctx, svc: svc, otherID: "bob"}
+	ch.OnClientMessage("read", json.RawMessage(`{"id":"m1"}`))
+}
+
+func TestChatUserChannel_OnClientMessage_NilService(t *testing.T) {
+	ctx := newCtx(&model.User{ID: "alice"})
+	ch := &ChatUserChannel{ctx: ctx, svc: nil, otherID: "bob"}
+	ch.OnClientMessage("read", json.RawMessage(`{"id":"m1"}`))
+}
+
+func TestChatUserChannel_OnClientMessage_ReadServiceError(t *testing.T) {
+	svc, _ := newChatSvc(t)
+	ctx := newCtx(&model.User{ID: "alice"})
+	ch := &ChatUserChannel{ctx: ctx, svc: svc, otherID: "bob"}
+	ch.OnClientMessage("read", json.RawMessage(`{"id":"ghost"}`))
+}
+
+func TestChatUserChannel_Dispose(t *testing.T) {
+	svc, _ := newChatSvc(t)
+	ctx := newCtx(&model.User{ID: "alice"})
+	ch := NewChatUserFactory(svc).New(ctx)
+	ch.Init(json.RawMessage(`{"otherId":"bob"}`))
+	ch.Dispose()
+	assert.Equal(t, []string{"chatUserStream:alice-bob"}, ctx.unsubs)
+}
+
+func TestChatUserChannel_Dispose_WithoutInit(t *testing.T) {
+	svc, _ := newChatSvc(t)
+	ctx := newCtx(nil)
+	ch := NewChatUserFactory(svc).New(ctx)
+	ch.Dispose()
+	assert.Empty(t, ctx.unsubs)
+}

--- a/internal/stream/chat_publisher.go
+++ b/internal/stream/chat_publisher.go
@@ -1,0 +1,70 @@
+package stream
+
+import (
+	"context"
+	"encoding/json"
+	"log/slog"
+)
+
+// ChatPublisher implements core/chat.StreamingPublisher by serializing
+// {type, body} envelopes and pushing them to the Redis pub/sub bus. The
+// channel names match upstream Misskey GlobalEventService helpers so that
+// existing frontend clients work unchanged.
+//
+//   - Room: chatRoomStream:{roomId}
+//   - Direct message: chatUserStream:{fromUserId}-{toUserId}
+//     本家と同じく A→B の会話ビューと B→A のビューは別トピックに publish
+//     する。各ユーザーは自分のビュー (chatUserStream:{myId}-{otherId}) を
+//     subscribe する。
+type ChatPublisher struct {
+	pub PubSubPublisher
+}
+
+// NewChatPublisher constructs a ChatPublisher.
+func NewChatPublisher(pub PubSubPublisher) *ChatPublisher {
+	return &ChatPublisher{pub: pub}
+}
+
+// PublishUserMessage dispatches a DM event to BOTH direction topics so that
+// the sender's and recipient's connected clients both receive it. 本家
+// Misskey の createMessageToUser が publishChatUserStream を 2 回呼ぶのと
+// 同等。
+func (p *ChatPublisher) PublishUserMessage(ctx context.Context, fromUserID, toUserID, eventType string, body any) {
+	if p == nil || p.pub == nil || fromUserID == "" || toUserID == "" {
+		return
+	}
+	raw, err := json.Marshal(map[string]any{"type": eventType, "body": body})
+	if err != nil {
+		slog.Warn("chat publisher: marshal user envelope failed",
+			"event", eventType, "err", err)
+		return
+	}
+	senderTopic := "chatUserStream:" + fromUserID + "-" + toUserID
+	recipientTopic := "chatUserStream:" + toUserID + "-" + fromUserID
+	if err := p.pub.Publish(ctx, senderTopic, json.RawMessage(raw)); err != nil {
+		slog.Warn("chat publisher: publish sender topic failed",
+			"topic", senderTopic, "err", err)
+	}
+	if err := p.pub.Publish(ctx, recipientTopic, json.RawMessage(raw)); err != nil {
+		slog.Warn("chat publisher: publish recipient topic failed",
+			"topic", recipientTopic, "err", err)
+	}
+}
+
+// PublishRoomMessage dispatches a room event to the single room topic.
+func (p *ChatPublisher) PublishRoomMessage(ctx context.Context, roomID, eventType string, body any) {
+	if p == nil || p.pub == nil || roomID == "" {
+		return
+	}
+	raw, err := json.Marshal(map[string]any{"type": eventType, "body": body})
+	if err != nil {
+		slog.Warn("chat publisher: marshal room envelope failed",
+			"event", eventType, "err", err)
+		return
+	}
+	topic := "chatRoomStream:" + roomID
+	if err := p.pub.Publish(ctx, topic, json.RawMessage(raw)); err != nil {
+		slog.Warn("chat publisher: publish room topic failed",
+			"topic", topic, "err", err)
+	}
+}

--- a/internal/stream/chat_publisher_test.go
+++ b/internal/stream/chat_publisher_test.go
@@ -1,0 +1,82 @@
+package stream
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// reuse capturingPubSub from reversi_publisher_test.go (same package)
+
+func TestChatPublisher_PublishUserMessage_BothDirections(t *testing.T) {
+	bus := &capturingPubSub{}
+	p := NewChatPublisher(bus)
+	p.PublishUserMessage(context.Background(), "alice", "bob", "message", map[string]any{"id": "m1"})
+
+	require.Len(t, bus.calls, 2)
+	topics := map[string]bool{}
+	for _, c := range bus.calls {
+		topics[c.topic] = true
+	}
+	assert.True(t, topics["chatUserStream:alice-bob"])
+	assert.True(t, topics["chatUserStream:bob-alice"])
+
+	// verify envelope format
+	raw, ok := bus.calls[0].payload.(json.RawMessage)
+	require.True(t, ok)
+	var env struct {
+		Type string `json:"type"`
+	}
+	require.NoError(t, json.Unmarshal(raw, &env))
+	assert.Equal(t, "message", env.Type)
+}
+
+func TestChatPublisher_PublishUserMessage_NilPub(t *testing.T) {
+	p := NewChatPublisher(nil)
+	p.PublishUserMessage(context.Background(), "a", "b", "x", nil) // no panic
+}
+
+func TestChatPublisher_PublishUserMessage_EmptyIDs(t *testing.T) {
+	bus := &capturingPubSub{}
+	p := NewChatPublisher(bus)
+	p.PublishUserMessage(context.Background(), "", "b", "x", nil)
+	p.PublishUserMessage(context.Background(), "a", "", "x", nil)
+	assert.Empty(t, bus.calls)
+}
+
+func TestChatPublisher_PublishUserMessage_Error(t *testing.T) {
+	bus := &capturingPubSub{err: errors.New("pub boom")}
+	p := NewChatPublisher(bus)
+	// should silently log and continue; no panic
+	p.PublishUserMessage(context.Background(), "a", "b", "msg", nil)
+}
+
+func TestChatPublisher_PublishRoomMessage(t *testing.T) {
+	bus := &capturingPubSub{}
+	p := NewChatPublisher(bus)
+	p.PublishRoomMessage(context.Background(), "r1", "message", map[string]any{"id": "m1"})
+	require.Len(t, bus.calls, 1)
+	assert.Equal(t, "chatRoomStream:r1", bus.calls[0].topic)
+}
+
+func TestChatPublisher_PublishRoomMessage_NilPub(t *testing.T) {
+	p := NewChatPublisher(nil)
+	p.PublishRoomMessage(context.Background(), "r1", "x", nil)
+}
+
+func TestChatPublisher_PublishRoomMessage_EmptyRoomID(t *testing.T) {
+	bus := &capturingPubSub{}
+	p := NewChatPublisher(bus)
+	p.PublishRoomMessage(context.Background(), "", "x", nil)
+	assert.Empty(t, bus.calls)
+}
+
+func TestChatPublisher_PublishRoomMessage_Error(t *testing.T) {
+	bus := &capturingPubSub{err: errors.New("pub boom")}
+	p := NewChatPublisher(bus)
+	p.PublishRoomMessage(context.Background(), "r1", "msg", nil)
+}


### PR DESCRIPTION
## Summary

Misskey 互換のチャット WebSocket リアルタイム配信を実装しました。\`core/chat\` service 層を新規追加し、既存の REST エンドポイント (create/update/delete/read) を service 経由にして、メッセージ送信時に Redis pub/sub + WebSocket で配信する構造にしています。

これまで \`/api/chat/messages/*\` は repository を直接叩いていたため、接続中のクライアントに何も通知されない状態でしたが、本 PR で相手の画面に即座に反映されるようになります。

## 主な変更点

### 新規パッケージ
- **\`internal/core/chat/\`** — chat service 層
  - \`service.go\`: \`Service\` struct、\`StreamingPublisher\` interface、\`CreateMessageToUser\` / \`CreateMessageToRoom\` / \`UpdateMessage\` / \`DeleteMessage\` / \`MarkReadByMessageID\` / \`IsRoomMember\` と packMessage ヘルパー
  - 各種エラー定数 (\`ErrNotFound\` / \`ErrForbidden\` / \`ErrInvalidTarget\`)
  - イベント名定数 (\`EventMessage\` / \`EventDeleted\` / \`EventEdited\` / \`EventRead\`)

### 新規ファイル
- **\`internal/stream/chat_publisher.go\`** — \`ChatPublisher\` が \`PubSubPublisher\` を使って \`{type, body}\` envelope を Redis に publish
- **\`internal/stream/channels/chat_room.go\`** — \`ChatRoomChannel\` と \`ChatRoomFactory\`。Init 時にメンバーシップチェック
- **\`internal/stream/channels/chat_user.go\`** — \`ChatUserChannel\` と \`ChatUserFactory\`。自分の conversation view を subscribe

### 既存コードへの変更
- **\`internal/repository/chat.go\`** — \`UpdateMessage(msg)\` を interface に追加
- **\`internal/api/chat/handler.go\`**
  - \`Handler\` struct に \`svc *corechat.Service\` 追加
  - \`SetService\` setter、\`mapChatErr\` ヘルパー
  - \`MessagesCreate\` / \`MessagesUpdate\` / \`MessagesDelete\` / \`MessagesRead\` を service 経由に書き換え
  - 未 wire 時のために legacy fallback パスを維持 (既存テスト互換)
- **\`internal/server/router.go\`**
  - \`chatRepo\` を repository block に移動
  - \`chatPublisher\` / \`chatService\` を構築してハンドラに注入
  - \`streamRegistry\` に \`chatRoom\` / \`chatUser\` を登録

## 互換性 (Misskey 本家準拠)

### トピック命名 (完全一致)
| コンテキスト | トピック |
|------------|---------|
| Room | \`chatRoomStream:{roomId}\` |
| DM (sender view) | \`chatUserStream:{fromUserId}-{toUserId}\` |
| DM (recipient view) | \`chatUserStream:{toUserId}-{fromUserId}\` |

DM は Misskey 本家の \`ChatService.createMessageToUser\` が \`publishChatUserStream\` を 2 回呼ぶのと同じく、\`ChatPublisher.PublishUserMessage\` で両方向トピックに publish します。各ユーザーは \`chatUserStream:{myId}-{otherId}\` (自分のビュー) を subscribe するので、自分が送ったメッセージも自分の他タブで見えます。

### イベント種別
| type | 発火タイミング | body |
|------|-------------|------|
| \`message\` | Create 成功時 | packed ChatMessage |
| \`deleted\` | Delete 成功時 | \`{id}\` |
| \`edited\` | Update 成功時 | packed ChatMessage |
| \`read\` | MarkRead 成功時 | \`{id, userId}\` |

- \`message\` / \`deleted\` は本家と同一
- \`edited\` は Handler の既存 \`MessagesUpdate\` を実装する流れで追加。本家 ChatService は edit 機能自体を持っていない
- \`read\` は **軽微な拡張**: Misskey 本家は \`readUserChatMessage\` / \`readRoomChatMessage\` で Redis cache を clear するだけで配信はしていないが、マルチ端末/タブ同期のため event を 1 つ発行している

### 権限判定
- \`ChatRoomChannel.Init\`: \`IsRoomMember(userId, roomId)\` チェック。メンバーでも owner でもなければ silent に沈黙 (= 本家 ChatRoomChannel と同じ挙動)
- \`ChatUserChannel.Init\`: \`otherId\` と自分の id が同じ場合は拒否 (self-DM 防止)
- \`CreateMessageToRoom\`: 非メンバー送信は \`ErrForbidden\`
- \`IsRoomMember\`: owner は implicit member (明示 row 無くても member 扱い、Misskey 同様)

## 制約事項 (スコープ外)

- **タイピングインジケーター** — issue で optional と明記されていたため本 PR では実装しない
- **メッセージ反応 (react/unreact)** — \`chat/messages/reactions/create|delete\` エンドポイントは既存の stub のまま
- **ブロック・approval フロー** — 本家 ChatService にはあるが本 PR では未対応
- **Multi-node PubSub** は既存 \`stream/event\` 層に乗るだけで追加作業不要 (既存の reversiGame チャネルと同じパターン)

## テスト

- \`internal/core/chat\` **94.8%**: service 全メソッド網羅 (正常系 / Err パス / empty param / repo error)、membership の owner implicit / explicit / non-member、nil publisher fallback、reads array 追加の round-trip
- \`internal/stream\` **98.0%**: chat publisher の両方向 publish 検証 / nil-pub / empty ID / publish error
- \`internal/stream/channels\` **100%**: chat room と chat user 両方のチャネルで Init 全分岐 (member / owner / non-member / unauthenticated / missing param / bad JSON)、OnRedisEvent (正常 / invalid / no-type)、OnClientMessage (read / unknown type / empty id / bad JSON / service error / nil service / unauthenticated)、Dispose (with / without init)
- \`internal/api/chat\` **98.7%**: service 注入経路の正常系 / not found / forbidden (DM + Room + Update + Delete + Read) を追加

ローカル実行で \`make fmt && make lint\` pass、全 77 パッケージが CI 閾値 (90% / admin 60%) をクリア。

### 再現コマンド
\`\`\`bash
PKGS=\$(go list -f '{{if (or .TestGoFiles .XTestGoFiles)}}{{.ImportPath}}{{end}}' ./... | tr '\n' ' ')
go test \$PKGS -race -count=1 -timeout 10m -coverprofile=coverage.out -covermode=atomic

# Phase 9.8 の主要パッケージのみ
go test ./internal/core/chat/... \\
        ./internal/stream/... \\
        ./internal/stream/channels/... \\
        ./internal/api/chat/...
\`\`\`

## Closes

Closes #6