### PR TITLE
Fix #301: mention/reply/renote の main チャネル emit

### DIFF
--- a/internal/core/note/note_create_service.go
+++ b/internal/core/note/note_create_service.go
@@ -146,7 +146,7 @@ type WebhookHook interface {
 // MainStreamPublisher emits real-time events to a single target user's `main`
 // WebSocket channel. Used here to deliver `reply`, `renote`, and `mention`
 // events so the frontend can reflect note-creation interactions immediately.
-// 循環依存を避けるため interface で受け取る (実装は internal/stream)。
+// 循環依存を避けるためinterfaceで受け取る(実装はinternal/stream)。
 type MainStreamPublisher interface {
 	PublishMainEvent(userID, eventType string, body any)
 }
@@ -516,8 +516,8 @@ func (s *CreateService) Create(in CreateInput) (*model.Note, error) {
 	if s.webhookHook != nil {
 		s.webhookHook.OnNoteCreated(finalNote, in.User, replyTarget, renoteTarget)
 	}
-	// reply / renote / mention 各イベントを対象 local user の main に emit。
-	// Misskey本家 NoteCreateService と同じ fan-out 方針 (TS lines 792 / 809 / 935)。
+	// reply / renote / mention 各イベントを対象local userのmainにemit。
+	// Misskey本家NoteCreateServiceと同じfan-out方針 (TS lines 792 / 809 / 935)。
 	s.publishNoteMainEvents(finalNote, in.User, replyTarget, renoteTarget)
 
 	// ユーザーのnotesCountをインクリメント (ベストエフォート)
@@ -527,26 +527,26 @@ func (s *CreateService) Create(in CreateInput) (*model.Note, error) {
 }
 
 // publishNoteMainEvents fans out `reply`, `renote`, and `mention` events to
-// the relevant local users' main channels. TS本家と同じく dedup はせず、
-// 同一 user に対して複数イベント (例: 相手へのリプライかつメンション) が
-// 並列で届きうる (frontend はイベント種別ごとに意味付けるため)。
+// the relevant local users' main channels. TS本家と同じくdedupはせず、
+// 同一userに対して複数イベント(例: 相手へのリプライかつメンション)が
+// 並列で届きうる(frontendはイベント種別ごとに意味付けるため)。
 func (s *CreateService) publishNoteMainEvents(note *model.Note, author *model.User, replyTarget, renoteTarget *model.Note) {
 	if s.mainStreamPublisher == nil {
 		return
 	}
 	packed := entity.PackNote(note, s.idGen)
-	// reply: reply 先が local (UserHost == nil) かつ 自分自身へのリプライで
-	// ない場合に emit。
+	// reply: reply先がlocal (UserHost == nil) かつ自分自身へのリプライで
+	// ない場合にemit。
 	if replyTarget != nil && replyTarget.UserHost == nil && replyTarget.UserID != author.ID {
 		s.mainStreamPublisher.PublishMainEvent(replyTarget.UserID, "reply", packed)
 	}
-	// renote: 同上 (TS: caller ≠ target author 条件あり)。
+	// renote: 同上 (TS: caller ≠ target author条件あり)。
 	if renoteTarget != nil && renoteTarget.UserHost == nil && renoteTarget.UserID != author.ID {
 		s.mainStreamPublisher.PublishMainEvent(renoteTarget.UserID, "renote", packed)
 	}
-	// mention: note.Mentions は (userRepo 設定時) user ID 配列なので、
-	// 各 user を fetch して local かつ author 自身でなければ emit する。
-	// userRepo 未設定時は Mentions が username 文字列のため解決不能でスキップ。
+	// mention: note.Mentionsは(userRepo設定時)user ID配列なので、
+	// 各userをfetchしてlocalかつauthor自身でなければemitする。
+	// userRepo未設定時はMentionsがusername文字列のため解決不能でスキップ。
 	if s.userRepo == nil {
 		return
 	}
@@ -559,7 +559,7 @@ func (s *CreateService) publishNoteMainEvents(note *model.Note, author *model.Us
 			continue
 		}
 		if u.Host != nil {
-			continue // remote user — AP 配送 (別レイヤ) が担当
+			continue // remote user — AP配送(別レイヤ)が担当
 		}
 		s.mainStreamPublisher.PublishMainEvent(uid, "mention", packed)
 	}

--- a/internal/core/note/note_create_service.go
+++ b/internal/core/note/note_create_service.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/shiroha-a/mk/internal/entity"
 	"github.com/shiroha-a/mk/internal/misc/id"
 	"github.com/shiroha-a/mk/internal/model"
 	"github.com/shiroha-a/mk/internal/repository"
@@ -142,25 +143,34 @@ type WebhookHook interface {
 	OnNoteCreated(note *model.Note, author *model.User, replyTarget, renoteTarget *model.Note)
 }
 
+// MainStreamPublisher emits real-time events to a single target user's `main`
+// WebSocket channel. Used here to deliver `reply`, `renote`, and `mention`
+// events so the frontend can reflect note-creation interactions immediately.
+// 循環依存を避けるため interface で受け取る (実装は internal/stream)。
+type MainStreamPublisher interface {
+	PublishMainEvent(userID, eventType string, body any)
+}
+
 // CreateService provides note creation logic.
 type CreateService struct {
-	noteRepo         repository.NoteRepository
-	pollRepo         repository.PollRepository
-	followingRepo    repository.FollowingRepository
-	idGen            id.Generator
-	fanoutHook       TimelineFanoutHook
-	notificationHook NotificationHook
-	federationHook   FederationHook
-	channelHook      ChannelHook
-	antennaHook      AntennaHook
-	indexHook        IndexHook
-	chartHook        ChartHook
-	webhookHook      WebhookHook
-	userRepo         repository.UserRepository
-	blockingRepo     repository.BlockingRepository
-	driveFileRepo    repository.DriveFileRepository
-	metaRepo         repository.MetaRepository
-	channelRepo      repository.ChannelRepository
+	noteRepo            repository.NoteRepository
+	pollRepo            repository.PollRepository
+	followingRepo       repository.FollowingRepository
+	idGen               id.Generator
+	fanoutHook          TimelineFanoutHook
+	notificationHook    NotificationHook
+	federationHook      FederationHook
+	channelHook         ChannelHook
+	antennaHook         AntennaHook
+	indexHook           IndexHook
+	chartHook           ChartHook
+	webhookHook         WebhookHook
+	mainStreamPublisher MainStreamPublisher
+	userRepo            repository.UserRepository
+	blockingRepo        repository.BlockingRepository
+	driveFileRepo       repository.DriveFileRepository
+	metaRepo            repository.MetaRepository
+	channelRepo         repository.ChannelRepository
 }
 
 // SetUserRepo attaches a UserRepository for resolving mention usernames to IDs.
@@ -255,6 +265,12 @@ func (s *CreateService) SetChartHook(h ChartHook) {
 // user webhooks subscribed to note / reply / renote / mention events can fire.
 func (s *CreateService) SetWebhookHook(h WebhookHook) {
 	s.webhookHook = h
+}
+
+// SetMainStreamPublisher attaches a publisher used to emit `reply`, `renote`,
+// and `mention` events to the main channel. Optional — nil disables emit.
+func (s *CreateService) SetMainStreamPublisher(p MainStreamPublisher) {
+	s.mainStreamPublisher = p
 }
 
 // Create creates a new note. It returns the persisted note (with the User
@@ -500,11 +516,53 @@ func (s *CreateService) Create(in CreateInput) (*model.Note, error) {
 	if s.webhookHook != nil {
 		s.webhookHook.OnNoteCreated(finalNote, in.User, replyTarget, renoteTarget)
 	}
+	// reply / renote / mention 各イベントを対象 local user の main に emit。
+	// Misskey本家 NoteCreateService と同じ fan-out 方針 (TS lines 792 / 809 / 935)。
+	s.publishNoteMainEvents(finalNote, in.User, replyTarget, renoteTarget)
 
 	// ユーザーのnotesCountをインクリメント (ベストエフォート)
 	_ = s.noteRepo.IncrementUserNotesCount(in.User.ID, 1)
 
 	return finalNote, nil
+}
+
+// publishNoteMainEvents fans out `reply`, `renote`, and `mention` events to
+// the relevant local users' main channels. TS本家と同じく dedup はせず、
+// 同一 user に対して複数イベント (例: 相手へのリプライかつメンション) が
+// 並列で届きうる (frontend はイベント種別ごとに意味付けるため)。
+func (s *CreateService) publishNoteMainEvents(note *model.Note, author *model.User, replyTarget, renoteTarget *model.Note) {
+	if s.mainStreamPublisher == nil {
+		return
+	}
+	packed := entity.PackNote(note, s.idGen)
+	// reply: reply 先が local (UserHost == nil) かつ 自分自身へのリプライで
+	// ない場合に emit。
+	if replyTarget != nil && replyTarget.UserHost == nil && replyTarget.UserID != author.ID {
+		s.mainStreamPublisher.PublishMainEvent(replyTarget.UserID, "reply", packed)
+	}
+	// renote: 同上 (TS: caller ≠ target author 条件あり)。
+	if renoteTarget != nil && renoteTarget.UserHost == nil && renoteTarget.UserID != author.ID {
+		s.mainStreamPublisher.PublishMainEvent(renoteTarget.UserID, "renote", packed)
+	}
+	// mention: note.Mentions は (userRepo 設定時) user ID 配列なので、
+	// 各 user を fetch して local かつ author 自身でなければ emit する。
+	// userRepo 未設定時は Mentions が username 文字列のため解決不能でスキップ。
+	if s.userRepo == nil {
+		return
+	}
+	for _, uid := range note.Mentions {
+		if uid == author.ID {
+			continue
+		}
+		u, err := s.userRepo.FindByID(uid)
+		if err != nil || u == nil {
+			continue
+		}
+		if u.Host != nil {
+			continue // remote user — AP 配送 (別レイヤ) が担当
+		}
+		s.mainStreamPublisher.PublishMainEvent(uid, "mention", packed)
+	}
 }
 
 // mentionRegex matches @username and @username@host occurrences anywhere in

--- a/internal/core/note/note_create_service_test.go
+++ b/internal/core/note/note_create_service_test.go
@@ -882,3 +882,152 @@ func TestCreateService_NoSuchFile_WrongOwner(t *testing.T) {
 	})
 	assert.ErrorIs(t, err, note.ErrNoSuchFile)
 }
+
+// --- MainStreamPublisher emit (Phase 7-4b-5 / #301) ---
+
+// stubMainStreamPublisher captures PublishMainEvent calls for test assertions.
+type stubMainStreamPublisher struct {
+	calls []mainEventCall
+}
+
+type mainEventCall struct {
+	userID    string
+	eventType string
+	body      any
+}
+
+func (s *stubMainStreamPublisher) PublishMainEvent(userID, eventType string, body any) {
+	s.calls = append(s.calls, mainEventCall{userID, eventType, body})
+}
+
+// eventsByType returns userIDs that received the given event type.
+func (s *stubMainStreamPublisher) userIDsOf(eventType string) []string {
+	var out []string
+	for _, c := range s.calls {
+		if c.eventType == eventType {
+			out = append(out, c.userID)
+		}
+	}
+	return out
+}
+
+func TestCreateService_PublishesReplyToLocalTarget(t *testing.T) {
+	svc, noteRepo, _ := newCreateService(t)
+	pub := &stubMainStreamPublisher{}
+	svc.SetMainStreamPublisher(pub)
+	// 相手のノート (local)
+	noteRepo.Notes["r1"] = &model.Note{
+		ID: "r1", UserID: "bob", Visibility: model.NoteVisibilityPublic,
+	}
+	replyID := "r1"
+	text := "hi"
+	_, err := svc.Create(note.CreateInput{
+		User: &model.User{ID: "alice"}, Text: &text, ReplyID: &replyID,
+	})
+	require.NoError(t, err)
+	assert.Equal(t, []string{"bob"}, pub.userIDsOf("reply"))
+}
+
+func TestCreateService_SkipsReplyToSelf(t *testing.T) {
+	svc, noteRepo, _ := newCreateService(t)
+	pub := &stubMainStreamPublisher{}
+	svc.SetMainStreamPublisher(pub)
+	noteRepo.Notes["r1"] = &model.Note{
+		ID: "r1", UserID: "alice", Visibility: model.NoteVisibilityPublic,
+	}
+	replyID := "r1"
+	text := "self reply"
+	_, err := svc.Create(note.CreateInput{
+		User: &model.User{ID: "alice"}, Text: &text, ReplyID: &replyID,
+	})
+	require.NoError(t, err)
+	assert.Empty(t, pub.userIDsOf("reply"))
+}
+
+func TestCreateService_SkipsReplyToRemoteTarget(t *testing.T) {
+	svc, noteRepo, _ := newCreateService(t)
+	pub := &stubMainStreamPublisher{}
+	svc.SetMainStreamPublisher(pub)
+	remoteHost := "remote.example"
+	noteRepo.Notes["r1"] = &model.Note{
+		ID: "r1", UserID: "remoteuser", UserHost: &remoteHost,
+		Visibility: model.NoteVisibilityPublic,
+	}
+	replyID := "r1"
+	text := "hi"
+	_, err := svc.Create(note.CreateInput{
+		User: &model.User{ID: "alice"}, Text: &text, ReplyID: &replyID,
+	})
+	require.NoError(t, err)
+	assert.Empty(t, pub.userIDsOf("reply"))
+}
+
+func TestCreateService_PublishesRenoteToLocalTarget(t *testing.T) {
+	svc, noteRepo, _ := newCreateService(t)
+	pub := &stubMainStreamPublisher{}
+	svc.SetMainStreamPublisher(pub)
+	noteRepo.Notes["r1"] = &model.Note{
+		ID: "r1", UserID: "bob", Visibility: model.NoteVisibilityPublic,
+	}
+	renoteID := "r1"
+	_, err := svc.Create(note.CreateInput{
+		User: &model.User{ID: "alice"}, RenoteID: &renoteID,
+	})
+	require.NoError(t, err)
+	assert.Equal(t, []string{"bob"}, pub.userIDsOf("renote"))
+}
+
+func TestCreateService_PublishesMentionToLocalUser(t *testing.T) {
+	svc, noteRepo, _ := newCreateService(t)
+	_ = noteRepo
+	userRepo := testutil.NewMockUserRepository()
+	userRepo.Users["uA"] = &model.User{ID: "uA", Username: "alice", UsernameLower: "alice"}
+	remoteHost := "remote.example"
+	userRepo.Users["uB"] = &model.User{
+		ID: "uB", Username: "bob", UsernameLower: "bob", Host: &remoteHost,
+	}
+	svc.SetUserRepo(userRepo)
+	pub := &stubMainStreamPublisher{}
+	svc.SetMainStreamPublisher(pub)
+
+	text := "hi @alice and @bob@remote.example"
+	_, err := svc.Create(note.CreateInput{
+		User: &model.User{ID: "author1"}, Text: &text,
+	})
+	require.NoError(t, err)
+	// local user (alice) にだけ mention emit、remote bob は skip。
+	assert.Equal(t, []string{"uA"}, pub.userIDsOf("mention"))
+}
+
+func TestCreateService_SkipsMentionToSelf(t *testing.T) {
+	svc, _, _ := newCreateService(t)
+	userRepo := testutil.NewMockUserRepository()
+	userRepo.Users["author1"] = &model.User{
+		ID: "author1", Username: "author1", UsernameLower: "author1",
+	}
+	svc.SetUserRepo(userRepo)
+	pub := &stubMainStreamPublisher{}
+	svc.SetMainStreamPublisher(pub)
+
+	text := "hi @author1"
+	_, err := svc.Create(note.CreateInput{
+		User: &model.User{ID: "author1"}, Text: &text,
+	})
+	require.NoError(t, err)
+	assert.Empty(t, pub.userIDsOf("mention"))
+}
+
+func TestCreateService_NoMainStreamPublisher_NoEmit(t *testing.T) {
+	svc, noteRepo, _ := newCreateService(t)
+	noteRepo.Notes["r1"] = &model.Note{
+		ID: "r1", UserID: "bob", Visibility: model.NoteVisibilityPublic,
+	}
+	// SetMainStreamPublisher を呼ばず、reply を作成しても panic / error
+	// しないことだけ確認。
+	replyID := "r1"
+	text := "hi"
+	_, err := svc.Create(note.CreateInput{
+		User: &model.User{ID: "alice"}, Text: &text, ReplyID: &replyID,
+	})
+	require.NoError(t, err)
+}

--- a/internal/server/router.go
+++ b/internal/server/router.go
@@ -1246,6 +1246,7 @@ func (s *Server) setupRoutes() {
 	driveService.SetStreamingPublisher(drivePublisher)
 	followingService.SetMainStreamPublisher(mainStreamPublisher)
 	userService.SetMainStreamPublisher(mainStreamPublisher)
+	noteCreateService.SetMainStreamPublisher(mainStreamPublisher)
 
 	// 5. Reversi WebSocket channel (Phase 9.6) を登録する
 	reversiService := corereversi.NewService(reversiRepo, reversiPublisher, s.redis.Default)


### PR DESCRIPTION
## Summary

#288 (umbrella) の中優先度 note-creation クラスタを実装。Misskey 本家 \`NoteCreateService.ts\` と同じ fan-out 方針で、note 作成時に \`reply\` / \`renote\` / \`mention\` の 3 種を対応する local user の main チャネルへ publish する。

## 主な変更点

### 実装 (\`internal/core/note/note_create_service.go\`)

- \`MainStreamPublisher\` interface + \`SetMainStreamPublisher\` setter を追加 (#246 pattern 踏襲)
- \`publishNoteMainEvents(note, author, replyTarget, renoteTarget)\` ヘルパーで 3 種 emit を集約:

| TS event | 条件 | body |
|---|---|---|
| \`reply\` | reply target が local (\`UserHost==nil\`) かつ \`caller != target author\` | \`entity.PackNote(note, idGen)\` |
| \`renote\` | renote target が local かつ \`caller != target author\` | 同上 |
| \`mention\` | \`note.Mentions\` の各 user を \`userRepo.FindByID\` で解決、local かつ author 以外 | 同上 |

- remote user は AP 配送 (別レイヤ) が担当するため skip
- TS と同じく dedup はしない (同一 user が reply+mention を独立受信可 — frontend がイベント種別で区別)
- \`note.Mentions\` は userRepo 設定時のみ user ID 配列になるため、未設定時は mention emit skip

### router 配線 (\`internal/server/router.go\`)

- \`mainStreamPublisher\` を \`noteCreateService.SetMainStreamPublisher\` に注入

## スコープ外

- thread-muting チェック (TS は ThreadMutingsRepository で mute 済み thread への emit を抑制するが Go 未実装)
- remote user mention の AP 配送 (別レイヤの責務)
- channel note の特殊ケース

## テスト

- \`make fmt && go vet ./...\` 通過
- 追加テスト 7 ケース:
  - \`PublishesReplyToLocalTarget\` — 正常 emit
  - \`SkipsReplyToSelf\` — 自分自身宛はスキップ
  - \`SkipsReplyToRemoteTarget\` — remote user はスキップ
  - \`PublishesRenoteToLocalTarget\` — renote 正常
  - \`PublishesMentionToLocalUser\` — local user のみ emit、remote はスキップ
  - \`SkipsMentionToSelf\` — 自分自身の mention はスキップ
  - \`NoMainStreamPublisher_NoEmit\` — publisher 未注入でも通常動作
- カバレッジ: \`internal/core/note\` 92.8%
- \`go test ./...\` 全体通過

### 実行コマンド

\`\`\`bash
make fmt && go vet ./... && go test ./...
\`\`\`

## Closes

Closes #301

## 関連

- Umbrella: #288 (main チャネル 22 種追跡)
- Base: #246 (MainStreamPublisher infrastructure)
- TS 参照: \`third_party/misskey/packages/backend/src/core/NoteCreateService.ts\` (lines 792 / 809 / 935)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/shiroha-a/mk/pull/302" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
