### PR TITLE
Phase 11.2: Backend E2E test infra + well-known tests

### DIFF
--- a/internal/api/wellknown/handler.go
+++ b/internal/api/wellknown/handler.go
@@ -16,11 +16,25 @@ type Handler struct {
 	urls        *activitypub.URLBuilder
 	userService *user.Service
 	host        string
+	origin      string // scheme + host (e.g. "https://example.com")
 }
 
 // NewHandler constructs a Handler.
-func NewHandler(urls *activitypub.URLBuilder, userService *user.Service, host string) *Handler {
-	return &Handler{urls: urls, userService: userService, host: host}
+// origin は config.URL 相当の完全URL (例: "https://example.com")。
+func NewHandler(urls *activitypub.URLBuilder, userService *user.Service, host, origin string) *Handler {
+	return &Handler{urls: urls, userService: userService, host: host, origin: origin}
+}
+
+// setDiscoveryCORS sets CORS headers on discovery endpoints.
+// TS本家は well-known ルートに preHandler hook で無条件に
+// CORSヘッダーを設定しているため、Echo の CORS middleware (Originヘッダー
+// がある場合のみ発動) とは別に明示的に付与する。
+func setDiscoveryCORS(c echo.Context) {
+	h := c.Response().Header()
+	h.Set("Access-Control-Allow-Origin", "*")
+	h.Set("Access-Control-Allow-Methods", "GET, OPTIONS")
+	h.Set("Access-Control-Allow-Headers", "Accept")
+	h.Set("Access-Control-Expose-Headers", "Vary")
 }
 
 // Webfinger handles GET /.well-known/webfinger.
@@ -44,6 +58,7 @@ func (h *Handler) Webfinger(c echo.Context) error {
 	}
 
 	uri := h.urls.UserURI(bundle.User.ID)
+	profileURL := h.origin + "/@" + bundle.User.Username
 	resp := map[string]any{
 		"subject": "acct:" + bundle.User.Username + "@" + h.host,
 		"links": []map[string]any{
@@ -55,31 +70,77 @@ func (h *Handler) Webfinger(c echo.Context) error {
 			{
 				"rel":  "http://webfinger.net/rel/profile-page",
 				"type": "text/html",
-				"href": uri,
+				"href": profileURL,
+			},
+			{
+				"rel":      "http://ostatus.org/schema/1.0/subscribe",
+				"template": h.origin + "/authorize-follow?acct={uri}",
 			},
 		},
 	}
+	setDiscoveryCORS(c)
+	c.Response().Header().Set("Vary", "Accept")
 	return c.JSON(http.StatusOK, resp)
 }
 
 // HostMeta handles GET /.well-known/host-meta.
 func (h *Handler) HostMeta(c echo.Context) error {
+	setDiscoveryCORS(c)
 	xml := `<?xml version="1.0" encoding="UTF-8"?>
 <XRD xmlns="http://docs.oasis-open.org/ns/xri/xrd-1.0">
-  <Link rel="lrdd" type="application/xrd+xml" template="https://` + h.host + `/.well-known/webfinger?resource={uri}"/>
+  <Link rel="lrdd" type="application/xrd+xml" template="` + h.origin + `/.well-known/webfinger?resource={uri}"/>
 </XRD>`
 	return c.Blob(http.StatusOK, "application/xrd+xml; charset=utf-8", []byte(xml))
 }
 
 // NodeInfoDiscovery handles GET /.well-known/nodeinfo.
 func (h *Handler) NodeInfoDiscovery(c echo.Context) error {
+	setDiscoveryCORS(c)
 	resp := map[string]any{
 		"links": []map[string]any{
 			{
 				"rel":  "http://nodeinfo.diaspora.software/ns/schema/2.1",
-				"href": "https://" + h.host + "/nodeinfo/2.1",
+				"href": h.origin + "/nodeinfo/2.1",
+			},
+			{
+				"rel":  "http://nodeinfo.diaspora.software/ns/schema/2.0",
+				"href": h.origin + "/nodeinfo/2.0",
 			},
 		},
+	}
+	return c.JSON(http.StatusOK, resp)
+}
+
+// HostMetaJSON handles GET /.well-known/host-meta.json.
+// host-metaのJSON版。TS本家と同じレスポンスを返す。
+func (h *Handler) HostMetaJSON(c echo.Context) error {
+	setDiscoveryCORS(c)
+	resp := map[string]any{
+		"links": []map[string]any{
+			{
+				"rel":      "lrdd",
+				"type":     "application/jrd+json",
+				"template": h.origin + "/.well-known/webfinger?resource={uri}",
+			},
+		},
+	}
+	return c.JSON(http.StatusOK, resp)
+}
+
+// OAuthAuthorizationServer handles GET /.well-known/oauth-authorization-server.
+// RFC 8414 OAuth 2.0 Authorization Server Metadata。
+func (h *Handler) OAuthAuthorizationServer(c echo.Context) error {
+	setDiscoveryCORS(c)
+	resp := map[string]any{
+		"issuer":                                         h.origin,
+		"authorization_endpoint":                         h.origin + "/oauth/authorize",
+		"token_endpoint":                                 h.origin + "/oauth/token",
+		"scopes_supported":                               []string{"read", "write", "follow"},
+		"response_types_supported":                       []string{"code"},
+		"grant_types_supported":                          []string{"authorization_code"},
+		"service_documentation":                          "https://misskey-hub.net",
+		"code_challenge_methods_supported":               []string{"S256"},
+		"authorization_response_iss_parameter_supported": true,
 	}
 	return c.JSON(http.StatusOK, resp)
 }

--- a/internal/api/wellknown/handler_test.go
+++ b/internal/api/wellknown/handler_test.go
@@ -22,7 +22,7 @@ func newHandler(t *testing.T) (*Handler, *testutil.MockUserRepository) {
 	idGen, _ := id.NewGenerator("aidx")
 	svc := user.NewService(userRepo, testutil.NewMockNoteRepository(), testutil.NewMockUserNotePiningRepository(), idGen)
 	urls := activitypub.NewURLBuilder("https://example.com")
-	return NewHandler(urls, svc, "example.com"), userRepo
+	return NewHandler(urls, svc, "example.com", "https://example.com"), userRepo
 }
 
 func newReq(t *testing.T, target string) (echo.Context, *httptest.ResponseRecorder) {
@@ -146,5 +146,72 @@ func TestNodeInfoDiscovery(t *testing.T) {
 	c, rec := newReq(t, "/.well-known/nodeinfo")
 	require.NoError(t, h.NodeInfoDiscovery(c))
 	assert.Equal(t, http.StatusOK, rec.Code)
+
+	var resp map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+	links := resp["links"].([]any)
+	// TS本家と同じく2.1と2.0の両方を返す
+	assert.Len(t, links, 2)
 	assert.Contains(t, rec.Body.String(), "nodeinfo/2.1")
+	assert.Contains(t, rec.Body.String(), "nodeinfo/2.0")
+}
+
+func TestWebfinger_ResponseLinks(t *testing.T) {
+	h, repo := newHandler(t)
+	addUser(repo, "u1", "alice")
+
+	c, rec := newReq(t, "/.well-known/webfinger?resource=acct:alice@example.com")
+	require.NoError(t, h.Webfinger(c))
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	var resp map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+	links := resp["links"].([]any)
+	// self, profile-page, subscribe の3リンク
+	require.Len(t, links, 3)
+
+	self := links[0].(map[string]any)
+	assert.Equal(t, "self", self["rel"])
+	assert.Equal(t, "application/activity+json", self["type"])
+
+	profile := links[1].(map[string]any)
+	assert.Equal(t, "http://webfinger.net/rel/profile-page", profile["rel"])
+	assert.Equal(t, "https://example.com/@alice", profile["href"])
+
+	subscribe := links[2].(map[string]any)
+	assert.Equal(t, "http://ostatus.org/schema/1.0/subscribe", subscribe["rel"])
+	assert.Equal(t, "https://example.com/authorize-follow?acct={uri}", subscribe["template"])
+
+	// CORSヘッダー
+	assert.Equal(t, "Accept", rec.Header().Get("Vary"))
+	assert.Equal(t, "Vary", rec.Header().Get("Access-Control-Expose-Headers"))
+}
+
+func TestHostMetaJSON(t *testing.T) {
+	h, _ := newHandler(t)
+	c, rec := newReq(t, "/.well-known/host-meta.json")
+	require.NoError(t, h.HostMetaJSON(c))
+	assert.Equal(t, http.StatusOK, rec.Code)
+
+	var resp map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+	links := resp["links"].([]any)
+	require.Len(t, links, 1)
+	link := links[0].(map[string]any)
+	assert.Equal(t, "lrdd", link["rel"])
+	assert.Equal(t, "application/jrd+json", link["type"])
+	assert.Equal(t, "https://example.com/.well-known/webfinger?resource={uri}", link["template"])
+}
+
+func TestOAuthAuthorizationServer(t *testing.T) {
+	h, _ := newHandler(t)
+	c, rec := newReq(t, "/.well-known/oauth-authorization-server")
+	require.NoError(t, h.OAuthAuthorizationServer(c))
+	assert.Equal(t, http.StatusOK, rec.Code)
+
+	var resp map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+	assert.Equal(t, "https://example.com", resp["issuer"])
+	assert.Equal(t, "https://example.com/oauth/authorize", resp["authorization_endpoint"])
+	assert.Equal(t, "https://example.com/oauth/token", resp["token_endpoint"])
 }

--- a/internal/server/router.go
+++ b/internal/server/router.go
@@ -930,10 +930,12 @@ func (s *Server) setupRoutes() {
 	s.echo.GET("/@:acct", apHandler.UserByAcct)
 
 	// Discovery endpoints
-	wellknownHandler := wellknown.NewHandler(apURLs, userService, s.config.Host)
+	wellknownHandler := wellknown.NewHandler(apURLs, userService, s.config.Host, s.config.URL)
 	s.echo.GET("/.well-known/webfinger", wellknownHandler.Webfinger)
 	s.echo.GET("/.well-known/host-meta", wellknownHandler.HostMeta)
+	s.echo.GET("/.well-known/host-meta.json", wellknownHandler.HostMetaJSON)
 	s.echo.GET("/.well-known/nodeinfo", wellknownHandler.NodeInfoDiscovery)
+	s.echo.GET("/.well-known/oauth-authorization-server", wellknownHandler.OAuthAuthorizationServer)
 
 	nodeinfoHandler := nodeinfo.NewHandler(s.config)
 	s.echo.GET("/nodeinfo/2.1", nodeinfoHandler.Version2_1)

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -85,6 +85,12 @@ func New(cfg *config.Config, db *gorm.DB, redis *cache.RedisClients) *Server {
 	return s
 }
 
+// Handler returns the underlying http.Handler for use with httptest.
+// E2Eテスト等でサーバーを外部から起動する場合に使う���
+func (s *Server) Handler() http.Handler {
+	return s.echo
+}
+
 // Start begins listening on the configured port (or UNIX domain socket) and
 // launches the asynq worker.
 //

--- a/test/e2e/helpers_test.go
+++ b/test/e2e/helpers_test.go
@@ -1,0 +1,144 @@
+package e2e
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// userToken は signup で得られるユーザー情報。
+// TS版 utils.ts の signup() 戻り値に対応する。
+type userToken struct {
+	ID       string
+	Username string
+	Token    string
+}
+
+// signup は /api/admin/accounts/create を呼んでユーザーを作成する。
+// 初回呼び出しは初期セットアップ (rootUser) として扱われ認証不要。
+// 2回目以降は最初に作ったユーザー (admin) のトークンが必要。
+func signup(t *testing.T, username string, admin *userToken) *userToken {
+	t.Helper()
+	params := map[string]any{
+		"username": username,
+		"password": "test",
+	}
+	if admin != nil {
+		params["i"] = admin.Token
+	}
+	resp := apiPost(t, "admin/accounts/create", params)
+	defer resp.Body.Close()
+	require.Equal(t, http.StatusOK, resp.StatusCode,
+		"signup %s failed: status %d", username, resp.StatusCode)
+
+	var result struct {
+		ID       string `json:"id"`
+		Username string `json:"username"`
+		Token    string `json:"token"`
+	}
+	require.NoError(t, json.NewDecoder(resp.Body).Decode(&result))
+	return &userToken{
+		ID:       result.ID,
+		Username: result.Username,
+		Token:    result.Token,
+	}
+}
+
+// apiPost は POST /api/<path> を呼ぶ。TS版 api(endpoint, params, user?) に対応。
+func apiPost(t *testing.T, path string, params map[string]any) *http.Response {
+	t.Helper()
+	body, err := json.Marshal(params)
+	require.NoError(t, err)
+
+	url := baseURL + "/api/" + path
+	req, err := http.NewRequest(http.MethodPost, url, bytes.NewReader(body))
+	require.NoError(t, err)
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := http.DefaultClient.Do(req)
+	require.NoError(t, err)
+	return resp
+}
+
+// httpGet は GET リクエストを送る。TS版 relativeFetch(path) に対応。
+func httpGet(t *testing.T, path string) *http.Response {
+	t.Helper()
+	resp, err := http.Get(baseURL + "/" + path)
+	require.NoError(t, err)
+	return resp
+}
+
+// httpFetch は任意のメソッド・ヘッダーでリクエストを送る。
+// TS版 relativeFetch(path, {method, headers}) に対応。
+func httpFetch(t *testing.T, method, path string, headers map[string]string) *http.Response {
+	t.Helper()
+	req, err := http.NewRequest(method, baseURL+"/"+path, nil)
+	require.NoError(t, err)
+	for k, v := range headers {
+		req.Header.Set(k, v)
+	}
+	resp, err := http.DefaultClient.Do(req)
+	require.NoError(t, err)
+	return resp
+}
+
+// readJSON はレスポンスボディをmap[string]anyとして読み取る。
+func readJSON(t *testing.T, resp *http.Response) map[string]any {
+	t.Helper()
+	defer resp.Body.Close()
+	data, err := io.ReadAll(resp.Body)
+	require.NoError(t, err)
+	var result map[string]any
+	require.NoError(t, json.Unmarshal(data, &result), "body: %s", string(data))
+	return result
+}
+
+// resetDB は /api/reset-db を呼んでDBをリセットする。
+func resetDB(t *testing.T) {
+	t.Helper()
+	resp := apiPost(t, "reset-db", nil)
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusNoContent {
+		body, _ := io.ReadAll(resp.Body)
+		require.Failf(t, "reset-db failed", "status=%d body=%s", resp.StatusCode, string(body))
+	}
+}
+
+// requireJSON はレスポンスがOKでJSONボディを返すことを検証する。
+func requireJSON(t *testing.T, resp *http.Response) map[string]any {
+	t.Helper()
+	require.True(t, resp.StatusCode >= 200 && resp.StatusCode < 300,
+		"expected 2xx, got %d", resp.StatusCode)
+	return readJSON(t, resp)
+}
+
+// apiCall は apiPost の結果をJSONで返す便利ヘルパー。
+func apiCall(t *testing.T, path string, params map[string]any) map[string]any {
+	t.Helper()
+	resp := apiPost(t, path, params)
+	return requireJSON(t, resp)
+}
+
+// jsonString はJSONのstring値を取得する。
+func jsonString(m map[string]any, key string) string {
+	v, ok := m[key]
+	if !ok {
+		return ""
+	}
+	s, _ := v.(string)
+	return s
+}
+
+// debugBody はレスポンスボディをデバッグ用に文字列として読む。
+func debugBody(resp *http.Response) string {
+	data, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return fmt.Sprintf("<read error: %v>", err)
+	}
+	return string(data)
+}

--- a/test/e2e/main_test.go
+++ b/test/e2e/main_test.go
@@ -1,0 +1,110 @@
+// Package e2e runs end-to-end tests against a real mk-go server.
+//
+// TestMain boots PostgreSQL + Redis via testcontainers, applies
+// migrations, starts the full Echo server via server.New(), and
+// exposes the base URL as a package-level variable for sub-tests.
+package e2e
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"testing"
+
+	goredis "github.com/redis/go-redis/v9"
+	"github.com/shiroha-a/mk/internal/config"
+	"github.com/shiroha-a/mk/internal/core/cache"
+	"github.com/shiroha-a/mk/internal/server"
+	"github.com/shiroha-a/mk/internal/testutil"
+)
+
+// テスト全体で共有するサーバーとベースURL
+var (
+	ts      *httptest.Server
+	baseURL string // "http://127.0.0.1:<port>"
+	origin  string // テスト用origin (baseURLと同じ)
+	host    string // "127.0.0.1:<port>"
+)
+
+func TestMain(m *testing.M) {
+	ctx := context.Background()
+
+	// PostgreSQL コンテナ起動 + マイグレーション
+	testDB, err := testutil.SetupPostgres(ctx)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "e2e: postgres setup failed: %v\n", err)
+		os.Exit(1)
+	}
+	defer testDB.Teardown(ctx)
+
+	// Redis コンテナ起動
+	testRedis, err := testutil.SetupRedis(ctx)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "e2e: redis setup failed: %v\n", err)
+		os.Exit(1)
+	}
+	defer testRedis.Teardown(ctx)
+
+	// ポートを事前確保して config に正しいURLを入れる。
+	// server.New() がハンドラにURLを渡すので、事後変更では間に合わない。
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "e2e: failed to allocate port: %v\n", err)
+		os.Exit(1)
+	}
+	addr := ln.Addr().String()
+	host = addr
+	baseURL = "http://" + addr
+	origin = baseURL
+
+	redisOpts := config.RedisOptions{
+		Host: testRedis.Host(),
+		Port: testRedis.Port(),
+	}
+	cfg := &config.Config{
+		URL:               baseURL,
+		Port:              ln.Addr().(*net.TCPAddr).Port,
+		Host:              host,
+		Hostname:          "127.0.0.1",
+		Scheme:            "http",
+		WsScheme:          "ws",
+		Version:           "2026.3.2",
+		TestMode:          true,
+		ID:                "aidx",
+		Redis:             redisOpts,
+		RedisForPubsub:    redisOpts,
+		RedisForJobQueue:  redisOpts,
+		RedisForTimelines: redisOpts,
+		RedisForReactions: redisOpts,
+	}
+
+	// cache.RedisClients を手動構築 (全チャネル同一Redis)
+	redisClient := goredis.NewClient(&goredis.Options{
+		Addr: fmt.Sprintf("%s:%d", testRedis.Host(), testRedis.Port()),
+	})
+	defer redisClient.Close()
+
+	redisClients := &cache.RedisClients{
+		Default:   redisClient,
+		Pubsub:    redisClient,
+		JobQueue:  redisClient,
+		Timelines: redisClient,
+		Reactions: redisClient,
+	}
+
+	// server.New でEchoサーバー構築
+	srv := server.New(cfg, testDB.DB, redisClients)
+
+	// 事前確保したlistenerでhttptestサーバー起動
+	ts = &httptest.Server{
+		Listener: ln,
+		Config:   &http.Server{Handler: srv.Handler()},
+	}
+	ts.Start()
+	defer ts.Close()
+
+	os.Exit(m.Run())
+}

