### PR TITLE
Public /api/signup: test-mode bypass for E2E

### DIFF
--- a/internal/api/signup/handler.go
+++ b/internal/api/signup/handler.go
@@ -28,6 +28,12 @@ type Handler struct {
 	idGen         id.Generator
 	captchaSvc    *captcha.Service // optional
 	ticketStore   TicketStore      // optional, invitation code検証用
+	testMode      bool             // true のとき disableRegistration / captcha をバイパス (本家 TS と同じ)
+}
+
+// SetTestMode enables test-mode bypass (本家 `process.env.NODE_ENV !== 'test'` 相当).
+func (h *Handler) SetTestMode(v bool) {
+	h.testMode = v
 }
 
 // NewHandler creates a new signup Handler.
@@ -69,14 +75,14 @@ func (h *Handler) Signup(c echo.Context) error {
 		return c.JSON(http.StatusInternalServerError, errResp("INTERNAL_ERROR", "Internal error.", "5d37dbcb-891e-41ca-a3d6-e690c97775ac"))
 	}
 
-	// メール認証フローは未実装
-	if meta.EmailRequiredForSignup {
+	// メール認証フローは未実装 (テストモードではスキップ)
+	if !h.testMode && meta.EmailRequiredForSignup {
 		return c.JSON(http.StatusBadRequest, errResp("INVALID_PARAM", "Email-required signup is not yet supported.", "3d81ceae-475f-4600-b2a8-2bc116157532"))
 	}
 
-	// 登録無効時はinvitation code必須
+	// 登録無効時はinvitation code必須 (テストモードではバイパス — 本家 TS 互換)
 	var ticket *model.RegistrationTicket
-	if meta.DisableRegistration {
+	if !h.testMode && meta.DisableRegistration {
 		t, vErr := h.validateInvitationCode(req.InvitationCode)
 		if vErr != nil {
 			return c.JSON(http.StatusBadRequest, errResp("INVITATION_CODE_INVALID", "Invalid invitation code.", "11e71a03-43c4-4a99-92cf-bb7e2c581998"))
@@ -84,8 +90,8 @@ func (h *Handler) Signup(c echo.Context) error {
 		ticket = t
 	}
 
-	// CAPTCHA検証
-	if h.captchaSvc != nil {
+	// CAPTCHA検証 (テストモードではスキップ)
+	if !h.testMode && h.captchaSvc != nil {
 		tokens := captcha.CaptchaTokens{
 			Hcaptcha:    req.HcaptchaResponse,
 			Recaptcha:   req.RecaptchaResponse,

--- a/internal/server/router.go
+++ b/internal/server/router.go
@@ -588,6 +588,7 @@ func (s *Server) setupRoutes() {
 		signupHandler.SetCaptcha(captchaSvc)
 	}
 	signupHandler.SetTicketStore(&gormTicketStore{db: s.db})
+	signupHandler.SetTestMode(s.config.TestMode)
 	api.POST("/signup", signupHandler.Signup)
 
 	// Signin (Phase 6)


### PR DESCRIPTION
## Summary

本家 Misskey TS の `process.env.NODE_ENV !== 'test'` と同等のテストモードバイパスを `/api/signup` に追加。

## 変更内容

- `Handler.testMode` フラグ追加 (config.TestMode から wire)
- テストモード時にスキップ:
  - `meta.disableRegistration` (invitation code チェック)
  - `meta.emailRequiredForSignup` (メール認証フロー)
  - CAPTCHA 検証
- 本番モードでは従来通り全チェック実施

## 根本原因

`meta.disableRegistration` のデフォルトが `true` のため、Cypress E2E の `cy.registerUser(username, password)` が `POST /api/signup` を呼ぶと `INVITATION_CODE_INVALID` で失敗していた。本家 TS は `NODE_ENV === 'test'` でこのチェックをスキップする。

## E2E テスト結果

signup 自体は通るようになった。残りの失敗は `cy.visitHome()` の `button` タイムアウト — フロントエンドが Vite dev モードで配信されており、ビルド済みアセットが使われていない問題 (別issue)。

カバレッジ: `internal/api/signup`: **97.9%**

Closes #89