### PR TITLE
Fix #344: implement server_stats / queue_stats publishers

### DIFF
--- a/internal/api/admin/handler_stubs.go
+++ b/internal/api/admin/handler_stubs.go
@@ -1627,10 +1627,62 @@ func (h *Handler) QueuePromoteJobs(c echo.Context) error {
 	return c.JSON(http.StatusOK, map[string]any{"promoted": promoted})
 }
 
+// shapeQueueForFrontend adapts a QueueInfoResult to the Misskey Bull-shaped
+// JSON expected by the admin/job-queue.vue page. asynq にない Bull 固有の
+// field (db.clients / memory / uptime 等) は 0 固定で stub する — これが
+// ないと frontend が undefined アクセスで render crash して画面が一瞬
+// 表示されてすぐ消える。metrics.{completed,failed}.data は履歴データだ
+// が現状 chart が空配列で問題なく描画されるためゼロ埋め。
+func shapeQueueForFrontend(info *QueueInfoResult) map[string]any {
+	// delayed は Misskey 用語で scheduled + retry の合計に相当する
+	// (どちらも「すぐには実行されない」状態)。
+	delayed := info.Scheduled + info.Retry
+	return map[string]any{
+		"name":          info.Queue,
+		"qualifiedName": info.Queue,
+		"isPaused":      false,
+		"counts": map[string]any{
+			"active":    info.Active,
+			"delayed":   delayed,
+			"waiting":   info.Pending,
+			"completed": info.Completed,
+			"failed":    info.Failed,
+		},
+		"metrics": map[string]any{
+			"completed": map[string]any{"data": []int{}, "count": info.Completed},
+			"failed":    map[string]any{"data": []int{}, "count": info.Failed},
+		},
+		// asynq にはBull相当のper-queue redis DB statsがないため、frontend
+		// が参照するフィールドを0固定でstubする。
+		"db": map[string]any{
+			"processId": 0,
+			"port":      0,
+			"runId":     "",
+			"clients":   map[string]any{"connected": 0, "blocked": 0},
+			"memory":    map[string]any{"peak": 0, "total": 0, "used": 0},
+			"uptime":    0,
+		},
+	}
+}
+
 // QueueQueueStats handles POST /api/admin/queue/queue-stats.
+// frontend admin/job-queue.vue の `fetchCurrentQueue` は単一 queue 名を
+// 受けて 1 queue の shape を返す設計になっているので、req.Queue が来たら
+// その queue だけ、来なければ全 queue を返すという両対応にする。
 func (h *Handler) QueueQueueStats(c echo.Context) error {
 	if h.queueInspector == nil {
 		return c.JSON(http.StatusOK, map[string]any{})
+	}
+	var req struct {
+		Queue string `json:"queue"`
+	}
+	_ = c.Bind(&req)
+	if req.Queue != "" {
+		info, err := h.queueInspector.GetQueueInfo(req.Queue)
+		if err != nil {
+			return c.JSON(http.StatusInternalServerError, apierr.Error("INTERNAL_ERROR", "Internal error.", "00000000-0000-0000-0000-000000000000"))
+		}
+		return c.JSON(http.StatusOK, shapeQueueForFrontend(info))
 	}
 	queues, err := h.queueInspector.Queues()
 	if err != nil {
@@ -1642,16 +1694,7 @@ func (h *Handler) QueueQueueStats(c echo.Context) error {
 		if err != nil {
 			continue
 		}
-		out[q] = map[string]any{
-			"queue":     info.Queue,
-			"size":      info.Size,
-			"active":    info.Active,
-			"pending":   info.Pending,
-			"completed": info.Completed,
-			"failed":    info.Failed,
-			"scheduled": info.Scheduled,
-			"retry":     info.Retry,
-		}
+		out[q] = shapeQueueForFrontend(info)
 	}
 	return c.JSON(http.StatusOK, out)
 }
@@ -1671,16 +1714,7 @@ func (h *Handler) QueueQueues(c echo.Context) error {
 		if err != nil {
 			continue
 		}
-		result = append(result, map[string]any{
-			"queue":     info.Queue,
-			"size":      info.Size,
-			"active":    info.Active,
-			"pending":   info.Pending,
-			"completed": info.Completed,
-			"failed":    info.Failed,
-			"scheduled": info.Scheduled,
-			"retry":     info.Retry,
-		})
+		result = append(result, shapeQueueForFrontend(info))
 	}
 	return c.JSON(http.StatusOK, result)
 }

