### PR TITLE
Fix #416: populate Renote/Reply on note entity and streaming payload

### DIFF
--- a/internal/api/i/handler_extra.go
+++ b/internal/api/i/handler_extra.go
@@ -89,15 +89,20 @@ func (h *Handler) Favorites(c echo.Context) error {
 	if err != nil {
 		return c.JSON(http.StatusInternalServerError, apierr.Error("INTERNAL_ERROR", "Internal error.", "5d37dbcb-891e-41ca-a3d6-e690c97775ac"))
 	}
-	// 複数の favorite note について remote user の instance を 1 回の batch
-	// fetch で resolve する。
+	// PackNotes 経由で renote / reply の embed まで含めて Instance / emoji
+	// 解決を一括適用する。favorite を NoteEntity と対応づけるために note ID
+	// → index の map を作り、後段の favorite イテレートで参照する (#416)。
 	notes := make([]*model.Note, 0, len(favs))
 	for _, f := range favs {
 		if f.Note != nil {
 			notes = append(notes, f.Note)
 		}
 	}
-	resolver := entity.NewInstanceResolver(h.instanceLookup(), entity.CollectNoteAuthors(notes)...)
+	packed := entity.PackNotes(notes, h.idGen, h.instanceLookup(), h.emojiLookup())
+	byID := make(map[string]*entity.NoteEntity, len(packed))
+	for i := range packed {
+		byID[packed[i].ID] = &packed[i]
+	}
 
 	result := make([]map[string]any, 0, len(favs))
 	for _, f := range favs {
@@ -106,9 +111,9 @@ func (h *Handler) Favorites(c echo.Context) error {
 			"noteId": f.NoteID,
 		}
 		if f.Note != nil {
-			pn := entity.PackNote(f.Note, h.idGen)
-			resolver.FillUserLite(&pn.User)
-			item["note"] = pn
+			if pn, ok := byID[f.Note.ID]; ok {
+				item["note"] = *pn
+			}
 		}
 		result = append(result, item)
 	}

--- a/internal/api/notes/handler.go
+++ b/internal/api/notes/handler.go
@@ -526,14 +526,16 @@ func (h *Handler) packMany(notes []*model.Note, viewer *model.User) []entity.Not
 
 // resolveFiles collects all fileIds from notes, fetches DriveFiles in bulk,
 // and populates the Files field of each NoteEntity.
+// Renote / Reply の embed エンティティにも同じ resolution を適用して、quote
+// renote の添付が空になる問題を避ける (#416 関連)。
 func (h *Handler) resolveFiles(notes []entity.NoteEntity) {
 	if h.driveFileRepo == nil {
 		return
 	}
-	// 全fileIDsを収集
+	// 全fileIDsを収集 (renote/reply の embed 分も含む)
 	var allIDs []string
-	for _, n := range notes {
-		allIDs = append(allIDs, n.FileIDs...)
+	for i := range notes {
+		allIDs = appendNoteFileIDs(allIDs, &notes[i])
 	}
 	if len(allIDs) == 0 {
 		return
@@ -554,24 +556,61 @@ func (h *Handler) resolveFiles(notes []entity.NoteEntity) {
 	folderCache, userCache := h.resolveFileOwners(files)
 
 	for i := range notes {
-		packed := make([]any, 0, len(notes[i].FileIDs))
-		for _, fid := range notes[i].FileIDs {
-			f, ok := fileMap[fid]
-			if !ok {
-				continue
-			}
-			var folder *model.DriveFolder
-			if f.FolderID != nil {
-				folder = folderCache[*f.FolderID]
-			}
-			var user *model.User
-			if f.UserID != nil {
-				user = userCache[*f.UserID]
-			}
-			packed = append(packed, entity.PackDriveFileWithRelations(f, h.idGen, folder, user))
-		}
-		notes[i].Files = packed
+		h.populateNoteFiles(&notes[i], fileMap, folderCache, userCache)
 	}
+}
+
+// appendNoteFileIDs collects fileIDs from the note plus its embedded Renote /
+// Reply targets (1 level deep, matching the repository preload depth).
+func appendNoteFileIDs(dst []string, n *entity.NoteEntity) []string {
+	if n == nil {
+		return dst
+	}
+	dst = append(dst, n.FileIDs...)
+	if n.Renote != nil {
+		dst = append(dst, n.Renote.FileIDs...)
+	}
+	if n.Reply != nil {
+		dst = append(dst, n.Reply.FileIDs...)
+	}
+	return dst
+}
+
+// populateNoteFiles fills NoteEntity.Files for the note plus its embedded
+// Renote / Reply targets using the shared file / folder / user caches.
+func (h *Handler) populateNoteFiles(n *entity.NoteEntity, fileMap map[string]*model.DriveFile, folderCache map[string]*model.DriveFolder, userCache map[string]*model.User) {
+	if n == nil {
+		return
+	}
+	n.Files = h.packNoteFiles(n.FileIDs, fileMap, folderCache, userCache)
+	if n.Renote != nil {
+		n.Renote.Files = h.packNoteFiles(n.Renote.FileIDs, fileMap, folderCache, userCache)
+	}
+	if n.Reply != nil {
+		n.Reply.Files = h.packNoteFiles(n.Reply.FileIDs, fileMap, folderCache, userCache)
+	}
+}
+
+// packNoteFiles resolves a note's fileIDs into packed file entities using the
+// shared cache populated by resolveFiles.
+func (h *Handler) packNoteFiles(fileIDs []string, fileMap map[string]*model.DriveFile, folderCache map[string]*model.DriveFolder, userCache map[string]*model.User) []any {
+	packed := make([]any, 0, len(fileIDs))
+	for _, fid := range fileIDs {
+		f, ok := fileMap[fid]
+		if !ok {
+			continue
+		}
+		var folder *model.DriveFolder
+		if f.FolderID != nil {
+			folder = folderCache[*f.FolderID]
+		}
+		var user *model.User
+		if f.UserID != nil {
+			user = userCache[*f.UserID]
+		}
+		packed = append(packed, entity.PackDriveFileWithRelations(f, h.idGen, folder, user))
+	}
+	return packed
 }
 
 // resolveFileOwners builds id→model caches for folder / user by iterating
@@ -605,35 +644,31 @@ func (h *Handler) resolveFileOwners(files []*model.DriveFile) (map[string]*model
 
 // resolveViewerFields populates viewer-dependent fields (MyReaction, Channel)
 // on packed NoteEntities. viewerがnilの場合はChannel解決のみ行う。
+// Renote / Reply の embed にも同じ処理を適用する (#416)。
 func (h *Handler) resolveViewerFields(notes []entity.NoteEntity, viewer *model.User) {
 	if len(notes) == 0 {
 		return
 	}
 
-	// MyReaction: viewerが認証済みの場合にバッチ取得
+	// MyReaction: viewerが認証済みの場合にバッチ取得 (embed 分も同じクエリで)
 	if viewer != nil && h.noteReactionRepo != nil {
-		noteIDs := make([]string, len(notes))
+		var noteIDs []string
 		for i := range notes {
-			noteIDs[i] = notes[i].ID
+			noteIDs = appendNoteIDs(noteIDs, &notes[i])
 		}
 		reactionMap, err := h.noteReactionRepo.FindByUserAndNoteIDs(viewer.ID, noteIDs)
 		if err == nil {
 			for i := range notes {
-				if r, ok := reactionMap[notes[i].ID]; ok {
-					nr := entity.NormalizeReactionKey(r.Reaction)
-					notes[i].MyReaction = &nr
-				}
+				applyMyReaction(&notes[i], reactionMap)
 			}
 		}
 	}
 
-	// Channel: ChannelIDがnon-nilのノートについてバッチ取得
+	// Channel: ChannelIDがnon-nilのノートについてバッチ取得 (embed 分も含む)
 	if h.channelRepo != nil {
 		var channelIDs []string
-		for _, n := range notes {
-			if n.ChannelID != nil && *n.ChannelID != "" {
-				channelIDs = append(channelIDs, *n.ChannelID)
-			}
+		for i := range notes {
+			channelIDs = appendNoteChannelIDs(channelIDs, &notes[i])
 		}
 		if len(channelIDs) > 0 {
 			channels, err := h.channelRepo.FindByIDs(channelIDs)
@@ -643,19 +678,91 @@ func (h *Handler) resolveViewerFields(notes []entity.NoteEntity, viewer *model.U
 					chMap[ch.ID] = ch
 				}
 				for i := range notes {
-					if notes[i].ChannelID != nil {
-						if ch, ok := chMap[*notes[i].ChannelID]; ok {
-							notes[i].Channel = &entity.ChannelLite{
-								ID:                    ch.ID,
-								Name:                  ch.Name,
-								Color:                 ch.Color,
-								IsSensitive:           ch.IsSensitive,
-								AllowRenoteToExternal: ch.AllowRenoteToExternal,
-							}
-						}
-					}
+					applyChannel(&notes[i], chMap)
 				}
 			}
 		}
 	}
+}
+
+// appendNoteIDs collects the id of the note plus embedded Renote / Reply.
+func appendNoteIDs(dst []string, n *entity.NoteEntity) []string {
+	if n == nil {
+		return dst
+	}
+	dst = append(dst, n.ID)
+	if n.Renote != nil {
+		dst = append(dst, n.Renote.ID)
+	}
+	if n.Reply != nil {
+		dst = append(dst, n.Reply.ID)
+	}
+	return dst
+}
+
+// applyMyReaction fills MyReaction on the note and embedded renote/reply.
+func applyMyReaction(n *entity.NoteEntity, reactionMap map[string]*model.NoteReaction) {
+	if n == nil {
+		return
+	}
+	if r, ok := reactionMap[n.ID]; ok {
+		nr := entity.NormalizeReactionKey(r.Reaction)
+		n.MyReaction = &nr
+	}
+	if n.Renote != nil {
+		if r, ok := reactionMap[n.Renote.ID]; ok {
+			nr := entity.NormalizeReactionKey(r.Reaction)
+			n.Renote.MyReaction = &nr
+		}
+	}
+	if n.Reply != nil {
+		if r, ok := reactionMap[n.Reply.ID]; ok {
+			nr := entity.NormalizeReactionKey(r.Reaction)
+			n.Reply.MyReaction = &nr
+		}
+	}
+}
+
+// appendNoteChannelIDs collects channelIDs from the note plus embedded
+// Renote / Reply.
+func appendNoteChannelIDs(dst []string, n *entity.NoteEntity) []string {
+	if n == nil {
+		return dst
+	}
+	if n.ChannelID != nil && *n.ChannelID != "" {
+		dst = append(dst, *n.ChannelID)
+	}
+	if n.Renote != nil && n.Renote.ChannelID != nil && *n.Renote.ChannelID != "" {
+		dst = append(dst, *n.Renote.ChannelID)
+	}
+	if n.Reply != nil && n.Reply.ChannelID != nil && *n.Reply.ChannelID != "" {
+		dst = append(dst, *n.Reply.ChannelID)
+	}
+	return dst
+}
+
+// applyChannel fills Channel on the note and embedded renote/reply.
+func applyChannel(n *entity.NoteEntity, chMap map[string]*model.Channel) {
+	if n == nil {
+		return
+	}
+	setChannel := func(target *entity.NoteEntity) {
+		if target == nil || target.ChannelID == nil {
+			return
+		}
+		ch, ok := chMap[*target.ChannelID]
+		if !ok {
+			return
+		}
+		target.Channel = &entity.ChannelLite{
+			ID:                    ch.ID,
+			Name:                  ch.Name,
+			Color:                 ch.Color,
+			IsSensitive:           ch.IsSensitive,
+			AllowRenoteToExternal: ch.AllowRenoteToExternal,
+		}
+	}
+	setChannel(n)
+	setChannel(n.Renote)
+	setChannel(n.Reply)
 }

--- a/internal/api/notes/resolve_files_test.go
+++ b/internal/api/notes/resolve_files_test.go
@@ -55,6 +55,44 @@ func TestResolveFiles_Populates(t *testing.T) {
 	require.Len(notes[1].Files, 1)
 }
 
+// Renote / Reply の embed にも Files が埋まる (#416)。
+func TestResolveFiles_EmbeddedRenoteAndReply(t *testing.T) {
+	h, _ := newTestHandler(t)
+	fileRepo := testutil.NewMockDriveFileRepository()
+	alice := "alice"
+	fileRepo.Files["f1"] = &model.DriveFile{ID: "f1", UserID: &alice, Name: "outer.png", Type: "image/png", URL: "https://example.com/f1"}
+	fileRepo.Files["f2"] = &model.DriveFile{ID: "f2", UserID: &alice, Name: "renote.png", Type: "image/png", URL: "https://example.com/f2"}
+	fileRepo.Files["f3"] = &model.DriveFile{ID: "f3", UserID: &alice, Name: "reply.png", Type: "image/png", URL: "https://example.com/f3"}
+	h.SetDriveFileRepo(fileRepo)
+
+	notes := []entity.NoteEntity{{
+		FileIDs: pq.StringArray{"f1"},
+		Renote:  &entity.NoteEntity{FileIDs: pq.StringArray{"f2"}},
+		Reply:   &entity.NoteEntity{FileIDs: pq.StringArray{"f3"}},
+	}}
+	h.resolveFiles(notes)
+
+	assert.Len(t, notes[0].Files, 1)
+	assert.Len(t, notes[0].Renote.Files, 1)
+	assert.Len(t, notes[0].Reply.Files, 1)
+}
+
+// Renote のみ、Reply のみでも問題なく動く。nil entity は populateNoteFiles で
+// 早期 return される。
+func TestResolveFiles_EmbeddedRenoteOnly(t *testing.T) {
+	h, _ := newTestHandler(t)
+	fileRepo := testutil.NewMockDriveFileRepository()
+	alice := "alice"
+	fileRepo.Files["f2"] = &model.DriveFile{ID: "f2", UserID: &alice, Name: "renote.png", Type: "image/png", URL: "https://example.com/f2"}
+	h.SetDriveFileRepo(fileRepo)
+
+	notes := []entity.NoteEntity{{
+		Renote: &entity.NoteEntity{FileIDs: pq.StringArray{"f2"}},
+	}}
+	h.resolveFiles(notes)
+	assert.Len(t, notes[0].Renote.Files, 1)
+}
+
 // 未知の fileID が含まれる場合は無視される (map lookup miss 経路)。
 func TestResolveFiles_UnknownFileIDsIgnored(t *testing.T) {
 	h, _ := newTestHandler(t)

--- a/internal/api/notes/resolve_viewer_fields_test.go
+++ b/internal/api/notes/resolve_viewer_fields_test.go
@@ -1,0 +1,75 @@
+package notes
+
+import (
+	"testing"
+
+	"github.com/shiroha-a/mk/internal/entity"
+	"github.com/shiroha-a/mk/internal/model"
+	"github.com/shiroha-a/mk/internal/testutil"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// resolveViewerFields の MyReaction 解決が Renote / Reply の embed にも
+// 波及することを確認する (#416)。
+func TestResolveViewerFields_MyReactionEmbedded(t *testing.T) {
+	h, _ := newTestHandler(t)
+	reactionRepo := testutil.NewMockNoteReactionRepository()
+	h.SetNoteReactionRepo(reactionRepo)
+
+	// 外側 / renote / reply それぞれに別の id を付け、全てにリアクションを登録
+	reactionRepo.Reactions["outer"] = &model.NoteReaction{ID: "outer", UserID: "v1", NoteID: "n1", Reaction: "👍"}
+	reactionRepo.Reactions["renote"] = &model.NoteReaction{ID: "renote", UserID: "v1", NoteID: "n2", Reaction: "❤"}
+	reactionRepo.Reactions["reply"] = &model.NoteReaction{ID: "reply", UserID: "v1", NoteID: "n3", Reaction: "🎉"}
+
+	notes := []entity.NoteEntity{{
+		ID:     "n1",
+		Renote: &entity.NoteEntity{ID: "n2"},
+		Reply:  &entity.NoteEntity{ID: "n3"},
+	}}
+	viewer := &model.User{ID: "v1"}
+
+	h.resolveViewerFields(notes, viewer)
+
+	require.NotNil(t, notes[0].MyReaction)
+	assert.Equal(t, "👍", *notes[0].MyReaction)
+	require.NotNil(t, notes[0].Renote.MyReaction)
+	assert.Equal(t, "❤", *notes[0].Renote.MyReaction)
+	require.NotNil(t, notes[0].Reply.MyReaction)
+	assert.Equal(t, "🎉", *notes[0].Reply.MyReaction)
+}
+
+// Channel 解決も Renote / Reply の embed に波及する。
+func TestResolveViewerFields_ChannelEmbedded(t *testing.T) {
+	h, _ := newTestHandler(t)
+	channelRepo := testutil.NewMockChannelRepository()
+	h.SetChannelRepo(channelRepo)
+	channelRepo.Channels["ch1"] = &model.Channel{ID: "ch1", Name: "outer-ch"}
+	channelRepo.Channels["ch2"] = &model.Channel{ID: "ch2", Name: "renote-ch"}
+
+	ch1 := "ch1"
+	ch2 := "ch2"
+	notes := []entity.NoteEntity{{
+		ID:        "n1",
+		ChannelID: &ch1,
+		Renote:    &entity.NoteEntity{ID: "n2", ChannelID: &ch2},
+	}}
+
+	h.resolveViewerFields(notes, nil)
+
+	require.NotNil(t, notes[0].Channel)
+	assert.Equal(t, "outer-ch", notes[0].Channel.Name)
+	require.NotNil(t, notes[0].Renote.Channel)
+	assert.Equal(t, "renote-ch", notes[0].Renote.Channel.Name)
+}
+
+// nil エンティティ / 空スライスでも panic しない。
+func TestResolveViewerFields_NilSafe(t *testing.T) {
+	h, _ := newTestHandler(t)
+	h.resolveViewerFields(nil, nil)
+	// helper function に直接 nil を渡す経路も確認
+	applyMyReaction(nil, map[string]*model.NoteReaction{})
+	applyChannel(nil, map[string]*model.Channel{})
+	assert.Equal(t, []string(nil), appendNoteIDs(nil, nil))
+	assert.Equal(t, []string(nil), appendNoteChannelIDs(nil, nil))
+}

--- a/internal/core/federation/processor.go
+++ b/internal/core/federation/processor.go
@@ -526,9 +526,27 @@ func (p *Processor) handleCreate(act genericActivity) error {
 		// IngestNoteが既存ノートを返した場合 (重複) でもfanout自体は
 		// べき等なので呼んで問題ない。authorはnoteに紐付くUserを使うが、
 		// IngestNoteはUser fieldを設定しないためactorを使う。
-		p.fanoutHook.OnNoteCreated(note, actor)
+		// Renote/Reply relation は IngestNote 直後では未ロード (ID だけ) な
+		// ので、ストリーミング payload で renote 先が null にならないように
+		// preload 付きで再取得する (#416)。
+		p.fanoutHook.OnNoteCreated(hydrateNoteForFanout(p.noteRepo, note), actor)
 	}
 	return nil
+}
+
+// hydrateNoteForFanout reloads a freshly-created note via FindByIDWithUser so
+// that Renote/Reply relations are preloaded before handing it to the fanout
+// hook. reload が失敗した場合は元の note をそのまま返す (best-effort)。
+func hydrateNoteForFanout(repo interface {
+	FindByIDWithUser(id string) (*model.Note, error)
+}, note *model.Note) *model.Note {
+	if repo == nil || note == nil {
+		return note
+	}
+	if loaded, err := repo.FindByIDWithUser(note.ID); err == nil && loaded != nil {
+		return loaded
+	}
+	return note
 }
 
 // handleLike attaches a reaction to a local note based on a Like activity.
@@ -609,7 +627,7 @@ func (p *Processor) handleAnnounce(act genericActivity) error {
 	}
 	_ = p.noteRepo.IncrementCount(target.ID, "renoteCount", 1)
 	if p.fanoutHook != nil {
-		p.fanoutHook.OnNoteCreated(renote, announcer)
+		p.fanoutHook.OnNoteCreated(hydrateNoteForFanout(p.noteRepo, renote), announcer)
 	}
 	return nil
 }

--- a/internal/core/federation/processor_test.go
+++ b/internal/core/federation/processor_test.go
@@ -1212,10 +1212,11 @@ type fakeFanoutHook struct {
 type fakeFanoutCall struct {
 	noteID   string
 	authorID string
+	note     *model.Note
 }
 
 func (f *fakeFanoutHook) OnNoteCreated(note *model.Note, author *model.User) {
-	f.calls = append(f.calls, fakeFanoutCall{noteID: note.ID, authorID: author.ID})
+	f.calls = append(f.calls, fakeFanoutCall{noteID: note.ID, authorID: author.ID, note: note})
 }
 
 func TestProcess_CreateCallsFanoutHook(t *testing.T) {
@@ -1270,6 +1271,11 @@ func TestProcess_AnnounceCallsFanoutHook(t *testing.T) {
 	require.Len(t, hook.calls, 1)
 	// Announce で作成された renote の ID が渡される
 	assert.NotEqual(t, "local1", hook.calls[0].noteID)
+	// hydrateNoteForFanout により Renote relation が preload された状態で
+	// 渡される (#416: streaming payload で renote が null にならない保証)。
+	require.NotNil(t, hook.calls[0].note)
+	require.NotNil(t, hook.calls[0].note.Renote, "Renote relation must be hydrated before fanout")
+	assert.Equal(t, "local1", hook.calls[0].note.Renote.ID)
 }
 
 func TestProcess_CreateWithoutFanoutHook(t *testing.T) {

--- a/internal/entity/note.go
+++ b/internal/entity/note.go
@@ -127,6 +127,19 @@ func PackNote(n *model.Note, idGen id.Generator) NoteEntity {
 		entity.User = PackUserLite(n.User)
 	}
 
+	// Renote / Reply の target は repository 層で Preload("Renote.User") /
+	// Preload("Reply.User") されている前提で 1 段だけ展開する。preload が
+	// 無ければ n.Renote == nil になり、フロントエンドはこれを「削除された投稿」
+	// として描画する (renoteId だけが入ってる状態と区別するため #416)。
+	if n.Renote != nil {
+		r := PackNote(n.Renote, idGen)
+		entity.Renote = &r
+	}
+	if n.Reply != nil {
+		r := PackNote(n.Reply, idGen)
+		entity.Reply = &r
+	}
+
 	return entity
 }
 
@@ -135,19 +148,18 @@ func PackNote(n *model.Note, idGen id.Generator) NoteEntity {
 // nil (convenient for handlers not yet wired or for contexts where instance
 // embed is unnecessary).
 //
-// CollectNoteAuthors で top-level note の User のみ集約してから resolver を
-// 作る (reply/renote の User は NoteEntity で別埋めする運用のため集約対象外)。
+// flattenNotesPlusRelations で top-level + Renote/Reply の target note を
+// 1 まとめにしてから resolver を作る。CollectNoteAuthors も flatten 済みの
+// スライスから author を拾うので、埋め込み note の remote user にも Instance /
+// emoji が正しく載る。
 func PackNotes(notes []*model.Note, idGen id.Generator, instLookup InstanceLookup, emojiLookup EmojiLookup) []NoteEntity {
-	instResolver := NewInstanceResolver(instLookup, CollectNoteAuthors(notes)...)
-	emojiResolver := NewEmojiResolver(emojiLookup, notes)
+	flat := flattenNotesPlusRelations(notes)
+	instResolver := NewInstanceResolver(instLookup, CollectNoteAuthors(flat)...)
+	emojiResolver := NewEmojiResolver(emojiLookup, flat)
 	out := make([]NoteEntity, 0, len(notes))
 	for _, n := range notes {
 		packed := PackNote(n, idGen)
-		instResolver.FillUserLite(&packed.User)
-		emojiResolver.PopulateNoteEmojis(n, &packed)
-		if n.User != nil {
-			emojiResolver.PopulateUserEmojis(n.User, &packed.User)
-		}
+		applyNoteResolvers(n, &packed, instResolver, emojiResolver)
 		out = append(out, packed)
 	}
 	return out
@@ -160,23 +172,57 @@ func PackNotes(notes []*model.Note, idGen id.Generator, instLookup InstanceLooku
 // instead — calling this in a loop produces N+1 queries.
 func PackNoteWithInstance(n *model.Note, idGen id.Generator, instLookup InstanceLookup, emojiLookup EmojiLookup) NoteEntity {
 	packed := PackNote(n, idGen)
-	notes := []*model.Note{n}
-	instResolver := NewInstanceResolver(instLookup, CollectNoteAuthors(notes)...)
-	instResolver.FillUserLite(&packed.User)
-	emojiResolver := NewEmojiResolver(emojiLookup, notes)
-	emojiResolver.PopulateNoteEmojis(n, &packed)
-	if n.User != nil {
-		emojiResolver.PopulateUserEmojis(n.User, &packed.User)
-	}
+	flat := flattenNotesPlusRelations([]*model.Note{n})
+	instResolver := NewInstanceResolver(instLookup, CollectNoteAuthors(flat)...)
+	emojiResolver := NewEmojiResolver(emojiLookup, flat)
+	applyNoteResolvers(n, &packed, instResolver, emojiResolver)
 	return packed
+}
+
+// applyNoteResolvers fills Instance + emojis on the packed entity and its
+// embedded renote/reply children. Preload は 1 段だけなので Renote.Renote や
+// Reply.Reply は常に nil で、深い再帰には成らない。
+func applyNoteResolvers(n *model.Note, e *NoteEntity, instResolver *InstanceResolver, emojiResolver *EmojiResolver) {
+	instResolver.FillUserLite(&e.User)
+	emojiResolver.PopulateNoteEmojis(n, e)
+	if n.User != nil {
+		emojiResolver.PopulateUserEmojis(n.User, &e.User)
+	}
+	if n.Renote != nil && e.Renote != nil {
+		applyNoteResolvers(n.Renote, e.Renote, instResolver, emojiResolver)
+	}
+	if n.Reply != nil && e.Reply != nil {
+		applyNoteResolvers(n.Reply, e.Reply, instResolver, emojiResolver)
+	}
+}
+
+// flattenNotesPlusRelations returns notes plus any preloaded Renote/Reply
+// targets (1 level deep, since GORM only preloads the relations we ask for).
+// resolver 構築時に embed 先 note の author / emoji も拾うために使う。
+func flattenNotesPlusRelations(notes []*model.Note) []*model.Note {
+	flat := make([]*model.Note, 0, len(notes)*2)
+	for _, n := range notes {
+		if n == nil {
+			continue
+		}
+		flat = append(flat, n)
+		if n.Renote != nil {
+			flat = append(flat, n.Renote)
+		}
+		if n.Reply != nil {
+			flat = append(flat, n.Reply)
+		}
+	}
+	return flat
 }
 
 // CollectNoteAuthors returns the author `User` pointer of each note that has
 // one preloaded. Used by packers and handlers when building an
 // InstanceResolver over a pre-fetched slice of notes.
 //
-// 現状は note.User のみ (reply/renote の User は NoteEntity で別埋めする運用
-// のため集約対象外)。
+// note.User のみを拾う。reply/renote の author も含めたい場合は呼び出し側で
+// flattenNotesPlusRelations を事前適用してから渡すこと (PackNotes はそうして
+// いる)。
 func CollectNoteAuthors(notes []*model.Note) []*model.User {
 	users := make([]*model.User, 0, len(notes))
 	for _, n := range notes {

--- a/internal/entity/note.go
+++ b/internal/entity/note.go
@@ -72,8 +72,20 @@ type PollChoice struct {
 	IsVoted bool   `json:"isVoted"`
 }
 
-// PackNote converts a model.Note to a NoteEntity.
+// maxNoteEmbedDepth caps how many levels of Renote / Reply are expanded when
+// packing. repository 側の preloadNoteRelations は 1 段しか preload しない
+// ので通常 1 で十分だが、テストや将来の preload 変更で n.Renote.Renote などが
+// 意図せず非 nil になった場合でも応答を bounded に保つためのガード (#416
+// Devin review)。
+const maxNoteEmbedDepth = 1
+
+// PackNote converts a model.Note to a NoteEntity. Renote / Reply の embed は
+// maxNoteEmbedDepth で制限する。
 func PackNote(n *model.Note, idGen id.Generator) NoteEntity {
+	return packNoteAtDepth(n, idGen, 0)
+}
+
+func packNoteAtDepth(n *model.Note, idGen id.Generator, depth int) NoteEntity {
 	createdAt := ""
 	if t, err := idGen.ParseTime(n.ID); err == nil {
 		createdAt = t.UTC().Format("2006-01-02T15:04:05.000Z")
@@ -131,13 +143,15 @@ func PackNote(n *model.Note, idGen id.Generator) NoteEntity {
 	// Preload("Reply.User") されている前提で 1 段だけ展開する。preload が
 	// 無ければ n.Renote == nil になり、フロントエンドはこれを「削除された投稿」
 	// として描画する (renoteId だけが入ってる状態と区別するため #416)。
-	if n.Renote != nil {
-		r := PackNote(n.Renote, idGen)
-		entity.Renote = &r
-	}
-	if n.Reply != nil {
-		r := PackNote(n.Reply, idGen)
-		entity.Reply = &r
+	if depth < maxNoteEmbedDepth {
+		if n.Renote != nil {
+			r := packNoteAtDepth(n.Renote, idGen, depth+1)
+			entity.Renote = &r
+		}
+		if n.Reply != nil {
+			r := packNoteAtDepth(n.Reply, idGen, depth+1)
+			entity.Reply = &r
+		}
 	}
 
 	return entity
@@ -200,7 +214,10 @@ func applyNoteResolvers(n *model.Note, e *NoteEntity, instResolver *InstanceReso
 // targets (1 level deep, since GORM only preloads the relations we ask for).
 // resolver 構築時に embed 先 note の author / emoji も拾うために使う。
 func flattenNotesPlusRelations(notes []*model.Note) []*model.Note {
-	flat := make([]*model.Note, 0, len(notes)*2)
+	// 最悪ケース (全 note が Renote + Reply 両方を持つ) で *3 要素になるので
+	// 容量もそれに合わせる。多くの note は片方以下なので余剰確保だが、
+	// timeline fetch 30 件 × 2 の再アロケートよりは安上がり。
+	flat := make([]*model.Note, 0, len(notes)*3)
 	for _, n := range notes {
 		if n == nil {
 			continue

--- a/internal/entity/note_test.go
+++ b/internal/entity/note_test.go
@@ -241,6 +241,151 @@ func TestPackNote_ReactionsKeyNormalized(t *testing.T) {
 	assert.Equal(t, 5, e.ReactionCount)
 }
 
+func TestPackNote_WithRenoteAndReply(t *testing.T) {
+	idGen := newTestIDGen(t)
+	renoteID := idGen.Generate(time.Now())
+	replyID := idGen.Generate(time.Now())
+	noteID := idGen.Generate(time.Now())
+
+	renoteText := "original"
+	replyText := "parent reply"
+	text := "quoting"
+
+	note := &model.Note{
+		ID:         noteID,
+		UserID:     "user1",
+		Text:       &text,
+		RenoteID:   &renoteID,
+		ReplyID:    &replyID,
+		Visibility: model.NoteVisibilityPublic,
+		Reactions:  datatypes.JSON([]byte("{}")),
+		Renote: &model.Note{
+			ID:         renoteID,
+			UserID:     "user2",
+			Text:       &renoteText,
+			Visibility: model.NoteVisibilityPublic,
+			Reactions:  datatypes.JSON([]byte("{}")),
+			User: &model.User{
+				ID:                "user2",
+				Username:          "author2",
+				AvatarDecorations: datatypes.JSON([]byte("[]")),
+			},
+		},
+		Reply: &model.Note{
+			ID:         replyID,
+			UserID:     "user3",
+			Text:       &replyText,
+			Visibility: model.NoteVisibilityPublic,
+			Reactions:  datatypes.JSON([]byte("{}")),
+		},
+	}
+
+	e := PackNote(note, idGen)
+
+	require.NotNil(t, e.Renote)
+	assert.Equal(t, renoteID, e.Renote.ID)
+	assert.Equal(t, &renoteText, e.Renote.Text)
+	assert.Equal(t, "author2", e.Renote.User.Username)
+
+	require.NotNil(t, e.Reply)
+	assert.Equal(t, replyID, e.Reply.ID)
+	assert.Equal(t, &replyText, e.Reply.Text)
+}
+
+func TestPackNotes_EmbeddedRenoteHasInstanceAndEmoji(t *testing.T) {
+	idGen := newTestIDGen(t)
+	renoteID := idGen.Generate(time.Now())
+	noteID := idGen.Generate(time.Now())
+	remoteHost := "remote.example"
+
+	renote := &model.Note{
+		ID:         renoteID,
+		UserID:     "user2",
+		Visibility: model.NoteVisibilityPublic,
+		Reactions:  datatypes.JSON([]byte("{}")),
+		UserHost:   &remoteHost,
+		Emojis:     []string{"wave"},
+		User: &model.User{
+			ID:                "user2",
+			Username:          "remoteuser",
+			Host:              &remoteHost,
+			AvatarDecorations: datatypes.JSON([]byte("[]")),
+			Emojis:            []string{"wave"},
+		},
+	}
+	note := &model.Note{
+		ID:         noteID,
+		UserID:     "user1",
+		RenoteID:   &renoteID,
+		Visibility: model.NoteVisibilityPublic,
+		Reactions:  datatypes.JSON([]byte("{}")),
+		User: &model.User{
+			ID:                "user1",
+			Username:          "localuser",
+			AvatarDecorations: datatypes.JSON([]byte("[]")),
+		},
+		Renote: renote,
+	}
+
+	instLookup := &stubInstanceLookup{data: map[string]*model.Instance{
+		remoteHost: {Host: remoteHost, Name: strPtr("Remote")},
+	}}
+	emojiLookup := &stubEmojiLookup{data: map[string][]*model.Emoji{
+		remoteHost: {{Name: "wave", PublicURL: "https://remote.example/emoji/wave.png"}},
+	}}
+
+	out := PackNotes([]*model.Note{note}, idGen, instLookup, emojiLookup)
+	require.Len(t, out, 1)
+	require.NotNil(t, out[0].Renote)
+	require.NotNil(t, out[0].Renote.User.Instance)
+	assert.Equal(t, strPtr("Remote"), out[0].Renote.User.Instance.Name)
+	assert.Equal(t, "https://remote.example/emoji/wave.png", out[0].Renote.Emojis["wave"])
+	assert.Equal(t, "https://remote.example/emoji/wave.png", out[0].Renote.User.Emojis["wave"])
+}
+
+func TestPackNoteWithInstance_EmbeddedRenote(t *testing.T) {
+	idGen := newTestIDGen(t)
+	renoteID := idGen.Generate(time.Now())
+	noteID := idGen.Generate(time.Now())
+	remoteHost := "remote.example"
+
+	note := &model.Note{
+		ID:         noteID,
+		UserID:     "user1",
+		RenoteID:   &renoteID,
+		Visibility: model.NoteVisibilityPublic,
+		Reactions:  datatypes.JSON([]byte("{}")),
+		Renote: &model.Note{
+			ID:         renoteID,
+			UserID:     "user2",
+			Visibility: model.NoteVisibilityPublic,
+			Reactions:  datatypes.JSON([]byte("{}")),
+			UserHost:   &remoteHost,
+			User: &model.User{
+				ID:                "user2",
+				Username:          "remoteuser",
+				Host:              &remoteHost,
+				AvatarDecorations: datatypes.JSON([]byte("[]")),
+			},
+		},
+	}
+
+	instLookup := &stubInstanceLookup{data: map[string]*model.Instance{
+		remoteHost: {Host: remoteHost, Name: strPtr("Remote")},
+	}}
+
+	out := PackNoteWithInstance(note, idGen, instLookup, nil)
+	require.NotNil(t, out.Renote)
+	require.NotNil(t, out.Renote.User.Instance)
+	assert.Equal(t, strPtr("Remote"), out.Renote.User.Instance.Name)
+}
+
+func TestFlattenNotesPlusRelations_NilSafe(t *testing.T) {
+	out := flattenNotesPlusRelations([]*model.Note{nil, {ID: "a"}})
+	require.Len(t, out, 1)
+	assert.Equal(t, "a", out[0].ID)
+}
+
 func TestPackNote_CreatedAtParsing(t *testing.T) {
 	idGen := newTestIDGen(t)
 	noteID := idGen.Generate(time.Now())

--- a/internal/repository/note.go
+++ b/internal/repository/note.go
@@ -98,6 +98,18 @@ func NewNoteRepository(db *gorm.DB) NoteRepository {
 	return &noteRepository{db: db}
 }
 
+// preloadNoteRelations applies Preload for the author plus 1 level of
+// reply/renote targets (with their authors). NoteEntity の packer は
+// renote/reply の target note を埋めるためこれらの preload が必須。
+// GORM の preload は明示した relation しか辿らないので N+1 には成らない。
+func preloadNoteRelations(db *gorm.DB) *gorm.DB {
+	return db.Preload("User").
+		Preload("Renote").
+		Preload("Renote.User").
+		Preload("Reply").
+		Preload("Reply.User")
+}
+
 func (r *noteRepository) Create(note *model.Note) error {
 	return r.db.Create(note).Error
 }
@@ -112,7 +124,7 @@ func (r *noteRepository) FindByID(id string) (*model.Note, error) {
 
 func (r *noteRepository) FindByIDWithUser(id string) (*model.Note, error) {
 	var note model.Note
-	if err := r.db.Preload("User").First(&note, "id = ?", id).Error; err != nil {
+	if err := preloadNoteRelations(r.db).First(&note, "id = ?", id).Error; err != nil {
 		return nil, err
 	}
 	return &note, nil
@@ -199,7 +211,7 @@ func (r *noteRepository) IncrementReaction(noteID, reaction string, delta int) e
 // constrained by sinceID/untilID for keyset pagination.
 func (r *noteRepository) ListByUserID(userID string, untilID, sinceID string, limit int) ([]*model.Note, error) {
 	var notes []*model.Note
-	q := r.db.Preload("User").Where("\"userId\" = ?", userID)
+	q := preloadNoteRelations(r.db).Where("\"userId\" = ?", userID)
 	if untilID != "" {
 		q = q.Where("id < ?", untilID)
 	}
@@ -215,7 +227,7 @@ func (r *noteRepository) ListByUserID(userID string, untilID, sinceID string, li
 // ListByChannelID returns notes posted to the channel.
 func (r *noteRepository) ListByChannelID(channelID string, untilID, sinceID string, limit int) ([]*model.Note, error) {
 	var notes []*model.Note
-	q := r.db.Preload("User").Where("\"channelId\" = ?", channelID)
+	q := preloadNoteRelations(r.db).Where("\"channelId\" = ?", channelID)
 	if untilID != "" {
 		q = q.Where("id < ?", untilID)
 	}
@@ -235,7 +247,7 @@ func (r *noteRepository) ListByChannelID(channelID string, untilID, sinceID stri
 // テキストやファイルを伴わない pure renote だけでなく quote renote も含む。
 func (r *noteRepository) ListRenotesOf(noteID string, untilID, sinceID string, limit int) ([]*model.Note, error) {
 	var notes []*model.Note
-	q := r.db.Preload("User").Where("\"renoteId\" = ?", noteID)
+	q := preloadNoteRelations(r.db).Where("\"renoteId\" = ?", noteID)
 	if untilID != "" {
 		q = q.Where("id < ?", untilID)
 	}
@@ -252,7 +264,7 @@ func (r *noteRepository) ListRenotesOf(noteID string, untilID, sinceID string, l
 // すべてのユーザーからの返信を返す(ミュート判定はServiceで行う)。
 func (r *noteRepository) ListRepliesOf(noteID string, untilID, sinceID string, limit int) ([]*model.Note, error) {
 	var notes []*model.Note
-	q := r.db.Preload("User").Where("\"replyId\" = ?", noteID)
+	q := preloadNoteRelations(r.db).Where("\"replyId\" = ?", noteID)
 	if untilID != "" {
 		q = q.Where("id < ?", untilID)
 	}
@@ -269,7 +281,7 @@ func (r *noteRepository) ListRepliesOf(noteID string, untilID, sinceID string, l
 // notes/childrenでスレッドツリーの直下を取得するために使用する。
 func (r *noteRepository) ListChildrenOf(noteID string, untilID, sinceID string, limit int) ([]*model.Note, error) {
 	var notes []*model.Note
-	q := r.db.Preload("User").
+	q := preloadNoteRelations(r.db).
 		Where("\"replyId\" = ? OR \"renoteId\" = ?", noteID, noteID)
 	if untilID != "" {
 		q = q.Where("id < ?", untilID)
@@ -288,7 +300,7 @@ func (r *noteRepository) ListChildrenOf(noteID string, untilID, sinceID string, 
 // テキストは ILIKE 部分一致、可視性は public/home に限定する。
 func (r *noteRepository) SearchByFilter(f model.NoteSearchFilter) ([]*model.Note, error) {
 	var notes []*model.Note
-	q := r.db.Preload("User").
+	q := preloadNoteRelations(r.db).
 		Where("text ILIKE ?", "%"+f.Query+"%").
 		Where("visibility IN ?", []string{
 			string(model.NoteVisibilityPublic),
@@ -331,7 +343,7 @@ func (r *noteRepository) FindManyByIDsWithUser(ids []string) ([]*model.Note, err
 		return nil, nil
 	}
 	var notes []*model.Note
-	if err := r.db.Preload("User").Where("id IN ?", ids).Find(&notes).Error; err != nil {
+	if err := preloadNoteRelations(r.db).Where("id IN ?", ids).Find(&notes).Error; err != nil {
 		return nil, err
 	}
 	// idsの順序を保つため、idでマップ化してから並び替える
@@ -352,7 +364,7 @@ func (r *noteRepository) ListFeatured(limit, offset int) ([]*model.Note, error) 
 	if limit <= 0 {
 		limit = 10
 	}
-	q := r.db.Preload("User").
+	q := preloadNoteRelations(r.db).
 		Where("visibility = 'public'").
 		Order("(\"renoteCount\" + \"repliesCount\") DESC, id DESC").
 		Limit(limit)
@@ -379,7 +391,7 @@ func (r *noteRepository) ListMentions(userID string, limit int, sinceID, untilID
 	if limit <= 0 {
 		limit = 10
 	}
-	q := r.db.Preload("User").
+	q := preloadNoteRelations(r.db).
 		Where("mentions @> ARRAY[?]::varchar[]", userID).
 		Order(paginationOrder(sinceID, untilID, "id")).Limit(limit)
 	if sinceID != "" {
@@ -399,7 +411,7 @@ func (r *noteRepository) SearchByTag(tag string, limit int, sinceID, untilID str
 	if limit <= 0 {
 		limit = 10
 	}
-	q := r.db.Preload("User").
+	q := preloadNoteRelations(r.db).
 		Where("tags @> ARRAY[?]::varchar[]", tag).
 		Order(paginationOrder(sinceID, untilID, "id")).Limit(limit)
 	if sinceID != "" {
@@ -417,7 +429,7 @@ func (r *noteRepository) SearchByTag(tag string, limit int, sinceID, untilID str
 
 func (r *noteRepository) ListByFileID(fileID string) ([]*model.Note, error) {
 	var notes []*model.Note
-	if err := r.db.Preload("User").Where(`"fileIds" @> ARRAY[?]::varchar[]`, fileID).Order(`"id" DESC`).Limit(20).Find(&notes).Error; err != nil {
+	if err := preloadNoteRelations(r.db).Where(`"fileIds" @> ARRAY[?]::varchar[]`, fileID).Order(`"id" DESC`).Limit(20).Find(&notes).Error; err != nil {
 		return nil, err
 	}
 	return notes, nil
@@ -466,7 +478,7 @@ func applyTimelineFilter(q *gorm.DB, f model.TimelineDBFilter) *gorm.DB {
 // ListHomeTimeline returns notes by the user and users they follow.
 // DBフォールバック用。Redisが空のときに使う。
 func (r *noteRepository) ListHomeTimeline(userID string, limit int, sinceID, untilID string, filter model.TimelineDBFilter) ([]*model.Note, error) {
-	q := r.db.Preload("User").
+	q := preloadNoteRelations(r.db).
 		Where(`("userId" = ? OR "userId" IN (SELECT "followeeId" FROM "following" WHERE "followerId" = ?)) AND "visibility" IN ('public','home','followers')`, userID, userID).
 		Order(paginationOrder(sinceID, untilID, `"id"`)).Limit(limit)
 	if sinceID != "" {
@@ -485,7 +497,7 @@ func (r *noteRepository) ListHomeTimeline(userID string, limit int, sinceID, unt
 
 // ListLocalTimeline returns public/home notes by local users.
 func (r *noteRepository) ListLocalTimeline(limit int, sinceID, untilID string, filter model.TimelineDBFilter) ([]*model.Note, error) {
-	q := r.db.Preload("User").
+	q := preloadNoteRelations(r.db).
 		Where(`"userHost" IS NULL AND "visibility" = 'public' AND "channelId" IS NULL`).
 		Order(paginationOrder(sinceID, untilID, `"id"`)).Limit(limit)
 	if sinceID != "" {
@@ -505,7 +517,7 @@ func (r *noteRepository) ListLocalTimeline(limit int, sinceID, untilID string, f
 // ListGlobalTimeline returns all public notes.
 // channelId IS NULL でチャンネルノートを除外する (TS互換)。
 func (r *noteRepository) ListGlobalTimeline(limit int, sinceID, untilID string, filter model.TimelineDBFilter) ([]*model.Note, error) {
-	q := r.db.Preload("User").
+	q := preloadNoteRelations(r.db).
 		Where(`"visibility" = 'public' AND "channelId" IS NULL`).
 		Order(paginationOrder(sinceID, untilID, `"id"`)).Limit(limit)
 	if sinceID != "" {
@@ -573,7 +585,7 @@ func (r *noteRepository) ListByUserList(listID string, limit int, sinceID, until
 	if limit <= 0 {
 		limit = 10
 	}
-	q := r.db.Preload("User").
+	q := preloadNoteRelations(r.db).
 		Joins(`INNER JOIN "user_list_membership" m ON m."userId" = "note"."userId" AND m."userListId" = ?`, listID).
 		Where(`"note"."channelId" IS NULL`).
 		Where(`"note"."visibility" IN ('public','home','followers')`)

--- a/internal/repository/note_favorite.go
+++ b/internal/repository/note_favorite.go
@@ -44,7 +44,11 @@ func (r *noteFavoriteRepository) ListByUser(userID string, limit, offset int) ([
 	if limit > 100 {
 		limit = 100
 	}
+	// お気に入り一覧は frontend で renote / reply 先も描画するので 1 段だけ
+	// preload する。深さは note 本体と同じ方針 (#416)。
 	q := r.db.Preload("Note").Preload("Note.User").
+		Preload("Note.Renote").Preload("Note.Renote.User").
+		Preload("Note.Reply").Preload("Note.Reply.User").
 		Where("\"userId\" = ?", userID).Order("id DESC").Limit(limit)
 	if offset > 0 {
 		q = q.Offset(offset)

--- a/internal/repository/role_notes_query.go
+++ b/internal/repository/role_notes_query.go
@@ -17,11 +17,12 @@ func NewRoleNotesQuery(db *gorm.DB) *RoleNotesQuery {
 
 // ListByRole returns public notes from users assigned to the given role.
 func (q *RoleNotesQuery) ListByRole(roleID string, limit int, sinceID, untilID string) ([]*model.Note, error) {
-	query := q.db.Model(&model.Note{}).
+	// preloadNoteRelations で User + Renote/Reply (+User) を preload し、
+	// note.go 側の他の list 系クエリと同一の embed 方針に揃える (#416)。
+	query := preloadNoteRelations(q.db).Model(&model.Note{}).
 		Joins(`JOIN "role_assignment" ON "role_assignment"."userId" = "note"."userId"`).
 		Where(`"role_assignment"."roleId" = ?`, roleID).
 		Where(`"note"."visibility" = 'public'`).
-		Preload("User").
 		Order(paginationOrder(sinceID, untilID, `"note"."id"`)).
 		Limit(limit)
 

--- a/internal/server/router.go
+++ b/internal/server/router.go
@@ -1321,6 +1321,7 @@ func (s *Server) setupRoutes() {
 	streamManager.SetNotificationReader(&notifReaderAdapter{svc: notificationService})
 	notePublisher := stream.NewNotePublisher(streamPubSub, idGen)
 	notePublisher.SetEmojiLookup(emojiRepo)
+	notePublisher.SetInstanceLookup(instanceRepo)
 	notificationPublisher := stream.NewNotificationPublisher(streamPubSub)
 	notificationPublisher.SetRepos(userRepo, noteRepo, idGen)
 	drivePublisher := stream.NewDrivePublisher(streamPubSub)

--- a/internal/stream/note_publisher.go
+++ b/internal/stream/note_publisher.go
@@ -26,9 +26,10 @@ type PubSubPublisher interface {
 // フォロワーfanout時に同じノートが複数topicにpublishされるため、直前の
 // ノートIDに対する serialized JSON をキャッシュして DB クエリを 1 回に抑える。
 type NotePublisher struct {
-	pub         PubSubPublisher
-	idGen       id.Generator
-	emojiLookup entity.EmojiLookup
+	pub            PubSubPublisher
+	idGen          id.Generator
+	emojiLookup    entity.EmojiLookup
+	instanceLookup entity.InstanceLookup
 
 	mu         sync.Mutex
 	cachedID   string
@@ -44,6 +45,15 @@ func NewNotePublisher(pub PubSubPublisher, idGen id.Generator) *NotePublisher {
 // custom emoji shortcodes resolved to URLs (#330).
 func (p *NotePublisher) SetEmojiLookup(lookup entity.EmojiLookup) {
 	p.emojiLookup = lookup
+}
+
+// SetInstanceLookup attaches an InstanceLookup so that UserLite.Instance
+// (used by frontend InstanceTicker for theme color / software name) is
+// populated on streaming payloads (#416). Without this the REST response
+// carries the instance info but the pubsub payload does not, causing a
+// visual flicker on page reload.
+func (p *NotePublisher) SetInstanceLookup(lookup entity.InstanceLookup) {
+	p.instanceLookup = lookup
 }
 
 // PublishNote implements core/timeline.StreamingPublisher.
@@ -64,7 +74,11 @@ func (p *NotePublisher) PublishNote(topic string, n *model.Note, author *model.U
 
 // packNote returns the serialized JSON for the note. フォロワーfanout時に
 // 同じノートが繰返しpublishされるため、直前のノートIDが一致する場合は
-// キャッシュを再利用して絵文字解決のDBクエリを1回に抑える。
+// キャッシュを再利用して絵文字 / インスタンス解決の DB クエリを 1 回に抑える。
+//
+// author を n.User に差し戻してから entity.PackNoteWithInstance に渡すことで、
+// Instance / emoji の解決が embed (Renote / Reply) にまで波及する。shallow
+// copy なので元の model.Note は変更されない (Renote 等のポインタは共有)。
 func (p *NotePublisher) packNote(n *model.Note, author *model.User) []byte {
 	p.mu.Lock()
 	defer p.mu.Unlock()
@@ -73,12 +87,11 @@ func (p *NotePublisher) packNote(n *model.Note, author *model.User) []byte {
 		return p.cachedBody
 	}
 
-	pn := entity.PackNote(n, p.idGen)
-	pn.User = entity.PackUserLite(author)
-	notes := []*model.Note{{Emojis: n.Emojis, UserHost: n.UserHost, User: author}}
-	emojiResolver := entity.NewEmojiResolver(p.emojiLookup, notes)
-	emojiResolver.PopulateNoteEmojis(n, &pn)
-	emojiResolver.PopulateUserEmojis(author, &pn.User)
+	noteForPack := *n
+	noteForPack.User = author
+
+	pn := entity.PackNoteWithInstance(&noteForPack, p.idGen, p.instanceLookup, p.emojiLookup)
+
 	body, err := json.Marshal(pn)
 	if err != nil {
 		slog.Warn("note publisher: marshal failed", "err", err)

--- a/internal/stream/note_publisher_test.go
+++ b/internal/stream/note_publisher_test.go
@@ -54,6 +54,89 @@ func TestNotePublisher_PublishesPackedNote(t *testing.T) {
 	assert.Equal(t, "homeTimeline:u1", pub.topics[0])
 }
 
+// stubInstanceLookup implements entity.InstanceLookup for tests.
+type stubInstanceLookup struct {
+	byHost map[string]*model.Instance
+}
+
+func (s *stubInstanceLookup) FindManyByHosts(hosts []string) ([]*model.Instance, error) {
+	out := make([]*model.Instance, 0, len(hosts))
+	for _, h := range hosts {
+		if inst, ok := s.byHost[h]; ok {
+			out = append(out, inst)
+		}
+	}
+	return out, nil
+}
+
+// InstanceLookup が配線されていれば author の Instance が streaming payload
+// に乗る (#416 InstanceTicker テーマカラー反映)。
+func TestNotePublisher_PopulatesAuthorInstance(t *testing.T) {
+	pub := &stubPublisher{}
+	idGen, _ := id.NewGenerator("aidx")
+	np := NewNotePublisher(pub, idGen)
+	themeColor := "#deadbe"
+	host := "remote.example"
+	np.SetInstanceLookup(&stubInstanceLookup{byHost: map[string]*model.Instance{
+		host: {Host: host, ThemeColor: &themeColor},
+	}})
+
+	n := &model.Note{
+		ID:         idGen.Generate(time.Now()),
+		UserID:     "u_remote",
+		UserHost:   &host,
+		Visibility: model.NoteVisibilityPublic,
+	}
+	author := &model.User{ID: "u_remote", Username: "remote", Host: &host}
+	np.PublishNote("globalTimeline", n, author)
+
+	require.Len(t, pub.payloads, 1)
+	raw := pub.payloads[0].(json.RawMessage)
+	var body map[string]any
+	require.NoError(t, json.Unmarshal(raw, &body))
+	user := body["user"].(map[string]any)
+	inst, ok := user["instance"].(map[string]any)
+	require.True(t, ok, "user.instance must be present on streaming payload")
+	assert.Equal(t, themeColor, inst["themeColor"])
+}
+
+// n.Renote が preload 済みならストリーミング payload に renote オブジェクトが
+// 乗ることを確認する (#416)。
+func TestNotePublisher_PublishesEmbeddedRenote(t *testing.T) {
+	pub := &stubPublisher{}
+	idGen, _ := id.NewGenerator("aidx")
+	np := NewNotePublisher(pub, idGen)
+
+	renoteID := idGen.Generate(time.Now())
+	noteID := idGen.Generate(time.Now())
+	renoteText := "original"
+	n := &model.Note{
+		ID:         noteID,
+		UserID:     "u1",
+		RenoteID:   &renoteID,
+		Visibility: model.NoteVisibilityPublic,
+		Renote: &model.Note{
+			ID:         renoteID,
+			UserID:     "u2",
+			Text:       &renoteText,
+			Visibility: model.NoteVisibilityPublic,
+			User:       &model.User{ID: "u2", Username: "author2"},
+		},
+	}
+	np.PublishNote("homeTimeline:u1", n, &model.User{ID: "u1", Username: "alice"})
+
+	require.Len(t, pub.payloads, 1)
+	raw, ok := pub.payloads[0].(json.RawMessage)
+	require.True(t, ok)
+	var body map[string]any
+	require.NoError(t, json.Unmarshal(raw, &body))
+
+	renote, ok := body["renote"].(map[string]any)
+	require.True(t, ok, "renote must be embedded in streaming payload")
+	assert.Equal(t, renoteID, renote["id"])
+	assert.Equal(t, renoteText, renote["text"])
+}
+
 func TestNotePublisher_NilPubIsNoOp(t *testing.T) {
 	idGen, _ := id.NewGenerator("aidx")
 	np := NewNotePublisher(nil, idGen)

--- a/internal/testutil/mock_repository.go
+++ b/internal/testutil/mock_repository.go
@@ -539,19 +539,22 @@ func (m *MockNoteRepository) FindByIDWithUser(id string) (*model.Note, error) {
 		return nil, err
 	}
 	// 本家 preloadNoteRelations と同等の挙動: RenoteID / ReplyID が立って
-	// いれば map から target note を引いて埋める (#416)。Note は pointer
-	// なので元の map エントリも連鎖的に更新されることに注意。
-	if n.Renote == nil && n.RenoteID != nil {
-		if target, ok := m.Notes[*n.RenoteID]; ok {
-			n.Renote = target
+	// いれば map から target note を引いて埋める (#416)。shallow-copy した
+	// コピーに書き込むことで、プロダクションの GORM 挙動 (クエリ毎に fresh
+	// struct) と合わせ、同じ note を FindByID で取り直した時に relation が
+	// 連鎖的に残らないようにする。
+	out := *n
+	if out.Renote == nil && out.RenoteID != nil {
+		if target, ok := m.Notes[*out.RenoteID]; ok {
+			out.Renote = target
 		}
 	}
-	if n.Reply == nil && n.ReplyID != nil {
-		if target, ok := m.Notes[*n.ReplyID]; ok {
-			n.Reply = target
+	if out.Reply == nil && out.ReplyID != nil {
+		if target, ok := m.Notes[*out.ReplyID]; ok {
+			out.Reply = target
 		}
 	}
-	return n, nil
+	return &out, nil
 }
 
 func (m *MockNoteRepository) FindByURI(uri string) (*model.Note, error) {

--- a/internal/testutil/mock_repository.go
+++ b/internal/testutil/mock_repository.go
@@ -534,7 +534,24 @@ func (m *MockNoteRepository) FindByID(id string) (*model.Note, error) {
 }
 
 func (m *MockNoteRepository) FindByIDWithUser(id string) (*model.Note, error) {
-	return m.FindByID(id)
+	n, err := m.FindByID(id)
+	if err != nil {
+		return nil, err
+	}
+	// 本家 preloadNoteRelations と同等の挙動: RenoteID / ReplyID が立って
+	// いれば map から target note を引いて埋める (#416)。Note は pointer
+	// なので元の map エントリも連鎖的に更新されることに注意。
+	if n.Renote == nil && n.RenoteID != nil {
+		if target, ok := m.Notes[*n.RenoteID]; ok {
+			n.Renote = target
+		}
+	}
+	if n.Reply == nil && n.ReplyID != nil {
+		if target, ok := m.Notes[*n.ReplyID]; ok {
+			n.Reply = target
+		}
+	}
+	return n, nil
 }
 
 func (m *MockNoteRepository) FindByURI(uri string) (*model.Note, error) {


### PR DESCRIPTION
## Summary

- リノート先のノートが存在していても API / ストリーミングの両方で `renote: null` が返り、フロントエンドで「削除された投稿」と表示される問題を修正
- 合わせてストリーミング経由で届く投稿の `user.instance` が空で InstanceTicker のテーマカラーが反映されない問題も修正

Closes #416

## 主な変更点

### Entity / Repository
- `internal/repository/note.go` — `preloadNoteRelations` ヘルパーを追加し、note を返す全クエリで `Renote.User` / `Reply.User` を preload
- `internal/entity/note.go` — `PackNote` が `n.Renote` / `n.Reply` を 1 段だけ展開するよう変更。`PackNotes` / `PackNoteWithInstance` では `flattenNotesPlusRelations` で embed 先をまとめて resolver に流し、Instance / emoji を埋め込む

### API Handler
- `internal/api/notes/handler.go` — `resolveFiles` / `resolveViewerFields` が Renote / Reply の embed にも `Files` / `MyReaction` / `Channel` を解決

### 連合 (Federation)
- `internal/core/federation/processor.go` — `handleCreate` / `handleAnnounce` で fanout hook を呼ぶ直前に `FindByIDWithUser` で hydrate する `hydrateNoteForFanout` ヘルパーを追加。`IngestNote` 直後は Renote relation が未ロードな点に対応

### Streaming
- `internal/stream/note_publisher.go` — `SetInstanceLookup` を追加し、`packNote` を `entity.PackNoteWithInstance` 経由に切替。これで streaming payload にも `user.instance` / embed 先の Instance / emoji が乗る
- `internal/server/router.go` — `notePublisher.SetInstanceLookup(instanceRepo)` を配線

### テスト
- `MockNoteRepository.FindByIDWithUser` を本家 preload と同等の挙動 (map から Renote / Reply target を引いて埋める) に更新
- entity / notes handler / federation processor / stream publisher に embed 先を検証するテストを追加

## テスト

- `make fmt && make lint && go test -race -count=1 ./...` すべてパス
- カバレッジ: entity 97.7%、repository 96.8%、api/notes 92.4%、stream 93.8%、core/federation 90.6% (すべて CI 閾値を満たす)
- UDS 環境 (go.k7a.org) で以下を実機確認済み
  - 過去リノート / ストリーミング経由のリノートいずれも renote 先が正しく表示される
  - リモートインスタンスのテーマカラーが InstanceTicker に反映される

## Related

Closes #416

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/shiroha-a/mk/pull/422" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
