### PR TITLE
Fix #359 #360: bundle twemoji and repo-level assets into runtime image

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -42,7 +42,9 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: "20"
+          # third_party/misskey/packages/backend は engines.node で
+          # ^22.15.0 || ^24.10.0 を要求するため 22 系を使う。
+          node-version: "22"
 
       - name: Install third_party/misskey node_modules
         working-directory: third_party/misskey

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -35,6 +35,22 @@ jobs:
           # COPY対象になるため、submoduleを取得しないとbuildが失敗する。
           submodules: recursive
 
+      # Dockerfileが /twemoji (本家frontendの絵文字SVG set) をCOPYするが、
+      # その実体は third_party/misskey/packages/backend/node_modules/@discordapp/twemoji
+      # 配下にあり、pnpm install 後にしか存在しない。runner上で事前にinstallして
+      # Docker build contextに含める (issue #359)。
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+
+      - name: Install third_party/misskey node_modules
+        working-directory: third_party/misskey
+        run: |
+          corepack enable
+          corepack prepare pnpm@latest --activate
+          pnpm install --frozen-lockfile
+
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -19,6 +19,12 @@ RUN test -f third_party/misskey/packages/backend/assets/favicon.ico || \
     (echo "ERROR: third_party/misskey submodule not initialized (or partial clone)." && \
      echo "Run: git submodule update --init --recursive" && exit 1)
 
+# twemojiは本家frontendがUnicode絵文字描画に使うSVG set。pnpm installで
+# node_modulesに hoistされる前提 (make e2e-frontend-build等で install済み)。
+RUN test -f third_party/misskey/packages/backend/node_modules/@discordapp/twemoji/dist/svg/1f004.svg || \
+    (echo "ERROR: twemoji assets not found (pnpm install not run?)." && \
+     echo "Run: make e2e-frontend-build (installs third_party/misskey node_modules)" && exit 1)
+
 RUN go build -trimpath -ldflags="-s -w" -o /app/built/misskey ./cmd/misskey && \
     go build -trimpath -ldflags="-s -w" -o /app/built/migrate ./cmd/migrate
 
@@ -39,6 +45,16 @@ COPY --from=builder /app/migration /app/migration
 # `git submodule update --init --recursive` が必要。
 COPY --from=builder /app/third_party/misskey/packages/backend/assets /app/static-assets
 ENV MISSKEY_STATIC_DIR=/app/static-assets
+
+# repo-level assets (ai.png等)。frontendが /assets/ai.png で参照する
+# (mascotImageUrl のデフォルト)。submodule直下 (issue #360)。
+COPY --from=builder /app/third_party/misskey/assets /app/repo-assets
+ENV MISSKEY_REPO_ASSETS_DIR=/app/repo-assets
+
+# twemoji SVG set (Unicode絵文字描画)。frontendが /twemoji/<codepoint>.svg
+# で参照する。約18MB (issue #359)。
+COPY --from=builder /app/third_party/misskey/packages/backend/node_modules/@discordapp/twemoji/dist/svg /app/twemoji
+ENV MISSKEY_TWEMOJI_DIR=/app/twemoji
 
 # デフォルト設定ファイルをコピー (docker-compose でマウント上書き可能)
 COPY .config/docker.yml /app/.config/default.yml

--- a/deploy/uds/Dockerfile.mkgo
+++ b/deploy/uds/Dockerfile.mkgo
@@ -26,6 +26,13 @@ RUN test -f third_party/misskey/packages/backend/assets/favicon.ico || \
     (echo "ERROR: third_party/misskey submodule not initialized (or partial clone)." && \
      echo "Run: git submodule update --init --recursive" && exit 1)
 
+# twemojiは本家frontendがUnicode絵文字描画に使うSVG set (~18MB, 3846 files)。
+# pnpm install 後に node_modules/@discordapp/twemoji として hoist される。
+# make uds-frontend-build を先に走らせる運用のためここに存在する前提。
+RUN test -f third_party/misskey/packages/backend/node_modules/@discordapp/twemoji/dist/svg/1f004.svg || \
+    (echo "ERROR: twemoji assets not found (pnpm install not run?)." && \
+     echo "Run: make uds-frontend-build (installs third_party/misskey node_modules)" && exit 1)
+
 RUN go build -trimpath -ldflags="-s -w" -o /app/built/misskey ./cmd/misskey \
  && go build -trimpath -ldflags="-s -w" -o /app/built/migrate ./cmd/migrate
 
