### PR TITLE
Phase 11.1 Cypress e2e 互換 blocker 修正 (Node22 / reset-db meta / sw.js)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -84,7 +84,7 @@ federation-misskey-logs:
 #
 # CLAUDE.md の規約で「パッケージはホストに直接入れずコンテナ経由で動かす」と
 # 決まっているため、pnpm / cypress はすべて docker run で実行する。
-E2E_NODE_IMAGE=node:20-bookworm
+E2E_NODE_IMAGE=node:22-bookworm
 E2E_CYPRESS_IMAGE=cypress/included:15.11.0
 E2E_WORKDIR=/work
 

--- a/internal/api/test/handler.go
+++ b/internal/api/test/handler.go
@@ -75,6 +75,14 @@ func (h *Handler) ResetDB(c echo.Context) error {
 			slog.Error("reset-db: table reset failed", "err", err)
 			return echo.NewHTTPError(http.StatusInternalServerError, "db reset failed")
 		}
+		// meta テーブルは TRUNCATE で消えるが、初期セットアップフロー
+		// (/api/admin/accounts/create) が `SELECT * FROM meta` を前提にしているので
+		// 空行を 1 つ再挿入する。id は singleton なので値は何でも良い。
+		// 全カラムは DB 側 default を持っているのでこれだけで有効な行になる。
+		if err := h.db.WithContext(ctx).Exec(`INSERT INTO "meta" ("id") VALUES ('meta-singleton') ON CONFLICT DO NOTHING`).Error; err != nil {
+			slog.Error("reset-db: meta re-init failed", "err", err)
+			return echo.NewHTTPError(http.StatusInternalServerError, "db reset failed")
+		}
 	}
 
 	return c.NoContent(http.StatusNoContent)

