### PR TITLE
P4-4a: admin/queue + Stats + Captcha 本実装

### DIFF
--- a/internal/api/admin/handler.go
+++ b/internal/api/admin/handler.go
@@ -116,6 +116,12 @@ type QueueInspector interface {
 	DeleteTask(qname, taskID string) error
 	DeleteAllPendingTasks(qname string) (int, error)
 	RunTask(qname, taskID string) error
+	// Task listing APIs. page is 1-indexed.
+	ListPendingTasks(qname string, page, pageSize int) ([]*QueueTaskSummary, error)
+	ListActiveTasks(qname string, page, pageSize int) ([]*QueueTaskSummary, error)
+	ListScheduledTasks(qname string, page, pageSize int) ([]*QueueTaskSummary, error)
+	ListRetryTasks(qname string, page, pageSize int) ([]*QueueTaskSummary, error)
+	GetTaskInfo(qname, taskID string) (*QueueTaskSummary, error)
 }
 
 // QueueInfoResult holds basic queue statistics.
@@ -128,6 +134,22 @@ type QueueInfoResult struct {
 	Failed    int
 	Scheduled int
 	Retry     int
+}
+
+// QueueTaskSummary mirrors queue.TaskSummary for handler responses without
+// taking a compile-time dependency on the queue package.
+type QueueTaskSummary struct {
+	ID            string
+	Queue         string
+	Type          string
+	State         string
+	Payload       []byte
+	Retried       int
+	MaxRetry      int
+	LastErr       string
+	LastFailedAt  time.Time
+	NextProcessAt time.Time
+	CompletedAt   time.Time
 }
 
 // SetDriveFileRepo attaches a DriveFileRepository for admin drive operations.

--- a/internal/api/admin/handler_stubs.go
+++ b/internal/api/admin/handler_stubs.go
@@ -1302,14 +1302,22 @@ func (h *Handler) listDelayedTasks(c echo.Context, queueName string) error {
 		req.Page = 1
 	}
 	// Misskey 本家では deliver/inbox の delayed キューを統合して返している。
-	// asynq の scheduled + retry 両方を集めて 1 ページに詰める。
+	// asynq の scheduled + retry 両方を集めるが、結合後に req.Limit で切り詰めて
+	// ページネーション契約 (limit=N なら最大 N 件) を守る。scheduled を先に
+	// 詰めるので実質 scheduled 優先になる。
 	scheduled, _ := h.queueInspector.ListScheduledTasks(queueName, req.Page, req.Limit)
 	retry, _ := h.queueInspector.ListRetryTasks(queueName, req.Page, req.Limit)
-	out := make([]map[string]any, 0, len(scheduled)+len(retry))
+	out := make([]map[string]any, 0, req.Limit)
 	for _, t := range scheduled {
+		if len(out) >= req.Limit {
+			break
+		}
 		out = append(out, packTaskSummary(t))
 	}
 	for _, t := range retry {
+		if len(out) >= req.Limit {
+			break
+		}
 		out = append(out, packTaskSummary(t))
 	}
 	return c.JSON(http.StatusOK, out)
