### PR TITLE
Fix #350: ingest remote actor icon/image into avatarUrl/bannerUrl

### DIFF
--- a/internal/core/federation/resolver.go
+++ b/internal/core/federation/resolver.go
@@ -226,6 +226,16 @@ func (r *Resolver) ResolveActor(uri string) (*model.User, error) {
 		aka := strings.Join(actor.AlsoKnownAs, ",")
 		user.AlsoKnownAs = &aka
 	}
+	// actor.icon / actor.image はそれぞれアバター / バナー画像。空 URL や
+	// icon自体が欠落している actor (Service 系など) もあるので nil チェック。
+	if actor.Icon != nil && actor.Icon.URL != "" {
+		avatarURL := actor.Icon.URL
+		user.AvatarURL = &avatarURL
+	}
+	if actor.Image != nil && actor.Image.URL != "" {
+		bannerURL := actor.Image.URL
+		user.BannerURL = &bannerURL
+	}
 	if err := r.userRepo.Create(user); err != nil {
 		return nil, err
 	}
@@ -313,6 +323,18 @@ func (r *Resolver) refreshActor(existing *model.User, uri string) {
 		akaStr := strings.Join(actor.AlsoKnownAs, ",")
 		fields["alsoKnownAs"] = &akaStr
 		existing.AlsoKnownAs = &akaStr
+	}
+	// アバター / バナー画像のURLリモート側で変更された場合に追従する。
+	// 他フィールドと同様、空値や欠落時は既存値を温存する (削除は追わない)。
+	if actor.Icon != nil && actor.Icon.URL != "" {
+		avatarURL := actor.Icon.URL
+		fields["avatarUrl"] = &avatarURL
+		existing.AvatarURL = &avatarURL
+	}
+	if actor.Image != nil && actor.Image.URL != "" {
+		bannerURL := actor.Image.URL
+		fields["bannerUrl"] = &bannerURL
+		existing.BannerURL = &bannerURL
 	}
 	existing.LastFetchedAt = &now
 	// UpdateUser エラーはベストエフォートで無視 (次回再試行される)

--- a/internal/core/federation/resolver_test.go
+++ b/internal/core/federation/resolver_test.go
@@ -61,6 +61,35 @@ func TestResolveActor_NewUser(t *testing.T) {
 	assert.Contains(t, pem, "FAKE")
 }
 
