### PR TITLE
Phase P2.2: Timeline filtering, signin captcha step, user_publickey persistence

### DIFF
--- a/internal/api/notes/handler_test.go
+++ b/internal/api/notes/handler_test.go
@@ -575,13 +575,13 @@ func (f *failingNoteRepo) SearchByTag(_ string, _ int, _, _ string) ([]*model.No
 }
 func (f *failingNoteRepo) ListByFileID(_ string) ([]*model.Note, error)  { return nil, nil }
 func (f *failingNoteRepo) IncrementUserNotesCount(_ string, _ int) error { return nil }
-func (f *failingNoteRepo) ListHomeTimeline(_ string, _ int, _, _ string) ([]*model.Note, error) {
+func (f *failingNoteRepo) ListHomeTimeline(_ string, _ int, _, _ string, _ model.TimelineDBFilter) ([]*model.Note, error) {
 	return nil, nil
 }
-func (f *failingNoteRepo) ListLocalTimeline(_ int, _, _ string) ([]*model.Note, error) {
+func (f *failingNoteRepo) ListLocalTimeline(_ int, _, _ string, _ model.TimelineDBFilter) ([]*model.Note, error) {
 	return nil, nil
 }
-func (f *failingNoteRepo) ListGlobalTimeline(_ int, _, _ string) ([]*model.Note, error) {
+func (f *failingNoteRepo) ListGlobalTimeline(_ int, _, _ string, _ model.TimelineDBFilter) ([]*model.Note, error) {
 	return nil, nil
 }
 func (f *failingNoteRepo) DeleteExpiredRemoteNotes(_, _ int) (int64, error) { return 0, nil }

--- a/internal/api/notes/timeline_handler.go
+++ b/internal/api/notes/timeline_handler.go
@@ -2,17 +2,28 @@ package notes
 
 import (
 	"net/http"
+	"time"
 
 	"github.com/labstack/echo/v4"
+	"github.com/shiroha-a/mk/internal/core/timeline"
 	"github.com/shiroha-a/mk/internal/model"
 	"github.com/shiroha-a/mk/internal/server/middleware"
 )
 
 // TimelineRequest is the common request body for the four timeline endpoints.
 type TimelineRequest struct {
-	Limit   int    `json:"limit"`
-	SinceID string `json:"sinceId"`
-	UntilID string `json:"untilId"`
+	Limit                 int    `json:"limit"`
+	SinceID               string `json:"sinceId"`
+	UntilID               string `json:"untilId"`
+	SinceDate             *int64 `json:"sinceDate"`
+	UntilDate             *int64 `json:"untilDate"`
+	WithFiles             bool   `json:"withFiles"`
+	WithRenotes           *bool  `json:"withRenotes"`
+	WithReplies           *bool  `json:"withReplies"`
+	IncludeMyRenotes      *bool  `json:"includeMyRenotes"`
+	IncludeRenotedMyNotes *bool  `json:"includeRenotedMyNotes"`
+	IncludeLocalRenotes   *bool  `json:"includeLocalRenotes"`
+	AllowPartial          bool   `json:"allowPartial"`
 }
 
 func (r *TimelineRequest) normalize() {
@@ -27,28 +38,56 @@ func (r *TimelineRequest) normalize() {
 // Timeline handles POST /api/notes/timeline (home timeline).
 func (h *Handler) Timeline(c echo.Context) error {
 	return h.serveTimeline(c, func(viewer *model.User, req TimelineRequest) ([]*model.Note, error) {
-		return h.timelineService.HomeTimeline(c.Request().Context(), viewer, req.UntilID, req.SinceID, req.Limit)
+		f := timeline.TimelineFilter{
+			WithFiles:             req.WithFiles,
+			WithRenotes:           req.WithRenotes,
+			IncludeMyRenotes:      req.IncludeMyRenotes,
+			IncludeRenotedMyNotes: req.IncludeRenotedMyNotes,
+			IncludeLocalRenotes:   req.IncludeLocalRenotes,
+			AllowPartial:          req.AllowPartial,
+		}
+		return h.timelineService.HomeTimeline(c.Request().Context(), viewer, req.UntilID, req.SinceID, req.Limit, f)
 	}, true)
 }
 
 // LocalTimeline handles POST /api/notes/local-timeline.
 func (h *Handler) LocalTimeline(c echo.Context) error {
 	return h.serveTimeline(c, func(viewer *model.User, req TimelineRequest) ([]*model.Note, error) {
-		return h.timelineService.LocalTimeline(c.Request().Context(), viewer, req.UntilID, req.SinceID, req.Limit)
+		f := timeline.TimelineFilter{
+			WithFiles:    req.WithFiles,
+			WithRenotes:  req.WithRenotes,
+			WithReplies:  req.WithReplies,
+			AllowPartial: req.AllowPartial,
+		}
+		return h.timelineService.LocalTimeline(c.Request().Context(), viewer, req.UntilID, req.SinceID, req.Limit, f)
 	}, false)
 }
 
 // GlobalTimeline handles POST /api/notes/global-timeline.
 func (h *Handler) GlobalTimeline(c echo.Context) error {
 	return h.serveTimeline(c, func(viewer *model.User, req TimelineRequest) ([]*model.Note, error) {
-		return h.timelineService.GlobalTimeline(c.Request().Context(), viewer, req.UntilID, req.SinceID, req.Limit)
+		f := timeline.TimelineFilter{
+			WithFiles:    req.WithFiles,
+			WithRenotes:  req.WithRenotes,
+			AllowPartial: req.AllowPartial,
+		}
+		return h.timelineService.GlobalTimeline(c.Request().Context(), viewer, req.UntilID, req.SinceID, req.Limit, f)
 	}, false)
 }
 
 // HybridTimeline handles POST /api/notes/hybrid-timeline.
 func (h *Handler) HybridTimeline(c echo.Context) error {
 	return h.serveTimeline(c, func(viewer *model.User, req TimelineRequest) ([]*model.Note, error) {
-		return h.timelineService.HybridTimeline(c.Request().Context(), viewer, req.UntilID, req.SinceID, req.Limit)
+		f := timeline.TimelineFilter{
+			WithFiles:             req.WithFiles,
+			WithRenotes:           req.WithRenotes,
+			WithReplies:           req.WithReplies,
+			IncludeMyRenotes:      req.IncludeMyRenotes,
+			IncludeRenotedMyNotes: req.IncludeRenotedMyNotes,
+			IncludeLocalRenotes:   req.IncludeLocalRenotes,
+			AllowPartial:          req.AllowPartial,
+		}
+		return h.timelineService.HybridTimeline(c.Request().Context(), viewer, req.UntilID, req.SinceID, req.Limit, f)
 	}, true)
 }
 
@@ -64,6 +103,14 @@ func (h *Handler) serveTimeline(
 		return invalidParam(c)
 	}
 	req.normalize()
+
+	// sinceDate/untilDate → sinceID/untilID 変換 (TS互換)
+	if req.SinceDate != nil && req.SinceID == "" {
+		req.SinceID = h.idGen.Generate(time.UnixMilli(*req.SinceDate))
+	}
+	if req.UntilDate != nil && req.UntilID == "" {
+		req.UntilID = h.idGen.Generate(time.UnixMilli(*req.UntilDate))
+	}
 
 	viewer := middleware.GetUser(c)
 	if requireAuth && viewer == nil {

--- a/internal/api/signin/handler.go
+++ b/internal/api/signin/handler.go
@@ -172,10 +172,17 @@ func (h *Handler) SigninFlow(c echo.Context) error {
 	}
 
 	// Step 1: パスワード未提供 → 次のステップを指示
+	// TSと同じ分岐: 2FA有効 → "password"、2FA無効+captcha有効 → "captcha"、それ以外 → "password"
 	if req.Password == nil {
+		next := "password"
+		if p, perr := h.userRepo.FindProfileByUserID(user.ID); perr == nil && p != nil {
+			if !p.TwoFactorEnabled && h.captchaSvc != nil && h.captchaSvc.IsEnabled() {
+				next = "captcha"
+			}
+		}
 		return c.JSON(http.StatusOK, map[string]any{
 			"finished": false,
-			"next":     "password",
+			"next":     next,
 		})
 	}
 

--- a/internal/api/signin/handler_test.go
+++ b/internal/api/signin/handler_test.go
@@ -276,3 +276,63 @@ func TestSigninFlow_CaptchaSkippedFor2FAUsers(t *testing.T) {
 	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
 	assert.Equal(t, "totp", resp["next"])
 }
+
+// --- Step 1 captcha branching ---
+
+func TestSigninFlow_Step1_CaptchaNext_WhenCaptchaEnabled(t *testing.T) {
+	h, repo := newTestHandler(t)
+	createTestUser(repo, "capstep", "pass")
+
+	captchaSvc := captcha.NewService(&model.Meta{EnableTestcaptcha: true})
+	h.SetCaptcha(captchaSvc)
+
+	// 2FA無効 + captcha有効 → Step 1で "captcha" を返す
+	rec := doPost(h.SigninFlow, `{"username":"capstep"}`)
+	assert.Equal(t, http.StatusOK, rec.Code)
+
+	var resp map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+	assert.Equal(t, false, resp["finished"])
+	assert.Equal(t, "captcha", resp["next"])
+}
+
+func TestSigninFlow_Step1_PasswordNext_When2FAEnabled(t *testing.T) {
+	h, repo := newTestHandler(t)
+	hash, _ := bcrypt.GenerateFromPassword([]byte("pass"), bcrypt.MinCost)
+	hashStr := string(hash)
+	token := "tok"
+	repo.Users["u2fa2"] = &model.User{
+		ID: "u2fa2", Username: "tfa2", UsernameLower: "tfa2", Token: &token,
+	}
+	repo.Profiles["u2fa2"] = &model.UserProfile{
+		UserID:           "u2fa2",
+		Password:         &hashStr,
+		TwoFactorEnabled: true,
+	}
+
+	captchaSvc := captcha.NewService(&model.Meta{EnableTestcaptcha: true})
+	h.SetCaptcha(captchaSvc)
+
+	// 2FA有効 + captcha有効 → Step 1で "password" を返す
+	rec := doPost(h.SigninFlow, `{"username":"tfa2"}`)
+	assert.Equal(t, http.StatusOK, rec.Code)
+
+	var resp map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+	assert.Equal(t, false, resp["finished"])
+	assert.Equal(t, "password", resp["next"])
+}
+
+func TestSigninFlow_Step1_PasswordNext_WhenNoCaptcha(t *testing.T) {
+	h, repo := newTestHandler(t)
+	createTestUser(repo, "nocap", "pass")
+
+	// captchaサービスなし → "password" を返す
+	rec := doPost(h.SigninFlow, `{"username":"nocap"}`)
+	assert.Equal(t, http.StatusOK, rec.Code)
+
+	var resp map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+	assert.Equal(t, false, resp["finished"])
+	assert.Equal(t, "password", resp["next"])
+}

--- a/internal/core/captcha/captcha.go
+++ b/internal/core/captcha/captcha.go
@@ -72,6 +72,11 @@ func NewService(meta *model.Meta) *Service {
 	return s
 }
 
+// IsEnabled reports whether any captcha provider is configured.
+func (s *Service) IsEnabled() bool {
+	return s.hcaptcha != nil || s.recaptcha != nil || s.turnstile != nil || s.mcaptcha != nil || s.testcap != nil
+}
+
 // Verify checks the token matching the first enabled provider. Returns nil
 // if no provider is enabled (captcha disabled).
 func (s *Service) Verify(ctx context.Context, tokens CaptchaTokens) error {

--- a/internal/core/federation/resolver.go
+++ b/internal/core/federation/resolver.go
@@ -11,6 +11,8 @@ import (
 	"strings"
 	"time"
 
+	"log/slog"
+
 	"github.com/shiroha-a/mk/internal/activitypub"
 	corenote "github.com/shiroha-a/mk/internal/core/note"
 	"github.com/shiroha-a/mk/internal/misc/id"
@@ -59,13 +61,19 @@ type publicKeyEntry struct {
 	fetchedAt time.Time
 }
 
+// PublickeyStore abstracts persistence of remote actor public keys. Resolver
+// uses this to fall back to the database when the in-memory cache misses.
+type PublickeyStore interface {
+	Upsert(pk *model.UserPublickey) error
+	FindByUserID(userID string) (*model.UserPublickey, error)
+}
+
 // Resolver fetches remote actors / notes and persists them in the local
 // user / note tables.
 //
-// 公開鍵は別キャッシュ (in-memory map) で actorID → publicKeyEntry を保持
+// 公開鍵は in-memory + DB (user_publickey テーブル) の二段キャッシュで管理
 // する。エントリは actorTTL を超えると miss として扱い、次回 ResolveActor 時
-// にリフレッシュされる。永続化は後続フェーズで user_publickey 相当のテーブル
-// に移す予定。
+// にリフレッシュされる。
 type Resolver struct {
 	userRepo        repository.UserRepository
 	noteRepo        repository.NoteRepository
@@ -77,6 +85,7 @@ type Resolver struct {
 	actorTTL        time.Duration             // アクター情報の最大寿命
 	instanceTracker InstanceTracker           // optional: ホスト発見を通知
 	chartHook       ChartHook                 // optional: 新規 remote user の集計
+	publickeyRepo   PublickeyStore            // optional: 公開鍵の永続化
 }
 
 // NewResolver constructs a Resolver.
@@ -129,20 +138,31 @@ func (r *Resolver) SetChartHook(h ChartHook) {
 	r.chartHook = h
 }
 
-// PublicKeyForActor returns the cached public key PEM for an actor ID. TTL を
-// 超過したエントリは miss として扱い、ErrPublicKeyMissing 相当のエラーを返す。
+// SetPublickeyRepo attaches a PublickeyStore for persistent public key
+// storage. nil 渡しは無効化と同義 (in-memory only に戻る)。
+func (r *Resolver) SetPublickeyRepo(repo PublickeyStore) {
+	r.publickeyRepo = repo
+}
+
+// PublicKeyForActor returns the cached public key PEM for an actor ID.
+// in-memory → DB → miss の順で探索する。TTL超過は miss として扱い、呼び出し
+// 側が ResolveActor を再実行することで refresh をトリガできる。
 func (r *Resolver) PublicKeyForActor(actorID string) (string, error) {
-	entry, ok := r.keys[actorID]
-	if !ok {
-		return "", fmt.Errorf("public key for actor %q not cached", actorID)
-	}
-	if r.clock().Sub(entry.fetchedAt) > r.actorTTL {
-		// 期限切れ: キャッシュを破棄しエラーを返す。呼び出し側 (inbox handler 等)
-		// は ResolveActor を再実行することで refresh をトリガできる。
+	// 1. in-memory cache (TTL内)
+	if entry, ok := r.keys[actorID]; ok {
+		if r.clock().Sub(entry.fetchedAt) <= r.actorTTL {
+			return entry.pem, nil
+		}
 		delete(r.keys, actorID)
-		return "", fmt.Errorf("public key for actor %q expired", actorID)
 	}
-	return entry.pem, nil
+	// 2. DB fallback
+	if r.publickeyRepo != nil {
+		if pk, err := r.publickeyRepo.FindByUserID(actorID); err == nil {
+			r.keys[actorID] = publicKeyEntry{pem: pk.KeyPEM, fetchedAt: r.clock()}
+			return pk.KeyPEM, nil
+		}
+	}
+	return "", fmt.Errorf("public key for actor %q not cached", actorID)
 }
 
 // ResolveActor returns the local model.User row for a remote actor URI,
@@ -190,7 +210,7 @@ func (r *Resolver) ResolveActor(uri string) (*model.User, error) {
 	if err := r.userRepo.Create(user); err != nil {
 		return nil, err
 	}
-	r.cachePublicKey(user.ID, actor.PublicKey.PublicKeyPEM)
+	r.cachePublicKey(user.ID, actor.PublicKey.ID, actor.PublicKey.PublicKeyPEM)
 	r.notifyInstance(host)
 	if r.chartHook != nil {
 		r.chartHook.OnRemoteUserCreated(user)
@@ -246,7 +266,7 @@ func (r *Resolver) refreshActor(existing *model.User, uri string) {
 	existing.LastFetchedAt = &now
 	// UpdateUser エラーはベストエフォートで無視 (次回再試行される)
 	_ = r.userRepo.UpdateUser(existing.ID, fields)
-	r.cachePublicKey(existing.ID, actor.PublicKey.PublicKeyPEM)
+	r.cachePublicKey(existing.ID, actor.PublicKey.ID, actor.PublicKey.PublicKeyPEM)
 	if existing.Host != nil {
 		r.notifyInstance(*existing.Host)
 	}
@@ -275,13 +295,22 @@ func (r *Resolver) refreshPublicKey(userID, uri string) {
 	if err != nil {
 		return
 	}
-	r.cachePublicKey(userID, actor.PublicKey.PublicKeyPEM)
+	r.cachePublicKey(userID, actor.PublicKey.ID, actor.PublicKey.PublicKeyPEM)
 }
 
-// cachePublicKey stores a PEM in the in-memory cache with the current clock
-// reading as the fetch time.
-func (r *Resolver) cachePublicKey(userID, pem string) {
+// cachePublicKey stores a PEM in the in-memory cache and optionally persists
+// it to the user_publickey table.
+func (r *Resolver) cachePublicKey(userID, keyID, pem string) {
 	r.keys[userID] = publicKeyEntry{pem: pem, fetchedAt: r.clock()}
+	if r.publickeyRepo != nil && keyID != "" {
+		if err := r.publickeyRepo.Upsert(&model.UserPublickey{
+			UserID: userID,
+			KeyID:  keyID,
+			KeyPEM: pem,
+		}); err != nil {
+			slog.Warn("failed to persist public key", "userId", userID, "err", err)
+		}
+	}
 }
 
 // ResolveActorByKeyID resolves an actor based on the keyId fragment URI.

--- a/internal/core/federation/resolver_test.go
+++ b/internal/core/federation/resolver_test.go
@@ -741,6 +741,54 @@ func TestResolveActor_TTLRefreshFetchError(t *testing.T) {
 	assert.Equal(t, "Original", *user.Name)
 }
 
+func TestPublicKeyForActor_DBFallback(t *testing.T) {
+	repo := testutil.NewMockUserRepository()
+	noteRepo := testutil.NewMockNoteRepository()
+	urls := activitypub.NewURLBuilder("https://example.com")
+	idGen, _ := id.NewGenerator("aidx")
+	r := federation.NewResolver(repo, noteRepo, urls, &stubFetcher{body: []byte(sampleActor)}, idGen)
+	pkRepo := testutil.NewMockUserPublickeyRepository()
+	r.SetPublickeyRepo(pkRepo)
+
+	// ResolveActorで公開鍵をin-memory + DBにキャッシュ
+	user, err := r.ResolveActor("https://remote.example/users/alice")
+	require.NoError(t, err)
+
+	// DBに永続化されていることを確認
+	require.Len(t, pkRepo.Keys, 1)
+	pk := pkRepo.Keys[user.ID]
+	require.NotNil(t, pk)
+	assert.Equal(t, "https://remote.example/users/alice#main-key", pk.KeyID)
+	assert.Contains(t, pk.KeyPEM, "FAKE")
+
+	// in-memoryキャッシュを期限切れにする
+	r.SetClock(func() time.Time { return time.Now().Add(48 * time.Hour) })
+
+	// DBフォールバックで復元できることを確認
+	pem, err := r.PublicKeyForActor(user.ID)
+	require.NoError(t, err)
+	assert.Contains(t, pem, "FAKE")
+}
+
+func TestPublicKeyForActor_DBFallback_NilRepo(t *testing.T) {
+	repo := testutil.NewMockUserRepository()
+	noteRepo := testutil.NewMockNoteRepository()
+	urls := activitypub.NewURLBuilder("https://example.com")
+	idGen, _ := id.NewGenerator("aidx")
+	r := federation.NewResolver(repo, noteRepo, urls, &stubFetcher{body: []byte(sampleActor)}, idGen)
+	// publickeyRepo未設定
+
+	user, err := r.ResolveActor("https://remote.example/users/alice")
+	require.NoError(t, err)
+
+	// in-memoryキャッシュを期限切れにする
+	r.SetClock(func() time.Time { return time.Now().Add(48 * time.Hour) })
+
+	// DB無しなのでmiss
+	_, err = r.PublicKeyForActor(user.ID)
+	assert.Error(t, err)
+}
+
 func TestPublicKeyForActor_TTLExpiry(t *testing.T) {
 	repo := testutil.NewMockUserRepository()
 	noteRepo := testutil.NewMockNoteRepository()

--- a/internal/core/timeline/timeline_filter.go
+++ b/internal/core/timeline/timeline_filter.go
@@ -1,0 +1,70 @@
+package timeline
+
+import "github.com/shiroha-a/mk/internal/model"
+
+// TimelineFilter holds filtering options for timeline queries.
+// *bool フィールドは nil のときデフォルト値として扱う。
+type TimelineFilter struct {
+	WithFiles             bool  // trueならファイル付きノートのみ
+	WithRenotes           *bool // nil=true。falseでpure renote除外
+	WithReplies           *bool // nil=false。local/hybridのみ
+	IncludeMyRenotes      *bool // nil=true。home/hybridのみ
+	IncludeRenotedMyNotes *bool // nil=true。home/hybridのみ
+	IncludeLocalRenotes   *bool // nil=true。home/hybridのみ
+	AllowPartial          bool  // trueならRedis結果が不足でもDBフォールバックしない
+}
+
+// boolDefault returns *b if non-nil, else def.
+func boolDefault(b *bool, def bool) bool {
+	if b != nil {
+		return *b
+	}
+	return def
+}
+
+// isPureRenote returns true if the note is a pure renote (no text, no files).
+func isPureRenote(n *model.Note) bool {
+	return n.RenoteID != nil && n.Text == nil && len(n.FileIDs) == 0
+}
+
+// ApplyFilter filters notes in-memory according to the given TimelineFilter.
+// viewerID is the currently authenticated user's ID (empty string if anonymous).
+func ApplyFilter(notes []*model.Note, viewerID string, f TimelineFilter) []*model.Note {
+	withRenotes := boolDefault(f.WithRenotes, true)
+	withReplies := boolDefault(f.WithReplies, false)
+	includeMyRenotes := boolDefault(f.IncludeMyRenotes, true)
+	includeRenotedMyNotes := boolDefault(f.IncludeRenotedMyNotes, true)
+	includeLocalRenotes := boolDefault(f.IncludeLocalRenotes, true)
+
+	out := make([]*model.Note, 0, len(notes))
+	for _, n := range notes {
+		if f.WithFiles && len(n.FileIDs) == 0 {
+			continue
+		}
+		if !withRenotes && isPureRenote(n) {
+			continue
+		}
+		// withReplies=false: 他人への返信を除外 (自分への返信は残す)
+		if !withReplies && n.ReplyID != nil {
+			if viewerID == "" || (n.ReplyUserID != nil && *n.ReplyUserID != viewerID) {
+				continue
+			}
+		}
+		if isPureRenote(n) {
+			// includeMyRenotes=false: 自分がした pure renote を除外
+			if !includeMyRenotes && viewerID != "" && n.UserID == viewerID {
+				continue
+			}
+			// includeRenotedMyNotes=false: 自分のノートの pure renote を除外
+			if !includeRenotedMyNotes && viewerID != "" && n.RenoteUserID != nil && *n.RenoteUserID == viewerID {
+				continue
+			}
+			// includeLocalRenotes=false: ローカルユーザーの pure renote を除外
+			if !includeLocalRenotes && n.RenoteUserHost == nil {
+				continue
+			}
+		}
+		out = append(out, n)
+	}
+	return out
+}

--- a/internal/core/timeline/timeline_filter_test.go
+++ b/internal/core/timeline/timeline_filter_test.go
@@ -1,0 +1,164 @@
+package timeline
+
+import (
+	"testing"
+
+	"github.com/lib/pq"
+	"github.com/shiroha-a/mk/internal/model"
+	"github.com/stretchr/testify/assert"
+)
+
+func boolPtr(b bool) *bool    { return &b }
+func strPtr(s string) *string { return &s }
+
+// テスト用ノート生成ヘルパ
+func makeNote(id string, opts ...func(*model.Note)) *model.Note {
+	n := &model.Note{
+		ID:         id,
+		UserID:     "author",
+		Visibility: model.NoteVisibilityPublic,
+	}
+	for _, o := range opts {
+		o(n)
+	}
+	return n
+}
+
+func withFiles(n *model.Note)               { n.FileIDs = pq.StringArray{"file1"} }
+func withRenote(n *model.Note)              { n.RenoteID = strPtr("rn1") }
+func withText(n *model.Note)                { n.Text = strPtr("hello") }
+func withReply(n *model.Note)               { n.ReplyID = strPtr("rp1"); n.ReplyUserID = strPtr("other") }
+func withReplySelf(n *model.Note)           { n.ReplyID = strPtr("rp1"); n.ReplyUserID = strPtr("viewer") }
+func withUser(uid string) func(*model.Note) { return func(n *model.Note) { n.UserID = uid } }
+func withRenoteUser(uid string) func(*model.Note) {
+	return func(n *model.Note) { n.RenoteUserID = strPtr(uid) }
+}
+func withRenoteUserHost(host string) func(*model.Note) {
+	return func(n *model.Note) { n.RenoteUserHost = strPtr(host) }
+}
+func withLocalRenoteUser(n *model.Note) {
+	n.RenoteUserHost = nil
+}
+
+func TestIsPureRenote(t *testing.T) {
+	assert.True(t, isPureRenote(makeNote("1", withRenote)))
+	assert.False(t, isPureRenote(makeNote("2")))
+	assert.False(t, isPureRenote(makeNote("3", withRenote, withText)))
+	assert.False(t, isPureRenote(makeNote("4", withRenote, withFiles)))
+}
+
+func TestApplyFilter_WithFiles(t *testing.T) {
+	notes := []*model.Note{
+		makeNote("1"),
+		makeNote("2", withFiles),
+	}
+	out := ApplyFilter(notes, "", TimelineFilter{WithFiles: true})
+	assert.Len(t, out, 1)
+	assert.Equal(t, "2", out[0].ID)
+}
+
+func TestApplyFilter_WithRenotes_False(t *testing.T) {
+	notes := []*model.Note{
+		makeNote("1"),
+		makeNote("2", withRenote),            // pure renote → 除外
+		makeNote("3", withRenote, withText),  // quote renote → 残る
+		makeNote("4", withRenote, withFiles), // quote renote (file) → 残る
+	}
+	out := ApplyFilter(notes, "", TimelineFilter{WithRenotes: boolPtr(false)})
+	assert.Len(t, out, 3)
+}
+
+func TestApplyFilter_WithRenotes_Default(t *testing.T) {
+	notes := []*model.Note{
+		makeNote("1"),
+		makeNote("2", withRenote),
+	}
+	// WithRenotes nil → true (全部残る)
+	out := ApplyFilter(notes, "", TimelineFilter{})
+	assert.Len(t, out, 2)
+}
+
+func TestApplyFilter_WithReplies_False(t *testing.T) {
+	notes := []*model.Note{
+		makeNote("1"),
+		makeNote("2", withReply),     // 他人への返信 → 除外
+		makeNote("3", withReplySelf), // 自分への返信 → 残る
+	}
+	out := ApplyFilter(notes, "viewer", TimelineFilter{WithReplies: boolPtr(false)})
+	assert.Len(t, out, 2)
+	assert.Equal(t, "1", out[0].ID)
+	assert.Equal(t, "3", out[1].ID)
+}
+
+func TestApplyFilter_WithReplies_True(t *testing.T) {
+	notes := []*model.Note{
+		makeNote("1"),
+		makeNote("2", withReply),
+	}
+	out := ApplyFilter(notes, "viewer", TimelineFilter{WithReplies: boolPtr(true)})
+	assert.Len(t, out, 2)
+}
+
+func TestApplyFilter_WithReplies_NoViewer(t *testing.T) {
+	notes := []*model.Note{
+		makeNote("1"),
+		makeNote("2", withReply),
+	}
+	// viewerなし + withReplies=false → 全返信除外
+	out := ApplyFilter(notes, "", TimelineFilter{WithReplies: boolPtr(false)})
+	assert.Len(t, out, 1)
+}
+
+func TestApplyFilter_IncludeMyRenotes_False(t *testing.T) {
+	notes := []*model.Note{
+		makeNote("1"),
+		makeNote("2", withRenote, withUser("viewer")),           // viewerのpure renote → 除外
+		makeNote("3", withRenote, withUser("other")),            // 他人のpure renote → 残る
+		makeNote("4", withRenote, withText, withUser("viewer")), // viewerのquote → 残る
+	}
+	out := ApplyFilter(notes, "viewer", TimelineFilter{IncludeMyRenotes: boolPtr(false)})
+	assert.Len(t, out, 3)
+}
+
+func TestApplyFilter_IncludeRenotedMyNotes_False(t *testing.T) {
+	notes := []*model.Note{
+		makeNote("1"),
+		makeNote("2", withRenote, withRenoteUser("viewer")), // viewerのノートのpure renote → 除外
+		makeNote("3", withRenote, withRenoteUser("other")),  // 他人のノートのpure renote → 残る
+	}
+	out := ApplyFilter(notes, "viewer", TimelineFilter{IncludeRenotedMyNotes: boolPtr(false)})
+	assert.Len(t, out, 2)
+}
+
+func TestApplyFilter_IncludeLocalRenotes_False(t *testing.T) {
+	notes := []*model.Note{
+		makeNote("1"),
+		makeNote("2", withRenote, withLocalRenoteUser),              // ローカルpure renote → 除外
+		makeNote("3", withRenote, withRenoteUserHost("remote.tld")), // リモートpure renote → 残る
+	}
+	out := ApplyFilter(notes, "viewer", TimelineFilter{IncludeLocalRenotes: boolPtr(false)})
+	assert.Len(t, out, 2)
+}
+
+func TestApplyFilter_CombinedFilters(t *testing.T) {
+	notes := []*model.Note{
+		makeNote("1", withFiles),                       // ファイル付き、通常ノート → 残る
+		makeNote("2"),                                  // ファイルなし → 除外 (withFiles)
+		makeNote("3", withRenote),                      // pure renote (ファイルなし) → 除外 (both)
+		makeNote("4", withFiles, withRenote, withText), // ファイル付きquote → 残る
+	}
+	out := ApplyFilter(notes, "", TimelineFilter{
+		WithFiles:   true,
+		WithRenotes: boolPtr(false),
+	})
+	assert.Len(t, out, 2)
+	assert.Equal(t, "1", out[0].ID)
+	assert.Equal(t, "4", out[1].ID)
+}
+
+func TestBoolDefault(t *testing.T) {
+	assert.True(t, boolDefault(nil, true))
+	assert.False(t, boolDefault(nil, false))
+	assert.True(t, boolDefault(boolPtr(true), false))
+	assert.False(t, boolDefault(boolPtr(false), true))
+}

--- a/internal/core/timeline/timeline_service.go
+++ b/internal/core/timeline/timeline_service.go
@@ -40,7 +40,7 @@ func NewService(fanout *FanoutTimelineService, noteRepo repository.NoteRepositor
 
 // HomeTimeline returns the timeline for a logged-in user. The home timeline
 // shows notes by users they follow plus their own notes.
-func (s *Service) HomeTimeline(ctx context.Context, viewer *model.User, untilID, sinceID string, limit int) ([]*model.Note, error) {
+func (s *Service) HomeTimeline(ctx context.Context, viewer *model.User, untilID, sinceID string, limit int, filter TimelineFilter) ([]*model.Note, error) {
 	if viewer == nil {
 		return nil, ErrUnauthenticated
 	}
@@ -52,46 +52,75 @@ func (s *Service) HomeTimeline(ctx context.Context, viewer *model.User, untilID,
 		return nil, err
 	}
 	if len(ids) > 0 {
-		return s.resolve(ids)
+		notes, err := s.resolve(ids)
+		if err != nil {
+			return nil, err
+		}
+		notes = ApplyFilter(notes, viewer.ID, filter)
+		if !filter.AllowPartial && len(notes) < limit {
+			return s.noteRepo.ListHomeTimeline(viewer.ID, limit, sinceID, untilID, toDBFilter(filter, viewer.ID))
+		}
+		return notes, nil
 	}
-	// Redisが空の場合、DBから直接取得 (自分+フォロー中のユーザーのノート)
-	return s.noteRepo.ListHomeTimeline(viewer.ID, limit, sinceID, untilID)
+	return s.noteRepo.ListHomeTimeline(viewer.ID, limit, sinceID, untilID, toDBFilter(filter, viewer.ID))
 }
 
 // LocalTimeline returns notes posted by local users with public/home visibility.
-func (s *Service) LocalTimeline(ctx context.Context, viewer *model.User, untilID, sinceID string, limit int) ([]*model.Note, error) {
+func (s *Service) LocalTimeline(ctx context.Context, viewer *model.User, untilID, sinceID string, limit int, filter TimelineFilter) ([]*model.Note, error) {
 	if limit <= 0 {
 		limit = 20
+	}
+	viewerID := ""
+	if viewer != nil {
+		viewerID = viewer.ID
 	}
 	ids, err := s.fanout.Get(ctx, LocalTimeline, untilID, sinceID, limit)
 	if err != nil {
 		return nil, err
 	}
 	if len(ids) > 0 {
-		return s.resolve(ids)
+		notes, err := s.resolve(ids)
+		if err != nil {
+			return nil, err
+		}
+		notes = ApplyFilter(notes, viewerID, filter)
+		if !filter.AllowPartial && len(notes) < limit {
+			return s.noteRepo.ListLocalTimeline(limit, sinceID, untilID, toDBFilter(filter, viewerID))
+		}
+		return notes, nil
 	}
-	// Redisが空の場合、DBから直接取得
-	return s.noteRepo.ListLocalTimeline(limit, sinceID, untilID)
+	return s.noteRepo.ListLocalTimeline(limit, sinceID, untilID, toDBFilter(filter, viewerID))
 }
 
 // GlobalTimeline returns all public notes including federated remotes.
-func (s *Service) GlobalTimeline(ctx context.Context, viewer *model.User, untilID, sinceID string, limit int) ([]*model.Note, error) {
+func (s *Service) GlobalTimeline(ctx context.Context, viewer *model.User, untilID, sinceID string, limit int, filter TimelineFilter) ([]*model.Note, error) {
 	if limit <= 0 {
 		limit = 20
+	}
+	viewerID := ""
+	if viewer != nil {
+		viewerID = viewer.ID
 	}
 	ids, err := s.fanout.Get(ctx, GlobalTimeline, untilID, sinceID, limit)
 	if err != nil {
 		return nil, err
 	}
 	if len(ids) > 0 {
-		return s.resolve(ids)
+		notes, err := s.resolve(ids)
+		if err != nil {
+			return nil, err
+		}
+		notes = ApplyFilter(notes, viewerID, filter)
+		if !filter.AllowPartial && len(notes) < limit {
+			return s.noteRepo.ListGlobalTimeline(limit, sinceID, untilID, toDBFilter(filter, viewerID))
+		}
+		return notes, nil
 	}
-	// Redisが空の場合、DBから直接取得
-	return s.noteRepo.ListGlobalTimeline(limit, sinceID, untilID)
+	return s.noteRepo.ListGlobalTimeline(limit, sinceID, untilID, toDBFilter(filter, viewerID))
 }
 
 // HybridTimeline merges home and local timelines into a single feed.
-func (s *Service) HybridTimeline(ctx context.Context, viewer *model.User, untilID, sinceID string, limit int) ([]*model.Note, error) {
+func (s *Service) HybridTimeline(ctx context.Context, viewer *model.User, untilID, sinceID string, limit int, filter TimelineFilter) ([]*model.Note, error) {
 	if viewer == nil {
 		return nil, ErrUnauthenticated
 	}
@@ -104,10 +133,30 @@ func (s *Service) HybridTimeline(ctx context.Context, viewer *model.User, untilI
 	}
 	merged := mergeIDs(multi, limit)
 	if len(merged) > 0 {
-		return s.resolve(merged)
+		notes, err := s.resolve(merged)
+		if err != nil {
+			return nil, err
+		}
+		notes = ApplyFilter(notes, viewer.ID, filter)
+		if !filter.AllowPartial && len(notes) < limit {
+			return s.noteRepo.ListHomeTimeline(viewer.ID, limit, sinceID, untilID, toDBFilter(filter, viewer.ID))
+		}
+		return notes, nil
 	}
-	// Redisが空の場合、DBフォールバック (homeとlocalを統合)
-	return s.noteRepo.ListHomeTimeline(viewer.ID, limit, sinceID, untilID)
+	return s.noteRepo.ListHomeTimeline(viewer.ID, limit, sinceID, untilID, toDBFilter(filter, viewer.ID))
+}
+
+// toDBFilter converts a TimelineFilter to a model.TimelineDBFilter.
+func toDBFilter(f TimelineFilter, viewerID string) model.TimelineDBFilter {
+	return model.TimelineDBFilter{
+		WithFiles:             f.WithFiles,
+		WithRenotes:           f.WithRenotes,
+		WithReplies:           f.WithReplies,
+		IncludeMyRenotes:      f.IncludeMyRenotes,
+		IncludeRenotedMyNotes: f.IncludeRenotedMyNotes,
+		IncludeLocalRenotes:   f.IncludeLocalRenotes,
+		ViewerID:              viewerID,
+	}
 }
 
 // resolve fetches notes from the repository preserving id ordering.

--- a/internal/core/timeline/timeline_service_test.go
+++ b/internal/core/timeline/timeline_service_test.go
@@ -25,7 +25,7 @@ func newTestServiceWithRepo(t *testing.T) (*Service, *FanoutTimelineService, *te
 
 func TestService_HomeTimelineRequiresUser(t *testing.T) {
 	svc, _, _ := newTestServiceWithRepo(t)
-	_, err := svc.HomeTimeline(context.Background(), nil, "", "", 10)
+	_, err := svc.HomeTimeline(context.Background(), nil, "", "", 10, TimelineFilter{})
 	require.ErrorIs(t, err, ErrUnauthenticated)
 }
 
@@ -38,7 +38,7 @@ func TestService_HomeTimeline(t *testing.T) {
 	repo.Notes[noteID] = &model.Note{ID: noteID, UserID: "viewer", Visibility: model.NoteVisibilityPublic}
 	require.NoError(t, fanout.Push(ctx, HomeTimelineName(user.ID), noteID, 100))
 
-	out, err := svc.HomeTimeline(ctx, user, "", "", 10)
+	out, err := svc.HomeTimeline(ctx, user, "", "", 10, TimelineFilter{})
 	require.NoError(t, err)
 	require.Len(t, out, 1)
 	assert.Equal(t, noteID, out[0].ID)
@@ -48,7 +48,7 @@ func TestService_HomeTimelineFanoutError(t *testing.T) {
 	noteRepo := testutil.NewMockNoteRepository()
 	fanout := NewFanoutTimelineService(closedClient(t), idGen)
 	svc := NewService(fanout, noteRepo, nil)
-	_, err := svc.HomeTimeline(context.Background(), &model.User{ID: "u"}, "", "", 10)
+	_, err := svc.HomeTimeline(context.Background(), &model.User{ID: "u"}, "", "", 10, TimelineFilter{})
 	assert.Error(t, err)
 }
 
@@ -60,7 +60,7 @@ func TestService_LocalTimeline(t *testing.T) {
 	repo.Notes[noteID] = &model.Note{ID: noteID, UserID: "a", Visibility: model.NoteVisibilityPublic}
 	require.NoError(t, fanout.Push(ctx, LocalTimeline, noteID, 100))
 
-	out, err := svc.LocalTimeline(ctx, nil, "", "", 10)
+	out, err := svc.LocalTimeline(ctx, nil, "", "", 10, TimelineFilter{})
 	require.NoError(t, err)
 	require.Len(t, out, 1)
 }
@@ -68,7 +68,7 @@ func TestService_LocalTimeline(t *testing.T) {
 func TestService_LocalTimelineFanoutError(t *testing.T) {
 	noteRepo := testutil.NewMockNoteRepository()
 	svc := NewService(NewFanoutTimelineService(closedClient(t), idGen), noteRepo, nil)
-	_, err := svc.LocalTimeline(context.Background(), nil, "", "", 10)
+	_, err := svc.LocalTimeline(context.Background(), nil, "", "", 10, TimelineFilter{})
 	assert.Error(t, err)
 }
 
@@ -80,7 +80,7 @@ func TestService_GlobalTimeline(t *testing.T) {
 	repo.Notes[noteID] = &model.Note{ID: noteID, UserID: "a", Visibility: model.NoteVisibilityPublic}
 	require.NoError(t, fanout.Push(ctx, GlobalTimeline, noteID, 100))
 
-	out, err := svc.GlobalTimeline(ctx, nil, "", "", 10)
+	out, err := svc.GlobalTimeline(ctx, nil, "", "", 10, TimelineFilter{})
 	require.NoError(t, err)
 	require.Len(t, out, 1)
 }
@@ -88,13 +88,13 @@ func TestService_GlobalTimeline(t *testing.T) {
 func TestService_GlobalTimelineFanoutError(t *testing.T) {
 	noteRepo := testutil.NewMockNoteRepository()
 	svc := NewService(NewFanoutTimelineService(closedClient(t), idGen), noteRepo, nil)
-	_, err := svc.GlobalTimeline(context.Background(), nil, "", "", 10)
+	_, err := svc.GlobalTimeline(context.Background(), nil, "", "", 10, TimelineFilter{})
 	assert.Error(t, err)
 }
 
 func TestService_HybridTimelineRequiresUser(t *testing.T) {
 	svc, _, _ := newTestServiceWithRepo(t)
-	_, err := svc.HybridTimeline(context.Background(), nil, "", "", 10)
+	_, err := svc.HybridTimeline(context.Background(), nil, "", "", 10, TimelineFilter{})
 	require.ErrorIs(t, err, ErrUnauthenticated)
 }
 
@@ -111,7 +111,7 @@ func TestService_HybridTimeline(t *testing.T) {
 	require.NoError(t, fanout.Push(ctx, HomeTimelineName(user.ID), homeID, 100))
 	require.NoError(t, fanout.Push(ctx, LocalTimeline, localID, 100))
 
-	out, err := svc.HybridTimeline(ctx, user, "", "", 10)
+	out, err := svc.HybridTimeline(ctx, user, "", "", 10, TimelineFilter{})
 	require.NoError(t, err)
 	require.Len(t, out, 2)
 }
@@ -119,7 +119,7 @@ func TestService_HybridTimeline(t *testing.T) {
 func TestService_HybridTimelineFanoutError(t *testing.T) {
 	noteRepo := testutil.NewMockNoteRepository()
 	svc := NewService(NewFanoutTimelineService(closedClient(t), idGen), noteRepo, nil)
-	_, err := svc.HybridTimeline(context.Background(), &model.User{ID: "u"}, "", "", 10)
+	_, err := svc.HybridTimeline(context.Background(), &model.User{ID: "u"}, "", "", 10, TimelineFilter{})
 	assert.Error(t, err)
 }
 
@@ -134,14 +134,14 @@ func TestService_HybridTimelineDeduplicates(t *testing.T) {
 	require.NoError(t, fanout.Push(ctx, HomeTimelineName(user.ID), noteID, 100))
 	require.NoError(t, fanout.Push(ctx, LocalTimeline, noteID, 100))
 
-	out, err := svc.HybridTimeline(ctx, user, "", "", 10)
+	out, err := svc.HybridTimeline(ctx, user, "", "", 10, TimelineFilter{})
 	require.NoError(t, err)
 	assert.Len(t, out, 1)
 }
 
 func TestService_ResolveEmpty(t *testing.T) {
 	svc, _, _ := newTestServiceWithRepo(t)
-	out, err := svc.LocalTimeline(context.Background(), nil, "", "", 10)
+	out, err := svc.LocalTimeline(context.Background(), nil, "", "", 10, TimelineFilter{})
 	require.NoError(t, err)
 	assert.Empty(t, out)
 }
@@ -152,7 +152,7 @@ func TestService_HomeTimeline_DBFallback(t *testing.T) {
 	svc, _, repo := newTestServiceWithRepo(t)
 	// Redisにpushしない → DBフォールバック
 	repo.Notes["n1"] = &model.Note{ID: "n1", UserID: "viewer", Visibility: model.NoteVisibilityPublic}
-	out, err := svc.HomeTimeline(context.Background(), &model.User{ID: "viewer"}, "", "", 10)
+	out, err := svc.HomeTimeline(context.Background(), &model.User{ID: "viewer"}, "", "", 10, TimelineFilter{})
 	require.NoError(t, err)
 	assert.Len(t, out, 1)
 }
@@ -160,7 +160,7 @@ func TestService_HomeTimeline_DBFallback(t *testing.T) {
 func TestService_LocalTimeline_DBFallback(t *testing.T) {
 	svc, _, repo := newTestServiceWithRepo(t)
 	repo.Notes["n1"] = &model.Note{ID: "n1", UserID: "a", Visibility: model.NoteVisibilityPublic}
-	out, err := svc.LocalTimeline(context.Background(), nil, "", "", 10)
+	out, err := svc.LocalTimeline(context.Background(), nil, "", "", 10, TimelineFilter{})
 	require.NoError(t, err)
 	assert.Len(t, out, 1)
 }
@@ -168,7 +168,7 @@ func TestService_LocalTimeline_DBFallback(t *testing.T) {
 func TestService_GlobalTimeline_DBFallback(t *testing.T) {
 	svc, _, repo := newTestServiceWithRepo(t)
 	repo.Notes["n1"] = &model.Note{ID: "n1", UserID: "a", Visibility: model.NoteVisibilityPublic}
-	out, err := svc.GlobalTimeline(context.Background(), nil, "", "", 10)
+	out, err := svc.GlobalTimeline(context.Background(), nil, "", "", 10, TimelineFilter{})
 	require.NoError(t, err)
 	assert.Len(t, out, 1)
 }
@@ -176,35 +176,35 @@ func TestService_GlobalTimeline_DBFallback(t *testing.T) {
 func TestService_HybridTimeline_DBFallback(t *testing.T) {
 	svc, _, repo := newTestServiceWithRepo(t)
 	repo.Notes["n1"] = &model.Note{ID: "n1", UserID: "viewer", Visibility: model.NoteVisibilityPublic}
-	out, err := svc.HybridTimeline(context.Background(), &model.User{ID: "viewer"}, "", "", 10)
+	out, err := svc.HybridTimeline(context.Background(), &model.User{ID: "viewer"}, "", "", 10, TimelineFilter{})
 	require.NoError(t, err)
 	assert.Len(t, out, 1)
 }
 
 func TestService_HomeTimeline_DefaultLimit(t *testing.T) {
 	svc, _, _ := newTestServiceWithRepo(t)
-	out, err := svc.HomeTimeline(context.Background(), &model.User{ID: "u"}, "", "", 0)
+	out, err := svc.HomeTimeline(context.Background(), &model.User{ID: "u"}, "", "", 0, TimelineFilter{})
 	require.NoError(t, err)
 	assert.Empty(t, out)
 }
 
 func TestService_LocalTimeline_DefaultLimit(t *testing.T) {
 	svc, _, _ := newTestServiceWithRepo(t)
-	out, err := svc.LocalTimeline(context.Background(), nil, "", "", 0)
+	out, err := svc.LocalTimeline(context.Background(), nil, "", "", 0, TimelineFilter{})
 	require.NoError(t, err)
 	assert.Empty(t, out)
 }
 
 func TestService_GlobalTimeline_DefaultLimit(t *testing.T) {
 	svc, _, _ := newTestServiceWithRepo(t)
-	out, err := svc.GlobalTimeline(context.Background(), nil, "", "", 0)
+	out, err := svc.GlobalTimeline(context.Background(), nil, "", "", 0, TimelineFilter{})
 	require.NoError(t, err)
 	assert.Empty(t, out)
 }
 
 func TestService_HybridTimeline_DefaultLimit(t *testing.T) {
 	svc, _, _ := newTestServiceWithRepo(t)
-	out, err := svc.HybridTimeline(context.Background(), &model.User{ID: "u"}, "", "", 0)
+	out, err := svc.HybridTimeline(context.Background(), &model.User{ID: "u"}, "", "", 0, TimelineFilter{})
 	require.NoError(t, err)
 	assert.Empty(t, out)
 }
@@ -219,7 +219,7 @@ func TestService_ResolveError(t *testing.T) {
 
 	noteID := idGen.Generate(time.Now())
 	require.NoError(t, fanout.Push(ctx, LocalTimeline, noteID, 100))
-	_, err := svc.LocalTimeline(ctx, nil, "", "", 10)
+	_, err := svc.LocalTimeline(ctx, nil, "", "", 10, TimelineFilter{})
 	assert.Error(t, err)
 }
 

--- a/internal/model/timeline_filter.go
+++ b/internal/model/timeline_filter.go
@@ -1,0 +1,13 @@
+package model
+
+// TimelineDBFilter holds filtering conditions for timeline DB fallback queries.
+// *bool フィールドは nil のときデフォルト値として扱う (WithRenotes nil=true 等)。
+type TimelineDBFilter struct {
+	WithFiles             bool
+	WithRenotes           *bool  // nil=true
+	WithReplies           *bool  // nil=false
+	IncludeMyRenotes      *bool  // nil=true
+	IncludeRenotedMyNotes *bool  // nil=true
+	IncludeLocalRenotes   *bool  // nil=true
+	ViewerID              string // home/hybridフィルタで使用
+}

--- a/internal/model/user_publickey.go
+++ b/internal/model/user_publickey.go
@@ -1,0 +1,13 @@
+package model
+
+// UserPublickey stores the public key of a remote user for HTTP Signature
+// verification. TS版の user_publickey テーブルに対応する。ローカルユーザーの
+// 鍵ペア (user_keypair) とは別。
+type UserPublickey struct {
+	UserID string `gorm:"column:userId;type:varchar(32);primaryKey"`
+	KeyID  string `gorm:"column:keyId;type:varchar(256);not null"`
+	KeyPEM string `gorm:"column:keyPem;type:varchar(4096);not null"`
+}
+
+// TableName returns the database table name.
+func (UserPublickey) TableName() string { return "user_publickey" }

--- a/internal/repository/note.go
+++ b/internal/repository/note.go
@@ -29,9 +29,9 @@ type NoteRepository interface {
 	SearchByTag(tag string, limit int, sinceID, untilID string) ([]*model.Note, error)
 	ListByFileID(fileID string) ([]*model.Note, error)
 	IncrementUserNotesCount(userID string, delta int) error
-	ListHomeTimeline(userID string, limit int, sinceID, untilID string) ([]*model.Note, error)
-	ListLocalTimeline(limit int, sinceID, untilID string) ([]*model.Note, error)
-	ListGlobalTimeline(limit int, sinceID, untilID string) ([]*model.Note, error)
+	ListHomeTimeline(userID string, limit int, sinceID, untilID string, filter model.TimelineDBFilter) ([]*model.Note, error)
+	ListLocalTimeline(limit int, sinceID, untilID string, filter model.TimelineDBFilter) ([]*model.Note, error)
+	ListGlobalTimeline(limit int, sinceID, untilID string, filter model.TimelineDBFilter) ([]*model.Note, error)
 	// DeleteExpiredRemoteNotes deletes remote notes older than expiryDays
 	// in batches of batchSize. Returns the total count of deleted notes.
 	DeleteExpiredRemoteNotes(expiryDays, batchSize int) (int64, error)
@@ -350,9 +350,38 @@ func (r *noteRepository) IncrementUserNotesCount(userID string, delta int) error
 	return r.db.Exec(`UPDATE "user" SET "notesCount" = "notesCount" + ? WHERE "id" = ?`, delta, userID).Error
 }
 
+// applyTimelineFilter adds common filter conditions to a GORM query builder.
+func applyTimelineFilter(q *gorm.DB, f model.TimelineDBFilter) *gorm.DB {
+	if f.WithFiles {
+		q = q.Where(`"fileIds" != '{}'`)
+	}
+	if f.WithRenotes != nil && !*f.WithRenotes {
+		// pure renote (テキストもファイルもない renote) を除外
+		q = q.Where(`NOT ("renoteId" IS NOT NULL AND text IS NULL AND "fileIds" = '{}')`)
+	}
+	if f.WithReplies != nil && !*f.WithReplies {
+		if f.ViewerID != "" {
+			// 自分への返信は残す
+			q = q.Where(`("replyId" IS NULL OR "replyUserId" = ?)`, f.ViewerID)
+		} else {
+			q = q.Where(`"replyId" IS NULL`)
+		}
+	}
+	if f.IncludeMyRenotes != nil && !*f.IncludeMyRenotes && f.ViewerID != "" {
+		q = q.Where(`NOT ("renoteId" IS NOT NULL AND text IS NULL AND "fileIds" = '{}' AND "userId" = ?)`, f.ViewerID)
+	}
+	if f.IncludeRenotedMyNotes != nil && !*f.IncludeRenotedMyNotes && f.ViewerID != "" {
+		q = q.Where(`NOT ("renoteId" IS NOT NULL AND text IS NULL AND "fileIds" = '{}' AND "renoteUserId" = ?)`, f.ViewerID)
+	}
+	if f.IncludeLocalRenotes != nil && !*f.IncludeLocalRenotes {
+		q = q.Where(`NOT ("renoteId" IS NOT NULL AND text IS NULL AND "fileIds" = '{}' AND "renoteUserHost" IS NULL)`)
+	}
+	return q
+}
+
 // ListHomeTimeline returns notes by the user and users they follow.
 // DBフォールバック用。Redisが空のときに使う。
-func (r *noteRepository) ListHomeTimeline(userID string, limit int, sinceID, untilID string) ([]*model.Note, error) {
+func (r *noteRepository) ListHomeTimeline(userID string, limit int, sinceID, untilID string, filter model.TimelineDBFilter) ([]*model.Note, error) {
 	q := r.db.Preload("User").
 		Where(`("userId" = ? OR "userId" IN (SELECT "followeeId" FROM "following" WHERE "followerId" = ?)) AND "visibility" IN ('public','home','followers')`, userID, userID).
 		Order(`"id" DESC`).Limit(limit)
@@ -362,6 +391,7 @@ func (r *noteRepository) ListHomeTimeline(userID string, limit int, sinceID, unt
 	if untilID != "" {
 		q = q.Where(`"id" < ?`, untilID)
 	}
+	q = applyTimelineFilter(q, filter)
 	var notes []*model.Note
 	if err := q.Find(&notes).Error; err != nil {
 		return nil, err
@@ -370,9 +400,9 @@ func (r *noteRepository) ListHomeTimeline(userID string, limit int, sinceID, unt
 }
 
 // ListLocalTimeline returns public/home notes by local users.
-func (r *noteRepository) ListLocalTimeline(limit int, sinceID, untilID string) ([]*model.Note, error) {
+func (r *noteRepository) ListLocalTimeline(limit int, sinceID, untilID string, filter model.TimelineDBFilter) ([]*model.Note, error) {
 	q := r.db.Preload("User").
-		Where(`"userHost" IS NULL AND "visibility" = 'public'`).
+		Where(`"userHost" IS NULL AND "visibility" = 'public' AND "channelId" IS NULL`).
 		Order(`"id" DESC`).Limit(limit)
 	if sinceID != "" {
 		q = q.Where(`"id" > ?`, sinceID)
@@ -380,6 +410,7 @@ func (r *noteRepository) ListLocalTimeline(limit int, sinceID, untilID string) (
 	if untilID != "" {
 		q = q.Where(`"id" < ?`, untilID)
 	}
+	q = applyTimelineFilter(q, filter)
 	var notes []*model.Note
 	if err := q.Find(&notes).Error; err != nil {
 		return nil, err
@@ -388,9 +419,10 @@ func (r *noteRepository) ListLocalTimeline(limit int, sinceID, untilID string) (
 }
 
 // ListGlobalTimeline returns all public notes.
-func (r *noteRepository) ListGlobalTimeline(limit int, sinceID, untilID string) ([]*model.Note, error) {
+// channelId IS NULL でチャンネルノートを除外する (TS互換)。
+func (r *noteRepository) ListGlobalTimeline(limit int, sinceID, untilID string, filter model.TimelineDBFilter) ([]*model.Note, error) {
 	q := r.db.Preload("User").
-		Where(`"visibility" = 'public'`).
+		Where(`"visibility" = 'public' AND "channelId" IS NULL`).
 		Order(`"id" DESC`).Limit(limit)
 	if sinceID != "" {
 		q = q.Where(`"id" > ?`, sinceID)
@@ -398,6 +430,7 @@ func (r *noteRepository) ListGlobalTimeline(limit int, sinceID, untilID string) 
 	if untilID != "" {
 		q = q.Where(`"id" < ?`, untilID)
 	}
+	q = applyTimelineFilter(q, filter)
 	var notes []*model.Note
 	if err := q.Find(&notes).Error; err != nil {
 		return nil, err

--- a/internal/repository/user_publickey.go
+++ b/internal/repository/user_publickey.go
@@ -1,0 +1,51 @@
+package repository
+
+import (
+	"github.com/shiroha-a/mk/internal/model"
+	"gorm.io/gorm"
+	"gorm.io/gorm/clause"
+)
+
+// UserPublickeyRepository provides data access for remote user public keys.
+type UserPublickeyRepository interface {
+	Upsert(pk *model.UserPublickey) error
+	FindByUserID(userID string) (*model.UserPublickey, error)
+	FindByKeyID(keyID string) (*model.UserPublickey, error)
+	Delete(userID string) error
+}
+
+type userPublickeyRepository struct {
+	db *gorm.DB
+}
+
+// NewUserPublickeyRepository creates a new UserPublickeyRepository.
+func NewUserPublickeyRepository(db *gorm.DB) UserPublickeyRepository {
+	return &userPublickeyRepository{db: db}
+}
+
+func (r *userPublickeyRepository) Upsert(pk *model.UserPublickey) error {
+	return r.db.Clauses(clause.OnConflict{
+		Columns:   []clause.Column{{Name: "userId"}},
+		DoUpdates: clause.AssignmentColumns([]string{"keyId", "keyPem"}),
+	}).Create(pk).Error
+}
+
+func (r *userPublickeyRepository) FindByUserID(userID string) (*model.UserPublickey, error) {
+	var pk model.UserPublickey
+	if err := r.db.Where(`"userId" = ?`, userID).First(&pk).Error; err != nil {
+		return nil, err
+	}
+	return &pk, nil
+}
+
+func (r *userPublickeyRepository) FindByKeyID(keyID string) (*model.UserPublickey, error) {
+	var pk model.UserPublickey
+	if err := r.db.Where(`"keyId" = ?`, keyID).First(&pk).Error; err != nil {
+		return nil, err
+	}
+	return &pk, nil
+}
+
+func (r *userPublickeyRepository) Delete(userID string) error {
+	return r.db.Where(`"userId" = ?`, userID).Delete(&model.UserPublickey{}).Error
+}

--- a/internal/server/router.go
+++ b/internal/server/router.go
@@ -340,6 +340,8 @@ func (s *Server) setupRoutes() {
 	}
 	apFetcher := corefederation.NewAPFetcher(apClient)
 	federationResolver := corefederation.NewResolver(userRepo, noteRepo, apURLs, apFetcher, idGen)
+	publickeyRepo := repository.NewUserPublickeyRepository(s.db)
+	federationResolver.SetPublickeyRepo(publickeyRepo)
 	federationProcessor := corefederation.NewProcessor(federationResolver, followingService, reactionService, noteDeleteService, userRepo, noteRepo)
 
 	// Instance management (Phase 3 Step H)

--- a/internal/testutil/mock_repository.go
+++ b/internal/testutil/mock_repository.go
@@ -703,15 +703,15 @@ func (m *MockNoteRepository) SearchByTag(tag string, limit int, _, _ string) ([]
 func (m *MockNoteRepository) ListByFileID(_ string) ([]*model.Note, error)  { return nil, nil }
 func (m *MockNoteRepository) IncrementUserNotesCount(_ string, _ int) error { return nil }
 
-func (m *MockNoteRepository) ListHomeTimeline(_ string, limit int, _, _ string) ([]*model.Note, error) {
+func (m *MockNoteRepository) ListHomeTimeline(_ string, limit int, _, _ string, _ model.TimelineDBFilter) ([]*model.Note, error) {
 	return m.listPublic(limit)
 }
 
-func (m *MockNoteRepository) ListLocalTimeline(limit int, _, _ string) ([]*model.Note, error) {
+func (m *MockNoteRepository) ListLocalTimeline(limit int, _, _ string, _ model.TimelineDBFilter) ([]*model.Note, error) {
 	return m.listPublic(limit)
 }
 
-func (m *MockNoteRepository) ListGlobalTimeline(limit int, _, _ string) ([]*model.Note, error) {
+func (m *MockNoteRepository) ListGlobalTimeline(limit int, _, _ string, _ model.TimelineDBFilter) ([]*model.Note, error) {
 	return m.listPublic(limit)
 }
 
@@ -2822,4 +2822,27 @@ func (m *MockUserMemoRepository) FindByPair(userID, targetUserID string) (*model
 func (m *MockUserMemoRepository) Delete(userID, targetUserID string) error {
 	delete(m.Memos, userID+":"+targetUserID)
 	return nil
+}
+
+// MockUserPublickeyRepository is a test double for federation.PublickeyStore.
+type MockUserPublickeyRepository struct {
+	// keyed by userID
+	Keys map[string]*model.UserPublickey
+}
+
+// NewMockUserPublickeyRepository creates an empty MockUserPublickeyRepository.
+func NewMockUserPublickeyRepository() *MockUserPublickeyRepository {
+	return &MockUserPublickeyRepository{Keys: make(map[string]*model.UserPublickey)}
+}
+
+func (m *MockUserPublickeyRepository) Upsert(pk *model.UserPublickey) error {
+	m.Keys[pk.UserID] = pk
+	return nil
+}
+
+func (m *MockUserPublickeyRepository) FindByUserID(userID string) (*model.UserPublickey, error) {
+	if pk, ok := m.Keys[userID]; ok {
+		return pk, nil
+	}
+	return nil, ErrNotFound
 }

--- a/migration/000031_user_publickey.down.sql
+++ b/migration/000031_user_publickey.down.sql
@@ -1,0 +1,1 @@
+DROP TABLE IF EXISTS "user_publickey";

--- a/migration/000031_user_publickey.up.sql
+++ b/migration/000031_user_publickey.up.sql
@@ -1,0 +1,7 @@
+-- user_publickey: リモートユーザーの公開鍵を永続化するテーブル (TS版 1000000000000-Init.js 準拠)
+CREATE TABLE IF NOT EXISTS "user_publickey" (
+    "userId" varchar(32) NOT NULL PRIMARY KEY REFERENCES "user"("id") ON DELETE CASCADE,
+    "keyId" varchar(256) NOT NULL,
+    "keyPem" varchar(4096) NOT NULL
+);
+CREATE UNIQUE INDEX IF NOT EXISTS "IDX_user_publickey_keyId" ON "user_publickey" ("keyId");


### PR DESCRIPTION
## Summary

- タイムラインエンドポイントにフィルタリングパラメータを実装（sinceDate/untilDate, withFiles, withRenotes, withReplies, includeMyRenotes, includeRenotedMyNotes, includeLocalRenotes, allowPartial）
- signin-flow Step 1でcaptchaステップの分岐を追加（2FA無効 + captcha有効 → `next: "captcha"`）
- リモートユーザー公開鍵をuser_publickeyテーブルに永続化し、プロセス再起動後もDB復元可能に
- GlobalTimeline/LocalTimelineに `channelId IS NULL` 条件漏れを修正

## 主な変更点

| ファイル | 内容 |
|---------|------|
| `internal/core/timeline/timeline_filter.go` | TimelineFilter構造体 + ApplyFilter（Redis path用in-memoryフィルタ） |
| `internal/model/timeline_filter.go` | TimelineDBFilter構造体（DB fallback用） |
| `internal/repository/note.go` | applyTimelineFilter SQLヘルパ + channelId IS NULLバグ修正 |
| `internal/core/timeline/timeline_service.go` | 全4メソッドにTimelineFilterパラメータ追加 |
| `internal/api/notes/timeline_handler.go` | リクエストパラメータ拡張 + sinceDate/untilDate→ID変換 |
| `internal/core/captcha/captcha.go` | IsEnabled()メソッド追加 |
| `internal/api/signin/handler.go` | Step 1 captcha分岐ロジック |
| `migration/000031_user_publickey.{up,down}.sql` | user_publickeyテーブル |
| `internal/model/user_publickey.go` | UserPublickeyモデル |
| `internal/repository/user_publickey.go` | Repository実装（UPSERT対応） |
| `internal/core/federation/resolver.go` | PublickeyStoreインターフェース + 二段キャッシュ統合 |
| `internal/server/router.go` | publickeyRepo配線 |

## テスト

```bash
go test -race -count=1 ./internal/core/timeline/...      # OK
go test -race -count=1 ./internal/api/notes/...           # OK
go test -race -count=1 ./internal/api/signin/...          # OK
go test -race -count=1 ./internal/core/federation/...     # OK
```

- `timeline_filter_test.go`: ApplyFilter全パターン（withFiles, withRenotes, withReplies, includeMyRenotes, includeRenotedMyNotes, includeLocalRenotes, combined）
- `resolver_test.go`: DB永続化テスト（in-memory expire後のDBフォールバック復元確認）
- `handler_test.go` (signin): captcha分岐テスト3件追加

Closes #112

🤖 Generated with [Claude Code](https://claude.com/claude-code)