### PR TITLE
DB-compat C-2: URL preview (OGP + SSRF + cache)

### DIFF
--- a/internal/api/meta/handler.go
+++ b/internal/api/meta/handler.go
@@ -91,7 +91,7 @@ func (h *Handler) Meta(c echo.Context) error {
 		"mascotImageUrl":               mascotURL(m.MascotImageURL),
 		"translatorAvailable":          m.DeeplAuthKey != nil && *m.DeeplAuthKey != "",
 		"enableEmail":                  m.EnableEmail,
-		"enableUrlPreview":             false,
+		"enableUrlPreview":             m.URLPreviewEnabled,
 		"ads":                          h.serializeActiveAds(),
 		"notesPerOneAd":                m.NotesPerOneAd,
 		"mediaProxy":                   h.config.MediaProxy,

--- a/internal/api/url/handler.go
+++ b/internal/api/url/handler.go
@@ -1,0 +1,51 @@
+// Package url provides the /api/url endpoint for URL preview.
+package url
+
+import (
+	"net/http"
+
+	"github.com/labstack/echo/v4"
+	"github.com/shiroha-a/mk/internal/core/urlpreview"
+)
+
+// Handler handles the URL preview endpoint.
+type Handler struct {
+	fetcher *urlpreview.Fetcher
+}
+
+// NewHandler creates a new URL preview handler.
+func NewHandler(fetcher *urlpreview.Fetcher) *Handler {
+	return &Handler{fetcher: fetcher}
+}
+
+// Preview handles GET /url (matches Misskey's endpoint path).
+// フロントエンドがリンクプレビューカード表示のために呼ぶ。
+func (h *Handler) Preview(c echo.Context) error {
+	rawURL := c.QueryParam("url")
+	if rawURL == "" {
+		return c.JSON(http.StatusBadRequest, map[string]any{
+			"error": map[string]any{
+				"message": "url is required.",
+				"code":    "INVALID_PARAM",
+				"id":      "3d81ceae-475f-4600-b2a8-2bc116157532",
+			},
+		})
+	}
+
+	result, err := h.fetcher.Fetch(c.Request().Context(), rawURL)
+	if err != nil {
+		return c.JSON(http.StatusOK, map[string]any{
+			"title":       nil,
+			"description": nil,
+			"thumbnail":   nil,
+			"icon":        nil,
+			"sitename":    nil,
+			"url":         rawURL,
+			"player":      map[string]any{"url": nil, "width": nil, "height": nil, "allow": []string{}},
+			"sensitive":   false,
+			"activityPub": nil,
+		})
+	}
+
+	return c.JSON(http.StatusOK, result)
+}

--- a/internal/core/urlpreview/fetcher.go
+++ b/internal/core/urlpreview/fetcher.go
@@ -1,0 +1,204 @@
+package urlpreview
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/redis/go-redis/v9"
+)
+
+var (
+	ErrDisabled    = errors.New("urlpreview: feature disabled")
+	ErrPrivateIP   = errors.New("urlpreview: private IP not allowed")
+	ErrTooLarge    = errors.New("urlpreview: content too large")
+	ErrFetchFailed = errors.New("urlpreview: fetch failed")
+)
+
+const cachePrefix = "url-preview:"
+const cacheTTL = 24 * time.Hour
+
+// Config holds URL preview settings read from Meta.
+type Config struct {
+	Enabled              bool
+	AllowRedirect        bool
+	TimeoutMs            int
+	MaxContentLength     int64
+	RequireContentLength bool
+	SummaryProxyURL      string
+	UserAgent            string
+}
+
+// Fetcher fetches and parses URL previews with caching and SSRF protection.
+type Fetcher struct {
+	cfg    Config
+	redis  *redis.Client
+	client *http.Client
+}
+
+// SetHTTPClient replaces the HTTP client (for tests that need to bypass
+// the SSRF dialer or use a custom transport).
+func (f *Fetcher) SetHTTPClient(c *http.Client) {
+	f.client = c
+}
+
+// NewFetcher creates a URL preview Fetcher.
+func NewFetcher(cfg Config, rdb *redis.Client) *Fetcher {
+	timeout := time.Duration(cfg.TimeoutMs) * time.Millisecond
+	if timeout <= 0 {
+		timeout = 10 * time.Second
+	}
+
+	transport := &http.Transport{
+		DialContext: func(ctx context.Context, network, addr string) (net.Conn, error) {
+			host, _, _ := net.SplitHostPort(addr)
+			if isPrivateHost(host) {
+				return nil, ErrPrivateIP
+			}
+			return (&net.Dialer{Timeout: 5 * time.Second}).DialContext(ctx, network, addr)
+		},
+	}
+
+	client := &http.Client{
+		Timeout:   timeout,
+		Transport: transport,
+	}
+	if !cfg.AllowRedirect {
+		client.CheckRedirect = func(_ *http.Request, _ []*http.Request) error {
+			return http.ErrUseLastResponse
+		}
+	}
+
+	return &Fetcher{cfg: cfg, redis: rdb, client: client}
+}
+
+// Fetch returns the URL preview, using Redis cache when available.
+func (f *Fetcher) Fetch(ctx context.Context, rawURL string) (*Result, error) {
+	if !f.cfg.Enabled {
+		return nil, ErrDisabled
+	}
+
+	// 外部 summarizer proxy が設定されていればそちらに委譲する。
+	if f.cfg.SummaryProxyURL != "" {
+		return f.fetchViaProxy(ctx, rawURL)
+	}
+
+	// Redis キャッシュ確認
+	cacheKey := cachePrefix + hashURL(rawURL)
+	if f.redis != nil {
+		if cached, err := f.redis.Get(ctx, cacheKey).Bytes(); err == nil {
+			var result Result
+			if json.Unmarshal(cached, &result) == nil {
+				return &result, nil
+			}
+		}
+	}
+
+	result, err := f.fetchAndParse(ctx, rawURL)
+	if err != nil {
+		return nil, err
+	}
+
+	// Redis キャッシュ保存
+	if f.redis != nil {
+		if data, err := json.Marshal(result); err == nil {
+			f.redis.Set(ctx, cacheKey, data, cacheTTL)
+		}
+	}
+
+	return result, nil
+}
+
+func (f *Fetcher) fetchAndParse(ctx context.Context, rawURL string) (*Result, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, rawURL, nil)
+	if err != nil {
+		return nil, fmt.Errorf("%w: %v", ErrFetchFailed, err)
+	}
+	ua := f.cfg.UserAgent
+	if ua == "" {
+		ua = "Misskey URL Preview"
+	}
+	req.Header.Set("User-Agent", ua)
+	req.Header.Set("Accept", "text/html,*/*;q=0.5")
+
+	resp, err := f.client.Do(req)
+	if err != nil {
+		if errors.Is(err, ErrPrivateIP) {
+			return nil, ErrPrivateIP
+		}
+		return nil, fmt.Errorf("%w: %v", ErrFetchFailed, err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return nil, fmt.Errorf("%w: status %d", ErrFetchFailed, resp.StatusCode)
+	}
+
+	// Content-Length チェック
+	if f.cfg.RequireContentLength {
+		cl := resp.Header.Get("Content-Length")
+		if cl == "" {
+			return nil, ErrTooLarge
+		}
+	}
+	if f.cfg.MaxContentLength > 0 {
+		if cl, err := strconv.ParseInt(resp.Header.Get("Content-Length"), 10, 64); err == nil && cl > f.cfg.MaxContentLength {
+			return nil, ErrTooLarge
+		}
+	}
+
+	// HTML のみ解析する。それ以外は URL だけ返す。
+	ct := resp.Header.Get("Content-Type")
+	if !strings.Contains(ct, "text/html") && !strings.Contains(ct, "application/xhtml") {
+		return &Result{URL: rawURL, Player: PlayerResult{Allow: []string{}}}, nil
+	}
+
+	body := io.LimitReader(resp.Body, f.cfg.MaxContentLength)
+	return ParseHTML(body, rawURL), nil
+}
+
+// fetchViaProxy delegates to an external summarizer service.
+// proxy は管理者が設定した信頼済み URL なので SSRF チェックを適用しない。
+func (f *Fetcher) fetchViaProxy(ctx context.Context, rawURL string) (*Result, error) {
+	proxyURL := f.cfg.SummaryProxyURL + "?url=" + rawURL
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, proxyURL, nil)
+	if err != nil {
+		return nil, fmt.Errorf("%w: %v", ErrFetchFailed, err)
+	}
+	proxyClient := &http.Client{Timeout: f.client.Timeout}
+	resp, err := proxyClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("%w: %v", ErrFetchFailed, err)
+	}
+	defer resp.Body.Close()
+
+	var result Result
+	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+		return nil, fmt.Errorf("%w: parse proxy response: %v", ErrFetchFailed, err)
+	}
+	return &result, nil
+}
+
+func hashURL(u string) string {
+	h := sha256.Sum256([]byte(u))
+	return hex.EncodeToString(h[:])
+}
+
+// isPrivateHost checks if a hostname resolves to a private/loopback IP.
+func isPrivateHost(host string) bool {
+	ip := net.ParseIP(host)
+	if ip == nil {
+		// DNS 名は解決してからチェック (Dialer 段階では IP が確定している)
+		return false
+	}
+	return ip.IsLoopback() || ip.IsPrivate() || ip.IsLinkLocalUnicast() || ip.IsLinkLocalMulticast()
+}

