### PR TITLE
Phase 7-5c follow-up Meta 3 フィールドをTS本家互換に

### DIFF
--- a/internal/api/meta/handler.go
+++ b/internal/api/meta/handler.go
@@ -12,11 +12,18 @@ import (
 	"github.com/shiroha-a/mk/internal/repository"
 )
 
+// ProxyAccountResolver returns the username of the "proxy" system account.
+// 呼び出し側 (router) が SystemAccountRepository + UserRepository を使って
+// type='proxy' の system_account から userId を辿り、username を返す。
+// 解決できないときは "" と false を返す。
+type ProxyAccountResolver func() (string, bool)
+
 // Handler handles meta-related API endpoints.
 type Handler struct {
-	config   *config.Config
-	metaRepo repository.MetaRepository
-	adRepo   repository.AdRepository
+	config           *config.Config
+	metaRepo         repository.MetaRepository
+	adRepo           repository.AdRepository
+	proxyAccountName ProxyAccountResolver
 }
 
 // NewHandler creates a new meta Handler.
@@ -29,6 +36,13 @@ func NewHandler(cfg *config.Config, metaRepo repository.MetaRepository) *Handler
 // without ad wiring keep passing.
 func (h *Handler) SetAdRepo(r repository.AdRepository) {
 	h.adRepo = r
+}
+
+// SetProxyAccountResolver wires the resolver used to populate the
+// `proxyAccountName` field on MetaDetailed responses. When unset (tests or
+// pre-setup instances), the field is reported as null.
+func (h *Handler) SetProxyAccountResolver(r ProxyAccountResolver) {
+	h.proxyAccountName = r
 }
 
 // Meta returns server metadata.
@@ -102,14 +116,14 @@ func (h *Handler) Meta(c echo.Context) error {
 		"cacheRemoteSensitiveFiles":    m.CacheRemoteSensitiveFiles,
 		"requireSetup":                 m.RootUserID == nil,
 		"singleUserMode":               m.SingleUserMode,
-		"providesTarball":              false,
+		"providesTarball":              h.config.PublishTarballInsteadOfProvideRepositoryUrl,
 		"maxFileSize":                  h.config.MaxFileSize,
-		"proxyAccountName":             nil,
+		"proxyAccountName":             resolveProxyAccountName(h.proxyAccountName),
 		"enableMcaptcha":               m.EnableMcaptcha,
 		"mcaptchaSiteKey":              m.McaptchaSiteKey,
 		"mcaptchaInstanceUrl":          m.McaptchaInstanceURL,
 		"enableTestcaptcha":            m.EnableTestcaptcha,
-		"sentryForFrontend":            nil,
+		"sentryForFrontend":            sentryForFrontendJSON(h.config.SentryForFrontend),
 		"googleAnalyticsMeasurementId": m.GoogleAnalyticsMeasurementID,
 		// clientOptions は jsonb なのでそのまま返す。空 jsonb なら frontend が
 		// デフォルト値を使う前提。
@@ -191,6 +205,32 @@ func clientOptionsJSON(raw []byte) any {
 		return map[string]any{}
 	}
 	return out
+}
+
+// resolveProxyAccountName looks up the `proxyAccountName` field via the
+// optional resolver wired by the router. Returns nil when the resolver is
+// absent (tests, pre-setup instances) or cannot find the system account.
+// Returning nil keeps the JSON field as null, matching the TS behavior when
+// no proxy account is configured.
+func resolveProxyAccountName(r ProxyAccountResolver) any {
+	if r == nil {
+		return nil
+	}
+	name, ok := r()
+	if !ok {
+		return nil
+	}
+	return name
+}
+
+// sentryForFrontendJSON normalizes config.SentryForFrontend for JSON output.
+// Empty (nil or zero-length) map is treated as absent and returns nil so
+// the JSON response carries `null` (TS behavior: `?? null`).
+func sentryForFrontendJSON(m map[string]any) any {
+	if len(m) == 0 {
+		return nil
+	}
+	return m
 }
 
 // PolicyBool reads a boolean policy value from role.DefaultPolicies() output