@@ -53,6 +60,19 @@ COPY --from=builder --chown=65532:65532 /app/migration /app/migration
 # ように runtime image側に持たせる。
 COPY --from=builder --chown=65532:65532 /app/third_party/misskey/packages/backend/assets /app/static-assets
 ENV MISSKEY_STATIC_DIR=/app/static-assets
+
+# repo-level assets (ai.png / banner / title など、`third_party/misskey/assets`)
+# は本家frontendが `/assets/ai.png` のようなpathで参照する (mascotImageUrl
+# のデフォルト等)。submodule直下にあるのでsubmodule initで十分取得済み。
+# bind-mount無しで /assets/* が serve できるようにimageへ焼き込む (issue #360)。
+COPY --from=builder --chown=65532:65532 /app/third_party/misskey/assets /app/repo-assets
+ENV MISSKEY_REPO_ASSETS_DIR=/app/repo-assets
+
+# twemoji SVG set (Unicode絵文字描画用)。frontendが /twemoji/<codepoint>.svg
+# で参照する。pnpm install で node_modulesに hoistされたものをそのまま置く
+# (約18MB / 3846 files、imageが重くなるが必要コスト、issue #359)。
+COPY --from=builder --chown=65532:65532 /app/third_party/misskey/packages/backend/node_modules/@discordapp/twemoji/dist/svg /app/twemoji
+ENV MISSKEY_TWEMOJI_DIR=/app/twemoji
 
 COPY --chown=65532:65532 deploy/uds/mkgo-entrypoint.sh /entrypoint.sh
 RUN chmod +x /entrypoint.sh

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,6 +14,7 @@ services:
       # MISSKEY_FRONTEND_DIST_DIR: /app/frontend_dist
       # MISSKEY_TWEMOJI_DIR: /app/twemoji
       # MISSKEY_STATIC_DIR: /app/static
+      # MISSKEY_REPO_ASSETS_DIR: /app/repo-assets
       TZ: Asia/Tokyo
     volumes:
       - ./files:/app/drive-files

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -165,7 +165,8 @@ Meilisearch未設定時はSQL ILIKE検索にフォールバック。
 | `MISSKEY_FRONTEND_DIST_DIR` | ビルド済みフロントエンドディレクトリ |
 | `MISSKEY_TWEMOJI_DIR` | Twemojiアセットディレクトリ |
 | `MISSKEY_CLIENT_ASSETS_DIR` | クライアントアセットディレクトリ |
-| `MISSKEY_STATIC_DIR` | 静的ファイルディレクトリ |
+| `MISSKEY_STATIC_DIR` | 静的ファイルディレクトリ (backend/assets: favicon等) |
+| `MISSKEY_REPO_ASSETS_DIR` | リポジトリ直下アセット (ai.png, banner等) |
 
 ## テスト用環境変数
 

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -32,7 +32,8 @@ docker compose up -d
 - `MISSKEY_FRONTEND_DIST_DIR` — dist出力 (locales, fonts)
 - `MISSKEY_TWEMOJI_DIR` — twemoji SVG
 - `MISSKEY_CLIENT_ASSETS_DIR` — クライアントアセット
-- `MISSKEY_STATIC_DIR` — 静的ファイル
+- `MISSKEY_STATIC_DIR` — 静的ファイル (backend/assets: favicon等)
+- `MISSKEY_REPO_ASSETS_DIR` — リポジトリ直下の共通アセット (ai.png, banner等)
 
 TS版Misskeyのイメージからアセットをコピーすることも可能:
 
@@ -43,11 +44,13 @@ COPY --from=misskey-assets /misskey/built /frontend
 COPY --from=misskey-assets /misskey/packages/frontend/assets /client-assets
 COPY --from=misskey-assets /misskey/packages/backend/node_modules/@discordapp/twemoji/dist/svg /twemoji
 COPY --from=misskey-assets /misskey/packages/backend/assets /static
