### PR TITLE
P4-3: admin/ad + avatar-decorations + invite + promo 本実装

### DIFF
--- a/internal/api/admin/ad_invite_promo_test.go
+++ b/internal/api/admin/ad_invite_promo_test.go
@@ -223,10 +223,13 @@ func TestInviteCreate_Default(t *testing.T) {
 	h.SetInviteRepo(repo)
 	rec := doPost(h.InviteCreate, `{}`, adminUser)
 	assert.Equal(t, http.StatusOK, rec.Code)
-	var rows []model.RegistrationTicket
+	var rows []map[string]any
 	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &rows))
-	assert.Len(t, rows, 1)
-	assert.NotEmpty(t, rows[0].Code)
+	require.Len(t, rows, 1)
+	assert.NotEmpty(t, rows[0]["code"])
+	// createdAt が含まれる (Misskey 本家互換)
+	assert.NotNil(t, rows[0]["createdAt"])
+	assert.Equal(t, false, rows[0]["used"])
 }
 
 func TestInviteCreate_MultipleCount(t *testing.T) {
@@ -235,7 +238,7 @@ func TestInviteCreate_MultipleCount(t *testing.T) {
 	h.SetInviteRepo(repo)
 	rec := doPost(h.InviteCreate, `{"count":5}`, adminUser)
 	assert.Equal(t, http.StatusOK, rec.Code)
-	var rows []model.RegistrationTicket
+	var rows []map[string]any
 	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &rows))
 	assert.Len(t, rows, 5)
 }
@@ -246,7 +249,7 @@ func TestInviteCreate_CountClampedToMax(t *testing.T) {
 	h.SetInviteRepo(repo)
 	rec := doPost(h.InviteCreate, `{"count":250}`, adminUser)
 	assert.Equal(t, http.StatusOK, rec.Code)
-	var rows []model.RegistrationTicket
+	var rows []map[string]any
 	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &rows))
 	assert.Len(t, rows, 100)
 }
@@ -262,16 +265,18 @@ func TestInviteList_FilterUnused(t *testing.T) {
 	h, _, _, _ := newTestHandler(t)
 	repo := testutil.NewMockRegistrationTicketRepository()
 	usedBy := "u1"
+	usedAt := time.Now()
 	require.NoError(t, repo.Create(&model.RegistrationTicket{ID: "t1", Code: "c1"}))
-	require.NoError(t, repo.Create(&model.RegistrationTicket{ID: "t2", Code: "c2", UsedByID: &usedBy}))
+	require.NoError(t, repo.Create(&model.RegistrationTicket{ID: "t2", Code: "c2", UsedByID: &usedBy, UsedAt: &usedAt}))
 	h.SetInviteRepo(repo)
 
 	rec := doPost(h.InviteList, `{"type":"unused"}`, adminUser)
 	assert.Equal(t, http.StatusOK, rec.Code)
-	var rows []model.RegistrationTicket
+	var rows []map[string]any
 	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &rows))
-	assert.Len(t, rows, 1)
-	assert.Equal(t, "t1", rows[0].ID)
+	require.Len(t, rows, 1)
+	assert.Equal(t, "t1", rows[0]["id"])
+	assert.Equal(t, false, rows[0]["used"])
 }
 
 // --- Promo ------------------------------------------------------------------

