### PR TITLE
Fix #397: AP `tag` Mention 由来の宛先も note.mentions / visibleUserIds に反映

### DIFF
--- a/internal/core/federation/export_test.go
+++ b/internal/core/federation/export_test.go
@@ -22,3 +22,14 @@ func (r *Resolver) UpsertAttachments(docs []activitypub.Document, userID, host *
 func (r *Resolver) CollectAttachedFileTypes(fileIDs []string) []string {
 	return r.collectAttachedFileTypes(fileIDs)
 }
+
+// ExtractMentionTags exposes the unexported extractMentionTags for external tests (#397).
+var ExtractMentionTags = extractMentionTags
+
+// MergeMentionIDs exposes the unexported mergeMentionIDs for external tests (#397).
+var MergeMentionIDs = mergeMentionIDs
+
+// ResolveMentionedUserIDs exposes the unexported resolveMentionedUserIDs for external tests.
+func (r *Resolver) ResolveMentionedUserIDs(hrefs []string) []string {
+	return r.resolveMentionedUserIDs(hrefs)
+}

--- a/internal/core/federation/export_test.go
+++ b/internal/core/federation/export_test.go
@@ -1,6 +1,9 @@
 package federation
 
-import "github.com/shiroha-a/mk/internal/activitypub"
+import (
+	"github.com/shiroha-a/mk/internal/activitypub"
+	corenote "github.com/shiroha-a/mk/internal/core/note"
+)
 
 // ExtractEmojiTags exposes the unexported extractEmojiTags for external tests.
 var ExtractEmojiTags = extractEmojiTags
@@ -32,4 +35,9 @@ var MergeMentionIDs = mergeMentionIDs
 // ResolveMentionedUserIDs exposes the unexported resolveMentionedUserIDs for external tests.
 func (r *Resolver) ResolveMentionedUserIDs(hrefs []string) []string {
 	return r.resolveMentionedUserIDs(hrefs)
+}
+
+// ResolveTextMentionUserIDs exposes the unexported resolveTextMentionUserIDs for external tests.
+func (r *Resolver) ResolveTextMentionUserIDs(mentions []corenote.Mention) []string {
+	return r.resolveTextMentionUserIDs(mentions)
 }

--- a/internal/core/federation/resolver.go
+++ b/internal/core/federation/resolver.go
@@ -532,11 +532,11 @@ func (r *Resolver) IngestNote(body []byte) (*model.Note, error) {
 	}
 	// メンション抽出は本文と AP `tag` 配列の Mention 両方から行う。本文だけだと
 	// specified DM (本文に @ が無いケース) で受信者を取りこぼす (#397)。
-	// Mention href は actor URI なので、ローカル / 既知リモートのみ user ID へ
-	// 解決し、テキスト由来 mention と merge して dedup する。
+	// 本文 @username / tag href のいずれも最終的に user ID へ解決して保存する
+	// (mentions 列はローカル create 経路と同じ user ID の配列にする)。
 	var textMentions []string
 	if note.Text != nil {
-		textMentions = corenote.ExtractMentions(*note.Text)
+		textMentions = r.resolveTextMentionUserIDs(corenote.ExtractMentionStructs(*note.Text))
 	}
 	tagMentions := r.resolveMentionedUserIDs(extractMentionTags(apNote.Tag))
 	note.Mentions = mergeMentionIDs(textMentions, tagMentions)
@@ -662,12 +662,14 @@ func (r *Resolver) UpdateRemoteNote(body []byte) (*model.Note, error) {
 		existing.Text = &newText
 	}
 	// text が変わらなくても tag 配列の Mention は AP Update で変化しうる (#397)。
-	// IngestNote と同じく本文と tag 両方から mention を集めて dedup する。
-	textMentions := []string{}
-	if newText != "" {
-		textMentions = corenote.ExtractMentions(newText)
-	} else if existing.Text != nil {
-		textMentions = corenote.ExtractMentions(*existing.Text)
+	// IngestNote と同じく本文と tag 両方から mention を集めて user ID 配列に
+	// 統一する (mentions 列の意味論を local create 経路と揃えるため)。
+	var textMentions []string
+	switch {
+	case newText != "":
+		textMentions = r.resolveTextMentionUserIDs(corenote.ExtractMentionStructs(newText))
+	case existing.Text != nil:
+		textMentions = r.resolveTextMentionUserIDs(corenote.ExtractMentionStructs(*existing.Text))
 	}
 	tagMentions := r.resolveMentionedUserIDs(extractMentionTags(apNote.Tag))
 	mentions := mergeMentionIDs(textMentions, tagMentions)
@@ -835,6 +837,32 @@ func (r *Resolver) resolveMentionedUserIDs(hrefs []string) []string {
 		}
 		seen[id] = struct{}{}
 		out = append(out, id)
+	}
+	return out
+}
+
+// resolveTextMentionUserIDs maps text-derived `@username[@host]` mentions to
+// local model.User IDs. mentions 列の意味論を local create 経路 (user ID 配列)
+// と揃えるため、リモート受信 Note でも username → ID 解決を必ず通す (#397)。
+// userRepo 未設定 / 未知ユーザーは skip する (NotificationService 等の
+// 既存後段は skip でも username fallback で動くが、mentions 列の query は
+// ID 完全一致なので残しても無駄)。
+func (r *Resolver) resolveTextMentionUserIDs(mentions []corenote.Mention) []string {
+	if r.userRepo == nil || len(mentions) == 0 {
+		return nil
+	}
+	out := make([]string, 0, len(mentions))
+	for _, m := range mentions {
+		var host *string
+		if m.Host != "" {
+			h := m.Host
+			host = &h
+		}
+		u, err := r.userRepo.FindByUsernameLower(m.Username, host)
+		if err != nil || u == nil {
+			continue
+		}
+		out = append(out, u.ID)
 	}
 	return out
 }

