### PR TITLE
Fix #419 federation: sign AP fetches by default with instance.actor

### DIFF
--- a/internal/activitypub/client.go
+++ b/internal/activitypub/client.go
@@ -3,6 +3,7 @@ package activitypub
 import (
 	"bytes"
 	"errors"
+	"io"
 	"net/http"
 	"strings"
 
@@ -106,6 +107,7 @@ func (c *Client) FetchJSON(url string, key *PrivateKey) ([]byte, error) {
 	}
 	defer resp.Body.Close()
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		drainBody(resp)
 		return nil, &StatusError{StatusCode: resp.StatusCode, Status: resp.Status, URL: url}
 	}
 	return safehttp.ReadAllLimit(resp.Body, MaxBodyBytes)
@@ -130,9 +132,21 @@ func (c *Client) FetchUnsigned(url string) ([]byte, error) {
 	}
 	defer resp.Body.Close()
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		drainBody(resp)
 		return nil, &StatusError{StatusCode: resp.StatusCode, Status: resp.Status, URL: url}
 	}
 	return safehttp.ReadAllLimit(resp.Body, MaxBodyBytes)
+}
+
+// drainBody discards remaining bytes (up to MaxBodyBytes) on a non-2xx
+// response so the underlying TCP connection can be reused by the http
+// transport pool。authorized-fetch fallback (#419) で signed→unsigned の
+// 二段階 GET を同じ host に投げる際の connection reuse 効率を上げる。
+func drainBody(resp *http.Response) {
+	if resp == nil || resp.Body == nil {
+		return
+	}
+	_, _ = io.Copy(io.Discard, io.LimitReader(resp.Body, MaxBodyBytes))
 }
 
 // FetchHTML performs a plain GET with Accept: text/html. リモートインスタンスの

