### PR TITLE
P6: admin/accounts/create に setupPassword 検証追加 (TS互換)

### DIFF
--- a/internal/api/admin/handler.go
+++ b/internal/api/admin/handler.go
@@ -2,7 +2,9 @@ package admin
 
 import (
 	"context"
+	"log/slog"
 	"net/http"
+	"strings"
 	"time"
 
 	"github.com/labstack/echo/v4"
@@ -71,6 +73,7 @@ type Handler struct {
 	emailSender           EmailSender
 	serverURL             string
 	idGen                 id.Generator
+	configSetupPassword   string
 }
 
 // EmailSender sends a plain-text email (to, subject, body). Same signature
@@ -83,6 +86,12 @@ type EmailSender func(to, subject, body string)
 // fake without implementing the full NoteRepository surface.
 type NoteFinder interface {
 	FindByID(id string) (*model.Note, error)
+}
+
+// SetConfigSetupPassword sets the initial setup password from config. TS互換:
+// 初回セットアップ時にクライアントが送るsetupPasswordとconfig値を照合する。
+func (h *Handler) SetConfigSetupPassword(pw string) {
+	h.configSetupPassword = pw
 }
 
 // SetSystemWebhookRepo attaches a SystemWebhookRepository for admin/system-webhook/*.
@@ -273,7 +282,21 @@ func (h *Handler) AccountsCreate(c echo.Context) error {
 	user := middleware.GetUser(c)
 	isInitialSetup := meta.RootUserID == nil && user == nil
 
-	if !isInitialSetup {
+	if isInitialSetup {
+		// TS互換: setupPassword検証。configにsetupPasswordが設定されている場合は
+		// クライアントの値と一致させる。未設定なのにクライアントが非空値を送った場合も拒否。
+		clientPW := ""
+		if req.SetupPassword != nil {
+			clientPW = strings.TrimSpace(*req.SetupPassword)
+		}
+		if h.configSetupPassword != "" {
+			if clientPW != h.configSetupPassword {
+				return c.JSON(http.StatusBadRequest, apierr.Error("INCORRECT_INITIAL_PASSWORD", "Initial password is incorrect.", "97147c55-1ae1-4f6f-91d6-e1c3e0e76d62"))
+			}
+		} else if clientPW != "" {
+			return c.JSON(http.StatusBadRequest, apierr.Error("INCORRECT_INITIAL_PASSWORD", "Initial password is incorrect.", "97147c55-1ae1-4f6f-91d6-e1c3e0e76d62"))
+		}
+	} else {
 		// 初回セットアップ以外はadmin権限必須
 		if user == nil {
 			return c.JSON(http.StatusForbidden, apierr.Error("ACCESS_DENIED", "Access denied.", "1fb7cb09-d46a-4fff-b8df-057708cce513"))
@@ -294,6 +317,7 @@ func (h *Handler) AccountsCreate(c echo.Context) error {
 		if err == signup.ErrUsernameReserved {
 			return c.JSON(http.StatusBadRequest, apierr.Error("USED_USERNAME", "That username is reserved.", "4b54bee6-2c25-42c3-a10f-7d0d1fbd91f9"))
 		}
+		slog.Error("admin/accounts/create: signup failed", "username", req.Username, "err", err)
 		return c.JSON(http.StatusInternalServerError, apierr.Error("INTERNAL_ERROR", "Internal error.", "5d37dbcb-891e-41ca-a3d6-e690c97775ac"))
 	}
 

--- a/internal/api/admin/handler_test.go
+++ b/internal/api/admin/handler_test.go
@@ -280,6 +280,36 @@ func TestAccountsCreate_PreservedUsername(t *testing.T) {
 	assert.Equal(t, "USED_USERNAME", errObj["code"])
 }
 
+func TestAccountsCreate_SetupPassword_ConfigSet_Matches(t *testing.T) {
+	h, _, _, _ := newTestHandler(t)
+	h.SetConfigSetupPassword("mysecret")
+	rec := doPost(h.AccountsCreate, `{"username":"admin","password":"pass","setupPassword":"mysecret"}`, nil)
+	assert.Equal(t, http.StatusOK, rec.Code)
+}
+
+func TestAccountsCreate_SetupPassword_ConfigSet_Mismatch(t *testing.T) {
+	h, _, _, _ := newTestHandler(t)
+	h.SetConfigSetupPassword("mysecret")
+	rec := doPost(h.AccountsCreate, `{"username":"admin","password":"pass","setupPassword":"wrong"}`, nil)
+	assert.Equal(t, http.StatusBadRequest, rec.Code)
+	assert.Contains(t, rec.Body.String(), "INCORRECT_INITIAL_PASSWORD")
+}
+
+func TestAccountsCreate_SetupPassword_ConfigNotSet_ClientSendsNonEmpty(t *testing.T) {
+	h, _, _, _ := newTestHandler(t)
+	// configにsetupPasswordなし、クライアントが非空値を送信 → 拒否
+	rec := doPost(h.AccountsCreate, `{"username":"admin","password":"pass","setupPassword":"unexpected"}`, nil)
+	assert.Equal(t, http.StatusBadRequest, rec.Code)
+	assert.Contains(t, rec.Body.String(), "INCORRECT_INITIAL_PASSWORD")
+}
+
+func TestAccountsCreate_SetupPassword_ConfigNotSet_ClientSendsEmpty(t *testing.T) {
+	h, _, _, _ := newTestHandler(t)
+	// configにsetupPasswordなし、クライアントもnull → OK
+	rec := doPost(h.AccountsCreate, `{"username":"admin","password":"pass"}`, nil)
+	assert.Equal(t, http.StatusOK, rec.Code)
+}
+
 func TestShowUsers_InvalidJSON(t *testing.T) {
 	h, _, _, _ := newTestHandler(t)
 	rec := doPost(h.ShowUsers, `invalid`, nil)

--- a/internal/server/router.go
+++ b/internal/server/router.go
@@ -1293,6 +1293,7 @@ func (s *Server) setupRoutes() {
 	adminHandler.SetDeleteAccountEnqueuer(s.queueClient)
 	adminHandler.SetPasswordResetRepo(resetReqRepo)
 	adminHandler.SetServerURL(s.config.URL)
+	adminHandler.SetConfigSetupPassword(s.config.SetupPassword)
 	if smtpMetaAdmin, err := metaRepo.Fetch(); err == nil && smtpMetaAdmin.EnableEmail && smtpMetaAdmin.Email != nil && smtpMetaAdmin.SmtpHost != nil {
 		fromAddr := *smtpMetaAdmin.Email
 		host := *smtpMetaAdmin.SmtpHost


### PR DESCRIPTION
## Summary
Cypress E2E テスト (#226) のデバッグで発見。TS本家の \`admin/accounts/create\` は
\`setupPassword\` パラメータを検証するが、Go側は無視していた。

## 問題
Cypress テストは \`setupPassword: 'example_password_please_change_this_or_you_will_get_hacked'\` を
送信するが、config に \`setupPassword\` が設定されていない環境では TS 本家は
\`INCORRECT_INITIAL_PASSWORD\` で拒否する。Go 側は検証しないため通過していた。

## 修正内容
- \`Handler.configSetupPassword\` フィールド + \`SetConfigSetupPassword\` setter
- \`AccountsCreate\` に TS 互換の setupPassword 検証ロジック追加:
  - config に setupPassword 設定済み → クライアントの値と一致しなければ 400
  - config に setupPassword 未設定 → クライアントが非空値を送ったら 400
- Signup 失敗時の \`slog.Error\` ログ追加 (500 の根本原因追跡用)

## テスト (4件)
- config 設定済み + 一致 → 200
- config 設定済み + 不一致 → 400 INCORRECT_INITIAL_PASSWORD
- config 未設定 + 非空値送信 → 400 INCORRECT_INITIAL_PASSWORD
- config 未設定 + null → 200

## 互換性影響
TS 本家と同じ挙動にする変更。setupPassword を送らないクライアントには影響なし。

Closes #226

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/shiroha-a/mk/pull/227" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
