### PR TITLE
Fix #417 P3: reversi federation capability check + remote invite resolve

### DIFF
--- a/internal/api/nodeinfo/handler.go
+++ b/internal/api/nodeinfo/handler.go
@@ -83,6 +83,10 @@ func (h *Handler) Version2_1(c echo.Context) error {
 			"name":  maintainerName,
 			"email": maintainerEmail,
 		},
+		// CherryPick 本家の reversi 連合拡張と互換性を示すバージョン。
+		// 相手側 (CherryPick) はこの値のメジャーバージョン一致で連合可否を
+		// 判定するので、破壊的変更が無い限り 1.1.x を維持する (#417 P3)。
+		"reversiVersion": "1.1.0-mkgo",
 	}
 	// 統計値は repo 経由で集計。未配線なら 0 (#403)。DB error は nodeinfo を
 	// 丸ごと failさせるより partial 値で返す方が federation crawler に優しい

--- a/internal/api/nodeinfo/handler.go
+++ b/internal/api/nodeinfo/handler.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/labstack/echo/v4"
 	"github.com/shiroha-a/mk/internal/config"
+	corereversi "github.com/shiroha-a/mk/internal/core/reversi"
 	"github.com/shiroha-a/mk/internal/repository"
 )
 
@@ -86,7 +87,8 @@ func (h *Handler) Version2_1(c echo.Context) error {
 		// CherryPick 本家の reversi 連合拡張と互換性を示すバージョン。
 		// 相手側 (CherryPick) はこの値のメジャーバージョン一致で連合可否を
 		// 判定するので、破壊的変更が無い限り 1.1.x を維持する (#417 P3)。
-		"reversiVersion": "1.1.0-mkgo",
+		// corereversi.ReversiVersion と drift しないよう定数参照する。
+		"reversiVersion": corereversi.ReversiVersion,
 	}
 	// 統計値は repo 経由で集計。未配線なら 0 (#403)。DB error は nodeinfo を
 	// 丸ごと failさせるより partial 値で返す方が federation crawler に優しい

