### PR TITLE
CI: extend e2e coverage exemption to e2e_federation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -84,7 +84,7 @@ jobs:
             pkg = $2
             match($0, /[0-9.]+%/)
             cov = substr($0, RSTART, RLENGTH-1) + 0
-            threshold = (pkg ~ /\/admin$/) ? 60 : (pkg ~ /\/e2e$/) ? 0 : 90
+            threshold = (pkg ~ /\/admin$/) ? 60 : (pkg ~ /\/e2e/) ? 0 : 90
             if (cov < threshold) {
               printf "FAIL: %s coverage %.1f%% is below %d%%\n", pkg, cov, threshold
               fail = 1


### PR DESCRIPTION
パターンを `/e2e$` → `/e2e/` に変更し、`test/e2e_federation` も閾値0%に。PR #104 のCI対応。