### PR TITLE
Phase P2: delegate local error helpers to apierr (#130 Phase 2-1)

### DIFF
--- a/internal/api/admin/handler.go
+++ b/internal/api/admin/handler.go
@@ -5,6 +5,7 @@ import (
 	"time"
 
 	"github.com/labstack/echo/v4"
+	"github.com/shiroha-a/mk/internal/api/apierr"
 	"github.com/shiroha-a/mk/internal/core/role"
 	"github.com/shiroha-a/mk/internal/core/signup"
 	"github.com/shiroha-a/mk/internal/entity"
@@ -921,11 +922,5 @@ func (h *Handler) ShowModerationLogs(c echo.Context) error {
 }
 
 func errResp(code, message, id string) map[string]any {
-	return map[string]any{
-		"error": map[string]any{
-			"message": message,
-			"code":    code,
-			"id":      id,
-		},
-	}
+	return apierr.Error(code, message, id)
 }

--- a/internal/api/announcements/handler.go
+++ b/internal/api/announcements/handler.go
@@ -5,6 +5,7 @@ import (
 	"time"
 
 	"github.com/labstack/echo/v4"
+	"github.com/shiroha-a/mk/internal/api/apierr"
 	"github.com/shiroha-a/mk/internal/misc/id"
 	"github.com/shiroha-a/mk/internal/model"
 	"github.com/shiroha-a/mk/internal/repository"
@@ -196,11 +197,5 @@ func packAnnouncement(a *model.Announcement, idGen id.Generator) map[string]any 
 }
 
 func errResp(code, message, id string) map[string]any {
-	return map[string]any{
-		"error": map[string]any{
-			"message": message,
-			"code":    code,
-			"id":      id,
-		},
-	}
+	return apierr.Error(code, message, id)
 }

--- a/internal/api/app/handler.go
+++ b/internal/api/app/handler.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/labstack/echo/v4"
 	"github.com/lib/pq"
+	"github.com/shiroha-a/mk/internal/api/apierr"
 	"github.com/shiroha-a/mk/internal/misc"
 	"github.com/shiroha-a/mk/internal/misc/id"
 	"github.com/shiroha-a/mk/internal/model"
@@ -25,9 +26,7 @@ func NewHandler(repo repository.AuthSessionRepository, idGen id.Generator) *Hand
 }
 
 func apiError(code, message, errID string) map[string]any {
-	return map[string]any{
-		"error": map[string]any{"message": message, "code": code, "id": errID},
-	}
+	return apierr.Error(code, message, errID)
 }
 
 // Create handles POST /api/app/create.

--- a/internal/api/auth/handler.go
+++ b/internal/api/auth/handler.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/google/uuid"
 	"github.com/labstack/echo/v4"
+	"github.com/shiroha-a/mk/internal/api/apierr"
 	"github.com/shiroha-a/mk/internal/config"
 	"github.com/shiroha-a/mk/internal/misc"
 	"github.com/shiroha-a/mk/internal/misc/id"
@@ -30,9 +31,7 @@ func NewHandler(repo repository.AuthSessionRepository, cfg *config.Config, idGen
 }
 
 func apiError(code, message, errID string) map[string]any {
-	return map[string]any{
-		"error": map[string]any{"message": message, "code": code, "id": errID},
-	}
+	return apierr.Error(code, message, errID)
 }
 
 // SessionGenerate handles POST /api/auth/session/generate.

--- a/internal/api/bubblegame/handler.go
+++ b/internal/api/bubblegame/handler.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/labstack/echo/v4"
+	"github.com/shiroha-a/mk/internal/api/apierr"
 	"github.com/shiroha-a/mk/internal/misc/id"
 	"github.com/shiroha-a/mk/internal/model"
 	"github.com/shiroha-a/mk/internal/repository"
@@ -25,9 +26,7 @@ func NewHandler(repo repository.BubbleGameRepository, idGen id.Generator) *Handl
 }
 
 func apiError(code, message, errID string) map[string]any {
-	return map[string]any{
-		"error": map[string]any{"message": message, "code": code, "id": errID},
-	}
+	return apierr.Error(code, message, errID)
 }
 
 // Register handles POST /api/bubble-game/register.

--- a/internal/api/chat/handler.go
+++ b/internal/api/chat/handler.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/labstack/echo/v4"
+	"github.com/shiroha-a/mk/internal/api/apierr"
 	corechat "github.com/shiroha-a/mk/internal/core/chat"
 	"github.com/shiroha-a/mk/internal/misc/id"
 	"github.com/shiroha-a/mk/internal/model"