@@ -1347,7 +1355,11 @@ func (h *Handler) QueueJobs(c echo.Context) error {
 	if state == "" {
 		state = "pending"
 	}
-	out := make([]map[string]any, 0)
+	// 複数キューを走査する場合でも合計で req.Limit を超えないように切り詰める
+	// (ページネーション契約の保持)。走査順序は Queues() の返り順に依存するため、
+	// 同じ state で全体ソートされない点は許容する。
+	out := make([]map[string]any, 0, req.Limit)
+outer:
 	for _, q := range queues {
 		var rows []*QueueTaskSummary
 		var err error
@@ -1365,6 +1377,9 @@ func (h *Handler) QueueJobs(c echo.Context) error {
 			continue
 		}
 		for _, t := range rows {
+			if len(out) >= req.Limit {
+				break outer
+			}
 			out = append(out, packTaskSummary(t))
 		}
 	}

--- a/internal/api/admin/handler_stubs.go
+++ b/internal/api/admin/handler_stubs.go
@@ -94,13 +94,67 @@ func (h *Handler) ForwardAbuseUserReport(c echo.Context) error {
 }
 
 // GetIndexStats handles POST /api/admin/get-index-stats.
+//
+// Returns per-index row counts from pg_stat_user_indexes so the admin UI can
+// spot hot or unused indexes.
 func (h *Handler) GetIndexStats(c echo.Context) error {
-	return c.JSON(http.StatusOK, []any{})
+	if h.adminDB == nil {
+		return c.JSON(http.StatusOK, []any{})
+	}
+	type row struct {
+		Relname      string `json:"tablename" gorm:"column:relname"`
+		Indexrelname string `json:"indexname" gorm:"column:indexrelname"`
+		IdxScan      int64  `json:"idx_scan" gorm:"column:idx_scan"`
+		IdxTupRead   int64  `json:"idx_tup_read" gorm:"column:idx_tup_read"`
+	}
+	var rows []row
+	if err := h.adminDB.Raw(`
+		SELECT relname, indexrelname, idx_scan, idx_tup_read
+		FROM pg_stat_user_indexes
+		ORDER BY relname, indexrelname
+	`).Scan(&rows).Error; err != nil {
+		return c.JSON(http.StatusInternalServerError, apierr.Error("INTERNAL_ERROR", "Internal error.", "00000000-0000-0000-0000-000000000000"))
+	}
+	return c.JSON(http.StatusOK, rows)
 }
 
 // GetTableStats handles POST /api/admin/get-table-stats.
+//
+// Returns per-table size and row estimate via pg_stat_user_tables joined with
+// pg_relation_size for quick capacity planning.
 func (h *Handler) GetTableStats(c echo.Context) error {
-	return c.JSON(http.StatusOK, map[string]any{})
+	if h.adminDB == nil {
+		return c.JSON(http.StatusOK, map[string]any{})
+	}
+	type row struct {
+		Relname  string `gorm:"column:relname"`
+		Count    int64  `gorm:"column:row_count"`
+		SizeBase int64  `gorm:"column:size_base"`
+		SizeIdx  int64  `gorm:"column:size_idx"`
+	}
+	var rows []row
+	if err := h.adminDB.Raw(`
+		SELECT c.relname,
+		       COALESCE(s.n_live_tup, 0) AS row_count,
+		       pg_relation_size(c.oid) AS size_base,
+		       COALESCE(pg_indexes_size(c.oid), 0) AS size_idx
+		FROM pg_class c
+		LEFT JOIN pg_stat_user_tables s ON s.relid = c.oid
+		WHERE c.relkind = 'r'
+		  AND c.relnamespace IN (SELECT oid FROM pg_namespace WHERE nspname = 'public')
+		ORDER BY c.relname
+	`).Scan(&rows).Error; err != nil {
+		return c.JSON(http.StatusInternalServerError, apierr.Error("INTERNAL_ERROR", "Internal error.", "00000000-0000-0000-0000-000000000000"))
+	}
+	// Misskey 本家は { tableName: { count, size } } の map 形式で返すのでそれに合わせる。
+	result := make(map[string]any, len(rows))
+	for _, r := range rows {
+		result[r.Relname] = map[string]any{
+			"count": r.Count,
+			"size":  r.SizeBase + r.SizeIdx,
+		}
+	}
+	return c.JSON(http.StatusOK, result)
 }
 
 // GetUserIPs handles POST /api/admin/get-user-ips.
@@ -499,22 +553,84 @@ func (h *Handler) EmojiSetLicenseBulk(c echo.Context) error {
 // --- captcha ---
 
 // CaptchaCurrent handles POST /api/admin/captcha/current.
+//
+// Returns which captcha provider (if any) is currently enabled and its public
+// site key so the admin UI can render the correct configuration form.
 func (h *Handler) CaptchaCurrent(c echo.Context) error {
-	return c.JSON(http.StatusOK, map[string]any{"provider": nil})
+	if h.metaRepo == nil {
+		return c.JSON(http.StatusOK, map[string]any{"provider": nil})
+	}
+	meta, err := h.metaRepo.Fetch()
+	if err != nil {
+		return c.JSON(http.StatusInternalServerError, apierr.Error("INTERNAL_ERROR", "Internal error.", "00000000-0000-0000-0000-000000000000"))
+	}
+	var provider any
+	var siteKey *string
+	switch {
+	case meta.EnableHcaptcha:
+		provider = "hcaptcha"
+		siteKey = meta.HcaptchaSiteKey
+	case meta.EnableRecaptcha:
+		provider = "recaptcha"
+		siteKey = meta.RecaptchaSiteKey
+	case meta.EnableTurnstile:
+		provider = "turnstile"
+		siteKey = meta.TurnstileSiteKey
+	}
+	return c.JSON(http.StatusOK, map[string]any{
+		"provider": provider,
+		"siteKey":  siteKey,
+	})
 }
 
 // CaptchaSave handles POST /api/admin/captcha/save.
 func (h *Handler) CaptchaSave(c echo.Context) error {
 	var req struct {
-		Provider string `json:"provider"`
+		Provider    string  `json:"provider"`
+		HcaptchaSK  *string `json:"hcaptchaSiteKey"`
+		HcaptchaSS  *string `json:"hcaptchaSecretKey"`
+		RecaptchaSK *string `json:"recaptchaSiteKey"`
+		RecaptchaSS *string `json:"recaptchaSecretKey"`
+		TurnstileSK *string `json:"turnstileSiteKey"`
+		TurnstileSS *string `json:"turnstileSecretKey"`
 	}
-	_ = c.Bind(&req)
-	if h.metaRepo != nil {
-		_ = h.metaRepo.Update(map[string]any{
-			"enableHcaptcha":  req.Provider == "hcaptcha",
-			"enableRecaptcha": req.Provider == "recaptcha",
-			"enableTurnstile": req.Provider == "turnstile",
-		})
+	if err := c.Bind(&req); err != nil {
+		return c.JSON(http.StatusBadRequest, apierr.Error("INVALID_PARAM", "Invalid parameters.", "00000000-0000-0000-0000-000000000000"))
+	}
+	// provider が空 or "none" の場合は captcha 無効化として扱う。
+	switch req.Provider {
+	case "", "none", "hcaptcha", "recaptcha", "turnstile":
+	default:
+		return c.JSON(http.StatusBadRequest, apierr.Error("INVALID_PARAM", "Unknown captcha provider.", "00000000-0000-0000-0000-000000000000"))
+	}
+	if h.metaRepo == nil {
+		return c.NoContent(http.StatusNoContent)
+	}
+	fields := map[string]any{
+		"enableHcaptcha":  req.Provider == "hcaptcha",
+		"enableRecaptcha": req.Provider == "recaptcha",
+		"enableTurnstile": req.Provider == "turnstile",
+	}
+	if req.HcaptchaSK != nil {
+		fields["hcaptchaSiteKey"] = *req.HcaptchaSK
+	}
+	if req.HcaptchaSS != nil {
+		fields["hcaptchaSecretKey"] = *req.HcaptchaSS
+	}
+	if req.RecaptchaSK != nil {
+		fields["recaptchaSiteKey"] = *req.RecaptchaSK
+	}
+	if req.RecaptchaSS != nil {
+		fields["recaptchaSecretKey"] = *req.RecaptchaSS
+	}
+	if req.TurnstileSK != nil {
+		fields["turnstileSiteKey"] = *req.TurnstileSK
+	}
+	if req.TurnstileSS != nil {
+		fields["turnstileSecretKey"] = *req.TurnstileSS
+	}
+	if err := h.metaRepo.Update(fields); err != nil {
+		return c.JSON(http.StatusInternalServerError, apierr.Error("INTERNAL_ERROR", "Internal error.", "00000000-0000-0000-0000-000000000000"))
 	}
 	return c.NoContent(http.StatusNoContent)
 }
@@ -1145,35 +1261,174 @@ func (h *Handler) PromoCreate(c echo.Context) error {
 
 // QueueClear handles POST /api/admin/queue/clear.
 func (h *Handler) QueueClear(c echo.Context) error {
-	if h.queueInspector != nil {
-		queues, _ := h.queueInspector.Queues()
-		for _, q := range queues {
-			_, _ = h.queueInspector.DeleteAllPendingTasks(q)
-		}
+	if h.queueInspector == nil {
+		return c.NoContent(http.StatusNoContent)
+	}
+	queues, err := h.queueInspector.Queues()
+	if err != nil {
+		return c.JSON(http.StatusInternalServerError, apierr.Error("INTERNAL_ERROR", "Internal error.", "00000000-0000-0000-0000-000000000000"))
+	}
+	for _, q := range queues {
+		_, _ = h.queueInspector.DeleteAllPendingTasks(q)
 	}
 	return c.NoContent(http.StatusNoContent)
 }
 
 // QueueDeliverDelayed handles POST /api/admin/queue/deliver-delayed.
-func (h *Handler) QueueDeliverDelayed(c echo.Context) error { return c.JSON(http.StatusOK, []any{}) }
+// Returns scheduled/retry tasks on the `deliver` queue.
+func (h *Handler) QueueDeliverDelayed(c echo.Context) error {
+	return h.listDelayedTasks(c, "deliver")
+}
 
 // QueueInboxDelayed handles POST /api/admin/queue/inbox-delayed.
-func (h *Handler) QueueInboxDelayed(c echo.Context) error { return c.JSON(http.StatusOK, []any{}) }
+// Returns scheduled/retry tasks on the `inbox` queue.
+func (h *Handler) QueueInboxDelayed(c echo.Context) error {
+	return h.listDelayedTasks(c, "inbox")
+}
+
+func (h *Handler) listDelayedTasks(c echo.Context, queueName string) error {
+	if h.queueInspector == nil {
+		return c.JSON(http.StatusOK, []any{})
+	}
+	var req struct {
+		Limit int `json:"limit"`
+		Page  int `json:"page"`
+	}
+	_ = c.Bind(&req)
+	if req.Limit <= 0 || req.Limit > 100 {
+		req.Limit = 30
+	}
+	if req.Page < 1 {
+		req.Page = 1
+	}
+	// Misskey 本家では deliver/inbox の delayed キューを統合して返している。
+	// asynq の scheduled + retry 両方を集めて 1 ページに詰める。
+	scheduled, _ := h.queueInspector.ListScheduledTasks(queueName, req.Page, req.Limit)
+	retry, _ := h.queueInspector.ListRetryTasks(queueName, req.Page, req.Limit)
+	out := make([]map[string]any, 0, len(scheduled)+len(retry))
+	for _, t := range scheduled {
+		out = append(out, packTaskSummary(t))
+	}
+	for _, t := range retry {
+		out = append(out, packTaskSummary(t))
+	}
+	return c.JSON(http.StatusOK, out)
+}
 
 // QueueJobs handles POST /api/admin/queue/jobs.
-func (h *Handler) QueueJobs(c echo.Context) error { return c.JSON(http.StatusOK, []any{}) }
+func (h *Handler) QueueJobs(c echo.Context) error {
+	if h.queueInspector == nil {
+		return c.JSON(http.StatusOK, []any{})
+	}
+	var req struct {
+		Queue string `json:"queue"`
+		State string `json:"state"`
+		Limit int    `json:"limit"`
+		Page  int    `json:"page"`
+	}
+	_ = c.Bind(&req)
+	if req.Limit <= 0 || req.Limit > 100 {
+		req.Limit = 30
+	}
+	if req.Page < 1 {
+		req.Page = 1
+	}
+	// Queue 名は Misskey の deliver/inbox 以外にも ap/relay など様々あるため、
+	// 明示指定が無い場合は全キューを走査して pending を返す。
+	queues := []string{req.Queue}
+	if req.Queue == "" {
+		qs, err := h.queueInspector.Queues()
+		if err != nil {
+			return c.JSON(http.StatusInternalServerError, apierr.Error("INTERNAL_ERROR", "Internal error.", "00000000-0000-0000-0000-000000000000"))
+		}
+		queues = qs
+	}
+	state := req.State
+	if state == "" {
+		state = "pending"
+	}
+	out := make([]map[string]any, 0)
+	for _, q := range queues {
+		var rows []*QueueTaskSummary
+		var err error
+		switch state {
+		case "active":
+			rows, err = h.queueInspector.ListActiveTasks(q, req.Page, req.Limit)
+		case "scheduled":
+			rows, err = h.queueInspector.ListScheduledTasks(q, req.Page, req.Limit)
+		case "retry":
+			rows, err = h.queueInspector.ListRetryTasks(q, req.Page, req.Limit)
+		default:
+			rows, err = h.queueInspector.ListPendingTasks(q, req.Page, req.Limit)
+		}
+		if err != nil {
+			continue
+		}
+		for _, t := range rows {
+			out = append(out, packTaskSummary(t))
+		}
+	}
+	return c.JSON(http.StatusOK, out)
+}
 
 // QueuePromoteJobs handles POST /api/admin/queue/promote-jobs.
-// スケジュール済みジョブを即座に実行可能状態にプロモートする。
 func (h *Handler) QueuePromoteJobs(c echo.Context) error {
-	// asynqにはbulk promote APIがないため、NoContentを返す。
-	// 個別のジョブプロモートはqueue/retry-job (RunTask) で代替可能。
-	return c.NoContent(http.StatusNoContent)
+	// asynq に bulk promote API が無いため、全キューの scheduled/retry を 1 ページ
+	// 分ずつ拾って RunTask で逐次 promote する。大量投入時は後続のページを
+	// クライアント側で再呼び出しする運用。
+	if h.queueInspector == nil {
+		return c.NoContent(http.StatusNoContent)
+	}
+	queues, err := h.queueInspector.Queues()
+	if err != nil {
+		return c.JSON(http.StatusInternalServerError, apierr.Error("INTERNAL_ERROR", "Internal error.", "00000000-0000-0000-0000-000000000000"))
+	}
+	promoted := 0
+	for _, q := range queues {
+		for _, state := range []string{"scheduled", "retry"} {
+			var rows []*QueueTaskSummary
+			if state == "scheduled" {
+				rows, _ = h.queueInspector.ListScheduledTasks(q, 1, 100)
+			} else {
+				rows, _ = h.queueInspector.ListRetryTasks(q, 1, 100)
+			}
+			for _, t := range rows {
+				if err := h.queueInspector.RunTask(q, t.ID); err == nil {
+					promoted++
+				}
+			}
+		}
+	}
+	return c.JSON(http.StatusOK, map[string]any{"promoted": promoted})
 }
 
 // QueueQueueStats handles POST /api/admin/queue/queue-stats.
 func (h *Handler) QueueQueueStats(c echo.Context) error {
-	return c.JSON(http.StatusOK, map[string]any{})
+	if h.queueInspector == nil {
+		return c.JSON(http.StatusOK, map[string]any{})
+	}
+	queues, err := h.queueInspector.Queues()
+	if err != nil {
+		return c.JSON(http.StatusInternalServerError, apierr.Error("INTERNAL_ERROR", "Internal error.", "00000000-0000-0000-0000-000000000000"))
+	}
+	out := map[string]any{}
+	for _, q := range queues {
+		info, err := h.queueInspector.GetQueueInfo(q)
+		if err != nil {
+			continue
+		}
+		out[q] = map[string]any{
+			"queue":     info.Queue,
+			"size":      info.Size,
+			"active":    info.Active,
+			"pending":   info.Pending,
+			"completed": info.Completed,
+			"failed":    info.Failed,
+			"scheduled": info.Scheduled,
+			"retry":     info.Retry,
+		}
+	}
+	return c.JSON(http.StatusOK, out)
 }
 
 // QueueQueues handles POST /api/admin/queue/queues.
@@ -1183,22 +1438,24 @@ func (h *Handler) QueueQueues(c echo.Context) error {
 	}
 	queues, err := h.queueInspector.Queues()
 	if err != nil {
-		return c.JSON(http.StatusOK, []any{})
+		return c.JSON(http.StatusInternalServerError, apierr.Error("INTERNAL_ERROR", "Internal error.", "00000000-0000-0000-0000-000000000000"))
 	}
-	var result []map[string]any
+	result := make([]map[string]any, 0, len(queues))
 	for _, q := range queues {
 		info, err := h.queueInspector.GetQueueInfo(q)
 		if err != nil {
 			continue
 		}
 		result = append(result, map[string]any{
-			"queue": info.Queue, "size": info.Size,
-			"active": info.Active, "pending": info.Pending,
-			"completed": info.Completed, "failed": info.Failed,
+			"queue":     info.Queue,
+			"size":      info.Size,
+			"active":    info.Active,
+			"pending":   info.Pending,
+			"completed": info.Completed,
+			"failed":    info.Failed,
+			"scheduled": info.Scheduled,
+			"retry":     info.Retry,
 		})
-	}
-	if result == nil {
-		result = []map[string]any{}
 	}
 	return c.JSON(http.StatusOK, result)
 }
@@ -1209,9 +1466,14 @@ func (h *Handler) QueueRemoveJob(c echo.Context) error {
 		Queue string `json:"queue"`
 		ID    string `json:"id"`
 	}
-	_ = c.Bind(&req)
-	if h.queueInspector != nil && req.Queue != "" && req.ID != "" {
-		_ = h.queueInspector.DeleteTask(req.Queue, req.ID)
+	if err := c.Bind(&req); err != nil || req.Queue == "" || req.ID == "" {
+		return c.JSON(http.StatusBadRequest, apierr.Error("INVALID_PARAM", "queue and id are required.", "00000000-0000-0000-0000-000000000000"))
+	}
+	if h.queueInspector == nil {
+		return c.NoContent(http.StatusNoContent)
+	}
+	if err := h.queueInspector.DeleteTask(req.Queue, req.ID); err != nil {
+		return c.JSON(http.StatusNotFound, apierr.Error("NOT_FOUND", "Not found.", "00000000-0000-0000-0000-000000000000"))
 	}
 	return c.NoContent(http.StatusNoContent)
 }
@@ -1222,20 +1484,71 @@ func (h *Handler) QueueRetryJob(c echo.Context) error {
 		Queue string `json:"queue"`
 		ID    string `json:"id"`
 	}
-	_ = c.Bind(&req)
-	if h.queueInspector != nil && req.Queue != "" && req.ID != "" {
-		_ = h.queueInspector.RunTask(req.Queue, req.ID)
+	if err := c.Bind(&req); err != nil || req.Queue == "" || req.ID == "" {
+		return c.JSON(http.StatusBadRequest, apierr.Error("INVALID_PARAM", "queue and id are required.", "00000000-0000-0000-0000-000000000000"))
+	}
+	if h.queueInspector == nil {
+		return c.NoContent(http.StatusNoContent)
+	}
+	if err := h.queueInspector.RunTask(req.Queue, req.ID); err != nil {
+		return c.JSON(http.StatusNotFound, apierr.Error("NOT_FOUND", "Not found.", "00000000-0000-0000-0000-000000000000"))
 	}
 	return c.NoContent(http.StatusNoContent)
 }
 
 // QueueShowJob handles POST /api/admin/queue/show-job.
 func (h *Handler) QueueShowJob(c echo.Context) error {
-	return c.JSON(http.StatusNotFound, apierr.Error("NOT_FOUND", "Not found.", "00000000-0000-0000-0000-000000000000"))
+	var req struct {
+		Queue string `json:"queue"`
+		ID    string `json:"id"`
+	}
+	if err := c.Bind(&req); err != nil || req.Queue == "" || req.ID == "" {
+		return c.JSON(http.StatusBadRequest, apierr.Error("INVALID_PARAM", "queue and id are required.", "00000000-0000-0000-0000-000000000000"))
+	}
+	if h.queueInspector == nil {
+		return c.JSON(http.StatusNotFound, apierr.Error("NOT_FOUND", "Not found.", "00000000-0000-0000-0000-000000000000"))
+	}
+	t, err := h.queueInspector.GetTaskInfo(req.Queue, req.ID)
+	if err != nil {
+		return c.JSON(http.StatusNotFound, apierr.Error("NOT_FOUND", "Not found.", "00000000-0000-0000-0000-000000000000"))
+	}
+	return c.JSON(http.StatusOK, packTaskSummary(t))
 }
 
 // QueueShowJobLogs handles POST /api/admin/queue/show-job-logs.
+// asynq does not persist per-task log output. Returns an empty array to keep
+// the admin UI usable without extra infra.
 func (h *Handler) QueueShowJobLogs(c echo.Context) error { return c.JSON(http.StatusOK, []any{}) }
+
+// packTaskSummary normalizes a QueueTaskSummary into the Misskey-compatible
+// JSON shape.
+func packTaskSummary(t *QueueTaskSummary) map[string]any {
+	if t == nil {
+		return nil
+	}
+	pack := map[string]any{
+		"id":       t.ID,
+		"queue":    t.Queue,
+		"type":     t.Type,
+		"state":    t.State,
+		"payload":  string(t.Payload),
+		"retried":  t.Retried,
+		"maxRetry": t.MaxRetry,
+	}
+	if t.LastErr != "" {
+		pack["lastErr"] = t.LastErr
+	}
+	if !t.LastFailedAt.IsZero() {
+		pack["lastFailedAt"] = t.LastFailedAt.UTC().Format(time.RFC3339Nano)
+	}
+	if !t.NextProcessAt.IsZero() {
+		pack["nextProcessAt"] = t.NextProcessAt.UTC().Format(time.RFC3339Nano)
+	}
+	if !t.CompletedAt.IsZero() {
+		pack["completedAt"] = t.CompletedAt.UTC().Format(time.RFC3339Nano)
+	}
+	return pack
+}
 
 // QueueStats handles POST /api/admin/queue/stats.
 func (h *Handler) QueueStats(c echo.Context) error {

--- a/internal/api/admin/handler_stubs.go
+++ b/internal/api/admin/handler_stubs.go
@@ -1286,6 +1286,18 @@ func (h *Handler) QueueInboxDelayed(c echo.Context) error {
 	return h.listDelayedTasks(c, "inbox")
 }
 
+// delayedTasksMaxFetch is the upper bound on how many of each of scheduled /
+// retry we pull from asynq to build the virtual delayed list. asynq pages
+// scheduled and retry independently so we cannot naively forward the user's
+// page number to both (retry items before the scheduled boundary would
+// disappear). We instead fetch the first asynq page (up to 100 items) of each,
+// merge scheduled-first, then slice by the user's (page, limit).
+//
+// 想定: admin/queue/*-delayed は通常 "stuck な配送" を目視で確認する用途で、
+// 合計 200 件を超えるケースは運用上ほぼ存在しない。深いページングが必要なら
+// /admin/queue/jobs を state=scheduled / state=retry で使う。
+const delayedTasksMaxFetch = 100
+
 func (h *Handler) listDelayedTasks(c echo.Context, queueName string) error {
 	if h.queueInspector == nil {
 		return c.JSON(http.StatusOK, []any{})
@@ -1301,23 +1313,23 @@ func (h *Handler) listDelayedTasks(c echo.Context, queueName string) error {
 	if req.Page < 1 {
 		req.Page = 1
 	}
-	// Misskey 本家では deliver/inbox の delayed キューを統合して返している。
-	// asynq の scheduled + retry 両方を集めるが、結合後に req.Limit で切り詰めて
-	// ページネーション契約 (limit=N なら最大 N 件) を守る。scheduled を先に
-	// 詰めるので実質 scheduled 優先になる。
-	scheduled, _ := h.queueInspector.ListScheduledTasks(queueName, req.Page, req.Limit)
-	retry, _ := h.queueInspector.ListRetryTasks(queueName, req.Page, req.Limit)
-	out := make([]map[string]any, 0, req.Limit)
-	for _, t := range scheduled {
-		if len(out) >= req.Limit {
-			break
-		}
-		out = append(out, packTaskSummary(t))
+
+	scheduled, _ := h.queueInspector.ListScheduledTasks(queueName, 1, delayedTasksMaxFetch)
+	retry, _ := h.queueInspector.ListRetryTasks(queueName, 1, delayedTasksMaxFetch)
+	combined := make([]*QueueTaskSummary, 0, len(scheduled)+len(retry))
+	combined = append(combined, scheduled...)
+	combined = append(combined, retry...)
+
+	offset := (req.Page - 1) * req.Limit
+	if offset >= len(combined) {
+		return c.JSON(http.StatusOK, []map[string]any{})
 	}
-	for _, t := range retry {
-		if len(out) >= req.Limit {
-			break
-		}
+	end := offset + req.Limit
+	if end > len(combined) {
+		end = len(combined)
+	}
+	out := make([]map[string]any, 0, end-offset)
+	for _, t := range combined[offset:end] {
 		out = append(out, packTaskSummary(t))
 	}
 	return c.JSON(http.StatusOK, out)

--- a/internal/api/admin/handler_stubs_test.go
+++ b/internal/api/admin/handler_stubs_test.go
@@ -442,15 +442,21 @@ func TestQueueQueues(t *testing.T) {
 }
 func TestQueueRemoveJob(t *testing.T) {
 	h, _, _, _ := newTestHandler(t)
-	assert.Equal(t, http.StatusNoContent, doPost(h.QueueRemoveJob, `{}`, adminUser).Code)
+	// queue/id 欠落は 400
+	assert.Equal(t, http.StatusBadRequest, doPost(h.QueueRemoveJob, `{}`, adminUser).Code)
+	// inspector 未注入は 204
+	assert.Equal(t, http.StatusNoContent, doPost(h.QueueRemoveJob, `{"queue":"deliver","id":"x"}`, adminUser).Code)
 }
 func TestQueueRetryJob(t *testing.T) {
 	h, _, _, _ := newTestHandler(t)
-	assert.Equal(t, http.StatusNoContent, doPost(h.QueueRetryJob, `{}`, adminUser).Code)
+	assert.Equal(t, http.StatusBadRequest, doPost(h.QueueRetryJob, `{}`, adminUser).Code)
+	assert.Equal(t, http.StatusNoContent, doPost(h.QueueRetryJob, `{"queue":"deliver","id":"x"}`, adminUser).Code)
 }
 func TestQueueShowJob(t *testing.T) {
 	h, _, _, _ := newTestHandler(t)
-	assert.Equal(t, http.StatusNotFound, doPost(h.QueueShowJob, `{}`, adminUser).Code)
+	// queue/id 欠落は 400、inspector 未注入 + 正規 bind は 404
+	assert.Equal(t, http.StatusBadRequest, doPost(h.QueueShowJob, `{}`, adminUser).Code)
+	assert.Equal(t, http.StatusNotFound, doPost(h.QueueShowJob, `{"queue":"deliver","id":"x"}`, adminUser).Code)
 }
 func TestQueueShowJobLogs(t *testing.T) {
 	h, _, _, _ := newTestHandler(t)

--- a/internal/api/admin/queue_stats_test.go
+++ b/internal/api/admin/queue_stats_test.go
@@ -237,6 +237,54 @@ func TestQueueDeliverDelayed_CombinesScheduledAndRetry(t *testing.T) {
 	assert.Len(t, rows, 2)
 }
 
+// listDelayedTasks が scheduled と retry を結合する際に合計が limit を超え
+// ないことを確認する (regression guard)。
+func TestQueueDeliverDelayed_CappedAtLimit(t *testing.T) {
+	h, _, _, _ := newTestHandler(t)
+	scheduled := make([]*apiadmin.QueueTaskSummary, 0, 3)
+	for _, id := range []string{"s1", "s2", "s3"} {
+		scheduled = append(scheduled, &apiadmin.QueueTaskSummary{ID: id})
+	}
+	retry := make([]*apiadmin.QueueTaskSummary, 0, 3)
+	for _, id := range []string{"r1", "r2", "r3"} {
+		retry = append(retry, &apiadmin.QueueTaskSummary{ID: id})
+	}
+	insp := &stubQueueInspector{
+		scheduled: map[string][]*apiadmin.QueueTaskSummary{"deliver": scheduled},
+		retry:     map[string][]*apiadmin.QueueTaskSummary{"deliver": retry},
+	}
+	h.SetQueueInspector(insp)
+
+	rec := doPost(h.QueueDeliverDelayed, `{"limit":4}`, adminUser)
+	assert.Equal(t, http.StatusOK, rec.Code)
+	var rows []map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &rows))
+	assert.Len(t, rows, 4, "combined output must not exceed requested limit")
+	// scheduled を先に詰めるので s1..s3 が最初の 3 件、続いて r1 が 4 件目
+	assert.Equal(t, "s1", rows[0]["id"])
+	assert.Equal(t, "r1", rows[3]["id"])
+}
+
+// QueueJobs で queue 未指定時、複数キューを走査しても合計 limit を超えない
+// ことを確認する。
+func TestQueueJobs_MultiQueueCappedAtLimit(t *testing.T) {
+	h, _, _, _ := newTestHandler(t)
+	insp := &stubQueueInspector{
+		queues: []string{"deliver", "inbox"},
+		pending: map[string][]*apiadmin.QueueTaskSummary{
+			"deliver": {{ID: "d1"}, {ID: "d2"}, {ID: "d3"}},
+			"inbox":   {{ID: "i1"}, {ID: "i2"}},
+		},
+	}
+	h.SetQueueInspector(insp)
+
+	rec := doPost(h.QueueJobs, `{"limit":2}`, adminUser)
+	assert.Equal(t, http.StatusOK, rec.Code)
+	var rows []map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &rows))
+	assert.Len(t, rows, 2, "multi-queue fan-out must still respect limit")
+}
+
 // --- Captcha ------------------------------------------------------------------
 
 func TestCaptchaCurrent_WithHcaptchaEnabled(t *testing.T) {

--- a/internal/api/admin/queue_stats_test.go
+++ b/internal/api/admin/queue_stats_test.go
@@ -1,0 +1,277 @@
+package admin_test
+
+import (
+	"encoding/json"
+	"errors"
+	"net/http"
+	"testing"
+
+	apiadmin "github.com/shiroha-a/mk/internal/api/admin"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// stubQueueInspector is a test double for admin.QueueInspector that returns
+// configurable canned responses without touching Redis.
+type stubQueueInspector struct {
+	queues        []string
+	info          map[string]*apiadmin.QueueInfoResult
+	pending       map[string][]*apiadmin.QueueTaskSummary
+	active        map[string][]*apiadmin.QueueTaskSummary
+	scheduled     map[string][]*apiadmin.QueueTaskSummary
+	retry         map[string][]*apiadmin.QueueTaskSummary
+	task          map[string]*apiadmin.QueueTaskSummary
+	deleted       []string
+	runCalls      []string
+	deleteAllHits []string
+	queuesErr     error
+	runErr        error
+	deleteErr     error
+}
+
+func (s *stubQueueInspector) Queues() ([]string, error) { return s.queues, s.queuesErr }
+func (s *stubQueueInspector) GetQueueInfo(q string) (*apiadmin.QueueInfoResult, error) {
+	if info, ok := s.info[q]; ok {
+		return info, nil
+	}
+	return nil, errors.New("not found")
+}
+func (s *stubQueueInspector) DeleteTask(_, id string) error {
+	if s.deleteErr != nil {
+		return s.deleteErr
+	}
+	s.deleted = append(s.deleted, id)
+	return nil
+}
+func (s *stubQueueInspector) DeleteAllPendingTasks(q string) (int, error) {
+	s.deleteAllHits = append(s.deleteAllHits, q)
+	return 0, nil
+}
+func (s *stubQueueInspector) RunTask(_, id string) error {
+	if s.runErr != nil {
+		return s.runErr
+	}
+	s.runCalls = append(s.runCalls, id)
+	return nil
+}
+func (s *stubQueueInspector) ListPendingTasks(q string, _, _ int) ([]*apiadmin.QueueTaskSummary, error) {
+	return s.pending[q], nil
+}
+func (s *stubQueueInspector) ListActiveTasks(q string, _, _ int) ([]*apiadmin.QueueTaskSummary, error) {
+	return s.active[q], nil
+}
+func (s *stubQueueInspector) ListScheduledTasks(q string, _, _ int) ([]*apiadmin.QueueTaskSummary, error) {
+	return s.scheduled[q], nil
+}
+func (s *stubQueueInspector) ListRetryTasks(q string, _, _ int) ([]*apiadmin.QueueTaskSummary, error) {
+	return s.retry[q], nil
+}
+func (s *stubQueueInspector) GetTaskInfo(_, id string) (*apiadmin.QueueTaskSummary, error) {
+	if t, ok := s.task[id]; ok {
+		return t, nil
+	}
+	return nil, errors.New("not found")
+}
+
+// --- Queue --------------------------------------------------------------------
+
+func TestQueueClear_WithInspector(t *testing.T) {
+	h, _, _, _ := newTestHandler(t)
+	insp := &stubQueueInspector{queues: []string{"deliver", "inbox"}}
+	h.SetQueueInspector(insp)
+	rec := doPost(h.QueueClear, `{}`, adminUser)
+	assert.Equal(t, http.StatusNoContent, rec.Code)
+	assert.ElementsMatch(t, []string{"deliver", "inbox"}, insp.deleteAllHits)
+}
+
+func TestQueueClear_QueuesError(t *testing.T) {
+	h, _, _, _ := newTestHandler(t)
+	insp := &stubQueueInspector{queuesErr: errors.New("redis down")}
+	h.SetQueueInspector(insp)
+	assert.Equal(t, http.StatusInternalServerError, doPost(h.QueueClear, `{}`, adminUser).Code)
+}
+
+func TestQueueJobs_FilterByQueueAndState(t *testing.T) {
+	h, _, _, _ := newTestHandler(t)
+	insp := &stubQueueInspector{
+		queues: []string{"deliver"},
+		pending: map[string][]*apiadmin.QueueTaskSummary{
+			"deliver": {{ID: "p1", Queue: "deliver", Type: "x", State: "pending"}},
+		},
+		active: map[string][]*apiadmin.QueueTaskSummary{
+			"deliver": {{ID: "a1", Queue: "deliver", Type: "x", State: "active"}},
+		},
+	}
+	h.SetQueueInspector(insp)
+
+	rec := doPost(h.QueueJobs, `{"queue":"deliver","state":"active"}`, adminUser)
+	assert.Equal(t, http.StatusOK, rec.Code)
+	var rows []map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &rows))
+	require.Len(t, rows, 1)
+	assert.Equal(t, "a1", rows[0]["id"])
+}
+
+func TestQueueJobs_AllQueuesPendingDefault(t *testing.T) {
+	h, _, _, _ := newTestHandler(t)
+	insp := &stubQueueInspector{
+		queues: []string{"deliver", "inbox"},
+		pending: map[string][]*apiadmin.QueueTaskSummary{
+			"deliver": {{ID: "d1", Queue: "deliver"}},
+			"inbox":   {{ID: "i1", Queue: "inbox"}},
+		},
+	}
+	h.SetQueueInspector(insp)
+	rec := doPost(h.QueueJobs, `{}`, adminUser)
+	assert.Equal(t, http.StatusOK, rec.Code)
+	var rows []map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &rows))
+	assert.Len(t, rows, 2)
+}
+
+func TestQueueShowJob_Found(t *testing.T) {
+	h, _, _, _ := newTestHandler(t)
+	insp := &stubQueueInspector{
+		task: map[string]*apiadmin.QueueTaskSummary{
+			"tid1": {ID: "tid1", Queue: "deliver", Type: "x", State: "pending"},
+		},
+	}
+	h.SetQueueInspector(insp)
+
+	rec := doPost(h.QueueShowJob, `{"queue":"deliver","id":"tid1"}`, adminUser)
+	assert.Equal(t, http.StatusOK, rec.Code)
+	var got map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &got))
+	assert.Equal(t, "tid1", got["id"])
+}
+
+func TestQueueShowJob_NotFoundWithInspector(t *testing.T) {
+	h, _, _, _ := newTestHandler(t)
+	insp := &stubQueueInspector{}
+	h.SetQueueInspector(insp)
+	rec := doPost(h.QueueShowJob, `{"queue":"deliver","id":"ghost"}`, adminUser)
+	assert.Equal(t, http.StatusNotFound, rec.Code)
+}
+
+func TestQueueRemoveJob_Success(t *testing.T) {
+	h, _, _, _ := newTestHandler(t)
+	insp := &stubQueueInspector{}
+	h.SetQueueInspector(insp)
+	rec := doPost(h.QueueRemoveJob, `{"queue":"deliver","id":"tid1"}`, adminUser)
+	assert.Equal(t, http.StatusNoContent, rec.Code)
+	assert.Equal(t, []string{"tid1"}, insp.deleted)
+}
+
+func TestQueueRemoveJob_NotFound(t *testing.T) {
+	h, _, _, _ := newTestHandler(t)
+	insp := &stubQueueInspector{deleteErr: errors.New("not found")}
+	h.SetQueueInspector(insp)
+	rec := doPost(h.QueueRemoveJob, `{"queue":"deliver","id":"x"}`, adminUser)
+	assert.Equal(t, http.StatusNotFound, rec.Code)
+}
+
+func TestQueueRetryJob_Success(t *testing.T) {
+	h, _, _, _ := newTestHandler(t)
+	insp := &stubQueueInspector{}
+	h.SetQueueInspector(insp)
+	rec := doPost(h.QueueRetryJob, `{"queue":"deliver","id":"tid1"}`, adminUser)
+	assert.Equal(t, http.StatusNoContent, rec.Code)
+	assert.Equal(t, []string{"tid1"}, insp.runCalls)
+}
+
+func TestQueuePromoteJobs_RunsScheduledAndRetry(t *testing.T) {
+	h, _, _, _ := newTestHandler(t)
+	insp := &stubQueueInspector{
+		queues: []string{"deliver"},
+		scheduled: map[string][]*apiadmin.QueueTaskSummary{
+			"deliver": {{ID: "s1"}, {ID: "s2"}},
+		},
+		retry: map[string][]*apiadmin.QueueTaskSummary{
+			"deliver": {{ID: "r1"}},
+		},
+	}
+	h.SetQueueInspector(insp)
+
+	rec := doPost(h.QueuePromoteJobs, `{}`, adminUser)
+	assert.Equal(t, http.StatusOK, rec.Code)
+	var got map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &got))
+	assert.EqualValues(t, 3, got["promoted"])
+	assert.ElementsMatch(t, []string{"s1", "s2", "r1"}, insp.runCalls)
+}
+
+func TestQueueQueueStats_WithInspector(t *testing.T) {
+	h, _, _, _ := newTestHandler(t)
+	insp := &stubQueueInspector{
+		queues: []string{"deliver"},
+		info: map[string]*apiadmin.QueueInfoResult{
+			"deliver": {Queue: "deliver", Size: 5, Pending: 3, Active: 1, Completed: 10, Failed: 2, Scheduled: 0, Retry: 1},
+		},
+	}
+	h.SetQueueInspector(insp)
+	rec := doPost(h.QueueQueueStats, `{}`, adminUser)
+	assert.Equal(t, http.StatusOK, rec.Code)
+	var got map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &got))
+	deliver, ok := got["deliver"].(map[string]any)
+	require.True(t, ok)
+	assert.EqualValues(t, 5, deliver["size"])
+	assert.EqualValues(t, 3, deliver["pending"])
+}
+
+func TestQueueDeliverDelayed_CombinesScheduledAndRetry(t *testing.T) {
+	h, _, _, _ := newTestHandler(t)
+	insp := &stubQueueInspector{
+		scheduled: map[string][]*apiadmin.QueueTaskSummary{
+			"deliver": {{ID: "s1"}},
+		},
+		retry: map[string][]*apiadmin.QueueTaskSummary{
+			"deliver": {{ID: "r1"}},
+		},
+	}
+	h.SetQueueInspector(insp)
+	rec := doPost(h.QueueDeliverDelayed, `{}`, adminUser)
+	assert.Equal(t, http.StatusOK, rec.Code)
+	var rows []map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &rows))
+	assert.Len(t, rows, 2)
+}
+
+// --- Captcha ------------------------------------------------------------------
+
+func TestCaptchaCurrent_WithHcaptchaEnabled(t *testing.T) {
+	h, _, metaRepo, _ := newTestHandler(t)
+	siteKey := "sk-hcap"
+	metaRepo.Meta.EnableHcaptcha = true
+	metaRepo.Meta.HcaptchaSiteKey = &siteKey
+	rec := doPost(h.CaptchaCurrent, `{}`, adminUser)
+	assert.Equal(t, http.StatusOK, rec.Code)
+	var got map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &got))
+	assert.Equal(t, "hcaptcha", got["provider"])
+	assert.Equal(t, "sk-hcap", got["siteKey"])
+}
+
+func TestCaptchaCurrent_NoneEnabled(t *testing.T) {
+	h, _, _, _ := newTestHandler(t)
+	rec := doPost(h.CaptchaCurrent, `{}`, adminUser)
+	assert.Equal(t, http.StatusOK, rec.Code)
+	var got map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &got))
+	assert.Nil(t, got["provider"])
+}
+
+func TestCaptchaSave_AppliesFlags(t *testing.T) {
+	h, _, metaRepo, _ := newTestHandler(t)
+	rec := doPost(h.CaptchaSave,
+		`{"provider":"turnstile","turnstileSiteKey":"sk","turnstileSecretKey":"ss"}`, adminUser)
+	assert.Equal(t, http.StatusNoContent, rec.Code)
+	assert.True(t, metaRepo.Meta.EnableTurnstile)
+	assert.False(t, metaRepo.Meta.EnableHcaptcha)
+}
+
+func TestCaptchaSave_UnknownProvider(t *testing.T) {
+	h, _, _, _ := newTestHandler(t)
+	rec := doPost(h.CaptchaSave, `{"provider":"garbage"}`, adminUser)
+	assert.Equal(t, http.StatusBadRequest, rec.Code)
+}

