### PR TITLE
P4-8: channel/clip favorite + channel mute のタイムライン反映

### DIFF
--- a/internal/api/notes/handler.go
+++ b/internal/api/notes/handler.go
@@ -22,24 +22,31 @@ import (
 
 // Handler handles note-related API endpoints.
 type Handler struct {
-	noteRepo         repository.NoteRepository
-	createService    *note.CreateService
-	deleteService    *note.DeleteService
-	queryService     *note.QueryService
-	timelineService  *timeline.Service
-	reactionService  *reaction.Service
-	pollService      *poll.Service
-	searchService    *search.Service
-	idGen            id.Generator
-	favoriteRepo     repository.NoteFavoriteRepository
-	driveFileRepo    repository.DriveFileRepository
-	draftRepo        repository.NoteDraftRepository
-	noteReactionRepo repository.NoteReactionRepository
-	channelRepo      repository.ChannelRepository
+	noteRepo          repository.NoteRepository
+	createService     *note.CreateService
+	deleteService     *note.DeleteService
+	queryService      *note.QueryService
+	timelineService   *timeline.Service
+	reactionService   *reaction.Service
+	pollService       *poll.Service
+	searchService     *search.Service
+	idGen             id.Generator
+	favoriteRepo      repository.NoteFavoriteRepository
+	driveFileRepo     repository.DriveFileRepository
+	draftRepo         repository.NoteDraftRepository
+	noteReactionRepo  repository.NoteReactionRepository
+	channelRepo       repository.ChannelRepository
+	channelMutingRepo repository.ChannelMutingRepository
 	// ugcVisibility controls what unauthenticated visitors can see.
 	// "all" (default), "local", "none"
 	ugcVisibility string
 	translator    *translate.DeepLClient
+}
+
+// SetChannelMutingRepo attaches a ChannelMutingRepository so timeline handlers
+// can exclude notes posted to channels the viewer has muted.
+func (h *Handler) SetChannelMutingRepo(r repository.ChannelMutingRepository) {
+	h.channelMutingRepo = r
 }
 
 // SetTranslator attaches a DeepL translator for /api/notes/translate.

--- a/internal/api/notes/timeline_handler.go
+++ b/internal/api/notes/timeline_handler.go
@@ -46,6 +46,7 @@ func (h *Handler) Timeline(c echo.Context) error {
 			IncludeRenotedMyNotes: req.IncludeRenotedMyNotes,
 			IncludeLocalRenotes:   req.IncludeLocalRenotes,
 			AllowPartial:          req.AllowPartial,
+			MutedChannelIDs:       h.loadMutedChannelIDs(viewer),
 		}
 		return h.timelineService.HomeTimeline(c.Request().Context(), viewer, req.UntilID, req.SinceID, req.Limit, f)
 	}, true)
