### PR TITLE
P5-6: 残エンドポイント10件ルート登録

### DIFF
--- a/internal/api/flash/handler.go
+++ b/internal/api/flash/handler.go
@@ -150,7 +150,7 @@ type SearchRequest struct {
 	Offset int    `json:"offset"`
 }
 
-// My handles POST /api/i/flashs (own list).
+// My handles POST /api/i/flashs and POST /api/flash/my (own list).
 func (h *Handler) My(c echo.Context) error {
 	user := middleware.GetUser(c)
 	var req PaginationRequest

--- a/internal/api/notes/handler.go
+++ b/internal/api/notes/handler.go
@@ -442,6 +442,7 @@ func (h *Handler) Conversation(c echo.Context) error {
 }
 
 // BulkShow handles POST /api/notes — bulk note lookup by noteIds.
+// visibility チェックを通して非公開ノートの漏洩を防ぐ。
 func (h *Handler) BulkShow(c echo.Context) error {
 	var req struct {
 		NoteIDs []string `json:"noteIds"`
@@ -460,6 +461,9 @@ func (h *Handler) BulkShow(c echo.Context) error {
 		return c.JSON(http.StatusOK, []any{})
 	}
 	viewer := middleware.GetUser(c)
+	if h.queryService != nil {
+		notes = h.queryService.FilterVisible(viewer, notes)
+	}
 	return c.JSON(http.StatusOK, h.packMany(notes, viewer))
 }
 

--- a/internal/api/notes/handler.go
+++ b/internal/api/notes/handler.go
@@ -441,6 +441,28 @@ func (h *Handler) Conversation(c echo.Context) error {
 	return c.JSON(http.StatusOK, h.packMany(notes, viewer))
 }
 
+// BulkShow handles POST /api/notes — bulk note lookup by noteIds.
+func (h *Handler) BulkShow(c echo.Context) error {
+	var req struct {
+		NoteIDs []string `json:"noteIds"`
+	}
+	if err := c.Bind(&req); err != nil {
+		return apierr.JSONInvalidParam(c)
+	}
+	if len(req.NoteIDs) == 0 {
+		return c.JSON(http.StatusOK, []any{})
+	}
+	if len(req.NoteIDs) > 100 {
+		req.NoteIDs = req.NoteIDs[:100]
+	}
+	notes, err := h.noteRepo.FindManyByIDsWithUser(req.NoteIDs)
+	if err != nil {
+		return c.JSON(http.StatusOK, []any{})
+	}
+	viewer := middleware.GetUser(c)
+	return c.JSON(http.StatusOK, h.packMany(notes, viewer))
+}
+
 // packMany serializes a list of notes into NoteEntity objects.
 // driveFileRepoが設定されている場合、ファイル情報を解決してFilesに含める。
 // viewerがnon-nilの場合、myReactionなどのviewer依存フィールドも解決する。

--- a/internal/api/notes/handler_test.go
+++ b/internal/api/notes/handler_test.go
@@ -651,3 +651,44 @@ func TestExtractMentions(t *testing.T) {
 		})
 	}
 }
+
+func TestBulkShow_Success(t *testing.T) {
+	h, noteRepo := newTestHandler(t)
+	noteRepo.Notes["n1"] = &model.Note{ID: "n1", UserID: "u1", Visibility: "public", User: &model.User{ID: "u1"}}
+	noteRepo.Notes["n2"] = &model.Note{ID: "n2", UserID: "u1", Visibility: "public", User: &model.User{ID: "u1"}}
+
+	e := echo.New()
+	req := httptest.NewRequest(http.MethodPost, "/api/notes", strings.NewReader(`{"noteIds":["n1","n2","ghost"]}`))
+	req.Header.Set(echo.HeaderContentType, echo.MIMEApplicationJSON)
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+	require.NoError(t, h.BulkShow(c))
+	assert.Equal(t, http.StatusOK, rec.Code)
+	var out []map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &out))
+	assert.Len(t, out, 2)
+}
+
+func TestBulkShow_Empty(t *testing.T) {
+	h, _ := newTestHandler(t)
+	e := echo.New()
+	req := httptest.NewRequest(http.MethodPost, "/api/notes", strings.NewReader(`{"noteIds":[]}`))
+	req.Header.Set(echo.HeaderContentType, echo.MIMEApplicationJSON)
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+	require.NoError(t, h.BulkShow(c))
+	assert.Equal(t, http.StatusOK, rec.Code)
+	assert.Equal(t, "[]\n", rec.Body.String())
+}
+
+func TestBulkShow_NoBody(t *testing.T) {
+	h, _ := newTestHandler(t)
+	e := echo.New()
+	req := httptest.NewRequest(http.MethodPost, "/api/notes", strings.NewReader(`{}`))
+	req.Header.Set(echo.HeaderContentType, echo.MIMEApplicationJSON)
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+	require.NoError(t, h.BulkShow(c))
+	assert.Equal(t, http.StatusOK, rec.Code)
+	assert.Equal(t, "[]\n", rec.Body.String())
+}

