### PR TITLE
Phase P3: Missing tables + auxiliary endpoints

### DIFF
--- a/internal/api/admin/handler.go
+++ b/internal/api/admin/handler.go
@@ -157,12 +157,112 @@ func (h *Handler) AccountsCreate(c echo.Context) error {
 		return c.JSON(http.StatusInternalServerError, errResp("INTERNAL_ERROR", "Internal error.", "5d37dbcb-891e-41ca-a3d6-e690c97775ac"))
 	}
 
-	resp := entity.PackUserDetailed(result.User, nil)
-	out := map[string]any{
-		"id":       resp.ID,
-		"username": resp.Username,
-		"token":    result.Token,
+	u := result.User
+	detailed := entity.PackUserDetailed(u, nil)
+
+	isAdmin := false
+	isMod := false
+	userPolicies := role.DefaultPolicies()
+	if h.roleService != nil {
+		isAdmin = h.roleService.IsAdministrator(u.ID)
+		isMod = h.roleService.IsModerator(u.ID)
+		userPolicies = h.roleService.GetUserPolicies(u.ID)
 	}
+
+	out := map[string]any{
+		// UserLite
+		"id":                u.ID,
+		"name":              detailed.Name,
+		"username":          detailed.Username,
+		"host":              detailed.Host,
+		"avatarUrl":         detailed.AvatarURL,
+		"avatarBlurhash":    detailed.AvatarBlurhash,
+		"avatarDecorations": detailed.AvatarDecorations,
+		"isBot":             detailed.IsBot,
+		"isCat":             detailed.IsCat,
+		"emojis":            detailed.Emojis,
+		"onlineStatus":      detailed.OnlineStatus,
+		"badgeRoles":        detailed.BadgeRoles,
+		// UserDetailed
+		"bannerUrl":      detailed.BannerURL,
+		"bannerBlurhash": detailed.BannerBlurhash,
+		"isLocked":       detailed.IsLocked,
+		"isSilenced":     false,
+		"isSuspended":    detailed.IsSuspended,
+		"description":    detailed.Description,
+		"location":       detailed.Location,
+		"birthday":       detailed.Birthday,
+		"lang":           detailed.Lang,
+		"fields":         detailed.Fields,
+		"verifiedLinks":  detailed.VerifiedLinks,
+		"followersCount": detailed.FollowersCount,
+		"followingCount": detailed.FollowingCount,
+		"notesCount":     detailed.NotesCount,
+		"uri":            detailed.URI,
+		"url":            detailed.URL,
+		"movedTo":        u.MovedToURI,
+		"alsoKnownAs":    u.AlsoKnownAs,
+		"updatedAt":      detailed.UpdatedAt,
+		"lastFetchedAt":  nil,
+		// MeDetailed (新規ユーザーなのでゼロ値が多い)
+		"avatarId":                        u.AvatarID,
+		"bannerId":                        u.BannerID,
+		"followersVisibility":             detailed.FollowersVisibility,
+		"followingVisibility":             detailed.FollowingVisibility,
+		"chatScope":                       u.ChatScope,
+		"canChat":                         true,
+		"followedMessage":                 nil,
+		"memo":                            nil,
+		"moderationNote":                  nil,
+		"hideOnlineStatus":                u.HideOnlineStatus,
+		"isAdmin":                         isAdmin,
+		"isModerator":                     isMod,
+		"isDeleted":                       u.IsDeleted,
+		"isExplorable":                    u.IsExplorable,
+		"hasUnreadNotification":           false,
+		"hasPendingReceivedFollowRequest": false,
+		"hasUnreadAnnouncement":           false,
+		"hasUnreadAntenna":                false,
+		"hasUnreadChannel":                false,
+		"hasUnreadMentions":               false,
+		"hasUnreadSpecifiedNotes":         false,
+		"hasUnreadChatMessages":           false,
+		"unreadNotificationsCount":        0,
+		"unreadAnnouncements":             []any{},
+		"pinnedNoteIds":                   []string{},
+		"pinnedNotes":                     []any{},
+		"pinnedPageId":                    nil,
+		"pinnedPage":                      nil,
+		"policies":                        userPolicies,
+		"roles":                           []any{},
+		"securityKeysList":                []any{},
+		"mutingNotificationTypes":         []any{},
+		"notificationRecieveConfig":       map[string]any{},
+		"emailNotificationTypes":          []string{"follow", "receiveFollowRequest"},
+		"twoFactorEnabled":                false,
+		"usePasswordLessLogin":            false,
+		"securityKeys":                    false,
+		"twoFactorBackupCodesStock":       "none",
+		"autoAcceptFollowed":              true,
+		"noCrawle":                        false,
+		"preventAiLearning":               true,
+		"alwaysMarkNsfw":                  false,
+		"autoSensitive":                   false,
+		"carefulBot":                      false,
+		"injectFeaturedNote":              true,
+		"receiveAnnouncementEmail":        true,
+		"publicReactions":                 true,
+		"loggedInDays":                    0,
+		"achievements":                    []any{},
+		// token (MeDetailed にない追加フィールド)
+		"token": result.Token,
+	}
+
+	// createdAt は ID から復元
+	if t, err := h.idGen.ParseTime(u.ID); err == nil {
+		out["createdAt"] = t.UTC().Format("2006-01-02T15:04:05.000Z")
+	}
+
 	return c.JSON(http.StatusOK, out)
 }
 

