### PR TITLE
Phase 12.2 フォローアップ: non-root mkgo + valkey perm + docs

### DIFF
--- a/deploy/uds/Dockerfile.mkgo
+++ b/deploy/uds/Dockerfile.mkgo
@@ -25,12 +25,23 @@ FROM alpine:3.21
 # wget は UDS をサポートしていないため不可。
 RUN apk add --no-cache ca-certificates tzdata curl
 
+# 非 root 専用ユーザーを作る。uid/gid 65532 は GoogleContainerTools の
+# distroless `nonroot` と同じ慣例で、複数のコンテナ間で衝突しない値。
+RUN addgroup -g 65532 -S mkgo && adduser -u 65532 -S -G mkgo -H -D mkgo
+
 WORKDIR /app
 
-COPY --from=builder /app/built/misskey /app/misskey
-COPY --from=builder /app/built/migrate /app/migrate
-COPY --from=builder /app/migration /app/migration
-COPY deploy/uds/mkgo-entrypoint.sh /entrypoint.sh
+COPY --from=builder --chown=65532:65532 /app/built/misskey /app/misskey
+COPY --from=builder --chown=65532:65532 /app/built/migrate /app/migrate
+COPY --from=builder --chown=65532:65532 /app/migration /app/migration
+COPY --chown=65532:65532 deploy/uds/mkgo-entrypoint.sh /entrypoint.sh
 RUN chmod +x /entrypoint.sh
+
+# drive-files を named volume として bind するときに、初回は本ディレクトリの
+# 所有権を docker が引き継ぐので mkgo:mkgo にしておく。compose.uds.yaml の
+# `mkgo_files:/app/drive-files` mount でこのオーナーが volume root に伝播する。
+RUN mkdir -p /app/drive-files && chown 65532:65532 /app/drive-files
+
+USER 65532:65532
 
 ENTRYPOINT ["/entrypoint.sh"]

--- a/deploy/uds/valkey/valkey.conf
+++ b/deploy/uds/valkey/valkey.conf
@@ -6,8 +6,10 @@ port 0
 
 # named volume (valkey_sock) に作成する socket ファイル。
 # mk-go コンテナも同じ named volume を /run/valkey に mount して参照する。
+# perm 666: read/write for everyone but no execute (mk-go の chmodSocket="666"
+# と一貫させる、最小権限)。
 unixsocket /run/valkey/valkey.sock
-unixsocketperm 777
+unixsocketperm 666
 
 # 永続化: AOF を有効にして 1 秒ごとに fsync する。
 # データ損失耐性と性能のバランスが取れているデフォルト設定。

--- a/docs/docker-uds.md
+++ b/docs/docker-uds.md
@@ -99,9 +99,39 @@ docker compose -f compose.uds.yaml logs -f nginx
 
 ## トラブルシューティング
 
+### `third_party/misskey` 自体が空 (submodule 未初期化)
+
+`compose.uds.yaml` は `./third_party/misskey/built` と `./third_party/misskey/packages/frontend/assets` を read-only で bind mount しています。submodule をまだ取得していない場合、このディレクトリが空になっていて mount source が存在せず `uds-up` がエラーで止まります。
+
+```sh
+git submodule update --init --recursive third_party/misskey
+make uds-frontend-build
+```
+
+submodule のチェックアウト先 (tag `2026.3.2`) は本リポジトリで pin 済みです。
+
 ### `third_party/misskey/built` が無い
 
 `make uds-frontend-build` を先に実行してください。bind mount の source が存在しないと `uds-up` が失敗します。
+
+### マイグレーションが失敗してコンテナが crash loop する
+
+`mkgo-entrypoint.sh` は `set -e` で migrate を実行してから mk-go server を起動します。migrate が失敗するとそのまま container exit し、`restart: unless-stopped` のため compose が再起動 → 同じエラーで再度 exit、というループに入ります。
+
+検出方法:
+
+```sh
+make uds-logs                                            # 全サービスのログを follow
+docker compose -f compose.uds.yaml logs mkgo | tail -50  # mkgo だけ、過去ログ含めて
+```
+
+`[mkgo-entrypoint] running migrations...` の直後に migrate がエラーを吐いていれば該当します。
+
+対応:
+
+- スキーマが壊れている場合は手動で `psql` で問題を解消する (`./built/migrate -direction down -steps 1` で直前の migration を巻き戻し、修正後に `up` し直す)
+- volume 自体がおかしい場合は `make uds-down-v` で named volume を消して綺麗な状態から再構築する (**DB データは全部消える**ので注意)
+- 開発中の migration 自体に問題があれば、まず `go run ./cmd/migrate -direction down -steps 1` で 1 段戻してから修正する
 
 ### `/healthz` が 404 になる
 


