### PR TITLE
Fix #351: ingest remote instance iconUrl / faviconUrl on first contact

### DIFF
--- a/internal/activitypub/client.go
+++ b/internal/activitypub/client.go
@@ -109,3 +109,27 @@ func (c *Client) FetchUnsigned(url string) ([]byte, error) {
 	}
 	return safehttp.ReadAllLimit(resp.Body, MaxBodyBytes)
 }
+
+// FetchHTML performs a plain GET with Accept: text/html. リモートインスタンスの
+// トップページを取得して <link rel="icon"> 等を抽出するための用途を想定。
+// 同じhttpClient (SSRF guard / timeout / redirect policy) を使うので nodeinfo
+// 取得と同水準の安全策が効く。
+func (c *Client) FetchHTML(url string) ([]byte, error) {
+	req, err := http.NewRequest(http.MethodGet, url, nil)
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("Accept", "text/html,application/xhtml+xml,*/*;q=0.5")
+	if c.userAgent != "" {
+		req.Header.Set("User-Agent", c.userAgent)
+	}
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return nil, errors.New("unexpected status: " + resp.Status)
+	}
+	return safehttp.ReadAllLimit(resp.Body, MaxBodyBytes)
+}

--- a/internal/activitypub/client.go
+++ b/internal/activitypub/client.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"errors"
 	"net/http"
+	"strings"
 
 	"github.com/shiroha-a/mk/internal/safehttp"
 )
@@ -136,6 +137,16 @@ func (c *Client) FetchHTML(url string) ([]byte, error) {
 	defer resp.Body.Close()
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
 		return nil, errors.New("unexpected status: " + resp.Status)
+	}
+	// Content-Type が明示的に text/html(または xhtml)以外なら 5 MiB まで
+	// 読み込まず早期 error。相手が JSON / binaryを返すケースで帯域と
+	// メモリを無駄にしない (Devin #4 指摘)。Content-Type 未設定は許容する
+	// (一部の古いサーバーが含めないため)。
+	if ct := resp.Header.Get("Content-Type"); ct != "" {
+		lower := strings.ToLower(ct)
+		if !strings.Contains(lower, "text/html") && !strings.Contains(lower, "application/xhtml") {
+			return nil, errors.New("unexpected content-type: " + ct)
+		}
 	}
 	return safehttp.ReadAllLimit(resp.Body, MaxHTMLBodyBytes)
 }

--- a/internal/activitypub/client.go
+++ b/internal/activitypub/client.go
@@ -12,6 +12,12 @@ import (
 // prevent memory exhaustion via attacker-controlled remote AP servers (#323).
 const MaxBodyBytes = safehttp.DefaultAPBodyLimit
 
+// MaxHTMLBodyBytes caps the response body size for FetchHTML. Landing pages
+// of real Misskey / Mastodon 等は inline JS/CSS が多く1MiB (AP payload想定)
+// だと超えることが多い (#351のDevin指摘)。SPAバンドル込みでも 5MiB あれば
+// 実用上 icon 抽出成功率が上がる。AP JSON 側の safety cap はそのまま。
+const MaxHTMLBodyBytes = 5 * 1024 * 1024
+
 // Client is a thin wrapper around http.Client that signs outgoing AP requests.
 type Client struct {
 	httpClient *http.Client
@@ -131,5 +137,5 @@ func (c *Client) FetchHTML(url string) ([]byte, error) {
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
 		return nil, errors.New("unexpected status: " + resp.Status)
 	}
-	return safehttp.ReadAllLimit(resp.Body, MaxBodyBytes)
+	return safehttp.ReadAllLimit(resp.Body, MaxHTMLBodyBytes)
 }

--- a/internal/activitypub/client_test.go
+++ b/internal/activitypub/client_test.go
@@ -208,7 +208,7 @@ func TestClient_FetchHTML_BadURL(t *testing.T) {
 }
 
 func TestClient_FetchHTML_ResponseTooLarge(t *testing.T) {
-	oversized := make([]byte, int(MaxBodyBytes)+10)
+	oversized := make([]byte, int(MaxHTMLBodyBytes)+10)
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		_, _ = w.Write(oversized)
 	}))

--- a/internal/activitypub/client_test.go
+++ b/internal/activitypub/client_test.go
@@ -207,9 +207,25 @@ func TestClient_FetchHTML_BadURL(t *testing.T) {
 	assert.Error(t, err)
 }
 
