### PR TITLE
Phase P2: WebSocket pong ack + shouldShare (#132 Phase 1)

### DIFF
--- a/internal/stream/channel.go
+++ b/internal/stream/channel.go
@@ -45,6 +45,19 @@ type ChannelContext interface {
 	Unsubscribe(topic string)
 }
 
+// ShareableChannel is an optional interface a Channel can implement to
+// signal that a single Connection should not hold multiple instances of the
+// same channel name simultaneously. 例: serverStats/queueStats のような
+// broadcast チャンネルは 1 接続につき 1 購読で十分。Dispatcher は connect
+// 時に既存の同名チャンネルを検出し、2 回目の接続を no-op にする。
+type ShareableChannel interface {
+	Channel
+	// ShouldShare reports whether this channel instance should be shared.
+	// true を返すと、同じ Connection 内の同名チャンネルへの追加 connect は
+	// 新しいエントリを作らずに無視される。
+	ShouldShare() bool
+}
+
 // ChannelFactory builds a new Channel for the given context. Channel name は
 // Misskey クライアントが connect.body.channel に指定する文字列 (e.g.
 // "homeTimeline").

--- a/internal/stream/dispatcher.go
+++ b/internal/stream/dispatcher.go
@@ -16,6 +16,7 @@ type PubSubBus interface {
 // list of pubsub topics.
 type channelEntry struct {
 	id      string
+	name    string // channel name from connect envelope (e.g. "homeTimeline")
 	channel Channel
 	topics  map[string]struct{}
 }
@@ -68,6 +69,7 @@ func (d *Dispatcher) handleConnect(body json.RawMessage) {
 		ID      string          `json:"id"`
 		Channel string          `json:"channel"`
 		Params  json.RawMessage `json:"params"`
+		Pong    bool            `json:"pong"`
 	}
 	if err := json.Unmarshal(body, &req); err != nil || req.ID == "" || req.Channel == "" {
 		return
@@ -84,7 +86,13 @@ func (d *Dispatcher) handleConnect(body json.RawMessage) {
 		d.mu.Unlock()
 		return
 	}
-	entry := &channelEntry{id: req.ID, topics: map[string]struct{}{}}
+	// shouldShare付きチャンネルで既に同名が接続済みなら新規作成しない
+	if d.hasShareableChannelLocked(req.Channel) {
+		d.mu.Unlock()
+		d.sendConnectedIfRequested(req.ID, req.Pong)
+		return
+	}
+	entry := &channelEntry{id: req.ID, name: req.Channel, topics: map[string]struct{}{}}
 	d.channels[req.ID] = entry
 	d.mu.Unlock()
 
@@ -92,6 +100,34 @@ func (d *Dispatcher) handleConnect(body json.RawMessage) {
 	ch := factory(ctx)
 	entry.channel = ch
 	ch.Init(req.Params)
+
+	d.sendConnectedIfRequested(req.ID, req.Pong)
+}
+
+// hasShareableChannelLocked checks if a shareable channel with the same name
+// already exists. mu must be held by the caller.
+func (d *Dispatcher) hasShareableChannelLocked(name string) bool {
+	for _, e := range d.channels {
+		if e.name != name || e.channel == nil {
+			continue
+		}
+		if sc, ok := e.channel.(ShareableChannel); ok && sc.ShouldShare() {
+			return true
+		}
+	}
+	return false
+}
+
+// sendConnectedIfRequested emits a `connected` envelope when the client
+// requested confirmation via pong=true in connect.
+func (d *Dispatcher) sendConnectedIfRequested(id string, pong bool) {
+	if !pong || d.conn == nil {
+		return
+	}
+	_ = d.conn.Send(map[string]any{
+		"type": "connected",
+		"body": map[string]any{"id": id},
+	})
 }
 
 // handleDisconnect tears down a previously-connected channel.

--- a/internal/stream/dispatcher_test.go
+++ b/internal/stream/dispatcher_test.go
@@ -369,3 +369,122 @@ func TestChannelContext_SendQueuesEnvelope(t *testing.T) {
 
 	require.Eventually(t, func() bool { return fc.writeCount() >= 1 }, time.Second, 10*time.Millisecond)
 }
+
+// --- pong ack ---
+
+func TestDispatcher_ConnectPongAck(t *testing.T) {
+	bus := newStubBus()
+	registry := NewRegistry()
+	registry.Register("test", func(ctx ChannelContext) Channel { return &fakeChannel{ctx: ctx} })
+
+	fc := newFakeConn()
+	conn := NewConnection("c1", &model.User{ID: "alice"}, fc)
+	d := NewDispatcher(conn, registry, bus)
+
+	go conn.Start()
+	defer conn.Close()
+
+	d.HandleClientMessage("connect", json.RawMessage(`{"id":"abc","channel":"test","pong":true}`))
+
+	// `connected` envelope should be queued on the connection
+	require.Eventually(t, func() bool { return fc.writeCount() >= 1 }, time.Second, 10*time.Millisecond)
+	fc.mu.Lock()
+	wrote := append([]byte(nil), fc.writes[0]...)
+	fc.mu.Unlock()
+	var env map[string]any
+	require.NoError(t, json.Unmarshal(wrote, &env))
+	assert.Equal(t, "connected", env["type"])
+	body := env["body"].(map[string]any)
+	assert.Equal(t, "abc", body["id"])
+}
+
+func TestDispatcher_ConnectNoPong_NoAck(t *testing.T) {
+	bus := newStubBus()
+	registry := NewRegistry()
+	registry.Register("test", func(ctx ChannelContext) Channel { return &fakeChannel{ctx: ctx} })
+
+	fc := newFakeConn()
+	conn := NewConnection("c1", &model.User{ID: "alice"}, fc)
+	d := NewDispatcher(conn, registry, bus)
+
+	go conn.Start()
+	defer conn.Close()
+
+	d.HandleClientMessage("connect", json.RawMessage(`{"id":"abc","channel":"test"}`))
+	// No `connected` envelope when pong is absent
+	time.Sleep(50 * time.Millisecond)
+	assert.Equal(t, 0, fc.writeCount())
+}
+
+// --- ShouldShare ---
+
+type shareableFakeChannel struct {
+	fakeChannel
+}
+
+func (s *shareableFakeChannel) ShouldShare() bool { return true }
+
+func TestDispatcher_ShareableChannel_DuplicateIgnored(t *testing.T) {
+	bus := newStubBus()
+	registry := NewRegistry()
+	registry.Register("shared", func(ctx ChannelContext) Channel {
+		return &shareableFakeChannel{fakeChannel: fakeChannel{ctx: ctx}}
+	})
+
+	conn := NewConnection("c1", &model.User{ID: "alice"}, newFakeConn())
+	d := NewDispatcher(conn, registry, bus)
+
+	d.HandleClientMessage("connect", json.RawMessage(`{"id":"a","channel":"shared"}`))
+	d.HandleClientMessage("connect", json.RawMessage(`{"id":"b","channel":"shared"}`))
+
+	// 1回目の接続でtopic-aがsubscribeされ、2回目はスキップされるので
+	// subscribe回数は1のはず
+	bus.mu.Lock()
+	defer bus.mu.Unlock()
+	count := 0
+	for _, t := range bus.subscribed {
+		if t == "topic-a" {
+			count++
+		}
+	}
+	assert.Equal(t, 1, count)
+}
+
+func TestDispatcher_NonShareableChannel_AllowsMultiple(t *testing.T) {
+	bus := newStubBus()
+	registry := NewRegistry()
+	registry.Register("test", func(ctx ChannelContext) Channel { return &fakeChannel{ctx: ctx} })
+
+	conn := NewConnection("c1", &model.User{ID: "alice"}, newFakeConn())
+	d := NewDispatcher(conn, registry, bus)
+
+	d.HandleClientMessage("connect", json.RawMessage(`{"id":"a","channel":"test"}`))
+	d.HandleClientMessage("connect", json.RawMessage(`{"id":"b","channel":"test"}`))
+
+	// non-shareable なら2つのエントリが作られる
+	d.mu.RLock()
+	defer d.mu.RUnlock()
+	assert.Len(t, d.channels, 2)
+}
+
+func TestDispatcher_ShareablePongAck(t *testing.T) {
+	bus := newStubBus()
+	registry := NewRegistry()
+	registry.Register("shared", func(ctx ChannelContext) Channel {
+		return &shareableFakeChannel{fakeChannel: fakeChannel{ctx: ctx}}
+	})
+
+	fc := newFakeConn()
+	conn := NewConnection("c1", &model.User{ID: "alice"}, fc)
+	d := NewDispatcher(conn, registry, bus)
+
+	go conn.Start()
+	defer conn.Close()
+
+	// 1回目: 作成される
+	d.HandleClientMessage("connect", json.RawMessage(`{"id":"a","channel":"shared","pong":true}`))
+	// 2回目: 既存共有なのでエントリは作られないが、pongはACKされる
+	d.HandleClientMessage("connect", json.RawMessage(`{"id":"b","channel":"shared","pong":true}`))
+
+	require.Eventually(t, func() bool { return fc.writeCount() >= 2 }, time.Second, 10*time.Millisecond)
+}


### PR DESCRIPTION
## Summary
- `connect`メッセージの `pong: true` に対する `connected` 応答を実装
- `ShareableChannel` オプションインターフェースを追加、shouldShare=true チャンネルの重複接続を防止

## 分割方針

issue #132は4機能を含むため、段階的に実装する方針:
- **Phase 1（本PR）**: pong応答 + shouldShare
- Phase 2（後続）: OAuth2スコープチェック (`RequiredPermission`)
- Phase 3（後続）: Init() シグネチャ変更によるパラメータバリデーション強化

## 主な変更点
| ファイル | 内容 |
|---------|------|
| `stream/channel.go` | `ShareableChannel` オプションインターフェース追加 |
| `stream/dispatcher.go` | handleConnect に pong 応答 + shouldShare 重複チェック。channelEntry にチャンネル名追加 |

## 動作

### pong応答
```json
// Client → Server
{"type":"connect","body":{"id":"abc","channel":"timeline","pong":true}}

// Server → Client (新規)
{"type":"connected","body":{"id":"abc"}}
```

### shouldShare
`ShouldShare()` が true のチャンネルは、同じ Connection 内で同名チャンネルへの追加接続を無視する（ただし pong 応答はする）。

## テスト
- pong: connect with pong=true → connected応答
- pong: connect without pong → 応答なし
- shouldShare: 同名重複拒否
- non-shareable: 同名でも両方接続
- shouldShareでもpong応答は送信される

```bash
go test -race -count=1 -cover ./internal/stream/...
```
- **97.7%** coverage (CI閾値90%超)

Refs #132
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/shiroha-a/mk/pull/146" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
