### PR TITLE
Fix #296: Pin/Unpin の meUpdated emit

### DIFF
--- a/internal/core/user/user_service.go
+++ b/internal/core/user/user_service.go
@@ -235,16 +235,23 @@ func (s *Service) UpdateProfile(userID string, in UpdateInput) (*UserWithProfile
 	}
 	// TS本家 UserEntityService.updateMe() 完了後に `meUpdated` を自分の main
 	// に publish する (プロフィールページ / UI 側 state を即時再描画させる
-	// ため)。body は packed UserDetailed full object。profile update は
-	// 頻度が低いので hot path 最適化は不要で full pack する。
-	if s.mainStreamPublisher != nil {
-		s.mainStreamPublisher.PublishMainEvent(
-			userID,
-			"meUpdated",
-			entity.PackUserDetailed(bundle.User, bundle.Profile, s.idGen),
-		)
-	}
+	// ため)。body は packed UserDetailed full object。
+	s.publishMeUpdated(bundle)
 	return bundle, nil
+}
+
+// publishMeUpdated emits `meUpdated` to the user's main channel with the
+// packed UserDetailed object. No-op when no publisher is attached. profile
+// update / pin / unpin は頻度が低く hot path ではないため full pack する。
+func (s *Service) publishMeUpdated(bundle *UserWithProfile) {
+	if s.mainStreamPublisher == nil || bundle == nil || bundle.User == nil {
+		return
+	}
+	s.mainStreamPublisher.PublishMainEvent(
+		bundle.User.ID,
+		"meUpdated",
+		entity.PackUserDetailed(bundle.User, bundle.Profile, s.idGen),
+	)
 }
 
 // PinNote pins the given note to the user's profile.
@@ -276,7 +283,16 @@ func (s *Service) PinNote(userID, noteID string) error {
 		UserID: userID,
 		NoteID: noteID,
 	}
-	return s.piningRepo.Create(p)
+	if err := s.piningRepo.Create(p); err != nil {
+		return err
+	}
+	// pinnedNoteIds が変わったので main に meUpdated を publish して
+	// UI を即時同期する (TS本家 UserEntityService.pinNote と同等)。
+	// ShowByID 失敗は emit 省略、pin 自体の成功は返す。
+	if bundle, err := s.ShowByID(userID); err == nil {
+		s.publishMeUpdated(bundle)
+	}
+	return nil
 }
 
 // UnpinNote removes a pinning entry. Returns ErrPinNotFound if the user has
@@ -286,7 +302,13 @@ func (s *Service) UnpinNote(userID, noteID string) error {
 	if err != nil {
 		return ErrPinNotFound
 	}
-	return s.piningRepo.Delete(p)
+	if err := s.piningRepo.Delete(p); err != nil {
+		return err
+	}
+	if bundle, err := s.ShowByID(userID); err == nil {
+		s.publishMeUpdated(bundle)
+	}
+	return nil
 }
 
 // ListPinnedNotes returns the notes pinned by userID, in pinning order

--- a/internal/core/user/user_service.go
+++ b/internal/core/user/user_service.go
@@ -243,18 +243,44 @@ func (s *Service) UpdateProfile(userID string, in UpdateInput) (*UserWithProfile
 
 // publishMeUpdated emits `meUpdated` to the user's main channel with the
 // packed UserDetailed object. No-op when no publisher is attached or the
-// bundle is missing its User.
+// bundle is missing its User. PinnedNoteIDs is populated from piningRepo
+// so pin/unpin changes are reflected in the event body.
 func (s *Service) publishMeUpdated(bundle *UserWithProfile) {
 	if s.mainStreamPublisher == nil || bundle == nil || bundle.User == nil {
 		return
 	}
 	// profile update / pin / unpin は頻度が低く hot path ではないため
 	// full pack する (UserLite ではなく UserDetailed)。
-	s.mainStreamPublisher.PublishMainEvent(
-		bundle.User.ID,
-		"meUpdated",
-		entity.PackUserDetailed(bundle.User, bundle.Profile, s.idGen),
-	)
+	body := entity.PackUserDetailed(bundle.User, bundle.Profile, s.idGen)
+	// PackUserDetailed は pinnedNoteIDs を空で返すため、piningRepo が
+	// あれば pin ID だけ埋める (full note pack は不要で frontend 側で
+	// 必要に応じて fetch する)。piningRepo がない read-only 構成や
+	// 取得失敗時はそのまま空で emit する (best-effort)。
+	if s.piningRepo != nil {
+		if pinings, err := s.piningRepo.ListByUser(bundle.User.ID); err == nil {
+			ids := make([]string, 0, len(pinings))
+			for _, p := range pinings {
+				ids = append(ids, p.NoteID)
+			}
+			body.PinnedNoteIDs = ids
+		}
+	}
+	s.mainStreamPublisher.PublishMainEvent(bundle.User.ID, "meUpdated", body)
+}
+
+// emitMeUpdatedForUser re-fetches the user bundle and publishes `meUpdated`.
+// Returns early when no publisher is attached so the ShowByID DB read is
+// avoided. contextLabel is used only in the warning log.
+func (s *Service) emitMeUpdatedForUser(userID, contextLabel string) {
+	if s.mainStreamPublisher == nil {
+		return
+	}
+	bundle, err := s.ShowByID(userID)
+	if err != nil {
+		slog.Warn("user: ShowByID failed, skipping meUpdated emit", "context", contextLabel, "userID", userID, "err", err)
+		return
+	}
+	s.publishMeUpdated(bundle)
 }
 
 // PinNote pins the given note to the user's profile.
@@ -291,12 +317,9 @@ func (s *Service) PinNote(userID, noteID string) error {
 	}
 	// pinnedNoteIds が変わったので main に meUpdated を publish して
 	// UI を即時同期する (TS本家 UserEntityService.pinNote と同等)。
-	// ShowByID 失敗は emit 省略、pin 自体の成功は返す。
-	if bundle, err := s.ShowByID(userID); err == nil {
-		s.publishMeUpdated(bundle)
-	} else {
-		slog.Warn("user.PinNote: ShowByID failed, skipping meUpdated emit", "userID", userID, "err", err)
-	}
+	// best-effort emit: publisher 未注入なら何もせず、ShowByID 失敗時は
+	// ログのみ残して pin 自体の成功は返す。
+	s.emitMeUpdatedForUser(userID, "PinNote")
 	return nil
 }
 
