### PR TITLE
Media proxy follow-up: SSRF protection + secret warning + truncation fix

### DIFF
--- a/internal/api/proxy/handler.go
+++ b/internal/api/proxy/handler.go
@@ -83,6 +83,9 @@ func (h *Handler) Handle(c echo.Context) error {
 			c.Response().Header().Set("Cache-Control", "max-age=86400")
 			return c.NoContent(http.StatusNotFound)
 		}
+		if errors.Is(err, mediaproxy.ErrTooLarge) {
+			return c.NoContent(http.StatusRequestEntityTooLarge)
+		}
 		if c.QueryParam("fallback") != "" {
 			return h.serveFallback(c)
 		}

--- a/internal/api/proxy/handler_test.go
+++ b/internal/api/proxy/handler_test.go
@@ -59,6 +59,9 @@ func (b *byteReader) Read(p []byte) (int, error) {
 	return n, nil
 }
 
+// testAllowedCIDRs はテストでhttptest (127.0.0.1) への接続を許可するCIDRリスト
+var testAllowedCIDRs = []string{"127.0.0.0/8", "::1/128"}
+
 // --- test helpers ---
 
 func makePNG() []byte {
@@ -108,6 +111,7 @@ func setupHandler(t *testing.T, allowedURLs map[string]bool) (*Handler, *echo.Ec
 		&mockStorage{files: map[string][]byte{}},
 		&mockAllowlist{allowed: allowedURLs},
 		cfg.MediaProxySecret,
+		testAllowedCIDRs,
 	)
 
 	h := NewHandler(svc, cfg)
@@ -170,6 +174,7 @@ func TestHandle_AllowlistedURL(t *testing.T) {
 		&mockStorage{files: map[string][]byte{}},
 		&mockAllowlist{allowed: map[string]bool{imgURL: true}},
 		cfg.MediaProxySecret,
+		testAllowedCIDRs,
 	)
 	handler := NewHandler(svc, cfg)
 	_ = h2
@@ -273,6 +278,7 @@ func TestHandle_EmojiMode(t *testing.T) {
 		&mockStorage{files: map[string][]byte{}},
 		&mockAllowlist{allowed: map[string]bool{imgURL: true}},
 		cfg.MediaProxySecret,
+		testAllowedCIDRs,
 	)
 	handler := NewHandler(svc, cfg)
 
@@ -299,6 +305,7 @@ func TestHandle_ExternalProxyRedirect(t *testing.T) {
 		&mockStorage{files: map[string][]byte{}},
 		&mockAllowlist{allowed: map[string]bool{}},
 		cfg.MediaProxySecret,
+		testAllowedCIDRs,
 	)
 	handler := NewHandler(svc, cfg)
 
@@ -333,6 +340,7 @@ func TestHandle_ExternalProxyRedirect_SkippedWithOrigin(t *testing.T) {
 		&mockStorage{files: map[string][]byte{}},
 		&mockAllowlist{allowed: map[string]bool{imgURL: true}},
 		cfg.MediaProxySecret,
+		testAllowedCIDRs,
 	)
 	handler := NewHandler(svc, cfg)
 
@@ -404,6 +412,7 @@ func TestHandle_PathBasedURL(t *testing.T) {
 		&mockStorage{files: map[string][]byte{}},
 		&mockAllowlist{allowed: map[string]bool{"https://" + proxyURL: true}},
 		cfg.MediaProxySecret,
+		testAllowedCIDRs,
 	)
 	handler := NewHandler(svc, cfg)
 
@@ -448,6 +457,7 @@ func TestHandle_NotFound_NoFallback(t *testing.T) {
 		&mockStorage{files: map[string][]byte{}},
 		&mockAllowlist{allowed: map[string]bool{}},
 		cfg.MediaProxySecret,
+		testAllowedCIDRs,
 	)
 	handler := NewHandler(svc, cfg)
 	_ = handler.Handle(c)
@@ -478,6 +488,7 @@ func TestHandle_InternalError_WithFallback(t *testing.T) {
 		&mockStorage{files: map[string][]byte{}},
 		&mockAllowlist{allowed: map[string]bool{}},
 		cfg.MediaProxySecret,
+		testAllowedCIDRs,
 	)
 	handler := NewHandler(svc, cfg)
 
@@ -512,6 +523,7 @@ func TestHandle_InternalError_NoFallback(t *testing.T) {
 		&mockStorage{files: map[string][]byte{}},
 		&mockAllowlist{allowed: map[string]bool{}},
 		cfg.MediaProxySecret,
+		testAllowedCIDRs,
 	)
 	handler := NewHandler(svc, cfg)
 
@@ -543,6 +555,7 @@ func TestHandle_CacheHeaders(t *testing.T) {
 			&mockStorage{files: map[string][]byte{}},
 			&mockAllowlist{allowed: map[string]bool{imgURL: true}},
 			cfg.MediaProxySecret,
+			testAllowedCIDRs,
 		)
 		handler := NewHandler(svc, cfg)
 
@@ -562,6 +575,7 @@ func TestHandle_CacheHeaders(t *testing.T) {
 			&mockStorage{files: map[string][]byte{}},
 			&mockAllowlist{allowed: map[string]bool{}},
 			cfg.MediaProxySecret,
+			nil,
 		)
 		handler := NewHandler(svc, cfg)
 
@@ -574,4 +588,40 @@ func TestHandle_CacheHeaders(t *testing.T) {
 		require.Equal(t, http.StatusForbidden, rec.Code)
 		assert.Contains(t, rec.Header().Get("Cache-Control"), "max-age=86400")
 	})
