### PR TITLE
P5-10: エラーヘルパー統一 (手書き map → apierr.Error) + UUID canonical化

### DIFF
--- a/internal/api/ap/handler.go
+++ b/internal/api/ap/handler.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/labstack/echo/v4"
 	"github.com/shiroha-a/mk/internal/activitypub"
+	"github.com/shiroha-a/mk/internal/api/apierr"
 	corenote "github.com/shiroha-a/mk/internal/core/note"
 	coreuser "github.com/shiroha-a/mk/internal/core/user"
 	"github.com/shiroha-a/mk/internal/misc/id"
@@ -136,7 +137,7 @@ func (h *Handler) APIGet(c echo.Context) error {
 		URI string `json:"uri"`
 	}
 	if err := c.Bind(&req); err != nil || req.URI == "" {
-		return c.JSON(http.StatusBadRequest, apAPIError("INVALID_PARAM", "uri is required.", "ed1d7571-a3ac-4370-899c-0dbe5e230cc8"))
+		return c.JSON(http.StatusBadRequest, apierr.Error("INVALID_PARAM", "uri is required.", "ed1d7571-a3ac-4370-899c-0dbe5e230cc8"))
 	}
 
 	// ローカルURIからオブジェクトを解決
@@ -156,7 +157,7 @@ func (h *Handler) APIGet(c echo.Context) error {
 		}
 	}
 
-	return c.JSON(http.StatusNotFound, apAPIError("NO_SUCH_OBJECT", "No such object.", "dc94d745-1262-4e63-a17d-fecaa57efc82"))
+	return c.JSON(http.StatusNotFound, apierr.Error("NO_SUCH_OBJECT", "No such object.", "dc94d745-1262-4e63-a17d-fecaa57efc82"))
 }
 
 // APIShow handles POST /api/ap/show — URIからUser/Noteを解決して返す。
@@ -165,7 +166,7 @@ func (h *Handler) APIShow(c echo.Context) error {
 		URI string `json:"uri"`
 	}
 	if err := c.Bind(&req); err != nil || req.URI == "" {
-		return c.JSON(http.StatusBadRequest, apAPIError("INVALID_PARAM", "uri is required.", "ed1d7571-a3ac-4370-899c-0dbe5e230cc8"))
+		return c.JSON(http.StatusBadRequest, apierr.Error("INVALID_PARAM", "uri is required.", "ed1d7571-a3ac-4370-899c-0dbe5e230cc8"))
 	}
 
 	// ローカルのノートURIかチェック (/notes/ を含む)
@@ -238,7 +239,7 @@ func (h *Handler) APIShow(c echo.Context) error {
 		}
 	}
 
-	return c.JSON(http.StatusNotFound, apAPIError("NO_SUCH_OBJECT", "No such object.", "dc94d745-1262-4e63-a17d-fecaa57efc82"))
+	return c.JSON(http.StatusNotFound, apierr.Error("NO_SUCH_OBJECT", "No such object.", "dc94d745-1262-4e63-a17d-fecaa57efc82"))
 }
 
 // resolveLocal attempts to resolve a local URI to an AP object.
@@ -262,12 +263,6 @@ func (h *Handler) resolveLocal(uri string) (any, error) {
 		return h.renderer.RenderPerson(bundle.User, bundle.Profile, keypair.PublicKey), nil
 	}
 	return nil, http.ErrNotSupported
