### PR TITLE
Fix #369: reply/reaction が remote target に届かない件を 3 点修正

### DIFF
--- a/internal/activitypub/keypair.go
+++ b/internal/activitypub/keypair.go
@@ -67,12 +67,29 @@ func GenerateEd25519Keypair() (privatePEM string, publicPEM string, err error) {
 }
 
 // ParseRSAPrivateKey decodes a PEM-encoded RSA private key.
+// PKCS1 ("BEGIN RSA PRIVATE KEY") と PKCS8 ("BEGIN PRIVATE KEY") の両形式を
+// 受け付ける。Misskey TS は PKCS8 で RSA 鍵を保存するため、drop-in 切替で
+// mk-go が TS 生成の鍵を読む場合に PKCS8 fallback が必要 (#369 関連)。
 func ParseRSAPrivateKey(pemStr string) (*rsa.PrivateKey, error) {
 	block, _ := pem.Decode([]byte(pemStr))
 	if block == nil {
 		return nil, errors.New("invalid PEM block")
 	}
-	return x509.ParsePKCS1PrivateKey(block.Bytes)
+	// 1. まず PKCS1 (mk-go が自分で生成した鍵はこの形式) を試す。
+	if key, err := x509.ParsePKCS1PrivateKey(block.Bytes); err == nil {
+		return key, nil
+	}
+	// 2. PKCS1 失敗時は PKCS8 を試す。TS Misskey は openssl 3.x デフォルトで
+	//    `-----BEGIN PRIVATE KEY-----` の PKCS8 形式を生成する。
+	parsed, err := x509.ParsePKCS8PrivateKey(block.Bytes)
+	if err != nil {
+		return nil, fmt.Errorf("parse RSA private key (tried PKCS1 and PKCS8): %w", err)
+	}
+	rsaKey, ok := parsed.(*rsa.PrivateKey)
+	if !ok {
+		return nil, fmt.Errorf("PKCS8 key is not RSA: %T", parsed)
+	}
+	return rsaKey, nil
 }
 
 // ParseEd25519PrivateKey decodes a PEM-encoded Ed25519 private key (PKCS8).