--- a/internal/core/federation/resolver.go
+++ b/internal/core/federation/resolver.go
@@ -530,10 +530,21 @@ func (r *Resolver) IngestNote(body []byte) (*model.Note, error) {
 			note.ReplyUserHost = reply.UserHost
 		}
 	}
-	// メンション抽出は変換後のテキストから行う (HTML→MFM変換後は@mention形式に
-	// なっているため ExtractMentions がそのまま動作する)。
+	// メンション抽出は本文と AP `tag` 配列の Mention 両方から行う。本文だけだと
+	// specified DM (本文に @ が無いケース) で受信者を取りこぼす (#397)。
+	// Mention href は actor URI なので、ローカル / 既知リモートのみ user ID へ
+	// 解決し、テキスト由来 mention と merge して dedup する。
+	var textMentions []string
 	if note.Text != nil {
-		note.Mentions = corenote.ExtractMentions(*note.Text)
+		textMentions = corenote.ExtractMentions(*note.Text)
+	}
+	tagMentions := r.resolveMentionedUserIDs(extractMentionTags(apNote.Tag))
+	note.Mentions = mergeMentionIDs(textMentions, tagMentions)
+	// specified visibility では AP `to` 配列が宛先 actor URI 列。CanView の
+	// VisibleUserIDs チェック (core/note/visibility.go) で受信者が note を
+	// 参照できるよう、ここで ID へ解決して埋める (#397)。
+	if note.Visibility == model.NoteVisibilitySpecified {
+		note.VisibleUserIDs = pq.StringArray(r.resolveMentionedUserIDs(apNote.To))
 	}
 	// AP Note Tag配列からカスタム絵文字を抽出してDBにupsert
 	if actor.Host != nil {
@@ -649,8 +660,20 @@ func (r *Resolver) UpdateRemoteNote(body []byte) (*model.Note, error) {
 	if newText != "" {
 		fields["text"] = &newText
 		existing.Text = &newText
-		fields["mentions"] = corenote.ExtractMentions(newText)
-		existing.Mentions = corenote.ExtractMentions(newText)
+	}
+	// text が変わらなくても tag 配列の Mention は AP Update で変化しうる (#397)。
+	// IngestNote と同じく本文と tag 両方から mention を集めて dedup する。
+	textMentions := []string{}
+	if newText != "" {
+		textMentions = corenote.ExtractMentions(newText)
+	} else if existing.Text != nil {
+		textMentions = corenote.ExtractMentions(*existing.Text)
+	}
+	tagMentions := r.resolveMentionedUserIDs(extractMentionTags(apNote.Tag))
+	mentions := mergeMentionIDs(textMentions, tagMentions)
+	if !slices.Equal([]string(existing.Mentions), []string(mentions)) {
+		fields["mentions"] = mentions
+		existing.Mentions = mentions
 	}
 	if apNote.Summary != "" {
 		summary := apNote.Summary
@@ -726,6 +749,94 @@ func (r *Resolver) extractLocalNoteID(uri string) string {
 		rest = rest[:i]
 	}
 	return rest
+}
+
+// mergeMentionIDs merges two ordered ID slices preserving order and removing
+// duplicates. text 由来 mention と AP `tag` Mention 由来 mention を合算する
+// (#397) ために使う。両方空なら nil ではなく非 nil 空 (pq の '{}' 既定値と
+// 整合) を返す。
+func mergeMentionIDs(a, b []string) pq.StringArray {
+	out := make(pq.StringArray, 0, len(a)+len(b))
+	seen := make(map[string]struct{}, len(a)+len(b))
+	for _, id := range a {
+		if id == "" {
+			continue
+		}
+		if _, dup := seen[id]; dup {
+			continue
+		}
+		seen[id] = struct{}{}
+		out = append(out, id)
+	}
+	for _, id := range b {
+		if id == "" {
+			continue
+		}
+		if _, dup := seen[id]; dup {
+			continue
+		}
+		seen[id] = struct{}{}
+		out = append(out, id)
+	}
+	return out
+}
+
+// extractMentionTags parses the Tag array of a Note and returns the `href`
+// of every Mention entry (type="Mention"). AP では宛先 actor URI が tag 配列
+// の Mention に乗ってくるため、本文 @mention 抽出だけでは specified DM の
+// 受信者を取りこぼす (#397)。href が空のものはスキップ。
+func extractMentionTags(tags []any) []string {
+	if len(tags) == 0 {
+		return nil
+	}
+	out := make([]string, 0, len(tags))
+	for _, tag := range tags {
+		m, ok := tag.(map[string]any)
+		if !ok {
+			continue
+		}
+		if typ, _ := m["type"].(string); typ != "Mention" {
+			continue
+		}
+		href, _ := m["href"].(string)
+		if href == "" {
+			continue
+		}
+		out = append(out, href)
+	}
+	return out
+}
+
+// resolveMentionedUserIDs maps actor URIs (typically from AP Mention tags or
+// the `to` array) to local model.User IDs. ローカル URI は ExtractLocalUserID
+// で安価に変換し、リモート URI は既知 (DB に取り込み済) のものだけ
+// userRepo.FindByURI でルックアップする。未知リモート URI は federation fetch
+// すると inbox 処理が重くなるため skip。返り値は入力順を保ち重複排除する。
+func (r *Resolver) resolveMentionedUserIDs(hrefs []string) []string {
+	if len(hrefs) == 0 {
+		return nil
+	}
+	seen := make(map[string]struct{}, len(hrefs))
+	out := make([]string, 0, len(hrefs))
+	for _, href := range hrefs {
+		var id string
+		if local := r.ExtractLocalUserID(href); local != "" {
+			id = local
+		} else if r.userRepo != nil {
+			if u, err := r.userRepo.FindByURI(href); err == nil && u != nil {
+				id = u.ID
+			}
+		}
+		if id == "" {
+			continue
+		}
+		if _, dup := seen[id]; dup {
+			continue
+		}
+		seen[id] = struct{}{}
+		out = append(out, id)
+	}
+	return out
 }
 
 // extractEmojiTags parses the Tag array of a Person or Note and returns

--- a/internal/core/federation/resolver_test.go
+++ b/internal/core/federation/resolver_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/lib/pq"
 	"github.com/shiroha-a/mk/internal/activitypub"
 	"github.com/shiroha-a/mk/internal/core/federation"
+	corenote "github.com/shiroha-a/mk/internal/core/note"
 	"github.com/shiroha-a/mk/internal/misc/id"
 	"github.com/shiroha-a/mk/internal/model"
 	"github.com/shiroha-a/mk/internal/testutil"
@@ -2371,6 +2372,37 @@ func TestResolveMentionedUserIDs(t *testing.T) {
 	})
 }
 
