### PR TITLE
P5-1c: AP連合 Misskey:ChatMessage 送受信 (CherryPickベース)

### DIFF
--- a/internal/activitypub/renderer.go
+++ b/internal/activitypub/renderer.go
@@ -97,6 +97,11 @@ func (b *URLBuilder) MoveURI(srcID, dstURI string) string {
 	return b.baseURL + "/moves/" + srcID + "/" + hex.EncodeToString(h[:16])
 }
 
+// ChatMessageURI returns the canonical URI for a chat message.
+func (b *URLBuilder) ChatMessageURI(messageID string) string {
+	return b.baseURL + "/chat-messages/" + messageID
+}
+
 // MentionResolver resolves a note.Mentions entry (user ID) into the data
 // required to build an AS Mention tag. 実装は server/router.go 側で
 // UserRepository を wrap する形で提供される。解決に失敗したら ok=false を
@@ -635,6 +640,25 @@ func (r *Renderer) RenderMove(src *model.User, dstURI string) *Move {
 	}
 	AddContext(m)
 	return m
+}
+
+// RenderChatMessage returns a CherryPick-compatible Misskey:ChatMessage
+// activity for 1-on-1 DM federation. Only used when the recipient is a remote
+// user. The activity type is `Misskey:ChatMessage` (not a standard AS type).
+func (r *Renderer) RenderChatMessage(msg *model.ChatMessage, senderURI, recipientURI string) *ChatMessageActivity {
+	cm := &ChatMessageActivity{
+		Object: Object{
+			ID:   r.urls.ChatMessageURI(msg.ID),
+			Type: "Misskey:ChatMessage",
+		},
+		AttributedTo: senderURI,
+		To:           recipientURI,
+	}
+	if msg.Text != nil {
+		cm.Content = *msg.Text
+	}
+	AddContext(cm)
+	return cm
 }
 
 // addressing computes to/cc lists for a note based on visibility.

--- a/internal/activitypub/renderer.go
+++ b/internal/activitypub/renderer.go
@@ -651,6 +651,7 @@ func (r *Renderer) RenderChatMessage(msg *model.ChatMessage, senderURI, recipien
 			ID:   r.urls.ChatMessageURI(msg.ID),
 			Type: "Misskey:ChatMessage",
 		},
+		Actor:        senderURI,
 		AttributedTo: senderURI,
 		To:           recipientURI,
 	}

--- a/internal/activitypub/types.go
+++ b/internal/activitypub/types.go
@@ -274,6 +274,17 @@ type Move struct {
 	Target string `json:"target"`
 }
 
+// ChatMessageActivity represents a CherryPick-compatible `Misskey:ChatMessage`
+// activity used for 1-on-1 DM federation with Misskey v12 and compatible forks.
+type ChatMessageActivity struct {
+	Object
+	AttributedTo string `json:"attributedTo"`
+	To           string `json:"to"`
+	Content      string `json:"content,omitempty"`
+	Tag          []any  `json:"tag,omitempty"`
+	Attachment   []any  `json:"attachment,omitempty"`
+}
+
 // MisskeyContext は Misskey/Mastodon/schema.org 拡張語彙を含むコンテキストオブジェクト。
 // TS版 contexts.ts と同等。
 var MisskeyContext = map[string]any{
@@ -341,6 +352,8 @@ func AddContext(o any) {
 	case *Flag:
 		v.Context = ctx
 	case *Move:
+		v.Context = ctx
+	case *ChatMessageActivity:
 		v.Context = ctx
 	}
 }

