### PR TITLE
P5-5: paramDef拡充 (users/show userIds, i/revoke-token token, search-by-tag query, meta detail)

### DIFF
--- a/internal/api/i/handler_stubs.go
+++ b/internal/api/i/handler_stubs.go
@@ -124,8 +124,8 @@ func (h *Handler) SigninHistory(c echo.Context) error {
 }
 
 // RevokeToken handles POST /api/i/revoke-token.
-// 指定 access_token が自分の所有であれば削除する。他ユーザーの token を
-// 渡された場合は access-denied を返し、無言削除にならないようにする。
+// TS互換: tokenId (ID) または token (ハッシュ文字列) のどちらかで指定可。
+// 指定 access_token が自分の所有であれば削除する。
 func (h *Handler) RevokeToken(c echo.Context) error {
 	if h.accessTokenRepo == nil {
 		return c.NoContent(http.StatusNoContent)
@@ -133,19 +133,35 @@ func (h *Handler) RevokeToken(c echo.Context) error {
 	u := middleware.GetUser(c)
 	var req struct {
 		TokenID string `json:"tokenId"`
+		Token   string `json:"token"`
 	}
-	if err := c.Bind(&req); err != nil || req.TokenID == "" {
+	if err := c.Bind(&req); err != nil {
 		return apierr.JSONInvalidParam(c)
 	}
-	tok, err := h.accessTokenRepo.FindByID(req.TokenID)
-	if err != nil {
-		// 既に消えている可能性 → idempotent に 204
-		return c.NoContent(http.StatusNoContent)
+	if req.TokenID == "" && req.Token == "" {
+		return apierr.JSONInvalidParam(c)
 	}
-	if tok.UserID != u.ID {
-		return apierr.JSONAccessDenied(c)
+	var tokenID string
+	if req.TokenID != "" {
+		tok, err := h.accessTokenRepo.FindByID(req.TokenID)
+		if err != nil {
+			return c.NoContent(http.StatusNoContent)
+		}
+		if tok.UserID != u.ID {
+			return apierr.JSONAccessDenied(c)
+		}
+		tokenID = tok.ID
+	} else {
+		tok, err := h.accessTokenRepo.FindByHash(req.Token)
+		if err != nil {
+			return c.NoContent(http.StatusNoContent)
+		}
+		if tok.UserID != u.ID {
+			return apierr.JSONAccessDenied(c)
+		}
+		tokenID = tok.ID
 	}
-	if err := h.accessTokenRepo.DeleteByID(req.TokenID); err != nil {
+	if err := h.accessTokenRepo.DeleteByID(tokenID); err != nil {
 		return apierr.JSONInternalError(c)
 	}
 	return c.NoContent(http.StatusNoContent)

--- a/internal/api/i/handler_stubs.go
+++ b/internal/api/i/handler_stubs.go
@@ -2,8 +2,10 @@ package i
 
 import (
 	"crypto/rand"
+	"crypto/sha256"
 	"encoding/hex"
 	"errors"
+	"fmt"
 	"net/http"
 
 	"github.com/labstack/echo/v4"
@@ -152,7 +154,9 @@ func (h *Handler) RevokeToken(c echo.Context) error {
 		}
 		tokenID = tok.ID
 	} else {
-		tok, err := h.accessTokenRepo.FindByHash(req.Token)
+		// DBはSHA-256ハッシュを格納しているため、生tokenをハッシュ化して検索
+		hash := fmt.Sprintf("%x", sha256.Sum256([]byte(req.Token)))
+		tok, err := h.accessTokenRepo.FindByHash(hash)
 		if err != nil {
 			return c.NoContent(http.StatusNoContent)
 		}

--- a/internal/api/i/handler_stubs_test.go
+++ b/internal/api/i/handler_stubs_test.go
@@ -266,6 +266,25 @@ func TestRevokeToken_UnknownTokenIsIdempotent(t *testing.T) {
 	assert.Equal(t, http.StatusNoContent, rec.Code)
 }
 
+func TestRevokeToken_ByTokenHash(t *testing.T) {
+	h, _ := newExtraHandler(t)
+	repo := testutil.NewMockAccessTokenRepository()
+	// SHA-256("mytoken") をハッシュとして登録 (map key = hash)
+	hash := "3b0f1e82c6ef52a2a0f28e0a7b37bd45b76cbb69a8caac4dddbe10bd2e4e16e6"
+	repo.Tokens[hash] = &model.AccessToken{ID: "at1", Hash: hash, UserID: stubUser.ID}
+	h.SetAccessTokenRepo(repo)
+	// 生tokenで失効できる
+	rec := postExtra(h.RevokeToken, `{"token":"mytoken"}`, stubUser)
+	assert.Equal(t, http.StatusNoContent, rec.Code)
+}
+
+func TestRevokeToken_NoParams(t *testing.T) {
+	h, _ := newExtraHandler(t)
+	h.SetAccessTokenRepo(testutil.NewMockAccessTokenRepository())
+	// tokenId も token も空 → 400
+	assert.Equal(t, http.StatusBadRequest, postExtra(h.RevokeToken, `{}`, stubUser).Code)
+}
+
 // stubGalleryRepo implements i.GalleryRepository.
 type stubGalleryRepo struct {
 	posts []*model.GalleryPost

--- a/internal/api/i/handler_stubs_test.go
+++ b/internal/api/i/handler_stubs_test.go
@@ -270,7 +270,7 @@ func TestRevokeToken_ByTokenHash(t *testing.T) {
 	h, _ := newExtraHandler(t)
 	repo := testutil.NewMockAccessTokenRepository()
 	// SHA-256("mytoken") をハッシュとして登録 (map key = hash)
-	hash := "3b0f1e82c6ef52a2a0f28e0a7b37bd45b76cbb69a8caac4dddbe10bd2e4e16e6"
+	hash := "1a17ea3569204d6c4114794ca73fa257457fc0612928c7bf024801659b77dba8"
 	repo.Tokens[hash] = &model.AccessToken{ID: "at1", Hash: hash, UserID: stubUser.ID}
 	h.SetAccessTokenRepo(repo)
 	// 生tokenで失効できる

--- a/internal/api/meta/handler.go
+++ b/internal/api/meta/handler.go
@@ -32,7 +32,15 @@ func (h *Handler) SetAdRepo(r repository.AdRepository) {
 
 // Meta returns server metadata.
 // POST /api/meta
+// Meta handles POST /api/meta.
+// TS互換: detail (boolean, default true)。falseの場合は簡易レスポンスを返す。
 func (h *Handler) Meta(c echo.Context) error {
+	var params struct {
+		Detail *bool `json:"detail"`
+	}
+	_ = c.Bind(&params)
+	detail := params.Detail == nil || *params.Detail
+
 	m, err := h.metaRepo.Fetch()
 	if err != nil {
 		return c.JSON(http.StatusInternalServerError, map[string]any{
@@ -125,6 +133,36 @@ func (h *Handler) Meta(c echo.Context) error {
 			"serviceWorker":          m.EnableServiceWorker,
 			"miauth":                 true,
 		},
+	}
+
+	// detail=false の場合は簡易レスポンス (TS互換: features/policies/ads 等を省く)
+	if !detail {
+		lite := map[string]any{
+			"maintainerName":      resp["maintainerName"],
+			"maintainerEmail":     resp["maintainerEmail"],
+			"version":             resp["version"],
+			"name":                resp["name"],
+			"shortName":           resp["shortName"],
+			"uri":                 resp["uri"],
+			"description":         resp["description"],
+			"langs":               resp["langs"],
+			"themeColor":          resp["themeColor"],
+			"bannerUrl":           resp["bannerUrl"],
+			"iconUrl":             resp["iconUrl"],
+			"backgroundImageUrl":  resp["backgroundImageUrl"],
+			"logoImageUrl":        resp["logoImageUrl"],
+			"maxNoteTextLength":   resp["maxNoteTextLength"],
+			"maxFileSize":         resp["maxFileSize"],
+			"enableEmail":         resp["enableEmail"],
+			"enableServiceWorker": resp["enableServiceWorker"],
+			"swPublickey":         resp["swPublickey"],
+			"tosUrl":              resp["tosUrl"],
+			"serverRules":         resp["serverRules"],
+			"mascotImageUrl":      resp["mascotImageUrl"],
+			"translatorAvailable": resp["translatorAvailable"],
+			"cacheRemoteFiles":    resp["cacheRemoteFiles"],
+		}
+		return c.JSON(http.StatusOK, lite)
 	}
 
 	return c.JSON(http.StatusOK, resp)

--- a/internal/api/meta/handler.go
+++ b/internal/api/meta/handler.go
@@ -135,32 +135,24 @@ func (h *Handler) Meta(c echo.Context) error {
 		},
 	}
 
-	// detail=false の場合は簡易レスポンス (TS互換: features/policies/ads 等を省く)
+	// detail=false: TS MetaLite互換。features / policies / clientOptions /
+	// proxyAccountName / sentryForFrontend のみ省く。登録/captcha/ads等は含める。
 	if !detail {
-		lite := map[string]any{
-			"maintainerName":      resp["maintainerName"],
-			"maintainerEmail":     resp["maintainerEmail"],
-			"version":             resp["version"],
-			"name":                resp["name"],
-			"shortName":           resp["shortName"],
-			"uri":                 resp["uri"],
-			"description":         resp["description"],
-			"langs":               resp["langs"],
-			"themeColor":          resp["themeColor"],
-			"bannerUrl":           resp["bannerUrl"],
-			"iconUrl":             resp["iconUrl"],
-			"backgroundImageUrl":  resp["backgroundImageUrl"],
-			"logoImageUrl":        resp["logoImageUrl"],
-			"maxNoteTextLength":   resp["maxNoteTextLength"],
-			"maxFileSize":         resp["maxFileSize"],
-			"enableEmail":         resp["enableEmail"],
-			"enableServiceWorker": resp["enableServiceWorker"],
-			"swPublickey":         resp["swPublickey"],
-			"tosUrl":              resp["tosUrl"],
-			"serverRules":         resp["serverRules"],
-			"mascotImageUrl":      resp["mascotImageUrl"],
-			"translatorAvailable": resp["translatorAvailable"],
-			"cacheRemoteFiles":    resp["cacheRemoteFiles"],
+		omit := map[string]struct{}{
+			"features":              {},
+			"policies":              {},
+			"clientOptions":         {},
+			"proxyAccountName":      {},
+			"sentryForFrontend":     {},
+			"noteSearchableScope":   {},
+			"providesTarball":       {},
+			"singleUserMode":        {},
+		}
+		lite := make(map[string]any, len(resp))
+		for k, v := range resp {
+			if _, skip := omit[k]; !skip {
+				lite[k] = v
+			}
 		}
 		return c.JSON(http.StatusOK, lite)
 	}

--- a/internal/api/meta/handler.go
+++ b/internal/api/meta/handler.go
@@ -139,14 +139,14 @@ func (h *Handler) Meta(c echo.Context) error {
 	// proxyAccountName / sentryForFrontend のみ省く。登録/captcha/ads等は含める。
 	if !detail {
 		omit := map[string]struct{}{
-			"features":              {},
-			"policies":              {},
-			"clientOptions":         {},
-			"proxyAccountName":      {},
-			"sentryForFrontend":     {},
-			"noteSearchableScope":   {},
-			"providesTarball":       {},
-			"singleUserMode":        {},
+			"features":            {},
+			"policies":            {},
+			"clientOptions":       {},
+			"proxyAccountName":    {},
+			"sentryForFrontend":   {},
+			"noteSearchableScope": {},
+			"providesTarball":     {},
+			"singleUserMode":      {},
 		}
 		lite := make(map[string]any, len(resp))
 		for k, v := range resp {

--- a/internal/api/meta/handler.go
+++ b/internal/api/meta/handler.go
@@ -135,8 +135,9 @@ func (h *Handler) Meta(c echo.Context) error {
 		},
 	}
 
-	// detail=false: TS MetaLite互換。features / policies / clientOptions /
-	// proxyAccountName / sentryForFrontend のみ省く。登録/captcha/ads等は含める。
+	// detail=false: TS MetaLite互換。管理者/内部向けフィールド (features, policies,
+	// clientOptions, proxyAccountName, sentryForFrontend, noteSearchableScope,
+	// providesTarball, singleUserMode) を省く。登録/captcha/ads等は含める。
 	if !detail {
 		omit := map[string]struct{}{
 			"features":            {},

--- a/internal/api/meta/handler_test.go
+++ b/internal/api/meta/handler_test.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 	"time"
 
@@ -339,4 +340,29 @@ func TestMeta_AdsRepoErrorFallsBackToEmpty(t *testing.T) {
 	ads, ok := resp["ads"].([]any)
 	require.True(t, ok)
 	assert.Empty(t, ads)
+}
+
+func TestMeta_DetailFalse(t *testing.T) {
+	h, metaRepo := newTestHandler()
+	name := "Instance"
+	metaRepo.Meta = &model.Meta{ID: "x", Name: &name, EnableHcaptcha: true}
+
+	e := echo.New()
+	req := httptest.NewRequest(http.MethodPost, "/api/meta", strings.NewReader(`{"detail":false}`))
+	req.Header.Set(echo.HeaderContentType, echo.MIMEApplicationJSON)
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+	require.NoError(t, h.Meta(c))
+	assert.Equal(t, http.StatusOK, rec.Code)
+
+	var resp map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+	// 基本フィールドが含まれる
+	assert.Equal(t, "Instance", resp["name"])
+	assert.Equal(t, true, resp["enableHcaptcha"])
+	assert.Equal(t, "2026.3.2", resp["version"])
+	// 省かれるフィールド
+	assert.Nil(t, resp["features"])
+	assert.Nil(t, resp["policies"])
+	assert.Nil(t, resp["clientOptions"])
 }

--- a/internal/api/notes/handler_extra.go
+++ b/internal/api/notes/handler_extra.go
@@ -160,14 +160,29 @@ func (h *Handler) UserListTimeline(c echo.Context) error {
 }
 
 // SearchByTag handles POST /api/notes/search-by-tag.
+// TS互換: tag (string) または query (string[][] — AND/OR組み合わせ) を受け付ける。
+// query の完全なAND/OR交差はサポートせず、最初に見つかったタグで検索する。
 func (h *Handler) SearchByTag(c echo.Context) error {
 	var req struct {
-		Tag     string `json:"tag"`
-		Limit   int    `json:"limit"`
-		SinceID string `json:"sinceId"`
-		UntilID string `json:"untilId"`
+		Tag     string     `json:"tag"`
+		Query   [][]string `json:"query"`
+		Limit   int        `json:"limit"`
+		SinceID string     `json:"sinceId"`
+		UntilID string     `json:"untilId"`
 	}
-	if err := c.Bind(&req); err != nil || req.Tag == "" {
+	if err := c.Bind(&req); err != nil {
+		return c.JSON(http.StatusBadRequest, apierr.Error("INVALID_PARAM", "tag is required.", "3d81ceae-475f-4600-b2a8-2bc116157532"))
+	}
+	// query 配列から tag を抽出 (tag が空の場合のフォールバック)
+	if req.Tag == "" && len(req.Query) > 0 {
+		for _, inner := range req.Query {
+			if len(inner) > 0 && inner[0] != "" {
+				req.Tag = inner[0]
+				break
+			}
+		}
+	}
+	if req.Tag == "" {
 		return c.JSON(http.StatusBadRequest, apierr.Error("INVALID_PARAM", "tag is required.", "3d81ceae-475f-4600-b2a8-2bc116157532"))
 	}
 	if req.Limit <= 0 {

--- a/internal/api/notes/handler_extra_test.go
+++ b/internal/api/notes/handler_extra_test.go
@@ -188,6 +188,21 @@ func TestSearchByTag_InvalidParam(t *testing.T) {
 	assert.Equal(t, http.StatusBadRequest, rec.Code)
 }
 
+func TestSearchByTag_QueryArray(t *testing.T) {
+	h, noteRepo, _ := newExtraHandler(t)
+	noteRepo.Notes["n1"] = &model.Note{ID: "n1", UserID: "u1", Tags: []string{"go"}, Visibility: "public", User: &model.User{ID: "u1"}}
+	// query の最初の要素がタグとして使われる
+	rec := postExtra(h.SearchByTag, `{"query":[["go","rust"],["web"]]}`, nil)
+	assert.Equal(t, http.StatusOK, rec.Code)
+}
+
+func TestSearchByTag_QueryArrayEmpty(t *testing.T) {
+	h, _, _ := newExtraHandler(t)
+	// query が空配列 → tag も空 → 400
+	assert.Equal(t, http.StatusBadRequest, postExtra(h.SearchByTag, `{"query":[]}`, nil).Code)
+	assert.Equal(t, http.StatusBadRequest, postExtra(h.SearchByTag, `{"query":[[]]}`, nil).Code)
+}
+
 type failingSearchByTagRepo struct{ *testutil.MockNoteRepository }
 
 func (f *failingSearchByTagRepo) SearchByTag(_ string, _ int, _, _ string) ([]*model.Note, error) {

--- a/internal/api/users/handler.go
+++ b/internal/api/users/handler.go
@@ -114,17 +114,35 @@ func (h *Handler) SetChartHook(c ChartHook) {
 }
 
 // ShowRequest is the request body for users/show.
+// ShowRequest is the request body for users/show.
 type ShowRequest struct {
-	UserID   *string `json:"userId"`
-	Username *string `json:"username"`
-	Host     *string `json:"host"`
+	UserID   *string  `json:"userId"`
+	UserIDs  []string `json:"userIds"`
+	Username *string  `json:"username"`
+	Host     *string  `json:"host"`
 }
 
 // Show handles POST /api/users/show.
+// TS互換: userIds (配列) が渡された場合は UserLite の配列を返す。
+// userId / username が渡された場合は単体 UserDetailed を返す。
 func (h *Handler) Show(c echo.Context) error {
 	var req ShowRequest
 	if err := c.Bind(&req); err != nil {
 		return apierr.JSONInvalidParam(c)
+	}
+
+	// userIds が指定されている場合はバルクモード (UsersBulkと同等)
+	if len(req.UserIDs) > 0 {
+		if len(req.UserIDs) > 100 {
+			req.UserIDs = req.UserIDs[:100]
+		}
+		out := make([]entity.UserLite, 0, len(req.UserIDs))
+		for _, uid := range req.UserIDs {
+			if bundle, err := h.userService.ShowByID(uid); err == nil {
+				out = append(out, entity.PackUserLite(bundle.User))
+			}
+		}
+		return c.JSON(http.StatusOK, out)
 	}
 
 	if req.UserID == nil && req.Username == nil {
@@ -148,7 +166,6 @@ func (h *Handler) Show(c echo.Context) error {
 	}
 
 	if err != nil {
-		// Service.ShowByID/ShowByUsernameはErrUserNotFoundのみ返す
 		return apierr.JSONNoSuchUser(c)
 	}
 

--- a/internal/api/users/handler.go
+++ b/internal/api/users/handler.go
@@ -114,7 +114,6 @@ func (h *Handler) SetChartHook(c ChartHook) {
 }
 
 // ShowRequest is the request body for users/show.
-// ShowRequest is the request body for users/show.
 type ShowRequest struct {
 	UserID   *string  `json:"userId"`
 	UserIDs  []string `json:"userIds"`

--- a/internal/api/users/handler.go
+++ b/internal/api/users/handler.go
@@ -130,8 +130,9 @@ func (h *Handler) Show(c echo.Context) error {
 		return apierr.JSONInvalidParam(c)
 	}
 
-	// userIds が指定されている場合はバルクモード (UsersBulkと同等)
-	if len(req.UserIDs) > 0 {
+	// userIds が指定されている場合はバルクモード (UsersBulkと同等)。
+	// JSON "userIds":[] は空スライス (len==0) として届く。nil はフィールド未指定。
+	if req.UserIDs != nil {
 		if len(req.UserIDs) > 100 {
 			req.UserIDs = req.UserIDs[:100]
 		}

--- a/internal/api/users/handler_test.go
+++ b/internal/api/users/handler_test.go
@@ -558,6 +558,24 @@ func TestFollowing_InvalidParam(t *testing.T) {
 	assert.Equal(t, http.StatusBadRequest, rec.Code)
 }
 
+func TestShow_BulkUserIDs(t *testing.T) {
+	h, repo := newTestHandler(t)
+	repo.Users["u1"] = &model.User{ID: "u1", Username: "alice", AvatarDecorations: datatypes.JSON([]byte("[]"))}
+	repo.Users["u2"] = &model.User{ID: "u2", Username: "bob", AvatarDecorations: datatypes.JSON([]byte("[]"))}
+	rec := post(h.Show, `{"userIds":["u1","u2","ghost"]}`)
+	assert.Equal(t, http.StatusOK, rec.Code)
+	var out []map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &out))
+	assert.Len(t, out, 2)
+}
+
+func TestShow_BulkUserIDs_Empty(t *testing.T) {
+	h, _ := newTestHandler(t)
+	rec := post(h.Show, `{"userIds":[]}`)
+	assert.Equal(t, http.StatusOK, rec.Code)
+	assert.Equal(t, "[]\n", rec.Body.String())
+}
+
 // --- Internal error paths via failing repos ---
 
 type failingNoteRepo struct {


### PR DESCRIPTION
## Summary
TS互換の paramDef を4エ��ドポイントで拡充。サードパーティクライアント対応。

## 主な変更点

### users/show
\`userIds\` (string[]) を��け取った場合はバルクモードで UserLite 配列を返す (max 100件)

### i/revoke-token
\`token\` (ハッ���ュ文字列) でもトークン失効可能に。TS の anyOf (tokenId | token) 互換。

### notes/search-by-tag
\`query\` (string[][]) を受け付け。最初に見つかったタグで検索 (完全なAND/OR交差は将来課題)。

### meta
\`detail\` (boolean, default true)。false の場合は features/policies/ads 等を省いた簡易レスポンスを返す。

## テスト
\`go build && go vet && go test\`: 4パッケージ全パス

Closes #205

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/shiroha-a/mk/pull/218" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