--- a/internal/api/channels/handler.go
+++ b/internal/api/channels/handler.go
@@ -15,8 +15,26 @@ import (
 
 // Handler handles channel-related API endpoints.
 type Handler struct {
-	svc   *corechannel.Service
-	idGen id.Generator
+	svc          *corechannel.Service
+	idGen        id.Generator
+	favoriteRepo ChannelFavoriteRepository
+	mutingRepo   ChannelMutingRepository
+}
+
+// ChannelFavoriteRepository is the interface for channel favorite operations.
+type ChannelFavoriteRepository interface {
+	Create(fav *model.ChannelFavorite) error
+	Delete(userID, channelID string) error
+	ListByUser(userID string) ([]*model.ChannelFavorite, error)
+	Exists(userID, channelID string) (bool, error)
+}
+
+// ChannelMutingRepository is the interface for channel muting operations.
+type ChannelMutingRepository interface {
+	Create(mut *model.ChannelMuting) error
+	Delete(userID, channelID string) error
+	ListByUser(userID string) ([]*model.ChannelMuting, error)
+	Exists(userID, channelID string) (bool, error)
 }
 
 // NewHandler creates a new channels Handler.

--- a/internal/api/channels/handler_stubs.go
+++ b/internal/api/channels/handler_stubs.go
@@ -2,36 +2,157 @@ package channels
 
 import (
 	"net/http"
+	"time"
 
 	"github.com/labstack/echo/v4"
+	"github.com/shiroha-a/mk/internal/model"
+	"github.com/shiroha-a/mk/internal/server/middleware"
 )
+
+// SetFavoriteRepo attaches a ChannelFavoriteRepository for favorite endpoints.
+func (h *Handler) SetFavoriteRepo(r ChannelFavoriteRepository) {
+	h.favoriteRepo = r
+}
+
+// SetMutingRepo attaches a ChannelMutingRepository for mute endpoints.
+func (h *Handler) SetMutingRepo(r ChannelMutingRepository) {
+	h.mutingRepo = r
+}
 
 // Favorite handles POST /api/channels/favorite.
 func (h *Handler) Favorite(c echo.Context) error {
+	user := middleware.GetUser(c)
+	var req struct {
+		ChannelID string `json:"channelId"`
+	}
+	if err := c.Bind(&req); err != nil || req.ChannelID == "" {
+		return invalidParam(c)
+	}
+	if h.favoriteRepo == nil {
+		return c.NoContent(http.StatusNoContent)
+	}
+	if _, err := h.svc.Show(req.ChannelID); err != nil {
+		return notFound(c)
+	}
+	already, _ := h.favoriteRepo.Exists(user.ID, req.ChannelID)
+	if already {
+		return c.NoContent(http.StatusNoContent)
+	}
+	fav := &model.ChannelFavorite{
+		ID:        h.idGen.Generate(time.Now()),
+		UserID:    user.ID,
+		ChannelID: req.ChannelID,
+	}
+	if err := h.favoriteRepo.Create(fav); err != nil {
+		return internalError(c)
+	}
 	return c.NoContent(http.StatusNoContent)
 }
 
 // Unfavorite handles POST /api/channels/unfavorite.
 func (h *Handler) Unfavorite(c echo.Context) error {
-	return c.NoContent(http.StatusNoContent)
-}
-
-// MuteCreate handles POST /api/channels/mute/create.
-func (h *Handler) MuteCreate(c echo.Context) error {
-	return c.NoContent(http.StatusNoContent)
-}
-
-// MuteDelete handles POST /api/channels/mute/delete.
-func (h *Handler) MuteDelete(c echo.Context) error {
+	user := middleware.GetUser(c)
+	var req struct {
+		ChannelID string `json:"channelId"`
+	}
+	if err := c.Bind(&req); err != nil || req.ChannelID == "" {
+		return invalidParam(c)
+	}
+	if h.favoriteRepo == nil {
+		return c.NoContent(http.StatusNoContent)
+	}
+	if err := h.favoriteRepo.Delete(user.ID, req.ChannelID); err != nil {
+		return internalError(c)
+	}
 	return c.NoContent(http.StatusNoContent)
 }
 
 // MyFavorites handles POST /api/channels/my-favorites.
 func (h *Handler) MyFavorites(c echo.Context) error {
-	return c.JSON(http.StatusOK, []any{})
+	user := middleware.GetUser(c)
+	if h.favoriteRepo == nil {
+		return c.JSON(http.StatusOK, []any{})
+	}
+	favs, err := h.favoriteRepo.ListByUser(user.ID)
+	if err != nil {
+		return internalError(c)
+	}
+	out := make([]map[string]any, 0, len(favs))
+	for _, f := range favs {
+		ch, err := h.svc.Show(f.ChannelID)
+		if err != nil {
+			continue
+		}
+		out = append(out, channelToMap(ch))
+	}
+	return c.JSON(http.StatusOK, out)
+}
+
+// MuteCreate handles POST /api/channels/mute/create.
+func (h *Handler) MuteCreate(c echo.Context) error {
+	user := middleware.GetUser(c)
+	var req struct {
+		ChannelID string `json:"channelId"`
+	}
+	if err := c.Bind(&req); err != nil || req.ChannelID == "" {
+		return invalidParam(c)
+	}
+	if h.mutingRepo == nil {
+		return c.NoContent(http.StatusNoContent)
+	}
+	if _, err := h.svc.Show(req.ChannelID); err != nil {
+		return notFound(c)
+	}
+	already, _ := h.mutingRepo.Exists(user.ID, req.ChannelID)
+	if already {
+		return c.NoContent(http.StatusNoContent)
+	}
+	mut := &model.ChannelMuting{
+		ID:        h.idGen.Generate(time.Now()),
+		UserID:    user.ID,
+		ChannelID: req.ChannelID,
+	}
+	if err := h.mutingRepo.Create(mut); err != nil {
+		return internalError(c)
+	}
+	return c.NoContent(http.StatusNoContent)
+}
+
+// MuteDelete handles POST /api/channels/mute/delete.
+func (h *Handler) MuteDelete(c echo.Context) error {
+	user := middleware.GetUser(c)
+	var req struct {
+		ChannelID string `json:"channelId"`
+	}
+	if err := c.Bind(&req); err != nil || req.ChannelID == "" {
+		return invalidParam(c)
+	}
+	if h.mutingRepo == nil {
+		return c.NoContent(http.StatusNoContent)
+	}
+	if err := h.mutingRepo.Delete(user.ID, req.ChannelID); err != nil {
+		return internalError(c)
+	}
+	return c.NoContent(http.StatusNoContent)
 }
 
 // MuteList handles POST /api/channels/mute/list.
 func (h *Handler) MuteList(c echo.Context) error {
-	return c.JSON(http.StatusOK, []any{})
+	user := middleware.GetUser(c)
+	if h.mutingRepo == nil {
+		return c.JSON(http.StatusOK, []any{})
+	}
+	mutings, err := h.mutingRepo.ListByUser(user.ID)
+	if err != nil {
+		return internalError(c)
+	}
+	out := make([]map[string]any, 0, len(mutings))
+	for _, m := range mutings {
+		ch, err := h.svc.Show(m.ChannelID)
+		if err != nil {
+			continue
+		}
+		out = append(out, channelToMap(ch))
+	}
+	return c.JSON(http.StatusOK, out)
 }

--- a/internal/api/channels/handler_stubs_test.go
+++ b/internal/api/channels/handler_stubs_test.go
@@ -1,14 +1,36 @@
 package channels
 
 import (
+	"encoding/json"
 	"net/http"
 	"net/http/httptest"
 	"strings"
 	"testing"
 
 	"github.com/labstack/echo/v4"
+	corechannel "github.com/shiroha-a/mk/internal/core/channel"
+	"github.com/shiroha-a/mk/internal/misc/id"
+	"github.com/shiroha-a/mk/internal/model"
+	"github.com/shiroha-a/mk/internal/server/middleware"
+	"github.com/shiroha-a/mk/internal/testutil"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
+
+func newStubHandler(t *testing.T) (*Handler, *testutil.MockChannelRepository, *testutil.MockChannelFavoriteRepository, *testutil.MockChannelMutingRepository) {
+	t.Helper()
+	repo := testutil.NewMockChannelRepository()
+	followRepo := testutil.NewMockChannelFollowingRepository()
+	noteRepo := testutil.NewMockNoteRepository()
+	idGen, _ := id.NewGenerator("aidx")
+	svc := corechannel.NewService(repo, followRepo, noteRepo, idGen)
+	h := NewHandler(svc, idGen)
+	favRepo := testutil.NewMockChannelFavoriteRepository()
+	mutRepo := testutil.NewMockChannelMutingRepository()
+	h.SetFavoriteRepo(favRepo)
+	h.SetMutingRepo(mutRepo)
+	return h, repo, favRepo, mutRepo
+}
 
 func postStub(handler func(echo.Context) error) *httptest.ResponseRecorder {
 	e := echo.New()
@@ -20,27 +42,168 @@ func postStub(handler func(echo.Context) error) *httptest.ResponseRecorder {
 	return rec
 }
 
-func TestFavorite(t *testing.T) {
-	h, _, _, _ := newHandler(t)
-	assert.Equal(t, http.StatusNoContent, postStub(h.Favorite).Code)
+func postStubWithBody(t *testing.T, handler func(echo.Context) error, body string, userID string) *httptest.ResponseRecorder {
+	t.Helper()
+	e := echo.New()
+	req := httptest.NewRequest(http.MethodPost, "/", strings.NewReader(body))
+	req.Header.Set(echo.HeaderContentType, echo.MIMEApplicationJSON)
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+	if userID != "" {
+		c.Set(string(middleware.UserContextKey), &model.User{ID: userID})
+	}
+	_ = handler(c)
+	return rec
 }
-func TestUnfavorite(t *testing.T) {
-	h, _, _, _ := newHandler(t)
-	assert.Equal(t, http.StatusNoContent, postStub(h.Unfavorite).Code)
+
+// --- Favorite ---
+
+func TestFavorite_MissingChannelID(t *testing.T) {
+	h, _, _, _ := newStubHandler(t)
+	rec := postStubWithBody(t, h.Favorite, `{}`, "u1")
+	assert.Equal(t, http.StatusBadRequest, rec.Code)
 }
-func TestMuteCreate(t *testing.T) {
-	h, _, _, _ := newHandler(t)
-	assert.Equal(t, http.StatusNoContent, postStub(h.MuteCreate).Code)
+
+func TestFavorite_ChannelNotFound(t *testing.T) {
+	h, _, _, _ := newStubHandler(t)
+	rec := postStubWithBody(t, h.Favorite, `{"channelId":"nonexist"}`, "u1")
+	assert.Equal(t, http.StatusNotFound, rec.Code)
 }
-func TestMuteDelete(t *testing.T) {
-	h, _, _, _ := newHandler(t)
-	assert.Equal(t, http.StatusNoContent, postStub(h.MuteDelete).Code)
+
+func TestFavorite_Success(t *testing.T) {
+	h, chRepo, favRepo, _ := newStubHandler(t)
+	chRepo.Channels["ch1"] = &model.Channel{ID: "ch1", Name: "test"}
+	rec := postStubWithBody(t, h.Favorite, `{"channelId":"ch1"}`, "u1")
+	assert.Equal(t, http.StatusNoContent, rec.Code)
+	exists, _ := favRepo.Exists("u1", "ch1")
+	assert.True(t, exists)
 }
-func TestMyFavorites(t *testing.T) {
-	h, _, _, _ := newHandler(t)
-	assert.Equal(t, http.StatusOK, postStub(h.MyFavorites).Code)
+
+func TestFavorite_AlreadyFavorited(t *testing.T) {
+	h, chRepo, favRepo, _ := newStubHandler(t)
+	chRepo.Channels["ch1"] = &model.Channel{ID: "ch1", Name: "test"}
+	favRepo.Favorites["u1:ch1"] = &model.ChannelFavorite{ID: "f1", UserID: "u1", ChannelID: "ch1"}
+	rec := postStubWithBody(t, h.Favorite, `{"channelId":"ch1"}`, "u1")
+	assert.Equal(t, http.StatusNoContent, rec.Code)
 }
-func TestMuteList(t *testing.T) {
-	h, _, _, _ := newHandler(t)
-	assert.Equal(t, http.StatusOK, postStub(h.MuteList).Code)
+
+func TestFavorite_NilRepo(t *testing.T) {
+	repo := testutil.NewMockChannelRepository()
+	followRepo := testutil.NewMockChannelFollowingRepository()
+	noteRepo := testutil.NewMockNoteRepository()
+	idGen, _ := id.NewGenerator("aidx")
+	svc := corechannel.NewService(repo, followRepo, noteRepo, idGen)
+	h := NewHandler(svc, idGen)
+	// favoriteRepo is nil
+	rec := postStubWithBody(t, h.Favorite, `{"channelId":"ch1"}`, "u1")
+	assert.Equal(t, http.StatusNoContent, rec.Code)
+}
+
+// --- Unfavorite ---
+
+func TestUnfavorite_Success(t *testing.T) {
+	h, _, favRepo, _ := newStubHandler(t)
+	favRepo.Favorites["u1:ch1"] = &model.ChannelFavorite{ID: "f1", UserID: "u1", ChannelID: "ch1"}
+	rec := postStubWithBody(t, h.Unfavorite, `{"channelId":"ch1"}`, "u1")
+	assert.Equal(t, http.StatusNoContent, rec.Code)
+	exists, _ := favRepo.Exists("u1", "ch1")
+	assert.False(t, exists)
+}
+
+func TestUnfavorite_MissingChannelID(t *testing.T) {
+	h, _, _, _ := newStubHandler(t)
+	rec := postStubWithBody(t, h.Unfavorite, `{}`, "u1")
+	assert.Equal(t, http.StatusBadRequest, rec.Code)
+}
+
+// --- MyFavorites ---
+
+func TestMyFavorites_Empty(t *testing.T) {
+	h, _, _, _ := newStubHandler(t)
+	rec := postStubWithBody(t, h.MyFavorites, `{}`, "u1")
+	assert.Equal(t, http.StatusOK, rec.Code)
+	var arr []any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &arr))
+	assert.Empty(t, arr)
+}
+
+func TestMyFavorites_WithData(t *testing.T) {
+	h, chRepo, favRepo, _ := newStubHandler(t)
+	chRepo.Channels["ch1"] = &model.Channel{ID: "ch1", Name: "test"}
+	favRepo.Favorites["u1:ch1"] = &model.ChannelFavorite{ID: "f1", UserID: "u1", ChannelID: "ch1"}
+	rec := postStubWithBody(t, h.MyFavorites, `{}`, "u1")
+	assert.Equal(t, http.StatusOK, rec.Code)
+	var arr []any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &arr))
+	assert.Len(t, arr, 1)
+}
+
+// --- MuteCreate ---
+
+func TestMuteCreate_Success(t *testing.T) {
+	h, chRepo, _, mutRepo := newStubHandler(t)
+	chRepo.Channels["ch1"] = &model.Channel{ID: "ch1", Name: "test"}
+	rec := postStubWithBody(t, h.MuteCreate, `{"channelId":"ch1"}`, "u1")
+	assert.Equal(t, http.StatusNoContent, rec.Code)
+	exists, _ := mutRepo.Exists("u1", "ch1")
+	assert.True(t, exists)
+}
+
+func TestMuteCreate_MissingChannelID(t *testing.T) {
+	h, _, _, _ := newStubHandler(t)
+	rec := postStubWithBody(t, h.MuteCreate, `{}`, "u1")
+	assert.Equal(t, http.StatusBadRequest, rec.Code)
+}
+
+func TestMuteCreate_ChannelNotFound(t *testing.T) {
+	h, _, _, _ := newStubHandler(t)
+	rec := postStubWithBody(t, h.MuteCreate, `{"channelId":"nonexist"}`, "u1")
+	assert.Equal(t, http.StatusNotFound, rec.Code)
+}
+
+func TestMuteCreate_AlreadyMuted(t *testing.T) {
+	h, chRepo, _, mutRepo := newStubHandler(t)
+	chRepo.Channels["ch1"] = &model.Channel{ID: "ch1", Name: "test"}
+	mutRepo.Mutings["u1:ch1"] = &model.ChannelMuting{ID: "m1", UserID: "u1", ChannelID: "ch1"}
+	rec := postStubWithBody(t, h.MuteCreate, `{"channelId":"ch1"}`, "u1")
+	assert.Equal(t, http.StatusNoContent, rec.Code)
+}
+
+// --- MuteDelete ---
+
+func TestMuteDelete_Success(t *testing.T) {
+	h, _, _, mutRepo := newStubHandler(t)
+	mutRepo.Mutings["u1:ch1"] = &model.ChannelMuting{ID: "m1", UserID: "u1", ChannelID: "ch1"}
+	rec := postStubWithBody(t, h.MuteDelete, `{"channelId":"ch1"}`, "u1")
+	assert.Equal(t, http.StatusNoContent, rec.Code)
+	exists, _ := mutRepo.Exists("u1", "ch1")
+	assert.False(t, exists)
+}
+
+func TestMuteDelete_MissingChannelID(t *testing.T) {
+	h, _, _, _ := newStubHandler(t)
+	rec := postStubWithBody(t, h.MuteDelete, `{}`, "u1")
+	assert.Equal(t, http.StatusBadRequest, rec.Code)
+}
+
+// --- MuteList ---
+
+func TestMuteList_Empty(t *testing.T) {
+	h, _, _, _ := newStubHandler(t)
+	rec := postStubWithBody(t, h.MuteList, `{}`, "u1")
+	assert.Equal(t, http.StatusOK, rec.Code)
+	var arr []any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &arr))
+	assert.Empty(t, arr)
+}
+
+func TestMuteList_WithData(t *testing.T) {
+	h, chRepo, _, mutRepo := newStubHandler(t)
+	chRepo.Channels["ch1"] = &model.Channel{ID: "ch1", Name: "test"}
+	mutRepo.Mutings["u1:ch1"] = &model.ChannelMuting{ID: "m1", UserID: "u1", ChannelID: "ch1"}
+	rec := postStubWithBody(t, h.MuteList, `{}`, "u1")
+	assert.Equal(t, http.StatusOK, rec.Code)
+	var arr []any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &arr))
+	assert.Len(t, arr, 1)
 }

--- a/internal/api/clips/handler.go
+++ b/internal/api/clips/handler.go
@@ -15,8 +15,9 @@ import (
 
 // Handler handles clip-related API endpoints.
 type Handler struct {
-	svc   *coreclip.Service
-	idGen id.Generator
+	svc          *coreclip.Service
+	idGen        id.Generator
+	favoriteRepo ClipFavoriteRepository
 }
 
 // NewHandler creates a new clips Handler.

--- a/internal/api/clips/handler_stubs.go
+++ b/internal/api/clips/handler_stubs.go
@@ -2,21 +2,92 @@ package clips
 
 import (
 	"net/http"
+	"time"
 
 	"github.com/labstack/echo/v4"
+	"github.com/shiroha-a/mk/internal/model"
+	"github.com/shiroha-a/mk/internal/server/middleware"
 )
+
+// ClipFavoriteRepository is the interface for clip favorite operations.
+type ClipFavoriteRepository interface {
+	Create(fav *model.ClipFavorite) error
+	Delete(userID, clipID string) error
+	ListByUser(userID string) ([]*model.ClipFavorite, error)
+	Exists(userID, clipID string) (bool, error)
+}
+
+// SetFavoriteRepo attaches a ClipFavoriteRepository for favorite endpoints.
+func (h *Handler) SetFavoriteRepo(r ClipFavoriteRepository) {
+	h.favoriteRepo = r
+}
 
 // Favorite handles POST /api/clips/favorite.
 func (h *Handler) Favorite(c echo.Context) error {
+	user := middleware.GetUser(c)
+	var req struct {
+		ClipID string `json:"clipId"`
+	}
+	if err := c.Bind(&req); err != nil || req.ClipID == "" {
+		return invalidParam(c)
+	}
+	if h.favoriteRepo == nil {
+		return c.NoContent(http.StatusNoContent)
+	}
+	// クリップの存在確認
+	if _, err := h.svc.Show(user.ID, req.ClipID); err != nil {
+		return notFound(c)
+	}
+	already, _ := h.favoriteRepo.Exists(user.ID, req.ClipID)
+	if already {
+		return c.NoContent(http.StatusNoContent)
+	}
+	fav := &model.ClipFavorite{
+		ID:     h.idGen.Generate(time.Now()),
+		UserID: user.ID,
+		ClipID: req.ClipID,
+	}
+	if err := h.favoriteRepo.Create(fav); err != nil {
+		return internalError(c)
+	}
 	return c.NoContent(http.StatusNoContent)
 }
 
 // Unfavorite handles POST /api/clips/unfavorite.
 func (h *Handler) Unfavorite(c echo.Context) error {
+	user := middleware.GetUser(c)
+	var req struct {
+		ClipID string `json:"clipId"`
+	}
+	if err := c.Bind(&req); err != nil || req.ClipID == "" {
+		return invalidParam(c)
+	}
+	if h.favoriteRepo == nil {
+		return c.NoContent(http.StatusNoContent)
+	}
+	if err := h.favoriteRepo.Delete(user.ID, req.ClipID); err != nil {
+		return internalError(c)
+	}
 	return c.NoContent(http.StatusNoContent)
 }
 
 // MyFavorites handles POST /api/clips/my-favorites.
 func (h *Handler) MyFavorites(c echo.Context) error {
-	return c.JSON(http.StatusOK, []any{})
+	user := middleware.GetUser(c)
+	if h.favoriteRepo == nil {
+		return c.JSON(http.StatusOK, []any{})
+	}
+	favs, err := h.favoriteRepo.ListByUser(user.ID)
+	if err != nil {
+		return internalError(c)
+	}
+	out := make([]map[string]any, 0, len(favs))
+	for _, f := range favs {
+		cl, err := h.svc.Show(user.ID, f.ClipID)
+		if err != nil {
+			continue
+		}
+		out = append(out, clipToMap(cl))
+	}
+	return c.JSON(http.StatusOK, out)
 }

--- a/internal/api/clips/handler_stubs_test.go
+++ b/internal/api/clips/handler_stubs_test.go
@@ -1,34 +1,110 @@
 package clips
 
 import (
+	"encoding/json"
 	"net/http"
 	"net/http/httptest"
 	"strings"
 	"testing"
 
 	"github.com/labstack/echo/v4"
+	coreclip "github.com/shiroha-a/mk/internal/core/clip"
+	"github.com/shiroha-a/mk/internal/misc/id"
+	"github.com/shiroha-a/mk/internal/model"
+	"github.com/shiroha-a/mk/internal/server/middleware"
+	"github.com/shiroha-a/mk/internal/testutil"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
-func postStub(handler func(echo.Context) error) *httptest.ResponseRecorder {
+func newStubHandler(t *testing.T) (*Handler, *testutil.MockClipRepository, *testutil.MockClipFavoriteRepository) {
+	t.Helper()
+	repo := testutil.NewMockClipRepository()
+	noteRepo := testutil.NewMockClipNoteRepository()
+	notes := testutil.NewMockNoteRepository()
+	idGen, _ := id.NewGenerator("aidx")
+	svc := coreclip.NewService(repo, noteRepo, notes, idGen)
+	h := NewHandler(svc, idGen)
+	favRepo := testutil.NewMockClipFavoriteRepository()
+	h.SetFavoriteRepo(favRepo)
+	return h, repo, favRepo
+}
+
+func postStubWithBody(t *testing.T, handler func(echo.Context) error, body string, userID string) *httptest.ResponseRecorder {
+	t.Helper()
 	e := echo.New()
-	req := httptest.NewRequest(http.MethodPost, "/", strings.NewReader(`{}`))
+	req := httptest.NewRequest(http.MethodPost, "/", strings.NewReader(body))
 	req.Header.Set(echo.HeaderContentType, echo.MIMEApplicationJSON)
 	rec := httptest.NewRecorder()
 	c := e.NewContext(req, rec)
+	if userID != "" {
+		c.Set(string(middleware.UserContextKey), &model.User{ID: userID})
+	}
 	_ = handler(c)
 	return rec
 }
 
-func TestFavorite(t *testing.T) {
-	h, _, _, _ := newHandler(t)
-	assert.Equal(t, http.StatusNoContent, postStub(h.Favorite).Code)
+func TestClipFavorite_MissingClipID(t *testing.T) {
+	h, _, _ := newStubHandler(t)
+	rec := postStubWithBody(t, h.Favorite, `{}`, "u1")
+	assert.Equal(t, http.StatusBadRequest, rec.Code)
 }
-func TestUnfavorite(t *testing.T) {
-	h, _, _, _ := newHandler(t)
-	assert.Equal(t, http.StatusNoContent, postStub(h.Unfavorite).Code)
+
+func TestClipFavorite_Success(t *testing.T) {
+	h, clipRepo, favRepo := newStubHandler(t)
+	clipRepo.Clips["cl1"] = &model.Clip{ID: "cl1", UserID: "u1", Name: "test", IsPublic: true}
+	rec := postStubWithBody(t, h.Favorite, `{"clipId":"cl1"}`, "u1")
+	assert.Equal(t, http.StatusNoContent, rec.Code)
+	exists, _ := favRepo.Exists("u1", "cl1")
+	assert.True(t, exists)
 }
-func TestMyFavorites(t *testing.T) {
+
+func TestClipFavorite_AlreadyFavorited(t *testing.T) {
+	h, clipRepo, favRepo := newStubHandler(t)
+	clipRepo.Clips["cl1"] = &model.Clip{ID: "cl1", UserID: "u1", Name: "test", IsPublic: true}
+	favRepo.Favorites["u1:cl1"] = &model.ClipFavorite{ID: "f1", UserID: "u1", ClipID: "cl1"}
+	rec := postStubWithBody(t, h.Favorite, `{"clipId":"cl1"}`, "u1")
+	assert.Equal(t, http.StatusNoContent, rec.Code)
+}
+
+func TestClipFavorite_NilRepo(t *testing.T) {
 	h, _, _, _ := newHandler(t)
-	assert.Equal(t, http.StatusOK, postStub(h.MyFavorites).Code)
+	// favoriteRepo is nil → graceful NoContent
+	rec := postStubWithBody(t, h.Favorite, `{"clipId":"cl1"}`, "u1")
+	assert.Equal(t, http.StatusNoContent, rec.Code)
+}
+
+func TestClipUnfavorite_Success(t *testing.T) {
+	h, _, favRepo := newStubHandler(t)
+	favRepo.Favorites["u1:cl1"] = &model.ClipFavorite{ID: "f1", UserID: "u1", ClipID: "cl1"}
+	rec := postStubWithBody(t, h.Unfavorite, `{"clipId":"cl1"}`, "u1")
+	assert.Equal(t, http.StatusNoContent, rec.Code)
+	exists, _ := favRepo.Exists("u1", "cl1")
+	assert.False(t, exists)
+}
+
+func TestClipUnfavorite_MissingClipID(t *testing.T) {
+	h, _, _ := newStubHandler(t)
+	rec := postStubWithBody(t, h.Unfavorite, `{}`, "u1")
+	assert.Equal(t, http.StatusBadRequest, rec.Code)
+}
+
+func TestClipMyFavorites_Empty(t *testing.T) {
+	h, _, _ := newStubHandler(t)
+	rec := postStubWithBody(t, h.MyFavorites, `{}`, "u1")
+	assert.Equal(t, http.StatusOK, rec.Code)
+	var arr []any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &arr))
+	assert.Empty(t, arr)
+}
+
+func TestClipMyFavorites_WithData(t *testing.T) {
+	h, clipRepo, favRepo := newStubHandler(t)
+	clipRepo.Clips["cl1"] = &model.Clip{ID: "cl1", UserID: "u1", Name: "test", IsPublic: true}
+	favRepo.Favorites["u1:cl1"] = &model.ClipFavorite{ID: "f1", UserID: "u1", ClipID: "cl1"}
+	rec := postStubWithBody(t, h.MyFavorites, `{}`, "u1")
+	assert.Equal(t, http.StatusOK, rec.Code)
+	var arr []any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &arr))
+	assert.Len(t, arr, 1)
 }

--- a/internal/api/emojis/handler.go
+++ b/internal/api/emojis/handler.go
@@ -41,3 +41,40 @@ func (h *Handler) Emojis(c echo.Context) error {
 
 	return c.JSON(http.StatusOK, map[string]any{"emojis": result})
 }
+
+// Emoji returns a single custom emoji by name.
+// POST /api/emoji
+func (h *Handler) Emoji(c echo.Context) error {
+	var req struct {
+		Name string `json:"name"`
+	}
+	if err := c.Bind(&req); err != nil || req.Name == "" {
+		return c.JSON(http.StatusBadRequest, map[string]any{
+			"error": map[string]any{
+				"message": "Invalid param.",
+				"code":    "INVALID_PARAM",
+				"id":      "3d81ceae-475f-4600-b2a8-2bc116157532",
+			},
+		})
+	}
+	e, err := h.emojiRepo.FindByNameAndHost(req.Name, nil)
+	if err != nil {
+		return c.JSON(http.StatusNotFound, map[string]any{
+			"error": map[string]any{
+				"message": "No such emoji.",
+				"code":    "NO_SUCH_EMOJI",
+				"id":      "14141e4b-dea8-41f0-9ba1-1721a6b5b92c",
+			},
+		})
+	}
+	return c.JSON(http.StatusOK, map[string]any{
+		"id":          e.ID,
+		"name":        e.Name,
+		"category":    e.Category,
+		"aliases":     e.Aliases,
+		"url":         e.PublicURL,
+		"localOnly":   e.LocalOnly,
+		"isSensitive": e.IsSensitive,
+		"host":        e.Host,
+	})
+}

--- a/internal/api/emojis/handler_test.go
+++ b/internal/api/emojis/handler_test.go
@@ -103,3 +103,51 @@ func TestEmojis_ExcludesRemote(t *testing.T) {
 	arr := body["emojis"].([]any)
 	assert.Empty(t, arr) // リモート絵文字は除外
 }
+
+// --- Emoji (singular) ---
+
+func doPostEmoji(h *emojis.Handler, body string) *httptest.ResponseRecorder {
+	e := echo.New()
+	req := httptest.NewRequest(http.MethodPost, "/api/emoji", strings.NewReader(body))
+	req.Header.Set(echo.HeaderContentType, echo.MIMEApplicationJSON)
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+	_ = h.Emoji(c)
+	return rec
+}
+
+func TestEmoji_MissingName(t *testing.T) {
+	h, _ := setup()
+	rec := doPostEmoji(h, `{}`)
+	assert.Equal(t, http.StatusBadRequest, rec.Code)
+}
+
+func TestEmoji_NotFound(t *testing.T) {
+	h, _ := setup()
+	rec := doPostEmoji(h, `{"name":"nonexist"}`)
+	assert.Equal(t, http.StatusNotFound, rec.Code)
+	var body map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &body))
+	errObj := body["error"].(map[string]any)
+	assert.Equal(t, "NO_SUCH_EMOJI", errObj["code"])
+}
+
+func TestEmoji_Found(t *testing.T) {
+	h, repo := setup()
+	cat := "faces"
+	repo.Emojis["smile@"] = &model.Emoji{
+		ID:        "e1",
+		Name:      "smile",
+		Category:  &cat,
+		PublicURL: "https://example.com/emoji/smile.png",
+		Aliases:   []string{"happy"},
+	}
+	rec := doPostEmoji(h, `{"name":"smile"}`)
+	assert.Equal(t, http.StatusOK, rec.Code)
+	var body map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &body))
+	assert.Equal(t, "e1", body["id"])
+	assert.Equal(t, "smile", body["name"])
+	assert.Equal(t, "faces", body["category"])
+	assert.Equal(t, "https://example.com/emoji/smile.png", body["url"])
+}

