### PR TITLE
Fix: docker-compose drive volume mount path

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,7 +16,7 @@ services:
       # MISSKEY_STATIC_DIR: /app/static
       TZ: Asia/Tokyo
     volumes:
-      - ./files:/app/files
+      - ./files:/app/drive-files
       # 設定ファイルを上書きする場合:
       # - ./.config/default.yml:/app/.config/default.yml:ro
     restart: unless-stopped

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -78,7 +78,9 @@ Docker環境ではコンテナ内の`.config/docker.yml`がデフォルトで読
 | `deliverJobMaxAttempts` | int | - | AP配信の最大リトライ回数 |
 | `inboxJobMaxAttempts` | int | - | Inbox処理の最大リトライ回数 |
 
-### メディア
+### メディ���
+
+ローカルストレージ (S3未設定時) のファイル保存先は`./drive-files`固定。Docker環境ではコンテナ内の`/app/drive-files`にボリュームマウントが必要。
 
 | キー | 型 | デフォルト | 説明 |
 |---|---|---|---|

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -78,7 +78,7 @@ Docker環境ではコンテナ内の`.config/docker.yml`がデフォルトで読
 | `deliverJobMaxAttempts` | int | - | AP配信の最大リトライ回数 |
 | `inboxJobMaxAttempts` | int | - | Inbox処理の最大リトライ回数 |
 
-### メディ���
+### メディア
 
 ローカルストレージ (S3未設定時) のファイル保存先は`./drive-files`固定。Docker環境ではコンテナ内の`/app/drive-files`にボリュームマウントが必要。
 


### PR DESCRIPTION
## Summary

ドライブファイル保存先が `./drive-files` だが、`docker-compose.yml` のマウントが `./files:/app/files` で不一致だった。

## 主な変更点

- `docker-compose.yml`: マウント先を `./files:/app/drive-files` に修正
- `docs/configuration.md`: ローカルストレージの保存先パスを明記

Closes #229

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/shiroha-a/mk/pull/239" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
