### PR TITLE
Phase 7-4: WebSocket 未発行イベントの追加 (receiveFollowRequest)

### DIFF
--- a/internal/core/following/following_service.go
+++ b/internal/core/following/following_service.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"time"
 
+	"github.com/shiroha-a/mk/internal/entity"
 	"github.com/shiroha-a/mk/internal/misc/id"
 	"github.com/shiroha-a/mk/internal/model"
 	"github.com/shiroha-a/mk/internal/repository"
@@ -78,17 +79,26 @@ type WebhookHook interface {
 	OnFollowed(follower, followee *model.User)
 }
 
+// MainStreamPublisher emits real-time events to a single target user's `main`
+// WebSocket channel. Used here to deliver `receiveFollowRequest` to the
+// followee when a locked user receives a follow request. 循環依存を避けるため
+// interface で受け取る (実装は internal/stream)。
+type MainStreamPublisher interface {
+	PublishMainEvent(userID, eventType string, body any)
+}
+
 // Service manages following relationships and follow requests.
 type Service struct {
-	userRepo          repository.UserRepository
-	followingRepo     repository.FollowingRepository
-	followRequestRepo repository.FollowRequestRepository
-	idGen             id.Generator
-	notificationHook  NotificationHook
-	blockingChecker   BlockingChecker
-	federationHook    FederationHook
-	chartHook         ChartHook
-	webhookHook       WebhookHook
+	userRepo            repository.UserRepository
+	followingRepo       repository.FollowingRepository
+	followRequestRepo   repository.FollowRequestRepository
+	idGen               id.Generator
+	notificationHook    NotificationHook
+	blockingChecker     BlockingChecker
+	federationHook      FederationHook
+	chartHook           ChartHook
+	webhookHook         WebhookHook
+	mainStreamPublisher MainStreamPublisher
 }
 
 // NewService creates a new following Service.
@@ -131,6 +141,12 @@ func (s *Service) SetChartHook(h ChartHook) {
 // follow-accepted events so user webhooks subscribed to follow events fire.
 func (s *Service) SetWebhookHook(h WebhookHook) {
 	s.webhookHook = h
+}
+
+// SetMainStreamPublisher attaches a publisher used to emit `main` channel
+// events (currently `receiveFollowRequest`). Optional — nil disables emit.
+func (s *Service) SetMainStreamPublisher(p MainStreamPublisher) {
+	s.mainStreamPublisher = p
 }
 
 // Follow creates a following relationship from follower to followee.
@@ -195,6 +211,14 @@ func (s *Service) Follow(followerID, followeeID string) (*FollowResult, error) {
 		}
 		if s.notificationHook != nil {
 			s.notificationHook.OnFollowRequested(followerID, followeeID)
+		}
+		// TS本家: UserFollowingService は `receiveFollowRequest` を
+		// followee の main stream に publish する。body は follower User。
+		// UserLite で送るのは他のWSイベント (notification内のuser等) と
+		// 揃える意図。Instance情報は PackUserLite に含まれないが、
+		// frontend は undefined 許容。
+		if s.mainStreamPublisher != nil {
+			s.mainStreamPublisher.PublishMainEvent(followeeID, "receiveFollowRequest", entity.PackUserLite(follower))
 		}
 		return &FollowResult{Request: req}, nil
 	}

