### PR TITLE
Perf #432: BuildKit cache mounts for Docker builds

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -30,7 +30,3 @@ tests/dropin
 tests/dropin_frontend
 tests/playwright
 tests/bench
-
-# pyhton/JS テストスタックのスナップショット / report (もし生成された時)
-tests/dropin*/cypress/screenshots
-tests/dropin*/cypress/videos

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,3 +1,4 @@
+# 既存除外: 開発時の git / 一時 / シークレット / 成果物
 .git
 .tmp
 .env
@@ -6,3 +7,30 @@ built
 files
 node_modules
 *.md
+
+# IDE / editor 設定 (image に焼き込む意味なし)
+.vscode
+.idea
+*.swp
+*.swo
+
+# Coverage / テスト成果物 (CI で生成され、ビルドコンテキストに混ざると無駄)
+coverage*.out
+*.test
+dist
+
+# CI / dev 用 docker compose のオーバーレイ。本体 Dockerfile が参照する
+# tests/federation/common/* は別 compose の COPY 対象なので blanket 除外
+# しない (.dockerignore は全 docker build context 共通)。代わりに
+# compose / GH workflow / 開発用 docs / e2e python テストなど image に
+# 入れる必要が無いものを個別に削る。
+.github
+docs
+tests/dropin
+tests/dropin_frontend
+tests/playwright
+tests/bench
+
+# pyhton/JS テストスタックのスナップショット / report (もし生成された時)
+tests/dropin*/cypress/screenshots
+tests/dropin*/cypress/videos

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,9 @@
+# syntax=docker/dockerfile:1.7
+#
+# `# syntax=` directive は BuildKit の RUN --mount=type=cache を有効に
+# するために必須 (#432)。ローカル `docker build` でも CI (GitHub Actions
+# runner) でも default frontend が 1.5+ になる現代では `1.7` で問題なし。
+
 # Stage 1: Build Go binary
 FROM golang:1.25-alpine AS builder
 
@@ -8,7 +14,10 @@ RUN apk add --no-cache git build-base
 WORKDIR /app
 
 COPY go.mod go.sum ./
-RUN go mod download
+# go module cache を BuildKit cache mount に乗せると、再ビルド時の
+# `go mod download` が依存に変更が無ければ no-op で済む (#432)。
+RUN --mount=type=cache,target=/go/pkg/mod \
+    go mod download
 
 COPY . .
 
@@ -25,7 +34,12 @@ RUN test -f third_party/misskey/packages/backend/node_modules/@discordapp/twemoj
     (echo "ERROR: twemoji assets not found (pnpm install not run?)." && \
      echo "Run: make e2e-frontend-build (installs third_party/misskey node_modules)" && exit 1)
 
-RUN go build -trimpath -ldflags="-s -w" -o /app/built/misskey ./cmd/misskey && \
+# Go の build cache (`$GOCACHE` = /root/.cache/go-build) と module cache を
+# BuildKit cache mount として永続化する。再ビルド時に変更の無いパッケージは
+# 再コンパイルされずに layer 完成までが秒単位になる (#432)。
+RUN --mount=type=cache,target=/go/pkg/mod \
+    --mount=type=cache,target=/root/.cache/go-build \
+    go build -trimpath -ldflags="-s -w" -o /app/built/misskey ./cmd/misskey && \
     go build -trimpath -ldflags="-s -w" -o /app/built/migrate ./cmd/migrate
 
 # Stage 2: Runtime

--- a/deploy/uds/Dockerfile.mkgo
+++ b/deploy/uds/Dockerfile.mkgo
@@ -1,3 +1,5 @@
+# syntax=docker/dockerfile:1.7
+#
 # Dockerfile used by compose.uds.yaml to run mk-go under the UDS-only stack.
 #
 # Unlike the main Dockerfile it also builds the migrate binary (so the
@@ -6,6 +8,7 @@
 # the mk-go UNIX socket with `curl --unix-socket`.
 #
 # Build context must be the repository root.
+# `# syntax=` directive は BuildKit の cache mount を有効化するため必要 (#432)。
 FROM golang:1.25-alpine AS builder
 
 RUN apk add --no-cache git build-base
@@ -13,7 +16,9 @@ RUN apk add --no-cache git build-base
 WORKDIR /app
 
 COPY go.mod go.sum ./
-RUN go mod download
+# module cache を BuildKit cache mount に永続化 (#432)。
+RUN --mount=type=cache,target=/go/pkg/mod \
+    go mod download
 
 COPY . .
 
@@ -33,7 +38,10 @@ RUN test -f third_party/misskey/packages/backend/node_modules/@discordapp/twemoj
     (echo "ERROR: twemoji assets not found (pnpm install not run?)." && \
      echo "Run: make uds-frontend-build (installs third_party/misskey node_modules)" && exit 1)
 