+COPY --from=misskey-assets /misskey/assets /repo-assets
 ENV MISSKEY_FRONTEND_DIR=/frontend/_frontend_vite_
 ENV MISSKEY_FRONTEND_DIST_DIR=/frontend/_frontend_dist_
 ENV MISSKEY_TWEMOJI_DIR=/twemoji
 ENV MISSKEY_CLIENT_ASSETS_DIR=/client-assets
 ENV MISSKEY_STATIC_DIR=/static
+ENV MISSKEY_REPO_ASSETS_DIR=/repo-assets
 ```
 
 ## Docker Compose (UDS)

--- a/docs/docker-uds.md
+++ b/docs/docker-uds.md
@@ -44,6 +44,13 @@ make uds-frontend-build
 - `third_party/misskey/built/_frontend_vite_/manifest.json`
 - `third_party/misskey/built/_frontend_dist_/`
 
+なお `pnpm install --frozen-lockfile` が本家のnode_modulesも生成するため、以下も同時に揃います。これらは `deploy/uds/Dockerfile.mkgo` が `COPY` で runtime image に焼き込み、mk-go の `/twemoji/*` / `/assets/*` ルートから配信します。
+
+- `third_party/misskey/packages/backend/node_modules/@discordapp/twemoji/dist/svg/` (twemoji SVG set、約18MB)
+- `third_party/misskey/assets/` (`ai.png` 等、約684KB)
+
+`make uds-frontend-build` を省略すると image ビルド時にこれらの存在チェックが fail してビルドが止まります。
+
 ### 2. スタックの起動
 
 ```sh


### PR DESCRIPTION
## Summary

frontend が参照する 2 種類のアセットが runtime image に入っておらず、本番で `/twemoji/<codepoint>.svg` が SPA catchall に吸われて HTML を返し、`/assets/ai.png` が 404 になっていた問題を修正する。

- `/twemoji/*`: frontend が Unicode 絵文字描画に使う SVG set (約18MB、3846 files)
- `/assets/ai.png` 等: `mascotImageUrl` のデフォルト (あい画像) や banner 等の repo 直下アセット (約684KB)

どちらも `#346` で入った `static-assets` と同じパターンで runtime image に焼き込む。bind-mount なしで完結するので production デプロイの負担は増えない。

## 主な変更点

- `Dockerfile` と `deploy/uds/Dockerfile.mkgo` の両方に以下を追加:
  - `third_party/misskey/assets` → `/app/repo-assets` に COPY、`MISSKEY_REPO_ASSETS_DIR` を設定
  - `third_party/misskey/packages/backend/node_modules/@discordapp/twemoji/dist/svg` → `/app/twemoji` に COPY、`MISSKEY_TWEMOJI_DIR` を設定
  - pnpm install 未実行で twemoji が無いときに image build が fail するように fail-fast チェックを追加
- `docs/docker-uds.md` の「本家フロントエンドのビルド」セクションに、twemoji / assets も `make uds-frontend-build` の副産物として揃うこと、省略すると image build が止まることを追記

Go 側の `internal/frontendutil/frontendutil.go` は元から `TwemojiDir()` / `RepoAssetsDir()` を env override 対応で実装済みで、router も登録済みだったため、**Dockerfile の COPY 漏れを埋めるだけ**で動作する。

## テスト

- `go test ./internal/frontendutil/...` — 既存の env override テストが pass
- `make fmt && make lint` clean
- `make uds-build && make uds-up` でローカルスタック再起動成功
- 本番 (go.k7a.org) での確認:

```
$ curl -sI https://go.k7a.org/assets/ai.png | head -3
HTTP/2 200
date: Tue, 21 Apr 2026 13:06:30 GMT
content-type: image/png

$ curl -sI https://go.k7a.org/twemoji/1f60a.svg | head -3
HTTP/2 200
date: Tue, 21 Apr 2026 13:06:31 GMT
content-type: image/svg+xml
```

どちらも 200 + 正しい Content-Type を返すようになった。

## Closes

Closes #359
Closes #360

## その他

- image size が約 18MB 増える (twemoji が支配的)。#346 の static-assets 追加より重いが、実用上許容範囲
- `third_party/misskey/assets` は submodule 直下なので `git submodule update --init --recursive` だけで揃う。twemoji は pnpm install 依存なので `make uds-frontend-build` (または `make e2e-frontend-build`) 実行前提

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/shiroha-a/mk/pull/386" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
