### PR TITLE
Phase 11.1 follow-up: implement /api/signup endpoint

### DIFF
--- a/internal/api/signup/handler.go
+++ b/internal/api/signup/handler.go
@@ -1,0 +1,259 @@
+package signup
+
+import (
+	"errors"
+	"net/http"
+	"time"
+
+	"github.com/labstack/echo/v4"
+
+	"github.com/shiroha-a/mk/internal/core/captcha"
+	coresignup "github.com/shiroha-a/mk/internal/core/signup"
+	"github.com/shiroha-a/mk/internal/entity"
+	"github.com/shiroha-a/mk/internal/misc/id"
+	"github.com/shiroha-a/mk/internal/model"
+	"github.com/shiroha-a/mk/internal/repository"
+)
+
+// TicketStore abstracts registration_ticket DB operations for testability.
+type TicketStore interface {
+	FindByCode(code string) (*model.RegistrationTicket, error)
+	MarkUsed(ticketID, userID string) error
+}
+
+// Handler handles POST /api/signup.
+type Handler struct {
+	signupService *coresignup.Service
+	metaRepo      repository.MetaRepository
+	idGen         id.Generator
+	captchaSvc    *captcha.Service // optional
+	ticketStore   TicketStore      // optional, invitation code検証用
+}
+
+// NewHandler creates a new signup Handler.
+func NewHandler(signupService *coresignup.Service, metaRepo repository.MetaRepository, idGen id.Generator) *Handler {
+	return &Handler{signupService: signupService, metaRepo: metaRepo, idGen: idGen}
+}
+
+// SetCaptcha attaches a CaptchaService for signup verification.
+func (h *Handler) SetCaptcha(svc *captcha.Service) {
+	h.captchaSvc = svc
+}
+
+// SetTicketStore attaches a TicketStore for invitation code validation.
+func (h *Handler) SetTicketStore(ts TicketStore) {
+	h.ticketStore = ts
+}
+
+type signupRequest struct {
+	Username       string `json:"username"`
+	Password       string `json:"password"`
+	InvitationCode string `json:"invitationCode"`
+	// CAPTCHA tokens (フィールド名はTS版スキーマに準拠)
+	HcaptchaResponse    string `json:"hcaptcha-response"`
+	RecaptchaResponse   string `json:"g-recaptcha-response"`
+	TurnstileResponse   string `json:"turnstile-response"`
+	McaptchaResponse    string `json:"m-captcha-response"`
+	TestcaptchaResponse string `json:"testcaptcha-response"`
+}
+
+// Signup handles POST /api/signup.
+func (h *Handler) Signup(c echo.Context) error {
+	var req signupRequest
+	if err := c.Bind(&req); err != nil || req.Username == "" || req.Password == "" {
+		return c.JSON(http.StatusBadRequest, errResp("INVALID_PARAM", "Invalid parameters.", "3d81ceae-475f-4600-b2a8-2bc116157532"))
+	}
+
+	meta, err := h.metaRepo.Fetch()
+	if err != nil {
+		return c.JSON(http.StatusInternalServerError, errResp("INTERNAL_ERROR", "Internal error.", "5d37dbcb-891e-41ca-a3d6-e690c97775ac"))
+	}
+
+	// メール認証フローは未実装
+	if meta.EmailRequiredForSignup {
+		return c.JSON(http.StatusBadRequest, errResp("INVALID_PARAM", "Email-required signup is not yet supported.", "3d81ceae-475f-4600-b2a8-2bc116157532"))
+	}
+
+	// 登録無効時はinvitation code必須
+	var ticket *model.RegistrationTicket
+	if meta.DisableRegistration {
+		t, vErr := h.validateInvitationCode(req.InvitationCode)
+		if vErr != nil {
+			return c.JSON(http.StatusBadRequest, errResp("INVITATION_CODE_INVALID", "Invalid invitation code.", "11e71a03-43c4-4a99-92cf-bb7e2c581998"))
+		}
+		ticket = t
+	}
+
+	// CAPTCHA検証
+	if h.captchaSvc != nil {
+		tokens := captcha.CaptchaTokens{
+			Hcaptcha:    req.HcaptchaResponse,
+			Recaptcha:   req.RecaptchaResponse,
+			Turnstile:   req.TurnstileResponse,
+			Mcaptcha:    req.McaptchaResponse,
+			Testcaptcha: req.TestcaptchaResponse,
+		}
+		if err := h.captchaSvc.Verify(c.Request().Context(), tokens); err != nil {
+			return c.JSON(http.StatusBadRequest, errResp("CAPTCHA_FAILED", "Captcha verification failed.", "bdc32ef5-b0f4-40c0-b767-673b2e3e1f5a"))
+		}
+	}
+
+	result, err := h.signupService.Signup(req.Username, req.Password, false)
+	if err != nil {
+		if err == coresignup.ErrUsernameAlreadyExists {
+			return c.JSON(http.StatusConflict, errResp("USERNAME_ALREADY_EXISTS", "Username already exists.", "a504947-b888-4a99-9f62-8c4a0f3a3dab"))
+		}
+		if err == coresignup.ErrInvalidUsername {
+			return c.JSON(http.StatusBadRequest, errResp("INVALID_PARAM", "Invalid username.", "3d81ceae-475f-4600-b2a8-2bc116157532"))
+		}
+		if err == coresignup.ErrUsernameReserved {
+			return c.JSON(http.StatusBadRequest, errResp("USED_USERNAME", "That username is reserved.", "4b54bee6-2c25-42c3-a10f-7d0d1fbd91f9"))
+		}
+		return c.JSON(http.StatusInternalServerError, errResp("INTERNAL_ERROR", "Internal error.", "5d37dbcb-891e-41ca-a3d6-e690c97775ac"))
+	}
+
+	// invitation code使用済みにする
+	if ticket != nil && h.ticketStore != nil {
+		_ = h.ticketStore.MarkUsed(ticket.ID, result.User.ID)
+	}
+
+	return c.JSON(http.StatusOK, packSignupResponse(result.User, result.Token, h.idGen))
+}
+
+// validateInvitationCode checks the ticket store for a valid invitation code.
+func (h *Handler) validateInvitationCode(code string) (*model.RegistrationTicket, error) {
+	if code == "" || h.ticketStore == nil {
+		return nil, errInvalidCode
+	}
+	ticket, err := h.ticketStore.FindByCode(code)
+	if err != nil {
+		return nil, errInvalidCode
+	}
+	if ticket.UsedByID != nil {
+		return nil, errInvalidCode
+	}
+	if ticket.ExpiresAt != nil && ticket.ExpiresAt.Before(time.Now()) {
+		return nil, errInvalidCode
+	}
+	return ticket, nil
+}
+
+// packSignupResponse builds a MeDetailed + token response for a newly created user.
+func packSignupResponse(u *model.User, token string, idGen id.Generator) map[string]any {
+	detailed := entity.PackUserDetailed(u, nil, idGen)
+	return map[string]any{
+		// UserLite
+		"id":                detailed.ID,
+		"name":              detailed.Name,
+		"username":          detailed.Username,
+		"host":              detailed.Host,
+		"avatarUrl":         detailed.AvatarURL,
+		"avatarBlurhash":    detailed.AvatarBlurhash,
+		"avatarDecorations": detailed.AvatarDecorations,
+		"isBot":             detailed.IsBot,
+		"isCat":             detailed.IsCat,
+		"emojis":            detailed.Emojis,
+		"onlineStatus":      detailed.OnlineStatus,
+		"badgeRoles":        detailed.BadgeRoles,
+		// UserDetailed
+		"bannerUrl":      detailed.BannerURL,
+		"bannerBlurhash": detailed.BannerBlurhash,
+		"isLocked":       detailed.IsLocked,
+		"isSilenced":     false,
+		"isSuspended":    detailed.IsSuspended,
+		"description":    detailed.Description,
+		"location":       detailed.Location,
+		"birthday":       detailed.Birthday,
+		"lang":           detailed.Lang,
+		"fields":         detailed.Fields,
+		"verifiedLinks":  []string{},
+		"followersCount": detailed.FollowersCount,
+		"followingCount": detailed.FollowingCount,
+		"notesCount":     detailed.NotesCount,
+		"pinnedNoteIds":  detailed.PinnedNoteIDs,
+		"pinnedNotes":    detailed.PinnedNotes,
+		"roles":          detailed.Roles,
+		"uri":            detailed.URI,
+		"url":            detailed.URL,
+		"movedTo":        nil,
+		"alsoKnownAs":    nil,
+		"createdAt":      detailed.CreatedAt,
+		"updatedAt":      detailed.UpdatedAt,
+		"lastFetchedAt":  nil,
+		// MeDetailed (新規ユーザーのデフォルト値)
+		"avatarId":                 nil,
+		"bannerId":                 nil,
+		"followersVisibility":      "public",
+		"followingVisibility":      "public",
+		"chatScope":                "mutual",
+		"canChat":                  true,
+		"followedMessage":          nil,
+		"memo":                     nil,
+		"moderationNote":           nil,
+		"isAdmin":                  false,
+		"isModerator":              false,
+		"hideOnlineStatus":         u.HideOnlineStatus,
+		"email":                    nil,
+		"emailVerified":            false,
+		"autoAcceptFollowed":       true,
+		"noCrawle":                 false,
+		"preventAiLearning":        true,
+		"alwaysMarkNsfw":           false,
+		"autoSensitive":            false,
+		"carefulBot":               false,
+		"injectFeaturedNote":       true,
+		"receiveAnnouncementEmail": true,
+		"twoFactorEnabled":         false,
+		"usePasswordLessLogin":     false,
+		"publicReactions":          true,
+		"mutedWords":               []any{},
+		"hardMutedWords":           []any{},
+		"mutedInstances":           []any{},
+		"policies":                 defaultPolicies(),
+		"token":                    token,
+	}
+}
+
+// defaultPolicies returns the Misskey default policies for a new user.
+func defaultPolicies() map[string]any {
+	return map[string]any{
+		"gtlAvailable":               true,
+		"ltlAvailable":               true,
+		"canPublicNote":              true,
+		"mentionLimit":               150,
+		"canInvite":                  false,
+		"inviteLimit":                0,
+		"inviteLimitCycle":           float64(525600),
+		"inviteExpirationTime":       float64(0),
+		"canManageCustomEmojis":      false,
+		"canManageAvatarDecorations": false,
+		"canSearchNotes":             true,
+		"canUseTranslator":           true,
+		"canHideAds":                 false,
+		"driveCapacityMb":            float64(100),
+		"alwaysMarkNsfw":             false,
+		"pinLimit":                   5,
+		"antennaLimit":               5,
+		"wordMuteLimit":              200,
+		"webhookLimit":               3,
+		"clipLimit":                  10,
+		"noteEachClipsLimit":         200,
+		"userListLimit":              10,
+		"userEachUserListsLimit":     50,
+		"rateLimitFactor":            float64(1),
+		"avatarDecorationLimit":      1,
+		"canImportAntennas":          true,
+		"canImportBlocking":          true,
+		"canImportFollowing":         true,
+		"canImportMuting":            true,
+		"canImportUserLists":         true,
+	}
+}
+
+var errInvalidCode = errors.New("invalid invitation code")
+
+func errResp(code, message, id string) map[string]any {
+	return map[string]any{
+		"error": map[string]any{"message": message, "code": code, "id": id},
+	}
+}

