### PR TITLE
devcontainer: full dev env (PostgreSQL 18 + Redis 7 + frontend)

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,10 @@
+FROM mcr.microsoft.com/devcontainers/go:1.25
+
+# Node.js (フロントエンドビルド用)
+RUN curl -fsSL https://deb.nodesource.com/setup_22.x | bash - \
+    && apt-get install -y nodejs \
+    && corepack enable \
+    && corepack prepare pnpm@latest --activate
+
+# golang-migrate CLI
+RUN go install -tags 'postgres' github.com/golang-migrate/migrate/v4/cmd/migrate@latest

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,13 +1,9 @@
 {
   "name": "misskey-go",
-  "image": "mcr.microsoft.com/devcontainers/go:1.25",
-  "features": {
-    "ghcr.io/devcontainers/features/docker-outside-of-docker:1": {
-      "moby": false
-    }
-  },
-  "runArgs": ["--network=host"],
-  "postCreateCommand": "go mod download",
+  "dockerComposeFile": "docker-compose.yml",
+  "service": "app",
+  "workspaceFolder": "/workspace",
+  "postCreateCommand": "bash .devcontainer/postCreate.sh",
   "customizations": {
     "vscode": {
       "extensions": ["golang.go"]

--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -1,0 +1,48 @@
+services:
+  app:
+    build:
+      context: ..
+      dockerfile: .devcontainer/Dockerfile
+    volumes:
+      - ..:/workspace:cached
+    command: sleep infinity
+    network_mode: host
+    environment:
+      # Go アプリ用 DB 接続
+      MK_DB_HOST: localhost
+      MK_DB_PORT: "5432"
+      MK_DB_DB: misskey
+      MK_DB_USER: misskey
+      MK_DB_PASS: misskey
+      MK_REDIS_HOST: localhost
+      MK_REDIS_PORT: "6379"
+      # テスト用 DB 接続 (CI と同じ形式)
+      TEST_DB_HOST: localhost
+      TEST_DB_PORT: "5432"
+      TEST_DB_NAME: misskey
+      TEST_DB_USER: misskey
+      TEST_DB_PASS: misskey
+      TEST_DB_SSLMODE: disable
+      TEST_REDIS_HOST: localhost
+      TEST_REDIS_PORT: "6379"
+      # マイグレーション用
+      DATABASE_URL: "postgres://misskey:misskey@localhost:5432/misskey?sslmode=disable"
+
+  db:
+    image: postgres:18-alpine
+    restart: unless-stopped
+    network_mode: host
+    environment:
+      POSTGRES_DB: misskey
+      POSTGRES_USER: misskey
+      POSTGRES_PASSWORD: misskey
+    volumes:
+      - pgdata:/var/lib/postgresql/data
+
+  redis:
+    image: redis:7-alpine
+    restart: unless-stopped
+    network_mode: host
+
+volumes:
+  pgdata:

--- a/.devcontainer/postCreate.sh
+++ b/.devcontainer/postCreate.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+set -euo pipefail
+
+echo "=== Go dependencies ==="
+cd /workspace
+go mod download
+
+echo "=== Submodule init ==="
+git submodule update --init --recursive third_party/misskey
+
+echo "=== Wait for PostgreSQL ==="
+for i in $(seq 1 30); do
+    pg_isready -h localhost -p 5432 -U misskey && break
+    echo "Waiting for PostgreSQL... ($i/30)"
+    sleep 1
+done
+
+echo "=== Database migration ==="
+make migrate-up || echo "Migration failed (may already be applied)"
+
+echo "=== Frontend build ==="
+cd /workspace/third_party/misskey
+pnpm install --frozen-lockfile
+pnpm build
+
+echo "=== Done! Run 'make dev' to start the server ==="


### PR DESCRIPTION
## Summary

devcontainerをフル開発環境に拡張。コンテナを開くだけでバックエンド+フロントエンドの開発が始められる。

## 構成

```
.devcontainer/
├── devcontainer.json      # docker-compose参照
├── Dockerfile             # Go 1.25 + Node.js 22 + pnpm + golang-migrate
├── docker-compose.yml     # app + PostgreSQL 18 + Redis 7
└── postCreate.sh          # 自動セットアップスクリプト
```

## 自動セットアップ (postCreate)

1. `go mod download`
2. `git submodule update --init --recursive` (Misskey フロントエンドソース取得)
3. PostgreSQL 起動待ち → `make migrate-up`
4. `pnpm install + pnpm build` (フロントエンドビルド)

## 使い方

1. VS Code で "Reopen in Container"
2. 初回セットアップ完了を待つ (フロントエンドビルド含め数分)
3. `make dev` でサーバー起動 → `http://localhost:3000`

## 環境変数

- `MK_DB_*` / `MK_REDIS_*`: アプリ用
- `TEST_DB_*` / `TEST_REDIS_*`: テスト用 (testcontainersをバイパス)
- `DATABASE_URL`: マイグレーション用

すべて `network_mode: host` で統一しているためポートフォワード不要。

Closes #82