### PR TITLE
Fix #347: publish unfollow stream event on reject/cancel FollowRequest

### DIFF
--- a/internal/core/following/following_service.go
+++ b/internal/core/following/following_service.go
@@ -385,12 +385,20 @@ func (s *Service) AcceptRequest(followeeID, followerID string) error {
 }
 
 // RejectRequest rejects a pending follow request received by the followee.
+// 拒否された側 (follower) の frontend MkFollowButton がリロードなしで
+// 「フォロー」表示に戻るよう、`unfollow` main stream event を publish する。
+// UserDetailed shape に isFollowing=false / hasPendingFollowRequestFromYou=
+// false を埋めるのは Unfollow / Follow event と同じ方針。
 func (s *Service) RejectRequest(followeeID, followerID string) error {
 	req, err := s.followRequestRepo.FindByPair(followerID, followeeID)
 	if err != nil {
 		return ErrRequestNotFound
 	}
-	return s.followRequestRepo.Delete(req)
+	if err := s.followRequestRepo.Delete(req); err != nil {
+		return err
+	}
+	s.publishFollowRequestResolved(followerID, followeeID)
+	return nil
 }
 
 // CancelRequest cancels an outgoing follow request created by the follower.
@@ -416,7 +424,24 @@ func (s *Service) CancelRequest(followerID, followeeID string) error {
 			s.federationHook.OnLocalUnfollowed(follower, followee)
 		}
 	}
+	s.publishFollowRequestResolved(followerID, followeeID)
 	return nil
+}
+
+// publishFollowRequestResolved notifies the local follower via the main stream
+// that a pending follow request has been resolved (rejected or canceled).
+// frontend MkFollowButton listens to `unfollow` events and resets
+// isFollowing / hasPendingFollowRequestFromYou to false, giving users a live
+// reset without reloading.
+func (s *Service) publishFollowRequestResolved(followerID, followeeID string) {
+	if s.mainStreamPublisher == nil {
+		return
+	}
+	followee, err := s.userRepo.FindByID(followeeID)
+	if err != nil {
+		return
+	}
+	s.mainStreamPublisher.PublishMainEvent(followerID, "unfollow", entity.PackUserForFollowStreamEvent(followee, false, false))
 }
 
 // ListReceivedRequests returns follow requests received by userID.

--- a/internal/core/following/following_service.go
+++ b/internal/core/following/following_service.go
@@ -385,10 +385,6 @@ func (s *Service) AcceptRequest(followeeID, followerID string) error {
 }
 
 // RejectRequest rejects a pending follow request received by the followee.
