### PR TITLE
Fix: /api/notes/reactions GET route + full UserLite

### DIFF
--- a/internal/api/notes/reactions_handler.go
+++ b/internal/api/notes/reactions_handler.go
@@ -73,11 +73,11 @@ func (h *Handler) ReactionsDelete(c echo.Context) error {
 
 // ReactionsListRequest is the request body for notes/reactions.
 type ReactionsListRequest struct {
-	NoteID  string `json:"noteId"`
-	Type    string `json:"type"`
-	Limit   int    `json:"limit"`
-	SinceID string `json:"sinceId"`
-	UntilID string `json:"untilId"`
+	NoteID  string `json:"noteId" query:"noteId"`
+	Type    string `json:"type" query:"type"`
+	Limit   int    `json:"limit" query:"limit"`
+	SinceID string `json:"sinceId" query:"sinceId"`
+	UntilID string `json:"untilId" query:"untilId"`
 }
 
 // Reactions handles POST /api/notes/reactions.

--- a/internal/api/notes/reactions_handler.go
+++ b/internal/api/notes/reactions_handler.go
@@ -7,6 +7,7 @@ import (
 	"github.com/labstack/echo/v4"
 	"github.com/shiroha-a/mk/internal/api/apierr"
 	"github.com/shiroha-a/mk/internal/core/reaction"
+	"github.com/shiroha-a/mk/internal/entity"
 	"github.com/shiroha-a/mk/internal/server/middleware"
 )
 
@@ -108,10 +109,14 @@ func (h *Handler) Reactions(c echo.Context) error {
 		if t, err := h.idGen.ParseTime(r.ID); err == nil {
 			createdAt = t.UTC().Format("2006-01-02T15:04:05.000Z")
 		}
+		var userField any = map[string]any{"id": r.UserID}
+		if r.User != nil {
+			userField = entity.PackUserLite(r.User)
+		}
 		out = append(out, map[string]any{
 			"id":        r.ID,
 			"createdAt": createdAt,
-			"user":      map[string]any{"id": r.UserID},
+			"user":      userField,
 			"type":      r.Reaction,
 		})
 	}

--- a/internal/api/notes/reactions_handler_test.go
+++ b/internal/api/notes/reactions_handler_test.go
@@ -266,6 +266,57 @@ func TestReactions_List_OK(t *testing.T) {
 	assert.NotEmpty(t, resp[0]["createdAt"])
 }
 
+func TestReactions_List_PackUserLite(t *testing.T) {
+	h, repo, reactRepo := newReactionHandler(t)
+	seedReactionNote(repo, "n1", "public")
+	idGen, _ := id.NewGenerator("aidx")
+	rxID := idGen.Generate(timeNow())
+	reactRepo.Reactions[rxID] = &model.NoteReaction{
+		ID: rxID, UserID: "u1", NoteID: "n1", Reaction: "❤",
+		User: &model.User{
+			ID:       "u1",
+			Username: "alice",
+			Host:     nil,
+		},
+	}
+
+	c, rec := newJSONRequest(t, "/api/notes/reactions", `{"noteId":"n1"}`)
+	require.NoError(t, h.Reactions(c))
+	assert.Equal(t, http.StatusOK, rec.Code)
+	var resp []map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+	require.Len(t, resp, 1)
+	user := resp[0]["user"].(map[string]any)
+	assert.Equal(t, "u1", user["id"])
+	assert.Equal(t, "alice", user["username"])
+	// PackUserLiteが返す追加フィールドの存在を確認
+	_, hasAvatar := user["avatarUrl"]
+	assert.True(t, hasAvatar, "PackUserLite should include avatarUrl")
+}
+
+func TestReactions_List_UserNil_Fallback(t *testing.T) {
+	h, repo, reactRepo := newReactionHandler(t)
+	seedReactionNote(repo, "n1", "public")
+	idGen, _ := id.NewGenerator("aidx")
+	rxID := idGen.Generate(timeNow())
+	reactRepo.Reactions[rxID] = &model.NoteReaction{
+		ID: rxID, UserID: "u2", NoteID: "n1", Reaction: "👍",
+		User: nil,
+	}
+
+	c, rec := newJSONRequest(t, "/api/notes/reactions", `{"noteId":"n1"}`)
+	require.NoError(t, h.Reactions(c))
+	assert.Equal(t, http.StatusOK, rec.Code)
+	var resp []map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+	require.Len(t, resp, 1)
+	user := resp[0]["user"].(map[string]any)
+	assert.Equal(t, "u2", user["id"])
+	// User=nil時はPackUserLiteのフィールドがない
+	_, hasUsername := user["username"]
+	assert.False(t, hasUsername, "fallback should only have id")
+}
+
 func timeNow() time.Time {
 	return time.Now()
 }

--- a/internal/server/router.go
+++ b/internal/server/router.go
@@ -750,6 +750,7 @@ func (s *Server) setupRoutes() {
 	api.POST("/notes/global-timeline", notesHandler.GlobalTimeline)
 	api.POST("/notes/hybrid-timeline", notesHandler.HybridTimeline, middleware.RequireAuth())
 	api.POST("/notes/reactions", notesHandler.Reactions)
+	api.GET("/notes/reactions", notesHandler.Reactions)
 	api.POST("/notes/reactions/create", notesHandler.ReactionsCreate, middleware.RequireAuth())
 	api.POST("/notes/reactions/delete", notesHandler.ReactionsDelete, middleware.RequireAuth())
 	api.POST("/notes/polls/vote", notesHandler.PollsVote, middleware.RequireAuth())


### PR DESCRIPTION
## Summary

フロントエンドがリアクション一覧を GET でリクエストするが POST のみ登録されていた。またユーザー情報が `{id: ...}` のみでフロントエンドが正しく描画できなかった。

## 主な変更点

- `/api/notes/reactions` に GET ルートを追加
- レスポンスの `user` を `entity.PackUserLite()` によるフル UserLite DTO に変更

## テスト

`go test ./internal/api/notes/... -run TestReactions` — 全パス

Closes #233

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/shiroha-a/mk/pull/236" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
