### PR TITLE
Phase P2: migrate all call sites to apierr (#130 Phase 2-2)

### DIFF
--- a/internal/api/admin/handler.go
+++ b/internal/api/admin/handler.go
@@ -123,12 +123,12 @@ func (h *Handler) AccountsCreate(c echo.Context) error {
 		SetupPassword *string `json:"setupPassword"`
 	}
 	if err := c.Bind(&req); err != nil || req.Username == "" || req.Password == "" {
-		return c.JSON(http.StatusBadRequest, errResp("INVALID_PARAM", "Invalid parameters.", "3d81ceae-475f-4600-b2a8-2bc116157532"))
+		return c.JSON(http.StatusBadRequest, apierr.Error("INVALID_PARAM", "Invalid parameters.", "3d81ceae-475f-4600-b2a8-2bc116157532"))
 	}
 
 	meta, err := h.metaRepo.Fetch()
 	if err != nil {
-		return c.JSON(http.StatusInternalServerError, errResp("INTERNAL_ERROR", "Internal error.", "5d37dbcb-891e-41ca-a3d6-e690c97775ac"))
+		return c.JSON(http.StatusInternalServerError, apierr.Error("INTERNAL_ERROR", "Internal error.", "5d37dbcb-891e-41ca-a3d6-e690c97775ac"))
 	}
 
 	user := middleware.GetUser(c)
@@ -137,25 +137,25 @@ func (h *Handler) AccountsCreate(c echo.Context) error {
 	if !isInitialSetup {
 		// 初回セットアップ以外はadmin権限必須
 		if user == nil {
-			return c.JSON(http.StatusForbidden, errResp("ACCESS_DENIED", "Access denied.", "1fb7cb09-d46a-4fff-b8df-057708cce513"))
+			return c.JSON(http.StatusForbidden, apierr.Error("ACCESS_DENIED", "Access denied.", "1fb7cb09-d46a-4fff-b8df-057708cce513"))
 		}
 		if meta.RootUserID == nil || *meta.RootUserID != user.ID {
-			return c.JSON(http.StatusForbidden, errResp("ACCESS_DENIED", "Access denied.", "1fb7cb09-d46a-4fff-b8df-057708cce513"))
+			return c.JSON(http.StatusForbidden, apierr.Error("ACCESS_DENIED", "Access denied.", "1fb7cb09-d46a-4fff-b8df-057708cce513"))
 		}
 	}
 
 	result, err := h.signupService.Signup(req.Username, req.Password, isInitialSetup)
 	if err != nil {
 		if err == signup.ErrUsernameAlreadyExists {
-			return c.JSON(http.StatusConflict, errResp("USERNAME_ALREADY_EXISTS", "Username already exists.", "a]504947-b888-4a99-9f62-8c4a0f3a3dab"))
+			return c.JSON(http.StatusConflict, apierr.Error("USERNAME_ALREADY_EXISTS", "Username already exists.", "a]504947-b888-4a99-9f62-8c4a0f3a3dab"))
 		}
 		if err == signup.ErrInvalidUsername {
-			return c.JSON(http.StatusBadRequest, errResp("INVALID_PARAM", "Invalid username.", "3d81ceae-475f-4600-b2a8-2bc116157532"))
+			return c.JSON(http.StatusBadRequest, apierr.Error("INVALID_PARAM", "Invalid username.", "3d81ceae-475f-4600-b2a8-2bc116157532"))
 		}
 		if err == signup.ErrUsernameReserved {
-			return c.JSON(http.StatusBadRequest, errResp("USED_USERNAME", "That username is reserved.", "4b54bee6-2c25-42c3-a10f-7d0d1fbd91f9"))
+			return c.JSON(http.StatusBadRequest, apierr.Error("USED_USERNAME", "That username is reserved.", "4b54bee6-2c25-42c3-a10f-7d0d1fbd91f9"))
 		}
-		return c.JSON(http.StatusInternalServerError, errResp("INTERNAL_ERROR", "Internal error.", "5d37dbcb-891e-41ca-a3d6-e690c97775ac"))
+		return c.JSON(http.StatusInternalServerError, apierr.Error("INTERNAL_ERROR", "Internal error.", "5d37dbcb-891e-41ca-a3d6-e690c97775ac"))
 	}
 
 	u := result.User
@@ -273,12 +273,12 @@ func (h *Handler) ShowUser(c echo.Context) error {
 		UserID string `json:"userId"`
 	}
 	if err := c.Bind(&req); err != nil || req.UserID == "" {
-		return c.JSON(http.StatusBadRequest, errResp("INVALID_PARAM", "userId is required.", "3d81ceae-475f-4600-b2a8-2bc116157532"))
+		return c.JSON(http.StatusBadRequest, apierr.Error("INVALID_PARAM", "userId is required.", "3d81ceae-475f-4600-b2a8-2bc116157532"))
 	}
 
 	user, err := h.userRepo.FindByID(req.UserID)
 	if err != nil {
-		return c.JSON(http.StatusNotFound, errResp("NO_SUCH_USER", "No such user.", "a]504947-b888-4a99-9f62-8c4a0f3a3dab"))
+		return c.JSON(http.StatusNotFound, apierr.Error("NO_SUCH_USER", "No such user.", "a]504947-b888-4a99-9f62-8c4a0f3a3dab"))
 	}
 
 	profile, _ := h.userRepo.FindProfileByUserID(user.ID)
@@ -296,7 +296,7 @@ func (h *Handler) ShowUsers(c echo.Context) error {
 		Offset int    `json:"offset"`
 	}
 	if err := c.Bind(&req); err != nil {
-		return c.JSON(http.StatusBadRequest, errResp("INVALID_PARAM", "Invalid parameters.", "3d81ceae-475f-4600-b2a8-2bc116157532"))
+		return c.JSON(http.StatusBadRequest, apierr.Error("INVALID_PARAM", "Invalid parameters.", "3d81ceae-475f-4600-b2a8-2bc116157532"))
 	}
 
 	users, err := h.userRepo.ListUsers(model.UserListFilter{
@@ -307,7 +307,7 @@ func (h *Handler) ShowUsers(c echo.Context) error {
 		Offset: req.Offset,
 	})
 	if err != nil {
-		return c.JSON(http.StatusInternalServerError, errResp("INTERNAL_ERROR", "Internal error.", "5d37dbcb-891e-41ca-a3d6-e690c97775ac"))
+		return c.JSON(http.StatusInternalServerError, apierr.Error("INTERNAL_ERROR", "Internal error.", "5d37dbcb-891e-41ca-a3d6-e690c97775ac"))
 	}
 
 	result := make([]map[string]any, 0, len(users))
@@ -401,15 +401,15 @@ func (h *Handler) SuspendUser(c echo.Context) error {
 		UserID string `json:"userId"`
 	}
 	if err := c.Bind(&req); err != nil || req.UserID == "" {
-		return c.JSON(http.StatusBadRequest, errResp("INVALID_PARAM", "userId is required.", "3d81ceae-475f-4600-b2a8-2bc116157532"))
+		return c.JSON(http.StatusBadRequest, apierr.Error("INVALID_PARAM", "userId is required.", "3d81ceae-475f-4600-b2a8-2bc116157532"))
 	}
 
 	if _, err := h.userRepo.FindByID(req.UserID); err != nil {
-		return c.JSON(http.StatusNotFound, errResp("NO_SUCH_USER", "No such user.", "a]504947-b888-4a99-9f62-8c4a0f3a3dab"))
+		return c.JSON(http.StatusNotFound, apierr.Error("NO_SUCH_USER", "No such user.", "a]504947-b888-4a99-9f62-8c4a0f3a3dab"))
 	}
 
 	if err := h.userRepo.UpdateUser(req.UserID, map[string]any{"isSuspended": true}); err != nil {
-		return c.JSON(http.StatusInternalServerError, errResp("INTERNAL_ERROR", "Internal error.", "5d37dbcb-891e-41ca-a3d6-e690c97775ac"))
+		return c.JSON(http.StatusInternalServerError, apierr.Error("INTERNAL_ERROR", "Internal error.", "5d37dbcb-891e-41ca-a3d6-e690c97775ac"))
 	}
 	return c.NoContent(http.StatusNoContent)
 }
@@ -420,15 +420,15 @@ func (h *Handler) UnsuspendUser(c echo.Context) error {
 		UserID string `json:"userId"`
 	}
 	if err := c.Bind(&req); err != nil || req.UserID == "" {
-		return c.JSON(http.StatusBadRequest, errResp("INVALID_PARAM", "userId is required.", "3d81ceae-475f-4600-b2a8-2bc116157532"))
+		return c.JSON(http.StatusBadRequest, apierr.Error("INVALID_PARAM", "userId is required.", "3d81ceae-475f-4600-b2a8-2bc116157532"))
 	}
 
 	if _, err := h.userRepo.FindByID(req.UserID); err != nil {
-		return c.JSON(http.StatusNotFound, errResp("NO_SUCH_USER", "No such user.", "a]504947-b888-4a99-9f62-8c4a0f3a3dab"))
+		return c.JSON(http.StatusNotFound, apierr.Error("NO_SUCH_USER", "No such user.", "a]504947-b888-4a99-9f62-8c4a0f3a3dab"))
 	}
 
 	if err := h.userRepo.UpdateUser(req.UserID, map[string]any{"isSuspended": false}); err != nil {
-		return c.JSON(http.StatusInternalServerError, errResp("INTERNAL_ERROR", "Internal error.", "5d37dbcb-891e-41ca-a3d6-e690c97775ac"))
+		return c.JSON(http.StatusInternalServerError, apierr.Error("INTERNAL_ERROR", "Internal error.", "5d37dbcb-891e-41ca-a3d6-e690c97775ac"))
 	}
 	return c.NoContent(http.StatusNoContent)
 }
@@ -437,7 +437,7 @@ func (h *Handler) UnsuspendUser(c echo.Context) error {
 func (h *Handler) AdminMeta(c echo.Context) error {
 	m, err := h.metaRepo.Fetch()
 	if err != nil {
-		return c.JSON(http.StatusInternalServerError, errResp("INTERNAL_ERROR", "Internal error.", "5d37dbcb-891e-41ca-a3d6-e690c97775ac"))
+		return c.JSON(http.StatusInternalServerError, apierr.Error("INTERNAL_ERROR", "Internal error.", "5d37dbcb-891e-41ca-a3d6-e690c97775ac"))
 	}
 	resp := map[string]any{
 		// Basic
@@ -561,13 +561,13 @@ func (h *Handler) AdminMeta(c echo.Context) error {
 func (h *Handler) UpdateMeta(c echo.Context) error {
 	var fields map[string]any
 	if err := c.Bind(&fields); err != nil {
-		return c.JSON(http.StatusBadRequest, errResp("INVALID_PARAM", "Invalid parameters.", "3d81ceae-475f-4600-b2a8-2bc116157532"))
+		return c.JSON(http.StatusBadRequest, apierr.Error("INVALID_PARAM", "Invalid parameters.", "3d81ceae-475f-4600-b2a8-2bc116157532"))
 	}
 	// "i" フィールドを除外 (auth token)
 	delete(fields, "i")
 
 	if err := h.metaRepo.Update(fields); err != nil {
-		return c.JSON(http.StatusInternalServerError, errResp("INTERNAL_ERROR", "Internal error.", "5d37dbcb-891e-41ca-a3d6-e690c97775ac"))
+		return c.JSON(http.StatusInternalServerError, apierr.Error("INTERNAL_ERROR", "Internal error.", "5d37dbcb-891e-41ca-a3d6-e690c97775ac"))
 	}
 	return c.NoContent(http.StatusNoContent)
 }
@@ -587,7 +587,7 @@ func (h *Handler) RolesCreate(c echo.Context) error {
 		DisplayOrder    int    `json:"displayOrder"`
 	}
 	if err := c.Bind(&req); err != nil || req.Name == "" {
-		return c.JSON(http.StatusBadRequest, errResp("INVALID_PARAM", "name is required.", "3d81ceae-475f-4600-b2a8-2bc116157532"))
+		return c.JSON(http.StatusBadRequest, apierr.Error("INVALID_PARAM", "name is required.", "3d81ceae-475f-4600-b2a8-2bc116157532"))
 	}
 	r, err := h.roleService.Create(req.Name, req.Description, role.CreateOptions{
 		IsModerator:     req.IsModerator,
@@ -598,7 +598,7 @@ func (h *Handler) RolesCreate(c echo.Context) error {
 		DisplayOrder:    req.DisplayOrder,
 	})
 	if err != nil {
-		return c.JSON(http.StatusInternalServerError, errResp("INTERNAL_ERROR", "Internal error.", "5d37dbcb-891e-41ca-a3d6-e690c97775ac"))
+		return c.JSON(http.StatusInternalServerError, apierr.Error("INTERNAL_ERROR", "Internal error.", "5d37dbcb-891e-41ca-a3d6-e690c97775ac"))
 	}
 	return c.JSON(http.StatusOK, r)
 }
@@ -609,11 +609,11 @@ func (h *Handler) RolesShow(c echo.Context) error {
 		RoleID string `json:"roleId"`
 	}
 	if err := c.Bind(&req); err != nil || req.RoleID == "" {
-		return c.JSON(http.StatusBadRequest, errResp("INVALID_PARAM", "roleId is required.", "3d81ceae-475f-4600-b2a8-2bc116157532"))
+		return c.JSON(http.StatusBadRequest, apierr.Error("INVALID_PARAM", "roleId is required.", "3d81ceae-475f-4600-b2a8-2bc116157532"))
 	}
 	r, err := h.roleService.Show(req.RoleID)
 	if err != nil {
-		return c.JSON(http.StatusNotFound, errResp("NO_SUCH_ROLE", "No such role.", "07dc7d34-c0d8-458b-9c04-4b18399b1f46"))
+		return c.JSON(http.StatusNotFound, apierr.Error("NO_SUCH_ROLE", "No such role.", "07dc7d34-c0d8-458b-9c04-4b18399b1f46"))
 	}
 	return c.JSON(http.StatusOK, r)
 }
@@ -622,7 +622,7 @@ func (h *Handler) RolesShow(c echo.Context) error {
 func (h *Handler) RolesList(c echo.Context) error {
 	roles, err := h.roleService.List()
 	if err != nil {
-		return c.JSON(http.StatusInternalServerError, errResp("INTERNAL_ERROR", "Internal error.", "5d37dbcb-891e-41ca-a3d6-e690c97775ac"))
+		return c.JSON(http.StatusInternalServerError, apierr.Error("INTERNAL_ERROR", "Internal error.", "5d37dbcb-891e-41ca-a3d6-e690c97775ac"))
 	}
 	return c.JSON(http.StatusOK, roles)
 }
@@ -638,10 +638,10 @@ func (h *Handler) RolesUpdate(c echo.Context) error {
 		IsPublic        *bool   `json:"isPublic"`
 	}
 	if err := c.Bind(&req); err != nil || req.RoleID == "" {
-		return c.JSON(http.StatusBadRequest, errResp("INVALID_PARAM", "roleId is required.", "3d81ceae-475f-4600-b2a8-2bc116157532"))
+		return c.JSON(http.StatusBadRequest, apierr.Error("INVALID_PARAM", "roleId is required.", "3d81ceae-475f-4600-b2a8-2bc116157532"))
 	}
 	if _, err := h.roleService.Show(req.RoleID); err != nil {
-		return c.JSON(http.StatusNotFound, errResp("NO_SUCH_ROLE", "No such role.", "07dc7d34-c0d8-458b-9c04-4b18399b1f46"))
+		return c.JSON(http.StatusNotFound, apierr.Error("NO_SUCH_ROLE", "No such role.", "07dc7d34-c0d8-458b-9c04-4b18399b1f46"))
 	}
 	fields := map[string]any{}
 	if req.Name != nil {
@@ -670,10 +670,10 @@ func (h *Handler) RolesDelete(c echo.Context) error {
 		RoleID string `json:"roleId"`
 	}
 	if err := c.Bind(&req); err != nil || req.RoleID == "" {
-		return c.JSON(http.StatusBadRequest, errResp("INVALID_PARAM", "roleId is required.", "3d81ceae-475f-4600-b2a8-2bc116157532"))
+		return c.JSON(http.StatusBadRequest, apierr.Error("INVALID_PARAM", "roleId is required.", "3d81ceae-475f-4600-b2a8-2bc116157532"))
 	}
 	if err := h.roleService.Delete(req.RoleID); err != nil {
-		return c.JSON(http.StatusNotFound, errResp("NO_SUCH_ROLE", "No such role.", "07dc7d34-c0d8-458b-9c04-4b18399b1f46"))
+		return c.JSON(http.StatusNotFound, apierr.Error("NO_SUCH_ROLE", "No such role.", "07dc7d34-c0d8-458b-9c04-4b18399b1f46"))
 	}
 	return c.NoContent(http.StatusNoContent)
 }
@@ -686,7 +686,7 @@ func (h *Handler) RolesAssign(c echo.Context) error {
 		ExpiresAt *string `json:"expiresAt"`
 	}
 	if err := c.Bind(&req); err != nil || req.UserID == "" || req.RoleID == "" {
-		return c.JSON(http.StatusBadRequest, errResp("INVALID_PARAM", "userId and roleId are required.", "3d81ceae-475f-4600-b2a8-2bc116157532"))
+		return c.JSON(http.StatusBadRequest, apierr.Error("INVALID_PARAM", "userId and roleId are required.", "3d81ceae-475f-4600-b2a8-2bc116157532"))
 	}
 	var expiresAt *time.Time
 	if req.ExpiresAt != nil {
@@ -696,12 +696,12 @@ func (h *Handler) RolesAssign(c echo.Context) error {
 	}
 	if err := h.roleService.Assign(req.UserID, req.RoleID, expiresAt); err != nil {
 		if err == role.ErrRoleNotFound {
-			return c.JSON(http.StatusNotFound, errResp("NO_SUCH_ROLE", "No such role.", "07dc7d34-c0d8-458b-9c04-4b18399b1f46"))
+			return c.JSON(http.StatusNotFound, apierr.Error("NO_SUCH_ROLE", "No such role.", "07dc7d34-c0d8-458b-9c04-4b18399b1f46"))
 		}
 		if err == role.ErrAlreadyAssigned {
-			return c.JSON(http.StatusConflict, errResp("ALREADY_ASSIGNED", "Role already assigned.", "67d8689c-25c6-435f-8eed-6ea68e5e53e9"))
+			return c.JSON(http.StatusConflict, apierr.Error("ALREADY_ASSIGNED", "Role already assigned.", "67d8689c-25c6-435f-8eed-6ea68e5e53e9"))
 		}
-		return c.JSON(http.StatusInternalServerError, errResp("INTERNAL_ERROR", "Internal error.", "5d37dbcb-891e-41ca-a3d6-e690c97775ac"))
+		return c.JSON(http.StatusInternalServerError, apierr.Error("INTERNAL_ERROR", "Internal error.", "5d37dbcb-891e-41ca-a3d6-e690c97775ac"))
 	}
 	return c.NoContent(http.StatusNoContent)
 }
@@ -713,13 +713,13 @@ func (h *Handler) RolesUnassign(c echo.Context) error {
 		RoleID string `json:"roleId"`
 	}
 	if err := c.Bind(&req); err != nil || req.UserID == "" || req.RoleID == "" {
-		return c.JSON(http.StatusBadRequest, errResp("INVALID_PARAM", "userId and roleId are required.", "3d81ceae-475f-4600-b2a8-2bc116157532"))
+		return c.JSON(http.StatusBadRequest, apierr.Error("INVALID_PARAM", "userId and roleId are required.", "3d81ceae-475f-4600-b2a8-2bc116157532"))
 	}
 	if err := h.roleService.Unassign(req.UserID, req.RoleID); err != nil {
 		if err == role.ErrNotAssigned {
-			return c.JSON(http.StatusNotFound, errResp("NOT_ASSIGNED", "Role not assigned.", "b9060ac7-5c94-4da4-9f55-2047140f5a68"))
+			return c.JSON(http.StatusNotFound, apierr.Error("NOT_ASSIGNED", "Role not assigned.", "b9060ac7-5c94-4da4-9f55-2047140f5a68"))
 		}
-		return c.JSON(http.StatusInternalServerError, errResp("INTERNAL_ERROR", "Internal error.", "5d37dbcb-891e-41ca-a3d6-e690c97775ac"))
+		return c.JSON(http.StatusInternalServerError, apierr.Error("INTERNAL_ERROR", "Internal error.", "5d37dbcb-891e-41ca-a3d6-e690c97775ac"))
 	}
 	return c.NoContent(http.StatusNoContent)
 }
@@ -732,10 +732,10 @@ func (h *Handler) RolesUsers(c echo.Context) error {
 		Offset int    `json:"offset"`
 	}
 	if err := c.Bind(&req); err != nil || req.RoleID == "" {
-		return c.JSON(http.StatusBadRequest, errResp("INVALID_PARAM", "roleId is required.", "3d81ceae-475f-4600-b2a8-2bc116157532"))
+		return c.JSON(http.StatusBadRequest, apierr.Error("INVALID_PARAM", "roleId is required.", "3d81ceae-475f-4600-b2a8-2bc116157532"))
 	}
 	if _, err := h.roleService.Show(req.RoleID); err != nil {
-		return c.JSON(http.StatusNotFound, errResp("NO_SUCH_ROLE", "No such role.", "07dc7d34-c0d8-458b-9c04-4b18399b1f46"))
+		return c.JSON(http.StatusNotFound, apierr.Error("NO_SUCH_ROLE", "No such role.", "07dc7d34-c0d8-458b-9c04-4b18399b1f46"))
 	}
 	limit := req.Limit
 	if limit <= 0 {
@@ -752,11 +752,11 @@ func (h *Handler) RolesUpdateDefaultPolicies(c echo.Context) error {
 		Policies map[string]any `json:"policies"`
 	}
 	if err := c.Bind(&req); err != nil {
-		return c.JSON(http.StatusBadRequest, errResp("INVALID_PARAM", "Invalid parameters.", "3d81ceae-475f-4600-b2a8-2bc116157532"))
+		return c.JSON(http.StatusBadRequest, apierr.Error("INVALID_PARAM", "Invalid parameters.", "3d81ceae-475f-4600-b2a8-2bc116157532"))
 	}
 	// Meta の policies フィールドを更新
 	if err := h.metaRepo.Update(map[string]any{"policies": req.Policies}); err != nil {
-		return c.JSON(http.StatusInternalServerError, errResp("INTERNAL_ERROR", "Internal error.", "5d37dbcb-891e-41ca-a3d6-e690c97775ac"))
+		return c.JSON(http.StatusInternalServerError, apierr.Error("INTERNAL_ERROR", "Internal error.", "5d37dbcb-891e-41ca-a3d6-e690c97775ac"))
 	}
 	return c.NoContent(http.StatusNoContent)
 }
@@ -773,10 +773,10 @@ func (h *Handler) EmojiAdd(c echo.Context) error {
 		URL  string `json:"url"`
 	}
 	if err := c.Bind(&req); err != nil || req.Name == "" {
-		return c.JSON(http.StatusBadRequest, errResp("INVALID_PARAM", "name is required.", "3d81ceae-475f-4600-b2a8-2bc116157532"))
+		return c.JSON(http.StatusBadRequest, apierr.Error("INVALID_PARAM", "name is required.", "3d81ceae-475f-4600-b2a8-2bc116157532"))
 	}
 	if h.emojiRepo == nil {
-		return c.JSON(http.StatusInternalServerError, errResp("INTERNAL_ERROR", "Internal error.", "5d37dbcb-891e-41ca-a3d6-e690c97775ac"))
+		return c.JSON(http.StatusInternalServerError, apierr.Error("INTERNAL_ERROR", "Internal error.", "5d37dbcb-891e-41ca-a3d6-e690c97775ac"))
 	}
 	e := &model.Emoji{
 		ID:          h.idGen.Generate(time.Now()),
@@ -785,7 +785,7 @@ func (h *Handler) EmojiAdd(c echo.Context) error {
 		PublicURL:   req.URL,
 	}
 	if err := h.emojiRepo.Create(e); err != nil {
-		return c.JSON(http.StatusInternalServerError, errResp("INTERNAL_ERROR", "Internal error.", "5d37dbcb-891e-41ca-a3d6-e690c97775ac"))
+		return c.JSON(http.StatusInternalServerError, apierr.Error("INTERNAL_ERROR", "Internal error.", "5d37dbcb-891e-41ca-a3d6-e690c97775ac"))
 	}
 	return c.JSON(http.StatusOK, e)
 }
@@ -799,10 +799,10 @@ func (h *Handler) EmojiUpdate(c echo.Context) error {
 		Aliases  []string `json:"aliases"`
 	}
 	if err := c.Bind(&req); err != nil || req.ID == "" {
-		return c.JSON(http.StatusBadRequest, errResp("INVALID_PARAM", "id is required.", "3d81ceae-475f-4600-b2a8-2bc116157532"))
+		return c.JSON(http.StatusBadRequest, apierr.Error("INVALID_PARAM", "id is required.", "3d81ceae-475f-4600-b2a8-2bc116157532"))
 	}
 	if h.emojiRepo == nil {
-		return c.JSON(http.StatusInternalServerError, errResp("INTERNAL_ERROR", "Internal error.", "5d37dbcb-891e-41ca-a3d6-e690c97775ac"))
+		return c.JSON(http.StatusInternalServerError, apierr.Error("INTERNAL_ERROR", "Internal error.", "5d37dbcb-891e-41ca-a3d6-e690c97775ac"))
 	}
 	fields := map[string]any{}
 	if req.Name != nil {
@@ -815,7 +815,7 @@ func (h *Handler) EmojiUpdate(c echo.Context) error {
 		fields["aliases"] = req.Aliases
 	}
 	if err := h.emojiRepo.UpdateFields(req.ID, fields); err != nil {
-		return c.JSON(http.StatusNotFound, errResp("NO_SUCH_EMOJI", "No such emoji.", "684b7e7e-7e91-4e4c-a5cc-8050e4b8e0d8"))
+		return c.JSON(http.StatusNotFound, apierr.Error("NO_SUCH_EMOJI", "No such emoji.", "684b7e7e-7e91-4e4c-a5cc-8050e4b8e0d8"))
 	}
 	return c.NoContent(http.StatusNoContent)
 }
@@ -826,13 +826,13 @@ func (h *Handler) EmojiDelete(c echo.Context) error {
 		ID string `json:"id"`
 	}
 	if err := c.Bind(&req); err != nil || req.ID == "" {
-		return c.JSON(http.StatusBadRequest, errResp("INVALID_PARAM", "id is required.", "3d81ceae-475f-4600-b2a8-2bc116157532"))
+		return c.JSON(http.StatusBadRequest, apierr.Error("INVALID_PARAM", "id is required.", "3d81ceae-475f-4600-b2a8-2bc116157532"))
 	}
 	if h.emojiRepo == nil {
-		return c.JSON(http.StatusInternalServerError, errResp("INTERNAL_ERROR", "Internal error.", "5d37dbcb-891e-41ca-a3d6-e690c97775ac"))
+		return c.JSON(http.StatusInternalServerError, apierr.Error("INTERNAL_ERROR", "Internal error.", "5d37dbcb-891e-41ca-a3d6-e690c97775ac"))
 	}
 	if err := h.emojiRepo.Delete(req.ID); err != nil {
-		return c.JSON(http.StatusNotFound, errResp("NO_SUCH_EMOJI", "No such emoji.", "684b7e7e-7e91-4e4c-a5cc-8050e4b8e0d8"))
+		return c.JSON(http.StatusNotFound, apierr.Error("NO_SUCH_EMOJI", "No such emoji.", "684b7e7e-7e91-4e4c-a5cc-8050e4b8e0d8"))
 	}
 	return c.NoContent(http.StatusNoContent)
 }
@@ -846,14 +846,14 @@ func (h *Handler) EmojiList(c echo.Context) error {
 		Offset   int    `json:"offset"`
 	}
 	if err := c.Bind(&req); err != nil {
-		return c.JSON(http.StatusBadRequest, errResp("INVALID_PARAM", "Invalid parameters.", "3d81ceae-475f-4600-b2a8-2bc116157532"))
+		return c.JSON(http.StatusBadRequest, apierr.Error("INVALID_PARAM", "Invalid parameters.", "3d81ceae-475f-4600-b2a8-2bc116157532"))
 	}
 	if h.emojiRepo == nil {
 		return c.JSON(http.StatusOK, []any{})
 	}
 	emojis, err := h.emojiRepo.ListWithFilter(req.Query, req.Category, true, req.Limit, req.Offset)
 	if err != nil {
-		return c.JSON(http.StatusInternalServerError, errResp("INTERNAL_ERROR", "Internal error.", "5d37dbcb-891e-41ca-a3d6-e690c97775ac"))
+		return c.JSON(http.StatusInternalServerError, apierr.Error("INTERNAL_ERROR", "Internal error.", "5d37dbcb-891e-41ca-a3d6-e690c97775ac"))
 	}
 	return c.JSON(http.StatusOK, emojis)
 }
@@ -868,14 +868,14 @@ func (h *Handler) AbuseReports(c echo.Context) error {
 		Offset   int   `json:"offset"`
 	}
 	if err := c.Bind(&req); err != nil {
-		return c.JSON(http.StatusBadRequest, errResp("INVALID_PARAM", "Invalid parameters.", "3d81ceae-475f-4600-b2a8-2bc116157532"))
+		return c.JSON(http.StatusBadRequest, apierr.Error("INVALID_PARAM", "Invalid parameters.", "3d81ceae-475f-4600-b2a8-2bc116157532"))
 	}
 	if h.abuseRepo == nil {
 		return c.JSON(http.StatusOK, []any{})
 	}
 	reports, err := h.abuseRepo.List(req.Resolved, req.Limit, req.Offset)
 	if err != nil {
-		return c.JSON(http.StatusInternalServerError, errResp("INTERNAL_ERROR", "Internal error.", "5d37dbcb-891e-41ca-a3d6-e690c97775ac"))
+		return c.JSON(http.StatusInternalServerError, apierr.Error("INTERNAL_ERROR", "Internal error.", "5d37dbcb-891e-41ca-a3d6-e690c97775ac"))
 	}
 	return c.JSON(http.StatusOK, reports)
 }
@@ -886,10 +886,10 @@ func (h *Handler) ResolveAbuseReport(c echo.Context) error {
 		ReportID string `json:"reportId"`
 	}
 	if err := c.Bind(&req); err != nil || req.ReportID == "" {
-		return c.JSON(http.StatusBadRequest, errResp("INVALID_PARAM", "reportId is required.", "3d81ceae-475f-4600-b2a8-2bc116157532"))
+		return c.JSON(http.StatusBadRequest, apierr.Error("INVALID_PARAM", "reportId is required.", "3d81ceae-475f-4600-b2a8-2bc116157532"))
 	}
 	if h.abuseRepo == nil {
-		return c.JSON(http.StatusNotFound, errResp("NO_SUCH_REPORT", "No such report.", "ac2cf84c-3c73-44f0-8e8f-0e76f2cb5eb3"))
+		return c.JSON(http.StatusNotFound, apierr.Error("NO_SUCH_REPORT", "No such report.", "ac2cf84c-3c73-44f0-8e8f-0e76f2cb5eb3"))
 	}
 	resolvedAs := "accept"
 	err := h.abuseRepo.UpdateFields(req.ReportID, map[string]any{
@@ -897,7 +897,7 @@ func (h *Handler) ResolveAbuseReport(c echo.Context) error {
 		"resolvedAs": resolvedAs,
 	})
 	if err != nil {
-		return c.JSON(http.StatusNotFound, errResp("NO_SUCH_REPORT", "No such report.", "ac2cf84c-3c73-44f0-8e8f-0e76f2cb5eb3"))
+		return c.JSON(http.StatusNotFound, apierr.Error("NO_SUCH_REPORT", "No such report.", "ac2cf84c-3c73-44f0-8e8f-0e76f2cb5eb3"))
 	}
 	return c.NoContent(http.StatusNoContent)
 }
@@ -909,18 +909,14 @@ func (h *Handler) ShowModerationLogs(c echo.Context) error {
 		Offset int `json:"offset"`
 	}
 	if err := c.Bind(&req); err != nil {
-		return c.JSON(http.StatusBadRequest, errResp("INVALID_PARAM", "Invalid parameters.", "3d81ceae-475f-4600-b2a8-2bc116157532"))
+		return c.JSON(http.StatusBadRequest, apierr.Error("INVALID_PARAM", "Invalid parameters.", "3d81ceae-475f-4600-b2a8-2bc116157532"))
 	}
 	if h.modLogRepo == nil {
 		return c.JSON(http.StatusOK, []any{})
 	}
 	logs, err := h.modLogRepo.List(req.Limit, req.Offset)
 	if err != nil {
-		return c.JSON(http.StatusInternalServerError, errResp("INTERNAL_ERROR", "Internal error.", "5d37dbcb-891e-41ca-a3d6-e690c97775ac"))
+		return c.JSON(http.StatusInternalServerError, apierr.Error("INTERNAL_ERROR", "Internal error.", "5d37dbcb-891e-41ca-a3d6-e690c97775ac"))
 	}
 	return c.JSON(http.StatusOK, logs)
-}
-
-func errResp(code, message, id string) map[string]any {
-	return apierr.Error(code, message, id)
 }

