### PR TITLE
Fix #346: bundle backend static assets into runtime image

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -30,6 +30,10 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          # third_party/misskey (packages/backend/assets など) がDockerfileの
+          # COPY対象になるため、submoduleを取得しないとbuildが失敗する。
+          submodules: recursive
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3

--- a/Dockerfile
+++ b/Dockerfile
@@ -25,6 +25,13 @@ COPY --from=builder /app/built/misskey /app/misskey
 COPY --from=builder /app/built/migrate /app/migrate
 COPY --from=builder /app/migration /app/migration
 
+# 本家のpackages/backend/assets (favicon / icons等) をimageに焼き込む。
+# bind-mountなしでも /favicon.ico / /static-assets/* 等が serve できる
+# (issue #346)。third_party/misskey はsubmoduleなのでビルド前に
+# `git submodule update --init --recursive` が必要。
+COPY --from=builder /app/third_party/misskey/packages/backend/assets /app/static-assets
+ENV MISSKEY_STATIC_DIR=/app/static-assets
+
 # デフォルト設定ファイルをコピー (docker-compose でマウント上書き可能)
 COPY .config/docker.yml /app/.config/default.yml
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,6 +11,14 @@ COPY go.mod go.sum ./
 RUN go mod download
 
 COPY . .
+
+# third_party/misskey (submodule) がruntime stageのCOPY対象になるので、
+# ビルド前に初期化されているか確認する。CIは docker.yml 側で submodules:
+# recursive を指定して取得する。ローカル build 時はユーザに指示を出す。
+RUN test -d third_party/misskey/packages/backend/assets || \
+    (echo "ERROR: third_party/misskey submodule not initialized." && \
+     echo "Run: git submodule update --init --recursive" && exit 1)
+
 RUN go build -trimpath -ldflags="-s -w" -o /app/built/misskey ./cmd/misskey && \
     go build -trimpath -ldflags="-s -w" -o /app/built/migrate ./cmd/migrate
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,8 +15,8 @@ COPY . .
 # third_party/misskey (submodule) がruntime stageのCOPY対象になるので、
 # ビルド前に初期化されているか確認する。CIは docker.yml 側で submodules:
 # recursive を指定して取得する。ローカル build 時はユーザに指示を出す。
