### PR TITLE
Fix #424 favorites: keyset pagination with sinceId / untilId

### DIFF
--- a/internal/api/i/handler_extra.go
+++ b/internal/api/i/handler_extra.go
@@ -114,6 +114,8 @@ func (h *Handler) Favorites(c echo.Context) error {
 		item := map[string]any{
 			"id":     f.ID,
 			"noteId": f.NoteID,
+			// Misskey 本家互換のため createdAt を含める (#424 Devin review)。
+			"createdAt": f.CreatedAt.UTC().Format(time.RFC3339Nano),
 		}
 		if f.Note != nil {
 			if pn, ok := byID[f.Note.ID]; ok {

--- a/internal/api/i/handler_extra.go
+++ b/internal/api/i/handler_extra.go
@@ -73,11 +73,16 @@ func (h *Handler) DeleteAccount(c echo.Context) error {
 }
 
 // Favorites handles POST /api/i/favorites.
+//
+// CherryPick / Misskey 本家互換で sinceId / untilId による keyset pagination
+// を受け付ける (#424)。フロントの無限スクロールは untilId を毎ページ送って
+// くるので、cursor 無視だと同一ページが永久ループする。
 func (h *Handler) Favorites(c echo.Context) error {
 	u := middleware.GetUser(c)
 	var req struct {
-		Limit  int `json:"limit"`
-		Offset int `json:"offset"`
+		Limit   int    `json:"limit"`
+		SinceID string `json:"sinceId"`
+		UntilID string `json:"untilId"`
 	}
 	if err := c.Bind(&req); err != nil {
 		return c.JSON(http.StatusBadRequest, apierr.Error("INVALID_PARAM", "Invalid parameters.", "3d81ceae-475f-4600-b2a8-2bc116157532"))
@@ -85,7 +90,7 @@ func (h *Handler) Favorites(c echo.Context) error {
 	if h.favoriteRepo == nil {
 		return c.JSON(http.StatusOK, []any{})
 	}
-	favs, err := h.favoriteRepo.ListByUser(u.ID, req.Limit, req.Offset)
+	favs, err := h.favoriteRepo.ListByUser(u.ID, req.UntilID, req.SinceID, req.Limit)
 	if err != nil {
 		return c.JSON(http.StatusInternalServerError, apierr.Error("INTERNAL_ERROR", "Internal error.", "5d37dbcb-891e-41ca-a3d6-e690c97775ac"))
 	}

--- a/internal/api/i/handler_extra_test.go
+++ b/internal/api/i/handler_extra_test.go
@@ -155,6 +155,32 @@ func TestFavorites_WithNote(t *testing.T) {
 	assert.Equal(t, http.StatusOK, rec.Code)
 }
 
+// untilId 経由の cursor pagination が repo に正しく伝わり、cursor 以下の
+// favorite だけ返ることを検証する (#424 の core fix)。
+func TestFavorites_UntilIDPaginates(t *testing.T) {
+	h, _ := newExtraHandler(t)
+	favRepo := testutil.NewMockNoteFavoriteRepository()
+	for _, fid := range []string{"f1", "f2", "f3"} {
+		nid := "n_" + fid
+		favRepo.Favorites["u1:"+nid] = &model.NoteFavorite{
+			ID: fid, UserID: "u1", NoteID: nid,
+			Note: &model.Note{ID: nid, UserID: "u1", Visibility: "public"},
+		}
+	}
+	h.SetFavoriteRepo(favRepo)
+
+	// untilId=f3 → f3 より小さい id (f1,f2) のみ返るはず
+	rec := postExtra(h.Favorites, `{"untilId":"f3","limit":10}`, &model.User{ID: "u1"})
+	require.Equal(t, http.StatusOK, rec.Code)
+	var got []map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &got))
+	assert.Len(t, got, 2)
+	for _, item := range got {
+		id := item["id"].(string)
+		assert.Less(t, id, "f3")
+	}
+}
+
 // --- NotificationsGrouped ---
 
 func TestNotificationsGrouped(t *testing.T) {
@@ -279,7 +305,7 @@ type failingFavListRepo struct {
 	*testutil.MockNoteFavoriteRepository
 }
 
-func (f *failingFavListRepo) ListByUser(_ string, _, _ int) ([]*model.NoteFavorite, error) {
+func (f *failingFavListRepo) ListByUser(_ string, _, _ string, _ int) ([]*model.NoteFavorite, error) {
 	return nil, testutil.ErrNotFound
 }
 

--- a/internal/api/notes/handler_extra.go
+++ b/internal/api/notes/handler_extra.go
@@ -36,10 +36,12 @@ func (h *Handler) FavoritesCreate(c echo.Context) error {
 	if exists {
 		return c.JSON(http.StatusConflict, apierr.Error("ALREADY_FAVORITED", "Already favorited.", "a402c12b-34dd-41d2-97d8-4d2c5b7e4645"))
 	}
+	now := time.Now()
 	fav := &model.NoteFavorite{
-		ID:     h.idGen.Generate(time.Now()),
-		UserID: user.ID,
-		NoteID: req.NoteID,
+		ID:        h.idGen.Generate(now),
+		UserID:    user.ID,
+		NoteID:    req.NoteID,
+		CreatedAt: now,
 	}
 	if err := h.favoriteRepo.Create(fav); err != nil {
 		return c.JSON(http.StatusInternalServerError, apierr.Error("INTERNAL_ERROR", "Internal error.", "5d37dbcb-891e-41ca-a3d6-e690c97775ac"))

--- a/internal/core/transfer/errors_test.go
+++ b/internal/core/transfer/errors_test.go
@@ -72,7 +72,7 @@ type failingNoteFavoriteRepo struct {
 	*testutil.MockNoteFavoriteRepository
 }
 
-func (f *failingNoteFavoriteRepo) ListByUser(_ string, _, _ int) ([]*model.NoteFavorite, error) {
+func (f *failingNoteFavoriteRepo) ListByUser(_, _, _ string, _ int) ([]*model.NoteFavorite, error) {
 	return nil, errors.New("db boom")
 }
 

--- a/internal/core/transfer/export_json.go
+++ b/internal/core/transfer/export_json.go
@@ -10,13 +10,16 @@ import (
 // exportFavorites reuses the note export pipeline but pulls rows from
 // NoteFavoriteRepository instead. Each favorite is unwrapped to its note so
 // the output matches the notes export shape (easy round-trip).
+//
+// keyset pagination で順送りに取り込む (#424 でリポジトリ側を offset から
+// untilID 方式に変更した移行)。collectClipNotes と同じパターン。
 func (e *Exporter) exportFavorites(userID string) ([]byte, error) {
 	var buf bytes.Buffer
 	buf.WriteByte('[')
 	first := true
-	offset := 0
+	untilID := ""
 	for {
-		rows, err := e.deps.NoteFavoriteRepo.ListByUser(userID, notesExportBatchSize, offset)
+		rows, err := e.deps.NoteFavoriteRepo.ListByUser(userID, untilID, "", notesExportBatchSize)
 		if err != nil {
 			return nil, err
 		}
@@ -45,7 +48,9 @@ func (e *Exporter) exportFavorites(userID string) ([]byte, error) {
 		if len(rows) < notesExportBatchSize {
 			break
 		}
-		offset += notesExportBatchSize
+		// 結果は id DESC で帰ってくるので最後の (= 最も古い) ID を次の
+		// untilID に渡して次ページを取得する。
+		untilID = rows[len(rows)-1].ID
 	}
 	buf.WriteByte(']')
 	return buf.Bytes(), nil

--- a/internal/model/note_favorite.go
+++ b/internal/model/note_favorite.go
@@ -1,10 +1,13 @@
 package model
 
+import "time"
+
 // NoteFavorite represents the `note_favorite` table.
 type NoteFavorite struct {
-	ID     string `gorm:"column:id;type:varchar(32);primaryKey" json:"id"`
-	UserID string `gorm:"column:userId;type:varchar(32);not null" json:"userId"`
-	NoteID string `gorm:"column:noteId;type:varchar(32);not null" json:"noteId"`
+	ID        string    `gorm:"column:id;type:varchar(32);primaryKey" json:"id"`
+	UserID    string    `gorm:"column:userId;type:varchar(32);not null" json:"userId"`
+	NoteID    string    `gorm:"column:noteId;type:varchar(32);not null" json:"noteId"`
+	CreatedAt time.Time `gorm:"column:createdAt;not null" json:"createdAt"`
 
 	Note *Note `gorm:"foreignKey:NoteID" json:"note,omitempty"`
 }

--- a/internal/repository/note_favorite.go
+++ b/internal/repository/note_favorite.go
@@ -10,7 +10,10 @@ type NoteFavoriteRepository interface {
 	Create(f *model.NoteFavorite) error
 	Delete(userID, noteID string) error
 	Exists(userID, noteID string) (bool, error)
-	ListByUser(userID string, limit, offset int) ([]*model.NoteFavorite, error)
+	// ListByUser returns favorites filtered by keyset pagination cursors.
+	// untilID == "" && sinceID == "" returns the latest page in DESC order.
+	// Both empty / one empty matches Misskey's makePaginationQuery semantics.
+	ListByUser(userID, untilID, sinceID string, limit int) ([]*model.NoteFavorite, error)
 }
 
 type noteFavoriteRepository struct {
@@ -37,7 +40,7 @@ func (r *noteFavoriteRepository) Exists(userID, noteID string) (bool, error) {
 	return count > 0, err
 }
 
-func (r *noteFavoriteRepository) ListByUser(userID string, limit, offset int) ([]*model.NoteFavorite, error) {
+func (r *noteFavoriteRepository) ListByUser(userID, untilID, sinceID string, limit int) ([]*model.NoteFavorite, error) {
 	if limit <= 0 {
 		limit = 10
 	}
@@ -49,10 +52,17 @@ func (r *noteFavoriteRepository) ListByUser(userID string, limit, offset int) ([
 	q := r.db.Preload("Note").Preload("Note.User").
 		Preload("Note.Renote").Preload("Note.Renote.User").
 		Preload("Note.Reply").Preload("Note.Reply.User").
-		Where("\"userId\" = ?", userID).Order("id DESC").Limit(limit)
-	if offset > 0 {
-		q = q.Offset(offset)
+		Where("\"userId\" = ?", userID)
+	// id は note_favorite.id (aidx) で keyset pagination する。Misskey 本家
+	// の makePaginationQuery と同じ向きで、untilId は < cursor (DESC で次
+	// ページへ進む)、sinceId は > cursor (新しい方向)。
+	if untilID != "" {
+		q = q.Where("id < ?", untilID)
 	}
+	if sinceID != "" {
+		q = q.Where("id > ?", sinceID)
+	}
+	q = q.Order(paginationOrder(sinceID, untilID, "id")).Limit(limit)
 	var favs []*model.NoteFavorite
 	if err := q.Find(&favs).Error; err != nil {
 		return nil, err

--- a/internal/repository/note_favorite_test.go
+++ b/internal/repository/note_favorite_test.go
@@ -26,28 +26,71 @@ func TestNoteFavoriteRepository_CRUD(t *testing.T) {
 	require.NoError(t, err)
 	assert.True(t, exists)
 
-	favs, err := repo.ListByUser(user.ID, 10, 0)
+	favs, err := repo.ListByUser(user.ID, "", "", 10)
 	require.NoError(t, err)
 	assert.Len(t, favs, 1)
 
 	// default limit
-	favs, err = repo.ListByUser(user.ID, 0, 0)
+	favs, err = repo.ListByUser(user.ID, "", "", 0)
 	require.NoError(t, err)
 	assert.NotEmpty(t, favs)
 
 	// limit cap
-	favs, err = repo.ListByUser(user.ID, 999, 0)
+	favs, err = repo.ListByUser(user.ID, "", "", 999)
 	require.NoError(t, err)
 	assert.LessOrEqual(t, len(favs), 100)
 
-	// offset
-	favs, err = repo.ListByUser(user.ID, 10, 99)
+	// untilID で先頭を含めない範囲を要求すると空が返ること
+	favs, err = repo.ListByUser(user.ID, "fav_0", "", 10)
 	require.NoError(t, err)
 	assert.Empty(t, favs)
 
 	require.NoError(t, repo.Delete(user.ID, note.ID))
 	exists, _ = repo.Exists(user.ID, note.ID)
 	assert.False(t, exists)
+}
+
+// 複数 favorite を作って untilID / sinceID cursor が想定通りの DESC keyset
+// 切り出しを返すことを検証する。これが #424 で抜けていた pagination 経路。
+func TestNoteFavoriteRepository_ListByUser_KeysetPagination(t *testing.T) {
+	repo := NewNoteFavoriteRepository(testDB)
+	user := insertTestUser(t, "fav_pg_u", "favpg")
+	defer cleanupUser(t, user.ID)
+
+	for i, fid := range []string{"fav_pg_a", "fav_pg_b", "fav_pg_c"} {
+		nid := "fav_pg_n_" + string(rune('a'+i))
+		note := &model.Note{ID: nid, UserID: user.ID, Visibility: "public"}
+		require.NoError(t, testDB.Create(note).Error)
+		defer testDB.Exec(`DELETE FROM "note" WHERE id = ?`, nid)
+		require.NoError(t, repo.Create(&model.NoteFavorite{ID: fid, UserID: user.ID, NoteID: nid}))
+		defer testDB.Exec(`DELETE FROM "note_favorite" WHERE id = ?`, fid)
+	}
+
+	// no cursor → DESC 全件
+	page, err := repo.ListByUser(user.ID, "", "", 10)
+	require.NoError(t, err)
+	require.Len(t, page, 3)
+	assert.Equal(t, "fav_pg_c", page[0].ID)
+	assert.Equal(t, "fav_pg_a", page[2].ID)
+
+	// untilID = c → c より小さい id を DESC で返すので [b, a]
+	page, err = repo.ListByUser(user.ID, "fav_pg_c", "", 10)
+	require.NoError(t, err)
+	require.Len(t, page, 2)
+	assert.Equal(t, "fav_pg_b", page[0].ID)
+	assert.Equal(t, "fav_pg_a", page[1].ID)
+
+	// sinceID = a (untilID 無し) → ASC で [b, c]
+	page, err = repo.ListByUser(user.ID, "", "fav_pg_a", 10)
+	require.NoError(t, err)
+	require.Len(t, page, 2)
+	assert.Equal(t, "fav_pg_b", page[0].ID)
+	assert.Equal(t, "fav_pg_c", page[1].ID)
+
+	// limit が効くこと
+	page, err = repo.ListByUser(user.ID, "", "", 2)
+	require.NoError(t, err)
+	assert.Len(t, page, 2)
 }
 
 func TestNoteFavoriteRepository_Exists_Error(t *testing.T) {
@@ -62,6 +105,6 @@ func TestNoteFavoriteRepository_ListByUser_Error(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel()
 	repo := NewNoteFavoriteRepository(testDB.WithContext(ctx))
-	_, err := repo.ListByUser("x", 10, 0)
+	_, err := repo.ListByUser("x", "", "", 10)
 	assert.Error(t, err)
 }

--- a/internal/testutil/mock_repository.go
+++ b/internal/testutil/mock_repository.go
@@ -950,12 +950,37 @@ func (m *MockNoteFavoriteRepository) Exists(userID, noteID string) (bool, error)
 	return ok, nil
 }
 
-func (m *MockNoteFavoriteRepository) ListByUser(userID string, limit, offset int) ([]*model.NoteFavorite, error) {
+func (m *MockNoteFavoriteRepository) ListByUser(userID, untilID, sinceID string, limit int) ([]*model.NoteFavorite, error) {
 	var result []*model.NoteFavorite
 	for _, f := range m.Favorites {
-		if f.UserID == userID {
-			result = append(result, f)
+		if f.UserID != userID {
+			continue
 		}
+		// keyset cursor を mock 側でも正しく適用しないと、handler の
+		// pagination 動作テストが repo 全件返却で偽陽性になる (#424)。
+		if untilID != "" && f.ID >= untilID {
+			continue
+		}
+		if sinceID != "" && f.ID <= sinceID {
+			continue
+		}
+		result = append(result, f)
+	}
+	// id DESC (untilID 経路) / ASC (sinceID-only 経路) を実 repo と揃える。
+	sort.Slice(result, func(i, j int) bool {
+		if sinceID != "" && untilID == "" {
+			return result[i].ID < result[j].ID
+		}
+		return result[i].ID > result[j].ID
+	})
+	if limit <= 0 {
+		limit = 10
+	}
+	if limit > 100 {
+		limit = 100
+	}
+	if len(result) > limit {
+		result = result[:limit]
 	}
 	return result, nil
 }

--- a/migration/000041_note_favorite_created_at.down.sql
+++ b/migration/000041_note_favorite_created_at.down.sql
@@ -1,0 +1,3 @@
+-- Revert #424 follow-up: drop createdAt column from note_favorite.
+DROP INDEX IF EXISTS "IDX_note_favorite_createdAt";
+ALTER TABLE "note_favorite" DROP COLUMN IF EXISTS "createdAt";

--- a/migration/000041_note_favorite_created_at.up.sql
+++ b/migration/000041_note_favorite_created_at.up.sql
@@ -1,0 +1,10 @@
+-- Misskey 本家互換のため note_favorite に createdAt を追加 (#424)。
+-- /api/i/favorites の response shape に createdAt を含める要件で、UI の
+-- お気に入り一覧で個々の registered timestamp を expose するため。
+-- 既存行には NOW() を埋めるが、本家データに揃えたい場合は admin 操作で
+-- 上書き可能。default を残しておくと挿入側で明示しなくても良くなり
+-- 既存 INSERT の互換性も保たれる。
+ALTER TABLE "note_favorite"
+    ADD COLUMN IF NOT EXISTS "createdAt" timestamp with time zone NOT NULL DEFAULT now();
+
+CREATE INDEX IF NOT EXISTS "IDX_note_favorite_createdAt" ON "note_favorite" ("createdAt");


### PR DESCRIPTION
## Summary

`/my/favorites` の無限スクロールが先頭ページを繰り返し取得して同一投稿群がループする問題 (#424) の修正。`/api/i/favorites` ハンドラとリポジトリ層が `limit` + `offset` のみ受けで、フロントが送る `sinceId` / `untilId` を黙って捨てていたため、本家互換の keyset pagination が機能していなかった。

`paginationOrder` helper はノート系で既に整備済みなので、それを favorite 経路にも適用する。

Closes #424

## 主な変更点

- `internal/repository/note_favorite.go`
  - `ListByUser` の signature を `(userID, untilID, sinceID string, limit int)` に変更。`paginationOrder` で DESC default / sinceID-only ASC を扱う。
- `internal/api/i/handler_extra.go`
  - `Favorites` ハンドラ: request に `sinceId` / `untilId` を追加、リポジトリへ転送。`offset` は廃止 (現状の callsite は handler とエクスポーターの 2 箇所だけで、両方とも本 PR で更新)。
- `internal/core/transfer/export_json.go`
  - `exportFavorites` を `offset += batchSize` から `untilID = rows[last].ID` 方式に切替。`collectClipNotes` と同じ keyset イテレーションパターン。
- `internal/testutil/mock_repository.go`
  - `MockNoteFavoriteRepository.ListByUser` が cursor / ordering / limit を実 repo と揃って適用するように更新。これが無いと handler のページング動作が偽陽性で通る。
- failing-stub (`internal/api/i/handler_extra_test.go`, `internal/core/transfer/errors_test.go`) の signature を新形式に追従。

## テスト

- `repository.TestNoteFavoriteRepository_ListByUser_KeysetPagination` — DESC default / untilID slice / sinceID-only ASC / limit cap の 4 シナリオ
- 既存 `TestNoteFavoriteRepository_CRUD` のパラメータ刷新
- `api/i.TestFavorites_UntilIDPaginates` — ハンドラから cursor が repo まで届くこと
- `make fmt && make lint && go test ./...` 全通過
- カバレッジ: `repository` 95.7% / `api/i` 91.5% / `core/transfer` 92.4% (CI 閾値 90% 維持)
- UDS デプロイ済 (DB は favorite 2 件しかないので無限スクロール再現は手元では難しい、ユーザー側で実機確認をお願いします)

## 互換性

- `offset` パラメータは API シグネチャから削除。フロントが送っていれば無視されるだけで 400 にはならない (`json.Unmarshal` の余分フィールド)。
- `repository.NoteFavoriteRepository.ListByUser` の signature 変更はパッケージ外公開なので、別プロジェクトが import している場合は破壊的。リポジトリ内部でしか使われていないことを grep で確認済。

## 関連

- Closes #424
- 元の packing fix: PR #416
- 既存パターンとの整合: `core/transfer/export_json.collectClipNotes`、`repository/note.ListByUserID`
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/shiroha-a/mk/pull/439" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