--- a/internal/api/admin/handler_stubs.go
+++ b/internal/api/admin/handler_stubs.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/labstack/echo/v4"
+	"github.com/shiroha-a/mk/internal/api/apierr"
 	"github.com/shiroha-a/mk/internal/core/serverstats"
 	"github.com/shiroha-a/mk/internal/entity"
 	"github.com/shiroha-a/mk/internal/model"
@@ -36,10 +37,10 @@ func (h *Handler) AccountsFindByEmail(c echo.Context) error {
 		Email string `json:"email"`
 	}
 	if err := c.Bind(&req); err != nil || req.Email == "" {
-		return c.JSON(http.StatusBadRequest, errResp("INVALID_PARAM", "email is required.", "3d81ceae-475f-4600-b2a8-2bc116157532"))
+		return c.JSON(http.StatusBadRequest, apierr.Error("INVALID_PARAM", "email is required.", "3d81ceae-475f-4600-b2a8-2bc116157532"))
 	}
 	// メール検索は未実装 (user_profileテーブルのemail列検索が必要)
-	return c.JSON(http.StatusNotFound, errResp("USER_NOT_FOUND", "User not found.", "a504947-b888-4a99-9f62-8c4a0f3a3dab"))
+	return c.JSON(http.StatusNotFound, apierr.Error("USER_NOT_FOUND", "User not found.", "a504947-b888-4a99-9f62-8c4a0f3a3dab"))
 }
 
 // --- single endpoints ---
@@ -99,7 +100,7 @@ func (h *Handler) GetUserIPs(c echo.Context) error {
 		UserID string `json:"userId"`
 	}
 	if err := c.Bind(&req); err != nil || req.UserID == "" {
-		return c.JSON(http.StatusBadRequest, errResp("INVALID_PARAM", "userId is required.", "3d81ceae-475f-4600-b2a8-2bc116157532"))
+		return c.JSON(http.StatusBadRequest, apierr.Error("INVALID_PARAM", "userId is required.", "3d81ceae-475f-4600-b2a8-2bc116157532"))
 	}
 	ips, err := h.userIPRepo.ListByUser(req.UserID, 30)
 	if err != nil {
@@ -121,7 +122,7 @@ func (h *Handler) ResetPassword(c echo.Context) error {
 		UserID string `json:"userId"`
 	}
 	if err := c.Bind(&req); err != nil || req.UserID == "" {
-		return c.JSON(http.StatusBadRequest, errResp("INVALID_PARAM", "userId is required.", "3d81ceae-475f-4600-b2a8-2bc116157532"))
+		return c.JSON(http.StatusBadRequest, apierr.Error("INVALID_PARAM", "userId is required.", "3d81ceae-475f-4600-b2a8-2bc116157532"))
 	}
 	// ランダムパスワード生成
 	b := make([]byte, 8)
@@ -281,14 +282,14 @@ func (h *Handler) DriveShowFile(c echo.Context) error {
 		FileID string `json:"fileId"`
 	}
 	if err := c.Bind(&req); err != nil || req.FileID == "" {
-		return c.JSON(http.StatusBadRequest, errResp("INVALID_PARAM", "fileId is required.", "3d81ceae-475f-4600-b2a8-2bc116157532"))
+		return c.JSON(http.StatusBadRequest, apierr.Error("INVALID_PARAM", "fileId is required.", "3d81ceae-475f-4600-b2a8-2bc116157532"))
 	}
 	if h.driveFileRepo == nil {
-		return c.JSON(http.StatusNotFound, errResp("NO_SUCH_FILE", "No such file.", "ac4f7b11-1a6e-47e3-bf3d-3dce9a0e07ab"))
+		return c.JSON(http.StatusNotFound, apierr.Error("NO_SUCH_FILE", "No such file.", "ac4f7b11-1a6e-47e3-bf3d-3dce9a0e07ab"))
 	}
 	file, err := h.driveFileRepo.FindByID(req.FileID)
 	if err != nil {
-		return c.JSON(http.StatusNotFound, errResp("NO_SUCH_FILE", "No such file.", "ac4f7b11-1a6e-47e3-bf3d-3dce9a0e07ab"))
+		return c.JSON(http.StatusNotFound, apierr.Error("NO_SUCH_FILE", "No such file.", "ac4f7b11-1a6e-47e3-bf3d-3dce9a0e07ab"))
 	}
 	return c.JSON(http.StatusOK, entity.PackDriveFile(file, h.idGen))
 }
@@ -668,7 +669,7 @@ func (h *Handler) AbuseReportNotificationRecipientList(c echo.Context) error {
 
 // AbuseReportNotificationRecipientShow handles POST /api/admin/abuse-report/notification-recipient/show.
 func (h *Handler) AbuseReportNotificationRecipientShow(c echo.Context) error {
-	return c.JSON(http.StatusNotFound, errResp("NOT_FOUND", "Not found.", "00000000-0000-0000-0000-000000000000"))
+	return c.JSON(http.StatusNotFound, apierr.Error("NOT_FOUND", "Not found.", "00000000-0000-0000-0000-000000000000"))
 }
 
 // AbuseReportNotificationRecipientUpdate handles POST /api/admin/abuse-report/notification-recipient/update.
@@ -785,7 +786,7 @@ func (h *Handler) PromoCreate(c echo.Context) error {
 		ExpiresAt int64  `json:"expiresAt"`
 	}
 	if err := c.Bind(&req); err != nil || req.NoteID == "" {
-		return c.JSON(http.StatusBadRequest, errResp("INVALID_PARAM", "noteId is required.", "3d81ceae-475f-4600-b2a8-2bc116157532"))
+		return c.JSON(http.StatusBadRequest, apierr.Error("INVALID_PARAM", "noteId is required.", "3d81ceae-475f-4600-b2a8-2bc116157532"))
 	}
 	u := middleware.GetUser(c)
 	userID := ""
@@ -891,7 +892,7 @@ func (h *Handler) QueueRetryJob(c echo.Context) error {
 
 // QueueShowJob handles POST /api/admin/queue/show-job.
 func (h *Handler) QueueShowJob(c echo.Context) error {
-	return c.JSON(http.StatusNotFound, errResp("NOT_FOUND", "Not found.", "00000000-0000-0000-0000-000000000000"))
+	return c.JSON(http.StatusNotFound, apierr.Error("NOT_FOUND", "Not found.", "00000000-0000-0000-0000-000000000000"))
 }
 
 // QueueShowJobLogs handles POST /api/admin/queue/show-job-logs.
@@ -1011,7 +1012,7 @@ func (h *Handler) SystemWebhookList(c echo.Context) error {
 // SystemWebhookShow handles POST /api/admin/system-webhook/show.
 func (h *Handler) SystemWebhookShow(c echo.Context) error {
 	if h.adminDB == nil {
-		return c.JSON(http.StatusNotFound, errResp("NOT_FOUND", "Not found.", "00000000-0000-0000-0000-000000000000"))
+		return c.JSON(http.StatusNotFound, apierr.Error("NOT_FOUND", "Not found.", "00000000-0000-0000-0000-000000000000"))
 	}
 	var req struct {
 		ID string `json:"id"`
@@ -1019,7 +1020,7 @@ func (h *Handler) SystemWebhookShow(c echo.Context) error {
 	_ = c.Bind(&req)
 	var sw model.SystemWebhook
 	if err := h.adminDB.Where(`"id" = ?`, req.ID).First(&sw).Error; err != nil {
-		return c.JSON(http.StatusNotFound, errResp("NOT_FOUND", "Not found.", "00000000-0000-0000-0000-000000000000"))
+		return c.JSON(http.StatusNotFound, apierr.Error("NOT_FOUND", "Not found.", "00000000-0000-0000-0000-000000000000"))
 	}
 	return c.JSON(http.StatusOK, sw)
 }

--- a/internal/api/announcements/handler.go
+++ b/internal/api/announcements/handler.go
@@ -31,7 +31,7 @@ func (h *Handler) List(c echo.Context) error {
 		IsActive *bool `json:"isActive"`
 	}
 	if err := c.Bind(&req); err != nil {
-		return c.JSON(http.StatusBadRequest, errResp("INVALID_PARAM", "Invalid parameters.", "3d81ceae-475f-4600-b2a8-2bc116157532"))
+		return c.JSON(http.StatusBadRequest, apierr.Error("INVALID_PARAM", "Invalid parameters.", "3d81ceae-475f-4600-b2a8-2bc116157532"))
 	}
 	activeOnly := true
 	if req.IsActive != nil {
@@ -39,7 +39,7 @@ func (h *Handler) List(c echo.Context) error {
 	}
 	items, err := h.repo.List(activeOnly, req.Limit, req.Offset)
 	if err != nil {
-		return c.JSON(http.StatusInternalServerError, errResp("INTERNAL_ERROR", "Internal error.", "5d37dbcb-891e-41ca-a3d6-e690c97775ac"))
+		return c.JSON(http.StatusInternalServerError, apierr.Error("INTERNAL_ERROR", "Internal error.", "5d37dbcb-891e-41ca-a3d6-e690c97775ac"))
 	}
 
 	// 認証ユーザーがいれば既読情報を付与
@@ -63,10 +63,10 @@ func (h *Handler) ReadAnnouncement(c echo.Context) error {
 		AnnouncementID string `json:"announcementId"`
 	}
 	if err := c.Bind(&req); err != nil || req.AnnouncementID == "" {
-		return c.JSON(http.StatusBadRequest, errResp("INVALID_PARAM", "announcementId is required.", "3d81ceae-475f-4600-b2a8-2bc116157532"))
+		return c.JSON(http.StatusBadRequest, apierr.Error("INVALID_PARAM", "announcementId is required.", "3d81ceae-475f-4600-b2a8-2bc116157532"))
 	}
 	if _, err := h.repo.FindByID(req.AnnouncementID); err != nil {
-		return c.JSON(http.StatusNotFound, errResp("NO_SUCH_ANNOUNCEMENT", "No such announcement.", "b57b5e1d-0158-4f8d-bd54-1ab374089a15"))
+		return c.JSON(http.StatusNotFound, apierr.Error("NO_SUCH_ANNOUNCEMENT", "No such announcement.", "b57b5e1d-0158-4f8d-bd54-1ab374089a15"))
 	}
 	already, _ := h.repo.IsRead(user.ID, req.AnnouncementID)
 	if already {
@@ -78,7 +78,7 @@ func (h *Handler) ReadAnnouncement(c echo.Context) error {
 		AnnouncementID: req.AnnouncementID,
 	}
 	if err := h.repo.MarkRead(read); err != nil {
-		return c.JSON(http.StatusInternalServerError, errResp("INTERNAL_ERROR", "Internal error.", "5d37dbcb-891e-41ca-a3d6-e690c97775ac"))
+		return c.JSON(http.StatusInternalServerError, apierr.Error("INTERNAL_ERROR", "Internal error.", "5d37dbcb-891e-41ca-a3d6-e690c97775ac"))
 	}
 	return c.NoContent(http.StatusNoContent)
 }
@@ -95,7 +95,7 @@ func (h *Handler) AdminCreate(c echo.Context) error {
 		Display  string  `json:"display"`
 	}
 	if err := c.Bind(&req); err != nil || req.Title == "" || req.Text == "" {
-		return c.JSON(http.StatusBadRequest, errResp("INVALID_PARAM", "title and text are required.", "3d81ceae-475f-4600-b2a8-2bc116157532"))
+		return c.JSON(http.StatusBadRequest, apierr.Error("INVALID_PARAM", "title and text are required.", "3d81ceae-475f-4600-b2a8-2bc116157532"))
 	}
 	if req.Icon == "" {
 		req.Icon = "info"
@@ -113,7 +113,7 @@ func (h *Handler) AdminCreate(c echo.Context) error {
 		IsActive: true,
 	}
 	if err := h.repo.Create(a); err != nil {
-		return c.JSON(http.StatusInternalServerError, errResp("INTERNAL_ERROR", "Internal error.", "5d37dbcb-891e-41ca-a3d6-e690c97775ac"))
+		return c.JSON(http.StatusInternalServerError, apierr.Error("INTERNAL_ERROR", "Internal error.", "5d37dbcb-891e-41ca-a3d6-e690c97775ac"))
 	}
 	return c.JSON(http.StatusOK, a)
 }
@@ -127,7 +127,7 @@ func (h *Handler) AdminUpdate(c echo.Context) error {
 		IsActive *bool   `json:"isActive"`
 	}
 	if err := c.Bind(&req); err != nil || req.ID == "" {
-		return c.JSON(http.StatusBadRequest, errResp("INVALID_PARAM", "id is required.", "3d81ceae-475f-4600-b2a8-2bc116157532"))
+		return c.JSON(http.StatusBadRequest, apierr.Error("INVALID_PARAM", "id is required.", "3d81ceae-475f-4600-b2a8-2bc116157532"))
 	}
 	fields := map[string]any{}
 	if req.Title != nil {
@@ -140,7 +140,7 @@ func (h *Handler) AdminUpdate(c echo.Context) error {
 		fields["isActive"] = *req.IsActive
 	}
 	if err := h.repo.UpdateFields(req.ID, fields); err != nil {
-		return c.JSON(http.StatusNotFound, errResp("NO_SUCH_ANNOUNCEMENT", "No such announcement.", "b57b5e1d-0158-4f8d-bd54-1ab374089a15"))
+		return c.JSON(http.StatusNotFound, apierr.Error("NO_SUCH_ANNOUNCEMENT", "No such announcement.", "b57b5e1d-0158-4f8d-bd54-1ab374089a15"))
 	}
 	return c.NoContent(http.StatusNoContent)
 }
@@ -151,10 +151,10 @@ func (h *Handler) AdminDelete(c echo.Context) error {
 		ID string `json:"id"`
 	}
 	if err := c.Bind(&req); err != nil || req.ID == "" {
-		return c.JSON(http.StatusBadRequest, errResp("INVALID_PARAM", "id is required.", "3d81ceae-475f-4600-b2a8-2bc116157532"))
+		return c.JSON(http.StatusBadRequest, apierr.Error("INVALID_PARAM", "id is required.", "3d81ceae-475f-4600-b2a8-2bc116157532"))
 	}
 	if err := h.repo.Delete(req.ID); err != nil {
-		return c.JSON(http.StatusNotFound, errResp("NO_SUCH_ANNOUNCEMENT", "No such announcement.", "b57b5e1d-0158-4f8d-bd54-1ab374089a15"))
+		return c.JSON(http.StatusNotFound, apierr.Error("NO_SUCH_ANNOUNCEMENT", "No such announcement.", "b57b5e1d-0158-4f8d-bd54-1ab374089a15"))
 	}
 	return c.NoContent(http.StatusNoContent)
 }
@@ -166,11 +166,11 @@ func (h *Handler) AdminList(c echo.Context) error {
 		Offset int `json:"offset"`
 	}
 	if err := c.Bind(&req); err != nil {
-		return c.JSON(http.StatusBadRequest, errResp("INVALID_PARAM", "Invalid parameters.", "3d81ceae-475f-4600-b2a8-2bc116157532"))
+		return c.JSON(http.StatusBadRequest, apierr.Error("INVALID_PARAM", "Invalid parameters.", "3d81ceae-475f-4600-b2a8-2bc116157532"))
 	}
 	items, err := h.repo.List(false, req.Limit, req.Offset)
 	if err != nil {
-		return c.JSON(http.StatusInternalServerError, errResp("INTERNAL_ERROR", "Internal error.", "5d37dbcb-891e-41ca-a3d6-e690c97775ac"))
+		return c.JSON(http.StatusInternalServerError, apierr.Error("INTERNAL_ERROR", "Internal error.", "5d37dbcb-891e-41ca-a3d6-e690c97775ac"))
 	}
 	return c.JSON(http.StatusOK, items)
 }
@@ -194,8 +194,4 @@ func packAnnouncement(a *model.Announcement, idGen id.Generator) map[string]any 
 		"forExistingUsers":       a.ForExistingUsers,
 		"isActive":               a.IsActive,
 	}
-}
-
-func errResp(code, message, id string) map[string]any {
-	return apierr.Error(code, message, id)
 }

--- a/internal/api/announcements/handler_show.go
+++ b/internal/api/announcements/handler_show.go
@@ -4,6 +4,7 @@ import (
 	"net/http"
 
 	"github.com/labstack/echo/v4"
+	"github.com/shiroha-a/mk/internal/api/apierr"
 )
 
 // Show handles POST /api/announcements/show.
@@ -12,11 +13,11 @@ func (h *Handler) Show(c echo.Context) error {
 		AnnouncementID string `json:"announcementId"`
 	}
 	if err := c.Bind(&req); err != nil || req.AnnouncementID == "" {
-		return c.JSON(http.StatusBadRequest, errResp("INVALID_PARAM", "announcementId is required.", "3d81ceae-475f-4600-b2a8-2bc116157532"))
+		return c.JSON(http.StatusBadRequest, apierr.Error("INVALID_PARAM", "announcementId is required.", "3d81ceae-475f-4600-b2a8-2bc116157532"))
 	}
 	a, err := h.repo.FindByID(req.AnnouncementID)
 	if err != nil {
-		return c.JSON(http.StatusNotFound, errResp("NO_SUCH_ANNOUNCEMENT", "No such announcement.", "e0ef2076-ee94-4ebc-a2c8-63bec9e7ab72"))
+		return c.JSON(http.StatusNotFound, apierr.Error("NO_SUCH_ANNOUNCEMENT", "No such announcement.", "e0ef2076-ee94-4ebc-a2c8-63bec9e7ab72"))
 	}
 	return c.JSON(http.StatusOK, packAnnouncement(a, h.idGen))
 }

--- a/internal/api/app/handler.go
+++ b/internal/api/app/handler.go
@@ -25,10 +25,6 @@ func NewHandler(repo repository.AuthSessionRepository, idGen id.Generator) *Hand
 	return &Handler{repo: repo, idGen: idGen}
 }
 
