### PR TITLE
Phase AP: ActivityPubレンダリング完全化 (MFM→HTML, attachment, context)

### DIFF
--- a/internal/activitypub/mfm/html.go
+++ b/internal/activitypub/mfm/html.go
@@ -106,6 +106,11 @@ func renderNode(b *strings.Builder, n *Node, host string) {
 			html.EscapeString(u), html.EscapeString(u)))
 	case NodeLink:
 		u, _ := n.Props["url"].(string)
+		// XSS防止: http/https以外のスキーム (javascript: 等) はリンク化しない
+		if !strings.HasPrefix(u, "http://") && !strings.HasPrefix(u, "https://") {
+			renderChildren(b, n.Children, host)
+			break
+		}
 		b.WriteString(fmt.Sprintf(`<a href="%s">`, html.EscapeString(u)))
 		renderChildren(b, n.Children, host)
 		b.WriteString("</a>")

--- a/internal/activitypub/mfm/html.go
+++ b/internal/activitypub/mfm/html.go
@@ -1,0 +1,204 @@
+package mfm
+
+import (
+	"fmt"
+	"html"
+	"net/url"
+	"strconv"
+	"strings"
+	"time"
+)
+
+// ToHTML converts MFM nodes to an HTML string.
+// host はローカルホスト名 (例: "example.com")。
+// メンションやハッシュタグのリンク先URLの生成に使う。
+func ToHTML(nodes []*Node, host string) string {
+	if len(nodes) == 0 {
+		return ""
+	}
+	var b strings.Builder
+	for _, n := range nodes {
+		renderNode(&b, n, host)
+	}
+	return b.String()
+}
+
+// IsSimple reports whether the AST contains only "standard" node types
+// that don't require _misskey_content / source fields.
+// TS版の noMisskeyContent ロジックに対応: text, unicodeEmoji, emojiCode,
+// mention, hashtag, url のみの場合に true を返す。
+func IsSimple(nodes []*Node) bool {
+	for _, n := range nodes {
+		if !isSimpleNode(n) {
+			return false
+		}
+	}
+	return true
+}
+
+func isSimpleNode(n *Node) bool {
+	switch n.Type {
+	case NodeText, NodeUnicodeEmoji, NodeEmojiCode, NodeMention, NodeHashtag, NodeURL:
+		return true
+	default:
+		return false
+	}
+}
+
+func renderNode(b *strings.Builder, n *Node, host string) {
+	switch n.Type {
+	case NodeText:
+		renderText(b, n.textValue())
+	case NodeBold:
+		b.WriteString("<b>")
+		renderChildren(b, n.Children, host)
+		b.WriteString("</b>")
+	case NodeItalic:
+		b.WriteString("<i>")
+		renderChildren(b, n.Children, host)
+		b.WriteString("</i>")
+	case NodeStrike:
+		b.WriteString("<del>")
+		renderChildren(b, n.Children, host)
+		b.WriteString("</del>")
+	case NodeSmall:
+		b.WriteString("<small>")
+		renderChildren(b, n.Children, host)
+		b.WriteString("</small>")
+	case NodeCenter:
+		b.WriteString(`<div style="text-align:center">`)
+		renderChildren(b, n.Children, host)
+		b.WriteString("</div>")
+	case NodePlain:
+		renderChildren(b, n.Children, host)
+	case NodeInlineCode:
+		code, _ := n.Props["code"].(string)
+		b.WriteString("<code>")
+		b.WriteString(html.EscapeString(code))
+		b.WriteString("</code>")
+	case NodeBlockCode:
+		code, _ := n.Props["code"].(string)
+		b.WriteString("<pre><code>")
+		b.WriteString(html.EscapeString(code))
+		b.WriteString("</code></pre>")
+	case NodeMathInline:
+		formula, _ := n.Props["formula"].(string)
+		b.WriteString("<code>")
+		b.WriteString(html.EscapeString(formula))
+		b.WriteString("</code>")
+	case NodeMathBlock:
+		formula, _ := n.Props["formula"].(string)
+		b.WriteString("<code>")
+		b.WriteString(html.EscapeString(formula))
+		b.WriteString("</code>")
+	case NodeQuote:
+		b.WriteString("<blockquote>")
+		renderChildren(b, n.Children, host)
+		b.WriteString("</blockquote>")
+	case NodeSearch:
+		query, _ := n.Props["query"].(string)
+		escaped := url.QueryEscape(query)
+		b.WriteString(fmt.Sprintf(`<a href="https://www.google.com/search?q=%s">%s</a>`,
+			escaped, html.EscapeString(query)))
+	case NodeURL:
+		u, _ := n.Props["url"].(string)
+		b.WriteString(fmt.Sprintf(`<a href="%s">%s</a>`,
+			html.EscapeString(u), html.EscapeString(u)))
+	case NodeLink:
+		u, _ := n.Props["url"].(string)
+		b.WriteString(fmt.Sprintf(`<a href="%s">`, html.EscapeString(u)))
+		renderChildren(b, n.Children, host)
+		b.WriteString("</a>")
+	case NodeMention:
+		username, _ := n.Props["username"].(string)
+		mentionHost, _ := n.Props["host"].(string)
+		acct, _ := n.Props["acct"].(string)
+
+		var href string
+		if mentionHost == "" {
+			href = fmt.Sprintf("https://%s/@%s", host, username)
+		} else {
+			href = fmt.Sprintf("https://%s/@%s", mentionHost, username)
+		}
+		b.WriteString(fmt.Sprintf(`<a href="%s" class="u-url mention">%s</a>`,
+			html.EscapeString(href), html.EscapeString(acct)))
+	case NodeHashtag:
+		tag, _ := n.Props["hashtag"].(string)
+		b.WriteString(fmt.Sprintf(`<a href="https://%s/tags/%s" rel="tag">#%s</a>`,
+			host, html.EscapeString(url.PathEscape(tag)), html.EscapeString(tag)))
+	case NodeUnicodeEmoji:
+		emoji, _ := n.Props["emoji"].(string)
+		b.WriteString(emoji)
+	case NodeEmojiCode:
+		name, _ := n.Props["name"].(string)
+		// ZWSP + :name: + ZWSP (TS版と同じ)
+		b.WriteString("\u200b:")
+		b.WriteString(html.EscapeString(name))
+		b.WriteString(":\u200b")
+	case NodeFn:
+		renderFn(b, n, host)
+	}
+}
+
+func renderFn(b *strings.Builder, n *Node, host string) {
+	name, _ := n.Props["name"].(string)
+	args, _ := n.Props["args"].(map[string]any)
+
+	switch name {
+	case "unixtime":
+		// $[unixtime 1234567890] → <time>
+		if len(n.Children) > 0 && n.Children[0].Type == NodeText {
+			text := n.Children[0].textValue()
+			if ts, err := strconv.ParseInt(strings.TrimSpace(text), 10, 64); err == nil {
+				t := time.Unix(ts, 0).UTC()
+				iso := t.Format(time.RFC3339)
+				b.WriteString(fmt.Sprintf(`<time datetime="%s">%s</time>`, iso, iso))
+				return
+			}
+		}
+		// フォールバック
+		b.WriteString("<i>")
+		renderChildren(b, n.Children, host)
+		b.WriteString("</i>")
+	case "ruby":
+		// $[ruby.rt=text base] → <ruby>
+		rt := ""
+		if args != nil {
+			if v, ok := args["rt"].(string); ok {
+				rt = v
+			}
+		}
+		if rt != "" {
+			b.WriteString("<ruby>")
+			renderChildren(b, n.Children, host)
+			b.WriteString("<rp>(</rp><rt>")
+			b.WriteString(html.EscapeString(rt))
+			b.WriteString("</rt><rp>)</rp></ruby>")
+		} else {
+			b.WriteString("<i>")
+			renderChildren(b, n.Children, host)
+			b.WriteString("</i>")
+		}
+	default:
+		// 不明な fn は italic でフォールバック
+		b.WriteString("<i>")
+		renderChildren(b, n.Children, host)
+		b.WriteString("</i>")
+	}
+}
+
+func renderText(b *strings.Builder, text string) {
+	lines := strings.Split(text, "\n")
+	for i, line := range lines {
+		b.WriteString(html.EscapeString(line))
+		if i < len(lines)-1 {
+			b.WriteString("<br>")
+		}
+	}
+}
+
+func renderChildren(b *strings.Builder, children []*Node, host string) {
+	for _, c := range children {
+		renderNode(b, c, host)
+	}
+}

--- a/internal/activitypub/mfm/html_test.go
+++ b/internal/activitypub/mfm/html_test.go
@@ -204,6 +204,31 @@ func TestToHTML_Fn_Ruby_NoArgs(t *testing.T) {
 	assert.Equal(t, "<i>base</i>", result)
 }
 
