### PR TITLE
Fix: Normalize reaction keys to merge legacy and canonical forms

### DIFF
--- a/internal/api/notes/handler.go
+++ b/internal/api/notes/handler.go
@@ -502,7 +502,8 @@ func (h *Handler) resolveViewerFields(notes []entity.NoteEntity, viewer *model.U
 		if err == nil {
 			for i := range notes {
 				if r, ok := reactionMap[notes[i].ID]; ok {
-					notes[i].MyReaction = &r.Reaction
+					nr := entity.NormalizeReactionKey(r.Reaction)
+					notes[i].MyReaction = &nr
 				}
 			}
 		}

--- a/internal/entity/note.go
+++ b/internal/entity/note.go
@@ -141,8 +141,8 @@ func NormalizeReactionKey(key string) string {
 }
 
 // normalizeReactionKeys rewrites reaction JSONB keys so that legacy
-// `:name:` entries are merged into `:name@.:`. TS時代のレコードと
-// mk時代のレコードが同一キーに集約される。
+// `:name:` entries are merged into `:name@.:`.
+// TS時代のレコードとmk時代のレコードが同一キーに集約される。
 func normalizeReactionKeys(raw datatypes.JSON) datatypes.JSON {
 	if len(raw) == 0 {
 		return raw

--- a/internal/entity/note.go
+++ b/internal/entity/note.go
@@ -2,11 +2,15 @@ package entity
 
 import (
 	"encoding/json"
+	"regexp"
 
 	"github.com/shiroha-a/mk/internal/misc/id"
 	"github.com/shiroha-a/mk/internal/model"
 	"gorm.io/datatypes"
 )
+
+// localEmojiPattern matches `:name:` without `@host` suffix.
+var localEmojiPattern = regexp.MustCompile(`^:([\w+\-]+):$`)
 
 // NoteEntity is the note representation returned by API endpoints.
 type NoteEntity struct {
@@ -99,7 +103,7 @@ func PackNote(n *model.Note, idGen id.Generator) NoteEntity {
 		Visibility:         string(n.Visibility),
 		LocalOnly:          n.LocalOnly,
 		ReactionAcceptance: n.ReactionAcceptance,
-		Reactions:          n.Reactions,
+		Reactions:          normalizeReactionKeys(n.Reactions),
 		ReactionCount:      sumReactions(n.Reactions),
 		ReactionEmojis:     make(map[string]string),
 		RenoteCount:        n.RenoteCount,
@@ -124,6 +128,39 @@ func PackNote(n *model.Note, idGen id.Generator) NoteEntity {
 	}
 
 	return entity
+}
+
+// NormalizeReactionKey converts a legacy `:name:` key to the canonical
+// `:name@.:` form used by the frontend. Remote and non-custom reactions
+// are returned unchanged.
+func NormalizeReactionKey(key string) string {
+	if m := localEmojiPattern.FindStringSubmatch(key); m != nil {
+		return ":" + m[1] + "@.:"
+	}
+	return key
+}
+
+// normalizeReactionKeys rewrites reaction JSONB keys so that legacy
+// `:name:` entries are merged into `:name@.:`. TS時代のレコードと
+// mk時代のレコードが同一キーに集約される。
+func normalizeReactionKeys(raw datatypes.JSON) datatypes.JSON {
+	if len(raw) == 0 {
+		return raw
+	}
+	var m map[string]float64
+	if err := json.Unmarshal(raw, &m); err != nil {
+		return raw
+	}
+	normalized := make(map[string]float64, len(m))
+	for k, v := range m {
+		nk := NormalizeReactionKey(k)
+		normalized[nk] += v
+	}
+	data, err := json.Marshal(normalized)
+	if err != nil {
+		return raw
+	}
+	return data
 }
 
 // sumReactions decodes the reactions JSONB and sums all values.

--- a/internal/entity/note_test.go
+++ b/internal/entity/note_test.go
@@ -1,6 +1,7 @@
 package entity
 
 import (
+	"encoding/json"
 	"testing"
 	"time"
 
@@ -192,6 +193,52 @@ func TestPackNote_NilVisibleUserIDs_Mentions(t *testing.T) {
 	assert.NotNil(t, entity.Mentions)
 	assert.Empty(t, entity.Mentions)
 	assert.False(t, entity.HasPoll)
+}
+
+func TestNormalizeReactionKey(t *testing.T) {
+	cases := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{"local legacy", ":smile:", ":smile@.:"},
+		{"local canonical", ":smile@.:", ":smile@.:"},
+		{"remote", ":smile@remote.example:", ":smile@remote.example:"},
+		{"unicode emoji", "👍", "👍"},
+		{"heart", "❤", "❤"},
+		{"empty", "", ""},
+		{"hyphen name", ":cat-smile:", ":cat-smile@.:"},
+		{"plus name", ":thumbs+up:", ":thumbs+up@.:"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, NormalizeReactionKey(tc.in))
+		})
+	}
+}
+
+func TestPackNote_ReactionsKeyNormalized(t *testing.T) {
+	idGen := newTestIDGen(t)
+	noteID := idGen.Generate(time.Now())
+
+	// TS時代の `:lifelog:` とmk時代の `:lifelog@.:` が混在
+	note := &model.Note{
+		ID:         noteID,
+		UserID:     "user1",
+		Visibility: model.NoteVisibilityPublic,
+		Reactions:  datatypes.JSON([]byte(`{":lifelog:":1,":lifelog@.:" :1,"👍":3}`)),
+	}
+
+	e := PackNote(note, idGen)
+
+	var reactions map[string]float64
+	require.NoError(t, json.Unmarshal(e.Reactions, &reactions))
+	// `:lifelog:` と `:lifelog@.:` が統合される
+	assert.Equal(t, float64(2), reactions[":lifelog@.:"])
+	assert.Equal(t, float64(3), reactions["👍"])
+	_, hasLegacy := reactions[":lifelog:"]
+	assert.False(t, hasLegacy)
+	assert.Equal(t, 5, e.ReactionCount)
 }
 
 func TestPackNote_CreatedAtParsing(t *testing.T) {


### PR DESCRIPTION
## Summary
- TS時代の `:name:` とmk時代の `:name@.:` がreactions集計で分裂する問題を修正
- `PackNote`でreactions JSONBキーを正規化し、`:name:` → `:name@.:` に変換して統合
- `resolveViewerFields`で`myReaction`も同様に正規化

## 主な変更点
- `internal/entity/note.go`: `NormalizeReactionKey`関数と`normalizeReactionKeys`関数を追加、`PackNote`で適用
- `internal/api/notes/handler.go`: `resolveViewerFields`内で`myReaction`を正規化
- `internal/entity/note_test.go`: キー正規化テスト、混在キー統合テスト追加

## テスト
- `go test ./internal/entity/... -v` 全PASS (カバレッジ96.1%)
- `go test ./internal/api/notes/... -v` 全PASS (カバレッジ94.4%)

Closes #257
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/shiroha-a/mk/pull/258" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
