### PR TITLE
chore: switch misskey submodule to shiroha-a/misskey-ts

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "third_party/misskey"]
 	path = third_party/misskey
-	url = https://github.com/misskey-dev/misskey.git
+	url = https://github.com/shiroha-a/misskey-ts.git

--- a/Makefile
+++ b/Makefile
@@ -92,18 +92,10 @@ E2E_WORKDIR=/work
 e2e-submodule-init:
 	git submodule update --init --recursive third_party/misskey
 
-# 本家フロントエンドの既知バグにパッチを当てる (ビルド前に実行)。
-# 本家リポジトリには直接コミットしない — mk-go 側でのみ適用する。
-e2e-patch-frontend:
-	@echo "Applying MkModal null guard patch..."
-	@cd third_party/misskey && \
-		sed -i '/const el = content\.value\.children\[0\];/{ n; /if (el == null) return;/!s/^/\t\tif (el == null) return;\n/ }' \
-		packages/frontend/src/components/MkModal.vue
-	@echo "Patch applied."
-
 # 本家フロントエンドを Docker 内でビルドする。数分〜10 分程度かかる。
 # 成果物は third_party/misskey/packages/frontend/... 配下に出力される。
-e2e-frontend-build: e2e-patch-frontend
+# パッチは submodule (shiroha-a/misskey-ts 2026.3.2-fix) に直接コミット済み。
+e2e-frontend-build:
 	docker run --rm -v $(PWD):$(E2E_WORKDIR) -w $(E2E_WORKDIR)/third_party/misskey \
 		$(E2E_NODE_IMAGE) \
 		bash -lc "corepack enable && corepack prepare pnpm@latest --activate && pnpm install --frozen-lockfile && pnpm build"


### PR DESCRIPTION
## Summary

submodule `third_party/misskey` のリモートURLを `misskey-dev/misskey` → `shiroha-a/misskey-ts` (フォーク) に変更。

フォークを使うことで、MkModal.vue パッチ等のフロントエンド修正を直接コミットでき、Makefile のパッチ自動適用が不要になる。

コミットは同じ `b97683cdb2` (Release 2026.3.2)。