### PR TITLE
Fix devcontainer: /go permission denied

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,5 +1,8 @@
 FROM mcr.microsoft.com/devcontainers/go:1.25
 
+# /go の所有権を vscode ユーザーに変更 (go mod download の権限エラー回避)
+RUN chown -R vscode:vscode /go
+
 # Node.js (フロントエンドビルド用)
 RUN curl -fsSL https://deb.nodesource.com/setup_22.x | bash - \
     && apt-get install -y nodejs \
@@ -7,4 +10,4 @@ RUN curl -fsSL https://deb.nodesource.com/setup_22.x | bash - \
     && corepack prepare pnpm@latest --activate
 
 # golang-migrate CLI
-RUN go install -tags 'postgres' github.com/golang-migrate/migrate/v4/cmd/migrate@latest
+RUN su vscode -c "go install -tags 'postgres' github.com/golang-migrate/migrate/v4/cmd/migrate@latest"

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -3,6 +3,7 @@
   "dockerComposeFile": "docker-compose.yml",
   "service": "app",
   "workspaceFolder": "/workspace",
+  "remoteUser": "vscode",
   "postCreateCommand": "bash .devcontainer/postCreate.sh",
   "customizations": {
     "vscode": {


### PR DESCRIPTION
## Summary

devcontainerのvscodeDユーザーで`go mod download`時に`/go/pkg/mod/cache`への書き込み権限がない問題を修正。

## 修正

- Dockerfile: `chown -R vscode:vscode /go` で所有権変更
- Dockerfile: `golang-migrate`をvscodeDユーザーで`go install`
- devcontainer.json: `remoteUser: "vscode"` を明示

Closes #85