--- a/internal/api/reversi/handler.go
+++ b/internal/api/reversi/handler.go
@@ -1,6 +1,7 @@
 package reversi
 
 import (
+	"context"
 	"encoding/json"
 	"errors"
 	"log/slog"
@@ -35,14 +36,28 @@ type ReversiStreamPublisher interface {
 
 // Handler handles reversi/* endpoints.
 type Handler struct {
-	repo      repository.ReversiRepository
-	svc       *corereversi.Service
-	idGen     id.Generator
-	baseURL   string
-	deliverer FederationDeliverer
-	fedCache  *corereversi.FederationIDCache
-	userRepo  repository.UserRepository
-	streamPub ReversiStreamPublisher
+	repo         repository.ReversiRepository
+	svc          *corereversi.Service
+	idGen        id.Generator
+	baseURL      string
+	deliverer    FederationDeliverer
+	fedCache     *corereversi.FederationIDCache
+	userRepo     repository.UserRepository
+	streamPub    ReversiStreamPublisher
+	fedChecker   FederationAvailabilityChecker
+	remoteLookup RemoteUserLookup
+}
+
+// FederationAvailabilityChecker は reversiVersion を advertise している相手
+// かどうかを判定する。実装は core/reversi.FederationChecker。
+type FederationAvailabilityChecker interface {
+	Available(ctx context.Context, host string) bool
+}
+
+// RemoteUserLookup は `@user@host` 形式で未キャッシュのリモートユーザーを
+// WebFinger + AP Person 経由で取り込む。実装は core/federation.RemoteUserResolver。
+type RemoteUserLookup interface {
+	ResolveByUsernameHost(username, host string) (*model.User, error)
 }
 
 // NewHandler creates a new reversi handler.
@@ -56,6 +71,21 @@ func NewHandler(repo repository.ReversiRepository, idGen id.Generator) *Handler 
 // バックするので既存テスト互換。
 func (h *Handler) SetService(svc *corereversi.Service) {
 	h.svc = svc
+}
+
+// SetFederationChecker attaches a FederationAvailabilityChecker used to
+// gate outbound Invite delivery when the remote host does not advertise a
+// compatible reversiVersion (#417 P3)。未設定なら常に送信を許可する
+// (従来互換)。
+func (h *Handler) SetFederationChecker(c FederationAvailabilityChecker) {
+	h.fedChecker = c
+}
+
+// SetRemoteUserLookup attaches a webfinger-capable remote user resolver so
+// that /match can accept `@user@host` acct for users not yet cached locally
+// (#417 P3 Enhancement)。
+func (h *Handler) SetRemoteUserLookup(r RemoteUserLookup) {
+	h.remoteLookup = r
 }
 
 // SetStreamPublisher attaches a per-user reversi stream publisher used for
@@ -127,27 +157,34 @@ var defaultMap = pq.StringArray{
 }
 
 // resolveAcct converts an acct form (`@user` or `@user@host`) into a local
-// user id by looking up the UserRepository. Remote users must already exist
-// locally — webfinger-based discovery is intentionally out of scope.
+// user id。最初に UserRepository を引き、remote でキャッシュ未取込ならば
+// RemoteUserLookup (WebFinger + AP Person fetch) にフォールバックする
+// (#417 P3 Enhancement: リモートユーザーを招待できるようにする)。
 func (h *Handler) resolveAcct(acct string) (string, error) {
 	trimmed := strings.TrimPrefix(acct, "@")
 	if trimmed == "" {
 		return "", errors.New("empty acct")
 	}
 	username := trimmed
-	var hostPtr *string
+	var host string
 	if at := strings.IndexByte(trimmed, '@'); at >= 0 {
 		username = trimmed[:at]
-		host := strings.ToLower(trimmed[at+1:])
-		if host != "" {
-			hostPtr = &host
+		host = strings.ToLower(trimmed[at+1:])
+	}
+	var hostPtr *string
+	if host != "" {
+		hostPtr = &host
+	}
+	if u, err := h.userRepo.FindByUsernameLower(strings.ToLower(username), hostPtr); err == nil {
+		return u.ID, nil
+	}
+	// ローカル DB に無い remote user → WebFinger で取り込む。
+	if host != "" && h.remoteLookup != nil {
+		if u, err := h.remoteLookup.ResolveByUsernameHost(username, host); err == nil && u != nil {
+			return u.ID, nil
 		}
 	}
-	u, err := h.userRepo.FindByUsernameLower(strings.ToLower(username), hostPtr)
-	if err != nil {
-		return "", err
-	}
-	return u.ID, nil
+	return "", errors.New("user not found")
 }
 
 // Games handles POST /api/reversi/games — list games.
@@ -272,6 +309,20 @@ func (h *Handler) Match(c echo.Context) error {
 		}
 	}
 
+	// 新規招待で remote target の場合は reversiVersion 互換性を先に確認する
+	// (#417 P3)。非対応ホストへの招待は silent に握りつぶされるだけで UI が
+	// 「待機中」のまま動かないので、ゲーム行作成前に 400 エラーで弾く。
+	if req.UserID != "" && h.userRepo != nil && h.fedChecker != nil {
+		if targetUser, err := h.userRepo.FindByID(req.UserID); err == nil && targetUser.Host != nil && *targetUser.Host != "" {
+			if !h.fedChecker.Available(c.Request().Context(), *targetUser.Host) {
+				return c.JSON(http.StatusBadRequest, apierr.Error(
+					"NO_REVERSI_FEDERATION",
+					"The target user's server does not support reversi federation.",
+					"3c9d76c8-8d40-4f6e-9bea-e4e57ae02fed"))
+			}
+		}
+	}
+
 	now := time.Now()
 	game := &model.ReversiGame{
 		ID:                   h.idGen.Generate(now),
@@ -303,7 +354,8 @@ func (h *Handler) Match(c echo.Context) error {
 	if req.UserID != "" && h.userRepo != nil {
 		if targetUser, err := h.userRepo.FindByID(req.UserID); err == nil {
 			if targetUser.Host != nil && targetUser.URI != nil {
-				// remote: AP Invite を配信
+				// remote: AP Invite を配信 (reversiVersion 互換性は
+				// ゲーム行作成前の pre-check 済み)。
 				if h.deliverer != nil && h.fedCache != nil {
 					sessionID := h.idGen.Generate(now) + "-fed"
 					h.fedCache.Set(c.Request().Context(), sessionID, game.ID)

--- a/internal/api/reversi/handler.go
+++ b/internal/api/reversi/handler.go
@@ -173,11 +173,15 @@ func (h *Handler) resolveAcct(acct string) (string, error) {
 		username = trimmed[:at]
 		host = strings.ToLower(trimmed[at+1:])
 	}
+	// DB 側は username_lower 比較、WebFinger は RFC 7033 case-insensitive、
+	// AP resolver も canonical username を再取得するので username を一度だけ
+	// 小文字化して両経路で同じ値を使う (#417 P3 Devin review)。
+	username = strings.ToLower(username)
 	var hostPtr *string
 	if host != "" {
 		hostPtr = &host
 	}
-	if u, err := h.userRepo.FindByUsernameLower(strings.ToLower(username), hostPtr); err == nil {
+	if u, err := h.userRepo.FindByUsernameLower(username, hostPtr); err == nil {
 		return u.ID, nil
 	}
 	// ローカル DB に無い remote user → WebFinger で取り込む。
@@ -311,17 +315,25 @@ func (h *Handler) Match(c echo.Context) error {
 		}
 	}
 
+	// target user を一度だけ引いて pre-check と deliver 両方で使い回す
+	// (#417 P3 Devin review: 元実装では pre-check と delivery で 2 回
+	// FindByID していた)。
+	var targetUser *model.User
+	if req.UserID != "" && h.userRepo != nil {
+		if u, err := h.userRepo.FindByID(req.UserID); err == nil {
+			targetUser = u
+		}
+	}
+
 	// 新規招待で remote target の場合は reversiVersion 互換性を先に確認する
 	// (#417 P3)。非対応ホストへの招待は silent に握りつぶされるだけで UI が
 	// 「待機中」のまま動かないので、ゲーム行作成前に 400 エラーで弾く。
-	if req.UserID != "" && h.userRepo != nil && h.fedChecker != nil {
-		if targetUser, err := h.userRepo.FindByID(req.UserID); err == nil && targetUser.Host != nil && *targetUser.Host != "" {
-			if !h.fedChecker.Available(c.Request().Context(), *targetUser.Host) {
-				return c.JSON(http.StatusBadRequest, apierr.Error(
-					"NO_REVERSI_FEDERATION",
-					"The target user's server does not support reversi federation.",
-					"3c9d76c8-8d40-4f6e-9bea-e4e57ae02fed"))
-			}
+	if targetUser != nil && h.fedChecker != nil && targetUser.Host != nil && *targetUser.Host != "" {
+		if !h.fedChecker.Available(c.Request().Context(), *targetUser.Host) {
+			return c.JSON(http.StatusBadRequest, apierr.Error(
+				"NO_REVERSI_FEDERATION",
+				"The target user's server does not support reversi federation.",
+				"3c9d76c8-8d40-4f6e-9bea-e4e57ae02fed"))
 		}
 	}
 
@@ -353,24 +365,22 @@ func (h *Handler) Match(c echo.Context) error {
 	//   - host はあるが URI が nil の degenerate state は理論上起こらない
 	//     (resolver が両方セットする) のでここで local 扱いに落ちても
 	//     Redis publish は subscriber 無しで no-op となり実害なし。
-	if req.UserID != "" && h.userRepo != nil {
-		if targetUser, err := h.userRepo.FindByID(req.UserID); err == nil {
-			if targetUser.Host != nil && targetUser.URI != nil {
-				// remote: AP Invite を配信 (reversiVersion 互換性は
-				// ゲーム行作成前の pre-check 済み)。
-				if h.deliverer != nil && h.fedCache != nil {
-					sessionID := h.idGen.Generate(now) + "-fed"
-					h.fedCache.Set(c.Request().Context(), sessionID, game.ID)
-					invite := corereversi.RenderInvite(h.baseURL, sessionID,
-						h.baseURL+"/users/"+user.ID, *targetUser.URI, now.UTC().Format(time.RFC3339))
-					if body, jerr := json.Marshal(invite); jerr == nil {
-						_ = h.deliverer.DeliverToUser(user.ID, targetUser, body)
-					}
+	if targetUser != nil {
+		if targetUser.Host != nil && targetUser.URI != nil {
+			// remote: AP Invite を配信 (reversiVersion 互換性は
+			// ゲーム行作成前の pre-check 済み)。
+			if h.deliverer != nil && h.fedCache != nil {
+				sessionID := h.idGen.Generate(now) + "-fed"
+				h.fedCache.Set(c.Request().Context(), sessionID, game.ID)
+				invite := corereversi.RenderInvite(h.baseURL, sessionID,
+					h.baseURL+"/users/"+user.ID, *targetUser.URI, now.UTC().Format(time.RFC3339))
+				if body, jerr := json.Marshal(invite); jerr == nil {
+					_ = h.deliverer.DeliverToUser(user.ID, targetUser, body)
 				}
-			} else if h.streamPub != nil {
-				// local: stream に invited イベントを push (#417 P2)
-				h.streamPub.PublishInvited(targetUser.ID, user)
 			}
+		} else if h.streamPub != nil {
+			// local: stream に invited イベントを push (#417 P2)
+			h.streamPub.PublishInvited(targetUser.ID, user)
 		}
 	}
 

--- a/internal/api/reversi/handler.go
+++ b/internal/api/reversi/handler.go
@@ -48,14 +48,16 @@ type Handler struct {
 	remoteLookup RemoteUserLookup
 }
 
-// FederationAvailabilityChecker は reversiVersion を advertise している相手
-// かどうかを判定する。実装は core/reversi.FederationChecker。
+// FederationAvailabilityChecker determines whether a remote host advertises
+// a compatible reversiVersion via its nodeinfo.
+// 実装は core/reversi.FederationChecker。
 type FederationAvailabilityChecker interface {
 	Available(ctx context.Context, host string) bool
 }
 
-// RemoteUserLookup は `@user@host` 形式で未キャッシュのリモートユーザーを
-// WebFinger + AP Person 経由で取り込む。実装は core/federation.RemoteUserResolver。
+// RemoteUserLookup resolves an uncached remote user identified by acct
+// (`@user@host`) via WebFinger + ActivityPub Person fetch.
+// 実装は core/federation.RemoteUserResolver。
 type RemoteUserLookup interface {
 	ResolveByUsernameHost(username, host string) (*model.User, error)
 }

--- a/internal/api/reversi/handler_test.go
+++ b/internal/api/reversi/handler_test.go
@@ -453,6 +453,95 @@ func TestVerify_DivergingCRC(t *testing.T) {
 
 // --- Federation ---
 
+// /match remote target で FederationChecker が unavailable を返したら
+// 400 エラーで弾いて Invite 配信もゲーム行作成もしない (#417 P3)。
+func TestMatch_Returns400WhenFederationUnavailable(t *testing.T) {
+	ctx := context.Background()
+	apiReversiRedis.FlushAll(ctx)
+	h, repo := newTestHandler()
+	d := &mockDeliverer{}
+	userRepo := testutil.NewMockUserRepository()
+	host := "nonreversi.example"
+	uri := "https://nonreversi.example/users/alice"
+	userRepo.Users["remoteAlice"] = &model.User{
+		ID: "remoteAlice", Username: "alice", Host: &host, URI: &uri,
+	}
+	fedCache := corereversi.NewFederationIDCache(apiReversiRedis.Client)
+	h.SetFederation("https://example.com", d, fedCache, userRepo)
+	h.SetFederationChecker(stubFedChecker{available: false})
+
+	rec := post(h.Match, `{"userId":"remoteAlice"}`, u1)
+	assert.Equal(t, http.StatusBadRequest, rec.Code)
+	assert.Equal(t, 0, d.calls, "非対応ホストには deliver しない")
+	// ゲーム行は作成されない (rollback 不要な early return)
+	assert.Len(t, repo.games, 0)
+
+	var resp map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+	errObj := resp["error"].(map[string]any)
+	assert.Equal(t, "NO_REVERSI_FEDERATION", errObj["code"])
+}
+
+// FederationChecker が available を返したら従来通り Invite 配信。
+func TestMatch_SendsInviteWhenFederationAvailable(t *testing.T) {
+	ctx := context.Background()
+	apiReversiRedis.FlushAll(ctx)
+	h, _ := newTestHandler()
+	d := &mockDeliverer{}
+	userRepo := testutil.NewMockUserRepository()
+	host := "remote.example"
+	uri := "https://remote.example/users/alice"
+	userRepo.Users["remoteAlice"] = &model.User{
+		ID: "remoteAlice", Username: "alice", Host: &host, URI: &uri,
+	}
+	fedCache := corereversi.NewFederationIDCache(apiReversiRedis.Client)
+	h.SetFederation("https://example.com", d, fedCache, userRepo)
+	h.SetFederationChecker(stubFedChecker{available: true})
+
+	rec := post(h.Match, `{"userId":"remoteAlice"}`, u1)
+	assert.Equal(t, http.StatusOK, rec.Code)
+	assert.Equal(t, 1, d.calls)
+}
+
+// Acct `@user@host` で未キャッシュのリモートユーザーを WebFinger で取り込む。
+func TestMatch_AcctRemoteResolvesViaWebfinger(t *testing.T) {
+	ctx := context.Background()
+	apiReversiRedis.FlushAll(ctx)
+	h, _ := newTestHandler()
+	d := &mockDeliverer{}
+	userRepo := testutil.NewMockUserRepository()
+	// ローカル DB には居ない相手
+	fedCache := corereversi.NewFederationIDCache(apiReversiRedis.Client)
+	h.SetFederation("https://example.com", d, fedCache, userRepo)
+	h.SetFederationChecker(stubFedChecker{available: true})
+
+	host := "remote.example"
+	uri := "https://remote.example/users/ghost"
+	discovered := &model.User{ID: "discovered", Username: "ghost", Host: &host, URI: &uri}
+	h.SetRemoteUserLookup(&stubRemoteLookup{user: discovered})
+	// acct を local id に解決した後、FindByID で再取得されるため登録しておく。
+	userRepo.Users["discovered"] = discovered
+
+	rec := post(h.Match, `{"userId":"@ghost@remote.example"}`, u1)
+	assert.Equal(t, http.StatusOK, rec.Code)
+	assert.Equal(t, 1, d.calls)
+}
+
+type stubFedChecker struct {
+	available bool
+}
+
+func (s stubFedChecker) Available(_ context.Context, _ string) bool { return s.available }
+
+type stubRemoteLookup struct {
+	user *model.User
+	err  error
+}
+
+func (s *stubRemoteLookup) ResolveByUsernameHost(_, _ string) (*model.User, error) {
+	return s.user, s.err
+}
+
 // Local ターゲットへの /match で reversi stream に `invited` が push される
 // (#417 P2)。リモートターゲットのときは Invite を deliver するのみで
 // local stream への push はしない。

--- a/internal/core/reversi/federation_check.go
+++ b/internal/core/reversi/federation_check.go
@@ -1,0 +1,185 @@
+package reversi
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/redis/go-redis/v9"
+)
+
+// ReversiVersion is the local reversi federation version advertised in nodeinfo
+// and compared against remote hosts' nodeinfo for compatibility checks.
+// CherryPick 本家の `NodeinfoServerService.reversiVersion` と互換なメジャー
+// バージョンで揃える (現状 1.1.x)。
+const ReversiVersion = "1.1.0-mkgo"
+
+// remoteVersionTTL はリモートホストの reversiVersion を Redis にキャッシュ
+// する時間。CherryPick は 5 分で揃えている。nodeinfo は頻繁に変わらないので
+// 短すぎず長すぎずの値。
+const remoteVersionTTL = 5 * time.Minute
+
+// FederationChecker determines whether a remote host speaks the reversi
+// federation protocol by fetching its nodeinfo and reading `metadata.
+// reversiVersion`. Redis にキャッシュして連続呼び出しでも HTTP 往復が
+// 最大 1 回に収まるようにする (#417 P3)。
+type FederationChecker struct {
+	redis  redis.Cmdable
+	client HTTPDoer
+}
+
+// HTTPDoer is the minimal interface the checker uses to issue HTTP GET.
+// 既存の safehttp.Client などをそのまま渡せるように narrow interface。
+type HTTPDoer interface {
+	Do(req *http.Request) (*http.Response, error)
+}
+
+// NewFederationChecker constructs a FederationChecker. client が nil なら
+// `http.DefaultClient` を使う (テスト / limitation は caller 側で注入)。
+func NewFederationChecker(r redis.Cmdable, client HTTPDoer) *FederationChecker {
+	if client == nil {
+		client = &http.Client{Timeout: 10 * time.Second}
+	}
+	return &FederationChecker{redis: r, client: client}
+}
+
+func federationVersionKey(host string) string {
+	return "reversi:federation:version:" + host
+}
+
+// Available reports whether the remote host exposes a reversiVersion with a
+// matching major. Return values:
+//   - true  : federation OK
+//   - false : host reachable but reversiVersion absent / incompatible
+//   - ("", err) — 別の signature で扱う必要があればそちらを使う
+//
+// キャッシュ hit なら HTTP を踏まない。cache miss で nodeinfo fetch に失敗
+// した場合は false (= unavailable) を返し、短い empty-string を cache して
+// しばらく問い合わせを抑える。
+func (c *FederationChecker) Available(ctx context.Context, host string) bool {
+	if c == nil || host == "" {
+		return false
+	}
+	version := c.remoteVersion(ctx, host)
+	return majorCompatible(version)
+}
+
+// remoteVersion returns the cached version string or empty when not available.
+// cache に値があればそれを使い、無ければ実 fetch + cache write。
+func (c *FederationChecker) remoteVersion(ctx context.Context, host string) string {
+	if c.redis != nil {
+		if v, err := c.redis.Get(ctx, federationVersionKey(host)).Result(); err == nil {
+			return v
+		}
+	}
+	version := c.fetchRemoteVersion(ctx, host)
+	if c.redis != nil {
+		// 空文字も cache する (short-circuit for repeated checks)
+		c.redis.Set(ctx, federationVersionKey(host), version, remoteVersionTTL)
+	}
+	return version
+}
+
+// fetchRemoteVersion does the actual nodeinfo fetch. 2 段階 (well-known
+// discovery → 実 nodeinfo URL) を踏む。失敗時は空文字を返す。
+func (c *FederationChecker) fetchRemoteVersion(ctx context.Context, host string) string {
+	discoveryURL := "https://" + host + "/.well-known/nodeinfo"
+	nodeinfoURL := c.resolveNodeinfoURL(ctx, discoveryURL)
+	if nodeinfoURL == "" {
+		return ""
+	}
+	body, err := c.httpGetJSON(ctx, nodeinfoURL)
+	if err != nil {
+		return ""
+	}
+	var info struct {
+		Metadata struct {
+			ReversiVersion string `json:"reversiVersion"`
+		} `json:"metadata"`
+	}
+	if err := json.Unmarshal(body, &info); err != nil {
+		return ""
+	}
+	return info.Metadata.ReversiVersion
+}
+
+// resolveNodeinfoURL walks the standard /.well-known/nodeinfo discovery
+// document and returns the actual nodeinfo JSON URL (preferring 2.1, then
+// 2.0)。discovery shape 見つからなければ空文字。
+func (c *FederationChecker) resolveNodeinfoURL(ctx context.Context, discoveryURL string) string {
+	body, err := c.httpGetJSON(ctx, discoveryURL)
+	if err != nil {
+		return ""
+	}
+	var doc struct {
+		Links []struct {
+			Rel  string `json:"rel"`
+			Href string `json:"href"`
+		} `json:"links"`
+	}
+	if err := json.Unmarshal(body, &doc); err != nil {
+		return ""
+	}
+	for _, want := range []string{
+		"http://nodeinfo.diaspora.software/ns/schema/2.1",
+		"http://nodeinfo.diaspora.software/ns/schema/2.0",
+	} {
+		for _, l := range doc.Links {
+			if l.Rel == want && l.Href != "" {
+				return l.Href
+			}
+		}
+	}
+	return ""
+}
+
+// httpGetJSON is a small GET helper that reads up to 1 MiB of body.
+func (c *FederationChecker) httpGetJSON(ctx context.Context, url string) ([]byte, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("Accept", "application/json")
+	resp, err := c.client.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return nil, errStatus{code: resp.StatusCode}
+	}
+	// 1 MiB 上限で偽装 nodeinfo による OOM を避ける。
+	return io.ReadAll(io.LimitReader(resp.Body, 1<<20))
+}
+
+type errStatus struct{ code int }
+
+func (e errStatus) Error() string { return http.StatusText(e.code) }
+
+// majorCompatible reports whether the remote reversiVersion's major matches
+// our local one. 空文字 (未知) は不可、prefix-pre-dot を比較する。
+//
+// 例: "1.1.0-mkgo" の major = "1"、"1.2.0-yojo" の major = "1"、
+//
+//	"2.0.0-foo" の major = "2"。
+func majorCompatible(remote string) bool {
+	if remote == "" {
+		return false
+	}
+	return firstDotSegment(remote) == firstDotSegment(ReversiVersion)
+}
+
+func firstDotSegment(s string) string {
+	// 先に "-" で切って (e.g. "1.1.0-mkgo" → "1.1.0") から最初の "." で切る。
+	head := s
+	if i := strings.IndexByte(head, '-'); i >= 0 {
+		head = head[:i]
+	}
+	if i := strings.IndexByte(head, '.'); i >= 0 {
+		head = head[:i]
+	}
+	return head
+}

--- a/internal/core/reversi/federation_check_test.go
+++ b/internal/core/reversi/federation_check_test.go
@@ -1,0 +1,99 @@
+package reversi
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// --- stubHTTPDoer ---
+
+type stubHTTPDoer struct {
+	responses map[string]string
+	calls     int
+}
+
+func (s *stubHTTPDoer) Do(req *http.Request) (*http.Response, error) {
+	s.calls++
+	body, ok := s.responses[req.URL.String()]
+	if !ok {
+		return &http.Response{StatusCode: http.StatusNotFound, Body: io.NopCloser(strings.NewReader(""))}, nil
+	}
+	return &http.Response{
+		StatusCode: http.StatusOK,
+		Body:       io.NopCloser(strings.NewReader(body)),
+	}, nil
+}
+
+func newStubDoer(reversiVersion string) *stubHTTPDoer {
+	discovery, _ := json.Marshal(map[string]any{
+		"links": []map[string]any{
+			{"rel": "http://nodeinfo.diaspora.software/ns/schema/2.1", "href": "https://remote.example/nodeinfo/2.1"},
+		},
+	})
+	nodeinfo, _ := json.Marshal(map[string]any{
+		"metadata": map[string]any{"reversiVersion": reversiVersion},
+	})
+	return &stubHTTPDoer{responses: map[string]string{
+		"https://remote.example/.well-known/nodeinfo": string(discovery),
+		"https://remote.example/nodeinfo/2.1":         string(nodeinfo),
+	}}
+}
+
+// --- tests ---
+
+func TestFederationChecker_AvailableMajorMatch(t *testing.T) {
+	doer := newStubDoer("1.2.5-yojo")
+	c := NewFederationChecker(nil, doer)
+	assert.True(t, c.Available(context.Background(), "remote.example"))
+}
+
+func TestFederationChecker_AvailableMajorMismatch(t *testing.T) {
+	doer := newStubDoer("2.0.0-foo")
+	c := NewFederationChecker(nil, doer)
+	assert.False(t, c.Available(context.Background(), "remote.example"))
+}
+
+func TestFederationChecker_EmptyReversiVersion(t *testing.T) {
+	doer := newStubDoer("")
+	c := NewFederationChecker(nil, doer)
+	assert.False(t, c.Available(context.Background(), "remote.example"))
+}
+
+func TestFederationChecker_DiscoveryFailure(t *testing.T) {
+	// unknown host → 404 → empty version → false
+	c := NewFederationChecker(nil, &stubHTTPDoer{responses: map[string]string{}})
+	assert.False(t, c.Available(context.Background(), "unknown.example"))
+}
+
+func TestFederationChecker_NilChecker(t *testing.T) {
+	var c *FederationChecker
+	assert.False(t, c.Available(context.Background(), "remote.example"))
+}
+
+func TestFederationChecker_EmptyHost(t *testing.T) {
+	c := NewFederationChecker(nil, &stubHTTPDoer{})
+	assert.False(t, c.Available(context.Background(), ""))
+}
+
+func TestMajorCompatible(t *testing.T) {
+	// ReversiVersion は "1.1.0-mkgo"
+	require.True(t, strings.HasPrefix(ReversiVersion, "1."))
+	assert.True(t, majorCompatible("1.1.0-mkgo"))
+	assert.True(t, majorCompatible("1.2.5-yojo"))
+	assert.False(t, majorCompatible("2.0.0-foo"))
+	assert.False(t, majorCompatible(""))
+}
+
+func TestFirstDotSegment(t *testing.T) {
+	assert.Equal(t, "1", firstDotSegment("1.1.0-mkgo"))
+	assert.Equal(t, "2", firstDotSegment("2.0"))
+	assert.Equal(t, "1", firstDotSegment("1-foo"))
+	assert.Equal(t, "1", firstDotSegment("1"))
+}

--- a/internal/server/router.go
+++ b/internal/server/router.go
@@ -1644,6 +1644,22 @@ func (s *Server) setupRoutes() {
 	reversiHandler.SetService(reversiService)
 	reversiHandler.SetFederation(s.config.URL, deliverService, reversiFedCache, userRepo)
 	reversiHandler.SetStreamPublisher(reversiPublisher)
+	// #417 P3: reversi 連合対応ホストのみ Invite を送る。Federation check
+	// 用の HTTP client は SSRF-safe transport + timeout を明示的に渡す
+	// (既存の webfingerClient と同じ設定を流用)。
+	reversiHandler.SetFederationChecker(corereversi.NewFederationChecker(
+		s.redis.Default,
+		&http.Client{
+			Timeout:   10 * time.Second,
+			Transport: safehttp.NewSSRFSafeTransport(s.config.AllowedPrivateNetworks),
+		},
+	))
+	// #417 P3: /match の acct 引数で未キャッシュのリモートユーザーを
+	// WebFinger 経由で取り込めるようにする。ここで webfingerClient /
+	// federationResolver は既存の users/show 用と同じインスタンスを再利用。
+	reversiHandler.SetRemoteUserLookup(corefederation.NewRemoteUserResolver(
+		webfingerClient, federationResolver, userRepo, localHost,
+	))
 	// Service 側にも federation 一式を注入して state 変化時に Update / Leave を
 	// 配信できるようにする (#417 P1)。fedCache も Service 側で
 	// session→game 解決に必要なので忘れず設定する。


### PR DESCRIPTION
## Summary

リバーシ連合対応サーバー同士のみマッチが成立するようにし、`@user@host` 形式で未キャッシュのリモートユーザーへの招待も可能にする。

### 具体的な機能

1. **nodeinfo に `metadata.reversiVersion` を公開** — 相手側 (CherryPick / 他 mk-go) がこちらの対応状況を判定できる
2. **`FederationChecker`** — 相手 host の nodeinfo から `reversiVersion` を取得し、メジャーバージョン一致で federation 可否を判定 (Redis 5 分キャッシュ)
3. **`/api/reversi/match` で非対応ホストを 400 弾き** — 無駄な Invite deliver と orphan game 行を防止
4. **`/api/reversi/match` で `@user@host` を WebFinger 解決** — 既存の `RemoteUserResolver` を配線

Continues #417 (P1: #429, P2: #430)

## 主な変更点

### Nodeinfo
- `api/nodeinfo/handler.go`: `metadata.reversiVersion = "1.1.0-mkgo"` (CherryPick `1.1.0-yojo` のメジャー一致)

### FederationChecker (新規)
- `core/reversi/federation_check.go`
- 2 段階 nodeinfo discovery (`/.well-known/nodeinfo` → 実 URL) → `metadata.reversiVersion` 取得
- `majorCompatible()` で先頭 `.` 区切りセグメントを比較
- Redis `reversi:federation:version:<host>` に 5 分キャッシュ
- SSRF-safe transport + 10s timeout + 1 MiB body limit

### /api/reversi/match enhancements
- remote target で `fedChecker.Available(host)` が false なら `400 NO_REVERSI_FEDERATION` を返す (ゲーム行作成前の pre-check)
- `@user@host` acct が local DB になければ `RemoteUserResolver.ResolveByUsernameHost` で WebFinger 取り込み

### Wiring
- `server/router.go` で `reversiHandler.SetFederationChecker` / `SetRemoteUserLookup` を配線 (既存 webfingerClient / federationResolver を再利用)

## フロント UX について (スコープ外の既知事項)

vanilla Misskey frontend は `/api/reversi/match` の 400 エラーを toast に surface しません (reversi/index.vue の `matchHeatbeat` 内 uncaught rejection)。そのため非対応ホストを招待すると waiting screen のまま cancel 待ちになります。

CherryPick frontend は `federation/show-instance` 経由でフロント側 pre-check + アラート表示を行いますが、フロント改修を伴うため backend-only な本プロジェクトのスコープ外です。

バックエンド側では以下 3 点を達成:
- 無駄な deliver job 発火を抑制
- orphan game 行の発生を防止
- 明示的なエラーコードで debug しやすくする

## テスト

- `TestFederationChecker_*` — nodeinfo fetch / major 判定 / unknown host / empty version / nil checker
- `TestMatch_Returns400WhenFederationUnavailable` — 非対応ホスト pre-check でゲーム行作成すらされない
- `TestMatch_SendsInviteWhenFederationAvailable` — 対応ホストは従来通り Invite 配信
- `TestMatch_AcctRemoteResolvesViaWebfinger` — `@user@host` で未キャッシュ remote user を取り込む

UDS (go.k7a.org) で実機確認:
- [x] `/nodeinfo/2.1` に `metadata.reversiVersion: "1.1.0-mkgo"` が入る
- [x] 非対応ホストへの `/match` が `400 NO_REVERSI_FEDERATION` を返す

## Related

Continues #417。残り follow-up:
- P4: Undo(Invite) 両方向
- P5: Like/reaction 両方向
- P6: round-trip integration test

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/shiroha-a/mk/pull/431" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
