### PR TITLE
P4-1: ActivityPub relay delivery / accept / broadcast (#161)

### DIFF
--- a/internal/activitypub/renderer.go
+++ b/internal/activitypub/renderer.go
@@ -80,6 +80,14 @@ func (b *URLBuilder) FollowURI(followerID, followeeID string) string {
 	return b.baseURL + "/follows/" + followerID + "/" + id
 }
 
+// FollowRelayURI returns the URI for a Follow-Relay activity.
+// Path 形式は upstream と一致させる (`/activities/follow-relay/{relayID}`):
+// Accept / Reject inbox ハンドラがこの正規表現で relay を特定するため、
+// 変更するときは processor 側の regex も一緒に更新すること。
+func (b *URLBuilder) FollowRelayURI(relayID string) string {
+	return b.baseURL + "/activities/follow-relay/" + relayID
+}
+
 // MentionResolver resolves a note.Mentions entry (user ID) into the data
 // required to build an AS Mention tag. 実装は server/router.go 側で
 // UserRepository を wrap する形で提供される。解決に失敗したら ok=false を
@@ -438,6 +446,32 @@ func (r *Renderer) RenderFollow(followerID, followeeURI string) *Follow {
 			Actor: r.urls.UserURI(followerID),
 		},
 		Object: followeeURI,
+	}
+	AddContext(f)
+	return f
+}
+
+// RenderFollowRelay returns the special-purpose Follow activity used to
+// subscribe the instance's relay system actor to a relay endpoint.
+//
+// Mirrors upstream ApRendererService.renderFollowRelay:
+//   - id: `${baseURL}/activities/follow-relay/${relayID}`
+//   - actor: relay actor's local URI
+//   - object: the ActivityStreams Public IRI (= subscribe to everything)
+//
+// The id format is load-bearing — inbox Accept/Reject activities are
+// matched against `/activities/follow-relay/([\w-]+)$` to look the
+// relay up when marking its status.
+func (r *Renderer) RenderFollowRelay(relayID string, relayActorID string) *Follow {
+	f := &Follow{
+		Activity: Activity{
+			Object: Object{
+				ID:   r.urls.FollowRelayURI(relayID),
+				Type: "Follow",
+			},
+			Actor: r.urls.UserURI(relayActorID),
+		},
+		Object: Public,
 	}
 	AddContext(f)
 	return f

--- a/internal/activitypub/renderer_test.go
+++ b/internal/activitypub/renderer_test.go
@@ -268,6 +268,22 @@ func TestRenderer_RenderAccept(t *testing.T) {
 	assert.NotNil(t, a.Object)
 }
 
+func TestRenderer_RenderFollowRelay(t *testing.T) {
+	r := newRenderer()
+	f := r.RenderFollowRelay("rel123", "relay-user-id")
+	assert.Equal(t, "Follow", f.Type)
+	assert.Equal(t, "https://example.com/users/relay-user-id", f.Actor)
+	// id は /activities/follow-relay/{relayID} 固定 (processor 側が regex で検出)
+	assert.Equal(t, "https://example.com/activities/follow-relay/rel123", f.ID)
+	// object は AS Public (relay は全 public 投稿を購読するため)
+	assert.Equal(t, Public, f.Object)
+}
+
+func TestURLBuilder_FollowRelayURI(t *testing.T) {
+	b := NewURLBuilder("https://example.com")
+	assert.Equal(t, "https://example.com/activities/follow-relay/abc", b.FollowRelayURI("abc"))
+}
+
 func TestStringValue(t *testing.T) {
 	s := "x"
 	assert.Equal(t, "x", stringValue(&s))

--- a/internal/api/admin/handler.go
+++ b/internal/api/admin/handler.go
@@ -1,6 +1,7 @@
 package admin
 
 import (
+	"context"
 	"net/http"
 	"time"
 
@@ -17,6 +18,15 @@ import (
 	"gorm.io/gorm"
 )
 
+// RelayService is the subset of core/relay.Service needed by the
+// admin/relays endpoints. Kept as an interface so tests can inject a
+// fake without the rest of the federation pipeline.
+type RelayService interface {
+	Add(ctx context.Context, inbox string) (*model.Relay, error)
+	Remove(ctx context.Context, id string) error
+	List(ctx context.Context) ([]*model.Relay, error)
+}
+
 // Handler handles admin API endpoints.
 type Handler struct {
 	signupService  *signup.Service
@@ -31,7 +41,14 @@ type Handler struct {
 	userIPRepo     repository.UserIPRepository
 	queueInspector QueueInspector
 	emojiEnqueuer  EmojiImportEnqueuer
+	relayService   RelayService
 	idGen          id.Generator
+}
+
+// SetRelayService wires the relay service used by admin/relays endpoints.
+// nil を渡せば Admin API が DB fallback (create/update/delete のみ) に戻る。
+func (h *Handler) SetRelayService(s RelayService) {
+	h.relayService = s
 }
 
 // EmojiImportEnqueuer is the subset of queue.Enqueuer needed to schedule

--- a/internal/api/admin/handler_stubs.go
+++ b/internal/api/admin/handler_stubs.go
@@ -922,16 +922,26 @@ func (h *Handler) QueueStats(c echo.Context) error {
 
 // --- relays ---
 
-// RelaysAdd handles POST /api/admin/relays/add.
+// RelaysAdd handles POST /api/admin/relays/add. Routes through the
+// relay Service so that a Follow activity is actually dispatched to
+// the relay's inbox (#161). Falls back to raw DB insertion when the
+// service is not wired (tests or early boot).
 func (h *Handler) RelaysAdd(c echo.Context) error {
-	if h.adminDB == nil {
-		return c.NoContent(http.StatusNoContent)
-	}
 	var req struct {
 		Inbox string `json:"inbox"`
 	}
 	_ = c.Bind(&req)
 	if req.Inbox == "" {
+		return c.NoContent(http.StatusNoContent)
+	}
+	if h.relayService != nil {
+		rel, err := h.relayService.Add(c.Request().Context(), req.Inbox)
+		if err != nil {
+			return apierr.JSONInternalError(c)
+		}
+		return c.JSON(http.StatusOK, rel)
+	}
+	if h.adminDB == nil {
 		return c.NoContent(http.StatusNoContent)
 	}
 	relay := &model.Relay{
@@ -943,6 +953,16 @@ func (h *Handler) RelaysAdd(c echo.Context) error {
 
 // RelaysList handles POST /api/admin/relays/list.
 func (h *Handler) RelaysList(c echo.Context) error {
+	if h.relayService != nil {
+		list, err := h.relayService.List(c.Request().Context())
+		if err != nil {
+			return apierr.JSONInternalError(c)
+		}
+		if list == nil {
+			list = []*model.Relay{}
+		}
+		return c.JSON(http.StatusOK, list)
+	}
 	if h.adminDB == nil {
 		return c.JSON(http.StatusOK, []any{})
 	}
@@ -951,15 +971,35 @@ func (h *Handler) RelaysList(c echo.Context) error {
 	return c.JSON(http.StatusOK, relays)
 }
 
-// RelaysRemove handles POST /api/admin/relays/remove.
+// RelaysRemove handles POST /api/admin/relays/remove. When the relay
+// service is configured, it sends an Undo(Follow) to the relay inbox
+// before deleting the row.
 func (h *Handler) RelaysRemove(c echo.Context) error {
+	var req struct {
+		ID    string `json:"id"`
+		Inbox string `json:"inbox"`
+	}
+	_ = c.Bind(&req)
+	if h.relayService != nil {
+		id := req.ID
+		if id == "" && req.Inbox != "" && h.adminDB != nil {
+			// 本家互換のため inbox 指定でも remove できるようにする
+			var rel model.Relay
+			if err := h.adminDB.Where(`"inbox" = ?`, req.Inbox).First(&rel).Error; err == nil {
+				id = rel.ID
+			}
+		}
+		if id == "" {
+			return c.NoContent(http.StatusNoContent)
+		}
+		if err := h.relayService.Remove(c.Request().Context(), id); err != nil {
+			return apierr.JSONInternalError(c)
+		}
+		return c.NoContent(http.StatusNoContent)
+	}
 	if h.adminDB == nil {
 		return c.NoContent(http.StatusNoContent)
 	}
-	var req struct {
-		ID string `json:"id"`
-	}
-	_ = c.Bind(&req)
 	h.adminDB.Where(`"id" = ?`, req.ID).Delete(&model.Relay{})
 	return c.NoContent(http.StatusNoContent)
 }

--- a/internal/api/admin/handler_stubs_test.go
+++ b/internal/api/admin/handler_stubs_test.go
@@ -1,6 +1,8 @@
 package admin_test
 
 import (
+	"context"
+	"errors"
 	"net/http"
 	"testing"
 
@@ -394,17 +396,99 @@ func TestQueueStatsAdmin(t *testing.T) {
 }
 
 // --- relays ---
+
+// fakeRelaySvc records calls + returns configurable results for the
+// admin/relays handlers.
+type fakeRelaySvc struct {
+	added   []string
+	removed []string
+	listed  int
+	retRel  *model.Relay
+	retList []*model.Relay
+	err     error
+}
+
+func (f *fakeRelaySvc) Add(_ context.Context, inbox string) (*model.Relay, error) {
+	f.added = append(f.added, inbox)
+	return f.retRel, f.err
+}
+func (f *fakeRelaySvc) Remove(_ context.Context, id string) error {
+	f.removed = append(f.removed, id)
+	return f.err
+}
+func (f *fakeRelaySvc) List(_ context.Context) ([]*model.Relay, error) {
+	f.listed++
+	return f.retList, f.err
+}
+
 func TestRelaysAdd(t *testing.T) {
 	h, _, _, _ := newTestHandler(t)
 	assert.Equal(t, http.StatusNoContent, doPost(h.RelaysAdd, `{}`, adminUser).Code)
 }
+
+func TestRelaysAdd_WithService(t *testing.T) {
+	h, _, _, _ := newTestHandler(t)
+	svc := &fakeRelaySvc{retRel: &model.Relay{ID: "rel1", Inbox: "https://r.example/inbox", Status: "requesting"}}
+	h.SetRelayService(svc)
+	rec := doPost(h.RelaysAdd, `{"inbox":"https://r.example/inbox"}`, adminUser)
+	assert.Equal(t, http.StatusOK, rec.Code)
+	assert.Equal(t, []string{"https://r.example/inbox"}, svc.added)
+}
+
+func TestRelaysAdd_ServiceError(t *testing.T) {
+	h, _, _, _ := newTestHandler(t)
+	svc := &fakeRelaySvc{err: errors.New("boom")}
+	h.SetRelayService(svc)
+	rec := doPost(h.RelaysAdd, `{"inbox":"https://r.example/inbox"}`, adminUser)
+	assert.Equal(t, http.StatusInternalServerError, rec.Code)
+}
+
 func TestRelaysList(t *testing.T) {
 	h, _, _, _ := newTestHandler(t)
 	assert.Equal(t, http.StatusOK, doPost(h.RelaysList, `{}`, adminUser).Code)
 }
+
+func TestRelaysList_WithService(t *testing.T) {
+	h, _, _, _ := newTestHandler(t)
+	svc := &fakeRelaySvc{retList: []*model.Relay{{ID: "a"}, {ID: "b"}}}
+	h.SetRelayService(svc)
+	rec := doPost(h.RelaysList, `{}`, adminUser)
+	assert.Equal(t, http.StatusOK, rec.Code)
+	assert.Equal(t, 1, svc.listed)
+}
+
+func TestRelaysList_WithService_NilSlice(t *testing.T) {
+	// list が nil を返しても [] を返す (本家互換)
+	h, _, _, _ := newTestHandler(t)
+	svc := &fakeRelaySvc{retList: nil}
+	h.SetRelayService(svc)
+	rec := doPost(h.RelaysList, `{}`, adminUser)
+	assert.Equal(t, http.StatusOK, rec.Code)
+	assert.Contains(t, rec.Body.String(), "[]")
+}
+
 func TestRelaysRemove(t *testing.T) {
 	h, _, _, _ := newTestHandler(t)
 	assert.Equal(t, http.StatusNoContent, doPost(h.RelaysRemove, `{}`, adminUser).Code)
+}
+
+func TestRelaysRemove_WithService(t *testing.T) {
+	h, _, _, _ := newTestHandler(t)
+	svc := &fakeRelaySvc{}
+	h.SetRelayService(svc)
+	rec := doPost(h.RelaysRemove, `{"id":"rel1"}`, adminUser)
+	assert.Equal(t, http.StatusNoContent, rec.Code)
+	assert.Equal(t, []string{"rel1"}, svc.removed)
+}
+
+func TestRelaysRemove_WithService_NoID(t *testing.T) {
+	// id も inbox も無い場合はスキップして 204 を返す
+	h, _, _, _ := newTestHandler(t)
+	svc := &fakeRelaySvc{}
+	h.SetRelayService(svc)
+	rec := doPost(h.RelaysRemove, `{}`, adminUser)
+	assert.Equal(t, http.StatusNoContent, rec.Code)
+	assert.Empty(t, svc.removed)
 }
 
 // --- system-webhook ---

--- a/internal/core/federation/note_delivery_hook.go
+++ b/internal/core/federation/note_delivery_hook.go
@@ -1,6 +1,7 @@
 package federation
 
 import (
+	"context"
 	"encoding/json"
 	"log/slog"
 
@@ -21,6 +22,13 @@ import (
 //
 // pure renote (text/cw/file/poll を伴わない renote) は Create ではなく
 // Announce activity として配信する。
+// RelayBroadcaster is the subset of core/relay.Service used by the note
+// delivery hook to fan a public Create activity out to every accepted
+// relay's inbox. nil を許容 (relay 未構築時は no-op)。
+type RelayBroadcaster interface {
+	DeliverToAccepted(ctx context.Context, signerUserID string, activity any) error
+}
+
 type NoteDeliveryHook struct {
 	deliver  *DeliverService
 	renderer *activitypub.Renderer
@@ -28,6 +36,8 @@ type NoteDeliveryHook struct {
 	idGen    id.Generator
 	userRepo repository.UserRepository
 	noteRepo repository.NoteRepository
+
+	relay RelayBroadcaster
 }
 
 // NewNoteDeliveryHook constructs a NoteDeliveryHook.
@@ -47,6 +57,12 @@ func NewNoteDeliveryHook(
 		userRepo: userRepo,
 		noteRepo: noteRepo,
 	}
+}
+
+// SetRelayBroadcaster wires the relay fan-out target. nil を渡せば
+// relay 配送を無効化できる (初期状態)。
+func (h *NoteDeliveryHook) SetRelayBroadcaster(r RelayBroadcaster) {
+	h.relay = r
 }
 
 // OnNoteCreated is invoked by NoteCreateService once a note has been
@@ -87,6 +103,15 @@ func (h *NoteDeliveryHook) OnNoteCreated(note *model.Note, author *model.User) {
 	// メンションされたリモートユーザーにも直接配信する。フォロワー配信だけでは
 	// 相手にノートが届かないため、メンション通知が発生しない。
 	h.deliverToMentionedRemotes(author, note, body)
+
+	// public な note のみ relay に fanout する。relay は AS Public addressed
+	// activity しか受け付けないため、home/followers/specified はスキップ。
+	if note.Visibility == model.NoteVisibilityPublic && h.relay != nil {
+		if err := h.relay.DeliverToAccepted(context.Background(), author.ID, create); err != nil {
+			slog.Warn("note delivery: relay fanout failed",
+				"noteId", note.ID, "err", err)
+		}
+	}
 }
 
 // deliverToMentionedRemotes finds remote users mentioned in the note text and

--- a/internal/core/federation/note_delivery_hook_test.go
+++ b/internal/core/federation/note_delivery_hook_test.go
@@ -1,6 +1,7 @@
 package federation_test
 
 import (
+	"context"
 	"encoding/json"
 	"testing"
 	"time"
@@ -349,4 +350,57 @@ func TestNoteDeliveryHook_PureRenote_DeliverError_DoesNotPanic(t *testing.T) {
 
 	hook.OnNoteCreated(renote, author)
 	assert.Empty(t, enq.calls)
+}
+
+// fakeRelayBroadcaster captures DeliverToAccepted calls to assert that
+// NoteDeliveryHook only fan outs public notes to relays (not home /
+// followers / specified).
+type fakeRelayBroadcaster struct {
+	calls []relayCall
+	err   error
+}
+
+type relayCall struct {
+	SignerID string
+	Activity any
+}
+
+func (f *fakeRelayBroadcaster) DeliverToAccepted(_ context.Context, signerUserID string, activity any) error {
+	f.calls = append(f.calls, relayCall{SignerID: signerUserID, Activity: activity})
+	return f.err
+}
+
+func TestNoteDeliveryHook_Public_FansOutToRelay(t *testing.T) {
+	hook, _, userRepo, _, keypairRepo, _ := newNoteDeliveryHook(t)
+	author := makeLocalAuthor(t, userRepo, keypairRepo)
+	relay := &fakeRelayBroadcaster{}
+	hook.SetRelayBroadcaster(relay)
+
+	note := makeNote(author.ID, model.NoteVisibilityPublic)
+	hook.OnNoteCreated(note, author)
+
+	require.Len(t, relay.calls, 1)
+	assert.Equal(t, author.ID, relay.calls[0].SignerID)
+}
+
+func TestNoteDeliveryHook_Home_SkipsRelay(t *testing.T) {
+	hook, _, userRepo, _, keypairRepo, _ := newNoteDeliveryHook(t)
+	author := makeLocalAuthor(t, userRepo, keypairRepo)
+	relay := &fakeRelayBroadcaster{}
+	hook.SetRelayBroadcaster(relay)
+
+	note := makeNote(author.ID, model.NoteVisibilityHome)
+	hook.OnNoteCreated(note, author)
+
+	// home visibility は relay 対象外 (as:Public addressed でないため)
+	assert.Empty(t, relay.calls)
+}
+
+func TestNoteDeliveryHook_RelayBroadcasterNil_IsSafe(t *testing.T) {
+	hook, _, userRepo, _, keypairRepo, _ := newNoteDeliveryHook(t)
+	author := makeLocalAuthor(t, userRepo, keypairRepo)
+
+	note := makeNote(author.ID, model.NoteVisibilityPublic)
+	// SetRelayBroadcaster を呼ばなくても panic しない
+	hook.OnNoteCreated(note, author)
 }

--- a/internal/core/federation/processor.go
+++ b/internal/core/federation/processor.go
@@ -1,10 +1,12 @@
 package federation
 
 import (
+	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
 	"log/slog"
+	"regexp"
 	"strings"
 	"time"
 
@@ -29,6 +31,14 @@ var (
 	ErrUnsupportedActivity = errors.New("unsupported activity type")
 )
 
+// RelayStatusMarker is the minimal interface needed from core/relay.Service
+// for the inbox processor to toggle relay status on Accept / Reject
+// activities whose id matches `/activities/follow-relay/{id}`.
+type RelayStatusMarker interface {
+	MarkAccepted(ctx context.Context, id string) error
+	MarkRejected(ctx context.Context, id string) error
+}
+
 // Processor dispatches inbound activities to the right handler.
 type Processor struct {
 	resolver         *Resolver
@@ -52,6 +62,9 @@ type Processor struct {
 	reversiRepo     repository.ReversiRepository
 	reversiIDGen    id.Generator
 	reversiFedCache *corereversi.FederationIDCache
+
+	// Relay follow-accept / -reject hook. nil 時は relay 特化処理をスキップ。
+	relayMarker RelayStatusMarker
 }
 
 // NewProcessor constructs a Processor. reactionService / noteDeleteSvc は省略
@@ -171,6 +184,28 @@ func (p *Processor) SetAbuseReportRepo(repo repository.AbuseReportRepository, id
 func (p *Processor) SetPinningRepo(repo repository.UserNotePiningRepository, idGen id.Generator) {
 	p.pinningRepo = repo
 	p.pinningIDGen = idGen
+}
+
+// SetRelayMarker wires a RelayStatusMarker so inbound Accept / Reject
+// activities whose id matches the follow-relay URI pattern can flip
+// the corresponding relay row to accepted / rejected.
+func (p *Processor) SetRelayMarker(m RelayStatusMarker) {
+	p.relayMarker = m
+}
+
+// followRelayIDPattern extracts the relay id embedded in
+// `.../activities/follow-relay/{id}` URIs. Must stay in lockstep with
+// activitypub.URLBuilder.FollowRelayURI.
+var followRelayIDPattern = regexp.MustCompile(`/activities/follow-relay/([\w-]+)$`)
+
+// matchFollowRelayID returns the relay id if uri is a follow-relay URI,
+// otherwise the empty string.
+func matchFollowRelayID(uri string) string {
+	m := followRelayIDPattern.FindStringSubmatch(uri)
+	if len(m) < 2 {
+		return ""
+	}
+	return m[1]
 }
 
 // SetReversi wires the reversi federation dependencies. When any of the
@@ -322,6 +357,8 @@ func (p *Processor) handleUndoAnnounce(act genericActivity, inner genericActivit
 
 // handleAccept processes an inbound Accept activity. リモートfolloweeがローカル
 // followerからのフォローリクエストを承認した場合に、フォロー関係を確立する。
+// inner.id が follow-relay パターンにマッチすれば relay の Accept とみなし、
+// RelayStatusMarker.MarkAccepted を呼び出す (upstream ApInboxService 互換)。
 func (p *Processor) handleAccept(act genericActivity) error {
 	var inner genericActivity
 	if err := json.Unmarshal(act.Object, &inner); err != nil {
@@ -330,6 +367,9 @@ func (p *Processor) handleAccept(act genericActivity) error {
 	}
 	if !strings.EqualFold(inner.Type, "follow") {
 		return nil
+	}
+	if relayID := matchFollowRelayID(inner.ID); relayID != "" && p.relayMarker != nil {
+		return p.relayMarker.MarkAccepted(context.Background(), relayID)
 	}
 	// actorはリモートfollowee（承認した側）
 	followee, err := p.resolver.ResolveActor(act.Actor)
@@ -564,7 +604,8 @@ func peekObjectType(raw json.RawMessage) string {
 //
 // 想定: 自分 (ローカル follower) が remote followee に対して Follow を送ったが
 // 拒否された場合に呼ばれる。inner.Follow.actor がローカル follower、object が
-// remote followee。
+// remote followee。inner.id が follow-relay パターンなら relay 関連として
+// RelayStatusMarker.MarkRejected を呼ぶ。
 func (p *Processor) handleReject(act genericActivity) error {
 	var inner genericActivity
 	if err := json.Unmarshal(act.Object, &inner); err != nil {
@@ -572,6 +613,9 @@ func (p *Processor) handleReject(act genericActivity) error {
 	}
 	if !strings.EqualFold(inner.Type, "follow") {
 		return ErrUnsupportedActivity
+	}
+	if relayID := matchFollowRelayID(inner.ID); relayID != "" && p.relayMarker != nil {
+		return p.relayMarker.MarkRejected(context.Background(), relayID)
 	}
 	followee, err := p.resolver.ResolveActor(act.Actor)
 	if err != nil {

--- a/internal/core/federation/processor_test.go
+++ b/internal/core/federation/processor_test.go
@@ -1,6 +1,7 @@
 package federation_test
 
 import (
+	"context"
 	"errors"
 	"testing"
 
@@ -907,4 +908,81 @@ func TestProcess_FlagWithoutRepo(t *testing.T) {
 		"object": ["https://example.com/users/bob"]
 	}`)
 	assert.ErrorIs(t, p.Process(body), federation.ErrUnsupportedActivity)
+}
+
+// fakeRelayMarker records MarkAccepted/MarkRejected calls for assertion.
+type fakeRelayMarker struct {
+	accepted []string
+	rejected []string
+	err      error
+}
+
+func (f *fakeRelayMarker) MarkAccepted(_ context.Context, id string) error {
+	f.accepted = append(f.accepted, id)
+	return f.err
+}
+
+func (f *fakeRelayMarker) MarkRejected(_ context.Context, id string) error {
+	f.rejected = append(f.rejected, id)
+	return f.err
+}
+
+func TestProcess_AcceptFollowRelay_MarksAccepted(t *testing.T) {
+	p, _, _, _ := newProcessor(t, aliceActor)
+	marker := &fakeRelayMarker{}
+	p.SetRelayMarker(marker)
+
+	body := []byte(`{
+		"type": "Accept",
+		"actor": "https://remote.example/users/alice",
+		"object": {
+			"id": "https://example.com/activities/follow-relay/rel123",
+			"type": "Follow",
+			"actor": "https://example.com/users/relay.actor",
+			"object": "https://www.w3.org/ns/activitystreams#Public"
+		}
+	}`)
+	require.NoError(t, p.Process(body))
+	assert.Equal(t, []string{"rel123"}, marker.accepted)
+	assert.Empty(t, marker.rejected)
+}
+
+func TestProcess_RejectFollowRelay_MarksRejected(t *testing.T) {
+	p, _, _, _ := newProcessor(t, aliceActor)
+	marker := &fakeRelayMarker{}
+	p.SetRelayMarker(marker)
+
+	body := []byte(`{
+		"type": "Reject",
+		"actor": "https://remote.example/users/alice",
+		"object": {
+			"id": "https://example.com/activities/follow-relay/rel456",
+			"type": "Follow"
+		}
+	}`)
+	require.NoError(t, p.Process(body))
+	assert.Equal(t, []string{"rel456"}, marker.rejected)
+}
+
+func TestProcess_AcceptNonRelay_IgnoresMarker(t *testing.T) {
+	p, repo, _, _ := newProcessor(t, aliceActor)
+	marker := &fakeRelayMarker{}
+	p.SetRelayMarker(marker)
+	bobURI := "https://example.com/users/bob"
+	repo.Users["bob"] = &model.User{ID: "bob", Username: "bob", URI: &bobURI}
+
+	body := []byte(`{
+		"type": "Accept",
+		"actor": "https://remote.example/users/alice",
+		"object": {
+			"id": "https://remote.example/activities/follow/xyz",
+			"type": "Follow",
+			"actor": "https://example.com/users/bob",
+			"object": "https://remote.example/users/alice"
+		}
+	}`)
+	// フォローリクエストが無いので内部的には ErrRequestNotFound を飲み込む
+	require.NoError(t, p.Process(body))
+	// relay marker は呼ばれない
+	assert.Empty(t, marker.accepted)
 }

--- a/internal/core/relay/relay.go
+++ b/internal/core/relay/relay.go
@@ -1,0 +1,254 @@
+// Package relay implements the ActivityPub relay subscription protocol.
+// It ties together the local `relay` table, the instance's relay system
+// actor (via core/systemaccount), and the outbound HTTP-signed delivery
+// pipeline (via DeliverEnqueuer).
+//
+// Upstream reference: Misskey's core/RelayService.ts.
+package relay
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"sync"
+	"time"
+
+	"github.com/shiroha-a/mk/internal/activitypub"
+	"github.com/shiroha-a/mk/internal/misc/id"
+	"github.com/shiroha-a/mk/internal/model"
+	"github.com/shiroha-a/mk/internal/repository"
+)
+
+// Relay statuses — mirror the upstream string values so admin UIs and
+// Accept/Reject inbox handlers can interoperate.
+const (
+	StatusRequesting = "requesting"
+	StatusAccepted   = "accepted"
+	StatusRejected   = "rejected"
+)
+
+// SystemAccountFetcher abstracts core/systemaccount.Service so relay
+// can be unit-tested without pulling in the user/keypair/SA repos.
+type SystemAccountFetcher interface {
+	Fetch(kind string) (*model.User, error)
+}
+
+// Deliverer is the subset of federation.DeliverService that relay
+// depends on. Separated as an interface so mocks can record activity
+// payloads without pulling the whole delivery pipeline.
+type Deliverer interface {
+	DeliverActivity(signerUserID string, body []byte, inboxes []string) error
+}
+
+// Service orchestrates add/remove/mark/list/deliver operations against
+// the local relay table and the AP delivery pipeline.
+type Service struct {
+	repo     repository.RelayRepository
+	sysAcct  SystemAccountFetcher
+	renderer *activitypub.Renderer
+	deliver  Deliverer
+	idGen    id.Generator
+	clock    func() time.Time
+
+	// accepted list cache with 10-minute TTL, matching upstream.
+	cacheMu     sync.RWMutex
+	cacheLoaded time.Time
+	cacheRelays []*model.Relay
+	cacheMaxAge time.Duration
+}
+
+// NewService constructs a Service.
+func NewService(
+	repo repository.RelayRepository,
+	sysAcct SystemAccountFetcher,
+	renderer *activitypub.Renderer,
+	deliver Deliverer,
+	idGen id.Generator,
+) *Service {
+	return &Service{
+		repo:        repo,
+		sysAcct:     sysAcct,
+		renderer:    renderer,
+		deliver:     deliver,
+		idGen:       idGen,
+		clock:       time.Now,
+		cacheMaxAge: 10 * time.Minute,
+	}
+}
+
+// SetClock replaces the clock, primarily for tests.
+func (s *Service) SetClock(now func() time.Time) {
+	if now != nil {
+		s.clock = now
+	}
+}
+
+// SetCacheMaxAge overrides the default 10-minute TTL on the accepted
+// relays cache. 0 以下は無視。
+func (s *Service) SetCacheMaxAge(d time.Duration) {
+	if d > 0 {
+		s.cacheMaxAge = d
+	}
+}
+
+// Add creates a relay row (status=requesting), renders a Follow
+// activity signed by the relay actor, and enqueues it to the relay
+// inbox. Returns the persisted row.
+func (s *Service) Add(ctx context.Context, inbox string) (*model.Relay, error) {
+	if inbox == "" {
+		return nil, errors.New("relay: inbox is required")
+	}
+	rel := &model.Relay{
+		ID:     s.idGen.Generate(s.clock()),
+		Inbox:  inbox,
+		Status: StatusRequesting,
+	}
+	if err := s.repo.Create(rel); err != nil {
+		return nil, fmt.Errorf("relay: create row: %w", err)
+	}
+	if err := s.sendFollow(ctx, rel); err != nil {
+		return nil, err
+	}
+	s.invalidateCache()
+	return rel, nil
+}
+
+// Remove sends an Undo(Follow) to the relay inbox and deletes the row.
+// 行が無ければ nil (idempotent)。
+func (s *Service) Remove(ctx context.Context, id string) error {
+	rel, err := s.repo.FindByID(id)
+	if err != nil {
+		return nil
+	}
+	if err := s.sendUndoFollow(ctx, rel); err != nil {
+		return err
+	}
+	if err := s.repo.Delete(id); err != nil {
+		return fmt.Errorf("relay: delete row: %w", err)
+	}
+	s.invalidateCache()
+	return nil
+}
+
+// List returns every relay row (regardless of status).
+func (s *Service) List(ctx context.Context) ([]*model.Relay, error) {
+	return s.repo.List()
+}
+
+// MarkAccepted flips the status of the given relay to "accepted". Used
+// by the inbox Accept handler when it detects a follow-relay activity.
+func (s *Service) MarkAccepted(ctx context.Context, id string) error {
+	if err := s.repo.UpdateStatus(id, StatusAccepted); err != nil {
+		return err
+	}
+	s.invalidateCache()
+	return nil
+}
+
+// MarkRejected flips the status to "rejected".
+func (s *Service) MarkRejected(ctx context.Context, id string) error {
+	if err := s.repo.UpdateStatus(id, StatusRejected); err != nil {
+		return err
+	}
+	s.invalidateCache()
+	return nil
+}
+
+// DeliverToAccepted enqueues activity to every accepted relay's inbox.
+// Signer is the author of the activity (typically a local user posting
+// a public note); the relay itself is not used as the signer because
+// the relay actor would not be recognised as the activity's author.
+//
+// activity は JSON にシリアライズ可能な構造体 or map。
+func (s *Service) DeliverToAccepted(ctx context.Context, signerUserID string, activity any) error {
+	if activity == nil {
+		return nil
+	}
+	relays, err := s.acceptedCached()
+	if err != nil {
+		return err
+	}
+	if len(relays) == 0 {
+		return nil
+	}
+	body, err := json.Marshal(activity)
+	if err != nil {
+		return fmt.Errorf("relay: marshal activity: %w", err)
+	}
+	inboxes := make([]string, 0, len(relays))
+	for _, r := range relays {
+		inboxes = append(inboxes, r.Inbox)
+	}
+	return s.deliver.DeliverActivity(signerUserID, body, inboxes)
+}
+
+// sendFollow renders a Follow-Relay activity and enqueues it, signed by
+// the relay system actor.
+func (s *Service) sendFollow(ctx context.Context, rel *model.Relay) error {
+	relayActor, err := s.sysAcct.Fetch("relay")
+	if err != nil {
+		return fmt.Errorf("relay: fetch relay actor: %w", err)
+	}
+	follow := s.renderer.RenderFollowRelay(rel.ID, relayActor.ID)
+	body, err := json.Marshal(follow)
+	if err != nil {
+		return fmt.Errorf("relay: marshal follow: %w", err)
+	}
+	return s.deliver.DeliverActivity(relayActor.ID, body, []string{rel.Inbox})
+}
+
+// sendUndoFollow emits Undo(Follow) for the relay. The Follow is
+// re-rendered from the stored relay id (the id format is stable) so
+// callers do not need to have kept the original Follow object.
+func (s *Service) sendUndoFollow(ctx context.Context, rel *model.Relay) error {
+	relayActor, err := s.sysAcct.Fetch("relay")
+	if err != nil {
+		return fmt.Errorf("relay: fetch relay actor: %w", err)
+	}
+	follow := s.renderer.RenderFollowRelay(rel.ID, relayActor.ID)
+	undo := map[string]any{
+		"@context": follow.Context,
+		"id":       follow.ID + "/undo",
+		"type":     "Undo",
+		"actor":    follow.Actor,
+		"object":   follow,
+	}
+	body, err := json.Marshal(undo)
+	if err != nil {
+		return fmt.Errorf("relay: marshal undo: %w", err)
+	}
+	return s.deliver.DeliverActivity(relayActor.ID, body, []string{rel.Inbox})
+}
+
+// acceptedCached returns the cached list of accepted relays, refreshing
+// from the DB when the cache is stale or empty.
+func (s *Service) acceptedCached() ([]*model.Relay, error) {
+	s.cacheMu.RLock()
+	if s.cacheRelays != nil && s.clock().Sub(s.cacheLoaded) < s.cacheMaxAge {
+		out := s.cacheRelays
+		s.cacheMu.RUnlock()
+		return out, nil
+	}
+	s.cacheMu.RUnlock()
+
+	s.cacheMu.Lock()
+	defer s.cacheMu.Unlock()
+	// 再チェック (他の goroutine が先に埋めたかも)
+	if s.cacheRelays != nil && s.clock().Sub(s.cacheLoaded) < s.cacheMaxAge {
+		return s.cacheRelays, nil
+	}
+	fresh, err := s.repo.ListByStatus(StatusAccepted)
+	if err != nil {
+		return nil, err
+	}
+	s.cacheRelays = fresh
+	s.cacheLoaded = s.clock()
+	return fresh, nil
+}
+
+func (s *Service) invalidateCache() {
+	s.cacheMu.Lock()
+	s.cacheRelays = nil
+	s.cacheMu.Unlock()
+}

--- a/internal/core/relay/relay.go
+++ b/internal/core/relay/relay.go
@@ -11,6 +11,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"log/slog"
 	"sync"
 	"time"
 
@@ -95,6 +96,10 @@ func (s *Service) SetCacheMaxAge(d time.Duration) {
 // Add creates a relay row (status=requesting), renders a Follow
 // activity signed by the relay actor, and enqueues it to the relay
 // inbox. Returns the persisted row.
+//
+// Follow 配信が失敗した場合は挿入済みの行をロールバックする。inbox 列は
+// unique index なので orphan 行が残ると同じ inbox での再 Add が
+// unique 制約で失敗してしまい、管理者が復旧できなくなるため。
 func (s *Service) Add(ctx context.Context, inbox string) (*model.Relay, error) {
 	if inbox == "" {
 		return nil, errors.New("relay: inbox is required")
@@ -108,6 +113,7 @@ func (s *Service) Add(ctx context.Context, inbox string) (*model.Relay, error) {
 		return nil, fmt.Errorf("relay: create row: %w", err)
 	}
 	if err := s.sendFollow(ctx, rel); err != nil {
+		_ = s.repo.Delete(rel.ID)
 		return nil, err
 	}
 	s.invalidateCache()
@@ -116,13 +122,18 @@ func (s *Service) Add(ctx context.Context, inbox string) (*model.Relay, error) {
 
 // Remove sends an Undo(Follow) to the relay inbox and deletes the row.
 // 行が無ければ nil (idempotent)。
+//
+// Undo 配信が失敗しても行自体は削除する: 行が残ると「削除したはずの relay が
+// admin UI から消えない」状態になり、管理者が二進も三進も行かなくなるため。
+// 失敗はログで警告するに留める。
 func (s *Service) Remove(ctx context.Context, id string) error {
 	rel, err := s.repo.FindByID(id)
 	if err != nil {
 		return nil
 	}
 	if err := s.sendUndoFollow(ctx, rel); err != nil {
-		return err
+		slog.Warn("relay: undo follow delivery failed; deleting row anyway",
+			"relayId", rel.ID, "inbox", rel.Inbox, "err", err)
 	}
 	if err := s.repo.Delete(id); err != nil {
 		return fmt.Errorf("relay: delete row: %w", err)

--- a/internal/core/relay/relay_test.go
+++ b/internal/core/relay/relay_test.go
@@ -92,10 +92,13 @@ func TestAdd_EmptyInboxRejected(t *testing.T) {
 }
 
 func TestAdd_DelivererErrorBubbles(t *testing.T) {
-	svc, _, _, deliv := newService(t)
+	svc, repo, _, deliv := newService(t)
 	deliv.err = errors.New("network")
 	_, err := svc.Add(context.Background(), "https://r.example/inbox")
-	assert.Error(t, err)
+	require.Error(t, err)
+	// Follow 配信失敗時に挿入済み行がロールバックされる: unique inbox 制約を
+	// 避けるため次回 Add を可能にする重要な挙動 (Devin review #171 対応)。
+	assert.Empty(t, repo.Relays)
 }
 
 func TestRemove_SendsUndoAndDeletes(t *testing.T) {
@@ -208,13 +211,17 @@ func TestAdd_SysAccountErrorBubbles(t *testing.T) {
 	assert.Contains(t, err.Error(), "sys-down")
 }
 
-func TestRemove_SysAccountErrorBubbles(t *testing.T) {
-	svc, _, sys, _ := newService(t)
+// Remove は Undo 配信エラーが起きても行自体は削除する (Devin review #171):
+// 行が残ると admin UI から relay が消えず管理者が復旧できなくなるため、
+// 配信失敗は警告ログで済ませ delete は必ず実行する。
+func TestRemove_UndoDeliveryErrorStillDeletesRow(t *testing.T) {
+	svc, repo, sys, _ := newService(t)
 	rel, err := svc.Add(context.Background(), "https://r.example/inbox")
 	require.NoError(t, err)
 	sys.err = errors.New("sys-down")
-	err = svc.Remove(context.Background(), rel.ID)
-	require.Error(t, err)
+	require.NoError(t, svc.Remove(context.Background(), rel.ID))
+	// 行が削除されている
+	assert.Empty(t, repo.Relays)
 }
 
 // failingRepo lets tests exercise repository error branches.

--- a/internal/core/relay/relay_test.go
+++ b/internal/core/relay/relay_test.go
@@ -1,0 +1,300 @@
+package relay_test
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/shiroha-a/mk/internal/activitypub"
+	"github.com/shiroha-a/mk/internal/core/relay"
+	"github.com/shiroha-a/mk/internal/misc/id"
+	"github.com/shiroha-a/mk/internal/model"
+	"github.com/shiroha-a/mk/internal/testutil"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// fakeSysAcct records Fetch calls and returns a canned user.
+type fakeSysAcct struct {
+	user *model.User
+	err  error
+	mu   sync.Mutex
+	n    int
+}
+
+func (f *fakeSysAcct) Fetch(kind string) (*model.User, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.n++
+	return f.user, f.err
+}
+
+// fakeDeliverer captures bodies + inboxes for assertion.
+type fakeDeliverer struct {
+	mu    sync.Mutex
+	calls []deliverCall
+	err   error
+}
+
+type deliverCall struct {
+	SignerID string
+	Body     []byte
+	Inboxes  []string
+}
+
+func (d *fakeDeliverer) DeliverActivity(signerUserID string, body []byte, inboxes []string) error {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	d.calls = append(d.calls, deliverCall{SignerID: signerUserID, Body: append([]byte(nil), body...), Inboxes: append([]string(nil), inboxes...)})
+	return d.err
+}
+
+func newService(t *testing.T) (*relay.Service, *testutil.MockRelayRepository, *fakeSysAcct, *fakeDeliverer) {
+	t.Helper()
+	repo := testutil.NewMockRelayRepository()
+	sys := &fakeSysAcct{user: &model.User{ID: "sysrelay"}}
+	deliv := &fakeDeliverer{}
+	r := activitypub.NewRenderer(activitypub.NewURLBuilder("https://example.com"))
+	idGen, err := id.NewGenerator("aidx")
+	require.NoError(t, err)
+	svc := relay.NewService(repo, sys, r, deliv, idGen)
+	svc.SetClock(func() time.Time { return time.Unix(1_700_000_000, 0).UTC() })
+	return svc, repo, sys, deliv
+}
+
+func TestAdd_PersistsRowAndDeliversFollow(t *testing.T) {
+	svc, repo, sys, deliv := newService(t)
+	rel, err := svc.Add(context.Background(), "https://r.example/inbox")
+	require.NoError(t, err)
+	require.NotNil(t, rel)
+	assert.Equal(t, "https://r.example/inbox", rel.Inbox)
+	assert.Equal(t, relay.StatusRequesting, rel.Status)
+	assert.Len(t, repo.Relays, 1)
+	assert.Equal(t, 1, sys.n)
+	require.Len(t, deliv.calls, 1)
+	call := deliv.calls[0]
+	assert.Equal(t, "sysrelay", call.SignerID)
+	assert.Equal(t, []string{"https://r.example/inbox"}, call.Inboxes)
+	// body は Follow Activity
+	var follow map[string]any
+	require.NoError(t, json.Unmarshal(call.Body, &follow))
+	assert.Equal(t, "Follow", follow["type"])
+	assert.Equal(t, activitypub.Public, follow["object"])
+}
+
+func TestAdd_EmptyInboxRejected(t *testing.T) {
+	svc, _, _, _ := newService(t)
+	_, err := svc.Add(context.Background(), "")
+	assert.Error(t, err)
+}
+
+func TestAdd_DelivererErrorBubbles(t *testing.T) {
+	svc, _, _, deliv := newService(t)
+	deliv.err = errors.New("network")
+	_, err := svc.Add(context.Background(), "https://r.example/inbox")
+	assert.Error(t, err)
+}
+
+func TestRemove_SendsUndoAndDeletes(t *testing.T) {
+	svc, repo, _, deliv := newService(t)
+	rel, err := svc.Add(context.Background(), "https://r.example/inbox")
+	require.NoError(t, err)
+	deliv.mu.Lock()
+	deliv.calls = nil
+	deliv.mu.Unlock()
+
+	require.NoError(t, svc.Remove(context.Background(), rel.ID))
+	assert.Empty(t, repo.Relays)
+	require.Len(t, deliv.calls, 1)
+	var undo map[string]any
+	require.NoError(t, json.Unmarshal(deliv.calls[0].Body, &undo))
+	assert.Equal(t, "Undo", undo["type"])
+	// 元 Follow が object にネストされている
+	inner, ok := undo["object"].(map[string]any)
+	require.True(t, ok)
+	assert.Equal(t, "Follow", inner["type"])
+}
+
+func TestRemove_NotFoundIsNoop(t *testing.T) {
+	svc, _, _, deliv := newService(t)
+	// 存在しない id を渡しても err=nil、deliver も呼ばれない
+	require.NoError(t, svc.Remove(context.Background(), "nonexistent"))
+	assert.Empty(t, deliv.calls)
+}
+
+func TestList_ReturnsAll(t *testing.T) {
+	svc, _, _, _ := newService(t)
+	_, err := svc.Add(context.Background(), "https://a.example/inbox")
+	require.NoError(t, err)
+	_, err = svc.Add(context.Background(), "https://b.example/inbox")
+	require.NoError(t, err)
+
+	list, err := svc.List(context.Background())
+	require.NoError(t, err)
+	assert.Len(t, list, 2)
+}
+
+func TestMarkAccepted_UpdatesStatus(t *testing.T) {
+	svc, repo, _, _ := newService(t)
+	rel, err := svc.Add(context.Background(), "https://r.example/inbox")
+	require.NoError(t, err)
+	require.NoError(t, svc.MarkAccepted(context.Background(), rel.ID))
+	assert.Equal(t, relay.StatusAccepted, repo.Relays[rel.ID].Status)
+}
+
+func TestMarkRejected_UpdatesStatus(t *testing.T) {
+	svc, repo, _, _ := newService(t)
+	rel, err := svc.Add(context.Background(), "https://r.example/inbox")
+	require.NoError(t, err)
+	require.NoError(t, svc.MarkRejected(context.Background(), rel.ID))
+	assert.Equal(t, relay.StatusRejected, repo.Relays[rel.ID].Status)
+}
+
+func TestMarkAccepted_InvalidatesCache(t *testing.T) {
+	svc, _, _, deliv := newService(t)
+	rel, err := svc.Add(context.Background(), "https://r.example/inbox")
+	require.NoError(t, err)
+	// まず何もない状態で DeliverToAccepted → no-op (accepted relay が無い)
+	require.NoError(t, svc.DeliverToAccepted(context.Background(), "alice", map[string]any{"type": "Note"}))
+	deliv.mu.Lock()
+	addedCalls := len(deliv.calls)
+	deliv.mu.Unlock()
+
+	// MarkAccepted してキャッシュ無効化、再度 DeliverToAccepted で届く
+	require.NoError(t, svc.MarkAccepted(context.Background(), rel.ID))
+	require.NoError(t, svc.DeliverToAccepted(context.Background(), "alice", map[string]any{"type": "Note"}))
+
+	deliv.mu.Lock()
+	finalCalls := len(deliv.calls)
+	deliv.mu.Unlock()
+	assert.Equal(t, addedCalls+1, finalCalls)
+}
+
+func TestDeliverToAccepted_NilActivity(t *testing.T) {
+	svc, _, _, deliv := newService(t)
+	require.NoError(t, svc.DeliverToAccepted(context.Background(), "alice", nil))
+	assert.Empty(t, deliv.calls)
+}
+
+func TestDeliverToAccepted_CacheHit(t *testing.T) {
+	svc, repo, _, _ := newService(t)
+	// accepted relay を直接 repo に入れる (Add→MarkAccepted の順番を短縮)
+	rel := &model.Relay{ID: "r1", Inbox: "https://a.example/inbox", Status: relay.StatusAccepted}
+	require.NoError(t, repo.Create(rel))
+
+	// 1 回目: DB から取得してキャッシュ
+	require.NoError(t, svc.DeliverToAccepted(context.Background(), "alice", map[string]any{"type": "Note"}))
+	// 途中で DB から消しても、キャッシュ TTL 内なら 2 回目も届く
+	delete(repo.Relays, "r1")
+	require.NoError(t, svc.DeliverToAccepted(context.Background(), "alice", map[string]any{"type": "Note"}))
+}
+
+func TestSetClockAndCacheMaxAge_NilZeroIgnored(t *testing.T) {
+	svc, _, _, _ := newService(t)
+	svc.SetClock(nil)
+	svc.SetCacheMaxAge(0)
+	_, err := svc.Add(context.Background(), "https://r.example/inbox")
+	require.NoError(t, err)
+}
+
+func TestAdd_SysAccountErrorBubbles(t *testing.T) {
+	svc, _, sys, _ := newService(t)
+	sys.err = errors.New("sys-down")
+	_, err := svc.Add(context.Background(), "https://r.example/inbox")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "sys-down")
+}
+
+func TestRemove_SysAccountErrorBubbles(t *testing.T) {
+	svc, _, sys, _ := newService(t)
+	rel, err := svc.Add(context.Background(), "https://r.example/inbox")
+	require.NoError(t, err)
+	sys.err = errors.New("sys-down")
+	err = svc.Remove(context.Background(), rel.ID)
+	require.Error(t, err)
+}
+
+// failingRepo lets tests exercise repository error branches.
+type failingRepo struct {
+	*testutil.MockRelayRepository
+	createErr error
+	updateErr error
+	listErr   error
+	deleteErr error
+}
+
+func (f *failingRepo) Create(r *model.Relay) error {
+	if f.createErr != nil {
+		return f.createErr
+	}
+	return f.MockRelayRepository.Create(r)
+}
+func (f *failingRepo) UpdateStatus(id, status string) error {
+	if f.updateErr != nil {
+		return f.updateErr
+	}
+	return f.MockRelayRepository.UpdateStatus(id, status)
+}
+func (f *failingRepo) ListByStatus(status string) ([]*model.Relay, error) {
+	if f.listErr != nil {
+		return nil, f.listErr
+	}
+	return f.MockRelayRepository.ListByStatus(status)
+}
+func (f *failingRepo) Delete(id string) error {
+	if f.deleteErr != nil {
+		return f.deleteErr
+	}
+	return f.MockRelayRepository.Delete(id)
+}
+
+func TestAdd_RepoCreateErrorBubbles(t *testing.T) {
+	repo := &failingRepo{MockRelayRepository: testutil.NewMockRelayRepository(), createErr: errors.New("db boom")}
+	sys := &fakeSysAcct{user: &model.User{ID: "sysrelay"}}
+	deliv := &fakeDeliverer{}
+	r := activitypub.NewRenderer(activitypub.NewURLBuilder("https://example.com"))
+	idGen, _ := id.NewGenerator("aidx")
+	svc := relay.NewService(repo, sys, r, deliv, idGen)
+	_, err := svc.Add(context.Background(), "https://r.example/inbox")
+	require.Error(t, err)
+}
+
+func TestMarkAccepted_RepoErrorBubbles(t *testing.T) {
+	repo := &failingRepo{MockRelayRepository: testutil.NewMockRelayRepository(), updateErr: errors.New("db boom")}
+	sys := &fakeSysAcct{user: &model.User{ID: "sysrelay"}}
+	deliv := &fakeDeliverer{}
+	r := activitypub.NewRenderer(activitypub.NewURLBuilder("https://example.com"))
+	idGen, _ := id.NewGenerator("aidx")
+	svc := relay.NewService(repo, sys, r, deliv, idGen)
+	err := svc.MarkAccepted(context.Background(), "x")
+	assert.Error(t, err)
+	err = svc.MarkRejected(context.Background(), "x")
+	assert.Error(t, err)
+}
+
+func TestDeliverToAccepted_RepoListError(t *testing.T) {
+	repo := &failingRepo{MockRelayRepository: testutil.NewMockRelayRepository(), listErr: errors.New("db boom")}
+	sys := &fakeSysAcct{user: &model.User{ID: "sysrelay"}}
+	deliv := &fakeDeliverer{}
+	r := activitypub.NewRenderer(activitypub.NewURLBuilder("https://example.com"))
+	idGen, _ := id.NewGenerator("aidx")
+	svc := relay.NewService(repo, sys, r, deliv, idGen)
+	err := svc.DeliverToAccepted(context.Background(), "alice", map[string]any{"type": "Note"})
+	assert.Error(t, err)
+}
+
+func TestRemove_RepoDeleteErrorBubbles(t *testing.T) {
+	repo := &failingRepo{MockRelayRepository: testutil.NewMockRelayRepository(), deleteErr: errors.New("db boom")}
+	sys := &fakeSysAcct{user: &model.User{ID: "sysrelay"}}
+	deliv := &fakeDeliverer{}
+	r := activitypub.NewRenderer(activitypub.NewURLBuilder("https://example.com"))
+	idGen, _ := id.NewGenerator("aidx")
+	svc := relay.NewService(repo, sys, r, deliv, idGen)
+	rel, err := svc.Add(context.Background(), "https://r.example/inbox")
+	require.NoError(t, err)
+	err = svc.Remove(context.Background(), rel.ID)
+	assert.Error(t, err)
+}

--- a/internal/core/systemaccount/systemaccount.go
+++ b/internal/core/systemaccount/systemaccount.go
@@ -1,0 +1,116 @@
+// Package systemaccount manages built-in local users that represent
+// subsystems of the instance itself (relay actor, instance actor,
+// proxy fetcher etc). 本家 Misskey の SystemAccountService 相当。
+//
+// 各 kind に 1 つずつ user + user_profile + user_keypair + system_account
+// 行を作成・取得する。初回 Fetch 時に行が無ければ lazy に作成する。
+package systemaccount
+
+import (
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/shiroha-a/mk/internal/activitypub"
+	"github.com/shiroha-a/mk/internal/misc/id"
+	"github.com/shiroha-a/mk/internal/model"
+	"github.com/shiroha-a/mk/internal/repository"
+	"gorm.io/gorm"
+)
+
+// Service fetches (or lazily creates) the built-in system users used
+// for subsystem-to-AP interactions. 各 kind は一意なので 1 行のみ。
+type Service struct {
+	userRepo    repository.UserRepository
+	keypairRepo repository.UserKeypairRepository
+	saRepo      repository.SystemAccountRepository
+	idGen       id.Generator
+	clock       func() time.Time
+}
+
+// NewService constructs a Service.
+func NewService(
+	userRepo repository.UserRepository,
+	keypairRepo repository.UserKeypairRepository,
+	saRepo repository.SystemAccountRepository,
+	idGen id.Generator,
+) *Service {
+	return &Service{
+		userRepo:    userRepo,
+		keypairRepo: keypairRepo,
+		saRepo:      saRepo,
+		idGen:       idGen,
+		clock:       time.Now,
+	}
+}
+
+// SetClock replaces the clock, primarily for tests.
+func (s *Service) SetClock(now func() time.Time) {
+	if now != nil {
+		s.clock = now
+	}
+}
+
+// Fetch returns the system user for the given kind, creating it if
+// necessary. kind は TS Misskey 本家と同じ識別子 ("relay", "actor",
+// "proxy") を想定する。
+func (s *Service) Fetch(kind string) (*model.User, error) {
+	if kind == "" {
+		return nil, errors.New("systemaccount: kind is required")
+	}
+	sa, err := s.saRepo.FindByType(kind)
+	if err == nil {
+		return s.userRepo.FindByID(sa.UserID)
+	}
+	if !errors.Is(err, gorm.ErrRecordNotFound) {
+		return nil, err
+	}
+	return s.create(kind)
+}
+
+// create materialises a new system user. username は kind ごとに決め打ち
+// ("relay.actor" / "instance.actor" / "proxy.actor") で、本家 Misskey の
+// SystemAccountService.createCorrespondingUser と同じ形式を採用する。
+func (s *Service) create(kind string) (*model.User, error) {
+	now := s.clock()
+	username := kind + ".actor"
+	// 鍵ペアを先に生成しておく (User 行を作ってから keypair 作成する順だが
+	// 鍵生成失敗時に user_profile を残さないよう先に作る)。
+	privPEM, pubPEM, err := activitypub.GenerateRSAKeypair()
+	if err != nil {
+		return nil, fmt.Errorf("systemaccount: generate keypair: %w", err)
+	}
+
+	user := &model.User{
+		ID:            s.idGen.Generate(now),
+		Username:      username,
+		UsernameLower: username,
+		Host:          nil,
+		IsExplorable:  false,
+		IsBot:         true,
+		IsLocked:      true,
+	}
+	if err := s.userRepo.Create(user); err != nil {
+		return nil, fmt.Errorf("systemaccount: create user: %w", err)
+	}
+	// user_profile は本家互換のため最小行だけ入れる (email/password は nil)
+	profile := &model.UserProfile{UserID: user.ID}
+	if err := s.userRepo.CreateProfile(profile); err != nil {
+		return nil, fmt.Errorf("systemaccount: create profile: %w", err)
+	}
+	if err := s.keypairRepo.Create(&model.UserKeypair{
+		UserID:     user.ID,
+		PublicKey:  pubPEM,
+		PrivateKey: privPEM,
+	}); err != nil {
+		return nil, fmt.Errorf("systemaccount: create keypair: %w", err)
+	}
+	if err := s.saRepo.Create(&model.SystemAccount{
+		ID:     s.idGen.Generate(now),
+		UserID: user.ID,
+		Type:   kind,
+	}); err != nil {
+		return nil, fmt.Errorf("systemaccount: create system_account: %w", err)
+	}
+	return user, nil
+}

--- a/internal/core/systemaccount/systemaccount.go
+++ b/internal/core/systemaccount/systemaccount.go
@@ -65,6 +65,14 @@ func (s *Service) Fetch(kind string) (*model.User, error) {
 	if !errors.Is(err, gorm.ErrRecordNotFound) {
 		return nil, err
 	}
+	// 前回の create が途中で失敗して user 行だけ残っているかもしれない
+	// ("relay.actor" 等の usernameLower は unique WHERE host IS NULL 制約)。
+	// 素朴に再 create すると unique violation で永続的に復旧不能になるため、
+	// 既存 user を検出できたら再利用して欠けた行だけ埋めに行く。
+	username := kind + ".actor"
+	if orphan, oerr := s.userRepo.FindByUsernameLower(username, nil); oerr == nil && orphan != nil {
+		return s.completeFromOrphan(kind, orphan)
+	}
 	return s.create(kind)
 }
 
@@ -74,13 +82,6 @@ func (s *Service) Fetch(kind string) (*model.User, error) {
 func (s *Service) create(kind string) (*model.User, error) {
 	now := s.clock()
 	username := kind + ".actor"
-	// 鍵ペアを先に生成しておく (User 行を作ってから keypair 作成する順だが
-	// 鍵生成失敗時に user_profile を残さないよう先に作る)。
-	privPEM, pubPEM, err := activitypub.GenerateRSAKeypair()
-	if err != nil {
-		return nil, fmt.Errorf("systemaccount: generate keypair: %w", err)
-	}
-
 	user := &model.User{
 		ID:            s.idGen.Generate(now),
 		Username:      username,
@@ -93,20 +94,37 @@ func (s *Service) create(kind string) (*model.User, error) {
 	if err := s.userRepo.Create(user); err != nil {
 		return nil, fmt.Errorf("systemaccount: create user: %w", err)
 	}
-	// user_profile は本家互換のため最小行だけ入れる (email/password は nil)
-	profile := &model.UserProfile{UserID: user.ID}
-	if err := s.userRepo.CreateProfile(profile); err != nil {
-		return nil, fmt.Errorf("systemaccount: create profile: %w", err)
+	return s.completeFromOrphan(kind, user)
+}
+
+// completeFromOrphan fills in whatever follow-up rows are missing for an
+// already-existing user (either a freshly inserted one from create, or
+// an orphan left over from a previous partial failure). Each secondary
+// insert is idempotent: a pre-existing row is treated as success so a
+// second Fetch after a keypair-insert-succeeded-but-system_account-failed
+// crash completes on the second try.
+func (s *Service) completeFromOrphan(kind string, user *model.User) (*model.User, error) {
+	if _, err := s.userRepo.FindProfileByUserID(user.ID); err != nil {
+		profile := &model.UserProfile{UserID: user.ID}
+		if perr := s.userRepo.CreateProfile(profile); perr != nil {
+			return nil, fmt.Errorf("systemaccount: create profile: %w", perr)
+		}
 	}
-	if err := s.keypairRepo.Create(&model.UserKeypair{
-		UserID:     user.ID,
-		PublicKey:  pubPEM,
-		PrivateKey: privPEM,
-	}); err != nil {
-		return nil, fmt.Errorf("systemaccount: create keypair: %w", err)
+	if _, err := s.keypairRepo.FindByUserID(user.ID); err != nil {
+		privPEM, pubPEM, kerr := activitypub.GenerateRSAKeypair()
+		if kerr != nil {
+			return nil, fmt.Errorf("systemaccount: generate keypair: %w", kerr)
+		}
+		if kerr := s.keypairRepo.Create(&model.UserKeypair{
+			UserID:     user.ID,
+			PublicKey:  pubPEM,
+			PrivateKey: privPEM,
+		}); kerr != nil {
+			return nil, fmt.Errorf("systemaccount: create keypair: %w", kerr)
+		}
 	}
 	if err := s.saRepo.Create(&model.SystemAccount{
-		ID:     s.idGen.Generate(now),
+		ID:     s.idGen.Generate(s.clock()),
 		UserID: user.ID,
 		Type:   kind,
 	}); err != nil {

--- a/internal/core/systemaccount/systemaccount_test.go
+++ b/internal/core/systemaccount/systemaccount_test.go
@@ -1,0 +1,185 @@
+package systemaccount_test
+
+import (
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/shiroha-a/mk/internal/core/systemaccount"
+	"github.com/shiroha-a/mk/internal/misc/id"
+	"github.com/shiroha-a/mk/internal/model"
+	"github.com/shiroha-a/mk/internal/testutil"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gorm.io/gorm"
+)
+
+// saMock wraps testutil.MockSystemAccountRepository to translate the
+// testutil-level ErrNotFound sentinel into the gorm.ErrRecordNotFound that
+// the production gorm repository would return. Service 側が gorm の
+// sentinel で分岐するため必須のアダプタ。
+type saMock struct {
+	*testutil.MockSystemAccountRepository
+}
+
+func newSAMock() *saMock {
+	return &saMock{MockSystemAccountRepository: testutil.NewMockSystemAccountRepository()}
+}
+
+func (s *saMock) FindByType(typ string) (*model.SystemAccount, error) {
+	sa, err := s.MockSystemAccountRepository.FindByType(typ)
+	if errors.Is(err, testutil.ErrNotFound) {
+		return nil, gorm.ErrRecordNotFound
+	}
+	return sa, err
+}
+
+// saFailCreate は Create だけ常にエラーを返す SystemAccountRepository モック。
+type saFailCreate struct {
+	*saMock
+	err error
+}
+
+func (f *saFailCreate) Create(sa *model.SystemAccount) error { return f.err }
+
+// keypairFailCreate は Create が常にエラーを返す UserKeypairRepository モック。
+type keypairFailCreate struct {
+	*testutil.MockUserKeypairRepository
+	err error
+}
+
+func (k *keypairFailCreate) Create(kp *model.UserKeypair) error { return k.err }
+
+// userFailProfile は CreateProfile だけエラーを返す。
+type userFailProfile struct {
+	*testutil.MockUserRepository
+	err error
+}
+
+func (u *userFailProfile) CreateProfile(p *model.UserProfile) error { return u.err }
+
+func newService(t *testing.T) (*systemaccount.Service, *testutil.MockUserRepository, *testutil.MockUserKeypairRepository, *saMock) {
+	t.Helper()
+	userRepo := testutil.NewMockUserRepository()
+	keypairRepo := testutil.NewMockUserKeypairRepository()
+	saRepo := newSAMock()
+	idGen, err := id.NewGenerator("aidx")
+	require.NoError(t, err)
+	svc := systemaccount.NewService(userRepo, keypairRepo, saRepo, idGen)
+	svc.SetClock(func() time.Time { return time.Unix(1_700_000_000, 0).UTC() })
+	return svc, userRepo, keypairRepo, saRepo
+}
+
+func TestFetch_CreatesRowsOnFirstCall(t *testing.T) {
+	svc, userRepo, keypairRepo, saRepo := newService(t)
+
+	user, err := svc.Fetch("relay")
+	require.NoError(t, err)
+	require.NotNil(t, user)
+	assert.Equal(t, "relay.actor", user.Username)
+	assert.True(t, user.IsBot)
+	assert.False(t, user.IsExplorable)
+	assert.Nil(t, user.Host) // 必ずローカル
+
+	// 各 repo に行が作られていることを確認
+	require.Len(t, userRepo.Users, 1)
+	require.Len(t, keypairRepo.Keypairs, 1)
+	require.Len(t, saRepo.Accounts, 1)
+	kp := keypairRepo.Keypairs[user.ID]
+	require.NotNil(t, kp)
+	assert.Contains(t, kp.PrivateKey, "PRIVATE KEY")
+	assert.Contains(t, kp.PublicKey, "PUBLIC KEY")
+}
+
+func TestFetch_ReturnsExistingOnSecondCall(t *testing.T) {
+	svc, userRepo, _, _ := newService(t)
+
+	user1, err := svc.Fetch("relay")
+	require.NoError(t, err)
+	user2, err := svc.Fetch("relay")
+	require.NoError(t, err)
+	assert.Equal(t, user1.ID, user2.ID)
+	// user はひとつだけ
+	assert.Len(t, userRepo.Users, 1)
+}
+
+func TestFetch_EmptyKindRejected(t *testing.T) {
+	svc, _, _, _ := newService(t)
+	_, err := svc.Fetch("")
+	assert.Error(t, err)
+}
+
+func TestFetch_ErrorBubblesFromSystemAccountCreate(t *testing.T) {
+	userRepo := testutil.NewMockUserRepository()
+	keypairRepo := testutil.NewMockUserKeypairRepository()
+	saRepo := &saFailCreate{
+		saMock: newSAMock(),
+		err:    errors.New("db down"),
+	}
+	idGen, _ := id.NewGenerator("aidx")
+	svc := systemaccount.NewService(userRepo, keypairRepo, saRepo, idGen)
+
+	_, err := svc.Fetch("relay")
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "db down")
+}
+
+func TestFetch_ErrorBubblesFromKeypairCreate(t *testing.T) {
+	userRepo := testutil.NewMockUserRepository()
+	keypairRepo := &keypairFailCreate{
+		MockUserKeypairRepository: testutil.NewMockUserKeypairRepository(),
+		err:                       errors.New("keypair db down"),
+	}
+	saRepo := newSAMock()
+	idGen, _ := id.NewGenerator("aidx")
+	svc := systemaccount.NewService(userRepo, keypairRepo, saRepo, idGen)
+
+	_, err := svc.Fetch("relay")
+	assert.Error(t, err)
+}
+
+func TestFetch_ErrorBubblesFromProfileCreate(t *testing.T) {
+	userRepo := &userFailProfile{
+		MockUserRepository: testutil.NewMockUserRepository(),
+		err:                errors.New("profile db down"),
+	}
+	keypairRepo := testutil.NewMockUserKeypairRepository()
+	saRepo := newSAMock()
+	idGen, _ := id.NewGenerator("aidx")
+	svc := systemaccount.NewService(userRepo, keypairRepo, saRepo, idGen)
+
+	_, err := svc.Fetch("relay")
+	assert.Error(t, err)
+}
+
+// saFailLookup は FindByType で gorm.ErrRecordNotFound 以外のエラーを返して
+// その分岐がきちんと上位に伝わることを確認する。
+type saFailLookup struct {
+	*saMock
+	err error
+}
+
+func (f *saFailLookup) FindByType(typ string) (*model.SystemAccount, error) { return nil, f.err }
+
+func TestFetch_ErrorBubblesFromUnexpectedLookup(t *testing.T) {
+	userRepo := testutil.NewMockUserRepository()
+	keypairRepo := testutil.NewMockUserKeypairRepository()
+	saRepo := &saFailLookup{
+		saMock: newSAMock(),
+		err:    errors.New("other db error"),
+	}
+	idGen, _ := id.NewGenerator("aidx")
+	svc := systemaccount.NewService(userRepo, keypairRepo, saRepo, idGen)
+
+	_, err := svc.Fetch("relay")
+	require.Error(t, err)
+	assert.NotErrorIs(t, err, gorm.ErrRecordNotFound)
+}
+
+func TestSetClock_NilIgnored(t *testing.T) {
+	svc, _, _, _ := newService(t)
+	// nil を渡しても panic しない
+	svc.SetClock(nil)
+	_, err := svc.Fetch("relay")
+	require.NoError(t, err)
+}

--- a/internal/core/systemaccount/systemaccount_test.go
+++ b/internal/core/systemaccount/systemaccount_test.go
@@ -183,3 +183,38 @@ func TestSetClock_NilIgnored(t *testing.T) {
 	_, err := svc.Fetch("relay")
 	require.NoError(t, err)
 }
+
+// Previous Fetch が user 行は作れたが system_account 作成に失敗した状態を
+// 模し、次の Fetch で orphan を検出して残りの行を埋めて復旧できることを確認。
+// Devin review #171 対応。
+func TestFetch_RecoversFromOrphanUser(t *testing.T) {
+	svc, userRepo, keypairRepo, saRepo := newService(t)
+
+	// 1 回目: system_account の Create を失敗させる
+	originalRepo := saRepo.MockSystemAccountRepository
+	failing := &saFailCreate{saMock: saRepo, err: errors.New("tx rolled back")}
+	svc2 := systemaccount.NewService(userRepo, keypairRepo, failing, idGenFor(t))
+	svc2.SetClock(func() time.Time { return time.Unix(1_700_000_000, 0).UTC() })
+	_, err := svc2.Fetch("relay")
+	require.Error(t, err)
+
+	// user 行だけ残っているが system_account は無い
+	require.Len(t, userRepo.Users, 1)
+	require.Empty(t, originalRepo.Accounts)
+
+	// 2 回目 (failing ではない普通の saRepo で) → orphan 検出 → recovery 成功
+	user, err := svc.Fetch("relay")
+	require.NoError(t, err)
+	assert.Equal(t, "relay.actor", user.Username)
+	// 新しい user は作られず既存を再利用
+	assert.Len(t, userRepo.Users, 1)
+	assert.Len(t, originalRepo.Accounts, 1)
+}
+
+// idGenFor は tests で idGen が必要な場合の小さなヘルパ。
+func idGenFor(t *testing.T) id.Generator {
+	t.Helper()
+	g, err := id.NewGenerator("aidx")
+	require.NoError(t, err)
+	return g
+}

--- a/internal/repository/relay.go
+++ b/internal/repository/relay.go
@@ -1,0 +1,63 @@
+package repository
+
+import (
+	"github.com/shiroha-a/mk/internal/model"
+	"gorm.io/gorm"
+)
+
+// RelayRepository provides data access for the `relay` table.
+type RelayRepository interface {
+	Create(r *model.Relay) error
+	FindByID(id string) (*model.Relay, error)
+	List() ([]*model.Relay, error)
+	ListByStatus(status string) ([]*model.Relay, error)
+	UpdateStatus(id, status string) error
+	Delete(id string) error
+}
+
+type relayRepository struct {
+	db *gorm.DB
+}
+
+// NewRelayRepository creates a RelayRepository backed by gorm.
+func NewRelayRepository(db *gorm.DB) RelayRepository {
+	return &relayRepository{db: db}
+}
+
+func (r *relayRepository) Create(rel *model.Relay) error {
+	return r.db.Create(rel).Error
+}
+
+func (r *relayRepository) FindByID(id string) (*model.Relay, error) {
+	var rel model.Relay
+	if err := r.db.Where(`"id" = ?`, id).First(&rel).Error; err != nil {
+		return nil, err
+	}
+	return &rel, nil
+}
+
+func (r *relayRepository) List() ([]*model.Relay, error) {
+	var rels []*model.Relay
+	if err := r.db.Order(`"id" DESC`).Find(&rels).Error; err != nil {
+		return nil, err
+	}
+	return rels, nil
+}
+
+func (r *relayRepository) ListByStatus(status string) ([]*model.Relay, error) {
+	var rels []*model.Relay
+	if err := r.db.Where(`"status" = ?`, status).Find(&rels).Error; err != nil {
+		return nil, err
+	}
+	return rels, nil
+}
+
+func (r *relayRepository) UpdateStatus(id, status string) error {
+	return r.db.Model(&model.Relay{}).
+		Where(`"id" = ?`, id).
+		Update("status", status).Error
+}
+
+func (r *relayRepository) Delete(id string) error {
+	return r.db.Where(`"id" = ?`, id).Delete(&model.Relay{}).Error
+}

--- a/internal/server/router.go
+++ b/internal/server/router.go
@@ -77,11 +77,13 @@ import (
 	corepage "github.com/shiroha-a/mk/internal/core/page"
 	corepoll "github.com/shiroha-a/mk/internal/core/poll"
 	corereaction "github.com/shiroha-a/mk/internal/core/reaction"
+	corerelay "github.com/shiroha-a/mk/internal/core/relay"
 	corereversi "github.com/shiroha-a/mk/internal/core/reversi"
 	corerole "github.com/shiroha-a/mk/internal/core/role"
 	coresearch "github.com/shiroha-a/mk/internal/core/search"
 	"github.com/shiroha-a/mk/internal/core/serverstats"
 	coresignup "github.com/shiroha-a/mk/internal/core/signup"
+	coresystemaccount "github.com/shiroha-a/mk/internal/core/systemaccount"
 	coretimeline "github.com/shiroha-a/mk/internal/core/timeline"
 	coretransfer "github.com/shiroha-a/mk/internal/core/transfer"
 	coretranslate "github.com/shiroha-a/mk/internal/core/translate"
@@ -364,7 +366,17 @@ func (s *Server) setupRoutes() {
 	// AP delivery: DeliverService + フック登録 + asynq processor 登録
 	deliverService := corefederation.NewDeliverService(s.queueClient, userRepo, followingRepo, keypairRepo, apURLs)
 	deliverService.SetHostBlockChecker(instanceService)
-	noteCreateService.SetFederationHook(corefederation.NewNoteDeliveryHook(deliverService, apRenderer, apURLs, idGen, userRepo, noteRepo))
+
+	// Relay 連携 (#161): relay actor system account + relay.Service。
+	// relay.Service は AP delivery を必要とするので deliverService 構築の
+	// 直後でセットアップする。admin/relays ハンドラへ注入し、Accept/Reject
+	// inbox 処理で status を更新できるように processor にも渡す。
+	sysAcctSvc := coresystemaccount.NewService(userRepo, keypairRepo, repository.NewSystemAccountRepository(s.db), idGen)
+	relaySvc := corerelay.NewService(repository.NewRelayRepository(s.db), sysAcctSvc, apRenderer, deliverService, idGen)
+
+	noteDeliveryHook := corefederation.NewNoteDeliveryHook(deliverService, apRenderer, apURLs, idGen, userRepo, noteRepo)
+	noteDeliveryHook.SetRelayBroadcaster(relaySvc)
+	noteCreateService.SetFederationHook(noteDeliveryHook)
 	followingService.SetFederationHook(corefederation.NewFollowingDeliveryHook(deliverService, apRenderer, apURLs))
 	reactionService.SetFederationHook(corefederation.NewReactionDeliveryHook(deliverService, apRenderer, apURLs, idGen, userRepo))
 	noteDeleteHook := corefederation.NewNoteDeleteDeliveryHook(deliverService, apRenderer, apURLs)
@@ -1159,6 +1171,7 @@ func (s *Server) setupRoutes() {
 	federationProcessor.SetBlockingService(blockingService)
 	federationProcessor.SetAbuseReportRepo(repository.NewAbuseReportRepository(s.db), idGen)
 	federationProcessor.SetPinningRepo(piningRepo, idGen)
+	federationProcessor.SetRelayMarker(relaySvc)
 
 	// 5. /streaming エンドポイント配線
 	streamingHandler := streaming.NewHandler(streamManager)
@@ -1245,6 +1258,7 @@ func (s *Server) setupRoutes() {
 	adminHandler.SetAdminDB(s.db)
 	adminHandler.SetUserIPRepo(userIPRepo)
 	adminHandler.SetEmojiImportEnqueuer(s.queueClient)
+	adminHandler.SetRelayService(relaySvc)
 	if s.queueInspector != nil {
 		adminHandler.SetQueueInspector(&queueInspectorAdapter{inner: s.queueInspector})
 	}

--- a/internal/testutil/mock_repository.go
+++ b/internal/testutil/mock_repository.go
@@ -3290,3 +3290,56 @@ func (m *MockUsedUsernameRepository) Create(username string) error {
 func (m *MockUsedUsernameRepository) Exists(username string) (bool, error) {
 	return m.Usernames[username], nil
 }
+
+// MockRelayRepository is a test double for repository.RelayRepository.
+type MockRelayRepository struct {
+	Relays map[string]*model.Relay
+}
+
+func NewMockRelayRepository() *MockRelayRepository {
+	return &MockRelayRepository{Relays: make(map[string]*model.Relay)}
+}
+
+func (m *MockRelayRepository) Create(r *model.Relay) error {
+	m.Relays[r.ID] = r
+	return nil
+}
+
+func (m *MockRelayRepository) FindByID(id string) (*model.Relay, error) {
+	if r, ok := m.Relays[id]; ok {
+		return r, nil
+	}
+	return nil, ErrNotFound
+}
+
+func (m *MockRelayRepository) List() ([]*model.Relay, error) {
+	out := make([]*model.Relay, 0, len(m.Relays))
+	for _, r := range m.Relays {
+		out = append(out, r)
+	}
+	return out, nil
+}
+
+func (m *MockRelayRepository) ListByStatus(status string) ([]*model.Relay, error) {
+	out := make([]*model.Relay, 0)
+	for _, r := range m.Relays {
+		if r.Status == status {
+			out = append(out, r)
+		}
+	}
+	return out, nil
+}
+
+func (m *MockRelayRepository) UpdateStatus(id, status string) error {
+	r, ok := m.Relays[id]
+	if !ok {
+		return ErrNotFound
+	}
+	r.Status = status
+	return nil
+}
+
+func (m *MockRelayRepository) Delete(id string) error {
+	delete(m.Relays, id)
+	return nil
+}


### PR DESCRIPTION
## Summary

Issue #161 (親 #159)。DB 行だけ存在していた Relay をちゃんと動かす実装。Follow 配送 → Accept 受信で status 更新 → 以降の public 投稿を自動 fanout、まで一貫させる。

## 主な変更点

### 新規パッケージ
- \`internal/core/systemaccount/\` — Relay/Instance/Proxy actor 用の lazy 生成 (user + user_profile + RSA user_keypair + system_account)
- \`internal/core/relay/\` — Add / Remove / List / MarkAccepted / MarkRejected / DeliverToAccepted + 10 分 TTL キャッシュ
- \`internal/repository/relay.go\` — RelayRepository + gorm 実装

### 既存拡張
- \`activitypub.URLBuilder.FollowRelayURI\` + \`Renderer.RenderFollowRelay\` — TS \`renderFollowRelay\` 相当 (id 形式が Accept/Reject 検出の鍵)
- \`federation.Processor.SetRelayMarker\` + regex 抽出 — handleAccept/handleReject で \`/activities/follow-relay/{id}\` を検出して status 更新
- \`federation.NoteDeliveryHook.SetRelayBroadcaster\` — \`NoteVisibilityPublic\` のみ relay に fanout
- \`admin.Handler.SetRelayService\` — admin/relays の CRUD を Service 経由化 (既存 adminDB fallback も残す)

### 配線 (\`router.go\`)
- relay.Service を構築して federation processor / delivery hook / admin handler の 3 か所に注入

## 設計上の注記

**受信 Announce wrapping はスコープ外**: Relay は Announce(Activity) で wrap して再配信するが、現行 \`handleAnnounce\` は Note URI しか扱えない。拡張は別 issue 送り (P4-1 フォローアップ候補)。

**grouped chart の resync と同じ TODO パターン**: Misskey 本家も RelayService を \`relayService.deliverToRelays\` 経由でしか呼び出していないので、P4-1 のスコープもそれに合わせた。

## テスト

新規 / 追加:
- \`systemaccount\`: 8 ケース (生成 / 既存取得 / 失敗パス)
- \`relay\`: 17 ケース (Add/Remove/Mark/Deliver + cache + エラー経路)
- \`activitypub\`: RenderFollowRelay + URL ビルダ
- \`federation\`: Accept/Reject の relay 検出 + non-relay の素通し
- \`federation\`: NoteDeliveryHook の public fanout / home skip / nil-safe
- \`admin\`: 新規 RelaysAdd/List/Remove の service 経由パス

実行:
\`\`\`bash
go test ./internal/core/systemaccount/ ./internal/core/relay/ ./internal/core/federation/ ./internal/activitypub/ ./internal/api/admin/
\`\`\`

カバレッジ:
- \`internal/core/systemaccount\`: 92.6%
- \`internal/core/relay\`: 93.9%
- \`internal/core/federation\`: 90.8%
- \`internal/activitypub\`: 97.6%
- \`internal/api/admin\`: 60.4% (CI 閾値 60% 超)

## 関連
- 親 issue: #159
Closes #161
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/shiroha-a/mk/pull/171" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