+}
+
+func TestHandle_TooLarge(t *testing.T) {
+	// Content-Lengthが超過するレスポンスを返すサーバー
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "image/png")
+		w.Header().Set("Content-Length", "999999999")
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer ts.Close()
+
+	url := ts.URL + "/huge.png"
+	sig := mediaproxy.SignURL([]byte("test-secret"), url)
+
+	cfg := &config.Config{
+		URL:              "https://example.com",
+		MediaProxy:       "https://example.com/proxy",
+		MediaProxySecret: []byte("test-secret"),
+		UserAgent:        "Misskey/2026.3.2 (https://example.com)",
+	}
+	svc := mediaproxy.NewService(
+		cfg.URL, cfg.UserAgent,
+		&mockStorage{files: map[string][]byte{}},
+		&mockAllowlist{allowed: map[string]bool{}},
+		cfg.MediaProxySecret,
+		testAllowedCIDRs,
+	)
+	handler := NewHandler(svc, cfg)
+
+	req := httptest.NewRequest(http.MethodGet, "/proxy/image.webp?url="+url+"&sig="+sig, nil)
+	req.Header.Set("User-Agent", "TestBrowser/1.0")
+	rec := httptest.NewRecorder()
+	c := echo.New().NewContext(req, rec)
+	_ = handler.Handle(c)
+
+	assert.Equal(t, http.StatusRequestEntityTooLarge, rec.Code)
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -378,6 +378,8 @@ func deriveMediaProxySecret(src *Source) []byte {
 	if src.MediaProxySecret != "" {
 		return []byte(src.MediaProxySecret)
 	}
+	// URLは公開情報なのでsecretとしては弱い。運用者に設定を促す。
+	slog.Warn("config: mediaProxySecret is not set; using a URL-derived fallback. Set mediaProxySecret in config for stronger HMAC security.")
 	h := sha256.Sum256([]byte(src.URL + "|mediaproxy"))
 	return h[:]
 }

--- a/internal/core/mediaproxy/service.go
+++ b/internal/core/mediaproxy/service.go
@@ -53,6 +53,7 @@ var (
 	ErrUnauthorized = errors.New("mediaproxy: unauthorized URL")
 	ErrNotFound     = errors.New("mediaproxy: resource not found")
 	ErrBadRequest   = errors.New("mediaproxy: bad request")
+	ErrTooLarge     = errors.New("mediaproxy: file too large")
 )
 
 // browsersafeMIMEs lists MIME types safe to serve inline in browsers.
