### PR TITLE
DB-compat J: user_profile.clientData / room jsonb 露出

### DIFF
--- a/internal/api/i/handler.go
+++ b/internal/api/i/handler.go
@@ -257,6 +257,11 @@ func (h *Handler) Me(c echo.Context) error {
 		resp["hardMutedWords"] = profile.HardMutedWords
 		resp["mutedInstances"] = profile.MutedInstances
 		resp["publicReactions"] = profile.PublicReactions
+		// clientData / room は jsonb を生のまま返すと frontend (本家) が
+		// オブジェクトとして parse するため、空/不正時は空オブジェクトに
+		// 正規化する。user が手動でキーを書き換えるだけなので scheme は持たない。
+		resp["clientData"] = jsonbObject(profile.ClientData)
+		resp["room"] = jsonbObject(profile.Room)
 	}
 
 	// フロントエンド互換性フィールド (Phase 4.5c / Phase 5)
@@ -341,6 +346,23 @@ type UpdateRequest struct {
 	AutoSensitive     *bool   `json:"autoSensitive"`
 	NoCrawle          *bool   `json:"noCrawle"`
 	PreventAiLearning *bool   `json:"preventAiLearning"`
+	// Room は frontend の「部屋」機能用の任意スキーマ jsonb。
+	// 本家も object をそのまま受け取って上書き保存する (部分マージはしない)。
+	Room json.RawMessage `json:"room"`
+}
+
+// jsonbObject normalizes a raw jsonb byte slice into map[string]any for the
+// Me response. Empty or malformed payloads become an empty object so the
+// frontend always sees a stable shape.
+func jsonbObject(raw []byte) any {
+	if len(raw) == 0 {
+		return map[string]any{}
+	}
+	var out map[string]any
+	if err := json.Unmarshal(raw, &out); err != nil || out == nil {
+		return map[string]any{}
+	}
+	return out
 }
 
 // Update handles POST /api/i/update.
@@ -377,6 +399,12 @@ func (h *Handler) Update(c echo.Context) error {
 	}
 	if req.Lang != nil {
 		in.Lang = &req.Lang
+	}
+	if len(req.Room) > 0 {
+		// json.RawMessage は親の Unmarshal が構文チェック済みの
+		// バイト列を格納する。改変されないよう独自のスライスにコピーする。
+		room := append(json.RawMessage(nil), req.Room...)
+		in.Room = &room
 	}
 
 	bundle, err := h.userService.UpdateProfile(me.ID, in)

--- a/internal/api/i/handler_test.go
+++ b/internal/api/i/handler_test.go
@@ -317,6 +317,85 @@ func TestMe_NoProfile(t *testing.T) {
 	assert.Equal(t, false, resp["hasUnreadNotification"])
 }
 
