### PR TITLE
CI: publish runtime image to ghcr.io (+ Dockerfile go 1.25 / cgo fix)

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,0 +1,80 @@
+name: Docker
+
+# GHCR (ghcr.io/<owner>/<repo>) にメインの runtime image を publish する。
+#
+# - develop / main への push と `v*` タグ push で実 push する。
+# - PR では build だけ行って、動く Dockerfile かどうかを検証する (push はしない)。
+#
+# image 名は `${{ github.repository }}` をそのまま使うので、upstream では
+# `ghcr.io/shiroha-a/mk`、fork では `ghcr.io/nananek/mk-go` になる。
+
+on:
+  push:
+    branches: [main, develop]
+    tags: ["v*"]
+  pull_request:
+    branches: [main, develop]
+
+# ghcr.io に push するには packages: write が必要。
+# contents: read は checkout 用。
+permissions:
+  contents: read
+  packages: write
+
+jobs:
+  build-and-push:
+    runs-on: ubuntu-latest
+    env:
+      REGISTRY: ghcr.io
+      IMAGE_NAME: ${{ github.repository }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      # PR の場合は push しないので login 不要。fork からの PR で secrets が
+      # 使えないケースでも build だけは回せるようにしておく。
+      - name: Log in to GHCR
+        if: github.event_name != 'pull_request'
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      # tag 付けルール:
+      #   - branch 名 (develop / main)
+      #   - `sha-<shortsha>` (immutable 参照用)
+      #   - git tag (v* 押した時)
+      #   - `latest` (default branch = develop への push 時)
+      - name: Extract metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          tags: |
+            type=ref,event=branch
+            type=ref,event=pr
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=sha,prefix=sha-,format=short
+            type=raw,value=latest,enable={{is_default_branch}}
+          labels: |
+            org.opencontainers.image.title=${{ github.event.repository.name }}
+            org.opencontainers.image.description=Misskey rewritten in Go
+            org.opencontainers.image.source=${{ github.event.repository.html_url }}
+
+      - name: Build and push
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: ./Dockerfile
+          platforms: linux/amd64
+          push: ${{ github.event_name != 'pull_request' }}
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          # GHA の cache backend を使って layer を再利用し、build 時間を短縮する。
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,9 @@
 # Stage 1: Build Go binary
-FROM golang:1.24-alpine AS builder
+FROM golang:1.25-alpine AS builder
 
-RUN apk add --no-cache git
+# build-base は chai2010/webp などの cgo 依存をリンクするのに必要。
+# git は go mod download 時の private module fetch に使う。
+RUN apk add --no-cache git build-base
 
 WORKDIR /app
 


### PR DESCRIPTION
## Summary

GitHub Container Registry (`ghcr.io`) にメインの Dockerfile ビルドを自動 publish する workflow を追加します。同時に、この workflow を走らせて初めて判明した既存 `Dockerfile` の build 不能問題も修正します。

- `develop` / `main` への push と `v*` タグ push で実 push
- PR では build only (push なし) で Dockerfile の健全性を検証
- image 名は `${{ github.repository }}` で、upstream マージ後は `ghcr.io/shiroha-a/mk`

## 主な変更点

### 1. `.github/workflows/docker.yml` (新規)

- `docker/metadata-action@v5` で tag を自動生成: branch 名 / PR 番号 / semver / `sha-<shortsha>` / (default branch のみ) `latest`
- `docker/build-push-action@v6` で build & push、`cache-from/cache-to: type=gha` で layer キャッシュ再利用
- Platforms: `linux/amd64` のみ (QEMU 経由の arm64 は必要になったら追加)
- `permissions: { contents: read, packages: write }` を明示
- `docker/login-action` は `github.event_name != 'pull_request'` のときだけ実行 (fork PR で secrets が無いケースのための保険)

### 2. `Dockerfile` の既存バグ修正

この workflow を fork 側で初めて実際に走らせたら、既存 Dockerfile が build できないことが判明した。2 つの問題がある。

**(a) Go バージョン不一致**

`go.mod` が `go 1.25.0` を要求しているのに `Dockerfile` は `golang:1.24-alpine` を使っており、`go mod download` で失敗する:

```
go: go.mod requires go >= 1.25.0 (running go 1.24.13; GOTOOLCHAIN=local)
```

→ `golang:1.25-alpine` に上げる。

**(b) cgo 依存のリンク失敗**

Phase 4 Step R (4.8) で drive image 処理用に `github.com/chai2010/webp v1.4.0` が追加済みだが、これは libwebp の C ラッパーで cgo を使う。`golang:<ver>-alpine` には gcc/make/musl-dev が同梱されていないので link 時に落ちる:

```
/go/pkg/mod/github.com/chai2010/webp@v1.4.0/webp.go:96:14: undefined: webpDecodeRGBAToSize
/go/pkg/mod/github.com/chai2010/webp@v1.4.0/webp.go:109:7: undefined: toGrayImage
/go/pkg/mod/github.com/chai2010/webp@v1.4.0/webp.go:110:14: undefined: webpEncodeGray
```

→ `apk add build-base` で解決 (既に `tests/federation/common/Dockerfile.mkgo` と `deploy/uds/Dockerfile.mkgo` はこのパターン)。

Go ソースコードおよび既存 workflow (`ci.yml`) は無変更。

## テスト / 動作確認

- `make fmt && make lint` pass (Go コード無変更)。
- ローカルで `docker build -t mk-go-test-build .` が完走。
- 起動時に `starting Misskey (Go) version=2026.3.2` ログが出ることを確認。
- `ldd` で musl libc のみに link されており、`alpine:3.21` runtime ABI と整合。
- fork (`nananek/mk-go`) 側で同内容 (PR #5 workflow + PR #6 Dockerfile fix) を既に merge 済みで、docker workflow build が PASS することを確認済み。

## Test plan

- [ ] PR 上で Docker workflow が build のみで完走する (push なし、`push: false`)
- [ ] merge 後、develop への push trigger で image が `ghcr.io/shiroha-a/mk:develop` と `:latest` に publish される
- [ ] published image を `docker pull` で取得し、`docker run` で起動できる
- [ ] tags 画面で `sha-<shortsha>` が immutable reference として残っている

🤖 Generated with [Claude Code](https://claude.com/claude-code)