--- a/internal/api/resetpassword/handler_test.go
+++ b/internal/api/resetpassword/handler_test.go
@@ -45,6 +45,7 @@ func (m *mockUserRepo) UpdateUser(string, map[string]any) error               { 
 func (m *mockUserRepo) CreateProfile(*model.UserProfile) error                { return nil }
 func (m *mockUserRepo) ListUsers(model.UserListFilter) ([]*model.User, error) { return nil, nil }
 func (m *mockUserRepo) ListRemoteInboxes() ([]string, error)                  { return nil, nil }
+func (m *mockUserRepo) CountOnlineUsers() (int64, error)                      { return 0, nil }
 
 func (m *mockUserRepo) findByID(id string) (*model.User, error) {
 	u, ok := m.users[id]

--- a/internal/api/roles/handler.go
+++ b/internal/api/roles/handler.go
@@ -5,17 +5,36 @@ import (
 
 	"github.com/labstack/echo/v4"
 	"github.com/shiroha-a/mk/internal/core/role"
+	"github.com/shiroha-a/mk/internal/entity"
+	"github.com/shiroha-a/mk/internal/misc/id"
 	"github.com/shiroha-a/mk/internal/model"
 )
+
+// RoleNotesQuery provides a way to fetch notes by role.
+type RoleNotesQuery interface {
+	ListByRole(roleID string, limit int, sinceID, untilID string) ([]*model.Note, error)
+}
 
 // Handler handles public role API endpoints.
 type Handler struct {
 	roleService *role.Service
+	notesQuery  RoleNotesQuery
+	idGen       id.Generator
 }
 
 // NewHandler creates a new roles Handler.
 func NewHandler(roleService *role.Service) *Handler {
 	return &Handler{roleService: roleService}
+}
+
+// SetNotesQuery attaches a RoleNotesQuery for the roles/notes endpoint.
+func (h *Handler) SetNotesQuery(q RoleNotesQuery) {
+	h.notesQuery = q
+}
+
+// SetIDGen attaches an ID generator for note packing.
+func (h *Handler) SetIDGen(g id.Generator) {
+	h.idGen = g
 }
 
 // List handles POST /api/roles/list.
@@ -24,7 +43,6 @@ func (h *Handler) List(c echo.Context) error {
 	if err != nil {
 		return c.JSON(http.StatusInternalServerError, errResp("INTERNAL_ERROR", "Internal error.", "5d37dbcb-891e-41ca-a3d6-e690c97775ac"))
 	}
-	// 公開ロールのみフィルタ
 	var result []any
 	for _, r := range roles {
 		if r.IsPublic {
@@ -63,8 +81,51 @@ func (h *Handler) Users(c echo.Context) error {
 	if _, err := h.roleService.Show(req.RoleID); err != nil {
 		return c.JSON(http.StatusNotFound, errResp("NO_SUCH_ROLE", "No such role.", "07dc7d34-c0d8-458b-9c04-4b18399b1f46"))
 	}
-	// ユーザー一覧は簡易版 (TODO: RoleService.ListByRole)
 	return c.JSON(http.StatusOK, []any{})
+}
+
+// Notes handles POST /api/roles/notes.
+func (h *Handler) Notes(c echo.Context) error {
+	var req struct {
+		RoleID  string `json:"roleId"`
+		Limit   int    `json:"limit"`
+		SinceID string `json:"sinceId"`
+		UntilID string `json:"untilId"`
+	}
+	if err := c.Bind(&req); err != nil || req.RoleID == "" {
+		return c.JSON(http.StatusBadRequest, errResp("INVALID_PARAM", "roleId is required.", "3d81ceae-475f-4600-b2a8-2bc116157532"))
+	}
+
+	r, err := h.roleService.Show(req.RoleID)
+	if err != nil {
+		return c.JSON(http.StatusNotFound, errResp("NO_SUCH_ROLE", "No such role.", "07dc7d34-c0d8-458b-9c04-4b18399b1f46"))
+	}
+	if !r.IsPublic {
+		return c.JSON(http.StatusNotFound, errResp("NO_SUCH_ROLE", "No such role.", "07dc7d34-c0d8-458b-9c04-4b18399b1f46"))
+	}
+
+	if h.notesQuery == nil {
+		return c.JSON(http.StatusOK, []any{})
+	}
+
+	limit := req.Limit
+	if limit <= 0 {
+		limit = 10
+	}
+	if limit > 100 {
+		limit = 100
+	}
+
+	notes, err := h.notesQuery.ListByRole(req.RoleID, limit, req.SinceID, req.UntilID)
+	if err != nil {
+		return c.JSON(http.StatusInternalServerError, errResp("INTERNAL_ERROR", "Internal error.", "5d37dbcb-891e-41ca-a3d6-e690c97775ac"))
+	}
+
+	out := make([]any, 0, len(notes))
+	for _, n := range notes {
+		out = append(out, entity.PackNote(n, h.idGen))
+	}
+	return c.JSON(http.StatusOK, out)
 }
 
 func packRole(r *model.Role) map[string]any {

--- a/internal/api/roles/handler_test.go
+++ b/internal/api/roles/handler_test.go
@@ -17,6 +17,23 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+// mockRoleNotesQuery is a test double for roles.RoleNotesQuery.
+type mockRoleNotesQuery struct {
+	Notes []*model.Note
+	Err   error
+}
+
+func (m *mockRoleNotesQuery) ListByRole(roleID string, limit int, sinceID, untilID string) ([]*model.Note, error) {
+	if m.Err != nil {
+		return nil, m.Err
+	}
+	result := m.Notes
+	if limit > 0 && len(result) > limit {
+		result = result[:limit]
+	}
+	return result, nil
+}
+
 func newTestHandler(t *testing.T) (*roles.Handler, *testutil.MockRoleRepository) {
 	t.Helper()
 	roleRepo := testutil.NewMockRoleRepository()
@@ -25,7 +42,9 @@ func newTestHandler(t *testing.T) (*roles.Handler, *testutil.MockRoleRepository)
 	metaRepo.Meta = &model.Meta{ID: "x"}
 	idGen, _ := id.NewGenerator("aidx")
 	svc := corerole.NewService(roleRepo, assignRepo, metaRepo, idGen)
-	return roles.NewHandler(svc), roleRepo
+	h := roles.NewHandler(svc)
+	h.SetIDGen(idGen)
+	return h, roleRepo
 }
 
 func doPost(h func(echo.Context) error, body string) *httptest.ResponseRecorder {
@@ -119,3 +138,79 @@ type failingListRepo struct {
 }
 
 func (f *failingListRepo) List() ([]*model.Role, error) { return nil, assert.AnError }
+
+// --- Notes ---
+
+func TestNotes_InvalidParam(t *testing.T) {
+	h, _ := newTestHandler(t)
+	rec := doPost(h.Notes, `{}`)
+	assert.Equal(t, http.StatusBadRequest, rec.Code)
+}
+
+func TestNotes_RoleNotFound(t *testing.T) {
+	h, _ := newTestHandler(t)
+	rec := doPost(h.Notes, `{"roleId":"ghost"}`)
+	assert.Equal(t, http.StatusNotFound, rec.Code)
+}
+
+func TestNotes_NotPublic(t *testing.T) {
+	h, roleRepo := newTestHandler(t)
+	roleRepo.Roles["r1"] = &model.Role{ID: "r1", Name: "Private", IsPublic: false}
+	rec := doPost(h.Notes, `{"roleId":"r1"}`)
+	assert.Equal(t, http.StatusNotFound, rec.Code)
+}
+
+func TestNotes_NilQuery(t *testing.T) {
+	h, roleRepo := newTestHandler(t)
+	roleRepo.Roles["r1"] = &model.Role{ID: "r1", Name: "Public", IsPublic: true}
+	rec := doPost(h.Notes, `{"roleId":"r1"}`)
+	assert.Equal(t, http.StatusOK, rec.Code)
+	var arr []any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &arr))
+	assert.Empty(t, arr)
+}
+
+func TestNotes_Success(t *testing.T) {
+	h, roleRepo := newTestHandler(t)
+	roleRepo.Roles["r1"] = &model.Role{ID: "r1", Name: "Public", IsPublic: true}
+	mock := &mockRoleNotesQuery{
+		Notes: []*model.Note{
+			{ID: "n1", UserID: "u1", Text: strPtr("hello"), Visibility: "public"},
+		},
+	}
+	h.SetNotesQuery(mock)
+	rec := doPost(h.Notes, `{"roleId":"r1"}`)
+	assert.Equal(t, http.StatusOK, rec.Code)
+	var arr []any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &arr))
+	assert.Len(t, arr, 1)
+}
+
+func TestNotes_QueryError(t *testing.T) {
+	h, roleRepo := newTestHandler(t)
+	roleRepo.Roles["r1"] = &model.Role{ID: "r1", Name: "Public", IsPublic: true}
+	mock := &mockRoleNotesQuery{Err: assert.AnError}
+	h.SetNotesQuery(mock)
+	rec := doPost(h.Notes, `{"roleId":"r1"}`)
+	assert.Equal(t, http.StatusInternalServerError, rec.Code)
+}
+
+func TestNotes_DefaultLimit(t *testing.T) {
+	h, roleRepo := newTestHandler(t)
+	roleRepo.Roles["r1"] = &model.Role{ID: "r1", Name: "Public", IsPublic: true}
+	mock := &mockRoleNotesQuery{}
+	h.SetNotesQuery(mock)
+	rec := doPost(h.Notes, `{"roleId":"r1","limit":0}`)
+	assert.Equal(t, http.StatusOK, rec.Code)
+}
+
+func TestNotes_LimitClamped(t *testing.T) {
+	h, roleRepo := newTestHandler(t)
+	roleRepo.Roles["r1"] = &model.Role{ID: "r1", Name: "Public", IsPublic: true}
+	mock := &mockRoleNotesQuery{}
+	h.SetNotesQuery(mock)
+	rec := doPost(h.Notes, `{"roleId":"r1","limit":999}`)
+	assert.Equal(t, http.StatusOK, rec.Code)
+}
+
+func strPtr(s string) *string { return &s }

--- a/internal/api/users/handler.go
+++ b/internal/api/users/handler.go
@@ -22,19 +22,20 @@ type ChartHook interface {
 
 // Handler handles user-related API endpoints.
 type Handler struct {
-	userService       *user.Service
-	followingService  *corefollowing.Service
-	noteRepo          repository.NoteRepository
-	idGen             id.Generator
-	chartHook         ChartHook
-	abuseRepo         repository.AbuseReportRepository
-	followingRepo     repository.FollowingRepository
-	memoRepo          repository.UserMemoRepository
-	blockingRepo      repository.BlockingRepository
-	mutingRepo        repository.MutingRepository
-	renoteMutingRepo  repository.RenoteMutingRepository
-	followRequestRepo repository.FollowRequestRepository
-	instanceRepo      repository.InstanceRepository
+	userService          *user.Service
+	followingService     *corefollowing.Service
+	noteRepo             repository.NoteRepository
+	idGen                id.Generator
+	chartHook            ChartHook
+	abuseRepo            repository.AbuseReportRepository
+	followingRepo        repository.FollowingRepository
+	memoRepo             repository.UserMemoRepository
+	blockingRepo         repository.BlockingRepository
+	mutingRepo           repository.MutingRepository
+	renoteMutingRepo     repository.RenoteMutingRepository
+	followRequestRepo    repository.FollowRequestRepository
+	instanceRepo         repository.InstanceRepository
+	userListFavoriteRepo UserListFavoriteRepository
 }
 
 // SetMemoRepo attaches a UserMemoRepository for users/update-memo.

--- a/internal/api/users/handler_stubs.go
+++ b/internal/api/users/handler_stubs.go
@@ -3,10 +3,26 @@ package users
 import (
 	"encoding/json"
 	"net/http"
+	"time"
 
 	"github.com/labstack/echo/v4"
 	"github.com/shiroha-a/mk/internal/entity"
+	"github.com/shiroha-a/mk/internal/model"
+	"github.com/shiroha-a/mk/internal/server/middleware"
 )
+
+// UserListFavoriteRepository is the interface for user list favorite operations.
+type UserListFavoriteRepository interface {
+	Create(fav *model.UserListFavorite) error
+	Delete(userID, listID string) error
+	ListByUser(userID string) ([]*model.UserListFavorite, error)
+	Exists(userID, listID string) (bool, error)
+}
+
+// SetUserListFavoriteRepo attaches a UserListFavoriteRepository.
+func (h *Handler) SetUserListFavoriteRepo(r UserListFavoriteRepository) {
+	h.userListFavoriteRepo = r
+}
 
 // Achievements handles POST /api/users/achievements.
 func (h *Handler) Achievements(c echo.Context) error {
@@ -90,11 +106,46 @@ func (h *Handler) ListsCreateFromPublic(c echo.Context) error {
 
 // ListsFavorite handles POST /api/users/lists/favorite.
 func (h *Handler) ListsFavorite(c echo.Context) error {
+	user := middleware.GetUser(c)
+	var req struct {
+		ListID string `json:"listId"`
+	}
+	if err := c.Bind(&req); err != nil || req.ListID == "" {
+		return invalidParam(c)
+	}
+	if h.userListFavoriteRepo == nil {
+		return c.NoContent(http.StatusNoContent)
+	}
+	already, _ := h.userListFavoriteRepo.Exists(user.ID, req.ListID)
+	if already {
+		return c.NoContent(http.StatusNoContent)
+	}
+	fav := &model.UserListFavorite{
+		ID:         h.idGen.Generate(time.Now()),
+		UserID:     user.ID,
+		UserListID: req.ListID,
+	}
+	if err := h.userListFavoriteRepo.Create(fav); err != nil {
+		return internalError(c)
+	}
 	return c.NoContent(http.StatusNoContent)
 }
 
 // ListsUnfavorite handles POST /api/users/lists/unfavorite.
 func (h *Handler) ListsUnfavorite(c echo.Context) error {
+	user := middleware.GetUser(c)
+	var req struct {
+		ListID string `json:"listId"`
+	}
+	if err := c.Bind(&req); err != nil || req.ListID == "" {
+		return invalidParam(c)
+	}
+	if h.userListFavoriteRepo == nil {
+		return c.NoContent(http.StatusNoContent)
+	}
+	if err := h.userListFavoriteRepo.Delete(user.ID, req.ListID); err != nil {
+		return internalError(c)
+	}
 	return c.NoContent(http.StatusNoContent)
 }
 

--- a/internal/api/users/handler_stubs_test.go
+++ b/internal/api/users/handler_stubs_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/labstack/echo/v4"
 	"github.com/shiroha-a/mk/internal/model"
 	"github.com/shiroha-a/mk/internal/server/middleware"
+	"github.com/shiroha-a/mk/internal/testutil"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"gorm.io/datatypes"
@@ -121,14 +122,16 @@ func TestListsCreateFromPublic(t *testing.T) {
 
 func TestListsFavorite(t *testing.T) {
 	h, _ := newTestHandler(t)
+	// listId未指定 → 400
 	rec := postStub(h.ListsFavorite, `{}`, &model.User{ID: "u1"})
-	assert.Equal(t, http.StatusNoContent, rec.Code)
+	assert.Equal(t, http.StatusBadRequest, rec.Code)
 }
 
 func TestListsUnfavorite(t *testing.T) {
 	h, _ := newTestHandler(t)
+	// listId未指定 → 400
 	rec := postStub(h.ListsUnfavorite, `{}`, &model.User{ID: "u1"})
-	assert.Equal(t, http.StatusNoContent, rec.Code)
+	assert.Equal(t, http.StatusBadRequest, rec.Code)
 }
 
 func TestListsUpdate(t *testing.T) {
@@ -163,6 +166,46 @@ func TestUsersBulk_InvalidParam(t *testing.T) {
 	h, _ := newTestHandler(t)
 	rec := postStub(h.UsersBulk, `invalid`, nil)
 	assert.Equal(t, http.StatusBadRequest, rec.Code)
+}
+
+// --- ListsFavorite with repo ---
+
+func TestListsFavorite_WithRepo(t *testing.T) {
+	h, _ := newTestHandler(t)
+	favRepo := testutil.NewMockUserListFavoriteRepository()
+	h.SetUserListFavoriteRepo(favRepo)
+	rec := postStub(h.ListsFavorite, `{"listId":"l1"}`, &model.User{ID: "u1"})
+	assert.Equal(t, http.StatusNoContent, rec.Code)
+	exists, _ := favRepo.Exists("u1", "l1")
+	assert.True(t, exists)
+}
+
+func TestListsFavorite_AlreadyFavorited(t *testing.T) {
+	h, _ := newTestHandler(t)
+	favRepo := testutil.NewMockUserListFavoriteRepository()
+	favRepo.Favorites["u1:l1"] = &model.UserListFavorite{ID: "f1", UserID: "u1", UserListID: "l1"}
+	h.SetUserListFavoriteRepo(favRepo)
+	rec := postStub(h.ListsFavorite, `{"listId":"l1"}`, &model.User{ID: "u1"})
+	assert.Equal(t, http.StatusNoContent, rec.Code)
+}
+
+func TestListsFavorite_MissingListID(t *testing.T) {
+	h, _ := newTestHandler(t)
+	favRepo := testutil.NewMockUserListFavoriteRepository()
+	h.SetUserListFavoriteRepo(favRepo)
+	rec := postStub(h.ListsFavorite, `{}`, &model.User{ID: "u1"})
+	assert.Equal(t, http.StatusBadRequest, rec.Code)
+}
+
+func TestListsUnfavorite_WithRepo(t *testing.T) {
+	h, _ := newTestHandler(t)
+	favRepo := testutil.NewMockUserListFavoriteRepository()
+	favRepo.Favorites["u1:l1"] = &model.UserListFavorite{ID: "f1", UserID: "u1", UserListID: "l1"}
+	h.SetUserListFavoriteRepo(favRepo)
+	rec := postStub(h.ListsUnfavorite, `{"listId":"l1"}`, &model.User{ID: "u1"})
+	assert.Equal(t, http.StatusNoContent, rec.Code)
+	exists, _ := favRepo.Exists("u1", "l1")
+	assert.False(t, exists)
 }
 
 // --- Show with isFollowing ---

--- a/internal/model/admin_models.go
+++ b/internal/model/admin_models.go
@@ -8,16 +8,17 @@ import (
 
 // Ad represents the `ad` table.
 type Ad struct {
-	ID        string    `gorm:"column:id;type:varchar(32);primaryKey" json:"id"`
-	ExpiresAt time.Time `gorm:"column:expiresAt;type:timestamp with time zone;not null" json:"expiresAt"`
-	StartsAt  time.Time `gorm:"column:startsAt;type:timestamp with time zone;not null;default:now()" json:"startsAt"`
-	Place     string    `gorm:"column:place;type:varchar(32);not null" json:"place"`
-	Priority  string    `gorm:"column:priority;type:varchar(32);not null;default:'middle'" json:"priority"`
-	Ratio     int       `gorm:"column:ratio;type:integer;not null;default:1" json:"ratio"`
-	URL       string    `gorm:"column:url;type:varchar(1024);not null" json:"url"`
-	ImageURL  string    `gorm:"column:imageUrl;type:varchar(1024);not null" json:"imageUrl"`
-	Memo      string    `gorm:"column:memo;type:varchar(8192);not null;default:''" json:"memo"`
-	DayOfWeek int       `gorm:"column:dayOfWeek;type:integer;not null;default:0" json:"dayOfWeek"`
+	ID          string    `gorm:"column:id;type:varchar(32);primaryKey" json:"id"`
+	ExpiresAt   time.Time `gorm:"column:expiresAt;type:timestamp with time zone;not null" json:"expiresAt"`
+	StartsAt    time.Time `gorm:"column:startsAt;type:timestamp with time zone;not null;default:now()" json:"startsAt"`
+	Place       string    `gorm:"column:place;type:varchar(32);not null" json:"place"`
+	Priority    string    `gorm:"column:priority;type:varchar(32);not null;default:'middle'" json:"priority"`
+	Ratio       int       `gorm:"column:ratio;type:integer;not null;default:1" json:"ratio"`
+	URL         string    `gorm:"column:url;type:varchar(1024);not null" json:"url"`
+	ImageURL    string    `gorm:"column:imageUrl;type:varchar(1024);not null" json:"imageUrl"`
+	Memo        string    `gorm:"column:memo;type:varchar(8192);not null;default:''" json:"memo"`
+	DayOfWeek   int       `gorm:"column:dayOfWeek;type:integer;not null;default:0" json:"dayOfWeek"`
+	IsSensitive bool      `gorm:"column:isSensitive;default:false" json:"isSensitive"`
 }
 
 func (Ad) TableName() string { return "ad" }

--- a/internal/model/antenna.go
+++ b/internal/model/antenna.go
@@ -27,22 +27,23 @@ const (
 
 // Antenna represents the `antenna` table.
 type Antenna struct {
-	ID              string         `gorm:"column:id;type:varchar(32);primaryKey" json:"id"`
-	LastUsedAt      time.Time      `gorm:"column:lastUsedAt;type:timestamp with time zone;not null" json:"lastUsedAt"`
-	UserID          string         `gorm:"column:userId;type:varchar(32);not null" json:"userId"`
-	Name            string         `gorm:"column:name;type:varchar(128);not null" json:"name"`
-	Src             AntennaSource  `gorm:"column:src;type:antenna_src_enum;not null" json:"src"`
-	UserListID      *string        `gorm:"column:userListId;type:varchar(32)" json:"userListId"`
-	Users           pq.StringArray `gorm:"column:users;type:varchar(1024)[];default:'{}'" json:"users"`
-	Keywords        datatypes.JSON `gorm:"column:keywords;type:jsonb;default:'[]'" json:"keywords"`
-	ExcludeKeywords datatypes.JSON `gorm:"column:excludeKeywords;type:jsonb;default:'[]'" json:"excludeKeywords"`
-	CaseSensitive   bool           `gorm:"column:caseSensitive;default:false" json:"caseSensitive"`
-	ExcludeBots     bool           `gorm:"column:excludeBots;default:false" json:"excludeBots"`
-	WithReplies     bool           `gorm:"column:withReplies;default:false" json:"withReplies"`
-	WithFile        bool           `gorm:"column:withFile;default:false" json:"withFile"`
-	Expression      *string        `gorm:"column:expression;type:varchar(2048)" json:"expression"`
-	IsActive        bool           `gorm:"column:isActive;default:true" json:"isActive"`
-	LocalOnly       bool           `gorm:"column:localOnly;default:false" json:"localOnly"`
+	ID                             string         `gorm:"column:id;type:varchar(32);primaryKey" json:"id"`
+	LastUsedAt                     time.Time      `gorm:"column:lastUsedAt;type:timestamp with time zone;not null" json:"lastUsedAt"`
+	UserID                         string         `gorm:"column:userId;type:varchar(32);not null" json:"userId"`
+	Name                           string         `gorm:"column:name;type:varchar(128);not null" json:"name"`
+	Src                            AntennaSource  `gorm:"column:src;type:antenna_src_enum;not null" json:"src"`
+	UserListID                     *string        `gorm:"column:userListId;type:varchar(32)" json:"userListId"`
+	Users                          pq.StringArray `gorm:"column:users;type:varchar(1024)[];default:'{}'" json:"users"`
+	Keywords                       datatypes.JSON `gorm:"column:keywords;type:jsonb;default:'[]'" json:"keywords"`
+	ExcludeKeywords                datatypes.JSON `gorm:"column:excludeKeywords;type:jsonb;default:'[]'" json:"excludeKeywords"`
+	CaseSensitive                  bool           `gorm:"column:caseSensitive;default:false" json:"caseSensitive"`
+	ExcludeBots                    bool           `gorm:"column:excludeBots;default:false" json:"excludeBots"`
+	WithReplies                    bool           `gorm:"column:withReplies;default:false" json:"withReplies"`
+	WithFile                       bool           `gorm:"column:withFile;default:false" json:"withFile"`
+	Expression                     *string        `gorm:"column:expression;type:varchar(2048)" json:"expression"`
+	IsActive                       bool           `gorm:"column:isActive;default:true" json:"isActive"`
+	LocalOnly                      bool           `gorm:"column:localOnly;default:false" json:"localOnly"`
+	ExcludeNotesInSensitiveChannel bool           `gorm:"column:excludeNotesInSensitiveChannel;default:false" json:"excludeNotesInSensitiveChannel"`
 }
 
 func (Antenna) TableName() string { return "antenna" }

--- a/internal/model/channel_favorite.go
+++ b/internal/model/channel_favorite.go
@@ -1,0 +1,10 @@
+package model
+
+// ChannelFavorite represents the `channel_favorite` table.
+type ChannelFavorite struct {
+	ID        string `gorm:"column:id;type:varchar(32);primaryKey"`
+	UserID    string `gorm:"column:userId;type:varchar(32);not null"`
+	ChannelID string `gorm:"column:channelId;type:varchar(32);not null"`
+}
+
+func (ChannelFavorite) TableName() string { return "channel_favorite" }

--- a/internal/model/channel_muting.go
+++ b/internal/model/channel_muting.go
@@ -1,0 +1,10 @@
+package model
+
+// ChannelMuting represents the `channel_muting` table.
+type ChannelMuting struct {
+	ID        string `gorm:"column:id;type:varchar(32);primaryKey"`
+	UserID    string `gorm:"column:userId;type:varchar(32);not null"`
+	ChannelID string `gorm:"column:channelId;type:varchar(32);not null"`
+}
+
+func (ChannelMuting) TableName() string { return "channel_muting" }

--- a/internal/model/clip_favorite.go
+++ b/internal/model/clip_favorite.go
@@ -1,0 +1,10 @@
+package model
+
+// ClipFavorite represents the `clip_favorite` table.
+type ClipFavorite struct {
+	ID     string `gorm:"column:id;type:varchar(32);primaryKey"`
+	UserID string `gorm:"column:userId;type:varchar(32);not null"`
+	ClipID string `gorm:"column:clipId;type:varchar(32);not null"`
+}
+
+func (ClipFavorite) TableName() string { return "clip_favorite" }

--- a/internal/model/note_draft.go
+++ b/internal/model/note_draft.go
@@ -27,6 +27,7 @@ type NoteDraft struct {
 	PollExpiresAt       *time.Time     `gorm:"column:pollExpiresAt;type:timestamp with time zone" json:"pollExpiresAt"`
 	ScheduledAt         *time.Time     `gorm:"column:scheduledAt;type:timestamp with time zone" json:"scheduledAt"`
 	IsActuallyScheduled bool           `gorm:"column:isActuallyScheduled;default:false" json:"isActuallyScheduled"`
+	PollExpiredAfter    *int64         `gorm:"column:pollExpiredAfter;type:bigint" json:"pollExpiredAfter"`
 
 	User *User `gorm:"foreignKey:UserID" json:"user,omitempty"`
 }

--- a/internal/model/note_thread_muting.go
+++ b/internal/model/note_thread_muting.go
@@ -1,0 +1,11 @@
+package model
+
+// NoteThreadMuting represents the `note_thread_muting` table.
+// Allows users to mute specific note threads.
+type NoteThreadMuting struct {
+	ID       string `gorm:"column:id;type:varchar(32);primaryKey"`
+	UserID   string `gorm:"column:userId;type:varchar(32);not null"`
+	ThreadID string `gorm:"column:threadId;type:varchar(256);not null"`
+}
+
+func (NoteThreadMuting) TableName() string { return "note_thread_muting" }

--- a/internal/model/retention_aggregation.go
+++ b/internal/model/retention_aggregation.go
@@ -1,0 +1,21 @@
+package model
+
+import (
+	"time"
+
+	"github.com/lib/pq"
+	"gorm.io/datatypes"
+)
+
+// RetentionAggregation represents the `retention_aggregation` table.
+type RetentionAggregation struct {
+	ID         string         `gorm:"column:id;type:varchar(32);primaryKey" json:"id"`
+	CreatedAt  time.Time      `gorm:"column:createdAt;type:timestamp with time zone;not null;default:now()" json:"createdAt"`
+	UpdatedAt  time.Time      `gorm:"column:updatedAt;type:timestamp with time zone;not null;default:now()" json:"updatedAt"`
+	UserIDs    pq.StringArray `gorm:"column:userIds;type:varchar(32)[];default:'{}'" json:"userIds"`
+	Data       datatypes.JSON `gorm:"column:data;type:jsonb;default:'{}'" json:"data"`
+	DateKey    string         `gorm:"column:dateKey;type:varchar(64);not null;uniqueIndex" json:"dateKey"`
+	UsersCount int            `gorm:"column:usersCount;type:integer;not null;default:0" json:"usersCount"`
+}
+
+func (RetentionAggregation) TableName() string { return "retention_aggregation" }

--- a/internal/model/system_account.go
+++ b/internal/model/system_account.go
@@ -1,0 +1,11 @@
+package model
+
+// SystemAccount represents the `system_account` table.
+// Maps a system account type (e.g. "actor", "relay", "proxy") to a user record.
+type SystemAccount struct {
+	ID     string `gorm:"column:id;type:varchar(32);primaryKey"`
+	UserID string `gorm:"column:userId;type:varchar(32);not null"`
+	Type   string `gorm:"column:type;type:varchar(256);not null;uniqueIndex"`
+}
+
+func (SystemAccount) TableName() string { return "system_account" }

--- a/internal/model/used_username.go
+++ b/internal/model/used_username.go
@@ -1,0 +1,11 @@
+package model
+
+import "time"
+
+// UsedUsername records usernames that have been used, preventing reuse.
+type UsedUsername struct {
+	Username  string    `gorm:"column:username;type:varchar(128);primaryKey"`
+	CreatedAt time.Time `gorm:"column:createdAt;type:timestamp with time zone;not null;default:now()"`
+}
+
+func (UsedUsername) TableName() string { return "used_username" }

--- a/internal/model/user_list.go
+++ b/internal/model/user_list.go
@@ -12,9 +12,11 @@ func (UserList) TableName() string { return "user_list" }
 
 // UserListMembership represents the `user_list_membership` table.
 type UserListMembership struct {
-	ID         string `gorm:"column:id;type:varchar(32);primaryKey" json:"id"`
-	UserListID string `gorm:"column:userListId;type:varchar(32);not null" json:"userListId"`
-	UserID     string `gorm:"column:userId;type:varchar(32);not null" json:"userId"`
+	ID             string  `gorm:"column:id;type:varchar(32);primaryKey" json:"id"`
+	UserListID     string  `gorm:"column:userListId;type:varchar(32);not null" json:"userListId"`
+	UserID         string  `gorm:"column:userId;type:varchar(32);not null" json:"userId"`
+	WithReplies    bool    `gorm:"column:withReplies;default:false" json:"withReplies"`
+	UserListUserID *string `gorm:"column:userListUserId;type:varchar(32)" json:"userListUserId"`
 
 	User *User `gorm:"foreignKey:UserID" json:"user,omitempty"`
 }

--- a/internal/model/user_list_favorite.go
+++ b/internal/model/user_list_favorite.go
@@ -1,0 +1,10 @@
+package model
+
+// UserListFavorite represents the `user_list_favorite` table.
+type UserListFavorite struct {
+	ID         string `gorm:"column:id;type:varchar(32);primaryKey"`
+	UserID     string `gorm:"column:userId;type:varchar(32);not null"`
+	UserListID string `gorm:"column:userListId;type:varchar(32);not null"`
+}
+
+func (UserListFavorite) TableName() string { return "user_list_favorite" }

--- a/internal/repository/channel_favorite.go
+++ b/internal/repository/channel_favorite.go
@@ -1,0 +1,47 @@
+package repository
+
+import (
+	"github.com/shiroha-a/mk/internal/model"
+	"gorm.io/gorm"
+)
+
+// ChannelFavoriteRepository provides data access for channel favorites.
+type ChannelFavoriteRepository interface {
+	Create(fav *model.ChannelFavorite) error
+	Delete(userID, channelID string) error
+	ListByUser(userID string) ([]*model.ChannelFavorite, error)
+	Exists(userID, channelID string) (bool, error)
+}
+
+type channelFavoriteRepository struct {
+	db *gorm.DB
+}
+
+// NewChannelFavoriteRepository creates a new ChannelFavoriteRepository.
+func NewChannelFavoriteRepository(db *gorm.DB) ChannelFavoriteRepository {
+	return &channelFavoriteRepository{db: db}
+}
+
+func (r *channelFavoriteRepository) Create(fav *model.ChannelFavorite) error {
+	return r.db.Create(fav).Error
+}
+
+func (r *channelFavoriteRepository) Delete(userID, channelID string) error {
+	return r.db.Where(`"userId" = ? AND "channelId" = ?`, userID, channelID).
+		Delete(&model.ChannelFavorite{}).Error
+}
+
+func (r *channelFavoriteRepository) ListByUser(userID string) ([]*model.ChannelFavorite, error) {
+	var favs []*model.ChannelFavorite
+	if err := r.db.Where(`"userId" = ?`, userID).Find(&favs).Error; err != nil {
+		return nil, err
+	}
+	return favs, nil
+}
+
+func (r *channelFavoriteRepository) Exists(userID, channelID string) (bool, error) {
+	var count int64
+	err := r.db.Model(&model.ChannelFavorite{}).
+		Where(`"userId" = ? AND "channelId" = ?`, userID, channelID).Count(&count).Error
+	return count > 0, err
+}

--- a/internal/repository/channel_muting.go
+++ b/internal/repository/channel_muting.go
@@ -1,0 +1,47 @@
+package repository
+
+import (
+	"github.com/shiroha-a/mk/internal/model"
+	"gorm.io/gorm"
+)
+
+// ChannelMutingRepository provides data access for channel muting.
+type ChannelMutingRepository interface {
+	Create(m *model.ChannelMuting) error
+	Delete(userID, channelID string) error
+	ListByUser(userID string) ([]*model.ChannelMuting, error)
+	Exists(userID, channelID string) (bool, error)
+}
+
+type channelMutingRepository struct {
+	db *gorm.DB
+}
+
+// NewChannelMutingRepository creates a new ChannelMutingRepository.
+func NewChannelMutingRepository(db *gorm.DB) ChannelMutingRepository {
+	return &channelMutingRepository{db: db}
+}
+
+func (r *channelMutingRepository) Create(m *model.ChannelMuting) error {
+	return r.db.Create(m).Error
+}
+
+func (r *channelMutingRepository) Delete(userID, channelID string) error {
+	return r.db.Where(`"userId" = ? AND "channelId" = ?`, userID, channelID).
+		Delete(&model.ChannelMuting{}).Error
+}
+
+func (r *channelMutingRepository) ListByUser(userID string) ([]*model.ChannelMuting, error) {
+	var mutes []*model.ChannelMuting
+	if err := r.db.Where(`"userId" = ?`, userID).Find(&mutes).Error; err != nil {
+		return nil, err
+	}
+	return mutes, nil
+}
+
+func (r *channelMutingRepository) Exists(userID, channelID string) (bool, error) {
+	var count int64
+	err := r.db.Model(&model.ChannelMuting{}).
+		Where(`"userId" = ? AND "channelId" = ?`, userID, channelID).Count(&count).Error
+	return count > 0, err
+}

--- a/internal/repository/clip_favorite.go
+++ b/internal/repository/clip_favorite.go
@@ -1,0 +1,47 @@
+package repository
+
+import (
+	"github.com/shiroha-a/mk/internal/model"
+	"gorm.io/gorm"
+)
+
+// ClipFavoriteRepository provides data access for clip favorites.
+type ClipFavoriteRepository interface {
+	Create(fav *model.ClipFavorite) error
+	Delete(userID, clipID string) error
+	ListByUser(userID string) ([]*model.ClipFavorite, error)
+	Exists(userID, clipID string) (bool, error)
+}
+
+type clipFavoriteRepository struct {
+	db *gorm.DB
+}
+
+// NewClipFavoriteRepository creates a new ClipFavoriteRepository.
+func NewClipFavoriteRepository(db *gorm.DB) ClipFavoriteRepository {
+	return &clipFavoriteRepository{db: db}
+}
+
+func (r *clipFavoriteRepository) Create(fav *model.ClipFavorite) error {
+	return r.db.Create(fav).Error
+}
+
+func (r *clipFavoriteRepository) Delete(userID, clipID string) error {
+	return r.db.Where(`"userId" = ? AND "clipId" = ?`, userID, clipID).
+		Delete(&model.ClipFavorite{}).Error
+}
+
+func (r *clipFavoriteRepository) ListByUser(userID string) ([]*model.ClipFavorite, error) {
+	var favs []*model.ClipFavorite
+	if err := r.db.Where(`"userId" = ?`, userID).Find(&favs).Error; err != nil {
+		return nil, err
+	}
+	return favs, nil
+}
+
+func (r *clipFavoriteRepository) Exists(userID, clipID string) (bool, error) {
+	var count int64
+	err := r.db.Model(&model.ClipFavorite{}).
+		Where(`"userId" = ? AND "clipId" = ?`, userID, clipID).Count(&count).Error
+	return count > 0, err
+}

--- a/internal/repository/note_thread_muting.go
+++ b/internal/repository/note_thread_muting.go
@@ -1,0 +1,38 @@
+package repository
+
+import (
+	"github.com/shiroha-a/mk/internal/model"
+	"gorm.io/gorm"
+)
+
+// NoteThreadMutingRepository provides data access for note thread muting.
+type NoteThreadMutingRepository interface {
+	Create(m *model.NoteThreadMuting) error
+	Delete(userID, threadID string) error
+	Exists(userID, threadID string) (bool, error)
+}
+
+type noteThreadMutingRepository struct {
+	db *gorm.DB
+}
+
+// NewNoteThreadMutingRepository creates a new NoteThreadMutingRepository.
+func NewNoteThreadMutingRepository(db *gorm.DB) NoteThreadMutingRepository {
+	return &noteThreadMutingRepository{db: db}
+}
+
+func (r *noteThreadMutingRepository) Create(m *model.NoteThreadMuting) error {
+	return r.db.Create(m).Error
+}
+
+func (r *noteThreadMutingRepository) Delete(userID, threadID string) error {
+	return r.db.Where(`"userId" = ? AND "threadId" = ?`, userID, threadID).
+		Delete(&model.NoteThreadMuting{}).Error
+}
+
+func (r *noteThreadMutingRepository) Exists(userID, threadID string) (bool, error) {
+	var count int64
+	err := r.db.Model(&model.NoteThreadMuting{}).
+		Where(`"userId" = ? AND "threadId" = ?`, userID, threadID).Count(&count).Error
+	return count > 0, err
+}

--- a/internal/repository/retention_aggregation.go
+++ b/internal/repository/retention_aggregation.go
@@ -1,0 +1,28 @@
+package repository
+
+import (
+	"github.com/shiroha-a/mk/internal/model"
+	"gorm.io/gorm"
+)
+
+// RetentionAggregationRepository provides data access for retention statistics.
+type RetentionAggregationRepository interface {
+	ListRecent(limit int) ([]*model.RetentionAggregation, error)
+}
+
+type retentionAggregationRepository struct {
+	db *gorm.DB
+}
+
+// NewRetentionAggregationRepository creates a new RetentionAggregationRepository.
+func NewRetentionAggregationRepository(db *gorm.DB) RetentionAggregationRepository {
+	return &retentionAggregationRepository{db: db}
+}
+
+func (r *retentionAggregationRepository) ListRecent(limit int) ([]*model.RetentionAggregation, error) {
+	var records []*model.RetentionAggregation
+	if err := r.db.Order(`"id" DESC`).Limit(limit).Find(&records).Error; err != nil {
+		return nil, err
+	}
+	return records, nil
+}

--- a/internal/repository/role_notes_query.go
+++ b/internal/repository/role_notes_query.go
@@ -1,0 +1,40 @@
+package repository
+
+import (
+	"github.com/shiroha-a/mk/internal/model"
+	"gorm.io/gorm"
+)
+
+// RoleNotesQuery fetches notes by role via GORM.
+type RoleNotesQuery struct {
+	db *gorm.DB
+}
+
+// NewRoleNotesQuery creates a new RoleNotesQuery.
+func NewRoleNotesQuery(db *gorm.DB) *RoleNotesQuery {
+	return &RoleNotesQuery{db: db}
+}
+
+// ListByRole returns public notes from users assigned to the given role.
+func (q *RoleNotesQuery) ListByRole(roleID string, limit int, sinceID, untilID string) ([]*model.Note, error) {
+	query := q.db.Model(&model.Note{}).
+		Joins(`JOIN "role_assignment" ON "role_assignment"."userId" = "note"."userId"`).
+		Where(`"role_assignment"."roleId" = ?`, roleID).
+		Where(`"note"."visibility" = 'public'`).
+		Preload("User").
+		Order(`"note"."id" DESC`).
+		Limit(limit)
+
+	if sinceID != "" {
+		query = query.Where(`"note"."id" > ?`, sinceID)
+	}
+	if untilID != "" {
+		query = query.Where(`"note"."id" < ?`, untilID)
+	}
+
+	var notes []*model.Note
+	if err := query.Find(&notes).Error; err != nil {
+		return nil, err
+	}
+	return notes, nil
+}

--- a/internal/repository/system_account.go
+++ b/internal/repository/system_account.go
@@ -1,0 +1,33 @@
+package repository
+
+import (
+	"github.com/shiroha-a/mk/internal/model"
+	"gorm.io/gorm"
+)
+
+// SystemAccountRepository provides data access for system accounts.
+type SystemAccountRepository interface {
+	FindByType(typ string) (*model.SystemAccount, error)
+	Create(sa *model.SystemAccount) error
+}
+
+type systemAccountRepository struct {
+	db *gorm.DB
+}
+
+// NewSystemAccountRepository creates a new SystemAccountRepository.
+func NewSystemAccountRepository(db *gorm.DB) SystemAccountRepository {
+	return &systemAccountRepository{db: db}
+}
+
+func (r *systemAccountRepository) FindByType(typ string) (*model.SystemAccount, error) {
+	var sa model.SystemAccount
+	if err := r.db.Where(`"type" = ?`, typ).First(&sa).Error; err != nil {
+		return nil, err
+	}
+	return &sa, nil
+}
+
+func (r *systemAccountRepository) Create(sa *model.SystemAccount) error {
+	return r.db.Create(sa).Error
+}

--- a/internal/repository/used_username.go
+++ b/internal/repository/used_username.go
@@ -1,0 +1,31 @@
+package repository
+
+import (
+	"github.com/shiroha-a/mk/internal/model"
+	"gorm.io/gorm"
+)
+
+// UsedUsernameRepository provides data access for the used_username table.
+type UsedUsernameRepository interface {
+	Create(username string) error
+	Exists(username string) (bool, error)
+}
+
+type usedUsernameRepository struct {
+	db *gorm.DB
+}
+
+// NewUsedUsernameRepository creates a new UsedUsernameRepository.
+func NewUsedUsernameRepository(db *gorm.DB) UsedUsernameRepository {
+	return &usedUsernameRepository{db: db}
+}
+
+func (r *usedUsernameRepository) Create(username string) error {
+	return r.db.Create(&model.UsedUsername{Username: username}).Error
+}
+
+func (r *usedUsernameRepository) Exists(username string) (bool, error) {
+	var count int64
+	err := r.db.Model(&model.UsedUsername{}).Where(`"username" = ?`, username).Count(&count).Error
+	return count > 0, err
+}

--- a/internal/repository/user.go
+++ b/internal/repository/user.go
@@ -1,6 +1,8 @@
 package repository
 
 import (
+	"time"
+
 	"github.com/shiroha-a/mk/internal/model"
 	"gorm.io/gorm"
 )
@@ -22,6 +24,7 @@ type UserRepository interface {
 	ListUsers(filter model.UserListFilter) ([]*model.User, error)
 	ListRemoteInboxes() ([]string, error)
 	FindProfileByVerifyCode(code string) (*model.UserProfile, error)
+	CountOnlineUsers() (int64, error)
 }
 
 type userRepository struct {
@@ -211,4 +214,15 @@ func (r *userRepository) ListUsers(filter model.UserListFilter) ([]*model.User, 
 		return nil, err
 	}
 	return users, nil
+}
+
+// CountOnlineUsers returns the number of local users active within the last 10 minutes.
+func (r *userRepository) CountOnlineUsers() (int64, error) {
+	var count int64
+	threshold := time.Now().Add(-10 * time.Minute)
+	err := r.db.Model(&model.User{}).
+		Where("host IS NULL").
+		Where(`"lastActiveDate" > ?`, threshold).
+		Count(&count).Error
+	return count, err
 }

--- a/internal/repository/user_list_favorite.go
+++ b/internal/repository/user_list_favorite.go
@@ -1,0 +1,47 @@
+package repository
+
+import (
+	"github.com/shiroha-a/mk/internal/model"
+	"gorm.io/gorm"
+)
+
+// UserListFavoriteRepository provides data access for user list favorites.
+type UserListFavoriteRepository interface {
+	Create(fav *model.UserListFavorite) error
+	Delete(userID, listID string) error
+	ListByUser(userID string) ([]*model.UserListFavorite, error)
+	Exists(userID, listID string) (bool, error)
+}
+
+type userListFavoriteRepository struct {
+	db *gorm.DB
+}
+
+// NewUserListFavoriteRepository creates a new UserListFavoriteRepository.
+func NewUserListFavoriteRepository(db *gorm.DB) UserListFavoriteRepository {
+	return &userListFavoriteRepository{db: db}
+}
+
+func (r *userListFavoriteRepository) Create(fav *model.UserListFavorite) error {
+	return r.db.Create(fav).Error
+}
+
+func (r *userListFavoriteRepository) Delete(userID, listID string) error {
+	return r.db.Where(`"userId" = ? AND "userListId" = ?`, userID, listID).
+		Delete(&model.UserListFavorite{}).Error
+}
+
+func (r *userListFavoriteRepository) ListByUser(userID string) ([]*model.UserListFavorite, error) {
+	var favs []*model.UserListFavorite
+	if err := r.db.Where(`"userId" = ?`, userID).Find(&favs).Error; err != nil {
+		return nil, err
+	}
+	return favs, nil
+}
+
+func (r *userListFavoriteRepository) Exists(userID, listID string) (bool, error) {
+	var count int64
+	err := r.db.Model(&model.UserListFavorite{}).
+		Where(`"userId" = ? AND "userListId" = ?`, userID, listID).Count(&count).Error
+	return count > 0, err
+}

--- a/internal/server/router.go
+++ b/internal/server/router.go
@@ -1533,16 +1533,19 @@ func (s *Server) setupRoutes() {
 			})
 		}
 		createdBy := entity.PackUserLite(user)
-		return c.JSON(http.StatusOK, map[string]any{
+		resp := map[string]any{
 			"id":        ticket.ID,
 			"code":      ticket.Code,
 			"expiresAt": ticket.ExpiresAt,
-			"createdAt": ticket.ID,
 			"createdBy": createdBy,
 			"usedBy":    nil,
 			"usedAt":    nil,
 			"used":      false,
-		})
+		}
+		if t, err := idGen.ParseTime(ticket.ID); err == nil {
+			resp["createdAt"] = t.UTC().Format("2006-01-02T15:04:05.000Z")
+		}
+		return c.JSON(http.StatusOK, resp)
 	}, middleware.RequireAuth())
 
 	// invite/list — 招待コード一覧 (認証必須)
@@ -1576,16 +1579,19 @@ func (s *Server) setupRoutes() {
 		}
 		out := make([]map[string]any, 0, len(tickets))
 		for _, t := range tickets {
-			out = append(out, map[string]any{
+			entry := map[string]any{
 				"id":        t.ID,
 				"code":      t.Code,
 				"expiresAt": t.ExpiresAt,
-				"createdAt": t.ID,
 				"createdBy": nil,
 				"usedBy":    nil,
 				"usedAt":    t.UsedAt,
 				"used":      t.UsedByID != nil,
-			})
+			}
+			if ts, err := idGen.ParseTime(t.ID); err == nil {
+				entry["createdAt"] = ts.UTC().Format("2006-01-02T15:04:05.000Z")
+			}
+			out = append(out, entry)
 		}
 		return c.JSON(http.StatusOK, out)
 	}, middleware.RequireAuth())
@@ -1661,7 +1667,9 @@ func (s *Server) setupRoutes() {
 func generateInviteCode() string {
 	const chars = "abcdefghijklmnopqrstuvwxyz0123456789"
 	b := make([]byte, 8)
-	_, _ = io.ReadFull(cryptorand.Reader, b)
+	if _, err := io.ReadFull(cryptorand.Reader, b); err != nil {
+		panic("crypto/rand failed: " + err.Error())
+	}
 	for i := range b {
 		b[i] = chars[b[i]%byte(len(chars))]
 	}

--- a/internal/server/router.go
+++ b/internal/server/router.go
@@ -2,6 +2,7 @@ package server
 
 import (
 	"bytes"
+	cryptorand "crypto/rand"
 	"io"
 	"net/http"
 	urlpkg "net/url"
@@ -77,6 +78,7 @@ import (
 	corereversi "github.com/shiroha-a/mk/internal/core/reversi"
 	corerole "github.com/shiroha-a/mk/internal/core/role"
 	coresearch "github.com/shiroha-a/mk/internal/core/search"
+	"github.com/shiroha-a/mk/internal/core/serverstats"
 	coresignup "github.com/shiroha-a/mk/internal/core/signup"
 	coretimeline "github.com/shiroha-a/mk/internal/core/timeline"
 	coretransfer "github.com/shiroha-a/mk/internal/core/transfer"
@@ -148,6 +150,12 @@ func (s *Server) setupRoutes() {
 	systemWebhookRepo := repository.NewSystemWebhookRepository(s.db)
 	reversiRepo := repository.NewReversiRepository(s.db)
 	chatRepo := repository.NewChatRepository(s.db)
+	channelFavoriteRepo := repository.NewChannelFavoriteRepository(s.db)
+	channelMutingRepo := repository.NewChannelMutingRepository(s.db)
+	clipFavoriteRepo := repository.NewClipFavoriteRepository(s.db)
+	userListFavoriteRepo := repository.NewUserListFavoriteRepository(s.db)
+	retentionRepo := repository.NewRetentionAggregationRepository(s.db)
+	promoReadRepo := repository.NewPromoReadRepository(s.db)
 
 	// Core services
 	roleService := corerole.NewService(roleRepo, roleAssignmentRepo, metaRepo, idGen)
@@ -639,9 +647,10 @@ func (s *Server) setupRoutes() {
 		signinHandler.SetWebAuthn(webauthnSvc, userSecurityKeyRepo)
 	}
 
-	// Emojis endpoint (public, Phase 4.5i)
+	// Emojis endpoints (public)
 	emojisHandler := apiemojis.NewHandler(emojiRepo)
 	api.POST("/emojis", emojisHandler.Emojis)
+	api.POST("/emoji", emojisHandler.Emoji)
 
 	// Notes endpoints
 	notesHandler := notes.NewHandler(noteRepo, noteCreateService, noteDeleteService, noteQueryService, timelineService, reactionService, pollService, searchService, idGen)
@@ -717,6 +726,7 @@ func (s *Server) setupRoutes() {
 	api.POST("/users/update-memo", usersHandler.UpdateMemo, middleware.RequireAuth())
 	usersHandler.SetAbuseRepo(repository.NewAbuseReportRepository(s.db))
 	usersHandler.SetMemoRepo(repository.NewUserMemoRepository(s.db))
+	usersHandler.SetUserListFavoriteRepo(userListFavoriteRepo)
 	// Phase 7.3: users/* 完全化 (実データハンドラ)
 	api.POST("/users/achievements", usersHandler.Achievements)
 	api.POST("/users/clips", usersHandler.Clips)
@@ -987,6 +997,8 @@ func (s *Server) setupRoutes() {
 
 	// Channels endpoints (Phase 4.2)
 	channelsHandler := apichannels.NewHandler(channelService, idGen)
+	channelsHandler.SetFavoriteRepo(channelFavoriteRepo)
+	channelsHandler.SetMutingRepo(channelMutingRepo)
 	api.POST("/channels/create", channelsHandler.Create, middleware.RequireAuth())
 	api.POST("/channels/show", channelsHandler.Show)
 	api.POST("/channels/update", channelsHandler.Update, middleware.RequireAuth())
@@ -1009,6 +1021,7 @@ func (s *Server) setupRoutes() {
 
 	// Clips endpoints (Phase 4.4)
 	clipsHandler := clips.NewHandler(clipService, idGen)
+	clipsHandler.SetFavoriteRepo(clipFavoriteRepo)
 	api.POST("/clips/create", clipsHandler.Create, middleware.RequireAuth())
 	api.POST("/clips/show", clipsHandler.Show)
 	api.POST("/clips/update", clipsHandler.Update, middleware.RequireAuth())
@@ -1139,9 +1152,12 @@ func (s *Server) setupRoutes() {
 
 	// Public roles (Phase 6)
 	rolesHandler := apiroles.NewHandler(roleService)
+	rolesHandler.SetNotesQuery(repository.NewRoleNotesQuery(s.db))
+	rolesHandler.SetIDGen(idGen)
 	api.POST("/roles/list", rolesHandler.List)
 	api.POST("/roles/show", rolesHandler.Show)
 	api.POST("/roles/users", rolesHandler.Users)
+	api.POST("/roles/notes", rolesHandler.Notes)
 
 	// User lists (Phase 6)
 	userListHandler := apiuserlists.NewHandler(userListRepo, idGen)
@@ -1348,6 +1364,232 @@ func (s *Server) setupRoutes() {
 	api.POST("/chat/history", chatHandler.History, middleware.RequireAuth())
 	api.POST("/chat/unread-count", chatHandler.UnreadCount, middleware.RequireAuth())
 
+	// --- Phase P3: 補助公開エンドポイント ---
+
+	// get-online-users-count — オンラインユーザー数
+	api.POST("/get-online-users-count", func(c echo.Context) error {
+		count, _ := userRepo.CountOnlineUsers()
+		return c.JSON(http.StatusOK, map[string]any{"count": count})
+	})
+
+	// server-info (公開版) — サーバー情報
+	api.POST("/server-info", func(c echo.Context) error {
+		if m, err := metaRepo.Fetch(); err == nil && m.EnableServerMachineStats {
+			return c.JSON(http.StatusOK, serverstats.Collect())
+		}
+		return c.JSON(http.StatusOK, serverstats.Empty())
+	})
+
+	// endpoints — 登録済みAPIエンドポイント一覧
+	api.POST("/endpoints", func(c echo.Context) error {
+		routes := s.echo.Routes()
+		names := make([]string, 0, len(routes))
+		seen := make(map[string]bool)
+		for _, r := range routes {
+			if r.Method != http.MethodPost {
+				continue
+			}
+			name := strings.TrimPrefix(r.Path, "/api/")
+			if name == r.Path || name == "" || name == "*" {
+				continue
+			}
+			if seen[name] {
+				continue
+			}
+			seen[name] = true
+			names = append(names, name)
+		}
+		return c.JSON(http.StatusOK, names)
+	})
+
+	// endpoint — エンドポイント情報 (簡易版: パラメータ情報なし)
+	api.POST("/endpoint", func(c echo.Context) error {
+		var req struct {
+			Endpoint string `json:"endpoint"`
+		}
+		if err := c.Bind(&req); err != nil || req.Endpoint == "" {
+			return c.JSON(http.StatusBadRequest, map[string]any{
+				"error": map[string]any{
+					"message": "Invalid param.",
+					"code":    "INVALID_PARAM",
+					"id":      "3d81ceae-475f-4600-b2a8-2bc116157532",
+				},
+			})
+		}
+		return c.JSON(http.StatusOK, map[string]any{"params": map[string]any{}})
+	})
+
+	// retention — リテンション統計
+	api.POST("/retention", func(c echo.Context) error {
+		records, err := retentionRepo.ListRecent(30)
+		if err != nil {
+			return c.JSON(http.StatusOK, []any{})
+		}
+		out := make([]map[string]any, 0, len(records))
+		for _, r := range records {
+			out = append(out, map[string]any{
+				"createdAt": r.CreatedAt,
+				"users":     r.UsersCount,
+				"data":      r.Data,
+			})
+		}
+		return c.JSON(http.StatusOK, out)
+	})
+
+	// get-avatar-decorations — アバターデコレーション全件取得
+	api.POST("/get-avatar-decorations", func(c echo.Context) error {
+		var decorations []model.AvatarDecoration
+		if err := s.db.Find(&decorations).Error; err != nil {
+			return c.JSON(http.StatusOK, []any{})
+		}
+		out := make([]map[string]any, 0, len(decorations))
+		for _, d := range decorations {
+			out = append(out, map[string]any{
+				"id":                                 d.ID,
+				"name":                               d.Name,
+				"description":                        d.Description,
+				"url":                                d.URL,
+				"roleIdsThatCanBeUsedThisDecoration": d.RoleIDs,
+			})
+		}
+		return c.JSON(http.StatusOK, out)
+	})
+
+	// email-address/available — メールアドレスの利用可否チェック (認証必須)
+	api.POST("/email-address/available", func(c echo.Context) error {
+		var req struct {
+			EmailAddress string `json:"emailAddress"`
+		}
+		if err := c.Bind(&req); err != nil || req.EmailAddress == "" {
+			return c.JSON(http.StatusBadRequest, map[string]any{
+				"error": map[string]any{
+					"message": "Invalid param.",
+					"code":    "INVALID_PARAM",
+					"id":      "3d81ceae-475f-4600-b2a8-2bc116157532",
+				},
+			})
+		}
+		var count int64
+		s.db.Model(&model.UserProfile{}).Where(`"email" = ?`, req.EmailAddress).Count(&count)
+		available := count == 0
+		var reason *string
+		if !available {
+			r := "unavailable"
+			reason = &r
+		}
+		return c.JSON(http.StatusOK, map[string]any{
+			"available": available,
+			"reason":    reason,
+		})
+	}, middleware.RequireAuth())
+
+	// promo/read — プロモノートの既読マーク (認証必須)
+	api.POST("/promo/read", func(c echo.Context) error {
+		user := middleware.GetUser(c)
+		var req struct {
+			NoteID string `json:"noteId"`
+		}
+		if err := c.Bind(&req); err != nil || req.NoteID == "" {
+			return c.JSON(http.StatusBadRequest, map[string]any{
+				"error": map[string]any{
+					"message": "Invalid param.",
+					"code":    "INVALID_PARAM",
+					"id":      "3d81ceae-475f-4600-b2a8-2bc116157532",
+				},
+			})
+		}
+		if _, err := noteRepo.FindByID(req.NoteID); err != nil {
+			return c.JSON(http.StatusNotFound, map[string]any{
+				"error": map[string]any{
+					"message": "No such note.",
+					"code":    "NO_SUCH_NOTE",
+					"id":      "fc8c0b49-c7a3-4664-a0a6-b418d386bb8d",
+				},
+			})
+		}
+		_ = promoReadRepo.MarkRead(&model.PromoRead{
+			ID:     idGen.Generate(time.Now()),
+			UserID: user.ID,
+			NoteID: req.NoteID,
+		})
+		return c.NoContent(http.StatusNoContent)
+	}, middleware.RequireAuth())
+
+	// invite/create — 招待コード作成 (認証必須)
+	api.POST("/invite/create", func(c echo.Context) error {
+		user := middleware.GetUser(c)
+		ticket := &model.RegistrationTicket{
+			ID:          idGen.Generate(time.Now()),
+			Code:        generateInviteCode(),
+			CreatedByID: &user.ID,
+		}
+		if err := s.db.Create(ticket).Error; err != nil {
+			return c.JSON(http.StatusInternalServerError, map[string]any{
+				"error": map[string]any{
+					"message": "Internal error.",
+					"code":    "INTERNAL_ERROR",
+					"id":      "5d37dbcb-891e-41ca-a3d6-e690c97775ac",
+				},
+			})
+		}
+		createdBy := entity.PackUserLite(user)
+		return c.JSON(http.StatusOK, map[string]any{
+			"id":        ticket.ID,
+			"code":      ticket.Code,
+			"expiresAt": ticket.ExpiresAt,
+			"createdAt": ticket.ID,
+			"createdBy": createdBy,
+			"usedBy":    nil,
+			"usedAt":    nil,
+			"used":      false,
+		})
+	}, middleware.RequireAuth())
+
+	// invite/list — 招待コード一覧 (認証必須)
+	api.POST("/invite/list", func(c echo.Context) error {
+		user := middleware.GetUser(c)
+		var req struct {
+			Limit   int    `json:"limit"`
+			SinceID string `json:"sinceId"`
+			UntilID string `json:"untilId"`
+		}
+		_ = c.Bind(&req)
+		if req.Limit <= 0 {
+			req.Limit = 30
+		}
+		if req.Limit > 100 {
+			req.Limit = 100
+		}
+		q := s.db.Model(&model.RegistrationTicket{}).
+			Where(`"createdById" = ?`, user.ID).
+			Order("id DESC").
+			Limit(req.Limit)
+		if req.SinceID != "" {
+			q = q.Where("id > ?", req.SinceID)
+		}
+		if req.UntilID != "" {
+			q = q.Where("id < ?", req.UntilID)
+		}
+		var tickets []*model.RegistrationTicket
+		if err := q.Find(&tickets).Error; err != nil {
+			return c.JSON(http.StatusOK, []any{})
+		}
+		out := make([]map[string]any, 0, len(tickets))
+		for _, t := range tickets {
+			out = append(out, map[string]any{
+				"id":        t.ID,
+				"code":      t.Code,
+				"expiresAt": t.ExpiresAt,
+				"createdAt": t.ID,
+				"createdBy": nil,
+				"usedBy":    nil,
+				"usedAt":    t.UsedAt,
+				"used":      t.UsedByID != nil,
+			})
+		}
+		return c.JSON(http.StatusOK, out)
+	}, middleware.RequireAuth())
+
 	// --- その他の残りエンドポイント ---
 	// test — フロントエンドのテスト用
 	api.POST("/test", func(c echo.Context) error {
@@ -1413,6 +1655,17 @@ func (s *Server) setupRoutes() {
 
 	// Frontend HTML shell — SPA catchall (最後に登録)
 	s.echo.GET("/*", frontendHTML(s.config, metaRepo))
+}
+
+// generateInviteCode creates a random invite code string.
+func generateInviteCode() string {
+	const chars = "abcdefghijklmnopqrstuvwxyz0123456789"
+	b := make([]byte, 8)
+	_, _ = io.ReadFull(cryptorand.Reader, b)
+	for i := range b {
+		b[i] = chars[b[i]%byte(len(chars))]
+	}
+	return string(b)
 }
 
 // gormTicketStore implements apisignup.TicketStore using GORM.

--- a/internal/testutil/mock_repository.go
+++ b/internal/testutil/mock_repository.go
@@ -194,6 +194,10 @@ func (m *MockUserRepository) ListRemoteInboxes() ([]string, error) {
 	return out, nil
 }
 
+func (m *MockUserRepository) CountOnlineUsers() (int64, error) {
+	return 0, nil
+}
+
 func (m *MockUserRepository) UpdateProfile(userID string, fields map[string]any) error {
 	p, ok := m.Profiles[userID]
 	if !ok {
@@ -2845,4 +2849,219 @@ func (m *MockUserPublickeyRepository) FindByUserID(userID string) (*model.UserPu
 		return pk, nil
 	}
 	return nil, ErrNotFound
+}
+
+// MockChannelFavoriteRepository is a test double for repository.ChannelFavoriteRepository.
+type MockChannelFavoriteRepository struct {
+	Favorites map[string]*model.ChannelFavorite // keyed by "userId:channelId"
+}
+
+func NewMockChannelFavoriteRepository() *MockChannelFavoriteRepository {
+	return &MockChannelFavoriteRepository{Favorites: make(map[string]*model.ChannelFavorite)}
+}
+
+func (m *MockChannelFavoriteRepository) Create(fav *model.ChannelFavorite) error {
+	m.Favorites[fav.UserID+":"+fav.ChannelID] = fav
+	return nil
+}
+
+func (m *MockChannelFavoriteRepository) Delete(userID, channelID string) error {
+	delete(m.Favorites, userID+":"+channelID)
+	return nil
+}
+
+func (m *MockChannelFavoriteRepository) ListByUser(userID string) ([]*model.ChannelFavorite, error) {
+	var result []*model.ChannelFavorite
+	for _, f := range m.Favorites {
+		if f.UserID == userID {
+			result = append(result, f)
+		}
+	}
+	return result, nil
+}
+
+func (m *MockChannelFavoriteRepository) Exists(userID, channelID string) (bool, error) {
+	_, ok := m.Favorites[userID+":"+channelID]
+	return ok, nil
+}
+
+// MockChannelMutingRepository is a test double for repository.ChannelMutingRepository.
+type MockChannelMutingRepository struct {
+	Mutings map[string]*model.ChannelMuting // keyed by "userId:channelId"
+}
+
+func NewMockChannelMutingRepository() *MockChannelMutingRepository {
+	return &MockChannelMutingRepository{Mutings: make(map[string]*model.ChannelMuting)}
+}
+
+func (m *MockChannelMutingRepository) Create(mut *model.ChannelMuting) error {
+	m.Mutings[mut.UserID+":"+mut.ChannelID] = mut
+	return nil
+}
+
+func (m *MockChannelMutingRepository) Delete(userID, channelID string) error {
+	delete(m.Mutings, userID+":"+channelID)
+	return nil
+}
+
+func (m *MockChannelMutingRepository) ListByUser(userID string) ([]*model.ChannelMuting, error) {
+	var result []*model.ChannelMuting
+	for _, mut := range m.Mutings {
+		if mut.UserID == userID {
+			result = append(result, mut)
+		}
+	}
+	return result, nil
+}
+
+func (m *MockChannelMutingRepository) Exists(userID, channelID string) (bool, error) {
+	_, ok := m.Mutings[userID+":"+channelID]
+	return ok, nil
+}
+
+// MockClipFavoriteRepository is a test double for repository.ClipFavoriteRepository.
+type MockClipFavoriteRepository struct {
+	Favorites map[string]*model.ClipFavorite // keyed by "userId:clipId"
+}
+
+func NewMockClipFavoriteRepository() *MockClipFavoriteRepository {
+	return &MockClipFavoriteRepository{Favorites: make(map[string]*model.ClipFavorite)}
+}
+
+func (m *MockClipFavoriteRepository) Create(fav *model.ClipFavorite) error {
+	m.Favorites[fav.UserID+":"+fav.ClipID] = fav
+	return nil
+}
+
+func (m *MockClipFavoriteRepository) Delete(userID, clipID string) error {
+	delete(m.Favorites, userID+":"+clipID)
+	return nil
+}
+
+func (m *MockClipFavoriteRepository) ListByUser(userID string) ([]*model.ClipFavorite, error) {
+	var result []*model.ClipFavorite
+	for _, f := range m.Favorites {
+		if f.UserID == userID {
+			result = append(result, f)
+		}
+	}
+	return result, nil
+}
+
+func (m *MockClipFavoriteRepository) Exists(userID, clipID string) (bool, error) {
+	_, ok := m.Favorites[userID+":"+clipID]
+	return ok, nil
+}
+
+// MockUserListFavoriteRepository is a test double for repository.UserListFavoriteRepository.
+type MockUserListFavoriteRepository struct {
+	Favorites map[string]*model.UserListFavorite // keyed by "userId:userListId"
+}
+
+func NewMockUserListFavoriteRepository() *MockUserListFavoriteRepository {
+	return &MockUserListFavoriteRepository{Favorites: make(map[string]*model.UserListFavorite)}
+}
+
+func (m *MockUserListFavoriteRepository) Create(fav *model.UserListFavorite) error {
+	m.Favorites[fav.UserID+":"+fav.UserListID] = fav
+	return nil
+}
+
+func (m *MockUserListFavoriteRepository) Delete(userID, listID string) error {
+	delete(m.Favorites, userID+":"+listID)
+	return nil
+}
+
+func (m *MockUserListFavoriteRepository) ListByUser(userID string) ([]*model.UserListFavorite, error) {
+	var result []*model.UserListFavorite
+	for _, f := range m.Favorites {
+		if f.UserID == userID {
+			result = append(result, f)
+		}
+	}
+	return result, nil
+}
+
+func (m *MockUserListFavoriteRepository) Exists(userID, listID string) (bool, error) {
+	_, ok := m.Favorites[userID+":"+listID]
+	return ok, nil
+}
+
+// MockRetentionAggregationRepository is a test double for repository.RetentionAggregationRepository.
+type MockRetentionAggregationRepository struct {
+	Records []*model.RetentionAggregation
+}
+
+func NewMockRetentionAggregationRepository() *MockRetentionAggregationRepository {
+	return &MockRetentionAggregationRepository{}
+}
+
+func (m *MockRetentionAggregationRepository) ListRecent(limit int) ([]*model.RetentionAggregation, error) {
+	if limit >= len(m.Records) {
+		return m.Records, nil
+	}
+	return m.Records[:limit], nil
+}
+
+// MockSystemAccountRepository is a test double for repository.SystemAccountRepository.
+type MockSystemAccountRepository struct {
+	Accounts map[string]*model.SystemAccount // keyed by type
+}
+
+func NewMockSystemAccountRepository() *MockSystemAccountRepository {
+	return &MockSystemAccountRepository{Accounts: make(map[string]*model.SystemAccount)}
+}
+
+func (m *MockSystemAccountRepository) FindByType(typ string) (*model.SystemAccount, error) {
+	if sa, ok := m.Accounts[typ]; ok {
+		return sa, nil
+	}
+	return nil, ErrNotFound
+}
+
+func (m *MockSystemAccountRepository) Create(sa *model.SystemAccount) error {
+	m.Accounts[sa.Type] = sa
+	return nil
+}
+
+// MockNoteThreadMutingRepository is a test double for repository.NoteThreadMutingRepository.
+type MockNoteThreadMutingRepository struct {
+	Mutings map[string]*model.NoteThreadMuting // keyed by "userId:threadId"
+}
+
+func NewMockNoteThreadMutingRepository() *MockNoteThreadMutingRepository {
+	return &MockNoteThreadMutingRepository{Mutings: make(map[string]*model.NoteThreadMuting)}
+}
+
+func (m *MockNoteThreadMutingRepository) Create(mut *model.NoteThreadMuting) error {
+	m.Mutings[mut.UserID+":"+mut.ThreadID] = mut
+	return nil
+}
+
+func (m *MockNoteThreadMutingRepository) Delete(userID, threadID string) error {
+	delete(m.Mutings, userID+":"+threadID)
+	return nil
+}
+
+func (m *MockNoteThreadMutingRepository) Exists(userID, threadID string) (bool, error) {
+	_, ok := m.Mutings[userID+":"+threadID]
+	return ok, nil
+}
+
+// MockUsedUsernameRepository is a test double for repository.UsedUsernameRepository.
+type MockUsedUsernameRepository struct {
+	Usernames map[string]bool
+}
+
+func NewMockUsedUsernameRepository() *MockUsedUsernameRepository {
+	return &MockUsedUsernameRepository{Usernames: make(map[string]bool)}
+}
+
+func (m *MockUsedUsernameRepository) Create(username string) error {
+	m.Usernames[username] = true
+	return nil
+}
+
+func (m *MockUsedUsernameRepository) Exists(username string) (bool, error) {
+	return m.Usernames[username], nil
 }

--- a/migration/000032_missing_tables_columns.down.sql
+++ b/migration/000032_missing_tables_columns.down.sql
@@ -1,0 +1,13 @@
+ALTER TABLE "user_list_membership" DROP COLUMN IF EXISTS "userListUserId";
+ALTER TABLE "user_list_membership" DROP COLUMN IF EXISTS "withReplies";
+ALTER TABLE "note_draft" DROP COLUMN IF EXISTS "pollExpiredAfter";
+ALTER TABLE "antenna" DROP COLUMN IF EXISTS "excludeNotesInSensitiveChannel";
+ALTER TABLE "ad" DROP COLUMN IF EXISTS "isSensitive";
+
+DROP TABLE IF EXISTS "system_account";
+DROP TABLE IF EXISTS "retention_aggregation";
+DROP TABLE IF EXISTS "user_list_favorite";
+DROP TABLE IF EXISTS "clip_favorite";
+DROP TABLE IF EXISTS "channel_muting";
+DROP TABLE IF EXISTS "channel_favorite";
+DROP TABLE IF EXISTS "used_username";

--- a/migration/000032_missing_tables_columns.up.sql
+++ b/migration/000032_missing_tables_columns.up.sql
@@ -1,0 +1,70 @@
+-- 欠損テーブル + カラム追加 (Issue #113)
+
+-- used_username: ユーザー名再利用防止
+CREATE TABLE IF NOT EXISTS "used_username" (
+    "username" varchar(128) NOT NULL PRIMARY KEY,
+    "createdAt" timestamp with time zone NOT NULL DEFAULT now()
+);
+
+-- channel_favorite: チャンネルお気に入り
+CREATE TABLE IF NOT EXISTS "channel_favorite" (
+    "id" varchar(32) NOT NULL PRIMARY KEY,
+    "userId" varchar(32) NOT NULL REFERENCES "user"("id") ON DELETE CASCADE,
+    "channelId" varchar(32) NOT NULL REFERENCES "channel"("id") ON DELETE CASCADE,
+    UNIQUE ("userId", "channelId")
+);
+CREATE INDEX IF NOT EXISTS "IDX_channel_favorite_userId" ON "channel_favorite" ("userId");
+
+-- channel_muting: チャンネルミュート
+CREATE TABLE IF NOT EXISTS "channel_muting" (
+    "id" varchar(32) NOT NULL PRIMARY KEY,
+    "userId" varchar(32) NOT NULL REFERENCES "user"("id") ON DELETE CASCADE,
+    "channelId" varchar(32) NOT NULL REFERENCES "channel"("id") ON DELETE CASCADE,
+    UNIQUE ("userId", "channelId")
+);
+CREATE INDEX IF NOT EXISTS "IDX_channel_muting_userId" ON "channel_muting" ("userId");
+
+-- clip_favorite: クリップお気に入り
+CREATE TABLE IF NOT EXISTS "clip_favorite" (
+    "id" varchar(32) NOT NULL PRIMARY KEY,
+    "userId" varchar(32) NOT NULL REFERENCES "user"("id") ON DELETE CASCADE,
+    "clipId" varchar(32) NOT NULL REFERENCES "clip"("id") ON DELETE CASCADE,
+    UNIQUE ("userId", "clipId")
+);
+CREATE INDEX IF NOT EXISTS "IDX_clip_favorite_userId" ON "clip_favorite" ("userId");
+
+-- user_list_favorite: ユーザーリストお気に入り
+CREATE TABLE IF NOT EXISTS "user_list_favorite" (
+    "id" varchar(32) NOT NULL PRIMARY KEY,
+    "userId" varchar(32) NOT NULL REFERENCES "user"("id") ON DELETE CASCADE,
+    "userListId" varchar(32) NOT NULL REFERENCES "user_list"("id") ON DELETE CASCADE,
+    UNIQUE ("userId", "userListId")
+);
+CREATE INDEX IF NOT EXISTS "IDX_user_list_favorite_userId" ON "user_list_favorite" ("userId");
+
+-- retention_aggregation: リテンション統計
+CREATE TABLE IF NOT EXISTS "retention_aggregation" (
+    "id" varchar(32) NOT NULL PRIMARY KEY,
+    "createdAt" timestamp with time zone NOT NULL DEFAULT now(),
+    "updatedAt" timestamp with time zone NOT NULL DEFAULT now(),
+    "userIds" varchar(32)[] NOT NULL DEFAULT '{}',
+    "data" jsonb NOT NULL DEFAULT '{}',
+    "dateKey" varchar(64) NOT NULL UNIQUE,
+    "usersCount" integer NOT NULL DEFAULT 0
+);
+CREATE INDEX IF NOT EXISTS "IDX_retention_aggregation_createdAt" ON "retention_aggregation" ("createdAt");
+
+-- system_account: システムアカウント (instance.actor, relay 等)
+CREATE TABLE IF NOT EXISTS "system_account" (
+    "id" varchar(32) NOT NULL PRIMARY KEY,
+    "userId" varchar(32) NOT NULL REFERENCES "user"("id") ON DELETE CASCADE,
+    "type" varchar(256) NOT NULL UNIQUE
+);
+CREATE INDEX IF NOT EXISTS "IDX_system_account_userId" ON "system_account" ("userId");
+
+-- 欠損カラム追加
+ALTER TABLE "ad" ADD COLUMN IF NOT EXISTS "isSensitive" boolean NOT NULL DEFAULT false;
+ALTER TABLE "antenna" ADD COLUMN IF NOT EXISTS "excludeNotesInSensitiveChannel" boolean NOT NULL DEFAULT false;
+ALTER TABLE "note_draft" ADD COLUMN IF NOT EXISTS "pollExpiredAfter" bigint;
+ALTER TABLE "user_list_membership" ADD COLUMN IF NOT EXISTS "withReplies" boolean NOT NULL DEFAULT false;
+ALTER TABLE "user_list_membership" ADD COLUMN IF NOT EXISTS "userListUserId" varchar(32);


### PR DESCRIPTION
## Summary
- Migration 000032: 7 new tables (used_username, channel_favorite, channel_muting, clip_favorite, user_list_favorite, retention_aggregation, system_account) + 5 new columns (Ad.isSensitive, Antenna.excludeNotesInSensitiveChannel, NoteDraft.pollExpiredAfter, UserListMembership.withReplies/userListUserId)
- 8 new models, 9 new repositories, 8 mock repositories
- 12+ new API endpoints: get-online-users-count, server-info, endpoints, endpoint, retention, get-avatar-decorations, emoji, email-address/available, promo/read, invite/create, invite/list, roles/notes
- Stub→real implementation: channels (favorite/unfavorite/my-favorites, mute create/delete/list), clips (favorite/unfavorite/my-favorites), users (lists/favorite, lists/unfavorite)
- admin/accounts/create response expanded to full MeDetailed format

## 主な変更点
- **40ファイル変更** (+2003 / -91行)
- 新規テーブルはTS版Misskeyとのスキーマ互換性を維持
- スタブだったエンドポイントをリポジトリ注入パターンで実装化
- roles/notesはRoleNotesQueryインターフェースで抽象化しDB結合クエリで実装
- admin/accounts/createはMeDetailed全フィールドを返すように拡充

## テスト
- channels: 93.0%, clips: 95.2%, emojis: 100%, roles: 100%, users: 94.5%, admin: 61.6%
- `make fmt && make lint` 通過済み
- 統合テスト (gallery/hashtags/repository) はローカルDB未起動のため除外、CIで検証

Closes #113

🤖 Generated with [Claude Code](https://claude.com/claude-code)