### PR TITLE
Phase AP: Accept follow + Question/poll ingestion

### DIFF
--- a/internal/activitypub/types.go
+++ b/internal/activitypub/types.go
@@ -88,6 +88,24 @@ type Note struct {
 	MisskeyContent string   `json:"_misskey_content,omitempty"`
 	MisskeyQuote   string   `json:"_misskey_quote,omitempty"`
 	QuoteURL       string   `json:"quoteUrl,omitempty"`
+	// Question (poll) fields — AP Question typeで使用
+	OneOf   []QuestionChoice `json:"oneOf,omitempty"`
+	AnyOf   []QuestionChoice `json:"anyOf,omitempty"`
+	EndTime string           `json:"endTime,omitempty"`
+	Closed  string           `json:"closed,omitempty"`
+}
+
+// QuestionChoice represents a single choice in an AP Question (poll).
+type QuestionChoice struct {
+	Type    string                 `json:"type"` // "Note"
+	Name    string                 `json:"name"`
+	Replies *QuestionChoiceReplies `json:"replies,omitempty"`
+}
+
+// QuestionChoiceReplies holds the vote count for a poll choice.
+type QuestionChoiceReplies struct {
+	Type       string `json:"type"` // "Collection"
+	TotalItems int    `json:"totalItems"`
 }
 
 // Mention is an ActivityStreams Mention tag used inside Note.tag to inform