--- a/internal/core/note/note_query_service.go
+++ b/internal/core/note/note_query_service.go
@@ -160,6 +160,12 @@ type NoteState struct {
 	IsMutedThread bool `json:"isMutedThread"`
 }
 
+// FilterVisible drops notes the viewer cannot see. Public API for use by
+// handlers that perform bulk lookups outside of QueryService (e.g. BulkShow).
+func (s *QueryService) FilterVisible(viewer *model.User, rows []*model.Note) []*model.Note {
+	return s.filterVisible(viewer, rows)
+}
+
 // filterVisible drops notes the viewer cannot see.
 func (s *QueryService) filterVisible(viewer *model.User, rows []*model.Note) []*model.Note {
 	out := make([]*model.Note, 0, len(rows))

--- a/internal/repository/registration_ticket.go
+++ b/internal/repository/registration_ticket.go
@@ -32,6 +32,7 @@ type RegistrationTicketRepository interface {
 	// `now` is passed by callers so tests can supply a deterministic clock
 	// when evaluating the `expired` filter.
 	List(filter string, limit, offset int, now time.Time) ([]*model.RegistrationTicket, error)
+	Delete(id string) error
 }
 
 type registrationTicketRepository struct {
@@ -68,4 +69,8 @@ func (r *registrationTicketRepository) List(filter string, limit, offset int, no
 		return nil, err
 	}
 	return rows, nil
+}
+
+func (r *registrationTicketRepository) Delete(id string) error {
+	return r.db.Where("id = ?", id).Delete(&model.RegistrationTicket{}).Error
 }

--- a/internal/server/router.go
+++ b/internal/server/router.go
@@ -1145,6 +1145,8 @@ func (s *Server) setupRoutes() {
 	api.POST("/flash/search", flashHandler.Search)
 	api.POST("/flash/like", flashHandler.Like, middleware.RequireAuth())
 	api.POST("/flash/unlike", flashHandler.Unlike, middleware.RequireAuth())
+	api.POST("/flash/my", flashHandler.My, middleware.RequireAuth())
+	api.POST("/flash/my-likes", flashHandler.MyLikes, middleware.RequireAuth())
 	api.POST("/i/flashs", flashHandler.My, middleware.RequireAuth())
 	api.POST("/i/flashs/likes", flashHandler.MyLikes, middleware.RequireAuth())
 
@@ -1746,6 +1748,81 @@ func (s *Server) setupRoutes() {
 		}
 		return c.JSON(http.StatusOK, out)
 	}, middleware.RequireAuth())
+
+	// invite/delete — 自分が作成した招待コード削除
+	api.POST("/invite/delete", func(c echo.Context) error {
+		user := middleware.GetUser(c)
+		var req struct {
+			InviteID string `json:"inviteId"`
+		}
+		if err := c.Bind(&req); err != nil || req.InviteID == "" {
+			return c.JSON(http.StatusBadRequest, map[string]any{"error": map[string]any{"message": "inviteId is required.", "code": "INVALID_PARAM", "id": "3d81ceae-475f-4600-b2a8-2bc116157532"}})
+		}
+		var ticket model.RegistrationTicket
+		if err := s.db.Where("id = ?", req.InviteID).First(&ticket).Error; err != nil {
+			return c.NoContent(http.StatusNoContent)
+		}
+		if ticket.CreatedByID == nil || *ticket.CreatedByID != user.ID {
+			return c.JSON(http.StatusForbidden, map[string]any{"error": map[string]any{"message": "Access denied.", "code": "ACCESS_DENIED", "id": "1fb7cb09-d46a-4fff-b8df-057708cce513"}})
+		}
+		s.db.Where("id = ?", req.InviteID).Delete(&model.RegistrationTicket{})
+		return c.NoContent(http.StatusNoContent)
+	}, middleware.RequireAuth())
+
+	// invite/limit — 残り招待枠を返す (policies から取得、簡易実装)
+	api.POST("/invite/limit", func(c echo.Context) error {
+		return c.JSON(http.StatusOK, map[string]any{
+			"remaining": 0,
+		})
+	}, middleware.RequireAuth())
+
+	// notes (plain) — bulk note lookup by noteIds
+	api.POST("/notes", func(c echo.Context) error {
+		var req struct {
+			NoteIDs []string `json:"noteIds"`
+		}
+		if err := c.Bind(&req); err != nil {
+			return c.JSON(http.StatusBadRequest, map[string]any{"error": map[string]any{"message": "Invalid param.", "code": "INVALID_PARAM", "id": "3d81ceae-475f-4600-b2a8-2bc116157532"}})
+		}
+		if len(req.NoteIDs) == 0 {
+			return c.JSON(http.StatusOK, []any{})
+		}
+		if len(req.NoteIDs) > 100 {
+			req.NoteIDs = req.NoteIDs[:100]
+		}
+		notes, err := noteRepo.FindManyByIDsWithUser(req.NoteIDs)
+		if err != nil {
+			return c.JSON(http.StatusOK, []any{})
+		}
+		out := make([]entity.NoteEntity, 0, len(notes))
+		for _, n := range notes {
+			out = append(out, entity.PackNote(n, idGen))
+		}
+		return c.JSON(http.StatusOK, out)
+	})
+
+	// export-custom-emojis — zip export (complex, stub)
+	api.POST("/export-custom-emojis", func(c echo.Context) error {
+		return c.NoContent(http.StatusNoContent)
+	}, middleware.RequireAuth())
+
+	// fetch-external-resources — URL proxy (stub)
+	api.POST("/fetch-external-resources", func(c echo.Context) error {
+		return c.JSON(http.StatusOK, map[string]any{"type": "unknown", "data": map[string]any{}})
+	})
+
+	// fetch-rss — RSS parser (stub)
+	api.POST("/fetch-rss", func(c echo.Context) error {
+		return c.JSON(http.StatusOK, map[string]any{"items": []any{}})
+	})
+
+	// page-push — push event to page subscribers (stub)
+	api.POST("/page-push", func(c echo.Context) error {
+		return c.NoContent(http.StatusNoContent)
+	}, middleware.RequireAuth())
+
+	// v2/admin/emoji/list — v2 paginated emoji list (delegates to existing admin handler)
+	api.POST("/v2/admin/emoji/list", adminHandler.EmojiList, middleware.RequireAdmin(roleService))
 
 	// --- その他の残りエンドポイント ---
 	// test — フロントエンドのテスト用

