### PR TITLE
Fix #298: newChatMessage の main チャネル emit

### DIFF
--- a/internal/core/chat/service.go
+++ b/internal/core/chat/service.go
@@ -214,6 +214,12 @@ func (s *Service) CreateMessageViaAP(ctx context.Context, uri string, fromUser *
 	if s.publisher != nil {
 		s.publisher.PublishUserMessage(ctx, fromUser.ID, toUserID, EventMessage, packMessage(msg))
 	}
+	// Remote → local DM を受信した場合も、CreateMessageToUser と同じく
+	// recipient の main チャネルに newChatMessage を emit してフロントの
+	// 未読インジケータを更新させる。sender は remote なので emit 対象外。
+	if s.mainStreamPublisher != nil {
+		s.mainStreamPublisher.PublishMainEvent(toUserID, "newChatMessage", packMessage(msg))
+	}
 	return msg, nil
 }
 
@@ -224,10 +230,12 @@ func (s *Service) CreateMessageToRoom(ctx context.Context, fromUserID, roomID, t
 		return nil, ErrInvalidTarget
 	}
 	// ルームが存在し、送信者がメンバーであることを確認する。
-	if _, err := s.repo.FindRoomByID(roomID); err != nil {
+	// 取得した room は後段の emitRoomNewChatMessage にも渡し、重複 fetch を避ける。
+	room, err := s.repo.FindRoomByID(roomID)
+	if err != nil {
 		return nil, ErrNotFound
 	}
-	isMember, err := s.IsRoomMember(fromUserID, roomID)
+	isMember, err := s.isRoomMemberWith(room, fromUserID, roomID)
 	if err != nil {
 		return nil, err
 	}
@@ -254,25 +262,32 @@ func (s *Service) CreateMessageToRoom(ctx context.Context, fromUserID, roomID, t
 	// Room 宛も同様に、sender 以外の全 member (owner 含む) の main に
 	// newChatMessage を emit する。Misskey 本家 ChatService
 	// .createMessageToRoom と同じ fan-out 方針。
-	s.emitRoomNewChatMessage(roomID, fromUserID, msg)
+	s.emitRoomNewChatMessage(room, fromUserID, msg)
 	return msg, nil
+}
+
+// isRoomMemberWith is IsRoomMember のうち room 取得済みケース向けバリアント。
+// owner は membership レコードが無くても implicit member 扱い。
+func (s *Service) isRoomMemberWith(room *model.ChatRoom, userID, roomID string) (bool, error) {
+	if room != nil && room.OwnerID == userID {
+		return true, nil
+	}
+	if _, err := s.repo.FindMembership(userID, roomID); err == nil {
+		return true, nil
+	}
+	return false, nil
 }
 
 // emitRoomNewChatMessage fans out `newChatMessage` to every room member
 // except the sender. Room membership 列挙失敗時は警告ログを残して emit を
 // スキップする (message 自体の作成は成功として返される前に呼ばれる)。
-func (s *Service) emitRoomNewChatMessage(roomID, fromUserID string, msg *model.ChatMessage) {
-	if s.mainStreamPublisher == nil {
+func (s *Service) emitRoomNewChatMessage(room *model.ChatRoom, fromUserID string, msg *model.ChatMessage) {
+	if s.mainStreamPublisher == nil || room == nil {
 		return
 	}
-	room, err := s.repo.FindRoomByID(roomID)
+	members, err := s.repo.ListMembersByRoom(room.ID)
 	if err != nil {
-		slog.Warn("chat: FindRoomByID failed, skipping newChatMessage emit", "roomID", roomID, "err", err)
-		return
-	}
-	members, err := s.repo.ListMembersByRoom(roomID)
-	if err != nil {
-		slog.Warn("chat: ListMembersByRoom failed, skipping newChatMessage emit", "roomID", roomID, "err", err)
+		slog.Warn("chat: ListMembersByRoom failed, skipping newChatMessage emit", "roomID", room.ID, "err", err)
 		return
 	}
 	packed := packMessage(msg)

--- a/internal/core/chat/service.go
+++ b/internal/core/chat/service.go
@@ -266,8 +266,9 @@ func (s *Service) CreateMessageToRoom(ctx context.Context, fromUserID, roomID, t
 	return msg, nil
 }
 
-// isRoomMemberWith is IsRoomMember のうち room 取得済みケース向けバリアント。
-// owner は membership レコードが無くても implicit member 扱い。
+// isRoomMemberWith reports whether userID is a member of the given room,
+// reusing an already-fetched room object to avoid a second FindRoomByID.
+// The owner is treated as an implicit member even without a membership row.
 func (s *Service) isRoomMemberWith(room *model.ChatRoom, userID, roomID string) (bool, error) {
 	if room != nil && room.OwnerID == userID {
 		return true, nil

--- a/internal/core/chat/service.go
+++ b/internal/core/chat/service.go
@@ -51,6 +51,14 @@ type APDeliverer interface {
 	DeliverToUser(signerUserID string, recipient *model.User, body []byte) error
 }
 
+// MainStreamPublisher emits real-time events to a single target user's `main`
+// WebSocket channel. Used here to deliver `newChatMessage` events to message
+// recipients so the frontend can surface unread-chat indicators immediately.
+// 循環依存を避けるため interface で受け取る (実装は internal/stream)。
+type MainStreamPublisher interface {
+	PublishMainEvent(userID, eventType string, body any)
+}
+
 // Event types mirrored by the WebSocket channel. 本家と同名。
 const (
 	EventMessage = "message"
@@ -61,13 +69,14 @@ const (
 
 // Service implements chat message CRUD + streaming fan-out.
 type Service struct {
-	repo      repository.ChatRepository
-	idGen     id.Generator
-	publisher StreamingPublisher
-	userRepo  repository.UserRepository
-	renderer  *activitypub.Renderer
-	urls      *activitypub.URLBuilder
-	deliverer APDeliverer
+	repo                repository.ChatRepository
+	idGen               id.Generator
+	publisher           StreamingPublisher
+	userRepo            repository.UserRepository
+	renderer            *activitypub.Renderer
+	urls                *activitypub.URLBuilder
+	deliverer           APDeliverer
+	mainStreamPublisher MainStreamPublisher
 }
 
 // NewService constructs a chat Service.
@@ -80,6 +89,13 @@ func NewService(repo repository.ChatRepository, idGen id.Generator) *Service {
 // DB 処理は変わらない)。
 func (s *Service) SetStreamingPublisher(p StreamingPublisher) {
 	s.publisher = p
+}
+
+// SetMainStreamPublisher attaches a publisher used to emit `newChatMessage`
+// on the recipient(s)' main channel. Optional — nil disables main-stream emit
+// but chat-stream `message` events remain unaffected.
+func (s *Service) SetMainStreamPublisher(p MainStreamPublisher) {
+	s.mainStreamPublisher = p
 }
 
 // SetAPDelivery wires the AP federation layer for chat message delivery to
@@ -116,6 +132,13 @@ func (s *Service) CreateMessageToUser(ctx context.Context, fromUserID, toUserID,
 	}
 	if s.publisher != nil {
 		s.publisher.PublishUserMessage(ctx, fromUserID, toUserID, EventMessage, packMessage(msg))
+	}
+	// Misskey 本家の ChatService.createMessageToUser は、3 秒後に未読判定して
+	// newChatMessage を publishMainStream する。本実装では未読判定を省略し、
+	// 作成と同時に recipient (toUserID) の main に emit する (sender には
+	// 送らない: TS と同じ fan-out 方針)。
+	if s.mainStreamPublisher != nil {
+		s.mainStreamPublisher.PublishMainEvent(toUserID, "newChatMessage", packMessage(msg))
 	}
 	// リモートユーザー宛ならAP配送 (best-effort)
 	s.tryDeliverToRemoteUser(msg, fromUserID, toUserID)
@@ -228,7 +251,45 @@ func (s *Service) CreateMessageToRoom(ctx context.Context, fromUserID, roomID, t
 	if s.publisher != nil {
 		s.publisher.PublishRoomMessage(ctx, roomID, EventMessage, packMessage(msg))
 	}
+	// Room 宛も同様に、sender 以外の全 member (owner 含む) の main に
+	// newChatMessage を emit する。Misskey 本家 ChatService
+	// .createMessageToRoom と同じ fan-out 方針。
+	s.emitRoomNewChatMessage(roomID, fromUserID, msg)
 	return msg, nil
+}
+
+// emitRoomNewChatMessage fans out `newChatMessage` to every room member
+// except the sender. Room membership 列挙失敗時は警告ログを残して emit を
+// スキップする (message 自体の作成は成功として返される前に呼ばれる)。
+func (s *Service) emitRoomNewChatMessage(roomID, fromUserID string, msg *model.ChatMessage) {
+	if s.mainStreamPublisher == nil {
+		return
+	}
+	room, err := s.repo.FindRoomByID(roomID)
+	if err != nil {
+		slog.Warn("chat: FindRoomByID failed, skipping newChatMessage emit", "roomID", roomID, "err", err)
+		return
+	}
+	members, err := s.repo.ListMembersByRoom(roomID)
+	if err != nil {
+		slog.Warn("chat: ListMembersByRoom failed, skipping newChatMessage emit", "roomID", roomID, "err", err)
+		return
+	}
+	packed := packMessage(msg)
+	// 重複 emit を防ぐため set 相当で ID を管理する (membership + owner)。
+	emitted := make(map[string]bool, len(members)+1)
+	if room.OwnerID != fromUserID {
+		emitted[room.OwnerID] = true
+	}
+	for _, m := range members {
+		if m.UserID == fromUserID || emitted[m.UserID] {
+			continue
+		}
+		emitted[m.UserID] = true
+	}
+	for uid := range emitted {
+		s.mainStreamPublisher.PublishMainEvent(uid, "newChatMessage", packed)
+	}
 }
 
 // DeleteMessage removes a message and fans out a `deleted` event on the

--- a/internal/core/chat/service_test.go
+++ b/internal/core/chat/service_test.go
@@ -331,6 +331,28 @@ func TestCreateMessageToUser_NoMainPublisher_NoEmit(t *testing.T) {
 	require.NoError(t, err)
 }
 
+func TestCreateMessageViaAP_PublishesNewChatMessageToLocalRecipient(t *testing.T) {
+	svc, _, _ := newSvc(t)
+	main := &stubMainPublisher{}
+	svc.SetMainStreamPublisher(main)
+
+	// Remote → local DM: fromUser は remote (host set)、toUserID はローカル。
+	remoteHost := "remote.example"
+	fromUser := &model.User{ID: "remote_user", Host: &remoteHost}
+	_, err := svc.CreateMessageViaAP(context.Background(), "https://remote.example/n/1", fromUser, "bob", "hello from remote")
+	require.NoError(t, err)
+
+	main.mu.Lock()
+	defer main.mu.Unlock()
+	require.Len(t, main.calls, 1)
+	assert.Equal(t, "bob", main.calls[0].userID)
+	assert.Equal(t, "newChatMessage", main.calls[0].eventType)
+	body, ok := main.calls[0].body.(map[string]any)
+	require.True(t, ok)
+	assert.Equal(t, "remote_user", body["fromUserId"])
+	assert.Equal(t, "bob", body["toUserId"])
+}
+
 func TestCreateMessageToRoom_PublishesNewChatMessageToMembersExceptSender(t *testing.T) {
 	svc, repo, _ := newSvc(t)
 	// owner=alice, members=bob,carol。sender=bob の場合 alice と carol に emit。

--- a/internal/core/chat/service_test.go
+++ b/internal/core/chat/service_test.go
@@ -117,8 +117,16 @@ func (r *fakeChatRepo) FindMembership(userID, roomID string) (*model.ChatRoomMem
 }
 func (r *fakeChatRepo) UpdateMembership(_ *model.ChatRoomMembership) error { return nil }
 func (r *fakeChatRepo) DeleteMembership(_, _ string) error                 { return nil }
-func (r *fakeChatRepo) ListMembersByRoom(_ string) ([]*model.ChatRoomMembership, error) {
-	return nil, nil
+func (r *fakeChatRepo) ListMembersByRoom(roomID string) ([]*model.ChatRoomMembership, error) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	out := make([]*model.ChatRoomMembership, 0)
+	for _, m := range r.memberships {
+		if m.RoomID == roomID {
+			out = append(out, m)
+		}
+	}
+	return out, nil
 }
 func (r *fakeChatRepo) CreateInvitation(_ *model.ChatRoomInvitation) error { return nil }
 func (r *fakeChatRepo) DeleteInvitation(_ string) error                    { return nil }
@@ -180,6 +188,23 @@ func (p *capturePublisher) PublishRoomMessage(_ context.Context, roomID, t strin
 	p.mu.Lock()
 	defer p.mu.Unlock()
 	p.roomCalls = append(p.roomCalls, roomCall{roomID, t, body})
+}
+
+// stubMainPublisher captures PublishMainEvent calls for newChatMessage tests.
+type stubMainPublisher struct {
+	mu    sync.Mutex
+	calls []mainEventCall
+}
+
+type mainEventCall struct {
+	userID, eventType string
+	body              any
+}
+
+func (p *stubMainPublisher) PublishMainEvent(userID, eventType string, body any) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	p.calls = append(p.calls, mainEventCall{userID, eventType, body})
 }
 
 // --- helper ---
@@ -274,6 +299,73 @@ func TestCreateMessageToRoom_NotMember(t *testing.T) {
 
 	_, err := svc.CreateMessageToRoom(context.Background(), "carol", "r1", "hi", "")
 	assert.ErrorIs(t, err, corechat.ErrForbidden)
+}
+
+// --- newChatMessage emit (Phase 7-4b-4 / #298) ---
+
+func TestCreateMessageToUser_PublishesNewChatMessage(t *testing.T) {
+	svc, _, _ := newSvc(t)
+	main := &stubMainPublisher{}
+	svc.SetMainStreamPublisher(main)
+
+	_, err := svc.CreateMessageToUser(context.Background(), "alice", "bob", "hi", "")
+	require.NoError(t, err)
+
+	main.mu.Lock()
+	defer main.mu.Unlock()
+	require.Len(t, main.calls, 1)
+	// sender (alice) には送らず recipient (bob) にだけ emit。
+	assert.Equal(t, "bob", main.calls[0].userID)
+	assert.Equal(t, "newChatMessage", main.calls[0].eventType)
+	body, ok := main.calls[0].body.(map[string]any)
+	require.True(t, ok)
+	assert.Equal(t, "alice", body["fromUserId"])
+	assert.Equal(t, "bob", body["toUserId"])
+	assert.Equal(t, "hi", body["text"])
+}
+
+func TestCreateMessageToUser_NoMainPublisher_NoEmit(t *testing.T) {
+	svc, _, _ := newSvc(t)
+	// SetMainStreamPublisher を呼ばない状態で正常終了することを確認。
+	_, err := svc.CreateMessageToUser(context.Background(), "alice", "bob", "hi", "")
+	require.NoError(t, err)
+}
+
+func TestCreateMessageToRoom_PublishesNewChatMessageToMembersExceptSender(t *testing.T) {
+	svc, repo, _ := newSvc(t)
+	// owner=alice, members=bob,carol。sender=bob の場合 alice と carol に emit。
+	seedRoom(t, repo, "r1", "alice", "bob", "carol")
+	main := &stubMainPublisher{}
+	svc.SetMainStreamPublisher(main)
+
+	_, err := svc.CreateMessageToRoom(context.Background(), "bob", "r1", "room hi", "")
+	require.NoError(t, err)
+
+	main.mu.Lock()
+	defer main.mu.Unlock()
+	// emit 対象 userID を set で検証 (順序は非決定的)。
+	gotUserIDs := make(map[string]bool, len(main.calls))
+	for _, c := range main.calls {
+		assert.Equal(t, "newChatMessage", c.eventType)
+		gotUserIDs[c.userID] = true
+	}
+	assert.Equal(t, map[string]bool{"alice": true, "carol": true}, gotUserIDs)
+}
+
+func TestCreateMessageToRoom_OwnerAsSender_EmitsToMembersOnly(t *testing.T) {
+	svc, repo, _ := newSvc(t)
+	seedRoom(t, repo, "r1", "alice", "bob")
+	main := &stubMainPublisher{}
+	svc.SetMainStreamPublisher(main)
+
+	// owner=alice が送信 → bob にだけ emit (alice は sender 自身なので除外)。
+	_, err := svc.CreateMessageToRoom(context.Background(), "alice", "r1", "hi", "")
+	require.NoError(t, err)
+
+	main.mu.Lock()
+	defer main.mu.Unlock()
+	require.Len(t, main.calls, 1)
+	assert.Equal(t, "bob", main.calls[0].userID)
 }
 
 func TestCreateMessageToRoom_RoomNotFound(t *testing.T) {

--- a/internal/server/router.go
+++ b/internal/server/router.go
@@ -1256,6 +1256,7 @@ func (s *Server) setupRoutes() {
 	chatPublisher := stream.NewChatPublisher(streamPubSub)
 	chatService := corechat.NewService(chatRepo, idGen)
 	chatService.SetStreamingPublisher(chatPublisher)
+	chatService.SetMainStreamPublisher(mainStreamPublisher)
 	// CherryPick互換AP連合: リモートユーザー宛DMをMisskey:ChatMessageで配送
 	chatService.SetAPDelivery(userRepo, apRenderer, apURLs, deliverService)
 	streamRegistry.Register("chatRoom", channels.NewChatRoomFactory(chatService).New)


### PR DESCRIPTION
## Summary

#288 (umbrella) の最後の高優先度イベント \`newChatMessage\` を実装。Misskey 本家 \`ChatService.createMessageToUser\` / \`createMessageToRoom\` と同じ fan-out 方針で、chat message 作成時に recipient (sender 以外) の main チャネルへ publish する。

## 主な変更点

### 実装 (\`internal/core/chat/service.go\`)

- \`MainStreamPublisher\` interface + \`SetMainStreamPublisher\` setter を追加 (#246 pattern 踏襲)
- **\`CreateMessageToUser\`**: \`toUserID\` だけに emit (sender には送らない)
- **\`CreateMessageToRoom\`**: room owner + membership から sender を除外した集合に emit。\`emitRoomNewChatMessage\` ヘルパーに集約
- body は既存 \`packMessage()\` を再利用
- 3 秒未読判定の最適化 (TS の \`setTimeout\`) は省略し即時 emit

### テスト (\`internal/core/chat/service_test.go\`)

- \`fakeChatRepo.ListMembersByRoom\` をテスト用に実装 (以前は nil 返しで本 issue で初めて使う)
- \`stubMainPublisher\` を追加
- 4 cases: User emit / No-publisher no-emit / Room fan-out (owner+members - sender) / Owner as sender (members only)

### router 配線

- \`mainStreamPublisher\` を \`chatService.SetMainStreamPublisher\` に注入

## スコープ外

- 3 秒未読判定 (\`setTimeout\` + redis marker) の完全再現
- push notification 連動
- \`chatEntityService.packMessageDetailed\` 相当の詳細 packing (ユーザー JOIN 等は frontend が補完する想定)

## テスト

- \`make fmt && go vet ./...\` 通過
- \`go test -cover ./internal/core/chat/...\` → **91.6%** 通過
- \`go test ./...\` 全体通過

### 実行コマンド

\`\`\`bash
make fmt && go vet ./... && go test ./...
\`\`\`

## Closes

Closes #298

## 関連

- Umbrella: #288 (main チャネル 22 種追跡) — 高優先度これにて完了
- Base: #246 (MainStreamPublisher infrastructure)
- TS 参照: \`third_party/misskey/packages/backend/src/core/ChatService.ts\` (チャットは Misskey ベース)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/shiroha-a/mk/pull/299" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