--- a/internal/core/urlpreview/fetcher_test.go
+++ b/internal/core/urlpreview/fetcher_test.go
@@ -1,0 +1,153 @@
+package urlpreview
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestFetcher_Disabled(t *testing.T) {
+	f := NewFetcher(Config{Enabled: false}, nil)
+	_, err := f.Fetch(context.Background(), "https://example.com")
+	assert.ErrorIs(t, err, ErrDisabled)
+}
+
+func newTestFetcher(cfg Config) *Fetcher {
+	f := NewFetcher(cfg, nil)
+	f.SetHTTPClient(&http.Client{Timeout: f.client.Timeout})
+	return f
+}
+
+func TestFetcher_FetchAndParse(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "text/html")
+		w.Write([]byte(`<html><head>
+			<meta property="og:title" content="Hello">
+			<meta property="og:description" content="World">
+		</head><body></body></html>`))
+	}))
+	defer srv.Close()
+
+	f := newTestFetcher(Config{Enabled: true, AllowRedirect: true, TimeoutMs: 5000, MaxContentLength: 1 << 20})
+	result, err := f.Fetch(context.Background(), srv.URL)
+	require.NoError(t, err)
+	assert.Equal(t, "Hello", *result.Title)
+	assert.Equal(t, "World", *result.Description)
+}
+
+func TestFetcher_NonHTML(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "image/png")
+		w.Write([]byte("PNG data"))
+	}))
+	defer srv.Close()
+
+	f := newTestFetcher(Config{Enabled: true, AllowRedirect: true, TimeoutMs: 5000, MaxContentLength: 1 << 20})
+	result, err := f.Fetch(context.Background(), srv.URL)
+	require.NoError(t, err)
+	assert.Equal(t, srv.URL, result.URL)
+	assert.Nil(t, result.Title)
+}
+
+func TestFetcher_TooLargeContentLength(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "text/html")
+		w.Header().Set("Content-Length", "999999999")
+		w.Write([]byte("<html></html>"))
+	}))
+	defer srv.Close()
+
+	f := newTestFetcher(Config{Enabled: true, AllowRedirect: true, TimeoutMs: 5000, MaxContentLength: 1000})
+	_, err := f.Fetch(context.Background(), srv.URL)
+	assert.ErrorIs(t, err, ErrTooLarge)
+}
+
+func TestFetcher_RequireContentLength(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "text/html")
+		// chunked 転送 (Content-Length なし) にするため Flush を使う。
+		w.Header().Del("Content-Length")
+		flusher := w.(http.Flusher)
+		w.Write([]byte("<html></html>"))
+		flusher.Flush()
+	}))
+	defer srv.Close()
+
+	f := newTestFetcher(Config{Enabled: true, AllowRedirect: true, TimeoutMs: 5000, MaxContentLength: 1 << 20, RequireContentLength: true})
+	_, err := f.Fetch(context.Background(), srv.URL)
+	assert.ErrorIs(t, err, ErrTooLarge)
+}
+
+func TestFetcher_PrivateIP(t *testing.T) {
+	// SSRF チェック付きの Fetcher を使う (newTestFetcher ではなく NewFetcher)
+	f := NewFetcher(Config{Enabled: true, AllowRedirect: true, TimeoutMs: 5000, MaxContentLength: 1 << 20}, nil)
+	_, err := f.Fetch(context.Background(), "http://127.0.0.1:9999/test")
+	assert.ErrorIs(t, err, ErrPrivateIP)
+}
+
+func TestFetcher_ServerError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer srv.Close()
+
+	f := newTestFetcher(Config{Enabled: true, AllowRedirect: true, TimeoutMs: 5000, MaxContentLength: 1 << 20})
+	_, err := f.Fetch(context.Background(), srv.URL)
+	assert.ErrorIs(t, err, ErrFetchFailed)
+}
+
+func TestFetcher_ViaProxy(t *testing.T) {
+	proxy := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Contains(t, r.URL.RawQuery, "url=")
+		json.NewEncoder(w).Encode(Result{
+			URL:    "https://example.com",
+			Player: PlayerResult{Allow: []string{}},
+		})
+	}))
+	defer proxy.Close()
+
+	f := NewFetcher(Config{Enabled: true, SummaryProxyURL: proxy.URL, TimeoutMs: 5000, MaxContentLength: 1 << 20}, nil)
+	result, err := f.Fetch(context.Background(), "https://example.com")
+	require.NoError(t, err)
+	assert.Equal(t, "https://example.com", result.URL)
+}
+
+func TestFetcher_NoRedirect(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		http.Redirect(w, &http.Request{}, "https://example.com", http.StatusFound)
+	}))
+	defer srv.Close()
+
+	// AllowRedirect=false のとき 302 で止まる。SSRF チェックを外すために
+	// newTestFetcher は使えないので直接 client を差し替える。
+	f := NewFetcher(Config{Enabled: true, AllowRedirect: false, TimeoutMs: 5000, MaxContentLength: 1 << 20}, nil)
+	f.SetHTTPClient(&http.Client{
+		Timeout:       f.client.Timeout,
+		CheckRedirect: f.client.CheckRedirect,
+	})
+	_, err := f.Fetch(context.Background(), srv.URL)
+	assert.ErrorIs(t, err, ErrFetchFailed)
+}
+
+func TestIsPrivateHost(t *testing.T) {
+	assert.True(t, isPrivateHost("127.0.0.1"))
+	assert.True(t, isPrivateHost("10.0.0.1"))
+	assert.True(t, isPrivateHost("192.168.1.1"))
+	assert.True(t, isPrivateHost("::1"))
+	assert.False(t, isPrivateHost("8.8.8.8"))
+	assert.False(t, isPrivateHost("example.com"))
+}
+
+func TestHashURL(t *testing.T) {
+	h1 := hashURL("https://example.com")
+	h2 := hashURL("https://example.com")
+	h3 := hashURL("https://other.com")
+	assert.Equal(t, h1, h2)
+	assert.NotEqual(t, h1, h3)
+	assert.Len(t, h1, 64)
+}

