### PR TITLE
Phase 7-5c features.{local,global}Timeline + noteSearchableScope 互換化

### DIFF
--- a/internal/api/meta/handler.go
+++ b/internal/api/meta/handler.go
@@ -105,7 +105,6 @@ func (h *Handler) Meta(c echo.Context) error {
 		"providesTarball":              false,
 		"maxFileSize":                  h.config.MaxFileSize,
 		"proxyAccountName":             nil,
-		"noteSearchableScope":          "local",
 		"enableMcaptcha":               m.EnableMcaptcha,
 		"mcaptchaSiteKey":              m.McaptchaSiteKey,
 		"mcaptchaInstanceUrl":          m.McaptchaInstanceURL,
@@ -121,6 +120,8 @@ func (h *Handler) Meta(c echo.Context) error {
 		"features": map[string]any{
 			"registration":           !m.DisableRegistration,
 			"emailRequiredForSignup": m.EmailRequiredForSignup,
+			"localTimeline":          policyBool(role.DefaultPolicies(), "ltlAvailable"),
+			"globalTimeline":         policyBool(role.DefaultPolicies(), "gtlAvailable"),
 			"hcaptcha":               m.EnableHcaptcha,
 			"recaptcha":              m.EnableRecaptcha,
 			"turnstile":              m.EnableTurnstile,
@@ -129,6 +130,10 @@ func (h *Handler) Meta(c echo.Context) error {
 			"miauth":                 true,
 		},
 	}
+
+	// noteSearchableScope: Meilisearch 設定に準拠。本家 (MetaEntityService.ts:135)
+	// では `meilisearch.scope !== 'local'` の場合のみ "global" を返す。
+	resp["noteSearchableScope"] = noteSearchableScope(h.config.Meilisearch)
 
 	// detail=false: TS MetaLite互換。管理者/内部向けフィールド (features, policies,
 	// clientOptions, proxyAccountName, sentryForFrontend, noteSearchableScope,
@@ -186,6 +191,35 @@ func clientOptionsJSON(raw []byte) any {
 		return map[string]any{}
 	}
 	return out
+}
+
+// policyBool reads a boolean policy value from role.DefaultPolicies() output
+// with a conservative default. Unknown or non-bool values fall back to false
+// so the client never sees an undefined flag in the features block.
+func policyBool(policies map[string]any, key string) bool {
+	v, ok := policies[key]
+	if !ok {
+		return false
+	}
+	b, ok := v.(bool)
+	if !ok {
+		return false
+	}
+	return b
+}
+
+// noteSearchableScope derives the "local"/"global" search scope flag from
+// the Meilisearch configuration. Behavior mirrors upstream
+// MetaEntityService.ts:135 — only return "global" when Meilisearch is wired
+// and its scope override is anything other than "local".
+func noteSearchableScope(m *config.MeilisearchOptions) string {
+	if m == nil {
+		return "local"
+	}
+	if m.Scope == "" || m.Scope == "local" {
+		return "local"
+	}
+	return "global"
 }
 
 // serializeActiveAds fetches currently-active ads via adRepo and projects

--- a/internal/api/meta/handler.go
+++ b/internal/api/meta/handler.go
@@ -120,8 +120,8 @@ func (h *Handler) Meta(c echo.Context) error {
 		"features": map[string]any{
 			"registration":           !m.DisableRegistration,
 			"emailRequiredForSignup": m.EmailRequiredForSignup,
-			"localTimeline":          policyBool(role.DefaultPolicies(), "ltlAvailable"),
-			"globalTimeline":         policyBool(role.DefaultPolicies(), "gtlAvailable"),
+			"localTimeline":          PolicyBool(role.DefaultPolicies(), "ltlAvailable"),
+			"globalTimeline":         PolicyBool(role.DefaultPolicies(), "gtlAvailable"),
 			"hcaptcha":               m.EnableHcaptcha,
 			"recaptcha":              m.EnableRecaptcha,
 			"turnstile":              m.EnableTurnstile,
@@ -133,7 +133,7 @@ func (h *Handler) Meta(c echo.Context) error {
 
 	// noteSearchableScope: Meilisearch 設定に準拠。本家 (MetaEntityService.ts:135)
 	// では `meilisearch.scope !== 'local'` の場合のみ "global" を返す。
-	resp["noteSearchableScope"] = noteSearchableScope(h.config.Meilisearch)
+	resp["noteSearchableScope"] = NoteSearchableScope(h.config.Meilisearch)
 
 	// detail=false: TS MetaLite互換。管理者/内部向けフィールド (features, policies,
 	// clientOptions, proxyAccountName, sentryForFrontend, noteSearchableScope,
@@ -193,10 +193,10 @@ func clientOptionsJSON(raw []byte) any {
 	return out
 }
 
-// policyBool reads a boolean policy value from role.DefaultPolicies() output
+// PolicyBool reads a boolean policy value from role.DefaultPolicies() output
 // with a conservative default. Unknown or non-bool values fall back to false
 // so the client never sees an undefined flag in the features block.
-func policyBool(policies map[string]any, key string) bool {
+func PolicyBool(policies map[string]any, key string) bool {
 	v, ok := policies[key]
 	if !ok {
 		return false
@@ -208,11 +208,11 @@ func policyBool(policies map[string]any, key string) bool {
 	return b
 }
 
-// noteSearchableScope derives the "local"/"global" search scope flag from
+// NoteSearchableScope derives the "local"/"global" search scope flag from
 // the Meilisearch configuration. Behavior mirrors upstream
 // MetaEntityService.ts:135 — only return "global" when Meilisearch is wired
 // and its scope override is anything other than "local".
-func noteSearchableScope(m *config.MeilisearchOptions) string {
+func NoteSearchableScope(m *config.MeilisearchOptions) string {
 	if m == nil {
 		return "local"
 	}

--- a/internal/api/meta/handler_test.go
+++ b/internal/api/meta/handler_test.go
@@ -365,4 +365,111 @@ func TestMeta_DetailFalse(t *testing.T) {
 	assert.Nil(t, resp["features"])
 	assert.Nil(t, resp["policies"])
 	assert.Nil(t, resp["clientOptions"])
+	assert.Nil(t, resp["noteSearchableScope"])
+}
+
+// TestMeta_FeaturesTimelineFlags verifies that features.localTimeline and
+// features.globalTimeline are exposed from the default role policies, so the
+// frontend can decide whether to render LTL/GTL tabs.
+func TestMeta_FeaturesTimelineFlags(t *testing.T) {
+	h, metaRepo := newTestHandler()
+	metaRepo.Meta = &model.Meta{ID: "x"}
+
+	e := echo.New()
+	req := httptest.NewRequest(http.MethodPost, "/api/meta", nil)
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+	require.NoError(t, h.Meta(c))
+
+	var resp map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+	features, ok := resp["features"].(map[string]any)
+	require.True(t, ok, "features should be present when detail=true")
+	assert.Equal(t, true, features["localTimeline"], "ltlAvailable default is true")
+	assert.Equal(t, true, features["globalTimeline"], "gtlAvailable default is true")
+}
+
+// TestMeta_NoteSearchableScope_DefaultLocal covers the fallback path where
+// Meilisearch is not configured: scope must default to "local".
+func TestMeta_NoteSearchableScope_DefaultLocal(t *testing.T) {
+	h, metaRepo := newTestHandler()
+	metaRepo.Meta = &model.Meta{ID: "x"}
+	// config.Meilisearch is nil in newTestHandler().
+
+	e := echo.New()
+	req := httptest.NewRequest(http.MethodPost, "/api/meta", nil)
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+	require.NoError(t, h.Meta(c))
+
+	var resp map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+	assert.Equal(t, "local", resp["noteSearchableScope"])
+}
+
+// TestMeta_NoteSearchableScope_Global covers the Meilisearch-wired path where
+// scope is anything other than "local" (e.g. "global") — the response must
+// switch to "global".
+func TestMeta_NoteSearchableScope_Global(t *testing.T) {
+	cfg := &config.Config{
+		Version:     "2026.3.2",
+		URL:         "https://misskey.example.com",
+		Meilisearch: &config.MeilisearchOptions{Host: "ms", Port: "7700", Scope: "global"},
+	}
+	metaRepo := testutil.NewMockMetaRepository()
+	metaRepo.Meta = &model.Meta{ID: "x"}
+	h := NewHandler(cfg, metaRepo)
+
+	e := echo.New()
+	req := httptest.NewRequest(http.MethodPost, "/api/meta", nil)
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+	require.NoError(t, h.Meta(c))
+
+	var resp map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+	assert.Equal(t, "global", resp["noteSearchableScope"])
+}
+
+// TestMeta_NoteSearchableScope_MeilisearchLocal ensures that an explicit
+// Meilisearch scope of "local" still produces "local" (config-present path).
+func TestMeta_NoteSearchableScope_MeilisearchLocal(t *testing.T) {
+	cfg := &config.Config{
+		Version:     "2026.3.2",
+		URL:         "https://misskey.example.com",
+		Meilisearch: &config.MeilisearchOptions{Host: "ms", Port: "7700", Scope: "local"},
+	}
+	metaRepo := testutil.NewMockMetaRepository()
+	metaRepo.Meta = &model.Meta{ID: "x"}
+	h := NewHandler(cfg, metaRepo)
+
+	e := echo.New()
+	req := httptest.NewRequest(http.MethodPost, "/api/meta", nil)
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+	require.NoError(t, h.Meta(c))
+
+	var resp map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+	assert.Equal(t, "local", resp["noteSearchableScope"])
+}
+
+func TestPolicyBool(t *testing.T) {
+	cases := []struct {
+		name     string
+		policies map[string]any
+		key      string
+		want     bool
+	}{
+		{"present true", map[string]any{"k": true}, "k", true},
+		{"present false", map[string]any{"k": false}, "k", false},
+		{"missing", map[string]any{}, "k", false},
+		{"non-bool type", map[string]any{"k": "yes"}, "k", false},
+		{"nil value", map[string]any{"k": nil}, "k", false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, policyBool(tc.policies, tc.key))
+		})
+	}
 }

--- a/internal/api/meta/handler_test.go
+++ b/internal/api/meta/handler_test.go
@@ -469,7 +469,7 @@ func TestPolicyBool(t *testing.T) {
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			assert.Equal(t, tc.want, policyBool(tc.policies, tc.key))
+			assert.Equal(t, tc.want, PolicyBool(tc.policies, tc.key))
 		})
 	}
 }

--- a/internal/server/frontend.go
+++ b/internal/server/frontend.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/labstack/echo/v4"
+	"github.com/shiroha-a/mk/internal/api/meta"
 	"github.com/shiroha-a/mk/internal/config"
 	"github.com/shiroha-a/mk/internal/core/role"
 	"github.com/shiroha-a/mk/internal/frontendutil"
@@ -173,7 +174,7 @@ func buildMetaJSON(cfg *config.Config, m *model.Meta) string {
 		"providesTarball":              false,
 		"maxFileSize":                  cfg.MaxFileSize,
 		"proxyAccountName":             nil,
-		"noteSearchableScope":          "local",
+		"noteSearchableScope":          meta.NoteSearchableScope(cfg.Meilisearch),
 		"enableMcaptcha":               m.EnableMcaptcha,
 		"mcaptchaSiteKey":              m.McaptchaSiteKey,
 		"mcaptchaInstanceUrl":          m.McaptchaInstanceURL,
@@ -185,6 +186,8 @@ func buildMetaJSON(cfg *config.Config, m *model.Meta) string {
 		"features": map[string]any{
 			"registration":           !m.DisableRegistration,
 			"emailRequiredForSignup": m.EmailRequiredForSignup,
+			"localTimeline":          meta.PolicyBool(role.DefaultPolicies(), "ltlAvailable"),
+			"globalTimeline":         meta.PolicyBool(role.DefaultPolicies(), "gtlAvailable"),
 			"hcaptcha":               m.EnableHcaptcha,
 			"recaptcha":              m.EnableRecaptcha,
 			"turnstile":              m.EnableTurnstile,


### PR DESCRIPTION
## Summary

本家フロントが `/api/meta` で期待する 3 フィールドのうち、Go 側で欠落 or ハードコードになっていたものを TS 本家挙動に合わせる。

- `features.localTimeline` / `features.globalTimeline` — 未実装だったフラグを追加。フロントが LTL / GTL タブの表示可否を判定する
- `noteSearchableScope` — ハードコード `"local"` を Meilisearch 設定から動的に導出

## 主な変更点

### `internal/api/meta/handler.go`

**features ブロックに 2 フラグ追加**（本家 `MetaEntityService.ts:162-163` 相当）：

\`\`\`go
"features": map[string]any{
    ...
    "localTimeline":  policyBool(role.DefaultPolicies(), "ltlAvailable"),
    "globalTimeline": policyBool(role.DefaultPolicies(), "gtlAvailable"),
    ...
}
\`\`\`

**`noteSearchableScope` 動的化**（本家 `MetaEntityService.ts:135` 相当）：

\`\`\`go
resp["noteSearchableScope"] = noteSearchableScope(h.config.Meilisearch)
\`\`\`

- `config.Meilisearch == nil` → `"local"`（デフォルト）
- `Meilisearch.Scope == "local"` or `""` → `"local"`
- それ以外 → `"global"`

**ヘルパー 2 種追加**：
- `policyBool(policies, key)` — unknown / non-bool / nil に対して保守的に false
- `noteSearchableScope(m *config.MeilisearchOptions)` — 上記ロジック

### `internal/api/meta/handler_test.go`

- `TestMeta_FeaturesTimelineFlags` — LTL / GTL フラグが features に含まれる
- `TestMeta_NoteSearchableScope_DefaultLocal` — Meilisearch 未設定時のフォールバック
- `TestMeta_NoteSearchableScope_Global` — `scope="global"` で `"global"` 返却
- `TestMeta_NoteSearchableScope_MeilisearchLocal` — 明示 `"local"` のパス
- `TestPolicyBool` — missing / non-bool / nil の境界値
- 既存 `TestMeta_DetailFalse` に `noteSearchableScope` の omit 検証を追加

## スコープ判断

issue #249 の完了条件のうち以下は**本 PR では対応しない**旨、下記で個別に判断：

### 対応不要と判定

**admin/meta update 側での受理**：
`localTimeline` / `globalTimeline` / `noteSearchableScope` はいずれも **DB の meta 行由来ではなく**、role policies および config.yaml の Meilisearch 設定から導出される。本家実装（`MetaEntityService.ts`）も同様で、admin/meta update でこれらを受け付ける設計になっていない。したがって admin/meta ハンドラの改修は不要。

### 別 issue で追跡

**Meta 全フィールドの field-by-field diff レポート**：
TS 本家 meta.ts の 50+ フィールドを全列挙して Go と diff する作業は、規模が別ユニットのため**別 issue に切り出す**（本 PR merge 後に立てる）。

## テスト

\`\`\`
$ go test -coverprofile=cov ./internal/api/meta/...
ok  github.com/shiroha-a/mk/internal/api/meta  0.021s  coverage: 100.0% of statements
\`\`\`

`make fmt` / `make lint` 通過。

## Closes

Closes #249

## 関連

- Parent: #242 Phase 7 TS フロント互換性ギャップ修正
- Follow-up (作成予定): Meta 全フィールド field-by-field diff

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/shiroha-a/mk/pull/255" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
