### PR TITLE
Fix #417 P2: real-time reversi invitation via WebSocket stream

### DIFF
--- a/internal/api/reversi/handler.go
+++ b/internal/api/reversi/handler.go
@@ -60,6 +60,11 @@ func (h *Handler) SetService(svc *corereversi.Service) {
 
 // SetStreamPublisher attaches a per-user reversi stream publisher used for
 // local-side `invited` events (#417 P2)。
+//
+// NOTE: local invite 経路でこのパブリッシャを使うには userRepo が必要で、
+// userRepo は SetFederation で設定される。プロダクションは router.go で
+// 両方同時に配線するので問題無いが、片方だけ呼んだ場合 publish は skip
+// される (Match 側で h.userRepo != nil guard がある)。
 func (h *Handler) SetStreamPublisher(p ReversiStreamPublisher) {
 	h.streamPub = p
 }
@@ -288,8 +293,13 @@ func (h *Handler) Match(c echo.Context) error {
 
 	// ターゲット種別によって挙動分岐:
 	//   - remote: federation session を Redis に保存 + Invite 送信
+	//            (Host != nil かつ URI != nil の両方を要求するのは remote
+	//             branch で AP Invite の targetURI として URI が必要なため)
 	//   - local : 招待された側の reversi stream に `invited` イベントを push
 	//            (CherryPick 互換。フロントが polling 無しで招待を検知できる)
+	//   - host はあるが URI が nil の degenerate state は理論上起こらない
+	//     (resolver が両方セットする) のでここで local 扱いに落ちても
+	//     Redis publish は subscriber 無しで no-op となり実害なし。
 	if req.UserID != "" && h.userRepo != nil {
 		if targetUser, err := h.userRepo.FindByID(req.UserID); err == nil {
 			if targetUser.Host != nil && targetUser.URI != nil {

--- a/internal/api/reversi/handler.go
+++ b/internal/api/reversi/handler.go
@@ -27,6 +27,12 @@ type FederationDeliverer interface {
 	DeliverToUser(signerUserID string, recipient *model.User, body []byte) error
 }
 
+// ReversiStreamPublisher publishes `invited` events to a local user's
+// reversi stream topic (#417 P2)。実装は internal/stream.ReversiGamePublisher。
+type ReversiStreamPublisher interface {
+	PublishInvited(targetUserID string, inviter *model.User)
+}
+
 // Handler handles reversi/* endpoints.
 type Handler struct {
 	repo      repository.ReversiRepository
@@ -36,6 +42,7 @@ type Handler struct {
 	deliverer FederationDeliverer
 	fedCache  *corereversi.FederationIDCache
 	userRepo  repository.UserRepository
+	streamPub ReversiStreamPublisher
 }
 
 // NewHandler creates a new reversi handler.
@@ -49,6 +56,12 @@ func NewHandler(repo repository.ReversiRepository, idGen id.Generator) *Handler 
 // バックするので既存テスト互換。
 func (h *Handler) SetService(svc *corereversi.Service) {
 	h.svc = svc
+}
+
+// SetStreamPublisher attaches a per-user reversi stream publisher used for
+// local-side `invited` events (#417 P2)。
+func (h *Handler) SetStreamPublisher(p ReversiStreamPublisher) {
+	h.streamPub = p
 }
 
 // SetFederation attaches federation support.
@@ -273,17 +286,26 @@ func (h *Handler) Match(c echo.Context) error {
 		return c.JSON(http.StatusInternalServerError, apierr.Error("INTERNAL_ERROR", "Internal error.", "5d37dbcb-891e-41ca-a3d6-e690c97775ac"))
 	}
 
-	// リモートユーザーの場合、federation session を Redis に保存 + Invite 送信。
-	// DB スキーマは本家互換を保つため、session id はカラムに持たせず Redis のみに
-	// 保持する (internal/core/reversi.FederationIDCache)。
-	if req.UserID != "" && h.userRepo != nil && h.deliverer != nil && h.fedCache != nil {
-		if targetUser, err := h.userRepo.FindByID(req.UserID); err == nil && targetUser.Host != nil && targetUser.URI != nil {
-			sessionID := h.idGen.Generate(now) + "-fed"
-			h.fedCache.Set(c.Request().Context(), sessionID, game.ID)
-			invite := corereversi.RenderInvite(h.baseURL, sessionID,
-				h.baseURL+"/users/"+user.ID, *targetUser.URI, now.UTC().Format(time.RFC3339))
-			if body, jerr := json.Marshal(invite); jerr == nil {
-				_ = h.deliverer.DeliverToUser(user.ID, targetUser, body)
+	// ターゲット種別によって挙動分岐:
+	//   - remote: federation session を Redis に保存 + Invite 送信
+	//   - local : 招待された側の reversi stream に `invited` イベントを push
+	//            (CherryPick 互換。フロントが polling 無しで招待を検知できる)
+	if req.UserID != "" && h.userRepo != nil {
+		if targetUser, err := h.userRepo.FindByID(req.UserID); err == nil {
+			if targetUser.Host != nil && targetUser.URI != nil {
+				// remote: AP Invite を配信
+				if h.deliverer != nil && h.fedCache != nil {
+					sessionID := h.idGen.Generate(now) + "-fed"
+					h.fedCache.Set(c.Request().Context(), sessionID, game.ID)
+					invite := corereversi.RenderInvite(h.baseURL, sessionID,
+						h.baseURL+"/users/"+user.ID, *targetUser.URI, now.UTC().Format(time.RFC3339))
+					if body, jerr := json.Marshal(invite); jerr == nil {
+						_ = h.deliverer.DeliverToUser(user.ID, targetUser, body)
+					}
+				}
+			} else if h.streamPub != nil {
+				// local: stream に invited イベントを push (#417 P2)
+				h.streamPub.PublishInvited(targetUser.ID, user)
 			}
 		}
 	}

--- a/internal/api/reversi/handler_test.go
+++ b/internal/api/reversi/handler_test.go
@@ -453,6 +453,63 @@ func TestVerify_DivergingCRC(t *testing.T) {
 
 // --- Federation ---
 
+// Local ターゲットへの /match で reversi stream に `invited` が push される
+// (#417 P2)。リモートターゲットのときは Invite を deliver するのみで
+// local stream への push はしない。
+func TestMatch_LocalTargetPublishesInvited(t *testing.T) {
+	h, _ := newTestHandler()
+	userRepo := testutil.NewMockUserRepository()
+	// local target u2 を登録
+	userRepo.Users["u2"] = &model.User{ID: "u2", Username: "bob"}
+	h.SetFederation("https://example.com", &mockDeliverer{}, nil, userRepo)
+	pub := &stubStreamPub{}
+	h.SetStreamPublisher(pub)
+
+	rec := post(h.Match, `{"userId":"u2"}`, u1)
+	assert.Equal(t, http.StatusOK, rec.Code)
+
+	require.Len(t, pub.calls, 1)
+	assert.Equal(t, "u2", pub.calls[0].targetUserID)
+	assert.Equal(t, "u1", pub.calls[0].inviter.ID)
+}
+
+// Remote ターゲットの /match では stream push は行わない (相手は別 instance)。
+func TestMatch_RemoteTargetSkipsStream(t *testing.T) {
+	ctx := context.Background()
+	apiReversiRedis.FlushAll(ctx)
+	h, _ := newTestHandler()
+	d := &mockDeliverer{}
+	userRepo := testutil.NewMockUserRepository()
+	host := "remote.example"
+	uri := "https://remote.example/users/alice"
+	userRepo.Users["remoteAlice"] = &model.User{
+		ID: "remoteAlice", Username: "alice", Host: &host, URI: &uri,
+	}
+	fedCache := corereversi.NewFederationIDCache(apiReversiRedis.Client)
+	h.SetFederation("https://example.com", d, fedCache, userRepo)
+	pub := &stubStreamPub{}
+	h.SetStreamPublisher(pub)
+
+	rec := post(h.Match, `{"userId":"remoteAlice"}`, u1)
+	assert.Equal(t, http.StatusOK, rec.Code)
+
+	assert.Equal(t, 1, d.calls, "remote target には Invite AP activity が配信される")
+	assert.Len(t, pub.calls, 0, "remote target では local stream push は無い")
+}
+
+type stubStreamPubCall struct {
+	targetUserID string
+	inviter      *model.User
+}
+
+type stubStreamPub struct {
+	calls []stubStreamPubCall
+}
+
+func (s *stubStreamPub) PublishInvited(targetUserID string, inviter *model.User) {
+	s.calls = append(s.calls, stubStreamPubCall{targetUserID: targetUserID, inviter: inviter})
+}
+
 type mockDeliverer struct {
 	calls int
 }

--- a/internal/core/federation/processor.go
+++ b/internal/core/federation/processor.go
@@ -62,6 +62,9 @@ type Processor struct {
 	reversiRepo     repository.ReversiRepository
 	reversiIDGen    id.Generator
 	reversiFedCache *corereversi.FederationIDCache
+	// reversiStreamPub: 招待受信時に recipient の `reversi:<id>` stream
+	// に `invited` イベントを publish する (#417 P2 リアルタイム招待)。
+	reversiStreamPub ReversiStreamPublisher
 
 	// Relay follow-accept / -reject hook. nil 時は relay 特化処理をスキップ。
 	relayMarker RelayStatusMarker
@@ -333,6 +336,12 @@ func (p *Processor) SetReversi(
 	p.reversiRepo = repo
 	p.reversiIDGen = idGen
 	p.reversiFedCache = fedCache
+}
+
+// SetReversiStreamPublisher wires a per-user reversi stream publisher used
+// by handleReversiInvite to push `invited` events in real-time (#417 P2)。
+func (p *Processor) SetReversiStreamPublisher(pub ReversiStreamPublisher) {
+	p.reversiStreamPub = pub
 }
 
 // handleFollow processes an inbound Follow activity.

--- a/internal/core/federation/reversi_inbox.go
+++ b/internal/core/federation/reversi_inbox.go
@@ -13,6 +13,14 @@ import (
 	"gorm.io/datatypes"
 )
 
+// ReversiStreamPublisher forwards per-user reversi events (Invite arrival)
+// to the `reversi:<userID>` pub/sub topic so that the WebSocket channel
+// can push `invited` in real-time to the recipient's UI (#417 P2). 実装は
+// internal/stream.ReversiGamePublisher。未設定なら publish しない。
+type ReversiStreamPublisher interface {
+	PublishInvited(targetUserID string, inviter *model.User)
+}
+
 // --- Incoming reversi AP activities (CherryPick compatible) ---
 //
 // All four activity types carry a custom Game object as `object`, structured
@@ -87,6 +95,12 @@ func (p *Processor) handleReversiInvite(act genericActivity) error {
 	p.reversiFedCache.Set(ctx, state.GameSessionID, game.ID)
 	slog.Info("reversi federation: accepted invite",
 		"gameId", game.ID, "session", state.GameSessionID, "inviter", actor.ID, "invitee", invitee.ID)
+	// 招待されたユーザーの reversi stream に `invited` を push することで
+	// Misskey/CherryPick フロントがリアルタイムで招待カードを表示する
+	// (#417 P2: polling/reload 依存の解消)。
+	if p.reversiStreamPub != nil {
+		p.reversiStreamPub.PublishInvited(invitee.ID, actor)
+	}
 	return nil
 }
 

--- a/internal/core/federation/reversi_inbox_test.go
+++ b/internal/core/federation/reversi_inbox_test.go
@@ -229,6 +229,46 @@ func TestReversiInbox_Invite_CreatesGame(t *testing.T) {
 	assert.Equal(t, "bob", g.User2ID)
 }
 
+// リモートから受信した Invite で local user の reversi stream に
+// `invited` イベントがリアルタイム push される (#417 P2)。
+func TestReversiInbox_Invite_PublishesInvitedToStream(t *testing.T) {
+	b := newReversiProcessor(t)
+	registerLocalBob(t, b.userRepo)
+	stub := &stubInvitedStreamPub{}
+	b.processor.SetReversiStreamPublisher(stub)
+
+	body := []byte(`{
+		"type": "Invite",
+		"actor": "https://remote.example/users/alice",
+		"to": "https://example.com/users/bob",
+		"object": {
+			"type": "Game",
+			"game_type_uuid": "1c086295-25e3-4b82-b31e-3e3959906312",
+			"game_state": {"game_session_id": "sess-p2"}
+		}
+	}`)
+	require.NoError(t, b.processor.Process(body))
+
+	require.Len(t, stub.calls, 1)
+	assert.Equal(t, "bob", stub.calls[0].targetUserID)
+	require.NotNil(t, stub.calls[0].inviter)
+	// inviter は resolveActor 結果 (remote alice)
+	assert.NotEmpty(t, stub.calls[0].inviter.ID)
+}
+
+type stubInvitedCall struct {
+	targetUserID string
+	inviter      *model.User
+}
+
+type stubInvitedStreamPub struct {
+	calls []stubInvitedCall
+}
+
+func (s *stubInvitedStreamPub) PublishInvited(targetUserID string, inviter *model.User) {
+	s.calls = append(s.calls, stubInvitedCall{targetUserID: targetUserID, inviter: inviter})
+}
+
 // CherryPick は ack が返らないと fresh session_id で Invite を 5 秒ごと再送
 // する。同じ (inviter, invitee) の pending game は 1 つに集約し、最新の
 // session_id に mapping を差し替える必要がある (#417 P1 UDS で発覚した増殖)。

--- a/internal/server/router.go
+++ b/internal/server/router.go
@@ -1643,6 +1643,7 @@ func (s *Server) setupRoutes() {
 	reversiHandler := apireversi.NewHandler(reversiRepo, idGen)
 	reversiHandler.SetService(reversiService)
 	reversiHandler.SetFederation(s.config.URL, deliverService, reversiFedCache, userRepo)
+	reversiHandler.SetStreamPublisher(reversiPublisher)
 	// Service 側にも federation 一式を注入して state 変化時に Update / Leave を
 	// 配信できるようにする (#417 P1)。fedCache も Service 側で
 	// session→game 解決に必要なので忘れず設定する。
@@ -1650,6 +1651,9 @@ func (s *Server) setupRoutes() {
 	reversiService.SetFederationDeliverer(deliverService)
 	reversiService.SetUserRepo(userRepo)
 	reversiService.SetBaseURL(s.config.URL)
+	// 連合 inbox 経由の invite 受信時にも local 被招待者の reversi stream に
+	// `invited` を push する (#417 P2: リアルタイム招待)。
+	federationProcessor.SetReversiStreamPublisher(reversiPublisher)
 	api.POST("/reversi/games", reversiHandler.Games)
 	api.POST("/reversi/invitations", reversiHandler.Invitations, middleware.RequireAuth())
 	api.POST("/reversi/show-game", reversiHandler.ShowGame)

--- a/internal/stream/reversi_publisher.go
+++ b/internal/stream/reversi_publisher.go
@@ -4,6 +4,9 @@ import (
 	"context"
 	"encoding/json"
 	"log/slog"
+
+	"github.com/shiroha-a/mk/internal/entity"
+	"github.com/shiroha-a/mk/internal/model"
 )
 
 // ReversiGamePublisher serializes {type, body} envelopes to the Redis topic
@@ -32,5 +35,31 @@ func (p *ReversiGamePublisher) PublishGameEvent(gameID, eventType string, body a
 	topic := "reversiGame:" + gameID
 	if err := p.pub.Publish(context.Background(), topic, json.RawMessage(raw)); err != nil {
 		slog.Warn("reversi publisher: publish failed", "topic", topic, "err", err)
+	}
+}
+
+// PublishInvited emits an `invited` event to the `reversi:<userID>` stream
+// topic that the Misskey/CherryPick frontend's `reversi` channel subscribes
+// to。body は CherryPick 互換で `{ user: UserLite }` shape。これを出さないと
+// フロントは polling (/api/reversi/invitations) でしか招待を検知できず
+// reload が必要になる (#417 P2)。
+func (p *ReversiGamePublisher) PublishInvited(targetUserID string, inviter *model.User) {
+	if p.pub == nil || targetUserID == "" || inviter == nil {
+		return
+	}
+	env := map[string]any{
+		"type": "invited",
+		"body": map[string]any{
+			"user": entity.PackUserLite(inviter),
+		},
+	}
+	raw, err := json.Marshal(env)
+	if err != nil {
+		slog.Warn("reversi publisher: marshal invited failed", "err", err)
+		return
+	}
+	topic := "reversi:" + targetUserID
+	if err := p.pub.Publish(context.Background(), topic, json.RawMessage(raw)); err != nil {
+		slog.Warn("reversi publisher: publish invited failed", "topic", topic, "err", err)
 	}
 }


### PR DESCRIPTION
## Summary

リバーシの招待が届いた際、従来は \`/api/reversi/invitations\` の polling またはリロードが必要だった。CherryPick 本家の \`publishReversiStream('invited', ...)\` と同じ挙動を実装して、フロントが既に subscribe している \`reversi:<userID>\` WebSocket ストリームにリアルタイムで招待イベントを流す。

Closes (continue #417)

## 主な変更点

### Stream publisher
- \`stream.ReversiGamePublisher.PublishInvited(targetUserID, inviter *model.User)\` 追加
- topic: \`reversi:<userID>\`、body: \`{ type: \"invited\", body: { user: UserLite } }\` (CherryPick 互換)

### 連合経路 (remote → local invite)
- \`core/federation.Processor\` に \`ReversiStreamPublisher\` interface + \`SetReversiStreamPublisher\` setter を追加
- \`handleReversiInvite\` で game 作成後に \`PublishInvited(invitee.ID, actor)\` を呼ぶ

### ローカル経路 (local → local invite)
- \`api/reversi.Handler\` に \`ReversiStreamPublisher\` interface + \`SetStreamPublisher\` setter を追加
- \`/api/reversi/match\` で target が local (Host=nil) なら \`PublishInvited\` を呼ぶ
- target が remote の場合は AP Invite を配信するだけで stream には流さない (相手は別 instance)

### 配線
- \`router.go\` で \`reversiPublisher\` を federation processor と reversi handler の両方に配線

## テスト

- \`TestReversiInbox_Invite_PublishesInvitedToStream\` — 連合受信経路で \`invited\` が stream に流れる
- \`TestMatch_LocalTargetPublishesInvited\` — ローカル招待経路で \`invited\` が local target に流れる
- \`TestMatch_RemoteTargetSkipsStream\` — リモート招待では local stream push は行わない

UDS (go.k7a.org) で以下を実機確認済み:
- [x] CherryPick リモート B → mk-go A の招待が、A 側の \`/reversi\` ページで**リロード無しに** invitation カードとして即時表示される

## スコープ外 / Out of scope

### 通知欄 (\`/my/notifications\`) への掲載
CherryPick 本家でも reversi 招待は通知テーブルには入らず、専用 WebSocket ストリームの \`invited\` ポップアップのみで表現される。通知欄に載せるとしたらフロントエンド (Misskey/CherryPick) 側で \`reversiInvited\` のような新規 notification type の rendering を追加する必要があるが、本プロジェクトはバックエンドのみのリライトでフロントは本家をそのまま使う方針のためスコープ外とした。

## Related

Continues #417 (P1 merged as #429)。残り follow-up は #417 issue の Out of scope 欄参照:
- P3: リモート招待 API (\`@user@host\`) + nodeinfo reversiVersion
- P4: Undo(Invite) 両方向
- P5: Like/reaction 両方向
- P6: round-trip integration test

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/shiroha-a/mk/pull/430" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
