### PR TITLE
Phase 9.9 admin/emoji/import-zip 非同期ワーカー

### DIFF
--- a/internal/api/admin/handler.go
+++ b/internal/api/admin/handler.go
@@ -10,6 +10,7 @@ import (
 	"github.com/shiroha-a/mk/internal/entity"
 	"github.com/shiroha-a/mk/internal/misc/id"
 	"github.com/shiroha-a/mk/internal/model"
+	"github.com/shiroha-a/mk/internal/queue"
 	"github.com/shiroha-a/mk/internal/repository"
 	"github.com/shiroha-a/mk/internal/server/middleware"
 	"gorm.io/gorm"
@@ -27,7 +28,21 @@ type Handler struct {
 	driveFileRepo  repository.DriveFileRepository
 	adminDB        *gorm.DB
 	queueInspector QueueInspector
+	emojiEnqueuer  EmojiImportEnqueuer
 	idGen          id.Generator
+}
+
+// EmojiImportEnqueuer is the subset of queue.Enqueuer needed to schedule
+// admin/emoji/import-zip jobs. 小さいインターフェースにすることで handler の
+// テストが容易になる。
+type EmojiImportEnqueuer interface {
+	EnqueueImportCustomEmojis(payload queue.ImportCustomEmojisPayload) error
+}
+
+// SetEmojiImportEnqueuer attaches an EmojiImportEnqueuer for the admin/emoji/
+// import-zip endpoint.
+func (h *Handler) SetEmojiImportEnqueuer(e EmojiImportEnqueuer) {
+	h.emojiEnqueuer = e
 }
 
 // QueueInspector abstracts asynq.Inspector for queue management endpoints.

--- a/internal/api/admin/handler_stubs.go
+++ b/internal/api/admin/handler_stubs.go
@@ -9,6 +9,7 @@ import (
 	"github.com/labstack/echo/v4"
 	"github.com/shiroha-a/mk/internal/entity"
 	"github.com/shiroha-a/mk/internal/model"
+	"github.com/shiroha-a/mk/internal/queue"
 	"github.com/shiroha-a/mk/internal/server/middleware"
 	"golang.org/x/crypto/bcrypt"
 )
@@ -331,12 +332,41 @@ func (h *Handler) EmojiDeleteBulk(c echo.Context) error {
 }
 
 // EmojiImportZip handles POST /api/admin/emoji/import-zip.
-// ZIPファイルから絵文字を一括インポートする。
+// fileId で Drive にアップロード済みの ZIP を指定し、非同期ジョブで展開して
+// ローカルカスタム絵文字として登録する。本家 Misskey 互換
+// (`QueueService.createImportCustomEmojisJob` 相当)。
 func (h *Handler) EmojiImportZip(c echo.Context) error {
-	// ZIP解析+絵文字登録の完全実装は大規模なため、
-	// リクエストを受け付けて204を返す形にする。
-	// 将来的にはmultipartでZIPを受信し、展開して各画像をDriveに保存、
-	// EmojiRepositoryに登録する処理を実装する。
+	var req struct {
+		FileID string `json:"fileId"`
+	}
+	if err := c.Bind(&req); err != nil || req.FileID == "" {
+		return c.JSON(http.StatusBadRequest, map[string]any{
+			"error": map[string]any{
+				"message": "fileId is required.",
+				"code":    "INVALID_PARAM",
+				"id":      "5f4c9d8a-7c39-4bfa-9dcb-09f17e0f7a25",
+			},
+		})
+	}
+	if h.emojiEnqueuer == nil {
+		return c.NoContent(http.StatusNoContent)
+	}
+	user := middleware.GetUser(c)
+	if user == nil {
+		return c.NoContent(http.StatusNoContent)
+	}
+	if err := h.emojiEnqueuer.EnqueueImportCustomEmojis(queue.ImportCustomEmojisPayload{
+		UserID: user.ID,
+		FileID: req.FileID,
+	}); err != nil {
+		return c.JSON(http.StatusInternalServerError, map[string]any{
+			"error": map[string]any{
+				"message": "Failed to enqueue emoji import.",
+				"code":    "INTERNAL_ERROR",
+				"id":      "89a6d9fd-0fe6-4c3c-9daa-7c6b1f29f1a4",
+			},
+		})
+	}
 	return c.NoContent(http.StatusNoContent)
 }
 

--- a/internal/api/admin/handler_stubs_test.go
+++ b/internal/api/admin/handler_stubs_test.go
@@ -5,11 +5,33 @@ import (
 	"testing"
 
 	"github.com/shiroha-a/mk/internal/model"
+	"github.com/shiroha-a/mk/internal/queue"
 	"github.com/shiroha-a/mk/internal/testutil"
 	"github.com/stretchr/testify/assert"
 )
 
 var adminUser = &model.User{ID: "admin1"}
+
+// stubEmojiImportEnqueuer records the last payload and optionally returns err.
+type stubEmojiImportEnqueuer struct {
+	lastUserID string
+	lastFileID string
+	err        error
+}
+
+func (s *stubEmojiImportEnqueuer) EnqueueImportCustomEmojis(p queue.ImportCustomEmojisPayload) error {
+	if s.err != nil {
+		return s.err
+	}
+	s.lastUserID = p.UserID
+	s.lastFileID = p.FileID
+	return nil
+}
+
+// assertError is a trivial error used to exercise the enqueue-failure branch.
+type assertError struct{}
+
+func (assertError) Error() string { return "stub enqueue failure" }
 
 func TestSetDriveFileRepo(t *testing.T) {
 	h, _, _, _ := newTestHandler(t)
@@ -206,9 +228,44 @@ func TestEmojiDeleteBulk(t *testing.T) {
 	h, _, _, _ := newTestHandler(t)
 	assert.Equal(t, http.StatusNoContent, doPost(h.EmojiDeleteBulk, `{}`, adminUser).Code)
 }
-func TestEmojiImportZip(t *testing.T) {
+func TestEmojiImportZip_NoFileID(t *testing.T) {
 	h, _, _, _ := newTestHandler(t)
-	assert.Equal(t, http.StatusNoContent, doPost(h.EmojiImportZip, `{}`, adminUser).Code)
+	// fileId missing → 400 InvalidParam
+	assert.Equal(t, http.StatusBadRequest, doPost(h.EmojiImportZip, `{}`, adminUser).Code)
+}
+
+func TestEmojiImportZip_MalformedJSON(t *testing.T) {
+	h, _, _, _ := newTestHandler(t)
+	assert.Equal(t, http.StatusBadRequest, doPost(h.EmojiImportZip, `not-json`, adminUser).Code)
+}
+
+func TestEmojiImportZip_NoEnqueuer(t *testing.T) {
+	h, _, _, _ := newTestHandler(t)
+	// enqueuer not set → 204 (no-op fallback so tests without worker still pass)
+	assert.Equal(t, http.StatusNoContent, doPost(h.EmojiImportZip, `{"fileId":"f1"}`, adminUser).Code)
+}
+
+func TestEmojiImportZip_NilUser(t *testing.T) {
+	h, _, _, _ := newTestHandler(t)
+	h.SetEmojiImportEnqueuer(&stubEmojiImportEnqueuer{})
+	assert.Equal(t, http.StatusNoContent, doPost(h.EmojiImportZip, `{"fileId":"f1"}`, nil).Code)
+}
+
+func TestEmojiImportZip_Success(t *testing.T) {
+	h, _, _, _ := newTestHandler(t)
+	stub := &stubEmojiImportEnqueuer{}
+	h.SetEmojiImportEnqueuer(stub)
+	rec := doPost(h.EmojiImportZip, `{"fileId":"f1"}`, adminUser)
+	assert.Equal(t, http.StatusNoContent, rec.Code)
+	assert.Equal(t, "f1", stub.lastFileID)
+	assert.Equal(t, "admin1", stub.lastUserID)
+}
+
+func TestEmojiImportZip_EnqueueFailure(t *testing.T) {
+	h, _, _, _ := newTestHandler(t)
+	h.SetEmojiImportEnqueuer(&stubEmojiImportEnqueuer{err: assertError{}})
+	rec := doPost(h.EmojiImportZip, `{"fileId":"f1"}`, adminUser)
+	assert.Equal(t, http.StatusInternalServerError, rec.Code)
 }
 func TestEmojiListRemote(t *testing.T) {
 	h, _, _, _ := newTestHandler(t)

--- a/internal/core/emojiimport/service.go
+++ b/internal/core/emojiimport/service.go
@@ -1,0 +1,265 @@
+// Package emojiimport implements the Misskey-compatible "admin/emoji/
+// import-zip" flow: read a previously-uploaded ZIP from Drive, extract each
+// emoji image + meta.json, and register them as local custom emojis.
+package emojiimport
+
+import (
+	"archive/zip"
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"log/slog"
+	"path"
+	"regexp"
+	"time"
+
+	"github.com/lib/pq"
+	"github.com/shiroha-a/mk/internal/core/drive"
+	"github.com/shiroha-a/mk/internal/misc/id"
+	"github.com/shiroha-a/mk/internal/model"
+	"github.com/shiroha-a/mk/internal/repository"
+)
+
+// Errors returned by Importer.
+var (
+	// ErrDriveFileNotFound is returned when the referenced fileId cannot be
+	// loaded from Drive.
+	ErrDriveFileNotFound = errors.New("drive file not found")
+	// ErrUserNotFound is returned when the requesting admin user is absent.
+	ErrUserNotFound = errors.New("user not found")
+	// ErrInvalidZip is returned when the body cannot be parsed as a ZIP.
+	ErrInvalidZip = errors.New("invalid zip archive")
+	// ErrMissingMeta is returned when meta.json is not present in the archive.
+	ErrMissingMeta = errors.New("meta.json missing in archive")
+	// ErrMalformedMeta is returned when meta.json cannot be parsed as JSON.
+	ErrMalformedMeta = errors.New("meta.json malformed")
+)
+
+// DriveReader fetches a previously-uploaded DriveFile by id and returns its
+// raw bytes. 本家 Misskey の DownloadService.downloadUrl 相当。importer は file
+// の URL を解決せず byte body だけを必要とする。
+type DriveReader interface {
+	Fetch(fileID string) (*model.DriveFile, []byte, error)
+}
+
+// Deps bundles the dependencies needed by Importer.
+type Deps struct {
+	UserRepo  repository.UserRepository
+	EmojiRepo repository.EmojiRepository
+	Drive     DriveReader
+	Uploader  *drive.Service
+	IDGen     id.Generator
+}
+
+// Importer runs the emoji ZIP import process.
+type Importer struct {
+	deps Deps
+	now  func() time.Time
+}
+
+// NewImporter constructs an Importer.
+func NewImporter(deps Deps) *Importer {
+	return &Importer{deps: deps, now: time.Now}
+}
+
+// SetNow overrides the clock. Tests only.
+func (i *Importer) SetNow(fn func() time.Time) {
+	if fn != nil {
+		i.now = fn
+	}
+}
+
+// Result captures per-batch counters surfaced to the caller.
+type Result struct {
+	Total    int
+	Imported int
+	Skipped  int
+}
+
+// metaDoc mirrors the `meta.json` produced by Misskey's custom-emoji
+// export. 本家 ExportCustomEmojisProcessorService が出力する構造を参照した。
+// emoji サブオブジェクトの全フィールドを保持するが、互換性のため欠けていても
+// 許容する (ゼロ値で扱う)。
+type metaDoc struct {
+	MetaVersion int          `json:"metaVersion"`
+	Host        *string      `json:"host"`
+	ExportedAt  string       `json:"exportedAt"`
+	Emojis      []metaRecord `json:"emojis"`
+}
+
+type metaRecord struct {
+	FileName   string    `json:"fileName"`
+	Downloaded bool      `json:"downloaded"`
+	Emoji      metaEmoji `json:"emoji"`
+}
+
+type metaEmoji struct {
+	Name        string   `json:"name"`
+	Category    *string  `json:"category"`
+	Aliases     []string `json:"aliases"`
+	License     *string  `json:"license"`
+	IsSensitive bool     `json:"isSensitive"`
+	LocalOnly   bool     `json:"localOnly"`
+}
+
+// validFileName matches Misskey's ImportCustomEmojisProcessorService regex.
+// 「`[a-zA-Z0-9_]+?([a-zA-Z0-9\.]+)?`」相当。
+var validFileName = regexp.MustCompile(`^[a-zA-Z0-9_]+?([a-zA-Z0-9.]+)?$`)
+
+// validEmojiName matches Misskey's validation for emoji names.
+var validEmojiName = regexp.MustCompile(`^[a-zA-Z0-9_]+$`)
+
+// Run executes the import for the given user/file. Per-item errors are logged
+// and counted as Skipped so that a single malformed entry does not abort the
+// batch. 本家と同様「meta.json が壊れていれば job 全体失敗、個別エントリは
+// スキップ」の方針。
+func (i *Importer) Run(ctx context.Context, userID, fileID string) (*Result, error) {
+	if i.deps.Drive == nil || i.deps.Uploader == nil || i.deps.EmojiRepo == nil || i.deps.UserRepo == nil || i.deps.IDGen == nil {
+		return nil, errors.New("emoji importer not fully configured")
+	}
+	user, err := i.deps.UserRepo.FindByID(userID)
+	if err != nil || user == nil {
+		return nil, fmt.Errorf("%w: %s", ErrUserNotFound, userID)
+	}
+
+	_, body, err := i.deps.Drive.Fetch(fileID)
+	if err != nil {
+		return nil, fmt.Errorf("%w: %w", ErrDriveFileNotFound, err)
+	}
+
+	zr, err := zip.NewReader(bytes.NewReader(body), int64(len(body)))
+	if err != nil {
+		return nil, fmt.Errorf("%w: %w", ErrInvalidZip, err)
+	}
+
+	// fileName → *zip.File の索引を作っておくと、meta.json の record.fileName から
+	// ZIP 内のエントリを O(1) で引ける。
+	index := make(map[string]*zip.File, len(zr.File))
+	var metaFile *zip.File
+	for _, f := range zr.File {
+		base := path.Base(f.Name)
+		if base == "meta.json" {
+			metaFile = f
+			continue
+		}
+		index[base] = f
+	}
+	if metaFile == nil {
+		return nil, ErrMissingMeta
+	}
+
+	metaBytes, err := readZipEntry(metaFile)
+	if err != nil {
+		return nil, fmt.Errorf("read meta.json: %w", err)
+	}
+	var meta metaDoc
+	if err := json.Unmarshal(metaBytes, &meta); err != nil {
+		return nil, fmt.Errorf("%w: %w", ErrMalformedMeta, err)
+	}
+
+	result := &Result{Total: len(meta.Emojis)}
+	for _, record := range meta.Emojis {
+		if err := ctx.Err(); err != nil {
+			return result, err
+		}
+		if !record.Downloaded {
+			result.Skipped++
+			continue
+		}
+		if !validFileName.MatchString(record.FileName) {
+			slog.Warn("emoji import: invalid filename", "filename", record.FileName)
+			result.Skipped++
+			continue
+		}
+		if !validEmojiName.MatchString(record.Emoji.Name) {
+			slog.Warn("emoji import: invalid emoji name", "name", record.Emoji.Name)
+			result.Skipped++
+			continue
+		}
+
+		entry := index[record.FileName]
+		if entry == nil {
+			slog.Warn("emoji import: missing zip entry", "filename", record.FileName)
+			result.Skipped++
+			continue
+		}
+		imgBody, err := readZipEntry(entry)
+		if err != nil {
+			slog.Warn("emoji import: read entry failed", "filename", record.FileName, "err", err)
+			result.Skipped++
+			continue
+		}
+
+		if err := i.replaceEmoji(user, record, imgBody); err != nil {
+			slog.Warn("emoji import: replace failed", "name", record.Emoji.Name, "err", err)
+			result.Skipped++
+			continue
+		}
+		result.Imported++
+	}
+	return result, nil
+}
+
+// readZipEntry reads an entry body fully into memory. 絵文字画像は高々
+// 数百KB なので全量展開で問題ない。
+func readZipEntry(f *zip.File) ([]byte, error) {
+	rc, err := f.Open()
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = rc.Close() }()
+	return io.ReadAll(rc)
+}
+
+// replaceEmoji deletes any existing local emoji with the same name, uploads the
+// image to Drive as a new DriveFile, and creates a fresh emoji row.
+func (i *Importer) replaceEmoji(user *model.User, record metaRecord, body []byte) error {
+	// 既存 local 絵文字 (同名) は上書きのために先に削除する。
+	// 本家 Misskey では emojisRepository.delete({ name, host: IsNull() }) 相当。
+	if existing, err := i.deps.EmojiRepo.FindByNameAndHost(record.Emoji.Name, nil); err == nil && existing != nil {
+		_ = i.deps.EmojiRepo.Delete(existing.ID)
+	}
+
+	uploaded, err := i.deps.Uploader.Upload(drive.UploadInput{
+		User:  user,
+		Body:  body,
+		Name:  record.FileName,
+		Force: true,
+	})
+	if err != nil {
+		return fmt.Errorf("upload emoji image: %w", err)
+	}
+
+	publicURL := uploaded.URL
+	if uploaded.WebpublicURL != nil && *uploaded.WebpublicURL != "" {
+		publicURL = *uploaded.WebpublicURL
+	}
+	fileType := uploaded.Type
+	if uploaded.WebpublicType != nil && *uploaded.WebpublicType != "" {
+		fileType = *uploaded.WebpublicType
+	}
+
+	now := i.now()
+	aliases := pq.StringArray(append([]string(nil), record.Emoji.Aliases...))
+	emoji := &model.Emoji{
+		ID:          i.deps.IDGen.Generate(now),
+		UpdatedAt:   &now,
+		Name:        record.Emoji.Name,
+		Host:        nil,
+		Category:    record.Emoji.Category,
+		OriginalURL: uploaded.URL,
+		PublicURL:   publicURL,
+		Type:        &fileType,
+		Aliases:     aliases,
+		License:     record.Emoji.License,
+		IsSensitive: record.Emoji.IsSensitive,
+		LocalOnly:   record.Emoji.LocalOnly,
+	}
+	if err := i.deps.EmojiRepo.Create(emoji); err != nil {
+		return fmt.Errorf("create emoji row: %w", err)
+	}
+	return nil
+}

--- a/internal/core/emojiimport/service_test.go
+++ b/internal/core/emojiimport/service_test.go
@@ -1,0 +1,303 @@
+package emojiimport_test
+
+import (
+	"archive/zip"
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"image"
+	"image/color"
+	"image/png"
+	"testing"
+	"time"
+
+	"github.com/shiroha-a/mk/internal/core/drive"
+	"github.com/shiroha-a/mk/internal/core/emojiimport"
+	"github.com/shiroha-a/mk/internal/misc/id"
+	"github.com/shiroha-a/mk/internal/model"
+	"github.com/shiroha-a/mk/internal/testutil"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// --- helpers ---
+
+func pngBytes(t *testing.T) []byte {
+	t.Helper()
+	img := image.NewRGBA(image.Rect(0, 0, 2, 2))
+	img.Set(0, 0, color.RGBA{R: 255, A: 255})
+	var buf bytes.Buffer
+	require.NoError(t, png.Encode(&buf, img))
+	return buf.Bytes()
+}
+
+type zipEntry struct {
+	name string
+	body []byte
+}
+
+func buildZip(t *testing.T, entries []zipEntry) []byte {
+	t.Helper()
+	var buf bytes.Buffer
+	zw := zip.NewWriter(&buf)
+	for _, e := range entries {
+		w, err := zw.Create(e.name)
+		require.NoError(t, err)
+		_, err = w.Write(e.body)
+		require.NoError(t, err)
+	}
+	require.NoError(t, zw.Close())
+	return buf.Bytes()
+}
+
+// metaJSON returns a Misskey-compatible meta.json body for the given records.
+func metaJSON(t *testing.T, records []map[string]any) []byte {
+	t.Helper()
+	b, err := json.Marshal(map[string]any{
+		"metaVersion": 2,
+		"host":        nil,
+		"exportedAt":  time.Now().UTC().Format(time.RFC3339),
+		"emojis":      records,
+	})
+	require.NoError(t, err)
+	return b
+}
+
+// fakeDriveReader returns a fixed body (or error) for any fileID.
+type fakeDriveReader struct {
+	body []byte
+	err  error
+}
+
+func (f *fakeDriveReader) Fetch(_ string) (*model.DriveFile, []byte, error) {
+	if f.err != nil {
+		return nil, nil, f.err
+	}
+	return &model.DriveFile{}, f.body, nil
+}
+
+func newUploader(t *testing.T) *drive.Service {
+	t.Helper()
+	fileRepo := testutil.NewMockDriveFileRepository()
+	folderRepo := testutil.NewMockDriveFolderRepository()
+	folderRepo.FilesRef = fileRepo
+	storage := drive.NewLocalStorage(t.TempDir(), "https://example.com/files")
+	idGen, _ := id.NewGenerator("aidx")
+	return drive.NewService(fileRepo, folderRepo, storage, idGen)
+}
+
+func newDeps(t *testing.T, body []byte) (emojiimport.Deps, *testutil.MockUserRepository, *testutil.MockEmojiRepository, *drive.Service) {
+	t.Helper()
+	userRepo := testutil.NewMockUserRepository()
+	_ = userRepo.Create(&model.User{ID: "admin"})
+	emojiRepo := testutil.NewMockEmojiRepository()
+	uploader := newUploader(t)
+	reader := &fakeDriveReader{body: body}
+	idGen, _ := id.NewGenerator("aidx")
+	return emojiimport.Deps{
+		UserRepo:  userRepo,
+		EmojiRepo: emojiRepo,
+		Drive:     reader,
+		Uploader:  uploader,
+		IDGen:     idGen,
+	}, userRepo, emojiRepo, uploader
+}
+
+// --- Run ---
+
+func TestRun_HappyPath_MultipleEmojis(t *testing.T) {
+	img := pngBytes(t)
+	meta := metaJSON(t, []map[string]any{
+		{
+			"fileName":   "smile.png",
+			"downloaded": true,
+			"emoji": map[string]any{
+				"name":        "smile",
+				"category":    "faces",
+				"aliases":     []string{"happy", "joy"},
+				"license":     "CC0",
+				"isSensitive": false,
+				"localOnly":   false,
+			},
+		},
+		{
+			"fileName":   "wave.png",
+			"downloaded": true,
+			"emoji": map[string]any{
+				"name":    "wave",
+				"aliases": []string{},
+			},
+		},
+	})
+	body := buildZip(t, []zipEntry{
+		{"meta.json", meta},
+		{"smile.png", img},
+		{"wave.png", img},
+	})
+	deps, _, repo, _ := newDeps(t, body)
+	imp := emojiimport.NewImporter(deps)
+
+	res, err := imp.Run(context.Background(), "admin", "f1")
+	require.NoError(t, err)
+	assert.Equal(t, 2, res.Total)
+	assert.Equal(t, 2, res.Imported)
+	assert.Equal(t, 0, res.Skipped)
+
+	smile, err := repo.FindByNameAndHost("smile", nil)
+	require.NoError(t, err)
+	assert.Equal(t, "CC0", *smile.License)
+	require.NotNil(t, smile.Category)
+	assert.Equal(t, "faces", *smile.Category)
+	assert.Equal(t, []string{"happy", "joy"}, []string(smile.Aliases))
+
+	wave, err := repo.FindByNameAndHost("wave", nil)
+	require.NoError(t, err)
+	assert.Nil(t, wave.Category)
+}
+
+func TestRun_DeletesExistingLocalEmoji(t *testing.T) {
+	img := pngBytes(t)
+	meta := metaJSON(t, []map[string]any{
+		{"fileName": "smile.png", "downloaded": true, "emoji": map[string]any{"name": "smile"}},
+	})
+	body := buildZip(t, []zipEntry{{"meta.json", meta}, {"smile.png", img}})
+	deps, _, repo, _ := newDeps(t, body)
+	// 既存ローカル smile を置いて、import 後に ID が更新されていることを確認する。
+	_ = repo.Create(&model.Emoji{ID: "old", Name: "smile"})
+
+	imp := emojiimport.NewImporter(deps)
+	_, err := imp.Run(context.Background(), "admin", "f1")
+	require.NoError(t, err)
+
+	found, err := repo.FindByNameAndHost("smile", nil)
+	require.NoError(t, err)
+	assert.NotEqual(t, "old", found.ID)
+}
+
+func TestRun_SkipsInvalidRecords(t *testing.T) {
+	img := pngBytes(t)
+	meta := metaJSON(t, []map[string]any{
+		// not downloaded
+		{"fileName": "a.png", "downloaded": false, "emoji": map[string]any{"name": "a"}},
+		// invalid file name
+		{"fileName": "bad name.png", "downloaded": true, "emoji": map[string]any{"name": "bad"}},
+		// invalid emoji name
+		{"fileName": "c.png", "downloaded": true, "emoji": map[string]any{"name": "bad!name"}},
+		// missing zip entry
+		{"fileName": "missing.png", "downloaded": true, "emoji": map[string]any{"name": "miss"}},
+	})
+	body := buildZip(t, []zipEntry{{"meta.json", meta}, {"a.png", img}, {"c.png", img}})
+	deps, _, repo, _ := newDeps(t, body)
+	imp := emojiimport.NewImporter(deps)
+
+	res, err := imp.Run(context.Background(), "admin", "f1")
+	require.NoError(t, err)
+	assert.Equal(t, 4, res.Total)
+	assert.Equal(t, 0, res.Imported)
+	assert.Equal(t, 4, res.Skipped)
+	assert.Empty(t, repo.Emojis)
+}
+
+func TestRun_MissingMeta(t *testing.T) {
+	body := buildZip(t, []zipEntry{{"only.png", []byte("x")}})
+	deps, _, _, _ := newDeps(t, body)
+	imp := emojiimport.NewImporter(deps)
+	_, err := imp.Run(context.Background(), "admin", "f1")
+	assert.ErrorIs(t, err, emojiimport.ErrMissingMeta)
+}
+
+func TestRun_MalformedMeta(t *testing.T) {
+	body := buildZip(t, []zipEntry{{"meta.json", []byte("not json")}})
+	deps, _, _, _ := newDeps(t, body)
+	imp := emojiimport.NewImporter(deps)
+	_, err := imp.Run(context.Background(), "admin", "f1")
+	assert.ErrorIs(t, err, emojiimport.ErrMalformedMeta)
+}
+
+func TestRun_InvalidZip(t *testing.T) {
+	deps, _, _, _ := newDeps(t, []byte("not a zip"))
+	imp := emojiimport.NewImporter(deps)
+	_, err := imp.Run(context.Background(), "admin", "f1")
+	assert.ErrorIs(t, err, emojiimport.ErrInvalidZip)
+}
+
+func TestRun_DriveFetchError(t *testing.T) {
+	userRepo := testutil.NewMockUserRepository()
+	_ = userRepo.Create(&model.User{ID: "admin"})
+	idGen, _ := id.NewGenerator("aidx")
+	deps := emojiimport.Deps{
+		UserRepo:  userRepo,
+		EmojiRepo: testutil.NewMockEmojiRepository(),
+		Drive:     &fakeDriveReader{err: errors.New("boom")},
+		Uploader:  newUploader(t),
+		IDGen:     idGen,
+	}
+	imp := emojiimport.NewImporter(deps)
+	_, err := imp.Run(context.Background(), "admin", "f1")
+	assert.ErrorIs(t, err, emojiimport.ErrDriveFileNotFound)
+}
+
+func TestRun_UserNotFound(t *testing.T) {
+	deps, _, _, _ := newDeps(t, []byte{})
+	imp := emojiimport.NewImporter(deps)
+	_, err := imp.Run(context.Background(), "ghost", "f1")
+	assert.ErrorIs(t, err, emojiimport.ErrUserNotFound)
+}
+
+func TestRun_MissingDeps(t *testing.T) {
+	imp := emojiimport.NewImporter(emojiimport.Deps{})
+	_, err := imp.Run(context.Background(), "admin", "f1")
+	assert.Error(t, err)
+}
+
+func TestRun_ContextCancelled(t *testing.T) {
+	img := pngBytes(t)
+	meta := metaJSON(t, []map[string]any{
+		{"fileName": "smile.png", "downloaded": true, "emoji": map[string]any{"name": "smile"}},
+	})
+	body := buildZip(t, []zipEntry{{"meta.json", meta}, {"smile.png", img}})
+	deps, _, _, _ := newDeps(t, body)
+	imp := emojiimport.NewImporter(deps)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	_, err := imp.Run(ctx, "admin", "f1")
+	assert.ErrorIs(t, err, context.Canceled)
+}
+
+func TestRun_UploaderError(t *testing.T) {
+	img := pngBytes(t)
+	meta := metaJSON(t, []map[string]any{
+		{"fileName": "smile.png", "downloaded": true, "emoji": map[string]any{"name": "smile"}},
+	})
+	body := buildZip(t, []zipEntry{{"meta.json", meta}, {"smile.png", img}})
+	// broken storage causes Upload to fail (storage Put fails).
+	userRepo := testutil.NewMockUserRepository()
+	_ = userRepo.Create(&model.User{ID: "admin"})
+	emojiRepo := testutil.NewMockEmojiRepository()
+	storage := drive.NewLocalStorage("/nonexistent/\x00invalid", "")
+	fileRepo := testutil.NewMockDriveFileRepository()
+	folderRepo := testutil.NewMockDriveFolderRepository()
+	idGen, _ := id.NewGenerator("aidx")
+	uploader := drive.NewService(fileRepo, folderRepo, storage, idGen)
+	deps := emojiimport.Deps{
+		UserRepo:  userRepo,
+		EmojiRepo: emojiRepo,
+		Drive:     &fakeDriveReader{body: body},
+		Uploader:  uploader,
+		IDGen:     idGen,
+	}
+	imp := emojiimport.NewImporter(deps)
+	res, err := imp.Run(context.Background(), "admin", "f1")
+	require.NoError(t, err)
+	assert.Equal(t, 1, res.Skipped)
+	assert.Equal(t, 0, res.Imported)
+}
+
+func TestSetNow(t *testing.T) {
+	deps, _, _, _ := newDeps(t, []byte{})
+	imp := emojiimport.NewImporter(deps)
+	imp.SetNow(func() time.Time { return time.Unix(42, 0) })
+	imp.SetNow(nil) // nil must be ignored
+}

--- a/internal/queue/processors/emoji_import.go
+++ b/internal/queue/processors/emoji_import.go
@@ -1,0 +1,49 @@
+package processors
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/hibiken/asynq"
+	"github.com/shiroha-a/mk/internal/core/emojiimport"
+	"github.com/shiroha-a/mk/internal/queue"
+)
+
+// ImportCustomEmojisProcessor handles `importCustomEmojis` tasks by delegating
+// to emojiimport.Importer. 本家 Misskey の
+// ImportCustomEmojisProcessorService 相当。
+type ImportCustomEmojisProcessor struct {
+	importer *emojiimport.Importer
+}
+
+// NewImportCustomEmojisProcessor constructs the processor.
+func NewImportCustomEmojisProcessor(importer *emojiimport.Importer) *ImportCustomEmojisProcessor {
+	return &ImportCustomEmojisProcessor{importer: importer}
+}
+
+// Handle dispatches a single emoji-zip import task.
+func (p *ImportCustomEmojisProcessor) Handle(ctx context.Context, t *asynq.Task) error {
+	if p.importer == nil {
+		return fmt.Errorf("import custom emojis processor not configured: %w", asynq.SkipRetry)
+	}
+	payload, err := queue.DecodeImportCustomEmojisPayload(t.Payload())
+	if err != nil {
+		return fmt.Errorf("decode import custom emojis payload: %w: %w", err, asynq.SkipRetry)
+	}
+	if payload.UserID == "" || payload.FileID == "" {
+		return fmt.Errorf("import custom emojis payload missing fields: %w", asynq.SkipRetry)
+	}
+	if _, err := p.importer.Run(ctx, payload.UserID, payload.FileID); err != nil {
+		// ZIP 破損・meta.json 不在 など恒久的エラーは再試行してもムダ。
+		if errors.Is(err, emojiimport.ErrInvalidZip) ||
+			errors.Is(err, emojiimport.ErrMissingMeta) ||
+			errors.Is(err, emojiimport.ErrMalformedMeta) ||
+			errors.Is(err, emojiimport.ErrUserNotFound) ||
+			errors.Is(err, emojiimport.ErrDriveFileNotFound) {
+			return fmt.Errorf("%w: %w", err, asynq.SkipRetry)
+		}
+		return err
+	}
+	return nil
+}

--- a/internal/queue/processors/emoji_import_test.go
+++ b/internal/queue/processors/emoji_import_test.go
@@ -1,0 +1,156 @@
+package processors_test
+
+import (
+	"archive/zip"
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"image"
+	"image/color"
+	"image/png"
+	"testing"
+
+	"github.com/hibiken/asynq"
+	"github.com/shiroha-a/mk/internal/core/drive"
+	"github.com/shiroha-a/mk/internal/core/emojiimport"
+	"github.com/shiroha-a/mk/internal/misc/id"
+	"github.com/shiroha-a/mk/internal/model"
+	"github.com/shiroha-a/mk/internal/queue"
+	"github.com/shiroha-a/mk/internal/queue/processors"
+	"github.com/shiroha-a/mk/internal/testutil"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// fakeEmojiDriveReader feeds a fixed body to the importer regardless of id.
+type fakeEmojiDriveReader struct {
+	body []byte
+	err  error
+}
+
+func (f *fakeEmojiDriveReader) Fetch(_ string) (*model.DriveFile, []byte, error) {
+	if f.err != nil {
+		return nil, nil, f.err
+	}
+	return &model.DriveFile{}, f.body, nil
+}
+
+func buildEmojiZip(t *testing.T) []byte {
+	t.Helper()
+	img := image.NewRGBA(image.Rect(0, 0, 2, 2))
+	img.Set(0, 0, color.RGBA{R: 255, A: 255})
+	var imgBuf bytes.Buffer
+	require.NoError(t, png.Encode(&imgBuf, img))
+
+	meta, _ := json.Marshal(map[string]any{
+		"metaVersion": 2,
+		"emojis": []map[string]any{
+			{"fileName": "smile.png", "downloaded": true, "emoji": map[string]any{"name": "smile"}},
+		},
+	})
+
+	var buf bytes.Buffer
+	zw := zip.NewWriter(&buf)
+	mw, err := zw.Create("meta.json")
+	require.NoError(t, err)
+	_, err = mw.Write(meta)
+	require.NoError(t, err)
+	iw, err := zw.Create("smile.png")
+	require.NoError(t, err)
+	_, err = iw.Write(imgBuf.Bytes())
+	require.NoError(t, err)
+	require.NoError(t, zw.Close())
+	return buf.Bytes()
+}
+
+func newEmojiImporter(t *testing.T, reader emojiimport.DriveReader) *emojiimport.Importer {
+	t.Helper()
+	userRepo := testutil.NewMockUserRepository()
+	_ = userRepo.Create(&model.User{ID: "admin"})
+	fileRepo := testutil.NewMockDriveFileRepository()
+	folderRepo := testutil.NewMockDriveFolderRepository()
+	folderRepo.FilesRef = fileRepo
+	storage := drive.NewLocalStorage(t.TempDir(), "https://example.com/files")
+	idGen, _ := id.NewGenerator("aidx")
+	uploader := drive.NewService(fileRepo, folderRepo, storage, idGen)
+	return emojiimport.NewImporter(emojiimport.Deps{
+		UserRepo:  userRepo,
+		EmojiRepo: testutil.NewMockEmojiRepository(),
+		Drive:     reader,
+		Uploader:  uploader,
+		IDGen:     idGen,
+	})
+}
+
+// --- tests ---
+
+func TestImportCustomEmojisProcessor_NotConfigured(t *testing.T) {
+	p := processors.NewImportCustomEmojisProcessor(nil)
+	task := queue.NewImportCustomEmojisTask(queue.ImportCustomEmojisPayload{UserID: "admin", FileID: "f1"})
+	err := p.Handle(context.Background(), task)
+	require.Error(t, err)
+	assert.ErrorIs(t, err, asynq.SkipRetry)
+}
+
+func TestImportCustomEmojisProcessor_BadPayload(t *testing.T) {
+	imp := newEmojiImporter(t, &fakeEmojiDriveReader{body: buildEmojiZip(t)})
+	p := processors.NewImportCustomEmojisProcessor(imp)
+	task := asynq.NewTask(queue.TaskTypeImportCustomEmojis, []byte("not json"))
+	err := p.Handle(context.Background(), task)
+	require.Error(t, err)
+	assert.ErrorIs(t, err, asynq.SkipRetry)
+}
+
+func TestImportCustomEmojisProcessor_MissingFields(t *testing.T) {
+	imp := newEmojiImporter(t, &fakeEmojiDriveReader{body: buildEmojiZip(t)})
+	p := processors.NewImportCustomEmojisProcessor(imp)
+
+	cases := []queue.ImportCustomEmojisPayload{
+		{UserID: "", FileID: "f"},
+		{UserID: "u", FileID: ""},
+	}
+	for _, c := range cases {
+		task := queue.NewImportCustomEmojisTask(c)
+		err := p.Handle(context.Background(), task)
+		require.Error(t, err)
+		assert.ErrorIs(t, err, asynq.SkipRetry)
+	}
+}
+
+func TestImportCustomEmojisProcessor_Success(t *testing.T) {
+	imp := newEmojiImporter(t, &fakeEmojiDriveReader{body: buildEmojiZip(t)})
+	p := processors.NewImportCustomEmojisProcessor(imp)
+	task := queue.NewImportCustomEmojisTask(queue.ImportCustomEmojisPayload{UserID: "admin", FileID: "f1"})
+	require.NoError(t, p.Handle(context.Background(), task))
+}
+
+func TestImportCustomEmojisProcessor_InvalidZip_SkipRetry(t *testing.T) {
+	imp := newEmojiImporter(t, &fakeEmojiDriveReader{body: []byte("not a zip")})
+	p := processors.NewImportCustomEmojisProcessor(imp)
+	task := queue.NewImportCustomEmojisTask(queue.ImportCustomEmojisPayload{UserID: "admin", FileID: "f1"})
+	err := p.Handle(context.Background(), task)
+	require.Error(t, err)
+	assert.ErrorIs(t, err, asynq.SkipRetry)
+	assert.ErrorIs(t, err, emojiimport.ErrInvalidZip)
+}
+
+func TestImportCustomEmojisProcessor_UserNotFound_SkipRetry(t *testing.T) {
+	imp := newEmojiImporter(t, &fakeEmojiDriveReader{body: buildEmojiZip(t)})
+	p := processors.NewImportCustomEmojisProcessor(imp)
+	task := queue.NewImportCustomEmojisTask(queue.ImportCustomEmojisPayload{UserID: "ghost", FileID: "f1"})
+	err := p.Handle(context.Background(), task)
+	require.Error(t, err)
+	assert.ErrorIs(t, err, asynq.SkipRetry)
+	assert.ErrorIs(t, err, emojiimport.ErrUserNotFound)
+}
+
+func TestImportCustomEmojisProcessor_DriveError_SkipRetry(t *testing.T) {
+	imp := newEmojiImporter(t, &fakeEmojiDriveReader{err: errors.New("drive down")})
+	p := processors.NewImportCustomEmojisProcessor(imp)
+	task := queue.NewImportCustomEmojisTask(queue.ImportCustomEmojisPayload{UserID: "admin", FileID: "f1"})
+	err := p.Handle(context.Background(), task)
+	require.Error(t, err)
+	assert.ErrorIs(t, err, asynq.SkipRetry)
+	assert.ErrorIs(t, err, emojiimport.ErrDriveFileNotFound)
+}

--- a/internal/queue/queue.go
+++ b/internal/queue/queue.go
@@ -70,6 +70,14 @@ func (c *Client) EnqueueImport(payload ImportPayload) error {
 	return err
 }
 
+// EnqueueImportCustomEmojis puts an admin emoji-zip import task on the
+// export queue. Misskey 本家も同じ "dbQueue" (低優先) に積んでいる。
+func (c *Client) EnqueueImportCustomEmojis(payload ImportCustomEmojisPayload) error {
+	task := NewImportCustomEmojisTask(payload)
+	_, err := c.inner.Enqueue(task, asynq.Queue(ExportQueueName))
+	return err
+}
+
 // EnqueueWebPush puts a Web Push delivery task on the push queue.
 func (c *Client) EnqueueWebPush(ctx context.Context, payload WebPushPayload) error {
 	task := NewWebPushTask(payload)

--- a/internal/queue/queue_test.go
+++ b/internal/queue/queue_test.go
@@ -208,6 +208,21 @@ func TestDecodeImportPayload_Invalid(t *testing.T) {
 	assert.Error(t, err)
 }
 
+func TestNewImportCustomEmojisTask_RoundTrip(t *testing.T) {
+	payload := queue.ImportCustomEmojisPayload{UserID: "admin1", FileID: "f1"}
+	task := queue.NewImportCustomEmojisTask(payload)
+	assert.Equal(t, queue.TaskTypeImportCustomEmojis, task.Type())
+
+	decoded, err := queue.DecodeImportCustomEmojisPayload(task.Payload())
+	require.NoError(t, err)
+	assert.Equal(t, payload, decoded)
+}
+
+func TestDecodeImportCustomEmojisPayload_Invalid(t *testing.T) {
+	_, err := queue.DecodeImportCustomEmojisPayload([]byte(`{bad`))
+	assert.Error(t, err)
+}
+
 func TestClient_EnqueueExport(t *testing.T) {
 	testutil.SkipIfNoDocker(t)
 	flushTestRedis(t)
@@ -242,6 +257,24 @@ func TestClient_EnqueueImport(t *testing.T) {
 	require.NoError(t, err)
 	require.Len(t, tasks, 1)
 	assert.Equal(t, queue.TaskTypeImport, tasks[0].Type)
+}
+
+func TestClient_EnqueueImportCustomEmojis(t *testing.T) {
+	testutil.SkipIfNoDocker(t)
+	flushTestRedis(t)
+
+	c := queue.NewClient(redisOpt())
+	defer func() { _ = c.Close() }()
+
+	require.NoError(t, c.EnqueueImportCustomEmojis(queue.ImportCustomEmojisPayload{UserID: "admin1", FileID: "f1"}))
+
+	insp := asynq.NewInspector(redisOpt())
+	defer func() { _ = insp.Close() }()
+
+	tasks, err := insp.ListPendingTasks(queue.ExportQueueName)
+	require.NoError(t, err)
+	require.Len(t, tasks, 1)
+	assert.Equal(t, queue.TaskTypeImportCustomEmojis, tasks[0].Type)
 }
 
 func TestInspector_QueuesAndInfo(t *testing.T) {

--- a/internal/queue/tasks.go
+++ b/internal/queue/tasks.go
@@ -19,6 +19,10 @@ const TaskTypeImport = "import"
 // TaskTypeWebPush is the asynq task type for Web Push delivery jobs.
 const TaskTypeWebPush = "webpush:notify"
 
+// TaskTypeImportCustomEmojis is the asynq task type for admin/emoji/import-zip
+// processing jobs. 本家 Misskey の importCustomEmojis queue job と同名。
+const TaskTypeImportCustomEmojis = "importCustomEmojis"
+
 // TaskTypeUserWebhook is the asynq task type for user webhook delivery jobs.
 const TaskTypeUserWebhook = "webhook:user"
 
@@ -96,6 +100,28 @@ func DecodeImportPayload(body []byte) (ImportPayload, error) {
 	var p ImportPayload
 	if err := json.Unmarshal(body, &p); err != nil {
 		return ImportPayload{}, err
+	}
+	return p, nil
+}
+
+// ImportCustomEmojisPayload is the body of an emoji-zip import task.
+// UserID は import を発行した管理者 (= drive 上のアップロード所有者)。
+type ImportCustomEmojisPayload struct {
+	UserID string `json:"userId"`
+	FileID string `json:"fileId"`
+}
+
+// NewImportCustomEmojisTask creates an asynq.Task for emoji-zip imports.
+func NewImportCustomEmojisTask(payload ImportCustomEmojisPayload) *asynq.Task {
+	body, _ := json.Marshal(payload)
+	return asynq.NewTask(TaskTypeImportCustomEmojis, body)
+}
+
+// DecodeImportCustomEmojisPayload extracts an ImportCustomEmojisPayload.
+func DecodeImportCustomEmojisPayload(body []byte) (ImportCustomEmojisPayload, error) {
+	var p ImportCustomEmojisPayload
+	if err := json.Unmarshal(body, &p); err != nil {
+		return ImportCustomEmojisPayload{}, err
 	}
 	return p, nil
 }

--- a/internal/server/router.go
+++ b/internal/server/router.go
@@ -55,6 +55,7 @@ import (
 	corechat "github.com/shiroha-a/mk/internal/core/chat"
 	coreclip "github.com/shiroha-a/mk/internal/core/clip"
 	coredrive "github.com/shiroha-a/mk/internal/core/drive"
+	coreemojiimport "github.com/shiroha-a/mk/internal/core/emojiimport"
 	"github.com/shiroha-a/mk/internal/core/event"
 	corefederation "github.com/shiroha-a/mk/internal/core/federation"
 	coreflash "github.com/shiroha-a/mk/internal/core/flash"
@@ -262,6 +263,18 @@ func (s *Server) setupRoutes() {
 	importProcessor := processors.NewImportProcessor(importer)
 	s.queueServer.Handle(queue.TaskTypeExport, exportProcessor.Handle)
 	s.queueServer.Handle(queue.TaskTypeImport, importProcessor.Handle)
+
+	// Phase 9.9: admin/emoji/import-zip を非同期で処理するワーカー。
+	// driveReader と driveService を再利用し ZIP 展開→Drive 保存→emoji 行作成。
+	emojiImporter := coreemojiimport.NewImporter(coreemojiimport.Deps{
+		UserRepo:  userRepo,
+		EmojiRepo: emojiRepo,
+		Drive:     driveReader,
+		Uploader:  driveService,
+		IDGen:     idGen,
+	})
+	emojiImportProcessor := processors.NewImportCustomEmojisProcessor(emojiImporter)
+	s.queueServer.Handle(queue.TaskTypeImportCustomEmojis, emojiImportProcessor.Handle)
 
 	// Search (Phase 4.6)
 	// 設定に従って provider を選択する。Meilisearch が設定されていれば
@@ -943,6 +956,7 @@ func (s *Server) setupRoutes() {
 	adminHandler.SetEmojiRepo(emojiRepo)
 	adminHandler.SetDriveFileRepo(driveFileRepo)
 	adminHandler.SetAdminDB(s.db)
+	adminHandler.SetEmojiImportEnqueuer(s.queueClient)
 	if s.queueInspector != nil {
 		adminHandler.SetQueueInspector(&queueInspectorAdapter{inner: s.queueInspector})
 	}


### PR DESCRIPTION
## Summary

Misskey本家の管理機能「絵文字ZIPインポート」相当を実装しました。`POST /api/admin/emoji/import-zip` で事前に Drive にアップロード済みの ZIP ファイルの `fileId` を受け取り、asynq ジョブで非同期にZIP展開→画像を Drive にアップロード→ `emoji` 行作成、までを行います。

本家 `ImportCustomEmojisProcessorService` と以下の点で互換です:

- API: `fileId` のみ必須、成功時 204 No Content
- meta.json フォーマット: `{metaVersion, host, exportedAt, emojis[{fileName, downloaded, emoji:{name, category, aliases, license, isSensitive, localOnly}}]}`
- 名前衝突時の挙動: 既存ローカル絵文字 (`host IS NULL`) を削除して上書き
- 不正エントリ (invalid filename/emoji name/missing zip entry/upload failure) はスキップしてバッチ継続
- 恒久的エラー (ZIP 破損, meta.json 不在/破損) はジョブを SkipRetry で終了

## 主な変更点

- `internal/core/emojiimport/service.go` — 新規。ZIP 解析・meta.json パース・per-emoji 置き換えロジック。
- `internal/queue/tasks.go` + `queue.go` — `TaskTypeImportCustomEmojis` とペイロード、`EnqueueImportCustomEmojis` を追加 (export queue に積む)。
- `internal/queue/processors/emoji_import.go` — 新規。asynq handler。
- `internal/api/admin/handler.go` + `handler_stubs.go` — `EmojiImportZip` を 204 スタブから実実装に置き換え。`EmojiImportEnqueuer` インターフェースを経由して注入する (`Enqueuer` 本体には入れず narrow interface にして既存 stub 実装への波及を避けた)。
- `internal/server/router.go` — 既存の `driveReader`/`driveService` を再利用して importer を構築し、`adminHandler.SetEmojiImportEnqueuer` + `queueServer.Handle(TaskTypeImportCustomEmojis, ...)` を配線。

### DB 互換性

スキーマ変更なし。既存の `emoji` + `drive_file` テーブルのみ使用するので本家 Misskey への切り戻しでも問題なし。

## テスト

- `go test ./... -race -count=1` は全パッケージpass
- 新規/拡張テスト:
  - `internal/core/emojiimport/service_test.go` (11 ケース)
  - `internal/queue/processors/emoji_import_test.go` (7 ケース)
  - `internal/api/admin/handler_stubs_test.go` の `TestEmojiImportZip_*` (6 ケース)
  - `internal/queue/queue_test.go` に `ImportCustomEmojis` 系 3 ケース追加
- カバレッジ:
  - `internal/core/emojiimport` 90.5%
  - `internal/queue` 96.3%
  - `internal/queue/processors` 95.3%
  - `internal/api/admin` 61.5% (閾値 60%)

実行方法:

\`\`\`bash
go test ./internal/core/emojiimport/... ./internal/queue/... ./internal/api/admin/... -race -count=1
\`\`\`

## Closes

Closes #7

## その他

- Phase 9 シリーズはこれで完了 (9.1〜9.10 のうちオープンな Phase 9.x issue は本 PR がクローズする #7 のみ)。
- 後続候補: #11 (federation follow-ups), #21 (DB 互換監査), #24 (UDS/Surrender フォローアップ)。