--- a/internal/api/admin/ad_invite_promo_test.go
+++ b/internal/api/admin/ad_invite_promo_test.go
@@ -1,0 +1,322 @@
+package admin_test
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/shiroha-a/mk/internal/model"
+	"github.com/shiroha-a/mk/internal/testutil"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// --- Ad ---------------------------------------------------------------------
+
+func TestAdCreate_Success(t *testing.T) {
+	h, _, _, _ := newTestHandler(t)
+	repo := testutil.NewMockAdRepository()
+	h.SetAdRepo(repo)
+	rec := doPost(h.AdCreate,
+		`{"url":"https://x","imageUrl":"https://y","place":"square","memo":"m","priority":"high","ratio":2,"dayOfWeek":3,"expiresAt":1760000000000,"startsAt":1759000000000,"isSensitive":true}`,
+		adminUser)
+	assert.Equal(t, http.StatusOK, rec.Code)
+	var got model.Ad
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &got))
+	assert.Equal(t, "https://x", got.URL)
+	assert.Equal(t, "square", got.Place)
+	assert.Equal(t, 2, got.Ratio)
+	assert.True(t, got.IsSensitive)
+	assert.Contains(t, repo.Ads, got.ID)
+}
+
+func TestAdCreate_MissingRequired(t *testing.T) {
+	h, _, _, _ := newTestHandler(t)
+	h.SetAdRepo(testutil.NewMockAdRepository())
+	assert.Equal(t, http.StatusBadRequest,
+		doPost(h.AdCreate, `{"url":""}`, adminUser).Code)
+}
+
+func TestAdCreate_Defaults(t *testing.T) {
+	h, _, _, _ := newTestHandler(t)
+	repo := testutil.NewMockAdRepository()
+	h.SetAdRepo(repo)
+	rec := doPost(h.AdCreate, `{"url":"https://x","imageUrl":"https://y"}`, adminUser)
+	assert.Equal(t, http.StatusOK, rec.Code)
+	var got model.Ad
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &got))
+	assert.Equal(t, "square", got.Place)
+	assert.Equal(t, "middle", got.Priority)
+	assert.Equal(t, 1, got.Ratio)
+}
+
+func TestAdCreate_RepoError(t *testing.T) {
+	h, _, _, _ := newTestHandler(t)
+	repo := testutil.NewMockAdRepository()
+	repo.CreateErr = assertError{}
+	h.SetAdRepo(repo)
+	rec := doPost(h.AdCreate, `{"url":"https://x","imageUrl":"https://y"}`, adminUser)
+	assert.Equal(t, http.StatusInternalServerError, rec.Code)
+}
+
+func TestAdList_Paginated(t *testing.T) {
+	h, _, _, _ := newTestHandler(t)
+	repo := testutil.NewMockAdRepository()
+	for i := 0; i < 5; i++ {
+		id := fmt.Sprintf("a%02d", i)
+		require.NoError(t, repo.Create(&model.Ad{
+			ID: id, URL: "u", ImageURL: "i", Place: "square", Priority: "middle", Ratio: 1,
+			StartsAt: time.Now().Add(-time.Hour), ExpiresAt: time.Now().Add(time.Hour),
+		}))
+	}
+	h.SetAdRepo(repo)
+
+	rec := doPost(h.AdList, `{"limit":3,"offset":0}`, adminUser)
+	assert.Equal(t, http.StatusOK, rec.Code)
+	var rows []model.Ad
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &rows))
+	assert.Len(t, rows, 3)
+	// id DESC
+	assert.Equal(t, "a04", rows[0].ID)
+}
+
+func TestAdUpdate_PartialFields(t *testing.T) {
+	h, _, _, _ := newTestHandler(t)
+	repo := testutil.NewMockAdRepository()
+	require.NoError(t, repo.Create(&model.Ad{
+		ID: "a1", URL: "old", Place: "square", Priority: "middle", Ratio: 1, ImageURL: "i",
+	}))
+	h.SetAdRepo(repo)
+
+	rec := doPost(h.AdUpdate,
+		`{"id":"a1","url":"new","priority":"high"}`, adminUser)
+	assert.Equal(t, http.StatusNoContent, rec.Code)
+	assert.Equal(t, "new", repo.Ads["a1"].URL)
+	assert.Equal(t, "high", repo.Ads["a1"].Priority)
+}
+
+func TestAdUpdate_NotFound(t *testing.T) {
+	h, _, _, _ := newTestHandler(t)
+	h.SetAdRepo(testutil.NewMockAdRepository())
+	assert.Equal(t, http.StatusNotFound,
+		doPost(h.AdUpdate, `{"id":"missing","url":"x"}`, adminUser).Code)
+}
+
+func TestAdUpdate_MissingID(t *testing.T) {
+	h, _, _, _ := newTestHandler(t)
+	h.SetAdRepo(testutil.NewMockAdRepository())
+	assert.Equal(t, http.StatusBadRequest,
+		doPost(h.AdUpdate, `{}`, adminUser).Code)
+}
+
+func TestAdDelete_WithRepo(t *testing.T) {
+	h, _, _, _ := newTestHandler(t)
+	repo := testutil.NewMockAdRepository()
+	require.NoError(t, repo.Create(&model.Ad{ID: "a1"}))
+	h.SetAdRepo(repo)
+
+	rec := doPost(h.AdDelete, `{"id":"a1"}`, adminUser)
+	assert.Equal(t, http.StatusNoContent, rec.Code)
+	assert.NotContains(t, repo.Ads, "a1")
+}
+
+// --- AvatarDecorations ------------------------------------------------------
+
+func TestAvatarDecorationsCreate_Success(t *testing.T) {
+	h, _, _, _ := newTestHandler(t)
+	repo := testutil.NewMockAvatarDecorationRepository()
+	h.SetAvatarDecorationRepo(repo)
+	rec := doPost(h.AvatarDecorationsCreate,
+		`{"name":"deco","description":"d","url":"https://i","roleIdsThatCanBeUsedThisDecoration":["r1","r2"]}`,
+		adminUser)
+	assert.Equal(t, http.StatusOK, rec.Code)
+	var got model.AvatarDecoration
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &got))
+	assert.Equal(t, "deco", got.Name)
+	assert.Equal(t, []string(got.RoleIDs), []string{"r1", "r2"})
+}
+
+func TestAvatarDecorationsCreate_MissingName(t *testing.T) {
+	h, _, _, _ := newTestHandler(t)
+	h.SetAvatarDecorationRepo(testutil.NewMockAvatarDecorationRepository())
+	assert.Equal(t, http.StatusBadRequest,
+		doPost(h.AvatarDecorationsCreate, `{"url":"https://i"}`, adminUser).Code)
+}
+
+func TestAvatarDecorationsList_WithRepo(t *testing.T) {
+	h, _, _, _ := newTestHandler(t)
+	repo := testutil.NewMockAvatarDecorationRepository()
+	require.NoError(t, repo.Create(&model.AvatarDecoration{ID: "d1", Name: "a"}))
+	require.NoError(t, repo.Create(&model.AvatarDecoration{ID: "d2", Name: "b"}))
+	h.SetAvatarDecorationRepo(repo)
+	rec := doPost(h.AvatarDecorationsList, `{}`, adminUser)
+	assert.Equal(t, http.StatusOK, rec.Code)
+	var rows []model.AvatarDecoration
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &rows))
+	assert.Len(t, rows, 2)
+}
+
+func TestAvatarDecorationsUpdate_Success(t *testing.T) {
+	h, _, _, _ := newTestHandler(t)
+	repo := testutil.NewMockAvatarDecorationRepository()
+	require.NoError(t, repo.Create(&model.AvatarDecoration{ID: "d1", Name: "old", URL: "u"}))
+	h.SetAvatarDecorationRepo(repo)
+	rec := doPost(h.AvatarDecorationsUpdate,
+		`{"id":"d1","name":"new","roleIdsThatCanBeUsedThisDecoration":["r"]}`, adminUser)
+	assert.Equal(t, http.StatusNoContent, rec.Code)
+	assert.Equal(t, "new", repo.Decorations["d1"].Name)
+	assert.Equal(t, []string(repo.Decorations["d1"].RoleIDs), []string{"r"})
+}
+
+func TestAvatarDecorationsUpdate_NotFound(t *testing.T) {
+	h, _, _, _ := newTestHandler(t)
+	h.SetAvatarDecorationRepo(testutil.NewMockAvatarDecorationRepository())
+	assert.Equal(t, http.StatusNotFound,
+		doPost(h.AvatarDecorationsUpdate, `{"id":"missing","name":"x"}`, adminUser).Code)
+}
+
+func TestAvatarDecorationsUpdate_MissingID(t *testing.T) {
+	h, _, _, _ := newTestHandler(t)
+	h.SetAvatarDecorationRepo(testutil.NewMockAvatarDecorationRepository())
+	assert.Equal(t, http.StatusBadRequest,
+		doPost(h.AvatarDecorationsUpdate, `{}`, adminUser).Code)
+}
+
+func TestAvatarDecorationsDelete_WithRepo(t *testing.T) {
+	h, _, _, _ := newTestHandler(t)
+	repo := testutil.NewMockAvatarDecorationRepository()
+	require.NoError(t, repo.Create(&model.AvatarDecoration{ID: "d1"}))
+	h.SetAvatarDecorationRepo(repo)
+	rec := doPost(h.AvatarDecorationsDelete, `{"id":"d1"}`, adminUser)
+	assert.Equal(t, http.StatusNoContent, rec.Code)
+	assert.NotContains(t, repo.Decorations, "d1")
+}
+
+// --- Invite -----------------------------------------------------------------
+
+func TestInviteCreate_Default(t *testing.T) {
+	h, _, _, _ := newTestHandler(t)
+	repo := testutil.NewMockRegistrationTicketRepository()
+	h.SetInviteRepo(repo)
+	rec := doPost(h.InviteCreate, `{}`, adminUser)
+	assert.Equal(t, http.StatusOK, rec.Code)
+	var rows []model.RegistrationTicket
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &rows))
+	assert.Len(t, rows, 1)
+	assert.NotEmpty(t, rows[0].Code)
+}
+
+func TestInviteCreate_MultipleCount(t *testing.T) {
+	h, _, _, _ := newTestHandler(t)
+	repo := testutil.NewMockRegistrationTicketRepository()
+	h.SetInviteRepo(repo)
+	rec := doPost(h.InviteCreate, `{"count":5}`, adminUser)
+	assert.Equal(t, http.StatusOK, rec.Code)
+	var rows []model.RegistrationTicket
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &rows))
+	assert.Len(t, rows, 5)
+}
+
+func TestInviteCreate_CountClampedToMax(t *testing.T) {
+	h, _, _, _ := newTestHandler(t)
+	repo := testutil.NewMockRegistrationTicketRepository()
+	h.SetInviteRepo(repo)
+	rec := doPost(h.InviteCreate, `{"count":250}`, adminUser)
+	assert.Equal(t, http.StatusOK, rec.Code)
+	var rows []model.RegistrationTicket
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &rows))
+	assert.Len(t, rows, 100)
+}
+
+func TestInviteCreate_InvalidExpiresAt(t *testing.T) {
+	h, _, _, _ := newTestHandler(t)
+	h.SetInviteRepo(testutil.NewMockRegistrationTicketRepository())
+	rec := doPost(h.InviteCreate, `{"expiresAt":"not-a-date"}`, adminUser)
+	assert.Equal(t, http.StatusBadRequest, rec.Code)
+}
+
+func TestInviteList_FilterUnused(t *testing.T) {
+	h, _, _, _ := newTestHandler(t)
+	repo := testutil.NewMockRegistrationTicketRepository()
+	usedBy := "u1"
+	require.NoError(t, repo.Create(&model.RegistrationTicket{ID: "t1", Code: "c1"}))
+	require.NoError(t, repo.Create(&model.RegistrationTicket{ID: "t2", Code: "c2", UsedByID: &usedBy}))
+	h.SetInviteRepo(repo)
+
+	rec := doPost(h.InviteList, `{"type":"unused"}`, adminUser)
+	assert.Equal(t, http.StatusOK, rec.Code)
+	var rows []model.RegistrationTicket
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &rows))
+	assert.Len(t, rows, 1)
+	assert.Equal(t, "t1", rows[0].ID)
+}
+
+// --- Promo ------------------------------------------------------------------
+
+// stubNoteFinder satisfies admin.NoteFinder with just FindByID.
+type stubNoteFinder struct {
+	note *model.Note
+	err  error
+}
+
+func (s *stubNoteFinder) FindByID(_ string) (*model.Note, error) { return s.note, s.err }
+
+type stubPromoRepo struct {
+	created  *model.PromoNote
+	exists   bool
+	existErr error
+}
+
+func (s *stubPromoRepo) Create(p *model.PromoNote) error {
+	s.created = p
+	return nil
+}
+func (s *stubPromoRepo) ListActive(_ time.Time) ([]*model.PromoNote, error) { return nil, nil }
+func (s *stubPromoRepo) Exists(_ string) (bool, error)                      { return s.exists, s.existErr }
+
+func TestPromoCreate_Success(t *testing.T) {
+	h, _, _, _ := newTestHandler(t)
+	promo := &stubPromoRepo{}
+	h.SetPromoNoteRepo(promo)
+	note := &model.Note{ID: "n1", UserID: "authorU"}
+	h.SetNoteFinder(&stubNoteFinder{note: note})
+
+	expires := time.Now().Add(24 * time.Hour).UnixMilli()
+	body := fmt.Sprintf(`{"noteId":"n1","expiresAt":%d}`, expires)
+	rec := doPost(h.PromoCreate, body, adminUser)
+	assert.Equal(t, http.StatusNoContent, rec.Code)
+	require.NotNil(t, promo.created)
+	assert.Equal(t, "n1", promo.created.NoteID)
+	assert.Equal(t, "authorU", promo.created.UserID)
+}
+
+func TestPromoCreate_MissingNoteID(t *testing.T) {
+	h, _, _, _ := newTestHandler(t)
+	h.SetPromoNoteRepo(&stubPromoRepo{})
+	h.SetNoteFinder(&stubNoteFinder{})
+	assert.Equal(t, http.StatusBadRequest,
+		doPost(h.PromoCreate, `{}`, adminUser).Code)
+}
+
+func TestPromoCreate_NoSuchNote(t *testing.T) {
+	h, _, _, _ := newTestHandler(t)
+	h.SetPromoNoteRepo(&stubPromoRepo{})
+	h.SetNoteFinder(&stubNoteFinder{err: assertError{}})
+	rec := doPost(h.PromoCreate, `{"noteId":"missing","expiresAt":1}`, adminUser)
+	assert.Equal(t, http.StatusBadRequest, rec.Code)
+}
+
+func TestPromoCreate_AlreadyPromoted(t *testing.T) {
+	h, _, _, _ := newTestHandler(t)
+	h.SetPromoNoteRepo(&stubPromoRepo{exists: true})
+	h.SetNoteFinder(&stubNoteFinder{note: &model.Note{ID: "n1", UserID: "u"}})
+	rec := doPost(h.PromoCreate, `{"noteId":"n1","expiresAt":1}`, adminUser)
+	assert.Equal(t, http.StatusBadRequest, rec.Code)
+	var body map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &body))
+	errField, ok := body["error"].(map[string]any)
+	require.True(t, ok)
+	assert.Equal(t, "ALREADY_PROMOTED", errField["code"])
+}

--- a/internal/api/admin/ad_invite_promo_test.go
+++ b/internal/api/admin/ad_invite_promo_test.go
@@ -111,6 +111,27 @@ func TestAdUpdate_MissingID(t *testing.T) {
 		doPost(h.AdUpdate, `{}`, adminUser).Code)
 }
 
