### PR TITLE
Phase 7-1 follow-up notes/create 残 sentinel 9種を実装

### DIFF
--- a/internal/api/apierr/echo.go
+++ b/internal/api/apierr/echo.go
@@ -55,3 +55,53 @@ func JSONCannotRenoteDueToVisibility(c echo.Context) error {
 func JSONNoSuchChannel(c echo.Context) error {
 	return c.JSON(http.StatusNotFound, NoSuchChannel())
 }
+
+// JSONCannotRenoteToAPureRenote writes a 403 response.
+func JSONCannotRenoteToAPureRenote(c echo.Context) error {
+	return c.JSON(http.StatusForbidden, CannotRenoteToAPureRenote())
+}
+
+// JSONCannotReplyToAPureRenote writes a 403 response.
+func JSONCannotReplyToAPureRenote(c echo.Context) error {
+	return c.JSON(http.StatusForbidden, CannotReplyToAPureRenote())
+}
+
+// JSONCannotReplyToSpecifiedVisibilityNoteWithExtendedVisibility writes a 403.
+func JSONCannotReplyToSpecifiedVisibilityNoteWithExtendedVisibility(c echo.Context) error {
+	return c.JSON(http.StatusForbidden, CannotReplyToSpecifiedVisibilityNoteWithExtendedVisibility())
+}
+
+// JSONCannotCreateAlreadyExpiredPoll writes a 400 response.
+func JSONCannotCreateAlreadyExpiredPoll(c echo.Context) error {
+	return c.JSON(http.StatusBadRequest, CannotCreateAlreadyExpiredPoll())
+}
+
+// JSONYouHaveBeenBlocked writes a 403 response.
+func JSONYouHaveBeenBlocked(c echo.Context) error {
+	return c.JSON(http.StatusForbidden, YouHaveBeenBlocked())
+}
+
+// JSONNoSuchFile writes a 400 response.
+func JSONNoSuchFile(c echo.Context) error {
+	return c.JSON(http.StatusBadRequest, NoSuchFile())
+}
+
+// JSONCannotRenoteOutsideOfChannel writes a 403 response.
+func JSONCannotRenoteOutsideOfChannel(c echo.Context) error {
+	return c.JSON(http.StatusForbidden, CannotRenoteOutsideOfChannel())
+}
+
+// JSONContainsProhibitedWords writes a 400 response.
+func JSONContainsProhibitedWords(c echo.Context) error {
+	return c.JSON(http.StatusBadRequest, ContainsProhibitedWords())
+}
+
+// JSONContainsTooManyMentions writes a 400 response.
+func JSONContainsTooManyMentions(c echo.Context) error {
+	return c.JSON(http.StatusBadRequest, ContainsTooManyMentions())
+}
+
+// JSONFailedToResolveRemoteUser writes a 404 response.
+func JSONFailedToResolveRemoteUser(c echo.Context) error {
+	return c.JSON(http.StatusNotFound, FailedToResolveRemoteUser())
+}

--- a/internal/api/apierr/echo_test.go
+++ b/internal/api/apierr/echo_test.go
@@ -102,3 +102,74 @@ func TestJSONNoSuchChannel(t *testing.T) {
 	assert.Equal(t, "NO_SUCH_CHANNEL", errObj["code"])
 	assert.Equal(t, UUIDNoSuchChannel, errObj["id"])
 }
+
+// Phase 7-1 follow-up (#254): 新規JSONヘルパーのカバレッジ
+func TestJSONCannotRenoteToAPureRenote(t *testing.T) {
+	code, body := invoke(t, JSONCannotRenoteToAPureRenote)
+	assert.Equal(t, http.StatusForbidden, code)
+	errObj := body["error"].(map[string]any)
+	assert.Equal(t, "CANNOT_RENOTE_TO_A_PURE_RENOTE", errObj["code"])
+}
+
+func TestJSONCannotReplyToAPureRenote(t *testing.T) {
+	code, body := invoke(t, JSONCannotReplyToAPureRenote)
+	assert.Equal(t, http.StatusForbidden, code)
+	errObj := body["error"].(map[string]any)
+	assert.Equal(t, "CANNOT_REPLY_TO_A_PURE_RENOTE", errObj["code"])
+}
+
+func TestJSONCannotReplyToSpecifiedVisibilityNoteWithExtendedVisibility(t *testing.T) {
+	code, body := invoke(t, JSONCannotReplyToSpecifiedVisibilityNoteWithExtendedVisibility)
+	assert.Equal(t, http.StatusForbidden, code)
+	errObj := body["error"].(map[string]any)
+	assert.Equal(t, "CANNOT_REPLY_TO_SPECIFIED_VISIBILITY_NOTE_WITH_EXTENDED_VISIBILITY", errObj["code"])
+}
+
+func TestJSONCannotCreateAlreadyExpiredPoll(t *testing.T) {
+	code, body := invoke(t, JSONCannotCreateAlreadyExpiredPoll)
+	assert.Equal(t, http.StatusBadRequest, code)
+	errObj := body["error"].(map[string]any)
+	assert.Equal(t, "CANNOT_CREATE_ALREADY_EXPIRED_POLL", errObj["code"])
+}
+
+func TestJSONYouHaveBeenBlocked(t *testing.T) {
+	code, body := invoke(t, JSONYouHaveBeenBlocked)
+	assert.Equal(t, http.StatusForbidden, code)
+	errObj := body["error"].(map[string]any)
+	assert.Equal(t, "YOU_HAVE_BEEN_BLOCKED", errObj["code"])
+}
+
+func TestJSONNoSuchFile(t *testing.T) {
+	code, body := invoke(t, JSONNoSuchFile)
+	assert.Equal(t, http.StatusBadRequest, code)
+	errObj := body["error"].(map[string]any)
+	assert.Equal(t, "NO_SUCH_FILE", errObj["code"])
+}
+
+func TestJSONCannotRenoteOutsideOfChannel(t *testing.T) {
+	code, body := invoke(t, JSONCannotRenoteOutsideOfChannel)
+	assert.Equal(t, http.StatusForbidden, code)
+	errObj := body["error"].(map[string]any)
+	assert.Equal(t, "CANNOT_RENOTE_OUTSIDE_OF_CHANNEL", errObj["code"])
+}
+
+func TestJSONContainsProhibitedWords(t *testing.T) {
+	code, body := invoke(t, JSONContainsProhibitedWords)
+	assert.Equal(t, http.StatusBadRequest, code)
+	errObj := body["error"].(map[string]any)
+	assert.Equal(t, "CONTAINS_PROHIBITED_WORDS", errObj["code"])
+}
+
+func TestJSONContainsTooManyMentions(t *testing.T) {
+	code, body := invoke(t, JSONContainsTooManyMentions)
+	assert.Equal(t, http.StatusBadRequest, code)
+	errObj := body["error"].(map[string]any)
+	assert.Equal(t, "CONTAINS_TOO_MANY_MENTIONS", errObj["code"])
+}
+
+func TestJSONFailedToResolveRemoteUser(t *testing.T) {
+	code, body := invoke(t, JSONFailedToResolveRemoteUser)
+	assert.Equal(t, http.StatusNotFound, code)
+	errObj := body["error"].(map[string]any)
+	assert.Equal(t, "FAILED_TO_RESOLVE_REMOTE_USER", errObj["code"])
+}

--- a/internal/api/apierr/errors.go
+++ b/internal/api/apierr/errors.go
@@ -101,3 +101,58 @@ func CannotRenoteDueToVisibility() map[string]any {
 func NoSuchChannel() map[string]any {
 	return Error("NO_SUCH_CHANNEL", "No such channel.", UUIDNoSuchChannel)
 }
+
+// CannotRenoteToAPureRenote returns a 403 CANNOT_RENOTE_TO_A_PURE_RENOTE response.
+func CannotRenoteToAPureRenote() map[string]any {
+	return Error("CANNOT_RENOTE_TO_A_PURE_RENOTE", "You can not Renote a pure Renote.", UUIDCannotRenoteToAPureRenote)
+}
+
+// CannotReplyToAPureRenote returns a 403 CANNOT_REPLY_TO_A_PURE_RENOTE response.
+func CannotReplyToAPureRenote() map[string]any {
+	return Error("CANNOT_REPLY_TO_A_PURE_RENOTE", "You can not reply to a pure Renote.", UUIDCannotReplyToAPureRenote)
+}
+
+// CannotReplyToSpecifiedVisibilityNoteWithExtendedVisibility returns the
+// matching 403 response for reply visibility-conflict.
+func CannotReplyToSpecifiedVisibilityNoteWithExtendedVisibility() map[string]any {
+	return Error(
+		"CANNOT_REPLY_TO_SPECIFIED_VISIBILITY_NOTE_WITH_EXTENDED_VISIBILITY",
+		"You cannot reply to a specified visibility note with extended visibility.",
+		UUIDCannotReplyToSpecifiedVisibilityNoteWithExtendedVisibility,
+	)
+}
+
+// CannotCreateAlreadyExpiredPoll returns a 400 CANNOT_CREATE_ALREADY_EXPIRED_POLL response.
+func CannotCreateAlreadyExpiredPoll() map[string]any {
+	return Error("CANNOT_CREATE_ALREADY_EXPIRED_POLL", "Poll is already expired.", UUIDCannotCreateAlreadyExpiredPoll)
+}
+
+// YouHaveBeenBlocked returns a 403 YOU_HAVE_BEEN_BLOCKED response.
+func YouHaveBeenBlocked() map[string]any {
+	return Error("YOU_HAVE_BEEN_BLOCKED", "You have been blocked by this user.", UUIDYouHaveBeenBlocked)
+}
+
+// NoSuchFile returns a 400 NO_SUCH_FILE response.
+func NoSuchFile() map[string]any {
+	return Error("NO_SUCH_FILE", "Some files are not found.", UUIDNoSuchFile)
+}
+
+// CannotRenoteOutsideOfChannel returns a 403 CANNOT_RENOTE_OUTSIDE_OF_CHANNEL response.
+func CannotRenoteOutsideOfChannel() map[string]any {
+	return Error("CANNOT_RENOTE_OUTSIDE_OF_CHANNEL", "Cannot renote outside of channel.", UUIDCannotRenoteOutsideOfChannel)
+}
+
+// ContainsProhibitedWords returns a 400 CONTAINS_PROHIBITED_WORDS response.
+func ContainsProhibitedWords() map[string]any {
+	return Error("CONTAINS_PROHIBITED_WORDS", "Cannot post because it contains prohibited words.", UUIDContainsProhibitedWords)
+}
+
+// ContainsTooManyMentions returns a 400 CONTAINS_TOO_MANY_MENTIONS response.
+func ContainsTooManyMentions() map[string]any {
+	return Error("CONTAINS_TOO_MANY_MENTIONS", "Cannot post because it exceeds the allowed number of mentions.", UUIDContainsTooManyMentions)
+}
+
+// FailedToResolveRemoteUser returns a 404 FAILED_TO_RESOLVE_REMOTE_USER response.
+func FailedToResolveRemoteUser() map[string]any {
+	return Error("FAILED_TO_RESOLVE_REMOTE_USER", "Failed to resolve remote user.", UUIDFailedToResolveRemoteUser)
+}

--- a/internal/api/apierr/errors_test.go
+++ b/internal/api/apierr/errors_test.go
@@ -120,3 +120,64 @@ func TestUUIDConstants_MatchUpstream(t *testing.T) {
 		})
 	}
 }