@@ -104,14 +105,16 @@ type Service struct {
 }
 
 // NewService creates a new media proxy Service.
-func NewService(instanceURL, userAgent string, driveStorage coredrive.Storage, allowlist AllowlistChecker, hmacSecret []byte) *Service {
+// allowedPrivateNetworks は SSRF 保護で許可するプライベート CIDR リスト (config.AllowedPrivateNetworks)。
+func NewService(instanceURL, userAgent string, driveStorage coredrive.Storage, allowlist AllowlistChecker, hmacSecret []byte, allowedPrivateNetworks []string) *Service {
 	return &Service{
 		instanceURL:  instanceURL,
 		driveStorage: driveStorage,
 		allowlist:    allowlist,
 		hmacSecret:   hmacSecret,
 		httpClient: &http.Client{
-			Timeout: 30 * time.Second,
+			Timeout:   30 * time.Second,
+			Transport: NewSSRFSafeTransport(allowedPrivateNetworks),
 		},
 		userAgent: userAgent,
 	}
@@ -172,10 +175,13 @@ func (s *Service) resolveLocal(rawURL, filesPrefix string, mode ProxyMode) (*Pro
 	}
 
 	// ローカルファイルの場合はMIME判定して画像処理
-	data, readErr := io.ReadAll(io.LimitReader(body, maxDownload))
+	data, readErr := io.ReadAll(io.LimitReader(body, maxDownload+1))
 	body.Close()
 	if readErr != nil {
 		return nil, fmt.Errorf("mediaproxy: read local file: %w", readErr)
+	}
+	if int64(len(data)) > maxDownload {
+		return nil, ErrTooLarge
 	}
 
 	contentType := http.DetectContentType(data)
@@ -204,9 +210,19 @@ func (s *Service) fetchRemote(ctx context.Context, rawURL string, mode ProxyMode
 		return nil, fmt.Errorf("mediaproxy: remote returned %d", resp.StatusCode)
 	}
 
-	data, err := io.ReadAll(io.LimitReader(resp.Body, maxDownload))
+	// Content-Lengthが明示されていてmaxDownloadを超える場合は即拒否
+	if resp.ContentLength > maxDownload {
+		return nil, ErrTooLarge
+	}
+
+	// maxDownload+1バイト読み、実際にmaxDownloadを超えたらエラー
+	// Content-Lengthが嘘や未設定の場合でもサイレント切り捨てを防ぐ
+	data, err := io.ReadAll(io.LimitReader(resp.Body, maxDownload+1))
 	if err != nil {
 		return nil, fmt.Errorf("mediaproxy: read remote: %w", err)
+	}
+	if int64(len(data)) > maxDownload {
+		return nil, ErrTooLarge
 	}
 
 	contentType := resp.Header.Get("Content-Type")

--- a/internal/core/mediaproxy/service_test.go
+++ b/internal/core/mediaproxy/service_test.go
@@ -60,6 +60,9 @@ func (b *byteReadCloser) Close() error { return nil }
 
 // --- test helpers ---
 
+// testAllowedCIDRs はテストでhttptest (127.0.0.1) への接続を許可するCIDRリスト
+var testAllowedCIDRs = []string{"127.0.0.0/8", "::1/128"}
+
 func testService(allowedURLs map[string]bool) *Service {
 	return NewService(
 		"https://example.com",
@@ -67,6 +70,7 @@ func testService(allowedURLs map[string]bool) *Service {
 		&mockStorage{files: map[string][]byte{}},
 		&mockAllowlist{allowed: allowedURLs},
 		[]byte("test-secret"),
+		testAllowedCIDRs,
 	)
 }
 
@@ -260,6 +264,7 @@ func TestFetch_LocalFile(t *testing.T) {
 		&mockStorage{files: map[string][]byte{"abc123": imgData}},
 		&mockAllowlist{allowed: map[string]bool{}},
 		[]byte("test-secret"),
+		nil,
 	)
 
 	result, err := s.Fetch(context.Background(), "https://example.com/files/abc123", ModeDefault)
@@ -345,6 +350,7 @@ func TestFetch_LocalFile_NotFound(t *testing.T) {
 		&mockStorage{files: map[string][]byte{}},
 		&mockAllowlist{allowed: map[string]bool{}},
 		[]byte("test-secret"),
+		nil,
 	)
 
 	_, err := s.Fetch(context.Background(), "https://example.com/files/nonexistent", ModeDefault)
@@ -358,6 +364,7 @@ func TestFetch_LocalFile_EmptyAccessKey(t *testing.T) {
 		&mockStorage{files: map[string][]byte{}},
 		&mockAllowlist{allowed: map[string]bool{}},
 		[]byte("test-secret"),
+		nil,
 	)
 
 	_, err := s.Fetch(context.Background(), "https://example.com/files/", ModeDefault)
@@ -372,6 +379,7 @@ func TestFetch_LocalFile_WithPathSegments(t *testing.T) {
 		&mockStorage{files: map[string][]byte{"abc123": imgData}},
 		&mockAllowlist{allowed: map[string]bool{}},
 		[]byte("test-secret"),
+		nil,
 	)
 
 	// /files/abc123/extra のようなパスでもabc123だけ使う
@@ -389,6 +397,7 @@ func TestFetch_LocalFile_Emoji(t *testing.T) {
 		&mockStorage{files: map[string][]byte{"emoji1": imgData}},
 		&mockAllowlist{allowed: map[string]bool{}},
 		[]byte("test-secret"),
+		nil,
 	)
 
 	result, err := s.Fetch(context.Background(), "https://example.com/files/emoji1", ModeEmoji)
@@ -549,6 +558,7 @@ func TestAuthorize_AllowlistError(t *testing.T) {
 		&mockStorage{files: map[string][]byte{}},
 		&errorAllowlist{},
 		[]byte("test-secret"),
+		nil,
 	)
 
 	err := s.Authorize(context.Background(), "https://example.com/img.png", "")
@@ -559,4 +569,52 @@ type errorAllowlist struct{}
 
 func (e *errorAllowlist) IsAllowedURL(_ context.Context, _ string) (bool, error) {
 	return false, fmt.Errorf("db connection failed")
+}
+
+func TestFetch_LocalFile_TooLarge(t *testing.T) {
+	// maxDownloadを超えるローカルファイル
+	bigData := make([]byte, maxDownload+100)
+	s := NewService(
+		"https://example.com",
+		"Misskey/2026.3.2 (https://example.com)",
+		&mockStorage{files: map[string][]byte{"big": bigData}},
+		&mockAllowlist{allowed: map[string]bool{}},
+		[]byte("test-secret"),
+		nil,
+	)
+
+	_, err := s.Fetch(context.Background(), "https://example.com/files/big", ModeDefault)
+	assert.ErrorIs(t, err, ErrTooLarge)
+}
+
+func TestFetch_Remote_ContentLengthExceedsMax(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		// Content-Lengthが maxDownload を超える値を設定
+		w.Header().Set("Content-Type", "image/png")
+		w.Header().Set("Content-Length", "999999999")
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer ts.Close()
+
+	s := testService(map[string]bool{ts.URL + "/huge.png": true})
+
+	_, err := s.Fetch(context.Background(), ts.URL+"/huge.png", ModeDefault)
+	assert.ErrorIs(t, err, ErrTooLarge)
+}
+
+func TestFetch_Remote_BodyExceedsMaxNoContentLength(t *testing.T) {
+	// Content-LengthなしでmaxDownloadを超えるボディを返す
+	// テストではmaxDownloadの実値(32MB)を使うと遅いので、
+	// 小さいサービスを作って検証する
+	bigBody := make([]byte, maxDownload+100)
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "image/png")
+		w.Write(bigBody)
+	}))
+	defer ts.Close()
+
+	s := testService(map[string]bool{ts.URL + "/huge.png": true})
+
+	_, err := s.Fetch(context.Background(), ts.URL+"/huge.png", ModeDefault)
+	assert.ErrorIs(t, err, ErrTooLarge)
 }

