### PR TITLE
Perf #300 P0: parallelize hot paths + add meta singleton cache

### DIFF
--- a/internal/api/test/handler.go
+++ b/internal/api/test/handler.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/labstack/echo/v4"
 	"github.com/redis/go-redis/v9"
+	"github.com/shiroha-a/mk/internal/repository"
 	"gorm.io/gorm"
 )
 
@@ -35,6 +36,7 @@ const resetDBMaxRetries = 3
 type Handler struct {
 	db       *gorm.DB
 	redis    *redis.Client
+	metaRepo repository.MetaRepository
 	testMode bool
 }
 
@@ -43,10 +45,11 @@ type Handler struct {
 // db and redis are both required when testMode is true. They are accepted
 // regardless so that test code that spins up a zero-value Handler cannot
 // accidentally pass a nil dependency without it being caught by the runtime.
-func NewHandler(db *gorm.DB, redisClient *redis.Client, testMode bool) *Handler {
+func NewHandler(db *gorm.DB, redisClient *redis.Client, metaRepo repository.MetaRepository, testMode bool) *Handler {
 	return &Handler{
 		db:       db,
 		redis:    redisClient,
+		metaRepo: metaRepo,
 		testMode: testMode,
 	}
 }
@@ -77,11 +80,13 @@ func (h *Handler) ResetDB(c echo.Context) error {
 		}
 		// meta テーブルは TRUNCATE で消えるが、初期セットアップフロー
 		// (/api/admin/accounts/create) が `SELECT * FROM meta` を前提にしているので
-		// 空行を 1 つ再挿入する。id は singleton なので値は何でも良い。
-		// 全カラムは DB 側 default を持っているのでこれだけで有効な行になる。
-		if err := h.db.WithContext(ctx).Exec(`INSERT INTO "meta" ("id") VALUES ('meta-singleton') ON CONFLICT DO NOTHING`).Error; err != nil {
-			slog.Error("reset-db: meta re-init failed", "err", err)
-			return echo.NewHTTPError(http.StatusInternalServerError, "db reset failed")
+		// 空行を 1 つ再挿入する。MetaRepository 経由で行うことで
+		// CachedMetaRepository のキャッシュも無効化される。
+		if h.metaRepo != nil {
+			if err := h.metaRepo.EnsureInitial("meta-singleton"); err != nil {
+				slog.Error("reset-db: meta re-init failed", "err", err)
+				return echo.NewHTTPError(http.StatusInternalServerError, "db reset failed")
+			}
 		}
 	}
 

--- a/internal/api/test/handler_test.go
+++ b/internal/api/test/handler_test.go
@@ -83,7 +83,7 @@ func quoteIdent(name string) string {
 }
 
 func TestResetDB_TestModeDisabled_Returns404(t *testing.T) {
-	h := NewHandler(nil, nil, false)
+	h := NewHandler(nil, nil, nil, false)
 
 	c, rec := freshEchoContext()
 	err := h.ResetDB(c)
@@ -105,7 +105,7 @@ func TestResetDB_FlushesRedisAndTables(t *testing.T) {
 	// meta テーブルに行を入れる (migration で必ず存在するテーブルなので安全)。
 	seedRow(t, testPg.DB, "meta", "m_reset_1")
 
-	h := NewHandler(testPg.DB, testRedis.Client, true)
+	h := NewHandler(testPg.DB, testRedis.Client, nil, true)
 
 	c, rec := freshEchoContext()
 	require.NoError(t, h.ResetDB(c))
@@ -141,7 +141,7 @@ func TestResetDB_MetaInsertError_Returns500(t *testing.T) {
 		_ = testPg.DB.Exec(`ALTER TABLE "meta_test_backup" RENAME TO "meta"`).Error
 	})
 
-	h := NewHandler(testPg.DB, testRedis.Client, true)
+	h := NewHandler(testPg.DB, testRedis.Client, nil, true)
 	c, rec := freshEchoContext()
 	err := h.ResetDB(c)
 
@@ -168,7 +168,7 @@ func TestResetDB_PreservesSchemaMigrations(t *testing.T) {
 		).Error)
 	}
 
-	h := NewHandler(testPg.DB, testRedis.Client, true)
+	h := NewHandler(testPg.DB, testRedis.Client, nil, true)
 	c, _ := freshEchoContext()
 	require.NoError(t, h.ResetDB(c))
 
@@ -179,7 +179,7 @@ func TestResetDB_PreservesSchemaMigrations(t *testing.T) {
 
 func TestResetDB_NilDependencies(t *testing.T) {
 	// TestMode=true でも db/redis が nil なら reset は no-op 扱いで 204 を返す。
-	h := NewHandler(nil, nil, true)
+	h := NewHandler(nil, nil, nil, true)
 	c, rec := freshEchoContext()
 	require.NoError(t, h.ResetDB(c))
 	assert.Equal(t, http.StatusNoContent, rec.Code)
@@ -192,7 +192,7 @@ func TestResetDB_RedisFlushError_Returns500(t *testing.T) {
 	brokenRedis := redis.NewClient(&redis.Options{Addr: "127.0.0.1:1"})
 	require.NoError(t, brokenRedis.Close())
 
-	h := NewHandler(testPg.DB, brokenRedis, true)
+	h := NewHandler(testPg.DB, brokenRedis, nil, true)
 	c, _ := freshEchoContext()
 	err := h.ResetDB(c)
 	require.Error(t, err)
@@ -237,7 +237,7 @@ func TestResetDB_DBError_HandlerReturns500(t *testing.T) {
 
 	// Redis 側は本物のクライアントのままだとキャンセル済み ctx で失敗する。
 	// 期待挙動としては 500 が返れば良い。
-	h := NewHandler(testPg.DB, testRedis.Client, true)
+	h := NewHandler(testPg.DB, testRedis.Client, nil, true)
 	err := h.ResetDB(c)
 	require.Error(t, err)
 	var he *echo.HTTPError
@@ -272,7 +272,7 @@ func TestResetDB_DBError_WithNilRedis(t *testing.T) {
 	requireContainers(t)
 
 	badDB := openBrokenDB(t)
-	h := NewHandler(badDB, nil, true)
+	h := NewHandler(badDB, nil, nil, true)
 	c, _ := freshEchoContext()
 	err := h.ResetDB(c)
 	require.Error(t, err)

--- a/internal/api/test/handler_test.go
+++ b/internal/api/test/handler_test.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/labstack/echo/v4"
 	"github.com/redis/go-redis/v9"
+	"github.com/shiroha-a/mk/internal/repository"
 	"github.com/shiroha-a/mk/internal/testutil"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -105,7 +106,8 @@ func TestResetDB_FlushesRedisAndTables(t *testing.T) {
 	// meta テーブルに行を入れる (migration で必ず存在するテーブルなので安全)。
 	seedRow(t, testPg.DB, "meta", "m_reset_1")
 
-	h := NewHandler(testPg.DB, testRedis.Client, nil, true)
+	metaRepo := repository.NewMetaRepository(testPg.DB)
+	h := NewHandler(testPg.DB, testRedis.Client, metaRepo, true)
 
 	c, rec := freshEchoContext()
 	require.NoError(t, h.ResetDB(c))
@@ -141,11 +143,12 @@ func TestResetDB_MetaInsertError_Returns500(t *testing.T) {
 		_ = testPg.DB.Exec(`ALTER TABLE "meta_test_backup" RENAME TO "meta"`).Error
 	})
 
-	h := NewHandler(testPg.DB, testRedis.Client, nil, true)
+	metaRepo := repository.NewMetaRepository(testPg.DB)
+	h := NewHandler(testPg.DB, testRedis.Client, metaRepo, true)
 	c, rec := freshEchoContext()
 	err := h.ResetDB(c)
 
-	// meta テーブルが存在しないので INSERT が失敗し、500 が返る
+	// meta テーブルが存在しないので EnsureInitial が失敗し、500 が返る
 	require.Error(t, err)
 	var he *echo.HTTPError
 	require.True(t, errors.As(err, &he))

--- a/internal/api/users/handler.go
+++ b/internal/api/users/handler.go
@@ -3,6 +3,7 @@ package users
 import (
 	"errors"
 	"net/http"
+	"sync"
 
 	"github.com/labstack/echo/v4"
 	"github.com/shiroha-a/mk/internal/api/apierr"
@@ -207,44 +208,76 @@ func (h *Handler) Show(c echo.Context) error {
 	// Phase 7-3 (#245): ピン止めnote / ピン止めpage を埋める。
 	h.fillPinned(bundle.User, bundle.Profile, &detailed)
 
-	// viewerがログインしている場合、viewer依存フィールドを追加
+	// viewerがログインしている場合、viewer依存フィールドを並列取得する。
+	// 各リポジトリへのクエリは完全に独立しているためgoroutineで並列実行し、
+	// 全結果が揃ってからdetailedに反映する。
 	if viewer := middleware.GetUser(c); viewer != nil && viewer.ID != bundle.User.ID {
+		var (
+			isFollowing, isFollowed      bool
+			isBlocking, isBlocked        bool
+			isMuted, isRenoteMuted       bool
+			hasPendingFrom, hasPendingTo bool
+			followRec                    *model.Following
+			memo                         *model.UserMemo
+			wg                           sync.WaitGroup
+		)
+
 		if h.followingRepo != nil {
-			isFollowing, _ := h.followingRepo.Exists(viewer.ID, bundle.User.ID)
-			isFollowed, _ := h.followingRepo.Exists(bundle.User.ID, viewer.ID)
+			wg.Add(3)
+			go func() { defer wg.Done(); isFollowing, _ = h.followingRepo.Exists(viewer.ID, bundle.User.ID) }()
+			go func() { defer wg.Done(); isFollowed, _ = h.followingRepo.Exists(bundle.User.ID, viewer.ID) }()
+			go func() { defer wg.Done(); followRec, _ = h.followingRepo.FindByPair(viewer.ID, bundle.User.ID) }()
+		}
+		if h.blockingRepo != nil {
+			wg.Add(2)
+			go func() { defer wg.Done(); isBlocking, _ = h.blockingRepo.Exists(viewer.ID, bundle.User.ID) }()
+			go func() { defer wg.Done(); isBlocked, _ = h.blockingRepo.Exists(bundle.User.ID, viewer.ID) }()
+		}
+		if h.mutingRepo != nil {
+			wg.Add(1)
+			go func() { defer wg.Done(); isMuted, _ = h.mutingRepo.Exists(viewer.ID, bundle.User.ID) }()
+		}
+		if h.renoteMutingRepo != nil {
+			wg.Add(1)
+			go func() { defer wg.Done(); isRenoteMuted, _ = h.renoteMutingRepo.Exists(viewer.ID, bundle.User.ID) }()
+		}
+		if h.followRequestRepo != nil {
+			wg.Add(2)
+			go func() { defer wg.Done(); hasPendingFrom, _ = h.followRequestRepo.Exists(viewer.ID, bundle.User.ID) }()
+			go func() { defer wg.Done(); hasPendingTo, _ = h.followRequestRepo.Exists(bundle.User.ID, viewer.ID) }()
+		}
+		if h.memoRepo != nil {
+			wg.Add(1)
+			go func() { defer wg.Done(); memo, _ = h.memoRepo.FindByPair(viewer.ID, bundle.User.ID) }()
+		}
+
+		wg.Wait()
+
+		if h.followingRepo != nil {
 			detailed.IsFollowing = &isFollowing
 			detailed.IsFollowed = &isFollowed
-			// notify/withReplies はフォロー関係レコードから取得
-			if f, err := h.followingRepo.FindByPair(viewer.ID, bundle.User.ID); err == nil {
-				detailed.Notify = f.Notify
-				wr := f.WithReplies
+			if followRec != nil {
+				detailed.Notify = followRec.Notify
+				wr := followRec.WithReplies
 				detailed.WithReplies = &wr
 			}
 		}
 		if h.blockingRepo != nil {
-			isBlocking, _ := h.blockingRepo.Exists(viewer.ID, bundle.User.ID)
-			isBlocked, _ := h.blockingRepo.Exists(bundle.User.ID, viewer.ID)
 			detailed.IsBlocking = &isBlocking
 			detailed.IsBlocked = &isBlocked
 		}
 		if h.mutingRepo != nil {
-			isMuted, _ := h.mutingRepo.Exists(viewer.ID, bundle.User.ID)
 			detailed.IsMuted = &isMuted
 		}
 		if h.renoteMutingRepo != nil {
-			isRenoteMuted, _ := h.renoteMutingRepo.Exists(viewer.ID, bundle.User.ID)
 			detailed.IsRenoteMuted = &isRenoteMuted
 		}
 		if h.followRequestRepo != nil {
-			hasPendingFrom, _ := h.followRequestRepo.Exists(viewer.ID, bundle.User.ID)
-			hasPendingTo, _ := h.followRequestRepo.Exists(bundle.User.ID, viewer.ID)
 			detailed.HasPendingFollowRequestFromYou = &hasPendingFrom
 			detailed.HasPendingFollowRequestToYou = &hasPendingTo
 		}
-		if h.memoRepo != nil {
-			if memo, err := h.memoRepo.FindByPair(viewer.ID, bundle.User.ID); err == nil {
-				detailed.Memo = &memo.Memo
-			}
+		if h.memoRepo != nil && memo != nil {
+			detailed.Memo = &memo.Memo
 		}
 	}
 

--- a/internal/core/note/export_test.go
+++ b/internal/core/note/export_test.go
@@ -4,3 +4,6 @@ package note
 func IsPureRenoteForTest(in CreateInput) bool {
 	return isPureRenote(in)
 }
+
+// SafeGoForTest exposes safeGo to package-external tests.
+func SafeGoForTest(fn func()) { safeGo(fn) }

--- a/internal/core/note/note_create_service.go
+++ b/internal/core/note/note_create_service.go
@@ -3,6 +3,7 @@ package note
 
 import (
 	"errors"
+	"log/slog"
 	"regexp"
 	"strings"
 	"time"
@@ -483,45 +484,38 @@ func (s *CreateService) Create(in CreateInput) (*model.Note, error) {
 		finalNote.User = in.User
 	}
 
-	// 永続化が成功してからtimelineへ配信する。fanoutが失敗してもnote自体は
-	// 既に保存済みなので、ハンドラへはエラーを返さずベストエフォートとする。
+	// ベストエフォートフックを非同期で並列実行する。各フックは独立しており、
+	// 失敗してもノート作成自体は成功扱い。TS版と同様にfire-and-forgetで配信する。
 	if s.fanoutHook != nil {
-		s.fanoutHook.OnNoteCreated(finalNote, in.User)
+		safeGo(func() { s.fanoutHook.OnNoteCreated(finalNote, in.User) })
 	}
-	// 通知も同様にベストエフォート。
 	if s.notificationHook != nil {
-		s.notificationHook.OnNoteCreated(finalNote, in.User, replyTarget, renoteTarget)
+		safeGo(func() { s.notificationHook.OnNoteCreated(finalNote, in.User, replyTarget, renoteTarget) })
 	}
-	// AP配信もベストエフォート。
 	if s.federationHook != nil {
-		s.federationHook.OnNoteCreated(finalNote, in.User)
+		safeGo(func() { s.federationHook.OnNoteCreated(finalNote, in.User) })
 	}
-	// チャンネル投稿の lastNotedAt / notesCount 更新もベストエフォート。
 	if s.channelHook != nil && in.ChannelID != nil && *in.ChannelID != "" {
-		s.channelHook.OnNotePosted(*in.ChannelID)
+		chID := *in.ChannelID
+		safeGo(func() { s.channelHook.OnNotePosted(chID) })
 	}
-	// アンテナの fan-out もベストエフォート (失敗してもノート作成自体は成功)。
 	if s.antennaHook != nil {
-		s.antennaHook.OnNoteCreated(finalNote, in.User)
+		safeGo(func() { s.antennaHook.OnNoteCreated(finalNote, in.User) })
 	}
-	// 検索インデックスへの反映もベストエフォート。
 	if s.indexHook != nil {
-		s.indexHook.OnNoteCreated(finalNote)
+		safeGo(func() { s.indexHook.OnNoteCreated(finalNote) })
 	}
-	// チャート集計もベストエフォート。失敗してもノート作成自体は成功扱い。
 	if s.chartHook != nil {
-		s.chartHook.OnNoteCreated(finalNote)
+		safeGo(func() { s.chartHook.OnNoteCreated(finalNote) })
 	}
-	// Webhook配信もベストエフォート。
 	if s.webhookHook != nil {
-		s.webhookHook.OnNoteCreated(finalNote, in.User, replyTarget, renoteTarget)
+		safeGo(func() { s.webhookHook.OnNoteCreated(finalNote, in.User, replyTarget, renoteTarget) })
 	}
 	// reply / renote / mention 各イベントを対象local userのmainにemit。
 	// Misskey本家NoteCreateServiceと同じfan-out方針 (TS lines 792 / 809 / 935)。
 	s.publishNoteMainEvents(finalNote, in.User, replyTarget, renoteTarget)
 
-	// ユーザーのnotesCountをインクリメント (ベストエフォート)
-	_ = s.noteRepo.IncrementUserNotesCount(in.User.ID, 1)
+	safeGo(func() { _ = s.noteRepo.IncrementUserNotesCount(in.User.ID, 1) })
 
 	return finalNote, nil
 }
@@ -563,6 +557,19 @@ func (s *CreateService) publishNoteMainEvents(note *model.Note, author *model.Us
 		}
 		s.mainStreamPublisher.PublishMainEvent(uid, "mention", packed)
 	}
+}
+
+// safeGo runs fn in a new goroutine, recovering from panics.
+// ベストエフォートフックでパニックが発生してもプロセス全体が落ちないようにする。
+func safeGo(fn func()) {
+	go func() {
+		defer func() {
+			if r := recover(); r != nil {
+				slog.Error("recovered panic in best-effort hook", "panic", r)
+			}
+		}()
+		fn()
+	}()
 }
 
 // mentionRegex matches @username and @username@host occurrences anywhere in

--- a/internal/core/note/note_create_service_test.go
+++ b/internal/core/note/note_create_service_test.go
@@ -2,6 +2,7 @@ package note_test
 
 import (
 	"errors"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -396,48 +397,77 @@ func TestIsPureRenote(t *testing.T) {
 
 func ptrString(s string) *string { return &s }
 
+// waitHook blocks until done receives a signal or 5s timeout.
+func waitHook(t *testing.T, done <-chan struct{}) {
+	t.Helper()
+	select {
+	case <-done:
+	case <-time.After(5 * time.Second):
+		t.Fatal("hook did not fire within timeout")
+	}
+}
+
 // recordingHook captures fanout invocations for tests.
 type recordingHook struct {
-	called bool
+	called atomic.Bool
 	note   *model.Note
 	user   *model.User
+	done   chan struct{}
+}
+
+func newRecordingHook() *recordingHook {
+	return &recordingHook{done: make(chan struct{}, 1)}
 }
 
 func (h *recordingHook) OnNoteCreated(n *model.Note, u *model.User) {
-	h.called = true
+	h.called.Store(true)
 	h.note = n
 	h.user = u
+	select {
+	case h.done <- struct{}{}:
+	default:
+	}
 }
 
 func TestCreateService_FanoutHookInvoked(t *testing.T) {
 	svc, _, _ := newCreateService(t)
-	hook := &recordingHook{}
+	hook := newRecordingHook()
 	svc.SetFanoutHook(hook)
 
 	user := &model.User{ID: "u1"}
 	text := "hello"
 	created, err := svc.Create(note.CreateInput{User: user, Text: &text})
 	require.NoError(t, err)
-	assert.True(t, hook.called)
+	waitHook(t, hook.done)
+	assert.True(t, hook.called.Load())
 	assert.Equal(t, created.ID, hook.note.ID)
 	assert.Equal(t, user, hook.user)
 }
 
 // recordingNotificationHook captures notification calls for tests.
 type recordingNotificationHook struct {
-	called       bool
+	called       atomic.Bool
 	gotNote      *model.Note
 	gotAuthor    *model.User
 	gotReplyTgt  *model.Note
 	gotRenoteTgt *model.Note
+	done         chan struct{}
+}
+
+func newRecordingNotificationHook() *recordingNotificationHook {
+	return &recordingNotificationHook{done: make(chan struct{}, 1)}
 }
 
 func (h *recordingNotificationHook) OnNoteCreated(n *model.Note, u *model.User, reply, renote *model.Note) {
-	h.called = true
+	h.called.Store(true)
 	h.gotNote = n
 	h.gotAuthor = u
 	h.gotReplyTgt = reply
 	h.gotRenoteTgt = renote
+	select {
+	case h.done <- struct{}{}:
+	default:
+	}
 }
 
 func TestCreateService_NotificationHookInvoked(t *testing.T) {
@@ -445,7 +475,7 @@ func TestCreateService_NotificationHookInvoked(t *testing.T) {
 	noteRepo.Notes["target"] = &model.Note{
 		ID: "target", UserID: "author", Visibility: model.NoteVisibilityPublic,
 	}
-	hook := &recordingNotificationHook{}
+	hook := newRecordingNotificationHook()
 	svc.SetNotificationHook(hook)
 
 	user := &model.User{ID: "u1"}
@@ -453,7 +483,8 @@ func TestCreateService_NotificationHookInvoked(t *testing.T) {
 	replyID := "target"
 	_, err := svc.Create(note.CreateInput{User: user, Text: &text, ReplyID: &replyID})
 	require.NoError(t, err)
-	assert.True(t, hook.called)
+	waitHook(t, hook.done)
+	assert.True(t, hook.called.Load())
 	assert.Equal(t, "target", hook.gotReplyTgt.ID)
 }
 
@@ -463,41 +494,52 @@ func TestCreateService_FanoutHookCalledOnFallbackPath(t *testing.T) {
 	noteRepo := &findFailNoteRepo{MockNoteRepository: testutil.NewMockNoteRepository()}
 	pollRepo := testutil.NewMockPollRepository()
 	svc := note.NewCreateService(noteRepo, pollRepo, idGen, nil)
-	hook := &recordingHook{}
+	hook := newRecordingHook()
 	svc.SetFanoutHook(hook)
 
 	user := &model.User{ID: "u1"}
 	text := "hi"
 	_, err := svc.Create(note.CreateInput{User: user, Text: &text})
 	require.NoError(t, err)
-	assert.True(t, hook.called)
+	waitHook(t, hook.done)
+	assert.True(t, hook.called.Load())
 	// fallbackパスではin.Userが埋め込まれる
 	assert.Equal(t, user, hook.note.User)
 }
 
 // recordingFederationHook captures federation hook calls for tests.
 type recordingFederationHook struct {
-	called bool
+	called atomic.Bool
 	note   *model.Note
 	user   *model.User
+	done   chan struct{}
+}
+
+func newRecordingFederationHook() *recordingFederationHook {
+	return &recordingFederationHook{done: make(chan struct{}, 1)}
 }
 
 func (h *recordingFederationHook) OnNoteCreated(n *model.Note, u *model.User) {
-	h.called = true
+	h.called.Store(true)
 	h.note = n
 	h.user = u
+	select {
+	case h.done <- struct{}{}:
+	default:
+	}
 }
 
 func TestCreateService_FederationHookInvoked(t *testing.T) {
 	svc, _, _ := newCreateService(t)
-	hook := &recordingFederationHook{}
+	hook := newRecordingFederationHook()
 	svc.SetFederationHook(hook)
 
 	user := &model.User{ID: "u1"}
 	text := "hello"
 	created, err := svc.Create(note.CreateInput{User: user, Text: &text})
 	require.NoError(t, err)
-	assert.True(t, hook.called)
+	waitHook(t, hook.done)
+	assert.True(t, hook.called.Load())
 	assert.Equal(t, created.ID, hook.note.ID)
 }
 
@@ -506,8 +548,13 @@ type recordingChannelHook struct {
 	ensureCalled bool
 	ensureID     string
 	ensureErr    error
-	postedCalled bool
+	postedCalled atomic.Bool
 	postedID     string
+	postedDone   chan struct{}
+}
+
+func newRecordingChannelHook() *recordingChannelHook {
+	return &recordingChannelHook{postedDone: make(chan struct{}, 1)}
 }
 
 func (h *recordingChannelHook) EnsureChannelExists(channelID string) error {
@@ -517,13 +564,17 @@ func (h *recordingChannelHook) EnsureChannelExists(channelID string) error {
 }
 
 func (h *recordingChannelHook) OnNotePosted(channelID string) {
-	h.postedCalled = true
+	h.postedCalled.Store(true)
 	h.postedID = channelID
+	select {
+	case h.postedDone <- struct{}{}:
+	default:
+	}
 }
 
 func TestCreateService_ChannelHookEnsureAndOnPosted(t *testing.T) {
 	svc, _, _ := newCreateService(t)
-	hook := &recordingChannelHook{}
+	hook := newRecordingChannelHook()
 	svc.SetChannelHook(hook)
 
 	user := &model.User{ID: "u1"}
@@ -531,15 +582,19 @@ func TestCreateService_ChannelHookEnsureAndOnPosted(t *testing.T) {
 	channelID := "ch1"
 	_, err := svc.Create(note.CreateInput{User: user, Text: &text, ChannelID: &channelID})
 	require.NoError(t, err)
+	// EnsureChannelExistsはCreate内で同期的に呼ばれる
 	assert.True(t, hook.ensureCalled)
 	assert.Equal(t, "ch1", hook.ensureID)
-	assert.True(t, hook.postedCalled)
+	// OnNotePostedは非同期
+	waitHook(t, hook.postedDone)
+	assert.True(t, hook.postedCalled.Load())
 	assert.Equal(t, "ch1", hook.postedID)
 }
 
 func TestCreateService_ChannelNotFound(t *testing.T) {
 	svc, _, _ := newCreateService(t)
-	hook := &recordingChannelHook{ensureErr: errors.New("missing")}
+	hook := newRecordingChannelHook()
+	hook.ensureErr = errors.New("missing")
 	svc.SetChannelHook(hook)
 
 	user := &model.User{ID: "u1"}
@@ -560,47 +615,69 @@ func TestCreateService_NoChannelHookSkipsCheck(t *testing.T) {
 
 // recordingAntennaHook captures antenna hook calls for tests.
 type recordingAntennaHook struct {
-	called bool
+	called atomic.Bool
 	note   *model.Note
+	done   chan struct{}
+}
+
+func newRecordingAntennaHook() *recordingAntennaHook {
+	return &recordingAntennaHook{done: make(chan struct{}, 1)}
 }
 
 func (h *recordingAntennaHook) OnNoteCreated(n *model.Note, _ *model.User) {
-	h.called = true
+	h.called.Store(true)
 	h.note = n
+	select {
+	case h.done <- struct{}{}:
+	default:
+	}
 }
 
 func TestCreateService_AntennaHookInvoked(t *testing.T) {
 	svc, _, _ := newCreateService(t)
-	hook := &recordingAntennaHook{}
+	hook := newRecordingAntennaHook()
 	svc.SetAntennaHook(hook)
 
 	user := &model.User{ID: "u1"}
 	text := "hello"
 	created, err := svc.Create(note.CreateInput{User: user, Text: &text})
 	require.NoError(t, err)
-	assert.True(t, hook.called)
+	waitHook(t, hook.done)
+	assert.True(t, hook.called.Load())
 	assert.Equal(t, created.ID, hook.note.ID)
 }
 
 // recordingIndexHook records calls into note.IndexHook so the create / delete
 // services の連携経路を検証できる。
 type recordingIndexHook struct {
-	created *model.Note
-	deleted *model.Note
+	created     *model.Note
+	deleted     *model.Note
+	createdDone chan struct{}
 }
 
-func (h *recordingIndexHook) OnNoteCreated(n *model.Note) { h.created = n }
+func newRecordingIndexHook() *recordingIndexHook {
+	return &recordingIndexHook{createdDone: make(chan struct{}, 1)}
+}
+
+func (h *recordingIndexHook) OnNoteCreated(n *model.Note) {
+	h.created = n
+	select {
+	case h.createdDone <- struct{}{}:
+	default:
+	}
+}
 func (h *recordingIndexHook) OnNoteDeleted(n *model.Note) { h.deleted = n }
 
 func TestCreateService_IndexHookInvoked(t *testing.T) {
 	svc, _, _ := newCreateService(t)
-	hook := &recordingIndexHook{}
+	hook := newRecordingIndexHook()
 	svc.SetIndexHook(hook)
 
 	user := &model.User{ID: "u1"}
 	text := "hello"
 	created, err := svc.Create(note.CreateInput{User: user, Text: &text})
 	require.NoError(t, err)
+	waitHook(t, hook.createdDone)
 	require.NotNil(t, hook.created)
 	assert.Equal(t, created.ID, hook.created.ID)
 }
@@ -610,19 +687,31 @@ func TestCreateService_IndexHookInvoked(t *testing.T) {
 // out alongside the other registered hooks.
 type recordingChartHook struct {
 	created *model.Note
+	done    chan struct{}
 }
 
-func (h *recordingChartHook) OnNoteCreated(n *model.Note) { h.created = n }
+func newRecordingChartHook() *recordingChartHook {
+	return &recordingChartHook{done: make(chan struct{}, 1)}
+}
+
+func (h *recordingChartHook) OnNoteCreated(n *model.Note) {
+	h.created = n
+	select {
+	case h.done <- struct{}{}:
+	default:
+	}
+}
 
 func TestCreateService_ChartHookInvoked(t *testing.T) {
 	svc, _, _ := newCreateService(t)
-	hook := &recordingChartHook{}
+	hook := newRecordingChartHook()
 	svc.SetChartHook(hook)
 
 	user := &model.User{ID: "u1"}
 	text := "hello"
 	created, err := svc.Create(note.CreateInput{User: user, Text: &text})
 	require.NoError(t, err)
+	waitHook(t, hook.done)
 	require.NotNil(t, hook.created)
 	assert.Equal(t, created.ID, hook.created.ID)
 }
@@ -1030,4 +1119,18 @@ func TestCreateService_NoMainStreamPublisher_NoEmit(t *testing.T) {
 		User: &model.User{ID: "alice"}, Text: &text, ReplyID: &replyID,
 	})
 	require.NoError(t, err)
+}
+
+func TestSafeGo_RecoversPanic(t *testing.T) {
+	done := make(chan struct{})
+	note.SafeGoForTest(func() {
+		defer func() { close(done) }()
+		panic("test panic")
+	})
+	select {
+	case <-done:
+		// パニックから回復して正常終了
+	case <-time.After(5 * time.Second):
+		t.Fatal("safeGo did not recover panic")
+	}
 }

--- a/internal/repository/meta_cached.go
+++ b/internal/repository/meta_cached.go
@@ -31,6 +31,8 @@ func NewCachedMetaRepositoryWithTTL(inner MetaRepository, ttl time.Duration) *Ca
 }
 
 // Fetch returns the cached meta if still valid, otherwise fetches from DB.
+// 返却される *model.Meta はキャッシュ内部と同一ポインタのため、呼び出し側で
+// フィールドを変更してはならない（read-only）。
 func (c *CachedMetaRepository) Fetch() (*model.Meta, error) {
 	c.mu.RLock()
 	if c.val != nil && time.Since(c.at) < c.ttl {

--- a/internal/repository/meta_cached.go
+++ b/internal/repository/meta_cached.go
@@ -1,0 +1,80 @@
+package repository
+
+import (
+	"sync"
+	"time"
+
+	"github.com/shiroha-a/mk/internal/model"
+)
+
+// CachedMetaRepository wraps a MetaRepository with a time-based in-memory
+// cache. The meta table is a singleton row that rarely changes (admin-only
+// updates), so a short TTL eliminates repeated DB round-trips on hot paths
+// such as federation host blocking checks.
+type CachedMetaRepository struct {
+	inner MetaRepository
+	ttl   time.Duration
+
+	mu  sync.RWMutex
+	val *model.Meta
+	at  time.Time
+}
+
+// NewCachedMetaRepository creates a cached wrapper with a 5-minute TTL.
+func NewCachedMetaRepository(inner MetaRepository) MetaRepository {
+	return &CachedMetaRepository{inner: inner, ttl: 5 * time.Minute}
+}
+
+// NewCachedMetaRepositoryWithTTL creates a cached wrapper with a custom TTL.
+func NewCachedMetaRepositoryWithTTL(inner MetaRepository, ttl time.Duration) *CachedMetaRepository {
+	return &CachedMetaRepository{inner: inner, ttl: ttl}
+}
+
+// Fetch returns the cached meta if still valid, otherwise fetches from DB.
+func (c *CachedMetaRepository) Fetch() (*model.Meta, error) {
+	c.mu.RLock()
+	if c.val != nil && time.Since(c.at) < c.ttl {
+		v := c.val
+		c.mu.RUnlock()
+		return v, nil
+	}
+	c.mu.RUnlock()
+
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	// ダブルチェック: RUnlock〜Lock間に別goroutineがフェッチ済みの場合
+	if c.val != nil && time.Since(c.at) < c.ttl {
+		return c.val, nil
+	}
+	m, err := c.inner.Fetch()
+	if err != nil {
+		return nil, err
+	}
+	c.val = m
+	c.at = time.Now()
+	return m, nil
+}
+
+// Update delegates to the inner repository and invalidates the cache.
+func (c *CachedMetaRepository) Update(fields map[string]any) error {
+	err := c.inner.Update(fields)
+	if err == nil {
+		c.invalidate()
+	}
+	return err
+}
+
+// EnsureInitial delegates to the inner repository and invalidates the cache.
+func (c *CachedMetaRepository) EnsureInitial(id string) error {
+	err := c.inner.EnsureInitial(id)
+	if err == nil {
+		c.invalidate()
+	}
+	return err
+}
+
+func (c *CachedMetaRepository) invalidate() {
+	c.mu.Lock()
+	c.val = nil
+	c.mu.Unlock()
+}

--- a/internal/repository/meta_cached_test.go
+++ b/internal/repository/meta_cached_test.go
@@ -1,0 +1,160 @@
+package repository_test
+
+import (
+	"errors"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/shiroha-a/mk/internal/model"
+	"github.com/shiroha-a/mk/internal/repository"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// countingMetaRepo counts calls to each method for cache verification.
+type countingMetaRepo struct {
+	fetchCount       atomic.Int32
+	updateCount      atomic.Int32
+	ensureCount      atomic.Int32
+	meta             *model.Meta
+	fetchErr         error
+	updateErr        error
+	ensureInitialErr error
+}
+
+func (r *countingMetaRepo) Fetch() (*model.Meta, error) {
+	r.fetchCount.Add(1)
+	if r.fetchErr != nil {
+		return nil, r.fetchErr
+	}
+	return r.meta, nil
+}
+
+func (r *countingMetaRepo) Update(fields map[string]any) error {
+	r.updateCount.Add(1)
+	return r.updateErr
+}
+
+func (r *countingMetaRepo) EnsureInitial(_ string) error {
+	r.ensureCount.Add(1)
+	return r.ensureInitialErr
+}
+
+func TestCachedMetaRepository_CacheHit(t *testing.T) {
+	inner := &countingMetaRepo{meta: &model.Meta{ID: "m1"}}
+	cached := repository.NewCachedMetaRepositoryWithTTL(inner, 1*time.Minute)
+
+	m1, err := cached.Fetch()
+	require.NoError(t, err)
+	assert.Equal(t, "m1", m1.ID)
+
+	m2, err := cached.Fetch()
+	require.NoError(t, err)
+	assert.Equal(t, "m1", m2.ID)
+
+	// inner.Fetchは1回だけ呼ばれる
+	assert.Equal(t, int32(1), inner.fetchCount.Load())
+}
+
+func TestCachedMetaRepository_TTLExpiry(t *testing.T) {
+	inner := &countingMetaRepo{meta: &model.Meta{ID: "m1"}}
+	cached := repository.NewCachedMetaRepositoryWithTTL(inner, 10*time.Millisecond)
+
+	_, err := cached.Fetch()
+	require.NoError(t, err)
+	assert.Equal(t, int32(1), inner.fetchCount.Load())
+
+	// TTL超過を待つ
+	time.Sleep(20 * time.Millisecond)
+
+	_, err = cached.Fetch()
+	require.NoError(t, err)
+	assert.Equal(t, int32(2), inner.fetchCount.Load())
+}
+
+func TestCachedMetaRepository_UpdateInvalidates(t *testing.T) {
+	inner := &countingMetaRepo{meta: &model.Meta{ID: "m1"}}
+	cached := repository.NewCachedMetaRepositoryWithTTL(inner, 1*time.Minute)
+
+	_, err := cached.Fetch()
+	require.NoError(t, err)
+	assert.Equal(t, int32(1), inner.fetchCount.Load())
+
+	err = cached.Update(map[string]any{"name": "new"})
+	require.NoError(t, err)
+
+	// Update後のFetchは再取得する
+	_, err = cached.Fetch()
+	require.NoError(t, err)
+	assert.Equal(t, int32(2), inner.fetchCount.Load())
+}
+
+func TestCachedMetaRepository_EnsureInitialInvalidates(t *testing.T) {
+	inner := &countingMetaRepo{meta: &model.Meta{ID: "m1"}}
+	cached := repository.NewCachedMetaRepositoryWithTTL(inner, 1*time.Minute)
+
+	_, err := cached.Fetch()
+	require.NoError(t, err)
+
+	err = cached.EnsureInitial("m1")
+	require.NoError(t, err)
+
+	_, err = cached.Fetch()
+	require.NoError(t, err)
+	assert.Equal(t, int32(2), inner.fetchCount.Load())
+}
+
+func TestCachedMetaRepository_ErrorNotCached(t *testing.T) {
+	fetchErr := errors.New("db error")
+	inner := &countingMetaRepo{fetchErr: fetchErr}
+	cached := repository.NewCachedMetaRepositoryWithTTL(inner, 1*time.Minute)
+
+	_, err := cached.Fetch()
+	require.ErrorIs(t, err, fetchErr)
+
+	// エラー時はキャッシュされないので次のFetchも再取得する
+	_, err = cached.Fetch()
+	require.ErrorIs(t, err, fetchErr)
+	assert.Equal(t, int32(2), inner.fetchCount.Load())
+}
+
+func TestCachedMetaRepository_UpdateErrorDoesNotInvalidate(t *testing.T) {
+	inner := &countingMetaRepo{
+		meta:      &model.Meta{ID: "m1"},
+		updateErr: errors.New("update failed"),
+	}
+	cached := repository.NewCachedMetaRepositoryWithTTL(inner, 1*time.Minute)
+
+	_, err := cached.Fetch()
+	require.NoError(t, err)
+
+	err = cached.Update(map[string]any{"name": "new"})
+	require.Error(t, err)
+
+	// Update失敗時はキャッシュを保持する
+	_, err = cached.Fetch()
+	require.NoError(t, err)
+	assert.Equal(t, int32(1), inner.fetchCount.Load())
+}
+
+func TestCachedMetaRepository_ConcurrentFetch(t *testing.T) {
+	inner := &countingMetaRepo{meta: &model.Meta{ID: "m1"}}
+	cached := repository.NewCachedMetaRepositoryWithTTL(inner, 1*time.Minute)
+
+	var wg sync.WaitGroup
+	for i := 0; i < 100; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			m, err := cached.Fetch()
+			assert.NoError(t, err)
+			assert.Equal(t, "m1", m.ID)
+		}()
+	}
+	wg.Wait()
+
+	// ダブルチェックロックにより1〜数回のFetchで済む
+	assert.LessOrEqual(t, inner.fetchCount.Load(), int32(3))
+}

--- a/internal/server/router.go
+++ b/internal/server/router.go
@@ -121,7 +121,7 @@ func (s *Server) setupRoutes() {
 	// Repositories
 	userRepo := repository.NewUserRepository(s.db)
 	noteRepo := repository.NewNoteRepository(s.db)
-	metaRepo := repository.NewMetaRepository(s.db)
+	metaRepo := repository.NewCachedMetaRepository(repository.NewMetaRepository(s.db))
 	// Seed the singleton meta row on first boot so that fresh installs
 	// can run /api/admin/accounts/create (initial setup) without tripping
 	// over a missing meta row.

--- a/internal/server/router.go
+++ b/internal/server/router.go
@@ -589,7 +589,7 @@ func (s *Server) setupRoutes() {
 	// Cypress の resetState コマンドが依存する /api/reset-db はここで登録する。
 	// 本番で絶対に有効化してはならない (config.go 側で起動時 warning を出す)。
 	if s.config.TestMode {
-		testHandler := apitest.NewHandler(s.db, s.redis.Default, true)
+		testHandler := apitest.NewHandler(s.db, s.redis.Default, metaRepo, true)
 		api.POST("/reset-db", testHandler.ResetDB)
 		slog.Warn("test mode: /api/reset-db endpoint is registered", "url", s.config.URL)
 	}


### PR DESCRIPTION
## Summary

#281のベンチマーク結果で判明したパフォーマンス課題(#300)のP0項目を対応。

- **ノート作成フック並列化**: 8つのベストエフォートフック(fanout/notification/federation/channel/antenna/index/chart/webhook)をfire-and-forget goroutineに変更。TS版Misskeyと同じ非同期セマンティクス
- **users/showビューアーフィールド並列化**: 10個の独立DBクエリをsync.WaitGroupで並列実行。mk-goがMisskeyに唯一劣るエンドポイント(p95 255ms vs 142ms)の改善
- **MetaシングルトンTTLキャッシュ**: CachedMetaRepository(5分TTL)でmetaテーブルへの繰り返しDBアクセスを排除。連合ホストブロックチェック等のホットパスを高速化

## 主な変更点

| ファイル | 変更内容 |
|---------|---------|
| `internal/core/note/note_create_service.go` | `safeGo`ヘルパー追加、8フック+IncrementUserNotesCountをgoroutine化 |
| `internal/core/note/note_create_service_test.go` | recordingHookをatomic.Bool+channel同期に変更(race-safe) |
| `internal/api/users/handler.go` | ビューアー依存フィールド10クエリをsync.WaitGroupで並列化 |
| `internal/repository/meta_cached.go` | 新規: CachedMetaRepository(ダブルチェックロック、TTLベースinvalidation) |
| `internal/repository/meta_cached_test.go` | 新規: 7テストケース(キャッシュヒット/TTL/invalidation/エラー/並行安全性) |
| `internal/server/router.go` | metaRepoをCachedMetaRepositoryでラップ |

## テスト

```bash
go test -race ./internal/core/note/...       # PASS
go test -race ./internal/api/users/...       # PASS
go test -race ./internal/repository/...      # PASS (CI, DB必要)
```

Closes #300

## 期待効果
- notes-create: フック実行時間分のレイテンシ削減(50-70%)
- users-show: ビューアーフィールド取得の並列化で40-60%改善
- 全エンドポイント: metaキャッシュによるDB負荷削減
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/shiroha-a/mk/pull/304" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
