### PR TITLE
P3-5: HTTP Signature multi-algorithm support (#155)

### DIFF
--- a/internal/activitypub/keypair.go
+++ b/internal/activitypub/keypair.go
@@ -26,9 +26,9 @@ var nowFunc = time.Now
 type KeyType int
 
 const (
-	// KeyTypeRSAはRSA-SHA256 / RSA-SHA512 / hs2019(RSA)で使われる。
+	// KeyTypeRSA is used for RSA-SHA256 / RSA-SHA512 / hs2019(RSA) signatures.
 	KeyTypeRSA KeyType = iota
-	// KeyTypeEd25519はed25519 / hs2019(Ed25519)で使われる。
+	// KeyTypeEd25519 is used for ed25519 / hs2019(Ed25519) signatures.
 	KeyTypeEd25519
 )
 

--- a/internal/activitypub/keypair.go
+++ b/internal/activitypub/keypair.go
@@ -21,14 +21,14 @@ var randReader io.Reader = rand.Reader
 var nowFunc = time.Now
 
 // KeyType discriminates between supported HTTP Signature key algorithms.
-// RSA は Mastodon/Misskey の事実上の標準、Ed25519 は新世代 Fediverse 実装で
+// RSAはMastodon/Misskeyの事実上の標準、Ed25519は新世代Fediverse実装で
 // 採用されつつある軽量・高速な署名方式。
 type KeyType int
 
 const (
-	// KeyTypeRSA は RSA-SHA256 / RSA-SHA512 / hs2019(RSA) で使われる。
+	// KeyTypeRSAはRSA-SHA256 / RSA-SHA512 / hs2019(RSA)で使われる。
 	KeyTypeRSA KeyType = iota
-	// KeyTypeEd25519 は ed25519 / hs2019(Ed25519) で使われる。
+	// KeyTypeEd25519はed25519 / hs2019(Ed25519)で使われる。
 	KeyTypeEd25519
 )
 
@@ -50,8 +50,8 @@ func GenerateRSAKeypair() (privatePEM string, publicPEM string, err error) {
 }
 
 // GenerateEd25519Keypair returns a fresh Ed25519 keypair encoded as PEM
-// strings (private + public). 鍵生成は io エラーの時だけ失敗するため、
-// MarshalPKCS8PrivateKey / MarshalPKIXPublicKey 側のエラーチェックは省略。
+// strings (private + public). 鍵生成はioエラーの時だけ失敗するため、
+// MarshalPKCS8PrivateKey / MarshalPKIXPublicKey側のエラーチェックは省略。
 func GenerateEd25519Keypair() (privatePEM string, publicPEM string, err error) {
 	pub, priv, err := ed25519.GenerateKey(randReader)
 	if err != nil {
@@ -93,7 +93,7 @@ func ParseEd25519PrivateKey(pemStr string) (ed25519.PrivateKey, error) {
 }
 
 // ParseRSAPublicKey decodes a PEM-encoded RSA public key.
-// 既存呼び出し側の互換のため残す。新規コードは ParsePublicKey を使うこと。
+// 既存呼び出し側の互換のため残す。新規コードはParsePublicKeyを使うこと。
 func ParseRSAPublicKey(pemStr string) (*rsa.PublicKey, error) {
 	pub, kt, err := ParsePublicKey(pemStr)
 	if err != nil {
@@ -106,8 +106,8 @@ func ParseRSAPublicKey(pemStr string) (*rsa.PublicKey, error) {
 }
 
 // ParsePublicKey decodes a PEM-encoded public key and reports its type.
-// RSA / Ed25519 を識別できる。それ以外は "unsupported public key type" で
-// 拒否する (Misskey フェデレーションでは ECDSA 等は事実上使われていない)。
+// RSA / Ed25519を識別できる。それ以外は "unsupported public key type" で
+// 拒否する (Misskeyフェデレーションでは ECDSA等は事実上使われていない)。
 func ParsePublicKey(pemStr string) (crypto.PublicKey, KeyType, error) {
 	block, _ := pem.Decode([]byte(pemStr))
 	if block == nil {

--- a/internal/activitypub/keypair.go
+++ b/internal/activitypub/keypair.go
@@ -1,11 +1,14 @@
 package activitypub
 
 import (
+	"crypto"
+	"crypto/ed25519"
 	"crypto/rand"
 	"crypto/rsa"
 	"crypto/x509"
 	"encoding/pem"
 	"errors"
+	"fmt"
 	"io"
 	"time"
 )
@@ -16,6 +19,18 @@ var randReader io.Reader = rand.Reader
 
 // nowFunc returns the current time. テストで差し替え可能。
 var nowFunc = time.Now
+
+// KeyType discriminates between supported HTTP Signature key algorithms.
+// RSA は Mastodon/Misskey の事実上の標準、Ed25519 は新世代 Fediverse 実装で
+// 採用されつつある軽量・高速な署名方式。
+type KeyType int
+
+const (
+	// KeyTypeRSA は RSA-SHA256 / RSA-SHA512 / hs2019(RSA) で使われる。
+	KeyTypeRSA KeyType = iota
+	// KeyTypeEd25519 は ed25519 / hs2019(Ed25519) で使われる。
+	KeyTypeEd25519
+)
 
 // GenerateRSAKeypair returns a fresh 2048-bit RSA keypair encoded as PEM
 // strings (private + public). 失敗時はエラーを返す。MarshalPKIXPublicKey は
@@ -34,6 +49,23 @@ func GenerateRSAKeypair() (privatePEM string, publicPEM string, err error) {
 	return string(pem.EncodeToMemory(privBlock)), string(pem.EncodeToMemory(pubBlock)), nil
 }
 
+// GenerateEd25519Keypair returns a fresh Ed25519 keypair encoded as PEM
+// strings (private + public). 鍵生成は io エラーの時だけ失敗するため、
+// MarshalPKCS8PrivateKey / MarshalPKIXPublicKey 側のエラーチェックは省略。
+func GenerateEd25519Keypair() (privatePEM string, publicPEM string, err error) {
+	pub, priv, err := ed25519.GenerateKey(randReader)
+	if err != nil {
+		return "", "", err
+	}
+	privBytes, _ := x509.MarshalPKCS8PrivateKey(priv)
+	privBlock := &pem.Block{Type: "PRIVATE KEY", Bytes: privBytes}
+
+	pubBytes, _ := x509.MarshalPKIXPublicKey(pub)
+	pubBlock := &pem.Block{Type: "PUBLIC KEY", Bytes: pubBytes}
+
+	return string(pem.EncodeToMemory(privBlock)), string(pem.EncodeToMemory(pubBlock)), nil
+}
+
 // ParseRSAPrivateKey decodes a PEM-encoded RSA private key.
 func ParseRSAPrivateKey(pemStr string) (*rsa.PrivateKey, error) {
 	block, _ := pem.Decode([]byte(pemStr))
@@ -43,19 +75,54 @@ func ParseRSAPrivateKey(pemStr string) (*rsa.PrivateKey, error) {
 	return x509.ParsePKCS1PrivateKey(block.Bytes)
 }
 
-// ParseRSAPublicKey decodes a PEM-encoded RSA public key.
-func ParseRSAPublicKey(pemStr string) (*rsa.PublicKey, error) {
+// ParseEd25519PrivateKey decodes a PEM-encoded Ed25519 private key (PKCS8).
+func ParseEd25519PrivateKey(pemStr string) (ed25519.PrivateKey, error) {
 	block, _ := pem.Decode([]byte(pemStr))
 	if block == nil {
 		return nil, errors.New("invalid PEM block")
 	}
-	pub, err := x509.ParsePKIXPublicKey(block.Bytes)
+	parsed, err := x509.ParsePKCS8PrivateKey(block.Bytes)
 	if err != nil {
 		return nil, err
 	}
-	rsaPub, ok := pub.(*rsa.PublicKey)
+	priv, ok := parsed.(ed25519.PrivateKey)
 	if !ok {
+		return nil, errors.New("not an Ed25519 private key")
+	}
+	return priv, nil
+}
+
+// ParseRSAPublicKey decodes a PEM-encoded RSA public key.
+// 既存呼び出し側の互換のため残す。新規コードは ParsePublicKey を使うこと。
+func ParseRSAPublicKey(pemStr string) (*rsa.PublicKey, error) {
+	pub, kt, err := ParsePublicKey(pemStr)
+	if err != nil {
+		return nil, err
+	}
+	if kt != KeyTypeRSA {
 		return nil, errors.New("not an RSA public key")
 	}
-	return rsaPub, nil
+	return pub.(*rsa.PublicKey), nil
+}
+
+// ParsePublicKey decodes a PEM-encoded public key and reports its type.
+// RSA / Ed25519 を識別できる。それ以外は "unsupported public key type" で
+// 拒否する (Misskey フェデレーションでは ECDSA 等は事実上使われていない)。
+func ParsePublicKey(pemStr string) (crypto.PublicKey, KeyType, error) {
+	block, _ := pem.Decode([]byte(pemStr))
+	if block == nil {
+		return nil, 0, errors.New("invalid PEM block")
+	}
+	pub, err := x509.ParsePKIXPublicKey(block.Bytes)
+	if err != nil {
+		return nil, 0, err
+	}
+	switch k := pub.(type) {
+	case *rsa.PublicKey:
+		return k, KeyTypeRSA, nil
+	case ed25519.PublicKey:
+		return k, KeyTypeEd25519, nil
+	default:
+		return nil, 0, fmt.Errorf("unsupported public key type: %T", pub)
+	}
 }

--- a/internal/activitypub/signature.go
+++ b/internal/activitypub/signature.go
@@ -2,8 +2,10 @@ package activitypub
 
 import (
 	"crypto"
+	"crypto/ed25519"
 	"crypto/rsa"
 	"crypto/sha256"
+	"crypto/sha512"
 	"encoding/base64"
 	"errors"
 	"fmt"
@@ -13,21 +15,42 @@ import (
 	"strings"
 )
 
-// PrivateKey bundles a parsed RSA private key with its public keyId URI.
-// keyId は他サーバーが公開鍵を取得するための URI (例: https://example.com/users/u1#main-key)。
+// PrivateKey wraps a parsed private key (RSA or Ed25519) and its keyId URI
+// used as the `keyId` parameter in outgoing Signature headers.
 type PrivateKey struct {
 	KeyID      string
 	PrivatePEM string
-	parsed     *rsa.PrivateKey
+	signer     crypto.Signer
+	keyType    KeyType
 }
 
 // NewPrivateKey wraps a PEM string into a PrivateKey, parsing it once.
+// 既存互換のため RSA を期待する。Ed25519 鍵は NewEd25519PrivateKey を使うこと。
 func NewPrivateKey(keyID, privatePEM string) (*PrivateKey, error) {
 	parsed, err := ParseRSAPrivateKey(privatePEM)
 	if err != nil {
 		return nil, err
 	}
-	return &PrivateKey{KeyID: keyID, PrivatePEM: privatePEM, parsed: parsed}, nil
+	return &PrivateKey{
+		KeyID:      keyID,
+		PrivatePEM: privatePEM,
+		signer:     parsed,
+		keyType:    KeyTypeRSA,
+	}, nil
+}
+
+// NewEd25519PrivateKey wraps an Ed25519 PKCS8 PEM into a PrivateKey.
+func NewEd25519PrivateKey(keyID, privatePEM string) (*PrivateKey, error) {
+	parsed, err := ParseEd25519PrivateKey(privatePEM)
+	if err != nil {
+		return nil, err
+	}
+	return &PrivateKey{
+		KeyID:      keyID,
+		PrivatePEM: privatePEM,
+		signer:     parsed,
+		keyType:    KeyTypeEd25519,
+	}, nil
 }
 
 // SHA256Digest returns the "SHA-256=<base64>" digest header value for body.
@@ -36,13 +59,24 @@ func SHA256Digest(body []byte) string {
 	return "SHA-256=" + base64.StdEncoding.EncodeToString(sum[:])
 }
 
+// algorithmForKeyType returns the Signature header `algorithm` value emitted
+// by SignRequest for the given key type.
+func algorithmForKeyType(kt KeyType) string {
+	if kt == KeyTypeEd25519 {
+		return "ed25519"
+	}
+	return "rsa-sha256"
+}
+
 // SignRequest mutates req to include the Date, Host, Digest (when bodyDigest!="")
 // and Signature headers required by the Cavage HTTP Signatures draft v12.
 //
 // includeHeaders はヘッダ名の小文字リスト。"(request-target)" を含めると
 // "(request-target): <method> <path>" が署名対象に追加される。
+//
+// algorithm は鍵種別から自動決定される (RSA→rsa-sha256, Ed25519→ed25519)。
 func SignRequest(req *http.Request, key *PrivateKey, bodyDigest string, includeHeaders []string) error {
-	if key == nil || key.parsed == nil {
+	if key == nil || key.signer == nil {
 		return errors.New("private key required")
 	}
 
@@ -61,13 +95,15 @@ func SignRequest(req *http.Request, key *PrivateKey, bodyDigest string, includeH
 		return err
 	}
 
-	hashed := sha256.Sum256([]byte(signingString))
-	// rsa.SignPKCS1v15 は PKCS1v15 では rand を使わないため失敗しない (RSA-PSS の場合は使う)。
-	sig, _ := rsa.SignPKCS1v15(randReader, key.parsed, crypto.SHA256, hashed[:])
+	sig, err := signWithKey(key, []byte(signingString))
+	if err != nil {
+		return err
+	}
 
 	header := fmt.Sprintf(
-		`keyId="%s",algorithm="rsa-sha256",headers="%s",signature="%s"`,
+		`keyId="%s",algorithm="%s",headers="%s",signature="%s"`,
 		key.KeyID,
+		algorithmForKeyType(key.keyType),
 		strings.Join(includeHeaders, " "),
 		base64.StdEncoding.EncodeToString(sig),
 	)
@@ -75,6 +111,23 @@ func SignRequest(req *http.Request, key *PrivateKey, bodyDigest string, includeH
 	// Hostヘッダはnet/httpがリクエストラインから自動付与するため取り除く。
 	req.Header.Del("Host")
 	return nil
+}
+
+// signWithKey produces a signature byte slice for the given signing input.
+// 鍵種別に応じて RSA-SHA256 / Ed25519 を切り替える。
+func signWithKey(key *PrivateKey, signingInput []byte) ([]byte, error) {
+	switch key.keyType {
+	case KeyTypeRSA:
+		hashed := sha256.Sum256(signingInput)
+		// rsa.SignPKCS1v15 は PKCS1v15 では rand を使わないため失敗しない。
+		return rsa.SignPKCS1v15(randReader, key.signer.(*rsa.PrivateKey), crypto.SHA256, hashed[:])
+	case KeyTypeEd25519:
+		// Ed25519 は内部で SHA-512 を使うため事前ハッシュ不要。Sign() の
+		// opts は必ず crypto.Hash(0) を渡す (ed25519 仕様)。
+		return key.signer.Sign(randReader, signingInput, crypto.Hash(0))
+	default:
+		return nil, fmt.Errorf("unsupported key type: %d", key.keyType)
+	}
 }
 
 // buildSigningString concatenates the canonical signing string for the
@@ -145,18 +198,21 @@ func ParseSignatureHeader(header string) (*ParsedSignature, error) {
 }
 
 // VerifyRequest verifies an incoming HTTP request signature against the
-// supplied PEM public key. requestURI overrides req.URL.RequestURI() to allow
-// callers to feed the original raw path (echo's c.Request().URL is normalized
-// in some cases).
+// supplied PEM public key. RSA / Ed25519 public keys are both supported,
+// dispatched on the parsed Signature `algorithm` parameter and the public
+// key type. requestURI overrides req.URL.RequestURI() to allow callers to
+// feed the original raw path (echo's c.Request().URL is normalized in some
+// cases).
 func VerifyRequest(req *http.Request, publicKeyPEM string) error {
 	parsed, err := ParseSignatureHeader(req.Header.Get("Signature"))
 	if err != nil {
 		return err
 	}
-	if parsed.Algorithm != "" && !strings.EqualFold(parsed.Algorithm, "rsa-sha256") {
+	// 早期に algorithm 名を弾く (公開鍵 PEM パースより前に判定したい)。
+	if !isKnownAlgorithm(parsed.Algorithm) {
 		return fmt.Errorf("unsupported algorithm %q", parsed.Algorithm)
 	}
-	pub, err := ParseRSAPublicKey(publicKeyPEM)
+	pub, kt, err := ParsePublicKey(publicKeyPEM)
 	if err != nil {
 		return err
 	}
@@ -168,8 +224,7 @@ func VerifyRequest(req *http.Request, publicKeyPEM string) error {
 	if err != nil {
 		return err
 	}
-	hashed := sha256.Sum256([]byte(signingString))
-	if err := rsa.VerifyPKCS1v15(pub, crypto.SHA256, hashed[:], sig); err != nil {
+	if err := verifyAlgorithm(parsed.Algorithm, kt, pub, []byte(signingString), sig); err != nil {
 		return err
 	}
 	// Digest check (for POST bodies)
@@ -181,6 +236,75 @@ func VerifyRequest(req *http.Request, publicKeyPEM string) error {
 		}
 	}
 	return nil
+}
+
+// isKnownAlgorithm reports whether the algorithm name is one we accept.
+// Empty string is allowed (Cavage default behaviour: derive from key type).
+func isKnownAlgorithm(alg string) bool {
+	switch strings.ToLower(alg) {
+	case "", "hs2019", "rsa-sha256", "rsa-sha512", "ed25519", "ed25519-sha512":
+		return true
+	}
+	return false
+}
+
+// verifyAlgorithm dispatches the actual signature verification based on the
+// Signature header's `algorithm` parameter and the public key type.
+//
+// 対応マトリクス:
+//   - "" / "hs2019": 鍵種別から判定 (RSA→SHA-256, Ed25519→ed25519)
+//   - "rsa-sha256": RSA + SHA-256
+//   - "rsa-sha512": RSA + SHA-512
+//   - "ed25519" / "ed25519-sha512": Ed25519
+//
+// algorithm と鍵種別が合わないケース (RSA鍵で algorithm=ed25519 等) は
+// 明示的に拒否する。
+func verifyAlgorithm(alg string, kt KeyType, pub crypto.PublicKey, signingInput, sig []byte) error {
+	algLower := strings.ToLower(alg)
+	switch algLower {
+	case "", "hs2019":
+		// 鍵種別ベースで dispatch
+		return verifyByKeyType(kt, pub, signingInput, sig)
+	case "rsa-sha256":
+		if kt != KeyTypeRSA {
+			return fmt.Errorf("algorithm %q requires RSA key", alg)
+		}
+		hashed := sha256.Sum256(signingInput)
+		return rsa.VerifyPKCS1v15(pub.(*rsa.PublicKey), crypto.SHA256, hashed[:], sig)
+	case "rsa-sha512":
+		if kt != KeyTypeRSA {
+			return fmt.Errorf("algorithm %q requires RSA key", alg)
+		}
+		hashed := sha512.Sum512(signingInput)
+		return rsa.VerifyPKCS1v15(pub.(*rsa.PublicKey), crypto.SHA512, hashed[:], sig)
+	case "ed25519", "ed25519-sha512":
+		if kt != KeyTypeEd25519 {
+			return fmt.Errorf("algorithm %q requires Ed25519 key", alg)
+		}
+		if !ed25519.Verify(pub.(ed25519.PublicKey), signingInput, sig) {
+			return errors.New("ed25519 verification failed")
+		}
+		return nil
+	default:
+		return fmt.Errorf("unsupported algorithm %q", alg)
+	}
+}
+
+// verifyByKeyType is the key-type-driven fallback used for hs2019 and
+// algorithm-omitted signatures.
+func verifyByKeyType(kt KeyType, pub crypto.PublicKey, signingInput, sig []byte) error {
+	switch kt {
+	case KeyTypeRSA:
+		hashed := sha256.Sum256(signingInput)
+		return rsa.VerifyPKCS1v15(pub.(*rsa.PublicKey), crypto.SHA256, hashed[:], sig)
+	case KeyTypeEd25519:
+		if !ed25519.Verify(pub.(ed25519.PublicKey), signingInput, sig) {
+			return errors.New("ed25519 verification failed")
+		}
+		return nil
+	default:
+		return fmt.Errorf("unsupported key type: %d", kt)
+	}
 }
 
 // ResolveKeyURL extracts the actor URI from a key fragment URI by stripping

--- a/internal/activitypub/signature.go
+++ b/internal/activitypub/signature.go
@@ -25,7 +25,7 @@ type PrivateKey struct {
 }
 
 // NewPrivateKey wraps a PEM string into a PrivateKey, parsing it once.
-// 既存互換のため RSA を期待する。Ed25519 鍵は NewEd25519PrivateKey を使うこと。
+// 既存互換のためRSAを期待する。Ed25519鍵はNewEd25519PrivateKeyを使うこと。
 func NewPrivateKey(keyID, privatePEM string) (*PrivateKey, error) {
 	parsed, err := ParseRSAPrivateKey(privatePEM)
 	if err != nil {
@@ -74,7 +74,7 @@ func algorithmForKeyType(kt KeyType) string {
 // includeHeaders はヘッダ名の小文字リスト。"(request-target)" を含めると
 // "(request-target): <method> <path>" が署名対象に追加される。
 //
-// algorithm は鍵種別から自動決定される (RSA→rsa-sha256, Ed25519→ed25519)。
+// algorithmは鍵種別から自動決定される (RSA→rsa-sha256, Ed25519→ed25519)。
 func SignRequest(req *http.Request, key *PrivateKey, bodyDigest string, includeHeaders []string) error {
 	if key == nil || key.signer == nil {
 		return errors.New("private key required")
@@ -114,16 +114,16 @@ func SignRequest(req *http.Request, key *PrivateKey, bodyDigest string, includeH
 }
 
 // signWithKey produces a signature byte slice for the given signing input.
-// 鍵種別に応じて RSA-SHA256 / Ed25519 を切り替える。
+// 鍵種別に応じてRSA-SHA256 / Ed25519を切り替える。
 func signWithKey(key *PrivateKey, signingInput []byte) ([]byte, error) {
 	switch key.keyType {
 	case KeyTypeRSA:
 		hashed := sha256.Sum256(signingInput)
-		// rsa.SignPKCS1v15 は PKCS1v15 では rand を使わないため失敗しない。
+		// rsa.SignPKCS1v15はPKCS1v15ではrandを使わないため失敗しない。
 		return rsa.SignPKCS1v15(randReader, key.signer.(*rsa.PrivateKey), crypto.SHA256, hashed[:])
 	case KeyTypeEd25519:
-		// Ed25519 は内部で SHA-512 を使うため事前ハッシュ不要。Sign() の
-		// opts は必ず crypto.Hash(0) を渡す (ed25519 仕様)。
+		// Ed25519は内部でSHA-512を使うため事前ハッシュ不要。Sign()の
+		// optsは必ずcrypto.Hash(0)を渡す (ed25519仕様)。
 		return key.signer.Sign(randReader, signingInput, crypto.Hash(0))
 	default:
 		return nil, fmt.Errorf("unsupported key type: %d", key.keyType)
@@ -200,15 +200,13 @@ func ParseSignatureHeader(header string) (*ParsedSignature, error) {
 // VerifyRequest verifies an incoming HTTP request signature against the
 // supplied PEM public key. RSA / Ed25519 public keys are both supported,
 // dispatched on the parsed Signature `algorithm` parameter and the public
-// key type. requestURI overrides req.URL.RequestURI() to allow callers to
-// feed the original raw path (echo's c.Request().URL is normalized in some
-// cases).
+// key type.
 func VerifyRequest(req *http.Request, publicKeyPEM string) error {
 	parsed, err := ParseSignatureHeader(req.Header.Get("Signature"))
 	if err != nil {
 		return err
 	}
-	// 早期に algorithm 名を弾く (公開鍵 PEM パースより前に判定したい)。
+	// 早期にalgorithm名を弾く (公開鍵PEMパースより前に判定したい)。
 	if !isKnownAlgorithm(parsed.Algorithm) {
 		return fmt.Errorf("unsupported algorithm %q", parsed.Algorithm)
 	}
@@ -257,7 +255,7 @@ func isKnownAlgorithm(alg string) bool {
 //   - "rsa-sha512": RSA + SHA-512
 //   - "ed25519" / "ed25519-sha512": Ed25519
 //
-// algorithm と鍵種別が合わないケース (RSA鍵で algorithm=ed25519 等) は
+// algorithmと鍵種別が合わないケース (RSA鍵でalgorithm=ed25519等) は
 // 明示的に拒否する。
 func verifyAlgorithm(alg string, kt KeyType, pub crypto.PublicKey, signingInput, sig []byte) error {
 	algLower := strings.ToLower(alg)

--- a/internal/activitypub/signature_test.go
+++ b/internal/activitypub/signature_test.go
@@ -5,6 +5,7 @@ import (
 	"crypto"
 	"crypto/rsa"
 	"crypto/sha256"
+	"crypto/sha512"
 	"encoding/base64"
 	"net/http"
 	"net/http/httptest"
@@ -233,6 +234,197 @@ func TestCryptoSmoke(t *testing.T) {
 	hashed := sha256.Sum256([]byte("x"))
 	_, err := rsa.SignPKCS1v15(nil, rsaKey, crypto.SHA256, hashed[:])
 	require.NoError(t, err)
+}
+
+// --- multi-algorithm tests (#155) ---
+
+func newTestEd25519Key(t *testing.T) (*PrivateKey, string) {
+	t.Helper()
+	priv, pub, err := GenerateEd25519Keypair()
+	require.NoError(t, err)
+	k, err := NewEd25519PrivateKey("https://example.com/users/u1#main-key", priv)
+	require.NoError(t, err)
+	return k, pub
+}
+
+func TestGenerateEd25519Keypair(t *testing.T) {
+	priv, pub, err := GenerateEd25519Keypair()
+	require.NoError(t, err)
+	assert.Contains(t, priv, "PRIVATE KEY")
+	assert.Contains(t, pub, "PUBLIC KEY")
+}
+
+func TestParsePublicKey_RSA(t *testing.T) {
+	_, pub, err := GenerateRSAKeypair()
+	require.NoError(t, err)
+	parsed, kt, err := ParsePublicKey(pub)
+	require.NoError(t, err)
+	assert.Equal(t, KeyTypeRSA, kt)
+	assert.NotNil(t, parsed)
+}
+
+func TestParsePublicKey_Ed25519(t *testing.T) {
+	_, pub, err := GenerateEd25519Keypair()
+	require.NoError(t, err)
+	parsed, kt, err := ParsePublicKey(pub)
+	require.NoError(t, err)
+	assert.Equal(t, KeyTypeEd25519, kt)
+	assert.NotNil(t, parsed)
+}
+
+func TestParsePublicKey_BadPEM(t *testing.T) {
+	_, _, err := ParsePublicKey("not pem")
+	assert.Error(t, err)
+}
+
+func TestNewEd25519PrivateKey_InvalidPEM(t *testing.T) {
+	_, err := NewEd25519PrivateKey("kid", "not pem")
+	assert.Error(t, err)
+}
+
+func TestNewEd25519PrivateKey_RSAKeyRejected(t *testing.T) {
+	rsaPriv, _, err := GenerateRSAKeypair()
+	require.NoError(t, err)
+	_, err = NewEd25519PrivateKey("kid", rsaPriv)
+	assert.Error(t, err)
+}
+
+func TestParseRSAPublicKey_Ed25519Rejected(t *testing.T) {
+	_, edPub, err := GenerateEd25519Keypair()
+	require.NoError(t, err)
+	_, err = ParseRSAPublicKey(edPub)
+	assert.Error(t, err)
+}
+
+// Round-trip sign + verify with Ed25519.
+func TestSignAndVerify_Ed25519(t *testing.T) {
+	key, pub := newTestEd25519Key(t)
+	body := []byte(`{"type":"Create"}`)
+	digest := SHA256Digest(body)
+	req, _ := http.NewRequest(http.MethodPost, "https://remote.example/inbox", bytes.NewReader(body))
+	require.NoError(t, SignRequest(req, key, digest, []string{"(request-target)", "date", "host", "digest"}))
+
+	// Signature ヘッダに algorithm="ed25519" が出力されている
+	assert.Contains(t, req.Header.Get("Signature"), `algorithm="ed25519"`)
+
+	req.Header.Set("Host", "remote.example")
+	require.NoError(t, VerifyRequest(req, pub))
+}
+
+// Verify accepts hs2019 algorithm with RSA key (key-type-driven dispatch).
+func TestVerifyRequest_HS2019_RSA(t *testing.T) {
+	key, pub := newTestKey(t)
+	req, _ := http.NewRequest(http.MethodGet, "https://remote.example/users/bob", nil)
+	require.NoError(t, SignRequest(req, key, "", []string{"(request-target)", "date", "host"}))
+
+	// signed header の algorithm を hs2019 に書き換える
+	sig := req.Header.Get("Signature")
+	sig = strings.Replace(sig, `algorithm="rsa-sha256"`, `algorithm="hs2019"`, 1)
+	req.Header.Set("Signature", sig)
+	req.Header.Set("Host", "remote.example")
+	require.NoError(t, VerifyRequest(req, pub))
+}
+
+// Verify accepts hs2019 algorithm with Ed25519 key.
+func TestVerifyRequest_HS2019_Ed25519(t *testing.T) {
+	key, pub := newTestEd25519Key(t)
+	req, _ := http.NewRequest(http.MethodGet, "https://remote.example/users/bob", nil)
+	require.NoError(t, SignRequest(req, key, "", []string{"(request-target)", "date", "host"}))
+
+	sig := req.Header.Get("Signature")
+	sig = strings.Replace(sig, `algorithm="ed25519"`, `algorithm="hs2019"`, 1)
+	req.Header.Set("Signature", sig)
+	req.Header.Set("Host", "remote.example")
+	require.NoError(t, VerifyRequest(req, pub))
+}
+
+// Verify accepts ed25519-sha512 alias.
+func TestVerifyRequest_Ed25519SHA512Alias(t *testing.T) {
+	key, pub := newTestEd25519Key(t)
+	req, _ := http.NewRequest(http.MethodGet, "https://remote.example/users/bob", nil)
+	require.NoError(t, SignRequest(req, key, "", []string{"(request-target)", "date", "host"}))
+
+	sig := req.Header.Get("Signature")
+	sig = strings.Replace(sig, `algorithm="ed25519"`, `algorithm="ed25519-sha512"`, 1)
+	req.Header.Set("Signature", sig)
+	req.Header.Set("Host", "remote.example")
+	require.NoError(t, VerifyRequest(req, pub))
+}
+
+// Verify omits algorithm; key type drives dispatch.
+func TestVerifyRequest_AlgorithmOmitted_Ed25519(t *testing.T) {
+	key, pub := newTestEd25519Key(t)
+	req, _ := http.NewRequest(http.MethodGet, "https://remote.example/users/bob", nil)
+	require.NoError(t, SignRequest(req, key, "", []string{"(request-target)", "date", "host"}))
+
+	// algorithm パラメータを削除して送信されたケース。replace で algorithm=...
+	// 部分を削る (簡易ハック)。
+	sig := req.Header.Get("Signature")
+	idx := strings.Index(sig, `algorithm="ed25519",`)
+	require.GreaterOrEqual(t, idx, 0)
+	stripped := sig[:idx] + sig[idx+len(`algorithm="ed25519",`):]
+	req.Header.Set("Signature", stripped)
+	req.Header.Set("Host", "remote.example")
+	require.NoError(t, VerifyRequest(req, pub))
+}
+
+// rsa-sha512 verification path: sign manually with SHA-512 then verify.
+func TestVerifyRequest_RSA_SHA512(t *testing.T) {
+	key, pub := newTestKey(t)
+	req, _ := http.NewRequest(http.MethodGet, "https://remote.example/users/bob", nil)
+	require.NoError(t, SignRequest(req, key, "", []string{"(request-target)", "date", "host"}))
+
+	// 既存の rsa-sha256 署名を破棄して、SHA-512 で再署名し直す。
+	signingString, err := buildSigningString(req, []string{"(request-target)", "date", "host"})
+	require.NoError(t, err)
+	hashed := sha512.Sum512([]byte(signingString))
+	rsaKey, err := ParseRSAPrivateKey(key.PrivatePEM)
+	require.NoError(t, err)
+	sig, err := rsa.SignPKCS1v15(nil, rsaKey, crypto.SHA512, hashed[:])
+	require.NoError(t, err)
+
+	header := `keyId="` + key.KeyID + `",algorithm="rsa-sha512",headers="(request-target) date host",signature="` + base64.StdEncoding.EncodeToString(sig) + `"`
+	req.Header.Set("Signature", header)
+	req.Header.Set("Host", "remote.example")
+	require.NoError(t, VerifyRequest(req, pub))
+}
+
+// Mismatch: RSA key with algorithm=ed25519 must be rejected.
+func TestVerifyRequest_RSAKey_Ed25519AlgRejected(t *testing.T) {
+	_, pub := newTestKey(t)
+	req, _ := http.NewRequest(http.MethodGet, "https://remote.example/", nil)
+	req.Header.Set("Date", "Mon, 01 Jan 2024 00:00:00 GMT")
+	dummySig := base64.StdEncoding.EncodeToString(make([]byte, 64))
+	req.Header.Set("Signature", `keyId="x",algorithm="ed25519",headers="date",signature="`+dummySig+`"`)
+	err := VerifyRequest(req, pub)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "Ed25519")
+}
+
+// Mismatch: Ed25519 key with algorithm=rsa-sha256 must be rejected.
+func TestVerifyRequest_Ed25519Key_RSAAlgRejected(t *testing.T) {
+	_, pub := newTestEd25519Key(t)
+	req, _ := http.NewRequest(http.MethodGet, "https://remote.example/", nil)
+	req.Header.Set("Date", "Mon, 01 Jan 2024 00:00:00 GMT")
+	dummySig := base64.StdEncoding.EncodeToString(make([]byte, 64))
+	req.Header.Set("Signature", `keyId="x",algorithm="rsa-sha256",headers="date",signature="`+dummySig+`"`)
+	err := VerifyRequest(req, pub)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "RSA")
+}
+
+// Bad Ed25519 signature bytes -> verify fails.
+func TestVerifyRequest_Ed25519BadSignature(t *testing.T) {
+	key, pub := newTestEd25519Key(t)
+	req, _ := http.NewRequest(http.MethodGet, "https://remote.example/users/bob", nil)
+	require.NoError(t, SignRequest(req, key, "", []string{"(request-target)", "date", "host"}))
+
+	// signature を改竄
+	sig := req.Header.Get("Signature")
+	tamperedSig := strings.Replace(sig, `signature="`, `signature="AAAA`, 1)
+	req.Header.Set("Signature", tamperedSig)
+	req.Header.Set("Host", "remote.example")
+	assert.Error(t, VerifyRequest(req, pub))
 }
 
 // Test using httptest.NewRecorder so the verifier sees a real request from a server context.


### PR DESCRIPTION
## Summary

Issue #155 (親 #134 / 互換性調査 #124)。HTTP Signature 実装に Ed25519 / hs2019 検証パスを追加し、新世代 Fediverse 実装との相互運用に備える。既存の rsa-sha256 sign/verify は完全互換。

## 主な変更点

### keypair.go
- \`KeyType\` 列挙 (RSA / Ed25519)
- \`GenerateEd25519Keypair()\` / \`ParseEd25519PrivateKey()\` 追加
- \`ParsePublicKey(pem) (crypto.PublicKey, KeyType, error)\` で RSA / Ed25519 自動判別
- \`ParseRSAPublicKey\` は \`ParsePublicKey\` 経由の薄い互換 wrapper として残す

### signature.go
- \`PrivateKey\` を \`crypto.Signer\` ベースに refactor (内部に keyType を保持)
- \`NewEd25519PrivateKey(keyID, pem)\` constructor 追加
- \`SignRequest\`: 鍵種別から \`algorithm\` を自動選択
  - RSA → \`rsa-sha256\` (既存挙動維持)
  - Ed25519 → \`ed25519\`
- \`VerifyRequest\`: 以下を受入れ
  | algorithm | 鍵種別 | 動作 |
  |---|---|---|
  | \`rsa-sha256\` | RSA | SHA-256 + PKCS1v15 (既存) |
  | \`rsa-sha512\` | RSA | SHA-512 + PKCS1v15 (新規) |
  | \`ed25519\` / \`ed25519-sha512\` | Ed25519 | Ed25519 (新規) |
  | \`hs2019\` | RSA | SHA-256 (Mastodon慣行) (新規) |
  | \`hs2019\` | Ed25519 | Ed25519 (新規) |
  | (省略) | 鍵種別 | 同上 (新規) |
- 鍵種別と algorithm の不整合は明示的に拒否 (例: RSA鍵で algorithm=ed25519)
- 未知のアルゴリズム名は早期に弾く (\`isKnownAlgorithm\`)

## TS Misskey との関係

TS 本家にも未実装 (Mastodon 互換の rsa-sha256 のみ)。本 PR は **Fediverse 全体の forward compatibility** を目的としたもので、TS パリティではなく将来対応。

## テスト

新規追加 (15ケース):
- 鍵生成 / parse: \`GenerateEd25519Keypair\`, \`ParsePublicKey\` (RSA/Ed25519/不正PEM)
- Constructor 拒否ケース: \`NewEd25519PrivateKey\` が RSA PEM を拒否, \`ParseRSAPublicKey\` が Ed25519 PEM を拒否
- ラウンドトリップ: Ed25519 sign + verify
- 各 algorithm 受入れ: \`hs2019\`(RSA), \`hs2019\`(Ed25519), \`ed25519-sha512\`, algorithm 省略
- \`rsa-sha512\` 検証 (手動 SHA-512 署名 → verify)
- 不整合拒否: RSA鍵 + ed25519, Ed25519鍵 + rsa-sha256
- 改竄署名拒否

実行方法:
\`\`\`bash
go test ./internal/activitypub/...
\`\`\`

カバレッジ:
- \`internal/activitypub\`: 97.5%
- \`internal/core/federation\`: 90.8% (波及無し)

## 関連
- 親issue: #134
Closes #155
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/shiroha-a/mk/pull/158" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