--- a/test/e2e/well_known_test.go
+++ b/test/e2e/well_known_test.go
@@ -1,0 +1,120 @@
+// well_known_test.go ports packages/backend/test/e2e/well-known.ts
+package e2e
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestWellKnown(t *testing.T) {
+	// TS版 beforeAll: signup alice + admin/update-meta federation=all
+	resetDB(t)
+	alice := signup(t, "alice", nil) // 初回=admin
+	resp := apiPost(t, "admin/update-meta", map[string]any{
+		"i":          alice.Token,
+		"federation": "all",
+	})
+	resp.Body.Close()
+	require.True(t, resp.StatusCode >= 200 && resp.StatusCode < 300,
+		"admin/update-meta failed: %d", resp.StatusCode)
+
+	t.Run("nodeinfo", func(t *testing.T) {
+		resp := httpGet(t, ".well-known/nodeinfo")
+		defer resp.Body.Close()
+		assert.True(t, resp.StatusCode >= 200 && resp.StatusCode < 300)
+		assert.Equal(t, "*", resp.Header.Get("Access-Control-Allow-Origin"))
+
+		body := readJSON(t, resp)
+		links, ok := body["links"].([]any)
+		require.True(t, ok, "links should be an array")
+		require.Len(t, links, 2)
+
+		link0 := links[0].(map[string]any)
+		assert.Equal(t, "http://nodeinfo.diaspora.software/ns/schema/2.1", link0["rel"])
+		assert.Equal(t, origin+"/nodeinfo/2.1", link0["href"])
+
+		link1 := links[1].(map[string]any)
+		assert.Equal(t, "http://nodeinfo.diaspora.software/ns/schema/2.0", link1["rel"])
+		assert.Equal(t, origin+"/nodeinfo/2.0", link1["href"])
+	})
+
+	t.Run("webfinger", func(t *testing.T) {
+		// OPTIONS preflight
+		preflight := httpFetch(t, "OPTIONS",
+			".well-known/webfinger?resource=acct:alice@"+host,
+			map[string]string{
+				"Access-Control-Request-Method": "GET",
+				"Origin":                        "http://example.com",
+			})
+		defer preflight.Body.Close()
+		assert.True(t, preflight.StatusCode >= 200 && preflight.StatusCode < 300)
+		assert.Contains(t, preflight.Header.Get("Access-Control-Allow-Headers"), "Accept")
+
+		// GET
+		resp := httpGet(t, ".well-known/webfinger?resource=acct:alice@"+host)
+		defer resp.Body.Close()
+		assert.True(t, resp.StatusCode >= 200 && resp.StatusCode < 300)
+		assert.Equal(t, "*", resp.Header.Get("Access-Control-Allow-Origin"))
+		assert.Equal(t, "Vary", resp.Header.Get("Access-Control-Expose-Headers"))
+		assert.Equal(t, "Accept", resp.Header.Get("Vary"))
+
+		body := readJSON(t, resp)
+		assert.Equal(t, "acct:alice@"+host, body["subject"])
+
+		links, ok := body["links"].([]any)
+		require.True(t, ok)
+		require.Len(t, links, 3)
+
+		self := links[0].(map[string]any)
+		assert.Equal(t, "self", self["rel"])
+		assert.Equal(t, "application/activity+json", self["type"])
+		assert.Equal(t, origin+"/users/"+alice.ID, self["href"])
+
+		profile := links[1].(map[string]any)
+		assert.Equal(t, "http://webfinger.net/rel/profile-page", profile["rel"])
+		assert.Equal(t, "text/html", profile["type"])
+		assert.Equal(t, origin+"/@alice", profile["href"])
+
+		subscribe := links[2].(map[string]any)
+		assert.Equal(t, "http://ostatus.org/schema/1.0/subscribe", subscribe["rel"])
+		assert.Equal(t, origin+"/authorize-follow?acct={uri}", subscribe["template"])
+	})
+
+	t.Run("host-meta", func(t *testing.T) {
+		resp := httpGet(t, ".well-known/host-meta")
+		defer resp.Body.Close()
+		assert.True(t, resp.StatusCode >= 200 && resp.StatusCode < 300)
+		assert.Equal(t, "*", resp.Header.Get("Access-Control-Allow-Origin"))
+	})
+
+	t.Run("host-meta.json", func(t *testing.T) {
+		resp := httpGet(t, ".well-known/host-meta.json")
+		defer resp.Body.Close()
+		assert.True(t, resp.StatusCode >= 200 && resp.StatusCode < 300)
+		assert.Equal(t, "*", resp.Header.Get("Access-Control-Allow-Origin"))
+
+		body := readJSON(t, resp)
+		links, ok := body["links"].([]any)
+		require.True(t, ok)
+		require.Len(t, links, 1)
+
+		link := links[0].(map[string]any)
+		assert.Equal(t, "lrdd", link["rel"])
+		assert.Equal(t, "application/jrd+json", link["type"])
+		assert.Equal(t, origin+"/.well-known/webfinger?resource={uri}", link["template"])
+	})
+
+	t.Run("oauth-authorization-server", func(t *testing.T) {
+		resp := httpGet(t, ".well-known/oauth-authorization-server")
+		defer resp.Body.Close()
+		assert.True(t, resp.StatusCode >= 200 && resp.StatusCode < 300)
+		assert.Equal(t, "*", resp.Header.Get("Access-Control-Allow-Origin"))
+
+		body := readJSON(t, resp)
+		assert.Equal(t, origin, body["issuer"])
+		assert.Equal(t, origin+"/oauth/authorize", body["authorization_endpoint"])
+		assert.Equal(t, origin+"/oauth/token", body["token_endpoint"])
+	})
+}


