### PR TITLE
Phase 7-2 MeDetailed 未読系 7 フィールドを実クエリ化

### DIFF
--- a/internal/api/i/handler.go
+++ b/internal/api/i/handler.go
@@ -1,6 +1,7 @@
 package i
 
 import (
+	"context"
 	"encoding/json"
 	"errors"
 	"net/http"
@@ -9,6 +10,7 @@ import (
 
 	"github.com/labstack/echo/v4"
 	"github.com/shiroha-a/mk/internal/api/apierr"
+	"github.com/shiroha-a/mk/internal/core/notification"
 	"github.com/shiroha-a/mk/internal/core/role"
 	"github.com/shiroha-a/mk/internal/core/twofactor"
 	"github.com/shiroha-a/mk/internal/core/user"
@@ -42,22 +44,46 @@ type AccountMover interface {
 
 // Handler handles account-related API endpoints.
 type Handler struct {
-	userService      *user.Service
-	idGen            id.Generator
-	roleProvider     RoleProvider
-	registryRepo     repository.RegistryRepository
-	favoriteRepo     repository.NoteFavoriteRepository
-	transferEnqueuer TransferEnqueuer
-	webauthnSvc      *twofactor.WebAuthnService
-	securityKeyRepo  repository.UserSecurityKeyRepository
-	metaRepo         repository.MetaRepository
-	emailSender      EmailSender
-	serverURL        string
-	signinRepo       repository.SigninRepository
-	accessTokenRepo  repository.AccessTokenRepository
-	galleryRepo      GalleryRepository
-	pageLikeRepo     repository.PageLikeRepository
-	mover            AccountMover
+	userService       *user.Service
+	idGen             id.Generator
+	roleProvider      RoleProvider
+	registryRepo      repository.RegistryRepository
+	favoriteRepo      repository.NoteFavoriteRepository
+	transferEnqueuer  TransferEnqueuer
+	webauthnSvc       *twofactor.WebAuthnService
+	securityKeyRepo   repository.UserSecurityKeyRepository
+	metaRepo          repository.MetaRepository
+	emailSender       EmailSender
+	serverURL         string
+	signinRepo        repository.SigninRepository
+	accessTokenRepo   repository.AccessTokenRepository
+	galleryRepo       GalleryRepository
+	pageLikeRepo      repository.PageLikeRepository
+	mover             AccountMover
+	notificationSvc   UnreadNotificationSource
+	followRequestRepo repository.FollowRequestRepository
+	announcementRepo  AnnouncementUnreadSource
+	chatRepo          ChatUnreadSource
+}
+
+// UnreadNotificationSource is the subset of notification.Service used by /api/i
+// to compute hasUnreadNotification / unreadNotificationsCount / hasUnreadMentions.
+// Keeping this as a local interface avoids pulling core/notification into the
+// handler test harness and lets the tests inject a stub.
+type UnreadNotificationSource interface {
+	UnreadCount(ctx context.Context, userID string) (int64, error)
+	HasUnreadOfTypes(ctx context.Context, userID string, types []notification.Type) (bool, error)
+}
+
+// AnnouncementUnreadSource lists active announcements the user has not read.
+// Mirrors the subset of AnnouncementRepository needed here.
+type AnnouncementUnreadSource interface {
+	UnreadForUser(userID string) ([]*model.Announcement, error)
+}
+
+// ChatUnreadSource returns the number of unread chat messages for a user.
+type ChatUnreadSource interface {
+	CountUnread(userID string) (int64, error)
 }
 
 // GalleryRepository is the subset of repository.GalleryRepository used by
@@ -132,6 +158,31 @@ func (h *Handler) SetFavoriteRepo(r repository.NoteFavoriteRepository) {
 // returns 501 so the endpoint fails loudly instead of silently no-oping.
 func (h *Handler) SetAccountMover(m AccountMover) {
 	h.mover = m
+}
+
+// SetNotificationService wires the notification service used to compute
+// hasUnreadNotification / unreadNotificationsCount / hasUnreadMentions on
+// /api/i. When unset those fields fall back to default (false/0).
+func (h *Handler) SetNotificationService(s UnreadNotificationSource) {
+	h.notificationSvc = s
+}
+
+// SetFollowRequestRepo wires the follow_request repository used to compute
+// hasPendingReceivedFollowRequest on /api/i.
+func (h *Handler) SetFollowRequestRepo(r repository.FollowRequestRepository) {
+	h.followRequestRepo = r
+}
+
+// SetAnnouncementRepo wires the announcement repository used to compute
+// hasUnreadAnnouncement / unreadAnnouncements on /api/i.
+func (h *Handler) SetAnnouncementRepo(r AnnouncementUnreadSource) {
+	h.announcementRepo = r
+}
+
+// SetChatRepo wires the chat repository used to compute hasUnreadChatMessages
+// on /api/i.
+func (h *Handler) SetChatRepo(r ChatUnreadSource) {
+	h.chatRepo = r
 }
 
 // NewHandler creates a new account Handler.
@@ -384,16 +435,10 @@ func (h *Handler) Me(c echo.Context) error {
 	resp["isModerator"] = isMod
 	resp["isDeleted"] = u.IsDeleted
 	resp["isExplorable"] = u.IsExplorable
-	resp["hasUnreadNotification"] = false
-	resp["hasPendingReceivedFollowRequest"] = false
-	resp["hasUnreadAnnouncement"] = false
-	resp["hasUnreadAntenna"] = false
-	resp["hasUnreadChannel"] = false
-	resp["hasUnreadMentions"] = false
-	resp["hasUnreadSpecifiedNotes"] = false
-	resp["hasUnreadChatMessages"] = false
-	resp["unreadNotificationsCount"] = 0
-	resp["unreadAnnouncements"] = []any{}
+	// 未読系フィールドを依存する repo / service から実際に引く。
+	// 未wireのものは false/0/[] にフォールバックする (テスト互換)。
+	// antenna / channel / specifiedNotes は別issueで追跡中のためここでは false 固定。
+	h.fillUnreadFields(c.Request().Context(), u, resp)
 	resp["pinnedNoteIds"] = []string{}
 	resp["pinnedNotes"] = []any{}
 	resp["pinnedPageId"] = nil
@@ -625,4 +670,68 @@ func (h *Handler) Unpin(c echo.Context) error {
 	}
 
 	return h.Me(c)
+}
+
+// fillUnreadFields writes the unread-related flags/counts onto resp.
+// 依存が未wireのフィールドはdefault (false/0/[]) にフォールバックする。
+// antenna / channel / specifiedNotes 系は別issueで追跡 (#244 の scope 外)
+// のため引き続き false 固定。
+func (h *Handler) fillUnreadFields(ctx context.Context, u *model.User, resp map[string]any) {
+	// Defaults
+	resp["hasUnreadNotification"] = false
+	resp["unreadNotificationsCount"] = 0
+	resp["hasUnreadMentions"] = false
+	resp["hasPendingReceivedFollowRequest"] = false
+	resp["hasUnreadAnnouncement"] = false
+	resp["unreadAnnouncements"] = []any{}
+	resp["hasUnreadChatMessages"] = false
+	// 別issueで追跡中 (Phase 7-2 follow-up)
+	resp["hasUnreadAntenna"] = false
+	resp["hasUnreadChannel"] = false
+	resp["hasUnreadSpecifiedNotes"] = false
+
+	// Notification (Redis Streams)
+	if h.notificationSvc != nil {
+		if n, err := h.notificationSvc.UnreadCount(ctx, u.ID); err == nil {
+			resp["unreadNotificationsCount"] = n
+			resp["hasUnreadNotification"] = n > 0
+		}
+		// hasUnreadMentions: 未読 notification のうち type=mention / reply
+		if ok, err := h.notificationSvc.HasUnreadOfTypes(ctx, u.ID, []notification.Type{
+			notification.TypeMention, notification.TypeReply,
+		}); err == nil {
+			resp["hasUnreadMentions"] = ok
+		}
+	}
+
+	// FollowRequest (DB)
+	if h.followRequestRepo != nil {
+		if n, err := h.followRequestRepo.CountReceived(u.ID); err == nil {
+			resp["hasPendingReceivedFollowRequest"] = n > 0
+		}
+	}
+
+	// Announcement (DB)
+	if h.announcementRepo != nil {
+		if ann, err := h.announcementRepo.UnreadForUser(u.ID); err == nil {
+			resp["hasUnreadAnnouncement"] = len(ann) > 0
+			out := make([]map[string]any, 0, len(ann))
+			for _, a := range ann {
+				out = append(out, map[string]any{
+					"id":       a.ID,
+					"title":    a.Title,
+					"text":     a.Text,
+					"imageUrl": a.ImageURL,
+				})
+			}
+			resp["unreadAnnouncements"] = out
+		}
+	}
+
+	// Chat (Redis set, wrapped in ChatRepository)
+	if h.chatRepo != nil {
+		if n, err := h.chatRepo.CountUnread(u.ID); err == nil {
+			resp["hasUnreadChatMessages"] = n > 0
+		}
+	}
 }

--- a/internal/api/i/handler_test.go
+++ b/internal/api/i/handler_test.go
@@ -1,6 +1,7 @@
 package i
 
 import (
+	"context"
 	"encoding/json"
 	"errors"
 	"net/http"
@@ -11,6 +12,7 @@ import (
 
 	"github.com/labstack/echo/v4"
 	"github.com/lib/pq"
+	"github.com/shiroha-a/mk/internal/core/notification"
 	coreuser "github.com/shiroha-a/mk/internal/core/user"
 	"github.com/shiroha-a/mk/internal/misc/id"
 	"github.com/shiroha-a/mk/internal/model"
@@ -976,4 +978,136 @@ func TestSetServerURL(t *testing.T) {
 func TestSetEmailSender(t *testing.T) {
 	h, _, _, _ := newTestHandler(t)
 	h.SetEmailSender(func(to, subject, body string) {})
+}
+
+// --- Phase 7-2 (#244): 未読系フィールド実装 ---
+
+// stubUnreadNotification is a local UnreadNotificationSource for tests.
+type stubUnreadNotification struct {
+	count        int64
+	hasTypes     bool
+	gotTypesArgs []notification.Type
+}
+
+func (s *stubUnreadNotification) UnreadCount(_ context.Context, _ string) (int64, error) {
+	return s.count, nil
+}
+func (s *stubUnreadNotification) HasUnreadOfTypes(_ context.Context, _ string, types []notification.Type) (bool, error) {
+	s.gotTypesArgs = types
+	return s.hasTypes, nil
+}
+
+type stubAnnouncementRepo struct {
+	rows []*model.Announcement
+}
+
+func (s *stubAnnouncementRepo) UnreadForUser(_ string) ([]*model.Announcement, error) {
+	return s.rows, nil
+}
+
+type stubChatRepo struct{ n int64 }
+
+func (s *stubChatRepo) CountUnread(_ string) (int64, error) { return s.n, nil }
+
+// runMe invokes h.Me with a minimal user + profile seeded and returns the
+// decoded response.
+func runMe(t *testing.T, h *Handler, userRepo *testutil.MockUserRepository, userID string) map[string]any {
+	t.Helper()
+	u := &model.User{
+		ID: userID, Username: "u", AvatarDecorations: datatypes.JSON([]byte("[]")),
+		ChatScope: "mutual",
+	}
+	userRepo.Profiles[userID] = &model.UserProfile{
+		UserID: userID, Fields: datatypes.JSON([]byte("[]")),
+	}
+	e := echo.New()
+	req := httptest.NewRequest(http.MethodPost, "/api/i", nil)
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+	c.Set(string(middleware.UserContextKey), u)
+	require.NoError(t, h.Me(c))
+	assert.Equal(t, http.StatusOK, rec.Code)
+	var resp map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+	return resp
+}
+
+func TestMe_UnreadNotification_Populated(t *testing.T) {
+	h, userRepo, _, _ := newTestHandler(t)
+	stub := &stubUnreadNotification{count: 3, hasTypes: true}
+	h.SetNotificationService(stub)
+
+	resp := runMe(t, h, userRepo, "u1")
+	assert.Equal(t, float64(3), resp["unreadNotificationsCount"])
+	assert.Equal(t, true, resp["hasUnreadNotification"])
+	assert.Equal(t, true, resp["hasUnreadMentions"])
+	assert.Equal(t, []notification.Type{notification.TypeMention, notification.TypeReply}, stub.gotTypesArgs)
+}
+
+func TestMe_UnreadNotification_ZeroCount(t *testing.T) {
+	h, userRepo, _, _ := newTestHandler(t)
+	h.SetNotificationService(&stubUnreadNotification{count: 0, hasTypes: false})
+
+	resp := runMe(t, h, userRepo, "u1")
+	assert.Equal(t, float64(0), resp["unreadNotificationsCount"])
+	assert.Equal(t, false, resp["hasUnreadNotification"])
+	assert.Equal(t, false, resp["hasUnreadMentions"])
+}
+
+func TestMe_PendingFollowRequest(t *testing.T) {
+	h, userRepo, _, _ := newTestHandler(t)
+	frRepo := testutil.NewMockFollowRequestRepository()
+	require.NoError(t, frRepo.Create(&model.FollowRequest{ID: "fr1", FollowerID: "other", FolloweeID: "u1"}))
+	h.SetFollowRequestRepo(frRepo)
+
+	resp := runMe(t, h, userRepo, "u1")
+	assert.Equal(t, true, resp["hasPendingReceivedFollowRequest"])
+}
+
+func TestMe_UnreadAnnouncement(t *testing.T) {
+	h, userRepo, _, _ := newTestHandler(t)
+	h.SetAnnouncementRepo(&stubAnnouncementRepo{
+		rows: []*model.Announcement{{ID: "a1", Title: "hello", Text: "world"}},
+	})
+
+	resp := runMe(t, h, userRepo, "u1")
+	assert.Equal(t, true, resp["hasUnreadAnnouncement"])
+	arr := resp["unreadAnnouncements"].([]any)
+	assert.Len(t, arr, 1)
+	first := arr[0].(map[string]any)
+	assert.Equal(t, "a1", first["id"])
+	assert.Equal(t, "hello", first["title"])
+}
+
+func TestMe_UnreadAnnouncement_Empty(t *testing.T) {
+	h, userRepo, _, _ := newTestHandler(t)
+	h.SetAnnouncementRepo(&stubAnnouncementRepo{rows: nil})
+
+	resp := runMe(t, h, userRepo, "u1")
+	assert.Equal(t, false, resp["hasUnreadAnnouncement"])
+	arr := resp["unreadAnnouncements"].([]any)
+	assert.Empty(t, arr)
+}
+
+func TestMe_UnreadChatMessages(t *testing.T) {
+	h, userRepo, _, _ := newTestHandler(t)
+	h.SetChatRepo(&stubChatRepo{n: 5})
+
+	resp := runMe(t, h, userRepo, "u1")
+	assert.Equal(t, true, resp["hasUnreadChatMessages"])
+}
+
+func TestMe_UnreadFieldsDefaults(t *testing.T) {
+	h, userRepo, _, _ := newTestHandler(t)
+	resp := runMe(t, h, userRepo, "u1")
+	assert.Equal(t, float64(0), resp["unreadNotificationsCount"])
+	assert.Equal(t, false, resp["hasUnreadNotification"])
+	assert.Equal(t, false, resp["hasUnreadMentions"])
+	assert.Equal(t, false, resp["hasPendingReceivedFollowRequest"])
+	assert.Equal(t, false, resp["hasUnreadAnnouncement"])
+	assert.Equal(t, false, resp["hasUnreadChatMessages"])
+	// 別issue (#271 等) で追跡: antenna / channel / specifiedNotes
+	assert.Equal(t, false, resp["hasUnreadAntenna"])
+	assert.Equal(t, false, resp["hasUnreadChannel"])
+	assert.Equal(t, false, resp["hasUnreadSpecifiedNotes"])
 }

--- a/internal/core/notification/notification_service.go
+++ b/internal/core/notification/notification_service.go
@@ -195,6 +195,70 @@ func (s *Service) LatestReadID(ctx context.Context, userID string) (string, erro
 	return val, nil
 }
 
+// UnreadCount returns the number of notifications in the user's stream that
+// are newer than the stored latest-read id. When there is no read marker (i.e.
+// the user has never marked anything as read) the full stream length is
+// returned. Callers typically derive hasUnreadNotification = UnreadCount > 0.
+func (s *Service) UnreadCount(ctx context.Context, userID string) (int64, error) {
+	readID, err := s.LatestReadID(ctx, userID)
+	if err != nil {
+		return 0, err
+	}
+	// Redis Streams は ID 単調増加。XLen で全件数を取り、readID 以前の
+	// 件数を差し引く方が O(1) でシンプルだが、readID より古いエントリが
+	// MAXLEN で削除されている場合があるので XRevRange で直接数える。
+	res, err := s.client.XRevRangeN(ctx, streamKey(userID), "+", exclusive(readID), MaxPerUser).Result()
+	if err != nil {
+		return 0, err
+	}
+	return int64(len(res)), nil
+}
+
+// HasUnreadOfTypes reports whether the user has any unread notification whose
+// type is in the provided list. Used by /api/i to compute hasUnreadMentions
+// (types: mention/reply). Returns false when types is empty.
+// readID 以降のエントリを XRevRange で読み、一件でもマッチしたら true。
+func (s *Service) HasUnreadOfTypes(ctx context.Context, userID string, types []Type) (bool, error) {
+	if len(types) == 0 {
+		return false, nil
+	}
+	readID, err := s.LatestReadID(ctx, userID)
+	if err != nil {
+		return false, err
+	}
+	res, err := s.client.XRevRangeN(ctx, streamKey(userID), "+", exclusive(readID), MaxPerUser).Result()
+	if err != nil {
+		return false, err
+	}
+	wanted := make(map[Type]struct{}, len(types))
+	for _, t := range types {
+		wanted[t] = struct{}{}
+	}
+	for _, msg := range res {
+		raw, ok := msg.Values["data"].(string)
+		if !ok {
+			continue
+		}
+		var n Notification
+		if err := json.Unmarshal([]byte(raw), &n); err != nil {
+			continue
+		}
+		if _, ok := wanted[n.Type]; ok {
+			return true, nil
+		}
+	}
+	return false, nil
+}
+
+// exclusive は XRevRange 用の「この ID より後 (newer)」を表す境界文字列を返す。
+// 空文字の場合は "-" で stream 先頭を表す。非空なら "(<id>" で exclusive 指定。
+func exclusive(readID string) string {
+	if readID == "" {
+		return "-"
+	}
+	return "(" + readID
+}
+
 // Flush deletes all notifications and the read marker for a user (used in tests
 // and account deletion).
 func (s *Service) Flush(ctx context.Context, userID string) error {

--- a/internal/core/notification/notification_service.go
+++ b/internal/core/notification/notification_service.go
@@ -250,8 +250,9 @@ func (s *Service) HasUnreadOfTypes(ctx context.Context, userID string, types []T
 	return false, nil
 }
 
-// exclusive は XRevRange 用の「この ID より後 (newer)」を表す境界文字列を返す。
-// 空文字の場合は "-" で stream 先頭を表す。非空なら "(<id>" で exclusive 指定。
+// exclusive returns the exclusive lower-bound string for XRevRange, i.e. the
+// boundary that means "strictly newer than this id". Empty readID becomes "-"
+// (stream head); non-empty uses the "(<id>" exclusive marker.
 func exclusive(readID string) string {
 	if readID == "" {
 		return "-"

--- a/internal/core/notification/notification_service_test.go
+++ b/internal/core/notification/notification_service_test.go
@@ -238,3 +238,96 @@ func TestService_List_SkipsBadEntries(t *testing.T) {
 	require.Len(t, out, 1)
 	assert.Equal(t, TypeFollow, out[0].Type)
 }
+
+// Phase 7-2 (#244): UnreadCount / HasUnreadOfTypes のテスト
+func TestService_UnreadCount_NoReadMarker(t *testing.T) {
+	svc := newTestSvc(t)
+	ctx := context.Background()
+
+	// 通知が無ければ0
+	n, err := svc.UnreadCount(ctx, "alice")
+	require.NoError(t, err)
+	assert.Equal(t, int64(0), n)
+
+	// 通知を3件作成し、readMarker未設定なら全件unread
+	for i := 0; i < 3; i++ {
+		_, err := svc.Create(ctx, CreateInput{NotifieeID: "alice", Type: TypeFollow, NotifierID: "bob"})
+		require.NoError(t, err)
+	}
+
+	n, err = svc.UnreadCount(ctx, "alice")
+	require.NoError(t, err)
+	assert.Equal(t, int64(3), n)
+}
+
+func TestService_UnreadCount_AfterMarkAllAsRead(t *testing.T) {
+	svc := newTestSvc(t)
+	ctx := context.Background()
+
+	for i := 0; i < 2; i++ {
+		_, err := svc.Create(ctx, CreateInput{NotifieeID: "alice", Type: TypeFollow, NotifierID: "bob"})
+		require.NoError(t, err)
+	}
+	require.NoError(t, svc.MarkAllAsRead(ctx, "alice"))
+
+	// 既読マーカー以降は0
+	n, err := svc.UnreadCount(ctx, "alice")
+	require.NoError(t, err)
+	assert.Equal(t, int64(0), n)
+
+	// 新規通知が1件来たら1
+	_, err = svc.Create(ctx, CreateInput{NotifieeID: "alice", Type: TypeReaction, NotifierID: "bob"})
+	require.NoError(t, err)
+	n, err = svc.UnreadCount(ctx, "alice")
+	require.NoError(t, err)
+	assert.Equal(t, int64(1), n)
+}
+
+func TestService_HasUnreadOfTypes_Match(t *testing.T) {
+	svc := newTestSvc(t)
+	ctx := context.Background()
+
+	_, err := svc.Create(ctx, CreateInput{NotifieeID: "alice", Type: TypeMention, NotifierID: "bob"})
+	require.NoError(t, err)
+
+	ok, err := svc.HasUnreadOfTypes(ctx, "alice", []Type{TypeMention, TypeReply})
+	require.NoError(t, err)
+	assert.True(t, ok)
+}
+
+func TestService_HasUnreadOfTypes_NoMatch(t *testing.T) {
+	svc := newTestSvc(t)
+	ctx := context.Background()
+
+	_, err := svc.Create(ctx, CreateInput{NotifieeID: "alice", Type: TypeFollow, NotifierID: "bob"})
+	require.NoError(t, err)
+
+	ok, err := svc.HasUnreadOfTypes(ctx, "alice", []Type{TypeMention, TypeReply})
+	require.NoError(t, err)
+	assert.False(t, ok)
+}
+
+func TestService_HasUnreadOfTypes_EmptyList(t *testing.T) {
+	svc := newTestSvc(t)
+	ctx := context.Background()
+
+	_, err := svc.Create(ctx, CreateInput{NotifieeID: "alice", Type: TypeMention, NotifierID: "bob"})
+	require.NoError(t, err)
+
+	ok, err := svc.HasUnreadOfTypes(ctx, "alice", nil)
+	require.NoError(t, err)
+	assert.False(t, ok)
+}
+
+func TestService_HasUnreadOfTypes_AfterMarkAllAsRead(t *testing.T) {
+	svc := newTestSvc(t)
+	ctx := context.Background()
+
+	_, err := svc.Create(ctx, CreateInput{NotifieeID: "alice", Type: TypeMention, NotifierID: "bob"})
+	require.NoError(t, err)
+	require.NoError(t, svc.MarkAllAsRead(ctx, "alice"))
+
+	ok, err := svc.HasUnreadOfTypes(ctx, "alice", []Type{TypeMention})
+	require.NoError(t, err)
+	assert.False(t, ok, "readMarker以降は該当typeがなくfalse")
+}

--- a/internal/repository/follow_request.go
+++ b/internal/repository/follow_request.go
@@ -13,6 +13,9 @@ type FollowRequestRepository interface {
 	Exists(followerID, followeeID string) (bool, error)
 	ListReceived(userID string, limit, offset int) ([]*model.FollowRequest, error)
 	ListSent(userID string, limit, offset int) ([]*model.FollowRequest, error)
+	// CountReceived returns the number of pending follow requests received by
+	// userID. Used by /api/i to compute hasPendingReceivedFollowRequest.
+	CountReceived(userID string) (int64, error)
 }
 
 type followRequestRepository struct {
@@ -60,6 +63,16 @@ func (r *followRequestRepository) ListReceived(userID string, limit, offset int)
 		return nil, err
 	}
 	return rows, nil
+}
+
+func (r *followRequestRepository) CountReceived(userID string) (int64, error) {
+	var count int64
+	if err := r.db.Model(&model.FollowRequest{}).
+		Where("\"followeeId\" = ?", userID).
+		Count(&count).Error; err != nil {
+		return 0, err
+	}
+	return count, nil
 }
 
 func (r *followRequestRepository) ListSent(userID string, limit, offset int) ([]*model.FollowRequest, error) {

--- a/internal/server/router.go
+++ b/internal/server/router.go
@@ -879,6 +879,12 @@ func (s *Server) setupRoutes() {
 	api.POST("/i/favorites", iHandler.Favorites, middleware.RequireAuth())
 	api.POST("/i/regenerate-token", iHandler.RegenerateToken, middleware.RequireAuth())
 	iHandler.SetFavoriteRepo(noteFavoriteRepo)
+	// Phase 7-2 (#244): /api/i の未読系フィールドを実クエリ化。
+	iHandler.SetNotificationService(notificationService)
+	iHandler.SetFollowRequestRepo(followRequestRepo)
+	iHandler.SetChatRepo(chatRepo)
+	// announcementRepoは後続で構築されるため SetupAdditional() 相当の順序依存があるが、
+	// 現状 announcementRepo := ... の行がここより後にあるため下で wire する。
 
 	// i/export-* and i/import-* (Phase 9.4)
 	iHandler.SetTransferEnqueuer(s.queueClient)
@@ -1292,6 +1298,8 @@ func (s *Server) setupRoutes() {
 
 	// Announcements (Phase 6)
 	announcementRepo := repository.NewAnnouncementRepository(s.db)
+	// Phase 7-2 (#244): /api/i の hasUnreadAnnouncement / unreadAnnouncements 配線
+	iHandler.SetAnnouncementRepo(announcementRepo)
 	announcementHandler := apiannouncements.NewHandler(announcementRepo, idGen)
 	api.POST("/announcements", announcementHandler.List)
 	api.POST("/i/read-announcement", announcementHandler.ReadAnnouncement, middleware.RequireAuth())

--- a/internal/testutil/mock_repository.go
+++ b/internal/testutil/mock_repository.go
@@ -3028,6 +3028,17 @@ func (m *MockFollowRequestRepository) ListSent(userID string, limit, offset int)
 	return paginateRequests(rows, limit, offset), nil
 }
 
+// CountReceived returns the number of pending requests addressed to userID.
+func (m *MockFollowRequestRepository) CountReceived(userID string) (int64, error) {
+	var n int64
+	for _, r := range m.Requests {
+		if r.FolloweeID == userID {
+			n++
+		}
+	}
+	return n, nil
+}
+
 func paginate(rows []*model.Following, limit, offset int) []*model.Following {
 	if offset >= len(rows) {
 		return nil


### PR DESCRIPTION
## Summary

#244 (Phase 7-2) として、`/api/i` レスポンスの MeDetailed 未読系フィールドが hardcoded `false`/`0`/`[]` になっていた問題を修正。TS本家互換の動的解決へ差し替え、UI 側の通知バッジ・未読表示が正しく点くようにする。

10 フィールド中 **7 フィールドを本 PR で実装**、残 3 (antenna / channel / specifiedNotes) は migration 追加等が必要なため **[#271](https://github.com/shiroha-a/mk/issues/271)** で分離追跡。

## 実装したフィールド (7)

| field | Before | After |
|---|---|---|
| `hasUnreadNotification` | `false` 固定 | `notificationService.UnreadCount > 0` |
| `unreadNotificationsCount` | `0` 固定 | `notificationService.UnreadCount` |
| `hasUnreadMentions` | `false` 固定 | `HasUnreadOfTypes(mention, reply)` |
| `hasPendingReceivedFollowRequest` | `false` 固定 | `followRequestRepo.CountReceived > 0` |
| `hasUnreadAnnouncement` | `false` 固定 | `announcementRepo.UnreadForUser` len > 0 |
| `unreadAnnouncements` | `[]` 固定 | announcement packed array |
| `hasUnreadChatMessages` | `false` 固定 | `chatRepo.CountUnread > 0` |

## 未実装 (別 issue)

| field | 理由 |
|---|---|
| `hasUnreadAntenna` | `antenna_note_unread` テーブルが未実装 (migration 必要) |
| `hasUnreadChannel` | `channel_note_unread` テーブルが未実装 |
| `hasUnreadSpecifiedNotes` | NotificationService + NoteRepo JOIN が必要 |

→ [#271](https://github.com/shiroha-a/mk/issues/271) で追跡。

## 主な変更点

### `internal/core/notification/notification_service.go`

新規メソッド 2 つ:

- `UnreadCount(ctx, userID) (int64, error)`
  - Redis Stream の `latestReadNotification` 以降を `XRevRangeN` でカウント
- `HasUnreadOfTypes(ctx, userID, types) (bool, error)`
  - 同 range を走査し、指定 Type に 1 件でもマッチすれば true

### `internal/repository/follow_request.go`

`CountReceived(userID) (int64, error)` を追加 (`followeeId = ?` カウント)。mock (`testutil/mock_repository.go`) も対応。

### `internal/api/i/handler.go`

- Handler に 4 つの optional setter を追加:
  - `SetNotificationService`
  - `SetFollowRequestRepo`
  - `SetAnnouncementRepo`
  - `SetChatRepo`
- `fillUnreadFields(ctx, u, resp)` ヘルパーで 10 フィールドを一括処理
  (未 wire フィールドは default に fallback、antenna/channel/specified の 3 つは default false 固定)
- 3 つの narrow local interface (`UnreadNotificationSource` / `AnnouncementUnreadSource` / `ChatUnreadSource`) で依存を受け、テスト時に core パッケージを import せずスタブ可能に

### `internal/server/router.go`

`iHandler` に `notificationService` / `followRequestRepo` / `chatRepo` / `announcementRepo` を wire。

## テスト

- `core/notification`: 5 ケース (no marker / marked / type match / no match / empty list)
- `api/i`: 7 ケース (各 field の populated / zero / empty / defaults 確認)
- すべて既存テストと 100% 互換 (新依存が未設定ならスキップ fallback)

## 検証

\`\`\`
$ make fmt && make lint
# 通過
$ (set -o pipefail; go test ./... -race -count=1 ...)
exit 0
All packages meet coverage thresholds
\`\`\`

## Closes

Partially closes #244 (7 / 10 フィールド)。残 3 は #271。

## 関連

- Parent: #242 Phase 7
- Follow-up: #271

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/shiroha-a/mk/pull/272" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