+
+// Phase 7-1 follow-up (#254): 新規追加ヘルパー関数のカバレッジテスト
+func TestCannotRenoteToAPureRenote(t *testing.T) {
+	errObj := CannotRenoteToAPureRenote()["error"].(map[string]any)
+	assert.Equal(t, "CANNOT_RENOTE_TO_A_PURE_RENOTE", errObj["code"])
+	assert.Equal(t, UUIDCannotRenoteToAPureRenote, errObj["id"])
+}
+
+func TestCannotReplyToAPureRenote(t *testing.T) {
+	errObj := CannotReplyToAPureRenote()["error"].(map[string]any)
+	assert.Equal(t, "CANNOT_REPLY_TO_A_PURE_RENOTE", errObj["code"])
+	assert.Equal(t, UUIDCannotReplyToAPureRenote, errObj["id"])
+}
+
+func TestCannotReplyToSpecifiedVisibilityNoteWithExtendedVisibility(t *testing.T) {
+	errObj := CannotReplyToSpecifiedVisibilityNoteWithExtendedVisibility()["error"].(map[string]any)
+	assert.Equal(t, "CANNOT_REPLY_TO_SPECIFIED_VISIBILITY_NOTE_WITH_EXTENDED_VISIBILITY", errObj["code"])
+	assert.Equal(t, UUIDCannotReplyToSpecifiedVisibilityNoteWithExtendedVisibility, errObj["id"])
+}
+
+func TestCannotCreateAlreadyExpiredPoll(t *testing.T) {
+	errObj := CannotCreateAlreadyExpiredPoll()["error"].(map[string]any)
+	assert.Equal(t, "CANNOT_CREATE_ALREADY_EXPIRED_POLL", errObj["code"])
+	assert.Equal(t, UUIDCannotCreateAlreadyExpiredPoll, errObj["id"])
+}
+
+func TestYouHaveBeenBlocked(t *testing.T) {
+	errObj := YouHaveBeenBlocked()["error"].(map[string]any)
+	assert.Equal(t, "YOU_HAVE_BEEN_BLOCKED", errObj["code"])
+	assert.Equal(t, UUIDYouHaveBeenBlocked, errObj["id"])
+}
+
+func TestNoSuchFile(t *testing.T) {
+	errObj := NoSuchFile()["error"].(map[string]any)
+	assert.Equal(t, "NO_SUCH_FILE", errObj["code"])
+	assert.Equal(t, UUIDNoSuchFile, errObj["id"])
+}
+
+func TestCannotRenoteOutsideOfChannel(t *testing.T) {
+	errObj := CannotRenoteOutsideOfChannel()["error"].(map[string]any)
+	assert.Equal(t, "CANNOT_RENOTE_OUTSIDE_OF_CHANNEL", errObj["code"])
+	assert.Equal(t, UUIDCannotRenoteOutsideOfChannel, errObj["id"])
+}
+
+func TestContainsProhibitedWords(t *testing.T) {
+	errObj := ContainsProhibitedWords()["error"].(map[string]any)
+	assert.Equal(t, "CONTAINS_PROHIBITED_WORDS", errObj["code"])
+	assert.Equal(t, UUIDContainsProhibitedWords, errObj["id"])
+}
+
+func TestContainsTooManyMentions(t *testing.T) {
+	errObj := ContainsTooManyMentions()["error"].(map[string]any)
+	assert.Equal(t, "CONTAINS_TOO_MANY_MENTIONS", errObj["code"])
+	assert.Equal(t, UUIDContainsTooManyMentions, errObj["id"])
+}
+
+func TestFailedToResolveRemoteUser(t *testing.T) {
+	errObj := FailedToResolveRemoteUser()["error"].(map[string]any)
+	assert.Equal(t, "FAILED_TO_RESOLVE_REMOTE_USER", errObj["code"])
+	assert.Equal(t, UUIDFailedToResolveRemoteUser, errObj["id"])
+}

