### PR TITLE
Phase 7-5b follow-up: notes handler の attachment に folder/user embed (#317)

### DIFF
--- a/internal/api/notes/handler.go
+++ b/internal/api/notes/handler.go
@@ -38,6 +38,8 @@ type Handler struct {
 	channelRepo       repository.ChannelRepository
 	channelMutingRepo repository.ChannelMutingRepository
 	instanceRepo      repository.InstanceRepository
+	driveFolderRepo   repository.DriveFolderRepository
+	userRepo          repository.UserRepository
 	// ugcVisibility controls what unauthenticated visitors can see.
 	// "all" (default), "local", "none"
 	ugcVisibility string
@@ -79,6 +81,18 @@ func (h *Handler) SetChannelRepo(r repository.ChannelRepository) {
 // note responses get their `instance` field populated (#277).
 func (h *Handler) SetInstanceRepo(r repository.InstanceRepository) {
 	h.instanceRepo = r
+}
+
+// SetDriveFolderRepo attaches a DriveFolderRepository so attached DriveFiles
+// in note responses can embed the owning folder (#317).
+func (h *Handler) SetDriveFolderRepo(r repository.DriveFolderRepository) {
+	h.driveFolderRepo = r
+}
+
+// SetUserRepo attaches a UserRepository so attached DriveFiles in note
+// responses can embed the owning user (#317).
+func (h *Handler) SetUserRepo(r repository.UserRepository) {
+	h.userRepo = r
 }
 
 // instanceLookup returns the repository as an entity.InstanceLookup, or nil
@@ -511,19 +525,60 @@ func (h *Handler) resolveFiles(notes []entity.NoteEntity) {
 	for _, f := range files {
 		fileMap[f.ID] = f
 	}
-	// 各ノートのFilesに設定。
-	// NOTE: TS本家は attachmentに folder / user を embed するが、notes
-	// handler には folderRepo / userRepo が未配線のため現状はIDのみ返す。
-	// 完全対応は follow-up issue #317 で検討。
+	// folder / user を best-effort で pre-fetch して embed する (#317)。
+	// 添付ファイル経由で重複して参照される folder/user を最小限の read に
+	// 抑えるため、unique ID を集めて cache に流し込む。N+1 は残るが attachment
+	// 数は実用上少ないので許容 (batch 最適化は follow-up)。
+	folderCache, userCache := h.resolveFileOwners(files)
+
 	for i := range notes {
 		packed := make([]any, 0, len(notes[i].FileIDs))
 		for _, fid := range notes[i].FileIDs {
-			if f, ok := fileMap[fid]; ok {
-				packed = append(packed, entity.PackDriveFile(f, h.idGen))
+			f, ok := fileMap[fid]
+			if !ok {
+				continue
 			}
+			var folder *model.DriveFolder
+			if f.FolderID != nil {
+				folder = folderCache[*f.FolderID]
+			}
+			var user *model.User
+			if f.UserID != nil {
+				user = userCache[*f.UserID]
+			}
+			packed = append(packed, entity.PackDriveFileWithRelations(f, h.idGen, folder, user))
 		}
 		notes[i].Files = packed
 	}
+}
+
+// resolveFileOwners builds id→model caches for folder / user by iterating
+// the unique IDs referenced by files. Missing repos / lookup failures are
+// silently treated as "no embed" (PackDriveFileWithRelations handles nil).
+func (h *Handler) resolveFileOwners(files []*model.DriveFile) (map[string]*model.DriveFolder, map[string]*model.User) {
+	folderCache := map[string]*model.DriveFolder{}
+	userCache := map[string]*model.User{}
+	for _, f := range files {
+		if h.driveFolderRepo != nil && f.FolderID != nil {
+			if _, seen := folderCache[*f.FolderID]; !seen {
+				if folder, err := h.driveFolderRepo.FindByID(*f.FolderID); err == nil {
+					folderCache[*f.FolderID] = folder
+				} else {
+					folderCache[*f.FolderID] = nil
+				}
+			}
+		}
+		if h.userRepo != nil && f.UserID != nil {
+			if _, seen := userCache[*f.UserID]; !seen {
+				if u, err := h.userRepo.FindByID(*f.UserID); err == nil {
+					userCache[*f.UserID] = u
+				} else {
+					userCache[*f.UserID] = nil
+				}
+			}
+		}
+	}
+	return folderCache, userCache
 }
 
 // resolveViewerFields populates viewer-dependent fields (MyReaction, Channel)

--- a/internal/api/notes/handler_test.go
+++ b/internal/api/notes/handler_test.go
@@ -181,6 +181,128 @@ func TestShow_Success(t *testing.T) {
 	assert.Equal(t, "existing note", resp["text"])
 }
 
+func TestShow_AttachmentEmbedsFolderAndUser(t *testing.T) {
+	// #317: 添付ファイルの folder / user を best-effort で埋めることを検証。
+	h, noteRepo := newTestHandler(t)
+
+	fileRepo := testutil.NewMockDriveFileRepository()
+	folderRepo := testutil.NewMockDriveFolderRepository()
+	userRepo := testutil.NewMockUserRepository()
+
+	ownerID := "user1"
+	folderID := "folder1"
+	fileURL := "https://example.com/f.png"
+	fileRepo.Files["file1"] = &model.DriveFile{
+		ID:       "file1",
+		UserID:   &ownerID,
+		FolderID: &folderID,
+		Type:     "image/png",
+		URL:      fileURL,
+		Name:     "pic.png",
+	}
+	folderRepo.Folders[folderID] = &model.DriveFolder{
+		ID:     folderID,
+		Name:   "My Folder",
+		UserID: &ownerID,
+	}
+	userRepo.Users[ownerID] = &model.User{
+		ID:                ownerID,
+		Username:          "testuser",
+		AvatarDecorations: datatypes.JSON([]byte("[]")),
+	}
+
+	h.SetDriveFileRepo(fileRepo)
+	h.SetDriveFolderRepo(folderRepo)
+	h.SetUserRepo(userRepo)
+
+	text := "note with attachment"
+	noteRepo.Notes["n1"] = &model.Note{
+		ID:         "n1",
+		UserID:     ownerID,
+		Text:       &text,
+		Visibility: model.NoteVisibilityPublic,
+		Reactions:  datatypes.JSON([]byte("{}")),
+		FileIDs:    []string{"file1"},
+		User: &model.User{
+			ID:                ownerID,
+			Username:          "testuser",
+			AvatarDecorations: datatypes.JSON([]byte("[]")),
+		},
+	}
+
+	body := `{"noteId": "n1"}`
+	e := echo.New()
+	req := httptest.NewRequest(http.MethodPost, "/api/notes/show", strings.NewReader(body))
+	req.Header.Set(echo.HeaderContentType, echo.MIMEApplicationJSON)
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+
+	require.NoError(t, h.Show(c))
+	assert.Equal(t, http.StatusOK, rec.Code)
+
+	var resp map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+	filesRaw, ok := resp["files"].([]any)
+	require.True(t, ok)
+	require.Len(t, filesRaw, 1)
+	file := filesRaw[0].(map[string]any)
+	folder, ok := file["folder"].(map[string]any)
+	require.True(t, ok, "attachment must embed folder")
+	assert.Equal(t, "My Folder", folder["name"])
+	user, ok := file["user"].(map[string]any)
+	require.True(t, ok, "attachment must embed user")
+	assert.Equal(t, "testuser", user["username"])
+}
+
+func TestShow_AttachmentWithoutRepos_OmitsFolderUser(t *testing.T) {
+	// folderRepo / userRepo 未配線のときは folder/user を埋めず、
+	// 従来通り file オブジェクトに folder/user が null になる。
+	h, noteRepo := newTestHandler(t)
+
+	fileRepo := testutil.NewMockDriveFileRepository()
+	ownerID := "user1"
+	fileURL := "https://example.com/f.png"
+	fileRepo.Files["file1"] = &model.DriveFile{
+		ID:     "file1",
+		UserID: &ownerID,
+		Type:   "image/png",
+		URL:    fileURL,
+		Name:   "pic.png",
+	}
+	h.SetDriveFileRepo(fileRepo)
+
+	text := "note with attachment"
+	noteRepo.Notes["n1"] = &model.Note{
+		ID:         "n1",
+		UserID:     ownerID,
+		Text:       &text,
+		Visibility: model.NoteVisibilityPublic,
+		Reactions:  datatypes.JSON([]byte("{}")),
+		FileIDs:    []string{"file1"},
+		User: &model.User{
+			ID:                ownerID,
+			Username:          "testuser",
+			AvatarDecorations: datatypes.JSON([]byte("[]")),
+		},
+	}
+
+	body := `{"noteId": "n1"}`
+	e := echo.New()
+	req := httptest.NewRequest(http.MethodPost, "/api/notes/show", strings.NewReader(body))
+	req.Header.Set(echo.HeaderContentType, echo.MIMEApplicationJSON)
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+
+	require.NoError(t, h.Show(c))
+	var resp map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+	filesRaw := resp["files"].([]any)
+	require.Len(t, filesRaw, 1)
+	file := filesRaw[0].(map[string]any)
+	assert.Nil(t, file["folder"])
+	assert.Nil(t, file["user"])
+}
+
 func TestShow_PopulatesUserInstanceForRemoteAuthor(t *testing.T) {
 	h, noteRepo := newTestHandler(t)
 

--- a/internal/server/router.go
+++ b/internal/server/router.go
@@ -796,6 +796,8 @@ func (s *Server) setupRoutes() {
 	notesHandler.SetChannelRepo(channelRepo)
 	notesHandler.SetChannelMutingRepo(channelMutingRepo)
 	notesHandler.SetInstanceRepo(instanceRepo)
+	notesHandler.SetDriveFolderRepo(driveFolderRepo)
+	notesHandler.SetUserRepo(userRepo)
 	if m, err := metaRepo.Fetch(); err == nil {
 		notesHandler.SetUGCVisibility(m.UgcVisibilityForVisitor)
 		if m.DeeplAuthKey != nil && *m.DeeplAuthKey != "" {


### PR DESCRIPTION
## Summary

\`/api/notes/show\` / timeline 系で返される attachment (\`files\`) に **\`folder\`** と **\`user\`** を embed するように修正。#248 (PR #316) で DriveFile entity に folder/user 対応を入れたが、notes handler 側の \`resolveFiles\` は \`PackDriveFile\` (ID のみ) を使っていたため、添付経由では空だった。

## 主な変更点

- **\`internal/api/notes/handler.go\`**
  - \`driveFolderRepo\` / \`userRepo\` を Handler に追加 (optional)
  - \`SetDriveFolderRepo\` / \`SetUserRepo\` を追加
  - \`resolveFiles\` を \`PackDriveFileWithRelations\` 呼び出しに変更
  - \`resolveFileOwners\` helper を追加: 添付ファイル群が参照する unique folder/user ID をまとめて cache に流し込む best-effort fetch。repo 未配線時は従来どおり nil (embed なし)
- **\`internal/server/router.go\`** で \`SetDriveFolderRepo(driveFolderRepo)\` / \`SetUserRepo(userRepo)\` を配線

## テスト

- \`go test -race ./...\` 全通過
- \`make fmt\` / \`go vet ./...\` clean
- カバレッジ: \`internal/api/notes\` 92.7% (下がらず)

追加ケース:
- \`TestShow_AttachmentEmbedsFolderAndUser\`: folder/user repo 注入時に \`files[0].folder.name\` / \`files[0].user.username\` がレスポンスに出る
- \`TestShow_AttachmentWithoutRepos_OmitsFolderUser\`: 未注入時は \`files[0].folder\` / \`files[0].user\` が null で従来どおり

## スコープ外 (follow-up 候補)

- folder / user 用 \`FindManyByIDs\` による batch 取得 (attachment 数は実用上少ないので許容、#248 と同じ判断)

Closes #317

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/shiroha-a/mk/pull/327" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