@@ -310,13 +333,7 @@ func (s *Service) UnpinNote(userID, noteID string) error {
 	if err := s.piningRepo.Delete(p); err != nil {
 		return err
 	}
-	// pin と同じく best-effort emit。ShowByID 失敗時は警告ログに
-	// 記録するが unpin 自体の成功は返す。
-	if bundle, err := s.ShowByID(userID); err == nil {
-		s.publishMeUpdated(bundle)
-	} else {
-		slog.Warn("user.UnpinNote: ShowByID failed, skipping meUpdated emit", "userID", userID, "err", err)
-	}
+	s.emitMeUpdatedForUser(userID, "UnpinNote")
 	return nil
 }
 

--- a/internal/core/user/user_service.go
+++ b/internal/core/user/user_service.go
@@ -4,6 +4,7 @@ package user
 import (
 	"encoding/json"
 	"errors"
+	"log/slog"
 	"strings"
 	"time"
 
@@ -241,12 +242,14 @@ func (s *Service) UpdateProfile(userID string, in UpdateInput) (*UserWithProfile
 }
 
 // publishMeUpdated emits `meUpdated` to the user's main channel with the
-// packed UserDetailed object. No-op when no publisher is attached. profile
-// update / pin / unpin は頻度が低く hot path ではないため full pack する。
+// packed UserDetailed object. No-op when no publisher is attached or the
+// bundle is missing its User.
 func (s *Service) publishMeUpdated(bundle *UserWithProfile) {
 	if s.mainStreamPublisher == nil || bundle == nil || bundle.User == nil {
 		return
 	}
+	// profile update / pin / unpin は頻度が低く hot path ではないため
+	// full pack する (UserLite ではなく UserDetailed)。
 	s.mainStreamPublisher.PublishMainEvent(
 		bundle.User.ID,
 		"meUpdated",
@@ -291,6 +294,8 @@ func (s *Service) PinNote(userID, noteID string) error {
 	// ShowByID 失敗は emit 省略、pin 自体の成功は返す。
 	if bundle, err := s.ShowByID(userID); err == nil {
 		s.publishMeUpdated(bundle)
+	} else {
+		slog.Warn("user.PinNote: ShowByID failed, skipping meUpdated emit", "userID", userID, "err", err)
 	}
 	return nil
 }
@@ -305,8 +310,12 @@ func (s *Service) UnpinNote(userID, noteID string) error {
 	if err := s.piningRepo.Delete(p); err != nil {
 		return err
 	}
+	// pin と同じく best-effort emit。ShowByID 失敗時は警告ログに
+	// 記録するが unpin 自体の成功は返す。
 	if bundle, err := s.ShowByID(userID); err == nil {
 		s.publishMeUpdated(bundle)
+	} else {
+		slog.Warn("user.UnpinNote: ShowByID failed, skipping meUpdated emit", "userID", userID, "err", err)
 	}
 	return nil
 }

--- a/internal/core/user/user_service_test.go
+++ b/internal/core/user/user_service_test.go
@@ -311,6 +311,21 @@ func TestService_PinNote_PublishesMeUpdated(t *testing.T) {
 	var m map[string]any
 	require.NoError(t, json.Unmarshal(raw, &m))
 	assert.Equal(t, "u1", m["id"])
+	// piningRepo から補完された pinnedNoteIds が含まれること
+	ids, ok := m["pinnedNoteIds"].([]any)
+	require.True(t, ok)
+	assert.Equal(t, []any{"n1"}, ids)
+}
+
+func TestService_PinNote_NoPublisher_NoDBRead(t *testing.T) {
+	// publisher 未注入時は ShowByID を呼ばないことを確認するため、
+	// pin 直後に user を repo から削除しても PinNote は error にならない
+	// (ShowByID されないため)。
+	svc, repo, noteRepo, _ := newFullSvc(t)
+	repo.Users["u1"] = &model.User{ID: "u1", Username: "alice"}
+	noteRepo.Notes["n1"] = &model.Note{ID: "n1", UserID: "u1"}
+	// publisher を意図的に設定しない
+	require.NoError(t, svc.PinNote("u1", "n1"))
 }
 
 func TestService_UnpinNote_PublishesMeUpdated(t *testing.T) {

--- a/internal/core/user/user_service_test.go
+++ b/internal/core/user/user_service_test.go
@@ -295,6 +295,40 @@ func TestService_UnpinNote_NotFound(t *testing.T) {
 	assert.True(t, errors.Is(err, user.ErrPinNotFound))
 }
 
+func TestService_PinNote_PublishesMeUpdated(t *testing.T) {
+	svc, repo, noteRepo, _ := newFullSvc(t)
+	repo.Users["u1"] = &model.User{ID: "u1", Username: "alice"}
+	noteRepo.Notes["n1"] = &model.Note{ID: "n1", UserID: "u1"}
+	pub := &stubMainStreamPublisher{}
+	svc.SetMainStreamPublisher(pub)
+
+	require.NoError(t, svc.PinNote("u1", "n1"))
+	require.Len(t, pub.calls, 1)
+	assert.Equal(t, "u1", pub.calls[0].userID)
+	assert.Equal(t, "meUpdated", pub.calls[0].eventType)
+	raw, err := json.Marshal(pub.calls[0].body)
+	require.NoError(t, err)
+	var m map[string]any
+	require.NoError(t, json.Unmarshal(raw, &m))
+	assert.Equal(t, "u1", m["id"])
+}
+
+func TestService_UnpinNote_PublishesMeUpdated(t *testing.T) {
+	svc, repo, noteRepo, _ := newFullSvc(t)
+	repo.Users["u1"] = &model.User{ID: "u1", Username: "alice"}
+	noteRepo.Notes["n1"] = &model.Note{ID: "n1", UserID: "u1"}
+	require.NoError(t, svc.PinNote("u1", "n1"))
+
+	// Pin で emit された分を除外するため publisher を差し替え。
+	pub := &stubMainStreamPublisher{}
+	svc.SetMainStreamPublisher(pub)
+
+	require.NoError(t, svc.UnpinNote("u1", "n1"))
+	require.Len(t, pub.calls, 1)
+	assert.Equal(t, "u1", pub.calls[0].userID)
+	assert.Equal(t, "meUpdated", pub.calls[0].eventType)
+}
+
 func TestService_ListPinnedNotes_Success(t *testing.T) {
 	svc, repo, noteRepo, _ := newFullSvc(t)
 	repo.Users["u1"] = &model.User{ID: "u1"}


### PR DESCRIPTION
## Summary

#294 (PR #295) の Devin Review で指摘された follow-up。\`/api/i/pin\` / \`/api/i/unpin\` は \`PinNote\` / \`UnpinNote\` 経由で \`UpdateProfile\` path に入らないため、これまで \`meUpdated\` が emit されていなかった。TS 本家に合わせて両操作で \`meUpdated\` を発火するよう対応。

## 主な変更点

### 実装 (\`internal/core/user/user_service.go\`)

- \`publishMeUpdated(bundle)\` プライベートヘルパーを追加し、emit ロジックを集約 (mainStreamPublisher nil 安全 / bundle nil 安全)
- \`PinNote()\` / \`UnpinNote()\` 成功後に \`ShowByID\` → \`publishMeUpdated\` を呼ぶ
- \`UpdateProfile\` も新ヘルパー経由に切り替え (挙動は不変のリファクタリング)
- ShowByID が失敗しても pin/unpin 自体の成功は返す (best-effort emit)

### テスト

- \`TestService_PinNote_PublishesMeUpdated\`: Pin 成功時 emit + body 検証
- \`TestService_UnpinNote_PublishesMeUpdated\`: Unpin 成功時 emit 検証

## テスト

- \`make fmt && go vet ./...\` 通過
- \`go test -cover ./internal/core/user/...\` → **92.8%** 通過
- \`go test ./...\` 全体通過

## Closes

Closes #296

## 関連

- Umbrella: #288 (main チャネル 22 種追跡)
- Upstream: #294 (UpdateProfile path の meUpdated)
- Base: #246 (MainStreamPublisher infrastructure)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/shiroha-a/mk/pull/297" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
