### PR TITLE
Phase P1: NoteEntity / UserDetailed レスポンス完全化

### DIFF
--- a/internal/api/i/handler.go
+++ b/internal/api/i/handler.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/labstack/echo/v4"
+	"github.com/shiroha-a/mk/internal/core/role"
 	"github.com/shiroha-a/mk/internal/core/twofactor"
 	"github.com/shiroha-a/mk/internal/core/user"
 	"github.com/shiroha-a/mk/internal/entity"
@@ -241,22 +242,22 @@ func (h *Handler) Me(c echo.Context) error {
 		"birthday":       detailed.Birthday,
 		"lang":           detailed.Lang,
 		"fields":         detailed.Fields,
-		"verifiedLinks":  []string{},
+		"verifiedLinks":  detailed.VerifiedLinks,
 		"followersCount": detailed.FollowersCount,
 		"followingCount": detailed.FollowingCount,
 		"notesCount":     detailed.NotesCount,
 		"uri":            detailed.URI,
 		"url":            detailed.URL,
-		"movedTo":        nil,
-		"alsoKnownAs":    nil,
+		"movedTo":        u.MovedToURI,
+		"alsoKnownAs":    u.AlsoKnownAs,
 		"updatedAt":      detailed.UpdatedAt,
 		"lastFetchedAt":  nil,
 		// MeDetailed fields
-		"avatarId":            nil,
-		"bannerId":            nil,
-		"followersVisibility": "public",
-		"followingVisibility": "public",
-		"chatScope":           "mutual",
+		"avatarId":            u.AvatarID,
+		"bannerId":            u.BannerID,
+		"followersVisibility": detailed.FollowersVisibility,
+		"followingVisibility": detailed.FollowingVisibility,
+		"chatScope":           u.ChatScope,
 		"canChat":             true,
 		"followedMessage":     nil,
 		"memo":                nil,
@@ -282,6 +283,12 @@ func (h *Handler) Me(c echo.Context) error {
 		resp["hardMutedWords"] = profile.HardMutedWords
 		resp["mutedInstances"] = profile.MutedInstances
 		resp["publicReactions"] = profile.PublicReactions
+		resp["followedMessage"] = profile.FollowedMessage
+		resp["loggedInDays"] = len(profile.LoggedInDates)
+		resp["achievements"] = jsonbArray(profile.Achievements)
+		resp["securityKeys"] = profile.SecurityKeysAvailable
+		// twoFactorBackupCodesStock: full/partial/none
+		resp["twoFactorBackupCodesStock"] = backupCodesStock(profile)
 		// clientData / room は jsonb を生のまま返すと frontend (本家) が
 		// オブジェクトとして parse するため、空/不正時は空オブジェクトに
 		// 正規化する。user が手動でキーを書き換えるだけなので scheme は持たない。
@@ -292,7 +299,7 @@ func (h *Handler) Me(c echo.Context) error {
 	// フロントエンド互換性フィールド (Phase 4.5c / Phase 5)
 	isAdmin := false
 	isMod := false
-	userPolicies := defaultMePolicies()
+	userPolicies := role.DefaultPolicies()
 	var userRoles []any
 	if h.roleProvider != nil {
 		isAdmin = h.roleProvider.IsAdministrator(u.ID)
@@ -334,13 +341,26 @@ func (h *Handler) Me(c echo.Context) error {
 	resp["pinnedNotes"] = []any{}
 	resp["pinnedPageId"] = nil
 	resp["pinnedPage"] = nil
-	resp["loggedInDays"] = 0
 	resp["policies"] = userPolicies
 	resp["roles"] = userRoles
-	resp["achievements"] = []any{}
-	resp["twoFactorBackupCodesStock"] = "none"
-	resp["securityKeys"] = false
-	resp["securityKeysList"] = []any{}
+	// securityKeysList: WebAuthnキーの一覧
+	if h.securityKeyRepo != nil {
+		if keys, err := h.securityKeyRepo.ListByUser(u.ID); err == nil && len(keys) > 0 {
+			list := make([]map[string]any, len(keys))
+			for i, k := range keys {
+				list[i] = map[string]any{
+					"id":       k.ID,
+					"name":     k.Name,
+					"lastUsed": k.LastUsed.UTC().Format("2006-01-02T15:04:05.000Z"),
+				}
+			}
+			resp["securityKeysList"] = list
+		} else {
+			resp["securityKeysList"] = []any{}
+		}
+	} else {
+		resp["securityKeysList"] = []any{}
+	}
 	resp["mutingNotificationTypes"] = []any{}
 	resp["notificationRecieveConfig"] = map[string]any{}
 	resp["emailNotificationTypes"] = []string{"follow", "receiveFollowRequest"}
@@ -388,6 +408,31 @@ func jsonbObject(raw []byte) any {
 		return map[string]any{}
 	}
 	return out
+}
+
+// jsonbArray normalizes a raw jsonb byte slice into []any for the Me response.
+// Empty or malformed payloads become an empty array.
+func jsonbArray(raw []byte) any {
+	if len(raw) == 0 {
+		return []any{}
+	}
+	var out []any
+	if err := json.Unmarshal(raw, &out); err != nil || out == nil {
+		return []any{}
+	}
+	return out
+}
+
+// backupCodesStock returns "full", "partial", or "none" based on the number of
+// remaining 2FA backup codes. Misskey uses 5 codes as the full set.
+func backupCodesStock(profile *model.UserProfile) string {
+	if !profile.TwoFactorEnabled || len(profile.TwoFactorBackupSecret) == 0 {
+		return "none"
+	}
+	if len(profile.TwoFactorBackupSecret) >= 5 {
+		return "full"
+	}
+	return "partial"
 }
 
 // containsProhibitedWord reports whether name contains any entry from words
@@ -532,50 +577,6 @@ func errEnvelope(message, code, id string) map[string]any {
 			"code":    code,
 			"id":      id,
 		},
-	}
-}
-
-// defaultMePolicies returns the Misskey default policies for MeDetailed.
-func defaultMePolicies() map[string]any {
-	return map[string]any{
-		"gtlAvailable":               true,
-		"ltlAvailable":               true,
-		"canPublicNote":              true,
-		"mentionLimit":               20,
-		"canInvite":                  false,
-		"inviteLimit":                0,
-		"inviteLimitCycle":           10080,
-		"inviteExpirationTime":       0,
-		"canManageCustomEmojis":      false,
-		"canManageAvatarDecorations": false,
-		"canSearchNotes":             false,
-		"canSearchUsers":             true,
-		"canUseTranslator":           true,
-		"canHideAds":                 false,
-		"driveCapacityMb":            100,
-		"maxFileSizeMb":              30,
-		"alwaysMarkNsfw":             false,
-		"canUpdateBioMedia":          true,
-		"pinLimit":                   5,
-		"antennaLimit":               5,
-		"wordMuteLimit":              200,
-		"webhookLimit":               3,
-		"clipLimit":                  10,
-		"noteEachClipsLimit":         200,
-		"userListLimit":              10,
-		"userEachUserListsLimit":     50,
-		"rateLimitFactor":            1,
-		"avatarDecorationLimit":      1,
-		"canImportAntennas":          false,
-		"canImportBlocking":          false,
-		"canImportFollowing":         false,
-		"canImportMuting":            false,
-		"canImportUserLists":         false,
-		"chatAvailability":           "available",
-		"uploadableFileTypes":        []string{"text/*", "application/json", "image/*", "video/*", "audio/*"},
-		"noteDraftLimit":             10,
-		"scheduledNoteLimit":         1,
-		"watermarkAvailable":         true,
 	}
 }
 

--- a/internal/api/i/handler_test.go
+++ b/internal/api/i/handler_test.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/labstack/echo/v4"
+	"github.com/lib/pq"
 	coreuser "github.com/shiroha-a/mk/internal/core/user"
 	"github.com/shiroha-a/mk/internal/misc/id"
 	"github.com/shiroha-a/mk/internal/model"
@@ -120,18 +121,21 @@ func TestMe_Success(t *testing.T) {
 		FollowingCount:    20,
 		NotesCount:        100,
 		AvatarDecorations: datatypes.JSON([]byte("[]")),
+		ChatScope:         "mutual",
 	}
 
 	email := "test@example.com"
 	userRepo.Profiles["user1"] = &model.UserProfile{
-		UserID:             "user1",
-		Email:              &email,
-		EmailVerified:      true,
-		TwoFactorEnabled:   false,
-		AutoAcceptFollowed: true,
-		NoCrawle:           false,
-		PreventAiLearning:  true,
-		Fields:             datatypes.JSON([]byte("[]")),
+		UserID:              "user1",
+		Email:               &email,
+		EmailVerified:       true,
+		TwoFactorEnabled:    false,
+		AutoAcceptFollowed:  true,
+		NoCrawle:            false,
+		PreventAiLearning:   true,
+		Fields:              datatypes.JSON([]byte("[]")),
+		FollowersVisibility: model.FollowingVisibilityPublic,
+		FollowingVisibility: model.FollowingVisibilityPublic,
 	}
 
 	e := echo.New()
@@ -190,6 +194,144 @@ func TestMe_Success(t *testing.T) {
 	assert.Equal(t, false, resp["securityKeys"])
 	assert.Nil(t, resp["movedTo"])
 	assert.Nil(t, resp["alsoKnownAs"])
+}
+
+func TestMe_LoggedInDays(t *testing.T) {
+	h, userRepo, _, _ := newTestHandler(t)
+
+	user := &model.User{
+		ID:                "user1",
+		Username:          "testuser",
+		AvatarDecorations: datatypes.JSON([]byte("[]")),
+		ChatScope:         "mutual",
+	}
+
+	userRepo.Profiles["user1"] = &model.UserProfile{
+		UserID:              "user1",
+		Fields:              datatypes.JSON([]byte("[]")),
+		LoggedInDates:       pq.StringArray{"2026-04-01", "2026-04-02", "2026-04-03"},
+		FollowersVisibility: model.FollowingVisibilityPublic,
+		FollowingVisibility: model.FollowingVisibilityPublic,
+	}
+
+	e := echo.New()
+	req := httptest.NewRequest(http.MethodPost, "/api/i", nil)
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+	c.Set(string(middleware.UserContextKey), user)
+
+	err := h.Me(c)
+	require.NoError(t, err)
+
+	var resp map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+	assert.Equal(t, float64(3), resp["loggedInDays"])
+}
+
+func TestMe_BackupCodesStock(t *testing.T) {
+	tests := []struct {
+		name     string
+		enabled  bool
+		codes    pq.StringArray
+		expected string
+	}{
+		{"disabled 2FA", false, nil, "none"},
+		{"enabled but no codes", true, pq.StringArray{}, "none"},
+		{"enabled with partial codes", true, pq.StringArray{"code1", "code2"}, "partial"},
+		{"enabled with full codes", true, pq.StringArray{"c1", "c2", "c3", "c4", "c5"}, "full"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			h, userRepo, _, _ := newTestHandler(t)
+
+			user := &model.User{
+				ID:                "user1",
+				Username:          "testuser",
+				AvatarDecorations: datatypes.JSON([]byte("[]")),
+				ChatScope:         "mutual",
+			}
+
+			userRepo.Profiles["user1"] = &model.UserProfile{
+				UserID:                "user1",
+				Fields:                datatypes.JSON([]byte("[]")),
+				TwoFactorEnabled:      tt.enabled,
+				TwoFactorBackupSecret: tt.codes,
+				FollowersVisibility:   model.FollowingVisibilityPublic,
+				FollowingVisibility:   model.FollowingVisibilityPublic,
+			}
+
+			e := echo.New()
+			req := httptest.NewRequest(http.MethodPost, "/api/i", nil)
+			rec := httptest.NewRecorder()
+			c := e.NewContext(req, rec)
+			c.Set(string(middleware.UserContextKey), user)
+
+			err := h.Me(c)
+			require.NoError(t, err)
+
+			var resp map[string]any
+			require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+			assert.Equal(t, tt.expected, resp["twoFactorBackupCodesStock"])
+		})
+	}
+}
+
+func TestJsonbArray(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    []byte
+		expected any
+	}{
+		{"nil input", nil, []any{}},
+		{"empty input", []byte{}, []any{}},
+		{"valid array", []byte(`[{"name":"test"}]`), []any{map[string]any{"name": "test"}}},
+		{"invalid JSON", []byte("not json"), []any{}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := jsonbArray(tt.input)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func TestMe_AvatarAndBannerIDs(t *testing.T) {
+	h, userRepo, _, _ := newTestHandler(t)
+
+	avatarID := "avatar123"
+	bannerID := "banner456"
+	user := &model.User{
+		ID:                "user1",
+		Username:          "testuser",
+		AvatarDecorations: datatypes.JSON([]byte("[]")),
+		ChatScope:         "mutual",
+		AvatarID:          &avatarID,
+		BannerID:          &bannerID,
+	}
+
+	userRepo.Profiles["user1"] = &model.UserProfile{
+		UserID:              "user1",
+		Fields:              datatypes.JSON([]byte("[]")),
+		FollowersVisibility: model.FollowingVisibilityPublic,
+		FollowingVisibility: model.FollowingVisibilityPublic,
+	}
+
+	e := echo.New()
+	req := httptest.NewRequest(http.MethodPost, "/api/i", nil)
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+	c.Set(string(middleware.UserContextKey), user)
+
+	err := h.Me(c)
+	require.NoError(t, err)
+
+	var resp map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+	assert.Equal(t, "avatar123", resp["avatarId"])
+	assert.Equal(t, "banner456", resp["bannerId"])
+	assert.NotNil(t, resp["securityKeysList"])
 }
 
 // stubRoleProvider implements i.RoleProvider for testing.

--- a/internal/api/meta/handler.go
+++ b/internal/api/meta/handler.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/labstack/echo/v4"
 	"github.com/shiroha-a/mk/internal/config"
+	"github.com/shiroha-a/mk/internal/core/role"
 	"github.com/shiroha-a/mk/internal/repository"
 )
 
@@ -112,7 +113,7 @@ func (h *Handler) Meta(c echo.Context) error {
 		// デフォルト値を使う前提。
 		"clientOptions": clientOptionsJSON(m.ClientOptions),
 
-		"policies": defaultPolicies(),
+		"policies": role.DefaultPolicies(),
 
 		"features": map[string]any{
 			"registration":           !m.DisableRegistration,
@@ -127,50 +128,6 @@ func (h *Handler) Meta(c echo.Context) error {
 	}
 
 	return c.JSON(http.StatusOK, resp)
-}
-
-// defaultPolicies returns the Misskey default policies matching the TS implementation.
-func defaultPolicies() map[string]any {
-	return map[string]any{
-		"gtlAvailable":               true,
-		"ltlAvailable":               true,
-		"canPublicNote":              true,
-		"mentionLimit":               20,
-		"canInvite":                  false,
-		"inviteLimit":                0,
-		"inviteLimitCycle":           10080,
-		"inviteExpirationTime":       0,
-		"canManageCustomEmojis":      false,
-		"canManageAvatarDecorations": false,
-		"canSearchNotes":             false,
-		"canSearchUsers":             true,
-		"canUseTranslator":           true,
-		"canHideAds":                 false,
-		"driveCapacityMb":            100,
-		"maxFileSizeMb":              30,
-		"alwaysMarkNsfw":             false,
-		"canUpdateBioMedia":          true,
-		"pinLimit":                   5,
-		"antennaLimit":               5,
-		"wordMuteLimit":              200,
-		"webhookLimit":               3,
-		"clipLimit":                  10,
-		"noteEachClipsLimit":         200,
-		"userListLimit":              10,
-		"userEachUserListsLimit":     50,
-		"rateLimitFactor":            1,
-		"avatarDecorationLimit":      1,
-		"canImportAntennas":          false,
-		"canImportBlocking":          false,
-		"canImportFollowing":         false,
-		"canImportMuting":            false,
-		"canImportUserLists":         false,
-		"chatAvailability":           "available",
-		"uploadableFileTypes":        []string{"text/*", "application/json", "image/*", "video/*", "audio/*"},
-		"noteDraftLimit":             10,
-		"scheduledNoteLimit":         1,
-		"watermarkAvailable":         true,
-	}
 }
 
 // Ping returns a simple pong response.

--- a/internal/api/notes/handler.go
+++ b/internal/api/notes/handler.go
@@ -21,18 +21,20 @@ import (
 
 // Handler handles note-related API endpoints.
 type Handler struct {
-	noteRepo        repository.NoteRepository
-	createService   *note.CreateService
-	deleteService   *note.DeleteService
-	queryService    *note.QueryService
-	timelineService *timeline.Service
-	reactionService *reaction.Service
-	pollService     *poll.Service
-	searchService   *search.Service
-	idGen           id.Generator
-	favoriteRepo    repository.NoteFavoriteRepository
-	driveFileRepo   repository.DriveFileRepository
-	draftRepo       repository.NoteDraftRepository
+	noteRepo         repository.NoteRepository
+	createService    *note.CreateService
+	deleteService    *note.DeleteService
+	queryService     *note.QueryService
+	timelineService  *timeline.Service
+	reactionService  *reaction.Service
+	pollService      *poll.Service
+	searchService    *search.Service
+	idGen            id.Generator
+	favoriteRepo     repository.NoteFavoriteRepository
+	driveFileRepo    repository.DriveFileRepository
+	draftRepo        repository.NoteDraftRepository
+	noteReactionRepo repository.NoteReactionRepository
+	channelRepo      repository.ChannelRepository
 	// ugcVisibility controls what unauthenticated visitors can see.
 	// "all" (default), "local", "none"
 	ugcVisibility string
@@ -52,6 +54,16 @@ func (h *Handler) SetUGCVisibility(v string) {
 // SetDriveFileRepo attaches a DriveFileRepository for file resolution.
 func (h *Handler) SetDriveFileRepo(r repository.DriveFileRepository) {
 	h.driveFileRepo = r
+}
+
+// SetNoteReactionRepo attaches a NoteReactionRepository for myReaction resolution.
+func (h *Handler) SetNoteReactionRepo(r repository.NoteReactionRepository) {
+	h.noteReactionRepo = r
+}
+
+// SetChannelRepo attaches a ChannelRepository for channel resolution.
+func (h *Handler) SetChannelRepo(r repository.ChannelRepository) {
+	h.channelRepo = r
 }
 
 // NewHandler creates a new notes Handler.
@@ -173,6 +185,7 @@ func (h *Handler) Create(c echo.Context) error {
 	packed := entity.PackNote(created, h.idGen)
 	s := []entity.NoteEntity{packed}
 	h.resolveFiles(s)
+	h.resolveViewerFields(s, user)
 	return c.JSON(http.StatusOK, map[string]any{
 		"createdNote": s[0],
 	})
@@ -199,6 +212,7 @@ func (h *Handler) Show(c echo.Context) error {
 	packed := entity.PackNote(n, h.idGen)
 	s := []entity.NoteEntity{packed}
 	h.resolveFiles(s)
+	h.resolveViewerFields(s, viewer)
 	return c.JSON(http.StatusOK, s[0])
 }
 
@@ -305,7 +319,7 @@ func (h *Handler) serveList(c echo.Context, fn func(*model.User, listRequest) ([
 		}
 		return internalError(c)
 	}
-	return c.JSON(http.StatusOK, h.packMany(notes))
+	return c.JSON(http.StatusOK, h.packMany(notes, viewer))
 }
 
 // SearchRequest is the request body for notes/search.
@@ -373,7 +387,7 @@ func (h *Handler) Search(c echo.Context) error {
 		}
 		return internalError(c)
 	}
-	return c.JSON(http.StatusOK, h.packMany(notes))
+	return c.JSON(http.StatusOK, h.packMany(notes, viewer))
 }
 
 // State handles POST /api/notes/state.
@@ -416,17 +430,19 @@ func (h *Handler) Conversation(c echo.Context) error {
 		// 現状QueryService.ConversationはErrNoteNotFound以外を返さない
 		return noSuchNote(c)
 	}
-	return c.JSON(http.StatusOK, h.packMany(notes))
+	return c.JSON(http.StatusOK, h.packMany(notes, viewer))
 }
 
 // packMany serializes a list of notes into NoteEntity objects.
 // driveFileRepoが設定されている場合、ファイル情報を解決してFilesに含める。
-func (h *Handler) packMany(notes []*model.Note) []entity.NoteEntity {
+// viewerがnon-nilの場合、myReactionなどのviewer依存フィールドも解決する。
+func (h *Handler) packMany(notes []*model.Note, viewer *model.User) []entity.NoteEntity {
 	out := make([]entity.NoteEntity, 0, len(notes))
 	for _, n := range notes {
 		out = append(out, entity.PackNote(n, h.idGen))
 	}
 	h.resolveFiles(out)
+	h.resolveViewerFields(out, viewer)
 	return out
 }
 
@@ -462,6 +478,62 @@ func (h *Handler) resolveFiles(notes []entity.NoteEntity) {
 			}
 		}
 		notes[i].Files = packed
+	}
+}
+
+// resolveViewerFields populates viewer-dependent fields (MyReaction, Channel)
+// on packed NoteEntities. viewerがnilの場合はChannel解決のみ行う。
+func (h *Handler) resolveViewerFields(notes []entity.NoteEntity, viewer *model.User) {
+	if len(notes) == 0 {
+		return
+	}
+
+	// MyReaction: viewerが認証済みの場合にバッチ取得
+	if viewer != nil && h.noteReactionRepo != nil {
+		noteIDs := make([]string, len(notes))
+		for i := range notes {
+			noteIDs[i] = notes[i].ID
+		}
+		reactionMap, err := h.noteReactionRepo.FindByUserAndNoteIDs(viewer.ID, noteIDs)
+		if err == nil {
+			for i := range notes {
+				if r, ok := reactionMap[notes[i].ID]; ok {
+					notes[i].MyReaction = &r.Reaction
+				}
+			}
+		}
+	}
+
+	// Channel: ChannelIDがnon-nilのノートについてバッチ取得
+	if h.channelRepo != nil {
+		var channelIDs []string
+		for _, n := range notes {
+			if n.ChannelID != nil && *n.ChannelID != "" {
+				channelIDs = append(channelIDs, *n.ChannelID)
+			}
+		}
+		if len(channelIDs) > 0 {
+			channels, err := h.channelRepo.FindByIDs(channelIDs)
+			if err == nil {
+				chMap := make(map[string]*model.Channel, len(channels))
+				for _, ch := range channels {
+					chMap[ch.ID] = ch
+				}
+				for i := range notes {
+					if notes[i].ChannelID != nil {
+						if ch, ok := chMap[*notes[i].ChannelID]; ok {
+							notes[i].Channel = &entity.ChannelLite{
+								ID:                    ch.ID,
+								Name:                  ch.Name,
+								Color:                 ch.Color,
+								IsSensitive:           ch.IsSensitive,
+								AllowRenoteToExternal: ch.AllowRenoteToExternal,
+							}
+						}
+					}
+				}
+			}
+		}
 	}
 }
 

--- a/internal/api/notes/handler_extra.go
+++ b/internal/api/notes/handler_extra.go
@@ -81,7 +81,7 @@ func (h *Handler) Featured(c echo.Context) error {
 	if err != nil {
 		return c.JSON(http.StatusInternalServerError, apiError("INTERNAL_ERROR", "Internal error.", "5d37dbcb-891e-41ca-a3d6-e690c97775ac"))
 	}
-	return c.JSON(http.StatusOK, h.packMany(notes))
+	return c.JSON(http.StatusOK, h.packMany(notes, middleware.GetUser(c)))
 }
 
 // Unrenote handles POST /api/notes/unrenote.
@@ -137,7 +137,7 @@ func (h *Handler) Mentions(c echo.Context) error {
 			}
 		}
 	}
