### PR TITLE
DB-compat I: signup policies (preserved / prohibited / ads)

### DIFF
--- a/internal/api/admin/handler.go
+++ b/internal/api/admin/handler.go
@@ -145,6 +145,9 @@ func (h *Handler) AccountsCreate(c echo.Context) error {
 		if err == signup.ErrInvalidUsername {
 			return c.JSON(http.StatusBadRequest, errResp("INVALID_PARAM", "Invalid username.", "3d81ceae-475f-4600-b2a8-2bc116157532"))
 		}
+		if err == signup.ErrUsernameReserved {
+			return c.JSON(http.StatusBadRequest, errResp("USED_USERNAME", "That username is reserved.", "4b54bee6-2c25-42c3-a10f-7d0d1fbd91f9"))
+		}
 		return c.JSON(http.StatusInternalServerError, errResp("INTERNAL_ERROR", "Internal error.", "5d37dbcb-891e-41ca-a3d6-e690c97775ac"))
 	}
 

--- a/internal/api/admin/handler_test.go
+++ b/internal/api/admin/handler_test.go
@@ -259,6 +259,27 @@ func TestAccountsCreate_WhitespaceOnlyUsername(t *testing.T) {
 	assert.Equal(t, http.StatusBadRequest, rec.Code)
 }
 
