### PR TITLE
Fix #348: admin '全般' page load + save + remote nodeinfo reflection

### DIFF
--- a/internal/api/admin/accounts_test.go
+++ b/internal/api/admin/accounts_test.go
@@ -1,6 +1,7 @@
 package admin_test
 
 import (
+	"errors"
 	"net/http"
 	"testing"
 
@@ -31,50 +32,57 @@ func TestDeleteAllFilesOfUser_DeletesOnlyTargetUserFiles(t *testing.T) {
 
 // --- UpdateProxyAccount ------------------------------------------------------
 
-func TestUpdateProxyAccount_SetsProxyAccountID(t *testing.T) {
-	h, userRepo, metaRepo, _ := newTestHandler(t)
-	u := &model.User{ID: "u-proxy", Username: "proxybot", UsernameLower: "proxybot"}
-	require.NoError(t, userRepo.Create(u))
-
-	rec := doPost(h.UpdateProxyAccount, `{"username":"proxybot"}`, adminUser)
-	assert.Equal(t, http.StatusNoContent, rec.Code)
-	require.NotNil(t, metaRepo.Meta.ProxyAccountID)
-	assert.Equal(t, "u-proxy", *metaRepo.Meta.ProxyAccountID)
+// stubSystemAccountFetcher is a minimal SystemAccountFetcher returning a
+// pre-configured user for any kind.
+type stubSystemAccountFetcher struct {
+	user *model.User
+	err  error
 }
 
-func TestUpdateProxyAccount_ClearWithNilUsername(t *testing.T) {
-	h, _, metaRepo, _ := newTestHandler(t)
-	existing := "old-proxy"
-	metaRepo.Meta.ProxyAccountID = &existing
-
-	rec := doPost(h.UpdateProxyAccount, `{"username":null}`, adminUser)
-	assert.Equal(t, http.StatusNoContent, rec.Code)
-	assert.Nil(t, metaRepo.Meta.ProxyAccountID)
+func (s *stubSystemAccountFetcher) Fetch(_ string) (*model.User, error) {
+	return s.user, s.err
 }
 
-func TestUpdateProxyAccount_ClearWithEmptyString(t *testing.T) {
-	h, _, metaRepo, _ := newTestHandler(t)
-	existing := "old-proxy"
-	metaRepo.Meta.ProxyAccountID = &existing
+func TestUpdateProxyAccount_UpdatesDescription(t *testing.T) {
+	h, userRepo, _, _ := newTestHandler(t)
+	proxy := &model.User{ID: "u-proxy", Username: "proxy.actor", UsernameLower: "proxy.actor"}
+	require.NoError(t, userRepo.Create(proxy))
+	require.NoError(t, userRepo.CreateProfile(&model.UserProfile{UserID: proxy.ID}))
+	h.SetSystemAccountFetcher(&stubSystemAccountFetcher{user: proxy})
 
-	rec := doPost(h.UpdateProxyAccount, `{"username":""}`, adminUser)
-	assert.Equal(t, http.StatusNoContent, rec.Code)
-	assert.Nil(t, metaRepo.Meta.ProxyAccountID)
+	rec := doPost(h.UpdateProxyAccount, `{"description":"hello"}`, adminUser)
+	require.Equal(t, http.StatusOK, rec.Code)
+	prof, err := userRepo.FindProfileByUserID(proxy.ID)
+	require.NoError(t, err)
+	require.NotNil(t, prof.Description)
+	assert.Equal(t, "hello", *prof.Description)
 }
 
-func TestUpdateProxyAccount_UnknownUsernameReturns404(t *testing.T) {
+func TestUpdateProxyAccount_NoFetcherIsNoOp(t *testing.T) {
 	h, _, _, _ := newTestHandler(t)
-	rec := doPost(h.UpdateProxyAccount, `{"username":"ghost"}`, adminUser)
-	assert.Equal(t, http.StatusNotFound, rec.Code)
+	rec := doPost(h.UpdateProxyAccount, `{"description":"x"}`, adminUser)
+	assert.Equal(t, http.StatusNoContent, rec.Code)
 }
 
-func TestUpdateProxyAccount_UsernameIsLowercased(t *testing.T) {
-	h, userRepo, metaRepo, _ := newTestHandler(t)
-	u := &model.User{ID: "u-case", Username: "MixedCase", UsernameLower: "mixedcase"}
-	require.NoError(t, userRepo.Create(u))
+func TestUpdateProxyAccount_FetcherErrorReturnsInternal(t *testing.T) {
+	h, _, _, _ := newTestHandler(t)
+	h.SetSystemAccountFetcher(&stubSystemAccountFetcher{err: errors.New("boom")})
+	rec := doPost(h.UpdateProxyAccount, `{"description":"x"}`, adminUser)
+	assert.Equal(t, http.StatusInternalServerError, rec.Code)
+}
 
-	rec := doPost(h.UpdateProxyAccount, `{"username":"MixedCase"}`, adminUser)
-	assert.Equal(t, http.StatusNoContent, rec.Code)
-	require.NotNil(t, metaRepo.Meta.ProxyAccountID)
-	assert.Equal(t, "u-case", *metaRepo.Meta.ProxyAccountID)
+// description が undefined (null/省略) のときは profile を更新しないが、
+// systemAccountFetcher 経由で取得した user は返す。
+func TestUpdateProxyAccount_NoDescriptionDoesNotUpdateProfile(t *testing.T) {
+	h, userRepo, _, _ := newTestHandler(t)
+	proxy := &model.User{ID: "u-noop", Username: "proxy.actor", UsernameLower: "proxy.actor"}
+	require.NoError(t, userRepo.Create(proxy))
+	require.NoError(t, userRepo.CreateProfile(&model.UserProfile{UserID: proxy.ID}))
+	h.SetSystemAccountFetcher(&stubSystemAccountFetcher{user: proxy})
+
+	rec := doPost(h.UpdateProxyAccount, `{}`, adminUser)
+	require.Equal(t, http.StatusOK, rec.Code)
+	prof, err := userRepo.FindProfileByUserID(proxy.ID)
+	require.NoError(t, err)
+	assert.Nil(t, prof.Description)
 }

--- a/internal/api/admin/handler.go
+++ b/internal/api/admin/handler.go
@@ -53,6 +53,13 @@ type InstanceMetadataFetcher interface {
 	Fetch(host string) error
 }
 
+// SystemAccountFetcher returns (and lazily creates) the built-in proxy /
+// relay / instance actor users. Narrow interface matching
+// coresystemaccount.Service.Fetch so admin handler tests stay decoupled.
+type SystemAccountFetcher interface {
+	Fetch(kind string) (*model.User, error)
+}
+
 // Handler handles admin API endpoints.
 type Handler struct {
 	signupService           *signup.Service
@@ -83,6 +90,7 @@ type Handler struct {
 	idGen                   id.Generator
 	configSetupPassword     string
 	instanceMetadataFetcher InstanceMetadataFetcher
+	systemAccountFetcher    SystemAccountFetcher
 }
 
 // EmailSender sends a plain-text email (to, subject, body). Same signature
@@ -113,6 +121,13 @@ func (h *Handler) SetSystemWebhookRepo(r repository.SystemWebhookRepository) {
 // icon for a specific host on demand.
 func (h *Handler) SetInstanceMetadataFetcher(f InstanceMetadataFetcher) {
 	h.instanceMetadataFetcher = f
+}
+
+// SetSystemAccountFetcher attaches the system account service used by
+// admin/meta and admin/update-proxy-account to materialize the built-in
+// proxy account.
+func (h *Handler) SetSystemAccountFetcher(f SystemAccountFetcher) {
+	h.systemAccountFetcher = f
 }
 
 // SetRecipientRepo attaches an AbuseReportNotificationRecipientRepository for
@@ -612,6 +627,21 @@ func (h *Handler) UnsuspendUser(c echo.Context) error {
 	return c.NoContent(http.StatusNoContent)
 }
 
+// fetchProxyAccountID returns the proxy system user ID for inclusion in the
+// admin/meta response. fetcher 未配線 / 取得失敗時は nil を返すが、その場合
+// frontend settings.vue の `users/show` 呼び出しが400で落ちて画面が真っ白
+// になるため production では必ず wire しておくこと。
+func (h *Handler) fetchProxyAccountID() any {
+	if h.systemAccountFetcher == nil {
+		return nil
+	}
+	user, err := h.systemAccountFetcher.Fetch("proxy")
+	if err != nil || user == nil {
+		return nil
+	}
+	return user.ID
+}
+
 // AdminMeta handles POST /api/admin/meta.
 func (h *Handler) AdminMeta(c echo.Context) error {
 	m, err := h.metaRepo.Fetch()
@@ -712,7 +742,11 @@ func (h *Handler) AdminMeta(c echo.Context) error {
 		"prohibitedWordsForNameOfUser": m.ProhibitedWordsForNameOfUser,
 		"deliverSuspendedSoftware":     []string{},
 		"verifymailAuthKey":            m.VerifymailAuthKey, "truemailAuthKey": m.TruemailAuthKey, "truemailInstance": m.TruemailInstance,
-		"proxyAccountId": nil,
+		// proxyAccountId は frontend admin/settings 画面が読み込み時に
+		// users/show でこの ID を引くため、必ず非空でなければ画面が
+		// 真っ白になる (#348)。本家 SystemAccountService.fetch('proxy')
+		// と同じく lazy 作成して埋める。
+		"proxyAccountId": h.fetchProxyAccountID(),
 		// URL Preview
 		"urlPreviewEnabled":              true,
 		"urlPreviewTimeout":              10000,
@@ -744,11 +778,34 @@ func (h *Handler) UpdateMeta(c echo.Context) error {
 	}
 	// "i" フィールドを除外 (auth token)
 	delete(fields, "i")
+	// frontend が送る API 名 → DB カラム名の差異を吸収する (#348)。API は
+	// 本家互換の camelCase alias (tosUrl 等) を使うが、DB 側は
+	// packages/backend/src/models/Meta.ts と同じ正規名で保持している。
+	// alias が frontend から来たら DB カラム名に translate して渡す。
+	renameUpdateMetaFields(fields)
 
 	if err := h.metaRepo.Update(fields); err != nil {
 		return c.JSON(http.StatusInternalServerError, apierr.Error("INTERNAL_ERROR", "Internal error.", "5d37dbcb-891e-41ca-a3d6-e690c97775ac"))
 	}
 	return c.NoContent(http.StatusNoContent)
+}
+
+// updateMetaFieldAliases maps frontend API names to DB column names for
+// update-meta. 本家 Misskey の admin/meta.ts / update-meta.ts は一部
+// field で alias を使っており、mk-go の AdminMeta も同じ alias で公開
+// しているため、save path にも逆向きの translate を入れる必要がある。
+var updateMetaFieldAliases = map[string]string{
+	"tosUrl":      "termsOfServiceUrl", // 本家: update-meta.ts の termsOfServiceUrl が admin/meta では tosUrl で出る
+	"swPublickey": "swPublicKey",
+}
+
+func renameUpdateMetaFields(fields map[string]any) {
+	for alias, canonical := range updateMetaFieldAliases {
+		if v, ok := fields[alias]; ok {
+			fields[canonical] = v
+			delete(fields, alias)
+		}
+	}
 }
 
 // --- Role endpoints ---

--- a/internal/api/admin/handler_stubs.go
+++ b/internal/api/admin/handler_stubs.go
@@ -360,36 +360,33 @@ func (h *Handler) UpdateAbuseUserReport(c echo.Context) error {
 
 // UpdateProxyAccount handles POST /api/admin/update-proxy-account.
 //
-// username (local) を解決してその user.id を meta.proxyAccountId に保存する。
-// 空 / null を渡した場合は proxyAccountId を NULL に戻して proxy を無効化する。
+// 本家 update-proxy-account.ts と同じく proxy system user の profile.description
+// を更新する handler (旧 stub は誤って meta.proxyAccountId を書き換えていた、#348)。
+// frontend admin/settings 画面の proxyAccountForm が `{ description }` 形式で
+// 呼び出すのでこれに合わせる。Response は UserDetailed (mk-go では UserLite +
+// description で代替)。
 func (h *Handler) UpdateProxyAccount(c echo.Context) error {
 	var req struct {
-		Username *string `json:"username"`
+		Description *string `json:"description"`
 	}
 	if err := c.Bind(&req); err != nil {
 		return c.JSON(http.StatusBadRequest, apierr.Error("INVALID_PARAM", "Invalid parameters.", "00000000-0000-0000-0000-000000000000"))
 	}
-	if h.metaRepo == nil {
+	if h.systemAccountFetcher == nil || h.userRepo == nil {
 		return c.NoContent(http.StatusNoContent)
 	}
-	// 明示的な空文字 / null → 解除
-	if req.Username == nil || *req.Username == "" {
-		if err := h.metaRepo.Update(map[string]any{"proxyAccountId": nil}); err != nil {
-			return c.JSON(http.StatusInternalServerError, apierr.Error("INTERNAL_ERROR", "Internal error.", "00000000-0000-0000-0000-000000000000"))
-		}
-		return c.NoContent(http.StatusNoContent)
-	}
-	if h.userRepo == nil {
-		return c.NoContent(http.StatusNoContent)
-	}
-	user, err := h.userRepo.FindByUsernameLower(strings.ToLower(*req.Username), nil)
-	if err != nil {
-		return c.JSON(http.StatusNotFound, apierr.Error("NO_SUCH_USER", "No such user.", "00000000-0000-0000-0000-000000000000"))
-	}
-	if err := h.metaRepo.Update(map[string]any{"proxyAccountId": user.ID}); err != nil {
+	proxy, err := h.systemAccountFetcher.Fetch("proxy")
+	if err != nil || proxy == nil {
 		return c.JSON(http.StatusInternalServerError, apierr.Error("INTERNAL_ERROR", "Internal error.", "00000000-0000-0000-0000-000000000000"))
 	}
-	return c.NoContent(http.StatusNoContent)
+	if req.Description != nil {
+		if err := h.userRepo.UpdateProfile(proxy.ID, map[string]any{"description": req.Description}); err != nil {
+			return c.JSON(http.StatusInternalServerError, apierr.Error("INTERNAL_ERROR", "Internal error.", "00000000-0000-0000-0000-000000000000"))
+		}
+	}
+	// 更新後 profile を再取得して UserDetailed を返す。
+	profile, _ := h.userRepo.FindProfileByUserID(proxy.ID)
+	return c.JSON(http.StatusOK, entity.PackUserDetailed(proxy, profile))
 }
 
 // UpdateUserNote handles POST /api/admin/update-user-note.

--- a/internal/api/admin/handler_test.go
+++ b/internal/api/admin/handler_test.go
@@ -239,10 +239,49 @@ func TestAdminMeta_FetchError(t *testing.T) {
 	assert.Equal(t, http.StatusInternalServerError, rec.Code)
 }
 
+// fetcher 配線済なら proxyAccountId が proxy system user の ID で埋まる。
+// frontend admin/settings 画面が users/show でこれを引くため必須 (#348)。
+func TestAdminMeta_ProxyAccountIDFromSystemAccount(t *testing.T) {
+	h, _, _, _ := newTestHandler(t)
+	proxy := &model.User{ID: "u-proxy-meta", Username: "proxy.actor", UsernameLower: "proxy.actor"}
+	h.SetSystemAccountFetcher(&stubSystemAccountFetcher{user: proxy})
+	rec := doPost(h.AdminMeta, `{}`, nil)
+	require.Equal(t, http.StatusOK, rec.Code)
+	assert.Contains(t, rec.Body.String(), `"proxyAccountId":"u-proxy-meta"`)
+}
+
+// fetcher 未配線なら proxyAccountId は null (フォロー実装まで safety fallback)。
+func TestAdminMeta_ProxyAccountIDNullWhenFetcherMissing(t *testing.T) {
+	h, _, _, _ := newTestHandler(t)
+	rec := doPost(h.AdminMeta, `{}`, nil)
+	require.Equal(t, http.StatusOK, rec.Code)
+	assert.Contains(t, rec.Body.String(), `"proxyAccountId":null`)
+}
+
 func TestUpdateMeta_Success(t *testing.T) {
 	h, _, _, _ := newTestHandler(t)
 	rec := doPost(h.UpdateMeta, `{"name":"My Instance"}`, nil)
 	assert.Equal(t, http.StatusNoContent, rec.Code)
+}
+
+// frontend が送る `tosUrl` alias は DB column `termsOfServiceUrl` に
+// translate されて update される (#348)。
+func TestUpdateMeta_TosUrlAliasIsTranslated(t *testing.T) {
+	h, _, metaRepo, _ := newTestHandler(t)
+	rec := doPost(h.UpdateMeta, `{"tosUrl":"https://example.test/tos"}`, nil)
+	require.Equal(t, http.StatusNoContent, rec.Code)
+	// mock は update 直後の値を Meta struct に反映するので
+	// TermsOfServiceURL が埋まっていれば translate 成功。
+	require.NotNil(t, metaRepo.Meta.TermsOfServiceURL)
+	assert.Equal(t, "https://example.test/tos", *metaRepo.Meta.TermsOfServiceURL)
+}
+
+func TestUpdateMeta_SwPublickeyAliasIsTranslated(t *testing.T) {
+	h, _, metaRepo, _ := newTestHandler(t)
+	rec := doPost(h.UpdateMeta, `{"swPublickey":"KEY"}`, nil)
+	require.Equal(t, http.StatusNoContent, rec.Code)
+	require.NotNil(t, metaRepo.Meta.SwPublicKey)
+	assert.Equal(t, "KEY", *metaRepo.Meta.SwPublicKey)
 }
 
 func TestAccountsCreate_EmptyUsername(t *testing.T) {

--- a/internal/api/nodeinfo/handler.go
+++ b/internal/api/nodeinfo/handler.go
@@ -6,16 +6,25 @@ import (
 
 	"github.com/labstack/echo/v4"
 	"github.com/shiroha-a/mk/internal/config"
+	"github.com/shiroha-a/mk/internal/repository"
 )
 
 // Handler handles nodeinfo endpoints.
 type Handler struct {
-	cfg *config.Config
+	cfg      *config.Config
+	metaRepo repository.MetaRepository
 }
 
 // NewHandler constructs a Handler.
 func NewHandler(cfg *config.Config) *Handler {
 	return &Handler{cfg: cfg}
+}
+
+// SetMetaRepo injects a MetaRepository so that the nodeName / nodeDescription
+// fields reflect the live admin settings instead of the config default.
+// 未配線のまま呼ばれると cfg.Host fallback になる (#348)。
+func (h *Handler) SetMetaRepo(r repository.MetaRepository) {
+	h.metaRepo = r
 }
 
 // nodeinfoVersion builds the version string for NodeInfo.
@@ -25,6 +34,36 @@ func nodeinfoVersion(mkgoVersion, misskeyVersion string) string {
 
 // Version2_1 handles GET /nodeinfo/2.1.
 func (h *Handler) Version2_1(c echo.Context) error {
+	nodeName := h.cfg.Host
+	var nodeDescription string
+	var maintainerName, maintainerEmail string
+	openRegistrations := false
+	if h.metaRepo != nil {
+		if m, err := h.metaRepo.Fetch(); err == nil && m != nil {
+			if m.Name != nil && *m.Name != "" {
+				nodeName = *m.Name
+			}
+			if m.Description != nil {
+				nodeDescription = *m.Description
+			}
+			if m.MaintainerName != nil {
+				maintainerName = *m.MaintainerName
+			}
+			if m.MaintainerEmail != nil {
+				maintainerEmail = *m.MaintainerEmail
+			}
+			// DisableRegistration=true が登録無効、openRegistrations はその反対。
+			openRegistrations = !m.DisableRegistration
+		}
+	}
+	metadata := map[string]any{
+		"nodeName":        nodeName,
+		"nodeDescription": nodeDescription,
+		"maintainer": map[string]any{
+			"name":  maintainerName,
+			"email": maintainerEmail,
+		},
+	}
 	resp := map[string]any{
 		"version": "2.1",
 		"software": map[string]any{
@@ -37,7 +76,7 @@ func (h *Handler) Version2_1(c echo.Context) error {
 			"inbound":  []string{},
 			"outbound": []string{"atom1.0", "rss2.0"},
 		},
-		"openRegistrations": false,
+		"openRegistrations": openRegistrations,
 		"usage": map[string]any{
 			"users": map[string]any{
 				"total":          0,
@@ -47,9 +86,7 @@ func (h *Handler) Version2_1(c echo.Context) error {
 			"localPosts":    0,
 			"localComments": 0,
 		},
-		"metadata": map[string]any{
-			"nodeName": h.cfg.Host,
-		},
+		"metadata": metadata,
 	}
 	return c.JSON(http.StatusOK, resp)
 }

--- a/internal/api/nodeinfo/handler_test.go
+++ b/internal/api/nodeinfo/handler_test.go
@@ -8,6 +8,8 @@ import (
 
 	"github.com/labstack/echo/v4"
 	"github.com/shiroha-a/mk/internal/config"
+	"github.com/shiroha-a/mk/internal/model"
+	"github.com/shiroha-a/mk/internal/testutil"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -32,4 +34,52 @@ func TestVersion2_1(t *testing.T) {
 
 func TestNodeinfoVersion(t *testing.T) {
 	assert.Equal(t, "0.0.1 (compatible: misskey 2026.3.2)", nodeinfoVersion("0.0.1", "2026.3.2"))
+}
+
+// admin で設定した Meta.Name / Description がnodeinfo.metadata に反映される
+// (#348)。これが効かないとリモートが受け取る nodeName はconfig default
+// (= host) のまま更新されない。
+func TestVersion2_1_ReflectsMetaName(t *testing.T) {
+	metaRepo := testutil.NewMockMetaRepository()
+	name := "My Custom Instance"
+	desc := "hello world"
+	mn := "admin"
+	me := "admin@example.com"
+	metaRepo.Meta = &model.Meta{
+		ID: "x", Name: &name, Description: &desc,
+		MaintainerName: &mn, MaintainerEmail: &me,
+	}
+	h := NewHandler(&config.Config{Version: "0.0.0", Host: "fallback.example"})
+	h.SetMetaRepo(metaRepo)
+
+	e := echo.New()
+	req := httptest.NewRequest(http.MethodGet, "/nodeinfo/2.1", nil)
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+	require.NoError(t, h.Version2_1(c))
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	var resp map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+	meta := resp["metadata"].(map[string]any)
+	assert.Equal(t, "My Custom Instance", meta["nodeName"])
+	assert.Equal(t, "hello world", meta["nodeDescription"])
+	maint := meta["maintainer"].(map[string]any)
+	assert.Equal(t, "admin", maint["name"])
+	assert.Equal(t, "admin@example.com", maint["email"])
+}
+
+// Meta未設定時は cfg.Host が nodeName に入る。
+func TestVersion2_1_FallbackToConfigHost(t *testing.T) {
+	h := NewHandler(&config.Config{Version: "0.0.0", Host: "example.com"})
+	e := echo.New()
+	req := httptest.NewRequest(http.MethodGet, "/nodeinfo/2.1", nil)
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+	require.NoError(t, h.Version2_1(c))
+
+	var resp map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+	meta := resp["metadata"].(map[string]any)
+	assert.Equal(t, "example.com", meta["nodeName"])
 }

--- a/internal/server/router.go
+++ b/internal/server/router.go
@@ -1188,6 +1188,7 @@ func (s *Server) setupRoutes() {
 	s.echo.GET("/.well-known/oauth-authorization-server", wellknownHandler.OAuthAuthorizationServer)
 
 	nodeinfoHandler := nodeinfo.NewHandler(s.config)
+	nodeinfoHandler.SetMetaRepo(metaRepo)
 	s.echo.GET("/nodeinfo/2.1", nodeinfoHandler.Version2_1)
 
 	// Inbox endpoints
@@ -1484,6 +1485,7 @@ func (s *Server) setupRoutes() {
 		adminHandler.SetQueueInspector(&queueInspectorAdapter{inner: s.queueInspector})
 	}
 	adminHandler.SetInstanceMetadataFetcher(metadataFetcher)
+	adminHandler.SetSystemAccountFetcher(sysAcctSvc)
 	api.POST("/admin/accounts/create", adminHandler.AccountsCreate)
 	api.POST("/admin/show-user", adminHandler.ShowUser, middleware.RequireModerator(roleService))
 	api.POST("/admin/show-users", adminHandler.ShowUsers, middleware.RequireModerator(roleService))

--- a/internal/testutil/mock_repository.go
+++ b/internal/testutil/mock_repository.go
@@ -1496,6 +1496,18 @@ func (m *MockMetaRepository) Update(fields map[string]any) error {
 			if s, ok := v.(string); ok {
 				m.Meta.TurnstileSecretKey = &s
 			}
+		case "termsOfServiceUrl":
+			if s, ok := v.(string); ok {
+				m.Meta.TermsOfServiceURL = &s
+			}
+		case "swPublicKey":
+			if s, ok := v.(string); ok {
+				m.Meta.SwPublicKey = &s
+			}
+		case "name":
+			if s, ok := v.(string); ok {
+				m.Meta.Name = &s
+			}
 		}
 	}
 	return nil


### PR DESCRIPTION
## Summary

手動検証で「コントロールパネル > 全般」が真っ白 → 表示 → 保存失敗 → リモート反映されない、という流れで4段階の問題があったので1 PRでまとめて修正する。

## 主な変更点

### 1. AdminMeta に proxyAccountId を埋める (表示崩れの根本原因)

frontend `settings.vue` は:
```js
const proxyAccount = await misskeyApi('users/show', { userId: meta.proxyAccountId });
```
を top-level で await している。`proxyAccountId` が `null` だと `users/show` が `INVALID_PARAM` で400を返し、ページ全体が描画されない。

本家 `SystemAccountService.fetch('proxy')` と同じく、既存の `coresystemaccount.Service.Fetch(\"proxy\")` (lazy 作成) を admin handler に注入して `admin/meta` response の `proxyAccountId` に差し込む。

- 新 narrow interface `SystemAccountFetcher` を admin handler に追加
- `SetSystemAccountFetcher` setter + `fetchProxyAccountID()` helper
- `router.go` で既存 `sysAcctSvc` を inject

### 2. `UpdateProxyAccount` を本家準拠に書き直し

旧 stub は `{username}` で `meta.proxyAccountId` を書き換える別物の実装だった。本家 `update-proxy-account.ts` 仕様 (= `{description}` で proxy system user の profile を更新、 response UserDetailed) に合わせて rewrite。frontend の `proxyAccountForm` が `apiWithDialog('admin/update-proxy-account', { description })` を叩くためこれが必須。

### 3. `UpdateMeta` の alias 翻訳

frontend が送る `tosUrl` / `swPublickey` は DB column として `termsOfServiceUrl` / `swPublicKey`。旧実装は受け取った JSON をそのまま `metaRepo.Update` に渡していたため `ERROR: column \"tosUrl\" of relation \"meta\" does not exist` で save が 500 を返していた。

`updateMetaFieldAliases` map を追加して alias → canonical column name に translate してから update する。

### 4. `/nodeinfo/2.1` が admin 設定を反映

旧実装は `h.cfg.Host` を `nodeName` にハードコードしていたため、admin 画面でインスタンス名を変更しても **リモートサーバーが取得する nodeName は変わらない** 状態だった。

`metaRepo.Fetch()` を呼んで以下を反映する:
- `metadata.nodeName`: `Meta.Name` fallback `cfg.Host`
- `metadata.nodeDescription`: `Meta.Description`
- `metadata.maintainer.name/email`: `Meta.MaintainerName / MaintainerEmail`
- `openRegistrations`: `!Meta.DisableRegistration`

## テスト

新規 / 更新:
- `TestAdminMeta_ProxyAccountIDFromSystemAccount` / `..._FetcherMissing`
- `TestUpdateProxyAccount_UpdatesDescription` / `..._NoFetcherIsNoOp` / `..._FetcherErrorReturnsInternal` / `..._NoDescriptionDoesNotUpdateProfile`
- `TestUpdateMeta_TosUrlAliasIsTranslated` / `..._SwPublickeyAliasIsTranslated`
- `TestVersion2_1_ReflectsMetaName` / `..._FallbackToConfigHost`
- 既存の `UpdateProxyAccount` 3本 (username ベースの旧仕様) を新仕様に合わせて置き換え

coverage:
- `internal/api/admin` 83.4% (CI 80% 閾値 OK)
- `internal/api/nodeinfo` 100%
- `internal/server/router`, `internal/testutil` 既存維持

本番 (go.k7a.org) 検証:
- [x] 全般ページが描画される
- [x] インスタンス名 / 利用規約 URL 等の保存が 200 OK
- [x] `/nodeinfo/2.1` の `nodeName` が admin 設定と同期

## 注意点

既存の remote instance 側では nodeinfo がキャッシュ済みなので、admin 名前変更を反映させるには相手側から refresh を trigger してもらう必要がある (mk-go 側の制御外)。periodic refresh cron は別 follow-up issue #393 で対応予定。

## Closes

Closes #348

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/shiroha-a/mk/pull/402" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