+func TestToHTML_Link_JavascriptXSS(t *testing.T) {
+	// javascript: スキームはリンク化せずテキストのみ出力
+	nodes := []*Node{{
+		Type:     NodeLink,
+		Props:    map[string]any{"url": "javascript:alert(1)"},
+		Children: []*Node{Text("click me")},
+	}}
+	result := ToHTML(nodes, testHost)
+	assert.NotContains(t, result, "javascript:")
+	assert.NotContains(t, result, "<a")
+	assert.Contains(t, result, "click me")
+}
+
+func TestToHTML_Link_DataScheme(t *testing.T) {
+	// data: スキームもリンク化しない
+	nodes := []*Node{{
+		Type:     NodeLink,
+		Props:    map[string]any{"url": "data:text/html,<script>alert(1)</script>"},
+		Children: []*Node{Text("label")},
+	}}
+	result := ToHTML(nodes, testHost)
+	assert.NotContains(t, result, "<a")
+	assert.Contains(t, result, "label")
+}
+
 func TestToHTML_Fn_Unixtime_Invalid(t *testing.T) {
 	// non-numeric → italic fallback
 	nodes := []*Node{{

--- a/internal/activitypub/mfm/html_test.go
+++ b/internal/activitypub/mfm/html_test.go
@@ -1,0 +1,216 @@
+package mfm
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+const testHost = "example.com"
+
+func TestToHTML_EmptyInput(t *testing.T) {
+	assert.Equal(t, "", ToHTML(nil, testHost))
+}
+
+func TestToHTML_PlainText(t *testing.T) {
+	nodes := Parse("hello world")
+	assert.Equal(t, "hello world", ToHTML(nodes, testHost))
+}
+
+func TestToHTML_TextWithNewline(t *testing.T) {
+	nodes := Parse("hello\nworld")
+	assert.Equal(t, "hello<br>world", ToHTML(nodes, testHost))
+}
+
+func TestToHTML_HTMLEscape(t *testing.T) {
+	nodes := []*Node{Text("<script>alert(1)</script>")}
+	assert.Equal(t, "&lt;script&gt;alert(1)&lt;/script&gt;", ToHTML(nodes, testHost))
+}
+
+func TestToHTML_Bold(t *testing.T) {
+	nodes := Parse("**bold**")
+	assert.Equal(t, "<b>bold</b>", ToHTML(nodes, testHost))
+}
+
+func TestToHTML_Italic(t *testing.T) {
+	nodes := Parse("<i>italic</i>")
+	assert.Equal(t, "<i>italic</i>", ToHTML(nodes, testHost))
+}
+
+func TestToHTML_Strike(t *testing.T) {
+	nodes := Parse("~~strike~~")
+	assert.Equal(t, "<del>strike</del>", ToHTML(nodes, testHost))
+}
+
+func TestToHTML_Small(t *testing.T) {
+	nodes := Parse("<small>small</small>")
+	assert.Equal(t, "<small>small</small>", ToHTML(nodes, testHost))
+}
+
+func TestToHTML_Center(t *testing.T) {
+	nodes := Parse("<center>centered</center>")
+	assert.Equal(t, `<div style="text-align:center">centered</div>`, ToHTML(nodes, testHost))
+}
+
+func TestToHTML_InlineCode(t *testing.T) {
+	nodes := Parse("`code`")
+	assert.Equal(t, "<code>code</code>", ToHTML(nodes, testHost))
+}
+
+func TestToHTML_InlineCode_Escapes(t *testing.T) {
+	nodes := []*Node{{Type: NodeInlineCode, Props: map[string]any{"code": "<b>x</b>"}}}
+	assert.Equal(t, "<code>&lt;b&gt;x&lt;/b&gt;</code>", ToHTML(nodes, testHost))
+}
+
+func TestToHTML_BlockCode(t *testing.T) {
+	nodes := Parse("```\nhello\n```")
+	assert.Equal(t, "<pre><code>hello</code></pre>", ToHTML(nodes, testHost))
+}
+
+func TestToHTML_MathInline(t *testing.T) {
+	nodes := Parse(`\(x^2\)`)
+	assert.Equal(t, "<code>x^2</code>", ToHTML(nodes, testHost))
+}
+
+func TestToHTML_MathBlock(t *testing.T) {
+	nodes := Parse(`\[E=mc^2\]`)
+	assert.Equal(t, "<code>E=mc^2</code>", ToHTML(nodes, testHost))
+}
+
+func TestToHTML_Quote(t *testing.T) {
+	nodes := Parse("> quoted")
+	assert.Equal(t, "<blockquote>quoted</blockquote>", ToHTML(nodes, testHost))
+}
+
+func TestToHTML_Search(t *testing.T) {
+	nodes := Parse("hello search")
+	assert.Contains(t, ToHTML(nodes, testHost), `href="https://www.google.com/search?q=hello"`)
+	assert.Contains(t, ToHTML(nodes, testHost), "hello</a>")
+}
+
+func TestToHTML_URL(t *testing.T) {
+	nodes := Parse("https://example.com/path")
+	result := ToHTML(nodes, testHost)
+	assert.Contains(t, result, `href="https://example.com/path"`)
+}
+
+func TestToHTML_Link(t *testing.T) {
+	nodes := Parse("[label](https://example.com)")
+	result := ToHTML(nodes, testHost)
+	assert.Contains(t, result, `href="https://example.com"`)
+	assert.Contains(t, result, "label</a>")
+}
+
+func TestToHTML_Mention_Local(t *testing.T) {
+	nodes := Parse("@alice")
+	result := ToHTML(nodes, testHost)
+	assert.Contains(t, result, `href="https://example.com/@alice"`)
+	assert.Contains(t, result, `class="u-url mention"`)
+	assert.Contains(t, result, "@alice</a>")
+}
+
+func TestToHTML_Mention_Remote(t *testing.T) {
+	nodes := Parse("@bob@remote.example")
+	result := ToHTML(nodes, testHost)
+	assert.Contains(t, result, `href="https://remote.example/@bob"`)
+	assert.Contains(t, result, "@bob@remote.example</a>")
+}
+
+func TestToHTML_Hashtag(t *testing.T) {
+	nodes := Parse("#hello")
+	result := ToHTML(nodes, testHost)
+	assert.Contains(t, result, `href="https://example.com/tags/hello"`)
+	assert.Contains(t, result, `rel="tag"`)
+	assert.Contains(t, result, "#hello</a>")
+}
+
+func TestToHTML_UnicodeEmoji(t *testing.T) {
+	nodes := []*Node{withProp(NodeUnicodeEmoji, "emoji", "😀")}
+	assert.Equal(t, "😀", ToHTML(nodes, testHost))
+}
+
+func TestToHTML_EmojiCode(t *testing.T) {
+	nodes := Parse(":thinking:")
+	result := ToHTML(nodes, testHost)
+	assert.Equal(t, "\u200b:thinking:\u200b", result)
+}
+
+func TestToHTML_Plain(t *testing.T) {
+	nodes := Parse("<plain>**not bold**</plain>")
+	result := ToHTML(nodes, testHost)
+	assert.Equal(t, "**not bold**", result)
+}
+
+func TestToHTML_Fn_Unixtime(t *testing.T) {
+	nodes := Parse("$[unixtime 0]")
+	result := ToHTML(nodes, testHost)
+	assert.Contains(t, result, "<time")
+	assert.Contains(t, result, "1970-01-01T00:00:00Z")
+}
+
+func TestToHTML_Fn_Ruby(t *testing.T) {
+	nodes := Parse("$[ruby.rt=ruby base]")
+	result := ToHTML(nodes, testHost)
+	assert.Contains(t, result, "<ruby>")
+	assert.Contains(t, result, "<rt>ruby</rt>")
+	assert.Contains(t, result, "base")
+}
+
+func TestToHTML_Fn_Unknown(t *testing.T) {
+	nodes := Parse("$[sparkle content]")
+	result := ToHTML(nodes, testHost)
+	assert.Equal(t, "<i>content</i>", result)
+}
+
+func TestToHTML_NestedBoldItalic(t *testing.T) {
+	nodes := Parse("**<i>bold italic</i>**")
+	result := ToHTML(nodes, testHost)
+	assert.Equal(t, "<b><i>bold italic</i></b>", result)
+}
+
+func TestToHTML_MixedContent(t *testing.T) {
+	nodes := Parse("hello **bold** world")
+	result := ToHTML(nodes, testHost)
+	assert.Equal(t, "hello <b>bold</b> world", result)
+}
+
+func TestIsSimple_SimpleNodes(t *testing.T) {
+	nodes := Parse("hello @alice #tag https://example.com :emoji: 😀")
+	assert.True(t, IsSimple(nodes))
+}
+
+func TestIsSimple_WithBold(t *testing.T) {
+	nodes := Parse("**bold**")
+	assert.False(t, IsSimple(nodes))
+}
+
+func TestIsSimple_WithCode(t *testing.T) {
+	nodes := Parse("`code`")
+	assert.False(t, IsSimple(nodes))
+}
+
+func TestIsSimple_Empty(t *testing.T) {
+	assert.True(t, IsSimple(nil))
+}
+
+func TestToHTML_Fn_Ruby_NoArgs(t *testing.T) {
+	// ruby without rt arg → italic fallback
+	nodes := []*Node{{
+		Type:     NodeFn,
+		Props:    map[string]any{"name": "ruby"},
+		Children: []*Node{Text("base")},
+	}}
+	result := ToHTML(nodes, testHost)
+	assert.Equal(t, "<i>base</i>", result)
+}
+
+func TestToHTML_Fn_Unixtime_Invalid(t *testing.T) {
+	// non-numeric → italic fallback
+	nodes := []*Node{{
+		Type:     NodeFn,
+		Props:    map[string]any{"name": "unixtime"},
+		Children: []*Node{Text("invalid")},
+	}}
+	result := ToHTML(nodes, testHost)
+	assert.Equal(t, "<i>invalid</i>", result)
+}

--- a/internal/activitypub/mfm/node.go
+++ b/internal/activitypub/mfm/node.go
@@ -1,0 +1,62 @@
+// Package mfm implements a parser and HTML renderer for Misskey Flavored
+// Markdown (MFM). The parser is a recursive-descent port of mfm-js that
+// produces an AST of Node values; ToHTML converts that AST to sanitised
+// HTML suitable for ActivityPub Note.content.
+package mfm
+
+// NodeType identifies the kind of a parsed MFM node.
+type NodeType string
+
+const (
+	NodeText         NodeType = "text"
+	NodeBold         NodeType = "bold"
+	NodeItalic       NodeType = "italic"
+	NodeStrike       NodeType = "strike"
+	NodeSmall        NodeType = "small"
+	NodeCenter       NodeType = "center"
+	NodePlain        NodeType = "plain"
+	NodeInlineCode   NodeType = "inlineCode"
+	NodeBlockCode    NodeType = "blockCode"
+	NodeMathInline   NodeType = "mathInline"
+	NodeMathBlock    NodeType = "mathBlock"
+	NodeQuote        NodeType = "quote"
+	NodeSearch       NodeType = "search"
+	NodeURL          NodeType = "url"
+	NodeLink         NodeType = "link"
+	NodeMention      NodeType = "mention"
+	NodeHashtag      NodeType = "hashtag"
+	NodeUnicodeEmoji NodeType = "unicodeEmoji"
+	NodeEmojiCode    NodeType = "emojiCode"
+	NodeFn           NodeType = "fn"
+)
+
+// Node is an element in the MFM abstract syntax tree.
+type Node struct {
+	Type     NodeType
+	Props    map[string]any
+	Children []*Node
+}
+
+// Text creates a text node.
+func Text(s string) *Node {
+	return &Node{Type: NodeText, Props: map[string]any{"text": s}}
+}
+
+// textValue returns the text property if present.
+func (n *Node) textValue() string {
+	if n.Props == nil {
+		return ""
+	}
+	v, _ := n.Props["text"].(string)
+	return v
+}
+
+// withChildren returns a new node with the given children.
+func withChildren(t NodeType, children []*Node) *Node {
+	return &Node{Type: t, Children: children}
+}
+
+// withProp returns a new node with a single named property.
+func withProp(t NodeType, key string, val any) *Node {
+	return &Node{Type: t, Props: map[string]any{key: val}}
+}

--- a/internal/activitypub/mfm/parser.go
+++ b/internal/activitypub/mfm/parser.go
@@ -1,0 +1,1155 @@
+package mfm
+
+import (
+	"strings"
+	"unicode"
+	"unicode/utf8"
+)
+
+// Parse tokenizes and parses the input MFM string into an AST.
+func Parse(input string) []*Node {
+	if input == "" {
+		return nil
+	}
+	s := &state{src: input, depth: 0, nestLimit: 20}
+	nodes := s.parseNodes(false)
+	return mergeText(nodes)
+}
+
+// ParseSimple parses with limited syntax: only text, unicodeEmoji, emojiCode, plain.
+func ParseSimple(input string) []*Node {
+	if input == "" {
+		return nil
+	}
+	s := &state{src: input, depth: 0, nestLimit: 20, simple: true}
+	nodes := s.parseNodes(false)
+	return mergeText(nodes)
+}
+
+// state tracks parser position and nesting.
+type state struct {
+	src       string
+	pos       int
+	depth     int
+	nestLimit int
+	inLink    bool
+	simple    bool
+}
+
+func (s *state) remaining() string { return s.src[s.pos:] }
+func (s *state) eof() bool         { return s.pos >= len(s.src) }
+
+func (s *state) peek() rune {
+	if s.eof() {
+		return 0
+	}
+	r, _ := utf8.DecodeRuneInString(s.src[s.pos:])
+	return r
+}
+
+func (s *state) advance(n int) { s.pos += n }
+
+func (s *state) hasPrefix(prefix string) bool {
+	return strings.HasPrefix(s.remaining(), prefix)
+}
+
+// parseNodes parses until EOF or (if inQuote) until a line doesn't start with >.
+func (s *state) parseNodes(inQuote bool) []*Node {
+	var nodes []*Node
+	for !s.eof() {
+		if inQuote {
+			// quoteの中で行頭が>でなくなったら終了
+			if s.pos > 0 && s.src[s.pos-1] == '\n' && !s.hasPrefix(">") {
+				break
+			}
+		}
+		node := s.parseOne()
+		if node == nil {
+			break
+		}
+		nodes = append(nodes, node)
+	}
+	return nodes
+}
+
+func (s *state) parseOne() *Node {
+	if s.eof() {
+		return nil
+	}
+	if s.simple {
+		return s.parseSimpleOne()
+	}
+	return s.parseFullOne()
+}
+
+func (s *state) parseSimpleOne() *Node {
+	if n := s.tryUnicodeEmoji(); n != nil {
+		return n
+	}
+	if n := s.tryEmojiCode(); n != nil {
+		return n
+	}
+	if n := s.tryPlainTag(); n != nil {
+		return n
+	}
+	return s.consumeChar()
+}
+
+func (s *state) parseFullOne() *Node {
+	// mfm-js の alt() 順序に従う
+	if n := s.tryUnicodeEmoji(); n != nil {
+		return n
+	}
+	if n := s.tryCenterTag(); n != nil {
+		return n
+	}
+	if n := s.trySmallTag(); n != nil {
+		return n
+	}
+	if n := s.tryPlainTag(); n != nil {
+		return n
+	}
+	if n := s.tryBoldTag(); n != nil {
+		return n
+	}
+	if n := s.tryItalicTag(); n != nil {
+		return n
+	}
+	if n := s.tryStrikeTag(); n != nil {
+		return n
+	}
+	if n := s.tryBoldAsta(); n != nil {
+		return n
+	}
+	if n := s.tryItalicAsta(); n != nil {
+		return n
+	}
+	if n := s.tryBoldUnder(); n != nil {
+		return n
+	}
+	if n := s.tryItalicUnder(); n != nil {
+		return n
+	}
+	if n := s.tryCodeBlock(); n != nil {
+		return n
+	}
+	if n := s.tryInlineCode(); n != nil {
+		return n
+	}
+	if n := s.tryQuote(); n != nil {
+		return n
+	}
+	if n := s.tryMathBlock(); n != nil {
+		return n
+	}
+	if n := s.tryMathInline(); n != nil {
+		return n
+	}
+	if n := s.tryStrikeWave(); n != nil {
+		return n
+	}
+	if n := s.tryFn(); n != nil {
+		return n
+	}
+	if n := s.tryMention(); n != nil {
+		return n
+	}
+	if n := s.tryHashtag(); n != nil {
+		return n
+	}
+	if n := s.tryEmojiCode(); n != nil {
+		return n
+	}
+	if !s.inLink {
+		if n := s.tryLink(); n != nil {
+			return n
+		}
+	}
+	if n := s.tryURL(); n != nil {
+		return n
+	}
+	if n := s.trySearch(); n != nil {
+		return n
+	}
+	return s.consumeChar()
+}
+
+// consumeChar takes one rune and returns it as a text node.
+func (s *state) consumeChar() *Node {
+	r, size := utf8.DecodeRuneInString(s.remaining())
+	s.advance(size)
+	return Text(string(r))
+}
+
+// nest runs parser function with incremented depth. nil on limit.
+func (s *state) nest(fn func() []*Node) []*Node {
+	s.depth++
+	if s.depth > s.nestLimit {
+		s.depth--
+		return nil
+	}
+	result := fn()
+	s.depth--
+	return result
+}
+
+// --- Block-level parsers ---
+
+func (s *state) tryQuote() *Node {
+	// 行頭もしくはテキスト先頭のみ
+	if s.pos > 0 && s.src[s.pos-1] != '\n' {
+		return nil
+	}
+	if !s.hasPrefix(">") {
+		return nil
+	}
+	save := s.pos
+	var lines []string
+	for !s.eof() && s.hasPrefix(">") {
+		s.advance(1) // skip >
+		if !s.eof() && (s.peek() == ' ' || s.peek() == '\t') {
+			s.advance(1) // skip optional space
+		}
+		lineStart := s.pos
+		for !s.eof() && s.peek() != '\n' {
+			s.advance(utf8.RuneLen(s.peek()))
+		}
+		lines = append(lines, s.src[lineStart:s.pos])
+		if !s.eof() {
+			s.advance(1) // skip \n
+		}
+	}
+	if len(lines) == 0 {
+		s.pos = save
+		return nil
+	}
+	inner := strings.Join(lines, "\n")
+	children := s.nest(func() []*Node {
+		sub := &state{src: inner, depth: s.depth, nestLimit: s.nestLimit}
+		return sub.parseNodes(false)
+	})
+	if children == nil {
+		s.pos = save
+		return nil
+	}
+	return withChildren(NodeQuote, mergeText(children))
+}
+
+func (s *state) tryCodeBlock() *Node {
+	if s.pos > 0 && s.src[s.pos-1] != '\n' {
+		return nil
+	}
+	if !s.hasPrefix("```") {
+		return nil
+	}
+	save := s.pos
+	s.advance(3) // skip ```
+	// optional lang
+	langStart := s.pos
+	for !s.eof() && s.peek() != '\n' {
+		s.advance(utf8.RuneLen(s.peek()))
+	}
+	lang := strings.TrimSpace(s.src[langStart:s.pos])
+	if s.eof() {
+		s.pos = save
+		return nil
+	}
+	s.advance(1) // skip \n
+
+	codeStart := s.pos
+	for !s.eof() {
+		if s.hasPrefix("\n```") {
+			code := s.src[codeStart:s.pos]
+			s.advance(4) // skip \n```
+			// 行末まで消費 (改行 or EOF)
+			for !s.eof() && s.peek() != '\n' {
+				s.advance(1)
+			}
+			if !s.eof() {
+				s.advance(1)
+			}
+			props := map[string]any{"code": code}
+			if lang != "" {
+				props["lang"] = lang
+			}
+			return &Node{Type: NodeBlockCode, Props: props}
+		}
+		s.advance(utf8.RuneLen(s.peek()))
+	}
+	s.pos = save
+	return nil
+}
+
+func (s *state) tryMathBlock() *Node {
+	if !s.hasPrefix("\\[") {
+		return nil
+	}
+	save := s.pos
+	s.advance(2)
+	start := s.pos
+	for !s.eof() {
+		if s.hasPrefix("\\]") {
+			formula := strings.TrimSpace(s.src[start:s.pos])
+			if formula == "" {
+				break
+			}
+			s.advance(2)
+			return withProp(NodeMathBlock, "formula", formula)
+		}
+		s.advance(utf8.RuneLen(s.peek()))
+	}
+	s.pos = save
+	return nil
+}
+
+func (s *state) tryCenterTag() *Node {
+	return s.tryHTMLTag("center", NodeCenter, true)
+}
+
+func (s *state) trySmallTag() *Node {
+	return s.tryHTMLTag("small", NodeSmall, true)
+}
+
+func (s *state) tryPlainTag() *Node {
+	if !s.hasPrefix("<plain>") {
+		return nil
+	}
+	save := s.pos
+	s.advance(7) // <plain>
+	start := s.pos
+	for !s.eof() {
+		if s.hasPrefix("</plain>") {
+			text := s.src[start:s.pos]
+			s.advance(8) // </plain>
+			return &Node{Type: NodePlain, Children: []*Node{Text(text)}}
+		}
+		s.advance(utf8.RuneLen(s.peek()))
+	}
+	s.pos = save
+	return nil
+}
+
+func (s *state) tryBoldTag() *Node {
+	return s.tryHTMLTag("b", NodeBold, true)
+}
+
+func (s *state) tryItalicTag() *Node {
+	return s.tryHTMLTag("i", NodeItalic, true)
+}
+
+func (s *state) tryStrikeTag() *Node {
+	return s.tryHTMLTag("s", NodeStrike, true)
+}
+
+// tryHTMLTag は <tag>...</tag> 形式のパースを試みる。
+// recurse=true で children を再帰パースする。
+func (s *state) tryHTMLTag(tag string, nodeType NodeType, recurse bool) *Node {
+	open := "<" + tag + ">"
+	close := "</" + tag + ">"
+	if !s.hasPrefix(open) {
+		return nil
+	}
+	save := s.pos
+	s.advance(len(open))
+
+	if recurse {
+		children := s.nest(func() []*Node {
+			var nodes []*Node
+			for !s.eof() && !s.hasPrefix(close) {
+				n := s.parseOne()
+				if n == nil {
+					break
+				}
+				nodes = append(nodes, n)
+			}
+			return nodes
+		})
+		if s.hasPrefix(close) {
+			s.advance(len(close))
+			return withChildren(nodeType, mergeText(children))
+		}
+	}
+	s.pos = save
+	return nil
+}
+
+// --- Inline parsers ---
+
+func (s *state) tryBoldAsta() *Node {
+	if !s.hasPrefix("**") {
+		return nil
+	}
+	return s.tryWrapped("**", "**", NodeBold)
+}
+
+func (s *state) tryItalicAsta() *Node {
+	if !s.hasPrefix("*") || s.hasPrefix("**") {
+		return nil
+	}
+	// 直前が英数字なら失敗
+	if s.pos > 0 && isAlphanumeric(s.prevRune()) {
+		return nil
+	}
+	return s.tryWrappedAlphaSpace("*", "*", NodeItalic)
+}
+
+func (s *state) tryBoldUnder() *Node {
+	if !s.hasPrefix("__") {
+		return nil
+	}
+	return s.tryWrappedAlphaSpace("__", "__", NodeBold)
+}
+
+func (s *state) tryItalicUnder() *Node {
+	if !s.hasPrefix("_") || s.hasPrefix("__") {
+		return nil
+	}
+	if s.pos > 0 && isAlphanumeric(s.prevRune()) {
+		return nil
+	}
+	return s.tryWrappedAlphaSpace("_", "_", NodeItalic)
+}
+
+func (s *state) tryStrikeWave() *Node {
+	if !s.hasPrefix("~~") {
+		return nil
+	}
+	return s.tryWrapped("~~", "~~", NodeStrike)
+}
+
+// tryWrapped は open...close で囲まれた部分を再帰パースする。
+func (s *state) tryWrapped(open, close string, nodeType NodeType) *Node {
+	save := s.pos
+	s.advance(len(open))
+	if s.eof() || s.hasPrefix(close) {
+		s.pos = save
+		return nil
+	}
+	children := s.nest(func() []*Node {
+		var nodes []*Node
+		for !s.eof() && !s.hasPrefix(close) {
+			if s.peek() == '\n' {
+				s.pos = save
+				return nil
+			}
+			n := s.parseOne()
+			if n == nil {
+				break
+			}
+			nodes = append(nodes, n)
+		}
+		return nodes
+	})
+	if children == nil || !s.hasPrefix(close) {
+		s.pos = save
+		return nil
+	}
+	s.advance(len(close))
+	return withChildren(nodeType, mergeText(children))
+}
+
+// tryWrappedAlphaSpace は英数字+空白のみを含むラップされた部分をパースする。
+func (s *state) tryWrappedAlphaSpace(open, close string, nodeType NodeType) *Node {
+	save := s.pos
+	s.advance(len(open))
+	start := s.pos
+	for !s.eof() {
+		if s.hasPrefix(close) {
+			content := s.src[start:s.pos]
+			if content == "" {
+				break
+			}
+			// 英数字+空白のみか確認
+			if !isAlphaSpaceOnly(content) {
+				break
+			}
+			s.advance(len(close))
+			return withChildren(nodeType, []*Node{Text(content)})
+		}
+		if s.peek() == '\n' {
+			break
+		}
+		s.advance(utf8.RuneLen(s.peek()))
+	}
+	s.pos = save
+	return nil
+}
+
+func (s *state) tryInlineCode() *Node {
+	if s.peek() != '`' || s.hasPrefix("```") {
+		return nil
+	}
+	save := s.pos
+	s.advance(1)
+	start := s.pos
+	for !s.eof() {
+		ch := s.peek()
+		if ch == '`' {
+			code := s.src[start:s.pos]
+			if code == "" {
+				break
+			}
+			s.advance(1)
+			return withProp(NodeInlineCode, "code", code)
+		}
+		if ch == '\n' || ch == 0xb4 { // ´ acute accent
+			break
+		}
+		s.advance(utf8.RuneLen(ch))
+	}
+	s.pos = save
+	return nil
+}
+
+func (s *state) tryMathInline() *Node {
+	if !s.hasPrefix("\\(") {
+		return nil
+	}
+	save := s.pos
+	s.advance(2)
+	start := s.pos
+	for !s.eof() {
+		if s.hasPrefix("\\)") {
+			formula := s.src[start:s.pos]
+			if formula == "" {
+				break
+			}
+			s.advance(2)
+			return withProp(NodeMathInline, "formula", formula)
+		}
+		if s.peek() == '\n' {
+			break
+		}
+		s.advance(utf8.RuneLen(s.peek()))
+	}
+	s.pos = save
+	return nil
+}
+
+func (s *state) tryFn() *Node {
+	if !s.hasPrefix("$[") {
+		return nil
+	}
+	save := s.pos
+	s.advance(2)
+	// 関数名をパース
+	nameStart := s.pos
+	for !s.eof() {
+		ch := s.peek()
+		if isASCIIAlphanumeric(ch) || ch == '_' {
+			s.advance(1)
+			continue
+		}
+		break
+	}
+	name := s.src[nameStart:s.pos]
+	if name == "" {
+		s.pos = save
+		return nil
+	}
+
+	// 引数をパース (ドットで始まる)
+	var args map[string]any
+	if !s.eof() && s.peek() == '.' {
+		s.advance(1)
+		args = s.parseFnArgs()
+	}
+
+	// スペース区切り
+	if s.eof() || s.peek() != ' ' {
+		s.pos = save
+		return nil
+	}
+	s.advance(1)
+
+	// children (] まで)
+	children := s.nest(func() []*Node {
+		var nodes []*Node
+		for !s.eof() && s.peek() != ']' {
+			n := s.parseOne()
+			if n == nil {
+				break
+			}
+			nodes = append(nodes, n)
+		}
+		return nodes
+	})
+	if !s.hasPrefix("]") {
+		s.pos = save
+		return nil
+	}
+	s.advance(1)
+
+	props := map[string]any{"name": name}
+	if args != nil {
+		props["args"] = args
+	}
+	return &Node{Type: NodeFn, Props: props, Children: mergeText(children)}
+}
+
+func (s *state) parseFnArgs() map[string]any {
+	args := map[string]any{}
+	for !s.eof() {
+		keyStart := s.pos
+		for !s.eof() {
+			ch := s.peek()
+			if isASCIIAlphanumeric(ch) || ch == '_' {
+				s.advance(1)
+				continue
+			}
+			break
+		}
+		key := s.src[keyStart:s.pos]
+		if key == "" {
+			break
+		}
+		if !s.eof() && s.peek() == '=' {
+			s.advance(1)
+			valStart := s.pos
+			for !s.eof() {
+				ch := s.peek()
+				if ch == ',' || ch == ' ' || ch == ']' {
+					break
+				}
+				s.advance(utf8.RuneLen(ch))
+			}
+			args[key] = s.src[valStart:s.pos]
+		} else {
+			args[key] = true
+		}
+		if !s.eof() && s.peek() == ',' {
+			s.advance(1)
+			continue
+		}
+		break
+	}
+	return args
+}
+
+func (s *state) tryMention() *Node {
+	if s.peek() != '@' {
+		return nil
+	}
+	// 直前が英数字なら失敗
+	if s.pos > 0 && isAlphanumeric(s.prevRune()) {
+		return nil
+	}
+	save := s.pos
+	s.advance(1) // skip @
+	username := s.consumeIdent()
+	if username == "" {
+		s.pos = save
+		return nil
+	}
+	var host string
+	if !s.eof() && s.peek() == '@' {
+		s.advance(1)
+		host = s.consumeIdent()
+		if host == "" {
+			// @user@ のようなパターンはホスト無しに戻す
+			s.pos -= 1 // @ を戻す
+		}
+	}
+	// 末尾のドット・ハイフンを削る
+	username = strings.TrimRight(username, ".-")
+	host = strings.TrimRight(host, ".-")
+	if username == "" {
+		s.pos = save
+		return nil
+	}
+
+	props := map[string]any{"username": username}
+	acct := "@" + username
+	if host != "" {
+		props["host"] = host
+		acct += "@" + host
+	}
+	props["acct"] = acct
+	return &Node{Type: NodeMention, Props: props}
+}
+
+func (s *state) consumeIdent() string {
+	start := s.pos
+	for !s.eof() {
+		ch := s.peek()
+		if isASCIIAlphanumeric(ch) || ch == '_' || ch == '-' || ch == '.' {
+			s.advance(1)
+			continue
+		}
+		break
+	}
+	return s.src[start:s.pos]
+}
+
+func (s *state) tryHashtag() *Node {
+	if s.peek() != '#' {
+		return nil
+	}
+	if s.pos > 0 && isAlphanumeric(s.prevRune()) {
+		return nil
+	}
+	save := s.pos
+	s.advance(1) // skip #
+
+	start := s.pos
+	s.consumeHashtagContent()
+	tag := s.src[start:s.pos]
+	if tag == "" {
+		s.pos = save
+		return nil
+	}
+	// 数字だけのハッシュタグは無効
+	if isDigitsOnly(tag) {
+		s.pos = save
+		return nil
+	}
+	return &Node{Type: NodeHashtag, Props: map[string]any{"hashtag": tag}}
+}
+
+func (s *state) consumeHashtagContent() {
+	for !s.eof() {
+		ch := s.peek()
+		// ハッシュタグで無効な文字
+		if ch == '#' || unicode.IsSpace(ch) || ch == '.' || ch == ',' || ch == '!' ||
+			ch == '?' || ch == '\'' || ch == '"' || ch == ':' || ch == '<' || ch == '>' {
+			return
+		}
+		// 括弧のネスト
+		switch ch {
+		case '(':
+			s.advance(1)
+			s.consumeHashtagContent()
+			if !s.eof() && s.peek() == ')' {
+				s.advance(1)
+			}
+			continue
+		case '[':
+			s.advance(1)
+			s.consumeHashtagContent()
+			if !s.eof() && s.peek() == ']' {
+				s.advance(1)
+			}
+			continue
+		case '「':
+			s.advance(utf8.RuneLen(ch))
+			s.consumeHashtagContent()
+			if !s.eof() && s.peek() == '」' {
+				s.advance(utf8.RuneLen('」'))
+			}
+			continue
+		case '（':
+			s.advance(utf8.RuneLen(ch))
+			s.consumeHashtagContent()
+			if !s.eof() && s.peek() == '）' {
+				s.advance(utf8.RuneLen('）'))
+			}
+			continue
+		case ')', ']', '」', '）':
+			return
+		}
+		s.advance(utf8.RuneLen(ch))
+	}
+}
+
+func (s *state) tryEmojiCode() *Node {
+	if s.peek() != ':' {
+		return nil
+	}
+	// 境界チェック
+	if s.pos > 0 && isAlphanumeric(s.prevRune()) {
+		return nil
+	}
+	save := s.pos
+	s.advance(1) // skip :
+	start := s.pos
+	for !s.eof() {
+		ch := s.peek()
+		if ch == ':' {
+			name := s.src[start:s.pos]
+			if name == "" {
+				break
+			}
+			// 英数字+_+-のみ
+			if !isEmojiName(name) {
+				break
+			}
+			s.advance(1)
+			return withProp(NodeEmojiCode, "name", name)
+		}
+		if ch == '\n' || unicode.IsSpace(ch) {
+			break
+		}
+		s.advance(utf8.RuneLen(ch))
+	}
+	s.pos = save
+	return nil
+}
+
+func (s *state) tryUnicodeEmoji() *Node {
+	rest := s.remaining()
+	if len(rest) == 0 {
+		return nil
+	}
+	r, size := utf8.DecodeRuneInString(rest)
+	if r == utf8.RuneError {
+		return nil
+	}
+
+	// 絵文字判定: Emoji/Symbol カテゴリ + FE0F (variation selector) の組み合わせ
+	if !isEmojiStart(r) {
+		return nil
+	}
+
+	// 連続する絵文字関連コードポイントを消費
+	end := size
+	for end < len(rest) {
+		nextR, nextSize := utf8.DecodeRuneInString(rest[end:])
+		if nextR == utf8.RuneError {
+			break
+		}
+		if isEmojiContinuation(nextR) {
+			end += nextSize
+			continue
+		}
+		break
+	}
+
+	emoji := rest[:end]
+	// FE0F 単体は絵文字ではない
+	if emoji == "\ufe0f" {
+		return nil
+	}
+	s.advance(end)
+	return withProp(NodeUnicodeEmoji, "emoji", emoji)
+}
+
+func (s *state) tryURL() *Node {
+	if !(s.hasPrefix("https://") || s.hasPrefix("http://")) {
+		return nil
+	}
+	save := s.pos
+	start := s.pos
+
+	// プロトコル部分を消費
+	if s.hasPrefix("https://") {
+		s.advance(8)
+	} else {
+		s.advance(7)
+	}
+	if s.eof() {
+		s.pos = save
+		return nil
+	}
+
+	// URL文字を消費 (括弧ネスト対応)
+	s.consumeURLChars()
+	url := s.src[start:s.pos]
+	// 末尾の句読点を削る
+	url = strings.TrimRight(url, ".,")
+	s.pos = start + len(url)
+
+	if len(url) <= 8 { // プロトコルのみ
+		s.pos = save
+		return nil
+	}
+	return withProp(NodeURL, "url", url)
+}
+
+func (s *state) consumeURLChars() {
+	for !s.eof() {
+		ch := s.peek()
+		if unicode.IsSpace(ch) || ch == '<' || ch == '>' || ch == '"' || ch == '\'' {
+			return
+		}
+		switch ch {
+		case '(':
+			s.advance(1)
+			s.consumeURLChars()
+			if !s.eof() && s.peek() == ')' {
+				s.advance(1)
+			}
+			continue
+		case '[':
+			s.advance(1)
+			s.consumeURLChars()
+			if !s.eof() && s.peek() == ']' {
+				s.advance(1)
+			}
+			continue
+		case ')', ']':
+			return
+		}
+		s.advance(utf8.RuneLen(ch))
+	}
+}
+
+func (s *state) tryLink() *Node {
+	// ?[label](url) or [label](url)
+	silent := false
+	if s.hasPrefix("?[") {
+		silent = true
+	} else if s.peek() != '[' {
+		return nil
+	}
+	save := s.pos
+	if silent {
+		s.advance(2)
+	} else {
+		s.advance(1)
+	}
+
+	// label
+	oldInLink := s.inLink
+	s.inLink = true
+	var labelNodes []*Node
+	for !s.eof() && s.peek() != ']' {
+		if s.peek() == '\n' {
+			s.inLink = oldInLink
+			s.pos = save
+			return nil
+		}
+		n := s.parseOne()
+		if n == nil {
+			break
+		}
+		labelNodes = append(labelNodes, n)
+	}
+	s.inLink = oldInLink
+
+	if !s.hasPrefix("](") {
+		s.pos = save
+		return nil
+	}
+	s.advance(2) // skip ](
+
+	urlStart := s.pos
+	parenDepth := 1
+	for !s.eof() && parenDepth > 0 {
+		ch := s.peek()
+		if ch == '(' {
+			parenDepth++
+		} else if ch == ')' {
+			parenDepth--
+			if parenDepth == 0 {
+				break
+			}
+		} else if ch == '\n' || unicode.IsSpace(ch) {
+			s.pos = save
+			return nil
+		}
+		s.advance(utf8.RuneLen(ch))
+	}
+	url := s.src[urlStart:s.pos]
+	if url == "" || !s.hasPrefix(")") {
+		s.pos = save
+		return nil
+	}
+	s.advance(1) // skip )
+
+	props := map[string]any{"url": url, "silent": silent}
+	return &Node{Type: NodeLink, Props: props, Children: mergeText(labelNodes)}
+}
+
+func (s *state) trySearch() *Node {
+	// 行頭から: "query 検索" / "query search" / "query [検索]" / "query [search]"
+	if s.pos > 0 && s.src[s.pos-1] != '\n' {
+		return nil
+	}
+	save := s.pos
+	// 行末まで読む
+	lineStart := s.pos
+	for !s.eof() && s.peek() != '\n' {
+		s.advance(utf8.RuneLen(s.peek()))
+	}
+	line := s.src[lineStart:s.pos]
+
+	// 検索キーワードで終わるか確認
+	for _, suffix := range []string{" 検索", " search", " [検索]", " [search]", " Search", " SEARCH"} {
+		if strings.HasSuffix(strings.TrimSpace(line), strings.TrimSpace(suffix)) {
+			query := strings.TrimSpace(line[:len(line)-len(suffix)])
+			if query == "" {
+				continue
+			}
+			if !s.eof() {
+				s.advance(1) // skip \n
+			}
+			return &Node{Type: NodeSearch, Props: map[string]any{"query": query}}
+		}
+	}
+	s.pos = save
+	return nil
+}
+
+// --- Helpers ---
+
+func (s *state) prevRune() rune {
+	if s.pos <= 0 {
+		return 0
+	}
+	r, _ := utf8.DecodeLastRuneInString(s.src[:s.pos])
+	return r
+}
+
+func isAlphanumeric(r rune) bool {
+	return (r >= 'a' && r <= 'z') || (r >= 'A' && r <= 'Z') || (r >= '0' && r <= '9')
+}
+
+func isASCIIAlphanumeric(r rune) bool {
+	return isAlphanumeric(r)
+}
+
+func isAlphaSpaceOnly(s string) bool {
+	for _, r := range s {
+		if !isAlphanumeric(r) && !unicode.IsSpace(r) {
+			return false
+		}
+	}
+	return true
+}
+
+func isDigitsOnly(s string) bool {
+	for _, r := range s {
+		if r < '0' || r > '9' {
+			return false
+		}
+	}
+	return len(s) > 0
+}
+
+func isEmojiName(s string) bool {
+	for _, r := range s {
+		if !isASCIIAlphanumeric(r) && r != '_' && r != '+' && r != '-' {
+			return false
+		}
+	}
+	return len(s) > 0
+}
+
+// isEmojiStart は絵文字シーケンスの先頭文字として妥当か判定する。
+// Unicode Emoji カテゴリの文字や、一般的な絵文字開始コードポイントを対象。
+func isEmojiStart(r rune) bool {
+	// 基本的な絵文字範囲
+	if r >= 0x1F600 && r <= 0x1F64F { // Emoticons
+		return true
+	}
+	if r >= 0x1F300 && r <= 0x1F5FF { // Misc Symbols and Pictographs
+		return true
+	}
+	if r >= 0x1F680 && r <= 0x1F6FF { // Transport and Map
+		return true
+	}
+	if r >= 0x1F700 && r <= 0x1F77F { // Alchemical Symbols
+		return true
+	}
+	if r >= 0x1F780 && r <= 0x1F7FF { // Geometric Shapes Extended
+		return true
+	}
+	if r >= 0x1F800 && r <= 0x1F8FF { // Supplemental Arrows-C
+		return true
+	}
+	if r >= 0x1F900 && r <= 0x1F9FF { // Supplemental Symbols and Pictographs
+		return true
+	}
+	if r >= 0x1FA00 && r <= 0x1FA6F { // Chess Symbols
+		return true
+	}
+	if r >= 0x1FA70 && r <= 0x1FAFF { // Symbols and Pictographs Extended-A
+		return true
+	}
+	if r >= 0x2600 && r <= 0x26FF { // Misc symbols
+		return true
+	}
+	if r >= 0x2700 && r <= 0x27BF { // Dingbats
+		return true
+	}
+	if r >= 0x231A && r <= 0x23F3 { // Misc Technical (watch, hourglass)
+		return true
+	}
+	if r >= 0x2300 && r <= 0x23FF { // Misc Technical
+		return true
+	}
+	if r >= 0x2B05 && r <= 0x2B55 { // Arrows, geometric
+		return true
+	}
+	if r >= 0x200D && r <= 0x200D { // ZWJ
+		return true
+	}
+	if r >= 0xFE00 && r <= 0xFE0F { // Variation selectors
+		return true
+	}
+	if r == 0x203C || r == 0x2049 { // ‼ ⁉
+		return true
+	}
+	if r == 0x20E3 { // Combining enclosing keycap
+		return true
+	}
+	if r >= 0x2100 && r <= 0x214F { // Letterlike symbols (™ etc)
+		return true
+	}
+	if r >= 0x2190 && r <= 0x21FF { // Arrows
+		return true
+	}
+	// keycap base digits 0-9, *, #
+	if r == '#' || r == '*' || (r >= '0' && r <= '9') {
+		// keycapとして使われる可能性があるが、FE0Fが続かないと絵文字にならない
+		return false
+	}
+	// Regional indicators
+	if r >= 0x1F1E0 && r <= 0x1F1FF {
+		return true
+	}
+	// © ®
+	if r == 0xA9 || r == 0xAE {
+		return true
+	}
+	return false
+}
+
+// isEmojiContinuation は絵文字シーケンスの継続文字として妥当か判定する。
+func isEmojiContinuation(r rune) bool {
+	if isEmojiStart(r) {
+		return true
+	}
+	// ZWJ (Zero Width Joiner)
+	if r == 0x200D {
+		return true
+	}
+	// Variation selectors
+	if r >= 0xFE00 && r <= 0xFE0F {
+		return true
+	}
+	// Combining enclosing keycap
+	if r == 0x20E3 {
+		return true
+	}
+	// Skin tone modifiers
+	if r >= 0x1F3FB && r <= 0x1F3FF {
+		return true
+	}
+	// Tag characters (used in flag sequences)
+	if r >= 0xE0020 && r <= 0xE007F {
+		return true
+	}
+	return false
+}
+
+// mergeText combines adjacent text nodes.
+func mergeText(nodes []*Node) []*Node {
+	if len(nodes) == 0 {
+		return nil
+	}
+	var result []*Node
+	for _, n := range nodes {
+		if n == nil {
+			continue
+		}
+		if n.Type == NodeText && len(result) > 0 && result[len(result)-1].Type == NodeText {
+			// 前のテキストノードと結合
+			prev := result[len(result)-1]
+			prev.Props["text"] = prev.textValue() + n.textValue()
+		} else {
+			result = append(result, n)
+		}
+	}
+	return result
+}

--- a/internal/activitypub/mfm/parser.go
+++ b/internal/activitypub/mfm/parser.go
@@ -964,9 +964,11 @@ func (s *state) trySearch() *Node {
 	line := s.src[lineStart:s.pos]
 
 	// 検索キーワードで終わるか確認
+	trimmedLine := strings.TrimSpace(line)
 	for _, suffix := range []string{" 検索", " search", " [検索]", " [search]", " Search", " SEARCH"} {
-		if strings.HasSuffix(strings.TrimSpace(line), strings.TrimSpace(suffix)) {
-			query := strings.TrimSpace(line[:len(line)-len(suffix)])
+		trimmedSuffix := strings.TrimSpace(suffix)
+		if strings.HasSuffix(trimmedLine, trimmedSuffix) {
+			query := strings.TrimSpace(trimmedLine[:len(trimmedLine)-len(trimmedSuffix)])
 			if query == "" {
 				continue
 			}

--- a/internal/activitypub/mfm/parser_test.go
+++ b/internal/activitypub/mfm/parser_test.go
@@ -1,0 +1,624 @@
+package mfm
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestParse_PlainText(t *testing.T) {
+	nodes := Parse("hello world")
+	require.Len(t, nodes, 1)
+	assert.Equal(t, NodeText, nodes[0].Type)
+	assert.Equal(t, "hello world", nodes[0].textValue())
+}
+
+func TestParse_EmptyInput(t *testing.T) {
+	nodes := Parse("")
+	assert.Nil(t, nodes)
+}
+
+func TestParse_Bold_Asterisks(t *testing.T) {
+	nodes := Parse("**bold**")
+	require.Len(t, nodes, 1)
+	assert.Equal(t, NodeBold, nodes[0].Type)
+	require.Len(t, nodes[0].Children, 1)
+	assert.Equal(t, "bold", nodes[0].Children[0].textValue())
+}
+
+func TestParse_Bold_Tag(t *testing.T) {
+	nodes := Parse("<b>bold</b>")
+	require.Len(t, nodes, 1)
+	assert.Equal(t, NodeBold, nodes[0].Type)
+}
+
+func TestParse_Bold_Underscores(t *testing.T) {
+	nodes := Parse("__bold text__")
+	require.Len(t, nodes, 1)
+	assert.Equal(t, NodeBold, nodes[0].Type)
+	require.Len(t, nodes[0].Children, 1)
+	assert.Equal(t, "bold text", nodes[0].Children[0].textValue())
+}
+
+func TestParse_Italic_Asterisk(t *testing.T) {
+	nodes := Parse("*italic*")
+	require.Len(t, nodes, 1)
+	assert.Equal(t, NodeItalic, nodes[0].Type)
+}
+
+func TestParse_Italic_Tag(t *testing.T) {
+	nodes := Parse("<i>italic</i>")
+	require.Len(t, nodes, 1)
+	assert.Equal(t, NodeItalic, nodes[0].Type)
+}
+
+func TestParse_Italic_Underscore(t *testing.T) {
+	nodes := Parse("_italic_")
+	require.Len(t, nodes, 1)
+	assert.Equal(t, NodeItalic, nodes[0].Type)
+}
+
+func TestParse_Strike_Wave(t *testing.T) {
+	nodes := Parse("~~strike~~")
+	require.Len(t, nodes, 1)
+	assert.Equal(t, NodeStrike, nodes[0].Type)
+	require.Len(t, nodes[0].Children, 1)
+	assert.Equal(t, "strike", nodes[0].Children[0].textValue())
+}
+
+func TestParse_Strike_Tag(t *testing.T) {
+	nodes := Parse("<s>strike</s>")
+	require.Len(t, nodes, 1)
+	assert.Equal(t, NodeStrike, nodes[0].Type)
+}
+
+func TestParse_InlineCode(t *testing.T) {
+	nodes := Parse("`code`")
+	require.Len(t, nodes, 1)
+	assert.Equal(t, NodeInlineCode, nodes[0].Type)
+	assert.Equal(t, "code", nodes[0].Props["code"])
+}
+
+func TestParse_BlockCode(t *testing.T) {
+	input := "```go\nfmt.Println()\n```"
+	nodes := Parse(input)
+	require.Len(t, nodes, 1)
+	assert.Equal(t, NodeBlockCode, nodes[0].Type)
+	assert.Equal(t, "fmt.Println()", nodes[0].Props["code"])
+	assert.Equal(t, "go", nodes[0].Props["lang"])
+}
+
+func TestParse_BlockCode_NoLang(t *testing.T) {
+	input := "```\nhello\n```"
+	nodes := Parse(input)
+	require.Len(t, nodes, 1)
+	assert.Equal(t, NodeBlockCode, nodes[0].Type)
+	assert.Equal(t, "hello", nodes[0].Props["code"])
+}
+
+func TestParse_MathInline(t *testing.T) {
+	nodes := Parse(`\(x^2\)`)
+	require.Len(t, nodes, 1)
+	assert.Equal(t, NodeMathInline, nodes[0].Type)
+	assert.Equal(t, "x^2", nodes[0].Props["formula"])
+}
+
+func TestParse_MathBlock(t *testing.T) {
+	nodes := Parse(`\[E=mc^2\]`)
+	require.Len(t, nodes, 1)
+	assert.Equal(t, NodeMathBlock, nodes[0].Type)
+	assert.Equal(t, "E=mc^2", nodes[0].Props["formula"])
+}
+
+func TestParse_Quote(t *testing.T) {
+	nodes := Parse("> quoted text")
+	require.Len(t, nodes, 1)
+	assert.Equal(t, NodeQuote, nodes[0].Type)
+	require.Len(t, nodes[0].Children, 1)
+	assert.Equal(t, "quoted text", nodes[0].Children[0].textValue())
+}
+
+func TestParse_Quote_MultiLine(t *testing.T) {
+	nodes := Parse("> line 1\n> line 2")
+	require.Len(t, nodes, 1)
+	assert.Equal(t, NodeQuote, nodes[0].Type)
+}
+
+func TestParse_Center(t *testing.T) {
+	nodes := Parse("<center>centered</center>")
+	require.Len(t, nodes, 1)
+	assert.Equal(t, NodeCenter, nodes[0].Type)
+}
+
+func TestParse_Small(t *testing.T) {
+	nodes := Parse("<small>small text</small>")
+	require.Len(t, nodes, 1)
+	assert.Equal(t, NodeSmall, nodes[0].Type)
+}
+
+func TestParse_Plain(t *testing.T) {
+	nodes := Parse("<plain>**not bold**</plain>")
+	require.Len(t, nodes, 1)
+	assert.Equal(t, NodePlain, nodes[0].Type)
+	require.Len(t, nodes[0].Children, 1)
+	assert.Equal(t, "**not bold**", nodes[0].Children[0].textValue())
+}
+
+func TestParse_Mention_Local(t *testing.T) {
+	nodes := Parse("@alice")
+	require.Len(t, nodes, 1)
+	assert.Equal(t, NodeMention, nodes[0].Type)
+	assert.Equal(t, "alice", nodes[0].Props["username"])
+	assert.Nil(t, nodes[0].Props["host"])
+	assert.Equal(t, "@alice", nodes[0].Props["acct"])
+}
+
+func TestParse_Mention_Remote(t *testing.T) {
+	nodes := Parse("@bob@remote.example")
+	require.Len(t, nodes, 1)
+	assert.Equal(t, NodeMention, nodes[0].Type)
+	assert.Equal(t, "bob", nodes[0].Props["username"])
+	assert.Equal(t, "remote.example", nodes[0].Props["host"])
+	assert.Equal(t, "@bob@remote.example", nodes[0].Props["acct"])
+}
+
+func TestParse_Mention_NotAfterAlphanumeric(t *testing.T) {
+	nodes := Parse("a@alice")
+	require.Len(t, nodes, 1)
+	assert.Equal(t, NodeText, nodes[0].Type)
+}
+
+func TestParse_Hashtag(t *testing.T) {
+	nodes := Parse("#hello")
+	require.Len(t, nodes, 1)
+	assert.Equal(t, NodeHashtag, nodes[0].Type)
+	assert.Equal(t, "hello", nodes[0].Props["hashtag"])
+}
+
+func TestParse_Hashtag_DigitsOnly(t *testing.T) {
+	nodes := Parse("#123")
+	require.Len(t, nodes, 1)
+	// 数字だけのハッシュタグは無効
+	assert.Equal(t, NodeText, nodes[0].Type)
+}
+
+func TestParse_Hashtag_NotAfterAlphanumeric(t *testing.T) {
+	nodes := Parse("a#tag")
+	require.Len(t, nodes, 1)
+	assert.Equal(t, NodeText, nodes[0].Type)
+}
+
+func TestParse_EmojiCode(t *testing.T) {
+	nodes := Parse(":thinking:")
+	require.Len(t, nodes, 1)
+	assert.Equal(t, NodeEmojiCode, nodes[0].Type)
+	assert.Equal(t, "thinking", nodes[0].Props["name"])
+}
+
+func TestParse_EmojiCode_NotAfterAlpha(t *testing.T) {
+	nodes := Parse("a:thinking:")
+	require.Len(t, nodes, 1)
+	assert.Equal(t, NodeText, nodes[0].Type)
+}
+
+func TestParse_UnicodeEmoji(t *testing.T) {
+	nodes := Parse("😀")
+	require.Len(t, nodes, 1)
+	assert.Equal(t, NodeUnicodeEmoji, nodes[0].Type)
+	assert.Equal(t, "😀", nodes[0].Props["emoji"])
+}
+
+func TestParse_URL(t *testing.T) {
+	nodes := Parse("https://example.com/path")
+	require.Len(t, nodes, 1)
+	assert.Equal(t, NodeURL, nodes[0].Type)
+	assert.Equal(t, "https://example.com/path", nodes[0].Props["url"])
+}
+
+func TestParse_URL_TrailingPunctuation(t *testing.T) {
+	nodes := Parse("https://example.com.")
+	require.Len(t, nodes, 2) // URL + text "."
+	assert.Equal(t, NodeURL, nodes[0].Type)
+	assert.Equal(t, "https://example.com", nodes[0].Props["url"])
+}
+
+func TestParse_URL_WithParens(t *testing.T) {
+	nodes := Parse("https://example.com/(path)")
+	require.Len(t, nodes, 1)
+	assert.Equal(t, NodeURL, nodes[0].Type)
+	assert.Equal(t, "https://example.com/(path)", nodes[0].Props["url"])
+}
+
+func TestParse_Link(t *testing.T) {
+	nodes := Parse("[label](https://example.com)")
+	require.Len(t, nodes, 1)
+	assert.Equal(t, NodeLink, nodes[0].Type)
+	assert.Equal(t, "https://example.com", nodes[0].Props["url"])
+	assert.Equal(t, false, nodes[0].Props["silent"])
+}
+
+func TestParse_Link_Silent(t *testing.T) {
+	nodes := Parse("?[label](https://example.com)")
+	require.Len(t, nodes, 1)
+	assert.Equal(t, NodeLink, nodes[0].Type)
+	assert.Equal(t, true, nodes[0].Props["silent"])
+}
+
+func TestParse_Fn(t *testing.T) {
+	nodes := Parse("$[tada hello]")
+	require.Len(t, nodes, 1)
+	assert.Equal(t, NodeFn, nodes[0].Type)
+	assert.Equal(t, "tada", nodes[0].Props["name"])
+}
+
+func TestParse_Fn_WithArgs(t *testing.T) {
+	nodes := Parse("$[ruby.rt=text base]")
+	require.Len(t, nodes, 1)
+	assert.Equal(t, NodeFn, nodes[0].Type)
+	assert.Equal(t, "ruby", nodes[0].Props["name"])
+	args, ok := nodes[0].Props["args"].(map[string]any)
+	require.True(t, ok)
+	assert.Equal(t, "text", args["rt"])
+}
+
+func TestParse_Fn_BoolArg(t *testing.T) {
+	nodes := Parse("$[spin.x content]")
+	require.Len(t, nodes, 1)
+	args := nodes[0].Props["args"].(map[string]any)
+	assert.Equal(t, true, args["x"])
+}
+
+func TestParse_Search(t *testing.T) {
+	nodes := Parse("hello search")
+	require.Len(t, nodes, 1)
+	assert.Equal(t, NodeSearch, nodes[0].Type)
+	assert.Equal(t, "hello", nodes[0].Props["query"])
+}
+
+func TestParse_Search_Japanese(t *testing.T) {
+	nodes := Parse("hello 検索")
+	require.Len(t, nodes, 1)
+	assert.Equal(t, NodeSearch, nodes[0].Type)
+}
+
+func TestParse_NestedBoldItalic(t *testing.T) {
+	nodes := Parse("**<i>bold italic</i>**")
+	require.Len(t, nodes, 1)
+	assert.Equal(t, NodeBold, nodes[0].Type)
+	require.Len(t, nodes[0].Children, 1)
+	assert.Equal(t, NodeItalic, nodes[0].Children[0].Type)
+}
+
+func TestParse_MixedContent(t *testing.T) {
+	nodes := Parse("hello **bold** world")
+	require.Len(t, nodes, 3)
+	assert.Equal(t, NodeText, nodes[0].Type)
+	assert.Equal(t, NodeBold, nodes[1].Type)
+	assert.Equal(t, NodeText, nodes[2].Type)
+}
+
+func TestParse_MentionInText(t *testing.T) {
+	nodes := Parse("hello @alice!")
+	require.Len(t, nodes, 3)
+	assert.Equal(t, NodeText, nodes[0].Type)
+	assert.Equal(t, NodeMention, nodes[1].Type)
+	assert.Equal(t, NodeText, nodes[2].Type)
+}
+
+func TestParseSimple_Text(t *testing.T) {
+	nodes := ParseSimple("**not bold**")
+	require.Len(t, nodes, 1)
+	assert.Equal(t, NodeText, nodes[0].Type)
+	assert.Equal(t, "**not bold**", nodes[0].textValue())
+}
+
+func TestParseSimple_EmojiCode(t *testing.T) {
+	nodes := ParseSimple(":smile:")
+	require.Len(t, nodes, 1)
+	assert.Equal(t, NodeEmojiCode, nodes[0].Type)
+}
+
+func TestParseSimple_UnicodeEmoji(t *testing.T) {
+	nodes := ParseSimple("😀 hello")
+	require.Len(t, nodes, 2)
+	assert.Equal(t, NodeUnicodeEmoji, nodes[0].Type)
+	assert.Equal(t, NodeText, nodes[1].Type)
+}
+
+func TestParseSimple_PlainTag(t *testing.T) {
+	nodes := ParseSimple("<plain>text</plain>")
+	require.Len(t, nodes, 1)
+	assert.Equal(t, NodePlain, nodes[0].Type)
+}
+
+func TestParse_Hashtag_WithBrackets(t *testing.T) {
+	nodes := Parse("#tag(sub)")
+	require.Len(t, nodes, 1)
+	assert.Equal(t, NodeHashtag, nodes[0].Type)
+	assert.Equal(t, "tag(sub)", nodes[0].Props["hashtag"])
+}
+
+func TestParse_MultilineQuote(t *testing.T) {
+	input := "> line1\n> line2\nnot quote"
+	nodes := Parse(input)
+	// quote + text
+	require.True(t, len(nodes) >= 1)
+	assert.Equal(t, NodeQuote, nodes[0].Type)
+}
+
+func TestParse_Hashtag_JapaneseBrackets(t *testing.T) {
+	nodes := Parse("#tag「sub」")
+	require.Len(t, nodes, 1)
+	assert.Equal(t, NodeHashtag, nodes[0].Type)
+	assert.Equal(t, "tag「sub」", nodes[0].Props["hashtag"])
+}
+
+func TestParse_Hashtag_FullWidthParens(t *testing.T) {
+	nodes := Parse("#tag（sub）")
+	require.Len(t, nodes, 1)
+	assert.Equal(t, NodeHashtag, nodes[0].Type)
+	assert.Equal(t, "tag（sub）", nodes[0].Props["hashtag"])
+}
+
+func TestParse_Hashtag_SquareBrackets(t *testing.T) {
+	nodes := Parse("#tag[sub]")
+	require.Len(t, nodes, 1)
+	assert.Equal(t, NodeHashtag, nodes[0].Type)
+	assert.Equal(t, "tag[sub]", nodes[0].Props["hashtag"])
+}
+
+func TestParse_UnicodeEmoji_WithSkinTone(t *testing.T) {
+	// 👋🏻 = U+1F44B U+1F3FB
+	nodes := Parse("👋🏻")
+	require.Len(t, nodes, 1)
+	assert.Equal(t, NodeUnicodeEmoji, nodes[0].Type)
+}
+
+func TestParse_UnicodeEmoji_DingbatRange(t *testing.T) {
+	// ✅ = U+2705
+	nodes := Parse("✅")
+	require.Len(t, nodes, 1)
+	assert.Equal(t, NodeUnicodeEmoji, nodes[0].Type)
+}
+
+func TestParse_UnicodeEmoji_RegionalIndicator(t *testing.T) {
+	// 🇯🇵 = U+1F1EF U+1F1F5
+	nodes := Parse("🇯🇵")
+	require.Len(t, nodes, 1)
+	assert.Equal(t, NodeUnicodeEmoji, nodes[0].Type)
+}
+
+func TestParse_UnicodeEmoji_Arrow(t *testing.T) {
+	// ⬛ = U+2B1B
+	nodes := Parse("⬛")
+	require.Len(t, nodes, 1)
+	assert.Equal(t, NodeUnicodeEmoji, nodes[0].Type)
+}
+
+func TestParse_UnicodeEmoji_LetterlikeSymbol(t *testing.T) {
+	// ™ = U+2122
+	nodes := Parse("™")
+	require.Len(t, nodes, 1)
+	assert.Equal(t, NodeUnicodeEmoji, nodes[0].Type)
+}
+
+func TestParse_UnicodeEmoji_ArrowRange(t *testing.T) {
+	// ← = U+2190
+	nodes := Parse("←")
+	require.Len(t, nodes, 1)
+	assert.Equal(t, NodeUnicodeEmoji, nodes[0].Type)
+}
+
+func TestParse_UnicodeEmoji_Copyright(t *testing.T) {
+	// © = U+00A9
+	nodes := Parse("©")
+	require.Len(t, nodes, 1)
+	assert.Equal(t, NodeUnicodeEmoji, nodes[0].Type)
+}
+
+func TestParse_UnicodeEmoji_Registered(t *testing.T) {
+	// ® = U+00AE
+	nodes := Parse("®")
+	require.Len(t, nodes, 1)
+	assert.Equal(t, NodeUnicodeEmoji, nodes[0].Type)
+}
+
+func TestParse_UnicodeEmoji_ExclamationMarks(t *testing.T) {
+	// ‼ = U+203C
+	nodes := Parse("‼")
+	require.Len(t, nodes, 1)
+	assert.Equal(t, NodeUnicodeEmoji, nodes[0].Type)
+}
+
+func TestParse_UnicodeEmoji_MiscTechnical(t *testing.T) {
+	// ⌚ = U+231A
+	nodes := Parse("⌚")
+	require.Len(t, nodes, 1)
+	assert.Equal(t, NodeUnicodeEmoji, nodes[0].Type)
+}
+
+func TestParse_UnicodeEmoji_SupplementalSymbols(t *testing.T) {
+	// 🤔 = U+1F914
+	nodes := Parse("🤔")
+	require.Len(t, nodes, 1)
+	assert.Equal(t, NodeUnicodeEmoji, nodes[0].Type)
+}
+
+func TestParse_UnicodeEmoji_ChessSymbol(t *testing.T) {
+	// 🩠 = U+1FA60 (not all fonts render)
+	nodes := Parse("\U0001FA00")
+	require.Len(t, nodes, 1)
+	assert.Equal(t, NodeUnicodeEmoji, nodes[0].Type)
+}
+
+func TestParse_UnicodeEmoji_ExtendedA(t *testing.T) {
+	// 🪐 = U+1FA90
+	nodes := Parse("🪐")
+	require.Len(t, nodes, 1)
+	assert.Equal(t, NodeUnicodeEmoji, nodes[0].Type)
+}
+
+func TestParse_URL_SquareBracketNesting(t *testing.T) {
+	nodes := Parse("https://example.com/[path]")
+	require.Len(t, nodes, 1)
+	assert.Equal(t, NodeURL, nodes[0].Type)
+	assert.Equal(t, "https://example.com/[path]", nodes[0].Props["url"])
+}
+
+func TestParse_URL_HTTP(t *testing.T) {
+	nodes := Parse("http://example.com/path")
+	require.Len(t, nodes, 1)
+	assert.Equal(t, NodeURL, nodes[0].Type)
+}
+
+func TestParse_Link_NotInLink(t *testing.T) {
+	// リンク内にリンクはネストできない
+	nodes := Parse("[outer [inner](https://inner.com)](https://outer.com)")
+	require.True(t, len(nodes) >= 1)
+	assert.Equal(t, NodeLink, nodes[0].Type)
+}
+
+func TestParse_Bold_Unclosed(t *testing.T) {
+	nodes := Parse("**unclosed")
+	// unclosed markup → text
+	require.True(t, len(nodes) >= 1)
+	assert.Equal(t, NodeText, nodes[0].Type)
+}
+
+func TestParse_InlineCode_Empty(t *testing.T) {
+	nodes := Parse("``") // empty code
+	require.True(t, len(nodes) >= 1)
+	assert.Equal(t, NodeText, nodes[0].Type)
+}
+
+func TestParse_MathInline_Empty(t *testing.T) {
+	nodes := Parse(`\(\)`)
+	require.True(t, len(nodes) >= 1)
+	assert.Equal(t, NodeText, nodes[0].Type)
+}
+
+func TestParse_MathBlock_Empty(t *testing.T) {
+	nodes := Parse(`\[\]`)
+	require.True(t, len(nodes) >= 1)
+	assert.Equal(t, NodeText, nodes[0].Type)
+}
+
+func TestParse_Fn_MissingSpace(t *testing.T) {
+	// $[name] without space → not a fn
+	nodes := Parse("$[name]")
+	require.True(t, len(nodes) >= 1)
+	assert.Equal(t, NodeText, nodes[0].Type)
+}
+
+func TestParse_Fn_EmptyName(t *testing.T) {
+	nodes := Parse("$[ content]")
+	require.True(t, len(nodes) >= 1)
+	assert.Equal(t, NodeText, nodes[0].Type)
+}
+
+func TestParse_EmojiCode_Invalid(t *testing.T) {
+	// emoji code with invalid character
+	nodes := Parse(":not valid:")
+	require.True(t, len(nodes) >= 1)
+	assert.Equal(t, NodeText, nodes[0].Type)
+}
+
+func TestParse_Mention_Trailing_Dot(t *testing.T) {
+	nodes := Parse("@user.")
+	require.True(t, len(nodes) >= 1)
+	assert.Equal(t, NodeMention, nodes[0].Type)
+	assert.Equal(t, "user", nodes[0].Props["username"])
+}
+
+func TestParse_Quote_NotAtLineStart(t *testing.T) {
+	nodes := Parse("text > not a quote")
+	require.True(t, len(nodes) >= 1)
+	assert.Equal(t, NodeText, nodes[0].Type)
+}
+
+func TestParse_CodeBlock_Unclosed(t *testing.T) {
+	nodes := Parse("```\nunclosed code")
+	require.True(t, len(nodes) >= 1)
+	assert.Equal(t, NodeText, nodes[0].Type)
+}
+
+func TestParse_PlainTag_Unclosed(t *testing.T) {
+	nodes := Parse("<plain>unclosed")
+	require.True(t, len(nodes) >= 1)
+	assert.Equal(t, NodeText, nodes[0].Type)
+}
+
+func TestParse_HTMLTag_Unclosed(t *testing.T) {
+	nodes := Parse("<b>unclosed")
+	require.True(t, len(nodes) >= 1)
+	assert.Equal(t, NodeText, nodes[0].Type)
+}
+
+func TestParse_Link_NoURL(t *testing.T) {
+	nodes := Parse("[label]()")
+	require.True(t, len(nodes) >= 1)
+	// empty URL → not a link
+	assert.Equal(t, NodeText, nodes[0].Type)
+}
+
+func TestParse_Fn_MultipleArgs(t *testing.T) {
+	nodes := Parse("$[spin.speed=0.5s,alternate content]")
+	require.Len(t, nodes, 1)
+	assert.Equal(t, NodeFn, nodes[0].Type)
+	args := nodes[0].Props["args"].(map[string]any)
+	assert.Equal(t, "0.5s", args["speed"])
+	assert.Equal(t, true, args["alternate"])
+}
+
+func TestParse_UnicodeEmoji_ZWJ(t *testing.T) {
+	// 👨‍💻 = U+1F468 U+200D U+1F4BB (ZWJ sequence)
+	nodes := Parse("👨\u200d💻")
+	require.Len(t, nodes, 1)
+	assert.Equal(t, NodeUnicodeEmoji, nodes[0].Type)
+}
+
+func TestParse_Search_BracketSuffix(t *testing.T) {
+	nodes := Parse("query [検索]")
+	require.Len(t, nodes, 1)
+	assert.Equal(t, NodeSearch, nodes[0].Type)
+}
+
+func TestParse_Search_NotMidLine(t *testing.T) {
+	nodes := Parse("hello\nquery search")
+	// 2行目が search
+	found := false
+	for _, n := range nodes {
+		if n.Type == NodeSearch {
+			found = true
+		}
+	}
+	assert.True(t, found)
+}
+
+func TestParse_InlineCode_AcuteAccent(t *testing.T) {
+	// ´ 内のコードは失敗
+	nodes := Parse("`co´de`")
+	require.True(t, len(nodes) >= 1)
+	assert.Equal(t, NodeText, nodes[0].Type)
+}
+
+func TestParse_StrikeWave_WithNewline(t *testing.T) {
+	// strikeWave は改行を含まない
+	nodes := Parse("~~str\nike~~")
+	require.True(t, len(nodes) >= 1)
+	assert.NotEqual(t, NodeStrike, nodes[0].Type)
+}
+
+func TestParse_Bold_Empty(t *testing.T) {
+	nodes := Parse("****")
+	require.True(t, len(nodes) >= 1)
+	assert.Equal(t, NodeText, nodes[0].Type)
+}
+
+func TestParse_ItalicAsta_AfterAlpha(t *testing.T) {
+	// 直前が英数字なら italic にならない
+	nodes := Parse("a*b*")
+	require.True(t, len(nodes) >= 1)
+	assert.Equal(t, NodeText, nodes[0].Type)
+}

--- a/internal/activitypub/renderer.go
+++ b/internal/activitypub/renderer.go
@@ -1,8 +1,12 @@
 package activitypub
 
 import (
+	"encoding/json"
+	"log/slog"
+	"strings"
 	"time"
 
+	"github.com/shiroha-a/mk/internal/activitypub/mfm"
 	"github.com/shiroha-a/mk/internal/misc/id"
 	"github.com/shiroha-a/mk/internal/model"
 )
@@ -79,10 +83,29 @@ type MentionResolver interface {
 	ResolveMention(userID string) (name, uri string, ok bool)
 }
 
+// FileResolver loads drive files by ID for rendering Note attachments.
+type FileResolver interface {
+	FindByIDs(ids []string) ([]*model.DriveFile, error)
+}
+
+// EmojiResolver resolves custom emoji names to their model data.
+type EmojiResolver interface {
+	FindByNameAndHost(name string, host *string) (*model.Emoji, error)
+}
+
+// NoteResolver resolves a note by ID (for quote renote URI lookup).
+type NoteResolver interface {
+	FindByID(id string) (*model.Note, error)
+}
+
 // Renderer converts model entities into AS objects.
 type Renderer struct {
 	urls            *URLBuilder
 	mentionResolver MentionResolver
+	fileResolver    FileResolver
+	emojiResolver   EmojiResolver
+	noteResolver    NoteResolver
+	host            string // ローカルホスト名 (MFM変換用)
 }
 
 // NewRenderer constructs a Renderer.
@@ -96,14 +119,41 @@ func (r *Renderer) SetMentionResolver(mr MentionResolver) {
 	r.mentionResolver = mr
 }
 
+// SetFileResolver attaches a FileResolver for Note attachment rendering.
+func (r *Renderer) SetFileResolver(fr FileResolver) {
+	r.fileResolver = fr
+}
+
+// SetEmojiResolver attaches an EmojiResolver for custom emoji tags.
+func (r *Renderer) SetEmojiResolver(er EmojiResolver) {
+	r.emojiResolver = er
+}
+
+// SetNoteResolver attaches a NoteResolver for quote renote URI lookup.
+func (r *Renderer) SetNoteResolver(nr NoteResolver) {
+	r.noteResolver = nr
+}
+
+// SetHost sets the local hostname for MFM→HTML conversion.
+func (r *Renderer) SetHost(host string) {
+	r.host = host
+}
+
 // RenderPerson packs a local user into a Person actor object.
+// profile は nil でもよい (その場合 summary 等のフィールドは省略される)。
 // publicKeyPEM はリポジトリから取得した公開鍵PEM文字列。
-func (r *Renderer) RenderPerson(u *model.User, publicKeyPEM string) *Person {
+func (r *Renderer) RenderPerson(u *model.User, profile *model.UserProfile, publicKeyPEM string) *Person {
 	uri := r.urls.UserURI(u.ID)
+
+	actorType := "Person"
+	if u.IsBot {
+		actorType = "Service"
+	}
+
 	p := &Person{
 		Object: Object{
 			ID:   uri,
-			Type: "Person",
+			Type: actorType,
 			Name: stringValue(u.Name),
 		},
 		Inbox:             r.urls.UserInbox(u.ID),
@@ -120,32 +170,135 @@ func (r *Renderer) RenderPerson(u *model.User, publicKeyPEM string) *Person {
 		},
 		ManuallyApproves: u.IsLocked,
 		Discoverable:     u.IsExplorable,
+		IsCat:            u.IsCat,
 	}
 	if u.AvatarURL != nil {
 		p.Icon = &Image{Type: "Image", URL: *u.AvatarURL}
 	}
+	if u.BannerURL != nil {
+		p.Image = &Image{Type: "Image", URL: *u.BannerURL}
+	}
+	if u.MovedToURI != nil && *u.MovedToURI != "" {
+		p.MovedTo = *u.MovedToURI
+	}
+	if u.AlsoKnownAs != nil && *u.AlsoKnownAs != "" {
+		p.AlsoKnownAs = strings.Split(*u.AlsoKnownAs, ",")
+	}
+	if u.Featured != nil && *u.Featured != "" {
+		p.Featured = *u.Featured
+	}
+
+	// profile から追加フィールドを埋める
+	if profile != nil {
+		r.enrichPersonFromProfile(p, profile)
+	}
+
+	// ユーザーのカスタム絵文字をEmoji tagとして追加
+	r.addEmojiTags(&p.Tag, u.Emojis, nil)
+
 	AddContext(p)
 	return p
 }
 
+// enrichPersonFromProfile fills profile-derived fields into Person.
+func (r *Renderer) enrichPersonFromProfile(p *Person, profile *model.UserProfile) {
+	if profile.Description != nil && *profile.Description != "" {
+		desc := *profile.Description
+		// MFM → HTML
+		nodes := mfm.Parse(desc)
+		p.Summary = mfm.ToHTML(nodes, r.host)
+		p.MisskeySummary = desc
+	}
+	if profile.Birthday != nil && *profile.Birthday != "" {
+		p.VcardBday = *profile.Birthday
+	}
+	if profile.Location != nil && *profile.Location != "" {
+		p.VcardAddress = *profile.Location
+	}
+	if profile.FollowedMessage != nil && *profile.FollowedMessage != "" {
+		p.MisskeyFollowedMessage = *profile.FollowedMessage
+	}
+
+	// profile.Fields → PropertyValue attachment
+	if len(profile.Fields) > 0 {
+		var fields []struct {
+			Name  string `json:"name"`
+			Value string `json:"value"`
+		}
+		if err := json.Unmarshal(profile.Fields, &fields); err == nil && len(fields) > 0 {
+			for _, f := range fields {
+				p.Attachment = append(p.Attachment, PropertyValue{
+					Type:  "PropertyValue",
+					Name:  f.Name,
+					Value: f.Value,
+				})
+			}
+		}
+	}
+}
+
 // RenderNote packs a local note into a Note object.
 func (r *Renderer) RenderNote(n *model.Note, idGen id.Generator) *Note {
+	text := stringValue(n.Text)
+
+	// MFM → HTML変換
+	var htmlContent string
+	var nodes []*mfm.Node
+	if text != "" {
+		nodes = mfm.Parse(text)
+		htmlContent = mfm.ToHTML(nodes, r.host)
+	}
+
 	out := &Note{
 		Object: Object{
 			ID:   r.urls.NoteURI(n.ID),
 			Type: "Note",
 		},
 		AttributedTo: r.urls.UserURI(n.UserID),
-		Content:      stringValue(n.Text),
+		Content:      htmlContent,
 		Published:    parseNoteTime(n.ID, idGen),
 		Sensitive:    n.CW != nil && *n.CW != "",
 	}
+
+	// _misskey_content / source: 標準ノードのみなら省略 (TS版 noMisskeyContent)
+	if text != "" && !mfm.IsSimple(nodes) {
+		out.MisskeyContent = text
+		out.Source = &Source{
+			Content:   text,
+			MediaType: "text/x.misskeymarkdown",
+		}
+	}
+
 	if n.CW != nil {
 		out.Summary = *n.CW
 	}
 	if n.ReplyID != nil {
 		out.InReplyTo = r.urls.NoteURI(*n.ReplyID)
 	}
+
+	// Quote renote: text付きrenoteは_misskey_quote + quoteUrlを付ける
+	if n.RenoteID != nil && text != "" {
+		quoteURI := r.resolveNoteURI(*n.RenoteID)
+		if quoteURI != "" {
+			out.MisskeyQuote = quoteURI
+			out.QuoteURL = quoteURI
+		}
+	}
+
+	// 添付ファイル
+	r.addAttachments(out, n)
+
+	// Hashtag tags
+	for _, tag := range n.Tags {
+		out.Tag = append(out.Tag, Hashtag{
+			Type: "Hashtag",
+			Href: "https://" + r.host + "/tags/" + tag,
+			Name: "#" + tag,
+		})
+	}
+
+	// Custom emoji tags
+	r.addEmojiTags(&out.Tag, n.Emojis, nil)
 
 	to, cc := r.addressing(n)
 
@@ -175,6 +328,65 @@ func (r *Renderer) RenderNote(n *model.Note, idGen id.Generator) *Note {
 
 	AddContext(out)
 	return out
+}
+
+// addAttachments loads drive files and adds Document entries to the note.
+func (r *Renderer) addAttachments(out *Note, n *model.Note) {
+	if r.fileResolver == nil || len(n.FileIDs) == 0 {
+		return
+	}
+	files, err := r.fileResolver.FindByIDs(n.FileIDs)
+	if err != nil {
+		slog.Warn("renderer: failed to load drive files", "noteId", n.ID, "err", err)
+		return
+	}
+	for _, f := range files {
+		doc := Document{
+			Type:      "Document",
+			MediaType: f.Type,
+			URL:       f.URL,
+			Name:      stringValue(f.Comment),
+			Sensitive: f.IsSensitive,
+		}
+		out.Attachment = append(out.Attachment, doc)
+		if f.IsSensitive {
+			out.Sensitive = true
+		}
+	}
+}
+
+// resolveNoteURI returns the canonical URI for a note (remote URI or local).
+func (r *Renderer) resolveNoteURI(noteID string) string {
+	if r.noteResolver != nil {
+		if note, err := r.noteResolver.FindByID(noteID); err == nil {
+			if note.URI != nil && *note.URI != "" {
+				return *note.URI
+			}
+		}
+	}
+	return r.urls.NoteURI(noteID)
+}
+
+// addEmojiTags resolves custom emoji names and appends EmojiTag entries.
+func (r *Renderer) addEmojiTags(tags *[]any, emojiNames []string, host *string) {
+	if r.emojiResolver == nil || len(emojiNames) == 0 {
+		return
+	}
+	for _, name := range emojiNames {
+		emoji, err := r.emojiResolver.FindByNameAndHost(name, host)
+		if err != nil {
+			continue
+		}
+		tag := EmojiTag{
+			Type: "Emoji",
+			Name: ":" + emoji.Name + ":",
+			Icon: Image{Type: "Image", URL: emoji.PublicURL},
+		}
+		if emoji.URI != nil {
+			tag.ID = *emoji.URI
+		}
+		*tags = append(*tags, tag)
+	}
 }
 
 // RenderCreate wraps a Note into a Create activity addressed to the same audience.

--- a/internal/activitypub/renderer.go
+++ b/internal/activitypub/renderer.go
@@ -1,6 +1,8 @@
 package activitypub
 
 import (
+	"crypto/sha256"
+	"encoding/hex"
 	"encoding/json"
 	"log/slog"
 	"strings"
@@ -67,9 +69,15 @@ func (b *URLBuilder) CreateActivityURI(noteID string) string {
 	return b.NoteURI(noteID) + "/activity"
 }
 
-// FollowURI returns the URI for a Follow activity (followerID-followeeID).
+// FollowURI returns the URI for a Follow activity.
+// followeeIDが完全なURIの場合はハッシュ化してパスセグメントに埋め込む。
 func (b *URLBuilder) FollowURI(followerID, followeeID string) string {
-	return b.baseURL + "/follows/" + followerID + "/" + followeeID
+	id := followeeID
+	if strings.Contains(followeeID, "/") {
+		h := sha256.Sum256([]byte(followeeID))
+		id = hex.EncodeToString(h[:16])
+	}
+	return b.baseURL + "/follows/" + followerID + "/" + id
 }
 
 // MentionResolver resolves a note.Mentions entry (user ID) into the data
@@ -79,6 +87,9 @@ func (b *URLBuilder) FollowURI(followerID, followeeID string) string {
 //
 // uri はローカルユーザーなら urls.UserURI(user.ID)、リモートユーザーなら
 // user.URI を返す。name は Misskey 互換で "@username" / "@username@host"。
+//
+// TODO: ok bool ではDB障害とユーザー未存在を区別できない。
+// 将来的に (name, uri string, err error) に変更してログ出力を改善する。
 type MentionResolver interface {
 	ResolveMention(userID string) (name, uri string, ok bool)
 }
@@ -560,6 +571,7 @@ func stringValue(p *string) string {
 func parseNoteTime(noteID string, idGen id.Generator) string {
 	t, err := idGen.ParseTime(noteID)
 	if err != nil {
+		slog.Warn("renderer: failed to parse note ID for timestamp, using time.Now()", "noteId", noteID, "err", err)
 		return time.Now().UTC().Format(time.RFC3339)
 	}
 	return t.UTC().Format(time.RFC3339)

--- a/internal/activitypub/renderer_test.go
+++ b/internal/activitypub/renderer_test.go
@@ -1,6 +1,7 @@
 package activitypub
 
 import (
+	"errors"
 	"testing"
 	"time"
 
@@ -9,6 +10,7 @@ import (
 	"github.com/shiroha-a/mk/internal/model"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"gorm.io/datatypes"
 )
 
 func newRenderer() *Renderer {
@@ -41,7 +43,7 @@ func TestRenderer_RenderPerson(t *testing.T) {
 		IsLocked:     true,
 		IsExplorable: true,
 	}
-	p := r.RenderPerson(u, "PUBKEY")
+	p := r.RenderPerson(u, nil, "PUBKEY")
 	assert.Equal(t, "https://example.com/users/u1", p.ID)
 	assert.Equal(t, "Person", p.Type)
 	assert.Equal(t, "alice", p.PreferredUsername)
@@ -56,7 +58,7 @@ func TestRenderer_RenderPerson(t *testing.T) {
 func TestRenderer_RenderPerson_NoOptionalFields(t *testing.T) {
 	r := newRenderer()
 	u := &model.User{ID: "u1", Username: "alice"}
-	p := r.RenderPerson(u, "PUBKEY")
+	p := r.RenderPerson(u, nil, "PUBKEY")
 	assert.Empty(t, p.Name)
 	assert.Nil(t, p.Icon)
 	assert.False(t, p.ManuallyApproves)
@@ -323,4 +325,311 @@ func TestRenderer_RenderDelete(t *testing.T) {
 	assert.Equal(t, "Tombstone", tomb.Type)
 	assert.Equal(t, "https://example.com/notes/n1", tomb.ID)
 	assert.Contains(t, d.To, Public)
+}
+
+func TestRenderer_RenderPerson_Bot(t *testing.T) {
+	r := newRenderer()
+	u := &model.User{ID: "u1", Username: "bot", IsBot: true}
+	p := r.RenderPerson(u, nil, "PUBKEY")
+	assert.Equal(t, "Service", p.Type)
+}
+
+func TestRenderer_RenderPerson_WithProfile(t *testing.T) {
+	r := newRenderer()
+	r.SetHost("example.com")
+	desc := "**hello** world"
+	bday := "2000-01-01"
+	loc := "Tokyo"
+	followedMsg := "Thanks!"
+	fields := datatypes.JSON(`[{"name":"Website","value":"https://example.com"}]`)
+	u := &model.User{ID: "u1", Username: "alice", IsCat: true}
+	profile := &model.UserProfile{
+		Description:     &desc,
+		Birthday:        &bday,
+		Location:        &loc,
+		FollowedMessage: &followedMsg,
+		Fields:          fields,
+	}
+	p := r.RenderPerson(u, profile, "PUBKEY")
+	assert.Contains(t, p.Summary, "<b>hello</b>")
+	assert.Equal(t, desc, p.MisskeySummary)
+	assert.Equal(t, "2000-01-01", p.VcardBday)
+	assert.Equal(t, "Tokyo", p.VcardAddress)
+	assert.Equal(t, "Thanks!", p.MisskeyFollowedMessage)
+	assert.True(t, p.IsCat)
+	require.Len(t, p.Attachment, 1)
+	pv, ok := p.Attachment[0].(PropertyValue)
+	require.True(t, ok)
+	assert.Equal(t, "PropertyValue", pv.Type)
+	assert.Equal(t, "Website", pv.Name)
+	assert.Equal(t, "https://example.com", pv.Value)
+}
+
+func TestRenderer_RenderPerson_BannerAndMovedTo(t *testing.T) {
+	r := newRenderer()
+	banner := "https://example.com/banner.png"
+	movedTo := "https://other.example/users/alice"
+	alsoKnownAs := "https://other.example/users/alice,https://third.example/users/a"
+	featured := "https://example.com/users/u1/collections/featured"
+	u := &model.User{
+		ID:          "u1",
+		Username:    "alice",
+		BannerURL:   &banner,
+		MovedToURI:  &movedTo,
+		AlsoKnownAs: &alsoKnownAs,
+		Featured:    &featured,
+	}
+	p := r.RenderPerson(u, nil, "PUBKEY")
+	require.NotNil(t, p.Image)
+	assert.Equal(t, banner, p.Image.URL)
+	assert.Equal(t, movedTo, p.MovedTo)
+	assert.Equal(t, []string{"https://other.example/users/alice", "https://third.example/users/a"}, p.AlsoKnownAs)
+	assert.Equal(t, featured, p.Featured)
+}
+
+// stubFileResolver returns fixed drive files.
+type stubFileResolver struct {
+	files []*model.DriveFile
+	err   error
+}
+
+func (s *stubFileResolver) FindByIDs(_ []string) ([]*model.DriveFile, error) {
+	return s.files, s.err
+}
+
+func TestRenderer_RenderNote_WithAttachment(t *testing.T) {
+	r := newRenderer()
+	comment := "photo"
+	r.SetFileResolver(&stubFileResolver{files: []*model.DriveFile{
+		{Type: "image/png", URL: "https://example.com/files/f1.png", Comment: &comment, IsSensitive: false},
+		{Type: "video/mp4", URL: "https://example.com/files/f2.mp4", IsSensitive: true},
+	}})
+	idGen := newIDGen(t)
+	n := &model.Note{
+		ID:         idGen.Generate(time.Now()),
+		UserID:     "author",
+		Visibility: model.NoteVisibilityPublic,
+		FileIDs:    pq.StringArray{"f1", "f2"},
+	}
+	out := r.RenderNote(n, idGen)
+	require.Len(t, out.Attachment, 2)
+	doc0, ok := out.Attachment[0].(Document)
+	require.True(t, ok)
+	assert.Equal(t, "Document", doc0.Type)
+	assert.Equal(t, "image/png", doc0.MediaType)
+	assert.Equal(t, "photo", doc0.Name)
+	assert.False(t, doc0.Sensitive)
+	doc1, ok := out.Attachment[1].(Document)
+	require.True(t, ok)
+	assert.True(t, doc1.Sensitive)
+	// sensitive ファイルがあるのでNote自体もsensitiveになる
+	assert.True(t, out.Sensitive)
+}
+
+func TestRenderer_RenderNote_AttachmentError(t *testing.T) {
+	r := newRenderer()
+	r.SetFileResolver(&stubFileResolver{err: errors.New("db error")})
+	idGen := newIDGen(t)
+	n := &model.Note{
+		ID:         idGen.Generate(time.Now()),
+		UserID:     "author",
+		Visibility: model.NoteVisibilityPublic,
+		FileIDs:    pq.StringArray{"f1"},
+	}
+	out := r.RenderNote(n, idGen)
+	// エラー時は添付なしで進む
+	assert.Empty(t, out.Attachment)
+}
+
+func TestRenderer_RenderNote_WithMFMContent(t *testing.T) {
+	r := newRenderer()
+	r.SetHost("example.com")
+	idGen := newIDGen(t)
+	text := "**bold** and `code`"
+	n := &model.Note{
+		ID:         idGen.Generate(time.Now()),
+		UserID:     "author",
+		Text:       &text,
+		Visibility: model.NoteVisibilityPublic,
+	}
+	out := r.RenderNote(n, idGen)
+	assert.Contains(t, out.Content, "<b>bold</b>")
+	assert.Contains(t, out.Content, "<code>code</code>")
+	// MFMマークアップあり → _misskey_content / source が設定される
+	assert.Equal(t, text, out.MisskeyContent)
+	require.NotNil(t, out.Source)
+	assert.Equal(t, text, out.Source.Content)
+	assert.Equal(t, "text/x.misskeymarkdown", out.Source.MediaType)
+}
+
+func TestRenderer_RenderNote_SimpleContent(t *testing.T) {
+	r := newRenderer()
+	idGen := newIDGen(t)
+	text := "hello world"
+	n := &model.Note{
+		ID:         idGen.Generate(time.Now()),
+		UserID:     "author",
+		Text:       &text,
+		Visibility: model.NoteVisibilityPublic,
+	}
+	out := r.RenderNote(n, idGen)
+	assert.Equal(t, "hello world", out.Content)
+	// 単純テキストのみ → _misskey_content / source 省略
+	assert.Empty(t, out.MisskeyContent)
+	assert.Nil(t, out.Source)
+}
+
+// stubNoteResolver returns a fixed note.
+type stubNoteResolver struct {
+	note *model.Note
+	err  error
+}
+
+func (s *stubNoteResolver) FindByID(_ string) (*model.Note, error) {
+	return s.note, s.err
+}
+
+func TestRenderer_RenderNote_QuoteRenote(t *testing.T) {
+	r := newRenderer()
+	remoteURI := "https://remote.example/notes/orig"
+	r.SetNoteResolver(&stubNoteResolver{note: &model.Note{URI: &remoteURI}})
+	idGen := newIDGen(t)
+	renoteID := "renote-target"
+	text := "quoting this"
+	n := &model.Note{
+		ID:         idGen.Generate(time.Now()),
+		UserID:     "author",
+		Text:       &text,
+		RenoteID:   &renoteID,
+		Visibility: model.NoteVisibilityPublic,
+	}
+	out := r.RenderNote(n, idGen)
+	assert.Equal(t, remoteURI, out.MisskeyQuote)
+	assert.Equal(t, remoteURI, out.QuoteURL)
+}
+
+func TestRenderer_RenderNote_QuoteRenote_LocalFallback(t *testing.T) {
+	r := newRenderer()
+	// noteResolver返すノートにURIがない → ローカルURIフォールバック
+	r.SetNoteResolver(&stubNoteResolver{note: &model.Note{}})
+	idGen := newIDGen(t)
+	renoteID := "local-note"
+	text := "quoting"
+	n := &model.Note{
+		ID:         idGen.Generate(time.Now()),
+		UserID:     "author",
+		Text:       &text,
+		RenoteID:   &renoteID,
+		Visibility: model.NoteVisibilityPublic,
+	}
+	out := r.RenderNote(n, idGen)
+	assert.Equal(t, "https://example.com/notes/local-note", out.MisskeyQuote)
+}
+
+func TestRenderer_RenderNote_HashtagTag(t *testing.T) {
+	r := newRenderer()
+	r.SetHost("example.com")
+	idGen := newIDGen(t)
+	n := &model.Note{
+		ID:         idGen.Generate(time.Now()),
+		UserID:     "author",
+		Visibility: model.NoteVisibilityPublic,
+		Tags:       pq.StringArray{"golang", "misskey"},
+	}
+	out := r.RenderNote(n, idGen)
+	require.Len(t, out.Tag, 2)
+	ht0, ok := out.Tag[0].(Hashtag)
+	require.True(t, ok)
+	assert.Equal(t, "Hashtag", ht0.Type)
+	assert.Equal(t, "#golang", ht0.Name)
+	assert.Equal(t, "https://example.com/tags/golang", ht0.Href)
+}
+
+// stubEmojiResolver returns a fixed emoji.
+type stubEmojiResolver struct {
+	emojis map[string]*model.Emoji
+}
+
+func (s *stubEmojiResolver) FindByNameAndHost(name string, _ *string) (*model.Emoji, error) {
+	e, ok := s.emojis[name]
+	if !ok {
+		return nil, errors.New("not found")
+	}
+	return e, nil
+}
+
+func TestRenderer_RenderNote_EmojiTag(t *testing.T) {
+	r := newRenderer()
+	emojiURI := "https://example.com/emojis/blobcat"
+	r.SetEmojiResolver(&stubEmojiResolver{emojis: map[string]*model.Emoji{
+		"blobcat": {Name: "blobcat", PublicURL: "https://example.com/files/blobcat.webp", URI: &emojiURI},
+	}})
+	idGen := newIDGen(t)
+	n := &model.Note{
+		ID:         idGen.Generate(time.Now()),
+		UserID:     "author",
+		Visibility: model.NoteVisibilityPublic,
+		Emojis:     pq.StringArray{"blobcat", "unknown"},
+	}
+	out := r.RenderNote(n, idGen)
+	// "unknown"は解決失敗してスキップされる
+	require.Len(t, out.Tag, 1)
+	et, ok := out.Tag[0].(EmojiTag)
+	require.True(t, ok)
+	assert.Equal(t, "Emoji", et.Type)
+	assert.Equal(t, ":blobcat:", et.Name)
+	assert.Equal(t, "https://example.com/files/blobcat.webp", et.Icon.URL)
+	assert.Equal(t, emojiURI, et.ID)
+}
+
+func TestRenderer_RenderPerson_EmojiTag(t *testing.T) {
+	r := newRenderer()
+	r.SetEmojiResolver(&stubEmojiResolver{emojis: map[string]*model.Emoji{
+		"verified": {Name: "verified", PublicURL: "https://example.com/files/verified.webp"},
+	}})
+	u := &model.User{
+		ID:       "u1",
+		Username: "alice",
+		Emojis:   pq.StringArray{"verified"},
+	}
+	p := r.RenderPerson(u, nil, "PUBKEY")
+	require.Len(t, p.Tag, 1)
+	et, ok := p.Tag[0].(EmojiTag)
+	require.True(t, ok)
+	assert.Equal(t, ":verified:", et.Name)
+}
+
+func TestRenderer_RenderNote_ContextIncludesMisskey(t *testing.T) {
+	r := newRenderer()
+	idGen := newIDGen(t)
+	n := &model.Note{
+		ID:         idGen.Generate(time.Now()),
+		UserID:     "author",
+		Visibility: model.NoteVisibilityPublic,
+	}
+	out := r.RenderNote(n, idGen)
+	ctx, ok := out.Context.([]any)
+	require.True(t, ok)
+	assert.Contains(t, ctx, ContextURL)
+	assert.Contains(t, ctx, SecurityContextURL)
+	// MisskeyContextのmapが含まれているか確認
+	var hasMk bool
+	for _, c := range ctx {
+		if m, ok := c.(map[string]any); ok {
+			if _, exists := m["misskey"]; exists {
+				hasMk = true
+			}
+		}
+	}
+	assert.True(t, hasMk, "context should include MisskeyContext map")
+}
+
+func TestRenderer_SetResolvers(t *testing.T) {
+	r := newRenderer()
+	// カバレッジ用: 各setter呼び出し
+	r.SetFileResolver(nil)
+	r.SetEmojiResolver(nil)
+	r.SetNoteResolver(nil)
+	r.SetHost("example.com")
+	assert.Equal(t, "example.com", r.host)
 }

--- a/internal/activitypub/renderer_test.go
+++ b/internal/activitypub/renderer_test.go
@@ -2,6 +2,7 @@ package activitypub
 
 import (
 	"errors"
+	"strings"
 	"testing"
 	"time"
 
@@ -28,7 +29,18 @@ func TestURLBuilder_Helpers(t *testing.T) {
 	assert.Equal(t, "https://example.com/inbox", b.SharedInbox())
 	assert.Equal(t, "https://example.com/notes/n1", b.NoteURI("n1"))
 	assert.Equal(t, "https://example.com/notes/n1/activity", b.CreateActivityURI("n1"))
+	// 短いIDはそのまま使われる
 	assert.Equal(t, "https://example.com/follows/a/b", b.FollowURI("a", "b"))
+}
+
+func TestURLBuilder_FollowURI_FullURI(t *testing.T) {
+	b := NewURLBuilder("https://example.com")
+	// 完全なURIはハッシュ化されてパスセグメントに入る
+	uri := b.FollowURI("alice", "https://remote.example/users/bob")
+	assert.True(t, strings.HasPrefix(uri, "https://example.com/follows/alice/"), "URI should start with follows prefix")
+	assert.NotContains(t, uri, "https://remote.example")
+	// 同じ入力で同じ出力
+	assert.Equal(t, uri, b.FollowURI("alice", "https://remote.example/users/bob"))
 }
 
 func TestRenderer_RenderPerson(t *testing.T) {
@@ -242,6 +254,9 @@ func TestRenderer_RenderFollow(t *testing.T) {
 	assert.Equal(t, "Follow", f.Type)
 	assert.Equal(t, "https://example.com/users/alice", f.Actor)
 	assert.Equal(t, "https://remote.example/users/bob", f.Object)
+	// IDはURI部分がハッシュ化されている
+	assert.Contains(t, f.ID, "https://example.com/follows/alice/")
+	assert.NotContains(t, f.ID, "https://remote.example")
 }
 
 func TestRenderer_RenderAccept(t *testing.T) {

--- a/internal/activitypub/types.go
+++ b/internal/activitypub/types.go
@@ -46,33 +46,48 @@ type Image struct {
 // Person represents a user actor.
 type Person struct {
 	Object
-	Inbox             string    `json:"inbox"`
-	Outbox            string    `json:"outbox"`
-	Followers         string    `json:"followers"`
-	Following         string    `json:"following"`
-	PreferredUsername string    `json:"preferredUsername"`
-	Summary           string    `json:"summary,omitempty"`
-	URL               string    `json:"url,omitempty"`
-	Endpoints         Endpoints `json:"endpoints,omitzero"`
-	PublicKey         PublicKey `json:"publicKey"`
-	Icon              *Image    `json:"icon,omitempty"`
-	ManuallyApproves  bool      `json:"manuallyApprovesFollowers,omitempty"`
-	Discoverable      bool      `json:"discoverable,omitempty"`
+	Inbox                  string    `json:"inbox"`
+	Outbox                 string    `json:"outbox"`
+	Followers              string    `json:"followers"`
+	Following              string    `json:"following"`
+	PreferredUsername      string    `json:"preferredUsername"`
+	Summary                string    `json:"summary,omitempty"`
+	URL                    string    `json:"url,omitempty"`
+	Endpoints              Endpoints `json:"endpoints,omitzero"`
+	PublicKey              PublicKey `json:"publicKey"`
+	Icon                   *Image    `json:"icon,omitempty"`
+	Image                  *Image    `json:"image,omitempty"`
+	Attachment             []any     `json:"attachment,omitempty"`
+	Tag                    []any     `json:"tag,omitempty"`
+	Featured               string    `json:"featured,omitempty"`
+	ManuallyApproves       bool      `json:"manuallyApprovesFollowers,omitempty"`
+	Discoverable           bool      `json:"discoverable,omitempty"`
+	IsCat                  bool      `json:"isCat,omitempty"`
+	VcardBday              string    `json:"vcard:bday,omitempty"`
+	VcardAddress           string    `json:"vcard:Address,omitempty"`
+	MisskeySummary         string    `json:"_misskey_summary,omitempty"`
+	MisskeyFollowedMessage string    `json:"_misskey_followedMessage,omitempty"`
+	MovedTo                string    `json:"movedTo,omitempty"`
+	AlsoKnownAs            []string  `json:"alsoKnownAs,omitempty"`
 }
 
 // Note represents a note object (microblog post).
 type Note struct {
 	Object
-	AttributedTo string   `json:"attributedTo"`
-	Content      string   `json:"content"`
-	Source       *Source  `json:"source,omitempty"`
-	Published    string   `json:"published"`
-	To           []string `json:"to"`
-	CC           []string `json:"cc,omitempty"`
-	InReplyTo    string   `json:"inReplyTo,omitempty"`
-	Summary      string   `json:"summary,omitempty"`
-	Sensitive    bool     `json:"sensitive,omitempty"`
-	Tag          []any    `json:"tag,omitempty"`
+	AttributedTo   string   `json:"attributedTo"`
+	Content        string   `json:"content"`
+	Source         *Source  `json:"source,omitempty"`
+	Published      string   `json:"published"`
+	To             []string `json:"to"`
+	CC             []string `json:"cc,omitempty"`
+	InReplyTo      string   `json:"inReplyTo,omitempty"`
+	Summary        string   `json:"summary,omitempty"`
+	Sensitive      bool     `json:"sensitive,omitempty"`
+	Tag            []any    `json:"tag,omitempty"`
+	Attachment     []any    `json:"attachment,omitempty"`
+	MisskeyContent string   `json:"_misskey_content,omitempty"`
+	MisskeyQuote   string   `json:"_misskey_quote,omitempty"`
+	QuoteURL       string   `json:"quoteUrl,omitempty"`
 }
 
 // Mention is an ActivityStreams Mention tag used inside Note.tag to inform
@@ -96,6 +111,38 @@ func NewMention(href, name string) Mention {
 type Source struct {
 	Content   string `json:"content"`
 	MediaType string `json:"mediaType"`
+}
+
+// Document represents an attached file (image/video/audio/...) in a Note.
+type Document struct {
+	Type      string `json:"type"` // "Document"
+	MediaType string `json:"mediaType"`
+	URL       string `json:"url"`
+	Name      string `json:"name,omitempty"`
+	Sensitive bool   `json:"sensitive,omitempty"`
+}
+
+// PropertyValue represents a profile field (schema.org PropertyValue).
+type PropertyValue struct {
+	Type  string `json:"type"` // "PropertyValue"
+	Name  string `json:"name"`
+	Value string `json:"value"`
+}
+
+// Hashtag is an ActivityStreams Hashtag tag.
+type Hashtag struct {
+	Type string `json:"type"` // "Hashtag"
+	Href string `json:"href"`
+	Name string `json:"name"` // "#tag"
+}
+
+// EmojiTag represents a toot:Emoji tag for custom emoji.
+type EmojiTag struct {
+	Type    string `json:"type"` // "Emoji"
+	Name    string `json:"name"` // ":name:"
+	Icon    Image  `json:"icon"`
+	ID      string `json:"id,omitempty"`
+	Updated string `json:"updated,omitempty"`
 }
 
 // Activity is the base type embedded by all activity types.
@@ -170,34 +217,59 @@ type Announce struct {
 	Object string `json:"object"` // target note URI
 }
 
-// AddContext attaches the standard AS+security context to any object that
-// embeds Object. 配列で持つことで複数 vocabulary を表現する。
+// MisskeyContext は Misskey/Mastodon/schema.org 拡張語彙を含むコンテキストオブジェクト。
+// TS版 contexts.ts と同等。
+var MisskeyContext = map[string]any{
+	"misskey":                  "https://misskey-hub.net/ns#",
+	"toot":                     "http://joinmastodon.org/ns#",
+	"schema":                   "http://schema.org/",
+	"vcard":                    "http://www.w3.org/2006/vcard/ns#",
+	"Key":                      SecurityContextURL + "#Key",
+	"Hashtag":                  ContextURL + "#Hashtag",
+	"sensitive":                ContextURL + "#sensitive",
+	"quoteUrl":                 "https://misskey-hub.net/ns#quoteUrl",
+	"Emoji":                    "toot:Emoji",
+	"featured":                 "toot:featured",
+	"discoverable":             "toot:discoverable",
+	"PropertyValue":            "schema:PropertyValue",
+	"value":                    "schema:value",
+	"isCat":                    "misskey:isCat",
+	"_misskey_content":         "misskey:_misskey_content",
+	"_misskey_quote":           "misskey:_misskey_quote",
+	"_misskey_reaction":        "misskey:_misskey_reaction",
+	"_misskey_votes":           "misskey:_misskey_votes",
+	"_misskey_summary":         "misskey:_misskey_summary",
+	"_misskey_followedMessage": "misskey:_misskey_followedMessage",
+}
+
+// fullContext は全AP出力で使われる完全なJSON-LDコンテキスト。
+var fullContext = []any{ContextURL, SecurityContextURL, MisskeyContext}
+
+// AddContext attaches the standard AS+security+Misskey context to any object
+// that embeds Object. 配列で持つことで複数 vocabulary を表現する。
 func AddContext(o any) {
-	type ctxSetter interface {
-		setContext(any)
-	}
 	switch v := o.(type) {
 	case *Person:
-		v.Context = []any{ContextURL, SecurityContextURL}
+		v.Context = fullContext
 	case *Note:
-		v.Context = ContextURL
+		v.Context = fullContext
 	case *Create:
-		v.Context = ContextURL
+		v.Context = fullContext
 	case *Follow:
-		v.Context = ContextURL
+		v.Context = fullContext
 	case *Accept:
-		v.Context = ContextURL
+		v.Context = fullContext
 	case *Reject:
-		v.Context = ContextURL
+		v.Context = fullContext
 	case *Undo:
-		v.Context = ContextURL
+		v.Context = fullContext
 	case *Delete:
-		v.Context = ContextURL
+		v.Context = fullContext
 	case *Update:
-		v.Context = ContextURL
+		v.Context = fullContext
 	case *Like:
-		v.Context = ContextURL
+		v.Context = fullContext
 	case *Announce:
-		v.Context = ContextURL
+		v.Context = fullContext
 	}
 }

--- a/internal/activitypub/types.go
+++ b/internal/activitypub/types.go
@@ -243,33 +243,43 @@ var MisskeyContext = map[string]any{
 }
 
 // fullContext は全AP出力で使われる完全なJSON-LDコンテキスト。
+// 不変として扱うこと。各オブジェクトには newContext() で新しいコピーを渡す。
 var fullContext = []any{ContextURL, SecurityContextURL, MisskeyContext}
+
+// newContext returns a fresh copy of fullContext so callers cannot
+// accidentally mutate the shared template via append.
+func newContext() []any {
+	c := make([]any, len(fullContext))
+	copy(c, fullContext)
+	return c
+}
 
 // AddContext attaches the standard AS+security+Misskey context to any object
 // that embeds Object. 配列で持つことで複数 vocabulary を表現する。
 func AddContext(o any) {
+	ctx := newContext()
 	switch v := o.(type) {
 	case *Person:
-		v.Context = fullContext
+		v.Context = ctx
 	case *Note:
-		v.Context = fullContext
+		v.Context = ctx
 	case *Create:
-		v.Context = fullContext
+		v.Context = ctx
 	case *Follow:
-		v.Context = fullContext
+		v.Context = ctx
 	case *Accept:
-		v.Context = fullContext
+		v.Context = ctx
 	case *Reject:
-		v.Context = fullContext
+		v.Context = ctx
 	case *Undo:
-		v.Context = fullContext
+		v.Context = ctx
 	case *Delete:
-		v.Context = fullContext
+		v.Context = ctx
 	case *Update:
-		v.Context = fullContext
+		v.Context = ctx
 	case *Like:
-		v.Context = fullContext
+		v.Context = ctx
 	case *Announce:
-		v.Context = fullContext
+		v.Context = ctx
 	}
 }

--- a/internal/activitypub/types_test.go
+++ b/internal/activitypub/types_test.go
@@ -31,7 +31,7 @@ func TestAddContext_Variants(t *testing.T) {
 	}
 	for _, c := range cases {
 		AddContext(c)
-		// 全て single string context (Person 以外)
+		// 全型で fullContext (AS + Security + MisskeyContext) が設定される
 		var ctx any
 		switch v := c.(type) {
 		case *Note:
@@ -55,7 +55,10 @@ func TestAddContext_Variants(t *testing.T) {
 		case *Announce:
 			ctx = v.Context
 		}
-		assert.Equal(t, ContextURL, ctx)
+		arr, ok := ctx.([]any)
+		assert.True(t, ok)
+		assert.Contains(t, arr, ContextURL)
+		assert.Contains(t, arr, SecurityContextURL)
 	}
 }
 

--- a/internal/activitypub/types_test.go
+++ b/internal/activitypub/types_test.go
@@ -62,6 +62,19 @@ func TestAddContext_Variants(t *testing.T) {
 	}
 }
 
+func TestAddContext_IndependentSlices(t *testing.T) {
+	// 異なるオブジェクトが独立したcontextスライスを持つこと
+	p := &Person{}
+	n := &Note{}
+	AddContext(p)
+	AddContext(n)
+	pCtx := p.Context.([]any)
+	nCtx := n.Context.([]any)
+	// appendしても互いに影響しない
+	pCtx = append(pCtx, "extra")
+	assert.Len(t, nCtx, 3)
+}
+
 func TestAddContext_NoOpForUnknown(t *testing.T) {
 	// 引数の型が switch にない場合はno-op
 	type other struct{}

--- a/internal/api/ap/handler.go
+++ b/internal/api/ap/handler.go
@@ -156,7 +156,7 @@ func (h *Handler) APIGet(c echo.Context) error {
 		}
 	}
 
-	return c.JSON(http.StatusOK, map[string]any{})
+	return c.JSON(http.StatusNotFound, apAPIError("NO_SUCH_OBJECT", "No such object.", "dc94d745-1262-4e63-a17d-fecaa57efc82"))
 }
 
 // APIShow handles POST /api/ap/show — URIからUser/Noteを解決して返す。
@@ -290,7 +290,12 @@ func extractLocalID(uri, pathPrefix string) string {
 	if prefixIdx < 0 {
 		return ""
 	}
-	return uri[prefixIdx+len(pathPrefix):]
+	id := uri[prefixIdx+len(pathPrefix):]
+	// フラグメント (#main-key 等) を除去
+	if i := strings.IndexByte(id, '#'); i >= 0 {
+		id = id[:i]
+	}
+	return id
 }
 
 func packNoteForAPI(n *model.Note) map[string]any {

--- a/internal/api/ap/handler.go
+++ b/internal/api/ap/handler.go
@@ -79,7 +79,7 @@ func (h *Handler) User(c echo.Context) error {
 	if err != nil {
 		return c.NoContent(http.StatusInternalServerError)
 	}
-	person := h.renderer.RenderPerson(bundle.User, keypair.PublicKey)
+	person := h.renderer.RenderPerson(bundle.User, bundle.Profile, keypair.PublicKey)
 	return writeActivityJSON(c, person)
 }
 
@@ -110,7 +110,7 @@ func (h *Handler) UserByAcct(c echo.Context) error {
 	if err != nil {
 		return c.NoContent(http.StatusInternalServerError)
 	}
-	person := h.renderer.RenderPerson(bundle.User, keypair.PublicKey)
+	person := h.renderer.RenderPerson(bundle.User, bundle.Profile, keypair.PublicKey)
 	return writeActivityJSON(c, person)
 }
 
@@ -259,7 +259,7 @@ func (h *Handler) resolveLocal(uri string) (any, error) {
 		if err != nil {
 			return nil, err
 		}
-		return h.renderer.RenderPerson(bundle.User, keypair.PublicKey), nil
+		return h.renderer.RenderPerson(bundle.User, bundle.Profile, keypair.PublicKey), nil
 	}
 	return nil, http.ErrNotSupported
 }

--- a/internal/api/ap/handler_test.go
+++ b/internal/api/ap/handler_test.go
@@ -169,8 +169,8 @@ func TestAPIGet_Success_User(t *testing.T) {
 func TestAPIGet_NotFound(t *testing.T) {
 	h, _, _, _ := newHandler(t)
 	rec := postJSON(h.APIGet, `{"uri":"https://example.com/notes/ghost"}`)
-	assert.Equal(t, http.StatusOK, rec.Code)
-	assert.Equal(t, "{}\n", rec.Body.String())
+	assert.Equal(t, http.StatusNotFound, rec.Code)
+	assert.Contains(t, rec.Body.String(), "NO_SUCH_OBJECT")
 }
 
 func TestAPIGet_InvalidParam(t *testing.T) {
@@ -182,8 +182,8 @@ func TestAPIGet_InvalidParam(t *testing.T) {
 func TestAPIGet_UserNotFound(t *testing.T) {
 	h, _, _, _ := newHandler(t)
 	rec := postJSON(h.APIGet, `{"uri":"https://example.com/users/ghost"}`)
-	assert.Equal(t, http.StatusOK, rec.Code)
-	assert.Equal(t, "{}\n", rec.Body.String())
+	assert.Equal(t, http.StatusNotFound, rec.Code)
+	assert.Contains(t, rec.Body.String(), "NO_SUCH_OBJECT")
 }
 
 func TestAPIGet_UserKeypairError(t *testing.T) {
@@ -191,15 +191,15 @@ func TestAPIGet_UserKeypairError(t *testing.T) {
 	userRepo.Users["u1"] = &model.User{ID: "u1", Username: "alice"}
 	keypairRepo.err = errors.New("db down")
 	rec := postJSON(h.APIGet, `{"uri":"https://example.com/users/u1"}`)
-	// keypairエラー → 空オブジェクト返却
-	assert.Equal(t, http.StatusOK, rec.Code)
-	assert.Equal(t, "{}\n", rec.Body.String())
+	// keypairエラー → 404
+	assert.Equal(t, http.StatusNotFound, rec.Code)
+	assert.Contains(t, rec.Body.String(), "NO_SUCH_OBJECT")
 }
 
 func TestAPIGet_NoMatch(t *testing.T) {
 	h, _, _, _ := newHandler(t)
 	rec := postJSON(h.APIGet, `{"uri":"https://other.example/something"}`)
-	assert.Equal(t, http.StatusOK, rec.Code)
+	assert.Equal(t, http.StatusNotFound, rec.Code)
 }
 
 func TestAPIShow_Note(t *testing.T) {
@@ -253,6 +253,12 @@ func TestExtractLocalID(t *testing.T) {
 	assert.Equal(t, "xyz", extractLocalID("https://example.com/users/xyz", "/users/"))
 	assert.Equal(t, "", extractLocalID("https://example.com/other", "/notes/"))
 	assert.Equal(t, "", extractLocalID("", "/notes/"))
+}
+
+func TestExtractLocalID_Fragment(t *testing.T) {
+	// #main-key 等のフラグメントが除去されること
+	assert.Equal(t, "u1", extractLocalID("https://example.com/users/u1#main-key", "/users/"))
+	assert.Equal(t, "n1", extractLocalID("https://example.com/notes/n1#fragment", "/notes/"))
 }
 
 func TestPackNoteForAPI_NilUser(t *testing.T) {
@@ -327,8 +333,8 @@ func TestAPIGet_RemoteFetchError(t *testing.T) {
 	h, _, _, _ := newHandler(t)
 	h.SetRemote(&mockFetcher{err: assert.AnError}, nil)
 	rec := postJSON(h.APIGet, `{"uri":"https://remote.example/notes/1"}`)
-	assert.Equal(t, http.StatusOK, rec.Code)
-	assert.Equal(t, "{}\n", rec.Body.String())
+	assert.Equal(t, http.StatusNotFound, rec.Code)
+	assert.Contains(t, rec.Body.String(), "NO_SUCH_OBJECT")
 }
 
 func TestAPIShow_RemoteResolveActor(t *testing.T) {
@@ -511,6 +517,6 @@ func TestAPIGet_RemoteInvalidJSON(t *testing.T) {
 	h, _, _, _ := newHandler(t)
 	h.SetRemote(&mockFetcher{data: []byte(`not json`)}, nil)
 	rec := postJSON(h.APIGet, `{"uri":"https://remote.example/x"}`)
-	assert.Equal(t, http.StatusOK, rec.Code)
-	assert.Equal(t, "{}\n", rec.Body.String())
+	assert.Equal(t, http.StatusNotFound, rec.Code)
+	assert.Contains(t, rec.Body.String(), "NO_SUCH_OBJECT")
 }

--- a/internal/server/router.go
+++ b/internal/server/router.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"io"
 	"net/http"
+	urlpkg "net/url"
 	"os"
 	"path/filepath"
 	"strings"
@@ -325,6 +326,13 @@ func (s *Server) setupRoutes() {
 	apRenderer := activitypub.NewRenderer(apURLs)
 	// Mention tag を AP Note に埋め込むための resolver。
 	apRenderer.SetMentionResolver(corefederation.NewUserMentionResolver(userRepo, apURLs))
+	apRenderer.SetFileResolver(driveFileRepo)
+	apRenderer.SetEmojiResolver(emojiRepo)
+	apRenderer.SetNoteResolver(noteRepo)
+	// config.URL は "https://example.com" 形式。ホスト部分だけ抽出する。
+	if u, err := urlpkg.Parse(s.config.URL); err == nil {
+		apRenderer.SetHost(u.Host)
+	}
 	apClient := activitypub.NewClient(nil, s.config.UserAgent)
 	// meta.allowExternalApRedirect が false なら AP fetch でのリダイレクトを拒否する。
 	if m, err := metaRepo.Fetch(); err == nil && !m.AllowExternalApRedirect {


### PR DESCRIPTION
## Summary
- MFMパーサ (`internal/activitypub/mfm/`) を新規実装。再帰下降パーサでmfm-jsの全20ノードタイプをサポートし、HTML変換 + `IsSimple()` 最適化を提供
- Person を拡充: summary (MFM→HTML), banner image, PropertyValue (プロフィールフィールド), vcard:bday/Address, isCat, movedTo, alsoKnownAs, featured, `_misskey_followedMessage`, bot→Service type
- Note を拡充: MFM→HTMLコンテンツ, `_misskey_content`/source, Document添付 (FileResolver経由), 引用Renote URI, Hashtag/Emoji tag
- Misskey/Mastodon/schema.org JSON-LDコンテキスト語彙を追加 (全AP型にfullContext配列)
- FileResolver, EmojiResolver, NoteResolver, Host をレンダラDIに接続

## 主な変更点
| ファイル | 変更内容 |
|---------|---------|
| `internal/activitypub/mfm/` (新規5ファイル) | MFMパーサ + HTML変換 + テスト |
| `internal/activitypub/types.go` | Person/Note フィールド追加、新型 (Document, PropertyValue, Hashtag, EmojiTag)、MisskeyContext |
| `internal/activitypub/renderer.go` | RenderPerson/RenderNote 拡充、Resolver インターフェース追加 |
| `internal/activitypub/renderer_test.go` | 16テスト追加 |
| `internal/api/ap/handler.go` | RenderPerson 呼び出しに profile 引数を追加 |
| `internal/server/router.go` | レンダラDI配線追加 |

## テスト
- `internal/activitypub/`: 99.5% coverage (renderer.go: 100%)
- `internal/activitypub/mfm/`: 91.0% coverage
- `internal/api/ap/`: 全テストパス
- Federation E2Eテスト: 全テストパス

```bash
go test -race -count=1 ./internal/activitypub/... ./internal/api/ap/...
```

Closes #109

🤖 Generated with [Claude Code](https://claude.com/claude-code)