### PR TITLE
Sync buildMetaJSON with /api/meta handler

### DIFF
--- a/internal/server/frontend.go
+++ b/internal/server/frontend.go
@@ -55,9 +55,15 @@ func frontendHTML(cfg *config.Config, metaRepo repository.MetaRepository) echo.H
 		// CLIENT_ENTRYの設定
 		clientEntryJS := "null"
 		viteClientTag := `<script type="module" src="/vite/@vite/client"></script>`
-		if clientEntry != "" {
-			clientEntryJS = fmt.Sprintf("'%s'", clientEntry)
+		cssLinkTags := ""
+		if clientEntry.Script != "" {
+			clientEntryJS = fmt.Sprintf("'%s'", clientEntry.Script)
 			viteClientTag = "" // production ではVite clientは不要
+			// Vite manifest の CSS 依存を <link> タグとして挿入する。
+			// これがないとエントリの CSS (100KB+) が読み込まれずスタイル崩れになる。
+			for _, css := range clientEntry.CSS {
+				cssLinkTags += fmt.Sprintf(`<link rel="stylesheet" href="/vite/%s">`, css) + "\n"
+			}
 		}
 
 		html := fmt.Sprintf(`<!DOCTYPE html>
@@ -79,6 +85,7 @@ func frontendHTML(cfg *config.Config, metaRepo repository.MetaRepository) echo.H
 <link rel="icon" href="%s">
 <link rel="manifest" href="/manifest.json">
 %s
+%s
 <link rel="stylesheet" href="/vite/loader/style.css">
 <script>const VERSION = '%s'; const CLIENT_ENTRY = %s; const LANGS = ["ja-JP","en-US"];</script>
 <script type="application/json" id="misskey_meta" data-generated-at="%d">%s</script>
@@ -92,7 +99,7 @@ func frontendHTML(cfg *config.Config, metaRepo repository.MetaRepository) echo.H
 </div>
 </div>
 </body></html>`, instanceName, instanceName, instanceDesc, iconURL, cfg.URL,
-			themeColor, cfg.URL, instanceName, iconURL, viteClientTag,
+			themeColor, cfg.URL, instanceName, iconURL, viteClientTag, cssLinkTags,
 			cfg.Version, clientEntryJS,
 			time.Now().UnixMilli(), metaJSON, mascotURL)
 
@@ -162,25 +169,32 @@ func StaticDir() string {
 	return filepath.Join(frontendBase, "packages", "backend", "assets")
 }
 
-// detectClientEntry reads the Vite manifest to find the entry script path.
-// ビルド済みアセットが存在しない場合は空文字列を返す (dev mode)。
-func detectClientEntry() string {
+// clientEntryInfo holds the Vite entry point script and its CSS dependencies.
+type clientEntryInfo struct {
+	Script string
+	CSS    []string
+}
+
+// detectClientEntry reads the Vite manifest to find the entry script and CSS.
+// ビルド済みアセットが存在しない場合は空値を返す (dev mode)。
+func detectClientEntry() clientEntryInfo {
 	manifestPath := filepath.Join(FrontendDir(), "manifest.json")
 	data, err := os.ReadFile(manifestPath)
 	if err != nil {
-		return ""
+		return clientEntryInfo{}
 	}
 	var manifest map[string]struct {
-		File    string `json:"file"`
-		IsEntry bool   `json:"isEntry"`
+		File    string   `json:"file"`
+		IsEntry bool     `json:"isEntry"`
+		CSS     []string `json:"css"`
 	}
 	if err := json.Unmarshal(data, &manifest); err != nil {
-		return ""
+		return clientEntryInfo{}
 	}
 	if entry, ok := manifest["src/_boot_.ts"]; ok {
-		return entry.File
+		return clientEntryInfo{Script: entry.File, CSS: entry.CSS}
 	}
-	return ""
+	return clientEntryInfo{}
 }
 
 // buildMetaJSON constructs the /api/meta equivalent JSON for inline embedding.

--- a/internal/server/frontend.go
+++ b/internal/server/frontend.go
@@ -143,21 +143,23 @@ func ClientAssetsDir() string {
 }
 
 // TwemojiDir returns the path to twemoji SVG files.
-// 環境変数 MISSKEY_TWEMOJI_DIR で上書き可能。
+// 環境変数 MISSKEY_TWEMOJI_DIR で上書き可能。pnpm の hoisted node_modules は
+// packages/backend 配下に配置されるため、そちらを参照する。
 func TwemojiDir() string {
 	if v := os.Getenv("MISSKEY_TWEMOJI_DIR"); v != "" {
 		return v
 	}
-	return filepath.Join(frontendBase, "node_modules", "@discordapp", "twemoji", "dist", "svg")
+	return filepath.Join(frontendBase, "packages", "backend", "node_modules", "@discordapp", "twemoji", "dist", "svg")
 }
 
 // StaticDir returns the path to static assets (icons, splash, favicon etc.).
-// 環境変数 MISSKEY_STATIC_DIR で上書き可能。
+// 環境変数 MISSKEY_STATIC_DIR で上書き可能。本家 TS では packages/backend/assets
+// が /static-assets として配信される。
 func StaticDir() string {
 	if v := os.Getenv("MISSKEY_STATIC_DIR"); v != "" {
 		return v
 	}
-	return filepath.Join(frontendBase, "assets")
+	return filepath.Join(frontendBase, "packages", "backend", "assets")
 }
 
 // detectClientEntry reads the Vite manifest to find the entry script path.

--- a/internal/server/frontend.go
+++ b/internal/server/frontend.go
@@ -182,39 +182,89 @@ func detectClientEntry() string {
 }
 
 // buildMetaJSON constructs the /api/meta equivalent JSON for inline embedding.
-// meta handler と同じフィールドを返す。フロントエンドはこのJSONを先に読んで
-// /api/meta の呼び出しを省略する。
+// /api/meta ハンドラ (meta/handler.go) と完全に同じフィールドを返す。
+// フロントエンドはこのJSONを先に読んで /api/meta の呼び出しを省略する。
 func buildMetaJSON(cfg *config.Config, m *model.Meta) string {
+	// mascotImageUrl フォールバック
+	mascot := "/assets/ai.png"
+	if m.MascotImageURL != nil && *m.MascotImageURL != "" {
+		mascot = *m.MascotImageURL
+	}
+	// translatorAvailable
+	translatorAvailable := m.DeeplAuthKey != nil && *m.DeeplAuthKey != ""
+
 	resp := map[string]any{
-		"maintainerName": m.MaintainerName, "maintainerEmail": m.MaintainerEmail,
-		"version": cfg.Version, "name": m.Name, "shortName": m.ShortName,
-		"uri": cfg.URL, "description": m.Description, "langs": m.Langs,
-		"disableRegistration":    m.DisableRegistration,
-		"emailRequiredForSignup": m.EmailRequiredForSignup,
-		"enableHcaptcha":         m.EnableHcaptcha, "hcaptchaSiteKey": m.HcaptchaSiteKey,
-		"enableRecaptcha": m.EnableRecaptcha, "recaptchaSiteKey": m.RecaptchaSiteKey,
-		"enableTurnstile": m.EnableTurnstile, "turnstileSiteKey": m.TurnstileSiteKey,
-		"themeColor": m.ThemeColor, "bannerUrl": m.BannerURL,
-		"backgroundImageUrl": m.BackgroundImageURL,
-		"logoImageUrl":       m.LogoImageURL, "iconUrl": m.IconURL,
-		"cacheRemoteFiles":    m.CacheRemoteFiles,
-		"enableServiceWorker": m.EnableServiceWorker,
-		"swPublickey":         m.SwPublicKey, "serverRules": m.ServerRules,
-		"maxNoteTextLength": 3000,
-		"tosUrl":            m.TermsOfServiceURL, "repositoryUrl": m.RepositoryURL,
-		"feedbackUrl": m.FeedbackURL, "impressumUrl": m.ImpressumURL,
-		"privacyPolicyUrl":    m.PrivacyPolicyURL,
-		"federation":          m.Federation,
-		"translatorAvailable": false, "enableEmail": m.EnableEmail,
-		"ads": []any{}, "notesPerOneAd": 0,
-		"cacheRemoteSensitiveFiles": m.CacheRemoteSensitiveFiles,
-		"requireSetup":              m.RootUserID == nil,
+		"maintainerName":               m.MaintainerName,
+		"maintainerEmail":              m.MaintainerEmail,
+		"version":                      cfg.Version,
+		"name":                         m.Name,
+		"shortName":                    m.ShortName,
+		"uri":                          cfg.URL,
+		"description":                  m.Description,
+		"langs":                        m.Langs,
+		"disableRegistration":          m.DisableRegistration,
+		"emailRequiredForSignup":       m.EmailRequiredForSignup,
+		"enableHcaptcha":               m.EnableHcaptcha,
+		"hcaptchaSiteKey":              m.HcaptchaSiteKey,
+		"enableRecaptcha":              m.EnableRecaptcha,
+		"recaptchaSiteKey":             m.RecaptchaSiteKey,
+		"enableTurnstile":              m.EnableTurnstile,
+		"turnstileSiteKey":             m.TurnstileSiteKey,
+		"themeColor":                   m.ThemeColor,
+		"bannerUrl":                    m.BannerURL,
+		"backgroundImageUrl":           m.BackgroundImageURL,
+		"logoImageUrl":                 m.LogoImageURL,
+		"iconUrl":                      m.IconURL,
+		"cacheRemoteFiles":             m.CacheRemoteFiles,
+		"enableServiceWorker":          m.EnableServiceWorker,
+		"swPublickey":                  m.SwPublicKey,
+		"serverRules":                  m.ServerRules,
+		"maxNoteTextLength":            3000,
+		"tosUrl":                       m.TermsOfServiceURL,
+		"repositoryUrl":                m.RepositoryURL,
+		"feedbackUrl":                  m.FeedbackURL,
+		"impressumUrl":                 m.ImpressumURL,
+		"privacyPolicyUrl":             m.PrivacyPolicyURL,
+		"inquiryUrl":                   m.InquiryURL,
+		"federation":                   m.Federation,
+		"defaultLightTheme":            m.DefaultLightTheme,
+		"defaultDarkTheme":             m.DefaultDarkTheme,
+		"serverErrorImageUrl":          m.ServerErrorImageURL,
+		"notFoundImageUrl":             m.NotFoundImageURL,
+		"infoImageUrl":                 m.InfoImageURL,
+		"app192IconUrl":                m.App192IconURL,
+		"app512IconUrl":                m.App512IconURL,
+		"mascotImageUrl":               mascot,
+		"translatorAvailable":          translatorAvailable,
+		"enableEmail":                  m.EnableEmail,
+		"enableUrlPreview":             m.URLPreviewEnabled,
+		"ads":                          []any{},
+		"notesPerOneAd":                m.NotesPerOneAd,
+		"mediaProxy":                   cfg.MediaProxy,
+		"cacheRemoteSensitiveFiles":    m.CacheRemoteSensitiveFiles,
+		"requireSetup":                 m.RootUserID == nil,
+		"singleUserMode":               m.SingleUserMode,
+		"providesTarball":              false,
+		"maxFileSize":                  cfg.MaxFileSize,
+		"proxyAccountName":             nil,
+		"noteSearchableScope":          "local",
+		"enableMcaptcha":               m.EnableMcaptcha,
+		"mcaptchaSiteKey":              m.McaptchaSiteKey,
+		"mcaptchaInstanceUrl":          m.McaptchaInstanceURL,
+		"enableTestcaptcha":            m.EnableTestcaptcha,
+		"sentryForFrontend":            nil,
+		"googleAnalyticsMeasurementId": m.GoogleAnalyticsMeasurementID,
+		"clientOptions":                clientOptionsJSON(m.ClientOptions),
+		"policies":                     defaultMetaPolicies(),
 		"features": map[string]any{
 			"registration":           !m.DisableRegistration,
 			"emailRequiredForSignup": m.EmailRequiredForSignup,
-			"hcaptcha":               m.EnableHcaptcha, "recaptcha": m.EnableRecaptcha,
-			"turnstile": m.EnableTurnstile, "objectStorage": m.UseObjectStorage,
-			"serviceWorker": m.EnableServiceWorker, "miauth": true,
+			"hcaptcha":               m.EnableHcaptcha,
+			"recaptcha":              m.EnableRecaptcha,
+			"turnstile":              m.EnableTurnstile,
+			"objectStorage":          m.UseObjectStorage,
+			"serviceWorker":          m.EnableServiceWorker,
+			"miauth":                 true,
 		},
 	}
 	data, err := json.Marshal(resp)
@@ -222,6 +272,39 @@ func buildMetaJSON(cfg *config.Config, m *model.Meta) string {
 		return "{}"
 	}
 	return string(data)
+}
+
+// clientOptionsJSON normalizes a jsonb byte slice into map[string]any.
+func clientOptionsJSON(raw []byte) any {
+	if len(raw) == 0 {
+		return map[string]any{}
+	}
+	var out map[string]any
+	if err := json.Unmarshal(raw, &out); err != nil || out == nil {
+		return map[string]any{}
+	}
+	return out
+}
+
+// defaultMetaPolicies returns the Misskey default policies for the inline meta.
+func defaultMetaPolicies() map[string]any {
+	return map[string]any{
+		"gtlAvailable": true, "ltlAvailable": true,
+		"canPublicNote": true, "mentionLimit": 20,
+		"canInvite": false, "inviteLimit": 0, "inviteLimitCycle": 10080,
+		"inviteExpirationTime": 0, "canManageCustomEmojis": false,
+		"canManageAvatarDecorations": false, "canSearchNotes": false,
+		"canSearchUsers": true, "canUseTranslator": true,
+		"canHideAds": false, "driveCapacityMb": 100, "maxFileSizeMb": 30,
+		"alwaysMarkNsfw": false, "canUpdateBioMedia": true,
+		"pinLimit": 5, "antennaLimit": 5, "wordMuteLimit": 200,
+		"webhookLimit": 3, "clipLimit": 10, "noteEachClipsLimit": 200,
+		"userListLimit": 10, "userEachUserListsLimit": 50,
+		"rateLimitFactor": 1, "avatarDecorationLimit": 1,
+		"canImportAntennas": false, "canImportBlocking": false,
+		"canImportFollowing": false, "canImportMuting": false,
+		"canImportUserLists": false, "chatAvailability": "available",
+	}
 }
 
 // manifestJSON generates a PWA manifest.json response.


### PR DESCRIPTION
## Summary

`buildMetaJSON()` (HTML inline `<script id="misskey_meta">`) に約20フィールドが欠けていたため、フロントエンドの表示崩れが発生していた。`/api/meta` ハンドラと完全同期。

## 欠けていたフィールド (追加分)

- **`policies`** — ユーザー権限判定に必須 (canPublicNote, pinLimit 等)
- `mascotImageUrl`, `mediaProxy`, `maxFileSize`
- `inquiryUrl`, `singleUserMode`, `enableUrlPreview`
- `defaultLightTheme`, `defaultDarkTheme`
- `serverErrorImageUrl`, `notFoundImageUrl`, `infoImageUrl`
- `app192IconUrl`, `app512IconUrl`
- `enableMcaptcha`, `mcaptchaSiteKey`, `mcaptchaInstanceUrl`, `enableTestcaptcha`
- `googleAnalyticsMeasurementId`, `clientOptions`
- `noteSearchableScope`, `providesTarball`, `proxyAccountName`, `sentryForFrontend`
- `translatorAvailable` (ハードコード false → meta実値)

## 影響

フロントエンドはページ読み込み時にまず inline meta を読み、`/api/meta` の呼び出しを省略する。inline meta にフィールドがないと undefined アクセスや権限チェック失敗でUIが壊れる。

Closes #95
Part of #92