-	return c.JSON(http.StatusOK, h.packMany(filtered))
+	return c.JSON(http.StatusOK, h.packMany(filtered, user))
 }
 
 // UserListTimeline handles POST /api/notes/user-list-timeline.
@@ -177,7 +177,7 @@ func (h *Handler) SearchByTag(c echo.Context) error {
 	if err != nil {
 		return c.JSON(http.StatusOK, []entity.NoteEntity{})
 	}
-	return c.JSON(http.StatusOK, h.packMany(notes))
+	return c.JSON(http.StatusOK, h.packMany(notes, middleware.GetUser(c)))
 }
 
 // Clips handles POST /api/notes/clips.
@@ -234,7 +234,7 @@ func (h *Handler) ShowPartialBulk(c echo.Context) error {
 	if err != nil {
 		return c.JSON(http.StatusOK, []entity.NoteEntity{})
 	}
-	return c.JSON(http.StatusOK, h.packMany(notes))
+	return c.JSON(http.StatusOK, h.packMany(notes, middleware.GetUser(c)))
 }
 
 func apiError(code, message, id string) map[string]any {

--- a/internal/api/notes/handler_test.go
+++ b/internal/api/notes/handler_test.go
@@ -207,6 +207,107 @@ func TestShow_MissingNoteId(t *testing.T) {
 	assert.Equal(t, http.StatusBadRequest, rec.Code)
 }
 
+func TestShow_MyReaction(t *testing.T) {
+	h, noteRepo := newTestHandler(t)
+
+	// リアクションリポジトリをセット
+	reactionRepo := testutil.NewMockNoteReactionRepository()
+	h.SetNoteReactionRepo(reactionRepo)
+
+	text := "test note"
+	noteRepo.Notes["note1"] = &model.Note{
+		ID:         "note1",
+		UserID:     "author1",
+		Text:       &text,
+		Visibility: model.NoteVisibilityPublic,
+		Reactions:  datatypes.JSON([]byte(`{"👍":1}`)),
+		User: &model.User{
+			ID:                "author1",
+			Username:          "author",
+			AvatarDecorations: datatypes.JSON([]byte("[]")),
+		},
+	}
+
+	// viewerのリアクションを登録
+	reactionRepo.Reactions["r1"] = &model.NoteReaction{
+		ID:       "r1",
+		UserID:   "viewer1",
+		NoteID:   "note1",
+		Reaction: "👍",
+	}
+
+	viewer := &model.User{ID: "viewer1", Username: "viewer"}
+
+	body := `{"noteId": "note1"}`
+	e := echo.New()
+	req := httptest.NewRequest(http.MethodPost, "/api/notes/show", strings.NewReader(body))
+	req.Header.Set(echo.HeaderContentType, echo.MIMEApplicationJSON)
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+	setAuthUser(c, viewer)
+
+	err := h.Show(c)
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusOK, rec.Code)
+
+	var resp map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+	assert.Equal(t, "👍", resp["myReaction"])
+	assert.Equal(t, float64(1), resp["reactionCount"])
+}
+
+func TestShow_Channel(t *testing.T) {
+	h, noteRepo := newTestHandler(t)
+
+	// チャンネルリポジトリをセット
+	channelRepo := testutil.NewMockChannelRepository()
+	h.SetChannelRepo(channelRepo)
+
+	channelRepo.Channels["ch1"] = &model.Channel{
+		ID:                    "ch1",
+		Name:                  "test-channel",
+		Color:                 "#ff0000",
+		IsSensitive:           true,
+		AllowRenoteToExternal: false,
+	}
+
+	text := "channel note"
+	chID := "ch1"
+	noteRepo.Notes["note2"] = &model.Note{
+		ID:         "note2",
+		UserID:     "user1",
+		Text:       &text,
+		Visibility: model.NoteVisibilityPublic,
+		ChannelID:  &chID,
+		Reactions:  datatypes.JSON([]byte("{}")),
+		User: &model.User{
+			ID:                "user1",
+			Username:          "testuser",
+			AvatarDecorations: datatypes.JSON([]byte("[]")),
+		},
+	}
+
+	body := `{"noteId": "note2"}`
+	e := echo.New()
+	req := httptest.NewRequest(http.MethodPost, "/api/notes/show", strings.NewReader(body))
+	req.Header.Set(echo.HeaderContentType, echo.MIMEApplicationJSON)
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+
+	err := h.Show(c)
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusOK, rec.Code)
+
+	var resp map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+	ch := resp["channel"].(map[string]any)
+	assert.Equal(t, "ch1", ch["id"])
+	assert.Equal(t, "test-channel", ch["name"])
+	assert.Equal(t, "#ff0000", ch["color"])
+	assert.Equal(t, true, ch["isSensitive"])
+	assert.Equal(t, false, ch["allowRenoteToExternal"])
+}
+
 func TestDelete_Success(t *testing.T) {
 	h, noteRepo := newTestHandler(t)
 

--- a/internal/api/notes/timeline_handler.go
+++ b/internal/api/notes/timeline_handler.go
@@ -88,5 +88,5 @@ func (h *Handler) serveTimeline(
 		// ErrUnauthenticatedはここには到達しない。残りはRedis等の障害のみ。
 		return internalError(c)
 	}
-	return c.JSON(http.StatusOK, h.packMany(notes))
+	return c.JSON(http.StatusOK, h.packMany(notes, viewer))
 }

