### PR TITLE
CI: set e2e package coverage threshold to 0%

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -84,7 +84,7 @@ jobs:
             pkg = $2
             match($0, /[0-9.]+%/)
             cov = substr($0, RSTART, RLENGTH-1) + 0
-            threshold = (pkg ~ /\/admin$/) ? 60 : 90
+            threshold = (pkg ~ /\/admin$/) ? 60 : (pkg ~ /\/e2e$/) ? 0 : 90
             if (cov < threshold) {
               printf "FAIL: %s coverage %.1f%% is below %d%%\n", pkg, cov, threshold
               fail = 1


### PR DESCRIPTION
test/e2e パッケージは Cypress E2E テスト用のヘルパーコードで、go test では実行されないためカバレッジが常に 0%。閾値を 0% に設定して CI をブロックしないようにする。

PR #100 のCI失敗を解消するため、先にマージが必要。