--- a/internal/activitypub/keypair_test.go
+++ b/internal/activitypub/keypair_test.go
@@ -3,6 +3,7 @@ package activitypub
 import (
 	"crypto/ed25519"
 	"crypto/rand"
+	"crypto/rsa"
 	"crypto/x509"
 	"encoding/pem"
 	"testing"
@@ -35,6 +36,41 @@ func TestParseRSAPrivateKey_BadContents(t *testing.T) {
 	pem := "-----BEGIN RSA PRIVATE KEY-----\nbm90YWtleQ==\n-----END RSA PRIVATE KEY-----\n"
 	_, err := ParseRSAPrivateKey(pem)
 	assert.Error(t, err)
+}
+
+// TestParseRSAPrivateKey_PKCS8 は Misskey TS が格納する PKCS8 形式の RSA
+// 秘密鍵を mk-go が読めることを確認する回帰テスト (#369 drop-in)。
+func TestParseRSAPrivateKey_PKCS8(t *testing.T) {
+	priv, err := rsa.GenerateKey(rand.Reader, 2048)
+	require.NoError(t, err)
+	// openssl 3.x デフォルトと同じ PKCS8 形式で encode する。
+	pkcs8Bytes, err := x509.MarshalPKCS8PrivateKey(priv)
+	require.NoError(t, err)
+	pemStr := string(pem.EncodeToMemory(&pem.Block{
+		Type:  "PRIVATE KEY",
+		Bytes: pkcs8Bytes,
+	}))
+
+	parsed, err := ParseRSAPrivateKey(pemStr)
+	require.NoError(t, err, "PKCS8 形式の RSA 鍵が parse できる")
+	assert.Equal(t, priv.N, parsed.N)
+}
+
+// TestParseRSAPrivateKey_PKCS8NotRSA は PKCS8 に RSA 以外の鍵 (ed25519)
+// が入っていた場合は明示的に reject することを確認する。
+func TestParseRSAPrivateKey_PKCS8NotRSA(t *testing.T) {
+	_, priv, err := ed25519.GenerateKey(rand.Reader)
+	require.NoError(t, err)
+	pkcs8Bytes, err := x509.MarshalPKCS8PrivateKey(priv)
+	require.NoError(t, err)
+	pemStr := string(pem.EncodeToMemory(&pem.Block{
+		Type:  "PRIVATE KEY",
+		Bytes: pkcs8Bytes,
+	}))
+
+	_, err = ParseRSAPrivateKey(pemStr)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "not RSA")
 }
 
 func TestParseRSAPublicKey_Invalid(t *testing.T) {

--- a/internal/activitypub/renderer.go
+++ b/internal/activitypub/renderer.go
@@ -329,7 +329,11 @@ func (r *Renderer) RenderNote(n *model.Note, idGen id.Generator) *Note {
 		out.Summary = *n.CW
 	}
 	if n.ReplyID != nil {
-		out.InReplyTo = r.urls.NoteURI(*n.ReplyID)
+		// リモート note への reply の場合、InReplyTo は相手側 (note.URI) を
+		// 指すべき。mk-go の local URL (`https://<self>/notes/<id>`) に
+		// してしまうと連合先が `inReplyTo` を解決できず reply chain が切れる
+		// (drop-in #369 で発覚)。
+		out.InReplyTo = r.resolveNoteURI(*n.ReplyID)
 	}
 
 	// Quote renote: text付きrenoteは_misskey_quote + quoteUrlを付ける

--- a/internal/activitypub/renderer_test.go
+++ b/internal/activitypub/renderer_test.go
@@ -222,7 +222,32 @@ func TestRenderer_RenderNote_Reply(t *testing.T) {
 		Visibility: model.NoteVisibilityPublic,
 	}
 	out := r.RenderNote(n, idGen)
+	// noteResolver が未設定なので local URI にフォールバックする。
 	assert.Equal(t, "https://example.com/notes/parent", out.InReplyTo)
+}
+
+// リモート note への reply は note.URI を使い、ローカル URL にしない。
+// drop-in #369 で TS-B が `https://a/notes/<a-copy-id>` を fetch して 404 に
+// なる問題を防ぐための回帰テスト。
+func TestRenderer_RenderNote_Reply_RemoteTarget(t *testing.T) {
+	parentID := "parent-remote"
+	remoteURI := "https://remote.example/notes/original-id"
+	remoteNote := &model.Note{
+		ID:  parentID,
+		URI: &remoteURI,
+	}
+	r := NewRenderer(NewURLBuilder("https://example.com"))
+	r.SetNoteResolver(&stubNoteResolver{note: remoteNote})
+
+	idGen := newIDGen(t)
+	n := &model.Note{
+		ID:         idGen.Generate(time.Now()),
+		UserID:     "author",
+		ReplyID:    &parentID,
+		Visibility: model.NoteVisibilityPublic,
+	}
+	out := r.RenderNote(n, idGen)
+	assert.Equal(t, remoteURI, out.InReplyTo)
 }
 
 func TestRenderer_RenderNote_InvalidIDFallback(t *testing.T) {

--- a/internal/core/federation/note_delivery_hook.go
+++ b/internal/core/federation/note_delivery_hook.go
@@ -100,9 +100,15 @@ func (h *NoteDeliveryHook) OnNoteCreated(note *model.Note, author *model.User) {
 		h.deliverToSpecified(author, note, body)
 	}
 
-	// メンションされたリモートユーザーにも直接配信する。フォロワー配信だけでは
-	// 相手にノートが届かないため、メンション通知が発生しない。
-	h.deliverToMentionedRemotes(author, note, body)
+	// 以下の remote user にも直接配信する。フォロワー配信だけでは相手に
+	// 届かず、リプライ / 引用リノート / メンション通知が発生しない。
+	//   - ノート本文に含まれるメンションのリモートユーザー
+	//   - リプライ対象 (ReplyID) の作者がリモートの場合
+	//   - 引用リノート (Renote + text/cw/files/poll) の renote 元作者がリモートの場合
+	// フォロワー配信先と重複したユーザーは DeliverService 側でも deduplicate
+	// されているが、ここでも user ID ベースで seen map を共有して無駄な
+	// enqueue を避ける。#369。
+	h.deliverToDirectRecipients(author, note, body)
 
 	// public な note のみ relay に fanout する。relay は AS Public addressed
 	// activity しか受け付けないため、home/followers/specified はスキップ。
@@ -114,39 +120,85 @@ func (h *NoteDeliveryHook) OnNoteCreated(note *model.Note, author *model.User) {
 	}
 }
 
