### PR TITLE
Fix #306: signin / myTokenRegenerated の main チャネル emit

### DIFF
--- a/internal/api/i/handler.go
+++ b/internal/api/i/handler.go
@@ -44,29 +44,45 @@ type AccountMover interface {
 
 // Handler handles account-related API endpoints.
 type Handler struct {
-	userService       *user.Service
-	idGen             id.Generator
-	roleProvider      RoleProvider
-	registryRepo      repository.RegistryRepository
-	favoriteRepo      repository.NoteFavoriteRepository
-	transferEnqueuer  TransferEnqueuer
-	webauthnSvc       *twofactor.WebAuthnService
-	securityKeyRepo   repository.UserSecurityKeyRepository
-	metaRepo          repository.MetaRepository
-	emailSender       EmailSender
-	serverURL         string
-	signinRepo        repository.SigninRepository
-	accessTokenRepo   repository.AccessTokenRepository
-	galleryRepo       GalleryRepository
-	pageLikeRepo      repository.PageLikeRepository
-	mover             AccountMover
-	notificationSvc   UnreadNotificationSource
-	followRequestRepo repository.FollowRequestRepository
-	announcementRepo  AnnouncementUnreadSource
-	chatRepo          ChatUnreadSource
-	piningRepo        repository.UserNotePiningRepository
-	noteRepo          repository.NoteRepository
-	pageRepo          repository.PageRepository
+	userService         *user.Service
+	idGen               id.Generator
+	roleProvider        RoleProvider
+	registryRepo        repository.RegistryRepository
+	favoriteRepo        repository.NoteFavoriteRepository
+	transferEnqueuer    TransferEnqueuer
+	webauthnSvc         *twofactor.WebAuthnService
+	securityKeyRepo     repository.UserSecurityKeyRepository
+	metaRepo            repository.MetaRepository
+	emailSender         EmailSender
+	serverURL           string
+	signinRepo          repository.SigninRepository
+	accessTokenRepo     repository.AccessTokenRepository
+	galleryRepo         GalleryRepository
+	pageLikeRepo        repository.PageLikeRepository
+	mover               AccountMover
+	notificationSvc     UnreadNotificationSource
+	followRequestRepo   repository.FollowRequestRepository
+	announcementRepo    AnnouncementUnreadSource
+	chatRepo            ChatUnreadSource
+	piningRepo          repository.UserNotePiningRepository
+	noteRepo            repository.NoteRepository
+	pageRepo            repository.PageRepository
+	mainStreamPublisher MainStreamPublisher
+}
+
+// MainStreamPublisher emits events to a single user's `main` WebSocket
+// channel. Used here to publish `myTokenRegenerated` so other sessions of
+// the same user learn that their API token was invalidated.
+// 循環依存を避けるためinterfaceで受け取る(実装はinternal/stream)。
+type MainStreamPublisher interface {
+	PublishMainEvent(userID, eventType string, body any)
+}
+
+// SetMainStreamPublisher attaches a publisher used to emit events on
+// /api/i/* endpoints (currently `myTokenRegenerated`). Optional — nil
+// disables emit.
+func (h *Handler) SetMainStreamPublisher(p MainStreamPublisher) {
+	h.mainStreamPublisher = p
 }
 
 // UnreadNotificationSource is the subset of notification.Service used by /api/i

--- a/internal/api/i/handler_extra.go
+++ b/internal/api/i/handler_extra.go
@@ -134,6 +134,12 @@ func (h *Handler) RegenerateToken(c echo.Context) error {
 	if err := h.userService.UpdateUserFields(u.ID, map[string]any{"token": newToken}); err != nil {
 		return c.JSON(http.StatusInternalServerError, apierr.Error("INTERNAL_ERROR", "Internal error.", "5d37dbcb-891e-41ca-a3d6-e690c97775ac"))
 	}
+	// TS本家 regenerate-token.ts:60 と同じく、 token 再生成成功後に main へ
+	// publish する。body は無し (type のみで、他セッションは token 無効化を
+	// 検知してログアウトする用途)。
+	if h.mainStreamPublisher != nil {
+		h.mainStreamPublisher.PublishMainEvent(u.ID, "myTokenRegenerated", nil)
+	}
 	return c.JSON(http.StatusOK, map[string]any{"token": newToken})
 }
 

--- a/internal/api/i/handler_extra.go
+++ b/internal/api/i/handler_extra.go
@@ -134,8 +134,8 @@ func (h *Handler) RegenerateToken(c echo.Context) error {
 	if err := h.userService.UpdateUserFields(u.ID, map[string]any{"token": newToken}); err != nil {
 		return c.JSON(http.StatusInternalServerError, apierr.Error("INTERNAL_ERROR", "Internal error.", "5d37dbcb-891e-41ca-a3d6-e690c97775ac"))
 	}
-	// TS本家 regenerate-token.ts:60 と同じく、 token 再生成成功後に main へ
-	// publish する。body は無し (type のみで、他セッションは token 無効化を
+	// TS本家 regenerate-token.ts:60 と同じく、token再生成成功後にmainへ
+	// publishする。body無し(type のみで、他セッションはtoken無効化を
 	// 検知してログアウトする用途)。
 	if h.mainStreamPublisher != nil {
 		h.mainStreamPublisher.PublishMainEvent(u.ID, "myTokenRegenerated", nil)

--- a/internal/api/i/handler_extra_test.go
+++ b/internal/api/i/handler_extra_test.go
@@ -192,6 +192,36 @@ func TestRegenerateToken_NoProfile(t *testing.T) {
 	assert.Equal(t, http.StatusForbidden, rec.Code)
 }
 
+// stubIMainStreamPublisher captures PublishMainEvent calls for assertion.
+type stubIMainStreamPublisher struct {
+	calls []iMainEventCall
+}
+
+type iMainEventCall struct {
+	userID    string
+	eventType string
+	body      any
+}
+
+func (s *stubIMainStreamPublisher) PublishMainEvent(userID, eventType string, body any) {
+	s.calls = append(s.calls, iMainEventCall{userID, eventType, body})
+}
+
+func TestRegenerateToken_PublishesMyTokenRegenerated(t *testing.T) {
+	h, repo := newExtraHandler(t)
+	user := setupUserWithPassword(repo, "u1", "pass")
+	pub := &stubIMainStreamPublisher{}
+	h.SetMainStreamPublisher(pub)
+	rec := postExtra(h.RegenerateToken, `{"password":"pass"}`, user)
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	require.Len(t, pub.calls, 1)
+	assert.Equal(t, "u1", pub.calls[0].userID)
+	assert.Equal(t, "myTokenRegenerated", pub.calls[0].eventType)
+	// TS本家はbody無し (type のみ) のため nil であること。
+	assert.Nil(t, pub.calls[0].body)
+}
+
 // --- Error path tests ---
 
 type failingUpdateUserRepo struct {

--- a/internal/api/signin/handler.go
+++ b/internal/api/signin/handler.go
@@ -13,6 +13,7 @@ import (
 	"github.com/lib/pq"
 	"github.com/shiroha-a/mk/internal/core/captcha"
 	"github.com/shiroha-a/mk/internal/core/twofactor"
+	"github.com/shiroha-a/mk/internal/entity"
 	"github.com/shiroha-a/mk/internal/misc/id"
 	"github.com/shiroha-a/mk/internal/model"
 	"github.com/shiroha-a/mk/internal/repository"
@@ -25,16 +26,25 @@ type IPLogger interface {
 	Upsert(userID, ip string) error
 }
 
+// MainStreamPublisher emits real-time events to a single user's `main`
+// WebSocket channel. Used here to publish the `signin` event so other
+// sessions / devices of the same user learn about the new login.
+// 循環依存を避けるためinterfaceで受け取る(実装はinternal/stream)。
+type MainStreamPublisher interface {
+	PublishMainEvent(userID, eventType string, body any)
+}
+
 // Handler handles signin-related API endpoints.
 type Handler struct {
-	userRepo        repository.UserRepository
-	webauthnSvc     *twofactor.WebAuthnService
-	securityKeyRepo repository.UserSecurityKeyRepository
-	captchaSvc      *captcha.Service
-	ipLogger        IPLogger
-	ipLoggingOn     bool
-	signinRepo      repository.SigninRepository
-	idGen           id.Generator
+	userRepo            repository.UserRepository
+	webauthnSvc         *twofactor.WebAuthnService
+	securityKeyRepo     repository.UserSecurityKeyRepository
+	captchaSvc          *captcha.Service
+	ipLogger            IPLogger
+	ipLoggingOn         bool
+	signinRepo          repository.SigninRepository
+	idGen               id.Generator
+	mainStreamPublisher MainStreamPublisher
 }
 
 // SetIPLogger attaches an IPLogger and enables IP logging.
@@ -66,6 +76,12 @@ func (h *Handler) SetCaptcha(svc *captcha.Service) {
 func (h *Handler) SetWebAuthn(svc *twofactor.WebAuthnService, repo repository.UserSecurityKeyRepository) {
 	h.webauthnSvc = svc
 	h.securityKeyRepo = repo
+}
+
+// SetMainStreamPublisher attaches a publisher used to emit the `signin`
+// event after a successful login. Optional — nil disables emit.
+func (h *Handler) SetMainStreamPublisher(p MainStreamPublisher) {
+	h.mainStreamPublisher = p
 }
 
 // Signin handles POST /api/signin.
@@ -307,6 +323,12 @@ func (h *Handler) recordSignin(userID, ip string, headers http.Header) {
 	}
 	if err := h.signinRepo.Create(s); err != nil {
 		slog.Warn("failed to record signin", "userId", userID, "err", err)
+		return
+	}
+	// TS本家 SigninService.ts:49 と同じく、signin成功後にmainへ publish する。
+	// multi-device間で新規ログインを即時同期する用途。
+	if h.mainStreamPublisher != nil {
+		h.mainStreamPublisher.PublishMainEvent(userID, "signin", entity.PackSignin(s, h.idGen))
 	}
 }
 

--- a/internal/api/signin/handler.go
+++ b/internal/api/signin/handler.go
@@ -325,7 +325,7 @@ func (h *Handler) recordSignin(userID, ip string, headers http.Header) {
 		slog.Warn("failed to record signin", "userId", userID, "err", err)
 		return
 	}
-	// TS本家 SigninService.ts:49 と同じく、signin成功後にmainへ publish する。
+	// TS本家 SigninService.ts:49 と同じく、signin成功後にmainへpublishする。
 	// multi-device間で新規ログインを即時同期する用途。
 	if h.mainStreamPublisher != nil {
 		h.mainStreamPublisher.PublishMainEvent(userID, "signin", entity.PackSignin(s, h.idGen))

--- a/internal/api/signin/handler_test.go
+++ b/internal/api/signin/handler_test.go
@@ -5,6 +5,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"strings"
+	"sync"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -305,6 +306,52 @@ func TestSignin_RecordsSigninHistory(t *testing.T) {
 	// goroutineでsigninレコードが作成されるのを待つ
 	time.Sleep(100 * time.Millisecond)
 	assert.Equal(t, 1, signinRepo.Len())
+}
+
+// stubMainStreamPublisher captures PublishMainEvent calls.
+type stubMainStreamPublisher struct {
+	mu    sync.Mutex
+	calls []mainEventCall
+}
+
+type mainEventCall struct {
+	userID    string
+	eventType string
+	body      any
+}
+
+func (s *stubMainStreamPublisher) PublishMainEvent(userID, eventType string, body any) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.calls = append(s.calls, mainEventCall{userID, eventType, body})
+}
+
+func TestSignin_PublishesSigninEvent(t *testing.T) {
+	h, repo := newTestHandler(t)
+	user := createTestUser(repo, "testuser", "password123")
+
+	signinRepo := testutil.NewMockSigninRepository()
+	idGen, _ := id.NewGenerator("aidx")
+	h.SetSigninRepo(signinRepo, idGen)
+	pub := &stubMainStreamPublisher{}
+	h.SetMainStreamPublisher(pub)
+
+	rec := doPost(h.Signin, `{"username":"testuser","password":"password123"}`)
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	// 非同期goroutineのrecordSignin完了を待つ
+	time.Sleep(100 * time.Millisecond)
+
+	pub.mu.Lock()
+	defer pub.mu.Unlock()
+	require.Len(t, pub.calls, 1)
+	assert.Equal(t, user.ID, pub.calls[0].userID)
+	assert.Equal(t, "signin", pub.calls[0].eventType)
+	// body は PackSignin の map。最低限 id/success が含まれる。
+	body, ok := pub.calls[0].body.(map[string]any)
+	require.True(t, ok)
+	assert.NotEmpty(t, body["id"])
+	assert.Equal(t, true, body["success"])
 }
 
 func TestSignin_IPLogging(t *testing.T) {

--- a/internal/entity/signin.go
+++ b/internal/entity/signin.go
@@ -1,0 +1,39 @@
+package entity
+
+import (
+	"encoding/json"
+
+	"github.com/shiroha-a/mk/internal/misc/id"
+	"github.com/shiroha-a/mk/internal/model"
+)
+
+// PackSignin converts a model.Signin into the map shape returned by the
+// `signin` WebSocket event on the `main` channel. Matches Misskey's
+// SigninEntityService.pack (id / createdAt / ip / headers / success).
+// createdAt is derived from the aidx-encoded signin ID when an idGen is
+// supplied. Returns nil when s is nil so callers can assign the result
+// directly to a nilable field.
+func PackSignin(s *model.Signin, idGens ...id.Generator) map[string]any {
+	if s == nil {
+		return nil
+	}
+	const tsFormat = "2006-01-02T15:04:05.000Z"
+	out := map[string]any{
+		"id":      s.ID,
+		"ip":      s.IP,
+		"success": s.Success,
+	}
+	// headers は jsonb として保存されているのでそのまま RawMessage にして
+	// frontend に渡す (文字列化を避ける)。
+	if len(s.Headers) > 0 {
+		out["headers"] = json.RawMessage(s.Headers)
+	} else {
+		out["headers"] = map[string]any{}
+	}
+	if len(idGens) > 0 && idGens[0] != nil {
+		if t, err := idGens[0].ParseTime(s.ID); err == nil {
+			out["createdAt"] = t.UTC().Format(tsFormat)
+		}
+	}
+	return out
+}

--- a/internal/entity/signin.go
+++ b/internal/entity/signin.go
@@ -23,8 +23,8 @@ func PackSignin(s *model.Signin, idGens ...id.Generator) map[string]any {
 		"ip":      s.IP,
 		"success": s.Success,
 	}
-	// headers は jsonb として保存されているのでそのまま RawMessage にして
-	// frontend に渡す (文字列化を避ける)。
+	// headersはjsonbとして保存されているのでそのままRawMessageにして
+	// frontendに渡す(文字列化を避ける)。
 	if len(s.Headers) > 0 {
 		out["headers"] = json.RawMessage(s.Headers)
 	} else {

--- a/internal/entity/signin_test.go
+++ b/internal/entity/signin_test.go
@@ -1,0 +1,58 @@
+package entity
+
+import (
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/shiroha-a/mk/internal/misc/id"
+	"github.com/shiroha-a/mk/internal/model"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gorm.io/datatypes"
+)
+
+func TestPackSignin_Basic(t *testing.T) {
+	idGen, _ := id.NewGenerator("aidx")
+	sid := idGen.Generate(time.Now())
+	s := &model.Signin{
+		ID:      sid,
+		UserID:  "u1",
+		IP:      "1.2.3.4",
+		Headers: datatypes.JSON([]byte(`{"user-agent":"test"}`)),
+		Success: true,
+	}
+	out := PackSignin(s, idGen)
+	assert.Equal(t, sid, out["id"])
+	assert.Equal(t, "1.2.3.4", out["ip"])
+	assert.Equal(t, true, out["success"])
+	// headers は RawMessage として埋まる (JSON encoder が生バイトを出す)
+	raw, ok := out["headers"].(json.RawMessage)
+	require.True(t, ok)
+	assert.JSONEq(t, `{"user-agent":"test"}`, string(raw))
+	// createdAt が aidx-ID から復元されていること
+	_, ok = out["createdAt"]
+	assert.True(t, ok)
+}
+
+func TestPackSignin_NilInput(t *testing.T) {
+	assert.Nil(t, PackSignin(nil))
+}
+
+func TestPackSignin_WithoutIDGen_OmitsCreatedAt(t *testing.T) {
+	s := &model.Signin{ID: "x", IP: "::1", Success: false}
+	out := PackSignin(s)
+	_, ok := out["createdAt"]
+	assert.False(t, ok)
+	// headers 空でも default map が入ること
+	_, ok = out["headers"].(map[string]any)
+	assert.True(t, ok)
+}
+
+func TestPackSignin_InvalidIDOmitsCreatedAt(t *testing.T) {
+	idGen, _ := id.NewGenerator("aidx")
+	s := &model.Signin{ID: "not-aidx", Success: true}
+	out := PackSignin(s, idGen)
+	_, ok := out["createdAt"]
+	assert.False(t, ok)
+}

--- a/internal/server/router.go
+++ b/internal/server/router.go
@@ -1248,6 +1248,8 @@ func (s *Server) setupRoutes() {
 	followingService.SetMainStreamPublisher(mainStreamPublisher)
 	userService.SetMainStreamPublisher(mainStreamPublisher)
 	noteCreateService.SetMainStreamPublisher(mainStreamPublisher)
+	signinHandler.SetMainStreamPublisher(mainStreamPublisher)
+	iHandler.SetMainStreamPublisher(mainStreamPublisher)
 
 	// 5. Reversi WebSocket channel (Phase 9.6) を登録する
 	reversiService := corereversi.NewService(reversiRepo, reversiPublisher, s.redis.Default)


### PR DESCRIPTION
## Summary

#288 (umbrella) の低優先度 auth cluster 2 種を実装。Misskey本家と同じく、sign-in成功時および API トークン再生成時にmulti-device同期用のイベントを \`main:{userID}\` へ emit する。

## 主な変更点

### 新規 entity packer (\`internal/entity/signin.go\`)

- \`PackSignin(s *model.Signin, idGens...) map[string]any\` を追加
- TS互換shape: \`{id, createdAt, ip, headers, success}\`
- \`createdAt\` は aidx-ID から復元
- \`headers\` は jsonb を raw保存して frontend に渡す

### 実装

| TS event | 発火点 | body |
|---|---|---|
| \`signin\` | \`signin.Handler.recordSignin\` 成功時 | \`PackSignin(record)\` |
| \`myTokenRegenerated\` | \`i.Handler.RegenerateToken\` 成功時 | \`nil\` (TS本家と同じ、type のみ) |

### handler 側配線

- \`api/signin.Handler\` に \`MainStreamPublisher\` interface + \`SetMainStreamPublisher\` setter を追加
- \`api/i.Handler\` も同様に追加
- \`internal/server/router.go\`: \`mainStreamPublisher\` 生成後のブロックで両 handler に注入

## テスト

- \`make fmt && go vet ./...\` 通過
- 追加テスト:
  - \`entity.PackSignin\` 4ケース (basic / nil input / idGen 未指定 / invalid ID)
  - \`TestSignin_PublishesSigninEvent\` — signin 成功時 emit + body shape 検証
  - \`TestRegenerateToken_PublishesMyTokenRegenerated\` — body nil 検証
- カバレッジ: entity 97.5% / api/signin 92.2% / api/i 91.8%
- \`go test ./...\` 全体通過

### 実行コマンド

\`\`\`bash
make fmt && go vet ./... && go test ./...
\`\`\`

## Closes

Closes #306

## 関連

- Umbrella: #288 (main チャネル追跡)
- Base: #246 (MainStreamPublisher infrastructure)
- TS 参照: \`SigninService.ts:49\`, \`regenerate-token.ts:60\`
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/shiroha-a/mk/pull/307" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
