### PR TITLE
Fix devcontainer: Debian Trixie互換性修正

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -2,7 +2,9 @@
   "name": "misskey-go",
   "image": "mcr.microsoft.com/devcontainers/go:1.25",
   "features": {
-    "ghcr.io/devcontainers/features/docker-outside-of-docker:1": {}
+    "ghcr.io/devcontainers/features/docker-outside-of-docker:1": {
+      "moby": false
+    }
   },
   "runArgs": ["--network=host"],
   "postCreateCommand": "go mod download",


### PR DESCRIPTION
## Summary

Go 1.25 devcontainerイメージがDebian Trixieベースで、`moby-cli`パッケージが削除済みのためビルドエラーが発生していた。

## 修正

`docker-outside-of-docker` featureに `"moby": false` を設定し、mobyパッケージ経由ではなくDocker CLIを直接インストールするように変更。

Closes #80