### PR TITLE
P5-7: WS protocol (readNotification / subNote / ShareableChannel / PermittedChannel)

### DIFF
--- a/internal/server/router.go
+++ b/internal/server/router.go
@@ -2,6 +2,7 @@ package server
 
 import (
 	"bytes"
+	"context"
 	cryptorand "crypto/rand"
 	"io"
 	"net/http"
@@ -1175,6 +1176,8 @@ func (s *Server) setupRoutes() {
 
 	// 3. Connection manager + 各 publisher の生成
 	streamManager := stream.NewManager(streamRegistry, streamBus)
+	// readNotificationメッセージをnotificationServiceに橋渡しする
+	streamManager.SetNotificationReader(&notifReaderAdapter{svc: notificationService})
 	notePublisher := stream.NewNotePublisher(streamPubSub, idGen)
 	notificationPublisher := stream.NewNotificationPublisher(streamPubSub)
 	drivePublisher := stream.NewDrivePublisher(streamPubSub)
@@ -1906,4 +1909,14 @@ func (s *gormTicketStore) MarkUsed(ticketID, userID string) error {
 		"usedById": userID,
 		"usedAt":   now,
 	}).Error
+}
+
+// notifReaderAdapter bridges stream.NotificationReader to
+// core/notification.Service.MarkAllAsRead.
+type notifReaderAdapter struct {
+	svc *corenotification.Service
+}
+
+func (a *notifReaderAdapter) ReadAll(userID string) error {
+	return a.svc.MarkAllAsRead(context.Background(), userID)
 }

