### PR TITLE
Phase 13-1: drop-in e2e 基盤 (Misskey TS 2 インスタンス federation smoke test)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -52,3 +52,4 @@ tests/bench/results/*.md
 
 # Claude Code local state
 .claude/
+__pycache__/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -121,6 +121,12 @@ make migrate-create         # 新規マイグレーションファイル作成�
 make docker-build
 make docker-up              # docker compose up -d
 make docker-down
+
+# Drop-in e2e (#364 / #365) — Misskey TS 2 インスタンスを立ち上げて
+# TS ↔ mk 切替互換性を検証する基盤。詳細は docs/dropin-e2e.md。
+make dropin-up              # TS-A / TS-B stack 起動
+make dropin-test            # pytest smoke test 実行
+make dropin-down            # stack + volume 全削除
 ```
 
 エントリポイント：
@@ -407,6 +413,7 @@ Issueの作成・操作には`gh`コマンドを使う（`gh issue create`, `gh 
 
 本ドキュメントの主要な変更履歴。新規変更時は一番上に追記する（日付降順）。
 
+- **2026-04-21**: drop-in e2e テスト基盤 Phase 13-1 (#365) を追加。`docker-compose.dropin.yml` と `tests/dropin/` で Misskey TS 2 インスタンスを立ち上げ、pytest で federation smoke test を実行する。Phase 13-2 で mk 差し替え overlay を追加予定。
 - **2026-04-20**: CIの`test`ジョブを4-way matrix shardで並列化。総実行時間を約4.7分→約1.5-2分に短縮。各shardは独立サービスコンテナで動作し、ImportPath順modulo分配で決定的にパッケージを割り当てる。
 - **2026-04-18**: `internal/repository`パッケージのテストを拡充しカバレッジを76.4%→99.9%に引き上げ、CI閾値を90%に戻す。`internal/api/admin`の閾値を60%→80%に引き上げ(現状83.8%)。CI step "Run all tests with coverage"に`set -o pipefail`を追加してテスト失敗の握り潰し解消 (#260)。
 - **2026-04-18**: `internal/repository`パッケージのCIカバレッジ閾値を暫定的に76%に緩和（#260で90%復帰予定）。

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,7 @@
 .PHONY: build run dev clean tidy test fmt lint migrate-up migrate-down migrate-create \
 	federation-misskey-build federation-misskey-up federation-misskey-test \
 	federation-misskey-down federation-misskey-logs \
+	dropin-up dropin-down dropin-test dropin-logs \
 	e2e-submodule-init e2e-frontend-build e2e-deps e2e-run e2e-open \
 	uds-init uds-frontend-build uds-build uds-up uds-down uds-down-v uds-logs uds-ps \
 	bench-up bench-run bench-down bench-logs
@@ -84,6 +85,23 @@ federation-misskey-down:
 
 federation-misskey-logs:
 	docker compose -f $(FEDERATION_MISSKEY_COMPOSE) logs -f
+
+# Drop-in e2e (#365) ― Misskey TS 2 インスタンス (A, B) を立ち上げて
+# 連合基盤を検証する。Phase 13-1 では TS ↔ TS の smoke test のみ。
+# Phase 13-2 以降で mk 差し替え overlay を追加する予定。
+DROPIN_COMPOSE=docker-compose.dropin.yml
+
+dropin-up:
+	docker compose -f $(DROPIN_COMPOSE) up -d --build
+
+dropin-test:
+	docker compose -f $(DROPIN_COMPOSE) --profile test run --rm test-runner
+
+dropin-down:
+	docker compose -f $(DROPIN_COMPOSE) down -v
+
+dropin-logs:
+	docker compose -f $(DROPIN_COMPOSE) logs -f
 
 # Cypress e2e ― Misskey 本家の cypress spec を mk-go に向けて実行する。
 #

--- a/docker-compose.dropin.yml
+++ b/docker-compose.dropin.yml
@@ -53,6 +53,14 @@ services:
         condition: service_healthy
     volumes:
       - ./tests/dropin/instance_a.yml:/misskey/.config/default.yml:ro
+    # POST /api/ping が pong を返すまでを healthy と判定する。Misskey TS は
+    # 起動に 20-60s かかるので start_period に余裕を持たせる。
+    healthcheck:
+      test: ["CMD-SHELL", "curl -fsS -X POST -H 'Content-Type: application/json' -d '{}' http://localhost:3000/api/ping | grep -q pong"]
+      interval: 5s
+      timeout: 5s
+      retries: 30
+      start_period: 30s
     networks:
       - dropin
 
@@ -62,8 +70,10 @@ services:
       - ./tests/dropin/nginx_a.conf:/etc/nginx/nginx.conf:ro
       - certs:/certs:ro
     depends_on:
+      # service_healthy にすることで Misskey 初期化中に nginx が 502 を
+      # 返す窓を消す (Devin #366 round-2)。
       app-a:
-        condition: service_started
+        condition: service_healthy
       # certs は one-shot コンテナなので start ではなく完了を待たないと
       # /certs/a.crt が無いまま nginx が起動してクラッシュする (Devin #366 #1)。
       certs:
@@ -109,6 +119,12 @@ services:
         condition: service_healthy
     volumes:
       - ./tests/dropin/instance_b.yml:/misskey/.config/default.yml:ro
+    healthcheck:
+      test: ["CMD-SHELL", "curl -fsS -X POST -H 'Content-Type: application/json' -d '{}' http://localhost:3000/api/ping | grep -q pong"]
+      interval: 5s
+      timeout: 5s
+      retries: 30
+      start_period: 30s
     networks:
       - dropin
 
@@ -119,7 +135,7 @@ services:
       - certs:/certs:ro
     depends_on:
       app-b:
-        condition: service_started
+        condition: service_healthy
       certs:
         condition: service_completed_successfully
     networks:

--- a/docker-compose.dropin.yml
+++ b/docker-compose.dropin.yml
@@ -62,8 +62,12 @@ services:
       - ./tests/dropin/nginx_a.conf:/etc/nginx/nginx.conf:ro
       - certs:/certs:ro
     depends_on:
-      - app-a
-      - certs
+      app-a:
+        condition: service_started
+      # certs は one-shot コンテナなので start ではなく完了を待たないと
+      # /certs/a.crt が無いまま nginx が起動してクラッシュする (Devin #366 #1)。
+      certs:
+        condition: service_completed_successfully
     networks:
       dropin:
         aliases:
@@ -114,8 +118,10 @@ services:
       - ./tests/dropin/nginx_b.conf:/etc/nginx/nginx.conf:ro
       - certs:/certs:ro
     depends_on:
-      - app-b
-      - certs
+      app-b:
+        condition: service_started
+      certs:
+        condition: service_completed_successfully
     networks:
       dropin:
         aliases:

--- a/docker-compose.dropin.yml
+++ b/docker-compose.dropin.yml
@@ -1,0 +1,158 @@
+# Drop-in e2e test stack: Misskey TS instance A ↔ Misskey TS instance B.
+#
+# Phase 13-1 (#365) lays the baseline for Phase 13-2 where instance A's
+# backend is swapped with mk-go against the same DB/Redis to verify drop-in
+# compatibility. For now both backends are Misskey TS so the suite just
+# confirms that federation works end-to-end under self-signed TLS.
+#
+# Run via `make dropin-up` / `make dropin-test` / `make dropin-down`.
+
+services:
+  # ── Certificate Generator ──────────────────────────────────
+  certs:
+    image: alpine:3.21
+    command: >
+      sh -c "apk add --no-cache openssl >/dev/null 2>&1 && /gen-certs.sh"
+    volumes:
+      - certs:/certs
+      - ./tests/dropin/gen-certs.sh:/gen-certs.sh:ro
+
+  # ── Instance A (Misskey TS) ────────────────────────────────
+  postgres-a:
+    image: postgres:16-alpine
+    environment:
+      POSTGRES_DB: misskey
+      POSTGRES_USER: misskey
+      POSTGRES_PASSWORD: testpass
+    healthcheck:
+      test: pg_isready -U misskey
+      interval: 3s
+      timeout: 3s
+      retries: 10
+    networks:
+      - dropin
+
+  redis-a:
+    image: redis:7-alpine
+    healthcheck:
+      test: redis-cli ping
+      interval: 3s
+      timeout: 3s
+      retries: 10
+    networks:
+      - dropin
+
+  app-a:
+    image: misskey/misskey:2025.2.1
+    environment:
+      NODE_TLS_REJECT_UNAUTHORIZED: "0"
+    depends_on:
+      postgres-a:
+        condition: service_healthy
+      redis-a:
+        condition: service_healthy
+    volumes:
+      - ./tests/dropin/instance_a.yml:/misskey/.config/default.yml:ro
+    networks:
+      - dropin
+
+  nginx-a:
+    image: nginx:alpine
+    volumes:
+      - ./tests/dropin/nginx_a.conf:/etc/nginx/nginx.conf:ro
+      - certs:/certs:ro
+    depends_on:
+      - app-a
+      - certs
+    networks:
+      dropin:
+        aliases:
+          - a
+
+  # ── Instance B (Misskey TS) ────────────────────────────────
+  postgres-b:
+    image: postgres:16-alpine
+    environment:
+      POSTGRES_DB: misskey
+      POSTGRES_USER: misskey
+      POSTGRES_PASSWORD: testpass
+    healthcheck:
+      test: pg_isready -U misskey
+      interval: 3s
+      timeout: 3s
+      retries: 10
+    networks:
+      - dropin
+
+  redis-b:
+    image: redis:7-alpine
+    healthcheck:
+      test: redis-cli ping
+      interval: 3s
+      timeout: 3s
+      retries: 10
+    networks:
+      - dropin
+
+  app-b:
+    image: misskey/misskey:2025.2.1
+    environment:
+      NODE_TLS_REJECT_UNAUTHORIZED: "0"
+    depends_on:
+      postgres-b:
+        condition: service_healthy
+      redis-b:
+        condition: service_healthy
+    volumes:
+      - ./tests/dropin/instance_b.yml:/misskey/.config/default.yml:ro
+    networks:
+      - dropin
+
+  nginx-b:
+    image: nginx:alpine
+    volumes:
+      - ./tests/dropin/nginx_b.conf:/etc/nginx/nginx.conf:ro
+      - certs:/certs:ro
+    depends_on:
+      - app-b
+      - certs
+    networks:
+      dropin:
+        aliases:
+          - b
+
+  # ── Test Runner ────────────────────────────────────────────
+  test-runner:
+    profiles: ["test"]
+    # 既存の tests/federation/common/Dockerfile は pytest + httpx + 共通
+    # conftest_base をインストールする。そのまま流用する。
+    build:
+      context: ./tests/federation
+      dockerfile: common/Dockerfile
+    environment:
+      A_URL: https://a
+      B_URL: https://b
+      A_DOMAIN: a
+      B_DOMAIN: b
+      PYTHONDONTWRITEBYTECODE: "1"
+    volumes:
+      # drop-in テストはルートとして tests/dropin を参照するが、shared
+      # `conftest_base.py` は tests/federation/common/ にあるので両方を
+      # マウントする (tests/dropin/conftest.py が sys.path に追加する)。
+      - ./tests/dropin:/tests/dropin:ro
+      - ./tests/federation/common:/tests/federation_common:ro
+    working_dir: /tests/dropin
+    depends_on:
+      nginx-a:
+        condition: service_started
+      nginx-b:
+        condition: service_started
+    networks:
+      - dropin
+
+volumes:
+  certs:
+
+networks:
+  dropin:
+    driver: bridge

--- a/docker-compose.federation.misskey.yml
+++ b/docker-compose.federation.misskey.yml
@@ -118,8 +118,13 @@ services:
       - ./tests/federation/misskey/nginx-misskey-ssl.conf:/etc/nginx/nginx.conf:ro
       - certs:/certs:ro
     depends_on:
-      - misskey-app
-      - certs
+      misskey-app:
+        condition: service_started
+      # certs は one-shot コンテナなので start ではなく完了を待たないと
+      # /certs/misskey.crt が無いまま nginx が起動してクラッシュする
+      # (Devin #366 で同種 race を発見し dropin と同時に修正)。
+      certs:
+        condition: service_completed_successfully
     networks:
       federation:
         aliases:

--- a/docs/dropin-e2e.md
+++ b/docs/dropin-e2e.md
@@ -1,0 +1,70 @@
+# Drop-in e2e テスト (#364, Phase 13-1〜)
+
+Misskey TS から mk-go への **drop-in 切替互換** を自動検証する e2e テスト基盤。
+#362 で露呈した Redis キー名前空間違い / HTML→MFM 変換の取りこぼしのような
+互換ギャップを、手動テストに頼らず CI / on-demand で再発検知することを目的とする。
+
+## 構成
+
+```
+tests/dropin/
+  gen-certs.sh        # 自己署名証明書 (a, b 用)
+  instance_a.yml      # Misskey TS 設定 (instance A)
+  instance_b.yml      # Misskey TS 設定 (instance B)
+  nginx_a.conf        # SSL 前段 (a domain)
+  nginx_b.conf        # SSL 前段 (b domain)
+  conftest.py         # pytest fixtures (tests/federation/common/ の Client を再利用)
+  test_smoke.py       # Phase 13-1 の smoke test
+
+docker-compose.dropin.yml  # TS-A / TS-B stack
+```
+
+### なぜ共通 harness が `tests/federation/common/` にあるのか
+
+mk-go は既に `tests/federation/` で mk-go ↔ Misskey TS 連合テストを持っており、
+そこに `MisskeyLikeClient` (httpx ベース) が整備済である。drop-in テストは
+さらに TS ↔ TS (後続フェーズで TS ↔ mk) に広げるだけなので client は共有する。
+
+## 実行方法
+
+すべて docker compose 経由。ホストに pnpm / Python をインストールしない。
+
+```bash
+# 1. インスタンス起動 (初回は misskey/misskey image の pull で数分)
+make dropin-up
+
+# 2. smoke test 実行
+make dropin-test
+
+# 3. 片付け (volume まで削除)
+make dropin-down
+
+# (任意) ログ追跡
+make dropin-logs
+```
+
+## Phase 進捗
+
+- [x] Phase 13-1 (#365): TS ↔ TS 基盤 + smoke test (本ドキュメント)
+- [ ] Phase 13-2: mk-go 差し替え overlay
+- [ ] Phase 13-3: 機能マトリクス (ノート / リアクション / カスタム絵文字 / タイムライン退行検出 / 通知)
+- [ ] Phase 13-4: CI nightly 統合
+
+## トラブルシューティング
+
+### `misskey/misskey:2025.2.1` が pull できない
+
+`docker login` 等の認証不要。pull が失敗する場合は network / rate limit。
+compose 内で pull を再試行するか `docker pull misskey/misskey:2025.2.1` で
+先読みしておく。
+
+### 連合 follow が timeout する
+
+両 instance が互いに到達できる必要がある。`make dropin-logs` で nginx / app の
+エラーを確認する。自己署名証明書のため app-a / app-b は
+`NODE_TLS_REJECT_UNAUTHORIZED=0` で起動している。
+
+### 残ったリソースが後続テストを汚染する
+
+`make dropin-down` が volume まで削除する (`down -v`)。named volume `certs` も
+同時に削除されるため、次回 `dropin-up` で再生成される。

--- a/tests/dropin/conftest.py
+++ b/tests/dropin/conftest.py
@@ -1,0 +1,66 @@
+"""Pytest fixtures for the drop-in e2e suite (#365).
+
+Two Misskey TS instances (A, B) run against their own Postgres / Redis pair
+and federate via self-signed TLS. Phase 13-1 only verifies that this
+baseline federates correctly; Phase 13-2 will add an overlay that swaps
+instance A's backend with mk-go.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+
+import pytest
+
+# `tests/federation/common/` is mounted at /tests/federation_common in the
+# test-runner (see docker-compose.dropin.yml). Reuse `conftest_base.py`
+# since mk-go's federation suite already maintains a
+# Misskey-compatible API client there.
+_COMMON_DIR = "/tests/federation_common"
+if os.path.isdir(_COMMON_DIR) and _COMMON_DIR not in sys.path:
+    sys.path.insert(0, _COMMON_DIR)
+else:
+    # Local/host runs (no docker mount) fall back to the repo path so the
+    # suite can be imported by linters or type-checkers.
+    _LOCAL_COMMON = os.path.abspath(
+        os.path.join(os.path.dirname(__file__), "..", "federation", "common")
+    )
+    if _LOCAL_COMMON not in sys.path:
+        sys.path.insert(0, _LOCAL_COMMON)
+
+from conftest_base import MisskeyLikeClient, wait_for_health  # noqa: E402
+
+A_URL = os.environ.get("A_URL", "https://a")
+B_URL = os.environ.get("B_URL", "https://b")
+A_DOMAIN = os.environ.get("A_DOMAIN", "a")
+B_DOMAIN = os.environ.get("B_DOMAIN", "b")
+
+
+@pytest.fixture(scope="session", autouse=True)
+def wait_for_instances() -> None:
+    """Block until both TS instances can accept API requests."""
+    wait_for_health(A_URL, "/api/ping", method="POST")
+    wait_for_health(B_URL, "/api/ping", method="POST")
+
+
+@pytest.fixture(scope="session")
+def instance_a() -> MisskeyLikeClient:
+    return MisskeyLikeClient(A_URL, A_DOMAIN)
+
+
+@pytest.fixture(scope="session")
+def instance_b() -> MisskeyLikeClient:
+    return MisskeyLikeClient(B_URL, B_DOMAIN)
+
+
+@pytest.fixture(scope="session")
+def alice(instance_a: MisskeyLikeClient) -> dict:
+    """Root user on instance A."""
+    return instance_a.create_admin("alice", "password1234")
+
+
+@pytest.fixture(scope="session")
+def bob(instance_b: MisskeyLikeClient) -> dict:
+    """Root user on instance B."""
+    return instance_b.create_admin("bob", "password1234")

--- a/tests/dropin/gen-certs.sh
+++ b/tests/dropin/gen-certs.sh
@@ -1,0 +1,24 @@
+#!/bin/sh
+# Generate self-signed certs for the two drop-in test instances (`a`, `b`).
+# Mirrors tests/federation/common/gen-certs.sh but with different domains —
+# keeping it separate avoids cross-suite coupling if the federation suite
+# changes its domain set later.
+set -e
+
+CERT_DIR=/certs
+mkdir -p "$CERT_DIR"
+
+DOMAINS="a b"
+
+for domain in $DOMAINS; do
+  if [ ! -f "$CERT_DIR/$domain.crt" ]; then
+    openssl req -x509 -newkey rsa:2048 -nodes \
+      -keyout "$CERT_DIR/$domain.key" \
+      -out "$CERT_DIR/$domain.crt" \
+      -days 1 \
+      -subj "/CN=$domain" \
+      -addext "subjectAltName=DNS:$domain" \
+      2>/dev/null
+    echo "Generated cert for $domain"
+  fi
+done

--- a/tests/dropin/instance_a.yml
+++ b/tests/dropin/instance_a.yml
@@ -1,0 +1,35 @@
+url: https://a/
+port: 3000
+
+db:
+  host: postgres-a
+  port: 5432
+  db: misskey
+  user: misskey
+  pass: testpass
+
+redis:
+  host: redis-a
+  port: 6379
+
+redisForPubsub:
+  host: redis-a
+  port: 6379
+
+redisForJobQueue:
+  host: redis-a
+  port: 6379
+
+redisForTimelines:
+  host: redis-a
+  port: 6379
+
+id: aidx
+
+# Misskey enforces allowedPrivateNetworks for outgoing HTTP, so we must
+# allow docker-internal ranges for federation between containers.
+allowedPrivateNetworks:
+  - 127.0.0.0/8
+  - 10.0.0.0/8
+  - 172.16.0.0/12
+  - 192.168.0.0/16

--- a/tests/dropin/instance_b.yml
+++ b/tests/dropin/instance_b.yml
@@ -1,0 +1,35 @@
+url: https://b/
+port: 3000
+
+db:
+  host: postgres-b
+  port: 5432
+  db: misskey
+  user: misskey
+  pass: testpass
+
+redis:
+  host: redis-b
+  port: 6379
+
+redisForPubsub:
+  host: redis-b
+  port: 6379
+
+redisForJobQueue:
+  host: redis-b
+  port: 6379
+
+redisForTimelines:
+  host: redis-b
+  port: 6379
+
+id: aidx
+
+# Misskey enforces allowedPrivateNetworks for outgoing HTTP, so we must
+# allow docker-internal ranges for federation between containers.
+allowedPrivateNetworks:
+  - 127.0.0.0/8
+  - 10.0.0.0/8
+  - 172.16.0.0/12
+  - 192.168.0.0/16

--- a/tests/dropin/nginx_a.conf
+++ b/tests/dropin/nginx_a.conf
@@ -1,0 +1,29 @@
+events {
+    worker_connections 1024;
+}
+
+http {
+    upstream a_backend {
+        server app-a:3000;
+    }
+
+    server {
+        listen 443 ssl;
+        server_name _;
+        client_max_body_size 10M;
+
+        ssl_certificate /certs/a.crt;
+        ssl_certificate_key /certs/a.key;
+
+        location / {
+            proxy_pass http://a_backend;
+            proxy_set_header Host $host;
+            proxy_set_header X-Real-IP $remote_addr;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header X-Forwarded-Proto https;
+            proxy_http_version 1.1;
+            proxy_set_header Upgrade $http_upgrade;
+            proxy_set_header Connection "upgrade";
+        }
+    }
+}

--- a/tests/dropin/nginx_b.conf
+++ b/tests/dropin/nginx_b.conf
@@ -1,0 +1,29 @@
+events {
+    worker_connections 1024;
+}
+
+http {
+    upstream b_backend {
+        server app-b:3000;
+    }
+
+    server {
+        listen 443 ssl;
+        server_name _;
+        client_max_body_size 10M;
+
+        ssl_certificate /certs/b.crt;
+        ssl_certificate_key /certs/b.key;
+
+        location / {
+            proxy_pass http://b_backend;
+            proxy_set_header Host $host;
+            proxy_set_header X-Real-IP $remote_addr;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header X-Forwarded-Proto https;
+            proxy_http_version 1.1;
+            proxy_set_header Upgrade $http_upgrade;
+            proxy_set_header Connection "upgrade";
+        }
+    }
+}

--- a/tests/dropin/test_smoke.py
+++ b/tests/dropin/test_smoke.py
@@ -1,0 +1,113 @@
+"""Smoke tests for Phase 13-1 (#365): verify TS-A ↔ TS-B federation baseline.
+
+These tests are the foundation that Phase 13-2 (mk swap) and Phase 13-3
+(feature matrix) build on. If these fail, nothing else in the drop-in suite
+can be trusted, so keep the scope deliberately small: health, federation
+follow, and one-hop note delivery.
+"""
+
+from __future__ import annotations
+
+from conftest import A_DOMAIN, B_DOMAIN  # type: ignore[import-not-found]
+from conftest_base import MisskeyLikeClient, poll_until  # type: ignore[import-not-found]
+
+
+class TestHealth:
+    """Both instances return a 200 from /api/ping."""
+
+    def test_instance_a_healthy(self, instance_a: MisskeyLikeClient, alice: dict) -> None:
+        assert instance_a.ping() is True
+
+    def test_instance_b_healthy(self, instance_b: MisskeyLikeClient, bob: dict) -> None:
+        assert instance_b.ping() is True
+
+
+class TestWebFinger:
+    """Each instance responds to its own webfinger and to cross-host lookups."""
+
+    def test_a_webfinger_local(self, instance_a: MisskeyLikeClient, alice: dict) -> None:
+        result = instance_a.webfinger(f"alice@{A_DOMAIN}")
+        assert result["subject"] == f"acct:alice@{A_DOMAIN}"
+
+    def test_b_webfinger_local(self, instance_b: MisskeyLikeClient, bob: dict) -> None:
+        result = instance_b.webfinger(f"bob@{B_DOMAIN}")
+        assert result["subject"] == f"acct:bob@{B_DOMAIN}"
+
+
+class TestFederationFollow:
+    """
+    Verify that instance A can follow a remote user on instance B via
+    ActivityPub. This is the minimal handshake that proves federation is
+    reachable under the self-signed TLS setup.
+    """
+
+    def test_alice_follows_bob(
+        self,
+        instance_a: MisskeyLikeClient,
+        instance_b: MisskeyLikeClient,
+        alice: dict,
+        bob: dict,
+    ) -> None:
+        # Instance A resolves bob@b via AP.
+        remote_bob = poll_until(
+            lambda: instance_a.users_show("bob", host=B_DOMAIN),
+            timeout=60,
+            desc="alice sees bob via AP",
+        )
+        assert remote_bob["username"] == "bob"
+        assert remote_bob["host"] == B_DOMAIN
+
+        try:
+            instance_a.follow(remote_bob["id"])
+        except RuntimeError as e:
+            # 前回 run の follow が残っていても許容 (docker compose down で
+            # volume ごと消すのが通常運用だが、手元検証を繰り返すと状態が
+            # 残りうる)。
+            if "ALREADY_FOLLOWING" not in str(e):
+                raise
+
+        # Instance B should register the follow within its inbox delivery window.
+        # `users/followers` response shape は Misskey バージョンで揺れるので、
+        # 複数キーをフォールバック的に見る。
+        def _followed() -> bool:
+            followers = instance_b._api("users/followers", {"userId": bob["id"]})
+            for f in followers:
+                follower = f.get("follower") or f
+                host = follower.get("host") or follower.get("followerHost")
+                if host == A_DOMAIN:
+                    return True
+            return False
+
+        assert poll_until(_followed, timeout=60, desc="bob sees alice as follower")
+
+
+class TestFederationNoteDelivery:
+    """
+    After the follow handshake above, a note from bob should federate into
+    alice's home timeline within a reasonable delivery window.
+    """
+
+    def test_bob_note_reaches_alice(
+        self,
+        instance_a: MisskeyLikeClient,
+        instance_b: MisskeyLikeClient,
+        alice: dict,
+        bob: dict,
+    ) -> None:
+        # Ensure alice follows bob (idempotent because of the test above).
+        remote_bob = instance_a.users_show("bob", host=B_DOMAIN)
+        try:
+            instance_a.follow(remote_bob["id"])
+        except RuntimeError:
+            # Already following is fine.
+            pass
+
+        marker = "dropin-smoke-" + bob["id"][-6:]
+        bob_note = instance_b.create_note(marker)
+
+        def _arrived() -> bool:
+            tl = instance_a._api("notes/timeline", {"limit": 40})
+            return any(n.get("text") == marker for n in tl)
+
+        assert poll_until(_arrived, timeout=90, desc="alice sees bob's note")
+        assert bob_note["createdNote"]["text"] == marker

--- a/tests/dropin/test_smoke.py
+++ b/tests/dropin/test_smoke.py
@@ -98,9 +98,11 @@ class TestFederationNoteDelivery:
         remote_bob = instance_a.users_show("bob", host=B_DOMAIN)
         try:
             instance_a.follow(remote_bob["id"])
-        except RuntimeError:
-            # Already following is fine.
-            pass
+        except RuntimeError as e:
+            # ALREADY_FOLLOWING のみ許容。それ以外 (network error, rate limit
+            # 等) はそのまま raise して原因を露呈させる (Devin #366 #2)。
+            if "ALREADY_FOLLOWING" not in str(e):
+                raise
 
         marker = "dropin-smoke-" + bob["id"][-6:]
         bob_note = instance_b.create_note(marker)


### PR DESCRIPTION
## Summary

#364 (Phase 13 drop-in e2e) のサブ 1。TS ↔ mk 切替互換性の自動検証基盤の
第 1 段階として、**Misskey TS 2 インスタンス間で federation が成立する stack**
を整備する。これが動いて初めて後続フェーズ (mk 差し替え、機能マトリクス検証、
CI 統合) に進める。

## 主な変更点

### 新規ファイル

| ファイル | 内容 |
|---------|------|
| `docker-compose.dropin.yml` | TS-A / TS-B + 各々独立の Postgres/Redis + nginx SSL 前段 + 自己署名証明書 + pytest runner |
| `tests/dropin/instance_a.yml` / `instance_b.yml` | Misskey TS インスタンス設定 |
| `tests/dropin/nginx_a.conf` / `nginx_b.conf` | SSL 前段 (alias: `a` / `b`) |
| `tests/dropin/gen-certs.sh` | `a.crt` / `b.crt` の自己署名生成 |
| `tests/dropin/conftest.py` | pytest fixtures (instance_a / instance_b / alice / bob) |
| `tests/dropin/test_smoke.py` | smoke test 6 ケース |
| `docs/dropin-e2e.md` | 運用手順 |

### 既存への変更

- `Makefile`: `dropin-up` / `dropin-test` / `dropin-down` / `dropin-logs`
- `CLAUDE.md`: Development Commands + 更新記録に追記
- `.gitignore`: `__pycache__/` 追加

### 設計

- Python pytest harness は `tests/federation/common/conftest_base.py` の
  `MisskeyLikeClient` を再利用。mk-go ↔ TS federation テストで既に
  整備済みなので重複実装しない。
- `docker-compose.dropin.yml` の `test-runner` が `tests/dropin` を
  working_dir にして `tests/federation/common` を sys.path に足す。
- 自己署名証明書は Phase ごとに別ディレクトリ (`tests/dropin/gen-certs.sh` は
  `a` / `b` のみ) として federation 側と独立させる。

## テスト

```bash
make dropin-up    # TS-A / TS-B を起動 (初回は misskey image pull で数分)
make dropin-test  # pytest smoke 実行
make dropin-down  # volume ごと片付け
```

### Smoke test 結果 (6/6 PASS)

```
test_smoke.py::TestHealth::test_instance_a_healthy PASSED
test_smoke.py::TestHealth::test_instance_b_healthy PASSED
test_smoke.py::TestWebFinger::test_a_webfinger_local PASSED
test_smoke.py::TestWebFinger::test_b_webfinger_local PASSED
test_smoke.py::TestFederationFollow::test_alice_follows_bob PASSED
test_smoke.py::TestFederationNoteDelivery::test_bob_note_reaches_alice PASSED
========================= 6 passed in 3.41s =========================
```

federation delivery は poll_until で 60-90s 許容。現状 3s 程度で届く。

## Phase 13 全体の残り

- [ ] Phase 13-2: mk-go 差し替え overlay (同じ DB/Redis に mk を向ける)
- [ ] Phase 13-3: 機能マトリクス (reaction / custom emoji / timeline 退行 /
      通知 / userList membership)
- [ ] Phase 13-4: CI nightly 統合

Closes #365

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/shiroha-a/mk/pull/366" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