--- a/internal/core/federation/processor.go
+++ b/internal/core/federation/processor.go
@@ -341,9 +341,15 @@ func (p *Processor) handleAccept(act genericActivity) error {
 	if err != nil {
 		return nil
 	}
-	follower, err := p.userRepo.FindByURI(followerURI)
+	// ローカルユーザーはURIカラムがNULLなのでFindByURIでは見つからない。
+	// ローカルURI（/users/{id}）からIDを抽出してFindByIDで検索する。
+	var follower *model.User
+	if localID := p.resolver.ExtractLocalUserID(followerURI); localID != "" {
+		follower, err = p.userRepo.FindByID(localID)
+	} else {
+		follower, err = p.userRepo.FindByURI(followerURI)
+	}
 	if err != nil {
-		// ローカルユーザーが見つからない場合は無視
 		return nil
 	}
 	// フォローリクエストを承認してフォロー関係を確立

--- a/internal/core/federation/processor.go
+++ b/internal/core/federation/processor.go
@@ -320,13 +320,43 @@ func (p *Processor) handleUndoAnnounce(act genericActivity, inner genericActivit
 	return nil
 }
 
-// handleAccept currently only logs that an Accept was received. リモートからの
-// Acceptは主に follow request の承認なので、Step E 以降で完全実装する。
-func (p *Processor) handleAccept(_ genericActivity) error {
+// handleAccept processes an inbound Accept activity. リモートfolloweeがローカル
+// followerからのフォローリクエストを承認した場合に、フォロー関係を確立する。
+func (p *Processor) handleAccept(act genericActivity) error {
+	var inner genericActivity
+	if err := json.Unmarshal(act.Object, &inner); err != nil {
+		// objectが文字列（Follow IDのURI）の場合もあるが、現状はnilで許容
+		return nil
+	}
+	if !strings.EqualFold(inner.Type, "follow") {
+		return nil
+	}
+	// actorはリモートfollowee（承認した側）
+	followee, err := p.resolver.ResolveActor(act.Actor)
+	if err != nil {
+		return err
+	}
+	// inner.actorはローカルfollower（フォローを申請した側）
+	followerURI, err := readActorString(inner)
+	if err != nil {
+		return nil
+	}
+	follower, err := p.userRepo.FindByURI(followerURI)
+	if err != nil {
+		// ローカルユーザーが見つからない場合は無視
+		return nil
+	}
+	// フォローリクエストを承認してフォロー関係を確立
+	if err := p.followingService.AcceptRequest(followee.ID, follower.ID); err != nil {
+		// フォローリクエストがない場合もある（既にフォロー済み等）
+		// その場合はエラーにせず無視
+		return nil
+	}
 	return nil
 }
 
-// handleCreate persists an inbound Note carried by a Create activity.
+// handleCreate persists an inbound Note or Question carried by a Create activity.
+// Question (投票) はNote同様にIngestNoteで処理され、Pollレコードが自動作成される。
 func (p *Processor) handleCreate(act genericActivity) error {
 	if _, err := p.resolver.ResolveActor(act.Actor); err != nil {
 		return err

--- a/internal/core/federation/processor.go
+++ b/internal/core/federation/processor.go
@@ -354,9 +354,11 @@ func (p *Processor) handleAccept(act genericActivity) error {
 	}
 	// フォローリクエストを承認してフォロー関係を確立
 	if err := p.followingService.AcceptRequest(followee.ID, follower.ID); err != nil {
-		// フォローリクエストがない場合もある（既にフォロー済み等）
-		// その場合はエラーにせず無視
-		return nil
+		// フォローリクエストが存在しない場合は無視（既にフォロー済み等）
+		if errors.Is(err, corefollowing.ErrRequestNotFound) {
+			return nil
+		}
+		return err
 	}
 	return nil
 }

--- a/internal/core/federation/processor_test.go
+++ b/internal/core/federation/processor_test.go
@@ -740,6 +740,165 @@ func TestProcess_RemoveWithoutRepo(t *testing.T) {
 	assert.ErrorIs(t, p.Process(body), federation.ErrUnsupportedActivity)
 }
 
+// --- Accept ---
+
+func TestProcess_AcceptFollow(t *testing.T) {
+	p, repo, _, _ := newProcessor(t, aliceActor)
+	// ローカルユーザーbob（follower）を登録
+	repo.Users["bob"] = &model.User{ID: "bob", Username: "bob"}
+
+	// aliceからのAcceptを処理（bobからaliceへのFollow承認）
+	// ExtractLocalUserIDで /users/bob → ID "bob" と解決される
+	acceptBody := []byte(`{
+		"type": "Accept",
+		"actor": "https://remote.example/users/alice",
+		"object": {
+			"type": "Follow",
+			"actor": "https://example.com/users/bob",
+			"object": "https://remote.example/users/alice"
+		}
+	}`)
+	// AcceptRequest自体はフォローリクエストが存在しなくてもエラーにならない（nil返却）
+	require.NoError(t, p.Process(acceptBody))
+}
+
+func TestProcess_AcceptNonFollow(t *testing.T) {
+	p, _, _, _ := newProcessor(t, aliceActor)
+	// inner objectがFollowでない場合は無視
+	body := []byte(`{
+		"type": "Accept",
+		"actor": "https://remote.example/users/alice",
+		"object": {
+			"type": "Like",
+			"actor": "https://example.com/users/bob"
+		}
+	}`)
+	require.NoError(t, p.Process(body))
+}
+
+func TestProcess_AcceptBadObject(t *testing.T) {
+	p, _, _, _ := newProcessor(t, aliceActor)
+	// objectが文字列（Follow IDのURI）の場合は無視
+	body := []byte(`{
+		"type": "Accept",
+		"actor": "https://remote.example/users/alice",
+		"object": "https://remote.example/follows/123"
+	}`)
+	require.NoError(t, p.Process(body))
+}
+
+func TestProcess_AcceptUnknownFollower(t *testing.T) {
+	p, _, _, _ := newProcessor(t, aliceActor)
+	// followerが見つからない場合は無視
+	body := []byte(`{
+		"type": "Accept",
+		"actor": "https://remote.example/users/alice",
+		"object": {
+			"type": "Follow",
+			"actor": "https://example.com/users/ghost",
+			"object": "https://remote.example/users/alice"
+		}
+	}`)
+	require.NoError(t, p.Process(body))
+}
+
+// --- Question/Poll ---
+
+func TestProcess_CreateQuestion(t *testing.T) {
+	p, repo, _, noteRepo := newProcessor(t, aliceActor)
+	// resolverにpollRepoを注入するためresolverへのアクセスが必要
+	// newProcessorで作成されたresolverにSetPollRepoできないため、
+	// processor経由でresolverを取得する方法がない。代わりにfull setup。
+	pollRepo := testutil.NewMockPollRepository()
+	followingRepo := testutil.NewMockFollowingRepository()
+	urls := activitypub.NewURLBuilder("https://example.com")
+	idGen2, _ := id.NewGenerator("aidx")
+	resolver := federation.NewResolver(repo, noteRepo, urls, &stubFetcher{body: []byte(aliceActor)}, idGen2)
+	resolver.SetPollRepo(pollRepo)
+	followingSvc := corefollowing.NewService(repo, followingRepo, testutil.NewMockFollowRequestRepository(), idGen2)
+	p = federation.NewProcessor(resolver, followingSvc, nil, nil, repo, noteRepo)
+
+	body := []byte(`{
+		"type": "Create",
+		"actor": "https://remote.example/users/alice",
+		"object": {
+			"type": "Question",
+			"id": "https://remote.example/notes/q1",
+			"attributedTo": "https://remote.example/users/alice",
+			"content": "Best language?",
+			"oneOf": [
+				{"type": "Note", "name": "Go", "replies": {"type": "Collection", "totalItems": 5}},
+				{"type": "Note", "name": "Rust", "replies": {"type": "Collection", "totalItems": 3}}
+			],
+			"endTime": "2026-12-31T23:59:59Z",
+			"to": ["https://www.w3.org/ns/activitystreams#Public"]
+		}
+	}`)
+	require.NoError(t, p.Process(body))
+	// ノートが作成されていること
+	assert.True(t, len(noteRepo.Notes) > 0)
+	// Pollが作成されていること
+	assert.Len(t, pollRepo.Polls, 1)
+	for _, poll := range pollRepo.Polls {
+		assert.False(t, poll.Multiple) // oneOf → single choice
+		assert.Len(t, poll.Choices, 2)
+		assert.Equal(t, "Go", poll.Choices[0])
+		assert.Equal(t, "Rust", poll.Choices[1])
+	}
+}
+
+func TestProcess_CreateQuestionAnyOf(t *testing.T) {
+	repo := testutil.NewMockUserRepository()
+	noteRepo := testutil.NewMockNoteRepository()
+	pollRepo := testutil.NewMockPollRepository()
+	followingRepo := testutil.NewMockFollowingRepository()
+	urls := activitypub.NewURLBuilder("https://example.com")
+	idGen2, _ := id.NewGenerator("aidx")
+	resolver := federation.NewResolver(repo, noteRepo, urls, &stubFetcher{body: []byte(aliceActor)}, idGen2)
+	resolver.SetPollRepo(pollRepo)
+	followingSvc := corefollowing.NewService(repo, followingRepo, testutil.NewMockFollowRequestRepository(), idGen2)
+	p := federation.NewProcessor(resolver, followingSvc, nil, nil, repo, noteRepo)
+
+	body := []byte(`{
+		"type": "Create",
+		"actor": "https://remote.example/users/alice",
+		"object": {
+			"type": "Question",
+			"id": "https://remote.example/notes/q2",
+			"attributedTo": "https://remote.example/users/alice",
+			"content": "Pick all that apply",
+			"anyOf": [
+				{"type": "Note", "name": "A"},
+				{"type": "Note", "name": "B"},
+				{"type": "Note", "name": "C"}
+			],
+			"closed": "2026-12-31T23:59:59Z",
+			"to": ["https://www.w3.org/ns/activitystreams#Public"]
+		}
+	}`)
+	require.NoError(t, p.Process(body))
+	assert.Len(t, pollRepo.Polls, 1)
+	for _, poll := range pollRepo.Polls {
+		assert.True(t, poll.Multiple) // anyOf → multiple choice
+		assert.Len(t, poll.Choices, 3)
+		assert.NotNil(t, poll.ExpiresAt) // closedから設定
+	}
+}
+
+// --- ExtractLocalUserID ---
+
+func TestExtractLocalUserID(t *testing.T) {
+	repo := testutil.NewMockUserRepository()
+	noteRepo := testutil.NewMockNoteRepository()
+	urls := activitypub.NewURLBuilder("https://example.com")
+	idGen, _ := id.NewGenerator("aidx")
+	resolver := federation.NewResolver(repo, noteRepo, urls, &stubFetcher{body: []byte(aliceActor)}, idGen)
+
+	assert.Equal(t, "abc123", resolver.ExtractLocalUserID("https://example.com/users/abc123"))
+	assert.Equal(t, "", resolver.ExtractLocalUserID("https://remote.example/users/abc123"))
+	assert.Equal(t, "", resolver.ExtractLocalUserID(""))
+}
+
 func TestProcess_FlagWithoutRepo(t *testing.T) {
 	p, _, _, _ := newProcessor(t, aliceActor)
 	body := []byte(`{

--- a/internal/core/federation/resolver.go
+++ b/internal/core/federation/resolver.go
@@ -86,6 +86,7 @@ type Resolver struct {
 	instanceTracker InstanceTracker           // optional: ホスト発見を通知
 	chartHook       ChartHook                 // optional: 新規 remote user の集計
 	publickeyRepo   PublickeyStore            // optional: 公開鍵の永続化
+	pollRepo        repository.PollRepository // optional: Question(投票)のPoll作成
 }
 
 // NewResolver constructs a Resolver.
@@ -142,6 +143,11 @@ func (r *Resolver) SetChartHook(h ChartHook) {
 // storage. nil 渡しは無効化と同義 (in-memory only に戻る)。
 func (r *Resolver) SetPublickeyRepo(repo PublickeyStore) {
 	r.publickeyRepo = repo
+}
+
+// SetPollRepo attaches a PollRepository for ingesting Question (poll) objects.
+func (r *Resolver) SetPollRepo(repo repository.PollRepository) {
+	r.pollRepo = repo
 }
 
 // PublicKeyForActor returns the cached public key PEM for an actor ID.
@@ -445,6 +451,10 @@ func (r *Resolver) IngestNote(body []byte) (*model.Note, error) {
 	if apNote.Content != "" {
 		note.Mentions = corenote.ExtractMentions(apNote.Content)
 	}
+	// Question（投票）の場合はhasPollフラグをCreate前に設定
+	if len(apNote.OneOf) > 0 || len(apNote.AnyOf) > 0 {
+		note.HasPoll = true
+	}
 	if err := r.noteRepo.Create(note); err != nil {
 		return nil, err
 	}
@@ -454,7 +464,49 @@ func (r *Resolver) IngestNote(body []byte) (*model.Note, error) {
 	if note.ReplyID != nil {
 		_ = r.noteRepo.IncrementCount(*note.ReplyID, "repliesCount", 1)
 	}
+	// Question (投票) の処理: oneOf/anyOf から Poll レコードを作成
+	if r.pollRepo != nil && note.HasPoll {
+		r.createPollFromQuestion(note, &apNote)
+	}
 	return note, nil
+}
+
+// createPollFromQuestion creates a Poll record from an AP Question's oneOf/anyOf choices.
+func (r *Resolver) createPollFromQuestion(note *model.Note, apNote *activitypub.Note) {
+	choices := apNote.OneOf
+	multiple := false
+	if len(apNote.AnyOf) > 0 {
+		choices = apNote.AnyOf
+		multiple = true
+	}
+	choiceNames := make([]string, len(choices))
+	votes := make([]int64, len(choices))
+	for i, c := range choices {
+		choiceNames[i] = c.Name
+		if c.Replies != nil {
+			votes[i] = int64(c.Replies.TotalItems)
+		}
+	}
+	poll := &model.Poll{
+		NoteID:         note.ID,
+		Multiple:       multiple,
+		Choices:        choiceNames,
+		Votes:          votes,
+		NoteVisibility: note.Visibility,
+		UserID:         note.UserID,
+		UserHost:       note.UserHost,
+	}
+	// endTime/closedから有効期限を設定
+	if apNote.EndTime != "" {
+		if t, err := time.Parse(time.RFC3339, apNote.EndTime); err == nil {
+			poll.ExpiresAt = &t
+		}
+	} else if apNote.Closed != "" {
+		if t, err := time.Parse(time.RFC3339, apNote.Closed); err == nil {
+			poll.ExpiresAt = &t
+		}
+	}
+	_ = r.pollRepo.Create(poll)
 }
 
 // UpdateRemoteNote applies an inbound Update Note activity body to an existing

--- a/internal/core/federation/resolver.go
+++ b/internal/core/federation/resolver.go
@@ -569,6 +569,23 @@ func (r *Resolver) UpdateRemoteNote(body []byte) (*model.Note, error) {
 	return existing, nil
 }
 
+// ExtractLocalUserID returns the user ID for a URI matching the local
+// /users/{id} pattern, or "" if the URI does not match.
+func (r *Resolver) ExtractLocalUserID(uri string) string {
+	if r.urls == nil {
+		return ""
+	}
+	prefix := r.urls.UserURI("")
+	if !strings.HasPrefix(uri, prefix) {
+		return ""
+	}
+	rest := uri[len(prefix):]
+	if i := strings.Index(rest, "/"); i >= 0 {
+		rest = rest[:i]
+	}
+	return rest
+}
+
 // extractLocalNoteID returns the trailing note ID for a URI rooted at the
 // local instance, or "" if the URI does not match the local pattern.
 func (r *Resolver) extractLocalNoteID(uri string) string {

--- a/internal/server/router.go
+++ b/internal/server/router.go
@@ -352,6 +352,7 @@ func (s *Server) setupRoutes() {
 	federationResolver := corefederation.NewResolver(userRepo, noteRepo, apURLs, apFetcher, idGen)
 	publickeyRepo := repository.NewUserPublickeyRepository(s.db)
 	federationResolver.SetPublickeyRepo(publickeyRepo)
+	federationResolver.SetPollRepo(pollRepo)
 	federationProcessor := corefederation.NewProcessor(federationResolver, followingService, reactionService, noteDeleteService, userRepo, noteRepo)
 
 	// Instance management (Phase 3 Step H)


### PR DESCRIPTION
## Summary
- handleAccept完全実装: Follow Acceptでフォローリクエスト承認→フォロー関係確立
- Question（投票）受信対応: AP QuestionのoneOf/anyOfからPollレコード自動作成
- EmojiReaction/EmojiReactバリアントは#126で対応済み

## 主な変更点
| ファイル | 内容 |
|---------|------|
| `processor.go` | handleAccept: inner Followを解析してAcceptRequest呼び出し |
| `types.go` | AP NoteにOneOf/AnyOf/EndTime/Closed + QuestionChoice型追加 |
| `resolver.go` | IngestNoteでPollレコード作成、SetPollRepo setter追加 |
| `router.go` | federationResolverにpollRepo注入 |

## テスト
```bash
go test -race -count=1 -cover ./internal/core/federation/...
```
- coverage: 88.1% (CI閾値90%未満だが既存コードの未カバー部分含む)

Closes #127
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/shiroha-a/mk/pull/137" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
