### PR TITLE
Phase 13-3: drop-in e2e 機能マトリクス拡充 (visibility / userList / DM)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -420,6 +420,7 @@ Issueの作成・操作には`gh`コマンドを使う（`gh issue create`, `gh 
 
 本ドキュメントの主要な変更履歴。新規変更時は一番上に追記する（日付降順）。
 
+- **2026-04-21**: drop-in e2e Phase 13-3 (#372) を追加。state preservation 機能マトリクスを 6 シナリオに拡充 (home/followers/specified visibility ノート, user list メタ, user list timeline)。`tests/dropin/test_swap_setup.py` と `test_swap_verify.py` に追加。
 - **2026-04-21**: drop-in e2e Phase 13-2 (#367) を追加。`docker-compose.dropin.mk.yml` overlay と `tests/dropin/run-swap-test.sh` orchestrator で「TS-A backend を mk-go に差し替えても DB / Redis 上の state が引き継がれる」ことを e2e 検証する。途中で発覚した `note.pageCount` / `note.renoteChannelId` カラム欠如を `migration/000039_dropin_compat.up.sql` で補填。reply / reaction の federation deliver 不足は別バグ #368 として切り出し、対応する 2 テストは `xfail` 済。
 - **2026-04-21**: drop-in e2e テスト基盤 Phase 13-1 (#365) を追加。`docker-compose.dropin.yml` と `tests/dropin/` で Misskey TS 2 インスタンスを立ち上げ、pytest で federation smoke test を実行する。Phase 13-2 で mk 差し替え overlay を追加予定。
 - **2026-04-20**: CIの`test`ジョブを4-way matrix shardで並列化。総実行時間を約4.7分→約1.5-2分に短縮。各shardは独立サービスコンテナで動作し、ImportPath順modulo分配で決定的にパッケージを割り当てる。

--- a/docs/dropin-e2e.md
+++ b/docs/dropin-e2e.md
@@ -91,14 +91,14 @@ state 引き継ぎは検証されない。state 検証は `dropin-swap-test` 専
 
 | シナリオ | テスト | 状態 |
 |---------|--------|------|
-| baseline note の home timeline 残存 | `test_post_swap_baseline_note_preserved` | ✅ |
-| home visibility ノート残存 | `test_post_swap_home_visibility_preserved` | ✅ |
-| followers visibility ノート残存 | `test_post_swap_followers_visibility_preserved` | ✅ |
-| specified visibility (DM) 残存 | `test_post_swap_specified_note_preserved` | ✅ |
-| user list メタデータ残存 | `test_post_swap_user_list_preserved` | ✅ |
-| user list timeline 残存 (membership 間接検証) | `test_post_swap_user_list_timeline_preserved` | ✅ |
-| mk-A から remote bob への reply 配信 | `test_post_swap_alice_can_reply` | ⏸ #369 待ち (xfail) |
-| mk-A から remote bob への reaction 配信 | `test_post_swap_alice_can_react` | ⏸ #369 待ち (xfail) |
+| baseline note の home timeline 残存 | `test_post_swap_baseline_note_preserved` | pass |
+| home visibility ノート残存 | `test_post_swap_home_visibility_preserved` | pass |
+| followers visibility ノート残存 | `test_post_swap_followers_visibility_preserved` | pass |
+| specified visibility (DM) 残存 | `test_post_swap_specified_note_preserved` | pass |
+| user list メタデータ残存 | `test_post_swap_user_list_preserved` | pass |
+| user list timeline 残存 (membership 間接検証) | `test_post_swap_user_list_timeline_preserved` | pass |
+| mk-A から remote bob への reply 配信 | `test_post_swap_alice_can_reply` | xfail (#369 待ち) |
+| mk-A から remote bob への reaction 配信 | `test_post_swap_alice_can_react` | xfail (#369 待ち) |
 
 未カバー (Phase 13-3.5 以降の検討対象):
 

--- a/docs/dropin-e2e.md
+++ b/docs/dropin-e2e.md
@@ -47,7 +47,7 @@ make dropin-logs
 
 - [x] Phase 13-1 (#365): TS ↔ TS 基盤 + smoke test
 - [x] Phase 13-2 (#367): mk-go 差し替え overlay + swap シナリオ test
-- [ ] Phase 13-3: 機能マトリクス (ノート / リアクション / カスタム絵文字 / タイムライン退行検出 / 通知)
+- [x] Phase 13-3 (#372): 機能マトリクス拡充 (visibility 種別 / userList / specified DM)
 - [ ] Phase 13-4: CI nightly 統合
 
 ## Phase 13-2: mk-go 差し替え (drop-in swap)
@@ -84,6 +84,28 @@ make dropin-mk-logs    # ログ追跡
 
 注意: `dropin-mk-up` は **clean DB** から mk-A を起動するので、TS-A→mk-A の
 state 引き継ぎは検証されない。state 検証は `dropin-swap-test` 専用。
+
+## Phase 13-3: 機能マトリクス (現状カバー範囲)
+
+`make dropin-swap-test` の verify 段階で以下を検証する:
+
+| シナリオ | テスト | 状態 |
+|---------|--------|------|
+| baseline note の home timeline 残存 | `test_post_swap_baseline_note_preserved` | ✅ |
+| home visibility ノート残存 | `test_post_swap_home_visibility_preserved` | ✅ |
+| followers visibility ノート残存 | `test_post_swap_followers_visibility_preserved` | ✅ |
+| specified visibility (DM) 残存 | `test_post_swap_specified_note_preserved` | ✅ |
+| user list メタデータ残存 | `test_post_swap_user_list_preserved` | ✅ |
+| user list timeline 残存 (membership 間接検証) | `test_post_swap_user_list_timeline_preserved` | ✅ |
+| mk-A から remote bob への reply 配信 | `test_post_swap_alice_can_reply` | ⏸ #369 待ち (xfail) |
+| mk-A から remote bob への reaction 配信 | `test_post_swap_alice_can_react` | ⏸ #369 待ち (xfail) |
+
+未カバー (Phase 13-3.5 以降の検討対象):
+
+- カスタム絵文字 (display name / note 本文の :emoji:) — TS で emoji を作成する admin API 周りが必要
+- WebSocket streaming (`/streaming` channel 接続後の note push 受信)
+- channel timeline 残存
+- 双方向切替 (mk-A → TS-A 戻し)
 
 ## トラブルシューティング
 

--- a/tests/dropin/test_swap_setup.py
+++ b/tests/dropin/test_swap_setup.py
@@ -17,6 +17,10 @@ from conftest_base import MisskeyLikeClient, poll_until  # type: ignore[import-n
 # verify 段で使う marker。run-swap-test.sh が同じ pytest コマンドを 2 回呼ぶので
 # テストファイル間で値を共有する必要があり、定数として定義する。
 BASELINE_NOTE_TEXT = "dropin-baseline-pre-swap"
+HOME_NOTE_TEXT = "dropin-home-visibility-pre-swap"
+FOLLOWERS_NOTE_TEXT = "dropin-followers-visibility-pre-swap"
+SPECIFIED_NOTE_TEXT = "dropin-specified-visibility-pre-swap"
+LIST_NAME = "dropin-buddies"
 
 
 def test_setup_alice_follows_bob(
@@ -63,3 +67,120 @@ def test_setup_baseline_note(
         return any(n.get("text") == BASELINE_NOTE_TEXT for n in tl)
 
     assert poll_until(_arrived, timeout=90, desc="alice receives baseline note")
+
+
+def test_setup_home_visibility_note(
+    instance_a: MisskeyLikeClient,
+    instance_b: MisskeyLikeClient,
+    alice: dict,
+    bob: dict,
+) -> None:
+    """bob が home visibility ノートを投稿し alice の home timeline に届く。
+
+    home visibility は AP `to: [followers]` + `cc: []` で配信される。public と
+    比べて global timeline には現れないが follower (= alice) の home には届く。
+    """
+    instance_b.create_note(HOME_NOTE_TEXT, visibility="home")
+
+    def _arrived() -> bool:
+        tl = instance_a._api("notes/timeline", {"limit": 40})
+        return any(n.get("text") == HOME_NOTE_TEXT for n in tl)
+
+    assert poll_until(_arrived, timeout=90, desc="alice receives home-visibility note")
+
+
+def test_setup_followers_visibility_note(
+    instance_a: MisskeyLikeClient,
+    instance_b: MisskeyLikeClient,
+    alice: dict,
+    bob: dict,
+) -> None:
+    """bob が followers visibility ノートを投稿し alice の home timeline に届く。
+
+    followers visibility は AP `to: [followers]`、cc 無しで完全に follower 限定。
+    """
+    instance_b.create_note(FOLLOWERS_NOTE_TEXT, visibility="followers")
+
+    def _arrived() -> bool:
+        tl = instance_a._api("notes/timeline", {"limit": 40})
+        return any(n.get("text") == FOLLOWERS_NOTE_TEXT for n in tl)
+
+    assert poll_until(_arrived, timeout=90, desc="alice receives followers-visibility note")
+
+
+def test_setup_specified_visibility_note(
+    instance_a: MisskeyLikeClient,
+    instance_b: MisskeyLikeClient,
+    alice: dict,
+    bob: dict,
+) -> None:
+    """bob が alice 宛 specified (DM) ノートを投稿し alice 側に届く。
+
+    specified visibility は AP `to: [<alice URI>]` で direct message 相当。
+    home timeline には載らないので /api/notes/mentions で確認する。
+    """
+    remote_alice = poll_until(
+        lambda: instance_b.users_show("alice", host=A_DOMAIN),
+        timeout=60,
+        desc="bob resolves alice via AP",
+    )
+    instance_b.create_note(
+        SPECIFIED_NOTE_TEXT,
+        visibility="specified",
+        visibleUserIds=[remote_alice["id"]],
+    )
+
+    def _arrived() -> bool:
+        # specified note は home timeline には現れない。/api/notes/mentions に
+        # `visibility="specified"` を指定して DM だけ引く (mk-go の仕様: 既定
+        # では non-specified mention のみ返るため)。
+        mentions = instance_a._api(
+            "notes/mentions", {"limit": 40, "visibility": "specified"}
+        )
+        return any(n.get("text") == SPECIFIED_NOTE_TEXT for n in mentions)
+
+    assert poll_until(_arrived, timeout=90, desc="alice receives specified-visibility DM")
+
+
+def test_setup_user_list_with_remote_member(
+    instance_a: MisskeyLikeClient,
+    instance_b: MisskeyLikeClient,
+    alice: dict,
+    bob: dict,
+) -> None:
+    """alice が user list を作って bob (remote) を member に追加する。
+
+    User list の membership は user_list_membership テーブルに保存される。
+    切替後に list 自体と member 構成が引き継がれることを後段で検証する。
+    """
+    remote_bob = poll_until(
+        lambda: instance_a.users_show("bob", host=B_DOMAIN),
+        timeout=60,
+        desc="alice resolves bob",
+    )
+
+    # 既存の同名 list があれば再利用 (再実行性)
+    existing = instance_a._api("users/lists/list")
+    list_id = None
+    for lst in existing:
+        if lst.get("name") == LIST_NAME:
+            list_id = lst["id"]
+            break
+    if list_id is None:
+        created = instance_a._api("users/lists/create", {"name": LIST_NAME})
+        list_id = created["id"]
+
+    try:
+        instance_a._api("users/lists/push", {"listId": list_id, "userId": remote_bob["id"]})
+    except RuntimeError as e:
+        # 既に member の場合は許容
+        if "ALREADY_ADDED" not in str(e) and "Already" not in str(e):
+            raise
+
+    # 直後に show して list 自体が存在することを確認 (member 構成の確認は
+    # 後段で user-list-timeline 経由で行う。Misskey TS の `users/lists/show` は
+    # `userIds: string[]` を返すが、mk-go の同 endpoint は raw UserList を
+    # 返すだけで userIds を含まない既知の API gap がある — drop-in test では
+    # この差分の影響を避けるため間接検証に倒す)。
+    shown = instance_a._api("users/lists/show", {"listId": list_id})
+    assert shown.get("id") == list_id, "user list lookup failed right after creation"

--- a/tests/dropin/test_swap_verify.py
+++ b/tests/dropin/test_swap_verify.py
@@ -17,7 +17,13 @@ import pytest
 
 from conftest import A_DOMAIN  # type: ignore[import-not-found]
 from conftest_base import MisskeyLikeClient, poll_until  # type: ignore[import-not-found]
-from test_swap_setup import BASELINE_NOTE_TEXT  # type: ignore[import-not-found]
+from test_swap_setup import (  # type: ignore[import-not-found]
+    BASELINE_NOTE_TEXT,
+    FOLLOWERS_NOTE_TEXT,
+    HOME_NOTE_TEXT,
+    LIST_NAME,
+    SPECIFIED_NOTE_TEXT,
+)
 
 
 def test_post_swap_baseline_note_preserved(
@@ -31,6 +37,78 @@ def test_post_swap_baseline_note_preserved(
     tl = instance_a._api("notes/timeline", {"limit": 40})
     assert any(n.get("text") == BASELINE_NOTE_TEXT for n in tl), \
         "baseline note disappeared from alice's home after backend swap"
+
+
+def test_post_swap_home_visibility_preserved(
+    instance_a: MisskeyLikeClient,
+    alice: dict,
+) -> None:
+    """home visibility ノートも切替後に home timeline に残っている。"""
+    tl = instance_a._api("notes/timeline", {"limit": 40})
+    assert any(n.get("text") == HOME_NOTE_TEXT for n in tl), \
+        "home-visibility note missing from alice's home after swap"
+
+
+def test_post_swap_followers_visibility_preserved(
+    instance_a: MisskeyLikeClient,
+    alice: dict,
+) -> None:
+    """followers visibility ノートも切替後に home timeline に残っている。"""
+    tl = instance_a._api("notes/timeline", {"limit": 40})
+    assert any(n.get("text") == FOLLOWERS_NOTE_TEXT for n in tl), \
+        "followers-visibility note missing from alice's home after swap"
+
+
+def test_post_swap_specified_note_preserved(
+    instance_a: MisskeyLikeClient,
+    alice: dict,
+) -> None:
+    """specified visibility (DM) ノートが /api/notes/mentions?visibility=specified
+    に残っている。
+    """
+    mentions = instance_a._api(
+        "notes/mentions", {"limit": 40, "visibility": "specified"}
+    )
+    assert any(n.get("text") == SPECIFIED_NOTE_TEXT for n in mentions), \
+        "specified-visibility DM missing from alice's mentions after swap"
+
+
+def test_post_swap_user_list_preserved(
+    instance_a: MisskeyLikeClient,
+    alice: dict,
+) -> None:
+    """alice の user list 自体が引き継がれている (list メタデータの存在確認)。
+
+    membership 構成の検証は test_post_swap_user_list_timeline_preserved で
+    user-list-timeline 経由 (= 実際に list メンバーのノートが返る) で間接的に
+    行う。mk-go の `users/lists/show` は TS 互換の `userIds` フィールドを
+    返さない既知の API gap があるため、ここでは list のメタ情報のみ確認。
+    """
+    lists = instance_a._api("users/lists/list")
+    target = next((l for l in lists if l.get("name") == LIST_NAME), None)
+    assert target is not None, f"user list '{LIST_NAME}' missing after swap"
+
+
+def test_post_swap_user_list_timeline_preserved(
+    instance_a: MisskeyLikeClient,
+    alice: dict,
+) -> None:
+    """user list timeline で baseline note (bob 由来) が引き続き読める。
+
+    /api/notes/user-list-timeline は user_list_membership JOIN クエリで
+    list メンバーのノートを集める。Redis fanout キャッシュが残っていれば
+    そこから、空なら DB fallback で同じ結果になる。
+    """
+    lists = instance_a._api("users/lists/list")
+    target = next((l for l in lists if l.get("name") == LIST_NAME), None)
+    assert target is not None
+
+    tl = instance_a._api(
+        "notes/user-list-timeline",
+        {"listId": target["id"], "limit": 40},
+    )
+    assert any(n.get("text") == BASELINE_NOTE_TEXT for n in tl), \
+        "user-list-timeline lost baseline note from list member after swap"
 
 
 @pytest.mark.xfail(


### PR DESCRIPTION
## Summary

#364 (Phase 13 drop-in e2e) のサブ 3。Phase 13-2 (#367) で組んだ TS→mk swap orchestrator の上に、**state preservation の機能マトリクス** を 6 シナリオに拡充して drop-in 互換性の網羅検出を強化する。

## 主な変更点

### `tests/dropin/test_swap_setup.py` 追加 setup

| シナリオ | 内容 |
|---------|------|
| `test_setup_home_visibility_note` | bob が home visibility ノートを投稿し alice の home に届くことを確認 |
| `test_setup_followers_visibility_note` | bob が followers visibility ノートを投稿 |
| `test_setup_specified_visibility_note` | bob が alice 宛 specified (DM) ノートを投稿 (`visibleUserIds` 指定) |
| `test_setup_user_list_with_remote_member` | alice が `dropin-buddies` リストを作成、remote bob を push |

### `tests/dropin/test_swap_verify.py` 追加 verify

| シナリオ | テスト | 結果 |
|---------|--------|------|
| home visibility ノート残存 | `test_post_swap_home_visibility_preserved` | ✅ |
| followers visibility ノート残存 | `test_post_swap_followers_visibility_preserved` | ✅ |
| specified DM 残存 | `test_post_swap_specified_note_preserved` (`visibility=specified` 指定) | ✅ |
| user list メタ残存 | `test_post_swap_user_list_preserved` | ✅ |
| user list timeline 残存 (membership 間接検証) | `test_post_swap_user_list_timeline_preserved` | ✅ |

### 設計上のメモ

- **specified ノートの query**: mk-go の `notes/mentions` は default で non-specified mention のみを返す。DM は `visibility=\"specified\"` パラメータが必要。これに合わせて test も指定。
- **user list membership の検証方針**: mk-go の `users/lists/show` は TS の `userIds: [string]` フィールドを返さない既知の API gap がある。membership 構成は `user-list-timeline` 経由 (= 実際に list メンバーのノートが返る) で間接検証する方針に倒した。
- 既存の reply / reaction xfail (#369) は変更なし。

## テスト結果

```bash
$ make dropin-swap-test
...
test_swap_verify.py::test_post_swap_baseline_note_preserved        PASSED
test_swap_verify.py::test_post_swap_home_visibility_preserved      PASSED
test_swap_verify.py::test_post_swap_followers_visibility_preserved PASSED
test_swap_verify.py::test_post_swap_specified_note_preserved       PASSED
test_swap_verify.py::test_post_swap_user_list_preserved            PASSED
test_swap_verify.py::test_post_swap_user_list_timeline_preserved   PASSED
test_swap_verify.py::test_post_swap_alice_can_reply                XFAIL (#369)
test_swap_verify.py::test_post_swap_alice_can_react                XFAIL (#369)
============= 6 passed, 2 xfailed, 1 warning in 241.60s (0:04:01) ==============
===> all stages PASS
```

## Phase 13 全体の残り

- [ ] Phase 13-4: CI nightly 統合 (`.github/workflows/dropin-e2e.yml`)
- (任意) Phase 13-3.5 候補: custom emoji / WebSocket streaming / channel timeline / 双方向切替

## 既知制限

- `mk-go users/lists/show` の `userIds` フィールド欠如は別途対応 (本 PR スコープ外、今回は間接検証で回避)
- reply / reaction の federation deliver は #369 待ち

Closes #372

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/shiroha-a/mk/pull/373" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
