### PR TITLE
P5-3: AP asPoll render (oneOf/anyOf/endTime/closed) + Question送信

### DIFF
--- a/internal/activitypub/renderer.go
+++ b/internal/activitypub/renderer.go
@@ -131,6 +131,12 @@ type NoteResolver interface {
 	FindByID(id string) (*model.Note, error)
 }
 
+// PollResolver loads a poll by its parent note ID. Used by RenderNote to
+// populate Question fields (oneOf/anyOf/endTime/closed).
+type PollResolver interface {
+	FindByNoteID(noteID string) (*model.Poll, error)
+}
+
 // actorTypeForUser returns the AP actor `type` to emit for a local user.
 // 現状: IsBot=true なら Service、それ以外は Person。Application (system actor)
 // 出力は将来のシステムアカウント機能で別経路を追加する想定。
@@ -148,6 +154,7 @@ type Renderer struct {
 	fileResolver    FileResolver
 	emojiResolver   EmojiResolver
 	noteResolver    NoteResolver
+	pollResolver    PollResolver
 	host            string // ローカルホスト名 (MFM変換用)
 }
 
@@ -165,6 +172,11 @@ func (r *Renderer) SetMentionResolver(mr MentionResolver) {
 // SetFileResolver attaches a FileResolver for Note attachment rendering.
 func (r *Renderer) SetFileResolver(fr FileResolver) {
 	r.fileResolver = fr
+}
+
+// SetPollResolver attaches a PollResolver for Question (poll) rendering.
+func (r *Renderer) SetPollResolver(pr PollResolver) {
+	r.pollResolver = pr
 }
 
 // SetEmojiResolver attaches an EmojiResolver for custom emoji tags.
@@ -369,8 +381,51 @@ func (r *Renderer) RenderNote(n *model.Note, idGen id.Generator) *Note {
 	out.To = to
 	out.CC = cc
 
+	// Poll (Question) の asPoll レンダリング。HasPoll が true かつ pollResolver
+	// が設定されている場合、Note type を "Question" に変更し、選択肢を oneOf/anyOf
+	// として出力する。upstream renderNote の asPoll 部分と同等。
+	if n.HasPoll && r.pollResolver != nil {
+		if poll, err := r.pollResolver.FindByNoteID(n.ID); err == nil {
+			r.applyPoll(out, poll)
+		}
+	}
+
 	AddContext(out)
 	return out
+}
+
+// applyPoll converts a Note into a Question by changing the type and populating
+// oneOf (single choice) or anyOf (multiple choice) + endTime/closed fields.
+func (r *Renderer) applyPoll(out *Note, poll *model.Poll) {
+	out.Type = "Question"
+	choices := make([]QuestionChoice, len(poll.Choices))
+	for i, c := range poll.Choices {
+		var count int
+		if i < len(poll.Votes) {
+			count = int(poll.Votes[i])
+		}
+		choices[i] = QuestionChoice{
+			Type: "Note",
+			Name: c,
+			Replies: &QuestionChoiceReplies{
+				Type:       "Collection",
+				TotalItems: count,
+			},
+		}
+	}
+	if poll.Multiple {
+		out.AnyOf = choices
+	} else {
+		out.OneOf = choices
+	}
+	if poll.ExpiresAt != nil {
+		ts := poll.ExpiresAt.UTC().Format("2006-01-02T15:04:05.000Z")
+		out.EndTime = ts
+		// 期限切れの場合は closed もセット
+		if poll.ExpiresAt.Before(time.Now()) {
+			out.Closed = ts
+		}
+	}
 }
 
 // addAttachments loads drive files and adds Document entries to the note.

--- a/internal/activitypub/renderer_test.go
+++ b/internal/activitypub/renderer_test.go
@@ -712,3 +712,105 @@ func TestRenderer_RenderFlag(t *testing.T) {
 	// AddContext 済 (Context が設定される)
 	assert.NotNil(t, flag.Context)
 }
+
+// --- Poll (Question) rendering ---
+
+type stubPollResolver struct {
+	polls map[string]*model.Poll
+}
+
+func (s *stubPollResolver) FindByNoteID(noteID string) (*model.Poll, error) {
+	if p, ok := s.polls[noteID]; ok {
+		return p, nil
+	}
+	return nil, assert.AnError
+}
+
+func TestRenderer_RenderNote_SingleChoicePoll(t *testing.T) {
+	r := newRenderer()
+	past := time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC)
+	r.SetPollResolver(&stubPollResolver{polls: map[string]*model.Poll{
+		"n1": {
+			NoteID:    "n1",
+			Multiple:  false,
+			Choices:   []string{"A", "B", "C"},
+			Votes:     []int64{10, 5, 3},
+			ExpiresAt: &past,
+		},
+	}})
+	idGen, _ := id.NewGenerator("aidx")
+	note := &model.Note{
+		ID: "n1", UserID: "u1", HasPoll: true,
+		Visibility: model.NoteVisibilityPublic,
+	}
+	out := r.RenderNote(note, idGen)
+	assert.Equal(t, "Question", out.Type)
+	require.Len(t, out.OneOf, 3)
+	assert.Empty(t, out.AnyOf)
+	assert.Equal(t, "A", out.OneOf[0].Name)
+	assert.Equal(t, 10, out.OneOf[0].Replies.TotalItems)
+	assert.Equal(t, "B", out.OneOf[1].Name)
+	assert.NotEmpty(t, out.EndTime)
+	assert.NotEmpty(t, out.Closed, "expired poll should have closed")
+}
+
+func TestRenderer_RenderNote_MultipleChoicePoll(t *testing.T) {
+	r := newRenderer()
+	future := time.Now().Add(24 * time.Hour)
+	r.SetPollResolver(&stubPollResolver{polls: map[string]*model.Poll{
+		"n2": {
+			NoteID:    "n2",
+			Multiple:  true,
+			Choices:   []string{"X", "Y"},
+			Votes:     []int64{1, 2},
+			ExpiresAt: &future,
+		},
+	}})
+	idGen, _ := id.NewGenerator("aidx")
+	note := &model.Note{
+		ID: "n2", UserID: "u1", HasPoll: true,
+		Visibility: model.NoteVisibilityPublic,
+	}
+	out := r.RenderNote(note, idGen)
+	assert.Equal(t, "Question", out.Type)
+	assert.Empty(t, out.OneOf)
+	require.Len(t, out.AnyOf, 2)
+	assert.Equal(t, "X", out.AnyOf[0].Name)
+	assert.NotEmpty(t, out.EndTime)
+	assert.Empty(t, out.Closed, "active poll should not be closed")
+}
+
+func TestRenderer_RenderNote_PollWithoutExpiry(t *testing.T) {
+	r := newRenderer()
+	r.SetPollResolver(&stubPollResolver{polls: map[string]*model.Poll{
+		"n3": {
+			NoteID:   "n3",
+			Multiple: false,
+			Choices:  []string{"Yes", "No"},
+			Votes:    []int64{0, 0},
+		},
+	}})
+	idGen, _ := id.NewGenerator("aidx")
+	note := &model.Note{
+		ID: "n3", UserID: "u1", HasPoll: true,
+		Visibility: model.NoteVisibilityPublic,
+	}
+	out := r.RenderNote(note, idGen)
+	assert.Equal(t, "Question", out.Type)
+	require.Len(t, out.OneOf, 2)
+	assert.Empty(t, out.EndTime)
+	assert.Empty(t, out.Closed)
+}
+
+func TestRenderer_RenderNote_NoPollResolver(t *testing.T) {
+	r := newRenderer()
+	// pollResolver未設定ならHasPoll=trueでもNoteのまま
+	idGen, _ := id.NewGenerator("aidx")
+	note := &model.Note{
+		ID: "n4", UserID: "u1", HasPoll: true,
+		Visibility: model.NoteVisibilityPublic,
+	}
+	out := r.RenderNote(note, idGen)
+	assert.Equal(t, "Note", out.Type)
+	assert.Empty(t, out.OneOf)
+}