--- a/internal/api/signup/handler_test.go
+++ b/internal/api/signup/handler_test.go
@@ -1,0 +1,315 @@
+package signup_test
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/labstack/echo/v4"
+	apisignup "github.com/shiroha-a/mk/internal/api/signup"
+	"github.com/shiroha-a/mk/internal/core/captcha"
+	coresignup "github.com/shiroha-a/mk/internal/core/signup"
+	"github.com/shiroha-a/mk/internal/misc/id"
+	"github.com/shiroha-a/mk/internal/model"
+	"github.com/shiroha-a/mk/internal/testutil"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// mockTicketStore is a test double for signup.TicketStore.
+type mockTicketStore struct {
+	tickets  map[string]*model.RegistrationTicket // keyed by code
+	markUsed map[string]string                    // ticketID → userID
+	markErr  error
+}
+
+func newMockTicketStore() *mockTicketStore {
+	return &mockTicketStore{
+		tickets:  make(map[string]*model.RegistrationTicket),
+		markUsed: make(map[string]string),
+	}
+}
+
+func (m *mockTicketStore) FindByCode(code string) (*model.RegistrationTicket, error) {
+	t, ok := m.tickets[code]
+	if !ok {
+		return nil, errors.New("not found")
+	}
+	return t, nil
+}
+
+func (m *mockTicketStore) MarkUsed(ticketID, userID string) error {
+	if m.markErr != nil {
+		return m.markErr
+	}
+	m.markUsed[ticketID] = userID
+	return nil
+}
+
+func newTestHandler(t *testing.T) (*apisignup.Handler, *testutil.MockUserRepository, *testutil.MockMetaRepository) {
+	t.Helper()
+	userRepo := testutil.NewMockUserRepository()
+	metaRepo := testutil.NewMockMetaRepository()
+	metaRepo.Meta = &model.Meta{ID: "x"}
+	idGen, _ := id.NewGenerator("aidx")
+	signupSvc := coresignup.NewService(userRepo, metaRepo, idGen)
+	h := apisignup.NewHandler(signupSvc, metaRepo, idGen)
+	return h, userRepo, metaRepo
+}
+
+func doPost(h func(echo.Context) error, body string) *httptest.ResponseRecorder {
+	e := echo.New()
+	req := httptest.NewRequest(http.MethodPost, "/", strings.NewReader(body))
+	req.Header.Set(echo.HeaderContentType, echo.MIMEApplicationJSON)
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+	_ = h(c)
+	return rec
+}
+
+func parseResp(t *testing.T, rec *httptest.ResponseRecorder) map[string]any {
+	t.Helper()
+	var resp map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+	return resp
+}
+
+// --- Success ---
+
+func TestSignup_Success(t *testing.T) {
+	h, _, _ := newTestHandler(t)
+	rec := doPost(h.Signup, `{"username":"alice","password":"pass1234"}`)
+	assert.Equal(t, http.StatusOK, rec.Code)
+
+	resp := parseResp(t, rec)
+	assert.NotEmpty(t, resp["id"])
+	assert.Equal(t, "alice", resp["username"])
+	assert.NotEmpty(t, resp["token"])
+	// MeDetailedフィールドが含まれていること
+	assert.Equal(t, false, resp["isAdmin"])
+	assert.Equal(t, false, resp["isModerator"])
+	assert.NotNil(t, resp["policies"])
+	assert.Equal(t, false, resp["twoFactorEnabled"])
+	assert.Equal(t, true, resp["preventAiLearning"])
+}
+
+// --- Validation ---
+
+func TestSignup_EmptyUsername(t *testing.T) {
+	h, _, _ := newTestHandler(t)
+	rec := doPost(h.Signup, `{"username":"","password":"pass"}`)
+	assert.Equal(t, http.StatusBadRequest, rec.Code)
+}
+
+func TestSignup_EmptyPassword(t *testing.T) {
+	h, _, _ := newTestHandler(t)
+	rec := doPost(h.Signup, `{"username":"alice","password":""}`)
+	assert.Equal(t, http.StatusBadRequest, rec.Code)
+}
+
+func TestSignup_InvalidJSON(t *testing.T) {
+	h, _, _ := newTestHandler(t)
+	rec := doPost(h.Signup, `not json`)
+	assert.Equal(t, http.StatusBadRequest, rec.Code)
+}
+
+func TestSignup_WhitespaceOnlyUsername(t *testing.T) {
+	h, _, _ := newTestHandler(t)
+	rec := doPost(h.Signup, `{"username":"   ","password":"pass"}`)
+	assert.Equal(t, http.StatusBadRequest, rec.Code)
+}
+
+// --- Username conflicts ---
+
+func TestSignup_DuplicateUsername(t *testing.T) {
+	h, userRepo, _ := newTestHandler(t)
+	userRepo.Users["u1"] = &model.User{ID: "u1", Username: "taken", UsernameLower: "taken"}
+	rec := doPost(h.Signup, `{"username":"taken","password":"pass"}`)
+	assert.Equal(t, http.StatusConflict, rec.Code)
+
+	resp := parseResp(t, rec)
+	errObj := resp["error"].(map[string]any)
+	assert.Equal(t, "USERNAME_ALREADY_EXISTS", errObj["code"])
+}
+
+func TestSignup_ReservedUsername(t *testing.T) {
+	h, _, metaRepo := newTestHandler(t)
+	metaRepo.Meta.PreservedUsernames = []string{"admin", "root"}
+	rec := doPost(h.Signup, `{"username":"admin","password":"pass"}`)
+	assert.Equal(t, http.StatusBadRequest, rec.Code)
+
+	resp := parseResp(t, rec)
+	errObj := resp["error"].(map[string]any)
+	assert.Equal(t, "USED_USERNAME", errObj["code"])
+}
+
+// --- Meta errors ---
+
+func TestSignup_MetaFetchError(t *testing.T) {
+	h, _, metaRepo := newTestHandler(t)
+	metaRepo.Meta = nil
+	rec := doPost(h.Signup, `{"username":"alice","password":"pass"}`)
+	assert.Equal(t, http.StatusInternalServerError, rec.Code)
+}
+
+func TestSignup_EmailRequired(t *testing.T) {
+	h, _, metaRepo := newTestHandler(t)
+	metaRepo.Meta.EmailRequiredForSignup = true
+	rec := doPost(h.Signup, `{"username":"alice","password":"pass"}`)
+	assert.Equal(t, http.StatusBadRequest, rec.Code)
+}
+
+// --- Registration disabled (invitation code) ---
+
+func TestSignup_RegistrationDisabled_NoCode(t *testing.T) {
+	h, _, metaRepo := newTestHandler(t)
+	metaRepo.Meta.DisableRegistration = true
+	rec := doPost(h.Signup, `{"username":"alice","password":"pass"}`)
+	assert.Equal(t, http.StatusBadRequest, rec.Code)
+
+	resp := parseResp(t, rec)
+	errObj := resp["error"].(map[string]any)
+	assert.Equal(t, "INVITATION_CODE_INVALID", errObj["code"])
+}
+
+func TestSignup_RegistrationDisabled_NoTicketStore(t *testing.T) {
+	h, _, metaRepo := newTestHandler(t)
+	metaRepo.Meta.DisableRegistration = true
+	// ticketStore未設定、codeあり → 検証不可
+	rec := doPost(h.Signup, `{"username":"alice","password":"pass","invitationCode":"abc"}`)
+	assert.Equal(t, http.StatusBadRequest, rec.Code)
+}
+
+func TestSignup_RegistrationDisabled_ValidCode(t *testing.T) {
+	h, _, metaRepo := newTestHandler(t)
+	metaRepo.Meta.DisableRegistration = true
+	store := newMockTicketStore()
+	store.tickets["valid-code"] = &model.RegistrationTicket{ID: "t1", Code: "valid-code"}
+	h.SetTicketStore(store)
+
+	rec := doPost(h.Signup, `{"username":"alice","password":"pass","invitationCode":"valid-code"}`)
+	assert.Equal(t, http.StatusOK, rec.Code)
+
+	// ticketが使用済みにされたことを確認
+	assert.Equal(t, store.markUsed["t1"], parseResp(t, rec)["id"])
+}
+
+func TestSignup_RegistrationDisabled_CodeNotFound(t *testing.T) {
+	h, _, metaRepo := newTestHandler(t)
+	metaRepo.Meta.DisableRegistration = true
+	store := newMockTicketStore()
+	h.SetTicketStore(store)
+
+	rec := doPost(h.Signup, `{"username":"alice","password":"pass","invitationCode":"bad-code"}`)
+	assert.Equal(t, http.StatusBadRequest, rec.Code)
+}
+
+func TestSignup_RegistrationDisabled_UsedCode(t *testing.T) {
+	h, _, metaRepo := newTestHandler(t)
+	metaRepo.Meta.DisableRegistration = true
+	store := newMockTicketStore()
+	usedBy := "someone"
+	store.tickets["used-code"] = &model.RegistrationTicket{ID: "t2", Code: "used-code", UsedByID: &usedBy}
+	h.SetTicketStore(store)
+
+	rec := doPost(h.Signup, `{"username":"alice","password":"pass","invitationCode":"used-code"}`)
+	assert.Equal(t, http.StatusBadRequest, rec.Code)
+}
+
+func TestSignup_RegistrationDisabled_ExpiredCode(t *testing.T) {
+	h, _, metaRepo := newTestHandler(t)
+	metaRepo.Meta.DisableRegistration = true
+	store := newMockTicketStore()
+	expired := time.Now().Add(-24 * time.Hour)
+	store.tickets["expired-code"] = &model.RegistrationTicket{ID: "t3", Code: "expired-code", ExpiresAt: &expired}
+	h.SetTicketStore(store)
+
+	rec := doPost(h.Signup, `{"username":"alice","password":"pass","invitationCode":"expired-code"}`)
+	assert.Equal(t, http.StatusBadRequest, rec.Code)
+}
+
+// --- CAPTCHA ---
+
+// failingCaptchaVerifier is defined but unused because we use the real testcaptcha.
+var _ captcha.Verifier = (*failingCaptchaVerifier)(nil)
+
+type failingCaptchaVerifier struct{}
+
+func (f *failingCaptchaVerifier) Verify(_ context.Context, _ string) error {
+	return captcha.ErrVerificationFail
+}
+
+func TestSignup_CaptchaFailed(t *testing.T) {
+	h, _, metaRepo := newTestHandler(t)
+	metaRepo.Meta.EnableTestcaptcha = true
+	captchaSvc := captcha.NewService(metaRepo.Meta)
+	h.SetCaptcha(captchaSvc)
+
+	// testcaptcha-response が空 → 検証失敗
+	rec := doPost(h.Signup, `{"username":"alice","password":"pass"}`)
+	assert.Equal(t, http.StatusBadRequest, rec.Code)
+
+	resp := parseResp(t, rec)
+	errObj := resp["error"].(map[string]any)
+	assert.Equal(t, "CAPTCHA_FAILED", errObj["code"])
+}
+
+func TestSignup_CaptchaSuccess(t *testing.T) {
+	h, _, metaRepo := newTestHandler(t)
+	metaRepo.Meta.EnableTestcaptcha = true
+	captchaSvc := captcha.NewService(metaRepo.Meta)
+	h.SetCaptcha(captchaSvc)
+
+	rec := doPost(h.Signup, `{"username":"alice","password":"pass","testcaptcha-response":"testcaptcha-passed"}`)
+	assert.Equal(t, http.StatusOK, rec.Code)
+}
+
+// --- Internal error from signup service ---
+
+type failingCreateUserRepo struct {
+	*testutil.MockUserRepository
+}
+
+func (r *failingCreateUserRepo) Create(_ *model.User) error {
+	return assert.AnError
+}
+
+func TestSignup_InternalError(t *testing.T) {
+	userRepo := testutil.NewMockUserRepository()
+	metaRepo := testutil.NewMockMetaRepository()
+	metaRepo.Meta = &model.Meta{ID: "x"}
+	idGen, _ := id.NewGenerator("aidx")
+	failRepo := &failingCreateUserRepo{userRepo}
+	signupSvc := coresignup.NewService(failRepo, metaRepo, idGen)
+	h := apisignup.NewHandler(signupSvc, metaRepo, idGen)
+
+	rec := doPost(h.Signup, `{"username":"alice","password":"pass"}`)
+	assert.Equal(t, http.StatusInternalServerError, rec.Code)
+}
+
+// --- Response shape ---
+
+func TestSignup_ResponseShape(t *testing.T) {
+	h, _, _ := newTestHandler(t)
+	rec := doPost(h.Signup, `{"username":"carol","password":"pass1234"}`)
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	resp := parseResp(t, rec)
+
+	requiredFields := []string{
+		"id", "username", "token", "host", "avatarUrl",
+		"isBot", "isCat", "isLocked", "isSuspended", "isSilenced",
+		"isAdmin", "isModerator", "followersCount", "followingCount", "notesCount",
+		"createdAt", "policies", "twoFactorEnabled", "preventAiLearning",
+		"publicReactions", "autoAcceptFollowed",
+	}
+	for _, f := range requiredFields {
+		_, exists := resp[f]
+		assert.True(t, exists, "missing field: %s", f)
+	}
+}

