### PR TITLE
Fix #378: AP attachment を ingest して remote 画像を drive_file 化する

### DIFF
--- a/internal/core/federation/export_test.go
+++ b/internal/core/federation/export_test.go
@@ -9,3 +9,11 @@ var ExtractEmojiTags = extractEmojiTags
 func (r *Resolver) UpsertEmojis(tags []activitypub.EmojiTag, host string) []string {
 	return r.upsertEmojis(tags, host)
 }
+
+// ExtractAttachments exposes the unexported extractAttachments for external tests (#378).
+var ExtractAttachments = extractAttachments
+
+// UpsertAttachments exposes the unexported upsertAttachments method for external tests.
+func (r *Resolver) UpsertAttachments(docs []activitypub.Document, userID, host *string) []string {
+	return r.upsertAttachments(docs, userID, host)
+}

--- a/internal/core/federation/export_test.go
+++ b/internal/core/federation/export_test.go
@@ -17,3 +17,8 @@ var ExtractAttachments = extractAttachments
 func (r *Resolver) UpsertAttachments(docs []activitypub.Document, userID, host *string) []string {
 	return r.upsertAttachments(docs, userID, host)
 }
+
+// CollectAttachedFileTypes exposes the unexported collectAttachedFileTypes for external tests.
+func (r *Resolver) CollectAttachedFileTypes(fileIDs []string) []string {
+	return r.collectAttachedFileTypes(fileIDs)
+}