--- a/internal/core/urlpreview/parser.go
+++ b/internal/core/urlpreview/parser.go
@@ -1,0 +1,113 @@
+package urlpreview
+
+import (
+	"io"
+	"strings"
+
+	"golang.org/x/net/html"
+)
+
+// ParseHTML extracts OGP and Twitter card metadata from HTML content.
+// 本家 Misskey の summaly と同じ優先順位: og:* > twitter:* > <title>/<link>。
+func ParseHTML(r io.Reader, pageURL string) *Result {
+	doc, err := html.Parse(r)
+	if err != nil {
+		return &Result{URL: pageURL, Player: PlayerResult{Allow: []string{}}}
+	}
+
+	meta := extractMeta(doc)
+
+	title := firstNonEmpty(meta["og:title"], meta["twitter:title"], meta["title"])
+	desc := firstNonEmpty(meta["og:description"], meta["twitter:description"], meta["description"])
+	thumb := firstNonEmpty(meta["og:image"], meta["twitter:image"], meta["twitter:image:src"])
+	icon := meta["icon"]
+	sitename := firstNonEmpty(meta["og:site_name"])
+	apID := firstNonEmpty(meta["ap:id"])
+
+	result := &Result{
+		URL:    firstNonEmpty(meta["og:url"], pageURL),
+		Player: PlayerResult{Allow: []string{}},
+	}
+	if title != "" {
+		result.Title = &title
+	}
+	if desc != "" {
+		result.Description = &desc
+	}
+	if thumb != "" {
+		result.Thumbnail = &thumb
+	}
+	if icon != "" {
+		result.Icon = &icon
+	}
+	if sitename != "" {
+		result.Sitename = &sitename
+	}
+	if apID != "" {
+		result.ActivityPub = &apID
+	}
+	return result
+}
+
+type metaMap map[string]string
+
+func extractMeta(n *html.Node) metaMap {
+	m := make(metaMap)
+	var walk func(*html.Node)
+	walk = func(n *html.Node) {
+		if n.Type == html.ElementNode {
+			switch n.Data {
+			case "meta":
+				key, val := metaKeyVal(n)
+				if key != "" && val != "" {
+					m[key] = val
+				}
+			case "title":
+				if n.FirstChild != nil && n.FirstChild.Type == html.TextNode {
+					m["title"] = strings.TrimSpace(n.FirstChild.Data)
+				}
+			case "link":
+				rel, href := attrVal(n, "rel"), attrVal(n, "href")
+				if (rel == "icon" || rel == "shortcut icon") && href != "" {
+					m["icon"] = href
+				}
+				// alternate + application/activity+json → AP ID
+				if rel == "alternate" && strings.Contains(attrVal(n, "type"), "activity+json") && href != "" {
+					m["ap:id"] = href
+				}
+			}
+		}
+		for c := n.FirstChild; c != nil; c = c.NextSibling {
+			walk(c)
+		}
+	}
+	walk(n)
+	return m
+}
+
+func metaKeyVal(n *html.Node) (string, string) {
+	name := attrVal(n, "property")
+	if name == "" {
+		name = attrVal(n, "name")
+	}
+	content := attrVal(n, "content")
+	return strings.ToLower(name), content
+}
+
+func attrVal(n *html.Node, key string) string {
+	for _, a := range n.Attr {
+		if a.Key == key {
+			return a.Val
+		}
+	}
+	return ""
+}
+
+func firstNonEmpty(vals ...string) string {
+	for _, v := range vals {
+		if v != "" {
+			return v
+		}
+	}
+	return ""
+}

