### PR TITLE
Phase WS: 9 missing streaming channels + timeline filter params

### DIFF
--- a/internal/server/router.go
+++ b/internal/server/router.go
@@ -1094,6 +1094,14 @@ func (s *Server) setupRoutes() {
 	streamRegistry.Register("notifications", channels.NewNotifications)
 	streamRegistry.Register("main", channels.NewMain)
 	streamRegistry.Register("drive", channels.NewDrive)
+	streamRegistry.Register("hashtag", channels.NewHashtag)
+	streamRegistry.Register("antenna", channels.NewAntenna)
+	streamRegistry.Register("channel", channels.NewChannelTimeline)
+	streamRegistry.Register("userList", channels.NewUserList)
+	streamRegistry.Register("roleTimeline", channels.NewRoleTimeline)
+	streamRegistry.Register("admin", channels.NewAdmin)
+	streamRegistry.Register("serverStats", channels.NewServerStats)
+	streamRegistry.Register("queueStats", channels.NewQueueStats)
 
 	// 3. Connection manager + 各 publisher の生成
 	streamManager := stream.NewManager(streamRegistry, streamBus)
@@ -1111,6 +1119,7 @@ func (s *Server) setupRoutes() {
 	// 5. Reversi WebSocket channel (Phase 9.6) を登録する
 	reversiService := corereversi.NewService(reversiRepo, reversiPublisher, s.redis.Default)
 	streamRegistry.Register("reversiGame", channels.NewReversiGameFactory(reversiService).New)
+	streamRegistry.Register("reversi", channels.NewReversi)
 
 	// 6. Chat WebSocket channels (Phase 9.8): chatRoom と chatUser を登録する
 	chatPublisher := stream.NewChatPublisher(streamPubSub)

--- a/internal/server/router.go
+++ b/internal/server/router.go
@@ -1099,7 +1099,7 @@ func (s *Server) setupRoutes() {
 	streamRegistry.Register("channel", channels.NewChannelTimeline)
 	streamRegistry.Register("userList", channels.NewUserList)
 	streamRegistry.Register("roleTimeline", channels.NewRoleTimeline)
-	streamRegistry.Register("admin", channels.NewAdmin)
+	streamRegistry.Register("admin", channels.NewAdminFactory(roleService).New)
 	streamRegistry.Register("serverStats", channels.NewServerStats)
 	streamRegistry.Register("queueStats", channels.NewQueueStats)
 

--- a/internal/stream/channels/admin.go
+++ b/internal/stream/channels/admin.go
@@ -7,15 +7,31 @@ import (
 	"github.com/shiroha-a/mk/internal/stream"
 )
 
-// AdminChannel forwards admin-only events. Requires authenticated admin user.
-type AdminChannel struct {
-	ctx       stream.ChannelContext
-	connected bool
+// AdminRoleChecker checks whether a user has admin privileges.
+type AdminRoleChecker interface {
+	IsAdministrator(userID string) bool
 }
 
-// NewAdmin returns a channel factory for "admin".
-func NewAdmin(ctx stream.ChannelContext) stream.Channel {
-	return &AdminChannel{ctx: ctx}
+// AdminChannel forwards admin-only events. Requires authenticated admin user.
+type AdminChannel struct {
+	ctx         stream.ChannelContext
+	roleChecker AdminRoleChecker
+	connected   bool
+}
+
+// AdminFactory holds the role checker dependency for admin channel creation.
+type AdminFactory struct {
+	roleChecker AdminRoleChecker
+}
+
+// NewAdminFactory constructs an AdminFactory with the given role checker.
+func NewAdminFactory(roleChecker AdminRoleChecker) *AdminFactory {
+	return &AdminFactory{roleChecker: roleChecker}
+}
+
+// New builds a new AdminChannel. Usable as a stream.ChannelFactory.
+func (f *AdminFactory) New(ctx stream.ChannelContext) stream.Channel {
+	return &AdminChannel{ctx: ctx, roleChecker: f.roleChecker}
 }
 
 func (c *AdminChannel) Init(_ json.RawMessage) {
@@ -23,8 +39,10 @@ func (c *AdminChannel) Init(_ json.RawMessage) {
 	if !ok || user == nil {
 		return
 	}
-	// admin権限チェック: IsAdminフィールドまたはロールシステムで判定
-	// ここではtopic購読のみ行い、publish側でadminイベントのみ流す前提
+	// admin権限チェック
+	if c.roleChecker == nil || !c.roleChecker.IsAdministrator(user.ID) {
+		return
+	}
 	c.connected = true
 	c.ctx.Subscribe("adminStream")
 }

--- a/internal/stream/channels/admin.go
+++ b/internal/stream/channels/admin.go
@@ -1,0 +1,51 @@
+package channels
+
+import (
+	"encoding/json"
+
+	"github.com/shiroha-a/mk/internal/model"
+	"github.com/shiroha-a/mk/internal/stream"
+)
+
+// AdminChannel forwards admin-only events. Requires authenticated admin user.
+type AdminChannel struct {
+	ctx       stream.ChannelContext
+	connected bool
+}
+
+// NewAdmin returns a channel factory for "admin".
+func NewAdmin(ctx stream.ChannelContext) stream.Channel {
+	return &AdminChannel{ctx: ctx}
+}
+
+func (c *AdminChannel) Init(_ json.RawMessage) {
+	user, ok := c.ctx.User().(*model.User)
+	if !ok || user == nil {
+		return
+	}
+	// admin権限チェック: IsAdminフィールドまたはロールシステムで判定
+	// ここではtopic購読のみ行い、publish側でadminイベントのみ流す前提
+	c.connected = true
+	c.ctx.Subscribe("adminStream")
+}
+
+func (c *AdminChannel) OnRedisEvent(payload []byte) {
+	// {type, body}エンベロープの展開
+	var envelope struct {
+		Type string          `json:"type"`
+		Body json.RawMessage `json:"body"`
+	}
+	if err := json.Unmarshal(payload, &envelope); err == nil && envelope.Type != "" {
+		_ = c.ctx.Send(envelope.Type, envelope.Body)
+		return
+	}
+	_ = c.ctx.Send("adminEvent", json.RawMessage(payload))
+}
+
+func (c *AdminChannel) OnClientMessage(string, json.RawMessage) {}
+
+func (c *AdminChannel) Dispose() {
+	if c.connected {
+		c.ctx.Unsubscribe("adminStream")
+	}
+}

--- a/internal/stream/channels/antenna.go
+++ b/internal/stream/channels/antenna.go
@@ -1,0 +1,50 @@
+package channels
+
+import (
+	"encoding/json"
+
+	"github.com/shiroha-a/mk/internal/model"
+	"github.com/shiroha-a/mk/internal/stream"
+)
+
+// AntennaChannel forwards notes captured by a user-defined antenna.
+type AntennaChannel struct {
+	ctx   stream.ChannelContext
+	topic string
+}
+
+// NewAntenna returns a channel factory for "antenna".
+func NewAntenna(ctx stream.ChannelContext) stream.Channel {
+	return &AntennaChannel{ctx: ctx}
+}
+
+func (c *AntennaChannel) Init(params json.RawMessage) {
+	// 認証必須
+	user, ok := c.ctx.User().(*model.User)
+	if !ok || user == nil {
+		return
+	}
+	var p struct {
+		AntennaID string `json:"antennaId"`
+	}
+	if len(params) > 0 {
+		_ = json.Unmarshal(params, &p)
+	}
+	if p.AntennaID == "" {
+		return
+	}
+	c.topic = "antennaTimeline:" + p.AntennaID
+	c.ctx.Subscribe(c.topic)
+}
+
+func (c *AntennaChannel) OnRedisEvent(payload []byte) {
+	_ = c.ctx.Send("note", json.RawMessage(payload))
+}
+
+func (c *AntennaChannel) OnClientMessage(string, json.RawMessage) {}
+
+func (c *AntennaChannel) Dispose() {
+	if c.topic != "" {
+		c.ctx.Unsubscribe(c.topic)
+	}
+}

--- a/internal/stream/channels/channel_timeline.go
+++ b/internal/stream/channels/channel_timeline.go
@@ -1,0 +1,49 @@
+package channels
+
+import (
+	"encoding/json"
+
+	"github.com/shiroha-a/mk/internal/stream"
+)
+
+// ChannelTimelineChannel forwards notes posted to a specific channel.
+type ChannelTimelineChannel struct {
+	ctx    stream.ChannelContext
+	topic  string
+	filter noteFilter
+}
+
+// NewChannelTimeline returns a channel factory for "channel".
+func NewChannelTimeline(ctx stream.ChannelContext) stream.Channel {
+	return &ChannelTimelineChannel{ctx: ctx}
+}
+
+func (c *ChannelTimelineChannel) Init(params json.RawMessage) {
+	var p struct {
+		ChannelID string `json:"channelId"`
+	}
+	if len(params) > 0 {
+		_ = json.Unmarshal(params, &p)
+	}
+	if p.ChannelID == "" {
+		return
+	}
+	c.filter = parseNoteFilter(params)
+	c.topic = "channel:" + p.ChannelID
+	c.ctx.Subscribe(c.topic)
+}
+
+func (c *ChannelTimelineChannel) OnRedisEvent(payload []byte) {
+	if !c.filter.shouldEmit(payload) {
+		return
+	}
+	_ = c.ctx.Send("note", json.RawMessage(payload))
+}
+
+func (c *ChannelTimelineChannel) OnClientMessage(string, json.RawMessage) {}
+
+func (c *ChannelTimelineChannel) Dispose() {
+	if c.topic != "" {
+		c.ctx.Unsubscribe(c.topic)
+	}
+}

--- a/internal/stream/channels/hashtag.go
+++ b/internal/stream/channels/hashtag.go
@@ -1,0 +1,51 @@
+package channels
+
+import (
+	"encoding/json"
+
+	"github.com/shiroha-a/mk/internal/stream"
+)
+
+// HashtagChannel forwards notes matching a specific hashtag.
+type HashtagChannel struct {
+	ctx    stream.ChannelContext
+	topic  string
+	filter noteFilter
+}
+
+// NewHashtag returns a channel factory for "hashtag".
+func NewHashtag(ctx stream.ChannelContext) stream.Channel {
+	return &HashtagChannel{ctx: ctx}
+}
+
+func (c *HashtagChannel) Init(params json.RawMessage) {
+	var p struct {
+		Q [][]string `json:"q"`
+	}
+	if len(params) > 0 {
+		_ = json.Unmarshal(params, &p)
+	}
+	// qが空ならno-op
+	if len(p.Q) == 0 || len(p.Q[0]) == 0 {
+		return
+	}
+	c.filter = parseNoteFilter(params)
+	// 最初のタグでトピック購読
+	c.topic = "hashtag:" + p.Q[0][0]
+	c.ctx.Subscribe(c.topic)
+}
+
+func (c *HashtagChannel) OnRedisEvent(payload []byte) {
+	if !c.filter.shouldEmit(payload) {
+		return
+	}
+	_ = c.ctx.Send("note", json.RawMessage(payload))
+}
+
+func (c *HashtagChannel) OnClientMessage(string, json.RawMessage) {}
+
+func (c *HashtagChannel) Dispose() {
+	if c.topic != "" {
+		c.ctx.Unsubscribe(c.topic)
+	}
+}

--- a/internal/stream/channels/new_channels_test.go
+++ b/internal/stream/channels/new_channels_test.go
@@ -1,0 +1,373 @@
+package channels
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/shiroha-a/mk/internal/model"
+	"github.com/shiroha-a/mk/internal/stream"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// interface conformance checks
+var (
+	_ stream.Channel = (*HashtagChannel)(nil)
+	_ stream.Channel = (*AntennaChannel)(nil)
+	_ stream.Channel = (*ChannelTimelineChannel)(nil)
+	_ stream.Channel = (*UserListChannel)(nil)
+	_ stream.Channel = (*RoleTimelineChannel)(nil)
+	_ stream.Channel = (*AdminChannel)(nil)
+	_ stream.Channel = (*ServerStatsChannel)(nil)
+	_ stream.Channel = (*QueueStatsChannel)(nil)
+	_ stream.Channel = (*ReversiChannel)(nil)
+)
+
+// --- Hashtag ---
+
+func TestHashtag_Lifecycle(t *testing.T) {
+	ctx := newCtx(nil)
+	ch := NewHashtag(ctx)
+	ch.Init(json.RawMessage(`{"q":[["golang"]]}`))
+	assert.Equal(t, []string{"hashtag:golang"}, ctx.subs)
+
+	ch.OnRedisEvent([]byte(`{"id":"n1"}`))
+	require.Len(t, ctx.sentType, 1)
+	assert.Equal(t, "note", ctx.sentType[0])
+
+	ch.Dispose()
+	assert.Equal(t, []string{"hashtag:golang"}, ctx.unsubs)
+}
+
+func TestHashtag_EmptyQ(t *testing.T) {
+	ctx := newCtx(nil)
+	ch := NewHashtag(ctx)
+	ch.Init(json.RawMessage(`{}`))
+	assert.Empty(t, ctx.subs)
+	ch.Dispose()
+}
+
+// --- Antenna ---
+
+func TestAntenna_Lifecycle(t *testing.T) {
+	ctx := newCtx(&model.User{ID: "alice"})
+	ch := NewAntenna(ctx)
+	ch.Init(json.RawMessage(`{"antennaId":"a1"}`))
+	assert.Equal(t, []string{"antennaTimeline:a1"}, ctx.subs)
+
+	ch.OnRedisEvent([]byte(`{"id":"n1"}`))
+	require.Len(t, ctx.sentType, 1)
+
+	ch.Dispose()
+	assert.Equal(t, []string{"antennaTimeline:a1"}, ctx.unsubs)
+}
+
+func TestAntenna_NoAuth(t *testing.T) {
+	ctx := newCtx(nil)
+	ch := NewAntenna(ctx)
+	ch.Init(json.RawMessage(`{"antennaId":"a1"}`))
+	assert.Empty(t, ctx.subs)
+}
+
+func TestAntenna_MissingID(t *testing.T) {
+	ctx := newCtx(&model.User{ID: "alice"})
+	ch := NewAntenna(ctx)
+	ch.Init(json.RawMessage(`{}`))
+	assert.Empty(t, ctx.subs)
+}
+
+// --- ChannelTimeline ---
+
+func TestChannelTimeline_Lifecycle(t *testing.T) {
+	ctx := newCtx(nil)
+	ch := NewChannelTimeline(ctx)
+	ch.Init(json.RawMessage(`{"channelId":"ch1"}`))
+	assert.Equal(t, []string{"channel:ch1"}, ctx.subs)
+
+	ch.OnRedisEvent([]byte(`{"id":"n1"}`))
+	require.Len(t, ctx.sentType, 1)
+
+	ch.Dispose()
+	assert.Equal(t, []string{"channel:ch1"}, ctx.unsubs)
+}
+
+func TestChannelTimeline_MissingID(t *testing.T) {
+	ctx := newCtx(nil)
+	ch := NewChannelTimeline(ctx)
+	ch.Init(json.RawMessage(`{}`))
+	assert.Empty(t, ctx.subs)
+}
+
+// --- UserList ---
+
+func TestUserList_Lifecycle(t *testing.T) {
+	ctx := newCtx(&model.User{ID: "alice"})
+	ch := NewUserList(ctx)
+	ch.Init(json.RawMessage(`{"listId":"l1"}`))
+	assert.Equal(t, []string{"userListTimeline:l1"}, ctx.subs)
+
+	ch.OnRedisEvent([]byte(`{"id":"n1"}`))
+	require.Len(t, ctx.sentType, 1)
+
+	ch.Dispose()
+	assert.Equal(t, []string{"userListTimeline:l1"}, ctx.unsubs)
+}
+
+func TestUserList_NoAuth(t *testing.T) {
+	ctx := newCtx(nil)
+	ch := NewUserList(ctx)
+	ch.Init(json.RawMessage(`{"listId":"l1"}`))
+	assert.Empty(t, ctx.subs)
+}
+
+func TestUserList_WithReplies(t *testing.T) {
+	ctx := newCtx(&model.User{ID: "alice"})
+	ch := NewUserList(ctx)
+	ch.Init(json.RawMessage(`{"listId":"l1","withReplies":true}`))
+	assert.Equal(t, []string{"userListTimeline:l1"}, ctx.subs)
+
+	// リプライが通過する
+	ch.OnRedisEvent([]byte(`{"text":"reply","replyId":"p1"}`))
+	require.Len(t, ctx.sentType, 1)
+}
+
+// --- RoleTimeline ---
+
+func TestRoleTimeline_Lifecycle(t *testing.T) {
+	ctx := newCtx(nil)
+	ch := NewRoleTimeline(ctx)
+	ch.Init(json.RawMessage(`{"roleId":"r1"}`))
+	assert.Equal(t, []string{"roleTimeline:r1"}, ctx.subs)
+
+	ch.OnRedisEvent([]byte(`{"id":"n1"}`))
+	require.Len(t, ctx.sentType, 1)
+
+	ch.Dispose()
+	assert.Equal(t, []string{"roleTimeline:r1"}, ctx.unsubs)
+}
+
+func TestRoleTimeline_MissingID(t *testing.T) {
+	ctx := newCtx(nil)
+	ch := NewRoleTimeline(ctx)
+	ch.Init(json.RawMessage(`{}`))
+	assert.Empty(t, ctx.subs)
+}
+
+// --- Admin ---
+
+func TestAdmin_Lifecycle(t *testing.T) {
+	ctx := newCtx(&model.User{ID: "admin1"})
+	ch := NewAdmin(ctx)
+	ch.Init(nil)
+	assert.Equal(t, []string{"adminStream"}, ctx.subs)
+
+	// エンベロープ展開
+	ch.OnRedisEvent([]byte(`{"type":"newReport","body":{"id":"r1"}}`))
+	require.Len(t, ctx.sentType, 1)
+	assert.Equal(t, "newReport", ctx.sentType[0])
+
+	ch.Dispose()
+	assert.Equal(t, []string{"adminStream"}, ctx.unsubs)
+}
+
+func TestAdmin_NoAuth(t *testing.T) {
+	ctx := newCtx(nil)
+	ch := NewAdmin(ctx)
+	ch.Init(nil)
+	assert.Empty(t, ctx.subs)
+}
+
+func TestAdmin_RawPayload(t *testing.T) {
+	ctx := newCtx(&model.User{ID: "admin1"})
+	ch := NewAdmin(ctx)
+	ch.Init(nil)
+	// エンベロープでないペイロード
+	ch.OnRedisEvent([]byte(`{"data":"raw"}`))
+	require.Len(t, ctx.sentType, 1)
+	assert.Equal(t, "adminEvent", ctx.sentType[0])
+}
+
+// --- ServerStats ---
+
+func TestServerStats_Lifecycle(t *testing.T) {
+	ctx := newCtx(nil)
+	ch := NewServerStats(ctx)
+	ch.Init(nil)
+	assert.Equal(t, []string{"serverStats"}, ctx.subs)
+
+	ch.OnRedisEvent([]byte(`{"cpu":0.5}`))
+	require.Len(t, ctx.sentType, 1)
+	assert.Equal(t, "stats", ctx.sentType[0])
+
+	ch.Dispose()
+	assert.Equal(t, []string{"serverStats"}, ctx.unsubs)
+}
+
+// --- QueueStats ---
+
+func TestQueueStats_Lifecycle(t *testing.T) {
+	ctx := newCtx(nil)
+	ch := NewQueueStats(ctx)
+	ch.Init(nil)
+	assert.Equal(t, []string{"queueStats"}, ctx.subs)
+
+	ch.OnRedisEvent([]byte(`{"deliver":10}`))
+	require.Len(t, ctx.sentType, 1)
+	assert.Equal(t, "stats", ctx.sentType[0])
+
+	ch.Dispose()
+	assert.Equal(t, []string{"queueStats"}, ctx.unsubs)
+}
+
+// --- Reversi ---
+
+func TestReversi_Lifecycle(t *testing.T) {
+	ctx := newCtx(&model.User{ID: "alice"})
+	ch := NewReversi(ctx)
+	ch.Init(nil)
+	assert.Equal(t, []string{"reversi:alice"}, ctx.subs)
+
+	ch.OnRedisEvent([]byte(`{"type":"invited","body":{"gameId":"g1"}}`))
+	require.Len(t, ctx.sentType, 1)
+	assert.Equal(t, "invited", ctx.sentType[0])
+
+	ch.Dispose()
+	assert.Equal(t, []string{"reversi:alice"}, ctx.unsubs)
+}
+
+func TestReversi_NoAuth(t *testing.T) {
+	ctx := newCtx(nil)
+	ch := NewReversi(ctx)
+	ch.Init(nil)
+	assert.Empty(t, ctx.subs)
+}
+
+// --- OnClientMessage no-op coverage ---
+
+func TestNoOpClientMessages(t *testing.T) {
+	body := json.RawMessage(`{}`)
+	cases := []struct {
+		name string
+		ch   stream.Channel
+	}{
+		{"hashtag", NewHashtag(newCtx(nil))},
+		{"antenna", NewAntenna(newCtx(&model.User{ID: "u1"}))},
+		{"channelTimeline", NewChannelTimeline(newCtx(nil))},
+		{"userList", NewUserList(newCtx(&model.User{ID: "u1"}))},
+		{"roleTimeline", NewRoleTimeline(newCtx(nil))},
+		{"admin", NewAdmin(newCtx(&model.User{ID: "u1"}))},
+		{"serverStats", NewServerStats(newCtx(nil))},
+		{"queueStats", NewQueueStats(newCtx(nil))},
+		{"reversi", NewReversi(newCtx(&model.User{ID: "u1"}))},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			tc.ch.OnClientMessage("test", body)
+		})
+	}
+}
+
+// --- Filter branch coverage for new channels ---
+
+func TestHashtag_FilteredRenote(t *testing.T) {
+	ctx := newCtx(nil)
+	ch := NewHashtag(ctx)
+	ch.Init(json.RawMessage(`{"q":[["go"]],"withRenotes":false}`))
+	ch.OnRedisEvent([]byte(`{"renoteId":"r1"}`))
+	assert.Empty(t, ctx.sentType)
+}
+
+func TestChannelTimeline_FilteredReply(t *testing.T) {
+	ctx := newCtx(nil)
+	ch := NewChannelTimeline(ctx)
+	ch.Init(json.RawMessage(`{"channelId":"ch1","withReplies":false}`))
+	ch.OnRedisEvent([]byte(`{"text":"reply","replyId":"p1"}`))
+	assert.Empty(t, ctx.sentType)
+}
+
+func TestRoleTimeline_FilteredRenote(t *testing.T) {
+	ctx := newCtx(nil)
+	ch := NewRoleTimeline(ctx)
+	ch.Init(json.RawMessage(`{"roleId":"r1","withRenotes":false}`))
+	ch.OnRedisEvent([]byte(`{"renoteId":"r1"}`))
+	assert.Empty(t, ctx.sentType)
+}
+
+func TestUserList_FilteredNoFiles(t *testing.T) {
+	ctx := newCtx(&model.User{ID: "alice"})
+	ch := NewUserList(ctx)
+	ch.Init(json.RawMessage(`{"listId":"l1","withFiles":true}`))
+	ch.OnRedisEvent([]byte(`{"text":"hello","fileIds":[]}`))
+	assert.Empty(t, ctx.sentType)
+}
+
+func TestUserList_MissingListID(t *testing.T) {
+	ctx := newCtx(&model.User{ID: "alice"})
+	ch := NewUserList(ctx)
+	ch.Init(json.RawMessage(`{}`))
+	assert.Empty(t, ctx.subs)
+}
+
+func TestReversi_RawPayload(t *testing.T) {
+	ctx := newCtx(&model.User{ID: "alice"})
+	ch := NewReversi(ctx)
+	ch.Init(nil)
+	// エンベロープでないペイロード
+	ch.OnRedisEvent([]byte(`{"data":"raw"}`))
+	require.Len(t, ctx.sentType, 1)
+	assert.Equal(t, "reversiEvent", ctx.sentType[0])
+}
+
+// --- Timeline filter integration ---
+
+func TestLocalTimeline_FilterPureRenote(t *testing.T) {
+	ctx := newCtx(nil)
+	ch := NewLocalTimeline(ctx)
+	ch.Init(json.RawMessage(`{"withRenotes":false}`))
+
+	// 純リノートはフィルタされる
+	ch.OnRedisEvent([]byte(`{"renoteId":"r1"}`))
+	assert.Empty(t, ctx.sentType)
+
+	// 通常ノートは通過
+	ch.OnRedisEvent([]byte(`{"text":"hello"}`))
+	require.Len(t, ctx.sentType, 1)
+}
+
+func TestGlobalTimeline_FilterReply(t *testing.T) {
+	ctx := newCtx(nil)
+	ch := NewGlobalTimeline(ctx)
+	ch.Init(json.RawMessage(`{"withReplies":false}`))
+
+	// リプライはフィルタされる（デフォルトでfalse）
+	ch.OnRedisEvent([]byte(`{"text":"reply","replyId":"p1"}`))
+	assert.Empty(t, ctx.sentType)
+}
+
+func TestHomeTimeline_WithFiles(t *testing.T) {
+	ctx := newCtx(&model.User{ID: "alice"})
+	ch := NewHomeTimeline(ctx)
+	ch.Init(json.RawMessage(`{"withFiles":true}`))
+
+	// ファイルなしはフィルタされる
+	ch.OnRedisEvent([]byte(`{"text":"hello","fileIds":[]}`))
+	assert.Empty(t, ctx.sentType)
+
+	// ファイルありは通過
+	ch.OnRedisEvent([]byte(`{"text":"hello","fileIds":["f1"]}`))
+	require.Len(t, ctx.sentType, 1)
+}
+
+func TestHybridTimeline_FilterDefault(t *testing.T) {
+	ctx := newCtx(&model.User{ID: "alice"})
+	ch := NewHybridTimeline(ctx)
+	ch.Init(nil) // デフォルトフィルタ
+
+	// 通常ノートは通過
+	ch.OnRedisEvent([]byte(`{"text":"hello"}`))
+	require.Len(t, ctx.sentType, 1)
+
+	// リプライはデフォルトでフィルタ
+	ch.OnRedisEvent([]byte(`{"text":"reply","replyId":"p1"}`))
+	assert.Len(t, ctx.sentType, 1) // 増えない
+}

--- a/internal/stream/channels/new_channels_test.go
+++ b/internal/stream/channels/new_channels_test.go
@@ -10,6 +10,24 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+// mockRoleChecker is a test double for AdminRoleChecker.
+type mockRoleChecker struct {
+	admins map[string]bool
+}
+
+func (m *mockRoleChecker) IsAdministrator(userID string) bool {
+	return m.admins[userID]
+}
+
+func newAdminCh(ctx stream.ChannelContext, isAdmin bool) stream.Channel {
+	userID := ""
+	if u, ok := ctx.User().(*model.User); ok && u != nil {
+		userID = u.ID
+	}
+	checker := &mockRoleChecker{admins: map[string]bool{userID: isAdmin}}
+	return NewAdminFactory(checker).New(ctx)
+}
+
 // interface conformance checks
 var (
 	_ stream.Channel = (*HashtagChannel)(nil)
@@ -157,7 +175,7 @@ func TestRoleTimeline_MissingID(t *testing.T) {
 
 func TestAdmin_Lifecycle(t *testing.T) {
 	ctx := newCtx(&model.User{ID: "admin1"})
-	ch := NewAdmin(ctx)
+	ch := newAdminCh(ctx, true)
 	ch.Init(nil)
 	assert.Equal(t, []string{"adminStream"}, ctx.subs)
 
@@ -172,14 +190,21 @@ func TestAdmin_Lifecycle(t *testing.T) {
 
 func TestAdmin_NoAuth(t *testing.T) {
 	ctx := newCtx(nil)
-	ch := NewAdmin(ctx)
+	ch := newAdminCh(ctx, false)
+	ch.Init(nil)
+	assert.Empty(t, ctx.subs)
+}
+
+func TestAdmin_NotAdmin(t *testing.T) {
+	ctx := newCtx(&model.User{ID: "normaluser"})
+	ch := newAdminCh(ctx, false)
 	ch.Init(nil)
 	assert.Empty(t, ctx.subs)
 }
 
 func TestAdmin_RawPayload(t *testing.T) {
 	ctx := newCtx(&model.User{ID: "admin1"})
-	ch := NewAdmin(ctx)
+	ch := newAdminCh(ctx, true)
 	ch.Init(nil)
 	// エンベロープでないペイロード
 	ch.OnRedisEvent([]byte(`{"data":"raw"}`))
@@ -255,7 +280,7 @@ func TestNoOpClientMessages(t *testing.T) {
 		{"channelTimeline", NewChannelTimeline(newCtx(nil))},
 		{"userList", NewUserList(newCtx(&model.User{ID: "u1"}))},
 		{"roleTimeline", NewRoleTimeline(newCtx(nil))},
-		{"admin", NewAdmin(newCtx(&model.User{ID: "u1"}))},
+		{"admin", newAdminCh(newCtx(&model.User{ID: "u1"}), true)},
 		{"serverStats", NewServerStats(newCtx(nil))},
 		{"queueStats", NewQueueStats(newCtx(nil))},
 		{"reversi", NewReversi(newCtx(&model.User{ID: "u1"}))},
@@ -273,7 +298,7 @@ func TestHashtag_FilteredRenote(t *testing.T) {
 	ctx := newCtx(nil)
 	ch := NewHashtag(ctx)
 	ch.Init(json.RawMessage(`{"q":[["go"]],"withRenotes":false}`))
-	ch.OnRedisEvent([]byte(`{"renoteId":"r1"}`))
+	ch.OnRedisEvent([]byte(`{"renoteId":"r1","fileIds":[]}`))
 	assert.Empty(t, ctx.sentType)
 }
 
@@ -289,7 +314,7 @@ func TestRoleTimeline_FilteredRenote(t *testing.T) {
 	ctx := newCtx(nil)
 	ch := NewRoleTimeline(ctx)
 	ch.Init(json.RawMessage(`{"roleId":"r1","withRenotes":false}`))
-	ch.OnRedisEvent([]byte(`{"renoteId":"r1"}`))
+	ch.OnRedisEvent([]byte(`{"renoteId":"r1","fileIds":[]}`))
 	assert.Empty(t, ctx.sentType)
 }
 
@@ -326,7 +351,7 @@ func TestLocalTimeline_FilterPureRenote(t *testing.T) {
 	ch.Init(json.RawMessage(`{"withRenotes":false}`))
 
 	// 純リノートはフィルタされる
-	ch.OnRedisEvent([]byte(`{"renoteId":"r1"}`))
+	ch.OnRedisEvent([]byte(`{"renoteId":"r1","fileIds":[]}`))
 	assert.Empty(t, ctx.sentType)
 
 	// 通常ノートは通過

--- a/internal/stream/channels/note_filter.go
+++ b/internal/stream/channels/note_filter.go
@@ -44,8 +44,9 @@ func (f *noteFilter) shouldEmit(payload []byte) bool {
 		return true
 	}
 
-	// 純リノート（テキストなし + renoteIdあり）をフィルタ
-	if !f.WithRenotes && note.Text == nil && note.RenoteID != nil {
+	// 純リノート（テキストなし + renoteIdあり + ファイルなし）をフィルタ
+	// timeline_filter.goのisPureRenoteと一致させる
+	if !f.WithRenotes && note.Text == nil && note.RenoteID != nil && len(note.FileIDs) == 0 {
 		return false
 	}
 

--- a/internal/stream/channels/note_filter.go
+++ b/internal/stream/channels/note_filter.go
@@ -1,0 +1,63 @@
+package channels
+
+import "encoding/json"
+
+// noteFilter provides client-controlled filtering for timeline channels.
+// タイムラインチャンネルのconnectパラメータで指定されるフィルタ条件。
+type noteFilter struct {
+	WithRenotes bool `json:"withRenotes"`
+	WithReplies bool `json:"withReplies"`
+	WithFiles   bool `json:"withFiles"`
+}
+
+// defaultNoteFilter returns a filter with default values matching TS behavior.
+func defaultNoteFilter() noteFilter {
+	return noteFilter{
+		WithRenotes: true,
+		WithReplies: false,
+		WithFiles:   false,
+	}
+}
+
+// parseNoteFilter parses filter parameters from the connect params JSON.
+func parseNoteFilter(params json.RawMessage) noteFilter {
+	f := defaultNoteFilter()
+	if len(params) > 0 {
+		_ = json.Unmarshal(params, &f)
+	}
+	return f
+}
+
+// notePayload is the minimal structure needed for filtering decisions.
+type notePayload struct {
+	Text     *string  `json:"text"`
+	RenoteID *string  `json:"renoteId"`
+	ReplyID  *string  `json:"replyId"`
+	FileIDs  []string `json:"fileIds"`
+}
+
+// shouldEmit returns true if the note passes all filter conditions.
+func (f *noteFilter) shouldEmit(payload []byte) bool {
+	var note notePayload
+	if err := json.Unmarshal(payload, &note); err != nil {
+		// パース失敗時はそのまま送信
+		return true
+	}
+
+	// 純リノート（テキストなし + renoteIdあり）をフィルタ
+	if !f.WithRenotes && note.Text == nil && note.RenoteID != nil {
+		return false
+	}
+
+	// リプライをフィルタ
+	if !f.WithReplies && note.ReplyID != nil {
+		return false
+	}
+
+	// ファイル付きのみモード
+	if f.WithFiles && len(note.FileIDs) == 0 {
+		return false
+	}
+
+	return true
+}

--- a/internal/stream/channels/note_filter_test.go
+++ b/internal/stream/channels/note_filter_test.go
@@ -1,0 +1,77 @@
+package channels
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestDefaultNoteFilter(t *testing.T) {
+	f := defaultNoteFilter()
+	assert.True(t, f.WithRenotes)
+	assert.False(t, f.WithReplies)
+	assert.False(t, f.WithFiles)
+}
+
+func TestParseNoteFilter_Empty(t *testing.T) {
+	f := parseNoteFilter(nil)
+	assert.True(t, f.WithRenotes)
+}
+
+func TestParseNoteFilter_Override(t *testing.T) {
+	f := parseNoteFilter(json.RawMessage(`{"withRenotes":false,"withReplies":true,"withFiles":true}`))
+	assert.False(t, f.WithRenotes)
+	assert.True(t, f.WithReplies)
+	assert.True(t, f.WithFiles)
+}
+
+func TestShouldEmit_PureRenoteFiltered(t *testing.T) {
+	f := noteFilter{WithRenotes: false, WithReplies: false, WithFiles: false}
+	// 純リノート: text=nil, renoteId!=nil
+	payload := []byte(`{"renoteId":"r1"}`)
+	assert.False(t, f.shouldEmit(payload))
+}
+
+func TestShouldEmit_QuoteRenoteAllowed(t *testing.T) {
+	f := noteFilter{WithRenotes: false, WithReplies: false, WithFiles: false}
+	// 引用リノート: text!=nil, renoteId!=nil → 通過
+	payload := []byte(`{"text":"hello","renoteId":"r1"}`)
+	assert.True(t, f.shouldEmit(payload))
+}
+
+func TestShouldEmit_ReplyFiltered(t *testing.T) {
+	f := noteFilter{WithRenotes: true, WithReplies: false, WithFiles: false}
+	payload := []byte(`{"text":"reply","replyId":"p1"}`)
+	assert.False(t, f.shouldEmit(payload))
+}
+
+func TestShouldEmit_ReplyAllowed(t *testing.T) {
+	f := noteFilter{WithRenotes: true, WithReplies: true, WithFiles: false}
+	payload := []byte(`{"text":"reply","replyId":"p1"}`)
+	assert.True(t, f.shouldEmit(payload))
+}
+
+func TestShouldEmit_WithFilesNoFiles(t *testing.T) {
+	f := noteFilter{WithRenotes: true, WithReplies: true, WithFiles: true}
+	payload := []byte(`{"text":"hello","fileIds":[]}`)
+	assert.False(t, f.shouldEmit(payload))
+}
+
+func TestShouldEmit_WithFilesHasFiles(t *testing.T) {
+	f := noteFilter{WithRenotes: true, WithReplies: true, WithFiles: true}
+	payload := []byte(`{"text":"hello","fileIds":["f1"]}`)
+	assert.True(t, f.shouldEmit(payload))
+}
+
+func TestShouldEmit_InvalidJSON(t *testing.T) {
+	f := noteFilter{WithRenotes: false}
+	// パース失敗時はそのまま送信
+	assert.True(t, f.shouldEmit([]byte(`{invalid`)))
+}
+
+func TestShouldEmit_NormalNote(t *testing.T) {
+	f := noteFilter{WithRenotes: true, WithReplies: false, WithFiles: false}
+	payload := []byte(`{"text":"hello"}`)
+	assert.True(t, f.shouldEmit(payload))
+}

--- a/internal/stream/channels/note_filter_test.go
+++ b/internal/stream/channels/note_filter_test.go
@@ -28,8 +28,8 @@ func TestParseNoteFilter_Override(t *testing.T) {
 
 func TestShouldEmit_PureRenoteFiltered(t *testing.T) {
 	f := noteFilter{WithRenotes: false, WithReplies: false, WithFiles: false}
-	// 純リノート: text=nil, renoteId!=nil
-	payload := []byte(`{"renoteId":"r1"}`)
+	// 純リノート: text=nil, renoteId!=nil, fileIds=[]
+	payload := []byte(`{"renoteId":"r1","fileIds":[]}`)
 	assert.False(t, f.shouldEmit(payload))
 }
 
@@ -37,6 +37,13 @@ func TestShouldEmit_QuoteRenoteAllowed(t *testing.T) {
 	f := noteFilter{WithRenotes: false, WithReplies: false, WithFiles: false}
 	// 引用リノート: text!=nil, renoteId!=nil → 通過
 	payload := []byte(`{"text":"hello","renoteId":"r1"}`)
+	assert.True(t, f.shouldEmit(payload))
+}
+
+func TestShouldEmit_RenoteWithFilesAllowed(t *testing.T) {
+	f := noteFilter{WithRenotes: false, WithReplies: false, WithFiles: false}
+	// ファイル添付付きリノート: text=nil, renoteId!=nil, fileIds非空 → 純リノートではない
+	payload := []byte(`{"renoteId":"r1","fileIds":["f1"]}`)
 	assert.True(t, f.shouldEmit(payload))
 }
 

--- a/internal/stream/channels/queue_stats.go
+++ b/internal/stream/channels/queue_stats.go
@@ -1,0 +1,35 @@
+package channels
+
+import (
+	"encoding/json"
+
+	"github.com/shiroha-a/mk/internal/stream"
+)
+
+// QueueStatsChannel broadcasts job queue statistics.
+type QueueStatsChannel struct {
+	ctx       stream.ChannelContext
+	connected bool
+}
+
+// NewQueueStats returns a channel factory for "queueStats".
+func NewQueueStats(ctx stream.ChannelContext) stream.Channel {
+	return &QueueStatsChannel{ctx: ctx}
+}
+
+func (c *QueueStatsChannel) Init(_ json.RawMessage) {
+	c.connected = true
+	c.ctx.Subscribe("queueStats")
+}
+
+func (c *QueueStatsChannel) OnRedisEvent(payload []byte) {
+	_ = c.ctx.Send("stats", json.RawMessage(payload))
+}
+
+func (c *QueueStatsChannel) OnClientMessage(string, json.RawMessage) {}
+
+func (c *QueueStatsChannel) Dispose() {
+	if c.connected {
+		c.ctx.Unsubscribe("queueStats")
+	}
+}

--- a/internal/stream/channels/reversi.go
+++ b/internal/stream/channels/reversi.go
@@ -1,0 +1,54 @@
+package channels
+
+import (
+	"encoding/json"
+
+	"github.com/shiroha-a/mk/internal/model"
+	"github.com/shiroha-a/mk/internal/stream"
+)
+
+// ReversiChannel forwards global reversi game events (match invitations, etc.).
+// reversiGameチャンネル（特定ゲームのイベント）とは異なり、ゲーム発見用。
+type ReversiChannel struct {
+	ctx       stream.ChannelContext
+	connected bool
+}
+
+// NewReversi returns a channel factory for "reversi".
+func NewReversi(ctx stream.ChannelContext) stream.Channel {
+	return &ReversiChannel{ctx: ctx}
+}
+
+func (c *ReversiChannel) Init(_ json.RawMessage) {
+	// 認証必須
+	user, ok := c.ctx.User().(*model.User)
+	if !ok || user == nil {
+		return
+	}
+	c.connected = true
+	c.ctx.Subscribe("reversi:" + user.ID)
+}
+
+func (c *ReversiChannel) OnRedisEvent(payload []byte) {
+	// {type, body}エンベロープの展開
+	var envelope struct {
+		Type string          `json:"type"`
+		Body json.RawMessage `json:"body"`
+	}
+	if err := json.Unmarshal(payload, &envelope); err == nil && envelope.Type != "" {
+		_ = c.ctx.Send(envelope.Type, envelope.Body)
+		return
+	}
+	_ = c.ctx.Send("reversiEvent", json.RawMessage(payload))
+}
+
+func (c *ReversiChannel) OnClientMessage(string, json.RawMessage) {}
+
+func (c *ReversiChannel) Dispose() {
+	if c.connected {
+		user, ok := c.ctx.User().(*model.User)
+		if ok && user != nil {
+			c.ctx.Unsubscribe("reversi:" + user.ID)
+		}
+	}
+}

--- a/internal/stream/channels/role_timeline.go
+++ b/internal/stream/channels/role_timeline.go
@@ -1,0 +1,49 @@
+package channels
+
+import (
+	"encoding/json"
+
+	"github.com/shiroha-a/mk/internal/stream"
+)
+
+// RoleTimelineChannel forwards notes from users with a specific role.
+type RoleTimelineChannel struct {
+	ctx    stream.ChannelContext
+	topic  string
+	filter noteFilter
+}
+
+// NewRoleTimeline returns a channel factory for "roleTimeline".
+func NewRoleTimeline(ctx stream.ChannelContext) stream.Channel {
+	return &RoleTimelineChannel{ctx: ctx}
+}
+
+func (c *RoleTimelineChannel) Init(params json.RawMessage) {
+	var p struct {
+		RoleID string `json:"roleId"`
+	}
+	if len(params) > 0 {
+		_ = json.Unmarshal(params, &p)
+	}
+	if p.RoleID == "" {
+		return
+	}
+	c.filter = parseNoteFilter(params)
+	c.topic = "roleTimeline:" + p.RoleID
+	c.ctx.Subscribe(c.topic)
+}
+
+func (c *RoleTimelineChannel) OnRedisEvent(payload []byte) {
+	if !c.filter.shouldEmit(payload) {
+		return
+	}
+	_ = c.ctx.Send("note", json.RawMessage(payload))
+}
+
+func (c *RoleTimelineChannel) OnClientMessage(string, json.RawMessage) {}
+
+func (c *RoleTimelineChannel) Dispose() {
+	if c.topic != "" {
+		c.ctx.Unsubscribe(c.topic)
+	}
+}

--- a/internal/stream/channels/server_stats.go
+++ b/internal/stream/channels/server_stats.go
@@ -1,0 +1,35 @@
+package channels
+
+import (
+	"encoding/json"
+
+	"github.com/shiroha-a/mk/internal/stream"
+)
+
+// ServerStatsChannel broadcasts server statistics.
+type ServerStatsChannel struct {
+	ctx       stream.ChannelContext
+	connected bool
+}
+
+// NewServerStats returns a channel factory for "serverStats".
+func NewServerStats(ctx stream.ChannelContext) stream.Channel {
+	return &ServerStatsChannel{ctx: ctx}
+}
+
+func (c *ServerStatsChannel) Init(_ json.RawMessage) {
+	c.connected = true
+	c.ctx.Subscribe("serverStats")
+}
+
+func (c *ServerStatsChannel) OnRedisEvent(payload []byte) {
+	_ = c.ctx.Send("stats", json.RawMessage(payload))
+}
+
+func (c *ServerStatsChannel) OnClientMessage(string, json.RawMessage) {}
+
+func (c *ServerStatsChannel) Dispose() {
+	if c.connected {
+		c.ctx.Unsubscribe("serverStats")
+	}
+}

--- a/internal/stream/channels/timeline.go
+++ b/internal/stream/channels/timeline.go
@@ -12,7 +12,8 @@ import (
 
 // LocalTimelineChannel forwards local-public/home notes.
 type LocalTimelineChannel struct {
-	ctx stream.ChannelContext
+	ctx    stream.ChannelContext
+	filter noteFilter
 }
 
 // NewLocalTimeline は ChannelFactory の形をした生成関数。Registry に
@@ -22,12 +23,16 @@ func NewLocalTimeline(ctx stream.ChannelContext) stream.Channel {
 }
 
 // Init subscribes to the local-timeline pubsub topic.
-func (c *LocalTimelineChannel) Init(_ json.RawMessage) {
+func (c *LocalTimelineChannel) Init(params json.RawMessage) {
+	c.filter = parseNoteFilter(params)
 	c.ctx.Subscribe("localTimeline")
 }
 
 // OnRedisEvent forwards a JSON-encoded note payload as a `note` event.
 func (c *LocalTimelineChannel) OnRedisEvent(payload []byte) {
+	if !c.filter.shouldEmit(payload) {
+		return
+	}
 	_ = c.ctx.Send("note", json.RawMessage(payload))
 }
 
@@ -41,7 +46,8 @@ func (c *LocalTimelineChannel) Dispose() {
 
 // GlobalTimelineChannel forwards every public note across the federation.
 type GlobalTimelineChannel struct {
-	ctx stream.ChannelContext
+	ctx    stream.ChannelContext
+	filter noteFilter
 }
 
 // NewGlobalTimeline returns a channel factory for "globalTimeline".
@@ -49,8 +55,14 @@ func NewGlobalTimeline(ctx stream.ChannelContext) stream.Channel {
 	return &GlobalTimelineChannel{ctx: ctx}
 }
 
-func (c *GlobalTimelineChannel) Init(_ json.RawMessage) { c.ctx.Subscribe("globalTimeline") }
+func (c *GlobalTimelineChannel) Init(params json.RawMessage) {
+	c.filter = parseNoteFilter(params)
+	c.ctx.Subscribe("globalTimeline")
+}
 func (c *GlobalTimelineChannel) OnRedisEvent(payload []byte) {
+	if !c.filter.shouldEmit(payload) {
+		return
+	}
 	_ = c.ctx.Send("note", json.RawMessage(payload))
 }
 func (c *GlobalTimelineChannel) OnClientMessage(string, json.RawMessage) {}
@@ -61,8 +73,9 @@ func (c *GlobalTimelineChannel) Dispose() {
 // HomeTimelineChannel forwards notes addressed to the authenticated user. 認証
 // 済みでない場合は subscribe しない (channel は接続するだけで何も送らない)。
 type HomeTimelineChannel struct {
-	ctx   stream.ChannelContext
-	topic string
+	ctx    stream.ChannelContext
+	topic  string
+	filter noteFilter
 }
 
 // NewHomeTimeline returns a channel factory for "homeTimeline".
@@ -70,7 +83,8 @@ func NewHomeTimeline(ctx stream.ChannelContext) stream.Channel {
 	return &HomeTimelineChannel{ctx: ctx}
 }
 
-func (c *HomeTimelineChannel) Init(_ json.RawMessage) {
+func (c *HomeTimelineChannel) Init(params json.RawMessage) {
+	c.filter = parseNoteFilter(params)
 	user, ok := c.ctx.User().(*model.User)
 	if !ok || user == nil {
 		return
@@ -80,6 +94,9 @@ func (c *HomeTimelineChannel) Init(_ json.RawMessage) {
 }
 
 func (c *HomeTimelineChannel) OnRedisEvent(payload []byte) {
+	if !c.filter.shouldEmit(payload) {
+		return
+	}
 	_ = c.ctx.Send("note", json.RawMessage(payload))
 }
 
@@ -97,6 +114,7 @@ func (c *HomeTimelineChannel) Dispose() {
 type HybridTimelineChannel struct {
 	ctx       stream.ChannelContext
 	homeTopic string
+	filter    noteFilter
 }
 
 // NewHybridTimeline returns a channel factory for "hybridTimeline".
@@ -104,7 +122,8 @@ func NewHybridTimeline(ctx stream.ChannelContext) stream.Channel {
 	return &HybridTimelineChannel{ctx: ctx}
 }
 
-func (c *HybridTimelineChannel) Init(_ json.RawMessage) {
+func (c *HybridTimelineChannel) Init(params json.RawMessage) {
+	c.filter = parseNoteFilter(params)
 	c.ctx.Subscribe("localTimeline")
 	if user, ok := c.ctx.User().(*model.User); ok && user != nil {
 		c.homeTopic = "homeTimeline:" + user.ID
@@ -113,6 +132,9 @@ func (c *HybridTimelineChannel) Init(_ json.RawMessage) {
 }
 
 func (c *HybridTimelineChannel) OnRedisEvent(payload []byte) {
+	if !c.filter.shouldEmit(payload) {
+		return
+	}
 	_ = c.ctx.Send("note", json.RawMessage(payload))
 }
 

--- a/internal/stream/channels/user_list.go
+++ b/internal/stream/channels/user_list.go
@@ -1,0 +1,60 @@
+package channels
+
+import (
+	"encoding/json"
+
+	"github.com/shiroha-a/mk/internal/model"
+	"github.com/shiroha-a/mk/internal/stream"
+)
+
+// UserListChannel forwards notes from members of a user list.
+type UserListChannel struct {
+	ctx    stream.ChannelContext
+	topic  string
+	filter noteFilter
+}
+
+// NewUserList returns a channel factory for "userList".
+func NewUserList(ctx stream.ChannelContext) stream.Channel {
+	return &UserListChannel{ctx: ctx}
+}
+
+func (c *UserListChannel) Init(params json.RawMessage) {
+	// 認証必須
+	user, ok := c.ctx.User().(*model.User)
+	if !ok || user == nil {
+		return
+	}
+	var p struct {
+		ListID      string `json:"listId"`
+		WithReplies *bool  `json:"withReplies"`
+	}
+	if len(params) > 0 {
+		_ = json.Unmarshal(params, &p)
+	}
+	if p.ListID == "" {
+		return
+	}
+	c.filter = parseNoteFilter(params)
+	// withRepliesパラメータがtrueなら上書き
+	if p.WithReplies != nil && *p.WithReplies {
+		c.filter.WithReplies = true
+	}
+	c.topic = "userListTimeline:" + p.ListID
+	c.ctx.Subscribe(c.topic)
+}
+
+func (c *UserListChannel) OnRedisEvent(payload []byte) {
+	if !c.filter.shouldEmit(payload) {
+		return
+	}
+	_ = c.ctx.Send("note", json.RawMessage(payload))
+}
+
+func (c *UserListChannel) OnClientMessage(string, json.RawMessage) {}
+
+func (c *UserListChannel) Dispose() {
+	if c.topic != "" {
+		c.ctx.Unsubscribe(c.topic)
+	}
+}


### PR DESCRIPTION
## Summary
- WebSocket欠損チャンネル9件を実装し、タイムラインフィルタパラメータを全4タイムラインチャンネルに追加

## 主な変更点
| ファイル | 操作 | 内容 |
|---------|------|------|
| `internal/stream/channels/note_filter.go` | 新規 | 共通フィルタロジック（withRenotes/withReplies/withFiles） |
| `internal/stream/channels/timeline.go` | 変更 | 4タイムラインチャンネルにフィルタ適用 |
| `internal/stream/channels/hashtag.go` | 新規 | ハッシュタグフィルタチャンネル |
| `internal/stream/channels/antenna.go` | 新規 | アンテナタイムラインチャンネル（認証必須） |
| `internal/stream/channels/channel_timeline.go` | 新規 | チャンネルタイムライン |
| `internal/stream/channels/user_list.go` | 新規 | ユーザーリストタイムライン（認証必須） |
| `internal/stream/channels/role_timeline.go` | 新規 | ロールタイムライン |
| `internal/stream/channels/admin.go` | 新規 | 管理者ストリーム（認証必須） |
| `internal/stream/channels/server_stats.go` | 新規 | サーバー統計ブロードキャスト |
| `internal/stream/channels/queue_stats.go` | 新規 | キュー統計ブロードキャスト |
| `internal/stream/channels/reversi.go` | 新規 | リバーシ待機チャンネル（認証必須） |
| `internal/server/router.go` | 変更 | 9チャンネルをRegistry登録 |

## テスト
- `internal/stream/channels`: **100%** coverage
- 全チャンネルのライフサイクル（Init/OnRedisEvent/Dispose）テスト
- フィルタパラメータの各パターン（純リノート除外、リプライ除外、ファイル付きのみ）テスト
- 認証なし時のno-op動作テスト

```bash
go test -race -count=1 -cover ./internal/stream/channels/...
```

Closes #125
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/shiroha-a/mk/pull/135" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
