### PR TITLE
P3-1: chart tick / resync / clean cron via asynq scheduler (#151)

### DIFF
--- a/internal/charttick/charttick.go
+++ b/internal/charttick/charttick.go
@@ -1,0 +1,134 @@
+// Package charttick provides TickFunc closures that re-derive absolute
+// chart counters from the live PostgreSQL state. They are bound to
+// chart engines at construction so the periodic chart cron (#151) can
+// correct event-driven drift.
+package charttick
+
+import (
+	"context"
+
+	"github.com/shiroha-a/mk/internal/core/chart"
+	"gorm.io/gorm"
+)
+
+// localRemoteCount は host 列の有無で local/remote を 1 クエリで集計するための
+// 共通ヘルパ。Users と Notes でロジックが同じなので集約してテスト面を縮める。
+func localRemoteCount(ctx context.Context, db *gorm.DB, table, hostCol string) (local, remote int64, err error) {
+	row := db.WithContext(ctx).Raw(
+		`SELECT COUNT(*) FILTER (WHERE "` + hostCol + `" IS NULL),
+		        COUNT(*) FILTER (WHERE "` + hostCol + `" IS NOT NULL)
+		   FROM "` + table + `"`,
+	).Row()
+	err = row.Scan(&local, &remote)
+	return local, remote, err
+}
+
+// Users returns a TickFunc that, on a major tick, recomputes the
+// instance-wide local / remote user totals against the live DB. Mirrors
+// upstream UsersChart.tickMajor; tickMinor is empty (returns nil).
+func Users(db *gorm.DB) chart.TickFunc {
+	return func(ctx context.Context, _ string, major bool) (map[string]int64, error) {
+		if !major {
+			return nil, nil
+		}
+		local, remote, err := localRemoteCount(ctx, db, "user", "host")
+		if err != nil {
+			return nil, err
+		}
+		return map[string]int64{
+			"local.total":  local,
+			"remote.total": remote,
+		}, nil
+	}
+}
+
+// Notes returns a TickFunc that, on a major tick, recomputes the
+// instance-wide local / remote note totals. Mirrors upstream
+// NotesChart.tickMajor; tickMinor is empty.
+func Notes(db *gorm.DB) chart.TickFunc {
+	return func(ctx context.Context, _ string, major bool) (map[string]int64, error) {
+		if !major {
+			return nil, nil
+		}
+		local, remote, err := localRemoteCount(ctx, db, "note", "userHost")
+		if err != nil {
+			return nil, err
+		}
+		return map[string]int64{
+			"local.total":  local,
+			"remote.total": remote,
+		}, nil
+	}
+}
+
+// Federation returns a TickFunc that, on a minor tick, recomputes the
+// federation chart's instance counters. Mirrors upstream
+// FederationChart.tickMinor; tickMajor is empty.
+//
+// 集計対象:
+//   - sub: 我々がフォローしている対象 host 数
+//   - pub: 我々をフォローしている remote host 数
+//   - pubsub: 双方向 (sub と pub の積集合)
+//   - subActive: 上記 sub のうち suspend されていない host 数
+//   - pubActive: 上記 pub のうち suspend されていない host 数
+//
+// blockedHosts のフィルタは Misskey 本家側で適用されるが、本実装では Phase 1 として
+// 全 host を対象とする。将来 meta.blockedHosts を渡せる構造に拡張予定。
+func Federation(db *gorm.DB) chart.TickFunc {
+	return func(ctx context.Context, _ string, major bool) (map[string]int64, error) {
+		if major {
+			return nil, nil
+		}
+		count := func(query string) (int64, error) {
+			var n int64
+			row := db.WithContext(ctx).Raw(query).Row()
+			if err := row.Scan(&n); err != nil {
+				return 0, err
+			}
+			return n, nil
+		}
+		sub, err := count(`SELECT COUNT(DISTINCT "followeeHost") FROM "following" WHERE "followeeHost" IS NOT NULL`)
+		if err != nil {
+			return nil, err
+		}
+		pub, err := count(`SELECT COUNT(DISTINCT "followerHost") FROM "following" WHERE "followerHost" IS NOT NULL`)
+		if err != nil {
+			return nil, err
+		}
+		pubsub, err := count(`
+			SELECT COUNT(DISTINCT host) FROM (
+				SELECT "followeeHost" AS host FROM "following" WHERE "followeeHost" IS NOT NULL
+				INTERSECT
+				SELECT "followerHost" FROM "following" WHERE "followerHost" IS NOT NULL
+			) AS pubsub_hosts
+		`)
+		if err != nil {
+			return nil, err
+		}
+		subActive, err := count(`
+			SELECT COUNT(DISTINCT f."followeeHost") FROM "following" f
+			LEFT JOIN "instance" i ON i.host = f."followeeHost"
+			WHERE f."followeeHost" IS NOT NULL
+			  AND (i."suspensionState" IS NULL OR i."suspensionState" = 'none')
+		`)
+		if err != nil {
+			return nil, err
+		}
+		pubActive, err := count(`
+			SELECT COUNT(DISTINCT f."followerHost") FROM "following" f
+			LEFT JOIN "instance" i ON i.host = f."followerHost"
+			WHERE f."followerHost" IS NOT NULL
+			  AND (i."suspensionState" IS NULL OR i."suspensionState" = 'none')
+		`)
+		if err != nil {
+			return nil, err
+		}
+		return map[string]int64{
+			"sub":       sub,
+			"pub":       pub,
+			"pubsub":    pubsub,
+			"subActive": subActive,
+			"pubActive": pubActive,
+		}, nil
+	}
+}

--- a/internal/charttick/charttick_test.go
+++ b/internal/charttick/charttick_test.go
@@ -1,0 +1,178 @@
+package charttick_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/shiroha-a/mk/internal/charttick"
+	"github.com/shiroha-a/mk/internal/testutil"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gorm.io/gorm"
+)
+
+// skipIfNoTestDB skips when the test DB is not reachable, mirroring the
+// pattern used by internal/db tests so local runs without a postgres
+// container do not spuriously fail.
+func skipIfNoTestDB(t *testing.T) *gorm.DB {
+	t.Helper()
+	db, err := testutil.OpenTestDB()
+	if err != nil {
+		t.Skipf("test DB not available: %v", err)
+	}
+	testutil.ApplyMigrations(db)
+	return db
+}
+
+// truncateChartTables clears the user/note/following/instance rows so each
+// test starts from a known state. We DELETE rather than TRUNCATE because
+// some FKs (instance.host) are referenced from other rows.
+func truncateChartTables(t *testing.T, db *gorm.DB) {
+	t.Helper()
+	for _, q := range []string{
+		`DELETE FROM "following"`,
+		`DELETE FROM "instance"`,
+		`DELETE FROM "note"`,
+		`DELETE FROM "user"`,
+	} {
+		require.NoError(t, db.Exec(q).Error, q)
+	}
+}
+
+func TestUsers_TickMinorIsNoop(t *testing.T) {
+	db := skipIfNoTestDB(t)
+	tick := charttick.Users(db)
+	got, err := tick(context.Background(), "", false)
+	require.NoError(t, err)
+	assert.Nil(t, got)
+}
+
+func TestUsers_TickMajorCountsLocalRemote(t *testing.T) {
+	db := skipIfNoTestDB(t)
+	truncateChartTables(t, db)
+
+	// 2 local, 3 remote
+	exec := func(q string) {
+		require.NoError(t, db.Exec(q).Error, q)
+	}
+	exec(`INSERT INTO "user" ("id","username","usernameLower") VALUES ('u1', 'a','a')`)
+	exec(`INSERT INTO "user" ("id","username","usernameLower") VALUES ('u2', 'b','b')`)
+	exec(`INSERT INTO "user" ("id","username","usernameLower","host") VALUES ('u3', 'c','c','remote.example')`)
+	exec(`INSERT INTO "user" ("id","username","usernameLower","host") VALUES ('u4', 'd','d','remote.example')`)
+	exec(`INSERT INTO "user" ("id","username","usernameLower","host") VALUES ('u5', 'e','e','other.example')`)
+
+	tick := charttick.Users(db)
+	got, err := tick(context.Background(), "", true)
+	require.NoError(t, err)
+	assert.Equal(t, int64(2), got["local.total"])
+	assert.Equal(t, int64(3), got["remote.total"])
+}
+
+func TestNotes_TickMajorCountsLocalRemote(t *testing.T) {
+	db := skipIfNoTestDB(t)
+	truncateChartTables(t, db)
+
+	exec := func(q string) { require.NoError(t, db.Exec(q).Error, q) }
+	// users for FK
+	exec(`INSERT INTO "user" ("id","username","usernameLower") VALUES ('u1', 'a','a')`)
+	exec(`INSERT INTO "user" ("id","username","usernameLower","host") VALUES ('u2', 'b','b','remote.example')`)
+	// 1 local note, 2 remote
+	exec(`INSERT INTO "note" ("id","userId","visibility") VALUES ('n1', 'u1', 'public')`)
+	exec(`INSERT INTO "note" ("id","userId","userHost","visibility") VALUES ('n2', 'u2', 'remote.example', 'public')`)
+	exec(`INSERT INTO "note" ("id","userId","userHost","visibility") VALUES ('n3', 'u2', 'remote.example', 'public')`)
+
+	tick := charttick.Notes(db)
+	got, err := tick(context.Background(), "", true)
+	require.NoError(t, err)
+	assert.Equal(t, int64(1), got["local.total"])
+	assert.Equal(t, int64(2), got["remote.total"])
+}
+
+func TestNotes_TickMinorIsNoop(t *testing.T) {
+	db := skipIfNoTestDB(t)
+	tick := charttick.Notes(db)
+	got, err := tick(context.Background(), "", false)
+	require.NoError(t, err)
+	assert.Nil(t, got)
+}
+
+func TestFederation_TickMajorIsNoop(t *testing.T) {
+	db := skipIfNoTestDB(t)
+	tick := charttick.Federation(db)
+	got, err := tick(context.Background(), "", true)
+	require.NoError(t, err)
+	assert.Nil(t, got)
+}
+
+// closedDB returns a *gorm.DB whose underlying SQL connection is closed,
+// so any subsequent query returns an error. Useful for exercising the
+// error branches of the TickFunc closures.
+func closedDB(t *testing.T) *gorm.DB {
+	t.Helper()
+	db := skipIfNoTestDB(t)
+	sqlDB, err := db.DB()
+	require.NoError(t, err)
+	require.NoError(t, sqlDB.Close())
+	return db
+}
+
+func TestUsers_TickMajor_DBErrorBubbles(t *testing.T) {
+	db := closedDB(t)
+	tick := charttick.Users(db)
+	_, err := tick(context.Background(), "", true)
+	assert.Error(t, err)
+}
+
+func TestNotes_TickMajor_DBErrorBubbles(t *testing.T) {
+	db := closedDB(t)
+	tick := charttick.Notes(db)
+	_, err := tick(context.Background(), "", true)
+	assert.Error(t, err)
+}
+
+func TestFederation_TickMinor_DBErrorBubbles(t *testing.T) {
+	db := closedDB(t)
+	tick := charttick.Federation(db)
+	_, err := tick(context.Background(), "", false)
+	assert.Error(t, err)
+}
+
+func TestFederation_TickMinorAggregates(t *testing.T) {
+	db := skipIfNoTestDB(t)
+	truncateChartTables(t, db)
+
+	exec := func(q string) { require.NoError(t, db.Exec(q).Error, q) }
+	// users
+	exec(`INSERT INTO "user" ("id","username","usernameLower") VALUES ('me', 'me','me')`)
+	exec(`INSERT INTO "user" ("id","username","usernameLower","host") VALUES ('a', 'a','a','a.example')`)
+	exec(`INSERT INTO "user" ("id","username","usernameLower","host") VALUES ('b', 'b','b','b.example')`)
+	exec(`INSERT INTO "user" ("id","username","usernameLower","host") VALUES ('c', 'c','c','c.example')`)
+
+	// followings:
+	//   me -> a (followee=a.example)  -> sub host: a.example
+	//   me -> b (followee=b.example)  -> sub host: b.example
+	//   c  -> me (follower=c.example) -> pub host: c.example
+	//   a  -> me (follower=a.example) -> pub host: a.example  (これで a.example は pubsub)
+	exec(`INSERT INTO "following" ("id","followerId","followeeId","followerHost","followeeHost") VALUES ('f1','me','a',NULL,'a.example')`)
+	exec(`INSERT INTO "following" ("id","followerId","followeeId","followerHost","followeeHost") VALUES ('f2','me','b',NULL,'b.example')`)
+	exec(`INSERT INTO "following" ("id","followerId","followeeId","followerHost","followeeHost") VALUES ('f3','c','me','c.example',NULL)`)
+	exec(`INSERT INTO "following" ("id","followerId","followeeId","followerHost","followeeHost") VALUES ('f4','a','me','a.example',NULL)`)
+
+	// b.example を suspend
+	exec(`INSERT INTO "instance" ("id","host","firstRetrievedAt","suspensionState") VALUES ('i1','b.example', NOW(), 'manuallySuspended')`)
+
+	tick := charttick.Federation(db)
+	got, err := tick(context.Background(), "", false)
+	require.NoError(t, err)
+
+	// sub: a.example, b.example -> 2
+	assert.Equal(t, int64(2), got["sub"])
+	// pub: c.example, a.example -> 2
+	assert.Equal(t, int64(2), got["pub"])
+	// pubsub: a.example のみ -> 1
+	assert.Equal(t, int64(1), got["pubsub"])
+	// subActive: a.example (b.example suspended) -> 1
+	assert.Equal(t, int64(1), got["subActive"])
+	// pubActive: a.example, c.example (どちらも non-suspended) -> 2
+	assert.Equal(t, int64(2), got["pubActive"])
+}

