### PR TITLE
Fix #284: pages.NewHandler で idGen を constructor 引数化

### DIFF
--- a/internal/api/pages/handler.go
+++ b/internal/api/pages/handler.go
@@ -21,15 +21,10 @@ type Handler struct {
 	idGen id.Generator
 }
 
-// NewHandler creates a new pages Handler.
-func NewHandler(svc *corepage.Service) *Handler {
-	return &Handler{svc: svc}
-}
-
-// SetIDGen attaches an ID generator so responses include createdAt derived
-// from the aidx-encoded page ID.
-func (h *Handler) SetIDGen(g id.Generator) {
-	h.idGen = g
+// NewHandler creates a new pages Handler. idGen is required so that
+// responses include createdAt derived from the aidx-encoded page ID.
+func NewHandler(svc *corepage.Service, idGen id.Generator) *Handler {
+	return &Handler{svc: svc, idGen: idGen}
 }
 
 // CreateRequest is the request body for pages/create. Content / Variables

--- a/internal/api/pages/handler_test.go
+++ b/internal/api/pages/handler_test.go
@@ -24,11 +24,7 @@ func newHandler(t *testing.T) (*Handler, *testutil.MockPageRepository, *testutil
 	likeRepo := testutil.NewMockPageLikeRepository()
 	idGen, _ := id.NewGenerator("aidx")
 	svc := corepage.NewService(repo, likeRepo, idGen)
-	h := NewHandler(svc)
-	// 実ハンドラと同様に idGen を wiring して entity.PackPage の createdAt パスが
-	// テストでも走るようにする。
-	h.SetIDGen(idGen)
-	return h, repo, likeRepo
+	return NewHandler(svc, idGen), repo, likeRepo
 }
 
 func newReq(t *testing.T, body string) (echo.Context, *httptest.ResponseRecorder) {
@@ -100,7 +96,7 @@ func TestCreate_RepoError(t *testing.T) {
 	repo := &failingPageRepo{MockPageRepository: mock}
 	idGen, _ := id.NewGenerator("aidx")
 	svc := corepage.NewService(repo, testutil.NewMockPageLikeRepository(), idGen)
-	h := NewHandler(svc)
+	h := NewHandler(svc, idGen)
 	c, rec := newReq(t, `{"title":"t","name":"alpha"}`)
 	setUser(c, "alice")
 	require.NoError(t, h.Create(c))
@@ -231,7 +227,7 @@ func TestUpdate_RepoError(t *testing.T) {
 	repo := &failingUpdateRepo{MockPageRepository: mock}
 	idGen, _ := id.NewGenerator("aidx")
 	svc := corepage.NewService(repo, testutil.NewMockPageLikeRepository(), idGen)
-	h := NewHandler(svc)
+	h := NewHandler(svc, idGen)
 	c, rec := newReq(t, `{"pageId":"p1","title":"x"}`)
 	setUser(c, "alice")
 	require.NoError(t, h.Update(c))
@@ -287,7 +283,7 @@ func TestDelete_RepoError(t *testing.T) {
 	repo := &failingDeleteRepo{MockPageRepository: mock}
 	idGen, _ := id.NewGenerator("aidx")
 	svc := corepage.NewService(repo, testutil.NewMockPageLikeRepository(), idGen)
-	h := NewHandler(svc)
+	h := NewHandler(svc, idGen)
 	c, rec := newReq(t, `{"pageId":"p1"}`)
 	setUser(c, "alice")
 	require.NoError(t, h.Delete(c))
@@ -327,7 +323,7 @@ func TestMy_RepoError(t *testing.T) {
 	repo := &listFailRepo{MockPageRepository: testutil.NewMockPageRepository()}
 	idGen, _ := id.NewGenerator("aidx")
 	svc := corepage.NewService(repo, testutil.NewMockPageLikeRepository(), idGen)
-	h := NewHandler(svc)
+	h := NewHandler(svc, idGen)
 	c, rec := newReq(t, `{}`)
 	setUser(c, "alice")
 	require.NoError(t, h.My(c))
@@ -364,7 +360,7 @@ func TestFeatured_RepoError(t *testing.T) {
 	repo := &featuredFailRepo{MockPageRepository: testutil.NewMockPageRepository()}
 	idGen, _ := id.NewGenerator("aidx")
 	svc := corepage.NewService(repo, testutil.NewMockPageLikeRepository(), idGen)
-	h := NewHandler(svc)
+	h := NewHandler(svc, idGen)
 	c, rec := newReq(t, `{}`)
 	require.NoError(t, h.Featured(c))
 	assert.Equal(t, http.StatusInternalServerError, rec.Code)
@@ -433,7 +429,7 @@ func TestLike_RepoError(t *testing.T) {
 	likeRepo := &failingCreateLikeRepo{MockPageLikeRepository: testutil.NewMockPageLikeRepository()}
 	idGen, _ := id.NewGenerator("aidx")
 	svc := corepage.NewService(repo, likeRepo, idGen)
-	h := NewHandler(svc)
+	h := NewHandler(svc, idGen)
 	c, rec := newReq(t, `{"pageId":"p1"}`)
 	setUser(c, "bob")
 	require.NoError(t, h.Like(c))
@@ -496,7 +492,7 @@ func TestUnlike_RepoError(t *testing.T) {
 	likeRepo := &failingDeleteLikeRepo{MockPageLikeRepository: mock}
 	idGen, _ := id.NewGenerator("aidx")
 	svc := corepage.NewService(repo, likeRepo, idGen)
-	h := NewHandler(svc)
+	h := NewHandler(svc, idGen)
 	c, rec := newReq(t, `{"pageId":"p1"}`)
 	setUser(c, "bob")
 	require.NoError(t, h.Unlike(c))

--- a/internal/server/router.go
+++ b/internal/server/router.go
@@ -1160,8 +1160,7 @@ func (s *Server) setupRoutes() {
 	api.POST("/clips/notes", clipsHandler.Notes)
 
 	// Pages endpoints (Phase 4.5)
-	pagesHandler := pages.NewHandler(pageService)
-	pagesHandler.SetIDGen(idGen)
+	pagesHandler := pages.NewHandler(pageService, idGen)
 	api.POST("/pages/create", pagesHandler.Create, middleware.RequireAuth())
 	api.POST("/pages/show", pagesHandler.Show)
 	api.POST("/pages/update", pagesHandler.Update, middleware.RequireAuth())


### PR DESCRIPTION
## Summary

PR #279 (Phase 7-3) の Devin Review で指摘された構造改善を反映。`pages.NewHandler` を他の handler (drive/chat/sw/userlists 等) と同じ constructor-injection パターンに揃える。

## 主な変更点

- `pages.NewHandler` のシグネチャを `NewHandler(svc, idGen)` に変更 (idGen 必須化)
- `SetIDGen` セッターを削除
- `internal/server/router.go`: `pages.NewHandler(pageService, idGen)` に統一、別呼び出しの `pagesHandler.SetIDGen(idGen)` を削除
- `internal/api/pages/handler_test.go`: 全 `NewHandler(svc)` 呼び出し (ヘルパー1箇所 + 個別テスト7箇所) を `NewHandler(svc, idGen)` に更新

## 動機

変更前は `router.go` で `SetIDGen` を呼び忘れた場合、`h.idGen` が nil のままで `entity.PackPage` が nil-check により `createdAt` を silent に省略する状態になる。constructor 必須化でこの silent failure path を構造的に排除。

## テスト

- `make fmt && go vet ./...` 通過
- `go test -cover ./internal/api/pages/...` → **100% 通過**
- `go test ./...` 全体通過

### 実行コマンド

```bash
make fmt && go vet ./... && go test ./...
```

## Closes

Closes #284

## その他

PR #279 (merge済) の Devin Review follow-up issue。
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/shiroha-a/mk/pull/285" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
