### PR TITLE
PR #23 フォローアップ: reversi Surrender service 経由 + UDS e2e テスト

### DIFF
--- a/internal/api/reversi/handler.go
+++ b/internal/api/reversi/handler.go
@@ -27,6 +27,7 @@ type FederationDeliverer interface {
 // Handler handles reversi/* endpoints.
 type Handler struct {
 	repo      repository.ReversiRepository
+	svc       *corereversi.Service
 	idGen     id.Generator
 	baseURL   string
 	deliverer FederationDeliverer
@@ -37,6 +38,14 @@ type Handler struct {
 // NewHandler creates a new reversi handler.
 func NewHandler(repo repository.ReversiRepository, idGen id.Generator) *Handler {
 	return &Handler{repo: repo, idGen: idGen}
+}
+
+// SetService attaches the core reversi service. 必須ではないが設定されていれば
+// Surrender 等の player action が service 経由で動く (IsStarted バリデーション +
+// WebSocket 通知が効くようになる)。nil の場合は従来の repo 直接操作にフォール
+// バックするので既存テスト互換。
+func (h *Handler) SetService(svc *corereversi.Service) {
+	h.svc = svc
 }
 
 // SetFederation attaches federation support.
@@ -252,6 +261,9 @@ func (h *Handler) CancelMatch(c echo.Context) error {
 }
 
 // Surrender handles POST /api/reversi/surrender.
+// 対局中 (IsStarted かつ not IsEnded) のみ許可する。service.Surrender を経由
+// することで WebSocket チャネルに `ended` イベントを publish するので、両
+// プレイヤーのクライアントが即座に終局状態を検出できる。
 func (h *Handler) Surrender(c echo.Context) error {
 	user := middleware.GetUser(c)
 	var req struct {
@@ -260,6 +272,10 @@ func (h *Handler) Surrender(c echo.Context) error {
 	if err := c.Bind(&req); err != nil || req.GameID == "" {
 		return c.JSON(http.StatusBadRequest, apiError("INVALID_PARAM", "gameId is required.", "ed1d7571-a3ac-4370-899c-0dbe5e230cc8"))
 	}
+
+	// federation Leave を送るために winner (= 相手) を先に引いておく。
+	// service.Surrender は repo 越しに game を読むが、federation session の
+	// lookup は handler のタイミングで必要なので preload する。
 	game, err := h.repo.FindByID(req.GameID)
 	if err != nil {
 		return c.JSON(http.StatusNotFound, apiError("NO_SUCH_GAME", "No such game.", "d8a95858-973b-4f3b-8592-fcf2eb4dd044"))
@@ -267,37 +283,59 @@ func (h *Handler) Surrender(c echo.Context) error {
 	if game.User1ID != user.ID && game.User2ID != user.ID {
 		return c.JSON(http.StatusForbidden, apiError("ACCESS_DENIED", "Access denied.", "00000000-0000-0000-0000-000000000000"))
 	}
-
-	// 相手が勝者
 	var winnerID string
 	if game.User1ID == user.ID {
 		winnerID = game.User2ID
 	} else {
 		winnerID = game.User1ID
 	}
-	now := time.Now()
-	game.IsEnded = true
-	game.EndedAt = &now
-	game.WinnerID = &winnerID
-	game.SurrenderedUserID = &user.ID
-	_ = h.repo.Update(game)
+
+	// service が注入されていればそちらを経由する (本来のパス)。
+	// フォールバックは従来の repo 直接操作 (service 未注入の古いテスト互換)。
+	if h.svc != nil {
+		if err := h.svc.Surrender(c.Request().Context(), req.GameID, user.ID); err != nil {
+			return surrenderErrorResponse(c, err)
+		}
+	} else {
+		now := time.Now()
+		game.IsEnded = true
+		game.EndedAt = &now
+		game.WinnerID = &winnerID
+		game.SurrenderedUserID = &user.ID
+		_ = h.repo.Update(game)
+	}
 
 	// リモート相手に Leave 送信。federation session は Redis 側にある。
 	if h.fedCache != nil && h.deliverer != nil && h.userRepo != nil {
-		if sessionID, ok := h.fedCache.GetSessionByGame(c.Request().Context(), game.ID); ok {
-			remoteID := winnerID // 相手
-			if remoteUser, err := h.userRepo.FindByID(remoteID); err == nil && remoteUser.Host != nil && remoteUser.URI != nil {
+		if sessionID, ok := h.fedCache.GetSessionByGame(c.Request().Context(), req.GameID); ok {
+			if remoteUser, err := h.userRepo.FindByID(winnerID); err == nil && remoteUser.Host != nil && remoteUser.URI != nil {
 				leave := corereversi.RenderLeave(h.baseURL+"/users/"+user.ID, *remoteUser.URI, sessionID)
 				if body, jerr := json.Marshal(leave); jerr == nil {
 					_ = h.deliverer.DeliverToUser(user.ID, remoteUser, body)
 				}
 			}
 			// ゲーム終了時に mapping を明示削除
-			h.fedCache.Delete(c.Request().Context(), sessionID, game.ID)
+			h.fedCache.Delete(c.Request().Context(), sessionID, req.GameID)
 		}
 	}
 
 	return c.NoContent(http.StatusNoContent)
+}
+
+// surrenderErrorResponse maps core/reversi service errors to Misskey-
+// compatible HTTP error bodies. Unknown errors fall back to 500.
+func surrenderErrorResponse(c echo.Context, err error) error {
+	switch {
+	case errors.Is(err, corereversi.ErrGameNotFound):
+		return c.JSON(http.StatusNotFound, apiError("NO_SUCH_GAME", "No such game.", "d8a95858-973b-4f3b-8592-fcf2eb4dd044"))
+	case errors.Is(err, corereversi.ErrNotPlayer):
+		return c.JSON(http.StatusForbidden, apiError("ACCESS_DENIED", "Access denied.", "00000000-0000-0000-0000-000000000000"))
+	case errors.Is(err, corereversi.ErrAlreadyEnded):
+		return c.JSON(http.StatusBadRequest, apiError("ALREADY_ENDED", "Game has already ended.", "2a3a7f72-bc06-4f4e-9f7c-b7f8d4f6a09e"))
+	case errors.Is(err, corereversi.ErrNotStarted):
+		return c.JSON(http.StatusBadRequest, apiError("NOT_STARTED", "Game has not started yet.", "ac4bb45f-ea81-44d3-a5b3-fe5f30be2c8d"))
+	}
+	return c.JSON(http.StatusInternalServerError, apiError("INTERNAL_ERROR", "Internal error.", "5d37dbcb-891e-41ca-a3d6-e690c97775ac"))
 }
 
 // Verify handles POST /api/reversi/verify — verify game integrity.

--- a/internal/api/reversi/handler_surrender_service_test.go
+++ b/internal/api/reversi/handler_surrender_service_test.go
@@ -1,0 +1,138 @@
+package reversi
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/lib/pq"
+	corereversi "github.com/shiroha-a/mk/internal/core/reversi"
+	"github.com/shiroha-a/mk/internal/model"
+	"github.com/shiroha-a/mk/internal/repository"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gorm.io/datatypes"
+)
+
+// mockReversiRepo は handler_test.go の既存 mock を使うが、
+// repository.ReversiRepository interface を満たすことを静的に確認する。
+var _ repository.ReversiRepository = (*mockReversiRepo)(nil)
+
+// capturingPublisher は corereversi.GamePublisher を実装する stub。
+// service.Surrender 経由で 'ended' が publish されるかをアサートする。
+type capturingPublisher struct {
+	events []string
+}
+
+func (p *capturingPublisher) PublishGameEvent(_ string, eventType string, _ any) {
+	p.events = append(p.events, eventType)
+}
+
+// --- helpers ---
+
+// newHandlerWithService builds a handler wired to a real corereversi.Service
+// so Surrender goes through the service layer (with IsStarted validation
+// and 'ended' event publish).
+func newHandlerWithService(t *testing.T) (*Handler, *mockReversiRepo, *capturingPublisher) {
+	t.Helper()
+	h, repo := newTestHandler()
+	pub := &capturingPublisher{}
+	// Redis なしの Service。turnTimer は nil redis でも動く (no-op)。
+	svc := corereversi.NewService(repo, pub, nil)
+	h.SetService(svc)
+	return h, repo, pub
+}
+
+// startedGameForSurrender は IsStarted=true / Black=1 / not ended の対局を
+// 返す。handler の pre-check と service の IsStarted ガードを同時にパスさせる。
+func startedGameForSurrender() *model.ReversiGame {
+	g := sampleGame()
+	g.IsStarted = true
+	b := 1
+	g.Black = &b
+	return g
+}
+
+// --- Service-backed Surrender tests ---
+
+func TestSurrender_Service_Success(t *testing.T) {
+	h, repo, pub := newHandlerWithService(t)
+	g := startedGameForSurrender()
+	repo.games[g.ID] = g
+
+	rec := post(h.Surrender, `{"gameId":"g1"}`, u1)
+	require.Equal(t, http.StatusNoContent, rec.Code)
+
+	got := repo.games["g1"]
+	assert.True(t, got.IsEnded)
+	require.NotNil(t, got.WinnerID)
+	assert.Equal(t, "u2", *got.WinnerID)
+	// Service 経由なので 'ended' が publish されている
+	assert.Contains(t, pub.events, "ended")
+}
+
+// 未開始の対局は ErrNotStarted → 400 NOT_STARTED にマップされる。
+// これが issue #24 の主眼 (repo 直接操作経路ではバリデーションを迂回していた)。
+func TestSurrender_Service_NotStarted(t *testing.T) {
+	h, repo, pub := newHandlerWithService(t)
+	g := sampleGame() // IsStarted=false
+	repo.games[g.ID] = g
+
+	rec := post(h.Surrender, `{"gameId":"g1"}`, u1)
+	assert.Equal(t, http.StatusBadRequest, rec.Code)
+	assert.Contains(t, rec.Body.String(), "NOT_STARTED")
+	// 対局は終局していない
+	assert.False(t, repo.games["g1"].IsEnded)
+	// ended イベントも飛ばない
+	assert.NotContains(t, pub.events, "ended")
+}
+
+// 終局済みの対局は ErrAlreadyEnded → 400 ALREADY_ENDED にマップされる。
+func TestSurrender_Service_AlreadyEnded(t *testing.T) {
+	h, repo, _ := newHandlerWithService(t)
+	g := startedGameForSurrender()
+	g.IsEnded = true
+	repo.games[g.ID] = g
+
+	rec := post(h.Surrender, `{"gameId":"g1"}`, u1)
+	assert.Equal(t, http.StatusBadRequest, rec.Code)
+	assert.Contains(t, rec.Body.String(), "ALREADY_ENDED")
+}
+
+// Handler の pre-check (repo.FindByID) で弾く経路は service を呼ばない。
+func TestSurrender_Service_NotFoundStillReturns404(t *testing.T) {
+	h, _, pub := newHandlerWithService(t)
+	rec := post(h.Surrender, `{"gameId":"ghost"}`, u1)
+	assert.Equal(t, http.StatusNotFound, rec.Code)
+	assert.Empty(t, pub.events)
+}
+
+// Handler の pre-check (非プレイヤー) で弾く経路も service を呼ばない。
+func TestSurrender_Service_NotPlayerCaughtByPreCheck(t *testing.T) {
+	h, repo, pub := newHandlerWithService(t)
+	repo.games["g1"] = startedGameForSurrender()
+	rec := post(h.Surrender, `{"gameId":"g1"}`, &model.User{ID: "u3"})
+	assert.Equal(t, http.StatusForbidden, rec.Code)
+	assert.Empty(t, pub.events)
+}
+
+// --- fallback path (svc nil) が従来通り動くことの回帰テスト ---
+// すでに TestSurrender_Success が同じことを確かめているが、refactor 後も
+// 明示的にフォールバック経路が生きていることを documentation として残す。
+func TestSurrender_FallbackPath_NoServiceInjected(t *testing.T) {
+	h, repo := newTestHandler()
+	// h.svc は nil のまま
+	g := &model.ReversiGame{
+		ID: "gX", User1ID: "u1", User2ID: "u2",
+		Map:  pq.StringArray{"--------", "--------", "--------", "---wb---", "---bw---", "--------", "--------", "--------"},
+		BW:   "random",
+		Logs: datatypes.JSON("[]"),
+	}
+	// IsStarted を立てずとも、fallback 経路は旧来の repo 直接操作なので通ってしまう。
+	// (issue #24 が指摘していた一貫性問題そのもの。fallback はテスト互換のため
+	// 残っているが、プロダクション経路では常に svc が注入される)
+	repo.games[g.ID] = g
+
+	rec := post(h.Surrender, `{"gameId":"gX"}`, u1)
+	assert.Equal(t, http.StatusNoContent, rec.Code)
+	assert.True(t, repo.games["gX"].IsEnded)
+}

--- a/internal/config/unix_socket_e2e_test.go
+++ b/internal/config/unix_socket_e2e_test.go
@@ -1,0 +1,126 @@
+package config_test
+
+import (
+	"context"
+	"errors"
+	"io"
+	"net"
+	"net/http"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/labstack/echo/v4"
+	"github.com/shiroha-a/mk/internal/config"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestUDSLifecycle_EndToEnd は Phase 12-1 (PR #23) で追加された UDS 対応を
+// end-to-end で検証する。issue #24 項目 2 のフォローアップ。
+//
+// 対象の composite 挙動:
+//  1. config.ListenUnixSocket でソケットファイルが作成される (+ chmod 反映)
+//  2. echo.Server.Serve(ln) で HTTP リクエストが UDS 経由で届く
+//  3. echo.Server.Shutdown(ctx) 後に Serve goroutine が ErrServerClosed を返す
+//  4. net.UnixListener.Close() の自動 unlink でソケットファイルが消える
+//  5. config.RemoveUnixSocket は既に消えているパスに対して冪等
+//
+// サーバー本体 (internal/server.Server) を起動するには DB/Redis/asynq が
+// 必要で重いため、同じ API 呼び出し列 (Server.Start/Shutdown が内部で走らせ
+// ている 4 ステップそのもの) をこのテストで直接実行する。
+func TestUDSLifecycle_EndToEnd(t *testing.T) {
+	dir := t.TempDir()
+	sockPath := filepath.Join(dir, "mkgo-e2e.sock")
+
+	e := echo.New()
+	e.HideBanner = true
+	e.HidePort = true
+	e.GET("/ping", func(c echo.Context) error {
+		return c.String(http.StatusOK, "pong")
+	})
+
+	ln, err := config.ListenUnixSocket(sockPath, "666")
+	require.NoError(t, err)
+	defer func() { _ = ln.Close() }()
+
+	fi, err := os.Stat(sockPath)
+	require.NoError(t, err, "socket file should exist after ListenUnixSocket")
+	assert.NotZero(t, fi.Mode()&os.ModeSocket, "path should be a socket")
+	assert.Equal(t, os.FileMode(0o666), fi.Mode().Perm())
+
+	serveErr := make(chan error, 1)
+	go func() {
+		serveErr <- e.Server.Serve(ln)
+	}()
+
+	// UDS 経由の http.Client を作り /ping に GET する。
+	client := &http.Client{
+		Transport: &http.Transport{
+			DialContext: func(_ context.Context, _, _ string) (net.Conn, error) {
+				return net.Dial("unix", sockPath)
+			},
+		},
+		Timeout: 2 * time.Second,
+	}
+
+	// Serve goroutine の listen 開始を短時間リトライで待つ。
+	var resp *http.Response
+	var lastErr error
+	for range 20 {
+		resp, lastErr = client.Get("http://unix/ping")
+		if lastErr == nil {
+			break
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	require.NoError(t, lastErr, "HTTP over UDS should succeed within retry budget")
+	defer func() { _ = resp.Body.Close() }()
+
+	body, _ := io.ReadAll(resp.Body)
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+	assert.Equal(t, "pong", string(body))
+
+	// Graceful shutdown → Serve goroutine は http.ErrServerClosed を返して終了する。
+	shutCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	require.NoError(t, e.Server.Shutdown(shutCtx))
+
+	select {
+	case err := <-serveErr:
+		assert.True(t, errors.Is(err, http.ErrServerClosed), "serve error should be ErrServerClosed, got %v", err)
+	case <-time.After(2 * time.Second):
+		t.Fatal("serve goroutine did not exit within timeout")
+	}
+
+	// net.UnixListener.Close() は SetUnlinkOnClose が既定 true なので socket file
+	// を自動 unlink する。Server.Shutdown が明示的に呼ぶ config.RemoveUnixSocket
+	// はこの時点で冪等 (既に消えている) である必要がある。
+	_, err = os.Stat(sockPath)
+	assert.ErrorIs(t, err, os.ErrNotExist, "socket file should be removed after listener Close")
+	assert.NoError(t, config.RemoveUnixSocket(sockPath))
+}
+
+// TestUDSLifecycle_ExplicitRemoveUnlinksLingeringSocket は UnixListener.Close()
+// が socket を unlink しないケースの防衛的な config.RemoveUnixSocket 呼び出しを
+// exercise する。SetUnlinkOnClose(false) にすることで Close 後も file が残る
+// 状況を意図的に作り出し、RemoveUnixSocket が確実に削除することを確認する。
+func TestUDSLifecycle_ExplicitRemoveUnlinksLingeringSocket(t *testing.T) {
+	dir := t.TempDir()
+	sockPath := filepath.Join(dir, "lingering.sock")
+
+	ln, err := config.ListenUnixSocket(sockPath, "")
+	require.NoError(t, err)
+	if ul, ok := ln.(*net.UnixListener); ok {
+		ul.SetUnlinkOnClose(false)
+	}
+	require.NoError(t, ln.Close())
+
+	_, err = os.Stat(sockPath)
+	require.NoError(t, err, "socket file should still be present when unlink-on-close is disabled")
+
+	require.NoError(t, config.RemoveUnixSocket(sockPath))
+	_, err = os.Stat(sockPath)
+	assert.ErrorIs(t, err, os.ErrNotExist)
+}

--- a/internal/server/router.go
+++ b/internal/server/router.go
@@ -1089,6 +1089,7 @@ func (s *Server) setupRoutes() {
 
 	// reversi/* — オセロゲーム (実データ)
 	reversiHandler := apireversi.NewHandler(reversiRepo, idGen)
+	reversiHandler.SetService(reversiService)
 	reversiHandler.SetFederation(s.config.URL, deliverService, reversiFedCache, userRepo)
 	api.POST("/reversi/games", reversiHandler.Games)
 	api.POST("/reversi/invitations", reversiHandler.Invitations, middleware.RequireAuth())


### PR DESCRIPTION
## Summary

issue #24 (PR #23 レビュー指摘フォローアップ) の 2 項目をまとめて対応しました。

## 主な変更点

### 1. \`api/reversi/handler.Surrender\` を service 経由に書き換え

Phase 9.7 (PR #23) で \`core/reversi.Service.Surrender\` に IsStarted バリデーションが追加されたものの、\`/api/reversi/surrender\` エンドポイントは repo 直接操作で \`IsEnded\`/\`WinnerID\` をセットしていたため、service 層のバリデーションを迂回していました。結果として pre-start の対局でも surrender が成立してしまう不整合が残っていました。federation inbox 経由では既に service を通るので防御されていましたが、API 経由でも同じ一貫性を持たせます。

- \`Handler\` に \`svc *corereversi.Service\` フィールドと \`SetService()\` setter を追加
- \`Surrender\` を \`h.svc.Surrender(ctx, gameID, userID)\` 呼び出しに変更
- 新規ヘルパ \`surrenderErrorResponse\` で service エラーを Misskey 互換エラーコードへマップ:
  - \`ErrGameNotFound\` → 404 \`NO_SUCH_GAME\`
  - \`ErrNotPlayer\` → 403 \`ACCESS_DENIED\`
  - \`ErrAlreadyEnded\` → 400 \`ALREADY_ENDED\`
  - \`ErrNotStarted\` → 400 \`NOT_STARTED\`
- 連合 Leave 送信ロジックは handler 側に維持
- \`service.Surrender\` は内部で \`publisher.PublishGameEvent(\"ended\", ...)\` を呼ぶので **API 経由の surrender でも WebSocket チャネルに \`ended\` 通知が飛ぶようになる**
- 後方互換: \`h.svc == nil\` の場合は従来の repo 直接操作にフォールバック
- \`router.go\` で \`reversiHandler.SetService(reversiService)\` を配線

### 2. UDS graceful shutdown end-to-end テスト

PR #23 で \`config.ListenUnixSocket\` / \`RemoveUnixSocket\` の単体テストは完備されていましたが、\`echo.Server.Serve → Shutdown → socket file unlink\` までの composite 動作を通しで確認する e2e テストが無かったので追加しました。

- **\`TestUDSLifecycle_EndToEnd\`**: 5 ステップ検証
  1. \`ListenUnixSocket\` + chmod (\"666\") の反映確認
  2. \`echo.Server.Serve\` + UDS dialer 経由の HTTP GET \`/ping\` → 200 \"pong\"
  3. \`echo.Server.Shutdown(ctx)\` → Serve goroutine が \`http.ErrServerClosed\` で終了
  4. \`net.UnixListener.Close()\` の auto-unlink でソケットファイルが消える
  5. \`config.RemoveUnixSocket\` が「既に消えているパス」に対して冪等
- **\`TestUDSLifecycle_ExplicitRemoveUnlinksLingeringSocket\`**: \`SetUnlinkOnClose(false)\` で意図的に残したソケットを \`RemoveUnixSocket\` が削除できることの回帰テスト

### 配置判断

e2e テストは \`internal/server/\` ではなく \`internal/config/\` (\`package config_test\`) に置きました。理由: \`internal/server/\` はこれまでテストファイルが 1 つも無かったので CI の \`go list -f '{{if (or .TestGoFiles .XTestGoFiles)}}'\` フィルタから除外されていました。server パッケージにテストを入れると 90% coverage gate が有効になり、本 PR のスコープ外 (他 50 以上の handler/init コード) をまとめてテストしなければならなくなります。テスト自体は \`config.ListenUnixSocket\`/\`RemoveUnixSocket\` の composite 挙動確認が中心なので config パッケージが自然な置き場所です。

## テスト

- \`go test -race -count=1 -timeout 10m ./...\` 全 pass
- カバレッジ:
  - \`api/reversi\` 94.5% → **97.1%** (Surrender の service 経路 6 ケース追加)
  - \`core/reversi\` **97.5%** (維持)
  - \`config\` **96.8%** (維持、e2e テストは XTestGoFiles)
- \`make fmt && make lint\` pass

実行方法:

\`\`\`bash
make fmt && make lint
go test -race -count=1 -timeout 10m ./...
\`\`\`

## Closes

Closes #24

## 関連

- PR #23 (Phase 12-1 UNIX domain socket support) — 元の実装
- PR #22 (Phase 9.7 reversi federation inbox) — service.Surrender に IsStarted ガードが入った経緯