### PR TITLE
P4-10 followup: notes/state から isWatching を削除

### DIFF
--- a/internal/core/note/note_query_service.go
+++ b/internal/core/note/note_query_service.go
@@ -123,8 +123,9 @@ func (s *QueryService) Conversation(viewer *model.User, noteID string, limit int
 
 // State returns the note's user-specific state flags.
 // 匿名閲覧者 (viewer==nil) はすべて false。
-// isWatching は note 通知購読テーブル (note_watching) を別 issue で扱うため、
-// ここでは常に false を返す。
+//
+// upstream Misskey の notes/state は isFavorited / isMutedThread のみを返す
+// (isWatching は廃止) ため、こちらも同じ shape に揃える。
 func (s *QueryService) State(viewer *model.User, noteID string) (*NoteState, error) {
 	note, err := s.Show(viewer, noteID)
 	if err != nil {
@@ -157,7 +158,6 @@ func (s *QueryService) State(viewer *model.User, noteID string) (*NoteState, err
 type NoteState struct {
 	IsFavorited   bool `json:"isFavorited"`
 	IsMutedThread bool `json:"isMutedThread"`
-	IsWatching    bool `json:"isWatching"`
 }
 
 // filterVisible drops notes the viewer cannot see.

--- a/internal/core/note/note_query_service_test.go
+++ b/internal/core/note/note_query_service_test.go
@@ -195,7 +195,6 @@ func TestQueryService_State_OK(t *testing.T) {
 	require.NoError(t, err)
 	assert.False(t, st.IsFavorited)
 	assert.False(t, st.IsMutedThread)
-	assert.False(t, st.IsWatching)
 }
 
 func TestQueryService_State_NotFound(t *testing.T) {
@@ -270,7 +269,6 @@ func TestQueryService_State_AnonymousIsAllFalse(t *testing.T) {
 	require.NoError(t, err)
 	assert.False(t, state.IsFavorited)
 	assert.False(t, state.IsMutedThread)
-	assert.False(t, state.IsWatching)
 }
 
 func TestQueryService_State_FavoritedTrue(t *testing.T) {


### PR DESCRIPTION
## Summary
upstream Misskey の \`notes/state\` は既に \`isFavorited\` / \`isMutedThread\` の
2 フィールドしか返さない (isWatching 廃止) ため、本家互換を優先して
我々の \`NoteState\` から \`IsWatching\` を削除する。

## 調査結果
- \`.tmp/misskey/packages/backend/src/server/api/endpoints/notes/state.ts\` の
  res schema は \`isFavorited\` と \`isMutedThread\` のみ
- \`notes/watching/create\` / \`notes/watching/delete\` エンドポイントも upstream から削除済
- \`note_watching\` テーブルへの参照は古い migration ファイルにのみ残存

## 主な変更点
- \`NoteState.IsWatching\` フィールドを削除 (\`internal/core/note/note_query_service.go\`)
- 該当フィールドを参照していたテスト 2 行を削除
- \`State()\` の GoDoc を「別 issue 送り」から「upstream 準拠で削除」に更新

## 非スコープ
- \`note_watching\` テーブル / repository / ハンドラの新設は行わない (upstream が廃止しているため)

## Testing
\`\`\`bash
go test -count=1 ./internal/core/note/...
\`\`\`
pass。\`make fmt && make lint\` クリーン。

## Closes
Closes #173

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/shiroha-a/mk/pull/197" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