+func TestAccountsCreate_PreservedUsername(t *testing.T) {
+	// rootUser 済み + admin ユーザーがリクエストしている前提 (初回セットアップ
+	// ではないので preservedUsernames チェックが有効)。
+	h, userRepo, metaRepo, _ := newTestHandler(t)
+	rootID := "root1"
+	userRepo.Users[rootID] = &model.User{ID: rootID, Username: "root", UsernameLower: "root"}
+	metaRepo.Meta = &model.Meta{
+		ID:                 "x",
+		RootUserID:         &rootID,
+		PreservedUsernames: []string{"admin", "support"},
+	}
+
+	rec := doPost(h.AccountsCreate, `{"username":"admin","password":"pass"}`, &model.User{ID: rootID})
+	assert.Equal(t, http.StatusBadRequest, rec.Code)
+
+	var resp map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+	errObj := resp["error"].(map[string]any)
+	assert.Equal(t, "USED_USERNAME", errObj["code"])
+}
+
 func TestShowUsers_InvalidJSON(t *testing.T) {
 	h, _, _, _ := newTestHandler(t)
 	rec := doPost(h.ShowUsers, `invalid`, nil)

--- a/internal/api/i/handler.go
+++ b/internal/api/i/handler.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"errors"
 	"net/http"
+	"strings"
 	"time"
 
 	"github.com/labstack/echo/v4"
@@ -35,6 +36,14 @@ type Handler struct {
 	transferEnqueuer TransferEnqueuer
 	webauthnSvc      *twofactor.WebAuthnService
 	securityKeyRepo  repository.UserSecurityKeyRepository
+	metaRepo         repository.MetaRepository
+}
+
+// SetMetaRepo attaches a MetaRepository. When set, i/update enforces
+// meta.prohibitedWordsForNameOfUser against the display name. Tests that
+// don't need this validation can leave it unset.
+func (h *Handler) SetMetaRepo(r repository.MetaRepository) {
+	h.metaRepo = r
 }
 
 // SetWebAuthn attaches the WebAuthn service + security key repository.
@@ -365,6 +374,23 @@ func jsonbObject(raw []byte) any {
 	return out
 }
 
+// containsProhibitedWord reports whether name contains any entry from words
+// case-insensitively (substring match). Empty or whitespace-only entries are
+// skipped so a misconfigured empty element cannot ban every display name.
+func containsProhibitedWord(name string, words []string) bool {
+	lname := strings.ToLower(name)
+	for _, w := range words {
+		w = strings.TrimSpace(w)
+		if w == "" {
+			continue
+		}
+		if strings.Contains(lname, strings.ToLower(w)) {
+			return true
+		}
+	}
+	return false
+}
+
 // Update handles POST /api/i/update.
 func (h *Handler) Update(c echo.Context) error {
 	me := middleware.GetUser(c)
@@ -386,6 +412,14 @@ func (h *Handler) Update(c echo.Context) error {
 		PreventAiLearning: req.PreventAiLearning,
 	}
 	if req.Name != nil {
+		// 表示名の禁止ワードチェック。meta 未注入 / 未設定時は素通りする。
+		// 本家 Misskey と同様に部分一致 case-insensitive で、空文字 ("") の
+		// クリアリクエストは検査対象外 (ユーザー体験上必要)。
+		if h.metaRepo != nil && *req.Name != "" {
+			if m, err := h.metaRepo.Fetch(); err == nil && containsProhibitedWord(*req.Name, m.ProhibitedWordsForNameOfUser) {
+				return c.JSON(http.StatusBadRequest, errEnvelope("Your new name contains prohibited words.", "NAME_CONTAINS_PROHIBITED_WORDS", "0b3f9f6a-2e7d-4c2c-9d7a-8c6f9b2e1a44"))
+			}
+		}
 		in.Name = &req.Name
 	}
 	if req.Description != nil {

--- a/internal/api/i/handler_test.go
+++ b/internal/api/i/handler_test.go
@@ -465,6 +465,74 @@ func TestUpdate_RoomMalformedOuterJSONRejected(t *testing.T) {
 	assert.Equal(t, http.StatusBadRequest, rec.Code)
 }
 
+func TestUpdate_ProhibitedWordRejected(t *testing.T) {
+	h, repo, _, _ := newTestHandler(t)
+	user := &model.User{
+		ID:                "user1",
+		Username:          "user1",
+		AvatarDecorations: datatypes.JSON([]byte("[]")),
+	}
+	repo.Users["user1"] = user
+
+	metaRepo := testutil.NewMockMetaRepository()
+	metaRepo.Meta = &model.Meta{ID: "x", ProhibitedWordsForNameOfUser: []string{"Spam", "foo"}}
+	h.SetMetaRepo(metaRepo)
+
+	// "ContainsSpamString" は "Spam" を含むのでブロック (case-insensitive)。
+	rec := post(h.Update, `{"name":"ContainsSPAMString"}`, user)
+	assert.Equal(t, http.StatusBadRequest, rec.Code)
+}
+
+func TestUpdate_ProhibitedWordAllowsClear(t *testing.T) {
+	h, repo, _, _ := newTestHandler(t)
+	user := &model.User{
+		ID:                "user1",
+		Username:          "user1",
+		AvatarDecorations: datatypes.JSON([]byte("[]")),
+	}
+	repo.Users["user1"] = user
+
+	metaRepo := testutil.NewMockMetaRepository()
+	metaRepo.Meta = &model.Meta{ID: "x", ProhibitedWordsForNameOfUser: []string{"spam"}}
+	h.SetMetaRepo(metaRepo)
+
+	// 空文字 (クリア) は検査対象外 — ユーザーが表示名を外せなくなるのを避ける。
+	rec := post(h.Update, `{"name":""}`, user)
+	assert.Equal(t, http.StatusOK, rec.Code)
+}
+
+func TestUpdate_ProhibitedWordNoMetaSkipped(t *testing.T) {
+	h, repo, _, _ := newTestHandler(t)
+	user := &model.User{
+		ID:                "user1",
+		Username:          "user1",
+		AvatarDecorations: datatypes.JSON([]byte("[]")),
+	}
+	repo.Users["user1"] = user
+
+	// metaRepo 未設定なら検査をスキップ。禁止ワードらしき値でも通る。
+	rec := post(h.Update, `{"name":"spammer"}`, user)
+	assert.Equal(t, http.StatusOK, rec.Code)
+}
+
+func TestUpdate_ProhibitedWordEmptyListSkipped(t *testing.T) {
+	h, repo, _, _ := newTestHandler(t)
+	user := &model.User{
+		ID:                "user1",
+		Username:          "user1",
+		AvatarDecorations: datatypes.JSON([]byte("[]")),
+	}
+	repo.Users["user1"] = user
+
+	metaRepo := testutil.NewMockMetaRepository()
+	// 空要素だけが入っているケース: 空文字比較で全 name がヒットしないことを検査する。
+	metaRepo.Meta = &model.Meta{ID: "x", ProhibitedWordsForNameOfUser: []string{"", "   "}}
+	h.SetMetaRepo(metaRepo)
+
+	rec := post(h.Update, `{"name":"anything"}`, user)
+	assert.Equal(t, http.StatusOK, rec.Code)
+}
+
 func TestUpdate_RoomOmittedLeavesUnchanged(t *testing.T) {
 	h, repo, _, _ := newTestHandler(t)
 	user := &model.User{

--- a/internal/api/meta/handler.go
+++ b/internal/api/meta/handler.go
@@ -3,6 +3,7 @@ package meta
 import (
 	"encoding/json"
 	"net/http"
+	"time"
 
 	"github.com/labstack/echo/v4"
 	"github.com/shiroha-a/mk/internal/config"
@@ -13,11 +14,19 @@ import (
 type Handler struct {
 	config   *config.Config
 	metaRepo repository.MetaRepository
+	adRepo   repository.AdRepository
 }
 
 // NewHandler creates a new meta Handler.
 func NewHandler(cfg *config.Config, metaRepo repository.MetaRepository) *Handler {
 	return &Handler{config: cfg, metaRepo: metaRepo}
+}
+
+// SetAdRepo wires an AdRepository for the `ads` field on the /api/meta
+// response. When unset, ads is returned as an empty array so existing tests
+// without ad wiring keep passing.
+func (h *Handler) SetAdRepo(r repository.AdRepository) {
+	h.adRepo = r
 }
 
 // Meta returns server metadata.
@@ -83,8 +92,8 @@ func (h *Handler) Meta(c echo.Context) error {
 		"translatorAvailable":          false,
 		"enableEmail":                  m.EnableEmail,
 		"enableUrlPreview":             false,
-		"ads":                          []any{},
-		"notesPerOneAd":                0,
+		"ads":                          h.serializeActiveAds(),
+		"notesPerOneAd":                m.NotesPerOneAd,
 		"mediaProxy":                   "",
 		"cacheRemoteSensitiveFiles":    m.CacheRemoteSensitiveFiles,
 		"requireSetup":                 false,
@@ -191,6 +200,32 @@ func clientOptionsJSON(raw []byte) any {
 	var out map[string]any
 	if err := json.Unmarshal(raw, &out); err != nil || out == nil {
 		return map[string]any{}
+	}
+	return out
+}
+
+// serializeActiveAds fetches currently-active ads via adRepo and projects
+// them into the Misskey-compatible shape. Returns an empty slice when the
+// repo is unwired (tests) or fetch fails, keeping the response stable.
+// フロントエンドが notesPerOneAd と組み合わせて timeline に差し込む前提。
+func (h *Handler) serializeActiveAds() []map[string]any {
+	if h.adRepo == nil {
+		return []map[string]any{}
+	}
+	ads, err := h.adRepo.ListActive(time.Now())
+	if err != nil || len(ads) == 0 {
+		return []map[string]any{}
+	}
+	out := make([]map[string]any, 0, len(ads))
+	for _, a := range ads {
+		out = append(out, map[string]any{
+			"id":        a.ID,
+			"url":       a.URL,
+			"place":     a.Place,
+			"ratio":     a.Ratio,
+			"imageUrl":  a.ImageURL,
+			"dayOfWeek": a.DayOfWeek,
+		})
 	}
 	return out
 }

--- a/internal/api/meta/handler_test.go
+++ b/internal/api/meta/handler_test.go
@@ -5,6 +5,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"testing"
+	"time"
 
 	"github.com/labstack/echo/v4"
 	"github.com/shiroha-a/mk/internal/config"
@@ -217,4 +218,87 @@ func TestMeta_ClientOptionsMalformed(t *testing.T) {
 	co, ok := resp["clientOptions"].(map[string]any)
 	assert.True(t, ok)
 	assert.Empty(t, co)
+}
+
+// --- Ads / notesPerOneAd (issue #52) ---
+
+// stubAdRepo implements repository.AdRepository for tests without a real DB.
+type stubAdRepo struct {
+	ads []*model.Ad
+	err error
+}
+
+func (s *stubAdRepo) ListActive(_ time.Time) ([]*model.Ad, error) {
+	return s.ads, s.err
+}
+
+// /api/meta returns the active ads list from AdRepository and notesPerOneAd
+// from meta. Frontend reads these and handles injection.
+func TestMeta_AdsExposed(t *testing.T) {
+	h, metaRepo := newTestHandler()
+	metaRepo.Meta = &model.Meta{ID: "x", NotesPerOneAd: 5}
+	h.SetAdRepo(&stubAdRepo{ads: []*model.Ad{
+		{ID: "ad1", URL: "https://example.com", Place: "square", Ratio: 1, ImageURL: "https://example.com/i.png", DayOfWeek: 0},
+		{ID: "ad2", URL: "https://e2.example.com", Place: "horizontal", Ratio: 2, ImageURL: "https://e2.example.com/i.png", DayOfWeek: 3},
+	}})
+
+	e := echo.New()
+	req := httptest.NewRequest(http.MethodPost, "/api/meta", nil)
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+	require.NoError(t, h.Meta(c))
+
+	var resp map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+
+	assert.Equal(t, float64(5), resp["notesPerOneAd"])
+
+	ads, ok := resp["ads"].([]any)
+	require.True(t, ok, "ads should be an array")
+	require.Len(t, ads, 2)
+	first := ads[0].(map[string]any)
+	assert.Equal(t, "ad1", first["id"])
+	assert.Equal(t, "square", first["place"])
+	assert.Equal(t, float64(1), first["ratio"])
+}
+
+// AdRepository が未設定の場合 (既存テスト互換) は空配列が返る。
+func TestMeta_AdsUnwiredReturnsEmpty(t *testing.T) {
+	h, metaRepo := newTestHandler()
+	metaRepo.Meta = &model.Meta{ID: "x", NotesPerOneAd: 0}
+
+	e := echo.New()
+	req := httptest.NewRequest(http.MethodPost, "/api/meta", nil)
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+	require.NoError(t, h.Meta(c))
+
+	var resp map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+	ads, ok := resp["ads"].([]any)
+	require.True(t, ok)
+	assert.Empty(t, ads)
+	assert.Equal(t, float64(0), resp["notesPerOneAd"])
+}
+
+// AdRepository がエラーを返したとき、meta エンドポイント全体は落とさずに
+// ads を空として継続する (DB 障害で /api/meta 全体が 500 になると起動ページ
+// がロードできない)。
+func TestMeta_AdsRepoErrorFallsBackToEmpty(t *testing.T) {
+	h, metaRepo := newTestHandler()
+	metaRepo.Meta = &model.Meta{ID: "x"}
+	h.SetAdRepo(&stubAdRepo{err: assert.AnError})
+
+	e := echo.New()
+	req := httptest.NewRequest(http.MethodPost, "/api/meta", nil)
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+	require.NoError(t, h.Meta(c))
+	assert.Equal(t, http.StatusOK, rec.Code)
+
+	var resp map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+	ads, ok := resp["ads"].([]any)
+	require.True(t, ok)
+	assert.Empty(t, ads)
 }

--- a/internal/core/signup/signup_service.go
+++ b/internal/core/signup/signup_service.go
@@ -19,6 +19,10 @@ var (
 	ErrUsernameAlreadyExists = errors.New("username already exists")
 	// ErrInvalidUsername is returned when the username is invalid.
 	ErrInvalidUsername = errors.New("invalid username")
+	// ErrUsernameReserved is returned when the username matches an entry in
+	// meta.preservedUsernames (case-insensitive). 初回セットアップ時は root
+	// ユーザー作成を妨げないため、このチェックはスキップする。
+	ErrUsernameReserved = errors.New("username is reserved")
 )
 
 // WebhookHook is invoked after a new local user has been created so that
@@ -73,6 +77,15 @@ func (s *Service) Signup(username, password string, isInitialSetup bool) (*Signu
 	lower := strings.ToLower(username)
 	if _, err := s.userRepo.FindByUsernameLower(lower, nil); err == nil {
 		return nil, ErrUsernameAlreadyExists
+	}
+
+	// meta.preservedUsernames チェック。初回セットアップ (root ユーザー作成) は
+	// admin / root が予約ワードに含まれうるので除外する。meta fetch 失敗時は
+	// ベストエフォートで通過させる (オンライン性を優先)。
+	if !isInitialSetup {
+		if meta, err := s.metaRepo.Fetch(); err == nil && isReservedUsername(lower, meta.PreservedUsernames) {
+			return nil, ErrUsernameReserved
+		}
 	}
 
 	// パスワードハッシュ (bcrypt.DefaultCostで有効なパスワードに対して失敗しない)
@@ -143,4 +156,17 @@ func generateToken() string {
 	b := make([]byte, 8)
 	_, _ = rand.Read(b)
 	return hex.EncodeToString(b)
+}
+
+// isReservedUsername reports whether lower (already lowercased) matches any
+// entry in reserved case-insensitively. Entries in reserved are trimmed and
+// lowercased before comparison so DB-side whitespace noise does not defeat
+// the check.
+func isReservedUsername(lower string, reserved []string) bool {
+	for _, r := range reserved {
+		if strings.EqualFold(strings.TrimSpace(r), lower) {
+			return true
+		}
+	}
+	return false
 }

--- a/internal/core/signup/signup_service_test.go
+++ b/internal/core/signup/signup_service_test.go
@@ -81,6 +81,39 @@ func TestSignup_TooLongUsername(t *testing.T) {
 	assert.ErrorIs(t, err, signup.ErrInvalidUsername)
 }
 
+func TestSignup_PreservedUsernameRejected(t *testing.T) {
+	svc, _, metaRepo := newTestService(t)
+	// meta.preservedUsernames に "admin" が入っている想定。
+	metaRepo.Meta.PreservedUsernames = []string{"admin", "root", "System"}
+
+	_, err := svc.Signup("admin", "pass", false)
+	assert.ErrorIs(t, err, signup.ErrUsernameReserved)
+
+	// case-insensitive (slot "System" を大文字で登録、小文字で試行)
+	_, err = svc.Signup("SYSTEM", "pass", false)
+	assert.ErrorIs(t, err, signup.ErrUsernameReserved)
+}
+
+func TestSignup_PreservedUsernameBypassedOnInitialSetup(t *testing.T) {
+	// 初回セットアップ時は root / admin が予約ワードでも作成可能にする。
+	// そうでないと本家デフォルトで admin / root が永久に作成できなくなる。
+	svc, _, metaRepo := newTestService(t)
+	metaRepo.Meta.PreservedUsernames = []string{"admin"}
+
+	result, err := svc.Signup("admin", "pass", true)
+	require.NoError(t, err)
+	assert.NotNil(t, result)
+}
+
+func TestSignup_PreservedUsernameAllowsOthers(t *testing.T) {
+	svc, _, metaRepo := newTestService(t)
+	metaRepo.Meta.PreservedUsernames = []string{"admin"}
+
+	result, err := svc.Signup("alice", "pass", false)
+	require.NoError(t, err)
+	assert.Equal(t, "alice", result.User.Username)
+}
+
 // --- Failing repo tests ---
 
 type failingCreateUserRepo struct {

--- a/internal/repository/ad.go
+++ b/internal/repository/ad.go
@@ -1,0 +1,39 @@
+package repository
+
+import (
+	"time"
+
+	"github.com/shiroha-a/mk/internal/model"
+	"gorm.io/gorm"
+)
+
+// AdRepository provides read access to the `ad` table for meta / timeline
+// ad exposure. Writes currently live in admin/handler_stubs.go with direct
+// DB access; this interface is scoped to the read side that the public
+// /api/meta endpoint needs.
+type AdRepository interface {
+	// ListActive returns ads whose window contains `now` (startsAt <= now
+	// < expiresAt). Ordering is by id DESC so newest ads come first, which
+	// matches the admin list order.
+	ListActive(now time.Time) ([]*model.Ad, error)
+}
+
+type adRepository struct {
+	db *gorm.DB
+}
+
+// NewAdRepository constructs the default AdRepository.
+func NewAdRepository(db *gorm.DB) AdRepository {
+	return &adRepository{db: db}
+}
+
+func (r *adRepository) ListActive(now time.Time) ([]*model.Ad, error) {
+	var ads []*model.Ad
+	if err := r.db.
+		Where(`"startsAt" <= ? AND "expiresAt" > ?`, now, now).
+		Order(`id DESC`).
+		Find(&ads).Error; err != nil {
+		return nil, err
+	}
+	return ads, nil
+}

--- a/internal/repository/ad_test.go
+++ b/internal/repository/ad_test.go
@@ -1,0 +1,69 @@
+package repository
+
+import (
+	"testing"
+	"time"
+
+	"github.com/shiroha-a/mk/internal/model"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func cleanupAd(t *testing.T, id string) {
+	t.Helper()
+	testDB.Exec(`DELETE FROM "ad" WHERE id = ?`, id)
+}
+
+func TestAdRepository_ListActive(t *testing.T) {
+	repo := NewAdRepository(testDB)
+	now := time.Now()
+
+	active := &model.Ad{
+		ID:        "ad_active",
+		URL:       "https://example.com/a",
+		ImageURL:  "https://example.com/a.png",
+		Place:     "square",
+		Priority:  "middle",
+		Ratio:     1,
+		StartsAt:  now.Add(-1 * time.Hour),
+		ExpiresAt: now.Add(1 * time.Hour),
+	}
+	expired := &model.Ad{
+		ID:        "ad_expired",
+		URL:       "https://example.com/b",
+		ImageURL:  "https://example.com/b.png",
+		Place:     "square",
+		Priority:  "middle",
+		Ratio:     1,
+		StartsAt:  now.Add(-2 * time.Hour),
+		ExpiresAt: now.Add(-1 * time.Hour),
+	}
+	future := &model.Ad{
+		ID:        "ad_future",
+		URL:       "https://example.com/c",
+		ImageURL:  "https://example.com/c.png",
+		Place:     "square",
+		Priority:  "middle",
+		Ratio:     1,
+		StartsAt:  now.Add(1 * time.Hour),
+		ExpiresAt: now.Add(2 * time.Hour),
+	}
+
+	require.NoError(t, testDB.Create(active).Error)
+	defer cleanupAd(t, active.ID)
+	require.NoError(t, testDB.Create(expired).Error)
+	defer cleanupAd(t, expired.ID)
+	require.NoError(t, testDB.Create(future).Error)
+	defer cleanupAd(t, future.ID)
+
+	got, err := repo.ListActive(now)
+	require.NoError(t, err)
+
+	ids := make(map[string]bool, len(got))
+	for _, a := range got {
+		ids[a.ID] = true
+	}
+	assert.True(t, ids["ad_active"], "active ad should be returned")
+	assert.False(t, ids["ad_expired"], "expired ad should not be returned")
+	assert.False(t, ids["ad_future"], "future ad should not be returned")
+}

--- a/internal/server/router.go
+++ b/internal/server/router.go
@@ -370,6 +370,7 @@ func (s *Server) setupRoutes() {
 
 	// Meta endpoint (public)
 	metaHandler := meta.NewHandler(s.config, metaRepo)
+	metaHandler.SetAdRepo(repository.NewAdRepository(s.db))
 	api.POST("/meta", metaHandler.Meta)
 	api.POST("/ping", metaHandler.Ping)
 
@@ -573,6 +574,7 @@ func (s *Server) setupRoutes() {
 	iHandler := i.NewHandler(userService, idGen)
 	iHandler.SetRoleProvider(roleService)
 	iHandler.SetRegistryRepo(registryRepo)
+	iHandler.SetMetaRepo(metaRepo)
 	if webauthnSvc != nil {
 		iHandler.SetWebAuthn(webauthnSvc, userSecurityKeyRepo)
 	}


### PR DESCRIPTION
## Summary

Issue #33 (DB-compat フォローアップ) の I 項目。signup / 表示名 / 広告露出の 3 機能を実装。item 4 (bannedEmailDomains) は email 経路を所有する #47 へ統合 (issue #47 にコメント済み)。

## 主な変更点

### Item 2: preservedUsernames (signup block)
- \`internal/core/signup/signup_service.go\`: \`Signup()\` が \`meta.preservedUsernames\` を case-insensitive に照合し、ヒットしたら新規エラー \`ErrUsernameReserved\` を返す。
- 初回セットアップ (rootUserId 未設定) はチェックをバイパス (本家デフォルトの \`admin\` / \`root\` プリセットが作れなくなるため)。
- \`internal/api/admin/handler.go\`: \`AccountsCreate\` で上記エラーを \`400 USED_USERNAME\` にマップ。

### Item 3: prohibitedWordsForNameOfUser (display name)
- \`internal/api/i/handler.go\`: \`SetMetaRepo\` で metaRepo を注入できるようにし、\`Update\` が name 変更時に \`meta.prohibitedWordsForNameOfUser\` を substring case-insensitive で検査。
- 表示名クリア (空文字) は検査対象外 (UI 上で名前を外せなくなるのを回避)。
- metaRepo 未注入または list が空要素のみの場合は素通り。
- Issue 文言は「username 変更経路」だが Misskey の username は immutable なので、本家同様 \`user.name\` (表示名) を対象にしている。

### Item 1: ads exposure via /api/meta
- \`internal/repository/ad.go\`: 新規 \`AdRepository\` interface + 実装。\`ListActive(now)\` で \`startsAt <= now < expiresAt\` の広告を返す。
- \`internal/api/meta/handler.go\`: \`SetAdRepo\` で注入、\`/api/meta\` の \`ads\` フィールドに active 広告、\`notesPerOneAd\` は meta から直接返す。AdRepo 未設定 / エラー時は空配列にフォールバック (起動中に DB 障害があっても meta 全体は 200 を維持)。
- \`internal/server/router.go\`: AdRepository と i.Handler への metaRepo を wire。
- **設計注記**: Issue は「timeline 取得経路で広告差し込み」と書いているが、本家 Misskey は \`ads\` + \`notesPerOneAd\` を \`/api/meta\` で返し、フロントエンドがタイムライン描画時に差し込む。サーバー側で note 列に広告オブジェクトを混入する方式は本家と互換性がないため採用しない。

### Item 4: bannedEmailDomains → #47 へ移管
signup / update-email いずれも email 経路に依存する (現状 signup に email パラメータがない) ため、email 経路を新規追加する #47 に統合。#47 にコメントで引き継ぎ済み。

## テスト

追加:
- \`TestSignup_PreservedUsernameRejected\` / \`_BypassedOnInitialSetup\` / \`_AllowsOthers\`
- \`TestAccountsCreate_PreservedUsername\` (admin handler path + \`USED_USERNAME\` コード確認)
- \`TestUpdate_ProhibitedWordRejected\` / \`_AllowsClear\` / \`_NoMetaSkipped\` / \`_EmptyListSkipped\`
- \`TestMeta_AdsExposed\` / \`_AdsUnwiredReturnsEmpty\` / \`_AdsRepoErrorFallsBackToEmpty\`
- \`TestAdRepository_ListActive\` (実 PostgreSQL via testcontainers)

カバレッジ:
- \`internal/api/i\`: **96.1%**
- \`internal/api/meta\`: **100.0%**
- \`internal/core/signup\`: **97.6%**
- \`internal/api/admin\`: **61.6%** (60% gate)
- \`internal/repository\`: **90.8%**

実行:
\`\`\`
go test -race -count=1 -timeout 10m ./...
\`\`\`

## 関連

Closes #52
Part of #33
Item 4 が統合された: #47