--- a/internal/core/urlpreview/parser_test.go
+++ b/internal/core/urlpreview/parser_test.go
@@ -1,0 +1,69 @@
+package urlpreview
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestParseHTML_OGP(t *testing.T) {
+	html := `<html><head>
+		<meta property="og:title" content="Test Page">
+		<meta property="og:description" content="A description">
+		<meta property="og:image" content="https://example.com/img.png">
+		<meta property="og:site_name" content="Example">
+		<meta property="og:url" content="https://example.com/page">
+		<link rel="icon" href="/favicon.ico">
+	</head><body></body></html>`
+
+	r := ParseHTML(strings.NewReader(html), "https://example.com/original")
+	require.NotNil(t, r)
+	assert.Equal(t, "Test Page", *r.Title)
+	assert.Equal(t, "A description", *r.Description)
+	assert.Equal(t, "https://example.com/img.png", *r.Thumbnail)
+	assert.Equal(t, "/favicon.ico", *r.Icon)
+	assert.Equal(t, "Example", *r.Sitename)
+	assert.Equal(t, "https://example.com/page", r.URL)
+}
+
+func TestParseHTML_TwitterCard(t *testing.T) {
+	html := `<html><head>
+		<meta name="twitter:title" content="Tweet Title">
+		<meta name="twitter:description" content="Tweet desc">
+		<meta name="twitter:image" content="https://example.com/tw.png">
+	</head><body></body></html>`
+
+	r := ParseHTML(strings.NewReader(html), "https://example.com")
+	assert.Equal(t, "Tweet Title", *r.Title)
+	assert.Equal(t, "Tweet desc", *r.Description)
+	assert.Equal(t, "https://example.com/tw.png", *r.Thumbnail)
+}
+
+func TestParseHTML_FallbackToTitle(t *testing.T) {
+	html := `<html><head><title>Fallback Title</title></head><body></body></html>`
+	r := ParseHTML(strings.NewReader(html), "https://example.com")
+	assert.Equal(t, "Fallback Title", *r.Title)
+	assert.Nil(t, r.Description)
+}
+
+func TestParseHTML_ActivityPub(t *testing.T) {
+	html := `<html><head>
+		<link rel="alternate" type="application/activity+json" href="https://example.com/users/alice">
+	</head><body></body></html>`
+	r := ParseHTML(strings.NewReader(html), "https://example.com")
+	require.NotNil(t, r.ActivityPub)
+	assert.Equal(t, "https://example.com/users/alice", *r.ActivityPub)
+}
+
+func TestParseHTML_Empty(t *testing.T) {
+	r := ParseHTML(strings.NewReader(""), "https://example.com")
+	assert.Equal(t, "https://example.com", r.URL)
+	assert.Nil(t, r.Title)
+}
+
+func TestParseHTML_InvalidHTML(t *testing.T) {
+	r := ParseHTML(strings.NewReader("<not valid <<< html"), "https://example.com")
+	assert.Equal(t, "https://example.com", r.URL)
+}