### PR DESCRIPTION
## Summary

issue #30 (PR #28 レビュー指摘フォローアップ) の 5 項目を順に対応しました。CGO_ENABLED=0 のみ chai2010/webp の cgo 必須仕様により skip。残り 4 項目は実装 + ローカルで動作確認済みです。

## 主な変更点

### 1. mkgo コンテナを非 root ユーザーで動かす

\`deploy/uds/Dockerfile.mkgo\`:
- alpine 上で uid/gid 65532 の専用 mkgo ユーザーを作成
- \`COPY --from=builder --chown=65532:65532\` で binary / migrate / migration を mkgo:mkgo 所有にする
- \`/app/drive-files\` を \`mkdir + chown\` して named volume への所有権伝播を仕込む (Docker は新規 named volume を mount 先ディレクトリのオーナーで初期化する)
- \`USER 65532:65532\` で runtime を非 root に切り替え

postgres / valkey の socket は perm 666 / 777 で誰でも read/write できるので非 root mkgo からの接続にも問題なし。nginx 側も \`chmodSocket: \"666\"\` で読める。

### 2. valkey の \`unixsocketperm\` を 666 に

\`deploy/uds/valkey/valkey.conf\`:
- \`unixsocketperm 777\` → \`666\`
- mk-go の \`chmodSocket: \"666\"\` と一貫させる
- socket に execute bit を立てる意味は無く、最小権限の観点で 666 が適切

### 3. CGO_ENABLED=0 — **スキップ**

\`chai2010/webp\` v1.4.0 が cgo 必須で pure-Go fallback を持っていません:

- \`webp.go\` (pure Go) が \`webpDecodeRGB\` / \`webpEncodeRGB\` 等を呼ぶ
- 定義は \`capi.go\` (cgo file: \`import \"C\"\`) にしかない
- \`CGO_ENABLED=0\` では capi.go が build から除外され、未定義シンボルで失敗

\`CGO_ENABLED=0 go build ./cmd/misskey\` を試して以下のエラーを実機確認:

\`\`\`
github.com/chai2010/webp/webp.go:22:9: undefined: webpGetInfo
github.com/chai2010/webp/webp.go:26:20: undefined: webpDecodeGray
...
\`\`\`

builder と runtime が両方 \`alpine:3.21\` なので musl 互換は問題なし。依存差し替え (\`golang.org/x/image/webp\` 等) は別 issue で扱うべき大きな変更なので本 PR では skip しています。

### 4. マイグレーション失敗時の crash loop を docs に追記

\`docs/docker-uds.md\` トラブルシューティング節:
- \`mkgo-entrypoint.sh\` が \`set -e\` + \`migrate\` なので migrate 失敗で container exit
- \`restart: unless-stopped\` で同じエラーで再起動 → ループになる旨を説明
- 検出方法 (\`make uds-logs\` / \`docker compose logs mkgo\`)
- 対応 (psql で手動修正、\`make uds-down-v\` で named volume 完全削除、\`go run ./cmd/migrate -direction down\` で 1 段戻して修正)

### 5. submodule 未初期化時のエラー説明を追加

\`docs/docker-uds.md\` トラブルシューティング節:
- **既存「\`third_party/misskey/built\` が無い」節は wording を維持** (純粋追記)
- その上に「\`third_party/misskey\` 自体が空 (submodule 未初期化)\」節を追加
- bind mount source が無いので uds-up が止まる旨と \`git submodule update --init --recursive third_party/misskey\` で解決を明示

## 検証 (ローカル)

- \`docker compose -f compose.uds.yaml config --quiet\` pass
- \`docker compose -f compose.uds.yaml build mkgo\` 成功
- \`docker run --rm misskey-go-mkgo id\` → **\`uid=65532(mkgo) gid=65532(mkgo) groups=65532(mkgo)\`**
- \`/app/{misskey,migrate,migration,drive-files}\` 全て \`mkgo:mkgo\` 所有
- \`nginx -t\` syntax pass (\`deploy/uds/nginx/mkgo.conf\`)
- \`valkey-server /etc/valkey/valkey.conf\` 起動 → \"Ready to accept connections unix\" 確認

\`make uds-up\` でフルスタック起動して \`http://localhost/\` を実際に開く動作確認は本 PR では実施していません (initial admin setup のフローまで自動化していないため)。動作確認したい場合は以下:

\`\`\`bash
git submodule update --init --recursive third_party/misskey
make uds-frontend-build
make uds-up
make uds-ps          # 全 service が healthy になることを確認
curl -i http://localhost/
\`\`\`

## Closes

Closes #30

## 関連

- PR #28 (Phase 12.2 docker-compose UDS)
- PR #28 のレビューコメントで指摘した 5 項目を本 PR で消化