### PR TITLE
Fix #263: Implement dedicated v2/admin/emoji/list handler

### DIFF
--- a/internal/api/admin/drive_emoji_test.go
+++ b/internal/api/admin/drive_emoji_test.go
@@ -11,6 +11,18 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+type failingListV2EmojiRepo struct {
+	*testutil.MockEmojiRepository
+}
+
+func (f *failingListV2EmojiRepo) ListV2(_ model.EmojiV2Filter) ([]*model.Emoji, error) {
+	return nil, assert.AnError
+}
+
+func (f *failingListV2EmojiRepo) CountV2(_ model.EmojiV2Filter) (int64, error) {
+	return 0, assert.AnError
+}
+
 // --- Drive ------------------------------------------------------------------
 
 func TestDriveFiles_FiltersByOrigin(t *testing.T) {
@@ -278,4 +290,177 @@ func TestEmojiImportZip_UnknownFileReturns400(t *testing.T) {
 	h.SetEmojiImportEnqueuer(&stubEmojiImportEnqueuer{})
 	rec := doPost(h.EmojiImportZip, `{"fileId":"missing"}`, adminUser)
 	assert.Equal(t, http.StatusBadRequest, rec.Code)
+}
+
+// --- EmojiListV2 -------------------------------------------------------------
+
+func TestEmojiListV2_Basic(t *testing.T) {
+	h, _, _, _ := newTestHandler(t)
+	repo := testutil.NewMockEmojiRepository()
+	require.NoError(t, repo.Create(&model.Emoji{ID: "e1", Name: "smile"}))
+	require.NoError(t, repo.Create(&model.Emoji{ID: "e2", Name: "wave"}))
+	h.SetEmojiRepo(repo)
+
+	rec := doPost(h.EmojiListV2, `{}`, adminUser)
+	assert.Equal(t, http.StatusOK, rec.Code)
+	var resp map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+	emojis := resp["emojis"].([]any)
+	assert.Len(t, emojis, 2)
+	assert.EqualValues(t, 2, resp["count"])
+	assert.EqualValues(t, 2, resp["allCount"])
+	assert.EqualValues(t, 1, resp["allPages"])
+}
+
+func TestEmojiListV2_NilRepo(t *testing.T) {
+	h, _, _, _ := newTestHandler(t)
+	rec := doPost(h.EmojiListV2, `{}`, adminUser)
+	assert.Equal(t, http.StatusOK, rec.Code)
+	var resp map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+	assert.Len(t, resp["emojis"].([]any), 0)
+	assert.EqualValues(t, 0, resp["allCount"])
+}
+
+func TestEmojiListV2_InvalidJSON(t *testing.T) {
+	h, _, _, _ := newTestHandler(t)
+	rec := doPost(h.EmojiListV2, `invalid`, adminUser)
+	assert.Equal(t, http.StatusBadRequest, rec.Code)
+}
+
+func TestEmojiListV2_HostType(t *testing.T) {
+	h, _, _, _ := newTestHandler(t)
+	repo := testutil.NewMockEmojiRepository()
+	host := "remote.example"
+	require.NoError(t, repo.Create(&model.Emoji{ID: "e1", Name: "local_only"}))
+	require.NoError(t, repo.Create(&model.Emoji{ID: "e2", Name: "remote_one", Host: &host}))
+	h.SetEmojiRepo(repo)
+
+	// local のみ
+	rec := doPost(h.EmojiListV2, `{"query":{"hostType":"local"}}`, adminUser)
+	assert.Equal(t, http.StatusOK, rec.Code)
+	var resp map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+	emojis := resp["emojis"].([]any)
+	assert.Len(t, emojis, 1)
+	assert.Equal(t, "e1", emojis[0].(map[string]any)["id"])
+
+	// remote のみ
+	rec = doPost(h.EmojiListV2, `{"query":{"hostType":"remote"}}`, adminUser)
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+	emojis = resp["emojis"].([]any)
+	assert.Len(t, emojis, 1)
+	assert.Equal(t, "e2", emojis[0].(map[string]any)["id"])
+
+	// all（デフォルト）
+	rec = doPost(h.EmojiListV2, `{"query":{"hostType":"all"}}`, adminUser)
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+	emojis = resp["emojis"].([]any)
+	assert.Len(t, emojis, 2)
+}
+
+func TestEmojiListV2_QueryFilter(t *testing.T) {
+	h, _, _, _ := newTestHandler(t)
+	repo := testutil.NewMockEmojiRepository()
+	require.NoError(t, repo.Create(&model.Emoji{ID: "e1", Name: "cat_smile"}))
+	require.NoError(t, repo.Create(&model.Emoji{ID: "e2", Name: "dog_run"}))
+	require.NoError(t, repo.Create(&model.Emoji{ID: "e3", Name: "caterpillar"}))
+	h.SetEmojiRepo(repo)
+
+	rec := doPost(h.EmojiListV2, `{"query":{"name":"cat"}}`, adminUser)
+	assert.Equal(t, http.StatusOK, rec.Code)
+	var resp map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+	emojis := resp["emojis"].([]any)
+	assert.Len(t, emojis, 2, "cat_smile and caterpillar should match")
+	assert.EqualValues(t, 2, resp["allCount"])
+}
+
+func TestEmojiListV2_Pagination(t *testing.T) {
+	h, _, _, _ := newTestHandler(t)
+	repo := testutil.NewMockEmojiRepository()
+	for i := 0; i < 5; i++ {
+		id := "e" + string(rune('1'+i))
+		require.NoError(t, repo.Create(&model.Emoji{ID: id, Name: "emoji_" + id}))
+	}
+	h.SetEmojiRepo(repo)
+
+	// page 1, limit 2
+	rec := doPost(h.EmojiListV2, `{"limit":2,"page":1}`, adminUser)
+	var resp map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+	emojis := resp["emojis"].([]any)
+	assert.Len(t, emojis, 2)
+	assert.EqualValues(t, 5, resp["allCount"])
+	assert.EqualValues(t, 3, resp["allPages"])
+
+	// page 3 — 残り1件
+	rec = doPost(h.EmojiListV2, `{"limit":2,"page":3}`, adminUser)
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+	emojis = resp["emojis"].([]any)
+	assert.Len(t, emojis, 1)
+	assert.EqualValues(t, 1, resp["count"])
+}
+
+func TestEmojiListV2_SortKeys(t *testing.T) {
+	h, _, _, _ := newTestHandler(t)
+	repo := testutil.NewMockEmojiRepository()
+	require.NoError(t, repo.Create(&model.Emoji{ID: "e1", Name: "beta"}))
+	require.NoError(t, repo.Create(&model.Emoji{ID: "e2", Name: "alpha"}))
+	require.NoError(t, repo.Create(&model.Emoji{ID: "e3", Name: "gamma"}))
+	h.SetEmojiRepo(repo)
+
+	// name ASC
+	rec := doPost(h.EmojiListV2, `{"sortKeys":["+name"]}`, adminUser)
+	var resp map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+	emojis := resp["emojis"].([]any)
+	require.Len(t, emojis, 3)
+	assert.Equal(t, "alpha", emojis[0].(map[string]any)["name"])
+	assert.Equal(t, "beta", emojis[1].(map[string]any)["name"])
+	assert.Equal(t, "gamma", emojis[2].(map[string]any)["name"])
+
+	// デフォルト: id DESC
+	rec = doPost(h.EmojiListV2, `{}`, adminUser)
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+	emojis = resp["emojis"].([]any)
+	require.Len(t, emojis, 3)
+	assert.Equal(t, "e3", emojis[0].(map[string]any)["id"])
+	assert.Equal(t, "e1", emojis[2].(map[string]any)["id"])
+}
+
+func TestEmojiListV2_SensitiveFilter(t *testing.T) {
+	h, _, _, _ := newTestHandler(t)
+	repo := testutil.NewMockEmojiRepository()
+	require.NoError(t, repo.Create(&model.Emoji{ID: "e1", Name: "safe", IsSensitive: false}))
+	require.NoError(t, repo.Create(&model.Emoji{ID: "e2", Name: "nsfw", IsSensitive: true}))
+	h.SetEmojiRepo(repo)
+
+	rec := doPost(h.EmojiListV2, `{"query":{"isSensitive":true}}`, adminUser)
+	var resp map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+	emojis := resp["emojis"].([]any)
+	assert.Len(t, emojis, 1)
+	assert.Equal(t, "e2", emojis[0].(map[string]any)["id"])
+}
+
+func TestEmojiListV2_LimitClamped(t *testing.T) {
+	h, _, _, _ := newTestHandler(t)
+	repo := testutil.NewMockEmojiRepository()
+	require.NoError(t, repo.Create(&model.Emoji{ID: "e1", Name: "a"}))
+	h.SetEmojiRepo(repo)
+
+	// limit > 100 は100にクランプされる
+	rec := doPost(h.EmojiListV2, `{"limit":999}`, adminUser)
+	assert.Equal(t, http.StatusOK, rec.Code)
+	var resp map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+	assert.EqualValues(t, 1, resp["allPages"])
+}
+
+func TestEmojiListV2_ListV2Error(t *testing.T) {
+	h, _, _, _ := newTestHandler(t)
+	h.SetEmojiRepo(&failingListV2EmojiRepo{testutil.NewMockEmojiRepository()})
+	rec := doPost(h.EmojiListV2, `{}`, adminUser)
+	assert.Equal(t, http.StatusInternalServerError, rec.Code)
 }

--- a/internal/api/admin/handler.go
+++ b/internal/api/admin/handler.go
@@ -1021,6 +1021,107 @@ func (h *Handler) EmojiList(c echo.Context) error {
 	return c.JSON(http.StatusOK, emojis)
 }
 
+// EmojiListV2 handles POST /api/v2/admin/emoji/list.
+// v2はページネーション情報(allCount, allPages)を含むオブジェクトを返す。
+func (h *Handler) EmojiListV2(c echo.Context) error {
+	var req struct {
+		Query    *emojiV2QueryReq `json:"query"`
+		SinceID  string           `json:"sinceId"`
+		UntilID  string           `json:"untilId"`
+		Limit    int              `json:"limit"`
+		Page     int              `json:"page"`
+		SortKeys []string         `json:"sortKeys"`
+	}
+	if err := c.Bind(&req); err != nil {
+		return c.JSON(http.StatusBadRequest, apierr.Error("INVALID_PARAM", "Invalid parameters.", "3d81ceae-475f-4600-b2a8-2bc116157532"))
+	}
+	if h.emojiRepo == nil {
+		return c.JSON(http.StatusOK, emojiListV2Response{
+			Emojis:   []*model.Emoji{},
+			Count:    0,
+			AllCount: 0,
+			AllPages: 0,
+		})
+	}
+
+	limit := req.Limit
+	if limit <= 0 {
+		limit = 10
+	}
+	if limit > 100 {
+		limit = 100
+	}
+
+	filter := model.EmojiV2Filter{
+		SinceID:  req.SinceID,
+		UntilID:  req.UntilID,
+		Limit:    limit,
+		Page:     req.Page,
+		SortKeys: req.SortKeys,
+	}
+	if req.Query != nil {
+		filter.Query = &model.EmojiV2Query{
+			Name:          req.Query.Name,
+			Host:          req.Query.Host,
+			HostType:      req.Query.HostType,
+			Category:      req.Query.Category,
+			Type:          req.Query.Type,
+			Aliases:       req.Query.Aliases,
+			License:       req.Query.License,
+			IsSensitive:   req.Query.IsSensitive,
+			LocalOnly:     req.Query.LocalOnly,
+			UpdatedAtFrom: req.Query.UpdatedAtFrom,
+			UpdatedAtTo:   req.Query.UpdatedAtTo,
+			RoleIDs:       req.Query.RoleIDs,
+		}
+	}
+
+	emojis, err := h.emojiRepo.ListV2(filter)
+	if err != nil {
+		slog.Error("EmojiListV2: ListV2 failed", "error", err)
+		return c.JSON(http.StatusInternalServerError, apierr.Error("INTERNAL_ERROR", "Internal error.", "5d37dbcb-891e-41ca-a3d6-e690c97775ac"))
+	}
+	allCount, err := h.emojiRepo.CountV2(filter)
+	if err != nil {
+		slog.Error("EmojiListV2: CountV2 failed", "error", err)
+		return c.JSON(http.StatusInternalServerError, apierr.Error("INTERNAL_ERROR", "Internal error.", "5d37dbcb-891e-41ca-a3d6-e690c97775ac"))
+	}
+
+	allPages := 0
+	if limit > 0 {
+		allPages = int((allCount + int64(limit) - 1) / int64(limit))
+	}
+
+	return c.JSON(http.StatusOK, emojiListV2Response{
+		Emojis:   emojis,
+		Count:    len(emojis),
+		AllCount: allCount,
+		AllPages: allPages,
+	})
+}
+
+type emojiV2QueryReq struct {
+	Name          string   `json:"name"`
+	Host          string   `json:"host"`
+	HostType      string   `json:"hostType"`
+	Category      string   `json:"category"`
+	Type          string   `json:"type"`
+	Aliases       string   `json:"aliases"`
+	License       string   `json:"license"`
+	IsSensitive   *bool    `json:"isSensitive"`
+	LocalOnly     *bool    `json:"localOnly"`
+	UpdatedAtFrom string   `json:"updatedAtFrom"`
+	UpdatedAtTo   string   `json:"updatedAtTo"`
+	RoleIDs       []string `json:"roleIds"`
+}
+
+type emojiListV2Response struct {
+	Emojis   []*model.Emoji `json:"emojis"`
+	Count    int            `json:"count"`
+	AllCount int64          `json:"allCount"`
+	AllPages int            `json:"allPages"`
+}
+
 // --- Abuse Report endpoints ---
 
 // AbuseReports handles POST /api/admin/abuse-user-reports.

--- a/internal/api/admin/handler.go
+++ b/internal/api/admin/handler.go
@@ -1022,7 +1022,7 @@ func (h *Handler) EmojiList(c echo.Context) error {
 }
 
 // EmojiListV2 handles POST /api/v2/admin/emoji/list.
-// v2はページネーション情報(allCount, allPages)を含むオブジェクトを返す。
+// Returns an object with pagination info (allCount, allPages) instead of a plain array.
 func (h *Handler) EmojiListV2(c echo.Context) error {
 	var req struct {
 		Query    *emojiV2QueryReq `json:"query"`

--- a/internal/core/emojiimport/coverage_boost_test.go
+++ b/internal/core/emojiimport/coverage_boost_test.go
@@ -194,5 +194,13 @@ func (r *failingEmojiRepo) ListRemoteWithFilter(q, host string, limit, offset in
 	return r.inner.ListRemoteWithFilter(q, host, limit, offset)
 }
 
+func (r *failingEmojiRepo) ListV2(filter model.EmojiV2Filter) ([]*model.Emoji, error) {
+	return r.inner.ListV2(filter)
+}
+
+func (r *failingEmojiRepo) CountV2(filter model.EmojiV2Filter) (int64, error) {
+	return r.inner.CountV2(filter)
+}
+
 // sanity: time import stay
 var _ = time.Now

--- a/internal/model/emoji.go
+++ b/internal/model/emoji.go
@@ -25,3 +25,29 @@ type Emoji struct {
 }
 
 func (Emoji) TableName() string { return "emoji" }
+
+// EmojiV2Filter holds parameters for v2 admin emoji listing.
+type EmojiV2Filter struct {
+	Query    *EmojiV2Query
+	SinceID  string
+	UntilID  string
+	Limit    int // default 10, max 100
+	Page     int // 1-indexed; page > 0の場合はoffsetベース
+	SortKeys []string
+}
+
+// EmojiV2Query holds query parameters for v2 admin emoji filtering.
+type EmojiV2Query struct {
+	Name          string
+	Host          string
+	HostType      string // "local" | "remote" | "all"
+	Category      string
+	Type          string
+	Aliases       string
+	License       string
+	IsSensitive   *bool
+	LocalOnly     *bool
+	UpdatedAtFrom string
+	UpdatedAtTo   string
+	RoleIDs       []string
+}

--- a/internal/repository/emoji.go
+++ b/internal/repository/emoji.go
@@ -149,7 +149,7 @@ func (r *emojiRepository) ListWithFilter(query, category string, local bool, lim
 	return emojis, nil
 }
 
-// v2SortAllowList はsortKeysに指定可能なカラム名の許可リスト
+// v2SortAllowList is the allow-list of column names accepted in sortKeys.
 var v2SortAllowList = map[string]string{
 	"id":          "id",
 	"updatedAt":   `"updatedAt"`,
@@ -222,25 +222,26 @@ func (r *emojiRepository) buildV2Query(filter model.EmojiV2Filter) *gorm.DB {
 func (r *emojiRepository) ListV2(filter model.EmojiV2Filter) ([]*model.Emoji, error) {
 	q := r.buildV2Query(filter)
 
-	// ソート
-	if len(filter.SortKeys) > 0 {
-		for _, sk := range filter.SortKeys {
-			if len(sk) < 2 {
-				continue
-			}
-			dir := sk[0]
-			col := sk[1:]
-			dbCol, ok := v2SortAllowList[col]
-			if !ok {
-				continue
-			}
-			if dir == '-' {
-				q = q.Order(fmt.Sprintf("%s DESC", dbCol))
-			} else {
-				q = q.Order(fmt.Sprintf("%s ASC", dbCol))
-			}
+	// 有効なsortKeyが1つもなければid DESCにfallbackする
+	applied := false
+	for _, sk := range filter.SortKeys {
+		if len(sk) < 2 {
+			continue
 		}
-	} else {
+		dir := sk[0]
+		col := sk[1:]
+		dbCol, ok := v2SortAllowList[col]
+		if !ok {
+			continue
+		}
+		if dir == '-' {
+			q = q.Order(fmt.Sprintf("%s DESC", dbCol))
+		} else {
+			q = q.Order(fmt.Sprintf("%s ASC", dbCol))
+		}
+		applied = true
+	}
+	if !applied {
 		q = q.Order("id DESC")
 	}
 

--- a/internal/repository/emoji.go
+++ b/internal/repository/emoji.go
@@ -1,6 +1,8 @@
 package repository
 
 import (
+	"fmt"
+
 	"github.com/shiroha-a/mk/internal/model"
 	"gorm.io/gorm"
 )
@@ -26,6 +28,10 @@ type EmojiRepository interface {
 	// ListRemoteWithFilter mirrors ListWithFilter for remote emojis. host empty
 	// matches any remote host.
 	ListRemoteWithFilter(query, host string, limit, offset int) ([]*model.Emoji, error)
+	// ListV2 returns emojis matching v2 filters with sorting + pagination.
+	ListV2(filter model.EmojiV2Filter) ([]*model.Emoji, error)
+	// CountV2 returns total count of emojis matching v2 filters (pagination ignored).
+	CountV2(filter model.EmojiV2Filter) (int64, error)
 }
 
 type emojiRepository struct {
@@ -141,6 +147,130 @@ func (r *emojiRepository) ListWithFilter(query, category string, local bool, lim
 		return nil, err
 	}
 	return emojis, nil
+}
+
+// v2SortAllowList はsortKeysに指定可能なカラム名の許可リスト
+var v2SortAllowList = map[string]string{
+	"id":          "id",
+	"updatedAt":   `"updatedAt"`,
+	"name":        "name",
+	"host":        "host",
+	"uri":         "uri",
+	"publicUrl":   `"publicUrl"`,
+	"type":        "type",
+	"category":    "category",
+	"license":     "license",
+	"isSensitive": `"isSensitive"`,
+	"localOnly":   `"localOnly"`,
+	"aliases":     "aliases",
+	"roleIdsThatCanBeUsedThisEmojiAsReaction": `"roleIdsThatCanBeUsedThisEmojiAsReaction"`,
+}
+
+// buildV2Query constructs the common WHERE clause for ListV2/CountV2.
+func (r *emojiRepository) buildV2Query(filter model.EmojiV2Filter) *gorm.DB {
+	q := r.db.Model(&model.Emoji{})
+	if filter.Query != nil {
+		fq := filter.Query
+		if fq.HostType == "local" {
+			q = q.Where("host IS NULL")
+		} else if fq.HostType == "remote" {
+			q = q.Where("host IS NOT NULL")
+		}
+		if fq.Name != "" {
+			q = q.Where("name ILIKE ?", "%"+fq.Name+"%")
+		}
+		if fq.Host != "" {
+			q = q.Where("host ILIKE ?", "%"+fq.Host+"%")
+		}
+		if fq.Category != "" {
+			q = q.Where("category ILIKE ?", "%"+fq.Category+"%")
+		}
+		if fq.Type != "" {
+			q = q.Where("type ILIKE ?", "%"+fq.Type+"%")
+		}
+		if fq.Aliases != "" {
+			q = q.Where("array_to_string(aliases, ',') ILIKE ?", "%"+fq.Aliases+"%")
+		}
+		if fq.License != "" {
+			q = q.Where("license ILIKE ?", "%"+fq.License+"%")
+		}
+		if fq.IsSensitive != nil {
+			q = q.Where(`"isSensitive" = ?`, *fq.IsSensitive)
+		}
+		if fq.LocalOnly != nil {
+			q = q.Where(`"localOnly" = ?`, *fq.LocalOnly)
+		}
+		if fq.UpdatedAtFrom != "" {
+			q = q.Where(`"updatedAt" >= ?`, fq.UpdatedAtFrom)
+		}
+		if fq.UpdatedAtTo != "" {
+			q = q.Where(`"updatedAt" <= ?`, fq.UpdatedAtTo)
+		}
+		if len(fq.RoleIDs) > 0 {
+			q = q.Where(`"roleIdsThatCanBeUsedThisEmojiAsReaction" && ARRAY[?]::varchar[]`, fq.RoleIDs)
+		}
+	}
+	if filter.SinceID != "" {
+		q = q.Where("id > ?", filter.SinceID)
+	}
+	if filter.UntilID != "" {
+		q = q.Where("id < ?", filter.UntilID)
+	}
+	return q
+}
+
+func (r *emojiRepository) ListV2(filter model.EmojiV2Filter) ([]*model.Emoji, error) {
+	q := r.buildV2Query(filter)
+
+	// ソート
+	if len(filter.SortKeys) > 0 {
+		for _, sk := range filter.SortKeys {
+			if len(sk) < 2 {
+				continue
+			}
+			dir := sk[0]
+			col := sk[1:]
+			dbCol, ok := v2SortAllowList[col]
+			if !ok {
+				continue
+			}
+			if dir == '-' {
+				q = q.Order(fmt.Sprintf("%s DESC", dbCol))
+			} else {
+				q = q.Order(fmt.Sprintf("%s ASC", dbCol))
+			}
+		}
+	} else {
+		q = q.Order("id DESC")
+	}
+
+	limit := filter.Limit
+	if limit <= 0 {
+		limit = 10
+	}
+	if limit > 100 {
+		limit = 100
+	}
+	q = q.Limit(limit)
+
+	if filter.Page > 0 {
+		q = q.Offset((filter.Page - 1) * limit)
+	}
+
+	var emojis []*model.Emoji
+	if err := q.Find(&emojis).Error; err != nil {
+		return nil, err
+	}
+	return emojis, nil
+}
+
+func (r *emojiRepository) CountV2(filter model.EmojiV2Filter) (int64, error) {
+	q := r.buildV2Query(filter)
+	var count int64
+	if err := q.Count(&count).Error; err != nil {
+		return 0, err
+	}
+	return count, nil
 }
 
 // FindByNameAndHost looks up a custom emoji by its name and host.

--- a/internal/repository/emoji_test.go
+++ b/internal/repository/emoji_test.go
@@ -284,3 +284,332 @@ func TestEmojiRepository_ListRemoteWithFilter(t *testing.T) {
 	_, err = repo.ListRemoteWithFilter("", host, 1000, 0) // clamped to 100
 	require.NoError(t, err)
 }
+
+func TestEmojiRepository_ListV2_Basic(t *testing.T) {
+	repo := NewEmojiRepository(testDB)
+
+	e1 := &model.Emoji{ID: "ev_b1", Name: "v2alpha", OriginalURL: "https://x"}
+	e2 := &model.Emoji{ID: "ev_b2", Name: "v2beta", OriginalURL: "https://y"}
+	require.NoError(t, repo.Create(e1))
+	require.NoError(t, repo.Create(e2))
+	defer cleanupEmoji(t, e1.ID)
+	defer cleanupEmoji(t, e2.ID)
+
+	rows, err := repo.ListV2(model.EmojiV2Filter{Limit: 10})
+	require.NoError(t, err)
+	assert.GreaterOrEqual(t, len(rows), 2)
+}
+
+func TestEmojiRepository_ListV2_HostType(t *testing.T) {
+	repo := NewEmojiRepository(testDB)
+
+	local := &model.Emoji{ID: "ev_h1", Name: "v2local", OriginalURL: "https://x"}
+	host := "v2remote.example"
+	remote := &model.Emoji{ID: "ev_h2", Name: "v2remote", Host: &host, OriginalURL: "https://y"}
+	require.NoError(t, repo.Create(local))
+	require.NoError(t, repo.Create(remote))
+	defer cleanupEmoji(t, local.ID)
+	defer cleanupEmoji(t, remote.ID)
+
+	// localのみ
+	rows, err := repo.ListV2(model.EmojiV2Filter{
+		Query: &model.EmojiV2Query{HostType: "local", Name: "v2"},
+		Limit: 100,
+	})
+	require.NoError(t, err)
+	for _, r := range rows {
+		assert.Nil(t, r.Host)
+	}
+
+	// remoteのみ
+	rows, err = repo.ListV2(model.EmojiV2Filter{
+		Query: &model.EmojiV2Query{HostType: "remote", Name: "v2"},
+		Limit: 100,
+	})
+	require.NoError(t, err)
+	for _, r := range rows {
+		assert.NotNil(t, r.Host)
+	}
+}
+
+func TestEmojiRepository_ListV2_NameFilter(t *testing.T) {
+	repo := NewEmojiRepository(testDB)
+
+	e := &model.Emoji{ID: "ev_n1", Name: "v2uniquename", OriginalURL: "https://x"}
+	require.NoError(t, repo.Create(e))
+	defer cleanupEmoji(t, e.ID)
+
+	rows, err := repo.ListV2(model.EmojiV2Filter{
+		Query: &model.EmojiV2Query{Name: "v2unique"},
+		Limit: 10,
+	})
+	require.NoError(t, err)
+	assert.Len(t, rows, 1)
+	assert.Equal(t, "ev_n1", rows[0].ID)
+}
+
+func TestEmojiRepository_ListV2_SortKeys(t *testing.T) {
+	repo := NewEmojiRepository(testDB)
+
+	e1 := &model.Emoji{ID: "ev_s1", Name: "v2zebra", OriginalURL: "https://x"}
+	e2 := &model.Emoji{ID: "ev_s2", Name: "v2apple", OriginalURL: "https://y"}
+	require.NoError(t, repo.Create(e1))
+	require.NoError(t, repo.Create(e2))
+	defer cleanupEmoji(t, e1.ID)
+	defer cleanupEmoji(t, e2.ID)
+
+	// name ASC
+	rows, err := repo.ListV2(model.EmojiV2Filter{
+		Query:    &model.EmojiV2Query{Name: "v2"},
+		SortKeys: []string{"+name"},
+		Limit:    10,
+	})
+	require.NoError(t, err)
+	require.GreaterOrEqual(t, len(rows), 2)
+	// v2apple < v2zebra
+	for i := 0; i < len(rows)-1; i++ {
+		assert.LessOrEqual(t, rows[i].Name, rows[i+1].Name)
+	}
+}
+
+func TestEmojiRepository_ListV2_Pagination(t *testing.T) {
+	repo := NewEmojiRepository(testDB)
+
+	ids := []string{"ev_p1", "ev_p2", "ev_p3"}
+	for i, id := range ids {
+		e := &model.Emoji{ID: id, Name: "v2page" + string(rune('a'+i)), OriginalURL: "https://x"}
+		require.NoError(t, repo.Create(e))
+		defer cleanupEmoji(t, id)
+	}
+
+	// page 1, limit 2
+	rows, err := repo.ListV2(model.EmojiV2Filter{
+		Query: &model.EmojiV2Query{Name: "v2page"},
+		Limit: 2,
+		Page:  1,
+	})
+	require.NoError(t, err)
+	assert.Len(t, rows, 2)
+
+	// page 2
+	rows, err = repo.ListV2(model.EmojiV2Filter{
+		Query: &model.EmojiV2Query{Name: "v2page"},
+		Limit: 2,
+		Page:  2,
+	})
+	require.NoError(t, err)
+	assert.Len(t, rows, 1)
+}
+
+func TestEmojiRepository_ListV2_SinceUntilID(t *testing.T) {
+	repo := NewEmojiRepository(testDB)
+
+	e1 := &model.Emoji{ID: "ev_c1", Name: "v2cursor1", OriginalURL: "https://x"}
+	e2 := &model.Emoji{ID: "ev_c2", Name: "v2cursor2", OriginalURL: "https://y"}
+	require.NoError(t, repo.Create(e1))
+	require.NoError(t, repo.Create(e2))
+	defer cleanupEmoji(t, e1.ID)
+	defer cleanupEmoji(t, e2.ID)
+
+	// sinceId: ev_c1より後
+	rows, err := repo.ListV2(model.EmojiV2Filter{
+		Query:   &model.EmojiV2Query{Name: "v2cursor"},
+		SinceID: "ev_c1",
+		Limit:   10,
+	})
+	require.NoError(t, err)
+	for _, r := range rows {
+		assert.Greater(t, r.ID, "ev_c1")
+	}
+
+	// untilId: ev_c2より前
+	rows, err = repo.ListV2(model.EmojiV2Filter{
+		Query:   &model.EmojiV2Query{Name: "v2cursor"},
+		UntilID: "ev_c2",
+		Limit:   10,
+	})
+	require.NoError(t, err)
+	for _, r := range rows {
+		assert.Less(t, r.ID, "ev_c2")
+	}
+}
+
+func TestEmojiRepository_ListV2_BooleanFilters(t *testing.T) {
+	repo := NewEmojiRepository(testDB)
+
+	e := &model.Emoji{ID: "ev_bf1", Name: "v2sensitive", IsSensitive: true, LocalOnly: true, OriginalURL: "https://x"}
+	require.NoError(t, repo.Create(e))
+	defer cleanupEmoji(t, e.ID)
+
+	boolTrue := true
+	boolFalse := false
+
+	// isSensitive=true
+	rows, err := repo.ListV2(model.EmojiV2Filter{
+		Query: &model.EmojiV2Query{Name: "v2sensitive", IsSensitive: &boolTrue},
+		Limit: 10,
+	})
+	require.NoError(t, err)
+	assert.Len(t, rows, 1)
+
+	// isSensitive=false
+	rows, err = repo.ListV2(model.EmojiV2Filter{
+		Query: &model.EmojiV2Query{Name: "v2sensitive", IsSensitive: &boolFalse},
+		Limit: 10,
+	})
+	require.NoError(t, err)
+	assert.Empty(t, rows)
+
+	// localOnly=true
+	rows, err = repo.ListV2(model.EmojiV2Filter{
+		Query: &model.EmojiV2Query{Name: "v2sensitive", LocalOnly: &boolTrue},
+		Limit: 10,
+	})
+	require.NoError(t, err)
+	assert.Len(t, rows, 1)
+}
+
+func TestEmojiRepository_ListV2_DefaultsAndLimitClamp(t *testing.T) {
+	repo := NewEmojiRepository(testDB)
+
+	// limit=0 → default 10
+	rows, err := repo.ListV2(model.EmojiV2Filter{Limit: 0})
+	require.NoError(t, err)
+	assert.LessOrEqual(t, len(rows), 10)
+
+	// limit > 100 → clamped
+	rows, err = repo.ListV2(model.EmojiV2Filter{Limit: 999})
+	require.NoError(t, err)
+	assert.LessOrEqual(t, len(rows), 100)
+}
+
+func TestEmojiRepository_ListV2_InvalidSortKeyIgnored(t *testing.T) {
+	repo := NewEmojiRepository(testDB)
+	// 不正なsortKeyは無視されエラーにならない
+	rows, err := repo.ListV2(model.EmojiV2Filter{
+		SortKeys: []string{"+invalid", "x", "-name"},
+		Limit:    10,
+	})
+	require.NoError(t, err)
+	_ = rows
+}
+
+func TestEmojiRepository_ListV2_Error(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	repo := NewEmojiRepository(testDB.WithContext(ctx))
+	_, err := repo.ListV2(model.EmojiV2Filter{Limit: 10})
+	assert.Error(t, err)
+}
+
+func TestEmojiRepository_CountV2_Basic(t *testing.T) {
+	repo := NewEmojiRepository(testDB)
+
+	e := &model.Emoji{ID: "ev_ct1", Name: "v2countme", OriginalURL: "https://x"}
+	require.NoError(t, repo.Create(e))
+	defer cleanupEmoji(t, e.ID)
+
+	count, err := repo.CountV2(model.EmojiV2Filter{
+		Query: &model.EmojiV2Query{Name: "v2countme"},
+	})
+	require.NoError(t, err)
+	assert.Equal(t, int64(1), count)
+}
+
+func TestEmojiRepository_CountV2_Error(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	repo := NewEmojiRepository(testDB.WithContext(ctx))
+	_, err := repo.CountV2(model.EmojiV2Filter{})
+	assert.Error(t, err)
+}
+
+func TestEmojiRepository_ListV2_CategoryFilter(t *testing.T) {
+	repo := NewEmojiRepository(testDB)
+
+	cat := "v2animals"
+	e := &model.Emoji{ID: "ev_cf1", Name: "v2catfilter", Category: &cat, OriginalURL: "https://x"}
+	require.NoError(t, repo.Create(e))
+	defer cleanupEmoji(t, e.ID)
+
+	rows, err := repo.ListV2(model.EmojiV2Filter{
+		Query: &model.EmojiV2Query{Category: "v2animal"},
+		Limit: 10,
+	})
+	require.NoError(t, err)
+	assert.Len(t, rows, 1)
+
+	rows, err = repo.ListV2(model.EmojiV2Filter{
+		Query: &model.EmojiV2Query{Category: "nonexistent"},
+		Limit: 10,
+	})
+	require.NoError(t, err)
+	assert.Empty(t, rows)
+}
+
+func TestEmojiRepository_ListV2_LicenseFilter(t *testing.T) {
+	repo := NewEmojiRepository(testDB)
+
+	lic := "CC-BY-4.0"
+	e := &model.Emoji{ID: "ev_lf1", Name: "v2licfilter", License: &lic, OriginalURL: "https://x"}
+	require.NoError(t, repo.Create(e))
+	defer cleanupEmoji(t, e.ID)
+
+	rows, err := repo.ListV2(model.EmojiV2Filter{
+		Query: &model.EmojiV2Query{License: "CC-BY"},
+		Limit: 10,
+	})
+	require.NoError(t, err)
+	assert.Len(t, rows, 1)
+}
+
+func TestEmojiRepository_ListV2_HostFilter(t *testing.T) {
+	repo := NewEmojiRepository(testDB)
+
+	host := "v2host.example"
+	e := &model.Emoji{ID: "ev_hf1", Name: "v2hostfilter", Host: &host, OriginalURL: "https://x"}
+	require.NoError(t, repo.Create(e))
+	defer cleanupEmoji(t, e.ID)
+
+	rows, err := repo.ListV2(model.EmojiV2Filter{
+		Query: &model.EmojiV2Query{Host: "v2host"},
+		Limit: 10,
+	})
+	require.NoError(t, err)
+	assert.Len(t, rows, 1)
+}
+
+func TestEmojiRepository_ListV2_AliasesFilter(t *testing.T) {
+	repo := NewEmojiRepository(testDB)
+
+	e := &model.Emoji{
+		ID: "ev_af1", Name: "v2aliasfilter",
+		Aliases:     []string{"v2happy", "v2joy"},
+		OriginalURL: "https://x",
+	}
+	require.NoError(t, repo.Create(e))
+	defer cleanupEmoji(t, e.ID)
+
+	rows, err := repo.ListV2(model.EmojiV2Filter{
+		Query: &model.EmojiV2Query{Aliases: "v2happy"},
+		Limit: 10,
+	})
+	require.NoError(t, err)
+	assert.Len(t, rows, 1)
+}
+
+func TestEmojiRepository_ListV2_TypeFilter(t *testing.T) {
+	repo := NewEmojiRepository(testDB)
+
+	tp := "image/webp"
+	e := &model.Emoji{ID: "ev_tf1", Name: "v2typefilter", Type: &tp, OriginalURL: "https://x"}
+	require.NoError(t, repo.Create(e))
+	defer cleanupEmoji(t, e.ID)
+
+	rows, err := repo.ListV2(model.EmojiV2Filter{
+		Query: &model.EmojiV2Query{Type: "webp"},
+		Limit: 10,
+	})
+	require.NoError(t, err)
+	assert.Len(t, rows, 1)
+}

--- a/internal/server/router.go
+++ b/internal/server/router.go
@@ -1804,8 +1804,8 @@ func (s *Server) setupRoutes() {
 		return c.NoContent(http.StatusNoContent)
 	}, middleware.RequireAuth())
 
-	// v2/admin/emoji/list — v2 paginated emoji list (delegates to existing admin handler)
-	api.POST("/v2/admin/emoji/list", adminHandler.EmojiList, middleware.RequireAdmin(roleService))
+	// v2/admin/emoji/list — v2はページネーション情報付きオブジェクトを返す専用ハンドラ
+	api.POST("/v2/admin/emoji/list", adminHandler.EmojiListV2, middleware.RequireAdmin(roleService))
 
 	// --- その他の残りエンドポイント ---
 	// test — フロントエンドのテスト用

--- a/internal/testutil/mock_repository.go
+++ b/internal/testutil/mock_repository.go
@@ -1196,6 +1196,158 @@ func (m *MockEmojiRepository) ListRemoteWithFilter(query, host string, limit, of
 	return out[offset:end], nil
 }
 
+func (m *MockEmojiRepository) ListV2(filter model.EmojiV2Filter) ([]*model.Emoji, error) {
+	all := m.filterV2(filter)
+	m.sortV2(all, filter.SortKeys)
+
+	limit := filter.Limit
+	if limit <= 0 {
+		limit = 10
+	}
+	if limit > 100 {
+		limit = 100
+	}
+
+	offset := 0
+	if filter.Page > 0 {
+		offset = (filter.Page - 1) * limit
+	}
+	if offset >= len(all) {
+		return []*model.Emoji{}, nil
+	}
+	end := offset + limit
+	if end > len(all) {
+		end = len(all)
+	}
+	return all[offset:end], nil
+}
+
+func (m *MockEmojiRepository) CountV2(filter model.EmojiV2Filter) (int64, error) {
+	return int64(len(m.filterV2(filter))), nil
+}
+
+// filterV2 はv2フィルタに一致するemojiを抽出する
+func (m *MockEmojiRepository) filterV2(filter model.EmojiV2Filter) []*model.Emoji {
+	seen := make(map[string]bool)
+	var out []*model.Emoji
+	for _, e := range m.Emojis {
+		if seen[e.ID] {
+			continue
+		}
+		if filter.Query != nil {
+			fq := filter.Query
+			if fq.HostType == "local" && e.Host != nil {
+				continue
+			}
+			if fq.HostType == "remote" && e.Host == nil {
+				continue
+			}
+			if fq.Name != "" && !mockILIKE(e.Name, fq.Name) {
+				continue
+			}
+			if fq.Host != "" {
+				if e.Host == nil || !mockILIKE(*e.Host, fq.Host) {
+					continue
+				}
+			}
+			if fq.Category != "" {
+				if e.Category == nil || !mockILIKE(*e.Category, fq.Category) {
+					continue
+				}
+			}
+			if fq.Type != "" {
+				if e.Type == nil || !mockILIKE(*e.Type, fq.Type) {
+					continue
+				}
+			}
+			if fq.Aliases != "" {
+				aliasStr := strings.Join(e.Aliases, ",")
+				if !mockILIKE(aliasStr, fq.Aliases) {
+					continue
+				}
+			}
+			if fq.License != "" {
+				if e.License == nil || !mockILIKE(*e.License, fq.License) {
+					continue
+				}
+			}
+			if fq.IsSensitive != nil && e.IsSensitive != *fq.IsSensitive {
+				continue
+			}
+			if fq.LocalOnly != nil && e.LocalOnly != *fq.LocalOnly {
+				continue
+			}
+		}
+		if filter.SinceID != "" && e.ID <= filter.SinceID {
+			continue
+		}
+		if filter.UntilID != "" && e.ID >= filter.UntilID {
+			continue
+		}
+		seen[e.ID] = true
+		out = append(out, e)
+	}
+	return out
+}
+
+// sortV2 はsortKeysに従ってemojiをソートする
+func (m *MockEmojiRepository) sortV2(emojis []*model.Emoji, sortKeys []string) {
+	if len(sortKeys) == 0 {
+		sortKeys = []string{"-id"}
+	}
+	sort.SliceStable(emojis, func(i, j int) bool {
+		for _, sk := range sortKeys {
+			if len(sk) < 2 {
+				continue
+			}
+			asc := sk[0] == '+'
+			col := sk[1:]
+			cmp := mockEmojiCompare(emojis[i], emojis[j], col)
+			if cmp == 0 {
+				continue
+			}
+			if asc {
+				return cmp < 0
+			}
+			return cmp > 0
+		}
+		return false
+	})
+}
+
+func mockEmojiCompare(a, b *model.Emoji, col string) int {
+	switch col {
+	case "id":
+		return strings.Compare(a.ID, b.ID)
+	case "name":
+		return strings.Compare(a.Name, b.Name)
+	case "host":
+		ah, bh := "", ""
+		if a.Host != nil {
+			ah = *a.Host
+		}
+		if b.Host != nil {
+			bh = *b.Host
+		}
+		return strings.Compare(ah, bh)
+	case "category":
+		ac, bc := "", ""
+		if a.Category != nil {
+			ac = *a.Category
+		}
+		if b.Category != nil {
+			bc = *b.Category
+		}
+		return strings.Compare(ac, bc)
+	default:
+		return 0
+	}
+}
+
+func mockILIKE(value, substr string) bool {
+	return strings.Contains(strings.ToLower(value), strings.ToLower(substr))
+}
+
 // MockMetaRepository is a test double for repository.MetaRepository.
 type MockMetaRepository struct {
 	Meta *model.Meta

--- a/internal/testutil/mock_repository.go
+++ b/internal/testutil/mock_repository.go
@@ -1226,7 +1226,7 @@ func (m *MockEmojiRepository) CountV2(filter model.EmojiV2Filter) (int64, error)
 	return int64(len(m.filterV2(filter))), nil
 }
 
-// filterV2 はv2フィルタに一致するemojiを抽出する
+// filterV2 extracts emojis matching the v2 filter criteria.
 func (m *MockEmojiRepository) filterV2(filter model.EmojiV2Filter) []*model.Emoji {
 	seen := make(map[string]bool)
 	var out []*model.Emoji
@@ -1290,9 +1290,18 @@ func (m *MockEmojiRepository) filterV2(filter model.EmojiV2Filter) []*model.Emoj
 	return out
 }
 
-// sortV2 はsortKeysに従ってemojiをソートする
+// sortV2 sorts emojis according to the given sortKeys.
+// Falls back to id DESC when no valid sort key is found.
 func (m *MockEmojiRepository) sortV2(emojis []*model.Emoji, sortKeys []string) {
-	if len(sortKeys) == 0 {
+	// 有効なsortKeyが1つもなければid DESCにfallback
+	hasValid := false
+	for _, sk := range sortKeys {
+		if len(sk) >= 2 {
+			hasValid = true
+			break
+		}
+	}
+	if !hasValid {
 		sortKeys = []string{"-id"}
 	}
 	sort.SliceStable(emojis, func(i, j int) bool {


### PR DESCRIPTION
## Summary
- v2/admin/emoji/list が v1 ハンドラに委譲されていたため、v2 のリクエスト構造体（ネストされた `query` オブジェクト、`sortKeys`、ページベースのページネーション）でバインドに失敗し `INVALID_PARAM` (400) が返っていた
- v2 専用の `EmojiListV2` ハンドラを実装し、`{emojis, count, allCount, allPages}` を返すように修正

## 主な変更点
- `internal/model/emoji.go`: `EmojiV2Filter` / `EmojiV2Query` 型を追加
- `internal/repository/emoji.go`: `ListV2` / `CountV2` メソッドを追加（hostType、ILIKE テキストフィルタ、boolean フィルタ、日付範囲、roleIDs 配列重複、sinceId/untilId カーソル、allowlist ベースのソート、ページベースのページネーション）
- `internal/api/admin/handler.go`: `EmojiListV2` ハンドラ追加
- `internal/server/router.go`: v2 ルートを新ハンドラに差し替え
- `internal/testutil/mock_repository.go`: モックに `ListV2` / `CountV2` 実装追加
- `internal/core/emojiimport/coverage_boost_test.go`: インターフェース変更に伴うスタブ追加

## テスト
- `TestEmojiListV2_Basic` — 基本動作、レスポンス形式確認
- `TestEmojiListV2_NilRepo` — repo nil 時の空レスポンス
- `TestEmojiListV2_InvalidJSON` — 不正JSON で 400
- `TestEmojiListV2_HostType` — local/remote/all フィルタ
- `TestEmojiListV2_QueryFilter` — name 検索
- `TestEmojiListV2_Pagination` — page ベースのページング + allPages 計算
- `TestEmojiListV2_SortKeys` — ソート順確認 (+name ASC, デフォルト id DESC)
- `TestEmojiListV2_SensitiveFilter` — isSensitive フィルタ
- `TestEmojiListV2_LimitClamped` — limit > 100 のクランプ
- `TestEmojiListV2_ListV2Error` — DB エラー時の 500

```bash
go test ./internal/api/admin/... -v -run "EmojiListV2" -count=1
```

Closes #263

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/shiroha-a/mk/pull/264" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
