### PR TITLE
Phase 7-5a UserLite に optional フィールド 4 種を追加

### DIFF
--- a/internal/entity/user.go
+++ b/internal/entity/user.go
@@ -7,6 +7,9 @@ import (
 )
 
 // UserLite is the minimal user representation returned by most API endpoints.
+// Phase 7-5a (#247): requireSigninToViewContents / makeNotes*Before / instance
+// を optional フィールドとして TS 本家互換に追加。すべて omitempty で、値が
+// 無いときはレスポンスから省かれる (TS: `?? undefined` / `?: undefined`)。
 type UserLite struct {
 	ID                string            `json:"id"`
 	Name              *string           `json:"name"`
@@ -20,6 +23,14 @@ type UserLite struct {
 	Emojis            map[string]string `json:"emojis"`
 	OnlineStatus      string            `json:"onlineStatus"`
 	BadgeRoles        []any             `json:"badgeRoles"`
+	// Optional TS-compat fields (Phase 7-5a)。
+	// TS側は `requireSigninToViewContents: user.x === false ? undefined : true`
+	// なので、値が true のときのみ expose する (*bool を &true に設定、
+	// false は nil のまま)。
+	RequireSigninToViewContents  *bool         `json:"requireSigninToViewContents,omitempty"`
+	MakeNotesFollowersOnlyBefore *int          `json:"makeNotesFollowersOnlyBefore,omitempty"`
+	MakeNotesHiddenBefore        *int          `json:"makeNotesHiddenBefore,omitempty"`
+	Instance                     *InstanceLite `json:"instance,omitempty"`
 }
 
 // UserDetailed includes additional fields for detailed user views.
@@ -50,7 +61,6 @@ type UserDetailed struct {
 	PinnedNoteIDs       []string       `json:"pinnedNoteIds"`
 	PinnedNotes         []any          `json:"pinnedNotes"`
 	Roles               []any          `json:"roles"`
-	Instance            *InstanceLite  `json:"instance,omitempty"`
 	// viewer依存フィールド (ハンドラ側でセット)
 	IsFollowing                    *bool   `json:"isFollowing"`
 	IsFollowed                     *bool   `json:"isFollowed"`
@@ -76,6 +86,9 @@ type InstanceLite struct {
 }
 
 // PackUserLite converts a model.User to a UserLite DTO.
+// Instance (nested remote instance info) は caller 側で InstanceRepository
+// 等を使って pre-fetch し、結果を UserLite.Instance に設定する。PackUserLite
+// 自体は DB アクセスを発生させない (hot path想定)。
 func PackUserLite(u *model.User) UserLite {
 	avatarURL := u.AvatarURL
 	// avatarUrlがnullの場合、identiconを生成
@@ -87,7 +100,7 @@ func PackUserLite(u *model.User) UserLite {
 		identicon := "/identicon/" + u.Username + host
 		avatarURL = &identicon
 	}
-	return UserLite{
+	out := UserLite{
 		ID:                u.ID,
 		Name:              u.Name,
 		Username:          u.Username,
@@ -101,6 +114,19 @@ func PackUserLite(u *model.User) UserLite {
 		OnlineStatus:      "unknown",
 		BadgeRoles:        []any{},
 	}
+	// requireSigninToViewContents: true のときだけ出す (TS は false→undefined)
+	if u.RequireSigninToViewContents {
+		tr := true
+		out.RequireSigninToViewContents = &tr
+	}
+	// makeNotes*Before: 設定値があればそのまま出す (nil→omit)
+	if u.MakeNotesFollowersOnlyBefore != nil {
+		out.MakeNotesFollowersOnlyBefore = u.MakeNotesFollowersOnlyBefore
+	}
+	if u.MakeNotesHiddenBefore != nil {
+		out.MakeNotesHiddenBefore = u.MakeNotesHiddenBefore
+	}
+	return out
 }
 
 // PackUserDetailed converts a model.User and optional profile to UserDetailed.

--- a/internal/entity/user.go
+++ b/internal/entity/user.go
@@ -7,9 +7,9 @@ import (
 )
 
 // UserLite is the minimal user representation returned by most API endpoints.
-// Phase 7-5a (#247): requireSigninToViewContents / makeNotes*Before / instance
-// を optional フィールドとして TS 本家互換に追加。すべて omitempty で、値が
-// 無いときはレスポンスから省かれる (TS: `?? undefined` / `?: undefined`)。
+// Phase 7-5a (#247) added requireSigninToViewContents, makeNotes*Before and
+// instance as optional TS-compat fields. All use omitempty so absent values
+// are elided from the response (TS: `?? undefined` / `?: undefined`).
 type UserLite struct {
 	ID                string            `json:"id"`
 	Name              *string           `json:"name"`
@@ -75,7 +75,9 @@ type UserDetailed struct {
 	Memo                           *string `json:"memo,omitempty"`
 }
 
-// InstanceLite is the minimal instance info embedded in UserDetailed for remote users.
+// InstanceLite is the minimal instance info embedded in UserLite for remote
+// users. Populated by the caller from InstanceRepository when needed; packers
+// keep it nil to avoid DB access on hot paths.
 type InstanceLite struct {
 	Name            *string `json:"name"`
 	SoftwareName    *string `json:"softwareName"`
@@ -86,9 +88,10 @@ type InstanceLite struct {
 }
 
 // PackUserLite converts a model.User to a UserLite DTO.
-// Instance (nested remote instance info) は caller 側で InstanceRepository
-// 等を使って pre-fetch し、結果を UserLite.Instance に設定する。PackUserLite
-// 自体は DB アクセスを発生させない (hot path想定)。
+// Instance (nested remote instance info) must be pre-fetched by the caller
+// via InstanceRepository and assigned to the returned UserLite.Instance.
+// PackUserLite itself performs no DB access (designed for hot paths such as
+// timeline packing).
 func PackUserLite(u *model.User) UserLite {
 	avatarURL := u.AvatarURL
 	// avatarUrlがnullの場合、identiconを生成

--- a/internal/entity/user_test.go
+++ b/internal/entity/user_test.go
@@ -231,18 +231,21 @@ func TestPackUserLite_RequireSigninToViewContents_FalseOmitted(t *testing.T) {
 }
 
 func TestPackUserLite_MakeNotesBefore(t *testing.T) {
-	followersMs := 1234567890000
-	hiddenMs := 999999999
+	// makeNotes*Before は integer カラム (TS MiUser.ts:208) で「秒単位、
+	// マイナスで相対時間」と定義されている。int32 (~2.1B) 範囲内の値を使う
+	// こと (ms timestamp 等の大きい値は DB round-trip で overflow する)。
+	followersSec := 1700000000 // 2023-11-14T22:13:20Z 相当の UNIX 秒
+	hiddenRelSec := -86400     // 過去 1 日 (相対時間の例)
 	u := &model.User{
 		ID: "u1", Username: "x", AvatarDecorations: datatypes.JSON([]byte("[]")),
-		MakeNotesFollowersOnlyBefore: &followersMs,
-		MakeNotesHiddenBefore:        &hiddenMs,
+		MakeNotesFollowersOnlyBefore: &followersSec,
+		MakeNotesHiddenBefore:        &hiddenRelSec,
 	}
 	lite := PackUserLite(u)
 	require.NotNil(t, lite.MakeNotesFollowersOnlyBefore)
-	assert.Equal(t, 1234567890000, *lite.MakeNotesFollowersOnlyBefore)
+	assert.Equal(t, 1700000000, *lite.MakeNotesFollowersOnlyBefore)
 	require.NotNil(t, lite.MakeNotesHiddenBefore)
-	assert.Equal(t, 999999999, *lite.MakeNotesHiddenBefore)
+	assert.Equal(t, -86400, *lite.MakeNotesHiddenBefore)
 }
 
 func TestPackUserLite_MakeNotesBefore_NilOmitted(t *testing.T) {

--- a/internal/entity/user_test.go
+++ b/internal/entity/user_test.go
@@ -1,6 +1,7 @@
 package entity
 
 import (
+	"encoding/json"
 	"testing"
 
 	"github.com/lib/pq"
@@ -200,4 +201,109 @@ func TestPackUserDetailed_NilProfile(t *testing.T) {
 	assert.Nil(t, detailed.Location)
 	assert.Nil(t, detailed.Birthday)
 	assert.Nil(t, detailed.Lang)
+}
+
+// --- Phase 7-5a (#247): UserLite 追加 optional フィールド ---
+
+func TestPackUserLite_RequireSigninToViewContents_TrueExposed(t *testing.T) {
+	u := &model.User{
+		ID: "u1", Username: "x", AvatarDecorations: datatypes.JSON([]byte("[]")),
+		RequireSigninToViewContents: true,
+	}
+	lite := PackUserLite(u)
+	require.NotNil(t, lite.RequireSigninToViewContents)
+	assert.Equal(t, true, *lite.RequireSigninToViewContents)
+}
+
+func TestPackUserLite_RequireSigninToViewContents_FalseOmitted(t *testing.T) {
+	u := &model.User{
+		ID: "u1", Username: "x", AvatarDecorations: datatypes.JSON([]byte("[]")),
+		RequireSigninToViewContents: false,
+	}
+	lite := PackUserLite(u)
+	// false → nil (TS で undefined、JSONはomit)
+	assert.Nil(t, lite.RequireSigninToViewContents)
+
+	// JSONマーシャル結果でもキーが出ないこと
+	b, err := json.Marshal(lite)
+	require.NoError(t, err)
+	assert.NotContains(t, string(b), "requireSigninToViewContents")
+}
+
+func TestPackUserLite_MakeNotesBefore(t *testing.T) {
+	followersMs := 1234567890000
+	hiddenMs := 999999999
+	u := &model.User{
+		ID: "u1", Username: "x", AvatarDecorations: datatypes.JSON([]byte("[]")),
+		MakeNotesFollowersOnlyBefore: &followersMs,
+		MakeNotesHiddenBefore:        &hiddenMs,
+	}
+	lite := PackUserLite(u)
+	require.NotNil(t, lite.MakeNotesFollowersOnlyBefore)
+	assert.Equal(t, 1234567890000, *lite.MakeNotesFollowersOnlyBefore)
+	require.NotNil(t, lite.MakeNotesHiddenBefore)
+	assert.Equal(t, 999999999, *lite.MakeNotesHiddenBefore)
+}
+
+func TestPackUserLite_MakeNotesBefore_NilOmitted(t *testing.T) {
+	u := &model.User{
+		ID: "u1", Username: "x", AvatarDecorations: datatypes.JSON([]byte("[]")),
+		// MakeNotes*Before は nil
+	}
+	lite := PackUserLite(u)
+	assert.Nil(t, lite.MakeNotesFollowersOnlyBefore)
+	assert.Nil(t, lite.MakeNotesHiddenBefore)
+
+	b, err := json.Marshal(lite)
+	require.NoError(t, err)
+	assert.NotContains(t, string(b), "makeNotesFollowersOnlyBefore")
+	assert.NotContains(t, string(b), "makeNotesHiddenBefore")
+}
+
+func TestPackUserLite_Instance_NilByDefault(t *testing.T) {
+	u := &model.User{
+		ID: "u1", Username: "x", AvatarDecorations: datatypes.JSON([]byte("[]")),
+	}
+	lite := PackUserLite(u)
+	// PackUserLite 自体は Instance を設定しない (caller がpre-fetchしてセット)
+	assert.Nil(t, lite.Instance)
+
+	b, err := json.Marshal(lite)
+	require.NoError(t, err)
+	assert.NotContains(t, string(b), "\"instance\"")
+}
+
+func TestUserLite_Instance_WhenSet(t *testing.T) {
+	u := &model.User{
+		ID: "u1", Username: "x", AvatarDecorations: datatypes.JSON([]byte("[]")),
+	}
+	lite := PackUserLite(u)
+	name := "example.com"
+	iconURL := "https://example.com/icon.png"
+	lite.Instance = &InstanceLite{Name: &name, IconURL: &iconURL}
+
+	b, err := json.Marshal(lite)
+	require.NoError(t, err)
+	assert.Contains(t, string(b), "\"instance\"")
+	assert.Contains(t, string(b), "example.com")
+}
+
+// UserDetailed は UserLite を埋め込むため、Instance 等もそこに含まれる
+// ことを確認する (移動に伴う regression guard)。
+func TestUserDetailed_EmbedsUserLiteOptionalFields(t *testing.T) {
+	req := true
+	u := &model.User{
+		ID: "u1", Username: "x", AvatarDecorations: datatypes.JSON([]byte("[]")),
+		RequireSigninToViewContents: req,
+	}
+	detailed := PackUserDetailed(u, nil)
+	require.NotNil(t, detailed.RequireSigninToViewContents)
+	assert.True(t, *detailed.RequireSigninToViewContents)
+
+	// Instance 設定も embed 経由で動く
+	host := "remote.example"
+	detailed.Instance = &InstanceLite{Name: &host}
+	b, err := json.Marshal(detailed)
+	require.NoError(t, err)
+	assert.Contains(t, string(b), "\"instance\"")
 }


### PR DESCRIPTION
## Summary

TS 本家 `packedUserLiteSchema` に合わせて UserLite に 4 つの optional フィールドを追加。Instance は従来 UserDetailed にあったのを UserLite に移動 (embed なので UserDetailed の JSON 形は不変)。

## 追加フィールド

| field | TS semantics | Go impl |
|---|---|---|
| `requireSigninToViewContents` | `false → undefined`、`true` のみ expose | `*bool` + `omitempty`。`user.X == true` のときだけ `&true` |
| `makeNotesFollowersOnlyBefore` | `nil → undefined`、値があれば expose | `*int` + `omitempty` (model が既に `*int`) |
| `makeNotesHiddenBefore` | 同上 | 同上 |
| `instance` | remote 時のみ nested object (optional) | `*InstanceLite` + `omitempty`、caller 設定 |

## 主な変更点

### `internal/entity/user.go`

- `UserLite` 構造体に 4 フィールド追加 (すべて `omitempty`)
- `PackUserLite` で下記 3 つを populate:
  - `requireSigninToViewContents`: true のときだけ `*bool` に設定
  - `makeNotesFollowersOnlyBefore` / `makeNotesHiddenBefore`: model の `*int` をそのまま渡す
  - `instance`: PackUserLite 内では設定しない (hot path で DB アクセス発生させないため、caller で pre-fetch 設定)
- `UserDetailed` から重複 `Instance` フィールドを削除 (`UserLite` の embed で継承)

### DB スキーマ

変更なし。`user` テーブルには既に `requireSigninToViewContents` / `makeNotesFollowersOnlyBefore` / `makeNotesHiddenBefore` カラムが存在する (`migration/000001_initial.up.sql:51-53`)、`model.User` にもフィールドあり。

### Instance の取扱い

- Packing は純関数で DB access なしが望ましい (timeline / reactions 等の hot path で大量呼出し)
- TS 本家も `instance` は Promise (async fetch) なので、Go の caller 側設定パターンと親和性が高い
- 既存の `internal/api/users/handler.go:188` の `detailed.Instance = &entity.InstanceLite{...}` は embed 経由で **変更不要で動き続ける**
- UserLite 単独 path (timelines など) で Instance が nil のまま → `omitempty` で JSON から消える → TS の optional schema に合致

## テスト (7 新ケース)

- `requireSigninToViewContents`: true expose / false omit + JSON key 不在確認
- `makeNotes*Before`: 値入り / nil omit + JSON key 不在確認
- `Instance`: default nil / 手動設定時の JSON 反映
- `UserDetailed` 経由で embed された optional フィールドの動作確認 (regression guard)

## 検証

\`\`\`
$ make fmt && make lint
# 通過
$ go test ./internal/entity/...
ok
$ CI simulation: test exit=0 + All packages meet coverage thresholds
\`\`\`

## Closes

Closes #247

## 関連

- Parent: #242 Phase 7 TS フロント互換性ギャップ修正

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/shiroha-a/mk/pull/275" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
