### PR TITLE
Federation follow-ups: repliesCount / ListRemoteInboxes / NewMention

### DIFF
--- a/internal/activitypub/renderer.go
+++ b/internal/activitypub/renderer.go
@@ -162,7 +162,7 @@ func (r *Renderer) RenderNote(n *model.Note, idGen id.Generator) *Note {
 			if !ok || uri == "" {
 				continue
 			}
-			out.Tag = append(out.Tag, Mention{Type: "Mention", Href: uri, Name: name})
+			out.Tag = append(out.Tag, NewMention(uri, name))
 			if _, dup := seenTo[uri]; !dup {
 				to = append(to, uri)
 				seenTo[uri] = struct{}{}

--- a/internal/activitypub/types.go
+++ b/internal/activitypub/types.go
@@ -85,6 +85,13 @@ type Mention struct {
 	Name string `json:"name,omitempty"`
 }
 
+// NewMention constructs a Mention with the fixed `Type` label pre-filled.
+// 呼び出し側で毎回 Type を書かなくて済むようにした factory。name は
+// 任意 (空文字でも許容される)。
+func NewMention(href, name string) Mention {
+	return Mention{Type: "Mention", Href: href, Name: name}
+}
+
 // Source represents the original markup of a note (Markdown / MFM).
 type Source struct {
 	Content   string `json:"content"`

--- a/internal/activitypub/types_test.go
+++ b/internal/activitypub/types_test.go
@@ -75,3 +75,20 @@ func TestPersonMarshalsCleanly(t *testing.T) {
 	assert.Contains(t, string(b), "Person")
 	assert.Contains(t, string(b), ContextURL)
 }
+
+func TestNewMention(t *testing.T) {
+	m := NewMention("https://example.com/users/u1", "@u1")
+	assert.Equal(t, "Mention", m.Type)
+	assert.Equal(t, "https://example.com/users/u1", m.Href)
+	assert.Equal(t, "@u1", m.Name)
+
+	// name が空でも factory は Type を必ず埋める
+	m2 := NewMention("https://example.com/users/u2", "")
+	assert.Equal(t, "Mention", m2.Type)
+	assert.Empty(t, m2.Name)
+
+	// JSON 出力時も type フィールドが出ていること
+	b, err := json.Marshal(m)
+	assert.NoError(t, err)
+	assert.Contains(t, string(b), `"type":"Mention"`)
+}

--- a/internal/core/federation/processor_step_f_test.go
+++ b/internal/core/federation/processor_step_f_test.go
@@ -266,6 +266,31 @@ func TestProcess_DeleteRemoteNote(t *testing.T) {
 	assert.Error(t, err)
 }
 
+// Delete アクティビティで返信が消されたとき、親ノートの repliesCount が
+// デクリメントされることを end-to-end で確認する (issue #11, item 1)。
+func TestProcess_DeleteRemoteReply_DecrementsParent(t *testing.T) {
+	env := newFullProcessor(t, aliceActor)
+	parentID := "parent1"
+	env.noteRepo.Notes[parentID] = &model.Note{ID: parentID, UserID: "local-user", RepliesCount: 2}
+
+	replyURI := "https://remote.example/notes/reply1"
+	parent := parentID
+	env.noteRepo.Notes["reply1"] = &model.Note{
+		ID: "reply1", UserID: "alice-id", URI: &replyURI, ReplyID: &parent,
+	}
+	aliceURI := "https://remote.example/users/alice"
+	env.userRepo.Users["alice-id"] = &model.User{ID: "alice-id", Username: "alice", URI: &aliceURI}
+
+	body := []byte(`{
+		"type": "Delete",
+		"actor": "https://remote.example/users/alice",
+		"object": {"id": "https://remote.example/notes/reply1", "type": "Tombstone"}
+	}`)
+	require.NoError(t, env.processor.Process(body))
+
+	assert.Equal(t, int16(1), env.noteRepo.Notes[parentID].RepliesCount)
+}
+
 func TestProcess_DeleteUnknownNote(t *testing.T) {
 	env := newFullProcessor(t, aliceActor)
 	body := []byte(`{

--- a/internal/core/note/note_delete_service.go
+++ b/internal/core/note/note_delete_service.go
@@ -79,6 +79,13 @@ func (s *DeleteService) Delete(user *model.User, noteID string) error {
 	if err := s.noteRepo.Delete(note); err != nil {
 		return err
 	}
+	// 返信を削除するときは親ノートの repliesCount を減算する。本家 Misskey の
+	// NoteDeleteService と同じく親の local/remote を問わず一律に減算する。
+	// DeleteService は local/remote どちらの削除経路でも共通で呼ばれるため、
+	// ここに置くと federation 側でも同じ動作になる。失敗はベストエフォート。
+	if note.ReplyID != nil {
+		_ = s.noteRepo.IncrementCount(*note.ReplyID, "repliesCount", -1)
+	}
 	if s.federationHook != nil {
 		s.federationHook.OnNoteDeleted(user, note)
 	}

--- a/internal/core/note/note_delete_service_test.go
+++ b/internal/core/note/note_delete_service_test.go
@@ -21,6 +21,35 @@ func TestDeleteService_Success(t *testing.T) {
 	assert.Empty(t, noteRepo.Notes)
 }
 
+// 返信を削除すると親ノートの repliesCount が減ることを確認する。
+// 本家 Misskey の NoteDeleteService と同じ振る舞い。
+func TestDeleteService_DecrementsParentRepliesCount(t *testing.T) {
+	noteRepo := testutil.NewMockNoteRepository()
+	parentID := "parent1"
+	noteRepo.Notes[parentID] = &model.Note{ID: parentID, UserID: "owner", RepliesCount: 3}
+	replyID := "reply1"
+	parent := parentID
+	noteRepo.Notes[replyID] = &model.Note{ID: replyID, UserID: "replier", ReplyID: &parent}
+
+	svc := note.NewDeleteService(noteRepo)
+	require.NoError(t, svc.Delete(&model.User{ID: "replier"}, replyID))
+
+	// 親のカウンタが 2 になっているはず
+	assert.Equal(t, int16(2), noteRepo.Notes[parentID].RepliesCount)
+}
+
+// ReplyID が無い通常ノートを削除しても余計な IncrementCount は走らず、
+// 既存ロジックを壊していないことを回帰テストする。
+func TestDeleteService_NoParentNoDecrement(t *testing.T) {
+	noteRepo := testutil.NewMockNoteRepository()
+	other := "other"
+	noteRepo.Notes[other] = &model.Note{ID: other, UserID: "owner", RepliesCount: 5}
+	noteRepo.Notes["standalone"] = &model.Note{ID: "standalone", UserID: "u"}
+	svc := note.NewDeleteService(noteRepo)
+	require.NoError(t, svc.Delete(&model.User{ID: "u"}, "standalone"))
+	assert.Equal(t, int16(5), noteRepo.Notes[other].RepliesCount)
+}
+
 func TestDeleteService_NotFound(t *testing.T) {
 	noteRepo := testutil.NewMockNoteRepository()
 	svc := note.NewDeleteService(noteRepo)

--- a/internal/repository/user.go
+++ b/internal/repository/user.go
@@ -133,34 +133,18 @@ func (r *userRepository) CreateProfile(profile *model.UserProfile) error {
 // ListRemoteInboxes returns a deduplicated list of inbox URLs belonging to
 // every known remote user. sharedInbox を優先し、無ければ個別 inbox を採用
 // する。Public なアクティビティ (Delete 等) の broadcast に使う。
+//
+// SELECT DISTINCT で PostgreSQL 側 dedup させるのでリモートユーザー数が
+// 数十万規模でも Go 側でマップを持たずに済む。空文字は NULLIF で NULL 化して
+// WHERE inbox IS NOT NULL で除外している。
 func (r *userRepository) ListRemoteInboxes() ([]string, error) {
-	var rows []struct {
-		Inbox       *string `gorm:"column:inbox"`
-		SharedInbox *string `gorm:"column:sharedInbox"`
-	}
-	if err := r.db.Model(&model.User{}).
-		Where("host IS NOT NULL").
-		Select("inbox, \"sharedInbox\"").
-		Find(&rows).Error; err != nil {
+	const query = `SELECT DISTINCT COALESCE(NULLIF("sharedInbox", ''), inbox) AS inbox
+FROM "user"
+WHERE host IS NOT NULL
+  AND (COALESCE(NULLIF("sharedInbox", ''), inbox)) IS NOT NULL`
+	var out []string
+	if err := r.db.Raw(query).Scan(&out).Error; err != nil {
 		return nil, err
-	}
-	seen := make(map[string]struct{}, len(rows))
-	out := make([]string, 0, len(rows))
-	for _, row := range rows {
-		var inbox string
-		if row.SharedInbox != nil && *row.SharedInbox != "" {
-			inbox = *row.SharedInbox
-		} else if row.Inbox != nil && *row.Inbox != "" {
-			inbox = *row.Inbox
-		}
-		if inbox == "" {
-			continue
-		}
-		if _, dup := seen[inbox]; dup {
-			continue
-		}
-		seen[inbox] = struct{}{}
-		out = append(out, inbox)
 	}
 	return out, nil
 }


### PR DESCRIPTION
## Summary

PR #9 のレビューで指摘した軽微な改善点 3 件をまとめて対応しました。いずれも動作は既に正しいが、堅牢性・性能・可読性の改善です。

## 主な変更点

### 1. 連合ノート削除時の `repliesCount` 減算 (`core/note/DeleteService`)

- `DeleteService.Delete` 内で `note.ReplyID != nil` のときに親ノートの `repliesCount` を `-1` するように修正
- 本家 Misskey `NoteDeleteService` と同じく親の local/remote は問わず一律に減算 (Create 時の `+1` と対称)
- Federation の `Delete` activity 経路は `handleDelete` → `DeleteService.Delete` に delegate しているため、ローカル削除と連合削除の両方で自動的に有効になる
- 結果として、リモートユーザーが返信を削除したときも親ノートの返信数表示が正しく追従する

### 2. `ListRemoteInboxes` の SQL DISTINCT 化 (`repository/user.go`)

- Go 側の map dedup を廃止し、PostgreSQL 側で重複排除するように変更:

\`\`\`sql
SELECT DISTINCT COALESCE(NULLIF(\"sharedInbox\", ''), inbox)
FROM \"user\"
WHERE host IS NOT NULL
  AND (COALESCE(NULLIF(\"sharedInbox\", ''), inbox)) IS NOT NULL
\`\`\`

- Delete broadcast でリモートユーザー数が数十万規模に増えてもメモリ消費は結果行数 (= 実際のホスト数) に抑えられる
- 既存の統合テスト `TestUserRepository_ListRemoteInboxes` は無修正で pass

### 3. `activitypub.NewMention` factory 追加

- `activitypub/types.go`: `NewMention(href, name) Mention` を追加し、`Type: \"Mention\"` を内包
- `renderer.go` の唯一の呼び出し箇所を `NewMention(uri, name)` に置き換え
- 呼び出し側で `Type` を毎回書く必要がなくなり、ミスの入る余地を減らした

## テスト

- 新規追加:
  - \`core/note\`: \`TestDeleteService_DecrementsParentRepliesCount\`, \`TestDeleteService_NoParentNoDecrement\`
  - \`core/federation\`: \`TestProcess_DeleteRemoteReply_DecrementsParent\` (Delete activity 受信 → 親 repliesCount 減算の end-to-end)
  - \`activitypub\`: \`TestNewMention\` (Type が埋まっている / name 空 / JSON 出力)
- 既存テストは全て無修正で pass
- カバレッジ: \`core/note\` 99.2% / \`core/federation\` 96.9% / \`activitypub\` 100% / \`repository\` 90.9% (いずれも閾値 90% 越え)

実行方法:

\`\`\`bash
make fmt && make lint
go test -race -count=1 ./internal/core/note/... ./internal/core/federation/... ./internal/activitypub/... ./internal/repository/...
\`\`\`

## Closes

Closes #11

## その他

- 3 項目すべて DB スキーマ変更なし・API 互換性維持
- \`DeleteService.Delete\` の修正はローカル削除の挙動も変わる (副作用として local note の親 \`repliesCount\` が正しく減るようになる) が、これは upstream Misskey と同じ振る舞いなので互換性の観点ではむしろ修正