### PR TITLE
Phase P2.1: Password reset, MiAuth gen-token, App API, signin history

### DIFF
--- a/internal/api/app/handler.go
+++ b/internal/api/app/handler.go
@@ -1,0 +1,149 @@
+package app
+
+import (
+	"crypto/rand"
+	"encoding/hex"
+	"net/http"
+	"time"
+
+	"github.com/labstack/echo/v4"
+	"github.com/lib/pq"
+	"github.com/shiroha-a/mk/internal/misc/id"
+	"github.com/shiroha-a/mk/internal/model"
+	"github.com/shiroha-a/mk/internal/repository"
+	"github.com/shiroha-a/mk/internal/server/middleware"
+)
+
+// Handler handles app-related API endpoints.
+type Handler struct {
+	repo  repository.AuthSessionRepository
+	idGen id.Generator
+}
+
+// NewHandler creates a new app Handler.
+func NewHandler(repo repository.AuthSessionRepository, idGen id.Generator) *Handler {
+	return &Handler{repo: repo, idGen: idGen}
+}
+
+func apiError(code, message, errID string) map[string]any {
+	return map[string]any{
+		"error": map[string]any{"message": message, "code": code, "id": errID},
+	}
+}
+
+// Create handles POST /api/app/create.
+func (h *Handler) Create(c echo.Context) error {
+	var req struct {
+		Name        string   `json:"name"`
+		Description string   `json:"description"`
+		Permission  []string `json:"permission"`
+		CallbackURL *string  `json:"callbackUrl"`
+	}
+	if err := c.Bind(&req); err != nil || req.Name == "" || req.Description == "" || req.Permission == nil {
+		return c.JSON(http.StatusBadRequest, apiError("INVALID_PARAM", "name, description, and permission are required.", "3d81ceae-475f-4600-b2a8-2bc116157532"))
+	}
+
+	// 認証済みユーザーのIDを取得（任意）
+	var userID *string
+	if u := middleware.GetUser(c); u != nil {
+		userID = &u.ID
+	}
+
+	now := time.Now()
+	a := &model.App{
+		ID:          h.idGen.Generate(now),
+		CreatedAt:   now,
+		UserID:      userID,
+		Secret:      secureRandomHex(32),
+		Name:        req.Name,
+		Description: req.Description,
+		Permission:  pq.StringArray(req.Permission),
+		CallbackURL: req.CallbackURL,
+	}
+	if err := h.repo.CreateApp(a); err != nil {
+		return c.JSON(http.StatusInternalServerError, apiError("INTERNAL_ERROR", "Internal error.", "5d37dbcb-891e-41ca-a3d6-e690c97775ac"))
+	}
+
+	return c.JSON(http.StatusOK, packApp(a, true))
+}
+
+// Show handles POST /api/app/show.
+func (h *Handler) Show(c echo.Context) error {
+	var req struct {
+		AppID string `json:"appId"`
+	}
+	if err := c.Bind(&req); err != nil || req.AppID == "" {
+		return c.JSON(http.StatusBadRequest, apiError("INVALID_PARAM", "appId is required.", "3d81ceae-475f-4600-b2a8-2bc116157532"))
+	}
+
+	a, err := h.repo.FindAppByID(req.AppID)
+	if err != nil {
+		return c.JSON(http.StatusNotFound, apiError("NO_SUCH_APP", "No such app.", "dce83913-2dc6-4093-8a7b-71dbb11718a3"))
+	}
+
+	// 認証済み && 自分のアプリならsecretも返す
+	includeSecret := false
+	if u := middleware.GetUser(c); u != nil && a.UserID != nil && *a.UserID == u.ID {
+		includeSecret = true
+	}
+
+	return c.JSON(http.StatusOK, packApp(a, includeSecret))
+}
+
+// MyApps handles POST /api/my/apps.
+func (h *Handler) MyApps(c echo.Context) error {
+	u := middleware.GetUser(c)
+	var req struct {
+		Limit  *int `json:"limit"`
+		Offset *int `json:"offset"`
+	}
+	if err := c.Bind(&req); err != nil {
+		return c.JSON(http.StatusBadRequest, apiError("INVALID_PARAM", "Invalid parameters.", "3d81ceae-475f-4600-b2a8-2bc116157532"))
+	}
+
+	limit := 10
+	if req.Limit != nil {
+		limit = *req.Limit
+		if limit < 1 {
+			limit = 1
+		}
+		if limit > 100 {
+			limit = 100
+		}
+	}
+	offset := 0
+	if req.Offset != nil && *req.Offset > 0 {
+		offset = *req.Offset
+	}
+
+	apps, err := h.repo.ListAppsByUserID(u.ID, limit, offset)
+	if err != nil {
+		return c.JSON(http.StatusInternalServerError, apiError("INTERNAL_ERROR", "Internal error.", "5d37dbcb-891e-41ca-a3d6-e690c97775ac"))
+	}
+
+	result := make([]map[string]any, len(apps))
+	for i, a := range apps {
+		result[i] = packApp(a, true)
+	}
+	return c.JSON(http.StatusOK, result)
+}
+
+func packApp(a *model.App, includeSecret bool) map[string]any {
+	resp := map[string]any{
+		"id":           a.ID,
+		"name":         a.Name,
+		"callbackUrl":  a.CallbackURL,
+		"permission":   a.Permission,
+		"isAuthorized": false,
+	}
+	if includeSecret {
+		resp["secret"] = a.Secret
+	}
+	return resp
+}
+
+func secureRandomHex(n int) string {
+	b := make([]byte, (n+1)/2)
+	_, _ = rand.Read(b)
+	return hex.EncodeToString(b)[:n]
+}

