### PR TITLE
P5-9: ACCESS_DENIED等のplaceholder UUID修正 (chat/reversi)

### DIFF
--- a/internal/api/chat/handler.go
+++ b/internal/api/chat/handler.go
@@ -41,9 +41,9 @@ func (h *Handler) SetService(svc *corechat.Service) {
 func (h *Handler) mapChatErr(c echo.Context, err error) error {
 	switch {
 	case errors.Is(err, corechat.ErrNotFound):
-		return c.JSON(http.StatusNotFound, apierr.Error("NO_SUCH_MESSAGE", "No such message.", "00000000-0000-0000-0000-000000000000"))
+		return c.JSON(http.StatusNotFound, apierr.Error("NO_SUCH_MESSAGE", "No such message.", "006d73c9-dada-5b5d-a0f5-00b01f70bc3c"))
 	case errors.Is(err, corechat.ErrForbidden):
-		return c.JSON(http.StatusForbidden, apierr.Error("ACCESS_DENIED", "Access denied.", "00000000-0000-0000-0000-000000000000"))
+		return c.JSON(http.StatusForbidden, apierr.Error("ACCESS_DENIED", "Access denied.", "1fb7cb09-d46a-4fff-b8df-057708cce513"))
 	case errors.Is(err, corechat.ErrInvalidTarget):
 		return c.JSON(http.StatusBadRequest, apierr.Error("INVALID_PARAM", "toUserId or toRoomId is required.", "ed1d7571-a3ac-4370-899c-0dbe5e230cc8"))
 	}
@@ -110,7 +110,7 @@ func (h *Handler) RoomsShow(c echo.Context) error {
 	}
 	room, err := h.repo.FindRoomByID(req.RoomID)
 	if err != nil {
-		return c.JSON(http.StatusNotFound, apierr.Error("NO_SUCH_ROOM", "No such room.", "00000000-0000-0000-0000-000000000000"))
+		return c.JSON(http.StatusNotFound, apierr.Error("NO_SUCH_ROOM", "No such room.", "6ab4d7df-5043-57b9-bd5d-ff9908288473"))
 	}
 	return c.JSON(http.StatusOK, packRoom(room))
 }
@@ -128,7 +128,7 @@ func (h *Handler) RoomsUpdate(c echo.Context) error {
 	}
 	room, err := h.repo.FindRoomByID(req.RoomID)
 	if err != nil || room.OwnerID != user.ID {
-		return c.JSON(http.StatusNotFound, apierr.Error("NO_SUCH_ROOM", "No such room.", "00000000-0000-0000-0000-000000000000"))
+		return c.JSON(http.StatusNotFound, apierr.Error("NO_SUCH_ROOM", "No such room.", "6ab4d7df-5043-57b9-bd5d-ff9908288473"))
 	}
 	if req.Name != "" {
 		room.Name = req.Name
@@ -153,7 +153,7 @@ func (h *Handler) RoomsDelete(c echo.Context) error {
 	}
 	room, err := h.repo.FindRoomByID(req.RoomID)
 	if err != nil || room.OwnerID != user.ID {
-		return c.JSON(http.StatusNotFound, apierr.Error("NO_SUCH_ROOM", "No such room.", "00000000-0000-0000-0000-000000000000"))
+		return c.JSON(http.StatusNotFound, apierr.Error("NO_SUCH_ROOM", "No such room.", "6ab4d7df-5043-57b9-bd5d-ff9908288473"))
 	}
 	_ = h.repo.DeleteRoom(req.RoomID)
 	return c.NoContent(http.StatusNoContent)
@@ -242,7 +242,7 @@ func (h *Handler) RoomsTransferOwnership(c echo.Context) error {
 	}
 	room, err := h.repo.FindRoomByID(req.RoomID)
 	if err != nil || room.OwnerID != user.ID {
-		return c.JSON(http.StatusNotFound, apierr.Error("NO_SUCH_ROOM", "No such room.", "00000000-0000-0000-0000-000000000000"))
+		return c.JSON(http.StatusNotFound, apierr.Error("NO_SUCH_ROOM", "No such room.", "6ab4d7df-5043-57b9-bd5d-ff9908288473"))
 	}
 	room.OwnerID = req.UserID
 	_ = h.repo.UpdateRoom(room)
@@ -319,7 +319,7 @@ func (h *Handler) MessagesShow(c echo.Context) error {
 	}
 	msg, err := h.repo.FindMessageByID(req.MessageID)
 	if err != nil {
-		return c.JSON(http.StatusNotFound, apierr.Error("NO_SUCH_MESSAGE", "No such message.", "00000000-0000-0000-0000-000000000000"))
+		return c.JSON(http.StatusNotFound, apierr.Error("NO_SUCH_MESSAGE", "No such message.", "006d73c9-dada-5b5d-a0f5-00b01f70bc3c"))
 	}
 	return c.JSON(http.StatusOK, packMessage(msg))
 }
@@ -338,7 +338,7 @@ func (h *Handler) MessagesUpdate(c echo.Context) error {
 		// legacy fallback
 		msg, err := h.repo.FindMessageByID(req.MessageID)
 		if err != nil || msg.FromUserID != user.ID {
-			return c.JSON(http.StatusNotFound, apierr.Error("NO_SUCH_MESSAGE", "No such message.", "00000000-0000-0000-0000-000000000000"))
+			return c.JSON(http.StatusNotFound, apierr.Error("NO_SUCH_MESSAGE", "No such message.", "006d73c9-dada-5b5d-a0f5-00b01f70bc3c"))
 		}
 		if req.Text != nil {
 			msg.Text = req.Text
@@ -368,7 +368,7 @@ func (h *Handler) MessagesDelete(c echo.Context) error {
 	if h.svc == nil {
 		msg, err := h.repo.FindMessageByID(req.MessageID)
 		if err != nil || msg.FromUserID != user.ID {
-			return c.JSON(http.StatusNotFound, apierr.Error("NO_SUCH_MESSAGE", "No such message.", "00000000-0000-0000-0000-000000000000"))
+			return c.JSON(http.StatusNotFound, apierr.Error("NO_SUCH_MESSAGE", "No such message.", "006d73c9-dada-5b5d-a0f5-00b01f70bc3c"))
 		}
 		_ = h.repo.DeleteMessage(req.MessageID)
 		return c.NoContent(http.StatusNoContent)

--- a/internal/api/reversi/handler.go
+++ b/internal/api/reversi/handler.go
@@ -276,7 +276,7 @@ func (h *Handler) Surrender(c echo.Context) error {
 		return c.JSON(http.StatusNotFound, apierr.Error("NO_SUCH_GAME", "No such game.", "d8a95858-973b-4f3b-8592-fcf2eb4dd044"))
 	}
 	if game.User1ID != user.ID && game.User2ID != user.ID {
-		return c.JSON(http.StatusForbidden, apierr.Error("ACCESS_DENIED", "Access denied.", "00000000-0000-0000-0000-000000000000"))
+		return c.JSON(http.StatusForbidden, apierr.Error("ACCESS_DENIED", "Access denied.", "1fb7cb09-d46a-4fff-b8df-057708cce513"))
 	}
 	var winnerID string
 	if game.User1ID == user.ID {
@@ -324,7 +324,7 @@ func surrenderErrorResponse(c echo.Context, err error) error {
 	case errors.Is(err, corereversi.ErrGameNotFound):
 		return c.JSON(http.StatusNotFound, apierr.Error("NO_SUCH_GAME", "No such game.", "d8a95858-973b-4f3b-8592-fcf2eb4dd044"))
 	case errors.Is(err, corereversi.ErrNotPlayer):
-		return c.JSON(http.StatusForbidden, apierr.Error("ACCESS_DENIED", "Access denied.", "00000000-0000-0000-0000-000000000000"))
+		return c.JSON(http.StatusForbidden, apierr.Error("ACCESS_DENIED", "Access denied.", "1fb7cb09-d46a-4fff-b8df-057708cce513"))
 	case errors.Is(err, corereversi.ErrAlreadyEnded):
 		return c.JSON(http.StatusBadRequest, apierr.Error("ALREADY_ENDED", "Game has already ended.", "2a3a7f72-bc06-4f4e-9f7c-b7f8d4f6a09e"))
 	case errors.Is(err, corereversi.ErrNotStarted):


### PR DESCRIPTION
## Summary
chat/handler.go (9箇所) と reversi/handler.go (2箇所) の placeholder UUID
\`00000000-0000-0000-0000-000000000000\` を適切な値に置換。

## 変更内容
- \`ACCESS_DENIED\` → canonical UUID \`1fb7cb09-...\` (\`apierr.UUIDAccessDenied\` と統一)
- \`NO_SUCH_MESSAGE\` → \`006d73c9-...\` (uuid5 deterministic)
- \`NO_SUCH_ROOM\` → \`6ab4d7df-...\` (uuid5 deterministic)

## 残り
72箇所 (admin/handler_stubs.go:66, i/handler_2fa.go:5, notes/handler_drafts.go:1) は #210 で一括対応予定。

Closes #209

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/shiroha-a/mk/pull/220" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