--- a/internal/core/chart/core.go
+++ b/internal/core/chart/core.go
@@ -80,6 +80,12 @@ func New(cfg Config) (*Chart, error) {
 // Name returns the chart's camelCase name.
 func (c *Chart) Name() string { return c.schema.Name }
 
+// IsGrouped reports whether this chart aggregates data into per-group
+// buckets (per-user, per-host etc.). Used by the chart cron processor
+// to skip charts that cannot be ticked without an external enumeration
+// source.
+func (c *Chart) IsGrouped() bool { return c.schema.Grouped }
+
 // Commit queues a diff to be merged into the current bucket on the next
 // Save(). The diff values may be int (any signed int type), int64, or
 // []string for uniqueIncrement columns. Unknown keys are silently

--- a/internal/core/chart/core_test.go
+++ b/internal/core/chart/core_test.go
@@ -774,3 +774,21 @@ func TestUniqueGroups_DuplicateAreCollapsed(t *testing.T) {
 	got := uniqueGroups(in)
 	assert.Equal(t, []string{"a", "b"}, got)
 }
+
+func TestChart_IsGrouped(t *testing.T) {
+	plain, err := New(Config{
+		Schema: Schema{Name: "plain", Columns: []ColumnDef{{Name: "x"}}},
+		Repo:   newFakeRepo(),
+		Lock:   NewMemoryLocker(),
+	})
+	require.NoError(t, err)
+	assert.False(t, plain.IsGrouped())
+
+	grouped, err := New(Config{
+		Schema: Schema{Name: "g", Grouped: true, Columns: []ColumnDef{{Name: "x"}}},
+		Repo:   newFakeRepo(),
+		Lock:   NewMemoryLocker(),
+	})
+	require.NoError(t, err)
+	assert.True(t, grouped.IsGrouped())
+}

--- a/internal/queue/processors/chart.go
+++ b/internal/queue/processors/chart.go
@@ -1,0 +1,69 @@
+package processors
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/hibiken/asynq"
+	"github.com/shiroha-a/mk/internal/core/chart"
+)
+
+// ChartProcessor implements the periodic tick / resync / clean handlers
+// that mirror Misskey upstream's tickCharts / resyncCharts / cleanCharts
+// queue processors. それぞれ asynq.Scheduler の cron pattern で起動される。
+type ChartProcessor struct {
+	// charts is the ordered list of every chart engine that should be
+	// ticked / resynced / cleaned. Caller passes them in the same order
+	// upstream lists them; ordering only matters for debug output since
+	// asynq cannot run more than one job concurrently.
+	charts []*chart.Chart
+}
+
+// NewChartProcessor wraps the given chart engines.
+func NewChartProcessor(charts []*chart.Chart) *ChartProcessor {
+	return &ChartProcessor{charts: charts}
+}
+
+// HandleTick runs a minor tick on every registered chart. ungrouped
+// charts only — grouped charts (per-user / per-host) cannot be enumerated
+// without an external driver and are skipped, matching the upstream
+// TickChartsProcessorService.process behaviour.
+func (p *ChartProcessor) HandleTick(ctx context.Context, _ *asynq.Task) error {
+	return p.runTick(ctx, false)
+}
+
+// HandleResync runs a major tick on every registered chart. Charts whose
+// TickFunc returns nil for major are no-ops; per-group charts that
+// require enumeration are skipped (TODO: per-user/per-host resync, same
+// as upstream).
+func (p *ChartProcessor) HandleResync(ctx context.Context, _ *asynq.Task) error {
+	return p.runTick(ctx, true)
+}
+
+// HandleClean clears expired uniqueIncrement temp arrays on every
+// registered chart.
+func (p *ChartProcessor) HandleClean(ctx context.Context, _ *asynq.Task) error {
+	for _, c := range p.charts {
+		if err := c.Clean(ctx); err != nil {
+			return fmt.Errorf("chart clean %s: %w", c.Name(), err)
+		}
+	}
+	return nil
+}
+
+// runTick walks every registered chart and calls Tick. ungrouped charts
+// pass an empty group; grouped charts are skipped here because the cron
+// driver has no enumeration source for them.
+func (p *ChartProcessor) runTick(ctx context.Context, major bool) error {
+	for _, c := range p.charts {
+		if c.IsGrouped() {
+			// upstream も grouped chart (instance / per-user-*) は cron で
+			// tick せず、関連サービス側で resync をトリガする設計。
+			continue
+		}
+		if err := c.Tick(ctx, major, ""); err != nil {
+			return fmt.Errorf("chart tick %s (major=%v): %w", c.Name(), major, err)
+		}
+	}
+	return nil
+}

