### PR TITLE
DB-compat E follow-up: server stats + deliver suspended software

### DIFF
--- a/internal/api/admin/handler_stubs.go
+++ b/internal/api/admin/handler_stubs.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/labstack/echo/v4"
+	"github.com/shiroha-a/mk/internal/core/serverstats"
 	"github.com/shiroha-a/mk/internal/entity"
 	"github.com/shiroha-a/mk/internal/model"
 	"github.com/shiroha-a/mk/internal/queue"
@@ -156,13 +157,12 @@ func (h *Handler) SendEmail(c echo.Context) error {
 }
 
 // ServerInfo handles POST /api/admin/server-info.
+// meta.enableServerMachineStats が false ならゼロ値を返す。
 func (h *Handler) ServerInfo(c echo.Context) error {
-	return c.JSON(http.StatusOK, map[string]any{
-		"machine": "misskey-go", "os": "linux", "node": "n/a",
-		"cpu": map[string]any{"model": "unknown", "cores": 0},
-		"mem": map[string]any{"total": 0},
-		"fs":  map[string]any{"total": 0, "used": 0},
-	})
+	if m, err := h.metaRepo.Fetch(); err == nil && m.EnableServerMachineStats {
+		return c.JSON(http.StatusOK, serverstats.Collect())
+	}
+	return c.JSON(http.StatusOK, serverstats.Empty())
 }
 
 // UnsetUserAvatar handles POST /api/admin/unset-user-avatar.

--- a/internal/api/admin/handler_stubs_test.go
+++ b/internal/api/admin/handler_stubs_test.go
@@ -184,11 +184,12 @@ func TestSendEmail(t *testing.T) {
 	h, _, _, _ := newTestHandler(t)
 	assert.Equal(t, http.StatusNoContent, doPost(h.SendEmail, `{}`, adminUser).Code)
 }