-// deliverToMentionedRemotes finds remote users mentioned in the note text and
-// ships the Create activity directly to each one's inbox.
-// ローカル DB にキャッシュ済みのリモートユーザーのみ対象 (それ以外は解決しない)。
-func (h *NoteDeliveryHook) deliverToMentionedRemotes(author *model.User, note *model.Note, body []byte) {
-	if note == nil || note.Text == nil || *note.Text == "" {
+// deliverToDirectRecipients は mention / reply target / quote renote target の
+// 3 経路から remote user を集めて dedup した上で Create activity を直接
+// 各 inbox へ送る。
+//
+// ローカル DB にキャッシュ済みの user だけを対象にする (未解決のリモート
+// user は webfinger を叩かない)。local user は連合配信の対象外。
+func (h *NoteDeliveryHook) deliverToDirectRecipients(author *model.User, note *model.Note, body []byte) {
+	if note == nil {
 		return
 	}
-	mentions := corenote.ExtractMentionStructs(*note.Text)
-	if len(mentions) == 0 {
-		return
+	seen := make(map[string]struct{})
+	recipients := make([]*model.User, 0, 3)
+
+	add := func(u *model.User) {
+		if u == nil || u.ID == author.ID || u.IsLocal() {
+			return
+		}
+		if _, dup := seen[u.ID]; dup {
+			return
+		}
+		seen[u.ID] = struct{}{}
+		recipients = append(recipients, u)
 	}
-	seen := make(map[string]struct{}, len(mentions))
-	for _, m := range mentions {
-		if m.Host == "" {
-			// ローカルメンション: 連合配信不要
-			continue
-		}
-		host := m.Host
-		user, err := h.userRepo.FindByUsernameLower(m.Username, &host)
-		if err != nil {
-			// 未知のリモートユーザー: webfinger 経由で事前に解決されていない
-			// ため配信先を得られない。スキップ。
-			continue
-		}
-		if _, dup := seen[user.ID]; dup {
-			continue
-		}
-		seen[user.ID] = struct{}{}
-		if err := h.deliver.DeliverToUser(author.ID, user, body); err != nil {
-			slog.Warn("mention delivery: deliver to user failed",
-				"noteId", note.ID, "userId", user.ID, "err", err)
+
+	// 1. text 中の mention
+	if note.Text != nil && *note.Text != "" {
+		for _, m := range corenote.ExtractMentionStructs(*note.Text) {
+			if m.Host == "" {
+				continue
+			}
+			host := m.Host
+			user, err := h.userRepo.FindByUsernameLower(m.Username, &host)
+			if err != nil {
+				// 未解決リモート: 配信先を得られないのでスキップ
+				continue
+			}
+			add(user)
 		}
 	}
+
+	// 2. reply target の作者
+	if note.ReplyID != nil && *note.ReplyID != "" {
+		if u := h.findNoteAuthor(*note.ReplyID, note, "reply"); u != nil {
+			add(u)
+		}
+	}
+
+	// 3. quote renote target の作者 (pure renote は Announce で follower 配信
+	//    済なので対象外、quote renote だけ対象)。
+	if note.RenoteID != nil && *note.RenoteID != "" && !corenote.IsPureRenote(note) {
+		if u := h.findNoteAuthor(*note.RenoteID, note, "renote"); u != nil {
+			add(u)
+		}
+	}
+
+	for _, u := range recipients {
+		if err := h.deliver.DeliverToUser(author.ID, u, body); err != nil {
+			slog.Warn("direct delivery: deliver to user failed",
+				"noteId", note.ID, "userId", u.ID, "err", err)
+		}
+	}
+}
+
+// findNoteAuthor は noteID の note を引いて作者 user を返す。失敗は warn log
+// して nil を返す。kind はログ用のラベル ("reply" / "renote" 等)。
+func (h *NoteDeliveryHook) findNoteAuthor(noteID string, origin *model.Note, kind string) *model.User {
+	target, err := h.noteRepo.FindByID(noteID)
+	if err != nil {
+		slog.Warn("direct delivery: "+kind+" target note not found",
+			"noteId", origin.ID, "targetId", noteID, "err", err)
+		return nil
+	}
+	user, err := h.userRepo.FindByID(target.UserID)
+	if err != nil {
+		slog.Warn("direct delivery: "+kind+" target author not found",
+			"noteId", origin.ID, "targetId", noteID, "authorId", target.UserID, "err", err)
+		return nil
+	}
+	return user
 }
 
 // deliverAnnounce renders an Announce activity for a pure renote and ships it

--- a/internal/core/federation/note_delivery_hook_test.go
+++ b/internal/core/federation/note_delivery_hook_test.go
@@ -283,6 +283,150 @@ func TestNoteDeliveryHook_MentionedRemoteUser_NoMentions(t *testing.T) {
 	assert.Empty(t, enq.calls)
 }
 
+// --- #369: reply target / quote renote target への直接 deliver -----------
+
+func TestNoteDeliveryHook_ReplyToRemote_DeliversToReplyAuthor(t *testing.T) {
+	hook, enq, userRepo, _, keypairRepo, noteRepo := newNoteDeliveryHook(t)
+	author := makeLocalAuthor(t, userRepo, keypairRepo)
+
+	host := "remote.example"
+	inbox := "https://remote.example/users/bob/inbox"
+	bob := &model.User{
+		ID: "bob", Username: "bob", UsernameLower: "bob",
+		Host: &host, Inbox: &inbox,
+	}
+	userRepo.Users["bob"] = bob
+	bobNote := &model.Note{ID: "bobnote", UserID: "bob"}
+	noteRepo.Notes["bobnote"] = bobNote
+
+	replyID := "bobnote"
+	note := makeNote(author.ID, model.NoteVisibilityPublic)
+	note.ReplyID = &replyID
+	// 本文には bob への mention を含めない (mention 経路で誤って拾われていない
+	// ことを確認するため)
+	text := "just a plain reply without @mention"
+	note.Text = &text
+
+	hook.OnNoteCreated(note, author)
+
+	// no followers、mention も text になし。reply target 経路のみで 1 回 enqueue。
+	require.Len(t, enq.calls, 1)
+	assert.Equal(t, inbox, enq.calls[0].Inbox)
+}
+
+func TestNoteDeliveryHook_ReplyToLocal_NoDelivery(t *testing.T) {
+	hook, enq, userRepo, _, keypairRepo, noteRepo := newNoteDeliveryHook(t)
+	author := makeLocalAuthor(t, userRepo, keypairRepo)
+
+	localBob := &model.User{ID: "bob", Username: "bob", UsernameLower: "bob"}
+	userRepo.Users["bob"] = localBob
+	bobNote := &model.Note{ID: "bobnote", UserID: "bob"}
+	noteRepo.Notes["bobnote"] = bobNote
+
+	replyID := "bobnote"
+	note := makeNote(author.ID, model.NoteVisibilityPublic)
+	note.ReplyID = &replyID
+
+	hook.OnNoteCreated(note, author)
+	// local target は連合配信不要
+	assert.Empty(t, enq.calls)
+}
+
+func TestNoteDeliveryHook_ReplyToSelf_NoDelivery(t *testing.T) {
+	// 自分の note への reply (self-reply) は連合配信不要。seen dedup で弾く。
+	hook, enq, userRepo, _, keypairRepo, noteRepo := newNoteDeliveryHook(t)
+	author := makeLocalAuthor(t, userRepo, keypairRepo)
+
+	selfNote := &model.Note{ID: "self1", UserID: author.ID}
+	noteRepo.Notes["self1"] = selfNote
+	replyID := "self1"
+
+	note := makeNote(author.ID, model.NoteVisibilityPublic)
+	note.ReplyID = &replyID
+
+	hook.OnNoteCreated(note, author)
+	assert.Empty(t, enq.calls)
+}
+
+func TestNoteDeliveryHook_ReplyMentionDedup(t *testing.T) {
+	// reply target が mention と同じリモートユーザーの場合、重複配信しない。
+	hook, enq, userRepo, _, keypairRepo, noteRepo := newNoteDeliveryHook(t)
+	author := makeLocalAuthor(t, userRepo, keypairRepo)
+
+	host := "remote.example"
+	inbox := "https://remote.example/users/bob/inbox"
+	bob := &model.User{
+		ID: "bob", Username: "bob", UsernameLower: "bob",
+		Host: &host, Inbox: &inbox,
+	}
+	userRepo.Users["bob"] = bob
+	bobNote := &model.Note{ID: "bobnote", UserID: "bob"}
+	noteRepo.Notes["bobnote"] = bobNote
+
+	replyID := "bobnote"
+	note := makeNote(author.ID, model.NoteVisibilityPublic)
+	note.ReplyID = &replyID
+	text := "@bob@remote.example hi" // mention にも bob
+	note.Text = &text
+
+	hook.OnNoteCreated(note, author)
+	// mention + reply target = 同一 user → 1 回のみ
+	require.Len(t, enq.calls, 1)
+}
+
+func TestNoteDeliveryHook_QuoteRenote_DeliversToRenoteAuthor(t *testing.T) {
+	hook, enq, userRepo, _, keypairRepo, noteRepo := newNoteDeliveryHook(t)
+	author := makeLocalAuthor(t, userRepo, keypairRepo)
+
+	host := "remote.example"
+	inbox := "https://remote.example/users/bob/inbox"
+	bob := &model.User{
+		ID: "bob", Username: "bob", UsernameLower: "bob",
+		Host: &host, Inbox: &inbox,
+	}
+	userRepo.Users["bob"] = bob
+	bobNote := &model.Note{ID: "bobnote", UserID: "bob"}
+	noteRepo.Notes["bobnote"] = bobNote
+
+	renoteID := "bobnote"
+	note := makeNote(author.ID, model.NoteVisibilityPublic)
+	note.RenoteID = &renoteID
+	text := "my quote comment" // text があるので pure renote ではなく quote renote
+	note.Text = &text
+
+	hook.OnNoteCreated(note, author)
+	require.Len(t, enq.calls, 1)
+	assert.Equal(t, inbox, enq.calls[0].Inbox)
+}
+
+func TestNoteDeliveryHook_PureRenoteRemote_NoDirectDelivery(t *testing.T) {
+	// pure renote は Announce で follower に配信されるので、quote 経路の
+	// 直接配信は発動しない。
+	hook, enq, userRepo, followingRepo, keypairRepo, noteRepo := newNoteDeliveryHook(t)
+	author := makeLocalAuthor(t, userRepo, keypairRepo)
+	// follower は 0。Announce でも enqueue されない。
+	followingRepo.RemoteInboxes[author.ID] = []string{}
+
+	host := "remote.example"
+	inbox := "https://remote.example/users/bob/inbox"
+	bob := &model.User{
+		ID: "bob", Username: "bob", UsernameLower: "bob",
+		Host: &host, Inbox: &inbox,
+	}
+	userRepo.Users["bob"] = bob
+	bobNote := &model.Note{ID: "bobnote", UserID: "bob"}
+	noteRepo.Notes["bobnote"] = bobNote
+
+	renoteID := "bobnote"
+	note := makeNote(author.ID, model.NoteVisibilityPublic)
+	note.RenoteID = &renoteID
+	// text/cw/files なし → pure renote
+
+	hook.OnNoteCreated(note, author)
+	// follower 0 + pure renote → enqueue 無し (quote 直接配信は発動しない)
+	assert.Empty(t, enq.calls)
+}
+
 func TestNoteDeliveryHook_PureRenote_LocalTarget_EmitsAnnounce(t *testing.T) {
 	hook, enq, userRepo, followingRepo, keypairRepo, noteRepo := newNoteDeliveryHook(t)
 	author := makeLocalAuthor(t, userRepo, keypairRepo)

--- a/tests/dropin/test_swap_verify.py
+++ b/tests/dropin/test_swap_verify.py
@@ -13,8 +13,6 @@ from __future__ import annotations
 
 import time
 
-import pytest
-
 from conftest import A_DOMAIN  # type: ignore[import-not-found]
 from conftest_base import MisskeyLikeClient, poll_until  # type: ignore[import-not-found]
 from test_swap_setup import (  # type: ignore[import-not-found]
@@ -111,13 +109,6 @@ def test_post_swap_user_list_timeline_preserved(
         "user-list-timeline lost baseline note from list member after swap"
 
 
-@pytest.mark.xfail(
-    reason="mk-go の NoteDeliveryHook (#369) は reply target 個別 deliver を未実装。"
-    "alice の followers (=0 人) + text mention (=なし) しか対象にしないため、"
-    "リモートユーザーへの reply は配信されない。drop-in 切替に固有の問題ではなく、"
-    "fresh インストールでも同じ振る舞い。Phase 13-3 で federation 修正後に xfail 解除。",
-    strict=True,
-)
 def test_post_swap_alice_can_reply(
     instance_a: MisskeyLikeClient,
     instance_b: MisskeyLikeClient,
@@ -150,12 +141,6 @@ def test_post_swap_alice_can_reply(
     assert poll_until(_arrived, timeout=120, desc="bob receives reply from mk-A alice")
 
 
-@pytest.mark.xfail(
-    reason="reaction の federation deliver も #369 と同じ NoteDeliveryHook 経路を"
-    "通るため、リモートユーザーへ reaction が配信されない。Phase 13-3 で連動して"
-    "解除予定。",
-    strict=True,
-)
 def test_post_swap_alice_can_react(
     instance_a: MisskeyLikeClient,
     instance_b: MisskeyLikeClient,


### PR DESCRIPTION
## Summary

drop-in 切替後に mk-A から remote user への reply / reaction が連合で届かない問題 (#369) を、**3 つの独立した原因** を潰すことで解決する。pytest swap test (`make dropin-swap-test`) が 8/8 pass になった (これまで reply / react が xfail)。

## 主な変更点

### 1. `NoteDeliveryHook` に reply / quote renote target 経路を追加

これまでの `OnNoteCreated` はフォロワー配信 + 本文 mention の 2 経路しかなく、alice (local, followers 0) が remote bob に reply しても本文に `@bob` が含まれない限り配信されなかった。

`deliverToDirectRecipients` に統合して以下を追加:
- `note.ReplyID` の作者が remote → 直接 deliver
- quote renote (text 付 renote) の renote 元作者が remote → 直接 deliver
- user ID ベースで dedup

### 2. RSA 秘密鍵を PKCS8 形式でもパースできるように

`ParseRSAPrivateKey` は PKCS1 (`RSA PRIVATE KEY`) のみ対応していたが、Misskey TS は PKCS8 (`PRIVATE KEY`) で格納する。drop-in 切替で mk-go が TS 生成の鍵を読もうとして x509 パース失敗 → deliver task が `skip retry for the task` で捨てられていた。

PKCS1 → PKCS8 の順に fallback、非 RSA (ed25519 等) は明示的に reject。

### 3. Renderer `inReplyTo` を remote target の URI に差し向ける

`RenderNote` は reply target の URI を常に local `urls.NoteURI(...)` で生成していた。reply target が remote note (A 側にキャッシュされた remote bob の note) の場合、`inReplyTo: https://a/notes/<a-copy-id>` となり、受信側 TS-B が fetch すると mk-A が 404 を返す (`ap.Handler.Note` が `userHost != nil` で 404)。chain が切れ reply が通知されない。

quote renote 経路と同じ `resolveNoteURI()` (remote なら note.URI を使う) に揃えた。

## テスト

### Unit

- `internal/activitypub/keypair_test.go`: PKCS8 RSA parse + PKCS8 非 RSA reject の 2 件
- `internal/activitypub/renderer_test.go`: `inReplyTo` が remote target の URI に差し向くことを確認する 1 件
- `internal/core/federation/note_delivery_hook_test.go`: reply to remote / to local / to self / mention dedup / quote renote / pure renote 非配信 の 6 件

### E2E

`tests/dropin/test_swap_verify.py` の `test_post_swap_alice_can_reply` / `test_post_swap_alice_can_react` の `xfail(strict=True)` を解除:

```bash
$ make dropin-swap-test
========================= 8 passed, 1 warning in 6.53s =========================
===> all stages PASS
```

## カバレッジ

- `internal/activitypub`: 95.1%
- `internal/core/federation`: 90.3%

## 残 follow-up

- #378 (画像 attachment ingest)
- #379 (削除済ノート残存)
- #396 (users/lists/push duplicate)
- #397 (specified DM mentions on swap)
- Phase 14-3 cypress swap の `skipInSwap` は #369 に直接紐づくものは無いが、関連 spec 通し確認は別途

Closes #369

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/shiroha-a/mk/pull/399" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