--- a/internal/queue/processors/chart_test.go
+++ b/internal/queue/processors/chart_test.go
@@ -1,0 +1,210 @@
+package processors_test
+
+import (
+	"context"
+	"database/sql"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/hibiken/asynq"
+	"github.com/shiroha-a/mk/internal/core/chart"
+	"github.com/shiroha-a/mk/internal/queue/processors"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// memRepo is a minimal in-memory chart.Repository sufficient for
+// ChartProcessor unit tests. Only the methods exercised by Tick and
+// Clean are non-trivial; the rest return ErrRowNotFound or nil.
+type memRepo struct {
+	mu      sync.Mutex
+	nextID  int64
+	rows    map[chart.Span]map[string][]*chart.Row
+	resetN  atomic.Int64
+	setColN atomic.Int64
+}
+
+func newMemRepo() *memRepo {
+	return &memRepo{
+		rows: map[chart.Span]map[string][]*chart.Row{
+			chart.SpanHour: {},
+			chart.SpanDay:  {},
+		},
+	}
+}
+
+func (r *memRepo) FindCurrent(_ context.Context, span chart.Span, group string, ts int64) (*chart.Row, error) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	for _, row := range r.rows[span][group] {
+		if row.Date == ts {
+			return row, nil
+		}
+	}
+	return nil, chart.ErrRowNotFound
+}
+
+func (r *memRepo) FindLatest(_ context.Context, span chart.Span, group string) (*chart.Row, error) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	rows := r.rows[span][group]
+	if len(rows) == 0 {
+		return nil, chart.ErrRowNotFound
+	}
+	return rows[len(rows)-1], nil
+}
+
+func (r *memRepo) FindBefore(_ context.Context, span chart.Span, group string, ts int64) (*chart.Row, error) {
+	return nil, chart.ErrRowNotFound
+}
+
+func (r *memRepo) FindRange(_ context.Context, span chart.Span, group string, gt, lt int64) ([]*chart.Row, error) {
+	return nil, nil
+}
+
+func (r *memRepo) Insert(_ context.Context, span chart.Span, group string, ts int64, cols map[string]any) (*chart.Row, error) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.nextID++
+	row := &chart.Row{
+		ID:   r.nextID,
+		Date: ts,
+		Cols: map[string]any{},
+	}
+	if group != "" {
+		row.Group = sql.NullString{Valid: true, String: group}
+	}
+	for k, v := range cols {
+		row.Cols[k] = v
+	}
+	r.rows[span][group] = append(r.rows[span][group], row)
+	return row, nil
+}
+
+func (r *memRepo) ApplyDeltas(_ context.Context, _ chart.Span, _ int64, _ map[string]int64, _ map[string][]string, _ map[string]int64) error {
+	return nil
+}
+
+func (r *memRepo) SetColumns(_ context.Context, _ chart.Span, _ int64, _ map[string]int64) error {
+	r.setColN.Add(1)
+	return nil
+}
+
+func (r *memRepo) ResetUniqueTempColumns(_ context.Context, _ chart.Span, _, _ int64, _ []string) error {
+	r.resetN.Add(1)
+	return nil
+}
+
+// makeChart constructs a chart.Chart wired to a memRepo for testing.
+func makeChart(t *testing.T, schema chart.Schema, tick chart.TickFunc) (*chart.Chart, *memRepo) {
+	t.Helper()
+	repo := newMemRepo()
+	c, err := chart.New(chart.Config{
+		Schema: schema,
+		Repo:   repo,
+		Lock:   chart.NewMemoryLocker(),
+		Tick:   tick,
+		Clock:  fixedClock{t: time.Date(2026, 4, 14, 12, 0, 0, 0, time.UTC)},
+	})
+	require.NoError(t, err)
+	return c, repo
+}
+
+type fixedClock struct{ t time.Time }
+
+func (c fixedClock) Now() time.Time { return c.t }
+
+// schemaWithUnique returns a tiny schema with one unique-increment column,
+// so Clean has work to do.
+func schemaWithUnique() chart.Schema {
+	return chart.Schema{
+		Name: "test_chart",
+		Columns: []chart.ColumnDef{
+			{Name: "u", UniqueIncrement: true},
+		},
+	}
+}
+
+// schemaPlain returns a schema with no unique columns; Clean is a no-op.
+func schemaPlain() chart.Schema {
+	return chart.Schema{
+		Name: "plain",
+		Columns: []chart.ColumnDef{
+			{Name: "x"},
+		},
+	}
+}
+
+// schemaGrouped returns a grouped schema; ChartProcessor must skip Tick.
+func schemaGrouped() chart.Schema {
+	return chart.Schema{
+		Name:    "grouped",
+		Grouped: true,
+		Columns: []chart.ColumnDef{
+			{Name: "x"},
+		},
+	}
+}
+
+func TestChartProcessor_HandleClean(t *testing.T) {
+	withUnique, repo1 := makeChart(t, schemaWithUnique(), nil)
+	plain, repo2 := makeChart(t, schemaPlain(), nil)
+	p := processors.NewChartProcessor([]*chart.Chart{withUnique, plain})
+
+	require.NoError(t, p.HandleClean(context.Background(), asynq.NewTask("x", nil)))
+	// withUnique chart は span hour + day で 2 回 ResetUniqueTempColumns が呼ばれる
+	assert.Equal(t, int64(2), repo1.resetN.Load())
+	// plain chart は uniqueColumn が無いので ResetUniqueTempColumns は呼ばれない
+	assert.Equal(t, int64(0), repo2.resetN.Load())
+}
+
+func TestChartProcessor_HandleTick_SkipsGrouped(t *testing.T) {
+	called := atomic.Int64{}
+	tickFn := chart.TickFunc(func(_ context.Context, _ string, _ bool) (map[string]int64, error) {
+		called.Add(1)
+		return map[string]int64{"x": 1}, nil
+	})
+	plain, _ := makeChart(t, schemaPlain(), tickFn)
+	grouped, _ := makeChart(t, schemaGrouped(), tickFn)
+	p := processors.NewChartProcessor([]*chart.Chart{plain, grouped})
+
+	require.NoError(t, p.HandleTick(context.Background(), asynq.NewTask("x", nil)))
+	// grouped chart は skip される
+	assert.Equal(t, int64(1), called.Load())
+}
+
+func TestChartProcessor_HandleResync_PassesMajorTrue(t *testing.T) {
+	gotMajor := atomic.Bool{}
+	tickFn := chart.TickFunc(func(_ context.Context, _ string, major bool) (map[string]int64, error) {
+		gotMajor.Store(major)
+		return map[string]int64{"x": 1}, nil
+	})
+	plain, _ := makeChart(t, schemaPlain(), tickFn)
+	p := processors.NewChartProcessor([]*chart.Chart{plain})
+
+	require.NoError(t, p.HandleResync(context.Background(), asynq.NewTask("x", nil)))
+	assert.True(t, gotMajor.Load())
+}
+
+func TestChartProcessor_HandleTick_PassesMajorFalse(t *testing.T) {
+	gotMajor := atomic.Bool{}
+	gotMajor.Store(true) // 初期値 true でデフォルトを区別できるようにする
+	tickFn := chart.TickFunc(func(_ context.Context, _ string, major bool) (map[string]int64, error) {
+		gotMajor.Store(major)
+		return map[string]int64{"x": 1}, nil
+	})
+	plain, _ := makeChart(t, schemaPlain(), tickFn)
+	p := processors.NewChartProcessor([]*chart.Chart{plain})
+
+	require.NoError(t, p.HandleTick(context.Background(), asynq.NewTask("x", nil)))
+	assert.False(t, gotMajor.Load())
+}
+
+func TestChartProcessor_HandleTick_NilTickFuncIsNoop(t *testing.T) {
+	plain, _ := makeChart(t, schemaPlain(), nil)
+	p := processors.NewChartProcessor([]*chart.Chart{plain})
+	require.NoError(t, p.HandleTick(context.Background(), asynq.NewTask("x", nil)))
+	require.NoError(t, p.HandleResync(context.Background(), asynq.NewTask("x", nil)))
+}