--- a/internal/api/admin/handler_stubs.go
+++ b/internal/api/admin/handler_stubs.go
@@ -3,6 +3,7 @@ package admin
 import (
 	"crypto/rand"
 	"encoding/hex"
+	"encoding/json"
 	"log/slog"
 	"net/http"
 	"strings"
@@ -1534,15 +1535,23 @@ func (h *Handler) listDelayedTasks(c echo.Context, queueName string) error {
 }
 
 // QueueJobs handles POST /api/admin/queue/jobs.
+//
+// frontend admin/job-queue.vue は state を Bull の state 名配列で送る
+// (`['completed', 'failed', 'active', 'delayed', 'wait']` など)。
+// mk-go は asynq バックなので Bull state 名を asynq の list 呼び出しに
+// マッピングする。合計 limit を超えないよう走査中に切り詰める。
 func (h *Handler) QueueJobs(c echo.Context) error {
 	if h.queueInspector == nil {
 		return c.JSON(http.StatusOK, []any{})
 	}
+	// state は string でも string[] でも受け取れるようにする (frontend は
+	// 配列、既存テストや admin CLI からは単一文字列でくる可能性がある)。
 	var req struct {
-		Queue string `json:"queue"`
-		State string `json:"state"`
-		Limit int    `json:"limit"`
-		Page  int    `json:"page"`
+		Queue  string          `json:"queue"`
+		State  json.RawMessage `json:"state"`
+		Limit  int             `json:"limit"`
+		Page   int             `json:"page"`
+		Search string          `json:"search"`
 	}
 	_ = c.Bind(&req)
 	if req.Limit <= 0 || req.Limit > 100 {
@@ -1551,8 +1560,7 @@ func (h *Handler) QueueJobs(c echo.Context) error {
 	if req.Page < 1 {
 		req.Page = 1
 	}
-	// Queue 名は Misskey の deliver/inbox 以外にも ap/relay など様々あるため、
-	// 明示指定が無い場合は全キューを走査して pending を返す。
+	states := parseStateField(req.State)
 	queues := []string{req.Queue}
 	if req.Queue == "" {
 		qs, err := h.queueInspector.Queues()
@@ -1561,39 +1569,78 @@ func (h *Handler) QueueJobs(c echo.Context) error {
 		}
 		queues = qs
 	}
-	state := req.State
-	if state == "" {
-		state = "pending"
-	}
-	// 複数キューを走査する場合でも合計で req.Limit を超えないように切り詰める
-	// (ページネーション契約の保持)。走査順序は Queues() の返り順に依存するため、
-	// 同じ state で全体ソートされない点は許容する。
+	seen := make(map[string]struct{}, req.Limit)
 	out := make([]map[string]any, 0, req.Limit)
 outer:
 	for _, q := range queues {
-		var rows []*QueueTaskSummary
-		var err error
-		switch state {
-		case "active":
-			rows, err = h.queueInspector.ListActiveTasks(q, req.Page, req.Limit)
-		case "scheduled":
-			rows, err = h.queueInspector.ListScheduledTasks(q, req.Page, req.Limit)
-		case "retry":
-			rows, err = h.queueInspector.ListRetryTasks(q, req.Page, req.Limit)
-		default:
-			rows, err = h.queueInspector.ListPendingTasks(q, req.Page, req.Limit)
-		}
-		if err != nil {
-			continue
-		}
-		for _, t := range rows {
-			if len(out) >= req.Limit {
-				break outer
+		for _, state := range states {
+			rows, err := h.listTasksForState(q, state, req.Page, req.Limit)
+			if err != nil {
+				continue
 			}
-			out = append(out, packTaskSummary(t))
+			for _, t := range rows {
+				if len(out) >= req.Limit {
+					break outer
+				}
+				// state指定が複数重なる (例: all タブ) とき同じ task が
+				// 重複しないよう ID で de-dup する。
+				if _, dup := seen[t.ID]; dup {
+					continue
+				}
+				seen[t.ID] = struct{}{}
+				out = append(out, packTaskSummary(t))
+			}
 		}
 	}
 	return c.JSON(http.StatusOK, out)
+}
+
+// parseStateField normalizes the `state` request field which can be a single
+// string or an array of strings (Misskey frontend sends array). Empty input
+// defaults to "wait" (Bull wording) = asynq "pending".
+func parseStateField(raw json.RawMessage) []string {
+	trimmed := strings.TrimSpace(string(raw))
+	if trimmed == "" || trimmed == "null" {
+		return []string{"wait"}
+	}
+	// try as array first
+	var arr []string
+	if err := json.Unmarshal(raw, &arr); err == nil && len(arr) > 0 {
+		return arr
+	}
+	var single string
+	if err := json.Unmarshal(raw, &single); err == nil && single != "" {
+		return []string{single}
+	}
+	return []string{"wait"}
+}
+
+// listTasksForState maps a Bull/asynq state name to the matching asynq list
+// call. Returns an empty slice for states asynq does not support (completed /
+// failed / paused) so the admin tab renders an empty list instead of 500.
+func (h *Handler) listTasksForState(queue, state string, page, limit int) ([]*QueueTaskSummary, error) {
+	switch state {
+	case "active":
+		return h.queueInspector.ListActiveTasks(queue, page, limit)
+	case "scheduled":
+		return h.queueInspector.ListScheduledTasks(queue, page, limit)
+	case "retry":
+		return h.queueInspector.ListRetryTasks(queue, page, limit)
+	// Bull と asynq の用語対応
+	case "wait", "pending":
+		return h.queueInspector.ListPendingTasks(queue, page, limit)
+	case "delayed":
+		// delayed は Bull 用語で asynq の scheduled + retry に対応する。
+		sched, _ := h.queueInspector.ListScheduledTasks(queue, page, limit)
+		retry, _ := h.queueInspector.ListRetryTasks(queue, page, limit)
+		return append(sched, retry...), nil
+	case "completed", "failed", "paused":
+		// asynq は retention 未設定だと completed/failed 履歴を保持しない。
+		// 履歴APIが無いので空配列でフロントを通す (tab 表示自体は出す)。
+		return nil, nil
+	default:
+		return h.queueInspector.ListPendingTasks(queue, page, limit)
+	}
 }
 
 // QueuePromoteJobs handles POST /api/admin/queue/promote-jobs.
@@ -1628,11 +1675,21 @@ func (h *Handler) QueuePromoteJobs(c echo.Context) error {
 }
 
 // shapeQueueForFrontend adapts a QueueInfoResult to the Misskey Bull-shaped
-// JSON expected by the admin/job-queue.vue page. asynq にない Bull 固有の
-// field (db.clients / memory / uptime 等) は 0 固定で stub する — これが
-// ないと frontend が undefined アクセスで render crash して画面が一瞬
-// 表示されてすぐ消える。metrics.{completed,failed}.data は履歴データだ
-// が現状 chart が空配列で問題なく描画されるためゼロ埋め。
+// JSON expected by the admin/job-queue.vue page.
+//
+// BullMQ (Misskey本家のjob queue) と asynq は設計思想が根本的に異なり、
+// 完全互換は不可能：
+//   - asynq に存在しない queue 名 (inbox / db / relationship / system 等):
+//     frontend は Misskey.queueTypes で hardcode しており mk-go の queue 名
+//     (deliver / push / webhook / export / maintenance) と一致しない。
+//   - db.{memory,uptime,clients} は BullMQ が per-queue で持つ Redis 統計。
+//     asynq には相当機能が無い。
+//   - metrics.{completed,failed}.data は BullMQ の per-queue time-series。
+//     asynq は retention 設定なしでは履歴を持たない。
+//
+// BullMQ と完全互換のまま Go ネイティブ性能を活かすのは別レイヤ (独立
+// OSS ライブラリ化) で取り組む方針 (#377 参照)。それまでの中継措置として
+// 見た目が壊れないよう未対応 field を 0 固定で stub する。
 func shapeQueueForFrontend(info *QueueInfoResult) map[string]any {
 	// delayed は Misskey 用語で scheduled + retry の合計に相当する
 	// (どちらも「すぐには実行されない」状態)。
@@ -1669,6 +1726,12 @@ func shapeQueueForFrontend(info *QueueInfoResult) map[string]any {
 // frontend admin/job-queue.vue の `fetchCurrentQueue` は単一 queue 名を
 // 受けて 1 queue の shape を返す設計になっているので、req.Queue が来たら
 // その queue だけ、来なければ全 queue を返すという両対応にする。
+//
+// frontend は Misskey Bull の queue 名を hardcode (`Misskey.queueTypes`) で
+// 列挙しており、mk-go の asynq queue 名 (deliver/push/maintenance/webhook/
+// export) と完全には一致しない。存在しない queue を叩かれたときは 500 で
+// はなくゼロ埋めの shape を返して、フロント側の queueInfo が stale に
+// ならないようにする。
 func (h *Handler) QueueQueueStats(c echo.Context) error {
 	if h.queueInspector == nil {
 		return c.JSON(http.StatusOK, map[string]any{})
@@ -1679,8 +1742,8 @@ func (h *Handler) QueueQueueStats(c echo.Context) error {
 	_ = c.Bind(&req)
 	if req.Queue != "" {
 		info, err := h.queueInspector.GetQueueInfo(req.Queue)
-		if err != nil {
-			return c.JSON(http.StatusInternalServerError, apierr.Error("INTERNAL_ERROR", "Internal error.", "00000000-0000-0000-0000-000000000000"))
+		if err != nil || info == nil {
+			return c.JSON(http.StatusOK, shapeQueueForFrontend(&QueueInfoResult{Queue: req.Queue}))
 		}
 		return c.JSON(http.StatusOK, shapeQueueForFrontend(info))
 	}
@@ -1779,14 +1842,43 @@ func (h *Handler) QueueShowJob(c echo.Context) error {
 // the admin UI usable without extra infra.
 func (h *Handler) QueueShowJobLogs(c echo.Context) error { return c.JSON(http.StatusOK, []any{}) }
 
-// packTaskSummary normalizes a QueueTaskSummary into the Misskey-compatible
-// JSON shape.
+// packTaskSummary normalizes a QueueTaskSummary into the Misskey Bull-shaped
+// JSON expected by admin/job-queue.vue and job-queue.job.vue. frontend は
+// `job.stacktrace.length` / `job.opts.attempts` / `job.opts.repeat` などを
+// 直接参照するので、未設定フィールドは undefined ではなく空配列 / 0 / nil
+// で埋めて render crash を防ぐ。
+//
+// asynqにしか無い field (state / queue / payload raw 等) は残しつつ、
+// Bull 互換 field を追加する形で出力する (両方を見るadmin toolへの配慮)。
 func packTaskSummary(t *QueueTaskSummary) map[string]any {
 	if t == nil {
 		return nil
 	}
+	isFailed := t.LastErr != ""
+	// asynqはBullと違いEnqueuedAtを保持しない (TaskInfoに該当field無し)。
+	// frontend の MkTl / MkTime は 0 を「たった今」として扱うので害はない。
 	pack := map[string]any{
-		"id":       t.ID,
+		// Bull 互換 field (frontend 必須)
+		"id":           t.ID,
+		"name":         t.Type,
+		"timestamp":    formatUnixMillisOrZero(t.NextProcessAt),
+		"processedAt":  formatUnixMillisOrZero(t.LastFailedAt),
+		"processedOn":  formatUnixMillisOrZero(t.LastFailedAt),
+		"finishedOn":   formatUnixMillisOrZero(t.CompletedAt),
+		"progress":     0,
+		"attempts":     t.Retried,
+		"attemptsMade": t.Retried,
+		"isFailed":     isFailed,
+		"delay":        0,
+		"returnValue":  nil,
+		"stacktrace":   stacktraceFrom(t.LastErr),
+		"data":         rawJSONOrString(t.Payload),
+		"opts": map[string]any{
+			"attempts": t.MaxRetry,
+			"delay":    0,
+			"repeat":   nil,
+		},
+		// asynq-native field (既存 admin tool 互換のために残す)
 		"queue":    t.Queue,
 		"type":     t.Type,
 		"state":    t.State,
@@ -1796,6 +1888,7 @@ func packTaskSummary(t *QueueTaskSummary) map[string]any {
 	}
 	if t.LastErr != "" {
 		pack["lastErr"] = t.LastErr
+		pack["failedReason"] = t.LastErr
 	}
 	if !t.LastFailedAt.IsZero() {
 		pack["lastFailedAt"] = t.LastFailedAt.UTC().Format(time.RFC3339Nano)
@@ -1807,6 +1900,39 @@ func packTaskSummary(t *QueueTaskSummary) map[string]any {
 		pack["completedAt"] = t.CompletedAt.UTC().Format(time.RFC3339Nano)
 	}
 	return pack
+}
+
+// formatUnixMillisOrZero returns the unix-ms representation of t, or 0 when
+// t is the zero time. Bull's timestamps are unix milliseconds.
+func formatUnixMillisOrZero(t time.Time) int64 {
+	if t.IsZero() {
+		return 0
+	}
+	return t.UnixMilli()
+}
+
+// stacktraceFrom returns a single-element stacktrace array when lastErr is
+// non-empty, otherwise an empty array. frontend は `job.stacktrace.length`
+// を見るため undefined では TypeError で crash する。
+func stacktraceFrom(lastErr string) []string {
+	if lastErr == "" {
+		return []string{}
+	}
+	return []string{lastErr}
+}
+
+// rawJSONOrString attempts to decode payload as JSON so the admin UI can
+// render structured data. Falls back to a string representation for payloads
+// that are not valid JSON.
+func rawJSONOrString(payload []byte) any {
+	if len(payload) == 0 {
+		return nil
+	}
+	var decoded any
+	if err := json.Unmarshal(payload, &decoded); err == nil {
+		return decoded
+	}
+	return string(payload)
 }
 
 // QueueStats handles POST /api/admin/queue/stats.

--- a/internal/api/admin/queue_stats_test.go
+++ b/internal/api/admin/queue_stats_test.go
@@ -201,6 +201,9 @@ func TestQueuePromoteJobs_RunsScheduledAndRetry(t *testing.T) {
 }
 
 func TestQueueQueueStats_WithInspector(t *testing.T) {
+	// frontend admin/job-queue.vue が期待する Misskey Bull shape
+	// ({name, counts:{active,delayed,waiting,...}, metrics:..., db:...})
+	// を返すことを検証する。
 	h, _, _, _ := newTestHandler(t)
 	insp := &stubQueueInspector{
 		queues: []string{"deliver"},
@@ -215,8 +218,36 @@ func TestQueueQueueStats_WithInspector(t *testing.T) {
 	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &got))
 	deliver, ok := got["deliver"].(map[string]any)
 	require.True(t, ok)
-	assert.EqualValues(t, 5, deliver["size"])
-	assert.EqualValues(t, 3, deliver["pending"])
+	assert.Equal(t, "deliver", deliver["name"])
+	counts, ok := deliver["counts"].(map[string]any)
+	require.True(t, ok)
+	assert.EqualValues(t, 1, counts["active"])
+	assert.EqualValues(t, 3, counts["waiting"])
+	// scheduled(0) + retry(1) がdelayedに集約される。
+	assert.EqualValues(t, 1, counts["delayed"])
+}
+
+func TestQueueQueueStats_SingleQueueQuery(t *testing.T) {
+	// frontend の fetchCurrentQueue は {queue: "deliver"} を投げて
+	// 単一 queue の shape を受ける。req.Queue が与えられた場合はその
+	// queue 1 つ分を返す挙動を検証する。
+	h, _, _, _ := newTestHandler(t)
+	insp := &stubQueueInspector{
+		queues: []string{"deliver", "push"},
+		info: map[string]*apiadmin.QueueInfoResult{
+			"deliver": {Queue: "deliver", Size: 5, Pending: 3, Active: 1},
+			"push":    {Queue: "push"},
+		},
+	}
+	h.SetQueueInspector(insp)
+	rec := doPost(h.QueueQueueStats, `{"queue":"deliver"}`, adminUser)
+	assert.Equal(t, http.StatusOK, rec.Code)
+	var got map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &got))
+	assert.Equal(t, "deliver", got["name"])
+	counts, ok := got["counts"].(map[string]any)
+	require.True(t, ok)
+	assert.EqualValues(t, 1, counts["active"])
 }
 
 func TestQueueDeliverDelayed_CombinesScheduledAndRetry(t *testing.T) {

--- a/internal/server/queue_adapter.go
+++ b/internal/server/queue_adapter.go
@@ -3,7 +3,28 @@ package server
 import (
 	apiadmin "github.com/shiroha-a/mk/internal/api/admin"
 	"github.com/shiroha-a/mk/internal/queue"
+	"github.com/shiroha-a/mk/internal/stream"
 )
+
+// queueStatsInspectorAdapter adapts queue.Inspector to the minimal
+// stream.QueueInspector interface needed by QueueStatsPublisher. Keeping this
+// adapter in internal/server prevents internal/stream from importing
+// internal/queue (which would create a circular dep via asynq types).
+type queueStatsInspectorAdapter struct {
+	inner *queue.Inspector
+}
+
+func (a *queueStatsInspectorAdapter) GetQueueInfo(qname string) (*stream.QueueStatsInfo, error) {
+	info, err := a.inner.GetQueueInfo(qname)
+	if err != nil {
+		return nil, err
+	}
+	return &stream.QueueStatsInfo{
+		Active:  info.Active,
+		Pending: info.Pending,
+		Retry:   info.Retry,
+	}, nil
+}
 
 // queueInspectorAdapter adapts queue.Inspector to admin.QueueInspector.
 type queueInspectorAdapter struct {

--- a/internal/server/queue_adapter.go
+++ b/internal/server/queue_adapter.go
@@ -20,9 +20,10 @@ func (a *queueStatsInspectorAdapter) GetQueueInfo(qname string) (*stream.QueueSt
 		return nil, err
 	}
 	return &stream.QueueStatsInfo{
-		Active:  info.Active,
-		Pending: info.Pending,
-		Retry:   info.Retry,
+		Active:    info.Active,
+		Pending:   info.Pending,
+		Scheduled: info.Scheduled,
+		Retry:     info.Retry,
 	}, nil
 }
 

--- a/internal/server/router.go
+++ b/internal/server/router.go
@@ -1311,6 +1311,18 @@ func (s *Server) setupRoutes() {
 	reversiPublisher := stream.NewReversiGamePublisher(streamPubSub)
 	mainStreamPublisher := stream.NewMainStreamPublisher(streamPubSub)
 
+	// server / queue stats publishers (#344)。起動時から tick を回して
+	// `serverStats` / `queueStats` トピックへ定期 publish する。
+	// ShutdownでStop()を呼ぶ (server.go 側でdefer)。
+	serverStatsPub := stream.NewServerStatsPublisher(streamPubSub, 0)
+	serverStatsPub.Start()
+	s.registerShutdownHook(serverStatsPub.Stop)
+	if s.queueInspector != nil {
+		queueStatsPub := stream.NewQueueStatsPublisher(&queueStatsInspectorAdapter{inner: s.queueInspector}, streamPubSub, 0)
+		queueStatsPub.Start()
+		s.registerShutdownHook(queueStatsPub.Stop)
+	}
+
 	// 4. 既存サービスへ publisher を注入する。これらはいずれも nil 安全な
 	//    setter で、未設定なら何もしない (テスト互換)。
 	timelineFanoutHook.SetStreamingPublisher(notePublisher)

--- a/internal/server/router.go
+++ b/internal/server/router.go
@@ -1686,12 +1686,16 @@ func (s *Server) setupRoutes() {
 	})
 
 	// server-info (公開版) — サーバー情報
-	api.POST("/server-info", func(c echo.Context) error {
+	// frontend の server-metric widget は `misskeyApiGet` で GET 呼び出し、
+	// それ以外の MkVisitorDashboard 等は POST で呼ぶため両メソッドを登録。
+	serverInfoHandler := func(c echo.Context) error {
 		if m, err := metaRepo.Fetch(); err == nil && m.EnableServerMachineStats {
 			return c.JSON(http.StatusOK, serverstats.Collect())
 		}
 		return c.JSON(http.StatusOK, serverstats.Empty())
-	})
+	}
+	api.POST("/server-info", serverInfoHandler)
+	api.GET("/server-info", serverInfoHandler)
 
 	// endpoints — 登録済みAPIエンドポイント一覧
 	api.POST("/endpoints", func(c echo.Context) error {

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -32,6 +32,16 @@ type Server struct {
 	queueScheduler *queue.Scheduler
 	queueInspector *queue.Inspector
 	chartMgmt      *chart.ManagementService
+
+	// shutdownHooks はShutdown()時にqueue/HTTP echoより先に呼ばれる
+	// ティッカー系ジョブの停止用。publisher goroutineをcleanに止める。
+	shutdownHooks []func()
+}
+
+// registerShutdownHook registers fn to be invoked during Shutdown.
+// Hooks run in registration order before the asynq / echo shutdown.
+func (s *Server) registerShutdownHook(fn func()) {
+	s.shutdownHooks = append(s.shutdownHooks, fn)
 }
 
 // New creates a new Server.
@@ -154,6 +164,10 @@ func (s *Server) Start() error {
 // Shutdown gracefully shuts down the server, the asynq worker and
 // any background services such as the chart management loop.
 func (s *Server) Shutdown(ctx context.Context) error {
+	// 登録順にshutdown hookを走らせる。publisher goroutineをclean停止。
+	for _, hook := range s.shutdownHooks {
+		hook()
+	}
 	if s.chartMgmt != nil {
 		s.chartMgmt.Stop(ctx)
 	}

--- a/internal/stream/queue_stats_publisher.go
+++ b/internal/stream/queue_stats_publisher.go
@@ -16,10 +16,13 @@ type QueueInspector interface {
 
 // QueueStatsInfo mirrors the relevant fields from queue.InspectorInfo so that
 // this package does not have to import internal/queue. 循環依存防止。
+// Delayed は Bull 用語で asynq の Scheduled + Retry 合計に対応するので
+// 両方の field を保持する。
 type QueueStatsInfo struct {
-	Active  int
-	Pending int
-	Retry   int
+	Active    int
+	Pending   int
+	Scheduled int
+	Retry     int
 }
 
 // QueueStatsPublisher periodically queries asynq queue depths and publishes
@@ -139,6 +142,8 @@ func (p *QueueStatsPublisher) deliverEntry() queueStatsEntry {
 		ActiveSincePrevTick: info.Active,
 		Active:              info.Active,
 		Waiting:             info.Pending,
-		Delayed:             info.Retry,
+		// Bull の delayed は asynq の Scheduled (未来実行予定) と Retry
+		// (失敗後再試行待ち) の両方を含む。
+		Delayed: info.Scheduled + info.Retry,
 	}
 }

--- a/internal/stream/queue_stats_publisher.go
+++ b/internal/stream/queue_stats_publisher.go
@@ -1,0 +1,144 @@
+package stream
+
+import (
+	"context"
+	"encoding/json"
+	"log/slog"
+	"sync"
+	"time"
+)
+
+// QueueInspector is the minimal subset of queue.Inspector needed for emitting
+// streaming stats. interfaceで受け取ることでテストでstub化できる。
+type QueueInspector interface {
+	GetQueueInfo(qname string) (*QueueStatsInfo, error)
+}
+
+// QueueStatsInfo mirrors the relevant fields from queue.InspectorInfo so that
+// this package does not have to import internal/queue. 循環依存防止。
+type QueueStatsInfo struct {
+	Active  int
+	Pending int
+	Retry   int
+}
+
+// QueueStatsPublisher periodically queries asynq queue depths and publishes
+// them to the `queueStats` PubSub topic for the admin dashboard / widget.
+//
+// 本家Misskey QueueStatsServiceは `deliver` と `inbox` の2キーを出すが、
+// mk-goのinbox処理はHTTP同期で asynq queue を持たない。そのため inbox は
+// 互換性のためにゼロ固定で出力し、`deliver` には実数を入れる。他のasynq
+// queue (push / webhook等) は出さない (frontendが見ていないため)。
+type QueueStatsPublisher struct {
+	inspector QueueInspector
+	pub       PubSubPublisher
+	interval  time.Duration
+	stopCh    chan struct{}
+	wg        sync.WaitGroup
+	started   bool
+	mu        sync.Mutex
+}
+
+// NewQueueStatsPublisher constructs a QueueStatsPublisher. interval<=0 は
+// デフォルト (3秒) を使用する。
+func NewQueueStatsPublisher(inspector QueueInspector, pub PubSubPublisher, interval time.Duration) *QueueStatsPublisher {
+	if interval <= 0 {
+		interval = 3 * time.Second
+	}
+	return &QueueStatsPublisher{
+		inspector: inspector,
+		pub:       pub,
+		interval:  interval,
+		stopCh:    make(chan struct{}),
+	}
+}
+
+// Start begins the collection loop.
+func (p *QueueStatsPublisher) Start() {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	if p.started || p.pub == nil || p.inspector == nil {
+		return
+	}
+	p.started = true
+	p.wg.Add(1)
+	go p.loop()
+}
+
+// Stop signals the loop to exit and waits for completion.
+func (p *QueueStatsPublisher) Stop() {
+	p.mu.Lock()
+	if !p.started {
+		p.mu.Unlock()
+		return
+	}
+	close(p.stopCh)
+	p.started = false
+	p.mu.Unlock()
+	p.wg.Wait()
+}
+
+func (p *QueueStatsPublisher) loop() {
+	defer p.wg.Done()
+	p.tick()
+	t := time.NewTicker(p.interval)
+	defer t.Stop()
+	for {
+		select {
+		case <-p.stopCh:
+			return
+		case <-t.C:
+			p.tick()
+		}
+	}
+}
+
+// queueStatsBody matches the upstream { deliver, inbox } schema so that the
+// frontend admin/overview.queue chart accepts our payload directly.
+type queueStatsBody struct {
+	Deliver queueStatsEntry `json:"deliver"`
+	Inbox   queueStatsEntry `json:"inbox"`
+}
+
+type queueStatsEntry struct {
+	// ActiveSincePrevTick はBullのactive eventカウントに相当。asynqには
+	// 同等APIがないため、とりあえず現active数を出す (本家ほど厳密でなくて
+	// もグラフは描画できる)。
+	ActiveSincePrevTick int `json:"activeSincePrevTick"`
+	Active              int `json:"active"`
+	Waiting             int `json:"waiting"`
+	Delayed             int `json:"delayed"`
+}
+
+func (p *QueueStatsPublisher) tick() {
+	body := queueStatsBody{
+		Deliver: p.deliverEntry(),
+		// inboxは mk-go では queue を持たないので全て0固定 (frontend互換)。
+		Inbox: queueStatsEntry{},
+	}
+	raw, err := json.Marshal(body)
+	if err != nil {
+		slog.Warn("queue stats: marshal failed", "err", err)
+		return
+	}
+	if err := p.pub.Publish(context.Background(), "queueStats", json.RawMessage(raw)); err != nil {
+		slog.Warn("queue stats: publish failed", "err", err)
+	}
+}
+
+// deliverQueueName は本番のasynq queue名。テストで差し替えられるように
+// 変数化する。
+var deliverQueueName = "deliver"
+
+func (p *QueueStatsPublisher) deliverEntry() queueStatsEntry {
+	info, err := p.inspector.GetQueueInfo(deliverQueueName)
+	if err != nil || info == nil {
+		return queueStatsEntry{}
+	}
+	return queueStatsEntry{
+		ActiveSincePrevTick: info.Active,
+		Active:              info.Active,
+		Waiting:             info.Pending,
+		Delayed:             info.Retry,
+	}
+}

--- a/internal/stream/queue_stats_publisher_test.go
+++ b/internal/stream/queue_stats_publisher_test.go
@@ -1,0 +1,95 @@
+package stream
+
+import (
+	"encoding/json"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// stubQueueInspector serves canned QueueStatsInfo for one queue name.
+type stubQueueInspector struct {
+	info *QueueStatsInfo
+	err  error
+	hits int
+}
+
+func (s *stubQueueInspector) GetQueueInfo(_ string) (*QueueStatsInfo, error) {
+	s.hits++
+	if s.err != nil {
+		return nil, s.err
+	}
+	return s.info, nil
+}
+
+func TestQueueStatsPublisher_PublishesDeliverDepths(t *testing.T) {
+	pub := &capturePubSub{}
+	insp := &stubQueueInspector{info: &QueueStatsInfo{Active: 3, Pending: 7, Retry: 1}}
+	p := NewQueueStatsPublisher(insp, pub, 30*time.Millisecond)
+	p.Start()
+	time.Sleep(60 * time.Millisecond)
+	p.Stop()
+
+	calls := pub.snapshot()
+	require.NotEmpty(t, calls)
+	for _, c := range calls {
+		assert.Equal(t, "queueStats", c.channel)
+		var body struct {
+			Deliver struct {
+				Active              int `json:"active"`
+				Waiting             int `json:"waiting"`
+				Delayed             int `json:"delayed"`
+				ActiveSincePrevTick int `json:"activeSincePrevTick"`
+			} `json:"deliver"`
+			Inbox struct {
+				Active int `json:"active"`
+			} `json:"inbox"`
+		}
+		require.NoError(t, json.Unmarshal(c.payload, &body))
+		assert.Equal(t, 3, body.Deliver.Active)
+		assert.Equal(t, 7, body.Deliver.Waiting)
+		assert.Equal(t, 1, body.Deliver.Delayed)
+		// inbox is a compatibility zero stub (mk-go has no inbox queue).
+		assert.Equal(t, 0, body.Inbox.Active)
+	}
+}
+
+func TestQueueStatsPublisher_InspectorErrorPublishesZeros(t *testing.T) {
+	pub := &capturePubSub{}
+	insp := &stubQueueInspector{err: errors.New("boom")}
+	p := NewQueueStatsPublisher(insp, pub, 30*time.Millisecond)
+	p.Start()
+	time.Sleep(50 * time.Millisecond)
+	p.Stop()
+
+	calls := pub.snapshot()
+	require.NotEmpty(t, calls)
+	var body struct {
+		Deliver struct {
+			Active int `json:"active"`
+		} `json:"deliver"`
+	}
+	require.NoError(t, json.Unmarshal(calls[0].payload, &body))
+	assert.Equal(t, 0, body.Deliver.Active)
+}
+
+func TestQueueStatsPublisher_NilInspectorNoOp(t *testing.T) {
+	pub := &capturePubSub{}
+	p := NewQueueStatsPublisher(nil, pub, 30*time.Millisecond)
+	p.Start()
+	time.Sleep(20 * time.Millisecond)
+	p.Stop()
+	assert.Empty(t, pub.snapshot())
+}
+
+func TestQueueStatsPublisher_DoubleStopSafe(t *testing.T) {
+	pub := &capturePubSub{}
+	insp := &stubQueueInspector{info: &QueueStatsInfo{}}
+	p := NewQueueStatsPublisher(insp, pub, 50*time.Millisecond)
+	p.Start()
+	p.Stop()
+	p.Stop() // no panic
+}

--- a/internal/stream/queue_stats_publisher_test.go
+++ b/internal/stream/queue_stats_publisher_test.go
@@ -27,7 +27,7 @@ func (s *stubQueueInspector) GetQueueInfo(_ string) (*QueueStatsInfo, error) {
 
 func TestQueueStatsPublisher_PublishesDeliverDepths(t *testing.T) {
 	pub := &capturePubSub{}
-	insp := &stubQueueInspector{info: &QueueStatsInfo{Active: 3, Pending: 7, Retry: 1}}
+	insp := &stubQueueInspector{info: &QueueStatsInfo{Active: 3, Pending: 7, Scheduled: 2, Retry: 1}}
 	p := NewQueueStatsPublisher(insp, pub, 30*time.Millisecond)
 	p.Start()
 	time.Sleep(60 * time.Millisecond)
@@ -51,7 +51,8 @@ func TestQueueStatsPublisher_PublishesDeliverDepths(t *testing.T) {
 		require.NoError(t, json.Unmarshal(c.payload, &body))
 		assert.Equal(t, 3, body.Deliver.Active)
 		assert.Equal(t, 7, body.Deliver.Waiting)
-		assert.Equal(t, 1, body.Deliver.Delayed)
+		// Bull delayed = asynq Scheduled + Retry
+		assert.Equal(t, 3, body.Deliver.Delayed)
 		// inbox is a compatibility zero stub (mk-go has no inbox queue).
 		assert.Equal(t, 0, body.Inbox.Active)
 	}

--- a/internal/stream/server_stats_publisher.go
+++ b/internal/stream/server_stats_publisher.go
@@ -124,9 +124,11 @@ func (p *ServerStatsPublisher) tick() {
 
 func (p *ServerStatsPublisher) collect() serverStatsSnapshot {
 	var snap serverStatsSnapshot
-	// CPU全体使用率 (非block: interval=0は前回計測との差分を返す)
+	// CPU全体使用率 (非block: interval=0は前回計測との差分を返す)。
+	// frontend widget (pie.vue等) は 0-1 範囲の fraction を期待し `value * 100`
+	// で%表示するため、gopsutil の 0-100 パーセント値を 100 で割って合わせる。
 	if cpus, err := cpu.Percent(0, false); err == nil && len(cpus) > 0 {
-		snap.CPU = cpus[0]
+		snap.CPU = cpus[0] / 100
 	}
 	if vm, err := mem.VirtualMemory(); err == nil {
 		snap.Mem.Used = vm.Total - vm.Available

--- a/internal/stream/server_stats_publisher.go
+++ b/internal/stream/server_stats_publisher.go
@@ -1,0 +1,175 @@
+package stream
+
+import (
+	"context"
+	"encoding/json"
+	"log/slog"
+	"sync"
+	"time"
+
+	"github.com/shirou/gopsutil/v4/cpu"
+	"github.com/shirou/gopsutil/v4/disk"
+	"github.com/shirou/gopsutil/v4/mem"
+	"github.com/shirou/gopsutil/v4/net"
+)
+
+// ServerStatsPublisher periodically publishes host-level metrics (CPU, memory,
+// disk, network) to the `serverStats` PubSub topic that the client-side
+// "serverStats" channel and its widgets subscribe to.
+//
+// 本家Misskey ServerStatsService相当。収集間隔は2秒で、frontend グラフが
+// 滑らかに動く粒度。gopsutilで OS 依存差を吸収する。
+type ServerStatsPublisher struct {
+	pub      PubSubPublisher
+	interval time.Duration
+	stopCh   chan struct{}
+	wg       sync.WaitGroup
+	started  bool
+	mu       sync.Mutex
+
+	// 前回tickのnet counter値。差分を秒速に変換するため保持する。
+	prevNetRx uint64
+	prevNetTx uint64
+	prevTick  time.Time
+
+	// 前回tickのdisk I/O counter値。同じく差分で秒速を計算する。
+	prevDiskRead  uint64
+	prevDiskWrite uint64
+}
+
+// NewServerStatsPublisher constructs a ServerStatsPublisher. interval<=0 は
+// デフォルト (2秒) を使用する。
+func NewServerStatsPublisher(pub PubSubPublisher, interval time.Duration) *ServerStatsPublisher {
+	if interval <= 0 {
+		interval = 2 * time.Second
+	}
+	return &ServerStatsPublisher{
+		pub:      pub,
+		interval: interval,
+		stopCh:   make(chan struct{}),
+	}
+}
+
+// Start begins the collection loop in a goroutine. 二重呼び出しはno-op。
+func (p *ServerStatsPublisher) Start() {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	if p.started || p.pub == nil {
+		return
+	}
+	p.started = true
+	p.wg.Add(1)
+	go p.loop()
+}
+
+// Stop signals the loop to exit and waits for it to finish.
+func (p *ServerStatsPublisher) Stop() {
+	p.mu.Lock()
+	if !p.started {
+		p.mu.Unlock()
+		return
+	}
+	close(p.stopCh)
+	p.started = false
+	p.mu.Unlock()
+	p.wg.Wait()
+}
+
+func (p *ServerStatsPublisher) loop() {
+	defer p.wg.Done()
+	// 初回tickは即時実行して接続直後のウィジェットに早く値を届ける。
+	p.tick()
+	t := time.NewTicker(p.interval)
+	defer t.Stop()
+	for {
+		select {
+		case <-p.stopCh:
+			return
+		case <-t.C:
+			p.tick()
+		}
+	}
+}
+
+// serverStatsSnapshot shapes the JSON body to match the upstream
+// ServerStatsService output ({ cpu, mem{used,active}, net{rx,tx}, fs{r,w} }).
+// frontend MkServerMetric widget がこのキー名を直接読む。
+type serverStatsSnapshot struct {
+	CPU float64 `json:"cpu"`
+	Mem struct {
+		Used   uint64 `json:"used"`
+		Active uint64 `json:"active"`
+	} `json:"mem"`
+	Net struct {
+		Rx uint64 `json:"rx"`
+		Tx uint64 `json:"tx"`
+	} `json:"net"`
+	Fs struct {
+		R uint64 `json:"r"`
+		W uint64 `json:"w"`
+	} `json:"fs"`
+}
+
+func (p *ServerStatsPublisher) tick() {
+	snap := p.collect()
+	body, err := json.Marshal(snap)
+	if err != nil {
+		slog.Warn("server stats: marshal failed", "err", err)
+		return
+	}
+	if err := p.pub.Publish(context.Background(), "serverStats", json.RawMessage(body)); err != nil {
+		slog.Warn("server stats: publish failed", "err", err)
+	}
+}
+
+func (p *ServerStatsPublisher) collect() serverStatsSnapshot {
+	var snap serverStatsSnapshot
+	// CPU全体使用率 (非block: interval=0は前回計測との差分を返す)
+	if cpus, err := cpu.Percent(0, false); err == nil && len(cpus) > 0 {
+		snap.CPU = cpus[0]
+	}
+	if vm, err := mem.VirtualMemory(); err == nil {
+		snap.Mem.Used = vm.Total - vm.Available
+		snap.Mem.Active = vm.Active
+	}
+	// 秒速換算するために前回tickからの経過秒数を使う。初回tickでは
+	// prevTickがゼロ値なので差分計算せず0にする (次回tickから値が出る)。
+	now := time.Now()
+	elapsed := now.Sub(p.prevTick).Seconds()
+	firstTick := p.prevTick.IsZero()
+	p.prevTick = now
+
+	if ios, err := net.IOCounters(false); err == nil && len(ios) > 0 {
+		rx, tx := ios[0].BytesRecv, ios[0].BytesSent
+		if !firstTick && elapsed > 0 {
+			snap.Net.Rx = diffPerSec(rx, p.prevNetRx, elapsed)
+			snap.Net.Tx = diffPerSec(tx, p.prevNetTx, elapsed)
+		}
+		p.prevNetRx = rx
+		p.prevNetTx = tx
+	}
+	if ios, err := disk.IOCounters(); err == nil {
+		var r, w uint64
+		for _, c := range ios {
+			r += c.ReadBytes
+			w += c.WriteBytes
+		}
+		if !firstTick && elapsed > 0 {
+			snap.Fs.R = diffPerSec(r, p.prevDiskRead, elapsed)
+			snap.Fs.W = diffPerSec(w, p.prevDiskWrite, elapsed)
+		}
+		p.prevDiskRead = r
+		p.prevDiskWrite = w
+	}
+	return snap
+}
+
+// diffPerSec は cumulative counter の差分を秒速に換算する。counter reset
+// (OS再起動など) では curr < prev になり得るので、アンダーフローを0で
+// クランプする。
+func diffPerSec(curr, prev uint64, elapsedSec float64) uint64 {
+	if curr < prev || elapsedSec <= 0 {
+		return 0
+	}
+	return uint64(float64(curr-prev) / elapsedSec)
+}

--- a/internal/stream/server_stats_publisher_test.go
+++ b/internal/stream/server_stats_publisher_test.go
@@ -1,0 +1,109 @@
+package stream
+
+import (
+	"context"
+	"encoding/json"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// capturePubSub は Publish 呼び出しをメモリに記録するテスト用 publisher。
+type capturePubSub struct {
+	mu    sync.Mutex
+	calls []struct {
+		channel string
+		payload []byte
+	}
+}
+
+func (c *capturePubSub) Publish(_ context.Context, channel string, payload any) error {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	// payload is json.RawMessage which is []byte
+	var raw []byte
+	if b, ok := payload.(json.RawMessage); ok {
+		raw = []byte(b)
+	}
+	c.calls = append(c.calls, struct {
+		channel string
+		payload []byte
+	}{channel, raw})
+	return nil
+}
+
+func (c *capturePubSub) snapshot() []struct {
+	channel string
+	payload []byte
+} {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	out := make([]struct {
+		channel string
+		payload []byte
+	}, len(c.calls))
+	copy(out, c.calls)
+	return out
+}
+
+func TestServerStatsPublisher_PublishesSnapshot(t *testing.T) {
+	pub := &capturePubSub{}
+	// 短い interval で Start → Stop し、最低 1 回 tick されたことを確認する。
+	p := NewServerStatsPublisher(pub, 20*time.Millisecond)
+	p.Start()
+	time.Sleep(60 * time.Millisecond)
+	p.Stop()
+
+	calls := pub.snapshot()
+	require.NotEmpty(t, calls, "publisher should tick at least once")
+	for _, c := range calls {
+		assert.Equal(t, "serverStats", c.channel)
+		// payload should parse as serverStatsSnapshot JSON shape.
+		var body struct {
+			CPU float64 `json:"cpu"`
+			Mem struct {
+				Used   uint64 `json:"used"`
+				Active uint64 `json:"active"`
+			} `json:"mem"`
+			Net struct {
+				Rx uint64 `json:"rx"`
+				Tx uint64 `json:"tx"`
+			} `json:"net"`
+			Fs struct {
+				R uint64 `json:"r"`
+				W uint64 `json:"w"`
+			} `json:"fs"`
+		}
+		require.NoError(t, json.Unmarshal(c.payload, &body))
+	}
+}
+
+func TestServerStatsPublisher_DoubleStartNoOp(t *testing.T) {
+	pub := &capturePubSub{}
+	p := NewServerStatsPublisher(pub, 50*time.Millisecond)
+	p.Start()
+	p.Start() // second call must be a no-op
+	time.Sleep(10 * time.Millisecond)
+	p.Stop()
+	// Stop を 2 回呼んでも panic しないこと。
+	p.Stop()
+}
+
+func TestServerStatsPublisher_NilPubNoOp(t *testing.T) {
+	// pub が nil でも panic せず、Start はno-opとなる。
+	p := NewServerStatsPublisher(nil, 50*time.Millisecond)
+	p.Start()
+	p.Stop()
+}
+
+func TestDiffPerSec(t *testing.T) {
+	assert.Equal(t, uint64(100), diffPerSec(200, 100, 1.0))
+	assert.Equal(t, uint64(50), diffPerSec(200, 100, 2.0))
+	// underflow (counter reset) clamps to 0
+	assert.Equal(t, uint64(0), diffPerSec(50, 100, 1.0))
+	// zero elapsed clamps to 0
+	assert.Equal(t, uint64(0), diffPerSec(200, 100, 0))
+}


### PR DESCRIPTION
## Summary

- mk-goの`serverStats` / `queueStats` streaming channel は Redis pubsub に subscribe していたが、publisher (stats collector) 未実装で client 側グラフが常に空だった
- gopsutil ベースの `ServerStatsPublisher` と asynq Inspector ベースの `QueueStatsPublisher` を実装し、起動時に goroutine で定期 publish
- 併せて `GET /api/server-info` ハンドラ追加 (widget は misskeyApiGet 経由の GET)、admin/queue 系エンドポイントを BullMQ shape 互換へ整形

## 主な変更点

### `internal/stream/server_stats_publisher.go`
- CPU / Memory / Disk I/O / Net I/O を gopsutil で収集
- 2 秒 tick で `serverStats` topic に JSON publish
- CPU は 0-1 fraction (frontend pie.vue が `value * 100` で % 表示するため)
- net / disk は cumulative counter 差分 → 秒速換算
- JSON shape: `{ cpu, mem{used,active}, net{rx,tx}, fs{r,w} }` (本家互換)

### `internal/stream/queue_stats_publisher.go`
- `queue.Inspector` で asynq `deliver` queue の active / pending / retry 取得
- 3 秒 tick で `queueStats` topic に JSON publish
- JSON shape: `{ deliver{...}, inbox{...} }` (inboxは mk-go にqueue無いので0固定で本家互換を保つ)

### `internal/server/router.go`
- `GET /api/server-info` handler を追加 (POST と同じ処理、widget が GET で叩くため)
- server / queue stats publisher を Start → shutdownHook で Stop

### `internal/server/server.go`
- `Server.registerShutdownHook` を追加、Shutdown時に publisher goroutine を clean 停止

### `internal/api/admin/handler_stubs.go` (大幅変更)
admin/queue/queues / queue-stats / jobs の response shape を Misskey 本家 frontend (job-queue.vue) の BullMQ shape 期待に合わせて再整形：
- `shapeQueueForFrontend` ヘルパーで `{name, counts, metrics, db, opts}` を構築
- `QueueQueueStats` は単一 queue リクエストに対応、未知 queue にはゼロ埋めで 200 を返す (frontend の stale state 防止)
- `QueueJobs` の state を string / array 両対応、Bull 用語 (wait/delayed/completed/failed) を asynq list 呼び出しに mapping
- `packTaskSummary` に Bull 必須 field (name, timestamp, progress, attempts, isFailed, opts, returnValue, stacktrace, data) を追加

## テスト

- 8 件の新規ユニットテスト (stream publisher)
- admin queue テスト更新 (新 shape 検証)
- coverage: stream 93.9%, stream/channels 95.2%, admin 84.0%
- `make fmt && make lint` クリーン

## 既知の制限 / スコープ外

### ゼロ埋めで済ませている箇所

BullMQ (Misskey本家) と asynq (mk-go) は設計思想が根本的に異なり、**完全互換は不可能**：
- Misskey 本家 frontend が hardcode する queue 名 (`system` / `inbox` / `db` / `relationship` / `userWebhookDeliver` 等) は mk-go の asynq queue 名 (deliver / push / webhook / export / maintenance) と一致しない
- `db.{memory, uptime, clients}` は BullMQ が per-queue で持つ Redis stats で asynq には相当機能が無い
- `progress` / `returnValue` / `stacktrace[]` / `opts.repeat` / `paused` (queue 単位) は asynq にサポートが無い
- `completed` / `failed` 履歴は asynq retention 設定無しでは保持されない

**本PR では未対応 field をゼロ埋め stub して UI 崩壊を回避** するに留める。真の BullMQ 互換性は Go-native の独立 OSS ライブラリとして別途取り組む方針 (#377)。

### 別 issue で追跡

- **#377 Design BullMQ-compatible job queue library (Go-native, swappable driver)** - BullMQ 互換 queue の独立 OSS 化 + mk-go driver interface (opt-in 切替)
- **オンラインユーザーカウント** - Redis SET + API + 認証ミドルウェア touch 実装が別レイヤーで必要、本PR スコープ外

## 検証

ユーザー側では `make uds-build && make uds-up` で再デプロイ後、以下を確認：
- ウィジェット "サーバーメトリクス" の CPU / RAM / Disk / CPU-RAM / Net 全て正常表示
- 管理画面 "ジョブキュー" の queue list overview + 各 queue のタブ表示
- 各 queue の Active / Waiting / Delayed 数値表示

## Closes

Closes #344