### PR TITLE
Fix #362: Redis keyPrefix for TS drop-in compat + HTML→MFM regression tests

### DIFF
--- a/internal/activitypub/mfm/from_html_test.go
+++ b/internal/activitypub/mfm/from_html_test.go
@@ -180,6 +180,27 @@ func TestFromHTML(t *testing.T) {
 			html: `<p>Check <a href="https://example.com">example.com</a></p><p>Done.</p>`,
 			want: "Check [example.com](https://example.com)\n\nDone.",
 		},
+		// --- #362 回帰テスト: drop-in 互換報告で DB に残っていた実データ ---
+		{
+			name: "#362 p class=quote-inline with RE: prefix + mastodon ellipsis link",
+			html: `<p class="quote-inline">RE: <a href="https://example.com/notes/x" target="_blank" rel="nofollow noopener" translate="no"><span class="invisible">https://</span><span class="ellipsis">example.com/notes</span><span class="invisible">/x</span></a></p><p>replied body</p>`,
+			want: "RE: https://example.com/notes/x\n\nreplied body",
+		},
+		{
+			name: "#362 h-card mention followed by body text",
+			html: `<p><span class="h-card"><a class="u-url mention" href="https://remote.example/@alice">@<span>alice</span></a></span> hello body</p>`,
+			want: "@alice@remote.example hello body",
+		},
+		{
+			name: "#362 consecutive <br /> in paragraph",
+			html: `<p>line1<br />line2<br />line3</p>`,
+			want: "line1\nline2\nline3",
+		},
+		{
+			name: "#362 <span> only wrapper inside <p>",
+			html: `<p><span>just text in span</span></p>`,
+			want: "just text in span",
+		},
 	}
 
 	for _, tt := range tests {

--- a/internal/api/notes/timeline_handler_test.go
+++ b/internal/api/notes/timeline_handler_test.go
@@ -55,7 +55,7 @@ func newRealTimelineService(t *testing.T, noteRepo *testutil.MockNoteRepository)
 	requireRedis(t)
 	testRedis.FlushAll(context.Background())
 	idGen, _ := id.NewGenerator("aidx")
-	fanout := coretimeline.NewFanoutTimelineService(testRedis.Client, idGen)
+	fanout := coretimeline.NewFanoutTimelineService(testRedis.Client, idGen, "")
 	svc := coretimeline.NewService(fanout, noteRepo, testutil.NewMockFollowingRepository())
 	return svc, fanout
 }