@@ -50,9 +51,7 @@ func (h *Handler) mapChatErr(c echo.Context, err error) error {
 }
 
 func apiError(code, message, errID string) map[string]any {
-	return map[string]any{
-		"error": map[string]any{"message": message, "code": code, "id": errID},
-	}
+	return apierr.Error(code, message, errID)
 }
 
 func packRoom(r *model.ChatRoom) map[string]any {

--- a/internal/api/drive/handler.go
+++ b/internal/api/drive/handler.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 
 	"github.com/labstack/echo/v4"
+	"github.com/shiroha-a/mk/internal/api/apierr"
 	coredrive "github.com/shiroha-a/mk/internal/core/drive"
 	"github.com/shiroha-a/mk/internal/entity"
 	"github.com/shiroha-a/mk/internal/misc/id"
@@ -299,13 +300,7 @@ func mapFolderError(c echo.Context, err error) error {
 }
 
 func errEnvelope(message, code, id string) map[string]any {
-	return map[string]any{
-		"error": map[string]any{
-			"message": message,
-			"code":    code,
-			"id":      id,
-		},
-	}
+	return apierr.Error(code, message, id)
 }
 
 func invalidParam(c echo.Context) error {

--- a/internal/api/following/handler.go
+++ b/internal/api/following/handler.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 
 	"github.com/labstack/echo/v4"
+	"github.com/shiroha-a/mk/internal/api/apierr"
 	corefollowing "github.com/shiroha-a/mk/internal/core/following"
 	coreuser "github.com/shiroha-a/mk/internal/core/user"
 	"github.com/shiroha-a/mk/internal/entity"
@@ -191,11 +192,5 @@ func internalError(c echo.Context) error {
 }
 
 func errEnvelope(message, code, id string) map[string]any {
-	return map[string]any{
-		"error": map[string]any{
-			"message": message,
-			"code":    code,
-			"id":      id,
-		},
-	}
+	return apierr.Error(code, message, id)
 }

--- a/internal/api/gallery/handler.go
+++ b/internal/api/gallery/handler.go
@@ -5,6 +5,7 @@ import (
 	"time"
 
 	"github.com/labstack/echo/v4"
+	"github.com/shiroha-a/mk/internal/api/apierr"
 	"github.com/shiroha-a/mk/internal/entity"
 	"github.com/shiroha-a/mk/internal/misc/id"
 	"github.com/shiroha-a/mk/internal/model"
@@ -217,7 +218,5 @@ func (h *Handler) packOne(p *model.GalleryPost) map[string]any {
 }
 
 func errResp(code, message, id string) map[string]any {
-	return map[string]any{
-		"error": map[string]any{"message": message, "code": code, "id": id},
-	}
+	return apierr.Error(code, message, id)
 }

--- a/internal/api/hashtags/handler.go
+++ b/internal/api/hashtags/handler.go
@@ -4,6 +4,7 @@ import (
 	"net/http"
 
 	"github.com/labstack/echo/v4"
+	"github.com/shiroha-a/mk/internal/api/apierr"
 	"github.com/shiroha-a/mk/internal/model"
 	"gorm.io/gorm"
 )
@@ -130,7 +131,5 @@ func packTag(t *model.Hashtag) map[string]any {
 }
 
 func errResp(code, message, id string) map[string]any {
-	return map[string]any{
-		"error": map[string]any{"message": message, "code": code, "id": id},
-	}
+	return apierr.Error(code, message, id)
 }

--- a/internal/api/i/handler.go
+++ b/internal/api/i/handler.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/labstack/echo/v4"
+	"github.com/shiroha-a/mk/internal/api/apierr"
 	"github.com/shiroha-a/mk/internal/core/role"
 	"github.com/shiroha-a/mk/internal/core/twofactor"
 	"github.com/shiroha-a/mk/internal/core/user"
@@ -577,21 +578,9 @@ func internalError(c echo.Context) error {
 }
 
 func errEnvelope(message, code, id string) map[string]any {
-	return map[string]any{
-		"error": map[string]any{
-			"message": message,
-			"code":    code,
-			"id":      id,
-		},
-	}
+	return apierr.Error(code, message, id)
 }
 
 func apiError(code, message, id string) map[string]any {
-	return map[string]any{
-		"error": map[string]any{
-			"message": message,
-			"code":    code,
-			"id":      id,
-		},
-	}
+	return apierr.Error(code, message, id)
 }

--- a/internal/api/notes/handler_extra.go
+++ b/internal/api/notes/handler_extra.go
@@ -5,6 +5,7 @@ import (
 	"time"
 
 	"github.com/labstack/echo/v4"
+	"github.com/shiroha-a/mk/internal/api/apierr"
 	"github.com/shiroha-a/mk/internal/entity"
 	"github.com/shiroha-a/mk/internal/model"
 	"github.com/shiroha-a/mk/internal/repository"
@@ -238,7 +239,5 @@ func (h *Handler) ShowPartialBulk(c echo.Context) error {
 }
 
 func apiError(code, message, id string) map[string]any {
-	return map[string]any{
-		"error": map[string]any{"message": message, "code": code, "id": id},
-	}
+	return apierr.Error(code, message, id)
 }

--- a/internal/api/resetpassword/handler.go
+++ b/internal/api/resetpassword/handler.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/labstack/echo/v4"
+	"github.com/shiroha-a/mk/internal/api/apierr"
 	"github.com/shiroha-a/mk/internal/misc"
 	"github.com/shiroha-a/mk/internal/misc/id"
 	"github.com/shiroha-a/mk/internal/model"
@@ -37,9 +38,7 @@ func (h *Handler) SetEmailSender(s EmailSender) { h.email = s }
 func (h *Handler) SetServerURL(u string) { h.serverURL = u }
 
 func apiError(code, message, errID string) map[string]any {
-	return map[string]any{
-		"error": map[string]any{"message": message, "code": code, "id": errID},
-	}
+	return apierr.Error(code, message, errID)
 }
 
 // RequestReset handles POST /api/request-reset-password.

--- a/internal/api/reversi/handler.go
+++ b/internal/api/reversi/handler.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/labstack/echo/v4"
 	"github.com/lib/pq"
+	"github.com/shiroha-a/mk/internal/api/apierr"
 	corereversi "github.com/shiroha-a/mk/internal/core/reversi"
 	"github.com/shiroha-a/mk/internal/entity"
 	"github.com/shiroha-a/mk/internal/misc/id"
@@ -57,9 +58,7 @@ func (h *Handler) SetFederation(baseURL string, deliverer FederationDeliverer, f
 }
 
 func apiError(code, message, errID string) map[string]any {
-	return map[string]any{
-		"error": map[string]any{"message": message, "code": code, "id": errID},
-	}
+	return apierr.Error(code, message, errID)
 }
 
 func packGame(g *model.ReversiGame, idGen id.Generator) map[string]any {

--- a/internal/api/roles/handler.go
+++ b/internal/api/roles/handler.go
@@ -4,6 +4,7 @@ import (
 	"net/http"
 
 	"github.com/labstack/echo/v4"
+	"github.com/shiroha-a/mk/internal/api/apierr"
 	"github.com/shiroha-a/mk/internal/core/role"
 	"github.com/shiroha-a/mk/internal/entity"
 	"github.com/shiroha-a/mk/internal/misc/id"
@@ -145,7 +146,5 @@ func packRole(r *model.Role) map[string]any {
 }
 
 func errResp(code, message, id string) map[string]any {
-	return map[string]any{
-		"error": map[string]any{"message": message, "code": code, "id": id},
-	}
+	return apierr.Error(code, message, id)
 }

--- a/internal/api/signup/handler.go
+++ b/internal/api/signup/handler.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/labstack/echo/v4"
 
+	"github.com/shiroha-a/mk/internal/api/apierr"
 	"github.com/shiroha-a/mk/internal/core/captcha"
 	"github.com/shiroha-a/mk/internal/core/role"
 	coresignup "github.com/shiroha-a/mk/internal/core/signup"
@@ -225,7 +226,5 @@ func packSignupResponse(u *model.User, token string, idGen id.Generator) map[str
 var errInvalidCode = errors.New("invalid invitation code")
 
 func errResp(code, message, id string) map[string]any {
-	return map[string]any{
-		"error": map[string]any{"message": message, "code": code, "id": id},
-	}
+	return apierr.Error(code, message, id)
 }

--- a/internal/api/sw/handler.go
+++ b/internal/api/sw/handler.go
@@ -5,6 +5,7 @@ import (
 	"time"
 
 	"github.com/labstack/echo/v4"
+	"github.com/shiroha-a/mk/internal/api/apierr"
 	"github.com/shiroha-a/mk/internal/misc/id"
 	"github.com/shiroha-a/mk/internal/model"
 	"github.com/shiroha-a/mk/internal/repository"
@@ -24,9 +25,7 @@ func NewHandler(repo repository.SwSubscriptionRepository, metaRepo repository.Me
 }
 
 func apiError(code, message, errID string) map[string]any {
-	return map[string]any{
-		"error": map[string]any{"message": message, "code": code, "id": errID},
-	}
+	return apierr.Error(code, message, errID)
 }
 
 // Register handles POST /api/sw/register.

--- a/internal/api/userlists/handler.go
+++ b/internal/api/userlists/handler.go
@@ -5,6 +5,7 @@ import (
 	"time"
 
 	"github.com/labstack/echo/v4"
+	"github.com/shiroha-a/mk/internal/api/apierr"
 	"github.com/shiroha-a/mk/internal/misc/id"
 	"github.com/shiroha-a/mk/internal/model"
 	"github.com/shiroha-a/mk/internal/repository"
@@ -120,7 +121,5 @@ func (h *Handler) Delete(c echo.Context) error {
 }
 
 func errResp(code, message, id string) map[string]any {
-	return map[string]any{
-		"error": map[string]any{"message": message, "code": code, "id": id},
-	}
+	return apierr.Error(code, message, id)
 }

--- a/internal/api/users/handler_extra.go
+++ b/internal/api/users/handler_extra.go
@@ -5,6 +5,7 @@ import (
 	"time"
 
 	"github.com/labstack/echo/v4"
+	"github.com/shiroha-a/mk/internal/api/apierr"
 	"github.com/shiroha-a/mk/internal/entity"
 	"github.com/shiroha-a/mk/internal/model"
 	"github.com/shiroha-a/mk/internal/repository"
@@ -159,7 +160,5 @@ func (h *Handler) UpdateMemo(c echo.Context) error {
 }
 
 func apiError(code, message, id string) map[string]any {
-	return map[string]any{
-		"error": map[string]any{"message": message, "code": code, "id": id},
-	}
+	return apierr.Error(code, message, id)
 }

--- a/internal/api/webhooks/handler.go
+++ b/internal/api/webhooks/handler.go
@@ -5,6 +5,7 @@ import (
 	"time"
 
 	"github.com/labstack/echo/v4"
+	"github.com/shiroha-a/mk/internal/api/apierr"
 	"github.com/shiroha-a/mk/internal/misc/id"
 	"github.com/shiroha-a/mk/internal/model"
 	"github.com/shiroha-a/mk/internal/repository"
@@ -37,9 +38,7 @@ func (h *Handler) SetDispatcher(d TestDispatcher) {
 }
 
 func apiError(code, message, errID string) map[string]any {
-	return map[string]any{
-		"error": map[string]any{"message": message, "code": code, "id": errID},
-	}
+	return apierr.Error(code, message, errID)
 }
 
 func packWebhook(w *model.Webhook) map[string]any {


### PR DESCRIPTION
## Summary
- 20ハンドラファイルのローカル`apiError`/`errEnvelope`/`errResp`関数の**実装**を`apierr.Error()`に委譲
- 関数シグネチャと呼び出し側は一切変更なし、動作は同一

## 主な変更点
| ヘルパー | ファイル数 | 対象 |
|---------|----------|------|
| `apiError` | 11 | auth, i, app, notes/handler_extra, users/handler_extra, chat, webhooks, reversi, resetpassword, bubblegame, sw |
| `errEnvelope` | 3 | i, following, drive |
| `errResp` | 7 | hashtags, admin, announcements, gallery, userlists, signup, roles |

## 効果
- エラーレスポンス生成ロジックが`apierr`に集約
- 削減: 87行 → 41行（46行減）
- 次Phase（呼び出し側の直接置き換え）の土台

## スコープ外
- 呼び出し側（`apiError(...)`等の呼び出し箇所）の`apierr.Error()`への直接置き換えは後続PR
- インラインヘルパー（`invalidParam(c)`等）の移行は後続PR

## テスト
```bash
go test -race -count=1 ./internal/api/...
```
- 全`internal/api`パッケージのテスト通過

Refs #130
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/shiroha-a/mk/pull/141" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