--- a/internal/api/signup/handler.go
+++ b/internal/api/signup/handler.go
@@ -8,6 +8,7 @@ import (
 	"github.com/labstack/echo/v4"
 
 	"github.com/shiroha-a/mk/internal/core/captcha"
+	"github.com/shiroha-a/mk/internal/core/role"
 	coresignup "github.com/shiroha-a/mk/internal/core/signup"
 	"github.com/shiroha-a/mk/internal/entity"
 	"github.com/shiroha-a/mk/internal/misc/id"
@@ -215,47 +216,12 @@ func packSignupResponse(u *model.User, token string, idGen id.Generator) map[str
 		"mutedWords":               []any{},
 		"hardMutedWords":           []any{},
 		"mutedInstances":           []any{},
-		"policies":                 defaultPolicies(),
+		"policies":                 role.DefaultPolicies(),
 		"token":                    token,
 	}
 }
 
 // defaultPolicies returns the Misskey default policies for a new user.
-func defaultPolicies() map[string]any {
-	return map[string]any{
-		"gtlAvailable":               true,
-		"ltlAvailable":               true,
-		"canPublicNote":              true,
-		"mentionLimit":               150,
-		"canInvite":                  false,
-		"inviteLimit":                0,
-		"inviteLimitCycle":           float64(525600),
-		"inviteExpirationTime":       float64(0),
-		"canManageCustomEmojis":      false,
-		"canManageAvatarDecorations": false,
-		"canSearchNotes":             true,
-		"canUseTranslator":           true,
-		"canHideAds":                 false,
-		"driveCapacityMb":            float64(100),
-		"alwaysMarkNsfw":             false,
-		"pinLimit":                   5,
-		"antennaLimit":               5,
-		"wordMuteLimit":              200,
-		"webhookLimit":               3,
-		"clipLimit":                  10,
-		"noteEachClipsLimit":         200,
-		"userListLimit":              10,
-		"userEachUserListsLimit":     50,
-		"rateLimitFactor":            float64(1),
-		"avatarDecorationLimit":      1,
-		"canImportAntennas":          true,
-		"canImportBlocking":          true,
-		"canImportFollowing":         true,
-		"canImportMuting":            true,
-		"canImportUserLists":         true,
-	}
-}
-
 var errInvalidCode = errors.New("invalid invitation code")
 
 func errResp(code, message, id string) map[string]any {

--- a/internal/api/users/handler.go
+++ b/internal/api/users/handler.go
@@ -22,14 +22,19 @@ type ChartHook interface {
 
 // Handler handles user-related API endpoints.
 type Handler struct {
-	userService      *user.Service
-	followingService *corefollowing.Service
-	noteRepo         repository.NoteRepository
-	idGen            id.Generator
-	chartHook        ChartHook
-	abuseRepo        repository.AbuseReportRepository
-	followingRepo    repository.FollowingRepository
-	memoRepo         repository.UserMemoRepository
+	userService       *user.Service
+	followingService  *corefollowing.Service
+	noteRepo          repository.NoteRepository
+	idGen             id.Generator
+	chartHook         ChartHook
+	abuseRepo         repository.AbuseReportRepository
+	followingRepo     repository.FollowingRepository
+	memoRepo          repository.UserMemoRepository
+	blockingRepo      repository.BlockingRepository
+	mutingRepo        repository.MutingRepository
+	renoteMutingRepo  repository.RenoteMutingRepository
+	followRequestRepo repository.FollowRequestRepository
+	instanceRepo      repository.InstanceRepository
 }
 
 // SetMemoRepo attaches a UserMemoRepository for users/update-memo.
@@ -40,6 +45,31 @@ func (h *Handler) SetMemoRepo(r repository.UserMemoRepository) {
 // SetFollowingRepo attaches a FollowingRepository for follow relation queries.
 func (h *Handler) SetFollowingRepo(r repository.FollowingRepository) {
 	h.followingRepo = r
+}
+
+// SetBlockingRepo attaches a BlockingRepository for block status queries.
+func (h *Handler) SetBlockingRepo(r repository.BlockingRepository) {
+	h.blockingRepo = r
+}
+
+// SetMutingRepo attaches a MutingRepository for mute status queries.
+func (h *Handler) SetMutingRepo(r repository.MutingRepository) {
+	h.mutingRepo = r
+}
+
+// SetRenoteMutingRepo attaches a RenoteMutingRepository for renote mute status queries.
+func (h *Handler) SetRenoteMutingRepo(r repository.RenoteMutingRepository) {
+	h.renoteMutingRepo = r
+}
+
+// SetFollowRequestRepo attaches a FollowRequestRepository for pending request queries.
+func (h *Handler) SetFollowRequestRepo(r repository.FollowRequestRepository) {
+	h.followRequestRepo = r
+}
+
+// SetInstanceRepo attaches an InstanceRepository for remote user instance info.
+func (h *Handler) SetInstanceRepo(r repository.InstanceRepository) {
+	h.instanceRepo = r
 }
 
 // NewHandler creates a new users Handler.
@@ -118,12 +148,59 @@ func (h *Handler) Show(c echo.Context) error {
 
 	detailed := entity.PackUserDetailed(bundle.User, bundle.Profile, h.idGen)
 
-	// viewerがログインしている場合、フォロー関係を追加
-	if viewer := middleware.GetUser(c); viewer != nil && viewer.ID != bundle.User.ID && h.followingRepo != nil {
-		isFollowing, _ := h.followingRepo.Exists(viewer.ID, bundle.User.ID)
-		isFollowed, _ := h.followingRepo.Exists(bundle.User.ID, viewer.ID)
-		detailed.IsFollowing = &isFollowing
-		detailed.IsFollowed = &isFollowed
+	// リモートユーザーの場合、Instance情報を付与
+	if bundle.User.Host != nil && h.instanceRepo != nil {
+		if inst, err := h.instanceRepo.FindByHost(*bundle.User.Host); err == nil {
+			detailed.Instance = &entity.InstanceLite{
+				Name:            inst.Name,
+				SoftwareName:    inst.SoftwareName,
+				SoftwareVersion: inst.SoftwareVersion,
+				IconURL:         inst.IconURL,
+				FaviconURL:      inst.FaviconURL,
+				ThemeColor:      inst.ThemeColor,
+			}
+		}
+	}
+
+	// viewerがログインしている場合、viewer依存フィールドを追加
+	if viewer := middleware.GetUser(c); viewer != nil && viewer.ID != bundle.User.ID {
+		if h.followingRepo != nil {
+			isFollowing, _ := h.followingRepo.Exists(viewer.ID, bundle.User.ID)
+			isFollowed, _ := h.followingRepo.Exists(bundle.User.ID, viewer.ID)
+			detailed.IsFollowing = &isFollowing
+			detailed.IsFollowed = &isFollowed
+			// notify/withReplies はフォロー関係レコードから取得
+			if f, err := h.followingRepo.FindByPair(viewer.ID, bundle.User.ID); err == nil {
+				detailed.Notify = f.Notify
+				wr := f.WithReplies
+				detailed.WithReplies = &wr
+			}
+		}
+		if h.blockingRepo != nil {
+			isBlocking, _ := h.blockingRepo.Exists(viewer.ID, bundle.User.ID)
+			isBlocked, _ := h.blockingRepo.Exists(bundle.User.ID, viewer.ID)
+			detailed.IsBlocking = &isBlocking
+			detailed.IsBlocked = &isBlocked
+		}
+		if h.mutingRepo != nil {
+			isMuted, _ := h.mutingRepo.Exists(viewer.ID, bundle.User.ID)
+			detailed.IsMuted = &isMuted
+		}
+		if h.renoteMutingRepo != nil {
+			isRenoteMuted, _ := h.renoteMutingRepo.Exists(viewer.ID, bundle.User.ID)
+			detailed.IsRenoteMuted = &isRenoteMuted
+		}
+		if h.followRequestRepo != nil {
+			hasPendingFrom, _ := h.followRequestRepo.Exists(viewer.ID, bundle.User.ID)
+			hasPendingTo, _ := h.followRequestRepo.Exists(bundle.User.ID, viewer.ID)
+			detailed.HasPendingFollowRequestFromYou = &hasPendingFrom
+			detailed.HasPendingFollowRequestToYou = &hasPendingTo
+		}
+		if h.memoRepo != nil {
+			if memo, err := h.memoRepo.FindByPair(viewer.ID, bundle.User.ID); err == nil {
+				detailed.Memo = &memo.Memo
+			}
+		}
 	}
 
 	return c.JSON(http.StatusOK, detailed)

--- a/internal/api/users/handler_test.go
+++ b/internal/api/users/handler_test.go
@@ -13,6 +13,7 @@ import (
 	coreuser "github.com/shiroha-a/mk/internal/core/user"
 	"github.com/shiroha-a/mk/internal/misc/id"
 	"github.com/shiroha-a/mk/internal/model"
+	"github.com/shiroha-a/mk/internal/server/middleware"
 	"github.com/shiroha-a/mk/internal/testutil"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -258,6 +259,153 @@ func TestShow_UsernameNotFound(t *testing.T) {
 	err := h.Show(c)
 	require.NoError(t, err)
 	assert.Equal(t, http.StatusNotFound, rec.Code)
+}
+
+func TestShow_ViewerDependentFields(t *testing.T) {
+	h, userRepo := newTestHandler(t)
+
+	// ターゲットユーザー
+	target := &model.User{
+		ID:                "target1",
+		Username:          "target",
+		AvatarDecorations: datatypes.JSON([]byte("[]")),
+	}
+	userRepo.Users["target1"] = target
+
+	// viewer
+	viewer := &model.User{ID: "viewer1", Username: "viewer"}
+
+	// blockingリポジトリをセット (viewerがtargetをブロック)
+	blockingRepo := testutil.NewMockBlockingRepository()
+	blockingRepo.Blockings["b1"] = &model.Blocking{ID: "b1", BlockerID: "viewer1", BlockeeID: "target1"}
+	h.SetBlockingRepo(blockingRepo)
+
+	// mutingリポジトリをセット
+	mutingRepo := testutil.NewMockMutingRepository()
+	h.SetMutingRepo(mutingRepo)
+
+	// followRequestリポジトリをセット
+	followRequestRepo := testutil.NewMockFollowRequestRepository()
+	h.SetFollowRequestRepo(followRequestRepo)
+
+	body := `{"userId": "target1"}`
+	e := echo.New()
+	req := httptest.NewRequest(http.MethodPost, "/api/users/show", strings.NewReader(body))
+	req.Header.Set(echo.HeaderContentType, echo.MIMEApplicationJSON)
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+	c.Set(string(middleware.UserContextKey), viewer)
+
+	err := h.Show(c)
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusOK, rec.Code)
+
+	var resp map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+	assert.Equal(t, true, resp["isBlocking"])
+	assert.Equal(t, false, resp["isBlocked"])
+	assert.Equal(t, false, resp["isMuted"])
+}
+
+func TestShow_ViewerMemo(t *testing.T) {
+	h, userRepo := newTestHandler(t)
+
+	target := &model.User{
+		ID:                "target1",
+		Username:          "target",
+		AvatarDecorations: datatypes.JSON([]byte("[]")),
+	}
+	userRepo.Users["target1"] = target
+
+	viewer := &model.User{ID: "viewer1", Username: "viewer"}
+
+	// memoリポジトリをセット
+	memoRepo := testutil.NewMockUserMemoRepository()
+	memoRepo.Memos["viewer1:target1"] = &model.UserMemo{
+		UserID:       "viewer1",
+		TargetUserID: "target1",
+		Memo:         "important person",
+	}
+	h.SetMemoRepo(memoRepo)
+
+	// followingリポジトリをセット (notify/withRepliesのテスト用)
+	followingRepo := testutil.NewMockFollowingRepository()
+	notify := "normal"
+	followingRepo.Followings["f1"] = &model.Following{
+		ID:          "f1",
+		FollowerID:  "viewer1",
+		FolloweeID:  "target1",
+		Notify:      &notify,
+		WithReplies: true,
+	}
+	h.SetFollowingRepo(followingRepo)
+
+	// renoteMutingリポジトリをセット
+	renoteMutingRepo := testutil.NewMockRenoteMutingRepository()
+	h.SetRenoteMutingRepo(renoteMutingRepo)
+
+	body := `{"userId": "target1"}`
+	e := echo.New()
+	req := httptest.NewRequest(http.MethodPost, "/api/users/show", strings.NewReader(body))
+	req.Header.Set(echo.HeaderContentType, echo.MIMEApplicationJSON)
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+	c.Set(string(middleware.UserContextKey), viewer)
+
+	err := h.Show(c)
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusOK, rec.Code)
+
+	var resp map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+	assert.Equal(t, "important person", resp["memo"])
+	assert.Equal(t, "normal", resp["notify"])
+	assert.Equal(t, true, resp["withReplies"])
+	assert.Equal(t, true, resp["isFollowing"])
+	assert.Equal(t, false, resp["isRenoteMuted"])
+}
+
+func TestShow_RemoteUserInstance(t *testing.T) {
+	h, userRepo := newTestHandler(t)
+
+	host := "remote.example.com"
+	target := &model.User{
+		ID:                "remote1",
+		Username:          "remoteuser",
+		Host:              &host,
+		AvatarDecorations: datatypes.JSON([]byte("[]")),
+	}
+	userRepo.Users["remote1"] = target
+
+	// instanceリポジトリをセット
+	instanceRepo := testutil.NewMockInstanceRepository()
+	instName := "Remote Instance"
+	softwareName := "misskey"
+	instanceRepo.Instances["remote.example.com"] = &model.Instance{
+		ID:               "inst1",
+		Host:             "remote.example.com",
+		Name:             &instName,
+		SoftwareName:     &softwareName,
+		FirstRetrievedAt: time.Now(),
+	}
+	h.SetInstanceRepo(instanceRepo)
+
+	body := `{"userId": "remote1"}`
+	e := echo.New()
+	req := httptest.NewRequest(http.MethodPost, "/api/users/show", strings.NewReader(body))
+	req.Header.Set(echo.HeaderContentType, echo.MIMEApplicationJSON)
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+
+	err := h.Show(c)
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusOK, rec.Code)
+
+	var resp map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+	inst := resp["instance"].(map[string]any)
+	assert.Equal(t, "Remote Instance", inst["name"])
+	assert.Equal(t, "misskey", inst["softwareName"])
 }
 
 // --- post is a small helper that exercises a handler with an optional body ---

--- a/internal/entity/note.go
+++ b/internal/entity/note.go
@@ -1,6 +1,8 @@
 package entity
 
 import (
+	"encoding/json"
+
 	"github.com/shiroha-a/mk/internal/misc/id"
 	"github.com/shiroha-a/mk/internal/model"
 	"gorm.io/datatypes"
@@ -35,6 +37,21 @@ type NoteEntity struct {
 	Poll               *PollEntity       `json:"poll,omitempty"`
 	Emojis             map[string]string `json:"emojis,omitempty"`
 	ChannelID          *string           `json:"channelId,omitempty"`
+	Channel            *ChannelLite      `json:"channel,omitempty"`
+	VisibleUserIDs     []string          `json:"visibleUserIds"`
+	Mentions           []string          `json:"mentions"`
+	HasPoll            bool              `json:"hasPoll"`
+	MyReaction         *string           `json:"myReaction,omitempty"`
+	IsHidden           bool              `json:"isHidden,omitempty"`
+}
+
+// ChannelLite is the minimal channel info embedded in NoteEntity.
+type ChannelLite struct {
+	ID                    string `json:"id"`
+	Name                  string `json:"name"`
+	Color                 string `json:"color"`
+	IsSensitive           bool   `json:"isSensitive"`
+	AllowRenoteToExternal bool   `json:"allowRenoteToExternal"`
 }
 
 // PollEntity is the poll representation in a note.
@@ -63,6 +80,16 @@ func PackNote(n *model.Note, idGen id.Generator) NoteEntity {
 		fileIDs = n.FileIDs
 	}
 
+	visibleUserIDs := make([]string, 0)
+	if n.VisibleUserIDs != nil {
+		visibleUserIDs = n.VisibleUserIDs
+	}
+
+	mentions := make([]string, 0)
+	if n.Mentions != nil {
+		mentions = n.Mentions
+	}
+
 	entity := NoteEntity{
 		ID:                 n.ID,
 		CreatedAt:          createdAt,
@@ -73,7 +100,7 @@ func PackNote(n *model.Note, idGen id.Generator) NoteEntity {
 		LocalOnly:          n.LocalOnly,
 		ReactionAcceptance: n.ReactionAcceptance,
 		Reactions:          n.Reactions,
-		ReactionCount:      0,
+		ReactionCount:      sumReactions(n.Reactions),
 		ReactionEmojis:     make(map[string]string),
 		RenoteCount:        n.RenoteCount,
 		RepliesCount:       n.RepliesCount,
@@ -87,6 +114,9 @@ func PackNote(n *model.Note, idGen id.Generator) NoteEntity {
 		Tags:               n.Tags,
 		Emojis:             make(map[string]string),
 		ChannelID:          n.ChannelID,
+		VisibleUserIDs:     visibleUserIDs,
+		Mentions:           mentions,
+		HasPoll:            n.HasPoll,
 	}
 
 	if n.User != nil {
@@ -94,4 +124,20 @@ func PackNote(n *model.Note, idGen id.Generator) NoteEntity {
 	}
 
 	return entity
+}
+
+// sumReactions decodes the reactions JSONB and sums all values.
+func sumReactions(raw datatypes.JSON) int {
+	if len(raw) == 0 {
+		return 0
+	}
+	var m map[string]float64
+	if err := json.Unmarshal(raw, &m); err != nil {
+		return 0
+	}
+	total := 0
+	for _, v := range m {
+		total += int(v)
+	}
+	return total
 }

--- a/internal/entity/note_test.go
+++ b/internal/entity/note_test.go
@@ -93,6 +93,107 @@ func TestPackNote_WithUser(t *testing.T) {
 	assert.Equal(t, "testuser", entity.User.Username)
 }
 
+func TestPackNote_ReactionCount(t *testing.T) {
+	idGen := newTestIDGen(t)
+	noteID := idGen.Generate(time.Now())
+
+	note := &model.Note{
+		ID:         noteID,
+		UserID:     "user1",
+		Visibility: model.NoteVisibilityPublic,
+		Reactions:  datatypes.JSON([]byte(`{"👍":3,"❤️":2,"🎉":1}`)),
+	}
+
+	entity := PackNote(note, idGen)
+	assert.Equal(t, 6, entity.ReactionCount)
+}
+
+func TestPackNote_ReactionCount_Empty(t *testing.T) {
+	idGen := newTestIDGen(t)
+	noteID := idGen.Generate(time.Now())
+
+	note := &model.Note{
+		ID:         noteID,
+		UserID:     "user1",
+		Visibility: model.NoteVisibilityPublic,
+		Reactions:  datatypes.JSON([]byte("{}")),
+	}
+
+	entity := PackNote(note, idGen)
+	assert.Equal(t, 0, entity.ReactionCount)
+}
+
+func TestPackNote_ReactionCount_NilReactions(t *testing.T) {
+	idGen := newTestIDGen(t)
+	noteID := idGen.Generate(time.Now())
+
+	note := &model.Note{
+		ID:         noteID,
+		UserID:     "user1",
+		Visibility: model.NoteVisibilityPublic,
+	}
+
+	entity := PackNote(note, idGen)
+	assert.Equal(t, 0, entity.ReactionCount)
+}
+
+func TestPackNote_ReactionCount_InvalidJSON(t *testing.T) {
+	idGen := newTestIDGen(t)
+	noteID := idGen.Generate(time.Now())
+
+	note := &model.Note{
+		ID:         noteID,
+		UserID:     "user1",
+		Visibility: model.NoteVisibilityPublic,
+		Reactions:  datatypes.JSON([]byte("invalid")),
+	}
+
+	entity := PackNote(note, idGen)
+	assert.Equal(t, 0, entity.ReactionCount)
+}
+
+func TestPackNote_VisibleUserIDs_Mentions_HasPoll(t *testing.T) {
+	idGen := newTestIDGen(t)
+	noteID := idGen.Generate(time.Now())
+
+	note := &model.Note{
+		ID:             noteID,
+		UserID:         "user1",
+		Visibility:     model.NoteVisibilitySpecified,
+		Reactions:      datatypes.JSON([]byte("{}")),
+		VisibleUserIDs: pq.StringArray{"user2", "user3"},
+		Mentions:       pq.StringArray{"user2"},
+		HasPoll:        true,
+	}
+
+	entity := PackNote(note, idGen)
+
+	assert.Equal(t, []string{"user2", "user3"}, entity.VisibleUserIDs)
+	assert.Equal(t, []string{"user2"}, entity.Mentions)
+	assert.True(t, entity.HasPoll)
+}
+
+func TestPackNote_NilVisibleUserIDs_Mentions(t *testing.T) {
+	idGen := newTestIDGen(t)
+	noteID := idGen.Generate(time.Now())
+
+	note := &model.Note{
+		ID:         noteID,
+		UserID:     "user1",
+		Visibility: model.NoteVisibilityPublic,
+		Reactions:  datatypes.JSON([]byte("{}")),
+	}
+
+	entity := PackNote(note, idGen)
+
+	// nil → empty slice
+	assert.NotNil(t, entity.VisibleUserIDs)
+	assert.Empty(t, entity.VisibleUserIDs)
+	assert.NotNil(t, entity.Mentions)
+	assert.Empty(t, entity.Mentions)
+	assert.False(t, entity.HasPoll)
+}
+
 func TestPackNote_CreatedAtParsing(t *testing.T) {
 	idGen := newTestIDGen(t)
 	noteID := idGen.Generate(time.Now())

--- a/internal/entity/user.go
+++ b/internal/entity/user.go
@@ -25,28 +25,52 @@ type UserLite struct {
 // UserDetailed includes additional fields for detailed user views.
 type UserDetailed struct {
 	UserLite
-	BannerURL      *string        `json:"bannerUrl"`
-	BannerBlurhash *string        `json:"bannerBlurhash"`
-	IsLocked       bool           `json:"isLocked"`
-	IsSilenced     bool           `json:"isSilenced"`
-	IsSuspended    bool           `json:"isSuspended"`
-	Description    *string        `json:"description"`
-	Location       *string        `json:"location"`
-	Birthday       *string        `json:"birthday"`
-	Lang           *string        `json:"lang"`
-	Fields         datatypes.JSON `json:"fields"`
-	FollowersCount int            `json:"followersCount"`
-	FollowingCount int            `json:"followingCount"`
-	NotesCount     int            `json:"notesCount"`
-	CreatedAt      string         `json:"createdAt"`
-	UpdatedAt      *string        `json:"updatedAt"`
-	URI            *string        `json:"uri"`
-	URL            *string        `json:"url"`
-	PinnedNoteIDs  []string       `json:"pinnedNoteIds"`
-	PinnedNotes    []any          `json:"pinnedNotes"`
-	Roles          []any          `json:"roles"`
-	IsFollowing    *bool          `json:"isFollowing"`
-	IsFollowed     *bool          `json:"isFollowed"`
+	BannerURL           *string        `json:"bannerUrl"`
+	BannerBlurhash      *string        `json:"bannerBlurhash"`
+	IsLocked            bool           `json:"isLocked"`
+	IsSilenced          bool           `json:"isSilenced"`
+	IsSuspended         bool           `json:"isSuspended"`
+	Description         *string        `json:"description"`
+	Location            *string        `json:"location"`
+	Birthday            *string        `json:"birthday"`
+	Lang                *string        `json:"lang"`
+	Fields              datatypes.JSON `json:"fields"`
+	VerifiedLinks       []string       `json:"verifiedLinks"`
+	FollowersCount      int            `json:"followersCount"`
+	FollowingCount      int            `json:"followingCount"`
+	NotesCount          int            `json:"notesCount"`
+	FollowersVisibility string         `json:"followersVisibility"`
+	FollowingVisibility string         `json:"followingVisibility"`
+	CreatedAt           string         `json:"createdAt"`
+	UpdatedAt           *string        `json:"updatedAt"`
+	URI                 *string        `json:"uri"`
+	URL                 *string        `json:"url"`
+	PinnedNoteIDs       []string       `json:"pinnedNoteIds"`
+	PinnedNotes         []any          `json:"pinnedNotes"`
+	Roles               []any          `json:"roles"`
+	Instance            *InstanceLite  `json:"instance,omitempty"`
+	// viewer依存フィールド (ハンドラ側でセット)
+	IsFollowing                    *bool   `json:"isFollowing"`
+	IsFollowed                     *bool   `json:"isFollowed"`
+	IsBlocking                     *bool   `json:"isBlocking,omitempty"`
+	IsBlocked                      *bool   `json:"isBlocked,omitempty"`
+	IsMuted                        *bool   `json:"isMuted,omitempty"`
+	IsRenoteMuted                  *bool   `json:"isRenoteMuted,omitempty"`
+	HasPendingFollowRequestFromYou *bool   `json:"hasPendingFollowRequestFromYou,omitempty"`
+	HasPendingFollowRequestToYou   *bool   `json:"hasPendingFollowRequestToYou,omitempty"`
+	Notify                         *string `json:"notify,omitempty"`
+	WithReplies                    *bool   `json:"withReplies,omitempty"`
+	Memo                           *string `json:"memo,omitempty"`
+}
+
+// InstanceLite is the minimal instance info embedded in UserDetailed for remote users.
+type InstanceLite struct {
+	Name            *string `json:"name"`
+	SoftwareName    *string `json:"softwareName"`
+	SoftwareVersion *string `json:"softwareVersion"`
+	IconURL         *string `json:"iconUrl"`
+	FaviconURL      *string `json:"faviconUrl"`
+	ThemeColor      *string `json:"themeColor"`
 }
 
 // PackUserLite converts a model.User to a UserLite DTO.
@@ -80,18 +104,21 @@ func PackUserLite(u *model.User) UserLite {
 // PackUserDetailed converts a model.User and optional profile to UserDetailed.
 func PackUserDetailed(u *model.User, profile *model.UserProfile, idGens ...id.Generator) UserDetailed {
 	d := UserDetailed{
-		UserLite:       PackUserLite(u),
-		BannerURL:      u.BannerURL,
-		BannerBlurhash: u.BannerBlurhash,
-		IsLocked:       u.IsLocked,
-		IsSuspended:    u.IsSuspended,
-		FollowersCount: u.FollowersCount,
-		FollowingCount: u.FollowingCount,
-		NotesCount:     u.NotesCount,
-		URI:            u.URI,
-		PinnedNoteIDs:  []string{},
-		PinnedNotes:    []any{},
-		Roles:          []any{},
+		UserLite:            PackUserLite(u),
+		BannerURL:           u.BannerURL,
+		BannerBlurhash:      u.BannerBlurhash,
+		IsLocked:            u.IsLocked,
+		IsSuspended:         u.IsSuspended,
+		FollowersCount:      u.FollowersCount,
+		FollowingCount:      u.FollowingCount,
+		NotesCount:          u.NotesCount,
+		VerifiedLinks:       []string{},
+		FollowersVisibility: "public",
+		FollowingVisibility: "public",
+		URI:                 u.URI,
+		PinnedNoteIDs:       []string{},
+		PinnedNotes:         []any{},
+		Roles:               []any{},
 	}
 
 	// IDからcreatedAtを抽出
@@ -107,6 +134,11 @@ func PackUserDetailed(u *model.User, profile *model.UserProfile, idGens ...id.Ge
 		d.Birthday = profile.Birthday
 		d.Lang = profile.Lang
 		d.Fields = profile.Fields
+		if len(profile.VerifiedLinks) > 0 {
+			d.VerifiedLinks = []string(profile.VerifiedLinks)
+		}
+		d.FollowersVisibility = string(profile.FollowersVisibility)
+		d.FollowingVisibility = string(profile.FollowingVisibility)
 	}
 
 	return d

--- a/internal/entity/user_test.go
+++ b/internal/entity/user_test.go
@@ -3,6 +3,7 @@ package entity
 import (
 	"testing"
 
+	"github.com/lib/pq"
 	"github.com/shiroha-a/mk/internal/model"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -129,6 +130,60 @@ func TestPackUserDetailed(t *testing.T) {
 	assert.Equal(t, &location, detailed.Location)
 	assert.Equal(t, &birthday, detailed.Birthday)
 	assert.Equal(t, &lang, detailed.Lang)
+}
+
+func TestPackUserDetailed_ProfileVisibility(t *testing.T) {
+	u := &model.User{
+		ID:                "user5",
+		Username:          "visible",
+		AvatarDecorations: datatypes.JSON([]byte("[]")),
+	}
+
+	profile := &model.UserProfile{
+		UserID:              "user5",
+		FollowersVisibility: model.FollowingVisibilityFollowers,
+		FollowingVisibility: model.FollowingVisibilityPrivate,
+		Fields:              datatypes.JSON([]byte("[]")),
+	}
+
+	detailed := PackUserDetailed(u, profile)
+
+	assert.Equal(t, "followers", detailed.FollowersVisibility)
+	assert.Equal(t, "private", detailed.FollowingVisibility)
+}
+
+func TestPackUserDetailed_VerifiedLinks(t *testing.T) {
+	u := &model.User{
+		ID:                "user6",
+		Username:          "verified",
+		AvatarDecorations: datatypes.JSON([]byte("[]")),
+	}
+
+	profile := &model.UserProfile{
+		UserID:        "user6",
+		VerifiedLinks: pq.StringArray{"https://example.com", "https://blog.example.com"},
+		Fields:        datatypes.JSON([]byte("[]")),
+	}
+
+	detailed := PackUserDetailed(u, profile)
+
+	assert.Equal(t, []string{"https://example.com", "https://blog.example.com"}, detailed.VerifiedLinks)
+}
+
+func TestPackUserDetailed_DefaultValues(t *testing.T) {
+	u := &model.User{
+		ID:                "user7",
+		Username:          "defaults",
+		AvatarDecorations: datatypes.JSON([]byte("[]")),
+	}
+
+	// nilプロフィールのデフォルト
+	detailed := PackUserDetailed(u, nil)
+
+	assert.Equal(t, "public", detailed.FollowersVisibility)
+	assert.Equal(t, "public", detailed.FollowingVisibility)
+	assert.NotNil(t, detailed.VerifiedLinks)
+	assert.Empty(t, detailed.VerifiedLinks)
 }
 
 func TestPackUserDetailed_NilProfile(t *testing.T) {

--- a/internal/repository/channel.go
+++ b/internal/repository/channel.go
@@ -9,6 +9,8 @@ import (
 type ChannelRepository interface {
 	Create(c *model.Channel) error
 	FindByID(id string) (*model.Channel, error)
+	// FindByIDs returns channels matching the given IDs.
+	FindByIDs(ids []string) ([]*model.Channel, error)
 	UpdateFields(channelID string, fields map[string]any) error
 	IncrementCount(channelID, column string, delta int) error
 	List(filter model.ChannelListFilter) ([]*model.Channel, error)
@@ -33,6 +35,17 @@ func (r *channelRepository) FindByID(id string) (*model.Channel, error) {
 		return nil, err
 	}
 	return &c, nil
+}
+
+func (r *channelRepository) FindByIDs(ids []string) ([]*model.Channel, error) {
+	if len(ids) == 0 {
+		return nil, nil
+	}
+	var rows []*model.Channel
+	if err := r.db.Where("id IN ?", ids).Find(&rows).Error; err != nil {
+		return nil, err
+	}
+	return rows, nil
 }
 
 // UpdateFields applies a map of column → value updates to the channel row.

--- a/internal/repository/note_reaction.go
+++ b/internal/repository/note_reaction.go
@@ -17,6 +17,9 @@ type NoteReactionRepository interface {
 	Create(r *model.NoteReaction) error
 	Delete(r *model.NoteReaction) error
 	FindByPair(userID, noteID string) (*model.NoteReaction, error)
+	// FindByUserAndNoteIDs returns reactions for a user across multiple notes.
+	// noteIDをキーとしたmapを返す。
+	FindByUserAndNoteIDs(userID string, noteIDs []string) (map[string]*model.NoteReaction, error)
 	ListByNoteID(noteID string, untilID, sinceID string, limit int, reaction string) ([]*model.NoteReaction, error)
 }
 
@@ -51,6 +54,21 @@ func (r *noteReactionRepository) FindByPair(userID, noteID string) (*model.NoteR
 		return nil, err
 	}
 	return &rec, nil
+}
+
+func (r *noteReactionRepository) FindByUserAndNoteIDs(userID string, noteIDs []string) (map[string]*model.NoteReaction, error) {
+	if len(noteIDs) == 0 {
+		return map[string]*model.NoteReaction{}, nil
+	}
+	var rows []*model.NoteReaction
+	if err := r.db.Where("\"userId\" = ? AND \"noteId\" IN ?", userID, noteIDs).Find(&rows).Error; err != nil {
+		return nil, err
+	}
+	m := make(map[string]*model.NoteReaction, len(rows))
+	for _, row := range rows {
+		m[row.NoteID] = row
+	}
+	return m, nil
 }
 
 // ListByNoteID returns reactions for the given noteID, optionally filtered by

--- a/internal/server/frontend.go
+++ b/internal/server/frontend.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/labstack/echo/v4"
 	"github.com/shiroha-a/mk/internal/config"
+	"github.com/shiroha-a/mk/internal/core/role"
 	"github.com/shiroha-a/mk/internal/model"
 	"github.com/shiroha-a/mk/internal/repository"
 )
@@ -271,7 +272,7 @@ func buildMetaJSON(cfg *config.Config, m *model.Meta) string {
 		"sentryForFrontend":            nil,
 		"googleAnalyticsMeasurementId": m.GoogleAnalyticsMeasurementID,
 		"clientOptions":                clientOptionsJSON(m.ClientOptions),
-		"policies":                     defaultMetaPolicies(),
+		"policies":                     role.DefaultPolicies(),
 		"features": map[string]any{
 			"registration":           !m.DisableRegistration,
 			"emailRequiredForSignup": m.EmailRequiredForSignup,
@@ -300,27 +301,6 @@ func clientOptionsJSON(raw []byte) any {
 		return map[string]any{}
 	}
 	return out
-}
-
-// defaultMetaPolicies returns the Misskey default policies for the inline meta.
-func defaultMetaPolicies() map[string]any {
-	return map[string]any{
-		"gtlAvailable": true, "ltlAvailable": true,
-		"canPublicNote": true, "mentionLimit": 20,
-		"canInvite": false, "inviteLimit": 0, "inviteLimitCycle": 10080,
-		"inviteExpirationTime": 0, "canManageCustomEmojis": false,
-		"canManageAvatarDecorations": false, "canSearchNotes": false,
-		"canSearchUsers": true, "canUseTranslator": true,
-		"canHideAds": false, "driveCapacityMb": 100, "maxFileSizeMb": 30,
-		"alwaysMarkNsfw": false, "canUpdateBioMedia": true,
-		"pinLimit": 5, "antennaLimit": 5, "wordMuteLimit": 200,
-		"webhookLimit": 3, "clipLimit": 10, "noteEachClipsLimit": 200,
-		"userListLimit": 10, "userEachUserListsLimit": 50,
-		"rateLimitFactor": 1, "avatarDecorationLimit": 1,
-		"canImportAntennas": false, "canImportBlocking": false,
-		"canImportFollowing": false, "canImportMuting": false,
-		"canImportUserLists": false, "chatAvailability": "available",
-	}
 }
 
 // manifestJSON generates a PWA manifest.json response.

--- a/internal/server/router.go
+++ b/internal/server/router.go
@@ -636,6 +636,8 @@ func (s *Server) setupRoutes() {
 	// Notes endpoints
 	notesHandler := notes.NewHandler(noteRepo, noteCreateService, noteDeleteService, noteQueryService, timelineService, reactionService, pollService, searchService, idGen)
 	notesHandler.SetDriveFileRepo(driveFileRepo)
+	notesHandler.SetNoteReactionRepo(reactionRepo)
+	notesHandler.SetChannelRepo(channelRepo)
 	if m, err := metaRepo.Fetch(); err == nil {
 		notesHandler.SetUGCVisibility(m.UgcVisibilityForVisitor)
 		if m.DeeplAuthKey != nil && *m.DeeplAuthKey != "" {
@@ -687,6 +689,11 @@ func (s *Server) setupRoutes() {
 	usersHandler := users.NewHandler(userService, followingService, noteRepo, idGen)
 	usersHandler.SetChartHook(chartHooks)
 	usersHandler.SetFollowingRepo(followingRepo)
+	usersHandler.SetBlockingRepo(blockingRepo)
+	usersHandler.SetMutingRepo(mutingRepo)
+	usersHandler.SetRenoteMutingRepo(renoteMutingRepo)
+	usersHandler.SetFollowRequestRepo(followRequestRepo)
+	usersHandler.SetInstanceRepo(instanceRepo)
 	api.POST("/users/show", usersHandler.Show)
 	api.POST("/users/search", usersHandler.Search)
 	api.POST("/users/notes", usersHandler.Notes)

--- a/internal/testutil/mock_repository.go
+++ b/internal/testutil/mock_repository.go
@@ -798,6 +798,20 @@ func (m *MockNoteReactionRepository) FindByPair(userID, noteID string) (*model.N
 	return nil, ErrNotFound
 }
 
+func (m *MockNoteReactionRepository) FindByUserAndNoteIDs(userID string, noteIDs []string) (map[string]*model.NoteReaction, error) {
+	result := make(map[string]*model.NoteReaction)
+	noteIDSet := make(map[string]bool, len(noteIDs))
+	for _, id := range noteIDs {
+		noteIDSet[id] = true
+	}
+	for _, r := range m.Reactions {
+		if r.UserID == userID && noteIDSet[r.NoteID] {
+			result[r.NoteID] = r
+		}
+	}
+	return result, nil
+}
+
 func (m *MockNoteReactionRepository) ListByNoteID(noteID, untilID, sinceID string, limit int, reaction string) ([]*model.NoteReaction, error) {
 	var rows []*model.NoteReaction
 	for _, r := range m.Reactions {
@@ -2015,6 +2029,16 @@ func (m *MockChannelRepository) FindByID(id string) (*model.Channel, error) {
 	return c, nil
 }
 
+func (m *MockChannelRepository) FindByIDs(ids []string) ([]*model.Channel, error) {
+	var result []*model.Channel
+	for _, id := range ids {
+		if ch, ok := m.Channels[id]; ok {
+			result = append(result, ch)
+		}
+	}
+	return result, nil
+}
+
 func (m *MockChannelRepository) UpdateFields(channelID string, fields map[string]any) error {
 	if m.UpdateErr != nil {
 		return m.UpdateErr
@@ -2770,4 +2794,32 @@ func (m *MockRoleAssignmentRepository) Exists(userID, roleID string) (bool, erro
 		return false, nil
 	}
 	return true, nil
+}
+
+// MockUserMemoRepository is a test double for repository.UserMemoRepository.
+type MockUserMemoRepository struct {
+	// keyed by "userID:targetUserID"
+	Memos map[string]*model.UserMemo
+}
+
+// NewMockUserMemoRepository creates an empty MockUserMemoRepository.
+func NewMockUserMemoRepository() *MockUserMemoRepository {
+	return &MockUserMemoRepository{Memos: make(map[string]*model.UserMemo)}
+}
+
+func (m *MockUserMemoRepository) CreateOrUpdate(memo *model.UserMemo) error {
+	m.Memos[memo.UserID+":"+memo.TargetUserID] = memo
+	return nil
+}
+
+func (m *MockUserMemoRepository) FindByPair(userID, targetUserID string) (*model.UserMemo, error) {
+	if memo, ok := m.Memos[userID+":"+targetUserID]; ok {
+		return memo, nil
+	}
+	return nil, ErrNotFound
+}
+
+func (m *MockUserMemoRepository) Delete(userID, targetUserID string) error {
+	delete(m.Memos, userID+":"+targetUserID)
+	return nil
 }


### PR DESCRIPTION
## Summary

フロントエンドが参照する NoteEntity と UserDetailed のレスポンスに多数のフィールドが欠落していた問題を修正。TS版Misskeyと同等のレスポンスを返すようにする。

## 主な変更点

### defaultPolicies 統一
- 5箇所にコピペされていた `defaultPolicies()` を `role.DefaultPolicies()` に統一
- signup版の誤った値 (mentionLimit=150, canImport*=true) を修正

### NoteEntity 拡充
- `reactionCount`: Reactions JSONから値を合算して計算
- `myReaction`: viewer のリアクションをバッチ取得して設定
- `channel`: ChannelLite オブジェクトをバッチ取得して設定
- `visibleUserIds`, `mentions`, `hasPoll`: model からマッピング
- `resolveViewerFields()`: N+1回避のバッチ解決パターン

### UserDetailed 拡充
- `instance`: リモートユーザーのインスタンス情報 (InstanceLite)
- `isBlocking`, `isBlocked`, `isMuted`, `isRenoteMuted`: viewer依存フィールド
- `hasPendingFollowRequestFromYou`, `hasPendingFollowRequestToYou`: フォローリクエスト状態
- `notify`, `withReplies`: フォロー関係レコードから取得
- `memo`: ユーザーメモ
- `verifiedLinks`, `followersVisibility`, `followingVisibility`: profile由来

### /api/i 修正
- ハードコードされていた値を実データに置換: `loggedInDays`, `achievements`, `twoFactorBackupCodesStock`, `securityKeys`, `securityKeysList`, `chatScope`, `followedMessage`, `avatarId`, `bannerId`, `movedTo`, `alsoKnownAs`

## テスト

- entity: 86.4% → 96.6%
- notes: 90.0% → 95.7%
- users: 82.3% → 95.7%
- i: 89.2% → 90.6%

```
go test ./internal/entity/... ./internal/api/notes/... ./internal/api/users/... ./internal/api/i/... ./internal/api/meta/... ./internal/api/signup/... ./internal/core/role/...
```

Closes #110

🤖 Generated with [Claude Code](https://claude.com/claude-code)