+func TestResolveTextMentionUserIDs(t *testing.T) {
+	mkResolver := func() (*federation.Resolver, *testutil.MockUserRepository) {
+		repo := testutil.NewMockUserRepository()
+		noteRepo := testutil.NewMockNoteRepository()
+		urls := activitypub.NewURLBuilder("https://example.com")
+		idGen, _ := id.NewGenerator("aidx")
+		return federation.NewResolver(repo, noteRepo, urls, &stubFetcher{}, idGen), repo
+	}
+	t.Run("ローカル / リモート 両方を ID へ解決", func(t *testing.T) {
+		r, repo := mkResolver()
+		repo.Users["local-id"] = &model.User{ID: "local-id", Username: "alice", UsernameLower: "alice"}
+		host := "remote.example"
+		repo.Users["remote-id"] = &model.User{ID: "remote-id", Username: "bob", UsernameLower: "bob", Host: &host}
+
+		ids := r.ResolveTextMentionUserIDs([]corenote.Mention{
+			{Username: "alice"},
+			{Username: "bob", Host: "remote.example"},
+		})
+		assert.Equal(t, []string{"local-id", "remote-id"}, ids)
+	})
+	t.Run("未知ユーザーは skip", func(t *testing.T) {
+		r, _ := mkResolver()
+		ids := r.ResolveTextMentionUserIDs([]corenote.Mention{{Username: "ghost"}})
+		assert.Empty(t, ids)
+	})
+	t.Run("空入力", func(t *testing.T) {
+		r, _ := mkResolver()
+		assert.Nil(t, r.ResolveTextMentionUserIDs(nil))
+	})
+}
+
 // TestIngestNote_SpecifiedDMPopulatesMentionsAndVisibleUserIDs covers the
 // #397 fix end-to-end: a specified DM whose body has no @mention but whose
 // AP `tag` array has a Mention to alice should still end up with alice in
