### PR TITLE
P3-3: ActivityPub multi actor type support (#153)

### DIFF
--- a/internal/activitypub/renderer.go
+++ b/internal/activitypub/renderer.go
@@ -109,6 +109,16 @@ type NoteResolver interface {
 	FindByID(id string) (*model.Note, error)
 }
 
+// actorTypeForUser returns the AP actor `type` to emit for a local user.
+// 現状: IsBot=true なら Service、それ以外は Person。Application (system actor)
+// 出力は将来のシステムアカウント機能で別経路を追加する想定。
+func actorTypeForUser(u *model.User) string {
+	if u.IsBot {
+		return "Service"
+	}
+	return "Person"
+}
+
 // Renderer converts model entities into AS objects.
 type Renderer struct {
 	urls            *URLBuilder
@@ -156,10 +166,7 @@ func (r *Renderer) SetHost(host string) {
 func (r *Renderer) RenderPerson(u *model.User, profile *model.UserProfile, publicKeyPEM string) *Person {
 	uri := r.urls.UserURI(u.ID)
 
-	actorType := "Person"
-	if u.IsBot {
-		actorType = "Service"
-	}
+	actorType := actorTypeForUser(u)
 
 	p := &Person{
 		Object: Object{

--- a/internal/activitypub/types.go
+++ b/internal/activitypub/types.go
@@ -2,6 +2,8 @@
 // rendering local model entities into AP-compatible JSON-LD documents.
 package activitypub
 
+import "slices"
+
 // ContextURL is the standard ActivityStreams 2.0 JSON-LD context.
 const ContextURL = "https://www.w3.org/ns/activitystreams"
 
@@ -10,6 +12,25 @@ const SecurityContextURL = "https://w3id.org/security/v1"
 
 // Public is the magic IRI used to denote a publicly addressable activity.
 const Public = "https://www.w3.org/ns/activitystreams#Public"
+
+// ValidActorTypes lists the AP object types acceptable as an Actor.
+// Mirrors Misskey's `validActor` array in core/activitypub/type.ts so that
+// inbound documents of any other Object type are rejected at parse time.
+var ValidActorTypes = []string{
+	"Person", "Service", "Group", "Organization", "Application",
+}
+
+// IsValidActorType reports whether t is one of the recognized actor types.
+// Empty strings are rejected.
+func IsValidActorType(t string) bool {
+	return slices.Contains(ValidActorTypes, t)
+}
+
+// IsBotActorType reports whether the given actor type maps to an automated
+// (non-human) account. Misskey treats both Service and Application as bots.
+func IsBotActorType(t string) bool {
+	return t == "Service" || t == "Application"
+}
 
 // MimeType is the canonical Content-Type for ActivityPub objects.
 const MimeType = `application/activity+json`

--- a/internal/activitypub/types_test.go
+++ b/internal/activitypub/types_test.go
@@ -108,3 +108,44 @@ func TestNewMention(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Contains(t, string(b), `"type":"Mention"`)
 }
+
+func TestIsValidActorType(t *testing.T) {
+	cases := []struct {
+		typ  string
+		want bool
+	}{
+		{"Person", true},
+		{"Service", true},
+		{"Group", true},
+		{"Organization", true},
+		{"Application", true},
+		{"Note", false},
+		{"Tombstone", false},
+		{"", false},
+		{"person", false}, // case sensitive (TS と同じ)
+	}
+	for _, c := range cases {
+		t.Run(c.typ, func(t *testing.T) {
+			assert.Equal(t, c.want, IsValidActorType(c.typ))
+		})
+	}
+}
+
+func TestIsBotActorType(t *testing.T) {
+	cases := []struct {
+		typ  string
+		want bool
+	}{
+		{"Service", true},
+		{"Application", true},
+		{"Person", false},
+		{"Group", false},
+		{"Organization", false},
+		{"", false},
+	}
+	for _, c := range cases {
+		t.Run(c.typ, func(t *testing.T) {
+			assert.Equal(t, c.want, IsBotActorType(c.typ))
+		})
+	}
+}

--- a/internal/core/federation/resolver.go
+++ b/internal/core/federation/resolver.go
@@ -205,6 +205,7 @@ func (r *Resolver) ResolveActor(uri string) (*model.User, error) {
 		Host:          &host,
 		URI:           &actor.ID,
 		Inbox:         &actor.Inbox,
+		IsBot:         activitypub.IsBotActorType(actor.Type),
 		LastFetchedAt: &now,
 	}
 	if name := actor.Name; name != "" {
@@ -275,6 +276,11 @@ func (r *Resolver) refreshActor(existing *model.User, uri string) {
 	fields := map[string]any{
 		"lastFetchedAt": &now,
 	}
+	// actor type が変わるケース (Person ↔ Service など) を反映する。常に上書きする
+	// (TS Misskey も同様)。
+	isBot := activitypub.IsBotActorType(actor.Type)
+	fields["isBot"] = isBot
+	existing.IsBot = isBot
 	if actor.Name != "" {
 		name := actor.Name
 		fields["name"] = &name
@@ -316,7 +322,9 @@ func (r *Resolver) refreshActor(existing *model.User, uri string) {
 	}
 }
 
-// fetchActor fetches and decodes a remote actor document.
+// fetchActor fetches and decodes a remote actor document. Reject any
+// document whose `type` is not in activitypub.ValidActorTypes — this guards
+// against a non-Actor object (e.g. a Note) being interpreted as a Person.
 func (r *Resolver) fetchActor(uri string) (*activitypub.Person, error) {
 	body, err := r.fetcher.FetchObject(uri)
 	if err != nil {
@@ -327,6 +335,12 @@ func (r *Resolver) fetchActor(uri string) (*activitypub.Person, error) {
 		return nil, ErrInvalidActor
 	}
 	if actor.ID == "" || actor.PreferredUsername == "" {
+		return nil, ErrInvalidActor
+	}
+	if !activitypub.IsValidActorType(actor.Type) {
+		// Note/Activity 等 Actor でない object が actor として参照された場合の
+		// 防衛策。デバッグのため URI と type を残してから拒否する。
+		slog.Warn("federation: rejecting non-actor type", "uri", uri, "type", actor.Type)
 		return nil, ErrInvalidActor
 	}
 	return &actor, nil

--- a/internal/core/federation/resolver_test.go
+++ b/internal/core/federation/resolver_test.go
@@ -973,3 +973,100 @@ func TestRefreshPublicKey_OnExistingUser_FetchError(t *testing.T) {
 	_, err = r.PublicKeyForActor("existing")
 	assert.Error(t, err)
 }
+
+// --- multi actor type support (#153) ---
+
+// actorJSON renders a minimal actor JSON document with the given type.
+func actorJSON(actorType string) string {
+	return fmt.Sprintf(`{
+		"id": "https://remote.example/users/x",
+		"type": %q,
+		"preferredUsername": "x",
+		"name": "X",
+		"inbox": "https://remote.example/users/x/inbox",
+		"endpoints": {"sharedInbox": "https://remote.example/inbox"},
+		"publicKey": {
+			"id": "https://remote.example/users/x#main-key",
+			"owner": "https://remote.example/users/x",
+			"publicKeyPem": "-----BEGIN PUBLIC KEY-----\nFAKE\n-----END PUBLIC KEY-----"
+		}
+	}`, actorType)
+}
+
+func TestResolveActor_AllValidActorTypesAccepted(t *testing.T) {
+	for _, typ := range activitypub.ValidActorTypes {
+		t.Run(typ, func(t *testing.T) {
+			r, repo := newResolver(t, actorJSON(typ), nil)
+			user, err := r.ResolveActor("https://remote.example/users/x")
+			require.NoError(t, err)
+			assert.Equal(t, "x", user.Username)
+			assert.Len(t, repo.Users, 1)
+		})
+	}
+}
+
+func TestResolveActor_InvalidActorTypeRejected(t *testing.T) {
+	for _, typ := range []string{"Note", "Tombstone", "Article", ""} {
+		t.Run(typ, func(t *testing.T) {
+			r, _ := newResolver(t, actorJSON(typ), nil)
+			_, err := r.ResolveActor("https://remote.example/users/x")
+			require.ErrorIs(t, err, federation.ErrInvalidActor)
+		})
+	}
+}
+
+func TestResolveActor_ServiceTypeSetsIsBot(t *testing.T) {
+	r, repo := newResolver(t, actorJSON("Service"), nil)
+	user, err := r.ResolveActor("https://remote.example/users/x")
+	require.NoError(t, err)
+	assert.True(t, user.IsBot)
+	// 永続化された user も isBot=true
+	require.Len(t, repo.Users, 1)
+	for _, u := range repo.Users {
+		assert.True(t, u.IsBot)
+	}
+}
+
+func TestResolveActor_ApplicationTypeSetsIsBot(t *testing.T) {
+	r, _ := newResolver(t, actorJSON("Application"), nil)
+	user, err := r.ResolveActor("https://remote.example/users/x")
+	require.NoError(t, err)
+	assert.True(t, user.IsBot)
+}
+
+func TestResolveActor_GroupTypeDoesNotSetIsBot(t *testing.T) {
+	r, _ := newResolver(t, actorJSON("Group"), nil)
+	user, err := r.ResolveActor("https://remote.example/users/x")
+	require.NoError(t, err)
+	assert.False(t, user.IsBot)
+}
+
+func TestResolveActor_OrganizationTypeDoesNotSetIsBot(t *testing.T) {
+	r, _ := newResolver(t, actorJSON("Organization"), nil)
+	user, err := r.ResolveActor("https://remote.example/users/x")
+	require.NoError(t, err)
+	assert.False(t, user.IsBot)
+}
+
+func TestRefreshActor_UpdatesIsBotOnTypeChange(t *testing.T) {
+	// 既存 Person ユーザーが Service に切り替わった場合、refresh で IsBot=true
+	// に追従する。
+	repo := testutil.NewMockUserRepository()
+	uri := "https://remote.example/users/x"
+	stale := time.Now().Add(-48 * time.Hour) // TTL超過
+	repo.Users["existing"] = &model.User{
+		ID:            "existing",
+		Username:      "x",
+		URI:           &uri,
+		IsBot:         false,
+		LastFetchedAt: &stale,
+	}
+	noteRepo := testutil.NewMockNoteRepository()
+	urls := activitypub.NewURLBuilder("https://example.com")
+	idGen, _ := id.NewGenerator("aidx")
+	r := federation.NewResolver(repo, noteRepo, urls, &stubFetcher{body: []byte(actorJSON("Service"))}, idGen)
+
+	user, err := r.ResolveActor(uri)
+	require.NoError(t, err)
+	assert.True(t, user.IsBot)
+}


### PR DESCRIPTION
## Summary

Issue #153 (親 #134 / 互換性調査 #124)。ActivityPub の Actor 受信が TS Misskey の `validActor` (Person/Service/Group/Organization/Application) 全てを受け入れ、Service/Application を `isBot` にマッピングするようにする。

## 主な変更点

### activitypub パッケージ
- \`ValidActorTypes\` 定数追加 (TS Misskey の \`validActor\` に対応)
- \`IsValidActorType(t string) bool\` ヘルパ
- \`IsBotActorType(t string) bool\` ヘルパ (\`Service\` または \`Application\` で true)
- \`actorTypeForUser(u *model.User) string\` を Renderer から切り出し (将来の Application 出力経路への布石)

### federation/resolver
- \`fetchActor\`: パース後に actor type をホワイトリスト検証。非 Actor (例: Note を actor として騙すリクエスト) は \`ErrInvalidActor\`、\`slog.Warn\` でログ
- \`ResolveActor\` (新規作成): \`actor.Type == Service|Application\` で \`user.IsBot = true\`
- \`refreshActor\`: 同条件で IsBot を更新 (Person ↔ Service の切替に追従)

## TS Misskey との対応

| | TS validActor | TS isBot | 本PR |
|---|---|---|---|
| Person | ✓ | – | 受信OK / IsBot=false |
| Service | ✓ | ✓ | 受信OK / IsBot=true |
| Group | ✓ | – | 受信OK / IsBot=false |
| Organization | ✓ | – | 受信OK / IsBot=false |
| Application | ✓ | ✓ | 受信OK / IsBot=true |
| Note 等 | ✗ | – | \`ErrInvalidActor\` |

## テスト

新規追加:
- \`TestIsValidActorType\` / \`TestIsBotActorType\`: テーブルテスト
- \`TestResolveActor_AllValidActorTypesAccepted\`: 全 5 種で成功
- \`TestResolveActor_InvalidActorTypeRejected\`: Note/Tombstone/Article/空文字で拒否
- \`TestResolveActor_ServiceTypeSetsIsBot\` / \`_ApplicationTypeSetsIsBot\`
- \`TestResolveActor_GroupTypeDoesNotSetIsBot\` / \`_OrganizationTypeDoesNotSetIsBot\`
- \`TestRefreshActor_UpdatesIsBotOnTypeChange\`: TTL超過後の Person→Service 切替で IsBot 追従

実行方法:
\`\`\`bash
go test ./internal/activitypub/... ./internal/core/federation/...
\`\`\`

カバレッジ:
- \`internal/activitypub\`: 99.5%
- \`internal/core/federation\`: 90.8%

## 関連
- 親issue: #134
Closes #153
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/shiroha-a/mk/pull/156" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
