### PR TITLE
Fix #417 P1: reversi federation (CherryPick-compat) — gameplay works end-to-end

### DIFF
--- a/internal/api/reversi/federation_surrender_test.go
+++ b/internal/api/reversi/federation_surrender_test.go
@@ -122,6 +122,110 @@ func TestMatch_AcceptsPendingRemoteInvitation_ReusesGameAndSendsJoin(t *testing.
 	assert.Equal(t, "gPending", resp["id"])
 }
 
+// /api/reversi/show-game で User2 が pending federated game を見たとき、
+// Join が自動で送られ、2回目以降は IsJoinSent でスキップされる (#417 P1)。
+func TestShowGame_AutoJoinDedup(t *testing.T) {
+	ctx := context.Background()
+	apiReversiRedis.FlushAll(ctx)
+
+	h, repo := newTestHandler()
+	d := &mockDeliverer{}
+	userRepo := testutil.NewMockUserRepository()
+	host := "remote.example"
+	uri := "https://remote.example/users/inviter"
+	userRepo.Users["inviter"] = &model.User{
+		ID: "inviter", Username: "alice", Host: &host, URI: &uri,
+	}
+
+	pending := &model.ReversiGame{
+		ID: "gAuto", User1ID: "inviter", User2ID: "u1",
+		Map:                  pq.StringArray{"--------", "--------", "--------", "---wb---", "---bw---", "--------", "--------", "--------"},
+		BW:                   "random",
+		TimeLimitForEachTurn: 90,
+		Logs:                 datatypes.JSON("[]"),
+	}
+	repo.games["gAuto"] = pending
+
+	fedCache := corereversi.NewFederationIDCache(apiReversiRedis.Client)
+	fedCache.Set(ctx, "sess-auto", "gAuto")
+	h.SetFederation("https://example.com", d, fedCache, userRepo)
+
+	// 1 回目の show-game で Join が送られる
+	rec := post(h.ShowGame, `{"gameId":"gAuto"}`, u1)
+	assert.Equal(t, http.StatusOK, rec.Code)
+	assert.Equal(t, 1, d.calls)
+
+	// 2 回目は IsJoinSent フラグで skip される
+	rec2 := post(h.ShowGame, `{"gameId":"gAuto"}`, u1)
+	assert.Equal(t, http.StatusOK, rec2.Code)
+	assert.Equal(t, 1, d.calls, "Join はセッションごとに 1 回だけ")
+}
+
+// inviter がまだ DB に取り込まれていないケース (remote user 未 fetch)。
+// sendJoinForAcceptedInvite は silent-skip する。
+func TestShowGame_AutoJoinSkipsWhenInviterMissing(t *testing.T) {
+	ctx := context.Background()
+	apiReversiRedis.FlushAll(ctx)
+
+	h, repo := newTestHandler()
+	d := &mockDeliverer{}
+	userRepo := testutil.NewMockUserRepository()
+	// inviter 未登録
+
+	pending := &model.ReversiGame{
+		ID: "gMissing", User1ID: "ghost", User2ID: "u1",
+		Map:                  pq.StringArray{"--------", "--------", "--------", "---wb---", "---bw---", "--------", "--------", "--------"},
+		BW:                   "random",
+		TimeLimitForEachTurn: 90,
+		Logs:                 datatypes.JSON("[]"),
+	}
+	repo.games["gMissing"] = pending
+
+	fedCache := corereversi.NewFederationIDCache(apiReversiRedis.Client)
+	fedCache.Set(ctx, "sess-m", "gMissing")
+	h.SetFederation("https://example.com", d, fedCache, userRepo)
+
+	rec := post(h.ShowGame, `{"gameId":"gMissing"}`, u1)
+	assert.Equal(t, http.StatusOK, rec.Code)
+	assert.Equal(t, 0, d.calls)
+}
+
+// Federation 未配線 (federation を SetFederation で wire しない) なら
+// sendJoinForAcceptedInvite は silent return。
+func TestShowGame_NoFederationWired(t *testing.T) {
+	h, repo := newTestHandler()
+	repo.games["gNoFed"] = &model.ReversiGame{
+		ID: "gNoFed", User1ID: "someone", User2ID: "u1",
+	}
+	rec := post(h.ShowGame, `{"gameId":"gNoFed"}`, u1)
+	assert.Equal(t, http.StatusOK, rec.Code)
+}
+
+// session mapping が無い pending game (つまり local-only の pending) は
+// Join 送信しない。
+func TestShowGame_LocalOnlyPendingSkipsJoin(t *testing.T) {
+	ctx := context.Background()
+	apiReversiRedis.FlushAll(ctx)
+
+	h, repo := newTestHandler()
+	d := &mockDeliverer{}
+	userRepo := testutil.NewMockUserRepository()
+	userRepo.Users["localalice"] = &model.User{ID: "localalice", Username: "alice"}
+
+	pending := &model.ReversiGame{
+		ID: "gLocal", User1ID: "localalice", User2ID: "u1",
+	}
+	repo.games["gLocal"] = pending
+
+	// fedCache は wire するが session を Set しない → GetSessionByGame が false
+	fedCache := corereversi.NewFederationIDCache(apiReversiRedis.Client)
+	h.SetFederation("https://example.com", d, fedCache, userRepo)
+
+	rec := post(h.ShowGame, `{"gameId":"gLocal"}`, u1)
+	assert.Equal(t, http.StatusOK, rec.Code)
+	assert.Equal(t, 0, d.calls)
+}
+
 // userRepo.FindByID が err を返すケース (リモート相手がまだ取り込まれていない)
 // では Leave 送信はスキップされる。
 func TestSurrender_FederatedGame_UserNotFound(t *testing.T) {

--- a/internal/api/reversi/federation_surrender_test.go
+++ b/internal/api/reversi/federation_surrender_test.go
@@ -122,6 +122,50 @@ func TestMatch_AcceptsPendingRemoteInvitation_ReusesGameAndSendsJoin(t *testing.
 	assert.Equal(t, "gPending", resp["id"])
 }
 
+// CancelMatch は Service.CancelGame 経由で Leave をリモート相手に配信する
+// (#417 Devin review: 直接 repo.Delete をバイパスしていたのを修正)。
+func TestCancelMatch_DeliversLeaveToRemote(t *testing.T) {
+	ctx := context.Background()
+	apiReversiRedis.FlushAll(ctx)
+
+	h, repo := newTestHandler()
+	d := &mockDeliverer{}
+	userRepo := testutil.NewMockUserRepository()
+	host := "remote.example"
+	uri := "https://remote.example/users/u2"
+	userRepo.Users["u2"] = &model.User{ID: "u2", Username: "bob", Host: &host, URI: &uri}
+	userRepo.Users["u1"] = &model.User{ID: "u1", Username: "alice"}
+
+	g := sampleGame()
+	// pre-start の federated pending game
+	g.IsStarted = false
+	g.IsEnded = false
+	repo.games["g1"] = g
+
+	fedCache := corereversi.NewFederationIDCache(apiReversiRedis.Client)
+	fedCache.Set(ctx, "sess-cancel", "g1")
+	h.SetFederation("https://example.com", d, fedCache, userRepo)
+
+	svc := corereversi.NewService(repo, nil, apiReversiRedis.Client)
+	svc.SetFederationCache(fedCache)
+	svc.SetFederationDeliverer(d)
+	svc.SetUserRepo(userRepo)
+	svc.SetBaseURL("https://example.com")
+	h.SetService(svc)
+
+	rec := post(h.CancelMatch, `{}`, u1)
+	assert.Equal(t, http.StatusNoContent, rec.Code)
+
+	// Leave が送られたこと
+	assert.Equal(t, 1, d.calls)
+	// game 行が消えたこと
+	_, exists := repo.games["g1"]
+	assert.False(t, exists)
+	// session mapping も消えていること
+	_, ok := fedCache.GetSessionByGame(ctx, "g1")
+	require.False(t, ok)
+}
+
 // /api/reversi/show-game で User2 が pending federated game を見たとき、
 // Join が自動で送られ、2回目以降は IsJoinSent でスキップされる (#417 P1)。
 func TestShowGame_AutoJoinDedup(t *testing.T) {

--- a/internal/api/reversi/federation_surrender_test.go
+++ b/internal/api/reversi/federation_surrender_test.go
@@ -2,16 +2,19 @@ package reversi
 
 import (
 	"context"
+	"encoding/json"
 	"log"
 	"net/http"
 	"os"
 	"testing"
 
+	"github.com/lib/pq"
 	corereversi "github.com/shiroha-a/mk/internal/core/reversi"
 	"github.com/shiroha-a/mk/internal/model"
 	"github.com/shiroha-a/mk/internal/testutil"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"gorm.io/datatypes"
 )
 
 var apiReversiRedis *testutil.TestRedis
@@ -29,7 +32,8 @@ func TestMain(m *testing.M) {
 }
 
 // federation 経路 (GetSessionByGame が true を返す) をカバーするため、
-// 実 Redis に federationId を Set してから Surrender を叩く。
+// 実 Redis に federationId を Set してから Surrender を叩く。delivery は
+// Service 側 (core/reversi) に移動したため (#417 P1)、Service も wire する。
 func TestSurrender_FederatedGame_SendsLeave(t *testing.T) {
 	ctx := context.Background()
 	apiReversiRedis.FlushAll(ctx)
@@ -40,16 +44,23 @@ func TestSurrender_FederatedGame_SendsLeave(t *testing.T) {
 	host := "remote.example"
 	uri := "https://remote.example/users/u2"
 	userRepo.Users["u2"] = &model.User{ID: "u2", Username: "bob", Host: &host, URI: &uri}
+	userRepo.Users["u1"] = &model.User{ID: "u1", Username: "alice"}
 
 	g := sampleGame()
 	g.IsStarted = true
 	repo.games["g1"] = g
 
-	// FederationIDCache を Redis ベースで構築し、session ↔ game を事前登録する。
 	fedCache := corereversi.NewFederationIDCache(apiReversiRedis.Client)
 	fedCache.Set(ctx, "sess-1", "g1")
-
 	h.SetFederation("https://example.com", d, fedCache, userRepo)
+
+	// Service 経由で delivery させるため Service を wire する。
+	svc := corereversi.NewService(repo, nil, apiReversiRedis.Client)
+	svc.SetFederationCache(fedCache)
+	svc.SetFederationDeliverer(d)
+	svc.SetUserRepo(userRepo)
+	svc.SetBaseURL("https://example.com")
+	h.SetService(svc)
 
 	rec := post(h.Surrender, `{"gameId":"g1"}`, u1)
 	assert.Equal(t, http.StatusNoContent, rec.Code)
@@ -62,6 +73,55 @@ func TestSurrender_FederatedGame_SendsLeave(t *testing.T) {
 	assert.False(t, ok)
 }
 
+// /api/reversi/match で同じ相手から既に招待を受けていれば、既存のゲーム行を
+// 再利用して Join を送り返すだけにする (#417 P1)。これをやらないと毎回
+// 新しいゲーム + 新 session_id を作って二重招待になり state 伝播が破綻する。
+func TestMatch_AcceptsPendingRemoteInvitation_ReusesGameAndSendsJoin(t *testing.T) {
+	ctx := context.Background()
+	apiReversiRedis.FlushAll(ctx)
+
+	h, repo := newTestHandler()
+	d := &mockDeliverer{}
+	userRepo := testutil.NewMockUserRepository()
+	host := "remote.example"
+	uri := "https://remote.example/users/remoteAlice"
+	userRepo.Users["remoteAlice"] = &model.User{
+		ID: "remoteAlice", Username: "alice", Host: &host, URI: &uri,
+	}
+
+	// inbound Invite で作成された pending game を事前に用意する。
+	pending := &model.ReversiGame{
+		ID:                   "gPending",
+		User1ID:              "remoteAlice", // inviter (remote)
+		User2ID:              "u1",          // invitee (local viewer)
+		Map:                  pq.StringArray{"--------", "--------", "--------", "---wb---", "---bw---", "--------", "--------", "--------"},
+		BW:                   "random",
+		TimeLimitForEachTurn: 90,
+		Logs:                 datatypes.JSON("[]"),
+	}
+	repo.games["gPending"] = pending
+
+	// handleReversiInvite で紐付けられていたと仮定する session 情報を Redis に入れる。
+	fedCache := corereversi.NewFederationIDCache(apiReversiRedis.Client)
+	fedCache.Set(ctx, "sess-inbound", "gPending")
+	h.SetFederation("https://example.com", d, fedCache, userRepo)
+
+	// match 呼び出し: 相手 ID を指定 (フロントエンドが invitation クリックで送る形)
+	rec := post(h.Match, `{"userId":"remoteAlice"}`, u1)
+	assert.Equal(t, http.StatusOK, rec.Code)
+
+	// ゲームが 1 件のまま (新しい row が作られていないこと)
+	assert.Len(t, repo.games, 1)
+
+	// deliverer に Join が 1 回送られたこと
+	assert.Equal(t, 1, d.calls)
+
+	// 返却ゲーム ID が既存の pending と同じであること
+	var resp map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+	assert.Equal(t, "gPending", resp["id"])
+}
+
 // userRepo.FindByID が err を返すケース (リモート相手がまだ取り込まれていない)
 // では Leave 送信はスキップされる。
 func TestSurrender_FederatedGame_UserNotFound(t *testing.T) {
@@ -72,6 +132,7 @@ func TestSurrender_FederatedGame_UserNotFound(t *testing.T) {
 	d := &mockDeliverer{}
 	userRepo := testutil.NewMockUserRepository()
 	// u2 を登録しない → FindByID が失敗する
+	userRepo.Users["u1"] = &model.User{ID: "u1", Username: "alice"}
 
 	g := sampleGame()
 	g.IsStarted = true
@@ -80,6 +141,13 @@ func TestSurrender_FederatedGame_UserNotFound(t *testing.T) {
 	fedCache := corereversi.NewFederationIDCache(apiReversiRedis.Client)
 	fedCache.Set(ctx, "sess-2", "g1")
 	h.SetFederation("https://example.com", d, fedCache, userRepo)
+
+	svc := corereversi.NewService(repo, nil, apiReversiRedis.Client)
+	svc.SetFederationCache(fedCache)
+	svc.SetFederationDeliverer(d)
+	svc.SetUserRepo(userRepo)
+	svc.SetBaseURL("https://example.com")
+	h.SetService(svc)
 
 	rec := post(h.Surrender, `{"gameId":"g1"}`, u1)
 	assert.Equal(t, http.StatusNoContent, rec.Code)

--- a/internal/api/reversi/handler.go
+++ b/internal/api/reversi/handler.go
@@ -457,27 +457,11 @@ func (h *Handler) Verify(c echo.Context) error {
 
 	// ログを再生して engine CRC を算出し、client が送ってきた crc32 と
 	// 比較する。CRC が合わなければ desync 判定。client が crc32 を送って
-	// こないケースは比較不可なので常に desynced=false。
-	opts := corereversi.Options{
-		IsLlotheo:        game.IsLlotheo,
-		CanPutEverywhere: game.CanPutEverywhere,
-		LoopedBoard:      game.LoopedBoard,
-	}
-	g := corereversi.NewGame(game.Map, opts)
-	// Log shape は EngineFromGame と同じ: misskey-reversi 形式
-	// [timeDelta, player, operation(0=put), pos]。旧 2 要素 [pos, color] は
-	// fallback (新旧両形式を読める)。以前の Verify は log[0] を pos と解釈
-	// していたが、新形式では timeDelta (兆オーダーのミリ秒) を PutStone に
-	// 渡すことになり盤面が崩壊していた (#417 P1 Devin review)。
-	var logs [][]int
-	_ = json.Unmarshal(game.Logs, &logs)
-	for _, log := range logs {
-		switch {
-		case len(log) >= 4 && log[2] == 0:
-			g.PutStone(log[3])
-		case len(log) == 2:
-			g.PutStone(log[0])
-		}
+	// こないケースは比較不可なので常に desynced=false。ログ parse は
+	// EngineFromGame を再利用して二重実装を避ける (#417 Devin review)。
+	g, err := corereversi.EngineFromGame(game)
+	if err != nil {
+		return c.JSON(http.StatusInternalServerError, apierr.Error("INTERNAL_ERROR", "Internal error.", "5d37dbcb-891e-41ca-a3d6-e690c97775ac"))
 	}
 
 	serverCRC := strconv.FormatUint(uint64(g.CalcCRC32()), 10)

--- a/internal/api/reversi/handler.go
+++ b/internal/api/reversi/handler.go
@@ -3,6 +3,7 @@ package reversi
 import (
 	"encoding/json"
 	"errors"
+	"log/slog"
 	"net/http"
 	"strconv"
 	"strings"
@@ -349,8 +350,13 @@ func (h *Handler) CancelMatch(c echo.Context) error {
 			// ListByUser snapshot 後に相手が ready / start させた場合、
 			// ErrAlreadyStarted で失敗する。その場合は進行中のゲームを
 			// 潰さないよう fedCache の掃除もせず skip する
-			// (#417 Devin review: TOCTOU)。
+			// (#417 Devin review: TOCTOU)。ErrAlreadyStarted 以外の
+			// 想定外エラー (DB障害等) は observability のため WARN する。
 			if err := h.svc.CancelGame(ctx, g.ID, user.ID); err != nil {
+				if !errors.Is(err, corereversi.ErrAlreadyStarted) {
+					slog.Warn("reversi cancel-match: cancel failed",
+						"gameId", g.ID, "userId", user.ID, "err", err)
+				}
 				continue
 			}
 		} else {

--- a/internal/api/reversi/handler.go
+++ b/internal/api/reversi/handler.go
@@ -321,8 +321,16 @@ func (h *Handler) sendJoinForAcceptedInvite(c echo.Context, accepter *model.User
 	if err != nil || inviter == nil || inviter.Host == nil || inviter.URI == nil {
 		return
 	}
-	sessionID, ok := h.fedCache.GetSessionByGame(c.Request().Context(), game.ID)
+	ctx := c.Request().Context()
+	sessionID, ok := h.fedCache.GetSessionByGame(ctx, game.ID)
 	if !ok {
+		return
+	}
+	// show-game 経由で User2 が pending game を表示するたびに呼ばれる
+	// 経路があるため、session ごとに 1 回だけ送るよう guard する
+	// (#417 Devin review)。相手側 (CherryPick) でも zset idempotent なので
+	// 重複しても実害は無いが、無駄な deliver job を抑える。
+	if h.fedCache.IsJoinSent(ctx, sessionID) {
 		return
 	}
 	join := corereversi.RenderJoin(h.baseURL, sessionID,
@@ -331,7 +339,10 @@ func (h *Handler) sendJoinForAcceptedInvite(c echo.Context, accepter *model.User
 	if err != nil {
 		return
 	}
-	_ = h.deliverer.DeliverToUser(accepter.ID, inviter, body)
+	if err := h.deliverer.DeliverToUser(accepter.ID, inviter, body); err != nil {
+		return
+	}
+	h.fedCache.MarkJoinSent(ctx, sessionID)
 }
 
 // CancelMatch handles POST /api/reversi/cancel-match.
@@ -440,10 +451,18 @@ func (h *Handler) Verify(c echo.Context) error {
 	}
 	g := corereversi.NewGame(game.Map, opts)
 
+	// Log shape は EngineFromGame と同じ: misskey-reversi 形式
+	// [timeDelta, player, operation(0=put), pos]。旧 2 要素 [pos, color] は
+	// fallback (新旧両形式を読める)。以前の Verify は log[0] を pos と解釈
+	// していたが、新形式では timeDelta (兆オーダーのミリ秒) を PutStone に
+	// 渡すことになり盤面が崩壊していた (#417 P1 Devin review)。
 	var logs [][]int
 	_ = json.Unmarshal(game.Logs, &logs)
 	for _, log := range logs {
-		if len(log) >= 1 {
+		switch {
+		case len(log) >= 4 && log[2] == 0:
+			g.PutStone(log[3])
+		case len(log) == 2:
 			g.PutStone(log[0])
 		}
 	}

--- a/internal/api/reversi/handler.go
+++ b/internal/api/reversi/handler.go
@@ -131,20 +131,30 @@ func (h *Handler) resolveAcct(acct string) (string, error) {
 }
 
 // Games handles POST /api/reversi/games — list games.
+// CherryPick 本家互換で sinceId / untilId / my の keyset pagination を受ける。
+// my=true (要認証) は自分が User1 or User2 のゲーム、それ以外は isStarted=true
+// のゲームを返す。pagination を無視すると frontend の無限スクロールが同じ
+// ページを繰り返しロードするので必須 (#417 P1 UDS 検証で発覚)。
 func (h *Handler) Games(c echo.Context) error {
 	var req struct {
-		Limit int `json:"limit"`
+		Limit   int    `json:"limit"`
+		SinceID string `json:"sinceId"`
+		UntilID string `json:"untilId"`
+		My      bool   `json:"my"`
 	}
 	_ = c.Bind(&req)
 	if req.Limit <= 0 {
 		req.Limit = 10
 	}
+	if req.Limit > 100 {
+		req.Limit = 100
+	}
 	viewer := middleware.GetUser(c)
 	var games []*model.ReversiGame
-	if viewer != nil {
-		games, _ = h.repo.ListByUser(viewer.ID, req.Limit)
+	if req.My && viewer != nil {
+		games, _ = h.repo.ListByUserCursor(viewer.ID, req.SinceID, req.UntilID, req.Limit)
 	} else {
-		games, _ = h.repo.ListActive()
+		games, _ = h.repo.ListStartedCursor(req.SinceID, req.UntilID, req.Limit)
 	}
 	out := make([]map[string]any, len(games))
 	for i, g := range games {
@@ -154,19 +164,34 @@ func (h *Handler) Games(c echo.Context) error {
 }
 
 // Invitations handles POST /api/reversi/invitations — list pending invitations.
+// レスポンス shape は CherryPick 本家と同じ UserLite[] (招待者一覧)。Game[] を
+// 返すと Misskey フロントエンドの matching UI が期待値と食い違って無限 loading
+// になる (#417 P1 deploy で発覚)。viewer が User2 (招待される側) となっている
+// 未開始 / 未終了 game の User1 を UserLite として返す。
 func (h *Handler) Invitations(c echo.Context) error {
 	user := middleware.GetUser(c)
 	games, _ := h.repo.ListByUser(user.ID, 20)
-	var pending []map[string]any
+	inviters := make([]entity.UserLite, 0)
+	seen := make(map[string]struct{})
 	for _, g := range games {
-		if !g.IsStarted && !g.IsEnded {
-			pending = append(pending, packGame(g, h.idGen))
+		if g.IsStarted || g.IsEnded {
+			continue
 		}
+		// 招待を受けている側 (User2) のみ対象。自分が招待側 (User1) のゲームは
+		// invitations UI の文脈的に表示しない。
+		if g.User2ID != user.ID {
+			continue
+		}
+		if g.User1 == nil {
+			continue
+		}
+		if _, dup := seen[g.User1.ID]; dup {
+			continue
+		}
+		seen[g.User1.ID] = struct{}{}
+		inviters = append(inviters, entity.PackUserLite(g.User1))
 	}
-	if pending == nil {
-		pending = []map[string]any{}
-	}
-	return c.JSON(http.StatusOK, pending)
+	return c.JSON(http.StatusOK, inviters)
 }
 
 // ShowGame handles POST /api/reversi/show-game.
@@ -180,6 +205,15 @@ func (h *Handler) ShowGame(c echo.Context) error {
 	game, err := h.repo.FindByID(req.GameID)
 	if err != nil {
 		return c.JSON(http.StatusNotFound, apierr.Error("NO_SUCH_GAME", "No such game.", "d8a95858-973b-4f3b-8592-fcf2eb4dd044"))
+	}
+	// ユーザーが invitations UI からではなく「自分の対局」一覧などから
+	// pending game に直接入った場合、/match が呼ばれないままなので相手側が
+	// ゲームを作成できない (Join が飛ばない)。viewer が User2 (招待された
+	// 側) で game が pre-start、かつ User1 がリモートなら Join を自動配信
+	// する (#417 P1 UDS 検証で発覚)。deliver は idempotent。
+	viewer := middleware.GetUser(c)
+	if viewer != nil && !game.IsStarted && !game.IsEnded && game.User2ID == viewer.ID {
+		h.sendJoinForAcceptedInvite(c, viewer, game)
 	}
 	return c.JSON(http.StatusOK, packGame(game, h.idGen))
 }
@@ -203,6 +237,19 @@ func (h *Handler) Match(c echo.Context) error {
 			return c.JSON(http.StatusNotFound, apierr.Error("NO_SUCH_USER", "No such user.", "6cc579cc-885d-43d8-95c2-b8c7fc963280"))
 		}
 		req.UserID = resolved
+	}
+
+	// 既に相手から招待を受けている pending game があれば、それを accept 扱いで
+	// 再利用する (#417 P1)。CherryPick 本家の matchSpecificUser と同じ動作:
+	// inbound Invite 経由で作成された reversi_game 行 (User1=相手, User2=自分)
+	// を流用し、相手に Join を返すだけにする。これをやらないと /match が毎回
+	// 新しいゲーム + 新しい session_id を作って二重招待になり、state 伝播が
+	// 噛み合わなくなる。
+	if req.UserID != "" {
+		if existing := h.findPendingInvitationFrom(user.ID, req.UserID); existing != nil {
+			h.sendJoinForAcceptedInvite(c, user, existing)
+			return c.JSON(http.StatusOK, packGame(existing, h.idGen))
+		}
 	}
 
 	now := time.Now()
@@ -240,6 +287,51 @@ func (h *Handler) Match(c echo.Context) error {
 	}
 
 	return c.JSON(http.StatusOK, packGame(game, h.idGen))
+}
+
+// findPendingInvitationFrom scans viewer's recent reversi_game rows and
+// returns the pending game where User1=inviter, User2=viewer, not started / ended.
+// inbound Invite によって作られた受信待ち招待を「ゲーム成立」として消費する
+// ために使う。相手から複数回招待が来ていれば最新のものを選ぶ (ListByUser は
+// id DESC で返る)。
+func (h *Handler) findPendingInvitationFrom(viewerID, inviterID string) *model.ReversiGame {
+	games, err := h.repo.ListByUser(viewerID, 20)
+	if err != nil {
+		return nil
+	}
+	for _, g := range games {
+		if g.IsStarted || g.IsEnded {
+			continue
+		}
+		if g.User1ID == inviterID && g.User2ID == viewerID {
+			return g
+		}
+	}
+	return nil
+}
+
+// sendJoinForAcceptedInvite delivers a Join activity to the remote inviter so
+// both sides agree the match has started. local-only の招待の場合 (User1 が
+// ローカル) は federation 不要なので何もしない。
+func (h *Handler) sendJoinForAcceptedInvite(c echo.Context, accepter *model.User, game *model.ReversiGame) {
+	if h.userRepo == nil || h.deliverer == nil || h.fedCache == nil {
+		return
+	}
+	inviter, err := h.userRepo.FindByID(game.User1ID)
+	if err != nil || inviter == nil || inviter.Host == nil || inviter.URI == nil {
+		return
+	}
+	sessionID, ok := h.fedCache.GetSessionByGame(c.Request().Context(), game.ID)
+	if !ok {
+		return
+	}
+	join := corereversi.RenderJoin(h.baseURL, sessionID,
+		h.baseURL+"/users/"+accepter.ID, *inviter.URI, time.Now().UTC().Format(time.RFC3339))
+	body, err := json.Marshal(join)
+	if err != nil {
+		return
+	}
+	_ = h.deliverer.DeliverToUser(accepter.ID, inviter, body)
 }
 
 // CancelMatch handles POST /api/reversi/cancel-match.
@@ -300,16 +392,10 @@ func (h *Handler) Surrender(c echo.Context) error {
 		_ = h.repo.Update(game)
 	}
 
-	// リモート相手に Leave 送信。federation session は Redis 側にある。
-	if h.fedCache != nil && h.deliverer != nil && h.userRepo != nil {
+	// Leave の送信は Service.Surrender 側で済ませている (#417 P1)。
+	// ここではゲーム終了時に federation mapping を cleanup するだけ。
+	if h.fedCache != nil {
 		if sessionID, ok := h.fedCache.GetSessionByGame(c.Request().Context(), req.GameID); ok {
-			if remoteUser, err := h.userRepo.FindByID(winnerID); err == nil && remoteUser.Host != nil && remoteUser.URI != nil {
-				leave := corereversi.RenderLeave(h.baseURL+"/users/"+user.ID, *remoteUser.URI, sessionID)
-				if body, jerr := json.Marshal(leave); jerr == nil {
-					_ = h.deliverer.DeliverToUser(user.ID, remoteUser, body)
-				}
-			}
-			// ゲーム終了時に mapping を明示削除
 			h.fedCache.Delete(c.Request().Context(), sessionID, req.GameID)
 		}
 	}

--- a/internal/api/reversi/handler.go
+++ b/internal/api/reversi/handler.go
@@ -356,12 +356,8 @@ func (h *Handler) CancelMatch(c echo.Context) error {
 		} else {
 			_ = h.repo.Delete(g.ID)
 		}
-		// 連合 session mapping もあれば明示的に掃除 (CancelGame 成功時のみ)
-		if h.fedCache != nil {
-			if sessionID, ok := h.fedCache.GetSessionByGame(ctx, g.ID); ok {
-				h.fedCache.Delete(ctx, sessionID, g.ID)
-			}
-		}
+		// fedCache 片付けは Service.CancelGame が既に実行済み (#417 Devin
+		// review で全終了経路に統一)。
 	}
 	return c.NoContent(http.StatusNoContent)
 }
@@ -411,14 +407,8 @@ func (h *Handler) Surrender(c echo.Context) error {
 		_ = h.repo.Update(game)
 	}
 
-	// Leave の送信は Service.Surrender 側で済ませている (#417 P1)。
-	// ここではゲーム終了時に federation mapping を cleanup するだけ。
-	if h.fedCache != nil {
-		if sessionID, ok := h.fedCache.GetSessionByGame(c.Request().Context(), req.GameID); ok {
-			h.fedCache.Delete(c.Request().Context(), sessionID, req.GameID)
-		}
-	}
-
+	// Leave 配信 + fedCache cleanup は Service.Surrender が実行済み
+	// (#417 Devin review で全終了経路を Service 側に統一)。
 	return c.NoContent(http.StatusNoContent)
 }
 

--- a/internal/api/reversi/handler.go
+++ b/internal/api/reversi/handler.go
@@ -292,22 +292,9 @@ func (h *Handler) Match(c echo.Context) error {
 // findPendingInvitationFrom scans viewer's recent reversi_game rows and
 // returns the pending game where User1=inviter, User2=viewer, not started / ended.
 // inbound Invite によって作られた受信待ち招待を「ゲーム成立」として消費する
-// ために使う。相手から複数回招待が来ていれば最新のものを選ぶ (ListByUser は
-// id DESC で返る)。
+// ために使う。corereversi.FindPendingInvitation に共有実装。
 func (h *Handler) findPendingInvitationFrom(viewerID, inviterID string) *model.ReversiGame {
-	games, err := h.repo.ListByUser(viewerID, 20)
-	if err != nil {
-		return nil
-	}
-	for _, g := range games {
-		if g.IsStarted || g.IsEnded {
-			continue
-		}
-		if g.User1ID == inviterID && g.User2ID == viewerID {
-			return g
-		}
-	}
-	return nil
+	return corereversi.FindPendingInvitation(h.repo, viewerID, inviterID)
 }
 
 // sendJoinForAcceptedInvite delivers a Join activity to the remote inviter so
@@ -358,11 +345,17 @@ func (h *Handler) CancelMatch(c echo.Context) error {
 			continue
 		}
 		if h.svc != nil {
-			_ = h.svc.CancelGame(ctx, g.ID, user.ID)
+			// ListByUser snapshot 後に相手が ready / start させた場合、
+			// ErrAlreadyStarted で失敗する。その場合は進行中のゲームを
+			// 潰さないよう fedCache の掃除もせず skip する
+			// (#417 Devin review: TOCTOU)。
+			if err := h.svc.CancelGame(ctx, g.ID, user.ID); err != nil {
+				continue
+			}
 		} else {
 			_ = h.repo.Delete(g.ID)
 		}
-		// 連合 session mapping もあれば明示的に掃除
+		// 連合 session mapping もあれば明示的に掃除 (CancelGame 成功時のみ)
 		if h.fedCache != nil {
 			if sessionID, ok := h.fedCache.GetSessionByGame(ctx, g.ID); ok {
 				h.fedCache.Delete(ctx, sessionID, g.ID)

--- a/internal/api/reversi/handler.go
+++ b/internal/api/reversi/handler.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"errors"
 	"net/http"
+	"strconv"
 	"strings"
 	"time"
 
@@ -438,9 +439,13 @@ func surrenderErrorResponse(c echo.Context, err error) error {
 }
 
 // Verify handles POST /api/reversi/verify — verify game integrity.
+// CherryPick 互換: クライアントが送ってくる `crc32` をサーバ側で再計算した
+// ものと比較し、不一致なら `{desynced: true, game}` を返してフロント側で
+// restoreGame を走らせる。一致なら `{desynced: false}` のみ。
 func (h *Handler) Verify(c echo.Context) error {
 	var req struct {
 		GameID string `json:"gameId"`
+		CRC32  string `json:"crc32"`
 	}
 	if err := c.Bind(&req); err != nil || req.GameID == "" {
 		return c.JSON(http.StatusBadRequest, apierr.Error("INVALID_PARAM", "gameId is required.", "ed1d7571-a3ac-4370-899c-0dbe5e230cc8"))
@@ -450,14 +455,15 @@ func (h *Handler) Verify(c echo.Context) error {
 		return c.JSON(http.StatusNotFound, apierr.Error("NO_SUCH_GAME", "No such game.", "d8a95858-973b-4f3b-8592-fcf2eb4dd044"))
 	}
 
-	// ゲームログを再生して検証
+	// ログを再生して engine CRC を算出し、client が送ってきた crc32 と
+	// 比較する。CRC が合わなければ desync 判定。client が crc32 を送って
+	// こないケースは比較不可なので常に desynced=false。
 	opts := corereversi.Options{
 		IsLlotheo:        game.IsLlotheo,
 		CanPutEverywhere: game.CanPutEverywhere,
 		LoopedBoard:      game.LoopedBoard,
 	}
 	g := corereversi.NewGame(game.Map, opts)
-
 	// Log shape は EngineFromGame と同じ: misskey-reversi 形式
 	// [timeDelta, player, operation(0=put), pos]。旧 2 要素 [pos, color] は
 	// fallback (新旧両形式を読める)。以前の Verify は log[0] を pos と解釈
@@ -474,8 +480,11 @@ func (h *Handler) Verify(c echo.Context) error {
 		}
 	}
 
-	return c.JSON(http.StatusOK, map[string]any{
-		"desynced": false,
-		"game":     packGame(game, h.idGen),
-	})
+	serverCRC := strconv.FormatUint(uint64(g.CalcCRC32()), 10)
+	desynced := req.CRC32 != "" && req.CRC32 != serverCRC
+	resp := map[string]any{"desynced": desynced}
+	if desynced {
+		resp["game"] = packGame(game, h.idGen)
+	}
+	return c.JSON(http.StatusOK, resp)
 }

--- a/internal/api/reversi/handler.go
+++ b/internal/api/reversi/handler.go
@@ -346,13 +346,27 @@ func (h *Handler) sendJoinForAcceptedInvite(c echo.Context, accepter *model.User
 }
 
 // CancelMatch handles POST /api/reversi/cancel-match.
+// Service.CancelGame 経由で: Leave をリモート相手に配信 + canceled
+// イベントを WebSocket に publish + fedCache の session mapping も
+// 片付く。svc 未配線な旧テスト互換のため repo.Delete フォールバックも残す。
 func (h *Handler) CancelMatch(c echo.Context) error {
 	user := middleware.GetUser(c)
-	// 未開始のゲームを削除
+	ctx := c.Request().Context()
 	games, _ := h.repo.ListByUser(user.ID, 10)
 	for _, g := range games {
-		if !g.IsStarted && !g.IsEnded {
+		if g.IsStarted || g.IsEnded {
+			continue
+		}
+		if h.svc != nil {
+			_ = h.svc.CancelGame(ctx, g.ID, user.ID)
+		} else {
 			_ = h.repo.Delete(g.ID)
+		}
+		// 連合 session mapping もあれば明示的に掃除
+		if h.fedCache != nil {
+			if sessionID, ok := h.fedCache.GetSessionByGame(ctx, g.ID); ok {
+				h.fedCache.Delete(ctx, sessionID, g.ID)
+			}
 		}
 	}
 	return c.NoContent(http.StatusNoContent)

--- a/internal/api/reversi/handler.go
+++ b/internal/api/reversi/handler.go
@@ -391,12 +391,6 @@ func (h *Handler) Surrender(c echo.Context) error {
 	if game.User1ID != user.ID && game.User2ID != user.ID {
 		return c.JSON(http.StatusForbidden, apierr.Error("ACCESS_DENIED", "Access denied.", "1fb7cb09-d46a-4fff-b8df-057708cce513"))
 	}
-	var winnerID string
-	if game.User1ID == user.ID {
-		winnerID = game.User2ID
-	} else {
-		winnerID = game.User1ID
-	}
 
 	// service が注入されていればそちらを経由する (本来のパス)。
 	// フォールバックは従来の repo 直接操作 (service 未注入の古いテスト互換)。
@@ -405,6 +399,13 @@ func (h *Handler) Surrender(c echo.Context) error {
 			return surrenderErrorResponse(c, err)
 		}
 	} else {
+		// svc 未配線 path は legacy test 互換。winnerID もここで計算する。
+		var winnerID string
+		if game.User1ID == user.ID {
+			winnerID = game.User2ID
+		} else {
+			winnerID = game.User1ID
+		}
 		now := time.Now()
 		game.IsEnded = true
 		game.EndedAt = &now

--- a/internal/api/reversi/handler_test.go
+++ b/internal/api/reversi/handler_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"strconv"
 	"strings"
 	"testing"
 
@@ -415,6 +416,39 @@ func TestVerify_WithLogs(t *testing.T) {
 	repo.games["g1"] = g
 	rec := post(h.Verify, `{"gameId":"g1"}`, nil)
 	assert.Equal(t, http.StatusOK, rec.Code)
+}
+
+// crc32 を送ってサーバ側計算値と比較: 一致で desynced=false
+// (#417 Devin review: Verify が従来 dead code だった)。
+func TestVerify_MatchingCRC(t *testing.T) {
+	h, repo := newTestHandler()
+	repo.games["g1"] = sampleGame()
+	// 空ログの初期状態 CRC を求めるため一度 empty payload で叩いて期待値を
+	// 得てから、その値を client crc32 として返し desynced=false を期待する。
+	g := corereversi.NewGame(sampleGame().Map, corereversi.Options{})
+	expectedCRC := strconv.FormatUint(uint64(g.CalcCRC32()), 10)
+
+	rec := post(h.Verify, `{"gameId":"g1","crc32":"`+expectedCRC+`"}`, nil)
+	assert.Equal(t, http.StatusOK, rec.Code)
+	var resp map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+	assert.Equal(t, false, resp["desynced"])
+	_, hasGame := resp["game"]
+	assert.False(t, hasGame, "同期時は game は返さない")
+}
+
+// crc32 が不一致で desynced=true + game が返る。
+func TestVerify_DivergingCRC(t *testing.T) {
+	h, repo := newTestHandler()
+	repo.games["g1"] = sampleGame()
+
+	rec := post(h.Verify, `{"gameId":"g1","crc32":"999999"}`, nil)
+	assert.Equal(t, http.StatusOK, rec.Code)
+	var resp map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+	assert.Equal(t, true, resp["desynced"])
+	_, hasGame := resp["game"]
+	assert.True(t, hasGame, "desync 時は game を返して restoreGame させる")
 }
 
 // --- Federation ---

--- a/internal/api/reversi/handler_test.go
+++ b/internal/api/reversi/handler_test.go
@@ -61,6 +61,46 @@ func (m *mockReversiRepo) ListByUser(userID string, limit int) ([]*model.Reversi
 	return result, nil
 }
 
+func (m *mockReversiRepo) ListByUserCursor(userID, sinceID, untilID string, limit int) ([]*model.ReversiGame, error) {
+	var result []*model.ReversiGame
+	for _, g := range m.games {
+		if g.User1ID != userID && g.User2ID != userID {
+			continue
+		}
+		if sinceID != "" && g.ID <= sinceID {
+			continue
+		}
+		if untilID != "" && g.ID >= untilID {
+			continue
+		}
+		result = append(result, g)
+	}
+	if limit > 0 && len(result) > limit {
+		result = result[:limit]
+	}
+	return result, nil
+}
+
+func (m *mockReversiRepo) ListStartedCursor(sinceID, untilID string, limit int) ([]*model.ReversiGame, error) {
+	var result []*model.ReversiGame
+	for _, g := range m.games {
+		if !g.IsStarted {
+			continue
+		}
+		if sinceID != "" && g.ID <= sinceID {
+			continue
+		}
+		if untilID != "" && g.ID >= untilID {
+			continue
+		}
+		result = append(result, g)
+	}
+	if limit > 0 && len(result) > limit {
+		result = result[:limit]
+	}
+	return result, nil
+}
+
 func (m *mockReversiRepo) ListActive() ([]*model.ReversiGame, error) {
 	var result []*model.ReversiGame
 	for _, g := range m.games {
@@ -110,26 +150,85 @@ func sampleGame() *model.ReversiGame {
 
 // --- Games ---
 
-func TestGames_WithUser(t *testing.T) {
+// my=true で viewer が関与するゲームのみ返す (CherryPick 互換)。
+func TestGames_MyFlag(t *testing.T) {
 	h, repo := newTestHandler()
 	repo.games["g1"] = sampleGame()
-	rec := post(h.Games, `{}`, u1)
+	rec := post(h.Games, `{"my": true}`, u1)
 	assert.Equal(t, http.StatusOK, rec.Code)
 	var resp []any
 	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
 	assert.Len(t, resp, 1)
 }
 
-func TestGames_Anonymous(t *testing.T) {
+// my=false (デフォルト) は isStarted=true のゲームのみ返す。sampleGame は
+// IsStarted=false なので空配列。
+func TestGames_PublicOnlyStarted(t *testing.T) {
 	h, repo := newTestHandler()
-	repo.games["g1"] = sampleGame()
+	repo.games["g1"] = sampleGame() // IsStarted=false
+	rec := post(h.Games, `{}`, u1)
+	assert.Equal(t, http.StatusOK, rec.Code)
+	var resp []any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+	assert.Len(t, resp, 0)
+}
+
+// started なゲームは my=false でも返る。
+func TestGames_PublicShowsStarted(t *testing.T) {
+	h, repo := newTestHandler()
+	g := sampleGame()
+	g.IsStarted = true
+	repo.games["g1"] = g
 	rec := post(h.Games, `{}`, nil)
 	assert.Equal(t, http.StatusOK, rec.Code)
+	var resp []any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+	assert.Len(t, resp, 1)
+}
+
+// untilId でページング (cursor より古い = id が小さいゲームだけ返す) —
+// 無限ループ防止の核。aidx ID と同じく新しいほど lexicographic で大きい前提。
+func TestGames_UntilIdPagination(t *testing.T) {
+	h, repo := newTestHandler()
+	older := sampleGame()
+	older.ID = "aaa-old"
+	older.IsStarted = true
+	repo.games[older.ID] = older
+	newer := sampleGame()
+	newer.ID = "zzz-new"
+	newer.IsStarted = true
+	repo.games[newer.ID] = newer
+	rec := post(h.Games, `{"untilId":"zzz-new"}`, nil)
+	assert.Equal(t, http.StatusOK, rec.Code)
+	var resp []map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+	require.Len(t, resp, 1)
+	assert.Equal(t, "aaa-old", resp[0]["id"])
 }
 
 // --- Invitations ---
 
+// CherryPick 互換で invitations は UserLite[] (招待者一覧) を返す。viewer が
+// User2 (招待される側) のゲームについてのみ、User1 を UserLite で載せる。
 func TestInvitations_Success(t *testing.T) {
+	h, repo := newTestHandler()
+	g := sampleGame()
+	// sampleGame は User1="u1", User2="u2" なので viewer を u2 にして
+	// u1 を招待者として得るパターンをテストする。
+	g.IsStarted = false
+	repo.games["g1"] = g
+	u2 := &model.User{ID: "u2", Username: "bob"}
+	rec := post(h.Invitations, `{}`, u2)
+	assert.Equal(t, http.StatusOK, rec.Code)
+	var resp []map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+	require.Len(t, resp, 1)
+	assert.Equal(t, "u1", resp[0]["id"])
+	assert.Equal(t, "alice", resp[0]["username"])
+}
+
+// viewer が User1 (招待側) の場合は自分の invitations に出さない。
+func TestInvitations_ViewerIsInviter_ExcludeOwn(t *testing.T) {
 	h, repo := newTestHandler()
 	g := sampleGame()
 	g.IsStarted = false
@@ -138,7 +237,7 @@ func TestInvitations_Success(t *testing.T) {
 	assert.Equal(t, http.StatusOK, rec.Code)
 	var resp []any
 	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
-	assert.Len(t, resp, 1)
+	assert.Len(t, resp, 0)
 }
 
 func TestInvitations_Empty(t *testing.T) {

--- a/internal/core/federation/reversi_inbox.go
+++ b/internal/core/federation/reversi_inbox.go
@@ -134,10 +134,18 @@ func (p *Processor) handleReversiLeave(act genericActivity) error {
 	if err != nil {
 		return fmt.Errorf("reversi leave: game %s gone", gameID)
 	}
+	var svcErr error
 	if game.IsStarted {
-		return p.reversiSvc.Surrender(ctx, game.ID, actor.ID)
+		svcErr = p.reversiSvc.Surrender(ctx, game.ID, actor.ID)
+	} else {
+		svcErr = p.reversiSvc.CancelGame(ctx, game.ID, actor.ID)
 	}
-	return p.reversiSvc.CancelGame(ctx, game.ID, actor.ID)
+	// Service が正常終了したら session mapping を片付ける (#417 Devin review:
+	// 24h TTL で自然消滅するが orphan が残ると Redis がじわじわ溜まる)。
+	if svcErr == nil {
+		p.reversiFedCache.Delete(ctx, state.GameSessionID, game.ID)
+	}
+	return svcErr
 }
 
 // handleReversiUpdate dispatches an Update carrying a reversi Game object.

--- a/internal/core/federation/reversi_inbox.go
+++ b/internal/core/federation/reversi_inbox.go
@@ -45,13 +45,29 @@ func (p *Processor) handleReversiInvite(act genericActivity) error {
 	if toURI == "" {
 		return errors.New("reversi invite: missing recipient")
 	}
-	invitee, err := p.userRepo.FindByURI(toURI)
+	// ローカルユーザーの user.uri は DB 上 NULL なので FindByURI では解決
+	// できない。inbound Follow と同じ resolveTargetUser を使って
+	// `{localBaseURL}/users/{id}` 形式もローカル ID として解決する。
+	invitee, err := p.resolveTargetUser(toURI)
 	if err != nil {
 		return fmt.Errorf("reversi invite: recipient %s not found", toURI)
 	}
 	ctx := context.Background()
 	// 既にこの sessionID に対応する game が Redis に居れば二重処理を防ぐ。
 	if gid, gerr := p.reversiFedCache.Get(ctx, state.GameSessionID); gerr == nil && gid != "" {
+		return nil
+	}
+
+	// CherryPick は fresh session_id で Invite を 5 秒ごと再送するため、
+	// 同じ (inviter, invitee) の pending game があれば session mapping を
+	// 最新に差し替えて再利用する。これが無いと招待ごとに row が増殖する。
+	if existing := findPendingReversiGame(p.reversiRepo, invitee.ID, actor.ID); existing != nil {
+		if oldSession, ok := p.reversiFedCache.GetSessionByGame(ctx, existing.ID); ok && oldSession != state.GameSessionID {
+			p.reversiFedCache.Delete(ctx, oldSession, "")
+		}
+		p.reversiFedCache.Set(ctx, state.GameSessionID, existing.ID)
+		slog.Info("reversi federation: invite session refreshed",
+			"gameId", existing.ID, "session", state.GameSessionID, "inviter", actor.ID, "invitee", invitee.ID)
 		return nil
 	}
 
@@ -71,6 +87,27 @@ func (p *Processor) handleReversiInvite(act genericActivity) error {
 	p.reversiFedCache.Set(ctx, state.GameSessionID, game.ID)
 	slog.Info("reversi federation: accepted invite",
 		"gameId", game.ID, "session", state.GameSessionID, "inviter", actor.ID, "invitee", invitee.ID)
+	return nil
+}
+
+// findPendingReversiGame looks for a pending game (not started / ended)
+// where User1=inviter and User2=invitee. 使うのは handleReversiInvite の
+// 再送 dedup。最新の pending を採用する (ListByUser は id DESC 順)。
+func findPendingReversiGame(repo interface {
+	ListByUser(userID string, limit int) ([]*model.ReversiGame, error)
+}, inviteeID, inviterID string) *model.ReversiGame {
+	games, err := repo.ListByUser(inviteeID, 20)
+	if err != nil {
+		return nil
+	}
+	for _, g := range games {
+		if g.IsStarted || g.IsEnded {
+			continue
+		}
+		if g.User1ID == inviterID && g.User2ID == inviteeID {
+			return g
+		}
+	}
 	return nil
 }
 
@@ -150,6 +187,9 @@ func (p *Processor) handleReversiUpdate(act genericActivity) error {
 	if err != nil {
 		return fmt.Errorf("reversi update: game %s gone", gameID)
 	}
+	slog.Info("reversi inbox: update received",
+		"gameId", game.ID, "session", state.GameSessionID, "actorID", actor.ID, "subtype", state.Type,
+		"readyPtr", state.Ready != nil, "posPtr", state.Pos != nil, "key", state.Key)
 	switch strings.ToLower(state.Type) {
 	case "settings":
 		if state.Key == "" {

--- a/internal/core/federation/reversi_inbox.go
+++ b/internal/core/federation/reversi_inbox.go
@@ -61,7 +61,7 @@ func (p *Processor) handleReversiInvite(act genericActivity) error {
 	// CherryPick は fresh session_id で Invite を 5 秒ごと再送するため、
 	// 同じ (inviter, invitee) の pending game があれば session mapping を
 	// 最新に差し替えて再利用する。これが無いと招待ごとに row が増殖する。
-	if existing := findPendingReversiGame(p.reversiRepo, invitee.ID, actor.ID); existing != nil {
+	if existing := corereversi.FindPendingInvitation(p.reversiRepo, invitee.ID, actor.ID); existing != nil {
 		if oldSession, ok := p.reversiFedCache.GetSessionByGame(ctx, existing.ID); ok && oldSession != state.GameSessionID {
 			p.reversiFedCache.Delete(ctx, oldSession, "")
 		}
@@ -87,27 +87,6 @@ func (p *Processor) handleReversiInvite(act genericActivity) error {
 	p.reversiFedCache.Set(ctx, state.GameSessionID, game.ID)
 	slog.Info("reversi federation: accepted invite",
 		"gameId", game.ID, "session", state.GameSessionID, "inviter", actor.ID, "invitee", invitee.ID)
-	return nil
-}
-
-// findPendingReversiGame looks for a pending game (not started / ended)
-// where User1=inviter and User2=invitee. 使うのは handleReversiInvite の
-// 再送 dedup。最新の pending を採用する (ListByUser は id DESC 順)。
-func findPendingReversiGame(repo interface {
-	ListByUser(userID string, limit int) ([]*model.ReversiGame, error)
-}, inviteeID, inviterID string) *model.ReversiGame {
-	games, err := repo.ListByUser(inviteeID, 20)
-	if err != nil {
-		return nil
-	}
-	for _, g := range games {
-		if g.IsStarted || g.IsEnded {
-			continue
-		}
-		if g.User1ID == inviterID && g.User2ID == inviteeID {
-			return g
-		}
-	}
 	return nil
 }
 

--- a/internal/core/federation/reversi_inbox.go
+++ b/internal/core/federation/reversi_inbox.go
@@ -134,18 +134,12 @@ func (p *Processor) handleReversiLeave(act genericActivity) error {
 	if err != nil {
 		return fmt.Errorf("reversi leave: game %s gone", gameID)
 	}
-	var svcErr error
+	// Service.Surrender / CancelGame が fedCache cleanup も担う
+	// (#417 Devin review で全終了経路を Service 側に統一)。
 	if game.IsStarted {
-		svcErr = p.reversiSvc.Surrender(ctx, game.ID, actor.ID)
-	} else {
-		svcErr = p.reversiSvc.CancelGame(ctx, game.ID, actor.ID)
+		return p.reversiSvc.Surrender(ctx, game.ID, actor.ID)
 	}
-	// Service が正常終了したら session mapping を片付ける (#417 Devin review:
-	// 24h TTL で自然消滅するが orphan が残ると Redis がじわじわ溜まる)。
-	if svcErr == nil {
-		p.reversiFedCache.Delete(ctx, state.GameSessionID, game.ID)
-	}
-	return svcErr
+	return p.reversiSvc.CancelGame(ctx, game.ID, actor.ID)
 }
 
 // handleReversiUpdate dispatches an Update carrying a reversi Game object.

--- a/internal/core/federation/reversi_inbox_test.go
+++ b/internal/core/federation/reversi_inbox_test.go
@@ -147,6 +147,9 @@ func newReversiProcessor(t *testing.T) *reversiFedBundle {
 	fedCache := corereversi.NewFederationIDCache(fedTestRedis.Client)
 	gameRepo := newFedFakeReversiRepo()
 	reversiSvc := corereversi.NewService(gameRepo, nil, fedTestRedis.Client)
+	// Service 側にも fedCache を配線 (プロダクション router.go と同じ)。
+	// Surrender/CancelGame/PutStone 終了時の cleanupFedCache が有効になる。
+	reversiSvc.SetFederationCache(fedCache)
 	processor.SetReversi(reversiSvc, gameRepo, idGen, fedCache)
 
 	return &reversiFedBundle{

--- a/internal/core/federation/reversi_inbox_test.go
+++ b/internal/core/federation/reversi_inbox_test.go
@@ -418,11 +418,16 @@ func TestReversiInbox_Leave_StartedSurrenders(t *testing.T) {
 	}`)
 	require.NoError(t, b.processor.Process(body))
 
-	g := b.gameRepo.findGameBySession(t, b.fedCache, "sess-leave-started")
-	require.NotNil(t, g)
+	// ゲーム行は IsEnded で残る。fedCache 側の session mapping は Surrender
+	// 成功時に削除される (#417 Devin review: orphan mapping 掃除)。
+	g, err := b.gameRepo.FindByID("fedg-sess-leave-started")
+	require.NoError(t, err)
 	assert.True(t, g.IsEnded)
 	require.NotNil(t, g.WinnerID)
 	assert.Equal(t, "bob", *g.WinnerID)
+	// session mapping は片付けられている
+	_, cacheErr := b.fedCache.Get(context.Background(), "sess-leave-started")
+	assert.Error(t, cacheErr, "session mapping must be cleaned up after Leave")
 }
 
 func TestReversiInbox_Leave_UnknownSession(t *testing.T) {

--- a/internal/core/federation/reversi_inbox_test.go
+++ b/internal/core/federation/reversi_inbox_test.go
@@ -74,7 +74,22 @@ func (r *fedFakeReversiRepo) Update(g *model.ReversiGame) error {
 	return nil
 }
 
-func (r *fedFakeReversiRepo) ListByUser(_ string, _ int) ([]*model.ReversiGame, error) {
+func (r *fedFakeReversiRepo) ListByUser(userID string, _ int) ([]*model.ReversiGame, error) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	out := make([]*model.ReversiGame, 0)
+	for _, g := range r.games {
+		if g.User1ID == userID || g.User2ID == userID {
+			clone := *g
+			out = append(out, &clone)
+		}
+	}
+	return out, nil
+}
+func (r *fedFakeReversiRepo) ListByUserCursor(_, _, _ string, _ int) ([]*model.ReversiGame, error) {
+	return nil, nil
+}
+func (r *fedFakeReversiRepo) ListStartedCursor(_, _ string, _ int) ([]*model.ReversiGame, error) {
 	return nil, nil
 }
 func (r *fedFakeReversiRepo) ListActive() ([]*model.ReversiGame, error) { return nil, nil }
@@ -211,6 +226,43 @@ func TestReversiInbox_Invite_CreatesGame(t *testing.T) {
 	assert.Equal(t, "bob", g.User2ID)
 }
 
+// CherryPick は ack が返らないと fresh session_id で Invite を 5 秒ごと再送
+// する。同じ (inviter, invitee) の pending game は 1 つに集約し、最新の
+// session_id に mapping を差し替える必要がある (#417 P1 UDS で発覚した増殖)。
+func TestReversiInbox_Invite_RetryWithNewSessionReusesPendingGame(t *testing.T) {
+	b := newReversiProcessor(t)
+	registerLocalBob(t, b.userRepo)
+	send := func(sessionID string) {
+		body := []byte(`{
+			"type": "Invite",
+			"actor": "https://remote.example/users/alice",
+			"to": "https://example.com/users/bob",
+			"object": {
+				"type": "Game",
+				"game_type_uuid": "1c086295-25e3-4b82-b31e-3e3959906312",
+				"game_state": {"game_session_id": "` + sessionID + `"}
+			}
+		}`)
+		require.NoError(t, b.processor.Process(body))
+	}
+
+	send("sess-retry-1")
+	send("sess-retry-2")
+	send("sess-retry-3")
+
+	// ゲームは 1 件のまま (dedup)
+	assert.Len(t, b.gameRepo.games, 1)
+
+	// 最新の session にだけ mapping が残っている
+	latestGameID, err := b.fedCache.Get(context.Background(), "sess-retry-3")
+	require.NoError(t, err)
+	assert.NotEmpty(t, latestGameID)
+
+	// 古い session は削除されている
+	_, err = b.fedCache.Get(context.Background(), "sess-retry-1")
+	assert.Error(t, err, "old session mapping must be cleaned up")
+}
+
 func TestReversiInbox_Invite_IdempotentOnResend(t *testing.T) {
 	b := newReversiProcessor(t)
 	registerLocalBob(t, b.userRepo)
@@ -241,6 +293,33 @@ func TestReversiInbox_Invite_MissingRecipient(t *testing.T) {
 		}
 	}`)
 	assert.Error(t, b.processor.Process(body))
+}
+
+// プロダクション DB の local user は user.uri が NULL なので、inbound Invite
+// の `to` が "{localBaseURL}/users/{id}" 形式のときは resolveTargetUser 経由で
+// ID から引く必要がある (FindByURI 直だと NULL 列とは match しないため)。
+// #417 P1 deploy で "recipient ... not found" エラーが出た regression を防ぐ。
+func TestReversiInbox_Invite_RecipientLocalWithoutURI(t *testing.T) {
+	b := newReversiProcessor(t)
+	b.processor.SetLocalBaseURL("https://example.com")
+	// local user は URI 未設定 (プロダクション挙動)
+	b.userRepo.Users["localbob"] = &model.User{
+		ID: "localbob", Username: "localbob", UsernameLower: "localbob",
+	}
+	body := []byte(`{
+		"type": "Invite",
+		"actor": "https://remote.example/users/alice",
+		"to": "https://example.com/users/localbob",
+		"object": {
+			"type": "Game",
+			"game_type_uuid": "1c086295-25e3-4b82-b31e-3e3959906312",
+			"game_state": {"game_session_id": "sess-local-noURI"}
+		}
+	}`)
+	require.NoError(t, b.processor.Process(body))
+	g := b.gameRepo.findGameBySession(t, b.fedCache, "sess-local-noURI")
+	require.NotNil(t, g)
+	assert.Equal(t, "localbob", g.User2ID)
 }
 
 func TestReversiInbox_Invite_RecipientNotLocal(t *testing.T) {

--- a/internal/core/reversi/coverage_boost_test.go
+++ b/internal/core/reversi/coverage_boost_test.go
@@ -272,7 +272,7 @@ func TestApplySetting_BadJSONPerKey(t *testing.T) {
 func TestPickBlack_RandomSamples(t *testing.T) {
 	seenOne, seenTwo := false, false
 	for range 1000 {
-		v := pickBlack("random")
+		v := pickBlack("random", "")
 		if v == 1 {
 			seenOne = true
 		} else if v == 2 {

--- a/internal/core/reversi/federation.go
+++ b/internal/core/reversi/federation.go
@@ -1,5 +1,7 @@
 package reversi
 
+import "github.com/google/uuid"
+
 // GameTypeUUID is the unique identifier for the reversi game type in ActivityPub.
 // CherryPick互換の固定UUID。
 const GameTypeUUID = "1c086295-25e3-4b82-b31e-3e3959906312"
@@ -36,6 +38,7 @@ func NewAPGame(sessionID string) APGame {
 
 // APActivity represents a generic ActivityPub activity for reversi.
 type APActivity struct {
+	Context   any      `json:"@context,omitempty"`
 	ID        string   `json:"id,omitempty"`
 	Type      string   `json:"type"`
 	Actor     string   `json:"actor"`
@@ -45,10 +48,38 @@ type APActivity struct {
 	Published string   `json:"published,omitempty"`
 }
 
+// defaultContext は activitypub パッケージが activity 一般に付けるのと同じ
+// JSON-LD @context。CherryPick の inbox はこれが無い reversi activity を
+// 弾く可能性があるため Render 時に必ず埋める (#417 P1)。
+var defaultContext = []any{
+	"https://www.w3.org/ns/activitystreams",
+	"https://w3id.org/security/v1",
+	map[string]any{
+		"Key":               "sec:Key",
+		"sensitive":         "as:sensitive",
+		"Hashtag":           "as:Hashtag",
+		"quoteUrl":          "as:quoteUrl",
+		"toot":              "http://joinmastodon.org/ns#",
+		"Emoji":             "toot:Emoji",
+		"featured":          "toot:featured",
+		"discoverable":      "toot:discoverable",
+		"schema":            "http://schema.org#",
+		"PropertyValue":     "schema:PropertyValue",
+		"value":             "schema:value",
+		"misskey":           "https://misskey-hub.net/ns#",
+		"_misskey_content":  "misskey:_misskey_content",
+		"_misskey_quote":    "misskey:_misskey_quote",
+		"_misskey_reaction": "misskey:_misskey_reaction",
+		"_misskey_votes":    "misskey:_misskey_votes",
+		"isCat":             "misskey:isCat",
+	},
+}
+
 // RenderInvite creates an Invite activity for a reversi game.
 func RenderInvite(baseURL, sessionID, actorURI, targetURI string, published string) APActivity {
 	game := NewAPGame(sessionID)
 	return APActivity{
+		Context:   defaultContext,
 		ID:        baseURL + "/games/" + GameTypeUUID + "/" + sessionID + "/activity",
 		Type:      "Invite",
 		Actor:     actorURI,
@@ -63,6 +94,7 @@ func RenderInvite(baseURL, sessionID, actorURI, targetURI string, published stri
 func RenderJoin(baseURL, sessionID, actorURI, targetURI string, published string) APActivity {
 	game := NewAPGame(sessionID)
 	return APActivity{
+		Context:   defaultContext,
 		ID:        baseURL + "/games/" + GameTypeUUID + "/" + sessionID + "/activity",
 		Type:      "Join",
 		Actor:     actorURI,
@@ -73,8 +105,17 @@ func RenderJoin(baseURL, sessionID, actorURI, targetURI string, published string
 	}
 }
 
+// activityID builds a per-activity id so that CherryPick's
+// InboxProcessorService does not silent-drop the payload. 同じ actor が複数
+// 回 Update/Leave/Undo を送るので session id ベースの決定的 id は衝突する。
+// 本家 addContext と同じくランダム UUID ベースにする。
+func activityID(baseURL string) string {
+	return baseURL + "/activities/" + uuid.NewString()
+}
+
 // RenderUpdate creates an Update activity for game state changes.
-func RenderUpdate(actorURI, targetURI string, state APGameState) APActivity {
+// baseURL はローカルインスタンスのベース URL (id フィールド生成用)。
+func RenderUpdate(baseURL, actorURI, targetURI string, state APGameState) APActivity {
 	game := APGame{
 		Type:         "Game",
 		GameTypeUUID: GameTypeUUID,
@@ -82,32 +123,38 @@ func RenderUpdate(actorURI, targetURI string, state APGameState) APActivity {
 		GameState:    state,
 	}
 	return APActivity{
-		Type:   "Update",
-		Actor:  actorURI,
-		Object: game,
-		To:     targetURI,
-		CC:     []string{},
+		Context: defaultContext,
+		ID:      activityID(baseURL),
+		Type:    "Update",
+		Actor:   actorURI,
+		Object:  game,
+		To:      targetURI,
+		CC:      []string{},
 	}
 }
 
 // RenderLeave creates a Leave activity for surrendering or cancelling.
-func RenderLeave(actorURI, targetURI string, sessionID string) APActivity {
+func RenderLeave(baseURL, actorURI, targetURI, sessionID string) APActivity {
 	game := NewAPGame(sessionID)
 	return APActivity{
-		Type:   "Leave",
-		Actor:  actorURI,
-		Object: game,
-		To:     targetURI,
-		CC:     []string{},
+		Context: defaultContext,
+		ID:      activityID(baseURL),
+		Type:    "Leave",
+		Actor:   actorURI,
+		Object:  game,
+		To:      targetURI,
+		CC:      []string{},
 	}
 }
 
 // RenderUndo creates an Undo activity wrapping another activity.
-func RenderUndo(actorURI string, original APActivity) APActivity {
+func RenderUndo(baseURL, actorURI string, original APActivity) APActivity {
 	return APActivity{
-		Type:   "Undo",
-		Actor:  actorURI,
-		Object: original,
+		Context: defaultContext,
+		ID:      activityID(baseURL),
+		Type:    "Undo",
+		Actor:   actorURI,
+		Object:  original,
 	}
 }
 

--- a/internal/core/reversi/federation.go
+++ b/internal/core/reversi/federation.go
@@ -1,6 +1,36 @@
 package reversi
 
-import "github.com/google/uuid"
+import (
+	"github.com/google/uuid"
+	"github.com/shiroha-a/mk/internal/model"
+)
+
+// PendingGameLookup is the minimal interface for finding a pending reversi
+// game between two users. repository.ReversiRepository がそのまま満たす。
+type PendingGameLookup interface {
+	ListByUser(userID string, limit int) ([]*model.ReversiGame, error)
+}
+
+// FindPendingInvitation returns the latest pending (not started / ended)
+// reversi_game row where User1=inviterID and User2=inviteeID. 招待の受諾
+// (/api/reversi/match) 経路と、連合経路 (handleReversiInvite の 5 秒再送
+// dedup) の両方から使う共有ヘルパー。ListByUser は id DESC なので最初に
+// ヒットしたものを返すだけで最新が取れる。
+func FindPendingInvitation(repo PendingGameLookup, inviteeID, inviterID string) *model.ReversiGame {
+	games, err := repo.ListByUser(inviteeID, 20)
+	if err != nil {
+		return nil
+	}
+	for _, g := range games {
+		if g.IsStarted || g.IsEnded {
+			continue
+		}
+		if g.User1ID == inviterID && g.User2ID == inviteeID {
+			return g
+		}
+	}
+	return nil
+}
 
 // GameTypeUUID is the unique identifier for the reversi game type in ActivityPub.
 // CherryPick互換の固定UUID。

--- a/internal/core/reversi/federation_test.go
+++ b/internal/core/reversi/federation_test.go
@@ -38,8 +38,9 @@ func TestRenderUpdate(t *testing.T) {
 		Type:          "putstone",
 		Pos:           &pos,
 	}
-	a := RenderUpdate("https://example.com/users/alice", "https://remote.example/users/bob", state)
+	a := RenderUpdate("https://example.com", "https://example.com/users/alice", "https://remote.example/users/bob", state)
 	assert.Equal(t, "Update", a.Type)
+	assert.NotEmpty(t, a.ID, "Update activity must carry id (#417 InboxProcessor requirement)")
 	game, ok := a.Object.(APGame)
 	require.True(t, ok)
 	assert.Equal(t, "putstone", game.GameState.Type)
@@ -47,14 +48,16 @@ func TestRenderUpdate(t *testing.T) {
 }
 
 func TestRenderLeave(t *testing.T) {
-	a := RenderLeave("https://example.com/users/alice", "https://remote.example/users/bob", "sess1")
+	a := RenderLeave("https://example.com", "https://example.com/users/alice", "https://remote.example/users/bob", "sess1")
 	assert.Equal(t, "Leave", a.Type)
+	assert.NotEmpty(t, a.ID, "Leave activity must carry id")
 }
 
 func TestRenderUndo(t *testing.T) {
 	invite := RenderInvite("https://example.com", "sess1", "actor", "target", "2026-01-01T00:00:00Z")
-	undo := RenderUndo("actor", invite)
+	undo := RenderUndo("https://example.com", "actor", invite)
 	assert.Equal(t, "Undo", undo.Type)
+	assert.NotEmpty(t, undo.ID, "Undo activity must carry id")
 }
 
 func TestIsReversiGame(t *testing.T) {

--- a/internal/core/reversi/service.go
+++ b/internal/core/reversi/service.go
@@ -538,18 +538,20 @@ func (s *Service) PutStone(ctx context.Context, gameID, userID string, pos int) 
 			"winnerId": game.WinnerID,
 			"game":     packGame(game),
 		})
-		// ゲーム自然終了 (投了・キャンセル以外の勝敗確定) でも federation
-		// session mapping を片付ける。24h TTL で自然消滅するが orphan が
-		// じわじわ積まれるのを避ける (#417 Devin review)。
-		s.cleanupFedCache(ctx, game.ID)
 	}
 	// 連合対戦の場合は putstone Update を相手に配信 (#417 P1)。ゲーム終了
 	// (engine.Turn == nil) でも相手側で同じ engine を回すため最後の手を送る。
+	// fedCache 参照に session mapping が必要なので、必ず配信後に cleanup する
+	// (#417 Devin review: 逆順だと mapping が既に消えていて deliver が skip
+	// されていた)。
 	posVal := pos
 	s.deliverStateToOpponent(ctx, game, userID, APGameState{
 		Type: "putstone",
 		Pos:  &posVal,
 	})
+	if engine.Turn == nil {
+		s.cleanupFedCache(ctx, game.ID)
+	}
 	return nil
 }
 

--- a/internal/core/reversi/service.go
+++ b/internal/core/reversi/service.go
@@ -396,12 +396,14 @@ func (s *Service) CancelGame(ctx context.Context, gameID, userID string) error {
 	if !isPlayer(game, userID) {
 		return ErrNotPlayer
 	}
-	// Leave の配信は Delete 前に行う (Delete で fedCache も後段で cleanup
-	// されるため、配信に必要な session マッピングが残っているうちに送る)。
+	// Leave の配信は Delete 前に行う (配信に必要な session マッピングが
+	// 残っているうちに送る)。成功後に fedCache も片付ける (#417 Devin
+	// review で全終了経路に統一)。
 	s.deliverLeaveToOpponent(ctx, game, userID)
 	if err := s.repo.Delete(gameID); err != nil {
 		return err
 	}
+	s.cleanupFedCache(ctx, gameID)
 	s.publish(gameID, "canceled", map[string]any{"userId": userID})
 	return nil
 }
@@ -536,6 +538,10 @@ func (s *Service) PutStone(ctx context.Context, gameID, userID string, pos int) 
 			"winnerId": game.WinnerID,
 			"game":     packGame(game),
 		})
+		// ゲーム自然終了 (投了・キャンセル以外の勝敗確定) でも federation
+		// session mapping を片付ける。24h TTL で自然消滅するが orphan が
+		// じわじわ積まれるのを避ける (#417 Devin review)。
+		s.cleanupFedCache(ctx, game.ID)
 	}
 	// 連合対戦の場合は putstone Update を相手に配信 (#417 P1)。ゲーム終了
 	// (engine.Turn == nil) でも相手側で同じ engine を回すため最後の手を送る。
@@ -545,6 +551,19 @@ func (s *Service) PutStone(ctx context.Context, gameID, userID string, pos int) 
 		Pos:  &posVal,
 	})
 	return nil
+}
+
+// cleanupFedCache removes the federation session mapping for a terminated
+// game。ゲーム終了 / キャンセル時にすべての経路 (PutStone 自然終了 /
+// Surrender / CancelGame / CheckTimeout) から呼び出して Redis の mapping
+// が 24h TTL で残り続けるのを防ぐ。
+func (s *Service) cleanupFedCache(ctx context.Context, gameID string) {
+	if s.fedCache == nil {
+		return
+	}
+	if sessionID, ok := s.fedCache.GetSessionByGame(ctx, gameID); ok {
+		s.fedCache.Delete(ctx, sessionID, gameID)
+	}
 }
 
 // Surrender marks the opposing user as the winner and ends the game.
@@ -578,8 +597,10 @@ func (s *Service) Surrender(ctx context.Context, gameID, userID string) error {
 		"reason":   "surrender",
 		"game":     packGame(game),
 	})
-	// 連合対戦の場合は Leave を相手に配信 (#417 P1)。
+	// 連合対戦の場合は Leave を相手に配信 (#417 P1)。配信後に fedCache を
+	// 片付ける (session mapping 参照が Leave 配信側に必要)。
 	s.deliverLeaveToOpponent(ctx, game, userID)
+	s.cleanupFedCache(ctx, gameID)
 	return nil
 }
 
@@ -631,6 +652,7 @@ func (s *Service) CheckTimeout(ctx context.Context, gameID string) error {
 		"reason":   "timeout",
 		"game":     packGame(game),
 	})
+	s.cleanupFedCache(ctx, gameID)
 	return nil
 }
 

--- a/internal/core/reversi/service.go
+++ b/internal/core/reversi/service.go
@@ -5,11 +5,13 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"log/slog"
 	"math/rand"
 	"strconv"
 	"time"
 
 	"github.com/redis/go-redis/v9"
+	"github.com/shiroha-a/mk/internal/entity"
 	"github.com/shiroha-a/mk/internal/model"
 	"github.com/shiroha-a/mk/internal/repository"
 )
@@ -131,6 +133,21 @@ type GamePublisher interface {
 	PublishGameEvent(gameID, eventType string, body any)
 }
 
+// FederationDeliverer is the minimal interface used by the Service to send AP
+// activities to a remote opponent when state changes (UpdateReady /
+// UpdateSettings / PutStone / CancelGame / Surrender)。循環依存を避けるため
+// interface で受ける (実装は core/federation.DeliverService)。
+type FederationDeliverer interface {
+	DeliverToUser(signerUserID string, recipient *model.User, body []byte) error
+}
+
+// UserLookup is the minimal interface used by the Service to resolve the
+// opposing player during federation delivery. repository.UserRepository が
+// そのまま満たすので実体実装の追加は不要。
+type UserLookup interface {
+	FindByID(id string) (*model.User, error)
+}
+
 // --- Core service ---
 
 // Service manages reversi game state transitions and publishes updates to
@@ -140,6 +157,11 @@ type Service struct {
 	publisher GamePublisher
 	redis     redis.Cmdable
 	fedCache  *FederationIDCache
+	// Federation delivery (#417)。未設定時は state 変化時の outbound を何も
+	// 送らない = ローカル同士の対戦や非連合セッションではそもそも deliver 不要。
+	deliverer FederationDeliverer
+	userRepo  UserLookup
+	baseURL   string
 }
 
 // NewService constructs a Service with the required dependencies.
@@ -155,6 +177,93 @@ func NewService(
 // Invite/Join/Leave messages can resolve the game id.
 func (s *Service) SetFederationCache(c *FederationIDCache) {
 	s.fedCache = c
+}
+
+// SetFederationDeliverer attaches a deliverer used to push reversi Update /
+// Leave activities to a remote opponent on state changes (#417 P1)。deliverer
+// が nil のときは連合外 Service として動作する (既存互換)。
+func (s *Service) SetFederationDeliverer(d FederationDeliverer) {
+	s.deliverer = d
+}
+
+// SetUserRepo attaches a user lookup used by federation delivery to resolve
+// actor / opponent Host / URI。
+func (s *Service) SetUserRepo(r UserLookup) {
+	s.userRepo = r
+}
+
+// SetBaseURL records the local instance base URL (https://<host>) used to
+// build actor URIs in outbound Reversi activities.
+func (s *Service) SetBaseURL(u string) {
+	s.baseURL = u
+}
+
+// deliverStateToOpponent renders an Update(Game) activity for the state change
+// and delivers it to the remote opponent when federation is wired and the
+// opponent is actually remote。
+//
+// actor が remote のとき (inbox 受信経由で Service を呼んだケース) は、相手に
+// echo back しないよう skip する。CherryPick は同じ guard を ApGameService 側
+// で effectively 入れているが、mk-go では Service 内部で判定して呼び出し元を
+// 軽くしている。
+func (s *Service) deliverStateToOpponent(ctx context.Context, game *model.ReversiGame, actorUserID string, state APGameState) {
+	if s.deliverer == nil || s.userRepo == nil || s.fedCache == nil || s.baseURL == "" {
+		slog.Info("reversi deliver: skipped (unwired)", "gameId", game.ID, "type", state.Type,
+			"deliverer", s.deliverer != nil, "userRepo", s.userRepo != nil, "fedCache", s.fedCache != nil, "baseURL", s.baseURL)
+		return
+	}
+	actor, err := s.userRepo.FindByID(actorUserID)
+	if err != nil || actor == nil || actor.Host != nil {
+		slog.Info("reversi deliver: skipped (actor issue)", "gameId", game.ID, "actorID", actorUserID, "err", err)
+		return
+	}
+	oppID := opponent(game, actorUserID)
+	opp, err := s.userRepo.FindByID(oppID)
+	if err != nil || opp == nil || opp.Host == nil || opp.URI == nil {
+		slog.Info("reversi deliver: skipped (opponent not remote)", "gameId", game.ID, "oppID", oppID,
+			"found", opp != nil, "host", opp != nil && opp.Host != nil, "uri", opp != nil && opp.URI != nil)
+		return
+	}
+	sessionID, ok := s.fedCache.GetSessionByGame(ctx, game.ID)
+	if !ok {
+		slog.Info("reversi deliver: skipped (no session)", "gameId", game.ID)
+		return
+	}
+	state.GameSessionID = sessionID
+	activity := RenderUpdate(s.baseURL, s.baseURL+"/users/"+actor.ID, *opp.URI, state)
+	body, err := json.Marshal(activity)
+	if err != nil {
+		return
+	}
+	slog.Info("reversi deliver: sending update", "gameId", game.ID, "type", state.Type, "session", sessionID, "to", oppID)
+	_ = s.deliverer.DeliverToUser(actor.ID, opp, body)
+}
+
+// deliverLeaveToOpponent renders a Leave(Game) activity and delivers it to
+// the remote opponent on Surrender / CancelGame by a local player。
+func (s *Service) deliverLeaveToOpponent(ctx context.Context, game *model.ReversiGame, actorUserID string) {
+	if s.deliverer == nil || s.userRepo == nil || s.fedCache == nil || s.baseURL == "" {
+		return
+	}
+	actor, err := s.userRepo.FindByID(actorUserID)
+	if err != nil || actor == nil || actor.Host != nil {
+		return
+	}
+	oppID := opponent(game, actorUserID)
+	opp, err := s.userRepo.FindByID(oppID)
+	if err != nil || opp == nil || opp.Host == nil || opp.URI == nil {
+		return
+	}
+	sessionID, ok := s.fedCache.GetSessionByGame(ctx, game.ID)
+	if !ok {
+		return
+	}
+	activity := RenderLeave(s.baseURL, s.baseURL+"/users/"+actor.ID, *opp.URI, sessionID)
+	body, err := json.Marshal(activity)
+	if err != nil {
+		return
+	}
+	_ = s.deliverer.DeliverToUser(actor.ID, opp, body)
 }
 
 // --- Queries ---
@@ -198,6 +307,12 @@ func (s *Service) UpdateReady(ctx context.Context, gameID, userID string, ready 
 		"user1": game.User1Ready,
 		"user2": game.User2Ready,
 	})
+	// 連合対戦の場合は ready_states Update を相手に配信 (#417 P1)。
+	readyVal := ready
+	s.deliverStateToOpponent(ctx, game, userID, APGameState{
+		Type:  "ready_states",
+		Ready: &readyVal,
+	})
 	if game.User1Ready && game.User2Ready {
 		return s.StartGame(ctx, game)
 	}
@@ -239,6 +354,12 @@ func (s *Service) UpdateSettings(ctx context.Context, gameID, userID, key string
 	s.publish(gameID, "changeReadyStates", map[string]any{
 		"user1": false, "user2": false,
 	})
+	// 連合対戦の場合は settings Update を相手に配信 (#417 P1)。
+	s.deliverStateToOpponent(ctx, game, userID, APGameState{
+		Type:  "settings",
+		Key:   key,
+		Value: valueAny,
+	})
 	return nil
 }
 
@@ -255,6 +376,9 @@ func (s *Service) CancelGame(ctx context.Context, gameID, userID string) error {
 	if !isPlayer(game, userID) {
 		return ErrNotPlayer
 	}
+	// Leave の配信は Delete 前に行う (Delete で fedCache も後段で cleanup
+	// されるため、配信に必要な session マッピングが残っているうちに送る)。
+	s.deliverLeaveToOpponent(ctx, game, userID)
 	if err := s.repo.Delete(gameID); err != nil {
 		return err
 	}
@@ -275,7 +399,15 @@ func (s *Service) StartGame(ctx context.Context, game *model.ReversiGame) error 
 		return ErrAlreadyEnded
 	}
 
-	black := pickBlack(game.BW)
+	// 連合対戦の場合は session id から決定論的に black を算出する
+	// (両サイドで同じ値になる必要がある)。CherryPick startGame と一致。
+	sessionID := ""
+	if s.fedCache != nil {
+		if sid, ok := s.fedCache.GetSessionByGame(ctx, game.ID); ok {
+			sessionID = sid
+		}
+	}
+	black := pickBlack(game.BW, sessionID)
 	game.Black = &black
 	game.IsStarted = true
 	now := time.Now()
@@ -324,16 +456,39 @@ func (s *Service) PutStone(ctx context.Context, gameID, userID string, pos int) 
 	}
 	engine.PutStone(pos)
 
-	// logs: [[pos, color], ...]
+	// logs format は misskey-reversi の SerializedLog と一致させる:
+	// [timeDelta, player(0|1), operation(0=put), pos]。フロントエンドの
+	// Reversi.Serializer.deserializeLogs がこの shape を要求するため、他の
+	// 形式だと restoreGame が空の engine を返し盤面が消える (#417 P1 UDS
+	// 検証で発覚)。player は Black=1 / White=0。operation は put のみ。
 	var logs [][]int
 	if len(game.Logs) > 0 {
 		_ = json.Unmarshal(game.Logs, &logs)
+	}
+	now := time.Now().UnixMilli()
+	var timeDelta int64
+	if len(logs) == 0 {
+		timeDelta = now
+	} else {
+		// CherryPick: timeDelta = log.time - logs[i-1].time。過去の
+		// timeDelta を全部積み上げれば前回 log の絶対時刻になる。
+		var prevTotal int64
+		for _, e := range logs {
+			if len(e) > 0 {
+				prevTotal += int64(e[0])
+			}
+		}
+		timeDelta = now - prevTotal
+	}
+	playerInt := 0
+	if myColor { // true == Black
+		playerInt = 1
 	}
 	colorInt := 1
 	if !myColor {
 		colorInt = 2
 	}
-	logs = append(logs, []int{pos, colorInt})
+	logs = append(logs, []int{int(timeDelta), playerInt, 0, pos})
 	raw, _ := json.Marshal(logs)
 	game.Logs = raw
 
@@ -362,6 +517,13 @@ func (s *Service) PutStone(ctx context.Context, gameID, userID string, pos int) 
 			"game":     packGame(game),
 		})
 	}
+	// 連合対戦の場合は putstone Update を相手に配信 (#417 P1)。ゲーム終了
+	// (engine.Turn == nil) でも相手側で同じ engine を回すため最後の手を送る。
+	posVal := pos
+	s.deliverStateToOpponent(ctx, game, userID, APGameState{
+		Type: "putstone",
+		Pos:  &posVal,
+	})
 	return nil
 }
 
@@ -396,6 +558,8 @@ func (s *Service) Surrender(ctx context.Context, gameID, userID string) error {
 		"reason":   "surrender",
 		"game":     packGame(game),
 	})
+	// 連合対戦の場合は Leave を相手に配信 (#417 P1)。
+	s.deliverLeaveToOpponent(ctx, game, userID)
 	return nil
 }
 
@@ -552,8 +716,11 @@ func colorFromBool(black bool) Color {
 	return White
 }
 
-// pickBlack returns 1 or 2 per the BW setting, defaulting to random.
-func pickBlack(bw string) int {
+// pickBlack returns 1 or 2 per the BW setting. For federated games
+// (sessionID != ""), bw == "random" を session id の先頭コードポイントから
+// 決定論的に導く (CherryPick startGame と一致させて両サイドで同じ bw を
+// 得るため)。ローカル対戦では従来通り rand.Intn を使う。
+func pickBlack(bw, sessionID string) int {
 	switch bw {
 	case "1":
 		return 1
@@ -561,6 +728,18 @@ func pickBlack(bw string) int {
 		return 2
 	}
 	// "random" など
+	if sessionID != "" {
+		// CherryPick: codePointAt(0) % 2 === 0 ? 1 : 2
+		var cp rune
+		for _, r := range sessionID {
+			cp = r
+			break
+		}
+		if cp%2 == 0 {
+			return 1
+		}
+		return 2
+	}
 	//nolint:gosec // G404 — UX randomness, non-cryptographic is fine
 	if rand.Intn(2) == 0 {
 		return 1
@@ -638,8 +817,13 @@ func EngineFromGame(game *model.ReversiGame) (*Game, error) {
 	if err := json.Unmarshal(game.Logs, &logs); err != nil {
 		return nil, fmt.Errorf("decode logs: %w", err)
 	}
+	// Log shape: [timeDelta, player, operation(0=put), pos]。過去の
+	// 2要素 [pos, color] 形式との互換も残す (旧データ移行中のフォールバック)。
 	for _, entry := range logs {
-		if len(entry) >= 1 {
+		switch {
+		case len(entry) >= 4 && entry[2] == 0: // put operation
+			engine.PutStone(entry[3])
+		case len(entry) == 2: // legacy [pos, color]
 			engine.PutStone(entry[0])
 		}
 	}
@@ -650,7 +834,7 @@ func EngineFromGame(game *model.ReversiGame) (*Game, error) {
 // は api ハンドラ側の packGame を使うため、ここでは stream 配信に必要な最小の
 // フィールドのみ含める。
 func packGame(game *model.ReversiGame) map[string]any {
-	return map[string]any{
+	out := map[string]any{
 		"id":                   game.ID,
 		"user1Id":              game.User1ID,
 		"user2Id":              game.User2ID,
@@ -673,4 +857,13 @@ func packGame(game *model.ReversiGame) map[string]any {
 		"startedAt":            game.StartedAt,
 		"endedAt":              game.EndedAt,
 	}
+	// user1 / user2 (UserLite) はフロントエンドの GameBoard が対戦相手の
+	// アバター描画などで必要とする。preload 済みなら埋め、nil ならキー省略。
+	if game.User1 != nil {
+		out["user1"] = entity.PackUserLite(game.User1)
+	}
+	if game.User2 != nil {
+		out["user2"] = entity.PackUserLite(game.User2)
+	}
+	return out
 }

--- a/internal/core/reversi/service.go
+++ b/internal/core/reversi/service.go
@@ -86,6 +86,31 @@ func (c *FederationIDCache) Delete(ctx context.Context, federationID, gameID str
 	}
 }
 
+// joinSentKey / IsJoinSent / MarkJoinSent は accept 時の Join が既に
+// 送信済みかを追跡する。/reversi/show-game で User2 が pending game を
+// 表示するたびに Join を再送してしまう問題の軽減 (#417 Devin review)。
+// delivery 自体は相手側で idempotent だが、無駄なネットワーク呼び出しと
+// log ノイズを減らす。
+func joinSentKey(federationID string) string { return "reversi:fed:join-sent:" + federationID }
+
+// IsJoinSent reports whether Join has already been delivered for the session.
+func (c *FederationIDCache) IsJoinSent(ctx context.Context, federationID string) bool {
+	if c.redis == nil || federationID == "" {
+		return false
+	}
+	n, err := c.redis.Exists(ctx, joinSentKey(federationID)).Result()
+	return err == nil && n > 0
+}
+
+// MarkJoinSent records that Join has been delivered. TTL は federation 本体
+// の mapping (24h) と合わせる。
+func (c *FederationIDCache) MarkJoinSent(ctx context.Context, federationID string) {
+	if c.redis == nil || federationID == "" {
+		return
+	}
+	c.redis.Set(ctx, joinSentKey(federationID), "1", FederationIDTTL)
+}
+
 // ValidUpdateKeys lists the keys that can be changed via federation Update.
 var ValidUpdateKeys = map[string]bool{
 	"map":                  true,
@@ -207,26 +232,22 @@ func (s *Service) SetBaseURL(u string) {
 // で effectively 入れているが、mk-go では Service 内部で判定して呼び出し元を
 // 軽くしている。
 func (s *Service) deliverStateToOpponent(ctx context.Context, game *model.ReversiGame, actorUserID string, state APGameState) {
+	// skip 経路はローカル対戦でも毎ターン踏むので log しない
+	// (#417 Devin review: Info だと busy instance でノイジー)。
 	if s.deliverer == nil || s.userRepo == nil || s.fedCache == nil || s.baseURL == "" {
-		slog.Info("reversi deliver: skipped (unwired)", "gameId", game.ID, "type", state.Type,
-			"deliverer", s.deliverer != nil, "userRepo", s.userRepo != nil, "fedCache", s.fedCache != nil, "baseURL", s.baseURL)
 		return
 	}
 	actor, err := s.userRepo.FindByID(actorUserID)
 	if err != nil || actor == nil || actor.Host != nil {
-		slog.Info("reversi deliver: skipped (actor issue)", "gameId", game.ID, "actorID", actorUserID, "err", err)
 		return
 	}
 	oppID := opponent(game, actorUserID)
 	opp, err := s.userRepo.FindByID(oppID)
 	if err != nil || opp == nil || opp.Host == nil || opp.URI == nil {
-		slog.Info("reversi deliver: skipped (opponent not remote)", "gameId", game.ID, "oppID", oppID,
-			"found", opp != nil, "host", opp != nil && opp.Host != nil, "uri", opp != nil && opp.URI != nil)
 		return
 	}
 	sessionID, ok := s.fedCache.GetSessionByGame(ctx, game.ID)
 	if !ok {
-		slog.Info("reversi deliver: skipped (no session)", "gameId", game.ID)
 		return
 	}
 	state.GameSessionID = sessionID

--- a/internal/core/reversi/service.go
+++ b/internal/core/reversi/service.go
@@ -11,7 +11,6 @@ import (
 	"time"
 
 	"github.com/redis/go-redis/v9"
-	"github.com/shiroha-a/mk/internal/entity"
 	"github.com/shiroha-a/mk/internal/model"
 	"github.com/shiroha-a/mk/internal/repository"
 )
@@ -878,13 +877,45 @@ func packGame(game *model.ReversiGame) map[string]any {
 		"startedAt":            game.StartedAt,
 		"endedAt":              game.EndedAt,
 	}
-	// user1 / user2 (UserLite) はフロントエンドの GameBoard が対戦相手の
-	// アバター描画などで必要とする。preload 済みなら埋め、nil ならキー省略。
+	// user1 / user2 (UserLite 互換) はフロントエンドの GameBoard が対戦
+	// 相手のアバター描画などで必要とする。preload 済みなら埋め、nil なら
+	// キー省略。entity パッケージに依存せず最小限のフィールドだけ手で組み
+	// 立てる (#417 Devin review: CLAUDE.md layer rule core → entity 禁止)。
 	if game.User1 != nil {
-		out["user1"] = entity.PackUserLite(game.User1)
+		out["user1"] = userLiteMap(game.User1)
 	}
 	if game.User2 != nil {
-		out["user2"] = entity.PackUserLite(game.User2)
+		out["user2"] = userLiteMap(game.User2)
 	}
 	return out
+}
+
+// userLiteMap builds a UserLite-compatible map without importing the
+// entity package (core layer must not depend on presentation layer).
+// フィールドは entity.PackUserLite の必須部分のみ (optional な TS 互換
+// フィールドは省略)。avatar が空なら identicon URL を返すのは本家互換。
+func userLiteMap(u *model.User) map[string]any {
+	avatarURL := u.AvatarURL
+	if avatarURL == nil || *avatarURL == "" {
+		host := ""
+		if u.Host != nil {
+			host = "@" + *u.Host
+		}
+		identicon := "/identicon/" + u.Username + host
+		avatarURL = &identicon
+	}
+	return map[string]any{
+		"id":                u.ID,
+		"name":              u.Name,
+		"username":          u.Username,
+		"host":              u.Host,
+		"avatarUrl":         avatarURL,
+		"avatarBlurhash":    u.AvatarBlurhash,
+		"avatarDecorations": u.AvatarDecorations,
+		"isBot":             u.IsBot,
+		"isCat":             u.IsCat,
+		"emojis":            map[string]string{},
+		"onlineStatus":      "unknown",
+		"badgeRoles":        []any{},
+	}
 }

--- a/internal/core/reversi/service_federation_test.go
+++ b/internal/core/reversi/service_federation_test.go
@@ -1,0 +1,211 @@
+package reversi
+
+import (
+	"context"
+	"encoding/json"
+	"sync"
+	"testing"
+
+	"github.com/shiroha-a/mk/internal/model"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// --- test doubles ---
+
+type captureDeliverer struct {
+	mu    sync.Mutex
+	calls []deliverCall
+}
+
+type deliverCall struct {
+	signerUserID string
+	recipientID  string
+	body         []byte
+}
+
+func (d *captureDeliverer) DeliverToUser(signerUserID string, recipient *model.User, body []byte) error {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	d.calls = append(d.calls, deliverCall{signerUserID: signerUserID, recipientID: recipient.ID, body: append([]byte(nil), body...)})
+	return nil
+}
+
+type stubUserLookup struct {
+	users map[string]*model.User
+}
+
+func (s *stubUserLookup) FindByID(id string) (*model.User, error) {
+	if u, ok := s.users[id]; ok {
+		return u, nil
+	}
+	return nil, ErrGameNotFound // reuse for simplicity
+}
+
+// wireFederated sets up a Service with a federation cache seeded with the
+// given session↔game mapping, plus a local "alice" user and a remote "bob"
+// user. Returns the deliverer so tests can assert on calls. Uses the shared
+// reversiTestRedis (testcontainers) from service_redis_test.go's TestMain.
+func wireFederated(t *testing.T, svc *Service, game *model.ReversiGame, sessionID string) *captureDeliverer {
+	t.Helper()
+	// 既存の reversiTestRedis を流用。FlushAll は caller が pendingGame 側で
+	// 済ませるので、ここでは追加 flush しない (同じ testcontainers client)。
+	fedCache := NewFederationIDCache(reversiTestRedis.Client)
+	fedCache.Set(context.Background(), sessionID, game.ID)
+	svc.SetFederationCache(fedCache)
+
+	remoteHost := "remote.example"
+	remoteURI := "https://remote.example/users/bob"
+	users := &stubUserLookup{users: map[string]*model.User{
+		"alice": {ID: "alice", Username: "alice"},
+		"bob":   {ID: "bob", Username: "bob", Host: &remoteHost, URI: &remoteURI},
+	}}
+	svc.SetUserRepo(users)
+	svc.SetBaseURL("https://local.example")
+
+	d := &captureDeliverer{}
+	svc.SetFederationDeliverer(d)
+	return d
+}
+
+// --- tests ---
+
+func TestService_UpdateReady_DeliversReadyStatesUpdateToRemote(t *testing.T) {
+	game, _, _, svc := newPendingGame(t)
+	d := wireFederated(t, svc, game, "sess-ready")
+
+	require.NoError(t, svc.UpdateReady(context.Background(), game.ID, "alice", true))
+
+	require.Len(t, d.calls, 1)
+	assert.Equal(t, "alice", d.calls[0].signerUserID)
+	assert.Equal(t, "bob", d.calls[0].recipientID)
+
+	var act map[string]any
+	require.NoError(t, json.Unmarshal(d.calls[0].body, &act))
+	assert.Equal(t, "Update", act["type"])
+	obj := act["object"].(map[string]any)
+	assert.Equal(t, "Game", obj["type"])
+	state := obj["game_state"].(map[string]any)
+	assert.Equal(t, "ready_states", state["type"])
+	assert.Equal(t, true, state["ready"])
+	assert.Equal(t, "sess-ready", state["game_session_id"])
+}
+
+func TestService_UpdateSettings_DeliversSettingsUpdateToRemote(t *testing.T) {
+	game, _, _, svc := newPendingGame(t)
+	d := wireFederated(t, svc, game, "sess-setting")
+
+	require.NoError(t, svc.UpdateSettings(context.Background(), game.ID, "alice", "isLlotheo", json.RawMessage("true")))
+
+	require.Len(t, d.calls, 1)
+	var act map[string]any
+	require.NoError(t, json.Unmarshal(d.calls[0].body, &act))
+	state := act["object"].(map[string]any)["game_state"].(map[string]any)
+	assert.Equal(t, "settings", state["type"])
+	assert.Equal(t, "isLlotheo", state["key"])
+	assert.Equal(t, true, state["value"])
+}
+
+func TestService_PutStone_DeliversPutstoneUpdateToRemote(t *testing.T) {
+	game, _, _, svc := newPendingGame(t)
+	d := wireFederated(t, svc, game, "sess-put")
+
+	ctx := context.Background()
+	require.NoError(t, svc.UpdateReady(ctx, game.ID, "alice", true))
+	require.NoError(t, svc.UpdateReady(ctx, game.ID, "bob", true))
+	// 1 つ目の PutStone 前のデリバリー: 2 件 (alice / bob の ready_states)
+	// ただし bob は local user (fakeRepo の newPendingGame で local) なので
+	// deliver は bob 側だけ skip される。alice が local、bob が remote という
+	// setup なので alice → remote bob に 2 回 ready_states が飛んだ状態。
+	require.GreaterOrEqual(t, len(d.calls), 1)
+	before := len(d.calls)
+
+	// alice が 1 手置く (初手は 19 などの有効な黒手)
+	require.NoError(t, svc.PutStone(ctx, game.ID, "alice", 19))
+
+	assert.Equal(t, before+1, len(d.calls))
+	last := d.calls[len(d.calls)-1]
+	var act map[string]any
+	require.NoError(t, json.Unmarshal(last.body, &act))
+	state := act["object"].(map[string]any)["game_state"].(map[string]any)
+	assert.Equal(t, "putstone", state["type"])
+	assert.Equal(t, float64(19), state["pos"])
+	assert.Equal(t, "sess-put", state["game_session_id"])
+}
+
+func TestService_CancelGame_DeliversLeaveToRemote(t *testing.T) {
+	game, _, _, svc := newPendingGame(t)
+	d := wireFederated(t, svc, game, "sess-cancel")
+
+	require.NoError(t, svc.CancelGame(context.Background(), game.ID, "alice"))
+
+	require.Len(t, d.calls, 1)
+	var act map[string]any
+	require.NoError(t, json.Unmarshal(d.calls[0].body, &act))
+	assert.Equal(t, "Leave", act["type"])
+}
+
+func TestService_Surrender_DeliversLeaveToRemote(t *testing.T) {
+	game, repo, _, svc := newPendingGame(t)
+	d := wireFederated(t, svc, game, "sess-surrender")
+
+	// start the game first (simulate both ready → start)。fedCache が設定済み
+	// なので ready 更新で deliver が 2 件走るが、この後 surrender の Leave を
+	// assert する目的なのでカウントを before で記録しておく。
+	ctx := context.Background()
+	require.NoError(t, svc.UpdateReady(ctx, game.ID, "alice", true))
+	require.NoError(t, svc.UpdateReady(ctx, game.ID, "bob", true))
+	// fakeRepo から最新 game を取り直して IsStarted を確認する
+	got, err := repo.FindByID(game.ID)
+	require.NoError(t, err)
+	require.True(t, got.IsStarted)
+
+	before := len(d.calls)
+	require.NoError(t, svc.Surrender(ctx, game.ID, "alice"))
+
+	require.Equal(t, before+1, len(d.calls))
+	var act map[string]any
+	require.NoError(t, json.Unmarshal(d.calls[before].body, &act))
+	assert.Equal(t, "Leave", act["type"])
+}
+
+// Remote actor (Host != nil) が state 変化を起こす場合は echo back しない。
+// inbox handler が Service を呼ぶ経路の guard。
+func TestService_UpdateReady_RemoteActor_NoDeliver(t *testing.T) {
+	game, _, _, svc := newPendingGame(t)
+	d := wireFederated(t, svc, game, "sess-echo")
+
+	// bob (remote) が ready を切り替えたケースをシミュレート
+	require.NoError(t, svc.UpdateReady(context.Background(), game.ID, "bob", true))
+
+	assert.Empty(t, d.calls, "remote actor update must not be echoed back")
+}
+
+// opponent がローカルユーザーならそもそも federate しない。
+func TestService_UpdateReady_LocalOpponent_NoDeliver(t *testing.T) {
+	game, _, _, svc := newPendingGame(t)
+	// federation cache / deliverer は wire するが、opponent "bob" を local に
+	// する (Host == nil)。
+	fedCache := NewFederationIDCache(reversiTestRedis.Client)
+	fedCache.Set(context.Background(), "sess-local", game.ID)
+	svc.SetFederationCache(fedCache)
+	users := &stubUserLookup{users: map[string]*model.User{
+		"alice": {ID: "alice", Username: "alice"},
+		"bob":   {ID: "bob", Username: "bob"}, // Host == nil
+	}}
+	svc.SetUserRepo(users)
+	svc.SetBaseURL("https://local.example")
+	d := &captureDeliverer{}
+	svc.SetFederationDeliverer(d)
+
+	require.NoError(t, svc.UpdateReady(context.Background(), game.ID, "alice", true))
+	assert.Empty(t, d.calls, "no delivery expected when opponent is local")
+}
+
+// deliverer 未配線では deliver 試行自体が no-op。
+func TestService_UpdateReady_DelivererUnwired_NoOp(t *testing.T) {
+	game, _, _, svc := newPendingGame(t)
+	// deliverer を wire せずに UpdateReady
+	require.NoError(t, svc.UpdateReady(context.Background(), game.ID, "alice", true))
+	// panic せず成功すれば OK
+}

--- a/internal/core/reversi/service_wire_test.go
+++ b/internal/core/reversi/service_wire_test.go
@@ -66,6 +66,14 @@ func (r *fakeRepo) ListByUser(userID string, limit int) ([]*model.ReversiGame, e
 	return nil, nil
 }
 
+func (r *fakeRepo) ListByUserCursor(_, _, _ string, _ int) ([]*model.ReversiGame, error) {
+	return nil, nil
+}
+
+func (r *fakeRepo) ListStartedCursor(_, _ string, _ int) ([]*model.ReversiGame, error) {
+	return nil, nil
+}
+
 func (r *fakeRepo) ListActive() ([]*model.ReversiGame, error) {
 	return nil, nil
 }
@@ -328,7 +336,10 @@ func TestService_PutStone_Valid(t *testing.T) {
 	var logs [][]int
 	_ = json.Unmarshal(got.Logs, &logs)
 	require.Len(t, logs, 1)
-	assert.Equal(t, 19, logs[0][0])
+	// log shape: [timeDelta, player, operation, pos] (misskey-reversi format)
+	require.Len(t, logs[0], 4)
+	assert.Equal(t, 0, logs[0][2], "operation: 0 (put)")
+	assert.Equal(t, 19, logs[0][3], "pos")
 
 	// log event published
 	types := pub.types()
@@ -430,13 +441,26 @@ func TestService_CheckTimeout_GameNotFound(t *testing.T) {
 // --- helpers ---
 
 func TestPickBlack_Explicit(t *testing.T) {
-	assert.Equal(t, 1, pickBlack("1"))
-	assert.Equal(t, 2, pickBlack("2"))
+	assert.Equal(t, 1, pickBlack("1", ""))
+	assert.Equal(t, 2, pickBlack("2", ""))
 	// random mode returns 1 or 2
 	for range 5 {
-		v := pickBlack("random")
+		v := pickBlack("random", "")
 		assert.True(t, v == 1 || v == 2)
 	}
+}
+
+// sessionID が与えられれば random でも両サイドで一致する決定論的な値を返す。
+func TestPickBlack_FederatedDeterministic(t *testing.T) {
+	// 同じ session で複数回呼んでも同じ値
+	v1 := pickBlack("random", "abc-123")
+	v2 := pickBlack("random", "abc-123")
+	assert.Equal(t, v1, v2)
+	// 先頭 codePoint の偶奇で決まる (CherryPick 仕様)
+	// "b" = 0x62 = 98 (偶) → 1
+	// "a" = 0x61 = 97 (奇) → 2
+	assert.Equal(t, 1, pickBlack("random", "b-xxx"))
+	assert.Equal(t, 2, pickBlack("random", "a-xxx"))
 }
 
 func TestPlayerColor(t *testing.T) {

--- a/internal/core/reversi/service_wire_test.go
+++ b/internal/core/reversi/service_wire_test.go
@@ -450,6 +450,31 @@ func TestPickBlack_Explicit(t *testing.T) {
 	}
 }
 
+// packGame が User1 / User2 に UserLite 互換 map を埋めることを確認
+// (#417 Devin review: entity 依存を外したあとの自前 userLiteMap)。
+func TestPackGame_EmbedsUserLiteMaps(t *testing.T) {
+	remoteHost := "remote.example"
+	name := "Alice"
+	g := &model.ReversiGame{
+		ID: "g1", User1ID: "alice", User2ID: "bob",
+		User1: &model.User{ID: "alice", Username: "alice", Name: &name, Host: &remoteHost},
+		User2: &model.User{ID: "bob", Username: "bob"},
+	}
+	out := packGame(g)
+	u1, ok := out["user1"].(map[string]any)
+	require.True(t, ok)
+	assert.Equal(t, "alice", u1["id"])
+	assert.Equal(t, "alice", u1["username"])
+	assert.Equal(t, &name, u1["name"])
+	assert.Equal(t, &remoteHost, u1["host"])
+	// avatar 未設定なら identicon URL が入る
+	if url, ok := u1["avatarUrl"].(*string); ok && url != nil {
+		assert.Contains(t, *url, "/identicon/alice")
+	}
+	u2, _ := out["user2"].(map[string]any)
+	assert.Equal(t, "bob", u2["id"])
+}
+
 // sessionID が与えられれば random でも両サイドで一致する決定論的な値を返す。
 func TestPickBlack_FederatedDeterministic(t *testing.T) {
 	// 同じ session で複数回呼んでも同じ値

--- a/internal/core/reversi/service_wire_test.go
+++ b/internal/core/reversi/service_wire_test.go
@@ -61,9 +61,19 @@ func (r *fakeRepo) Update(g *model.ReversiGame) error {
 }
 
 func (r *fakeRepo) ListByUser(userID string, limit int) ([]*model.ReversiGame, error) {
-	_ = userID
-	_ = limit
-	return nil, nil
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	out := make([]*model.ReversiGame, 0)
+	for _, g := range r.games {
+		if g.User1ID == userID || g.User2ID == userID {
+			clone := *g
+			out = append(out, &clone)
+		}
+	}
+	if limit > 0 && len(out) > limit {
+		out = out[:limit]
+	}
+	return out, nil
 }
 
 func (r *fakeRepo) ListByUserCursor(_, _, _ string, _ int) ([]*model.ReversiGame, error) {

--- a/internal/repository/reversi.go
+++ b/internal/repository/reversi.go
@@ -11,7 +11,13 @@ type ReversiRepository interface {
 	FindByID(id string) (*model.ReversiGame, error)
 	Update(game *model.ReversiGame) error
 	ListByUser(userID string, limit int) ([]*model.ReversiGame, error)
+	// ListByUserCursor returns user's games (User1 or User2) with keyset
+	// pagination via sinceID / untilID。limit は上限 (0 → 10)。id DESC 順。
+	ListByUserCursor(userID, sinceID, untilID string, limit int) ([]*model.ReversiGame, error)
 	ListActive() ([]*model.ReversiGame, error)
+	// ListStartedCursor returns only started games with keyset pagination。
+	// "my=false" な /reversi/games 用。
+	ListStartedCursor(sinceID, untilID string, limit int) ([]*model.ReversiGame, error)
 	Delete(id string) error
 }
 
@@ -71,6 +77,43 @@ func (r *reversiRepository) ListActive() ([]*model.ReversiGame, error) {
 	if err := r.db.Preload("User1").Preload("User2").
 		Where(`"isEnded" = false`).
 		Order(`"id" DESC`).Limit(50).Find(&games).Error; err != nil {
+		return nil, err
+	}
+	return games, nil
+}
+
+func (r *reversiRepository) ListByUserCursor(userID, sinceID, untilID string, limit int) ([]*model.ReversiGame, error) {
+	if limit <= 0 {
+		limit = 10
+	}
+	q := r.db.Preload("User1").Preload("User2").
+		Where(`"user1Id" = ? OR "user2Id" = ?`, userID, userID)
+	if sinceID != "" {
+		q = q.Where(`"id" > ?`, sinceID)
+	}
+	if untilID != "" {
+		q = q.Where(`"id" < ?`, untilID)
+	}
+	var games []*model.ReversiGame
+	if err := q.Order(`"id" DESC`).Limit(limit).Find(&games).Error; err != nil {
+		return nil, err
+	}
+	return games, nil
+}
+
+func (r *reversiRepository) ListStartedCursor(sinceID, untilID string, limit int) ([]*model.ReversiGame, error) {
+	if limit <= 0 {
+		limit = 10
+	}
+	q := r.db.Preload("User1").Preload("User2").Where(`"isStarted" = true`)
+	if sinceID != "" {
+		q = q.Where(`"id" > ?`, sinceID)
+	}
+	if untilID != "" {
+		q = q.Where(`"id" < ?`, untilID)
+	}
+	var games []*model.ReversiGame
+	if err := q.Order(`"id" DESC`).Limit(limit).Find(&games).Error; err != nil {
 		return nil, err
 	}
 	return games, nil

--- a/internal/server/router.go
+++ b/internal/server/router.go
@@ -1643,6 +1643,13 @@ func (s *Server) setupRoutes() {
 	reversiHandler := apireversi.NewHandler(reversiRepo, idGen)
 	reversiHandler.SetService(reversiService)
 	reversiHandler.SetFederation(s.config.URL, deliverService, reversiFedCache, userRepo)
+	// Service 側にも federation 一式を注入して state 変化時に Update / Leave を
+	// 配信できるようにする (#417 P1)。fedCache も Service 側で
+	// session→game 解決に必要なので忘れず設定する。
+	reversiService.SetFederationCache(reversiFedCache)
+	reversiService.SetFederationDeliverer(deliverService)
+	reversiService.SetUserRepo(userRepo)
+	reversiService.SetBaseURL(s.config.URL)
 	api.POST("/reversi/games", reversiHandler.Games)
 	api.POST("/reversi/invitations", reversiHandler.Invitations, middleware.RequireAuth())
 	api.POST("/reversi/show-game", reversiHandler.ShowGame)

--- a/internal/stream/channels/reversi_game.go
+++ b/internal/stream/channels/reversi_game.go
@@ -84,7 +84,6 @@ func (c *ReversiGameChannel) OnClientMessage(msgType string, body json.RawMessag
 	}
 	ctx := context.Background()
 	var err error
-	slog.Info("reversi channel: client message", "gameId", c.gameID, "user", user.ID, "type", msgType)
 	switch msgType {
 	case "ready":
 		var ready bool

--- a/internal/stream/channels/reversi_game.go
+++ b/internal/stream/channels/reversi_game.go
@@ -84,6 +84,7 @@ func (c *ReversiGameChannel) OnClientMessage(msgType string, body json.RawMessag
 	}
 	ctx := context.Background()
 	var err error
+	slog.Info("reversi channel: client message", "gameId", c.gameID, "user", user.ID, "type", msgType)
 	switch msgType {
 	case "ready":
 		var ready bool

--- a/internal/stream/channels/reversi_game_test.go
+++ b/internal/stream/channels/reversi_game_test.go
@@ -37,6 +37,12 @@ func (r *channelFakeRepo) Update(g *model.ReversiGame) error {
 func (r *channelFakeRepo) ListByUser(_ string, _ int) ([]*model.ReversiGame, error) {
 	return nil, nil
 }
+func (r *channelFakeRepo) ListByUserCursor(_, _, _ string, _ int) ([]*model.ReversiGame, error) {
+	return nil, nil
+}
+func (r *channelFakeRepo) ListStartedCursor(_, _ string, _ int) ([]*model.ReversiGame, error) {
+	return nil, nil
+}
 func (r *channelFakeRepo) ListActive() ([]*model.ReversiGame, error) { return nil, nil }
 func (r *channelFakeRepo) Delete(id string) error {
 	delete(r.games, id)


### PR DESCRIPTION
## Summary

リバーシの連合対戦 (CherryPick 本家の reversi federation 拡張) を mk-go バックエンドのみで再現。「招待は届くが対戦できない」状態を解消し、招待 → 受諾 → 先手/後手決定 → 交互着手 → 終局まで一通り動くようにする。

Closes #417 (P1)

## 解決された具体的症状 (UDS 検証で段階的に発覚した順)

| 症状 | 原因 | 対処 |
|---|---|---|
| リモートユーザーから招待が来ない | `handleReversiInvite` が local user (uri=NULL) を `FindByURI` で引こうとして失敗 | `resolveTargetUser` に切替 |
| 招待が 5 秒おきに無限増殖 | CherryPick の retry で新 session id 毎にゲーム行生成 | (inviter, invitee) で dedup、session mapping のみ最新に refresh |
| 招待クリック後の対戦画面で準備完了を押すと画面が消える | `Service.packGame` が user1/user2 objects を含まず GameBoard 描画失敗 | entity.PackUserLite を埋め込み |
| 準備完了しても B 側で反映されない / ゲーム開始しない | `RenderUpdate` に activity.id 欠落 → CherryPick の InboxProcessor が silent drop | 全 reversi renderer に uuid id を付与 + @context 追加 |
| ゲーム開始しても B 側で配置がずれる | `pickBlack("random")` が `math/rand` で両サイド非決定的 | session id の先頭コードポイントから決定論的に算出 (CherryPick 互換) |
| 自分の着手で既存の盤面がリセット | logs が 2 要素 `[pos, color]` 形式で保存され frontend の `deserializeLogs` が `[timeDelta, player, op, pos]` を要求 | 4 要素形式に統一 (旧形式は fallback read) |
| 「自分の対局」から pending game に入ると進行しない | `/show-game` が Join を送らないため B 側に G_B が作られない | viewer=User2 & pre-start で自動 Join 送信 |
| 「自分の対局」「みんなの対局」が無限ループでロード | `/games` が sinceId/untilId/my を無視 | keyset pagination 対応 |
| Service 側で state 変化が deliver されない | `reversiService.SetFederationCache` が router.go で未配線 | 配線追加 |

## 主な変更点

### Service 層
- `corereversi.Service`: `SetFederationDeliverer` / `SetFederationCache` / `SetUserRepo` / `SetBaseURL` を追加
- `UpdateReady` / `UpdateSettings` / `PutStone` / `CancelGame` / `Surrender` で状態変化を相手に配信 (local actor のときのみ。remote actor は echo back しない)
- `pickBlack(bw, sessionID)`: session id の先頭 codePoint 偶奇で black を決定論化

### Inbox
- `handleReversiInvite`: 重複招待 dedup + local user resolve 修正
- `handleReversiUpdate`: subtype 別の diag ログ追加

### API handler
- `/reversi/match`: 既存の pending 招待があれば再利用して Join を返送 (matchSpecificUser 互換)
- `/reversi/invitations`: UserLite[] を返す (CherryPick 仕様)
- `/reversi/show-game`: viewer=User2 & pre-start なら自動 Join 送信
- `/reversi/games`: sinceId / untilId / my の keyset pagination 対応

### Repository
- `ListByUserCursor` / `ListStartedCursor` を追加 (keyset pagination)

### AP renderer
- `RenderUpdate` / `RenderLeave` / `RenderUndo` に uuid ベースの `id` を必ず付与 (CherryPick InboxProcessor の silent-drop 対策)
- `APActivity` に `@context` を追加

### Log format
- `PutStone` のログ追加を misskey-reversi 互換の `[timeDelta, player(0|1), operation(0=put), pos]` 4 要素形式に
- `EngineFromGame` は 4 要素 + 旧 2 要素の両方を読める fallback

### Service.packGame
- user1 / user2 を entity.PackUserLite で含めるよう追加 (GameBoard 描画用)

## テスト

- `make fmt && make lint && go test -race -count=1 ./...` 全パス
- 主な追加テスト:
  - federation service outbound: ready_states / settings / putstone / leave delivery + remote actor echo-back skip
  - handleReversiInvite retry dedup + local URI resolve
  - pickBlack federated deterministic
  - /reversi/match が pending 招待を再利用し Join を送る
  - /reversi/invitations が UserLite[] を返す
  - /reversi/games の untilId pagination / my フラグ
- UDS (go.k7a.org) + CherryPick remote peer で end-to-end 動作確認:
  - [x] リモートユーザーから招待 → A 側で 1 件だけ表示
  - [x] 招待クリック or 「自分の対局」から入る → 対戦画面遷移
  - [x] A / B 双方 ready → 3 秒で対戦開始 (先手が両側一致)
  - [x] 交互に着手 → 両側で盤面同期
  - [x] 最後まで完走 (winner 判定)
  - [x] 「自分の対局」「みんなの対局」が無限ループせず scroll 可能

## Out of scope (別 PR / 別 Phase)

- **P2**: 招待 accept 時の Join 自動配信 (現状は show-game からの auto-Join で代替)
- **P3**: `/reversi/match` の `userId` に `@user@host` 形式のリモート指定 + nodeinfo `reversiVersion` 公開 + `federationAvailable(host)` check
- **P4**: Undo(Invite) outbound + inbound
- **P5**: Like (ゲーム中リアクション) outbound + inbound
- **P6**: round-trip integration test (mk ↔ mk federation smoke)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/shiroha-a/mk/pull/429" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
