### PR TITLE
Fix E2E: /api/username/available + MkModal auto-patch

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -92,9 +92,18 @@ E2E_WORKDIR=/work
 e2e-submodule-init:
 	git submodule update --init --recursive third_party/misskey
 
+# 本家フロントエンドの既知バグにパッチを当てる (ビルド前に実行)。
+# 本家リポジトリには直接コミットしない — mk-go 側でのみ適用する。
+e2e-patch-frontend:
+	@echo "Applying MkModal null guard patch..."
+	@cd third_party/misskey && \
+		sed -i '/const el = content\.value\.children\[0\];/{ n; /if (el == null) return;/!s/^/\t\tif (el == null) return;\n/ }' \
+		packages/frontend/src/components/MkModal.vue
+	@echo "Patch applied."
+
 # 本家フロントエンドを Docker 内でビルドする。数分〜10 分程度かかる。
 # 成果物は third_party/misskey/packages/frontend/... 配下に出力される。
-e2e-frontend-build:
+e2e-frontend-build: e2e-patch-frontend
 	docker run --rm -v $(PWD):$(E2E_WORKDIR) -w $(E2E_WORKDIR)/third_party/misskey \
 		$(E2E_NODE_IMAGE) \
 		bash -lc "corepack enable && corepack prepare pnpm@latest --activate && pnpm install --frozen-lockfile && pnpm build"

--- a/internal/server/router.go
+++ b/internal/server/router.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 	"os"
 	"path/filepath"
+	"strings"
 	"time"
 
 	"github.com/labstack/echo/v4"
@@ -590,6 +591,19 @@ func (s *Server) setupRoutes() {
 	signupHandler.SetTicketStore(&gormTicketStore{db: s.db})
 	signupHandler.SetTestMode(s.config.TestMode)
 	api.POST("/signup", signupHandler.Signup)
+
+	// Username availability check (フロントエンドの signup フォームが呼ぶ)
+	api.POST("/username/available", func(c echo.Context) error {
+		var req struct {
+			Username string `json:"username"`
+		}
+		if err := c.Bind(&req); err != nil || req.Username == "" {
+			return c.JSON(http.StatusOK, map[string]any{"available": false})
+		}
+		_, err := userRepo.FindByUsernameLower(strings.ToLower(req.Username), nil)
+		available := err != nil
+		return c.JSON(http.StatusOK, map[string]any{"available": available})
+	})
 
 	// Signin (Phase 6)
 	userIPRepo := repository.NewUserIPRepository(s.db)


### PR DESCRIPTION
## Summary

E2Eテスト失敗の原因2件を修正。

## 変更内容

### /api/username/available エンドポイント追加

フロントエンドの `MkSignupDialog.form.vue` が signup フォームで `misskeyApi('username/available', { username })` を呼び、`{ available: true }` が返らないと submit ボタンが disabled のまま (`usernameState !== 'ok'`)。

このエンドポイントが未実装だったため、APIの catchall が `{}` を返し、`result.available` が undefined → ボタン disabled。

### Makefile e2e-patch-frontend

`make e2e-frontend-build` の前に MkModal.vue の null guard パッチを自動適用する target を追加。`content.value.children[0]` が undefined のときの `addEventListener` クラッシュを防ぐ。本家リポジトリには直接コミットしない。

## E2E結果

| テスト | 修正前 | 修正後 |
|--------|--------|--------|
| basic.cy.ts | 7/12 | **8/12** |
| router.cy.ts | 0/1 | 0/1 |

残り4 fail: user-setup wizard モーダルが表示されない問題 (別途調査継続)

Part of #92