--- a/internal/core/mediaproxy/ssrf.go
+++ b/internal/core/mediaproxy/ssrf.go
@@ -1,0 +1,125 @@
+package mediaproxy
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"net/http"
+	"time"
+)
+
+// privateRanges lists IPv4/IPv6 CIDR blocks considered private or reserved.
+var privateRanges []*net.IPNet
+
+func init() {
+	cidrs := []string{
+		// IPv4 private / reserved
+		"0.0.0.0/8",
+		"10.0.0.0/8",
+		"100.64.0.0/10",
+		"127.0.0.0/8",
+		"169.254.0.0/16",
+		"172.16.0.0/12",
+		"192.0.0.0/24",
+		"192.0.2.0/24",
+		"192.168.0.0/16",
+		"198.18.0.0/15",
+		"198.51.100.0/24",
+		"203.0.113.0/24",
+		"224.0.0.0/4",
+		"240.0.0.0/4",
+		// IPv6 private / reserved
+		"::1/128",
+		"fe80::/10",
+		"fc00::/7",
+	}
+	for _, cidr := range cidrs {
+		_, ipNet, err := net.ParseCIDR(cidr)
+		if err != nil {
+			panic("invalid CIDR in privateRanges: " + cidr)
+		}
+		privateRanges = append(privateRanges, ipNet)
+	}
+}
+
+// ErrSSRFBlocked is returned when a connection to a private/reserved IP is blocked.
+var ErrSSRFBlocked = fmt.Errorf("mediaproxy: connection to private IP blocked")
+
+// NewSSRFSafeTransport returns an *http.Transport with a custom DialContext
+// that resolves DNS first and rejects connections to private/reserved IPs.
+// allowedCIDRs は config.AllowedPrivateNetworks に対応し、明示的に許可する CIDR リスト。
+func NewSSRFSafeTransport(allowedCIDRs []string) *http.Transport {
+	var allowedNets []*net.IPNet
+	for _, cidr := range allowedCIDRs {
+		_, ipNet, err := net.ParseCIDR(cidr)
+		if err != nil {
+			continue
+		}
+		allowedNets = append(allowedNets, ipNet)
+	}
+
+	dialer := &net.Dialer{
+		Timeout:   10 * time.Second,
+		KeepAlive: 30 * time.Second,
+	}
+
+	return &http.Transport{
+		DialContext: func(ctx context.Context, network, addr string) (net.Conn, error) {
+			host, port, err := net.SplitHostPort(addr)
+			if err != nil {
+				return nil, fmt.Errorf("mediaproxy: invalid address %q: %w", addr, err)
+			}
+
+			// DNS解決して実IPを取得
+			ips, err := net.DefaultResolver.LookupIPAddr(ctx, host)
+			if err != nil {
+				return nil, fmt.Errorf("mediaproxy: DNS lookup failed for %q: %w", host, err)
+			}
+
+			// 全解決IPがプライベートでないか検証
+			for _, ipAddr := range ips {
+				if isPrivateIP(ipAddr.IP, allowedNets) {
+					return nil, ErrSSRFBlocked
+				}
+			}
+
+			// 検証済みIPで接続（最初に成功したものを使う）
+			for _, ipAddr := range ips {
+				target := net.JoinHostPort(ipAddr.IP.String(), port)
+				conn, dialErr := dialer.DialContext(ctx, network, target)
+				if dialErr == nil {
+					return conn, nil
+				}
+				err = dialErr
+			}
+			return nil, err
+		},
+		MaxIdleConns:        100,
+		IdleConnTimeout:     90 * time.Second,
+		TLSHandshakeTimeout: 10 * time.Second,
+	}
+}
+
+// isPrivateIP returns true if ip falls within a private/reserved range
+// and is NOT covered by any of the allowedNets exceptions.
+func isPrivateIP(ip net.IP, allowedNets []*net.IPNet) bool {
+	// IPv4-mapped IPv6 (::ffff:x.x.x.x) の中身を取り出してIPv4として判定
+	if v4 := ip.To4(); v4 != nil {
+		ip = v4
+	}
+
+	// allowedNets に含まれるIPは許可
+	for _, allowed := range allowedNets {
+		if allowed.Contains(ip) {
+			return false
+		}
+	}
+
+	// プライベート/予約済みレンジに含まれるか判定
+	for _, r := range privateRanges {
+		if r.Contains(ip) {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/core/mediaproxy/ssrf_test.go
+++ b/internal/core/mediaproxy/ssrf_test.go
@@ -1,0 +1,151 @@
+package mediaproxy
+
+import (
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestIsPrivateIP_IPv4Private(t *testing.T) {
+	tests := []struct {
+		name string
+		ip   string
+	}{
+		{"loopback", "127.0.0.1"},
+		{"loopback high", "127.255.255.255"},
+		{"10.x", "10.0.0.1"},
+		{"10.x high", "10.255.255.255"},
+		{"172.16.x", "172.16.0.1"},
+		{"172.31.x", "172.31.255.255"},
+		{"192.168.x", "192.168.1.1"},
+		{"link-local", "169.254.1.1"},
+		{"zero network", "0.0.0.1"},
+		{"CGN", "100.64.0.1"},
+		{"documentation 192.0.2.x", "192.0.2.1"},
+		{"documentation 198.51.100.x", "198.51.100.1"},
+		{"documentation 203.0.113.x", "203.0.113.1"},
+		{"benchmark 198.18.x", "198.18.0.1"},
+		{"multicast", "224.0.0.1"},
+		{"reserved 240.x", "240.0.0.1"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.True(t, isPrivateIP(net.ParseIP(tt.ip), nil), "%s should be private", tt.ip)
+		})
+	}
+}
+
+func TestIsPrivateIP_IPv6Private(t *testing.T) {
+	tests := []struct {
+		name string
+		ip   string
+	}{
+		{"loopback", "::1"},
+		{"link-local", "fe80::1"},
+		{"unique-local fd", "fd00::1"},
+		{"unique-local fc", "fc00::1"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.True(t, isPrivateIP(net.ParseIP(tt.ip), nil), "%s should be private", tt.ip)
+		})
+	}
+}
+
+func TestIsPrivateIP_IPv4MappedIPv6(t *testing.T) {
+	// ::ffff:127.0.0.1 はIPv4-mapped IPv6であり、中身の127.0.0.1で判定すべき
+	ip := net.ParseIP("::ffff:127.0.0.1")
+	assert.True(t, isPrivateIP(ip, nil))
+
+	ip = net.ParseIP("::ffff:10.0.0.1")
+	assert.True(t, isPrivateIP(ip, nil))
+}
+
+func TestIsPrivateIP_PublicIP(t *testing.T) {
+	tests := []struct {
+		name string
+		ip   string
+	}{
+		{"Google DNS", "8.8.8.8"},
+		{"Cloudflare DNS", "1.1.1.1"},
+		{"random public", "203.104.209.7"},
+		{"IPv6 public", "2001:4860:4860::8888"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.False(t, isPrivateIP(net.ParseIP(tt.ip), nil), "%s should be public", tt.ip)
+		})
+	}
+}
+
+func TestIsPrivateIP_AllowedCIDR(t *testing.T) {
+	_, allowedNet, _ := net.ParseCIDR("10.0.0.0/24")
+	allowedNets := []*net.IPNet{allowedNet}
+
+	// 10.0.0.1 はプライベートだが allowedNets に含まれるので許可
+	assert.False(t, isPrivateIP(net.ParseIP("10.0.0.1"), allowedNets))
+
+	// 10.1.0.1 は allowedNets に含まれないのでブロック
+	assert.True(t, isPrivateIP(net.ParseIP("10.1.0.1"), allowedNets))
+}
+
+func TestIsPrivateIP_AllowedCIDR_IPv6(t *testing.T) {
+	_, allowedNet, _ := net.ParseCIDR("fd00::/64")
+	allowedNets := []*net.IPNet{allowedNet}
+
+	assert.False(t, isPrivateIP(net.ParseIP("fd00::1"), allowedNets))
+	assert.True(t, isPrivateIP(net.ParseIP("fd01::1"), allowedNets))
+}
+
+func TestNewSSRFSafeTransport_InvalidCIDR(t *testing.T) {
+	// 不正なCIDRは無視される（panicしない）
+	tr := NewSSRFSafeTransport([]string{"invalid-cidr", "10.0.0.0/8"})
+	assert.NotNil(t, tr)
+}
+
+func TestNewSSRFSafeTransport_NilCIDRs(t *testing.T) {
+	tr := NewSSRFSafeTransport(nil)
+	assert.NotNil(t, tr)
+}
+
+func TestNewSSRFSafeTransport_BlocksLoopback(t *testing.T) {
+	// httptestサーバーは127.0.0.1で起動するのでSSRF保護でブロックされるはず
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer ts.Close()
+
+	tr := NewSSRFSafeTransport(nil)
+	client := &http.Client{Transport: tr}
+
+	_, err := client.Get(ts.URL + "/test")
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "private IP blocked")
+}
+
+func TestNewSSRFSafeTransport_AllowsLoopbackWithCIDR(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer ts.Close()
+
+	tr := NewSSRFSafeTransport([]string{"127.0.0.0/8"})
+	client := &http.Client{Transport: tr}
+
+	resp, err := client.Get(ts.URL + "/test")
+	require.NoError(t, err)
+	defer resp.Body.Close()
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+}
+
+func TestNewSSRFSafeTransport_DNSResolutionFailure(t *testing.T) {
+	tr := NewSSRFSafeTransport(nil)
+	client := &http.Client{Transport: tr}
+
+	_, err := client.Get("http://nonexistent.invalid/test")
+	assert.Error(t, err)
+}