--- a/internal/core/federation/resolver.go
+++ b/internal/core/federation/resolver.go
@@ -938,9 +938,9 @@ func extractAttachments(rawAttachments []any) []activitypub.Document {
 // in original order. URI による dedup を行うので、同じ remote attachment が
 // 複数の note に紐付いても drive_file は 1 行のみ。
 //
-// driveFileRepo が未設定なら nil を返す (旧挙動)。userID はリモート user の
-// ID (note.UserID 相当)、host はリモート host (nil = ローカル、
-// attachment 文脈ではほぼ常に non-nil)。
+// driveFileRepo が未設定なら空 (pq.StringArray{}) を返す (旧挙動)。userID は
+// リモート user の ID (note.UserID 相当)、host はリモート host (nil =
+// ローカル、attachment 文脈ではほぼ常に non-nil)。
 func (r *Resolver) upsertAttachments(docs []activitypub.Document, userID, host *string) pq.StringArray {
 	if r.driveFileRepo == nil || len(docs) == 0 {
 		return pq.StringArray{}

--- a/internal/core/federation/resolver.go
+++ b/internal/core/federation/resolver.go
@@ -671,14 +671,18 @@ func (r *Resolver) UpdateRemoteNote(body []byte) (*model.Note, error) {
 			existing.Emojis = emojis
 		}
 	}
-	// AP `attachment` 配列の差分を反映する (#378)。
-	fileIDs := r.upsertAttachments(extractAttachments(apNote.Attachment), &existing.UserID, existing.UserHost)
-	if !slices.Equal([]string(existing.FileIDs), []string(fileIDs)) {
-		fields["fileIds"] = pq.StringArray(fileIDs)
-		existing.FileIDs = pq.StringArray(fileIDs)
-		types := r.collectAttachedFileTypes(fileIDs)
-		fields["attachedFileTypes"] = pq.StringArray(types)
-		existing.AttachedFileTypes = pq.StringArray(types)
+	// AP `attachment` 配列の差分を反映する (#378)。driveFileRepo 未設定時は
+	// upsertAttachments が空 slice を返すので何もしない (= 既存 fileIDs を
+	// 誤って空に上書きしない、Devin #400 #1)。
+	if r.driveFileRepo != nil {
+		fileIDs := r.upsertAttachments(extractAttachments(apNote.Attachment), &existing.UserID, existing.UserHost)
+		if !slices.Equal([]string(existing.FileIDs), []string(fileIDs)) {
+			fields["fileIds"] = pq.StringArray(fileIDs)
+			existing.FileIDs = pq.StringArray(fileIDs)
+			types := r.collectAttachedFileTypes(fileIDs)
+			fields["attachedFileTypes"] = pq.StringArray(types)
+			existing.AttachedFileTypes = pq.StringArray(types)
+		}
 	}
 	if len(fields) == 0 {
 		return existing, nil

--- a/internal/core/federation/resolver.go
+++ b/internal/core/federation/resolver.go
@@ -82,14 +82,15 @@ type Resolver struct {
 	urls            *activitypub.URLBuilder
 	fetcher         HTTPFetcher
 	idGen           id.Generator
-	keys            map[string]publicKeyEntry  // userID → publicKey + fetchedAt
-	clock           func() time.Time           // テストで差し替える時計
-	actorTTL        time.Duration              // アクター情報の最大寿命
-	instanceTracker InstanceTracker            // optional: ホスト発見を通知
-	chartHook       ChartHook                  // optional: 新規 remote user の集計
-	publickeyRepo   PublickeyStore             // optional: 公開鍵の永続化
-	pollRepo        repository.PollRepository  // optional: Question(投票)のPoll作成
-	emojiRepo       repository.EmojiRepository // optional: リモート絵文字の永続化
+	keys            map[string]publicKeyEntry      // userID → publicKey + fetchedAt
+	clock           func() time.Time               // テストで差し替える時計
+	actorTTL        time.Duration                  // アクター情報の最大寿命
+	instanceTracker InstanceTracker                // optional: ホスト発見を通知
+	chartHook       ChartHook                      // optional: 新規 remote user の集計
+	publickeyRepo   PublickeyStore                 // optional: 公開鍵の永続化
+	pollRepo        repository.PollRepository      // optional: Question(投票)のPoll作成
+	emojiRepo       repository.EmojiRepository     // optional: リモート絵文字の永続化
+	driveFileRepo   repository.DriveFileRepository // optional: リモート添付の link 化
 }
 
 // NewResolver constructs a Resolver.
@@ -157,6 +158,13 @@ func (r *Resolver) SetPollRepo(repo repository.PollRepository) {
 // remote custom emoji from AP Person/Note Tag arrays (#330).
 func (r *Resolver) SetEmojiRepo(repo repository.EmojiRepository) {
 	r.emojiRepo = repo
+}
+
+// SetDriveFileRepo attaches a DriveFileRepository for ingesting AP
+// `attachment` arrays into drive_file rows (#378). 未設定なら attachment
+// は無視される (旧挙動)。
+func (r *Resolver) SetDriveFileRepo(repo repository.DriveFileRepository) {
+	r.driveFileRepo = repo
 }
 
 // PublicKeyForActor returns the cached public key PEM for an actor ID.
@@ -531,6 +539,13 @@ func (r *Resolver) IngestNote(body []byte) (*model.Note, error) {
 	if actor.Host != nil {
 		note.Emojis = r.upsertEmojis(extractEmojiTags(apNote.Tag), *actor.Host)
 	}
+	// AP `attachment` 配列を drive_file 行に upsert (#378)。link 形式のみで
+	// 実 fetch はせず、frontend が drive_file.url 経由で remote 取得する。
+	note.FileIDs = r.upsertAttachments(extractAttachments(apNote.Attachment), &actor.ID, actor.Host)
+	if len(note.FileIDs) > 0 {
+		// AttachedFileTypes は MIME type の配列 (TS との互換性)。
+		note.AttachedFileTypes = r.collectAttachedFileTypes(note.FileIDs)
+	}
 	// Question（投票）の場合はhasPollフラグをCreate前に設定
 	if len(apNote.OneOf) > 0 || len(apNote.AnyOf) > 0 {
 		note.HasPoll = true
@@ -655,6 +670,15 @@ func (r *Resolver) UpdateRemoteNote(body []byte) (*model.Note, error) {
 			fields["emojis"] = emojis
 			existing.Emojis = emojis
 		}
+	}
+	// AP `attachment` 配列の差分を反映する (#378)。
+	fileIDs := r.upsertAttachments(extractAttachments(apNote.Attachment), &existing.UserID, existing.UserHost)
+	if !slices.Equal([]string(existing.FileIDs), []string(fileIDs)) {
+		fields["fileIds"] = pq.StringArray(fileIDs)
+		existing.FileIDs = pq.StringArray(fileIDs)
+		types := r.collectAttachedFileTypes(fileIDs)
+		fields["attachedFileTypes"] = pq.StringArray(types)
+		existing.AttachedFileTypes = pq.StringArray(types)
 	}
 	if len(fields) == 0 {
 		return existing, nil
@@ -864,4 +888,127 @@ func hostFromURI(uri string) (string, error) {
 		return "", fmt.Errorf("missing host in %q", uri)
 	}
 	return u.Host, nil
+}
+
+// extractAttachments parses the AP `attachment` array (heterogeneous []any
+// after JSON unmarshal) and returns Document entries. type が "Document" /
+// "Image" / "Audio" / "Video" のいずれかで `url` を持つもののみ採用する。
+// #378。
+func extractAttachments(rawAttachments []any) []activitypub.Document {
+	if len(rawAttachments) == 0 {
+		return nil
+	}
+	out := make([]activitypub.Document, 0, len(rawAttachments))
+	for _, raw := range rawAttachments {
+		m, ok := raw.(map[string]any)
+		if !ok {
+			continue
+		}
+		typ, _ := m["type"].(string)
+		switch typ {
+		case "Document", "Image", "Audio", "Video":
+			// ok
+		default:
+			continue
+		}
+		urlStr, _ := m["url"].(string)
+		if urlStr == "" {
+			continue
+		}
+		mediaType, _ := m["mediaType"].(string)
+		name, _ := m["name"].(string)
+		sensitive, _ := m["sensitive"].(bool)
+		out = append(out, activitypub.Document{
+			Type:      typ,
+			MediaType: mediaType,
+			URL:       urlStr,
+			Name:      name,
+			Sensitive: sensitive,
+		})
+	}
+	return out
+}
+
+// upsertAttachments persists each AP Document as a drive_file row (link
+// 形式、isLink=true、実 fetch なし) and returns the resulting drive_file IDs
+// in original order. URI による dedup を行うので、同じ remote attachment が
+// 複数の note に紐付いても drive_file は 1 行のみ。
+//
+// driveFileRepo が未設定なら nil を返す (旧挙動)。userID はリモート user の
+// ID (note.UserID 相当)、host はリモート host (nil = ローカル、
+// attachment 文脈ではほぼ常に non-nil)。
+func (r *Resolver) upsertAttachments(docs []activitypub.Document, userID, host *string) pq.StringArray {
+	if r.driveFileRepo == nil || len(docs) == 0 {
+		return pq.StringArray{}
+	}
+	ids := make(pq.StringArray, 0, len(docs))
+	for _, doc := range docs {
+		// URI ベースで dedup。既存ならその ID を再利用する。
+		if existing, err := r.driveFileRepo.FindByURI(doc.URL); err == nil && existing != nil {
+			ids = append(ids, existing.ID)
+			continue
+		}
+		now := r.clock()
+		mediaType := doc.MediaType
+		if mediaType == "" {
+			mediaType = "application/octet-stream"
+		}
+		name := doc.Name
+		if name == "" {
+			name = "file" // NOT NULL カラムへのフォールバック
+		}
+		var comment *string
+		if doc.Name != "" {
+			cn := doc.Name
+			comment = &cn
+		}
+		uri := doc.URL
+		f := &model.DriveFile{
+			ID:             r.idGen.Generate(now),
+			UserID:         userID,
+			UserHost:       host,
+			MD5:            "", // link 形式のため content hash 取得不可、placeholder
+			Name:           name,
+			Type:           mediaType,
+			Size:           0, // 未 fetch のため未知
+			Comment:        comment,
+			URL:            doc.URL,
+			URI:            &uri,
+			IsLink:         true,
+			IsSensitive:    doc.Sensitive,
+			MaybeSensitive: doc.Sensitive,
+			StoredInternal: false,
+		}
+		if err := r.driveFileRepo.Create(f); err != nil {
+			slog.Warn("upsertAttachments: create failed",
+				"url", doc.URL, "err", err)
+			continue
+		}
+		ids = append(ids, f.ID)
+	}
+	return ids
+}
+
+// collectAttachedFileTypes returns the MIME type list for the given drive
+// file IDs. note.AttachedFileTypes は TS 互換のためノート行に冗長保持される。
+func (r *Resolver) collectAttachedFileTypes(fileIDs []string) pq.StringArray {
+	if r.driveFileRepo == nil || len(fileIDs) == 0 {
+		return pq.StringArray{}
+	}
+	files, err := r.driveFileRepo.FindByIDs(fileIDs)
+	if err != nil {
+		return pq.StringArray{}
+	}
+	// FindByIDs の戻り順は不定なので id → type のマップで再整列する。
+	byID := make(map[string]string, len(files))
+	for _, f := range files {
+		byID[f.ID] = f.Type
+	}
+	out := make(pq.StringArray, 0, len(fileIDs))
+	for _, id := range fileIDs {
+		if t, ok := byID[id]; ok {
+			out = append(out, t)
+		}
+	}
+	return out
 }

--- a/internal/core/federation/resolver_test.go
+++ b/internal/core/federation/resolver_test.go
@@ -1952,3 +1952,165 @@ func TestUpdateRemoteNote_EmojiTagExtraction_ExistingEmoji(t *testing.T) {
 
 // strPtr is a helper that returns a pointer to its argument.
 func strPtr(s string) *string { return &s }
+
+// --- #378 attachment ingest --------------------------------------------------
+
+func TestExtractAttachments(t *testing.T) {
+	tests := []struct {
+		name     string
+		raw      []any
+		expected int
+	}{
+		{
+			name: "Document image is extracted",
+			raw: []any{
+				map[string]any{
+					"type":      "Document",
+					"mediaType": "image/png",
+					"url":       "https://remote.example/files/cat.png",
+					"name":      "cute cat",
+					"sensitive": false,
+				},
+			},
+			expected: 1,
+		},
+		{
+			name: "Image / Audio / Video types accepted",
+			raw: []any{
+				map[string]any{"type": "Image", "url": "https://r/i.jpg"},
+				map[string]any{"type": "Audio", "url": "https://r/a.mp3"},
+				map[string]any{"type": "Video", "url": "https://r/v.mp4"},
+			},
+			expected: 3,
+		},
+		{
+			name: "Unknown types skipped",
+			raw: []any{
+				map[string]any{"type": "Note", "url": "https://r/n"},
+				map[string]any{"type": "Document", "url": "https://r/ok.png"},
+			},
+			expected: 1,
+		},
+		{
+			name: "missing url skipped",
+			raw: []any{
+				map[string]any{"type": "Document"},
+				map[string]any{"type": "Document", "url": ""},
+			},
+			expected: 0,
+		},
+		{
+			name:     "empty input",
+			raw:      nil,
+			expected: 0,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := federation.ExtractAttachments(tt.raw)
+			assert.Len(t, got, tt.expected)
+		})
+	}
+}
+
+func TestUpsertAttachments(t *testing.T) {
+	t.Run("creates new drive_file as link", func(t *testing.T) {
+		repo := testutil.NewMockUserRepository()
+		noteRepo := testutil.NewMockNoteRepository()
+		urls := activitypub.NewURLBuilder("https://example.com")
+		idGen, _ := id.NewGenerator("aidx")
+		r := federation.NewResolver(repo, noteRepo, urls, &stubFetcher{}, idGen)
+		drive := testutil.NewMockDriveFileRepository()
+		r.SetDriveFileRepo(drive)
+
+		userID := "u1"
+		host := "remote.example"
+		docs := []activitypub.Document{
+			{Type: "Document", MediaType: "image/png", URL: "https://r/cat.png", Name: "cat", Sensitive: false},
+			{Type: "Image", MediaType: "image/jpeg", URL: "https://r/dog.jpg", Sensitive: true},
+		}
+		ids := r.UpsertAttachments(docs, &userID, &host)
+		require.Len(t, ids, 2)
+
+		// 各 drive_file を引いて期待値を確認
+		f1, err := drive.FindByURI("https://r/cat.png")
+		require.NoError(t, err)
+		assert.True(t, f1.IsLink, "remote attachment は link 形式")
+		assert.Equal(t, "image/png", f1.Type)
+		assert.Equal(t, "cat", f1.Name)
+		require.NotNil(t, f1.Comment)
+		assert.Equal(t, "cat", *f1.Comment)
+		require.NotNil(t, f1.UserHost)
+		assert.Equal(t, "remote.example", *f1.UserHost)
+		assert.Equal(t, "https://r/cat.png", f1.URL)
+
+		f2, err := drive.FindByURI("https://r/dog.jpg")
+		require.NoError(t, err)
+		assert.True(t, f2.IsSensitive)
+	})
+
+	t.Run("dedup by URI: 既存 row を再利用する", func(t *testing.T) {
+		repo := testutil.NewMockUserRepository()
+		noteRepo := testutil.NewMockNoteRepository()
+		urls := activitypub.NewURLBuilder("https://example.com")
+		idGen, _ := id.NewGenerator("aidx")
+		r := federation.NewResolver(repo, noteRepo, urls, &stubFetcher{}, idGen)
+		drive := testutil.NewMockDriveFileRepository()
+		r.SetDriveFileRepo(drive)
+
+		uri := "https://r/dup.png"
+		drive.Files["pre-existing"] = &model.DriveFile{
+			ID: "pre-existing", URI: &uri, URL: uri, Type: "image/png", Name: "dup",
+		}
+
+		userID := "u1"
+		host := "remote.example"
+		ids := r.UpsertAttachments(
+			[]activitypub.Document{{Type: "Document", URL: uri, Name: "dup"}},
+			&userID, &host,
+		)
+		require.Len(t, ids, 1)
+		assert.Equal(t, "pre-existing", ids[0], "既存 row の ID が返る")
+		// drive_file が新規追加されていない
+		assert.Len(t, drive.Files, 1)
+	})
+
+	t.Run("missing mediaType / name fallbacks", func(t *testing.T) {
+		repo := testutil.NewMockUserRepository()
+		noteRepo := testutil.NewMockNoteRepository()
+		urls := activitypub.NewURLBuilder("https://example.com")
+		idGen, _ := id.NewGenerator("aidx")
+		r := federation.NewResolver(repo, noteRepo, urls, &stubFetcher{}, idGen)
+		drive := testutil.NewMockDriveFileRepository()
+		r.SetDriveFileRepo(drive)
+
+		userID := "u1"
+		host := "remote.example"
+		ids := r.UpsertAttachments(
+			[]activitypub.Document{{Type: "Document", URL: "https://r/no-meta.bin"}},
+			&userID, &host,
+		)
+		require.Len(t, ids, 1)
+		f, err := drive.FindByURI("https://r/no-meta.bin")
+		require.NoError(t, err)
+		assert.Equal(t, "application/octet-stream", f.Type)
+		assert.Equal(t, "file", f.Name)
+		assert.Nil(t, f.Comment, "AP name 空のとき comment は nil")
+	})
+
+	t.Run("nil driveFileRepo returns empty", func(t *testing.T) {
+		repo := testutil.NewMockUserRepository()
+		noteRepo := testutil.NewMockNoteRepository()
+		urls := activitypub.NewURLBuilder("https://example.com")
+		idGen, _ := id.NewGenerator("aidx")
+		r := federation.NewResolver(repo, noteRepo, urls, &stubFetcher{}, idGen)
+
+		userID := "u1"
+		host := "remote.example"
+		ids := r.UpsertAttachments(
+			[]activitypub.Document{{Type: "Document", URL: "https://r/x.png"}},
+			&userID, &host,
+		)
+		assert.Empty(t, ids)
+	})
+}

--- a/internal/core/federation/resolver_test.go
+++ b/internal/core/federation/resolver_test.go
@@ -2004,6 +2004,15 @@ func TestExtractAttachments(t *testing.T) {
 			raw:      nil,
 			expected: 0,
 		},
+		{
+			name: "non-map entries skipped",
+			raw: []any{
+				"https://r/string-not-object.png",
+				42,
+				map[string]any{"type": "Document", "url": "https://r/ok.png"},
+			},
+			expected: 1,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -2113,4 +2122,110 @@ func TestUpsertAttachments(t *testing.T) {
 		)
 		assert.Empty(t, ids)
 	})
+
+	t.Run("Create error skips attachment but keeps processing", func(t *testing.T) {
+		repo := testutil.NewMockUserRepository()
+		noteRepo := testutil.NewMockNoteRepository()
+		urls := activitypub.NewURLBuilder("https://example.com")
+		idGen, _ := id.NewGenerator("aidx")
+		r := federation.NewResolver(repo, noteRepo, urls, &stubFetcher{}, idGen)
+		drive := &createErrDriveRepo{
+			MockDriveFileRepository: testutil.NewMockDriveFileRepository(),
+			err:                     errors.New("db down"),
+		}
+		r.SetDriveFileRepo(drive)
+
+		userID := "u1"
+		host := "remote.example"
+		ids := r.UpsertAttachments(
+			[]activitypub.Document{{Type: "Document", URL: "https://r/err.png"}},
+			&userID, &host,
+		)
+		// Create が失敗した attachment は ID リストに含まれない
+		assert.Empty(t, ids)
+	})
+}
+
+// createErrDriveRepo wraps the mock and forces Create to error so the
+// upsertAttachments error branch can be exercised.
+type createErrDriveRepo struct {
+	*testutil.MockDriveFileRepository
+	err error
+}
+
+func (c *createErrDriveRepo) Create(_ *model.DriveFile) error { return c.err }
+
+func TestCollectAttachedFileTypes(t *testing.T) {
+	t.Run("nil driveFileRepo returns empty", func(t *testing.T) {
+		repo := testutil.NewMockUserRepository()
+		noteRepo := testutil.NewMockNoteRepository()
+		urls := activitypub.NewURLBuilder("https://example.com")
+		idGen, _ := id.NewGenerator("aidx")
+		r := federation.NewResolver(repo, noteRepo, urls, &stubFetcher{}, idGen)
+		assert.Empty(t, r.CollectAttachedFileTypes([]string{"f1"}))
+	})
+
+	t.Run("empty fileIDs returns empty", func(t *testing.T) {
+		repo := testutil.NewMockUserRepository()
+		noteRepo := testutil.NewMockNoteRepository()
+		urls := activitypub.NewURLBuilder("https://example.com")
+		idGen, _ := id.NewGenerator("aidx")
+		r := federation.NewResolver(repo, noteRepo, urls, &stubFetcher{}, idGen)
+		drive := testutil.NewMockDriveFileRepository()
+		r.SetDriveFileRepo(drive)
+		assert.Empty(t, r.CollectAttachedFileTypes(nil))
+	})
+
+	t.Run("returns MIME types in input order", func(t *testing.T) {
+		repo := testutil.NewMockUserRepository()
+		noteRepo := testutil.NewMockNoteRepository()
+		urls := activitypub.NewURLBuilder("https://example.com")
+		idGen, _ := id.NewGenerator("aidx")
+		r := federation.NewResolver(repo, noteRepo, urls, &stubFetcher{}, idGen)
+		drive := testutil.NewMockDriveFileRepository()
+		r.SetDriveFileRepo(drive)
+		drive.Files["a"] = &model.DriveFile{ID: "a", Type: "image/png"}
+		drive.Files["b"] = &model.DriveFile{ID: "b", Type: "image/jpeg"}
+		drive.Files["c"] = &model.DriveFile{ID: "c", Type: "video/mp4"}
+
+		got := r.CollectAttachedFileTypes([]string{"c", "a", "b"})
+		assert.Equal(t, []string{"video/mp4", "image/png", "image/jpeg"}, got)
+	})
+
+	t.Run("missing IDs are skipped", func(t *testing.T) {
+		repo := testutil.NewMockUserRepository()
+		noteRepo := testutil.NewMockNoteRepository()
+		urls := activitypub.NewURLBuilder("https://example.com")
+		idGen, _ := id.NewGenerator("aidx")
+		r := federation.NewResolver(repo, noteRepo, urls, &stubFetcher{}, idGen)
+		drive := testutil.NewMockDriveFileRepository()
+		r.SetDriveFileRepo(drive)
+		drive.Files["a"] = &model.DriveFile{ID: "a", Type: "image/png"}
+
+		got := r.CollectAttachedFileTypes([]string{"a", "missing"})
+		assert.Equal(t, []string{"image/png"}, got)
+	})
+
+	t.Run("FindByIDs error returns empty", func(t *testing.T) {
+		repo := testutil.NewMockUserRepository()
+		noteRepo := testutil.NewMockNoteRepository()
+		urls := activitypub.NewURLBuilder("https://example.com")
+		idGen, _ := id.NewGenerator("aidx")
+		r := federation.NewResolver(repo, noteRepo, urls, &stubFetcher{}, idGen)
+		r.SetDriveFileRepo(&findIDsErrDriveRepo{
+			MockDriveFileRepository: testutil.NewMockDriveFileRepository(),
+			err:                     errors.New("db down"),
+		})
+		assert.Empty(t, r.CollectAttachedFileTypes([]string{"a"}))
+	})
+}
+
+// findIDsErrDriveRepo forces FindByIDs to error.
+type findIDsErrDriveRepo struct {
+	*testutil.MockDriveFileRepository
+	err error
+}
+
+func (f *findIDsErrDriveRepo) FindByIDs(_ []string) ([]*model.DriveFile, error) {
+	return nil, f.err
 }

--- a/internal/core/transfer/drive_reader_test.go
+++ b/internal/core/transfer/drive_reader_test.go
@@ -59,6 +59,9 @@ func (f *fakeDriveFileRepo) FindByIDs(ids []string) ([]*model.DriveFile, error) 
 func (f *fakeDriveFileRepo) FindByMD5(_, _ string) (*model.DriveFile, error) {
 	return nil, errors.New("not found")
 }
+func (f *fakeDriveFileRepo) FindByURI(_ string) (*model.DriveFile, error) {
+	return nil, errors.New("not found")
+}
 func (f *fakeDriveFileRepo) Create(file *model.DriveFile) error {
 	f.files[file.ID] = file
 	return nil

--- a/internal/repository/drive_file.go
+++ b/internal/repository/drive_file.go
@@ -11,6 +11,9 @@ type DriveFileRepository interface {
 	FindByID(id string) (*model.DriveFile, error)
 	FindByIDs(ids []string) ([]*model.DriveFile, error)
 	FindByMD5(userID, md5 string) (*model.DriveFile, error)
+	// FindByURI looks up a drive_file by its AP `uri` field. Used for
+	// deduping remote attachments on inbound Note ingest (#378).
+	FindByURI(uri string) (*model.DriveFile, error)
 	Update(id string, fields map[string]any) error
 	Delete(f *model.DriveFile) error
 	ListByUser(userID string, folderID *string, untilID, sinceID string, limit int) ([]*model.DriveFile, error)
@@ -72,6 +75,17 @@ func (r *driveFileRepository) FindByMD5(userID, md5 string) (*model.DriveFile, e
 		Where("\"userId\" = ? AND md5 = ?", userID, md5).
 		Order("id DESC").
 		First(&f).Error; err != nil {
+		return nil, err
+	}
+	return &f, nil
+}
+
+func (r *driveFileRepository) FindByURI(uri string) (*model.DriveFile, error) {
+	if uri == "" {
+		return nil, gorm.ErrRecordNotFound
+	}
+	var f model.DriveFile
+	if err := r.db.Where("uri = ?", uri).First(&f).Error; err != nil {
 		return nil, err
 	}
 	return &f, nil

--- a/internal/server/router.go
+++ b/internal/server/router.go
@@ -399,6 +399,7 @@ func (s *Server) setupRoutes() {
 	federationResolver.SetPublickeyRepo(publickeyRepo)
 	federationResolver.SetPollRepo(pollRepo)
 	federationResolver.SetEmojiRepo(emojiRepo)
+	federationResolver.SetDriveFileRepo(driveFileRepo)
 	federationProcessor := corefederation.NewProcessor(federationResolver, followingService, reactionService, noteDeleteService, userRepo, noteRepo)
 	federationProcessor.SetLocalBaseURL(s.config.URL)
 

--- a/internal/testutil/mock_drive.go
+++ b/internal/testutil/mock_drive.go
@@ -53,6 +53,18 @@ func (m *MockDriveFileRepository) FindByMD5(userID, md5 string) (*model.DriveFil
 	return match, nil
 }
 
+func (m *MockDriveFileRepository) FindByURI(uri string) (*model.DriveFile, error) {
+	if uri == "" {
+		return nil, ErrNotFound
+	}
+	for _, f := range m.Files {
+		if f.URI != nil && *f.URI == uri {
+			return f, nil
+		}
+	}
+	return nil, ErrNotFound
+}
+
 func (m *MockDriveFileRepository) Update(id string, fields map[string]any) error {
 	f, ok := m.Files[id]
 	if !ok {

--- a/migration/000040_drive_file_uri_index.down.sql
+++ b/migration/000040_drive_file_uri_index.down.sql
@@ -1,0 +1,1 @@
+DROP INDEX IF EXISTS "IDX_drive_file_uri";

--- a/migration/000040_drive_file_uri_index.up.sql
+++ b/migration/000040_drive_file_uri_index.up.sql
@@ -1,0 +1,15 @@
+-- #378 (PR #400) AP attachment ingest 用の dedup index。
+--
+-- internal/core/federation/resolver.go の upsertAttachments は
+-- リモートから受信した各 attachment について driveFileRepo.FindByURI(url)
+-- を呼んで既存 drive_file 行を再利用する。drive_file テーブルは federation
+-- 量に比例して数百万行に膨らむため、uri カラムを未 index のまま seq scan
+-- させると inbound Note 1 件 (画像 4 枚) で 4 回フルスキャンが走り
+-- federation worker のスループットを直撃する。
+--
+-- 実 query は WHERE uri = $1 のみで NULL を引かないので部分 index
+-- (WHERE uri IS NOT NULL) にしてローカル file (uri NULL) を除外し index
+-- を小さく保つ。Misskey TS 側にはこの index は無いが、TS は AP attachment
+-- を fetch して MD5 で dedup する設計のため uri 検索パスを持たない。
+-- mk-go は link 形式 (isLink=true、未 fetch) で持つので URI dedup が必須。
+CREATE INDEX IF NOT EXISTS "IDX_drive_file_uri" ON "drive_file" ("uri") WHERE "uri" IS NOT NULL;


### PR DESCRIPTION
## Summary

リモートから受信したノートに添付された画像 (AP `attachment`) が mk-go では DB に格納されず、フロントエンドで何も表示されない問題 (#378) を修正する。

## 原因

`internal/core/federation/resolver.go` の `IngestNote` / `UpdateRemoteNote` が `apNote.Attachment` を完全に無視しており、

- `note.fileIds` が空のまま
- `drive_file` 行も作られない

ため、フロントエンドが添付情報を取得できずに画像欄が空になる。

## 修正

| 追加 | 内容 |
|------|------|
| `extractAttachments(rawAttachments []any) []activitypub.Document` | AP `attachment` 配列から Document/Image/Audio/Video を抽出 (`extractEmojiTags` と同 pattern) |
| `Resolver.upsertAttachments(docs, userID, host) []driveFileID` | 各 Document を `isLink=true` の drive_file 行として作成。実 fetch せず URL のみ保持。URI ベースで dedup |
| `Resolver.collectAttachedFileTypes(fileIDs)` | TS 互換の `note.attachedFileTypes` (MIME 配列) 構築 |
| `repository.DriveFileRepository.FindByURI` | URI dedup 用 lookup |
| `Resolver.SetDriveFileRepo` | optional setter |

`IngestNote` / `UpdateRemoteNote` から呼び出して `note.FileIDs` / `AttachedFileTypes` を populate / 差分更新。

router.go で `federationResolver.SetDriveFileRepo(driveFileRepo)` を配線。

## 設計上のポイント

- **link 形式 (isLink=true)**: 実 fetch + 自前 storage 保存はしない。frontend が `drive_file.url` 経由で remote から直接 fetch する形 (TS の `cacheRemoteFiles=false` モード相当)。実 fetch / cache 対応は follow-up。
- **MD5 placeholder**: link 形式では content hash が無いので空文字列。`FindByMD5` ベースの dedup は使わず URI ベースで dedup する。
- **mediaType / name fallback**: 欠損時は `application/octet-stream` / `"file"` (NOT NULL カラム制約への safe value)。

## テスト

- `TestExtractAttachments` 5 ケース (Document/Image/Audio/Video / unknown skip / missing url skip / empty)
- `TestUpsertAttachments` 4 ケース (新規作成 / URI dedup / fallback mediaType・name / nil repo)
- `make dropin-swap-test`: 8/8 pass で regression なし

## カバレッジ

- `internal/core/federation`: 既存 90% を維持

## Follow-up (本 PR 範囲外)

- 実 fetch + キャッシュ (`cacheRemoteFiles` 設定) 対応
- thumbnail / webpublic 派生生成
- size / md5 を fetch して後埋め

Closes #378

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/shiroha-a/mk/pull/400" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