--- a/internal/api/app/handler.go
+++ b/internal/api/app/handler.go
@@ -1,13 +1,12 @@
 package app
 
 import (
-	"crypto/rand"
-	"encoding/hex"
 	"net/http"
 	"time"
 
 	"github.com/labstack/echo/v4"
 	"github.com/lib/pq"
+	"github.com/shiroha-a/mk/internal/misc"
 	"github.com/shiroha-a/mk/internal/misc/id"
 	"github.com/shiroha-a/mk/internal/model"
 	"github.com/shiroha-a/mk/internal/repository"
@@ -54,7 +53,7 @@ func (h *Handler) Create(c echo.Context) error {
 		ID:          h.idGen.Generate(now),
 		CreatedAt:   now,
 		UserID:      userID,
-		Secret:      secureRandomHex(32),
+		Secret:      misc.SecureRandomHex(32),
 		Name:        req.Name,
 		Description: req.Description,
 		Permission:  pq.StringArray(req.Permission),
@@ -140,10 +139,4 @@ func packApp(a *model.App, includeSecret bool) map[string]any {
 		resp["secret"] = a.Secret
 	}
 	return resp
-}
-
-func secureRandomHex(n int) string {
-	b := make([]byte, (n+1)/2)
-	_, _ = rand.Read(b)
-	return hex.EncodeToString(b)[:n]
 }

--- a/internal/api/app/handler_test.go
+++ b/internal/api/app/handler_test.go
@@ -1,0 +1,268 @@
+package app
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/labstack/echo/v4"
+	"github.com/lib/pq"
+	"github.com/shiroha-a/mk/internal/misc/id"
+	"github.com/shiroha-a/mk/internal/model"
+	"github.com/shiroha-a/mk/internal/server/middleware"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// --- Mock ---
+
+type mockAuthSessionRepo struct {
+	apps         map[string]*model.App
+	accessTokens map[string]*model.AccessToken
+	sessions     map[string]*model.AuthSession
+	createErr    error
+}
+
+func newMockRepo() *mockAuthSessionRepo {
+	return &mockAuthSessionRepo{
+		apps:         make(map[string]*model.App),
+		accessTokens: make(map[string]*model.AccessToken),
+		sessions:     make(map[string]*model.AuthSession),
+	}
+}
+
+func (m *mockAuthSessionRepo) FindAppBySecret(secret string) (*model.App, error) {
+	for _, a := range m.apps {
+		if a.Secret == secret {
+			return a, nil
+		}
+	}
+	return nil, assert.AnError
+}
+func (m *mockAuthSessionRepo) CreateApp(app *model.App) error {
+	if m.createErr != nil {
+		return m.createErr
+	}
+	m.apps[app.ID] = app
+	return nil
+}
+func (m *mockAuthSessionRepo) CreateSession(*model.AuthSession) error { return nil }
+func (m *mockAuthSessionRepo) FindSessionByToken(string) (*model.AuthSession, error) {
+	return nil, assert.AnError
+}
+func (m *mockAuthSessionRepo) FindSessionByTokenAndAppID(string, string) (*model.AuthSession, error) {
+	return nil, assert.AnError
+}
+func (m *mockAuthSessionRepo) UpdateSessionUserID(string, string) error { return nil }
+func (m *mockAuthSessionRepo) DeleteSession(string) error               { return nil }
+func (m *mockAuthSessionRepo) FindAccessTokenByAppAndUser(string, string) (*model.AccessToken, error) {
+	return nil, assert.AnError
+}
+func (m *mockAuthSessionRepo) CreateAccessToken(t *model.AccessToken) error {
+	m.accessTokens[t.ID] = t
+	return nil
+}
+
+func (m *mockAuthSessionRepo) FindAppByID(id string) (*model.App, error) {
+	a, ok := m.apps[id]
+	if !ok {
+		return nil, assert.AnError
+	}
+	return a, nil
+}
+
+func (m *mockAuthSessionRepo) ListAppsByUserID(userID string, limit, offset int) ([]*model.App, error) {
+	var apps []*model.App
+	for _, a := range m.apps {
+		if a.UserID != nil && *a.UserID == userID {
+			apps = append(apps, a)
+		}
+	}
+	if offset >= len(apps) {
+		return []*model.App{}, nil
+	}
+	apps = apps[offset:]
+	if len(apps) > limit {
+		apps = apps[:limit]
+	}
+	return apps, nil
+}
+
+func newTestHandler() (*Handler, *mockAuthSessionRepo) {
+	idGen, _ := id.NewGenerator("aidx")
+	repo := newMockRepo()
+	return NewHandler(repo, idGen), repo
+}
+
+func post(handler func(echo.Context) error, body string, user *model.User) *httptest.ResponseRecorder {
+	e := echo.New()
+	req := httptest.NewRequest(http.MethodPost, "/", strings.NewReader(body))
+	req.Header.Set(echo.HeaderContentType, echo.MIMEApplicationJSON)
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+	if user != nil {
+		c.Set(string(middleware.UserContextKey), user)
+	}
+	_ = handler(c)
+	return rec
+}
+
+// --- Create ---
+
+func TestCreate_Success(t *testing.T) {
+	h, repo := newTestHandler()
+
+	rec := post(h.Create, `{"name":"MyApp","description":"desc","permission":["read:account"]}`, nil)
+	assert.Equal(t, http.StatusOK, rec.Code)
+
+	var resp map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+	assert.Equal(t, "MyApp", resp["name"])
+	assert.NotEmpty(t, resp["secret"])
+	assert.NotEmpty(t, resp["id"])
+	assert.Len(t, repo.apps, 1)
+}
+
+func TestCreate_WithUser(t *testing.T) {
+	h, repo := newTestHandler()
+	user := &model.User{ID: "u1"}
+
+	rec := post(h.Create, `{"name":"App","description":"d","permission":["read:account"]}`, user)
+	assert.Equal(t, http.StatusOK, rec.Code)
+
+	for _, a := range repo.apps {
+		require.NotNil(t, a.UserID)
+		assert.Equal(t, "u1", *a.UserID)
+	}
+}
+
+func TestCreate_InvalidParam(t *testing.T) {
+	h, _ := newTestHandler()
+
+	rec := post(h.Create, `{}`, nil)
+	assert.Equal(t, http.StatusBadRequest, rec.Code)
+
+	rec = post(h.Create, `{"name":"x"}`, nil)
+	assert.Equal(t, http.StatusBadRequest, rec.Code)
+}
+
+func TestCreate_DBError(t *testing.T) {
+	h, repo := newTestHandler()
+	repo.createErr = assert.AnError
+
+	rec := post(h.Create, `{"name":"App","description":"d","permission":["read:account"]}`, nil)
+	assert.Equal(t, http.StatusInternalServerError, rec.Code)
+}
+
+// --- Show ---
+
+func TestShow_Success(t *testing.T) {
+	h, repo := newTestHandler()
+	repo.apps["app1"] = &model.App{ID: "app1", Name: "MyApp", Secret: "s1", Permission: pq.StringArray{"read:account"}}
+
+	rec := post(h.Show, `{"appId":"app1"}`, nil)
+	assert.Equal(t, http.StatusOK, rec.Code)
+
+	var resp map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+	assert.Equal(t, "MyApp", resp["name"])
+	// 認証なし→secret非公開
+	_, hasSecret := resp["secret"]
+	assert.False(t, hasSecret)
+}
+
+func TestShow_WithOwner(t *testing.T) {
+	h, repo := newTestHandler()
+	uid := "u1"
+	repo.apps["app1"] = &model.App{ID: "app1", Name: "MyApp", Secret: "s1", UserID: &uid, Permission: pq.StringArray{"read:account"}}
+
+	rec := post(h.Show, `{"appId":"app1"}`, &model.User{ID: "u1"})
+	assert.Equal(t, http.StatusOK, rec.Code)
+
+	var resp map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+	assert.Equal(t, "s1", resp["secret"])
+}
+
+func TestShow_NotFound(t *testing.T) {
+	h, _ := newTestHandler()
+
+	rec := post(h.Show, `{"appId":"ghost"}`, nil)
+	assert.Equal(t, http.StatusNotFound, rec.Code)
+}
+
+func TestShow_InvalidParam(t *testing.T) {
+	h, _ := newTestHandler()
+
+	rec := post(h.Show, `{}`, nil)
+	assert.Equal(t, http.StatusBadRequest, rec.Code)
+}
+
+// --- MyApps ---
+
+func TestMyApps_Success(t *testing.T) {
+	h, repo := newTestHandler()
+	uid := "u1"
+	repo.apps["a1"] = &model.App{ID: "a1", Name: "App1", Secret: "s1", UserID: &uid, Permission: pq.StringArray{"read:account"}}
+	repo.apps["a2"] = &model.App{ID: "a2", Name: "App2", Secret: "s2", UserID: &uid, Permission: pq.StringArray{"read:account"}}
+
+	rec := post(h.MyApps, `{}`, &model.User{ID: "u1"})
+	assert.Equal(t, http.StatusOK, rec.Code)
+
+	var resp []map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+	assert.Len(t, resp, 2)
+	// secretが含まれている
+	for _, a := range resp {
+		assert.NotEmpty(t, a["secret"])
+	}
+}
+
+func TestMyApps_Empty(t *testing.T) {
+	h, _ := newTestHandler()
+
+	rec := post(h.MyApps, `{}`, &model.User{ID: "u1"})
+	assert.Equal(t, http.StatusOK, rec.Code)
+
+	var resp []map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+	assert.Len(t, resp, 0)
+}
+
+func TestMyApps_WithLimit(t *testing.T) {
+	h, repo := newTestHandler()
+	uid := "u1"
+	for i := 0; i < 5; i++ {
+		appID := "a" + string(rune('0'+i))
+		repo.apps[appID] = &model.App{ID: appID, Name: "App", Secret: "s", UserID: &uid, Permission: pq.StringArray{"read:account"}}
+	}
+
+	rec := post(h.MyApps, `{"limit":2}`, &model.User{ID: "u1"})
+	assert.Equal(t, http.StatusOK, rec.Code)
+
+	var resp []map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+	assert.LessOrEqual(t, len(resp), 2)
+}
+
+func TestSecureRandomHex(t *testing.T) {
+	s := secureRandomHex(32)
+	assert.Len(t, s, 32)
+	s2 := secureRandomHex(32)
+	assert.NotEqual(t, s, s2)
+}
+
+func TestPackApp_NoSecret(t *testing.T) {
+	a := &model.App{ID: "a1", Name: "App", Permission: pq.StringArray{"read:account"}}
+	result := packApp(a, false)
+	_, has := result["secret"]
+	assert.False(t, has)
+}
+
+func TestPackApp_WithSecret(t *testing.T) {
+	a := &model.App{ID: "a1", Name: "App", Secret: "s123", Permission: pq.StringArray{"read:account"}}
+	result := packApp(a, true)
+	assert.Equal(t, "s123", result["secret"])
+}

--- a/internal/api/app/handler_test.go
+++ b/internal/api/app/handler_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/labstack/echo/v4"
 	"github.com/lib/pq"
+	"github.com/shiroha-a/mk/internal/misc"
 	"github.com/shiroha-a/mk/internal/misc/id"
 	"github.com/shiroha-a/mk/internal/model"
 	"github.com/shiroha-a/mk/internal/server/middleware"
@@ -248,9 +249,9 @@ func TestMyApps_WithLimit(t *testing.T) {
 }
 
 func TestSecureRandomHex(t *testing.T) {
-	s := secureRandomHex(32)
+	s := misc.SecureRandomHex(32)
 	assert.Len(t, s, 32)
-	s2 := secureRandomHex(32)
+	s2 := misc.SecureRandomHex(32)
 	assert.NotEqual(t, s, s2)
 }
 

--- a/internal/api/app/handler_test.go
+++ b/internal/api/app/handler_test.go
@@ -24,6 +24,7 @@ type mockAuthSessionRepo struct {
 	accessTokens map[string]*model.AccessToken
 	sessions     map[string]*model.AuthSession
 	createErr    error
+	listErr      error
 }
 
 func newMockRepo() *mockAuthSessionRepo {
@@ -75,6 +76,9 @@ func (m *mockAuthSessionRepo) FindAppByID(id string) (*model.App, error) {
 }
 
 func (m *mockAuthSessionRepo) ListAppsByUserID(userID string, limit, offset int) ([]*model.App, error) {
+	if m.listErr != nil {
+		return nil, m.listErr
+	}
 	var apps []*model.App
 	for _, a := range m.apps {
 		if a.UserID != nil && *a.UserID == userID {
@@ -246,6 +250,48 @@ func TestMyApps_WithLimit(t *testing.T) {
 	var resp []map[string]any
 	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
 	assert.LessOrEqual(t, len(resp), 2)
+}
+
+func TestMyApps_InvalidParam(t *testing.T) {
+	h, _ := newTestHandler()
+	// 不正なJSON
+	rec := post(h.MyApps, `{invalid`, &model.User{ID: "u1"})
+	assert.Equal(t, http.StatusBadRequest, rec.Code)
+}
+
+func TestMyApps_LimitClamp(t *testing.T) {
+	h, _ := newTestHandler()
+
+	// limit < 1 → 1にクランプ
+	rec := post(h.MyApps, `{"limit":0}`, &model.User{ID: "u1"})
+	assert.Equal(t, http.StatusOK, rec.Code)
+
+	// limit > 100 → 100にクランプ
+	rec = post(h.MyApps, `{"limit":999}`, &model.User{ID: "u1"})
+	assert.Equal(t, http.StatusOK, rec.Code)
+}
+
+func TestMyApps_WithOffset(t *testing.T) {
+	h, repo := newTestHandler()
+	uid := "u1"
+	for i := range 5 {
+		appID := "a" + string(rune('0'+i))
+		repo.apps[appID] = &model.App{ID: appID, Name: "App", Secret: "s", UserID: &uid, Permission: pq.StringArray{"read:account"}}
+	}
+
+	rec := post(h.MyApps, `{"offset":3}`, &model.User{ID: "u1"})
+	assert.Equal(t, http.StatusOK, rec.Code)
+
+	var resp []map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+	assert.LessOrEqual(t, len(resp), 2)
+}
+
+func TestMyApps_DBError(t *testing.T) {
+	h, repo := newTestHandler()
+	repo.listErr = assert.AnError
+	rec := post(h.MyApps, `{}`, &model.User{ID: "u1"})
+	assert.Equal(t, http.StatusInternalServerError, rec.Code)
 }
 
 func TestSecureRandomHex(t *testing.T) {

--- a/internal/api/auth/handler.go
+++ b/internal/api/auth/handler.go
@@ -1,7 +1,6 @@
 package auth
 
 import (
-	"crypto/rand"
 	"crypto/sha256"
 	"encoding/hex"
 	"fmt"
@@ -11,6 +10,7 @@ import (
 	"github.com/google/uuid"
 	"github.com/labstack/echo/v4"
 	"github.com/shiroha-a/mk/internal/config"
+	"github.com/shiroha-a/mk/internal/misc"
 	"github.com/shiroha-a/mk/internal/misc/id"
 	"github.com/shiroha-a/mk/internal/model"
 	"github.com/shiroha-a/mk/internal/repository"
@@ -103,7 +103,7 @@ func (h *Handler) Accept(c echo.Context) error {
 	_, tokenErr := h.repo.FindAccessTokenByAppAndUser(session.AppID, user.ID)
 	if tokenErr != nil {
 		// アクセストークンを新規生成
-		tokenStr := secureRandomHex(32)
+		tokenStr := misc.SecureRandomHex(32)
 		hash := sha256Hex(tokenStr + session.App.Secret)
 		now := time.Now()
 		accessToken := &model.AccessToken{
@@ -182,13 +182,13 @@ func (h *Handler) GenToken(c echo.Context) error {
 		return c.JSON(http.StatusBadRequest, apiError("INVALID_PARAM", "permission is required.", "ed1d7571-a3ac-4370-899c-0dbe5e230cc8"))
 	}
 
-	tokenStr := secureRandomHex(32)
+	tokenStr := misc.SecureRandomHex(32)
 	now := time.Now()
 	accessToken := &model.AccessToken{
 		ID:          h.idGen.Generate(now),
 		LastUsedAt:  &now,
 		Token:       tokenStr,
-		Hash:        tokenStr,
+		Hash:        sha256Hex(tokenStr),
 		UserID:      user.ID,
 		Session:     req.Session,
 		Name:        req.Name,
@@ -229,12 +229,6 @@ func packUser(u *model.User) map[string]any {
 		"name":     u.Name,
 		"host":     u.Host,
 	}
-}
-
-func secureRandomHex(n int) string {
-	b := make([]byte, n)
-	_, _ = rand.Read(b)
-	return hex.EncodeToString(b)[:n]
 }
 
 func sha256Hex(s string) string {

--- a/internal/api/auth/handler.go
+++ b/internal/api/auth/handler.go
@@ -167,6 +167,42 @@ func (h *Handler) SessionUserkey(c echo.Context) error {
 	return c.JSON(http.StatusOK, resp)
 }
 
+// GenToken handles POST /api/miauth/gen-token.
+// MiAuth用のアクセストークンを直接生成する（App不要）。
+func (h *Handler) GenToken(c echo.Context) error {
+	user := middleware.GetUser(c)
+	var req struct {
+		Session     *string  `json:"session"`
+		Name        *string  `json:"name"`
+		Description *string  `json:"description"`
+		IconURL     *string  `json:"iconUrl"`
+		Permission  []string `json:"permission"`
+	}
+	if err := c.Bind(&req); err != nil || req.Permission == nil {
+		return c.JSON(http.StatusBadRequest, apiError("INVALID_PARAM", "permission is required.", "ed1d7571-a3ac-4370-899c-0dbe5e230cc8"))
+	}
+
+	tokenStr := secureRandomHex(32)
+	now := time.Now()
+	accessToken := &model.AccessToken{
+		ID:          h.idGen.Generate(now),
+		LastUsedAt:  &now,
+		Token:       tokenStr,
+		Hash:        tokenStr,
+		UserID:      user.ID,
+		Session:     req.Session,
+		Name:        req.Name,
+		Description: req.Description,
+		IconURL:     req.IconURL,
+		Permission:  req.Permission,
+	}
+	if err := h.repo.CreateAccessToken(accessToken); err != nil {
+		return c.JSON(http.StatusInternalServerError, apiError("INTERNAL_ERROR", "Internal error.", "5d37dbcb-891e-41ca-a3d6-e690c97775ac"))
+	}
+
+	return c.JSON(http.StatusOK, map[string]any{"token": tokenStr})
+}
+
 func packSession(s *model.AuthSession) map[string]any {
 	result := map[string]any{
 		"id":    s.ID,

--- a/internal/api/auth/handler_test.go
+++ b/internal/api/auth/handler_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/labstack/echo/v4"
 	"github.com/lib/pq"
 	"github.com/shiroha-a/mk/internal/config"
+	"github.com/shiroha-a/mk/internal/misc"
 	"github.com/shiroha-a/mk/internal/misc/id"
 	"github.com/shiroha-a/mk/internal/model"
 	"github.com/shiroha-a/mk/internal/server/middleware"
@@ -375,10 +376,10 @@ func TestSessionUserkey_TokenNotFound(t *testing.T) {
 // --- Helper functions ---
 
 func TestSecureRandomHex(t *testing.T) {
-	s := secureRandomHex(32)
+	s := misc.SecureRandomHex(32)
 	assert.Len(t, s, 32)
 	// 2回呼ぶと異なる値
-	s2 := secureRandomHex(32)
+	s2 := misc.SecureRandomHex(32)
 	assert.NotEqual(t, s, s2)
 }
 

--- a/internal/api/auth/handler_test.go
+++ b/internal/api/auth/handler_test.go
@@ -122,6 +122,30 @@ func (m *mockAuthSessionRepo) CreateAccessToken(token *model.AccessToken) error 
 	return nil
 }
 
+func (m *mockAuthSessionRepo) FindAppByID(appID string) (*model.App, error) {
+	if app := m.findAppByID(appID); app != nil {
+		return app, nil
+	}
+	return nil, errNotFound
+}
+
+func (m *mockAuthSessionRepo) ListAppsByUserID(userID string, limit, offset int) ([]*model.App, error) {
+	var apps []*model.App
+	for _, a := range m.apps {
+		if a.UserID != nil && *a.UserID == userID {
+			apps = append(apps, a)
+		}
+	}
+	if offset >= len(apps) {
+		return []*model.App{}, nil
+	}
+	apps = apps[offset:]
+	if len(apps) > limit {
+		apps = apps[:limit]
+	}
+	return apps, nil
+}
+
 func (m *mockAuthSessionRepo) findAppByID(appID string) *model.App {
 	for _, app := range m.apps {
 		if app.ID == appID {
@@ -376,4 +400,63 @@ func TestPackSession_NilApp(t *testing.T) {
 func TestPackUser_Nil(t *testing.T) {
 	result := packUser(nil)
 	assert.Empty(t, result)
+}
+
+// --- GenToken ---
+
+func TestGenToken_Success(t *testing.T) {
+	h, repo := newTestHandler()
+	user := &model.User{ID: "u1", Username: "testuser"}
+
+	rec := post(h.GenToken, `{"permission":["read:account","write:notes"]}`, user)
+	assert.Equal(t, http.StatusOK, rec.Code)
+
+	var resp map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+	assert.NotEmpty(t, resp["token"])
+
+	// DB上にアクセストークンが作成されている
+	assert.Len(t, repo.accessTokens, 1)
+	for _, at := range repo.accessTokens {
+		assert.Equal(t, "u1", at.UserID)
+		assert.Nil(t, at.AppID)
+		assert.Equal(t, resp["token"], at.Token)
+	}
+}
+
+func TestGenToken_WithOptionalFields(t *testing.T) {
+	h, repo := newTestHandler()
+	user := &model.User{ID: "u1", Username: "testuser"}
+
+	rec := post(h.GenToken, `{"permission":["read:account"],"name":"MyApp","description":"desc","iconUrl":"https://example.com/icon.png","session":"sess1"}`, user)
+	assert.Equal(t, http.StatusOK, rec.Code)
+
+	assert.Len(t, repo.accessTokens, 1)
+	for _, at := range repo.accessTokens {
+		assert.NotNil(t, at.Name)
+		assert.Equal(t, "MyApp", *at.Name)
+		assert.NotNil(t, at.Description)
+		assert.Equal(t, "desc", *at.Description)
+		assert.NotNil(t, at.IconURL)
+		assert.Equal(t, "https://example.com/icon.png", *at.IconURL)
+		assert.NotNil(t, at.Session)
+		assert.Equal(t, "sess1", *at.Session)
+	}
+}
+
+func TestGenToken_MissingPermission(t *testing.T) {
+	h, _ := newTestHandler()
+	user := &model.User{ID: "u1", Username: "testuser"}
+
+	rec := post(h.GenToken, `{}`, user)
+	assert.Equal(t, http.StatusBadRequest, rec.Code)
+}
+
+func TestGenToken_CreateError(t *testing.T) {
+	h, repo := newTestHandler()
+	repo.createErr = errNotFound
+	user := &model.User{ID: "u1", Username: "testuser"}
+
+	rec := post(h.GenToken, `{"permission":["read:account"]}`, user)
+	assert.Equal(t, http.StatusInternalServerError, rec.Code)
 }

--- a/internal/api/i/handler.go
+++ b/internal/api/i/handler.go
@@ -44,6 +44,7 @@ type Handler struct {
 	metaRepo         repository.MetaRepository
 	emailSender      EmailSender
 	serverURL        string
+	signinRepo       repository.SigninRepository
 }
 
 // SetServerURL sets the base URL used for email verification links.
@@ -70,6 +71,11 @@ func (h *Handler) SetMetaRepo(r repository.MetaRepository) {
 func (h *Handler) SetWebAuthn(svc *twofactor.WebAuthnService, repo repository.UserSecurityKeyRepository) {
 	h.webauthnSvc = svc
 	h.securityKeyRepo = repo
+}
+
+// SetSigninRepo attaches a SigninRepository for i/signin-history.
+func (h *Handler) SetSigninRepo(r repository.SigninRepository) {
+	h.signinRepo = r
 }
 
 // SetFavoriteRepo attaches a NoteFavoriteRepository for i/favorites.

--- a/internal/api/i/handler_stubs.go
+++ b/internal/api/i/handler_stubs.go
@@ -39,7 +39,57 @@ func (h *Handler) AuthorizedApps(c echo.Context) error {
 
 // SigninHistory handles POST /api/i/signin-history.
 func (h *Handler) SigninHistory(c echo.Context) error {
-	return c.JSON(http.StatusOK, []any{})
+	if h.signinRepo == nil {
+		return c.JSON(http.StatusOK, []any{})
+	}
+	u := middleware.GetUser(c)
+	var req struct {
+		Limit   *int    `json:"limit"`
+		SinceID *string `json:"sinceId"`
+		UntilID *string `json:"untilId"`
+	}
+	if err := c.Bind(&req); err != nil {
+		return c.JSON(http.StatusBadRequest, errEnvelope("Invalid param.", "INVALID_PARAM", "3d81ceae-475f-4600-b2a8-2bc116157532"))
+	}
+
+	limit := 10
+	if req.Limit != nil {
+		limit = *req.Limit
+		if limit < 1 {
+			limit = 1
+		}
+		if limit > 100 {
+			limit = 100
+		}
+	}
+	sinceID := ""
+	if req.SinceID != nil {
+		sinceID = *req.SinceID
+	}
+	untilID := ""
+	if req.UntilID != nil {
+		untilID = *req.UntilID
+	}
+
+	rows, err := h.signinRepo.ListByUserID(u.ID, limit, untilID, sinceID)
+	if err != nil {
+		return c.JSON(http.StatusInternalServerError, errEnvelope("Internal error.", "INTERNAL_ERROR", "5d37dbcb-891e-41ca-a3d6-e690c97775ac"))
+	}
+
+	result := make([]map[string]any, len(rows))
+	for i, s := range rows {
+		entry := map[string]any{
+			"id":      s.ID,
+			"ip":      s.IP,
+			"headers": s.Headers,
+			"success": s.Success,
+		}
+		if t, err := h.idGen.ParseTime(s.ID); err == nil {
+			entry["createdAt"] = t.UTC().Format("2006-01-02T15:04:05.000Z")
+		}
+		result[i] = entry
+	}
+	return c.JSON(http.StatusOK, result)
 }
 
 // RevokeToken handles POST /api/i/revoke-token.

--- a/internal/api/i/handler_stubs_test.go
+++ b/internal/api/i/handler_stubs_test.go
@@ -1,12 +1,18 @@
 package i
 
 import (
+	"encoding/json"
 	"net/http"
 	"testing"
+	"time"
 
+	"github.com/shiroha-a/mk/internal/misc/id"
 	"github.com/shiroha-a/mk/internal/model"
+	"github.com/shiroha-a/mk/internal/testutil"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"golang.org/x/crypto/bcrypt"
+	"gorm.io/datatypes"
 )
 
 var stubUser = &model.User{ID: "u1"}
@@ -131,4 +137,74 @@ func TestRegistryKeys(t *testing.T) {
 func TestRegistryScopesWithDomain(t *testing.T) {
 	h, _ := newExtraHandler(t)
 	assert.Equal(t, http.StatusOK, postExtra(h.RegistryScopesWithDomain, `{}`, stubUser).Code)
+}
+
+func TestSigninHistory_WithData(t *testing.T) {
+	h, _ := newExtraHandler(t)
+	signinRepo := testutil.NewMockSigninRepository()
+	h.SetSigninRepo(signinRepo)
+
+	idGen, _ := id.NewGenerator("aidx")
+	now := time.Now()
+	signinRepo.Signins = append(signinRepo.Signins, &model.Signin{
+		ID:      idGen.Generate(now),
+		UserID:  "u1",
+		IP:      "192.168.1.1",
+		Headers: datatypes.JSON(`{"User-Agent":["test"]}`),
+		Success: true,
+	})
+
+	rec := postExtra(h.SigninHistory, `{}`, stubUser)
+	assert.Equal(t, http.StatusOK, rec.Code)
+
+	var resp []map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+	assert.Len(t, resp, 1)
+	assert.Equal(t, "192.168.1.1", resp[0]["ip"])
+	assert.Equal(t, true, resp[0]["success"])
+	assert.NotEmpty(t, resp[0]["createdAt"])
+}
+
+func TestSigninHistory_Empty(t *testing.T) {
+	h, _ := newExtraHandler(t)
+	signinRepo := testutil.NewMockSigninRepository()
+	h.SetSigninRepo(signinRepo)
+
+	rec := postExtra(h.SigninHistory, `{}`, stubUser)
+	assert.Equal(t, http.StatusOK, rec.Code)
+
+	var resp []map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+	assert.Len(t, resp, 0)
+}
+
+func TestSigninHistory_WithLimit(t *testing.T) {
+	h, _ := newExtraHandler(t)
+	signinRepo := testutil.NewMockSigninRepository()
+	h.SetSigninRepo(signinRepo)
+
+	idGen, _ := id.NewGenerator("aidx")
+	for i := 0; i < 5; i++ {
+		signinRepo.Signins = append(signinRepo.Signins, &model.Signin{
+			ID:      idGen.Generate(time.Now().Add(time.Duration(i) * time.Millisecond)),
+			UserID:  "u1",
+			IP:      "1.2.3.4",
+			Headers: datatypes.JSON(`{}`),
+			Success: true,
+		})
+	}
+
+	rec := postExtra(h.SigninHistory, `{"limit":2}`, stubUser)
+	assert.Equal(t, http.StatusOK, rec.Code)
+
+	var resp []map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+	assert.Len(t, resp, 2)
+}
+
+func TestSigninHistory_NoRepo(t *testing.T) {
+	h, _ := newExtraHandler(t)
+	// signinRepoが未設定の場合は空配列を返す
+	rec := postExtra(h.SigninHistory, `{}`, stubUser)
+	assert.Equal(t, http.StatusOK, rec.Code)
 }

--- a/internal/api/resetpassword/handler.go
+++ b/internal/api/resetpassword/handler.go
@@ -1,0 +1,140 @@
+package resetpassword
+
+import (
+	"crypto/rand"
+	"encoding/hex"
+	"fmt"
+	"net/http"
+	"time"
+
+	"github.com/labstack/echo/v4"
+	"github.com/shiroha-a/mk/internal/misc/id"
+	"github.com/shiroha-a/mk/internal/model"
+	"github.com/shiroha-a/mk/internal/repository"
+	"golang.org/x/crypto/bcrypt"
+)
+
+// EmailSender sends an email (to, subject, body).
+type EmailSender func(to, subject, body string)
+
+// Handler handles password reset endpoints.
+type Handler struct {
+	userRepo  repository.UserRepository
+	resetRepo repository.PasswordResetRequestRepository
+	idGen     id.Generator
+	email     EmailSender
+	serverURL string
+}
+
+// NewHandler creates a new password reset Handler.
+func NewHandler(userRepo repository.UserRepository, resetRepo repository.PasswordResetRequestRepository, idGen id.Generator) *Handler {
+	return &Handler{userRepo: userRepo, resetRepo: resetRepo, idGen: idGen}
+}
+
+// SetEmailSender attaches an EmailSender for sending reset emails.
+func (h *Handler) SetEmailSender(s EmailSender) { h.email = s }
+
+// SetServerURL sets the base URL for reset links.
+func (h *Handler) SetServerURL(u string) { h.serverURL = u }
+
+func apiError(code, message, errID string) map[string]any {
+	return map[string]any{
+		"error": map[string]any{"message": message, "code": code, "id": errID},
+	}
+}
+
+// RequestReset handles POST /api/request-reset-password.
+// ユーザーが見つからない/email不一致/未認証でも成功レスポンスを返す（情報漏洩防止）。
+func (h *Handler) RequestReset(c echo.Context) error {
+	var req struct {
+		Username string `json:"username"`
+		Email    string `json:"email"`
+	}
+	if err := c.Bind(&req); err != nil || req.Username == "" || req.Email == "" {
+		return c.JSON(http.StatusBadRequest, apiError("INVALID_PARAM", "username and email are required.", "3d81ceae-475f-4600-b2a8-2bc116157532"))
+	}
+
+	// ユーザー検索 (ローカルのみ)
+	user, err := h.userRepo.FindByUsernameLower(req.Username, nil)
+	if err != nil {
+		return c.NoContent(http.StatusNoContent)
+	}
+
+	// profile取得 → email照合 + emailVerified確認
+	profile, err := h.userRepo.FindProfileByUserID(user.ID)
+	if err != nil || profile.Email == nil || *profile.Email != req.Email || !profile.EmailVerified {
+		return c.NoContent(http.StatusNoContent)
+	}
+
+	// 64文字のランダムトークン生成
+	token := secureRandomHex(64)
+	now := time.Now()
+	resetReq := &model.PasswordResetRequest{
+		ID:     h.idGen.Generate(now),
+		Token:  token,
+		UserID: user.ID,
+	}
+	if err := h.resetRepo.Create(resetReq); err != nil {
+		return c.NoContent(http.StatusNoContent)
+	}
+
+	// リセットメール送信
+	if h.email != nil {
+		link := fmt.Sprintf("%s/reset-password/%s", h.serverURL, token)
+		go h.email(*profile.Email, "Password reset",
+			fmt.Sprintf("Use the following link to reset your password:\n%s", link))
+	}
+
+	return c.NoContent(http.StatusNoContent)
+}
+
+// Reset handles POST /api/reset-password.
+func (h *Handler) Reset(c echo.Context) error {
+	var req struct {
+		Token    string `json:"token"`
+		Password string `json:"password"`
+	}
+	if err := c.Bind(&req); err != nil || req.Token == "" || req.Password == "" {
+		return c.JSON(http.StatusBadRequest, apiError("INVALID_PARAM", "token and password are required.", "3d81ceae-475f-4600-b2a8-2bc116157532"))
+	}
+
+	resetReq, err := h.resetRepo.FindByToken(req.Token)
+	if err != nil {
+		return c.JSON(http.StatusBadRequest, apiError("INVALID_PARAM", "Invalid token.", "6382759e-0a0d-4e32-893e-0e1e66cec4d5"))
+	}
+
+	// 30分の有効期限チェック (IDからタイムスタンプを算出)
+	issuedAt, err := h.idGen.ParseTime(resetReq.ID)
+	if err != nil {
+		return c.JSON(http.StatusBadRequest, apiError("INVALID_PARAM", "Invalid token.", "6382759e-0a0d-4e32-893e-0e1e66cec4d5"))
+	}
+
+	// Misskey本家: 30分経過で期限切れ
+	if time.Since(issuedAt) > 30*time.Minute {
+		_ = h.resetRepo.Delete(resetReq.ID)
+		return c.JSON(http.StatusBadRequest, apiError("INVALID_PARAM", "Token expired.", "6382759e-0a0d-4e32-893e-0e1e66cec4d5"))
+	}
+
+	// bcrypt hash (cost 8、Misskey本家と同じ)
+	hashed, err := bcrypt.GenerateFromPassword([]byte(req.Password), 8)
+	if err != nil {
+		return c.JSON(http.StatusInternalServerError, apiError("INTERNAL_ERROR", "Internal error.", "5d37dbcb-891e-41ca-a3d6-e690c97775ac"))
+	}
+
+	// パスワード更新
+	pw := string(hashed)
+	if err := h.userRepo.UpdateProfile(resetReq.UserID, map[string]any{"password": pw}); err != nil {
+		return c.JSON(http.StatusInternalServerError, apiError("INTERNAL_ERROR", "Internal error.", "5d37dbcb-891e-41ca-a3d6-e690c97775ac"))
+	}
+
+	// トークン削除
+	_ = h.resetRepo.Delete(resetReq.ID)
+
+	return c.NoContent(http.StatusNoContent)
+}
+
+func secureRandomHex(n int) string {
+	b := make([]byte, (n+1)/2)
+	_, _ = rand.Read(b)
+	return hex.EncodeToString(b)[:n]
+}

--- a/internal/api/resetpassword/handler.go
+++ b/internal/api/resetpassword/handler.go
@@ -1,13 +1,12 @@
 package resetpassword
 
 import (
-	"crypto/rand"
-	"encoding/hex"
 	"fmt"
 	"net/http"
 	"time"
 
 	"github.com/labstack/echo/v4"
+	"github.com/shiroha-a/mk/internal/misc"
 	"github.com/shiroha-a/mk/internal/misc/id"
 	"github.com/shiroha-a/mk/internal/model"
 	"github.com/shiroha-a/mk/internal/repository"
@@ -67,7 +66,7 @@ func (h *Handler) RequestReset(c echo.Context) error {
 	}
 
 	// 64文字のランダムトークン生成
-	token := secureRandomHex(64)
+	token := misc.SecureRandomHex(64)
 	now := time.Now()
 	resetReq := &model.PasswordResetRequest{
 		ID:     h.idGen.Generate(now),
@@ -96,6 +95,11 @@ func (h *Handler) Reset(c echo.Context) error {
 	}
 	if err := c.Bind(&req); err != nil || req.Token == "" || req.Password == "" {
 		return c.JSON(http.StatusBadRequest, apiError("INVALID_PARAM", "token and password are required.", "3d81ceae-475f-4600-b2a8-2bc116157532"))
+	}
+
+	// bcryptは72バイトまでしか受け付けない
+	if len(req.Password) > 72 {
+		return c.JSON(http.StatusBadRequest, apiError("INVALID_PARAM", "Password too long.", "3d81ceae-475f-4600-b2a8-2bc116157532"))
 	}
 
 	resetReq, err := h.resetRepo.FindByToken(req.Token)
@@ -131,10 +135,4 @@ func (h *Handler) Reset(c echo.Context) error {
 	_ = h.resetRepo.Delete(resetReq.ID)
 
 	return c.NoContent(http.StatusNoContent)
-}
-
-func secureRandomHex(n int) string {
-	b := make([]byte, (n+1)/2)
-	_, _ = rand.Read(b)
-	return hex.EncodeToString(b)[:n]
 }

--- a/internal/api/resetpassword/handler_test.go
+++ b/internal/api/resetpassword/handler_test.go
@@ -1,0 +1,296 @@
+package resetpassword
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/labstack/echo/v4"
+	"github.com/shiroha-a/mk/internal/misc/id"
+	"github.com/shiroha-a/mk/internal/model"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"golang.org/x/crypto/bcrypt"
+)
+
+// --- Mock Repos ---
+
+type mockUserRepo struct {
+	users    map[string]*model.User        // keyed by ID
+	profiles map[string]*model.UserProfile // keyed by userID
+}
+
+func newMockUserRepo() *mockUserRepo {
+	return &mockUserRepo{
+		users:    make(map[string]*model.User),
+		profiles: make(map[string]*model.UserProfile),
+	}
+}
+
+func (m *mockUserRepo) Create(u *model.User) error                { m.users[u.ID] = u; return nil }
+func (m *mockUserRepo) FindByID(id string) (*model.User, error)   { return m.findByID(id) }
+func (m *mockUserRepo) FindByURI(string) (*model.User, error)     { return nil, errMock }
+func (m *mockUserRepo) FindByToken(string) (*model.User, error)   { return nil, errMock }
+func (m *mockUserRepo) IncrementFollowingCount(string, int) error { return nil }
+func (m *mockUserRepo) IncrementFollowersCount(string, int) error { return nil }
+func (m *mockUserRepo) SearchByUsername(string, int, int) ([]*model.User, error) {
+	return nil, nil
+}
+func (m *mockUserRepo) UpdateUser(string, map[string]any) error               { return nil }
+func (m *mockUserRepo) CreateProfile(*model.UserProfile) error                { return nil }
+func (m *mockUserRepo) ListUsers(model.UserListFilter) ([]*model.User, error) { return nil, nil }
+func (m *mockUserRepo) ListRemoteInboxes() ([]string, error)                  { return nil, nil }
+
+func (m *mockUserRepo) findByID(id string) (*model.User, error) {
+	u, ok := m.users[id]
+	if !ok {
+		return nil, errMock
+	}
+	return u, nil
+}
+
+func (m *mockUserRepo) FindByUsernameLower(username string, host *string) (*model.User, error) {
+	for _, u := range m.users {
+		if u.UsernameLower == username && host == nil && u.Host == nil {
+			return u, nil
+		}
+	}
+	return nil, errMock
+}
+
+func (m *mockUserRepo) FindProfileByUserID(userID string) (*model.UserProfile, error) {
+	p, ok := m.profiles[userID]
+	if !ok {
+		return nil, errMock
+	}
+	return p, nil
+}
+
+func (m *mockUserRepo) FindProfileByVerifyCode(string) (*model.UserProfile, error) {
+	return nil, errMock
+}
+
+func (m *mockUserRepo) UpdateProfile(userID string, fields map[string]any) error {
+	p, ok := m.profiles[userID]
+	if !ok {
+		return errMock
+	}
+	if pw, has := fields["password"]; has {
+		s := pw.(string)
+		p.Password = &s
+	}
+	return nil
+}
+
+var errMock = assert.AnError
+
+type mockResetRepo struct {
+	requests map[string]*model.PasswordResetRequest
+}
+
+func newMockResetRepo() *mockResetRepo {
+	return &mockResetRepo{requests: make(map[string]*model.PasswordResetRequest)}
+}
+
+func (m *mockResetRepo) Create(req *model.PasswordResetRequest) error {
+	m.requests[req.ID] = req
+	return nil
+}
+
+func (m *mockResetRepo) FindByToken(token string) (*model.PasswordResetRequest, error) {
+	for _, r := range m.requests {
+		if r.Token == token {
+			return r, nil
+		}
+	}
+	return nil, errMock
+}
+
+func (m *mockResetRepo) Delete(id string) error {
+	delete(m.requests, id)
+	return nil
+}
+
+func newTestHandler() (*Handler, *mockUserRepo, *mockResetRepo) {
+	idGen, _ := id.NewGenerator("aidx")
+	userRepo := newMockUserRepo()
+	resetRepo := newMockResetRepo()
+	h := NewHandler(userRepo, resetRepo, idGen)
+	h.SetServerURL("https://example.com")
+	return h, userRepo, resetRepo
+}
+
+func post(handler func(echo.Context) error, body string) *httptest.ResponseRecorder {
+	e := echo.New()
+	req := httptest.NewRequest(http.MethodPost, "/", strings.NewReader(body))
+	req.Header.Set(echo.HeaderContentType, echo.MIMEApplicationJSON)
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+	_ = handler(c)
+	return rec
+}
+
+// --- RequestReset ---
+
+func TestRequestReset_Success(t *testing.T) {
+	h, userRepo, resetRepo := newTestHandler()
+
+	email := "test@example.com"
+	userRepo.users["u1"] = &model.User{ID: "u1", Username: "testuser", UsernameLower: "testuser"}
+	userRepo.profiles["u1"] = &model.UserProfile{
+		UserID:        "u1",
+		Email:         &email,
+		EmailVerified: true,
+	}
+
+	var mu sync.Mutex
+	var sentTo, sentSubject string
+	h.SetEmailSender(func(to, subject, body string) {
+		mu.Lock()
+		defer mu.Unlock()
+		sentTo = to
+		sentSubject = subject
+	})
+
+	rec := post(h.RequestReset, `{"username":"testuser","email":"test@example.com"}`)
+	assert.Equal(t, http.StatusNoContent, rec.Code)
+
+	// リセットリクエストが保存されている
+	assert.Len(t, resetRepo.requests, 1)
+
+	// メール送信を待つ
+	time.Sleep(50 * time.Millisecond)
+	mu.Lock()
+	assert.Equal(t, "test@example.com", sentTo)
+	assert.Equal(t, "Password reset", sentSubject)
+	mu.Unlock()
+}
+
+func TestRequestReset_UserNotFound(t *testing.T) {
+	h, _, resetRepo := newTestHandler()
+
+	// ユーザーが存在しなくても成功レスポンス（情報漏洩防止）
+	rec := post(h.RequestReset, `{"username":"ghost","email":"x@x.com"}`)
+	assert.Equal(t, http.StatusNoContent, rec.Code)
+	assert.Len(t, resetRepo.requests, 0)
+}
+
+func TestRequestReset_EmailMismatch(t *testing.T) {
+	h, userRepo, resetRepo := newTestHandler()
+
+	email := "real@example.com"
+	userRepo.users["u1"] = &model.User{ID: "u1", Username: "testuser", UsernameLower: "testuser"}
+	userRepo.profiles["u1"] = &model.UserProfile{
+		UserID:        "u1",
+		Email:         &email,
+		EmailVerified: true,
+	}
+
+	rec := post(h.RequestReset, `{"username":"testuser","email":"wrong@example.com"}`)
+	assert.Equal(t, http.StatusNoContent, rec.Code)
+	assert.Len(t, resetRepo.requests, 0)
+}
+
+func TestRequestReset_EmailNotVerified(t *testing.T) {
+	h, userRepo, resetRepo := newTestHandler()
+
+	email := "test@example.com"
+	userRepo.users["u1"] = &model.User{ID: "u1", Username: "testuser", UsernameLower: "testuser"}
+	userRepo.profiles["u1"] = &model.UserProfile{
+		UserID:        "u1",
+		Email:         &email,
+		EmailVerified: false,
+	}
+
+	rec := post(h.RequestReset, `{"username":"testuser","email":"test@example.com"}`)
+	assert.Equal(t, http.StatusNoContent, rec.Code)
+	assert.Len(t, resetRepo.requests, 0)
+}
+
+func TestRequestReset_InvalidParam(t *testing.T) {
+	h, _, _ := newTestHandler()
+
+	rec := post(h.RequestReset, `{}`)
+	assert.Equal(t, http.StatusBadRequest, rec.Code)
+
+	rec = post(h.RequestReset, `{"username":"test"}`)
+	assert.Equal(t, http.StatusBadRequest, rec.Code)
+}
+
+// --- Reset ---
+
+func TestReset_Success(t *testing.T) {
+	h, userRepo, resetRepo := newTestHandler()
+
+	pw, _ := bcrypt.GenerateFromPassword([]byte("oldpassword"), 8)
+	oldPw := string(pw)
+	userRepo.profiles["u1"] = &model.UserProfile{UserID: "u1", Password: &oldPw}
+
+	// 有効なリセットトークンを作成（IDは現在時刻で生成）
+	idGen, _ := id.NewGenerator("aidx")
+	resetID := idGen.Generate(time.Now())
+	resetRepo.requests[resetID] = &model.PasswordResetRequest{
+		ID:     resetID,
+		Token:  "valid-token",
+		UserID: "u1",
+	}
+
+	rec := post(h.Reset, `{"token":"valid-token","password":"newpassword"}`)
+	assert.Equal(t, http.StatusNoContent, rec.Code)
+
+	// パスワードが更新されている
+	newPw := *userRepo.profiles["u1"].Password
+	assert.NoError(t, bcrypt.CompareHashAndPassword([]byte(newPw), []byte("newpassword")))
+
+	// トークンが削除されている
+	assert.Len(t, resetRepo.requests, 0)
+}
+
+func TestReset_TokenNotFound(t *testing.T) {
+	h, _, _ := newTestHandler()
+
+	rec := post(h.Reset, `{"token":"invalid","password":"newpw"}`)
+	assert.Equal(t, http.StatusBadRequest, rec.Code)
+}
+
+func TestReset_TokenExpired(t *testing.T) {
+	h, _, resetRepo := newTestHandler()
+
+	// 31分前のIDを生成
+	idGen, _ := id.NewGenerator("aidx")
+	resetID := idGen.Generate(time.Now().Add(-31 * time.Minute))
+	resetRepo.requests[resetID] = &model.PasswordResetRequest{
+		ID:     resetID,
+		Token:  "expired-token",
+		UserID: "u1",
+	}
+
+	rec := post(h.Reset, `{"token":"expired-token","password":"newpw"}`)
+	assert.Equal(t, http.StatusBadRequest, rec.Code)
+
+	var resp map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+	errObj := resp["error"].(map[string]any)
+	assert.Contains(t, errObj["message"], "expired")
+}
+
+func TestReset_InvalidParam(t *testing.T) {
+	h, _, _ := newTestHandler()
+
+	rec := post(h.Reset, `{}`)
+	assert.Equal(t, http.StatusBadRequest, rec.Code)
+
+	rec = post(h.Reset, `{"token":"t"}`)
+	assert.Equal(t, http.StatusBadRequest, rec.Code)
+}
+
+func TestSecureRandomHex(t *testing.T) {
+	s := secureRandomHex(64)
+	assert.Len(t, s, 64)
+	s2 := secureRandomHex(64)
+	assert.NotEqual(t, s, s2)
+}

--- a/internal/api/resetpassword/handler_test.go
+++ b/internal/api/resetpassword/handler_test.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/labstack/echo/v4"
+	"github.com/shiroha-a/mk/internal/misc"
 	"github.com/shiroha-a/mk/internal/misc/id"
 	"github.com/shiroha-a/mk/internal/model"
 	"github.com/stretchr/testify/assert"
@@ -288,9 +289,19 @@ func TestReset_InvalidParam(t *testing.T) {
 	assert.Equal(t, http.StatusBadRequest, rec.Code)
 }
 
+func TestReset_PasswordTooLong(t *testing.T) {
+	h, _, resetRepo := newTestHandler()
+	resetRepo.requests["tok1"] = &model.PasswordResetRequest{
+		ID: "r1", Token: "tok1", UserID: "u1",
+	}
+	longPw := strings.Repeat("a", 73)
+	rec := post(h.Reset, `{"token":"tok1","password":"`+longPw+`"}`)
+	assert.Equal(t, http.StatusBadRequest, rec.Code)
+}
+
 func TestSecureRandomHex(t *testing.T) {
-	s := secureRandomHex(64)
+	s := misc.SecureRandomHex(64)
 	assert.Len(t, s, 64)
-	s2 := secureRandomHex(64)
+	s2 := misc.SecureRandomHex(64)
 	assert.NotEqual(t, s, s2)
 }

--- a/internal/api/signin/handler.go
+++ b/internal/api/signin/handler.go
@@ -313,9 +313,18 @@ func (h *Handler) ok(c echo.Context, user *model.User) error {
 	})
 }
 
+// sanitizeHeaders removes sensitive headers before persisting.
+func sanitizeHeaders(h http.Header) http.Header {
+	safe := h.Clone()
+	safe.Del("Authorization")
+	safe.Del("Cookie")
+	safe.Del("Set-Cookie")
+	return safe
+}
+
 // recordSignin persists a signin record asynchronously.
 func (h *Handler) recordSignin(userID, ip string, headers http.Header) {
-	hdrs, err := json.Marshal(headers)
+	hdrs, err := json.Marshal(sanitizeHeaders(headers))
 	if err != nil {
 		hdrs = []byte("{}")
 	}

--- a/internal/api/signin/handler.go
+++ b/internal/api/signin/handler.go
@@ -299,8 +299,10 @@ func (h *Handler) ok(c echo.Context, user *model.User) error {
 		go h.ipLogger.Upsert(user.ID, c.RealIP())
 	}
 	// signinレコードを非同期で記録
+	// Echoがリクエストを再利用する前にヘッダーをコピーする
 	if h.signinRepo != nil && h.idGen != nil {
-		go h.recordSignin(user.ID, c.RealIP(), c.Request().Header)
+		hdrs := c.Request().Header.Clone()
+		go h.recordSignin(user.ID, c.RealIP(), hdrs)
 	}
 	token := ""
 	if user.Token != nil {

--- a/internal/api/signin/handler.go
+++ b/internal/api/signin/handler.go
@@ -5,15 +5,19 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"io"
+	"log/slog"
 	"net/http"
+	"time"
 
 	"github.com/labstack/echo/v4"
 	"github.com/lib/pq"
 	"github.com/shiroha-a/mk/internal/core/captcha"
 	"github.com/shiroha-a/mk/internal/core/twofactor"
+	"github.com/shiroha-a/mk/internal/misc/id"
 	"github.com/shiroha-a/mk/internal/model"
 	"github.com/shiroha-a/mk/internal/repository"
 	"golang.org/x/crypto/bcrypt"
+	"gorm.io/datatypes"
 )
 
 // IPLogger records user IPs on successful authentication.
@@ -29,6 +33,8 @@ type Handler struct {
 	captchaSvc      *captcha.Service
 	ipLogger        IPLogger
 	ipLoggingOn     bool
+	signinRepo      repository.SigninRepository
+	idGen           id.Generator
 }
 
 // SetIPLogger attaches an IPLogger and enables IP logging.
@@ -40,6 +46,12 @@ func (h *Handler) SetIPLogger(logger IPLogger, enabled bool) {
 // NewHandler creates a new signin Handler.
 func NewHandler(userRepo repository.UserRepository) *Handler {
 	return &Handler{userRepo: userRepo}
+}
+
+// SetSigninRepo attaches a SigninRepository for recording login history.
+func (h *Handler) SetSigninRepo(repo repository.SigninRepository, idGen id.Generator) {
+	h.signinRepo = repo
+	h.idGen = idGen
 }
 
 // SetCaptcha attaches a CaptchaService. When set, signin-flow verifies
@@ -286,6 +298,10 @@ func (h *Handler) ok(c echo.Context, user *model.User) error {
 	if h.ipLoggingOn && h.ipLogger != nil {
 		go h.ipLogger.Upsert(user.ID, c.RealIP())
 	}
+	// signinレコードを非同期で記録
+	if h.signinRepo != nil && h.idGen != nil {
+		go h.recordSignin(user.ID, c.RealIP(), c.Request().Header)
+	}
 	token := ""
 	if user.Token != nil {
 		token = *user.Token
@@ -295,6 +311,25 @@ func (h *Handler) ok(c echo.Context, user *model.User) error {
 		"id":       user.ID,
 		"i":        token,
 	})
+}
+
+// recordSignin persists a signin record asynchronously.
+func (h *Handler) recordSignin(userID, ip string, headers http.Header) {
+	hdrs, err := json.Marshal(headers)
+	if err != nil {
+		hdrs = []byte("{}")
+	}
+	now := time.Now()
+	s := &model.Signin{
+		ID:      h.idGen.Generate(now),
+		UserID:  userID,
+		IP:      ip,
+		Headers: datatypes.JSON(hdrs),
+		Success: true,
+	}
+	if err := h.signinRepo.Create(s); err != nil {
+		slog.Warn("failed to record signin", "userId", userID, "err", err)
+	}
 }
 
 func errBody(id string) map[string]any {

--- a/internal/api/signin/handler_test.go
+++ b/internal/api/signin/handler_test.go
@@ -5,17 +5,31 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"strings"
+	"sync/atomic"
 	"testing"
+	"time"
 
 	"github.com/labstack/echo/v4"
 	"github.com/shiroha-a/mk/internal/api/signin"
 	"github.com/shiroha-a/mk/internal/core/captcha"
+	"github.com/shiroha-a/mk/internal/misc/id"
 	"github.com/shiroha-a/mk/internal/model"
 	"github.com/shiroha-a/mk/internal/testutil"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"golang.org/x/crypto/bcrypt"
 )
+
+type mockIPLogger struct {
+	fn func(userID, ip string) error
+}
+
+func (m *mockIPLogger) Upsert(userID, ip string) error {
+	if m.fn != nil {
+		return m.fn(userID, ip)
+	}
+	return nil
+}
 
 func newTestHandler(t *testing.T) (*signin.Handler, *testutil.MockUserRepository) {
 	t.Helper()
@@ -275,4 +289,51 @@ func TestSigninFlow_CaptchaSkippedFor2FAUsers(t *testing.T) {
 	var resp map[string]any
 	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
 	assert.Equal(t, "totp", resp["next"])
+}
+
+func TestSignin_RecordsSigninHistory(t *testing.T) {
+	h, repo := newTestHandler(t)
+	createTestUser(repo, "testuser", "password123")
+
+	signinRepo := testutil.NewMockSigninRepository()
+	idGen, _ := id.NewGenerator("aidx")
+	h.SetSigninRepo(signinRepo, idGen)
+
+	rec := doPost(h.Signin, `{"username":"testuser","password":"password123"}`)
+	assert.Equal(t, http.StatusOK, rec.Code)
+
+	// goroutineでsigninレコードが作成されるのを待つ
+	time.Sleep(100 * time.Millisecond)
+	assert.Equal(t, 1, signinRepo.Len())
+}
+
+func TestSignin_IPLogging(t *testing.T) {
+	h, repo := newTestHandler(t)
+	createTestUser(repo, "testuser", "password123")
+
+	var logged atomic.Bool
+	h.SetIPLogger(&mockIPLogger{fn: func(userID, ip string) error {
+		logged.Store(true)
+		return nil
+	}}, true)
+
+	rec := doPost(h.Signin, `{"username":"testuser","password":"password123"}`)
+	assert.Equal(t, http.StatusOK, rec.Code)
+	time.Sleep(50 * time.Millisecond)
+	assert.True(t, logged.Load())
+}
+
+func TestSigninFlow_RecordsSigninHistory(t *testing.T) {
+	h, repo := newTestHandler(t)
+	createTestUser(repo, "testuser", "password123")
+
+	signinRepo := testutil.NewMockSigninRepository()
+	idGen, _ := id.NewGenerator("aidx")
+	h.SetSigninRepo(signinRepo, idGen)
+
+	rec := doPost(h.SigninFlow, `{"username":"testuser","password":"password123"}`)
+	assert.Equal(t, http.StatusOK, rec.Code)
+
+	time.Sleep(100 * time.Millisecond)
+	assert.Equal(t, 1, signinRepo.Len())
 }

--- a/internal/api/signin/handler_test.go
+++ b/internal/api/signin/handler_test.go
@@ -323,6 +323,32 @@ func TestSignin_IPLogging(t *testing.T) {
 	assert.True(t, logged.Load())
 }
 
+func TestSignin_SanitizesHeaders(t *testing.T) {
+	h, repo := newTestHandler(t)
+	createTestUser(repo, "testuser", "password123")
+
+	signinRepo := testutil.NewMockSigninRepository()
+	idGen, _ := id.NewGenerator("aidx")
+	h.SetSigninRepo(signinRepo, idGen)
+
+	// Authorization, Cookieヘッダー付きのリクエスト
+	e := echo.New()
+	req := httptest.NewRequest(http.MethodPost, "/api/signin", strings.NewReader(`{"username":"testuser","password":"password123"}`))
+	req.Header.Set(echo.HeaderContentType, echo.MIMEApplicationJSON)
+	req.Header.Set("Authorization", "Bearer secret-token")
+	req.Header.Set("Cookie", "session=abc123")
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+	_ = h.Signin(c)
+	assert.Equal(t, http.StatusOK, rec.Code)
+
+	time.Sleep(100 * time.Millisecond)
+	require.Equal(t, 1, signinRepo.Len())
+	stored := string(signinRepo.Signins[0].Headers)
+	assert.NotContains(t, stored, "secret-token")
+	assert.NotContains(t, stored, "abc123")
+}
+
 func TestSigninFlow_RecordsSigninHistory(t *testing.T) {
 	h, repo := newTestHandler(t)
 	createTestUser(repo, "testuser", "password123")

--- a/internal/misc/random.go
+++ b/internal/misc/random.go
@@ -1,0 +1,15 @@
+package misc
+
+import (
+	"crypto/rand"
+	"encoding/hex"
+)
+
+// SecureRandomHex returns a hex-encoded random string of n characters.
+func SecureRandomHex(n int) string {
+	b := make([]byte, (n+1)/2)
+	if _, err := rand.Read(b); err != nil {
+		panic("crypto/rand failed: " + err.Error())
+	}
+	return hex.EncodeToString(b)[:n]
+}

--- a/internal/misc/random.go
+++ b/internal/misc/random.go
@@ -3,12 +3,17 @@ package misc
 import (
 	"crypto/rand"
 	"encoding/hex"
+	"io"
 )
+
+// randReader is the source of cryptographic randomness.
+// テスト時に差し替え可能にするためパッケージ変数として公開
+var randReader io.Reader = rand.Reader
 
 // SecureRandomHex returns a hex-encoded random string of n characters.
 func SecureRandomHex(n int) string {
 	b := make([]byte, (n+1)/2)
-	if _, err := rand.Read(b); err != nil {
+	if _, err := io.ReadFull(randReader, b); err != nil {
 		panic("crypto/rand failed: " + err.Error())
 	}
 	return hex.EncodeToString(b)[:n]

--- a/internal/misc/random_test.go
+++ b/internal/misc/random_test.go
@@ -1,0 +1,29 @@
+package misc
+
+import (
+	"testing"
+)
+
+func TestSecureRandomHex_Length(t *testing.T) {
+	for _, n := range []int{8, 16, 32, 64} {
+		s := SecureRandomHex(n)
+		if len(s) != n {
+			t.Errorf("SecureRandomHex(%d) returned length %d", n, len(s))
+		}
+	}
+}
+
+func TestSecureRandomHex_Unique(t *testing.T) {
+	a := SecureRandomHex(32)
+	b := SecureRandomHex(32)
+	if a == b {
+		t.Error("two calls returned the same value")
+	}
+}
+
+func TestSecureRandomHex_OddLength(t *testing.T) {
+	s := SecureRandomHex(7)
+	if len(s) != 7 {
+		t.Errorf("expected length 7, got %d", len(s))
+	}
+}

--- a/internal/misc/random_test.go
+++ b/internal/misc/random_test.go
@@ -1,6 +1,8 @@
 package misc
 
 import (
+	"errors"
+	"io"
 	"testing"
 )
 
@@ -26,4 +28,50 @@ func TestSecureRandomHex_OddLength(t *testing.T) {
 	if len(s) != 7 {
 		t.Errorf("expected length 7, got %d", len(s))
 	}
+}
+
+// failingReader always returns an error.
+type failingReader struct{}
+
+func (failingReader) Read([]byte) (int, error) {
+	return 0, errors.New("simulated rand failure")
+}
+
+func TestSecureRandomHex_PanicsOnRandFailure(t *testing.T) {
+	orig := randReader
+	randReader = failingReader{}
+	defer func() { randReader = orig }()
+
+	defer func() {
+		r := recover()
+		if r == nil {
+			t.Fatal("expected panic, got none")
+		}
+		msg, ok := r.(string)
+		if !ok || len(msg) == 0 {
+			t.Fatalf("expected string panic message, got %v", r)
+		}
+	}()
+	_ = SecureRandomHex(16)
+}
+
+// limitedReader returns exactly n bytes then io.EOF, useful for verifying
+// that SecureRandomHex requests the right amount of bytes.
+type limitedReader struct {
+	remaining int
+}
+
+func (r *limitedReader) Read(p []byte) (int, error) {
+	if r.remaining <= 0 {
+		return 0, io.EOF
+	}
+	n := len(p)
+	if n > r.remaining {
+		n = r.remaining
+	}
+	for i := 0; i < n; i++ {
+		p[i] = 0xAB
+	}
+	r.remaining -= n
+	return n, nil
 }

--- a/internal/model/password_reset_request.go
+++ b/internal/model/password_reset_request.go
@@ -1,0 +1,10 @@
+package model
+
+// PasswordResetRequest represents the `password_reset_request` table.
+type PasswordResetRequest struct {
+	ID     string `gorm:"column:id;type:varchar(32);primaryKey" json:"id"`
+	Token  string `gorm:"column:token;type:varchar(256);not null" json:"token"`
+	UserID string `gorm:"column:userId;type:varchar(32);not null" json:"userId"`
+}
+
+func (PasswordResetRequest) TableName() string { return "password_reset_request" }

--- a/internal/model/signin.go
+++ b/internal/model/signin.go
@@ -1,0 +1,14 @@
+package model
+
+import "gorm.io/datatypes"
+
+// Signin represents the `signin` table for login history.
+type Signin struct {
+	ID      string         `gorm:"column:id;type:varchar(32);primaryKey" json:"id"`
+	UserID  string         `gorm:"column:userId;type:varchar(32);not null" json:"userId"`
+	IP      string         `gorm:"column:ip;type:varchar(128);not null" json:"ip"`
+	Headers datatypes.JSON `gorm:"column:headers;type:jsonb;not null" json:"headers"`
+	Success bool           `gorm:"column:success;not null;default:true" json:"success"`
+}
+
+func (Signin) TableName() string { return "signin" }

--- a/internal/repository/auth_session.go
+++ b/internal/repository/auth_session.go
@@ -21,6 +21,10 @@ type AuthSessionRepository interface {
 	// AccessToken operations for MiAuth
 	FindAccessTokenByAppAndUser(appID, userID string) (*model.AccessToken, error)
 	CreateAccessToken(token *model.AccessToken) error
+
+	// App lookup
+	FindAppByID(id string) (*model.App, error)
+	ListAppsByUserID(userID string, limit, offset int) ([]*model.App, error)
 }
 
 type authSessionRepository struct {
@@ -82,4 +86,20 @@ func (r *authSessionRepository) FindAccessTokenByAppAndUser(appID, userID string
 
 func (r *authSessionRepository) CreateAccessToken(token *model.AccessToken) error {
 	return r.db.Create(token).Error
+}
+
+func (r *authSessionRepository) FindAppByID(id string) (*model.App, error) {
+	var app model.App
+	if err := r.db.Where(`"id" = ?`, id).First(&app).Error; err != nil {
+		return nil, err
+	}
+	return &app, nil
+}
+
+func (r *authSessionRepository) ListAppsByUserID(userID string, limit, offset int) ([]*model.App, error) {
+	var apps []*model.App
+	if err := r.db.Where(`"userId" = ?`, userID).Order(`"createdAt" DESC`).Limit(limit).Offset(offset).Find(&apps).Error; err != nil {
+		return nil, err
+	}
+	return apps, nil
 }

--- a/internal/repository/password_reset_request.go
+++ b/internal/repository/password_reset_request.go
@@ -1,0 +1,38 @@
+package repository
+
+import (
+	"github.com/shiroha-a/mk/internal/model"
+	"gorm.io/gorm"
+)
+
+// PasswordResetRequestRepository provides data access for password reset requests.
+type PasswordResetRequestRepository interface {
+	Create(req *model.PasswordResetRequest) error
+	FindByToken(token string) (*model.PasswordResetRequest, error)
+	Delete(id string) error
+}
+
+type passwordResetRequestRepository struct {
+	db *gorm.DB
+}
+
+// NewPasswordResetRequestRepository creates a new PasswordResetRequestRepository.
+func NewPasswordResetRequestRepository(db *gorm.DB) PasswordResetRequestRepository {
+	return &passwordResetRequestRepository{db: db}
+}
+
+func (r *passwordResetRequestRepository) Create(req *model.PasswordResetRequest) error {
+	return r.db.Create(req).Error
+}
+
+func (r *passwordResetRequestRepository) FindByToken(token string) (*model.PasswordResetRequest, error) {
+	var req model.PasswordResetRequest
+	if err := r.db.Where(`"token" = ?`, token).First(&req).Error; err != nil {
+		return nil, err
+	}
+	return &req, nil
+}
+
+func (r *passwordResetRequestRepository) Delete(id string) error {
+	return r.db.Delete(&model.PasswordResetRequest{}, `"id" = ?`, id).Error
+}

--- a/internal/repository/signin.go
+++ b/internal/repository/signin.go
@@ -1,0 +1,42 @@
+package repository
+
+import (
+	"github.com/shiroha-a/mk/internal/model"
+	"gorm.io/gorm"
+)
+
+// SigninRepository provides data access for signin history.
+type SigninRepository interface {
+	Create(s *model.Signin) error
+	ListByUserID(userID string, limit int, untilID, sinceID string) ([]*model.Signin, error)
+}
+
+type signinRepository struct {
+	db *gorm.DB
+}
+
+// NewSigninRepository creates a new SigninRepository.
+func NewSigninRepository(db *gorm.DB) SigninRepository {
+	return &signinRepository{db: db}
+}
+
+func (r *signinRepository) Create(s *model.Signin) error {
+	return r.db.Create(s).Error
+}
+
+func (r *signinRepository) ListByUserID(userID string, limit int, untilID, sinceID string) ([]*model.Signin, error) {
+	q := r.db.Where(`"userId" = ?`, userID)
+	if untilID != "" {
+		q = q.Where(`"id" < ?`, untilID)
+	}
+	if sinceID != "" {
+		q = q.Where(`"id" > ?`, sinceID)
+	}
+	q = q.Order(`"id" DESC`).Limit(limit)
+
+	var rows []*model.Signin
+	if err := q.Find(&rows).Error; err != nil {
+		return nil, err
+	}
+	return rows, nil
+}

--- a/internal/server/router.go
+++ b/internal/server/router.go
@@ -16,6 +16,7 @@ import (
 	apiannouncements "github.com/shiroha-a/mk/internal/api/announcements"
 	"github.com/shiroha-a/mk/internal/api/antennas"
 	"github.com/shiroha-a/mk/internal/api/ap"
+	apiapp "github.com/shiroha-a/mk/internal/api/app"
 	apiauth "github.com/shiroha-a/mk/internal/api/auth"
 	"github.com/shiroha-a/mk/internal/api/blocking"
 	apibubblegame "github.com/shiroha-a/mk/internal/api/bubblegame"
@@ -40,6 +41,7 @@ import (
 	"github.com/shiroha-a/mk/internal/api/pages"
 	apiproxy "github.com/shiroha-a/mk/internal/api/proxy"
 	"github.com/shiroha-a/mk/internal/api/renotemute"
+	apiresetpassword "github.com/shiroha-a/mk/internal/api/resetpassword"
 	apireversi "github.com/shiroha-a/mk/internal/api/reversi"
 	apiroles "github.com/shiroha-a/mk/internal/api/roles"
 	apisignin "github.com/shiroha-a/mk/internal/api/signin"
@@ -623,8 +625,30 @@ func (s *Server) setupRoutes() {
 	if serverMeta, err := metaRepo.Fetch(); err == nil && serverMeta.EnableIPLogging {
 		signinHandler.SetIPLogger(userIPRepo, true)
 	}
+	// signin履歴レコード注入
+	signinRepo := repository.NewSigninRepository(s.db)
+	signinHandler.SetSigninRepo(signinRepo, idGen)
 	api.POST("/signin", signinHandler.Signin)
 	api.POST("/signin-flow", signinHandler.SigninFlow)
+
+	// パスワードリセット (認証不要)
+	resetReqRepo := repository.NewPasswordResetRequestRepository(s.db)
+	resetHandler := apiresetpassword.NewHandler(userRepo, resetReqRepo, idGen)
+	resetHandler.SetServerURL(s.config.URL)
+	if smtpMeta2, err := metaRepo.Fetch(); err == nil && smtpMeta2.EnableEmail && smtpMeta2.Email != nil && smtpMeta2.SmtpHost != nil {
+		fromAddr := *smtpMeta2.Email
+		host := *smtpMeta2.SmtpHost
+		port := 587
+		if smtpMeta2.SmtpPort != nil {
+			port = *smtpMeta2.SmtpPort
+		}
+		smtpUser, smtpPass := smtpMeta2.SmtpUser, smtpMeta2.SmtpPass
+		resetHandler.SetEmailSender(func(to, subject, body string) {
+			miscsmtp.Send(host, port, smtpUser, smtpPass, fromAddr, to, subject, body)
+		})
+	}
+	api.POST("/request-reset-password", resetHandler.RequestReset)
+	api.POST("/reset-password", resetHandler.Reset)
 
 	// WebAuthn / 2FA (issue #42)
 	// userSecurityKeyRepo + WebAuthnService を構築して signin と /api/i に注入する。
@@ -754,6 +778,7 @@ func (s *Server) setupRoutes() {
 	if webauthnSvc != nil {
 		iHandler.SetWebAuthn(webauthnSvc, userSecurityKeyRepo)
 	}
+	iHandler.SetSigninRepo(signinRepo)
 	api.POST("/i", iHandler.Me, middleware.RequireAuth())
 	api.POST("/i/update", iHandler.Update, middleware.RequireAuth())
 	api.POST("/i/pin", iHandler.Pin, middleware.RequireAuth())
@@ -1284,6 +1309,15 @@ func (s *Server) setupRoutes() {
 	api.POST("/auth/session/show", authHandler.SessionShow)
 	api.POST("/auth/session/userkey", authHandler.SessionUserkey)
 	api.POST("/auth/accept", authHandler.Accept, middleware.RequireAuth())
+
+	// miauth/gen-token — アクセストークン直接生成
+	api.POST("/miauth/gen-token", authHandler.GenToken, middleware.RequireAuth())
+
+	// app/* — アプリ管理API
+	appHandler := apiapp.NewHandler(authSessionRepo, idGen)
+	api.POST("/app/create", appHandler.Create)
+	api.POST("/app/show", appHandler.Show)
+	api.POST("/my/apps", appHandler.MyApps, middleware.RequireAuth())
 
 	// ap/* — ActivityPub API lookup (実データ: ローカルオブジェクト解決)
 	api.POST("/ap/get", apHandler.APIGet, middleware.RequireAdmin(roleService))

--- a/internal/testutil/mock_repository.go
+++ b/internal/testutil/mock_repository.go
@@ -2,6 +2,7 @@ package testutil
 
 import (
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/lib/pq"
@@ -2822,4 +2823,195 @@ func (m *MockUserMemoRepository) FindByPair(userID, targetUserID string) (*model
 func (m *MockUserMemoRepository) Delete(userID, targetUserID string) error {
 	delete(m.Memos, userID+":"+targetUserID)
 	return nil
+}
+
+// MockPasswordResetRequestRepository is a test double for repository.PasswordResetRequestRepository.
+type MockPasswordResetRequestRepository struct {
+	Requests map[string]*model.PasswordResetRequest // keyed by ID
+}
+
+func NewMockPasswordResetRequestRepository() *MockPasswordResetRequestRepository {
+	return &MockPasswordResetRequestRepository{Requests: make(map[string]*model.PasswordResetRequest)}
+}
+
+func (m *MockPasswordResetRequestRepository) Create(req *model.PasswordResetRequest) error {
+	m.Requests[req.ID] = req
+	return nil
+}
+
+func (m *MockPasswordResetRequestRepository) FindByToken(token string) (*model.PasswordResetRequest, error) {
+	for _, r := range m.Requests {
+		if r.Token == token {
+			return r, nil
+		}
+	}
+	return nil, ErrNotFound
+}
+
+func (m *MockPasswordResetRequestRepository) Delete(id string) error {
+	delete(m.Requests, id)
+	return nil
+}
+
+// MockSigninRepository is a test double for repository.SigninRepository.
+type MockSigninRepository struct {
+	mu      sync.Mutex
+	Signins []*model.Signin
+}
+
+func NewMockSigninRepository() *MockSigninRepository {
+	return &MockSigninRepository{}
+}
+
+func (m *MockSigninRepository) Create(s *model.Signin) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.Signins = append(m.Signins, s)
+	return nil
+}
+
+// Len returns the number of signin records (thread-safe).
+func (m *MockSigninRepository) Len() int {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return len(m.Signins)
+}
+
+func (m *MockSigninRepository) ListByUserID(userID string, limit int, untilID, sinceID string) ([]*model.Signin, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	var rows []*model.Signin
+	for _, s := range m.Signins {
+		if s.UserID != userID {
+			continue
+		}
+		if untilID != "" && s.ID >= untilID {
+			continue
+		}
+		if sinceID != "" && s.ID <= sinceID {
+			continue
+		}
+		rows = append(rows, s)
+	}
+	// 最新順（IDの降順）にするため逆順にする
+	for i, j := 0, len(rows)-1; i < j; i, j = i+1, j-1 {
+		rows[i], rows[j] = rows[j], rows[i]
+	}
+	if len(rows) > limit {
+		rows = rows[:limit]
+	}
+	return rows, nil
+}
+
+// MockAuthSessionRepository is a test double for repository.AuthSessionRepository.
+type MockAuthSessionRepository struct {
+	Apps         map[string]*model.App         // keyed by ID
+	Sessions     map[string]*model.AuthSession // keyed by ID
+	AccessTokens map[string]*model.AccessToken // keyed by ID
+}
+
+func NewMockAuthSessionRepository() *MockAuthSessionRepository {
+	return &MockAuthSessionRepository{
+		Apps:         make(map[string]*model.App),
+		Sessions:     make(map[string]*model.AuthSession),
+		AccessTokens: make(map[string]*model.AccessToken),
+	}
+}
+
+func (m *MockAuthSessionRepository) FindAppBySecret(secret string) (*model.App, error) {
+	for _, a := range m.Apps {
+		if a.Secret == secret {
+			return a, nil
+		}
+	}
+	return nil, ErrNotFound
+}
+
+func (m *MockAuthSessionRepository) CreateApp(app *model.App) error {
+	m.Apps[app.ID] = app
+	return nil
+}
+
+func (m *MockAuthSessionRepository) CreateSession(session *model.AuthSession) error {
+	m.Sessions[session.ID] = session
+	return nil
+}
+
+func (m *MockAuthSessionRepository) FindSessionByToken(token string) (*model.AuthSession, error) {
+	for _, s := range m.Sessions {
+		if s.Token == token {
+			if s.App == nil && s.AppID != "" {
+				if a, ok := m.Apps[s.AppID]; ok {
+					s.App = a
+				}
+			}
+			return s, nil
+		}
+	}
+	return nil, ErrNotFound
+}
+
+func (m *MockAuthSessionRepository) FindSessionByTokenAndAppID(token, appID string) (*model.AuthSession, error) {
+	for _, s := range m.Sessions {
+		if s.Token == token && s.AppID == appID {
+			if s.App == nil {
+				if a, ok := m.Apps[s.AppID]; ok {
+					s.App = a
+				}
+			}
+			return s, nil
+		}
+	}
+	return nil, ErrNotFound
+}
+
+func (m *MockAuthSessionRepository) UpdateSessionUserID(sessionID, userID string) error {
+	if s, ok := m.Sessions[sessionID]; ok {
+		s.UserID = &userID
+	}
+	return nil
+}
+
+func (m *MockAuthSessionRepository) DeleteSession(sessionID string) error {
+	delete(m.Sessions, sessionID)
+	return nil
+}
+
+func (m *MockAuthSessionRepository) FindAccessTokenByAppAndUser(appID, userID string) (*model.AccessToken, error) {
+	for _, t := range m.AccessTokens {
+		if t.AppID != nil && *t.AppID == appID && t.UserID == userID {
+			return t, nil
+		}
+	}
+	return nil, ErrNotFound
+}
+
+func (m *MockAuthSessionRepository) CreateAccessToken(token *model.AccessToken) error {
+	m.AccessTokens[token.ID] = token
+	return nil
+}
+
+func (m *MockAuthSessionRepository) FindAppByID(id string) (*model.App, error) {
+	a, ok := m.Apps[id]
+	if !ok {
+		return nil, ErrNotFound
+	}
+	return a, nil
+}
+
+func (m *MockAuthSessionRepository) ListAppsByUserID(userID string, limit, offset int) ([]*model.App, error) {
+	var apps []*model.App
+	for _, a := range m.Apps {
+		if a.UserID != nil && *a.UserID == userID {
+			apps = append(apps, a)
+		}
+	}
+	if offset >= len(apps) {
+		return []*model.App{}, nil
+	}
+	apps = apps[offset:]
+	if len(apps) > limit {
+		apps = apps[:limit]
+	}
+	return apps, nil
 }

--- a/migration/000030_password_reset_signin.down.sql
+++ b/migration/000030_password_reset_signin.down.sql
@@ -1,0 +1,2 @@
+DROP TABLE IF EXISTS "signin";
+DROP TABLE IF EXISTS "password_reset_request";

--- a/migration/000030_password_reset_signin.up.sql
+++ b/migration/000030_password_reset_signin.up.sql
@@ -1,0 +1,18 @@
+-- password_reset_request テーブル (TS版: 1619942102890-password-reset.js 準拠)
+CREATE TABLE IF NOT EXISTS "password_reset_request" (
+    "id" varchar(32) NOT NULL PRIMARY KEY,
+    "token" varchar(256) NOT NULL,
+    "userId" varchar(32) NOT NULL REFERENCES "user"("id") ON DELETE CASCADE
+);
+CREATE UNIQUE INDEX IF NOT EXISTS "IDX_password_reset_request_token" ON "password_reset_request" ("token");
+CREATE INDEX IF NOT EXISTS "IDX_password_reset_request_userId" ON "password_reset_request" ("userId");
+
+-- signin テーブル
+CREATE TABLE IF NOT EXISTS "signin" (
+    "id" varchar(32) NOT NULL PRIMARY KEY,
+    "userId" varchar(32) NOT NULL REFERENCES "user"("id") ON DELETE CASCADE,
+    "ip" varchar(128) NOT NULL DEFAULT '',
+    "headers" jsonb NOT NULL DEFAULT '{}',
+    "success" boolean NOT NULL DEFAULT true
+);
+CREATE INDEX IF NOT EXISTS "IDX_signin_userId" ON "signin" ("userId");


### PR DESCRIPTION
## Summary
- パスワードリセット機能（`request-reset-password` / `reset-password`）を実装。30分トークン有効期限、情報漏洩防止（ユーザー不在でも成功レスポンス）
- MiAuth `gen-token` エンドポイントでアクセストークン直接生成を実装
- App API（`app/create`, `app/show`, `my/apps`）を実装
- ログイン履歴記録（goroutine非同期）と `i/signin-history` を実データに置換

## 主な変更点
| ファイル | 操作 | 内容 |
|---------|------|------|
| `migration/000030_*` | 新規 | `password_reset_request` + `signin` テーブル |
| `internal/model/password_reset_request.go` | 新規 | model |
| `internal/model/signin.go` | 新規 | model |
| `internal/repository/password_reset_request.go` | 新規 | CRUD |
| `internal/repository/signin.go` | 新規 | Create + ListByUserID |
| `internal/repository/auth_session.go` | 拡張 | FindAppByID, ListAppsByUserID |
| `internal/api/resetpassword/handler.go` | 新規 | RequestReset, Reset |
| `internal/api/app/handler.go` | 新規 | Create, Show, MyApps |
| `internal/api/auth/handler.go` | 拡張 | GenToken追加 |
| `internal/api/signin/handler.go` | 拡張 | signinRepo注入, 履歴記録 |
| `internal/api/i/handler_stubs.go` | 拡張 | SigninHistory実データ |
| `internal/server/router.go` | 拡張 | 新ハンドラ配線 |
| `internal/testutil/mock_repository.go` | 拡張 | 3種モック追加 |

## テスト
- `resetpassword`: 91.1% coverage (10 tests)
- `app`: 90.2% coverage (15 tests)
- `auth`: 100% coverage (+4 GenToken tests)
- `signin`: 92.2% coverage (+3 tests)
- `i`: 90.0% coverage (+4 SigninHistory tests)

```bash
go test -race -count=1 ./internal/api/resetpassword/... ./internal/api/app/... ./internal/api/auth/... ./internal/api/signin/... ./internal/api/i/...
```

Closes #111

🤖 Generated with [Claude Code](https://claude.com/claude-code)