### PR TITLE
Fix #310: registryUpdated の main チャネル emit

### DIFF
--- a/internal/api/i/handler.go
+++ b/internal/api/i/handler.go
@@ -284,6 +284,16 @@ func (h *Handler) RegistrySet(c echo.Context) error {
 	if err := h.registryRepo.Set(item); err != nil {
 		return c.JSON(http.StatusInternalServerError, apierr.Error("INTERNAL_ERROR", "Internal error.", "5d37dbcb-891e-41ca-a3d6-e690c97775ac"))
 	}
+	// TS本家 RegistryApiService.set (lines 59-66): domain == null のとき
+	// のみmainにpublishする。domain指定はサードパーティアプリ固有の領域
+	// なので他クライアントには broadcast しない仕様。
+	if h.mainStreamPublisher != nil && req.Domain == nil {
+		h.mainStreamPublisher.PublishMainEvent(u.ID, "registryUpdated", map[string]any{
+			"scope": req.Scope,
+			"key":   req.Key,
+			"value": json.RawMessage(req.Value),
+		})
+	}
 	return c.NoContent(http.StatusNoContent)
 }
 

--- a/internal/api/i/handler_test.go
+++ b/internal/api/i/handler_test.go
@@ -878,7 +878,7 @@ func TestRegistrySet_SkipsPublishWhenDomainSpecified(t *testing.T) {
 	pub := &stubIMainStreamPublisher{}
 	h.SetMainStreamPublisher(pub)
 
-	// domain 指定時は TS 本家同様 emit しない (サードパーティアプリ領域)
+	// domain指定時はTS本家同様emitしない(サードパーティアプリ領域)
 	rec := post(h.RegistrySet, `{"key":"k","value":"v","domain":"app.example"}`, &model.User{ID: "u1"})
 	require.Equal(t, http.StatusNoContent, rec.Code)
 	assert.Empty(t, pub.calls)

--- a/internal/api/i/handler_test.go
+++ b/internal/api/i/handler_test.go
@@ -849,6 +849,48 @@ func TestRegistrySet_InvalidParam(t *testing.T) {
 	assert.Equal(t, http.StatusBadRequest, rec.Code)
 }
 
+func TestRegistrySet_PublishesRegistryUpdated_WhenDomainNil(t *testing.T) {
+	h, _ := newHandlerWithRegistry(t)
+	pub := &stubIMainStreamPublisher{}
+	h.SetMainStreamPublisher(pub)
+
+	rec := post(h.RegistrySet, `{"key":"theme","value":"dark","scope":["client"]}`, &model.User{ID: "u1"})
+	require.Equal(t, http.StatusNoContent, rec.Code)
+
+	require.Len(t, pub.calls, 1)
+	assert.Equal(t, "u1", pub.calls[0].userID)
+	assert.Equal(t, "registryUpdated", pub.calls[0].eventType)
+	body, ok := pub.calls[0].body.(map[string]any)
+	require.True(t, ok)
+	assert.Equal(t, "theme", body["key"])
+	// scope は []string で渡される
+	scope, ok := body["scope"].([]string)
+	require.True(t, ok)
+	assert.Equal(t, []string{"client"}, scope)
+	// value は json.RawMessage (生バイトを frontend にそのまま渡すため)
+	val, ok := body["value"].(json.RawMessage)
+	require.True(t, ok)
+	assert.Equal(t, `"dark"`, string(val))
+}
+
+func TestRegistrySet_SkipsPublishWhenDomainSpecified(t *testing.T) {
+	h, _ := newHandlerWithRegistry(t)
+	pub := &stubIMainStreamPublisher{}
+	h.SetMainStreamPublisher(pub)
+
+	// domain 指定時は TS 本家同様 emit しない (サードパーティアプリ領域)
+	rec := post(h.RegistrySet, `{"key":"k","value":"v","domain":"app.example"}`, &model.User{ID: "u1"})
+	require.Equal(t, http.StatusNoContent, rec.Code)
+	assert.Empty(t, pub.calls)
+}
+
+func TestRegistrySet_NoPublisher_NoEmit(t *testing.T) {
+	h, _ := newHandlerWithRegistry(t)
+	// publisher 未設定でも通常動作すること
+	rec := post(h.RegistrySet, `{"key":"k","value":"v"}`, &model.User{ID: "u1"})
+	assert.Equal(t, http.StatusNoContent, rec.Code)
+}
+
 func TestRegistryGet_Success(t *testing.T) {
 	h, _ := newHandlerWithRegistry(t)
 	user := &model.User{ID: "u1"}


### PR DESCRIPTION
## Summary

#288 (umbrella) の低優先度 \`registryUpdated\` を実装。Misskey本家 \`RegistryApiService.set\` と同じく、registry set 成功時に domain nil の場合のみ \`main:{userID}\` へ publish してクライアント間の設定同期を実現する。

## 主な変更点

### 実装 (\`internal/api/i/handler.go\`)

- \`RegistrySet\` 成功後、\`req.Domain == nil\` かつ publisher 設定済みなら \`{type: "registryUpdated", body: {scope, key, value}}\` を emit
- TS本家のdomainフィルタロジック(lines 59-66)と整合 — domain指定はサードパーティアプリ固有領域のため broadcast しない
- Handler には既存の \`mainStreamPublisher\` 配線(#306)を流用し、新規 setter 追加なし
- \`RegistryRemove\` は TS本家もemit していないため本 issue でも対応しない

## スコープ外

- \`registryUpdated\` 以外の registry 系イベント (該当無し)
- registry API のその他 endpoints (get/remove/scopes/keys等) は既存実装を維持

## テスト

- \`make fmt && go vet ./...\` 通過
- 追加テスト 3 ケース:
  - \`TestRegistrySet_PublishesRegistryUpdated_WhenDomainNil\` — 正常 emit + body shape (scope/key/value)
  - \`TestRegistrySet_SkipsPublishWhenDomainSpecified\` — domain指定時に emit されない
  - \`TestRegistrySet_NoPublisher_NoEmit\` — publisher 未設定時でも通常動作
- カバレッジ: \`internal/api/i\` 91.8%
- \`go test ./...\` 全体通過

### 実行コマンド

\`\`\`bash
make fmt && go vet ./... && go test ./...
\`\`\`

## Closes

Closes #310

## 関連

- Umbrella: #288 (main チャネル追跡)
- Base: #246 (MainStreamPublisher infrastructure) / #306 (i handler publisher 配線)
- TS 参照: \`RegistryApiService.ts:59-66\`
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/shiroha-a/mk/pull/311" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
