### PR TITLE
Fix #340: apply safehttp.ReadAllLimit to first-party external fetchers

### DIFF
--- a/internal/core/captcha/captcha_test.go
+++ b/internal/core/captcha/captcha_test.go
@@ -290,5 +290,7 @@ func TestTurnstile_ResponseTooLarge(t *testing.T) {
 
 	v := captcha.NewTurnstileWithURL("sec", srv.URL, srv.Client())
 	err := v.Verify(context.Background(), "token")
-	assert.Error(t, err)
+	// Mcaptcha と同じく ErrRequestFailed が返ることを明示 (TestMcaptcha_ResponseTooLarge
+	// と揃える、Devin #404 指摘)。
+	assert.ErrorIs(t, err, captcha.ErrRequestFailed)
 }

--- a/internal/core/captcha/captcha_test.go
+++ b/internal/core/captcha/captcha_test.go
@@ -265,3 +265,30 @@ func TestMcaptcha_InvalidJSON(t *testing.T) {
 	err := v.Verify(context.Background(), "token")
 	assert.ErrorIs(t, err, captcha.ErrRequestFailed)
 }
+
+// #340: captcha fetcher が safehttp.ReadAllLimit (1 MiB cap) で過大 response
+// を弾くこと。1 MiB 超を返すサーバをsimulate して ErrRequestFailed が返る
+// ことを検証する。
+func TestMcaptcha_ResponseTooLarge(t *testing.T) {
+	oversized := make([]byte, 2<<20) // 2 MiB > 1 MiB cap
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Write(oversized)
+	}))
+	defer srv.Close()
+
+	v := captcha.NewMcaptchaWithClient(srv.URL, "site", "sec", srv.Client())
+	err := v.Verify(context.Background(), "token")
+	assert.ErrorIs(t, err, captcha.ErrRequestFailed)
+}
+
+func TestTurnstile_ResponseTooLarge(t *testing.T) {
+	oversized := make([]byte, 2<<20)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Write(oversized)
+	}))
+	defer srv.Close()
+
+	v := captcha.NewTurnstileWithURL("sec", srv.URL, srv.Client())
+	err := v.Verify(context.Background(), "token")
+	assert.Error(t, err)
+}

--- a/internal/core/captcha/mcaptcha.go
+++ b/internal/core/captcha/mcaptcha.go
@@ -5,9 +5,10 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"io"
 	"net/http"
 	"strings"
+
+	"github.com/shiroha-a/mk/internal/safehttp"
 )
 
 type mcaptchaVerifier struct {
@@ -78,7 +79,7 @@ func (v *mcaptchaVerifier) Verify(ctx context.Context, token string) error {
 		return fmt.Errorf("%w: status %d", ErrVerificationFail, resp.StatusCode)
 	}
 
-	data, err := io.ReadAll(resp.Body)
+	data, err := safehttp.ReadAllLimit(resp.Body, safehttp.DefaultThirdPartyAPILimit)
 	if err != nil {
 		return fmt.Errorf("%w: read body: %v", ErrRequestFailed, err)
 	}

--- a/internal/core/captcha/siteverify.go
+++ b/internal/core/captcha/siteverify.go
@@ -4,10 +4,11 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"io"
 	"net/http"
 	"net/url"
 	"strings"
+
+	"github.com/shiroha-a/mk/internal/safehttp"
 )
 
 // siteVerifyResponse is the common JSON shape returned by hCaptcha,
@@ -52,7 +53,7 @@ func (v *siteVerifier) Verify(ctx context.Context, token string) error {
 	}
 	defer resp.Body.Close()
 
-	data, err := io.ReadAll(resp.Body)
+	data, err := safehttp.ReadAllLimit(resp.Body, safehttp.DefaultThirdPartyAPILimit)
 	if err != nil {
 		return fmt.Errorf("%w: read body: %v", ErrRequestFailed, err)
 	}

--- a/internal/core/email/email_test.go
+++ b/internal/core/email/email_test.go
@@ -278,3 +278,27 @@ func TestDomainOf(t *testing.T) {
 	assert.Equal(t, "sub.domain.org", domainOf("a@sub.domain.org"))
 	assert.Equal(t, "", domainOf("noatsign"))
 }
