### PR TITLE
Fix #379: Delete 受信 / 自ノート削除で Redis fanout timeline を LREM 掃除

### DIFF
--- a/internal/core/note/note_delete_service.go
+++ b/internal/core/note/note_delete_service.go
@@ -29,12 +29,22 @@ type DeleteChartHook interface {
 	OnNoteDeleted(note *model.Note)
 }
 
+// DeleteTimelineHook is invoked after a note is deleted so Redis fanout
+// timelines (home/local/global/user/userList) can have the note ID
+// purged via LREM (#379)。inbound Delete activity 経由でも local
+// `notes/delete` 経由でも同じ DeleteService を通るので、ここに hook を
+// 1 つ生やせば両方の経路で timeline 残留を防げる。実装は core/timeline。
+type DeleteTimelineHook interface {
+	OnNoteDeleted(note *model.Note, author *model.User)
+}
+
 // DeleteService provides note deletion logic.
 type DeleteService struct {
 	noteRepo       repository.NoteRepository
 	federationHook DeleteFederationHook
 	indexHook      IndexHook
 	chartHook      DeleteChartHook
+	timelineHook   DeleteTimelineHook
 }
 
 // NewDeleteService creates a new DeleteService.
@@ -57,6 +67,12 @@ func (s *DeleteService) SetIndexHook(h IndexHook) {
 // deleted so the chart subsystem can decrement the relevant counters.
 func (s *DeleteService) SetChartHook(h DeleteChartHook) {
 	s.chartHook = h
+}
+
+// SetTimelineHook attaches a DeleteTimelineHook invoked after Delete so
+// Redis fanout timelines can be purged of the note ID (#379)。
+func (s *DeleteService) SetTimelineHook(h DeleteTimelineHook) {
+	s.timelineHook = h
 }
 
 // Delete removes a note authored by the given user. It returns
@@ -96,6 +112,10 @@ func (s *DeleteService) Delete(user *model.User, noteID string) error {
 	// チャート集計もベストエフォート。
 	if s.chartHook != nil {
 		s.chartHook.OnNoteDeleted(note)
+	}
+	// Redis fanout timeline 残留を防ぐ (#379)。ベストエフォート。
+	if s.timelineHook != nil {
+		s.timelineHook.OnNoteDeleted(note, user)
 	}
 	return nil
 }

--- a/internal/core/note/note_delete_service_test.go
+++ b/internal/core/note/note_delete_service_test.go
@@ -160,3 +160,31 @@ func TestDeleteService_ChartHookInvoked(t *testing.T) {
 	require.NotNil(t, hook.deleted)
 	assert.Equal(t, "n1", hook.deleted.ID)
 }
+
+// recordingDeleteTimelineHook captures timeline-purge hook calls (#379)。
+type recordingDeleteTimelineHook struct {
+	called bool
+	note   *model.Note
+	author *model.User
+}
+
+func (h *recordingDeleteTimelineHook) OnNoteDeleted(n *model.Note, author *model.User) {
+	h.called = true
+	h.note = n
+	h.author = author
+}
+
+func TestDeleteService_TimelineHookInvoked(t *testing.T) {
+	noteRepo := testutil.NewMockNoteRepository()
+	noteRepo.Notes["n1"] = &model.Note{ID: "n1", UserID: "user1"}
+	svc := note.NewDeleteService(noteRepo)
+	hook := &recordingDeleteTimelineHook{}
+	svc.SetTimelineHook(hook)
+
+	require.NoError(t, svc.Delete(&model.User{ID: "user1"}, "n1"))
+	assert.True(t, hook.called)
+	require.NotNil(t, hook.note)
+	assert.Equal(t, "n1", hook.note.ID)
+	require.NotNil(t, hook.author)
+	assert.Equal(t, "user1", hook.author.ID)
+}

--- a/internal/core/timeline/fanout_hook.go
+++ b/internal/core/timeline/fanout_hook.go
@@ -280,3 +280,83 @@ func (h *FanoutHook) pushWithLimit(ctx context.Context, name Name, id string, ma
 		slog.Warn("timeline push failed", "name", string(name), "id", id, "err", err)
 	}
 }
