### PR TITLE
Phase 13-2: drop-in mk overlay + swap シナリオ test (TS→mk 切替)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -127,6 +127,13 @@ make docker-down
 make dropin-up              # TS-A / TS-B stack 起動
 make dropin-test            # pytest smoke test 実行
 make dropin-down            # stack + volume 全削除
+
+# Drop-in mk overlay + swap test (#367) — instance A の backend を mk-go に
+# 差し替える e2e シナリオ。
+make dropin-mk-up           # base + mk overlay (clean DB から mk-A 起動)
+make dropin-mk-test         # mk-A に対する smoke test
+make dropin-mk-down         # cleanup
+make dropin-swap-test       # TS-then-mk 切替シナリオ (bash orchestrator)
 ```
 
 エントリポイント：
@@ -413,6 +420,7 @@ Issueの作成・操作には`gh`コマンドを使う（`gh issue create`, `gh 
 
 本ドキュメントの主要な変更履歴。新規変更時は一番上に追記する（日付降順）。
 
+- **2026-04-21**: drop-in e2e Phase 13-2 (#367) を追加。`docker-compose.dropin.mk.yml` overlay と `tests/dropin/run-swap-test.sh` orchestrator で「TS-A backend を mk-go に差し替えても DB / Redis 上の state が引き継がれる」ことを e2e 検証する。途中で発覚した `note.pageCount` / `note.renoteChannelId` カラム欠如を `migration/000039_dropin_compat.up.sql` で補填。reply / reaction の federation deliver 不足は別バグ #368 として切り出し、対応する 2 テストは `xfail` 済。
 - **2026-04-21**: drop-in e2e テスト基盤 Phase 13-1 (#365) を追加。`docker-compose.dropin.yml` と `tests/dropin/` で Misskey TS 2 インスタンスを立ち上げ、pytest で federation smoke test を実行する。Phase 13-2 で mk 差し替え overlay を追加予定。
 - **2026-04-20**: CIの`test`ジョブを4-way matrix shardで並列化。総実行時間を約4.7分→約1.5-2分に短縮。各shardは独立サービスコンテナで動作し、ImportPath順modulo分配で決定的にパッケージを割り当てる。
 - **2026-04-18**: `internal/repository`パッケージのテストを拡充しカバレッジを76.4%→99.9%に引き上げ、CI閾値を90%に戻す。`internal/api/admin`の閾値を60%→80%に引き上げ(現状83.8%)。CI step "Run all tests with coverage"に`set -o pipefail`を追加してテスト失敗の握り潰し解消 (#260)。

--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,7 @@
 	federation-misskey-build federation-misskey-up federation-misskey-test \
 	federation-misskey-down federation-misskey-logs \
 	dropin-up dropin-down dropin-test dropin-logs \
+	dropin-mk-up dropin-mk-test dropin-mk-down dropin-mk-logs dropin-swap-test \
 	e2e-submodule-init e2e-frontend-build e2e-deps e2e-run e2e-open \
 	uds-init uds-frontend-build uds-build uds-up uds-down uds-down-v uds-logs uds-ps \
 	bench-up bench-run bench-down bench-logs
@@ -102,6 +103,33 @@ dropin-down:
 
 dropin-logs:
 	docker compose -f $(DROPIN_COMPOSE) logs -f
+
+# Drop-in mk overlay (#367) — instance A の backend を mk-go に差し替えた
+# 状態で TS-A 用 stack を起動する。連合先 (instance B) は TS のままなので
+# mk ↔ TS federation も同時に検証できる。
+DROPIN_MK_OVERLAY=docker-compose.dropin.mk.yml
+
+dropin-mk-up:
+	docker compose -f $(DROPIN_COMPOSE) -f $(DROPIN_MK_OVERLAY) up -d --build
+
+dropin-mk-test:
+	docker compose -f $(DROPIN_COMPOSE) -f $(DROPIN_MK_OVERLAY) --profile test run --rm test-runner
+
+dropin-mk-down:
+	docker compose -f $(DROPIN_COMPOSE) -f $(DROPIN_MK_OVERLAY) down -v
+
+dropin-mk-logs:
+	docker compose -f $(DROPIN_COMPOSE) -f $(DROPIN_MK_OVERLAY) logs -f
+
+# Drop-in swap シナリオ (#367): TS-A → mk-A 切替で state が引き継げることを
+# 検証する end-to-end テスト。bash orchestrator が以下を順次実行する:
+#   1. TS-A + TS-B 起動
+#   2. test_swap_setup.py で alice/bob/follow/note を作る
+#   3. TS-A backend を停止
+#   4. overlay で mk-A 起動 (DB-A / Redis-A はそのまま)
+#   5. test_swap_verify.py で state preserved + 新規 federation を確認
+dropin-swap-test:
+	./tests/dropin/run-swap-test.sh
 
 # Cypress e2e ― Misskey 本家の cypress spec を mk-go に向けて実行する。
 #

--- a/docker-compose.dropin.mk.yml
+++ b/docker-compose.dropin.mk.yml
@@ -1,0 +1,51 @@
+# docker-compose.dropin.mk.yml — Phase 13-2 (#367) overlay.
+#
+# 使い方:
+#   docker compose \
+#     -f docker-compose.dropin.yml \
+#     -f docker-compose.dropin.mk.yml up -d --build
+#
+# このオーバーレイは `app-a` (Misskey TS) を mk-go ビルドに差し替える。
+# postgres-a / redis-a / nginx-a / instance B 系列はベースから引き継ぐので、
+# nginx-a の upstream (`app-a:3000`) はそのまま mk-go を指す。
+#
+# Phase 13-1 (TS-A only) と Phase 13-2 (mk-A) の両方で `app-a` というサービス
+# 名を維持しているのは、nginx config が `upstream a_backend { server app-a:3000; }`
+# のようにハードコードしているため。サービス名を変えると nginx config も書き
+# 換える必要があり、TS↔mk swap シナリオの外科性が損なわれる。
+
+services:
+  app-a:
+    # 既存 TS image を上書きする (compose merge ルールで image / build /
+    # entrypoint が overlay 側に置き換わる)。
+    image: ""
+    build:
+      context: .
+      # 既存の federation 用 Dockerfile を再利用する。migrate と server を
+      # 両方ビルドし、entrypoint で migrate up → server start する構成。
+      # mk-go のマイグレーションは TS schema に対して追加のみで破壊的変更
+      # なし (CLAUDE.md §10) なので、TS-A が書いた DB-A をそのまま読める。
+      dockerfile: tests/federation/common/Dockerfile.mkgo
+    environment:
+      # Go 標準 trust store に dropin 用 self-signed cert を読ませる。
+      # gen-certs.sh が生成する bundle.pem には a / b の両 cert が入っている。
+      SSL_CERT_FILE: /certs/bundle.pem
+      TZ: Asia/Tokyo
+    volumes:
+      - ./tests/dropin/instance_a_mk.yml:/app/.config/default.yml:ro
+      - certs:/certs:ro
+    # mk-go の /healthz は GET なので TS の healthcheck (POST /api/ping) と
+    # 命令が違う。差し替え後は GET /healthz で healthy を判定する。
+    healthcheck:
+      test: ["CMD", "wget", "-qO-", "http://localhost:3000/healthz"]
+      interval: 5s
+      timeout: 5s
+      retries: 30
+      start_period: 30s
+    depends_on:
+      postgres-a:
+        condition: service_healthy
+      redis-a:
+        condition: service_healthy
+      certs:
+        condition: service_completed_successfully

--- a/docs/dropin-e2e.md
+++ b/docs/dropin-e2e.md
@@ -45,10 +45,45 @@ make dropin-logs
 
 ## Phase 進捗
 
-- [x] Phase 13-1 (#365): TS ↔ TS 基盤 + smoke test (本ドキュメント)
-- [ ] Phase 13-2: mk-go 差し替え overlay
+- [x] Phase 13-1 (#365): TS ↔ TS 基盤 + smoke test
+- [x] Phase 13-2 (#367): mk-go 差し替え overlay + swap シナリオ test
 - [ ] Phase 13-3: 機能マトリクス (ノート / リアクション / カスタム絵文字 / タイムライン退行検出 / 通知)
 - [ ] Phase 13-4: CI nightly 統合
+
+## Phase 13-2: mk-go 差し替え (drop-in swap)
+
+`docker-compose.dropin.mk.yml` overlay と bash orchestrator
+(`tests/dropin/run-swap-test.sh`) で「TS-A backend を mk-go に差し替えても DB /
+Redis 上の state がそのまま引き継がれる」ことを e2e で検証する。
+
+### 通常実行
+
+```bash
+# 完全自動の swap シナリオ test (推奨)
+make dropin-swap-test
+
+# orchestrator は以下を順次実行する:
+#   1. TS-A + TS-B stack 起動
+#   2. pytest test_swap_setup.py    (alice/bob/follow/baseline note)
+#   3. docker compose stop app-a    (TS-A backend 停止、DB / Redis は維持)
+#   4. overlay で app-a を mk-go ビルドに差し替えて起動
+#   5. pytest test_swap_verify.py   (timeline 残存、新規 reply / reaction の連合)
+#   6. teardown
+```
+
+### 手動運用 (デバッグ向け)
+
+mk overlay を直接立ち上げて確認したい場合:
+
+```bash
+make dropin-mk-up      # base + overlay (= mk-A + TS-B)
+make dropin-mk-test    # smoke test を mk-A に対して実行
+make dropin-mk-down    # cleanup
+make dropin-mk-logs    # ログ追跡
+```
+
+注意: `dropin-mk-up` は **clean DB** から mk-A を起動するので、TS-A→mk-A の
+state 引き継ぎは検証されない。state 検証は `dropin-swap-test` 専用。
 
 ## トラブルシューティング
 

--- a/migration/000007_antenna.up.sql
+++ b/migration/000007_antenna.up.sql
@@ -1,5 +1,10 @@
--- antenna_src enum: フィードのソースを表す
-CREATE TYPE antenna_src_enum AS ENUM ('home', 'all', 'users', 'list', 'users_blacklist');
+-- antenna_src enum: フィードのソースを表す。
+-- TS Misskey が同名 enum を既に作っているケース (drop-in 切替 #367) でも
+-- migrate up が失敗しないよう duplicate_object を無視する。
+DO $$ BEGIN
+    CREATE TYPE antenna_src_enum AS ENUM ('home', 'all', 'users', 'list', 'users_blacklist');
+EXCEPTION WHEN duplicate_object THEN NULL;
+END $$;
 
 -- antenna: ユーザー作成のキーワード/ユーザベースカスタムフィード (Misskey 互換)
 CREATE TABLE IF NOT EXISTS "antenna" (

--- a/migration/000009_page.up.sql
+++ b/migration/000009_page.up.sql
@@ -1,5 +1,9 @@
--- page_visibility enum
-CREATE TYPE page_visibility_enum AS ENUM ('public', 'followers', 'specified');
+-- page_visibility enum。drop-in 切替 (#367) で TS が既に作成済みの場合
+-- duplicate_object を無視して continue する。
+DO $$ BEGIN
+    CREATE TYPE page_visibility_enum AS ENUM ('public', 'followers', 'specified');
+EXCEPTION WHEN duplicate_object THEN NULL;
+END $$;
 
 -- page: ユーザー作成のページ (Misskey 互換)
 CREATE TABLE IF NOT EXISTS "page" (

--- a/migration/000039_dropin_compat.down.sql
+++ b/migration/000039_dropin_compat.down.sql
@@ -1,0 +1,4 @@
+-- 000039 の down: drop-in 互換のために追加した列を取り除く。本家 TS が
+-- 同名 migration を後から回せば再追加される。
+ALTER TABLE "note" DROP COLUMN IF EXISTS "pageCount";
+ALTER TABLE "note" DROP COLUMN IF EXISTS "renoteChannelId";

--- a/migration/000039_dropin_compat.up.sql
+++ b/migration/000039_dropin_compat.up.sql
@@ -1,0 +1,20 @@
+-- Phase 13-2 (#367) drop-in 互換: TS-A → mk-A 切替で発覚した欠損カラム補填。
+--
+-- mk-go の internal/model/note.go は note テーブルに `pageCount` smallint
+-- (Misskey TS 側で 1755168347001_PageCountInNote として 2025-08 に追加) が
+-- 存在することを前提にしている。一方、それより古い TS バックエンド (例えば
+-- misskey/misskey:2025.2.1) で初期化された DB にはこのカラムが無い。
+--
+-- 000001_initial.up.sql は CREATE TABLE IF NOT EXISTS で note テーブルを作る
+-- が、既に TS-create された note テーブルに対しては no-op となるため
+-- pageCount カラムは追加されない。drop-in 切替時に mk-go が
+-- "column \"pageCount\" of relation \"note\" does not exist" で 500 を返す
+-- 原因になっていた。
+--
+-- ここでは ALTER TABLE ... ADD COLUMN IF NOT EXISTS で冪等に追加する。
+
+ALTER TABLE "note" ADD COLUMN IF NOT EXISTS "pageCount" smallint NOT NULL DEFAULT 0;
+
+-- renoteChannelId: TS 側で channel-renote 機能向けに追加された列。古い TS
+-- にはまだ無いため drop-in 切替で mk-go の INSERT が失敗する。
+ALTER TABLE "note" ADD COLUMN IF NOT EXISTS "renoteChannelId" varchar(32);

--- a/tests/dropin/conftest.py
+++ b/tests/dropin/conftest.py
@@ -54,13 +54,30 @@ def instance_b() -> MisskeyLikeClient:
     return MisskeyLikeClient(B_URL, B_DOMAIN)
 
 
+def _ensure_user_id(client: MisskeyLikeClient, raw: dict) -> dict:
+    """Return raw with an `id` field even if create_admin fell through to signin.
+
+    create_admin returns either:
+    - admin/accounts/create response (fresh): `{id, username, token, ...}`
+    - signin response (existing): `{i: token, finished: true}` (no id)
+
+    Phase 13-2 の swap シナリオでは setup → swap → verify と pytest セッションが
+    分かれるため、後段 (verify) は必ず signin パスに落ちる。`alice["id"]` を
+    使う test_swap_verify.py が動くように /api/i で hydrate する。
+    """
+    if "id" in raw:
+        return raw
+    me = client._api("i")
+    return {**me, **raw}
+
+
 @pytest.fixture(scope="session")
 def alice(instance_a: MisskeyLikeClient) -> dict:
     """Root user on instance A."""
-    return instance_a.create_admin("alice", "password1234")
+    return _ensure_user_id(instance_a, instance_a.create_admin("alice", "password1234"))
 
 
 @pytest.fixture(scope="session")
 def bob(instance_b: MisskeyLikeClient) -> dict:
     """Root user on instance B."""
-    return instance_b.create_admin("bob", "password1234")
+    return _ensure_user_id(instance_b, instance_b.create_admin("bob", "password1234"))

--- a/tests/dropin/gen-certs.sh
+++ b/tests/dropin/gen-certs.sh
@@ -22,3 +22,13 @@ for domain in $DOMAINS; do
     echo "Generated cert for $domain"
   fi
 done
+
+# bundle.pem は mk-go が SSL_CERT_FILE 経由で trust store に読ませるためのもの。
+# Phase 13-2 (#367) で TS-A の backend を mk-A に差し替える時、mk-A が連合先
+# instance B の自己署名 cert を検証できるようにする。Phase 13-1 では未使用だが
+# ファイル生成は冪等なので常に作って置く。
+: > "$CERT_DIR/bundle.pem"
+for domain in $DOMAINS; do
+  cat "$CERT_DIR/$domain.crt" >> "$CERT_DIR/bundle.pem"
+done
+echo "Wrote $CERT_DIR/bundle.pem"

--- a/tests/dropin/instance_a_mk.yml
+++ b/tests/dropin/instance_a_mk.yml
@@ -1,0 +1,45 @@
+# mk-go configuration for instance A (drop-in swap target).
+#
+# Phase 13-2 (#367): TS-A の backend を mk-go に差し替えるシナリオで使う。
+# 接続先は instance_a.yml と完全に同じ postgres-a / redis-a で、TS-A が書いた
+# DB / Redis をそのまま読み続ける必要がある。
+#
+# - `url` は TS-A と同一 (`https://a/`) — 連合相手 (instance B) から見た host が
+#   切り替えで変わってはいけない。
+# - `redis.prefix` は未指定 → config.go の resolveRedis が `<host>:` (= `a:`)
+#   に解決する (#363)。これにより TS-A と同じ Redis キー名前空間に乗る。
+
+url: https://a/
+port: 3000
+
+db:
+  host: postgres-a
+  port: 5432
+  db: misskey
+  user: misskey
+  pass: testpass
+
+redis:
+  host: redis-a
+  port: 6379
+
+redisForPubsub:
+  host: redis-a
+  port: 6379
+
+redisForJobQueue:
+  host: redis-a
+  port: 6379
+
+redisForTimelines:
+  host: redis-a
+  port: 6379
+
+id: aidx
+
+# 連合先 (instance B) との相互到達のため docker 内部 IP を許可する。
+allowedPrivateNetworks:
+  - 127.0.0.0/8
+  - 10.0.0.0/8
+  - 172.16.0.0/12
+  - 192.168.0.0/16

--- a/tests/dropin/run-swap-test.sh
+++ b/tests/dropin/run-swap-test.sh
@@ -1,0 +1,91 @@
+#!/bin/bash
+# Phase 13-2 (#367) drop-in swap test orchestrator.
+#
+# 流れ:
+#   1. TS-A + TS-B stack を起動 (Phase 13-1 と同じ)
+#   2. test_swap_setup.py で alice/bob/follow/baseline note を作る
+#   3. TS-A backend (app-a) を停止 — DB-A / Redis-A は走り続ける
+#   4. mk-go overlay で app-a を mk-go ビルドに置き換えて起動
+#   5. mk-A の healthy 待ち
+#   6. test_swap_verify.py で state preserved + 新規 federation 動作を確認
+#   7. cleanup
+#
+# pytest セッションを跨いで docker compose を切り替える必要があるため、
+# orchestration を bash で外側に置く。test runner コンテナ内に docker CLI を
+# 入れるとイメージが太るしソケットマウントの security trade-off があるので、
+# bash + 複数回 pytest 起動の構成にした。
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
+cd "$REPO_ROOT"
+
+BASE=docker-compose.dropin.yml
+OVERLAY=docker-compose.dropin.mk.yml
+
+cleanup() {
+  echo "===> cleanup"
+  docker compose -f "$BASE" -f "$OVERLAY" down -v >/dev/null 2>&1 || true
+}
+trap cleanup EXIT
+
+echo "===> stage 1: bring up TS-A + TS-B stack"
+docker compose -f "$BASE" up -d --build
+
+echo "===> stage 1b: wait for both TS instances healthy"
+deadline=$(($(date +%s) + 240))
+while :; do
+  states=$(docker compose -f "$BASE" ps --format json | python3 -c "
+import sys, json
+ls=[json.loads(l) for l in sys.stdin if l.strip()]
+healthy=[s for s in ls if s.get('Service') in ('app-a','app-b') and s.get('Health')=='healthy']
+print(len(healthy))
+")
+  if [ "$states" = "2" ]; then
+    break
+  fi
+  if [ "$(date +%s)" -ge "$deadline" ]; then
+    echo "FAIL: TS instances did not become healthy within 240s"
+    docker compose -f "$BASE" ps
+    exit 1
+  fi
+  sleep 3
+done
+
+echo "===> stage 2: setup alice / bob / follow / baseline note"
+docker compose -f "$BASE" --profile test run --rm test-runner pytest test_swap_setup.py -v
+
+echo "===> stage 3: stop TS-A backend (DB-A / Redis-A keep state)"
+docker compose -f "$BASE" stop app-a
+
+echo "===> stage 4: bring up mk-go overlay on instance A"
+docker compose -f "$BASE" -f "$OVERLAY" up -d --build app-a
+
+echo "===> stage 5: wait for mk-A healthy"
+deadline=$(($(date +%s) + 180))
+while :; do
+  state=$(docker compose -f "$BASE" -f "$OVERLAY" ps --format json | python3 -c "
+import sys, json
+ls=[json.loads(l) for l in sys.stdin if l.strip()]
+ms=[s for s in ls if s.get('Service')=='app-a']
+print(ms[0].get('Health') if ms else 'missing')
+")
+  if [ "$state" = "healthy" ]; then
+    break
+  fi
+  if [ "$(date +%s)" -ge "$deadline" ]; then
+    echo "FAIL: mk-A did not become healthy within 180s"
+    docker compose -f "$BASE" -f "$OVERLAY" logs app-a | tail -50
+    exit 1
+  fi
+  sleep 3
+done
+
+echo "===> stage 5b: restart nginx-a so the upstream re-resolves to mk-A"
+# stop app-a 中に nginx-a が backend を unreachable と覚え込む可能性があるので
+# 念のため restart する。
+docker compose -f "$BASE" -f "$OVERLAY" restart nginx-a
+
+echo "===> stage 6: verify state preserved on mk-A"
+docker compose -f "$BASE" -f "$OVERLAY" --profile test run --rm test-runner pytest test_swap_verify.py -v
+
+echo "===> all stages PASS"

--- a/tests/dropin/test_swap_setup.py
+++ b/tests/dropin/test_swap_setup.py
@@ -1,0 +1,65 @@
+"""Phase 13-2 (#367) drop-in swap シナリオ: setup 段階。
+
+`run-swap-test.sh` から `pytest test_swap_setup.py` の形で実行され、TS-A の
+backend が動いている状態で alice/bob/follow/note を作る。後段の `pytest
+test_swap_verify.py` は backend が mk-go に差し替わった後で同じ instance A
+URL に対してこの state が残存していることを確認する。
+
+ここで作る state は DB-A / Redis-A に persist される。docker compose stop で
+backend だけ落として overlay で mk-go を立て直しても DB / Redis は無事。
+"""
+
+from __future__ import annotations
+
+from conftest import A_DOMAIN, B_DOMAIN  # type: ignore[import-not-found]
+from conftest_base import MisskeyLikeClient, poll_until  # type: ignore[import-not-found]
+
+# verify 段で使う marker。run-swap-test.sh が同じ pytest コマンドを 2 回呼ぶので
+# テストファイル間で値を共有する必要があり、定数として定義する。
+BASELINE_NOTE_TEXT = "dropin-baseline-pre-swap"
+
+
+def test_setup_alice_follows_bob(
+    instance_a: MisskeyLikeClient,
+    instance_b: MisskeyLikeClient,
+    alice: dict,
+    bob: dict,
+) -> None:
+    """alice@a が bob@b を AP 経由で resolve して follow する。"""
+    remote_bob = poll_until(
+        lambda: instance_a.users_show("bob", host=B_DOMAIN),
+        timeout=60,
+        desc="alice resolves bob via AP",
+    )
+    try:
+        instance_a.follow(remote_bob["id"])
+    except RuntimeError as e:
+        if "ALREADY_FOLLOWING" not in str(e):
+            raise
+
+    def _followed() -> bool:
+        followers = instance_b._api("users/followers", {"userId": bob["id"]})
+        for f in followers:
+            follower = f.get("follower") or f
+            host = follower.get("host") or follower.get("followerHost")
+            if host == A_DOMAIN:
+                return True
+        return False
+
+    assert poll_until(_followed, timeout=60, desc="bob registers alice as follower")
+
+
+def test_setup_baseline_note(
+    instance_a: MisskeyLikeClient,
+    instance_b: MisskeyLikeClient,
+    alice: dict,
+    bob: dict,
+) -> None:
+    """bob が baseline note を投稿し alice の home に届くことを確認する。"""
+    instance_b.create_note(BASELINE_NOTE_TEXT)
+
+    def _arrived() -> bool:
+        tl = instance_a._api("notes/timeline", {"limit": 40})
+        return any(n.get("text") == BASELINE_NOTE_TEXT for n in tl)
+
+    assert poll_until(_arrived, timeout=90, desc="alice receives baseline note")

--- a/tests/dropin/test_swap_verify.py
+++ b/tests/dropin/test_swap_verify.py
@@ -1,0 +1,111 @@
+"""Phase 13-2 (#367) drop-in swap シナリオ: verify 段階。
+
+`run-swap-test.sh` が test_swap_setup.py を実行 → backend を mk-go に差し替え
+→ この test を実行する流れ。instance A の URL は変わらず https://a/ のまま
+だが、その背後で動いている backend が TS から mk-go に切り替わっている。
+
+DB-A / Redis-A は無事なので alice の token / follow 関係 / home timeline 内容
+がすべて引き継がれているはず。さらに mk-A 上で alice が新しい操作 (reply,
+reaction) を行い、TS-B 側に federation 経由で届くことも確認する。
+"""
+
+from __future__ import annotations
+
+import time
+
+import pytest
+
+from conftest import B_DOMAIN  # type: ignore[import-not-found]
+from conftest_base import MisskeyLikeClient, poll_until  # type: ignore[import-not-found]
+from test_swap_setup import BASELINE_NOTE_TEXT  # type: ignore[import-not-found]
+
+
+def test_post_swap_baseline_note_preserved(
+    instance_a: MisskeyLikeClient,
+    alice: dict,
+) -> None:
+    """切替前に bob が投稿し alice の home に届いていた note が、mk-A でも
+    引き続き読めることを確認する。Redis prefix が TS と揃っていなければ
+    ここでタイムラインが空になる (まさに #362 の症状)。
+    """
+    tl = instance_a._api("notes/timeline", {"limit": 40})
+    assert any(n.get("text") == BASELINE_NOTE_TEXT for n in tl), \
+        "baseline note disappeared from alice's home after backend swap"
+
+
+@pytest.mark.xfail(
+    reason="mk-go の NoteDeliveryHook (#368) は reply target 個別 deliver を未実装。"
+    "alice の followers (=0 人) + text mention (=なし) しか対象にしないため、"
+    "リモートユーザーへの reply は配信されない。drop-in 切替に固有の問題ではなく、"
+    "fresh インストールでも同じ振る舞い。Phase 13-3 で federation 修正後に xfail 解除。",
+    strict=True,
+)
+def test_post_swap_alice_can_reply(
+    instance_a: MisskeyLikeClient,
+    instance_b: MisskeyLikeClient,
+    alice: dict,
+    bob: dict,
+) -> None:
+    """mk-A で alice が新しいリプライを投稿し、TS-B の bob 側に届くことを確認する。
+
+    federation deliver のキュー (asynq) が稼働していれば届く。これが届かない
+    場合は mk-go の deliver 処理 / SSL_CERT_FILE バンドル / inbox URL 解決
+    のいずれかが壊れている。
+    """
+    tl = instance_a._api("notes/timeline", {"limit": 40})
+    baseline = next((n for n in tl if n.get("text") == BASELINE_NOTE_TEXT), None)
+    assert baseline is not None, "baseline note missing — cannot reply"
+
+    reply_text = f"dropin-reply-{int(time.time())}"
+    instance_a._api(
+        "notes/create",
+        {"text": reply_text, "replyId": baseline["id"]},
+    )
+
+    def _arrived() -> bool:
+        notifications = instance_b.get_notifications(limit=20)
+        return any(
+            (n.get("note") or {}).get("text") == reply_text
+            for n in notifications
+        )
+
+    assert poll_until(_arrived, timeout=120, desc="bob receives reply from mk-A alice")
+
+
+@pytest.mark.xfail(
+    reason="reaction の federation deliver も #368 と同じ NoteDeliveryHook 経路を"
+    "通るため、リモートユーザーへ reaction が配信されない。Phase 13-3 で連動して"
+    "解除予定。",
+    strict=True,
+)
+def test_post_swap_alice_can_react(
+    instance_a: MisskeyLikeClient,
+    instance_b: MisskeyLikeClient,
+    alice: dict,
+    bob: dict,
+) -> None:
+    """mk-A の alice が baseline note にリアクションを付け、TS-B の bob 側に
+    届くことを確認する。
+    """
+    tl = instance_a._api("notes/timeline", {"limit": 40})
+    baseline = next((n for n in tl if n.get("text") == BASELINE_NOTE_TEXT), None)
+    assert baseline is not None
+
+    try:
+        instance_a.react(baseline["id"], "👍")
+    except RuntimeError as e:
+        # 切替前に既にリアクション済みの場合は許容 (ALREADY_REACTED 等)
+        if "ALREADY" not in str(e).upper():
+            raise
+
+    def _arrived() -> bool:
+        notifications = instance_b.get_notifications(limit=20)
+        for n in notifications:
+            if n.get("type") != "reaction":
+                continue
+            from_user = n.get("user") or {}
+            if from_user.get("host") in (None, "") or from_user.get("username") == "alice":
+                return True
+        return False
+
+    assert poll_until(_arrived, timeout=120, desc="bob receives reaction from mk-A alice")

--- a/tests/dropin/test_swap_verify.py
+++ b/tests/dropin/test_swap_verify.py
@@ -34,7 +34,7 @@ def test_post_swap_baseline_note_preserved(
 
 
 @pytest.mark.xfail(
-    reason="mk-go の NoteDeliveryHook (#368) は reply target 個別 deliver を未実装。"
+    reason="mk-go の NoteDeliveryHook (#369) は reply target 個別 deliver を未実装。"
     "alice の followers (=0 人) + text mention (=なし) しか対象にしないため、"
     "リモートユーザーへの reply は配信されない。drop-in 切替に固有の問題ではなく、"
     "fresh インストールでも同じ振る舞い。Phase 13-3 で federation 修正後に xfail 解除。",
@@ -73,7 +73,7 @@ def test_post_swap_alice_can_reply(
 
 
 @pytest.mark.xfail(
-    reason="reaction の federation deliver も #368 と同じ NoteDeliveryHook 経路を"
+    reason="reaction の federation deliver も #369 と同じ NoteDeliveryHook 経路を"
     "通るため、リモートユーザーへ reaction が配信されない。Phase 13-3 で連動して"
     "解除予定。",
     strict=True,

--- a/tests/dropin/test_swap_verify.py
+++ b/tests/dropin/test_swap_verify.py
@@ -15,7 +15,7 @@ import time
 
 import pytest
 
-from conftest import B_DOMAIN  # type: ignore[import-not-found]
+from conftest import A_DOMAIN  # type: ignore[import-not-found]
 from conftest_base import MisskeyLikeClient, poll_until  # type: ignore[import-not-found]
 from test_swap_setup import BASELINE_NOTE_TEXT  # type: ignore[import-not-found]
 
@@ -103,8 +103,12 @@ def test_post_swap_alice_can_react(
         for n in notifications:
             if n.get("type") != "reaction":
                 continue
+            # alice は instance B から見ると remote (host = A_DOMAIN = "a")。
+            # 旧実装は `host in (None, "")` で local user を許容していたが、
+            # それだと B 上の任意の local user の reaction が誤マッチして
+            # xfail(strict=True) を意図せず通してしまう (Devin #370 #2)。
             from_user = n.get("user") or {}
-            if from_user.get("host") in (None, "") or from_user.get("username") == "alice":
+            if from_user.get("username") == "alice" and from_user.get("host") == A_DOMAIN:
                 return True
         return False
 


### PR DESCRIPTION
## Summary

#364 (Phase 13 drop-in e2e) のサブ 2。Phase 13-1 (#365) で構築した TS↔TS 基盤の上に、**instance A の backend を Misskey TS から mk-go に差し替える docker-compose overlay と bash orchestrator** を追加し、共有 DB / Redis 上で mk-go が TS の続きを引き継げることを e2e で検証する。

## 主な変更点

### 新規ファイル

| ファイル | 内容 |
|---------|------|
| `docker-compose.dropin.mk.yml` | `app-a` を mk-go ビルドに差し替える overlay (image / build / volumes / healthcheck / SSL_CERT_FILE 上書き) |
| `tests/dropin/instance_a_mk.yml` | `postgres-a` / `redis-a` を指す mk-go config (TS-A と完全に同じ接続先) |
| `tests/dropin/run-swap-test.sh` | TS-A 起動 → setup → mk-A 差し替え → verify を順次実行する bash orchestrator |
| `tests/dropin/test_swap_setup.py` | setup 段 (alice/bob/follow/baseline note) |
| `tests/dropin/test_swap_verify.py` | verify 段 (state preserved + reply / reaction) |
| `migration/000039_dropin_compat.{up,down}.sql` | `note.pageCount` / `note.renoteChannelId` を `ALTER TABLE ... ADD COLUMN IF NOT EXISTS` で補填 |

### 既存への変更

| ファイル | 変更 |
|---------|------|
| `migration/000007_antenna.up.sql`, `migration/000009_page.up.sql` | `CREATE TYPE` を `DO $$ BEGIN ... EXCEPTION WHEN duplicate_object` で冪等化 (TS-A が同名 enum を既に作っている DB に対しても migrate up を通す) |
| `tests/dropin/gen-certs.sh` | `bundle.pem` を生成 (mk-go の SSL_CERT_FILE 用) |
| `tests/dropin/conftest.py` | `_ensure_user_id` ヘルパ追加。signin フォールバック経路でも `alice["id"]` / `bob["id"]` が使えるよう `/api/i` で hydrate |
| `Makefile` | `dropin-mk-up` / `dropin-mk-test` / `dropin-mk-down` / `dropin-mk-logs` / `dropin-swap-test` |
| `CLAUDE.md`, `docs/dropin-e2e.md` | Phase 13-2 の運用手順を追記 |

### 設計上のポイント

- **bash orchestrator**: pytest セッションを跨いで `docker compose stop / up` する必要があるため、test runner コンテナ内に docker CLI を入れる代わりに bash で外側に置いた。setup / verify は別 pytest 実行で独立。
- **マイグレーション冪等化**: TS-A が既に作成済みの type を mk-go が再作成しようとして fail する drop-in 切替の典型的バグを修正。`CREATE TABLE IF NOT EXISTS` は mk-go 側で既に使っているが `CREATE TYPE` は一部抜けていた。
- **欠損カラム補填**: 古い TS image (例えば `misskey/misskey:2025.2.1`) が note テーブルを作った後、mk-go が `pageCount` / `renoteChannelId` 列に書き込もうとして失敗していた。`ALTER TABLE ... ADD COLUMN IF NOT EXISTS` で冪等に補う。

## テスト結果

```bash
$ make dropin-swap-test
...
test_swap_setup.py::test_setup_alice_follows_bob              PASSED
test_swap_setup.py::test_setup_baseline_note                  PASSED
test_swap_verify.py::test_post_swap_baseline_note_preserved   PASSED
test_swap_verify.py::test_post_swap_alice_can_reply           XFAIL (#369)
test_swap_verify.py::test_post_swap_alice_can_react           XFAIL (#369)
============= 1 passed, 2 xfailed, 1 warning in 242.53s =====================
===> all stages PASS
```

**baseline note の home timeline 残存** (= #362 退行検出) は実際にパスする — これが drop-in test の中核価値。

reply / reaction の federation deliver は mk-go の `NoteDeliveryHook` / `ReactionDeliveryHook` が reply target / reaction target の remote owner に直接 deliver しないため失敗する。これは drop-in 切替に固有のバグではなく fresh インストールでも同じ振る舞いなので **#369 として切り出して `xfail(strict=True)` 化**。#369 修正後に xfail を解除する想定。

## Phase 13 全体の残り

- [ ] Phase 13-3: 機能マトリクス (custom emoji / userList / channel timeline / visibility 種別ごとの deliver 等)
- [ ] Phase 13-4: CI nightly 統合

Closes #367

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/shiroha-a/mk/pull/370" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