--- a/internal/activitypub/types.go
+++ b/internal/activitypub/types.go
@@ -276,8 +276,11 @@ type Move struct {
 
 // ChatMessageActivity represents a CherryPick-compatible `Misskey:ChatMessage`
 // activity used for 1-on-1 DM federation with Misskey v12 and compatible forks.
+// ActivityではなくObjectを埋め込みつつ、Actorを独立フィールドで持つ。
+// To はCherryPick互換のため string (配列ではない)。
 type ChatMessageActivity struct {
 	Object
+	Actor        string `json:"actor"`
 	AttributedTo string `json:"attributedTo"`
 	To           string `json:"to"`
 	Content      string `json:"content,omitempty"`

--- a/internal/api/chat/handler_test.go
+++ b/internal/api/chat/handler_test.go
@@ -2,6 +2,7 @@ package chat
 
 import (
 	"encoding/json"
+	"errors"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -143,6 +144,9 @@ func (m *mockChatRepo) MarkAllRead(_ string) error                         { ret
 func (m *mockChatRepo) AddReaction(_, _ string) error                      { return nil }
 func (m *mockChatRepo) RemoveReaction(_, _ string) error                   { return nil }
 func (m *mockChatRepo) UpdateInvitation(_ *model.ChatRoomInvitation) error { return nil }
+func (m *mockChatRepo) FindMessageByURI(_ string) (*model.ChatMessage, error) {
+	return nil, errors.New("not found")
+}
 
 func newTestHandler() (*Handler, *mockChatRepo) {
 	repo := newMock()

--- a/internal/core/chat/ap_delivery_test.go
+++ b/internal/core/chat/ap_delivery_test.go
@@ -1,0 +1,106 @@
+package chat_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/shiroha-a/mk/internal/activitypub"
+	corechat "github.com/shiroha-a/mk/internal/core/chat"
+	"github.com/shiroha-a/mk/internal/misc/id"
+	"github.com/shiroha-a/mk/internal/model"
+	"github.com/shiroha-a/mk/internal/testutil"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type fakeAPDeliverer struct {
+	called    int
+	lastBody  []byte
+	returnErr error
+}
+
+func (f *fakeAPDeliverer) DeliverToUser(_ string, _ *model.User, body []byte) error {
+	f.called++
+	f.lastBody = body
+	return f.returnErr
+}
+
+func newAPService(t *testing.T) (*corechat.Service, *testutil.MockUserRepository, *fakeAPDeliverer) {
+	t.Helper()
+	chatRepo := newFakeRepo()
+	idGen, _ := id.NewGenerator("aidx")
+	svc := corechat.NewService(chatRepo, idGen)
+	userRepo := testutil.NewMockUserRepository()
+	urls := activitypub.NewURLBuilder("https://local.example")
+	renderer := activitypub.NewRenderer(urls)
+	deliverer := &fakeAPDeliverer{}
+	svc.SetAPDelivery(userRepo, renderer, urls, deliverer)
+	return svc, userRepo, deliverer
+}
+
+func TestCreateMessageToUser_DeliversToRemoteUser(t *testing.T) {
+	svc, userRepo, deliverer := newAPService(t)
+	remoteHost := "remote.example"
+	remoteURI := "https://remote.example/users/bob"
+	userRepo.Users["alice"] = &model.User{ID: "alice", Username: "alice"}
+	userRepo.Users["bob"] = &model.User{ID: "bob", Username: "bob", Host: &remoteHost, URI: &remoteURI}
+
+	msg, err := svc.CreateMessageToUser(context.Background(), "alice", "bob", "hello remote", "")
+	require.NoError(t, err)
+	require.NotNil(t, msg)
+	assert.Equal(t, 1, deliverer.called)
+	assert.Contains(t, string(deliverer.lastBody), "Misskey:ChatMessage")
+	assert.Contains(t, string(deliverer.lastBody), "hello remote")
+}
+
+func TestCreateMessageToUser_SkipsLocalRecipient(t *testing.T) {
+	svc, userRepo, deliverer := newAPService(t)
+	userRepo.Users["alice"] = &model.User{ID: "alice", Username: "alice"}
+	userRepo.Users["bob"] = &model.User{ID: "bob", Username: "bob"}
+
+	_, err := svc.CreateMessageToUser(context.Background(), "alice", "bob", "local msg", "")
+	require.NoError(t, err)
+	assert.Equal(t, 0, deliverer.called)
+}
+
+func TestCreateMessageToUser_DeliveryFailureIsSwallowed(t *testing.T) {
+	svc, userRepo, deliverer := newAPService(t)
+	deliverer.returnErr = assert.AnError
+	remoteHost := "remote.example"
+	remoteURI := "https://remote.example/users/bob"
+	userRepo.Users["alice"] = &model.User{ID: "alice", Username: "alice"}
+	userRepo.Users["bob"] = &model.User{ID: "bob", Username: "bob", Host: &remoteHost, URI: &remoteURI}
+
+	msg, err := svc.CreateMessageToUser(context.Background(), "alice", "bob", "hi", "")
+	require.NoError(t, err, "delivery failure must not propagate")
+	require.NotNil(t, msg)
+	assert.Equal(t, 1, deliverer.called)
+}
+
+func TestCreateMessageViaAP(t *testing.T) {
+	chatRepo := newFakeRepo()
+	idGen, _ := id.NewGenerator("aidx")
+	svc := corechat.NewService(chatRepo, idGen)
+	sender := &model.User{ID: "remote1", Username: "remote1"}
+
+	msg, err := svc.CreateMessageViaAP(context.Background(), "https://remote.example/chat-messages/1", sender, "local1", "hello from remote")
+	require.NoError(t, err)
+	require.NotNil(t, msg)
+	assert.Equal(t, "remote1", msg.FromUserID)
+	require.NotNil(t, msg.ToUserID)
+	assert.Equal(t, "local1", *msg.ToUserID)
+	require.NotNil(t, msg.URI)
+	assert.Equal(t, "https://remote.example/chat-messages/1", *msg.URI)
+}
+
+func TestCreateMessageViaAP_InvalidTarget(t *testing.T) {
+	chatRepo := newFakeRepo()
+	idGen, _ := id.NewGenerator("aidx")
+	svc := corechat.NewService(chatRepo, idGen)
+
+	_, err := svc.CreateMessageViaAP(context.Background(), "", nil, "local1", "hi")
+	assert.Error(t, err)
+
+	_, err = svc.CreateMessageViaAP(context.Background(), "", &model.User{ID: "x"}, "", "hi")
+	assert.Error(t, err)
+}

--- a/internal/core/chat/service.go
+++ b/internal/core/chat/service.go
@@ -9,10 +9,13 @@ package chat
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
+	"log/slog"
 	"time"
 
+	"github.com/shiroha-a/mk/internal/activitypub"
 	"github.com/shiroha-a/mk/internal/misc/id"
 	"github.com/shiroha-a/mk/internal/model"
 	"github.com/shiroha-a/mk/internal/repository"
@@ -42,6 +45,12 @@ type StreamingPublisher interface {
 	PublishRoomMessage(ctx context.Context, roomID, eventType string, body any)
 }
 
+// APDeliverer delivers a pre-rendered activity body to a single remote user's
+// inbox. Implemented by federation.DeliverService.DeliverToUser.
+type APDeliverer interface {
+	DeliverToUser(signerUserID string, recipient *model.User, body []byte) error
+}
+
 // Event types mirrored by the WebSocket channel. 本家と同名。
 const (
 	EventMessage = "message"
@@ -55,6 +64,10 @@ type Service struct {
 	repo      repository.ChatRepository
 	idGen     id.Generator
 	publisher StreamingPublisher
+	userRepo  repository.UserRepository
+	renderer  *activitypub.Renderer
+	urls      *activitypub.URLBuilder
+	deliverer APDeliverer
 }
 
 // NewService constructs a chat Service.
@@ -67,6 +80,15 @@ func NewService(repo repository.ChatRepository, idGen id.Generator) *Service {
 // DB 処理は変わらない)。
 func (s *Service) SetStreamingPublisher(p StreamingPublisher) {
 	s.publisher = p
+}
+
+// SetAPDelivery wires the AP federation layer for chat message delivery to
+// remote users. All parameters are required; pass nil to disable federation.
+func (s *Service) SetAPDelivery(userRepo repository.UserRepository, renderer *activitypub.Renderer, urls *activitypub.URLBuilder, deliverer APDeliverer) {
+	s.userRepo = userRepo
+	s.renderer = renderer
+	s.urls = urls
+	s.deliverer = deliverer
 }
 
 // --- Message lifecycle ---
@@ -94,6 +116,73 @@ func (s *Service) CreateMessageToUser(ctx context.Context, fromUserID, toUserID,
 	}
 	if s.publisher != nil {
 		s.publisher.PublishUserMessage(ctx, fromUserID, toUserID, EventMessage, packMessage(msg))
+	}
+	// リモートユーザー宛ならAP配送 (best-effort)
+	s.tryDeliverToRemoteUser(msg, fromUserID, toUserID)
+	return msg, nil
+}
+
+// tryDeliverToRemoteUser attempts AP delivery for a 1-on-1 chat message when
+// the recipient is a remote user. Errors are logged and swallowed (DB commit
+// is already done).
+func (s *Service) tryDeliverToRemoteUser(msg *model.ChatMessage, fromUserID, toUserID string) {
+	if s.deliverer == nil || s.userRepo == nil || s.renderer == nil {
+		return
+	}
+	recipient, err := s.userRepo.FindByID(toUserID)
+	if err != nil || recipient.IsLocal() {
+		return
+	}
+	sender, err := s.userRepo.FindByID(fromUserID)
+	if err != nil || !sender.IsLocal() {
+		return
+	}
+	senderURI := s.urls.UserURI(sender.ID)
+	recipientURI := ""
+	if recipient.URI != nil {
+		recipientURI = *recipient.URI
+	}
+	if recipientURI == "" {
+		return
+	}
+	_ = s.repo.UpdateDeliveryStatus(msg.ID, true, false)
+	cm := s.renderer.RenderChatMessage(msg, senderURI, recipientURI)
+	body, err := json.Marshal(cm)
+	if err != nil {
+		_ = s.repo.UpdateDeliveryStatus(msg.ID, false, true)
+		slog.Warn("chat: failed to marshal ChatMessage activity", "msgID", msg.ID, "err", err)
+		return
+	}
+	if err := s.deliverer.DeliverToUser(sender.ID, recipient, body); err != nil {
+		_ = s.repo.UpdateDeliveryStatus(msg.ID, false, true)
+		slog.Warn("chat: failed to deliver ChatMessage to remote user", "msgID", msg.ID, "err", err)
+		return
+	}
+	_ = s.repo.UpdateDeliveryStatus(msg.ID, false, false)
+}
+
+// CreateMessageViaAP persists a chat message received via ActivityPub from a
+// remote user. The uri parameter is the activity's canonical ID.
+func (s *Service) CreateMessageViaAP(ctx context.Context, uri string, fromUser *model.User, toUserID, text string) (*model.ChatMessage, error) {
+	if fromUser == nil || toUserID == "" {
+		return nil, ErrInvalidTarget
+	}
+	msg := &model.ChatMessage{
+		ID:         s.idGen.Generate(time.Now()),
+		FromUserID: fromUser.ID,
+		ToUserID:   &toUserID,
+	}
+	if text != "" {
+		msg.Text = &text
+	}
+	if uri != "" {
+		msg.URI = &uri
+	}
+	if err := s.repo.CreateMessage(msg); err != nil {
+		return nil, fmt.Errorf("create AP message: %w", err)
+	}
+	if s.publisher != nil {
+		s.publisher.PublishUserMessage(ctx, fromUser.ID, toUserID, EventMessage, packMessage(msg))
 	}
 	return msg, nil
 }

--- a/internal/core/chat/service.go
+++ b/internal/core/chat/service.go
@@ -126,7 +126,7 @@ func (s *Service) CreateMessageToUser(ctx context.Context, fromUserID, toUserID,
 // the recipient is a remote user. Errors are logged and swallowed (DB commit
 // is already done).
 func (s *Service) tryDeliverToRemoteUser(msg *model.ChatMessage, fromUserID, toUserID string) {
-	if s.deliverer == nil || s.userRepo == nil || s.renderer == nil {
+	if s.deliverer == nil || s.userRepo == nil || s.renderer == nil || s.urls == nil {
 		return
 	}
 	recipient, err := s.userRepo.FindByID(toUserID)
@@ -162,10 +162,17 @@ func (s *Service) tryDeliverToRemoteUser(msg *model.ChatMessage, fromUserID, toU
 }
 
 // CreateMessageViaAP persists a chat message received via ActivityPub from a
-// remote user. The uri parameter is the activity's canonical ID.
+// remote user. The uri parameter is the activity's canonical ID. AP retries
+// are common so URI-based dedup is performed (IngestNote と同じパターン).
 func (s *Service) CreateMessageViaAP(ctx context.Context, uri string, fromUser *model.User, toUserID, text string) (*model.ChatMessage, error) {
 	if fromUser == nil || toUserID == "" {
 		return nil, ErrInvalidTarget
+	}
+	// AP retry による重複メッセージ作成を防ぐ
+	if uri != "" {
+		if existing, err := s.repo.FindMessageByURI(uri); err == nil {
+			return existing, nil
+		}
 	}
 	msg := &model.ChatMessage{
 		ID:         s.idGen.Generate(time.Now()),

--- a/internal/core/chat/service_test.go
+++ b/internal/core/chat/service_test.go
@@ -148,6 +148,9 @@ func (r *fakeChatRepo) MarkAllRead(_ string) error                         { ret
 func (r *fakeChatRepo) AddReaction(_, _ string) error                      { return nil }
 func (r *fakeChatRepo) RemoveReaction(_, _ string) error                   { return nil }
 func (r *fakeChatRepo) UpdateInvitation(_ *model.ChatRoomInvitation) error { return nil }
+func (r *fakeChatRepo) FindMessageByURI(_ string) (*model.ChatMessage, error) {
+	return nil, errors.New("not found")
+}
 
 // --- capture publisher ---
 

--- a/internal/core/federation/processor.go
+++ b/internal/core/federation/processor.go
@@ -933,12 +933,16 @@ func (p *Processor) handleChatMessage(act genericActivity) error {
 	if err != nil {
 		return fmt.Errorf("chat message: resolve sender: %w", err)
 	}
-	// to (受信者) をローカルユーザーとして検索
+	// ローカルユーザーはDB上URI==nilのためFindByURIでは解決できない。
+	// handleAcceptと同じパターンでExtractLocalUserID→FindByIDにフォールバック。
 	recipient, err := p.userRepo.FindByURI(raw.To)
 	if err != nil {
-		// URI で見つからない場合 ID で試す (ローカルユーザーの URI は
-		// /users/{id} 形式のため直接 FindByID でも解決できる)
-		return fmt.Errorf("chat message: resolve recipient: %w", err)
+		if localID := p.resolver.ExtractLocalUserID(raw.To); localID != "" {
+			recipient, err = p.userRepo.FindByID(localID)
+		}
+		if err != nil {
+			return fmt.Errorf("chat message: resolve recipient: %w", err)
+		}
 	}
 	if !recipient.IsLocal() {
 		return fmt.Errorf("chat message: recipient %s is not local", raw.To)

--- a/internal/core/federation/processor.go
+++ b/internal/core/federation/processor.go
@@ -65,6 +65,14 @@ type Processor struct {
 
 	// Relay follow-accept / -reject hook. nil 時は relay 特化処理をスキップ。
 	relayMarker RelayStatusMarker
+
+	// Chat federation (CherryPick互換)
+	chatService ChatMessageReceiver
+}
+
+// ChatMessageReceiver handles inbound Misskey:ChatMessage activities.
+type ChatMessageReceiver interface {
+	CreateMessageViaAP(ctx context.Context, uri string, fromUser *model.User, toUserID, text string) (*model.ChatMessage, error)
 }
 
 // NewProcessor constructs a Processor. reactionService / noteDeleteSvc は省略
@@ -165,6 +173,8 @@ func (p *Processor) Process(body []byte) error {
 		return p.handleReversiJoin(act)
 	case "leave":
 		return p.handleReversiLeave(act)
+	case "misskey:chatmessage":
+		return p.handleChatMessage(act)
 	}
 	return ErrUnsupportedActivity
 }
@@ -191,6 +201,12 @@ func (p *Processor) SetPinningRepo(repo repository.UserNotePiningRepository, idG
 // the corresponding relay row to accepted / rejected.
 func (p *Processor) SetRelayMarker(m RelayStatusMarker) {
 	p.relayMarker = m
+}
+
+// SetChatService wires a ChatMessageReceiver for inbound Misskey:ChatMessage
+// activities (CherryPick v12 federation).
+func (p *Processor) SetChatService(svc ChatMessageReceiver) {
+	p.chatService = svc
 }
 
 // followRelayIDPattern extracts the relay id embedded in
@@ -888,4 +904,45 @@ func readActorString(act genericActivity) (string, error) {
 		return act.Actor, nil
 	}
 	return "", errors.New("inner activity missing actor")
+}
+
+// handleChatMessage processes an inbound Misskey:ChatMessage activity
+// (CherryPick v12 federation). The activity itself IS the message object
+// (not wrapped in Create), so act.ID is the message URI.
+func (p *Processor) handleChatMessage(act genericActivity) error {
+	if p.chatService == nil {
+		return ErrUnsupportedActivity
+	}
+	// attributedTo と actor の一致を検証
+	var raw struct {
+		AttributedTo string `json:"attributedTo"`
+		To           string `json:"to"`
+		Content      string `json:"content"`
+	}
+	if err := json.Unmarshal(act.raw, &raw); err != nil {
+		return fmt.Errorf("chat message: unmarshal: %w", err)
+	}
+	if raw.AttributedTo == "" || raw.AttributedTo != act.Actor {
+		return fmt.Errorf("chat message: attributedTo (%s) != actor (%s)", raw.AttributedTo, act.Actor)
+	}
+	if raw.To == "" {
+		return fmt.Errorf("chat message: missing 'to' field")
+	}
+	// actor (送信者) を解決
+	sender, err := p.resolver.ResolveActor(act.Actor)
+	if err != nil {
+		return fmt.Errorf("chat message: resolve sender: %w", err)
+	}
+	// to (受信者) をローカルユーザーとして検索
+	recipient, err := p.userRepo.FindByURI(raw.To)
+	if err != nil {
+		// URI で見つからない場合 ID で試す (ローカルユーザーの URI は
+		// /users/{id} 形式のため直接 FindByID でも解決できる)
+		return fmt.Errorf("chat message: resolve recipient: %w", err)
+	}
+	if !recipient.IsLocal() {
+		return fmt.Errorf("chat message: recipient %s is not local", raw.To)
+	}
+	_, err = p.chatService.CreateMessageViaAP(context.Background(), act.ID, sender, recipient.ID, raw.Content)
+	return err
 }

--- a/internal/core/federation/processor_test.go
+++ b/internal/core/federation/processor_test.go
@@ -986,3 +986,94 @@ func TestProcess_AcceptNonRelay_IgnoresMarker(t *testing.T) {
 	// relay marker は呼ばれない
 	assert.Empty(t, marker.accepted)
 }
+
+// --- Chat federation (Misskey:ChatMessage) ---
+
+type stubChatReceiver struct {
+	called    int
+	lastURI   string
+	lastFrom  *model.User
+	lastTo    string
+	lastText  string
+	returnErr error
+}
+
+func (s *stubChatReceiver) CreateMessageViaAP(_ context.Context, uri string, fromUser *model.User, toUserID, text string) (*model.ChatMessage, error) {
+	s.called++
+	s.lastURI = uri
+	s.lastFrom = fromUser
+	s.lastTo = toUserID
+	s.lastText = text
+	if s.returnErr != nil {
+		return nil, s.returnErr
+	}
+	return &model.ChatMessage{ID: "cm_ap_1"}, nil
+}
+
+func TestProcess_ChatMessage_HappyPath(t *testing.T) {
+	p, repo, _, _ := newProcessor(t, aliceActor)
+	bobURI := "https://example.com/users/bob"
+	repo.Users["bob"] = &model.User{ID: "bob", Username: "bob", URI: &bobURI}
+	chatSvc := &stubChatReceiver{}
+	p.SetChatService(chatSvc)
+
+	body := []byte(`{
+		"id": "https://remote.example/chat-messages/1",
+		"type": "Misskey:ChatMessage",
+		"actor": "https://remote.example/users/alice",
+		"attributedTo": "https://remote.example/users/alice",
+		"to": "https://example.com/users/bob",
+		"content": "hello via AP"
+	}`)
+	require.NoError(t, p.Process(body))
+	assert.Equal(t, 1, chatSvc.called)
+	assert.Equal(t, "https://remote.example/chat-messages/1", chatSvc.lastURI)
+	assert.Equal(t, "bob", chatSvc.lastTo)
+	assert.Equal(t, "hello via AP", chatSvc.lastText)
+}
+
+func TestProcess_ChatMessage_NoChatService(t *testing.T) {
+	p, _, _, _ := newProcessor(t, aliceActor)
+	body := []byte(`{
+		"id": "https://remote.example/chat-messages/2",
+		"type": "Misskey:ChatMessage",
+		"actor": "https://remote.example/users/alice",
+		"attributedTo": "https://remote.example/users/alice",
+		"to": "https://example.com/users/bob",
+		"content": "hi"
+	}`)
+	err := p.Process(body)
+	assert.ErrorIs(t, err, federation.ErrUnsupportedActivity)
+}
+
+func TestProcess_ChatMessage_ActorMismatch(t *testing.T) {
+	p, _, _, _ := newProcessor(t, aliceActor)
+	chatSvc := &stubChatReceiver{}
+	p.SetChatService(chatSvc)
+	body := []byte(`{
+		"id": "https://remote.example/chat-messages/3",
+		"type": "Misskey:ChatMessage",
+		"actor": "https://remote.example/users/alice",
+		"attributedTo": "https://remote.example/users/mallory",
+		"to": "https://example.com/users/bob",
+		"content": "spoof"
+	}`)
+	err := p.Process(body)
+	assert.Error(t, err)
+	assert.Equal(t, 0, chatSvc.called)
+}
+
+func TestProcess_ChatMessage_MissingTo(t *testing.T) {
+	p, _, _, _ := newProcessor(t, aliceActor)
+	chatSvc := &stubChatReceiver{}
+	p.SetChatService(chatSvc)
+	body := []byte(`{
+		"id": "https://remote.example/chat-messages/4",
+		"type": "Misskey:ChatMessage",
+		"actor": "https://remote.example/users/alice",
+		"attributedTo": "https://remote.example/users/alice",
+		"content": "no to"
+	}`)
+	err := p.Process(body)
+	assert.Error(t, err)
+}

--- a/internal/core/federation/processor_test.go
+++ b/internal/core/federation/processor_test.go
@@ -1012,8 +1012,8 @@ func (s *stubChatReceiver) CreateMessageViaAP(_ context.Context, uri string, fro
 
 func TestProcess_ChatMessage_HappyPath(t *testing.T) {
 	p, repo, _, _ := newProcessor(t, aliceActor)
-	bobURI := "https://example.com/users/bob"
-	repo.Users["bob"] = &model.User{ID: "bob", Username: "bob", URI: &bobURI}
+	// ローカルユーザーはURI==nil (本番と同じ)。ExtractLocalUserID→FindByIDで解決。
+	repo.Users["bob"] = &model.User{ID: "bob", Username: "bob"}
 	chatSvc := &stubChatReceiver{}
 	p.SetChatService(chatSvc)
 

--- a/internal/repository/chat.go
+++ b/internal/repository/chat.go
@@ -18,6 +18,7 @@ type ChatRepository interface {
 	// Message operations
 	CreateMessage(msg *model.ChatMessage) error
 	FindMessageByID(id string) (*model.ChatMessage, error)
+	FindMessageByURI(uri string) (*model.ChatMessage, error)
 	UpdateMessage(msg *model.ChatMessage) error
 	DeleteMessage(id string) error
 	ListMessagesByRoom(roomID string, limit int) ([]*model.ChatMessage, error)
@@ -116,6 +117,14 @@ func (r *chatRepository) CreateMessage(msg *model.ChatMessage) error {
 func (r *chatRepository) FindMessageByID(id string) (*model.ChatMessage, error) {
 	var msg model.ChatMessage
 	if err := r.db.Preload("FromUser").Where(`"id" = ?`, id).First(&msg).Error; err != nil {
+		return nil, err
+	}
+	return &msg, nil
+}
+
+func (r *chatRepository) FindMessageByURI(uri string) (*model.ChatMessage, error) {
+	var msg model.ChatMessage
+	if err := r.db.Preload("FromUser").Where(`"uri" = ?`, uri).First(&msg).Error; err != nil {
 		return nil, err
 	}
 	return &msg, nil

--- a/internal/server/router.go
+++ b/internal/server/router.go
@@ -1192,6 +1192,8 @@ func (s *Server) setupRoutes() {
 	chatPublisher := stream.NewChatPublisher(streamPubSub)
 	chatService := corechat.NewService(chatRepo, idGen)
 	chatService.SetStreamingPublisher(chatPublisher)
+	// CherryPick互換AP連合: リモートユーザー宛DMをMisskey:ChatMessageで配送
+	chatService.SetAPDelivery(userRepo, apRenderer, apURLs, deliverService)
 	streamRegistry.Register("chatRoom", channels.NewChatRoomFactory(chatService).New)
 	streamRegistry.Register("chatUser", channels.NewChatUserFactory(chatService).New)
 	// Phase 9.7: federation processor / reversi handler に reversi 依存を注入。
@@ -1204,6 +1206,7 @@ func (s *Server) setupRoutes() {
 	federationProcessor.SetAbuseReportRepo(repository.NewAbuseReportRepository(s.db), idGen)
 	federationProcessor.SetPinningRepo(piningRepo, idGen)
 	federationProcessor.SetRelayMarker(relaySvc)
+	federationProcessor.SetChatService(chatService)
 
 	// 5. /streaming エンドポイント配線
 	streamingHandler := streaming.NewHandler(streamManager)

--- a/internal/stream/channels/chat_room_test.go
+++ b/internal/stream/channels/chat_room_test.go
@@ -99,6 +99,9 @@ func (r *chatFakeRepo) MarkAllRead(_ string) error                         { ret
 func (r *chatFakeRepo) AddReaction(_, _ string) error                      { return nil }
 func (r *chatFakeRepo) RemoveReaction(_, _ string) error                   { return nil }
 func (r *chatFakeRepo) UpdateInvitation(_ *model.ChatRoomInvitation) error { return nil }
+func (r *chatFakeRepo) FindMessageByURI(_ string) (*model.ChatMessage, error) {
+	return nil, errors.New("not found")
+}
 
 // --- test helpers ---
 


### PR DESCRIPTION
## Summary
CherryPick互換のAP連合チャット機能を実装。リモートユーザー宛の1対1DMを
\`Misskey:ChatMessage\` activity type で inbox 配送し、受信側は processor で
メッセージを永続化 + WebSocket 配信する。P5-1 (#201) の最終弾。

## 主な変更点

### activitypub 層
- \`ChatMessageActivity\` 型追加 (\`type: Misskey:ChatMessage\`)
- \`URLBuilder.ChatMessageURI(messageID)\`: \`/chat-messages/{id}\` パス
- \`Renderer.RenderChatMessage(msg, senderURI, recipientURI)\`: attributedTo/to/content を生成
- \`AddContext\` に \`*ChatMessageActivity\` ケース追加

### core/chat (送信)
- \`APDeliverer\` interface + \`SetAPDelivery()\` で federation 層を narrow interface 経由で注入
- \`CreateMessageToUser\` でリモート宛の場合 \`tryDeliverToRemoteUser\` を呼ぶ
- \`isDelivering\` → true → 配送成功で false、失敗で \`isDeliverFailed\` = true
- 配送失敗は \`slog.Warn\` で握り潰し (DB commit 済みなので best-effort)

### core/chat (受信)
- \`CreateMessageViaAP(uri, fromUser, toUserID, text)\`: AP 経由メッセージの永続化 + WebSocket 配信

### core/federation (inbox)
- \`ChatMessageReceiver\` interface + \`SetChatService()\`
- \`processor.Process\` に \`"misskey:chatmessage"\` case 追加
- \`handleChatMessage\`: attributedTo/actor 一致検証、\`to\` でローカル受信者解決

### wiring (router.go)
- \`chatService.SetAPDelivery(userRepo, apRenderer, apURLs, deliverService)\`
- \`federationProcessor.SetChatService(chatService)\`

## テスト
- \`internal/core/chat/ap_delivery_test.go\`: リモート宛配送 / ローカルスキップ / 配送失敗握り潰し / ViaAP 成功 / ViaAP invalid target
- \`internal/core/federation/processor_test.go\`: ChatMessage happy path / NoChatService / ActorMismatch / MissingTo
- \`core/chat\` coverage: 93.5%
- \`make fmt && make lint\`: クリーン

## Closes
Closes #201

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/shiroha-a/mk/pull/214" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