+func TestClient_FetchHTML_NonHTMLContentType(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"ok":true}`))
+	}))
+	defer srv.Close()
+
+	c := NewClient(nil, "")
+	_, err := c.FetchHTML(srv.URL)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "unexpected content-type")
+}
+
 func TestClient_FetchHTML_ResponseTooLarge(t *testing.T) {
 	oversized := make([]byte, int(MaxHTMLBodyBytes)+10)
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		// body sniffingで application/octet-stream に推定されてContent-Type
+		// checkに引っかからないよう明示的にtext/htmlをセットする。
+		w.Header().Set("Content-Type", "text/html")
 		_, _ = w.Write(oversized)
 	}))
 	defer srv.Close()

--- a/internal/activitypub/client_test.go
+++ b/internal/activitypub/client_test.go
@@ -175,6 +175,51 @@ func TestClient_FetchJSON_Error(t *testing.T) {
 	assert.Error(t, err)
 }
 
+func TestClient_FetchHTML(t *testing.T) {
+	const body = `<html><head><link rel="icon" href="/x.png"></head></html>`
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Contains(t, r.Header.Get("Accept"), "text/html")
+		w.Header().Set("Content-Type", "text/html; charset=utf-8")
+		_, _ = w.Write([]byte(body))
+	}))
+	defer srv.Close()
+
+	c := NewClient(nil, "mk-test/1.0")
+	got, err := c.FetchHTML(srv.URL)
+	require.NoError(t, err)
+	assert.Equal(t, body, string(got))
+}
+
+func TestClient_FetchHTML_NonOK(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer srv.Close()
+
+	c := NewClient(nil, "")
+	_, err := c.FetchHTML(srv.URL)
+	assert.Error(t, err)
+}
+
+func TestClient_FetchHTML_BadURL(t *testing.T) {
+	c := NewClient(nil, "")
+	_, err := c.FetchHTML("://bad")
+	assert.Error(t, err)
+}
+
+func TestClient_FetchHTML_ResponseTooLarge(t *testing.T) {
+	oversized := make([]byte, int(MaxBodyBytes)+10)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write(oversized)
+	}))
+	defer srv.Close()
+
+	c := NewClient(nil, "")
+	_, err := c.FetchHTML(srv.URL)
+	require.Error(t, err)
+	assert.True(t, errors.Is(err, safehttp.ErrResponseTooLarge))
+}
+
 func TestNewClient_DefaultHTTPClient(t *testing.T) {
 	c := NewClient(nil, "")
 	assert.NotNil(t, c)

--- a/internal/api/admin/handler.go
+++ b/internal/api/admin/handler.go
@@ -45,35 +45,44 @@ type DeleteAccountEnqueuer interface {
 	EnqueueDeleteAccount(payload queue.DeleteAccountPayload) error
 }
 
+// InstanceMetadataFetcher refreshes remote instance metadata (nodeinfo +
+// iconUrl/faviconUrl) for the given host. Narrow interface that matches
+// coreinstance.FetchMetadataService.Fetch so admin handler tests don't
+// have to pull in the full federation stack.
+type InstanceMetadataFetcher interface {
+	Fetch(host string) error
+}
+
 // Handler handles admin API endpoints.
 type Handler struct {
-	signupService         *signup.Service
-	roleService           *role.Service
-	metaRepo              repository.MetaRepository
-	userRepo              repository.UserRepository
-	abuseRepo             repository.AbuseReportRepository
-	modLogRepo            repository.ModerationLogRepository
-	emojiRepo             repository.EmojiRepository
-	driveFileRepo         repository.DriveFileRepository
-	adminDB               *gorm.DB
-	userIPRepo            repository.UserIPRepository
-	queueInspector        QueueInspector
-	emojiEnqueuer         EmojiImportEnqueuer
-	relayService          RelayService
-	abuseForwarder        AbuseForwarder
-	deleteAccountEnqueuer DeleteAccountEnqueuer
-	systemWebhookRepo     repository.SystemWebhookRepository
-	recipientRepo         repository.AbuseReportNotificationRecipientRepository
-	adRepo                repository.AdRepository
-	avatarDecoRepo        repository.AvatarDecorationRepository
-	inviteRepo            repository.RegistrationTicketRepository
-	promoNoteRepo         repository.PromoNoteRepository
-	noteFinder            NoteFinder
-	resetReqRepo          repository.PasswordResetRequestRepository
-	emailSender           EmailSender
-	serverURL             string
-	idGen                 id.Generator
-	configSetupPassword   string
+	signupService           *signup.Service
+	roleService             *role.Service
+	metaRepo                repository.MetaRepository
+	userRepo                repository.UserRepository
+	abuseRepo               repository.AbuseReportRepository
+	modLogRepo              repository.ModerationLogRepository
+	emojiRepo               repository.EmojiRepository
+	driveFileRepo           repository.DriveFileRepository
+	adminDB                 *gorm.DB
+	userIPRepo              repository.UserIPRepository
+	queueInspector          QueueInspector
+	emojiEnqueuer           EmojiImportEnqueuer
+	relayService            RelayService
+	abuseForwarder          AbuseForwarder
+	deleteAccountEnqueuer   DeleteAccountEnqueuer
+	systemWebhookRepo       repository.SystemWebhookRepository
+	recipientRepo           repository.AbuseReportNotificationRecipientRepository
+	adRepo                  repository.AdRepository
+	avatarDecoRepo          repository.AvatarDecorationRepository
+	inviteRepo              repository.RegistrationTicketRepository
+	promoNoteRepo           repository.PromoNoteRepository
+	noteFinder              NoteFinder
+	resetReqRepo            repository.PasswordResetRequestRepository
+	emailSender             EmailSender
+	serverURL               string
+	idGen                   id.Generator
+	configSetupPassword     string
+	instanceMetadataFetcher InstanceMetadataFetcher
 }
 
 // EmailSender sends a plain-text email (to, subject, body). Same signature
@@ -97,6 +106,13 @@ func (h *Handler) SetConfigSetupPassword(pw string) {
 // SetSystemWebhookRepo attaches a SystemWebhookRepository for admin/system-webhook/*.
 func (h *Handler) SetSystemWebhookRepo(r repository.SystemWebhookRepository) {
 	h.systemWebhookRepo = r
+}
+
+// SetInstanceMetadataFetcher attaches the fetcher used by
+// admin/federation/refresh-remote-instance-metadata to re-fetch nodeinfo +
+// icon for a specific host on demand.
+func (h *Handler) SetInstanceMetadataFetcher(f InstanceMetadataFetcher) {
+	h.instanceMetadataFetcher = f
 }
 
 // SetRecipientRepo attaches an AbuseReportNotificationRecipientRepository for

--- a/internal/api/admin/handler_stubs.go
+++ b/internal/api/admin/handler_stubs.go
@@ -1234,12 +1234,22 @@ func (h *Handler) FederationDeleteAllFiles(c echo.Context) error {
 }
 
 // FederationRefreshRemoteInstanceMetadata handles POST /api/admin/federation/refresh-remote-instance-metadata.
+// InstanceMetadataFetcher (= coreinstance.FetchMetadataService) 経由で指定ホストの
+// nodeinfo + iconUrl / faviconUrl を再取得する。fetcher 未設定または host 未指定
+// の場合は no-op で 204 を返す (本家 TS も失敗時エラーコードは返さない挙動)。
 func (h *Handler) FederationRefreshRemoteInstanceMetadata(c echo.Context) error {
 	var req struct {
 		Host string `json:"host"`
 	}
 	_ = c.Bind(&req)
-	// メタデータ再取得は将来対応 (FetchMetadataServiceの呼び出しが必要)
+	if h.instanceMetadataFetcher == nil || req.Host == "" {
+		return c.NoContent(http.StatusNoContent)
+	}
+	// fetch 失敗はユーザーへ明示的にエラー返す必要はない (frontendは成功前提
+	// でUI更新するだけ)。ログに残してリトライ可能な状態にしておく。
+	if err := h.instanceMetadataFetcher.Fetch(req.Host); err != nil {
+		slog.Warn("federation refresh metadata failed", "host", req.Host, "err", err)
+	}
 	return c.NoContent(http.StatusNoContent)
 }
 

--- a/internal/api/admin/handler_stubs_test.go
+++ b/internal/api/admin/handler_stubs_test.go
@@ -596,7 +596,48 @@ func TestFederationDeleteAllFiles(t *testing.T) {
 }
 func TestFederationRefreshRemoteInstanceMetadata(t *testing.T) {
 	h, _, _, _ := newTestHandler(t)
+	// fetcher 未設定で host 未指定 (stub 相当の呼出) → 204 で no-op
 	assert.Equal(t, http.StatusNoContent, doPost(h.FederationRefreshRemoteInstanceMetadata, `{}`, adminUser).Code)
+}
+
+// stubInstanceMetadataFetcher records Fetch calls for assertion.
+type stubInstanceMetadataFetcher struct {
+	calls []string
+	err   error
+}
+
+func (s *stubInstanceMetadataFetcher) Fetch(host string) error {
+	s.calls = append(s.calls, host)
+	return s.err
+}
+
+func TestFederationRefreshRemoteInstanceMetadata_CallsFetcher(t *testing.T) {
+	h, _, _, _ := newTestHandler(t)
+	fetcher := &stubInstanceMetadataFetcher{}
+	h.SetInstanceMetadataFetcher(fetcher)
+	assert.Equal(t, http.StatusNoContent,
+		doPost(h.FederationRefreshRemoteInstanceMetadata, `{"host":"remote.example"}`, adminUser).Code)
+	assert.Equal(t, []string{"remote.example"}, fetcher.calls)
+}
+
+func TestFederationRefreshRemoteInstanceMetadata_EmptyHostNoCall(t *testing.T) {
+	h, _, _, _ := newTestHandler(t)
+	fetcher := &stubInstanceMetadataFetcher{}
+	h.SetInstanceMetadataFetcher(fetcher)
+	assert.Equal(t, http.StatusNoContent,
+		doPost(h.FederationRefreshRemoteInstanceMetadata, `{}`, adminUser).Code)
+	// host 未指定で fetcher は叩かれない
+	assert.Empty(t, fetcher.calls)
+}
+
+func TestFederationRefreshRemoteInstanceMetadata_FetchError_Still204(t *testing.T) {
+	h, _, _, _ := newTestHandler(t)
+	fetcher := &stubInstanceMetadataFetcher{err: errors.New("net down")}
+	h.SetInstanceMetadataFetcher(fetcher)
+	// fetch 失敗してもクライアントには 204 を返す (ログのみ)
+	assert.Equal(t, http.StatusNoContent,
+		doPost(h.FederationRefreshRemoteInstanceMetadata, `{"host":"remote.example"}`, adminUser).Code)
+	assert.Equal(t, []string{"remote.example"}, fetcher.calls)
 }
 func TestFederationRemoveAllFollowing(t *testing.T) {
 	h, _, _, _ := newTestHandler(t)

--- a/internal/core/federation/fetcher.go
+++ b/internal/core/federation/fetcher.go
@@ -19,3 +19,9 @@ func NewAPFetcher(client *activitypub.Client) *APFetcher {
 func (f *APFetcher) FetchObject(uri string) ([]byte, error) {
 	return f.client.FetchUnsigned(uri)
 }
+
+// FetchHTML performs an unsigned GET with Accept: text/html. Instance metadata
+// fetcher がリモートトップページから <link rel="icon"> を抜き出す用途で使う。
+func (f *APFetcher) FetchHTML(uri string) ([]byte, error) {
+	return f.client.FetchHTML(uri)
+}

--- a/internal/core/federation/fetcher_test.go
+++ b/internal/core/federation/fetcher_test.go
@@ -23,3 +23,17 @@ func TestAPFetcher_FetchObject(t *testing.T) {
 	require.NoError(t, err)
 	assert.Contains(t, string(body), "x")
 }
+
+func TestAPFetcher_FetchHTML(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "text/html; charset=utf-8")
+		_, _ = w.Write([]byte(`<html><head><link rel="icon" href="/a.png"></head></html>`))
+	}))
+	defer srv.Close()
+
+	c := activitypub.NewClient(nil, "test")
+	f := NewAPFetcher(c)
+	body, err := f.FetchHTML(srv.URL)
+	require.NoError(t, err)
+	assert.Contains(t, string(body), "<link rel=\"icon\"")
+}

--- a/internal/core/instance/fetch_metadata.go
+++ b/internal/core/instance/fetch_metadata.go
@@ -122,17 +122,23 @@ func (s *FetchMetadataService) Fetch(host string) error {
 
 	// nodeinfoはicon/faviconを含まないため、リモートトップページHTMLから
 	// 抽出する。取得失敗は致命ではない (nodeinfo 情報のpersistは継続する)。
-	if iconURL, faviconURL := s.fetchIcons(host); iconURL != "" || faviconURL != "" {
-		if iconURL != "" {
-			fields["iconUrl"] = &iconURL
-		}
-		if faviconURL != "" {
-			fields["faviconUrl"] = &faviconURL
-		}
+	// DB側 varchar(256) 制約に引っかかるとUPDATE全体が失敗してnodeinfoまで
+	// 失うため長さチェックを必ずかける (攻撃者制御の長いCDN URLを想定)。
+	iconURL, faviconURL := s.fetchIcons(host)
+	if iconURL != "" && len(iconURL) <= maxInstanceURLLen {
+		fields["iconUrl"] = &iconURL
+	}
+	if faviconURL != "" && len(faviconURL) <= maxInstanceURLLen {
+		fields["faviconUrl"] = &faviconURL
 	}
 
 	return s.repo.UpdateFields(host, fields)
 }
+
+// maxInstanceURLLen は instance.iconUrl / faviconUrl カラムの varchar(256)
+// 制約と一致させる。これを超えるURLは無視する (DB エラーで他 field まで
+// 失わないため)。
+const maxInstanceURLLen = 256
 
 // fetchIcons attempts to extract iconUrl (from <link rel="icon">) and set
 // faviconUrl to the conventional /favicon.ico path. 本家Misskey の

--- a/internal/core/instance/fetch_metadata.go
+++ b/internal/core/instance/fetch_metadata.go
@@ -1,17 +1,22 @@
 package instance
 
 import (
+	"bytes"
 	"encoding/json"
 	"errors"
+	"net/url"
+	"strings"
 	"time"
 
 	"github.com/shiroha-a/mk/internal/repository"
+	"golang.org/x/net/html"
 )
 
-// HTTPFetcher abstracts the HTTP client used to fetch nodeinfo documents.
-// 実装は activitypub.Client の薄いラッパで十分。
+// HTTPFetcher abstracts the HTTP clients used to fetch nodeinfo documents and
+// remote HTML. 実装は activitypub.Client の薄いラッパで十分。
 type HTTPFetcher interface {
 	FetchObject(uri string) ([]byte, error)
+	FetchHTML(uri string) ([]byte, error)
 }
 
 // FetchMetadataService fetches /.well-known/nodeinfo for a remote host and
@@ -114,7 +119,103 @@ func (s *FetchMetadataService) Fetch(host string) error {
 		v := doc.Metadata.ThemeColor
 		fields["themeColor"] = &v
 	}
+
+	// nodeinfoはicon/faviconを含まないため、リモートトップページHTMLから
+	// 抽出する。取得失敗は致命ではない (nodeinfo 情報のpersistは継続する)。
+	if iconURL, faviconURL := s.fetchIcons(host); iconURL != "" || faviconURL != "" {
+		if iconURL != "" {
+			fields["iconUrl"] = &iconURL
+		}
+		if faviconURL != "" {
+			fields["faviconUrl"] = &faviconURL
+		}
+	}
+
 	return s.repo.UpdateFields(host, fields)
+}
+
+// fetchIcons attempts to extract iconUrl (from <link rel="icon">) and set
+// faviconUrl to the conventional /favicon.ico path. 本家Misskey の
+// FetchInstanceMetadataService と同様、faviconは実在検証せず `https://host/favicon.ico`
+// を決め打ちで保存する (frontendが404時は非表示になるだけなので害は小さい)。
+func (s *FetchMetadataService) fetchIcons(host string) (iconURL, faviconURL string) {
+	rootURL := "https://" + host + "/"
+	// 画面に表示される favicon は frontend で fallback されるので、HTMLが
+	// 取得できなくても /favicon.ico は必ずセットする。
+	faviconURL = "https://" + host + "/favicon.ico"
+
+	body, err := s.fetcher.FetchHTML(rootURL)
+	if err != nil {
+		return "", faviconURL
+	}
+	iconURL = parseIconFromHTML(body, rootURL)
+	return iconURL, faviconURL
+}
+
+// parseIconFromHTML finds the first <link rel="icon"> or <link rel="apple-touch-icon">
+// in doc and returns its href resolved against pageURL. 解析失敗や該当なしは空文字。
+func parseIconFromHTML(body []byte, pageURL string) string {
+	doc, err := html.Parse(bytes.NewReader(body))
+	if err != nil {
+		return ""
+	}
+	base, err := url.Parse(pageURL)
+	if err != nil {
+		return ""
+	}
+	var icon, appleTouchIcon string
+	var walk func(*html.Node)
+	walk = func(n *html.Node) {
+		if n.Type == html.ElementNode && n.Data == "link" {
+			rel := strings.ToLower(attrValue(n, "rel"))
+			href := attrValue(n, "href")
+			if href != "" {
+				switch rel {
+				case "icon", "shortcut icon":
+					if icon == "" {
+						icon = href
+					}
+				case "apple-touch-icon", "apple-touch-icon-precomposed":
+					if appleTouchIcon == "" {
+						appleTouchIcon = href
+					}
+				}
+			}
+		}
+		for c := n.FirstChild; c != nil; c = c.NextSibling {
+			walk(c)
+		}
+	}
+	walk(doc)
+
+	// 本家優先順位に倣い、appleTouchIconの方が高解像度で綺麗なため優先する。
+	chosen := firstNonEmptyStr(appleTouchIcon, icon)
+	if chosen == "" {
+		return ""
+	}
+	ref, err := url.Parse(chosen)
+	if err != nil {
+		return ""
+	}
+	return base.ResolveReference(ref).String()
+}
+
+func attrValue(n *html.Node, key string) string {
+	for _, a := range n.Attr {
+		if a.Key == key {
+			return a.Val
+		}
+	}
+	return ""
+}
+
+func firstNonEmptyStr(vals ...string) string {
+	for _, v := range vals {
+		if v != "" {
+			return v
+		}
+	}
+	return ""
 }
 
 // fetchDiscovery fetches /.well-known/nodeinfo and decodes the link list.

