### PR TITLE
Fix: db.port default 5432 when omitted

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -387,7 +387,7 @@ func resolve(src *Source) (*Config, error) {
 
 		DB:             resolveDB(src.DB),
 		DBReplications: src.DBReplications,
-		DBSlaves:       src.DBSlaves,
+		DBSlaves:       resolveDBSlaves(src.DBSlaves),
 
 		Redis:             redis,
 		RedisForPubsub:    resolveRedisOrDefault(src.RedisForPubsub, redis, host),
@@ -460,6 +460,15 @@ func resolveDB(opts DBOptions) DBOptions {
 		opts.Port = 5432
 	}
 	return opts
+}
+
+func resolveDBSlaves(slaves []DBSlaveOptions) []DBSlaveOptions {
+	for i := range slaves {
+		if slaves[i].Port == 0 {
+			slaves[i].Port = 5432
+		}
+	}
+	return slaves
 }
 
 func resolveRedis(opts RedisOptions, host string) RedisOptions {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -385,7 +385,7 @@ func resolve(src *Source) (*Config, error) {
 		EnableIPRateLimit: enableIPRateLimit,
 		SetupPassword:     src.SetupPassword,
 
-		DB:             src.DB,
+		DB:             resolveDB(src.DB),
 		DBReplications: src.DBReplications,
 		DBSlaves:       src.DBSlaves,
 
@@ -453,6 +453,13 @@ func resolve(src *Source) (*Config, error) {
 	}
 
 	return cfg, nil
+}
+
+func resolveDB(opts DBOptions) DBOptions {
+	if opts.Port == 0 {
+		opts.Port = 5432
+	}
+	return opts
 }
 
 func resolveRedis(opts RedisOptions, host string) RedisOptions {

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -85,6 +85,26 @@ func TestLoad_Defaults(t *testing.T) {
 	assert.Equal(t, 500, cfg.PerUserNotificationsMaxCount)
 }
 
+func TestLoad_DBPortDefault(t *testing.T) {
+	yaml := `
+url: https://example.com
+port: 3000
+db:
+  host: /var/run/postgresql
+  db: misskey
+  user: postgres
+  pass: secret
+redis:
+  host: localhost
+  port: 6379
+id: aidx
+`
+	path := writeTestConfig(t, yaml)
+	cfg, err := Load(path)
+	require.NoError(t, err)
+	assert.Equal(t, 5432, cfg.DB.Port)
+}
+
 func TestLoad_HTTPScheme(t *testing.T) {
 	yaml := `
 url: http://localhost:3000


### PR DESCRIPTION
## Summary

`db.port` を YAML で省略すると 0 になり UDS 接続でも parse error が発生していた。`resolveDB()` でデフォルト 5432 を適用するよう修正。

## 主な変更点

- `resolveDB()` 関数を追加: `Port == 0` の場合に 5432 を設定
- テスト追加: `TestLoad_DBPortDefault`

## テスト

`go test ./internal/config/...` — 全パス

Closes #230

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/shiroha-a/mk/pull/237" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
