### PR TITLE
Fix compose.uds.yaml: migrate UDS URL と mkgo_sock の所有権

### DIFF
--- a/cmd/migrate/main.go
+++ b/cmd/migrate/main.go
@@ -4,6 +4,7 @@ import (
 	"flag"
 	"fmt"
 	"log/slog"
+	"net/url"
 	"os"
 
 	"github.com/golang-migrate/migrate/v4"
@@ -28,9 +29,23 @@ func main() {
 		os.Exit(1)
 	}
 
-	dbURL := fmt.Sprintf("postgres://%s:%s@%s:%d/%s?sslmode=disable",
-		cfg.DB.User, cfg.DB.Pass, cfg.DB.Host, cfg.DB.Port, cfg.DB.DB,
-	)
+	var dbURL string
+	if config.IsUnixSocketPath(cfg.DB.Host) {
+		// UDS の場合はホスト部を空にして host クエリにソケットディレクトリを渡す。
+		// postgres://...@/var/run/postgresql:5432/... の形式は libpq が UDS として
+		// 解釈できず TCP localhost にフォールバックするため。
+		dbURL = fmt.Sprintf("postgres:///%s?host=%s&port=%d&user=%s&password=%s&sslmode=disable",
+			cfg.DB.DB,
+			url.QueryEscape(cfg.DB.Host),
+			cfg.DB.Port,
+			url.QueryEscape(cfg.DB.User),
+			url.QueryEscape(cfg.DB.Pass),
+		)
+	} else {
+		dbURL = fmt.Sprintf("postgres://%s:%s@%s:%d/%s?sslmode=disable",
+			cfg.DB.User, cfg.DB.Pass, cfg.DB.Host, cfg.DB.Port, cfg.DB.DB,
+		)
+	}
 
 	m, err := migrate.New("file://migration", dbURL)
 	if err != nil {

--- a/deploy/uds/Dockerfile.mkgo
+++ b/deploy/uds/Dockerfile.mkgo
@@ -42,6 +42,11 @@ RUN chmod +x /entrypoint.sh
 # `mkgo_files:/app/drive-files` mount でこのオーナーが volume root に伝播する。
 RUN mkdir -p /app/drive-files && chown 65532:65532 /app/drive-files
 
+# mkgo_sock named volume の初回マウント時にオーナーが mkgo:mkgo になるよう、
+# image 側に空ディレクトリを用意しておく。non-root (uid 65532) で bind するには
+# ディレクトリ自体への書き込み権が必要。
+RUN mkdir -p /run/mkgo && chown 65532:65532 /run/mkgo
+
 USER 65532:65532
 
 ENTRYPOINT ["/entrypoint.sh"]


### PR DESCRIPTION
## Summary

`compose.uds.yaml`（UDS-only参照デプロイ）をクリーンな状態から起動するとmk-goコンテナが起動できない問題を修正。

- migrateがUDSホストパスをTCP URLに埋めてしまい接続拒否になっていた
- `/run/mkgo`がroot所有で、非rootで動くmk-goがsocketをbindできなかった

## 主な変更点

### `cmd/migrate/main.go`

DBホストがUDSパス（\`/\`始まり）のとき、\`postgres://user:pass@<path>:port/db\`というURLはlibpqがUDSとして解釈できずTCP \`[::1]:5432\`にフォールバックしていた。\`config.IsUnixSocketPath\`で分岐し、標準のUDS対応URL形式に切り替える：

\`\`\`
postgres:///db?host=/var/run/postgresql&port=5432&user=...&password=...&sslmode=disable
\`\`\`

非UDSホスト（TCP）の場合のURL組み立ては変更なし。

### \`deploy/uds/Dockerfile.mkgo\`

named volume \`mkgo_sock\`の初回マウント時にオーナーが\`65532:65532\`になるよう、image側で\`/run/mkgo\`を非rootユーザー所有で作成しておく。既存の\`/app/drive-files\`と同じパターン。

## テスト

- [x] \`make fmt\` / \`make lint\` 通過
- [x] \`make test\` 全パス
- [x] クリーン状態 (\`docker volume rm mk_mkgo_sock\`後) から\`docker compose -f compose.uds.yaml up -d\`で全コンテナhealthy
- [x] \`/healthz\`エンドポイントが200を返すことを確認

### 実行方法

\`\`\`bash
# クリーンな状態から起動確認
docker compose -f compose.uds.yaml down
docker volume rm mk_mkgo_sock 2>/dev/null || true
docker compose -f compose.uds.yaml build mkgo
docker compose -f compose.uds.yaml up -d
docker compose -f compose.uds.yaml ps
curl -sI http://localhost/healthz
\`\`\`

## 影響範囲

非UDS構成（TCPホスト）には影響なし：

- \`cmd/migrate/main.go\`はUDS判定の分岐のみ追加。TCPパスは従来と同一のURL生成ロジック。
- \`deploy/uds/Dockerfile.mkgo\`は\`compose.uds.yaml\`専用のDockerfileなので、メインの\`Dockerfile\`経由のビルドには無関係。

## Closes

Closes #331
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/shiroha-a/mk/pull/332" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
