### PR TITLE
Phase 7-5a follow-up: notes hot path で UserLite.instance を populate (#277)

### DIFF
--- a/internal/api/antennas/handler.go
+++ b/internal/api/antennas/handler.go
@@ -17,15 +17,29 @@ import (
 
 // Handler handles antenna-related API endpoints.
 type Handler struct {
-	svc      *coreantenna.Service
-	noteRepo repository.NoteRepository
-	idGen    id.Generator
+	svc          *coreantenna.Service
+	noteRepo     repository.NoteRepository
+	idGen        id.Generator
+	instanceRepo repository.InstanceRepository
 }
 
 // NewHandler constructs an antennas Handler. noteRepo は antennas/notes で
 // note id → entity 変換に使う。
 func NewHandler(svc *coreantenna.Service, noteRepo repository.NoteRepository, idGen id.Generator) *Handler {
 	return &Handler{svc: svc, noteRepo: noteRepo, idGen: idGen}
+}
+
+// SetInstanceRepo attaches an InstanceRepository so antennas/notes populates
+// UserLite.Instance for remote users (#277).
+func (h *Handler) SetInstanceRepo(r repository.InstanceRepository) {
+	h.instanceRepo = r
+}
+
+func (h *Handler) instanceLookup() entity.InstanceLookup {
+	if h.instanceRepo == nil {
+		return nil
+	}
+	return h.instanceRepo
 }
 
 // CreateRequest is the request body for antennas/create.
@@ -216,9 +230,10 @@ func (h *Handler) Notes(c echo.Context) error {
 	if err != nil {
 		return apierr.JSONInternalError(c)
 	}
-	out := make([]any, 0, len(notes))
-	for _, n := range notes {
-		out = append(out, entity.PackNote(n, h.idGen))
+	entities := entity.PackNotes(notes, h.idGen, h.instanceLookup())
+	out := make([]any, 0, len(entities))
+	for _, pn := range entities {
+		out = append(out, pn)
 	}
 	return c.JSON(http.StatusOK, out)
 }

--- a/internal/api/channels/handler.go
+++ b/internal/api/channels/handler.go
@@ -11,6 +11,7 @@ import (
 	"github.com/shiroha-a/mk/internal/entity"
 	"github.com/shiroha-a/mk/internal/misc/id"
 	"github.com/shiroha-a/mk/internal/model"
+	"github.com/shiroha-a/mk/internal/repository"
 	"github.com/shiroha-a/mk/internal/server/middleware"
 )
 
@@ -20,6 +21,20 @@ type Handler struct {
 	idGen        id.Generator
 	favoriteRepo ChannelFavoriteRepository
 	mutingRepo   ChannelMutingRepository
+	instanceRepo repository.InstanceRepository
+}
+
+// SetInstanceRepo attaches an InstanceRepository so channel timeline responses
+// populate UserLite.Instance for remote users (#277).
+func (h *Handler) SetInstanceRepo(r repository.InstanceRepository) {
+	h.instanceRepo = r
+}
+
+func (h *Handler) instanceLookup() entity.InstanceLookup {
+	if h.instanceRepo == nil {
+		return nil
+	}
+	return h.instanceRepo
 }
 
 // ChannelFavoriteRepository is the interface for channel favorite operations.
@@ -267,9 +282,10 @@ func (h *Handler) Timeline(c echo.Context) error {
 		}
 		return apierr.JSONInternalError(c)
 	}
-	out := make([]any, 0, len(notes))
-	for _, n := range notes {
-		out = append(out, entity.PackNote(n, h.idGen))
+	entities := entity.PackNotes(notes, h.idGen, h.instanceLookup())
+	out := make([]any, 0, len(entities))
+	for _, pn := range entities {
+		out = append(out, pn)
 	}
 	return c.JSON(http.StatusOK, out)
 }

--- a/internal/api/clips/handler.go
+++ b/internal/api/clips/handler.go
@@ -11,6 +11,7 @@ import (
 	"github.com/shiroha-a/mk/internal/entity"
 	"github.com/shiroha-a/mk/internal/misc/id"
 	"github.com/shiroha-a/mk/internal/model"
+	"github.com/shiroha-a/mk/internal/repository"
 	"github.com/shiroha-a/mk/internal/server/middleware"
 )
 
@@ -19,6 +20,20 @@ type Handler struct {
 	svc          *coreclip.Service
 	idGen        id.Generator
 	favoriteRepo ClipFavoriteRepository
+	instanceRepo repository.InstanceRepository
+}
+
+// SetInstanceRepo attaches an InstanceRepository so clips/notes populates
+// UserLite.Instance for remote users (#277).
+func (h *Handler) SetInstanceRepo(r repository.InstanceRepository) {
+	h.instanceRepo = r
+}
+
+func (h *Handler) instanceLookup() entity.InstanceLookup {
+	if h.instanceRepo == nil {
+		return nil
+	}
+	return h.instanceRepo
 }
 
 // NewHandler creates a new clips Handler.
@@ -249,9 +264,10 @@ func (h *Handler) Notes(c echo.Context) error {
 		}
 		return apierr.JSONInternalError(c)
 	}
-	out := make([]any, 0, len(notes))
-	for _, n := range notes {
-		out = append(out, entity.PackNote(n, h.idGen))
+	entities := entity.PackNotes(notes, h.idGen, h.instanceLookup())
+	out := make([]any, 0, len(entities))
+	for _, pn := range entities {
+		out = append(out, pn)
 	}
 	return c.JSON(http.StatusOK, out)
 }

--- a/internal/api/drive/handler.go
+++ b/internal/api/drive/handler.go
@@ -18,12 +18,13 @@ import (
 
 // Handler handles drive-related API endpoints.
 type Handler struct {
-	svc        *coredrive.Service
-	idGen      id.Generator
-	fileRepo   repository.DriveFileRepository
-	folderRepo repository.DriveFolderRepository
-	noteRepo   repository.NoteRepository
-	userRepo   repository.UserRepository
+	svc          *coredrive.Service
+	idGen        id.Generator
+	fileRepo     repository.DriveFileRepository
+	folderRepo   repository.DriveFolderRepository
+	noteRepo     repository.NoteRepository
+	userRepo     repository.UserRepository
+	instanceRepo repository.InstanceRepository
 }
 
 // NewHandler creates a new drive Handler.
@@ -43,6 +44,19 @@ func (h *Handler) SetRepos(fileRepo repository.DriveFileRepository, folderRepo r
 // it the `user` field is omitted.
 func (h *Handler) SetUserRepo(r repository.UserRepository) {
 	h.userRepo = r
+}
+
+// SetInstanceRepo attaches an InstanceRepository so drive/files/attached-notes
+// populates UserLite.Instance for remote users (#277).
+func (h *Handler) SetInstanceRepo(r repository.InstanceRepository) {
+	h.instanceRepo = r
+}
+
+func (h *Handler) instanceLookup() entity.InstanceLookup {
+	if h.instanceRepo == nil {
+		return nil
+	}
+	return h.instanceRepo
 }
 
 // packDriveFileFull packs a drive file and, when repositories are wired,
@@ -432,10 +446,7 @@ func (h *Handler) FilesAttachedNotes(c echo.Context) error {
 	if err != nil {
 		return c.JSON(http.StatusOK, []any{})
 	}
-	out := make([]entity.NoteEntity, 0, len(notes))
-	for _, n := range notes {
-		out = append(out, entity.PackNote(n, h.idGen))
-	}
+	out := entity.PackNotes(notes, h.idGen, h.instanceLookup())
 	return c.JSON(http.StatusOK, out)
 }
 

--- a/internal/api/i/handler.go
+++ b/internal/api/i/handler.go
@@ -69,6 +69,7 @@ type Handler struct {
 	piningRepo          repository.UserNotePiningRepository
 	noteRepo            repository.NoteRepository
 	pageRepo            repository.PageRepository
+	instanceRepo        repository.InstanceRepository
 	mainStreamPublisher MainStreamPublisher
 }
 
@@ -85,6 +86,19 @@ type MainStreamPublisher interface {
 // disables emit.
 func (h *Handler) SetMainStreamPublisher(p MainStreamPublisher) {
 	h.mainStreamPublisher = p
+}
+
+// SetInstanceRepo attaches an InstanceRepository so favorites/notifications
+// note embeds populate UserLite.Instance for remote users (#277).
+func (h *Handler) SetInstanceRepo(r repository.InstanceRepository) {
+	h.instanceRepo = r
+}
+
+func (h *Handler) instanceLookup() entity.InstanceLookup {
+	if h.instanceRepo == nil {
+		return nil
+	}
+	return h.instanceRepo
 }
 
 // UnreadNotificationSource is the subset of notification.Service used by /api/i
@@ -844,9 +858,10 @@ func (h *Handler) fillPinnedFields(u *model.User, profile *model.UserProfile, re
 
 			if h.noteRepo != nil {
 				if notes, err := h.noteRepo.FindManyByIDsWithUser(ids); err == nil {
-					packed := make([]any, 0, len(notes))
-					for _, n := range notes {
-						packed = append(packed, entity.PackNote(n, h.idGen))
+					entities := entity.PackNotes(notes, h.idGen, h.instanceLookup())
+					packed := make([]any, 0, len(entities))
+					for _, pn := range entities {
+						packed = append(packed, pn)
 					}
 					resp["pinnedNotes"] = packed
 				}

--- a/internal/api/i/handler_extra.go
+++ b/internal/api/i/handler_extra.go
@@ -97,7 +97,7 @@ func (h *Handler) Favorites(c echo.Context) error {
 			notes = append(notes, f.Note)
 		}
 	}
-	resolver := entity.NewInstanceResolver(h.instanceLookup(), collectNoteAuthors(notes)...)
+	resolver := entity.NewInstanceResolver(h.instanceLookup(), entity.CollectNoteAuthors(notes)...)
 
 	result := make([]map[string]any, 0, len(favs))
 	for _, f := range favs {
@@ -113,19 +113,6 @@ func (h *Handler) Favorites(c echo.Context) error {
 		result = append(result, item)
 	}
 	return c.JSON(http.StatusOK, result)
-}
-
-// collectNoteAuthors returns the author User pointer of each note that has
-// one preloaded. Used to build an entity.InstanceResolver over a set of
-// notes without pulling in the full model package in entity.
-func collectNoteAuthors(notes []*model.Note) []*model.User {
-	out := make([]*model.User, 0, len(notes))
-	for _, n := range notes {
-		if n != nil && n.User != nil {
-			out = append(out, n.User)
-		}
-	}
-	return out
 }
 
 // NotificationsGrouped handles POST /api/i/notifications-grouped.

--- a/internal/api/i/handler_extra.go
+++ b/internal/api/i/handler_extra.go
@@ -10,6 +10,7 @@ import (
 	"github.com/labstack/echo/v4"
 	"github.com/shiroha-a/mk/internal/api/apierr"
 	"github.com/shiroha-a/mk/internal/entity"
+	"github.com/shiroha-a/mk/internal/model"
 	"github.com/shiroha-a/mk/internal/server/middleware"
 	"golang.org/x/crypto/bcrypt"
 )
@@ -88,6 +89,16 @@ func (h *Handler) Favorites(c echo.Context) error {
 	if err != nil {
 		return c.JSON(http.StatusInternalServerError, apierr.Error("INTERNAL_ERROR", "Internal error.", "5d37dbcb-891e-41ca-a3d6-e690c97775ac"))
 	}
+	// 複数の favorite note について remote user の instance を 1 回の batch
+	// fetch で resolve する。
+	notes := make([]*model.Note, 0, len(favs))
+	for _, f := range favs {
+		if f.Note != nil {
+			notes = append(notes, f.Note)
+		}
+	}
+	resolver := entity.NewInstanceResolver(h.instanceLookup(), collectNoteAuthors(notes)...)
+
 	result := make([]map[string]any, 0, len(favs))
 	for _, f := range favs {
 		item := map[string]any{
@@ -95,11 +106,26 @@ func (h *Handler) Favorites(c echo.Context) error {
 			"noteId": f.NoteID,
 		}
 		if f.Note != nil {
-			item["note"] = entity.PackNote(f.Note, h.idGen)
+			pn := entity.PackNote(f.Note, h.idGen)
+			resolver.FillUserLite(&pn.User)
+			item["note"] = pn
 		}
 		result = append(result, item)
 	}
 	return c.JSON(http.StatusOK, result)
+}
+
+// collectNoteAuthors returns the author User pointer of each note that has
+// one preloaded. Used to build an entity.InstanceResolver over a set of
+// notes without pulling in the full model package in entity.
+func collectNoteAuthors(notes []*model.Note) []*model.User {
+	out := make([]*model.User, 0, len(notes))
+	for _, n := range notes {
+		if n != nil && n.User != nil {
+			out = append(out, n.User)
+		}
+	}
+	return out
 }
 
 // NotificationsGrouped handles POST /api/i/notifications-grouped.

--- a/internal/api/notes/handler.go
+++ b/internal/api/notes/handler.go
@@ -37,6 +37,7 @@ type Handler struct {
 	noteReactionRepo  repository.NoteReactionRepository
 	channelRepo       repository.ChannelRepository
 	channelMutingRepo repository.ChannelMutingRepository
+	instanceRepo      repository.InstanceRepository
 	// ugcVisibility controls what unauthenticated visitors can see.
 	// "all" (default), "local", "none"
 	ugcVisibility string
@@ -72,6 +73,22 @@ func (h *Handler) SetNoteReactionRepo(r repository.NoteReactionRepository) {
 // SetChannelRepo attaches a ChannelRepository for channel resolution.
 func (h *Handler) SetChannelRepo(r repository.ChannelRepository) {
 	h.channelRepo = r
+}
+
+// SetInstanceRepo attaches an InstanceRepository so remote user embeds in
+// note responses get their `instance` field populated (#277).
+func (h *Handler) SetInstanceRepo(r repository.InstanceRepository) {
+	h.instanceRepo = r
+}
+
+// instanceLookup returns the repository as an entity.InstanceLookup, or nil
+// when no repo has been wired. Narrowing to the entity interface keeps the
+// packer independent from repository details.
+func (h *Handler) instanceLookup() entity.InstanceLookup {
+	if h.instanceRepo == nil {
+		return nil
+	}
+	return h.instanceRepo
 }
 
 // NewHandler creates a new notes Handler.
@@ -196,7 +213,7 @@ func (h *Handler) Create(c echo.Context) error {
 		return apierr.JSONInternalError(c)
 	}
 
-	packed := entity.PackNote(created, h.idGen)
+	packed := entity.PackNoteWithInstance(created, h.idGen, h.instanceLookup())
 	s := []entity.NoteEntity{packed}
 	h.resolveFiles(s)
 	h.resolveViewerFields(s, user)
@@ -223,7 +240,7 @@ func (h *Handler) Show(c echo.Context) error {
 		return apierr.JSONNoSuchNote(c)
 	}
 
-	packed := entity.PackNote(n, h.idGen)
+	packed := entity.PackNoteWithInstance(n, h.idGen, h.instanceLookup())
 	s := []entity.NoteEntity{packed}
 	h.resolveFiles(s)
 	h.resolveViewerFields(s, viewer)
@@ -465,10 +482,7 @@ func (h *Handler) BulkShow(c echo.Context) error {
 // driveFileRepoが設定されている場合、ファイル情報を解決してFilesに含める。
 // viewerがnon-nilの場合、myReactionなどのviewer依存フィールドも解決する。
 func (h *Handler) packMany(notes []*model.Note, viewer *model.User) []entity.NoteEntity {
-	out := make([]entity.NoteEntity, 0, len(notes))
-	for _, n := range notes {
-		out = append(out, entity.PackNote(n, h.idGen))
-	}
+	out := entity.PackNotes(notes, h.idGen, h.instanceLookup())
 	h.resolveFiles(out)
 	h.resolveViewerFields(out, viewer)
 	return out

--- a/internal/api/notes/handler_test.go
+++ b/internal/api/notes/handler_test.go
@@ -181,6 +181,53 @@ func TestShow_Success(t *testing.T) {
 	assert.Equal(t, "existing note", resp["text"])
 }
 
+func TestShow_PopulatesUserInstanceForRemoteAuthor(t *testing.T) {
+	h, noteRepo := newTestHandler(t)
+
+	// InstanceRepo を注入して remote host に対応する Instance row を用意する。
+	instanceRepo := testutil.NewMockInstanceRepository()
+	name := "Remote Misskey"
+	instanceRepo.Instances["remote.example"] = &model.Instance{
+		Host: "remote.example",
+		Name: &name,
+	}
+	h.SetInstanceRepo(instanceRepo)
+
+	host := "remote.example"
+	text := "remote note"
+	noteRepo.Notes["n1"] = &model.Note{
+		ID:         "n1",
+		UserID:     "uR",
+		Text:       &text,
+		Visibility: model.NoteVisibilityPublic,
+		Reactions:  datatypes.JSON([]byte("{}")),
+		User: &model.User{
+			ID:                "uR",
+			Username:          "remoteuser",
+			Host:              &host,
+			AvatarDecorations: datatypes.JSON([]byte("[]")),
+		},
+	}
+
+	body := `{"noteId": "n1"}`
+	e := echo.New()
+	req := httptest.NewRequest(http.MethodPost, "/api/notes/show", strings.NewReader(body))
+	req.Header.Set(echo.HeaderContentType, echo.MIMEApplicationJSON)
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+
+	require.NoError(t, h.Show(c))
+	assert.Equal(t, http.StatusOK, rec.Code)
+
+	var resp map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+	user, ok := resp["user"].(map[string]any)
+	require.True(t, ok, "response must contain user object")
+	instance, ok := user["instance"].(map[string]any)
+	require.True(t, ok, "user must have instance field populated for remote author")
+	assert.Equal(t, "Remote Misskey", instance["name"])
+}
+
 func TestShow_NotFound(t *testing.T) {
 	h, _ := newTestHandler(t)
 

--- a/internal/api/notes/reactions_handler.go
+++ b/internal/api/notes/reactions_handler.go
@@ -8,6 +8,7 @@ import (
 	"github.com/shiroha-a/mk/internal/api/apierr"
 	"github.com/shiroha-a/mk/internal/core/reaction"
 	"github.com/shiroha-a/mk/internal/entity"
+	"github.com/shiroha-a/mk/internal/model"
 	"github.com/shiroha-a/mk/internal/server/middleware"
 )
 
@@ -103,6 +104,15 @@ func (h *Handler) Reactions(c echo.Context) error {
 		return apierr.JSONInternalError(c)
 	}
 
+	// リモート user の instance を 1 回の batch fetch で resolve する。
+	reactionUsers := make([]*model.User, 0, len(rows))
+	for _, r := range rows {
+		if r.User != nil {
+			reactionUsers = append(reactionUsers, r.User)
+		}
+	}
+	resolver := entity.NewInstanceResolver(h.instanceLookup(), reactionUsers...)
+
 	out := make([]map[string]any, 0, len(rows))
 	for _, r := range rows {
 		createdAt := ""
@@ -111,7 +121,9 @@ func (h *Handler) Reactions(c echo.Context) error {
 		}
 		var userField any = map[string]any{"id": r.UserID}
 		if r.User != nil {
-			userField = entity.PackUserLite(r.User)
+			lite := entity.PackUserLite(r.User)
+			resolver.FillUserLite(&lite)
+			userField = lite
 		}
 		out = append(out, map[string]any{
 			"id":        r.ID,

--- a/internal/api/roles/handler.go
+++ b/internal/api/roles/handler.go
@@ -9,6 +9,7 @@ import (
 	"github.com/shiroha-a/mk/internal/entity"
 	"github.com/shiroha-a/mk/internal/misc/id"
 	"github.com/shiroha-a/mk/internal/model"
+	"github.com/shiroha-a/mk/internal/repository"
 )
 
 // RoleNotesQuery provides a way to fetch notes by role.
@@ -18,9 +19,10 @@ type RoleNotesQuery interface {
 
 // Handler handles public role API endpoints.
 type Handler struct {
-	roleService *role.Service
-	notesQuery  RoleNotesQuery
-	idGen       id.Generator
+	roleService  *role.Service
+	notesQuery   RoleNotesQuery
+	idGen        id.Generator
+	instanceRepo repository.InstanceRepository
 }
 
 // NewHandler creates a new roles Handler. idGen is required for note packing
@@ -32,6 +34,19 @@ func NewHandler(roleService *role.Service, idGen id.Generator) *Handler {
 // SetNotesQuery attaches a RoleNotesQuery for the roles/notes endpoint.
 func (h *Handler) SetNotesQuery(q RoleNotesQuery) {
 	h.notesQuery = q
+}
+
+// SetInstanceRepo attaches an InstanceRepository so roles/notes populates
+// UserLite.Instance for remote users (#277).
+func (h *Handler) SetInstanceRepo(r repository.InstanceRepository) {
+	h.instanceRepo = r
+}
+
+func (h *Handler) instanceLookup() entity.InstanceLookup {
+	if h.instanceRepo == nil {
+		return nil
+	}
+	return h.instanceRepo
 }
 
 // List handles POST /api/roles/list.
@@ -118,9 +133,10 @@ func (h *Handler) Notes(c echo.Context) error {
 		return c.JSON(http.StatusInternalServerError, apierr.Error("INTERNAL_ERROR", "Internal error.", "5d37dbcb-891e-41ca-a3d6-e690c97775ac"))
 	}
 
-	out := make([]any, 0, len(notes))
-	for _, n := range notes {
-		out = append(out, entity.PackNote(n, h.idGen))
+	entities := entity.PackNotes(notes, h.idGen, h.instanceLookup())
+	out := make([]any, 0, len(entities))
+	for _, pn := range entities {
+		out = append(out, pn)
 	}
 	return c.JSON(http.StatusOK, out)
 }

--- a/internal/api/users/handler.go
+++ b/internal/api/users/handler.go
@@ -101,6 +101,15 @@ func (h *Handler) SetInstanceRepo(r repository.InstanceRepository) {
 	h.instanceRepo = r
 }
 
+// instanceLookup adapts instanceRepo to entity.InstanceLookup. Returns nil
+// when no repo is wired (entity.PackNotes treats nil as "skip Instance").
+func (h *Handler) instanceLookup() entity.InstanceLookup {
+	if h.instanceRepo == nil {
+		return nil
+	}
+	return h.instanceRepo
+}
+
 // NewHandler creates a new users Handler.
 // followingService, noteRepo, idGen are optional for the bare /show endpoint.
 func NewHandler(
@@ -344,10 +353,7 @@ func (h *Handler) Notes(c echo.Context) error {
 		return apierr.JSONInternalError(c)
 	}
 
-	out := make([]entity.NoteEntity, 0, len(notes))
-	for _, n := range notes {
-		out = append(out, entity.PackNote(n, h.idGen))
-	}
+	out := entity.PackNotes(notes, h.idGen, h.instanceLookup())
 	return c.JSON(http.StatusOK, out)
 }
 
@@ -471,9 +477,10 @@ func (h *Handler) fillPinned(u *model.User, profile *model.UserProfile, detailed
 			detailed.PinnedNoteIDs = ids
 			if h.noteRepo != nil {
 				if notes, err := h.noteRepo.FindManyByIDsWithUser(ids); err == nil {
-					packed := make([]any, 0, len(notes))
-					for _, n := range notes {
-						packed = append(packed, entity.PackNote(n, h.idGen))
+					entities := entity.PackNotes(notes, h.idGen, h.instanceLookup())
+					packed := make([]any, 0, len(entities))
+					for _, pn := range entities {
+						packed = append(packed, pn)
 					}
 					detailed.PinnedNotes = packed
 				}

--- a/internal/api/users/handler.go
+++ b/internal/api/users/handler.go
@@ -155,11 +155,24 @@ func (h *Handler) Show(c echo.Context) error {
 		if len(req.UserIDs) > 100 {
 			req.UserIDs = req.UserIDs[:100]
 		}
-		out := make([]entity.UserLite, 0, len(req.UserIDs))
+		// bulk fetch してから 1 回の batch で instance を resolve する (#277)。
+		// single-user path と同じ UserLite.instance 表示互換を維持する。
+		bundles := make([]*user.UserWithProfile, 0, len(req.UserIDs))
 		for _, uid := range req.UserIDs {
 			if bundle, err := h.userService.ShowByID(uid); err == nil {
-				out = append(out, entity.PackUserLite(bundle.User))
+				bundles = append(bundles, bundle)
 			}
+		}
+		users := make([]*model.User, 0, len(bundles))
+		for _, b := range bundles {
+			users = append(users, b.User)
+		}
+		resolver := entity.NewInstanceResolver(h.instanceLookup(), users...)
+		out := make([]entity.UserLite, 0, len(bundles))
+		for _, b := range bundles {
+			lite := entity.PackUserLite(b.User)
+			resolver.FillUserLite(&lite)
+			out = append(out, lite)
 		}
 		return c.JSON(http.StatusOK, out)
 	}

--- a/internal/api/users/handler.go
+++ b/internal/api/users/handler.go
@@ -328,10 +328,13 @@ func (h *Handler) Search(c echo.Context) error {
 		return apierr.JSONInternalError(c)
 	}
 
+	resolver := entity.NewInstanceResolver(h.instanceLookup(), users...)
 	out := make([]entity.UserDetailed, 0, len(users))
 	for _, u := range users {
 		profile := h.userService.GetProfile(u.ID)
-		out = append(out, entity.PackUserDetailed(u, profile))
+		d := entity.PackUserDetailed(u, profile)
+		resolver.FillUserLite(&d.UserLite)
+		out = append(out, d)
 	}
 	return c.JSON(http.StatusOK, out)
 }

--- a/internal/api/users/handler.go
+++ b/internal/api/users/handler.go
@@ -332,7 +332,7 @@ func (h *Handler) Search(c echo.Context) error {
 	out := make([]entity.UserDetailed, 0, len(users))
 	for _, u := range users {
 		profile := h.userService.GetProfile(u.ID)
-		d := entity.PackUserDetailed(u, profile)
+		d := entity.PackUserDetailed(u, profile, h.idGen)
 		resolver.FillUserLite(&d.UserLite)
 		out = append(out, d)
 	}
@@ -449,7 +449,7 @@ func (h *Handler) collectFollowers(req FollowersRequest) ([]relationItem, error)
 		}
 		item := relationItem{ID: f.ID, FollowerID: f.FollowerID, FolloweeID: f.FolloweeID}
 		if b, err := h.userService.ShowByID(f.FollowerID); err == nil {
-			d := entity.PackUserDetailed(b.User, b.Profile)
+			d := entity.PackUserDetailed(b.User, b.Profile, h.idGen)
 			item.Follower = &d
 		}
 		out = append(out, item)
@@ -472,7 +472,7 @@ func (h *Handler) collectFollowing(req FollowersRequest) ([]relationItem, error)
 		}
 		item := relationItem{ID: f.ID, FollowerID: f.FollowerID, FolloweeID: f.FolloweeID}
 		if b, err := h.userService.ShowByID(f.FolloweeID); err == nil {
-			d := entity.PackUserDetailed(b.User, b.Profile)
+			d := entity.PackUserDetailed(b.User, b.Profile, h.idGen)
 			item.Followee = &d
 		}
 		out = append(out, item)

--- a/internal/api/users/handler.go
+++ b/internal/api/users/handler.go
@@ -438,18 +438,35 @@ func (h *Handler) collectFollowers(req FollowersRequest) ([]relationItem, error)
 	if err != nil {
 		return nil, err
 	}
-	out := make([]relationItem, 0, len(rows))
+	// 一旦 bundle を全件集めてから resolver を 1 度構築する。ShowByID は
+	// N+1 のままだが、instance は batch 1 回に集約できる (#277)。
+	type resolved struct {
+		f      *model.Following
+		bundle *user.UserWithProfile
+	}
+	pending := make([]resolved, 0, len(rows))
+	remoteUsers := make([]*model.User, 0, len(rows))
 	for _, f := range rows {
-		// カーソルベースページネーション
 		if req.SinceID != "" && f.ID <= req.SinceID {
 			continue
 		}
 		if req.UntilID != "" && f.ID >= req.UntilID {
 			continue
 		}
-		item := relationItem{ID: f.ID, FollowerID: f.FollowerID, FolloweeID: f.FolloweeID}
+		r := resolved{f: f}
 		if b, err := h.userService.ShowByID(f.FollowerID); err == nil {
-			d := entity.PackUserDetailed(b.User, b.Profile, h.idGen)
+			r.bundle = b
+			remoteUsers = append(remoteUsers, b.User)
+		}
+		pending = append(pending, r)
+	}
+	resolver := entity.NewInstanceResolver(h.instanceLookup(), remoteUsers...)
+	out := make([]relationItem, 0, len(pending))
+	for _, r := range pending {
+		item := relationItem{ID: r.f.ID, FollowerID: r.f.FollowerID, FolloweeID: r.f.FolloweeID}
+		if r.bundle != nil {
+			d := entity.PackUserDetailed(r.bundle.User, r.bundle.Profile, h.idGen)
+			resolver.FillUserLite(&d.UserLite)
 			item.Follower = &d
 		}
 		out = append(out, item)
@@ -462,7 +479,12 @@ func (h *Handler) collectFollowing(req FollowersRequest) ([]relationItem, error)
 	if err != nil {
 		return nil, err
 	}
-	out := make([]relationItem, 0, len(rows))
+	type resolved struct {
+		f      *model.Following
+		bundle *user.UserWithProfile
+	}
+	pending := make([]resolved, 0, len(rows))
+	remoteUsers := make([]*model.User, 0, len(rows))
 	for _, f := range rows {
 		if req.SinceID != "" && f.ID <= req.SinceID {
 			continue
@@ -470,9 +492,20 @@ func (h *Handler) collectFollowing(req FollowersRequest) ([]relationItem, error)
 		if req.UntilID != "" && f.ID >= req.UntilID {
 			continue
 		}
-		item := relationItem{ID: f.ID, FollowerID: f.FollowerID, FolloweeID: f.FolloweeID}
+		r := resolved{f: f}
 		if b, err := h.userService.ShowByID(f.FolloweeID); err == nil {
-			d := entity.PackUserDetailed(b.User, b.Profile, h.idGen)
+			r.bundle = b
+			remoteUsers = append(remoteUsers, b.User)
+		}
+		pending = append(pending, r)
+	}
+	resolver := entity.NewInstanceResolver(h.instanceLookup(), remoteUsers...)
+	out := make([]relationItem, 0, len(pending))
+	for _, r := range pending {
+		item := relationItem{ID: r.f.ID, FollowerID: r.f.FollowerID, FolloweeID: r.f.FolloweeID}
+		if r.bundle != nil {
+			d := entity.PackUserDetailed(r.bundle.User, r.bundle.Profile, h.idGen)
+			resolver.FillUserLite(&d.UserLite)
 			item.Followee = &d
 		}
 		out = append(out, item)

--- a/internal/api/users/handler_extra.go
+++ b/internal/api/users/handler_extra.go
@@ -96,10 +96,7 @@ func (h *Handler) FeaturedNotes(c echo.Context) error {
 	if err != nil {
 		return c.JSON(http.StatusInternalServerError, apierr.Error("INTERNAL_ERROR", "Internal error.", "5d37dbcb-891e-41ca-a3d6-e690c97775ac"))
 	}
-	result := make([]entity.NoteEntity, 0, len(notes))
-	for _, n := range notes {
-		result = append(result, entity.PackNote(n, h.idGen))
-	}
+	result := entity.PackNotes(notes, h.idGen, h.instanceLookup())
 	return c.JSON(http.StatusOK, result)
 }
 

--- a/internal/api/users/handler_extra.go
+++ b/internal/api/users/handler_extra.go
@@ -117,9 +117,12 @@ func (h *Handler) SearchByUsernameAndHost(c echo.Context) error {
 	if err != nil {
 		return c.JSON(http.StatusInternalServerError, apierr.Error("INTERNAL_ERROR", "Internal error.", "5d37dbcb-891e-41ca-a3d6-e690c97775ac"))
 	}
+	resolver := entity.NewInstanceResolver(h.instanceLookup(), users...)
 	result := make([]entity.UserLite, 0, len(users))
 	for _, u := range users {
-		result = append(result, entity.PackUserLite(u))
+		lite := entity.PackUserLite(u)
+		resolver.FillUserLite(&lite)
+		result = append(result, lite)
 	}
 	return c.JSON(http.StatusOK, result)
 }

--- a/internal/entity/instance_resolver.go
+++ b/internal/entity/instance_resolver.go
@@ -23,6 +23,11 @@ type InstanceResolver struct {
 //
 // lookup が nil なら cache は空 (Resolve は常に nil を返す) のリゾルバを返す。
 // users は可変長で reply/renote のユーザーもまとめて渡せる。
+//
+// lookup.FindManyByHosts が error を返した場合も best-effort として空 cache の
+// resolver を返す (entity 層に slog 依存を入れないため)。DB 失敗時の観測性が
+// 重要な場面では caller 側で lookup を直接呼んでログを取ってから、この
+// resolver に別途 seed する実装を検討すること。
 func NewInstanceResolver(lookup InstanceLookup, users ...*model.User) *InstanceResolver {
 	r := &InstanceResolver{cache: map[string]*InstanceLite{}}
 	if lookup == nil {

--- a/internal/entity/instance_resolver.go
+++ b/internal/entity/instance_resolver.go
@@ -18,8 +18,9 @@ type InstanceResolver struct {
 }
 
 // NewInstanceResolver extracts the set of remote hosts referenced by `users`
-// and fetches their Instance rows in a single query. Missing hosts are cached
-// as nil so repeated Resolve calls do not trigger extra work.
+// and fetches their Instance rows in a single query. Hosts absent from the
+// lookup result stay out of the cache; `Resolve` then returns the map zero
+// value (`nil`) for them, avoiding any repeat fetch.
 //
 // lookup が nil なら cache は空 (Resolve は常に nil を返す) のリゾルバを返す。
 // users は可変長で reply/renote のユーザーもまとめて渡せる。

--- a/internal/entity/instance_resolver.go
+++ b/internal/entity/instance_resolver.go
@@ -1,0 +1,95 @@
+package entity
+
+import "github.com/shiroha-a/mk/internal/model"
+
+// InstanceLookup is the minimal interface required to batch-fetch instance
+// rows for UserLite.Instance populate. 循環依存を避けるため interface で受け
+// 取る (実装は repository.InstanceRepository)。
+type InstanceLookup interface {
+	FindManyByHosts(hosts []string) ([]*model.Instance, error)
+}
+
+// InstanceResolver caches host → *InstanceLite lookups so that packers can
+// populate UserLite.Instance without repeating DB queries for shared hosts.
+// 1 回の batch fetch + 以降 O(1) 参照。nil レシーバは常に nil を返す
+// (FillUserLite を no-op にしたい callsite 向け)。
+type InstanceResolver struct {
+	cache map[string]*InstanceLite
+}
+
+// NewInstanceResolver extracts the set of remote hosts referenced by `users`
+// and fetches their Instance rows in a single query. Missing hosts are cached
+// as nil so repeated Resolve calls do not trigger extra work.
+//
+// lookup が nil なら cache は空 (Resolve は常に nil を返す) のリゾルバを返す。
+// users は可変長で reply/renote のユーザーもまとめて渡せる。
+func NewInstanceResolver(lookup InstanceLookup, users ...*model.User) *InstanceResolver {
+	r := &InstanceResolver{cache: map[string]*InstanceLite{}}
+	if lookup == nil {
+		return r
+	}
+	// unique remote host を集める
+	seen := map[string]struct{}{}
+	hosts := make([]string, 0, len(users))
+	for _, u := range users {
+		if u == nil || u.Host == nil || *u.Host == "" {
+			continue
+		}
+		h := *u.Host
+		if _, ok := seen[h]; ok {
+			continue
+		}
+		seen[h] = struct{}{}
+		hosts = append(hosts, h)
+	}
+	if len(hosts) == 0 {
+		return r
+	}
+	rows, err := lookup.FindManyByHosts(hosts)
+	if err != nil {
+		// DB error はログしない (entity 層で slog 依存を増やしたくない)。
+		// 呼び出し側は populate の best-effort として扱う。
+		return r
+	}
+	for _, inst := range rows {
+		r.cache[inst.Host] = instanceLiteFromModel(inst)
+	}
+	return r
+}
+
+// Resolve returns the cached InstanceLite for host, or nil if the host is
+// unknown or was not found in the lookup step.
+func (r *InstanceResolver) Resolve(host string) *InstanceLite {
+	if r == nil || host == "" {
+		return nil
+	}
+	return r.cache[host]
+}
+
+// FillUserLite assigns lite.Instance from the resolver cache when lite
+// represents a remote user. No-op when resolver / lite is nil, lite is local,
+// or the host was not cached.
+func (r *InstanceResolver) FillUserLite(lite *UserLite) {
+	if r == nil || lite == nil || lite.Host == nil || *lite.Host == "" {
+		return
+	}
+	if inst := r.Resolve(*lite.Host); inst != nil {
+		lite.Instance = inst
+	}
+}
+
+// instanceLiteFromModel converts a model.Instance into the InstanceLite DTO
+// embedded in UserLite.Instance.
+func instanceLiteFromModel(inst *model.Instance) *InstanceLite {
+	if inst == nil {
+		return nil
+	}
+	return &InstanceLite{
+		Name:            inst.Name,
+		SoftwareName:    inst.SoftwareName,
+		SoftwareVersion: inst.SoftwareVersion,
+		IconURL:         inst.IconURL,
+		FaviconURL:      inst.FaviconURL,
+		ThemeColor:      inst.ThemeColor,
+	}
+}

--- a/internal/entity/instance_resolver_test.go
+++ b/internal/entity/instance_resolver_test.go
@@ -1,0 +1,169 @@
+package entity
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/shiroha-a/mk/internal/model"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type stubInstanceLookup struct {
+	calls [][]string
+	data  map[string]*model.Instance
+	err   error
+}
+
+func (s *stubInstanceLookup) FindManyByHosts(hosts []string) ([]*model.Instance, error) {
+	// copy slice so we can assert on stable input
+	cp := append([]string(nil), hosts...)
+	s.calls = append(s.calls, cp)
+	if s.err != nil {
+		return nil, s.err
+	}
+	out := make([]*model.Instance, 0, len(hosts))
+	for _, h := range hosts {
+		if inst, ok := s.data[h]; ok {
+			out = append(out, inst)
+		}
+	}
+	return out, nil
+}
+
+func remoteUser(id, host string) *model.User {
+	h := host
+	return &model.User{ID: id, Username: id, UsernameLower: id, Host: &h}
+}
+
+func localUser(id string) *model.User {
+	return &model.User{ID: id, Username: id, UsernameLower: id}
+}
+
+func TestNewInstanceResolver_BatchFetchesUniqueRemoteHosts(t *testing.T) {
+	name := "A"
+	lookup := &stubInstanceLookup{data: map[string]*model.Instance{
+		"a.example": {Host: "a.example", Name: &name},
+	}}
+
+	r := NewInstanceResolver(lookup,
+		remoteUser("u1", "a.example"),
+		remoteUser("u2", "a.example"), // duplicate host
+		remoteUser("u3", "b.example"), // missing in lookup
+		localUser("u4"),
+	)
+
+	require.Len(t, lookup.calls, 1)
+	assert.ElementsMatch(t, []string{"a.example", "b.example"}, lookup.calls[0])
+
+	got := r.Resolve("a.example")
+	require.NotNil(t, got)
+	assert.Equal(t, "A", *got.Name)
+	assert.Nil(t, r.Resolve("b.example"))
+	assert.Nil(t, r.Resolve("unknown"))
+}
+
+func TestNewInstanceResolver_NilLookupSkipsFetch(t *testing.T) {
+	r := NewInstanceResolver(nil, remoteUser("u1", "a.example"))
+	assert.Nil(t, r.Resolve("a.example"))
+}
+
+func TestNewInstanceResolver_NoRemoteUsersSkipsFetch(t *testing.T) {
+	lookup := &stubInstanceLookup{}
+	r := NewInstanceResolver(lookup, localUser("u1"), localUser("u2"))
+	assert.Empty(t, lookup.calls)
+	assert.Nil(t, r.Resolve("anywhere"))
+}
+
+func TestNewInstanceResolver_LookupErrorProducesEmptyCache(t *testing.T) {
+	lookup := &stubInstanceLookup{err: errors.New("db down")}
+	r := NewInstanceResolver(lookup, remoteUser("u1", "a.example"))
+	assert.Nil(t, r.Resolve("a.example"))
+}
+
+func TestInstanceResolver_FillUserLite(t *testing.T) {
+	name := "Foo"
+	lookup := &stubInstanceLookup{data: map[string]*model.Instance{
+		"a.example": {Host: "a.example", Name: &name},
+	}}
+	r := NewInstanceResolver(lookup, remoteUser("u1", "a.example"))
+
+	// remote user: Instance populated
+	remote := PackUserLite(remoteUser("u1", "a.example"))
+	r.FillUserLite(&remote)
+	require.NotNil(t, remote.Instance)
+	assert.Equal(t, "Foo", *remote.Instance.Name)
+
+	// local user: Instance remains nil
+	local := PackUserLite(localUser("u2"))
+	r.FillUserLite(&local)
+	assert.Nil(t, local.Instance)
+
+	// unknown host: Instance remains nil
+	unknown := PackUserLite(remoteUser("u3", "unknown.example"))
+	r.FillUserLite(&unknown)
+	assert.Nil(t, unknown.Instance)
+
+	// nil lite / nil resolver: no panic
+	var nilResolver *InstanceResolver
+	nilResolver.FillUserLite(&remote)
+	r.FillUserLite(nil)
+}
+
+func TestPackNotes_PopulatesRemoteUserInstance(t *testing.T) {
+	name := "Remote HQ"
+	lookup := &stubInstanceLookup{data: map[string]*model.Instance{
+		"remote.example": {Host: "remote.example", Name: &name},
+	}}
+	idGen := newTestIDGen(t)
+
+	host := "remote.example"
+	notes := []*model.Note{
+		{ID: "n1", UserID: "u1", User: &model.User{ID: "u1", Username: "alice", Host: &host}},
+		{ID: "n2", UserID: "u2", User: &model.User{ID: "u2", Username: "bob"}}, // local
+	}
+
+	out := PackNotes(notes, idGen, lookup)
+	require.Len(t, out, 2)
+	require.NotNil(t, out[0].User.Instance)
+	assert.Equal(t, "Remote HQ", *out[0].User.Instance.Name)
+	assert.Nil(t, out[1].User.Instance)
+	// 1 回の batch fetch に集約されていることを確認
+	require.Len(t, lookup.calls, 1)
+	assert.Equal(t, []string{"remote.example"}, lookup.calls[0])
+}
+
+func TestPackNotes_NilLookup_InstanceRemainsNil(t *testing.T) {
+	idGen := newTestIDGen(t)
+	host := "remote.example"
+	notes := []*model.Note{
+		{ID: "n1", UserID: "u1", User: &model.User{ID: "u1", Username: "alice", Host: &host}},
+	}
+	out := PackNotes(notes, idGen, nil)
+	require.Len(t, out, 1)
+	assert.Nil(t, out[0].User.Instance)
+}
+
+func TestPackNoteWithInstance(t *testing.T) {
+	name := "Solo"
+	lookup := &stubInstanceLookup{data: map[string]*model.Instance{
+		"solo.example": {Host: "solo.example", Name: &name},
+	}}
+	idGen := newTestIDGen(t)
+
+	host := "solo.example"
+	n := &model.Note{ID: "n1", UserID: "u1", User: &model.User{ID: "u1", Username: "alice", Host: &host}}
+
+	packed := PackNoteWithInstance(n, idGen, lookup)
+	require.NotNil(t, packed.User.Instance)
+	assert.Equal(t, "Solo", *packed.User.Instance.Name)
+}
+
+func TestInstanceResolver_NilReceiverResolveReturnsNil(t *testing.T) {
+	var r *InstanceResolver
+	assert.Nil(t, r.Resolve("any.example"))
+}
+
+func TestInstanceLiteFromModel_NilSafe(t *testing.T) {
+	assert.Nil(t, instanceLiteFromModel(nil))
+}

--- a/internal/entity/note.go
+++ b/internal/entity/note.go
@@ -135,8 +135,8 @@ func PackNote(n *model.Note, idGen id.Generator) NoteEntity {
 // nil (convenient for handlers not yet wired or for contexts where instance
 // embed is unnecessary).
 //
-// reply / renote の User も instance resolver の対象に含めるため、ここで
-// collectUsers により集約してから resolver を作る。
+// CollectNoteAuthors で top-level note の User のみ集約してから resolver を
+// 作る (reply/renote の User は NoteEntity で別埋めする運用のため集約対象外)。
 func PackNotes(notes []*model.Note, idGen id.Generator, lookup InstanceLookup) []NoteEntity {
 	resolver := NewInstanceResolver(lookup, CollectNoteAuthors(notes)...)
 	out := make([]NoteEntity, 0, len(notes))

--- a/internal/entity/note.go
+++ b/internal/entity/note.go
@@ -138,7 +138,7 @@ func PackNote(n *model.Note, idGen id.Generator) NoteEntity {
 // reply / renote の User も instance resolver の対象に含めるため、ここで
 // collectUsers により集約してから resolver を作る。
 func PackNotes(notes []*model.Note, idGen id.Generator, lookup InstanceLookup) []NoteEntity {
-	resolver := NewInstanceResolver(lookup, collectNoteUsers(notes)...)
+	resolver := NewInstanceResolver(lookup, CollectNoteAuthors(notes)...)
 	out := make([]NoteEntity, 0, len(notes))
 	for _, n := range notes {
 		packed := PackNote(n, idGen)
@@ -151,17 +151,24 @@ func PackNotes(notes []*model.Note, idGen id.Generator, lookup InstanceLookup) [
 }
 
 // PackNoteWithInstance is a single-note convenience wrapper: pack + populate.
+//
+// **Single-note only.** Each call spins up a fresh InstanceResolver (1 DB
+// query via lookup.FindManyByHosts). For a slice of notes, call `PackNotes`
+// instead — calling this in a loop produces N+1 queries.
 func PackNoteWithInstance(n *model.Note, idGen id.Generator, lookup InstanceLookup) NoteEntity {
 	packed := PackNote(n, idGen)
-	resolver := NewInstanceResolver(lookup, collectNoteUsers([]*model.Note{n})...)
+	resolver := NewInstanceResolver(lookup, CollectNoteAuthors([]*model.Note{n})...)
 	resolver.FillUserLite(&packed.User)
 	return packed
 }
 
-// collectNoteUsers extracts User pointers from a slice of notes for instance
-// resolution. 現状は note.User のみ (reply/renote は NoteEntity で別埋めする
-// 運用)。
-func collectNoteUsers(notes []*model.Note) []*model.User {
+// CollectNoteAuthors returns the author `User` pointer of each note that has
+// one preloaded. Used by packers and handlers when building an
+// InstanceResolver over a pre-fetched slice of notes.
+//
+// 現状は note.User のみ (reply/renote の User は NoteEntity で別埋めする運用
+// のため集約対象外)。
+func CollectNoteAuthors(notes []*model.Note) []*model.User {
 	users := make([]*model.User, 0, len(notes))
 	for _, n := range notes {
 		if n == nil || n.User == nil {

--- a/internal/entity/note.go
+++ b/internal/entity/note.go
@@ -130,6 +130,48 @@ func PackNote(n *model.Note, idGen id.Generator) NoteEntity {
 	return entity
 }
 
+// PackNotes packs a slice of notes and populates UserLite.Instance for remote
+// users in a single batch fetch via lookup. lookup == nil keeps Instance as
+// nil (convenient for handlers not yet wired or for contexts where instance
+// embed is unnecessary).
+//
+// reply / renote の User も instance resolver の対象に含めるため、ここで
+// collectUsers により集約してから resolver を作る。
+func PackNotes(notes []*model.Note, idGen id.Generator, lookup InstanceLookup) []NoteEntity {
+	resolver := NewInstanceResolver(lookup, collectNoteUsers(notes)...)
+	out := make([]NoteEntity, 0, len(notes))
+	for _, n := range notes {
+		packed := PackNote(n, idGen)
+		resolver.FillUserLite(&packed.User)
+		// reply / renote は PackNote 呼び出し側が別途 populate する運用のため
+		// ここでは top-level note のみ埋める。
+		out = append(out, packed)
+	}
+	return out
+}
+
+// PackNoteWithInstance is a single-note convenience wrapper: pack + populate.
+func PackNoteWithInstance(n *model.Note, idGen id.Generator, lookup InstanceLookup) NoteEntity {
+	packed := PackNote(n, idGen)
+	resolver := NewInstanceResolver(lookup, collectNoteUsers([]*model.Note{n})...)
+	resolver.FillUserLite(&packed.User)
+	return packed
+}
+
+// collectNoteUsers extracts User pointers from a slice of notes for instance
+// resolution. 現状は note.User のみ (reply/renote は NoteEntity で別埋めする
+// 運用)。
+func collectNoteUsers(notes []*model.Note) []*model.User {
+	users := make([]*model.User, 0, len(notes))
+	for _, n := range notes {
+		if n == nil || n.User == nil {
+			continue
+		}
+		users = append(users, n.User)
+	}
+	return users
+}
+
 // NormalizeReactionKey converts a legacy `:name:` key to the canonical
 // `:name@.:` form used by the frontend. Remote and non-custom reactions
 // are returned unchanged.

--- a/internal/repository/instance.go
+++ b/internal/repository/instance.go
@@ -9,6 +9,10 @@ import (
 type InstanceRepository interface {
 	Create(i *model.Instance) error
 	FindByHost(host string) (*model.Instance, error)
+	// FindManyByHosts returns instance rows matching any of the given hosts.
+	// Used by entity packers to batch-resolve UserLite.Instance info on
+	// timeline hot paths (#277). Empty input returns nil.
+	FindManyByHosts(hosts []string) ([]*model.Instance, error)
 	UpdateFields(host string, fields map[string]any) error
 	IncrementCount(host, column string, delta int) error
 	List(filter model.InstanceListFilter) ([]*model.Instance, error)
@@ -33,6 +37,17 @@ func (r *instanceRepository) FindByHost(host string) (*model.Instance, error) {
 		return nil, err
 	}
 	return &inst, nil
+}
+
+func (r *instanceRepository) FindManyByHosts(hosts []string) ([]*model.Instance, error) {
+	if len(hosts) == 0 {
+		return nil, nil
+	}
+	var rows []*model.Instance
+	if err := r.db.Where("host IN ?", hosts).Find(&rows).Error; err != nil {
+		return nil, err
+	}
+	return rows, nil
 }
 
 // UpdateFields applies a map of column → value updates to the instance row

--- a/internal/repository/instance_test.go
+++ b/internal/repository/instance_test.go
@@ -41,6 +41,37 @@ func TestInstanceRepository_FindByHost_NotFound(t *testing.T) {
 	assert.Error(t, err)
 }
 
+func TestInstanceRepository_FindManyByHosts(t *testing.T) {
+	repo := NewInstanceRepository(testDB)
+	inst1 := newTestInstance("i_fmbh_1", "fmbh1.example")
+	inst2 := newTestInstance("i_fmbh_2", "fmbh2.example")
+	inst3 := newTestInstance("i_fmbh_3", "fmbh3.example")
+	require.NoError(t, repo.Create(inst1))
+	defer cleanupInstance(t, inst1.ID)
+	require.NoError(t, repo.Create(inst2))
+	defer cleanupInstance(t, inst2.ID)
+	require.NoError(t, repo.Create(inst3))
+	defer cleanupInstance(t, inst3.ID)
+
+	// batch fetch 2 existing + 1 missing host
+	got, err := repo.FindManyByHosts([]string{"fmbh1.example", "fmbh3.example", "missing.example"})
+	require.NoError(t, err)
+	require.Len(t, got, 2)
+	hosts := []string{got[0].Host, got[1].Host}
+	assert.ElementsMatch(t, []string{"fmbh1.example", "fmbh3.example"}, hosts)
+}
+
+func TestInstanceRepository_FindManyByHosts_Empty(t *testing.T) {
+	repo := NewInstanceRepository(testDB)
+	got, err := repo.FindManyByHosts(nil)
+	require.NoError(t, err)
+	assert.Nil(t, got)
+
+	got, err = repo.FindManyByHosts([]string{})
+	require.NoError(t, err)
+	assert.Nil(t, got)
+}
+
 func TestInstanceRepository_UpdateFields(t *testing.T) {
 	repo := NewInstanceRepository(testDB)
 	inst := newTestInstance("i_ir_2", "beta.example")

--- a/internal/server/router.go
+++ b/internal/server/router.go
@@ -795,6 +795,7 @@ func (s *Server) setupRoutes() {
 	notesHandler.SetNoteReactionRepo(reactionRepo)
 	notesHandler.SetChannelRepo(channelRepo)
 	notesHandler.SetChannelMutingRepo(channelMutingRepo)
+	notesHandler.SetInstanceRepo(instanceRepo)
 	if m, err := metaRepo.Fetch(); err == nil {
 		notesHandler.SetUGCVisibility(m.UgcVisibilityForVisitor)
 		if m.DeeplAuthKey != nil && *m.DeeplAuthKey != "" {
@@ -944,6 +945,7 @@ func (s *Server) setupRoutes() {
 	iHandler.SetPiningRepo(piningRepo)
 	iHandler.SetNoteRepo(noteRepo)
 	iHandler.SetPageRepo(pageRepo)
+	iHandler.SetInstanceRepo(instanceRepo)
 	// announcementRepoは後続で構築されるため SetupAdditional() 相当の順序依存があるが、
 	// 現状 announcementRepo := ... の行がここより後にあるため下で wire する。
 
@@ -1076,6 +1078,7 @@ func (s *Server) setupRoutes() {
 	driveHandler := drive.NewHandler(driveService, idGen)
 	driveHandler.SetRepos(driveFileRepo, driveFolderRepo, noteRepo)
 	driveHandler.SetUserRepo(userRepo)
+	driveHandler.SetInstanceRepo(instanceRepo)
 	api.POST("/drive", driveHandler.Usage, middleware.RequireAuth())
 	api.POST("/drive/files", driveHandler.FilesList, middleware.RequireAuth())
 	api.POST("/drive/files/create", driveHandler.FilesCreate, middleware.RequireAuth())
@@ -1184,9 +1187,11 @@ func (s *Server) setupRoutes() {
 	api.POST("/channels/featured", channelsHandler.Featured)
 	api.POST("/channels/search", channelsHandler.Search)
 	api.POST("/channels/timeline", channelsHandler.Timeline)
+	channelsHandler.SetInstanceRepo(instanceRepo)
 
 	// Antennas endpoints (Phase 4.3)
 	antennasHandler := antennas.NewHandler(antennaService, noteRepo, idGen)
+	antennasHandler.SetInstanceRepo(instanceRepo)
 	api.POST("/antennas/create", antennasHandler.Create, middleware.RequireAuth())
 	api.POST("/antennas/show", antennasHandler.Show, middleware.RequireAuth())
 	api.POST("/antennas/update", antennasHandler.Update, middleware.RequireAuth())
@@ -1197,6 +1202,7 @@ func (s *Server) setupRoutes() {
 	// Clips endpoints (Phase 4.4)
 	clipsHandler := clips.NewHandler(clipService, idGen)
 	clipsHandler.SetFavoriteRepo(clipFavoriteRepo)
+	clipsHandler.SetInstanceRepo(instanceRepo)
 	api.POST("/clips/create", clipsHandler.Create, middleware.RequireAuth())
 	api.POST("/clips/show", clipsHandler.Show)
 	api.POST("/clips/update", clipsHandler.Update, middleware.RequireAuth())
@@ -1356,6 +1362,7 @@ func (s *Server) setupRoutes() {
 	// Public roles (Phase 6)
 	rolesHandler := apiroles.NewHandler(roleService, idGen)
 	rolesHandler.SetNotesQuery(repository.NewRoleNotesQuery(s.db))
+	rolesHandler.SetInstanceRepo(instanceRepo)
 	api.POST("/roles/list", rolesHandler.List)
 	api.POST("/roles/show", rolesHandler.Show)
 	api.POST("/roles/users", rolesHandler.Users)

--- a/internal/testutil/mock_repository.go
+++ b/internal/testutil/mock_repository.go
@@ -1641,6 +1641,19 @@ func (m *MockInstanceRepository) FindByHost(host string) (*model.Instance, error
 	return i, nil
 }
 
+func (m *MockInstanceRepository) FindManyByHosts(hosts []string) ([]*model.Instance, error) {
+	if len(hosts) == 0 {
+		return nil, nil
+	}
+	out := make([]*model.Instance, 0, len(hosts))
+	for _, h := range hosts {
+		if inst, ok := m.Instances[h]; ok {
+			out = append(out, inst)
+		}
+	}
+	return out, nil
+}
+
 func (m *MockInstanceRepository) UpdateFields(host string, fields map[string]any) error {
 	if m.UpdateErr != nil {
 		return m.UpdateErr


### PR DESCRIPTION
## Summary

\`/api/notes/\*\` / \`/api/channels/timeline\` / \`/api/users/notes\` / \`/api/antennas/notes\` などに埋め込まれる \`note.user\` (と reaction user list) に、remote user のときは **\`instance\`** (\`name\` / \`softwareName\` / \`softwareVersion\` / \`iconUrl\` / \`faviconUrl\` / \`themeColor\`) を populate する。

#247 で \`UserLite.Instance\` は入れ子されたが populate は \`/users/show\` の \`detailed\` のみで、timeline 系の hot path では常に nil だった (Devin review #275 ANALYSIS #0003 の指摘)。

## 主な変更点

### 新規

- **\`internal/entity/instance_resolver.go\`** — host → \`*InstanceLite\` の batch-cache resolver。\`NewInstanceResolver(lookup, users...)\` が unique remote host を 1 回の \`FindManyByHosts\` で埋める。nil レシーバ / nil lookup / local user は no-op
- **\`internal/entity/note.go\`** に \`PackNotes\` / \`PackNoteWithInstance\` 追加 — 既存 \`PackNote\` のシグネチャは変えず、batch pack 用 wrapper を提供

### 変更

- **\`internal/repository/instance.go\`** に \`FindManyByHosts([]string)\` 追加
- 各 handler に \`instanceRepo\` + \`SetInstanceRepo\` + \`PackNotes\` 呼び出し切替
  - notes (Create / Show / packMany → timeline系)
  - users (Notes / PinnedNotes / featured)
  - channels (Timeline)
  - antennas (Notes)
  - clips (Notes)
  - drive (FilesAttachedNotes)
  - i (PinnedNotes / Favorites)
  - roles (Notes)
  - notes/reactions (UserLite list)
- \`internal/server/router.go\` で上記 handler に配線

## テスト

- \`go test -race ./...\` 全通過
- \`make fmt\` / \`go vet ./...\` clean
- カバレッジ: entity 97.6% / repository 98.6% / notes 92.8% / users 92.6% / channels 92.0% / antennas 97.3% / clips 93.9% / drive 95.0% / i 91.7% / roles 96.2%

追加ケース:
- \`internal/entity/instance_resolver_test.go\` — batch 収集 / dup dedup / nil lookup / local user skip / miss host / lookup error / nil receiver / \`PackNotes\` 本体 / \`FillUserLite\` 各経路
- \`internal/repository/instance_test.go\` に \`FindManyByHosts\` (DB) 追加
- \`internal/api/notes/handler_test.go\` に \`TestShow_PopulatesUserInstanceForRemoteAuthor\` を追加し、remote 作者の note で \`user.instance.name\` が JSON に出ることを検証

## スコープ外 (follow-up 候補)

- \`stream/note_publisher.go\` の WebSocket イベントに instance を入れる件 (per-event 発火で lookup 流儀が異なる)
- 通知 payload (webpush / ws) の \`user.instance\`
- \`NoteEntity.Reply.User\` / \`.Renote.User\` の instance populate (nested level で追加 pass が必要。今回は top-level User のみ)

Closes #277

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/shiroha-a/mk/pull/326" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
