### PR TITLE
Fix #303: driveFileCreated の main チャネル emit

### DIFF
--- a/internal/core/drive/drive_service.go
+++ b/internal/core/drive/drive_service.go
@@ -10,6 +10,7 @@ import (
 	"io"
 	"time"
 
+	"github.com/shiroha-a/mk/internal/entity"
 	"github.com/shiroha-a/mk/internal/misc/id"
 	"github.com/shiroha-a/mk/internal/model"
 	"github.com/shiroha-a/mk/internal/repository"
@@ -31,10 +32,18 @@ var (
 
 // StreamingPublisher receives drive file life-cycle events so that
 // WebSocket subscribers (the "drive" channel) can be pushed in real time.
-// パッケージ間の循環依存を避けるため interface で受け取る (実装は internal/
-// stream)。eventType は "fileCreated" / "fileUpdated" / "fileDeleted"。
+// パッケージ間の循環依存を避けるためinterfaceで受け取る(実装はinternal/
+// stream)。eventTypeは"fileCreated"/"fileUpdated"/"fileDeleted"。
 type StreamingPublisher interface {
 	PublishDriveEvent(userID, eventType string, file *model.DriveFile)
+}
+
+// MainStreamPublisher emits real-time events to a single target user's `main`
+// WebSocket channel. Used here to deliver `driveFileCreated` so the frontend
+// can reflect uploads across screens (e.g. drop-upload UI).
+// 循環依存を避けるためinterfaceで受け取る(実装はinternal/stream)。
+type MainStreamPublisher interface {
+	PublishMainEvent(userID, eventType string, body any)
 }
 
 // ChartHook is invoked after a drive file has been uploaded or deleted
@@ -48,14 +57,15 @@ type ChartHook interface {
 
 // Service manages drive files and folders.
 type Service struct {
-	fileRepo       repository.DriveFileRepository
-	folderRepo     repository.DriveFolderRepository
-	storage        Storage
-	idGen          id.Generator
-	publisher      StreamingPublisher
-	chartHook      ChartHook
-	imageProcessor ImageProcessor
-	videoProcessor VideoProcessor
+	fileRepo            repository.DriveFileRepository
+	folderRepo          repository.DriveFolderRepository
+	storage             Storage
+	idGen               id.Generator
+	publisher           StreamingPublisher
+	mainStreamPublisher MainStreamPublisher
+	chartHook           ChartHook
+	imageProcessor      ImageProcessor
+	videoProcessor      VideoProcessor
 	// Sensitive media detection
 	sensitiveDetector SensitiveDetector
 	sensitiveCfg      SensitiveConfig
@@ -86,6 +96,13 @@ func NewService(
 // after Upload / Update / Delete succeed.
 func (s *Service) SetStreamingPublisher(p StreamingPublisher) {
 	s.publisher = p
+}
+
+// SetMainStreamPublisher attaches a publisher used to emit `driveFileCreated`
+// on the uploader's main channel. Optional — nil disables main-stream emit
+// but the drive-channel `fileCreated` event remains unaffected.
+func (s *Service) SetMainStreamPublisher(p MainStreamPublisher) {
+	s.mainStreamPublisher = p
 }
 
 // SetChartHook attaches a ChartHook invoked best-effort after a drive
@@ -245,6 +262,12 @@ func (s *Service) Upload(in UploadInput) (*model.DriveFile, error) {
 		return nil, err
 	}
 	s.publishEvent(in.User.ID, "fileCreated", f)
+	// Misskey本家 DriveService.addFileはdrive topicに加えてmainにも
+	// driveFileCreatedをemitしてUploader自身のUI (ドロップアップロード等)
+	// を即時反映させる (TS: DriveService.ts:665)。
+	if s.mainStreamPublisher != nil {
+		s.mainStreamPublisher.PublishMainEvent(in.User.ID, "driveFileCreated", entity.PackDriveFile(f, s.idGen))
+	}
 	if s.chartHook != nil {
 		s.chartHook.OnFileUploaded(f)
 	}

--- a/internal/core/drive/drive_service.go
+++ b/internal/core/drive/drive_service.go
@@ -48,7 +48,7 @@ type MainStreamPublisher interface {
 
 // ChartHook is invoked after a drive file has been uploaded or deleted
 // so the chart subsystem can record the byte / count delta. パッケージ
-// 間の循環依存を避けるため interface で受け取る (実装は core/chart/
+// 間の循環依存を避けるためinterfaceで受け取る(実装はcore/chart/
 // charthook)。
 type ChartHook interface {
 	OnFileUploaded(file *model.DriveFile)

--- a/internal/core/drive/drive_service.go
+++ b/internal/core/drive/drive_service.go
@@ -262,9 +262,9 @@ func (s *Service) Upload(in UploadInput) (*model.DriveFile, error) {
 		return nil, err
 	}
 	s.publishEvent(in.User.ID, "fileCreated", f)
-	// Misskey本家 DriveService.addFileはdrive topicに加えてmainにも
-	// driveFileCreatedをemitしてUploader自身のUI (ドロップアップロード等)
-	// を即時反映させる (TS: DriveService.ts:665)。
+	// Misskey本家DriveService.addFileはdrive topicに加えてmainにも
+	// driveFileCreatedをemitしてUploader自身のUI(ドロップアップロード等)
+	// を即時反映させる(TS: DriveService.ts:665)。
 	if s.mainStreamPublisher != nil {
 		s.mainStreamPublisher.PublishMainEvent(in.User.ID, "driveFileCreated", entity.PackDriveFile(f, s.idGen))
 	}

--- a/internal/core/drive/drive_service_test.go
+++ b/internal/core/drive/drive_service_test.go
@@ -13,6 +13,7 @@ import (
 	"testing"
 
 	"github.com/shiroha-a/mk/internal/core/drive"
+	"github.com/shiroha-a/mk/internal/entity"
 	"github.com/shiroha-a/mk/internal/misc/id"
 	"github.com/shiroha-a/mk/internal/model"
 	"github.com/shiroha-a/mk/internal/testutil"
@@ -58,6 +59,47 @@ func TestUpload_HappyPath(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, "hello.txt", f.Name)
 	assert.Len(t, fileRepo.Files, 1)
+}
+
+// stubMainStreamPublisher captures PublishMainEvent calls.
+type stubMainStreamPublisher struct {
+	calls []mainEventCall
+}
+
+type mainEventCall struct {
+	userID    string
+	eventType string
+	body      any
+}
+
+func (s *stubMainStreamPublisher) PublishMainEvent(userID, eventType string, body any) {
+	s.calls = append(s.calls, mainEventCall{userID, eventType, body})
+}
+
+func TestUpload_PublishesDriveFileCreatedOnMain(t *testing.T) {
+	svc, _, _ := newSvc(t)
+	pub := &stubMainStreamPublisher{}
+	svc.SetMainStreamPublisher(pub)
+
+	user := &model.User{ID: "u1"}
+	f, err := svc.Upload(drive.UploadInput{User: user, Body: []byte("hello"), Name: "hello.txt"})
+	require.NoError(t, err)
+
+	require.Len(t, pub.calls, 1)
+	assert.Equal(t, "u1", pub.calls[0].userID)
+	assert.Equal(t, "driveFileCreated", pub.calls[0].eventType)
+	// bodyはentity.PackDriveFileでpackされたfileのはず。file IDが一致。
+	body, ok := pub.calls[0].body.(entity.DriveFileEntity)
+	require.True(t, ok)
+	assert.Equal(t, f.ID, body.ID)
+	assert.Equal(t, "hello.txt", body.Name)
+}
+
+func TestUpload_NoMainPublisher_NoEmit(t *testing.T) {
+	svc, _, _ := newSvc(t)
+	// SetMainStreamPublisherを呼ばない状態でもUpload自体は成功する。
+	_, err := svc.Upload(drive.UploadInput{User: &model.User{ID: "u1"}, Body: []byte("hi"), Name: "hi.txt"})
+	require.NoError(t, err)
 }
 
 func TestUpload_DedupByMD5(t *testing.T) {

--- a/internal/server/router.go
+++ b/internal/server/router.go
@@ -1244,6 +1244,7 @@ func (s *Server) setupRoutes() {
 	notificationService.SetStreamingPublisher(notificationPublisher)
 	notificationService.SetMainStreamPublisher(mainStreamPublisher)
 	driveService.SetStreamingPublisher(drivePublisher)
+	driveService.SetMainStreamPublisher(mainStreamPublisher)
 	followingService.SetMainStreamPublisher(mainStreamPublisher)
 	userService.SetMainStreamPublisher(mainStreamPublisher)
 	noteCreateService.SetMainStreamPublisher(mainStreamPublisher)


### PR DESCRIPTION
## Summary

#288 (umbrella) の中優先度drive clusterのうち、実装コストが小さい\`driveFileCreated\`を先行対応。Misskey本家\`DriveService.addFile\`は\`drive:{userID}\`トピックと\`main:{userID}\`の両方にemitしているのに合わせて、Go側も同時emitするよう変更。

## 主な変更点

### 実装 (\`internal/core/drive/drive_service.go\`)

- \`MainStreamPublisher\` interface + \`SetMainStreamPublisher\` setterを追加 (#246 pattern踏襲)
- \`Upload()\` 成功時、既存の\`drive:{userID}\` \`fileCreated\` emit に加えて\`main:{userID}\` へ\`{type: "driveFileCreated", body: <PackDriveFile>}\`をemit
- bodyは\`entity.PackDriveFile(f, idGen)\`を再利用

### router 配線 (\`internal/server/router.go\`)

- \`mainStreamPublisher\`を\`driveService.SetMainStreamPublisher\`に注入

## スコープ外 (別 sub-issue で検討)

- **\`urlUploadFinished\`**: \`/api/drive/files/upload-from-url\` エンドポイント自体が現状204 NoContentを返すだけのstub実装。URLからのasync HTTP download → drive保存 → event発火というbackground job pipelineの新規実装が必要で、規模が大きいため別issueで扱う。

## テスト

- \`make fmt && go vet ./...\` 通過
- 追加テスト 2 ケース:
  - \`TestUpload_PublishesDriveFileCreatedOnMain\` — emit検証 + body形状 (id/name確認)
  - \`TestUpload_NoMainPublisher_NoEmit\` — publisher未注入時にUpload自体は正常
- カバレッジ: \`internal/core/drive\` 97.0%
- \`go test ./...\` 全体通過

### 実行コマンド

\`\`\`bash
make fmt && go vet ./... && go test ./...
\`\`\`

## Closes

Closes #303

## 関連

- Umbrella: #288 (main チャネル22種追跡)
- Base: #246 (MainStreamPublisher infrastructure)
- TS 参照: \`third_party/misskey/packages/backend/src/core/DriveService.ts:665\`
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/shiroha-a/mk/pull/305" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