--- a/internal/core/following/following_service_test.go
+++ b/internal/core/following/following_service_test.go
@@ -1,6 +1,7 @@
 package following_test
 
 import (
+	"encoding/json"
 	"errors"
 	"testing"
 
@@ -146,6 +147,57 @@ func TestFollow_LockedUser_CreatesRequest(t *testing.T) {
 	// counterは更新されない
 	assert.Equal(t, 0, userRepo.Users["alice"].FollowingCount)
 	assert.Equal(t, 0, userRepo.Users["bob"].FollowersCount)
+}
+
+// stubMainStreamPublisher captures PublishMainEvent calls for assertion.
+type stubMainStreamPublisher struct {
+	calls []mainEventCall
+}
+
+type mainEventCall struct {
+	userID    string
+	eventType string
+	body      any
+}
+
+func (s *stubMainStreamPublisher) PublishMainEvent(userID, eventType string, body any) {
+	s.calls = append(s.calls, mainEventCall{userID, eventType, body})
+}
+
+func TestFollow_LockedUser_PublishesReceiveFollowRequest(t *testing.T) {
+	svc, userRepo, _, _ := newSvc(t)
+	addUser(t, userRepo, "alice", false)
+	addUser(t, userRepo, "bob", true)
+	pub := &stubMainStreamPublisher{}
+	svc.SetMainStreamPublisher(pub)
+
+	_, err := svc.Follow("alice", "bob")
+	require.NoError(t, err)
+
+	require.Len(t, pub.calls, 1)
+	assert.Equal(t, "bob", pub.calls[0].userID)
+	assert.Equal(t, "receiveFollowRequest", pub.calls[0].eventType)
+	// body は PackUserLite(follower=alice) で、最低限 id/username が詰まっている
+	// ことを JSON round-trip で確認する (UserLite は struct なので直接 map
+	// assertion はできない)。
+	raw, err := json.Marshal(pub.calls[0].body)
+	require.NoError(t, err)
+	var m map[string]any
+	require.NoError(t, json.Unmarshal(raw, &m))
+	assert.Equal(t, "alice", m["id"])
+	assert.Equal(t, "alice", m["username"])
+}
+
+func TestFollow_PublicUser_DoesNotPublishReceiveFollowRequest(t *testing.T) {
+	svc, userRepo, _, _ := newSvc(t)
+	addUser(t, userRepo, "alice", false)
+	addUser(t, userRepo, "bob", false)
+	pub := &stubMainStreamPublisher{}
+	svc.SetMainStreamPublisher(pub)
+
+	_, err := svc.Follow("alice", "bob")
+	require.NoError(t, err)
+	assert.Empty(t, pub.calls)
 }
 
 func TestFollow_SelfFollow(t *testing.T) {

--- a/internal/core/reversi/service_wire_test.go
+++ b/internal/core/reversi/service_wire_test.go
@@ -156,6 +156,28 @@ func TestService_UpdateReady_Both_TriggersStart(t *testing.T) {
 	assert.Contains(t, kinds, "started")
 }
 
+// TS本家 reversiGame.changeReadyStates の body shape は
+// `{ user1: boolean; user2: boolean }`。Go 側の emit がそのまま一致して
+// いることを確認する (Phase 7-4 疎通検証)。
+func TestService_UpdateReady_ChangeReadyStatesBodyShape(t *testing.T) {
+	game, _, pub, svc := newPendingGame(t)
+	ctx := context.Background()
+
+	require.NoError(t, svc.UpdateReady(ctx, game.ID, "alice", true))
+
+	// 最初の event が changeReadyStates で body が期待形式であることを確認。
+	require.GreaterOrEqual(t, len(pub.events), 1)
+	first := pub.events[0]
+	assert.Equal(t, "g1", first.gameID)
+	assert.Equal(t, "changeReadyStates", first.kind)
+	body, ok := first.body.(map[string]any)
+	require.True(t, ok, "body should be map")
+	assert.Equal(t, true, body["user1"])
+	assert.Equal(t, false, body["user2"])
+	// TS 型にない余計なキーが混入していないこと。
+	assert.Len(t, body, 2)
+}
+
 func TestService_UpdateReady_NotPlayer(t *testing.T) {
 	game, _, _, svc := newPendingGame(t)
 	err := svc.UpdateReady(context.Background(), game.ID, "carol", true)

--- a/internal/server/router.go
+++ b/internal/server/router.go
@@ -1216,12 +1216,14 @@ func (s *Server) setupRoutes() {
 	notificationPublisher := stream.NewNotificationPublisher(streamPubSub)
 	drivePublisher := stream.NewDrivePublisher(streamPubSub)
 	reversiPublisher := stream.NewReversiGamePublisher(streamPubSub)
+	mainStreamPublisher := stream.NewMainStreamPublisher(streamPubSub)
 
 	// 4. 既存サービスへ publisher を注入する。これらはいずれも nil 安全な
 	//    setter で、未設定なら何もしない (テスト互換)。
 	timelineFanoutHook.SetStreamingPublisher(notePublisher)
 	notificationService.SetStreamingPublisher(notificationPublisher)
 	driveService.SetStreamingPublisher(drivePublisher)
+	followingService.SetMainStreamPublisher(mainStreamPublisher)
 
 	// 5. Reversi WebSocket channel (Phase 9.6) を登録する
 	reversiService := corereversi.NewService(reversiRepo, reversiPublisher, s.redis.Default)

--- a/internal/stream/dispatcher_test.go
+++ b/internal/stream/dispatcher_test.go
@@ -795,6 +795,80 @@ func TestDispatcher_SubNote_InvalidBody(t *testing.T) {
 	d.HandleClientMessage("un", json.RawMessage(`{}`))
 }
 
+// TS互換性検証: forwardNoteEvent は noteStream:{id} に届いた
+// {type, body} envelope を、クライアントに `{type: "noteUpdated",
+// body: {id, type, body}}` という外殻で送信する必要がある (TS
+// NoteUpdatedEvent discriminated union)。各 subtype (reacted /
+// unreacted / deleted / pollVoted) で形状が維持されることを確認する。
+func TestDispatcher_ForwardNoteEvent_TSEnvelope(t *testing.T) {
+	cases := []struct {
+		name   string
+		inner  string
+		evType string
+	}{
+		{"reacted", `{"type":"reacted","body":{"reaction":":smile:","userId":"u1"}}`, "reacted"},
+		{"unreacted", `{"type":"unreacted","body":{"reaction":":smile:","userId":"u1"}}`, "unreacted"},
+		{"deleted", `{"type":"deleted","body":{"deletedAt":"2026-04-19T00:00:00.000Z"}}`, "deleted"},
+		{"pollVoted", `{"type":"pollVoted","body":{"choice":1,"userId":"u1"}}`, "pollVoted"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			fc := newFakeConn()
+			conn := NewConnection("test", &model.User{ID: "alice"}, fc)
+			go conn.Start()
+			defer conn.Close()
+			bus := newStubBus()
+			d := NewDispatcher(conn, nil, bus)
+			d.HandleClientMessage("s", json.RawMessage(`{"id":"n1"}`))
+
+			bus.deliver("noteStream:n1", []byte(tc.inner))
+
+			require.Eventually(t, func() bool { return fc.writeCount() >= 1 }, time.Second, 5*time.Millisecond)
+			fc.mu.Lock()
+			writes := append([][]byte(nil), fc.writes...)
+			fc.mu.Unlock()
+			require.Len(t, writes, 1)
+
+			var outer struct {
+				Type string `json:"type"`
+				Body struct {
+					ID   string          `json:"id"`
+					Type string          `json:"type"`
+					Body json.RawMessage `json:"body"`
+				} `json:"body"`
+			}
+			require.NoError(t, json.Unmarshal(writes[0], &outer))
+			assert.Equal(t, "noteUpdated", outer.Type)
+			assert.Equal(t, "n1", outer.Body.ID)
+			assert.Equal(t, tc.evType, outer.Body.Type)
+			// inner body は json.RawMessage として原形保存される (TS schema を
+			// そのまま frontend に渡す)。
+			assert.NotEmpty(t, outer.Body.Body)
+		})
+	}
+}
+
+func TestDispatcher_ForwardNoteEvent_InvalidPayload(t *testing.T) {
+	fc := newFakeConn()
+	conn := NewConnection("test", &model.User{ID: "alice"}, fc)
+	go conn.Start()
+	defer conn.Close()
+	bus := newStubBus()
+	d := NewDispatcher(conn, nil, bus)
+	d.HandleClientMessage("s", json.RawMessage(`{"id":"n1"}`))
+
+	// invalid JSON / 空 type のどちらも Send しない (早期 return)。
+	bus.deliver("noteStream:n1", []byte(`not-json`))
+	bus.deliver("noteStream:n1", []byte(`{"type":""}`))
+
+	// すぐには届かない可能性もあるため少し待ってから確認。
+	time.Sleep(50 * time.Millisecond)
+	fc.mu.Lock()
+	n := len(fc.writes)
+	fc.mu.Unlock()
+	assert.Zero(t, n)
+}
+
 func countOccurrences(slice []string, target string) int {
 	n := 0
 	for _, s := range slice {

--- a/internal/stream/main_publisher.go
+++ b/internal/stream/main_publisher.go
@@ -1,0 +1,39 @@
+package stream
+
+import (
+	"context"
+	"encoding/json"
+	"log/slog"
+)
+
+// MainStreamPublisher serializes `{type, body}` envelopes to the Redis topic
+// `main:{userID}` which the per-user `main` WebSocket channel subscribes to.
+// Used to emit events such as `receiveFollowRequest`, `follow`, `unfollow`,
+// `meUpdated` etc. to a single target user.
+type MainStreamPublisher struct {
+	pub PubSubPublisher
+}
+
+// NewMainStreamPublisher constructs a MainStreamPublisher backed by the given
+// PubSubPublisher.
+func NewMainStreamPublisher(pub PubSubPublisher) *MainStreamPublisher {
+	return &MainStreamPublisher{pub: pub}
+}
+
+// PublishMainEvent emits an event to `main:{userID}` with a `{type, body}`
+// envelope, matching TS `main` stream event shape.
+func (p *MainStreamPublisher) PublishMainEvent(userID, eventType string, body any) {
+	if p.pub == nil || userID == "" || eventType == "" {
+		return
+	}
+	env := map[string]any{"type": eventType, "body": body}
+	raw, err := json.Marshal(env)
+	if err != nil {
+		slog.Warn("main publisher: marshal failed", "event", eventType, "err", err)
+		return
+	}
+	topic := "main:" + userID
+	if err := p.pub.Publish(context.Background(), topic, json.RawMessage(raw)); err != nil {
+		slog.Warn("main publisher: publish failed", "topic", topic, "err", err)
+	}
+}

--- a/internal/stream/main_publisher_test.go
+++ b/internal/stream/main_publisher_test.go
@@ -1,0 +1,58 @@
+package stream
+
+import (
+	"encoding/json"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestMainStreamPublisher_PublishEnvelope(t *testing.T) {
+	bus := &capturingPubSub{}
+	p := NewMainStreamPublisher(bus)
+	p.PublishMainEvent("u1", "receiveFollowRequest", map[string]any{"id": "u2", "username": "bob"})
+
+	require.Len(t, bus.calls, 1)
+	assert.Equal(t, "main:u1", bus.calls[0].topic)
+
+	raw, ok := bus.calls[0].payload.(json.RawMessage)
+	require.True(t, ok)
+	var env struct {
+		Type string          `json:"type"`
+		Body json.RawMessage `json:"body"`
+	}
+	require.NoError(t, json.Unmarshal(raw, &env))
+	assert.Equal(t, "receiveFollowRequest", env.Type)
+
+	var body map[string]any
+	require.NoError(t, json.Unmarshal(env.Body, &body))
+	assert.Equal(t, "u2", body["id"])
+	assert.Equal(t, "bob", body["username"])
+}
+
+func TestMainStreamPublisher_NilPub(t *testing.T) {
+	p := NewMainStreamPublisher(nil)
+	p.PublishMainEvent("u1", "any", nil) // no panic
+}
+
+func TestMainStreamPublisher_EmptyUserID(t *testing.T) {
+	bus := &capturingPubSub{}
+	p := NewMainStreamPublisher(bus)
+	p.PublishMainEvent("", "receiveFollowRequest", nil)
+	assert.Empty(t, bus.calls)
+}
+
+func TestMainStreamPublisher_EmptyEventType(t *testing.T) {
+	bus := &capturingPubSub{}
+	p := NewMainStreamPublisher(bus)
+	p.PublishMainEvent("u1", "", nil)
+	assert.Empty(t, bus.calls)
+}
+
+func TestMainStreamPublisher_PublishError(t *testing.T) {
+	bus := &capturingPubSub{err: errors.New("pub boom")}
+	p := NewMainStreamPublisher(bus)
+	p.PublishMainEvent("u1", "receiveFollowRequest", nil) // logged but not panicked
+}


### PR DESCRIPTION
## Summary

Phase 7-4 として TS 本家の \`main\` stream に対する publish infrastructure を整備し、\`receiveFollowRequest\` を実装。併せて \`changeReadyStates\` と \`noteUpdated\` envelope の TS 互換性を検証するテストを追加。

## 主な変更点

### A. \`receiveFollowRequest\` 新規実装

- \`internal/stream/main_publisher.go\` に \`MainStreamPublisher\` を新設。\`main:{userId}\` トピックに \`{type, body}\` envelope で publish する (ReversiGamePublisher と同パターン)。
- \`core/following.Service\` に \`SetMainStreamPublisher\` オプショナル hook を追加し、locked user の follow request 作成時に followee の main channel へ \`{type: "receiveFollowRequest", body: <PackUserLite(follower)>}\` を emit。
- \`internal/server/router.go\` で \`MainStreamPublisher\` を生成して \`followingService\` へ注入。

### B. \`changeReadyStates\` body-shape 検証

- 実装は既存 (\`core/reversi/service.go:197\`)。TS 型 \`{user1: boolean; user2: boolean}\` と一致することを検証するテストを追加。

### C. \`noteUpdated\` envelope 検証

- \`stream/dispatcher.go\` \`forwardNoteEvent\` が送信する外殻 (\`{type: "noteUpdated", body: {id, type, body}}\`) が TS \`NoteUpdatedEvent\` discriminated union (reacted / unreacted / deleted / pollVoted) と一致することを確認するテストを追加。

### D. 未実装 \`main\` イベントの棚卸し

TS定義 23 種のうち 22 種は未だ publish 実装なし。umbrella issue **#288** で追跡する (本PRスコープ外)。

## テスト

- \`make fmt && go vet ./...\` 通過
- 追加テスト:
  - \`stream\` package: MainStreamPublisher の envelope / nil 安全性 / 空入力 / publish エラー (5 cases)
  - \`stream\` package: forwardNoteEvent の 4 subtype × envelope 形状 + invalid payload
  - \`following\` package: locked user 受信時の receiveFollowRequest emit + public user では emit されないこと
  - \`reversi\` package: changeReadyStates の body shape が \`{user1, user2}\` のみで余計なキー混入無し
- カバレッジ: following 98.3% / reversi 97.5% / stream 95.0% / channels 95.2%
- \`go test ./...\` 全体通過

### 実行コマンド

\`\`\`bash
make fmt && go vet ./... && go test ./...
\`\`\`

## Closes

Closes #246

## 関連

- Parent: #242 (Phase 7)
- Follow-up umbrella: #288 (残り 22 種の main event)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/shiroha-a/mk/pull/289" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
