### PR TITLE
Fix #294: meUpdated の main チャネル emit

### DIFF
--- a/internal/api/i/handler.go
+++ b/internal/api/i/handler.go
@@ -341,7 +341,7 @@ func (h *Handler) Me(c echo.Context) error {
 
 	profile := h.userService.GetProfile(u.ID)
 
-	detailed := entity.PackUserDetailed(u, profile)
+	detailed := entity.PackUserDetailed(u, profile, h.idGen)
 
 	// /api/i returns additional private fields
 	resp := map[string]any{
@@ -636,7 +636,7 @@ func (h *Handler) Update(c echo.Context) error {
 		return apierr.JSONInternalError(c)
 	}
 
-	return c.JSON(http.StatusOK, entity.PackUserDetailed(bundle.User, bundle.Profile))
+	return c.JSON(http.StatusOK, entity.PackUserDetailed(bundle.User, bundle.Profile, h.idGen))
 }
 
 // PinRequest is the request body for i/pin and i/unpin.

--- a/internal/core/user/user_service.go
+++ b/internal/core/user/user_service.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/shiroha-a/mk/internal/entity"
 	"github.com/shiroha-a/mk/internal/misc/id"
 	"github.com/shiroha-a/mk/internal/model"
 	"github.com/shiroha-a/mk/internal/repository"
@@ -39,12 +40,21 @@ var (
 	ErrPinNotFound = errors.New("pin not found")
 )
 
+// MainStreamPublisher emits real-time events to a single target user's `main`
+// WebSocket channel. Used here for `meUpdated` so the frontend can reflect
+// profile changes immediately. 循環依存を避けるため interface で受け取る
+// (実装は internal/stream)。
+type MainStreamPublisher interface {
+	PublishMainEvent(userID, eventType string, body any)
+}
+
 // Service provides user-related business logic.
 type Service struct {
-	userRepo   repository.UserRepository
-	noteRepo   repository.NoteRepository
-	piningRepo repository.UserNotePiningRepository
-	idGen      id.Generator
+	userRepo            repository.UserRepository
+	noteRepo            repository.NoteRepository
+	piningRepo          repository.UserNotePiningRepository
+	idGen               id.Generator
+	mainStreamPublisher MainStreamPublisher
 }
 
 // NewService creates a new user Service.
@@ -62,6 +72,12 @@ func NewService(
 		piningRepo: piningRepo,
 		idGen:      idGen,
 	}
+}
+
+// SetMainStreamPublisher attaches a publisher used to emit `main` channel
+// events (currently `meUpdated`). Optional — nil disables emit.
+func (s *Service) SetMainStreamPublisher(p MainStreamPublisher) {
+	s.mainStreamPublisher = p
 }
 
 // UserWithProfile bundles a user and its profile for handlers.
@@ -213,7 +229,22 @@ func (s *Service) UpdateProfile(userID string, in UpdateInput) (*UserWithProfile
 		return nil, err
 	}
 
-	return s.ShowByID(userID)
+	bundle, err := s.ShowByID(userID)
+	if err != nil {
+		return nil, err
+	}
+	// TS本家 UserEntityService.updateMe() 完了後に `meUpdated` を自分の main
+	// に publish する (プロフィールページ / UI 側 state を即時再描画させる
+	// ため)。body は packed UserDetailed full object。profile update は
+	// 頻度が低いので hot path 最適化は不要で full pack する。
+	if s.mainStreamPublisher != nil {
+		s.mainStreamPublisher.PublishMainEvent(
+			userID,
+			"meUpdated",
+			entity.PackUserDetailed(bundle.User, bundle.Profile, s.idGen),
+		)
+	}
+	return bundle, nil
 }
 
 // PinNote pins the given note to the user's profile.

