### PR TITLE
Fix: :name@.: reaction normalized as local emoji

### DIFF
--- a/internal/core/reaction/reaction_service.go
+++ b/internal/core/reaction/reaction_service.go
@@ -296,6 +296,10 @@ func (s *Service) normalizeReaction(raw string) string {
 		if len(m) >= 3 {
 			host = m[2]
 		}
+		// "@." はローカルを表すcanonical suffix (TS互換)
+		if host == "." {
+			host = ""
+		}
 		var hostPtr *string
 		if host != "" {
 			hostPtr = &host

--- a/internal/core/reaction/reaction_service_test.go
+++ b/internal/core/reaction/reaction_service_test.go
@@ -121,6 +121,15 @@ func TestService_Create_CustomEmojiRemote(t *testing.T) {
 	assert.Equal(t, ":smile@remote.example:", r)
 }
 
+func TestService_Create_CustomEmojiLocalWithDotHost(t *testing.T) {
+	svc, repo, _, emojiRepo, _ := newService(t)
+	seedNote(repo, "n1", "author", model.NoteVisibilityPublic)
+	emojiRepo.Emojis["smile@"] = &model.Emoji{Name: "smile"}
+	r, err := svc.Create(&model.User{ID: "viewer"}, "n1", ":smile@.:")
+	require.NoError(t, err)
+	assert.Equal(t, ":smile@.:", r)
+}
+
 func TestService_Create_CustomEmojiNotFoundFallback(t *testing.T) {
 	svc, repo, _, _, _ := newService(t)
 	seedNote(repo, "n1", "author", model.NoteVisibilityPublic)


### PR DESCRIPTION
## Summary
- `:name@.:` 形式のリアクションで `host = "."` が文字列としてDB検索に渡され、`host IS NULL` のローカル絵文字にヒットしなかった問題を修正
- `normalizeReaction` 内で `host == "."` を `host = ""` に正規化

## 主な変更点
- `internal/core/reaction/reaction_service.go`: `normalizeReaction` に `host == "."` → `host = ""` の正規化を追加
- `internal/core/reaction/reaction_service_test.go`: `:smile@.:` でローカル絵文字が正しく解決されるテスト追加

## テスト
- `go test ./internal/core/reaction/... -v` 全PASS
- カバレッジ 92.2%

Closes #250
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/shiroha-a/mk/pull/251" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
