### PR TITLE
Phase P2: apierr package + unify NO_SUCH_NOTE UUIDs (#130 Phase 1)

### DIFF
--- a/internal/api/apierr/errors.go
+++ b/internal/api/apierr/errors.go
@@ -25,7 +25,7 @@ func Error(code, message, id string) map[string]any {
 const (
 	UUIDInvalidParam  = "3d81ceae-475f-4600-b2a8-2bc116157532"
 	UUIDInternalError = "5d37dbcb-891e-41ca-a3d6-e690c97775ac"
-	UUIDNoSuchNote    = "24fcbfc6-2e37-42b6-8388-c29b3272571530"
+	UUIDNoSuchNote    = "24fcbfc6-2e37-42b6-8388-c29b32725715"
 	UUIDNoSuchUser    = "4362f8dc-731f-4ad8-a694-be5a88922a24"
 	UUIDAccessDenied  = "1fb7cb09-d46a-4fff-b8df-057708cce513"
 )

--- a/internal/api/apierr/errors.go
+++ b/internal/api/apierr/errors.go
@@ -1,0 +1,56 @@
+// Package apierr provides Misskey-compatible error response helpers
+// shared across all API handlers.
+//
+// All error responses follow the format:
+//
+//	{"error": {"message": ..., "code": ..., "id": ...}}
+//
+// Frequently used errors have canonical UUIDs to avoid drift between handlers.
+package apierr
+
+// Error returns a Misskey-compatible error response map.
+// The returned map is safe to pass to echo.Context.JSON.
+func Error(code, message, id string) map[string]any {
+	return map[string]any{
+		"error": map[string]any{
+			"message": message,
+			"code":    code,
+			"id":      id,
+		},
+	}
+}
+
+// Canonical UUIDs for frequently-used error codes.
+// Any handler returning these codes should use the constants to prevent drift.
+const (
+	UUIDInvalidParam  = "3d81ceae-475f-4600-b2a8-2bc116157532"
+	UUIDInternalError = "5d37dbcb-891e-41ca-a3d6-e690c97775ac"
+	UUIDNoSuchNote    = "24fcbfc6-2e37-42b6-8388-c29b3272571530"
+	UUIDNoSuchUser    = "4362f8dc-731f-4ad8-a694-be5a88922a24"
+	UUIDAccessDenied  = "1fb7cb09-d46a-4fff-b8df-057708cce513"
+)
+
+// InvalidParam returns a 400 INVALID_PARAM error response.
+func InvalidParam() map[string]any {
+	return Error("INVALID_PARAM", "Invalid param.", UUIDInvalidParam)
+}
+
+// InternalError returns a 500 INTERNAL_ERROR error response.
+func InternalError() map[string]any {
+	return Error("INTERNAL_ERROR", "Internal error.", UUIDInternalError)
+}
+
+// NoSuchNote returns a 404 NO_SUCH_NOTE error response.
+func NoSuchNote() map[string]any {
+	return Error("NO_SUCH_NOTE", "No such note.", UUIDNoSuchNote)
+}
+
+// NoSuchUser returns a 404 NO_SUCH_USER error response.
+func NoSuchUser() map[string]any {
+	return Error("NO_SUCH_USER", "No such user.", UUIDNoSuchUser)
+}
+
+// AccessDenied returns a 403 ACCESS_DENIED error response.
+func AccessDenied() map[string]any {
+	return Error("ACCESS_DENIED", "Access denied.", UUIDAccessDenied)
+}

--- a/internal/api/apierr/errors_test.go
+++ b/internal/api/apierr/errors_test.go
@@ -1,0 +1,51 @@
+package apierr
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestError_Structure(t *testing.T) {
+	result := Error("INVALID_PARAM", "Invalid.", "abc-123")
+	errObj, ok := result["error"].(map[string]any)
+	assert.True(t, ok)
+	assert.Equal(t, "Invalid.", errObj["message"])
+	assert.Equal(t, "INVALID_PARAM", errObj["code"])
+	assert.Equal(t, "abc-123", errObj["id"])
+}
+
+func TestInvalidParam(t *testing.T) {
+	result := InvalidParam()
+	errObj := result["error"].(map[string]any)
+	assert.Equal(t, "INVALID_PARAM", errObj["code"])
+	assert.Equal(t, UUIDInvalidParam, errObj["id"])
+}
+
+func TestInternalError(t *testing.T) {
+	result := InternalError()
+	errObj := result["error"].(map[string]any)
+	assert.Equal(t, "INTERNAL_ERROR", errObj["code"])
+	assert.Equal(t, UUIDInternalError, errObj["id"])
+}
+
+func TestNoSuchNote(t *testing.T) {
+	result := NoSuchNote()
+	errObj := result["error"].(map[string]any)
+	assert.Equal(t, "NO_SUCH_NOTE", errObj["code"])
+	assert.Equal(t, UUIDNoSuchNote, errObj["id"])
+}
+
+func TestNoSuchUser(t *testing.T) {
+	result := NoSuchUser()
+	errObj := result["error"].(map[string]any)
+	assert.Equal(t, "NO_SUCH_USER", errObj["code"])
+	assert.Equal(t, UUIDNoSuchUser, errObj["id"])
+}
+
+func TestAccessDenied(t *testing.T) {
+	result := AccessDenied()
+	errObj := result["error"].(map[string]any)
+	assert.Equal(t, "ACCESS_DENIED", errObj["code"])
+	assert.Equal(t, UUIDAccessDenied, errObj["id"])
+}

--- a/internal/api/clips/handler.go
+++ b/internal/api/clips/handler.go
@@ -312,7 +312,7 @@ func notFoundNote(c echo.Context) error {
 		"error": map[string]any{
 			"message": "No such note.",
 			"code":    "NO_SUCH_NOTE",
-			"id":      "fc8c0b49-c7a3-4664-a0a6-b418d386bb8d",
+			"id":      "24fcbfc6-2e37-42b6-8388-c29b3272571530",
 		},
 	})
 }

