### PR TITLE
Phase 7-1 notes系エラー UUID を TS互換に修正 + apierr 拡充

### DIFF
--- a/internal/api/apierr/echo.go
+++ b/internal/api/apierr/echo.go
@@ -30,3 +30,28 @@ func JSONNoSuchNote(c echo.Context) error {
 func JSONAccessDenied(c echo.Context) error {
 	return c.JSON(http.StatusForbidden, AccessDenied())
 }
+
+// JSONNoSuchRenoteTarget writes a 404 NO_SUCH_RENOTE_TARGET response to the client.
+func JSONNoSuchRenoteTarget(c echo.Context) error {
+	return c.JSON(http.StatusNotFound, NoSuchRenoteTarget())
+}
+
+// JSONNoSuchReplyTarget writes a 404 NO_SUCH_REPLY_TARGET response to the client.
+func JSONNoSuchReplyTarget(c echo.Context) error {
+	return c.JSON(http.StatusNotFound, NoSuchReplyTarget())
+}
+
+// JSONCannotReplyToAnInvisibleNote writes a 403 CANNOT_REPLY_TO_AN_INVISIBLE_NOTE response.
+func JSONCannotReplyToAnInvisibleNote(c echo.Context) error {
+	return c.JSON(http.StatusForbidden, CannotReplyToAnInvisibleNote())
+}
+
+// JSONCannotRenoteDueToVisibility writes a 403 CANNOT_RENOTE_DUE_TO_VISIBILITY response.
+func JSONCannotRenoteDueToVisibility(c echo.Context) error {
+	return c.JSON(http.StatusForbidden, CannotRenoteDueToVisibility())
+}
+
+// JSONNoSuchChannel writes a 404 NO_SUCH_CHANNEL response to the client.
+func JSONNoSuchChannel(c echo.Context) error {
+	return c.JSON(http.StatusNotFound, NoSuchChannel())
+}

--- a/internal/api/apierr/echo_test.go
+++ b/internal/api/apierr/echo_test.go
@@ -62,3 +62,43 @@ func TestJSONAccessDenied(t *testing.T) {
 	assert.Equal(t, "ACCESS_DENIED", errObj["code"])
 	assert.Equal(t, UUIDAccessDenied, errObj["id"])
 }
+
+func TestJSONNoSuchRenoteTarget(t *testing.T) {
+	code, body := invoke(t, JSONNoSuchRenoteTarget)
+	assert.Equal(t, http.StatusNotFound, code)
+	errObj := body["error"].(map[string]any)
+	assert.Equal(t, "NO_SUCH_RENOTE_TARGET", errObj["code"])
+	assert.Equal(t, UUIDNoSuchRenoteTarget, errObj["id"])
+}
+
+func TestJSONNoSuchReplyTarget(t *testing.T) {
+	code, body := invoke(t, JSONNoSuchReplyTarget)
+	assert.Equal(t, http.StatusNotFound, code)
+	errObj := body["error"].(map[string]any)
+	assert.Equal(t, "NO_SUCH_REPLY_TARGET", errObj["code"])
+	assert.Equal(t, UUIDNoSuchReplyTarget, errObj["id"])
+}
+
+func TestJSONCannotReplyToAnInvisibleNote(t *testing.T) {
+	code, body := invoke(t, JSONCannotReplyToAnInvisibleNote)
+	assert.Equal(t, http.StatusForbidden, code)
+	errObj := body["error"].(map[string]any)
+	assert.Equal(t, "CANNOT_REPLY_TO_AN_INVISIBLE_NOTE", errObj["code"])
+	assert.Equal(t, UUIDCannotReplyToAnInvisibleNote, errObj["id"])
+}
+
+func TestJSONCannotRenoteDueToVisibility(t *testing.T) {
+	code, body := invoke(t, JSONCannotRenoteDueToVisibility)
+	assert.Equal(t, http.StatusForbidden, code)
+	errObj := body["error"].(map[string]any)
+	assert.Equal(t, "CANNOT_RENOTE_DUE_TO_VISIBILITY", errObj["code"])
+	assert.Equal(t, UUIDCannotRenoteDueToVisibility, errObj["id"])
+}
+
+func TestJSONNoSuchChannel(t *testing.T) {
+	code, body := invoke(t, JSONNoSuchChannel)
+	assert.Equal(t, http.StatusNotFound, code)
+	errObj := body["error"].(map[string]any)
+	assert.Equal(t, "NO_SUCH_CHANNEL", errObj["code"])
+	assert.Equal(t, UUIDNoSuchChannel, errObj["id"])
+}

--- a/internal/api/apierr/errors.go
+++ b/internal/api/apierr/errors.go
@@ -22,12 +22,34 @@ func Error(code, message, id string) map[string]any {
 
 // Canonical UUIDs for frequently-used error codes.
 // Any handler returning these codes should use the constants to prevent drift.
+// UUIDs are sourced from third_party/misskey/packages/backend/src/server/api/endpoints/
+// and must match the upstream Misskey implementation so that clients can identify
+// errors by their `id` field.
 const (
 	UUIDInvalidParam  = "3d81ceae-475f-4600-b2a8-2bc116157532"
 	UUIDInternalError = "5d37dbcb-891e-41ca-a3d6-e690c97775ac"
-	UUIDNoSuchNote    = "24fcbfc6-2e37-42b6-8388-c29b32725715"
+	UUIDNoSuchNote    = "24fcbfc6-2e37-42b6-8388-c29b3861a08d"
 	UUIDNoSuchUser    = "4362f8dc-731f-4ad8-a694-be5a88922a24"
 	UUIDAccessDenied  = "1fb7cb09-d46a-4fff-b8df-057708cce513"
+
+	// UUIDs for notes/create errors (third_party/misskey/.../endpoints/notes/create.ts).
+	UUIDNoSuchRenoteTarget                                         = "b5c90186-4ab0-49c8-9bba-a1f76c282ba4"
+	UUIDCannotRenoteToAPureRenote                                  = "fd4cc33e-2a37-48dd-99cc-9b806eb2031a"
+	UUIDCannotRenoteDueToVisibility                                = "be9529e9-fe72-4de0-ae43-0b363c4938af"
+	UUIDNoSuchReplyTarget                                          = "749ee0f6-d3da-459a-bf02-282e2da4292c"
+	UUIDCannotReplyToAnInvisibleNote                               = "b98980fa-3780-406c-a935-b6d0eeee10d1"
+	UUIDCannotReplyToAPureRenote                                   = "3ac74a84-8fd5-4bb0-870f-01804f82ce15"
+	UUIDCannotReplyToSpecifiedVisibilityNoteWithExtendedVisibility = "ed940410-535c-4d5e-bfa3-af798671e93c"
+	UUIDCannotCreateAlreadyExpiredPoll                             = "04da457d-b083-4055-9082-955525eda5a5"
+	UUIDNoSuchChannel                                              = "b1653923-5453-4edc-b786-7c4f39bb0bbb"
+	UUIDYouHaveBeenBlocked                                         = "b390d7e1-8a5e-46ed-b625-06271cafd3d3"
+	UUIDNoSuchFile                                                 = "b6992544-63e7-67f0-fa7f-32444b1b5306"
+	UUIDCannotRenoteOutsideOfChannel                               = "33510210-8452-094c-6227-4a6c05d99f00"
+	UUIDContainsProhibitedWords                                    = "aa6e01d3-a85c-669d-758a-76aab43af334"
+	UUIDContainsTooManyMentions                                    = "4de0363a-3046-481b-9b0f-feff3e211025"
+
+	// UUID for users/show (third_party/misskey/.../endpoints/users/show.ts).
+	UUIDFailedToResolveRemoteUser = "ef7b9be4-9cba-4e6f-ab41-90ed171c7d3c"
 )
 
 // InvalidParam returns a 400 INVALID_PARAM error response.
@@ -53,4 +75,29 @@ func NoSuchUser() map[string]any {
 // AccessDenied returns a 403 ACCESS_DENIED error response.
 func AccessDenied() map[string]any {
 	return Error("ACCESS_DENIED", "Access denied.", UUIDAccessDenied)
+}
+
+// NoSuchRenoteTarget returns a 404 NO_SUCH_RENOTE_TARGET error response.
+func NoSuchRenoteTarget() map[string]any {
+	return Error("NO_SUCH_RENOTE_TARGET", "No such renote target.", UUIDNoSuchRenoteTarget)
+}
+
+// NoSuchReplyTarget returns a 404 NO_SUCH_REPLY_TARGET error response.
+func NoSuchReplyTarget() map[string]any {
+	return Error("NO_SUCH_REPLY_TARGET", "No such reply target.", UUIDNoSuchReplyTarget)
+}
+
+// CannotReplyToAnInvisibleNote returns a 403 CANNOT_REPLY_TO_AN_INVISIBLE_NOTE error response.
+func CannotReplyToAnInvisibleNote() map[string]any {
+	return Error("CANNOT_REPLY_TO_AN_INVISIBLE_NOTE", "You cannot reply to an invisible Note.", UUIDCannotReplyToAnInvisibleNote)
+}
+
+// CannotRenoteDueToVisibility returns a 403 CANNOT_RENOTE_DUE_TO_VISIBILITY error response.
+func CannotRenoteDueToVisibility() map[string]any {
+	return Error("CANNOT_RENOTE_DUE_TO_VISIBILITY", "You can not Renote due to target visibility.", UUIDCannotRenoteDueToVisibility)
+}
+
+// NoSuchChannel returns a 404 NO_SUCH_CHANNEL error response.
+func NoSuchChannel() map[string]any {
+	return Error("NO_SUCH_CHANNEL", "No such channel.", UUIDNoSuchChannel)
 }

--- a/internal/api/apierr/errors_test.go
+++ b/internal/api/apierr/errors_test.go
@@ -49,3 +49,74 @@ func TestAccessDenied(t *testing.T) {
 	assert.Equal(t, "ACCESS_DENIED", errObj["code"])
 	assert.Equal(t, UUIDAccessDenied, errObj["id"])
 }
+
+func TestNoSuchRenoteTarget(t *testing.T) {
+	result := NoSuchRenoteTarget()
+	errObj := result["error"].(map[string]any)
+	assert.Equal(t, "NO_SUCH_RENOTE_TARGET", errObj["code"])
+	assert.Equal(t, UUIDNoSuchRenoteTarget, errObj["id"])
+}
+
+func TestNoSuchReplyTarget(t *testing.T) {
+	result := NoSuchReplyTarget()
+	errObj := result["error"].(map[string]any)
+	assert.Equal(t, "NO_SUCH_REPLY_TARGET", errObj["code"])
+	assert.Equal(t, UUIDNoSuchReplyTarget, errObj["id"])
+}
+
+func TestCannotReplyToAnInvisibleNote(t *testing.T) {
+	result := CannotReplyToAnInvisibleNote()
+	errObj := result["error"].(map[string]any)
+	assert.Equal(t, "CANNOT_REPLY_TO_AN_INVISIBLE_NOTE", errObj["code"])
+	assert.Equal(t, UUIDCannotReplyToAnInvisibleNote, errObj["id"])
+}
+
+func TestCannotRenoteDueToVisibility(t *testing.T) {
+	result := CannotRenoteDueToVisibility()
+	errObj := result["error"].(map[string]any)
+	assert.Equal(t, "CANNOT_RENOTE_DUE_TO_VISIBILITY", errObj["code"])
+	assert.Equal(t, UUIDCannotRenoteDueToVisibility, errObj["id"])
+}
+
+func TestNoSuchChannel(t *testing.T) {
+	result := NoSuchChannel()
+	errObj := result["error"].(map[string]any)
+	assert.Equal(t, "NO_SUCH_CHANNEL", errObj["code"])
+	assert.Equal(t, UUIDNoSuchChannel, errObj["id"])
+}
+
+// TestUUIDConstants_MatchUpstream guards against drift between the Go
+// constants and the upstream Misskey error UUIDs. The values on the right
+// are copied verbatim from third_party/misskey/packages/backend/src/server/
+// api/endpoints/.../meta.errors blocks and must never be edited without
+// updating the corresponding upstream reference.
+func TestUUIDConstants_MatchUpstream(t *testing.T) {
+	cases := []struct {
+		name     string
+		got      string
+		expected string
+	}{
+		{"NoSuchNote", UUIDNoSuchNote, "24fcbfc6-2e37-42b6-8388-c29b3861a08d"},
+		{"NoSuchUser", UUIDNoSuchUser, "4362f8dc-731f-4ad8-a694-be5a88922a24"},
+		{"NoSuchRenoteTarget", UUIDNoSuchRenoteTarget, "b5c90186-4ab0-49c8-9bba-a1f76c282ba4"},
+		{"CannotRenoteToAPureRenote", UUIDCannotRenoteToAPureRenote, "fd4cc33e-2a37-48dd-99cc-9b806eb2031a"},
+		{"CannotRenoteDueToVisibility", UUIDCannotRenoteDueToVisibility, "be9529e9-fe72-4de0-ae43-0b363c4938af"},
+		{"NoSuchReplyTarget", UUIDNoSuchReplyTarget, "749ee0f6-d3da-459a-bf02-282e2da4292c"},
+		{"CannotReplyToAnInvisibleNote", UUIDCannotReplyToAnInvisibleNote, "b98980fa-3780-406c-a935-b6d0eeee10d1"},
+		{"CannotReplyToAPureRenote", UUIDCannotReplyToAPureRenote, "3ac74a84-8fd5-4bb0-870f-01804f82ce15"},
+		{"CannotReplyToSpecifiedVisibilityNoteWithExtendedVisibility", UUIDCannotReplyToSpecifiedVisibilityNoteWithExtendedVisibility, "ed940410-535c-4d5e-bfa3-af798671e93c"},
+		{"CannotCreateAlreadyExpiredPoll", UUIDCannotCreateAlreadyExpiredPoll, "04da457d-b083-4055-9082-955525eda5a5"},
+		{"NoSuchChannel", UUIDNoSuchChannel, "b1653923-5453-4edc-b786-7c4f39bb0bbb"},
+		{"YouHaveBeenBlocked", UUIDYouHaveBeenBlocked, "b390d7e1-8a5e-46ed-b625-06271cafd3d3"},
+		{"NoSuchFile", UUIDNoSuchFile, "b6992544-63e7-67f0-fa7f-32444b1b5306"},
+		{"CannotRenoteOutsideOfChannel", UUIDCannotRenoteOutsideOfChannel, "33510210-8452-094c-6227-4a6c05d99f00"},
+		{"ContainsProhibitedWords", UUIDContainsProhibitedWords, "aa6e01d3-a85c-669d-758a-76aab43af334"},
+		{"ContainsTooManyMentions", UUIDContainsTooManyMentions, "4de0363a-3046-481b-9b0f-feff3e211025"},
+		{"FailedToResolveRemoteUser", UUIDFailedToResolveRemoteUser, "ef7b9be4-9cba-4e6f-ab41-90ed171c7d3c"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.expected, tc.got)
+		})
+	}
+}

--- a/internal/api/i/handler.go
+++ b/internal/api/i/handler.go
@@ -595,7 +595,7 @@ func (h *Handler) Pin(c echo.Context) error {
 	if err := h.userService.PinNote(me.ID, req.NoteID); err != nil {
 		switch {
 		case errors.Is(err, user.ErrNoteNotFound):
-			return c.JSON(http.StatusNotFound, apierr.Error("NO_SUCH_NOTE", "No such note.", "24fcbfc6-2e37-42b6-8388-c29b32725715"))
+			return apierr.JSONNoSuchNote(c)
 		case errors.Is(err, user.ErrAlreadyPinned):
 			return c.JSON(http.StatusBadRequest, apierr.Error("ALREADY_PINNED", "That note has already been pinned.", "8b18c2b7-68fe-4edb-9892-c0cbaeb6c913"))
 		case errors.Is(err, user.ErrPinLimitExceeded):
@@ -619,7 +619,7 @@ func (h *Handler) Unpin(c echo.Context) error {
 
 	if err := h.userService.UnpinNote(me.ID, req.NoteID); err != nil {
 		if errors.Is(err, user.ErrPinNotFound) {
-			return c.JSON(http.StatusNotFound, apierr.Error("NO_SUCH_NOTE", "No such note.", "24fcbfc6-2e37-42b6-8388-c29b32725715"))
+			return apierr.JSONNoSuchNote(c)
 		}
 		return apierr.JSONInternalError(c)
 	}

--- a/internal/api/notes/handler.go
+++ b/internal/api/notes/handler.go
@@ -164,10 +164,16 @@ func (h *Handler) Create(c echo.Context) error {
 		switch {
 		case errors.Is(err, note.ErrNoteContentRequired):
 			return c.JSON(http.StatusBadRequest, apierr.Error("INVALID_PARAM", "Text, fileIds, or renoteId is required.", apierr.UUIDInvalidParam))
-		case errors.Is(err, note.ErrReplyTargetNotFound), errors.Is(err, note.ErrRenoteTargetNotFound):
-			return c.JSON(http.StatusNotFound, apierr.NoSuchNote())
-		case errors.Is(err, note.ErrCannotReplyToInvisibleNote), errors.Is(err, note.ErrCannotRenoteInvisibleNote):
-			return c.JSON(http.StatusForbidden, apierr.Error("CANNOT_REPLY_TO_INVISIBLE_NOTE", "You can not see this note.", "44b07c37-2deb-4b34-9ec9-b1deeed42f0d"))
+		case errors.Is(err, note.ErrReplyTargetNotFound):
+			return apierr.JSONNoSuchReplyTarget(c)
+		case errors.Is(err, note.ErrRenoteTargetNotFound):
+			return apierr.JSONNoSuchRenoteTarget(c)
+		case errors.Is(err, note.ErrCannotReplyToInvisibleNote):
+			return apierr.JSONCannotReplyToAnInvisibleNote(c)
+		case errors.Is(err, note.ErrCannotRenoteInvisibleNote):
+			return apierr.JSONCannotRenoteDueToVisibility(c)
+		case errors.Is(err, note.ErrChannelNotFound):
+			return apierr.JSONNoSuchChannel(c)
 		}
 		return apierr.JSONInternalError(c)
 	}

--- a/internal/api/notes/handler_extra.go
+++ b/internal/api/notes/handler_extra.go
@@ -27,7 +27,7 @@ func (h *Handler) FavoritesCreate(c echo.Context) error {
 		return c.JSON(http.StatusBadRequest, apierr.Error("INVALID_PARAM", "noteId is required.", "3d81ceae-475f-4600-b2a8-2bc116157532"))
 	}
 	if _, err := h.noteRepo.FindByID(req.NoteID); err != nil {
-		return c.JSON(http.StatusNotFound, apierr.Error("NO_SUCH_NOTE", "No such note.", "24fcbfc6-2e37-42b6-8388-c29b32725715"))
+		return apierr.JSONNoSuchNote(c)
 	}
 	if h.favoriteRepo == nil {
 		return c.JSON(http.StatusInternalServerError, apierr.Error("INTERNAL_ERROR", "Internal error.", "5d37dbcb-891e-41ca-a3d6-e690c97775ac"))
@@ -97,7 +97,7 @@ func (h *Handler) Unrenote(c echo.Context) error {
 	// renoteId が指定ノートの自分のノートを探して削除
 	renote, err := h.noteRepo.FindRenoteByUser(user.ID, req.NoteID)
 	if err != nil {
-		return c.JSON(http.StatusNotFound, apierr.Error("NO_SUCH_NOTE", "No such renote.", "24fcbfc6-2e37-42b6-8388-c29b32725715"))
+		return apierr.JSONNoSuchNote(c)
 	}
 	if err := h.deleteService.Delete(user, renote.ID); err != nil {
 		return c.JSON(http.StatusInternalServerError, apierr.Error("INTERNAL_ERROR", "Internal error.", "5d37dbcb-891e-41ca-a3d6-e690c97775ac"))
@@ -217,7 +217,7 @@ func (h *Handler) Translate(c echo.Context) error {
 
 	n, err := h.noteRepo.FindByID(req.NoteID)
 	if err != nil {
-		return c.JSON(http.StatusNotFound, apierr.Error("NO_SUCH_NOTE", "No such note.", "24fcbfc6-2e37-42b6-8388-c29b32725715"))
+		return apierr.JSONNoSuchNote(c)
 	}
 
 	if n.Text == nil || *n.Text == "" {

--- a/internal/api/notes/handler_query_test.go
+++ b/internal/api/notes/handler_query_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	"github.com/labstack/echo/v4"
+	"github.com/shiroha-a/mk/internal/api/apierr"
 	corenote "github.com/shiroha-a/mk/internal/core/note"
 	"github.com/shiroha-a/mk/internal/core/search"
 	"github.com/shiroha-a/mk/internal/misc/id"
@@ -359,8 +360,8 @@ func (f *findFailQueryRepo) FindByIDWithUser(_ string) (*model.Note, error) {
 	return nil, testutil.ErrNotFound
 }
 
-// TestCreate_ReplyTargetNotFound triggers the new "No such note" branch in Create
-// when the reply target does not exist.
+// TestCreate_ReplyTargetNotFound triggers the NO_SUCH_REPLY_TARGET branch in
+// Create when the reply target does not exist.
 func TestCreate_ReplyTargetNotFound(t *testing.T) {
 	h, _ := newQueryHandler(t)
 	user := &model.User{ID: "u", Username: "u"}
@@ -370,10 +371,15 @@ func TestCreate_ReplyTargetNotFound(t *testing.T) {
 	setAuthUser(c, user)
 	require.NoError(t, h.Create(c))
 	assert.Equal(t, http.StatusNotFound, rec.Code)
+	var resp map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+	errObj := resp["error"].(map[string]any)
+	assert.Equal(t, "NO_SUCH_REPLY_TARGET", errObj["code"])
+	assert.Equal(t, apierr.UUIDNoSuchReplyTarget, errObj["id"])
 }
 
-// TestCreate_RenoteTargetInvisible triggers the new "forbidden" branch when the
-// renote target is not visible to the actor.
+// TestCreate_RenoteTargetInvisible triggers the CANNOT_RENOTE_DUE_TO_VISIBILITY
+// branch when the renote target is not visible to the actor.
 func TestCreate_RenoteTargetInvisible(t *testing.T) {
 	h, repo := newQueryHandler(t)
 	repo.Notes["secret"] = &model.Note{
@@ -386,6 +392,11 @@ func TestCreate_RenoteTargetInvisible(t *testing.T) {
 	setAuthUser(c, user)
 	require.NoError(t, h.Create(c))
 	assert.Equal(t, http.StatusForbidden, rec.Code)
+	var resp map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+	errObj := resp["error"].(map[string]any)
+	assert.Equal(t, "CANNOT_RENOTE_DUE_TO_VISIBILITY", errObj["code"])
+	assert.Equal(t, apierr.UUIDCannotRenoteDueToVisibility, errObj["id"])
 }
 
 // TestShow_FallbackNoQueryService verifies the lookupVisible nil-queryService path.

--- a/internal/api/notes/handler_test.go
+++ b/internal/api/notes/handler_test.go
@@ -2,12 +2,14 @@ package notes
 
 import (
 	"encoding/json"
+	"errors"
 	"net/http"
 	"net/http/httptest"
 	"strings"
 	"testing"
 
 	"github.com/labstack/echo/v4"
+	"github.com/shiroha-a/mk/internal/api/apierr"
 	corenote "github.com/shiroha-a/mk/internal/core/note"
 	"github.com/shiroha-a/mk/internal/misc/id"
 	"github.com/shiroha-a/mk/internal/model"
@@ -505,6 +507,114 @@ func TestCreate_FindByIDWithUserFails(t *testing.T) {
 	err := h.Create(c)
 	require.NoError(t, err)
 	assert.Equal(t, http.StatusOK, rec.Code)
+}
+
+// decodeError extracts the error.id field from a JSON error response.
+func decodeError(t *testing.T, body []byte) (code, id string) {
+	t.Helper()
+	var resp map[string]any
+	require.NoError(t, json.Unmarshal(body, &resp))
+	errObj := resp["error"].(map[string]any)
+	return errObj["code"].(string), errObj["id"].(string)
+}
+
+func TestCreate_RenoteTargetNotFound(t *testing.T) {
+	noteRepo := &failingNoteRepo{}
+	pollRepo := testutil.NewMockPollRepository()
+	idGen, _ := id.NewGenerator("aidx")
+	createSvc := corenote.NewCreateService(noteRepo, pollRepo, idGen, nil)
+	deleteSvc := corenote.NewDeleteService(noteRepo)
+	querySvc := corenote.NewQueryService(noteRepo, nil)
+	h := NewHandler(noteRepo, createSvc, deleteSvc, querySvc, nil, nil, nil, nil, idGen)
+
+	user := &model.User{ID: "user1", Username: "testuser"}
+
+	body := `{"renoteId": "nonexistent"}`
+	e := echo.New()
+	req := httptest.NewRequest(http.MethodPost, "/api/notes/create", strings.NewReader(body))
+	req.Header.Set(echo.HeaderContentType, echo.MIMEApplicationJSON)
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+	setAuthUser(c, user)
+
+	require.NoError(t, h.Create(c))
+	assert.Equal(t, http.StatusNotFound, rec.Code)
+	code, uuidStr := decodeError(t, rec.Body.Bytes())
+	assert.Equal(t, "NO_SUCH_RENOTE_TARGET", code)
+	assert.Equal(t, apierr.UUIDNoSuchRenoteTarget, uuidStr)
+}
+
+// fixedNoteRepo returns a preset note for FindByIDWithUser so visibility-check
+// paths can be exercised without touching a real database.
+type fixedNoteRepo struct {
+	*testutil.MockNoteRepository
+	note *model.Note
+}
+
+func (r *fixedNoteRepo) FindByIDWithUser(_ string) (*model.Note, error) {
+	return r.note, nil
+}
+
+func TestCreate_CannotReplyToInvisibleNote(t *testing.T) {
+	hiddenNote := &model.Note{ID: "n1", UserID: "other", Visibility: model.NoteVisibilityFollowers}
+	noteRepo := &fixedNoteRepo{MockNoteRepository: testutil.NewMockNoteRepository(), note: hiddenNote}
+	pollRepo := testutil.NewMockPollRepository()
+	idGen, _ := id.NewGenerator("aidx")
+	createSvc := corenote.NewCreateService(noteRepo, pollRepo, idGen, nil)
+	deleteSvc := corenote.NewDeleteService(noteRepo)
+	querySvc := corenote.NewQueryService(noteRepo, nil)
+	h := NewHandler(noteRepo, createSvc, deleteSvc, querySvc, nil, nil, nil, nil, idGen)
+
+	user := &model.User{ID: "user1", Username: "testuser"}
+
+	body := `{"text": "reply", "replyId": "n1"}`
+	e := echo.New()
+	req := httptest.NewRequest(http.MethodPost, "/api/notes/create", strings.NewReader(body))
+	req.Header.Set(echo.HeaderContentType, echo.MIMEApplicationJSON)
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+	setAuthUser(c, user)
+
+	require.NoError(t, h.Create(c))
+	assert.Equal(t, http.StatusForbidden, rec.Code)
+	code, uuidStr := decodeError(t, rec.Body.Bytes())
+	assert.Equal(t, "CANNOT_REPLY_TO_AN_INVISIBLE_NOTE", code)
+	assert.Equal(t, apierr.UUIDCannotReplyToAnInvisibleNote, uuidStr)
+}
+
+// channelNotFoundHook は EnsureChannelExists が常にエラーを返すテストスタブ。
+type channelNotFoundHook struct{}
+
+func (channelNotFoundHook) EnsureChannelExists(_ string) error { return errNotFoundSentinel }
+func (channelNotFoundHook) OnNotePosted(_ string)              {}
+
+var errNotFoundSentinel = errors.New("channel not found")
+
+func TestCreate_ChannelNotFound(t *testing.T) {
+	noteRepo := testutil.NewMockNoteRepository()
+	pollRepo := testutil.NewMockPollRepository()
+	idGen, _ := id.NewGenerator("aidx")
+	createSvc := corenote.NewCreateService(noteRepo, pollRepo, idGen, nil)
+	createSvc.SetChannelHook(channelNotFoundHook{})
+	deleteSvc := corenote.NewDeleteService(noteRepo)
+	querySvc := corenote.NewQueryService(noteRepo, nil)
+	h := NewHandler(noteRepo, createSvc, deleteSvc, querySvc, nil, nil, nil, nil, idGen)
+
+	user := &model.User{ID: "user1", Username: "testuser"}
+
+	body := `{"text": "to channel", "channelId": "nonexistent"}`
+	e := echo.New()
+	req := httptest.NewRequest(http.MethodPost, "/api/notes/create", strings.NewReader(body))
+	req.Header.Set(echo.HeaderContentType, echo.MIMEApplicationJSON)
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+	setAuthUser(c, user)
+
+	require.NoError(t, h.Create(c))
+	assert.Equal(t, http.StatusNotFound, rec.Code)
+	code, uuidStr := decodeError(t, rec.Body.Bytes())
+	assert.Equal(t, "NO_SUCH_CHANNEL", code)
+	assert.Equal(t, apierr.UUIDNoSuchChannel, uuidStr)
 }
 
 func TestDelete_InvalidJSON(t *testing.T) {

--- a/internal/server/router.go
+++ b/internal/server/router.go
@@ -18,6 +18,7 @@ import (
 	apiannouncements "github.com/shiroha-a/mk/internal/api/announcements"
 	"github.com/shiroha-a/mk/internal/api/antennas"
 	"github.com/shiroha-a/mk/internal/api/ap"
+	"github.com/shiroha-a/mk/internal/api/apierr"
 	apiapp "github.com/shiroha-a/mk/internal/api/app"
 	apiauth "github.com/shiroha-a/mk/internal/api/auth"
 	"github.com/shiroha-a/mk/internal/api/blocking"
@@ -1660,13 +1661,7 @@ func (s *Server) setupRoutes() {
 			})
 		}
 		if _, err := noteRepo.FindByID(req.NoteID); err != nil {
-			return c.JSON(http.StatusNotFound, map[string]any{
-				"error": map[string]any{
-					"message": "No such note.",
-					"code":    "NO_SUCH_NOTE",
-					"id":      "24fcbfc6-2e37-42b6-8388-c29b32725715",
-				},
-			})
+			return apierr.JSONNoSuchNote(c)
 		}
 		_ = promoReadRepo.MarkRead(&model.PromoRead{
 			ID:     idGen.Generate(time.Now()),


### PR DESCRIPTION
## Summary

Misskey 本家フロント (TypeScript) との**エラー互換性**を回復するため、notes 系の UUID 不整合と apierr パッケージの整備を行う。

フロントは `err.id` (UUID) でエラーを識別するため、UUID が本家と一致しないと「削除された note の UI 表示」等のエラーハンドリング分岐が動かない。本 PR でこの互換性を回復する。

## 主な変更点

### 1. UUID 修正

`UUIDNoSuchNote` を本家と一致させる：

| | Before | After |
|---|---|---|
| UUID | `24fcbfc6-2e37-42b6-8388-c29b32725715` | `24fcbfc6-2e37-42b6-8388-c29b3861a08d` |

本家 TS 出典: `third_party/misskey/packages/backend/src/server/api/endpoints/notes/show.ts:29`

### 2. UUID 定数の追加

`notes/create` で使われる 14 種と `users/show` の 1 種を `internal/api/apierr/errors.go` に定数化：

- `UUIDNoSuchRenoteTarget` / `UUIDCannotRenoteToAPureRenote` / `UUIDCannotRenoteDueToVisibility`
- `UUIDNoSuchReplyTarget` / `UUIDCannotReplyToAnInvisibleNote` / `UUIDCannotReplyToAPureRenote` / `UUIDCannotReplyToSpecifiedVisibilityNoteWithExtendedVisibility`
- `UUIDCannotCreateAlreadyExpiredPoll` / `UUIDNoSuchChannel` / `UUIDYouHaveBeenBlocked` / `UUIDNoSuchFile`
- `UUIDCannotRenoteOutsideOfChannel` / `UUIDContainsProhibitedWords` / `UUIDContainsTooManyMentions`
- `UUIDFailedToResolveRemoteUser`

### 3. apierr ヘルパー追加

service 層に既に sentinel error がある 5 種に対応する helper と JSON ヘルパーを追加：
`NoSuchRenoteTarget` / `NoSuchReplyTarget` / `CannotReplyToAnInvisibleNote` / `CannotRenoteDueToVisibility` / `NoSuchChannel`

### 4. notes/Create の error mapping 修正

従来は 5 種の sentinel error を 2 種にまとめて同じエラーを返していた。これを分離：

| sentinel | Before | After |
|---|---|---|
| `ErrReplyTargetNotFound` | NO_SUCH_NOTE | NO_SUCH_REPLY_TARGET |
| `ErrRenoteTargetNotFound` | NO_SUCH_NOTE | NO_SUCH_RENOTE_TARGET |
| `ErrCannotReplyToInvisibleNote` | CANNOT_REPLY_TO_INVISIBLE_NOTE (非 TS互換 UUID) | CANNOT_REPLY_TO_AN_INVISIBLE_NOTE |
| `ErrCannotRenoteInvisibleNote` | 同上 (同じ UUID に collapse) | CANNOT_RENOTE_DUE_TO_VISIBILITY |
| `ErrChannelNotFound` | ハンドリングなし (500 INTERNAL_ERROR にフォールバック) | NO_SUCH_CHANNEL |

### 5. ハードコード UUID の集約

旧実装で直接リテラル UUID を埋め込んでいた 6 箇所を `apierr.JSONNoSuchNote(c)` 等のヘルパー経由に統一。これにより今後 UUID がドリフトしない：

- `internal/api/notes/handler_extra.go` (3 箇所)
- `internal/api/i/handler.go` (2 箇所 — pin/unpin)
- `internal/server/router.go` (1 箇所 — promo read)

## スコープ外（追跡 issue あり）

以下は service 層の改修が必要なため、本 PR では **UUID 定数追加のみ**：

- `YOU_HAVE_BEEN_BLOCKED` / `NO_SUCH_FILE` / `CANNOT_CREATE_ALREADY_EXPIRED_POLL`
- `CANNOT_RENOTE_TO_A_PURE_RENOTE` / `CANNOT_RENOTE_OUTSIDE_OF_CHANNEL`
- `CONTAINS_PROHIBITED_WORDS` / `CONTAINS_TOO_MANY_MENTIONS`
- `FAILED_TO_RESOLVE_REMOTE_USER`

これらの実際の emit は service 層への sentinel error 追加と分岐条件実装が必要で、別 issue で追跡します。

## テスト

追加：
- `TestUUIDConstants_MatchUpstream` — 17 件の UUID を TS本家出典と golden assertion 比較（将来のドリフト検出）
- `TestNoSuchRenoteTarget` / `TestNoSuchReplyTarget` / `TestCannotReplyToAnInvisibleNote` / `TestCannotRenoteDueToVisibility` / `TestNoSuchChannel` — helper 単体
- 対応する `TestJSON*` — echo 経由テスト
- `TestCreate_RenoteTargetNotFound` / `TestCreate_CannotReplyToInvisibleNote` / `TestCreate_ChannelNotFound` — handler の分岐挙動
- 既存の `TestCreate_ReplyTargetNotFound` / `TestCreate_RenoteTargetInvisible` を error code + UUID assertion 付きに格上げ

検証：
\`\`\`
go test ./internal/api/apierr/...   # coverage 100%
go test ./internal/api/notes/...    # coverage 94.4%
go test ./internal/api/i/...        # coverage 91.2%
\`\`\`

make fmt / make lint 通過。make test で 2 件の失敗があるが、`internal/core/mediaproxy` と `internal/repository/emoji` で**本 PR と無関係の既存失敗**（develop ブランチでも再現）。別 issue で追跡予定。

## Closes

Closes #243

## 関連

- Parent: #242 Phase 7 TS フロント互換性ギャップ修正（トラッカー）
- 過去の類似修正: #225 (P5-11), #224 (P5-10), #209 (P5-9 placeholder UUID)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/shiroha-a/mk/pull/252" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