-RUN go build -trimpath -ldflags="-s -w" -o /app/built/misskey ./cmd/misskey \
+# Go の build cache + module cache を BuildKit cache mount として永続化 (#432)。
+RUN --mount=type=cache,target=/go/pkg/mod \
+    --mount=type=cache,target=/root/.cache/go-build \
+    go build -trimpath -ldflags="-s -w" -o /app/built/misskey ./cmd/misskey \
  && go build -trimpath -ldflags="-s -w" -o /app/built/migrate ./cmd/migrate
 
 FROM alpine:3.21

--- a/tests/federation/common/Dockerfile.mkgo
+++ b/tests/federation/common/Dockerfile.mkgo
@@ -1,8 +1,11 @@
+# syntax=docker/dockerfile:1.7
+#
 # Dockerfile used only by docker-compose.federation.*.yml to run mk-go
 # inside federation tests. Unlike the main Dockerfile it also builds the
 # migrate binary and runs migrations before starting the server.
 #
 # Build context must be the repository root.
+# `# syntax=` directive は BuildKit cache mount 用 (#432)。
 FROM golang:1.25-alpine AS builder
 
 RUN apk add --no-cache git build-base
@@ -10,10 +13,13 @@ RUN apk add --no-cache git build-base
 WORKDIR /app
 
 COPY go.mod go.sum ./
-RUN go mod download
+RUN --mount=type=cache,target=/go/pkg/mod \
+    go mod download
 
 COPY . .
-RUN go build -trimpath -ldflags="-s -w" -o /app/built/misskey ./cmd/misskey \
+RUN --mount=type=cache,target=/go/pkg/mod \
+    --mount=type=cache,target=/root/.cache/go-build \
+    go build -trimpath -ldflags="-s -w" -o /app/built/misskey ./cmd/misskey \
  && go build -trimpath -ldflags="-s -w" -o /app/built/migrate ./cmd/migrate
 
 FROM alpine:3.21


### PR DESCRIPTION
## Summary

ローカル Docker build が毎回 `go mod download` + `go build` をフルでやり直していたのを、BuildKit の `RUN --mount=type=cache` で永続化する。`Dockerfile` / `deploy/uds/Dockerfile.mkgo` / `tests/federation/common/Dockerfile.mkgo` の 3 Dockerfile すべてに適用。

合わせて `.dockerignore` も拡充。本体 Dockerfile が context として使う submodule (`third_party/misskey`) は触らないが、build 成果物に焼き込まれない CI / IDE / e2e python テストスタックなどを個別に除外する。

Closes #432

## ベンチマーク（ローカル `docker build .`）

| ケース | go build step | 全体 wall-clock |
|---|---|---|
| Cold (fresh cache) | 52.3s | ~95s |
| Trivial code change の rebuild | **2.8s** | **30s** |

`go build` ステップが約 18x 高速化。再ビルド全体でも 3x 程度速くなる。

## 主な変更点

### `Dockerfile` (主)
- `# syntax=docker/dockerfile:1.7` directive を追加（cache mount を有効にするため必須）
- `COPY go.mod go.sum ./` 後の `go mod download` に `--mount=type=cache,target=/go/pkg/mod`
- `COPY . .` 後の `go build` に `--mount=type=cache,target=/go/pkg/mod` + `--mount=type=cache,target=/root/.cache/go-build`

### `deploy/uds/Dockerfile.mkgo` / `tests/federation/common/Dockerfile.mkgo`
- 上と同じパターンを適用

### `.dockerignore`
- 既存除外（`.git` / `.tmp` / `built` 等）はそのまま
- 追加: `.vscode` / `.idea` / `*.swp` / `coverage*.out` / `*.test` / `dist`
- 追加: `.github` / `docs` / `tests/dropin` / `tests/dropin_frontend` / `tests/playwright` / `tests/bench`
  - `tests/federation/common/` は別 compose の COPY 対象なので blanket 除外せず個別指定
- 追加: `tests/dropin*/cypress/screenshots` / `videos`（cypress 実行成果物）

## 互換性

- BuildKit cache mount は Docker 23+ でデフォルト有効（GitHub Actions runner / 一般的な開発環境はすべて満たす）
- 既存 `docker.yml` workflow は `cache-from/to: type=gha` を既に設定済みで、layer cache はそのまま。新しい mount cache はその上で**追加**で効くだけなので CI 動作変更なし
- runtime image の中身（binary / static-assets / twemoji / config）は不変

## テスト

- `docker build -t mk-go-test .` を 2 回流して時間計測（上記表）
- runtime image の `/app/misskey` が起動可能なことを `docker run` で確認

## 関連

- Closes #432
- フォローアップ候補: dropin-e2e / dropin-frontend-e2e workflow の `make docker-...` 経由ビルドも buildx + GHA cache に乗せる（本 PR では scope 外）
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/shiroha-a/mk/pull/436" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
