### PR TITLE
Phase P2: migrate call sites to apierr Echo helpers (#130 Phase 2-4)

### DIFF
--- a/internal/api/antennas/handler.go
+++ b/internal/api/antennas/handler.go
@@ -47,7 +47,7 @@ func (h *Handler) Create(c echo.Context) error {
 	user := middleware.GetUser(c)
 	var req CreateRequest
 	if err := c.Bind(&req); err != nil || req.Name == "" {
-		return invalidParam(c)
+		return apierr.JSONInvalidParam(c)
 	}
 	a, err := h.svc.Create(coreantenna.CreateInput{
 		OwnerID:         user.ID,
@@ -66,9 +66,9 @@ func (h *Handler) Create(c echo.Context) error {
 		// Name は事前 invalidParam で弾いているため、ここに来るのは
 		// ErrInvalidSource か repo エラーのみ。
 		if errors.Is(err, coreantenna.ErrInvalidSource) {
-			return invalidParam(c)
+			return apierr.JSONInvalidParam(c)
 		}
-		return internalError(c)
+		return apierr.JSONInternalError(c)
 	}
 	return c.JSON(http.StatusOK, antennaToMap(a))
 }
@@ -83,12 +83,12 @@ func (h *Handler) Show(c echo.Context) error {
 	user := middleware.GetUser(c)
 	var req ShowRequest
 	if err := c.Bind(&req); err != nil || req.AntennaID == "" {
-		return invalidParam(c)
+		return apierr.JSONInvalidParam(c)
 	}
 	a, err := h.svc.Show(user.ID, req.AntennaID)
 	if err != nil {
 		if errors.Is(err, coreantenna.ErrAccessDenied) {
-			return accessDenied(c)
+			return apierr.JSONAccessDenied(c)
 		}
 		// Show は ErrAntennaNotFound 以外を返さない (未マップ含む)
 		return notFound(c)
@@ -117,7 +117,7 @@ func (h *Handler) Update(c echo.Context) error {
 	user := middleware.GetUser(c)
 	var req UpdateRequest
 	if err := c.Bind(&req); err != nil || req.AntennaID == "" {
-		return invalidParam(c)
+		return apierr.JSONInvalidParam(c)
 	}
 	a, err := h.svc.Update(user.ID, req.AntennaID, coreantenna.UpdateInput{
 		Name:            req.Name,
@@ -137,12 +137,12 @@ func (h *Handler) Update(c echo.Context) error {
 		case errors.Is(err, coreantenna.ErrAntennaNotFound):
 			return notFound(c)
 		case errors.Is(err, coreantenna.ErrAccessDenied):
-			return accessDenied(c)
+			return apierr.JSONAccessDenied(c)
 		case errors.Is(err, coreantenna.ErrAntennaNameRequired),
 			errors.Is(err, coreantenna.ErrInvalidSource):
-			return invalidParam(c)
+			return apierr.JSONInvalidParam(c)
 		}
-		return internalError(c)
+		return apierr.JSONInternalError(c)
 	}
 	return c.JSON(http.StatusOK, antennaToMap(a))
 }
@@ -157,16 +157,16 @@ func (h *Handler) Delete(c echo.Context) error {
 	user := middleware.GetUser(c)
 	var req DeleteRequest
 	if err := c.Bind(&req); err != nil || req.AntennaID == "" {
-		return invalidParam(c)
+		return apierr.JSONInvalidParam(c)
 	}
 	if err := h.svc.Delete(user.ID, req.AntennaID); err != nil {
 		switch {
 		case errors.Is(err, coreantenna.ErrAntennaNotFound):
 			return notFound(c)
 		case errors.Is(err, coreantenna.ErrAccessDenied):
-			return accessDenied(c)
+			return apierr.JSONAccessDenied(c)
 		}
-		return internalError(c)
+		return apierr.JSONInternalError(c)
 	}
 	return c.NoContent(http.StatusNoContent)
 }
@@ -176,7 +176,7 @@ func (h *Handler) List(c echo.Context) error {
 	user := middleware.GetUser(c)
 	rows, err := h.svc.ListByUser(user.ID)
 	if err != nil {
-		return internalError(c)
+		return apierr.JSONInternalError(c)
 	}
 	out := make([]map[string]any, 0, len(rows))
 	for _, a := range rows {
@@ -196,7 +196,7 @@ func (h *Handler) Notes(c echo.Context) error {
 	user := middleware.GetUser(c)
 	var req NotesRequest
 	if err := c.Bind(&req); err != nil || req.AntennaID == "" {
-		return invalidParam(c)
+		return apierr.JSONInvalidParam(c)
 	}
 	ids, err := h.svc.Notes(c.Request().Context(), user.ID, req.AntennaID, req.Limit)
 	if err != nil {
@@ -204,13 +204,13 @@ func (h *Handler) Notes(c echo.Context) error {
 		case errors.Is(err, coreantenna.ErrAntennaNotFound):
 			return notFound(c)
 		case errors.Is(err, coreantenna.ErrAccessDenied):
-			return accessDenied(c)
+			return apierr.JSONAccessDenied(c)
 		}
-		return internalError(c)
+		return apierr.JSONInternalError(c)
 	}
 	notes, err := h.noteRepo.FindManyByIDsWithUser(ids)
 	if err != nil {
-		return internalError(c)
+		return apierr.JSONInternalError(c)
 	}
 	out := make([]any, 0, len(notes))
 	for _, n := range notes {
@@ -238,18 +238,6 @@ func antennaToMap(a *model.Antenna) map[string]any {
 	}
 }
 
-func invalidParam(c echo.Context) error {
-	return c.JSON(http.StatusBadRequest, apierr.InvalidParam())
-}
-
-func internalError(c echo.Context) error {
-	return c.JSON(http.StatusInternalServerError, apierr.InternalError())
-}
-
 func notFound(c echo.Context) error {
 	return c.JSON(http.StatusNotFound, apierr.Error("NO_SUCH_ANTENNA", "No such antenna.", "3a1fb010-b54c-4f28-9a06-a5c7c7c1c33a"))
-}
-
-func accessDenied(c echo.Context) error {
-	return c.JSON(http.StatusForbidden, apierr.AccessDenied())
 }

--- a/internal/api/apierr/echo.go
+++ b/internal/api/apierr/echo.go
@@ -1,0 +1,32 @@
+package apierr
+
+import (
+	"net/http"
+
+	"github.com/labstack/echo/v4"
+)
+
+// JSONInvalidParam writes a 400 INVALID_PARAM response to the client.
+func JSONInvalidParam(c echo.Context) error {
+	return c.JSON(http.StatusBadRequest, InvalidParam())
+}
+
+// JSONInternalError writes a 500 INTERNAL_ERROR response to the client.
+func JSONInternalError(c echo.Context) error {
+	return c.JSON(http.StatusInternalServerError, InternalError())
+}
+
+// JSONNoSuchUser writes a 404 NO_SUCH_USER response to the client.
+func JSONNoSuchUser(c echo.Context) error {
+	return c.JSON(http.StatusNotFound, NoSuchUser())
+}
+
+// JSONNoSuchNote writes a 404 NO_SUCH_NOTE response to the client.
+func JSONNoSuchNote(c echo.Context) error {
+	return c.JSON(http.StatusNotFound, NoSuchNote())
+}
+
+// JSONAccessDenied writes a 403 ACCESS_DENIED response to the client.
+func JSONAccessDenied(c echo.Context) error {
+	return c.JSON(http.StatusForbidden, AccessDenied())
+}

--- a/internal/api/apierr/echo_test.go
+++ b/internal/api/apierr/echo_test.go
@@ -1,0 +1,64 @@
+package apierr
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/labstack/echo/v4"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func invoke(t *testing.T, fn func(echo.Context) error) (int, map[string]any) {
+	t.Helper()
+	e := echo.New()
+	req := httptest.NewRequest(http.MethodPost, "/", nil)
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+	_ = fn(c)
+	var body map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &body))
+	return rec.Code, body
+}
+
+func TestJSONInvalidParam(t *testing.T) {
+	code, body := invoke(t, JSONInvalidParam)
+	assert.Equal(t, http.StatusBadRequest, code)
+	errObj := body["error"].(map[string]any)
+	assert.Equal(t, "INVALID_PARAM", errObj["code"])
+	assert.Equal(t, UUIDInvalidParam, errObj["id"])
+}
+
+func TestJSONInternalError(t *testing.T) {
+	code, body := invoke(t, JSONInternalError)
+	assert.Equal(t, http.StatusInternalServerError, code)
+	errObj := body["error"].(map[string]any)
+	assert.Equal(t, "INTERNAL_ERROR", errObj["code"])
+	assert.Equal(t, UUIDInternalError, errObj["id"])
+}
+
+func TestJSONNoSuchUser(t *testing.T) {
+	code, body := invoke(t, JSONNoSuchUser)
+	assert.Equal(t, http.StatusNotFound, code)
+	errObj := body["error"].(map[string]any)
+	assert.Equal(t, "NO_SUCH_USER", errObj["code"])
+	assert.Equal(t, UUIDNoSuchUser, errObj["id"])
+}
+
+func TestJSONNoSuchNote(t *testing.T) {
+	code, body := invoke(t, JSONNoSuchNote)
+	assert.Equal(t, http.StatusNotFound, code)
+	errObj := body["error"].(map[string]any)
+	assert.Equal(t, "NO_SUCH_NOTE", errObj["code"])
+	assert.Equal(t, UUIDNoSuchNote, errObj["id"])
+}
+
+func TestJSONAccessDenied(t *testing.T) {
+	code, body := invoke(t, JSONAccessDenied)
+	assert.Equal(t, http.StatusForbidden, code)
+	errObj := body["error"].(map[string]any)
+	assert.Equal(t, "ACCESS_DENIED", errObj["code"])
+	assert.Equal(t, UUIDAccessDenied, errObj["id"])
+}

--- a/internal/api/blocking/handler.go
+++ b/internal/api/blocking/handler.go
@@ -31,7 +31,7 @@ func (h *Handler) Create(c echo.Context) error {
 	user := middleware.GetUser(c)
 	var req PairRequest
 	if err := c.Bind(&req); err != nil || req.UserID == "" {
-		return invalidParam(c)
+		return apierr.JSONInvalidParam(c)
 	}
 
 	if _, err := h.svc.Block(user.ID, req.UserID); err != nil {
@@ -45,7 +45,7 @@ func (h *Handler) Create(c echo.Context) error {
 				},
 			})
 		case errors.Is(err, coreblocking.ErrBlockeeNotFound):
-			return noSuchUser(c)
+			return apierr.JSONNoSuchUser(c)
 		case errors.Is(err, coreblocking.ErrAlreadyBlocking):
 			return c.JSON(http.StatusBadRequest, map[string]any{
 				"error": map[string]any{
@@ -55,7 +55,7 @@ func (h *Handler) Create(c echo.Context) error {
 				},
 			})
 		}
-		return internalError(c)
+		return apierr.JSONInternalError(c)
 	}
 	return c.NoContent(http.StatusNoContent)
 }
@@ -65,7 +65,7 @@ func (h *Handler) Delete(c echo.Context) error {
 	user := middleware.GetUser(c)
 	var req PairRequest
 	if err := c.Bind(&req); err != nil || req.UserID == "" {
-		return invalidParam(c)
+		return apierr.JSONInvalidParam(c)
 	}
 	if err := h.svc.Unblock(user.ID, req.UserID); err != nil {
 		switch {
@@ -86,7 +86,7 @@ func (h *Handler) Delete(c echo.Context) error {
 				},
 			})
 		}
-		return internalError(c)
+		return apierr.JSONInternalError(c)
 	}
 	return c.NoContent(http.StatusNoContent)
 }
@@ -102,7 +102,7 @@ func (h *Handler) List(c echo.Context) error {
 	user := middleware.GetUser(c)
 	var req ListRequest
 	if err := c.Bind(&req); err != nil {
-		return invalidParam(c)
+		return apierr.JSONInvalidParam(c)
 	}
 	if req.Limit <= 0 {
 		req.Limit = 30
@@ -112,7 +112,7 @@ func (h *Handler) List(c echo.Context) error {
 	}
 	rows, err := h.svc.List(user.ID, req.Limit, req.Offset)
 	if err != nil {
-		return internalError(c)
+		return apierr.JSONInternalError(c)
 	}
 	out := make([]map[string]any, 0, len(rows))
 	for _, b := range rows {
@@ -122,16 +122,4 @@ func (h *Handler) List(c echo.Context) error {
 		})
 	}
 	return c.JSON(http.StatusOK, out)
-}
-
-func invalidParam(c echo.Context) error {
-	return c.JSON(http.StatusBadRequest, apierr.InvalidParam())
-}
-
-func internalError(c echo.Context) error {
-	return c.JSON(http.StatusInternalServerError, apierr.InternalError())
-}
-
-func noSuchUser(c echo.Context) error {
-	return c.JSON(http.StatusNotFound, apierr.NoSuchUser())
 }

--- a/internal/api/channels/handler.go
+++ b/internal/api/channels/handler.go
@@ -56,7 +56,7 @@ func (h *Handler) Create(c echo.Context) error {
 	user := middleware.GetUser(c)
 	var req CreateRequest
 	if err := c.Bind(&req); err != nil || req.Name == "" {
-		return invalidParam(c)
+		return apierr.JSONInvalidParam(c)
 	}
 	ch, err := h.svc.Create(corechannel.CreateInput{
 		OwnerID:     user.ID,
@@ -66,7 +66,7 @@ func (h *Handler) Create(c echo.Context) error {
 		IsSensitive: req.IsSensitive,
 	})
 	if err != nil {
-		return internalError(c)
+		return apierr.JSONInternalError(c)
 	}
 	return c.JSON(http.StatusOK, channelToMap(ch))
 }
@@ -80,7 +80,7 @@ type ShowRequest struct {
 func (h *Handler) Show(c echo.Context) error {
 	var req ShowRequest
 	if err := c.Bind(&req); err != nil || req.ChannelID == "" {
-		return invalidParam(c)
+		return apierr.JSONInvalidParam(c)
 	}
 	ch, err := h.svc.Show(req.ChannelID)
 	if err != nil {
@@ -104,7 +104,7 @@ func (h *Handler) Update(c echo.Context) error {
 	user := middleware.GetUser(c)
 	var req UpdateRequest
 	if err := c.Bind(&req); err != nil || req.ChannelID == "" {
-		return invalidParam(c)
+		return apierr.JSONInvalidParam(c)
 	}
 	in := corechannel.UpdateInput{
 		Name:        req.Name,
@@ -122,11 +122,11 @@ func (h *Handler) Update(c echo.Context) error {
 		case errors.Is(err, corechannel.ErrChannelNotFound):
 			return notFound(c)
 		case errors.Is(err, corechannel.ErrAccessDenied):
-			return accessDenied(c)
+			return apierr.JSONAccessDenied(c)
 		case errors.Is(err, corechannel.ErrChannelNameRequired):
-			return invalidParam(c)
+			return apierr.JSONInvalidParam(c)
 		}
-		return internalError(c)
+		return apierr.JSONInternalError(c)
 	}
 	return c.JSON(http.StatusOK, channelToMap(ch))
 }
@@ -141,7 +141,7 @@ func (h *Handler) Follow(c echo.Context) error {
 	user := middleware.GetUser(c)
 	var req FollowRequest
 	if err := c.Bind(&req); err != nil || req.ChannelID == "" {
-		return invalidParam(c)
+		return apierr.JSONInvalidParam(c)
 	}
 	if err := h.svc.Follow(user.ID, req.ChannelID); err != nil {
 		switch {
@@ -150,7 +150,7 @@ func (h *Handler) Follow(c echo.Context) error {
 		case errors.Is(err, corechannel.ErrAlreadyFollowing):
 			return alreadyFollowing(c)
 		}
-		return internalError(c)
+		return apierr.JSONInternalError(c)
 	}
 	return c.NoContent(http.StatusNoContent)
 }
@@ -160,13 +160,13 @@ func (h *Handler) Unfollow(c echo.Context) error {
 	user := middleware.GetUser(c)
 	var req FollowRequest
 	if err := c.Bind(&req); err != nil || req.ChannelID == "" {
-		return invalidParam(c)
+		return apierr.JSONInvalidParam(c)
 	}
 	if err := h.svc.Unfollow(user.ID, req.ChannelID); err != nil {
 		if errors.Is(err, corechannel.ErrNotFollowing) {
 			return notFollowing(c)
 		}
-		return internalError(c)
+		return apierr.JSONInternalError(c)
 	}
 	return c.NoContent(http.StatusNoContent)
 }
@@ -183,11 +183,11 @@ func (h *Handler) Followed(c echo.Context) error {
 	user := middleware.GetUser(c)
 	var req PaginatedListRequest
 	if err := c.Bind(&req); err != nil {
-		return invalidParam(c)
+		return apierr.JSONInvalidParam(c)
 	}
 	rows, err := h.svc.ListFollowed(user.ID, req.Limit, req.Offset)
 	if err != nil {
-		return internalError(c)
+		return apierr.JSONInternalError(c)
 	}
 	return c.JSON(http.StatusOK, channelsToList(rows))
 }
@@ -197,11 +197,11 @@ func (h *Handler) Owned(c echo.Context) error {
 	user := middleware.GetUser(c)
 	var req PaginatedListRequest
 	if err := c.Bind(&req); err != nil {
-		return invalidParam(c)
+		return apierr.JSONInvalidParam(c)
 	}
 	rows, err := h.svc.ListOwned(user.ID, req.Limit, req.Offset)
 	if err != nil {
-		return internalError(c)
+		return apierr.JSONInternalError(c)
 	}
 	return c.JSON(http.StatusOK, channelsToList(rows))
 }
@@ -210,11 +210,11 @@ func (h *Handler) Owned(c echo.Context) error {
 func (h *Handler) Featured(c echo.Context) error {
 	var req PaginatedListRequest
 	if err := c.Bind(&req); err != nil {
-		return invalidParam(c)
+		return apierr.JSONInvalidParam(c)
 	}
 	rows, err := h.svc.ListFeatured(req.Limit, req.Offset)
 	if err != nil {
-		return internalError(c)
+		return apierr.JSONInternalError(c)
 	}
 	return c.JSON(http.StatusOK, channelsToList(rows))
 }
@@ -230,11 +230,11 @@ type SearchRequest struct {
 func (h *Handler) Search(c echo.Context) error {
 	var req SearchRequest
 	if err := c.Bind(&req); err != nil {
-		return invalidParam(c)
+		return apierr.JSONInvalidParam(c)
 	}
 	rows, err := h.svc.Search(req.Query, req.Limit, req.Offset)
 	if err != nil {
-		return internalError(c)
+		return apierr.JSONInternalError(c)
 	}
 	return c.JSON(http.StatusOK, channelsToList(rows))
 }
@@ -251,7 +251,7 @@ type TimelineRequest struct {
 func (h *Handler) Timeline(c echo.Context) error {
 	var req TimelineRequest
 	if err := c.Bind(&req); err != nil || req.ChannelID == "" {
-		return invalidParam(c)
+		return apierr.JSONInvalidParam(c)
 	}
 	limit := req.Limit
 	if limit <= 0 {
@@ -265,7 +265,7 @@ func (h *Handler) Timeline(c echo.Context) error {
 		if errors.Is(err, corechannel.ErrChannelNotFound) {
 			return notFound(c)
 		}
-		return internalError(c)
+		return apierr.JSONInternalError(c)
 	}
 	out := make([]any, 0, len(notes))
 	for _, n := range notes {
@@ -300,20 +300,8 @@ func channelsToList(rows []*model.Channel) []map[string]any {
 	return out
 }
 
-func invalidParam(c echo.Context) error {
-	return c.JSON(http.StatusBadRequest, apierr.InvalidParam())
-}
-
-func internalError(c echo.Context) error {
-	return c.JSON(http.StatusInternalServerError, apierr.InternalError())
-}
-
 func notFound(c echo.Context) error {
 	return c.JSON(http.StatusNotFound, apierr.Error("NO_SUCH_CHANNEL", "No such channel.", "8ee5d9d4-9cb0-4f40-bba4-aaa31a3b48b9"))
-}
-
-func accessDenied(c echo.Context) error {
-	return c.JSON(http.StatusForbidden, apierr.AccessDenied())
 }
 
 func alreadyFollowing(c echo.Context) error {

--- a/internal/api/channels/handler_stubs.go
+++ b/internal/api/channels/handler_stubs.go
@@ -5,6 +5,7 @@ import (
 	"time"
 
 	"github.com/labstack/echo/v4"
+	"github.com/shiroha-a/mk/internal/api/apierr"
 	"github.com/shiroha-a/mk/internal/model"
 	"github.com/shiroha-a/mk/internal/server/middleware"
 )
@@ -26,7 +27,7 @@ func (h *Handler) Favorite(c echo.Context) error {
 		ChannelID string `json:"channelId"`
 	}
 	if err := c.Bind(&req); err != nil || req.ChannelID == "" {
-		return invalidParam(c)
+		return apierr.JSONInvalidParam(c)
 	}
 	if h.favoriteRepo == nil {
 		return c.NoContent(http.StatusNoContent)
@@ -44,7 +45,7 @@ func (h *Handler) Favorite(c echo.Context) error {
 		ChannelID: req.ChannelID,
 	}
 	if err := h.favoriteRepo.Create(fav); err != nil {
-		return internalError(c)
+		return apierr.JSONInternalError(c)
 	}
 	return c.NoContent(http.StatusNoContent)
 }
@@ -56,13 +57,13 @@ func (h *Handler) Unfavorite(c echo.Context) error {
 		ChannelID string `json:"channelId"`
 	}
 	if err := c.Bind(&req); err != nil || req.ChannelID == "" {
-		return invalidParam(c)
+		return apierr.JSONInvalidParam(c)
 	}
 	if h.favoriteRepo == nil {
 		return c.NoContent(http.StatusNoContent)
 	}
 	if err := h.favoriteRepo.Delete(user.ID, req.ChannelID); err != nil {
-		return internalError(c)
+		return apierr.JSONInternalError(c)
 	}
 	return c.NoContent(http.StatusNoContent)
 }
@@ -75,7 +76,7 @@ func (h *Handler) MyFavorites(c echo.Context) error {
 	}
 	favs, err := h.favoriteRepo.ListByUser(user.ID)
 	if err != nil {
-		return internalError(c)
+		return apierr.JSONInternalError(c)
 	}
 	out := make([]map[string]any, 0, len(favs))
 	for _, f := range favs {
@@ -95,7 +96,7 @@ func (h *Handler) MuteCreate(c echo.Context) error {
 		ChannelID string `json:"channelId"`
 	}
 	if err := c.Bind(&req); err != nil || req.ChannelID == "" {
-		return invalidParam(c)
+		return apierr.JSONInvalidParam(c)
 	}
 	if h.mutingRepo == nil {
 		return c.NoContent(http.StatusNoContent)
@@ -113,7 +114,7 @@ func (h *Handler) MuteCreate(c echo.Context) error {
 		ChannelID: req.ChannelID,
 	}
 	if err := h.mutingRepo.Create(mut); err != nil {
-		return internalError(c)
+		return apierr.JSONInternalError(c)
 	}
 	return c.NoContent(http.StatusNoContent)
 }
@@ -125,13 +126,13 @@ func (h *Handler) MuteDelete(c echo.Context) error {
 		ChannelID string `json:"channelId"`
 	}
 	if err := c.Bind(&req); err != nil || req.ChannelID == "" {
-		return invalidParam(c)
+		return apierr.JSONInvalidParam(c)
 	}
 	if h.mutingRepo == nil {
 		return c.NoContent(http.StatusNoContent)
 	}
 	if err := h.mutingRepo.Delete(user.ID, req.ChannelID); err != nil {
-		return internalError(c)
+		return apierr.JSONInternalError(c)
 	}
 	return c.NoContent(http.StatusNoContent)
 }
@@ -144,7 +145,7 @@ func (h *Handler) MuteList(c echo.Context) error {
 	}
 	mutings, err := h.mutingRepo.ListByUser(user.ID)
 	if err != nil {
-		return internalError(c)
+		return apierr.JSONInternalError(c)
 	}
 	out := make([]map[string]any, 0, len(mutings))
 	for _, m := range mutings {

--- a/internal/api/clips/handler.go
+++ b/internal/api/clips/handler.go
@@ -38,7 +38,7 @@ func (h *Handler) Create(c echo.Context) error {
 	user := middleware.GetUser(c)
 	var req CreateRequest
 	if err := c.Bind(&req); err != nil || req.Name == "" {
-		return invalidParam(c)
+		return apierr.JSONInvalidParam(c)
 	}
 	cl, err := h.svc.Create(coreclip.CreateInput{
 		OwnerID:     user.ID,
@@ -47,7 +47,7 @@ func (h *Handler) Create(c echo.Context) error {
 		IsPublic:    req.IsPublic,
 	})
 	if err != nil {
-		return internalError(c)
+		return apierr.JSONInternalError(c)
 	}
 	return c.JSON(http.StatusOK, clipToMap(cl))
 }
@@ -62,7 +62,7 @@ func (h *Handler) Show(c echo.Context) error {
 	user := middleware.GetUser(c)
 	var req ShowRequest
 	if err := c.Bind(&req); err != nil || req.ClipID == "" {
-		return invalidParam(c)
+		return apierr.JSONInvalidParam(c)
 	}
 	requesterID := ""
 	if user != nil {
@@ -71,7 +71,7 @@ func (h *Handler) Show(c echo.Context) error {
 	cl, err := h.svc.Show(requesterID, req.ClipID)
 	if err != nil {
 		if errors.Is(err, coreclip.ErrAccessDenied) {
-			return accessDenied(c)
+			return apierr.JSONAccessDenied(c)
 		}
 		return notFound(c)
 	}
@@ -91,7 +91,7 @@ func (h *Handler) Update(c echo.Context) error {
 	user := middleware.GetUser(c)
 	var req UpdateRequest
 	if err := c.Bind(&req); err != nil || req.ClipID == "" {
-		return invalidParam(c)
+		return apierr.JSONInvalidParam(c)
 	}
 	in := coreclip.UpdateInput{
 		Name:     req.Name,
@@ -107,11 +107,11 @@ func (h *Handler) Update(c echo.Context) error {
 		case errors.Is(err, coreclip.ErrClipNotFound):
 			return notFound(c)
 		case errors.Is(err, coreclip.ErrAccessDenied):
-			return accessDenied(c)
+			return apierr.JSONAccessDenied(c)
 		case errors.Is(err, coreclip.ErrClipNameRequired):
-			return invalidParam(c)
+			return apierr.JSONInvalidParam(c)
 		}
-		return internalError(c)
+		return apierr.JSONInternalError(c)
 	}
 	return c.JSON(http.StatusOK, clipToMap(cl))
 }
@@ -126,16 +126,16 @@ func (h *Handler) Delete(c echo.Context) error {
 	user := middleware.GetUser(c)
 	var req DeleteRequest
 	if err := c.Bind(&req); err != nil || req.ClipID == "" {
-		return invalidParam(c)
+		return apierr.JSONInvalidParam(c)
 	}
 	if err := h.svc.Delete(user.ID, req.ClipID); err != nil {
 		switch {
 		case errors.Is(err, coreclip.ErrClipNotFound):
 			return notFound(c)
 		case errors.Is(err, coreclip.ErrAccessDenied):
-			return accessDenied(c)
+			return apierr.JSONAccessDenied(c)
 		}
-		return internalError(c)
+		return apierr.JSONInternalError(c)
 	}
 	return c.NoContent(http.StatusNoContent)
 }
@@ -151,11 +151,11 @@ func (h *Handler) List(c echo.Context) error {
 	user := middleware.GetUser(c)
 	var req ListRequest
 	if err := c.Bind(&req); err != nil {
-		return invalidParam(c)
+		return apierr.JSONInvalidParam(c)
 	}
 	rows, err := h.svc.ListByUser(user.ID, req.Limit, req.Offset)
 	if err != nil {
-		return internalError(c)
+		return apierr.JSONInternalError(c)
 	}
 	out := make([]map[string]any, 0, len(rows))
 	for _, cl := range rows {
@@ -175,20 +175,20 @@ func (h *Handler) AddNote(c echo.Context) error {
 	user := middleware.GetUser(c)
 	var req AddNoteRequest
 	if err := c.Bind(&req); err != nil || req.ClipID == "" || req.NoteID == "" {
-		return invalidParam(c)
+		return apierr.JSONInvalidParam(c)
 	}
 	if err := h.svc.AddNote(user.ID, req.ClipID, req.NoteID); err != nil {
 		switch {
 		case errors.Is(err, coreclip.ErrClipNotFound):
 			return notFound(c)
 		case errors.Is(err, coreclip.ErrAccessDenied):
-			return accessDenied(c)
+			return apierr.JSONAccessDenied(c)
 		case errors.Is(err, coreclip.ErrNoteNotFound):
 			return notFoundNote(c)
 		case errors.Is(err, coreclip.ErrAlreadyClipped):
 			return alreadyClipped(c)
 		}
-		return internalError(c)
+		return apierr.JSONInternalError(c)
 	}
 	return c.NoContent(http.StatusNoContent)
 }
@@ -204,18 +204,18 @@ func (h *Handler) RemoveNote(c echo.Context) error {
 	user := middleware.GetUser(c)
 	var req RemoveNoteRequest
 	if err := c.Bind(&req); err != nil || req.ClipID == "" || req.NoteID == "" {
-		return invalidParam(c)
+		return apierr.JSONInvalidParam(c)
 	}
 	if err := h.svc.RemoveNote(user.ID, req.ClipID, req.NoteID); err != nil {
 		switch {
 		case errors.Is(err, coreclip.ErrClipNotFound):
 			return notFound(c)
 		case errors.Is(err, coreclip.ErrAccessDenied):
-			return accessDenied(c)
+			return apierr.JSONAccessDenied(c)
 		case errors.Is(err, coreclip.ErrNotClipped):
 			return notClipped(c)
 		}
-		return internalError(c)
+		return apierr.JSONInternalError(c)
 	}
 	return c.NoContent(http.StatusNoContent)
 }
@@ -233,7 +233,7 @@ func (h *Handler) Notes(c echo.Context) error {
 	user := middleware.GetUser(c)
 	var req NotesRequest
 	if err := c.Bind(&req); err != nil || req.ClipID == "" {
-		return invalidParam(c)
+		return apierr.JSONInvalidParam(c)
 	}
 	requesterID := ""
 	if user != nil {
@@ -245,9 +245,9 @@ func (h *Handler) Notes(c echo.Context) error {
 		case errors.Is(err, coreclip.ErrClipNotFound):
 			return notFound(c)
 		case errors.Is(err, coreclip.ErrAccessDenied):
-			return accessDenied(c)
+			return apierr.JSONAccessDenied(c)
 		}
-		return internalError(c)
+		return apierr.JSONInternalError(c)
 	}
 	out := make([]any, 0, len(notes))
 	for _, n := range notes {
@@ -268,20 +268,8 @@ func clipToMap(cl *model.Clip) map[string]any {
 	}
 }
 
-func invalidParam(c echo.Context) error {
-	return c.JSON(http.StatusBadRequest, apierr.InvalidParam())
-}
-
-func internalError(c echo.Context) error {
-	return c.JSON(http.StatusInternalServerError, apierr.InternalError())
-}
-
 func notFound(c echo.Context) error {
 	return c.JSON(http.StatusNotFound, apierr.Error("NO_SUCH_CLIP", "No such clip.", "f4a9c0c6-a6c3-4a07-8e6b-0a4f2b1a27e9"))
-}
-
-func accessDenied(c echo.Context) error {
-	return c.JSON(http.StatusForbidden, apierr.AccessDenied())
 }
 
 func notFoundNote(c echo.Context) error {

--- a/internal/api/clips/handler_stubs.go
+++ b/internal/api/clips/handler_stubs.go
@@ -5,6 +5,7 @@ import (
 	"time"
 
 	"github.com/labstack/echo/v4"
+	"github.com/shiroha-a/mk/internal/api/apierr"
 	"github.com/shiroha-a/mk/internal/model"
 	"github.com/shiroha-a/mk/internal/server/middleware"
 )
@@ -29,7 +30,7 @@ func (h *Handler) Favorite(c echo.Context) error {
 		ClipID string `json:"clipId"`
 	}
 	if err := c.Bind(&req); err != nil || req.ClipID == "" {
-		return invalidParam(c)
+		return apierr.JSONInvalidParam(c)
 	}
 	if h.favoriteRepo == nil {
 		return c.NoContent(http.StatusNoContent)
@@ -48,7 +49,7 @@ func (h *Handler) Favorite(c echo.Context) error {
 		ClipID: req.ClipID,
 	}
 	if err := h.favoriteRepo.Create(fav); err != nil {
-		return internalError(c)
+		return apierr.JSONInternalError(c)
 	}
 	return c.NoContent(http.StatusNoContent)
 }
@@ -60,13 +61,13 @@ func (h *Handler) Unfavorite(c echo.Context) error {
 		ClipID string `json:"clipId"`
 	}
 	if err := c.Bind(&req); err != nil || req.ClipID == "" {
-		return invalidParam(c)
+		return apierr.JSONInvalidParam(c)
 	}
 	if h.favoriteRepo == nil {
 		return c.NoContent(http.StatusNoContent)
 	}
 	if err := h.favoriteRepo.Delete(user.ID, req.ClipID); err != nil {
-		return internalError(c)
+		return apierr.JSONInternalError(c)
 	}
 	return c.NoContent(http.StatusNoContent)
 }
@@ -79,7 +80,7 @@ func (h *Handler) MyFavorites(c echo.Context) error {
 	}
 	favs, err := h.favoriteRepo.ListByUser(user.ID)
 	if err != nil {
-		return internalError(c)
+		return apierr.JSONInternalError(c)
 	}
 	out := make([]map[string]any, 0, len(favs))
 	for _, f := range favs {

--- a/internal/api/drive/handler.go
+++ b/internal/api/drive/handler.go
@@ -59,7 +59,7 @@ func (h *Handler) FilesCreate(c echo.Context) error {
 
 	body, filename, err := readMultipartFile(c)
 	if err != nil {
-		return invalidParam(c)
+		return apierr.JSONInvalidParam(c)
 	}
 
 	in := coredrive.UploadInput{
@@ -91,7 +91,7 @@ func (h *Handler) FilesCreate(c echo.Context) error {
 		case errors.Is(err, coredrive.ErrAccessDenied):
 			return c.JSON(http.StatusForbidden, apierr.Error("ACCESS_DENIED", "Access denied.", "fe8d7103-0ea8-4ec3-814d-f8b401dc69e9"))
 		}
-		return internalError(c)
+		return apierr.JSONInternalError(c)
 	}
 	return c.JSON(http.StatusOK, entity.PackDriveFile(f, h.idGen))
 }
@@ -106,7 +106,7 @@ func (h *Handler) FilesShow(c echo.Context) error {
 	user := middleware.GetUser(c)
 	var req FileIDRequest
 	if err := c.Bind(&req); err != nil || req.FileID == "" {
-		return invalidParam(c)
+		return apierr.JSONInvalidParam(c)
 	}
 	f, err := h.svc.Show(user, req.FileID)
 	if err != nil {
@@ -131,7 +131,7 @@ func (h *Handler) FilesUpdate(c echo.Context) error {
 	user := middleware.GetUser(c)
 	var req FilesUpdateRequest
 	if err := c.Bind(&req); err != nil || req.FileID == "" {
-		return invalidParam(c)
+		return apierr.JSONInvalidParam(c)
 	}
 	in := coredrive.UpdateInput{
 		Name:        req.Name,
@@ -161,7 +161,7 @@ func (h *Handler) FilesDelete(c echo.Context) error {
 	user := middleware.GetUser(c)
 	var req FileIDRequest
 	if err := c.Bind(&req); err != nil || req.FileID == "" {
-		return invalidParam(c)
+		return apierr.JSONInvalidParam(c)
 	}
 	if err := h.svc.Delete(user, req.FileID); err != nil {
 		return mapFileError(c, err)
@@ -179,7 +179,7 @@ func (h *Handler) FilesFindByHash(c echo.Context) error {
 	user := middleware.GetUser(c)
 	var req FilesFindByHashRequest
 	if err := c.Bind(&req); err != nil || req.MD5 == "" {
-		return invalidParam(c)
+		return apierr.JSONInvalidParam(c)
 	}
 	f, err := h.svc.FindByHash(user, req.MD5)
 	if err != nil {
@@ -199,7 +199,7 @@ func (h *Handler) FoldersCreate(c echo.Context) error {
 	user := middleware.GetUser(c)
 	var req FoldersCreateRequest
 	if err := c.Bind(&req); err != nil {
-		return invalidParam(c)
+		return apierr.JSONInvalidParam(c)
 	}
 	if req.Name == "" {
 		req.Name = "Untitled"
@@ -221,7 +221,7 @@ func (h *Handler) FoldersShow(c echo.Context) error {
 	user := middleware.GetUser(c)
 	var req FolderIDRequest
 	if err := c.Bind(&req); err != nil || req.FolderID == "" {
-		return invalidParam(c)
+		return apierr.JSONInvalidParam(c)
 	}
 	f, err := h.svc.ShowFolder(user, req.FolderID)
 	if err != nil {
@@ -243,7 +243,7 @@ func (h *Handler) FoldersUpdate(c echo.Context) error {
 	user := middleware.GetUser(c)
 	var req FoldersUpdateRequest
 	if err := c.Bind(&req); err != nil || req.FolderID == "" {
-		return invalidParam(c)
+		return apierr.JSONInvalidParam(c)
 	}
 	in := coredrive.UpdateFolderInput{Name: req.Name}
 	if req.UnsetParent {
@@ -265,7 +265,7 @@ func (h *Handler) FoldersDelete(c echo.Context) error {
 	user := middleware.GetUser(c)
 	var req FolderIDRequest
 	if err := c.Bind(&req); err != nil || req.FolderID == "" {
-		return invalidParam(c)
+		return apierr.JSONInvalidParam(c)
 	}
 	if err := h.svc.DeleteFolder(user, req.FolderID); err != nil {
 		return mapFolderError(c, err)
@@ -284,7 +284,7 @@ func mapFileError(c echo.Context, err error) error {
 	case errors.Is(err, coredrive.ErrAccessDenied):
 		return c.JSON(http.StatusForbidden, apierr.Error("ACCESS_DENIED", "Access denied.", "fe8d7103-0ea8-4ec3-814d-f8b401dc69e9"))
 	}
-	return internalError(c)
+	return apierr.JSONInternalError(c)
 }
 
 func mapFolderError(c echo.Context, err error) error {
@@ -296,15 +296,7 @@ func mapFolderError(c echo.Context, err error) error {
 	case errors.Is(err, coredrive.ErrFolderNotEmpty):
 		return c.JSON(http.StatusBadRequest, apierr.Error("HAS_CHILD_FILES_OR_FOLDERS", "Folder is not empty.", "b0fc8a17-963c-405d-bfbc-859a487295e1"))
 	}
-	return internalError(c)
-}
-
-func invalidParam(c echo.Context) error {
-	return c.JSON(http.StatusBadRequest, apierr.InvalidParam())
-}
-
-func internalError(c echo.Context) error {
-	return c.JSON(http.StatusInternalServerError, apierr.InternalError())
+	return apierr.JSONInternalError(c)
 }
 
 // --- Drive listing endpoints ---
@@ -333,7 +325,7 @@ func (h *Handler) FilesList(c echo.Context) error {
 		Type     string  `json:"type"`
 	}
 	if err := c.Bind(&req); err != nil {
-		return invalidParam(c)
+		return apierr.JSONInvalidParam(c)
 	}
 	if req.Limit <= 0 {
 		req.Limit = 10
@@ -360,7 +352,7 @@ func (h *Handler) FilesFind(c echo.Context) error {
 		FolderID *string `json:"folderId"`
 	}
 	if err := c.Bind(&req); err != nil || req.Name == "" {
-		return invalidParam(c)
+		return apierr.JSONInvalidParam(c)
 	}
 	if h.fileRepo == nil {
 		return c.JSON(http.StatusOK, []any{})
@@ -383,7 +375,7 @@ func (h *Handler) FilesCheckExistence(c echo.Context) error {
 		MD5 string `json:"md5"`
 	}
 	if err := c.Bind(&req); err != nil || req.MD5 == "" {
-		return invalidParam(c)
+		return apierr.JSONInvalidParam(c)
 	}
 	if h.fileRepo == nil {
 		return c.JSON(http.StatusOK, false)
@@ -398,7 +390,7 @@ func (h *Handler) FilesAttachedNotes(c echo.Context) error {
 		FileID string `json:"fileId"`
 	}
 	if err := c.Bind(&req); err != nil || req.FileID == "" {
-		return invalidParam(c)
+		return apierr.JSONInvalidParam(c)
 	}
 	// fileIds配列にfileIDを含むノートを検索 (PostgreSQL配列演算子)
 	if h.noteRepo == nil {
@@ -434,7 +426,7 @@ func (h *Handler) FilesMoveBulk(c echo.Context) error {
 		FolderID *string  `json:"folderId"`
 	}
 	if err := c.Bind(&req); err != nil || len(req.FileIDs) == 0 {
-		return invalidParam(c)
+		return apierr.JSONInvalidParam(c)
 	}
 	if h.fileRepo != nil {
 		_ = h.fileRepo.UpdateBulkFolder(req.FileIDs, req.FolderID)
@@ -452,7 +444,7 @@ func (h *Handler) Stream(c echo.Context) error {
 		Type    string `json:"type"`
 	}
 	if err := c.Bind(&req); err != nil {
-		return invalidParam(c)
+		return apierr.JSONInvalidParam(c)
 	}
 	if req.Limit <= 0 {
 		req.Limit = 10
@@ -481,7 +473,7 @@ func (h *Handler) FoldersList(c echo.Context) error {
 		FolderID *string `json:"folderId"`
 	}
 	if err := c.Bind(&req); err != nil {
-		return invalidParam(c)
+		return apierr.JSONInvalidParam(c)
 	}
 	if req.Limit <= 0 {
 		req.Limit = 10
@@ -512,7 +504,7 @@ func (h *Handler) FoldersFind(c echo.Context) error {
 		ParentID *string `json:"parentId"`
 	}
 	if err := c.Bind(&req); err != nil || req.Name == "" {
-		return invalidParam(c)
+		return apierr.JSONInvalidParam(c)
 	}
 	if h.folderRepo == nil {
 		return c.JSON(http.StatusOK, []any{})

--- a/internal/api/federation/handler.go
+++ b/internal/api/federation/handler.go
@@ -37,7 +37,7 @@ type InstancesRequest struct {
 func (h *Handler) Instances(c echo.Context) error {
 	var req InstancesRequest
 	if err := c.Bind(&req); err != nil {
-		return invalidParam(c)
+		return apierr.JSONInvalidParam(c)
 	}
 	filter := model.InstanceListFilter{
 		Host:          req.Host,
@@ -52,7 +52,7 @@ func (h *Handler) Instances(c echo.Context) error {
 	}
 	rows, err := h.svc.List(filter)
 	if err != nil {
-		return internalError(c)
+		return apierr.JSONInternalError(c)
 	}
 	out := make([]map[string]any, 0, len(rows))
 	for _, inst := range rows {
@@ -70,7 +70,7 @@ type ShowInstanceRequest struct {
 func (h *Handler) ShowInstance(c echo.Context) error {
 	var req ShowInstanceRequest
 	if err := c.Bind(&req); err != nil || req.Host == "" {
-		return invalidParam(c)
+		return apierr.JSONInvalidParam(c)
 	}
 	inst, err := h.svc.FindByHost(req.Host)
 	if err != nil {
@@ -111,14 +111,6 @@ func instanceToMap(inst *model.Instance) map[string]any {
 		"infoUpdatedAt":           inst.InfoUpdatedAt,
 		"moderationNote":          inst.ModerationNote,
 	}
-}
-
-func invalidParam(c echo.Context) error {
-	return c.JSON(http.StatusBadRequest, apierr.InvalidParam())
-}
-
-func internalError(c echo.Context) error {
-	return c.JSON(http.StatusInternalServerError, apierr.InternalError())
 }
 
 func notFound(c echo.Context) error {

--- a/internal/api/flash/handler.go
+++ b/internal/api/flash/handler.go
@@ -36,7 +36,7 @@ func (h *Handler) Create(c echo.Context) error {
 	user := middleware.GetUser(c)
 	var req CreateRequest
 	if err := c.Bind(&req); err != nil || req.Title == "" || req.Script == "" {
-		return invalidParam(c)
+		return apierr.JSONInvalidParam(c)
 	}
 	f, err := h.svc.Create(coreflash.CreateInput{
 		OwnerID:     user.ID,
@@ -47,7 +47,7 @@ func (h *Handler) Create(c echo.Context) error {
 		Visibility:  req.Visibility,
 	})
 	if err != nil {
-		return internalError(c)
+		return apierr.JSONInternalError(c)
 	}
 	return c.JSON(http.StatusOK, flashToMap(f))
 }
@@ -62,7 +62,7 @@ func (h *Handler) Show(c echo.Context) error {
 	user := middleware.GetUser(c)
 	var req ShowRequest
 	if err := c.Bind(&req); err != nil || req.FlashID == "" {
-		return invalidParam(c)
+		return apierr.JSONInvalidParam(c)
 	}
 	requesterID := ""
 	if user != nil {
@@ -90,7 +90,7 @@ func (h *Handler) Update(c echo.Context) error {
 	user := middleware.GetUser(c)
 	var req UpdateRequest
 	if err := c.Bind(&req); err != nil || req.FlashID == "" {
-		return invalidParam(c)
+		return apierr.JSONInvalidParam(c)
 	}
 	f, err := h.svc.Update(user.ID, req.FlashID, coreflash.UpdateInput{
 		Title:       req.Title,
@@ -104,11 +104,11 @@ func (h *Handler) Update(c echo.Context) error {
 		case errors.Is(err, coreflash.ErrFlashNotFound):
 			return notFound(c)
 		case errors.Is(err, coreflash.ErrAccessDenied):
-			return accessDenied(c)
+			return apierr.JSONAccessDenied(c)
 		case errors.Is(err, coreflash.ErrFlashTitleRequired):
-			return invalidParam(c)
+			return apierr.JSONInvalidParam(c)
 		}
-		return internalError(c)
+		return apierr.JSONInternalError(c)
 	}
 	return c.JSON(http.StatusOK, flashToMap(f))
 }
@@ -123,16 +123,16 @@ func (h *Handler) Delete(c echo.Context) error {
 	user := middleware.GetUser(c)
 	var req DeleteRequest
 	if err := c.Bind(&req); err != nil || req.FlashID == "" {
-		return invalidParam(c)
+		return apierr.JSONInvalidParam(c)
 	}
 	if err := h.svc.Delete(user.ID, req.FlashID); err != nil {
 		switch {
 		case errors.Is(err, coreflash.ErrFlashNotFound):
 			return notFound(c)
 		case errors.Is(err, coreflash.ErrAccessDenied):
-			return accessDenied(c)
+			return apierr.JSONAccessDenied(c)
 		}
-		return internalError(c)
+		return apierr.JSONInternalError(c)
 	}
 	return c.NoContent(http.StatusNoContent)
 }
@@ -155,11 +155,11 @@ func (h *Handler) My(c echo.Context) error {
 	user := middleware.GetUser(c)
 	var req PaginationRequest
 	if err := c.Bind(&req); err != nil {
-		return invalidParam(c)
+		return apierr.JSONInvalidParam(c)
 	}
 	rows, err := h.svc.My(user.ID, req.Limit, req.Offset)
 	if err != nil {
-		return internalError(c)
+		return apierr.JSONInternalError(c)
 	}
 	return c.JSON(http.StatusOK, flashesToList(rows))
 }
@@ -168,11 +168,11 @@ func (h *Handler) My(c echo.Context) error {
 func (h *Handler) Featured(c echo.Context) error {
 	var req PaginationRequest
 	if err := c.Bind(&req); err != nil {
-		return invalidParam(c)
+		return apierr.JSONInvalidParam(c)
 	}
 	rows, err := h.svc.Featured(req.Limit, req.Offset)
 	if err != nil {
-		return internalError(c)
+		return apierr.JSONInternalError(c)
 	}
 	return c.JSON(http.StatusOK, flashesToList(rows))
 }
@@ -181,11 +181,11 @@ func (h *Handler) Featured(c echo.Context) error {
 func (h *Handler) Search(c echo.Context) error {
 	var req SearchRequest
 	if err := c.Bind(&req); err != nil || req.Query == "" {
-		return invalidParam(c)
+		return apierr.JSONInvalidParam(c)
 	}
 	rows, err := h.svc.Search(req.Query, req.Limit, req.Offset)
 	if err != nil {
-		return internalError(c)
+		return apierr.JSONInternalError(c)
 	}
 	return c.JSON(http.StatusOK, flashesToList(rows))
 }
@@ -200,7 +200,7 @@ func (h *Handler) Like(c echo.Context) error {
 	user := middleware.GetUser(c)
 	var req LikeRequest
 	if err := c.Bind(&req); err != nil || req.FlashID == "" {
-		return invalidParam(c)
+		return apierr.JSONInvalidParam(c)
 	}
 	if err := h.svc.Like(user.ID, req.FlashID); err != nil {
 		switch {
@@ -209,7 +209,7 @@ func (h *Handler) Like(c echo.Context) error {
 		case errors.Is(err, coreflash.ErrAlreadyLiked):
 			return alreadyLiked(c)
 		}
-		return internalError(c)
+		return apierr.JSONInternalError(c)
 	}
 	return c.NoContent(http.StatusNoContent)
 }
@@ -219,7 +219,7 @@ func (h *Handler) Unlike(c echo.Context) error {
 	user := middleware.GetUser(c)
 	var req LikeRequest
 	if err := c.Bind(&req); err != nil || req.FlashID == "" {
-		return invalidParam(c)
+		return apierr.JSONInvalidParam(c)
 	}
 	if err := h.svc.Unlike(user.ID, req.FlashID); err != nil {
 		switch {
@@ -228,7 +228,7 @@ func (h *Handler) Unlike(c echo.Context) error {
 		case errors.Is(err, coreflash.ErrNotLiked):
 			return notLiked(c)
 		}
-		return internalError(c)
+		return apierr.JSONInternalError(c)
 	}
 	return c.NoContent(http.StatusNoContent)
 }
@@ -238,11 +238,11 @@ func (h *Handler) MyLikes(c echo.Context) error {
 	user := middleware.GetUser(c)
 	var req PaginationRequest
 	if err := c.Bind(&req); err != nil {
-		return invalidParam(c)
+		return apierr.JSONInvalidParam(c)
 	}
 	rows, err := h.svc.MyLikes(user.ID, req.Limit, req.Offset)
 	if err != nil {
-		return internalError(c)
+		return apierr.JSONInternalError(c)
 	}
 	return c.JSON(http.StatusOK, flashesToList(rows))
 }
@@ -269,20 +269,8 @@ func flashToMap(f *model.Flash) map[string]any {
 	}
 }
 
-func invalidParam(c echo.Context) error {
-	return c.JSON(http.StatusBadRequest, apierr.InvalidParam())
-}
-
-func internalError(c echo.Context) error {
-	return c.JSON(http.StatusInternalServerError, apierr.InternalError())
-}
-
 func notFound(c echo.Context) error {
 	return c.JSON(http.StatusNotFound, apierr.Error("NO_SUCH_FLASH", "No such flash.", "f0d34a1a-d29a-401d-90ba-1982122b5630"))
-}
-
-func accessDenied(c echo.Context) error {
-	return c.JSON(http.StatusForbidden, apierr.AccessDenied())
 }
 
 func alreadyLiked(c echo.Context) error {

--- a/internal/api/following/handler.go
+++ b/internal/api/following/handler.go
@@ -36,7 +36,7 @@ func (h *Handler) Create(c echo.Context) error {
 
 	var req CreateRequest
 	if err := c.Bind(&req); err != nil || req.UserID == "" {
-		return invalidParam(c)
+		return apierr.JSONInvalidParam(c)
 	}
 
 	// followeeを先に取得し、エラー時はNO_SUCH_USERを返す
@@ -54,7 +54,7 @@ func (h *Handler) Create(c echo.Context) error {
 		case errors.Is(err, corefollowing.ErrBlocked):
 			return c.JSON(http.StatusForbidden, apierr.Error("BLOCKED", "You are blocked by that user.", "c4ab57cc-4e41-45e9-bfd9-584f61e35ce0"))
 		default:
-			return internalError(c)
+			return apierr.JSONInternalError(c)
 		}
 	}
 
@@ -72,7 +72,7 @@ func (h *Handler) Delete(c echo.Context) error {
 
 	var req DeleteRequest
 	if err := c.Bind(&req); err != nil || req.UserID == "" {
-		return invalidParam(c)
+		return apierr.JSONInvalidParam(c)
 	}
 
 	bundle, err := h.userService.ShowByID(req.UserID)
@@ -87,7 +87,7 @@ func (h *Handler) Delete(c echo.Context) error {
 		case errors.Is(err, corefollowing.ErrNotFollowing):
 			return c.JSON(http.StatusBadRequest, apierr.Error("NOT_FOLLOWING", "You are not following that user.", "5dbf82f5-c92b-40b1-87d1-6c8c0741fd09"))
 		default:
-			return internalError(c)
+			return apierr.JSONInternalError(c)
 		}
 	}
 
@@ -105,14 +105,14 @@ func (h *Handler) AcceptRequest(c echo.Context) error {
 
 	var req RequestActionRequest
 	if err := c.Bind(&req); err != nil || req.UserID == "" {
-		return invalidParam(c)
+		return apierr.JSONInvalidParam(c)
 	}
 
 	if err := h.followingService.AcceptRequest(me.ID, req.UserID); err != nil {
 		if errors.Is(err, corefollowing.ErrRequestNotFound) {
 			return c.JSON(http.StatusNotFound, apierr.Error("NO_FOLLOW_REQUEST", "No such follow request.", "bcde4f8b-0913-4614-8881-614e522fb041"))
 		}
-		return internalError(c)
+		return apierr.JSONInternalError(c)
 	}
 	return c.NoContent(http.StatusNoContent)
 }
@@ -123,14 +123,14 @@ func (h *Handler) RejectRequest(c echo.Context) error {
 
 	var req RequestActionRequest
 	if err := c.Bind(&req); err != nil || req.UserID == "" {
-		return invalidParam(c)
+		return apierr.JSONInvalidParam(c)
 	}
 
 	if err := h.followingService.RejectRequest(me.ID, req.UserID); err != nil {
 		if errors.Is(err, corefollowing.ErrRequestNotFound) {
 			return c.JSON(http.StatusNotFound, apierr.Error("NO_FOLLOW_REQUEST", "No such follow request.", "abc2ffa6-25b2-4380-ba99-321ff3a94555"))
 		}
-		return internalError(c)
+		return apierr.JSONInternalError(c)
 	}
 	return c.NoContent(http.StatusNoContent)
 }
@@ -141,14 +141,14 @@ func (h *Handler) CancelRequest(c echo.Context) error {
 
 	var req RequestActionRequest
 	if err := c.Bind(&req); err != nil || req.UserID == "" {
-		return invalidParam(c)
+		return apierr.JSONInvalidParam(c)
 	}
 
 	if err := h.followingService.CancelRequest(me.ID, req.UserID); err != nil {
 		if errors.Is(err, corefollowing.ErrRequestNotFound) {
 			return c.JSON(http.StatusNotFound, apierr.Error("NO_FOLLOW_REQUEST", "No such follow request.", "17447091-ea95-43eb-a7d4-c78cb2853c20"))
 		}
-		return internalError(c)
+		return apierr.JSONInternalError(c)
 	}
 	return c.NoContent(http.StatusNoContent)
 }
@@ -166,7 +166,7 @@ func (h *Handler) ListRequests(c echo.Context) error {
 
 	requests, err := h.followingService.ListReceivedRequests(me.ID, 100, 0)
 	if err != nil {
-		return internalError(c)
+		return apierr.JSONInternalError(c)
 	}
 
 	out := make([]ListRequestsResponseItem, 0, len(requests))
@@ -181,12 +181,4 @@ func (h *Handler) ListRequests(c echo.Context) error {
 		out = append(out, item)
 	}
 	return c.JSON(http.StatusOK, out)
-}
-
-func invalidParam(c echo.Context) error {
-	return c.JSON(http.StatusBadRequest, apierr.InvalidParam())
-}
-
-func internalError(c echo.Context) error {
-	return c.JSON(http.StatusInternalServerError, apierr.InternalError())
 }

--- a/internal/api/i/handler.go
+++ b/internal/api/i/handler.go
@@ -465,7 +465,7 @@ func (h *Handler) Update(c echo.Context) error {
 
 	var req UpdateRequest
 	if err := c.Bind(&req); err != nil {
-		return invalidParam(c)
+		return apierr.JSONInvalidParam(c)
 	}
 
 	in := user.UpdateInput{
@@ -514,7 +514,7 @@ func (h *Handler) Update(c echo.Context) error {
 		if errors.Is(err, user.ErrUserNotFound) {
 			return c.JSON(http.StatusNotFound, apierr.Error("NO_SUCH_USER", "No such user.", "4362f8dc-731f-4ad8-a694-be5a88922a24"))
 		}
-		return internalError(c)
+		return apierr.JSONInternalError(c)
 	}
 
 	return c.JSON(http.StatusOK, entity.PackUserDetailed(bundle.User, bundle.Profile))
@@ -531,7 +531,7 @@ func (h *Handler) Pin(c echo.Context) error {
 
 	var req PinRequest
 	if err := c.Bind(&req); err != nil || req.NoteID == "" {
-		return invalidParam(c)
+		return apierr.JSONInvalidParam(c)
 	}
 
 	if err := h.userService.PinNote(me.ID, req.NoteID); err != nil {
@@ -543,7 +543,7 @@ func (h *Handler) Pin(c echo.Context) error {
 		case errors.Is(err, user.ErrPinLimitExceeded):
 			return c.JSON(http.StatusBadRequest, apierr.Error("PIN_LIMIT_EXCEEDED", "You can not pin notes any more.", "72dab508-c64d-498f-8740-a8eec1ba385a"))
 		default:
-			return internalError(c)
+			return apierr.JSONInternalError(c)
 		}
 	}
 
@@ -556,23 +556,15 @@ func (h *Handler) Unpin(c echo.Context) error {
 
 	var req PinRequest
 	if err := c.Bind(&req); err != nil || req.NoteID == "" {
-		return invalidParam(c)
+		return apierr.JSONInvalidParam(c)
 	}
 
 	if err := h.userService.UnpinNote(me.ID, req.NoteID); err != nil {
 		if errors.Is(err, user.ErrPinNotFound) {
 			return c.JSON(http.StatusNotFound, apierr.Error("NO_SUCH_NOTE", "No such note.", "24fcbfc6-2e37-42b6-8388-c29b32725715"))
 		}
-		return internalError(c)
+		return apierr.JSONInternalError(c)
 	}
 
 	return h.Me(c)
-}
-
-func invalidParam(c echo.Context) error {
-	return c.JSON(http.StatusBadRequest, apierr.InvalidParam())
-}
-
-func internalError(c echo.Context) error {
-	return c.JSON(http.StatusInternalServerError, apierr.InternalError())
 }

--- a/internal/api/i/handler_stubs.go
+++ b/internal/api/i/handler_stubs.go
@@ -112,12 +112,12 @@ func (h *Handler) UpdateEmail(c echo.Context) error {
 		Email    *string `json:"email"`
 	}
 	if err := c.Bind(&req); err != nil {
-		return invalidParam(c)
+		return apierr.JSONInvalidParam(c)
 	}
 
 	profile := h.userService.GetProfile(u.ID)
 	if profile == nil || profile.Password == nil {
-		return internalError(c)
+		return apierr.JSONInternalError(c)
 	}
 
 	// パスワード検証
@@ -162,7 +162,7 @@ func (h *Handler) UpdateEmail(c echo.Context) error {
 	}
 
 	if err := h.userService.UpdateProfileFields(u.ID, fields); err != nil {
-		return internalError(c)
+		return apierr.JSONInternalError(c)
 	}
 
 	return h.Me(c)
@@ -175,7 +175,7 @@ func (h *Handler) VerifyEmail(c echo.Context) error {
 		Code string `json:"code"`
 	}
 	if err := c.Bind(&req); err != nil || req.Code == "" {
-		return invalidParam(c)
+		return apierr.JSONInvalidParam(c)
 	}
 
 	profile, err := h.userService.FindProfileByVerifyCode(req.Code)
@@ -187,7 +187,7 @@ func (h *Handler) VerifyEmail(c echo.Context) error {
 		"emailVerified":   true,
 		"emailVerifyCode": nil,
 	}); verr != nil {
-		return internalError(c)
+		return apierr.JSONInternalError(c)
 	}
 
 	return c.NoContent(http.StatusNoContent)

--- a/internal/api/i/handler_test.go
+++ b/internal/api/i/handler_test.go
@@ -944,3 +944,15 @@ func TestRegistryRemove_InvalidParam(t *testing.T) {
 	rec := post(h.RegistryRemove, `{}`, &model.User{ID: "u1"})
 	assert.Equal(t, http.StatusBadRequest, rec.Code)
 }
+
+// --- Handler setters ---
+
+func TestSetServerURL(t *testing.T) {
+	h, _, _, _ := newTestHandler(t)
+	h.SetServerURL("https://example.com")
+}
+
+func TestSetEmailSender(t *testing.T) {
+	h, _, _, _ := newTestHandler(t)
+	h.SetEmailSender(func(to, subject, body string) {})
+}

--- a/internal/api/mute/handler.go
+++ b/internal/api/mute/handler.go
@@ -33,7 +33,7 @@ func (h *Handler) Create(c echo.Context) error {
 	user := middleware.GetUser(c)
 	var req CreateRequest
 	if err := c.Bind(&req); err != nil || req.UserID == "" {
-		return invalidParam(c)
+		return apierr.JSONInvalidParam(c)
 	}
 
 	var expires *time.Time
@@ -53,7 +53,7 @@ func (h *Handler) Create(c echo.Context) error {
 				},
 			})
 		case errors.Is(err, coremuting.ErrMuteeNotFound):
-			return noSuchUser(c)
+			return apierr.JSONNoSuchUser(c)
 		case errors.Is(err, coremuting.ErrAlreadyMuting):
 			return c.JSON(http.StatusBadRequest, map[string]any{
 				"error": map[string]any{
@@ -63,7 +63,7 @@ func (h *Handler) Create(c echo.Context) error {
 				},
 			})
 		}
-		return internalError(c)
+		return apierr.JSONInternalError(c)
 	}
 	return c.NoContent(http.StatusNoContent)
 }
@@ -78,7 +78,7 @@ func (h *Handler) Delete(c echo.Context) error {
 	user := middleware.GetUser(c)
 	var req PairRequest
 	if err := c.Bind(&req); err != nil || req.UserID == "" {
-		return invalidParam(c)
+		return apierr.JSONInvalidParam(c)
 	}
 	if err := h.svc.Unmute(user.ID, req.UserID); err != nil {
 		switch {
@@ -99,7 +99,7 @@ func (h *Handler) Delete(c echo.Context) error {
 				},
 			})
 		}
-		return internalError(c)
+		return apierr.JSONInternalError(c)
 	}
 	return c.NoContent(http.StatusNoContent)
 }
@@ -115,7 +115,7 @@ func (h *Handler) List(c echo.Context) error {
 	user := middleware.GetUser(c)
 	var req ListRequest
 	if err := c.Bind(&req); err != nil {
-		return invalidParam(c)
+		return apierr.JSONInvalidParam(c)
 	}
 	if req.Limit <= 0 {
 		req.Limit = 30
@@ -125,7 +125,7 @@ func (h *Handler) List(c echo.Context) error {
 	}
 	rows, err := h.svc.List(user.ID, req.Limit, req.Offset)
 	if err != nil {
-		return internalError(c)
+		return apierr.JSONInternalError(c)
 	}
 	out := make([]map[string]any, 0, len(rows))
 	for _, m := range rows {
@@ -139,16 +139,4 @@ func (h *Handler) List(c echo.Context) error {
 		out = append(out, entry)
 	}
 	return c.JSON(http.StatusOK, out)
-}
-
-func invalidParam(c echo.Context) error {
-	return c.JSON(http.StatusBadRequest, apierr.InvalidParam())
-}
-
-func internalError(c echo.Context) error {
-	return c.JSON(http.StatusInternalServerError, apierr.InternalError())
-}
-
-func noSuchUser(c echo.Context) error {
-	return c.JSON(http.StatusNotFound, apierr.NoSuchUser())
 }

--- a/internal/api/notes/handler.go
+++ b/internal/api/notes/handler.go
@@ -124,7 +124,7 @@ func (h *Handler) Create(c echo.Context) error {
 
 	var req CreateRequest
 	if err := c.Bind(&req); err != nil {
-		return invalidParam(c)
+		return apierr.JSONInvalidParam(c)
 	}
 
 	in := note.CreateInput{
@@ -180,7 +180,7 @@ func (h *Handler) Create(c echo.Context) error {
 				},
 			})
 		}
-		return internalError(c)
+		return apierr.JSONInternalError(c)
 	}
 
 	packed := entity.PackNote(created, h.idGen)
@@ -201,13 +201,13 @@ type ShowRequest struct {
 func (h *Handler) Show(c echo.Context) error {
 	var req ShowRequest
 	if err := c.Bind(&req); err != nil || req.NoteID == "" {
-		return invalidParam(c)
+		return apierr.JSONInvalidParam(c)
 	}
 
 	viewer := middleware.GetUser(c)
 	n, err := h.lookupVisible(viewer, req.NoteID)
 	if err != nil {
-		return noSuchNote(c)
+		return apierr.JSONNoSuchNote(c)
 	}
 
 	packed := entity.PackNote(n, h.idGen)
@@ -238,7 +238,7 @@ func (h *Handler) Delete(c echo.Context) error {
 
 	var req DeleteRequest
 	if err := c.Bind(&req); err != nil || req.NoteID == "" {
-		return invalidParam(c)
+		return apierr.JSONInvalidParam(c)
 	}
 
 	if err := h.deleteService.Delete(user, req.NoteID); err != nil {
@@ -260,7 +260,7 @@ func (h *Handler) Delete(c echo.Context) error {
 				},
 			})
 		default:
-			return internalError(c)
+			return apierr.JSONInternalError(c)
 		}
 	}
 
@@ -308,7 +308,7 @@ func (h *Handler) Children(c echo.Context) error {
 func (h *Handler) serveList(c echo.Context, fn func(*model.User, listRequest) ([]*model.Note, error)) error {
 	var req listRequest
 	if err := c.Bind(&req); err != nil || req.NoteID == "" {
-		return invalidParam(c)
+		return apierr.JSONInvalidParam(c)
 	}
 	req.normalize()
 
@@ -316,9 +316,9 @@ func (h *Handler) serveList(c echo.Context, fn func(*model.User, listRequest) ([
 	notes, err := fn(viewer, req)
 	if err != nil {
 		if errors.Is(err, note.ErrNoteNotFound) {
-			return noSuchNote(c)
+			return apierr.JSONNoSuchNote(c)
 		}
-		return internalError(c)
+		return apierr.JSONInternalError(c)
 	}
 	return c.JSON(http.StatusOK, h.packMany(notes, viewer))
 }
@@ -344,10 +344,10 @@ type SearchRequest struct {
 func (h *Handler) Search(c echo.Context) error {
 	var req SearchRequest
 	if err := c.Bind(&req); err != nil {
-		return invalidParam(c)
+		return apierr.JSONInvalidParam(c)
 	}
 	if h.searchService == nil {
-		return internalError(c)
+		return apierr.JSONInternalError(c)
 	}
 	if req.Limit <= 0 {
 		req.Limit = 10
@@ -384,9 +384,9 @@ func (h *Handler) Search(c echo.Context) error {
 		// 空クエリは invalidParam として返す。
 		// それ以外のエラー (DB障害など) はinternalErrorで返す。
 		if errors.Is(err, search.ErrEmptyQuery) {
-			return invalidParam(c)
+			return apierr.JSONInvalidParam(c)
 		}
-		return internalError(c)
+		return apierr.JSONInternalError(c)
 	}
 	return c.JSON(http.StatusOK, h.packMany(notes, viewer))
 }
@@ -395,13 +395,13 @@ func (h *Handler) Search(c echo.Context) error {
 func (h *Handler) State(c echo.Context) error {
 	var req ShowRequest
 	if err := c.Bind(&req); err != nil || req.NoteID == "" {
-		return invalidParam(c)
+		return apierr.JSONInvalidParam(c)
 	}
 	viewer := middleware.GetUser(c)
 	st, err := h.queryService.State(viewer, req.NoteID)
 	if err != nil {
 		// 現状QueryService.StateはErrNoteNotFound以外を返さない
-		return noSuchNote(c)
+		return apierr.JSONNoSuchNote(c)
 	}
 	return c.JSON(http.StatusOK, st)
 }
@@ -416,7 +416,7 @@ type ConversationRequest struct {
 func (h *Handler) Conversation(c echo.Context) error {
 	var req ConversationRequest
 	if err := c.Bind(&req); err != nil || req.NoteID == "" {
-		return invalidParam(c)
+		return apierr.JSONInvalidParam(c)
 	}
 	if req.Limit <= 0 {
 		req.Limit = 10
@@ -429,7 +429,7 @@ func (h *Handler) Conversation(c echo.Context) error {
 	notes, err := h.queryService.Conversation(viewer, req.NoteID, req.Limit)
 	if err != nil {
 		// 現状QueryService.ConversationはErrNoteNotFound以外を返さない
-		return noSuchNote(c)
+		return apierr.JSONNoSuchNote(c)
 	}
 	return c.JSON(http.StatusOK, h.packMany(notes, viewer))
 }
@@ -536,16 +536,4 @@ func (h *Handler) resolveViewerFields(notes []entity.NoteEntity, viewer *model.U
 			}
 		}
 	}
-}
-
-func noSuchNote(c echo.Context) error {
-	return c.JSON(http.StatusNotFound, apierr.NoSuchNote())
-}
-
-func invalidParam(c echo.Context) error {
-	return c.JSON(http.StatusBadRequest, apierr.InvalidParam())
-}
-
-func internalError(c echo.Context) error {
-	return c.JSON(http.StatusInternalServerError, apierr.InternalError())
 }

--- a/internal/api/notes/polls_handler.go
+++ b/internal/api/notes/polls_handler.go
@@ -5,6 +5,7 @@ import (
 	"net/http"
 
 	"github.com/labstack/echo/v4"
+	"github.com/shiroha-a/mk/internal/api/apierr"
 	"github.com/shiroha-a/mk/internal/core/poll"
 	"github.com/shiroha-a/mk/internal/server/middleware"
 )
@@ -20,13 +21,13 @@ func (h *Handler) PollsVote(c echo.Context) error {
 	user := middleware.GetUser(c)
 	var req PollVoteRequest
 	if err := c.Bind(&req); err != nil || req.NoteID == "" || req.Choice == nil {
-		return invalidParam(c)
+		return apierr.JSONInvalidParam(c)
 	}
 
 	if err := h.pollService.Vote(user, req.NoteID, *req.Choice); err != nil {
 		switch {
 		case errors.Is(err, poll.ErrNoteNotFound), errors.Is(err, poll.ErrNoPoll):
-			return noSuchNote(c)
+			return apierr.JSONNoSuchNote(c)
 		case errors.Is(err, poll.ErrNoteNotVisible):
 			return c.JSON(http.StatusForbidden, map[string]any{
 				"error": map[string]any{
@@ -60,7 +61,7 @@ func (h *Handler) PollsVote(c echo.Context) error {
 				},
 			})
 		}
-		return internalError(c)
+		return apierr.JSONInternalError(c)
 	}
 	return c.NoContent(http.StatusNoContent)
 }

--- a/internal/api/notes/reactions_handler.go
+++ b/internal/api/notes/reactions_handler.go
@@ -5,6 +5,7 @@ import (
 	"net/http"
 
 	"github.com/labstack/echo/v4"
+	"github.com/shiroha-a/mk/internal/api/apierr"
 	"github.com/shiroha-a/mk/internal/core/reaction"
 	"github.com/shiroha-a/mk/internal/server/middleware"
 )
@@ -21,14 +22,14 @@ func (h *Handler) ReactionsCreate(c echo.Context) error {
 
 	var req ReactionCreateRequest
 	if err := c.Bind(&req); err != nil || req.NoteID == "" {
-		return invalidParam(c)
+		return apierr.JSONInvalidParam(c)
 	}
 
 	_, err := h.reactionService.Create(user, req.NoteID, req.Reaction)
 	if err != nil {
 		switch {
 		case errors.Is(err, reaction.ErrNoteNotFound):
-			return noSuchNote(c)
+			return apierr.JSONNoSuchNote(c)
 		case errors.Is(err, reaction.ErrNoteNotVisible):
 			return c.JSON(http.StatusForbidden, map[string]any{
 				"error": map[string]any{
@@ -62,7 +63,7 @@ func (h *Handler) ReactionsCreate(c echo.Context) error {
 				},
 			})
 		}
-		return internalError(c)
+		return apierr.JSONInternalError(c)
 	}
 	return c.NoContent(http.StatusNoContent)
 }
@@ -78,13 +79,13 @@ func (h *Handler) ReactionsDelete(c echo.Context) error {
 
 	var req ReactionDeleteRequest
 	if err := c.Bind(&req); err != nil || req.NoteID == "" {
-		return invalidParam(c)
+		return apierr.JSONInvalidParam(c)
 	}
 
 	if err := h.reactionService.Delete(user, req.NoteID); err != nil {
 		switch {
 		case errors.Is(err, reaction.ErrNoteNotFound):
-			return noSuchNote(c)
+			return apierr.JSONNoSuchNote(c)
 		case errors.Is(err, reaction.ErrReactionNotFound):
 			return c.JSON(http.StatusNotFound, map[string]any{
 				"error": map[string]any{
@@ -94,7 +95,7 @@ func (h *Handler) ReactionsDelete(c echo.Context) error {
 				},
 			})
 		}
-		return internalError(c)
+		return apierr.JSONInternalError(c)
 	}
 	return c.NoContent(http.StatusNoContent)
 }
@@ -112,7 +113,7 @@ type ReactionsListRequest struct {
 func (h *Handler) Reactions(c echo.Context) error {
 	var req ReactionsListRequest
 	if err := c.Bind(&req); err != nil || req.NoteID == "" {
-		return invalidParam(c)
+		return apierr.JSONInvalidParam(c)
 	}
 	if req.Limit <= 0 {
 		req.Limit = 10
@@ -126,9 +127,9 @@ func (h *Handler) Reactions(c echo.Context) error {
 	if err != nil {
 		switch {
 		case errors.Is(err, reaction.ErrNoteNotFound), errors.Is(err, reaction.ErrNoteNotVisible):
-			return noSuchNote(c)
+			return apierr.JSONNoSuchNote(c)
 		}
-		return internalError(c)
+		return apierr.JSONInternalError(c)
 	}
 
 	out := make([]map[string]any, 0, len(rows))

--- a/internal/api/notes/timeline_handler.go
+++ b/internal/api/notes/timeline_handler.go
@@ -5,6 +5,7 @@ import (
 	"time"
 
 	"github.com/labstack/echo/v4"
+	"github.com/shiroha-a/mk/internal/api/apierr"
 	"github.com/shiroha-a/mk/internal/core/timeline"
 	"github.com/shiroha-a/mk/internal/model"
 	"github.com/shiroha-a/mk/internal/server/middleware"
@@ -100,7 +101,7 @@ func (h *Handler) serveTimeline(
 ) error {
 	var req TimelineRequest
 	if err := c.Bind(&req); err != nil {
-		return invalidParam(c)
+		return apierr.JSONInvalidParam(c)
 	}
 	req.normalize()
 
@@ -133,7 +134,7 @@ func (h *Handler) serveTimeline(
 	if err != nil {
 		// requireAuthでviewer nilチェックは事前に行っているので、Service層からの
 		// ErrUnauthenticatedはここには到達しない。残りはRedis等の障害のみ。
-		return internalError(c)
+		return apierr.JSONInternalError(c)
 	}
 	return c.JSON(http.StatusOK, h.packMany(notes, viewer))
 }

--- a/internal/api/notifications/handler.go
+++ b/internal/api/notifications/handler.go
@@ -47,12 +47,12 @@ func (h *Handler) Show(c echo.Context) error {
 	user := middleware.GetUser(c)
 	var req ListRequest
 	if err := c.Bind(&req); err != nil {
-		return invalidParam(c)
+		return apierr.JSONInvalidParam(c)
 	}
 
 	rows, err := h.svc.List(c.Request().Context(), user.ID, req.Limit)
 	if err != nil {
-		return internalError(c)
+		return apierr.JSONInternalError(c)
 	}
 
 	// includeTypes / excludeTypes フィルタ
@@ -114,17 +114,9 @@ func (h *Handler) Show(c echo.Context) error {
 func (h *Handler) MarkAllAsRead(c echo.Context) error {
 	user := middleware.GetUser(c)
 	if err := h.svc.MarkAllAsRead(c.Request().Context(), user.ID); err != nil {
-		return internalError(c)
+		return apierr.JSONInternalError(c)
 	}
 	return c.NoContent(http.StatusNoContent)
-}
-
-func invalidParam(c echo.Context) error {
-	return c.JSON(http.StatusBadRequest, apierr.InvalidParam())
-}
-
-func internalError(c echo.Context) error {
-	return c.JSON(http.StatusInternalServerError, apierr.InternalError())
 }
 
 // Create handles POST /api/notifications/create.

--- a/internal/api/pages/handler.go
+++ b/internal/api/pages/handler.go
@@ -44,7 +44,7 @@ func (h *Handler) Create(c echo.Context) error {
 	user := middleware.GetUser(c)
 	var req CreateRequest
 	if err := c.Bind(&req); err != nil || req.Title == "" || req.Name == "" {
-		return invalidParam(c)
+		return apierr.JSONInvalidParam(c)
 	}
 	p, err := h.svc.Create(corepage.CreateInput{
 		OwnerID:             user.ID,
@@ -64,7 +64,7 @@ func (h *Handler) Create(c echo.Context) error {
 		if errors.Is(err, corepage.ErrPageNameConflict) {
 			return nameConflict(c)
 		}
-		return internalError(c)
+		return apierr.JSONInternalError(c)
 	}
 	return c.JSON(http.StatusOK, pageToMap(p))
 }
@@ -82,7 +82,7 @@ func (h *Handler) Show(c echo.Context) error {
 	user := middleware.GetUser(c)
 	var req ShowRequest
 	if err := c.Bind(&req); err != nil {
-		return invalidParam(c)
+		return apierr.JSONInvalidParam(c)
 	}
 	requesterID := ""
 	if user != nil {
@@ -98,11 +98,11 @@ func (h *Handler) Show(c echo.Context) error {
 	case req.UserID != "" && req.Name != "":
 		p, err = h.svc.ShowByName(requesterID, req.UserID, req.Name)
 	default:
-		return invalidParam(c)
+		return apierr.JSONInvalidParam(c)
 	}
 	if err != nil {
 		if errors.Is(err, corepage.ErrAccessDenied) {
-			return accessDenied(c)
+			return apierr.JSONAccessDenied(c)
 		}
 		return notFound(c)
 	}
@@ -130,7 +130,7 @@ func (h *Handler) Update(c echo.Context) error {
 	user := middleware.GetUser(c)
 	var req UpdateRequest
 	if err := c.Bind(&req); err != nil || req.PageID == "" {
-		return invalidParam(c)
+		return apierr.JSONInvalidParam(c)
 	}
 	in := corepage.UpdateInput{
 		Title:               req.Title,
@@ -161,14 +161,14 @@ func (h *Handler) Update(c echo.Context) error {
 		case errors.Is(err, corepage.ErrPageNotFound):
 			return notFound(c)
 		case errors.Is(err, corepage.ErrAccessDenied):
-			return accessDenied(c)
+			return apierr.JSONAccessDenied(c)
 		case errors.Is(err, corepage.ErrPageNameRequired),
 			errors.Is(err, corepage.ErrPageTitleRequired):
-			return invalidParam(c)
+			return apierr.JSONInvalidParam(c)
 		case errors.Is(err, corepage.ErrPageNameConflict):
 			return nameConflict(c)
 		}
-		return internalError(c)
+		return apierr.JSONInternalError(c)
 	}
 	return c.JSON(http.StatusOK, pageToMap(p))
 }
@@ -183,16 +183,16 @@ func (h *Handler) Delete(c echo.Context) error {
 	user := middleware.GetUser(c)
 	var req DeleteRequest
 	if err := c.Bind(&req); err != nil || req.PageID == "" {
-		return invalidParam(c)
+		return apierr.JSONInvalidParam(c)
 	}
 	if err := h.svc.Delete(user.ID, req.PageID); err != nil {
 		switch {
 		case errors.Is(err, corepage.ErrPageNotFound):
 			return notFound(c)
 		case errors.Is(err, corepage.ErrAccessDenied):
-			return accessDenied(c)
+			return apierr.JSONAccessDenied(c)
 		}
-		return internalError(c)
+		return apierr.JSONInternalError(c)
 	}
 	return c.NoContent(http.StatusNoContent)
 }
@@ -208,11 +208,11 @@ func (h *Handler) My(c echo.Context) error {
 	user := middleware.GetUser(c)
 	var req MyRequest
 	if err := c.Bind(&req); err != nil {
-		return invalidParam(c)
+		return apierr.JSONInvalidParam(c)
 	}
 	rows, err := h.svc.ListByUser(user.ID, req.Limit, req.Offset)
 	if err != nil {
-		return internalError(c)
+		return apierr.JSONInternalError(c)
 	}
 	return c.JSON(http.StatusOK, pagesToList(rows))
 }
@@ -227,11 +227,11 @@ type FeaturedRequest struct {
 func (h *Handler) Featured(c echo.Context) error {
 	var req FeaturedRequest
 	if err := c.Bind(&req); err != nil {
-		return invalidParam(c)
+		return apierr.JSONInvalidParam(c)
 	}
 	rows, err := h.svc.Featured(req.Limit, req.Offset)
 	if err != nil {
-		return internalError(c)
+		return apierr.JSONInternalError(c)
 	}
 	return c.JSON(http.StatusOK, pagesToList(rows))
 }
@@ -246,18 +246,18 @@ func (h *Handler) Like(c echo.Context) error {
 	user := middleware.GetUser(c)
 	var req LikeRequest
 	if err := c.Bind(&req); err != nil || req.PageID == "" {
-		return invalidParam(c)
+		return apierr.JSONInvalidParam(c)
 	}
 	if err := h.svc.Like(user.ID, req.PageID); err != nil {
 		switch {
 		case errors.Is(err, corepage.ErrPageNotFound):
 			return notFound(c)
 		case errors.Is(err, corepage.ErrAccessDenied):
-			return accessDenied(c)
+			return apierr.JSONAccessDenied(c)
 		case errors.Is(err, corepage.ErrAlreadyLiked):
 			return alreadyLiked(c)
 		}
-		return internalError(c)
+		return apierr.JSONInternalError(c)
 	}
 	return c.NoContent(http.StatusNoContent)
 }
@@ -267,7 +267,7 @@ func (h *Handler) Unlike(c echo.Context) error {
 	user := middleware.GetUser(c)
 	var req LikeRequest
 	if err := c.Bind(&req); err != nil || req.PageID == "" {
-		return invalidParam(c)
+		return apierr.JSONInvalidParam(c)
 	}
 	if err := h.svc.Unlike(user.ID, req.PageID); err != nil {
 		switch {
@@ -276,7 +276,7 @@ func (h *Handler) Unlike(c echo.Context) error {
 		case errors.Is(err, corepage.ErrNotLiked):
 			return notLiked(c)
 		}
-		return internalError(c)
+		return apierr.JSONInternalError(c)
 	}
 	return c.NoContent(http.StatusNoContent)
 }
@@ -318,20 +318,8 @@ func rawJSON(b []byte) any {
 	return json.RawMessage(b)
 }
 
-func invalidParam(c echo.Context) error {
-	return c.JSON(http.StatusBadRequest, apierr.InvalidParam())
-}
-
-func internalError(c echo.Context) error {
-	return c.JSON(http.StatusInternalServerError, apierr.InternalError())
-}
-
 func notFound(c echo.Context) error {
 	return c.JSON(http.StatusNotFound, apierr.Error("NO_SUCH_PAGE", "No such page.", "222120c0-3ead-4528-811b-b96f233388d7"))
-}
-
-func accessDenied(c echo.Context) error {
-	return c.JSON(http.StatusForbidden, apierr.AccessDenied())
 }
 
 func nameConflict(c echo.Context) error {

--- a/internal/api/renotemute/handler.go
+++ b/internal/api/renotemute/handler.go
@@ -31,7 +31,7 @@ func (h *Handler) Create(c echo.Context) error {
 	user := middleware.GetUser(c)
 	var req PairRequest
 	if err := c.Bind(&req); err != nil || req.UserID == "" {
-		return invalidParam(c)
+		return apierr.JSONInvalidParam(c)
 	}
 	if _, err := h.svc.Mute(user.ID, req.UserID); err != nil {
 		switch {
@@ -44,7 +44,7 @@ func (h *Handler) Create(c echo.Context) error {
 				},
 			})
 		case errors.Is(err, coremuting.ErrMuteeNotFound):
-			return noSuchUser(c)
+			return apierr.JSONNoSuchUser(c)
 		case errors.Is(err, coremuting.ErrAlreadyMuting):
 			return c.JSON(http.StatusBadRequest, map[string]any{
 				"error": map[string]any{
@@ -54,7 +54,7 @@ func (h *Handler) Create(c echo.Context) error {
 				},
 			})
 		}
-		return internalError(c)
+		return apierr.JSONInternalError(c)
 	}
 	return c.NoContent(http.StatusNoContent)
 }
@@ -64,7 +64,7 @@ func (h *Handler) Delete(c echo.Context) error {
 	user := middleware.GetUser(c)
 	var req PairRequest
 	if err := c.Bind(&req); err != nil || req.UserID == "" {
-		return invalidParam(c)
+		return apierr.JSONInvalidParam(c)
 	}
 	if err := h.svc.Unmute(user.ID, req.UserID); err != nil {
 		switch {
@@ -85,7 +85,7 @@ func (h *Handler) Delete(c echo.Context) error {
 				},
 			})
 		}
-		return internalError(c)
+		return apierr.JSONInternalError(c)
 	}
 	return c.NoContent(http.StatusNoContent)
 }
@@ -101,7 +101,7 @@ func (h *Handler) List(c echo.Context) error {
 	user := middleware.GetUser(c)
 	var req ListRequest
 	if err := c.Bind(&req); err != nil {
-		return invalidParam(c)
+		return apierr.JSONInvalidParam(c)
 	}
 	if req.Limit <= 0 {
 		req.Limit = 30
@@ -111,7 +111,7 @@ func (h *Handler) List(c echo.Context) error {
 	}
 	rows, err := h.svc.List(user.ID, req.Limit, req.Offset)
 	if err != nil {
-		return internalError(c)
+		return apierr.JSONInternalError(c)
 	}
 	out := make([]map[string]any, 0, len(rows))
 	for _, m := range rows {
@@ -121,16 +121,4 @@ func (h *Handler) List(c echo.Context) error {
 		})
 	}
 	return c.JSON(http.StatusOK, out)
-}
-
-func invalidParam(c echo.Context) error {
-	return c.JSON(http.StatusBadRequest, apierr.InvalidParam())
-}
-
-func internalError(c echo.Context) error {
-	return c.JSON(http.StatusInternalServerError, apierr.InternalError())
-}
-
-func noSuchUser(c echo.Context) error {
-	return c.JSON(http.StatusNotFound, apierr.NoSuchUser())
 }

--- a/internal/api/users/handler.go
+++ b/internal/api/users/handler.go
@@ -108,7 +108,7 @@ type ShowRequest struct {
 func (h *Handler) Show(c echo.Context) error {
 	var req ShowRequest
 	if err := c.Bind(&req); err != nil {
-		return invalidParam(c)
+		return apierr.JSONInvalidParam(c)
 	}
 
 	if req.UserID == nil && req.Username == nil {
@@ -133,7 +133,7 @@ func (h *Handler) Show(c echo.Context) error {
 
 	if err != nil {
 		// Service.ShowByID/ShowByUsernameはErrUserNotFoundのみ返す
-		return noSuchUser(c)
+		return apierr.JSONNoSuchUser(c)
 	}
 
 	// チャート集計はベストエフォート。匿名訪問者は visitor key として
@@ -220,7 +220,7 @@ type SearchRequest struct {
 func (h *Handler) Search(c echo.Context) error {
 	var req SearchRequest
 	if err := c.Bind(&req); err != nil {
-		return invalidParam(c)
+		return apierr.JSONInvalidParam(c)
 	}
 	if req.Limit <= 0 {
 		req.Limit = 10
@@ -228,7 +228,7 @@ func (h *Handler) Search(c echo.Context) error {
 
 	users, err := h.userService.Search(req.Query, req.Limit, req.Offset)
 	if err != nil {
-		return internalError(c)
+		return apierr.JSONInternalError(c)
 	}
 
 	out := make([]entity.UserDetailed, 0, len(users))
@@ -251,7 +251,7 @@ type NotesRequest struct {
 func (h *Handler) Notes(c echo.Context) error {
 	var req NotesRequest
 	if err := c.Bind(&req); err != nil || req.UserID == "" {
-		return invalidParam(c)
+		return apierr.JSONInvalidParam(c)
 	}
 	if req.Limit <= 0 {
 		req.Limit = 10
@@ -261,12 +261,12 @@ func (h *Handler) Notes(c echo.Context) error {
 	}
 
 	if _, err := h.userService.ShowByID(req.UserID); err != nil {
-		return noSuchUser(c)
+		return apierr.JSONNoSuchUser(c)
 	}
 
 	notes, err := h.noteRepo.ListByUserID(req.UserID, req.UntilID, req.SinceID, req.Limit)
 	if err != nil {
-		return internalError(c)
+		return apierr.JSONInternalError(c)
 	}
 
 	out := make([]entity.NoteEntity, 0, len(notes))
@@ -298,7 +298,7 @@ func (h *Handler) Following(c echo.Context) error {
 func (h *Handler) listRelations(c echo.Context, followers bool) error {
 	var req FollowersRequest
 	if err := c.Bind(&req); err != nil || req.UserID == "" {
-		return invalidParam(c)
+		return apierr.JSONInvalidParam(c)
 	}
 	if req.Limit <= 0 {
 		req.Limit = 10
@@ -308,7 +308,7 @@ func (h *Handler) listRelations(c echo.Context, followers bool) error {
 	}
 
 	if _, err := h.userService.ShowByID(req.UserID); err != nil {
-		return noSuchUser(c)
+		return apierr.JSONNoSuchUser(c)
 	}
 
 	var (
@@ -321,7 +321,7 @@ func (h *Handler) listRelations(c echo.Context, followers bool) error {
 		rows, err = h.collectFollowing(req)
 	}
 	if err != nil {
-		return internalError(c)
+		return apierr.JSONInternalError(c)
 	}
 
 	return c.JSON(http.StatusOK, rows)
@@ -381,16 +381,4 @@ func (h *Handler) collectFollowing(req FollowersRequest) ([]relationItem, error)
 		out = append(out, item)
 	}
 	return out, nil
-}
-
-func internalError(c echo.Context) error {
-	return c.JSON(http.StatusInternalServerError, apierr.InternalError())
-}
-
-func invalidParam(c echo.Context) error {
-	return c.JSON(http.StatusBadRequest, apierr.InvalidParam())
-}
-
-func noSuchUser(c echo.Context) error {
-	return c.JSON(http.StatusNotFound, apierr.NoSuchUser())
 }

--- a/internal/api/users/handler_stubs.go
+++ b/internal/api/users/handler_stubs.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/labstack/echo/v4"
+	"github.com/shiroha-a/mk/internal/api/apierr"
 	"github.com/shiroha-a/mk/internal/entity"
 	"github.com/shiroha-a/mk/internal/model"
 	"github.com/shiroha-a/mk/internal/repository"
@@ -38,11 +39,11 @@ func (h *Handler) Achievements(c echo.Context) error {
 		UserID string `json:"userId"`
 	}
 	if err := c.Bind(&req); err != nil || req.UserID == "" {
-		return invalidParam(c)
+		return apierr.JSONInvalidParam(c)
 	}
 	bundle, err := h.userService.ShowByID(req.UserID)
 	if err != nil {
-		return noSuchUser(c)
+		return apierr.JSONNoSuchUser(c)
 	}
 	if bundle.Profile == nil || bundle.Profile.Achievements == nil {
 		return c.JSON(http.StatusOK, []any{})
@@ -93,7 +94,7 @@ func (h *Handler) UsersBulk(c echo.Context) error {
 		UserIDs []string `json:"userIds"`
 	}
 	if err := c.Bind(&req); err != nil {
-		return invalidParam(c)
+		return apierr.JSONInvalidParam(c)
 	}
 	if len(req.UserIDs) == 0 {
 		return c.JSON(http.StatusOK, []any{})
@@ -119,7 +120,7 @@ func (h *Handler) ListsFavorite(c echo.Context) error {
 		ListID string `json:"listId"`
 	}
 	if err := c.Bind(&req); err != nil || req.ListID == "" {
-		return invalidParam(c)
+		return apierr.JSONInvalidParam(c)
 	}
 	if h.userListFavoriteRepo == nil {
 		return c.NoContent(http.StatusNoContent)
@@ -134,7 +135,7 @@ func (h *Handler) ListsFavorite(c echo.Context) error {
 		UserListID: req.ListID,
 	}
 	if err := h.userListFavoriteRepo.Create(fav); err != nil {
-		return internalError(c)
+		return apierr.JSONInternalError(c)
 	}
 	return c.NoContent(http.StatusNoContent)
 }
@@ -146,13 +147,13 @@ func (h *Handler) ListsUnfavorite(c echo.Context) error {
 		ListID string `json:"listId"`
 	}
 	if err := c.Bind(&req); err != nil || req.ListID == "" {
-		return invalidParam(c)
+		return apierr.JSONInvalidParam(c)
 	}
 	if h.userListFavoriteRepo == nil {
 		return c.NoContent(http.StatusNoContent)
 	}
 	if err := h.userListFavoriteRepo.Delete(user.ID, req.ListID); err != nil {
-		return internalError(c)
+		return apierr.JSONInternalError(c)
 	}
 	return c.NoContent(http.StatusNoContent)
 }
@@ -166,7 +167,7 @@ func (h *Handler) ListsUpdate(c echo.Context) error {
 		IsPublic *bool  `json:"isPublic"`
 	}
 	if err := c.Bind(&req); err != nil || req.ListID == "" {
-		return invalidParam(c)
+		return apierr.JSONInvalidParam(c)
 	}
 	if h.userListRepo == nil {
 		return c.NoContent(http.StatusNoContent)
@@ -190,7 +191,7 @@ func (h *Handler) ListsUpdate(c echo.Context) error {
 	}
 	if len(fields) > 0 {
 		if err := h.userListRepo.UpdateList(req.ListID, fields); err != nil {
-			return internalError(c)
+			return apierr.JSONInternalError(c)
 		}
 	}
 	return c.JSON(http.StatusOK, list)
@@ -205,7 +206,7 @@ func (h *Handler) ListsUpdateMembership(c echo.Context) error {
 		WithReplies bool   `json:"withReplies"`
 	}
 	if err := c.Bind(&req); err != nil || req.ListID == "" || req.UserID == "" {
-		return invalidParam(c)
+		return apierr.JSONInvalidParam(c)
 	}
 	if h.userListRepo == nil {
 		return c.NoContent(http.StatusNoContent)
@@ -222,7 +223,7 @@ func (h *Handler) ListsUpdateMembership(c echo.Context) error {
 		if errors.Is(err, gorm.ErrRecordNotFound) {
 			return c.JSON(http.StatusNotFound, map[string]any{"error": map[string]any{"message": "No such user.", "code": "NO_SUCH_USER", "id": "588e7f72-c744-4a61-b180-d354e912bda2"}})
 		}
-		return internalError(c)
+		return apierr.JSONInternalError(c)
 	}
 	return c.NoContent(http.StatusNoContent)
 }


### PR DESCRIPTION
## Summary
- `apierr`にEcho向けヘルパー追加（`JSONInvalidParam`, `JSONInternalError`, `JSONNoSuchUser`, `JSONNoSuchNote`, `JSONAccessDenied`）
- 16パッケージの呼び出し側を直接`apierr.JSON*`に移行
- 共通系のローカルヘルパー関数（invalidParam/internalError/noSuchUser/noSuchNote/accessDenied）を削除

## 主な変更点
| 種類 | 変更 |
|------|------|
| 新規 | `internal/api/apierr/echo.go` + テスト（カバレッジ100%維持） |
| 置換 | `invalidParam(c)` → `apierr.JSONInvalidParam(c)` (122箇所) |
| 置換 | `internalError(c)` → `apierr.JSONInternalError(c)` (92箇所) |
| 置換 | `noSuchUser(c)` → `apierr.JSONNoSuchUser(c)` (7箇所) |
| 置換 | `noSuchNote(c)` → `apierr.JSONNoSuchNote(c)` (8箇所) |
| 置換 | `accessDenied(c)` → `apierr.JSONAccessDenied(c)` (17箇所) |
| 削除 | 各パッケージのローカルヘルパー関数 |

## 特記事項
- **charts package**: API互換性のため独自UUIDを保持する`invalidParam`/`internalError`はローカルに残す（#143のDevin指摘対応）
- **パッケージ固有関数**: `notFound`(NO_SUCH_CHANNEL等)、`alreadyLiked`、`nameConflict`等はローカルに維持

## 効果
- 22ファイル変更: +245 / -399 行（**154行削減**）
- エラーレスポンス生成が`apierr`に完全集約
- Issue #130（エラーレスポンス標準化）の主要部分が完了

## テスト
```bash
go test -race -count=1 ./internal/api/...
```
- 全42パッケージ通過
- apierr: 100%カバレッジ

Refs #130
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/shiroha-a/mk/pull/144" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
