### PR TITLE
Fix #428: batch InstanceResolver / EmojiResolver in PackNotifications

### DIFF
--- a/internal/api/notifications/handler.go
+++ b/internal/api/notifications/handler.go
@@ -116,7 +116,9 @@ func (h *Handler) Show(c echo.Context) error {
 		excludeSet[t] = true
 	}
 
-	out := make([]map[string]any, 0, len(rows))
+	// 1 ページ分の通知を filter してから entity.PackNotifications に渡し、
+	// InstanceResolver / EmojiResolver を 1 回だけ構築する (#428 N+1 解消)。
+	items := make([]entity.NotificationItem, 0, len(rows))
 	for _, n := range rows {
 		// カーソルベースページネーション
 		if req.SinceID != "" && n.ID <= req.SinceID {
@@ -140,10 +142,8 @@ func (h *Handler) Show(c echo.Context) error {
 				continue
 			}
 		}
-		// WebSocket 経由の packing と一貫性を保つため entity.PackNotification
-		// にdelegateする(Devin #315 指摘)。user/note 取得は handler 側で
-		// repo が wire されていれば best-effort。外側の認証ユーザー(`user`
-		// at line 48)をshadowしないよう明示的に notifier 名で受ける。
+		// user/note 取得は handler 側で repo が wire されていれば best-effort。
+		// 外側の認証ユーザー (`user`) を shadow しないよう notifier 名で受ける。
 		var notifier *model.User
 		if h.userRepo != nil && n.NotifierID != "" {
 			if u, err := h.userRepo.FindByID(n.NotifierID); err == nil {
@@ -156,8 +156,9 @@ func (h *Handler) Show(c echo.Context) error {
 				note = nn
 			}
 		}
-		out = append(out, entity.PackNotification(n, notifier, note, h.idGen, h.instanceLookup(), h.emojiLookup()))
+		items = append(items, entity.NotificationItem{N: n, User: notifier, Note: note})
 	}
+	out := entity.PackNotifications(items, h.idGen, h.instanceLookup(), h.emojiLookup())
 	// 本家 i/notifications と互換: markAsRead 未指定または true なら通知一覧
 	// 取得の副作用で全通知を既読化し、main stream に readAllNotifications を
 	// publish する。これが無いとフロントエンドが /my/notifications を開いても

--- a/internal/entity/notification.go
+++ b/internal/entity/notification.go
@@ -70,6 +70,12 @@ func PackNotifications(items []NotificationItem, idGen id.Generator, instLookup 
 	// (単品ケース packNotificationCore でも同じ shell を経由する形)。
 	syntheticUserOnlyNotes := make([]*model.Note, 0, len(items))
 	for _, it := range items {
+		// it.N == nil の要素は最終的に skip されるので resolver 入力にも
+		// 含めない。User / Note だけが詰まった「亡霊」item を渡された場合に
+		// 無駄な host / 絵文字 fetch を起こさないための防御。
+		if it.N == nil {
+			continue
+		}
 		if it.User != nil {
 			notifierUsers = append(notifierUsers, it.User)
 			syntheticUserOnlyNotes = append(syntheticUserOnlyNotes, &model.Note{User: it.User})

--- a/internal/entity/notification.go
+++ b/internal/entity/notification.go
@@ -67,7 +67,7 @@ func PackNotifications(items []NotificationItem, idGen id.Generator, instLookup 
 	notes := make([]*model.Note, 0, len(items))
 	// EmojiResolver は notes ベースで host 別に集約するので、notifier user の
 	// User.Emojis を拾うために合成 note shell ({User: u}) を別途 push する
-	// (単品 packUserLiteWithResolvers と同じテクニック)。
+	// (単品ケース packNotificationCore でも同じ shell を経由する形)。
 	syntheticUserOnlyNotes := make([]*model.Note, 0, len(items))
 	for _, it := range items {
 		if it.User != nil {
@@ -79,7 +79,14 @@ func PackNotifications(items []NotificationItem, idGen id.Generator, instLookup 
 		}
 	}
 	flat := flattenNotesPlusRelations(notes)
-	allUsers := append(notifierUsers, CollectNoteAuthors(flat)...)
+	noteAuthors := CollectNoteAuthors(flat)
+	// notifierUsers の backing array は cap=len(items) で確保済み。素朴な
+	// append(notifierUsers, ...) だと余剰 cap 内で同じ backing array に書く
+	// 可能性があり、後で notifierUsers を再利用したくなった時に aliasing
+	// バグになりうる。意識的に新規 backing array を確保しておく。
+	allUsers := make([]*model.User, 0, len(notifierUsers)+len(noteAuthors))
+	allUsers = append(allUsers, notifierUsers...)
+	allUsers = append(allUsers, noteAuthors...)
 	instResolver := NewInstanceResolver(instLookup, allUsers...)
 	emojiInput := append(append([]*model.Note(nil), flat...), syntheticUserOnlyNotes...)
 	emojiResolver := NewEmojiResolver(emojiLookup, emojiInput)

--- a/internal/entity/notification.go
+++ b/internal/entity/notification.go
@@ -13,6 +13,16 @@ import (
 	"github.com/shiroha-a/mk/internal/model"
 )
 
+// NotificationItem bundles a notification record with its already-resolved
+// notifier user and referenced note. PackNotifications takes a slice of
+// these so the caller can pre-fetch users / notes once and the packer can
+// build InstanceResolver / EmojiResolver once for the whole batch (#428)。
+type NotificationItem struct {
+	N    *notification.Notification
+	User *model.User
+	Note *model.Note
+}
+
 // PackNotification converts a Notification record into the map shape
 // emitted over the `main` WebSocket channel and returned by
 // /api/i/notifications. Matches Misskey's NotificationEntityService.pack
@@ -23,7 +33,70 @@ import (
 // instLookup / emojiLookup を渡すと top-level user と note.user に
 // Instance / 絵文字 URL を埋める。nil なら no-op リゾルバとして扱われ、
 // 従来互換の挙動になる (#415 notifications page InstanceTicker)。
+//
+// **Single-item only.** 内部で 1 件用の InstanceResolver / EmojiResolver を
+// 都度作るので、ループから呼ぶと N+1 クエリになる。複数件をまとめて pack
+// する callsite (例: /api/i/notifications) は PackNotifications を使うこと
+// (#428)。
 func PackNotification(n *notification.Notification, user *model.User, note *model.Note, idGen id.Generator, instLookup InstanceLookup, emojiLookup EmojiLookup) map[string]any {
+	if n == nil {
+		return nil
+	}
+	out := PackNotifications([]NotificationItem{{N: n, User: user, Note: note}}, idGen, instLookup, emojiLookup)
+	if len(out) == 0 {
+		return nil
+	}
+	return out[0]
+}
+
+// PackNotifications batches PackNotification across a slice of items with a
+// single InstanceResolver / EmojiResolver shared across all items. Callers
+// must pre-resolve notifier User and target Note (FindByID / FindByIDWithUser)
+// per item; the packer is responsible only for resolver-level batching
+// (Instance / 絵文字)。
+//
+// 通知一覧 hot-path (#428) で 1 件ごとに resolver を作っていた N+1 を解消する。
+// 20 件ページで Instance lookup × 2 + Emoji lookup × 2 (note 用 + user 用) =
+// 約 80 クエリ → 各 1 回に削減される (host / 絵文字名は内部で uniq 化)。
+//
+// items 内で N == nil の要素は単純に skip する。残りは入力順序を保って返す。
+func PackNotifications(items []NotificationItem, idGen id.Generator, instLookup InstanceLookup, emojiLookup EmojiLookup) []map[string]any {
+	// 全 item の notifier user + 埋め込み note.user / Renote/Reply author を
+	// flatten して resolver の入力にする。
+	notifierUsers := make([]*model.User, 0, len(items))
+	notes := make([]*model.Note, 0, len(items))
+	// EmojiResolver は notes ベースで host 別に集約するので、notifier user の
+	// User.Emojis を拾うために合成 note shell ({User: u}) を別途 push する
+	// (単品 packUserLiteWithResolvers と同じテクニック)。
+	syntheticUserOnlyNotes := make([]*model.Note, 0, len(items))
+	for _, it := range items {
+		if it.User != nil {
+			notifierUsers = append(notifierUsers, it.User)
+			syntheticUserOnlyNotes = append(syntheticUserOnlyNotes, &model.Note{User: it.User})
+		}
+		if it.Note != nil {
+			notes = append(notes, it.Note)
+		}
+	}
+	flat := flattenNotesPlusRelations(notes)
+	allUsers := append(notifierUsers, CollectNoteAuthors(flat)...)
+	instResolver := NewInstanceResolver(instLookup, allUsers...)
+	emojiInput := append(append([]*model.Note(nil), flat...), syntheticUserOnlyNotes...)
+	emojiResolver := NewEmojiResolver(emojiLookup, emojiInput)
+
+	out := make([]map[string]any, 0, len(items))
+	for _, it := range items {
+		if packed := packNotificationCore(it.N, it.User, it.Note, idGen, instResolver, emojiResolver); packed != nil {
+			out = append(out, packed)
+		}
+	}
+	return out
+}
+
+// packNotificationCore is the resolver-aware body shared by the single-item
+// PackNotification entry point and the batched PackNotifications. Resolvers
+// are passed in so the same instance can be re-used across many items.
+func packNotificationCore(n *notification.Notification, user *model.User, note *model.Note, idGen id.Generator, instResolver *InstanceResolver, emojiResolver *EmojiResolver) map[string]any {
 	if n == nil {
 		return nil
 	}
@@ -37,18 +110,23 @@ func PackNotification(n *notification.Notification, user *model.User, note *mode
 		// TS本家はnotifierIdを"userId"として返す。
 		out["userId"] = n.NotifierID
 		if user != nil {
-			out["user"] = packUserLiteWithResolvers(user, instLookup, emojiLookup)
+			lite := PackUserLite(user)
+			instResolver.FillUserLite(&lite)
+			emojiResolver.PopulateUserEmojis(user, &lite)
+			out["user"] = lite
 		}
 	}
 	if n.NoteID != "" {
 		// reply/mention/reaction/renote/quote/pollEnded等、noteを要する
 		// 通知タイプ向け。REST API互換のため noteId は常に含める。
 		// 加えて note object が fetch できていればpacked Noteも入れる。
-		// PackNoteWithInstance で note.user / Renote/Reply の embed にも
+		// applyNoteResolvers で note.user / Renote/Reply の embed にも
 		// Instance / 絵文字を適用する。
 		out["noteId"] = n.NoteID
 		if note != nil && idGen != nil {
-			out["note"] = PackNoteWithInstance(note, idGen, instLookup, emojiLookup)
+			packed := PackNote(note, idGen)
+			applyNoteResolvers(note, &packed, instResolver, emojiResolver)
+			out["note"] = packed
 		}
 	}
 	if n.Reaction != "" {
@@ -67,23 +145,4 @@ func PackNotification(n *notification.Notification, user *model.User, note *mode
 		out[k] = v
 	}
 	return out
-}
-
-// packUserLiteWithResolvers packs a model.User and applies optional Instance /
-// emoji resolution so that top-level user surfaces (notification userId / user)
-// carry the same InstanceTicker metadata as embedded note authors. nil lookups
-// leave Instance / Emojis empty (same as plain PackUserLite).
-func packUserLiteWithResolvers(u *model.User, instLookup InstanceLookup, emojiLookup EmojiLookup) UserLite {
-	lite := PackUserLite(u)
-	if u == nil {
-		return lite
-	}
-	instResolver := NewInstanceResolver(instLookup, u)
-	instResolver.FillUserLite(&lite)
-	// 絵文字は note.User の User.Emojis を引く経路と同じ interface を再利用。
-	// 合成 note に User だけ詰めた shell を渡すと NewEmojiResolver は
-	// user.Emojis から unique name を拾って一括 fetch してくれる。
-	emojiResolver := NewEmojiResolver(emojiLookup, []*model.Note{{User: u}})
-	emojiResolver.PopulateUserEmojis(u, &lite)
-	return lite
 }

--- a/internal/entity/notification_test.go
+++ b/internal/entity/notification_test.go
@@ -120,3 +120,89 @@ func TestPackNotification_ExtraFields_Merged(t *testing.T) {
 }
 
 func ptrStr(s string) *string { return &s }
+
+// PackNotifications は N 件の通知を pack しても InstanceLookup を 1 回 /
+// EmojiLookup は host 数分しか叩かないことを確認する (#428 N+1 解消)。
+// 単品 PackNotification を loop で呼ぶと 1 件あたり 2 + 2 (note 用 +
+// user 用) クエリ発生するため、20 件で 80 クエリにふくらむ前提を防ぐ。
+func TestPackNotifications_BatchesResolvers(t *testing.T) {
+	idGen, _ := id.NewGenerator("aidx")
+	hostA := "a.example"
+	hostB := "b.example"
+	themeColor := "#cafe00"
+	instLookup := &stubInstanceLookup{data: map[string]*model.Instance{
+		hostA: {Host: hostA, ThemeColor: &themeColor},
+		hostB: {Host: hostB, ThemeColor: &themeColor},
+	}}
+	emojiLookup := &stubEmojiLookup{data: map[string][]*model.Emoji{}}
+
+	// 3 件の通知: 同じ host を含む / 別 host / local の混在で host 集約も確認。
+	mkItem := func(id string, host *string) NotificationItem {
+		u := &model.User{ID: "u" + id, Username: "u" + id, UsernameLower: "u" + id, Host: host}
+		return NotificationItem{
+			N: &notification.Notification{
+				ID: id, CreatedAt: time.Now(), Type: notification.TypeFollow, NotifierID: "u" + id,
+			},
+			User: u,
+		}
+	}
+	items := []NotificationItem{
+		mkItem("n1", &hostA),
+		mkItem("n2", &hostA),
+		mkItem("n3", &hostB),
+	}
+
+	out := PackNotifications(items, idGen, instLookup, emojiLookup)
+	require.Len(t, out, 3)
+
+	assert.Len(t, instLookup.calls, 1, "InstanceResolver は 1 batch fetch のみ")
+	// host は a/b の 2 つ uniq 化されている。
+	assert.ElementsMatch(t, []string{hostA, hostB}, instLookup.calls[0])
+
+	// remote user の Instance が乗っていることだけ抜き取り検証。
+	for _, item := range out {
+		u, ok := item["user"].(UserLite)
+		require.True(t, ok)
+		require.NotNil(t, u.Instance)
+		assert.Equal(t, themeColor, *u.Instance.ThemeColor)
+	}
+}
+
+// item 内で N == nil な要素は skip され、残りは入力順序を保つことを確認。
+func TestPackNotifications_SkipsNilNotifications(t *testing.T) {
+	idGen, _ := id.NewGenerator("aidx")
+	items := []NotificationItem{
+		{N: &notification.Notification{ID: "x1", CreatedAt: time.Now(), Type: notification.TypeFollow}},
+		{N: nil},
+		{N: &notification.Notification{ID: "x2", CreatedAt: time.Now(), Type: notification.TypeFollow}},
+	}
+	out := PackNotifications(items, idGen, nil, nil)
+	require.Len(t, out, 2)
+	assert.Equal(t, "x1", out[0]["id"])
+	assert.Equal(t, "x2", out[1]["id"])
+}
+
+// note を持つ通知も 1 batch で resolve されることを確認 (note.user の Instance
+// と top-level notifier の Instance が同じ host でも fetch は 1 回)。
+func TestPackNotifications_NoteAndUserShareInstanceFetch(t *testing.T) {
+	idGen, _ := id.NewGenerator("aidx")
+	host := "remote.example"
+	themeColor := "#abcdef"
+	instLookup := &stubInstanceLookup{data: map[string]*model.Instance{
+		host: {Host: host, ThemeColor: &themeColor},
+	}}
+
+	notifier := &model.User{ID: "u_a", Username: "a", UsernameLower: "a", Host: &host}
+	noteAuthor := &model.User{ID: "u_b", Username: "b", UsernameLower: "b", Host: &host}
+	note := &model.Note{ID: "n_1", UserID: "u_b", User: noteAuthor, Text: ptrStr("hi")}
+
+	n := &notification.Notification{
+		ID: "x", CreatedAt: time.Now(), Type: notification.TypeReply,
+		NotifierID: "u_a", NoteID: "n_1",
+	}
+
+	out := PackNotifications([]NotificationItem{{N: n, User: notifier, Note: note}}, idGen, instLookup, nil)
+	require.Len(t, out, 1)
+	assert.Len(t, instLookup.calls, 1, "host 重複は uniq 化されて 1 回の fetch")
+	assert.ElementsMatch(t, []string{host}, instLookup.calls[0])
+}


### PR DESCRIPTION
## Summary

通知 1 件ごとに `packUserLiteWithResolvers` が `InstanceResolver` / `EmojiResolver` を新規構築していた N+1 を解消する (#428)。

- `entity.PackNotifications(items, idGen, instLookup, emojiLookup) []map[string]any` を新設
- 全 item の notifier user + 埋め込み note.user / Renote/Reply author を flatten し、resolver を 1 回だけ構築
- 内部 helper `packNotificationCore` に resolver 注入版を寄せ、`PackNotification` は単品用の薄い wrapper に変更 (backward compat)
- `/api/i/notifications` ハンドラを filter ループ + `PackNotifications` 1 回呼び出しの形に書き換え

## クエリ削減

20 件ページ想定:
- before: notifier 用 `FindManyByHosts` + `FindManyByNamesAndHost` × 20、note 用 同 × 20 = 約 80 クエリ
- after: host 集約後の `FindManyByHosts` 1 回、host 別 `FindManyByNamesAndHost` (host 数分)。同 host が多ければ実質数本に収束。

## Stream 側

`stream.NotificationPublisher.Pack` は 1 件 publish のみのため `PackNotification` (= 内部で 1 件用 batch) のまま維持。

## 主な変更点

- `internal/entity/notification.go`: `NotificationItem` 型 + `PackNotifications` を追加。`PackNotification` は wrapper に。
- `internal/entity/notification_test.go`: 1 batch fetch 検証 / nil skip / host 重複 dedup の回帰テスト追加。
- `internal/api/notifications/handler.go`: ループを batch に書き換え。

## テスト

```
go test -count=1 -cover ./internal/entity/... ./internal/api/notifications/... ./internal/stream/...
ok  internal/entity                           coverage: 97.6%
ok  internal/api/notifications                coverage: 92.2%
ok  internal/stream                           coverage: 91.8%
```

`go vet ./...` クリーン、`gofmt -s -d .` 差分なし。

Closes #428
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/shiroha-a/mk/pull/443" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
