### PR TITLE
P5-1a: chat DB migration + model + repo拡張 (CherryPickベース)

### DIFF
--- a/internal/api/chat/handler_test.go
+++ b/internal/api/chat/handler_test.go
@@ -129,6 +129,19 @@ func (m *mockChatRepo) FindInvitation(userID, roomID string) (*model.ChatRoomInv
 }
 func (m *mockChatRepo) CountUnread(_ string) (int64, error) { return 0, nil }
 func (m *mockChatRepo) MarkRead(_, _ string) error          { return nil }
+func (m *mockChatRepo) ListInvitationsByUser(_ string, _ bool) ([]*model.ChatRoomInvitation, error) {
+	return nil, nil
+}
+func (m *mockChatRepo) ListInvitationsByRoom(_ string) ([]*model.ChatRoomInvitation, error) {
+	return nil, nil
+}
+func (m *mockChatRepo) UpdateDeliveryStatus(_ string, _, _ bool) error { return nil }
+func (m *mockChatRepo) ListHistory(_ string, _ int) ([]*model.ChatMessage, error) {
+	return nil, nil
+}
+func (m *mockChatRepo) MarkAllRead(_ string) error       { return nil }
+func (m *mockChatRepo) AddReaction(_, _ string) error    { return nil }
+func (m *mockChatRepo) RemoveReaction(_, _ string) error { return nil }
 
 func newTestHandler() (*Handler, *mockChatRepo) {
 	repo := newMock()

--- a/internal/core/chat/service_test.go
+++ b/internal/core/chat/service_test.go
@@ -134,6 +134,19 @@ func (r *fakeChatRepo) MarkRead(userID, messageID string) error {
 	}
 	return nil
 }
+func (r *fakeChatRepo) ListInvitationsByUser(_ string, _ bool) ([]*model.ChatRoomInvitation, error) {
+	return nil, nil
+}
+func (r *fakeChatRepo) ListInvitationsByRoom(_ string) ([]*model.ChatRoomInvitation, error) {
+	return nil, nil
+}
+func (r *fakeChatRepo) UpdateDeliveryStatus(_ string, _, _ bool) error { return nil }
+func (r *fakeChatRepo) ListHistory(_ string, _ int) ([]*model.ChatMessage, error) {
+	return nil, nil
+}
+func (r *fakeChatRepo) MarkAllRead(_ string) error       { return nil }
+func (r *fakeChatRepo) AddReaction(_, _ string) error    { return nil }
+func (r *fakeChatRepo) RemoveReaction(_, _ string) error { return nil }
 
 // --- capture publisher ---
 