--- a/internal/api/notes/handler.go
+++ b/internal/api/notes/handler.go
@@ -174,6 +174,24 @@ func (h *Handler) Create(c echo.Context) error {
 			return apierr.JSONCannotRenoteDueToVisibility(c)
 		case errors.Is(err, note.ErrChannelNotFound):
 			return apierr.JSONNoSuchChannel(c)
+		case errors.Is(err, note.ErrCannotRenoteToAPureRenote):
+			return apierr.JSONCannotRenoteToAPureRenote(c)
+		case errors.Is(err, note.ErrCannotReplyToAPureRenote):
+			return apierr.JSONCannotReplyToAPureRenote(c)
+		case errors.Is(err, note.ErrCannotReplyToSpecifiedVisibility):
+			return apierr.JSONCannotReplyToSpecifiedVisibilityNoteWithExtendedVisibility(c)
+		case errors.Is(err, note.ErrYouHaveBeenBlocked):
+			return apierr.JSONYouHaveBeenBlocked(c)
+		case errors.Is(err, note.ErrCannotCreateAlreadyExpiredPoll):
+			return apierr.JSONCannotCreateAlreadyExpiredPoll(c)
+		case errors.Is(err, note.ErrNoSuchFile):
+			return apierr.JSONNoSuchFile(c)
+		case errors.Is(err, note.ErrCannotRenoteOutsideOfChannel):
+			return apierr.JSONCannotRenoteOutsideOfChannel(c)
+		case errors.Is(err, note.ErrContainsProhibitedWords):
+			return apierr.JSONContainsProhibitedWords(c)
+		case errors.Is(err, note.ErrContainsTooManyMentions):
+			return apierr.JSONContainsTooManyMentions(c)
 		}
 		return apierr.JSONInternalError(c)
 	}

