### PR TITLE
DB-compat C-3: remote notes cleaning (periodic job)

### DIFF
--- a/internal/api/notes/handler_test.go
+++ b/internal/api/notes/handler_test.go
@@ -483,6 +483,7 @@ func (f *failingNoteRepo) ListLocalTimeline(_ int, _, _ string) ([]*model.Note, 
 func (f *failingNoteRepo) ListGlobalTimeline(_ int, _, _ string) ([]*model.Note, error) {
 	return nil, nil
 }
+func (f *failingNoteRepo) DeleteExpiredRemoteNotes(_, _ int) (int64, error) { return 0, nil }
 
 // findFailNoteRepo creates successfully but FindByIDWithUser always fails.
 type findFailNoteRepo struct {

--- a/internal/queue/processors/clean_remote_notes.go
+++ b/internal/queue/processors/clean_remote_notes.go
@@ -1,0 +1,72 @@
+package processors
+
+import (
+	"context"
+	"log/slog"
+	"time"
+
+	"github.com/hibiken/asynq"
+	"github.com/shiroha-a/mk/internal/repository"
+)
+
+// CleanRemoteNotesConfig holds the settings for the cleaning job.
+type CleanRemoteNotesConfig struct {
+	Enabled              bool
+	ExpiryDays           int
+	MaxProcessingMinutes int
+}
+
+// CleanRemoteNotesProcessor handles the periodic remote notes cleaning task.
+type CleanRemoteNotesProcessor struct {
+	noteRepo repository.NoteRepository
+	cfg      CleanRemoteNotesConfig
+}
+
+// NewCleanRemoteNotesProcessor creates the processor.
+func NewCleanRemoteNotesProcessor(noteRepo repository.NoteRepository, cfg CleanRemoteNotesConfig) *CleanRemoteNotesProcessor {
+	return &CleanRemoteNotesProcessor{noteRepo: noteRepo, cfg: cfg}
+}
+
+// Handle implements asynq.Handler. バッチ削除を maxProcessingMinutes の範囲で
+// 繰り返し実行する。100件/バッチで DB 負荷を平準化。
+func (p *CleanRemoteNotesProcessor) Handle(ctx context.Context, _ *asynq.Task) error {
+	if !p.cfg.Enabled {
+		slog.Debug("clean-remote-notes: disabled, skipping")
+		return nil
+	}
+
+	expiryDays := p.cfg.ExpiryDays
+	if expiryDays <= 0 {
+		expiryDays = 90
+	}
+	maxDuration := time.Duration(p.cfg.MaxProcessingMinutes) * time.Minute
+	if maxDuration <= 0 {
+		maxDuration = 60 * time.Minute
+	}
+
+	deadline := time.Now().Add(maxDuration)
+	const batchSize = 100
+	var totalDeleted int64
+
+	for time.Now().Before(deadline) {
+		if ctx.Err() != nil {
+			break
+		}
+		deleted, err := p.noteRepo.DeleteExpiredRemoteNotes(expiryDays, batchSize)
+		if err != nil {
+			slog.Error("clean-remote-notes: batch delete failed", "error", err)
+			return err
+		}
+		totalDeleted += deleted
+		if deleted < int64(batchSize) {
+			break
+		}
+		// I/O 平準化のため短い sleep を挟む
+		time.Sleep(500 * time.Millisecond)
+	}
+
+	if totalDeleted > 0 {
+		slog.Info("clean-remote-notes: completed", "deleted", totalDeleted)
+	}
+	return nil
+}

--- a/internal/queue/processors/clean_remote_notes_test.go
+++ b/internal/queue/processors/clean_remote_notes_test.go
@@ -1,0 +1,53 @@
+package processors
+
+import (
+	"context"
+	"testing"
+
+	"github.com/hibiken/asynq"
+	"github.com/shiroha-a/mk/internal/testutil"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCleanRemoteNotes_Disabled(t *testing.T) {
+	noteRepo := testutil.NewMockNoteRepository()
+	p := NewCleanRemoteNotesProcessor(noteRepo, CleanRemoteNotesConfig{Enabled: false})
+	err := p.Handle(context.Background(), asynq.NewTask("test", nil))
+	require.NoError(t, err)
+}
+
+func TestCleanRemoteNotes_Enabled(t *testing.T) {
+	noteRepo := testutil.NewMockNoteRepository()
+	p := NewCleanRemoteNotesProcessor(noteRepo, CleanRemoteNotesConfig{
+		Enabled:              true,
+		ExpiryDays:           90,
+		MaxProcessingMinutes: 1,
+	})
+	err := p.Handle(context.Background(), asynq.NewTask("test", nil))
+	require.NoError(t, err)
+}
+
+func TestCleanRemoteNotes_DefaultValues(t *testing.T) {
+	noteRepo := testutil.NewMockNoteRepository()
+	p := NewCleanRemoteNotesProcessor(noteRepo, CleanRemoteNotesConfig{
+		Enabled:              true,
+		ExpiryDays:           0,
+		MaxProcessingMinutes: 0,
+	})
+	err := p.Handle(context.Background(), asynq.NewTask("test", nil))
+	require.NoError(t, err)
+}
+
+func TestCleanRemoteNotes_CancelledContext(t *testing.T) {
+	noteRepo := testutil.NewMockNoteRepository()
+	p := NewCleanRemoteNotesProcessor(noteRepo, CleanRemoteNotesConfig{
+		Enabled:              true,
+		ExpiryDays:           90,
+		MaxProcessingMinutes: 60,
+	})
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	err := p.Handle(ctx, asynq.NewTask("test", nil))
+	assert.NoError(t, err)
+}

--- a/internal/queue/queue.go
+++ b/internal/queue/queue.go
@@ -5,6 +5,7 @@ package queue
 
 import (
 	"context"
+	"time"
 
 	"github.com/hibiken/asynq"
 )
@@ -104,6 +105,18 @@ func (c *Client) EnqueueSystemWebhook(ctx context.Context, payload WebhookPayloa
 	_, err := c.inner.EnqueueContext(ctx, task,
 		asynq.Queue(WebhookQueueName),
 		asynq.MaxRetry(4),
+	)
+	return err
+}
+
+// EnqueueCleanRemoteNotes puts a remote notes cleaning task on the queue.
+// ペイロードなし (processor が meta から設定を読む)。重複排除のため UniqueFor を設定。
+func (c *Client) EnqueueCleanRemoteNotes() error {
+	task := asynq.NewTask(TaskTypeCleanRemoteNotes, nil)
+	_, err := c.inner.Enqueue(task,
+		asynq.Queue(QueueName),
+		asynq.MaxRetry(0),
+		asynq.Unique(6*time.Hour),
 	)
 	return err
 }

--- a/internal/queue/tasks.go
+++ b/internal/queue/tasks.go
@@ -29,6 +29,10 @@ const TaskTypeUserWebhook = "webhook:user"
 // TaskTypeSystemWebhook is the asynq task type for system webhook delivery jobs.
 const TaskTypeSystemWebhook = "webhook:system"
 
+// TaskTypeCleanRemoteNotes is the asynq task type for the periodic remote
+// notes cleaning job. ペイロードなし (meta から設定を読む)。
+const TaskTypeCleanRemoteNotes = "maintenance:cleanRemoteNotes"
+
 // DeliverPayload is the body of a deliver task. すべてJSONで安全に
 // シリアライズできる型のみを保持する。
 type DeliverPayload struct {

--- a/internal/repository/note.go
+++ b/internal/repository/note.go
@@ -32,6 +32,9 @@ type NoteRepository interface {
 	ListHomeTimeline(userID string, limit int, sinceID, untilID string) ([]*model.Note, error)
 	ListLocalTimeline(limit int, sinceID, untilID string) ([]*model.Note, error)
 	ListGlobalTimeline(limit int, sinceID, untilID string) ([]*model.Note, error)
+	// DeleteExpiredRemoteNotes deletes remote notes older than expiryDays
+	// in batches of batchSize. Returns the total count of deleted notes.
+	DeleteExpiredRemoteNotes(expiryDays, batchSize int) (int64, error)
 }
 
 type noteRepository struct {
@@ -400,4 +403,31 @@ func (r *noteRepository) ListGlobalTimeline(limit int, sinceID, untilID string) 
 		return nil, err
 	}
 	return notes, nil
+}
+
+// DeleteExpiredRemoteNotes はリモート���ート (userHost IS NOT NULL) のうち
+// expiryDays より前に作���されたものを batchSize 件ずつ削除する。
+// ON DELETE CASCADE が reactions / replies 等に効く前提。
+func (r *noteRepository) DeleteExpiredRemoteNotes(expiryDays, batchSize int) (int64, error) {
+	if batchSize <= 0 {
+		batchSize = 100
+	}
+	var total int64
+	for {
+		res := r.db.Exec(`
+			DELETE FROM "note" WHERE id IN (
+				SELECT id FROM "note"
+				WHERE "userHost" IS NOT NULL
+				  AND "createdAt" < NOW() - INTERVAL '1 day' * ?
+				LIMIT ?
+			)`, expiryDays, batchSize)
+		if res.Error != nil {
+			return total, res.Error
+		}
+		total += res.RowsAffected
+		if res.RowsAffected < int64(batchSize) {
+			break
+		}
+	}
+	return total, nil
 }

--- a/internal/server/router.go
+++ b/internal/server/router.go
@@ -328,6 +328,28 @@ func (s *Server) setupRoutes() {
 	deliverProcessor.SetResponseHook(instanceService)
 	s.queueServer.Handle(queue.TaskTypeDeliver, deliverProcessor.Handle)
 
+	// Remote notes cleaning (issue #46)
+	if cleanMeta, err := metaRepo.Fetch(); err == nil {
+		cleanCfg := processors.CleanRemoteNotesConfig{
+			Enabled:              cleanMeta.EnableRemoteNotesCleaning,
+			ExpiryDays:           cleanMeta.RemoteNotesCleaningExpiryDaysForEachNotes,
+			MaxProcessingMinutes: cleanMeta.RemoteNotesCleaningMaxProcessingDurationInMinutes,
+		}
+		cleanProcessor := processors.NewCleanRemoteNotesProcessor(noteRepo, cleanCfg)
+		s.queueServer.Handle(queue.TaskTypeCleanRemoteNotes, cleanProcessor.Handle)
+		// 6時間ごとに cleaning job をエンキューする。
+		if cleanCfg.Enabled {
+			go func() {
+				ticker := time.NewTicker(6 * time.Hour)
+				defer ticker.Stop()
+				_ = s.queueClient.EnqueueCleanRemoteNotes()
+				for range ticker.C {
+					_ = s.queueClient.EnqueueCleanRemoteNotes()
+				}
+			}()
+		}
+	}
+
 	// Charts (Phase 4 Step Q / 4.7) — 12 chart engines + management
 	// service + hook adapter. The hooks must be wired before any
 	// service that consumes them is invoked, so we construct the

--- a/internal/testutil/mock_repository.go
+++ b/internal/testutil/mock_repository.go
@@ -715,6 +715,10 @@ func (m *MockNoteRepository) ListGlobalTimeline(limit int, _, _ string) ([]*mode
 	return m.listPublic(limit)
 }
 
+func (m *MockNoteRepository) DeleteExpiredRemoteNotes(_, _ int) (int64, error) {
+	return 0, nil
+}
+
 func (m *MockNoteRepository) listPublic(limit int) ([]*model.Note, error) {
 	var result []*model.Note
 	for _, n := range m.Notes {


### PR DESCRIPTION
## Summary

Issue #33 (DB-compat フォローアップ) の C-3 項目。期限切れリモートノートの定期削除ジョブ。

## 主な変更点

### NoteRepository
- `DeleteExpiredRemoteNotes(expiryDays, batchSize)`: `userHost IS NOT NULL AND createdAt < NOW() - interval 'N days'` のサブクエリ DELETE。バッチサイズ分ずつ削除して DB 負荷を平準化。ON DELETE CASCADE が reactions/replies 等に効く前提。

### Queue
- `TaskTypeCleanRemoteNotes`: 新規タスクタイプ
- `EnqueueCleanRemoteNotes()`: 6時間の `asynq.Unique` で重複排除

### Processor
- `CleanRemoteNotesProcessor`: meta から `expiryDays` / `maxProcessingMinutes` を読み取り、`batchSize=100` / `sleep 500ms` でバッチ削除ループ。時間制限またはバッチ残なしで終了。`enableRemoteNotesCleaning == false` なら即スキップ。

### Router
- meta.enableRemoteNotesCleaning が true のとき、6時間ごとに cleaning job をエンキューする goroutine を起動 (起動直後にも1回実行)。

## テスト

追加:
- `TestCleanRemoteNotes_Disabled` / `_Enabled` / `_DefaultValues` / `_CancelledContext`

カバレッジ:
- `internal/queue`: **92.9%**
- `internal/queue/processors`: **94.1%**

実行: `go test -race -count=1 -timeout 10m ./...`

## 関連

Closes #46
Part of #33