### PR TITLE
Fix #421 (1/4) admin dashboard: moderator filter + GET on chart endpoints

### DIFF
--- a/internal/api/charts/handler.go
+++ b/internal/api/charts/handler.go
@@ -58,12 +58,18 @@ func NewHandler(c Charts, clock chart.Clock) *Handler {
 // `Limit` defaults to 30 and is clamped to [1, 500]; `Offset` shifts
 // the window back in time by that many spans (so offset=24 with
 // span=hour returns the chart ending 24 hours ago).
+// Request is the shared shape of chart query parameters.
+//
+// `query` タグは GET 経路で必要 (#421)。Misskey フロントは
+// `misskeyApiGet('charts/...')` で chart を引きに来るため、`json` タグだけ
+// だと query string が bind されずに span="" → INVALID_PARAM になる。
+// POST 経路の挙動を変えないよう既存 `json` タグを残しつつ `query` を追加。
 type Request struct {
-	Span   string `json:"span"`
-	Limit  *int   `json:"limit"`
-	Offset *int   `json:"offset"`
-	UserID string `json:"userId"`
-	Host   string `json:"host"`
+	Span   string `json:"span" query:"span"`
+	Limit  *int   `json:"limit" query:"limit"`
+	Offset *int   `json:"offset" query:"offset"`
+	UserID string `json:"userId" query:"userId"`
+	Host   string `json:"host" query:"host"`
 }
 
 // --- instance-wide endpoints -------------------------------------------------

--- a/internal/api/charts/handler.go
+++ b/internal/api/charts/handler.go
@@ -58,13 +58,11 @@ func NewHandler(c Charts, clock chart.Clock) *Handler {
 // `Limit` defaults to 30 and is clamped to [1, 500]; `Offset` shifts
 // the window back in time by that many spans (so offset=24 with
 // span=hour returns the chart ending 24 hours ago).
-// Request is the shared shape of chart query parameters.
-//
-// `query` タグは GET 経路で必要 (#421)。Misskey フロントは
-// `misskeyApiGet('charts/...')` で chart を引きに来るため、`json` タグだけ
-// だと query string が bind されずに span="" → INVALID_PARAM になる。
-// POST 経路の挙動を変えないよう既存 `json` タグを残しつつ `query` を追加。
 type Request struct {
+	// Misskey フロントは `misskeyApiGet('charts/...')` で chart を引きに来る
+	// ため、`json` タグだけだと GET 経路で query string が bind されず
+	// span="" → INVALID_PARAM になる (#421)。POST 経路の挙動を変えない
+	// よう既存 `json` タグを残しつつ `query` も付与する。
 	Span   string `json:"span" query:"span"`
 	Limit  *int   `json:"limit" query:"limit"`
 	Offset *int   `json:"offset" query:"offset"`

--- a/internal/api/federation/handler_stubs.go
+++ b/internal/api/federation/handler_stubs.go
@@ -116,8 +116,10 @@ func (h *Handler) Users(c echo.Context) error {
 // 連合統計: followers / following がもっとも多いリモートインスタンス上位
 // N 件と、そのほかのインスタンスをまとめた残り総計を返す。
 func (h *Handler) Stats(c echo.Context) error {
+	// admin/overview は GET で叩いてくるので `query` タグも必要
+	// (#421 Devin review: charts.Request と同じ pattern)。
 	var req struct {
-		Limit int `json:"limit"`
+		Limit int `json:"limit" query:"limit"`
 	}
 	_ = c.Bind(&req)
 	if req.Limit <= 0 || req.Limit > 100 {

--- a/internal/core/chart/repository.go
+++ b/internal/core/chart/repository.go
@@ -125,17 +125,39 @@ func (r *gormRepository) scanRow(raw map[string]any) *Row {
 	return row
 }
 
-// toInt64 coerces a database driver value (int / int64 / float64 / []byte)
-// into int64. Defaults to zero on unknown types.
+// toInt64 coerces a database driver value into int64. Postgres `smallint`
+// (Range: chart.RangeSmall) comes back as int16 from pgx, so we MUST handle
+// it explicitly — without this the federation / charts API silently returns
+// 0 for every smallint column even though the underlying row has real data
+// (#421).
+//
+// The full set covers every signed integer width and a couple of unsigned
+// edge cases just in case a future driver hands us those.
 func toInt64(v any) int64 {
 	switch x := v.(type) {
 	case int64:
 		return x
 	case int32:
 		return int64(x)
+	case int16:
+		return int64(x)
+	case int8:
+		return int64(x)
 	case int:
 		return int64(x)
+	case uint64:
+		return int64(x)
+	case uint32:
+		return int64(x)
+	case uint16:
+		return int64(x)
+	case uint8:
+		return int64(x)
+	case uint:
+		return int64(x)
 	case float64:
+		return int64(x)
+	case float32:
 		return int64(x)
 	case []byte:
 		var n int64

--- a/internal/repository/instance.go
+++ b/internal/repository/instance.go
@@ -194,41 +194,34 @@ func (r *instanceRepository) List(filter model.InstanceListFilter) ([]*model.Ins
 // columns of every instance row from the live `following` table. Used at
 // startup to backfill stale zeros until incremental hooks land (#421)。
 //
-// `followersCount`: 当該リモートインスタンスの user を、ローカル user が
-// 何人 follow しているか (= 我々から見た subscribe 元 instance 別)。
-// `followingCount`: 当該リモートインスタンスの user が、ローカル user を
-// 何人 follow しているか (= 我々を subscribe している側)。
-//
-// 命名は本家 Misskey と揃えてある。
+// 命名は本家 Misskey と揃える:
+//   - `followersCount`: 当該リモートインスタンスの user が **我々を**
+//     何人 follow しているか (= 受信側 = subscribing)。SQL では
+//     follower.host = X を数える。
+//   - `followingCount`: 我々のローカル user が **当該インスタンスの user
+//     を** 何人 follow しているか (= 配信側 = publishing)。SQL では
+//     followee.host = X を数える。
 //
 // Reset → backfill の二段構え: 過去 follow が消えた host (= subquery に
 // 出てこない) は subquery JOIN だと UPDATE 対象外になり、古い非ゼロ値が
 // 永遠に残ってしまう (#421 Devin review)。先に全 instance を 0 にしてから
 // 該当 host のみ再上書きすることで、follow を全部解除した instance も
 // 確実に 0 へ戻す。
+//
+// 3 つの UPDATE は単一トランザクションでまとめる: reset だけ先に走って
+// 後段で fail すると全 instance が永続的に 0 になってしまうため (#421
+// Devin review)。
 func (r *instanceRepository) RecomputeFollowCounts() error {
-	if err := r.db.Exec(
-		`UPDATE "instance" SET "followersCount" = 0, "followingCount" = 0`,
-	).Error; err != nil {
-		return err
-	}
-	// followersCount: COUNT of remote followees per host.
-	const followers = `
+	return r.db.Transaction(func(tx *gorm.DB) error {
+		if err := tx.Exec(
+			`UPDATE "instance" SET "followersCount" = 0, "followingCount" = 0`,
+		).Error; err != nil {
+			return err
+		}
+		// followersCount = COUNT of remote followers per host (follower.host).
+		// "How many users on host X follow any local user" ≒ they subscribe to us.
+		const followers = `
 UPDATE "instance" SET "followersCount" = c.cnt
-FROM (
-  SELECT u.host AS host, COUNT(*)::int AS cnt
-  FROM "following" f
-  JOIN "user" u ON f."followeeId" = u.id
-  WHERE u.host IS NOT NULL
-  GROUP BY u.host
-) c
-WHERE "instance".host = c.host`
-	if err := r.db.Exec(followers).Error; err != nil {
-		return err
-	}
-	// followingCount: COUNT of remote followers per host.
-	const following = `
-UPDATE "instance" SET "followingCount" = c.cnt
 FROM (
   SELECT u.host AS host, COUNT(*)::int AS cnt
   FROM "following" f
@@ -237,5 +230,21 @@ FROM (
   GROUP BY u.host
 ) c
 WHERE "instance".host = c.host`
-	return r.db.Exec(following).Error
+		if err := tx.Exec(followers).Error; err != nil {
+			return err
+		}
+		// followingCount = COUNT of remote followees per host (followee.host).
+		// "How many users on host X are followed by any local user" ≒ we publish to them.
+		const following = `
+UPDATE "instance" SET "followingCount" = c.cnt
+FROM (
+  SELECT u.host AS host, COUNT(*)::int AS cnt
+  FROM "following" f
+  JOIN "user" u ON f."followeeId" = u.id
+  WHERE u.host IS NOT NULL
+  GROUP BY u.host
+) c
+WHERE "instance".host = c.host`
+		return tx.Exec(following).Error
+	})
 }

--- a/internal/repository/instance.go
+++ b/internal/repository/instance.go
@@ -200,10 +200,21 @@ func (r *instanceRepository) List(filter model.InstanceListFilter) ([]*model.Ins
 // 何人 follow しているか (= 我々を subscribe している側)。
 //
 // 命名は本家 Misskey と揃えてある。
+//
+// Reset → backfill の二段構え: 過去 follow が消えた host (= subquery に
+// 出てこない) は subquery JOIN だと UPDATE 対象外になり、古い非ゼロ値が
+// 永遠に残ってしまう (#421 Devin review)。先に全 instance を 0 にしてから
+// 該当 host のみ再上書きすることで、follow を全部解除した instance も
+// 確実に 0 へ戻す。
 func (r *instanceRepository) RecomputeFollowCounts() error {
+	if err := r.db.Exec(
+		`UPDATE "instance" SET "followersCount" = 0, "followingCount" = 0`,
+	).Error; err != nil {
+		return err
+	}
 	// followersCount: COUNT of remote followees per host.
 	const followers = `
-UPDATE "instance" SET "followersCount" = COALESCE(c.cnt, 0)
+UPDATE "instance" SET "followersCount" = c.cnt
 FROM (
   SELECT u.host AS host, COUNT(*)::int AS cnt
   FROM "following" f
@@ -217,7 +228,7 @@ WHERE "instance".host = c.host`
 	}
 	// followingCount: COUNT of remote followers per host.
 	const following = `
-UPDATE "instance" SET "followingCount" = COALESCE(c.cnt, 0)
+UPDATE "instance" SET "followingCount" = c.cnt
 FROM (
   SELECT u.host AS host, COUNT(*)::int AS cnt
   FROM "following" f

--- a/internal/repository/instance.go
+++ b/internal/repository/instance.go
@@ -25,6 +25,13 @@ type InstanceRepository interface {
 	// returned. Ordered by infoUpdatedAt ASC NULLS FIRST so the oldest data
 	// is refreshed first.
 	ListForRefresh(staleBefore time.Time, limit int) ([]*model.Instance, error)
+	// RecomputeFollowCounts refreshes followersCount / followingCount on
+	// every instance row from the live `following` table. Currently nobody
+	// keeps these counters in sync incrementally, so admin/overview's
+	// federation pie chart gets all-zero slices. Running this on startup
+	// gives the dashboard the right pie until incremental hooks land
+	// (#421)。
+	RecomputeFollowCounts() error
 }
 
 type instanceRepository struct {
@@ -181,4 +188,43 @@ func (r *instanceRepository) List(filter model.InstanceListFilter) ([]*model.Ins
 		return nil, err
 	}
 	return rows, nil
+}
+
+// RecomputeFollowCounts recomputes the followersCount / followingCount
+// columns of every instance row from the live `following` table. Used at
+// startup to backfill stale zeros until incremental hooks land (#421)。
+//
+// `followersCount`: 当該リモートインスタンスの user を、ローカル user が
+// 何人 follow しているか (= 我々から見た subscribe 元 instance 別)。
+// `followingCount`: 当該リモートインスタンスの user が、ローカル user を
+// 何人 follow しているか (= 我々を subscribe している側)。
+//
+// 命名は本家 Misskey と揃えてある。
+func (r *instanceRepository) RecomputeFollowCounts() error {
+	// followersCount: COUNT of remote followees per host.
+	const followers = `
+UPDATE "instance" SET "followersCount" = COALESCE(c.cnt, 0)
+FROM (
+  SELECT u.host AS host, COUNT(*)::int AS cnt
+  FROM "following" f
+  JOIN "user" u ON f."followeeId" = u.id
+  WHERE u.host IS NOT NULL
+  GROUP BY u.host
+) c
+WHERE "instance".host = c.host`
+	if err := r.db.Exec(followers).Error; err != nil {
+		return err
+	}
+	// followingCount: COUNT of remote followers per host.
+	const following = `
+UPDATE "instance" SET "followingCount" = COALESCE(c.cnt, 0)
+FROM (
+  SELECT u.host AS host, COUNT(*)::int AS cnt
+  FROM "following" f
+  JOIN "user" u ON f."followerId" = u.id
+  WHERE u.host IS NOT NULL
+  GROUP BY u.host
+) c
+WHERE "instance".host = c.host`
+	return r.db.Exec(following).Error
 }

--- a/internal/repository/user.go
+++ b/internal/repository/user.go
@@ -214,23 +214,33 @@ func (r *userRepository) ListUsers(filter model.UserListFilter) ([]*model.User, 
 		// isAdministrator / isModerator フラグで絞る。host は問わない方が
 		// 上位表示で柔軟だが、admin/overview の moderator カードはローカル
 		// だけを期待するので host IS NULL も付ける (#421)。
+		//
+		// root user (meta.rootUserId) は role_assignment 行を持たない
+		// 暗黙の administrator なので admin / adminOrModerator では OR 条件
+		// で必ず含める。本家 getModeratorIds の rootUserIds union と同じ
+		// (#421 Devin review)。pure moderator フィルタは root を含まない。
 		var roleCond string
+		includeRoot := false
 		switch filter.State {
 		case "admin":
 			roleCond = `r."isAdministrator" = true`
+			includeRoot = true
 		case "moderator":
 			roleCond = `r."isModerator" = true`
 		default: // adminOrModerator
 			roleCond = `(r."isAdministrator" = true OR r."isModerator" = true)`
+			includeRoot = true
 		}
-		q = q.Where("host IS NULL").Where(`
-			id IN (
-				SELECT ra."userId" FROM role_assignment ra
-				JOIN role r ON ra."roleId" = r.id
-				WHERE ` + roleCond + `
-				  AND (ra."expiresAt" IS NULL OR ra."expiresAt" > now())
-			)
-		`)
+		idCond := `id IN (
+			SELECT ra."userId" FROM role_assignment ra
+			JOIN role r ON ra."roleId" = r.id
+			WHERE ` + roleCond + `
+			  AND (ra."expiresAt" IS NULL OR ra."expiresAt" > now())
+		)`
+		if includeRoot {
+			idCond = "(" + idCond + ` OR id = (SELECT "rootUserId" FROM meta WHERE "rootUserId" IS NOT NULL LIMIT 1))`
+		}
+		q = q.Where("host IS NULL").Where(idCond)
 	}
 
 	switch filter.Sort {

--- a/internal/repository/user.go
+++ b/internal/repository/user.go
@@ -203,8 +203,34 @@ func (r *userRepository) ListUsers(filter model.UserListFilter) ([]*model.User, 
 	switch filter.State {
 	case "suspended":
 		q = q.Where("\"isSuspended\" = true")
-	case "alive":
+	case "alive", "available":
+		// `available` は本家 admin/show-users で `alive` と同義 (suspended で
+		// ない = アクティブ)。`alive` だけ受け付けると admin UI が空返却に
+		// なるので両方カバーする。
 		q = q.Where("\"isSuspended\" = false")
+	case "admin", "moderator", "adminOrModerator":
+		// 本家 RoleService.getModeratorIds と等価な条件を SQL に落とす。
+		// expiresAt が過ぎている assignment は除外、role の
+		// isAdministrator / isModerator フラグで絞る。host は問わない方が
+		// 上位表示で柔軟だが、admin/overview の moderator カードはローカル
+		// だけを期待するので host IS NULL も付ける (#421)。
+		var roleCond string
+		switch filter.State {
+		case "admin":
+			roleCond = `r."isAdministrator" = true`
+		case "moderator":
+			roleCond = `r."isModerator" = true`
+		default: // adminOrModerator
+			roleCond = `(r."isAdministrator" = true OR r."isModerator" = true)`
+		}
+		q = q.Where("host IS NULL").Where(`
+			id IN (
+				SELECT ra."userId" FROM role_assignment ra
+				JOIN role r ON ra."roleId" = r.id
+				WHERE ` + roleCond + `
+				  AND (ra."expiresAt" IS NULL OR ra."expiresAt" > now())
+			)
+		`)
 	}
 
 	switch filter.Sort {
@@ -216,6 +242,15 @@ func (r *userRepository) ListUsers(filter model.UserListFilter) ([]*model.User, 
 		q = q.Order("\"updatedAt\" ASC NULLS LAST")
 	case "-updatedAt":
 		q = q.Order("\"updatedAt\" DESC NULLS LAST")
+	case "+lastActiveDate", "-lastActiveDate":
+		// 本家 admin/show-users が moderator 一覧に使う sort key (#421)。
+		// NULLS は最後に固定して accidental ASC で空アクティビティ user が
+		// 先頭に来ないようにする。
+		dir := "DESC"
+		if filter.Sort == "+lastActiveDate" {
+			dir = "ASC"
+		}
+		q = q.Order(`"lastActiveDate" ` + dir + ` NULLS LAST`)
 	case "+followersCount":
 		q = q.Order("\"followersCount\" ASC")
 	case "-followersCount":

--- a/internal/repository/user_test.go
+++ b/internal/repository/user_test.go
@@ -347,6 +347,57 @@ func TestUserRepository_ListUsers_AdminOrModerator(t *testing.T) {
 	assert.NotContains(t, ids, remote.ID, "remote user must be excluded even if assigned the role")
 }
 
+// admin / adminOrModerator フィルタは meta.rootUserId を暗黙の admin として
+// 含める必要がある。本家 RoleService.getModeratorIds の rootUserIds union と
+// 同じ挙動で、これが無いと「初期 root のみ」のインスタンスでは moderator
+// カードが空になる (#421 Devin review)。
+func TestUserRepository_ListUsers_AdminIncludesRootUser(t *testing.T) {
+	repo := NewUserRepository(testDB)
+	root := insertTestUser(t, "lu_root", "rootuser")
+	defer cleanupUser(t, root.ID)
+	other := insertTestUser(t, "lu_other", "otheruser")
+	defer cleanupUser(t, other.ID)
+
+	// root を meta.rootUserId に設定する。テスト終了時に元の値へ戻す。
+	// migration には meta シードが無いので、行が無ければ INSERT でブート
+	// ストラップする。
+	var rowCount int64
+	require.NoError(t, testDB.Raw(`SELECT COUNT(*) FROM meta`).Scan(&rowCount).Error)
+	if rowCount == 0 {
+		require.NoError(t, testDB.Exec(`INSERT INTO meta (id, "rootUserId") VALUES ('x', ?)`, root.ID).Error)
+		t.Cleanup(func() { testDB.Exec(`DELETE FROM meta WHERE id = 'x'`) })
+	} else {
+		var prev *string
+		require.NoError(t, testDB.Raw(`SELECT "rootUserId" FROM meta LIMIT 1`).Scan(&prev).Error)
+		require.NoError(t, testDB.Exec(`UPDATE meta SET "rootUserId" = ?`, root.ID).Error)
+		t.Cleanup(func() {
+			if prev != nil {
+				testDB.Exec(`UPDATE meta SET "rootUserId" = ?`, *prev)
+			} else {
+				testDB.Exec(`UPDATE meta SET "rootUserId" = NULL`)
+			}
+		})
+	}
+
+	for _, state := range []string{"admin", "adminOrModerator"} {
+		users, err := repo.ListUsers(model.UserListFilter{State: state, Limit: 100})
+		require.NoError(t, err)
+		ids := make(map[string]struct{}, len(users))
+		for _, u := range users {
+			ids[u.ID] = struct{}{}
+		}
+		assert.Contains(t, ids, root.ID, "root user must be in state=%s results", state)
+		assert.NotContains(t, ids, other.ID, "non-admin local user must not be in state=%s results", state)
+	}
+
+	// pure moderator フィルタは root (admin) を含まない。
+	users, err := repo.ListUsers(model.UserListFilter{State: "moderator", Limit: 100})
+	require.NoError(t, err)
+	for _, u := range users {
+		assert.NotEqual(t, root.ID, u.ID, "root must NOT be in state=moderator (admin-only)")
+	}
+}
+
 func TestUserRepository_ListUsers_SortAndPagination(t *testing.T) {
 	repo := NewUserRepository(testDB)
 	u1 := insertTestUser(t, "lu_s1", "sortuser1")

--- a/internal/repository/user_test.go
+++ b/internal/repository/user_test.go
@@ -301,6 +301,52 @@ func TestUserRepository_ListUsers_Suspended(t *testing.T) {
 	}
 }
 
+// adminOrModerator filter joins role_assignment + role and returns only
+// users with isAdministrator/isModerator role and host IS NULL (#421)。
+// 旧実装は state=adminOrModerator を黙って無視していたので admin/overview
+// の moderator 一覧に観測した全リモートユーザーが流れ込んでいた。
+func TestUserRepository_ListUsers_AdminOrModerator(t *testing.T) {
+	repo := NewUserRepository(testDB)
+	host := "remote.example"
+	mod := insertTestUser(t, "lu_mod", "modlocal")
+	defer cleanupUser(t, mod.ID)
+	plain := insertTestUser(t, "lu_plain", "plainlocal")
+	defer cleanupUser(t, plain.ID)
+	remote := insertTestUser(t, "lu_remote", "remotemod")
+	require.NoError(t, repo.UpdateUser(remote.ID, map[string]any{"host": host}))
+	defer cleanupUser(t, remote.ID)
+
+	// moderator role + assignment
+	now := time.Now()
+	role := &model.Role{
+		ID:              "role_lu_mod",
+		Name:            "test-mod",
+		IsModerator:     true,
+		IsAdministrator: false,
+		UpdatedAt:       now,
+		LastUsedAt:      now,
+	}
+	require.NoError(t, testDB.Create(role).Error)
+	defer testDB.Exec(`DELETE FROM "role" WHERE id = ?`, role.ID)
+
+	// local mod + remote (incorrectly) get the moderator role
+	for _, uid := range []string{mod.ID, remote.ID} {
+		ra := &model.RoleAssignment{ID: "ra_" + uid, UserID: uid, RoleID: role.ID}
+		require.NoError(t, testDB.Create(ra).Error)
+		defer testDB.Exec(`DELETE FROM "role_assignment" WHERE id = ?`, ra.ID)
+	}
+
+	users, err := repo.ListUsers(model.UserListFilter{State: "adminOrModerator", Limit: 100})
+	require.NoError(t, err)
+	ids := make(map[string]struct{}, len(users))
+	for _, u := range users {
+		ids[u.ID] = struct{}{}
+	}
+	assert.Contains(t, ids, mod.ID, "local moderator must be listed")
+	assert.NotContains(t, ids, plain.ID, "non-moderator local user must be excluded")
+	assert.NotContains(t, ids, remote.ID, "remote user must be excluded even if assigned the role")
+}
+
 func TestUserRepository_ListUsers_SortAndPagination(t *testing.T) {
 	repo := NewUserRepository(testDB)
 	u1 := insertTestUser(t, "lu_s1", "sortuser1")

--- a/internal/server/middleware/auth.go
+++ b/internal/server/middleware/auth.go
@@ -72,6 +72,13 @@ func (a *AuthMiddleware) Authenticate() echo.MiddlewareFunc {
 // touchLastActive bumps the user's `lastActiveDate` column to now() if the
 // last update was more than `lastActiveUpdateInterval` ago. The DB write
 // runs in a goroutine to keep the request hot path lean (#421)。
+//
+// 同じ map で eviction も行う。古いエントリ (= last update から
+// `lastActiveUpdateInterval * 2` 以上経過) は次回 lookup の機会に削除する
+// ことで、長期稼働しても map サイズが「直近アクティブな user 数」程度に
+// 収束する (#421 Devin review: unbounded growth 対策)。
+//
+// 通過頻度が高くないので、専用 ticker goroutine ではなく lazy 削除で十分。
 func (a *AuthMiddleware) touchLastActive(userID string) {
 	if userID == "" || a.userRepo == nil {
 		return
@@ -84,6 +91,15 @@ func (a *AuthMiddleware) touchLastActive(userID string) {
 		return
 	}
 	a.lastActiveSeen[userID] = now
+	// 古い entry の lazy eviction。同じ lock 取得中に O(n) 走査するが、
+	// touch は既に DB 書き込み rate-limited されている (5 分間隔) ので
+	// hot path への影響は限定的。
+	staleBefore := now.Add(-2 * lastActiveUpdateInterval)
+	for uid, t := range a.lastActiveSeen {
+		if t.Before(staleBefore) {
+			delete(a.lastActiveSeen, uid)
+		}
+	}
 	a.lastActiveMu.Unlock()
 
 	go func(uid string, t time.Time) {

--- a/internal/server/middleware/auth.go
+++ b/internal/server/middleware/auth.go
@@ -6,8 +6,11 @@ import (
 	"encoding/hex"
 	"encoding/json"
 	"io"
+	"log/slog"
 	"net/http"
 	"strings"
+	"sync"
+	"time"
 
 	"github.com/labstack/echo/v4"
 	"github.com/shiroha-a/mk/internal/model"
@@ -18,15 +21,30 @@ type contextKey string
 
 const UserContextKey contextKey = "misskeyUser"
 
+// lastActiveUpdateInterval は同一ユーザーの lastActiveDate 書き込みを抑制
+// する間隔。本家 TS は WebSocket 接続中 5 分おきに更新する (#421)。HTTP
+// 経路でも 5 分おきの memory-throttle で十分 online 判定できる。
+const lastActiveUpdateInterval = 5 * time.Minute
+
 // AuthMiddleware provides token-based authentication.
 type AuthMiddleware struct {
 	userRepo        repository.UserRepository
 	accessTokenRepo repository.AccessTokenRepository
+
+	// lastActiveSeen はユーザー ID → 直近で lastActiveDate を更新した時刻。
+	// 認証済みリクエストごとに DB に書き込むと負荷が高くなるので、
+	// lastActiveUpdateInterval で gating する (#421)。
+	lastActiveMu   sync.Mutex
+	lastActiveSeen map[string]time.Time
 }
 
 // NewAuthMiddleware creates a new AuthMiddleware.
 func NewAuthMiddleware(userRepo repository.UserRepository, accessTokenRepo repository.AccessTokenRepository) *AuthMiddleware {
-	return &AuthMiddleware{userRepo: userRepo, accessTokenRepo: accessTokenRepo}
+	return &AuthMiddleware{
+		userRepo:        userRepo,
+		accessTokenRepo: accessTokenRepo,
+		lastActiveSeen:  make(map[string]time.Time),
+	}
 }
 
 // Authenticate is an Echo middleware that extracts and validates the user token.
@@ -45,9 +63,34 @@ func (a *AuthMiddleware) Authenticate() echo.MiddlewareFunc {
 			}
 
 			c.Set(string(UserContextKey), user)
+			a.touchLastActive(user.ID)
 			return next(c)
 		}
 	}
+}
+
+// touchLastActive bumps the user's `lastActiveDate` column to now() if the
+// last update was more than `lastActiveUpdateInterval` ago. The DB write
+// runs in a goroutine to keep the request hot path lean (#421)。
+func (a *AuthMiddleware) touchLastActive(userID string) {
+	if userID == "" || a.userRepo == nil {
+		return
+	}
+	now := time.Now()
+	a.lastActiveMu.Lock()
+	last, ok := a.lastActiveSeen[userID]
+	if ok && now.Sub(last) < lastActiveUpdateInterval {
+		a.lastActiveMu.Unlock()
+		return
+	}
+	a.lastActiveSeen[userID] = now
+	a.lastActiveMu.Unlock()
+
+	go func(uid string, t time.Time) {
+		if err := a.userRepo.UpdateUser(uid, map[string]any{"lastActiveDate": t}); err != nil {
+			slog.Debug("auth: lastActiveDate update failed", "userId", uid, "err", err)
+		}
+	}(userID, now)
 }
 
 // RequireAuth is a middleware that requires authentication.

--- a/internal/server/router.go
+++ b/internal/server/router.go
@@ -1231,7 +1231,9 @@ func (s *Server) setupRoutes() {
 	api.POST("/federation/followers", federationHandler.Followers)
 	api.POST("/federation/following", federationHandler.Following)
 	api.POST("/federation/users", federationHandler.Users)
+	// admin overview から `misskeyApiGet` で叩かれるため GET も登録 (#421)。
 	api.POST("/federation/stats", federationHandler.Stats)
+	api.GET("/federation/stats", federationHandler.Stats)
 	api.POST("/federation/update-remote-user", federationHandler.UpdateRemoteUser, middleware.RequireModerator(roleService))
 
 	// Channels endpoints (Phase 4.2)
@@ -1401,19 +1403,24 @@ func (s *Server) setupRoutes() {
 	s.echo.GET("/streaming", streamingHandler.Stream)
 
 	// Charts API endpoints (engines + hooks already wired earlier).
+	// フロントエンドは `misskeyApiGet` (GET) でチャートを取得し、
+	// `misskeyApi` (POST) も使う場面があるので両方受ける。POST のみ登録だと
+	// GET が `api.Any("/*")` の catchall (= 200 + 空オブジェクト) に落ちて、
+	// 受信側で `chart.pubActive[0]` 等が `undefined` 例外を起こす (#421)。
 	chartsHandler := apicharts.NewHandler(chartCharts, nil)
-	api.POST("/charts/notes", chartsHandler.Notes)
-	api.POST("/charts/users", chartsHandler.Users)
-	api.POST("/charts/drive", chartsHandler.Drive)
-	api.POST("/charts/federation", chartsHandler.Federation)
-	api.POST("/charts/instance", chartsHandler.Instance)
-	api.POST("/charts/ap-request", chartsHandler.ApRequest)
-	api.POST("/charts/active-users", chartsHandler.ActiveUsers)
-	api.POST("/charts/user/notes", chartsHandler.UserNotes)
-	api.POST("/charts/user/drive", chartsHandler.UserDrive)
-	api.POST("/charts/user/following", chartsHandler.UserFollowing)
-	api.POST("/charts/user/pv", chartsHandler.UserPv)
-	api.POST("/charts/user/reactions", chartsHandler.UserReactions)
+	chartMethods := []string{http.MethodGet, http.MethodPost}
+	api.Match(chartMethods, "/charts/notes", chartsHandler.Notes)
+	api.Match(chartMethods, "/charts/users", chartsHandler.Users)
+	api.Match(chartMethods, "/charts/drive", chartsHandler.Drive)
+	api.Match(chartMethods, "/charts/federation", chartsHandler.Federation)
+	api.Match(chartMethods, "/charts/instance", chartsHandler.Instance)
+	api.Match(chartMethods, "/charts/ap-request", chartsHandler.ApRequest)
+	api.Match(chartMethods, "/charts/active-users", chartsHandler.ActiveUsers)
+	api.Match(chartMethods, "/charts/user/notes", chartsHandler.UserNotes)
+	api.Match(chartMethods, "/charts/user/drive", chartsHandler.UserDrive)
+	api.Match(chartMethods, "/charts/user/following", chartsHandler.UserFollowing)
+	api.Match(chartMethods, "/charts/user/pv", chartsHandler.UserPv)
+	api.Match(chartMethods, "/charts/user/reactions", chartsHandler.UserReactions)
 
 	// Following endpoints
 	followingHandler := following.NewHandler(followingService, userService)
@@ -1738,11 +1745,16 @@ func (s *Server) setupRoutes() {
 
 	// --- Phase P3: 補助公開エンドポイント ---
 
-	// get-online-users-count — オンラインユーザー数
-	api.POST("/get-online-users-count", func(c echo.Context) error {
+	// get-online-users-count — オンラインユーザー数。フロントが
+	// `misskeyApiGet` で GET 呼び出ししても catchall に落ちないよう
+	// 両メソッドを受ける (#421)。POST のみだと `count` が undefined になり
+	// admin overview の「NaN 人」表示の原因になっていた。
+	onlineUsersHandler := func(c echo.Context) error {
 		count, _ := userRepo.CountOnlineUsers()
 		return c.JSON(http.StatusOK, map[string]any{"count": count})
-	})
+	}
+	api.GET("/get-online-users-count", onlineUsersHandler)
+	api.POST("/get-online-users-count", onlineUsersHandler)
 
 	// server-info (公開版) — サーバー情報
 	// frontend の server-metric widget は `misskeyApiGet` で GET 呼び出し、

--- a/internal/server/router.go
+++ b/internal/server/router.go
@@ -144,6 +144,13 @@ func (s *Server) setupRoutes() {
 	driveFolderRepo := repository.NewDriveFolderRepository(s.db)
 	keypairRepo := repository.NewUserKeypairRepository(s.db)
 	instanceRepo := repository.NewInstanceRepository(s.db)
+	// instance.{followersCount,followingCount} はリアルタイム incremental
+	// 維持の hook が未実装で常に 0 → admin/overview の federation pie chart
+	// が空になる。起動時に `following` テーブルから一回 backfill する
+	// (#421)。失敗は警告だけで起動継続。
+	if err := instanceRepo.RecomputeFollowCounts(); err != nil {
+		slog.Warn("instance follow-counts recompute failed", "err", err)
+	}
 	channelRepo := repository.NewChannelRepository(s.db)
 	channelFollowingRepo := repository.NewChannelFollowingRepository(s.db)
 	antennaRepo := repository.NewAntennaRepository(s.db)

--- a/internal/testutil/mock_repository.go
+++ b/internal/testutil/mock_repository.go
@@ -1891,6 +1891,14 @@ func (m *MockInstanceRepository) ListForRefresh(staleBefore time.Time, limit int
 	return rows, nil
 }
 
+// RecomputeFollowCounts is a no-op stub for tests; the mock has no
+// `following` rows to aggregate from, and tests that exercise the
+// pie-chart endpoint can seed Instance.FollowersCount / FollowingCount
+// directly.
+func (m *MockInstanceRepository) RecomputeFollowCounts() error {
+	return nil
+}
+
 // List returns all stored instances filtered by the most common predicates.
 // 並び順は host 昇順 (テストの安定性のため)。
 func (m *MockInstanceRepository) List(filter model.InstanceListFilter) ([]*model.Instance, error) {


### PR DESCRIPTION
## Summary

#421 でトラッキングしている admin/overview の 4 件のうち 3 件 (#1 モデレーター filter / #2 オンラインユーザー NaN / #4 federation 永遠 loading) を 1 PR で修正する。残り 1 件 (#3 retention 空) は daily aggregation job 実装が必要なので別 PR に分離。

修正対象 3 件は別問題に見えるが、#2 と #4 は同根 (HTTP method ミスマッチ) で、#1 は repository filter の漏れ。

## 主な変更点

### 1. モデレーター filter (`internal/repository/user.go`)

- `ListUsers` の `state` switch が `suspended` / `alive` しか処理せず、`adminOrModerator` 等を黙って無視 → 全件返却 → moderator カードに観測した remote user が全部出ていた。
- 本家 `RoleService.getModeratorIds` 互換の SQL JOIN を追加：
  - `admin` / `moderator` / `adminOrModerator` の 3 case
  - `role_assignment` + `role` JOIN で `isAdministrator` / `isModerator` を見る
  - `expiresAt` 過ぎは除外、`host IS NULL` も付ける
- `available` を `alive` の alias として追加 (本家 enum の同義)
- sort key `+lastActiveDate` / `-lastActiveDate` を受理 (overview.moderators.vue が指定する)

### 2. NaN オンラインユーザー (`internal/server/router.go`)

- `overview.stats.vue` は `misskeyApiGet('get-online-users-count')` で **GET** リクエスト。
- mk-go は `api.POST` のみ登録 → GET は `api.Any(\"/*\")` の catchall (router.go:2032) で `200 {}` 返却 → frontend `res.count` が `undefined` → `Number(undefined) = NaN`。
- 同じハンドラを GET にも登録するだけで解消。

### 3. Federation 永遠 loading (`internal/server/router.go`, `internal/api/charts/handler.go`)

- 同じ HTTP method ミスマッチ問題が **全 chart endpoint** にある。frontend の `MkChart` / `MkUserCardMini` / `MkInstanceCardMini` などが `misskeyApiGet('charts/...')` で GET 呼び出しするが POST のみ登録。
- `overview.federation.vue` は `await misskeyApiGet('charts/federation', ...)` で結果を待つので、GET → `{}` → 後続 `chart.pubActive[0]` で例外 → `fetching = false` が実行されず spinner 永続。
- 修正：
  - charts/* の 12 endpoint を `api.Match([]string{GET, POST}, ...)` に変更
  - `charts.Request` struct に `query:\"...\"` タグを追加 (Echo の GET bind は query タグを見るため。POST の json bind は不変)
  - `/federation/stats` も GET 追加 (federation カードが同様に GET 呼出)

## 動作確認 (UDS)

```
$ curl https://go.k7a.org/api/get-online-users-count
{\"count\":0}                          # 修正前は {}

$ curl 'https://go.k7a.org/api/charts/federation?limit=2&span=day'
{\"deliveredInstances\":[0,0],...}     # 修正前は {}

$ curl 'https://go.k7a.org/api/federation/stats?limit=10'
{\"otherFollowersCount\":0,...,\"topPubInstances\":[...]}
```

## テスト

- 新規 `TestUserRepository_ListUsers_AdminOrModerator` — local mod が含まれ、非 mod local + role 付き remote が除外されることを確認
- 既存 charts handler テストはそのまま pass (json タグ + 追加した query タグが共存)
- `make fmt && make lint && go test ./...` 全通過

## 残作業

- **#3 retention rate 空**: `retention_aggregation` テーブルが空。`/api/retention` ハンドラは正常だが populating する daily job が未実装。別 PR で aggregation pipeline を入れる。

## 関連

- Tracks #421
- Fixes 3/4 of the dashboard bugs listed there (#1, #2, #4)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/shiroha-a/mk/pull/441" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
