### PR TITLE
chore: centralize version constants + nodeinfo/UA format

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,14 @@ BUILD_DIR=./built
 
 # Go parameters
 GOFLAGS=-trimpath
-LDFLAGS=-s -w
+
+# バージョン情報: submodule の package.json があれば Misskey バージョンを自動取得
+MKGO_VERSION ?= 0.0.1
+MISSKEY_PKG_JSON = third_party/misskey/package.json
+MISSKEY_VERSION ?= $(shell [ -f $(MISSKEY_PKG_JSON) ] && grep -o '"version": *"[^"]*"' $(MISSKEY_PKG_JSON) | head -1 | grep -o '"[^"]*"$$' | tr -d '"' || echo "2026.3.2")
+LDFLAGS=-s -w \
+	-X github.com/shiroha-a/mk/internal/config.MkGoVersion=$(MKGO_VERSION) \
+	-X github.com/shiroha-a/mk/internal/config.MisskeyVersion=$(MISSKEY_VERSION)
 
 build:
 	go build $(GOFLAGS) -ldflags "$(LDFLAGS)" -o $(BUILD_DIR)/$(BINARY) ./cmd/misskey

--- a/internal/api/nodeinfo/handler.go
+++ b/internal/api/nodeinfo/handler.go
@@ -18,13 +18,18 @@ func NewHandler(cfg *config.Config) *Handler {
 	return &Handler{cfg: cfg}
 }
 
+// nodeinfoVersion builds the version string for NodeInfo.
+func nodeinfoVersion(mkgoVersion, misskeyVersion string) string {
+	return mkgoVersion + " (compatible: misskey " + misskeyVersion + ")"
+}
+
 // Version2_1 handles GET /nodeinfo/2.1.
 func (h *Handler) Version2_1(c echo.Context) error {
 	resp := map[string]any{
 		"version": "2.1",
 		"software": map[string]any{
 			"name":       "misskey-go",
-			"version":    h.cfg.Version,
+			"version":    nodeinfoVersion(config.MkGoVersion, h.cfg.Version),
 			"repository": "https://github.com/shiroha-a/mk",
 		},
 		"protocols": []string{"activitypub"},

--- a/internal/api/nodeinfo/handler_test.go
+++ b/internal/api/nodeinfo/handler_test.go
@@ -27,4 +27,9 @@ func TestVersion2_1(t *testing.T) {
 	assert.Equal(t, "2.1", resp["version"])
 	sw := resp["software"].(map[string]any)
 	assert.Equal(t, "misskey-go", sw["name"])
+	assert.Contains(t, sw["version"], "compatible: misskey 0.0.0")
+}
+
+func TestNodeinfoVersion(t *testing.T) {
+	assert.Equal(t, "0.0.1 (compatible: misskey 2026.3.2)", nodeinfoVersion("0.0.1", "2026.3.2"))
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -10,6 +10,16 @@ import (
 	"github.com/spf13/viper"
 )
 
+// MkGoVersion is the misskey-go version. Override at build time via:
+//
+//	go build -ldflags "-X github.com/shiroha-a/mk/internal/config.MkGoVersion=1.0.0"
+var MkGoVersion = "0.0.1"
+
+// MisskeyVersion is the compatible Misskey version. Override at build time via:
+//
+//	go build -ldflags "-X github.com/shiroha-a/mk/internal/config.MisskeyVersion=2026.3.2"
+var MisskeyVersion = "2026.3.2"
+
 // RedisOptions represents Redis connection configuration.
 type RedisOptions struct {
 	Host     string `mapstructure:"host"`
@@ -283,7 +293,7 @@ func resolve(src *Source) (*Config, error) {
 	mediaProxySecret := deriveMediaProxySecret(src)
 
 	cfg := &Config{
-		Version:     "2026.3.2", // Misskeyバージョンと合わせる
+		Version:     MisskeyVersion,
 		URL:         parsedURL.Scheme + "://" + parsedURL.Host,
 		Port:        src.Port,
 		Socket:      src.Socket,
@@ -338,7 +348,7 @@ func resolve(src *Source) (*Config, error) {
 		ExternalMediaProxyEnabled:    externalMediaProxyEnabled,
 		MediaProxySecret:             mediaProxySecret,
 		VideoThumbnailGenerator:      strings.TrimRight(src.VideoThumbnailGenerator, "/"),
-		UserAgent:                    fmt.Sprintf("Misskey/%s (%s)", "2026.3.2", src.URL),
+		UserAgent:                    fmt.Sprintf("Misskey-Go/%s (%s)", MkGoVersion, src.URL),
 		PerChannelMaxNoteCacheCount:  perChannelMaxNoteCacheCount,
 		PerUserNotificationsMaxCount: perUserNotificationsMaxCount,
 		DeactivateAntennaThreshold:   deactivateAntennaThreshold,

--- a/internal/server/router.go
+++ b/internal/server/router.go
@@ -325,7 +325,7 @@ func (s *Server) setupRoutes() {
 	apRenderer := activitypub.NewRenderer(apURLs)
 	// Mention tag を AP Note に埋め込むための resolver。
 	apRenderer.SetMentionResolver(corefederation.NewUserMentionResolver(userRepo, apURLs))
-	apClient := activitypub.NewClient(nil, "misskey-go/"+s.config.Version)
+	apClient := activitypub.NewClient(nil, s.config.UserAgent)
 	// meta.allowExternalApRedirect が false なら AP fetch でのリダイレクトを拒否する。
 	if m, err := metaRepo.Fetch(); err == nil && !m.AllowExternalApRedirect {
 		apClient.DisableRedirect()


### PR DESCRIPTION
## Summary

バージョン管理を一元化し、NodeInfo と User-Agent のフォーマットを変更。

## 変更内容

### バージョン定数 (`internal/config/config.go`)
- `config.MkGoVersion = "0.0.1"` — misskey-go 自体のバージョン
- `config.MisskeyVersion = "2026.3.2"` — 互換 Misskey バージョン
- 両方とも `-ldflags` でビルド時に上書き可能:
  ```bash
  go build -ldflags "-X github.com/shiroha-a/mk/internal/config.MkGoVersion=1.0.0 \
    -X github.com/shiroha-a/mk/internal/config.MisskeyVersion=2026.3.2" ...
  ```
- submodule がある場合は Makefile で `package.json` から自動取得も可能

### NodeInfo (`/nodeinfo/2.1`)
- `software.name`: `misskey-go` (変更なし)
- `software.version`: `0.0.1 (compatible: misskey 2026.3.2)`

### User-Agent
- AP配送 + media proxy: `Misskey-Go/0.0.1 (https://your-instance.example.com)`

### ハードコード除去
- `config.go` から `"2026.3.2"` のハードコード3箇所を `MisskeyVersion` / `MkGoVersion` 変数参照に置換