### PR TITLE
ユーザーページの表示周り修正: リロード時のSPAフォールバック + リモート概要タブ空白

### DIFF
--- a/internal/api/ap/handler.go
+++ b/internal/api/ap/handler.go
@@ -36,12 +36,35 @@ type Handler struct {
 	idGen          id.Generator
 	remoteFetcher  RemoteFetcher
 	remoteResolver RemoteResolver
+	nonAPFallback  echo.HandlerFunc
 }
 
 // SetRemote attaches remote AP fetcher and resolver.
 func (h *Handler) SetRemote(fetcher RemoteFetcher, resolver RemoteResolver) {
 	h.remoteFetcher = fetcher
 	h.remoteResolver = resolver
+}
+
+// SetNonAPFallback registers a handler to serve when the incoming Accept
+// header does not request an ActivityPub document. Typically the SPA HTML
+// frontend is registered here so that browser reloads on actor/note URLs
+// render the frontend instead of returning a bare 404 JSON. Echo does not
+// re-dispatch errored handlers to the catch-all route, so this delegation
+// has to happen inside the AP handler itself.
+func (h *Handler) SetNonAPFallback(fn echo.HandlerFunc) {
+	h.nonAPFallback = fn
+}
+
+// serveNonAP is called from AP resource handlers when the client did not
+// request application/activity+json. When a fallback is wired (runtime)
+// it renders the frontend HTML; otherwise (tests) it returns ErrNotFound
+// so the behavior degrades gracefully when the handler is used in
+// isolation.
+func (h *Handler) serveNonAP(c echo.Context) error {
+	if h.nonAPFallback != nil {
+		return h.nonAPFallback(c)
+	}
+	return echo.ErrNotFound
 }
 
 // NewHandler constructs a Handler.
@@ -61,12 +84,14 @@ func NewHandler(
 	}
 }
 