+
+// OnNoteDeleted purges the deleted note ID from every Redis timeline list
+// it could have been pushed to by OnNoteCreated (#379)。inbound Delete も
+// ローカル削除も同じ経路を通って届くので、ここ 1 か所で fan-out 先全てを
+// 掃除する。失敗はベストエフォート (DB は既に消えているので部分残留しても
+// 後段の note hydrate で missing として落ちる)。
+func (h *FanoutHook) OnNoteDeleted(n *model.Note, author *model.User) {
+	if n == nil || author == nil {
+		return
+	}
+	ctx := context.Background()
+
+	// 1. ユーザータイムライン
+	h.removeBestEffort(ctx, UserTimelineName(author.ID), n.ID)
+
+	// 2. ホームタイムライン: 投稿者本人 + フォロワー全員
+	h.removeBestEffort(ctx, HomeTimelineName(author.ID), n.ID)
+	if h.followingRepo != nil && shouldFanoutToFollowers(n) {
+		h.removeFromFollowerHomes(ctx, author.ID, n.ID)
+	}
+
+	// 3. ローカルタイムライン
+	if author.Host == nil && n.Visibility == model.NoteVisibilityPublic {
+		h.removeBestEffort(ctx, LocalTimeline, n.ID)
+	}
+
+	// 4. グローバルタイムライン
+	if n.Visibility == model.NoteVisibilityPublic {
+		h.removeBestEffort(ctx, GlobalTimeline, n.ID)
+	}
+
+	// 5. ユーザーリストタイムライン
+	if h.userListRepo != nil && shouldFanoutToFollowers(n) {
+		h.removeFromUserLists(ctx, author.ID, n.ID)
+	}
+}
+
+// removeBestEffort wraps Remove with error logging.
+func (h *FanoutHook) removeBestEffort(ctx context.Context, name Name, noteID string) {
+	if err := h.fanout.Remove(ctx, name, noteID); err != nil {
+		slog.Warn("timeline remove failed", "name", string(name), "id", noteID, "err", err)
+	}
+}
+
+// removeFromFollowerHomes mirrors fanoutToFollowers: page through followers and
+// LREM the note ID from each follower's home timeline list.
+func (h *FanoutHook) removeFromFollowerHomes(ctx context.Context, authorID, noteID string) {
+	const pageSize = 200
+	offset := 0
+	for {
+		rows, err := h.followingRepo.ListFollowers(authorID, pageSize, offset)
+		if err != nil {
+			slog.Warn("removeFromFollowerHomes: list followers failed", "err", err, "author", authorID)
+			return
+		}
+		if len(rows) == 0 {
+			return
+		}
+		for _, f := range rows {
+			h.removeBestEffort(ctx, HomeTimelineName(f.FollowerID), noteID)
+		}
+		if len(rows) < pageSize {
+			return
+		}
+		offset += pageSize
+	}
+}
+
+// removeFromUserLists mirrors fanoutToUserLists: query the lists that contain
+// the author at delete time and LREM the note ID from each.
+func (h *FanoutHook) removeFromUserLists(ctx context.Context, authorID, noteID string) {
+	listIDs, err := h.userListRepo.ListIDsByMember(authorID)
+	if err != nil {
+		slog.Warn("removeFromUserLists: list lookup failed", "err", err, "author", authorID)
+		return
+	}
+	for _, listID := range listIDs {
+		h.removeBestEffort(ctx, UserListTimelineName(listID), noteID)
+	}
+}

--- a/internal/core/timeline/fanout_hook_test.go
+++ b/internal/core/timeline/fanout_hook_test.go
@@ -418,3 +418,165 @@ func TestFanoutHook_FanoutToUserLists_LookupError(t *testing.T) {
 	require.NoError(t, err)
 	assert.Empty(t, out)
 }