-// 拒否された側 (follower) の frontend MkFollowButton がリロードなしで
-// 「フォロー」表示に戻るよう、`unfollow` main stream event を publish する。
-// UserDetailed shape に isFollowing=false / hasPendingFollowRequestFromYou=
-// false を埋めるのは Unfollow / Follow event と同じ方針。
 func (s *Service) RejectRequest(followeeID, followerID string) error {
 	req, err := s.followRequestRepo.FindByPair(followerID, followeeID)
 	if err != nil {
@@ -397,7 +393,12 @@ func (s *Service) RejectRequest(followeeID, followerID string) error {
 	if err := s.followRequestRepo.Delete(req); err != nil {
 		return err
 	}
-	s.publishFollowRequestResolved(followerID, followeeID)
+	// 拒否された側 (follower) の frontend MkFollowButton がリロード
+	// なしで「フォロー」表示に戻るよう、unfollow main stream event を
+	// publish する (Unfollow / Follow event と同じ経路)。
+	if followee, ferr := s.userRepo.FindByID(followeeID); ferr == nil {
+		s.publishFollowRequestResolved(followerID, followee)
+	}
 	return nil
 }
 
@@ -415,16 +416,17 @@ func (s *Service) CancelRequest(followerID, followeeID string) error {
 	if err := s.followRequestRepo.Delete(req); err != nil {
 		return err
 	}
-	// federationHook.OnLocalUnfollowed は shouldDeliverFollow でローカル→
-	// リモート条件を判定するので、ローカル followee の場合は自動的に no-op。
-	if s.federationHook != nil {
-		follower, ferr := s.userRepo.FindByID(followerID)
-		followee, eerr := s.userRepo.FindByID(followeeID)
-		if ferr == nil && eerr == nil {
+	// federation hook と streaming publish で followee を再利用する。
+	// federation hook は shouldDeliverFollow でローカル → リモート条件を
+	// 判定するので、ローカル followee の場合は自動的に no-op。
+	follower, ferr := s.userRepo.FindByID(followerID)
+	followee, eerr := s.userRepo.FindByID(followeeID)
+	if ferr == nil && eerr == nil {
+		if s.federationHook != nil {
 			s.federationHook.OnLocalUnfollowed(follower, followee)
 		}
+		s.publishFollowRequestResolved(followerID, followee)
 	}
-	s.publishFollowRequestResolved(followerID, followeeID)
 	return nil
 }
 
@@ -432,13 +434,10 @@ func (s *Service) CancelRequest(followerID, followeeID string) error {
 // that a pending follow request has been resolved (rejected or canceled).
 // frontend MkFollowButton listens to `unfollow` events and resets
 // isFollowing / hasPendingFollowRequestFromYou to false, giving users a live
-// reset without reloading.
-func (s *Service) publishFollowRequestResolved(followerID, followeeID string) {
-	if s.mainStreamPublisher == nil {
-		return
-	}
-	followee, err := s.userRepo.FindByID(followeeID)
-	if err != nil {
+// reset without reloading. Callers must pass the pre-loaded followee to avoid
+// a redundant DB lookup.
+func (s *Service) publishFollowRequestResolved(followerID string, followee *model.User) {
+	if s.mainStreamPublisher == nil || followee == nil {
 		return
 	}
 	s.mainStreamPublisher.PublishMainEvent(followerID, "unfollow", entity.PackUserForFollowStreamEvent(followee, false, false))

--- a/internal/core/following/following_service.go
+++ b/internal/core/following/following_service.go
@@ -393,9 +393,13 @@ func (s *Service) RejectRequest(followeeID, followerID string) error {
 	if err := s.followRequestRepo.Delete(req); err != nil {
 		return err
 	}
+	// CancelRequest と同じく publisher 未配線なら DB lookup を省く。
 	// 拒否された側 (follower) の frontend MkFollowButton がリロード
-	// なしで「フォロー」表示に戻るよう、unfollow main stream event を
-	// publish する (Unfollow / Follow event と同じ経路)。
+	// なしで「フォロー」表示に戻るよう unfollow main stream event を
+	// publish する経路。
+	if s.mainStreamPublisher == nil {
+		return nil
+	}
 	if followee, ferr := s.userRepo.FindByID(followeeID); ferr == nil {
 		s.publishFollowRequestResolved(followerID, followee)
 	}
@@ -446,6 +450,13 @@ func (s *Service) CancelRequest(followerID, followeeID string) error {
 // a redundant DB lookup.
 func (s *Service) publishFollowRequestResolved(followerID string, followee *model.User) {
 	if s.mainStreamPublisher == nil || followee == nil {
+		return
+	}
+	// follower がリモートなら local WebSocket subscriber はいないので publish
+	// 不要。federation processor 経由の Undo / Reject ではここに remote user ID
+	// が入ることがあるので明示的にスキップする。
+	follower, err := s.userRepo.FindByID(followerID)
+	if err != nil || !follower.IsLocal() {
 		return
 	}
 	s.mainStreamPublisher.PublishMainEvent(followerID, "unfollow", entity.PackUserForFollowStreamEvent(followee, false, false))

--- a/internal/core/following/following_service.go
+++ b/internal/core/following/following_service.go
@@ -416,17 +416,25 @@ func (s *Service) CancelRequest(followerID, followeeID string) error {
 	if err := s.followRequestRepo.Delete(req); err != nil {
 		return err
 	}
-	// federation hook と streaming publish で followee を再利用する。
-	// federation hook は shouldDeliverFollow でローカル → リモート条件を
-	// 判定するので、ローカル followee の場合は自動的に no-op。
-	follower, ferr := s.userRepo.FindByID(followerID)
+	// Unfollow と同じ guard: hooks / publisher のいずれもが未配線なら DB
+	// lookup 自体を省く。テスト時に userRepo が minimal でも影響しない。
+	if s.federationHook == nil && s.mainStreamPublisher == nil {
+		return nil
+	}
 	followee, eerr := s.userRepo.FindByID(followeeID)
-	if ferr == nil && eerr == nil {
-		if s.federationHook != nil {
+	if eerr != nil {
+		return nil
+	}
+	// federationHook.OnLocalUnfollowed は shouldDeliverFollow でローカル →
+	// リモート条件を判定するので、ローカル followee の場合は自動的に no-op。
+	// 呼ぶには follower も必要なので follower の lookup もここで行う
+	// (失敗時は federation hook だけスキップして streaming publish は続行)。
+	if s.federationHook != nil {
+		if follower, ferr := s.userRepo.FindByID(followerID); ferr == nil {
 			s.federationHook.OnLocalUnfollowed(follower, followee)
 		}
-		s.publishFollowRequestResolved(followerID, followee)
 	}
+	s.publishFollowRequestResolved(followerID, followee)
 	return nil
 }
 

--- a/internal/core/following/following_service.go
+++ b/internal/core/following/following_service.go
@@ -393,7 +393,9 @@ func (s *Service) RejectRequest(followeeID, followerID string) error {
 	if err := s.followRequestRepo.Delete(req); err != nil {
 		return err
 	}
-	// CancelRequest と同じく publisher 未配線なら DB lookup を省く。
+	// publisher 未配線なら DB lookup を省く (RejectRequest は federation
+	// hook を呼ばないので CancelRequest と違い mainStreamPublisher だけ
+	// チェックすれば十分)。
 	// 拒否された側 (follower) の frontend MkFollowButton がリロード
 	// なしで「フォロー」表示に戻るよう unfollow main stream event を
 	// publish する経路。

--- a/internal/core/following/following_service_test.go
+++ b/internal/core/following/following_service_test.go
@@ -557,6 +557,46 @@ func TestCancelRequest_InvokesUnfollowHook(t *testing.T) {
 	assert.Equal(t, []string{"alice->bob"}, fed.unfollowed)
 }
 
+func TestCancelRequest_PublishesUnfollowEvent(t *testing.T) {
+	// frontend MkFollowButton は main channel の unfollow event を受けて
+	// ボタンを「フォロー」表示にリセットする。CancelRequest でも publish する
+	// ことでリロードなしの UI 更新を実現する。
+	svc, userRepo, _, _ := newSvc(t)
+	addUser(t, userRepo, "alice", false)
+	addUser(t, userRepo, "bob", true)
+	pub := &stubMainStreamPublisher{}
+	svc.SetMainStreamPublisher(pub)
+	_, err := svc.Follow("alice", "bob")
+	require.NoError(t, err)
+	// Follow() 内の receiveFollowRequest は followee (bob) 宛。cancel 分を
+	// 観察するためリセット。
+	pub.calls = nil
+
+	require.NoError(t, svc.CancelRequest("alice", "bob"))
+	require.Len(t, pub.calls, 1)
+	assert.Equal(t, "alice", pub.calls[0].userID)
+	assert.Equal(t, "unfollow", pub.calls[0].eventType)
+	assertFollowStreamBody(t, pub.calls[0].body, "bob", false, false)
+}
+
+func TestRejectRequest_PublishesUnfollowEvent(t *testing.T) {
+	// 拒否された follower (alice) の frontend が「承認待ち」→「フォロー」
+	// にリロードなしで戻るよう、main channel に unfollow event を publish する。
+	svc, userRepo, _, _ := newSvc(t)
+	addUser(t, userRepo, "alice", false)
+	addUser(t, userRepo, "bob", true)
+	_, err := svc.Follow("alice", "bob")
+	require.NoError(t, err)
+	pub := &stubMainStreamPublisher{}
+	svc.SetMainStreamPublisher(pub)
+
+	require.NoError(t, svc.RejectRequest("bob", "alice"))
+	require.Len(t, pub.calls, 1)
+	assert.Equal(t, "alice", pub.calls[0].userID)
+	assert.Equal(t, "unfollow", pub.calls[0].eventType)
+	assertFollowStreamBody(t, pub.calls[0].body, "bob", false, false)
+}
+
 func TestListReceivedRequests(t *testing.T) {
 	svc, userRepo, _, _ := newSvc(t)
 	addUser(t, userRepo, "alice", false)


### PR DESCRIPTION
## Summary

- #343 PR で「フォロー → 承認待ち → フォロー中」のリアルタイム反映は完成したが、「承認待ち → フォロー (拒否 or キャンセル)」の遷移が streaming event を発行していなかったため、リロードするまでボタンが戻らない問題が残っていた
- `RejectRequest` (followee 拒否) と `CancelRequest` (follower 取り消し) の両方で main channel に `unfollow` event を publish するようにした
- frontend MkFollowButton が listen している既存経路を再利用（body = UserDetailed + isFollowing=false + hasPendingFollowRequestFromYou=false）

## 主な変更点

- `Service.publishFollowRequestResolved(followerID, followeeID)` ヘルパーを追加
  - `mainStreamPublisher` が未配線なら no-op
  - `followee` を lookup して UserDetailed body を組み立てる
- `RejectRequest` と `CancelRequest` から呼び出し
- テスト 2 件追加
  - `TestCancelRequest_PublishesUnfollowEvent`
  - `TestRejectRequest_PublishesUnfollowEvent`

## テスト

- `go test -race -count=1 ./internal/core/following/...` パス
- coverage: 96.6%（維持）
- `make fmt && make lint` クリーン

## Closes

Closes #347
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/shiroha-a/mk/pull/371" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
