### PR TITLE
Fix: /api/emojis GET route + sort order

### DIFF
--- a/internal/api/emojis/handler.go
+++ b/internal/api/emojis/handler.go
@@ -47,7 +47,7 @@ func (h *Handler) Emojis(c echo.Context) error {
 // POST /api/emoji
 func (h *Handler) Emoji(c echo.Context) error {
 	var req struct {
-		Name string `json:"name"`
+		Name string `json:"name" query:"name"`
 	}
 	if err := c.Bind(&req); err != nil || req.Name == "" {
 		return c.JSON(http.StatusBadRequest, apierr.InvalidParam())

--- a/internal/api/emojis/handler_test.go
+++ b/internal/api/emojis/handler_test.go
@@ -104,7 +104,61 @@ func TestEmojis_ExcludesRemote(t *testing.T) {
 	assert.Empty(t, arr) // リモート絵文字は除外
 }
 
+func doGetEmojis(h *emojis.Handler) *httptest.ResponseRecorder {
+	e := echo.New()
+	req := httptest.NewRequest(http.MethodGet, "/api/emojis", nil)
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+	_ = h.Emojis(c)
+	return rec
+}
+
+func TestEmojis_GET(t *testing.T) {
+	h, repo := setup()
+	cat := "faces"
+	repo.Emojis["wave@"] = &model.Emoji{
+		Name:      "wave",
+		Category:  &cat,
+		PublicURL: "https://example.com/emoji/wave.png",
+	}
+	rec := doGetEmojis(h)
+	assert.Equal(t, http.StatusOK, rec.Code)
+	var body map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &body))
+	arr := body["emojis"].([]any)
+	assert.Len(t, arr, 1)
+}
+
 // --- Emoji (singular) ---
+
+func doGetEmoji(h *emojis.Handler, name string) *httptest.ResponseRecorder {
+	e := echo.New()
+	req := httptest.NewRequest(http.MethodGet, "/api/emoji?name="+name, nil)
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+	_ = h.Emoji(c)
+	return rec
+}
+
+func TestEmoji_GET_Found(t *testing.T) {
+	h, repo := setup()
+	repo.Emojis["smile@"] = &model.Emoji{
+		ID:        "e2",
+		Name:      "smile",
+		PublicURL: "https://example.com/emoji/smile.png",
+	}
+	rec := doGetEmoji(h, "smile")
+	assert.Equal(t, http.StatusOK, rec.Code)
+	var body map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &body))
+	assert.Equal(t, "smile", body["name"])
+}
+
+func TestEmoji_GET_MissingName(t *testing.T) {
+	h, _ := setup()
+	rec := doGetEmoji(h, "")
+	assert.Equal(t, http.StatusBadRequest, rec.Code)
+}
 
 func doPostEmoji(h *emojis.Handler, body string) *httptest.ResponseRecorder {
 	e := echo.New()

--- a/internal/repository/emoji.go
+++ b/internal/repository/emoji.go
@@ -39,7 +39,7 @@ func NewEmojiRepository(db *gorm.DB) EmojiRepository {
 
 func (r *emojiRepository) ListLocal() ([]*model.Emoji, error) {
 	var emojis []*model.Emoji
-	if err := r.db.Where("host IS NULL").Find(&emojis).Error; err != nil {
+	if err := r.db.Where("host IS NULL").Order("category ASC, name ASC").Find(&emojis).Error; err != nil {
 		return nil, err
 	}
 	return emojis, nil

--- a/internal/server/router.go
+++ b/internal/server/router.go
@@ -722,7 +722,9 @@ func (s *Server) setupRoutes() {
 	// Emojis endpoints (public)
 	emojisHandler := apiemojis.NewHandler(emojiRepo)
 	api.POST("/emojis", emojisHandler.Emojis)
+	api.GET("/emojis", emojisHandler.Emojis)
 	api.POST("/emoji", emojisHandler.Emoji)
+	api.GET("/emoji", emojisHandler.Emoji)
 
 	// Notes endpoints
 	notesHandler := notes.NewHandler(noteRepo, noteCreateService, noteDeleteService, noteQueryService, timelineService, reactionService, pollService, searchService, idGen)


### PR DESCRIPTION
## Summary

フロントエンドが `/api/emojis` を GET でリクエストするが、POST のみ登録されていたため catch-all に落ちてカスタム絵文字が表示されなかった。

## 主な変更点

- `/api/emojis`, `/api/emoji` に GET ルートを追加
- `ListLocal()` に `ORDER BY category ASC, name ASC` を追加 (TS版と同じ)

## テスト

`go test ./internal/api/emojis/...` — 全パス

Closes #232

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/shiroha-a/mk/pull/235" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
