### PR TITLE
Fix devcontainer: postCreate起動エラー2件を修正

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -3,6 +3,9 @@ FROM mcr.microsoft.com/devcontainers/go:1.25
 # /go の所有権を vscode ユーザーに変更 (go mod download の権限エラー回避)
 RUN chown -R vscode:vscode /go
 
+# PostgreSQL client (pg_isready 等のユーティリティ)
+RUN apt-get update && apt-get install -y postgresql-client && rm -rf /var/lib/apt/lists/*
+
 # Node.js (フロントエンドビルド用)
 RUN curl -fsSL https://deb.nodesource.com/setup_22.x | bash - \
     && apt-get install -y nodejs \

--- a/.devcontainer/postCreate.sh
+++ b/.devcontainer/postCreate.sh
@@ -20,6 +20,8 @@ make migrate-up || echo "Migration failed (may already be applied)"
 
 echo "=== Frontend build ==="
 cd /workspace/third_party/misskey
+# Corepackがバージョン不一致時にダウンロード確認を求めないようにする
+export COREPACK_ENABLE_DOWNLOAD_PROMPT=0
 pnpm install --frozen-lockfile
 pnpm build
 


### PR DESCRIPTION
## Summary
devcontainer の postCreate.sh 実行中につまずいていた2つのエラーを修正しました。

## 主な変更点
- `.devcontainer/Dockerfile`: `postgresql-client` を追加（`pg_isready` が見つからない問題を解消）
- `.devcontainer/postCreate.sh`: `COREPACK_ENABLE_DOWNLOAD_PROMPT=0` を設定（フロントエンドビルド時に Corepack がダウンロード確認を求めて止まってしまう問題を解消）

## テスト
devcontainer を Rebuild して postCreate.sh が最後まで完走することを確認。