--- a/internal/api/meta/handler_test.go
+++ b/internal/api/meta/handler_test.go
@@ -473,3 +473,136 @@ func TestPolicyBool(t *testing.T) {
 		})
 	}
 }
+
+// --- Phase 7-5c follow-up (#256): providesTarball / sentryForFrontend /
+//     proxyAccountName のフィールド追加 ---
+
+// providesTarballはconfig.PublishTarballInsteadOfProvideRepositoryUrlをそのまま返す。
+func TestMeta_ProvidesTarball(t *testing.T) {
+	cfg := &config.Config{
+		Version: "2026.3.2",
+		URL:     "https://misskey.example.com",
+		PublishTarballInsteadOfProvideRepositoryUrl: true,
+	}
+	metaRepo := testutil.NewMockMetaRepository()
+	metaRepo.Meta = &model.Meta{ID: "x"}
+	h := NewHandler(cfg, metaRepo)
+
+	e := echo.New()
+	req := httptest.NewRequest(http.MethodPost, "/api/meta", nil)
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+	require.NoError(t, h.Meta(c))
+
+	var resp map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+	assert.Equal(t, true, resp["providesTarball"])
+}
+
+func TestMeta_ProvidesTarball_DefaultFalse(t *testing.T) {
+	h, repo := newTestHandler()
+	repo.Meta = &model.Meta{ID: "x"}
+
+	e := echo.New()
+	req := httptest.NewRequest(http.MethodPost, "/api/meta", nil)
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+	require.NoError(t, h.Meta(c))
+
+	var resp map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+	assert.Equal(t, false, resp["providesTarball"])
+}
+
+// sentryForFrontendはconfig.SentryForFrontend mapをそのまま返し、空なら null。
+func TestMeta_SentryForFrontend_Populated(t *testing.T) {
+	cfg := &config.Config{
+		Version: "2026.3.2",
+		URL:     "https://misskey.example.com",
+		SentryForFrontend: map[string]any{
+			"options": map[string]any{"dsn": "https://sentry.example/1"},
+		},
+	}
+	metaRepo := testutil.NewMockMetaRepository()
+	metaRepo.Meta = &model.Meta{ID: "x"}
+	h := NewHandler(cfg, metaRepo)
+
+	e := echo.New()
+	req := httptest.NewRequest(http.MethodPost, "/api/meta", nil)
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+	require.NoError(t, h.Meta(c))
+
+	var resp map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+	sentry, ok := resp["sentryForFrontend"].(map[string]any)
+	require.True(t, ok)
+	opts, _ := sentry["options"].(map[string]any)
+	assert.Equal(t, "https://sentry.example/1", opts["dsn"])
+}
+
+func TestMeta_SentryForFrontend_EmptyReturnsNil(t *testing.T) {
+	h, repo := newTestHandler()
+	repo.Meta = &model.Meta{ID: "x"}
+
+	e := echo.New()
+	req := httptest.NewRequest(http.MethodPost, "/api/meta", nil)
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+	require.NoError(t, h.Meta(c))
+
+	var resp map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+	assert.Nil(t, resp["sentryForFrontend"])
+}
+
+// proxyAccountNameはresolverが値を返せばそれをexpose、解決不能ならnull。
+func TestMeta_ProxyAccountName_Resolved(t *testing.T) {
+	h, repo := newTestHandler()
+	repo.Meta = &model.Meta{ID: "x"}
+	h.SetProxyAccountResolver(func() (string, bool) {
+		return "instance.proxy", true
+	})
+
+	e := echo.New()
+	req := httptest.NewRequest(http.MethodPost, "/api/meta", nil)
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+	require.NoError(t, h.Meta(c))
+
+	var resp map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+	assert.Equal(t, "instance.proxy", resp["proxyAccountName"])
+}
+
+func TestMeta_ProxyAccountName_ResolverReturnsFalse(t *testing.T) {
+	h, repo := newTestHandler()
+	repo.Meta = &model.Meta{ID: "x"}
+	h.SetProxyAccountResolver(func() (string, bool) { return "", false })
+
+	e := echo.New()
+	req := httptest.NewRequest(http.MethodPost, "/api/meta", nil)
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+	require.NoError(t, h.Meta(c))
+
+	var resp map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+	assert.Nil(t, resp["proxyAccountName"])
+}
+
+func TestMeta_ProxyAccountName_NoResolver(t *testing.T) {
+	h, repo := newTestHandler()
+	repo.Meta = &model.Meta{ID: "x"}
+	// resolver未設定時はnil返却 (tests / pre-setup でのデフォルト動作)
+
+	e := echo.New()
+	req := httptest.NewRequest(http.MethodPost, "/api/meta", nil)
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+	require.NoError(t, h.Meta(c))
+
+	var resp map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+	assert.Nil(t, resp["proxyAccountName"])
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -166,6 +166,12 @@ type Source struct {
 	// backend itself does not consume it; downstream API handlers may forward
 	// it to the frontend bundle. map[string]any keeps the YAML shape as-is.
 	SentryForFrontend map[string]any `mapstructure:"sentryForFrontend"`
+
+	// PublishTarballInsteadOfProvideRepositoryUrl mirrors the upstream Misskey
+	// YAML flag. When true, the frontend treats the release as a tarball
+	// distribution rather than pointing at the source repository URL. Exposed
+	// via /api/meta.providesTarball.
+	PublishTarballInsteadOfProvideRepositoryUrl bool `mapstructure:"publishTarballInsteadOfProvideRepositoryUrl"`
 }
 
 // Config represents the resolved application configuration.
@@ -252,6 +258,10 @@ type Config struct {
 	// SentryForFrontend is forwarded as-is to clients that need it (parsed
 	// for YAML compatibility; the Go backend itself does not consume it).
 	SentryForFrontend map[string]any
+
+	// PublishTarballInsteadOfProvideRepositoryUrl is exposed to clients via
+	// /api/meta.providesTarball. See the Source struct for details.
+	PublishTarballInsteadOfProvideRepositoryUrl bool
 }
 
 const defaultMaxFileSize int64 = 262144000
@@ -436,6 +446,8 @@ func resolve(src *Source) (*Config, error) {
 
 		SentryForBackend:  src.SentryForBackend,
 		SentryForFrontend: src.SentryForFrontend,
+
+		PublishTarballInsteadOfProvideRepositoryUrl: src.PublishTarballInsteadOfProvideRepositoryUrl,
 	}
 
 	if cfg.TestMode {

--- a/internal/server/frontend.go
+++ b/internal/server/frontend.go
@@ -21,7 +21,9 @@ import (
 // frontendHTML generates the HTML shell for the Misskey frontend.
 // ビルド済みアセットがある場合は CLIENT_ENTRY を設定して production モードで配信。
 // なければ Vite dev server 経由の development モードで配信。
-func frontendHTML(cfg *config.Config, metaRepo repository.MetaRepository) echo.HandlerFunc {
+// proxyAccountResolverは/api/metaのproxyAccountNameフィールド解決用で、
+// nilを渡すとその値はnullになる (pre-setup等)。
+func frontendHTML(cfg *config.Config, metaRepo repository.MetaRepository, proxyAccountResolver meta.ProxyAccountResolver) echo.HandlerFunc {
 	// ビルド済みアセットからCLIENT_ENTRYを取得
 	clientEntry := frontendutil.DetectClientEntry()
 
@@ -50,7 +52,7 @@ func frontendHTML(cfg *config.Config, metaRepo repository.MetaRepository) echo.H
 			if m.MascotImageURL != nil && *m.MascotImageURL != "" {
 				mascotURL = *m.MascotImageURL
 			}
-			metaJSON = buildMetaJSON(cfg, m)
+			metaJSON = buildMetaJSON(cfg, m, proxyAccountResolver)
 		}
 
 		// CLIENT_ENTRYの設定
@@ -111,7 +113,7 @@ func frontendHTML(cfg *config.Config, metaRepo repository.MetaRepository) echo.H
 // buildMetaJSON constructs the /api/meta equivalent JSON for inline embedding.
 // /api/meta ハンドラ (meta/handler.go) と完全に同じフィールドを返す。
 // フロントエンドはこのJSONを先に読んで /api/meta の呼び出しを省略する。
-func buildMetaJSON(cfg *config.Config, m *model.Meta) string {
+func buildMetaJSON(cfg *config.Config, m *model.Meta, proxyAccountResolver meta.ProxyAccountResolver) string {
 	// mascotImageUrl フォールバック
 	mascot := "/assets/ai.png"
 	if m.MascotImageURL != nil && *m.MascotImageURL != "" {
@@ -171,15 +173,15 @@ func buildMetaJSON(cfg *config.Config, m *model.Meta) string {
 		"cacheRemoteSensitiveFiles":    m.CacheRemoteSensitiveFiles,
 		"requireSetup":                 m.RootUserID == nil,
 		"singleUserMode":               m.SingleUserMode,
-		"providesTarball":              false,
+		"providesTarball":              cfg.PublishTarballInsteadOfProvideRepositoryUrl,
 		"maxFileSize":                  cfg.MaxFileSize,
-		"proxyAccountName":             nil,
+		"proxyAccountName":             resolveProxyAccountNameForSSR(proxyAccountResolver),
 		"noteSearchableScope":          meta.NoteSearchableScope(cfg.Meilisearch),
 		"enableMcaptcha":               m.EnableMcaptcha,
 		"mcaptchaSiteKey":              m.McaptchaSiteKey,
 		"mcaptchaInstanceUrl":          m.McaptchaInstanceURL,
 		"enableTestcaptcha":            m.EnableTestcaptcha,
-		"sentryForFrontend":            nil,
+		"sentryForFrontend":            sentryForFrontendForSSR(cfg.SentryForFrontend),
 		"googleAnalyticsMeasurementId": m.GoogleAnalyticsMeasurementID,
 		"clientOptions":                clientOptionsJSON(m.ClientOptions),
 		"policies":                     role.DefaultPolicies(),
@@ -201,6 +203,48 @@ func buildMetaJSON(cfg *config.Config, m *model.Meta) string {
 		return "{}"
 	}
 	return string(data)
+}
+
+// newProxyAccountResolverはtype='proxy'のsystem_accountから対応する
+// user.usernameを解決するmeta.ProxyAccountResolverを返す。読み取り専用で、
+// 未作成なら(_, false)を返す (TS版のfetchは未存在時に作成するが、
+// /api/metaの副作用として自動作成するのは避け、明示セットアップ経由に寄せる)。
+func newProxyAccountResolver(saRepo repository.SystemAccountRepository, userRepo repository.UserRepository) meta.ProxyAccountResolver {
+	return func() (string, bool) {
+		sa, err := saRepo.FindByType("proxy")
+		if err != nil || sa == nil {
+			return "", false
+		}
+		user, err := userRepo.FindByID(sa.UserID)
+		if err != nil || user == nil {
+			return "", false
+		}
+		return user.Username, true
+	}
+}
+
+// resolveProxyAccountNameForSSRはSSR埋め込みJSON向けのproxy account名解決。
+// /api/meta の resolveProxyAccountName と同じ挙動 (meta.ProxyAccountResolver は
+// meta パッケージ定義なのでロジックは共有されるが、SSR 側は独自の nil-safe
+// ラッパーで呼ぶ)。
+func resolveProxyAccountNameForSSR(r meta.ProxyAccountResolver) any {
+	if r == nil {
+		return nil
+	}
+	name, ok := r()
+	if !ok {
+		return nil
+	}
+	return name
+}
+
+// sentryForFrontendForSSR normalizes config.SentryForFrontend for SSR embed.
+// Empty map == null (TS: `?? null`).
+func sentryForFrontendForSSR(m map[string]any) any {
+	if len(m) == 0 {
+		return nil
+	}
+	return m
 }
 
 // clientOptionsJSON normalizes a jsonb byte slice into map[string]any.

--- a/internal/server/frontend.go
+++ b/internal/server/frontend.go
@@ -18,11 +18,12 @@ import (
 	"github.com/shiroha-a/mk/internal/repository"
 )
 
-// frontendHTML generates the HTML shell for the Misskey frontend.
-// ビルド済みアセットがある場合は CLIENT_ENTRY を設定して production モードで配信。
-// なければ Vite dev server 経由の development モードで配信。
-// proxyAccountResolverは/api/metaのproxyAccountNameフィールド解決用で、
-// nilを渡すとその値はnullになる (pre-setup等)。
+// frontendHTML generates the HTML shell for the Misskey frontend. When a
+// built asset bundle is present the HTML wires CLIENT_ENTRY for production
+// mode; otherwise it falls back to the Vite dev-server path.
+// proxyAccountResolver is used to populate the embedded meta JSON's
+// proxyAccountName field; passing nil leaves the value as null (appropriate
+// for pre-setup instances).
 func frontendHTML(cfg *config.Config, metaRepo repository.MetaRepository, proxyAccountResolver meta.ProxyAccountResolver) echo.HandlerFunc {
 	// ビルド済みアセットからCLIENT_ENTRYを取得
 	clientEntry := frontendutil.DetectClientEntry()
@@ -205,10 +206,12 @@ func buildMetaJSON(cfg *config.Config, m *model.Meta, proxyAccountResolver meta.
 	return string(data)
 }
 
-// newProxyAccountResolverはtype='proxy'のsystem_accountから対応する
-// user.usernameを解決するmeta.ProxyAccountResolverを返す。読み取り専用で、
-// 未作成なら(_, false)を返す (TS版のfetchは未存在時に作成するが、
-// /api/metaの副作用として自動作成するのは避け、明示セットアップ経由に寄せる)。
+// newProxyAccountResolver returns a ProxyAccountResolver that looks up the
+// system_account with type='proxy' and resolves the corresponding username.
+// Read-only: if the row does not exist yet (_, false) is returned.
+// 本家TSのsystemAccountService.fetchは未存在時に自動作成するが、/api/metaの
+// 副作用としてシステムアカウントが勝手に生成されるのを避けるため、Go側は
+// 明示セットアップ経路 (admin系エンドポイント) に生成を寄せている。
 func newProxyAccountResolver(saRepo repository.SystemAccountRepository, userRepo repository.UserRepository) meta.ProxyAccountResolver {
 	return func() (string, bool) {
 		sa, err := saRepo.FindByType("proxy")
@@ -223,10 +226,10 @@ func newProxyAccountResolver(saRepo repository.SystemAccountRepository, userRepo
 	}
 }
 
-// resolveProxyAccountNameForSSRはSSR埋め込みJSON向けのproxy account名解決。
-// /api/meta の resolveProxyAccountName と同じ挙動 (meta.ProxyAccountResolver は
-// meta パッケージ定義なのでロジックは共有されるが、SSR 側は独自の nil-safe
-// ラッパーで呼ぶ)。
+// resolveProxyAccountNameForSSR resolves the proxy account name for the
+// SSR-embedded meta JSON. Mirrors the behavior of resolveProxyAccountName
+// in the meta package; returns nil when the resolver is absent or lookup
+// fails so the JSON field serializes as null.
 func resolveProxyAccountNameForSSR(r meta.ProxyAccountResolver) any {
 	if r == nil {
 		return nil

--- a/internal/server/router.go
+++ b/internal/server/router.go
@@ -524,6 +524,8 @@ func (s *Server) setupRoutes() {
 	// Meta endpoint (public)
 	metaHandler := meta.NewHandler(s.config, metaRepo)
 	metaHandler.SetAdRepo(repository.NewAdRepository(s.db))
+	proxyAccountResolver := newProxyAccountResolver(repository.NewSystemAccountRepository(s.db), userRepo)
+	metaHandler.SetProxyAccountResolver(proxyAccountResolver)
 	api.POST("/meta", metaHandler.Meta)
 	api.POST("/ping", metaHandler.Ping)
 
@@ -1875,7 +1877,7 @@ func (s *Server) setupRoutes() {
 	}
 
 	// Frontend HTML shell — SPA catchall (最後に登録)
-	s.echo.GET("/*", frontendHTML(s.config, metaRepo))
+	s.echo.GET("/*", frontendHTML(s.config, metaRepo, proxyAccountResolver))
 }
 
 // generateInviteCode creates a random invite code string.


### PR DESCRIPTION
## Summary

#256 (Phase 7-5c follow-up) として Meta 全フィールドを TS 本家 (`packedMetaLiteSchema` + `packedMetaDetailedOnlySchema`, 合計 60+ フィールド) と field-by-field で diff し、修正が必要な 3 フィールドを本家互換に揃える。

## 調査結果

| フィールド | Before | After |
|---|---|---|
| `providesTarball` | Hardcoded `false` | `config.PublishTarballInsteadOfProvideRepositoryUrl` |
| `sentryForFrontend` | Hardcoded `nil` | `config.SentryForFrontend` (空 map は null に正規化) |
| `proxyAccountName` | Hardcoded `nil` | `system_account (type='proxy')` → `user.username` |

全体の 95%+ のフィールドは既に完全一致していたため、本 PR のスコープは上記 3 フィールドのみ。

### 対応しないフィールド (意図的スキップ)

- `defaultLightTheme` / `defaultDarkTheme`: TS は JSON5 parse → stringify で正規化。Go は raw 返却。フロント側で robust に処理される想定で実害薄
- `maxNoteTextLength: 3000` / `features.miauth: true`: intentional な定数 (TS 側も定数)

## 主な変更点

### `internal/config/config.go`

- `Source.PublishTarballInsteadOfProvideRepositoryUrl bool` + mapstructure
- `Config.PublishTarballInsteadOfProvideRepositoryUrl bool`
- `Load()` で src → cfg にコピー
- `SentryForFrontend` は既存フィールドを wire するだけ

### `internal/api/meta/handler.go`

- `type ProxyAccountResolver func() (string, bool)` を定義
- `SetProxyAccountResolver(r)` で optional 注入 (nil safe、未設定時は null)
- `resolveProxyAccountName(r)` / `sentryForFrontendJSON(m)` ヘルパー追加
- resp map の 3 フィールドをハードコードから動的解決に置換

### `internal/server/frontend.go`

- `frontendHTML` と `buildMetaJSON` のシグネチャに `proxyAccountResolver meta.ProxyAccountResolver` 追加
- buildMetaJSON にも同じ 3 フィールド変更を mirror (GoDoc で明記されている「/api/meta と完全同じフィールド」契約を維持)
- `newProxyAccountResolver(saRepo, userRepo)` helper:
  - `type='proxy'` の system_account から userId を取り、`user.username` を返す
  - 未存在時は `(_, false)` 返却 (TS の `systemAccountService.fetch` は自動作成するが、`/api/meta` の副作用で system account を自動生成するのは避け、明示セットアップ経路に寄せる設計判断)
- `resolveProxyAccountNameForSSR` / `sentryForFrontendForSSR` は SSR 向け同等ヘルパー

### `internal/server/router.go`

- `newProxyAccountResolver(repository.NewSystemAccountRepository(s.db), userRepo)` を構築し `metaHandler` と `frontendHTML` の両方に注入

## テスト

`internal/api/meta/handler_test.go` に 7 ケース追加:

- `TestMeta_ProvidesTarball` — config 有効時 true 返却
- `TestMeta_ProvidesTarball_DefaultFalse` — デフォルト false
- `TestMeta_SentryForFrontend_Populated` — map 有効時そのまま expose
- `TestMeta_SentryForFrontend_EmptyReturnsNil` — 空 map は null
- `TestMeta_ProxyAccountName_Resolved` — resolver が値を返す
- `TestMeta_ProxyAccountName_ResolverReturnsFalse` — 未存在時 null
- `TestMeta_ProxyAccountName_NoResolver` — resolver 未設定時 null

## 検証

- `make fmt` / `make lint` 通過
- meta パッケージ coverage: **100% 維持**
- 全 CI simulation 通過: `test exit=0` + All packages meet coverage thresholds

## Closes

Closes #256

## 関連

- Parent: #242 Phase 7 TS フロント互換性ギャップ修正
- 前段: #249 (Phase 7-5c、#255 でマージ、3 フィールド先行対応済み)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/shiroha-a/mk/pull/268" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