--- a/internal/activitypub/client.go
+++ b/internal/activitypub/client.go
@@ -13,6 +13,21 @@ import (
 // prevent memory exhaustion via attacker-controlled remote AP servers (#323).
 const MaxBodyBytes = safehttp.DefaultAPBodyLimit
 
+// StatusError carries the HTTP status from a failed Fetch* call so callers
+// can react to specific codes (e.g. retry with signed GET on 401/403 for
+// authorized-fetch peers like IceShrimp.NET, #419)。
+type StatusError struct {
+	StatusCode int
+	Status     string
+	URL        string
+}
+
+// Error returns "unexpected status: NNN <text>" — same shape as the legacy
+// errors.New("unexpected status: ...") so existing log readers keep working.
+func (e *StatusError) Error() string {
+	return "unexpected status: " + e.Status
+}
+
 // MaxHTMLBodyBytes caps the response body size for FetchHTML. Landing pages
 // of real Misskey / Mastodon 等は inline JS/CSS が多く1MiB (AP payload想定)
 // だと超えることが多い (#351のDevin指摘)。SPAバンドル込みでも 5MiB あれば
@@ -82,7 +97,8 @@ func (c *Client) GetSigned(url string, key *PrivateKey, acceptOverride string) (
 }
 
 // FetchJSON performs a signed GET and returns the response body. Non-2xx
-// responses produce an error.
+// responses produce a *StatusError so callers can branch on status (e.g.
+// authorized-fetch fallback on 401/403, #419)。
 func (c *Client) FetchJSON(url string, key *PrivateKey) ([]byte, error) {
 	resp, err := c.GetSigned(url, key, "")
 	if err != nil {
@@ -90,13 +106,15 @@ func (c *Client) FetchJSON(url string, key *PrivateKey) ([]byte, error) {
 	}
 	defer resp.Body.Close()
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		return nil, errors.New("unexpected status: " + resp.Status)
+		return nil, &StatusError{StatusCode: resp.StatusCode, Status: resp.Status, URL: url}
 	}
 	return safehttp.ReadAllLimit(resp.Body, MaxBodyBytes)
 }
 
 // FetchUnsigned performs a plain GET without HTTP signing. 多くのAPサーバーは
 // アクター取得を未署名で許可するため、resolver の初回 fetch 用に使う。
+// Non-2xx responses produce a *StatusError so callers can branch on status
+// (e.g. authorized-fetch fallback on 401/403, #419)。
 func (c *Client) FetchUnsigned(url string) ([]byte, error) {
 	req, err := http.NewRequest(http.MethodGet, url, nil)
 	if err != nil {
@@ -112,7 +130,7 @@ func (c *Client) FetchUnsigned(url string) ([]byte, error) {
 	}
 	defer resp.Body.Close()
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		return nil, errors.New("unexpected status: " + resp.Status)
+		return nil, &StatusError{StatusCode: resp.StatusCode, Status: resp.Status, URL: url}
 	}
 	return safehttp.ReadAllLimit(resp.Body, MaxBodyBytes)
 }

--- a/internal/activitypub/client.go
+++ b/internal/activitypub/client.go
@@ -138,7 +138,15 @@ func (c *Client) FetchUnsigned(url string) ([]byte, error) {
 	return safehttp.ReadAllLimit(resp.Body, MaxBodyBytes)
 }
 
-// drainBody discards remaining bytes (up to MaxBodyBytes) on a non-2xx
+// drainBodyLimit caps how many bytes `drainBody` is willing to read from
+// a non-2xx response before giving up on connection reuse. Most error
+// payloads (Misskey/Mastodon JSON error envelope, plain-text 4xx page) fit
+// in well under 16 KiB, so 64 KiB leaves margin for verbose stack traces
+// without giving an adversarial peer a 1 MiB read budget per error
+// response (#419 Devin review)。
+const drainBodyLimit = 64 * 1024
+
+// drainBody discards remaining bytes (up to drainBodyLimit) on a non-2xx
 // response so the underlying TCP connection can be reused by the http
 // transport pool。authorized-fetch fallback (#419) で signed→unsigned の
 // 二段階 GET を同じ host に投げる際の connection reuse 効率を上げる。
@@ -146,7 +154,7 @@ func drainBody(resp *http.Response) {
 	if resp == nil || resp.Body == nil {
 		return
 	}
-	_, _ = io.Copy(io.Discard, io.LimitReader(resp.Body, MaxBodyBytes))
+	_, _ = io.Copy(io.Discard, io.LimitReader(resp.Body, drainBodyLimit))
 }
 
 // FetchHTML performs a plain GET with Accept: text/html. リモートインスタンスの

--- a/internal/core/federation/fetcher.go
+++ b/internal/core/federation/fetcher.go
@@ -48,7 +48,15 @@ func (f *APFetcher) SetSigner(s SignerProvider) {
 func (f *APFetcher) FetchObject(uri string) ([]byte, error) {
 	if f.signer != nil {
 		key, err := f.signer.Signer()
-		if err == nil && key != nil {
+		switch {
+		case err != nil:
+			// signer が unavailable な場合の degradation がログ無しで隠れて
+			// しまうのを避ける (#419 Devin review)。事象自体の Warn ログは
+			// signer 実装側で出すので、ここでは per-fetch の Debug にとどめ
+			// て log spam を抑える。
+			slog.Debug("ap fetcher: signer unavailable, falling back to unsigned",
+				"uri", uri, "err", err)
+		case key != nil:
 			body, ferr := f.client.FetchJSON(uri, key)
 			if ferr == nil {
 				return body, nil

--- a/internal/core/federation/fetcher.go
+++ b/internal/core/federation/fetcher.go
@@ -12,8 +12,14 @@ import (
 // instance.actor system account) used to sign outgoing AP fetches.
 // 戻り値の `*PrivateKey` は parse 済みなので fetcher 側での再 parse は不要。
 // instance.actor の row / keypair は実質変わらないので実装側でキャッシュ
-// してよい。返却値が nil / err == ErrNoSigner なら APFetcher は unsigned
-// only モードで継続する。
+// してよい。
+//
+// 契約:
+//   - 成功時: (*PrivateKey, nil) を返す。nil key + nil error は invalid と
+//     し、APFetcher は unsigned-only モードにフォールバックする (将来の
+//     実装が誤って (nil, nil) を返した場合の defensive default)。
+//   - 失敗時: (nil, ErrNoSigner) を返す。実装側で transient / permanent の
+//     区別を吸収すること (例: 一定時間 backoff してから再試行)。
 type SignerProvider interface {
 	Signer() (*activitypub.PrivateKey, error)
 }

--- a/internal/core/federation/fetcher.go
+++ b/internal/core/federation/fetcher.go
@@ -3,24 +3,29 @@ package federation
 import (
 	"errors"
 	"log/slog"
+	"net/http"
 
 	"github.com/shiroha-a/mk/internal/activitypub"
 )
 
-// SignerProvider supplies the credentials of a local signer (typically the
-// instance.actor system account) used to sign outgoing AP fetches. Returning
-// an error keeps APFetcher in unsigned-only mode for that call so callers
-// don't fail just because the system account isn't available yet.
+// SignerProvider supplies the parsed private key (typically the
+// instance.actor system account) used to sign outgoing AP fetches.
+// 戻り値の `*PrivateKey` は parse 済みなので fetcher 側での再 parse は不要。
+// instance.actor の row / keypair は実質変わらないので実装側でキャッシュ
+// してよい。返却値が nil / err == ErrNoSigner なら APFetcher は unsigned
+// only モードで継続する。
 type SignerProvider interface {
-	SignerCredentials() (keyID, keyPEM string, err error)
+	Signer() (*activitypub.PrivateKey, error)
 }
 
 // APFetcher wraps an activitypub.Client to satisfy HTTPFetcher。
 //
 // Default behaviour after #419: try signed GET first using the configured
-// SignerProvider (instance.actor), fall back to unsigned GET on failure.
-// If no SignerProvider is wired, behaviour reverts to plain unsigned GET so
-// existing tests continue to work.
+// SignerProvider (instance.actor)。ピアが authorized-fetch を強制する
+// (Iceshrimp.NET / Mastodon secure mode 等) ケースを fail せずに通す。
+// 署名 GET が 401/403 を返した場合のみ unsigned GET にフォールバックする
+// (404/410 等の一過性でないエラーで二重リクエストはしない)。SignerProvider
+// が unset なら従来通り unsigned GET 一発で動く。
 type APFetcher struct {
 	client *activitypub.Client
 	signer SignerProvider
@@ -38,44 +43,54 @@ func (f *APFetcher) SetSigner(s SignerProvider) {
 }
 
 // FetchObject performs a default-signed GET against uri, falling back to
-// unsigned GET on signed-side error. Resolver でアクター取得やリモート Note
-// 取得に共通で使う。
-//
-// IceShrimp.NET のように authorized-fetch を強制する peer ではこちらが署名
-// しないと 401 が返る (#419)。逆に署名検証が緩い peer では unsigned GET の
-// 方が成功するケースもあるため、signed → unsigned の二段構えにしておく。
+// unsigned GET on 401/403. Resolver でアクター取得やリモート Note 取得に
+// 共通で使う (#419)。
 func (f *APFetcher) FetchObject(uri string) ([]byte, error) {
-	// signer が wire されていないか、credentials 取得失敗時はそのまま
-	// unsigned で行く (test / 起動直後の race)。
 	if f.signer != nil {
-		if keyID, keyPEM, err := f.signer.SignerCredentials(); err == nil {
-			if key, kerr := activitypub.NewPrivateKey(keyID, keyPEM); kerr == nil {
-				body, ferr := f.client.FetchJSON(uri, key)
-				if ferr == nil {
-					return body, nil
-				}
-				// 署名 fetch が失敗したら unsigned にフォールバック。
-				// 失敗種別 (network / 4xx / 5xx) を問わず試行する: peer の
-				// 設定次第で signed を弾くケースも有り得るため。
-				slog.Debug("ap fetcher: signed fetch failed, falling back to unsigned",
-					"uri", uri, "err", ferr)
-			} else {
-				slog.Debug("ap fetcher: signer key parse failed, falling back to unsigned",
-					"err", kerr)
+		key, err := f.signer.Signer()
+		if err == nil && key != nil {
+			body, ferr := f.client.FetchJSON(uri, key)
+			if ferr == nil {
+				return body, nil
 			}
+			// 4xx の中でも 401/403 だけがフォールバック対象。404/410 は
+			// 「リソース不在」を意味するので unsigned で再リクエストしても
+			// 結果は同じ (#419 Devin review)。
+			if !shouldFallbackToUnsigned(ferr) {
+				return nil, ferr
+			}
+			slog.Debug("ap fetcher: signed fetch unauthorized, falling back to unsigned",
+				"uri", uri, "err", ferr)
 		}
 	}
-	body, err := f.client.FetchUnsigned(uri)
-	if err != nil {
-		return nil, err
-	}
-	return body, nil
+	return f.client.FetchUnsigned(uri)
+}
+
+// FetchObjectUnsigned performs an explicit unsigned GET. nodeinfo /
+// .well-known/* など peer 認証を要求しない discovery endpoint 用 (#419
+// Devin review)。SignerProvider が wire されていても署名を付けない。
+func (f *APFetcher) FetchObjectUnsigned(uri string) ([]byte, error) {
+	return f.client.FetchUnsigned(uri)
 }
 
 // FetchHTML performs an unsigned GET with Accept: text/html. Instance metadata
 // fetcher がリモートトップページから <link rel="icon"> を抜き出す用途で使う。
 func (f *APFetcher) FetchHTML(uri string) ([]byte, error) {
 	return f.client.FetchHTML(uri)
+}
+
+// shouldFallbackToUnsigned reports whether an error from a signed fetch
+// warrants retrying without the signature. AP の authorized-fetch 系の peer
+// は鍵検証失敗で 401 / 403 を返すので、この 2 つだけフォールバック対象に
+// する。それ以外 (network error, 404, 5xx) は signed/unsigned で結果が
+// 変わらないので二重リクエストしない (#419 Devin review)。
+func shouldFallbackToUnsigned(err error) bool {
+	var se *activitypub.StatusError
+	if !errors.As(err, &se) {
+		return false
+	}
+	return se.StatusCode == http.StatusUnauthorized ||
+		se.StatusCode == http.StatusForbidden
 }
 
 // ErrNoSigner is returned by SignerProvider implementations when the local

--- a/internal/core/federation/fetcher.go
+++ b/internal/core/federation/fetcher.go
@@ -1,12 +1,29 @@
 package federation
 
 import (
+	"errors"
+	"log/slog"
+
 	"github.com/shiroha-a/mk/internal/activitypub"
 )
 
-// APFetcher wraps an activitypub.Client to satisfy HTTPFetcher.
+// SignerProvider supplies the credentials of a local signer (typically the
+// instance.actor system account) used to sign outgoing AP fetches. Returning
+// an error keeps APFetcher in unsigned-only mode for that call so callers
+// don't fail just because the system account isn't available yet.
+type SignerProvider interface {
+	SignerCredentials() (keyID, keyPEM string, err error)
+}
+
+// APFetcher wraps an activitypub.Client to satisfy HTTPFetcher。
+//
+// Default behaviour after #419: try signed GET first using the configured
+// SignerProvider (instance.actor), fall back to unsigned GET on failure.
+// If no SignerProvider is wired, behaviour reverts to plain unsigned GET so
+// existing tests continue to work.
 type APFetcher struct {
 	client *activitypub.Client
+	signer SignerProvider
 }
 
 // NewAPFetcher constructs an APFetcher.
@@ -14,10 +31,45 @@ func NewAPFetcher(client *activitypub.Client) *APFetcher {
 	return &APFetcher{client: client}
 }
 
-// FetchObject performs an unsigned GET against uri. Resolver でアクター取得や
-// リモート Note 取得に共通で使う。
+// SetSigner attaches a SignerProvider used for default signed AP fetches.
+// 未配線なら従来通り未署名 GET のみ。
+func (f *APFetcher) SetSigner(s SignerProvider) {
+	f.signer = s
+}
+
+// FetchObject performs a default-signed GET against uri, falling back to
+// unsigned GET on signed-side error. Resolver でアクター取得やリモート Note
+// 取得に共通で使う。
+//
+// IceShrimp.NET のように authorized-fetch を強制する peer ではこちらが署名
+// しないと 401 が返る (#419)。逆に署名検証が緩い peer では unsigned GET の
+// 方が成功するケースもあるため、signed → unsigned の二段構えにしておく。
 func (f *APFetcher) FetchObject(uri string) ([]byte, error) {
-	return f.client.FetchUnsigned(uri)
+	// signer が wire されていないか、credentials 取得失敗時はそのまま
+	// unsigned で行く (test / 起動直後の race)。
+	if f.signer != nil {
+		if keyID, keyPEM, err := f.signer.SignerCredentials(); err == nil {
+			if key, kerr := activitypub.NewPrivateKey(keyID, keyPEM); kerr == nil {
+				body, ferr := f.client.FetchJSON(uri, key)
+				if ferr == nil {
+					return body, nil
+				}
+				// 署名 fetch が失敗したら unsigned にフォールバック。
+				// 失敗種別 (network / 4xx / 5xx) を問わず試行する: peer の
+				// 設定次第で signed を弾くケースも有り得るため。
+				slog.Debug("ap fetcher: signed fetch failed, falling back to unsigned",
+					"uri", uri, "err", ferr)
+			} else {
+				slog.Debug("ap fetcher: signer key parse failed, falling back to unsigned",
+					"err", kerr)
+			}
+		}
+	}
+	body, err := f.client.FetchUnsigned(uri)
+	if err != nil {
+		return nil, err
+	}
+	return body, nil
 }
 
 // FetchHTML performs an unsigned GET with Accept: text/html. Instance metadata
@@ -25,3 +77,8 @@ func (f *APFetcher) FetchObject(uri string) ([]byte, error) {
 func (f *APFetcher) FetchHTML(uri string) ([]byte, error) {
 	return f.client.FetchHTML(uri)
 }
+
+// ErrNoSigner is returned by SignerProvider implementations when the local
+// instance actor / keypair is not yet provisioned. Callers treat this as
+// "skip signing this call" rather than a hard failure.
+var ErrNoSigner = errors.New("federation: instance signer not available")

--- a/internal/core/federation/fetcher_test.go
+++ b/internal/core/federation/fetcher_test.go
@@ -24,8 +24,8 @@ func genTestRSAKey(t *testing.T) *activitypub.PrivateKey {
 	key, err := rsa.GenerateKey(rand.Reader, 1024)
 	require.NoError(t, err)
 	der := x509.MarshalPKCS1PrivateKey(key)
-	pem := string(pem.EncodeToMemory(&pem.Block{Type: "RSA PRIVATE KEY", Bytes: der}))
-	pk, err := activitypub.NewPrivateKey("https://local.example/users/sys#main-key", pem)
+	pemStr := string(pem.EncodeToMemory(&pem.Block{Type: "RSA PRIVATE KEY", Bytes: der}))
+	pk, err := activitypub.NewPrivateKey("https://local.example/users/sys#main-key", pemStr)
 	require.NoError(t, err)
 	return pk
 }

--- a/internal/core/federation/fetcher_test.go
+++ b/internal/core/federation/fetcher_test.go
@@ -1,14 +1,42 @@
 package federation
 
 import (
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/x509"
+	"encoding/pem"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 
 	"github.com/shiroha-a/mk/internal/activitypub"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+// genTestRSAPEM produces a small RSA private key in PKCS#1 PEM format. Key
+// size is intentionally small (1024-bit) to keep tests fast — never use
+// these helpers in production paths.
+func genTestRSAPEM(t *testing.T) string {
+	t.Helper()
+	key, err := rsa.GenerateKey(rand.Reader, 1024)
+	require.NoError(t, err)
+	der := x509.MarshalPKCS1PrivateKey(key)
+	return string(pem.EncodeToMemory(&pem.Block{Type: "RSA PRIVATE KEY", Bytes: der}))
+}
+
+// stubSigner returns canned credentials. err != nil simulates the
+// "instance.actor not yet provisioned" branch (= ErrNoSigner)。
+type stubSigner struct {
+	keyID  string
+	keyPEM string
+	err    error
+}
+
+func (s *stubSigner) SignerCredentials() (string, string, error) {
+	return s.keyID, s.keyPEM, s.err
+}
 
 func TestAPFetcher_FetchObject(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
@@ -22,6 +50,163 @@ func TestAPFetcher_FetchObject(t *testing.T) {
 	body, err := f.FetchObject(srv.URL + "/users/alice")
 	require.NoError(t, err)
 	assert.Contains(t, string(body), "x")
+}
+
+// signer 未配線時は従来通り unsigned GET だけで動作する (#419 互換性)。
+func TestAPFetcher_FetchObject_NoSigner_UnsignedOnly(t *testing.T) {
+	var sawSig bool
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Header.Get("Signature") != "" {
+			sawSig = true
+		}
+		w.Header().Set("Content-Type", "application/activity+json")
+		_, _ = w.Write([]byte(`{"id":"x"}`))
+	}))
+	defer srv.Close()
+
+	f := NewAPFetcher(activitypub.NewClient(nil, "test"))
+	_, err := f.FetchObject(srv.URL + "/users/alice")
+	require.NoError(t, err)
+	assert.False(t, sawSig, "unsigned mode must not set Signature header")
+}
+
+// signer 配線済 + peer が signed GET を受け入れる場合は signed リクエストが
+// 通り、unsigned へのフォールバックは発生しない (#419)。
+func TestAPFetcher_FetchObject_SignedDefault_PeerAcceptsSigned(t *testing.T) {
+	var calls int
+	var firstHadSig bool
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		calls++
+		if calls == 1 && r.Header.Get("Signature") != "" {
+			firstHadSig = true
+		}
+		w.Header().Set("Content-Type", "application/activity+json")
+		_, _ = w.Write([]byte(`{"id":"signed"}`))
+	}))
+	defer srv.Close()
+
+	f := NewAPFetcher(activitypub.NewClient(nil, "test"))
+	f.SetSigner(&stubSigner{
+		keyID:  "https://local.example/users/sys#main-key",
+		keyPEM: genTestRSAPEM(t),
+	})
+	body, err := f.FetchObject(srv.URL + "/users/alice")
+	require.NoError(t, err)
+	assert.Equal(t, 1, calls, "should not fall back when signed succeeded")
+	assert.True(t, firstHadSig, "signed GET must include Signature header")
+	assert.Contains(t, string(body), "signed")
+}
+
+// IceShrimp.NET 等の authorized-fetch peer (signed のみ受理) でも、署名
+// 鍵が wire されていれば 1 発で通る。これが #419 の core fix。
+func TestAPFetcher_FetchObject_SignedDefault_AuthorizedFetchPeer(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Header.Get("Signature") == "" {
+			w.WriteHeader(http.StatusUnauthorized)
+			_, _ = w.Write([]byte(`{"error":"missing signature"}`))
+			return
+		}
+		w.Header().Set("Content-Type", "application/activity+json")
+		_, _ = w.Write([]byte(`{"id":"ok"}`))
+	}))
+	defer srv.Close()
+
+	f := NewAPFetcher(activitypub.NewClient(nil, "test"))
+	f.SetSigner(&stubSigner{
+		keyID:  "https://local.example/users/sys#main-key",
+		keyPEM: genTestRSAPEM(t),
+	})
+	body, err := f.FetchObject(srv.URL + "/users/alice")
+	require.NoError(t, err)
+	assert.Contains(t, string(body), "ok")
+}
+
+// signed GET が失敗した時は従来の unsigned GET にフォールバックする (signature
+// 検証が緩い peer や signer key 不在時の互換性確保)。
+func TestAPFetcher_FetchObject_FallsBackToUnsignedOnSignedError(t *testing.T) {
+	var unsignedHits int
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Header.Get("Signature") != "" {
+			// 例えば peer 側で signature verification 失敗 → 4xx
+			w.WriteHeader(http.StatusForbidden)
+			_, _ = w.Write([]byte(`{"error":"bad sig"}`))
+			return
+		}
+		unsignedHits++
+		w.Header().Set("Content-Type", "application/activity+json")
+		_, _ = w.Write([]byte(`{"id":"unsigned-ok"}`))
+	}))
+	defer srv.Close()
+
+	f := NewAPFetcher(activitypub.NewClient(nil, "test"))
+	f.SetSigner(&stubSigner{
+		keyID:  "https://local.example/users/sys#main-key",
+		keyPEM: genTestRSAPEM(t),
+	})
+	body, err := f.FetchObject(srv.URL + "/users/alice")
+	require.NoError(t, err)
+	assert.Equal(t, 1, unsignedHits, "expect single unsigned fallback")
+	assert.Contains(t, string(body), "unsigned-ok")
+}
+
+// SignerCredentials がエラー (instance.actor 未プロビジョン等) を返す場合は
+// 即 unsigned へ落ちる。ErrNoSigner のセマンティクスを担保する。
+func TestAPFetcher_FetchObject_SignerErrorSkipsToUnsigned(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/activity+json")
+		_, _ = w.Write([]byte(`{"id":"y"}`))
+	}))
+	defer srv.Close()
+
+	f := NewAPFetcher(activitypub.NewClient(nil, "test"))
+	f.SetSigner(&stubSigner{err: ErrNoSigner})
+	body, err := f.FetchObject(srv.URL + "/users/alice")
+	require.NoError(t, err)
+	assert.Contains(t, string(body), "y")
+}
+
+// FetchUnsigned / FetchJSON が non-2xx で StatusError を返すことを確認する。
+// IceShrimp.NET の 401 を上位で識別するための土台 (#419)。
+func TestActivityPubClient_FetchUnsigned_NonOkReturnsStatusError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusUnauthorized)
+	}))
+	defer srv.Close()
+	_, err := activitypub.NewClient(nil, "test").FetchUnsigned(srv.URL + "/")
+	require.Error(t, err)
+	var se *activitypub.StatusError
+	require.True(t, errorsAs(err, &se))
+	assert.Equal(t, http.StatusUnauthorized, se.StatusCode)
+}
+
+// errorsAs is a tiny errors.As shim usable in test code without pulling in
+// the whole errors package import here. Keeps the test file imports tidy.
+func errorsAs(err error, target any) bool {
+	se, ok := target.(**activitypub.StatusError)
+	if !ok {
+		return false
+	}
+	for e := err; e != nil; {
+		if v, ok := e.(*activitypub.StatusError); ok {
+			*se = v
+			return true
+		}
+		// 単純な Wrap 想定: Errorf("...: %w", inner) を unwrap
+		type unwrapper interface{ Unwrap() error }
+		if u, ok := e.(unwrapper); ok {
+			e = u.Unwrap()
+			continue
+		}
+		break
+	}
+	return false
+}
+
+// 互換性: 既存の fmt.Errorf("unexpected status: ...").Error() 文字列依存
+// callsite が無いか軽くチェックする (regression 防止)。
+func TestStatusError_PreservesLegacyErrorString(t *testing.T) {
+	se := &activitypub.StatusError{StatusCode: 401, Status: "401 Unauthorized", URL: "x"}
+	assert.True(t, strings.HasPrefix(se.Error(), "unexpected status:"))
 }
 
 func TestAPFetcher_FetchHTML(t *testing.T) {

--- a/internal/core/federation/fetcher_test.go
+++ b/internal/core/federation/fetcher_test.go
@@ -5,6 +5,7 @@ import (
 	"crypto/rsa"
 	"crypto/x509"
 	"encoding/pem"
+	"errors"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -15,27 +16,29 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// genTestRSAPEM produces a small RSA private key in PKCS#1 PEM format. Key
-// size is intentionally small (1024-bit) to keep tests fast — never use
-// these helpers in production paths.
-func genTestRSAPEM(t *testing.T) string {
+// genTestRSAKey produces a parsed *PrivateKey backed by a small RSA key.
+// Key size is intentionally small (1024-bit) to keep tests fast — never
+// use this helper in production paths.
+func genTestRSAKey(t *testing.T) *activitypub.PrivateKey {
 	t.Helper()
 	key, err := rsa.GenerateKey(rand.Reader, 1024)
 	require.NoError(t, err)
 	der := x509.MarshalPKCS1PrivateKey(key)
-	return string(pem.EncodeToMemory(&pem.Block{Type: "RSA PRIVATE KEY", Bytes: der}))
+	pem := string(pem.EncodeToMemory(&pem.Block{Type: "RSA PRIVATE KEY", Bytes: der}))
+	pk, err := activitypub.NewPrivateKey("https://local.example/users/sys#main-key", pem)
+	require.NoError(t, err)
+	return pk
 }
 
-// stubSigner returns canned credentials. err != nil simulates the
+// stubSigner returns a canned PrivateKey. err != nil simulates the
 // "instance.actor not yet provisioned" branch (= ErrNoSigner)。
 type stubSigner struct {
-	keyID  string
-	keyPEM string
-	err    error
+	key *activitypub.PrivateKey
+	err error
 }
 
-func (s *stubSigner) SignerCredentials() (string, string, error) {
-	return s.keyID, s.keyPEM, s.err
+func (s *stubSigner) Signer() (*activitypub.PrivateKey, error) {
+	return s.key, s.err
 }
 
 func TestAPFetcher_FetchObject(t *testing.T) {
@@ -86,10 +89,7 @@ func TestAPFetcher_FetchObject_SignedDefault_PeerAcceptsSigned(t *testing.T) {
 	defer srv.Close()
 
 	f := NewAPFetcher(activitypub.NewClient(nil, "test"))
-	f.SetSigner(&stubSigner{
-		keyID:  "https://local.example/users/sys#main-key",
-		keyPEM: genTestRSAPEM(t),
-	})
+	f.SetSigner(&stubSigner{key: genTestRSAKey(t)})
 	body, err := f.FetchObject(srv.URL + "/users/alice")
 	require.NoError(t, err)
 	assert.Equal(t, 1, calls, "should not fall back when signed succeeded")
@@ -112,22 +112,18 @@ func TestAPFetcher_FetchObject_SignedDefault_AuthorizedFetchPeer(t *testing.T) {
 	defer srv.Close()
 
 	f := NewAPFetcher(activitypub.NewClient(nil, "test"))
-	f.SetSigner(&stubSigner{
-		keyID:  "https://local.example/users/sys#main-key",
-		keyPEM: genTestRSAPEM(t),
-	})
+	f.SetSigner(&stubSigner{key: genTestRSAKey(t)})
 	body, err := f.FetchObject(srv.URL + "/users/alice")
 	require.NoError(t, err)
 	assert.Contains(t, string(body), "ok")
 }
 
-// signed GET が失敗した時は従来の unsigned GET にフォールバックする (signature
-// 検証が緩い peer や signer key 不在時の互換性確保)。
-func TestAPFetcher_FetchObject_FallsBackToUnsignedOnSignedError(t *testing.T) {
+// signed GET が 401/403 を返した時は unsigned GET にフォールバックする
+// (signature 検証が緩い peer での互換性確保, #419)。
+func TestAPFetcher_FetchObject_FallsBackToUnsignedOnAuthError(t *testing.T) {
 	var unsignedHits int
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.Header.Get("Signature") != "" {
-			// 例えば peer 側で signature verification 失敗 → 4xx
 			w.WriteHeader(http.StatusForbidden)
 			_, _ = w.Write([]byte(`{"error":"bad sig"}`))
 			return
@@ -139,14 +135,28 @@ func TestAPFetcher_FetchObject_FallsBackToUnsignedOnSignedError(t *testing.T) {
 	defer srv.Close()
 
 	f := NewAPFetcher(activitypub.NewClient(nil, "test"))
-	f.SetSigner(&stubSigner{
-		keyID:  "https://local.example/users/sys#main-key",
-		keyPEM: genTestRSAPEM(t),
-	})
+	f.SetSigner(&stubSigner{key: genTestRSAKey(t)})
 	body, err := f.FetchObject(srv.URL + "/users/alice")
 	require.NoError(t, err)
 	assert.Equal(t, 1, unsignedHits, "expect single unsigned fallback")
 	assert.Contains(t, string(body), "unsigned-ok")
+}
+
+// 404 / 5xx 等で unsigned リトライを飛ばすことで二重リクエストを抑制する
+// (#419 Devin review)。signed の失敗をそのまま上位に返す。
+func TestAPFetcher_FetchObject_DoesNotFallBackOnNotFound(t *testing.T) {
+	var totalHits int
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		totalHits++
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	defer srv.Close()
+
+	f := NewAPFetcher(activitypub.NewClient(nil, "test"))
+	f.SetSigner(&stubSigner{key: genTestRSAKey(t)})
+	_, err := f.FetchObject(srv.URL + "/users/alice")
+	require.Error(t, err)
+	assert.Equal(t, 1, totalHits, "404 must not trigger unsigned retry")
 }
 
 // SignerCredentials がエラー (instance.actor 未プロビジョン等) を返す場合は
@@ -175,31 +185,8 @@ func TestActivityPubClient_FetchUnsigned_NonOkReturnsStatusError(t *testing.T) {
 	_, err := activitypub.NewClient(nil, "test").FetchUnsigned(srv.URL + "/")
 	require.Error(t, err)
 	var se *activitypub.StatusError
-	require.True(t, errorsAs(err, &se))
+	require.True(t, errors.As(err, &se))
 	assert.Equal(t, http.StatusUnauthorized, se.StatusCode)
-}
-
-// errorsAs is a tiny errors.As shim usable in test code without pulling in
-// the whole errors package import here. Keeps the test file imports tidy.
-func errorsAs(err error, target any) bool {
-	se, ok := target.(**activitypub.StatusError)
-	if !ok {
-		return false
-	}
-	for e := err; e != nil; {
-		if v, ok := e.(*activitypub.StatusError); ok {
-			*se = v
-			return true
-		}
-		// 単純な Wrap 想定: Errorf("...: %w", inner) を unwrap
-		type unwrapper interface{ Unwrap() error }
-		if u, ok := e.(unwrapper); ok {
-			e = u.Unwrap()
-			continue
-		}
-		break
-	}
-	return false
 }
 
 // 互換性: 既存の fmt.Errorf("unexpected status: ...").Error() 文字列依存

--- a/internal/core/instance/fetch_metadata.go
+++ b/internal/core/instance/fetch_metadata.go
@@ -14,8 +14,12 @@ import (
 
 // HTTPFetcher abstracts the HTTP clients used to fetch nodeinfo documents and
 // remote HTML. 実装は activitypub.Client の薄いラッパで十分。
+//
+// nodeinfo / .well-known は peer 認証を要求しない discovery endpoint なので
+// 署名 GET を付ける必要がない。FetchObjectUnsigned 経由で明示的に未署名
+// リクエストを投げる (#419)。
 type HTTPFetcher interface {
-	FetchObject(uri string) ([]byte, error)
+	FetchObjectUnsigned(uri string) ([]byte, error)
 	FetchHTML(uri string) ([]byte, error)
 }
 
@@ -226,7 +230,7 @@ func firstNonEmptyStr(vals ...string) string {
 
 // fetchDiscovery fetches /.well-known/nodeinfo and decodes the link list.
 func (s *FetchMetadataService) fetchDiscovery(host string) (*nodeinfoDiscovery, error) {
-	body, err := s.fetcher.FetchObject("https://" + host + "/.well-known/nodeinfo")
+	body, err := s.fetcher.FetchObjectUnsigned("https://" + host + "/.well-known/nodeinfo")
 	if err != nil {
 		return nil, err
 	}
@@ -239,7 +243,7 @@ func (s *FetchMetadataService) fetchDiscovery(host string) (*nodeinfoDiscovery, 
 
 // fetchDocument fetches the actual nodeinfo document.
 func (s *FetchMetadataService) fetchDocument(href string) (*nodeinfoDocument, error) {
-	body, err := s.fetcher.FetchObject(href)
+	body, err := s.fetcher.FetchObjectUnsigned(href)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/core/instance/fetch_metadata_test.go
+++ b/internal/core/instance/fetch_metadata_test.go
@@ -14,20 +14,21 @@ import (
 )
 
 // scriptedFetcher returns canned responses keyed by call order.
-// FetchObject / FetchHTML それぞれ独立カウンタで bodies / errs を消費する。
+// FetchObjectUnsigned / FetchHTML それぞれ独立カウンタで bodies / errs を
+// 消費する。
 type scriptedFetcher struct {
 	bodies [][]byte
 	errs   []error
 	idx    int
 
-	// HTMLレスポンスは FetchObject と独立に供給する。未設定ならFetchHTML呼出
-	// は error を返してicon抽出 step を no-op にする (nodeinfo テストを
-	// icon logicの追加で壊さないため)。
+	// HTMLレスポンスは nodeinfo fetch と独立に供給する。未設定なら
+	// FetchHTML 呼出は error を返して icon 抽出 step を no-op にする
+	// (nodeinfo テストを icon logic の追加で壊さないため)。
 	htmlBody []byte
 	htmlErr  error
 }
 
-func (s *scriptedFetcher) FetchObject(_ string) ([]byte, error) {
+func (s *scriptedFetcher) FetchObjectUnsigned(_ string) ([]byte, error) {
 	if s.idx >= len(s.bodies) {
 		return nil, errors.New("no more bodies")
 	}

--- a/internal/server/router.go
+++ b/internal/server/router.go
@@ -2150,7 +2150,7 @@ type instanceActorSigner struct {
 	keypair repository.UserKeypairRepository
 	urls    *activitypub.URLBuilder
 
-	mu          sync.Mutex
+	mu          sync.RWMutex
 	cachedKey   *activitypub.PrivateKey
 	lastFailure time.Time
 }
@@ -2169,9 +2169,23 @@ func newInstanceActorSigner(
 
 // Signer returns the parsed instance.actor PrivateKey. corefederation.ErrNoSigner
 // を返した場合 APFetcher は unsigned-only モードで継続する。
+//
+// double-checked locking で hot path (cache hit) を read-lock のみにし、
+// 同時 fetch が DB query 待ちで直列化しないようにする (#419 Devin review)。
 func (s *instanceActorSigner) Signer() (*activitypub.PrivateKey, error) {
+	// Fast path: 既に load 済みなら read-lock だけで返す
+	s.mu.RLock()
+	if k := s.cachedKey; k != nil {
+		s.mu.RUnlock()
+		return k, nil
+	}
+	s.mu.RUnlock()
+
+	// Slow path: load を試みる
 	s.mu.Lock()
 	defer s.mu.Unlock()
+	// double-check: lock 取得待ちの間に他 goroutine が load を成功させた
+	// 可能性
 	if s.cachedKey != nil {
 		return s.cachedKey, nil
 	}

--- a/internal/server/router.go
+++ b/internal/server/router.go
@@ -11,6 +11,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/labstack/echo/v4"
@@ -2136,14 +2137,19 @@ func (a *notifReaderAdapter) ReadAll(userID string) error {
 // instanceActorSigner is the SignerProvider used by APFetcher to sign
 // outgoing GETs with the instance.actor system account (#419)。
 //
-// 各 fetch ごとに systemaccount.Fetch + keypair Lookup を呼ぶ。実体は in-memory
-// cache 化されており (systemaccount は upsert + saRepo lookup、keypairRepo は
-// 単純 row fetch) per-fetch overhead は無視できる。lazy 解決により起動順序
-// (apFetcher 構築 < sysAcctSvc 構築) の制約を緩める利点もある。
+// 初回 Signer() で systemaccount.Fetch + keypair lookup + RSA PEM parse を
+// やってから、結果 (parse 済みの *PrivateKey) を sync.Once 経由でキャッシュ
+// する。instance.actor は process lifetime 中に変わらない前提なので無期限
+// に握ってよい。再起動で再ロードされる。lazy 解決により起動順序
+// (apFetcher 構築 < sysAcctSvc 構築) の制約を緩めている。
 type instanceActorSigner struct {
 	sysAcct *coresystemaccount.Service
 	keypair repository.UserKeypairRepository
 	urls    *activitypub.URLBuilder
+
+	once sync.Once
+	key  *activitypub.PrivateKey
+	err  error
 }
 
 func newInstanceActorSigner(
@@ -2154,17 +2160,31 @@ func newInstanceActorSigner(
 	return &instanceActorSigner{sysAcct: svc, keypair: kp, urls: urls}
 }
 
-// SignerCredentials returns the keyId URI and PEM private key of
-// instance.actor. corefederation.ErrNoSigner を返した場合 APFetcher は
-// unsigned-only モードで継続する。
-func (s *instanceActorSigner) SignerCredentials() (string, string, error) {
+// Signer returns the parsed instance.actor PrivateKey. corefederation.ErrNoSigner
+// を返した場合 APFetcher は unsigned-only モードで継続する。
+func (s *instanceActorSigner) Signer() (*activitypub.PrivateKey, error) {
+	s.once.Do(s.load)
+	if s.err != nil {
+		return nil, s.err
+	}
+	return s.key, nil
+}
+
+func (s *instanceActorSigner) load() {
 	user, err := s.sysAcct.Fetch("instance")
 	if err != nil || user == nil {
-		return "", "", corefederation.ErrNoSigner
+		s.err = corefederation.ErrNoSigner
+		return
 	}
 	kp, err := s.keypair.FindByUserID(user.ID)
 	if err != nil || kp == nil || kp.PrivateKey == "" {
-		return "", "", corefederation.ErrNoSigner
+		s.err = corefederation.ErrNoSigner
+		return
 	}
-	return s.urls.UserKeyURI(user.ID), kp.PrivateKey, nil
+	key, err := activitypub.NewPrivateKey(s.urls.UserKeyURI(user.ID), kp.PrivateKey)
+	if err != nil {
+		s.err = corefederation.ErrNoSigner
+		return
+	}
+	s.key = key
 }

--- a/internal/server/router.go
+++ b/internal/server/router.go
@@ -2138,19 +2138,26 @@ func (a *notifReaderAdapter) ReadAll(userID string) error {
 // outgoing GETs with the instance.actor system account (#419)。
 //
 // 初回 Signer() で systemaccount.Fetch + keypair lookup + RSA PEM parse を
-// やってから、結果 (parse 済みの *PrivateKey) を sync.Once 経由でキャッシュ
-// する。instance.actor は process lifetime 中に変わらない前提なので無期限
-// に握ってよい。再起動で再ロードされる。lazy 解決により起動順序
-// (apFetcher 構築 < sysAcctSvc 構築) の制約を緩めている。
+// やってから、結果 (parse 済みの *PrivateKey) を mutex 配下にキャッシュする。
+// 一度成功した key は process lifetime 中に変わらない前提で無期限保持し、
+// 再起動で再ロードされる。
+//
+// 失敗側はキャッシュしない: transient な DB glitch で起動直後に load が
+// コケた時、その後ずっと unsigned-only に張り付くことを避けるため、失敗
+// を `signerLoadBackoff` だけ抑制してから再試行する (#419 Devin review)。
 type instanceActorSigner struct {
 	sysAcct *coresystemaccount.Service
 	keypair repository.UserKeypairRepository
 	urls    *activitypub.URLBuilder
 
-	once sync.Once
-	key  *activitypub.PrivateKey
-	err  error
+	mu          sync.Mutex
+	cachedKey   *activitypub.PrivateKey
+	lastFailure time.Time
 }
+
+// signerLoadBackoff は load() 失敗後の再試行抑制間隔。DB が一時的に死んだ
+// 時に Signer() の per-fetch で同じクエリを叩き続けないようにする。
+const signerLoadBackoff = 30 * time.Second
 
 func newInstanceActorSigner(
 	svc *coresystemaccount.Service,
@@ -2163,28 +2170,46 @@ func newInstanceActorSigner(
 // Signer returns the parsed instance.actor PrivateKey. corefederation.ErrNoSigner
 // を返した場合 APFetcher は unsigned-only モードで継続する。
 func (s *instanceActorSigner) Signer() (*activitypub.PrivateKey, error) {
-	s.once.Do(s.load)
-	if s.err != nil {
-		return nil, s.err
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.cachedKey != nil {
+		return s.cachedKey, nil
 	}
-	return s.key, nil
+	if !s.lastFailure.IsZero() && time.Since(s.lastFailure) < signerLoadBackoff {
+		// 直近の失敗から十分時間が経っていない → DB spam 抑制で
+		// 即 ErrNoSigner を返す。
+		return nil, corefederation.ErrNoSigner
+	}
+	key, err := s.loadLocked()
+	if err != nil {
+		s.lastFailure = time.Now()
+		return nil, corefederation.ErrNoSigner
+	}
+	s.cachedKey = key
+	s.lastFailure = time.Time{}
+	return key, nil
 }
 
-func (s *instanceActorSigner) load() {
+// loadLocked performs the actual systemaccount + keypair + PEM parse. mu を
+// 既に保持している前提。
+func (s *instanceActorSigner) loadLocked() (*activitypub.PrivateKey, error) {
 	user, err := s.sysAcct.Fetch("instance")
 	if err != nil || user == nil {
-		s.err = corefederation.ErrNoSigner
-		return
+		slog.Warn("instance.actor signer: system account fetch failed; AP fetches will fall back to unsigned",
+			"err", err)
+		return nil, corefederation.ErrNoSigner
 	}
 	kp, err := s.keypair.FindByUserID(user.ID)
 	if err != nil || kp == nil || kp.PrivateKey == "" {
-		s.err = corefederation.ErrNoSigner
-		return
+		slog.Warn("instance.actor signer: keypair lookup failed; AP fetches will fall back to unsigned",
+			"userId", user.ID, "err", err)
+		return nil, corefederation.ErrNoSigner
 	}
 	key, err := activitypub.NewPrivateKey(s.urls.UserKeyURI(user.ID), kp.PrivateKey)
 	if err != nil {
-		s.err = corefederation.ErrNoSigner
-		return
+		slog.Warn("instance.actor signer: PEM parse failed; AP fetches will fall back to unsigned",
+			"userId", user.ID, "err", err)
+		return nil, corefederation.ErrNoSigner
 	}
-	s.key = key
+	return key, nil
 }

--- a/internal/server/router.go
+++ b/internal/server/router.go
@@ -440,6 +440,13 @@ func (s *Server) setupRoutes() {
 	sysAcctSvc := coresystemaccount.NewService(userRepo, keypairRepo, repository.NewSystemAccountRepository(s.db), idGen)
 	relaySvc := corerelay.NewService(repository.NewRelayRepository(s.db), sysAcctSvc, apRenderer, deliverService, idGen)
 
+	// AP fetch のデフォルト signer に instance.actor を配線する (#419)。
+	// IceShrimp.NET 等の authorized-fetch peer では未署名 GET が 401 で
+	// 弾かれるため、apFetcher.FetchObject は signed GET を優先しに行く。
+	// 署名失敗時は従来通り unsigned にフォールバック (deliver_service と
+	// 同じ keyID 形式 = `<baseURL>/users/<id>#main-key`)。
+	apFetcher.SetSigner(newInstanceActorSigner(sysAcctSvc, keypairRepo, apURLs))
+
 	noteDeliveryHook := corefederation.NewNoteDeliveryHook(deliverService, apRenderer, apURLs, idGen, userRepo, noteRepo)
 	noteDeliveryHook.SetRelayBroadcaster(relaySvc)
 	noteCreateService.SetFederationHook(noteDeliveryHook)
@@ -2124,4 +2131,40 @@ type notifReaderAdapter struct {
 
 func (a *notifReaderAdapter) ReadAll(userID string) error {
 	return a.svc.MarkAllAsRead(context.Background(), userID)
+}
+
+// instanceActorSigner is the SignerProvider used by APFetcher to sign
+// outgoing GETs with the instance.actor system account (#419)。
+//
+// 各 fetch ごとに systemaccount.Fetch + keypair Lookup を呼ぶ。実体は in-memory
+// cache 化されており (systemaccount は upsert + saRepo lookup、keypairRepo は
+// 単純 row fetch) per-fetch overhead は無視できる。lazy 解決により起動順序
+// (apFetcher 構築 < sysAcctSvc 構築) の制約を緩める利点もある。
+type instanceActorSigner struct {
+	sysAcct *coresystemaccount.Service
+	keypair repository.UserKeypairRepository
+	urls    *activitypub.URLBuilder
+}
+
+func newInstanceActorSigner(
+	svc *coresystemaccount.Service,
+	kp repository.UserKeypairRepository,
+	urls *activitypub.URLBuilder,
+) *instanceActorSigner {
+	return &instanceActorSigner{sysAcct: svc, keypair: kp, urls: urls}
+}
+
+// SignerCredentials returns the keyId URI and PEM private key of
+// instance.actor. corefederation.ErrNoSigner を返した場合 APFetcher は
+// unsigned-only モードで継続する。
+func (s *instanceActorSigner) SignerCredentials() (string, string, error) {
+	user, err := s.sysAcct.Fetch("instance")
+	if err != nil || user == nil {
+		return "", "", corefederation.ErrNoSigner
+	}
+	kp, err := s.keypair.FindByUserID(user.ID)
+	if err != nil || kp == nil || kp.PrivateKey == "" {
+		return "", "", corefederation.ErrNoSigner
+	}
+	return s.urls.UserKeyURI(user.ID), kp.PrivateKey, nil
 }

--- a/internal/server/router.go
+++ b/internal/server/router.go
@@ -2172,6 +2172,8 @@ func newInstanceActorSigner(
 //
 // double-checked locking で hot path (cache hit) を read-lock のみにし、
 // 同時 fetch が DB query 待ちで直列化しないようにする (#419 Devin review)。
+// slog.Warn は lock 解除後に呼んで、log handler が遅い時に他の goroutine を
+// 詰まらせない (#419 Devin review)。
 func (s *instanceActorSigner) Signer() (*activitypub.PrivateKey, error) {
 	// Fast path: 既に load 済みなら read-lock だけで返す
 	s.mu.RLock()
@@ -2182,48 +2184,64 @@ func (s *instanceActorSigner) Signer() (*activitypub.PrivateKey, error) {
 	s.mu.RUnlock()
 
 	// Slow path: load を試みる
+	var (
+		loaded  *activitypub.PrivateKey
+		loadLog func() // nil 以外なら lock 解除後に呼ぶ Warn ログ
+	)
 	s.mu.Lock()
-	defer s.mu.Unlock()
-	// double-check: lock 取得待ちの間に他 goroutine が load を成功させた
-	// 可能性
-	if s.cachedKey != nil {
-		return s.cachedKey, nil
+	switch {
+	case s.cachedKey != nil:
+		// double-check: lock 取得待ちの間に他 goroutine が load を成功させた
+		loaded = s.cachedKey
+	case !s.lastFailure.IsZero() && time.Since(s.lastFailure) < signerLoadBackoff:
+		// 直近の失敗から十分時間が経っていない → DB spam 抑制で skip
+	default:
+		key, logFn := s.loadLocked()
+		loadLog = logFn
+		if key != nil {
+			s.cachedKey = key
+			s.lastFailure = time.Time{}
+			loaded = key
+		} else {
+			s.lastFailure = time.Now()
+		}
 	}
-	if !s.lastFailure.IsZero() && time.Since(s.lastFailure) < signerLoadBackoff {
-		// 直近の失敗から十分時間が経っていない → DB spam 抑制で
-		// 即 ErrNoSigner を返す。
-		return nil, corefederation.ErrNoSigner
+	s.mu.Unlock()
+
+	if loadLog != nil {
+		loadLog()
 	}
-	key, err := s.loadLocked()
-	if err != nil {
-		s.lastFailure = time.Now()
-		return nil, corefederation.ErrNoSigner
+	if loaded != nil {
+		return loaded, nil
 	}
-	s.cachedKey = key
-	s.lastFailure = time.Time{}
-	return key, nil
+	return nil, corefederation.ErrNoSigner
 }
 
 // loadLocked performs the actual systemaccount + keypair + PEM parse. mu を
-// 既に保持している前提。
-func (s *instanceActorSigner) loadLocked() (*activitypub.PrivateKey, error) {
+// 既に保持している前提。Warn ログ呼び出しは caller (Signer) が lock 解除後
+// に走らせるよう関数値で返す (sync 化されたログハンドラ呼び出しが他の
+// goroutine をブロックしないため, #419 Devin review)。
+func (s *instanceActorSigner) loadLocked() (*activitypub.PrivateKey, func()) {
 	user, err := s.sysAcct.Fetch("instance")
 	if err != nil || user == nil {
-		slog.Warn("instance.actor signer: system account fetch failed; AP fetches will fall back to unsigned",
-			"err", err)
-		return nil, corefederation.ErrNoSigner
+		return nil, func() {
+			slog.Warn("instance.actor signer: system account fetch failed; AP fetches will fall back to unsigned",
+				"err", err)
+		}
 	}
 	kp, err := s.keypair.FindByUserID(user.ID)
 	if err != nil || kp == nil || kp.PrivateKey == "" {
-		slog.Warn("instance.actor signer: keypair lookup failed; AP fetches will fall back to unsigned",
-			"userId", user.ID, "err", err)
-		return nil, corefederation.ErrNoSigner
+		return nil, func() {
+			slog.Warn("instance.actor signer: keypair lookup failed; AP fetches will fall back to unsigned",
+				"userId", user.ID, "err", err)
+		}
 	}
 	key, err := activitypub.NewPrivateKey(s.urls.UserKeyURI(user.ID), kp.PrivateKey)
 	if err != nil {
-		slog.Warn("instance.actor signer: PEM parse failed; AP fetches will fall back to unsigned",
-			"userId", user.ID, "err", err)
-		return nil, corefederation.ErrNoSigner
+		return nil, func() {
+			slog.Warn("instance.actor signer: PEM parse failed; AP fetches will fall back to unsigned",
+				"userId", user.ID, "err", err)
+		}
 	}
 	return key, nil
 }


### PR DESCRIPTION
## Summary

特定のリモートピア（IceShrimp.NET 系インスタンス、および Mastodon の secure mode を有効にしているサーバー）は ActivityPub の actor / object 取得 GET に **HTTP Signature 必須**の認可ミドルウェアを掛けている。mk-go の `APFetcher.FetchObject` は `client.FetchUnsigned` を呼ぶ実装だったため、これらのピアでは：

```
HTTP/2 401 Unauthorized
{"error":"Unauthorized","message":"Request is missing the signature header",
 "source":"...AuthorizedFetchMiddleware..."}
```

で弾かれ、WebFinger → upsert の途中で resolver が抜けてしまっていた。結果としてフロントは「ユーザーが見つかりません」を表示する。

本 PR では mk-go が既に持っている **instance.actor** system account（`systemaccount.Service` の `instance` kind）の鍵で AP fetch をデフォルト署名するよう変更する。署名失敗時は従来通り unsigned にフォールバックするので緩いピアとの互換性も維持する。

Closes #419

## 変更

- `internal/activitypub/client.go`
  - `StatusError` を導入。`FetchUnsigned` / `FetchJSON` が non-2xx で返すエラーを構造化（HTTP status を上位で参照可能に）。エラー文字列フォーマット `"unexpected status: ..."` は据え置き。
- `internal/core/federation/fetcher.go`
  - `SignerProvider` インターフェース + `APFetcher.SetSigner` セッターを追加。
  - `FetchObject` は signer が wire されていれば signed GET を先に試み、失敗したら unsigned にフォールバック。signer が unset / `ErrNoSigner` の場合は unsigned 一発（既存テスト互換）。
- `internal/server/router.go`
  - `instanceActorSigner` adapter を追加。`systemaccount.Service.Fetch(\"instance\")` + `UserKeypairRepository.FindByUserID` を **lazy** に呼んで keyID/PEM を返す。construction order の制約を緩めるため遅延解決にしている。
  - `sysAcctSvc` 構築直後に `apFetcher.SetSigner(...)` で配線。

### テスト

新規 7 件 + 既存維持：

- `TestAPFetcher_FetchObject_SignedDefault_PeerAcceptsSigned` — signed 1 発で完了、unsigned へフォールバックしない
- `TestAPFetcher_FetchObject_SignedDefault_AuthorizedFetchPeer` — **#419 の再現**：peer が `Signature` ヘッダ無しで 401 を返すケースで signed が通ることを確認
- `TestAPFetcher_FetchObject_FallsBackToUnsignedOnSignedError` — signed が 4xx の時 unsigned に落ちる
- `TestAPFetcher_FetchObject_SignerErrorSkipsToUnsigned` — `ErrNoSigner` で signed をスキップ
- `TestAPFetcher_FetchObject_NoSigner_UnsignedOnly` — 既存挙動の regression guard
- `TestActivityPubClient_FetchUnsigned_NonOkReturnsStatusError` — `*StatusError` で status を露出
- `TestStatusError_PreservesLegacyErrorString` — エラー文字列フォーマット regression guard

カバレッジ: `core/federation` 90.6% / `activitypub` 94.5%（CI 閾値 90% 維持）。

## UDS 動作確認

知人提供の Iceshrimp.NET 2025.1 ライブインスタンスのユーザー（個人情報につき詳細省略）に対して `/api/users/show?username=…&host=…` を実行：

- 修正前: 401 で resolver が abort → "ユーザーが見つかりません"
- 修正後: signed GET で 200 → User row upsert + avatar / display name / instance metadata 取得まで成功

mk-go ログ抜粋（個人情報は伏せ字）：
```
SELECT * FROM "user" WHERE "usernameLower"=lower('XXXXX') AND host='XXXXX'  → rows:0
SELECT * FROM "user" WHERE uri='https://XXXXX/users/XXXXX'  → rows:0
SELECT * FROM "user" WHERE "usernameLower"=lower('instance.actor') AND host IS NULL  ← lazy 作成
GET /.well-known/webfinger?resource=acct:instance.actor@<localhost>  200
…(signed actor fetch 成功 → upsert)
POST /api/users/show 200
```

## 互換性

- **既存ピア (Misskey / Sharkey / CherryPick / Mastodon w/o secure mode)**: signed を最初に試み、もし peer が signed を弾くケースがあっても unsigned にフォールバックするため挙動変化なし。
- **未配線テスト**: `SetSigner` 未呼出なら従来通り unsigned only。`internal/core/federation/fetcher_test.go` の既存テストはそのまま pass。
- **secure mode/AuthorizedFetch peer**: 401 が解消し正常解決される（本 PR の主目的）。

## 関連

- Closes #419
- 隣接ファイル: `internal/core/instance/fetch_metadata.go` も同じ APFetcher を使うので nodeinfo / icon 取得も恩恵あり
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/shiroha-a/mk/pull/438" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
