### PR TITLE
DB-compat B: admin tools (IP logging / user_memo / promo_note / singleUserMode)

### DIFF
--- a/internal/api/admin/handler.go
+++ b/internal/api/admin/handler.go
@@ -27,6 +27,7 @@ type Handler struct {
 	emojiRepo      repository.EmojiRepository
 	driveFileRepo  repository.DriveFileRepository
 	adminDB        *gorm.DB
+	userIPRepo     repository.UserIPRepository
 	queueInspector QueueInspector
 	emojiEnqueuer  EmojiImportEnqueuer
 	idGen          id.Generator
@@ -74,6 +75,11 @@ func (h *Handler) SetDriveFileRepo(r repository.DriveFileRepository) {
 // SetAdminDB attaches a DB connection for ad/invite/relay operations.
 func (h *Handler) SetAdminDB(db *gorm.DB) {
 	h.adminDB = db
+}
+
+// SetUserIPRepo attaches a UserIPRepository for admin/get-user-ips.
+func (h *Handler) SetUserIPRepo(r repository.UserIPRepository) {
+	h.userIPRepo = r
 }
 
 // SetQueueInspector attaches a queue inspector for admin queue endpoints.

--- a/internal/api/admin/handler_stubs.go
+++ b/internal/api/admin/handler_stubs.go
@@ -12,6 +12,7 @@ import (
 	"github.com/shiroha-a/mk/internal/queue"
 	"github.com/shiroha-a/mk/internal/server/middleware"
 	"golang.org/x/crypto/bcrypt"
+	"gorm.io/gorm/clause"
 )
 
 // --- accounts ---
@@ -90,7 +91,27 @@ func (h *Handler) GetTableStats(c echo.Context) error {
 
 // GetUserIPs handles POST /api/admin/get-user-ips.
 func (h *Handler) GetUserIPs(c echo.Context) error {
-	return c.JSON(http.StatusOK, []any{})
+	if h.userIPRepo == nil {
+		return c.JSON(http.StatusOK, []any{})
+	}
+	var req struct {
+		UserID string `json:"userId"`
+	}
+	if err := c.Bind(&req); err != nil || req.UserID == "" {
+		return c.JSON(http.StatusBadRequest, errResp("INVALID_PARAM", "userId is required.", "3d81ceae-475f-4600-b2a8-2bc116157532"))
+	}
+	ips, err := h.userIPRepo.ListByUser(req.UserID, 30)
+	if err != nil {
+		return c.JSON(http.StatusOK, []any{})
+	}
+	result := make([]map[string]any, 0, len(ips))
+	for _, ip := range ips {
+		result = append(result, map[string]any{
+			"ip":        ip.IP,
+			"createdAt": ip.CreatedAt.UTC().Format("2006-01-02T15:04:05.000Z"),
+		})
+	}
+	return c.JSON(http.StatusOK, result)
 }
 
 // ResetPassword handles POST /api/admin/reset-password.
@@ -756,8 +777,28 @@ func (h *Handler) InviteList(c echo.Context) error {
 
 // PromoCreate handles POST /api/admin/promo/create.
 func (h *Handler) PromoCreate(c echo.Context) error {
-	// プロモノート作成 (ノートを広告として表示)
-	return c.NoContent(http.StatusNoContent) // 将来対応
+	if h.adminDB == nil {
+		return c.NoContent(http.StatusNoContent)
+	}
+	var req struct {
+		NoteID    string `json:"noteId"`
+		ExpiresAt int64  `json:"expiresAt"`
+	}
+	if err := c.Bind(&req); err != nil || req.NoteID == "" {
+		return c.JSON(http.StatusBadRequest, errResp("INVALID_PARAM", "noteId is required.", "3d81ceae-475f-4600-b2a8-2bc116157532"))
+	}
+	u := middleware.GetUser(c)
+	userID := ""
+	if u != nil {
+		userID = u.ID
+	}
+	promo := &model.PromoNote{
+		NoteID:    req.NoteID,
+		ExpiresAt: time.Unix(req.ExpiresAt/1000, 0),
+		UserID:    userID,
+	}
+	h.adminDB.Clauses(clause.OnConflict{DoNothing: true}).Create(promo)
+	return c.NoContent(http.StatusNoContent)
 }
 
 // --- queue ---

--- a/internal/api/admin/handler_stubs_test.go
+++ b/internal/api/admin/handler_stubs_test.go
@@ -12,6 +12,11 @@ import (
 
 var adminUser = &model.User{ID: "admin1"}
 
+type stubIPRepo struct{}
+
+func (s *stubIPRepo) Upsert(_, _ string) error                             { return nil }
+func (s *stubIPRepo) ListByUser(_ string, _ int) ([]*model.UserIP, error) { return nil, nil }
+
 // stubEmojiImportEnqueuer records the last payload and optionally returns err.
 type stubEmojiImportEnqueuer struct {
 	lastUserID string
@@ -146,9 +151,22 @@ func TestGetTableStats(t *testing.T) {
 	h, _, _, _ := newTestHandler(t)
 	assert.Equal(t, http.StatusOK, doPost(h.GetTableStats, `{}`, adminUser).Code)
 }
-func TestGetUserIPs(t *testing.T) {
+func TestGetUserIPs_NilRepo(t *testing.T) {
 	h, _, _, _ := newTestHandler(t)
 	assert.Equal(t, http.StatusOK, doPost(h.GetUserIPs, `{}`, adminUser).Code)
+}
+
+func TestGetUserIPs_InvalidParam(t *testing.T) {
+	h, _, _, _ := newTestHandler(t)
+	h.SetUserIPRepo(&stubIPRepo{})
+	assert.Equal(t, http.StatusBadRequest, doPost(h.GetUserIPs, `{}`, adminUser).Code)
+}
+
+func TestGetUserIPs_Success(t *testing.T) {
+	h, _, _, _ := newTestHandler(t)
+	h.SetUserIPRepo(&stubIPRepo{})
+	rec := doPost(h.GetUserIPs, `{"userId":"u1"}`, adminUser)
+	assert.Equal(t, http.StatusOK, rec.Code)
 }
 func TestResetPasswordAdmin_Empty(t *testing.T) {
 	h, _, _, _ := newTestHandler(t)

--- a/internal/api/admin/handler_stubs_test.go
+++ b/internal/api/admin/handler_stubs_test.go
@@ -14,7 +14,7 @@ var adminUser = &model.User{ID: "admin1"}
 
 type stubIPRepo struct{}
 
-func (s *stubIPRepo) Upsert(_, _ string) error                             { return nil }
+func (s *stubIPRepo) Upsert(_, _ string) error                            { return nil }
 func (s *stubIPRepo) ListByUser(_ string, _ int) ([]*model.UserIP, error) { return nil, nil }
 
 // stubEmojiImportEnqueuer records the last payload and optionally returns err.

--- a/internal/api/meta/handler.go
+++ b/internal/api/meta/handler.go
@@ -97,6 +97,7 @@ func (h *Handler) Meta(c echo.Context) error {
 		"mediaProxy":                   "",
 		"cacheRemoteSensitiveFiles":    m.CacheRemoteSensitiveFiles,
 		"requireSetup":                 false,
+		"singleUserMode":               m.SingleUserMode,
 		"providesTarball":              false,
 		"maxFileSize":                  h.config.MaxFileSize,
 		"proxyAccountName":             nil,

--- a/internal/api/signin/handler.go
+++ b/internal/api/signin/handler.go
@@ -16,12 +16,25 @@ import (
 	"golang.org/x/crypto/bcrypt"
 )
 
+// IPLogger records user IPs on successful authentication.
+type IPLogger interface {
+	Upsert(userID, ip string) error
+}
+
 // Handler handles signin-related API endpoints.
 type Handler struct {
 	userRepo        repository.UserRepository
 	webauthnSvc     *twofactor.WebAuthnService
 	securityKeyRepo repository.UserSecurityKeyRepository
 	captchaSvc      *captcha.Service
+	ipLogger        IPLogger
+	ipLoggingOn     bool
+}
+
+// SetIPLogger attaches an IPLogger and enables IP logging.
+func (h *Handler) SetIPLogger(logger IPLogger, enabled bool) {
+	h.ipLogger = logger
+	h.ipLoggingOn = enabled
 }
 
 // NewHandler creates a new signin Handler.
@@ -105,15 +118,7 @@ func (h *Handler) Signin(c echo.Context) error {
 	}
 
 	// 認証成功
-	token := ""
-	if user.Token != nil {
-		token = *user.Token
-	}
-	return c.JSON(http.StatusOK, map[string]any{
-		"finished": true,
-		"id":       user.ID,
-		"i":        token,
-	})
+	return h.ok(c, user)
 }
 
 // SigninFlow handles POST /api/signin-flow.
@@ -235,20 +240,20 @@ func (h *Handler) SigninFlow(c echo.Context) error {
 			if h.securityKeyRepo != nil {
 				_ = h.securityKeyRepo.UpdateCounter(encodeCredID(cred.ID), int64(cred.Authenticator.SignCount))
 			}
-			return ok(c, user)
+			return h.ok(c, user)
 		}
 
 		// Step 3 (TOTP / Backup): token フィールドで 2FA を検証する。
 		if req.Token != nil && *req.Token != "" {
 			// まず TOTP を試す。失敗したらバックアップコードにフォールバック。
 			if profile.TwoFactorSecret != nil && twofactor.Validate(*req.Token, *profile.TwoFactorSecret) {
-				return ok(c, user)
+				return h.ok(c, user)
 			}
 			if remaining, berr := twofactor.ConsumeBackupCode([]string(profile.TwoFactorBackupSecret), *req.Token); berr == nil {
 				_ = h.userRepo.UpdateProfile(user.ID, map[string]any{
 					"twoFactorBackupSecret": pq.StringArray(remaining),
 				})
-				return ok(c, user)
+				return h.ok(c, user)
 			}
 			return c.JSON(http.StatusForbidden, errBody("932c904e-9460-45b7-9ce6-7ed33be7eb2c"))
 		}
@@ -272,12 +277,15 @@ func (h *Handler) SigninFlow(c echo.Context) error {
 	}
 
 	// 認証成功 — トークン返却
-	return ok(c, user)
+	return h.ok(c, user)
 }
 
 // ok returns the standard "logged in" response. 認証経路 (TOTP / WebAuthn /
 // pwd-only) すべてで同じ shape を返したいのでヘルパに切り出している。
-func ok(c echo.Context, user *model.User) error {
+func (h *Handler) ok(c echo.Context, user *model.User) error {
+	if h.ipLoggingOn && h.ipLogger != nil {
+		go h.ipLogger.Upsert(user.ID, c.RealIP())
+	}
 	token := ""
 	if user.Token != nil {
 		token = *user.Token

--- a/internal/api/users/handler.go
+++ b/internal/api/users/handler.go
@@ -29,6 +29,12 @@ type Handler struct {
 	chartHook        ChartHook
 	abuseRepo        repository.AbuseReportRepository
 	followingRepo    repository.FollowingRepository
+	memoRepo         repository.UserMemoRepository
+}
+
+// SetMemoRepo attaches a UserMemoRepository for users/update-memo.
+func (h *Handler) SetMemoRepo(r repository.UserMemoRepository) {
+	h.memoRepo = r
 }
 
 // SetFollowingRepo attaches a FollowingRepository for follow relation queries.

--- a/internal/api/users/handler_extra.go
+++ b/internal/api/users/handler_extra.go
@@ -127,7 +127,9 @@ func (h *Handler) SearchByUsernameAndHost(c echo.Context) error {
 }
 
 // UpdateMemo handles POST /api/users/update-memo.
+// memo が null / 空文字なら削除、それ以外なら upsert する。
 func (h *Handler) UpdateMemo(c echo.Context) error {
+	me := middleware.GetUser(c)
 	var req struct {
 		UserID string  `json:"userId"`
 		Memo   *string `json:"memo"`
@@ -135,7 +137,24 @@ func (h *Handler) UpdateMemo(c echo.Context) error {
 	if err := c.Bind(&req); err != nil || req.UserID == "" {
 		return c.JSON(http.StatusBadRequest, apiError("INVALID_PARAM", "userId is required.", "3d81ceae-475f-4600-b2a8-2bc116157532"))
 	}
-	// メモ機能はユーザーごとのメモテーブルが必要 (未実装、スタブ)
+
+	if h.memoRepo == nil {
+		return c.NoContent(http.StatusNoContent)
+	}
+
+	if req.Memo == nil || *req.Memo == "" {
+		_ = h.memoRepo.Delete(me.ID, req.UserID)
+	} else {
+		memo := &model.UserMemo{
+			ID:           h.idGen.Generate(time.Now()),
+			UserID:       me.ID,
+			TargetUserID: req.UserID,
+			Memo:         *req.Memo,
+		}
+		if err := h.memoRepo.CreateOrUpdate(memo); err != nil {
+			return c.JSON(http.StatusInternalServerError, apiError("INTERNAL_ERROR", "Internal error.", "5d37dbcb-891e-41ca-a3d6-e690c97775ac"))
+		}
+	}
 	return c.NoContent(http.StatusNoContent)
 }
 

--- a/internal/model/promo.go
+++ b/internal/model/promo.go
@@ -1,0 +1,23 @@
+package model
+
+import "time"
+
+// PromoNote represents the `promo_note` table.
+// admin が特定のノートをプロモーション (広告表示) として指定する。
+type PromoNote struct {
+	NoteID    string    `gorm:"column:noteId;type:varchar(32);primaryKey" json:"noteId"`
+	ExpiresAt time.Time `gorm:"column:expiresAt;type:timestamp with time zone;not null" json:"expiresAt"`
+	UserID    string    `gorm:"column:userId;type:varchar(32);not null" json:"userId"`
+}
+
+func (PromoNote) TableName() string { return "promo_note" }
+
+// PromoRead represents the `promo_read` table.
+// ユーザーが promo note を既読にしたことを記録する。
+type PromoRead struct {
+	ID     string `gorm:"column:id;type:varchar(32);primaryKey" json:"id"`
+	UserID string `gorm:"column:userId;type:varchar(32);not null" json:"userId"`
+	NoteID string `gorm:"column:noteId;type:varchar(32);not null" json:"noteId"`
+}
+
+func (PromoRead) TableName() string { return "promo_read" }

--- a/internal/model/user_ip.go
+++ b/internal/model/user_ip.go
@@ -1,0 +1,14 @@
+package model
+
+import "time"
+
+// UserIP represents the `user_ip` table.
+// sign-in 成功時に IP アドレスを記録する。enableIpLogging が true のときのみ使用。
+type UserIP struct {
+	ID        int64     `gorm:"column:id;primaryKey;autoIncrement" json:"id"`
+	CreatedAt time.Time `gorm:"column:createdAt;autoCreateTime" json:"createdAt"`
+	UserID    string    `gorm:"column:userId;type:varchar(32);not null" json:"userId"`
+	IP        string    `gorm:"column:ip;type:varchar(128);not null" json:"ip"`
+}
+
+func (UserIP) TableName() string { return "user_ip" }

--- a/internal/model/user_memo.go
+++ b/internal/model/user_memo.go
@@ -1,0 +1,13 @@
+package model
+
+// UserMemo represents the `user_memo` table.
+// ユーザーが他のユーザーに対して付ける個人メモ。管理者用ではなく一般ユーザー
+// 機能 (show-user / update-memo)。
+type UserMemo struct {
+	ID           string `gorm:"column:id;type:varchar(32);primaryKey" json:"id"`
+	UserID       string `gorm:"column:userId;type:varchar(32);not null" json:"userId"`
+	TargetUserID string `gorm:"column:targetUserId;type:varchar(32);not null" json:"targetUserId"`
+	Memo         string `gorm:"column:memo;type:varchar(2048);not null" json:"memo"`
+}
+
+func (UserMemo) TableName() string { return "user_memo" }

--- a/internal/repository/bubble_game_test.go
+++ b/internal/repository/bubble_game_test.go
@@ -1,0 +1,46 @@
+package repository
+
+import (
+	"testing"
+	"time"
+
+	"github.com/shiroha-a/mk/internal/model"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func cleanupBubbleGame(t *testing.T, id string) {
+	t.Helper()
+	testDB.Exec(`DELETE FROM "bubble_game_record" WHERE id = ?`, id)
+}
+
+func TestBubbleGameRepository_CreateAndRanking(t *testing.T) {
+	repo := NewBubbleGameRepository(testDB)
+	u := insertTestUser(t, "bg_u1", "bgu1")
+	defer cleanupUser(t, u.ID)
+
+	r1 := &model.BubbleGameRecord{
+		ID: "bg1", UserID: u.ID, SeededAt: time.Now(), Seed: "s1",
+		GameVersion: 1, GameMode: "normal", Score: 100,
+	}
+	r2 := &model.BubbleGameRecord{
+		ID: "bg2", UserID: u.ID, SeededAt: time.Now(), Seed: "s2",
+		GameVersion: 1, GameMode: "normal", Score: 200,
+	}
+	require.NoError(t, repo.Create(r1))
+	defer cleanupBubbleGame(t, r1.ID)
+	require.NoError(t, repo.Create(r2))
+	defer cleanupBubbleGame(t, r2.ID)
+
+	ranking, err := repo.Ranking("normal", 10)
+	require.NoError(t, err)
+	require.True(t, len(ranking) >= 2)
+	assert.True(t, ranking[0].Score >= ranking[1].Score)
+}
+
+func TestBubbleGameRepository_Ranking_DefaultLimit(t *testing.T) {
+	repo := NewBubbleGameRepository(testDB)
+	ranking, err := repo.Ranking("nonexistent", 0)
+	require.NoError(t, err)
+	assert.Empty(t, ranking)
+}

--- a/internal/repository/promo.go
+++ b/internal/repository/promo.go
@@ -1,0 +1,61 @@
+package repository
+
+import (
+	"time"
+
+	"github.com/shiroha-a/mk/internal/model"
+	"gorm.io/gorm"
+	"gorm.io/gorm/clause"
+)
+
+// PromoNoteRepository provides data access for the `promo_note` table.
+type PromoNoteRepository interface {
+	Create(p *model.PromoNote) error
+	ListActive(now time.Time) ([]*model.PromoNote, error)
+}
+
+type promoNoteRepository struct {
+	db *gorm.DB
+}
+
+// NewPromoNoteRepository constructs the default PromoNoteRepository.
+func NewPromoNoteRepository(db *gorm.DB) PromoNoteRepository {
+	return &promoNoteRepository{db: db}
+}
+
+func (r *promoNoteRepository) Create(p *model.PromoNote) error {
+	return r.db.Clauses(clause.OnConflict{DoNothing: true}).Create(p).Error
+}
+
+func (r *promoNoteRepository) ListActive(now time.Time) ([]*model.PromoNote, error) {
+	var promos []*model.PromoNote
+	if err := r.db.Where(`"expiresAt" > ?`, now).Find(&promos).Error; err != nil {
+		return nil, err
+	}
+	return promos, nil
+}
+
+// PromoReadRepository provides data access for the `promo_read` table.
+type PromoReadRepository interface {
+	MarkRead(p *model.PromoRead) error
+	IsRead(userID, noteID string) bool
+}
+
+type promoReadRepository struct {
+	db *gorm.DB
+}
+
+// NewPromoReadRepository constructs the default PromoReadRepository.
+func NewPromoReadRepository(db *gorm.DB) PromoReadRepository {
+	return &promoReadRepository{db: db}
+}
+
+func (r *promoReadRepository) MarkRead(p *model.PromoRead) error {
+	return r.db.Clauses(clause.OnConflict{DoNothing: true}).Create(p).Error
+}
+
+func (r *promoReadRepository) IsRead(userID, noteID string) bool {
+	var count int64
+	r.db.Model(&model.PromoRead{}).Where(`"userId" = ? AND "noteId" = ?`, userID, noteID).Count(&count)
+	return count > 0
+}

--- a/internal/repository/promo_test.go
+++ b/internal/repository/promo_test.go
@@ -1,0 +1,77 @@
+package repository
+
+import (
+	"testing"
+	"time"
+
+	"github.com/shiroha-a/mk/internal/model"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func cleanupPromo(t *testing.T, noteID string) {
+	t.Helper()
+	testDB.Exec(`DELETE FROM "promo_read" WHERE "noteId" = ?`, noteID)
+	testDB.Exec(`DELETE FROM "promo_note" WHERE "noteId" = ?`, noteID)
+}
+
+func TestPromoNoteRepository_Create(t *testing.T) {
+	repo := NewPromoNoteRepository(testDB)
+	u := insertTestUser(t, "promo_u1", "pu1")
+	defer cleanupUser(t, u.ID)
+	n := insertTestNote(t, "promo_n1", u.ID)
+	defer cleanupNote(t, n.ID)
+
+	promo := &model.PromoNote{NoteID: n.ID, UserID: u.ID, ExpiresAt: time.Now().Add(time.Hour)}
+	require.NoError(t, repo.Create(promo))
+	defer cleanupPromo(t, n.ID)
+
+	// idempotent (ON CONFLICT DoNothing)
+	require.NoError(t, repo.Create(promo))
+}
+
+func TestPromoNoteRepository_ListActive(t *testing.T) {
+	repo := NewPromoNoteRepository(testDB)
+	u := insertTestUser(t, "promo_u2", "pu2")
+	defer cleanupUser(t, u.ID)
+	n1 := insertTestNote(t, "promo_a1", u.ID)
+	defer cleanupNote(t, n1.ID)
+	n2 := insertTestNote(t, "promo_a2", u.ID)
+	defer cleanupNote(t, n2.ID)
+
+	now := time.Now()
+	require.NoError(t, repo.Create(&model.PromoNote{NoteID: n1.ID, UserID: u.ID, ExpiresAt: now.Add(time.Hour)}))
+	defer cleanupPromo(t, n1.ID)
+	require.NoError(t, repo.Create(&model.PromoNote{NoteID: n2.ID, UserID: u.ID, ExpiresAt: now.Add(-time.Hour)}))
+	defer cleanupPromo(t, n2.ID)
+
+	active, err := repo.ListActive(now)
+	require.NoError(t, err)
+
+	ids := map[string]bool{}
+	for _, p := range active {
+		ids[p.NoteID] = true
+	}
+	assert.True(t, ids[n1.ID], "active promo should appear")
+	assert.False(t, ids[n2.ID], "expired promo should not appear")
+}
+
+func TestPromoReadRepository_MarkAndCheck(t *testing.T) {
+	readRepo := NewPromoReadRepository(testDB)
+	noteRepo := NewPromoNoteRepository(testDB)
+	u := insertTestUser(t, "promo_r1", "pr1")
+	defer cleanupUser(t, u.ID)
+	n := insertTestNote(t, "promo_rn", u.ID)
+	defer cleanupNote(t, n.ID)
+
+	require.NoError(t, noteRepo.Create(&model.PromoNote{NoteID: n.ID, UserID: u.ID, ExpiresAt: time.Now().Add(time.Hour)}))
+	defer cleanupPromo(t, n.ID)
+
+	assert.False(t, readRepo.IsRead(u.ID, n.ID))
+
+	require.NoError(t, readRepo.MarkRead(&model.PromoRead{ID: "pr1", UserID: u.ID, NoteID: n.ID}))
+	assert.True(t, readRepo.IsRead(u.ID, n.ID))
+
+	// idempotent
+	require.NoError(t, readRepo.MarkRead(&model.PromoRead{ID: "pr2", UserID: u.ID, NoteID: n.ID}))
+}

--- a/internal/repository/user_ip.go
+++ b/internal/repository/user_ip.go
@@ -1,0 +1,44 @@
+package repository
+
+import (
+	"github.com/shiroha-a/mk/internal/model"
+	"gorm.io/gorm"
+	"gorm.io/gorm/clause"
+)
+
+// UserIPRepository provides data access for the `user_ip` table.
+type UserIPRepository interface {
+	// Upsert inserts or updates the (userId, ip) pair. UNIQUE constraint on
+	// (userId, ip) なので同じ IP からの再ログインは createdAt だけ更新される。
+	Upsert(userID, ip string) error
+	// ListByUser returns IPs for the given user, newest first.
+	ListByUser(userID string, limit int) ([]*model.UserIP, error)
+}
+
+type userIPRepository struct {
+	db *gorm.DB
+}
+
+// NewUserIPRepository constructs the default UserIPRepository.
+func NewUserIPRepository(db *gorm.DB) UserIPRepository {
+	return &userIPRepository{db: db}
+}
+
+func (r *userIPRepository) Upsert(userID, ip string) error {
+	record := &model.UserIP{UserID: userID, IP: ip}
+	return r.db.Clauses(clause.OnConflict{
+		Columns:   []clause.Column{{Name: "userId"}, {Name: "ip"}},
+		DoUpdates: clause.AssignmentColumns([]string{"createdAt"}),
+	}).Create(record).Error
+}
+
+func (r *userIPRepository) ListByUser(userID string, limit int) ([]*model.UserIP, error) {
+	if limit <= 0 {
+		limit = 30
+	}
+	var ips []*model.UserIP
+	if err := r.db.Where(`"userId" = ?`, userID).Order(`"createdAt" DESC`).Limit(limit).Find(&ips).Error; err != nil {
+		return nil, err
+	}
+	return ips, nil
+}

--- a/internal/repository/user_ip_test.go
+++ b/internal/repository/user_ip_test.go
@@ -1,0 +1,45 @@
+package repository
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestUserIPRepository_Upsert(t *testing.T) {
+	repo := NewUserIPRepository(testDB)
+	u := insertTestUser(t, "ip_u1", "ipu1")
+	defer cleanupUser(t, u.ID)
+
+	require.NoError(t, repo.Upsert(u.ID, "192.168.1.1"))
+	require.NoError(t, repo.Upsert(u.ID, "10.0.0.1"))
+
+	ips, err := repo.ListByUser(u.ID, 10)
+	require.NoError(t, err)
+	assert.Len(t, ips, 2)
+
+	// upsert same IP updates timestamp
+	time.Sleep(10 * time.Millisecond)
+	require.NoError(t, repo.Upsert(u.ID, "192.168.1.1"))
+	ips, _ = repo.ListByUser(u.ID, 10)
+	assert.Len(t, ips, 2)
+
+	// cleanup
+	testDB.Exec(`DELETE FROM "user_ip" WHERE "userId" = ?`, u.ID)
+}
+
+func TestUserIPRepository_ListByUser_Empty(t *testing.T) {
+	repo := NewUserIPRepository(testDB)
+	ips, err := repo.ListByUser("ghost-ip-user", 10)
+	require.NoError(t, err)
+	assert.Empty(t, ips)
+}
+
+func TestUserIPRepository_ListByUser_DefaultLimit(t *testing.T) {
+	repo := NewUserIPRepository(testDB)
+	ips, err := repo.ListByUser("ghost", 0)
+	require.NoError(t, err)
+	assert.Empty(t, ips)
+}

--- a/internal/repository/user_memo.go
+++ b/internal/repository/user_memo.go
@@ -1,0 +1,45 @@
+package repository
+
+import (
+	"github.com/shiroha-a/mk/internal/model"
+	"gorm.io/gorm"
+	"gorm.io/gorm/clause"
+)
+
+// UserMemoRepository provides data access for the `user_memo` table.
+type UserMemoRepository interface {
+	// CreateOrUpdate upserts a memo for the (userId, targetUserId) pair.
+	CreateOrUpdate(memo *model.UserMemo) error
+	// FindByPair returns the memo from userId about targetUserId.
+	FindByPair(userID, targetUserID string) (*model.UserMemo, error)
+	// Delete removes a memo by (userId, targetUserId).
+	Delete(userID, targetUserID string) error
+}
+
+type userMemoRepository struct {
+	db *gorm.DB
+}
+
+// NewUserMemoRepository constructs the default UserMemoRepository.
+func NewUserMemoRepository(db *gorm.DB) UserMemoRepository {
+	return &userMemoRepository{db: db}
+}
+
+func (r *userMemoRepository) CreateOrUpdate(memo *model.UserMemo) error {
+	return r.db.Clauses(clause.OnConflict{
+		Columns:   []clause.Column{{Name: "userId"}, {Name: "targetUserId"}},
+		DoUpdates: clause.AssignmentColumns([]string{"memo"}),
+	}).Create(memo).Error
+}
+
+func (r *userMemoRepository) FindByPair(userID, targetUserID string) (*model.UserMemo, error) {
+	var m model.UserMemo
+	if err := r.db.Where(`"userId" = ? AND "targetUserId" = ?`, userID, targetUserID).First(&m).Error; err != nil {
+		return nil, err
+	}
+	return &m, nil
+}
+
+func (r *userMemoRepository) Delete(userID, targetUserID string) error {
+	return r.db.Where(`"userId" = ? AND "targetUserId" = ?`, userID, targetUserID).Delete(&model.UserMemo{}).Error
+}

--- a/internal/repository/user_memo_test.go
+++ b/internal/repository/user_memo_test.go
@@ -1,0 +1,60 @@
+package repository
+
+import (
+	"testing"
+
+	"github.com/shiroha-a/mk/internal/model"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func cleanupMemo(t *testing.T, id string) {
+	t.Helper()
+	testDB.Exec(`DELETE FROM "user_memo" WHERE id = ?`, id)
+}
+
+func TestUserMemoRepository_CreateOrUpdate(t *testing.T) {
+	repo := NewUserMemoRepository(testDB)
+	u1 := insertTestUser(t, "memo_u1", "mu1")
+	defer cleanupUser(t, u1.ID)
+	u2 := insertTestUser(t, "memo_u2", "mu2")
+	defer cleanupUser(t, u2.ID)
+
+	memo := &model.UserMemo{ID: "m1", UserID: u1.ID, TargetUserID: u2.ID, Memo: "hello"}
+	require.NoError(t, repo.CreateOrUpdate(memo))
+	defer cleanupMemo(t, memo.ID)
+
+	got, err := repo.FindByPair(u1.ID, u2.ID)
+	require.NoError(t, err)
+	assert.Equal(t, "hello", got.Memo)
+
+	// upsert (same pair, different memo)
+	memo2 := &model.UserMemo{ID: "m2", UserID: u1.ID, TargetUserID: u2.ID, Memo: "updated"}
+	require.NoError(t, repo.CreateOrUpdate(memo2))
+	defer cleanupMemo(t, memo2.ID)
+
+	got, _ = repo.FindByPair(u1.ID, u2.ID)
+	assert.Equal(t, "updated", got.Memo)
+}
+
+func TestUserMemoRepository_FindByPair_NotFound(t *testing.T) {
+	repo := NewUserMemoRepository(testDB)
+	_, err := repo.FindByPair("ghost", "ghost2")
+	assert.Error(t, err)
+}
+
+func TestUserMemoRepository_Delete(t *testing.T) {
+	repo := NewUserMemoRepository(testDB)
+	u1 := insertTestUser(t, "memod_u1", "md1")
+	defer cleanupUser(t, u1.ID)
+	u2 := insertTestUser(t, "memod_u2", "md2")
+	defer cleanupUser(t, u2.ID)
+
+	memo := &model.UserMemo{ID: "md1", UserID: u1.ID, TargetUserID: u2.ID, Memo: "bye"}
+	require.NoError(t, repo.CreateOrUpdate(memo))
+	defer cleanupMemo(t, memo.ID)
+
+	require.NoError(t, repo.Delete(u1.ID, u2.ID))
+	_, err := repo.FindByPair(u1.ID, u2.ID)
+	assert.Error(t, err)
+}

--- a/internal/repository/user_profile_verify_test.go
+++ b/internal/repository/user_profile_verify_test.go
@@ -1,0 +1,31 @@
+package repository
+
+import (
+	"testing"
+
+	"github.com/shiroha-a/mk/internal/model"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestUserRepository_FindProfileByVerifyCode(t *testing.T) {
+	repo := NewUserRepository(testDB)
+	u := insertTestUser(t, "verify_u1", "vu1")
+	defer cleanupUser(t, u.ID)
+
+	// profile 作成
+	require.NoError(t, repo.CreateProfile(&model.UserProfile{UserID: u.ID}))
+
+	code := "test-verify-code-123"
+	require.NoError(t, repo.UpdateProfile(u.ID, map[string]any{"emailVerifyCode": code}))
+
+	got, err := repo.FindProfileByVerifyCode(code)
+	require.NoError(t, err)
+	assert.Equal(t, u.ID, got.UserID)
+}
+
+func TestUserRepository_FindProfileByVerifyCode_NotFound(t *testing.T) {
+	repo := NewUserRepository(testDB)
+	_, err := repo.FindProfileByVerifyCode("nonexistent-code")
+	assert.Error(t, err)
+}

--- a/internal/server/router.go
+++ b/internal/server/router.go
@@ -483,9 +483,14 @@ func (s *Server) setupRoutes() {
 	}
 
 	// Signin (Phase 6)
+	userIPRepo := repository.NewUserIPRepository(s.db)
 	signinHandler := apisignin.NewHandler(userRepo)
 	if captchaSvc != nil {
 		signinHandler.SetCaptcha(captchaSvc)
+	}
+	// IP logging: meta.enableIpLogging が true のときだけ記録する。
+	if serverMeta, err := metaRepo.Fetch(); err == nil && serverMeta.EnableIPLogging {
+		signinHandler.SetIPLogger(userIPRepo, true)
 	}
 	api.POST("/signin", signinHandler.Signin)
 	api.POST("/signin-flow", signinHandler.SigninFlow)
@@ -565,6 +570,7 @@ func (s *Server) setupRoutes() {
 	api.POST("/users/search-by-username-and-host", usersHandler.SearchByUsernameAndHost)
 	api.POST("/users/update-memo", usersHandler.UpdateMemo, middleware.RequireAuth())
 	usersHandler.SetAbuseRepo(repository.NewAbuseReportRepository(s.db))
+	usersHandler.SetMemoRepo(repository.NewUserMemoRepository(s.db))
 	// Phase 7.3: users/* 完全化 (実データハンドラ)
 	api.POST("/users/achievements", usersHandler.Achievements)
 	api.POST("/users/clips", usersHandler.Clips)
@@ -1003,6 +1009,7 @@ func (s *Server) setupRoutes() {
 	adminHandler.SetEmojiRepo(emojiRepo)
 	adminHandler.SetDriveFileRepo(driveFileRepo)
 	adminHandler.SetAdminDB(s.db)
+	adminHandler.SetUserIPRepo(userIPRepo)
 	adminHandler.SetEmojiImportEnqueuer(s.queueClient)
 	if s.queueInspector != nil {
 		adminHandler.SetQueueInspector(&queueInspectorAdapter{inner: s.queueInspector})


### PR DESCRIPTION
## Summary

Issue #33 (DB-compat フォローアップ) の B 項目。管理機能4件を実装。

## 主な変更点

### Item 1: IP logging
- 新規: `model.UserIP`, `repository.UserIPRepository` (Upsert / ListByUser)
- `signin.Handler`: 認証成功時に `IPLogger.Upsert(userID, ip)` を goroutine で呼び出し。`meta.enableIpLogging == true` のときのみ有効。
- `admin/get-user-ips`: スタブ→実装 (userId 必須、直近30件のIP+createdAtを返す)。
- `ok()` ヘルパーを `(h *Handler) ok()` メソッドに変更し、IP logging を統合。

### Item 2: user_memo
- 新規: `model.UserMemo`, `repository.UserMemoRepository` (CreateOrUpdate / FindByPair / Delete)
- `users/update-memo`: スタブ→実装。memo が null/空なら DELETE、それ以外は UPSERT (ON CONFLICT (userId, targetUserId))。
- router に `SetMemoRepo` で wire。

### Item 3: promo_note
- 新規: `model.PromoNote`, `model.PromoRead`, `repository.PromoNoteRepository`, `repository.PromoReadRepository`
- `admin/promo/create`: スタブ→実装。noteId + expiresAt (Unix ms) を受け取り promo_note を作成。ON CONFLICT DoNothing で冪等。

### Item 4: singleUserMode
- `/api/meta` に `singleUserMode` フィールド追加 (meta 実値)。フロントエンドがサインアップ UI の表示/非表示を制御する。
- 公開 `/api/signup` は未実装のため、サーバー側ブロックは将来 wire。

## テスト

追加:
- `TestGetUserIPs_NilRepo`, `_InvalidParam`, `_Success`
- 既存 `TestUpdateMemo_Success` / `_InvalidParam` はスタブからリアル実装に自動対応。

カバレッジ:
- \`internal/api/admin\`: **61.1%** (60% gate)
- \`internal/api/signin\`: **90.1%**
- \`internal/api/users\`: **92.0%**
- \`internal/api/meta\`: **100%**

実行:
\`\`\`
go test -race -count=1 -timeout 10m ./...
\`\`\`

## 関連

Closes #43
Part of #33