--- a/internal/api/clips/handler.go
+++ b/internal/api/clips/handler.go
@@ -312,7 +312,7 @@ func notFoundNote(c echo.Context) error {
 		"error": map[string]any{
 			"message": "No such note.",
 			"code":    "NO_SUCH_NOTE",
-			"id":      "24fcbfc6-2e37-42b6-8388-c29b3272571530",
+			"id":      "24fcbfc6-2e37-42b6-8388-c29b32725715",
 		},
 	})
 }

--- a/internal/api/i/handler.go
+++ b/internal/api/i/handler.go
@@ -536,7 +536,7 @@ func (h *Handler) Pin(c echo.Context) error {
 	if err := h.userService.PinNote(me.ID, req.NoteID); err != nil {
 		switch {
 		case errors.Is(err, user.ErrNoteNotFound):
-			return c.JSON(http.StatusNotFound, errEnvelope("No such note.", "NO_SUCH_NOTE", "24fcbfc6-2e37-42b6-8388-c29b3272571530"))
+			return c.JSON(http.StatusNotFound, errEnvelope("No such note.", "NO_SUCH_NOTE", "24fcbfc6-2e37-42b6-8388-c29b32725715"))
 		case errors.Is(err, user.ErrAlreadyPinned):
 			return c.JSON(http.StatusBadRequest, errEnvelope("That note has already been pinned.", "ALREADY_PINNED", "8b18c2b7-68fe-4edb-9892-c0cbaeb6c913"))
 		case errors.Is(err, user.ErrPinLimitExceeded):
@@ -560,7 +560,7 @@ func (h *Handler) Unpin(c echo.Context) error {
 
 	if err := h.userService.UnpinNote(me.ID, req.NoteID); err != nil {
 		if errors.Is(err, user.ErrPinNotFound) {
-			return c.JSON(http.StatusNotFound, errEnvelope("No such note.", "NO_SUCH_NOTE", "24fcbfc6-2e37-42b6-8388-c29b3272571530"))
+			return c.JSON(http.StatusNotFound, errEnvelope("No such note.", "NO_SUCH_NOTE", "24fcbfc6-2e37-42b6-8388-c29b32725715"))
 		}
 		return internalError(c)
 	}

--- a/internal/api/i/handler.go
+++ b/internal/api/i/handler.go
@@ -536,7 +536,7 @@ func (h *Handler) Pin(c echo.Context) error {
 	if err := h.userService.PinNote(me.ID, req.NoteID); err != nil {
 		switch {
 		case errors.Is(err, user.ErrNoteNotFound):
-			return c.JSON(http.StatusNotFound, errEnvelope("No such note.", "NO_SUCH_NOTE", "56734f8b-3928-431e-bf80-6ff87df40cb3"))
+			return c.JSON(http.StatusNotFound, errEnvelope("No such note.", "NO_SUCH_NOTE", "24fcbfc6-2e37-42b6-8388-c29b3272571530"))
 		case errors.Is(err, user.ErrAlreadyPinned):
 			return c.JSON(http.StatusBadRequest, errEnvelope("That note has already been pinned.", "ALREADY_PINNED", "8b18c2b7-68fe-4edb-9892-c0cbaeb6c913"))
 		case errors.Is(err, user.ErrPinLimitExceeded):
@@ -560,7 +560,7 @@ func (h *Handler) Unpin(c echo.Context) error {
 
 	if err := h.userService.UnpinNote(me.ID, req.NoteID); err != nil {
 		if errors.Is(err, user.ErrPinNotFound) {
-			return c.JSON(http.StatusNotFound, errEnvelope("No such note.", "NO_SUCH_NOTE", "454170ce-44d9-4d2a-94fc-e6854ec2f7d1"))
+			return c.JSON(http.StatusNotFound, errEnvelope("No such note.", "NO_SUCH_NOTE", "24fcbfc6-2e37-42b6-8388-c29b3272571530"))
 		}
 		return internalError(c)
 	}

--- a/internal/api/notes/handler.go
+++ b/internal/api/notes/handler.go
@@ -167,7 +167,7 @@ func (h *Handler) Create(c echo.Context) error {
 				"error": map[string]any{
 					"message": "No such note.",
 					"code":    "NO_SUCH_NOTE",
-					"id":      "24fcbfc6-2e37-42b6-8388-c29b3272571530",
+					"id":      "24fcbfc6-2e37-42b6-8388-c29b32725715",
 				},
 			})
 		case errors.Is(err, note.ErrCannotReplyToInvisibleNote), errors.Is(err, note.ErrCannotRenoteInvisibleNote):
@@ -247,7 +247,7 @@ func (h *Handler) Delete(c echo.Context) error {
 				"error": map[string]any{
 					"message": "No such note.",
 					"code":    "NO_SUCH_NOTE",
-					"id":      "24fcbfc6-2e37-42b6-8388-c29b3272571530",
+					"id":      "24fcbfc6-2e37-42b6-8388-c29b32725715",
 				},
 			})
 		case errors.Is(err, note.ErrNoteAccessDenied):
@@ -542,7 +542,7 @@ func noSuchNote(c echo.Context) error {
 		"error": map[string]any{
 			"message": "No such note.",
 			"code":    "NO_SUCH_NOTE",
-			"id":      "24fcbfc6-2e37-42b6-8388-c29b3272571530",
+			"id":      "24fcbfc6-2e37-42b6-8388-c29b32725715",
 		},
 	})
 }

--- a/internal/api/notes/handler.go
+++ b/internal/api/notes/handler.go
@@ -167,7 +167,7 @@ func (h *Handler) Create(c echo.Context) error {
 				"error": map[string]any{
 					"message": "No such note.",
 					"code":    "NO_SUCH_NOTE",
-					"id":      "eef6c173-3010-4a23-8674-7c4fcaeba719",
+					"id":      "24fcbfc6-2e37-42b6-8388-c29b3272571530",
 				},
 			})
 		case errors.Is(err, note.ErrCannotReplyToInvisibleNote), errors.Is(err, note.ErrCannotRenoteInvisibleNote):
@@ -247,7 +247,7 @@ func (h *Handler) Delete(c echo.Context) error {
 				"error": map[string]any{
 					"message": "No such note.",
 					"code":    "NO_SUCH_NOTE",
-					"id":      "490be23f-8c1f-4796-819f-94cb4f9d1630",
+					"id":      "24fcbfc6-2e37-42b6-8388-c29b3272571530",
 				},
 			})
 		case errors.Is(err, note.ErrNoteAccessDenied):

--- a/internal/api/notes/handler_extra.go
+++ b/internal/api/notes/handler_extra.go
@@ -26,7 +26,7 @@ func (h *Handler) FavoritesCreate(c echo.Context) error {
 		return c.JSON(http.StatusBadRequest, apiError("INVALID_PARAM", "noteId is required.", "3d81ceae-475f-4600-b2a8-2bc116157532"))
 	}
 	if _, err := h.noteRepo.FindByID(req.NoteID); err != nil {
-		return c.JSON(http.StatusNotFound, apiError("NO_SUCH_NOTE", "No such note.", "24fcbfc6-2e37-42b6-8388-c29b3272571530"))
+		return c.JSON(http.StatusNotFound, apiError("NO_SUCH_NOTE", "No such note.", "24fcbfc6-2e37-42b6-8388-c29b32725715"))
 	}
 	if h.favoriteRepo == nil {
 		return c.JSON(http.StatusInternalServerError, apiError("INTERNAL_ERROR", "Internal error.", "5d37dbcb-891e-41ca-a3d6-e690c97775ac"))
@@ -96,7 +96,7 @@ func (h *Handler) Unrenote(c echo.Context) error {
 	// renoteId が指定ノートの自分のノートを探して削除
 	renote, err := h.noteRepo.FindRenoteByUser(user.ID, req.NoteID)
 	if err != nil {
-		return c.JSON(http.StatusNotFound, apiError("NO_SUCH_NOTE", "No such renote.", "24fcbfc6-2e37-42b6-8388-c29b3272571530"))
+		return c.JSON(http.StatusNotFound, apiError("NO_SUCH_NOTE", "No such renote.", "24fcbfc6-2e37-42b6-8388-c29b32725715"))
 	}
 	if err := h.deleteService.Delete(user, renote.ID); err != nil {
 		return c.JSON(http.StatusInternalServerError, apiError("INTERNAL_ERROR", "Internal error.", "5d37dbcb-891e-41ca-a3d6-e690c97775ac"))
@@ -201,7 +201,7 @@ func (h *Handler) Translate(c echo.Context) error {
 
 	n, err := h.noteRepo.FindByID(req.NoteID)
 	if err != nil {
-		return c.JSON(http.StatusNotFound, apiError("NO_SUCH_NOTE", "No such note.", "24fcbfc6-2e37-42b6-8388-c29b3272571530"))
+		return c.JSON(http.StatusNotFound, apiError("NO_SUCH_NOTE", "No such note.", "24fcbfc6-2e37-42b6-8388-c29b32725715"))
 	}
 
 	if n.Text == nil || *n.Text == "" {

--- a/internal/api/notes/handler_extra.go
+++ b/internal/api/notes/handler_extra.go
@@ -26,7 +26,7 @@ func (h *Handler) FavoritesCreate(c echo.Context) error {
 		return c.JSON(http.StatusBadRequest, apiError("INVALID_PARAM", "noteId is required.", "3d81ceae-475f-4600-b2a8-2bc116157532"))
 	}
 	if _, err := h.noteRepo.FindByID(req.NoteID); err != nil {
-		return c.JSON(http.StatusNotFound, apiError("NO_SUCH_NOTE", "No such note.", "a6584e14-6e01-4ad3-b566-851571b1e7c6"))
+		return c.JSON(http.StatusNotFound, apiError("NO_SUCH_NOTE", "No such note.", "24fcbfc6-2e37-42b6-8388-c29b3272571530"))
 	}
 	if h.favoriteRepo == nil {
 		return c.JSON(http.StatusInternalServerError, apiError("INTERNAL_ERROR", "Internal error.", "5d37dbcb-891e-41ca-a3d6-e690c97775ac"))
@@ -96,7 +96,7 @@ func (h *Handler) Unrenote(c echo.Context) error {
 	// renoteId が指定ノートの自分のノートを探して削除
 	renote, err := h.noteRepo.FindRenoteByUser(user.ID, req.NoteID)
 	if err != nil {
-		return c.JSON(http.StatusNotFound, apiError("NO_SUCH_NOTE", "No such renote.", "a6584e14-6e01-4ad3-b566-851571b1e7c6"))
+		return c.JSON(http.StatusNotFound, apiError("NO_SUCH_NOTE", "No such renote.", "24fcbfc6-2e37-42b6-8388-c29b3272571530"))
 	}
 	if err := h.deleteService.Delete(user, renote.ID); err != nil {
 		return c.JSON(http.StatusInternalServerError, apiError("INTERNAL_ERROR", "Internal error.", "5d37dbcb-891e-41ca-a3d6-e690c97775ac"))
@@ -201,7 +201,7 @@ func (h *Handler) Translate(c echo.Context) error {
 
 	n, err := h.noteRepo.FindByID(req.NoteID)
 	if err != nil {
-		return c.JSON(http.StatusNotFound, apiError("NO_SUCH_NOTE", "No such note.", "bea9b03f-36e0-49c5-a4db-369571c8c0d4"))
+		return c.JSON(http.StatusNotFound, apiError("NO_SUCH_NOTE", "No such note.", "24fcbfc6-2e37-42b6-8388-c29b3272571530"))
 	}
 
 	if n.Text == nil || *n.Text == "" {

--- a/internal/server/router.go
+++ b/internal/server/router.go
@@ -1551,7 +1551,7 @@ func (s *Server) setupRoutes() {
 				"error": map[string]any{
 					"message": "No such note.",
 					"code":    "NO_SUCH_NOTE",
-					"id":      "fc8c0b49-c7a3-4664-a0a6-b418d386bb8d",
+					"id":      "24fcbfc6-2e37-42b6-8388-c29b3272571530",
 				},
 			})
 		}

--- a/internal/server/router.go
+++ b/internal/server/router.go
@@ -1551,7 +1551,7 @@ func (s *Server) setupRoutes() {
 				"error": map[string]any{
 					"message": "No such note.",
 					"code":    "NO_SUCH_NOTE",
-					"id":      "24fcbfc6-2e37-42b6-8388-c29b3272571530",
+					"id":      "24fcbfc6-2e37-42b6-8388-c29b32725715",
 				},
 			})
 		}


### PR DESCRIPTION
## Summary
- 共通エラーパッケージ `internal/api/apierr` を作成
- `NO_SUCH_NOTE`の6つの異なるUUIDを単一UUIDに統一

## 主な変更点
| ファイル | 内容 |
|---------|------|
| `internal/api/apierr/errors.go`（新規） | `Error()`関数 + 5ヘルパー（InvalidParam, InternalError, NoSuchNote, NoSuchUser, AccessDenied） + UUID定数 |
| `internal/api/apierr/errors_test.go`（新規） | 6テスト、カバレッジ100% |
| `internal/api/clips/handler.go` | fc8c0b49 → 24fcbfc6 |
| `internal/api/i/handler.go` | 56734f8b, 454170ce → 24fcbfc6 |
| `internal/api/notes/handler.go` | eef6c173, 490be23f → 24fcbfc6 |
| `internal/api/notes/handler_extra.go` | a6584e14, bea9b03f → 24fcbfc6 |
| `internal/server/router.go` | fc8c0b49 → 24fcbfc6 |

## 結果
全ての`NO_SUCH_NOTE`が`24fcbfc6-2e37-42b6-8388-c29b3272571530`に統一。

## スコープ外（後続PRで対応）
- 各ハンドラの`apiError`/`errEnvelope`/`errResp`ヘルパー関数を`apierr`にマイグレーション
- インラインヘルパー（`invalidParam(c)`等）の移行

#130 は規模が大きいため段階的に進める。本PRは Phase 1（基盤整備 + UUID統一）。

## テスト
```bash
go test -race -count=1 -cover ./internal/api/apierr/...
go test -race -count=1 ./internal/api/i/... ./internal/api/notes/... ./internal/api/clips/...
```
- apierr: **100%** coverage
- 既存ハンドラテスト全パス

Refs #130
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/shiroha-a/mk/pull/140" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