--- a/internal/stream/channels/admin.go
+++ b/internal/stream/channels/admin.go
@@ -63,6 +63,12 @@ func (c *AdminChannel) OnRedisEvent(payload []byte) {
 
 func (c *AdminChannel) OnClientMessage(string, json.RawMessage) {}
 
+// ShouldShare implements stream.ShareableChannel.
+func (c *AdminChannel) ShouldShare() bool { return true }
+
+// RequiredPermission implements stream.PermittedChannel.
+func (c *AdminChannel) RequiredPermission() string { return "read:admin:stream" }
+
 func (c *AdminChannel) Dispose() {
 	if c.connected {
 		c.ctx.Unsubscribe("adminStream")

--- a/internal/stream/channels/antenna.go
+++ b/internal/stream/channels/antenna.go
@@ -44,6 +44,9 @@ func (c *AntennaChannel) OnRedisEvent(payload []byte) {
 
 func (c *AntennaChannel) OnClientMessage(string, json.RawMessage) {}
 
+// RequiredPermission implements stream.PermittedChannel.
+func (c *AntennaChannel) RequiredPermission() string { return "read:account" }
+
 func (c *AntennaChannel) Dispose() {
 	if c.topic != "" {
 		c.ctx.Unsubscribe(c.topic)

--- a/internal/stream/channels/chat_room.go
+++ b/internal/stream/channels/chat_room.go
@@ -102,6 +102,9 @@ func (c *ChatRoomChannel) OnClientMessage(msgType string, body json.RawMessage) 
 	}
 }
 
+// RequiredPermission implements stream.PermittedChannel.
+func (c *ChatRoomChannel) RequiredPermission() string { return "read:chat" }
+
 // Dispose unsubscribes from the room topic.
 func (c *ChatRoomChannel) Dispose() {
 	if c.topic != "" {

--- a/internal/stream/channels/chat_user.go
+++ b/internal/stream/channels/chat_user.go
@@ -94,6 +94,9 @@ func (c *ChatUserChannel) OnClientMessage(msgType string, body json.RawMessage) 
 	}
 }
 
+// RequiredPermission implements stream.PermittedChannel.
+func (c *ChatUserChannel) RequiredPermission() string { return "read:chat" }
+
 // Dispose unsubscribes from the user's conversation topic.
 func (c *ChatUserChannel) Dispose() {
 	if c.topic != "" {

--- a/internal/stream/channels/drive.go
+++ b/internal/stream/channels/drive.go
@@ -46,6 +46,12 @@ func (c *DriveChannel) OnRedisEvent(payload []byte) {
 
 func (c *DriveChannel) OnClientMessage(string, json.RawMessage) {}
 
+// ShouldShare implements stream.ShareableChannel.
+func (c *DriveChannel) ShouldShare() bool { return true }
+
+// RequiredPermission implements stream.PermittedChannel.
+func (c *DriveChannel) RequiredPermission() string { return "read:account" }
+
 func (c *DriveChannel) Dispose() {
 	if c.topic != "" {
 		c.ctx.Unsubscribe(c.topic)

--- a/internal/stream/channels/notifications.go
+++ b/internal/stream/channels/notifications.go
@@ -36,6 +36,12 @@ func (c *NotificationsChannel) OnRedisEvent(payload []byte) {
 
 func (c *NotificationsChannel) OnClientMessage(string, json.RawMessage) {}
 
+// ShouldShare implements stream.ShareableChannel.
+func (c *NotificationsChannel) ShouldShare() bool { return true }
+
+// RequiredPermission implements stream.PermittedChannel.
+func (c *NotificationsChannel) RequiredPermission() string { return "read:account" }
+
 func (c *NotificationsChannel) Dispose() {
 	if c.topic != "" {
 		c.ctx.Unsubscribe(c.topic)
@@ -91,6 +97,12 @@ func (c *MainChannel) OnRedisEvent(payload []byte) {
 }
 
 func (c *MainChannel) OnClientMessage(string, json.RawMessage) {}
+
+// ShouldShare implements stream.ShareableChannel.
+func (c *MainChannel) ShouldShare() bool { return true }
+
+// RequiredPermission implements stream.PermittedChannel.
+func (c *MainChannel) RequiredPermission() string { return "read:account" }
 
 func (c *MainChannel) Dispose() {
 	if c.notif != "" {

--- a/internal/stream/channels/queue_stats.go
+++ b/internal/stream/channels/queue_stats.go
@@ -29,6 +29,9 @@ func (c *QueueStatsChannel) OnRedisEvent(payload []byte) {
 
 func (c *QueueStatsChannel) OnClientMessage(string, json.RawMessage) {}
 
+// ShouldShare implements stream.ShareableChannel.
+func (c *QueueStatsChannel) ShouldShare() bool { return true }
+
 func (c *QueueStatsChannel) Dispose() {
 	if c.connected {
 		c.ctx.Unsubscribe("queueStats")

--- a/internal/stream/channels/reversi.go
+++ b/internal/stream/channels/reversi.go
@@ -45,6 +45,12 @@ func (c *ReversiChannel) OnRedisEvent(payload []byte) {
 
 func (c *ReversiChannel) OnClientMessage(string, json.RawMessage) {}
 
+// ShouldShare implements stream.ShareableChannel.
+func (c *ReversiChannel) ShouldShare() bool { return true }
+
+// RequiredPermission implements stream.PermittedChannel.
+func (c *ReversiChannel) RequiredPermission() string { return "read:account" }
+
 func (c *ReversiChannel) Dispose() {
 	if c.connected {
 		user, ok := c.ctx.User().(*model.User)

--- a/internal/stream/channels/server_stats.go
+++ b/internal/stream/channels/server_stats.go
@@ -29,6 +29,9 @@ func (c *ServerStatsChannel) OnRedisEvent(payload []byte) {
 
 func (c *ServerStatsChannel) OnClientMessage(string, json.RawMessage) {}
 
+// ShouldShare implements stream.ShareableChannel.
+func (c *ServerStatsChannel) ShouldShare() bool { return true }
+
 func (c *ServerStatsChannel) Dispose() {
 	if c.connected {
 		c.ctx.Unsubscribe("serverStats")

--- a/internal/stream/channels/timeline.go
+++ b/internal/stream/channels/timeline.go
@@ -108,6 +108,9 @@ func (c *HomeTimelineChannel) OnRedisEvent(payload []byte) {
 
 func (c *HomeTimelineChannel) OnClientMessage(string, json.RawMessage) {}
 
+// RequiredPermission implements stream.PermittedChannel.
+func (c *HomeTimelineChannel) RequiredPermission() string { return "read:account" }
+
 func (c *HomeTimelineChannel) Dispose() {
 	if c.topic != "" {
 		c.ctx.Unsubscribe(c.topic)
@@ -146,6 +149,9 @@ func (c *HybridTimelineChannel) OnRedisEvent(payload []byte) {
 }
 
 func (c *HybridTimelineChannel) OnClientMessage(string, json.RawMessage) {}
+
+// RequiredPermission implements stream.PermittedChannel.
+func (c *HybridTimelineChannel) RequiredPermission() string { return "read:account" }
 
 func (c *HybridTimelineChannel) Dispose() {
 	c.ctx.Unsubscribe("localTimeline")

--- a/internal/stream/dispatcher.go
+++ b/internal/stream/dispatcher.go
@@ -255,8 +255,8 @@ func (d *Dispatcher) removeChannel(id string) {
 	}
 }
 
-// CloseAll tears down every registered channel. Manager が connection close
-// 時に呼ぶ。
+// CloseAll tears down every registered channel and noteStream subscription.
+// Manager が connection close 時に呼ぶ。
 func (d *Dispatcher) CloseAll() {
 	d.mu.Lock()
 	ids := make([]string, 0, len(d.channels))
@@ -266,6 +266,19 @@ func (d *Dispatcher) CloseAll() {
 	d.mu.Unlock()
 	for _, id := range ids {
 		d.removeChannel(id)
+	}
+	// noteStream の Redis subscription もクリーンアップ
+	d.noteSubMu.Lock()
+	noteIDs := make([]string, 0, len(d.noteSubs))
+	for noteID := range d.noteSubs {
+		noteIDs = append(noteIDs, noteID)
+	}
+	d.noteSubs = make(map[string]int)
+	d.noteSubMu.Unlock()
+	if d.bus != nil {
+		for _, noteID := range noteIDs {
+			d.bus.Unsubscribe("noteStream:" + noteID)
+		}
 	}
 }
 
@@ -443,20 +456,24 @@ func (d *Dispatcher) handleUnsubNote(body json.RawMessage) {
 
 // forwardNoteEvent sends a noteStream event directly to the connection
 // (not wrapped in a channel envelope). TS互換のトップレベル noteUpdated 形式。
+// Redis payload は {type, body} envelope で届く (reacted, deleted, pollVoted 等)。
 func (d *Dispatcher) forwardNoteEvent(noteID string, payload []byte) {
 	if d.conn == nil {
 		return
 	}
-	var event json.RawMessage
-	if err := json.Unmarshal(payload, &event); err != nil {
+	var env struct {
+		Type string          `json:"type"`
+		Body json.RawMessage `json:"body"`
+	}
+	if err := json.Unmarshal(payload, &env); err != nil || env.Type == "" {
 		return
 	}
 	_ = d.conn.Send(map[string]any{
 		"type": "noteUpdated",
 		"body": map[string]any{
 			"id":   noteID,
-			"type": "updated",
-			"body": event,
+			"type": env.Type,
+			"body": env.Body,
 		},
 	})
 }

--- a/internal/stream/dispatcher.go
+++ b/internal/stream/dispatcher.go
@@ -80,8 +80,11 @@ func (d *Dispatcher) HandleClientMessage(msgType string, body json.RawMessage) {
 		d.handleChannelMessage(body)
 	case "readNotification":
 		d.handleReadNotification()
-	case "subNote", "s", "sr":
+	case "subNote", "s":
 		d.handleSubNote(body)
+	case "sr":
+		d.handleSubNote(body)
+		d.handleReadNotification()
 	case "unsubNote", "un":
 		d.handleUnsubNote(body)
 	}

--- a/internal/stream/dispatcher.go
+++ b/internal/stream/dispatcher.go
@@ -2,6 +2,7 @@ package stream
 
 import (
 	"encoding/json"
+	"log/slog"
 	"sync"
 )
 
@@ -21,6 +22,12 @@ type channelEntry struct {
 	topics  map[string]struct{}
 }
 
+// NotificationReader marks all notifications as read for a user. Implemented
+// by core/notification or similar service; nil disables readNotification.
+type NotificationReader interface {
+	ReadAll(userID string) error
+}
+
 // Dispatcher is the per-Connection state holding registered channels and the
 // reverse map "topic → channel id" used to route inbound pubsub events.
 //
@@ -36,6 +43,11 @@ type Dispatcher struct {
 	mu       sync.RWMutex
 	channels map[string]*channelEntry   // channel id → entry
 	topics   map[string]map[string]bool // topic → set of channel ids
+
+	// subNote の refcount 管理 (noteID → count)
+	noteSubMu   sync.Mutex
+	noteSubs    map[string]int
+	notifReader NotificationReader
 }
 
 // NewDispatcher constructs a Dispatcher for the given connection. registry /
@@ -47,7 +59,13 @@ func NewDispatcher(conn *Connection, registry *Registry, bus PubSubBus) *Dispatc
 		bus:      bus,
 		channels: make(map[string]*channelEntry),
 		topics:   make(map[string]map[string]bool),
+		noteSubs: make(map[string]int),
 	}
+}
+
+// SetNotificationReader wires a NotificationReader for readNotification.
+func (d *Dispatcher) SetNotificationReader(nr NotificationReader) {
+	d.notifReader = nr
 }
 
 // HandleClientMessage parses a Misskey-style envelope and forwards it to the
@@ -60,6 +78,12 @@ func (d *Dispatcher) HandleClientMessage(msgType string, body json.RawMessage) {
 		d.handleDisconnect(body)
 	case "ch":
 		d.handleChannelMessage(body)
+	case "readNotification":
+		d.handleReadNotification()
+	case "subNote", "s", "sr":
+		d.handleSubNote(body)
+	case "unsubNote", "un":
+		d.handleUnsubNote(body)
 	}
 }
 
@@ -353,3 +377,86 @@ func (c *channelContext) Send(msgType string, body any) error {
 
 func (c *channelContext) Subscribe(topic string)   { c.dispatcher.subscribe(c.id, topic) }
 func (c *channelContext) Unsubscribe(topic string) { c.dispatcher.unsubscribe(c.id, topic) }
+
+// --- readNotification / subNote / unsubNote ---
+
+// handleReadNotification marks all notifications as read for the connected user.
+func (d *Dispatcher) handleReadNotification() {
+	if d.notifReader == nil || d.conn == nil || d.conn.User() == nil {
+		return
+	}
+	if err := d.notifReader.ReadAll(d.conn.User().ID); err != nil {
+		slog.Warn("stream: readNotification failed", "err", err)
+	}
+}
+
+// handleSubNote subscribes to note-level events (reactions, deletions, etc.)
+// for a specific note. TS互換: refcount で同一noteIDの重複subscribeを管理。
+func (d *Dispatcher) handleSubNote(body json.RawMessage) {
+	var req struct {
+		ID string `json:"id"`
+	}
+	if err := json.Unmarshal(body, &req); err != nil || req.ID == "" {
+		return
+	}
+	topic := "noteStream:" + req.ID
+	d.noteSubMu.Lock()
+	d.noteSubs[req.ID]++
+	first := d.noteSubs[req.ID] == 1
+	d.noteSubMu.Unlock()
+
+	if first && d.bus != nil {
+		d.bus.Subscribe(topic, func(payload []byte) {
+			d.forwardNoteEvent(req.ID, payload)
+		})
+	}
+}
+
+// handleUnsubNote decrements the refcount for a note subscription and
+// unsubscribes when it reaches zero.
+func (d *Dispatcher) handleUnsubNote(body json.RawMessage) {
+	var req struct {
+		ID string `json:"id"`
+	}
+	if err := json.Unmarshal(body, &req); err != nil || req.ID == "" {
+		return
+	}
+	topic := "noteStream:" + req.ID
+	d.noteSubMu.Lock()
+	count, ok := d.noteSubs[req.ID]
+	if !ok {
+		d.noteSubMu.Unlock()
+		return
+	}
+	count--
+	if count <= 0 {
+		delete(d.noteSubs, req.ID)
+		d.noteSubMu.Unlock()
+		if d.bus != nil {
+			d.bus.Unsubscribe(topic)
+		}
+		return
+	}
+	d.noteSubs[req.ID] = count
+	d.noteSubMu.Unlock()
+}
+
+// forwardNoteEvent sends a noteStream event directly to the connection
+// (not wrapped in a channel envelope). TS互換のトップレベル noteUpdated 形式。
+func (d *Dispatcher) forwardNoteEvent(noteID string, payload []byte) {
+	if d.conn == nil {
+		return
+	}
+	var event json.RawMessage
+	if err := json.Unmarshal(payload, &event); err != nil {
+		return
+	}
+	_ = d.conn.Send(map[string]any{
+		"type": "noteUpdated",
+		"body": map[string]any{
+			"id":   noteID,
+			"type": "updated",
+			"body": event,
+		},
+	})
+}

--- a/internal/stream/dispatcher_test.go
+++ b/internal/stream/dispatcher_test.go
@@ -721,3 +721,86 @@ func TestDispatcher_InitError_CleansUpSubscriptions(t *testing.T) {
 	// Dispose も呼ばれる
 	assert.Equal(t, 1, created.disposeCount)
 }
+
+// --- readNotification / subNote / unsubNote tests ---
+
+type stubNotifReader struct {
+	called int
+	lastID string
+}
+
+func (s *stubNotifReader) ReadAll(userID string) error {
+	s.called++
+	s.lastID = userID
+	return nil
+}
+
+func TestDispatcher_ReadNotification(t *testing.T) {
+	conn := NewConnection("test", &model.User{ID: "alice"}, newFakeConn())
+	bus := newStubBus()
+	d := NewDispatcher(conn, nil, bus)
+	nr := &stubNotifReader{}
+	d.SetNotificationReader(nr)
+
+	d.HandleClientMessage("readNotification", nil)
+	assert.Equal(t, 1, nr.called)
+	assert.Equal(t, "alice", nr.lastID)
+}
+
+func TestDispatcher_ReadNotification_NoReader(t *testing.T) {
+	conn := NewConnection("test", &model.User{ID: "alice"}, newFakeConn())
+	d := NewDispatcher(conn, nil, nil)
+	// notifReader未設定でもpanic しない
+	d.HandleClientMessage("readNotification", nil)
+}
+
+func TestDispatcher_SubNote_UnsubNote(t *testing.T) {
+	conn := NewConnection("test", &model.User{ID: "alice"}, newFakeConn())
+	bus := newStubBus()
+	d := NewDispatcher(conn, nil, bus)
+
+	// subscribe
+	d.HandleClientMessage("s", json.RawMessage(`{"id":"n1"}`))
+	bus.mu.Lock()
+	_, subbed := bus.subs["noteStream:n1"]
+	bus.mu.Unlock()
+	assert.True(t, subbed)
+
+	// duplicate subscribe: refcount increments, no duplicate bus.Subscribe
+	d.HandleClientMessage("subNote", json.RawMessage(`{"id":"n1"}`))
+	bus.mu.Lock()
+	assert.Equal(t, 1, countOccurrences(bus.subscribed, "noteStream:n1"))
+	bus.mu.Unlock()
+
+	// unsubscribe once: refcount decrements but still > 0
+	d.HandleClientMessage("un", json.RawMessage(`{"id":"n1"}`))
+	bus.mu.Lock()
+	_, stillSubbed := bus.subs["noteStream:n1"]
+	bus.mu.Unlock()
+	assert.True(t, stillSubbed)
+
+	// unsubscribe again: refcount reaches 0, bus.Unsubscribe called
+	d.HandleClientMessage("unsubNote", json.RawMessage(`{"id":"n1"}`))
+	bus.mu.Lock()
+	_, stillSubbed2 := bus.subs["noteStream:n1"]
+	bus.mu.Unlock()
+	assert.False(t, stillSubbed2)
+}
+
+func TestDispatcher_SubNote_InvalidBody(t *testing.T) {
+	conn := NewConnection("test", &model.User{ID: "alice"}, newFakeConn())
+	d := NewDispatcher(conn, nil, newStubBus())
+	// empty body → no panic
+	d.HandleClientMessage("s", json.RawMessage(`{}`))
+	d.HandleClientMessage("un", json.RawMessage(`{}`))
+}
+
+func countOccurrences(slice []string, target string) int {
+	n := 0
+	for _, s := range slice {
+		if s == target {
+			n++
+		}
+	}
+	return n
+}

--- a/internal/stream/manager.go
+++ b/internal/stream/manager.go
@@ -12,11 +12,12 @@ import (
 // PubSub bus を握り、各 connection に Dispatcher を割り当てて pubsub →
 // channel のルーティングを行う。
 type Manager struct {
-	mu       sync.RWMutex
-	conns    map[string]*Connection
-	nextID   atomic.Uint64
-	registry *Registry
-	bus      PubSubBus
+	mu          sync.RWMutex
+	conns       map[string]*Connection
+	nextID      atomic.Uint64
+	registry    *Registry
+	bus         PubSubBus
+	notifReader NotificationReader
 }
 
 // NewManager constructs a Manager with no live connections. registry / bus が
@@ -29,12 +30,21 @@ func NewManager(registry *Registry, bus PubSubBus) *Manager {
 	}
 }
 
+// SetNotificationReader wires a NotificationReader so readNotification
+// messages from clients are handled.
+func (m *Manager) SetNotificationReader(nr NotificationReader) {
+	m.notifReader = nr
+}
+
 // Accept implements api/streaming.ConnectionAcceptor. *websocket.Conn から
 // Connection を組み立て、Dispatcher 経由で channel framework に橋渡しする。
 func (m *Manager) Accept(ws *websocket.Conn, user *model.User) {
 	id := m.allocateID()
 	c := NewConnection(id, user, ws)
 	dispatcher := NewDispatcher(c, m.registry, m.bus)
+	if m.notifReader != nil {
+		dispatcher.SetNotificationReader(m.notifReader)
+	}
 	c.SetMessageHandler(dispatcher.HandleClientMessage)
 	c.SetCloseHandler(func() {
 		dispatcher.CloseAll()


### PR DESCRIPTION
## Summary
WebSocket protocol レベルで未対応だった4機能を一括実装。P1最後のissue。

## 主な変更点

### readNotification
- Dispatcher に \`handleReadNotification\` 追加
- \`NotificationReader\` interface + \`Manager.SetNotificationReader\`
- router.go で \`notifReaderAdapter\` 経由で notificationService を接続

### subNote (s/sr) / unsubNote (un)
- Dispatcher に \`handleSubNote\` / \`handleUnsubNote\` 追加
- noteID ごとの refcount 管理 (TS 互換: 同一 noteID への複数 subscribe を正しくカウント)
- \`noteStream:{noteID}\` トピックを subscribe/unsubscribe
- \`forwardNoteEvent\` で \`noteUpdated\` envelope を直接送信

### ShareableChannel (6チャンネル)
admin, drive, notifications(main), queue-stats, reversi, server-stats に \`ShouldShare() bool\` → true を追加。同一接続内の重複 connect を no-op に。

### PermittedChannel (10構造体)
| Channel | Scope |
|---------|-------|
| admin | read:admin:stream |
| antenna, drive, notifications, main, reversi | read:account |
| chat-room, chat-user | read:chat |
| homeTimeline, hybridTimeline | read:account |

localTimeline, globalTimeline は public のため制限なし。

## テスト
- readNotification: 正常パス + reader 未設定
- subNote/unsubNote: subscribe → refcount → unsubscribe + invalid body
- stream パッケージ全テストパス

Closes #207

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/shiroha-a/mk/pull/222" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
