### PR TITLE
Fix #396: users/lists/push を既 member 時に TS 互換 ALREADY_ADDED で返す

### DIFF
--- a/internal/api/userlists/handler.go
+++ b/internal/api/userlists/handler.go
@@ -1,6 +1,7 @@
 package userlists
 
 import (
+	"errors"
 	"net/http"
 	"time"
 
@@ -86,6 +87,11 @@ func (h *Handler) Push(c echo.Context) error {
 		UserID:     req.UserID,
 	}
 	if err := h.repo.AddMember(m); err != nil {
+		// 既 member への push は TS 互換の ALREADY_ADDED (HTTP 400) で
+		// 返す (#396)。UUID は misskey/.../users/lists/push.ts と一致。
+		if errors.Is(err, repository.ErrUserListDuplicateMember) {
+			return c.JSON(http.StatusBadRequest, apierr.Error("ALREADY_ADDED", "That user has already been added to that list.", "1de7c884-1595-49e9-857e-61f12f4d4fc5"))
+		}
 		return c.JSON(http.StatusInternalServerError, apierr.Error("INTERNAL_ERROR", "Internal error.", "5d37dbcb-891e-41ca-a3d6-e690c97775ac"))
 	}
 	return c.NoContent(http.StatusNoContent)

--- a/internal/api/userlists/handler_test.go
+++ b/internal/api/userlists/handler_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/shiroha-a/mk/internal/api/userlists"
 	"github.com/shiroha-a/mk/internal/misc/id"
 	"github.com/shiroha-a/mk/internal/model"
+	"github.com/shiroha-a/mk/internal/repository"
 	"github.com/shiroha-a/mk/internal/server/middleware"
 	"github.com/shiroha-a/mk/internal/testutil"
 	"github.com/stretchr/testify/assert"
@@ -164,6 +165,29 @@ func TestPush_Error(t *testing.T) {
 	h := userlists.NewHandler(repo, idGen)
 	rec := doPost(h.Push, `{"listId":"l1","userId":"u2"}`, &model.User{ID: "u1"})
 	assert.Equal(t, http.StatusInternalServerError, rec.Code)
+}
+
+// duplicateAddMemberRepo always returns the duplicate sentinel from AddMember
+// so we can verify the handler translates it to ALREADY_ADDED (#396).
+type duplicateAddMemberRepo struct {
+	*testutil.MockUserListRepository
+}
+
+func (d *duplicateAddMemberRepo) AddMember(_ *model.UserListMembership) error {
+	return repository.ErrUserListDuplicateMember
+}
+
+func TestPush_AlreadyAdded(t *testing.T) {
+	repo := &duplicateAddMemberRepo{testutil.NewMockUserListRepository()}
+	repo.Lists["l1"] = &model.UserList{ID: "l1"}
+	idGen, _ := id.NewGenerator("aidx")
+	h := userlists.NewHandler(repo, idGen)
+	rec := doPost(h.Push, `{"listId":"l1","userId":"u2"}`, &model.User{ID: "u1"})
+	assert.Equal(t, http.StatusBadRequest, rec.Code)
+	body := rec.Body.String()
+	assert.Contains(t, body, `"code":"ALREADY_ADDED"`)
+	assert.Contains(t, body, `1de7c884-1595-49e9-857e-61f12f4d4fc5`,
+		"TS 互換 error UUID を返すこと")
 }
 
 type failingRemoveMemberRepo struct {

--- a/internal/repository/user_list.go
+++ b/internal/repository/user_list.go
@@ -1,9 +1,17 @@
 package repository
 
 import (
+	"errors"
+
+	"github.com/jackc/pgx/v5/pgconn"
 	"github.com/shiroha-a/mk/internal/model"
 	"gorm.io/gorm"
 )
+
+// ErrUserListDuplicateMember is returned by UserListRepository.AddMember when
+// the (userListId, userId) pair already exists. Misskey TS の `ALREADY_ADDED`
+// error と対応する (#396)。
+var ErrUserListDuplicateMember = errors.New("user is already a member of this list")
 
 // UserListRepository provides data access for user lists.
 type UserListRepository interface {
@@ -57,7 +65,16 @@ func (r *userListRepository) Delete(id string) error {
 }
 
 func (r *userListRepository) AddMember(m *model.UserListMembership) error {
-	return r.db.Create(m).Error
+	if err := r.db.Create(m).Error; err != nil {
+		// (userListId, userId) 一意制約違反 (23505) を ErrUserListDuplicateMember
+		// に変換して、API 層で TS 互換の ALREADY_ADDED に翻訳する (#396)。
+		var pgErr *pgconn.PgError
+		if errors.As(err, &pgErr) && pgErr.Code == "23505" {
+			return ErrUserListDuplicateMember
+		}
+		return err
+	}
+	return nil
 }
 
 func (r *userListRepository) RemoveMember(listID, userID string) error {

--- a/internal/repository/user_list_test.go
+++ b/internal/repository/user_list_test.go
@@ -2,6 +2,7 @@ package repository
 
 import (
 	"context"
+	"errors"
 	"testing"
 
 	"github.com/shiroha-a/mk/internal/model"
@@ -77,4 +78,26 @@ func TestUserListRepository_ListMembers_Error(t *testing.T) {
 	repo := NewUserListRepository(testDB.WithContext(ctx))
 	_, err := repo.ListMembers("x")
 	assert.Error(t, err)
+}
+
+// TestUserListRepository_AddMember_Duplicate verifies the (userListId, userId)
+// unique-constraint violation is mapped to ErrUserListDuplicateMember (#396),
+// so the API layer can return the TS-compat ALREADY_ADDED error.
+func TestUserListRepository_AddMember_Duplicate(t *testing.T) {
+	repo := NewUserListRepository(testDB)
+	createTestUser(t, "ul_o3")
+	createTestUser(t, "ul_m3")
+
+	list := &model.UserList{ID: "ul_3", UserID: "ul_o3", Name: "Dup"}
+	require.NoError(t, repo.Create(list))
+	defer cleanupUserList(t, list.ID)
+
+	first := &model.UserListMembership{ID: "ulm_3a", UserListID: list.ID, UserID: "ul_m3"}
+	require.NoError(t, repo.AddMember(first))
+
+	dup := &model.UserListMembership{ID: "ulm_3b", UserListID: list.ID, UserID: "ul_m3"}
+	err := repo.AddMember(dup)
+	require.Error(t, err)
+	assert.True(t, errors.Is(err, ErrUserListDuplicateMember),
+		"既 member の AddMember は ErrUserListDuplicateMember を返すこと, got: %v", err)
 }


### PR DESCRIPTION
## Summary

drop-in 切替 (Phase 14-3 frontend e2e) で、既に list に居る member を再度 push すると mk-A が `INTERNAL_ERROR` (500) を返してフロントエンドが原因不明の失敗扱いになる (#396)。Misskey TS は同条件で `ALREADY_ADDED` (HTTP 400, UUID `1de7c884-1595-49e9-857e-61f12f4d4fc5`) を返す。

## 主な変更点

- `repository.ErrUserListDuplicateMember` sentinel を追加。`AddMember` が PostgreSQL 23505 (一意制約違反) を検出したら sentinel へ変換。`user_list_membership` には `IDX_user_list_membership_pair` (`userListId`, `userId`) の unique index が貼ってあるので duplicate insert で必ず発火する。`NoteReactionRepository` の同等パターン (`note_reaction.go:35-44`) を踏襲。
- `api/userlists.Push`: `errors.Is` で sentinel を判定して TS 互換の error body (`code: ALREADY_ADDED`, `id: 1de7c884-...`) を HTTP 400 で返す。UUID は `misskey/.../users/lists/push.ts` と一致。

## テスト

- `TestPush_AlreadyAdded`: `duplicateAddMemberRepo` で sentinel を返したとき、HTTP 400 + body に `ALREADY_ADDED` と TS 互換 UUID が含まれること。
- `TestUserListRepository_AddMember_Duplicate` (DB-backed): 同じ `(userListId, userId)` ペアを 2 回 `AddMember` した時に `ErrUserListDuplicateMember` が返ることを実 PostgreSQL で確認。

`internal/api/userlists` は 100% カバー。

## Closes

Closes #396

## 関連

- 検出元: #394 (Phase 14-3 drop-in frontend e2e swap)
- 同パターン: `internal/repository/note_reaction.go` の重複 reaction → `ErrDuplicateReaction`
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/shiroha-a/mk/pull/411" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