-func apiError(code, message, errID string) map[string]any {
-	return apierr.Error(code, message, errID)
-}
-
 // Create handles POST /api/app/create.
 func (h *Handler) Create(c echo.Context) error {
 	var req struct {
@@ -38,7 +34,7 @@ func (h *Handler) Create(c echo.Context) error {
 		CallbackURL *string  `json:"callbackUrl"`
 	}
 	if err := c.Bind(&req); err != nil || req.Name == "" || req.Description == "" || req.Permission == nil {
-		return c.JSON(http.StatusBadRequest, apiError("INVALID_PARAM", "name, description, and permission are required.", "3d81ceae-475f-4600-b2a8-2bc116157532"))
+		return c.JSON(http.StatusBadRequest, apierr.Error("INVALID_PARAM", "name, description, and permission are required.", "3d81ceae-475f-4600-b2a8-2bc116157532"))
 	}
 
 	// 認証済みユーザーのIDを取得（任意）
@@ -59,7 +55,7 @@ func (h *Handler) Create(c echo.Context) error {
 		CallbackURL: req.CallbackURL,
 	}
 	if err := h.repo.CreateApp(a); err != nil {
-		return c.JSON(http.StatusInternalServerError, apiError("INTERNAL_ERROR", "Internal error.", "5d37dbcb-891e-41ca-a3d6-e690c97775ac"))
+		return c.JSON(http.StatusInternalServerError, apierr.Error("INTERNAL_ERROR", "Internal error.", "5d37dbcb-891e-41ca-a3d6-e690c97775ac"))
 	}
 
 	return c.JSON(http.StatusOK, packApp(a, true))
@@ -71,12 +67,12 @@ func (h *Handler) Show(c echo.Context) error {
 		AppID string `json:"appId"`
 	}
 	if err := c.Bind(&req); err != nil || req.AppID == "" {
-		return c.JSON(http.StatusBadRequest, apiError("INVALID_PARAM", "appId is required.", "3d81ceae-475f-4600-b2a8-2bc116157532"))
+		return c.JSON(http.StatusBadRequest, apierr.Error("INVALID_PARAM", "appId is required.", "3d81ceae-475f-4600-b2a8-2bc116157532"))
 	}
 
 	a, err := h.repo.FindAppByID(req.AppID)
 	if err != nil {
-		return c.JSON(http.StatusNotFound, apiError("NO_SUCH_APP", "No such app.", "dce83913-2dc6-4093-8a7b-71dbb11718a3"))
+		return c.JSON(http.StatusNotFound, apierr.Error("NO_SUCH_APP", "No such app.", "dce83913-2dc6-4093-8a7b-71dbb11718a3"))
 	}
 
 	// 認証済み && 自分のアプリならsecretも返す
@@ -96,7 +92,7 @@ func (h *Handler) MyApps(c echo.Context) error {
 		Offset *int `json:"offset"`
 	}
 	if err := c.Bind(&req); err != nil {
-		return c.JSON(http.StatusBadRequest, apiError("INVALID_PARAM", "Invalid parameters.", "3d81ceae-475f-4600-b2a8-2bc116157532"))
+		return c.JSON(http.StatusBadRequest, apierr.Error("INVALID_PARAM", "Invalid parameters.", "3d81ceae-475f-4600-b2a8-2bc116157532"))
 	}
 
 	limit := 10
@@ -116,7 +112,7 @@ func (h *Handler) MyApps(c echo.Context) error {
 
 	apps, err := h.repo.ListAppsByUserID(u.ID, limit, offset)
 	if err != nil {
-		return c.JSON(http.StatusInternalServerError, apiError("INTERNAL_ERROR", "Internal error.", "5d37dbcb-891e-41ca-a3d6-e690c97775ac"))
+		return c.JSON(http.StatusInternalServerError, apierr.Error("INTERNAL_ERROR", "Internal error.", "5d37dbcb-891e-41ca-a3d6-e690c97775ac"))
 	}
 
 	result := make([]map[string]any, len(apps))

--- a/internal/api/auth/handler.go
+++ b/internal/api/auth/handler.go
@@ -30,22 +30,18 @@ func NewHandler(repo repository.AuthSessionRepository, cfg *config.Config, idGen
 	return &Handler{repo: repo, cfg: cfg, idGen: idGen}
 }
 
-func apiError(code, message, errID string) map[string]any {
-	return apierr.Error(code, message, errID)
-}
-
 // SessionGenerate handles POST /api/auth/session/generate.
 func (h *Handler) SessionGenerate(c echo.Context) error {
 	var req struct {
 		AppSecret string `json:"appSecret"`
 	}
 	if err := c.Bind(&req); err != nil || req.AppSecret == "" {
-		return c.JSON(http.StatusBadRequest, apiError("INVALID_PARAM", "appSecret is required.", "ed1d7571-a3ac-4370-899c-0dbe5e230cc8"))
+		return c.JSON(http.StatusBadRequest, apierr.Error("INVALID_PARAM", "appSecret is required.", "ed1d7571-a3ac-4370-899c-0dbe5e230cc8"))
 	}
 
 	app, err := h.repo.FindAppBySecret(req.AppSecret)
 	if err != nil {
-		return c.JSON(http.StatusNotFound, apiError("NO_SUCH_APP", "No such app.", "c5628b5a-3c9e-4e3f-b765-44952b2bfb0e"))
+		return c.JSON(http.StatusNotFound, apierr.Error("NO_SUCH_APP", "No such app.", "c5628b5a-3c9e-4e3f-b765-44952b2bfb0e"))
 	}
 
 	token := uuid.New().String()
@@ -57,7 +53,7 @@ func (h *Handler) SessionGenerate(c echo.Context) error {
 		AppID:     app.ID,
 	}
 	if err := h.repo.CreateSession(session); err != nil {
-		return c.JSON(http.StatusInternalServerError, apiError("INTERNAL_ERROR", "Internal error.", "5d37dbcb-891e-41ca-a3d6-e690c97775ac"))
+		return c.JSON(http.StatusInternalServerError, apierr.Error("INTERNAL_ERROR", "Internal error.", "5d37dbcb-891e-41ca-a3d6-e690c97775ac"))
 	}
 
 	return c.JSON(http.StatusOK, map[string]any{
@@ -72,12 +68,12 @@ func (h *Handler) SessionShow(c echo.Context) error {
 		Token string `json:"token"`
 	}
 	if err := c.Bind(&req); err != nil || req.Token == "" {
-		return c.JSON(http.StatusBadRequest, apiError("INVALID_PARAM", "token is required.", "ed1d7571-a3ac-4370-899c-0dbe5e230cc8"))
+		return c.JSON(http.StatusBadRequest, apierr.Error("INVALID_PARAM", "token is required.", "ed1d7571-a3ac-4370-899c-0dbe5e230cc8"))
 	}
 
 	session, err := h.repo.FindSessionByToken(req.Token)
 	if err != nil {
-		return c.JSON(http.StatusNotFound, apiError("NO_SUCH_SESSION", "No such session.", "bd72c97d-eca4-4403-8269-7b9cc0b9a2c0"))
+		return c.JSON(http.StatusNotFound, apierr.Error("NO_SUCH_SESSION", "No such session.", "bd72c97d-eca4-4403-8269-7b9cc0b9a2c0"))
 	}
 
 	return c.JSON(http.StatusOK, packSession(session))
@@ -90,12 +86,12 @@ func (h *Handler) Accept(c echo.Context) error {
 		Token string `json:"token"`
 	}
 	if err := c.Bind(&req); err != nil || req.Token == "" {
-		return c.JSON(http.StatusBadRequest, apiError("INVALID_PARAM", "token is required.", "ed1d7571-a3ac-4370-899c-0dbe5e230cc8"))
+		return c.JSON(http.StatusBadRequest, apierr.Error("INVALID_PARAM", "token is required.", "ed1d7571-a3ac-4370-899c-0dbe5e230cc8"))
 	}
 
 	session, err := h.repo.FindSessionByToken(req.Token)
 	if err != nil {
-		return c.JSON(http.StatusNotFound, apiError("NO_SUCH_SESSION", "No such session.", "bd72c97d-eca4-4403-8269-7b9cc0b9a2c0"))
+		return c.JSON(http.StatusNotFound, apierr.Error("NO_SUCH_SESSION", "No such session.", "bd72c97d-eca4-4403-8269-7b9cc0b9a2c0"))
 	}
 
 	// アクセストークンが既に存在するか確認
@@ -115,13 +111,13 @@ func (h *Handler) Accept(c echo.Context) error {
 			LastUsedAt: &now,
 		}
 		if err := h.repo.CreateAccessToken(accessToken); err != nil {
-			return c.JSON(http.StatusInternalServerError, apiError("INTERNAL_ERROR", "Internal error.", "5d37dbcb-891e-41ca-a3d6-e690c97775ac"))
+			return c.JSON(http.StatusInternalServerError, apierr.Error("INTERNAL_ERROR", "Internal error.", "5d37dbcb-891e-41ca-a3d6-e690c97775ac"))
 		}
 	}
 
 	// セッションにユーザーIDを設定
 	if err := h.repo.UpdateSessionUserID(session.ID, user.ID); err != nil {
-		return c.JSON(http.StatusInternalServerError, apiError("INTERNAL_ERROR", "Internal error.", "5d37dbcb-891e-41ca-a3d6-e690c97775ac"))
+		return c.JSON(http.StatusInternalServerError, apierr.Error("INTERNAL_ERROR", "Internal error.", "5d37dbcb-891e-41ca-a3d6-e690c97775ac"))
 	}
 
 	return c.NoContent(http.StatusNoContent)
@@ -134,26 +130,26 @@ func (h *Handler) SessionUserkey(c echo.Context) error {
 		Token     string `json:"token"`
 	}
 	if err := c.Bind(&req); err != nil || req.AppSecret == "" || req.Token == "" {
-		return c.JSON(http.StatusBadRequest, apiError("INVALID_PARAM", "appSecret and token are required.", "ed1d7571-a3ac-4370-899c-0dbe5e230cc8"))
+		return c.JSON(http.StatusBadRequest, apierr.Error("INVALID_PARAM", "appSecret and token are required.", "ed1d7571-a3ac-4370-899c-0dbe5e230cc8"))
 	}
 
 	app, err := h.repo.FindAppBySecret(req.AppSecret)
 	if err != nil {
-		return c.JSON(http.StatusNotFound, apiError("NO_SUCH_APP", "No such app.", "c5628b5a-3c9e-4e3f-b765-44952b2bfb0e"))
+		return c.JSON(http.StatusNotFound, apierr.Error("NO_SUCH_APP", "No such app.", "c5628b5a-3c9e-4e3f-b765-44952b2bfb0e"))
 	}
 
 	session, err := h.repo.FindSessionByTokenAndAppID(req.Token, app.ID)
 	if err != nil {
-		return c.JSON(http.StatusNotFound, apiError("NO_SUCH_SESSION", "No such session.", "bd72c97d-eca4-4403-8269-7b9cc0b9a2c0"))
+		return c.JSON(http.StatusNotFound, apierr.Error("NO_SUCH_SESSION", "No such session.", "bd72c97d-eca4-4403-8269-7b9cc0b9a2c0"))
 	}
 
 	if session.UserID == nil {
-		return c.JSON(http.StatusForbidden, apiError("PENDING_SESSION", "This session is not yet approved.", "8c8a4145-02cc-4cca-8e66-29ba60445a8e"))
+		return c.JSON(http.StatusForbidden, apierr.Error("PENDING_SESSION", "This session is not yet approved.", "8c8a4145-02cc-4cca-8e66-29ba60445a8e"))
 	}
 
 	accessToken, err := h.repo.FindAccessTokenByAppAndUser(app.ID, *session.UserID)
 	if err != nil {
-		return c.JSON(http.StatusInternalServerError, apiError("INTERNAL_ERROR", "Internal error.", "5d37dbcb-891e-41ca-a3d6-e690c97775ac"))
+		return c.JSON(http.StatusInternalServerError, apierr.Error("INTERNAL_ERROR", "Internal error.", "5d37dbcb-891e-41ca-a3d6-e690c97775ac"))
 	}
 
 	// セッション削除（使い捨て）
@@ -178,7 +174,7 @@ func (h *Handler) GenToken(c echo.Context) error {
 		Permission  []string `json:"permission"`
 	}
 	if err := c.Bind(&req); err != nil || req.Permission == nil {
-		return c.JSON(http.StatusBadRequest, apiError("INVALID_PARAM", "permission is required.", "ed1d7571-a3ac-4370-899c-0dbe5e230cc8"))
+		return c.JSON(http.StatusBadRequest, apierr.Error("INVALID_PARAM", "permission is required.", "ed1d7571-a3ac-4370-899c-0dbe5e230cc8"))
 	}
 
 	tokenStr := misc.SecureRandomHex(32)
@@ -196,7 +192,7 @@ func (h *Handler) GenToken(c echo.Context) error {
 		Permission:  req.Permission,
 	}
 	if err := h.repo.CreateAccessToken(accessToken); err != nil {
-		return c.JSON(http.StatusInternalServerError, apiError("INTERNAL_ERROR", "Internal error.", "5d37dbcb-891e-41ca-a3d6-e690c97775ac"))
+		return c.JSON(http.StatusInternalServerError, apierr.Error("INTERNAL_ERROR", "Internal error.", "5d37dbcb-891e-41ca-a3d6-e690c97775ac"))
 	}
 
 	return c.JSON(http.StatusOK, map[string]any{"token": tokenStr})

--- a/internal/api/bubblegame/handler.go
+++ b/internal/api/bubblegame/handler.go
@@ -25,10 +25,6 @@ func NewHandler(repo repository.BubbleGameRepository, idGen id.Generator) *Handl
 	return &Handler{repo: repo, idGen: idGen}
 }
 
-func apiError(code, message, errID string) map[string]any {
-	return apierr.Error(code, message, errID)
-}
-
 // Register handles POST /api/bubble-game/register.
 func (h *Handler) Register(c echo.Context) error {
 	user := middleware.GetUser(c)
@@ -40,24 +36,24 @@ func (h *Handler) Register(c echo.Context) error {
 		GameVersion int     `json:"gameVersion"`
 	}
 	if err := c.Bind(&req); err != nil || req.Seed == "" || req.GameMode == "" {
-		return c.JSON(http.StatusBadRequest, apiError("INVALID_PARAM", "score, seed, logs, gameMode, gameVersion are required.", "ed1d7571-a3ac-4370-899c-0dbe5e230cc8"))
+		return c.JSON(http.StatusBadRequest, apierr.Error("INVALID_PARAM", "score, seed, logs, gameMode, gameVersion are required.", "ed1d7571-a3ac-4370-899c-0dbe5e230cc8"))
 	}
 
 	// シード検証: seedはUnixタイムスタンプ文字列
 	seedMs, err := strconv.ParseInt(req.Seed, 10, 64)
 	if err != nil {
-		return c.JSON(http.StatusBadRequest, apiError("INVALID_SEED", "Provided seed is invalid.", "eb627bc7-574b-4a52-a860-3c3eae772b88"))
+		return c.JSON(http.StatusBadRequest, apierr.Error("INVALID_SEED", "Provided seed is invalid.", "eb627bc7-574b-4a52-a860-3c3eae772b88"))
 	}
 	seedDate := time.UnixMilli(seedMs)
 	now := time.Now()
 
 	// 未来のシードは不正
 	if seedDate.After(now) {
-		return c.JSON(http.StatusBadRequest, apiError("INVALID_SEED", "Provided seed is invalid.", "eb627bc7-574b-4a52-a860-3c3eae772b88"))
+		return c.JSON(http.StatusBadRequest, apierr.Error("INVALID_SEED", "Provided seed is invalid.", "eb627bc7-574b-4a52-a860-3c3eae772b88"))
 	}
 	// 5時間以上前のシードは不正
 	if seedDate.Before(now.Add(-5 * time.Hour)) {
-		return c.JSON(http.StatusBadRequest, apiError("INVALID_SEED", "Provided seed is invalid.", "eb627bc7-574b-4a52-a860-3c3eae772b88"))
+		return c.JSON(http.StatusBadRequest, apierr.Error("INVALID_SEED", "Provided seed is invalid.", "eb627bc7-574b-4a52-a860-3c3eae772b88"))
 	}
 
 	logsJSON, _ := json.Marshal(req.Logs)
@@ -73,7 +69,7 @@ func (h *Handler) Register(c echo.Context) error {
 		IsVerified:  false,
 	}
 	if err := h.repo.Create(record); err != nil {
-		return c.JSON(http.StatusInternalServerError, apiError("INTERNAL_ERROR", "Internal error.", "5d37dbcb-891e-41ca-a3d6-e690c97775ac"))
+		return c.JSON(http.StatusInternalServerError, apierr.Error("INTERNAL_ERROR", "Internal error.", "5d37dbcb-891e-41ca-a3d6-e690c97775ac"))
 	}
 	return c.NoContent(http.StatusNoContent)
 }
@@ -84,7 +80,7 @@ func (h *Handler) Ranking(c echo.Context) error {
 		GameMode string `json:"gameMode"`
 	}
 	if err := c.Bind(&req); err != nil || req.GameMode == "" {
-		return c.JSON(http.StatusBadRequest, apiError("INVALID_PARAM", "gameMode is required.", "ed1d7571-a3ac-4370-899c-0dbe5e230cc8"))
+		return c.JSON(http.StatusBadRequest, apierr.Error("INVALID_PARAM", "gameMode is required.", "ed1d7571-a3ac-4370-899c-0dbe5e230cc8"))
 	}
 
 	records, err := h.repo.Ranking(req.GameMode, 10)

--- a/internal/api/chat/handler.go
+++ b/internal/api/chat/handler.go
@@ -41,17 +41,13 @@ func (h *Handler) SetService(svc *corechat.Service) {
 func (h *Handler) mapChatErr(c echo.Context, err error) error {
 	switch {
 	case errors.Is(err, corechat.ErrNotFound):
-		return c.JSON(http.StatusNotFound, apiError("NO_SUCH_MESSAGE", "No such message.", "00000000-0000-0000-0000-000000000000"))
+		return c.JSON(http.StatusNotFound, apierr.Error("NO_SUCH_MESSAGE", "No such message.", "00000000-0000-0000-0000-000000000000"))
 	case errors.Is(err, corechat.ErrForbidden):
-		return c.JSON(http.StatusForbidden, apiError("ACCESS_DENIED", "Access denied.", "00000000-0000-0000-0000-000000000000"))
+		return c.JSON(http.StatusForbidden, apierr.Error("ACCESS_DENIED", "Access denied.", "00000000-0000-0000-0000-000000000000"))
 	case errors.Is(err, corechat.ErrInvalidTarget):
-		return c.JSON(http.StatusBadRequest, apiError("INVALID_PARAM", "toUserId or toRoomId is required.", "ed1d7571-a3ac-4370-899c-0dbe5e230cc8"))
+		return c.JSON(http.StatusBadRequest, apierr.Error("INVALID_PARAM", "toUserId or toRoomId is required.", "ed1d7571-a3ac-4370-899c-0dbe5e230cc8"))
 	}
-	return c.JSON(http.StatusInternalServerError, apiError("INTERNAL_ERROR", "Internal error.", "5d37dbcb-891e-41ca-a3d6-e690c97775ac"))
-}
-
-func apiError(code, message, errID string) map[string]any {
-	return apierr.Error(code, message, errID)
+	return c.JSON(http.StatusInternalServerError, apierr.Error("INTERNAL_ERROR", "Internal error.", "5d37dbcb-891e-41ca-a3d6-e690c97775ac"))
 }
 
 func packRoom(r *model.ChatRoom) map[string]any {
@@ -92,14 +88,14 @@ func (h *Handler) RoomsCreate(c echo.Context) error {
 		Description string `json:"description"`
 	}
 	if err := c.Bind(&req); err != nil || req.Name == "" {
-		return c.JSON(http.StatusBadRequest, apiError("INVALID_PARAM", "name is required.", "ed1d7571-a3ac-4370-899c-0dbe5e230cc8"))
+		return c.JSON(http.StatusBadRequest, apierr.Error("INVALID_PARAM", "name is required.", "ed1d7571-a3ac-4370-899c-0dbe5e230cc8"))
 	}
 	room := &model.ChatRoom{
 		ID: h.idGen.Generate(time.Now()), Name: req.Name,
 		OwnerID: user.ID, Description: req.Description,
 	}
 	if err := h.repo.CreateRoom(room); err != nil {
-		return c.JSON(http.StatusInternalServerError, apiError("INTERNAL_ERROR", "Internal error.", "5d37dbcb-891e-41ca-a3d6-e690c97775ac"))
+		return c.JSON(http.StatusInternalServerError, apierr.Error("INTERNAL_ERROR", "Internal error.", "5d37dbcb-891e-41ca-a3d6-e690c97775ac"))
 	}
 	return c.JSON(http.StatusOK, packRoom(room))
 }
@@ -110,11 +106,11 @@ func (h *Handler) RoomsShow(c echo.Context) error {
 		RoomID string `json:"roomId"`
 	}
 	if err := c.Bind(&req); err != nil || req.RoomID == "" {
-		return c.JSON(http.StatusBadRequest, apiError("INVALID_PARAM", "roomId is required.", "ed1d7571-a3ac-4370-899c-0dbe5e230cc8"))
+		return c.JSON(http.StatusBadRequest, apierr.Error("INVALID_PARAM", "roomId is required.", "ed1d7571-a3ac-4370-899c-0dbe5e230cc8"))
 	}
 	room, err := h.repo.FindRoomByID(req.RoomID)
 	if err != nil {
-		return c.JSON(http.StatusNotFound, apiError("NO_SUCH_ROOM", "No such room.", "00000000-0000-0000-0000-000000000000"))
+		return c.JSON(http.StatusNotFound, apierr.Error("NO_SUCH_ROOM", "No such room.", "00000000-0000-0000-0000-000000000000"))
 	}
 	return c.JSON(http.StatusOK, packRoom(room))
 }
@@ -128,11 +124,11 @@ func (h *Handler) RoomsUpdate(c echo.Context) error {
 		Description string `json:"description"`
 	}
 	if err := c.Bind(&req); err != nil || req.RoomID == "" {
-		return c.JSON(http.StatusBadRequest, apiError("INVALID_PARAM", "roomId is required.", "ed1d7571-a3ac-4370-899c-0dbe5e230cc8"))
+		return c.JSON(http.StatusBadRequest, apierr.Error("INVALID_PARAM", "roomId is required.", "ed1d7571-a3ac-4370-899c-0dbe5e230cc8"))
 	}
 	room, err := h.repo.FindRoomByID(req.RoomID)
 	if err != nil || room.OwnerID != user.ID {
-		return c.JSON(http.StatusNotFound, apiError("NO_SUCH_ROOM", "No such room.", "00000000-0000-0000-0000-000000000000"))
+		return c.JSON(http.StatusNotFound, apierr.Error("NO_SUCH_ROOM", "No such room.", "00000000-0000-0000-0000-000000000000"))
 	}
 	if req.Name != "" {
 		room.Name = req.Name
@@ -141,7 +137,7 @@ func (h *Handler) RoomsUpdate(c echo.Context) error {
 		room.Description = req.Description
 	}
 	if err := h.repo.UpdateRoom(room); err != nil {
-		return c.JSON(http.StatusInternalServerError, apiError("INTERNAL_ERROR", "Internal error.", "5d37dbcb-891e-41ca-a3d6-e690c97775ac"))
+		return c.JSON(http.StatusInternalServerError, apierr.Error("INTERNAL_ERROR", "Internal error.", "5d37dbcb-891e-41ca-a3d6-e690c97775ac"))
 	}
 	return c.JSON(http.StatusOK, packRoom(room))
 }
@@ -153,11 +149,11 @@ func (h *Handler) RoomsDelete(c echo.Context) error {
 		RoomID string `json:"roomId"`
 	}
 	if err := c.Bind(&req); err != nil || req.RoomID == "" {
-		return c.JSON(http.StatusBadRequest, apiError("INVALID_PARAM", "roomId is required.", "ed1d7571-a3ac-4370-899c-0dbe5e230cc8"))
+		return c.JSON(http.StatusBadRequest, apierr.Error("INVALID_PARAM", "roomId is required.", "ed1d7571-a3ac-4370-899c-0dbe5e230cc8"))
 	}
 	room, err := h.repo.FindRoomByID(req.RoomID)
 	if err != nil || room.OwnerID != user.ID {
-		return c.JSON(http.StatusNotFound, apiError("NO_SUCH_ROOM", "No such room.", "00000000-0000-0000-0000-000000000000"))
+		return c.JSON(http.StatusNotFound, apierr.Error("NO_SUCH_ROOM", "No such room.", "00000000-0000-0000-0000-000000000000"))
 	}
 	_ = h.repo.DeleteRoom(req.RoomID)
 	return c.NoContent(http.StatusNoContent)
@@ -192,7 +188,7 @@ func (h *Handler) RoomsLeave(c echo.Context) error {
 		RoomID string `json:"roomId"`
 	}
 	if err := c.Bind(&req); err != nil || req.RoomID == "" {
-		return c.JSON(http.StatusBadRequest, apiError("INVALID_PARAM", "roomId is required.", "ed1d7571-a3ac-4370-899c-0dbe5e230cc8"))
+		return c.JSON(http.StatusBadRequest, apierr.Error("INVALID_PARAM", "roomId is required.", "ed1d7571-a3ac-4370-899c-0dbe5e230cc8"))
 	}
 	_ = h.repo.DeleteMembership(user.ID, req.RoomID)
 	return c.NoContent(http.StatusNoContent)
@@ -205,7 +201,7 @@ func (h *Handler) RoomsMute(c echo.Context) error {
 		RoomID string `json:"roomId"`
 	}
 	if err := c.Bind(&req); err != nil || req.RoomID == "" {
-		return c.JSON(http.StatusBadRequest, apiError("INVALID_PARAM", "roomId is required.", "ed1d7571-a3ac-4370-899c-0dbe5e230cc8"))
+		return c.JSON(http.StatusBadRequest, apierr.Error("INVALID_PARAM", "roomId is required.", "ed1d7571-a3ac-4370-899c-0dbe5e230cc8"))
 	}
 	m, err := h.repo.FindMembership(user.ID, req.RoomID)
 	if err != nil {
@@ -223,7 +219,7 @@ func (h *Handler) RoomsUnmute(c echo.Context) error {
 		RoomID string `json:"roomId"`
 	}
 	if err := c.Bind(&req); err != nil || req.RoomID == "" {
-		return c.JSON(http.StatusBadRequest, apiError("INVALID_PARAM", "roomId is required.", "ed1d7571-a3ac-4370-899c-0dbe5e230cc8"))
+		return c.JSON(http.StatusBadRequest, apierr.Error("INVALID_PARAM", "roomId is required.", "ed1d7571-a3ac-4370-899c-0dbe5e230cc8"))
 	}
 	m, err := h.repo.FindMembership(user.ID, req.RoomID)
 	if err != nil {
@@ -242,11 +238,11 @@ func (h *Handler) RoomsTransferOwnership(c echo.Context) error {
 		UserID string `json:"userId"`
 	}
 	if err := c.Bind(&req); err != nil || req.RoomID == "" || req.UserID == "" {
-		return c.JSON(http.StatusBadRequest, apiError("INVALID_PARAM", "roomId and userId are required.", "ed1d7571-a3ac-4370-899c-0dbe5e230cc8"))
+		return c.JSON(http.StatusBadRequest, apierr.Error("INVALID_PARAM", "roomId and userId are required.", "ed1d7571-a3ac-4370-899c-0dbe5e230cc8"))
 	}
 	room, err := h.repo.FindRoomByID(req.RoomID)
 	if err != nil || room.OwnerID != user.ID {
-		return c.JSON(http.StatusNotFound, apiError("NO_SUCH_ROOM", "No such room.", "00000000-0000-0000-0000-000000000000"))
+		return c.JSON(http.StatusNotFound, apierr.Error("NO_SUCH_ROOM", "No such room.", "00000000-0000-0000-0000-000000000000"))
 	}
 	room.OwnerID = req.UserID
 	_ = h.repo.UpdateRoom(room)
@@ -266,7 +262,7 @@ func (h *Handler) MessagesCreate(c echo.Context) error {
 		FileID   *string `json:"fileId"`
 	}
 	if err := c.Bind(&req); err != nil {
-		return c.JSON(http.StatusBadRequest, apiError("INVALID_PARAM", "Invalid parameters.", "ed1d7571-a3ac-4370-899c-0dbe5e230cc8"))
+		return c.JSON(http.StatusBadRequest, apierr.Error("INVALID_PARAM", "Invalid parameters.", "ed1d7571-a3ac-4370-899c-0dbe5e230cc8"))
 	}
 	if h.svc == nil {
 		// 未wire時のフォールバック (テスト互換)
@@ -290,7 +286,7 @@ func (h *Handler) MessagesCreate(c echo.Context) error {
 	case req.ToUserID != nil && *req.ToUserID != "":
 		msg, err = h.svc.CreateMessageToUser(c.Request().Context(), user.ID, *req.ToUserID, text, fileID)
 	default:
-		return c.JSON(http.StatusBadRequest, apiError("INVALID_PARAM", "toUserId or toRoomId is required.", "ed1d7571-a3ac-4370-899c-0dbe5e230cc8"))
+		return c.JSON(http.StatusBadRequest, apierr.Error("INVALID_PARAM", "toUserId or toRoomId is required.", "ed1d7571-a3ac-4370-899c-0dbe5e230cc8"))
 	}
 	if err != nil {
 		return h.mapChatErr(c, err)
@@ -308,7 +304,7 @@ func (h *Handler) messagesCreateLegacy(c echo.Context, user *model.User, text, t
 		Text: text, FileID: fileID,
 	}
 	if err := h.repo.CreateMessage(msg); err != nil {
-		return c.JSON(http.StatusInternalServerError, apiError("INTERNAL_ERROR", "Internal error.", "5d37dbcb-891e-41ca-a3d6-e690c97775ac"))
+		return c.JSON(http.StatusInternalServerError, apierr.Error("INTERNAL_ERROR", "Internal error.", "5d37dbcb-891e-41ca-a3d6-e690c97775ac"))
 	}
 	return c.JSON(http.StatusOK, packMessage(msg))
 }
@@ -319,11 +315,11 @@ func (h *Handler) MessagesShow(c echo.Context) error {
 		MessageID string `json:"messageId"`
 	}
 	if err := c.Bind(&req); err != nil || req.MessageID == "" {
-		return c.JSON(http.StatusBadRequest, apiError("INVALID_PARAM", "messageId is required.", "ed1d7571-a3ac-4370-899c-0dbe5e230cc8"))
+		return c.JSON(http.StatusBadRequest, apierr.Error("INVALID_PARAM", "messageId is required.", "ed1d7571-a3ac-4370-899c-0dbe5e230cc8"))
 	}
 	msg, err := h.repo.FindMessageByID(req.MessageID)
 	if err != nil {
-		return c.JSON(http.StatusNotFound, apiError("NO_SUCH_MESSAGE", "No such message.", "00000000-0000-0000-0000-000000000000"))
+		return c.JSON(http.StatusNotFound, apierr.Error("NO_SUCH_MESSAGE", "No such message.", "00000000-0000-0000-0000-000000000000"))
 	}
 	return c.JSON(http.StatusOK, packMessage(msg))
 }
@@ -336,13 +332,13 @@ func (h *Handler) MessagesUpdate(c echo.Context) error {
 		Text      *string `json:"text"`
 	}
 	if err := c.Bind(&req); err != nil || req.MessageID == "" {
-		return c.JSON(http.StatusBadRequest, apiError("INVALID_PARAM", "messageId is required.", "ed1d7571-a3ac-4370-899c-0dbe5e230cc8"))
+		return c.JSON(http.StatusBadRequest, apierr.Error("INVALID_PARAM", "messageId is required.", "ed1d7571-a3ac-4370-899c-0dbe5e230cc8"))
 	}
 	if h.svc == nil {
 		// legacy fallback
 		msg, err := h.repo.FindMessageByID(req.MessageID)
 		if err != nil || msg.FromUserID != user.ID {
-			return c.JSON(http.StatusNotFound, apiError("NO_SUCH_MESSAGE", "No such message.", "00000000-0000-0000-0000-000000000000"))
+			return c.JSON(http.StatusNotFound, apierr.Error("NO_SUCH_MESSAGE", "No such message.", "00000000-0000-0000-0000-000000000000"))
 		}
 		if req.Text != nil {
 			msg.Text = req.Text
@@ -367,12 +363,12 @@ func (h *Handler) MessagesDelete(c echo.Context) error {
 		MessageID string `json:"messageId"`
 	}
 	if err := c.Bind(&req); err != nil || req.MessageID == "" {
-		return c.JSON(http.StatusBadRequest, apiError("INVALID_PARAM", "messageId is required.", "ed1d7571-a3ac-4370-899c-0dbe5e230cc8"))
+		return c.JSON(http.StatusBadRequest, apierr.Error("INVALID_PARAM", "messageId is required.", "ed1d7571-a3ac-4370-899c-0dbe5e230cc8"))
 	}
 	if h.svc == nil {
 		msg, err := h.repo.FindMessageByID(req.MessageID)
 		if err != nil || msg.FromUserID != user.ID {
-			return c.JSON(http.StatusNotFound, apiError("NO_SUCH_MESSAGE", "No such message.", "00000000-0000-0000-0000-000000000000"))
+			return c.JSON(http.StatusNotFound, apierr.Error("NO_SUCH_MESSAGE", "No such message.", "00000000-0000-0000-0000-000000000000"))
 		}
 		_ = h.repo.DeleteMessage(req.MessageID)
 		return c.NoContent(http.StatusNoContent)
@@ -390,7 +386,7 @@ func (h *Handler) MessagesRead(c echo.Context) error {
 		MessageID string `json:"messageId"`
 	}
 	if err := c.Bind(&req); err != nil || req.MessageID == "" {
-		return c.JSON(http.StatusBadRequest, apiError("INVALID_PARAM", "messageId is required.", "ed1d7571-a3ac-4370-899c-0dbe5e230cc8"))
+		return c.JSON(http.StatusBadRequest, apierr.Error("INVALID_PARAM", "messageId is required.", "ed1d7571-a3ac-4370-899c-0dbe5e230cc8"))
 	}
 	if h.svc != nil {
 		if err := h.svc.MarkReadByMessageID(c.Request().Context(), user.ID, req.MessageID); err != nil {
@@ -411,7 +407,7 @@ func (h *Handler) Messages(c echo.Context) error {
 		Limit  int    `json:"limit"`
 	}
 	if err := c.Bind(&req); err != nil {
-		return c.JSON(http.StatusBadRequest, apiError("INVALID_PARAM", "Invalid parameters.", "ed1d7571-a3ac-4370-899c-0dbe5e230cc8"))
+		return c.JSON(http.StatusBadRequest, apierr.Error("INVALID_PARAM", "Invalid parameters.", "ed1d7571-a3ac-4370-899c-0dbe5e230cc8"))
 	}
 	var msgs []*model.ChatMessage
 	if req.RoomID != "" {
@@ -434,7 +430,7 @@ func (h *Handler) MessagesSearch(c echo.Context) error {
 		Limit int    `json:"limit"`
 	}
 	if err := c.Bind(&req); err != nil {
-		return c.JSON(http.StatusBadRequest, apiError("INVALID_PARAM", "Invalid parameters.", "ed1d7571-a3ac-4370-899c-0dbe5e230cc8"))
+		return c.JSON(http.StatusBadRequest, apierr.Error("INVALID_PARAM", "Invalid parameters.", "ed1d7571-a3ac-4370-899c-0dbe5e230cc8"))
 	}
 	msgs, _ := h.repo.SearchMessages(user.ID, req.Query, req.Limit)
 	result := make([]map[string]any, len(msgs))
@@ -463,13 +459,13 @@ func (h *Handler) InvitationsCreate(c echo.Context) error {
 		UserID string `json:"userId"`
 	}
 	if err := c.Bind(&req); err != nil || req.RoomID == "" || req.UserID == "" {
-		return c.JSON(http.StatusBadRequest, apiError("INVALID_PARAM", "roomId and userId are required.", "ed1d7571-a3ac-4370-899c-0dbe5e230cc8"))
+		return c.JSON(http.StatusBadRequest, apierr.Error("INVALID_PARAM", "roomId and userId are required.", "ed1d7571-a3ac-4370-899c-0dbe5e230cc8"))
 	}
 	inv := &model.ChatRoomInvitation{
 		ID: h.idGen.Generate(time.Now()), UserID: req.UserID, RoomID: req.RoomID,
 	}
 	if err := h.repo.CreateInvitation(inv); err != nil {
-		return c.JSON(http.StatusInternalServerError, apiError("INTERNAL_ERROR", "Internal error.", "5d37dbcb-891e-41ca-a3d6-e690c97775ac"))
+		return c.JSON(http.StatusInternalServerError, apierr.Error("INTERNAL_ERROR", "Internal error.", "5d37dbcb-891e-41ca-a3d6-e690c97775ac"))
 	}
 	return c.NoContent(http.StatusNoContent)
 }
@@ -480,7 +476,7 @@ func (h *Handler) InvitationsDelete(c echo.Context) error {
 		InvitationID string `json:"invitationId"`
 	}
 	if err := c.Bind(&req); err != nil || req.InvitationID == "" {
-		return c.JSON(http.StatusBadRequest, apiError("INVALID_PARAM", "invitationId is required.", "ed1d7571-a3ac-4370-899c-0dbe5e230cc8"))
+		return c.JSON(http.StatusBadRequest, apierr.Error("INVALID_PARAM", "invitationId is required.", "ed1d7571-a3ac-4370-899c-0dbe5e230cc8"))
 	}
 	_ = h.repo.DeleteInvitation(req.InvitationID)
 	return c.NoContent(http.StatusNoContent)
@@ -494,7 +490,7 @@ func (h *Handler) InvitationsAccept(c echo.Context) error {
 		RoomID       string `json:"roomId"`
 	}
 	if err := c.Bind(&req); err != nil || req.RoomID == "" {
-		return c.JSON(http.StatusBadRequest, apiError("INVALID_PARAM", "roomId is required.", "ed1d7571-a3ac-4370-899c-0dbe5e230cc8"))
+		return c.JSON(http.StatusBadRequest, apierr.Error("INVALID_PARAM", "roomId is required.", "ed1d7571-a3ac-4370-899c-0dbe5e230cc8"))
 	}
 	// メンバーシップを作成
 	m := &model.ChatRoomMembership{
@@ -515,7 +511,7 @@ func (h *Handler) InvitationsReject(c echo.Context) error {
 		RoomID string `json:"roomId"`
 	}
 	if err := c.Bind(&req); err != nil || req.RoomID == "" {
-		return c.JSON(http.StatusBadRequest, apiError("INVALID_PARAM", "roomId is required.", "ed1d7571-a3ac-4370-899c-0dbe5e230cc8"))
+		return c.JSON(http.StatusBadRequest, apierr.Error("INVALID_PARAM", "roomId is required.", "ed1d7571-a3ac-4370-899c-0dbe5e230cc8"))
 	}
 	if inv, err := h.repo.FindInvitation(user.ID, req.RoomID); err == nil {
 		_ = h.repo.DeleteInvitation(inv.ID)
@@ -530,7 +526,7 @@ func (h *Handler) MembersBan(c echo.Context) error {
 		UserID string `json:"userId"`
 	}
 	if err := c.Bind(&req); err != nil || req.RoomID == "" || req.UserID == "" {
-		return c.JSON(http.StatusBadRequest, apiError("INVALID_PARAM", "roomId and userId are required.", "ed1d7571-a3ac-4370-899c-0dbe5e230cc8"))
+		return c.JSON(http.StatusBadRequest, apierr.Error("INVALID_PARAM", "roomId and userId are required.", "ed1d7571-a3ac-4370-899c-0dbe5e230cc8"))
 	}
 	_ = h.repo.DeleteMembership(req.UserID, req.RoomID)
 	return c.NoContent(http.StatusNoContent)

--- a/internal/api/drive/handler.go
+++ b/internal/api/drive/handler.go
@@ -87,9 +87,9 @@ func (h *Handler) FilesCreate(c echo.Context) error {
 	if err != nil {
 		switch {
 		case errors.Is(err, coredrive.ErrFolderNotFound):
-			return c.JSON(http.StatusNotFound, errEnvelope("No such folder.", "NO_SUCH_FOLDER", "d77545ec-1283-4b73-bbe1-e90e1da6a4e7"))
+			return c.JSON(http.StatusNotFound, apierr.Error("NO_SUCH_FOLDER", "No such folder.", "d77545ec-1283-4b73-bbe1-e90e1da6a4e7"))
 		case errors.Is(err, coredrive.ErrAccessDenied):
-			return c.JSON(http.StatusForbidden, errEnvelope("Access denied.", "ACCESS_DENIED", "fe8d7103-0ea8-4ec3-814d-f8b401dc69e9"))
+			return c.JSON(http.StatusForbidden, apierr.Error("ACCESS_DENIED", "Access denied.", "fe8d7103-0ea8-4ec3-814d-f8b401dc69e9"))
 		}
 		return internalError(c)
 	}
@@ -278,11 +278,11 @@ func (h *Handler) FoldersDelete(c echo.Context) error {
 func mapFileError(c echo.Context, err error) error {
 	switch {
 	case errors.Is(err, coredrive.ErrFileNotFound):
-		return c.JSON(http.StatusNotFound, errEnvelope("No such file.", "NO_SUCH_FILE", "067bc436-2718-4795-b0fb-ecbe43949e31"))
+		return c.JSON(http.StatusNotFound, apierr.Error("NO_SUCH_FILE", "No such file.", "067bc436-2718-4795-b0fb-ecbe43949e31"))
 	case errors.Is(err, coredrive.ErrFolderNotFound):
-		return c.JSON(http.StatusNotFound, errEnvelope("No such folder.", "NO_SUCH_FOLDER", "ea8fb7a5-af77-4a08-b608-c0218176cd73"))
+		return c.JSON(http.StatusNotFound, apierr.Error("NO_SUCH_FOLDER", "No such folder.", "ea8fb7a5-af77-4a08-b608-c0218176cd73"))
 	case errors.Is(err, coredrive.ErrAccessDenied):
-		return c.JSON(http.StatusForbidden, errEnvelope("Access denied.", "ACCESS_DENIED", "fe8d7103-0ea8-4ec3-814d-f8b401dc69e9"))
+		return c.JSON(http.StatusForbidden, apierr.Error("ACCESS_DENIED", "Access denied.", "fe8d7103-0ea8-4ec3-814d-f8b401dc69e9"))
 	}
 	return internalError(c)
 }
@@ -290,25 +290,21 @@ func mapFileError(c echo.Context, err error) error {
 func mapFolderError(c echo.Context, err error) error {
 	switch {
 	case errors.Is(err, coredrive.ErrFolderNotFound):
-		return c.JSON(http.StatusNotFound, errEnvelope("No such folder.", "NO_SUCH_FOLDER", "ea8fb7a5-af77-4a08-b608-c0218176cd73"))
+		return c.JSON(http.StatusNotFound, apierr.Error("NO_SUCH_FOLDER", "No such folder.", "ea8fb7a5-af77-4a08-b608-c0218176cd73"))
 	case errors.Is(err, coredrive.ErrAccessDenied):
-		return c.JSON(http.StatusForbidden, errEnvelope("Access denied.", "ACCESS_DENIED", "fe8d7103-0ea8-4ec3-814d-f8b401dc69e9"))
+		return c.JSON(http.StatusForbidden, apierr.Error("ACCESS_DENIED", "Access denied.", "fe8d7103-0ea8-4ec3-814d-f8b401dc69e9"))
 	case errors.Is(err, coredrive.ErrFolderNotEmpty):
-		return c.JSON(http.StatusBadRequest, errEnvelope("Folder is not empty.", "HAS_CHILD_FILES_OR_FOLDERS", "b0fc8a17-963c-405d-bfbc-859a487295e1"))
+		return c.JSON(http.StatusBadRequest, apierr.Error("HAS_CHILD_FILES_OR_FOLDERS", "Folder is not empty.", "b0fc8a17-963c-405d-bfbc-859a487295e1"))
 	}
 	return internalError(c)
 }
 
-func errEnvelope(message, code, id string) map[string]any {
-	return apierr.Error(code, message, id)
-}
-
 func invalidParam(c echo.Context) error {
-	return c.JSON(http.StatusBadRequest, errEnvelope("Invalid param.", "INVALID_PARAM", "3d81ceae-475f-4600-b2a8-2bc116157532"))
+	return c.JSON(http.StatusBadRequest, apierr.Error("INVALID_PARAM", "Invalid param.", "3d81ceae-475f-4600-b2a8-2bc116157532"))
 }
 
 func internalError(c echo.Context) error {
-	return c.JSON(http.StatusInternalServerError, errEnvelope("Internal error.", "INTERNAL_ERROR", "5d37dbcb-891e-41ca-a3d6-e690c97775ac"))
+	return c.JSON(http.StatusInternalServerError, apierr.Error("INTERNAL_ERROR", "Internal error.", "5d37dbcb-891e-41ca-a3d6-e690c97775ac"))
 }
 
 // --- Drive listing endpoints ---

--- a/internal/api/following/handler.go
+++ b/internal/api/following/handler.go
@@ -42,17 +42,17 @@ func (h *Handler) Create(c echo.Context) error {
 	// followeeを先に取得し、エラー時はNO_SUCH_USERを返す
 	bundle, err := h.userService.ShowByID(req.UserID)
 	if err != nil {
-		return c.JSON(http.StatusNotFound, errEnvelope("No such user.", "NO_SUCH_USER", "fcd2eef9-a9b2-4c4f-8624-038099e90aa5"))
+		return c.JSON(http.StatusNotFound, apierr.Error("NO_SUCH_USER", "No such user.", "fcd2eef9-a9b2-4c4f-8624-038099e90aa5"))
 	}
 
 	if _, err := h.followingService.Follow(me.ID, req.UserID); err != nil {
 		switch {
 		case errors.Is(err, corefollowing.ErrSelfFollow):
-			return c.JSON(http.StatusBadRequest, errEnvelope("Followee is yourself.", "FOLLOWEE_IS_YOURSELF", "26fbe7bb-a331-4857-af17-205b426669a9"))
+			return c.JSON(http.StatusBadRequest, apierr.Error("FOLLOWEE_IS_YOURSELF", "Followee is yourself.", "26fbe7bb-a331-4857-af17-205b426669a9"))
 		case errors.Is(err, corefollowing.ErrAlreadyFollowing), errors.Is(err, corefollowing.ErrAlreadyRequested):
-			return c.JSON(http.StatusBadRequest, errEnvelope("You are already following that user.", "ALREADY_FOLLOWING", "35387507-38c7-4cb9-9197-300b93783fa0"))
+			return c.JSON(http.StatusBadRequest, apierr.Error("ALREADY_FOLLOWING", "You are already following that user.", "35387507-38c7-4cb9-9197-300b93783fa0"))
 		case errors.Is(err, corefollowing.ErrBlocked):
-			return c.JSON(http.StatusForbidden, errEnvelope("You are blocked by that user.", "BLOCKED", "c4ab57cc-4e41-45e9-bfd9-584f61e35ce0"))
+			return c.JSON(http.StatusForbidden, apierr.Error("BLOCKED", "You are blocked by that user.", "c4ab57cc-4e41-45e9-bfd9-584f61e35ce0"))
 		default:
 			return internalError(c)
 		}
@@ -77,15 +77,15 @@ func (h *Handler) Delete(c echo.Context) error {
 
 	bundle, err := h.userService.ShowByID(req.UserID)
 	if err != nil {
-		return c.JSON(http.StatusNotFound, errEnvelope("No such user.", "NO_SUCH_USER", "5b12c78d-2b28-4dca-99d2-f56139b42ff8"))
+		return c.JSON(http.StatusNotFound, apierr.Error("NO_SUCH_USER", "No such user.", "5b12c78d-2b28-4dca-99d2-f56139b42ff8"))
 	}
 
 	if err := h.followingService.Unfollow(me.ID, req.UserID); err != nil {
 		switch {
 		case errors.Is(err, corefollowing.ErrSelfFollow):
-			return c.JSON(http.StatusBadRequest, errEnvelope("Followee is yourself.", "FOLLOWEE_IS_YOURSELF", "d9e400b9-36b0-4808-b1d8-79e707f1296c"))
+			return c.JSON(http.StatusBadRequest, apierr.Error("FOLLOWEE_IS_YOURSELF", "Followee is yourself.", "d9e400b9-36b0-4808-b1d8-79e707f1296c"))
 		case errors.Is(err, corefollowing.ErrNotFollowing):
-			return c.JSON(http.StatusBadRequest, errEnvelope("You are not following that user.", "NOT_FOLLOWING", "5dbf82f5-c92b-40b1-87d1-6c8c0741fd09"))
+			return c.JSON(http.StatusBadRequest, apierr.Error("NOT_FOLLOWING", "You are not following that user.", "5dbf82f5-c92b-40b1-87d1-6c8c0741fd09"))
 		default:
 			return internalError(c)
 		}
@@ -110,7 +110,7 @@ func (h *Handler) AcceptRequest(c echo.Context) error {
 
 	if err := h.followingService.AcceptRequest(me.ID, req.UserID); err != nil {
 		if errors.Is(err, corefollowing.ErrRequestNotFound) {
-			return c.JSON(http.StatusNotFound, errEnvelope("No such follow request.", "NO_FOLLOW_REQUEST", "bcde4f8b-0913-4614-8881-614e522fb041"))
+			return c.JSON(http.StatusNotFound, apierr.Error("NO_FOLLOW_REQUEST", "No such follow request.", "bcde4f8b-0913-4614-8881-614e522fb041"))
 		}
 		return internalError(c)
 	}
@@ -128,7 +128,7 @@ func (h *Handler) RejectRequest(c echo.Context) error {
 
 	if err := h.followingService.RejectRequest(me.ID, req.UserID); err != nil {
 		if errors.Is(err, corefollowing.ErrRequestNotFound) {
-			return c.JSON(http.StatusNotFound, errEnvelope("No such follow request.", "NO_FOLLOW_REQUEST", "abc2ffa6-25b2-4380-ba99-321ff3a94555"))
+			return c.JSON(http.StatusNotFound, apierr.Error("NO_FOLLOW_REQUEST", "No such follow request.", "abc2ffa6-25b2-4380-ba99-321ff3a94555"))
 		}
 		return internalError(c)
 	}
@@ -146,7 +146,7 @@ func (h *Handler) CancelRequest(c echo.Context) error {
 
 	if err := h.followingService.CancelRequest(me.ID, req.UserID); err != nil {
 		if errors.Is(err, corefollowing.ErrRequestNotFound) {
-			return c.JSON(http.StatusNotFound, errEnvelope("No such follow request.", "NO_FOLLOW_REQUEST", "17447091-ea95-43eb-a7d4-c78cb2853c20"))
+			return c.JSON(http.StatusNotFound, apierr.Error("NO_FOLLOW_REQUEST", "No such follow request.", "17447091-ea95-43eb-a7d4-c78cb2853c20"))
 		}
 		return internalError(c)
 	}
@@ -184,13 +184,9 @@ func (h *Handler) ListRequests(c echo.Context) error {
 }
 
 func invalidParam(c echo.Context) error {
-	return c.JSON(http.StatusBadRequest, errEnvelope("Invalid param.", "INVALID_PARAM", "3d81ceae-475f-4600-b2a8-2bc116157532"))
+	return c.JSON(http.StatusBadRequest, apierr.Error("INVALID_PARAM", "Invalid param.", "3d81ceae-475f-4600-b2a8-2bc116157532"))
 }
 
 func internalError(c echo.Context) error {
-	return c.JSON(http.StatusInternalServerError, errEnvelope("Internal error.", "INTERNAL_ERROR", "5d37dbcb-891e-41ca-a3d6-e690c97775ac"))
-}
-
-func errEnvelope(message, code, id string) map[string]any {
-	return apierr.Error(code, message, id)
+	return c.JSON(http.StatusInternalServerError, apierr.Error("INTERNAL_ERROR", "Internal error.", "5d37dbcb-891e-41ca-a3d6-e690c97775ac"))
 }

--- a/internal/api/gallery/handler.go
+++ b/internal/api/gallery/handler.go
@@ -28,7 +28,7 @@ func NewHandler(db *gorm.DB, idGen id.Generator) *Handler {
 func (h *Handler) Featured(c echo.Context) error {
 	var posts []*model.GalleryPost
 	if err := h.db.Preload("User").Order("\"likedCount\" DESC").Limit(10).Find(&posts).Error; err != nil {
-		return c.JSON(http.StatusInternalServerError, errResp("INTERNAL_ERROR", "Internal error.", "5d37dbcb-891e-41ca-a3d6-e690c97775ac"))
+		return c.JSON(http.StatusInternalServerError, apierr.Error("INTERNAL_ERROR", "Internal error.", "5d37dbcb-891e-41ca-a3d6-e690c97775ac"))
 	}
 	return c.JSON(http.StatusOK, h.packMany(posts))
 }
@@ -45,7 +45,7 @@ func (h *Handler) Posts(c echo.Context) error {
 		Offset int `json:"offset"`
 	}
 	if err := c.Bind(&req); err != nil {
-		return c.JSON(http.StatusBadRequest, errResp("INVALID_PARAM", "Invalid parameters.", "3d81ceae-475f-4600-b2a8-2bc116157532"))
+		return c.JSON(http.StatusBadRequest, apierr.Error("INVALID_PARAM", "Invalid parameters.", "3d81ceae-475f-4600-b2a8-2bc116157532"))
 	}
 	if req.Limit <= 0 {
 		req.Limit = 10
@@ -56,7 +56,7 @@ func (h *Handler) Posts(c echo.Context) error {
 	}
 	var posts []*model.GalleryPost
 	if err := q.Find(&posts).Error; err != nil {
-		return c.JSON(http.StatusInternalServerError, errResp("INTERNAL_ERROR", "Internal error.", "5d37dbcb-891e-41ca-a3d6-e690c97775ac"))
+		return c.JSON(http.StatusInternalServerError, apierr.Error("INTERNAL_ERROR", "Internal error.", "5d37dbcb-891e-41ca-a3d6-e690c97775ac"))
 	}
 	return c.JSON(http.StatusOK, h.packMany(posts))
 }
@@ -71,7 +71,7 @@ func (h *Handler) PostsCreate(c echo.Context) error {
 		IsSensitive bool     `json:"isSensitive"`
 	}
 	if err := c.Bind(&req); err != nil || req.Title == "" {
-		return c.JSON(http.StatusBadRequest, errResp("INVALID_PARAM", "title is required.", "3d81ceae-475f-4600-b2a8-2bc116157532"))
+		return c.JSON(http.StatusBadRequest, apierr.Error("INVALID_PARAM", "title is required.", "3d81ceae-475f-4600-b2a8-2bc116157532"))
 	}
 	if req.FileIDs == nil {
 		req.FileIDs = []string{}
@@ -88,7 +88,7 @@ func (h *Handler) PostsCreate(c echo.Context) error {
 		Tags:        []string{},
 	}
 	if err := h.db.Create(post).Error; err != nil {
-		return c.JSON(http.StatusInternalServerError, errResp("INTERNAL_ERROR", "Internal error.", "5d37dbcb-891e-41ca-a3d6-e690c97775ac"))
+		return c.JSON(http.StatusInternalServerError, apierr.Error("INTERNAL_ERROR", "Internal error.", "5d37dbcb-891e-41ca-a3d6-e690c97775ac"))
 	}
 	post.User = user
 	return c.JSON(http.StatusOK, h.packOne(post))
@@ -100,11 +100,11 @@ func (h *Handler) PostsShow(c echo.Context) error {
 		PostID string `json:"postId"`
 	}
 	if err := c.Bind(&req); err != nil || req.PostID == "" {
-		return c.JSON(http.StatusBadRequest, errResp("INVALID_PARAM", "postId is required.", "3d81ceae-475f-4600-b2a8-2bc116157532"))
+		return c.JSON(http.StatusBadRequest, apierr.Error("INVALID_PARAM", "postId is required.", "3d81ceae-475f-4600-b2a8-2bc116157532"))
 	}
 	var post model.GalleryPost
 	if err := h.db.Preload("User").Where("id = ?", req.PostID).First(&post).Error; err != nil {
-		return c.JSON(http.StatusNotFound, errResp("NO_SUCH_POST", "No such post.", "1137bf14-c27b-46e0-86d3-0cbbf8b0aca5"))
+		return c.JSON(http.StatusNotFound, apierr.Error("NO_SUCH_POST", "No such post.", "1137bf14-c27b-46e0-86d3-0cbbf8b0aca5"))
 	}
 	return c.JSON(http.StatusOK, h.packOne(&post))
 }
@@ -116,11 +116,11 @@ func (h *Handler) PostsDelete(c echo.Context) error {
 		PostID string `json:"postId"`
 	}
 	if err := c.Bind(&req); err != nil || req.PostID == "" {
-		return c.JSON(http.StatusBadRequest, errResp("INVALID_PARAM", "postId is required.", "3d81ceae-475f-4600-b2a8-2bc116157532"))
+		return c.JSON(http.StatusBadRequest, apierr.Error("INVALID_PARAM", "postId is required.", "3d81ceae-475f-4600-b2a8-2bc116157532"))
 	}
 	result := h.db.Where("id = ? AND \"userId\" = ?", req.PostID, user.ID).Delete(&model.GalleryPost{})
 	if result.RowsAffected == 0 {
-		return c.JSON(http.StatusNotFound, errResp("NO_SUCH_POST", "No such post.", "1137bf14-c27b-46e0-86d3-0cbbf8b0aca5"))
+		return c.JSON(http.StatusNotFound, apierr.Error("NO_SUCH_POST", "No such post.", "1137bf14-c27b-46e0-86d3-0cbbf8b0aca5"))
 	}
 	return c.NoContent(http.StatusNoContent)
 }
@@ -134,7 +134,7 @@ func (h *Handler) PostsUpdate(c echo.Context) error {
 		Description *string `json:"description"`
 	}
 	if err := c.Bind(&req); err != nil || req.PostID == "" {
-		return c.JSON(http.StatusBadRequest, errResp("INVALID_PARAM", "postId is required.", "3d81ceae-475f-4600-b2a8-2bc116157532"))
+		return c.JSON(http.StatusBadRequest, apierr.Error("INVALID_PARAM", "postId is required.", "3d81ceae-475f-4600-b2a8-2bc116157532"))
 	}
 	fields := map[string]any{}
 	if req.Title != nil {
@@ -145,7 +145,7 @@ func (h *Handler) PostsUpdate(c echo.Context) error {
 	}
 	result := h.db.Model(&model.GalleryPost{}).Where("id = ? AND \"userId\" = ?", req.PostID, user.ID).Updates(fields)
 	if result.RowsAffected == 0 {
-		return c.JSON(http.StatusNotFound, errResp("NO_SUCH_POST", "No such post.", "1137bf14-c27b-46e0-86d3-0cbbf8b0aca5"))
+		return c.JSON(http.StatusNotFound, apierr.Error("NO_SUCH_POST", "No such post.", "1137bf14-c27b-46e0-86d3-0cbbf8b0aca5"))
 	}
 	return c.NoContent(http.StatusNoContent)
 }
@@ -157,7 +157,7 @@ func (h *Handler) PostsLike(c echo.Context) error {
 		PostID string `json:"postId"`
 	}
 	if err := c.Bind(&req); err != nil || req.PostID == "" {
-		return c.JSON(http.StatusBadRequest, errResp("INVALID_PARAM", "postId is required.", "3d81ceae-475f-4600-b2a8-2bc116157532"))
+		return c.JSON(http.StatusBadRequest, apierr.Error("INVALID_PARAM", "postId is required.", "3d81ceae-475f-4600-b2a8-2bc116157532"))
 	}
 	like := &model.GalleryLike{
 		ID:     h.idGen.Generate(time.Now()),
@@ -165,7 +165,7 @@ func (h *Handler) PostsLike(c echo.Context) error {
 		PostID: req.PostID,
 	}
 	if err := h.db.Create(like).Error; err != nil {
-		return c.JSON(http.StatusConflict, errResp("ALREADY_LIKED", "Already liked.", "40e8fb37-7a93-4e2c-87fc-c1c25e4a68a1"))
+		return c.JSON(http.StatusConflict, apierr.Error("ALREADY_LIKED", "Already liked.", "40e8fb37-7a93-4e2c-87fc-c1c25e4a68a1"))
 	}
 	h.db.Model(&model.GalleryPost{}).Where("id = ?", req.PostID).UpdateColumn("\"likedCount\"", gorm.Expr("\"likedCount\" + 1"))
 	return c.NoContent(http.StatusNoContent)
@@ -178,7 +178,7 @@ func (h *Handler) PostsUnlike(c echo.Context) error {
 		PostID string `json:"postId"`
 	}
 	if err := c.Bind(&req); err != nil || req.PostID == "" {
-		return c.JSON(http.StatusBadRequest, errResp("INVALID_PARAM", "postId is required.", "3d81ceae-475f-4600-b2a8-2bc116157532"))
+		return c.JSON(http.StatusBadRequest, apierr.Error("INVALID_PARAM", "postId is required.", "3d81ceae-475f-4600-b2a8-2bc116157532"))
 	}
 	h.db.Where("\"userId\" = ? AND \"postId\" = ?", user.ID, req.PostID).Delete(&model.GalleryLike{})
 	h.db.Model(&model.GalleryPost{}).Where("id = ?", req.PostID).UpdateColumn("\"likedCount\"", gorm.Expr("GREATEST(\"likedCount\" - 1, 0)"))
@@ -215,8 +215,4 @@ func (h *Handler) packOne(p *model.GalleryPost) map[string]any {
 		resp["user"] = entity.PackUserLite(p.User)
 	}
 	return resp
-}
-
-func errResp(code, message, id string) map[string]any {
-	return apierr.Error(code, message, id)
 }

--- a/internal/api/hashtags/handler.go
+++ b/internal/api/hashtags/handler.go
@@ -27,7 +27,7 @@ func (h *Handler) List(c echo.Context) error {
 		Offset int    `json:"offset"`
 	}
 	if err := c.Bind(&req); err != nil {
-		return c.JSON(http.StatusBadRequest, errResp("INVALID_PARAM", "Invalid parameters.", "3d81ceae-475f-4600-b2a8-2bc116157532"))
+		return c.JSON(http.StatusBadRequest, apierr.Error("INVALID_PARAM", "Invalid parameters.", "3d81ceae-475f-4600-b2a8-2bc116157532"))
 	}
 	if req.Limit <= 0 {
 		req.Limit = 10
@@ -41,7 +41,7 @@ func (h *Handler) List(c echo.Context) error {
 	}
 	var tags []*model.Hashtag
 	if err := q.Find(&tags).Error; err != nil {
-		return c.JSON(http.StatusInternalServerError, errResp("INTERNAL_ERROR", "Internal error.", "5d37dbcb-891e-41ca-a3d6-e690c97775ac"))
+		return c.JSON(http.StatusInternalServerError, apierr.Error("INTERNAL_ERROR", "Internal error.", "5d37dbcb-891e-41ca-a3d6-e690c97775ac"))
 	}
 	result := make([]map[string]any, 0, len(tags))
 	for _, t := range tags {
@@ -57,14 +57,14 @@ func (h *Handler) Search(c echo.Context) error {
 		Limit int    `json:"limit"`
 	}
 	if err := c.Bind(&req); err != nil || req.Query == "" {
-		return c.JSON(http.StatusBadRequest, errResp("INVALID_PARAM", "query is required.", "3d81ceae-475f-4600-b2a8-2bc116157532"))
+		return c.JSON(http.StatusBadRequest, apierr.Error("INVALID_PARAM", "query is required.", "3d81ceae-475f-4600-b2a8-2bc116157532"))
 	}
 	if req.Limit <= 0 {
 		req.Limit = 10
 	}
 	var tags []*model.Hashtag
 	if err := h.db.Where("name ILIKE ?", "%"+req.Query+"%").Limit(req.Limit).Find(&tags).Error; err != nil {
-		return c.JSON(http.StatusInternalServerError, errResp("INTERNAL_ERROR", "Internal error.", "5d37dbcb-891e-41ca-a3d6-e690c97775ac"))
+		return c.JSON(http.StatusInternalServerError, apierr.Error("INTERNAL_ERROR", "Internal error.", "5d37dbcb-891e-41ca-a3d6-e690c97775ac"))
 	}
 	names := make([]string, 0, len(tags))
 	for _, t := range tags {
@@ -79,11 +79,11 @@ func (h *Handler) Show(c echo.Context) error {
 		Tag string `json:"tag"`
 	}
 	if err := c.Bind(&req); err != nil || req.Tag == "" {
-		return c.JSON(http.StatusBadRequest, errResp("INVALID_PARAM", "tag is required.", "3d81ceae-475f-4600-b2a8-2bc116157532"))
+		return c.JSON(http.StatusBadRequest, apierr.Error("INVALID_PARAM", "tag is required.", "3d81ceae-475f-4600-b2a8-2bc116157532"))
 	}
 	var tag model.Hashtag
 	if err := h.db.Where("name = ?", req.Tag).First(&tag).Error; err != nil {
-		return c.JSON(http.StatusNotFound, errResp("NO_SUCH_HASHTAG", "No such hashtag.", "110ee688-193e-4a3a-9ecf-c167234e6f7d"))
+		return c.JSON(http.StatusNotFound, apierr.Error("NO_SUCH_HASHTAG", "No such hashtag.", "110ee688-193e-4a3a-9ecf-c167234e6f7d"))
 	}
 	return c.JSON(http.StatusOK, packTag(&tag))
 }
@@ -92,7 +92,7 @@ func (h *Handler) Show(c echo.Context) error {
 func (h *Handler) Trend(c echo.Context) error {
 	var tags []*model.Hashtag
 	if err := h.db.Order("\"mentionedUsersCount\" DESC").Limit(10).Find(&tags).Error; err != nil {
-		return c.JSON(http.StatusInternalServerError, errResp("INTERNAL_ERROR", "Internal error.", "5d37dbcb-891e-41ca-a3d6-e690c97775ac"))
+		return c.JSON(http.StatusInternalServerError, apierr.Error("INTERNAL_ERROR", "Internal error.", "5d37dbcb-891e-41ca-a3d6-e690c97775ac"))
 	}
 	result := make([]map[string]any, 0, len(tags))
 	for _, t := range tags {
@@ -112,7 +112,7 @@ func (h *Handler) Users(c echo.Context) error {
 		Limit int    `json:"limit"`
 	}
 	if err := c.Bind(&req); err != nil || req.Tag == "" {
-		return c.JSON(http.StatusBadRequest, errResp("INVALID_PARAM", "tag is required.", "3d81ceae-475f-4600-b2a8-2bc116157532"))
+		return c.JSON(http.StatusBadRequest, apierr.Error("INVALID_PARAM", "tag is required.", "3d81ceae-475f-4600-b2a8-2bc116157532"))
 	}
 	// ハッシュタグを使ったユーザー一覧 (簡易版: 空配列)
 	return c.JSON(http.StatusOK, []any{})
@@ -128,8 +128,4 @@ func packTag(t *model.Hashtag) map[string]any {
 		"attachedLocalUsersCount":   t.AttachedLocalUsersCount,
 		"attachedRemoteUsersCount":  t.AttachedRemoteUsersCount,
 	}
-}
-
-func errResp(code, message, id string) map[string]any {
-	return apierr.Error(code, message, id)
 }

--- a/internal/api/i/handler.go
+++ b/internal/api/i/handler.go
@@ -108,14 +108,14 @@ func (h *Handler) RegistryGet(c echo.Context) error {
 		Domain *string  `json:"domain"`
 	}
 	if err := c.Bind(&req); err != nil || req.Key == "" {
-		return c.JSON(http.StatusBadRequest, apiError("INVALID_PARAM", "key is required.", "3d81ceae-475f-4600-b2a8-2bc116157532"))
+		return c.JSON(http.StatusBadRequest, apierr.Error("INVALID_PARAM", "key is required.", "3d81ceae-475f-4600-b2a8-2bc116157532"))
 	}
 	if req.Scope == nil {
 		req.Scope = []string{}
 	}
 	item, err := h.registryRepo.Get(u.ID, req.Key, req.Scope, req.Domain)
 	if err != nil {
-		return c.JSON(http.StatusNotFound, apiError("NO_SUCH_KEY", "No such key.", "ac3ed68a-62f0-422b-a7bc-d5e09e8f6a6a"))
+		return c.JSON(http.StatusNotFound, apierr.Error("NO_SUCH_KEY", "No such key.", "ac3ed68a-62f0-422b-a7bc-d5e09e8f6a6a"))
 	}
 	// value をそのまま返す (JSONBの中身)
 	return c.JSONBlob(http.StatusOK, item.Value)
@@ -131,7 +131,7 @@ func (h *Handler) RegistrySet(c echo.Context) error {
 		Domain *string         `json:"domain"`
 	}
 	if err := c.Bind(&req); err != nil || req.Key == "" {
-		return c.JSON(http.StatusBadRequest, apiError("INVALID_PARAM", "key is required.", "3d81ceae-475f-4600-b2a8-2bc116157532"))
+		return c.JSON(http.StatusBadRequest, apierr.Error("INVALID_PARAM", "key is required.", "3d81ceae-475f-4600-b2a8-2bc116157532"))
 	}
 	if req.Scope == nil {
 		req.Scope = []string{}
@@ -146,7 +146,7 @@ func (h *Handler) RegistrySet(c echo.Context) error {
 		Domain:    req.Domain,
 	}
 	if err := h.registryRepo.Set(item); err != nil {
-		return c.JSON(http.StatusInternalServerError, apiError("INTERNAL_ERROR", "Internal error.", "5d37dbcb-891e-41ca-a3d6-e690c97775ac"))
+		return c.JSON(http.StatusInternalServerError, apierr.Error("INTERNAL_ERROR", "Internal error.", "5d37dbcb-891e-41ca-a3d6-e690c97775ac"))
 	}
 	return c.NoContent(http.StatusNoContent)
 }
@@ -159,14 +159,14 @@ func (h *Handler) RegistryGetAll(c echo.Context) error {
 		Domain *string  `json:"domain"`
 	}
 	if err := c.Bind(&req); err != nil {
-		return c.JSON(http.StatusBadRequest, apiError("INVALID_PARAM", "Invalid parameters.", "3d81ceae-475f-4600-b2a8-2bc116157532"))
+		return c.JSON(http.StatusBadRequest, apierr.Error("INVALID_PARAM", "Invalid parameters.", "3d81ceae-475f-4600-b2a8-2bc116157532"))
 	}
 	if req.Scope == nil {
 		req.Scope = []string{}
 	}
 	items, err := h.registryRepo.GetAll(u.ID, req.Scope, req.Domain)
 	if err != nil {
-		return c.JSON(http.StatusInternalServerError, apiError("INTERNAL_ERROR", "Internal error.", "5d37dbcb-891e-41ca-a3d6-e690c97775ac"))
+		return c.JSON(http.StatusInternalServerError, apierr.Error("INTERNAL_ERROR", "Internal error.", "5d37dbcb-891e-41ca-a3d6-e690c97775ac"))
 	}
 	result := make(map[string]json.RawMessage, len(items))
 	for _, item := range items {
@@ -183,14 +183,14 @@ func (h *Handler) RegistryKeysWithType(c echo.Context) error {
 		Domain *string  `json:"domain"`
 	}
 	if err := c.Bind(&req); err != nil {
-		return c.JSON(http.StatusBadRequest, apiError("INVALID_PARAM", "Invalid parameters.", "3d81ceae-475f-4600-b2a8-2bc116157532"))
+		return c.JSON(http.StatusBadRequest, apierr.Error("INVALID_PARAM", "Invalid parameters.", "3d81ceae-475f-4600-b2a8-2bc116157532"))
 	}
 	if req.Scope == nil {
 		req.Scope = []string{}
 	}
 	keys, err := h.registryRepo.KeysWithType(u.ID, req.Scope, req.Domain)
 	if err != nil {
-		return c.JSON(http.StatusInternalServerError, apiError("INTERNAL_ERROR", "Internal error.", "5d37dbcb-891e-41ca-a3d6-e690c97775ac"))
+		return c.JSON(http.StatusInternalServerError, apierr.Error("INTERNAL_ERROR", "Internal error.", "5d37dbcb-891e-41ca-a3d6-e690c97775ac"))
 	}
 	return c.JSON(http.StatusOK, keys)
 }
@@ -204,13 +204,13 @@ func (h *Handler) RegistryRemove(c echo.Context) error {
 		Domain *string  `json:"domain"`
 	}
 	if err := c.Bind(&req); err != nil || req.Key == "" {
-		return c.JSON(http.StatusBadRequest, apiError("INVALID_PARAM", "key is required.", "3d81ceae-475f-4600-b2a8-2bc116157532"))
+		return c.JSON(http.StatusBadRequest, apierr.Error("INVALID_PARAM", "key is required.", "3d81ceae-475f-4600-b2a8-2bc116157532"))
 	}
 	if req.Scope == nil {
 		req.Scope = []string{}
 	}
 	if err := h.registryRepo.Remove(u.ID, req.Key, req.Scope, req.Domain); err != nil {
-		return c.JSON(http.StatusInternalServerError, apiError("INTERNAL_ERROR", "Internal error.", "5d37dbcb-891e-41ca-a3d6-e690c97775ac"))
+		return c.JSON(http.StatusInternalServerError, apierr.Error("INTERNAL_ERROR", "Internal error.", "5d37dbcb-891e-41ca-a3d6-e690c97775ac"))
 	}
 	return c.NoContent(http.StatusNoContent)
 }
@@ -485,7 +485,7 @@ func (h *Handler) Update(c echo.Context) error {
 		// クリアリクエストは検査対象外 (ユーザー体験上必要)。
 		if h.metaRepo != nil && *req.Name != "" {
 			if m, err := h.metaRepo.Fetch(); err == nil && containsProhibitedWord(*req.Name, m.ProhibitedWordsForNameOfUser) {
-				return c.JSON(http.StatusBadRequest, errEnvelope("Your new name contains prohibited words.", "NAME_CONTAINS_PROHIBITED_WORDS", "0b3f9f6a-2e7d-4c2c-9d7a-8c6f9b2e1a44"))
+				return c.JSON(http.StatusBadRequest, apierr.Error("NAME_CONTAINS_PROHIBITED_WORDS", "Your new name contains prohibited words.", "0b3f9f6a-2e7d-4c2c-9d7a-8c6f9b2e1a44"))
 			}
 		}
 		in.Name = &req.Name
@@ -512,7 +512,7 @@ func (h *Handler) Update(c echo.Context) error {
 	bundle, err := h.userService.UpdateProfile(me.ID, in)
 	if err != nil {
 		if errors.Is(err, user.ErrUserNotFound) {
-			return c.JSON(http.StatusNotFound, errEnvelope("No such user.", "NO_SUCH_USER", "4362f8dc-731f-4ad8-a694-be5a88922a24"))
+			return c.JSON(http.StatusNotFound, apierr.Error("NO_SUCH_USER", "No such user.", "4362f8dc-731f-4ad8-a694-be5a88922a24"))
 		}
 		return internalError(c)
 	}
@@ -537,11 +537,11 @@ func (h *Handler) Pin(c echo.Context) error {
 	if err := h.userService.PinNote(me.ID, req.NoteID); err != nil {
 		switch {
 		case errors.Is(err, user.ErrNoteNotFound):
-			return c.JSON(http.StatusNotFound, errEnvelope("No such note.", "NO_SUCH_NOTE", "24fcbfc6-2e37-42b6-8388-c29b32725715"))
+			return c.JSON(http.StatusNotFound, apierr.Error("NO_SUCH_NOTE", "No such note.", "24fcbfc6-2e37-42b6-8388-c29b32725715"))
 		case errors.Is(err, user.ErrAlreadyPinned):
-			return c.JSON(http.StatusBadRequest, errEnvelope("That note has already been pinned.", "ALREADY_PINNED", "8b18c2b7-68fe-4edb-9892-c0cbaeb6c913"))
+			return c.JSON(http.StatusBadRequest, apierr.Error("ALREADY_PINNED", "That note has already been pinned.", "8b18c2b7-68fe-4edb-9892-c0cbaeb6c913"))
 		case errors.Is(err, user.ErrPinLimitExceeded):
-			return c.JSON(http.StatusBadRequest, errEnvelope("You can not pin notes any more.", "PIN_LIMIT_EXCEEDED", "72dab508-c64d-498f-8740-a8eec1ba385a"))
+			return c.JSON(http.StatusBadRequest, apierr.Error("PIN_LIMIT_EXCEEDED", "You can not pin notes any more.", "72dab508-c64d-498f-8740-a8eec1ba385a"))
 		default:
 			return internalError(c)
 		}
@@ -561,7 +561,7 @@ func (h *Handler) Unpin(c echo.Context) error {
 
 	if err := h.userService.UnpinNote(me.ID, req.NoteID); err != nil {
 		if errors.Is(err, user.ErrPinNotFound) {
-			return c.JSON(http.StatusNotFound, errEnvelope("No such note.", "NO_SUCH_NOTE", "24fcbfc6-2e37-42b6-8388-c29b32725715"))
+			return c.JSON(http.StatusNotFound, apierr.Error("NO_SUCH_NOTE", "No such note.", "24fcbfc6-2e37-42b6-8388-c29b32725715"))
 		}
 		return internalError(c)
 	}
@@ -570,17 +570,9 @@ func (h *Handler) Unpin(c echo.Context) error {
 }
 
 func invalidParam(c echo.Context) error {
-	return c.JSON(http.StatusBadRequest, errEnvelope("Invalid param.", "INVALID_PARAM", "3d81ceae-475f-4600-b2a8-2bc116157532"))
+	return c.JSON(http.StatusBadRequest, apierr.Error("INVALID_PARAM", "Invalid param.", "3d81ceae-475f-4600-b2a8-2bc116157532"))
 }
 
 func internalError(c echo.Context) error {
-	return c.JSON(http.StatusInternalServerError, errEnvelope("Internal error.", "INTERNAL_ERROR", "5d37dbcb-891e-41ca-a3d6-e690c97775ac"))
-}
-
-func errEnvelope(message, code, id string) map[string]any {
-	return apierr.Error(code, message, id)
-}
-
-func apiError(code, message, id string) map[string]any {
-	return apierr.Error(code, message, id)
+	return c.JSON(http.StatusInternalServerError, apierr.Error("INTERNAL_ERROR", "Internal error.", "5d37dbcb-891e-41ca-a3d6-e690c97775ac"))
 }

--- a/internal/api/i/handler_2fa.go
+++ b/internal/api/i/handler_2fa.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/labstack/echo/v4"
 	"github.com/lib/pq"
+	"github.com/shiroha-a/mk/internal/api/apierr"
 	"github.com/shiroha-a/mk/internal/core/twofactor"
 	"github.com/shiroha-a/mk/internal/model"
 	"github.com/shiroha-a/mk/internal/server/middleware"
@@ -37,19 +38,19 @@ func (h *Handler) TwoFARegister(c echo.Context) error {
 		Password string `json:"password"`
 	}
 	if err := c.Bind(&req); err != nil || req.Password == "" {
-		return c.JSON(http.StatusBadRequest, apiError("INVALID_PARAM", "password is required.", "ed1d7571-a3ac-4370-899c-0dbe5e230cc8"))
+		return c.JSON(http.StatusBadRequest, apierr.Error("INVALID_PARAM", "password is required.", "ed1d7571-a3ac-4370-899c-0dbe5e230cc8"))
 	}
 	profile := h.userService.GetProfile(user.ID)
 	if profile == nil || profile.Password == nil {
-		return c.JSON(http.StatusForbidden, apiError("ACCESS_DENIED", "No password set.", "1fb7cb09-d46a-4fff-b8df-057708cce513"))
+		return c.JSON(http.StatusForbidden, apierr.Error("ACCESS_DENIED", "No password set.", "1fb7cb09-d46a-4fff-b8df-057708cce513"))
 	}
 	if err := bcrypt.CompareHashAndPassword([]byte(*profile.Password), []byte(req.Password)); err != nil {
-		return c.JSON(http.StatusForbidden, apiError("INCORRECT_PASSWORD", "Incorrect password.", "932c904e-9460-45b7-9ce6-7ed33be7eb2c"))
+		return c.JSON(http.StatusForbidden, apierr.Error("INCORRECT_PASSWORD", "Incorrect password.", "932c904e-9460-45b7-9ce6-7ed33be7eb2c"))
 	}
 
 	secret, uri, err := twofactor.GenerateSecret("Misskey", user.Username)
 	if err != nil {
-		return c.JSON(http.StatusInternalServerError, apiError("INTERNAL_ERROR", "Internal error.", "5d37dbcb-891e-41ca-a3d6-e690c97775ac"))
+		return c.JSON(http.StatusInternalServerError, apierr.Error("INTERNAL_ERROR", "Internal error.", "5d37dbcb-891e-41ca-a3d6-e690c97775ac"))
 	}
 
 	// tempSecretに保存 (doneで確認後にsecretに移動)
@@ -73,23 +74,23 @@ func (h *Handler) TwoFADone(c echo.Context) error {
 		Token string `json:"token"`
 	}
 	if err := c.Bind(&req); err != nil || req.Token == "" {
-		return c.JSON(http.StatusBadRequest, apiError("INVALID_PARAM", "token is required.", "ed1d7571-a3ac-4370-899c-0dbe5e230cc8"))
+		return c.JSON(http.StatusBadRequest, apierr.Error("INVALID_PARAM", "token is required.", "ed1d7571-a3ac-4370-899c-0dbe5e230cc8"))
 	}
 
 	profile := h.userService.GetProfile(user.ID)
 	if profile == nil || profile.TwoFactorTempSecret == nil {
-		return c.JSON(http.StatusBadRequest, apiError("INVALID_PARAM", "2FA registration not started.", "ed1d7571-a3ac-4370-899c-0dbe5e230cc8"))
+		return c.JSON(http.StatusBadRequest, apierr.Error("INVALID_PARAM", "2FA registration not started.", "ed1d7571-a3ac-4370-899c-0dbe5e230cc8"))
 	}
 
 	if !twofactor.Validate(req.Token, *profile.TwoFactorTempSecret) {
-		return c.JSON(http.StatusForbidden, apiError("INVALID_TOKEN", "Invalid token.", "00000000-0000-0000-0000-000000000000"))
+		return c.JSON(http.StatusForbidden, apierr.Error("INVALID_TOKEN", "Invalid token.", "00000000-0000-0000-0000-000000000000"))
 	}
 
 	// バックアップコードを生成。crypto/rand 失敗は実質起きないが、起きた場合は
 	// 2FA セットアップ自体を中断して 500 を返す。
 	backupCodes, err := twofactor.GenerateBackupCodes()
 	if err != nil {
-		return c.JSON(http.StatusInternalServerError, apiError("INTERNAL_ERROR", "Failed to generate backup codes.", "5d37dbcb-891e-41ca-a3d6-e690c97775ac"))
+		return c.JSON(http.StatusInternalServerError, apierr.Error("INTERNAL_ERROR", "Failed to generate backup codes.", "5d37dbcb-891e-41ca-a3d6-e690c97775ac"))
 	}
 
 	// tempSecretをsecretに移動、2FAを有効化、backup codes を保存
@@ -113,14 +114,14 @@ func (h *Handler) TwoFAUnregister(c echo.Context) error {
 		Password string `json:"password"`
 	}
 	if err := c.Bind(&req); err != nil || req.Password == "" {
-		return c.JSON(http.StatusBadRequest, apiError("INVALID_PARAM", "password is required.", "ed1d7571-a3ac-4370-899c-0dbe5e230cc8"))
+		return c.JSON(http.StatusBadRequest, apierr.Error("INVALID_PARAM", "password is required.", "ed1d7571-a3ac-4370-899c-0dbe5e230cc8"))
 	}
 	profile := h.userService.GetProfile(user.ID)
 	if profile == nil || profile.Password == nil {
-		return c.JSON(http.StatusForbidden, apiError("ACCESS_DENIED", "No password set.", "1fb7cb09-d46a-4fff-b8df-057708cce513"))
+		return c.JSON(http.StatusForbidden, apierr.Error("ACCESS_DENIED", "No password set.", "1fb7cb09-d46a-4fff-b8df-057708cce513"))
 	}
 	if err := bcrypt.CompareHashAndPassword([]byte(*profile.Password), []byte(req.Password)); err != nil {
-		return c.JSON(http.StatusForbidden, apiError("INCORRECT_PASSWORD", "Incorrect password.", "932c904e-9460-45b7-9ce6-7ed33be7eb2c"))
+		return c.JSON(http.StatusForbidden, apierr.Error("INCORRECT_PASSWORD", "Incorrect password.", "932c904e-9460-45b7-9ce6-7ed33be7eb2c"))
 	}
 
 	_ = h.userService.UpdateProfileFields(user.ID, map[string]any{
@@ -143,21 +144,21 @@ func (h *Handler) TwoFAUnregister(c echo.Context) error {
 // nil を return する。
 func (h *Handler) requireWebAuthn(c echo.Context, password string) (*model.User, *model.UserProfile, bool) {
 	if h.webauthnSvc == nil || h.securityKeyRepo == nil {
-		_ = c.JSON(http.StatusServiceUnavailable, apiError("UNAVAILABLE", "WebAuthn is not configured.", "5d37dbcb-891e-41ca-a3d6-e690c97775ac"))
+		_ = c.JSON(http.StatusServiceUnavailable, apierr.Error("UNAVAILABLE", "WebAuthn is not configured.", "5d37dbcb-891e-41ca-a3d6-e690c97775ac"))
 		return nil, nil, false
 	}
 	user := middleware.GetUser(c)
 	if user == nil {
-		_ = c.JSON(http.StatusForbidden, apiError("ACCESS_DENIED", "Access denied.", "1fb7cb09-d46a-4fff-b8df-057708cce513"))
+		_ = c.JSON(http.StatusForbidden, apierr.Error("ACCESS_DENIED", "Access denied.", "1fb7cb09-d46a-4fff-b8df-057708cce513"))
 		return nil, nil, false
 	}
 	profile := h.userService.GetProfile(user.ID)
 	if profile == nil || profile.Password == nil {
-		_ = c.JSON(http.StatusForbidden, apiError("ACCESS_DENIED", "No password set.", "1fb7cb09-d46a-4fff-b8df-057708cce513"))
+		_ = c.JSON(http.StatusForbidden, apierr.Error("ACCESS_DENIED", "No password set.", "1fb7cb09-d46a-4fff-b8df-057708cce513"))
 		return nil, nil, false
 	}
 	if err := bcrypt.CompareHashAndPassword([]byte(*profile.Password), []byte(password)); err != nil {
-		_ = c.JSON(http.StatusForbidden, apiError("INCORRECT_PASSWORD", "Incorrect password.", "932c904e-9460-45b7-9ce6-7ed33be7eb2c"))
+		_ = c.JSON(http.StatusForbidden, apierr.Error("INCORRECT_PASSWORD", "Incorrect password.", "932c904e-9460-45b7-9ce6-7ed33be7eb2c"))
 		return nil, nil, false
 	}
 	return user, profile, true
@@ -173,7 +174,7 @@ func (h *Handler) TwoFARegisterKey(c echo.Context) error {
 		Password string `json:"password"`
 	}
 	if err := c.Bind(&req); err != nil || req.Password == "" {
-		return c.JSON(http.StatusBadRequest, apiError("INVALID_PARAM", "password is required.", "ed1d7571-a3ac-4370-899c-0dbe5e230cc8"))
+		return c.JSON(http.StatusBadRequest, apierr.Error("INVALID_PARAM", "password is required.", "ed1d7571-a3ac-4370-899c-0dbe5e230cc8"))
 	}
 	user, _, ok := h.requireWebAuthn(c, req.Password)
 	if !ok {
@@ -182,11 +183,11 @@ func (h *Handler) TwoFARegisterKey(c echo.Context) error {
 
 	existing, err := h.securityKeyRepo.ListByUser(user.ID)
 	if err != nil {
-		return c.JSON(http.StatusInternalServerError, apiError("INTERNAL_ERROR", "Internal error.", "5d37dbcb-891e-41ca-a3d6-e690c97775ac"))
+		return c.JSON(http.StatusInternalServerError, apierr.Error("INTERNAL_ERROR", "Internal error.", "5d37dbcb-891e-41ca-a3d6-e690c97775ac"))
 	}
 	creation, sessionID, err := h.webauthnSvc.BeginRegistration(c.Request().Context(), user, existing)
 	if err != nil {
-		return c.JSON(http.StatusInternalServerError, apiError("INTERNAL_ERROR", "Failed to begin registration.", "5d37dbcb-891e-41ca-a3d6-e690c97775ac"))
+		return c.JSON(http.StatusInternalServerError, apierr.Error("INTERNAL_ERROR", "Failed to begin registration.", "5d37dbcb-891e-41ca-a3d6-e690c97775ac"))
 	}
 	return c.JSON(http.StatusOK, map[string]any{
 		"sessionId": sessionID,
@@ -207,7 +208,7 @@ func (h *Handler) TwoFAKeyDone(c echo.Context) error {
 		Response  json.RawMessage `json:"response"`
 	}
 	if err := c.Bind(&req); err != nil || req.Password == "" || req.SessionID == "" || len(req.Response) == 0 {
-		return c.JSON(http.StatusBadRequest, apiError("INVALID_PARAM", "password / sessionId / response are required.", "ed1d7571-a3ac-4370-899c-0dbe5e230cc8"))
+		return c.JSON(http.StatusBadRequest, apierr.Error("INVALID_PARAM", "password / sessionId / response are required.", "ed1d7571-a3ac-4370-899c-0dbe5e230cc8"))
 	}
 	if req.Name == "" {
 		req.Name = "Security Key"
@@ -219,23 +220,23 @@ func (h *Handler) TwoFAKeyDone(c echo.Context) error {
 
 	existing, err := h.securityKeyRepo.ListByUser(user.ID)
 	if err != nil {
-		return c.JSON(http.StatusInternalServerError, apiError("INTERNAL_ERROR", "Internal error.", "5d37dbcb-891e-41ca-a3d6-e690c97775ac"))
+		return c.JSON(http.StatusInternalServerError, apierr.Error("INTERNAL_ERROR", "Internal error.", "5d37dbcb-891e-41ca-a3d6-e690c97775ac"))
 	}
 
 	// go-webauthn の FinishRegistration は *http.Request からボディを読むので、
 	// JSON-RPC 経由で受け取った response を新しい http.Request にラップして渡す。
 	httpReq, err := wrapWebAuthnRequest(c.Request(), req.Response)
 	if err != nil {
-		return c.JSON(http.StatusBadRequest, apiError("INVALID_PARAM", "invalid response payload.", "ed1d7571-a3ac-4370-899c-0dbe5e230cc8"))
+		return c.JSON(http.StatusBadRequest, apierr.Error("INVALID_PARAM", "invalid response payload.", "ed1d7571-a3ac-4370-899c-0dbe5e230cc8"))
 	}
 	cred, err := h.webauthnSvc.FinishRegistration(c.Request().Context(), user, existing, req.SessionID, httpReq)
 	if err != nil {
-		return c.JSON(http.StatusForbidden, apiError("REGISTRATION_FAILED", "Failed to finish registration.", "00000000-0000-0000-0000-000000000000"))
+		return c.JSON(http.StatusForbidden, apierr.Error("REGISTRATION_FAILED", "Failed to finish registration.", "00000000-0000-0000-0000-000000000000"))
 	}
 
 	key := twofactor.CredentialToModel(cred, user.ID, req.Name)
 	if err := h.securityKeyRepo.Create(key); err != nil {
-		return c.JSON(http.StatusInternalServerError, apiError("INTERNAL_ERROR", "Failed to persist key.", "5d37dbcb-891e-41ca-a3d6-e690c97775ac"))
+		return c.JSON(http.StatusInternalServerError, apierr.Error("INTERNAL_ERROR", "Failed to persist key.", "5d37dbcb-891e-41ca-a3d6-e690c97775ac"))
 	}
 
 	// 1 つ以上の鍵が登録されたら user_profile.securityKeysAvailable +
@@ -259,7 +260,7 @@ func (h *Handler) TwoFARemoveKey(c echo.Context) error {
 		CredentialID string `json:"credentialId"`
 	}
 	if err := c.Bind(&req); err != nil || req.Password == "" || req.CredentialID == "" {
-		return c.JSON(http.StatusBadRequest, apiError("INVALID_PARAM", "password and credentialId are required.", "ed1d7571-a3ac-4370-899c-0dbe5e230cc8"))
+		return c.JSON(http.StatusBadRequest, apierr.Error("INVALID_PARAM", "password and credentialId are required.", "ed1d7571-a3ac-4370-899c-0dbe5e230cc8"))
 	}
 	user, _, ok := h.requireWebAuthn(c, req.Password)
 	if !ok {
@@ -267,7 +268,7 @@ func (h *Handler) TwoFARemoveKey(c echo.Context) error {
 	}
 
 	if err := h.securityKeyRepo.Delete(req.CredentialID, user.ID); err != nil {
-		return c.JSON(http.StatusNotFound, apiError("NO_SUCH_KEY", "Key not found.", "00000000-0000-0000-0000-000000000000"))
+		return c.JSON(http.StatusNotFound, apierr.Error("NO_SUCH_KEY", "Key not found.", "00000000-0000-0000-0000-000000000000"))
 	}
 
 	if remaining, err := h.securityKeyRepo.CountByUser(user.ID); err == nil && remaining == 0 {
@@ -288,14 +289,14 @@ func (h *Handler) TwoFAUpdateKey(c echo.Context) error {
 		Name         string `json:"name"`
 	}
 	if err := c.Bind(&req); err != nil || req.Password == "" || req.CredentialID == "" || req.Name == "" {
-		return c.JSON(http.StatusBadRequest, apiError("INVALID_PARAM", "password / credentialId / name are required.", "ed1d7571-a3ac-4370-899c-0dbe5e230cc8"))
+		return c.JSON(http.StatusBadRequest, apierr.Error("INVALID_PARAM", "password / credentialId / name are required.", "ed1d7571-a3ac-4370-899c-0dbe5e230cc8"))
 	}
 	user, _, ok := h.requireWebAuthn(c, req.Password)
 	if !ok {
 		return nil
 	}
 	if err := h.securityKeyRepo.UpdateName(req.CredentialID, user.ID, req.Name); err != nil {
-		return c.JSON(http.StatusNotFound, apiError("NO_SUCH_KEY", "Key not found.", "00000000-0000-0000-0000-000000000000"))
+		return c.JSON(http.StatusNotFound, apierr.Error("NO_SUCH_KEY", "Key not found.", "00000000-0000-0000-0000-000000000000"))
 	}
 	return c.NoContent(http.StatusNoContent)
 }
@@ -309,7 +310,7 @@ func (h *Handler) TwoFAPasswordLess(c echo.Context) error {
 		Value    bool   `json:"value"`
 	}
 	if err := c.Bind(&req); err != nil || req.Password == "" {
-		return c.JSON(http.StatusBadRequest, apiError("INVALID_PARAM", "password is required.", "ed1d7571-a3ac-4370-899c-0dbe5e230cc8"))
+		return c.JSON(http.StatusBadRequest, apierr.Error("INVALID_PARAM", "password is required.", "ed1d7571-a3ac-4370-899c-0dbe5e230cc8"))
 	}
 	user, _, ok := h.requireWebAuthn(c, req.Password)
 	if !ok {
@@ -317,7 +318,7 @@ func (h *Handler) TwoFAPasswordLess(c echo.Context) error {
 	}
 	if req.Value {
 		if n, err := h.securityKeyRepo.CountByUser(user.ID); err != nil || n == 0 {
-			return c.JSON(http.StatusBadRequest, apiError("NO_SECURITY_KEYS", "Register at least one security key first.", "00000000-0000-0000-0000-000000000000"))
+			return c.JSON(http.StatusBadRequest, apierr.Error("NO_SECURITY_KEYS", "Register at least one security key first.", "00000000-0000-0000-0000-000000000000"))
 		}
 	}
 	_ = h.userService.UpdateProfileFields(user.ID, map[string]any{

--- a/internal/api/i/handler_extra.go
+++ b/internal/api/i/handler_extra.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/labstack/echo/v4"
+	"github.com/shiroha-a/mk/internal/api/apierr"
 	"github.com/shiroha-a/mk/internal/entity"
 	"github.com/shiroha-a/mk/internal/server/middleware"
 	"golang.org/x/crypto/bcrypt"
@@ -21,22 +22,22 @@ func (h *Handler) ChangePassword(c echo.Context) error {
 		NewPassword     string `json:"newPassword"`
 	}
 	if err := c.Bind(&req); err != nil || req.CurrentPassword == "" || req.NewPassword == "" {
-		return c.JSON(http.StatusBadRequest, apiError("INVALID_PARAM", "currentPassword and newPassword are required.", "3d81ceae-475f-4600-b2a8-2bc116157532"))
+		return c.JSON(http.StatusBadRequest, apierr.Error("INVALID_PARAM", "currentPassword and newPassword are required.", "3d81ceae-475f-4600-b2a8-2bc116157532"))
 	}
 
 	profile := h.userService.GetProfile(u.ID)
 	if profile == nil || profile.Password == nil {
-		return c.JSON(http.StatusForbidden, apiError("ACCESS_DENIED", "No password set.", "1fb7cb09-d46a-4fff-b8df-057708cce513"))
+		return c.JSON(http.StatusForbidden, apierr.Error("ACCESS_DENIED", "No password set.", "1fb7cb09-d46a-4fff-b8df-057708cce513"))
 	}
 
 	if err := bcrypt.CompareHashAndPassword([]byte(*profile.Password), []byte(req.CurrentPassword)); err != nil {
-		return c.JSON(http.StatusForbidden, apiError("INCORRECT_PASSWORD", "Incorrect password.", "932c904e-9460-45b7-9ce6-7ed33be7eb2c"))
+		return c.JSON(http.StatusForbidden, apierr.Error("INCORRECT_PASSWORD", "Incorrect password.", "932c904e-9460-45b7-9ce6-7ed33be7eb2c"))
 	}
 
 	hash, _ := bcrypt.GenerateFromPassword([]byte(req.NewPassword), bcrypt.DefaultCost)
 	hashStr := string(hash)
 	if err := h.userService.UpdateProfileFields(u.ID, map[string]any{"password": hashStr}); err != nil {
-		return c.JSON(http.StatusInternalServerError, apiError("INTERNAL_ERROR", "Internal error.", "5d37dbcb-891e-41ca-a3d6-e690c97775ac"))
+		return c.JSON(http.StatusInternalServerError, apierr.Error("INTERNAL_ERROR", "Internal error.", "5d37dbcb-891e-41ca-a3d6-e690c97775ac"))
 	}
 	return c.NoContent(http.StatusNoContent)
 }
@@ -48,16 +49,16 @@ func (h *Handler) DeleteAccount(c echo.Context) error {
 		Password string `json:"password"`
 	}
 	if err := c.Bind(&req); err != nil || req.Password == "" {
-		return c.JSON(http.StatusBadRequest, apiError("INVALID_PARAM", "password is required.", "3d81ceae-475f-4600-b2a8-2bc116157532"))
+		return c.JSON(http.StatusBadRequest, apierr.Error("INVALID_PARAM", "password is required.", "3d81ceae-475f-4600-b2a8-2bc116157532"))
 	}
 
 	profile := h.userService.GetProfile(u.ID)
 	if profile == nil || profile.Password == nil {
-		return c.JSON(http.StatusForbidden, apiError("ACCESS_DENIED", "No password set.", "1fb7cb09-d46a-4fff-b8df-057708cce513"))
+		return c.JSON(http.StatusForbidden, apierr.Error("ACCESS_DENIED", "No password set.", "1fb7cb09-d46a-4fff-b8df-057708cce513"))
 	}
 
 	if err := bcrypt.CompareHashAndPassword([]byte(*profile.Password), []byte(req.Password)); err != nil {
-		return c.JSON(http.StatusForbidden, apiError("INCORRECT_PASSWORD", "Incorrect password.", "932c904e-9460-45b7-9ce6-7ed33be7eb2c"))
+		return c.JSON(http.StatusForbidden, apierr.Error("INCORRECT_PASSWORD", "Incorrect password.", "932c904e-9460-45b7-9ce6-7ed33be7eb2c"))
 	}
 
 	// isSuspended + isDeleted を true に設定 (論理削除)
@@ -65,7 +66,7 @@ func (h *Handler) DeleteAccount(c echo.Context) error {
 		"isSuspended": true,
 		"isDeleted":   true,
 	}); err != nil {
-		return c.JSON(http.StatusInternalServerError, apiError("INTERNAL_ERROR", "Internal error.", "5d37dbcb-891e-41ca-a3d6-e690c97775ac"))
+		return c.JSON(http.StatusInternalServerError, apierr.Error("INTERNAL_ERROR", "Internal error.", "5d37dbcb-891e-41ca-a3d6-e690c97775ac"))
 	}
 	return c.NoContent(http.StatusNoContent)
 }
@@ -78,14 +79,14 @@ func (h *Handler) Favorites(c echo.Context) error {
 		Offset int `json:"offset"`
 	}
 	if err := c.Bind(&req); err != nil {
-		return c.JSON(http.StatusBadRequest, apiError("INVALID_PARAM", "Invalid parameters.", "3d81ceae-475f-4600-b2a8-2bc116157532"))
+		return c.JSON(http.StatusBadRequest, apierr.Error("INVALID_PARAM", "Invalid parameters.", "3d81ceae-475f-4600-b2a8-2bc116157532"))
 	}
 	if h.favoriteRepo == nil {
 		return c.JSON(http.StatusOK, []any{})
 	}
 	favs, err := h.favoriteRepo.ListByUser(u.ID, req.Limit, req.Offset)
 	if err != nil {
-		return c.JSON(http.StatusInternalServerError, apiError("INTERNAL_ERROR", "Internal error.", "5d37dbcb-891e-41ca-a3d6-e690c97775ac"))
+		return c.JSON(http.StatusInternalServerError, apierr.Error("INTERNAL_ERROR", "Internal error.", "5d37dbcb-891e-41ca-a3d6-e690c97775ac"))
 	}
 	result := make([]map[string]any, 0, len(favs))
 	for _, f := range favs {
@@ -114,16 +115,16 @@ func (h *Handler) RegenerateToken(c echo.Context) error {
 		Password string `json:"password"`
 	}
 	if err := c.Bind(&req); err != nil || req.Password == "" {
-		return c.JSON(http.StatusBadRequest, apiError("INVALID_PARAM", "password is required.", "3d81ceae-475f-4600-b2a8-2bc116157532"))
+		return c.JSON(http.StatusBadRequest, apierr.Error("INVALID_PARAM", "password is required.", "3d81ceae-475f-4600-b2a8-2bc116157532"))
 	}
 
 	profile := h.userService.GetProfile(u.ID)
 	if profile == nil || profile.Password == nil {
-		return c.JSON(http.StatusForbidden, apiError("ACCESS_DENIED", "No password set.", "1fb7cb09-d46a-4fff-b8df-057708cce513"))
+		return c.JSON(http.StatusForbidden, apierr.Error("ACCESS_DENIED", "No password set.", "1fb7cb09-d46a-4fff-b8df-057708cce513"))
 	}
 
 	if err := bcrypt.CompareHashAndPassword([]byte(*profile.Password), []byte(req.Password)); err != nil {
-		return c.JSON(http.StatusForbidden, apiError("INCORRECT_PASSWORD", "Incorrect password.", "932c904e-9460-45b7-9ce6-7ed33be7eb2c"))
+		return c.JSON(http.StatusForbidden, apierr.Error("INCORRECT_PASSWORD", "Incorrect password.", "932c904e-9460-45b7-9ce6-7ed33be7eb2c"))
 	}
 
 	b := make([]byte, 8)
@@ -131,7 +132,7 @@ func (h *Handler) RegenerateToken(c echo.Context) error {
 	newToken := hex.EncodeToString(b)
 
 	if err := h.userService.UpdateUserFields(u.ID, map[string]any{"token": newToken}); err != nil {
-		return c.JSON(http.StatusInternalServerError, apiError("INTERNAL_ERROR", "Internal error.", "5d37dbcb-891e-41ca-a3d6-e690c97775ac"))
+		return c.JSON(http.StatusInternalServerError, apierr.Error("INTERNAL_ERROR", "Internal error.", "5d37dbcb-891e-41ca-a3d6-e690c97775ac"))
 	}
 	return c.JSON(http.StatusOK, map[string]any{"token": newToken})
 }
@@ -144,7 +145,7 @@ func (h *Handler) ClaimAchievement(c echo.Context) error {
 		Name string `json:"name"`
 	}
 	if err := c.Bind(&req); err != nil || req.Name == "" {
-		return c.JSON(http.StatusBadRequest, apiError("INVALID_PARAM", "name is required.", "ed1d7571-a3ac-4370-899c-0dbe5e230cc8"))
+		return c.JSON(http.StatusBadRequest, apierr.Error("INVALID_PARAM", "name is required.", "ed1d7571-a3ac-4370-899c-0dbe5e230cc8"))
 	}
 
 	profile := h.userService.GetProfile(u.ID)
@@ -173,7 +174,7 @@ func (h *Handler) ClaimAchievement(c echo.Context) error {
 	data, _ := json.Marshal(achievements)
 
 	if err := h.userService.UpdateProfileFields(u.ID, map[string]any{"achievements": string(data)}); err != nil {
-		return c.JSON(http.StatusInternalServerError, apiError("INTERNAL_ERROR", "Internal error.", "5d37dbcb-891e-41ca-a3d6-e690c97775ac"))
+		return c.JSON(http.StatusInternalServerError, apierr.Error("INTERNAL_ERROR", "Internal error.", "5d37dbcb-891e-41ca-a3d6-e690c97775ac"))
 	}
 
 	return c.NoContent(http.StatusNoContent)

--- a/internal/api/i/handler_stubs.go
+++ b/internal/api/i/handler_stubs.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 
 	"github.com/labstack/echo/v4"
+	"github.com/shiroha-a/mk/internal/api/apierr"
 	coreemail "github.com/shiroha-a/mk/internal/core/email"
 	"github.com/shiroha-a/mk/internal/server/middleware"
 	"golang.org/x/crypto/bcrypt"
@@ -49,7 +50,7 @@ func (h *Handler) SigninHistory(c echo.Context) error {
 		UntilID *string `json:"untilId"`
 	}
 	if err := c.Bind(&req); err != nil {
-		return c.JSON(http.StatusBadRequest, errEnvelope("Invalid param.", "INVALID_PARAM", "3d81ceae-475f-4600-b2a8-2bc116157532"))
+		return c.JSON(http.StatusBadRequest, apierr.Error("INVALID_PARAM", "Invalid param.", "3d81ceae-475f-4600-b2a8-2bc116157532"))
 	}
 
 	limit := 10
@@ -73,7 +74,7 @@ func (h *Handler) SigninHistory(c echo.Context) error {
 
 	rows, err := h.signinRepo.ListByUserID(u.ID, limit, untilID, sinceID)
 	if err != nil {
-		return c.JSON(http.StatusInternalServerError, errEnvelope("Internal error.", "INTERNAL_ERROR", "5d37dbcb-891e-41ca-a3d6-e690c97775ac"))
+		return c.JSON(http.StatusInternalServerError, apierr.Error("INTERNAL_ERROR", "Internal error.", "5d37dbcb-891e-41ca-a3d6-e690c97775ac"))
 	}
 
 	result := make([]map[string]any, len(rows))
@@ -121,7 +122,7 @@ func (h *Handler) UpdateEmail(c echo.Context) error {
 
 	// パスワード検証
 	if err := bcrypt.CompareHashAndPassword([]byte(*profile.Password), []byte(req.Password)); err != nil {
-		return c.JSON(http.StatusForbidden, errEnvelope("Incorrect password.", "INCORRECT_PASSWORD", "e86c14a4-0da8-4571-8f36-8a2e9f9b3a00"))
+		return c.JSON(http.StatusForbidden, apierr.Error("INCORRECT_PASSWORD", "Incorrect password.", "e86c14a4-0da8-4571-8f36-8a2e9f9b3a00"))
 	}
 
 	fields := map[string]any{
@@ -133,7 +134,7 @@ func (h *Handler) UpdateEmail(c echo.Context) error {
 		// email クリア。emailRequiredForSignup 時はクリア不可。
 		if h.metaRepo != nil {
 			if m, err := h.metaRepo.Fetch(); err == nil && m.EmailRequiredForSignup {
-				return c.JSON(http.StatusBadRequest, errEnvelope("Email is required.", "INVALID_PARAM", "3d81ceae-475f-4600-b2a8-2bc116157532"))
+				return c.JSON(http.StatusBadRequest, apierr.Error("INVALID_PARAM", "Email is required.", "3d81ceae-475f-4600-b2a8-2bc116157532"))
 			}
 		}
 		fields["email"] = nil
@@ -144,7 +145,7 @@ func (h *Handler) UpdateEmail(c echo.Context) error {
 			if m, err := h.metaRepo.Fetch(); err == nil {
 				svc := coreemail.NewService(m)
 				if verr := svc.Validate(c.Request().Context(), addr); verr != nil {
-					return c.JSON(http.StatusBadRequest, errEnvelope("Email is not available.", "UNAVAILABLE", "a]504947-b888-4a99-9f62-8c4a0f3a3dab"))
+					return c.JSON(http.StatusBadRequest, apierr.Error("UNAVAILABLE", "Email is not available.", "a]504947-b888-4a99-9f62-8c4a0f3a3dab"))
 				}
 			}
 		}
@@ -179,7 +180,7 @@ func (h *Handler) VerifyEmail(c echo.Context) error {
 
 	profile, err := h.userService.FindProfileByVerifyCode(req.Code)
 	if err != nil {
-		return c.JSON(http.StatusNotFound, errEnvelope("No such code.", "NO_SUCH_CODE", "1e53842e-b7f4-4e1c-8f1e-8d0a2d9b0c7e"))
+		return c.JSON(http.StatusNotFound, apierr.Error("NO_SUCH_CODE", "No such code.", "1e53842e-b7f4-4e1c-8f1e-8d0a2d9b0c7e"))
 	}
 
 	if verr := h.userService.UpdateProfileFields(profile.UserID, map[string]any{

--- a/internal/api/i/transfer_handler.go
+++ b/internal/api/i/transfer_handler.go
@@ -4,6 +4,7 @@ import (
 	"net/http"
 
 	"github.com/labstack/echo/v4"
+	"github.com/shiroha-a/mk/internal/api/apierr"
 	"github.com/shiroha-a/mk/internal/core/transfer"
 	"github.com/shiroha-a/mk/internal/queue"
 	"github.com/shiroha-a/mk/internal/server/middleware"
@@ -29,13 +30,13 @@ func (h *Handler) exportHandler(exportType string) echo.HandlerFunc {
 	return func(c echo.Context) error {
 		u := middleware.GetUser(c)
 		if h.transferEnqueuer == nil {
-			return c.JSON(http.StatusInternalServerError, apiError("INTERNAL_ERROR", "Transfer queue not configured.", "5d37dbcb-891e-41ca-a3d6-e690c97775ac"))
+			return c.JSON(http.StatusInternalServerError, apierr.Error("INTERNAL_ERROR", "Transfer queue not configured.", "5d37dbcb-891e-41ca-a3d6-e690c97775ac"))
 		}
 		if err := h.transferEnqueuer.EnqueueExport(queue.ExportPayload{
 			UserID: u.ID,
 			Type:   exportType,
 		}); err != nil {
-			return c.JSON(http.StatusInternalServerError, apiError("INTERNAL_ERROR", "Failed to enqueue export.", "5d37dbcb-891e-41ca-a3d6-e690c97775ac"))
+			return c.JSON(http.StatusInternalServerError, apierr.Error("INTERNAL_ERROR", "Failed to enqueue export.", "5d37dbcb-891e-41ca-a3d6-e690c97775ac"))
 		}
 		return c.NoContent(http.StatusNoContent)
 	}
@@ -50,17 +51,17 @@ func (h *Handler) importHandler(importType string) echo.HandlerFunc {
 			FileID string `json:"fileId"`
 		}
 		if err := c.Bind(&req); err != nil || req.FileID == "" {
-			return c.JSON(http.StatusBadRequest, apiError("INVALID_PARAM", "fileId is required.", "3d81ceae-475f-4600-b2a8-2bc116157532"))
+			return c.JSON(http.StatusBadRequest, apierr.Error("INVALID_PARAM", "fileId is required.", "3d81ceae-475f-4600-b2a8-2bc116157532"))
 		}
 		if h.transferEnqueuer == nil {
-			return c.JSON(http.StatusInternalServerError, apiError("INTERNAL_ERROR", "Transfer queue not configured.", "5d37dbcb-891e-41ca-a3d6-e690c97775ac"))
+			return c.JSON(http.StatusInternalServerError, apierr.Error("INTERNAL_ERROR", "Transfer queue not configured.", "5d37dbcb-891e-41ca-a3d6-e690c97775ac"))
 		}
 		if err := h.transferEnqueuer.EnqueueImport(queue.ImportPayload{
 			UserID: u.ID,
 			Type:   importType,
 			FileID: req.FileID,
 		}); err != nil {
-			return c.JSON(http.StatusInternalServerError, apiError("INTERNAL_ERROR", "Failed to enqueue import.", "5d37dbcb-891e-41ca-a3d6-e690c97775ac"))
+			return c.JSON(http.StatusInternalServerError, apierr.Error("INTERNAL_ERROR", "Failed to enqueue import.", "5d37dbcb-891e-41ca-a3d6-e690c97775ac"))
 		}
 		return c.NoContent(http.StatusNoContent)
 	}

--- a/internal/api/notes/handler_drafts.go
+++ b/internal/api/notes/handler_drafts.go
@@ -5,6 +5,7 @@ import (
 	"time"
 
 	"github.com/labstack/echo/v4"
+	"github.com/shiroha-a/mk/internal/api/apierr"
 	"github.com/shiroha-a/mk/internal/model"
 	"github.com/shiroha-a/mk/internal/repository"
 	"github.com/shiroha-a/mk/internal/server/middleware"
@@ -45,7 +46,7 @@ func (h *Handler) DraftsCreate(c echo.Context) error {
 		FileIDs    []string `json:"fileIds"`
 	}
 	if err := c.Bind(&req); err != nil {
-		return c.JSON(http.StatusBadRequest, apiError("INVALID_PARAM", "Invalid parameters.", "3d81ceae-475f-4600-b2a8-2bc116157532"))
+		return c.JSON(http.StatusBadRequest, apierr.Error("INVALID_PARAM", "Invalid parameters.", "3d81ceae-475f-4600-b2a8-2bc116157532"))
 	}
 	if req.Visibility == "" {
 		req.Visibility = "public"
@@ -59,7 +60,7 @@ func (h *Handler) DraftsCreate(c echo.Context) error {
 		FileIDs:    req.FileIDs,
 	}
 	if err := h.draftRepo.Create(draft); err != nil {
-		return c.JSON(http.StatusInternalServerError, apiError("INTERNAL_ERROR", "Internal error.", "5d37dbcb-891e-41ca-a3d6-e690c97775ac"))
+		return c.JSON(http.StatusInternalServerError, apierr.Error("INTERNAL_ERROR", "Internal error.", "5d37dbcb-891e-41ca-a3d6-e690c97775ac"))
 	}
 	return c.JSON(http.StatusOK, packDraft(draft, h.idGen))
 }
@@ -78,11 +79,11 @@ func (h *Handler) DraftsUpdate(c echo.Context) error {
 		FileIDs    []string `json:"fileIds"`
 	}
 	if err := c.Bind(&req); err != nil || req.DraftID == "" {
-		return c.JSON(http.StatusBadRequest, apiError("INVALID_PARAM", "draftId is required.", "3d81ceae-475f-4600-b2a8-2bc116157532"))
+		return c.JSON(http.StatusBadRequest, apierr.Error("INVALID_PARAM", "draftId is required.", "3d81ceae-475f-4600-b2a8-2bc116157532"))
 	}
 	draft, err := h.draftRepo.FindByIDAndUser(req.DraftID, user.ID)
 	if err != nil {
-		return c.JSON(http.StatusNotFound, apiError("NO_SUCH_DRAFT", "No such draft.", "00000000-0000-0000-0000-000000000000"))
+		return c.JSON(http.StatusNotFound, apierr.Error("NO_SUCH_DRAFT", "No such draft.", "00000000-0000-0000-0000-000000000000"))
 	}
 	if req.Text != nil {
 		draft.Text = req.Text
@@ -110,7 +111,7 @@ func (h *Handler) DraftsDelete(c echo.Context) error {
 		DraftID string `json:"draftId"`
 	}
 	if err := c.Bind(&req); err != nil || req.DraftID == "" {
-		return c.JSON(http.StatusBadRequest, apiError("INVALID_PARAM", "draftId is required.", "3d81ceae-475f-4600-b2a8-2bc116157532"))
+		return c.JSON(http.StatusBadRequest, apierr.Error("INVALID_PARAM", "draftId is required.", "3d81ceae-475f-4600-b2a8-2bc116157532"))
 	}
 	_ = h.draftRepo.Delete(req.DraftID, user.ID)
 	return c.NoContent(http.StatusNoContent)
@@ -132,7 +133,7 @@ func (h *Handler) ThreadMutingCreate(c echo.Context) error {
 		NoteID string `json:"noteId"`
 	}
 	if err := c.Bind(&req); err != nil || req.NoteID == "" {
-		return c.JSON(http.StatusBadRequest, apiError("INVALID_PARAM", "noteId is required.", "3d81ceae-475f-4600-b2a8-2bc116157532"))
+		return c.JSON(http.StatusBadRequest, apierr.Error("INVALID_PARAM", "noteId is required.", "3d81ceae-475f-4600-b2a8-2bc116157532"))
 	}
 	return c.NoContent(http.StatusNoContent)
 }
@@ -143,7 +144,7 @@ func (h *Handler) ThreadMutingDelete(c echo.Context) error {
 		NoteID string `json:"noteId"`
 	}
 	if err := c.Bind(&req); err != nil || req.NoteID == "" {
-		return c.JSON(http.StatusBadRequest, apiError("INVALID_PARAM", "noteId is required.", "3d81ceae-475f-4600-b2a8-2bc116157532"))
+		return c.JSON(http.StatusBadRequest, apierr.Error("INVALID_PARAM", "noteId is required.", "3d81ceae-475f-4600-b2a8-2bc116157532"))
 	}
 	return c.NoContent(http.StatusNoContent)
 }

--- a/internal/api/notes/handler_extra.go
+++ b/internal/api/notes/handler_extra.go
@@ -24,17 +24,17 @@ func (h *Handler) FavoritesCreate(c echo.Context) error {
 		NoteID string `json:"noteId"`
 	}
 	if err := c.Bind(&req); err != nil || req.NoteID == "" {
-		return c.JSON(http.StatusBadRequest, apiError("INVALID_PARAM", "noteId is required.", "3d81ceae-475f-4600-b2a8-2bc116157532"))
+		return c.JSON(http.StatusBadRequest, apierr.Error("INVALID_PARAM", "noteId is required.", "3d81ceae-475f-4600-b2a8-2bc116157532"))
 	}
 	if _, err := h.noteRepo.FindByID(req.NoteID); err != nil {
-		return c.JSON(http.StatusNotFound, apiError("NO_SUCH_NOTE", "No such note.", "24fcbfc6-2e37-42b6-8388-c29b32725715"))
+		return c.JSON(http.StatusNotFound, apierr.Error("NO_SUCH_NOTE", "No such note.", "24fcbfc6-2e37-42b6-8388-c29b32725715"))
 	}
 	if h.favoriteRepo == nil {
-		return c.JSON(http.StatusInternalServerError, apiError("INTERNAL_ERROR", "Internal error.", "5d37dbcb-891e-41ca-a3d6-e690c97775ac"))
+		return c.JSON(http.StatusInternalServerError, apierr.Error("INTERNAL_ERROR", "Internal error.", "5d37dbcb-891e-41ca-a3d6-e690c97775ac"))
 	}
 	exists, _ := h.favoriteRepo.Exists(user.ID, req.NoteID)
 	if exists {
-		return c.JSON(http.StatusConflict, apiError("ALREADY_FAVORITED", "Already favorited.", "a402c12b-34dd-41d2-97d8-4d2c5b7e4645"))
+		return c.JSON(http.StatusConflict, apierr.Error("ALREADY_FAVORITED", "Already favorited.", "a402c12b-34dd-41d2-97d8-4d2c5b7e4645"))
 	}
 	fav := &model.NoteFavorite{
 		ID:     h.idGen.Generate(time.Now()),
@@ -42,7 +42,7 @@ func (h *Handler) FavoritesCreate(c echo.Context) error {
 		NoteID: req.NoteID,
 	}
 	if err := h.favoriteRepo.Create(fav); err != nil {
-		return c.JSON(http.StatusInternalServerError, apiError("INTERNAL_ERROR", "Internal error.", "5d37dbcb-891e-41ca-a3d6-e690c97775ac"))
+		return c.JSON(http.StatusInternalServerError, apierr.Error("INTERNAL_ERROR", "Internal error.", "5d37dbcb-891e-41ca-a3d6-e690c97775ac"))
 	}
 	return c.NoContent(http.StatusNoContent)
 }
@@ -54,13 +54,13 @@ func (h *Handler) FavoritesDelete(c echo.Context) error {
 		NoteID string `json:"noteId"`
 	}
 	if err := c.Bind(&req); err != nil || req.NoteID == "" {
-		return c.JSON(http.StatusBadRequest, apiError("INVALID_PARAM", "noteId is required.", "3d81ceae-475f-4600-b2a8-2bc116157532"))
+		return c.JSON(http.StatusBadRequest, apierr.Error("INVALID_PARAM", "noteId is required.", "3d81ceae-475f-4600-b2a8-2bc116157532"))
 	}
 	if h.favoriteRepo == nil {
-		return c.JSON(http.StatusInternalServerError, apiError("INTERNAL_ERROR", "Internal error.", "5d37dbcb-891e-41ca-a3d6-e690c97775ac"))
+		return c.JSON(http.StatusInternalServerError, apierr.Error("INTERNAL_ERROR", "Internal error.", "5d37dbcb-891e-41ca-a3d6-e690c97775ac"))
 	}
 	if err := h.favoriteRepo.Delete(user.ID, req.NoteID); err != nil {
-		return c.JSON(http.StatusInternalServerError, apiError("INTERNAL_ERROR", "Internal error.", "5d37dbcb-891e-41ca-a3d6-e690c97775ac"))
+		return c.JSON(http.StatusInternalServerError, apierr.Error("INTERNAL_ERROR", "Internal error.", "5d37dbcb-891e-41ca-a3d6-e690c97775ac"))
 	}
 	return c.NoContent(http.StatusNoContent)
 }
@@ -73,14 +73,14 @@ func (h *Handler) Featured(c echo.Context) error {
 		Offset int `json:"offset"`
 	}
 	if err := c.Bind(&req); err != nil {
-		return c.JSON(http.StatusBadRequest, apiError("INVALID_PARAM", "Invalid parameters.", "3d81ceae-475f-4600-b2a8-2bc116157532"))
+		return c.JSON(http.StatusBadRequest, apierr.Error("INVALID_PARAM", "Invalid parameters.", "3d81ceae-475f-4600-b2a8-2bc116157532"))
 	}
 	if req.Limit <= 0 {
 		req.Limit = 10
 	}
 	notes, err := h.noteRepo.ListFeatured(req.Limit, req.Offset)
 	if err != nil {
-		return c.JSON(http.StatusInternalServerError, apiError("INTERNAL_ERROR", "Internal error.", "5d37dbcb-891e-41ca-a3d6-e690c97775ac"))
+		return c.JSON(http.StatusInternalServerError, apierr.Error("INTERNAL_ERROR", "Internal error.", "5d37dbcb-891e-41ca-a3d6-e690c97775ac"))
 	}
 	return c.JSON(http.StatusOK, h.packMany(notes, middleware.GetUser(c)))
 }
@@ -92,15 +92,15 @@ func (h *Handler) Unrenote(c echo.Context) error {
 		NoteID string `json:"noteId"`
 	}
 	if err := c.Bind(&req); err != nil || req.NoteID == "" {
-		return c.JSON(http.StatusBadRequest, apiError("INVALID_PARAM", "noteId is required.", "3d81ceae-475f-4600-b2a8-2bc116157532"))
+		return c.JSON(http.StatusBadRequest, apierr.Error("INVALID_PARAM", "noteId is required.", "3d81ceae-475f-4600-b2a8-2bc116157532"))
 	}
 	// renoteId が指定ノートの自分のノートを探して削除
 	renote, err := h.noteRepo.FindRenoteByUser(user.ID, req.NoteID)
 	if err != nil {
-		return c.JSON(http.StatusNotFound, apiError("NO_SUCH_NOTE", "No such renote.", "24fcbfc6-2e37-42b6-8388-c29b32725715"))
+		return c.JSON(http.StatusNotFound, apierr.Error("NO_SUCH_NOTE", "No such renote.", "24fcbfc6-2e37-42b6-8388-c29b32725715"))
 	}
 	if err := h.deleteService.Delete(user, renote.ID); err != nil {
-		return c.JSON(http.StatusInternalServerError, apiError("INTERNAL_ERROR", "Internal error.", "5d37dbcb-891e-41ca-a3d6-e690c97775ac"))
+		return c.JSON(http.StatusInternalServerError, apierr.Error("INTERNAL_ERROR", "Internal error.", "5d37dbcb-891e-41ca-a3d6-e690c97775ac"))
 	}
 	return c.NoContent(http.StatusNoContent)
 }
@@ -115,14 +115,14 @@ func (h *Handler) Mentions(c echo.Context) error {
 		Visibility string `json:"visibility"`
 	}
 	if err := c.Bind(&req); err != nil {
-		return c.JSON(http.StatusBadRequest, apiError("INVALID_PARAM", "Invalid parameters.", "3d81ceae-475f-4600-b2a8-2bc116157532"))
+		return c.JSON(http.StatusBadRequest, apierr.Error("INVALID_PARAM", "Invalid parameters.", "3d81ceae-475f-4600-b2a8-2bc116157532"))
 	}
 	if req.Limit <= 0 {
 		req.Limit = 10
 	}
 	notes, err := h.noteRepo.ListMentions(user.ID, req.Limit, req.SinceID, req.UntilID)
 	if err != nil {
-		return c.JSON(http.StatusInternalServerError, apiError("INTERNAL_ERROR", "Internal error.", "5d37dbcb-891e-41ca-a3d6-e690c97775ac"))
+		return c.JSON(http.StatusInternalServerError, apierr.Error("INTERNAL_ERROR", "Internal error.", "5d37dbcb-891e-41ca-a3d6-e690c97775ac"))
 	}
 	// visibilityフィルタ
 	// "specified" → DMのみ、未指定 → DM以外
@@ -150,7 +150,7 @@ func (h *Handler) UserListTimeline(c echo.Context) error {
 		UntilID string `json:"untilId"`
 	}
 	if err := c.Bind(&req); err != nil || req.ListID == "" {
-		return c.JSON(http.StatusBadRequest, apiError("INVALID_PARAM", "listId is required.", "3d81ceae-475f-4600-b2a8-2bc116157532"))
+		return c.JSON(http.StatusBadRequest, apierr.Error("INVALID_PARAM", "listId is required.", "3d81ceae-475f-4600-b2a8-2bc116157532"))
 	}
 	if req.Limit <= 0 {
 		req.Limit = 10
@@ -168,7 +168,7 @@ func (h *Handler) SearchByTag(c echo.Context) error {
 		UntilID string `json:"untilId"`
 	}
 	if err := c.Bind(&req); err != nil || req.Tag == "" {
-		return c.JSON(http.StatusBadRequest, apiError("INVALID_PARAM", "tag is required.", "3d81ceae-475f-4600-b2a8-2bc116157532"))
+		return c.JSON(http.StatusBadRequest, apierr.Error("INVALID_PARAM", "tag is required.", "3d81ceae-475f-4600-b2a8-2bc116157532"))
 	}
 	if req.Limit <= 0 {
 		req.Limit = 10
@@ -193,25 +193,25 @@ func (h *Handler) Translate(c echo.Context) error {
 		TargetLang string `json:"targetLang"`
 	}
 	if err := c.Bind(&req); err != nil || req.NoteID == "" || req.TargetLang == "" {
-		return c.JSON(http.StatusBadRequest, apiError("INVALID_PARAM", "noteId and targetLang are required.", "3d81ceae-475f-4600-b2a8-2bc116157532"))
+		return c.JSON(http.StatusBadRequest, apierr.Error("INVALID_PARAM", "noteId and targetLang are required.", "3d81ceae-475f-4600-b2a8-2bc116157532"))
 	}
 
 	if h.translator == nil {
-		return c.JSON(http.StatusServiceUnavailable, apiError("UNAVAILABLE", "Translator is not configured.", "bef6e895-c05f-4572-96ab-58f5ae1e2e28"))
+		return c.JSON(http.StatusServiceUnavailable, apierr.Error("UNAVAILABLE", "Translator is not configured.", "bef6e895-c05f-4572-96ab-58f5ae1e2e28"))
 	}
 
 	n, err := h.noteRepo.FindByID(req.NoteID)
 	if err != nil {
-		return c.JSON(http.StatusNotFound, apiError("NO_SUCH_NOTE", "No such note.", "24fcbfc6-2e37-42b6-8388-c29b32725715"))
+		return c.JSON(http.StatusNotFound, apierr.Error("NO_SUCH_NOTE", "No such note.", "24fcbfc6-2e37-42b6-8388-c29b32725715"))
 	}
 
 	if n.Text == nil || *n.Text == "" {
-		return c.JSON(http.StatusBadRequest, apiError("CANNOT_TRANSLATE", "Nothing to translate.", "bef6e895-c05f-4572-96ab-58f5ae1e2e28"))
+		return c.JSON(http.StatusBadRequest, apierr.Error("CANNOT_TRANSLATE", "Nothing to translate.", "bef6e895-c05f-4572-96ab-58f5ae1e2e28"))
 	}
 
 	result, err := h.translator.Translate(c.Request().Context(), *n.Text, req.TargetLang)
 	if err != nil {
-		return c.JSON(http.StatusInternalServerError, apiError("INTERNAL_ERROR", "Translation failed.", "5d37dbcb-891e-41ca-a3d6-e690c97775ac"))
+		return c.JSON(http.StatusInternalServerError, apierr.Error("INTERNAL_ERROR", "Translation failed.", "5d37dbcb-891e-41ca-a3d6-e690c97775ac"))
 	}
 
 	return c.JSON(http.StatusOK, map[string]any{
@@ -226,7 +226,7 @@ func (h *Handler) ShowPartialBulk(c echo.Context) error {
 		NoteIDs []string `json:"noteIds"`
 	}
 	if err := c.Bind(&req); err != nil {
-		return c.JSON(http.StatusBadRequest, apiError("INVALID_PARAM", "noteIds is required.", "3d81ceae-475f-4600-b2a8-2bc116157532"))
+		return c.JSON(http.StatusBadRequest, apierr.Error("INVALID_PARAM", "noteIds is required.", "3d81ceae-475f-4600-b2a8-2bc116157532"))
 	}
 	if len(req.NoteIDs) == 0 {
 		return c.JSON(http.StatusOK, []entity.NoteEntity{})
@@ -236,8 +236,4 @@ func (h *Handler) ShowPartialBulk(c echo.Context) error {
 		return c.JSON(http.StatusOK, []entity.NoteEntity{})
 	}
 	return c.JSON(http.StatusOK, h.packMany(notes, middleware.GetUser(c)))
-}
-
-func apiError(code, message, id string) map[string]any {
-	return apierr.Error(code, message, id)
 }

--- a/internal/api/resetpassword/handler.go
+++ b/internal/api/resetpassword/handler.go
@@ -37,10 +37,6 @@ func (h *Handler) SetEmailSender(s EmailSender) { h.email = s }
 // SetServerURL sets the base URL for reset links.
 func (h *Handler) SetServerURL(u string) { h.serverURL = u }
 
-func apiError(code, message, errID string) map[string]any {
-	return apierr.Error(code, message, errID)
-}
-
 // RequestReset handles POST /api/request-reset-password.
 // ユーザーが見つからない/email不一致/未認証でも成功レスポンスを返す（情報漏洩防止）。
 func (h *Handler) RequestReset(c echo.Context) error {
@@ -49,7 +45,7 @@ func (h *Handler) RequestReset(c echo.Context) error {
 		Email    string `json:"email"`
 	}
 	if err := c.Bind(&req); err != nil || req.Username == "" || req.Email == "" {
-		return c.JSON(http.StatusBadRequest, apiError("INVALID_PARAM", "username and email are required.", "3d81ceae-475f-4600-b2a8-2bc116157532"))
+		return c.JSON(http.StatusBadRequest, apierr.Error("INVALID_PARAM", "username and email are required.", "3d81ceae-475f-4600-b2a8-2bc116157532"))
 	}
 
 	// ユーザー検索 (ローカルのみ)
@@ -93,41 +89,41 @@ func (h *Handler) Reset(c echo.Context) error {
 		Password string `json:"password"`
 	}
 	if err := c.Bind(&req); err != nil || req.Token == "" || req.Password == "" {
-		return c.JSON(http.StatusBadRequest, apiError("INVALID_PARAM", "token and password are required.", "3d81ceae-475f-4600-b2a8-2bc116157532"))
+		return c.JSON(http.StatusBadRequest, apierr.Error("INVALID_PARAM", "token and password are required.", "3d81ceae-475f-4600-b2a8-2bc116157532"))
 	}
 
 	// bcryptは72バイトまでしか受け付けない
 	if len(req.Password) > 72 {
-		return c.JSON(http.StatusBadRequest, apiError("INVALID_PARAM", "Password too long.", "3d81ceae-475f-4600-b2a8-2bc116157532"))
+		return c.JSON(http.StatusBadRequest, apierr.Error("INVALID_PARAM", "Password too long.", "3d81ceae-475f-4600-b2a8-2bc116157532"))
 	}
 
 	resetReq, err := h.resetRepo.FindByToken(req.Token)
 	if err != nil {
-		return c.JSON(http.StatusBadRequest, apiError("INVALID_PARAM", "Invalid token.", "6382759e-0a0d-4e32-893e-0e1e66cec4d5"))
+		return c.JSON(http.StatusBadRequest, apierr.Error("INVALID_PARAM", "Invalid token.", "6382759e-0a0d-4e32-893e-0e1e66cec4d5"))
 	}
 
 	// 30分の有効期限チェック (IDからタイムスタンプを算出)
 	issuedAt, err := h.idGen.ParseTime(resetReq.ID)
 	if err != nil {
-		return c.JSON(http.StatusBadRequest, apiError("INVALID_PARAM", "Invalid token.", "6382759e-0a0d-4e32-893e-0e1e66cec4d5"))
+		return c.JSON(http.StatusBadRequest, apierr.Error("INVALID_PARAM", "Invalid token.", "6382759e-0a0d-4e32-893e-0e1e66cec4d5"))
 	}
 
 	// Misskey本家: 30分経過で期限切れ
 	if time.Since(issuedAt) > 30*time.Minute {
 		_ = h.resetRepo.Delete(resetReq.ID)
-		return c.JSON(http.StatusBadRequest, apiError("INVALID_PARAM", "Token expired.", "6382759e-0a0d-4e32-893e-0e1e66cec4d5"))
+		return c.JSON(http.StatusBadRequest, apierr.Error("INVALID_PARAM", "Token expired.", "6382759e-0a0d-4e32-893e-0e1e66cec4d5"))
 	}
 
 	// bcrypt hash (cost 8、Misskey本家と同じ)
 	hashed, err := bcrypt.GenerateFromPassword([]byte(req.Password), 8)
 	if err != nil {
-		return c.JSON(http.StatusInternalServerError, apiError("INTERNAL_ERROR", "Internal error.", "5d37dbcb-891e-41ca-a3d6-e690c97775ac"))
+		return c.JSON(http.StatusInternalServerError, apierr.Error("INTERNAL_ERROR", "Internal error.", "5d37dbcb-891e-41ca-a3d6-e690c97775ac"))
 	}
 
 	// パスワード更新
 	pw := string(hashed)
 	if err := h.userRepo.UpdateProfile(resetReq.UserID, map[string]any{"password": pw}); err != nil {
-		return c.JSON(http.StatusInternalServerError, apiError("INTERNAL_ERROR", "Internal error.", "5d37dbcb-891e-41ca-a3d6-e690c97775ac"))
+		return c.JSON(http.StatusInternalServerError, apierr.Error("INTERNAL_ERROR", "Internal error.", "5d37dbcb-891e-41ca-a3d6-e690c97775ac"))
 	}
 
 	// トークン削除

--- a/internal/api/reversi/handler.go
+++ b/internal/api/reversi/handler.go
@@ -57,10 +57,6 @@ func (h *Handler) SetFederation(baseURL string, deliverer FederationDeliverer, f
 	h.userRepo = userRepo
 }
 
-func apiError(code, message, errID string) map[string]any {
-	return apierr.Error(code, message, errID)
-}
-
 func packGame(g *model.ReversiGame, idGen id.Generator) map[string]any {
 	result := map[string]any{
 		"id":                   g.ID,
@@ -179,11 +175,11 @@ func (h *Handler) ShowGame(c echo.Context) error {
 		GameID string `json:"gameId"`
 	}
 	if err := c.Bind(&req); err != nil || req.GameID == "" {
-		return c.JSON(http.StatusBadRequest, apiError("INVALID_PARAM", "gameId is required.", "ed1d7571-a3ac-4370-899c-0dbe5e230cc8"))
+		return c.JSON(http.StatusBadRequest, apierr.Error("INVALID_PARAM", "gameId is required.", "ed1d7571-a3ac-4370-899c-0dbe5e230cc8"))
 	}
 	game, err := h.repo.FindByID(req.GameID)
 	if err != nil {
-		return c.JSON(http.StatusNotFound, apiError("NO_SUCH_GAME", "No such game.", "d8a95858-973b-4f3b-8592-fcf2eb4dd044"))
+		return c.JSON(http.StatusNotFound, apierr.Error("NO_SUCH_GAME", "No such game.", "d8a95858-973b-4f3b-8592-fcf2eb4dd044"))
 	}
 	return c.JSON(http.StatusOK, packGame(game, h.idGen))
 }
@@ -204,7 +200,7 @@ func (h *Handler) Match(c echo.Context) error {
 	if strings.HasPrefix(req.UserID, "@") && h.userRepo != nil {
 		resolved, err := h.resolveAcct(req.UserID)
 		if err != nil {
-			return c.JSON(http.StatusNotFound, apiError("NO_SUCH_USER", "No such user.", "6cc579cc-885d-43d8-95c2-b8c7fc963280"))
+			return c.JSON(http.StatusNotFound, apierr.Error("NO_SUCH_USER", "No such user.", "6cc579cc-885d-43d8-95c2-b8c7fc963280"))
 		}
 		req.UserID = resolved
 	}
@@ -225,7 +221,7 @@ func (h *Handler) Match(c echo.Context) error {
 	}
 
 	if err := h.repo.Create(game); err != nil {
-		return c.JSON(http.StatusInternalServerError, apiError("INTERNAL_ERROR", "Internal error.", "5d37dbcb-891e-41ca-a3d6-e690c97775ac"))
+		return c.JSON(http.StatusInternalServerError, apierr.Error("INTERNAL_ERROR", "Internal error.", "5d37dbcb-891e-41ca-a3d6-e690c97775ac"))
 	}
 
 	// リモートユーザーの場合、federation session を Redis に保存 + Invite 送信。
@@ -269,7 +265,7 @@ func (h *Handler) Surrender(c echo.Context) error {
 		GameID string `json:"gameId"`
 	}
 	if err := c.Bind(&req); err != nil || req.GameID == "" {
-		return c.JSON(http.StatusBadRequest, apiError("INVALID_PARAM", "gameId is required.", "ed1d7571-a3ac-4370-899c-0dbe5e230cc8"))
+		return c.JSON(http.StatusBadRequest, apierr.Error("INVALID_PARAM", "gameId is required.", "ed1d7571-a3ac-4370-899c-0dbe5e230cc8"))
 	}
 
 	// federation Leave を送るために winner (= 相手) を先に引いておく。
@@ -277,10 +273,10 @@ func (h *Handler) Surrender(c echo.Context) error {
 	// lookup は handler のタイミングで必要なので preload する。
 	game, err := h.repo.FindByID(req.GameID)
 	if err != nil {
-		return c.JSON(http.StatusNotFound, apiError("NO_SUCH_GAME", "No such game.", "d8a95858-973b-4f3b-8592-fcf2eb4dd044"))
+		return c.JSON(http.StatusNotFound, apierr.Error("NO_SUCH_GAME", "No such game.", "d8a95858-973b-4f3b-8592-fcf2eb4dd044"))
 	}
 	if game.User1ID != user.ID && game.User2ID != user.ID {
-		return c.JSON(http.StatusForbidden, apiError("ACCESS_DENIED", "Access denied.", "00000000-0000-0000-0000-000000000000"))
+		return c.JSON(http.StatusForbidden, apierr.Error("ACCESS_DENIED", "Access denied.", "00000000-0000-0000-0000-000000000000"))
 	}
 	var winnerID string
 	if game.User1ID == user.ID {
@@ -326,15 +322,15 @@ func (h *Handler) Surrender(c echo.Context) error {
 func surrenderErrorResponse(c echo.Context, err error) error {
 	switch {
 	case errors.Is(err, corereversi.ErrGameNotFound):
-		return c.JSON(http.StatusNotFound, apiError("NO_SUCH_GAME", "No such game.", "d8a95858-973b-4f3b-8592-fcf2eb4dd044"))
+		return c.JSON(http.StatusNotFound, apierr.Error("NO_SUCH_GAME", "No such game.", "d8a95858-973b-4f3b-8592-fcf2eb4dd044"))
 	case errors.Is(err, corereversi.ErrNotPlayer):
-		return c.JSON(http.StatusForbidden, apiError("ACCESS_DENIED", "Access denied.", "00000000-0000-0000-0000-000000000000"))
+		return c.JSON(http.StatusForbidden, apierr.Error("ACCESS_DENIED", "Access denied.", "00000000-0000-0000-0000-000000000000"))
 	case errors.Is(err, corereversi.ErrAlreadyEnded):
-		return c.JSON(http.StatusBadRequest, apiError("ALREADY_ENDED", "Game has already ended.", "2a3a7f72-bc06-4f4e-9f7c-b7f8d4f6a09e"))
+		return c.JSON(http.StatusBadRequest, apierr.Error("ALREADY_ENDED", "Game has already ended.", "2a3a7f72-bc06-4f4e-9f7c-b7f8d4f6a09e"))
 	case errors.Is(err, corereversi.ErrNotStarted):
-		return c.JSON(http.StatusBadRequest, apiError("NOT_STARTED", "Game has not started yet.", "ac4bb45f-ea81-44d3-a5b3-fe5f30be2c8d"))
+		return c.JSON(http.StatusBadRequest, apierr.Error("NOT_STARTED", "Game has not started yet.", "ac4bb45f-ea81-44d3-a5b3-fe5f30be2c8d"))
 	}
-	return c.JSON(http.StatusInternalServerError, apiError("INTERNAL_ERROR", "Internal error.", "5d37dbcb-891e-41ca-a3d6-e690c97775ac"))
+	return c.JSON(http.StatusInternalServerError, apierr.Error("INTERNAL_ERROR", "Internal error.", "5d37dbcb-891e-41ca-a3d6-e690c97775ac"))
 }
 
 // Verify handles POST /api/reversi/verify — verify game integrity.
@@ -343,11 +339,11 @@ func (h *Handler) Verify(c echo.Context) error {
 		GameID string `json:"gameId"`
 	}
 	if err := c.Bind(&req); err != nil || req.GameID == "" {
-		return c.JSON(http.StatusBadRequest, apiError("INVALID_PARAM", "gameId is required.", "ed1d7571-a3ac-4370-899c-0dbe5e230cc8"))
+		return c.JSON(http.StatusBadRequest, apierr.Error("INVALID_PARAM", "gameId is required.", "ed1d7571-a3ac-4370-899c-0dbe5e230cc8"))
 	}
 	game, err := h.repo.FindByID(req.GameID)
 	if err != nil {
-		return c.JSON(http.StatusNotFound, apiError("NO_SUCH_GAME", "No such game.", "d8a95858-973b-4f3b-8592-fcf2eb4dd044"))
+		return c.JSON(http.StatusNotFound, apierr.Error("NO_SUCH_GAME", "No such game.", "d8a95858-973b-4f3b-8592-fcf2eb4dd044"))
 	}
 
 	// ゲームログを再生して検証

--- a/internal/api/roles/handler.go
+++ b/internal/api/roles/handler.go
@@ -42,7 +42,7 @@ func (h *Handler) SetIDGen(g id.Generator) {
 func (h *Handler) List(c echo.Context) error {
 	roles, err := h.roleService.List()
 	if err != nil {
-		return c.JSON(http.StatusInternalServerError, errResp("INTERNAL_ERROR", "Internal error.", "5d37dbcb-891e-41ca-a3d6-e690c97775ac"))
+		return c.JSON(http.StatusInternalServerError, apierr.Error("INTERNAL_ERROR", "Internal error.", "5d37dbcb-891e-41ca-a3d6-e690c97775ac"))
 	}
 	var result []any
 	for _, r := range roles {
@@ -62,11 +62,11 @@ func (h *Handler) Show(c echo.Context) error {
 		RoleID string `json:"roleId"`
 	}
 	if err := c.Bind(&req); err != nil || req.RoleID == "" {
-		return c.JSON(http.StatusBadRequest, errResp("INVALID_PARAM", "roleId is required.", "3d81ceae-475f-4600-b2a8-2bc116157532"))
+		return c.JSON(http.StatusBadRequest, apierr.Error("INVALID_PARAM", "roleId is required.", "3d81ceae-475f-4600-b2a8-2bc116157532"))
 	}
 	r, err := h.roleService.Show(req.RoleID)
 	if err != nil || !r.IsPublic {
-		return c.JSON(http.StatusNotFound, errResp("NO_SUCH_ROLE", "No such role.", "07dc7d34-c0d8-458b-9c04-4b18399b1f46"))
+		return c.JSON(http.StatusNotFound, apierr.Error("NO_SUCH_ROLE", "No such role.", "07dc7d34-c0d8-458b-9c04-4b18399b1f46"))
 	}
 	return c.JSON(http.StatusOK, packRole(r))
 }
@@ -77,10 +77,10 @@ func (h *Handler) Users(c echo.Context) error {
 		RoleID string `json:"roleId"`
 	}
 	if err := c.Bind(&req); err != nil || req.RoleID == "" {
-		return c.JSON(http.StatusBadRequest, errResp("INVALID_PARAM", "roleId is required.", "3d81ceae-475f-4600-b2a8-2bc116157532"))
+		return c.JSON(http.StatusBadRequest, apierr.Error("INVALID_PARAM", "roleId is required.", "3d81ceae-475f-4600-b2a8-2bc116157532"))
 	}
 	if _, err := h.roleService.Show(req.RoleID); err != nil {
-		return c.JSON(http.StatusNotFound, errResp("NO_SUCH_ROLE", "No such role.", "07dc7d34-c0d8-458b-9c04-4b18399b1f46"))
+		return c.JSON(http.StatusNotFound, apierr.Error("NO_SUCH_ROLE", "No such role.", "07dc7d34-c0d8-458b-9c04-4b18399b1f46"))
 	}
 	return c.JSON(http.StatusOK, []any{})
 }
@@ -94,15 +94,15 @@ func (h *Handler) Notes(c echo.Context) error {
 		UntilID string `json:"untilId"`
 	}
 	if err := c.Bind(&req); err != nil || req.RoleID == "" {
-		return c.JSON(http.StatusBadRequest, errResp("INVALID_PARAM", "roleId is required.", "3d81ceae-475f-4600-b2a8-2bc116157532"))
+		return c.JSON(http.StatusBadRequest, apierr.Error("INVALID_PARAM", "roleId is required.", "3d81ceae-475f-4600-b2a8-2bc116157532"))
 	}
 
 	r, err := h.roleService.Show(req.RoleID)
 	if err != nil {
-		return c.JSON(http.StatusNotFound, errResp("NO_SUCH_ROLE", "No such role.", "07dc7d34-c0d8-458b-9c04-4b18399b1f46"))
+		return c.JSON(http.StatusNotFound, apierr.Error("NO_SUCH_ROLE", "No such role.", "07dc7d34-c0d8-458b-9c04-4b18399b1f46"))
 	}
 	if !r.IsPublic {
-		return c.JSON(http.StatusNotFound, errResp("NO_SUCH_ROLE", "No such role.", "07dc7d34-c0d8-458b-9c04-4b18399b1f46"))
+		return c.JSON(http.StatusNotFound, apierr.Error("NO_SUCH_ROLE", "No such role.", "07dc7d34-c0d8-458b-9c04-4b18399b1f46"))
 	}
 
 	if h.notesQuery == nil {
@@ -119,7 +119,7 @@ func (h *Handler) Notes(c echo.Context) error {
 
 	notes, err := h.notesQuery.ListByRole(req.RoleID, limit, req.SinceID, req.UntilID)
 	if err != nil {
-		return c.JSON(http.StatusInternalServerError, errResp("INTERNAL_ERROR", "Internal error.", "5d37dbcb-891e-41ca-a3d6-e690c97775ac"))
+		return c.JSON(http.StatusInternalServerError, apierr.Error("INTERNAL_ERROR", "Internal error.", "5d37dbcb-891e-41ca-a3d6-e690c97775ac"))
 	}
 
 	out := make([]any, 0, len(notes))
@@ -143,8 +143,4 @@ func packRole(r *model.Role) map[string]any {
 		"asBadge":         r.AsBadge,
 		"displayOrder":    r.DisplayOrder,
 	}
-}
-
-func errResp(code, message, id string) map[string]any {
-	return apierr.Error(code, message, id)
 }

--- a/internal/api/signup/handler.go
+++ b/internal/api/signup/handler.go
@@ -69,17 +69,17 @@ type signupRequest struct {
 func (h *Handler) Signup(c echo.Context) error {
 	var req signupRequest
 	if err := c.Bind(&req); err != nil || req.Username == "" || req.Password == "" {
-		return c.JSON(http.StatusBadRequest, errResp("INVALID_PARAM", "Invalid parameters.", "3d81ceae-475f-4600-b2a8-2bc116157532"))
+		return c.JSON(http.StatusBadRequest, apierr.Error("INVALID_PARAM", "Invalid parameters.", "3d81ceae-475f-4600-b2a8-2bc116157532"))
 	}
 
 	meta, err := h.metaRepo.Fetch()
 	if err != nil {
-		return c.JSON(http.StatusInternalServerError, errResp("INTERNAL_ERROR", "Internal error.", "5d37dbcb-891e-41ca-a3d6-e690c97775ac"))
+		return c.JSON(http.StatusInternalServerError, apierr.Error("INTERNAL_ERROR", "Internal error.", "5d37dbcb-891e-41ca-a3d6-e690c97775ac"))
 	}
 
 	// メール認証フローは未実装 (テストモードではスキップ)
 	if !h.testMode && meta.EmailRequiredForSignup {
-		return c.JSON(http.StatusBadRequest, errResp("INVALID_PARAM", "Email-required signup is not yet supported.", "3d81ceae-475f-4600-b2a8-2bc116157532"))
+		return c.JSON(http.StatusBadRequest, apierr.Error("INVALID_PARAM", "Email-required signup is not yet supported.", "3d81ceae-475f-4600-b2a8-2bc116157532"))
 	}
 
 	// 登録無効時はinvitation code必須 (テストモードではバイパス — 本家 TS 互換)
@@ -87,7 +87,7 @@ func (h *Handler) Signup(c echo.Context) error {
 	if !h.testMode && meta.DisableRegistration {
 		t, vErr := h.validateInvitationCode(req.InvitationCode)
 		if vErr != nil {
-			return c.JSON(http.StatusBadRequest, errResp("INVITATION_CODE_INVALID", "Invalid invitation code.", "11e71a03-43c4-4a99-92cf-bb7e2c581998"))
+			return c.JSON(http.StatusBadRequest, apierr.Error("INVITATION_CODE_INVALID", "Invalid invitation code.", "11e71a03-43c4-4a99-92cf-bb7e2c581998"))
 		}
 		ticket = t
 	}
@@ -102,22 +102,22 @@ func (h *Handler) Signup(c echo.Context) error {
 			Testcaptcha: req.TestcaptchaResponse,
 		}
 		if err := h.captchaSvc.Verify(c.Request().Context(), tokens); err != nil {
-			return c.JSON(http.StatusBadRequest, errResp("CAPTCHA_FAILED", "Captcha verification failed.", "bdc32ef5-b0f4-40c0-b767-673b2e3e1f5a"))
+			return c.JSON(http.StatusBadRequest, apierr.Error("CAPTCHA_FAILED", "Captcha verification failed.", "bdc32ef5-b0f4-40c0-b767-673b2e3e1f5a"))
 		}
 	}
 
 	result, err := h.signupService.Signup(req.Username, req.Password, false)
 	if err != nil {
 		if err == coresignup.ErrUsernameAlreadyExists {
-			return c.JSON(http.StatusConflict, errResp("USERNAME_ALREADY_EXISTS", "Username already exists.", "a504947-b888-4a99-9f62-8c4a0f3a3dab"))
+			return c.JSON(http.StatusConflict, apierr.Error("USERNAME_ALREADY_EXISTS", "Username already exists.", "a504947-b888-4a99-9f62-8c4a0f3a3dab"))
 		}
 		if err == coresignup.ErrInvalidUsername {
-			return c.JSON(http.StatusBadRequest, errResp("INVALID_PARAM", "Invalid username.", "3d81ceae-475f-4600-b2a8-2bc116157532"))
+			return c.JSON(http.StatusBadRequest, apierr.Error("INVALID_PARAM", "Invalid username.", "3d81ceae-475f-4600-b2a8-2bc116157532"))
 		}
 		if err == coresignup.ErrUsernameReserved {
-			return c.JSON(http.StatusBadRequest, errResp("USED_USERNAME", "That username is reserved.", "4b54bee6-2c25-42c3-a10f-7d0d1fbd91f9"))
+			return c.JSON(http.StatusBadRequest, apierr.Error("USED_USERNAME", "That username is reserved.", "4b54bee6-2c25-42c3-a10f-7d0d1fbd91f9"))
 		}
-		return c.JSON(http.StatusInternalServerError, errResp("INTERNAL_ERROR", "Internal error.", "5d37dbcb-891e-41ca-a3d6-e690c97775ac"))
+		return c.JSON(http.StatusInternalServerError, apierr.Error("INTERNAL_ERROR", "Internal error.", "5d37dbcb-891e-41ca-a3d6-e690c97775ac"))
 	}
 
 	// invitation code使用済みにする
@@ -224,7 +224,3 @@ func packSignupResponse(u *model.User, token string, idGen id.Generator) map[str
 
 // defaultPolicies returns the Misskey default policies for a new user.
 var errInvalidCode = errors.New("invalid invitation code")
-
-func errResp(code, message, id string) map[string]any {
-	return apierr.Error(code, message, id)
-}

--- a/internal/api/sw/handler.go
+++ b/internal/api/sw/handler.go
@@ -24,10 +24,6 @@ func NewHandler(repo repository.SwSubscriptionRepository, metaRepo repository.Me
 	return &Handler{repo: repo, metaRepo: metaRepo, idGen: idGen}
 }
 
-func apiError(code, message, errID string) map[string]any {
-	return apierr.Error(code, message, errID)
-}
-
 // Register handles POST /api/sw/register.
 func (h *Handler) Register(c echo.Context) error {
 	user := middleware.GetUser(c)
@@ -38,7 +34,7 @@ func (h *Handler) Register(c echo.Context) error {
 		SendReadMessage bool   `json:"sendReadMessage"`
 	}
 	if err := c.Bind(&req); err != nil || req.Endpoint == "" || req.Auth == "" || req.PublicKey == "" {
-		return c.JSON(http.StatusBadRequest, apiError("INVALID_PARAM", "endpoint, auth, and publickey are required.", "ed1d7571-a3ac-4370-899c-0dbe5e230cc8"))
+		return c.JSON(http.StatusBadRequest, apierr.Error("INVALID_PARAM", "endpoint, auth, and publickey are required.", "ed1d7571-a3ac-4370-899c-0dbe5e230cc8"))
 	}
 
 	var swPublicKey *string
@@ -68,7 +64,7 @@ func (h *Handler) Register(c echo.Context) error {
 		SendReadMessage: req.SendReadMessage,
 	}
 	if err := h.repo.Create(sub); err != nil {
-		return c.JSON(http.StatusInternalServerError, apiError("INTERNAL_ERROR", "Internal error.", "5d37dbcb-891e-41ca-a3d6-e690c97775ac"))
+		return c.JSON(http.StatusInternalServerError, apierr.Error("INTERNAL_ERROR", "Internal error.", "5d37dbcb-891e-41ca-a3d6-e690c97775ac"))
 	}
 
 	return c.JSON(http.StatusOK, map[string]any{
@@ -87,7 +83,7 @@ func (h *Handler) ShowRegistration(c echo.Context) error {
 		Endpoint string `json:"endpoint"`
 	}
 	if err := c.Bind(&req); err != nil || req.Endpoint == "" {
-		return c.JSON(http.StatusBadRequest, apiError("INVALID_PARAM", "endpoint is required.", "ed1d7571-a3ac-4370-899c-0dbe5e230cc8"))
+		return c.JSON(http.StatusBadRequest, apierr.Error("INVALID_PARAM", "endpoint is required.", "ed1d7571-a3ac-4370-899c-0dbe5e230cc8"))
 	}
 
 	sub, err := h.repo.FindByUserAndEndpoint(user.ID, req.Endpoint)
@@ -110,19 +106,19 @@ func (h *Handler) UpdateRegistration(c echo.Context) error {
 		SendReadMessage *bool  `json:"sendReadMessage"`
 	}
 	if err := c.Bind(&req); err != nil || req.Endpoint == "" {
-		return c.JSON(http.StatusBadRequest, apiError("INVALID_PARAM", "endpoint is required.", "ed1d7571-a3ac-4370-899c-0dbe5e230cc8"))
+		return c.JSON(http.StatusBadRequest, apierr.Error("INVALID_PARAM", "endpoint is required.", "ed1d7571-a3ac-4370-899c-0dbe5e230cc8"))
 	}
 
 	sub, err := h.repo.FindByUserAndEndpoint(user.ID, req.Endpoint)
 	if err != nil {
-		return c.JSON(http.StatusNotFound, apiError("NO_SUCH_REGISTRATION", "No such registration.", "b09d8066-8064-5613-efb6-0e963b21d012"))
+		return c.JSON(http.StatusNotFound, apierr.Error("NO_SUCH_REGISTRATION", "No such registration.", "b09d8066-8064-5613-efb6-0e963b21d012"))
 	}
 
 	if req.SendReadMessage != nil {
 		sub.SendReadMessage = *req.SendReadMessage
 	}
 	if err := h.repo.Update(sub); err != nil {
-		return c.JSON(http.StatusInternalServerError, apiError("INTERNAL_ERROR", "Internal error.", "5d37dbcb-891e-41ca-a3d6-e690c97775ac"))
+		return c.JSON(http.StatusInternalServerError, apierr.Error("INTERNAL_ERROR", "Internal error.", "5d37dbcb-891e-41ca-a3d6-e690c97775ac"))
 	}
 
 	return c.JSON(http.StatusOK, map[string]any{
@@ -139,7 +135,7 @@ func (h *Handler) Unregister(c echo.Context) error {
 		Endpoint string `json:"endpoint"`
 	}
 	if err := c.Bind(&req); err != nil || req.Endpoint == "" {
-		return c.JSON(http.StatusBadRequest, apiError("INVALID_PARAM", "endpoint is required.", "ed1d7571-a3ac-4370-899c-0dbe5e230cc8"))
+		return c.JSON(http.StatusBadRequest, apierr.Error("INVALID_PARAM", "endpoint is required.", "ed1d7571-a3ac-4370-899c-0dbe5e230cc8"))
 	}
 
 	if user != nil {

--- a/internal/api/userlists/handler.go
+++ b/internal/api/userlists/handler.go
@@ -28,7 +28,7 @@ func (h *Handler) List(c echo.Context) error {
 	user := middleware.GetUser(c)
 	lists, err := h.repo.ListByUser(user.ID)
 	if err != nil {
-		return c.JSON(http.StatusInternalServerError, errResp("INTERNAL_ERROR", "Internal error.", "5d37dbcb-891e-41ca-a3d6-e690c97775ac"))
+		return c.JSON(http.StatusInternalServerError, apierr.Error("INTERNAL_ERROR", "Internal error.", "5d37dbcb-891e-41ca-a3d6-e690c97775ac"))
 	}
 	return c.JSON(http.StatusOK, lists)
 }
@@ -40,7 +40,7 @@ func (h *Handler) Create(c echo.Context) error {
 		Name string `json:"name"`
 	}
 	if err := c.Bind(&req); err != nil || req.Name == "" {
-		return c.JSON(http.StatusBadRequest, errResp("INVALID_PARAM", "name is required.", "3d81ceae-475f-4600-b2a8-2bc116157532"))
+		return c.JSON(http.StatusBadRequest, apierr.Error("INVALID_PARAM", "name is required.", "3d81ceae-475f-4600-b2a8-2bc116157532"))
 	}
 	list := &model.UserList{
 		ID:     h.idGen.Generate(time.Now()),
@@ -48,7 +48,7 @@ func (h *Handler) Create(c echo.Context) error {
 		Name:   req.Name,
 	}
 	if err := h.repo.Create(list); err != nil {
-		return c.JSON(http.StatusInternalServerError, errResp("INTERNAL_ERROR", "Internal error.", "5d37dbcb-891e-41ca-a3d6-e690c97775ac"))
+		return c.JSON(http.StatusInternalServerError, apierr.Error("INTERNAL_ERROR", "Internal error.", "5d37dbcb-891e-41ca-a3d6-e690c97775ac"))
 	}
 	return c.JSON(http.StatusOK, list)
 }
@@ -59,11 +59,11 @@ func (h *Handler) Show(c echo.Context) error {
 		ListID string `json:"listId"`
 	}
 	if err := c.Bind(&req); err != nil || req.ListID == "" {
-		return c.JSON(http.StatusBadRequest, errResp("INVALID_PARAM", "listId is required.", "3d81ceae-475f-4600-b2a8-2bc116157532"))
+		return c.JSON(http.StatusBadRequest, apierr.Error("INVALID_PARAM", "listId is required.", "3d81ceae-475f-4600-b2a8-2bc116157532"))
 	}
 	list, err := h.repo.FindByID(req.ListID)
 	if err != nil {
-		return c.JSON(http.StatusNotFound, errResp("NO_SUCH_LIST", "No such list.", "7bc05c21-1d7a-41ae-88f1-66820f4dc686"))
+		return c.JSON(http.StatusNotFound, apierr.Error("NO_SUCH_LIST", "No such list.", "7bc05c21-1d7a-41ae-88f1-66820f4dc686"))
 	}
 	return c.JSON(http.StatusOK, list)
 }
@@ -75,10 +75,10 @@ func (h *Handler) Push(c echo.Context) error {
 		UserID string `json:"userId"`
 	}
 	if err := c.Bind(&req); err != nil || req.ListID == "" || req.UserID == "" {
-		return c.JSON(http.StatusBadRequest, errResp("INVALID_PARAM", "listId and userId are required.", "3d81ceae-475f-4600-b2a8-2bc116157532"))
+		return c.JSON(http.StatusBadRequest, apierr.Error("INVALID_PARAM", "listId and userId are required.", "3d81ceae-475f-4600-b2a8-2bc116157532"))
 	}
 	if _, err := h.repo.FindByID(req.ListID); err != nil {
-		return c.JSON(http.StatusNotFound, errResp("NO_SUCH_LIST", "No such list.", "7bc05c21-1d7a-41ae-88f1-66820f4dc686"))
+		return c.JSON(http.StatusNotFound, apierr.Error("NO_SUCH_LIST", "No such list.", "7bc05c21-1d7a-41ae-88f1-66820f4dc686"))
 	}
 	m := &model.UserListMembership{
 		ID:         h.idGen.Generate(time.Now()),
@@ -86,7 +86,7 @@ func (h *Handler) Push(c echo.Context) error {
 		UserID:     req.UserID,
 	}
 	if err := h.repo.AddMember(m); err != nil {
-		return c.JSON(http.StatusInternalServerError, errResp("INTERNAL_ERROR", "Internal error.", "5d37dbcb-891e-41ca-a3d6-e690c97775ac"))
+		return c.JSON(http.StatusInternalServerError, apierr.Error("INTERNAL_ERROR", "Internal error.", "5d37dbcb-891e-41ca-a3d6-e690c97775ac"))
 	}
 	return c.NoContent(http.StatusNoContent)
 }
@@ -98,10 +98,10 @@ func (h *Handler) Pull(c echo.Context) error {
 		UserID string `json:"userId"`
 	}
 	if err := c.Bind(&req); err != nil || req.ListID == "" || req.UserID == "" {
-		return c.JSON(http.StatusBadRequest, errResp("INVALID_PARAM", "listId and userId are required.", "3d81ceae-475f-4600-b2a8-2bc116157532"))
+		return c.JSON(http.StatusBadRequest, apierr.Error("INVALID_PARAM", "listId and userId are required.", "3d81ceae-475f-4600-b2a8-2bc116157532"))
 	}
 	if err := h.repo.RemoveMember(req.ListID, req.UserID); err != nil {
-		return c.JSON(http.StatusInternalServerError, errResp("INTERNAL_ERROR", "Internal error.", "5d37dbcb-891e-41ca-a3d6-e690c97775ac"))
+		return c.JSON(http.StatusInternalServerError, apierr.Error("INTERNAL_ERROR", "Internal error.", "5d37dbcb-891e-41ca-a3d6-e690c97775ac"))
 	}
 	return c.NoContent(http.StatusNoContent)
 }
@@ -112,14 +112,10 @@ func (h *Handler) Delete(c echo.Context) error {
 		ListID string `json:"listId"`
 	}
 	if err := c.Bind(&req); err != nil || req.ListID == "" {
-		return c.JSON(http.StatusBadRequest, errResp("INVALID_PARAM", "listId is required.", "3d81ceae-475f-4600-b2a8-2bc116157532"))
+		return c.JSON(http.StatusBadRequest, apierr.Error("INVALID_PARAM", "listId is required.", "3d81ceae-475f-4600-b2a8-2bc116157532"))
 	}
 	if err := h.repo.Delete(req.ListID); err != nil {
-		return c.JSON(http.StatusInternalServerError, errResp("INTERNAL_ERROR", "Internal error.", "5d37dbcb-891e-41ca-a3d6-e690c97775ac"))
+		return c.JSON(http.StatusInternalServerError, apierr.Error("INTERNAL_ERROR", "Internal error.", "5d37dbcb-891e-41ca-a3d6-e690c97775ac"))
 	}
 	return c.NoContent(http.StatusNoContent)
-}
-
-func errResp(code, message, id string) map[string]any {
-	return apierr.Error(code, message, id)
 }

--- a/internal/api/users/handler_extra.go
+++ b/internal/api/users/handler_extra.go
@@ -25,7 +25,7 @@ func (h *Handler) Relation(c echo.Context) error {
 		UserID string `json:"userId"`
 	}
 	if err := c.Bind(&req); err != nil || req.UserID == "" {
-		return c.JSON(http.StatusBadRequest, apiError("INVALID_PARAM", "userId is required.", "3d81ceae-475f-4600-b2a8-2bc116157532"))
+		return c.JSON(http.StatusBadRequest, apierr.Error("INVALID_PARAM", "userId is required.", "3d81ceae-475f-4600-b2a8-2bc116157532"))
 	}
 
 	return c.JSON(http.StatusOK, map[string]any{
@@ -49,7 +49,7 @@ func (h *Handler) ReportAbuse(c echo.Context) error {
 		Comment string `json:"comment"`
 	}
 	if err := c.Bind(&req); err != nil || req.UserID == "" || req.Comment == "" {
-		return c.JSON(http.StatusBadRequest, apiError("INVALID_PARAM", "userId and comment are required.", "3d81ceae-475f-4600-b2a8-2bc116157532"))
+		return c.JSON(http.StatusBadRequest, apierr.Error("INVALID_PARAM", "userId and comment are required.", "3d81ceae-475f-4600-b2a8-2bc116157532"))
 	}
 	if h.abuseRepo == nil {
 		return c.NoContent(http.StatusNoContent)
@@ -61,7 +61,7 @@ func (h *Handler) ReportAbuse(c echo.Context) error {
 		Comment:      req.Comment,
 	}
 	if err := h.abuseRepo.Create(report); err != nil {
-		return c.JSON(http.StatusInternalServerError, apiError("INTERNAL_ERROR", "Internal error.", "5d37dbcb-891e-41ca-a3d6-e690c97775ac"))
+		return c.JSON(http.StatusInternalServerError, apierr.Error("INTERNAL_ERROR", "Internal error.", "5d37dbcb-891e-41ca-a3d6-e690c97775ac"))
 	}
 	return c.NoContent(http.StatusNoContent)
 }
@@ -74,7 +74,7 @@ func (h *Handler) Reactions(c echo.Context) error {
 		Limit  int    `json:"limit"`
 	}
 	if err := c.Bind(&req); err != nil || req.UserID == "" {
-		return c.JSON(http.StatusBadRequest, apiError("INVALID_PARAM", "userId is required.", "3d81ceae-475f-4600-b2a8-2bc116157532"))
+		return c.JSON(http.StatusBadRequest, apierr.Error("INVALID_PARAM", "userId is required.", "3d81ceae-475f-4600-b2a8-2bc116157532"))
 	}
 	// 簡易版: 空配列を返す (リアクション履歴クエリは重いため後続で最適化)
 	return c.JSON(http.StatusOK, []any{})
@@ -87,14 +87,14 @@ func (h *Handler) FeaturedNotes(c echo.Context) error {
 		Limit  int    `json:"limit"`
 	}
 	if err := c.Bind(&req); err != nil || req.UserID == "" {
-		return c.JSON(http.StatusBadRequest, apiError("INVALID_PARAM", "userId is required.", "3d81ceae-475f-4600-b2a8-2bc116157532"))
+		return c.JSON(http.StatusBadRequest, apierr.Error("INVALID_PARAM", "userId is required.", "3d81ceae-475f-4600-b2a8-2bc116157532"))
 	}
 	if req.Limit <= 0 {
 		req.Limit = 10
 	}
 	notes, err := h.noteRepo.ListByUserID(req.UserID, "", "", req.Limit)
 	if err != nil {
-		return c.JSON(http.StatusInternalServerError, apiError("INTERNAL_ERROR", "Internal error.", "5d37dbcb-891e-41ca-a3d6-e690c97775ac"))
+		return c.JSON(http.StatusInternalServerError, apierr.Error("INTERNAL_ERROR", "Internal error.", "5d37dbcb-891e-41ca-a3d6-e690c97775ac"))
 	}
 	result := make([]entity.NoteEntity, 0, len(notes))
 	for _, n := range notes {
@@ -111,14 +111,14 @@ func (h *Handler) SearchByUsernameAndHost(c echo.Context) error {
 		Limit    int     `json:"limit"`
 	}
 	if err := c.Bind(&req); err != nil || req.Username == "" {
-		return c.JSON(http.StatusBadRequest, apiError("INVALID_PARAM", "username is required.", "3d81ceae-475f-4600-b2a8-2bc116157532"))
+		return c.JSON(http.StatusBadRequest, apierr.Error("INVALID_PARAM", "username is required.", "3d81ceae-475f-4600-b2a8-2bc116157532"))
 	}
 	if req.Limit <= 0 {
 		req.Limit = 10
 	}
 	users, err := h.userService.Search(req.Username, req.Limit, 0)
 	if err != nil {
-		return c.JSON(http.StatusInternalServerError, apiError("INTERNAL_ERROR", "Internal error.", "5d37dbcb-891e-41ca-a3d6-e690c97775ac"))
+		return c.JSON(http.StatusInternalServerError, apierr.Error("INTERNAL_ERROR", "Internal error.", "5d37dbcb-891e-41ca-a3d6-e690c97775ac"))
 	}
 	result := make([]entity.UserLite, 0, len(users))
 	for _, u := range users {
@@ -136,7 +136,7 @@ func (h *Handler) UpdateMemo(c echo.Context) error {
 		Memo   *string `json:"memo"`
 	}
 	if err := c.Bind(&req); err != nil || req.UserID == "" {
-		return c.JSON(http.StatusBadRequest, apiError("INVALID_PARAM", "userId is required.", "3d81ceae-475f-4600-b2a8-2bc116157532"))
+		return c.JSON(http.StatusBadRequest, apierr.Error("INVALID_PARAM", "userId is required.", "3d81ceae-475f-4600-b2a8-2bc116157532"))
 	}
 
 	if h.memoRepo == nil {
@@ -153,12 +153,8 @@ func (h *Handler) UpdateMemo(c echo.Context) error {
 			Memo:         *req.Memo,
 		}
 		if err := h.memoRepo.CreateOrUpdate(memo); err != nil {
-			return c.JSON(http.StatusInternalServerError, apiError("INTERNAL_ERROR", "Internal error.", "5d37dbcb-891e-41ca-a3d6-e690c97775ac"))
+			return c.JSON(http.StatusInternalServerError, apierr.Error("INTERNAL_ERROR", "Internal error.", "5d37dbcb-891e-41ca-a3d6-e690c97775ac"))
 		}
 	}
 	return c.NoContent(http.StatusNoContent)
-}
-
-func apiError(code, message, id string) map[string]any {
-	return apierr.Error(code, message, id)
 }

--- a/internal/api/webhooks/handler.go
+++ b/internal/api/webhooks/handler.go
@@ -37,10 +37,6 @@ func (h *Handler) SetDispatcher(d TestDispatcher) {
 	h.dispatcher = d
 }
 
-func apiError(code, message, errID string) map[string]any {
-	return apierr.Error(code, message, errID)
-}
-
 func packWebhook(w *model.Webhook) map[string]any {
 	return map[string]any{
 		"id":           w.ID,
@@ -65,7 +61,7 @@ func (h *Handler) Create(c echo.Context) error {
 		On     []string `json:"on"`
 	}
 	if err := c.Bind(&req); err != nil || req.Name == "" || req.URL == "" {
-		return c.JSON(http.StatusBadRequest, apiError("INVALID_PARAM", "name and url are required.", "ed1d7571-a3ac-4370-899c-0dbe5e230cc8"))
+		return c.JSON(http.StatusBadRequest, apierr.Error("INVALID_PARAM", "name and url are required.", "ed1d7571-a3ac-4370-899c-0dbe5e230cc8"))
 	}
 
 	webhook := &model.Webhook{
@@ -78,7 +74,7 @@ func (h *Handler) Create(c echo.Context) error {
 		Active: true,
 	}
 	if err := h.repo.Create(webhook); err != nil {
-		return c.JSON(http.StatusInternalServerError, apiError("INTERNAL_ERROR", "Internal error.", "5d37dbcb-891e-41ca-a3d6-e690c97775ac"))
+		return c.JSON(http.StatusInternalServerError, apierr.Error("INTERNAL_ERROR", "Internal error.", "5d37dbcb-891e-41ca-a3d6-e690c97775ac"))
 	}
 
 	return c.JSON(http.StatusOK, packWebhook(webhook))
@@ -89,7 +85,7 @@ func (h *Handler) List(c echo.Context) error {
 	user := middleware.GetUser(c)
 	webhooks, err := h.repo.ListByUserID(user.ID)
 	if err != nil {
-		return c.JSON(http.StatusInternalServerError, apiError("INTERNAL_ERROR", "Internal error.", "5d37dbcb-891e-41ca-a3d6-e690c97775ac"))
+		return c.JSON(http.StatusInternalServerError, apierr.Error("INTERNAL_ERROR", "Internal error.", "5d37dbcb-891e-41ca-a3d6-e690c97775ac"))
 	}
 	result := make([]map[string]any, len(webhooks))
 	for i, w := range webhooks {
@@ -105,12 +101,12 @@ func (h *Handler) Show(c echo.Context) error {
 		WebhookID string `json:"webhookId"`
 	}
 	if err := c.Bind(&req); err != nil || req.WebhookID == "" {
-		return c.JSON(http.StatusBadRequest, apiError("INVALID_PARAM", "webhookId is required.", "ed1d7571-a3ac-4370-899c-0dbe5e230cc8"))
+		return c.JSON(http.StatusBadRequest, apierr.Error("INVALID_PARAM", "webhookId is required.", "ed1d7571-a3ac-4370-899c-0dbe5e230cc8"))
 	}
 
 	w, err := h.repo.FindByIDAndUserID(req.WebhookID, user.ID)
 	if err != nil {
-		return c.JSON(http.StatusNotFound, apiError("NO_SUCH_WEBHOOK", "No such webhook.", "50f614d9-3e73-4e43-8345-2e1e25012b7a"))
+		return c.JSON(http.StatusNotFound, apierr.Error("NO_SUCH_WEBHOOK", "No such webhook.", "50f614d9-3e73-4e43-8345-2e1e25012b7a"))
 	}
 
 	return c.JSON(http.StatusOK, packWebhook(w))
@@ -128,12 +124,12 @@ func (h *Handler) Update(c echo.Context) error {
 		Active    *bool    `json:"active"`
 	}
 	if err := c.Bind(&req); err != nil || req.WebhookID == "" {
-		return c.JSON(http.StatusBadRequest, apiError("INVALID_PARAM", "webhookId is required.", "ed1d7571-a3ac-4370-899c-0dbe5e230cc8"))
+		return c.JSON(http.StatusBadRequest, apierr.Error("INVALID_PARAM", "webhookId is required.", "ed1d7571-a3ac-4370-899c-0dbe5e230cc8"))
 	}
 
 	w, err := h.repo.FindByIDAndUserID(req.WebhookID, user.ID)
 	if err != nil {
-		return c.JSON(http.StatusNotFound, apiError("NO_SUCH_WEBHOOK", "No such webhook.", "50f614d9-3e73-4e43-8345-2e1e25012b7a"))
+		return c.JSON(http.StatusNotFound, apierr.Error("NO_SUCH_WEBHOOK", "No such webhook.", "50f614d9-3e73-4e43-8345-2e1e25012b7a"))
 	}
 
 	if req.Name != "" {
@@ -153,7 +149,7 @@ func (h *Handler) Update(c echo.Context) error {
 	}
 
 	if err := h.repo.Update(w); err != nil {
-		return c.JSON(http.StatusInternalServerError, apiError("INTERNAL_ERROR", "Internal error.", "5d37dbcb-891e-41ca-a3d6-e690c97775ac"))
+		return c.JSON(http.StatusInternalServerError, apierr.Error("INTERNAL_ERROR", "Internal error.", "5d37dbcb-891e-41ca-a3d6-e690c97775ac"))
 	}
 
 	return c.JSON(http.StatusOK, packWebhook(w))
@@ -166,15 +162,15 @@ func (h *Handler) Delete(c echo.Context) error {
 		WebhookID string `json:"webhookId"`
 	}
 	if err := c.Bind(&req); err != nil || req.WebhookID == "" {
-		return c.JSON(http.StatusBadRequest, apiError("INVALID_PARAM", "webhookId is required.", "ed1d7571-a3ac-4370-899c-0dbe5e230cc8"))
+		return c.JSON(http.StatusBadRequest, apierr.Error("INVALID_PARAM", "webhookId is required.", "ed1d7571-a3ac-4370-899c-0dbe5e230cc8"))
 	}
 
 	if _, err := h.repo.FindByIDAndUserID(req.WebhookID, user.ID); err != nil {
-		return c.JSON(http.StatusNotFound, apiError("NO_SUCH_WEBHOOK", "No such webhook.", "50f614d9-3e73-4e43-8345-2e1e25012b7a"))
+		return c.JSON(http.StatusNotFound, apierr.Error("NO_SUCH_WEBHOOK", "No such webhook.", "50f614d9-3e73-4e43-8345-2e1e25012b7a"))
 	}
 
 	if err := h.repo.Delete(req.WebhookID, user.ID); err != nil {
-		return c.JSON(http.StatusInternalServerError, apiError("INTERNAL_ERROR", "Internal error.", "5d37dbcb-891e-41ca-a3d6-e690c97775ac"))
+		return c.JSON(http.StatusInternalServerError, apierr.Error("INTERNAL_ERROR", "Internal error.", "5d37dbcb-891e-41ca-a3d6-e690c97775ac"))
 	}
 
 	return c.NoContent(http.StatusNoContent)
@@ -190,12 +186,12 @@ func (h *Handler) Test(c echo.Context) error {
 		Type      string `json:"type"`
 	}
 	if err := c.Bind(&req); err != nil || req.WebhookID == "" {
-		return c.JSON(http.StatusBadRequest, apiError("INVALID_PARAM", "webhookId is required.", "ed1d7571-a3ac-4370-899c-0dbe5e230cc8"))
+		return c.JSON(http.StatusBadRequest, apierr.Error("INVALID_PARAM", "webhookId is required.", "ed1d7571-a3ac-4370-899c-0dbe5e230cc8"))
 	}
 
 	webhook, err := h.repo.FindByIDAndUserID(req.WebhookID, user.ID)
 	if err != nil {
-		return c.JSON(http.StatusNotFound, apiError("NO_SUCH_WEBHOOK", "No such webhook.", "50f614d9-3e73-4e43-8345-2e1e25012b7a"))
+		return c.JSON(http.StatusNotFound, apierr.Error("NO_SUCH_WEBHOOK", "No such webhook.", "50f614d9-3e73-4e43-8345-2e1e25012b7a"))
 	}
 
 	if h.dispatcher != nil {


### PR DESCRIPTION
## Summary
- 全20+ファイルの`apiError`/`errEnvelope`/`errResp`呼び出しを`apierr.Error()`に直接置換
- ローカルヘルパー関数定義を削除

## 主な変更点
| ヘルパー種別 | 引数順 | 対象ファイル数 |
|------------|--------|-------------|
| `apiError(code, msg, id)` | 同じ | 17 |
| `errEnvelope(msg, code, id)` | **入れ替え必要** | 4 |
| `errResp(code, msg, id)` | 同じ | 9 |

## 注意点
`errEnvelope`は引数順が`(message, code, id)`で`apierr.Error(code, message, id)`と異なるため、一件ずつ手動で入れ替えました。

## 効果
- 27ファイル変更: +387 / -464 行（77行削減）
- エラーレスポンス生成が`apierr`に完全集約
- Phase 2-1で作ったローカル委譲関数がすべて不要になり削除

## スコープ外（後続PR）
- インラインヘルパー（`invalidParam(c)`, `internalError(c)`, `notFound(c)`等）の移行
- これらは多数のファイルに存在し、別PRで扱う予定

## テスト
```bash
go test -race -count=1 ./internal/api/...
```
- 全42パッケージ通過

Refs #130
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/shiroha-a/mk/pull/142" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