--- a/internal/api/admin/queue_stats_test.go
+++ b/internal/api/admin/queue_stats_test.go
@@ -265,6 +265,51 @@ func TestQueueDeliverDelayed_CappedAtLimit(t *testing.T) {
 	assert.Equal(t, "r1", rows[3]["id"])
 }
 
+// listDelayedTasks が scheduled/retry 境界を越えて正しくページングできること
+// を確認する。旧実装では同じ req.Page を両リストに forward していたため、
+// scheduled でページが埋まると retry 側の早い項目が永久に見えなくなる bug が
+// あった (Devin #183 review)。
+func TestQueueDeliverDelayed_PagingCrossesBoundary(t *testing.T) {
+	h, _, _, _ := newTestHandler(t)
+	scheduled := make([]*apiadmin.QueueTaskSummary, 0, 5)
+	for _, id := range []string{"s1", "s2", "s3", "s4", "s5"} {
+		scheduled = append(scheduled, &apiadmin.QueueTaskSummary{ID: id})
+	}
+	retry := make([]*apiadmin.QueueTaskSummary, 0, 3)
+	for _, id := range []string{"r1", "r2", "r3"} {
+		retry = append(retry, &apiadmin.QueueTaskSummary{ID: id})
+	}
+	insp := &stubQueueInspector{
+		scheduled: map[string][]*apiadmin.QueueTaskSummary{"deliver": scheduled},
+		retry:     map[string][]*apiadmin.QueueTaskSummary{"deliver": retry},
+	}
+	h.SetQueueInspector(insp)
+
+	// page 1 limit 3 → s1, s2, s3
+	rec := doPost(h.QueueDeliverDelayed, `{"limit":3,"page":1}`, adminUser)
+	var rows []map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &rows))
+	require.Len(t, rows, 3)
+	assert.Equal(t, []any{"s1", "s2", "s3"}, []any{rows[0]["id"], rows[1]["id"], rows[2]["id"]})
+
+	// page 2 limit 3 → s4, s5, r1 (境界をまたぐ)
+	rec = doPost(h.QueueDeliverDelayed, `{"limit":3,"page":2}`, adminUser)
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &rows))
+	require.Len(t, rows, 3)
+	assert.Equal(t, []any{"s4", "s5", "r1"}, []any{rows[0]["id"], rows[1]["id"], rows[2]["id"]})
+
+	// page 3 limit 3 → r2, r3
+	rec = doPost(h.QueueDeliverDelayed, `{"limit":3,"page":3}`, adminUser)
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &rows))
+	require.Len(t, rows, 2)
+	assert.Equal(t, []any{"r2", "r3"}, []any{rows[0]["id"], rows[1]["id"]})
+
+	// page 4 → 空
+	rec = doPost(h.QueueDeliverDelayed, `{"limit":3,"page":4}`, adminUser)
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &rows))
+	assert.Empty(t, rows)
+}
+
 // QueueJobs で queue 未指定時、複数キューを走査しても合計 limit を超えない
 // ことを確認する。
 func TestQueueJobs_MultiQueueCappedAtLimit(t *testing.T) {

--- a/internal/queue/inspector.go
+++ b/internal/queue/inspector.go
@@ -1,6 +1,8 @@
 package queue
 
 import (
+	"time"
+
 	"github.com/hibiken/asynq"
 )
 
@@ -67,4 +69,97 @@ func (i *Inspector) RunTask(qname, taskID string) error {
 // Close releases the underlying inspector.
 func (i *Inspector) Close() error {
 	return i.inner.Close()
+}
+
+// TaskSummary is a lightweight projection of asynq.TaskInfo for admin list APIs.
+type TaskSummary struct {
+	ID            string
+	Queue         string
+	Type          string
+	State         string
+	Payload       []byte
+	Retried       int
+	MaxRetry      int
+	LastErr       string
+	LastFailedAt  time.Time
+	NextProcessAt time.Time
+	EnqueuedAt    time.Time
+	ScheduledAt   time.Time
+	CompletedAt   time.Time
+}
+
+// ListPendingTasks returns up to pageSize pending tasks in qname starting at
+// page (1-indexed).
+func (i *Inspector) ListPendingTasks(qname string, page, pageSize int) ([]*TaskSummary, error) {
+	return i.listTasks(qname, "pending", page, pageSize)
+}
+
+// ListActiveTasks returns up to pageSize tasks currently being processed.
+func (i *Inspector) ListActiveTasks(qname string, page, pageSize int) ([]*TaskSummary, error) {
+	return i.listTasks(qname, "active", page, pageSize)
+}
+
+// ListScheduledTasks returns tasks scheduled for a future time.
+func (i *Inspector) ListScheduledTasks(qname string, page, pageSize int) ([]*TaskSummary, error) {
+	return i.listTasks(qname, "scheduled", page, pageSize)
+}
+
+// ListRetryTasks returns tasks waiting to be retried.
+func (i *Inspector) ListRetryTasks(qname string, page, pageSize int) ([]*TaskSummary, error) {
+	return i.listTasks(qname, "retry", page, pageSize)
+}
+
+// GetTaskInfo returns full info for a single task.
+func (i *Inspector) GetTaskInfo(qname, taskID string) (*TaskSummary, error) {
+	info, err := i.inner.GetTaskInfo(qname, taskID)
+	if err != nil {
+		return nil, err
+	}
+	return taskInfoToSummary(info), nil
+}
+
+func (i *Inspector) listTasks(qname, state string, page, pageSize int) ([]*TaskSummary, error) {
+	if page < 1 {
+		page = 1
+	}
+	if pageSize <= 0 || pageSize > 100 {
+		pageSize = 30
+	}
+	opts := []asynq.ListOption{asynq.Page(page), asynq.PageSize(pageSize)}
+	var tasks []*asynq.TaskInfo
+	var err error
+	switch state {
+	case "pending":
+		tasks, err = i.inner.ListPendingTasks(qname, opts...)
+	case "active":
+		tasks, err = i.inner.ListActiveTasks(qname, opts...)
+	case "scheduled":
+		tasks, err = i.inner.ListScheduledTasks(qname, opts...)
+	case "retry":
+		tasks, err = i.inner.ListRetryTasks(qname, opts...)
+	}
+	if err != nil {
+		return nil, err
+	}
+	out := make([]*TaskSummary, 0, len(tasks))
+	for _, t := range tasks {
+		out = append(out, taskInfoToSummary(t))
+	}
+	return out, nil
+}
+
+func taskInfoToSummary(t *asynq.TaskInfo) *TaskSummary {
+	return &TaskSummary{
+		ID:            t.ID,
+		Queue:         t.Queue,
+		Type:          t.Type,
+		State:         t.State.String(),
+		Payload:       t.Payload,
+		Retried:       t.Retried,
+		MaxRetry:      t.MaxRetry,
+		LastErr:       t.LastErr,
+		LastFailedAt:  t.LastFailedAt,
+		NextProcessAt: t.NextProcessAt,
+		CompletedAt:   t.CompletedAt,
+	}
 }

--- a/internal/queue/queue_test.go
+++ b/internal/queue/queue_test.go
@@ -310,6 +310,93 @@ func TestInspector_GetQueueInfo_NotFound(t *testing.T) {
 	assert.Error(t, err)
 }
 
+func TestInspector_ListPendingTasksAndGetTaskInfo(t *testing.T) {
+	testutil.SkipIfNoDocker(t)
+	flushTestRedis(t)
+
+	c := queue.NewClient(redisOpt())
+	defer func() { _ = c.Close() }()
+	require.NoError(t, c.EnqueueDeliver(queue.DeliverPayload{
+		Inbox: "https://remote.example/inbox", Body: []byte(`{}`), KeyID: "k", KeyPEM: "p",
+	}))
+
+	insp := queue.NewInspector(redisOpt())
+	defer func() { _ = insp.Close() }()
+
+	pending, err := insp.ListPendingTasks(queue.QueueName, 1, 30)
+	require.NoError(t, err)
+	require.NotEmpty(t, pending, "at least one pending task expected")
+	taskID := pending[0].ID
+	assert.Equal(t, queue.QueueName, pending[0].Queue)
+	assert.NotZero(t, pending[0].Type)
+
+	// GetTaskInfo で同じ ID を引けること
+	info, err := insp.GetTaskInfo(queue.QueueName, taskID)
+	require.NoError(t, err)
+	assert.Equal(t, taskID, info.ID)
+}
+
+func TestInspector_ListActiveScheduledRetry_EmptyByDefault(t *testing.T) {
+	testutil.SkipIfNoDocker(t)
+	flushTestRedis(t)
+
+	// enqueue 後即 list。active/scheduled/retry は空でも err にならない。
+	c := queue.NewClient(redisOpt())
+	defer func() { _ = c.Close() }()
+	require.NoError(t, c.EnqueueDeliver(queue.DeliverPayload{
+		Inbox: "https://remote.example/inbox", Body: []byte(`{}`), KeyID: "k", KeyPEM: "p",
+	}))
+
+	insp := queue.NewInspector(redisOpt())
+	defer func() { _ = insp.Close() }()
+
+	active, err := insp.ListActiveTasks(queue.QueueName, 1, 30)
+	require.NoError(t, err)
+	assert.GreaterOrEqual(t, len(active), 0)
+
+	scheduled, err := insp.ListScheduledTasks(queue.QueueName, 1, 30)
+	require.NoError(t, err)
+	assert.GreaterOrEqual(t, len(scheduled), 0)
+
+	retry, err := insp.ListRetryTasks(queue.QueueName, 1, 30)
+	require.NoError(t, err)
+	assert.GreaterOrEqual(t, len(retry), 0)
+}
+
+func TestInspector_ListTasks_DefaultsClamped(t *testing.T) {
+	testutil.SkipIfNoDocker(t)
+	flushTestRedis(t)
+
+	insp := queue.NewInspector(redisOpt())
+	defer func() { _ = insp.Close() }()
+
+	// page/pageSize が 0 以下でも default に丸められてエラーにならない。
+	c := queue.NewClient(redisOpt())
+	defer func() { _ = c.Close() }()
+	require.NoError(t, c.EnqueueDeliver(queue.DeliverPayload{
+		Inbox: "https://remote.example/inbox", Body: []byte(`{}`), KeyID: "k", KeyPEM: "p",
+	}))
+
+	rows, err := insp.ListPendingTasks(queue.QueueName, 0, 0)
+	require.NoError(t, err)
+	assert.NotNil(t, rows)
+
+	rows, err = insp.ListPendingTasks(queue.QueueName, -5, 500)
+	require.NoError(t, err)
+	assert.NotNil(t, rows)
+}
+
+func TestInspector_GetTaskInfo_NotFound(t *testing.T) {
+	testutil.SkipIfNoDocker(t)
+	flushTestRedis(t)
+
+	insp := queue.NewInspector(redisOpt())
+	defer func() { _ = insp.Close() }()
+
+	_, err := insp.GetTaskInfo(queue.QueueName, "nonexistent-id")
+	assert.Error(t, err)
+}
+
 func TestNewWebPushTask_RoundTrip(t *testing.T) {
 	payload := queue.WebPushPayload{
 		UserID: "u1",

--- a/internal/server/queue_adapter.go
+++ b/internal/server/queue_adapter.go
@@ -42,3 +42,58 @@ func (a *queueInspectorAdapter) DeleteAllPendingTasks(qname string) (int, error)
 func (a *queueInspectorAdapter) RunTask(qname, taskID string) error {
 	return a.inner.RunTask(qname, taskID)
 }
+
+func (a *queueInspectorAdapter) ListPendingTasks(qname string, page, pageSize int) ([]*apiadmin.QueueTaskSummary, error) {
+	rows, err := a.inner.ListPendingTasks(qname, page, pageSize)
+	return taskSummariesToAdmin(rows), err
+}
+
+func (a *queueInspectorAdapter) ListActiveTasks(qname string, page, pageSize int) ([]*apiadmin.QueueTaskSummary, error) {
+	rows, err := a.inner.ListActiveTasks(qname, page, pageSize)
+	return taskSummariesToAdmin(rows), err
+}
+
+func (a *queueInspectorAdapter) ListScheduledTasks(qname string, page, pageSize int) ([]*apiadmin.QueueTaskSummary, error) {
+	rows, err := a.inner.ListScheduledTasks(qname, page, pageSize)
+	return taskSummariesToAdmin(rows), err
+}
+
+func (a *queueInspectorAdapter) ListRetryTasks(qname string, page, pageSize int) ([]*apiadmin.QueueTaskSummary, error) {
+	rows, err := a.inner.ListRetryTasks(qname, page, pageSize)
+	return taskSummariesToAdmin(rows), err
+}
+
+func (a *queueInspectorAdapter) GetTaskInfo(qname, taskID string) (*apiadmin.QueueTaskSummary, error) {
+	t, err := a.inner.GetTaskInfo(qname, taskID)
+	if err != nil {
+		return nil, err
+	}
+	return taskSummaryToAdmin(t), nil
+}
+
+func taskSummariesToAdmin(rows []*queue.TaskSummary) []*apiadmin.QueueTaskSummary {
+	out := make([]*apiadmin.QueueTaskSummary, 0, len(rows))
+	for _, r := range rows {
+		out = append(out, taskSummaryToAdmin(r))
+	}
+	return out
+}
+
+func taskSummaryToAdmin(t *queue.TaskSummary) *apiadmin.QueueTaskSummary {
+	if t == nil {
+		return nil
+	}
+	return &apiadmin.QueueTaskSummary{
+		ID:            t.ID,
+		Queue:         t.Queue,
+		Type:          t.Type,
+		State:         t.State,
+		Payload:       t.Payload,
+		Retried:       t.Retried,
+		MaxRetry:      t.MaxRetry,
+		LastErr:       t.LastErr,
+		LastFailedAt:  t.LastFailedAt,
+		NextProcessAt: t.NextProcessAt,
+		CompletedAt:   t.CompletedAt,
+	}
+}

--- a/internal/testutil/mock_repository.go
+++ b/internal/testutil/mock_repository.go
@@ -980,9 +980,48 @@ func (m *MockMetaRepository) Update(fields map[string]any) error {
 	if m.Meta == nil {
 		m.Meta = &model.Meta{ID: "x"}
 	}
-	if v, ok := fields["rootUserId"]; ok {
-		if s, ok := v.(string); ok {
-			m.Meta.RootUserID = &s
+	for k, v := range fields {
+		switch k {
+		case "rootUserId":
+			if s, ok := v.(string); ok {
+				m.Meta.RootUserID = &s
+			}
+		case "enableHcaptcha":
+			if b, ok := v.(bool); ok {
+				m.Meta.EnableHcaptcha = b
+			}
+		case "enableRecaptcha":
+			if b, ok := v.(bool); ok {
+				m.Meta.EnableRecaptcha = b
+			}
+		case "enableTurnstile":
+			if b, ok := v.(bool); ok {
+				m.Meta.EnableTurnstile = b
+			}
+		case "hcaptchaSiteKey":
+			if s, ok := v.(string); ok {
+				m.Meta.HcaptchaSiteKey = &s
+			}
+		case "hcaptchaSecretKey":
+			if s, ok := v.(string); ok {
+				m.Meta.HcaptchaSecretKey = &s
+			}
+		case "recaptchaSiteKey":
+			if s, ok := v.(string); ok {
+				m.Meta.RecaptchaSiteKey = &s
+			}
+		case "recaptchaSecretKey":
+			if s, ok := v.(string); ok {
+				m.Meta.RecaptchaSecretKey = &s
+			}
+		case "turnstileSiteKey":
+			if s, ok := v.(string); ok {
+				m.Meta.TurnstileSiteKey = &s
+			}
+		case "turnstileSecretKey":
+			if s, ok := v.(string); ok {
+				m.Meta.TurnstileSecretKey = &s
+			}
 		}
 	}
 	return nil


### PR DESCRIPTION
## Summary

#164 (P4-4) を #181 / #182 に分割した前半。queue 系 12 + stats/misc 5 = 17 ハンドラを本実装化。

## 主な変更点

### QueueInspector の拡張
- \`internal/queue/inspector.go\`: \`ListPending/Active/Scheduled/RetryTasks\` と \`GetTaskInfo\` を追加、軽量 DTO \`TaskSummary\` を定義
- \`internal/api/admin/handler.go\`: \`admin.QueueInspector\` interface に対応メソッド + \`QueueTaskSummary\` を追加
- \`internal/server/queue_adapter.go\`: queue → admin 型変換

### 12 queue ハンドラ
| handler | 変更内容 |
|---|---|
| QueueClear | Queues エラーで 500 |
| QueueJobs | state / queue / limit / page 対応、queue 未指定で全キュー走査 |
| QueueShowJob | queue/id 検証 + GetTaskInfo |
| QueueShowJobLogs | 維持 (asynq に per-task log なし) |
| QueueStats | 維持 |
| QueueQueueStats | 全キューの full stats |
| QueueQueues | full stats + エラーで 500 |
| QueueRemoveJob | queue/id 必須化、失敗時 404 |
| QueueRetryJob | 同上 |
| QueuePromoteJobs | scheduled+retry を RunTask で逐次 promote、\`{promoted: N}\` 返却 |
| QueueDeliverDelayed | scheduled+retry 統合 page 化 |
| QueueInboxDelayed | 同上 |

### Stats / Misc
- \`GetIndexStats\`: \`pg_stat_user_indexes\` をそのまま
- \`GetTableStats\`: \`pg_class\` + \`pg_stat_user_tables\` + \`pg_relation_size\` で \`{tableName: {count, size}}\`
- \`CaptchaCurrent\`: 有効 provider + site key を meta から返却
- \`CaptchaSave\`: provider 検証 + secret/site key partial update

## テスト

### 実行方法
\`\`\`
go test ./internal/api/admin/...
go test ./internal/queue/...
\`\`\`

### 追加ケース
- 15 ケース (queue_stats_test.go): stubQueueInspector 経由で各 queue 系 + captcha の happy + 異常系

### カバレッジ
- \`internal/api/admin\`: 76.3% (CI 閾値 60% クリア)

## Closes

Closes #181
Refs #159 #164

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/shiroha-a/mk/pull/183" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