--- a/internal/server/router.go
+++ b/internal/server/router.go
@@ -1765,7 +1765,9 @@ func (s *Server) setupRoutes() {
 		if ticket.CreatedByID == nil || *ticket.CreatedByID != user.ID {
 			return c.JSON(http.StatusForbidden, map[string]any{"error": map[string]any{"message": "Access denied.", "code": "ACCESS_DENIED", "id": "1fb7cb09-d46a-4fff-b8df-057708cce513"}})
 		}
-		s.db.Where("id = ?", req.InviteID).Delete(&model.RegistrationTicket{})
+		if err := s.db.Where("id = ?", req.InviteID).Delete(&model.RegistrationTicket{}).Error; err != nil {
+			return c.JSON(http.StatusInternalServerError, map[string]any{"error": map[string]any{"message": "Internal error.", "code": "INTERNAL_ERROR", "id": "5d37dbcb-891e-41ca-a3d6-e690c97775ac"}})
+		}
 		return c.NoContent(http.StatusNoContent)
 	}, middleware.RequireAuth())
 
@@ -1777,29 +1779,7 @@ func (s *Server) setupRoutes() {
 	}, middleware.RequireAuth())
 
 	// notes (plain) — bulk note lookup by noteIds
-	api.POST("/notes", func(c echo.Context) error {
-		var req struct {
-			NoteIDs []string `json:"noteIds"`
-		}
-		if err := c.Bind(&req); err != nil {
-			return c.JSON(http.StatusBadRequest, map[string]any{"error": map[string]any{"message": "Invalid param.", "code": "INVALID_PARAM", "id": "3d81ceae-475f-4600-b2a8-2bc116157532"}})
-		}
-		if len(req.NoteIDs) == 0 {
-			return c.JSON(http.StatusOK, []any{})
-		}
-		if len(req.NoteIDs) > 100 {
-			req.NoteIDs = req.NoteIDs[:100]
-		}
-		notes, err := noteRepo.FindManyByIDsWithUser(req.NoteIDs)
-		if err != nil {
-			return c.JSON(http.StatusOK, []any{})
-		}
-		out := make([]entity.NoteEntity, 0, len(notes))
-		for _, n := range notes {
-			out = append(out, entity.PackNote(n, idGen))
-		}
-		return c.JSON(http.StatusOK, out)
-	})
+	api.POST("/notes", notesHandler.BulkShow)
 
 	// export-custom-emojis — zip export (complex, stub)
 	api.POST("/export-custom-emojis", func(c echo.Context) error {

--- a/internal/testutil/mock_repository.go
+++ b/internal/testutil/mock_repository.go
@@ -4391,3 +4391,8 @@ func (m *MockRegistrationTicketRepository) List(filter string, limit, offset int
 	}
 	return rows[offset:end], nil
 }
+
+func (m *MockRegistrationTicketRepository) Delete(id string) error {
+	delete(m.Tickets, id)
+	return nil
+}


### PR DESCRIPTION
## Summary
TS互換エンドポイントのうち未登録だった10件をルート登録。

## 実装済み (既存repo/service活用)
- \`flash/my\` — flashHandler.My alias
- \`flash/my-likes\` — flashHandler.MyLikes alias
- \`invite/delete\` — 所有者チェック付き削除
- \`notes\` (plain) — bulk note lookup by noteIds (max 100)
- \`v2/admin/emoji/list\` — 既存EmojiListへの alias

## 簡易実装 (正しいshapeの空レスポンス)
- \`invite/limit\` — \`{remaining: 0}\`
- \`fetch-external-resources\` — \`{type, data}\`
- \`fetch-rss\` — \`{items: []}\`

## スタブ (204)
- \`export-custom-emojis\` — zip export は複雑
- \`page-push\` — WS push

## repository
- \`RegistrationTicketRepository.Delete\` + mock 追加

Closes #206

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/shiroha-a/mk/pull/219" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
