### PR TITLE
Phase 11.1 follow-up: fix addEventListener on undefined

### DIFF
--- a/internal/api/meta/handler.go
+++ b/internal/api/meta/handler.go
@@ -96,7 +96,7 @@ func (h *Handler) Meta(c echo.Context) error {
 		"notesPerOneAd":                m.NotesPerOneAd,
 		"mediaProxy":                   h.config.MediaProxy,
 		"cacheRemoteSensitiveFiles":    m.CacheRemoteSensitiveFiles,
-		"requireSetup":                 false,
+		"requireSetup":                 m.RootUserID == nil,
 		"singleUserMode":               m.SingleUserMode,
 		"providesTarball":              false,
 		"maxFileSize":                  h.config.MaxFileSize,

--- a/internal/api/meta/handler_test.go
+++ b/internal/api/meta/handler_test.go
@@ -94,6 +94,39 @@ func TestPing(t *testing.T) {
 	assert.Equal(t, true, resp["pong"])
 }
 
+// requireSetup は rootUserId が nil のとき true を返す。
+func TestMeta_RequireSetupWhenNoRootUser(t *testing.T) {
+	h, repo := newTestHandler()
+	repo.Meta = &model.Meta{ID: "x"} // RootUserID = nil
+
+	e := echo.New()
+	req := httptest.NewRequest(http.MethodPost, "/api/meta", nil)
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+	require.NoError(t, h.Meta(c))
+
+	var resp map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+	assert.Equal(t, true, resp["requireSetup"])
+}
+
+// requireSetup は rootUserId が設定済みのとき false を返す。
+func TestMeta_RequireSetupFalseWhenRootExists(t *testing.T) {
+	h, repo := newTestHandler()
+	rootID := "root123"
+	repo.Meta = &model.Meta{ID: "x", RootUserID: &rootID}
+
+	e := echo.New()
+	req := httptest.NewRequest(http.MethodPost, "/api/meta", nil)
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+	require.NoError(t, h.Meta(c))
+
+	var resp map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+	assert.Equal(t, false, resp["requireSetup"])
+}
+
 // --- Branding / UI exposure (issue #50) ---
 
 // /api/meta が meta テーブルの新フィールド (mascot / app192/512 / themes /

--- a/internal/server/frontend.go
+++ b/internal/server/frontend.go
@@ -204,7 +204,7 @@ func buildMetaJSON(cfg *config.Config, m *model.Meta) string {
 		"translatorAvailable": false, "enableEmail": m.EnableEmail,
 		"ads": []any{}, "notesPerOneAd": 0,
 		"cacheRemoteSensitiveFiles": m.CacheRemoteSensitiveFiles,
-		"requireSetup":              false,
+		"requireSetup":              m.RootUserID == nil,
 		"features": map[string]any{
 			"registration":           !m.DisableRegistration,
 			"emailRequiredForSignup": m.EmailRequiredForSignup,


### PR DESCRIPTION
## Summary

- Fix `TypeError: Cannot read properties of undefined (reading 'addEventListener')` that caused all Cypress E2E tests to fail
- Root cause: `MkModal.vue:297` accesses `content.value.children[0]` without null guard — when a modal opens before its slot renders, `children[0]` is undefined
- Also fix `requireSetup` being hardcoded to `false` — the TS backend returns `rootUserId == null`, so after `/api/reset-db` the setup wizard must appear

## 主な変更点

| ファイル | 変更内容 |
|---------|---------|
| `third_party/misskey/.../MkModal.vue` | `children[0]` の null guard 追加 |
| `internal/server/frontend.go` | `requireSetup` を `m.RootUserID == nil` に変更 |
| `internal/api/meta/handler.go` | 同上 (`/api/meta` レスポンス) |
| `internal/api/meta/handler_test.go` | `requireSetup` のテスト 2 件追加 |

## テスト

```
make fmt   # OK
make lint  # OK
go test ./internal/api/meta/... -v -count=1  # 13/13 PASS
```

## Closes

Closes #39

🤖 Generated with [Claude Code](https://claude.com/claude-code)