### PR TITLE
Fix #286: roles.NewHandler で idGen を constructor 引数化

### DIFF
--- a/internal/api/roles/handler.go
+++ b/internal/api/roles/handler.go
@@ -23,19 +23,15 @@ type Handler struct {
 	idGen       id.Generator
 }
 
-// NewHandler creates a new roles Handler.
-func NewHandler(roleService *role.Service) *Handler {
-	return &Handler{roleService: roleService}
+// NewHandler creates a new roles Handler. idGen is required for note packing
+// under /api/roles/notes.
+func NewHandler(roleService *role.Service, idGen id.Generator) *Handler {
+	return &Handler{roleService: roleService, idGen: idGen}
 }
 
 // SetNotesQuery attaches a RoleNotesQuery for the roles/notes endpoint.
 func (h *Handler) SetNotesQuery(q RoleNotesQuery) {
 	h.notesQuery = q
-}
-
-// SetIDGen attaches an ID generator for note packing.
-func (h *Handler) SetIDGen(g id.Generator) {
-	h.idGen = g
 }
 
 // List handles POST /api/roles/list.

--- a/internal/api/roles/handler_test.go
+++ b/internal/api/roles/handler_test.go
@@ -42,8 +42,7 @@ func newTestHandler(t *testing.T) (*roles.Handler, *testutil.MockRoleRepository)
 	metaRepo.Meta = &model.Meta{ID: "x"}
 	idGen, _ := id.NewGenerator("aidx")
 	svc := corerole.NewService(roleRepo, assignRepo, metaRepo, idGen)
-	h := roles.NewHandler(svc)
-	h.SetIDGen(idGen)
+	h := roles.NewHandler(svc, idGen)
 	return h, roleRepo
 }
 
@@ -128,7 +127,7 @@ func TestList_Error(t *testing.T) {
 	metaRepo.Meta = &model.Meta{ID: "x"}
 	idGen, _ := id.NewGenerator("aidx")
 	svc := corerole.NewService(roleRepo, assignRepo, metaRepo, idGen)
-	h := roles.NewHandler(svc)
+	h := roles.NewHandler(svc, idGen)
 	rec := doPost(h.List, `{}`)
 	assert.Equal(t, http.StatusInternalServerError, rec.Code)
 }

--- a/internal/server/router.go
+++ b/internal/server/router.go
@@ -1294,9 +1294,8 @@ func (s *Server) setupRoutes() {
 	// federation の残ルートは上で登録済 (federationHandler 初期化直後)
 
 	// Public roles (Phase 6)
-	rolesHandler := apiroles.NewHandler(roleService)
+	rolesHandler := apiroles.NewHandler(roleService, idGen)
 	rolesHandler.SetNotesQuery(repository.NewRoleNotesQuery(s.db))
-	rolesHandler.SetIDGen(idGen)
 	api.POST("/roles/list", rolesHandler.List)
 	api.POST("/roles/show", rolesHandler.Show)
 	api.POST("/roles/users", rolesHandler.Users)


### PR DESCRIPTION
## Summary

#284 (PR #285) と同様に、`roles.NewHandler` を constructor-injection パターンに揃える。Devin Review で指摘された一貫性改善。

## 主な変更点

- `roles.NewHandler` のシグネチャを `NewHandler(roleService, idGen)` に変更 (idGen 必須化)
- `SetIDGen` セッターを削除
- `internal/server/router.go`: `apiroles.NewHandler(roleService, idGen)` に統一、別呼び出しの `rolesHandler.SetIDGen(idGen)` を削除
- `internal/api/roles/handler_test.go`: 2箇所の `NewHandler(svc)` 呼び出しを更新、ヘルパー内の `h.SetIDGen(idGen)` を削除

## 動機

`SetIDGen` 呼び忘れで `h.idGen` が nil のまま `/api/roles/notes` が note packing に入ると panic する silent failure path を構造的に排除。pages/drive/chat/sw/userlists 等と同じ constructor-injection パターンに統一。

## テスト

- `make fmt && go vet ./...` 通過
- `go test -cover ./internal/api/roles/...` → **100% 通過**
- `go test ./...` 全体通過

### 実行コマンド

```bash
make fmt && go vet ./... && go test ./...
```

## Closes

Closes #286

## その他

PR #285 (#284 対応) の Devin Review follow-up。
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/shiroha-a/mk/pull/287" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