-RUN test -d third_party/misskey/packages/backend/assets || \
-    (echo "ERROR: third_party/misskey submodule not initialized." && \
+RUN test -f third_party/misskey/packages/backend/assets/favicon.ico || \
+    (echo "ERROR: third_party/misskey submodule not initialized (or partial clone)." && \
      echo "Run: git submodule update --init --recursive" && exit 1)
 
 RUN go build -trimpath -ldflags="-s -w" -o /app/built/misskey ./cmd/misskey && \

--- a/deploy/uds/Dockerfile.mkgo
+++ b/deploy/uds/Dockerfile.mkgo
@@ -34,6 +34,16 @@ WORKDIR /app
 COPY --from=builder --chown=65532:65532 /app/built/misskey /app/misskey
 COPY --from=builder --chown=65532:65532 /app/built/migrate /app/migrate
 COPY --from=builder --chown=65532:65532 /app/migration /app/migration
+
+# 本家のpackages/backend/assets (favicon / icons / apple-touch-icon / robots.txtなど)
+# をimageに焼き込んでおく。これがないと /favicon.ico / /static-assets/* /
+# /apple-touch-icon.png などがSPA catchallに吸われてHTMLを返してしまい、
+# frontendが "instance.iconUrl || '/favicon.ico'" というfallbackを使っても
+# 画像が表示されない (issue #346)。bind-mountを使わなくてもserve できる
+# ように runtime image側に持たせる。
+COPY --from=builder --chown=65532:65532 /app/third_party/misskey/packages/backend/assets /app/static-assets
+ENV MISSKEY_STATIC_DIR=/app/static-assets
+
 COPY --chown=65532:65532 deploy/uds/mkgo-entrypoint.sh /entrypoint.sh
 RUN chmod +x /entrypoint.sh
 

--- a/deploy/uds/Dockerfile.mkgo
+++ b/deploy/uds/Dockerfile.mkgo
@@ -22,8 +22,8 @@ COPY . .
 # `git submodule update --init --recursive` 手順を忘れたときに早期にfail
 # する。CI (docker.yml) 側ではactions/checkoutにsubmodules: recursiveを
 # 指定して取得する。
-RUN test -d third_party/misskey/packages/backend/assets || \
-    (echo "ERROR: third_party/misskey submodule not initialized." && \
+RUN test -f third_party/misskey/packages/backend/assets/favicon.ico || \
+    (echo "ERROR: third_party/misskey submodule not initialized (or partial clone)." && \
      echo "Run: git submodule update --init --recursive" && exit 1)
 
 RUN go build -trimpath -ldflags="-s -w" -o /app/built/misskey ./cmd/misskey \

--- a/deploy/uds/Dockerfile.mkgo
+++ b/deploy/uds/Dockerfile.mkgo
@@ -16,6 +16,16 @@ COPY go.mod go.sum ./
 RUN go mod download
 
 COPY . .
+
+# third_party/misskey (submodule) がruntime stageのCOPY対象になるので、
+# ビルド前に初期化されているか確認する。docs/docker-uds.mdが要求する
+# `git submodule update --init --recursive` 手順を忘れたときに早期にfail
+# する。CI (docker.yml) 側ではactions/checkoutにsubmodules: recursiveを
+# 指定して取得する。
+RUN test -d third_party/misskey/packages/backend/assets || \
+    (echo "ERROR: third_party/misskey submodule not initialized." && \
+     echo "Run: git submodule update --init --recursive" && exit 1)
+
 RUN go build -trimpath -ldflags="-s -w" -o /app/built/misskey ./cmd/misskey \
  && go build -trimpath -ldflags="-s -w" -o /app/built/migrate ./cmd/migrate
 


### PR DESCRIPTION
## Summary

- 手動検証で「デフォルトサーバーアイコンが表示されない」の真因を調査
- `api/meta` の `iconUrl: null` は本家と同じ正しい挙動で、frontend は `instance.iconUrl || '/favicon.ico'` の fallback を持っていた
- 真の原因: mk-go コンテナに本家の `packages/backend/assets` が存在せず、`/favicon.ico` / `/static-assets/*` / `/apple-touch-icon.png` などが SPA catchall に吸われて HTML を返していた
- 両 Dockerfile に `COPY` + `ENV MISSKEY_STATIC_DIR` を追加して bind-mount なしでも image 単体で静的アセットを serve できるようにした

## 主な変更点

### `deploy/uds/Dockerfile.mkgo`
```dockerfile
COPY --from=builder --chown=65532:65532 \
    /app/third_party/misskey/packages/backend/assets /app/static-assets
ENV MISSKEY_STATIC_DIR=/app/static-assets
```

### `Dockerfile` (主)
同等の追加。third_party/misskey は submodule なので `git submodule update --init --recursive` が前提 (既存の build flow と同じ)。

## 内部実装

- `internal/server/router.go:1970` は `os.Stat(staticDir)` が成功したときのみ `/static-assets` / `/favicon.ico` などのルートを登録する設計
- `frontendutil.StaticDir()` のデフォルト path は `third_party/misskey/packages/backend/assets` だが、Dockerfile 側にこのディレクトリを COPY していなかった
- 起動時にルートが登録されないので SPA catchall (`GET /*`) が全て吸収 → `text/html` 応答 → ブラウザが画像として扱えない

## 影響範囲

- image size: backend/assets は 544KB 程度。無視できる
- bind-mount override: `MISSKEY_STATIC_DIR` 環境変数で compose.uds.yaml 側からの上書きは従来どおり可能

## 対象外 (別 issue 化検討)

- `/twemoji/*` (twemoji SVG): 同じ理由で壊れているが twemoji は node_modules 経路で重い
- `/assets/*` fallback (repo-level ai.png など): 現状 `application/json` を返しており別問題

本 PR は server icon (favicon / icons) に絞る (1 PR 1 purpose)。

## 検証

- `docker compose -f compose.uds.yaml build mkgo` OK
- image 内 `/app/static-assets/favicon.ico` / `/app/static-assets/icons/192.png` を確認
- `MISSKEY_STATIC_DIR=/app/static-assets` が ENV に設定されているのを確認
- `make fmt && make lint` クリーン
- 既存テスト ( `internal/frontendutil/...`、 middleware ) パス

## Closes

Closes #346
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/shiroha-a/mk/pull/358" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