+
+// #340: verifymail / truemail fetcher が過大 response を safehttp.ReadAllLimit
+// で弾くこと。1 MiB cap を超えるbodyを返す stub server に対して error が
+// 伝播することを検証する。
+func TestVerifymail_ResponseTooLarge(t *testing.T) {
+	oversized := make([]byte, 2<<20)
+	c := verifymailWithStub(t, func(w http.ResponseWriter, _ *http.Request) {
+		w.Write(oversized)
+	})
+	err := c.verify(context.Background(), "a@example.com")
+	assert.Error(t, err)
+}
+
+func TestTruemail_ResponseTooLarge(t *testing.T) {
+	oversized := make([]byte, 2<<20)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Write(oversized)
+	}))
+	defer srv.Close()
+
+	c := &truemailClient{instanceURL: srv.URL, authKey: "key", client: srv.Client()}
+	err := c.verify(context.Background(), "a@example.com")
+	assert.Error(t, err)
+}

--- a/internal/core/email/truemail.go
+++ b/internal/core/email/truemail.go
@@ -4,10 +4,11 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"io"
 	"net/http"
 	"net/url"
 	"strings"
+
+	"github.com/shiroha-a/mk/internal/safehttp"
 )
 
 type truemailClient struct {
@@ -53,7 +54,7 @@ func (c *truemailClient) verify(ctx context.Context, emailAddr string) error {
 	}
 	defer resp.Body.Close()
 
-	data, err := io.ReadAll(resp.Body)
+	data, err := safehttp.ReadAllLimit(resp.Body, safehttp.DefaultThirdPartyAPILimit)
 	if err != nil {
 		return fmt.Errorf("%w: read body: %v", ErrNetwork, err)
 	}

--- a/internal/core/email/verifymail.go
+++ b/internal/core/email/verifymail.go
@@ -4,9 +4,10 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"io"
 	"net/http"
 	"net/url"
+
+	"github.com/shiroha-a/mk/internal/safehttp"
 )
 
 type verifymailClient struct {
@@ -40,7 +41,7 @@ func (c *verifymailClient) verify(ctx context.Context, email string) error {
 	}
 	defer resp.Body.Close()
 
-	data, err := io.ReadAll(resp.Body)
+	data, err := safehttp.ReadAllLimit(resp.Body, safehttp.DefaultThirdPartyAPILimit)
 	if err != nil {
 		return fmt.Errorf("%w: read body: %v", ErrNetwork, err)
 	}

--- a/internal/core/translate/deepl.go
+++ b/internal/core/translate/deepl.go
@@ -7,6 +7,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
 	"net/http"
 	"net/url"
 	"strings"
@@ -84,7 +85,10 @@ func (c *DeepLClient) Translate(ctx context.Context, text, targetLang string) (*
 	// message に出ず debug が難しくなるため (#404 Devin 指摘)。
 	if resp.StatusCode != http.StatusOK {
 		// error body は full に読まず 8 KiB snippet だけ引いてメッセージに含める。
-		snippet, _ := safehttp.ReadAllLimit(resp.Body, 8*1024)
+		// io.LimitReader は cap 超過時に error を返さずに切り詰めるので、
+		// 8 KiB 超のbodyでも先頭snippetが確実に取れる (ReadAllLimitだと
+		// 超過時に nil を返してしまう、Devin指摘)。
+		snippet, _ := io.ReadAll(io.LimitReader(resp.Body, 8*1024))
 		return nil, fmt.Errorf("%w: status %d: %s", ErrRequestFailed, resp.StatusCode, string(snippet))
 	}
 

--- a/internal/core/translate/deepl.go
+++ b/internal/core/translate/deepl.go
@@ -7,10 +7,11 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io"
 	"net/http"
 	"net/url"
 	"strings"
+
+	"github.com/shiroha-a/mk/internal/safehttp"
 )
 
 var (
@@ -78,7 +79,7 @@ func (c *DeepLClient) Translate(ctx context.Context, text, targetLang string) (*
 	}
 	defer resp.Body.Close()
 
-	data, err := io.ReadAll(resp.Body)
+	data, err := safehttp.ReadAllLimit(resp.Body, safehttp.DefaultThirdPartyAPILimit)
 	if err != nil {
 		return nil, fmt.Errorf("%w: read body: %v", ErrRequestFailed, err)
 	}

--- a/internal/core/translate/deepl.go
+++ b/internal/core/translate/deepl.go
@@ -79,13 +79,18 @@ func (c *DeepLClient) Translate(ctx context.Context, text, targetLang string) (*
 	}
 	defer resp.Body.Close()
 
+	// status check を body 読込より先に行う。non-200 で body が巨大だと
+	// ReadAllLimit が ErrResponseTooLarge を返して status 情報が error
+	// message に出ず debug が難しくなるため (#404 Devin 指摘)。
+	if resp.StatusCode != http.StatusOK {
+		// error body は full に読まず 8 KiB snippet だけ引いてメッセージに含める。
+		snippet, _ := safehttp.ReadAllLimit(resp.Body, 8*1024)
+		return nil, fmt.Errorf("%w: status %d: %s", ErrRequestFailed, resp.StatusCode, string(snippet))
+	}
+
 	data, err := safehttp.ReadAllLimit(resp.Body, safehttp.DefaultThirdPartyAPILimit)
 	if err != nil {
 		return nil, fmt.Errorf("%w: read body: %v", ErrRequestFailed, err)
-	}
-
-	if resp.StatusCode != http.StatusOK {
-		return nil, fmt.Errorf("%w: status %d: %s", ErrRequestFailed, resp.StatusCode, string(data))
 	}
 
 	var result deeplResponse

--- a/internal/core/translate/deepl_test.go
+++ b/internal/core/translate/deepl_test.go
@@ -85,3 +85,17 @@ func TestNewDeepL_FreeEndpoint(t *testing.T) {
 	c := NewDeepL("key", false)
 	assert.Equal(t, deeplFreeURL, c.apiURL)
 }
+
+// #340: DeepL fetcher が過大 response を safehttp.ReadAllLimit で弾くこと。
+// 1 MiB cap を超える body を返す stub server に対して ErrRequestFailed を返す。
+func TestDeepL_Translate_ResponseTooLarge(t *testing.T) {
+	oversized := make([]byte, 2<<20)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Write(oversized)
+	}))
+	defer srv.Close()
+
+	c := NewDeepLWithClient("key", srv.URL, srv.Client())
+	_, err := c.Translate(context.Background(), "text", "en")
+	assert.ErrorIs(t, err, ErrRequestFailed)
+}