+func TestResolveActor_NewUserIngestsIconBanner(t *testing.T) {
+	// actor.icon / actor.image があれば avatarUrl / bannerUrl に取り込む。
+	body := `{
+		"id": "https://remote.example/users/alice",
+		"type": "Person",
+		"preferredUsername": "alice",
+		"inbox": "https://remote.example/users/alice/inbox",
+		"icon": {"type": "Image", "url": "https://remote.example/avatar.png"},
+		"image": {"type": "Image", "url": "https://remote.example/banner.png"},
+		"publicKey": {"publicKeyPem": "FAKE"}
+	}`
+	r, _ := newResolver(t, body, nil)
+	user, err := r.ResolveActor("https://remote.example/users/alice")
+	require.NoError(t, err)
+	require.NotNil(t, user.AvatarURL)
+	assert.Equal(t, "https://remote.example/avatar.png", *user.AvatarURL)
+	require.NotNil(t, user.BannerURL)
+	assert.Equal(t, "https://remote.example/banner.png", *user.BannerURL)
+}
+
+func TestResolveActor_NewUserWithoutIconBanner(t *testing.T) {
+	// icon / image を持たない actor は avatarUrl / bannerUrl を nil のまま。
+	r, _ := newResolver(t, sampleActor, nil)
+	user, err := r.ResolveActor("https://remote.example/users/alice")
+	require.NoError(t, err)
+	assert.Nil(t, user.AvatarURL)
+	assert.Nil(t, user.BannerURL)
+}
+
 func TestResolveActor_ExistingUser(t *testing.T) {
 	r, repo := newResolver(t, sampleActor, nil)
 	uri := "https://remote.example/users/alice"
@@ -800,6 +829,73 @@ func TestResolveActor_TTLRefresh(t *testing.T) {
 	pem, err := r.PublicKeyForActor("existing")
 	require.NoError(t, err)
 	assert.Contains(t, pem, "REFRESHED")
+}
+
+func TestResolveActor_TTLRefreshUpdatesIconBanner(t *testing.T) {
+	// refresh 時にリモートの icon / image が更新されていれば反映する。
+	repo := testutil.NewMockUserRepository()
+	noteRepo := testutil.NewMockNoteRepository()
+	urls := activitypub.NewURLBuilder("https://example.com")
+	idGen, _ := id.NewGenerator("aidx")
+	uri := "https://remote.example/users/alice"
+	old := time.Now().Add(-48 * time.Hour)
+	oldAvatar := "https://remote.example/old-avatar.png"
+	oldBanner := "https://remote.example/old-banner.png"
+	repo.Users["existing"] = &model.User{
+		ID:            "existing",
+		Username:      "alice",
+		URI:           &uri,
+		AvatarURL:     &oldAvatar,
+		BannerURL:     &oldBanner,
+		LastFetchedAt: &old,
+	}
+	updated := `{
+		"id": "https://remote.example/users/alice",
+		"type": "Person",
+		"preferredUsername": "alice",
+		"inbox": "https://remote.example/users/alice/inbox",
+		"icon": {"type": "Image", "url": "https://remote.example/new-avatar.png"},
+		"image": {"type": "Image", "url": "https://remote.example/new-banner.png"},
+		"publicKey": {"publicKeyPem": "REFRESHED"}
+	}`
+	r := federation.NewResolver(repo, noteRepo, urls, &stubFetcher{body: []byte(updated)}, idGen)
+	user, err := r.ResolveActor(uri)
+	require.NoError(t, err)
+	require.NotNil(t, user.AvatarURL)
+	assert.Equal(t, "https://remote.example/new-avatar.png", *user.AvatarURL)
+	require.NotNil(t, user.BannerURL)
+	assert.Equal(t, "https://remote.example/new-banner.png", *user.BannerURL)
+}
+
+func TestResolveActor_TTLRefreshPreservesIconWhenOmitted(t *testing.T) {
+	// refresh 先の actor から icon が欠落していたら既存値を保持する (削除は追わない)。
+	repo := testutil.NewMockUserRepository()
+	noteRepo := testutil.NewMockNoteRepository()
+	urls := activitypub.NewURLBuilder("https://example.com")
+	idGen, _ := id.NewGenerator("aidx")
+	uri := "https://remote.example/users/alice"
+	old := time.Now().Add(-48 * time.Hour)
+	oldAvatar := "https://remote.example/keep-avatar.png"
+	repo.Users["existing"] = &model.User{
+		ID:            "existing",
+		Username:      "alice",
+		URI:           &uri,
+		AvatarURL:     &oldAvatar,
+		LastFetchedAt: &old,
+	}
+	// icon / image を含まない更新 actor
+	updated := `{
+		"id": "https://remote.example/users/alice",
+		"type": "Person",
+		"preferredUsername": "alice",
+		"inbox": "https://remote.example/users/alice/inbox",
+		"publicKey": {"publicKeyPem": "REFRESHED"}
+	}`
+	r := federation.NewResolver(repo, noteRepo, urls, &stubFetcher{body: []byte(updated)}, idGen)
+	user, err := r.ResolveActor(uri)
+	require.NoError(t, err)
+	require.NotNil(t, user.AvatarURL)
+	assert.Equal(t, "https://remote.example/keep-avatar.png", *user.AvatarURL)
 }
 
 func TestResolveActor_NoRefreshWhenFresh(t *testing.T) {

--- a/internal/testutil/mock_repository.go
+++ b/internal/testutil/mock_repository.go
@@ -329,6 +329,14 @@ func applyUserFields(u *model.User, fields map[string]any) {
 			if s, ok := v.(string); ok {
 				u.AlsoKnownAs = &s
 			}
+		case "avatarUrl":
+			if s, ok := v.(*string); ok {
+				u.AvatarURL = s
+			}
+		case "bannerUrl":
+			if s, ok := v.(*string); ok {
+				u.BannerURL = s
+			}
 		}
 	}
 }


### PR DESCRIPTION
## Summary

- `ResolveActor` / `refreshActor` で ActivityPub Actor の `icon` / `image` フィールドを読み取り、`user.AvatarURL` / `user.BannerURL` に反映
- 従来は両フィールドとも常に `nil` で、frontend でリモートユーザーのアバター・バナーが常にデフォルト画像表示になっていた

## 主な変更点

- `internal/core/federation/resolver.go`
  - `ResolveActor` (新規作成経路): `actor.Icon.URL` / `actor.Image.URL` が非空なら `user.AvatarURL` / `user.BannerURL` に設定
  - `refreshActor` (TTL refresh 経路): 同上。既存値がある状態でリモートが欠落している場合は既存値を温存 (削除追従はしない。他フィールドの更新方針と揃える)
- `internal/core/federation/resolver_test.go`
  - 新規テスト 4 本を追加

## 追加テスト

- `TestResolveActor_NewUserIngestsIconBanner` — icon/image ありの新規 actor で URL が保存される
- `TestResolveActor_NewUserWithoutIconBanner` — icon/image なしの actor では nil のまま (既存挙動との互換性)
- `TestResolveActor_TTLRefreshUpdatesIconBanner` — TTL 切れ refresh で新しい URL に更新される
- `TestResolveActor_TTLRefreshPreservesIconWhenOmitted` — refresh 先 actor が icon を含まないとき既存値を温存する

## テスト結果

- `go test -race -count=1 ./internal/core/federation/...` パス (coverage 90.8%)
- `make fmt && make lint` クリーン

## Closes

Closes #350
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/shiroha-a/mk/pull/356" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
