### PR TITLE
P5-11: queue-stats/server-stats statsLog + signin エラー定数化

### DIFF
--- a/internal/api/signin/handler.go
+++ b/internal/api/signin/handler.go
@@ -78,29 +78,17 @@ func (h *Handler) Signin(c echo.Context) error {
 		Password *string `json:"password"`
 	}
 	if err := c.Bind(&req); err != nil || req.Username == "" {
-		return c.JSON(http.StatusBadRequest, map[string]any{
-			"error": map[string]any{
-				"id": "6cc579cc-885d-43d8-95c2-b8c7fc963280",
-			},
-		})
+		return c.JSON(http.StatusBadRequest, errBody("6cc579cc-885d-43d8-95c2-b8c7fc963280"))
 	}
 
 	// ユーザー検索
 	user, err := h.userRepo.FindByUsernameLower(req.Username, nil)
 	if err != nil {
-		return c.JSON(http.StatusNotFound, map[string]any{
-			"error": map[string]any{
-				"id": "6cc579cc-885d-43d8-95c2-b8c7fc963280",
-			},
-		})
+		return c.JSON(http.StatusNotFound, errBody("6cc579cc-885d-43d8-95c2-b8c7fc963280"))
 	}
 
 	if user.IsSuspended {
-		return c.JSON(http.StatusForbidden, map[string]any{
-			"error": map[string]any{
-				"id": "e03a5f46-d309-4865-9b69-56282d94e1eb",
-			},
-		})
+		return c.JSON(http.StatusForbidden, errBody("e03a5f46-d309-4865-9b69-56282d94e1eb"))
 	}
 
 	// Step 1: パスワードなしの場合、次のステップを返す
