### PR TITLE
Phase 12.2: docker-compose (UDS + nginx + 本家 vite フロント)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,8 @@
 .PHONY: build run dev clean tidy test fmt lint migrate-up migrate-down migrate-create \
 	federation-misskey-build federation-misskey-up federation-misskey-test \
 	federation-misskey-down federation-misskey-logs \
-	e2e-submodule-init e2e-frontend-build e2e-deps e2e-run e2e-open
+	e2e-submodule-init e2e-frontend-build e2e-deps e2e-run e2e-open \
+	uds-frontend-build uds-build uds-up uds-down uds-down-v uds-logs uds-ps
 
 # Binary output
 BINARY=misskey
@@ -119,3 +120,31 @@ e2e-open:
 		-e E2E_BASE_URL=$${E2E_BASE_URL:-http://localhost:3000} \
 		$(E2E_CYPRESS_IMAGE) \
 		cypress open --e2e --browser electron --config-file cypress.config.ts
+
+# UDS-only compose stack (Phase 12-2)。Phase 12-1 で入った UNIX domain socket
+# 対応を使って nginx → mk-go → postgres / valkey をすべて UDS で繋ぐ。
+# 詳細は docs/docker-uds.md を参照。
+UDS_COMPOSE=compose.uds.yaml
+
+# 本家 vite フロントエンドを docker 内でビルドする。初回は 3〜10 分程度かかる。
+# 既存 e2e-frontend-build のエイリアス (成果物先が同じなので共有して OK)。
+uds-frontend-build: e2e-frontend-build
+
+uds-build:
+	docker compose -f $(UDS_COMPOSE) build
+
+uds-up:
+	docker compose -f $(UDS_COMPOSE) up -d --build
+
+uds-down:
+	docker compose -f $(UDS_COMPOSE) down
+
+# named volume も含めて完全削除する (DB データも全部消える)。
+uds-down-v:
+	docker compose -f $(UDS_COMPOSE) down -v
+
+uds-logs:
+	docker compose -f $(UDS_COMPOSE) logs -f
+
+uds-ps:
+	docker compose -f $(UDS_COMPOSE) ps

--- a/compose.uds.yaml
+++ b/compose.uds.yaml
@@ -1,0 +1,134 @@
+# docker compose -f compose.uds.yaml up -d
+#
+# UNIX domain socket only 構成。Phase 12-1 で mk-go に入った UDS listen 経路
+# (HTTP / PostgreSQL / Valkey) を end-to-end で使う production-like な参照デプロイ。
+#
+# 前提: ホスト側で `make uds-frontend-build` を実行済みで、
+#   third_party/misskey/built/_frontend_vite_/ と
+#   third_party/misskey/built/_frontend_dist_/ が存在すること。
+#
+# 構成:
+#   host:80 → nginx → (mkgo_sock) → mk-go → (pg_sock)     → postgres
+#                                            (valkey_sock) → valkey
+#
+# 注意: どのサービスにも `ports:` を切らない。ホストから到達できるのは
+# nginx の 80 番だけ。`ss -tlnp | grep -E ':(5432|6379|3000)'` が空なら
+# TCP を閉じきれている証拠になる。
+
+services:
+  postgres:
+    image: postgres:16-alpine
+    environment:
+      POSTGRES_DB: mkgo
+      POSTGRES_USER: mkgo
+      POSTGRES_PASSWORD: mkgo_dev_pass
+      # postgres 16 の alpine image はデフォルトで /var/run/postgresql/.s.PGSQL.5432
+      # に socket を作るので、そのまま共有ボリュームに流し込むだけで良い。
+      PGDATA: /var/lib/postgresql/data/pgdata
+    volumes:
+      - pg_data:/var/lib/postgresql/data
+      - pg_sock:/var/run/postgresql
+    healthcheck:
+      test:
+        - CMD-SHELL
+        - pg_isready -h /var/run/postgresql -U mkgo -d mkgo
+      interval: 5s
+      timeout: 5s
+      retries: 10
+    networks:
+      - mkgo-uds
+    restart: unless-stopped
+
+  valkey:
+    image: valkey/valkey:8-alpine
+    command: ["valkey-server", "/etc/valkey/valkey.conf"]
+    volumes:
+      - ./deploy/uds/valkey/valkey.conf:/etc/valkey/valkey.conf:ro
+      - valkey_data:/data
+      - valkey_sock:/run/valkey
+    healthcheck:
+      # port 0 で TCP を切っているので、valkey-cli も必ず UDS 経由で叩く。
+      test:
+        - CMD-SHELL
+        - valkey-cli -s /run/valkey/valkey.sock ping | grep -q PONG
+      interval: 5s
+      timeout: 5s
+      retries: 10
+    networks:
+      - mkgo-uds
+    restart: unless-stopped
+
+  mkgo:
+    build:
+      context: .
+      dockerfile: deploy/uds/Dockerfile.mkgo
+    depends_on:
+      postgres:
+        condition: service_healthy
+      valkey:
+        condition: service_healthy
+    environment:
+      TZ: Asia/Tokyo
+      # 本家 vite のビルド成果物を mk-go に食わせる (Phase 11-1 で入った env 経路)。
+      MISSKEY_FRONTEND_DIR: /frontend/_frontend_vite_
+      MISSKEY_FRONTEND_DIST_DIR: /frontend/_frontend_dist_
+      MISSKEY_CLIENT_ASSETS_DIR: /misskey/packages/frontend/assets
+    volumes:
+      - ./deploy/uds/config/default.yml:/app/.config/default.yml:ro
+      # 本家フロントの vite ビルド成果物。`make uds-frontend-build` で用意する。
+      - ./third_party/misskey/built:/frontend:ro
+      # ClientAssetsDir が読む静的アセット (ゲーム用画像など)。
+      - ./third_party/misskey/packages/frontend/assets:/misskey/packages/frontend/assets:ro
+      # drive ファイルの保存先。
+      - mkgo_files:/app/files
+      # socket 共有用の named volume。
+      - pg_sock:/var/run/postgresql
+      - valkey_sock:/run/valkey
+      - mkgo_sock:/run/mkgo
+    healthcheck:
+      # UDS 経由なので curl --unix-socket を使う (wget は UDS 非対応)。
+      # /healthz は router.go で公開している health check エンドポイント。
+      test:
+        - CMD-SHELL
+        - curl --fail --silent --unix-socket /run/mkgo/mkgo.sock http://localhost/healthz || exit 1
+      interval: 10s
+      timeout: 5s
+      retries: 10
+      start_period: 30s
+    networks:
+      - mkgo-uds
+    restart: unless-stopped
+
+  nginx:
+    image: nginx:1.27-alpine
+    depends_on:
+      mkgo:
+        condition: service_healthy
+    ports:
+      - "80:80"
+    volumes:
+      - ./deploy/uds/nginx/mkgo.conf:/etc/nginx/nginx.conf:ro
+      - mkgo_sock:/run/mkgo
+    healthcheck:
+      test: ["CMD-SHELL", "nginx -t >/dev/null 2>&1"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+    networks:
+      - mkgo-uds
+    restart: unless-stopped
+
+networks:
+  mkgo-uds:
+    driver: bridge
+
+volumes:
+  pg_data:
+  valkey_data:
+  mkgo_files:
+  # socket 共有用の named volume。ファイルシステム実体は root 所有だが、
+  # 各プロセスが作る socket ファイル自体に適切な mode を付与することで
+  # non-root の consumer からも読める。
+  pg_sock:
+  valkey_sock:
+  mkgo_sock:

--- a/compose.uds.yaml
+++ b/compose.uds.yaml
@@ -79,8 +79,9 @@ services:
       - ./third_party/misskey/built:/frontend:ro
       # ClientAssetsDir が読む静的アセット (ゲーム用画像など)。
       - ./third_party/misskey/packages/frontend/assets:/misskey/packages/frontend/assets:ro
-      # drive ファイルの保存先。
-      - mkgo_files:/app/files
+      # drive ファイルの保存先。router.go がローカルストレージに ./drive-files を
+      # ハードコードしており、WORKDIR は /app なので /app/drive-files に書き込まれる。
+      - mkgo_files:/app/drive-files
       # socket 共有用の named volume。
       - pg_sock:/var/run/postgresql
       - valkey_sock:/run/valkey

--- a/deploy/uds/Dockerfile.mkgo
+++ b/deploy/uds/Dockerfile.mkgo
@@ -1,0 +1,36 @@
+# Dockerfile used by compose.uds.yaml to run mk-go under the UDS-only stack.
+#
+# Unlike the main Dockerfile it also builds the migrate binary (so the
+# entrypoint can apply schema migrations before starting the server) and
+# installs curl into the runtime image so that the healthcheck can talk to
+# the mk-go UNIX socket with `curl --unix-socket`.
+#
+# Build context must be the repository root.
+FROM golang:1.25-alpine AS builder
+
+RUN apk add --no-cache git build-base
+
+WORKDIR /app
+
+COPY go.mod go.sum ./
+RUN go mod download
+
+COPY . .
+RUN go build -trimpath -ldflags="-s -w" -o /app/built/misskey ./cmd/misskey \
+ && go build -trimpath -ldflags="-s -w" -o /app/built/migrate ./cmd/migrate
+
+FROM alpine:3.21
+
+# curl は healthcheck で `--unix-socket` を使って mk-go を叩くので必須。
+# wget は UDS をサポートしていないため不可。
+RUN apk add --no-cache ca-certificates tzdata curl
+
+WORKDIR /app
+
+COPY --from=builder /app/built/misskey /app/misskey
+COPY --from=builder /app/built/migrate /app/migrate
+COPY --from=builder /app/migration /app/migration
+COPY deploy/uds/mkgo-entrypoint.sh /entrypoint.sh
+RUN chmod +x /entrypoint.sh
+
+ENTRYPOINT ["/entrypoint.sh"]

--- a/deploy/uds/config/default.yml
+++ b/deploy/uds/config/default.yml
@@ -1,0 +1,33 @@
+# mk-go config for the UDS-only stack (compose.uds.yaml).
+#
+# HTTP / PostgreSQL / Redis すべて UNIX domain socket で接続する。
+# TCP を使わないので host から直接触れるのは nginx の 80 番だけ。
+
+# ブラウザに返す URL。nginx が 80 番でリッスンしている前提。
+url: http://localhost
+
+# HTTP listen を UNIX domain socket にする (Phase 12-1 で入った経路)。
+# nginx コンテナが同じ named volume (mkgo_sock) を /run/mkgo に mount して
+# この socket を upstream 先にする。
+socket: /run/mkgo/mkgo.sock
+# nginx (alpine image では uid 101, non-root) から読める必要があるので 666 にする。
+chmodSocket: "666"
+
+db:
+  # 絶対パス (/ で始まる) なので Phase 12-1 の IsUnixSocketPath で UDS と判定される。
+  # libpq / pgx は host=<dir> から <dir>/.s.PGSQL.<port> を組み立てるので、
+  # postgres 側が作る socket ファイル名と port を一致させる必要がある。
+  host: /var/run/postgresql
+  port: 5432
+  db: mkgo
+  user: mkgo
+  pass: mkgo_dev_pass
+
+redis:
+  # 同じく絶対パスなので go-redis の Network=unix 経路に入る (internal/core/cache/redis.go)。
+  host: /run/valkey/valkey.sock
+  # UDS 接続では port は無視されるが、viper の schema 上 int が期待されるので
+  # 6379 を書いておく (実通信では使われない)。
+  port: 6379
+
+id: aidx

--- a/deploy/uds/mkgo-entrypoint.sh
+++ b/deploy/uds/mkgo-entrypoint.sh
@@ -1,0 +1,12 @@
+#!/bin/sh
+# Run schema migrations then exec the mk-go server.
+# compose.uds.yaml から /app/.config/default.yml がマウントされる想定。
+set -e
+
+cd /app
+
+echo "[mkgo-entrypoint] running migrations..."
+/app/migrate -config /app/.config/default.yml -direction up
+
+echo "[mkgo-entrypoint] starting misskey server..."
+exec /app/misskey -config /app/.config/default.yml

--- a/deploy/uds/nginx/mkgo.conf
+++ b/deploy/uds/nginx/mkgo.conf
@@ -1,0 +1,43 @@
+events {
+    worker_connections 1024;
+}
+
+http {
+    # mk-go が /run/mkgo/mkgo.sock に作る UNIX domain socket を upstream にする。
+    # TCP は一切使わない (Phase 12-1 で入れた UDS listen の実運用デプロイ参照)。
+    upstream mkgo {
+        server unix:/run/mkgo/mkgo.sock;
+    }
+
+    # ファイルアップロードのデフォルト上限 (mk-go の maxFileSize 250MB) に合わせて
+    # 余裕を持って 512M にしておく。小さすぎると drive アップロードが 413 で落ちる。
+    client_max_body_size 512M;
+
+    # /streaming の WebSocket 接続が切れないようにアイドルタイムアウトを長めに。
+    proxy_read_timeout 1d;
+    proxy_send_timeout 1d;
+
+    # access/error ログは docker logs でそのまま見えるよう stdout/stderr に流す。
+    access_log /dev/stdout;
+    error_log /dev/stderr;
+
+    server {
+        listen 80 default_server;
+        listen [::]:80 default_server;
+        server_name _;
+
+        # 静的ファイルも API も全部 mk-go に委譲する。nginx 側でパスを二重管理しない。
+        # WebSocket upgrade も同じ location で拾う。
+        location / {
+            proxy_pass http://mkgo;
+            proxy_http_version 1.1;
+            proxy_set_header Upgrade $http_upgrade;
+            proxy_set_header Connection "upgrade";
+            proxy_set_header Host $host;
+            proxy_set_header X-Real-IP $remote_addr;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header X-Forwarded-Proto http;
+            proxy_redirect off;
+        }
+    }
+}

--- a/deploy/uds/valkey/valkey.conf
+++ b/deploy/uds/valkey/valkey.conf
@@ -1,0 +1,16 @@
+# Valkey config for compose.uds.yaml: UNIX domain socket only, no TCP.
+#
+# port 0 で TCP listen を完全に無効化する。mk-go から誤って TCP で繋ごうと
+# した瞬間に connection refused で気付けるので、むしろ望ましい挙動。
+port 0
+
+# named volume (valkey_sock) に作成する socket ファイル。
+# mk-go コンテナも同じ named volume を /run/valkey に mount して参照する。
+unixsocket /run/valkey/valkey.sock
+unixsocketperm 777
+
+# 永続化: AOF を有効にして 1 秒ごとに fsync する。
+# データ損失耐性と性能のバランスが取れているデフォルト設定。
+appendonly yes
+appendfsync everysec
+dir /data

--- a/docs/docker-uds.md
+++ b/docs/docker-uds.md
@@ -1,0 +1,134 @@
+# docker-compose で動かす UDS-only スタック
+
+Phase 12-1 で入った UNIX domain socket (UDS) 対応を使って、mk-go の全コンポーネントを TCP 無しで動かす参照デプロイメントです。ブラウザ側には本家 Misskey の vite ビルド成果物をそのまま配信するので、`http://localhost/` を開けば Misskey の UI が出ます。
+
+- nginx が受けるのは host の 80 番だけ (HTTP のみ)
+- nginx → mk-go は UDS (`/run/mkgo/mkgo.sock`)
+- mk-go → postgres は UDS (`/var/run/postgresql/.s.PGSQL.5432`)
+- mk-go → valkey は UDS (`/run/valkey/valkey.sock`、`port 0` で TCP 完全無効)
+
+既存の `docker-compose.yml` (TCP 版 quick-start) とは別ファイル (`compose.uds.yaml`) として併存しているので、従来の `docker compose up -d` 体験は壊れません。
+
+## 前提条件
+
+- Docker と docker compose v2
+- `third_party/misskey` サブモジュールの初期化 (tag `2026.3.2` が pin されています)
+- host 側のインストールは不要です。フロントエンドのビルドも docker 経由で行います。
+
+```sh
+git submodule update --init --recursive third_party/misskey
+```
+
+## 初回セットアップ
+
+### 1. 本家フロントエンドのビルド
+
+初回のみ、本家 Misskey の vite ビルドを行います (3〜10 分)。`make uds-frontend-build` は既存の `e2e-frontend-build` と同一のターゲットで、`node:20-bookworm` コンテナの中で `pnpm install --frozen-lockfile && pnpm build` を走らせます。
+
+```sh
+make uds-frontend-build
+```
+
+終了すると以下のパスに成果物ができます。`compose.uds.yaml` が read-only で bind mount します。
+
+- `third_party/misskey/built/_frontend_vite_/manifest.json`
+- `third_party/misskey/built/_frontend_dist_/`
+
+### 2. スタックの起動
+
+```sh
+make uds-up
+```
+
+以下が順番に立ち上がります。
+
+1. `postgres` — `/var/run/postgresql/.s.PGSQL.5432` を作成
+2. `valkey` — `/run/valkey/valkey.sock` を作成 (TCP は `port 0` で無効)
+3. `mkgo` — マイグレーション実行後、`/run/mkgo/mkgo.sock` で HTTP listen
+4. `nginx` — host の 80 番で受けて mk-go の socket に proxy
+
+```sh
+make uds-ps
+```
+
+全サービスが `healthy` になれば準備完了です。
+
+### 3. 動作確認
+
+```sh
+curl -i http://localhost/
+curl -i -X POST http://localhost/api/meta -H 'Content-Type: application/json' -d '{}'
+```
+
+ブラウザで `http://localhost/` を開き、Misskey のログイン画面が出ることを確認してください。DevTools の Network タブで `/streaming` が `ws://localhost/streaming` で確立していれば WebSocket の upgrade も成功しています。
+
+## UDS で繋がっていることの確認
+
+どのサービスにも `ports:` を切っていないので、ホスト側で 80 番以外の TCP は一切 listen していないはずです。
+
+```sh
+ss -tlnp | grep -E ':(80|3000|5432|6379)'
+```
+
+80 番だけが出て、3000 / 5432 / 6379 は出てこないことを確認してください。
+
+socket ファイルの実体も `docker compose exec` で覗けます。
+
+```sh
+docker compose -f compose.uds.yaml exec mkgo ls -la /var/run/postgresql /run/valkey /run/mkgo
+docker compose -f compose.uds.yaml exec nginx ls -la /run/mkgo
+```
+
+## 停止 / クリーンアップ
+
+```sh
+# コンテナだけ停止 (named volume のデータは残る)
+make uds-down
+
+# named volume まで削除 (DB / valkey / drive files が全部消える)
+make uds-down-v
+```
+
+## ログ確認
+
+```sh
+make uds-logs            # 全サービスのログを follow
+docker compose -f compose.uds.yaml logs -f mkgo
+docker compose -f compose.uds.yaml logs -f nginx
+```
+
+## トラブルシューティング
+
+### `third_party/misskey/built` が無い
+
+`make uds-frontend-build` を先に実行してください。bind mount の source が存在しないと `uds-up` が失敗します。
+
+### `/healthz` が 404 になる
+
+mk-go 側の実装変更で `/healthz` のパスが変わっている可能性があります。`internal/server/router.go` を grep して、存在するパスに `deploy/uds/Dockerfile.mkgo` の curl 先を合わせてください。
+
+### nginx が `connect() to unix:/run/mkgo/mkgo.sock failed (13: Permission denied)`
+
+`chmodSocket: "666"` が正しく反映されていません。`deploy/uds/config/default.yml` を確認し、mk-go 側のログ `[server] listening on unix:` が `mode=0666` になっているか見てください。
+
+### valkey が `Creating Server TCP listening socket *:6379: bind` で起動しない
+
+`deploy/uds/valkey/valkey.conf` の `port 0` が効いていません。`command:` で正しく `valkey.conf` を読み込めているか、bind mount のパスを確認してください。
+
+## TLS を足したい場合
+
+このデプロイは HTTP のみです。本番で TLS を張りたい場合は以下のいずれかで。
+
+- 上位に Caddy や Cloudflare Tunnel を置いて TLS 終端する (nginx の 80 番はそのまま)
+- `deploy/uds/nginx/mkgo.conf` に 443 listen + `ssl_certificate` を足す (`tests/federation/common/nginx-mkgo-ssl.conf` が参考になる)
+
+## 構成ファイル一覧
+
+| ファイル | 役割 |
+|---------|------|
+| `compose.uds.yaml` | 全サービスを繋ぐ compose エントリポイント |
+| `deploy/uds/Dockerfile.mkgo` | mk-go runtime image (migrate 同梱 + curl) |
+| `deploy/uds/mkgo-entrypoint.sh` | migrate → exec misskey |
+| `deploy/uds/nginx/mkgo.conf` | UDS upstream + WebSocket upgrade 付き nginx 設定 |
+| `deploy/uds/valkey/valkey.conf` | `port 0` + UNIX socket listen の valkey 設定 |
+| `deploy/uds/config/default.yml` | UDS 前提の mk-go 設定 |


### PR DESCRIPTION
## Summary

Phase 12-1 (#20 / PR #23) で mk-go に入った UNIX domain socket 対応 (HTTP / PostgreSQL / Valkey) を end-to-end で使う production-like な参照デプロイを追加します。ブラウザ側には Phase 11-1 で入った `third_party/misskey/` submodule の vite ビルド成果物をそのまま配信するので、`http://localhost/` を開けば Misskey の UI が出ます。

TCP が露出するのは nginx の 80 番だけで、postgres/valkey/mk-go の通信経路は全部 UDS。Phase 12-1 の UDS 経路が end-to-end で動いていることの実証も兼ねています。

- nginx → mk-go: UDS (`/run/mkgo/mkgo.sock`)
- mk-go → postgres: UDS (`/var/run/postgresql/.s.PGSQL.5432`)
- mk-go → valkey: UDS (`/run/valkey/valkey.sock`、`port 0` で TCP 完全無効)

既存の `docker-compose.yml` (TCP 版 quick-start) は変更せず、新規ファイル `compose.uds.yaml` として併存します。

## 主な変更点

### 新規

- **`compose.uds.yaml`** — 4 services (postgres / valkey / mkgo / nginx) + socket 共有用 named volume (`pg_sock` / `valkey_sock` / `mkgo_sock`)。どのサービスにも `ports:` を切らないので host から到達できるのは nginx の 80 番だけ。
- **`deploy/uds/Dockerfile.mkgo`** — `golang:1.25-alpine` で misskey + migrate をビルドし、`alpine:3.21` runtime に `curl` を同梱して healthcheck 用に使う (wget は UDS 非対応のため不可)。
- **`deploy/uds/mkgo-entrypoint.sh`** — `migrate -direction up` 後に `exec` で server 起動。
- **`deploy/uds/nginx/mkgo.conf`** — `upstream mkgo { server unix:/run/mkgo/mkgo.sock; }` で UDS upstream を定義。`client_max_body_size 512M` + WebSocket upgrade + `proxy_read_timeout 1d` で `/streaming` も通るように設定。
- **`deploy/uds/valkey/valkey.conf`** — `port 0` で TCP を完全無効化し、`unixsocket /run/valkey/valkey.sock` / `unixsocketperm 777` を設定。
- **`deploy/uds/config/default.yml`** — `socket: /run/mkgo/mkgo.sock` / `chmodSocket: "666"` で nginx (non-root) から読める権限にし、`db.host: /var/run/postgresql` と `redis.host: /run/valkey/valkey.sock` を絶対パスで UDS 経由に。
- **`docs/docker-uds.md`** — セットアップ手順、動作確認、トラブルシューティング、TLS を足す場合の参考を記述。

### 編集

- **`Makefile`** — `uds-frontend-build` / `uds-build` / `uds-up` / `uds-down` / `uds-down-v` / `uds-logs` / `uds-ps` ターゲットを追加。`uds-frontend-build` は既存 `e2e-frontend-build` のエイリアス (本家 vite ビルド成果物は同じ場所に出すので共有できる)。

### 触っていない

- `docker-compose.yml` (TCP 版 quick-start、既存ユーザーの `docker compose up -d` 体験を保護)
- `Dockerfile` (既存メイン)
- `docker-compose.federation.misskey.yml` (federation test 用、別物)
- `internal/**/*.go` — Phase 12-1 の実装をそのまま使うので **Go コードは 1 行も変更していない**

## テスト / 動作確認

- `make fmt && make lint` — pass (Go 側は無変更なので CI と同じ条件)。
- `go build ./...` — pass。
- `docker compose -f compose.uds.yaml config --quiet` — YAML validate OK。
- `docker compose -f compose.uds.yaml build mkgo` — image build 成功。
- `docker run ... nginx -t` — `deploy/uds/nginx/mkgo.conf` syntax OK。
- `docker run ... valkey-server /tmp/valkey.conf` → `valkey-cli -s /run/valkey/valkey.sock ping` → `PONG` を確認。
- fork PR #4 の CI (build / test / lint / CodeQL go / CodeQL js-ts) 全 pass。

フルスタック起動 (`make uds-frontend-build && make uds-up` でブラウザから動作確認) は本家フロント submodule build に 3〜10 分かかるため、別途実施予定。

## 使い方

```sh
git submodule update --init --recursive third_party/misskey
make uds-frontend-build  # 初回のみ、3〜10 分
make uds-up
curl -i http://localhost/
# ブラウザで http://localhost/ を開く
```

詳細は `docs/docker-uds.md` を参照。

## 関連

- Phase 12-1 UDS 実装: #20 / PR #23 (merged)
- Phase 11-1 e2e + 本家 vite submodule: 既存
- fork PR (Devin review 通過): nananek/mk-go#4 (merged `0515de1`)

Closes #25

🤖 Generated with [Claude Code](https://claude.com/claude-code)