-// User handles GET /users/:id.
-//
-// Acceptヘッダ application/activity+json (または HTML 経由でない場合) なら
-// AS Person を返す。HTMLリクエストは将来のWebUIでハンドルする想定だが、現状
-// はリダイレクトせず常にAP表現を返す。
+// User handles GET /users/:id with ActivityPub content negotiation.
+// AP clients (Accept: application/activity+json) receive the Person
+// document; other callers (browser reloads) are handed off to the
+// frontend fallback.
 func (h *Handler) User(c echo.Context) error {
+	if !wantsActivityJSON(c.Request().Header.Get("Accept")) {
+		return h.serveNonAP(c)
+	}
 	id := c.Param("id")
 	bundle, err := h.userService.ShowByID(id)
 	if err != nil {
@@ -87,12 +112,12 @@ func (h *Handler) User(c echo.Context) error {
 // UserByAcct handles GET /@:acct with ActivityPub content negotiation.
 // When the Accept header prefers application/activity+json (which is how
 // other AP implementations resolve actors that they discovered via
-// WebFinger or a raw link), return the Person document. Otherwise fall
-// through to the HTML frontend by returning echo.ErrNotFound so the
-// catch-all route can handle it.
+// WebFinger or a raw link), return the Person document. Otherwise
+// delegate to the non-AP fallback so browser reloads render the SPA
+// frontend instead of a bare 404.
 func (h *Handler) UserByAcct(c echo.Context) error {
 	if !wantsActivityJSON(c.Request().Header.Get("Accept")) {
-		return echo.ErrNotFound
+		return h.serveNonAP(c)
 	}
 	acct := c.Param("acct")
 	// /@alice or /@alice@host 形式。ローカルのみ扱う。
@@ -323,8 +348,13 @@ func (h *Handler) APNotes(c echo.Context) error {
 	return c.JSON(http.StatusOK, []any{})
 }
 
-// Note handles GET /notes/:id.
+// Note handles GET /notes/:id with ActivityPub content negotiation.
+// AP clients receive the AS Note object; browser reloads are handed
+// off to the frontend fallback so the SPA renders the note permalink.
 func (h *Handler) Note(c echo.Context) error {
+	if !wantsActivityJSON(c.Request().Header.Get("Accept")) {
+		return h.serveNonAP(c)
+	}
 	noteID := c.Param("id")
 	// 公開ノートのみAPでフェッチ可能 (非ログインから取得されるため viewer=nil)
 	n, err := h.queryService.Show(nil, noteID)

--- a/internal/api/ap/handler_test.go
+++ b/internal/api/ap/handler_test.go
@@ -64,6 +64,9 @@ func newReq(t *testing.T, paramName, paramValue string) (echo.Context, *httptest
 	t.Helper()
 	e := echo.New()
 	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	// User/Note ハンドラは Accept ベースでAPか否かを切り替えるので、既存の
+	// AP レスポンスを検証するテストでは AP Accept を明示する。
+	req.Header.Set(echo.HeaderAccept, "application/activity+json")
 	rec := httptest.NewRecorder()
 	c := e.NewContext(req, rec)
 	c.SetParamNames(paramName)
@@ -457,8 +460,57 @@ func TestUserByAcct_HTMLFallsThrough(t *testing.T) {
 	h, _, _, _ := newHandler(t)
 	c, _ := newAcctReq(t, "text/html", "alice")
 	err := h.UserByAcct(c)
-	// Non-AP accept → return echo.ErrNotFound to let catch-all serve HTML.
+	// フォールバック未設定なら serveNonAP は ErrNotFound を返すので、
+	// ハンドラ単体のテストで確実に 404 相当を観測できる。
 	assert.Equal(t, echo.ErrNotFound, err)
+}
+
+func TestUserByAcct_HTMLUsesFallback(t *testing.T) {
+	h, _, _, _ := newHandler(t)
+	called := false
+	h.SetNonAPFallback(func(c echo.Context) error {
+		called = true
+		return c.String(http.StatusOK, "FRONTEND")
+	})
+	c, rec := newAcctReq(t, "text/html", "alice")
+	require.NoError(t, h.UserByAcct(c))
+	assert.True(t, called, "fallback should be invoked for non-AP Accept")
+	assert.Equal(t, http.StatusOK, rec.Code)
+	assert.Equal(t, "FRONTEND", rec.Body.String())
+}
+
+func TestUser_HTMLUsesFallback(t *testing.T) {
+	h, userRepo, _, _ := newHandler(t)
+	userRepo.Users["u1"] = &model.User{ID: "u1", Username: "alice"}
+	h.SetNonAPFallback(func(c echo.Context) error {
+		return c.String(http.StatusOK, "FRONTEND")
+	})
+	e := echo.New()
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	req.Header.Set(echo.HeaderAccept, "text/html")
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+	c.SetParamNames("id")
+	c.SetParamValues("u1")
+	require.NoError(t, h.User(c))
+	assert.Equal(t, "FRONTEND", rec.Body.String())
+}
+
+func TestNote_HTMLUsesFallback(t *testing.T) {
+	h, _, noteRepo, _ := newHandler(t)
+	noteRepo.Notes["n1"] = &model.Note{ID: "n1", UserID: "u1", Visibility: model.NoteVisibilityPublic}
+	h.SetNonAPFallback(func(c echo.Context) error {
+		return c.String(http.StatusOK, "FRONTEND")
+	})
+	e := echo.New()
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	req.Header.Set(echo.HeaderAccept, "text/html")
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+	c.SetParamNames("id")
+	c.SetParamValues("n1")
+	require.NoError(t, h.Note(c))
+	assert.Equal(t, "FRONTEND", rec.Body.String())
 }
 
 func TestUserByAcct_LDJSON(t *testing.T) {

--- a/internal/entity/user.go
+++ b/internal/entity/user.go
@@ -149,6 +149,7 @@ func PackUserDetailed(u *model.User, profile *model.UserProfile, idGens ...id.Ge
 		FollowersCount:      u.FollowersCount,
 		FollowingCount:      u.FollowingCount,
 		NotesCount:          u.NotesCount,
+		Fields:              datatypes.JSON([]byte("[]")),
 		VerifiedLinks:       []string{},
 		FollowersVisibility: "public",
 		FollowingVisibility: "public",

--- a/internal/entity/user_test.go
+++ b/internal/entity/user_test.go
@@ -310,3 +310,16 @@ func TestUserDetailed_EmbedsUserLiteOptionalFields(t *testing.T) {
 	require.NoError(t, err)
 	assert.Contains(t, string(b), "\"instance\"")
 }
+
+// profile が nil (リモートユーザーで user_profile レコードが未生成) の場合でも
+// fields は空配列 `[]` として marshal されるべき。null だとフロントが
+// user.fields.length で TypeError を起こし、ユーザーページの概要タブが
+// 真っ白になる。
+func TestPackUserDetailed_FieldsDefaultWhenProfileNil(t *testing.T) {
+	u := &model.User{ID: "u1", Username: "x", AvatarDecorations: datatypes.JSON([]byte("[]"))}
+	detailed := PackUserDetailed(u, nil)
+	b, err := json.Marshal(detailed)
+	require.NoError(t, err)
+	assert.Contains(t, string(b), `"fields":[]`)
+	assert.NotContains(t, string(b), `"fields":null`)
+}

--- a/internal/server/router.go
+++ b/internal/server/router.go
@@ -591,6 +591,11 @@ func (s *Server) setupRoutes() {
 	api.POST("/meta", metaHandler.Meta)
 	api.POST("/ping", metaHandler.Ping)
 
+	// Frontend SPA shell — AP resource handlers fall back to this when the
+	// request prefers HTML over application/activity+json, and the final
+	// catch-all route at the bottom of RegisterRoutes uses the same handler.
+	frontend := frontendHTML(s.config, metaRepo, proxyAccountResolver)
+
 	// URL preview endpoint
 	if previewMeta, err := metaRepo.Fetch(); err == nil {
 		previewCfg := coreurlpreview.Config{
@@ -1138,11 +1143,12 @@ func (s *Server) setupRoutes() {
 	// ActivityPub resource endpoints
 	apHandler := ap.NewHandler(apRenderer, userService, noteQueryService, keypairRepo, idGen)
 	apHandler.SetRemote(apFetcher, federationResolver)
+	// AP リソース系エンドポイントは Accept ヘッダで content negotiation する。
+	// ブラウザからのリロード (Accept: text/html など) では SPA 用の HTML を
+	// 返したいので、フォールバックとして frontendHTML を注入しておく。
+	apHandler.SetNonAPFallback(frontend)
 	s.echo.GET("/users/:id", apHandler.User)
 	s.echo.GET("/notes/:id", apHandler.Note)
-	// Content-negotiated actor endpoint: /@username (and /@username@host).
-	// When the caller asks for application/activity+json we return the
-	// Person document; otherwise the catch-all serves the HTML frontend.
 	s.echo.GET("/@:acct", apHandler.UserByAcct)
 
 	// Discovery endpoints
@@ -1976,7 +1982,7 @@ func (s *Server) setupRoutes() {
 	}
 
 	// Frontend HTML shell — SPA catchall (最後に登録)
-	s.echo.GET("/*", frontendHTML(s.config, metaRepo, proxyAccountResolver))
+	s.echo.GET("/*", frontend)
 }
 
 // generateInviteCode creates a random invite code string.


### PR DESCRIPTION
## Summary

ユーザーページを実機で使って見つかった 2 つの独立したバグを 1 コミットずつ修正。

1. ブラウザで\`/@username\` / \`/users/:id\` / \`/notes/:id\`をリロードすると\`{\"message\":\"Not Found\"}\`のJSONが返り、SPAが起動しない。
2. リモートユーザーのプロフィール画面で概要タブが空白になる (他タブは正常)。

## 主な変更点

### 1. AP resource handler の content negotiation (\`ap: fall back to SPA on non-AP Accept\`)

- \`ap.Handler\`に\`SetNonAPFallback\`と\`serveNonAP\`ヘルパーを追加
- \`User\` / \`UserByAcct\` / \`Note\` すべてで\`Accept\`を見て AP でなければフォールバックに委譲
- \`router.go\`側で\`frontendHTML\`の戻り値を変数に hoist し、catch-all (\`/*\`) と ap handler のフォールバックで共有
- 従来コメントには「catch-allに流す」と書かれていたが、Echoはハンドラがエラーを返しても catch-all に再 dispatch しないため成立していなかった

### 2. \`PackUserDetailed\`の\`Fields\`デフォルト値 (\`PackUserDetailed: default fields to [] when profile is nil\`)

- user_profileが存在しないリモートユーザーに対する\`/api/users/show\`レスポンスで\`fields: null\`になっていた
- frontend の\`home.vue\`が\`user.fields.length\`を参照するため TypeError で概要タブ描画が中断していた
- \`VerifiedLinks\` / \`PinnedNoteIDs\` / \`PinnedNotes\` / \`Roles\`と同じパターンで空配列デフォルトを追加

## テスト

- [x] \`make fmt\` / \`make lint\` 通過
- [x] \`make test\` 全パス

### 追加したテスト

\`internal/api/ap/handler_test.go\`:
- \`TestUserByAcct_HTMLUsesFallback\` — fallback 設定時に呼ばれることを確認
- \`TestUser_HTMLUsesFallback\` — \`/users/:id\`版
- \`TestNote_HTMLUsesFallback\` — \`/notes/:id\`版
- 既存の\`TestUser_*\`/\`TestNote_*\` が AP レスポンスを検証できるよう、\`newReq\`helper に\`Accept: application/activity+json\`を既定で付与
- \`TestUserByAcct_HTMLFallsThrough\` はコメントを更新 (fallback未設定時は\`ErrNotFound\`に degrade する挙動を確認)

\`internal/entity/user_test.go\`:
- \`TestPackUserDetailed_FieldsDefaultWhenProfileNil\` — profile=nil のとき JSON 出力に\`\"fields\":[]\`が含まれ\`\"fields\":null\`を含まないことを確認

### 実機確認 (compose.uds.yaml 上)

\`\`\`bash
# ブラウザリロード相当
curl -H 'Accept: text/html' http://localhost/@shiroha                 # → 200 text/html (SPA)
curl -H 'Accept: application/activity+json' http://localhost/@shiroha # → 200 application/activity+json

# リモートユーザーのfields
curl -X POST -H 'Content-Type: application/json' \\
  -d '{\"username\":\"Iris\",\"host\":\"mk.k7a.org\"}' \\
  http://localhost/api/users/show | jq .fields
# → []  (従来は null)
\`\`\`

ブラウザで両問題が解消することを確認済み。

## 影響範囲

- AP クライアント (Mastodon, Misskey 等) は常に\`Accept: application/activity+json\`を送るので従来通り AP レスポンスを受け取る
- \`/users/:id\` / \`/notes/:id\` は従来\`Accept\`を無視して常に AP を返していたが、コメント (\`将来のWebUIでハンドルする想定\`) の意図通りに content negotiation を入れた。既存の AP 連合クライアントへの影響なし
- \`Fields\`デフォルト値は API の型互換性を高める方向の変更 (null 許容 → 空配列保証)。TSオリジナル実装も非 null な配列を返すので、互換性に寄与する

## Closes

Closes #338
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/shiroha-a/mk/pull/339" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
