### PR TITLE
Fix: Include cmd/migrate in Docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,8 @@ COPY go.mod go.sum ./
 RUN go mod download
 
 COPY . .
-RUN go build -trimpath -ldflags="-s -w" -o /app/built/misskey ./cmd/misskey
+RUN go build -trimpath -ldflags="-s -w" -o /app/built/misskey ./cmd/misskey && \
+    go build -trimpath -ldflags="-s -w" -o /app/built/migrate ./cmd/migrate
 
 # Stage 2: Runtime
 FROM alpine:3.21
@@ -21,6 +22,7 @@ RUN apk add --no-cache ca-certificates tzdata
 WORKDIR /app
 
 COPY --from=builder /app/built/misskey /app/misskey
+COPY --from=builder /app/built/migrate /app/migrate
 COPY --from=builder /app/migration /app/migration
 
 # デフォルト設定ファイルをコピー (docker-compose でマウント上書き可能)

--- a/docs/migration-from-ts.md
+++ b/docs/migration-from-ts.md
@@ -72,8 +72,11 @@ id: aidx             # Misskey-TS側のID生成方式と一致させること
 Misskey-Goは既存のMisskey-TSテーブルには手を加えず、独自のテーブルを追加する形で共存する。既存データは保持される。
 
 ```bash
-# Misskey-Goのマイグレーションを適用
+# ローカルビルドの場合
 go run ./cmd/migrate -direction up
+
+# Docker imageの場合 (migrateバイナリが同梱されている)
+docker compose exec app /app/migrate -config .config/default.yml -direction up
 ```
 
 これによりGo側で必要な追加テーブル (`app`, `auth_session`, `webhook`, `sw_subscription`, `chat_room`, `chat_message`, `bubble_game_record` 等) が作成される。


### PR DESCRIPTION
## Summary

Dockerfile で `cmd/misskey` のみビルドしており `cmd/migrate` が同梱されていなかった。`migration-from-ts.md` の手順と乖離していた問題を修正。

## 主な変更点

- Dockerfile: `cmd/migrate` もビルドして `/app/migrate` に配置
- `docs/migration-from-ts.md`: Docker 環境での migration 実行例を追加

Closes #231

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/shiroha-a/mk/pull/240" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