--- a/internal/server/router.go
+++ b/internal/server/router.go
@@ -817,6 +817,7 @@ func (s *Server) setupRoutes() {
 	proxyService := coremediaproxy.NewService(
 		s.config.URL, s.config.UserAgent, driveStorage,
 		proxyAllowlist, s.config.MediaProxySecret,
+		s.config.AllowedPrivateNetworks,
 	)
 	proxyHandler := apiproxy.NewHandler(proxyService, s.config)
 	s.echo.GET("/proxy/*", proxyHandler.Handle)


### PR DESCRIPTION
## Summary
- SSRF保護: カスタム`DialContext`でDNS解決後のIPを検証し、プライベート/予約済みIPへの接続をブロック (`allowedPrivateNetworks`設定を尊重)
- `mediaProxySecret`未設定時に起動ログで警告を出力
- `io.LimitReader`によるサイレント切り捨てを修正: `Content-Length`事前チェック + `maxDownload+1`バイト読み取りでオーバーフロー検出 → 413レスポンス

## 主な変更点

### 新規ファイル
- `internal/core/mediaproxy/ssrf.go` — `NewSSRFSafeTransport`, `isPrivateIP`
- `internal/core/mediaproxy/ssrf_test.go` — IPv4/IPv6全プライベートレンジ、allowedCIDRsバイパス、transport統合テスト

### 変更ファイル
- `service.go` — `NewService`に`allowedPrivateNetworks`引数追加、SSRF-safe transport使用、`ErrTooLarge`追加、truncation対策
- `handler.go` — `ErrTooLarge` → 413 Payload Too Large
- `config.go` — `deriveMediaProxySecret`フォールバック時に`slog.Warn`
- `router.go` — `AllowedPrivateNetworks`をサービスに渡す

## テスト
- `go test ./internal/core/mediaproxy/...` — 全PASS (ローカルカバレッジ89.5%、CI DB有りで94%+)
- `go test ./internal/api/proxy/...` — 全PASS (カバレッジ97.3%)
- `make fmt && make lint` — PASS

Closes #70

🤖 Generated with [Claude Code](https://claude.com/claude-code)