+func TestMe_ClientDataAndRoomExposed(t *testing.T) {
+	h, userRepo, _, _ := newTestHandler(t)
+
+	userRepo.Profiles["user1"] = &model.UserProfile{
+		UserID:     "user1",
+		ClientData: datatypes.JSON([]byte(`{"theme":"dark","sidebar":{"collapsed":true}}`)),
+		Room:       datatypes.JSON([]byte(`{"furnitures":[{"id":"chair1"}]}`)),
+		Fields:     datatypes.JSON([]byte("[]")),
+	}
+
+	user := &model.User{
+		ID:                "user1",
+		Username:          "cdroom",
+		AvatarDecorations: datatypes.JSON([]byte("[]")),
+	}
+
+	e := echo.New()
+	req := httptest.NewRequest(http.MethodPost, "/api/i", nil)
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+	c.Set(string(middleware.UserContextKey), user)
+
+	require.NoError(t, h.Me(c))
+
+	var resp map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+
+	cd, ok := resp["clientData"].(map[string]any)
+	require.True(t, ok, "clientData should be an object, got %T", resp["clientData"])
+	assert.Equal(t, "dark", cd["theme"])
+	sidebar, ok := cd["sidebar"].(map[string]any)
+	require.True(t, ok)
+	assert.Equal(t, true, sidebar["collapsed"])
+
+	room, ok := resp["room"].(map[string]any)
+	require.True(t, ok, "room should be an object")
+	furnitures, ok := room["furnitures"].([]any)
+	require.True(t, ok)
+	require.Len(t, furnitures, 1)
+}
+
+func TestMe_ClientDataAndRoomEmptyNormalized(t *testing.T) {
+	h, userRepo, _, _ := newTestHandler(t)
+
+	// profile が存在するが jsonb が空/不正なケース。
+	// frontend に安定した空 object を返すことを保証する。
+	userRepo.Profiles["user1"] = &model.UserProfile{
+		UserID:     "user1",
+		ClientData: nil,
+		Room:       datatypes.JSON([]byte("null")),
+		Fields:     datatypes.JSON([]byte("[]")),
+	}
+
+	user := &model.User{
+		ID:                "user1",
+		Username:          "empty",
+		AvatarDecorations: datatypes.JSON([]byte("[]")),
+	}
+
+	e := echo.New()
+	req := httptest.NewRequest(http.MethodPost, "/api/i", nil)
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+	c.Set(string(middleware.UserContextKey), user)
+
+	require.NoError(t, h.Me(c))
+
+	var resp map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+
+	cd, ok := resp["clientData"].(map[string]any)
+	require.True(t, ok, "clientData should normalize to {} when nil")
+	assert.Empty(t, cd)
+
+	room, ok := resp["room"].(map[string]any)
+	require.True(t, ok, "room should normalize to {} when payload is JSON null")
+	assert.Empty(t, room)
+}
+
 // --- Update ---
 
 func TestUpdate_Success(t *testing.T) {
@@ -351,6 +430,60 @@ func TestUpdate_InternalError(t *testing.T) {
 	user := &model.User{ID: "user1"}
 	rec := post(h.Update, `{"isLocked": true}`, user)
 	assert.Equal(t, http.StatusInternalServerError, rec.Code)
+}
+
+func TestUpdate_RoomAccepted(t *testing.T) {
+	h, repo, _, _ := newTestHandler(t)
+	user := &model.User{
+		ID:                "user1",
+		Username:          "user1",
+		AvatarDecorations: datatypes.JSON([]byte("[]")),
+	}
+	repo.Users["user1"] = user
+	repo.Profiles["user1"] = &model.UserProfile{UserID: "user1", Fields: datatypes.JSON([]byte("[]"))}
+
+	rec := post(h.Update, `{"room":{"furnitures":[{"id":"bed1"}],"seed":42}}`, user)
+	assert.Equal(t, http.StatusOK, rec.Code)
+
+	// profile 側に反映されていること。
+	got := repo.Profiles["user1"]
+	require.NotNil(t, got)
+	assert.JSONEq(t, `{"furnitures":[{"id":"bed1"}],"seed":42}`, string(got.Room))
+}
+
+func TestUpdate_RoomMalformedOuterJSONRejected(t *testing.T) {
+	h, repo, _, _ := newTestHandler(t)
+	user := &model.User{
+		ID:                "user1",
+		Username:          "user1",
+		AvatarDecorations: datatypes.JSON([]byte("[]")),
+	}
+	repo.Users["user1"] = user
+
+	// 親 JSON が壊れていれば c.Bind が失敗するため 400。
+	rec := post(h.Update, `{"room":{"broken":`, user)
+	assert.Equal(t, http.StatusBadRequest, rec.Code)
+}
+
+func TestUpdate_RoomOmittedLeavesUnchanged(t *testing.T) {
+	h, repo, _, _ := newTestHandler(t)
+	user := &model.User{
+		ID:                "user1",
+		Username:          "user1",
+		AvatarDecorations: datatypes.JSON([]byte("[]")),
+	}
+	repo.Users["user1"] = user
+	repo.Profiles["user1"] = &model.UserProfile{
+		UserID: "user1",
+		Room:   datatypes.JSON([]byte(`{"keep":true}`)),
+		Fields: datatypes.JSON([]byte("[]")),
+	}
+
+	rec := post(h.Update, `{"name":"renamed"}`, user)
+	assert.Equal(t, http.StatusOK, rec.Code)
+
+	got := repo.Profiles["user1"]
+	assert.JSONEq(t, `{"keep":true}`, string(got.Room))
 }
 
 // --- Pin ---

--- a/internal/core/user/user_service.go
+++ b/internal/core/user/user_service.go
@@ -2,6 +2,7 @@
 package user
 
 import (
+	"encoding/json"
 	"errors"
 	"strings"
 	"time"
@@ -123,6 +124,9 @@ type UpdateInput struct {
 	AutoSensitive     *bool
 	NoCrawle          *bool
 	PreventAiLearning *bool
+	// Room は jsonb 列に書き込む生バイト列。nil の場合は更新しない。
+	// 呼び出し側で JSON として妥当であることを保証する必要がある。
+	Room *json.RawMessage
 }
 
 // UpdateProfile applies the non-nil fields to the user and user_profile rows.
@@ -175,6 +179,11 @@ func (s *Service) UpdateProfile(userID string, in UpdateInput) (*UserWithProfile
 	}
 	if in.PreventAiLearning != nil {
 		profileFields["preventAiLearning"] = *in.PreventAiLearning
+	}
+	if in.Room != nil {
+		// GORM は map で渡された値を jsonb 列に直接書き込む。
+		// []byte を渡すと bytea 扱いされてしまうので string にキャストする。
+		profileFields["room"] = string(*in.Room)
 	}
 
 	if err := s.userRepo.UpdateUser(userID, userFields); err != nil {

--- a/internal/testutil/mock_repository.go
+++ b/internal/testutil/mock_repository.go
@@ -330,6 +330,20 @@ func applyProfileFields(p *model.UserProfile, fields map[string]any) {
 			if b, ok := v.(bool); ok {
 				p.UsePasswordLessLogin = b
 			}
+		case "room":
+			switch val := v.(type) {
+			case string:
+				p.Room = []byte(val)
+			case []byte:
+				p.Room = val
+			}
+		case "clientData":
+			switch val := v.(type) {
+			case string:
+				p.ClientData = []byte(val)
+			case []byte:
+				p.ClientData = val
+			}
 		}
 	}
 }


### PR DESCRIPTION
## Summary

Issue #33 (DB-compat フォローアップ) の J 項目。`user_profile` に同期追加済みの `clientData` / `room` jsonb 列を `/api/i` の読み書きに露出し、本家 Misskey のフロントエンド互換性を回復する。

## 主な変更点

- **`internal/api/i/handler.go`**
  - `Me()` のレスポンスに `clientData` / `room` を追加。`jsonbObject()` ヘルパーで nil / 空 / `null` 等を空オブジェクトに正規化する (frontend は object を期待するため)。
  - `UpdateRequest.Room` に `json.RawMessage` を追加。`c.Bind` で検証済みのバイト列を `UpdateInput.Room` へコピーして渡す。
- **`internal/core/user/user_service.go`**
  - `UpdateInput.Room *json.RawMessage` を追加。非 nil のときだけ `profileFields["room"] = string(raw)` として書き込む。`handler_extra.go` の achievements 書き込みと同じパターン。
- **`internal/testutil/mock_repository.go`**
  - `applyProfileFields` に `room` / `clientData` ケースを追加 (unit テストで書き込み検証ができるように)。

## テスト

既存: `go test ./...` 全緑。

追加:
- `TestMe_ClientDataAndRoomExposed` — 既存 jsonb がオブジェクトとして復元される
- `TestMe_ClientDataAndRoomEmptyNormalized` — `nil` / `null` が `{}` に正規化される
- `TestUpdate_RoomAccepted` — room を update すると profile に反映される
- `TestUpdate_RoomOmittedLeavesUnchanged` — room 未指定時は既存値が残る
- `TestUpdate_RoomMalformedOuterJSONRejected` — 親 JSON 破損時は 400 を返す

カバレッジ (race + atomic):
- \`internal/api/i\`: **96.0%**
- \`internal/core/user\`: **98.9%**

実行:
\`\`\`
go test -race -count=1 -timeout 10m -coverprofile=coverage.out -covermode=atomic ./internal/api/i/... ./internal/core/user/...
\`\`\`

## 関連

Closes #53
Part of #33