--- a/internal/queue/queue.go
+++ b/internal/queue/queue.go
@@ -163,10 +163,11 @@ func NewServer(redisOpt asynq.RedisClientOpt, cfg ServerConfig) *Server {
 		// map のキーが登録済み queue として扱われ、未登録の queue は
 		// processor を実行しないので新しい TaskType 追加時は忘れずに足す。
 		Queues: map[string]int{
-			QueueName:        1,
-			PushQueueName:    1,
-			ExportQueueName:  1,
-			WebhookQueueName: 1,
+			QueueName:            1,
+			PushQueueName:        1,
+			ExportQueueName:      1,
+			WebhookQueueName:     1,
+			MaintenanceQueueName: 1,
 		},
 	})
 	return &Server{inner: inner, mux: asynq.NewServeMux()}

--- a/internal/queue/scheduler.go
+++ b/internal/queue/scheduler.go
@@ -1,0 +1,66 @@
+package queue
+
+import (
+	"github.com/hibiken/asynq"
+)
+
+// MaintenanceQueueName is the asynq queue used for low-priority
+// maintenance jobs (chart tick / resync / clean etc). Kept separate
+// from the latency-sensitive deliver queue so a long aggregation does
+// not stall federation traffic.
+const MaintenanceQueueName = "maintenance"
+
+// Scheduler wraps asynq.Scheduler. It registers cron-style entries
+// once at startup and continuously enqueues tasks per their schedule
+// onto the standard worker queues.
+//
+// asynq.Scheduler は redis 上のロックで重複起動を防ぐので、複数 process
+// で起動しても同時刻に同じジョブを 2 回 enqueue することはない。
+type Scheduler struct {
+	inner *asynq.Scheduler
+}
+
+// NewScheduler constructs a Scheduler backed by the given Redis.
+func NewScheduler(redisOpt asynq.RedisClientOpt) *Scheduler {
+	return &Scheduler{
+		inner: asynq.NewScheduler(redisOpt, &asynq.SchedulerOpts{}),
+	}
+}
+
+// RegisterChartJobs registers the 3 chart-related cron jobs.
+//
+//   - tickCharts : 毎時 55 分 (TS Misskey と同一 cron pattern)
+//   - resyncCharts: 毎日 00:00 UTC
+//   - cleanCharts : 毎日 00:00 UTC
+//
+// 重複 enqueue 防止のため Unique TTL を cron 周期と合わせる。
+func (s *Scheduler) RegisterChartJobs() error {
+	jobs := []struct {
+		cron     string
+		taskType string
+	}{
+		{"55 * * * *", TaskTypeChartTick},
+		{"0 0 * * *", TaskTypeChartResync},
+		{"0 0 * * *", TaskTypeChartClean},
+	}
+	for _, j := range jobs {
+		task := asynq.NewTask(j.taskType, nil)
+		if _, err := s.inner.Register(j.cron, task,
+			asynq.Queue(MaintenanceQueueName),
+			asynq.MaxRetry(0),
+		); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// Start launches the scheduler in the background. Returns immediately.
+func (s *Scheduler) Start() error {
+	return s.inner.Start()
+}
+
+// Shutdown stops the scheduler and releases its Redis connection.
+func (s *Scheduler) Shutdown() {
+	s.inner.Shutdown()
+}

--- a/internal/queue/scheduler.go
+++ b/internal/queue/scheduler.go
@@ -1,6 +1,8 @@
 package queue
 
 import (
+	"time"
+
 	"github.com/hibiken/asynq"
 )
 
@@ -33,21 +35,25 @@ func NewScheduler(redisOpt asynq.RedisClientOpt) *Scheduler {
 //   - resyncCharts: 毎日 00:00 UTC
 //   - cleanCharts : 毎日 00:00 UTC
 //
-// 重複 enqueue 防止のため Unique TTL を cron 周期と合わせる。
+// 重複 enqueue 防止のため Unique TTL を cron 周期と合わせる。前回の
+// 同種ジョブが処理中のまま次回 cron が発火しても、TTL 内であれば asynq が
+// 重複 enqueue を弾く。
 func (s *Scheduler) RegisterChartJobs() error {
 	jobs := []struct {
-		cron     string
-		taskType string
+		cron      string
+		taskType  string
+		uniqueTTL time.Duration
 	}{
-		{"55 * * * *", TaskTypeChartTick},
-		{"0 0 * * *", TaskTypeChartResync},
-		{"0 0 * * *", TaskTypeChartClean},
+		{"55 * * * *", TaskTypeChartTick, 1 * time.Hour},
+		{"0 0 * * *", TaskTypeChartResync, 24 * time.Hour},
+		{"0 0 * * *", TaskTypeChartClean, 24 * time.Hour},
 	}
 	for _, j := range jobs {
 		task := asynq.NewTask(j.taskType, nil)
 		if _, err := s.inner.Register(j.cron, task,
 			asynq.Queue(MaintenanceQueueName),
 			asynq.MaxRetry(0),
+			asynq.Unique(j.uniqueTTL),
 		); err != nil {
 			return err
 		}

--- a/internal/queue/scheduler_test.go
+++ b/internal/queue/scheduler_test.go
@@ -1,0 +1,35 @@
+package queue
+
+import (
+	"testing"
+
+	"github.com/hibiken/asynq"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestNewScheduler_NotNil is a simple smoke test that the Scheduler
+// wrapper builds without touching Redis. asynq.Scheduler does not
+// connect on construction, so this can run without a Redis instance.
+func TestNewScheduler_NotNil(t *testing.T) {
+	s := NewScheduler(asynq.RedisClientOpt{Addr: "127.0.0.1:6379"})
+	require.NotNil(t, s)
+	require.NotNil(t, s.inner)
+	// Shutdown を呼んでも Start していなければ no-op で安全。
+	s.Shutdown()
+}
+
+// TestScheduler_RegisterChartJobs_NoErr verifies the cron syntax + queue
+// options are accepted by asynq. Register does not enqueue — it simply
+// records the schedule — so no Redis is required.
+func TestScheduler_RegisterChartJobs_NoErr(t *testing.T) {
+	s := NewScheduler(asynq.RedisClientOpt{Addr: "127.0.0.1:6379"})
+	defer s.Shutdown()
+
+	require.NoError(t, s.RegisterChartJobs())
+}
+
+func TestMaintenanceQueueName_Const(t *testing.T) {
+	// 既存定数と被らないこと (ベタ書きの同期ミスを防ぐ smoke)
+	assert.Equal(t, "maintenance", MaintenanceQueueName)
+}

--- a/internal/queue/tasks.go
+++ b/internal/queue/tasks.go
@@ -37,6 +37,18 @@ const TaskTypeCleanRemoteNotes = "maintenance:cleanRemoteNotes"
 // reaction counts from Redis to the database.
 const TaskTypeReactionFlush = "maintenance:reactionFlush"
 
+// TaskTypeChartTick is the asynq task type for the hourly tick-charts
+// job. Mirrors upstream `tickCharts` (cron `55 * * * *`).
+const TaskTypeChartTick = "chart:tick"
+
+// TaskTypeChartResync is the asynq task type for the daily resync-charts
+// job. Mirrors upstream `resyncCharts` (cron `0 0 * * *`).
+const TaskTypeChartResync = "chart:resync"
+
+// TaskTypeChartClean is the asynq task type for the daily clean-charts
+// job. Mirrors upstream `cleanCharts` (cron `0 0 * * *`).
+const TaskTypeChartClean = "chart:clean"
+
 // DeliverPayload is the body of a deliver task. すべてJSONで安全に
 // シリアライズできる型のみを保持する。
 type DeliverPayload struct {

--- a/internal/server/charts.go
+++ b/internal/server/charts.go
@@ -2,6 +2,7 @@ package server
 
 import (
 	apicharts "github.com/shiroha-a/mk/internal/api/charts"
+	"github.com/shiroha-a/mk/internal/charttick"
 	"github.com/shiroha-a/mk/internal/core/chart"
 	corechartcharts "github.com/shiroha-a/mk/internal/core/chart/charts"
 	"gorm.io/gorm"
@@ -10,15 +11,18 @@ import (
 // buildChartBundle constructs every chart engine the server needs and
 // returns them packaged for the API handler. Each engine gets its own
 // gormRepository instance bound to its specific schema; lock and clock
-// are shared singletons. The function is package-level so router.go
-// stays focused on routing.
+// are shared singletons. Charts whose upstream tickMajor/tickMinor
+// performs an absolute count get a TickFunc closure (see
+// internal/charttick) so the periodic chart cron can correct
+// event-driven drift (#151).
 func buildChartBundle(db *gorm.DB) apicharts.Charts {
 	locker := chart.NewMemoryLocker()
-	mk := func(schema chart.Schema) *chart.Chart {
+	mk := func(schema chart.Schema, tick chart.TickFunc) *chart.Chart {
 		c, err := chart.New(chart.Config{
 			Schema: schema,
 			Repo:   chart.NewRepository(db, schema),
 			Lock:   locker,
+			Tick:   tick,
 		})
 		if err != nil {
 			// Schema 不正は起動時に検出したいので panic で弾く。
@@ -28,17 +32,17 @@ func buildChartBundle(db *gorm.DB) apicharts.Charts {
 		return c
 	}
 	return apicharts.Charts{
-		Notes:            mk(corechartcharts.SchemaNotes()),
-		Users:            mk(corechartcharts.SchemaUsers()),
-		Drive:            mk(corechartcharts.SchemaDrive()),
-		Federation:       mk(corechartcharts.SchemaFederation()),
-		Instance:         mk(corechartcharts.SchemaInstance()),
-		ApRequest:        mk(corechartcharts.SchemaApRequest()),
-		ActiveUsers:      mk(corechartcharts.SchemaActiveUsers()),
-		PerUserNotes:     mk(corechartcharts.SchemaPerUserNotes()),
-		PerUserDrive:     mk(corechartcharts.SchemaPerUserDrive()),
-		PerUserFollowing: mk(corechartcharts.SchemaPerUserFollowing()),
-		PerUserPv:        mk(corechartcharts.SchemaPerUserPv()),
-		PerUserReaction:  mk(corechartcharts.SchemaPerUserReaction()),
+		Notes:            mk(corechartcharts.SchemaNotes(), charttick.Notes(db)),
+		Users:            mk(corechartcharts.SchemaUsers(), charttick.Users(db)),
+		Drive:            mk(corechartcharts.SchemaDrive(), nil),
+		Federation:       mk(corechartcharts.SchemaFederation(), charttick.Federation(db)),
+		Instance:         mk(corechartcharts.SchemaInstance(), nil),
+		ApRequest:        mk(corechartcharts.SchemaApRequest(), nil),
+		ActiveUsers:      mk(corechartcharts.SchemaActiveUsers(), nil),
+		PerUserNotes:     mk(corechartcharts.SchemaPerUserNotes(), nil),
+		PerUserDrive:     mk(corechartcharts.SchemaPerUserDrive(), nil),
+		PerUserFollowing: mk(corechartcharts.SchemaPerUserFollowing(), nil),
+		PerUserPv:        mk(corechartcharts.SchemaPerUserPv(), nil),
+		PerUserReaction:  mk(corechartcharts.SchemaPerUserReaction(), nil),
 	}
 }

--- a/internal/server/router.go
+++ b/internal/server/router.go
@@ -465,6 +465,27 @@ func (s *Server) setupRoutes() {
 	federationResolver.SetChartHook(chartHooks)
 	deliverProcessor.SetChartHook(chartHooks)
 
+	// Chart cron processor: tickCharts (毎時) / resyncCharts (毎日) /
+	// cleanCharts (毎日) を queue.Scheduler 経由で受け取る。Scheduler
+	// 自体の cron 登録は server.Start() で行う。
+	chartProcessor := processors.NewChartProcessor([]*chart.Chart{
+		chartCharts.Notes,
+		chartCharts.Users,
+		chartCharts.Drive,
+		chartCharts.Federation,
+		chartCharts.Instance,
+		chartCharts.ApRequest,
+		chartCharts.ActiveUsers,
+		chartCharts.PerUserNotes,
+		chartCharts.PerUserDrive,
+		chartCharts.PerUserFollowing,
+		chartCharts.PerUserPv,
+		chartCharts.PerUserReaction,
+	})
+	s.queueServer.Handle(queue.TaskTypeChartTick, chartProcessor.HandleTick)
+	s.queueServer.Handle(queue.TaskTypeChartResync, chartProcessor.HandleResync)
+	s.queueServer.Handle(queue.TaskTypeChartClean, chartProcessor.HandleClean)
+
 	// Health check
 	s.echo.GET("/healthz", func(c echo.Context) error {
 		return c.JSON(http.StatusOK, map[string]string{"status": "ok"})

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -29,6 +29,7 @@ type Server struct {
 	auth           *middleware.AuthMiddleware
 	queueClient    *queue.Client
 	queueServer    *queue.Server
+	queueScheduler *queue.Scheduler
 	queueInspector *queue.Inspector
 	chartMgmt      *chart.ManagementService
 }
@@ -80,6 +81,7 @@ func New(cfg *config.Config, db *gorm.DB, redis *cache.RedisClients) *Server {
 	}
 	queueClient := queue.NewClient(redisOpt)
 	queueServer := queue.NewServer(redisOpt, queue.ServerConfig{Concurrency: concurrency})
+	queueScheduler := queue.NewScheduler(redisOpt)
 	queueInspector := queue.NewInspector(redisOpt)
 
 	s := &Server{
@@ -90,6 +92,7 @@ func New(cfg *config.Config, db *gorm.DB, redis *cache.RedisClients) *Server {
 		auth:           auth,
 		queueClient:    queueClient,
 		queueServer:    queueServer,
+		queueScheduler: queueScheduler,
 		queueInspector: queueInspector,
 	}
 
@@ -113,6 +116,13 @@ func (s *Server) Handler() http.Handler {
 func (s *Server) Start() error {
 	if err := s.queueServer.Start(); err != nil {
 		return fmt.Errorf("start queue worker: %w", err)
+	}
+	if s.queueScheduler != nil {
+		if err := s.queueScheduler.RegisterChartJobs(); err != nil {
+			slog.Warn("chart scheduler register failed", "err", err)
+		} else if err := s.queueScheduler.Start(); err != nil {
+			slog.Warn("chart scheduler start failed", "err", err)
+		}
 	}
 	if s.chartMgmt != nil {
 		if err := s.chartMgmt.Start(context.Background()); err != nil {
@@ -146,6 +156,9 @@ func (s *Server) Start() error {
 func (s *Server) Shutdown(ctx context.Context) error {
 	if s.chartMgmt != nil {
 		s.chartMgmt.Stop(ctx)
+	}
+	if s.queueScheduler != nil {
+		s.queueScheduler.Shutdown()
 	}
 	s.queueServer.Shutdown()
 	if err := s.queueClient.Close(); err != nil {


### PR DESCRIPTION
## Summary

Issue #151 (親 #134 / 互換性調査 #124)。chart 集計の **定期実行 (tick / resync / clean)** を asynq Scheduler で実装し、TS Misskey 本家と同じ cron pattern で動作させる。これまで Save() の 20 分毎フラッシュだけだったので絶対値カウンタが永続的にズレていた問題を解消する。

## 主な変更点

### `internal/charttick` 新パッケージ
- **`Users(db)` / `Notes(db)`**: tickMajor (毎日 00:00) で local/remote の絶対値を `COUNT(*) FILTER (WHERE host IS NULL)` 一発で再計算
- **`Federation(db)`**: tickMinor (毎時 55 分) で sub / pub / pubsub / subActive / pubActive の 5 値を集計 (suspend済みインスタンス除外を含む)

### `internal/core/chart`
- **`Chart.IsGrouped()`** ヘルパ追加
- 既存 `Chart.Clean()` (uniqueIncrement temp 列の prune) はそのまま再利用

### `internal/queue/scheduler.go` 新規
- **`asynq.Scheduler` ラッパ**
- **`MaintenanceQueueName = "maintenance"`** 低優先度キュー追加
- **3 つの cron 登録**:
  | task type | cron | upstream |
  |---|---|---|
  | \`chart:tick\` | \`55 * * * *\` | \`tickCharts\` |
  | \`chart:resync\` | \`0 0 * * *\` | \`resyncCharts\` |
  | \`chart:clean\` | \`0 0 * * *\` | \`cleanCharts\` |

### `internal/queue/processors/chart.go` 新規
- **`HandleTick`** (minor=false で全 ungrouped chart に Tick)
- **`HandleResync`** (major=true で全 ungrouped chart に Tick)
- **`HandleClean`** (全 chart に Clean)
- grouped chart (instance / per-user-*) は upstream と同様 skip — enumeration source 無しでは tick できないため

### 起動シーケンス
- **`server.go`**: `queueScheduler` フィールド追加、Start で `RegisterChartJobs()` + `Start()`、Shutdown で停止
- **`router.go`**: ChartProcessor を queue.Server に登録
- **`server/charts.go`**: TickFunc を chart 構築時に注入 (注入元は `internal/charttick`)

## 設計上の注記

### なぜ `internal/charttick` を分離したか
DB を叩く統合テストを `internal/server` 配下に置くと 2.8k LOC のテスト無し本体パッケージが CI のパッケージ別カバレッジ (90%) で巻き込まれて落ちる。`internal/db` (#133) や `internal/sentry` (#154) と同じ理由で別パッケージに切り出した。

### grouped chart の resync
TS 本家も per-user/per-host chart の resync は \`// TODO: ユーザーごとのチャートも更新する\` と TODO 扱いなので、Go 版でも同じく後続 issue 送り。

## テスト

新規追加:
- **charttick**: Users/Notes/Federation の major/minor 動作確認 (DB) + 各 DB エラーパス
- **scheduler**: 構築 + RegisterChartJobs の cron syntax 検証
- **chart_processor**: in-memory chart engine で HandleTick/Resync/Clean、grouped chart skip、major/minor フラグ伝播
- **chart core**: `IsGrouped()` の plain/grouped 両ケース

実行方法:
\`\`\`bash
go test ./internal/charttick/ ./internal/queue/... ./internal/core/chart/...
\`\`\`

カバレッジ:
- \`internal/charttick\`: 90.5%
- \`internal/queue\`: 94.8%
- \`internal/queue/processors\`: 91.7%
- \`internal/core/chart\`: 100.0%

## 関連
- 親issue: #134
Closes #151
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/shiroha-a/mk/pull/160" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