@@ -72,7 +72,7 @@ func closedRedisClient(t *testing.T) *redis.Client {
 func newFailingTimelineService(t *testing.T) *coretimeline.Service {
 	t.Helper()
 	idGen, _ := id.NewGenerator("aidx")
-	fanout := coretimeline.NewFanoutTimelineService(closedRedisClient(t), idGen)
+	fanout := coretimeline.NewFanoutTimelineService(closedRedisClient(t), idGen, "")
 	return coretimeline.NewService(fanout, testutil.NewMockNoteRepository(), nil)
 }
 

--- a/internal/api/notifications/handler_test.go
+++ b/internal/api/notifications/handler_test.go
@@ -42,7 +42,7 @@ func TestMain(m *testing.M) {
 func newTestHandler(t *testing.T) (*Handler, *notification.Service) {
 	t.Helper()
 	testRedis.FlushAll(context.Background())
-	svc := notification.NewService(testRedis.Client, idGen)
+	svc := notification.NewService(testRedis.Client, idGen, "")
 	return NewHandler(svc, idGen), svc
 }
 
@@ -108,7 +108,7 @@ func TestShow_InvalidJSON(t *testing.T) {
 func TestShow_RedisError(t *testing.T) {
 	closed := redis.NewClient(&redis.Options{Addr: "127.0.0.1:1"})
 	_ = closed.Close()
-	svc := notification.NewService(closed, idGen)
+	svc := notification.NewService(closed, idGen, "")
 	h := NewHandler(svc, idGen)
 
 	c, rec := newJSONRequest(t, "/api/i/notifications", `{}`)
@@ -133,7 +133,7 @@ func TestMarkAllAsRead_OK(t *testing.T) {
 func TestMarkAllAsRead_RedisError(t *testing.T) {
 	closed := redis.NewClient(&redis.Options{Addr: "127.0.0.1:1"})
 	_ = closed.Close()
-	svc := notification.NewService(closed, idGen)
+	svc := notification.NewService(closed, idGen, "")
 	h := NewHandler(svc, idGen)
 
 	c, rec := newJSONRequest(t, "/api/notifications/mark-all-as-read", `{}`)
@@ -183,7 +183,7 @@ func TestFlush_NilService(t *testing.T) {
 func TestFlush_RedisError(t *testing.T) {
 	closed := redis.NewClient(&redis.Options{Addr: "127.0.0.1:1"})
 	_ = closed.Close()
-	svc := notification.NewService(closed, idGen)
+	svc := notification.NewService(closed, idGen, "")
 	h := NewHandler(svc, idGen)
 
 	c, rec := newJSONRequest(t, "/api/notifications/flush", `{}`)

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -517,6 +517,20 @@ func resolveRedis(opts RedisOptions, host string) RedisOptions {
 	return opts
 }
 
+// KeyPrefix returns the Redis key prefix to prepend to bare keys so that
+// mk-go shares the same namespace as Misskey TS (TS uses ioredis `keyPrefix:
+// <host>:` which gets applied to every key transparently). Empty Prefix
+// returns "" for backwards compat with keys that were never prefixed.
+//
+// Consumers should prepend this to every Redis key they construct, e.g.
+// `cfg.Redis.KeyPrefix() + "list:homeTimeline:" + userID`.
+func (r RedisOptions) KeyPrefix() string {
+	if r.Prefix == "" {
+		return ""
+	}
+	return r.Prefix + ":"
+}
+
 // DefaultTrustProxy is the default set of CIDR ranges for trusted proxies,
 // matching the TypeScript Misskey defaults (private IP ranges).
 var DefaultTrustProxy = []string{

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -804,3 +804,23 @@ func TestLoad_EnablePprof_DefaultFalse(t *testing.T) {
 	require.NoError(t, err)
 	assert.False(t, cfg.EnablePprof)
 }
+
+// TestRedisOptions_KeyPrefix は #362 drop-in 互換の回帰テスト。
+// TS 本家の ioredis keyPrefix (`<host>:`) と同じ形式の prefix を返すことを確認する。
+func TestRedisOptions_KeyPrefix(t *testing.T) {
+	tests := []struct {
+		name   string
+		prefix string
+		want   string
+	}{
+		{name: "empty prefix returns empty string", prefix: "", want: ""},
+		{name: "hostname prefix gets trailing colon", prefix: "example.com", want: "example.com:"},
+		{name: "custom prefix gets trailing colon", prefix: "my-instance", want: "my-instance:"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			opts := RedisOptions{Prefix: tt.prefix}
+			assert.Equal(t, tt.want, opts.KeyPrefix())
+		})
+	}
+}

--- a/internal/core/notification/hooks_test.go
+++ b/internal/core/notification/hooks_test.go
@@ -14,7 +14,7 @@ import (
 func newTestHook(t *testing.T) (*Hook, *Service, *testutil.MockUserRepository) {
 	t.Helper()
 	testRedis.FlushAll(context.Background())
-	svc := NewService(testRedis.Client, idGen)
+	svc := NewService(testRedis.Client, idGen, "")
 	userRepo := testutil.NewMockUserRepository()
 	return NewHook(svc, userRepo), svc, userRepo
 }
@@ -261,7 +261,7 @@ func TestHook_OnNoteCreated_NoteUnreadPublicNoop(t *testing.T) {
 func TestService_MarkAllAsRead_ClearsNoteUnread(t *testing.T) {
 	// MarkAllAsRead が呼ばれたら note_unread 行を全削除し、
 	// HasUnreadSpecifiedNotes が false に戻ることを確認する (#319 BUG 修正)。
-	svc := NewService(testRedis.Client, idGen)
+	svc := NewService(testRedis.Client, idGen, "")
 	unread := testutil.NewMockNoteUnreadRepository()
 	svc.SetNoteUnreadRepo(unread)
 
@@ -286,7 +286,7 @@ func TestService_MarkAllAsRead_ClearsNoteUnread(t *testing.T) {
 func TestService_Flush_ClearsNoteUnread(t *testing.T) {
 	// Flush (account deletion 等) でも note_unread を clear する。
 	testRedis.FlushAll(context.Background())
-	svc := NewService(testRedis.Client, idGen)
+	svc := NewService(testRedis.Client, idGen, "")
 	unread := testutil.NewMockNoteUnreadRepository()
 	svc.SetNoteUnreadRepo(unread)
 
@@ -302,7 +302,7 @@ func TestHook_OnNoteCreated_NoteUnreadSkipsMentionWithoutUserRepo(t *testing.T) 
 	// userRepo が未配線でも mention 解決を試みずに panic せず、
 	// visibleUserIds 経由の note_unread だけ作られる (nil deref 回避)。
 	testRedis.FlushAll(context.Background())
-	svc := NewService(testRedis.Client, idGen)
+	svc := NewService(testRedis.Client, idGen, "")
 	h := NewHook(svc, nil) // userRepo 未配線
 
 	unread := testutil.NewMockNoteUnreadRepository()
@@ -328,7 +328,7 @@ func TestHook_OnNoteCreated_NoteUnreadSkipsMentionWithoutUserRepo(t *testing.T) 
 
 func TestService_HasUnreadSpecifiedNotes_UsesRepoWhenSet(t *testing.T) {
 	// repo 注入時は Redis scan でなく repo.HasAnySpecified を参照する。
-	svc := NewService(testRedis.Client, idGen)
+	svc := NewService(testRedis.Client, idGen, "")
 	unread := testutil.NewMockNoteUnreadRepository()
 	svc.SetNoteUnreadRepo(unread)
 
@@ -423,7 +423,7 @@ func TestHook_NotifyMissingUserSkipped(t *testing.T) {
 func TestHook_NotifyWithoutUserRepo(t *testing.T) {
 	// userRepo == nil の場合はホストチェックをスキップする
 	testRedis.FlushAll(context.Background())
-	svc := NewService(testRedis.Client, idGen)
+	svc := NewService(testRedis.Client, idGen, "")
 	h := NewHook(svc, nil)
 	h.OnFollowed("bob", "alice")
 
@@ -434,7 +434,7 @@ func TestHook_NotifyWithoutUserRepo(t *testing.T) {
 
 func TestHook_NotifyServiceErrorLogged(t *testing.T) {
 	// closed clientではCreate失敗 → ログ出力されるだけで例外なし
-	svc := NewService(closedClient(t), idGen)
+	svc := NewService(closedClient(t), idGen, "")
 	repo := testutil.NewMockUserRepository()
 	addLocalUser(repo, "alice", "alice")
 	h := NewHook(svc, repo)
@@ -588,7 +588,7 @@ func TestHook_WebPushWithoutPackers(t *testing.T) {
 }
 
 func TestHook_WebPushSkippedWhenCreateFails(t *testing.T) {
-	svc := NewService(closedClient(t), idGen)
+	svc := NewService(closedClient(t), idGen, "")
 	repo := testutil.NewMockUserRepository()
 	addLocalUser(repo, "alice", "alice")
 	h := NewHook(svc, repo)

--- a/internal/core/notification/notification_service.go
+++ b/internal/core/notification/notification_service.go
@@ -38,13 +38,14 @@ const (
 const MaxPerUser = 300
 
 // streamKey returns the Redis Stream key for a user's notification timeline.
-func streamKey(userID string) string {
-	return "notificationTimeline:" + userID
+// TS drop-in互換のため keyPrefix (通常 `<host>:`) を前置する。
+func (s *Service) streamKey(userID string) string {
+	return s.keyPrefix + "notificationTimeline:" + userID
 }
 
 // readKey returns the Redis key that stores the latest read notification id.
-func readKey(userID string) string {
-	return "latestReadNotification:" + userID
+func (s *Service) readKey(userID string) string {
+	return s.keyPrefix + "latestReadNotification:" + userID
 }
 
 // Notification is the payload stored in Redis.
@@ -106,6 +107,7 @@ type Packer interface {
 type Service struct {
 	client              *redis.Client
 	idGen               id.Generator
+	keyPrefix           string // TS drop-in互換用 `<host>:` prefix
 	publisher           StreamingPublisher
 	mainStreamPublisher MainStreamPublisher
 	packer              Packer
@@ -113,8 +115,12 @@ type Service struct {
 }
 
 // NewService constructs a new NotificationService.
-func NewService(client *redis.Client, idGen id.Generator) *Service {
-	return &Service{client: client, idGen: idGen}
+//
+// keyPrefix (通常は `cfg.Redis.KeyPrefix()` = `<host>:`) は TS 本家と同じキー
+// 名前空間 (`<host>:notificationTimeline:*`, `<host>:latestReadNotification:*`)
+// を使うために全 Redis キーの前に付与される。空文字列ならprefix無し。
+func NewService(client *redis.Client, idGen id.Generator, keyPrefix string) *Service {
+	return &Service{client: client, idGen: idGen, keyPrefix: keyPrefix}
 }
 
 // SetStreamingPublisher attaches a StreamingPublisher invoked best-effort
@@ -181,7 +187,7 @@ func (s *Service) Create(ctx context.Context, in CreateInput) (*Notification, er
 	// MAXLEN ~ で古い通知を確率的にtrim、IDフィールドはGorm IDを利用する
 	streamID := toXAddID(n.ID, now)
 	if err := s.client.XAdd(ctx, &redis.XAddArgs{
-		Stream: streamKey(in.NotifieeID),
+		Stream: s.streamKey(in.NotifieeID),
 		MaxLen: MaxPerUser,
 		Approx: true,
 		ID:     streamID,
@@ -224,7 +230,7 @@ func (s *Service) List(ctx context.Context, userID string, limit int) ([]*Notifi
 	if limit > 100 {
 		limit = 100
 	}
-	res, err := s.client.XRevRangeN(ctx, streamKey(userID), "+", "-", int64(limit)).Result()
+	res, err := s.client.XRevRangeN(ctx, s.streamKey(userID), "+", "-", int64(limit)).Result()
 	if err != nil {
 		return nil, err
 	}
@@ -250,7 +256,7 @@ func (s *Service) List(ctx context.Context, userID string, limit int) ([]*Notifi
 // (hasUnreadSpecifiedNotes / hasUnreadMentionsをfalseに戻すため)。
 // Redis SET失敗時はnote_unreadを温存する (整合性維持)。
 func (s *Service) MarkAllAsRead(ctx context.Context, userID string) error {
-	res, err := s.client.XRevRangeN(ctx, streamKey(userID), "+", "-", 1).Result()
+	res, err := s.client.XRevRangeN(ctx, s.streamKey(userID), "+", "-", 1).Result()
 	if err != nil {
 		return err
 	}
@@ -264,7 +270,7 @@ func (s *Service) MarkAllAsRead(ctx context.Context, userID string) error {
 		}
 		return nil
 	}
-	if err := s.client.Set(ctx, readKey(userID), res[0].ID, 0).Err(); err != nil {
+	if err := s.client.Set(ctx, s.readKey(userID), res[0].ID, 0).Err(); err != nil {
 		return err
 	}
 	// Redis SET成功後にnote_unreadを消す (SET失敗時は温存して次回retryで
@@ -292,7 +298,7 @@ func (s *Service) clearNoteUnread(userID string) {
 // LatestReadID returns the most recently read notification id for the user.
 // 未読履歴がなければ空文字を返す。
 func (s *Service) LatestReadID(ctx context.Context, userID string) (string, error) {
-	val, err := s.client.Get(ctx, readKey(userID)).Result()
+	val, err := s.client.Get(ctx, s.readKey(userID)).Result()
 	if err == redis.Nil {
 		return "", nil
 	}
@@ -314,7 +320,7 @@ func (s *Service) UnreadCount(ctx context.Context, userID string) (int64, error)
 	// Redis Streams は ID 単調増加。XLen で全件数を取り、readID 以前の
 	// 件数を差し引く方が O(1) でシンプルだが、readID より古いエントリが
 	// MAXLEN で削除されている場合があるので XRevRange で直接数える。
-	res, err := s.client.XRevRangeN(ctx, streamKey(userID), "+", exclusive(readID), MaxPerUser).Result()
+	res, err := s.client.XRevRangeN(ctx, s.streamKey(userID), "+", exclusive(readID), MaxPerUser).Result()
 	if err != nil {
 		return 0, err
 	}
@@ -350,7 +356,7 @@ func (s *Service) UnreadSummary(ctx context.Context, userID string, mentionTypes
 	if err != nil {
 		return summary, err
 	}
-	res, err := s.client.XRevRangeN(ctx, streamKey(userID), "+", exclusive(readID), MaxPerUser).Result()
+	res, err := s.client.XRevRangeN(ctx, s.streamKey(userID), "+", exclusive(readID), MaxPerUser).Result()
 	if err != nil {
 		return summary, err
 	}
@@ -417,7 +423,7 @@ func (s *Service) HasUnreadOfTypes(ctx context.Context, userID string, types []T
 	if err != nil {
 		return false, err
 	}
-	res, err := s.client.XRevRangeN(ctx, streamKey(userID), "+", exclusive(readID), MaxPerUser).Result()
+	res, err := s.client.XRevRangeN(ctx, s.streamKey(userID), "+", exclusive(readID), MaxPerUser).Result()
 	if err != nil {
 		return false, err
 	}
@@ -456,7 +462,7 @@ func (s *Service) HasUnreadSpecifiedNotes(ctx context.Context, userID string) (b
 	if err != nil {
 		return false, err
 	}
-	res, err := s.client.XRevRangeN(ctx, streamKey(userID), "+", exclusive(readID), MaxPerUser).Result()
+	res, err := s.client.XRevRangeN(ctx, s.streamKey(userID), "+", exclusive(readID), MaxPerUser).Result()
 	if err != nil {
 		return false, err
 	}
@@ -490,10 +496,10 @@ func exclusive(readID string) string {
 // and account deletion). Emits `notificationFlushed` to the user's main stream
 // on success. note_unread repoが注入されていれば同時にclearする。
 func (s *Service) Flush(ctx context.Context, userID string) error {
-	if err := s.client.Del(ctx, streamKey(userID)).Err(); err != nil {
+	if err := s.client.Del(ctx, s.streamKey(userID)).Err(); err != nil {
 		return err
 	}
-	if err := s.client.Del(ctx, readKey(userID)).Err(); err != nil {
+	if err := s.client.Del(ctx, s.readKey(userID)).Err(); err != nil {
 		return err
 	}
 	s.clearNoteUnread(userID)

--- a/internal/core/notification/notification_service_test.go
+++ b/internal/core/notification/notification_service_test.go
@@ -37,7 +37,7 @@ func TestMain(m *testing.M) {
 func newTestSvc(t *testing.T) *Service {
 	t.Helper()
 	testRedis.FlushAll(context.Background())
-	return NewService(testRedis.Client, idGen)
+	return NewService(testRedis.Client, idGen, "")
 }
 
 func closedClient(t *testing.T) *redis.Client {
@@ -51,6 +51,40 @@ func TestService_Create_RequiresNotifiee(t *testing.T) {
 	svc := newTestSvc(t)
 	_, err := svc.Create(context.Background(), CreateInput{Type: TypeFollow})
 	assert.Error(t, err)
+}
+
+// TestService_KeyPrefix は #362 drop-in 互換の回帰テスト。
+// TS 本家と同じ `<host>:notificationTimeline:*` / `<host>:latestReadNotification:*`
+// 名前空間にキーが置かれることを確認する。
+func TestService_KeyPrefix(t *testing.T) {
+	testRedis.FlushAll(context.Background())
+	const host = "example.test"
+	svc := NewService(testRedis.Client, idGen, host+":")
+	ctx := context.Background()
+
+	_, err := svc.Create(ctx, CreateInput{
+		NotifieeID: "u1", NotifierID: "u2", Type: TypeMention, NoteID: "n1",
+	})
+	require.NoError(t, err)
+
+	// prefix 付きストリームに entry がある
+	prefixed := host + ":notificationTimeline:u1"
+	n, err := testRedis.Client.XLen(ctx, prefixed).Result()
+	require.NoError(t, err)
+	assert.Equal(t, int64(1), n, "prefixed stream receives the notification")
+
+	// 旧 prefix 無しキーには無い
+	bare := "notificationTimeline:u1"
+	n, err = testRedis.Client.XLen(ctx, bare).Result()
+	require.NoError(t, err)
+	assert.Equal(t, int64(0), n, "bare stream remains empty")
+
+	// readKey も prefix 下に置かれる
+	require.NoError(t, svc.MarkAllAsRead(ctx, "u1"))
+	readKey := host + ":latestReadNotification:u1"
+	got, err := testRedis.Client.Exists(ctx, readKey).Result()
+	require.NoError(t, err)
+	assert.Equal(t, int64(1), got, "prefixed read key should exist after MarkAllAsRead")
 }
 
 func TestService_Create_SelfNotificationRejected(t *testing.T) {
@@ -268,7 +302,7 @@ func TestService_Flush(t *testing.T) {
 }
 
 func TestService_RedisErrors(t *testing.T) {
-	svc := NewService(closedClient(t), idGen)
+	svc := NewService(closedClient(t), idGen, "")
 	ctx := context.Background()
 
 	_, err := svc.Create(ctx, CreateInput{NotifieeID: "u", NotifierID: "v", Type: TypeFollow})

--- a/internal/core/timeline/fanout_hook_test.go
+++ b/internal/core/timeline/fanout_hook_test.go
@@ -14,7 +14,7 @@ import (
 func newTestHook(t *testing.T) (*FanoutHook, *FanoutTimelineService, *testutil.MockFollowingRepository) {
 	t.Helper()
 	testRedis.FlushAll(context.Background())
-	fanout := NewFanoutTimelineService(testRedis.Client, idGen)
+	fanout := NewFanoutTimelineService(testRedis.Client, idGen, "")
 	fanout.randFn = func() float64 { return 1.0 }
 	following := testutil.NewMockFollowingRepository()
 	return NewFanoutHook(fanout, following), fanout, following
@@ -134,7 +134,7 @@ func (assertError) Error() string { return "boom" }
 
 func TestFanoutHook_ListFollowersError(t *testing.T) {
 	testRedis.FlushAll(context.Background())
-	fanout := NewFanoutTimelineService(testRedis.Client, idGen)
+	fanout := NewFanoutTimelineService(testRedis.Client, idGen, "")
 	fanout.randFn = func() float64 { return 1.0 }
 	following := &failingFollowingRepo{MockFollowingRepository: testutil.NewMockFollowingRepository()}
 	h := NewFanoutHook(fanout, following)
@@ -147,7 +147,7 @@ func TestFanoutHook_ListFollowersError(t *testing.T) {
 
 func TestFanoutHook_FanoutsAcrossPages(t *testing.T) {
 	testRedis.FlushAll(context.Background())
-	fanout := NewFanoutTimelineService(testRedis.Client, idGen)
+	fanout := NewFanoutTimelineService(testRedis.Client, idGen, "")
 	fanout.randFn = func() float64 { return 1.0 }
 	following := testutil.NewMockFollowingRepository()
 	// 201人のフォロワーを用意してページ境界を踏ませる
@@ -170,7 +170,7 @@ func TestFanoutHook_FanoutsAcrossPages(t *testing.T) {
 func TestFanoutHook_PushErrorIsLogged(t *testing.T) {
 	// closed clientへのpushでエラーを発生させる. ログ出力されるだけで例外なし.
 	following := testutil.NewMockFollowingRepository()
-	fanout := NewFanoutTimelineService(closedClient(t), idGen)
+	fanout := NewFanoutTimelineService(closedClient(t), idGen, "")
 	h := NewFanoutHook(fanout, following)
 	noteID := idGen.Generate(time.Now())
 	h.OnNoteCreated(&model.Note{ID: noteID, UserID: "u", Visibility: model.NoteVisibilityPublic}, &model.User{ID: "u"})
@@ -178,7 +178,7 @@ func TestFanoutHook_PushErrorIsLogged(t *testing.T) {
 
 func TestFanoutHook_NilFollowingRepo(t *testing.T) {
 	testRedis.FlushAll(context.Background())
-	fanout := NewFanoutTimelineService(testRedis.Client, idGen)
+	fanout := NewFanoutTimelineService(testRedis.Client, idGen, "")
 	fanout.randFn = func() float64 { return 1.0 }
 	h := NewFanoutHook(fanout, nil)
 	noteID := idGen.Generate(time.Now())
@@ -262,7 +262,7 @@ func TestFanoutHook_StreamingFanoutErrorPath(t *testing.T) {
 	// failingFollowingRepo は ListFollowers でエラーを返す → fanoutStreamingToFollowers
 	// は早期 return する
 	testRedis.FlushAll(context.Background())
-	fanout := NewFanoutTimelineService(testRedis.Client, idGen)
+	fanout := NewFanoutTimelineService(testRedis.Client, idGen, "")
 	fanout.randFn = func() float64 { return 1.0 }
 	following := &failingFollowingRepo{MockFollowingRepository: testutil.NewMockFollowingRepository()}
 	h := NewFanoutHook(fanout, following)
@@ -278,7 +278,7 @@ func TestFanoutHook_StreamingFanoutErrorPath(t *testing.T) {
 
 func TestFanoutHook_StreamingFanoutAcrossPages(t *testing.T) {
 	testRedis.FlushAll(context.Background())
-	fanout := NewFanoutTimelineService(testRedis.Client, idGen)
+	fanout := NewFanoutTimelineService(testRedis.Client, idGen, "")
 	fanout.randFn = func() float64 { return 1.0 }
 	following := testutil.NewMockFollowingRepository()
 	for i := range 201 {
@@ -302,7 +302,7 @@ func TestFanoutHook_StreamingFanoutAcrossPages(t *testing.T) {
 
 func TestFanoutHook_StreamingPublisherNilFollowingRepo(t *testing.T) {
 	testRedis.FlushAll(context.Background())
-	fanout := NewFanoutTimelineService(testRedis.Client, idGen)
+	fanout := NewFanoutTimelineService(testRedis.Client, idGen, "")
 	fanout.randFn = func() float64 { return 1.0 }
 	h := NewFanoutHook(fanout, nil)
 	pub := &stubStreamingPublisher{}

--- a/internal/core/timeline/fanout_timeline_service.go
+++ b/internal/core/timeline/fanout_timeline_service.go
@@ -53,8 +53,9 @@ func UserListTimelineName(listID string) Name {
 
 // FanoutTimelineService manages Redis-backed timeline lists.
 type FanoutTimelineService struct {
-	client *redis.Client
-	idGen  id.Generator
+	client    *redis.Client
+	idGen     id.Generator
+	keyPrefix string // TS drop-in互換用 `<host>:` prefix。空なら従来通り。
 	// nowFn / randFn allow tests to inject deterministic values.
 	nowFn  func() time.Time
 	randFn func() float64
@@ -63,18 +64,23 @@ type FanoutTimelineService struct {
 // NewFanoutTimelineService creates a new FanoutTimelineService bound to the
 // timelines Redis database. idGen is used to extract a note's creation time
 // from its ID for the late-insert ordering check.
-func NewFanoutTimelineService(client *redis.Client, idGen id.Generator) *FanoutTimelineService {
+//
+// keyPrefix (通常は `cfg.Redis.KeyPrefix()` = `<host>:`) は TS 本家と同じキー
+// 名前空間 (`<host>:list:homeTimeline:<userId>` 等) を使うために全キーの前に
+// 付与される。空文字列を渡すとprefix無しになり、従来の mk-only 挙動に戻る。
+func NewFanoutTimelineService(client *redis.Client, idGen id.Generator, keyPrefix string) *FanoutTimelineService {
 	return &FanoutTimelineService{
-		client: client,
-		idGen:  idGen,
-		nowFn:  time.Now,
-		randFn: rand.Float64,
+		client:    client,
+		idGen:     idGen,
+		keyPrefix: keyPrefix,
+		nowFn:     time.Now,
+		randFn:    rand.Float64,
 	}
 }
 
-// key returns the Redis key for a timeline name.
+// key returns the Redis key for a timeline name, with TS-compatible prefix.
 func (s *FanoutTimelineService) key(name Name) string {
-	return fmt.Sprintf(timelineKeyFmt, name)
+	return s.keyPrefix + fmt.Sprintf(timelineKeyFmt, name)
 }
 
 // Push appends id to the named timeline. maxLen caps the list size; values

--- a/internal/core/timeline/fanout_timeline_service_test.go
+++ b/internal/core/timeline/fanout_timeline_service_test.go
@@ -40,7 +40,7 @@ func TestMain(m *testing.M) {
 func newTestService(t *testing.T) *FanoutTimelineService {
 	t.Helper()
 	testRedis.FlushAll(context.Background())
-	svc := NewFanoutTimelineService(testRedis.Client, idGen)
+	svc := NewFanoutTimelineService(testRedis.Client, idGen, "")
 	// テストでは確率トリムをoffにする (常にtrimしない)
 	svc.randFn = func() float64 { return 1.0 }
 	return svc
@@ -215,7 +215,7 @@ func closedClient(t *testing.T) *redis.Client {
 
 func TestFanoutTimelineService_RedisErrors(t *testing.T) {
 	c := closedClient(t)
-	svc := NewFanoutTimelineService(c, idGen)
+	svc := NewFanoutTimelineService(c, idGen, "")
 	svc.randFn = func() float64 { return 1.0 }
 
 	ctx := context.Background()
@@ -241,6 +241,53 @@ func TestFanoutTimelineService_RedisErrors(t *testing.T) {
 	// Purge fails on Del
 	err = svc.Purge(ctx, LocalTimeline)
 	assert.Error(t, err)
+}
+
+// TestFanoutTimelineService_KeyPrefix は #362 drop-in 互換の回帰テスト。
+// TS 本家と同じ `<host>:list:...` 名前空間にキーが置かれることを確認する。
+func TestFanoutTimelineService_KeyPrefix(t *testing.T) {
+	testRedis.FlushAll(context.Background())
+	const host = "example.test"
+	svc := NewFanoutTimelineService(testRedis.Client, idGen, host+":")
+	svc.randFn = func() float64 { return 1.0 }
+	ctx := context.Background()
+
+	noteID := idGen.Generate(time.Now())
+	require.NoError(t, svc.Push(ctx, LocalTimeline, noteID, 100))
+
+	// prefix 付きキーには値が入っていること
+	prefixedKey := host + ":list:" + string(LocalTimeline)
+	n, err := testRedis.Client.LLen(ctx, prefixedKey).Result()
+	require.NoError(t, err)
+	assert.Equal(t, int64(1), n, "prefixed key should contain the pushed note")
+
+	// 旧 prefix 無しキーには何も入っていないこと
+	bareKey := "list:" + string(LocalTimeline)
+	n, err = testRedis.Client.LLen(ctx, bareKey).Result()
+	require.NoError(t, err)
+	assert.Equal(t, int64(0), n, "bare key should remain untouched")
+
+	// Get 経由で読めること
+	out, err := svc.Get(ctx, LocalTimeline, "", "", 10)
+	require.NoError(t, err)
+	assert.Equal(t, []string{noteID}, out)
+}
+
+// TestFanoutTimelineService_KeyPrefixEmpty はprefix空文字列時に従来挙動
+// (prefix 無しキー) のままであることを確認する。
+func TestFanoutTimelineService_KeyPrefixEmpty(t *testing.T) {
+	testRedis.FlushAll(context.Background())
+	svc := NewFanoutTimelineService(testRedis.Client, idGen, "")
+	svc.randFn = func() float64 { return 1.0 }
+	ctx := context.Background()
+
+	noteID := idGen.Generate(time.Now())
+	require.NoError(t, svc.Push(ctx, LocalTimeline, noteID, 100))
+
+	bareKey := "list:" + string(LocalTimeline)
+	n, err := testRedis.Client.LLen(ctx, bareKey).Result()
+	require.NoError(t, err)
+	assert.Equal(t, int64(1), n, "bare key receives value when prefix is empty")
 }
 
 func TestFanoutTimelineService_GetMultiEmpty(t *testing.T) {

--- a/internal/core/timeline/timeline_service_test.go
+++ b/internal/core/timeline/timeline_service_test.go
@@ -17,7 +17,7 @@ func newTestServiceWithRepo(t *testing.T) (*Service, *FanoutTimelineService, *te
 	t.Helper()
 	testRedis.FlushAll(context.Background())
 	noteRepo := testutil.NewMockNoteRepository()
-	fanout := NewFanoutTimelineService(testRedis.Client, idGen)
+	fanout := NewFanoutTimelineService(testRedis.Client, idGen, "")
 	fanout.randFn = func() float64 { return 1.0 }
 	svc := NewService(fanout, noteRepo, testutil.NewMockFollowingRepository())
 	return svc, fanout, noteRepo
@@ -46,7 +46,7 @@ func TestService_HomeTimeline(t *testing.T) {
 
 func TestService_HomeTimelineFanoutError(t *testing.T) {
 	noteRepo := testutil.NewMockNoteRepository()
-	fanout := NewFanoutTimelineService(closedClient(t), idGen)
+	fanout := NewFanoutTimelineService(closedClient(t), idGen, "")
 	svc := NewService(fanout, noteRepo, nil)
 	_, err := svc.HomeTimeline(context.Background(), &model.User{ID: "u"}, "", "", 10, TimelineFilter{})
 	assert.Error(t, err)
@@ -67,7 +67,7 @@ func TestService_LocalTimeline(t *testing.T) {
 
 func TestService_LocalTimelineFanoutError(t *testing.T) {
 	noteRepo := testutil.NewMockNoteRepository()
-	svc := NewService(NewFanoutTimelineService(closedClient(t), idGen), noteRepo, nil)
+	svc := NewService(NewFanoutTimelineService(closedClient(t), idGen, ""), noteRepo, nil)
 	_, err := svc.LocalTimeline(context.Background(), nil, "", "", 10, TimelineFilter{})
 	assert.Error(t, err)
 }
@@ -87,7 +87,7 @@ func TestService_GlobalTimeline(t *testing.T) {
 
 func TestService_GlobalTimelineFanoutError(t *testing.T) {
 	noteRepo := testutil.NewMockNoteRepository()
-	svc := NewService(NewFanoutTimelineService(closedClient(t), idGen), noteRepo, nil)
+	svc := NewService(NewFanoutTimelineService(closedClient(t), idGen, ""), noteRepo, nil)
 	_, err := svc.GlobalTimeline(context.Background(), nil, "", "", 10, TimelineFilter{})
 	assert.Error(t, err)
 }
@@ -118,7 +118,7 @@ func TestService_HybridTimeline(t *testing.T) {
 
 func TestService_HybridTimelineFanoutError(t *testing.T) {
 	noteRepo := testutil.NewMockNoteRepository()
-	svc := NewService(NewFanoutTimelineService(closedClient(t), idGen), noteRepo, nil)
+	svc := NewService(NewFanoutTimelineService(closedClient(t), idGen, ""), noteRepo, nil)
 	_, err := svc.HybridTimeline(context.Background(), &model.User{ID: "u"}, "", "", 10, TimelineFilter{})
 	assert.Error(t, err)
 }
@@ -213,7 +213,7 @@ func TestService_ResolveError(t *testing.T) {
 	// RedisにIDはあるがrepoのFindManyByIDsWithUserがエラー
 	testRedis.FlushAll(context.Background())
 	failRepo := &failingFindManyRepo{testutil.NewMockNoteRepository()}
-	fanout := NewFanoutTimelineService(testRedis.Client, idGen)
+	fanout := NewFanoutTimelineService(testRedis.Client, idGen, "")
 	svc := NewService(fanout, failRepo, testutil.NewMockFollowingRepository())
 	ctx := context.Background()
 

--- a/internal/core/urlpreview/fetcher.go
+++ b/internal/core/urlpreview/fetcher.go
@@ -43,6 +43,7 @@ type Config struct {
 type Fetcher struct {
 	cfg         Config
 	redis       *redis.Client
+	keyPrefix   string // TS drop-in互換用 `<host>:` prefix
 	client      *http.Client
 	proxyClient *http.Client
 }
@@ -54,7 +55,11 @@ func (f *Fetcher) SetHTTPClient(c *http.Client) {
 }
 
 // NewFetcher creates a URL preview Fetcher.
-func NewFetcher(cfg Config, rdb *redis.Client) *Fetcher {
+//
+// keyPrefix (通常は `cfg.Redis.KeyPrefix()` = `<host>:`) は TS 本家と同じ
+// キー名前空間の下にキャッシュキーを置くために前置される。空文字列なら
+// prefix 無し。
+func NewFetcher(cfg Config, rdb *redis.Client, keyPrefix string) *Fetcher {
 	timeout := time.Duration(cfg.TimeoutMs) * time.Millisecond
 	if timeout <= 0 {
 		timeout = 10 * time.Second
@@ -81,9 +86,10 @@ func NewFetcher(cfg Config, rdb *redis.Client) *Fetcher {
 	}
 
 	return &Fetcher{
-		cfg:    cfg,
-		redis:  rdb,
-		client: client,
+		cfg:       cfg,
+		redis:     rdb,
+		keyPrefix: keyPrefix,
+		client:    client,
 		// proxyClientはSSRF保護なしの専用クライアント。管理者が設定した
 		// 信頼済みプロキシURLはlocalhostやプライベートネットワーク上に
 		// 配置されることが多いため、プライベートIPブロックを適用しない。
@@ -103,7 +109,7 @@ func (f *Fetcher) Fetch(ctx context.Context, rawURL string) (*Result, error) {
 	}
 
 	// Redisキャッシュ確認
-	cacheKey := cachePrefix + hashURL(rawURL)
+	cacheKey := f.keyPrefix + cachePrefix + hashURL(rawURL)
 	if f.redis != nil {
 		if cached, err := f.redis.Get(ctx, cacheKey).Bytes(); err == nil {
 			var result Result

--- a/internal/core/urlpreview/fetcher_test.go
+++ b/internal/core/urlpreview/fetcher_test.go
@@ -12,13 +12,13 @@ import (
 )
 
 func TestFetcher_Disabled(t *testing.T) {
-	f := NewFetcher(Config{Enabled: false}, nil)
+	f := NewFetcher(Config{Enabled: false}, nil, "")
 	_, err := f.Fetch(context.Background(), "https://example.com")
 	assert.ErrorIs(t, err, ErrDisabled)
 }
 
 func newTestFetcher(cfg Config) *Fetcher {
-	f := NewFetcher(cfg, nil)
+	f := NewFetcher(cfg, nil, "")
 	f.SetHTTPClient(&http.Client{Timeout: f.client.Timeout})
 	return f
 }
@@ -85,7 +85,7 @@ func TestFetcher_RequireContentLength(t *testing.T) {
 
 func TestFetcher_PrivateIP(t *testing.T) {
 	// SSRF チェック付きの Fetcher を使う (newTestFetcher ではなく NewFetcher)
-	f := NewFetcher(Config{Enabled: true, AllowRedirect: true, TimeoutMs: 5000, MaxContentLength: 1 << 20}, nil)
+	f := NewFetcher(Config{Enabled: true, AllowRedirect: true, TimeoutMs: 5000, MaxContentLength: 1 << 20}, nil, "")
 	_, err := f.Fetch(context.Background(), "http://127.0.0.1:9999/test")
 	assert.ErrorIs(t, err, ErrPrivateIP)
 }
@@ -111,7 +111,7 @@ func TestFetcher_ViaProxy(t *testing.T) {
 	}))
 	defer proxy.Close()
 
-	f := NewFetcher(Config{Enabled: true, SummaryProxyURL: proxy.URL, TimeoutMs: 5000, MaxContentLength: 1 << 20}, nil)
+	f := NewFetcher(Config{Enabled: true, SummaryProxyURL: proxy.URL, TimeoutMs: 5000, MaxContentLength: 1 << 20}, nil, "")
 	result, err := f.Fetch(context.Background(), "https://example.com")
 	require.NoError(t, err)
 	assert.Equal(t, "https://example.com", result.URL)
@@ -125,7 +125,7 @@ func TestFetcher_NoRedirect(t *testing.T) {
 
 	// AllowRedirect=false のとき 302 で止まる。SSRF チェックを外すために
 	// newTestFetcher は使えないので直接 client を差し替える。
-	f := NewFetcher(Config{Enabled: true, AllowRedirect: false, TimeoutMs: 5000, MaxContentLength: 1 << 20}, nil)
+	f := NewFetcher(Config{Enabled: true, AllowRedirect: false, TimeoutMs: 5000, MaxContentLength: 1 << 20}, nil, "")
 	f.SetHTTPClient(&http.Client{
 		Timeout:       f.client.Timeout,
 		CheckRedirect: f.client.CheckRedirect,

--- a/internal/server/router.go
+++ b/internal/server/router.go
@@ -189,7 +189,9 @@ func (s *Server) setupRoutes() {
 	followingService := corefollowing.NewService(userRepo, followingRepo, followRequestRepo, idGen)
 
 	// Timeline services (Redis-backed fanout)
-	fanoutTimelineService := coretimeline.NewFanoutTimelineService(s.redis.Timelines, idGen)
+	// keyPrefix で TS 本家と同じ `<host>:list:*` 名前空間に揃える (#362)。
+	fanoutTimelineService := coretimeline.NewFanoutTimelineService(
+		s.redis.Timelines, idGen, s.config.RedisForTimelines.KeyPrefix())
 	timelineService := coretimeline.NewService(fanoutTimelineService, noteRepo, followingRepo)
 	timelineFanoutHook := coretimeline.NewFanoutHook(fanoutTimelineService, followingRepo)
 	// Phase DB-compat (#51): meta から timeline cache cap を動的に読む。
@@ -238,7 +240,8 @@ func (s *Server) setupRoutes() {
 	}
 
 	// Notifications (Redis Streams)
-	notificationService := corenotification.NewService(s.redis.Default, idGen)
+	// keyPrefix で TS 本家と同じ `<host>:notificationTimeline:*` 等に揃える (#362)。
+	notificationService := corenotification.NewService(s.redis.Default, idGen, s.config.Redis.KeyPrefix())
 	notificationService.SetNoteUnreadRepo(noteUnreadRepo)
 	notificationHook := corenotification.NewHook(notificationService, userRepo)
 	notificationHook.SetNoteUnreadRepo(noteUnreadRepo)
@@ -622,7 +625,7 @@ func (s *Server) setupRoutes() {
 		if previewMeta.URLPreviewSummaryProxyURL != nil {
 			previewCfg.SummaryProxyURL = *previewMeta.URLPreviewSummaryProxyURL
 		}
-		urlPreviewFetcher := coreurlpreview.NewFetcher(previewCfg, s.redis.Default)
+		urlPreviewFetcher := coreurlpreview.NewFetcher(previewCfg, s.redis.Default, s.config.Redis.KeyPrefix())
 		urlHandler := apiurl.NewHandler(urlPreviewFetcher)
 		s.echo.GET("/url", urlHandler.Preview)
 	}


### PR DESCRIPTION
## Summary

#362 で報告された TS ↔ mk drop-in 切替の互換ギャップに対応する。

- **Issue A (Redis key namespace)**: TS は ioredis `keyPrefix: <host>:` で
  全キーをホスト名空間に配置するが、mk-go はこの prefix を無視して
  `list:homeTimeline:*` のように bare なキーを書き込んでいたため、
  同一 Valkey を共有した drop-in 切替でタイムライン等のキャッシュが退行する。
- **Issue B (HTML→MFM)**: 既に `#330` (`ef5b14649`) で `mfm.FromHTML()` 実装済で、
  `IngestNote` / `UpdateRemoteNote` 両方で適用されている。#362 で報告された
  具体的な HTML パターン 4 種全てを正しく変換することを検証し、regression test
  として追加した。

## 主な変更点

### Issue A: Redis keyPrefix 対応

| ファイル | 変更 |
|---------|------|
| `internal/config/config.go` | `RedisOptions.KeyPrefix()` ヘルパー追加 (`prefix` 空なら `""`, 非空なら `prefix+":"` を返す) |
| `internal/core/timeline/fanout_timeline_service.go` | `keyPrefix` field + `NewFanoutTimelineService(client, idGen, keyPrefix)` に変更。`key()` で前置 |
| `internal/core/notification/notification_service.go` | `keyPrefix` field 追加、`streamKey`/`readKey` を method 化して前置 |
| `internal/core/urlpreview/fetcher.go` | `keyPrefix` field 追加、`Fetch` でキャッシュキーに前置 |
| `internal/server/router.go` | 各 `New*` に `s.config.Redis.KeyPrefix()` / `s.config.RedisForTimelines.KeyPrefix()` を配線 |

TS 本家と同じ `<host>:list:homeTimeline:*`, `<host>:notificationTimeline:*` 形式で
キーを構築するため drop-in 切替で TS が書いた最新キャッシュを読めるようになる。

### Issue B: 回帰テスト追加

| ファイル | 変更 |
|---------|------|
| `internal/activitypub/mfm/from_html_test.go` | #362 報告 HTML パターン 4 件を追加 (`<p class=\"quote-inline\">RE:...</p><p>...</p>`, h-card mention + 本文, 連続 `<br />`, span wrapper) |

### 残る既知制限

- `asynq` (job queue) は BullMQ と完全別系統のため prefix 対応不可能。#362 でも
  フォールバック容認が明示されている。
- `core/chart/lock.go`, `core/reversi`, `core/twofactor/webauthn.go`,
  `core/webpush`, `core/reaction/count_writer.go`, `core/event/pubsub.go` 等
  mk 固有キーへの prefix 適用は follow-up (hygiene だが drop-in 切替の致命的
  ブロッカーではない)。

## テスト

- `TestRedisOptions_KeyPrefix` (3 cases)
- `TestFanoutTimelineService_KeyPrefix` / `TestFanoutTimelineService_KeyPrefixEmpty`
- `TestService_KeyPrefix` (notification stream + read key 両方検証)
- `TestFromHTML` に #362 regression 4 件追加

カバレッジ:
- `timeline`: 96.4%
- `notification`: 91.6%
- `urlpreview`: 90.2%
- `config`: 96.2%
- `activitypub/mfm`: 91.1%

```bash
make fmt && make lint  # OK
go test ./internal/core/timeline/ ./internal/core/notification/ \
        ./internal/core/urlpreview/ ./internal/config/ \
        ./internal/activitypub/mfm/ -count=1  # ALL PASS
```

Closes #362

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/shiroha-a/mk/pull/363" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