--- a/internal/server/router.go
+++ b/internal/server/router.go
@@ -348,6 +348,7 @@ func (s *Server) setupRoutes() {
 	apRenderer.SetFileResolver(driveFileRepo)
 	apRenderer.SetEmojiResolver(emojiRepo)
 	apRenderer.SetNoteResolver(noteRepo)
+	apRenderer.SetPollResolver(pollRepo)
 	// config.URL は "https://example.com" 形式。ホスト部分だけ抽出する。
 	if u, err := urlpkg.Parse(s.config.URL); err == nil {
 		apRenderer.SetHost(u.Host)


### PR DESCRIPTION
## Summary
投票付きノートがAP配送時に \`Question\` 型で選択肢・投票数・期限情報を
含むようになり、連合相手で投票が正しく表示される。

## 主な変更点

### renderer.go
- \`PollResolver\` interface + \`SetPollResolver()\` 追加
- \`RenderNote\`: \`HasPoll=true\` かつ pollResolver 設定済みなら \`applyPoll()\` を呼ぶ
- \`applyPoll\`:
  - type を \`"Note"\` → \`"Question"\` に変更
  - single choice → \`oneOf\`、multiple choice → \`anyOf\`
  - 各選択肢に \`replies.totalItems\` (投票数) を付与
  - \`ExpiresAt\` → \`endTime\`、期限切れなら \`closed\` もセット

### router.go
- \`apRenderer.SetPollResolver(pollRepo)\` で接続

## テスト (4件)
- **SingleChoicePoll**: oneOf 3件 + endTime + closed (expired)
- **MultipleChoicePoll**: anyOf 2件 + endTime (active, no closed)
- **PollWithoutExpiry**: endTime/closed なし
- **NoPollResolver**: pollResolver 未設定なら Note のまま

Closes #203

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/shiroha-a/mk/pull/216" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