--- a/internal/api/test/handler_test.go
+++ b/internal/api/test/handler_test.go
@@ -115,10 +115,42 @@ func TestResetDB_FlushesRedisAndTables(t *testing.T) {
 	val, err := testRedis.Client.Get(ctx, "reset-db:marker").Result()
 	assert.ErrorIs(t, err, redis.Nil, "got value=%q", val)
 
-	// meta 行が消えていること。
+	// meta テーブルは TRUNCATE されるが、reset-db は initial-setup フローを
+	// 維持するため空の singleton 行を即座に再 INSERT する。事前に入れた行は
+	// 消え、replacement 行 (id="meta-singleton") が 1 つだけ残るのが正しい。
 	var count int64
 	require.NoError(t, testPg.DB.Raw(`SELECT COUNT(*) FROM "meta"`).Scan(&count).Error)
-	assert.Equal(t, int64(0), count)
+	assert.Equal(t, int64(1), count)
+
+	var ids []string
+	require.NoError(t, testPg.DB.Raw(`SELECT id FROM "meta"`).Scan(&ids).Error)
+	assert.Equal(t, []string{"meta-singleton"}, ids)
+}
+
+// meta INSERT のエラー経路をカバーする。テスト前に meta テーブル自体を一時的に
+// rename することで「TRUNCATE は対象テーブル一覧から meta が消えるので no-op、
+// その後の INSERT INTO "meta" が relation not found で失敗する」状況を作る。
+// テスト後に元に戻す。
+func TestResetDB_MetaInsertError_Returns500(t *testing.T) {
+	requireContainers(t)
+
+	// meta を退避する。名前が重複しないよう一時テーブル名を使う。
+	require.NoError(t, testPg.DB.Exec(`ALTER TABLE "meta" RENAME TO "meta_test_backup"`).Error)
+	t.Cleanup(func() {
+		_ = testPg.DB.Exec(`DROP TABLE IF EXISTS "meta"`).Error
+		_ = testPg.DB.Exec(`ALTER TABLE "meta_test_backup" RENAME TO "meta"`).Error
+	})
+
+	h := NewHandler(testPg.DB, testRedis.Client, true)
+	c, rec := freshEchoContext()
+	err := h.ResetDB(c)
+
+	// meta テーブルが存在しないので INSERT が失敗し、500 が返る
+	require.Error(t, err)
+	var he *echo.HTTPError
+	require.True(t, errors.As(err, &he))
+	assert.Equal(t, http.StatusInternalServerError, he.Code)
+	_ = rec
 }
 
 func TestResetDB_PreservesSchemaMigrations(t *testing.T) {

--- a/internal/server/frontend.go
+++ b/internal/server/frontend.go
@@ -110,6 +110,17 @@ func FrontendDistDir() string {
 	return filepath.Join("built", "_frontend_dist_")
 }
 
+// SwDistDir returns the path to _sw_dist_ assets (service worker sw.js).
+// 環境変数 MISSKEY_SW_DIST_DIR で上書き可能。Frontend build の
+// sibling ディレクトリに出力されるのでデフォルトは FrontendDir の親 +
+// "_sw_dist_"。
+func SwDistDir() string {
+	if v := os.Getenv("MISSKEY_SW_DIST_DIR"); v != "" {
+		return v
+	}
+	return filepath.Join(filepath.Dir(FrontendDir()), "_sw_dist_")
+}
+
 // ClientAssetsDir returns the path to frontend client assets (game images, etc.).
 // 環境変数 MISSKEY_CLIENT_ASSETS_DIR で上書き可能。
 func ClientAssetsDir() string {

--- a/internal/server/router.go
+++ b/internal/server/router.go
@@ -1189,6 +1189,14 @@ func (s *Server) setupRoutes() {
 	// manifest.json — PWA用
 	s.echo.GET("/manifest.json", manifestJSON(s.config, metaRepo))
 
+	// Service Worker (sw.js) — Misskey frontend は GET /sw.js を登録しにくる。
+	// SPA catchall より前に登録しないと text/html にフォールバックしてしまい
+	// ブラウザが "unsupported MIME type" エラーで SW 登録を拒否する。
+	swDistDir := SwDistDir()
+	if _, err := os.Stat(filepath.Join(swDistDir, "sw.js")); err == nil {
+		s.echo.File("/sw.js", filepath.Join(swDistDir, "sw.js"))
+	}
+
 	// Frontend HTML shell — SPA catchall (最後に登録)
 	s.echo.GET("/*", frontendHTML(s.config, metaRepo))
 }


### PR DESCRIPTION
## Summary

Phase 11-1 で入った Cypress e2e ラッパーを初めて実行した結果、3 つの blocker が見つかったので修正します。これらを当てた状態で 13 tests のうち 2 tests がパスするようになります。残りの失敗 (`/api/signup` 未実装 / frontend bootstrap の addEventListener エラー) は別 issue で追跡します。

## 主な変更点

### 1. Frontend build に Node 22+ が必要

Misskey 2026.3.2 (`packages/backend/package.json`) の \`engines.node\` は \`^22.15.0 || ^24.10.0\` に固定されており、Makefile の \`E2E_NODE_IMAGE=node:20-bookworm\` では \`make e2e-frontend-build\` が起動直後に \`ERR_PNPM_UNSUPPORTED_ENGINE\` で死にます。

- \`Makefile\`: \`E2E_NODE_IMAGE\` を \`node:22-bookworm\` に更新

### 2. \`/api/reset-db\` 後の \`meta\` テーブル再初期化

Cypress の \`resetState\` カスタムコマンドが \`POST /api/reset-db\` を呼ぶと \`TRUNCATE meta CASCADE\` で meta 行が消えます。直後に \`registerUser(admin=true)\` が \`POST /api/admin/accounts/create\` を呼ぶと、handler が \`metaRepo.Fetch()\` で \`record not found\` を受けて 500 を返してしまい、**すべての Cypress テストが before each で死ぬ**状態になっていました。

- \`internal/api/test/handler.go\`: \`resetTables\` 成功後に
  \`INSERT INTO \"meta\" (\"id\") VALUES ('meta-singleton') ON CONFLICT DO NOTHING\`
  を発行して空の singleton 行を再生成。すべてのカラムは DB 側 default を持っているので id だけ指定すれば valid な行になる
- \`internal/api/test/handler_test.go\`:
  - \`TestResetDB_FlushesRedisAndTables\` を新挙動に合わせて更新 (meta 行が 1 つ残り id=\"meta-singleton\" であることを確認)
  - 新規 \`TestResetDB_MetaInsertError_Returns500\` で meta テーブルを一時的に rename して INSERT が失敗する経路をカバー (`ResetDB` 100% カバレッジ達成)

### 3. \`/sw.js\` が \`text/html\` で配信される

Frontend の boot コードは \`navigator.serviceWorker.register('/sw.js')\` を呼びますが、mk-go は \`/sw.js\` のルートを持っておらず SPA catchall (\`frontendHTML\`) が \`text/html\` で index.html を返してしまっていました。ブラウザは \"unsupported MIME type ('text/html')\" で SW 登録を拒否し、Cypress は SecurityError で fail。

- \`internal/server/frontend.go\`: \`SwDistDir()\` helper を追加 (env \`MISSKEY_SW_DIST_DIR\` で上書き可、デフォルトは \`FrontendDir\` の sibling \`_sw_dist_\`)
- \`internal/server/router.go\`: SPA catchall より前に
  \`s.echo.File(\"/sw.js\", filepath.Join(swDistDir, \"sw.js\"))\` を登録

## Cypress 実行結果 (修正後)

| Spec | Tests | Pass | Fail | Skipped |
|---|---|---|---|---|
| basic.cy.ts | 12 | **2** | 7 | 3 |
| router.cy.ts | 1 | 0 | 1 | 0 |
| widgets.cy.ts | 0 | – | – | – |

✅ 通るようになったテスト
- \`Before setup instance > successfully loads\`
- \`After setup instance > successfully loads\`

(setup フローと初期 SPA ロードはこれで通る)

## テスト

- \`go test -race -count=1 -timeout 10m ./...\` 全 pass
- \`internal/api/test\` 91.9% → **92.5%** (>90% 閾値クリア)
- \`internal/api/test/handler.go ResetDB\` 86.7% → **100%**
- \`make fmt && make lint\` pass

実行方法:

\`\`\`bash
make fmt && make lint
go test -race -count=1 -timeout 10m ./...

# Cypress を実行する場合 (要 docker, ~10 min 初回ビルド)
git submodule update --init --recursive third_party/misskey
make e2e-frontend-build
make e2e-deps
MK_TESTMODE=1 \\
MISSKEY_FRONTEND_DIR=\$(pwd)/third_party/misskey/built/_frontend_vite_ \\
MISSKEY_FRONTEND_DIST_DIR=\$(pwd)/third_party/misskey/built/_frontend_dist_ \\
MISSKEY_SW_DIST_DIR=\$(pwd)/third_party/misskey/built/_sw_dist_ \\
MISSKEY_CLIENT_ASSETS_DIR=\$(pwd)/third_party/misskey/packages/frontend/assets \\
./built/misskey -config .config/default.yml &
make e2e-run
\`\`\`

## 残課題 (別 issue で追跡)

実行で見つかった残りの 8 失敗は本 PR では修正せず、次の issue で追跡します:

1. **\`/api/signup\` / \`/api/signin-flow\` 未実装** — handler が \`api.Any(\"/*\")\` catchall に吸われて空オブジェクトを返している
2. **Frontend bootstrap の \`addEventListener on undefined\`** — vite chunk 内で何かが undefined。原因要調査 (WebSocket streaming / api/i / navigator など候補多数)

## 関連

- Phase 11-1: Cypress e2e ラッパー本体 (Misskey 本家の cypress spec を mk-go に向けて実行)
- 本 PR は Phase 11-1 を実際に走らせて見つかった blocker 3 件をまとめて修正