### PR TITLE
Fix #324: Add sinceId/untilId cursor pagination to /api/announcements

### DIFF
--- a/internal/api/announcements/handler.go
+++ b/internal/api/announcements/handler.go
@@ -213,13 +213,15 @@ func (h *Handler) AdminDelete(c echo.Context) error {
 // AdminList handles POST /api/admin/announcements/list.
 func (h *Handler) AdminList(c echo.Context) error {
 	var req struct {
-		Limit  int `json:"limit"`
-		Offset int `json:"offset"`
+		Limit   int    `json:"limit"`
+		Offset  int    `json:"offset"`
+		SinceID string `json:"sinceId"`
+		UntilID string `json:"untilId"`
 	}
 	if err := c.Bind(&req); err != nil {
 		return c.JSON(http.StatusBadRequest, apierr.Error("INVALID_PARAM", "Invalid parameters.", "3d81ceae-475f-4600-b2a8-2bc116157532"))
 	}
-	items, err := h.repo.List(false, req.Limit, req.Offset, "", "")
+	items, err := h.repo.List(false, req.Limit, req.Offset, req.SinceID, req.UntilID)
 	if err != nil {
 		return c.JSON(http.StatusInternalServerError, apierr.Error("INTERNAL_ERROR", "Internal error.", "5d37dbcb-891e-41ca-a3d6-e690c97775ac"))
 	}

--- a/internal/api/announcements/handler.go
+++ b/internal/api/announcements/handler.go
@@ -43,9 +43,11 @@ func (h *Handler) SetMainStreamPublisher(p MainStreamPublisher) {
 // List handles POST /api/announcements.
 func (h *Handler) List(c echo.Context) error {
 	var req struct {
-		Limit    int   `json:"limit"`
-		Offset   int   `json:"offset"`
-		IsActive *bool `json:"isActive"`
+		Limit    int    `json:"limit"`
+		Offset   int    `json:"offset"`
+		SinceID  string `json:"sinceId"`
+		UntilID  string `json:"untilId"`
+		IsActive *bool  `json:"isActive"`
 	}
 	if err := c.Bind(&req); err != nil {
 		return c.JSON(http.StatusBadRequest, apierr.Error("INVALID_PARAM", "Invalid parameters.", "3d81ceae-475f-4600-b2a8-2bc116157532"))
@@ -62,9 +64,9 @@ func (h *Handler) List(c echo.Context) error {
 	var items []*model.Announcement
 	var err error
 	if user != nil {
-		items, err = h.repo.ListForUser(user.ID, activeOnly, req.Limit, req.Offset)
+		items, err = h.repo.ListForUser(user.ID, activeOnly, req.Limit, req.Offset, req.SinceID, req.UntilID)
 	} else {
-		items, err = h.repo.ListGlobal(activeOnly, req.Limit, req.Offset)
+		items, err = h.repo.ListGlobal(activeOnly, req.Limit, req.Offset, req.SinceID, req.UntilID)
 	}
 	if err != nil {
 		return c.JSON(http.StatusInternalServerError, apierr.Error("INTERNAL_ERROR", "Internal error.", "5d37dbcb-891e-41ca-a3d6-e690c97775ac"))
@@ -217,7 +219,7 @@ func (h *Handler) AdminList(c echo.Context) error {
 	if err := c.Bind(&req); err != nil {
 		return c.JSON(http.StatusBadRequest, apierr.Error("INVALID_PARAM", "Invalid parameters.", "3d81ceae-475f-4600-b2a8-2bc116157532"))
 	}
-	items, err := h.repo.List(false, req.Limit, req.Offset)
+	items, err := h.repo.List(false, req.Limit, req.Offset, "", "")
 	if err != nil {
 		return c.JSON(http.StatusInternalServerError, apierr.Error("INTERNAL_ERROR", "Internal error.", "5d37dbcb-891e-41ca-a3d6-e690c97775ac"))
 	}

--- a/internal/api/announcements/handler_test.go
+++ b/internal/api/announcements/handler_test.go
@@ -80,6 +80,48 @@ func TestList_ActiveFalse(t *testing.T) {
 	assert.Equal(t, http.StatusOK, rec.Code)
 }
 
+func TestList_UntilID(t *testing.T) {
+	h, repo := newTestHandler(t)
+	idGen, _ := id.NewGenerator("aidx")
+	id1 := idGen.Generate(time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC))
+	id2 := idGen.Generate(time.Date(2024, 6, 1, 0, 0, 0, 0, time.UTC))
+	id3 := idGen.Generate(time.Date(2024, 12, 1, 0, 0, 0, 0, time.UTC))
+	repo.Items[id1] = &model.Announcement{ID: id1, Title: "Old", Text: "t", IsActive: true}
+	repo.Items[id2] = &model.Announcement{ID: id2, Title: "Mid", Text: "t", IsActive: true}
+	repo.Items[id3] = &model.Announcement{ID: id3, Title: "New", Text: "t", IsActive: true}
+
+	// untilId=id3 → id3より古いものだけ返る（id1, id2）
+	rec := doPost(h.List, `{"untilId":"`+id3+`"}`, nil)
+	assert.Equal(t, http.StatusOK, rec.Code)
+	var resp []map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+	assert.Len(t, resp, 2)
+	for _, item := range resp {
+		assert.NotEqual(t, id3, item["id"])
+	}
+}
+
+func TestList_SinceID(t *testing.T) {
+	h, repo := newTestHandler(t)
+	idGen, _ := id.NewGenerator("aidx")
+	id1 := idGen.Generate(time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC))
+	id2 := idGen.Generate(time.Date(2024, 6, 1, 0, 0, 0, 0, time.UTC))
+	id3 := idGen.Generate(time.Date(2024, 12, 1, 0, 0, 0, 0, time.UTC))
+	repo.Items[id1] = &model.Announcement{ID: id1, Title: "Old", Text: "t", IsActive: true}
+	repo.Items[id2] = &model.Announcement{ID: id2, Title: "Mid", Text: "t", IsActive: true}
+	repo.Items[id3] = &model.Announcement{ID: id3, Title: "New", Text: "t", IsActive: true}
+
+	// sinceId=id1 → id1より新しいものだけ返る（id2, id3）
+	rec := doPost(h.List, `{"sinceId":"`+id1+`"}`, nil)
+	assert.Equal(t, http.StatusOK, rec.Code)
+	var resp []map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+	assert.Len(t, resp, 2)
+	for _, item := range resp {
+		assert.NotEqual(t, id1, item["id"])
+	}
+}
+
 // --- ReadAnnouncement ---
 
 func TestReadAnnouncement_Success(t *testing.T) {
@@ -314,15 +356,15 @@ type failingListAnnouncementRepo struct {
 	*testutil.MockAnnouncementRepository
 }
 
-func (f *failingListAnnouncementRepo) List(_ bool, _, _ int) ([]*model.Announcement, error) {
+func (f *failingListAnnouncementRepo) List(_ bool, _, _ int, _, _ string) ([]*model.Announcement, error) {
 	return nil, assert.AnError
 }
 
-func (f *failingListAnnouncementRepo) ListGlobal(_ bool, _, _ int) ([]*model.Announcement, error) {
+func (f *failingListAnnouncementRepo) ListGlobal(_ bool, _, _ int, _, _ string) ([]*model.Announcement, error) {
 	return nil, assert.AnError
 }
 
-func (f *failingListAnnouncementRepo) ListForUser(_ string, _ bool, _, _ int) ([]*model.Announcement, error) {
+func (f *failingListAnnouncementRepo) ListForUser(_ string, _ bool, _, _ int, _, _ string) ([]*model.Announcement, error) {
 	return nil, assert.AnError
 }
 

--- a/internal/repository/announcement.go
+++ b/internal/repository/announcement.go
@@ -12,16 +12,16 @@ type AnnouncementRepository interface {
 	// List returns ALL announcements regardless of targeting. Use this for
 	// admin-only surfaces; do not expose to unauthenticated users because
 	// it returns per-user announcements targeted at other users.
-	List(activeOnly bool, limit, offset int) ([]*model.Announcement, error)
+	List(activeOnly bool, limit, offset int, sinceID, untilID string) ([]*model.Announcement, error)
 	// ListForUser returns announcements visible to userID: global ones
 	// (userId IS NULL) plus those targeted at this user. Used by
 	// /api/announcements so per-user announcements do not leak to unrelated
 	// users.
-	ListForUser(userID string, activeOnly bool, limit, offset int) ([]*model.Announcement, error)
+	ListForUser(userID string, activeOnly bool, limit, offset int, sinceID, untilID string) ([]*model.Announcement, error)
 	// ListGlobal returns only global announcements (userId IS NULL). Used
 	// for unauthenticated /api/announcements requests so targeted
 	// announcements are never exposed.
-	ListGlobal(activeOnly bool, limit, offset int) ([]*model.Announcement, error)
+	ListGlobal(activeOnly bool, limit, offset int, sinceID, untilID string) ([]*model.Announcement, error)
 	UpdateFields(id string, fields map[string]any) error
 	Delete(id string) error
 	// Read management
@@ -50,7 +50,7 @@ func (r *announcementRepository) FindByID(id string) (*model.Announcement, error
 	return &a, nil
 }
 
-func (r *announcementRepository) List(activeOnly bool, limit, offset int) ([]*model.Announcement, error) {
+func (r *announcementRepository) List(activeOnly bool, limit, offset int, sinceID, untilID string) ([]*model.Announcement, error) {
 	q := r.db.Order("id DESC")
 	if activeOnly {
 		q = q.Where("\"isActive\" = true")
@@ -62,7 +62,14 @@ func (r *announcementRepository) List(activeOnly bool, limit, offset int) ([]*mo
 		limit = 100
 	}
 	q = q.Limit(limit)
-	if offset > 0 {
+	// カーソル指定時はoffsetを無視する（本家TS実装と同じ挙動）
+	if sinceID != "" {
+		q = q.Where("id > ?", sinceID)
+	}
+	if untilID != "" {
+		q = q.Where("id < ?", untilID)
+	}
+	if sinceID == "" && untilID == "" && offset > 0 {
 		q = q.Offset(offset)
 	}
 	var announcements []*model.Announcement
@@ -72,7 +79,7 @@ func (r *announcementRepository) List(activeOnly bool, limit, offset int) ([]*mo
 	return announcements, nil
 }
 
-func (r *announcementRepository) ListGlobal(activeOnly bool, limit, offset int) ([]*model.Announcement, error) {
+func (r *announcementRepository) ListGlobal(activeOnly bool, limit, offset int, sinceID, untilID string) ([]*model.Announcement, error) {
 	q := r.db.Where(`"userId" IS NULL`).Order("id DESC")
 	if activeOnly {
 		q = q.Where("\"isActive\" = true")
@@ -84,7 +91,13 @@ func (r *announcementRepository) ListGlobal(activeOnly bool, limit, offset int) 
 		limit = 100
 	}
 	q = q.Limit(limit)
-	if offset > 0 {
+	if sinceID != "" {
+		q = q.Where("id > ?", sinceID)
+	}
+	if untilID != "" {
+		q = q.Where("id < ?", untilID)
+	}
+	if sinceID == "" && untilID == "" && offset > 0 {
 		q = q.Offset(offset)
 	}
 	var announcements []*model.Announcement
@@ -94,7 +107,7 @@ func (r *announcementRepository) ListGlobal(activeOnly bool, limit, offset int) 
 	return announcements, nil
 }
 
-func (r *announcementRepository) ListForUser(userID string, activeOnly bool, limit, offset int) ([]*model.Announcement, error) {
+func (r *announcementRepository) ListForUser(userID string, activeOnly bool, limit, offset int, sinceID, untilID string) ([]*model.Announcement, error) {
 	// GORMは連続.WhereをANDで繋ぐがraw SQL側のORはデフォルトでは括弧で
 	// 囲まれないので、明示的に囲まないとAND側の他フィルタ(isActive等)を
 	// バイパスしてしまう(SQL優先順位: AND > OR)。note.go:423と同じ gotcha。
@@ -109,7 +122,13 @@ func (r *announcementRepository) ListForUser(userID string, activeOnly bool, lim
 		limit = 100
 	}
 	q = q.Limit(limit)
-	if offset > 0 {
+	if sinceID != "" {
+		q = q.Where("id > ?", sinceID)
+	}
+	if untilID != "" {
+		q = q.Where("id < ?", untilID)
+	}
+	if sinceID == "" && untilID == "" && offset > 0 {
 		q = q.Offset(offset)
 	}
 	var announcements []*model.Announcement

--- a/internal/repository/announcement_test.go
+++ b/internal/repository/announcement_test.go
@@ -27,12 +27,12 @@ func TestAnnouncementRepository_CRUD(t *testing.T) {
 	assert.Equal(t, "Test", found.Title)
 
 	// List (active)
-	items, err := repo.List(true, 10, 0)
+	items, err := repo.List(true, 10, 0, "", "")
 	require.NoError(t, err)
 	assert.NotEmpty(t, items)
 
 	// List (all)
-	items, err = repo.List(false, 10, 0)
+	items, err = repo.List(false, 10, 0, "", "")
 	require.NoError(t, err)
 	assert.NotEmpty(t, items)
 
@@ -62,21 +62,21 @@ func TestAnnouncementRepository_List_Pagination(t *testing.T) {
 	defer cleanupAnnouncement(t, a1.ID)
 	defer cleanupAnnouncement(t, a2.ID)
 
-	items, err := repo.List(true, 1, 0)
+	items, err := repo.List(true, 1, 0, "", "")
 	require.NoError(t, err)
 	assert.Len(t, items, 1)
 
-	items, err = repo.List(true, 10, 1)
+	items, err = repo.List(true, 10, 1, "", "")
 	require.NoError(t, err)
 	assert.NotEmpty(t, items)
 
 	// default limit
-	items, err = repo.List(true, 0, 0)
+	items, err = repo.List(true, 0, 0, "", "")
 	require.NoError(t, err)
 	assert.NotEmpty(t, items)
 
 	// limit cap
-	items, err = repo.List(true, 999, 0)
+	items, err = repo.List(true, 999, 0, "", "")
 	require.NoError(t, err)
 	assert.LessOrEqual(t, len(items), 100)
 }
@@ -85,7 +85,7 @@ func TestAnnouncementRepository_List_Error(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel()
 	repo := NewAnnouncementRepository(testDB.WithContext(ctx))
-	_, err := repo.List(true, 10, 0)
+	_, err := repo.List(true, 10, 0, "", "")
 	assert.Error(t, err)
 }
 
@@ -102,7 +102,7 @@ func TestAnnouncementRepository_ListGlobal_ExcludesPerUser(t *testing.T) {
 	require.NoError(t, repo.Create(global))
 	require.NoError(t, repo.Create(targeted))
 
-	items, err := repo.ListGlobal(true, 100, 0)
+	items, err := repo.ListGlobal(true, 100, 0, "", "")
 	require.NoError(t, err)
 	ids := make(map[string]bool, len(items))
 	for _, a := range items {
@@ -121,18 +121,18 @@ func TestAnnouncementRepository_ListGlobal_Pagination(t *testing.T) {
 	require.NoError(t, repo.Create(a1))
 	require.NoError(t, repo.Create(a2))
 
-	items, err := repo.ListGlobal(true, 1, 0)
+	items, err := repo.ListGlobal(true, 1, 0, "", "")
 	require.NoError(t, err)
 	assert.Len(t, items, 1)
 	// default limitとcap経路
-	items, err = repo.ListGlobal(true, 0, 0)
+	items, err = repo.ListGlobal(true, 0, 0, "", "")
 	require.NoError(t, err)
 	assert.NotEmpty(t, items)
-	items, err = repo.ListGlobal(true, 999, 0)
+	items, err = repo.ListGlobal(true, 999, 0, "", "")
 	require.NoError(t, err)
 	assert.LessOrEqual(t, len(items), 100)
 	// offset
-	items, err = repo.ListGlobal(true, 10, 1)
+	items, err = repo.ListGlobal(true, 10, 1, "", "")
 	require.NoError(t, err)
 	assert.NotEmpty(t, items)
 }
@@ -141,7 +141,7 @@ func TestAnnouncementRepository_ListGlobal_Error(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel()
 	repo := NewAnnouncementRepository(testDB.WithContext(ctx))
-	_, err := repo.ListGlobal(true, 10, 0)
+	_, err := repo.ListGlobal(true, 10, 0, "", "")
 	assert.Error(t, err)
 }
 
@@ -161,7 +161,7 @@ func TestAnnouncementRepository_ListForUser_IncludesGlobalAndOwnTargeted(t *test
 	require.NoError(t, repo.Create(mine))
 	require.NoError(t, repo.Create(others))
 
-	items, err := repo.ListForUser(me, true, 100, 0)
+	items, err := repo.ListForUser(me, true, 100, 0, "", "")
 	require.NoError(t, err)
 	ids := make(map[string]bool, len(items))
 	for _, a := range items {
@@ -181,16 +181,16 @@ func TestAnnouncementRepository_ListForUser_Pagination(t *testing.T) {
 	require.NoError(t, repo.Create(a1))
 	require.NoError(t, repo.Create(a2))
 
-	items, err := repo.ListForUser("u", true, 1, 0)
+	items, err := repo.ListForUser("u", true, 1, 0, "", "")
 	require.NoError(t, err)
 	assert.Len(t, items, 1)
-	items, err = repo.ListForUser("u", true, 0, 0)
+	items, err = repo.ListForUser("u", true, 0, 0, "", "")
 	require.NoError(t, err)
 	assert.NotEmpty(t, items)
-	items, err = repo.ListForUser("u", true, 999, 0)
+	items, err = repo.ListForUser("u", true, 999, 0, "", "")
 	require.NoError(t, err)
 	assert.LessOrEqual(t, len(items), 100)
-	items, err = repo.ListForUser("u", true, 10, 1)
+	items, err = repo.ListForUser("u", true, 10, 1, "", "")
 	require.NoError(t, err)
 	assert.NotEmpty(t, items)
 }
@@ -199,7 +199,7 @@ func TestAnnouncementRepository_ListForUser_Error(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel()
 	repo := NewAnnouncementRepository(testDB.WithContext(ctx))
-	_, err := repo.ListForUser("u", true, 10, 0)
+	_, err := repo.ListForUser("u", true, 10, 0, "", "")
 	assert.Error(t, err)
 }
 
@@ -217,7 +217,7 @@ func TestAnnouncementRepository_ListForUser_ActiveOnlyAppliesToGlobal(t *testing
 
 	// activeOnly=true の場合、inactive な global announcement も除外される
 	// はず(括弧無しだと isActive filter が global に適用されず漏れる)。
-	items, err := repo.ListForUser("some_user", true, 100, 0)
+	items, err := repo.ListForUser("some_user", true, 100, 0, "", "")
 	require.NoError(t, err)
 	for _, a := range items {
 		assert.NotEqual(t, inactive.ID, a.ID)

--- a/internal/repository/announcement_test.go
+++ b/internal/repository/announcement_test.go
@@ -195,6 +195,83 @@ func TestAnnouncementRepository_ListForUser_Pagination(t *testing.T) {
 	assert.NotEmpty(t, items)
 }
 
+func TestAnnouncementRepository_ListGlobal_CursorPagination(t *testing.T) {
+	repo := NewAnnouncementRepository(testDB)
+	// IDの辞書順 = 時系列順になるようにIDを付ける
+	a1 := &model.Announcement{ID: "ann_cur_a", Title: "A", Text: "t", Icon: "info", Display: "normal", IsActive: true}
+	a2 := &model.Announcement{ID: "ann_cur_b", Title: "B", Text: "t", Icon: "info", Display: "normal", IsActive: true}
+	a3 := &model.Announcement{ID: "ann_cur_c", Title: "C", Text: "t", Icon: "info", Display: "normal", IsActive: true}
+	defer cleanupAnnouncement(t, a1.ID)
+	defer cleanupAnnouncement(t, a2.ID)
+	defer cleanupAnnouncement(t, a3.ID)
+	require.NoError(t, repo.Create(a1))
+	require.NoError(t, repo.Create(a2))
+	require.NoError(t, repo.Create(a3))
+
+	// untilId: a3より古いもの → a1, a2
+	items, err := repo.ListGlobal(true, 100, 0, "", a3.ID)
+	require.NoError(t, err)
+	ids := make(map[string]bool, len(items))
+	for _, a := range items {
+		ids[a.ID] = true
+	}
+	assert.True(t, ids[a1.ID])
+	assert.True(t, ids[a2.ID])
+	assert.False(t, ids[a3.ID])
+
+	// sinceId: a1より新しいもの → a2, a3
+	items, err = repo.ListGlobal(true, 100, 0, a1.ID, "")
+	require.NoError(t, err)
+	ids = make(map[string]bool, len(items))
+	for _, a := range items {
+		ids[a.ID] = true
+	}
+	assert.False(t, ids[a1.ID])
+	assert.True(t, ids[a2.ID])
+	assert.True(t, ids[a3.ID])
+
+	// sinceId + untilId: a1 < id < a3 → a2のみ
+	items, err = repo.ListGlobal(true, 100, 0, a1.ID, a3.ID)
+	require.NoError(t, err)
+	assert.Len(t, items, 1)
+	assert.Equal(t, a2.ID, items[0].ID)
+}
+
+func TestAnnouncementRepository_ListForUser_CursorPagination(t *testing.T) {
+	repo := NewAnnouncementRepository(testDB)
+	a1 := &model.Announcement{ID: "ann_ucur_a", Title: "A", Text: "t", Icon: "info", Display: "normal", IsActive: true}
+	a2 := &model.Announcement{ID: "ann_ucur_b", Title: "B", Text: "t", Icon: "info", Display: "normal", IsActive: true}
+	a3 := &model.Announcement{ID: "ann_ucur_c", Title: "C", Text: "t", Icon: "info", Display: "normal", IsActive: true}
+	defer cleanupAnnouncement(t, a1.ID)
+	defer cleanupAnnouncement(t, a2.ID)
+	defer cleanupAnnouncement(t, a3.ID)
+	require.NoError(t, repo.Create(a1))
+	require.NoError(t, repo.Create(a2))
+	require.NoError(t, repo.Create(a3))
+
+	// untilId: a3より古いもの → a1, a2
+	items, err := repo.ListForUser("u", true, 100, 0, "", a3.ID)
+	require.NoError(t, err)
+	ids := make(map[string]bool, len(items))
+	for _, a := range items {
+		ids[a.ID] = true
+	}
+	assert.True(t, ids[a1.ID])
+	assert.True(t, ids[a2.ID])
+	assert.False(t, ids[a3.ID])
+
+	// sinceId: a1より新しいもの → a2, a3
+	items, err = repo.ListForUser("u", true, 100, 0, a1.ID, "")
+	require.NoError(t, err)
+	ids = make(map[string]bool, len(items))
+	for _, a := range items {
+		ids[a.ID] = true
+	}
+	assert.False(t, ids[a1.ID])
+	assert.True(t, ids[a2.ID])
+	assert.True(t, ids[a3.ID])
+}
+
 func TestAnnouncementRepository_ListForUser_Error(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel()

--- a/internal/testutil/mock_repository.go
+++ b/internal/testutil/mock_repository.go
@@ -3303,10 +3303,16 @@ func (m *MockAnnouncementRepository) FindByID(id string) (*model.Announcement, e
 	return a, nil
 }
 
-func (m *MockAnnouncementRepository) List(activeOnly bool, limit, offset int) ([]*model.Announcement, error) {
+func (m *MockAnnouncementRepository) List(activeOnly bool, limit, offset int, sinceID, untilID string) ([]*model.Announcement, error) {
 	var result []*model.Announcement
 	for _, a := range m.Items {
 		if activeOnly && !a.IsActive {
+			continue
+		}
+		if sinceID != "" && a.ID <= sinceID {
+			continue
+		}
+		if untilID != "" && a.ID >= untilID {
 			continue
 		}
 		result = append(result, a)
@@ -3314,14 +3320,20 @@ func (m *MockAnnouncementRepository) List(activeOnly bool, limit, offset int) ([
 	if limit <= 0 {
 		limit = 10
 	}
-	if offset >= len(result) {
-		return nil, nil
+	if sinceID == "" && untilID == "" {
+		if offset >= len(result) {
+			return nil, nil
+		}
+		end := min(offset+limit, len(result))
+		return result[offset:end], nil
 	}
-	end := min(offset+limit, len(result))
-	return result[offset:end], nil
+	if limit > len(result) {
+		limit = len(result)
+	}
+	return result[:limit], nil
 }
 
-func (m *MockAnnouncementRepository) ListGlobal(activeOnly bool, limit, offset int) ([]*model.Announcement, error) {
+func (m *MockAnnouncementRepository) ListGlobal(activeOnly bool, limit, offset int, sinceID, untilID string) ([]*model.Announcement, error) {
 	var result []*model.Announcement
 	for _, a := range m.Items {
 		if a.UserID != nil {
@@ -3330,19 +3342,31 @@ func (m *MockAnnouncementRepository) ListGlobal(activeOnly bool, limit, offset i
 		if activeOnly && !a.IsActive {
 			continue
 		}
+		if sinceID != "" && a.ID <= sinceID {
+			continue
+		}
+		if untilID != "" && a.ID >= untilID {
+			continue
+		}
 		result = append(result, a)
 	}
 	if limit <= 0 {
 		limit = 10
 	}
-	if offset >= len(result) {
-		return nil, nil
+	if sinceID == "" && untilID == "" {
+		if offset >= len(result) {
+			return nil, nil
+		}
+		end := min(offset+limit, len(result))
+		return result[offset:end], nil
 	}
-	end := min(offset+limit, len(result))
-	return result[offset:end], nil
+	if limit > len(result) {
+		limit = len(result)
+	}
+	return result[:limit], nil
 }
 
-func (m *MockAnnouncementRepository) ListForUser(userID string, activeOnly bool, limit, offset int) ([]*model.Announcement, error) {
+func (m *MockAnnouncementRepository) ListForUser(userID string, activeOnly bool, limit, offset int, sinceID, untilID string) ([]*model.Announcement, error) {
 	var result []*model.Announcement
 	for _, a := range m.Items {
 		// per-user announcementのうち他ユーザー宛ては除外
@@ -3352,16 +3376,28 @@ func (m *MockAnnouncementRepository) ListForUser(userID string, activeOnly bool,
 		if activeOnly && !a.IsActive {
 			continue
 		}
+		if sinceID != "" && a.ID <= sinceID {
+			continue
+		}
+		if untilID != "" && a.ID >= untilID {
+			continue
+		}
 		result = append(result, a)
 	}
 	if limit <= 0 {
 		limit = 10
 	}
-	if offset >= len(result) {
-		return nil, nil
+	if sinceID == "" && untilID == "" {
+		if offset >= len(result) {
+			return nil, nil
+		}
+		end := min(offset+limit, len(result))
+		return result[offset:end], nil
 	}
-	end := min(offset+limit, len(result))
-	return result[offset:end], nil
+	if limit > len(result) {
+		limit = len(result)
+	}
+	return result[:limit], nil
 }
 
 func (m *MockAnnouncementRepository) UpdateFields(id string, fields map[string]any) error {


### PR DESCRIPTION
## Summary
- `/api/announcements` が `sinceId`/`untilId` パラメータを無視していたため、本家フロントエンドの `MkPagination` が無限ロードになっていた問題を修正
- `AnnouncementRepository` のList系3メソッドにカーソルベースページング (`sinceID`/`untilID`) を追加
- カーソル指定時は `offset` を無視（本家TS実装と同じ挙動）

## 主な変更点
- `internal/repository/announcement.go`: インターフェースと実装に `sinceID, untilID string` 引数を追加。`id > sinceID` / `id < untilID` でフィルタ
- `internal/api/announcements/handler.go`: リクエスト構造体に `sinceId`/`untilId` フィールド追加
- `internal/api/announcements/handler_test.go`: `TestList_UntilID`, `TestList_SinceID` テスト追加
- `internal/testutil/mock_repository.go`: モック実装を新シグネチャに合わせて更新

## テスト
```bash
go test -race -count=1 ./internal/api/announcements/...
```

Closes #324
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/shiroha-a/mk/pull/325" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