--- a/internal/core/instance/fetch_metadata_test.go
+++ b/internal/core/instance/fetch_metadata_test.go
@@ -13,10 +13,17 @@ import (
 )
 
 // scriptedFetcher returns canned responses keyed by call order.
+// FetchObject / FetchHTML それぞれ独立カウンタで bodies / errs を消費する。
 type scriptedFetcher struct {
 	bodies [][]byte
 	errs   []error
 	idx    int
+
+	// HTMLレスポンスは FetchObject と独立に供給する。未設定ならFetchHTML呼出
+	// は error を返してicon抽出 step を no-op にする (nodeinfo テストを
+	// icon logicの追加で壊さないため)。
+	htmlBody []byte
+	htmlErr  error
 }
 
 func (s *scriptedFetcher) FetchObject(_ string) ([]byte, error) {
@@ -30,6 +37,16 @@ func (s *scriptedFetcher) FetchObject(_ string) ([]byte, error) {
 	}
 	s.idx++
 	return b, err
+}
+
+func (s *scriptedFetcher) FetchHTML(_ string) ([]byte, error) {
+	if s.htmlErr != nil {
+		return nil, s.htmlErr
+	}
+	if s.htmlBody == nil {
+		return nil, errors.New("no html body")
+	}
+	return s.htmlBody, nil
 }
 
 func newFetchSvc(t *testing.T, bodies [][]byte, errs []error) (*instance.FetchMetadataService, *testutil.MockInstanceRepository) {
@@ -148,6 +165,84 @@ func TestFetch_DocumentMinimalFields(t *testing.T) {
 	assert.Nil(t, got.Name)
 	assert.Nil(t, got.Description)
 	assert.Nil(t, got.ThemeColor)
+}
+
+func TestFetch_IconFromHTML(t *testing.T) {
+	htmlBody := `<html><head>
+		<link rel="icon" href="/favicon-16.png">
+		<link rel="apple-touch-icon" href="https://cdn.example/apple-touch.png">
+	</head></html>`
+	svc, repo := newFetchSvc(t,
+		[][]byte{[]byte(discoveryBody), []byte(documentBody)}, nil)
+	repo.Instances["remote.example"] = &model.Instance{ID: "i1", Host: "remote.example"}
+	// scriptedFetcherに直接htmlBody仕込む。 fetcher取得はnewFetchSvc内部なので
+	// この test では直接 service を作り直す必要がある。
+	fetcher := &scriptedFetcher{
+		bodies:   [][]byte{[]byte(discoveryBody), []byte(documentBody)},
+		htmlBody: []byte(htmlBody),
+	}
+	svc = instance.NewFetchMetadataService(repo, fetcher)
+	require.NoError(t, svc.Fetch("remote.example"))
+
+	got := repo.Instances["remote.example"]
+	require.NotNil(t, got.IconURL)
+	// apple-touch-iconが優先され、絶対URLのまま保存される。
+	assert.Equal(t, "https://cdn.example/apple-touch.png", *got.IconURL)
+	require.NotNil(t, got.FaviconURL)
+	assert.Equal(t, "https://remote.example/favicon.ico", *got.FaviconURL)
+}
+
+func TestFetch_IconFromHTML_RelativeResolved(t *testing.T) {
+	htmlBody := `<html><head><link rel="shortcut icon" href="/static/icon.svg"></head></html>`
+	repo := testutil.NewMockInstanceRepository()
+	repo.Instances["remote.example"] = &model.Instance{ID: "i1", Host: "remote.example"}
+	fetcher := &scriptedFetcher{
+		bodies:   [][]byte{[]byte(discoveryBody), []byte(documentBody)},
+		htmlBody: []byte(htmlBody),
+	}
+	svc := instance.NewFetchMetadataService(repo, fetcher)
+	require.NoError(t, svc.Fetch("remote.example"))
+
+	got := repo.Instances["remote.example"]
+	require.NotNil(t, got.IconURL)
+	// 相対パスは pageURL (https://remote.example/) を基準に絶対化される。
+	assert.Equal(t, "https://remote.example/static/icon.svg", *got.IconURL)
+}
+
+func TestFetch_IconFromHTML_NoLinkTag(t *testing.T) {
+	htmlBody := `<html><head><title>no icon</title></head></html>`
+	repo := testutil.NewMockInstanceRepository()
+	repo.Instances["remote.example"] = &model.Instance{ID: "i1", Host: "remote.example"}
+	fetcher := &scriptedFetcher{
+		bodies:   [][]byte{[]byte(discoveryBody), []byte(documentBody)},
+		htmlBody: []byte(htmlBody),
+	}
+	svc := instance.NewFetchMetadataService(repo, fetcher)
+	require.NoError(t, svc.Fetch("remote.example"))
+
+	got := repo.Instances["remote.example"]
+	// iconUrl は抽出できないので nilのまま。
+	assert.Nil(t, got.IconURL)
+	// faviconUrl は HTML取得成功時でもconventionalな /favicon.ico で上書きされる。
+	require.NotNil(t, got.FaviconURL)
+	assert.Equal(t, "https://remote.example/favicon.ico", *got.FaviconURL)
+}
+
+func TestFetch_IconHTMLFetchError(t *testing.T) {
+	repo := testutil.NewMockInstanceRepository()
+	repo.Instances["remote.example"] = &model.Instance{ID: "i1", Host: "remote.example"}
+	fetcher := &scriptedFetcher{
+		bodies:  [][]byte{[]byte(discoveryBody), []byte(documentBody)},
+		htmlErr: errors.New("conn refused"),
+	}
+	svc := instance.NewFetchMetadataService(repo, fetcher)
+	require.NoError(t, svc.Fetch("remote.example"))
+
+	got := repo.Instances["remote.example"]
+	// HTMLが取れなくてもfaviconは決め打ちで保存される。
+	assert.Nil(t, got.IconURL)
+	require.NotNil(t, got.FaviconURL)
+	assert.Equal(t, "https://remote.example/favicon.ico", *got.FaviconURL)
 }
 
 func TestFetch_SetClock(t *testing.T) {

--- a/internal/core/instance/fetch_metadata_test.go
+++ b/internal/core/instance/fetch_metadata_test.go
@@ -2,6 +2,7 @@ package instance_test
 
 import (
 	"errors"
+	"strings"
 	"testing"
 	"time"
 
@@ -226,6 +227,30 @@ func TestFetch_IconFromHTML_NoLinkTag(t *testing.T) {
 	// faviconUrl は HTML取得成功時でもconventionalな /favicon.ico で上書きされる。
 	require.NotNil(t, got.FaviconURL)
 	assert.Equal(t, "https://remote.example/favicon.ico", *got.FaviconURL)
+}
+
+func TestFetch_IconURLExceedsColumnLimit(t *testing.T) {
+	// 256文字制約を超えるCDN URL。この場合iconUrlは書き込まずに
+	// nodeinfo だけ UpdateFields できるはず (Devin BUG 指摘の回帰防止)。
+	longPath := strings.Repeat("a", 300)
+	htmlBody := `<html><head><link rel="icon" href="https://cdn.example/` + longPath + `.png"></head></html>`
+	repo := testutil.NewMockInstanceRepository()
+	repo.Instances["remote.example"] = &model.Instance{ID: "i1", Host: "remote.example"}
+	fetcher := &scriptedFetcher{
+		bodies:   [][]byte{[]byte(discoveryBody), []byte(documentBody)},
+		htmlBody: []byte(htmlBody),
+	}
+	svc := instance.NewFetchMetadataService(repo, fetcher)
+	require.NoError(t, svc.Fetch("remote.example"))
+
+	got := repo.Instances["remote.example"]
+	// 長すぎるicon URLは保存されない
+	assert.Nil(t, got.IconURL)
+	// favicon (https://remote.example/favicon.ico = 34文字) は保存される
+	require.NotNil(t, got.FaviconURL)
+	// nodeinfo fields は失われない
+	require.NotNil(t, got.SoftwareName)
+	assert.Equal(t, "misskey", *got.SoftwareName)
 }
 
 func TestFetch_IconHTMLFetchError(t *testing.T) {

--- a/internal/server/router.go
+++ b/internal/server/router.go
@@ -419,8 +419,11 @@ func (s *Server) setupRoutes() {
 	// Instance management (Phase 3 Step H)
 	instanceService := coreinstance.NewService(instanceRepo, metaRepo, idGen)
 	federationResolver.SetInstanceTracker(instanceService)
-	// 新規 instance row 発見時に nodeinfo を取得して metadata を更新する
-	instanceService.SetMetadataFetcher(coreinstance.NewFetchMetadataService(instanceRepo, apFetcher))
+	// 新規 instance row 発見時に nodeinfo を取得して metadata を更新する。
+	// admin/federation/refresh-remote-instance-metadata でも同じ fetcher を
+	// 再利用して on-demand で再取得する (#351 フォロー)。
+	metadataFetcher := coreinstance.NewFetchMetadataService(instanceRepo, apFetcher)
+	instanceService.SetMetadataFetcher(metadataFetcher)
 
 	// AP delivery: DeliverService + フック登録 + asynq processor 登録
 	deliverService := corefederation.NewDeliverService(s.queueClient, userRepo, followingRepo, keypairRepo, apURLs)
@@ -1479,6 +1482,7 @@ func (s *Server) setupRoutes() {
 	if s.queueInspector != nil {
 		adminHandler.SetQueueInspector(&queueInspectorAdapter{inner: s.queueInspector})
 	}
+	adminHandler.SetInstanceMetadataFetcher(metadataFetcher)
 	api.POST("/admin/accounts/create", adminHandler.AccountsCreate)
 	api.POST("/admin/show-user", adminHandler.ShowUser, middleware.RequireModerator(roleService))
 	api.POST("/admin/show-users", adminHandler.ShowUsers, middleware.RequireModerator(roleService))


### PR DESCRIPTION
## Summary

手動検証で federation 画面のリモートサーバーアイコンが表示されない問題を修正する。原因は `instance` レコードの `iconUrl` / `faviconUrl` フィールドが常に null で、既存の `FetchMetadataService` が nodeinfo の software/description 等は取り込むものの、nodeinfo 仕様には icon が含まれないため未実装だった。

本家 Misskey `FetchInstanceMetadataService` に倣い、HTML `<link rel=\"icon\">` / `<link rel=\"apple-touch-icon\">` の解析 + `/favicon.ico` の決め打ちで埋める実装に拡張する。

## 主な変更点

- `internal/activitypub/client.go`: `FetchHTML(url) ([]byte, error)` を追加。Accept: `text/html,application/xhtml+xml,*/*;q=0.5` で既存 httpClient (SSRF guard / `safehttp.ReadAllLimit` 継承) を使う
- `internal/core/federation/fetcher.go`: `APFetcher.FetchHTML` を追加して上記を expose
- `internal/core/instance/fetch_metadata.go`:
  - `HTTPFetcher` interface に `FetchHTML` を追加
  - `Fetch()` の末尾で `fetchIcons(host)` を呼び `iconUrl` / `faviconUrl` を `UpdateFields` に積む
  - `parseIconFromHTML` は `golang.org/x/net/html` で link tag を走査、`apple-touch-icon` > `icon/shortcut icon` の優先順位、相対 URL は pageURL (https://host/) 基準で絶対化
  - HTML 取得失敗時も `faviconUrl` は `https://host/favicon.ico` 決め打ちで保存 (本家挙動)
- tests:
  - `TestClient_FetchHTML` 系 4 件 (happy / non-OK / bad URL / oversized)
  - `TestAPFetcher_FetchHTML`
  - `TestFetch_IconFromHTML` / `IconFromHTML_RelativeResolved` / `IconFromHTML_NoLinkTag` / `IconHTMLFetchError`

## テスト

- `go test ./internal/activitypub/ ./internal/core/federation/ ./internal/core/instance/ -count=1` 全 pass
- coverage: `internal/activitypub` 92.8% → 95.0%、`internal/core/instance` 97.6% 維持
- `make fmt && make lint` clean

## 影響範囲 / 注意点

- **新規 instance** 登録時に自動で iconUrl / faviconUrl が埋まる
- **既存 instance** は `InfoUpdatedAt` がセット済みでも backfill されないため、アイコン未取得の既存レコードは別途 refresh が必要。periodic refresh cron (本家 `UpdateRemoteInstanceService` 相当) は scope 外、follow-up issue で対応予定

## Closes

Closes #351

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/shiroha-a/mk/pull/392" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