### PR DESCRIPTION
## Summary
- E2Eテスト基盤を `test/e2e/` に新設。testcontainers (PostgreSQL + Redis) → `server.New()` → `httptest` で実サーバーを起動し、TS版 `utils.ts` 相当のGoヘルパー群を提供
- Misskey TS backend E2E `well-known.ts` の5テストをGoに移植し全PASS
- well-knownハンドラをTS本家と互換に修正 (NodeInfo 2.0リンク追加、Webfinger subscribeリンク+`/@username`形式、host-meta.json/OAuth discoveryエンドポイント新設、CORS)

## 主な変更点
| ファイル | 変更 |
|---------|------|
| `test/e2e/main_test.go` | 新規: TestMain (testcontainers + server.New + httptest) |
| `test/e2e/helpers_test.go` | 新規: apiPost, signup, httpGet, httpFetch, readJSON, resetDB |
| `test/e2e/well_known_test.go` | 新規: nodeinfo, webfinger, host-meta, host-meta.json, oauth-authorization-server |
| `internal/api/wellknown/handler.go` | NodeInfo 2.0追加、Webfinger修正、HostMetaJSON/OAuthAuthorizationServer新規、setDiscoveryCORS |
| `internal/api/wellknown/handler_test.go` | 新エンドポイントのユニットテスト追加 |
| `internal/server/server.go` | `Handler() http.Handler` メソッド追加 |
| `internal/server/router.go` | 新ルート2件追加、NewHandler引数にorigin追加 |

## テスト
```
go test -v -race -count=1 ./internal/api/wellknown/...  # 17 PASS
go test -v -race -count=1 ./test/e2e/...                # 5 PASS (testcontainers)
go build ./...                                           # OK
go vet ./...                                             # OK
gofmt -s -d .                                            # no diff
```

Closes #98

🤖 Generated with [Claude Code](https://claude.com/claude-code)