-}
-
-func apAPIError(code, message, id string) map[string]any {
-	return map[string]any{
-		"error": map[string]any{"message": message, "code": code, "id": id},
-	}
 }
 
 func extractLocalID(uri, pathPrefix string) string {

--- a/internal/api/blocking/handler.go
+++ b/internal/api/blocking/handler.go
@@ -37,23 +37,11 @@ func (h *Handler) Create(c echo.Context) error {
 	if _, err := h.svc.Block(user.ID, req.UserID); err != nil {
 		switch {
 		case errors.Is(err, coreblocking.ErrSelfBlock):
-			return c.JSON(http.StatusBadRequest, map[string]any{
-				"error": map[string]any{
-					"message": "You cannot block yourself.",
-					"code":    "BLOCKEE_IS_YOURSELF",
-					"id":      "88b19138-f28d-42c0-8499-6a31bbd0fdc6",
-				},
-			})
+			return c.JSON(http.StatusBadRequest, apierr.Error("BLOCKEE_IS_YOURSELF", "You cannot block yourself.", "88b19138-f28d-42c0-8499-6a31bbd0fdc6"))
 		case errors.Is(err, coreblocking.ErrBlockeeNotFound):
 			return apierr.JSONNoSuchUser(c)
 		case errors.Is(err, coreblocking.ErrAlreadyBlocking):
-			return c.JSON(http.StatusBadRequest, map[string]any{
-				"error": map[string]any{
-					"message": "You are already blocking that user.",
-					"code":    "ALREADY_BLOCKING",
-					"id":      "787fed64-acb9-464a-82eb-afbd745b9614",
-				},
-			})
+			return c.JSON(http.StatusBadRequest, apierr.Error("ALREADY_BLOCKING", "You are already blocking that user.", "787fed64-acb9-464a-82eb-afbd745b9614"))
 		}
 		return apierr.JSONInternalError(c)
 	}
@@ -70,21 +58,9 @@ func (h *Handler) Delete(c echo.Context) error {
 	if err := h.svc.Unblock(user.ID, req.UserID); err != nil {
 		switch {
 		case errors.Is(err, coreblocking.ErrSelfBlock):
-			return c.JSON(http.StatusBadRequest, map[string]any{
-				"error": map[string]any{
-					"message": "You cannot unblock yourself.",
-					"code":    "BLOCKEE_IS_YOURSELF",
-					"id":      "06f6fac6-524b-473c-a354-e97a40ae6eac",
-				},
-			})
+			return c.JSON(http.StatusBadRequest, apierr.Error("BLOCKEE_IS_YOURSELF", "You cannot unblock yourself.", "06f6fac6-524b-473c-a354-e97a40ae6eac"))
 		case errors.Is(err, coreblocking.ErrNotBlocking):
-			return c.JSON(http.StatusBadRequest, map[string]any{
-				"error": map[string]any{
-					"message": "You are not blocking that user.",
-					"code":    "NOT_BLOCKING",
-					"id":      "291b2efa-60c6-45c0-9f6a-045c8f9b02cd",
-				},
-			})
+			return c.JSON(http.StatusBadRequest, apierr.Error("NOT_BLOCKING", "You are not blocking that user.", "291b2efa-60c6-45c0-9f6a-045c8f9b02cd"))
 		}
 		return apierr.JSONInternalError(c)
 	}

--- a/internal/api/emojis/handler.go
+++ b/internal/api/emojis/handler.go
@@ -4,6 +4,7 @@ import (
 	"net/http"
 
 	"github.com/labstack/echo/v4"
+	"github.com/shiroha-a/mk/internal/api/apierr"
 	"github.com/shiroha-a/mk/internal/repository"
 )
 
@@ -49,23 +50,11 @@ func (h *Handler) Emoji(c echo.Context) error {
 		Name string `json:"name"`
 	}
 	if err := c.Bind(&req); err != nil || req.Name == "" {
-		return c.JSON(http.StatusBadRequest, map[string]any{
-			"error": map[string]any{
-				"message": "Invalid param.",
-				"code":    "INVALID_PARAM",
-				"id":      "3d81ceae-475f-4600-b2a8-2bc116157532",
-			},
-		})
+		return c.JSON(http.StatusBadRequest, apierr.InvalidParam())
 	}
 	e, err := h.emojiRepo.FindByNameAndHost(req.Name, nil)
 	if err != nil {
-		return c.JSON(http.StatusNotFound, map[string]any{
-			"error": map[string]any{
-				"message": "No such emoji.",
-				"code":    "NO_SUCH_EMOJI",
-				"id":      "14141e4b-dea8-41f0-9ba1-1721a6b5b92c",
-			},
-		})
+		return c.JSON(http.StatusNotFound, apierr.Error("NO_SUCH_EMOJI", "No such emoji.", "14141e4b-dea8-41f0-9ba1-1721a6b5b92c"))
 	}
 	return c.JSON(http.StatusOK, map[string]any{
 		"id":          e.ID,

--- a/internal/api/meta/handler.go
+++ b/internal/api/meta/handler.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/labstack/echo/v4"
+	"github.com/shiroha-a/mk/internal/api/apierr"
 	"github.com/shiroha-a/mk/internal/config"
 	"github.com/shiroha-a/mk/internal/core/role"
 	"github.com/shiroha-a/mk/internal/repository"
@@ -43,13 +44,7 @@ func (h *Handler) Meta(c echo.Context) error {
 
 	m, err := h.metaRepo.Fetch()
 	if err != nil {
-		return c.JSON(http.StatusInternalServerError, map[string]any{
-			"error": map[string]any{
-				"message": "Internal error.",
-				"code":    "INTERNAL_ERROR",
-				"id":      "5d37dbcb-891e-41ca-a3d6-e690c97775ac",
-			},
-		})
+		return c.JSON(http.StatusInternalServerError, apierr.InternalError())
 	}
 
 	resp := map[string]any{

--- a/internal/api/mute/handler.go
+++ b/internal/api/mute/handler.go
@@ -45,23 +45,11 @@ func (h *Handler) Create(c echo.Context) error {
 	if _, err := h.svc.Mute(user.ID, req.UserID, expires); err != nil {
 		switch {
 		case errors.Is(err, coremuting.ErrSelfMute):
-			return c.JSON(http.StatusBadRequest, map[string]any{
-				"error": map[string]any{
-					"message": "You cannot mute yourself.",
-					"code":    "MUTEE_IS_YOURSELF",
-					"id":      "a4619cb2-5f23-484b-9301-94c903074e10",
-				},
-			})
+			return c.JSON(http.StatusBadRequest, apierr.Error("MUTEE_IS_YOURSELF", "You cannot mute yourself.", "a4619cb2-5f23-484b-9301-94c903074e10"))
 		case errors.Is(err, coremuting.ErrMuteeNotFound):
 			return apierr.JSONNoSuchUser(c)
 		case errors.Is(err, coremuting.ErrAlreadyMuting):
-			return c.JSON(http.StatusBadRequest, map[string]any{
-				"error": map[string]any{
-					"message": "You are already muting that user.",
-					"code":    "ALREADY_MUTING",
-					"id":      "7e7359cb-160c-4956-b08f-4d1c653cd007",
-				},
-			})
+			return c.JSON(http.StatusBadRequest, apierr.Error("ALREADY_MUTING", "You are already muting that user.", "7e7359cb-160c-4956-b08f-4d1c653cd007"))
 		}
 		return apierr.JSONInternalError(c)
 	}
@@ -83,21 +71,9 @@ func (h *Handler) Delete(c echo.Context) error {
 	if err := h.svc.Unmute(user.ID, req.UserID); err != nil {
 		switch {
 		case errors.Is(err, coremuting.ErrSelfMute):
-			return c.JSON(http.StatusBadRequest, map[string]any{
-				"error": map[string]any{
-					"message": "You cannot unmute yourself.",
-					"code":    "MUTEE_IS_YOURSELF",
-					"id":      "f428b029-6b39-4d48-a1d2-cc1ae6dd5cf9",
-				},
-			})
+			return c.JSON(http.StatusBadRequest, apierr.Error("MUTEE_IS_YOURSELF", "You cannot unmute yourself.", "f428b029-6b39-4d48-a1d2-cc1ae6dd5cf9"))
 		case errors.Is(err, coremuting.ErrNotMuting):
-			return c.JSON(http.StatusBadRequest, map[string]any{
-				"error": map[string]any{
-					"message": "You are not muting that user.",
-					"code":    "NOT_MUTING",
-					"id":      "5467d020-daa9-4553-81e1-135c0c35a96d",
-				},
-			})
+			return c.JSON(http.StatusBadRequest, apierr.Error("NOT_MUTING", "You are not muting that user.", "5467d020-daa9-4553-81e1-135c0c35a96d"))
 		}
 		return apierr.JSONInternalError(c)
 	}

--- a/internal/api/notes/handler.go
+++ b/internal/api/notes/handler.go
@@ -163,29 +163,11 @@ func (h *Handler) Create(c echo.Context) error {
 	if err != nil {
 		switch {
 		case errors.Is(err, note.ErrNoteContentRequired):
-			return c.JSON(http.StatusBadRequest, map[string]any{
-				"error": map[string]any{
-					"message": "Text, fileIds, or renoteId is required.",
-					"code":    "INVALID_PARAM",
-					"id":      "3d81ceae-475f-4600-b2a8-2bc116157532",
-				},
-			})
+			return c.JSON(http.StatusBadRequest, apierr.InvalidParam())
 		case errors.Is(err, note.ErrReplyTargetNotFound), errors.Is(err, note.ErrRenoteTargetNotFound):
-			return c.JSON(http.StatusNotFound, map[string]any{
-				"error": map[string]any{
-					"message": "No such note.",
-					"code":    "NO_SUCH_NOTE",
-					"id":      "24fcbfc6-2e37-42b6-8388-c29b32725715",
-				},
-			})
+			return c.JSON(http.StatusNotFound, apierr.NoSuchNote())
 		case errors.Is(err, note.ErrCannotReplyToInvisibleNote), errors.Is(err, note.ErrCannotRenoteInvisibleNote):
-			return c.JSON(http.StatusForbidden, map[string]any{
-				"error": map[string]any{
-					"message": "You can not see this note.",
-					"code":    "CANNOT_REPLY_TO_INVISIBLE_NOTE",
-					"id":      "44b07c37-2deb-4b34-9ec9-b1deeed42f0d",
-				},
-			})
+			return c.JSON(http.StatusForbidden, apierr.Error("CANNOT_REPLY_TO_INVISIBLE_NOTE", "You can not see this note.", "44b07c37-2deb-4b34-9ec9-b1deeed42f0d"))
 		}
 		return apierr.JSONInternalError(c)
 	}
@@ -251,21 +233,9 @@ func (h *Handler) Delete(c echo.Context) error {
 	if err := h.deleteService.Delete(user, req.NoteID); err != nil {
 		switch {
 		case errors.Is(err, note.ErrNoteNotFound):
-			return c.JSON(http.StatusNotFound, map[string]any{
-				"error": map[string]any{
-					"message": "No such note.",
-					"code":    "NO_SUCH_NOTE",
-					"id":      "24fcbfc6-2e37-42b6-8388-c29b32725715",
-				},
-			})
+			return c.JSON(http.StatusNotFound, apierr.NoSuchNote())
 		case errors.Is(err, note.ErrNoteAccessDenied):
-			return c.JSON(http.StatusForbidden, map[string]any{
-				"error": map[string]any{
-					"message": "You are not the author of this note.",
-					"code":    "ACCESS_DENIED",
-					"id":      "fe8d7103-0ea8-4ec3-814d-f8b401dc69e9",
-				},
-			})
+			return c.JSON(http.StatusForbidden, apierr.Error("ACCESS_DENIED", "You are not the author of this note.", "fe8d7103-0ea8-4ec3-814d-f8b401dc69e9"))
 		default:
 			return apierr.JSONInternalError(c)
 		}

--- a/internal/api/notes/handler.go
+++ b/internal/api/notes/handler.go
@@ -163,7 +163,7 @@ func (h *Handler) Create(c echo.Context) error {
 	if err != nil {
 		switch {
 		case errors.Is(err, note.ErrNoteContentRequired):
-			return c.JSON(http.StatusBadRequest, apierr.InvalidParam())
+			return c.JSON(http.StatusBadRequest, apierr.Error("INVALID_PARAM", "Text, fileIds, or renoteId is required.", apierr.UUIDInvalidParam))
 		case errors.Is(err, note.ErrReplyTargetNotFound), errors.Is(err, note.ErrRenoteTargetNotFound):
 			return c.JSON(http.StatusNotFound, apierr.NoSuchNote())
 		case errors.Is(err, note.ErrCannotReplyToInvisibleNote), errors.Is(err, note.ErrCannotRenoteInvisibleNote):

--- a/internal/api/notes/polls_handler.go
+++ b/internal/api/notes/polls_handler.go
@@ -29,37 +29,13 @@ func (h *Handler) PollsVote(c echo.Context) error {
 		case errors.Is(err, poll.ErrNoteNotFound), errors.Is(err, poll.ErrNoPoll):
 			return apierr.JSONNoSuchNote(c)
 		case errors.Is(err, poll.ErrNoteNotVisible):
-			return c.JSON(http.StatusForbidden, map[string]any{
-				"error": map[string]any{
-					"message": "You can not see this note.",
-					"code":    "ACCESS_DENIED",
-					"id":      "fe8d7103-0ea8-4ec3-814d-f8b401dc69e9",
-				},
-			})
+			return c.JSON(http.StatusForbidden, apierr.Error("ACCESS_DENIED", "You can not see this note.", "fe8d7103-0ea8-4ec3-814d-f8b401dc69e9"))
 		case errors.Is(err, poll.ErrInvalidChoice):
-			return c.JSON(http.StatusBadRequest, map[string]any{
-				"error": map[string]any{
-					"message": "Invalid choice.",
-					"code":    "INVALID_CHOICE",
-					"id":      "e0cc9a04-f2e8-41e4-a5f1-4127293260cc",
-				},
-			})
+			return c.JSON(http.StatusBadRequest, apierr.Error("INVALID_CHOICE", "Invalid choice.", "e0cc9a04-f2e8-41e4-a5f1-4127293260cc"))
 		case errors.Is(err, poll.ErrPollExpired):
-			return c.JSON(http.StatusBadRequest, map[string]any{
-				"error": map[string]any{
-					"message": "The poll is already expired.",
-					"code":    "ALREADY_EXPIRED",
-					"id":      "1022a357-b085-4054-9083-8f8de358337e",
-				},
-			})
+			return c.JSON(http.StatusBadRequest, apierr.Error("ALREADY_EXPIRED", "The poll is already expired.", "1022a357-b085-4054-9083-8f8de358337e"))
 		case errors.Is(err, poll.ErrAlreadyVoted):
-			return c.JSON(http.StatusBadRequest, map[string]any{
-				"error": map[string]any{
-					"message": "You have already voted.",
-					"code":    "ALREADY_VOTED",
-					"id":      "0963fc77-efac-419b-9424-b391608dc6d8",
-				},
-			})
+			return c.JSON(http.StatusBadRequest, apierr.Error("ALREADY_VOTED", "You have already voted.", "0963fc77-efac-419b-9424-b391608dc6d8"))
 		}
 		return apierr.JSONInternalError(c)
 	}

--- a/internal/api/notes/reactions_handler.go
+++ b/internal/api/notes/reactions_handler.go
@@ -31,37 +31,13 @@ func (h *Handler) ReactionsCreate(c echo.Context) error {
 		case errors.Is(err, reaction.ErrNoteNotFound):
 			return apierr.JSONNoSuchNote(c)
 		case errors.Is(err, reaction.ErrNoteNotVisible):
-			return c.JSON(http.StatusForbidden, map[string]any{
-				"error": map[string]any{
-					"message": "You can not see this note.",
-					"code":    "ACCESS_DENIED",
-					"id":      "fe8d7103-0ea8-4ec3-814d-f8b401dc69e9",
-				},
-			})
+			return c.JSON(http.StatusForbidden, apierr.Error("ACCESS_DENIED", "You can not see this note.", "fe8d7103-0ea8-4ec3-814d-f8b401dc69e9"))
 		case errors.Is(err, reaction.ErrAlreadyReacted):
-			return c.JSON(http.StatusBadRequest, map[string]any{
-				"error": map[string]any{
-					"message": "You are already reacting to that note.",
-					"code":    "ALREADY_REACTED",
-					"id":      "71efcf98-86d6-4e2b-b2ad-9d032369366b",
-				},
-			})
+			return c.JSON(http.StatusBadRequest, apierr.Error("ALREADY_REACTED", "You are already reacting to that note.", "71efcf98-86d6-4e2b-b2ad-9d032369366b"))
 		case errors.Is(err, reaction.ErrCannotReactToPureRenote):
-			return c.JSON(http.StatusBadRequest, map[string]any{
-				"error": map[string]any{
-					"message": "You can not react to a pure Renote.",
-					"code":    "CANNOT_REACT_TO_RENOTE",
-					"id":      "eaccdc08-ddef-43fe-908f-d108faad57f5",
-				},
-			})
+			return c.JSON(http.StatusBadRequest, apierr.Error("CANNOT_REACT_TO_RENOTE", "You can not react to a pure Renote.", "eaccdc08-ddef-43fe-908f-d108faad57f5"))
 		case errors.Is(err, reaction.ErrBlocked):
-			return c.JSON(http.StatusForbidden, map[string]any{
-				"error": map[string]any{
-					"message": "You are blocked by that user.",
-					"code":    "BLOCKED",
-					"id":      "e70412a4-7197-4726-8e74-f3e0deb92aa7",
-				},
-			})
+			return c.JSON(http.StatusForbidden, apierr.Error("BLOCKED", "You are blocked by that user.", "e70412a4-7197-4726-8e74-f3e0deb92aa7"))
 		}
 		return apierr.JSONInternalError(c)
 	}
@@ -87,13 +63,7 @@ func (h *Handler) ReactionsDelete(c echo.Context) error {
 		case errors.Is(err, reaction.ErrNoteNotFound):
 			return apierr.JSONNoSuchNote(c)
 		case errors.Is(err, reaction.ErrReactionNotFound):
-			return c.JSON(http.StatusNotFound, map[string]any{
-				"error": map[string]any{
-					"message": "You are not reacting to that note.",
-					"code":    "NOT_REACTED",
-					"id":      "92f4426d-4196-4125-aa5b-02943e2ec8fc",
-				},
-			})
+			return c.JSON(http.StatusNotFound, apierr.Error("NOT_REACTED", "You are not reacting to that note.", "92f4426d-4196-4125-aa5b-02943e2ec8fc"))
 		}
 		return apierr.JSONInternalError(c)
 	}

--- a/internal/api/notes/timeline_handler.go
+++ b/internal/api/notes/timeline_handler.go
@@ -143,13 +143,7 @@ func (h *Handler) serveTimeline(
 
 	viewer := middleware.GetUser(c)
 	if requireAuth && viewer == nil {
-		return c.JSON(http.StatusUnauthorized, map[string]any{
-			"error": map[string]any{
-				"message": "Credential required.",
-				"code":    "CREDENTIAL_REQUIRED",
-				"id":      "1384574d-a912-4b81-8601-c7b1c4085df1",
-			},
-		})
+		return c.JSON(http.StatusUnauthorized, apierr.Error("CREDENTIAL_REQUIRED", "Credential required.", "1384574d-a912-4b81-8601-c7b1c4085df1"))
 	}
 
 	// UGC visibility: 未ログインユーザーの閲覧を制限する (meta.ugcVisibilityForVisitor)。

--- a/internal/api/renotemute/handler.go
+++ b/internal/api/renotemute/handler.go
@@ -36,23 +36,11 @@ func (h *Handler) Create(c echo.Context) error {
 	if _, err := h.svc.Mute(user.ID, req.UserID); err != nil {
 		switch {
 		case errors.Is(err, coremuting.ErrSelfMute):
-			return c.JSON(http.StatusBadRequest, map[string]any{
-				"error": map[string]any{
-					"message": "You cannot mute yourself.",
-					"code":    "MUTEE_IS_YOURSELF",
-					"id":      "37285718-52f7-4aef-b7de-c38b8e8a8420",
-				},
-			})
+			return c.JSON(http.StatusBadRequest, apierr.Error("MUTEE_IS_YOURSELF", "You cannot mute yourself.", "37285718-52f7-4aef-b7de-c38b8e8a8420"))
 		case errors.Is(err, coremuting.ErrMuteeNotFound):
 			return apierr.JSONNoSuchUser(c)
 		case errors.Is(err, coremuting.ErrAlreadyMuting):
-			return c.JSON(http.StatusBadRequest, map[string]any{
-				"error": map[string]any{
-					"message": "You are already muting that user.",
-					"code":    "ALREADY_MUTING",
-					"id":      "ccfecbe4-1f1c-4fc2-8bdb-9f3672ab7191",
-				},
-			})
+			return c.JSON(http.StatusBadRequest, apierr.Error("ALREADY_MUTING", "You are already muting that user.", "ccfecbe4-1f1c-4fc2-8bdb-9f3672ab7191"))
 		}
 		return apierr.JSONInternalError(c)
 	}
@@ -69,21 +57,9 @@ func (h *Handler) Delete(c echo.Context) error {
 	if err := h.svc.Unmute(user.ID, req.UserID); err != nil {
 		switch {
 		case errors.Is(err, coremuting.ErrSelfMute):
-			return c.JSON(http.StatusBadRequest, map[string]any{
-				"error": map[string]any{
-					"message": "You cannot unmute yourself.",
-					"code":    "MUTEE_IS_YOURSELF",
-					"id":      "afa929cc-95f0-4e30-92c1-b4b5e5e0f38e",
-				},
-			})
+			return c.JSON(http.StatusBadRequest, apierr.Error("MUTEE_IS_YOURSELF", "You cannot unmute yourself.", "afa929cc-95f0-4e30-92c1-b4b5e5e0f38e"))
 		case errors.Is(err, coremuting.ErrNotMuting):
-			return c.JSON(http.StatusBadRequest, map[string]any{
-				"error": map[string]any{
-					"message": "You are not muting that user.",
-					"code":    "NOT_MUTING",
-					"id":      "5467d020-daa9-4553-81e1-135c0c35a96d",
-				},
-			})
+			return c.JSON(http.StatusBadRequest, apierr.Error("NOT_MUTING", "You are not muting that user.", "5467d020-daa9-4553-81e1-135c0c35a96d"))
 		}
 		return apierr.JSONInternalError(c)
 	}

--- a/internal/api/url/handler.go
+++ b/internal/api/url/handler.go
@@ -5,6 +5,7 @@ import (
 	"net/http"
 
 	"github.com/labstack/echo/v4"
+	"github.com/shiroha-a/mk/internal/api/apierr"
 	"github.com/shiroha-a/mk/internal/core/urlpreview"
 )
 
@@ -23,13 +24,7 @@ func NewHandler(fetcher *urlpreview.Fetcher) *Handler {
 func (h *Handler) Preview(c echo.Context) error {
 	rawURL := c.QueryParam("url")
 	if rawURL == "" {
-		return c.JSON(http.StatusBadRequest, map[string]any{
-			"error": map[string]any{
-				"message": "url is required.",
-				"code":    "INVALID_PARAM",
-				"id":      "3d81ceae-475f-4600-b2a8-2bc116157532",
-			},
-		})
+		return c.JSON(http.StatusBadRequest, apierr.InvalidParam())
 	}
 
 	result, err := h.fetcher.Fetch(c.Request().Context(), rawURL)

--- a/internal/api/url/handler.go
+++ b/internal/api/url/handler.go
@@ -24,7 +24,7 @@ func NewHandler(fetcher *urlpreview.Fetcher) *Handler {
 func (h *Handler) Preview(c echo.Context) error {
 	rawURL := c.QueryParam("url")
 	if rawURL == "" {
-		return c.JSON(http.StatusBadRequest, apierr.InvalidParam())
+		return c.JSON(http.StatusBadRequest, apierr.Error("INVALID_PARAM", "url is required.", apierr.UUIDInvalidParam))
 	}
 
 	result, err := h.fetcher.Fetch(c.Request().Context(), rawURL)

--- a/internal/api/users/handler.go
+++ b/internal/api/users/handler.go
@@ -146,13 +146,7 @@ func (h *Handler) Show(c echo.Context) error {
 	}
 
 	if req.UserID == nil && req.Username == nil {
-		return c.JSON(http.StatusBadRequest, map[string]any{
-			"error": map[string]any{
-				"message": "userId or username is required.",
-				"code":    "INVALID_PARAM",
-				"id":      "3d81ceae-475f-4600-b2a8-2bc116157532",
-			},
-		})
+		return c.JSON(http.StatusBadRequest, apierr.InvalidParam())
 	}
 
 	var (

--- a/internal/api/users/handler.go
+++ b/internal/api/users/handler.go
@@ -146,7 +146,7 @@ func (h *Handler) Show(c echo.Context) error {
 	}
 
 	if req.UserID == nil && req.Username == nil {
-		return c.JSON(http.StatusBadRequest, apierr.InvalidParam())
+		return c.JSON(http.StatusBadRequest, apierr.Error("INVALID_PARAM", "userId or username is required.", apierr.UUIDInvalidParam))
 	}
 
 	var (

--- a/internal/api/users/handler_stubs.go
+++ b/internal/api/users/handler_stubs.go
@@ -441,11 +441,7 @@ func (h *Handler) ListsCreateFromPublic(c echo.Context) error {
 	}
 	src, err := h.userListRepo.FindByID(req.ListID)
 	if err != nil || !src.IsPublic {
-		return c.JSON(http.StatusNotFound, map[string]any{"error": map[string]any{
-			"message": "No such list.",
-			"code":    "NO_SUCH_LIST",
-			"id":      "9292f798-6175-4f7d-93f4-b6742279667d",
-		}})
+		return c.JSON(http.StatusNotFound, apierr.Error("NO_SUCH_LIST", "No such list.", "9292f798-6175-4f7d-93f4-b6742279667d"))
 	}
 	now := time.Now()
 	newList := &model.UserList{
@@ -534,11 +530,11 @@ func (h *Handler) ListsUpdate(c echo.Context) error {
 	}
 	list, err := h.userListRepo.FindByID(req.ListID)
 	if err != nil {
-		return c.JSON(http.StatusNotFound, map[string]any{"error": map[string]any{"message": "No such list.", "code": "NO_SUCH_LIST", "id": "796666fe-3dff-4d39-becb-8a5932c1d5b7"}})
+		return c.JSON(http.StatusNotFound, apierr.Error("NO_SUCH_LIST", "No such list.", "796666fe-3dff-4d39-becb-8a5932c1d5b7"))
 	}
 	// 所有権チェック
 	if list.UserID != user.ID {
-		return c.JSON(http.StatusNotFound, map[string]any{"error": map[string]any{"message": "No such list.", "code": "NO_SUCH_LIST", "id": "796666fe-3dff-4d39-becb-8a5932c1d5b7"}})
+		return c.JSON(http.StatusNotFound, apierr.Error("NO_SUCH_LIST", "No such list.", "796666fe-3dff-4d39-becb-8a5932c1d5b7"))
 	}
 	fields := map[string]any{}
 	if req.Name != "" {
@@ -573,15 +569,15 @@ func (h *Handler) ListsUpdateMembership(c echo.Context) error {
 	}
 	list, err := h.userListRepo.FindByID(req.ListID)
 	if err != nil {
-		return c.JSON(http.StatusNotFound, map[string]any{"error": map[string]any{"message": "No such list.", "code": "NO_SUCH_LIST", "id": "7f44670e-ab16-43b8-b4c1-ccd2ee89cc02"}})
+		return c.JSON(http.StatusNotFound, apierr.Error("NO_SUCH_LIST", "No such list.", "7f44670e-ab16-43b8-b4c1-ccd2ee89cc02"))
 	}
 	// 所有権チェック
 	if list.UserID != user.ID {
-		return c.JSON(http.StatusNotFound, map[string]any{"error": map[string]any{"message": "No such list.", "code": "NO_SUCH_LIST", "id": "7f44670e-ab16-43b8-b4c1-ccd2ee89cc02"}})
+		return c.JSON(http.StatusNotFound, apierr.Error("NO_SUCH_LIST", "No such list.", "7f44670e-ab16-43b8-b4c1-ccd2ee89cc02"))
 	}
 	if err := h.userListRepo.UpdateMembership(req.ListID, req.UserID, req.WithReplies); err != nil {
 		if errors.Is(err, gorm.ErrRecordNotFound) {
-			return c.JSON(http.StatusNotFound, map[string]any{"error": map[string]any{"message": "No such user.", "code": "NO_SUCH_USER", "id": "588e7f72-c744-4a61-b180-d354e912bda2"}})
+			return c.JSON(http.StatusNotFound, apierr.Error("NO_SUCH_USER", "No such user.", "588e7f72-c744-4a61-b180-d354e912bda2"))
 		}
 		return apierr.JSONInternalError(c)
 	}


### PR DESCRIPTION
## Summary
13ファイル・40箇所の手書き inline error JSON map を \`apierr.Error()\` ヘルパーに統一。
-244 行 / +46 行のネット削減。

## 変更内容
共通エラーコードは canonical helper を使用:
- \`INVALID_PARAM\` → \`apierr.InvalidParam()\`
- \`INTERNAL_ERROR\` → \`apierr.InternalError()\`
- \`NO_SUCH_NOTE\` → \`apierr.NoSuchNote()\`

その他のエンドポイント固有コードは \`apierr.Error("CODE", "msg", "uuid")\` で統一。

## 対象ファイル (13件)
notes (handler, reactions, polls, timeline), users (handler, stubs),
blocking, mute, renotemute, emojis, meta, url, ap

## 据え置き
signin/handler.go (11件) — TS互換の id-only パターン (\`{error: {id: ...}}\`) のため #211 で対応。

## テスト
全9パッケージのテスト pass。\`go build && go vet && gofmt\`: クリーン。

Closes #210

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/shiroha-a/mk/pull/224" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
