### PR TITLE
E2E: WebAuthn register + login via Virtual Authenticator

### DIFF
--- a/e2e/cypress/cypress.config.ts
+++ b/e2e/cypress/cypress.config.ts
@@ -18,8 +18,11 @@ export default defineConfig({
   e2e: {
     baseUrl: process.env.E2E_BASE_URL ?? 'http://localhost:3000',
 
-    // Spec / support / fixtures はすべて submodule の現物を指す。
-    specPattern: path.join(misskeyCypress, 'e2e', '**', '*.cy.{js,jsx,ts,tsx}'),
+    // Spec は submodule の本家 spec + mk-go 独自 spec の両方を読む。
+    specPattern: [
+      path.join(misskeyCypress, 'e2e', '**', '*.cy.{js,jsx,ts,tsx}'),
+      path.join(__dirname, 'e2e', '**', '*.cy.{js,jsx,ts,tsx}'),
+    ],
     supportFile: path.join(misskeyCypress, 'support', 'e2e.ts'),
     fixturesFolder: path.join(misskeyCypress, 'fixtures'),
 

--- a/e2e/cypress/e2e/webauthn.cy.ts
+++ b/e2e/cypress/e2e/webauthn.cy.ts
@@ -5,12 +5,18 @@
 // Go 側の FinishLogin success path が実際のブラウザ WebAuthn API 経由で
 // 動作することを確認する (issue #55)。
 
+// base64url → Uint8Array
+const b64u = (s: string) =>
+  Uint8Array.from(atob(s.replace(/-/g, '+').replace(/_/g, '/')), c => c.charCodeAt(0));
+
+// Uint8Array → base64 (standard, for sending back to server)
+const toB64 = (buf: ArrayBuffer) =>
+  btoa(String.fromCharCode(...new Uint8Array(buf)));
+
 describe('WebAuthn (Virtual Authenticator)', () => {
   const admin = { username: 'admin', password: 'adminpass' };
-  const user = { username: 'webauthnuser', password: 'pass123456' };
+  const user = { username: 'wanuser', password: 'pass123456' };
 
-  // CDP (Chrome DevTools Protocol) でvirtual authenticatorを有効化する。
-  // Cypress は Chromium ベースブラウザで CDP コマンドを直接送れる。
   let authenticatorId: string;
 
   function enableVirtualAuthenticator(): Cypress.Chainable {
@@ -53,10 +59,16 @@ describe('WebAuthn (Virtual Authenticator)', () => {
   }
 
   before(() => {
-    // 初期状態にリセットし admin + テストユーザーを作成する。
     cy.resetState();
     cy.registerUser(admin.username, admin.password, true);
-    cy.registerUser(user.username, user.password);
+    cy.get(`@${admin.username}`).then((res: any) => {
+      cy.request({
+        method: 'POST',
+        url: '/api/admin/accounts/create',
+        headers: { Authorization: `Bearer ${res.token}` },
+        body: { username: user.username, password: user.password },
+      });
+    });
   });
 
   afterEach(() => {
@@ -73,137 +85,127 @@ describe('WebAuthn (Virtual Authenticator)', () => {
     }).then((signinRes) => {
       expect(signinRes.body.finished).to.be.true;
       const token = signinRes.body.i;
+      const authHeader = { Authorization: `Bearer ${token}` };
 
-      // Step 2: 2FA を有効化 (TOTP 登録)
+      // Step 2: セキュリティキー登録 challenge 取得
+      // (2FA が有効でなくても register-key は呼べる — key 追加時に自動で有効化)
       cy.request({
         method: 'POST',
-        url: '/api/i/2fa/register',
-        headers: { Authorization: `Bearer ${token}` },
+        url: '/api/i/2fa/register-key',
+        headers: authHeader,
         body: { password: user.password },
-      }).then((tfaRes) => {
-        // TOTP secret を使って OTP を生成してdoneに渡す (簡易: backupコード経由)
-        // ここでは TOTP secret を直接使って検証コードを生成する代わりに、
-        // register → done の流れをAPI経由でテストする。
-        const secret = tfaRes.body.secret;
-        expect(secret).to.be.a('string');
+      }).then((regKeyRes) => {
+        expect(regKeyRes.status).to.eq(200);
+        const regSessionId = regKeyRes.body.sessionId;
+        const creationOpts = regKeyRes.body.creation.publicKey;
+        expect(creationOpts).to.have.property('rp');
+        expect(creationOpts).to.have.property('challenge');
 
-        // TOTP コードを生成 (テスト用に secret から計算)
-        // Cypress では Node.js の crypto を使えないため、
-        // テスト用のワンタイムパスワード生成はサーバーサイドで行う。
-        // 代替: バックアップコードを使わずに、register-key エンドポイントだけをテストする。
+        // Step 3: ブラウザの WebAuthn API で credential を作成
+        cy.window().then(async (win) => {
+          const publicKey = {
+            ...creationOpts,
+            challenge: b64u(creationOpts.challenge),
+            user: {
+              ...creationOpts.user,
+              id: b64u(creationOpts.user.id),
+            },
+            ...(creationOpts.excludeCredentials
+              ? {
+                  excludeCredentials: creationOpts.excludeCredentials.map((c: any) => ({
+                    ...c,
+                    id: b64u(c.id),
+                  })),
+                }
+              : {}),
+          };
 
-        // Step 3: セキュリティキー登録 (register-key → ブラウザ WebAuthn API → key-done)
-        cy.request({
-          method: 'POST',
-          url: '/api/i/2fa/register-key',
-          headers: { Authorization: `Bearer ${token}` },
-          body: { password: user.password },
-        }).then((regKeyRes) => {
-          // register-key は WebAuthn credential creation options を返す
-          const options = regKeyRes.body;
-          expect(options).to.have.property('rp');
-          expect(options).to.have.property('challenge');
+          const credential = (await win.navigator.credentials.create({
+            publicKey,
+          })) as PublicKeyCredential;
+          expect(credential).to.not.be.null;
 
-          // Step 4: ブラウザの WebAuthn API で credential を作成
-          // (Virtual Authenticator が自動応答する)
-          cy.window().then(async (win) => {
-            const publicKey = {
-              ...options,
-              challenge: Uint8Array.from(atob(options.challenge.replace(/-/g, '+').replace(/_/g, '/')), c => c.charCodeAt(0)),
-              user: {
-                ...options.user,
-                id: Uint8Array.from(atob(options.user.id.replace(/-/g, '+').replace(/_/g, '/')), c => c.charCodeAt(0)),
+          const attResp = credential.response as AuthenticatorAttestationResponse;
+
+          // Step 4: key-done に attestation を送信して登録完了
+          // handler は { password, name, sessionId, response } を期待する。
+          // response は go-webauthn が parse する credential creation data。
+          cy.request({
+            method: 'POST',
+            url: '/api/i/2fa/key-done',
+            headers: authHeader,
+            body: {
+              password: user.password,
+              name: 'virtual-key',
+              sessionId: regSessionId,
+              response: {
+                id: credential.id,
+                rawId: toB64(credential.rawId),
+                type: credential.type,
+                response: {
+                  clientDataJSON: toB64(attResp.clientDataJSON),
+                  attestationObject: toB64(attResp.attestationObject),
+                },
               },
-              ...(options.excludeCredentials ? {
-                excludeCredentials: options.excludeCredentials.map((c: any) => ({
-                  ...c,
-                  id: Uint8Array.from(atob(c.id.replace(/-/g, '+').replace(/_/g, '/')), c2 => c2.charCodeAt(0)),
-                })),
-              } : {}),
-            };
+            },
+          }).then((doneRes) => {
+            expect(doneRes.status).to.eq(200);
 
-            const credential = await win.navigator.credentials.create({ publicKey }) as PublicKeyCredential;
-            expect(credential).to.not.be.null;
+            // Step 5: signin-flow で password → 2FA step
+            cy.request('POST', '/api/signin-flow', {
+              username: user.username,
+              password: user.password,
+            }).then((step2Res) => {
+              expect(step2Res.body.finished).to.be.false;
+              expect(step2Res.body.next).to.eq('captcha-keys');
+              expect(step2Res.body).to.have.property('assertion');
+              expect(step2Res.body).to.have.property('sessionId');
 
-            const response = credential.response as AuthenticatorAttestationResponse;
-            const attestationObject = btoa(String.fromCharCode(...new Uint8Array(response.attestationObject)));
-            const clientDataJSON = btoa(String.fromCharCode(...new Uint8Array(response.clientDataJSON)));
-            const rawId = btoa(String.fromCharCode(...new Uint8Array(credential.rawId)));
+              const assertion = step2Res.body.assertion;
+              const loginSessionId = step2Res.body.sessionId;
 
-            // Step 5: key-done に attestation を送信して登録完了
-            cy.request({
-              method: 'POST',
-              url: '/api/i/2fa/key-done',
-              headers: { Authorization: `Bearer ${token}` },
-              body: {
-                clientDataJSON,
-                attestationObject,
-                password: user.password,
-                name: 'test-key',
-              },
-            }).then((doneRes) => {
-              expect(doneRes.status).to.eq(200);
+              // Step 6: ブラウザの WebAuthn API で assertion を取得
+              cy.window().then(async (win2) => {
+                const getOpts: PublicKeyCredentialRequestOptions = {
+                  challenge: b64u(assertion.publicKey.challenge),
+                  rpId: assertion.publicKey.rpId,
+                  allowCredentials: (assertion.publicKey.allowCredentials || []).map(
+                    (c: any) => ({ ...c, id: b64u(c.id) })
+                  ),
+                  timeout: assertion.publicKey.timeout,
+                  userVerification: assertion.publicKey.userVerification,
+                };
 
-              // Step 6: FinishLogin テスト — セキュリティキーでログイン
-              // signin-flow で password を送ると 2FA step に入る
-              cy.request('POST', '/api/signin-flow', {
-                username: user.username,
-                password: user.password,
-              }).then((step2Res) => {
-                expect(step2Res.body.finished).to.be.false;
-                // セキュリティキーがあるので "captcha-keys" が返る
-                expect(step2Res.body.next).to.eq('captcha-keys');
-                expect(step2Res.body).to.have.property('assertion');
-                expect(step2Res.body).to.have.property('sessionId');
+                const assertCred = (await win2.navigator.credentials.get({
+                  publicKey: getOpts,
+                })) as PublicKeyCredential;
+                expect(assertCred).to.not.be.null;
 
-                const assertion = step2Res.body.assertion;
-                const sessionId = step2Res.body.sessionId;
+                const assertResp = assertCred.response as AuthenticatorAssertionResponse;
+                const credJSON = {
+                  id: assertCred.id,
+                  rawId: toB64(assertCred.rawId),
+                  type: assertCred.type,
+                  response: {
+                    authenticatorData: toB64(assertResp.authenticatorData),
+                    clientDataJSON: toB64(assertResp.clientDataJSON),
+                    signature: toB64(assertResp.signature),
+                    userHandle: assertResp.userHandle ? toB64(assertResp.userHandle) : null,
+                  },
+                };
 
-                // Step 7: ブラウザの WebAuthn API で assertion を取得
-                cy.window().then(async (win2) => {
-                  const getOptions: PublicKeyCredentialRequestOptions = {
-                    challenge: Uint8Array.from(atob(assertion.publicKey.challenge.replace(/-/g, '+').replace(/_/g, '/')), c => c.charCodeAt(0)),
-                    rpId: assertion.publicKey.rpId,
-                    allowCredentials: (assertion.publicKey.allowCredentials || []).map((c: any) => ({
-                      ...c,
-                      id: Uint8Array.from(atob(c.id.replace(/-/g, '+').replace(/_/g, '/')), c2 => c2.charCodeAt(0)),
-                    })),
-                    timeout: assertion.publicKey.timeout,
-                    userVerification: assertion.publicKey.userVerification,
-                  };
-
-                  const assertionCred = await win2.navigator.credentials.get({ publicKey: getOptions }) as PublicKeyCredential;
-                  expect(assertionCred).to.not.be.null;
-
-                  const assertionResponse = assertionCred.response as AuthenticatorAssertionResponse;
-
-                  const credJSON = {
-                    id: assertionCred.id,
-                    rawId: btoa(String.fromCharCode(...new Uint8Array(assertionCred.rawId))),
-                    type: assertionCred.type,
-                    response: {
-                      authenticatorData: btoa(String.fromCharCode(...new Uint8Array(assertionResponse.authenticatorData))),
-                      clientDataJSON: btoa(String.fromCharCode(...new Uint8Array(assertionResponse.clientDataJSON))),
-                      signature: btoa(String.fromCharCode(...new Uint8Array(assertionResponse.signature))),
-                      userHandle: assertionResponse.userHandle
-                        ? btoa(String.fromCharCode(...new Uint8Array(assertionResponse.userHandle)))
-                        : null,
-                    },
-                  };
-
-                  // Step 8: signin-flow にcredentialを送ってログイン完了
-                  cy.request('POST', '/api/signin-flow', {
-                    username: user.username,
-                    password: user.password,
-                    credential: credJSON,
-                    sessionId,
-                  }).then((loginRes) => {
-                    // FinishLogin success path がここで検証される
-                    expect(loginRes.status).to.eq(200);
-                    expect(loginRes.body.finished).to.be.true;
-                    expect(loginRes.body).to.have.property('i');
-                    expect(loginRes.body.i).to.be.a('string').and.not.be.empty;
-                  });
+                // Step 7: signin-flow に credential を送ってログイン完了
+                // ここが FinishLogin success path の検証ポイント
+                cy.request('POST', '/api/signin-flow', {
+                  username: user.username,
+                  password: user.password,
+                  credential: credJSON,
+                  sessionId: loginSessionId,
+                }).then((loginRes) => {
+                  expect(loginRes.status).to.eq(200);
+                  expect(loginRes.body.finished).to.be.true;
+                  expect(loginRes.body).to.have.property('i');
+                  expect(loginRes.body.i).to.be.a('string').and.not.be.empty;
                 });
               });
             });

--- a/e2e/cypress/e2e/webauthn.cy.ts
+++ b/e2e/cypress/e2e/webauthn.cy.ts
@@ -1,0 +1,215 @@
+/// <reference types="cypress" />
+
+// WebAuthn E2E: Chrome DevTools Protocol の Virtual Authenticator を使い、
+// FIDO2 セキュリティキーの登録 → ログインのフルフローを検証する。
+// Go 側の FinishLogin success path が実際のブラウザ WebAuthn API 経由で
+// 動作することを確認する (issue #55)。
+
+describe('WebAuthn (Virtual Authenticator)', () => {
+  const admin = { username: 'admin', password: 'adminpass' };
+  const user = { username: 'webauthnuser', password: 'pass123456' };
+
+  // CDP (Chrome DevTools Protocol) でvirtual authenticatorを有効化する。
+  // Cypress は Chromium ベースブラウザで CDP コマンドを直接送れる。
+  let authenticatorId: string;
+
+  function enableVirtualAuthenticator(): Cypress.Chainable {
+    return cy.wrap(
+      Cypress.automation('remote:debugger:protocol', {
+        command: 'WebAuthn.enable',
+        params: {},
+      }).then(() =>
+        Cypress.automation('remote:debugger:protocol', {
+          command: 'WebAuthn.addVirtualAuthenticator',
+          params: {
+            options: {
+              protocol: 'ctap2',
+              transport: 'usb',
+              hasResidentKey: true,
+              hasUserVerification: true,
+              isUserVerified: true,
+            },
+          },
+        })
+      ).then((result: { authenticatorId: string }) => {
+        authenticatorId = result.authenticatorId;
+      })
+    );
+  }
+
+  function disableVirtualAuthenticator(): Cypress.Chainable {
+    if (!authenticatorId) return cy.wrap(null);
+    return cy.wrap(
+      Cypress.automation('remote:debugger:protocol', {
+        command: 'WebAuthn.removeVirtualAuthenticator',
+        params: { authenticatorId },
+      }).then(() =>
+        Cypress.automation('remote:debugger:protocol', {
+          command: 'WebAuthn.disable',
+          params: {},
+        })
+      )
+    );
+  }
+
+  before(() => {
+    // 初期状態にリセットし admin + テストユーザーを作成する。
+    cy.resetState();
+    cy.registerUser(admin.username, admin.password, true);
+    cy.registerUser(user.username, user.password);
+  });
+
+  afterEach(() => {
+    disableVirtualAuthenticator();
+  });
+
+  it('registers a security key and logs in with it', () => {
+    enableVirtualAuthenticator();
+
+    // Step 1: ログインしてトークンを取得
+    cy.request('POST', '/api/signin-flow', {
+      username: user.username,
+      password: user.password,
+    }).then((signinRes) => {
+      expect(signinRes.body.finished).to.be.true;
+      const token = signinRes.body.i;
+
+      // Step 2: 2FA を有効化 (TOTP 登録)
+      cy.request({
+        method: 'POST',
+        url: '/api/i/2fa/register',
+        headers: { Authorization: `Bearer ${token}` },
+        body: { password: user.password },
+      }).then((tfaRes) => {
+        // TOTP secret を使って OTP を生成してdoneに渡す (簡易: backupコード経由)
+        // ここでは TOTP secret を直接使って検証コードを生成する代わりに、
+        // register → done の流れをAPI経由でテストする。
+        const secret = tfaRes.body.secret;
+        expect(secret).to.be.a('string');
+
+        // TOTP コードを生成 (テスト用に secret から計算)
+        // Cypress では Node.js の crypto を使えないため、
+        // テスト用のワンタイムパスワード生成はサーバーサイドで行う。
+        // 代替: バックアップコードを使わずに、register-key エンドポイントだけをテストする。
+
+        // Step 3: セキュリティキー登録 (register-key → ブラウザ WebAuthn API → key-done)
+        cy.request({
+          method: 'POST',
+          url: '/api/i/2fa/register-key',
+          headers: { Authorization: `Bearer ${token}` },
+          body: { password: user.password },
+        }).then((regKeyRes) => {
+          // register-key は WebAuthn credential creation options を返す
+          const options = regKeyRes.body;
+          expect(options).to.have.property('rp');
+          expect(options).to.have.property('challenge');
+
+          // Step 4: ブラウザの WebAuthn API で credential を作成
+          // (Virtual Authenticator が自動応答する)
+          cy.window().then(async (win) => {
+            const publicKey = {
+              ...options,
+              challenge: Uint8Array.from(atob(options.challenge.replace(/-/g, '+').replace(/_/g, '/')), c => c.charCodeAt(0)),
+              user: {
+                ...options.user,
+                id: Uint8Array.from(atob(options.user.id.replace(/-/g, '+').replace(/_/g, '/')), c => c.charCodeAt(0)),
+              },
+              ...(options.excludeCredentials ? {
+                excludeCredentials: options.excludeCredentials.map((c: any) => ({
+                  ...c,
+                  id: Uint8Array.from(atob(c.id.replace(/-/g, '+').replace(/_/g, '/')), c2 => c2.charCodeAt(0)),
+                })),
+              } : {}),
+            };
+
+            const credential = await win.navigator.credentials.create({ publicKey }) as PublicKeyCredential;
+            expect(credential).to.not.be.null;
+
+            const response = credential.response as AuthenticatorAttestationResponse;
+            const attestationObject = btoa(String.fromCharCode(...new Uint8Array(response.attestationObject)));
+            const clientDataJSON = btoa(String.fromCharCode(...new Uint8Array(response.clientDataJSON)));
+            const rawId = btoa(String.fromCharCode(...new Uint8Array(credential.rawId)));
+
+            // Step 5: key-done に attestation を送信して登録完了
+            cy.request({
+              method: 'POST',
+              url: '/api/i/2fa/key-done',
+              headers: { Authorization: `Bearer ${token}` },
+              body: {
+                clientDataJSON,
+                attestationObject,
+                password: user.password,
+                name: 'test-key',
+              },
+            }).then((doneRes) => {
+              expect(doneRes.status).to.eq(200);
+
+              // Step 6: FinishLogin テスト — セキュリティキーでログイン
+              // signin-flow で password を送ると 2FA step に入る
+              cy.request('POST', '/api/signin-flow', {
+                username: user.username,
+                password: user.password,
+              }).then((step2Res) => {
+                expect(step2Res.body.finished).to.be.false;
+                // セキュリティキーがあるので "captcha-keys" が返る
+                expect(step2Res.body.next).to.eq('captcha-keys');
+                expect(step2Res.body).to.have.property('assertion');
+                expect(step2Res.body).to.have.property('sessionId');
+
+                const assertion = step2Res.body.assertion;
+                const sessionId = step2Res.body.sessionId;
+
+                // Step 7: ブラウザの WebAuthn API で assertion を取得
+                cy.window().then(async (win2) => {
+                  const getOptions: PublicKeyCredentialRequestOptions = {
+                    challenge: Uint8Array.from(atob(assertion.publicKey.challenge.replace(/-/g, '+').replace(/_/g, '/')), c => c.charCodeAt(0)),
+                    rpId: assertion.publicKey.rpId,
+                    allowCredentials: (assertion.publicKey.allowCredentials || []).map((c: any) => ({
+                      ...c,
+                      id: Uint8Array.from(atob(c.id.replace(/-/g, '+').replace(/_/g, '/')), c2 => c2.charCodeAt(0)),
+                    })),
+                    timeout: assertion.publicKey.timeout,
+                    userVerification: assertion.publicKey.userVerification,
+                  };
+
+                  const assertionCred = await win2.navigator.credentials.get({ publicKey: getOptions }) as PublicKeyCredential;
+                  expect(assertionCred).to.not.be.null;
+
+                  const assertionResponse = assertionCred.response as AuthenticatorAssertionResponse;
+
+                  const credJSON = {
+                    id: assertionCred.id,
+                    rawId: btoa(String.fromCharCode(...new Uint8Array(assertionCred.rawId))),
+                    type: assertionCred.type,
+                    response: {
+                      authenticatorData: btoa(String.fromCharCode(...new Uint8Array(assertionResponse.authenticatorData))),
+                      clientDataJSON: btoa(String.fromCharCode(...new Uint8Array(assertionResponse.clientDataJSON))),
+                      signature: btoa(String.fromCharCode(...new Uint8Array(assertionResponse.signature))),
+                      userHandle: assertionResponse.userHandle
+                        ? btoa(String.fromCharCode(...new Uint8Array(assertionResponse.userHandle)))
+                        : null,
+                    },
+                  };
+
+                  // Step 8: signin-flow にcredentialを送ってログイン完了
+                  cy.request('POST', '/api/signin-flow', {
+                    username: user.username,
+                    password: user.password,
+                    credential: credJSON,
+                    sessionId,
+                  }).then((loginRes) => {
+                    // FinishLogin success path がここで検証される
+                    expect(loginRes.status).to.eq(200);
+                    expect(loginRes.body.finished).to.be.true;
+                    expect(loginRes.body).to.have.property('i');
+                    expect(loginRes.body.i).to.be.a('string').and.not.be.empty;
+                  });
+                });
+              });
+            });
+          });
+        });
+      });
+    });
+  });
+});

--- a/e2e/cypress/e2e/webauthn.cy.ts
+++ b/e2e/cypress/e2e/webauthn.cy.ts
@@ -9,9 +9,12 @@
 const b64u = (s: string) =>
   Uint8Array.from(atob(s.replace(/-/g, '+').replace(/_/g, '/')), c => c.charCodeAt(0));
 
-// Uint8Array → base64 (standard, for sending back to server)
-const toB64 = (buf: ArrayBuffer) =>
-  btoa(String.fromCharCode(...new Uint8Array(buf)));
+// Uint8Array → base64url (go-webauthn の URLEncodedBase64 に合わせる)
+const toB64url = (buf: ArrayBuffer) =>
+  btoa(String.fromCharCode(...new Uint8Array(buf)))
+    .replace(/\+/g, '-')
+    .replace(/\//g, '_')
+    .replace(/=+$/, '');
 
 describe('WebAuthn (Virtual Authenticator)', () => {
   const admin = { username: 'admin', password: 'adminpass' };
@@ -140,11 +143,11 @@ describe('WebAuthn (Virtual Authenticator)', () => {
               sessionId: regSessionId,
               response: {
                 id: credential.id,
-                rawId: toB64(credential.rawId),
+                rawId: toB64url(credential.rawId),
                 type: credential.type,
                 response: {
-                  clientDataJSON: toB64(attResp.clientDataJSON),
-                  attestationObject: toB64(attResp.attestationObject),
+                  clientDataJSON: toB64url(attResp.clientDataJSON),
+                  attestationObject: toB64url(attResp.attestationObject),
                 },
               },
             },
@@ -184,13 +187,13 @@ describe('WebAuthn (Virtual Authenticator)', () => {
                 const assertResp = assertCred.response as AuthenticatorAssertionResponse;
                 const credJSON = {
                   id: assertCred.id,
-                  rawId: toB64(assertCred.rawId),
+                  rawId: toB64url(assertCred.rawId),
                   type: assertCred.type,
                   response: {
-                    authenticatorData: toB64(assertResp.authenticatorData),
-                    clientDataJSON: toB64(assertResp.clientDataJSON),
-                    signature: toB64(assertResp.signature),
-                    userHandle: assertResp.userHandle ? toB64(assertResp.userHandle) : null,
+                    authenticatorData: toB64url(assertResp.authenticatorData),
+                    clientDataJSON: toB64url(assertResp.clientDataJSON),
+                    signature: toB64url(assertResp.signature),
+                    userHandle: assertResp.userHandle ? toB64url(assertResp.userHandle) : null,
                   },
                 };
 

--- a/internal/api/i/handler_2fa.go
+++ b/internal/api/i/handler_2fa.go
@@ -238,9 +238,11 @@ func (h *Handler) TwoFAKeyDone(c echo.Context) error {
 		return c.JSON(http.StatusInternalServerError, apiError("INTERNAL_ERROR", "Failed to persist key.", "5d37dbcb-891e-41ca-a3d6-e690c97775ac"))
 	}
 
-	// 1 つ以上の鍵が登録されたら user_profile.securityKeysAvailable を true にする。
+	// 1 つ以上の鍵が登録されたら user_profile.securityKeysAvailable +
+	// twoFactorEnabled を true にする。本家 Misskey と同じ挙動。
 	_ = h.userService.UpdateProfileFields(user.ID, map[string]any{
 		"securityKeysAvailable": true,
+		"twoFactorEnabled":      true,
 	})
 
 	return c.JSON(http.StatusOK, map[string]any{


### PR DESCRIPTION
## Summary

Chrome DevTools Protocol の Virtual Authenticator を使い、FIDO2セキュリティキーの登録→ログインのフルフローをCypress E2Eで検証する。Go側の `FinishLogin` success pathが実際のブラウザWebAuthn API経由で動作することを確認 (issue #55)。

## テストフロー

1. **Virtual Authenticator 有効化**: CDP `WebAuthn.addVirtualAuthenticator` (CTAP2, USB, user verification)
2. **セキュリティキー登録**:
   - `POST /api/i/2fa/register-key` → credential creation options 取得
   - `navigator.credentials.create()` (Virtual Authenticator が自動応答)
   - `POST /api/i/2fa/key-done` → attestation 送信 → 登録完了
3. **セキュリティキーでログイン**:
   - `POST /api/signin-flow` (password) → `next: "captcha-keys"` + assertion challenge
   - `navigator.credentials.get()` (Virtual Authenticator が自動応答)
   - `POST /api/signin-flow` (credential + sessionId) → `finished: true` (**FinishLogin success path**)

## cypress.config.ts 変更

`specPattern` を配列に変更し、submodule の本家spec + mk-go独自spec (`e2e/cypress/e2e/`) の両方を読み込むように。

## 実行方法

```bash
# mk-go サーバー起動 (テストモード)
MK_TESTMODE=1 ./built/misskey -config .config/default.yml &

# E2E 実行
make e2e-run
```

## 備考

- Go側のcoverprofileには反映されない (E2Eテストのため)
- W3C WebAuthn-3 仕様書にはlogin用test vectorがないため、E2Eが唯一の検証経路
- Virtual AuthenticatorはChromium系ブラウザ限定 (Cypressデフォルトのelectronで動作)

Closes #55