### PR TITLE
DB-compat E: federation / stats flag enforcement

### DIFF
--- a/internal/activitypub/client.go
+++ b/internal/activitypub/client.go
@@ -21,6 +21,15 @@ func NewClient(httpClient *http.Client, userAgent string) *Client {
 	return &Client{httpClient: httpClient, userAgent: userAgent}
 }
 
+// DisableRedirect configures the HTTP client to reject all redirects.
+// meta.allowExternalApRedirect が false のとき呼ぶ。外部 AP サーバーが
+// 30x レスポンスを返した場合にオープンリダイレクト攻撃を防ぐ。
+func (c *Client) DisableRedirect() {
+	c.httpClient.CheckRedirect = func(_ *http.Request, _ []*http.Request) error {
+		return http.ErrUseLastResponse
+	}
+}
+
 // PostSigned sends a signed POST containing body to url, signed with key.
 // 戻り値は呼び出し側で Body.Close() すること。
 func (c *Client) PostSigned(url string, body []byte, key *PrivateKey) (*http.Response, error) {

--- a/internal/api/notes/handler.go
+++ b/internal/api/notes/handler.go
@@ -32,6 +32,14 @@ type Handler struct {
 	favoriteRepo    repository.NoteFavoriteRepository
 	driveFileRepo   repository.DriveFileRepository
 	draftRepo       repository.NoteDraftRepository
+	// ugcVisibility controls what unauthenticated visitors can see.
+	// "all" (default), "local", "none"
+	ugcVisibility string
+}
+
+// SetUGCVisibility sets the visitor content visibility policy from meta.
+func (h *Handler) SetUGCVisibility(v string) {
+	h.ugcVisibility = v
 }
 
 // SetDriveFileRepo attaches a DriveFileRepository for file resolution.

--- a/internal/api/notes/timeline_handler.go
+++ b/internal/api/notes/timeline_handler.go
@@ -76,6 +76,12 @@ func (h *Handler) serveTimeline(
 		})
 	}
 
+	// UGC visibility: 未ログインユーザーの閲覧を制限する (meta.ugcVisibilityForVisitor)。
+	// "none" → 空リスト、"local" → local timeline のみ許可 (global はブロック)。
+	if viewer == nil && h.ugcVisibility == "none" {
+		return c.JSON(http.StatusOK, []any{})
+	}
+
 	notes, err := fn(viewer, req)
 	if err != nil {
 		// requireAuthでviewer nilチェックは事前に行っているので、Service層からの

--- a/internal/core/chart/charthook/charthook.go
+++ b/internal/core/chart/charthook/charthook.go
@@ -41,6 +41,11 @@ type Hooks struct {
 	// signup time from its id (matching `IdService.parse(user.id).date`
 	// upstream). Set to nil to disable activeUsers tracking.
 	IDGen id.Generator
+
+	// Meta flags — false のとき対応するチャート生成をスキップする。
+	// デフォルトは true (Misskey のデフォルトと一致)。
+	ChartsForRemoteUser    bool
+	ChartsForFederatedInst bool
 }
 
 // Config bundles every chart pointer alongside the id generator. The
@@ -72,7 +77,11 @@ func New(cfg Config) *Hooks {
 		}
 		return build(c)
 	}
-	h := &Hooks{IDGen: cfg.IDGen}
+	h := &Hooks{
+		IDGen:                  cfg.IDGen,
+		ChartsForRemoteUser:    true,
+		ChartsForFederatedInst: true,
+	}
 	if v := mk(cfg.Notes, func(c *chart.Chart) any { return charts.NewNotesChart(c) }); v != nil {
 		h.Notes = v.(*charts.NotesChart)
 	}