--- a/internal/api/notes/handler_test.go
+++ b/internal/api/notes/handler_test.go
@@ -3,10 +3,12 @@ package notes
 import (
 	"encoding/json"
 	"errors"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/labstack/echo/v4"
 	"github.com/shiroha-a/mk/internal/api/apierr"
@@ -439,7 +441,9 @@ func TestCreate_WithPollExpiresAt(t *testing.T) {
 		AvatarDecorations: datatypes.JSON([]byte("[]")),
 	}
 
-	body := `{"text": "Vote!", "poll": {"choices": ["A", "B"], "multiple": true, "expiresAt": 1700000000000}}`
+	// 未来日時を動的に算出 (hardcoded 値だと時間経過でテストが expired 判定で落ちる)
+	futureMs := time.Now().Add(24 * time.Hour).UnixMilli()
+	body := fmt.Sprintf(`{"text": "Vote!", "poll": {"choices": ["A", "B"], "multiple": true, "expiresAt": %d}}`, futureMs)
 	e := echo.New()
 	req := httptest.NewRequest(http.MethodPost, "/api/notes/create", strings.NewReader(body))
 	req.Header.Set(echo.HeaderContentType, echo.MIMEApplicationJSON)

--- a/internal/api/users/handler.go
+++ b/internal/api/users/handler.go
@@ -1,6 +1,7 @@
 package users
 
 import (
+	"errors"
 	"net/http"
 
 	"github.com/labstack/echo/v4"
@@ -160,6 +161,9 @@ func (h *Handler) Show(c echo.Context) error {
 	}
 
 	if err != nil {
+		if errors.Is(err, user.ErrFailedToResolveRemoteUser) {
+			return apierr.JSONFailedToResolveRemoteUser(c)
+		}
 		return apierr.JSONNoSuchUser(c)
 	}
 

--- a/internal/core/note/note_create_service.go
+++ b/internal/core/note/note_create_service.go
@@ -687,6 +687,10 @@ func defaultMentionLimit() int {
 // DriveFileRepo未設定ならskipする。
 // TS本家は user.id 所有の files のみ拾うが、Go の DriveFileRepo は ID ベース
 // の bulk 取得しか持たないため、取得後に userId 一致をチェックする。
+// 本家TSは Promise.all で個別解決するため fileIds に重複があっても通る。
+// Go 側も `WHERE id IN ?` の SQL 重複排除による false positive を避けるため、
+// 返却 file を「所有者一致の ID 集合」に畳んだ上で、入力 ID が全て集合に
+// 含まれることを確認する (Devin review #270)。
 func (s *CreateService) checkFileIDs(userID string, fileIDs []string) error {
 	if len(fileIDs) == 0 || s.driveFileRepo == nil {
 		return nil
@@ -695,11 +699,14 @@ func (s *CreateService) checkFileIDs(userID string, fileIDs []string) error {
 	if err != nil {
 		return err
 	}
-	if len(files) != len(fileIDs) {
-		return ErrNoSuchFile
-	}
+	owned := make(map[string]struct{}, len(files))
 	for _, f := range files {
-		if f.UserID == nil || *f.UserID != userID {
+		if f.UserID != nil && *f.UserID == userID {
+			owned[f.ID] = struct{}{}
+		}
+	}
+	for _, id := range fileIDs {
+		if _, ok := owned[id]; !ok {
 			return ErrNoSuchFile
 		}
 	}

--- a/internal/core/note/note_create_service.go
+++ b/internal/core/note/note_create_service.go
@@ -4,6 +4,7 @@ package note
 import (
 	"errors"
 	"regexp"
+	"strings"
 	"time"
 
 	"github.com/shiroha-a/mk/internal/misc/id"
@@ -25,6 +26,32 @@ var (
 	ErrCannotRenoteInvisibleNote = errors.New("cannot renote this note")
 	// ErrChannelNotFound is returned when the channelId references a missing channel.
 	ErrChannelNotFound = errors.New("channel not found")
+	// ErrCannotRenoteToAPureRenote is returned when the renote target is a pure
+	// renote (renote of another note with no original content). Misskey disallows
+	// renoting a pure renote to avoid redundant propagation chains.
+	ErrCannotRenoteToAPureRenote = errors.New("cannot renote a pure renote")
+	// ErrCannotReplyToAPureRenote is returned when the reply target is a pure renote.
+	ErrCannotReplyToAPureRenote = errors.New("cannot reply to a pure renote")
+	// ErrCannotReplyToSpecifiedVisibility is returned when replying to a
+	// "specified" visibility note with a wider visibility (non-specified).
+	ErrCannotReplyToSpecifiedVisibility = errors.New("cannot reply to specified visibility note with extended visibility")
+	// ErrYouHaveBeenBlocked is returned when the target user (reply/renote target)
+	// has blocked the actor.
+	ErrYouHaveBeenBlocked = errors.New("you have been blocked by the target user")
+	// ErrCannotCreateAlreadyExpiredPoll is returned when poll.ExpiresAt is in
+	// the past at creation time.
+	ErrCannotCreateAlreadyExpiredPoll = errors.New("poll is already expired")
+	// ErrNoSuchFile is returned when one or more fileIds reference missing files.
+	ErrNoSuchFile = errors.New("some files are not found")
+	// ErrCannotRenoteOutsideOfChannel is returned when the renote target belongs
+	// to a channel that disallows renoting outside of its context.
+	ErrCannotRenoteOutsideOfChannel = errors.New("cannot renote outside of channel")
+	// ErrContainsProhibitedWords is returned when the note text contains a word
+	// in meta.prohibitedWords.
+	ErrContainsProhibitedWords = errors.New("note contains prohibited words")
+	// ErrContainsTooManyMentions is returned when the note exceeds the role
+	// policy's mentionLimit.
+	ErrContainsTooManyMentions = errors.New("note contains too many mentions")
 )
 
 // CreateInput is the input parameter for CreateService.Create.
@@ -130,11 +157,39 @@ type CreateService struct {
 	chartHook        ChartHook
 	webhookHook      WebhookHook
 	userRepo         repository.UserRepository
+	blockingRepo     repository.BlockingRepository
+	driveFileRepo    repository.DriveFileRepository
+	metaRepo         repository.MetaRepository
+	channelRepo      repository.ChannelRepository
 }
 
 // SetUserRepo attaches a UserRepository for resolving mention usernames to IDs.
 func (s *CreateService) SetUserRepo(r repository.UserRepository) {
 	s.userRepo = r
+}
+
+// SetBlockingRepo attaches a BlockingRepository for detecting reply/renote
+// block violations. When unset the block check is skipped (backward compat).
+func (s *CreateService) SetBlockingRepo(r repository.BlockingRepository) {
+	s.blockingRepo = r
+}
+
+// SetDriveFileRepo attaches a DriveFileRepository for validating fileIds.
+// When unset fileId validation is skipped (backward compat).
+func (s *CreateService) SetDriveFileRepo(r repository.DriveFileRepository) {
+	s.driveFileRepo = r
+}
+
+// SetMetaRepo attaches a MetaRepository for prohibited-word detection.
+// When unset the check is skipped.
+func (s *CreateService) SetMetaRepo(r repository.MetaRepository) {
+	s.metaRepo = r
+}
+
+// SetChannelRepo attaches a ChannelRepository for the "renote outside of
+// channel" rule evaluation. Required alongside ChannelHook for strict checks.
+func (s *CreateService) SetChannelRepo(r repository.ChannelRepository) {
+	s.channelRepo = r
 }
 
 // NewCreateService creates a new CreateService.
@@ -219,6 +274,26 @@ func (s *CreateService) Create(in CreateInput) (*model.Note, error) {
 		visibility = model.NoteVisibilityPublic
 	}
 
+	// プロhibited wordsチェック (meta.prohibitedWordsマッチ)
+	if err := s.checkProhibitedWords(in.Text, in.CW); err != nil {
+		return nil, err
+	}
+
+	// mentionLimitチェック (role policiesの制限)
+	if err := s.checkMentionLimit(in.Text); err != nil {
+		return nil, err
+	}
+
+	// pollのexpiresAtが既に過去なら弾く
+	if in.Poll != nil && in.Poll.ExpiresAt != nil && in.Poll.ExpiresAt.Before(time.Now()) {
+		return nil, ErrCannotCreateAlreadyExpiredPoll
+	}
+
+	// fileIdsのうち存在しないIDがあれば弾く
+	if err := s.checkFileIDs(in.User.ID, in.FileIDs); err != nil {
+		return nil, err
+	}
+
 	// channelId が指定されていれば存在チェック。channelHook 未設定なら
 	// channel 機能が無効なものとして扱い、エラーは返さない。
 	if in.ChannelID != nil && *in.ChannelID != "" && s.channelHook != nil {
@@ -235,8 +310,22 @@ func (s *CreateService) Create(in CreateInput) (*model.Note, error) {
 		if err != nil {
 			return nil, ErrReplyTargetNotFound
 		}
+		// pure renote (renoteIdあり、text/files/poll/cwなし) への返信は許可しない
+		if IsPureRenote(t) {
+			return nil, ErrCannotReplyToAPureRenote
+		}
 		if !CanSeeNote(in.User, t, s.followingRepo) {
 			return nil, ErrCannotReplyToInvisibleNote
+		}
+		// specified可視性noteへの返信時は visibility も specified でなければ拒否
+		if t.Visibility == model.NoteVisibilitySpecified && visibility != model.NoteVisibilitySpecified {
+			return nil, ErrCannotReplyToSpecifiedVisibility
+		}
+		// reply対象のユーザーに block されていたら拒否
+		if t.UserID != in.User.ID {
+			if err := s.checkBlocked(t.UserID, in.User.ID); err != nil {
+				return nil, err
+			}
 		}
 		replyTarget = t
 	}
@@ -245,8 +334,26 @@ func (s *CreateService) Create(in CreateInput) (*model.Note, error) {
 		if err != nil {
 			return nil, ErrRenoteTargetNotFound
 		}
+		// pure renoteを更にrenoteするのは禁止 (TS: isRenote && !isQuote)
+		if IsPureRenote(t) {
+			return nil, ErrCannotRenoteToAPureRenote
+		}
 		if !CanSeeNote(in.User, t, s.followingRepo) {
 			return nil, ErrCannotRenoteInvisibleNote
+		}
+		// renote対象のユーザーに block されていたら拒否
+		if t.UserID != in.User.ID {
+			if err := s.checkBlocked(t.UserID, in.User.ID); err != nil {
+				return nil, err
+			}
+		}
+		// チャンネル外への renote 可否: 対象がチャンネル note で、本 note の
+		// ChannelID が対象と異なる (= チャンネル外への転送) 場合は channel の
+		// allowRenoteToExternal を確認する。
+		if t.ChannelID != nil && !sameChannel(t.ChannelID, in.ChannelID) {
+			if err := s.checkRenoteOutsideOfChannel(*t.ChannelID); err != nil {
+				return nil, err
+			}
 		}
 		renoteTarget = t
 	}
@@ -503,4 +610,130 @@ func IsPureRenote(n *model.Note) bool {
 		return false
 	}
 	return true
+}
+
+// sameChannel reports whether two optional channel IDs refer to the same channel.
+// Both nil or same pointer or same string → true; differing strings → false.
+func sameChannel(a, b *string) bool {
+	if a == nil && b == nil {
+		return true
+	}
+	if a == nil || b == nil {
+		return false
+	}
+	return *a == *b
+}
+
+// checkProhibitedWords scans text + cw for any word listed in
+// meta.prohibitedWords. Returns ErrContainsProhibitedWords on match.
+// MetaRepo未設定、または prohibitedWords が空ならskipする。
+func (s *CreateService) checkProhibitedWords(text, cw *string) error {
+	if s.metaRepo == nil {
+		return nil
+	}
+	meta, err := s.metaRepo.Fetch()
+	if err != nil || meta == nil || len(meta.ProhibitedWords) == 0 {
+		return nil
+	}
+	haystacks := make([]string, 0, 2)
+	if text != nil && *text != "" {
+		haystacks = append(haystacks, strings.ToLower(*text))
+	}
+	if cw != nil && *cw != "" {
+		haystacks = append(haystacks, strings.ToLower(*cw))
+	}
+	for _, word := range meta.ProhibitedWords {
+		word = strings.TrimSpace(strings.ToLower(word))
+		if word == "" {
+			continue
+		}
+		for _, h := range haystacks {
+			if strings.Contains(h, word) {
+				return ErrContainsProhibitedWords
+			}
+		}
+	}
+	return nil
+}
+
+// checkMentionLimit counts mentions in text and compares against the default
+// role policy's mentionLimit. Per-user role override is not yet supported
+// (TS side merges per-user policies; follow-up issue should wire that).
+func (s *CreateService) checkMentionLimit(text *string) error {
+	if text == nil || *text == "" {
+		return nil
+	}
+	mentions := ExtractMentionStructs(*text)
+	limit := defaultMentionLimit()
+	if limit > 0 && len(mentions) > limit {
+		return ErrContainsTooManyMentions
+	}
+	return nil
+}
+
+// defaultMentionLimit returns the baseline mentionLimit from role.DefaultPolicies.
+// 本家TSではrole per-userのmerge値を使うが、Go側は現状default値でチェック。
+func defaultMentionLimit() int {
+	// role.DefaultPolicies() を直接 import すると循環依存になるため、
+	// 同期を保つ意図で本家TSの現行既定値 (20) をここに直書きする。
+	return 20
+}
+
+// checkFileIDs verifies all provided fileIds exist and belong to the user.
+// DriveFileRepo未設定ならskipする。
+// TS本家は user.id 所有の files のみ拾うが、Go の DriveFileRepo は ID ベース
+// の bulk 取得しか持たないため、取得後に userId 一致をチェックする。
+func (s *CreateService) checkFileIDs(userID string, fileIDs []string) error {
+	if len(fileIDs) == 0 || s.driveFileRepo == nil {
+		return nil
+	}
+	files, err := s.driveFileRepo.ListByFileIDs(fileIDs)
+	if err != nil {
+		return err
+	}
+	if len(files) != len(fileIDs) {
+		return ErrNoSuchFile
+	}
+	for _, f := range files {
+		if f.UserID == nil || *f.UserID != userID {
+			return ErrNoSuchFile
+		}
+	}
+	return nil
+}
+
+// checkBlocked returns ErrYouHaveBeenBlocked when blockerID has blocked
+// blockeeID. BlockingRepo未設定ならskip。
+func (s *CreateService) checkBlocked(blockerID, blockeeID string) error {
+	if s.blockingRepo == nil {
+		return nil
+	}
+	blocked, err := s.blockingRepo.Exists(blockerID, blockeeID)
+	if err != nil {
+		return err
+	}
+	if blocked {
+		return ErrYouHaveBeenBlocked
+	}
+	return nil
+}
+
+// checkRenoteOutsideOfChannel resolves the channel referenced by channelID
+// and rejects renoting outside of it when the channel forbids it.
+// ChannelRepo未設定ならskip (strictチェック不能として許可側に倒す)。
+func (s *CreateService) checkRenoteOutsideOfChannel(channelID string) error {
+	if s.channelRepo == nil {
+		return nil
+	}
+	ch, err := s.channelRepo.FindByID(channelID)
+	if err != nil {
+		// チャンネル不明時は TS 側は NO_SUCH_CHANNEL を投げるが、本経路は
+		// 既に renote ターゲットが作られている (= channel は存在した時点が
+		// ある) 前提なので、取得失敗は allow 側に倒す。
+		return nil
+	}
+	if !ch.AllowRenoteToExternal {
+		return ErrCannotRenoteOutsideOfChannel
+	}
+	return nil
 }

--- a/internal/core/note/note_create_service.go
+++ b/internal/core/note/note_create_service.go
@@ -310,12 +310,15 @@ func (s *CreateService) Create(in CreateInput) (*model.Note, error) {
 		if err != nil {
 			return nil, ErrReplyTargetNotFound
 		}
+		// 可視性チェックを先に行う。FindByIDWithUserは無条件に行を返すため、
+		// 不可視noteに対して別error (pure renote 等) を返すと「対象noteが
+		// 何であるか」を攻撃者が推測できる情報漏洩になる。Devin review #270。
+		if !CanSeeNote(in.User, t, s.followingRepo) {
+			return nil, ErrCannotReplyToInvisibleNote
+		}
 		// pure renote (renoteIdあり、text/files/poll/cwなし) への返信は許可しない
 		if IsPureRenote(t) {
 			return nil, ErrCannotReplyToAPureRenote
-		}
-		if !CanSeeNote(in.User, t, s.followingRepo) {
-			return nil, ErrCannotReplyToInvisibleNote
 		}
 		// specified可視性noteへの返信時は visibility も specified でなければ拒否
 		if t.Visibility == model.NoteVisibilitySpecified && visibility != model.NoteVisibilitySpecified {
@@ -334,12 +337,13 @@ func (s *CreateService) Create(in CreateInput) (*model.Note, error) {
 		if err != nil {
 			return nil, ErrRenoteTargetNotFound
 		}
+		// 可視性チェックを先に行う (Devin review #270 — 情報漏洩防止)。
+		if !CanSeeNote(in.User, t, s.followingRepo) {
+			return nil, ErrCannotRenoteInvisibleNote
+		}
 		// pure renoteを更にrenoteするのは禁止 (TS: isRenote && !isQuote)
 		if IsPureRenote(t) {
 			return nil, ErrCannotRenoteToAPureRenote
-		}
-		if !CanSeeNote(in.User, t, s.followingRepo) {
-			return nil, ErrCannotRenoteInvisibleNote
 		}
 		// renote対象のユーザーに block されていたら拒否
 		if t.UserID != in.User.ID {

--- a/internal/core/note/note_create_service_test.go
+++ b/internal/core/note/note_create_service_test.go
@@ -846,3 +846,39 @@ func TestCreateService_InvisiblePureRenote_NoLeak_Renote(t *testing.T) {
 	assert.ErrorIs(t, err, note.ErrCannotRenoteInvisibleNote)
 	assert.NotErrorIs(t, err, note.ErrCannotRenoteToAPureRenote)
 }
+
+// Devin review #270: 重複 fileId で false positive にならないこと。
+func TestCreateService_DuplicateFileIDs_Accepted(t *testing.T) {
+	svc, _, _ := newCreateService(t)
+	fileRepo := testutil.NewMockDriveFileRepository()
+	svc.SetDriveFileRepo(fileRepo)
+
+	uid := "u1"
+	fileRepo.Files["f1"] = &model.DriveFile{ID: "f1", UserID: &uid}
+
+	text := "hello"
+	_, err := svc.Create(note.CreateInput{
+		User:    &model.User{ID: uid},
+		Text:    &text,
+		FileIDs: []string{"f1", "f1"}, // 重複
+	})
+	assert.NoError(t, err)
+}
+
+// 所有者違いの file は拒否される (regression)。
+func TestCreateService_NoSuchFile_WrongOwner(t *testing.T) {
+	svc, _, _ := newCreateService(t)
+	fileRepo := testutil.NewMockDriveFileRepository()
+	svc.SetDriveFileRepo(fileRepo)
+
+	otherUID := "other_user"
+	fileRepo.Files["f1"] = &model.DriveFile{ID: "f1", UserID: &otherUID}
+
+	text := "hello"
+	_, err := svc.Create(note.CreateInput{
+		User:    &model.User{ID: "u1"},
+		Text:    &text,
+		FileIDs: []string{"f1"},
+	})
+	assert.ErrorIs(t, err, note.ErrNoSuchFile)
+}

--- a/internal/core/note/note_create_service_test.go
+++ b/internal/core/note/note_create_service_test.go
@@ -650,3 +650,158 @@ func TestIsPureRenote_ModelNote(t *testing.T) {
 		})
 	}
 }
+
+// --- Phase 7-1 follow-up (#254): 追加 sentinel error 検出テスト ---
+
+func strPtr254(s string) *string { return &s }
+
+func TestCreateService_ExpiredPoll(t *testing.T) {
+	svc, _, _ := newCreateService(t)
+	past := time.Now().Add(-1 * time.Hour)
+	text := "vote!"
+	_, err := svc.Create(note.CreateInput{
+		User: &model.User{ID: "u1"},
+		Text: &text,
+		Poll: &note.PollInput{Choices: []string{"a", "b"}, ExpiresAt: &past},
+	})
+	assert.ErrorIs(t, err, note.ErrCannotCreateAlreadyExpiredPoll)
+}
+
+func TestCreateService_CannotRenoteToAPureRenote(t *testing.T) {
+	svc, noteRepo, _ := newCreateService(t)
+	noteID := "pure_renote_target"
+	renoteTargetInner := "other_note"
+	noteRepo.Notes[noteID] = &model.Note{
+		ID: noteID, UserID: "other", Visibility: model.NoteVisibilityPublic,
+		RenoteID: &renoteTargetInner, // pure renote: text/cw/files/poll なし
+	}
+	_, err := svc.Create(note.CreateInput{
+		User:     &model.User{ID: "u1"},
+		RenoteID: strPtr254(noteID),
+	})
+	assert.ErrorIs(t, err, note.ErrCannotRenoteToAPureRenote)
+}
+
+func TestCreateService_CannotReplyToAPureRenote(t *testing.T) {
+	svc, noteRepo, _ := newCreateService(t)
+	noteID := "pure_renote_target_2"
+	inner := "other_note"
+	noteRepo.Notes[noteID] = &model.Note{
+		ID: noteID, UserID: "other", Visibility: model.NoteVisibilityPublic,
+		RenoteID: &inner,
+	}
+	text := "hi"
+	_, err := svc.Create(note.CreateInput{
+		User:    &model.User{ID: "u1"},
+		Text:    &text,
+		ReplyID: strPtr254(noteID),
+	})
+	assert.ErrorIs(t, err, note.ErrCannotReplyToAPureRenote)
+}
+
+func TestCreateService_CannotReplyToSpecifiedVisibility(t *testing.T) {
+	svc, noteRepo, _ := newCreateService(t)
+	noteID := "specified_target"
+	noteRepo.Notes[noteID] = &model.Note{
+		ID: noteID, UserID: "u1", Visibility: model.NoteVisibilitySpecified,
+		VisibleUserIDs: []string{"u1"},
+	}
+	text := "hi"
+	_, err := svc.Create(note.CreateInput{
+		User:       &model.User{ID: "u1"},
+		Text:       &text,
+		ReplyID:    strPtr254(noteID),
+		Visibility: model.NoteVisibilityPublic, // widerで不許可
+	})
+	assert.ErrorIs(t, err, note.ErrCannotReplyToSpecifiedVisibility)
+}
+
+func TestCreateService_YouHaveBeenBlocked_Renote(t *testing.T) {
+	svc, noteRepo, _ := newCreateService(t)
+	blockRepo := testutil.NewMockBlockingRepository()
+	svc.SetBlockingRepo(blockRepo)
+
+	// block: target user が actor を block している
+	require.NoError(t, blockRepo.Create(&model.Blocking{ID: "b1", BlockerID: "target_user", BlockeeID: "u1"}))
+
+	noteID := "renote_target_blocked"
+	noteRepo.Notes[noteID] = &model.Note{
+		ID: noteID, UserID: "target_user", Visibility: model.NoteVisibilityPublic,
+	}
+	_, err := svc.Create(note.CreateInput{
+		User:     &model.User{ID: "u1"},
+		RenoteID: strPtr254(noteID),
+	})
+	assert.ErrorIs(t, err, note.ErrYouHaveBeenBlocked)
+}
+
+func TestCreateService_YouHaveBeenBlocked_Reply(t *testing.T) {
+	svc, noteRepo, _ := newCreateService(t)
+	blockRepo := testutil.NewMockBlockingRepository()
+	svc.SetBlockingRepo(blockRepo)
+
+	require.NoError(t, blockRepo.Create(&model.Blocking{ID: "b1", BlockerID: "target_user", BlockeeID: "u1"}))
+
+	noteID := "reply_target_blocked"
+	noteRepo.Notes[noteID] = &model.Note{
+		ID: noteID, UserID: "target_user", Visibility: model.NoteVisibilityPublic,
+	}
+	text := "hi"
+	_, err := svc.Create(note.CreateInput{
+		User:    &model.User{ID: "u1"},
+		Text:    &text,
+		ReplyID: strPtr254(noteID),
+	})
+	assert.ErrorIs(t, err, note.ErrYouHaveBeenBlocked)
+}
+
+func TestCreateService_NoSuchFile(t *testing.T) {
+	svc, _, _ := newCreateService(t)
+	fileRepo := testutil.NewMockDriveFileRepository()
+	svc.SetDriveFileRepo(fileRepo)
+
+	text := "hello"
+	_, err := svc.Create(note.CreateInput{
+		User:    &model.User{ID: "u1"},
+		Text:    &text,
+		FileIDs: []string{"nonexistent_file"},
+	})
+	assert.ErrorIs(t, err, note.ErrNoSuchFile)
+}
+
+func TestCreateService_ContainsProhibitedWords(t *testing.T) {
+	svc, _, _ := newCreateService(t)
+	metaRepo := testutil.NewMockMetaRepository()
+	metaRepo.Meta = &model.Meta{ID: "m1", ProhibitedWords: []string{"badword"}}
+	svc.SetMetaRepo(metaRepo)
+
+	text := "contains badword here"
+	_, err := svc.Create(note.CreateInput{
+		User: &model.User{ID: "u1"},
+		Text: &text,
+	})
+	assert.ErrorIs(t, err, note.ErrContainsProhibitedWords)
+}
+
+func TestCreateService_ContainsTooManyMentions(t *testing.T) {
+	svc, _, _ := newCreateService(t)
+	// 21 メンションで default limit (20) 超過
+	mentions := ""
+	for i := 0; i < 21; i++ {
+		mentions += "@user" + strPtr254Str(i) + " "
+	}
+	_, err := svc.Create(note.CreateInput{
+		User: &model.User{ID: "u1"},
+		Text: &mentions,
+	})
+	assert.ErrorIs(t, err, note.ErrContainsTooManyMentions)
+}
+
+func strPtr254Str(i int) string {
+	// base36: 0-9,a-z
+	const chars = "0123456789abcdefghijklmnopqrstuvwxyz"
+	if i < 36 {
+		return string(chars[i])
+	}
+	return string(chars[i/36]) + string(chars[i%36])
+}

--- a/internal/core/note/note_create_service_test.go
+++ b/internal/core/note/note_create_service_test.go
@@ -805,3 +805,44 @@ func strPtr254Str(i int) string {
 	}
 	return string(chars[i/36]) + string(chars[i%36])
 }
+
+// Devin review #270: IsPureRenote check must not leak note structure to
+// unauthorized viewers. invisible な pure renote への reply/renote では
+// 「見えない」エラーを返し、pure renote であることが推測できないようにする。
+func TestCreateService_InvisiblePureRenote_NoLeak_Reply(t *testing.T) {
+	svc, noteRepo, _ := newCreateService(t)
+	noteID := "invisible_pure_renote"
+	inner := "original_note"
+	noteRepo.Notes[noteID] = &model.Note{
+		ID: noteID, UserID: "other_user",
+		Visibility: model.NoteVisibilityFollowers, // viewerはfollowしていない
+		RenoteID:   &inner,                        // pure renote
+	}
+	text := "hi"
+	_, err := svc.Create(note.CreateInput{
+		User:    &model.User{ID: "u1"},
+		Text:    &text,
+		ReplyID: strPtr254(noteID),
+	})
+	// pure renote error ではなく invisible error が返るべき
+	assert.ErrorIs(t, err, note.ErrCannotReplyToInvisibleNote)
+	assert.NotErrorIs(t, err, note.ErrCannotReplyToAPureRenote)
+}
+
+func TestCreateService_InvisiblePureRenote_NoLeak_Renote(t *testing.T) {
+	svc, noteRepo, _ := newCreateService(t)
+	noteID := "invisible_pure_renote_2"
+	inner := "original_note"
+	noteRepo.Notes[noteID] = &model.Note{
+		ID: noteID, UserID: "other_user",
+		Visibility: model.NoteVisibilityFollowers,
+		RenoteID:   &inner,
+	}
+	_, err := svc.Create(note.CreateInput{
+		User:     &model.User{ID: "u1"},
+		RenoteID: strPtr254(noteID),
+	})
+	// pure renote error ではなく invisible error
+	assert.ErrorIs(t, err, note.ErrCannotRenoteInvisibleNote)
+	assert.NotErrorIs(t, err, note.ErrCannotRenoteToAPureRenote)
+}

--- a/internal/core/user/user_service.go
+++ b/internal/core/user/user_service.go
@@ -20,6 +20,12 @@ const MaxPinnedNotes = 5
 var (
 	// ErrUserNotFound is returned when the target user does not exist.
 	ErrUserNotFound = errors.New("user not found")
+	// ErrFailedToResolveRemoteUser is returned when ShowByUsername is called
+	// with a non-local host and remote resolution fails. The sentinel exists
+	// so handlers can map the dedicated FAILED_TO_RESOLVE_REMOTE_USER API
+	// error, but the service does not yet attempt remote resolution; the
+	// actual wiring (ActorResolver integration) is a follow-up task.
+	ErrFailedToResolveRemoteUser = errors.New("failed to resolve remote user")
 	// ErrInvalidParam is returned when neither userId nor username is given.
 	ErrInvalidParam = errors.New("userId or username is required")
 	// ErrNoteNotFound is returned when the target note does not exist or is

--- a/internal/server/router.go
+++ b/internal/server/router.go
@@ -173,6 +173,12 @@ func (s *Server) setupRoutes() {
 	// ActivityPub 配信のためにローカルユーザーは RSA 鍵対を必要とする。
 	signupService.SetKeypairRepo(keypairRepo)
 	noteCreateService := corenote.NewCreateService(noteRepo, pollRepo, idGen, followingRepo)
+	// Phase 7-1 follow-up (#254): 本家互換の残存 error 検出ロジック用依存を注入。
+	// Setter経由なのでテストでは任意に省略可能。
+	noteCreateService.SetBlockingRepo(repository.NewBlockingRepository(s.db))
+	noteCreateService.SetDriveFileRepo(driveFileRepo)
+	noteCreateService.SetMetaRepo(metaRepo)
+	noteCreateService.SetChannelRepo(repository.NewChannelRepository(s.db))
 	noteDeleteService := corenote.NewDeleteService(noteRepo)
 	noteQueryService := corenote.NewQueryService(noteRepo, followingRepo)
 	noteQueryService.SetFavoriteRepo(noteFavoriteRepo)

--- a/internal/server/router.go
+++ b/internal/server/router.go
@@ -174,11 +174,11 @@ func (s *Server) setupRoutes() {
 	signupService.SetKeypairRepo(keypairRepo)
 	noteCreateService := corenote.NewCreateService(noteRepo, pollRepo, idGen, followingRepo)
 	// Phase 7-1 follow-up (#254): 本家互換の残存 error 検出ロジック用依存を注入。
-	// Setter経由なのでテストでは任意に省略可能。
-	noteCreateService.SetBlockingRepo(repository.NewBlockingRepository(s.db))
+	// Setter経由なのでテストでは任意に省略可能。既存の同repository変数を再利用。
+	noteCreateService.SetBlockingRepo(blockingRepo)
 	noteCreateService.SetDriveFileRepo(driveFileRepo)
 	noteCreateService.SetMetaRepo(metaRepo)
-	noteCreateService.SetChannelRepo(repository.NewChannelRepository(s.db))
+	noteCreateService.SetChannelRepo(channelRepo)
 	noteDeleteService := corenote.NewDeleteService(noteRepo)
 	noteQueryService := corenote.NewQueryService(noteRepo, followingRepo)
 	noteQueryService.SetFavoriteRepo(noteFavoriteRepo)


### PR DESCRIPTION
## Summary

#254 (Phase 7-1 follow-up) の notes/create 側 9 sentinel error + 検出ロジックを実装。TS本家 `NoteCreateService.ts` の IdentifiableError 群と互換になる。UUID / error code は #243 で既に apierr に定義済みのため、本 PR は factory helper と検出ロジックを追加する形。

users/show の `FAILED_TO_RESOLVE_REMOTE_USER` は remote resolver 統合が別スコープのため分離: #269 で追跡。

## 追加した sentinel error と検出ロジック

| Error | Detection (in `note_create_service.go`) |
|---|---|
| `ErrCannotRenoteToAPureRenote` | `IsPureRenote(renoteTarget)` |
| `ErrCannotReplyToAPureRenote` | `IsPureRenote(replyTarget)` |
| `ErrCannotReplyToSpecifiedVisibility` | `replyTarget.Visibility=='specified' && in.Visibility!='specified'` |
| `ErrYouHaveBeenBlocked` | `blockingRepo.Exists(target.UserID, actor.ID)` for reply/renote |
| `ErrCannotCreateAlreadyExpiredPoll` | `poll.ExpiresAt.Before(now)` |
| `ErrNoSuchFile` | `driveFileRepo.ListByFileIDs(ids)` + ownership check |
| `ErrCannotRenoteOutsideOfChannel` | `channelRepo.FindByID(id).AllowRenoteToExternal == false` |
| `ErrContainsProhibitedWords` | `metaRepo.Fetch().ProhibitedWords` substring match on text + cw |
| `ErrContainsTooManyMentions` | mention count > `defaultMentionLimit()` (20) |

### Dependency 注入方式

新しく必要な repo はすべて **optional setter** 経由で挿入:

\`\`\`go
svc.SetBlockingRepo(blockingRepo)
svc.SetDriveFileRepo(driveFileRepo)
svc.SetMetaRepo(metaRepo)
svc.SetChannelRepo(channelRepo)
\`\`\`

setter 未設定のパッケージでは該当 check が skip されるため、既存テスト・既存呼び出しは**無変更でビルド**する。router.go で本番用 repo を wire した。

### 本家との差分

- TS は per-user role merged policies から `mentionLimit` を引くが、Go 側は role service 経由の per-user policy が未統合のため、現状は `role.DefaultPolicies()` 相当の定数 20 を使用。将来の改善余地として `defaultMentionLimit()` を単独関数に切り出した
- TS の file check は `driveFilesRepository.createQueryBuilder('file').where('file.userId = :userId')` で一発だが、Go の repo は ID 一括取得しか持たないため fetch 後に ownership チェック

## apierr 拡張

#243 で UUID 定数だけ定義済みだった 10 種 (上記 9 + `FAILED_TO_RESOLVE_REMOTE_USER`) の factory と echo JSON wrapper を追加 (計 20 新シンボル)。apierr package coverage は **100% 維持**。

## user.ErrFailedToResolveRemoteUser

sentinel のみ追加。handler 側 (`users/show`) も mapping 配線済みだが、実 emit は remote resolver 統合が必要で別スコープ。follow-up として [#269](https://github.com/shiroha-a/mk/issues/269) を作成。

## テスト

- `core/note`: 9 検出シナリオ
- `api/notes`: 既存 `TestCreate_WithPollExpiresAt` が hardcoded 過去時刻で落ちるのを動的未来時刻に修正
- `api/apierr`: 10 factory + 10 JSON wrapper → coverage 100%
- 全 CI simulation: `test exit=0` + All packages meet coverage thresholds

## 副次的改善

- `TestCreate_WithPollExpiresAt`: `1700000000000` (2023年) ハードコードを `time.Now().Add(24*time.Hour).UnixMilli()` に変更。これで新しい expired-poll check が passing test を壊さない上、時間経過に対して頑健

## Closes

Closes #254 (notes/create 側)

## 関連

- Parent: #242 Phase 7
- Follow-up: #269 (users/show FAILED_TO_RESOLVE_REMOTE_USER の remote resolver 統合)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/shiroha-a/mk/pull/270" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
