### PR TITLE
DB-compat 実装G: ブランディング / UI メタ露出 (軽量)

### DIFF
--- a/internal/api/meta/handler.go
+++ b/internal/api/meta/handler.go
@@ -1,6 +1,7 @@
 package meta
 
 import (
+	"encoding/json"
 	"net/http"
 
 	"github.com/labstack/echo/v4"
@@ -62,19 +63,23 @@ func (h *Handler) Meta(c echo.Context) error {
 		"maxNoteTextLength":      3000,
 
 		// フロントエンド互換性フィールド (Phase 4.5c)
-		"tosUrl":                       m.TermsOfServiceURL,
-		"repositoryUrl":                m.RepositoryURL,
-		"feedbackUrl":                  m.FeedbackURL,
-		"impressumUrl":                 m.ImpressumURL,
-		"privacyPolicyUrl":             m.PrivacyPolicyURL,
-		"inquiryUrl":                   nil,
-		"federation":                   m.Federation,
-		"defaultLightTheme":            nil,
-		"defaultDarkTheme":             nil,
-		"serverErrorImageUrl":          nil,
-		"notFoundImageUrl":             nil,
-		"infoImageUrl":                 nil,
-		"mascotImageUrl":               "/assets/ai.png",
+		"tosUrl":              m.TermsOfServiceURL,
+		"repositoryUrl":       m.RepositoryURL,
+		"feedbackUrl":         m.FeedbackURL,
+		"impressumUrl":        m.ImpressumURL,
+		"privacyPolicyUrl":    m.PrivacyPolicyURL,
+		"inquiryUrl":          m.InquiryURL,
+		"federation":          m.Federation,
+		"defaultLightTheme":   m.DefaultLightTheme,
+		"defaultDarkTheme":    m.DefaultDarkTheme,
+		"serverErrorImageUrl": m.ServerErrorImageURL,
+		"notFoundImageUrl":    m.NotFoundImageURL,
+		"infoImageUrl":        m.InfoImageURL,
+		"app192IconUrl":       m.App192IconURL,
+		"app512IconUrl":       m.App512IconURL,
+		// mascotImageUrl: meta 値があればそれを返す。空または nil なら従来の
+		// /assets/ai.png にフォールバック (フロントエンドが no-image にならないため)。
+		"mascotImageUrl":               mascotURL(m.MascotImageURL),
 		"translatorAvailable":          false,
 		"enableEmail":                  m.EnableEmail,
 		"enableUrlPreview":             false,
@@ -92,8 +97,10 @@ func (h *Handler) Meta(c echo.Context) error {
 		"mcaptchaInstanceUrl":          nil,
 		"enableTestcaptcha":            false,
 		"sentryForFrontend":            nil,
-		"googleAnalyticsMeasurementId": nil,
-		"clientOptions":                map[string]any{},
+		"googleAnalyticsMeasurementId": m.GoogleAnalyticsMeasurementID,
+		// clientOptions は jsonb なのでそのまま返す。空 jsonb なら frontend が
+		// デフォルト値を使う前提。
+		"clientOptions": clientOptionsJSON(m.ClientOptions),
 
 		"policies": defaultPolicies(),
 
@@ -162,4 +169,28 @@ func (h *Handler) Ping(c echo.Context) error {
 	return c.JSON(http.StatusOK, map[string]any{
 		"pong": true,
 	})
+}
+
+// mascotURL applies the legacy fallback for the mascot. Misskey フロントエンドは
+// このフィールドが空文字 / 未設定でも特定の no-image を出すだけだが、本家挙動と
+// 互換にするため /assets/ai.png をフォールバックに使う。
+func mascotURL(v *string) string {
+	if v != nil && *v != "" {
+		return *v
+	}
+	return "/assets/ai.png"
+}
+
+// clientOptionsJSON returns m.ClientOptions as a generic any. JSON encoder の
+// raw bytes をそのまま返すと frontend が parse しないので、空の場合は空 map に
+// 正規化する (本家フロントエンドは object を期待する)。
+func clientOptionsJSON(raw []byte) any {
+	if len(raw) == 0 {
+		return map[string]any{}
+	}
+	var out map[string]any
+	if err := json.Unmarshal(raw, &out); err != nil || out == nil {
+		return map[string]any{}
+	}
+	return out
 }

--- a/internal/api/meta/handler_test.go
+++ b/internal/api/meta/handler_test.go
@@ -92,3 +92,129 @@ func TestPing(t *testing.T) {
 	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
 	assert.Equal(t, true, resp["pong"])
 }
+
+// --- Branding / UI exposure (issue #50) ---
+
+// /api/meta が meta テーブルの新フィールド (mascot / app192/512 / themes /
+// inquiryUrl / clientOptions / ga) を返すことを確認する。
+func TestMeta_BrandingFieldsExposed(t *testing.T) {
+	h, repo := newTestHandler()
+	mascot := "https://example.com/mascot.png"
+	app192 := "https://example.com/app192.png"
+	app512 := "https://example.com/app512.png"
+	srvErr := "https://example.com/err.png"
+	notFound := "https://example.com/404.png"
+	info := "https://example.com/info.png"
+	dlt := "{\"name\":\"light\"}"
+	ddt := "{\"name\":\"dark\"}"
+	inquiry := "https://example.com/inquiry"
+	ga := "G-XXXXXX"
+	repo.Meta = &model.Meta{
+		ID:                           "x",
+		MascotImageURL:               &mascot,
+		App192IconURL:                &app192,
+		App512IconURL:                &app512,
+		ServerErrorImageURL:          &srvErr,
+		NotFoundImageURL:             &notFound,
+		InfoImageURL:                 &info,
+		DefaultLightTheme:            &dlt,
+		DefaultDarkTheme:             &ddt,
+		InquiryURL:                   &inquiry,
+		GoogleAnalyticsMeasurementID: &ga,
+		ClientOptions:                []byte(`{"entrancePageStyle":"simple","showTimelineForVisitor":true}`),
+	}
+
+	e := echo.New()
+	req := httptest.NewRequest(http.MethodPost, "/api/meta", nil)
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+
+	require.NoError(t, h.Meta(c))
+	assert.Equal(t, http.StatusOK, rec.Code)
+
+	var resp map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+	assert.Equal(t, mascot, resp["mascotImageUrl"])
+	assert.Equal(t, app192, resp["app192IconUrl"])
+	assert.Equal(t, app512, resp["app512IconUrl"])
+	assert.Equal(t, srvErr, resp["serverErrorImageUrl"])
+	assert.Equal(t, notFound, resp["notFoundImageUrl"])
+	assert.Equal(t, info, resp["infoImageUrl"])
+	assert.Equal(t, dlt, resp["defaultLightTheme"])
+	assert.Equal(t, ddt, resp["defaultDarkTheme"])
+	assert.Equal(t, inquiry, resp["inquiryUrl"])
+	assert.Equal(t, ga, resp["googleAnalyticsMeasurementId"])
+
+	co, _ := resp["clientOptions"].(map[string]any)
+	assert.Equal(t, "simple", co["entrancePageStyle"])
+	assert.Equal(t, true, co["showTimelineForVisitor"])
+}
+
+// mascotImageUrl 未設定時は legacy /assets/ai.png にフォールバック。
+func TestMeta_MascotFallback(t *testing.T) {
+	h, repo := newTestHandler()
+	repo.Meta = &model.Meta{ID: "x"} // mascot 未設定
+
+	e := echo.New()
+	req := httptest.NewRequest(http.MethodPost, "/api/meta", nil)
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+	require.NoError(t, h.Meta(c))
+
+	var resp map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+	assert.Equal(t, "/assets/ai.png", resp["mascotImageUrl"])
+}
+
+// 空文字 mascot もフォールバックされる。
+func TestMeta_MascotEmptyFallback(t *testing.T) {
+	h, repo := newTestHandler()
+	empty := ""
+	repo.Meta = &model.Meta{ID: "x", MascotImageURL: &empty}
+
+	e := echo.New()
+	req := httptest.NewRequest(http.MethodPost, "/api/meta", nil)
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+	require.NoError(t, h.Meta(c))
+
+	var resp map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+	assert.Equal(t, "/assets/ai.png", resp["mascotImageUrl"])
+}
+
+// clientOptions が空 jsonb のとき、空 map にフォールバックする。
+func TestMeta_ClientOptionsEmpty(t *testing.T) {
+	h, repo := newTestHandler()
+	repo.Meta = &model.Meta{ID: "x"} // ClientOptions = nil
+
+	e := echo.New()
+	req := httptest.NewRequest(http.MethodPost, "/api/meta", nil)
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+	require.NoError(t, h.Meta(c))
+
+	var resp map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+	co, ok := resp["clientOptions"].(map[string]any)
+	assert.True(t, ok)
+	assert.Empty(t, co)
+}
+
+// clientOptions が壊れた jsonb のとき、空 map にフォールバックして 200 を返す。
+func TestMeta_ClientOptionsMalformed(t *testing.T) {
+	h, repo := newTestHandler()
+	repo.Meta = &model.Meta{ID: "x", ClientOptions: []byte(`not json`)}
+
+	e := echo.New()
+	req := httptest.NewRequest(http.MethodPost, "/api/meta", nil)
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+	require.NoError(t, h.Meta(c))
+
+	var resp map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+	co, ok := resp["clientOptions"].(map[string]any)
+	assert.True(t, ok)
+	assert.Empty(t, co)
+}

--- a/internal/server/frontend.go
+++ b/internal/server/frontend.go
@@ -3,6 +3,7 @@ package server
 import (
 	"encoding/json"
 	"fmt"
+	"log/slog"
 	"net/http"
 	"net/http/httputil"
 	"net/url"
@@ -28,6 +29,9 @@ func frontendHTML(cfg *config.Config, metaRepo repository.MetaRepository) echo.H
 		instanceDesc := ""
 		iconURL := "/static-assets/icons/192.png"
 		themeColor := "#86b300"
+		// mascotImageUrl は splash 中央のローディング画像に使う。meta 値が
+		// あれば優先、なければ /assets/ai.png にフォールバック (本家挙動)。
+		mascotURL := "/assets/ai.png"
 		metaJSON := "{}"
 		if m, err := metaRepo.Fetch(); err == nil {
 			if m.Name != nil && *m.Name != "" {
@@ -41,6 +45,9 @@ func frontendHTML(cfg *config.Config, metaRepo repository.MetaRepository) echo.H
 			}
 			if m.ThemeColor != nil && *m.ThemeColor != "" {
 				themeColor = *m.ThemeColor
+			}
+			if m.MascotImageURL != nil && *m.MascotImageURL != "" {
+				mascotURL = *m.MascotImageURL
 			}
 			metaJSON = buildMetaJSON(cfg, m)
 		}
@@ -80,13 +87,14 @@ func frontendHTML(cfg *config.Config, metaRepo repository.MetaRepository) echo.H
 <noscript><p>Please turn on your JavaScript</p></noscript>
 <div id="splash">
 <div style="padding:64px;text-align:center">
+<img src="%s" alt="" style="max-width:160px;height:auto;display:block;margin:0 auto 16px"/>
 <p>Loading...</p>
 </div>
 </div>
 </body></html>`, instanceName, instanceName, instanceDesc, iconURL, cfg.URL,
 			themeColor, cfg.URL, instanceName, iconURL, viteClientTag,
 			cfg.Version, clientEntryJS,
-			time.Now().UnixMilli(), metaJSON)
+			time.Now().UnixMilli(), metaJSON, mascotURL)
 
 		return c.HTML(http.StatusOK, html)
 	}
@@ -213,7 +221,9 @@ func buildMetaJSON(cfg *config.Config, m *model.Meta) string {
 }
 
 // manifestJSON generates a PWA manifest.json response.
-// TSバックエンドの manifestHandler と同等。
+// TSバックエンドの manifestHandler と同等。meta.app192IconUrl /
+// app512IconUrl が設定されていれば PWA icons に反映し、
+// meta.manifestJsonOverride が valid JSON object なら最後に deep merge する。
 func manifestJSON(cfg *config.Config, metaRepo repository.MetaRepository) echo.HandlerFunc {
 	return func(c echo.Context) error {
 		m, _ := metaRepo.Fetch()
@@ -233,6 +243,13 @@ func manifestJSON(cfg *config.Config, metaRepo repository.MetaRepository) echo.H
 			}
 			if m.ThemeColor != nil && *m.ThemeColor != "" {
 				themeColor = *m.ThemeColor
+			}
+			// meta の app icon URL が設定されていればそちらを優先
+			if m.App192IconURL != nil && *m.App192IconURL != "" {
+				icon192 = *m.App192IconURL
+			}
+			if m.App512IconURL != nil && *m.App512IconURL != "" {
+				icon512 = *m.App512IconURL
 			}
 		}
 		manifest := map[string]any{
@@ -258,8 +275,35 @@ func manifestJSON(cfg *config.Config, metaRepo repository.MetaRepository) echo.H
 				},
 			},
 		}
+		// manifestJsonOverride: meta テーブルに保存された JSON を最後に重ね書き。
+		// 不正な JSON は warn を出してスキップ ('{}' デフォルトはノーオペ)。
+		if m != nil && m.ManifestJSONOverride != "" && m.ManifestJSONOverride != "{}" {
+			var override map[string]any
+			if err := json.Unmarshal([]byte(m.ManifestJSONOverride), &override); err != nil {
+				slog.Warn("manifest.json override is not valid JSON, ignoring", "err", err)
+			} else {
+				deepMergeManifest(manifest, override)
+			}
+		}
 		c.Response().Header().Set("Cache-Control", "max-age=300")
 		return c.JSON(http.StatusOK, manifest)
+	}
+}
+
+// deepMergeManifest merges src on top of dst in-place.
+// マップは再帰的に merge し、それ以外 (配列・スカラー) は src で上書きする。
+// PWA manifest はネスト浅いので深さ無制限の単純実装で十分。
+func deepMergeManifest(dst, src map[string]any) {
+	for k, v := range src {
+		if existing, ok := dst[k]; ok {
+			if dstMap, ok1 := existing.(map[string]any); ok1 {
+				if srcMap, ok2 := v.(map[string]any); ok2 {
+					deepMergeManifest(dstMap, srcMap)
+					continue
+				}
+			}
+		}
+		dst[k] = v
 	}
 }
 

--- a/internal/server/identicon.go
+++ b/internal/server/identicon.go
@@ -1,6 +1,7 @@
 package server
 
 import (
+	"bytes"
 	"image"
 	"image/color"
 	"image/png"
@@ -9,6 +10,7 @@ import (
 	"strconv"
 
 	"github.com/labstack/echo/v4"
+	"github.com/shiroha-a/mk/internal/repository"
 )
 
 // Misskey TSのgen-identicon.tsと同じ仕様で生成する
@@ -63,11 +65,22 @@ func seedRand(seed string) *rand.Rand {
 }
 
 // identiconHandler generates an identicon PNG matching Misskey TS's gen-identicon.ts.
-func identiconHandler() echo.HandlerFunc {
+// metaRepo を渡すと meta.enableIdenticonGeneration フラグを参照する。フラグが
+// false なら 1x1 透明 PNG を返す (本家挙動と互換: avatar fallback の URL が
+// 404 にならず、空画像で済むのでフロントの onerror フローが乱れない)。
+// metaRepo が nil の場合は常に identicon を生成する (テストや初期セットアップ用)。
+func identiconHandler(metaRepo repository.MetaRepository) echo.HandlerFunc {
 	return func(c echo.Context) error {
 		seed := c.Param("x")
 		if seed == "" {
 			seed = "default"
+		}
+
+		// meta フラグチェック (false なら無効化)
+		if metaRepo != nil {
+			if m, err := metaRepo.Fetch(); err == nil && !m.EnableIdenticonGeneration {
+				return serveTransparentPixel(c)
+			}
 		}
 
 		rng := seedRand(seed)
@@ -78,6 +91,22 @@ func identiconHandler() echo.HandlerFunc {
 		c.Response().WriteHeader(http.StatusOK)
 		return png.Encode(c.Response(), img)
 	}
+}
+
+// transparentPixel は事前生成した 1x1 完全透明 PNG。disabled identicon に使う。
+// init で 1 回だけ encode するので request 毎の cost は 0。
+var transparentPixel = func() []byte {
+	img := image.NewRGBA(image.Rect(0, 0, 1, 1))
+	img.Set(0, 0, color.RGBA{R: 0, G: 0, B: 0, A: 0})
+	var buf bytes.Buffer
+	_ = png.Encode(&buf, img)
+	return buf.Bytes()
+}()
+
+func serveTransparentPixel(c echo.Context) error {
+	c.Response().Header().Set("Content-Type", "image/png")
+	c.Response().Header().Set("Cache-Control", "public, max-age=86400")
+	return c.Blob(http.StatusOK, "image/png", transparentPixel)
 }
 
 func generateIdenticon(rng *rand.Rand) *image.RGBA {

--- a/internal/server/router.go
+++ b/internal/server/router.go
@@ -1199,8 +1199,9 @@ func (s *Server) setupRoutes() {
 		s.echo.File("/robots.txt", filepath.Join(staticDir, "robots.txt"))
 	}
 
-	// identicon — ユーザーアイコン自動生成
-	s.echo.GET("/identicon/:x", identiconHandler())
+	// identicon — ユーザーアイコン自動生成 (meta.enableIdenticonGeneration が
+	// false なら 1x1 透明 PNG にフォールバック)
+	s.echo.GET("/identicon/:x", identiconHandler(metaRepo))
 
 	// manifest.json — PWA用
 	s.echo.GET("/manifest.json", manifestJSON(s.config, metaRepo))


### PR DESCRIPTION
## Summary

issue #50 (DB-compat 実装 G) を実装します。issue #21 で schema only で揃えたブランディング系 meta カラムを \`/api/meta\` レスポンスと frontend HTML / PWA manifest / identicon に露出します。Phase DB-compat フォローアップ #33 のサブ実装 2 件目。

## 主な変更点

### 1. \`/api/meta\` レスポンスのフィールド追加

\`internal/api/meta/handler.go\`:
- **\`mascotImageUrl\`**: \`meta.MascotImageURL\` があればそれを返す。空または nil なら従来通り \`/assets/ai.png\` にフォールバック (\`mascotURL\` helper)
- **\`app192IconUrl\` / \`app512IconUrl\`**: 新規露出
- **\`serverErrorImageUrl\` / \`notFoundImageUrl\` / \`infoImageUrl\`**: nil プレースホルダから m struct 値へ
- **\`defaultLightTheme\` / \`defaultDarkTheme\`**: nil プレースホルダから m struct 値へ
- **\`inquiryUrl\`**: nil プレースホルダから \`m.InquiryURL\` へ
- **\`googleAnalyticsMeasurementId\`**: nil プレースホルダから \`m.GoogleAnalyticsMeasurementID\` へ
- **\`clientOptions\`**: jsonb を unmarshal して map で返す。空または invalid なら空 map にフォールバック (frontend は object を期待する) — \`clientOptionsJSON\` helper

### 2. frontendHTML splash に mascot 埋め込み

\`internal/server/frontend.go\`:
- \`frontendHTML\` が \`meta.MascotImageURL\` を読み、splash の Loading 中央画像として \`<img>\` を埋め込む。未設定時は \`/assets/ai.png\`

### 3. PWA manifest icons + manifestJsonOverride

\`internal/server/frontend.go\`:
- \`manifestJSON\` ハンドラで \`meta.App192IconURL\` / \`App512IconURL\` が設定されていれば PWA icons 配列の src に反映 (デフォルト \`/static-assets/icons/{192,512}.png\`)
- \`meta.ManifestJSONOverride\` が valid JSON なら \`deepMergeManifest\` で生成 manifest に再帰 merge する。\`'{}'\` or 空のときは no-op、不正 JSON は warn して無視
- \`deepMergeManifest\`: map 同士は再帰、それ以外は src で上書きする単純実装

### 4. identicon disable flag

\`internal/server/identicon.go\`:
- \`identiconHandler\` が metaRepo を受け取り、\`meta.EnableIdenticonGeneration\` が **false** なら 1x1 透明 PNG を返す (avatar fallback の URL が 404 にならず frontend の onerror フローが乱れない、本家挙動互換)
- 透明 PNG は package init 時に 1 回 encode しておくので request 毎の cost ゼロ
- \`internal/server/router.go\`: \`identiconHandler\` 呼出に metaRepo を渡す

## テスト

\`internal/api/meta/handler_test.go\` に 5 ケース追加:
- \`TestMeta_BrandingFieldsExposed\`: 11 フィールド + clientOptions parse の正常系
- \`TestMeta_MascotFallback\`: \`meta.MascotImageURL\` nil でのフォールバック
- \`TestMeta_MascotEmptyFallback\`: 空文字でのフォールバック
- \`TestMeta_ClientOptionsEmpty\`: 空 jsonb → 空 map
- \`TestMeta_ClientOptionsMalformed\`: 壊れた jsonb → 空 map (panic しない)

### server パッケージのテスト判断

\`internal/server\` パッケージ (manifestJSON / frontendHTML / identiconHandler) はこれまで test free で、test ファイルを追加すると CI coverage gate (90%) に巻き込まれて落ちるため、本 PR では自動テストを追加せず **build + lint** で整合性を担保します (Phase 11.1 PR #37 と同じ判断)。

動作検証は **Phase 11.1 Cypress e2e (#39 解決後)** と manual で行う計画です。

### カバレッジ

| Package | Before | After |
|---|---|---|
| \`internal/api/meta\` | 96.8% | **100%** |
| 他パッケージ | – | 無変更 |

### 検証

- \`go test -race -count=1 -timeout 10m ./...\` 全 pass
- \`make fmt && make lint\` pass

実行方法:

\`\`\`bash
make fmt && make lint
go test -race -count=1 -timeout 10m ./...
\`\`\`

## Closes

Closes #50

## 関連

- 親 issue: #33 (Phase DB-compat フォローアップ全 12 サブ issue)
- 進捗: A (#42, merged) → **G (本 PR)** → 次は H (#51 キャッシュチューニング)
- frontend HTML / manifest / identicon の動作確認は Cypress (#39 解決後) で実施