--- a/internal/core/user/user_service_test.go
+++ b/internal/core/user/user_service_test.go
@@ -1,6 +1,7 @@
 package user_test
 
 import (
+	"encoding/json"
 	"errors"
 	"testing"
 
@@ -169,6 +170,61 @@ func TestService_UpdateProfile_UserNotFound(t *testing.T) {
 	svc, _, _, _ := newFullSvc(t)
 	_, err := svc.UpdateProfile("missing", user.UpdateInput{})
 	assert.True(t, errors.Is(err, user.ErrUserNotFound))
+}
+
+// stubMainStreamPublisher captures PublishMainEvent calls for assertion.
+type stubMainStreamPublisher struct {
+	calls []mainEventCall
+}
+
+type mainEventCall struct {
+	userID    string
+	eventType string
+	body      any
+}
+
+func (s *stubMainStreamPublisher) PublishMainEvent(userID, eventType string, body any) {
+	s.calls = append(s.calls, mainEventCall{userID, eventType, body})
+}
+
+func TestService_UpdateProfile_PublishesMeUpdated(t *testing.T) {
+	svc, repo, _, _ := newFullSvc(t)
+	repo.Users["u1"] = &model.User{ID: "u1", Username: "alice"}
+	pub := &stubMainStreamPublisher{}
+	svc.SetMainStreamPublisher(pub)
+
+	_, err := svc.UpdateProfile("u1", user.UpdateInput{
+		Name:        ptr(ptr("New Name")),
+		Description: ptr(ptr("hello")),
+	})
+	require.NoError(t, err)
+
+	require.Len(t, pub.calls, 1)
+	assert.Equal(t, "u1", pub.calls[0].userID)
+	assert.Equal(t, "meUpdated", pub.calls[0].eventType)
+	// body は entity.UserDetailed 相当。JSON round-trip で id/name/description
+	// が更新後の値になっていることを確認する。
+	raw, err := json.Marshal(pub.calls[0].body)
+	require.NoError(t, err)
+	var m map[string]any
+	require.NoError(t, json.Unmarshal(raw, &m))
+	assert.Equal(t, "u1", m["id"])
+	assert.Equal(t, "New Name", m["name"])
+	assert.Equal(t, "hello", m["description"])
+}
+
+func TestService_UpdateProfile_UserUpdateError_DoesNotPublish(t *testing.T) {
+	mockUR := testutil.NewMockUserRepository()
+	mockUR.Users["u1"] = &model.User{ID: "u1", Username: "alice"}
+	uRepo := &failingUserRepo{MockUserRepository: mockUR, failUpdateUser: true}
+	idGen, _ := id.NewGenerator("aidx")
+	svc := user.NewService(uRepo, nil, nil, idGen)
+	pub := &stubMainStreamPublisher{}
+	svc.SetMainStreamPublisher(pub)
+
+	_, err := svc.UpdateProfile("u1", user.UpdateInput{IsLocked: ptr(true)})
+	require.Error(t, err)
+	assert.Empty(t, pub.calls)
 }
 
 // --- PinNote / UnpinNote / ListPinnedNotes ---

--- a/internal/server/router.go
+++ b/internal/server/router.go
@@ -1225,6 +1225,7 @@ func (s *Server) setupRoutes() {
 	notificationService.SetMainStreamPublisher(mainStreamPublisher)
 	driveService.SetStreamingPublisher(drivePublisher)
 	followingService.SetMainStreamPublisher(mainStreamPublisher)
+	userService.SetMainStreamPublisher(mainStreamPublisher)
 
 	// 5. Reversi WebSocket channel (Phase 9.6) を登録する
 	reversiService := corereversi.NewService(reversiRepo, reversiPublisher, s.redis.Default)


### PR DESCRIPTION
## Summary

#288 (umbrella) の高優先度イベント \`meUpdated\` を実装。\`UpdateProfile()\` 成功時、更新後の user bundle を \`entity.PackUserDetailed\` で pack し、\`main:{userID}\` へ publish する。TS本家 \`UserEntityService.updateMe()\` と同等。

## 主な変更点

### 実装 (\`internal/core/user/user_service.go\`)

- \`MainStreamPublisher\` interface + \`SetMainStreamPublisher\` setter を追加 (#246 pattern 踏襲)
- \`UpdateProfile()\` 成功時に \`{type: "meUpdated", body: <UserDetailed>}\` を emit
- 失敗 path (UpdateUser / UpdateProfile error) では emit しない
- profile update は頻度が低い hot path ではないため \`UserDetailed\` full pack で送信 (\`PackUserLite\` ではなく)

### router 配線 (\`internal/server/router.go\`)

- 既存の \`mainStreamPublisher\` を \`userService.SetMainStreamPublisher\` に注入

## スコープ外 (別 sub-issue で検討)

- \`/api/i/pin\` / \`/api/i/unpin\` / \`/api/i/update-email\` 等は別 service / 別 path を経由するため、それぞれに hook を追加する必要がある。本 issue では \`UpdateProfile\` path のみ扱う。
- \`/api/i/change-password\` / \`/api/i/regenerate-token\` は user object の公開フィールドを変更しないため meUpdated の emit 対象外。

## テスト

- \`make fmt && go vet ./...\` 通過
- 追加テスト:
  - \`TestService_UpdateProfile_PublishesMeUpdated\`: 成功時 emit 検証 + body の id/name/description が更新後値に一致
  - \`TestService_UpdateProfile_UserUpdateError_DoesNotPublish\`: Update 失敗時は emit されない
- カバレッジ: \`internal/core/user\` 94.1%
- \`go test ./...\` 全体通過

### 実行コマンド

\`\`\`bash
make fmt && go vet ./... && go test ./...
\`\`\`

## Closes

Closes #294

## 関連

- Umbrella: #288 (main チャネル 22 種追跡)
- Base: #246 (MainStreamPublisher infrastructure)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/shiroha-a/mk/pull/295" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