--- a/internal/core/urlpreview/preview.go
+++ b/internal/core/urlpreview/preview.go
@@ -1,0 +1,24 @@
+// Package urlpreview fetches and parses URL metadata (OGP, Twitter card)
+// for link preview cards. Mirrors the original Misskey's summaly behavior.
+package urlpreview
+
+// Result is the URL preview response shape matching Misskey's SummalyResult.
+type Result struct {
+	Title       *string      `json:"title"`
+	Description *string      `json:"description"`
+	Thumbnail   *string      `json:"thumbnail"`
+	Icon        *string      `json:"icon"`
+	Sitename    *string      `json:"sitename"`
+	URL         string       `json:"url"`
+	Player      PlayerResult `json:"player"`
+	Sensitive   bool         `json:"sensitive"`
+	ActivityPub *string      `json:"activityPub"`
+}
+
+// PlayerResult holds embedded player (oEmbed) info.
+type PlayerResult struct {
+	URL    *string  `json:"url"`
+	Width  *int     `json:"width"`
+	Height *int     `json:"height"`
+	Allow  []string `json:"allow"`
+}

--- a/internal/server/router.go
+++ b/internal/server/router.go
@@ -44,6 +44,7 @@ import (
 	"github.com/shiroha-a/mk/internal/api/streaming"
 	apisw "github.com/shiroha-a/mk/internal/api/sw"
 	apitest "github.com/shiroha-a/mk/internal/api/test"
+	apiurl "github.com/shiroha-a/mk/internal/api/url"
 	apiuserlists "github.com/shiroha-a/mk/internal/api/userlists"
 	"github.com/shiroha-a/mk/internal/api/users"
 	apiwebhooks "github.com/shiroha-a/mk/internal/api/webhooks"
@@ -78,6 +79,7 @@ import (
 	coretransfer "github.com/shiroha-a/mk/internal/core/transfer"
 	coretranslate "github.com/shiroha-a/mk/internal/core/translate"
 	coretwofactor "github.com/shiroha-a/mk/internal/core/twofactor"
+	coreurlpreview "github.com/shiroha-a/mk/internal/core/urlpreview"
 	coreuser "github.com/shiroha-a/mk/internal/core/user"
 	corewebhook "github.com/shiroha-a/mk/internal/core/webhook"
 	corewebpush "github.com/shiroha-a/mk/internal/core/webpush"
@@ -387,6 +389,26 @@ func (s *Server) setupRoutes() {
 	metaHandler.SetAdRepo(repository.NewAdRepository(s.db))
 	api.POST("/meta", metaHandler.Meta)
 	api.POST("/ping", metaHandler.Ping)
+
+	// URL preview endpoint
+	if previewMeta, err := metaRepo.Fetch(); err == nil {
+		previewCfg := coreurlpreview.Config{
+			Enabled:              previewMeta.URLPreviewEnabled,
+			AllowRedirect:        previewMeta.URLPreviewAllowRedirect,
+			TimeoutMs:            previewMeta.URLPreviewTimeout,
+			MaxContentLength:     previewMeta.URLPreviewMaximumContentLength,
+			RequireContentLength: previewMeta.URLPreviewRequireContentLength,
+		}
+		if previewMeta.URLPreviewUserAgent != nil {
+			previewCfg.UserAgent = *previewMeta.URLPreviewUserAgent
+		}
+		if previewMeta.URLPreviewSummaryProxyURL != nil {
+			previewCfg.SummaryProxyURL = *previewMeta.URLPreviewSummaryProxyURL
+		}
+		urlPreviewFetcher := coreurlpreview.NewFetcher(previewCfg, s.redis.Default)
+		urlHandler := apiurl.NewHandler(urlPreviewFetcher)
+		s.echo.GET("/url", urlHandler.Preview)
+	}
 
 	// Test-only endpoints — TestMode=true のときだけ公開する。
 	// Cypress の resetState コマンドが依存する /api/reset-db はここで登録する。


### PR DESCRIPTION
## Summary

Issue #33 (DB-compat フォローアップ) の C-2 項目。URL プレビュー機能を新規実装。

## 主な変更点

### 新規: `internal/core/urlpreview/`
- **`preview.go`**: `Result` struct (Misskey SummalyResult 互換: title, description, thumbnail, icon, sitename, url, player, sensitive, activityPub)
- **`parser.go`**: `x/net/html` で OGP (`og:*`) / Twitter Card (`twitter:*`) / `<title>` / `<link rel=icon>` / AP alternate link を抽出。優先順位: og > twitter > fallback
- **`fetcher.go`**: Meta config 制御の HTTP fetcher
  - `timeout` / `maxContentLength` / `requireContentLength` / `allowRedirect` / `userAgent` を Meta から読み取り
  - **SSRF 保護**: `net.Dialer.DialContext` でプライベート/ループバックIP接続を拒否 (`isPrivateHost`)
  - **Redis キャッシュ**: `url-preview:<sha256(url)>` キーで 24h TTL
  - **外部 proxy 委譲**: `summaryProxyUrl` が設定されていれば外部サービスに JSON 委譲

### 新規: `internal/api/url/handler.go`
- `GET /url?url=X`: SummalyResult JSON を返す。エラー時は全フィールド null の安全なレスポンス (frontend が壊れないように)

### meta 露出
- `enableUrlPreview`: ハードコード `false` → `m.URLPreviewEnabled` (実値)

## テスト

追加 (17 tests):
- `parser_test.go`: OGP, Twitter Card, fallback title, ActivityPub link, empty/invalid HTML
- `fetcher_test.go`: disabled, fetch+parse, non-HTML, content-length too large, require content-length, private IP (SSRF), server error, via proxy, no redirect, isPrivateHost, hashURL

カバレッジ: `internal/core/urlpreview`: **90.3%**

実行: `go test -race -count=1 -timeout 10m ./...`

## 関連

Closes #45
Part of #33