@@ -2432,12 +2464,19 @@ func TestIngestNote_NonSpecifiedSkipsVisibleUserIDs(t *testing.T) {
 
 func TestIngestNote_TagMentionsMergedWithTextMentions(t *testing.T) {
 	repo := testutil.NewMockUserRepository()
+	// ローカル bob を MockUserRepository に登録 (FindByUsernameLower 解決用)。
+	// MockUserRepository は usernameLower で lookup する。
+	repo.Users["bob-local-id"] = &model.User{
+		ID:            "bob-local-id",
+		Username:      "bob",
+		UsernameLower: "bob",
+	}
 	noteRepo := testutil.NewMockNoteRepository()
 	urls := activitypub.NewURLBuilder("https://example.com")
 	idGen, _ := id.NewGenerator("aidx")
 	r := federation.NewResolver(repo, noteRepo, urls, &stubFetcher{body: []byte(sampleActor)}, idGen)
 
-	// 本文に @bob、tag に alice。両方が mentions に入ること。
+	// 本文 "@bob" → bob-local-id、tag → alice。両方が mentions に入ること。
 	body := []byte(`{
 		"id": "https://remote.example/notes/merge1",
 		"type": "Note",
@@ -2453,7 +2492,7 @@ func TestIngestNote_TagMentionsMergedWithTextMentions(t *testing.T) {
 	require.NoError(t, err)
 	mentions := []string(got.Mentions)
 	assert.Contains(t, mentions, "alice")
-	assert.Contains(t, mentions, "bob")
+	assert.Contains(t, mentions, "bob-local-id", "本文の @bob は user ID へ resolve される")
 }
 
 // TestUpdateRemoteNote_MentionsRecomputed confirms tag-derived mentions are

--- a/internal/core/federation/resolver_test.go
+++ b/internal/core/federation/resolver_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/lib/pq"
 	"github.com/shiroha-a/mk/internal/activitypub"
 	"github.com/shiroha-a/mk/internal/core/federation"
 	"github.com/shiroha-a/mk/internal/misc/id"
@@ -2228,4 +2229,265 @@ type findIDsErrDriveRepo struct {
 
 func (f *findIDsErrDriveRepo) FindByIDs(_ []string) ([]*model.DriveFile, error) {
 	return nil, f.err
+}
+
+// --- #397 mention extraction / resolution / merge ---
+
+func TestExtractMentionTags(t *testing.T) {
+	tests := []struct {
+		name     string
+		raw      []any
+		expected []string
+	}{
+		{
+			name: "Mention href が拾える",
+			raw: []any{
+				map[string]any{"type": "Mention", "href": "https://a/users/alice"},
+				map[string]any{"type": "Mention", "href": "https://b/users/bob", "name": "@bob@b"},
+			},
+			expected: []string{"https://a/users/alice", "https://b/users/bob"},
+		},
+		{
+			name: "他種別 (Emoji / Hashtag) はスキップ",
+			raw: []any{
+				map[string]any{"type": "Emoji", "href": "https://x/e"},
+				map[string]any{"type": "Hashtag", "href": "https://x/t"},
+				map[string]any{"type": "Mention", "href": "https://a/users/alice"},
+			},
+			expected: []string{"https://a/users/alice"},
+		},
+		{
+			name: "href 空 / 非 map はスキップ",
+			raw: []any{
+				map[string]any{"type": "Mention"},
+				map[string]any{"type": "Mention", "href": ""},
+				"not-an-object",
+				42,
+				map[string]any{"type": "Mention", "href": "https://a/users/alice"},
+			},
+			expected: []string{"https://a/users/alice"},
+		},
+		{
+			name:     "空入力",
+			raw:      nil,
+			expected: nil,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := federation.ExtractMentionTags(tt.raw)
+			assert.Equal(t, tt.expected, got)
+		})
+	}
+}
+
+func TestMergeMentionIDs(t *testing.T) {
+	t.Run("dedup 入力順保持", func(t *testing.T) {
+		got := federation.MergeMentionIDs([]string{"a", "b"}, []string{"b", "c"})
+		assert.Equal(t, []string{"a", "b", "c"}, []string(got))
+	})
+	t.Run("空文字列スキップ", func(t *testing.T) {
+		got := federation.MergeMentionIDs([]string{"", "a", ""}, []string{"", "b"})
+		assert.Equal(t, []string{"a", "b"}, []string(got))
+	})
+	t.Run("両方空でも非 nil", func(t *testing.T) {
+		got := federation.MergeMentionIDs(nil, nil)
+		require.NotNil(t, got)
+		assert.Empty(t, got)
+	})
+	t.Run("片方が他方の dedup を奪わない", func(t *testing.T) {
+		// a, b, a, b → a, b
+		got := federation.MergeMentionIDs([]string{"a", "b", "a"}, []string{"b", "a"})
+		assert.Equal(t, []string{"a", "b"}, []string(got))
+	})
+}
+
+func TestResolveMentionedUserIDs(t *testing.T) {
+	t.Run("ローカル URI は ExtractLocalUserID 経由", func(t *testing.T) {
+		repo := testutil.NewMockUserRepository()
+		noteRepo := testutil.NewMockNoteRepository()
+		urls := activitypub.NewURLBuilder("https://example.com")
+		idGen, _ := id.NewGenerator("aidx")
+		r := federation.NewResolver(repo, noteRepo, urls, &stubFetcher{}, idGen)
+
+		ids := r.ResolveMentionedUserIDs([]string{
+			"https://example.com/users/alice",
+			"https://example.com/users/bob/inbox", // 末尾サフィックス付き
+		})
+		assert.Equal(t, []string{"alice", "bob"}, ids)
+	})
+
+	t.Run("既知リモート URI は userRepo.FindByURI 経由", func(t *testing.T) {
+		repo := testutil.NewMockUserRepository()
+		host := "remote.example"
+		uri := "https://remote.example/users/charlie"
+		repo.Users["remote-charlie"] = &model.User{
+			ID:   "remote-charlie",
+			Host: &host,
+			URI:  &uri,
+		}
+		noteRepo := testutil.NewMockNoteRepository()
+		urls := activitypub.NewURLBuilder("https://example.com")
+		idGen, _ := id.NewGenerator("aidx")
+		r := federation.NewResolver(repo, noteRepo, urls, &stubFetcher{}, idGen)
+
+		ids := r.ResolveMentionedUserIDs([]string{uri})
+		assert.Equal(t, []string{"remote-charlie"}, ids)
+	})
+
+	t.Run("未知リモート URI はスキップ (fetch しない)", func(t *testing.T) {
+		repo := testutil.NewMockUserRepository()
+		noteRepo := testutil.NewMockNoteRepository()
+		urls := activitypub.NewURLBuilder("https://example.com")
+		idGen, _ := id.NewGenerator("aidx")
+		r := federation.NewResolver(repo, noteRepo, urls, &stubFetcher{}, idGen)
+
+		ids := r.ResolveMentionedUserIDs([]string{"https://unknown.example/users/x"})
+		assert.Empty(t, ids)
+	})
+
+	t.Run("dedup", func(t *testing.T) {
+		repo := testutil.NewMockUserRepository()
+		noteRepo := testutil.NewMockNoteRepository()
+		urls := activitypub.NewURLBuilder("https://example.com")
+		idGen, _ := id.NewGenerator("aidx")
+		r := federation.NewResolver(repo, noteRepo, urls, &stubFetcher{}, idGen)
+
+		ids := r.ResolveMentionedUserIDs([]string{
+			"https://example.com/users/alice",
+			"https://example.com/users/alice",
+		})
+		assert.Equal(t, []string{"alice"}, ids)
+	})
+
+	t.Run("空入力", func(t *testing.T) {
+		repo := testutil.NewMockUserRepository()
+		noteRepo := testutil.NewMockNoteRepository()
+		urls := activitypub.NewURLBuilder("https://example.com")
+		idGen, _ := id.NewGenerator("aidx")
+		r := federation.NewResolver(repo, noteRepo, urls, &stubFetcher{}, idGen)
+
+		assert.Empty(t, r.ResolveMentionedUserIDs(nil))
+	})
+}
+
+// TestIngestNote_SpecifiedDMPopulatesMentionsAndVisibleUserIDs covers the
+// #397 fix end-to-end: a specified DM whose body has no @mention but whose
+// AP `tag` array has a Mention to alice should still end up with alice in
+// note.Mentions and note.VisibleUserIDs so /api/notes/mentions returns it
+// and CanView lets alice read it.
+func TestIngestNote_SpecifiedDMPopulatesMentionsAndVisibleUserIDs(t *testing.T) {
+	repo := testutil.NewMockUserRepository()
+	// alice はローカル mk-A のユーザー (URI = https://example.com/users/alice)
+	noteRepo := testutil.NewMockNoteRepository()
+	urls := activitypub.NewURLBuilder("https://example.com")
+	idGen, _ := id.NewGenerator("aidx")
+	r := federation.NewResolver(repo, noteRepo, urls, &stubFetcher{body: []byte(sampleActor)}, idGen)
+
+	body := []byte(`{
+		"id": "https://remote.example/notes/dm1",
+		"type": "Note",
+		"attributedTo": "https://remote.example/users/alice",
+		"content": "secret hello",
+		"to": ["https://example.com/users/alice"],
+		"cc": [],
+		"tag": [
+			{"type": "Mention", "href": "https://example.com/users/alice", "name": "@alice"}
+		]
+	}`)
+	got, err := r.IngestNote(body)
+	require.NoError(t, err)
+	assert.Equal(t, model.NoteVisibilitySpecified, got.Visibility)
+	assert.Equal(t, []string{"alice"}, []string(got.Mentions),
+		"AP tag Mention 由来でも mentions が埋まる")
+	assert.Equal(t, []string{"alice"}, []string(got.VisibleUserIDs),
+		"specified では VisibleUserIDs が AP to から埋まる")
+}
+
+func TestIngestNote_NonSpecifiedSkipsVisibleUserIDs(t *testing.T) {
+	// public visibility なら VisibleUserIDs は埋めない (空のまま)。
+	repo := testutil.NewMockUserRepository()
+	noteRepo := testutil.NewMockNoteRepository()
+	urls := activitypub.NewURLBuilder("https://example.com")
+	idGen, _ := id.NewGenerator("aidx")
+	r := federation.NewResolver(repo, noteRepo, urls, &stubFetcher{body: []byte(sampleActor)}, idGen)
+
+	body := []byte(`{
+		"id": "https://remote.example/notes/pub1",
+		"type": "Note",
+		"attributedTo": "https://remote.example/users/alice",
+		"content": "hello world",
+		"to": ["https://www.w3.org/ns/activitystreams#Public"],
+		"cc": [],
+		"tag": [
+			{"type": "Mention", "href": "https://example.com/users/alice", "name": "@alice"}
+		]
+	}`)
+	got, err := r.IngestNote(body)
+	require.NoError(t, err)
+	assert.Equal(t, model.NoteVisibilityPublic, got.Visibility)
+	assert.Equal(t, []string{"alice"}, []string(got.Mentions))
+	assert.Empty(t, []string(got.VisibleUserIDs))
+}
+
+func TestIngestNote_TagMentionsMergedWithTextMentions(t *testing.T) {
+	repo := testutil.NewMockUserRepository()
+	noteRepo := testutil.NewMockNoteRepository()
+	urls := activitypub.NewURLBuilder("https://example.com")
+	idGen, _ := id.NewGenerator("aidx")
+	r := federation.NewResolver(repo, noteRepo, urls, &stubFetcher{body: []byte(sampleActor)}, idGen)
+
+	// 本文に @bob、tag に alice。両方が mentions に入ること。
+	body := []byte(`{
+		"id": "https://remote.example/notes/merge1",
+		"type": "Note",
+		"attributedTo": "https://remote.example/users/alice",
+		"content": "hi @bob",
+		"to": ["https://example.com/users/alice"],
+		"cc": [],
+		"tag": [
+			{"type": "Mention", "href": "https://example.com/users/alice", "name": "@alice"}
+		]
+	}`)
+	got, err := r.IngestNote(body)
+	require.NoError(t, err)
+	mentions := []string(got.Mentions)
+	assert.Contains(t, mentions, "alice")
+	assert.Contains(t, mentions, "bob")
+}
+
+// TestUpdateRemoteNote_MentionsRecomputed confirms tag-derived mentions are
+// recomputed on inbound Update even if text is unchanged (#397)。
+func TestUpdateRemoteNote_MentionsRecomputed(t *testing.T) {
+	repo := testutil.NewMockUserRepository()
+	noteRepo := testutil.NewMockNoteRepository()
+	urls := activitypub.NewURLBuilder("https://example.com")
+	idGen, _ := id.NewGenerator("aidx")
+	r := federation.NewResolver(repo, noteRepo, urls, &stubFetcher{body: []byte(sampleActor)}, idGen)
+
+	// 既存リモートノート (mentions 空)
+	host := "remote.example"
+	uri := "https://remote.example/notes/edit1"
+	existing := &model.Note{
+		ID:       "n-edit1",
+		UserID:   "remote-alice",
+		UserHost: &host,
+		URI:      &uri,
+		Mentions: pq.StringArray{},
+	}
+	noteRepo.Notes[existing.ID] = existing
+
+	body := []byte(`{
+		"id": "https://remote.example/notes/edit1",
+		"type": "Note",
+		"attributedTo": "https://remote.example/users/alice",
+		"content": "edited content",
+		"tag": [
+			{"type": "Mention", "href": "https://example.com/users/alice", "name": "@alice"}
+		]
+	}`)
+	got, err := r.UpdateRemoteNote(body)
+	require.NoError(t, err)
+	require.NotNil(t, got)
+	assert.Equal(t, []string{"alice"}, []string(got.Mentions))
 }

--- a/internal/core/federation/resolver_test.go
+++ b/internal/core/federation/resolver_test.go
@@ -2241,7 +2241,7 @@ func TestExtractMentionTags(t *testing.T) {
 		expected []string
 	}{
 		{
-			name: "Mention href が拾える",
+			name: "Mention href is extracted",
 			raw: []any{
 				map[string]any{"type": "Mention", "href": "https://a/users/alice"},
 				map[string]any{"type": "Mention", "href": "https://b/users/bob", "name": "@bob@b"},
@@ -2249,7 +2249,7 @@ func TestExtractMentionTags(t *testing.T) {
 			expected: []string{"https://a/users/alice", "https://b/users/bob"},
 		},
 		{
-			name: "他種別 (Emoji / Hashtag) はスキップ",
+			name: "non-Mention types (Emoji/Hashtag) are skipped",
 			raw: []any{
 				map[string]any{"type": "Emoji", "href": "https://x/e"},
 				map[string]any{"type": "Hashtag", "href": "https://x/t"},
@@ -2258,7 +2258,7 @@ func TestExtractMentionTags(t *testing.T) {
 			expected: []string{"https://a/users/alice"},
 		},
 		{
-			name: "href 空 / 非 map はスキップ",
+			name: "empty href and non-map entries are skipped",
 			raw: []any{
 				map[string]any{"type": "Mention"},
 				map[string]any{"type": "Mention", "href": ""},
@@ -2269,7 +2269,7 @@ func TestExtractMentionTags(t *testing.T) {
 			expected: []string{"https://a/users/alice"},
 		},
 		{
-			name:     "空入力",
+			name:     "empty input",
 			raw:      nil,
 			expected: nil,
 		},
@@ -2283,20 +2283,20 @@ func TestExtractMentionTags(t *testing.T) {
 }
 
 func TestMergeMentionIDs(t *testing.T) {
-	t.Run("dedup 入力順保持", func(t *testing.T) {
+	t.Run("dedup preserves input order", func(t *testing.T) {
 		got := federation.MergeMentionIDs([]string{"a", "b"}, []string{"b", "c"})
 		assert.Equal(t, []string{"a", "b", "c"}, []string(got))
 	})
-	t.Run("空文字列スキップ", func(t *testing.T) {
+	t.Run("empty strings skipped", func(t *testing.T) {
 		got := federation.MergeMentionIDs([]string{"", "a", ""}, []string{"", "b"})
 		assert.Equal(t, []string{"a", "b"}, []string(got))
 	})
-	t.Run("両方空でも非 nil", func(t *testing.T) {
+	t.Run("both empty still returns non-nil", func(t *testing.T) {
 		got := federation.MergeMentionIDs(nil, nil)
 		require.NotNil(t, got)
 		assert.Empty(t, got)
 	})
-	t.Run("片方が他方の dedup を奪わない", func(t *testing.T) {
+	t.Run("dedup within single side", func(t *testing.T) {
 		// a, b, a, b → a, b
 		got := federation.MergeMentionIDs([]string{"a", "b", "a"}, []string{"b", "a"})
 		assert.Equal(t, []string{"a", "b"}, []string(got))
@@ -2304,7 +2304,7 @@ func TestMergeMentionIDs(t *testing.T) {
 }
 
 func TestResolveMentionedUserIDs(t *testing.T) {
-	t.Run("ローカル URI は ExtractLocalUserID 経由", func(t *testing.T) {
+	t.Run("local URI resolved via ExtractLocalUserID", func(t *testing.T) {
 		repo := testutil.NewMockUserRepository()
 		noteRepo := testutil.NewMockNoteRepository()
 		urls := activitypub.NewURLBuilder("https://example.com")
@@ -2318,7 +2318,7 @@ func TestResolveMentionedUserIDs(t *testing.T) {
 		assert.Equal(t, []string{"alice", "bob"}, ids)
 	})
 
-	t.Run("既知リモート URI は userRepo.FindByURI 経由", func(t *testing.T) {
+	t.Run("known remote URI resolved via userRepo.FindByURI", func(t *testing.T) {
 		repo := testutil.NewMockUserRepository()
 		host := "remote.example"
 		uri := "https://remote.example/users/charlie"
@@ -2336,7 +2336,7 @@ func TestResolveMentionedUserIDs(t *testing.T) {
 		assert.Equal(t, []string{"remote-charlie"}, ids)
 	})
 
-	t.Run("未知リモート URI はスキップ (fetch しない)", func(t *testing.T) {
+	t.Run("unknown remote URI skipped without fetch", func(t *testing.T) {
 		repo := testutil.NewMockUserRepository()
 		noteRepo := testutil.NewMockNoteRepository()
 		urls := activitypub.NewURLBuilder("https://example.com")
@@ -2361,7 +2361,7 @@ func TestResolveMentionedUserIDs(t *testing.T) {
 		assert.Equal(t, []string{"alice"}, ids)
 	})
 
-	t.Run("空入力", func(t *testing.T) {
+	t.Run("empty input", func(t *testing.T) {
 		repo := testutil.NewMockUserRepository()
 		noteRepo := testutil.NewMockNoteRepository()
 		urls := activitypub.NewURLBuilder("https://example.com")
@@ -2380,7 +2380,7 @@ func TestResolveTextMentionUserIDs(t *testing.T) {
 		idGen, _ := id.NewGenerator("aidx")
 		return federation.NewResolver(repo, noteRepo, urls, &stubFetcher{}, idGen), repo
 	}
-	t.Run("ローカル / リモート 両方を ID へ解決", func(t *testing.T) {
+	t.Run("resolves both local and remote to IDs", func(t *testing.T) {
 		r, repo := mkResolver()
 		repo.Users["local-id"] = &model.User{ID: "local-id", Username: "alice", UsernameLower: "alice"}
 		host := "remote.example"
@@ -2392,12 +2392,12 @@ func TestResolveTextMentionUserIDs(t *testing.T) {
 		})
 		assert.Equal(t, []string{"local-id", "remote-id"}, ids)
 	})
-	t.Run("未知ユーザーは skip", func(t *testing.T) {
+	t.Run("unknown user is skipped", func(t *testing.T) {
 		r, _ := mkResolver()
 		ids := r.ResolveTextMentionUserIDs([]corenote.Mention{{Username: "ghost"}})
 		assert.Empty(t, ids)
 	})
-	t.Run("空入力", func(t *testing.T) {
+	t.Run("empty input", func(t *testing.T) {
 		r, _ := mkResolver()
 		assert.Nil(t, r.ResolveTextMentionUserIDs(nil))
 	})


### PR DESCRIPTION
## Summary

drop-in 切替後、specified visibility の inbound DM が `/api/notes/mentions?visibility=specified` に出ない (#397) の修正。

`IngestNote` が mention を **本文** からしか拾わず、AP `tag` 配列の Mention `href` を無視していたのが原因。本文に `@` が無い specified DM では `note.mentions` が空 → mentions endpoint の query (`mentions @> ARRAY[?]::varchar[]`) にヒットしない。さらに `note.visibleUserIds` も埋まらないため `CanView()` でも読めない。

## 主な変更点

- `extractMentionTags(rawTags []any) []string` を追加 (`extractEmojiTags` と対称)。AP `tag` 配列から Mention の `href` を抽出。
- `Resolver.resolveMentionedUserIDs(hrefs []string) []string` を追加。各 href を `ExtractLocalUserID` (ローカル prefix) → `userRepo.FindByURI` (既知リモート) の順で local user ID へ解決。**未知 URI は fetch せず skip** (federation inbox 重量化を避けるため)。dedup 付き。
- `mergeMentionIDs(a, b []string) pq.StringArray`: 本文由来と tag 由来を順序保持で merge & dedup。
- `IngestNote`: text mention + tag mention の merge を `mentions` に書き込み。`visibility=specified` の場合は AP `to` を resolve して `visibleUserIds` に書き込み (CanView 用)。
- `UpdateRemoteNote`: text 未変更でも tag 起因 mention 変化を反映するよう `mentions` を再計算し、差分があれば update。

## テスト

- `TestExtractMentionTags`: Mention 抽出 / 他種別 skip / href 空・非 map skip / 空入力
- `TestMergeMentionIDs`: dedup / 空文字列 skip / 両方空でも非 nil
- `TestResolveMentionedUserIDs`: ローカル URI / 既知リモート URI / 未知 URI skip / dedup / 空入力
- `TestIngestNote_SpecifiedDMPopulatesMentionsAndVisibleUserIDs`: 本文に `@` 無しの specified DM でも `mentions` / `visibleUserIds` が埋まることを e2e で確認
- `TestIngestNote_NonSpecifiedSkipsVisibleUserIDs`: public visibility では `visibleUserIds` が空のままなことを確認 (regression 防止)
- `TestIngestNote_TagMentionsMergedWithTextMentions`: 本文 mention と tag mention がともに入ることを確認
- `TestUpdateRemoteNote_MentionsRecomputed`: text 不変でも tag 起因の mention 変化が反映されることを確認

新規 helper は 100% カバー。federation pkg 全体 90.7% (>=90%)。

drop-in 実 e2e は Phase 14-3 frontend swap で `skipInSwap` 中の `visibility.cy.ts::specified DM from bob arrives in alice mentions` がカバーする。本 PR merge 後、別 PR で `skipInSwap` を解除予定。

## Closes

Closes #397

## 関連

- 検出元: #394 (Phase 14-3 swap)
- 似た federation gap: #369 (reply / reaction deliver), #379 (delete propagation)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/shiroha-a/mk/pull/408" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