+// Explicit expiresAt:0 in Update はクライアントが明示的に 1970-01-01 を指定した
+// ケースとして扱う (nil なら変更なし)。handler 側の millisOrNow 適用で now に
+// 読み替えてしまう regression を防ぐ。
+func TestAdUpdate_ExplicitZeroExpiresAtStays1970(t *testing.T) {
+	h, _, _, _ := newTestHandler(t)
+	repo := testutil.NewMockAdRepository()
+	require.NoError(t, repo.Create(&model.Ad{
+		ID: "a1", URL: "u", Place: "square", Priority: "middle", Ratio: 1, ImageURL: "i",
+		StartsAt:  time.Now(),
+		ExpiresAt: time.Now().Add(time.Hour),
+	}))
+	h.SetAdRepo(repo)
+
+	rec := doPost(h.AdUpdate, `{"id":"a1","expiresAt":0}`, adminUser)
+	assert.Equal(t, http.StatusNoContent, rec.Code)
+	// time.UnixMilli(0) は UTC 1970-01-01。time.Now() と大きく異なること。
+	got := repo.Ads["a1"].ExpiresAt
+	assert.Equal(t, int64(0), got.UnixMilli(),
+		"explicit expiresAt:0 should map to UNIX epoch, not time.Now()")
+}
+
 func TestAdDelete_WithRepo(t *testing.T) {
 	h, _, _, _ := newTestHandler(t)
 	repo := testutil.NewMockAdRepository()

--- a/internal/api/admin/handler.go
+++ b/internal/api/admin/handler.go
@@ -44,7 +44,19 @@ type Handler struct {
 	relayService      RelayService
 	systemWebhookRepo repository.SystemWebhookRepository
 	recipientRepo     repository.AbuseReportNotificationRecipientRepository
+	adRepo            repository.AdRepository
+	avatarDecoRepo    repository.AvatarDecorationRepository
+	inviteRepo        repository.RegistrationTicketRepository
+	promoNoteRepo     repository.PromoNoteRepository
+	noteFinder        NoteFinder
 	idGen             id.Generator
+}
+
+// NoteFinder is the minimal subset of repository.NoteRepository that admin
+// handlers need to validate a noteId. Kept narrow so tests can supply a tiny
+// fake without implementing the full NoteRepository surface.
+type NoteFinder interface {
+	FindByID(id string) (*model.Note, error)
 }
 
 // SetSystemWebhookRepo attaches a SystemWebhookRepository for admin/system-webhook/*.
@@ -57,6 +69,26 @@ func (h *Handler) SetSystemWebhookRepo(r repository.SystemWebhookRepository) {
 func (h *Handler) SetRecipientRepo(r repository.AbuseReportNotificationRecipientRepository) {
 	h.recipientRepo = r
 }
+
+// SetAdRepo attaches an AdRepository for admin/ad/*.
+func (h *Handler) SetAdRepo(r repository.AdRepository) { h.adRepo = r }
+
+// SetAvatarDecorationRepo attaches an AvatarDecorationRepository for
+// admin/avatar-decorations/*.
+func (h *Handler) SetAvatarDecorationRepo(r repository.AvatarDecorationRepository) {
+	h.avatarDecoRepo = r
+}
+
+// SetInviteRepo attaches a RegistrationTicketRepository for admin/invite/*.
+func (h *Handler) SetInviteRepo(r repository.RegistrationTicketRepository) {
+	h.inviteRepo = r
+}
+
+// SetPromoNoteRepo attaches a PromoNoteRepository for admin/promo/*.
+func (h *Handler) SetPromoNoteRepo(r repository.PromoNoteRepository) { h.promoNoteRepo = r }
+
+// SetNoteFinder attaches a NoteFinder used to validate noteId inputs.
+func (h *Handler) SetNoteFinder(r NoteFinder) { h.noteFinder = r }
 
 // SetRelayService wires the relay service used by admin/relays endpoints.
 // nil を渡せば Admin API が DB fallback (create/update/delete のみ) に戻る。

--- a/internal/api/admin/handler_stubs.go
+++ b/internal/api/admin/handler_stubs.go
@@ -14,7 +14,6 @@ import (
 	"github.com/shiroha-a/mk/internal/queue"
 	"github.com/shiroha-a/mk/internal/server/middleware"
 	"golang.org/x/crypto/bcrypt"
-	"gorm.io/gorm/clause"
 )
 
 // --- accounts ---
@@ -524,18 +523,24 @@ func (h *Handler) CaptchaSave(c echo.Context) error {
 
 // AdCreate handles POST /api/admin/ad/create.
 func (h *Handler) AdCreate(c echo.Context) error {
-	if h.adminDB == nil {
+	if h.adRepo == nil {
 		return c.NoContent(http.StatusNoContent)
 	}
 	var req struct {
-		URL      string `json:"url"`
-		ImageURL string `json:"imageUrl"`
-		Place    string `json:"place"`
-		Memo     string `json:"memo"`
-		Priority string `json:"priority"`
-		Ratio    int    `json:"ratio"`
+		URL         string `json:"url"`
+		ImageURL    string `json:"imageUrl"`
+		Place       string `json:"place"`
+		Memo        string `json:"memo"`
+		Priority    string `json:"priority"`
+		Ratio       int    `json:"ratio"`
+		DayOfWeek   int    `json:"dayOfWeek"`
+		ExpiresAt   int64  `json:"expiresAt"`
+		StartsAt    int64  `json:"startsAt"`
+		IsSensitive bool   `json:"isSensitive"`
 	}
-	_ = c.Bind(&req)
+	if err := c.Bind(&req); err != nil || req.URL == "" || req.ImageURL == "" {
+		return c.JSON(http.StatusBadRequest, apierr.Error("INVALID_PARAM", "Invalid parameters.", "00000000-0000-0000-0000-000000000000"))
+	}
 	if req.Place == "" {
 		req.Place = "square"
 	}
@@ -546,98 +551,235 @@ func (h *Handler) AdCreate(c echo.Context) error {
 		req.Ratio = 1
 	}
 	ad := &model.Ad{
-		ID: h.idGen.Generate(time.Now()), URL: req.URL, ImageURL: req.ImageURL,
-		Place: req.Place, Memo: req.Memo, Priority: req.Priority, Ratio: req.Ratio,
-		ExpiresAt: time.Now().Add(30 * 24 * time.Hour), StartsAt: time.Now(),
+		ID:          h.idGen.Generate(time.Now()),
+		URL:         req.URL,
+		ImageURL:    req.ImageURL,
+		Place:       req.Place,
+		Memo:        req.Memo,
+		Priority:    req.Priority,
+		Ratio:       req.Ratio,
+		DayOfWeek:   req.DayOfWeek,
+		IsSensitive: req.IsSensitive,
+		StartsAt:    millisOrNow(req.StartsAt),
+		ExpiresAt:   millisOrDefault(req.ExpiresAt, time.Now().Add(30*24*time.Hour)),
 	}
-	h.adminDB.Create(ad)
+	if err := h.adRepo.Create(ad); err != nil {
+		return c.JSON(http.StatusInternalServerError, apierr.Error("INTERNAL_ERROR", "Internal error.", "00000000-0000-0000-0000-000000000000"))
+	}
 	return c.JSON(http.StatusOK, ad)
 }
 
 // AdDelete handles POST /api/admin/ad/delete.
 func (h *Handler) AdDelete(c echo.Context) error {
-	if h.adminDB == nil {
+	if h.adRepo == nil {
 		return c.NoContent(http.StatusNoContent)
 	}
 	var req struct {
 		ID string `json:"id"`
 	}
 	_ = c.Bind(&req)
-	h.adminDB.Where(`"id" = ?`, req.ID).Delete(&model.Ad{})
+	_ = h.adRepo.Delete(req.ID)
 	return c.NoContent(http.StatusNoContent)
 }
 
 // AdList handles POST /api/admin/ad/list.
 func (h *Handler) AdList(c echo.Context) error {
-	if h.adminDB == nil {
+	if h.adRepo == nil {
 		return c.JSON(http.StatusOK, []any{})
 	}
-	var ads []*model.Ad
-	h.adminDB.Order(`"id" DESC`).Limit(20).Find(&ads)
-	return c.JSON(http.StatusOK, ads)
+	var req struct {
+		Limit  int `json:"limit"`
+		Offset int `json:"offset"`
+	}
+	_ = c.Bind(&req)
+	if req.Limit <= 0 || req.Limit > 100 {
+		req.Limit = 30
+	}
+	rows, err := h.adRepo.List(req.Limit, req.Offset)
+	if err != nil {
+		return c.JSON(http.StatusInternalServerError, apierr.Error("INTERNAL_ERROR", "Internal error.", "00000000-0000-0000-0000-000000000000"))
+	}
+	if rows == nil {
+		return c.JSON(http.StatusOK, []any{})
+	}
+	return c.JSON(http.StatusOK, rows)
 }
 
 // AdUpdate handles POST /api/admin/ad/update.
+//
+// 旧実装が `c.Request().Body` を `Updates` に直接渡しており部分更新が機能して
+// いなかった。partial field map に差し替え、リクエストで明示された項目のみ
+// 書き換える。
 func (h *Handler) AdUpdate(c echo.Context) error {
-	if h.adminDB == nil {
+	if h.adRepo == nil {
 		return c.NoContent(http.StatusNoContent)
 	}
 	var req struct {
-		ID string `json:"id"`
+		ID          string  `json:"id"`
+		URL         *string `json:"url"`
+		ImageURL    *string `json:"imageUrl"`
+		Place       *string `json:"place"`
+		Memo        *string `json:"memo"`
+		Priority    *string `json:"priority"`
+		Ratio       *int    `json:"ratio"`
+		DayOfWeek   *int    `json:"dayOfWeek"`
+		ExpiresAt   *int64  `json:"expiresAt"`
+		StartsAt    *int64  `json:"startsAt"`
+		IsSensitive *bool   `json:"isSensitive"`
 	}
-	_ = c.Bind(&req)
-	if req.ID != "" {
-		h.adminDB.Model(&model.Ad{}).Where(`"id" = ?`, req.ID).Updates(c.Request().Body)
+	if err := c.Bind(&req); err != nil || req.ID == "" {
+		return c.JSON(http.StatusBadRequest, apierr.Error("INVALID_PARAM", "Invalid parameters.", "00000000-0000-0000-0000-000000000000"))
+	}
+	if _, err := h.adRepo.FindByID(req.ID); err != nil {
+		return c.JSON(http.StatusNotFound, apierr.Error("NOT_FOUND", "Not found.", "00000000-0000-0000-0000-000000000000"))
+	}
+	fields := map[string]any{}
+	if req.URL != nil {
+		fields["url"] = *req.URL
+	}
+	if req.ImageURL != nil {
+		fields["imageUrl"] = *req.ImageURL
+	}
+	if req.Place != nil {
+		fields["place"] = *req.Place
+	}
+	if req.Memo != nil {
+		fields["memo"] = *req.Memo
+	}
+	if req.Priority != nil {
+		fields["priority"] = *req.Priority
+	}
+	if req.Ratio != nil {
+		fields["ratio"] = *req.Ratio
+	}
+	if req.DayOfWeek != nil {
+		fields["dayOfWeek"] = *req.DayOfWeek
+	}
+	if req.IsSensitive != nil {
+		fields["isSensitive"] = *req.IsSensitive
+	}
+	if req.StartsAt != nil {
+		fields["startsAt"] = millisOrNow(*req.StartsAt)
+	}
+	if req.ExpiresAt != nil {
+		fields["expiresAt"] = millisOrNow(*req.ExpiresAt)
+	}
+	if err := h.adRepo.UpdateFields(req.ID, fields); err != nil {
+		return c.JSON(http.StatusInternalServerError, apierr.Error("INTERNAL_ERROR", "Internal error.", "00000000-0000-0000-0000-000000000000"))
 	}
 	return c.NoContent(http.StatusNoContent)
+}
+
+// millisOrNow converts a UNIX millisecond timestamp to time.Time; 0 falls back
+// to the current wall clock.
+func millisOrNow(ms int64) time.Time {
+	if ms == 0 {
+		return time.Now()
+	}
+	return time.UnixMilli(ms)
+}
+
+// millisOrDefault converts a UNIX millisecond timestamp to time.Time; 0 falls
+// back to the provided default.
+func millisOrDefault(ms int64, def time.Time) time.Time {
+	if ms == 0 {
+		return def
+	}
+	return time.UnixMilli(ms)
 }
 
 // --- avatar-decorations ---
 
 // AvatarDecorationsCreate handles POST /api/admin/avatar-decorations/create.
 func (h *Handler) AvatarDecorationsCreate(c echo.Context) error {
-	if h.adminDB == nil {
+	if h.avatarDecoRepo == nil {
 		return c.NoContent(http.StatusNoContent)
 	}
 	var req struct {
-		Name        string `json:"name"`
-		Description string `json:"description"`
-		URL         string `json:"url"`
+		Name        string   `json:"name"`
+		Description string   `json:"description"`
+		URL         string   `json:"url"`
+		RoleIDs     []string `json:"roleIdsThatCanBeUsedThisDecoration"`
 	}
-	_ = c.Bind(&req)
+	if err := c.Bind(&req); err != nil || req.Name == "" || req.URL == "" {
+		return c.JSON(http.StatusBadRequest, apierr.Error("INVALID_PARAM", "Invalid parameters.", "00000000-0000-0000-0000-000000000000"))
+	}
 	d := &model.AvatarDecoration{
-		ID: h.idGen.Generate(time.Now()), Name: req.Name, Description: req.Description, URL: req.URL,
+		ID:          h.idGen.Generate(time.Now()),
+		Name:        req.Name,
+		Description: req.Description,
+		URL:         req.URL,
+		RoleIDs:     req.RoleIDs,
 	}
-	h.adminDB.Create(d)
+	if err := h.avatarDecoRepo.Create(d); err != nil {
+		return c.JSON(http.StatusInternalServerError, apierr.Error("INTERNAL_ERROR", "Internal error.", "00000000-0000-0000-0000-000000000000"))
+	}
 	return c.JSON(http.StatusOK, d)
 }
 
 // AvatarDecorationsDelete handles POST /api/admin/avatar-decorations/delete.
 func (h *Handler) AvatarDecorationsDelete(c echo.Context) error {
-	if h.adminDB == nil {
+	if h.avatarDecoRepo == nil {
 		return c.NoContent(http.StatusNoContent)
 	}
 	var req struct {
 		ID string `json:"id"`
 	}
 	_ = c.Bind(&req)
-	h.adminDB.Where(`"id" = ?`, req.ID).Delete(&model.AvatarDecoration{})
+	_ = h.avatarDecoRepo.Delete(req.ID)
 	return c.NoContent(http.StatusNoContent)
 }
 
 // AvatarDecorationsList handles POST /api/admin/avatar-decorations/list.
 func (h *Handler) AvatarDecorationsList(c echo.Context) error {
-	if h.adminDB == nil {
+	if h.avatarDecoRepo == nil {
 		return c.JSON(http.StatusOK, []any{})
 	}
-	var decorations []*model.AvatarDecoration
-	h.adminDB.Order(`"id" DESC`).Find(&decorations)
-	return c.JSON(http.StatusOK, decorations)
+	rows, err := h.avatarDecoRepo.List()
+	if err != nil {
+		return c.JSON(http.StatusInternalServerError, apierr.Error("INTERNAL_ERROR", "Internal error.", "00000000-0000-0000-0000-000000000000"))
+	}
+	if rows == nil {
+		return c.JSON(http.StatusOK, []any{})
+	}
+	return c.JSON(http.StatusOK, rows)
 }
 
 // AvatarDecorationsUpdate handles POST /api/admin/avatar-decorations/update.
 func (h *Handler) AvatarDecorationsUpdate(c echo.Context) error {
-	return c.NoContent(http.StatusNoContent) // 更新ロジックは将来対応
+	if h.avatarDecoRepo == nil {
+		return c.NoContent(http.StatusNoContent)
+	}
+	var req struct {
+		ID          string    `json:"id"`
+		Name        *string   `json:"name"`
+		Description *string   `json:"description"`
+		URL         *string   `json:"url"`
+		RoleIDs     *[]string `json:"roleIdsThatCanBeUsedThisDecoration"`
+	}
+	if err := c.Bind(&req); err != nil || req.ID == "" {
+		return c.JSON(http.StatusBadRequest, apierr.Error("INVALID_PARAM", "Invalid parameters.", "00000000-0000-0000-0000-000000000000"))
+	}
+	if _, err := h.avatarDecoRepo.FindByID(req.ID); err != nil {
+		return c.JSON(http.StatusNotFound, apierr.Error("NOT_FOUND", "Not found.", "00000000-0000-0000-0000-000000000000"))
+	}
+	fields := map[string]any{"updatedAt": time.Now()}
+	if req.Name != nil {
+		fields["name"] = *req.Name
+	}
+	if req.Description != nil {
+		fields["description"] = *req.Description
+	}
+	if req.URL != nil {
+		fields["url"] = *req.URL
+	}
+	if req.RoleIDs != nil {
+		fields["roleIdsThatCanBeUsedThisDecoration"] = *req.RoleIDs
+	}
+	if err := h.avatarDecoRepo.UpdateFields(req.ID, fields); err != nil {
+		return c.JSON(http.StatusInternalServerError, apierr.Error("INTERNAL_ERROR", "Internal error.", "00000000-0000-0000-0000-000000000000"))
+	}
+	return c.NoContent(http.StatusNoContent)
 }
 
 // --- abuse-report/notification-recipient ---
@@ -831,39 +973,89 @@ func (h *Handler) FederationUpdateInstance(c echo.Context) error {
 // --- invite ---
 
 // InviteCreate handles POST /api/admin/invite/create.
+// 本家 TS は count (1-100, default 1) 分のチケットを配列で返す。個々の Create
+// 失敗時でも既作成分はロールバックしない (本家も Promise.all で非原子的)。
 func (h *Handler) InviteCreate(c echo.Context) error {
-	if h.adminDB == nil {
+	if h.inviteRepo == nil {
 		return c.NoContent(http.StatusNoContent)
 	}
-	user := middleware.GetUser(c)
-	b := make([]byte, 16)
-	_, _ = rand.Read(b)
-	code := hex.EncodeToString(b)
-	ticket := &model.RegistrationTicket{
-		ID: h.idGen.Generate(time.Now()), Code: code, CreatedByID: &user.ID,
+	var req struct {
+		Count     int     `json:"count"`
+		ExpiresAt *string `json:"expiresAt"`
 	}
-	h.adminDB.Create(ticket)
-	return c.JSON(http.StatusOK, map[string]any{
-		"id": ticket.ID, "code": ticket.Code, "expiresAt": ticket.ExpiresAt,
-		"createdAt": time.Now().UTC().Format("2006-01-02T15:04:05.000Z"),
-	})
+	_ = c.Bind(&req)
+	if req.Count <= 0 {
+		req.Count = 1
+	}
+	if req.Count > 100 {
+		req.Count = 100
+	}
+	var expiresAt *time.Time
+	if req.ExpiresAt != nil && *req.ExpiresAt != "" {
+		parsed, err := time.Parse(time.RFC3339, *req.ExpiresAt)
+		if err != nil {
+			return c.JSON(http.StatusBadRequest, apierr.Error("INVALID_DATE_TIME", "Invalid date-time format", "f1380b15-3760-4c6c-a1db-5c3aaf1cbd49"))
+		}
+		expiresAt = &parsed
+	}
+	user := middleware.GetUser(c)
+	var createdByID *string
+	if user != nil {
+		createdByID = &user.ID
+	}
+	tickets := make([]*model.RegistrationTicket, 0, req.Count)
+	for i := 0; i < req.Count; i++ {
+		b := make([]byte, 16)
+		_, _ = rand.Read(b)
+		t := &model.RegistrationTicket{
+			ID:          h.idGen.Generate(time.Now()),
+			Code:        hex.EncodeToString(b),
+			ExpiresAt:   expiresAt,
+			CreatedByID: createdByID,
+		}
+		if err := h.inviteRepo.Create(t); err != nil {
+			continue
+		}
+		tickets = append(tickets, t)
+	}
+	return c.JSON(http.StatusOK, tickets)
 }
 
 // InviteList handles POST /api/admin/invite/list.
 func (h *Handler) InviteList(c echo.Context) error {
-	if h.adminDB == nil {
+	if h.inviteRepo == nil {
 		return c.JSON(http.StatusOK, []any{})
 	}
-	var tickets []*model.RegistrationTicket
-	h.adminDB.Order(`"id" DESC`).Limit(20).Find(&tickets)
-	return c.JSON(http.StatusOK, tickets)
+	var req struct {
+		Limit  int    `json:"limit"`
+		Offset int    `json:"offset"`
+		Type   string `json:"type"`
+	}
+	_ = c.Bind(&req)
+	if req.Limit <= 0 || req.Limit > 100 {
+		req.Limit = 30
+	}
+	filter := req.Type
+	switch filter {
+	case "unused", "used", "expired", "all":
+	default:
+		filter = "all"
+	}
+	rows, err := h.inviteRepo.List(filter, req.Limit, req.Offset, time.Now())
+	if err != nil {
+		return c.JSON(http.StatusInternalServerError, apierr.Error("INTERNAL_ERROR", "Internal error.", "00000000-0000-0000-0000-000000000000"))
+	}
+	if rows == nil {
+		return c.JSON(http.StatusOK, []any{})
+	}
+	return c.JSON(http.StatusOK, rows)
 }
 
 // --- promo ---
 
 // PromoCreate handles POST /api/admin/promo/create.
 func (h *Handler) PromoCreate(c echo.Context) error {
-	if h.adminDB == nil {
+	if h.promoNoteRepo == nil {
 		return c.NoContent(http.StatusNoContent)
 	}
 	var req struct {
@@ -873,17 +1065,40 @@ func (h *Handler) PromoCreate(c echo.Context) error {
 	if err := c.Bind(&req); err != nil || req.NoteID == "" {
 		return c.JSON(http.StatusBadRequest, apierr.Error("INVALID_PARAM", "noteId is required.", "3d81ceae-475f-4600-b2a8-2bc116157532"))
 	}
-	u := middleware.GetUser(c)
-	userID := ""
-	if u != nil {
-		userID = u.ID
+
+	// 対象 note の存在確認 → 既に promote 済みでないか確認
+	var targetUserID string
+	if h.noteFinder != nil {
+		note, err := h.noteFinder.FindByID(req.NoteID)
+		if err != nil {
+			return c.JSON(http.StatusBadRequest, apierr.Error("NO_SUCH_NOTE", "No such note.", "ee449fbe-af2a-453b-9cae-cf2fe7c895fc"))
+		}
+		targetUserID = note.UserID
 	}
+
+	exists, err := h.promoNoteRepo.Exists(req.NoteID)
+	if err != nil {
+		return c.JSON(http.StatusInternalServerError, apierr.Error("INTERNAL_ERROR", "Internal error.", "00000000-0000-0000-0000-000000000000"))
+	}
+	if exists {
+		return c.JSON(http.StatusBadRequest, apierr.Error("ALREADY_PROMOTED", "The note has already promoted.", "ae427aa2-7a41-484f-a18c-2c1104051604"))
+	}
+
+	// note 情報が取れなかった場合は呼び出し admin を userId として記録 (最低限の整合)
+	if targetUserID == "" {
+		if u := middleware.GetUser(c); u != nil {
+			targetUserID = u.ID
+		}
+	}
+
 	promo := &model.PromoNote{
 		NoteID:    req.NoteID,
-		ExpiresAt: time.Unix(req.ExpiresAt/1000, 0),
-		UserID:    userID,
+		ExpiresAt: time.UnixMilli(req.ExpiresAt),
+		UserID:    targetUserID,
 	}
-	h.adminDB.Clauses(clause.OnConflict{DoNothing: true}).Create(promo)
+	if err := h.promoNoteRepo.Create(promo); err != nil {
+		return c.JSON(http.StatusInternalServerError, apierr.Error("INTERNAL_ERROR", "Internal error.", "00000000-0000-0000-0000-000000000000"))
+	}
 	return c.NoContent(http.StatusNoContent)
 }
 

--- a/internal/api/admin/handler_stubs.go
+++ b/internal/api/admin/handler_stubs.go
@@ -606,11 +606,10 @@ func (h *Handler) AdList(c echo.Context) error {
 }
 
 // AdUpdate handles POST /api/admin/ad/update.
-//
-// 旧実装が `c.Request().Body` を `Updates` に直接渡しており部分更新が機能して
-// いなかった。partial field map に差し替え、リクエストで明示された項目のみ
-// 書き換える。
 func (h *Handler) AdUpdate(c echo.Context) error {
+	// 旧実装が `c.Request().Body` を `Updates` に直接渡しており部分更新が機能して
+	// いなかった。partial field map に差し替え、リクエストで明示された項目のみ
+	// 書き換える。
 	if h.adRepo == nil {
 		return c.NoContent(http.StatusNoContent)
 	}
@@ -976,9 +975,9 @@ func (h *Handler) FederationUpdateInstance(c echo.Context) error {
 // --- invite ---
 
 // InviteCreate handles POST /api/admin/invite/create.
-// 本家 TS は count (1-100, default 1) 分のチケットを配列で返す。個々の Create
-// 失敗時でも既作成分はロールバックしない (本家も Promise.all で非原子的)。
 func (h *Handler) InviteCreate(c echo.Context) error {
+	// 本家 TS は count (1-100, default 1) 分のチケットを配列で返す。個々の Create
+	// 失敗時でも既作成分はロールバックしない (本家も Promise.all で非原子的)。
 	if h.inviteRepo == nil {
 		return c.NoContent(http.StatusNoContent)
 	}
@@ -1024,9 +1023,11 @@ func (h *Handler) InviteCreate(c echo.Context) error {
 	return c.JSON(http.StatusOK, h.packInviteTickets(tickets))
 }
 
-// packInviteTickets マッピング。Misskey 本家 InviteCodeEntityService.pack と
-// 同じ形 (createdAt は aidx ID から抽出、used は usedAt 有無で導出)。
+// packInviteTickets transforms RegistrationTicket rows into the
+// Misskey-compatible InviteCodeEntityService.pack shape.
 func (h *Handler) packInviteTickets(rows []*model.RegistrationTicket) []map[string]any {
+	// Misskey 本家 InviteCodeEntityService.pack と同じ形にする。
+	// createdAt は aidx ID から抽出、used は usedAt の有無で導出する。
 	out := make([]map[string]any, 0, len(rows))
 	for _, t := range rows {
 		var createdAt *string

--- a/internal/api/admin/handler_stubs.go
+++ b/internal/api/admin/handler_stubs.go
@@ -1021,7 +1021,45 @@ func (h *Handler) InviteCreate(c echo.Context) error {
 		}
 		tickets = append(tickets, t)
 	}
-	return c.JSON(http.StatusOK, tickets)
+	return c.JSON(http.StatusOK, h.packInviteTickets(tickets))
+}
+
+// packInviteTickets マッピング。Misskey 本家 InviteCodeEntityService.pack と
+// 同じ形 (createdAt は aidx ID から抽出、used は usedAt 有無で導出)。
+func (h *Handler) packInviteTickets(rows []*model.RegistrationTicket) []map[string]any {
+	out := make([]map[string]any, 0, len(rows))
+	for _, t := range rows {
+		var createdAt *string
+		if h.idGen != nil {
+			if ts, err := h.idGen.ParseTime(t.ID); err == nil {
+				s := ts.UTC().Format("2006-01-02T15:04:05.000Z")
+				createdAt = &s
+			}
+		}
+		var expiresAt *string
+		if t.ExpiresAt != nil {
+			s := t.ExpiresAt.UTC().Format("2006-01-02T15:04:05.000Z")
+			expiresAt = &s
+		}
+		var usedAt *string
+		if t.UsedAt != nil {
+			s := t.UsedAt.UTC().Format("2006-01-02T15:04:05.000Z")
+			usedAt = &s
+		}
+		out = append(out, map[string]any{
+			"id":          t.ID,
+			"code":        t.Code,
+			"expiresAt":   expiresAt,
+			"createdAt":   createdAt,
+			"createdBy":   nil,
+			"usedBy":      nil,
+			"usedAt":      usedAt,
+			"used":        t.UsedAt != nil,
+			"createdById": t.CreatedByID,
+			"usedById":    t.UsedByID,
+		})
+	}
+	return out
 }
 
 // InviteList handles POST /api/admin/invite/list.
@@ -1048,10 +1086,7 @@ func (h *Handler) InviteList(c echo.Context) error {
 	if err != nil {
 		return c.JSON(http.StatusInternalServerError, apierr.Error("INTERNAL_ERROR", "Internal error.", "00000000-0000-0000-0000-000000000000"))
 	}
-	if rows == nil {
-		return c.JSON(http.StatusOK, []any{})
-	}
-	return c.JSON(http.StatusOK, rows)
+	return c.JSON(http.StatusOK, h.packInviteTickets(rows))
 }
 
 // --- promo ---

--- a/internal/api/admin/handler_stubs.go
+++ b/internal/api/admin/handler_stubs.go
@@ -658,11 +658,14 @@ func (h *Handler) AdUpdate(c echo.Context) error {
 	if req.IsSensitive != nil {
 		fields["isSensitive"] = *req.IsSensitive
 	}
+	// pointer 型フィールドは nil (未指定) と 0 (明示的に 0) を区別できるので、
+	// 受け取った値をそのまま UnixMilli に変換する。Create 側と違い 0 を now に
+	// 読み替えない。
 	if req.StartsAt != nil {
-		fields["startsAt"] = millisOrNow(*req.StartsAt)
+		fields["startsAt"] = time.UnixMilli(*req.StartsAt)
 	}
 	if req.ExpiresAt != nil {
-		fields["expiresAt"] = millisOrNow(*req.ExpiresAt)
+		fields["expiresAt"] = time.UnixMilli(*req.ExpiresAt)
 	}
 	if err := h.adRepo.UpdateFields(req.ID, fields); err != nil {
 		return c.JSON(http.StatusInternalServerError, apierr.Error("INTERNAL_ERROR", "Internal error.", "00000000-0000-0000-0000-000000000000"))

--- a/internal/api/meta/handler_test.go
+++ b/internal/api/meta/handler_test.go
@@ -264,6 +264,11 @@ type stubAdRepo struct {
 func (s *stubAdRepo) ListActive(_ time.Time) ([]*model.Ad, error) {
 	return s.ads, s.err
 }
+func (s *stubAdRepo) Create(_ *model.Ad) error                      { return nil }
+func (s *stubAdRepo) FindByID(_ string) (*model.Ad, error)          { return nil, nil }
+func (s *stubAdRepo) List(_, _ int) ([]*model.Ad, error)            { return nil, nil }
+func (s *stubAdRepo) UpdateFields(_ string, _ map[string]any) error { return nil }
+func (s *stubAdRepo) Delete(_ string) error                         { return nil }
 
 // /api/meta returns the active ads list from AdRepository and notesPerOneAd
 // from meta. Frontend reads these and handles injection.

--- a/internal/repository/ad.go
+++ b/internal/repository/ad.go
@@ -7,15 +7,19 @@ import (
 	"gorm.io/gorm"
 )
 
-// AdRepository provides read access to the `ad` table for meta / timeline
-// ad exposure. Writes currently live in admin/handler_stubs.go with direct
-// DB access; this interface is scoped to the read side that the public
-// /api/meta endpoint needs.
+// AdRepository provides data access for the `ad` table. ListActive is used by
+// /api/meta for timeline ad exposure; the rest supports the admin CRUD.
 type AdRepository interface {
 	// ListActive returns ads whose window contains `now` (startsAt <= now
-	// < expiresAt). Ordering is by id DESC so newest ads come first, which
-	// matches the admin list order.
+	// < expiresAt). Ordering is by id DESC so newest ads come first.
 	ListActive(now time.Time) ([]*model.Ad, error)
+	Create(a *model.Ad) error
+	FindByID(id string) (*model.Ad, error)
+	// List returns ads ordered by id DESC with limit/offset pagination.
+	List(limit, offset int) ([]*model.Ad, error)
+	// UpdateFields applies a partial update. Keys must be GORM column names.
+	UpdateFields(id string, fields map[string]any) error
+	Delete(id string) error
 }
 
 type adRepository struct {
@@ -36,4 +40,41 @@ func (r *adRepository) ListActive(now time.Time) ([]*model.Ad, error) {
 		return nil, err
 	}
 	return ads, nil
+}
+
+func (r *adRepository) Create(a *model.Ad) error {
+	return r.db.Create(a).Error
+}
+
+func (r *adRepository) FindByID(id string) (*model.Ad, error) {
+	var a model.Ad
+	if err := r.db.Where(`"id" = ?`, id).First(&a).Error; err != nil {
+		return nil, err
+	}
+	return &a, nil
+}
+
+func (r *adRepository) List(limit, offset int) ([]*model.Ad, error) {
+	if limit <= 0 {
+		limit = 30
+	}
+	if offset < 0 {
+		offset = 0
+	}
+	var ads []*model.Ad
+	if err := r.db.Order(`"id" DESC`).Limit(limit).Offset(offset).Find(&ads).Error; err != nil {
+		return nil, err
+	}
+	return ads, nil
+}
+
+func (r *adRepository) UpdateFields(id string, fields map[string]any) error {
+	if len(fields) == 0 {
+		return nil
+	}
+	return r.db.Model(&model.Ad{}).Where(`"id" = ?`, id).Updates(fields).Error
+}
+
+func (r *adRepository) Delete(id string) error {
+	return r.db.Where(`"id" = ?`, id).Delete(&model.Ad{}).Error
 }

--- a/internal/repository/ad_test.go
+++ b/internal/repository/ad_test.go
@@ -67,3 +67,54 @@ func TestAdRepository_ListActive(t *testing.T) {
 	assert.False(t, ids["ad_expired"], "expired ad should not be returned")
 	assert.False(t, ids["ad_future"], "future ad should not be returned")
 }
+
+func TestAdRepository_CRUD(t *testing.T) {
+	repo := NewAdRepository(testDB)
+	now := time.Now()
+
+	a := &model.Ad{
+		ID:        "ad_crud",
+		URL:       "https://example.com/x",
+		ImageURL:  "https://example.com/x.png",
+		Place:     "square",
+		Priority:  "middle",
+		Ratio:     1,
+		StartsAt:  now,
+		ExpiresAt: now.Add(time.Hour),
+	}
+	require.NoError(t, repo.Create(a))
+	defer cleanupAd(t, a.ID)
+
+	got, err := repo.FindByID(a.ID)
+	require.NoError(t, err)
+	assert.Equal(t, "square", got.Place)
+
+	_, err = repo.FindByID("ghost_ad")
+	assert.Error(t, err)
+
+	rows, err := repo.List(10, 0)
+	require.NoError(t, err)
+	assert.NotEmpty(t, rows)
+
+	require.NoError(t, repo.UpdateFields(a.ID, map[string]any{
+		"url":      "https://example.com/renamed",
+		"priority": "high",
+	}))
+	got, err = repo.FindByID(a.ID)
+	require.NoError(t, err)
+	assert.Equal(t, "https://example.com/renamed", got.URL)
+	assert.Equal(t, "high", got.Priority)
+
+	require.NoError(t, repo.UpdateFields(a.ID, map[string]any{}))
+
+	require.NoError(t, repo.Delete(a.ID))
+	_, err = repo.FindByID(a.ID)
+	assert.Error(t, err)
+}
+
+func TestAdRepository_ListDefaults(t *testing.T) {
+	repo := NewAdRepository(testDB)
+	// 負数 / 0 は default に丸められて成功するだけを確認する。
+	_, err := repo.List(0, -1)
+	require.NoError(t, err)
+}

--- a/internal/repository/avatar_decoration.go
+++ b/internal/repository/avatar_decoration.go
@@ -1,0 +1,57 @@
+package repository
+
+import (
+	"github.com/shiroha-a/mk/internal/model"
+	"gorm.io/gorm"
+)
+
+// AvatarDecorationRepository handles persistence for the `avatar_decoration`
+// table. Avatar decorations are instance-wide assets administrators can attach
+// to user profiles.
+type AvatarDecorationRepository interface {
+	Create(d *model.AvatarDecoration) error
+	FindByID(id string) (*model.AvatarDecoration, error)
+	List() ([]*model.AvatarDecoration, error)
+	UpdateFields(id string, fields map[string]any) error
+	Delete(id string) error
+}
+
+type avatarDecorationRepository struct {
+	db *gorm.DB
+}
+
+// NewAvatarDecorationRepository returns a GORM-backed AvatarDecorationRepository.
+func NewAvatarDecorationRepository(db *gorm.DB) AvatarDecorationRepository {
+	return &avatarDecorationRepository{db: db}
+}
+
+func (r *avatarDecorationRepository) Create(d *model.AvatarDecoration) error {
+	return r.db.Create(d).Error
+}
+
+func (r *avatarDecorationRepository) FindByID(id string) (*model.AvatarDecoration, error) {
+	var d model.AvatarDecoration
+	if err := r.db.Where(`"id" = ?`, id).First(&d).Error; err != nil {
+		return nil, err
+	}
+	return &d, nil
+}
+
+func (r *avatarDecorationRepository) List() ([]*model.AvatarDecoration, error) {
+	var rows []*model.AvatarDecoration
+	if err := r.db.Order(`"id" DESC`).Find(&rows).Error; err != nil {
+		return nil, err
+	}
+	return rows, nil
+}
+
+func (r *avatarDecorationRepository) UpdateFields(id string, fields map[string]any) error {
+	if len(fields) == 0 {
+		return nil
+	}
+	return r.db.Model(&model.AvatarDecoration{}).Where(`"id" = ?`, id).Updates(fields).Error
+}
+
+func (r *avatarDecorationRepository) Delete(id string) error {
+	return r.db.Where(`"id" = ?`, id).Delete(&model.AvatarDecoration{}).Error
+}

--- a/internal/repository/avatar_decoration_test.go
+++ b/internal/repository/avatar_decoration_test.go
@@ -1,0 +1,57 @@
+package repository
+
+import (
+	"testing"
+	"time"
+
+	"github.com/lib/pq"
+	"github.com/shiroha-a/mk/internal/model"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func cleanupAvatarDeco(t *testing.T, id string) {
+	t.Helper()
+	testDB.Exec(`DELETE FROM "avatar_decoration" WHERE id = ?`, id)
+}
+
+func TestAvatarDecorationRepository_CRUD(t *testing.T) {
+	repo := NewAvatarDecorationRepository(testDB)
+
+	d := &model.AvatarDecoration{
+		ID:      "ad_1",
+		Name:    "deco",
+		URL:     "https://example.com/d.png",
+		RoleIDs: pq.StringArray{"role1"},
+	}
+	require.NoError(t, repo.Create(d))
+	defer cleanupAvatarDeco(t, d.ID)
+
+	got, err := repo.FindByID(d.ID)
+	require.NoError(t, err)
+	assert.Equal(t, "deco", got.Name)
+
+	_, err = repo.FindByID("ghost")
+	assert.Error(t, err)
+
+	rows, err := repo.List()
+	require.NoError(t, err)
+	assert.GreaterOrEqual(t, len(rows), 1)
+
+	now := time.Now()
+	require.NoError(t, repo.UpdateFields(d.ID, map[string]any{
+		"name":      "renamed",
+		"updatedAt": now,
+	}))
+	got, err = repo.FindByID(d.ID)
+	require.NoError(t, err)
+	assert.Equal(t, "renamed", got.Name)
+	require.NotNil(t, got.UpdatedAt)
+
+	// empty fields は no-op
+	require.NoError(t, repo.UpdateFields(d.ID, map[string]any{}))
+
+	require.NoError(t, repo.Delete(d.ID))
+	_, err = repo.FindByID(d.ID)
+	assert.Error(t, err)
+}

--- a/internal/repository/promo.go
+++ b/internal/repository/promo.go
@@ -12,6 +12,9 @@ import (
 type PromoNoteRepository interface {
 	Create(p *model.PromoNote) error
 	ListActive(now time.Time) ([]*model.PromoNote, error)
+	// Exists reports whether a promo row exists for noteID. Used by
+	// admin/promo/create to return ALREADY_PROMOTED on duplicates.
+	Exists(noteID string) (bool, error)
 }
 
 type promoNoteRepository struct {
@@ -33,6 +36,14 @@ func (r *promoNoteRepository) ListActive(now time.Time) ([]*model.PromoNote, err
 		return nil, err
 	}
 	return promos, nil
+}
+
+func (r *promoNoteRepository) Exists(noteID string) (bool, error) {
+	var count int64
+	if err := r.db.Model(&model.PromoNote{}).Where(`"noteId" = ?`, noteID).Count(&count).Error; err != nil {
+		return false, err
+	}
+	return count > 0, nil
 }
 
 // PromoReadRepository provides data access for the `promo_read` table.

--- a/internal/repository/promo_test.go
+++ b/internal/repository/promo_test.go
@@ -75,3 +75,22 @@ func TestPromoReadRepository_MarkAndCheck(t *testing.T) {
 	// idempotent
 	require.NoError(t, readRepo.MarkRead(&model.PromoRead{ID: "pr2", UserID: u.ID, NoteID: n.ID}))
 }
+
+func TestPromoNoteRepository_Exists(t *testing.T) {
+	repo := NewPromoNoteRepository(testDB)
+	u := insertTestUser(t, "promo_e", "pe")
+	defer cleanupUser(t, u.ID)
+	n := insertTestNote(t, "promo_en", u.ID)
+	defer cleanupNote(t, n.ID)
+
+	exists, err := repo.Exists(n.ID)
+	require.NoError(t, err)
+	assert.False(t, exists)
+
+	require.NoError(t, repo.Create(&model.PromoNote{NoteID: n.ID, UserID: u.ID, ExpiresAt: time.Now().Add(time.Hour)}))
+	defer cleanupPromo(t, n.ID)
+
+	exists, err = repo.Exists(n.ID)
+	require.NoError(t, err)
+	assert.True(t, exists)
+}

--- a/internal/repository/registration_ticket.go
+++ b/internal/repository/registration_ticket.go
@@ -1,0 +1,71 @@
+package repository
+
+import (
+	"time"
+
+	"github.com/shiroha-a/mk/internal/model"
+	"gorm.io/gorm"
+)
+
+// Registration ticket filter values accepted by
+// RegistrationTicketRepository.List. Declared as plain string constants so
+// callers (admin handlers, testutil mocks) can pass literals without taking a
+// dependency on this package's type system — avoiding an import cycle with
+// testutil.
+const (
+	// RegistrationTicketAll returns every ticket.
+	RegistrationTicketAll = "all"
+	// RegistrationTicketUnused returns tickets that have not been redeemed.
+	RegistrationTicketUnused = "unused"
+	// RegistrationTicketUsed returns tickets that have been redeemed.
+	RegistrationTicketUsed = "used"
+	// RegistrationTicketExpired returns tickets past their expiresAt.
+	RegistrationTicketExpired = "expired"
+)
+
+// RegistrationTicketRepository handles persistence for the
+// `registration_ticket` table that backs admin invite code management.
+type RegistrationTicketRepository interface {
+	Create(t *model.RegistrationTicket) error
+	// List returns tickets matching the filter, paginated with limit/offset.
+	// Unknown filter values are treated as "all".
+	// `now` is passed by callers so tests can supply a deterministic clock
+	// when evaluating the `expired` filter.
+	List(filter string, limit, offset int, now time.Time) ([]*model.RegistrationTicket, error)
+}
+
+type registrationTicketRepository struct {
+	db *gorm.DB
+}
+
+// NewRegistrationTicketRepository returns a GORM-backed RegistrationTicketRepository.
+func NewRegistrationTicketRepository(db *gorm.DB) RegistrationTicketRepository {
+	return &registrationTicketRepository{db: db}
+}
+
+func (r *registrationTicketRepository) Create(t *model.RegistrationTicket) error {
+	return r.db.Create(t).Error
+}
+
+func (r *registrationTicketRepository) List(filter string, limit, offset int, now time.Time) ([]*model.RegistrationTicket, error) {
+	if limit <= 0 {
+		limit = 30
+	}
+	if offset < 0 {
+		offset = 0
+	}
+	q := r.db.Model(&model.RegistrationTicket{})
+	switch filter {
+	case RegistrationTicketUnused:
+		q = q.Where(`"usedById" IS NULL`)
+	case RegistrationTicketUsed:
+		q = q.Where(`"usedById" IS NOT NULL`)
+	case RegistrationTicketExpired:
+		q = q.Where(`"expiresAt" IS NOT NULL AND "expiresAt" < ?`, now)
+	}
+	var rows []*model.RegistrationTicket
+	if err := q.Order(`"id" DESC`).Limit(limit).Offset(offset).Find(&rows).Error; err != nil {
+		return nil, err
+	}
+	return rows, nil
+}

--- a/internal/repository/registration_ticket_test.go
+++ b/internal/repository/registration_ticket_test.go
@@ -1,0 +1,76 @@
+package repository
+
+import (
+	"testing"
+	"time"
+
+	"github.com/shiroha-a/mk/internal/model"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func cleanupInvite(t *testing.T, ids ...string) {
+	t.Helper()
+	for _, id := range ids {
+		testDB.Exec(`DELETE FROM "registration_ticket" WHERE id = ?`, id)
+	}
+}
+
+func TestRegistrationTicketRepository_CreateAndListAll(t *testing.T) {
+	repo := NewRegistrationTicketRepository(testDB)
+
+	// 前回の失敗テスト残骸を掃除してから始める。
+	cleanupInvite(t, "rt_unused", "rt_used", "rt_exp")
+
+	// usedBy は FK 制約 → user テーブルに実体が必要。テスト用の user を作る。
+	u := insertTestUser(t, "rt_user", "rtu")
+	defer cleanupUser(t, u.ID)
+
+	unused := &model.RegistrationTicket{ID: "rt_unused", Code: "uuu-unused"}
+	usedAt := time.Now().UTC().Truncate(time.Second)
+	used := &model.RegistrationTicket{ID: "rt_used", Code: "uuu-used", UsedByID: &u.ID, UsedAt: &usedAt}
+	past := time.Now().Add(-time.Hour).UTC().Truncate(time.Second)
+	expired := &model.RegistrationTicket{ID: "rt_exp", Code: "uuu-exp", ExpiresAt: &past}
+
+	require.NoError(t, repo.Create(unused))
+	require.NoError(t, repo.Create(used))
+	require.NoError(t, repo.Create(expired))
+	defer cleanupInvite(t, unused.ID, used.ID, expired.ID)
+
+	all, err := repo.List(RegistrationTicketAll, 100, 0, time.Now())
+	require.NoError(t, err)
+	ids := collectIDs(all)
+	assert.Contains(t, ids, "rt_unused")
+	assert.Contains(t, ids, "rt_used")
+	assert.Contains(t, ids, "rt_exp")
+
+	unusedRows, err := repo.List(RegistrationTicketUnused, 100, 0, time.Now())
+	require.NoError(t, err)
+	assert.Contains(t, collectIDs(unusedRows), "rt_unused")
+	assert.NotContains(t, collectIDs(unusedRows), "rt_used")
+
+	usedRows, err := repo.List(RegistrationTicketUsed, 100, 0, time.Now())
+	require.NoError(t, err)
+	assert.Contains(t, collectIDs(usedRows), "rt_used")
+	assert.NotContains(t, collectIDs(usedRows), "rt_unused")
+
+	expiredRows, err := repo.List(RegistrationTicketExpired, 100, 0, time.Now())
+	require.NoError(t, err)
+	assert.Contains(t, collectIDs(expiredRows), "rt_exp")
+	assert.NotContains(t, collectIDs(expiredRows), "rt_unused")
+}
+
+func TestRegistrationTicketRepository_LimitOffsetDefaults(t *testing.T) {
+	repo := NewRegistrationTicketRepository(testDB)
+	// 負数 / 0 は default に丸められる
+	_, err := repo.List(RegistrationTicketAll, 0, -1, time.Now())
+	require.NoError(t, err)
+}
+
+func collectIDs(rows []*model.RegistrationTicket) []string {
+	out := make([]string, len(rows))
+	for i, r := range rows {
+		out[i] = r.ID
+	}
+	return out
+}

--- a/internal/server/router.go
+++ b/internal/server/router.go
@@ -1271,6 +1271,11 @@ func (s *Server) setupRoutes() {
 	adminHandler.SetRelayService(relaySvc)
 	adminHandler.SetSystemWebhookRepo(systemWebhookRepo)
 	adminHandler.SetRecipientRepo(recipientRepo)
+	adminHandler.SetAdRepo(repository.NewAdRepository(s.db))
+	adminHandler.SetAvatarDecorationRepo(repository.NewAvatarDecorationRepository(s.db))
+	adminHandler.SetInviteRepo(repository.NewRegistrationTicketRepository(s.db))
+	adminHandler.SetPromoNoteRepo(repository.NewPromoNoteRepository(s.db))
+	adminHandler.SetNoteFinder(noteRepo)
 	if s.queueInspector != nil {
 		adminHandler.SetQueueInspector(&queueInspectorAdapter{inner: s.queueInspector})
 	}

--- a/internal/testutil/mock_repository.go
+++ b/internal/testutil/mock_repository.go
@@ -3640,3 +3640,285 @@ func (m *MockAbuseReportNotificationRecipientRepository) Delete(id string) error
 	delete(m.Recipients, id)
 	return nil
 }
+
+// MockAdRepository is a test double for repository.AdRepository.
+type MockAdRepository struct {
+	Ads       map[string]*model.Ad
+	CreateErr error
+	ListErr   error
+}
+
+// NewMockAdRepository creates an empty MockAdRepository.
+func NewMockAdRepository() *MockAdRepository {
+	return &MockAdRepository{Ads: make(map[string]*model.Ad)}
+}
+
+func (m *MockAdRepository) ListActive(now time.Time) ([]*model.Ad, error) {
+	if m.ListErr != nil {
+		return nil, m.ListErr
+	}
+	rows := make([]*model.Ad, 0)
+	for _, a := range m.Ads {
+		if !a.StartsAt.After(now) && a.ExpiresAt.After(now) {
+			rows = append(rows, a)
+		}
+	}
+	sortAdsByIDDesc(rows)
+	return rows, nil
+}
+
+func (m *MockAdRepository) Create(a *model.Ad) error {
+	if m.CreateErr != nil {
+		return m.CreateErr
+	}
+	m.Ads[a.ID] = a
+	return nil
+}
+
+func (m *MockAdRepository) FindByID(id string) (*model.Ad, error) {
+	a, ok := m.Ads[id]
+	if !ok {
+		return nil, ErrNotFound
+	}
+	return a, nil
+}
+
+func (m *MockAdRepository) List(limit, offset int) ([]*model.Ad, error) {
+	if m.ListErr != nil {
+		return nil, m.ListErr
+	}
+	rows := make([]*model.Ad, 0, len(m.Ads))
+	for _, a := range m.Ads {
+		rows = append(rows, a)
+	}
+	sortAdsByIDDesc(rows)
+	if limit <= 0 {
+		limit = 30
+	}
+	if offset < 0 {
+		offset = 0
+	}
+	if offset >= len(rows) {
+		return []*model.Ad{}, nil
+	}
+	end := offset + limit
+	if end > len(rows) {
+		end = len(rows)
+	}
+	return rows[offset:end], nil
+}
+
+func (m *MockAdRepository) UpdateFields(id string, fields map[string]any) error {
+	if len(fields) == 0 {
+		return nil
+	}
+	a, ok := m.Ads[id]
+	if !ok {
+		return nil // GORM Updates(map) は行欠損でも nil を返す
+	}
+	for k, v := range fields {
+		switch k {
+		case "url":
+			if s, ok := v.(string); ok {
+				a.URL = s
+			}
+		case "imageUrl":
+			if s, ok := v.(string); ok {
+				a.ImageURL = s
+			}
+		case "memo":
+			if s, ok := v.(string); ok {
+				a.Memo = s
+			}
+		case "place":
+			if s, ok := v.(string); ok {
+				a.Place = s
+			}
+		case "priority":
+			if s, ok := v.(string); ok {
+				a.Priority = s
+			}
+		case "ratio":
+			if n, ok := v.(int); ok {
+				a.Ratio = n
+			}
+		case "dayOfWeek":
+			if n, ok := v.(int); ok {
+				a.DayOfWeek = n
+			}
+		case "isSensitive":
+			if b, ok := v.(bool); ok {
+				a.IsSensitive = b
+			}
+		case "startsAt":
+			if ts, ok := v.(time.Time); ok {
+				a.StartsAt = ts
+			}
+		case "expiresAt":
+			if ts, ok := v.(time.Time); ok {
+				a.ExpiresAt = ts
+			}
+		}
+	}
+	return nil
+}
+
+func (m *MockAdRepository) Delete(id string) error {
+	delete(m.Ads, id)
+	return nil
+}
+
+func sortAdsByIDDesc(rows []*model.Ad) {
+	for i := 0; i < len(rows); i++ {
+		for j := i + 1; j < len(rows); j++ {
+			if rows[i].ID < rows[j].ID {
+				rows[i], rows[j] = rows[j], rows[i]
+			}
+		}
+	}
+}
+
+// MockAvatarDecorationRepository is a test double for
+// repository.AvatarDecorationRepository.
+type MockAvatarDecorationRepository struct {
+	Decorations map[string]*model.AvatarDecoration
+	CreateErr   error
+}
+
+// NewMockAvatarDecorationRepository creates an empty mock.
+func NewMockAvatarDecorationRepository() *MockAvatarDecorationRepository {
+	return &MockAvatarDecorationRepository{Decorations: make(map[string]*model.AvatarDecoration)}
+}
+
+func (m *MockAvatarDecorationRepository) Create(d *model.AvatarDecoration) error {
+	if m.CreateErr != nil {
+		return m.CreateErr
+	}
+	m.Decorations[d.ID] = d
+	return nil
+}
+
+func (m *MockAvatarDecorationRepository) FindByID(id string) (*model.AvatarDecoration, error) {
+	d, ok := m.Decorations[id]
+	if !ok {
+		return nil, ErrNotFound
+	}
+	return d, nil
+}
+
+func (m *MockAvatarDecorationRepository) List() ([]*model.AvatarDecoration, error) {
+	rows := make([]*model.AvatarDecoration, 0, len(m.Decorations))
+	for _, d := range m.Decorations {
+		rows = append(rows, d)
+	}
+	for i := 0; i < len(rows); i++ {
+		for j := i + 1; j < len(rows); j++ {
+			if rows[i].ID < rows[j].ID {
+				rows[i], rows[j] = rows[j], rows[i]
+			}
+		}
+	}
+	return rows, nil
+}
+
+func (m *MockAvatarDecorationRepository) UpdateFields(id string, fields map[string]any) error {
+	if len(fields) == 0 {
+		return nil
+	}
+	d, ok := m.Decorations[id]
+	if !ok {
+		return nil
+	}
+	for k, v := range fields {
+		switch k {
+		case "name":
+			if s, ok := v.(string); ok {
+				d.Name = s
+			}
+		case "description":
+			if s, ok := v.(string); ok {
+				d.Description = s
+			}
+		case "url":
+			if s, ok := v.(string); ok {
+				d.URL = s
+			}
+		case "roleIdsThatCanBeUsedThisDecoration":
+			if arr, ok := v.([]string); ok {
+				d.RoleIDs = arr
+			}
+		case "updatedAt":
+			if ts, ok := v.(time.Time); ok {
+				d.UpdatedAt = &ts
+			}
+		}
+	}
+	return nil
+}
+
+func (m *MockAvatarDecorationRepository) Delete(id string) error {
+	delete(m.Decorations, id)
+	return nil
+}
+
+// MockRegistrationTicketRepository is a test double for
+// repository.RegistrationTicketRepository.
+type MockRegistrationTicketRepository struct {
+	Tickets   map[string]*model.RegistrationTicket
+	CreateErr error
+}
+
+// NewMockRegistrationTicketRepository creates an empty mock.
+func NewMockRegistrationTicketRepository() *MockRegistrationTicketRepository {
+	return &MockRegistrationTicketRepository{Tickets: make(map[string]*model.RegistrationTicket)}
+}
+
+func (m *MockRegistrationTicketRepository) Create(t *model.RegistrationTicket) error {
+	if m.CreateErr != nil {
+		return m.CreateErr
+	}
+	m.Tickets[t.ID] = t
+	return nil
+}
+
+func (m *MockRegistrationTicketRepository) List(filter string, limit, offset int, now time.Time) ([]*model.RegistrationTicket, error) {
+	rows := make([]*model.RegistrationTicket, 0, len(m.Tickets))
+	for _, t := range m.Tickets {
+		switch filter {
+		case "unused":
+			if t.UsedByID != nil {
+				continue
+			}
+		case "used":
+			if t.UsedByID == nil {
+				continue
+			}
+		case "expired":
+			if t.ExpiresAt == nil || !t.ExpiresAt.Before(now) {
+				continue
+			}
+		}
+		rows = append(rows, t)
+	}
+	for i := 0; i < len(rows); i++ {
+		for j := i + 1; j < len(rows); j++ {
+			if rows[i].ID < rows[j].ID {
+				rows[i], rows[j] = rows[j], rows[i]
+			}
+		}
+	}
+	if limit <= 0 {
+		limit = 30
+	}
+	if offset < 0 {
+		offset = 0
+	}
+	if offset >= len(rows) {
+		return []*model.RegistrationTicket{}, nil
+	}
+	end := offset + limit
+	if end > len(rows) {
+		end = len(rows)
+	}
+	return rows[offset:end], nil
+}


### PR DESCRIPTION
## Summary

Issue #163 (P4-3) を本実装。admin 配下の 11 スタブハンドラを repo 経由の本実装に置換。

## 主な変更点

### 新規
- `internal/repository/avatar_decoration.go` — `AvatarDecorationRepository` (CRUD + partial Update)
- `internal/repository/registration_ticket.go` — `RegistrationTicketRepository` (Create + List with filter)
- `internal/api/admin/ad_invite_promo_test.go` — 18 ケース

### 修正 (本実装化)
- Ad: Create / Delete / List (limit,offset) / Update (partial map)
- AvatarDecorations: Create / Delete / List / Update (partial + roleIdsThatCanBeUsedThisDecoration)
- Invite: Create (count 1-100, expiresAt RFC3339, 配列返却) / List (limit/offset/type filter)
- Promo: Create (noteId 存在確認 + ALREADY_PROMOTED)

### 拡張
- `internal/repository/ad.go`: Create/FindByID/List/UpdateFields/Delete 追加
- `internal/repository/promo.go`: Exists 追加
- `internal/testutil/mock_repository.go`: Mock × 3 (Ad / AvatarDecoration / RegistrationTicket)
- `internal/api/admin/handler.go`: 4 repo フィールド + Setter + `NoteFinder` narrow interface
- `internal/server/router.go`: admin Handler に 5 repo 注入
- `internal/api/meta/handler_test.go`: stubAdRepo を拡張した interface に適応

### 設計判断
- **AdUpdate の bug 修正**: 旧実装が `c.Request().Body` を `Updates` に直接渡しており partial 更新が実質機能していなかった。明示された項目のみ map で更新するよう修正。
- **NoteFinder narrow interface**: admin Handler は noteId 存在確認だけ必要なので、`repository.NoteRepository` 全体を import せず FindByID だけの小さい interface にした。テストもシンプルに。

## テスト

### 実行方法
\`\`\`
go test ./internal/api/admin/...                                   # handler
go test ./internal/repository/ -run 'Ad|Promo|AvatarDecoration|RegistrationTicket'
\`\`\`

### 追加ケース (抜粋)
- Ad: Create 成功 / 必須欠落 / default 補完 / repo エラー / List paginated / Update partial / NotFound / Delete
- AvatarDecorations: Create 成功 / name 欠落 / List / Update 成功 / NotFound / Delete
- Invite: count default 1 / count 5 / count 250 は 100 にクランプ / 無効 expiresAt / filter=unused
- Promo: 成功 / noteId 欠落 / note 不在 / ALREADY_PROMOTED

### カバレッジ
- `internal/api/admin`: 75.8% (CI 閾値 60% クリア)
- 新規 repo: testcontainers で CRUD 全経路

## Closes

Closes #163

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/shiroha-a/mk/pull/180" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
