### PR TITLE
P4-10: wipe out scattered 未実装 markers (#170)

### DIFF
--- a/internal/api/admin/handler_stubs.go
+++ b/internal/api/admin/handler_stubs.go
@@ -49,7 +49,11 @@ func (h *Handler) AccountsFindByEmail(c echo.Context) error {
 	if err != nil {
 		return c.JSON(http.StatusNotFound, apierr.Error("USER_NOT_FOUND", "User not found.", "a504947-b888-4a99-9f62-8c4a0f3a3dab"))
 	}
-	return c.JSON(http.StatusOK, user)
+	// 他の admin エンドポイント (ShowUser 等) と同じ packAdminUser を通して
+	// Misskey 本家互換のレスポンス整形をする。生 model.User を返すと
+	// inbox / sharedInbox / usernameLower 等の内部フィールドが漏れ、
+	// createdAt / roles / policies 等のフロントが期待するフィールドが欠落する。
+	return c.JSON(http.StatusOK, h.packAdminUser(user, profile))
 }
 
 // --- single endpoints ---

--- a/internal/api/admin/handler_stubs.go
+++ b/internal/api/admin/handler_stubs.go
@@ -32,6 +32,8 @@ func (h *Handler) AccountsDelete(c echo.Context) error {
 }
 
 // AccountsFindByEmail handles POST /api/admin/accounts/find-by-email.
+// user_profile.email 列を検索して、紐づく user を返す。本家 Misskey の
+// admin/accounts/find-by-email と同等。
 func (h *Handler) AccountsFindByEmail(c echo.Context) error {
 	var req struct {
 		Email string `json:"email"`
@@ -39,8 +41,15 @@ func (h *Handler) AccountsFindByEmail(c echo.Context) error {
 	if err := c.Bind(&req); err != nil || req.Email == "" {
 		return c.JSON(http.StatusBadRequest, apierr.Error("INVALID_PARAM", "email is required.", "3d81ceae-475f-4600-b2a8-2bc116157532"))
 	}
-	// メール検索は未実装 (user_profileテーブルのemail列検索が必要)
-	return c.JSON(http.StatusNotFound, apierr.Error("USER_NOT_FOUND", "User not found.", "a504947-b888-4a99-9f62-8c4a0f3a3dab"))
+	profile, err := h.userRepo.FindProfileByEmail(req.Email)
+	if err != nil {
+		return c.JSON(http.StatusNotFound, apierr.Error("USER_NOT_FOUND", "User not found.", "a504947-b888-4a99-9f62-8c4a0f3a3dab"))
+	}
+	user, err := h.userRepo.FindByID(profile.UserID)
+	if err != nil {
+		return c.JSON(http.StatusNotFound, apierr.Error("USER_NOT_FOUND", "User not found.", "a504947-b888-4a99-9f62-8c4a0f3a3dab"))
+	}
+	return c.JSON(http.StatusOK, user)
 }
 
 // --- single endpoints ---

--- a/internal/api/admin/handler_stubs_test.go
+++ b/internal/api/admin/handler_stubs_test.go
@@ -64,6 +64,17 @@ func TestAccountsFindByEmail_NotFound(t *testing.T) {
 	assert.Equal(t, http.StatusNotFound, doPost(h.AccountsFindByEmail, `{"email":"ghost@example.com"}`, adminUser).Code)
 }
 
+func TestAccountsFindByEmail_Found(t *testing.T) {
+	h, userRepo, _, _ := newTestHandler(t)
+	email := "alice@example.com"
+	userRepo.Users["alice"] = &model.User{ID: "alice", Username: "alice"}
+	userRepo.Profiles["alice"] = &model.UserProfile{UserID: "alice", Email: &email}
+
+	rec := doPost(h.AccountsFindByEmail, `{"email":"alice@example.com"}`, adminUser)
+	assert.Equal(t, http.StatusOK, rec.Code)
+	assert.Contains(t, rec.Body.String(), `"alice"`)
+}
+
 // --- ad ---
 func TestAdCreate(t *testing.T) {
 	h, _, _, _ := newTestHandler(t)

--- a/internal/api/antennas/handler.go
+++ b/internal/api/antennas/handler.go
@@ -32,6 +32,7 @@ func NewHandler(svc *coreantenna.Service, noteRepo repository.NoteRepository, id
 type CreateRequest struct {
 	Name            string              `json:"name"`
 	Src             model.AntennaSource `json:"src"`
+	UserListID      *string             `json:"userListId"`
 	Users           []string            `json:"users"`
 	Keywords        [][]string          `json:"keywords"`
 	ExcludeKeywords [][]string          `json:"excludeKeywords"`
@@ -53,6 +54,7 @@ func (h *Handler) Create(c echo.Context) error {
 		OwnerID:         user.ID,
 		Name:            req.Name,
 		Src:             req.Src,
+		UserListID:      req.UserListID,
 		Users:           req.Users,
 		Keywords:        req.Keywords,
 		ExcludeKeywords: req.ExcludeKeywords,
@@ -101,6 +103,7 @@ type UpdateRequest struct {
 	AntennaID       string               `json:"antennaId"`
 	Name            *string              `json:"name"`
 	Src             *model.AntennaSource `json:"src"`
+	UserListID      *string              `json:"userListId"`
 	Users           *[]string            `json:"users"`
 	Keywords        *[][]string          `json:"keywords"`
 	ExcludeKeywords *[][]string          `json:"excludeKeywords"`
@@ -122,6 +125,7 @@ func (h *Handler) Update(c echo.Context) error {
 	a, err := h.svc.Update(user.ID, req.AntennaID, coreantenna.UpdateInput{
 		Name:            req.Name,
 		Src:             req.Src,
+		UserListID:      req.UserListID,
 		Users:           req.Users,
 		Keywords:        req.Keywords,
 		ExcludeKeywords: req.ExcludeKeywords,
@@ -226,6 +230,7 @@ func antennaToMap(a *model.Antenna) map[string]any {
 		"userId":          a.UserID,
 		"name":            a.Name,
 		"src":             a.Src,
+		"userListId":      a.UserListID,
 		"users":           a.Users,
 		"keywords":        a.Keywords,
 		"excludeKeywords": a.ExcludeKeywords,

--- a/internal/api/i/handler.go
+++ b/internal/api/i/handler.go
@@ -24,6 +24,7 @@ import (
 type RoleProvider interface {
 	IsAdministrator(userID string) bool
 	IsModerator(userID string) bool
+	IsSilenced(userID string) bool
 	GetUserRoles(userID string) ([]*model.Role, error)
 	GetUserPolicies(userID string) map[string]any
 }
@@ -46,6 +47,16 @@ type Handler struct {
 	emailSender      EmailSender
 	serverURL        string
 	signinRepo       repository.SigninRepository
+}
+
+// isSilenced returns whether the given user has any role whose merged
+// policies deny canPublicNote. Wraps roleProvider so a nil provider
+// (early boot / tests that skip role wiring) yields false.
+func (h *Handler) isSilenced(userID string) bool {
+	if h.roleProvider == nil {
+		return false
+	}
+	return h.roleProvider.IsSilenced(userID)
 }
 
 // SetServerURL sets the base URL used for email verification links.
@@ -242,7 +253,7 @@ func (h *Handler) Me(c echo.Context) error {
 		"bannerUrl":      detailed.BannerURL,
 		"bannerBlurhash": detailed.BannerBlurhash,
 		"isLocked":       detailed.IsLocked,
-		"isSilenced":     u.IsSuspended && false, // ロールベースで判定 (未実装)
+		"isSilenced":     h.isSilenced(u.ID),
 		"isSuspended":    detailed.IsSuspended,
 		"description":    detailed.Description,
 		"location":       detailed.Location,

--- a/internal/api/i/handler_test.go
+++ b/internal/api/i/handler_test.go
@@ -338,12 +338,14 @@ func TestMe_AvatarAndBannerIDs(t *testing.T) {
 type stubRoleProvider struct {
 	admin     bool
 	moderator bool
+	silenced  bool
 	roles     []*model.Role
 	policies  map[string]any
 }
 
 func (s *stubRoleProvider) IsAdministrator(_ string) bool { return s.admin }
 func (s *stubRoleProvider) IsModerator(_ string) bool     { return s.moderator }
+func (s *stubRoleProvider) IsSilenced(_ string) bool      { return s.silenced }
 func (s *stubRoleProvider) GetUserRoles(_ string) ([]*model.Role, error) {
 	return s.roles, nil
 }

--- a/internal/api/resetpassword/handler_test.go
+++ b/internal/api/resetpassword/handler_test.go
@@ -76,6 +76,10 @@ func (m *mockUserRepo) FindProfileByVerifyCode(string) (*model.UserProfile, erro
 	return nil, errMock
 }
 
+func (m *mockUserRepo) FindProfileByEmail(string) (*model.UserProfile, error) {
+	return nil, errMock
+}
+
 func (m *mockUserRepo) UpdateProfile(userID string, fields map[string]any) error {
 	p, ok := m.profiles[userID]
 	if !ok {

--- a/internal/api/signup/handler.go
+++ b/internal/api/signup/handler.go
@@ -77,7 +77,9 @@ func (h *Handler) Signup(c echo.Context) error {
 		return c.JSON(http.StatusInternalServerError, apierr.Error("INTERNAL_ERROR", "Internal error.", "5d37dbcb-891e-41ca-a3d6-e690c97775ac"))
 	}
 
-	// メール認証フローは未実装 (テストモードではスキップ)
+	// メール認証フローは #165 (P4-5 admin/accounts + email) で実装予定。
+	// 現状は meta.EmailRequiredForSignup を真にすると INVALID_PARAM で登録を
+	// 拒否するのみで、実際の確認メール送信は行わない。testMode 下は完全バイパス。
 	if !h.testMode && meta.EmailRequiredForSignup {
 		return c.JSON(http.StatusBadRequest, apierr.Error("INVALID_PARAM", "Email-required signup is not yet supported.", "3d81ceae-475f-4600-b2a8-2bc116157532"))
 	}

--- a/internal/core/antenna/antenna_service.go
+++ b/internal/core/antenna/antenna_service.go
@@ -71,7 +71,8 @@ func NewService(
 
 // SetFollowingRepo enables the `home` antenna source by providing a
 // way to check whether the antenna owner follows the note author.
-// nil でも antenna service は動くが `home` は `all` にフォールバックする。
+// nil でも antenna service は動くが `home` source は常に不一致扱いになる
+// (matchSource 実装と揃える)。
 func (s *Service) SetFollowingRepo(r repository.FollowingRepository) {
 	s.followingRepo = r
 }

--- a/internal/core/antenna/antenna_service.go
+++ b/internal/core/antenna/antenna_service.go
@@ -42,16 +42,18 @@ func streamKey(antennaID string) string {
 
 // Service provides antenna CRUD plus matchNote / OnNoteCreated push.
 type Service struct {
-	repo     repository.AntennaRepository
-	userRepo repository.UserRepository
-	client   *redis.Client
-	idGen    id.Generator
-	clock    func() time.Time
+	repo          repository.AntennaRepository
+	userRepo      repository.UserRepository
+	followingRepo repository.FollowingRepository
+	userListRepo  repository.UserListRepository
+	client        *redis.Client
+	idGen         id.Generator
+	clock         func() time.Time
 }
 
-// NewService constructs an antenna Service. userRepo は home source の判定で
-// follower 情報が必要になる将来拡張のために受けるが、Phase 4.3 では使わない。
-// nil 渡し可能。
+// NewService constructs an antenna Service. userRepo は現状未使用だが、将来
+// 拡張のため受け取る (nil 許容)。home / list source を有効にするには、別途
+// SetFollowingRepo / SetUserListRepo で repository を注入する必要がある。
 func NewService(
 	repo repository.AntennaRepository,
 	userRepo repository.UserRepository,
@@ -67,6 +69,19 @@ func NewService(
 	}
 }
 
+// SetFollowingRepo enables the `home` antenna source by providing a
+// way to check whether the antenna owner follows the note author.
+// nil でも antenna service は動くが `home` は `all` にフォールバックする。
+func (s *Service) SetFollowingRepo(r repository.FollowingRepository) {
+	s.followingRepo = r
+}
+
+// SetUserListRepo enables the `list` antenna source. nil なら list sources は
+// 登録/マッチともに reject される。
+func (s *Service) SetUserListRepo(r repository.UserListRepository) {
+	s.userListRepo = r
+}
+
 // SetClock overrides the time source. Intended for tests.
 func (s *Service) SetClock(now func() time.Time) {
 	if now != nil {
@@ -79,6 +94,7 @@ type CreateInput struct {
 	OwnerID         string
 	Name            string
 	Src             model.AntennaSource
+	UserListID      *string
 	Users           []string
 	Keywords        [][]string
 	ExcludeKeywords [][]string
@@ -110,6 +126,7 @@ func (s *Service) Create(in CreateInput) (*model.Antenna, error) {
 		UserID:          in.OwnerID,
 		Name:            in.Name,
 		Src:             in.Src,
+		UserListID:      in.UserListID,
 		Users:           in.Users,
 		Keywords:        keywords,
 		ExcludeKeywords: exclude,
@@ -328,17 +345,44 @@ func (s *Service) matchNote(a *model.Antenna, n *model.Note, author *model.User)
 	return true
 }
 
-// matchSource applies the antenna's source filter (users / users_blacklist /
-// home / all). home は本来「フォローしている人」だが Phase 4.3 では未実装で
-// `all` と同等扱い (WithReplies / Keywords 等のフィルタで補う)。
+// matchSource applies the antenna's source filter.
+//
+//   - users: whitelist — author.username が a.Users に含まれていれば match
+//   - users_blacklist: blacklist — 含まれていなければ match
+//   - home: a の owner がフォロー中のユーザーのみ match (followingRepo 必須)
+//   - list: a.UserListID に紐づいた UserListMembership に author が含まれる
+//   - all: すべて match
+//
+// followingRepo / userListRepo が未注入のときは対応ソースを match 不成立
+// とみなす (all へのフォールバックではなく、設定ミスが検出しやすい側)。
 func (s *Service) matchSource(a *model.Antenna, author *model.User) bool {
 	switch a.Src {
 	case model.AntennaSourceUsers:
 		return slices.Contains(a.Users, author.Username)
 	case model.AntennaSourceUsersBlacklist:
 		return !slices.Contains(a.Users, author.Username)
+	case model.AntennaSourceHome:
+		if s.followingRepo == nil {
+			return false
+		}
+		ok, err := s.followingRepo.Exists(a.UserID, author.ID)
+		return err == nil && ok
+	case model.AntennaSourceList:
+		if s.userListRepo == nil || a.UserListID == nil || *a.UserListID == "" {
+			return false
+		}
+		members, err := s.userListRepo.ListMembers(*a.UserListID)
+		if err != nil {
+			return false
+		}
+		for _, m := range members {
+			if m.UserID == author.ID {
+				return true
+			}
+		}
+		return false
 	default:
-		// home / all / list は all と同等扱い
+		// all
 		return true
 	}
 }
@@ -422,11 +466,11 @@ func normalizeKeywords(in [][]string) [][]string {
 }
 
 // validSource reports whether s is one of the allowed antenna source values.
-// list はモデルにあるが Phase 4.3 では UserList が未実装のため reject する。
 func validSource(s model.AntennaSource) bool {
 	switch s {
 	case model.AntennaSourceAll, model.AntennaSourceHome,
-		model.AntennaSourceUsers, model.AntennaSourceUsersBlacklist:
+		model.AntennaSourceUsers, model.AntennaSourceUsersBlacklist,
+		model.AntennaSourceList:
 		return true
 	}
 	return false

--- a/internal/core/antenna/antenna_service.go
+++ b/internal/core/antenna/antenna_service.go
@@ -160,6 +160,7 @@ func (s *Service) Show(ownerID, antennaID string) (*model.Antenna, error) {
 type UpdateInput struct {
 	Name            *string
 	Src             *model.AntennaSource
+	UserListID      *string
 	Users           *[]string
 	Keywords        *[][]string
 	ExcludeKeywords *[][]string
@@ -192,6 +193,10 @@ func (s *Service) Update(ownerID, antennaID string, in UpdateInput) (*model.Ante
 			return nil, ErrInvalidSource
 		}
 		fields["src"] = *in.Src
+	}
+	if in.UserListID != nil {
+		// 空文字列での nullify を許すため ポインタ非 nil なら上書き対象扱い。
+		fields["userListId"] = in.UserListID
 	}
 	if in.Users != nil {
 		fields["users"] = *in.Users

--- a/internal/core/antenna/antenna_service_test.go
+++ b/internal/core/antenna/antenna_service_test.go
@@ -84,10 +84,12 @@ func TestCreate_InvalidSource(t *testing.T) {
 	assert.ErrorIs(t, err, ErrInvalidSource)
 }
 
-func TestCreate_ListSourceRejected(t *testing.T) {
+func TestCreate_ListSourceAccepted(t *testing.T) {
+	// #170 以降 list ソースも正規値として扱う (validSource に追加済み)。
 	svc, _ := newSvc(t)
-	_, err := svc.Create(CreateInput{OwnerID: "u1", Name: "alpha", Src: model.AntennaSourceList})
-	assert.ErrorIs(t, err, ErrInvalidSource)
+	listID := "ul1"
+	_, err := svc.Create(CreateInput{OwnerID: "u1", Name: "alpha", Src: model.AntennaSourceList, UserListID: &listID})
+	require.NoError(t, err)
 }
 
 func TestCreate_RepoError(t *testing.T) {
@@ -537,4 +539,66 @@ func TestSetClock(t *testing.T) {
 	a, err := svc.Create(CreateInput{OwnerID: "u1", Name: "alpha", Src: model.AntennaSourceAll})
 	require.NoError(t, err)
 	assert.Equal(t, fixed, a.LastUsedAt)
+}
+
+// Home source: owner follows author → match, otherwise miss.
+func TestMatchNote_HomeSource_Follows(t *testing.T) {
+	svc, _ := newSvc(t)
+	follows := testutil.NewMockFollowingRepository()
+	svc.SetFollowingRepo(follows)
+	// u1 → alice をフォロー
+	require.NoError(t, follows.Create(&model.Following{ID: "f1", FollowerID: "u1", FolloweeID: "alice"}))
+	a, err := svc.Create(CreateInput{OwnerID: "u1", Name: "homeA", Src: model.AntennaSourceHome})
+	require.NoError(t, err)
+	text := "hi"
+	n := &model.Note{ID: "n1", UserID: "alice", Text: &text}
+	assert.True(t, svc.matchNote(a, n, &model.User{ID: "alice", Username: "alice"}))
+}
+
+func TestMatchNote_HomeSource_NotFollowing(t *testing.T) {
+	svc, _ := newSvc(t)
+	svc.SetFollowingRepo(testutil.NewMockFollowingRepository())
+	a, err := svc.Create(CreateInput{OwnerID: "u1", Name: "homeB", Src: model.AntennaSourceHome})
+	require.NoError(t, err)
+	text := "hi"
+	n := &model.Note{ID: "n1", UserID: "bob", Text: &text}
+	assert.False(t, svc.matchNote(a, n, &model.User{ID: "bob", Username: "bob"}))
+}
+
+func TestMatchNote_HomeSource_NilRepoMisses(t *testing.T) {
+	// followingRepo 未注入なら home source は必ず miss (設定ミスを気付かせる)
+	svc, _ := newSvc(t)
+	a, err := svc.Create(CreateInput{OwnerID: "u1", Name: "homeC", Src: model.AntennaSourceHome})
+	require.NoError(t, err)
+	text := "hi"
+	n := &model.Note{ID: "n1", UserID: "alice", Text: &text}
+	assert.False(t, svc.matchNote(a, n, &model.User{ID: "alice", Username: "alice"}))
+}
+
+// List source: author が UserList に含まれていれば match。
+func TestMatchNote_ListSource_MemberMatches(t *testing.T) {
+	svc, _ := newSvc(t)
+	lists := testutil.NewMockUserListRepository()
+	svc.SetUserListRepo(lists)
+	listID := "ul1"
+	require.NoError(t, lists.Create(&model.UserList{ID: listID, UserID: "u1", Name: "friends"}))
+	require.NoError(t, lists.AddMember(&model.UserListMembership{UserListID: listID, UserID: "alice"}))
+	a, err := svc.Create(CreateInput{OwnerID: "u1", Name: "listA", Src: model.AntennaSourceList, UserListID: &listID})
+	require.NoError(t, err)
+	text := "hi"
+	n := &model.Note{ID: "n1", UserID: "alice", Text: &text}
+	assert.True(t, svc.matchNote(a, n, &model.User{ID: "alice", Username: "alice"}))
+}
+
+func TestMatchNote_ListSource_NonMember(t *testing.T) {
+	svc, _ := newSvc(t)
+	lists := testutil.NewMockUserListRepository()
+	svc.SetUserListRepo(lists)
+	listID := "ul1"
+	require.NoError(t, lists.Create(&model.UserList{ID: listID, UserID: "u1", Name: "friends"}))
+	a, err := svc.Create(CreateInput{OwnerID: "u1", Name: "listB", Src: model.AntennaSourceList, UserListID: &listID})
+	require.NoError(t, err)
+	text := "hi"
+	n := &model.Note{ID: "n1", UserID: "bob", Text: &text}
+	assert.False(t, svc.matchNote(a, n, &model.User{ID: "bob", Username: "bob"}))
 }

--- a/internal/core/note/note_query_service.go
+++ b/internal/core/note/note_query_service.go
@@ -7,14 +7,28 @@ import (
 
 // QueryService provides read-only note queries used by notes/* endpoints.
 type QueryService struct {
-	noteRepo      repository.NoteRepository
-	followingRepo repository.FollowingRepository
+	noteRepo       repository.NoteRepository
+	followingRepo  repository.FollowingRepository
+	favoriteRepo   repository.NoteFavoriteRepository
+	threadMuteRepo repository.NoteThreadMutingRepository
 }
 
 // NewQueryService creates a new QueryService.
 // followingRepoはfollowers可視性のチェックに使われる。nilを許容する。
 func NewQueryService(noteRepo repository.NoteRepository, followingRepo repository.FollowingRepository) *QueryService {
 	return &QueryService{noteRepo: noteRepo, followingRepo: followingRepo}
+}
+
+// SetFavoriteRepo enables isFavorited reporting on State(). nil でも State
+// は動くが isFavorited は常に false になる。
+func (s *QueryService) SetFavoriteRepo(r repository.NoteFavoriteRepository) {
+	s.favoriteRepo = r
+}
+
+// SetThreadMutingRepo enables isMutedThread reporting on State(). nil でも
+// State は動くが isMutedThread は常に false になる。
+func (s *QueryService) SetThreadMutingRepo(r repository.NoteThreadMutingRepository) {
+	s.threadMuteRepo = r
 }
 
 // Show returns the requested note if it exists and the viewer can see it.
@@ -108,13 +122,35 @@ func (s *QueryService) Conversation(viewer *model.User, noteID string, limit int
 }
 
 // State returns the note's user-specific state flags.
-// 現状はreaction/clip/notification系のスキーマが未実装のため、すべてfalseを返す。
-// noteの存在および閲覧可能性のみを検証する。
+// 匿名閲覧者 (viewer==nil) はすべて false。
+// isWatching は note 通知購読テーブル (note_watching) を別 issue で扱うため、
+// ここでは常に false を返す。
 func (s *QueryService) State(viewer *model.User, noteID string) (*NoteState, error) {
-	if _, err := s.Show(viewer, noteID); err != nil {
+	note, err := s.Show(viewer, noteID)
+	if err != nil {
 		return nil, err
 	}
-	return &NoteState{}, nil
+	state := &NoteState{}
+	if viewer == nil {
+		return state, nil
+	}
+	if s.favoriteRepo != nil {
+		if ok, err := s.favoriteRepo.Exists(viewer.ID, note.ID); err == nil && ok {
+			state.IsFavorited = true
+		}
+	}
+	if s.threadMuteRepo != nil {
+		// 本家 Misskey の threadId は note.threadId (ルート) を指す。reply 系の
+		// ノートは自身の threadId を、ルートは自身の id を threadId として扱う。
+		threadID := note.ID
+		if note.ThreadID != nil && *note.ThreadID != "" {
+			threadID = *note.ThreadID
+		}
+		if ok, err := s.threadMuteRepo.Exists(viewer.ID, threadID); err == nil && ok {
+			state.IsMutedThread = true
+		}
+	}
+	return state, nil
 }
 
 // NoteState represents notes/state response payload.

--- a/internal/core/note/note_query_service_test.go
+++ b/internal/core/note/note_query_service_test.go
@@ -258,3 +258,51 @@ func TestQueryService_ListChildren_RepoError(t *testing.T) {
 	_, err := svc.ListChildren(nil, "p", "", "", 10)
 	require.Error(t, err)
 }
+
+func TestQueryService_State_AnonymousIsAllFalse(t *testing.T) {
+	mock := testutil.NewMockNoteRepository()
+	mock.Notes["n1"] = &model.Note{ID: "n1", UserID: "a", Visibility: model.NoteVisibilityPublic}
+	svc := note.NewQueryService(mock, nil)
+	svc.SetFavoriteRepo(testutil.NewMockNoteFavoriteRepository())
+	svc.SetThreadMutingRepo(testutil.NewMockNoteThreadMutingRepository())
+
+	state, err := svc.State(nil, "n1")
+	require.NoError(t, err)
+	assert.False(t, state.IsFavorited)
+	assert.False(t, state.IsMutedThread)
+	assert.False(t, state.IsWatching)
+}
+
+func TestQueryService_State_FavoritedTrue(t *testing.T) {
+	mock := testutil.NewMockNoteRepository()
+	mock.Notes["n1"] = &model.Note{ID: "n1", UserID: "a", Visibility: model.NoteVisibilityPublic}
+	svc := note.NewQueryService(mock, nil)
+	favRepo := testutil.NewMockNoteFavoriteRepository()
+	require.NoError(t, favRepo.Create(&model.NoteFavorite{UserID: "viewer", NoteID: "n1"}))
+	svc.SetFavoriteRepo(favRepo)
+
+	state, err := svc.State(&model.User{ID: "viewer"}, "n1")
+	require.NoError(t, err)
+	assert.True(t, state.IsFavorited)
+	assert.False(t, state.IsMutedThread)
+}
+
+func TestQueryService_State_MutedThreadTrue(t *testing.T) {
+	mock := testutil.NewMockNoteRepository()
+	rootID := "thread-root"
+	mock.Notes["child"] = &model.Note{ID: "child", UserID: "a", ThreadID: &rootID, Visibility: model.NoteVisibilityPublic}
+	svc := note.NewQueryService(mock, nil)
+	mutes := testutil.NewMockNoteThreadMutingRepository()
+	require.NoError(t, mutes.Create(&model.NoteThreadMuting{UserID: "viewer", ThreadID: rootID}))
+	svc.SetThreadMutingRepo(mutes)
+
+	state, err := svc.State(&model.User{ID: "viewer"}, "child")
+	require.NoError(t, err)
+	assert.True(t, state.IsMutedThread)
+}
+
+func TestQueryService_State_NoteNotFound(t *testing.T) {
+	svc := note.NewQueryService(testutil.NewMockNoteRepository(), nil)
+	_, err := svc.State(&model.User{ID: "viewer"}, "missing")
+	require.Error(t, err)
+}

--- a/internal/core/role/role_service.go
+++ b/internal/core/role/role_service.go
@@ -83,6 +83,19 @@ func (s *Service) IsAdministrator(userID string) bool {
 	return false
 }
 
+// IsSilenced reports whether the user's merged role policies deny
+// `canPublicNote`. Mirrors upstream Misskey where silencing is not a
+// direct user flag but the outcome of a policy override on an assigned
+// role. Users without any overriding role fall back to DefaultPolicies
+// (canPublicNote=true) and are therefore not silenced.
+func (s *Service) IsSilenced(userID string) bool {
+	policies := s.GetUserPolicies(userID)
+	if canPublic, ok := policies["canPublicNote"].(bool); ok {
+		return !canPublic
+	}
+	return false
+}
+
 // IsModerator checks if the user has any moderator/admin role or is root.
 func (s *Service) IsModerator(userID string) bool {
 	if s.isRootUser(userID) {

--- a/internal/core/role/role_service_test.go
+++ b/internal/core/role/role_service_test.go
@@ -447,3 +447,24 @@ func TestDefaultPolicies(t *testing.T) {
 	assert.Equal(t, 100, p["driveCapacityMb"])
 	assert.Equal(t, 5, p["pinLimit"])
 }
+
+func TestIsSilenced_DefaultIsFalse(t *testing.T) {
+	svc, _, _, _ := newTestService(t)
+	// 誰もロールを持っていない → DefaultPolicies は canPublicNote=true
+	assert.False(t, svc.IsSilenced("user1"))
+}
+
+func TestIsSilenced_CanPublicNoteFalseMeansSilenced(t *testing.T) {
+	svc, roleRepo, assignRepo, _ := newTestService(t)
+	// policies JSON で canPublicNote=false を上書きした role を持たせる
+	roleRepo.Roles["r1"] = &model.Role{
+		ID: "r1",
+		Policies: datatypes.JSON([]byte(
+			`{"canPublicNote":{"useDefault":false,"priority":1,"value":false}}`,
+		)),
+	}
+	assignRepo.Assignments["user1:r1"] = &model.RoleAssignment{
+		ID: "a1", UserID: "user1", RoleID: "r1",
+	}
+	assert.True(t, svc.IsSilenced("user1"))
+}

--- a/internal/model/user_profile.go
+++ b/internal/model/user_profile.go
@@ -56,7 +56,9 @@ type UserProfile struct {
 	NotificationRecieveConfig datatypes.JSON      `gorm:"column:notificationRecieveConfig;type:jsonb;default:'{}'" json:"notificationRecieveConfig"`
 	LoggedInDates             pq.StringArray      `gorm:"column:loggedInDates;type:varchar(32)[];default:'{}'" json:"loggedInDates"`
 	Achievements              datatypes.JSON      `gorm:"column:achievements;type:jsonb;default:'[]'" json:"achievements"`
-	// 本家 Misskey 互換のため保持する。Go 側で読み書きする機能は未実装 (後続 issue)。
+	// ClientData / Room はクライアント固有の任意 JSON を pass-through 保存する
+	// フィールド。Go バックエンドは値を解釈せず、i/update で受け取ったものをそのまま
+	// 保存し、i で返却する。Go 側に解釈ロジックを追加する予定は現状なし。
 	ClientData datatypes.JSON `gorm:"column:clientData;type:jsonb;default:'{}'" json:"clientData"`
 	Room       datatypes.JSON `gorm:"column:room;type:jsonb;default:'{}'" json:"room"`
 	UserHost   *string        `gorm:"column:userHost;type:varchar(128)" json:"userHost"`

--- a/internal/repository/user.go
+++ b/internal/repository/user.go
@@ -24,6 +24,7 @@ type UserRepository interface {
 	ListUsers(filter model.UserListFilter) ([]*model.User, error)
 	ListRemoteInboxes() ([]string, error)
 	FindProfileByVerifyCode(code string) (*model.UserProfile, error)
+	FindProfileByEmail(email string) (*model.UserProfile, error)
 	CountOnlineUsers() (int64, error)
 }
 
@@ -138,6 +139,18 @@ func (r *userRepository) CreateProfile(profile *model.UserProfile) error {
 func (r *userRepository) FindProfileByVerifyCode(code string) (*model.UserProfile, error) {
 	var p model.UserProfile
 	if err := r.db.Where(`"emailVerifyCode" = ?`, code).First(&p).Error; err != nil {
+		return nil, err
+	}
+	return &p, nil
+}
+
+// FindProfileByEmail looks up a user_profile by email. admin/accounts/
+// find-by-email で使う (本家 Misskey の accounts/find-by-email 相当)。
+// email 列は nullable + case-insensitive 検索にしたいが、本家 DB は
+// unique index を張っていないので「最初に見つかった 1 件」を返す。
+func (r *userRepository) FindProfileByEmail(email string) (*model.UserProfile, error) {
+	var p model.UserProfile
+	if err := r.db.Where(`"email" = ?`, email).First(&p).Error; err != nil {
 		return nil, err
 	}
 	return &p, nil

--- a/internal/server/router.go
+++ b/internal/server/router.go
@@ -149,6 +149,7 @@ func (s *Server) setupRoutes() {
 	roleAssignmentRepo := repository.NewRoleAssignmentRepository(s.db)
 	swSubRepo := repository.NewSwSubscriptionRepository(s.db)
 	noteFavoriteRepo := repository.NewNoteFavoriteRepository(s.db)
+	noteThreadMutingRepo := repository.NewNoteThreadMutingRepository(s.db)
 	userListRepo := repository.NewUserListRepository(s.db)
 	webhookRepo := repository.NewWebhookRepository(s.db)
 	systemWebhookRepo := repository.NewSystemWebhookRepository(s.db)
@@ -169,6 +170,8 @@ func (s *Server) setupRoutes() {
 	noteCreateService := corenote.NewCreateService(noteRepo, pollRepo, idGen, followingRepo)
 	noteDeleteService := corenote.NewDeleteService(noteRepo)
 	noteQueryService := corenote.NewQueryService(noteRepo, followingRepo)
+	noteQueryService.SetFavoriteRepo(noteFavoriteRepo)
+	noteQueryService.SetThreadMutingRepo(noteThreadMutingRepo)
 	userService := coreuser.NewService(userRepo, noteRepo, piningRepo, idGen)
 	followingService := corefollowing.NewService(userRepo, followingRepo, followRequestRepo, idGen)
 
@@ -187,6 +190,8 @@ func (s *Server) setupRoutes() {
 
 	// Antennas (Phase 4.3)
 	antennaService := coreantenna.NewService(antennaRepo, userRepo, s.redis.Default, idGen)
+	antennaService.SetFollowingRepo(followingRepo)
+	antennaService.SetUserListRepo(userListRepo)
 	noteCreateService.SetAntennaHook(coreantenna.NewNoteCreateHook(antennaService))
 
 	// Clips (Phase 4.4)
@@ -1685,7 +1690,10 @@ func (s *Server) setupRoutes() {
 		return c.JSON(http.StatusOK, map[string]any{})
 	})
 
-	// API catchall — 未実装エンドポイントに 200 を返してフロントエンドのクラッシュを防ぐ
+	// API catchall — 意図的に 200 + 空オブジェクトを返す。未登録エンドポイントへの
+	// 404 は Misskey 公式フロントの一部ページで例外を投げてしまうため、
+	// 互換性優先で pass-through にしている (本家 TS Misskey と同じ運用)。
+	// 実装漏れは warn ログで検知する。
 	api.Any("/*", func(c echo.Context) error {
 		slog.Warn("unimplemented API endpoint", "method", c.Request().Method, "path", c.Request().URL.Path)
 		return c.JSON(http.StatusOK, map[string]any{})

--- a/internal/testutil/mock_repository.go
+++ b/internal/testutil/mock_repository.go
@@ -90,6 +90,15 @@ func (m *MockUserRepository) FindProfileByVerifyCode(code string) (*model.UserPr
 	return nil, ErrNotFound
 }
 
+func (m *MockUserRepository) FindProfileByEmail(email string) (*model.UserProfile, error) {
+	for _, p := range m.Profiles {
+		if p.Email != nil && *p.Email == email {
+			return p, nil
+		}
+	}
+	return nil, ErrNotFound
+}
+
 func (m *MockUserRepository) IncrementFollowingCount(userID string, delta int) error {
 	if u, ok := m.Users[userID]; ok {
 		u.FollowingCount += delta


### PR DESCRIPTION
## Summary

Issue #170 (親 #159)。internal/ 配下の `// 未実装` コメントを **実装** か **「意図的に未実装」コメント明示化** のどちらかに全置換。grep で検出ゼロになった。

## 実装化した 4 箇所

| 対象 | 実装内容 |
|---|---|
| \`i/handler.go:isSilenced\` | \`role.Service.IsSilenced\` (policies.canPublicNote否定) を RoleProvider 経由で呼ぶ |
| \`admin/accounts/find-by-email\` | \`UserRepository.FindProfileByEmail\` を追加して user_profile.email 検索を実装 |
| \`note.QueryService.State\` | isFavorited / isMutedThread を note_favorite / note_thread_muting テーブルから取得 |
| \`antenna\` home/list source | FollowingRepository / UserListRepository を setter 注入して matchSource を本実装。AntennaSourceList を validSource へ昇格、CreateInput に UserListID 追加 |

## コメント明示化 (意図的に現状維持) 3 箇所

- \`user_profile.ClientData / Room\`: クライアント固有 JSON を pass-through 保存するだけのフィールドで、Go 側が解釈する予定はない
- \`router.go\` API catchall: 200 + 空 JSON を返す方針は本家 TS Misskey と同じ。404 にするとフロントの一部ページで例外になる
- \`signup/handler.go\` メール必須化: 実際の確認メール送信は **#165 (P4-5 admin/accounts + メール送信)** で実装予定

## 別 issue 送り

- **#165 (P4-5)**: signup のメール確認フロー本実装 (本 PR では \`EmailRequiredForSignup\` 時に 400 を返すだけ)
- **#173 (P4-10 followup)**: note_watching テーブル新設 + \`isWatching\` 応答 — 本 PR では常に false を返し、コメントで明示

## テスト

新規追加:
- role: \`IsSilenced\` の default/canPublicNote=false 2 ケース
- admin: \`AccountsFindByEmail_Found\` (email → user 解決)
- note: \`State_AnonymousIsAllFalse\` / \`_FavoritedTrue\` / \`_MutedThreadTrue\` / \`_NoteNotFound\`
- antenna: home (follows / not-following / nil-repo) + list (member / non-member) 合計 5 ケース
- 既存 \`TestCreate_ListSourceRejected\` を \`TestCreate_ListSourceAccepted\` に更新

実行:
\`\`\`bash
go test ./internal/core/role/ ./internal/core/note/ ./internal/core/antenna/ ./internal/api/i/ ./internal/api/admin/ ./internal/api/signup/ ./internal/api/resetpassword/
\`\`\`

## 完了確認

\`\`\`
$ grep -rn '未実装' internal/ --include='*.go' | grep -v _test.go
# => 0 件
\`\`\`

## 関連
- 親issue: #159
Closes #170