--- a/internal/model/chat.go
+++ b/internal/model/chat.go
@@ -26,6 +26,11 @@ type ChatMessage struct {
 	Reads      pq.StringArray `gorm:"column:reads;type:varchar(32)[];default:'{}'" json:"reads"`
 	FileID     *string        `gorm:"column:fileId;type:varchar(32)" json:"fileId"`
 	Reactions  pq.StringArray `gorm:"column:reactions;type:varchar(1024)[];default:'{}'" json:"reactions"`
+	// CherryPick連合用カラム: リモートインスタンスへのDM配送状態を管理する。
+	// ローカル同士のメッセージでは使用されない (デフォルト値のまま)。
+	Emojis          pq.StringArray `gorm:"column:emojis;type:varchar(128)[];default:'{}'" json:"emojis"`
+	IsDelivering    bool           `gorm:"column:isDelivering;default:false" json:"isDelivering"`
+	IsDeliverFailed bool           `gorm:"column:isDeliverFailed;default:false" json:"isDeliverFailed"`
 
 	FromUser *User     `gorm:"foreignKey:FromUserID" json:"fromUser,omitempty"`
 	ToUser   *User     `gorm:"foreignKey:ToUserID" json:"toUser,omitempty"`
@@ -59,3 +64,29 @@ type ChatRoomInvitation struct {
 }
 
 func (ChatRoomInvitation) TableName() string { return "chat_room_invitation" }
+
+// ChatApproval represents the `chat_approval` table.
+// 1対1チャットの個別許可を管理する。User.ChatScope による全体設定を
+// オーバーライドして特定の相手からの DM を許可する。
+type ChatApproval struct {
+	ID      string `gorm:"column:id;type:varchar(32);primaryKey" json:"id"`
+	UserID  string `gorm:"column:userId;type:varchar(32);not null" json:"userId"`
+	OtherID string `gorm:"column:otherId;type:varchar(32);not null" json:"otherId"`
+
+	User  *User `gorm:"foreignKey:UserID" json:"user,omitempty"`
+	Other *User `gorm:"foreignKey:OtherID" json:"other,omitempty"`
+}
+
+func (ChatApproval) TableName() string { return "chat_approval" }
+
+// UserPending represents the `user_pending` table.
+// 招待制登録でメール確認待ちのユーザーを保持する。
+type UserPending struct {
+	ID       string `gorm:"column:id;type:varchar(32);primaryKey" json:"id"`
+	Code     string `gorm:"column:code;type:varchar(128);not null;uniqueIndex" json:"code"`
+	Username string `gorm:"column:username;type:varchar(128);not null" json:"username"`
+	Email    string `gorm:"column:email;type:varchar(128);not null" json:"email"`
+	Password string `gorm:"column:password;type:varchar(128);not null" json:"-"`
+}
+
+func (UserPending) TableName() string { return "user_pending" }

--- a/internal/model/chat.go
+++ b/internal/model/chat.go
@@ -66,8 +66,8 @@ type ChatRoomInvitation struct {
 func (ChatRoomInvitation) TableName() string { return "chat_room_invitation" }
 
 // ChatApproval represents the `chat_approval` table.
-// 1対1チャットの個別許可を管理する。User.ChatScope による全体設定を
-// オーバーライドして特定の相手からの DM を許可する。
+// 1対1チャットの個別許可を管理する。User.ChatScopeによる全体設定を
+// オーバーライドして特定の相手からのDMを許可する。
 type ChatApproval struct {
 	ID      string `gorm:"column:id;type:varchar(32);primaryKey" json:"id"`
 	UserID  string `gorm:"column:userId;type:varchar(32);not null" json:"userId"`

--- a/internal/model/chat.go
+++ b/internal/model/chat.go
@@ -17,15 +17,15 @@ func (ChatRoom) TableName() string { return "chat_room" }
 
 // ChatMessage represents the `chat_message` table.
 type ChatMessage struct {
-	ID         string         `gorm:"column:id;type:varchar(32);primaryKey" json:"id"`
-	FromUserID string         `gorm:"column:fromUserId;type:varchar(32);not null" json:"fromUserId"`
-	ToUserID   *string        `gorm:"column:toUserId;type:varchar(32)" json:"toUserId"`
-	ToRoomID   *string        `gorm:"column:toRoomId;type:varchar(32)" json:"toRoomId"`
-	Text       *string        `gorm:"column:text;type:varchar(4096)" json:"text"`
-	URI        *string        `gorm:"column:uri;type:varchar(512)" json:"uri"`
-	Reads      pq.StringArray `gorm:"column:reads;type:varchar(32)[];default:'{}'" json:"reads"`
-	FileID     *string        `gorm:"column:fileId;type:varchar(32)" json:"fileId"`
-	Reactions  pq.StringArray `gorm:"column:reactions;type:varchar(1024)[];default:'{}'" json:"reactions"`
+	ID              string         `gorm:"column:id;type:varchar(32);primaryKey" json:"id"`
+	FromUserID      string         `gorm:"column:fromUserId;type:varchar(32);not null" json:"fromUserId"`
+	ToUserID        *string        `gorm:"column:toUserId;type:varchar(32)" json:"toUserId"`
+	ToRoomID        *string        `gorm:"column:toRoomId;type:varchar(32)" json:"toRoomId"`
+	Text            *string        `gorm:"column:text;type:varchar(4096)" json:"text"`
+	URI             *string        `gorm:"column:uri;type:varchar(512)" json:"uri"`
+	Reads           pq.StringArray `gorm:"column:reads;type:varchar(32)[];default:'{}'" json:"reads"`
+	FileID          *string        `gorm:"column:fileId;type:varchar(32)" json:"fileId"`
+	Reactions       pq.StringArray `gorm:"column:reactions;type:varchar(1024)[];default:'{}'" json:"reactions"`
 	Emojis          pq.StringArray `gorm:"column:emojis;type:varchar(128)[];default:'{}'" json:"emojis"`
 	IsDelivering    bool           `gorm:"column:isDelivering;default:false" json:"isDelivering"`
 	IsDeliverFailed bool           `gorm:"column:isDeliverFailed;default:false" json:"isDeliverFailed"`

--- a/internal/model/chat.go
+++ b/internal/model/chat.go
@@ -26,8 +26,6 @@ type ChatMessage struct {
 	Reads      pq.StringArray `gorm:"column:reads;type:varchar(32)[];default:'{}'" json:"reads"`
 	FileID     *string        `gorm:"column:fileId;type:varchar(32)" json:"fileId"`
 	Reactions  pq.StringArray `gorm:"column:reactions;type:varchar(1024)[];default:'{}'" json:"reactions"`
-	// CherryPick連合用カラム: リモートインスタンスへのDM配送状態を管理する。
-	// ローカル同士のメッセージでは使用されない (デフォルト値のまま)。
 	Emojis          pq.StringArray `gorm:"column:emojis;type:varchar(128)[];default:'{}'" json:"emojis"`
 	IsDelivering    bool           `gorm:"column:isDelivering;default:false" json:"isDelivering"`
 	IsDeliverFailed bool           `gorm:"column:isDeliverFailed;default:false" json:"isDeliverFailed"`
@@ -65,9 +63,8 @@ type ChatRoomInvitation struct {
 
 func (ChatRoomInvitation) TableName() string { return "chat_room_invitation" }
 
-// ChatApproval represents the `chat_approval` table.
-// 1対1チャットの個別許可を管理する。User.ChatScopeによる全体設定を
-// オーバーライドして特定の相手からのDMを許可する。
+// ChatApproval represents the `chat_approval` table. It manages per-user
+// overrides for 1-on-1 chat permissions (works with User.ChatScope).
 type ChatApproval struct {
 	ID      string `gorm:"column:id;type:varchar(32);primaryKey" json:"id"`
 	UserID  string `gorm:"column:userId;type:varchar(32);not null" json:"userId"`
@@ -79,8 +76,8 @@ type ChatApproval struct {
 
 func (ChatApproval) TableName() string { return "chat_approval" }
 
-// UserPending represents the `user_pending` table.
-// 招待制登録でメール確認待ちのユーザーを保持する。
+// UserPending represents the `user_pending` table. It holds users awaiting
+// email confirmation during invite-based registration.
 type UserPending struct {
 	ID       string `gorm:"column:id;type:varchar(32);primaryKey" json:"id"`
 	Code     string `gorm:"column:code;type:varchar(128);not null;uniqueIndex" json:"code"`

--- a/internal/repository/chat.go
+++ b/internal/repository/chat.go
@@ -263,9 +263,12 @@ func (r *chatRepository) ListHistory(userID string, limit int) ([]*model.ChatMes
 	// DISTINCT ONはconversation_keyの昇順を強制するため、そのままLIMITを
 	// 掛けるとアルファベット順で先頭N件が返ってしまう。外側のサブクエリで
 	// id DESCに並べ直してからLIMITすることで最新のN会話を取得する。
-	var msgs []*model.ChatMessage
+	// Raw SQLではPreloadが使えないため、2段階で取得する:
+	// 1) Raw SQLで対象メッセージIDを取得
+	// 2) 通常のGORMクエリでPreload("FromUser")付きで再取得
+	var ids []string
 	err := r.db.Raw(`
-		SELECT * FROM (
+		SELECT id FROM (
 			SELECT DISTINCT ON (conversation_key) *
 			FROM (
 				SELECT *, LEAST("fromUserId","toUserId") || '-' || GREATEST("fromUserId","toUserId") AS conversation_key
@@ -281,8 +284,15 @@ func (r *chatRepository) ListHistory(userID string, limit int) ([]*model.ChatMes
 		) conversations
 		ORDER BY id DESC
 		LIMIT ?
-	`, userID, userID, userID, limit).Find(&msgs).Error
+	`, userID, userID, userID, limit).Pluck("id", &ids).Error
 	if err != nil {
+		return nil, err
+	}
+	if len(ids) == 0 {
+		return nil, nil
+	}
+	var msgs []*model.ChatMessage
+	if err := r.db.Preload("FromUser").Where("id IN ?", ids).Order("id DESC").Find(&msgs).Error; err != nil {
 		return nil, err
 	}
 	return msgs, nil
@@ -294,8 +304,9 @@ func (r *chatRepository) MarkAllRead(userID string) error {
 }
 
 func (r *chatRepository) AddReaction(messageID, reaction string) error {
-	return r.db.Exec(`UPDATE "chat_message" SET "reactions" = array_append("reactions", ?) WHERE "id" = ?`,
-		reaction, messageID).Error
+	// MarkReadと同じく重複ガード付き。同一reactionの二重追加を防ぐ。
+	return r.db.Exec(`UPDATE "chat_message" SET "reactions" = array_append("reactions", ?) WHERE "id" = ? AND NOT ("reactions" @> ARRAY[?]::varchar[])`,
+		reaction, messageID, reaction).Error
 }
 
 func (r *chatRepository) RemoveReaction(messageID, reaction string) error {

--- a/internal/repository/chat.go
+++ b/internal/repository/chat.go
@@ -260,20 +260,26 @@ func (r *chatRepository) ListHistory(userID string, limit int) ([]*model.ChatMes
 	// 1対1 (toUserId/fromUserId) とルーム (toRoomId経由のmembership) をUNION
 	// し、会話keyごとの最新メッセージを取る。
 	// GORMの.Limit()は.Raw()の後では無視されるため、SQL内にLIMITを埋め込む。
+	// DISTINCT ONはconversation_keyの昇順を強制するため、そのままLIMITを
+	// 掛けるとアルファベット順で先頭N件が返ってしまう。外側のサブクエリで
+	// id DESCに並べ直してからLIMITすることで最新のN会話を取得する。
 	var msgs []*model.ChatMessage
 	err := r.db.Raw(`
-		SELECT DISTINCT ON (conversation_key) *
-		FROM (
-			SELECT *, LEAST("fromUserId","toUserId") || '-' || GREATEST("fromUserId","toUserId") AS conversation_key
-			FROM "chat_message"
-			WHERE ("fromUserId" = ? OR "toUserId" = ?) AND "toRoomId" IS NULL
-			UNION ALL
-			SELECT cm.*, 'room:' || cm."toRoomId" AS conversation_key
-			FROM "chat_message" cm
-			JOIN "chat_room_membership" m ON m."roomId" = cm."toRoomId" AND m."userId" = ?
-			WHERE cm."toRoomId" IS NOT NULL
-		) sub
-		ORDER BY conversation_key, id DESC
+		SELECT * FROM (
+			SELECT DISTINCT ON (conversation_key) *
+			FROM (
+				SELECT *, LEAST("fromUserId","toUserId") || '-' || GREATEST("fromUserId","toUserId") AS conversation_key
+				FROM "chat_message"
+				WHERE ("fromUserId" = ? OR "toUserId" = ?) AND "toRoomId" IS NULL
+				UNION ALL
+				SELECT cm.*, 'room:' || cm."toRoomId" AS conversation_key
+				FROM "chat_message" cm
+				JOIN "chat_room_membership" m ON m."roomId" = cm."toRoomId" AND m."userId" = ?
+				WHERE cm."toRoomId" IS NOT NULL
+			) sub
+			ORDER BY conversation_key, id DESC
+		) conversations
+		ORDER BY id DESC
 		LIMIT ?
 	`, userID, userID, userID, limit).Find(&msgs).Error
 	if err != nil {

--- a/internal/repository/chat.go
+++ b/internal/repository/chat.go
@@ -249,7 +249,7 @@ func (r *chatRepository) UpdateDeliveryStatus(messageID string, delivering, fail
 }
 
 // ListHistory returns the most recent message per conversation (1-on-1 or
-// room) involving userID. DISTINCT ON で会話ごとの最新 1 件を抽出する。
+// room) involving userID. DISTINCT ONで会話ごとの最新1件を抽出する。
 func (r *chatRepository) ListHistory(userID string, limit int) ([]*model.ChatMessage, error) {
 	if limit <= 0 {
 		limit = 10
@@ -257,8 +257,9 @@ func (r *chatRepository) ListHistory(userID string, limit int) ([]*model.ChatMes
 	if limit > 100 {
 		limit = 100
 	}
-	// 1対1 (toUserId / fromUserId) とルーム (toRoomId 経由の membership) を UNION
-	// し、会話 key ごとの最新メッセージを取る。
+	// 1対1 (toUserId/fromUserId) とルーム (toRoomId経由のmembership) をUNION
+	// し、会話keyごとの最新メッセージを取る。
+	// GORMの.Limit()は.Raw()の後では無視されるため、SQL内にLIMITを埋め込む。
 	var msgs []*model.ChatMessage
 	err := r.db.Raw(`
 		SELECT DISTINCT ON (conversation_key) *
@@ -273,7 +274,8 @@ func (r *chatRepository) ListHistory(userID string, limit int) ([]*model.ChatMes
 			WHERE cm."toRoomId" IS NOT NULL
 		) sub
 		ORDER BY conversation_key, id DESC
-	`, userID, userID, userID).Limit(limit).Find(&msgs).Error
+		LIMIT ?
+	`, userID, userID, userID, limit).Find(&msgs).Error
 	if err != nil {
 		return nil, err
 	}

--- a/internal/repository/chat.go
+++ b/internal/repository/chat.go
@@ -46,10 +46,11 @@ type ChatRepository interface {
 	ListInvitationsByUser(userID string, ignored bool) ([]*model.ChatRoomInvitation, error)
 	ListInvitationsByRoom(roomID string) ([]*model.ChatRoomInvitation, error)
 
-	// Delivery status (CherryPick連合用)
+	// UpdateDeliveryStatus sets the AP delivery flags on a chat message.
 	UpdateDeliveryStatus(messageID string, delivering, failed bool) error
 
-	// History: 1対1とルームの最新メッセージ混合取得
+	// ListHistory returns the most recent message per conversation (DM + room)
+	// involving userID, ordered by recency.
 	ListHistory(userID string, limit int) ([]*model.ChatMessage, error)
 
 	// Mark all as read
@@ -249,7 +250,7 @@ func (r *chatRepository) UpdateDeliveryStatus(messageID string, delivering, fail
 }
 
 // ListHistory returns the most recent message per conversation (1-on-1 or
-// room) involving userID. DISTINCT ONで会話ごとの最新1件を抽出する。
+// room) involving userID, using DISTINCT ON to pick one row per conversation.
 func (r *chatRepository) ListHistory(userID string, limit int) ([]*model.ChatMessage, error) {
 	if limit <= 0 {
 		limit = 10

--- a/internal/repository/chat.go
+++ b/internal/repository/chat.go
@@ -267,6 +267,8 @@ func (r *chatRepository) ListHistory(userID string, limit int) ([]*model.ChatMes
 	// Raw SQLではPreloadが使えないため、2段階で取得する:
 	// 1) Raw SQLで対象メッセージIDを取得
 	// 2) 通常のGORMクエリでPreload("FromUser")付きで再取得
+	// ルーム所有者はmembershipレコードなしでも暗黙メンバーとして扱う
+	// (IsRoomMemberと同じセマンティクス)。EXISTS句でmembership OR owner を判定。
 	var ids []string
 	err := r.db.Raw(`
 		SELECT id FROM (
@@ -278,14 +280,17 @@ func (r *chatRepository) ListHistory(userID string, limit int) ([]*model.ChatMes
 				UNION ALL
 				SELECT cm.*, 'room:' || cm."toRoomId" AS conversation_key
 				FROM "chat_message" cm
-				JOIN "chat_room_membership" m ON m."roomId" = cm."toRoomId" AND m."userId" = ?
 				WHERE cm."toRoomId" IS NOT NULL
+				AND (
+					EXISTS (SELECT 1 FROM "chat_room_membership" m WHERE m."roomId" = cm."toRoomId" AND m."userId" = ?)
+					OR EXISTS (SELECT 1 FROM "chat_room" cr WHERE cr."id" = cm."toRoomId" AND cr."ownerId" = ?)
+				)
 			) sub
 			ORDER BY conversation_key, id DESC
 		) conversations
 		ORDER BY id DESC
 		LIMIT ?
-	`, userID, userID, userID, limit).Pluck("id", &ids).Error
+	`, userID, userID, userID, userID, limit).Pluck("id", &ids).Error
 	if err != nil {
 		return nil, err
 	}

--- a/internal/repository/chat.go
+++ b/internal/repository/chat.go
@@ -41,6 +41,23 @@ type ChatRepository interface {
 
 	// Mark read
 	MarkRead(userID, messageID string) error
+
+	// Invitation listing
+	ListInvitationsByUser(userID string, ignored bool) ([]*model.ChatRoomInvitation, error)
+	ListInvitationsByRoom(roomID string) ([]*model.ChatRoomInvitation, error)
+
+	// Delivery status (CherryPick連合用)
+	UpdateDeliveryStatus(messageID string, delivering, failed bool) error
+
+	// History: 1対1とルームの最新メッセージ混合取得
+	ListHistory(userID string, limit int) ([]*model.ChatMessage, error)
+
+	// Mark all as read
+	MarkAllRead(userID string) error
+
+	// Reactions
+	AddReaction(messageID, reaction string) error
+	RemoveReaction(messageID, reaction string) error
 }
 
 type chatRepository struct {
@@ -206,4 +223,74 @@ func (r *chatRepository) CountUnread(userID string) (int64, error) {
 func (r *chatRepository) MarkRead(userID, messageID string) error {
 	return r.db.Exec(`UPDATE "chat_message" SET "reads" = array_append("reads", ?) WHERE "id" = ? AND NOT ("reads" @> ARRAY[?]::varchar[])`,
 		userID, messageID, userID).Error
+}
+
+func (r *chatRepository) ListInvitationsByUser(userID string, ignored bool) ([]*model.ChatRoomInvitation, error) {
+	var rows []*model.ChatRoomInvitation
+	if err := r.db.Preload("Room").Where(`"userId" = ? AND "ignored" = ?`, userID, ignored).
+		Order("id DESC").Find(&rows).Error; err != nil {
+		return nil, err
+	}
+	return rows, nil
+}
+
+func (r *chatRepository) ListInvitationsByRoom(roomID string) ([]*model.ChatRoomInvitation, error) {
+	var rows []*model.ChatRoomInvitation
+	if err := r.db.Preload("User").Where(`"roomId" = ?`, roomID).
+		Order("id DESC").Find(&rows).Error; err != nil {
+		return nil, err
+	}
+	return rows, nil
+}
+
+func (r *chatRepository) UpdateDeliveryStatus(messageID string, delivering, failed bool) error {
+	return r.db.Model(&model.ChatMessage{}).Where("id = ?", messageID).
+		Updates(map[string]any{"isDelivering": delivering, "isDeliverFailed": failed}).Error
+}
+
+// ListHistory returns the most recent message per conversation (1-on-1 or
+// room) involving userID. DISTINCT ON で会話ごとの最新 1 件を抽出する。
+func (r *chatRepository) ListHistory(userID string, limit int) ([]*model.ChatMessage, error) {
+	if limit <= 0 {
+		limit = 10
+	}
+	if limit > 100 {
+		limit = 100
+	}
+	// 1対1 (toUserId / fromUserId) とルーム (toRoomId 経由の membership) を UNION
+	// し、会話 key ごとの最新メッセージを取る。
+	var msgs []*model.ChatMessage
+	err := r.db.Raw(`
+		SELECT DISTINCT ON (conversation_key) *
+		FROM (
+			SELECT *, LEAST("fromUserId","toUserId") || '-' || GREATEST("fromUserId","toUserId") AS conversation_key
+			FROM "chat_message"
+			WHERE ("fromUserId" = ? OR "toUserId" = ?) AND "toRoomId" IS NULL
+			UNION ALL
+			SELECT cm.*, 'room:' || cm."toRoomId" AS conversation_key
+			FROM "chat_message" cm
+			JOIN "chat_room_membership" m ON m."roomId" = cm."toRoomId" AND m."userId" = ?
+			WHERE cm."toRoomId" IS NOT NULL
+		) sub
+		ORDER BY conversation_key, id DESC
+	`, userID, userID, userID).Limit(limit).Find(&msgs).Error
+	if err != nil {
+		return nil, err
+	}
+	return msgs, nil
+}
+
+func (r *chatRepository) MarkAllRead(userID string) error {
+	return r.db.Exec(`UPDATE "chat_message" SET "reads" = array_append("reads", ?) WHERE "toUserId" = ? AND NOT ("reads" @> ARRAY[?]::varchar[])`,
+		userID, userID, userID).Error
+}
+
+func (r *chatRepository) AddReaction(messageID, reaction string) error {
+	return r.db.Exec(`UPDATE "chat_message" SET "reactions" = array_append("reactions", ?) WHERE "id" = ?`,
+		reaction, messageID).Error
+}
+
+func (r *chatRepository) RemoveReaction(messageID, reaction string) error {
+	return r.db.Exec(`UPDATE "chat_message" SET "reactions" = array_remove("reactions", ?) WHERE "id" = ?`,
+		reaction, messageID).Error
 }

--- a/internal/repository/chat_approval.go
+++ b/internal/repository/chat_approval.go
@@ -1,0 +1,50 @@
+package repository
+
+import (
+	"github.com/shiroha-a/mk/internal/model"
+	"gorm.io/gorm"
+)
+
+// ChatApprovalRepository manages 1-on-1 chat permission overrides.
+type ChatApprovalRepository interface {
+	Create(a *model.ChatApproval) error
+	Delete(userID, otherID string) error
+	Exists(userID, otherID string) (bool, error)
+	ListByUser(userID string) ([]*model.ChatApproval, error)
+}
+
+type chatApprovalRepository struct {
+	db *gorm.DB
+}
+
+// NewChatApprovalRepository creates a new ChatApprovalRepository.
+func NewChatApprovalRepository(db *gorm.DB) ChatApprovalRepository {
+	return &chatApprovalRepository{db: db}
+}
+
+func (r *chatApprovalRepository) Create(a *model.ChatApproval) error {
+	return r.db.Create(a).Error
+}
+
+func (r *chatApprovalRepository) Delete(userID, otherID string) error {
+	return r.db.Where(`"userId" = ? AND "otherId" = ?`, userID, otherID).
+		Delete(&model.ChatApproval{}).Error
+}
+
+func (r *chatApprovalRepository) Exists(userID, otherID string) (bool, error) {
+	var count int64
+	if err := r.db.Model(&model.ChatApproval{}).
+		Where(`"userId" = ? AND "otherId" = ?`, userID, otherID).
+		Count(&count).Error; err != nil {
+		return false, err
+	}
+	return count > 0, nil
+}
+
+func (r *chatApprovalRepository) ListByUser(userID string) ([]*model.ChatApproval, error) {
+	var rows []*model.ChatApproval
+	if err := r.db.Where(`"userId" = ?`, userID).Find(&rows).Error; err != nil {
+		return nil, err
+	}
+	return rows, nil
+}

--- a/internal/repository/chat_approval_test.go
+++ b/internal/repository/chat_approval_test.go
@@ -1,0 +1,72 @@
+package repository
+
+import (
+	"context"
+	"testing"
+
+	"github.com/shiroha-a/mk/internal/model"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestChatApprovalRepository_CRUD(t *testing.T) {
+	repo := NewChatApprovalRepository(testDB)
+	u1 := insertTestUser(t, "u_ca_1", "causer1")
+	u2 := insertTestUser(t, "u_ca_2", "causer2")
+	u3 := insertTestUser(t, "u_ca_3", "causer3")
+	defer cleanupUser(t, u1.ID)
+	defer cleanupUser(t, u2.ID)
+	defer cleanupUser(t, u3.ID)
+
+	// Exists: initially false
+	exists, err := repo.Exists(u1.ID, u2.ID)
+	require.NoError(t, err)
+	assert.False(t, exists)
+
+	// Create
+	a := &model.ChatApproval{ID: "ca_1", UserID: u1.ID, OtherID: u2.ID}
+	require.NoError(t, repo.Create(a))
+	defer testDB.Exec(`DELETE FROM "chat_approval" WHERE id = ?`, a.ID)
+
+	a2 := &model.ChatApproval{ID: "ca_2", UserID: u1.ID, OtherID: u3.ID}
+	require.NoError(t, repo.Create(a2))
+	defer testDB.Exec(`DELETE FROM "chat_approval" WHERE id = ?`, a2.ID)
+
+	// Exists: now true
+	exists, err = repo.Exists(u1.ID, u2.ID)
+	require.NoError(t, err)
+	assert.True(t, exists)
+
+	// Exists: reverse pair is false
+	exists, err = repo.Exists(u2.ID, u1.ID)
+	require.NoError(t, err)
+	assert.False(t, exists)
+
+	// ListByUser
+	rows, err := repo.ListByUser(u1.ID)
+	require.NoError(t, err)
+	assert.Len(t, rows, 2)
+
+	// Delete
+	require.NoError(t, repo.Delete(u1.ID, u2.ID))
+	exists, err = repo.Exists(u1.ID, u2.ID)
+	require.NoError(t, err)
+	assert.False(t, exists)
+
+	// ListByUser after delete
+	rows, err = repo.ListByUser(u1.ID)
+	require.NoError(t, err)
+	assert.Len(t, rows, 1)
+}
+
+func TestChatApprovalRepository_Errors(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	repo := NewChatApprovalRepository(testDB.WithContext(ctx))
+
+	_, err := repo.Exists("a", "b")
+	assert.Error(t, err)
+
+	_, err = repo.ListByUser("a")
+	assert.Error(t, err)
+}

--- a/internal/repository/chat_test.go
+++ b/internal/repository/chat_test.go
@@ -172,6 +172,173 @@ func TestChatRepository_Membership(t *testing.T) {
 	require.NoError(t, repo.DeleteMembership(user.ID, room.ID))
 }
 
+func TestChatRepository_Reactions(t *testing.T) {
+	repo := NewChatRepository(testDB)
+	user1 := insertTestUser(t, "u_chat_rx1", "chatrx1")
+	user2 := insertTestUser(t, "u_chat_rx2", "chatrx2")
+	defer cleanupUser(t, user1.ID)
+	defer cleanupUser(t, user2.ID)
+
+	msg := &model.ChatMessage{
+		ID: "cm_rx", FromUserID: user1.ID, ToUserID: &user2.ID,
+		Reads: pq.StringArray{}, Reactions: pq.StringArray{},
+	}
+	require.NoError(t, repo.CreateMessage(msg))
+	defer testDB.Exec(`DELETE FROM "chat_message" WHERE id = ?`, msg.ID)
+
+	// AddReaction
+	require.NoError(t, repo.AddReaction(msg.ID, user1.ID+"/👍"))
+	require.NoError(t, repo.AddReaction(msg.ID, user2.ID+"/❤️"))
+
+	found, _ := repo.FindMessageByID(msg.ID)
+	assert.Len(t, found.Reactions, 2)
+
+	// RemoveReaction
+	require.NoError(t, repo.RemoveReaction(msg.ID, user1.ID+"/👍"))
+	found, _ = repo.FindMessageByID(msg.ID)
+	assert.Len(t, found.Reactions, 1)
+}
+
+func TestChatRepository_DeliveryStatus(t *testing.T) {
+	repo := NewChatRepository(testDB)
+	user1 := insertTestUser(t, "u_chat_ds1", "chatds1")
+	user2 := insertTestUser(t, "u_chat_ds2", "chatds2")
+	defer cleanupUser(t, user1.ID)
+	defer cleanupUser(t, user2.ID)
+
+	msg := &model.ChatMessage{
+		ID: "cm_ds", FromUserID: user1.ID, ToUserID: &user2.ID,
+		Reads: pq.StringArray{}, Reactions: pq.StringArray{}, Emojis: pq.StringArray{},
+	}
+	require.NoError(t, repo.CreateMessage(msg))
+	defer testDB.Exec(`DELETE FROM "chat_message" WHERE id = ?`, msg.ID)
+
+	require.NoError(t, repo.UpdateDeliveryStatus(msg.ID, true, false))
+	found, _ := repo.FindMessageByID(msg.ID)
+	assert.True(t, found.IsDelivering)
+	assert.False(t, found.IsDeliverFailed)
+
+	require.NoError(t, repo.UpdateDeliveryStatus(msg.ID, false, true))
+	found, _ = repo.FindMessageByID(msg.ID)
+	assert.False(t, found.IsDelivering)
+	assert.True(t, found.IsDeliverFailed)
+}
+
+func TestChatRepository_MarkAllRead(t *testing.T) {
+	repo := NewChatRepository(testDB)
+	user1 := insertTestUser(t, "u_chat_mr1", "chatmr1")
+	user2 := insertTestUser(t, "u_chat_mr2", "chatmr2")
+	defer cleanupUser(t, user1.ID)
+	defer cleanupUser(t, user2.ID)
+
+	text := "hi"
+	for _, id := range []string{"cm_mr1", "cm_mr2"} {
+		m := &model.ChatMessage{
+			ID: id, FromUserID: user1.ID, ToUserID: &user2.ID, Text: &text,
+			Reads: pq.StringArray{}, Reactions: pq.StringArray{}, Emojis: pq.StringArray{},
+		}
+		require.NoError(t, repo.CreateMessage(m))
+		defer testDB.Exec(`DELETE FROM "chat_message" WHERE id = ?`, id)
+	}
+
+	count, _ := repo.CountUnread(user2.ID)
+	assert.EqualValues(t, 2, count)
+
+	require.NoError(t, repo.MarkAllRead(user2.ID))
+	count, _ = repo.CountUnread(user2.ID)
+	assert.EqualValues(t, 0, count)
+}
+
+func TestChatRepository_ListHistory(t *testing.T) {
+	repo := NewChatRepository(testDB)
+	me := insertTestUser(t, "u_chat_h1", "chath1")
+	other1 := insertTestUser(t, "u_chat_h2", "chath2")
+	other2 := insertTestUser(t, "u_chat_h3", "chath3")
+	defer cleanupUser(t, me.ID)
+	defer cleanupUser(t, other1.ID)
+	defer cleanupUser(t, other2.ID)
+
+	room := &model.ChatRoom{ID: "cr_h1", Name: "HistRoom", OwnerID: me.ID}
+	require.NoError(t, repo.CreateRoom(room))
+	defer testDB.Exec(`DELETE FROM "chat_room" WHERE id = ?`, room.ID)
+	mem := &model.ChatRoomMembership{ID: "mem_h1", UserID: me.ID, RoomID: room.ID}
+	require.NoError(t, repo.CreateMembership(mem))
+	defer testDB.Exec(`DELETE FROM "chat_room_membership" WHERE id = ?`, mem.ID)
+
+	text := "msg"
+	// DM: me -> other1 (2件、最新はcm_h2)
+	for _, id := range []string{"cm_h1", "cm_h2"} {
+		m := &model.ChatMessage{
+			ID: id, FromUserID: me.ID, ToUserID: &other1.ID, Text: &text,
+			Reads: pq.StringArray{}, Reactions: pq.StringArray{}, Emojis: pq.StringArray{},
+		}
+		require.NoError(t, repo.CreateMessage(m))
+		defer testDB.Exec(`DELETE FROM "chat_message" WHERE id = ?`, id)
+	}
+	// DM: me -> other2
+	dm3 := &model.ChatMessage{
+		ID: "cm_h3", FromUserID: me.ID, ToUserID: &other2.ID, Text: &text,
+		Reads: pq.StringArray{}, Reactions: pq.StringArray{}, Emojis: pq.StringArray{},
+	}
+	require.NoError(t, repo.CreateMessage(dm3))
+	defer testDB.Exec(`DELETE FROM "chat_message" WHERE id = ?`, dm3.ID)
+	// ルームメッセージ
+	rm := &model.ChatMessage{
+		ID: "cm_h4", FromUserID: me.ID, ToRoomID: &room.ID, Text: &text,
+		Reads: pq.StringArray{}, Reactions: pq.StringArray{}, Emojis: pq.StringArray{},
+	}
+	require.NoError(t, repo.CreateMessage(rm))
+	defer testDB.Exec(`DELETE FROM "chat_message" WHERE id = ?`, rm.ID)
+
+	// 3会話あるはず: me-other1, me-other2, room:cr_h1
+	hist, err := repo.ListHistory(me.ID, 10)
+	require.NoError(t, err)
+	assert.Len(t, hist, 3)
+	// 最新順: cm_h4 > cm_h3 > cm_h2 (cm_h1はme-other1会話の古い方で除外)
+	assert.Equal(t, "cm_h4", hist[0].ID)
+
+	// limit=1で最新1会話のみ
+	hist1, err := repo.ListHistory(me.ID, 1)
+	require.NoError(t, err)
+	assert.Len(t, hist1, 1)
+
+	// limit=0はデフォルト10
+	histDef, err := repo.ListHistory(me.ID, 0)
+	require.NoError(t, err)
+	assert.Len(t, histDef, 3)
+}
+
+func TestChatRepository_ListInvitationsByUserAndRoom(t *testing.T) {
+	repo := NewChatRepository(testDB)
+	user1 := insertTestUser(t, "u_chat_li1", "chatli1")
+	user2 := insertTestUser(t, "u_chat_li2", "chatli2")
+	defer cleanupUser(t, user1.ID)
+	defer cleanupUser(t, user2.ID)
+
+	room := &model.ChatRoom{ID: "cr_li", Name: "Room", OwnerID: user1.ID}
+	require.NoError(t, repo.CreateRoom(room))
+	defer testDB.Exec(`DELETE FROM "chat_room" WHERE id = ?`, room.ID)
+
+	inv := &model.ChatRoomInvitation{ID: "inv_li1", UserID: user2.ID, RoomID: room.ID}
+	require.NoError(t, repo.CreateInvitation(inv))
+	defer testDB.Exec(`DELETE FROM "chat_room_invitation" WHERE id = ?`, inv.ID)
+
+	// ListInvitationsByUser: ignored=false
+	rows, err := repo.ListInvitationsByUser(user2.ID, false)
+	require.NoError(t, err)
+	assert.Len(t, rows, 1)
+
+	// ignored=trueは0件
+	rows2, err := repo.ListInvitationsByUser(user2.ID, true)
+	require.NoError(t, err)
+	assert.Empty(t, rows2)
+
+	// ListInvitationsByRoom
+	roomInvs, err := repo.ListInvitationsByRoom(room.ID)
+	require.NoError(t, err)
+	assert.Len(t, roomInvs, 1)
+}
+
 func TestChatRepository_Invitation(t *testing.T) {
 	repo := NewChatRepository(testDB)
 	user := insertTestUser(t, "u_chat_5", "chatuser5")

--- a/internal/repository/chat_test.go
+++ b/internal/repository/chat_test.go
@@ -258,12 +258,11 @@ func TestChatRepository_ListHistory(t *testing.T) {
 	defer cleanupUser(t, other1.ID)
 	defer cleanupUser(t, other2.ID)
 
+	// ownerはmembershipレコードなしでも暗黙メンバーとして扱われることを検証する
+	// (明示的なCreateMembershipを入れない)。
 	room := &model.ChatRoom{ID: "cr_h1", Name: "HistRoom", OwnerID: me.ID}
 	require.NoError(t, repo.CreateRoom(room))
 	defer testDB.Exec(`DELETE FROM "chat_room" WHERE id = ?`, room.ID)
-	mem := &model.ChatRoomMembership{ID: "mem_h1", UserID: me.ID, RoomID: room.ID}
-	require.NoError(t, repo.CreateMembership(mem))
-	defer testDB.Exec(`DELETE FROM "chat_room_membership" WHERE id = ?`, mem.ID)
 
 	text := "msg"
 	// DM: me -> other1 (2件、最新はcm_h2)

--- a/internal/repository/user_pending.go
+++ b/internal/repository/user_pending.go
@@ -1,0 +1,39 @@
+package repository
+
+import (
+	"github.com/shiroha-a/mk/internal/model"
+	"gorm.io/gorm"
+)
+
+// UserPendingRepository manages pending user registrations (invite-based
+// signup with email confirmation).
+type UserPendingRepository interface {
+	Create(p *model.UserPending) error
+	FindByCode(code string) (*model.UserPending, error)
+	Delete(id string) error
+}
+
+type userPendingRepository struct {
+	db *gorm.DB
+}
+
+// NewUserPendingRepository creates a new UserPendingRepository.
+func NewUserPendingRepository(db *gorm.DB) UserPendingRepository {
+	return &userPendingRepository{db: db}
+}
+
+func (r *userPendingRepository) Create(p *model.UserPending) error {
+	return r.db.Create(p).Error
+}
+
+func (r *userPendingRepository) FindByCode(code string) (*model.UserPending, error) {
+	var row model.UserPending
+	if err := r.db.Where("code = ?", code).First(&row).Error; err != nil {
+		return nil, err
+	}
+	return &row, nil
+}
+
+func (r *userPendingRepository) Delete(id string) error {
+	return r.db.Where("id = ?", id).Delete(&model.UserPending{}).Error
+}

--- a/internal/repository/user_pending_test.go
+++ b/internal/repository/user_pending_test.go
@@ -1,0 +1,49 @@
+package repository
+
+import (
+	"context"
+	"testing"
+
+	"github.com/shiroha-a/mk/internal/model"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestUserPendingRepository_CRUD(t *testing.T) {
+	repo := NewUserPendingRepository(testDB)
+
+	p := &model.UserPending{
+		ID:       "up_1",
+		Code:     "test_code_abc",
+		Username: "pendinguser",
+		Email:    "pending@example.com",
+		Password: "$2a$10$fakehash",
+	}
+	require.NoError(t, repo.Create(p))
+	defer testDB.Exec(`DELETE FROM "user_pending" WHERE id = ?`, p.ID)
+
+	// FindByCode
+	found, err := repo.FindByCode("test_code_abc")
+	require.NoError(t, err)
+	assert.Equal(t, "up_1", found.ID)
+	assert.Equal(t, "pendinguser", found.Username)
+	assert.Equal(t, "pending@example.com", found.Email)
+
+	// FindByCode: not found
+	_, err = repo.FindByCode("nonexistent")
+	assert.Error(t, err)
+
+	// Delete
+	require.NoError(t, repo.Delete("up_1"))
+	_, err = repo.FindByCode("test_code_abc")
+	assert.Error(t, err)
+}
+
+func TestUserPendingRepository_Errors(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	repo := NewUserPendingRepository(testDB.WithContext(ctx))
+
+	_, err := repo.FindByCode("x")
+	assert.Error(t, err)
+}

--- a/internal/stream/channels/chat_room_test.go
+++ b/internal/stream/channels/chat_room_test.go
@@ -85,6 +85,19 @@ func (r *chatFakeRepo) FindInvitation(_, _ string) (*model.ChatRoomInvitation, e
 }
 func (r *chatFakeRepo) CountUnread(_ string) (int64, error) { return 0, nil }
 func (r *chatFakeRepo) MarkRead(_, _ string) error          { return nil }
+func (r *chatFakeRepo) ListInvitationsByUser(_ string, _ bool) ([]*model.ChatRoomInvitation, error) {
+	return nil, nil
+}
+func (r *chatFakeRepo) ListInvitationsByRoom(_ string) ([]*model.ChatRoomInvitation, error) {
+	return nil, nil
+}
+func (r *chatFakeRepo) UpdateDeliveryStatus(_ string, _, _ bool) error { return nil }
+func (r *chatFakeRepo) ListHistory(_ string, _ int) ([]*model.ChatMessage, error) {
+	return nil, nil
+}
+func (r *chatFakeRepo) MarkAllRead(_ string) error       { return nil }
+func (r *chatFakeRepo) AddReaction(_, _ string) error    { return nil }
+func (r *chatFakeRepo) RemoveReaction(_, _ string) error { return nil }
 
 // --- test helpers ---
 

--- a/migration/000035_chat_approval_pending_federation.down.sql
+++ b/migration/000035_chat_approval_pending_federation.down.sql
@@ -1,0 +1,5 @@
+ALTER TABLE "chat_message" DROP COLUMN IF EXISTS "isDeliverFailed";
+ALTER TABLE "chat_message" DROP COLUMN IF EXISTS "isDelivering";
+ALTER TABLE "chat_message" DROP COLUMN IF EXISTS "emojis";
+DROP TABLE IF EXISTS "user_pending";
+DROP TABLE IF EXISTS "chat_approval";

--- a/migration/000035_chat_approval_pending_federation.up.sql
+++ b/migration/000035_chat_approval_pending_federation.up.sql
@@ -1,0 +1,23 @@
+-- chat_approval: 1対1チャット許可管理 (User.chatScope と組み合わせて使う)
+CREATE TABLE IF NOT EXISTS "chat_approval" (
+    "id" varchar(32) PRIMARY KEY,
+    "userId" varchar(32) NOT NULL REFERENCES "user"("id") ON DELETE CASCADE,
+    "otherId" varchar(32) NOT NULL REFERENCES "user"("id") ON DELETE CASCADE
+);
+CREATE INDEX IF NOT EXISTS "IDX_chat_approval_userId" ON "chat_approval" ("userId");
+CREATE INDEX IF NOT EXISTS "IDX_chat_approval_otherId" ON "chat_approval" ("otherId");
+CREATE UNIQUE INDEX IF NOT EXISTS "IDX_chat_approval_userId_otherId" ON "chat_approval" ("userId", "otherId");
+
+-- user_pending: 登録待機テーブル (招待制登録時のメール確認待ち)
+CREATE TABLE IF NOT EXISTS "user_pending" (
+    "id" varchar(32) PRIMARY KEY,
+    "code" varchar(128) NOT NULL UNIQUE,
+    "username" varchar(128) NOT NULL,
+    "email" varchar(128) NOT NULL,
+    "password" varchar(128) NOT NULL
+);
+
+-- chat_message: CherryPick連合用カラム追加
+ALTER TABLE "chat_message" ADD COLUMN IF NOT EXISTS "emojis" varchar(128)[] NOT NULL DEFAULT '{}';
+ALTER TABLE "chat_message" ADD COLUMN IF NOT EXISTS "isDelivering" boolean NOT NULL DEFAULT false;
+ALTER TABLE "chat_message" ADD COLUMN IF NOT EXISTS "isDeliverFailed" boolean NOT NULL DEFAULT false;


### PR DESCRIPTION
## Summary
Misskey-TS互換のDB構造を維持しつつ、CherryPickの連合用カラムを上乗せする。
P5-1 (#201) の 3 分割のうち第 1 弾 (DB層)。

## 主な変更点

### migration/000035
- **chat_approval** テーブル新設: 1対1チャットの個別許可管理 (userId, otherId, UNIQUE制約)
- **user_pending** テーブル新設: 招待制登録のメール確認待ち (code UNIQUE, username, email, password)
- **chat_message** にCherryPick連合用カラム追加:
  - \`emojis\` varchar(128)[] DEFAULT '{}' — リモートカスタム絵文字
  - \`isDelivering\` boolean DEFAULT false — AP配送中フラグ
  - \`isDeliverFailed\` boolean DEFAULT false — AP配送失敗フラグ
  - 既存Misskey-TS DBからの移行時はDEFAULT値が入るだけでデータ損失なし

### model
- \`ChatApproval\`, \`UserPending\` struct 追加
- \`ChatMessage\` に Emojis/IsDelivering/IsDeliverFailed フィールド追加

### repository
- **ChatApprovalRepository** 新設 (Create/Delete/Exists/ListByUser)
- **UserPendingRepository** 新設 (Create/FindByCode/Delete)
- **ChatRepository** に 7 メソッド追加:
  - ListInvitationsByUser/Room — 招待一覧取得
  - UpdateDeliveryStatus — 配送状態更新 (CherryPick連合用)
  - ListHistory — 会話ごとの最新メッセージ混合取得 (DISTINCT ON)
  - MarkAllRead — 全メッセージ一括既読
  - AddReaction/RemoveReaction — リアクション配列操作

### テスト
- 3ファイルのmock structに no-op stub 7メソッド追加 (インターフェース整合)
- \`go build && go vet\`: クリーン
- \`go test ./internal/api/chat/... ./internal/core/chat/... ./internal/stream/channels/...\`: 全パス

## DB互換性
既存Misskey-TS DBテーブル構造を完全に包含。CherryPickの3カラムは純粋な追加 (DEFAULT値付き) のため、TS→Go移行でデータ損失なし。

## 後続PR
- P5-1b: 未ルート登録12件 + stub本実装 + chatScope承認フロー
- P5-1c: AP連合 (Misskey:ChatMessage送受信 + 配送状態管理)

Closes #201 (部分: DB層のみ)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/shiroha-a/mk/pull/212" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