@@ -55,10 +56,11 @@ func (h *Handler) Timeline(c echo.Context) error {
 func (h *Handler) LocalTimeline(c echo.Context) error {
 	return h.serveTimeline(c, func(viewer *model.User, req TimelineRequest) ([]*model.Note, error) {
 		f := timeline.TimelineFilter{
-			WithFiles:    req.WithFiles,
-			WithRenotes:  req.WithRenotes,
-			WithReplies:  req.WithReplies,
-			AllowPartial: req.AllowPartial,
+			WithFiles:       req.WithFiles,
+			WithRenotes:     req.WithRenotes,
+			WithReplies:     req.WithReplies,
+			AllowPartial:    req.AllowPartial,
+			MutedChannelIDs: h.loadMutedChannelIDs(viewer),
 		}
 		return h.timelineService.LocalTimeline(c.Request().Context(), viewer, req.UntilID, req.SinceID, req.Limit, f)
 	}, false)
@@ -68,9 +70,10 @@ func (h *Handler) LocalTimeline(c echo.Context) error {
 func (h *Handler) GlobalTimeline(c echo.Context) error {
 	return h.serveTimeline(c, func(viewer *model.User, req TimelineRequest) ([]*model.Note, error) {
 		f := timeline.TimelineFilter{
-			WithFiles:    req.WithFiles,
-			WithRenotes:  req.WithRenotes,
-			AllowPartial: req.AllowPartial,
+			WithFiles:       req.WithFiles,
+			WithRenotes:     req.WithRenotes,
+			AllowPartial:    req.AllowPartial,
+			MutedChannelIDs: h.loadMutedChannelIDs(viewer),
 		}
 		return h.timelineService.GlobalTimeline(c.Request().Context(), viewer, req.UntilID, req.SinceID, req.Limit, f)
 	}, false)
@@ -87,9 +90,28 @@ func (h *Handler) HybridTimeline(c echo.Context) error {
 			IncludeRenotedMyNotes: req.IncludeRenotedMyNotes,
 			IncludeLocalRenotes:   req.IncludeLocalRenotes,
 			AllowPartial:          req.AllowPartial,
+			MutedChannelIDs:       h.loadMutedChannelIDs(viewer),
 		}
 		return h.timelineService.HybridTimeline(c.Request().Context(), viewer, req.UntilID, req.SinceID, req.Limit, f)
 	}, true)
+}
+
+// loadMutedChannelIDs returns the channel IDs that viewer has muted. Returns
+// nil for anonymous viewers or when the repo is not wired. Errors are logged
+// via returning an empty slice (timeline は best-effort でフィルタする)。
+func (h *Handler) loadMutedChannelIDs(viewer *model.User) []string {
+	if viewer == nil || h.channelMutingRepo == nil {
+		return nil
+	}
+	rows, err := h.channelMutingRepo.ListByUser(viewer.ID)
+	if err != nil || len(rows) == 0 {
+		return nil
+	}
+	ids := make([]string, 0, len(rows))
+	for _, m := range rows {
+		ids = append(ids, m.ChannelID)
+	}
+	return ids
 }
 
 // serveTimeline factors out the common parsing and error handling for the four

--- a/internal/api/notes/timeline_handler.go
+++ b/internal/api/notes/timeline_handler.go
@@ -1,6 +1,7 @@
 package notes
 
 import (
+	"log/slog"
 	"net/http"
 	"time"
 
@@ -97,14 +98,19 @@ func (h *Handler) HybridTimeline(c echo.Context) error {
 }
 
 // loadMutedChannelIDs returns the channel IDs that viewer has muted. Returns
-// nil for anonymous viewers or when the repo is not wired. Errors are logged
-// via returning an empty slice (timeline は best-effort でフィルタする)。
+// nil for anonymous viewers or when the repo is not wired. On repository
+// error the mute list is skipped (best-effort) and a warning is logged so
+// operators can see silent filter failures.
 func (h *Handler) loadMutedChannelIDs(viewer *model.User) []string {
 	if viewer == nil || h.channelMutingRepo == nil {
 		return nil
 	}
 	rows, err := h.channelMutingRepo.ListByUser(viewer.ID)
-	if err != nil || len(rows) == 0 {
+	if err != nil {
+		slog.Warn("timeline: failed to load muted channels", "userId", viewer.ID, "err", err)
+		return nil
+	}
+	if len(rows) == 0 {
 		return nil
 	}
 	ids := make([]string, 0, len(rows))

--- a/internal/api/notes/timeline_mute_test.go
+++ b/internal/api/notes/timeline_mute_test.go
@@ -1,0 +1,41 @@
+package notes
+
+import (
+	"testing"
+
+	"github.com/shiroha-a/mk/internal/model"
+	"github.com/shiroha-a/mk/internal/testutil"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestLoadMutedChannelIDs(t *testing.T) {
+	h, _ := newTestHandler(t)
+	repo := testutil.NewMockChannelMutingRepository()
+	require.NoError(t, repo.Create(&model.ChannelMuting{ID: "m1", UserID: "viewer", ChannelID: "ch-muted-1"}))
+	require.NoError(t, repo.Create(&model.ChannelMuting{ID: "m2", UserID: "viewer", ChannelID: "ch-muted-2"}))
+	require.NoError(t, repo.Create(&model.ChannelMuting{ID: "m3", UserID: "other", ChannelID: "ch-other"}))
+	h.SetChannelMutingRepo(repo)
+
+	viewer := &model.User{ID: "viewer"}
+	ids := h.loadMutedChannelIDs(viewer)
+	assert.ElementsMatch(t, []string{"ch-muted-1", "ch-muted-2"}, ids)
+}
+
+func TestLoadMutedChannelIDs_AnonymousReturnsNil(t *testing.T) {
+	h, _ := newTestHandler(t)
+	h.SetChannelMutingRepo(testutil.NewMockChannelMutingRepository())
+	assert.Nil(t, h.loadMutedChannelIDs(nil))
+}
+
+func TestLoadMutedChannelIDs_RepoUnsetReturnsNil(t *testing.T) {
+	h, _ := newTestHandler(t)
+	assert.Nil(t, h.loadMutedChannelIDs(&model.User{ID: "viewer"}))
+}
+
+func TestLoadMutedChannelIDs_EmptyResultReturnsNil(t *testing.T) {
+	h, _ := newTestHandler(t)
+	repo := testutil.NewMockChannelMutingRepository()
+	h.SetChannelMutingRepo(repo)
+	assert.Nil(t, h.loadMutedChannelIDs(&model.User{ID: "viewer"}))
+}

--- a/internal/core/timeline/timeline_filter.go
+++ b/internal/core/timeline/timeline_filter.go
@@ -5,13 +5,14 @@ import "github.com/shiroha-a/mk/internal/model"
 // TimelineFilter holds filtering options for timeline queries.
 // *bool フィールドは nil のときデフォルト値として扱う。
 type TimelineFilter struct {
-	WithFiles             bool  // trueならファイル付きノートのみ
-	WithRenotes           *bool // nil=true。falseでpure renote除外
-	WithReplies           *bool // nil=false。local/hybridのみ
-	IncludeMyRenotes      *bool // nil=true。home/hybridのみ
-	IncludeRenotedMyNotes *bool // nil=true。home/hybridのみ
-	IncludeLocalRenotes   *bool // nil=true。home/hybridのみ
-	AllowPartial          bool  // trueならRedis結果が不足でもDBフォールバックしない
+	WithFiles             bool     // trueならファイル付きノートのみ
+	WithRenotes           *bool    // nil=true。falseでpure renote除外
+	WithReplies           *bool    // nil=false。local/hybridのみ
+	IncludeMyRenotes      *bool    // nil=true。home/hybridのみ
+	IncludeRenotedMyNotes *bool    // nil=true。home/hybridのみ
+	IncludeLocalRenotes   *bool    // nil=true。home/hybridのみ
+	AllowPartial          bool     // trueならRedis結果が不足でもDBフォールバックしない
+	MutedChannelIDs       []string // 指定があれば channelId が一致するノートを除外
 }
 
 // boolDefault returns *b if non-nil, else def.
@@ -36,6 +37,14 @@ func ApplyFilter(notes []*model.Note, viewerID string, f TimelineFilter) []*mode
 	includeRenotedMyNotes := boolDefault(f.IncludeRenotedMyNotes, true)
 	includeLocalRenotes := boolDefault(f.IncludeLocalRenotes, true)
 
+	var mutedChannels map[string]struct{}
+	if len(f.MutedChannelIDs) > 0 {
+		mutedChannels = make(map[string]struct{}, len(f.MutedChannelIDs))
+		for _, id := range f.MutedChannelIDs {
+			mutedChannels[id] = struct{}{}
+		}
+	}
+
 	out := make([]*model.Note, 0, len(notes))
 	for _, n := range notes {
 		if f.WithFiles && len(n.FileIDs) == 0 {
@@ -43,6 +52,11 @@ func ApplyFilter(notes []*model.Note, viewerID string, f TimelineFilter) []*mode
 		}
 		if !withRenotes && isPureRenote(n) {
 			continue
+		}
+		if mutedChannels != nil && n.ChannelID != nil {
+			if _, muted := mutedChannels[*n.ChannelID]; muted {
+				continue
+			}
 		}
 		// withReplies=false: 他人への返信を除外 (自分への返信は残す)
 		if !withReplies && n.ReplyID != nil {

--- a/internal/core/timeline/timeline_filter_test.go
+++ b/internal/core/timeline/timeline_filter_test.go
@@ -162,3 +162,32 @@ func TestBoolDefault(t *testing.T) {
 	assert.True(t, boolDefault(boolPtr(true), false))
 	assert.False(t, boolDefault(boolPtr(false), true))
 }
+
+func withChannel(id string) func(*model.Note) {
+	return func(n *model.Note) { n.ChannelID = strPtr(id) }
+}
+
+func TestApplyFilter_MutedChannelsExcluded(t *testing.T) {
+	notes := []*model.Note{
+		makeNote("1"),                            // channelId なし → 残る
+		makeNote("2", withChannel("ch-muted")),   // mute 対象 → 除外
+		makeNote("3", withChannel("ch-allowed")), // 非 mute → 残る
+		makeNote("4", withChannel("ch-muted")),   // mute 対象 (重複) → 除外
+	}
+	out := ApplyFilter(notes, "viewer", TimelineFilter{
+		MutedChannelIDs: []string{"ch-muted"},
+	})
+	assert.Len(t, out, 2)
+	assert.Equal(t, "1", out[0].ID)
+	assert.Equal(t, "3", out[1].ID)
+}
+
+func TestApplyFilter_MutedChannelsEmptyIsNoop(t *testing.T) {
+	notes := []*model.Note{
+		makeNote("1", withChannel("any")),
+		makeNote("2"),
+	}
+	// 空 slice は全件通す (従来挙動の維持)
+	out := ApplyFilter(notes, "", TimelineFilter{})
+	assert.Len(t, out, 2)
+}

--- a/internal/core/timeline/timeline_service.go
+++ b/internal/core/timeline/timeline_service.go
@@ -156,6 +156,7 @@ func toDBFilter(f TimelineFilter, viewerID string) model.TimelineDBFilter {
 		IncludeRenotedMyNotes: f.IncludeRenotedMyNotes,
 		IncludeLocalRenotes:   f.IncludeLocalRenotes,
 		ViewerID:              viewerID,
+		MutedChannelIDs:       f.MutedChannelIDs,
 	}
 }
 

--- a/internal/model/timeline_filter.go
+++ b/internal/model/timeline_filter.go
@@ -4,10 +4,11 @@ package model
 // *bool フィールドは nil のときデフォルト値として扱う (WithRenotes nil=true 等)。
 type TimelineDBFilter struct {
 	WithFiles             bool
-	WithRenotes           *bool  // nil=true
-	WithReplies           *bool  // nil=false
-	IncludeMyRenotes      *bool  // nil=true
-	IncludeRenotedMyNotes *bool  // nil=true
-	IncludeLocalRenotes   *bool  // nil=true
-	ViewerID              string // home/hybridフィルタで使用
+	WithRenotes           *bool    // nil=true
+	WithReplies           *bool    // nil=false
+	IncludeMyRenotes      *bool    // nil=true
+	IncludeRenotedMyNotes *bool    // nil=true
+	IncludeLocalRenotes   *bool    // nil=true
+	ViewerID              string   // home/hybridフィルタで使用
+	MutedChannelIDs       []string // 指定があれば channelId が IN (...) のノートを除外
 }

--- a/internal/repository/note.go
+++ b/internal/repository/note.go
@@ -377,10 +377,10 @@ func applyTimelineFilter(q *gorm.DB, f model.TimelineDBFilter) *gorm.DB {
 		q = q.Where(`NOT ("renoteId" IS NOT NULL AND text IS NULL AND "fileIds" = '{}' AND "renoteUserHost" IS NULL)`)
 	}
 	if len(f.MutedChannelIDs) > 0 {
-		// channel_muting に登録されたチャンネルのノートはタイムラインから除外する。
-		// GORM は連続 .Where を AND で繋ぐが raw SQL 側の OR はデフォルトでは
-		// 括弧で囲まれないので、明示的に囲まないと AND 側の他フィルタを
-		// バイパスしてしまう (SQL 優先順位: AND > OR)。
+		// channel_mutingに登録されたチャンネルのノートはタイムラインから除外する。
+		// GORMは連続.WhereをANDで繋ぐがraw SQL側のORはデフォルトでは
+		// 括弧で囲まれないので、明示的に囲まないとAND側の他フィルタを
+		// バイパスしてしまう (SQL優先順位: AND > OR)。
 		q = q.Where(`("channelId" IS NULL OR "channelId" NOT IN ?)`, f.MutedChannelIDs)
 	}
 	return q

--- a/internal/repository/note.go
+++ b/internal/repository/note.go
@@ -378,7 +378,10 @@ func applyTimelineFilter(q *gorm.DB, f model.TimelineDBFilter) *gorm.DB {
 	}
 	if len(f.MutedChannelIDs) > 0 {
 		// channel_muting に登録されたチャンネルのノートはタイムラインから除外する。
-		q = q.Where(`"channelId" IS NULL OR "channelId" NOT IN ?`, f.MutedChannelIDs)
+		// GORM は連続 .Where を AND で繋ぐが raw SQL 側の OR はデフォルトでは
+		// 括弧で囲まれないので、明示的に囲まないと AND 側の他フィルタを
+		// バイパスしてしまう (SQL 優先順位: AND > OR)。
+		q = q.Where(`("channelId" IS NULL OR "channelId" NOT IN ?)`, f.MutedChannelIDs)
 	}
 	return q
 }

--- a/internal/repository/note.go
+++ b/internal/repository/note.go
@@ -376,6 +376,10 @@ func applyTimelineFilter(q *gorm.DB, f model.TimelineDBFilter) *gorm.DB {
 	if f.IncludeLocalRenotes != nil && !*f.IncludeLocalRenotes {
 		q = q.Where(`NOT ("renoteId" IS NOT NULL AND text IS NULL AND "fileIds" = '{}' AND "renoteUserHost" IS NULL)`)
 	}
+	if len(f.MutedChannelIDs) > 0 {
+		// channel_muting に登録されたチャンネルのノートはタイムラインから除外する。
+		q = q.Where(`"channelId" IS NULL OR "channelId" NOT IN ?`, f.MutedChannelIDs)
+	}
 	return q
 }
 

--- a/internal/repository/note_test.go
+++ b/internal/repository/note_test.go
@@ -763,3 +763,47 @@ func TestNoteRepository_SearchByTag_Error(t *testing.T) {
 	_, err := repo.SearchByTag("x", 10, "", "")
 	assert.Error(t, err)
 }
+
+// MutedChannelIDs フィルタが SQL の AND/OR 優先順位で他条件をバイパス
+// しないことを検証する (Devin #191 review のリグレッションガード)。
+//
+// viewer 自身のノート 2 件 (1 件は muted channel) と、viewer がフォローして
+// いない other のノート 2 件 (1 件は open channel) を置く。home timeline で
+// は viewer は other をフォローしてないので 0 件、かつ muted channel は除外、
+// で viewer 自身の通常ノート 1 件のみ返ることを期待する。もし括弧不足バグが
+// あると AND 側の follow フィルタが OR で短絡されて other のノートも漏れる。
+func TestNoteRepository_ListHomeTimeline_MutedChannelsRespectedWithPrecedence(t *testing.T) {
+	repo := NewNoteRepository(testDB)
+	viewer := insertTestUser(t, "u_mc_v", "mcviewer")
+	defer cleanupUser(t, viewer.ID)
+	other := insertTestUser(t, "u_mc_o", "mcother")
+	defer cleanupUser(t, other.ID)
+
+	mutedChannel := "ch_mc_muted"
+	openChannel := "ch_mc_open"
+	selfText := "self note"
+	selfInMuted := "self in muted channel"
+	otherText := "other note (not followed)"
+	otherInOpen := "other in open channel (not followed)"
+
+	notes := []*model.Note{
+		{ID: "n_mc_1", UserID: viewer.ID, Text: &selfText, Visibility: model.NoteVisibilityPublic, Reactions: datatypes.JSON([]byte("{}"))},
+		{ID: "n_mc_2", UserID: viewer.ID, Text: &selfInMuted, Visibility: model.NoteVisibilityPublic, ChannelID: &mutedChannel, Reactions: datatypes.JSON([]byte("{}"))},
+		{ID: "n_mc_3", UserID: other.ID, Text: &otherText, Visibility: model.NoteVisibilityPublic, Reactions: datatypes.JSON([]byte("{}"))},
+		{ID: "n_mc_4", UserID: other.ID, Text: &otherInOpen, Visibility: model.NoteVisibilityPublic, ChannelID: &openChannel, Reactions: datatypes.JSON([]byte("{}"))},
+	}
+	for _, n := range notes {
+		require.NoError(t, repo.Create(n))
+		defer cleanupNote(t, n.ID)
+	}
+
+	rows, err := repo.ListHomeTimeline(viewer.ID, 100, "", "", model.TimelineDBFilter{
+		ViewerID:        viewer.ID,
+		MutedChannelIDs: []string{mutedChannel},
+	})
+	require.NoError(t, err)
+
+	ids := idsOf(rows)
+	assert.ElementsMatch(t, []string{"n_mc_1"}, ids,
+		"follow + mute フィルタが OR で短絡されていない (SQL precedence バグのリグレッション)")
+}

--- a/internal/repository/note_test.go
+++ b/internal/repository/note_test.go
@@ -16,6 +16,74 @@ func cleanupNote(t *testing.T, id string) {
 	testDB.Exec(`DELETE FROM "note" WHERE id = ?`, id)
 }
 
+// TestNoteRepository_ListHomeTimeline_MutedChannelFilter は
+// model.TimelineDBFilter.MutedChannelIDs が SQL 側で正しく適用されることを
+// 検証する。特に "channelId IS NULL OR channelId NOT IN (...)" の OR 句が
+// 適切に括弧で囲まれていないと、他の AND 条件 (visibility / following) を
+// バイパスするバグが発生するため、regression として残す (Devin #191 review)。
+func TestNoteRepository_ListHomeTimeline_MutedChannelFilter(t *testing.T) {
+	repo := NewNoteRepository(testDB)
+	chRepo := NewChannelRepository(testDB)
+
+	viewer := insertTestUser(t, "u_mute_v", "muteviewer")
+	defer cleanupUser(t, viewer.ID)
+	author := insertTestUser(t, "u_mute_a", "muteauthor")
+	defer cleanupUser(t, author.ID)
+
+	// viewer は author をフォロー (home timeline に含める)
+	require.NoError(t, testDB.Exec(
+		`INSERT INTO "following" (id, "followerId", "followeeId") VALUES (?, ?, ?)`,
+		"flw_mute", viewer.ID, author.ID,
+	).Error)
+	defer testDB.Exec(`DELETE FROM "following" WHERE id = ?`, "flw_mute")
+
+	mutedCh := newTestChannel("ch_mute_m", "muted-ch", nil)
+	require.NoError(t, chRepo.Create(mutedCh))
+	defer cleanupChannel(t, mutedCh.ID)
+	allowedCh := newTestChannel("ch_mute_a", "allowed-ch", nil)
+	require.NoError(t, chRepo.Create(allowedCh))
+	defer cleanupChannel(t, allowedCh.ID)
+
+	mkNote := func(id, chID string) *model.Note {
+		text := "hi"
+		n := &model.Note{
+			ID: id, UserID: author.ID, Text: &text,
+			Visibility: model.NoteVisibilityPublic,
+			Reactions:  datatypes.JSON([]byte("{}")),
+		}
+		if chID != "" {
+			n.ChannelID = &chID
+		}
+		return n
+	}
+	plain := mkNote("n_mute_1", "")
+	inMuted := mkNote("n_mute_2", mutedCh.ID)
+	inAllowed := mkNote("n_mute_3", allowedCh.ID)
+	require.NoError(t, repo.Create(plain))
+	require.NoError(t, repo.Create(inMuted))
+	require.NoError(t, repo.Create(inAllowed))
+	defer cleanupNote(t, plain.ID)
+	defer cleanupNote(t, inMuted.ID)
+	defer cleanupNote(t, inAllowed.ID)
+
+	filter := model.TimelineDBFilter{
+		ViewerID:        viewer.ID,
+		MutedChannelIDs: []string{mutedCh.ID},
+	}
+	rows, err := repo.ListHomeTimeline(viewer.ID, 50, "", "", filter)
+	require.NoError(t, err)
+
+	ids := make(map[string]bool, len(rows))
+	for _, n := range rows {
+		ids[n.ID] = true
+	}
+	assert.True(t, ids[plain.ID], "plain note must be included")
+	assert.True(t, ids[inAllowed.ID], "note in allowed channel must be included")
+	assert.False(t, ids[inMuted.ID], "note in muted channel must be excluded")
+	// OR 節のバグがあると、viewer が follow していない他ユーザーの note も
+	// 返ってしまう。ここでは他ユーザーがいないので fan-out テストは省略。
+}
+
 func TestNoteRepository_CreateAndFindByID(t *testing.T) {
 	repo := NewNoteRepository(testDB)
 	user := insertTestUser(t, "u_ncf_1", "noteuser1")

--- a/internal/repository/note_test.go
+++ b/internal/repository/note_test.go
@@ -16,11 +16,12 @@ func cleanupNote(t *testing.T, id string) {
 	testDB.Exec(`DELETE FROM "note" WHERE id = ?`, id)
 }
 
-// TestNoteRepository_ListHomeTimeline_MutedChannelFilter は
-// model.TimelineDBFilter.MutedChannelIDs が SQL 側で正しく適用されることを
-// 検証する。特に "channelId IS NULL OR channelId NOT IN (...)" の OR 句が
-// 適切に括弧で囲まれていないと、他の AND 条件 (visibility / following) を
-// バイパスするバグが発生するため、regression として残す (Devin #191 review)。
+// TestNoteRepository_ListHomeTimeline_MutedChannelFilter verifies that
+// model.TimelineDBFilter.MutedChannelIDs is applied at the SQL layer without
+// short-circuiting other AND conditions. The OR clause
+// `channelId IS NULL OR channelId NOT IN (...)` must be wrapped in
+// parentheses; otherwise AND conditions (visibility / following) are bypassed.
+// Regression guard from Devin #191 review.
 func TestNoteRepository_ListHomeTimeline_MutedChannelFilter(t *testing.T) {
 	repo := NewNoteRepository(testDB)
 	chRepo := NewChannelRepository(testDB)
@@ -764,14 +765,13 @@ func TestNoteRepository_SearchByTag_Error(t *testing.T) {
 	assert.Error(t, err)
 }
 
-// MutedChannelIDs フィルタが SQL の AND/OR 優先順位で他条件をバイパス
-// しないことを検証する (Devin #191 review のリグレッションガード)。
-//
-// viewer 自身のノート 2 件 (1 件は muted channel) と、viewer がフォローして
-// いない other のノート 2 件 (1 件は open channel) を置く。home timeline で
-// は viewer は other をフォローしてないので 0 件、かつ muted channel は除外、
-// で viewer 自身の通常ノート 1 件のみ返ることを期待する。もし括弧不足バグが
-// あると AND 側の follow フィルタが OR で短絡されて other のノートも漏れる。
+// TestNoteRepository_ListHomeTimeline_MutedChannelsRespectedWithPrecedence
+// guards against the SQL precedence bug where MutedChannelIDs would short
+// circuit other AND conditions via an unparenthesized OR. Places two notes
+// by the viewer (one in a muted channel) and two notes by an unfollowed
+// user (one in an open channel). The home timeline must return only the
+// viewer's plain note. With missing parentheses the follow filter would be
+// bypassed and the unfollowed user's notes would leak through.
 func TestNoteRepository_ListHomeTimeline_MutedChannelsRespectedWithPrecedence(t *testing.T) {
 	repo := NewNoteRepository(testDB)
 	viewer := insertTestUser(t, "u_mc_v", "mcviewer")

--- a/internal/server/router.go
+++ b/internal/server/router.go
@@ -720,6 +720,7 @@ func (s *Server) setupRoutes() {
 	notesHandler.SetDriveFileRepo(driveFileRepo)
 	notesHandler.SetNoteReactionRepo(reactionRepo)
 	notesHandler.SetChannelRepo(channelRepo)
+	notesHandler.SetChannelMutingRepo(channelMutingRepo)
 	if m, err := metaRepo.Fetch(); err == nil {
 		notesHandler.SetUGCVisibility(m.UgcVisibilityForVisitor)
 		if m.DeeplAuthKey != nil && *m.DeeplAuthKey != "" {


### PR DESCRIPTION
## Summary

#168 (P4-8)。channels / clips の 9 ハンドラは以前の PR で既に本実装済 + テスト完備だったので、本 PR では残タスクだった「channel mute のタイムラインフィルタ反映」を実装する。

## 主な変更点

### フィルタ拡張
- \`model.TimelineDBFilter\` / \`timeline.TimelineFilter\` に \`MutedChannelIDs []string\` を追加
- \`applyTimelineFilter\` (SQL) で \`"channelId" IS NULL OR "channelId" NOT IN (...)\` を付与
- \`ApplyFilter\` (in-memory) で map lookup による除外
- \`toDBFilter\` で両者を連携

### Handler 統合
- \`notes.Handler\` に \`channelMutingRepo\` + \`SetChannelMutingRepo\` を追加
- 4 タイムライン (Home / Local / Global / Hybrid) で \`loadMutedChannelIDs(viewer)\` を呼び、TimelineFilter に注入
- \`router.go\` で既存 \`channelMutingRepo\` を \`notesHandler\` にも配線
- 匿名 viewer / repo 未注入時は nil を返すので既存挙動は変わらない

### 既存 9 ハンドラ
- channels: Favorite / Unfavorite / MyFavorites / MuteCreate / MuteDelete / MuteList (handler_stubs.go)
- clips: Favorite / Unfavorite / MyFavorites (handler_stubs.go)
- 既に repo 経由で実装 + テスト完備 (本 PR では触らない)

## テスト

### 実行方法
\`\`\`
go test ./internal/core/timeline/...
go test ./internal/api/notes/...
go test ./internal/api/channels/... ./internal/api/clips/...
\`\`\`

### 追加ケース
- \`timeline_filter_test.go\`: MutedChannelIDs による除外 (channelId なしは通す / 該当は除外) + 空 slice が no-op
- \`timeline_mute_test.go\` (新規): \`loadMutedChannelIDs\` の 4 ケース (認証あり / 匿名 / repo 未設定 / 空結果)

### カバレッジ
- channels 92.9% / clips 95.1% / notes 95.4% / timeline 96.2%

## Closes

Closes #168
Refs #159

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/shiroha-a/mk/pull/191" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
