### PR TITLE
Fix #261: List reactions matching both legacy and canonical forms

### DIFF
--- a/internal/api/notes/reactions_handler_test.go
+++ b/internal/api/notes/reactions_handler_test.go
@@ -348,7 +348,7 @@ type listFailingReactionRepo struct {
 	*testutil.MockNoteReactionRepository
 }
 
-func (f *listFailingReactionRepo) ListByNoteID(_, _, _ string, _ int, _ string) ([]*model.NoteReaction, error) {
+func (f *listFailingReactionRepo) ListByNoteID(_, _, _ string, _ int, _ []string) ([]*model.NoteReaction, error) {
 	return nil, errors.New("list boom")
 }
 

--- a/internal/core/reaction/reaction_service.go
+++ b/internal/core/reaction/reaction_service.go
@@ -271,10 +271,11 @@ func (s *Service) List(user *model.User, noteID, untilID, sinceID string, limit 
 	if limit <= 0 {
 		limit = 10
 	}
+	var reactions []string
 	if reaction != "" {
-		reaction = s.normalizeReaction(reaction)
+		reactions = reactionVariants(s.normalizeReaction(reaction))
 	}
-	return s.reactionRepo.ListByNoteID(target.ID, untilID, sinceID, limit, reaction)
+	return s.reactionRepo.ListByNoteID(target.ID, untilID, sinceID, limit, reactions)
 }
 
 // normalizeReaction returns the canonical form of a reaction string.
@@ -314,6 +315,19 @@ func (s *Service) normalizeReaction(raw string) string {
 		return FallbackReaction
 	}
 	return raw
+}
+
+// localCanonicalPattern matches the canonical local emoji form `:name@.:`.
+var localCanonicalPattern = regexp.MustCompile(`^:([\w+\-]+)@\.:$`)
+
+// reactionVariants returns a slice of reaction strings to match in the DB.
+// TS時代のレコードは `:name:` 形式、mk時代は `:name@.:` 形式で保存されて
+// いるため、ローカルカスタム絵文字の場合は両方の形式で検索する必要がある。
+func reactionVariants(normalized string) []string {
+	if m := localCanonicalPattern.FindStringSubmatch(normalized); m != nil {
+		return []string{normalized, ":" + m[1] + ":"}
+	}
+	return []string{normalized}
 }
 
 // isPureRenote reports whether the given note is a pure renote (no text/cw/files/poll).

--- a/internal/core/reaction/reaction_service_test.go
+++ b/internal/core/reaction/reaction_service_test.go
@@ -274,6 +274,30 @@ func TestService_List_Filtered(t *testing.T) {
 	assert.Equal(t, "👍", out[0].Reaction)
 }
 