--- a/internal/server/router.go
+++ b/internal/server/router.go
@@ -41,6 +41,7 @@ import (
 	apireversi "github.com/shiroha-a/mk/internal/api/reversi"
 	apiroles "github.com/shiroha-a/mk/internal/api/roles"
 	apisignin "github.com/shiroha-a/mk/internal/api/signin"
+	apisignup "github.com/shiroha-a/mk/internal/api/signup"
 	"github.com/shiroha-a/mk/internal/api/streaming"
 	apisw "github.com/shiroha-a/mk/internal/api/sw"
 	apitest "github.com/shiroha-a/mk/internal/api/test"
@@ -93,6 +94,7 @@ import (
 	"github.com/shiroha-a/mk/internal/server/middleware"
 	"github.com/shiroha-a/mk/internal/stream"
 	"github.com/shiroha-a/mk/internal/stream/channels"
+	"gorm.io/gorm"
 	"log/slog"
 )
 
@@ -537,6 +539,14 @@ func (s *Server) setupRoutes() {
 	if serverMeta, err := metaRepo.Fetch(); err == nil {
 		captchaSvc = corecaptcha.NewService(serverMeta)
 	}
+
+	// Signup (public)
+	signupHandler := apisignup.NewHandler(signupService, metaRepo, idGen)
+	if captchaSvc != nil {
+		signupHandler.SetCaptcha(captchaSvc)
+	}
+	signupHandler.SetTicketStore(&gormTicketStore{db: s.db})
+	api.POST("/signup", signupHandler.Signup)
 
 	// Signin (Phase 6)
 	userIPRepo := repository.NewUserIPRepository(s.db)
@@ -1327,4 +1337,25 @@ func (s *Server) setupRoutes() {
 
 	// Frontend HTML shell — SPA catchall (最後に登録)
 	s.echo.GET("/*", frontendHTML(s.config, metaRepo))
+}
+
+// gormTicketStore implements apisignup.TicketStore using GORM.
+type gormTicketStore struct {
+	db *gorm.DB
+}
+
+func (s *gormTicketStore) FindByCode(code string) (*model.RegistrationTicket, error) {
+	var ticket model.RegistrationTicket
+	if err := s.db.Where(`"code" = ?`, code).First(&ticket).Error; err != nil {
+		return nil, err
+	}
+	return &ticket, nil
+}
+
+func (s *gormTicketStore) MarkUsed(ticketID, userID string) error {
+	now := time.Now()
+	return s.db.Model(&model.RegistrationTicket{}).Where(`"id" = ?`, ticketID).Updates(map[string]any{
+		"usedById": userID,
+		"usedAt":   now,
+	}).Error
 }


### PR DESCRIPTION
## Summary

- `/api/signup` エンドポイントを新���実装。既存の `coresignup.Service.Signup()` を呼び出し、MeDetailed + token レスポンスを返す
- `meta.disableRegistration` 時の invitation code (registration_ticket) 検���に対応
- CAPTCHA検証 (全5プロバイダ) に対応
- `/api/signin-flow` は既に実装済み (`router.go:530`) のため本PRでは���応不要

## 主な変更点

| ファイル | 変更 |
|---------|------|
| `internal/api/signup/handler.go` | 新規: Handler, Signup, TicketStore interface, packSignupResponse |
| `internal/api/signup/handler_test.go` | 新規: 19テスト, カバレッジ100% |
| `internal/server/router.go` | signup handler登録 + gormTicketStore実装 |

## テスト

- `go test -race -count=1 -coverprofile=coverage.out -covermode=atomic ./internal/api/signup/...` → 100%
- `make fmt && make lint` pass
- `make test` pass (gallery/hashtags/repository のDB依存テスト失敗は既知の pre-existing)

Closes #38

🤖 Generated with [Claude Code](https://claude.com/claude-code)