### PR TITLE
Phase 14-2: frontend e2e spec マトリクス拡充 (visibility/userList/cross-instance/delete)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -435,6 +435,7 @@ Issueの作成・操作には`gh`コマンドを使う（`gh issue create`, `gh 
 
 本ドキュメントの主要な変更履歴。新規変更時は一番上に追記する（日付降順）。
 
+- **2026-04-21**: drop-in frontend e2e Phase 14-2 (#387) を追加。spec マトリクスに `visibility.cy.ts` / `user_list.cy.ts` / `cross_instance_view.cy.ts` / `delete_note.cy.ts` の 4 本を追加 (12 passing)。`reply_chain.cy.ts` は federation queue back-pressure で brittle なので #389 で調整後に activate 予定 (現状 `describe.skip`)。共通 setup を `support/setup.ts` に切り出し、cypress plugin task `tokenCache:*` で token を spec 間共有して signin rate limit を回避する。
 - **2026-04-21**: drop-in frontend e2e Phase 14-1 (#381) を追加。3 Misskey TS インスタンス (A/B/C) + cypress runner 構成 (`docker-compose.dropin-frontend.yml` + `tests/dropin_frontend/`) で baseline smoke spec (`smoke.cy.ts`) を動かす。spec マトリクス拡充は Phase 14-2、mk 差し替え overlay + CI 統合は Phase 14-3。
 - **2026-04-21**: drop-in e2e Phase 13-4 (#374) を追加。`.github/workflows/dropin-e2e.yml` で `make dropin-swap-test` を nightly cron (18:00 UTC) + workflow_dispatch で実行。PR の required check には含めず、失敗時は docker compose logs を artifact 化して原因調査できるようにする。
 - **2026-04-21**: drop-in e2e Phase 13-3 (#372) を追加。state preservation 機能マトリクスを 6 シナリオに拡充 (home/followers/specified visibility ノート, user list メタ, user list timeline)。`tests/dropin/test_swap_setup.py` と `test_swap_verify.py` に追加。

--- a/docs/dropin-frontend-e2e.md
+++ b/docs/dropin-frontend-e2e.md
@@ -66,9 +66,23 @@ make dropin-frontend-logs
 
 ## Phase 進捗
 
-- [x] Phase 14-1 (#381): 3 TS 基盤 + cypress smoke spec (本ドキュメント)
-- [ ] Phase 14-2: spec マトリクス拡充 (attachment / delete / reaction / visibility / emoji / userList / reply chain)
+- [x] Phase 14-1 (#381): 3 TS 基盤 + cypress smoke spec
+- [x] Phase 14-2 (#387): spec マトリクス拡充 (visibility / userList / cross-instance / delete)
 - [ ] Phase 14-3: mk-go 差し替え overlay + baseline / swap 両モード orchestrator + CI nightly
+
+## Phase 14-2 カバー spec
+
+| spec | 内容 | 状態 |
+|------|------|------|
+| `smoke.cy.ts` | ping / webfinger / A follows B / C note → A | pass |
+| `visibility.cy.ts` | public / home / followers / specified (DM) 4 種 | pass |
+| `user_list.cy.ts` | alice が list 作成 + bob 追加 + list timeline 取得 | pass |
+| `cross_instance_view.cy.ts` | charlie note を A/B 両方から observe して一致確認 | pass |
+| `delete_note.cy.ts` | charlie 削除 → A/B timeline から消える | pass |
+| `reply_chain.cy.ts` | charlie → bob reply の 2 hop | skip (#389 で調整後 activate) |
+
+attachment / emoji / reaction は Phase 14-2.5 以降 (admin emoji 投入フロー / 
+remote image ingest (#378) / reaction deliver (#369) の条件整備が必要)。
 
 ## トラブルシューティング
 

--- a/tests/dropin_frontend/cypress/cypress.config.ts
+++ b/tests/dropin_frontend/cypress/cypress.config.ts
@@ -1,13 +1,15 @@
 import { defineConfig } from 'cypress';
 
-// Phase 14-1 (#381) drop-in frontend e2e 向け cypress 設定。
+// Phase 14-1 (#381) / Phase 14-2 (#387) drop-in frontend e2e 向け cypress 設定。
 //
-// - spec は `e2e/*.cy.ts` にフラットに置く (階層化は Phase 14-2 で検討)
+// - spec は `e2e/*.cy.ts` にフラットに置く (階層化は 14-2.5 以降で検討)
 // - baseUrl は設定しない (spec 内で 3 instance の URL を個別に叩く)
 // - self-signed cert は `NODE_TLS_REJECT_UNAUTHORIZED=0` を compose で
 //   cypress-runner に渡して node 側 (= cy.request の backing runtime) に
-//   許容させる。Phase 14-2 でブラウザ navigation を足す時は electron 側の
-//   `--ignore-certificate-errors` も別途必要 (現状の cy.request だけなら不要)。
+//   許容させる。
+// - signin rate limit 対策として plugin task (`tokenCache:get` / `tokenCache:set`)
+//   で spec 間共有を実現する。plugin process は cypress run 全体で 1 つだけ
+//   起動されるので、memory 上の変数が spec をまたいで persistent。
 
 export default defineConfig({
   e2e: {
@@ -21,5 +23,19 @@ export default defineConfig({
     defaultCommandTimeout: 15_000,
     requestTimeout: 30_000,
     responseTimeout: 30_000,
+
+    setupNodeEvents(on) {
+      const cache: Record<string, unknown> = {};
+      on('task', {
+        // unknown な key は null を返す (cypress task は undefined を許さない)。
+        'tokenCache:get': (key: string) => {
+          return cache[key] ?? null;
+        },
+        'tokenCache:set': ({ key, value }: { key: string; value: unknown }) => {
+          cache[key] = value;
+          return null;
+        },
+      });
+    },
   },
 });

--- a/tests/dropin_frontend/cypress/e2e/cross_instance_view.cy.ts
+++ b/tests/dropin_frontend/cypress/e2e/cross_instance_view.cy.ts
@@ -4,8 +4,8 @@
 // から観測した note (text / user.username / user.host) が一致することを確認。
 // federation delivery の整合性が取れているか = 同じ原本が両サイドで見えるか。
 //
-// 観測先は `notes/timeline` (home 経由) に加えて `users/notes` (by userId) も
-// 見て、両 path で一致することを検証する。
+// 観測先は `notes/timeline` (home 経由) のみ。A と B の home それぞれに
+// charlie の note が届いて同一内容に見えれば十分。
 
 import { api, INSTANCES } from '../support/api';
 import { establishFederation, setupTrio, waitForNoteInTimeline, Trio } from '../support/setup';
@@ -20,7 +20,7 @@ describe('dropin-frontend cross-instance view (Phase 14-2)', () => {
     cy.then(() => establishFederation(trio));
   });
 
-  it('charlie の 1 note が A と B で同じ text / author として観測できる', () => {
+  it('charlie note is observed identically on A and B via federation', () => {
     const marker = `phase14-cross-${Date.now()}`;
 
     api(INSTANCES.c, 'notes/create', {

--- a/tests/dropin_frontend/cypress/e2e/cross_instance_view.cy.ts
+++ b/tests/dropin_frontend/cypress/e2e/cross_instance_view.cy.ts
@@ -1,0 +1,71 @@
+// Phase 14-2 (#387) cross-instance view consistency.
+//
+// charlie が 1 つ public note を投稿して、A と B それぞれの cypress セッション
+// から観測した note (text / user.username / user.host) が一致することを確認。
+// federation delivery の整合性が取れているか = 同じ原本が両サイドで見えるか。
+//
+// 観測先は `notes/timeline` (home 経由) に加えて `users/notes` (by userId) も
+// 見て、両 path で一致することを検証する。
+
+import { api, INSTANCES } from '../support/api';
+import { establishFederation, setupTrio, waitForNoteInTimeline, Trio } from '../support/setup';
+
+describe('dropin-frontend cross-instance view (Phase 14-2)', () => {
+  let trio: Trio;
+
+  before(() => {
+    setupTrio().then((t) => {
+      trio = t;
+    });
+    cy.then(() => establishFederation(trio));
+  });
+
+  it('charlie の 1 note が A と B で同じ text / author として観測できる', () => {
+    const marker = `phase14-cross-${Date.now()}`;
+
+    api(INSTANCES.c, 'notes/create', {
+      i: trio.charlie.token,
+      text: marker,
+      visibility: 'public',
+    });
+
+    // A と B 両方に届くまで待つ
+    cy.then(() => waitForNoteInTimeline(trio.alice, marker, { retries: 40 }));
+    cy.then(() => waitForNoteInTimeline(trio.bob, marker, { retries: 40 }));
+
+    // A 側で見える note
+    let aSide: Record<string, unknown> | undefined;
+    cy.then(() =>
+      api(INSTANCES.a, 'notes/timeline', {
+        i: trio.alice.token,
+        limit: 40,
+      }).then((resp) => {
+        aSide = (resp.body as Record<string, unknown>[]).find((n) => n.text === marker);
+        expect(aSide, 'note visible on instance A').to.exist;
+      }),
+    );
+
+    // B 側で見える note
+    let bSide: Record<string, unknown> | undefined;
+    cy.then(() =>
+      api(INSTANCES.b, 'notes/timeline', {
+        i: trio.bob.token,
+        limit: 40,
+      }).then((resp) => {
+        bSide = (resp.body as Record<string, unknown>[]).find((n) => n.text === marker);
+        expect(bSide, 'note visible on instance B').to.exist;
+      }),
+    );
+
+    // author と text が一致する
+    cy.then(() => {
+      expect(aSide!.text).to.eq(bSide!.text);
+      const aUser = aSide!.user as Record<string, unknown>;
+      const bUser = bSide!.user as Record<string, unknown>;
+      expect(aUser.username).to.eq('charlie');
+      expect(bUser.username).to.eq('charlie');
+      expect(aUser.host).to.eq(INSTANCES.c.domain);
+      expect(bUser.host).to.eq(INSTANCES.c.domain);
+    });
+  });
+});

--- a/tests/dropin_frontend/cypress/e2e/delete_note.cy.ts
+++ b/tests/dropin_frontend/cypress/e2e/delete_note.cy.ts
@@ -19,7 +19,7 @@ describe('dropin-frontend delete propagation (Phase 14-2)', () => {
     cy.then(() => establishFederation(trio));
   });
 
-  it('charlie がノートを削除すると A と B の timeline から消える', () => {
+  it('charlie deletes a note and it disappears from A and B timelines', () => {
     const marker = `phase14-delete-${Date.now()}`;
     let originalId = '';
 

--- a/tests/dropin_frontend/cypress/e2e/delete_note.cy.ts
+++ b/tests/dropin_frontend/cypress/e2e/delete_note.cy.ts
@@ -1,0 +1,76 @@
+// Phase 14-2 (#387) ノート削除の federation 伝播検証。
+//
+// charlie が public note を投稿 → alice / bob の home に届く → charlie が削除
+// → alice / bob の timeline からも消える、を確認。
+//
+// Misskey TS 同士なら baseline として通るべき挙動。Phase 14-3 で mk-A 切替時
+// に #379 (削除済ノートが TL に残存) が regression として検出される予定。
+
+import { api, INSTANCES } from '../support/api';
+import { establishFederation, setupTrio, waitForNoteInTimeline, Trio } from '../support/setup';
+
+describe('dropin-frontend delete propagation (Phase 14-2)', () => {
+  let trio: Trio;
+
+  before(() => {
+    setupTrio().then((t) => {
+      trio = t;
+    });
+    cy.then(() => establishFederation(trio));
+  });
+
+  it('charlie がノートを削除すると A と B の timeline から消える', () => {
+    const marker = `phase14-delete-${Date.now()}`;
+    let originalId = '';
+
+    // charlie が投稿
+    api(INSTANCES.c, 'notes/create', {
+      i: trio.charlie.token,
+      text: marker,
+      visibility: 'public',
+    }).then((resp) => {
+      originalId = resp.body.createdNote.id;
+    });
+
+    // A / B 両方で一度届くのを確認する (= 削除テストの前提条件)
+    cy.then(() => waitForNoteInTimeline(trio.alice, marker, { retries: 40 }));
+    cy.then(() => waitForNoteInTimeline(trio.bob, marker, { retries: 40 }));
+
+    // charlie が削除
+    cy.then(() =>
+      api(INSTANCES.c, 'notes/delete', {
+        i: trio.charlie.token,
+        noteId: originalId,
+      }).then((resp) => {
+        expect(resp.status).to.be.oneOf([200, 204]);
+      }),
+    );
+
+    // A 側から消えるまで poll
+    const pollGone = (viewer: typeof trio.alice, inst: typeof INSTANCES.a) =>
+      cy.then(() => {
+        const attempt = (left: number): Cypress.Chainable => {
+          return api(inst, 'notes/timeline', {
+            i: viewer.token,
+            limit: 40,
+          }).then((resp) => {
+            const stillThere =
+              resp.status === 200 &&
+              Array.isArray(resp.body) &&
+              resp.body.some((n: Record<string, unknown>) => n.text === marker);
+            if (!stillThere) return resp;
+            if (left <= 0) {
+              throw new Error(
+                `note "${marker}" still visible on ${inst.domain} after delete`,
+              );
+            }
+            return cy.wait(3_000, { log: false }).then(() => attempt(left - 1));
+          });
+        };
+        attempt(30);
+      });
+
+    pollGone(trio.alice, INSTANCES.a);
+    pollGone(trio.bob, INSTANCES.b);
+  });
+});

--- a/tests/dropin_frontend/cypress/e2e/delete_note.cy.ts
+++ b/tests/dropin_frontend/cypress/e2e/delete_note.cy.ts
@@ -46,7 +46,9 @@ describe('dropin-frontend delete propagation (Phase 14-2)', () => {
       }),
     );
 
-    // A 側から消えるまで poll
+    // A 側から消えるまで poll。non-200 / 非配列 response は "削除成功"
+    // とせず retry を続ける (Devin #390-2 #1): 過渡的な 500 などを false
+    // positive にしないため。
     const pollGone = (viewer: typeof trio.alice, inst: typeof INSTANCES.a) =>
       cy.then(() => {
         const attempt = (left: number): Cypress.Chainable => {
@@ -54,12 +56,20 @@ describe('dropin-frontend delete propagation (Phase 14-2)', () => {
             i: viewer.token,
             limit: 40,
           }).then((resp) => {
-            const stillThere =
-              resp.status === 200 &&
-              Array.isArray(resp.body) &&
-              resp.body.some((n: Record<string, unknown>) => n.text === marker);
-            if (!stillThere) return resp;
+            const okBody = resp.status === 200 && Array.isArray(resp.body);
+            if (okBody) {
+              const stillThere = (resp.body as Record<string, unknown>[]).some(
+                (n) => n.text === marker,
+              );
+              if (!stillThere) return resp;
+            }
+            // response が壊れているか、まだ note が見える場合は retry
             if (left <= 0) {
+              if (!okBody) {
+                throw new Error(
+                  `timeline fetch never returned 200 array on ${inst.domain} (last status ${resp.status})`,
+                );
+              }
               throw new Error(
                 `note "${marker}" still visible on ${inst.domain} after delete`,
               );

--- a/tests/dropin_frontend/cypress/e2e/reply_chain.cy.ts
+++ b/tests/dropin_frontend/cypress/e2e/reply_chain.cy.ts
@@ -21,7 +21,7 @@ describe.skip('dropin-frontend reply chain (Phase 14-2, skipped — #389)', () =
     cy.then(() => establishFederation(trio));
   });
 
-  it('charlie の note に bob が reply した chain が alice に届く', () => {
+  it('bob reply to charlie note reaches alice via federation', () => {
     const tag = Date.now().toString();
     const originalText = `phase14-chain-origin-${tag}`;
     const bobReplyText = `phase14-chain-bob-${tag}`;

--- a/tests/dropin_frontend/cypress/e2e/reply_chain.cy.ts
+++ b/tests/dropin_frontend/cypress/e2e/reply_chain.cy.ts
@@ -1,0 +1,64 @@
+// Phase 14-2 (#387) reply chain の federation 連鎖検証 (簡略版)。
+//
+// charlie → bob reply の 2 hop chain が A に届くまで確認する。実装開始時に
+// 4 hop (charlie → bob → charlie → alice) も組んだが、各 hop で AP ack を
+// 待つため 2 分程度かかり cypress の default timeout 超過で不安定だった
+// ため絞った。4 hop 版は Phase 14-2.5 以降 timeout 調整した上で追加検討。
+
+import { api, INSTANCES } from '../support/api';
+import { establishFederation, setupTrio, waitForNoteInTimeline, Trio } from '../support/setup';
+
+// NOTE: Phase 14-2 時点では 3 instance 間の reply chain federation が複数
+// spec 同時走行の queue back-pressure で不安定なため一旦 skip する。後続で
+// timeout 調整 / spec 分離 / 単独 nightly 等で再 activate する (#389)。
+describe.skip('dropin-frontend reply chain (Phase 14-2, skipped — #389)', () => {
+  let trio: Trio;
+
+  before(() => {
+    setupTrio().then((t) => {
+      trio = t;
+    });
+    cy.then(() => establishFederation(trio));
+  });
+
+  it('charlie の note に bob が reply した chain が alice に届く', () => {
+    const tag = Date.now().toString();
+    const originalText = `phase14-chain-origin-${tag}`;
+    const bobReplyText = `phase14-chain-bob-${tag}`;
+
+    let originalId = '';
+
+    // charlie が起点 note を投稿
+    api(INSTANCES.c, 'notes/create', {
+      i: trio.charlie.token,
+      text: originalText,
+      visibility: 'public',
+    }).then((resp) => {
+      originalId = resp.body.createdNote.id;
+    });
+
+    // alice の home に charlie ノートが届くまで待つ
+    cy.then(() => waitForNoteInTimeline(trio.alice, originalText, { retries: 40 }));
+
+    // bob が AP resolve で charlie の note を取得して reply する
+    cy.then(() =>
+      api(INSTANCES.b, 'ap/show', {
+        i: trio.bob.token,
+        uri: `${INSTANCES.c.url}/notes/${originalId}`,
+      }).then((apResp) => {
+        const bobSideOriginalId = apResp.body.object.id;
+        return api(INSTANCES.b, 'notes/create', {
+          i: trio.bob.token,
+          text: bobReplyText,
+          replyId: bobSideOriginalId,
+          visibility: 'public',
+        }).then((r) => {
+          expect(r.status).to.eq(200);
+        });
+      }),
+    );
+
+    // alice の home に bob reply が届くまで待つ
+    cy.then(() => waitForNoteInTimeline(trio.alice, bobReplyText, { retries: 40 }));
+  });
+});

--- a/tests/dropin_frontend/cypress/e2e/user_list.cy.ts
+++ b/tests/dropin_frontend/cypress/e2e/user_list.cy.ts
@@ -1,0 +1,97 @@
+// Phase 14-2 (#387) user list membership + list timeline 検証。
+//
+// alice が `dropin-buddies` list を作成し、bob (remote) を member として追加。
+// - `users/lists/list` に list が載る
+// - `notes/user-list-timeline` で bob のノートが引ける (= membership が効いている)
+
+import { api, INSTANCES } from '../support/api';
+import { establishFederation, setupTrio, Trio } from '../support/setup';
+
+const LIST_NAME = 'dropin-buddies-phase14';
+
+describe('dropin-frontend user list (Phase 14-2)', () => {
+  let trio: Trio;
+  let listId: string;
+
+  before(() => {
+    setupTrio().then((t) => {
+      trio = t;
+    });
+    cy.then(() => establishFederation(trio));
+  });
+
+  it('alice creates a user list and pushes remote bob as member', () => {
+    // 既存 (再実行時に残存) list を再利用する
+    api(INSTANCES.a, 'users/lists/list', { i: trio.alice.token }).then((listResp) => {
+      const existing = Array.isArray(listResp.body)
+        ? listResp.body.find((l: Record<string, unknown>) => l.name === LIST_NAME)
+        : undefined;
+      if (existing) {
+        listId = existing.id as string;
+        return;
+      }
+      return api(INSTANCES.a, 'users/lists/create', {
+        i: trio.alice.token,
+        name: LIST_NAME,
+      }).then((createResp) => {
+        listId = createResp.body.id;
+      });
+    });
+
+    // bob の remote id を resolve
+    cy.then(() => {
+      return api(INSTANCES.a, 'users/show', {
+        i: trio.alice.token,
+        username: 'bob',
+        host: INSTANCES.b.domain,
+      }).then((showResp) => {
+        const remoteBobId = showResp.body.id;
+        return api(INSTANCES.a, 'users/lists/push', {
+          i: trio.alice.token,
+          listId,
+          userId: remoteBobId,
+        }).then((pushResp) => {
+          if (pushResp.status !== 204 && pushResp.status !== 200) {
+            const code = pushResp.body?.error?.code;
+            if (code !== 'ALREADY_ADDED') {
+              throw new Error(
+                `list push failed: ${pushResp.status} ${JSON.stringify(pushResp.body)}`,
+              );
+            }
+          }
+        });
+      });
+    });
+  });
+
+  it("bob's note appears in alice's user-list-timeline", () => {
+    const marker = `phase14-list-${Date.now()}`;
+    api(INSTANCES.b, 'notes/create', {
+      i: trio.bob.token,
+      text: marker,
+      visibility: 'public',
+    });
+
+    // list timeline は Redis fanout + DB fallback で引く
+    const poll = (left: number): Cypress.Chainable => {
+      return api(INSTANCES.a, 'notes/user-list-timeline', {
+        i: trio.alice.token,
+        listId,
+        limit: 40,
+      }).then((resp) => {
+        if (
+          resp.status === 200 &&
+          Array.isArray(resp.body) &&
+          resp.body.some((n: Record<string, unknown>) => n.text === marker)
+        ) {
+          return resp;
+        }
+        if (left <= 0) {
+          throw new Error(`user-list-timeline never included "${marker}"`);
+        }
+        return cy.wait(3_000, { log: false }).then(() => poll(left - 1));
+      });
+    };
+    poll(40);
+  });
+});

--- a/tests/dropin_frontend/cypress/e2e/visibility.cy.ts
+++ b/tests/dropin_frontend/cypress/e2e/visibility.cy.ts
@@ -1,0 +1,94 @@
+// Phase 14-2 (#387) visibility 種別の federation 挙動検証。
+//
+// bob (on B) が alice (on A, フォロワー) 向けに public / home / followers /
+// specified の 4 種 visibility ノートを投稿する。alice 側の home timeline と
+// mentions に届くべきものだけが届くことを確認する。
+
+import { api, INSTANCES } from '../support/api';
+import { establishFederation, setupTrio, waitForNoteInTimeline, Trio } from '../support/setup';
+
+describe('dropin-frontend visibility (Phase 14-2)', () => {
+  let trio: Trio;
+
+  before(() => {
+    setupTrio().then((t) => {
+      trio = t;
+    });
+    cy.then(() => establishFederation(trio));
+  });
+
+  it('public note from bob reaches alice home timeline', () => {
+    const marker = `phase14-vis-public-${Date.now()}`;
+    api(INSTANCES.b, 'notes/create', {
+      i: trio.bob.token,
+      text: marker,
+      visibility: 'public',
+    });
+    waitForNoteInTimeline(trio.alice, marker);
+  });
+
+  it('home visibility note from bob reaches alice home timeline', () => {
+    const marker = `phase14-vis-home-${Date.now()}`;
+    api(INSTANCES.b, 'notes/create', {
+      i: trio.bob.token,
+      text: marker,
+      visibility: 'home',
+    });
+    waitForNoteInTimeline(trio.alice, marker);
+  });
+
+  it('followers visibility note from bob reaches alice home timeline', () => {
+    const marker = `phase14-vis-followers-${Date.now()}`;
+    api(INSTANCES.b, 'notes/create', {
+      i: trio.bob.token,
+      text: marker,
+      visibility: 'followers',
+    });
+    waitForNoteInTimeline(trio.alice, marker);
+  });
+
+  it('specified DM from bob does not appear in alice home but does in mentions', () => {
+    const marker = `phase14-vis-specified-${Date.now()}`;
+
+    // bob から見た alice@a の remote id を resolve
+    cy.request({
+      method: 'POST',
+      url: `${INSTANCES.b.url}/api/users/show`,
+      body: { i: trio.bob.token, username: 'alice', host: INSTANCES.a.domain },
+    }).then((resp) => {
+      const remoteAliceId = resp.body.id;
+      return api(INSTANCES.b, 'notes/create', {
+        i: trio.bob.token,
+        text: marker,
+        visibility: 'specified',
+        visibleUserIds: [remoteAliceId],
+      });
+    });
+
+    // specified は home に現れない。mentions 経由で確認する。Misskey TS は
+    // `notes/mentions` default で DM も含む (mk-go は visibility=specified
+    // 指定が必要な別仕様) ので baseline (all TS) では default query で届く。
+    // Phase 14-3 で mk 差し替え時にここの挙動差が見えてくるはず。
+    cy.then(() => {
+      const poll = (left: number): Cypress.Chainable => {
+        return api(INSTANCES.a, 'notes/mentions', {
+          i: trio.alice.token,
+          limit: 40,
+        }).then((resp) => {
+          if (
+            resp.status === 200 &&
+            Array.isArray(resp.body) &&
+            resp.body.some((n: Record<string, unknown>) => n.text === marker)
+          ) {
+            return resp;
+          }
+          if (left <= 0) {
+            throw new Error(`alice never saw specified DM "${marker}" in mentions`);
+          }
+          return cy.wait(3_000, { log: false }).then(() => poll(left - 1));
+        });
+      };
+      poll(30);
+    });
+  });
+});

--- a/tests/dropin_frontend/cypress/e2e/visibility.cy.ts
+++ b/tests/dropin_frontend/cypress/e2e/visibility.cy.ts
@@ -67,10 +67,12 @@ describe('dropin-frontend visibility (Phase 14-2)', () => {
       });
     });
 
-    // specified は home に現れない。mentions 経由で確認する。Misskey TS は
+    // specified DM を mentions 経由で確認する。Misskey TS は
     // `notes/mentions` default で DM も含む (mk-go は visibility=specified
-    // 指定が必要な別仕様) ので baseline (all TS) では default query で届く。
+    // 指定が必要な別仕様)。baseline (all TS) では default query で届く。
     // Phase 14-3 で mk 差し替え時にここの挙動差が見えてくるはず。
+    // なお下記 home timeline assertion で判明した通り TS 2025.2.1 は
+    // specified が自分宛の場合 home にも表示するのが default 挙動。
     cy.then(() => {
       const poll = (left: number): Cypress.Chainable => {
         return api(INSTANCES.a, 'notes/mentions', {

--- a/tests/dropin_frontend/cypress/e2e/visibility.cy.ts
+++ b/tests/dropin_frontend/cypress/e2e/visibility.cy.ts
@@ -47,15 +47,17 @@ describe('dropin-frontend visibility (Phase 14-2)', () => {
     waitForNoteInTimeline(trio.alice, marker);
   });
 
-  it('specified DM from bob does not appear in alice home but does in mentions', () => {
+  it('specified DM from bob arrives in alice mentions (and home, per TS baseline)', () => {
     const marker = `phase14-vis-specified-${Date.now()}`;
 
-    // bob から見た alice@a の remote id を resolve
-    cy.request({
-      method: 'POST',
-      url: `${INSTANCES.b.url}/api/users/show`,
-      body: { i: trio.bob.token, username: 'alice', host: INSTANCES.a.domain },
+    // bob から見た alice@a の remote id を resolve。api() helper で統一
+    // (Devin #390-2 #6)。
+    api(INSTANCES.b, 'users/show', {
+      i: trio.bob.token,
+      username: 'alice',
+      host: INSTANCES.a.domain,
     }).then((resp) => {
+      expect(resp.status, 'bob can resolve alice').to.eq(200);
       const remoteAliceId = resp.body.id;
       return api(INSTANCES.b, 'notes/create', {
         i: trio.bob.token,
@@ -89,6 +91,27 @@ describe('dropin-frontend visibility (Phase 14-2)', () => {
         });
       };
       poll(30);
+    });
+
+    // home timeline での挙動も確認する。Misskey TS 2025.2.1 の実挙動は
+    // specified で自分が recipient の場合 home にも表示されるので、
+    // baseline としてはそれを golden にする。Phase 14-3 で mk-A に差し替えた
+    // ときにこの挙動が一致するかが互換性チェックとなる (もし TS の挙動が
+    // 変わっていたら mk もそれに追従する必要がある)。
+    cy.then(() => {
+      api(INSTANCES.a, 'notes/timeline', {
+        i: trio.alice.token,
+        limit: 40,
+      }).then((resp) => {
+        expect(resp.status, 'home timeline fetch').to.eq(200);
+        const presentInHome = (resp.body as Record<string, unknown>[]).some(
+          (n) => n.text === marker,
+        );
+        expect(
+          presentInHome,
+          'specified DM appears in home timeline on TS baseline (per 2025.2.1 実挙動)',
+        ).to.eq(true);
+      });
     });
   });
 });

--- a/tests/dropin_frontend/cypress/support/setup.ts
+++ b/tests/dropin_frontend/cypress/support/setup.ts
@@ -121,12 +121,30 @@ export function followRemote(viewer: Principal, target: Principal): Cypress.Chai
     );
 }
 
-// A→B, A→C, B→C の mutual follow を全部張る。
+// A→B, A→C, B→C の**片方向** follow を 3 本張る。alice が bob / charlie を
+// follow、bob が charlie を follow する形。Phase 14-2 時点の spec は
+// "follower が followee のノートを home で受け取る" 検証に使うため片方向で
+// 十分。逆方向 (B→A, C→A, C→B) が必要になる場合 (例: bob が alice の
+// followers-visibility note を見るテスト) は別関数で拡張する。
 export function establishFederation(trio: Trio): Cypress.Chainable {
   return cy
     .then(() => followRemote(trio.alice, trio.bob))
     .then(() => followRemote(trio.alice, trio.charlie))
     .then(() => followRemote(trio.bob, trio.charlie));
+}
+
+// A↔B, A↔C, B↔C の 6 本 bidirectional follow を張る。establishFederation が
+// 片方向で足りない spec (例: bob が alice の followers-only note を観測) の
+// ために用意。Phase 14-2 時点では未使用だが Phase 14-3 以降で追加予定
+// (Devin #390)。
+export function establishMutualFederation(trio: Trio): Cypress.Chainable {
+  return cy
+    .then(() => followRemote(trio.alice, trio.bob))
+    .then(() => followRemote(trio.bob, trio.alice))
+    .then(() => followRemote(trio.alice, trio.charlie))
+    .then(() => followRemote(trio.charlie, trio.alice))
+    .then(() => followRemote(trio.bob, trio.charlie))
+    .then(() => followRemote(trio.charlie, trio.bob));
 }
 
 // 一つのノート投稿 + 指定 instance の timeline に届くまで poll。

--- a/tests/dropin_frontend/cypress/support/setup.ts
+++ b/tests/dropin_frontend/cypress/support/setup.ts
@@ -1,0 +1,151 @@
+// Phase 14-2 (#387) 以降で複数 spec から共用する federation setup helper。
+//
+// 3 instance (A, B, C) 全てに alice / bob / charlie を作って互いに follow
+// 済にするには AP handshake (resolve + Follow Accept) 完了を待つ必要がある。
+// 各 spec が before で独立に呼べるよう idempotent に設計する。
+//
+// 一度 setup が完了した DB (= compose を down しない run) であれば、
+// 次回以降は signin-flow だけで速く通過する。
+
+import { api, createRootOrSignin, INSTANCES, retryUntil, waitForInstance } from './api';
+
+export interface Principal {
+  id: string;
+  token: string;
+  username: string;
+  instance: keyof typeof INSTANCES;
+}
+
+export interface Trio {
+  alice: Principal;
+  bob: Principal;
+  charlie: Principal;
+}
+
+// 3 instance が ready なのを待ち、alice/bob/charlie を作成/再利用する。
+//
+// cypress は spec ごとに新しい runner プロセスで起動するため memory 上の
+// token を再利用できない。admin/accounts/create は root 作成時しか通らず
+// 2 回目以降は signin-flow にフォールバックする。signin-flow は Misskey の
+// rate limit に引っかかって 429 を返すため、6 spec × 3 instance = 18 回
+// 連続で叩くと rate limit 窓内で溢れる。
+//
+// 対策: cypress plugin task (`tokenCache:*`) で spec 間共有する。plugin
+// process は cypress run 全体で 1 つなので memory 上の変数が persistent。
+const CACHE_KEY = 'trio';
+
+export function setupTrio(): Cypress.Chainable<Trio> {
+  waitForInstance(INSTANCES.a);
+  waitForInstance(INSTANCES.b);
+  waitForInstance(INSTANCES.c);
+
+  return cy.task<Trio | null>('tokenCache:get', CACHE_KEY).then((cached) => {
+    if (cached && cached.alice?.token && cached.bob?.token && cached.charlie?.token) {
+      return cy.wrap(cached);
+    }
+    return freshSetupTrio();
+  });
+}
+
+function freshSetupTrio(): Cypress.Chainable<Trio> {
+  const trio = {} as Trio;
+  return createRootOrSignin(INSTANCES.a, 'alice', 'password1234')
+    .then((r) => {
+      trio.alice = { ...r, username: 'alice', instance: 'a' };
+    })
+    .then(() => createRootOrSignin(INSTANCES.b, 'bob', 'password1234'))
+    .then((r) => {
+      trio.bob = { ...r, username: 'bob', instance: 'b' };
+    })
+    .then(() => createRootOrSignin(INSTANCES.c, 'charlie', 'password1234'))
+    .then((r) => {
+      trio.charlie = { ...r, username: 'charlie', instance: 'c' };
+    })
+    .then(() => cy.task('tokenCache:set', { key: CACHE_KEY, value: trio }))
+    .then(() => cy.wrap(trio));
+}
+
+// source instance の viewer が target Principal (= remote user + own token) を
+// AP resolve して follow する。既 follow は許容。AP Follow ack の反映
+// (target 側 instance の followers list に source が載る) まで待つ。
+export function followRemote(viewer: Principal, target: Principal): Cypress.Chainable {
+  const viewerInst = INSTANCES[viewer.instance];
+  const targetInst = INSTANCES[target.instance];
+
+  return retryUntil(
+    () =>
+      api(viewerInst, 'users/show', {
+        i: viewer.token,
+        username: target.username,
+        host: targetInst.domain,
+      }),
+    (resp) => resp.status === 200 && resp.body?.username === target.username,
+  )
+    .then((resp) => {
+      const remoteId = resp.body.id;
+      return api(viewerInst, 'following/create', {
+        i: viewer.token,
+        userId: remoteId,
+      });
+    })
+    .then((followResp) => {
+      if (followResp.status !== 204 && followResp.status !== 200) {
+        const code = followResp.body?.error?.code;
+        if (code !== 'ALREADY_FOLLOWING') {
+          throw new Error(
+            `follow failed: ${followResp.status} ${JSON.stringify(followResp.body)}`,
+          );
+        }
+      }
+    })
+    .then(() =>
+      // target 側 instance に follower として載るのを待つ (AP ack まで)。
+      // users/followers は Misskey では認証必須なので target 自身の token を使う。
+      retryUntil(
+        () =>
+          api(targetInst, 'users/followers', {
+            i: target.token,
+            userId: target.id,
+          }),
+        (resp) => {
+          if (resp.status !== 200 || !Array.isArray(resp.body)) {
+            return false;
+          }
+          return resp.body.some((f: Record<string, unknown>) => {
+            const follower = (f.follower ?? f) as Record<string, unknown>;
+            return (follower.host ?? follower.followerHost) === viewerInst.domain;
+          });
+        },
+        { retries: 30, interval: 3_000 },
+      ),
+    );
+}
+
+// A→B, A→C, B→C の mutual follow を全部張る。
+export function establishFederation(trio: Trio): Cypress.Chainable {
+  return cy
+    .then(() => followRemote(trio.alice, trio.bob))
+    .then(() => followRemote(trio.alice, trio.charlie))
+    .then(() => followRemote(trio.bob, trio.charlie));
+}
+
+// 一つのノート投稿 + 指定 instance の timeline に届くまで poll。
+export function waitForNoteInTimeline(
+  viewer: Principal,
+  text: string,
+  opts: { retries?: number; interval?: number } = {},
+): Cypress.Chainable {
+  const inst = INSTANCES[viewer.instance];
+  return retryUntil(
+    () =>
+      api(inst, 'notes/timeline', {
+        i: viewer.token,
+        limit: 40,
+      }),
+    (resp) =>
+      resp.status === 200 &&
+      Array.isArray(resp.body) &&
+      resp.body.some((n: Record<string, unknown>) => n.text === text),
+    { retries: opts.retries ?? 30, interval: opts.interval ?? 3_000 },
+  );
+}


### PR DESCRIPTION
## Summary

#380 (Phase 14 frontend e2e drop-in) のサブ 2。Phase 14-1 で構築した 3 Misskey TS + cypress runner 基盤に、**state preservation を広く検証する spec を 5 本追加** する (#389 で触れる reply chain は一旦 skip)。

## 主な変更点

### 新規 spec (`tests/dropin_frontend/cypress/e2e/`)

| spec | 検証内容 | 結果 |
|------|---------|------|
| `visibility.cy.ts` | bob → alice の public / home / followers / specified (DM) 各 visibility の federation 到達 | 4/4 pass |
| `user_list.cy.ts` | alice が list 作成 + remote bob 追加 + list timeline で bob ノート取得 | 2/2 pass |
| `cross_instance_view.cy.ts` | charlie の 1 note が A と B で同一内容 (text / user.username / host) に見えること | 1/1 pass |
| `delete_note.cy.ts` | charlie 投稿 → A/B が見る → charlie 削除 → A/B から消える (#379 regression detection) | 1/1 pass |
| `reply_chain.cy.ts` | charlie → bob reply の 2 hop | 0/1 skipped (#389) |

### 新規 helper (`tests/dropin_frontend/cypress/support/setup.ts`)

- `setupTrio()`: 3 instance ready 待ち + alice/bob/charlie 作成 / 再利用
- `followRemote(viewer, target)`: AP resolve + follow + ack 待ちを一本化
- `establishFederation(trio)`: 3 人間の mutual follow を張る
- `waitForNoteInTimeline(viewer, text)`: home timeline poll

### 既存への変更

- `tests/dropin_frontend/cypress/cypress.config.ts`: `setupNodeEvents` で `tokenCache:get` / `tokenCache:set` plugin task を登録
- `docs/dropin-frontend-e2e.md`: Phase 14-2 カバー表を追記
- `CLAUDE.md`: 更新記録に追記

### 設計上のポイント

- **signin rate limit 回避**: cypress は spec ごとに新しい runner で起動するため、6 spec × 3 instance = 18 回連続 `signin-flow` を叩くと Misskey TS の 429 rate limit にヒットする。plugin process は cypress run 全体で 1 つなので、plugin task で token を memory キャッシュし、spec 間で共有する。
- **reply chain skip**: 3 instance 同時走行で AP deliver queue back-pressure が発生し、`waitForNoteInTimeline` の 120s retry が exhaust するケースがあった。#389 で調整後に activate 予定。

## テスト結果

clean `make dropin-frontend-baseline` で:

```
✔  cross_instance_view.cy.ts                00:03        1        1        -        -        -
✔  delete_note.cy.ts                        00:03        1        1        -        -        -
-  reply_chain.cy.ts                        skipped (#389)
✔  smoke.cy.ts                              00:03        4        4        -        -        -
✔  user_list.cy.ts                          00:03        2        2        -        -        -
✔  visibility.cy.ts                         00:12        4        4        -        -        -
✔  All specs passed!                        00:39       13       12        -        1        -
```

## Phase 14 残り

- [ ] Phase 14-3: mk-go 差し替え overlay + baseline / swap 両モード orchestrator + GitHub Actions nightly 統合
- (任意) #389 reply chain spec の stability 向上

Closes #387

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/shiroha-a/mk/pull/390" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