--- a/internal/core/translate/deepl_test.go
+++ b/internal/core/translate/deepl_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -98,4 +99,23 @@ func TestDeepL_Translate_ResponseTooLarge(t *testing.T) {
 	c := NewDeepLWithClient("key", srv.URL, srv.Client())
 	_, err := c.Translate(context.Background(), "text", "en")
 	assert.ErrorIs(t, err, ErrRequestFailed)
+}
+
+// #404 Devin指摘: non-200 で error body が 8 KiB 超の場合も snippet が
+// error message に含まれること (io.LimitReader で cap せず先頭を取り込む)。
+func TestDeepL_Translate_NonOKLargeBody_IncludesSnippet(t *testing.T) {
+	// 10 KiB の repeating marker — 先頭 8 KiB が snippet に入る想定。
+	body := strings.Repeat("x", 10*1024)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusBadRequest)
+		w.Write([]byte(body))
+	}))
+	defer srv.Close()
+
+	c := NewDeepLWithClient("key", srv.URL, srv.Client())
+	_, err := c.Translate(context.Background(), "text", "en")
+	require.ErrorIs(t, err, ErrRequestFailed)
+	// "x" がerror messageに多数含まれているはず (snippetとして)
+	assert.Contains(t, err.Error(), "status 400")
+	assert.Contains(t, err.Error(), strings.Repeat("x", 100))
 }

