### PR TITLE
Fix #265: Add url field to admin/emoji/list responses

### DIFF
--- a/internal/api/admin/drive_emoji_test.go
+++ b/internal/api/admin/drive_emoji_test.go
@@ -310,16 +310,12 @@ func TestEmojiListV2_Basic(t *testing.T) {
 	assert.EqualValues(t, 2, resp["count"])
 	assert.EqualValues(t, 2, resp["allCount"])
 	assert.EqualValues(t, 1, resp["allPages"])
-	// packDetailedによりurl (= publicUrl || originalUrl) フィールドが含まれること
-	urlByName := map[string]string{}
+	// v2はpackDetailedAdmin相当: publicUrl/originalUrlを直接返す（computed urlは含まない）
 	for _, raw := range emojis {
 		em := raw.(map[string]any)
-		_, hasURL := em["url"]
-		assert.True(t, hasURL, "emoji should have url field")
-		urlByName[em["name"].(string)] = em["url"].(string)
+		_, hasPublicURL := em["publicUrl"]
+		assert.True(t, hasPublicURL, "v2 emoji should have publicUrl field")
 	}
-	assert.Equal(t, "https://example.com/smile.png", urlByName["smile"])
-	assert.Equal(t, "https://example.com/wave-orig.png", urlByName["wave"])
 }
 
 func TestEmojiListV2_NilRepo(t *testing.T) {

--- a/internal/api/admin/drive_emoji_test.go
+++ b/internal/api/admin/drive_emoji_test.go
@@ -297,8 +297,8 @@ func TestEmojiImportZip_UnknownFileReturns400(t *testing.T) {
 func TestEmojiListV2_Basic(t *testing.T) {
 	h, _, _, _ := newTestHandler(t)
 	repo := testutil.NewMockEmojiRepository()
-	require.NoError(t, repo.Create(&model.Emoji{ID: "e1", Name: "smile"}))
-	require.NoError(t, repo.Create(&model.Emoji{ID: "e2", Name: "wave"}))
+	require.NoError(t, repo.Create(&model.Emoji{ID: "e1", Name: "smile", PublicURL: "https://example.com/smile.png"}))
+	require.NoError(t, repo.Create(&model.Emoji{ID: "e2", Name: "wave", OriginalURL: "https://example.com/wave-orig.png"}))
 	h.SetEmojiRepo(repo)
 
 	rec := doPost(h.EmojiListV2, `{}`, adminUser)
@@ -310,6 +310,16 @@ func TestEmojiListV2_Basic(t *testing.T) {
 	assert.EqualValues(t, 2, resp["count"])
 	assert.EqualValues(t, 2, resp["allCount"])
 	assert.EqualValues(t, 1, resp["allPages"])
+	// packDetailedによりurl (= publicUrl || originalUrl) フィールドが含まれること
+	urlByName := map[string]string{}
+	for _, raw := range emojis {
+		em := raw.(map[string]any)
+		_, hasURL := em["url"]
+		assert.True(t, hasURL, "emoji should have url field")
+		urlByName[em["name"].(string)] = em["url"].(string)
+	}
+	assert.Equal(t, "https://example.com/smile.png", urlByName["smile"])
+	assert.Equal(t, "https://example.com/wave-orig.png", urlByName["wave"])
 }
 
 func TestEmojiListV2_NilRepo(t *testing.T) {

--- a/internal/api/admin/handler.go
+++ b/internal/api/admin/handler.go
@@ -1037,7 +1037,7 @@ func (h *Handler) EmojiListV2(c echo.Context) error {
 	}
 	if h.emojiRepo == nil {
 		return c.JSON(http.StatusOK, emojiListV2Response{
-			Emojis:   []entity.EmojiDetailed{},
+			Emojis:   []*model.Emoji{},
 			Count:    0,
 			AllCount: 0,
 			AllPages: 0,
@@ -1092,10 +1092,9 @@ func (h *Handler) EmojiListV2(c echo.Context) error {
 		allPages = int((allCount + int64(limit) - 1) / int64(limit))
 	}
 
-	packed := entity.PackEmojiDetailedList(emojis)
 	return c.JSON(http.StatusOK, emojiListV2Response{
-		Emojis:   packed,
-		Count:    len(packed),
+		Emojis:   emojis,
+		Count:    len(emojis),
 		AllCount: allCount,
 		AllPages: allPages,
 	})
@@ -1117,10 +1116,10 @@ type emojiV2QueryReq struct {
 }
 
 type emojiListV2Response struct {
-	Emojis   []entity.EmojiDetailed `json:"emojis"`
-	Count    int                    `json:"count"`
-	AllCount int64                  `json:"allCount"`
-	AllPages int                    `json:"allPages"`
+	Emojis   []*model.Emoji `json:"emojis"`
+	Count    int            `json:"count"`
+	AllCount int64          `json:"allCount"`
+	AllPages int            `json:"allPages"`
 }
 
 // --- Abuse Report endpoints ---

--- a/internal/api/admin/handler.go
+++ b/internal/api/admin/handler.go
@@ -1018,7 +1018,7 @@ func (h *Handler) EmojiList(c echo.Context) error {
 	if err != nil {
 		return c.JSON(http.StatusInternalServerError, apierr.Error("INTERNAL_ERROR", "Internal error.", "5d37dbcb-891e-41ca-a3d6-e690c97775ac"))
 	}
-	return c.JSON(http.StatusOK, emojis)
+	return c.JSON(http.StatusOK, entity.PackEmojiDetailedList(emojis))
 }
 
 // EmojiListV2 handles POST /api/v2/admin/emoji/list.
@@ -1037,7 +1037,7 @@ func (h *Handler) EmojiListV2(c echo.Context) error {
 	}
 	if h.emojiRepo == nil {
 		return c.JSON(http.StatusOK, emojiListV2Response{
-			Emojis:   []*model.Emoji{},
+			Emojis:   []entity.EmojiDetailed{},
 			Count:    0,
 			AllCount: 0,
 			AllPages: 0,
@@ -1092,9 +1092,10 @@ func (h *Handler) EmojiListV2(c echo.Context) error {
 		allPages = int((allCount + int64(limit) - 1) / int64(limit))
 	}
 
+	packed := entity.PackEmojiDetailedList(emojis)
 	return c.JSON(http.StatusOK, emojiListV2Response{
-		Emojis:   emojis,
-		Count:    len(emojis),
+		Emojis:   packed,
+		Count:    len(packed),
 		AllCount: allCount,
 		AllPages: allPages,
 	})
@@ -1116,10 +1117,10 @@ type emojiV2QueryReq struct {
 }
 
 type emojiListV2Response struct {
-	Emojis   []*model.Emoji `json:"emojis"`
-	Count    int            `json:"count"`
-	AllCount int64          `json:"allCount"`
-	AllPages int            `json:"allPages"`
+	Emojis   []entity.EmojiDetailed `json:"emojis"`
+	Count    int                    `json:"count"`
+	AllCount int64                  `json:"allCount"`
+	AllPages int                    `json:"allPages"`
 }
 
 // --- Abuse Report endpoints ---

--- a/internal/api/admin/handler_test.go
+++ b/internal/api/admin/handler_test.go
@@ -886,10 +886,28 @@ func TestEmojiDelete_NilRepo(t *testing.T) {
 func TestEmojiList_Success(t *testing.T) {
 	h, _, _, _ := newTestHandler(t)
 	emojiRepo := testutil.NewMockEmojiRepository()
-	emojiRepo.Emojis["smile@"] = &model.Emoji{ID: "e1", Name: "smile"}
+	emojiRepo.Emojis["smile@"] = &model.Emoji{ID: "e1", Name: "smile", PublicURL: "https://example.com/smile.png"}
 	h.SetEmojiRepo(emojiRepo)
 	rec := doPost(h.EmojiList, `{}`, nil)
 	assert.Equal(t, http.StatusOK, rec.Code)
+	var rows []map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &rows))
+	require.Len(t, rows, 1)
+	assert.Equal(t, "https://example.com/smile.png", rows[0]["url"])
+}
+
+func TestEmojiList_URLFallbackToOriginalUrl(t *testing.T) {
+	h, _, _, _ := newTestHandler(t)
+	emojiRepo := testutil.NewMockEmojiRepository()
+	// publicUrl空 → originalUrlにフォールバック
+	emojiRepo.Emojis["wave@"] = &model.Emoji{ID: "e2", Name: "wave", PublicURL: "", OriginalURL: "https://example.com/wave-orig.png"}
+	h.SetEmojiRepo(emojiRepo)
+	rec := doPost(h.EmojiList, `{}`, nil)
+	assert.Equal(t, http.StatusOK, rec.Code)
+	var rows []map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &rows))
+	require.Len(t, rows, 1)
+	assert.Equal(t, "https://example.com/wave-orig.png", rows[0]["url"])
 }
 
 func TestEmojiList_NilRepo(t *testing.T) {

--- a/internal/entity/emoji.go
+++ b/internal/entity/emoji.go
@@ -14,7 +14,7 @@ type EmojiDetailed struct {
 	License                                 *string  `json:"license"`
 	IsSensitive                             bool     `json:"isSensitive"`
 	LocalOnly                               bool     `json:"localOnly"`
-	RoleIdsThatCanBeUsedThisEmojiAsReaction []string `json:"roleIdsThatCanBeUsedThisEmojiAsReaction"`
+	RoleIDsThatCanBeUsedThisEmojiAsReaction []string `json:"roleIdsThatCanBeUsedThisEmojiAsReaction"`
 }
 
 // PackEmojiDetailed converts a model.Emoji to an EmojiDetailed DTO.
@@ -38,7 +38,7 @@ func PackEmojiDetailed(e *model.Emoji) EmojiDetailed {
 		License:                                 e.License,
 		IsSensitive:                             e.IsSensitive,
 		LocalOnly:                               e.LocalOnly,
-		RoleIdsThatCanBeUsedThisEmojiAsReaction: roleIDs,
+		RoleIDsThatCanBeUsedThisEmojiAsReaction: roleIDs,
 	}
 }
 

--- a/internal/entity/emoji.go
+++ b/internal/entity/emoji.go
@@ -1,0 +1,52 @@
+package entity
+
+import "github.com/shiroha-a/mk/internal/model"
+
+// EmojiDetailed is the emoji representation returned by admin emoji endpoints.
+// Matches the TypeScript EmojiDetailed schema (packDetailed).
+type EmojiDetailed struct {
+	ID                                      string   `json:"id"`
+	Aliases                                 []string `json:"aliases"`
+	Name                                    string   `json:"name"`
+	Category                                *string  `json:"category"`
+	Host                                    *string  `json:"host"`
+	URL                                     string   `json:"url"`
+	License                                 *string  `json:"license"`
+	IsSensitive                             bool     `json:"isSensitive"`
+	LocalOnly                               bool     `json:"localOnly"`
+	RoleIdsThatCanBeUsedThisEmojiAsReaction []string `json:"roleIdsThatCanBeUsedThisEmojiAsReaction"`
+}
+
+// PackEmojiDetailed converts a model.Emoji to an EmojiDetailed DTO.
+// URL is computed as publicUrl || originalUrl for backward compatibility.
+func PackEmojiDetailed(e *model.Emoji) EmojiDetailed {
+	url := e.PublicURL
+	if url == "" {
+		url = e.OriginalURL
+	}
+	aliases := make([]string, len(e.Aliases))
+	copy(aliases, e.Aliases)
+	roleIDs := make([]string, len(e.RoleIDsThatCanBeUsedThisEmojiAsReaction))
+	copy(roleIDs, e.RoleIDsThatCanBeUsedThisEmojiAsReaction)
+	return EmojiDetailed{
+		ID:                                      e.ID,
+		Aliases:                                 aliases,
+		Name:                                    e.Name,
+		Category:                                e.Category,
+		Host:                                    e.Host,
+		URL:                                     url,
+		License:                                 e.License,
+		IsSensitive:                             e.IsSensitive,
+		LocalOnly:                               e.LocalOnly,
+		RoleIdsThatCanBeUsedThisEmojiAsReaction: roleIDs,
+	}
+}
+
+// PackEmojiDetailedList converts a slice of model.Emoji to EmojiDetailed DTOs.
+func PackEmojiDetailedList(emojis []*model.Emoji) []EmojiDetailed {
+	out := make([]EmojiDetailed, len(emojis))
+	for i, e := range emojis {
+		out[i] = PackEmojiDetailed(e)
+	}
+	return out
+}

--- a/internal/entity/emoji_test.go
+++ b/internal/entity/emoji_test.go
@@ -1,0 +1,104 @@
+package entity
+
+import (
+	"testing"
+
+	"github.com/lib/pq"
+	"github.com/shiroha-a/mk/internal/model"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestPackEmojiDetailed_URLFromPublicURL(t *testing.T) {
+	e := &model.Emoji{
+		ID:          "e1",
+		Name:        "smile",
+		PublicURL:   "https://example.com/smile.webp",
+		OriginalURL: "https://example.com/smile-orig.png",
+	}
+	d := PackEmojiDetailed(e)
+	assert.Equal(t, "https://example.com/smile.webp", d.URL)
+}
+
+func TestPackEmojiDetailed_URLFallbackToOriginalURL(t *testing.T) {
+	e := &model.Emoji{
+		ID:          "e2",
+		Name:        "wave",
+		PublicURL:   "",
+		OriginalURL: "https://example.com/wave-orig.png",
+	}
+	d := PackEmojiDetailed(e)
+	assert.Equal(t, "https://example.com/wave-orig.png", d.URL)
+}
+
+func TestPackEmojiDetailed_AllFields(t *testing.T) {
+	cat := "faces"
+	lic := "CC0"
+	e := &model.Emoji{
+		ID:                                      "e3",
+		Name:                                    "grin",
+		Category:                                &cat,
+		PublicURL:                               "https://example.com/grin.webp",
+		OriginalURL:                             "https://example.com/grin.png",
+		License:                                 &lic,
+		IsSensitive:                             true,
+		LocalOnly:                               true,
+		Aliases:                                 pq.StringArray{"happy", "joy"},
+		RoleIDsThatCanBeUsedThisEmojiAsReaction: pq.StringArray{"role1"},
+	}
+	d := PackEmojiDetailed(e)
+	assert.Equal(t, "e3", d.ID)
+	assert.Equal(t, "grin", d.Name)
+	assert.Equal(t, &cat, d.Category)
+	assert.Nil(t, d.Host)
+	assert.Equal(t, "https://example.com/grin.webp", d.URL)
+	assert.Equal(t, &lic, d.License)
+	assert.True(t, d.IsSensitive)
+	assert.True(t, d.LocalOnly)
+	assert.Equal(t, []string{"happy", "joy"}, d.Aliases)
+	assert.Equal(t, []string{"role1"}, d.RoleIdsThatCanBeUsedThisEmojiAsReaction)
+}
+
+func TestPackEmojiDetailed_NilSlicesReturnEmpty(t *testing.T) {
+	e := &model.Emoji{
+		ID:          "e4",
+		Name:        "test",
+		OriginalURL: "https://example.com/test.png",
+	}
+	d := PackEmojiDetailed(e)
+	assert.NotNil(t, d.Aliases, "aliases should be empty slice, not nil")
+	assert.NotNil(t, d.RoleIdsThatCanBeUsedThisEmojiAsReaction, "roleIds should be empty slice, not nil")
+	assert.Len(t, d.Aliases, 0)
+	assert.Len(t, d.RoleIdsThatCanBeUsedThisEmojiAsReaction, 0)
+}
+
+func TestPackEmojiDetailedList(t *testing.T) {
+	emojis := []*model.Emoji{
+		{ID: "e1", Name: "a", PublicURL: "https://example.com/a.png"},
+		{ID: "e2", Name: "b", OriginalURL: "https://example.com/b.png"},
+	}
+	list := PackEmojiDetailedList(emojis)
+	assert.Len(t, list, 2)
+	assert.Equal(t, "https://example.com/a.png", list[0].URL)
+	assert.Equal(t, "https://example.com/b.png", list[1].URL)
+}
+
+func TestPackEmojiDetailedList_Empty(t *testing.T) {
+	list := PackEmojiDetailedList([]*model.Emoji{})
+	assert.NotNil(t, list)
+	assert.Len(t, list, 0)
+}
+
+func TestPackEmojiDetailed_DoesNotMutateInput(t *testing.T) {
+	e := &model.Emoji{
+		ID:                                      "e5",
+		Name:                                    "safe",
+		Aliases:                                 pq.StringArray{"orig"},
+		RoleIDsThatCanBeUsedThisEmojiAsReaction: pq.StringArray{"r1"},
+		OriginalURL:                             "https://example.com/safe.png",
+	}
+	d := PackEmojiDetailed(e)
+	d.Aliases[0] = "mutated"
+	d.RoleIdsThatCanBeUsedThisEmojiAsReaction[0] = "mutated"
+	assert.Equal(t, "orig", e.Aliases[0], "original aliases should not be mutated")
+	assert.Equal(t, "r1", e.RoleIDsThatCanBeUsedThisEmojiAsReaction[0], "original roleIds should not be mutated")
+}

--- a/internal/entity/emoji_test.go
+++ b/internal/entity/emoji_test.go
@@ -55,7 +55,7 @@ func TestPackEmojiDetailed_AllFields(t *testing.T) {
 	assert.True(t, d.IsSensitive)
 	assert.True(t, d.LocalOnly)
 	assert.Equal(t, []string{"happy", "joy"}, d.Aliases)
-	assert.Equal(t, []string{"role1"}, d.RoleIdsThatCanBeUsedThisEmojiAsReaction)
+	assert.Equal(t, []string{"role1"}, d.RoleIDsThatCanBeUsedThisEmojiAsReaction)
 }
 
 func TestPackEmojiDetailed_NilSlicesReturnEmpty(t *testing.T) {
@@ -66,9 +66,9 @@ func TestPackEmojiDetailed_NilSlicesReturnEmpty(t *testing.T) {
 	}
 	d := PackEmojiDetailed(e)
 	assert.NotNil(t, d.Aliases, "aliases should be empty slice, not nil")
-	assert.NotNil(t, d.RoleIdsThatCanBeUsedThisEmojiAsReaction, "roleIds should be empty slice, not nil")
+	assert.NotNil(t, d.RoleIDsThatCanBeUsedThisEmojiAsReaction, "roleIds should be empty slice, not nil")
 	assert.Len(t, d.Aliases, 0)
-	assert.Len(t, d.RoleIdsThatCanBeUsedThisEmojiAsReaction, 0)
+	assert.Len(t, d.RoleIDsThatCanBeUsedThisEmojiAsReaction, 0)
 }
 
 func TestPackEmojiDetailedList(t *testing.T) {
@@ -98,7 +98,7 @@ func TestPackEmojiDetailed_DoesNotMutateInput(t *testing.T) {
 	}
 	d := PackEmojiDetailed(e)
 	d.Aliases[0] = "mutated"
-	d.RoleIdsThatCanBeUsedThisEmojiAsReaction[0] = "mutated"
+	d.RoleIDsThatCanBeUsedThisEmojiAsReaction[0] = "mutated"
 	assert.Equal(t, "orig", e.Aliases[0], "original aliases should not be mutated")
 	assert.Equal(t, "r1", e.RoleIDsThatCanBeUsedThisEmojiAsReaction[0], "original roleIds should not be mutated")
 }


### PR DESCRIPTION
## Summary
- `admin/emoji/list` (v1) と `v2/admin/emoji/list` のレスポンスに `url` フィールドを追加
- TS版の `packDetailed` と同様に `url = publicUrl || originalUrl` を計算する `EmojiDetailed` DTOを導入
- フロントエンドの `<img src>` が空になる問題を修正

## 主な変更点
- `internal/entity/emoji.go`: `EmojiDetailed` DTO + `PackEmojiDetailed` / `PackEmojiDetailedList` 関数を新規作成
- `internal/api/admin/handler.go`: v1 `EmojiList` と v2 `EmojiListV2` で `entity.PackEmojiDetailedList` を使用するよう変更
- `internal/entity/emoji_test.go`: URL fallback、全フィールド、mutation安全性テスト (7件)
- `internal/api/admin/handler_test.go`: v1の `url` フィールド存在確認テスト追加
- `internal/api/admin/drive_emoji_test.go`: v2の `url` フィールド存在確認テスト追加

## テスト
```bash
go test ./internal/entity/... -v -run Emoji     # 7/7 PASS
go test ./internal/api/admin/... -v -run EmojiList  # 18/18 PASS
make fmt && make lint  # OK
```

Closes #265

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/shiroha-a/mk/pull/266" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