+
+// --- OnNoteDeleted (#379) ---
+
+func TestFanoutHook_OnNoteDeleted_Nil(t *testing.T) {
+	h, _, _ := newTestHook(t)
+	h.OnNoteDeleted(nil, &model.User{ID: "u"})
+	h.OnNoteDeleted(&model.Note{ID: "n"}, nil)
+}
+
+func TestFanoutHook_OnNoteDeleted_PurgesAllTimelines(t *testing.T) {
+	h, fanout, following := newTestHook(t)
+	ctx := context.Background()
+	following.Followings["f1"] = &model.Following{ID: "f1", FollowerID: "follower1", FolloweeID: "author"}
+	following.Followings["f2"] = &model.Following{ID: "f2", FollowerID: "follower2", FolloweeID: "author"}
+
+	noteID := idGen.Generate(time.Now())
+	n := &model.Note{ID: noteID, UserID: "author", Visibility: model.NoteVisibilityPublic}
+	author := &model.User{ID: "author"}
+	h.OnNoteCreated(n, author)
+
+	// 配信された 5 つの timeline すべてに入っていることを前提として確認
+	for _, name := range []Name{
+		HomeTimelineName("author"),
+		HomeTimelineName("follower1"),
+		HomeTimelineName("follower2"),
+		UserTimelineName("author"),
+		LocalTimeline,
+		GlobalTimeline,
+	} {
+		out, err := fanout.Get(ctx, name, "", "", 10)
+		require.NoError(t, err)
+		assert.Equal(t, []string{noteID}, out, "precondition: %q should contain note", name)
+	}
+
+	// 削除すると全部から消える
+	h.OnNoteDeleted(n, author)
+	for _, name := range []Name{
+		HomeTimelineName("author"),
+		HomeTimelineName("follower1"),
+		HomeTimelineName("follower2"),
+		UserTimelineName("author"),
+		LocalTimeline,
+		GlobalTimeline,
+	} {
+		out, err := fanout.Get(ctx, name, "", "", 10)
+		require.NoError(t, err)
+		assert.Empty(t, out, "after delete: %q should be empty", name)
+	}
+}
+
+func TestFanoutHook_OnNoteDeleted_RemoteAuthorSkipsLocal(t *testing.T) {
+	h, fanout, _ := newTestHook(t)
+	ctx := context.Background()
+
+	host := "remote.example"
+	noteID := idGen.Generate(time.Now())
+	n := &model.Note{ID: noteID, UserID: "ra", UserHost: &host, Visibility: model.NoteVisibilityPublic}
+	author := &model.User{ID: "ra", Host: &host}
+
+	// LocalTimeline に直接 LPUSH しておいて、OnNoteDeleted で消えないことを確認
+	require.NoError(t, fanout.client.LPush(ctx, fanout.key(LocalTimeline), noteID).Err())
+
+	h.OnNoteDeleted(n, author)
+
+	out, err := fanout.Get(ctx, LocalTimeline, "", "", 10)
+	require.NoError(t, err)
+	assert.Equal(t, []string{noteID}, out, "remote author の delete は LocalTimeline を触らない")
+}
+
+func TestFanoutHook_OnNoteDeleted_FollowersListError(t *testing.T) {
+	testRedis.FlushAll(context.Background())
+	fanout := NewFanoutTimelineService(testRedis.Client, idGen, "")
+	fanout.randFn = func() float64 { return 1.0 }
+	following := &failingFollowingRepo{MockFollowingRepository: testutil.NewMockFollowingRepository()}
+	h := NewFanoutHook(fanout, following)
+
+	noteID := idGen.Generate(time.Now())
+	n := &model.Note{ID: noteID, UserID: "author", Visibility: model.NoteVisibilityPublic}
+	// エラーがあっても上位に伝搬しない
+	h.OnNoteDeleted(n, &model.User{ID: "author"})
+}
+
+func TestFanoutHook_OnNoteDeleted_FollowersAcrossPages(t *testing.T) {
+	testRedis.FlushAll(context.Background())
+	fanout := NewFanoutTimelineService(testRedis.Client, idGen, "")
+	fanout.randFn = func() float64 { return 1.0 }
+	following := testutil.NewMockFollowingRepository()
+	for i := range 201 {
+		fid := "f-" + idGen.Generate(time.Now().Add(time.Duration(i)*time.Microsecond))
+		following.Followings[fid] = &model.Following{
+			ID:         fid,
+			FollowerID: "follower-" + fid,
+			FolloweeID: "author",
+		}
+	}
+	h := NewFanoutHook(fanout, following)
+
+	noteID := idGen.Generate(time.Now())
+	n := &model.Note{ID: noteID, UserID: "author", Visibility: model.NoteVisibilityPublic}
+	h.OnNoteDeleted(n, &model.User{ID: "author"})
+}
+
+func TestFanoutHook_OnNoteDeleted_RemoveErrorIsLogged(t *testing.T) {
+	following := testutil.NewMockFollowingRepository()
+	fanout := NewFanoutTimelineService(closedClient(t), idGen, "")
+	h := NewFanoutHook(fanout, following)
+	noteID := idGen.Generate(time.Now())
+	h.OnNoteDeleted(
+		&model.Note{ID: noteID, UserID: "u", Visibility: model.NoteVisibilityPublic},
+		&model.User{ID: "u"},
+	)
+}
+
+func TestFanoutHook_OnNoteDeleted_SpecifiedSkipsFollowers(t *testing.T) {
+	h, fanout, following := newTestHook(t)
+	ctx := context.Background()
+	following.Followings["f1"] = &model.Following{ID: "f1", FollowerID: "follower1", FolloweeID: "author"}
+
+	noteID := idGen.Generate(time.Now())
+	n := &model.Note{ID: noteID, UserID: "author", Visibility: model.NoteVisibilitySpecified}
+	author := &model.User{ID: "author"}
+
+	// follower の home に直接入れておいて、specified delete では消されないことを確認
+	require.NoError(t, fanout.client.LPush(ctx, fanout.key(HomeTimelineName("follower1")), noteID).Err())
+
+	h.OnNoteDeleted(n, author)
+
+	out, err := fanout.Get(ctx, HomeTimelineName("follower1"), "", "", 10)
+	require.NoError(t, err)
+	assert.Equal(t, []string{noteID}, out, "specified delete は follower home を触らない")
+}
+
+func TestFanoutHook_OnNoteDeleted_UserListPurge(t *testing.T) {
+	h, fanout, _ := newTestHook(t)
+	ctx := context.Background()
+
+	lookup := &stubUserListLookup{memberToLists: map[string][]string{
+		"author": {"list1", "list2"},
+	}}
+	h.SetUserListRepo(lookup)
+
+	noteID := idGen.Generate(time.Now())
+	n := &model.Note{ID: noteID, UserID: "author", Visibility: model.NoteVisibilityPublic}
+	author := &model.User{ID: "author"}
+	h.OnNoteCreated(n, author)
+	h.OnNoteDeleted(n, author)
+
+	for _, listID := range []string{"list1", "list2"} {
+		out, err := fanout.Get(ctx, UserListTimelineName(listID), "", "", 10)
+		require.NoError(t, err)
+		assert.Empty(t, out, "userListTimeline:%s should be purged", listID)
+	}
+}
+
+func TestFanoutHook_OnNoteDeleted_UserListLookupError(t *testing.T) {
+	h, _, _ := newTestHook(t)
+	h.SetUserListRepo(&failingUserListLookup{})
+
+	noteID := idGen.Generate(time.Now())
+	n := &model.Note{ID: noteID, UserID: "author", Visibility: model.NoteVisibilityPublic}
+	h.OnNoteDeleted(n, &model.User{ID: "author"})
+}