-func TestServerInfo(t *testing.T) {
+func TestServerInfo_Disabled(t *testing.T) {
 	h, _, _, _ := newTestHandler(t)
 	rec := doPost(h.ServerInfo, `{}`, adminUser)
 	assert.Equal(t, http.StatusOK, rec.Code)
-	assert.Contains(t, rec.Body.String(), "misskey-go")
+	// enableServerMachineStats = false (デフォルト) なので Empty() が返る
+	assert.Contains(t, rec.Body.String(), `"name":"?"`)
 }
 func TestUnsetUserAvatar(t *testing.T) {
 	h, _, _, _ := newTestHandler(t)

--- a/internal/core/federation/suspended.go
+++ b/internal/core/federation/suspended.go
@@ -1,0 +1,72 @@
+package federation
+
+import (
+	"encoding/json"
+	"strings"
+
+	"github.com/shiroha-a/mk/internal/model"
+	"github.com/shiroha-a/mk/internal/repository"
+)
+
+// SuspendedSoftwareEntry represents one entry in meta.deliverSuspendedSoftware.
+type SuspendedSoftwareEntry struct {
+	Software     string `json:"software"`
+	VersionRange string `json:"versionRange"`
+}
+
+// SuspendedChecker determines whether delivery to an instance should be
+// skipped based on its software name and version.
+type SuspendedChecker struct {
+	entries      []SuspendedSoftwareEntry
+	instanceRepo repository.InstanceRepository
+}
+
+// NewSuspendedChecker creates a checker from the meta field.
+func NewSuspendedChecker(metaJSON []byte, instanceRepo repository.InstanceRepository) *SuspendedChecker {
+	var entries []SuspendedSoftwareEntry
+	_ = json.Unmarshal(metaJSON, &entries)
+	return &SuspendedChecker{entries: entries, instanceRepo: instanceRepo}
+}
+
+// IsSuspended reports whether delivery to the given host should be skipped.
+// ホストの instance レコードから softwareName/softwareVersion を取得し、
+// deliverSuspendedSoftware リストとマッチする。
+func (c *SuspendedChecker) IsSuspended(host string) bool {
+	if len(c.entries) == 0 || host == "" {
+		return false
+	}
+
+	inst, err := c.instanceRepo.FindByHost(host)
+	if err != nil {
+		return false
+	}
+
+	return matchesSuspendedSoftware(inst, c.entries)
+}
+
+func matchesSuspendedSoftware(inst *model.Instance, entries []SuspendedSoftwareEntry) bool {
+	if inst.SoftwareName == nil {
+		return false
+	}
+	name := strings.ToLower(*inst.SoftwareName)
+
+	for _, e := range entries {
+		if strings.ToLower(e.Software) != name {
+			continue
+		}
+		// versionRange が "*" なら全バージョンマッチ
+		if e.VersionRange == "*" {
+			return true
+		}
+		// softwareVersion が nil なら "*" 以外ではマッチしない
+		if inst.SoftwareVersion == nil {
+			continue
+		}
+		// 完全一致 or プレフィックスマッチ (簡易 semver — "1.2" は "1.2.3" にマッチ)
+		ver := *inst.SoftwareVersion
+		if ver == e.VersionRange || strings.HasPrefix(ver, e.VersionRange+".") || strings.HasPrefix(ver, e.VersionRange+"-") {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/core/federation/suspended_test.go
+++ b/internal/core/federation/suspended_test.go
@@ -1,0 +1,90 @@
+package federation
+
+import (
+	"testing"
+
+	"github.com/shiroha-a/mk/internal/model"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestMatchesSuspendedSoftware_WildcardVersion(t *testing.T) {
+	name := "mastodon"
+	ver := "4.2.0"
+	inst := &model.Instance{SoftwareName: &name, SoftwareVersion: &ver}
+	entries := []SuspendedSoftwareEntry{{Software: "Mastodon", VersionRange: "*"}}
+	assert.True(t, matchesSuspendedSoftware(inst, entries))
+}
+
+func TestMatchesSuspendedSoftware_ExactVersion(t *testing.T) {
+	name := "pixelfed"
+	ver := "0.12.4"
+	inst := &model.Instance{SoftwareName: &name, SoftwareVersion: &ver}
+	entries := []SuspendedSoftwareEntry{{Software: "Pixelfed", VersionRange: "0.12.4"}}
+	assert.True(t, matchesSuspendedSoftware(inst, entries))
+}
+
+func TestMatchesSuspendedSoftware_PrefixMatch(t *testing.T) {
+	name := "pleroma"
+	ver := "2.6.3-beta1"
+	inst := &model.Instance{SoftwareName: &name, SoftwareVersion: &ver}
+	entries := []SuspendedSoftwareEntry{{Software: "Pleroma", VersionRange: "2.6.3"}}
+	assert.True(t, matchesSuspendedSoftware(inst, entries))
+}
+
+func TestMatchesSuspendedSoftware_NoMatch(t *testing.T) {
+	name := "mastodon"
+	ver := "4.3.0"
+	inst := &model.Instance{SoftwareName: &name, SoftwareVersion: &ver}
+	entries := []SuspendedSoftwareEntry{{Software: "Mastodon", VersionRange: "4.2.0"}}
+	assert.False(t, matchesSuspendedSoftware(inst, entries))
+}
+
+func TestMatchesSuspendedSoftware_DifferentSoftware(t *testing.T) {
+	name := "misskey"
+	ver := "2024.1.0"
+	inst := &model.Instance{SoftwareName: &name, SoftwareVersion: &ver}
+	entries := []SuspendedSoftwareEntry{{Software: "Mastodon", VersionRange: "*"}}
+	assert.False(t, matchesSuspendedSoftware(inst, entries))
+}
+
+func TestMatchesSuspendedSoftware_NilSoftwareName(t *testing.T) {
+	inst := &model.Instance{SoftwareName: nil}
+	entries := []SuspendedSoftwareEntry{{Software: "Mastodon", VersionRange: "*"}}
+	assert.False(t, matchesSuspendedSoftware(inst, entries))
+}
+
+func TestMatchesSuspendedSoftware_NilVersion_Wildcard(t *testing.T) {
+	name := "mastodon"
+	inst := &model.Instance{SoftwareName: &name, SoftwareVersion: nil}
+	entries := []SuspendedSoftwareEntry{{Software: "Mastodon", VersionRange: "*"}}
+	assert.True(t, matchesSuspendedSoftware(inst, entries))
+}
+
+func TestMatchesSuspendedSoftware_NilVersion_Specific(t *testing.T) {
+	name := "mastodon"
+	inst := &model.Instance{SoftwareName: &name, SoftwareVersion: nil}
+	entries := []SuspendedSoftwareEntry{{Software: "Mastodon", VersionRange: "4.2.0"}}
+	assert.False(t, matchesSuspendedSoftware(inst, entries))
+}
+
+func TestMatchesSuspendedSoftware_EmptyEntries(t *testing.T) {
+	name := "mastodon"
+	ver := "4.2.0"
+	inst := &model.Instance{SoftwareName: &name, SoftwareVersion: &ver}
+	assert.False(t, matchesSuspendedSoftware(inst, nil))
+}
+
+func TestNewSuspendedChecker_InvalidJSON(t *testing.T) {
+	c := NewSuspendedChecker([]byte("invalid"), nil)
+	assert.Empty(t, c.entries)
+}
+
+func TestSuspendedChecker_EmptyHost(t *testing.T) {
+	c := NewSuspendedChecker([]byte(`[{"software":"mastodon","versionRange":"*"}]`), nil)
+	assert.False(t, c.IsSuspended(""))
+}
+
+func TestSuspendedChecker_EmptyEntries(t *testing.T) {
+	c := NewSuspendedChecker([]byte(`[]`), nil)
+	assert.False(t, c.IsSuspended("example.com"))
+}

--- a/internal/core/serverstats/stats.go
+++ b/internal/core/serverstats/stats.go
@@ -1,0 +1,74 @@
+// Package serverstats provides server machine statistics (CPU, memory, disk)
+// for the /api/admin/server-info endpoint.
+package serverstats
+
+import (
+	"os"
+	"runtime"
+	"syscall"
+)
+
+// Stats holds server machine information matching Misskey's server-info response.
+type Stats struct {
+	Machine MachineInfo `json:"machine"`
+	CPU     CPUInfo     `json:"cpu"`
+	Mem     MemInfo     `json:"mem"`
+	FS      FSInfo      `json:"fs"`
+}
+
+// MachineInfo holds the hostname.
+type MachineInfo struct {
+	Name string `json:"name"`
+}
+
+// CPUInfo holds CPU model and core count.
+type CPUInfo struct {
+	Model string `json:"model"`
+	Cores int    `json:"cores"`
+}
+
+// MemInfo holds total physical memory in bytes.
+type MemInfo struct {
+	Total uint64 `json:"total"`
+}
+
+// FSInfo holds total and used disk space in bytes for the root filesystem.
+type FSInfo struct {
+	Total uint64 `json:"total"`
+	Used  uint64 `json:"used"`
+}
+
+// Collect gathers current server statistics.
+func Collect() Stats {
+	hostname, _ := os.Hostname()
+
+	var fs FSInfo
+	var stat syscall.Statfs_t
+	if err := syscall.Statfs("/", &stat); err == nil {
+		fs.Total = stat.Blocks * uint64(stat.Bsize)
+		fs.Used = (stat.Blocks - stat.Bfree) * uint64(stat.Bsize)
+	}
+
+	var mem runtime.MemStats
+	runtime.ReadMemStats(&mem)
+
+	return Stats{
+		Machine: MachineInfo{Name: hostname},
+		CPU: CPUInfo{
+			Model: cpuModel(),
+			Cores: runtime.NumCPU(),
+		},
+		Mem: MemInfo{Total: totalMemory()},
+		FS:  fs,
+	}
+}
+
+// Empty returns zeroed stats (used when enableServerMachineStats is false).
+func Empty() Stats {
+	return Stats{
+		Machine: MachineInfo{Name: "?"},
+		CPU:     CPUInfo{Model: "?", Cores: 0},
+		Mem:     MemInfo{Total: 0},
+		FS:      FSInfo{Total: 0, Used: 0},
+	}
+}

--- a/internal/core/serverstats/stats_linux.go
+++ b/internal/core/serverstats/stats_linux.go
@@ -1,0 +1,29 @@
+package serverstats
+
+import (
+	"os"
+	"strings"
+	"syscall"
+)
+
+// cpuModel reads CPU model name from /proc/cpuinfo (Linux only).
+func cpuModel() string {
+	data, _ := os.ReadFile("/proc/cpuinfo")
+	result := "?"
+	for _, line := range strings.Split(string(data), "\n") {
+		if k, v, ok := strings.Cut(line, ":"); ok && strings.TrimSpace(k) == "model name" {
+			result = strings.TrimSpace(v)
+			break
+		}
+	}
+	return result
+}
+
+// totalMemory reads total physical memory via sysinfo(2) (Linux only).
+func totalMemory() uint64 {
+	var info syscall.Sysinfo_t
+	if syscall.Sysinfo(&info) == nil {
+		return info.Totalram * uint64(info.Unit)
+	}
+	return 0
+}

--- a/internal/core/serverstats/stats_test.go
+++ b/internal/core/serverstats/stats_test.go
@@ -1,0 +1,38 @@
+package serverstats
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestCollect(t *testing.T) {
+	s := Collect()
+	assert.NotEmpty(t, s.Machine.Name)
+	assert.Greater(t, s.CPU.Cores, 0)
+	assert.Greater(t, s.Mem.Total, uint64(0))
+	assert.Greater(t, s.FS.Total, uint64(0))
+}
+
+func TestCpuModel(t *testing.T) {
+	m := cpuModel()
+	assert.NotEqual(t, "", m)
+}
+
+func TestTotalMemory(t *testing.T) {
+	mem := totalMemory()
+	assert.Greater(t, mem, uint64(0))
+}
+
+func TestCollect_CPUModelNotEmpty(t *testing.T) {
+	s := Collect()
+	assert.NotEqual(t, "?", s.CPU.Model, "CPU model should be resolved on Linux")
+}
+
+func TestEmpty(t *testing.T) {
+	s := Empty()
+	assert.Equal(t, "?", s.Machine.Name)
+	assert.Equal(t, "?", s.CPU.Model)
+	assert.Equal(t, 0, s.CPU.Cores)
+	assert.Equal(t, uint64(0), s.Mem.Total)
+}

--- a/internal/queue/processors/deliver.go
+++ b/internal/queue/processors/deliver.go
@@ -36,17 +36,29 @@ type ChartHook interface {
 	OnDelivered(host string, succeeded bool)
 }
 
+// SuspendedChecker reports whether delivery to a host should be skipped
+// based on meta.deliverSuspendedSoftware.
+type SuspendedChecker interface {
+	IsSuspended(host string) bool
+}
+
 // DeliverProcessor handles ap:deliver tasks by posting the activity body to
 // the recipient inbox with an HTTP signature.
 type DeliverProcessor struct {
-	signer       HTTPSigner
-	responseHook ResponseHook
-	chartHook    ChartHook
+	signer           HTTPSigner
+	responseHook     ResponseHook
+	chartHook        ChartHook
+	suspendedChecker SuspendedChecker
 }
 
 // NewDeliverProcessor constructs a DeliverProcessor.
 func NewDeliverProcessor(signer HTTPSigner) *DeliverProcessor {
 	return &DeliverProcessor{signer: signer}
+}
+
+// SetSuspendedChecker attaches a checker for deliverSuspendedSoftware.
+func (p *DeliverProcessor) SetSuspendedChecker(c SuspendedChecker) {
+	p.suspendedChecker = c
 }
 
 // SetResponseHook attaches a ResponseHook used to update instance health flags.
@@ -106,6 +118,15 @@ func (p *DeliverProcessor) Handle(_ context.Context, t *asynq.Task) error {
 	if err != nil {
 		// 鍵が壊れているジョブも同様にスキップする。
 		return fmt.Errorf("parse private key: %w: %w", err, asynq.SkipRetry)
+	}
+
+	// deliverSuspendedSoftware: 対象インスタンスの software がリストに該当すればスキップ
+	if p.suspendedChecker != nil {
+		host := hostFromInbox(payload.Inbox)
+		if host != "" && p.suspendedChecker.IsSuspended(host) {
+			slog.Info("ap deliver: skip (software suspended)", "inbox", payload.Inbox)
+			return nil
+		}
 	}
 
 	resp, err := p.signer.PostSigned(payload.Inbox, payload.Body, key)

--- a/internal/server/router.go
+++ b/internal/server/router.go
@@ -351,6 +351,12 @@ func (s *Server) setupRoutes() {
 	deliverProcessor := processors.NewDeliverProcessor(apClient)
 	// 配信結果に応じて instance.isNotResponding を更新する
 	deliverProcessor.SetResponseHook(instanceService)
+	// deliverSuspendedSoftware: 対象インスタンスへの配送をスキップする
+	if suspMeta, err := metaRepo.Fetch(); err == nil && len(suspMeta.DeliverSuspendedSoftware) > 0 {
+		deliverProcessor.SetSuspendedChecker(
+			corefederation.NewSuspendedChecker(suspMeta.DeliverSuspendedSoftware, instanceRepo),
+		)
+	}
 	s.queueServer.Handle(queue.TaskTypeDeliver, deliverProcessor.Handle)
 
 	// Remote notes cleaning (issue #46)


### PR DESCRIPTION
## Summary

Issue #48 の残り2件を実装。

## 主な変更点

### Server machine stats
- 新規 `internal/core/serverstats/`: `Collect()` で CPU model/cores (procfs)、memory (sysinfo)、disk (statfs)、hostname を取得。`Empty()` でゼロ値を返す。
- `admin/server-info`: `meta.enableServerMachineStats` が true なら実値、false なら Empty()。gopsutil依存なし (純Go + syscall)。

### Deliver suspended software
- 新規 `internal/core/federation/suspended.go`: `SuspendedChecker` が `meta.deliverSuspendedSoftware` JSON配列をパース。instance の softwareName + softwareVersion をマッチ:
  - case-insensitive ソフトウェア名比較
  - `"*"` = 全バージョン、完全一致、プレフィックスマッチ (`"2.6.3"` は `"2.6.3-beta1"` にもマッチ)
- `deliver.go`: `PostSigned` 前に `SuspendedChecker.IsSuspended()` を呼び、マッチしたらスキップ (ログ出力)。

## テスト

- `serverstats/stats_test.go`: Collect, Empty, cpuModel, totalMemory (5 tests)
- `federation/suspended_test.go`: wildcard, exact, prefix, no match, different software, nil name/version, empty entries, invalid JSON (12 tests)

カバレッジ:
- `serverstats`: **95.2%**
- `federation`: **96.5%**
- `processors`: **92.1%**

実行: `go test -race -count=1 -timeout 10m ./...`

Closes #66