@@ -114,19 +102,11 @@ func (h *Handler) Signin(c echo.Context) error {
 	// Step 2: パスワード検証
 	profile, err := h.userRepo.FindProfileByUserID(user.ID)
 	if err != nil || profile.Password == nil {
-		return c.JSON(http.StatusForbidden, map[string]any{
-			"error": map[string]any{
-				"id": "932c904e-9460-45b7-9ce6-7ed33be7eb2c",
-			},
-		})
+		return c.JSON(http.StatusForbidden, errBody("932c904e-9460-45b7-9ce6-7ed33be7eb2c"))
 	}
 
 	if err := bcrypt.CompareHashAndPassword([]byte(*profile.Password), []byte(*req.Password)); err != nil {
-		return c.JSON(http.StatusForbidden, map[string]any{
-			"error": map[string]any{
-				"id": "932c904e-9460-45b7-9ce6-7ed33be7eb2c",
-			},
-		})
+		return c.JSON(http.StatusForbidden, errBody("932c904e-9460-45b7-9ce6-7ed33be7eb2c"))
 	}
 
 	// 認証成功
@@ -158,29 +138,17 @@ func (h *Handler) SigninFlow(c echo.Context) error {
 		TestcaptchaResponse string `json:"testcaptcha-response"`
 	}
 	if err := c.Bind(&req); err != nil || req.Username == "" {
-		return c.JSON(http.StatusBadRequest, map[string]any{
-			"error": map[string]any{
-				"id": "6cc579cc-885d-43d8-95c2-b8c7fc963280",
-			},
-		})
+		return c.JSON(http.StatusBadRequest, errBody("6cc579cc-885d-43d8-95c2-b8c7fc963280"))
 	}
 
 	// ユーザー検索 (小文字で検索)
 	user, err := h.userRepo.FindByUsernameLower(req.Username, nil)
 	if err != nil {
-		return c.JSON(http.StatusNotFound, map[string]any{
-			"error": map[string]any{
-				"id": "6cc579cc-885d-43d8-95c2-b8c7fc963280",
-			},
-		})
+		return c.JSON(http.StatusNotFound, errBody("6cc579cc-885d-43d8-95c2-b8c7fc963280"))
 	}
 
 	if user.IsSuspended {
-		return c.JSON(http.StatusForbidden, map[string]any{
-			"error": map[string]any{
-				"id": "e03a5f46-d309-4865-9b69-56282d94e1eb",
-			},
-		})
+		return c.JSON(http.StatusForbidden, errBody("e03a5f46-d309-4865-9b69-56282d94e1eb"))
 	}
 
 	// Step 1: パスワード未提供 → 次のステップを指示
@@ -201,19 +169,11 @@ func (h *Handler) SigninFlow(c echo.Context) error {
 	// Step 2: パスワード検証
 	profile, err := h.userRepo.FindProfileByUserID(user.ID)
 	if err != nil || profile.Password == nil {
-		return c.JSON(http.StatusForbidden, map[string]any{
-			"error": map[string]any{
-				"id": "932c904e-9460-45b7-9ce6-7ed33be7eb2c",
-			},
-		})
+		return c.JSON(http.StatusForbidden, errBody("932c904e-9460-45b7-9ce6-7ed33be7eb2c"))
 	}
 
 	if err := bcrypt.CompareHashAndPassword([]byte(*profile.Password), []byte(*req.Password)); err != nil {
-		return c.JSON(http.StatusForbidden, map[string]any{
-			"error": map[string]any{
-				"id": "932c904e-9460-45b7-9ce6-7ed33be7eb2c",
-			},
-		})
+		return c.JSON(http.StatusForbidden, errBody("932c904e-9460-45b7-9ce6-7ed33be7eb2c"))
 	}
 
 	// CAPTCHA 検証 (password step 完了後、2FA 無しの場合のみ)。

--- a/internal/stream/channels/new_channels_test.go
+++ b/internal/stream/channels/new_channels_test.go
@@ -246,6 +246,23 @@ func TestServerStats_Lifecycle(t *testing.T) {
 	assert.Equal(t, []string{"serverStats"}, ctx.unsubs)
 }
 
+func TestServerStats_RequestLog(t *testing.T) {
+	ctx := newCtx(nil)
+	ch := NewServerStats(ctx)
+	ch.Init(nil)
+	ch.OnClientMessage("requestLog", json.RawMessage(`{"id":"req1","length":50}`))
+	require.Len(t, ctx.sentType, 1)
+	assert.Equal(t, "statsLog", ctx.sentType[0])
+}
+
+func TestServerStats_RequestLog_IgnoresOtherTypes(t *testing.T) {
+	ctx := newCtx(nil)
+	ch := NewServerStats(ctx)
+	ch.Init(nil)
+	ch.OnClientMessage("other", nil)
+	assert.Empty(t, ctx.sentType)
+}
+
 // --- QueueStats ---
 
 func TestQueueStats_Lifecycle(t *testing.T) {
@@ -260,6 +277,23 @@ func TestQueueStats_Lifecycle(t *testing.T) {
 
 	ch.Dispose()
 	assert.Equal(t, []string{"queueStats"}, ctx.unsubs)
+}
+
+func TestQueueStats_RequestLog(t *testing.T) {
+	ctx := newCtx(nil)
+	ch := NewQueueStats(ctx)
+	ch.Init(nil)
+	ch.OnClientMessage("requestLog", json.RawMessage(`{"id":"req1","length":50}`))
+	require.Len(t, ctx.sentType, 1)
+	assert.Equal(t, "statsLog", ctx.sentType[0])
+}
+
+func TestQueueStats_RequestLog_IgnoresOtherTypes(t *testing.T) {
+	ctx := newCtx(nil)
+	ch := NewQueueStats(ctx)
+	ch.Init(nil)
+	ch.OnClientMessage("other", nil)
+	assert.Empty(t, ctx.sentType)
 }
 
 // --- Reversi ---

--- a/internal/stream/channels/queue_stats.go
+++ b/internal/stream/channels/queue_stats.go
@@ -27,7 +27,15 @@ func (c *QueueStatsChannel) OnRedisEvent(payload []byte) {
 	_ = c.ctx.Send("stats", json.RawMessage(payload))
 }
 
-func (c *QueueStatsChannel) OnClientMessage(string, json.RawMessage) {}
+// OnClientMessage handles requestLog from the client. TS本家ではstats
+// collectorがqueueStatsLog:{id}トピックに応答する request-response パターンを
+// 使うが、現状collectorは未実装のため空配列を返す。
+func (c *QueueStatsChannel) OnClientMessage(msgType string, body json.RawMessage) {
+	if msgType != "requestLog" {
+		return
+	}
+	_ = c.ctx.Send("statsLog", []any{})
+}
 
 // ShouldShare implements stream.ShareableChannel.
 func (c *QueueStatsChannel) ShouldShare() bool { return true }

--- a/internal/stream/channels/queue_stats.go
+++ b/internal/stream/channels/queue_stats.go
@@ -28,7 +28,7 @@ func (c *QueueStatsChannel) OnRedisEvent(payload []byte) {
 }
 
 // OnClientMessage handles requestLog from the client. TS本家ではstats
-// collectorがqueueStatsLog:{id}トピックに応答する request-response パターンを
+// collectorがqueueStatsLog:{id}トピックに応答するrequest-responseパターンを
 // 使うが、現状collectorは未実装のため空配列を返す。
 func (c *QueueStatsChannel) OnClientMessage(msgType string, body json.RawMessage) {
 	if msgType != "requestLog" {

--- a/internal/stream/channels/server_stats.go
+++ b/internal/stream/channels/server_stats.go
@@ -27,7 +27,14 @@ func (c *ServerStatsChannel) OnRedisEvent(payload []byte) {
 	_ = c.ctx.Send("stats", json.RawMessage(payload))
 }
 
-func (c *ServerStatsChannel) OnClientMessage(string, json.RawMessage) {}
+// OnClientMessage handles requestLog from the client. 現状stats collectorが
+// 未実装のため空配列を返す (queue_stats.go と同じ)。
+func (c *ServerStatsChannel) OnClientMessage(msgType string, body json.RawMessage) {
+	if msgType != "requestLog" {
+		return
+	}
+	_ = c.ctx.Send("statsLog", []any{})
+}
 
 // ShouldShare implements stream.ShareableChannel.
 func (c *ServerStatsChannel) ShouldShare() bool { return true }

--- a/internal/stream/channels/server_stats.go
+++ b/internal/stream/channels/server_stats.go
@@ -28,7 +28,7 @@ func (c *ServerStatsChannel) OnRedisEvent(payload []byte) {
 }
 
 // OnClientMessage handles requestLog from the client. 現状stats collectorが
-// 未実装のため空配列を返す (queue_stats.go と同じ)。
+// 未実装のため空配列を返す (queue_stats.goと同じ)。
 func (c *ServerStatsChannel) OnClientMessage(msgType string, body json.RawMessage) {
 	if msgType != "requestLog" {
 		return


### PR DESCRIPTION
## Summary
P5互換性調査の最後のサブissue。WebSocket statsLogイベント対応 + signinエラーの定数化。

## statsLog
- queue-stats / server-stats の \`OnClientMessage\` に \`requestLog\` ハンドリング追加
- 現状 stats collector は未実装のため空配列を返す (TS互換の response shape)
- 将来 collector 実装時に pubsub 経由で実データを返すよう拡張可能

## signin エラー定数化
- 10箇所の inline \`map[string]any{"error": map[string]any{"id": ...}}\` を既存の \`errBody()\` ヘルパーに統一
- TS互換の id-only パターンを維持 (-25行)

## テスト
\`go build && go test ./internal/api/signin/... ./internal/stream/channels/...\`: パス

Closes #211

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/shiroha-a/mk/pull/225" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