--- a/internal/core/timeline/fanout_timeline_service.go
+++ b/internal/core/timeline/fanout_timeline_service.go
@@ -171,6 +171,17 @@ func (s *FanoutTimelineService) Purge(ctx context.Context, name Name) error {
 	return s.client.Del(ctx, s.key(name)).Err()
 }
 
+// Remove drops every occurrence of noteID from the named timeline list (#379)。
+// Misskey TS の `RedisTimelineService.removeFromTimeline` 相当。Delete activity
+// 受信時 / ローカル削除時に各 fanout 先 (home/local/global/user/userList) から
+// 該当 ID を消すために使う。
+//
+// LREM count=0 は全 occurrence を削除する。空 list / 不在 ID でもエラーには
+// ならず削除件数 0 が返るだけなので呼び出し側で気にする必要はない。
+func (s *FanoutTimelineService) Remove(ctx context.Context, name Name, noteID string) error {
+	return s.client.LRem(ctx, s.key(name), 0, noteID).Err()
+}
+
 // filterAndSort applies the since/until filter to a slice of IDs and returns
 // them sorted in id-descending order, capped to limit if positive.
 func filterAndSort(ids []string, untilID, sinceID string, limit int) []string {

--- a/internal/core/timeline/fanout_timeline_service_test.go
+++ b/internal/core/timeline/fanout_timeline_service_test.go
@@ -241,6 +241,10 @@ func TestFanoutTimelineService_RedisErrors(t *testing.T) {
 	// Purge fails on Del
 	err = svc.Purge(ctx, LocalTimeline)
 	assert.Error(t, err)
+
+	// Remove fails on LRem (#379)
+	err = svc.Remove(ctx, LocalTimeline, noteID)
+	assert.Error(t, err)
 }
 
 // TestFanoutTimelineService_KeyPrefix は #362 drop-in 互換の回帰テスト。
@@ -335,6 +339,35 @@ func TestFanoutTimelineService_Purge(t *testing.T) {
 	out, err := svc.Get(ctx, LocalTimeline, "", "", 10)
 	require.NoError(t, err)
 	assert.Empty(t, out)
+}
+
+// TestFanoutTimelineService_Remove は #379 の delete propagation 用 LREM。
+// 該当 ID だけを消し、他の ID は残ること、不在 ID 渡しでもエラーにならない
+// ことを確認する。
+func TestFanoutTimelineService_Remove(t *testing.T) {
+	svc := newTestService(t)
+	ctx := context.Background()
+
+	id1 := idGen.Generate(time.Now().Add(-2 * time.Minute))
+	id2 := idGen.Generate(time.Now().Add(-1 * time.Minute))
+	id3 := idGen.Generate(time.Now())
+
+	require.NoError(t, svc.Push(ctx, LocalTimeline, id1, 100))
+	require.NoError(t, svc.Push(ctx, LocalTimeline, id2, 100))
+	require.NoError(t, svc.Push(ctx, LocalTimeline, id3, 100))
+
+	// 中間の id2 だけ削除
+	require.NoError(t, svc.Remove(ctx, LocalTimeline, id2))
+
+	out, err := svc.Get(ctx, LocalTimeline, "", "", 10)
+	require.NoError(t, err)
+	assert.Equal(t, []string{id3, id1}, out)
+
+	// 不在 ID の削除は no-op (エラーにならない)
+	require.NoError(t, svc.Remove(ctx, LocalTimeline, "nonexistent"))
+
+	// 空 list への Remove も no-op
+	require.NoError(t, svc.Remove(ctx, GlobalTimeline, id1))
 }
 
 // TestFanoutTimelineService_PushOldNoteCorruptedTail_isFollowedByErr asserts

--- a/internal/server/router.go
+++ b/internal/server/router.go
@@ -199,6 +199,9 @@ func (s *Server) setupRoutes() {
 	timelineFanoutHook.SetCacheLimitsProvider(coretimeline.NewMetaRepoCacheLimits(metaRepo))
 	timelineFanoutHook.SetUserListRepo(userListRepo)
 	noteCreateService.SetFanoutHook(timelineFanoutHook)
+	// #379: Delete (inbound activity / local notes/delete どちらも) で
+	// Redis fanout timelines から note ID を LREM するための hook。
+	noteDeleteService.SetTimelineHook(timelineFanoutHook)
 
 	// Channels (Phase 4.2)
 	channelService := corechannel.NewService(channelRepo, channelFollowingRepo, noteRepo, idGen)


### PR DESCRIPTION
## Summary

drop-in 切替後に「削除されたはずの note がタイムラインに残る」 (#379) の修正。
inbound Delete activity / ローカル `notes/delete` どちらの経路でも、Redis 上の fanout timeline list から note ID を消す処理が無く、DB だけ消えて Redis に幽霊 ID が残り続けていた。

## 主な変更点

- `FanoutTimelineService.Remove(name, noteID)` を追加。Redis LREM で個別削除 (TS の `RedisTimelineService.removeFromTimeline` 相当)。`Purge` は list 全削除なので使えない。
- `FanoutHook.OnNoteDeleted(note, author)` を追加。`OnNoteCreated` と対称に home (本人 + フォロワー) / user / local / global / userList の各 timeline list から note ID を LREM する。失敗はベストエフォート。
- `note.DeleteService` に `DeleteTimelineHook` interface と `SetTimelineHook` を追加し、Delete 完了後に呼ぶ。inbound Delete 経路 (federation processor → `noteDeleteSvc.Delete`) でも同じ hook が走る。
- `router.go`: `noteDeleteService.SetTimelineHook(timelineFanoutHook)` で配線。

## テスト

- `FanoutTimelineService_Remove` (基本 / 不在 ID no-op / 空 list no-op / Redis エラー)
- `FanoutHook_OnNoteDeleted` (nil 入力 / 全 timeline 掃除 / remote author は LocalTimeline 触らない / followers エラー / page 越え / Redis エラー / specified visibility は follower 触らない / userList 掃除 / userList エラー)
- `DeleteService_TimelineHookInvoked` (hook 配線確認)
- 新規コードは 100% カバー。federation / timeline / note 全 package テスト pass。

実 e2e (drop-in: TS-A → mk-A 切替後の bob delete → alice TL から消える) は nightly drop-in workflow (#374) でカバーされる。

## Closes

Closes #379

## 関連

- 似た federation deliver gap: #369 (reply / reaction)
- 親: #364 (Phase 13 drop-in e2e)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/shiroha-a/mk/pull/407" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