+func TestService_List_LegacyReactionMatched(t *testing.T) {
+	svc, noteRepo, reactRepo, emojiRepo, _ := newService(t)
+	seedNote(noteRepo, "n1", "author", model.NoteVisibilityPublic)
+	// TS時代の `:smile:` 形式でDBに保存されたリアクションを直接挿入
+	emojiRepo.Emojis["smile@"] = &model.Emoji{Name: "smile"}
+	reactRepo.Reactions["rx_legacy"] = &model.NoteReaction{
+		ID: "rx_legacy", UserID: "u1", NoteID: "n1", Reaction: ":smile:",
+	}
+	// mk時代の `:smile@.:` 形式でもリアクションを追加
+	reactRepo.Reactions["rx_canonical"] = &model.NoteReaction{
+		ID: "rx_canonical", UserID: "u2", NoteID: "n1", Reaction: ":smile@.:",
+	}
+
+	// `:smile@.:` でフィルタすると両方ヒットする
+	out, err := svc.List(nil, "n1", "", "", 10, ":smile@.:")
+	require.NoError(t, err)
+	assert.Len(t, out, 2)
+
+	// `:smile:` でフィルタしても正規化されて両方ヒットする
+	out, err = svc.List(nil, "n1", "", "", 10, ":smile:")
+	require.NoError(t, err)
+	assert.Len(t, out, 2)
+}
+
 func TestIsPureRenote_Variants(t *testing.T) {
 	target := "x"
 	cases := []struct {

--- a/internal/repository/note_reaction.go
+++ b/internal/repository/note_reaction.go
@@ -20,7 +20,7 @@ type NoteReactionRepository interface {
 	// FindByUserAndNoteIDs returns reactions for a user across multiple notes.
 	// noteIDをキーとしたmapを返す。
 	FindByUserAndNoteIDs(userID string, noteIDs []string) (map[string]*model.NoteReaction, error)
-	ListByNoteID(noteID string, untilID, sinceID string, limit int, reaction string) ([]*model.NoteReaction, error)
+	ListByNoteID(noteID string, untilID, sinceID string, limit int, reactions []string) ([]*model.NoteReaction, error)
 }
 
 type noteReactionRepository struct {
@@ -73,11 +73,13 @@ func (r *noteReactionRepository) FindByUserAndNoteIDs(userID string, noteIDs []s
 
 // ListByNoteID returns reactions for the given noteID, optionally filtered by
 // reaction string. Ordered by id DESC for keyset pagination.
-func (r *noteReactionRepository) ListByNoteID(noteID string, untilID, sinceID string, limit int, reaction string) ([]*model.NoteReaction, error) {
+func (r *noteReactionRepository) ListByNoteID(noteID string, untilID, sinceID string, limit int, reactions []string) ([]*model.NoteReaction, error) {
 	var rows []*model.NoteReaction
 	q := r.db.Preload("User").Where("\"noteId\" = ?", noteID)
-	if reaction != "" {
-		q = q.Where("reaction = ?", reaction)
+	if len(reactions) == 1 {
+		q = q.Where("reaction = ?", reactions[0])
+	} else if len(reactions) > 1 {
+		q = q.Where("reaction IN ?", reactions)
 	}
 	if untilID != "" {
 		q = q.Where("id < ?", untilID)

--- a/internal/repository/note_reaction_test.go
+++ b/internal/repository/note_reaction_test.go
@@ -116,23 +116,23 @@ func TestNoteReactionRepository_ListByNoteID(t *testing.T) {
 		defer cleanupReaction(t, rec.ID)
 	}
 
-	out, err := repo.ListByNoteID(note.ID, "", "", 10, "")
+	out, err := repo.ListByNoteID(note.ID, "", "", 10, nil)
 	require.NoError(t, err)
 	assert.Len(t, out, 2)
 
 	// 種類絞り込み
-	out, err = repo.ListByNoteID(note.ID, "", "", 10, "👍")
+	out, err = repo.ListByNoteID(note.ID, "", "", 10, []string{"👍"})
 	require.NoError(t, err)
 	require.Len(t, out, 1)
 	assert.Equal(t, "👍", out[0].Reaction)
 
 	// untilID で絞り込み
-	out, err = repo.ListByNoteID(note.ID, "rx_l2", "", 10, "")
+	out, err = repo.ListByNoteID(note.ID, "rx_l2", "", 10, nil)
 	require.NoError(t, err)
 	assert.Len(t, out, 1)
 
 	// sinceID で絞り込み
-	out, err = repo.ListByNoteID(note.ID, "", "rx_l1", 10, "")
+	out, err = repo.ListByNoteID(note.ID, "", "rx_l1", 10, nil)
 	require.NoError(t, err)
 	assert.Len(t, out, 1)
 }
@@ -151,6 +151,6 @@ func TestNoteReactionRepository_QueryErrors(t *testing.T) {
 	_, err = repo.FindByPair("u", "n")
 	assert.Error(t, err)
 
-	_, err = repo.ListByNoteID("n", "", "", 10, "")
+	_, err = repo.ListByNoteID("n", "", "", 10, nil)
 	assert.Error(t, err)
 }

--- a/internal/testutil/mock_repository.go
+++ b/internal/testutil/mock_repository.go
@@ -934,14 +934,23 @@ func (m *MockNoteReactionRepository) FindByUserAndNoteIDs(userID string, noteIDs
 	return result, nil
 }
 
-func (m *MockNoteReactionRepository) ListByNoteID(noteID, untilID, sinceID string, limit int, reaction string) ([]*model.NoteReaction, error) {
+func (m *MockNoteReactionRepository) ListByNoteID(noteID, untilID, sinceID string, limit int, reactions []string) ([]*model.NoteReaction, error) {
 	var rows []*model.NoteReaction
 	for _, r := range m.Reactions {
 		if r.NoteID != noteID {
 			continue
 		}
-		if reaction != "" && r.Reaction != reaction {
-			continue
+		if len(reactions) > 0 {
+			matched := false
+			for _, rx := range reactions {
+				if r.Reaction == rx {
+					matched = true
+					break
+				}
+			}
+			if !matched {
+				continue
+			}
 		}
 		if untilID != "" && r.ID >= untilID {
 			continue


### PR DESCRIPTION
## Summary
- `ListByNoteID` now accepts `[]string` for reaction filtering instead of a single string
- The service layer expands `:name@.:` to also include the legacy `:name:` form via `reactionVariants()`
- TS-era records stored as `:name:` are now found when filtering by `:name@.:`

## Changes
- `internal/repository/note_reaction.go`: `ListByNoteID` signature changed to `reactions []string`, uses `IN` query for multiple variants
- `internal/core/reaction/reaction_service.go`: Added `reactionVariants()` helper and `localCanonicalPattern` regex
- `internal/testutil/mock_repository.go`: Mock updated to match new interface
- Tests: Added `TestService_List_LegacyReactionMatched`

## Test
```
go test ./internal/core/reaction/... ./internal/api/notes/... -v
```

Closes #261

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/shiroha-a/mk/pull/262" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