--- a/internal/safehttp/limited_reader.go
+++ b/internal/safehttp/limited_reader.go
@@ -15,8 +15,8 @@ var ErrResponseTooLarge = errors.New("safehttp: response body exceeds size limit
 // exhaustion を防ぎつつ典型的な AP/JRD payload には十分なサイズ。
 const DefaultAPBodyLimit int64 = 1 << 20
 
-// DefaultThirdPartyAPILimit caps first-party third-party API responses
-// (captcha verify, email verify, DeepL translate etc.). これらは
+// DefaultThirdPartyAPILimit caps responses from third-party APIs called by
+// mk-go itself (captcha verify, email verify, DeepL translate etc.). これらは
 // 設定済み信頼済みサービスとの通信なので攻撃者制御リスクは低いが、
 // defense-in-depth のため #340 で統一 cap を当てる。
 //

--- a/internal/safehttp/limited_reader.go
+++ b/internal/safehttp/limited_reader.go
@@ -16,14 +16,14 @@ var ErrResponseTooLarge = errors.New("safehttp: response body exceeds size limit
 const DefaultAPBodyLimit int64 = 1 << 20
 
 // DefaultThirdPartyAPILimit caps responses from third-party APIs called by
-// mk-go itself (captcha verify, email verify, DeepL translate etc.). これらは
-// 設定済み信頼済みサービスとの通信なので攻撃者制御リスクは低いが、
-// defense-in-depth のため #340 で統一 cap を当てる。
+// mk-go itself (captcha / email verify / translate etc.). Calls target
+// admin-configured trusted services, so the attacker-control surface is
+// small, but this cap still guards against misconfiguration or malicious
+// responses that could otherwise exhaust memory.
 //
-// 大半の captcha/email verify は数 KiB 以内の JSON、DeepL は翻訳長に
-// 依存するがドキュメント上限 5,000 文字 × JSON overhead = 数百 KiB 程度。
-// 1 MiB あれば実用上十分で、misconfiguration / 攻撃的巨大 response の
-// memory exhaustion を防げる。
+// Sized at 1 MiB: captcha / email-verify responses are a few KiB of JSON,
+// and DeepL translations stay well under 1 MiB for the 5,000-character
+// document limit.
 const DefaultThirdPartyAPILimit int64 = 1 << 20
 
 // ReadAllLimit reads r up to max bytes. If r contains more than max bytes,

--- a/internal/safehttp/limited_reader.go
+++ b/internal/safehttp/limited_reader.go
@@ -15,6 +15,17 @@ var ErrResponseTooLarge = errors.New("safehttp: response body exceeds size limit
 // exhaustion を防ぎつつ典型的な AP/JRD payload には十分なサイズ。
 const DefaultAPBodyLimit int64 = 1 << 20
 
+// DefaultThirdPartyAPILimit caps first-party third-party API responses
+// (captcha verify, email verify, DeepL translate etc.). これらは
+// 設定済み信頼済みサービスとの通信なので攻撃者制御リスクは低いが、
+// defense-in-depth のため #340 で統一 cap を当てる。
+//
+// 大半の captcha/email verify は数 KiB 以内の JSON、DeepL は翻訳長に
+// 依存するがドキュメント上限 5,000 文字 × JSON overhead = 数百 KiB 程度。
+// 1 MiB あれば実用上十分で、misconfiguration / 攻撃的巨大 response の
+// memory exhaustion を防げる。
+const DefaultThirdPartyAPILimit int64 = 1 << 20
+
 // ReadAllLimit reads r up to max bytes. If r contains more than max bytes,
 // ErrResponseTooLarge is returned. max <= 0 disables the cap (matches
 // io.ReadAll). max >= math.MaxInt64 is treated as unlimited to avoid


### PR DESCRIPTION
## Summary

PR #336 (#323) で AP / WebFinger の外向き HTTP fetcher を `safehttp.ReadAllLimit` に統一した follow-up。Devin review で指摘された残り 5 箇所の first-party 外向き fetcher (captcha / email verify / DeepL) にも同じ defense-in-depth を適用する。

設定済み信頼済みサービスとの通信なので攻撃者制御リスクは低いが、misconfiguration / 巨大 response による memory exhaustion を防ぐ目的で統一する。

## 主な変更点

- `internal/safehttp/limited_reader.go`: `DefaultThirdPartyAPILimit = 1 MiB` 定数を追加 (`DefaultAPBodyLimit` と同値だが意味論的に分離)
- 以下 5 箇所の `io.ReadAll(resp.Body)` を `safehttp.ReadAllLimit(resp.Body, safehttp.DefaultThirdPartyAPILimit)` に置換:
  - `internal/core/captcha/mcaptcha.go:81`
  - `internal/core/captcha/siteverify.go:55` (hCaptcha / reCAPTCHA / Turnstile 共通)
  - `internal/core/email/verifymail.go:43`
  - `internal/core/email/truemail.go:56`
  - `internal/core/translate/deepl.go:81`
- 各 fetcher に「過大 response 返却 → error 伝播」の regression test 5 件追加

## サイズキャップの妥当性

- mCaptcha / siteverify / verifymail / truemail: 数 KiB の JSON response が典型 → 1 MiB で十分
- DeepL: ドキュメント上限 5,000 文字 × JSON overhead = 数百 KiB 程度 → 1 MiB で余裕あり

## テスト

- 新規 5 テスト (2 MiB body を返す stub server で error が返ることを検証)
- coverage:
  - `internal/core/captcha` 93.3%
  - `internal/core/email` 95.7%
  - `internal/core/translate` 96.2%
  - `internal/safehttp` 91.5%
  - いずれも 90% 閾値クリア、むしろテスト追加で向上
- `make fmt && make lint` clean

## Closes

Closes #340

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/shiroha-a/mk/pull/404" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