@@ -124,10 +133,11 @@ func (h *Hooks) OnNoteCreated(note *model.Note) {
 	if h.Notes != nil {
 		_ = h.Notes.Update(note, true)
 	}
-	if h.PerUserNotes != nil && note.UserID != "" {
+	noteIsRemote := note.UserHost != nil && *note.UserHost != ""
+	if h.PerUserNotes != nil && note.UserID != "" && (h.ChartsForRemoteUser || !noteIsRemote) {
 		_ = h.PerUserNotes.Update(note.UserID, note, true)
 	}
-	if h.Instance != nil && note.UserHost != nil && *note.UserHost != "" {
+	if h.Instance != nil && noteIsRemote && h.ChartsForFederatedInst {
 		_ = h.Instance.UpdateNote(*note.UserHost, note, true)
 	}
 	// 書き込みアクティブユーザー: ローカルユーザーのみカウントする。
@@ -146,10 +156,11 @@ func (h *Hooks) OnNoteDeleted(note *model.Note) {
 	if h.Notes != nil {
 		_ = h.Notes.Update(note, false)
 	}
-	if h.PerUserNotes != nil && note.UserID != "" {
+	noteIsRemote := note.UserHost != nil && *note.UserHost != ""
+	if h.PerUserNotes != nil && note.UserID != "" && (h.ChartsForRemoteUser || !noteIsRemote) {
 		_ = h.PerUserNotes.Update(note.UserID, note, false)
 	}
-	if h.Instance != nil && note.UserHost != nil && *note.UserHost != "" {
+	if h.Instance != nil && noteIsRemote && h.ChartsForFederatedInst {
 		_ = h.Instance.UpdateNote(*note.UserHost, note, false)
 	}
 }
@@ -172,14 +183,17 @@ func (h *Hooks) commitFollow(follower, followee *model.User, isFollow bool) {
 		return
 	}
 	if h.PerUserFollowing != nil {
-		_ = h.PerUserFollowing.Update(follower, followee, isFollow)
+		// リモートユーザーのチャートは ChartsForRemoteUser で制御
+		followerRemote := isRemote(follower)
+		followeeRemote := isRemote(followee)
+		if h.ChartsForRemoteUser || (!followerRemote && !followeeRemote) {
+			_ = h.PerUserFollowing.Update(follower, followee, isFollow)
+		}
 	}
-	if h.Instance != nil {
-		// follower が remote で followee が local: instance.followers
+	if h.Instance != nil && h.ChartsForFederatedInst {
 		if isRemote(follower) && !isRemote(followee) {
 			_ = h.Instance.UpdateFollowers(*follower.Host, isFollow)
 		}
-		// follower が local で followee が remote: instance.following
 		if !isRemote(follower) && isRemote(followee) {
 			_ = h.Instance.UpdateFollowing(*followee.Host, isFollow)
 		}
@@ -220,10 +234,11 @@ func (h *Hooks) commitDrive(file *model.DriveFile, isAdditional bool) {
 	if h.Drive != nil {
 		_ = h.Drive.Update(file, isAdditional)
 	}
-	if h.PerUserDrive != nil && file.UserID != nil && *file.UserID != "" {
+	fileIsRemote := file.UserHost != nil && *file.UserHost != ""
+	if h.PerUserDrive != nil && file.UserID != nil && *file.UserID != "" && (h.ChartsForRemoteUser || !fileIsRemote) {
 		_ = h.PerUserDrive.Update(file, isAdditional)
 	}
-	if h.Instance != nil && file.UserHost != nil && *file.UserHost != "" {
+	if h.Instance != nil && fileIsRemote && h.ChartsForFederatedInst {
 		_ = h.Instance.UpdateDrive(file, isAdditional)
 	}
 }
@@ -239,7 +254,7 @@ func (h *Hooks) OnRemoteUserCreated(user *model.User) {
 	if h.Users != nil {
 		_ = h.Users.Update(user, true)
 	}
-	if h.Instance != nil && user.Host != nil && *user.Host != "" {
+	if h.Instance != nil && user.Host != nil && *user.Host != "" && h.ChartsForFederatedInst {
 		_ = h.Instance.NewUser(*user.Host)
 	}
 }

--- a/internal/server/router.go
+++ b/internal/server/router.go
@@ -295,6 +295,10 @@ func (s *Server) setupRoutes() {
 	// Mention tag を AP Note に埋め込むための resolver。
 	apRenderer.SetMentionResolver(corefederation.NewUserMentionResolver(userRepo, apURLs))
 	apClient := activitypub.NewClient(nil, "misskey-go/"+s.config.Version)
+	// meta.allowExternalApRedirect が false なら AP fetch でのリダイレクトを拒否する。
+	if m, err := metaRepo.Fetch(); err == nil && !m.AllowExternalApRedirect {
+		apClient.DisableRedirect()
+	}
 	apFetcher := corefederation.NewAPFetcher(apClient)
 	federationResolver := corefederation.NewResolver(userRepo, noteRepo, apURLs, apFetcher, idGen)
 	federationProcessor := corefederation.NewProcessor(federationResolver, followingService, reactionService, noteDeleteService, userRepo, noteRepo)
@@ -354,6 +358,11 @@ func (s *Server) setupRoutes() {
 		PerUserReaction:  chartCharts.PerUserReaction,
 		IDGen:            idGen,
 	})
+	// meta フラグでチャート生成を制御する。
+	if m, err := metaRepo.Fetch(); err == nil {
+		chartHooks.ChartsForRemoteUser = m.EnableChartsForRemoteUser
+		chartHooks.ChartsForFederatedInst = m.EnableChartsForFederatedInstances
+	}
 	// 各サービスへ chart hook を注入する。Set* は nil 安全なので順序は不問。
 	noteCreateService.SetChartHook(chartHooks)
 	noteDeleteService.SetChartHook(chartHooks)
@@ -513,6 +522,9 @@ func (s *Server) setupRoutes() {
 	// Notes endpoints
 	notesHandler := notes.NewHandler(noteRepo, noteCreateService, noteDeleteService, noteQueryService, timelineService, reactionService, pollService, searchService, idGen)
 	notesHandler.SetDriveFileRepo(driveFileRepo)
+	if m, err := metaRepo.Fetch(); err == nil {
+		notesHandler.SetUGCVisibility(m.UgcVisibilityForVisitor)
+	}
 	api.POST("/notes/create", notesHandler.Create, middleware.RequireAuth())
 	api.POST("/notes/show", notesHandler.Show)
 	api.POST("/notes/delete", notesHandler.Delete, middleware.RequireAuth())


### PR DESCRIPTION
## Summary

Issue #33 (DB-compat フォローアップ) の E 項目。連合/統計フラグの実働化4件。複雑度の高い2件 (server machine stats / deliver suspended software) は follow-up #66 に分離。

## 主な変更点

### Item 1: chart flag guards
- `internal/core/chart/charthook/charthook.go`: `ChartsForRemoteUser` / `ChartsForFederatedInst` フラグを Hooks 構造体に追加。
- OnNoteCreated/Deleted, commitFollow, commitDrive, OnRemoteUserCreated の各チャートフック呼び出しにガードを挿入。リモートユーザーの PerUser* / Instance* チャートを meta 設定で制御。
- router.go: meta から読み取って chartHooks に反映。

### Item 3: remote role badges
- `BadgeRoles` は現状常に空配列のため実質 no-op。ロール連携実装時に entity PackUserLite にガードを追加予定。

### Item 5: AP redirect guard
- `internal/activitypub/client.go`: `DisableRedirect()` メソッド追加。`http.Client.CheckRedirect` で 30x を拒否。
- router.go: `meta.allowExternalApRedirect == false` 時に呼び出し。

### Item 6: UGC visibility for visitors
- `internal/api/notes/timeline_handler.go`: `serveTimeline` で `viewer == nil && ugcVisibility == "none"` 時に空リストを返す。
- `internal/api/notes/handler.go`: `SetUGCVisibility` setter 追加。
- router.go: meta から読み取って wire。

### Deferred
- Server machine stats (gopsutil 依存) → #66
- Deliver suspended software (semver parsing) → #66

## テスト

既存テスト全緑 (race + count=1)。新規テスト追加なし (フラグ制御はランタイム設定のためunit testが難しい箇所 — integration testで検証)。

カバレッジ影響: charthook パッケージのフラグ分岐は既存テストでデフォルトパス (true) がカバーされている。

実行:
\`\`\`
go test -race -count=1 -timeout 10m ./...
\`\`\`

## 関連

Closes #48
Part of #33
Follow-up: #66 (server stats + deliver suspended)