### PR TITLE
Fix #345: exclude home-visibility notes from localTimeline fanout

### DIFF
--- a/internal/core/timeline/fanout_hook.go
+++ b/internal/core/timeline/fanout_hook.go
@@ -102,8 +102,9 @@ func (h *FanoutHook) OnNoteCreated(n *model.Note, author *model.User) {
 		h.fanoutStreamingToFollowers(author.ID, n, author)
 	}
 
-	// 3. ローカルタイムライン: ローカル投稿でvisibility=public/homeのみ
-	if author.Host == nil && (n.Visibility == model.NoteVisibilityPublic || n.Visibility == model.NoteVisibilityHome) {
+	// 3. ローカルタイムライン: ローカル投稿でvisibility=publicのみ。
+	// home visibilityはフォロワー向けなのでLTLには出さない (本家と同じ挙動)。
+	if author.Host == nil && n.Visibility == model.NoteVisibilityPublic {
 		h.pushWithLimit(ctx, LocalTimeline, n.ID, MaxTimelineLength)
 		h.publishNote("localTimeline", n, author)
 	}

--- a/internal/core/timeline/fanout_hook_test.go
+++ b/internal/core/timeline/fanout_hook_test.go
@@ -225,6 +225,32 @@ func TestFanoutHook_StreamingHomeOnlyForFollowersVisibility(t *testing.T) {
 	assert.Contains(t, pub.topics, "homeTimeline:author")
 }
 
+func TestFanoutHook_HomeVisibilityNotInLocalTimeline(t *testing.T) {
+	// home visibility はフォロワー向けなので、LTL / GTL の fanout キャッシュにも
+	// streaming トピックにも流してはいけない (本家 Misskey 仕様)。
+	h, fanout, _ := newTestHook(t)
+	ctx := context.Background()
+	pub := &stubStreamingPublisher{}
+	h.SetStreamingPublisher(pub)
+
+	noteID := idGen.Generate(time.Now())
+	n := &model.Note{ID: noteID, UserID: "author", Visibility: model.NoteVisibilityHome}
+	h.OnNoteCreated(n, &model.User{ID: "author"})
+
+	// LTL / GTL の fanout キャッシュには入らない
+	for _, name := range []Name{LocalTimeline, GlobalTimeline} {
+		out, err := fanout.Get(ctx, name, "", "", 10)
+		require.NoError(t, err)
+		assert.Empty(t, out, "home visibility note must not enter %q cache", name)
+	}
+
+	// streaming トピックにも配信されない
+	assert.NotContains(t, pub.topics, "localTimeline")
+	assert.NotContains(t, pub.topics, "globalTimeline")
+	// homeTimeline には入る (本人 + フォロワー)
+	assert.Contains(t, pub.topics, "homeTimeline:author")
+}
+
 func TestFanoutHook_StreamingPublisherUnsetIsNoOp(t *testing.T) {
 	h, _, _ := newTestHook(t)
 	noteID := idGen.Generate(time.Now())


### PR DESCRIPTION
## Summary

- LTL / GTL の fanout キャッシュと streaming トピックに home 公開範囲の投稿が混入していた不具合を修正
- `fanout_hook.go:106` の条件から `|| n.Visibility == model.NoteVisibilityHome` を削除し、関連コメントも本家仕様 (home 投稿は LTL に出さない) に合わせて更新
- home visibility が LTL / GTL にも streaming にも流れないことを保証する回帰テストを追加

## 主な変更点

- `internal/core/timeline/fanout_hook.go`
  - `OnNoteCreated` の section 3 (LTL) から home visibility 条件を除外
  - コメントを実仕様に合わせて修正
- `internal/core/timeline/fanout_hook_test.go`
  - `TestFanoutHook_HomeVisibilityNotInLocalTimeline` を追加
    - LTL / GTL の fanout キャッシュに入らないこと
    - `localTimeline` / `globalTimeline` streaming トピックに push されないこと
    - `homeTimeline:author` には正しく入ること (本人 + フォロワー配信は維持)

## テスト

- `go test -race -count=1 ./internal/core/timeline/...` パス (coverage 96.2%)
- `make fmt && make lint` クリーン

## Closes

Closes #345
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/shiroha-a/mk/pull/353" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
