### PR TITLE
Add devcontainer configuration

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,14 @@
+{
+  "name": "misskey-go",
+  "image": "mcr.microsoft.com/devcontainers/go:1.25",
+  "features": {
+    "ghcr.io/devcontainers/features/docker-outside-of-docker:1": {}
+  },
+  "runArgs": ["--network=host"],
+  "postCreateCommand": "go mod download",
+  "customizations": {
+    "vscode": {
+      "extensions": ["golang.go"]
+    }
+  }
+}


### PR DESCRIPTION
## Summary

最小構成のdevcontainerを追加。

## 内容

- **ベース**: `mcr.microsoft.com/devcontainers/go:1.25`
- **Docker**: `docker-outside-of-docker` feature でホストDocker socket を共有
- **ネットワーク**: `--network=host` でtestcontainersのポートマッピングが動作
- **初期化**: `go mod download`
- **拡張**: Go VS Code extension

DB/Redisサイドカーは含まない — testcontainersが自動でコンテナを起動するため不要。`make test` がそのまま通る。

Closes #77