### PR TITLE
Fix #122: GenToken hash assertion + sanitizeHeaders double-clone

### DIFF
--- a/internal/api/auth/handler_test.go
+++ b/internal/api/auth/handler_test.go
@@ -422,6 +422,9 @@ func TestGenToken_Success(t *testing.T) {
 		assert.Equal(t, "u1", at.UserID)
 		assert.Nil(t, at.AppID)
 		assert.Equal(t, resp["token"], at.Token)
+		// SHA-256ハッシュ化の検証: HashはTokenと異なり、sha256Hexの結果と一致する
+		assert.NotEqual(t, at.Token, at.Hash, "Hash should differ from raw Token")
+		assert.Equal(t, sha256Hex(at.Token), at.Hash, "Hash should be SHA-256 of Token")
 	}
 }
 

--- a/internal/api/signin/handler.go
+++ b/internal/api/signin/handler.go
@@ -322,18 +322,18 @@ func (h *Handler) ok(c echo.Context, user *model.User) error {
 	})
 }
 
-// sanitizeHeaders removes sensitive headers before persisting.
-func sanitizeHeaders(h http.Header) http.Header {
-	safe := h.Clone()
-	safe.Del("Authorization")
-	safe.Del("Cookie")
-	safe.Del("Set-Cookie")
-	return safe
+// sanitizeHeaders removes sensitive headers in-place before persisting.
+// 呼び出し元でClone済みのヘッダーを受け取る前提
+func sanitizeHeaders(h http.Header) {
+	h.Del("Authorization")
+	h.Del("Cookie")
+	h.Del("Set-Cookie")
 }
 
 // recordSignin persists a signin record asynchronously.
 func (h *Handler) recordSignin(userID, ip string, headers http.Header) {
-	hdrs, err := json.Marshal(sanitizeHeaders(headers))
+	sanitizeHeaders(headers)
+	hdrs, err := json.Marshal(headers)
 	if err != nil {
 		hdrs = []byte("{}")
 	}


### PR DESCRIPTION
## Summary
- GenTokenテストにSHA-256ハッシュ化の検証アサーションを追加
- sanitizeHeadersの二重Clone問題を解消（in-place変更に変更）

## 主な変更点
| ファイル | 内容 |
|---------|------|
| `internal/api/auth/handler_test.go` | `Hash != Token` + `Hash == sha256Hex(Token)` アサーション追加 |
| `internal/api/signin/handler.go` | `sanitizeHeaders`をin-place変更に変更、冗長なCloneを削除 |

## テスト
```bash
go test -race -count=1 ./internal/api/auth/... ./internal/api/signin/...
```
- auth: 全テストパス
- signin: 全テストパス

Closes #122
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/shiroha-a/mk/pull/123" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
