### PR TITLE
queue: driver 抽象化 + asynq driver 化 (#447)

### DIFF
--- a/internal/core/federation/deliver_service_test.go
+++ b/internal/core/federation/deliver_service_test.go
@@ -5,11 +5,11 @@ import (
 	"errors"
 	"testing"
 
-	"github.com/hibiken/asynq"
 	"github.com/shiroha-a/mk/internal/activitypub"
 	"github.com/shiroha-a/mk/internal/core/federation"
 	"github.com/shiroha-a/mk/internal/model"
 	"github.com/shiroha-a/mk/internal/queue"
+	"github.com/shiroha-a/mk/internal/queue/driver"
 	"github.com/shiroha-a/mk/internal/testutil"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -21,7 +21,7 @@ type stubEnqueuer struct {
 	err   error
 }
 
-func (s *stubEnqueuer) EnqueueDeliver(payload queue.DeliverPayload, _ ...asynq.Option) error {
+func (s *stubEnqueuer) EnqueueDeliver(payload queue.DeliverPayload, _ ...driver.EnqueueOption) error {
 	if s.err != nil {
 		return s.err
 	}

--- a/internal/core/webhook/service_test.go
+++ b/internal/core/webhook/service_test.go
@@ -7,11 +7,11 @@ import (
 	"testing"
 	"time"
 
-	"github.com/hibiken/asynq"
 	"github.com/lib/pq"
 	"github.com/shiroha-a/mk/internal/core/webhook"
 	"github.com/shiroha-a/mk/internal/model"
 	"github.com/shiroha-a/mk/internal/queue"
+	"github.com/shiroha-a/mk/internal/queue/driver"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -25,7 +25,9 @@ type fakeEnqueuer struct {
 	systemErr   error
 }
 
-func (f *fakeEnqueuer) EnqueueDeliver(_ queue.DeliverPayload, _ ...asynq.Option) error { return nil }
+func (f *fakeEnqueuer) EnqueueDeliver(_ queue.DeliverPayload, _ ...driver.EnqueueOption) error {
+	return nil
+}
 func (f *fakeEnqueuer) EnqueueExport(_ queue.ExportPayload) error                      { return nil }
 func (f *fakeEnqueuer) EnqueueImport(_ queue.ImportPayload) error                      { return nil }
 func (f *fakeEnqueuer) EnqueueWebPush(_ context.Context, _ queue.WebPushPayload) error { return nil }

--- a/internal/core/webpush/service_test.go
+++ b/internal/core/webpush/service_test.go
@@ -6,9 +6,9 @@ import (
 	"errors"
 	"testing"
 
-	"github.com/hibiken/asynq"
 	"github.com/shiroha-a/mk/internal/core/webpush"
 	"github.com/shiroha-a/mk/internal/queue"
+	"github.com/shiroha-a/mk/internal/queue/driver"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -19,7 +19,7 @@ type fakeEnqueuer struct {
 	err   error
 }
 
-func (f *fakeEnqueuer) EnqueueDeliver(_ queue.DeliverPayload, _ ...asynq.Option) error {
+func (f *fakeEnqueuer) EnqueueDeliver(_ queue.DeliverPayload, _ ...driver.EnqueueOption) error {
 	return nil
 }
 func (f *fakeEnqueuer) EnqueueExport(_ queue.ExportPayload) error { return nil }

--- a/internal/queue/driver/asynqdriver/asynqdriver_test.go
+++ b/internal/queue/driver/asynqdriver/asynqdriver_test.go
@@ -1,0 +1,202 @@
+package asynqdriver
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/hibiken/asynq"
+
+	"github.com/shiroha-a/mk/internal/config"
+	"github.com/shiroha-a/mk/internal/queue/driver"
+)
+
+func TestBuildRedisOpt_TCP(t *testing.T) {
+	got := BuildRedisOpt(config.RedisOptions{
+		Host: "redis.example",
+		Port: 16379,
+		Pass: "p",
+		DB:   3,
+	})
+	want := asynq.RedisClientOpt{
+		Addr:     "redis.example:16379",
+		Password: "p",
+		DB:       3,
+	}
+	if got != want {
+		t.Fatalf("got %#v want %#v", got, want)
+	}
+}
+
+func TestBuildRedisOpt_UnixSocket(t *testing.T) {
+	got := BuildRedisOpt(config.RedisOptions{
+		Host: "/tmp/redis.sock",
+		Pass: "p",
+	})
+	want := asynq.RedisClientOpt{
+		Network:  "unix",
+		Addr:     "/tmp/redis.sock",
+		Password: "p",
+	}
+	if got != want {
+		t.Fatalf("got %#v want %#v", got, want)
+	}
+}
+
+func TestToAsynqOptions(t *testing.T) {
+	o := driver.ApplyEnqueueOptions([]driver.EnqueueOption{
+		driver.WithQueue("deliver"),
+		driver.WithMaxRetry(0),
+		driver.WithUnique(time.Hour),
+		driver.WithProcessIn(2 * time.Second),
+	})
+	got := toAsynqOptions(o)
+	if len(got) != 4 {
+		t.Fatalf("expected 4 options, got %d (%+v)", len(got), got)
+	}
+}
+
+func TestToAsynqOptions_DefaultsSkipped(t *testing.T) {
+	got := toAsynqOptions(driver.EnqueueOptions{})
+	if len(got) != 0 {
+		t.Fatalf("expected no options for zero EnqueueOptions, got %d", len(got))
+	}
+}
+
+func TestToAsynqOptions_MaxRetryRequiresExplicit(t *testing.T) {
+	// MaxRetrySet=false means "use driver default" so the option
+	// must NOT be added even though MaxRetry==0.
+	got := toAsynqOptions(driver.EnqueueOptions{MaxRetry: 5})
+	if len(got) != 0 {
+		t.Fatalf("MaxRetry without MaxRetrySet must be skipped, got %d", len(got))
+	}
+}
+
+// fakeRedis returns a non-routable RedisClientOpt; we never Start the
+// server in these tests so the address is fine. asynq client/inspector
+// constructors do not Dial until the first request.
+func fakeRedis() asynq.RedisClientOpt {
+	return asynq.RedisClientOpt{Addr: "127.0.0.1:0"}
+}
+
+func TestDriver_LazyConstruction(t *testing.T) {
+	d := New(fakeRedis(), ServerConfig{Concurrency: 4})
+
+	if d.client != nil || d.server != nil || d.inspector != nil || d.scheduler != nil {
+		t.Fatalf("Driver fields must be nil before first access")
+	}
+
+	if d.Client() == nil {
+		t.Fatal("Client must be non-nil")
+	}
+	if d.client == nil {
+		t.Fatal("Client field must be cached after access")
+	}
+
+	if d.Server() == nil {
+		t.Fatal("Server must be non-nil")
+	}
+	if d.Inspector() == nil {
+		t.Fatal("Inspector must be non-nil")
+	}
+	if d.Scheduler() == nil {
+		t.Fatal("Scheduler must be non-nil")
+	}
+
+	// 2nd call must return the cached instance.
+	first := d.Client()
+	second := d.Client()
+	if first != second {
+		t.Fatal("Client must be cached")
+	}
+}
+
+func TestDriver_Close_NoComponents(t *testing.T) {
+	d := New(fakeRedis(), ServerConfig{})
+	if err := d.Close(); err != nil {
+		t.Fatalf("Close on unused Driver: %v", err)
+	}
+}
+
+func TestDriver_Close_ClosesConstructedComponents(t *testing.T) {
+	d := New(fakeRedis(), ServerConfig{})
+	_ = d.Client()
+	_ = d.Inspector()
+	if err := d.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+}
+
+func TestServer_HandleSkipRetryConversion(t *testing.T) {
+	s := NewServer(fakeRedis(), ServerConfig{})
+	wrapped := fmt.Errorf("decode: %w", driver.SkipRetry)
+
+	var captured error
+	s.Handle("dummy", func(_ context.Context, _ driver.Task) error {
+		return wrapped
+	})
+
+	// Pull the registered handler out of the mux and invoke it
+	// directly to verify the SkipRetry conversion. asynq's ServeMux
+	// exposes the handler via Handler(*asynq.Task) but only when a
+	// task type matches; we synthesize the task here.
+	t.Helper()
+	h, _ := s.mux.Handler(asynq.NewTask("dummy", nil))
+	if h == nil {
+		t.Fatal("handler not registered")
+	}
+	captured = h.ProcessTask(context.Background(), asynq.NewTask("dummy", nil))
+	if !errors.Is(captured, asynq.SkipRetry) {
+		t.Fatalf("captured error must wrap asynq.SkipRetry, got %v", captured)
+	}
+	if !errors.Is(captured, driver.SkipRetry) {
+		t.Fatalf("captured error must still wrap driver.SkipRetry, got %v", captured)
+	}
+}
+
+func TestServer_HandlePassesNonSkipErrorThrough(t *testing.T) {
+	s := NewServer(fakeRedis(), ServerConfig{})
+	want := errors.New("transient")
+	s.Handle("plain", func(_ context.Context, _ driver.Task) error {
+		return want
+	})
+
+	h, _ := s.mux.Handler(asynq.NewTask("plain", nil))
+	got := h.ProcessTask(context.Background(), asynq.NewTask("plain", nil))
+	if !errors.Is(got, want) {
+		t.Fatalf("expected %v, got %v", want, got)
+	}
+	if errors.Is(got, asynq.SkipRetry) {
+		t.Fatal("non-SkipRetry handler error must not be tagged with asynq.SkipRetry")
+	}
+}
+
+func TestServer_DefaultQueueWeights(t *testing.T) {
+	// Queues=nil → default fillup applies.
+	s := NewServer(fakeRedis(), ServerConfig{Queues: nil})
+	if s.inner == nil {
+		t.Fatal("inner asynq.Server not constructed")
+	}
+}
+
+func TestNewServer_ConcurrencyDefault(t *testing.T) {
+	// Concurrency<=0 falls back to 16 (covered indirectly — verify
+	// constructor does not panic and produces an inner server).
+	s := NewServer(fakeRedis(), ServerConfig{})
+	if s.inner == nil || s.mux == nil {
+		t.Fatal("Server must be fully constructed")
+	}
+}
+
+func TestAsynqTask_Wrapper(t *testing.T) {
+	t1 := asynq.NewTask("foo", []byte("bar"))
+	w := asynqTask{t: t1}
+	if w.Type() != "foo" {
+		t.Fatalf("Type: got %q", w.Type())
+	}
+	if string(w.Payload()) != "bar" {
+		t.Fatalf("Payload: got %q", string(w.Payload()))
+	}
+}

--- a/internal/queue/driver/asynqdriver/client.go
+++ b/internal/queue/driver/asynqdriver/client.go
@@ -1,0 +1,33 @@
+package asynqdriver
+
+import (
+	"context"
+
+	"github.com/hibiken/asynq"
+
+	"github.com/shiroha-a/mk/internal/queue/driver"
+)
+
+// Client implements driver.Client over *asynq.Client.
+type Client struct {
+	inner *asynq.Client
+}
+
+// NewClient constructs a Client backed by the supplied asynq
+// connection options.
+func NewClient(redisOpt asynq.RedisClientOpt) *Client {
+	return &Client{inner: asynq.NewClient(redisOpt)}
+}
+
+// Enqueue submits the given task. driver.WithProcessIn(d) maps to
+// asynq.ProcessIn(d); other options follow the obvious mapping.
+func (c *Client) Enqueue(ctx context.Context, taskType string, payload []byte, opts ...driver.EnqueueOption) error {
+	o := driver.ApplyEnqueueOptions(opts)
+	task := asynq.NewTask(taskType, payload)
+	asynqOpts := toAsynqOptions(o)
+	_, err := c.inner.EnqueueContext(ctx, task, asynqOpts...)
+	return err
+}
+
+// Close releases the underlying asynq client.
+func (c *Client) Close() error { return c.inner.Close() }

--- a/internal/queue/driver/asynqdriver/driver.go
+++ b/internal/queue/driver/asynqdriver/driver.go
@@ -1,0 +1,83 @@
+package asynqdriver
+
+import (
+	"errors"
+
+	"github.com/hibiken/asynq"
+
+	"github.com/shiroha-a/mk/internal/queue/driver"
+)
+
+// Driver bundles the four asynq sub-services into a single
+// driver.Driver. Each call to a getter returns the lazily-built
+// component so a Driver instance can be created without immediately
+// touching Redis.
+type Driver struct {
+	redisOpt  asynq.RedisClientOpt
+	serverCfg ServerConfig
+
+	client    *Client
+	server    *Server
+	inspector *Inspector
+	scheduler *Scheduler
+}
+
+// New constructs an asynq-backed driver.Driver. The redisOpt is
+// shared by every sub-service; the serverCfg only affects the
+// worker side (concurrency / queue priority weights).
+func New(redisOpt asynq.RedisClientOpt, serverCfg ServerConfig) *Driver {
+	return &Driver{redisOpt: redisOpt, serverCfg: serverCfg}
+}
+
+// Client returns the lazily-constructed driver.Client.
+func (d *Driver) Client() driver.Client {
+	if d.client == nil {
+		d.client = NewClient(d.redisOpt)
+	}
+	return d.client
+}
+
+// Server returns the lazily-constructed driver.Server.
+func (d *Driver) Server() driver.Server {
+	if d.server == nil {
+		d.server = NewServer(d.redisOpt, d.serverCfg)
+	}
+	return d.server
+}
+
+// Inspector returns the lazily-constructed driver.Inspector.
+func (d *Driver) Inspector() driver.Inspector {
+	if d.inspector == nil {
+		d.inspector = NewInspector(d.redisOpt)
+	}
+	return d.inspector
+}
+
+// Scheduler returns the lazily-constructed driver.Scheduler.
+func (d *Driver) Scheduler() driver.Scheduler {
+	if d.scheduler == nil {
+		d.scheduler = NewScheduler(d.redisOpt)
+	}
+	return d.scheduler
+}
+
+// Close releases every constructed sub-service. Components that
+// have not been built yet are skipped. Errors are aggregated so a
+// failure in one Close does not mask the others.
+func (d *Driver) Close() error {
+	var errs []error
+	if d.client != nil {
+		if err := d.client.Close(); err != nil {
+			errs = append(errs, err)
+		}
+	}
+	if d.inspector != nil {
+		if err := d.inspector.Close(); err != nil {
+			errs = append(errs, err)
+		}
+	}
+	// Server / Scheduler は Shutdown() で停止する。Close 失敗の概念は
+	// asynq 側に存在しないため、ここでは触らない (呼び出し側が
+	// driver.Server.Shutdown / driver.Scheduler.Shutdown を別途呼ぶ)。
+	return errors.Join(errs...)
+}

--- a/internal/queue/driver/asynqdriver/inspector.go
+++ b/internal/queue/driver/asynqdriver/inspector.go
@@ -1,0 +1,133 @@
+package asynqdriver
+
+import (
+	"github.com/hibiken/asynq"
+
+	"github.com/shiroha-a/mk/internal/queue/driver"
+)
+
+// Inspector implements driver.Inspector over *asynq.Inspector.
+type Inspector struct {
+	inner *asynq.Inspector
+}
+
+// NewInspector constructs an Inspector backed by the supplied asynq
+// connection options.
+func NewInspector(redisOpt asynq.RedisClientOpt) *Inspector {
+	return &Inspector{inner: asynq.NewInspector(redisOpt)}
+}
+
+// Queues returns the list of queue names known to the inspector.
+func (i *Inspector) Queues() ([]string, error) { return i.inner.Queues() }
+
+// GetQueueInfo returns aggregated counters for the named queue.
+func (i *Inspector) GetQueueInfo(qname string) (*driver.InspectorInfo, error) {
+	info, err := i.inner.GetQueueInfo(qname)
+	if err != nil {
+		return nil, err
+	}
+	return &driver.InspectorInfo{
+		Queue:     info.Queue,
+		Size:      info.Size,
+		Active:    info.Active,
+		Pending:   info.Pending,
+		Completed: info.Completed,
+		Failed:    info.Failed,
+		Scheduled: info.Scheduled,
+		Retry:     info.Retry,
+	}, nil
+}
+
+// DeleteTask deletes the named task from the named queue.
+func (i *Inspector) DeleteTask(qname, taskID string) error {
+	return i.inner.DeleteTask(qname, taskID)
+}
+
+// DeleteAllPendingTasks deletes every pending task in the named queue.
+func (i *Inspector) DeleteAllPendingTasks(qname string) (int, error) {
+	return i.inner.DeleteAllPendingTasks(qname)
+}
+
+// RunTask promotes a scheduled / retry task to run immediately.
+func (i *Inspector) RunTask(qname, taskID string) error {
+	return i.inner.RunTask(qname, taskID)
+}
+
+// Close releases the underlying inspector.
+func (i *Inspector) Close() error { return i.inner.Close() }
+
+// ListPendingTasks returns up to pageSize pending tasks in qname,
+// starting at the given page (1-indexed).
+func (i *Inspector) ListPendingTasks(qname string, page, pageSize int) ([]*driver.TaskSummary, error) {
+	return i.listTasks(qname, "pending", page, pageSize)
+}
+
+// ListActiveTasks returns up to pageSize active tasks.
+func (i *Inspector) ListActiveTasks(qname string, page, pageSize int) ([]*driver.TaskSummary, error) {
+	return i.listTasks(qname, "active", page, pageSize)
+}
+
+// ListScheduledTasks returns up to pageSize scheduled tasks.
+func (i *Inspector) ListScheduledTasks(qname string, page, pageSize int) ([]*driver.TaskSummary, error) {
+	return i.listTasks(qname, "scheduled", page, pageSize)
+}
+
+// ListRetryTasks returns up to pageSize retry tasks.
+func (i *Inspector) ListRetryTasks(qname string, page, pageSize int) ([]*driver.TaskSummary, error) {
+	return i.listTasks(qname, "retry", page, pageSize)
+}
+
+// GetTaskInfo returns full info for a single task.
+func (i *Inspector) GetTaskInfo(qname, taskID string) (*driver.TaskSummary, error) {
+	info, err := i.inner.GetTaskInfo(qname, taskID)
+	if err != nil {
+		return nil, err
+	}
+	return taskInfoToSummary(info), nil
+}
+
+func (i *Inspector) listTasks(qname, state string, page, pageSize int) ([]*driver.TaskSummary, error) {
+	if page < 1 {
+		page = 1
+	}
+	if pageSize <= 0 || pageSize > 100 {
+		pageSize = 30
+	}
+	opts := []asynq.ListOption{asynq.Page(page), asynq.PageSize(pageSize)}
+	var tasks []*asynq.TaskInfo
+	var err error
+	switch state {
+	case "pending":
+		tasks, err = i.inner.ListPendingTasks(qname, opts...)
+	case "active":
+		tasks, err = i.inner.ListActiveTasks(qname, opts...)
+	case "scheduled":
+		tasks, err = i.inner.ListScheduledTasks(qname, opts...)
+	case "retry":
+		tasks, err = i.inner.ListRetryTasks(qname, opts...)
+	}
+	if err != nil {
+		return nil, err
+	}
+	out := make([]*driver.TaskSummary, 0, len(tasks))
+	for _, t := range tasks {
+		out = append(out, taskInfoToSummary(t))
+	}
+	return out, nil
+}
+
+func taskInfoToSummary(t *asynq.TaskInfo) *driver.TaskSummary {
+	return &driver.TaskSummary{
+		ID:            t.ID,
+		Queue:         t.Queue,
+		Type:          t.Type,
+		State:         t.State.String(),
+		Payload:       t.Payload,
+		Retried:       t.Retried,
+		MaxRetry:      t.MaxRetry,
+		LastErr:       t.LastErr,
+		LastFailedAt:  t.LastFailedAt,
+		NextProcessAt: t.NextProcessAt,
+		CompletedAt:   t.CompletedAt,
+	}
+}

--- a/internal/queue/driver/asynqdriver/integration_test.go
+++ b/internal/queue/driver/asynqdriver/integration_test.go
@@ -1,0 +1,202 @@
+package asynqdriver_test
+
+import (
+	"context"
+	"log"
+	"os"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/hibiken/asynq"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/shiroha-a/mk/internal/queue/driver"
+	"github.com/shiroha-a/mk/internal/queue/driver/asynqdriver"
+	"github.com/shiroha-a/mk/internal/testutil"
+)
+
+var testRedis *testutil.TestRedis
+
+func TestMain(m *testing.M) {
+	ctx := context.Background()
+	var err error
+	testRedis, err = testutil.SetupRedis(ctx)
+	if err != nil {
+		log.Fatalf("setup redis: %v", err)
+	}
+	code := m.Run()
+	testRedis.Teardown(ctx)
+	os.Exit(code)
+}
+
+func redisOpt() asynq.RedisClientOpt {
+	return asynq.RedisClientOpt{Addr: testRedis.Addr}
+}
+
+func newDriver() *asynqdriver.Driver {
+	return asynqdriver.New(redisOpt(), asynqdriver.ServerConfig{Concurrency: 2})
+}
+
+func flushRedis(t *testing.T) {
+	t.Helper()
+	if err := testRedis.Client.FlushAll(context.Background()).Err(); err != nil {
+		t.Fatalf("flush: %v", err)
+	}
+}
+
+func waitGroupTimeout(wg *sync.WaitGroup, d time.Duration) bool {
+	done := make(chan struct{})
+	go func() { wg.Wait(); close(done) }()
+	select {
+	case <-done:
+		return true
+	case <-time.After(d):
+		return false
+	}
+}
+
+// TestEndToEnd_EnqueueProcess confirms the asynq driver wires
+// Client.Enqueue, Server.Handle and the SkipRetry conversion through
+// to the real asynq runtime against a live Redis.
+func TestEndToEnd_EnqueueProcess(t *testing.T) {
+	testutil.SkipIfNoDocker(t)
+	flushRedis(t)
+
+	d := newDriver()
+	t.Cleanup(func() { _ = d.Close() })
+
+	srv := d.Server()
+	var (
+		wg       sync.WaitGroup
+		received int32
+	)
+	wg.Add(1)
+	srv.Handle("e2e:ok", func(_ context.Context, task driver.Task) error {
+		defer wg.Done()
+		atomic.AddInt32(&received, 1)
+		assert.Equal(t, "e2e:ok", task.Type())
+		assert.Equal(t, []byte("body"), task.Payload())
+		return nil
+	})
+	require.NoError(t, srv.Start())
+	t.Cleanup(srv.Shutdown)
+
+	require.NoError(t, d.Client().Enqueue(context.Background(), "e2e:ok", []byte("body"),
+		driver.WithQueue("deliver")))
+
+	if !waitGroupTimeout(&wg, 5*time.Second) {
+		t.Fatal("handler not invoked")
+	}
+	assert.Equal(t, int32(1), atomic.LoadInt32(&received))
+}
+
+// TestInspector_LiveQueue exercises every Inspector method that the
+// driver delegates to asynq. We enqueue a single task, then ensure the
+// listing/inspection methods all return non-error results.
+func TestInspector_LiveQueue(t *testing.T) {
+	testutil.SkipIfNoDocker(t)
+	flushRedis(t)
+
+	d := newDriver()
+	t.Cleanup(func() { _ = d.Close() })
+
+	require.NoError(t, d.Client().Enqueue(context.Background(),
+		"inspector:list", []byte("a"),
+		driver.WithQueue("deliver"),
+	))
+
+	ins := d.Inspector()
+	queues, err := ins.Queues()
+	require.NoError(t, err)
+	assert.Contains(t, queues, "deliver")
+
+	info, err := ins.GetQueueInfo("deliver")
+	require.NoError(t, err)
+	assert.Equal(t, "deliver", info.Queue)
+
+	pending, err := ins.ListPendingTasks("deliver", 1, 30)
+	require.NoError(t, err)
+	require.NotEmpty(t, pending)
+	taskID := pending[0].ID
+
+	got, err := ins.GetTaskInfo("deliver", taskID)
+	require.NoError(t, err)
+	assert.Equal(t, taskID, got.ID)
+
+	// Ranges that must succeed even when empty.
+	_, err = ins.ListActiveTasks("deliver", 1, 30)
+	require.NoError(t, err)
+	_, err = ins.ListScheduledTasks("deliver", 1, 30)
+	require.NoError(t, err)
+	_, err = ins.ListRetryTasks("deliver", 1, 30)
+	require.NoError(t, err)
+
+	// page/pageSize の clamp 経路: 0 と 過大値の双方を default に
+	// 戻すロジックを一度通す。
+	_, err = ins.ListPendingTasks("deliver", 0, 0)
+	require.NoError(t, err)
+	_, err = ins.ListPendingTasks("deliver", -3, 999)
+	require.NoError(t, err)
+
+	// DeleteTask: 1 件削除 → 残り 0
+	require.NoError(t, ins.DeleteTask("deliver", taskID))
+
+	// 再 enqueue して DeleteAllPendingTasks をテスト
+	require.NoError(t, d.Client().Enqueue(context.Background(),
+		"inspector:list", []byte("b"),
+		driver.WithQueue("deliver"),
+	))
+	count, err := ins.DeleteAllPendingTasks("deliver")
+	require.NoError(t, err)
+	assert.Equal(t, 1, count)
+}
+
+// TestInspector_RunTask promotes a scheduled task using the live
+// Redis. Scheduled enqueueing uses driver.WithProcessIn so the task
+// lands in the scheduled bucket; RunTask then pulls it back to
+// pending.
+func TestInspector_RunTask(t *testing.T) {
+	testutil.SkipIfNoDocker(t)
+	flushRedis(t)
+
+	d := newDriver()
+	t.Cleanup(func() { _ = d.Close() })
+
+	require.NoError(t, d.Client().Enqueue(context.Background(),
+		"inspector:run", []byte{},
+		driver.WithQueue("deliver"),
+		driver.WithProcessIn(time.Hour),
+	))
+
+	ins := d.Inspector()
+	scheduled, err := ins.ListScheduledTasks("deliver", 1, 30)
+	require.NoError(t, err)
+	require.NotEmpty(t, scheduled)
+	taskID := scheduled[0].ID
+
+	require.NoError(t, ins.RunTask("deliver", taskID))
+}
+
+// TestScheduler_RegisterAndStart exercises the cron scheduler. The
+// schedule pattern fires every minute, but we only verify Start /
+// Shutdown succeed against a live Redis (Register validates cron
+// syntax client-side).
+func TestScheduler_RegisterAndStart(t *testing.T) {
+	testutil.SkipIfNoDocker(t)
+	flushRedis(t)
+
+	d := newDriver()
+	t.Cleanup(func() { _ = d.Close() })
+
+	sched := d.Scheduler()
+	require.NoError(t, sched.Register("* * * * *", "scheduled:every-min", []byte{},
+		driver.WithQueue("maintenance"),
+		driver.WithMaxRetry(0),
+		driver.WithUnique(time.Minute),
+	))
+	require.NoError(t, sched.Start())
+	sched.Shutdown()
+}

--- a/internal/queue/driver/asynqdriver/option.go
+++ b/internal/queue/driver/asynqdriver/option.go
@@ -1,0 +1,30 @@
+package asynqdriver
+
+import (
+	"github.com/hibiken/asynq"
+
+	"github.com/shiroha-a/mk/internal/queue/driver"
+)
+
+// toAsynqOptions translates a driver.EnqueueOptions into the
+// equivalent []asynq.Option list. Empty / zero fields are skipped so
+// the asynq library applies its own defaults (e.g. MaxRetry=25).
+func toAsynqOptions(o driver.EnqueueOptions) []asynq.Option {
+	out := make([]asynq.Option, 0, 4)
+	if o.Queue != "" {
+		out = append(out, asynq.Queue(o.Queue))
+	}
+	if o.MaxRetrySet {
+		// 0 を明示的に指定するケース (cleanRemoteNotes / chart 等の
+		// retry 不要ジョブ) があるため driver 側の MaxRetrySet で
+		// 「default 値ではない」ことを判定する。
+		out = append(out, asynq.MaxRetry(o.MaxRetry))
+	}
+	if o.UniqueTTL > 0 {
+		out = append(out, asynq.Unique(o.UniqueTTL))
+	}
+	if o.ProcessIn > 0 {
+		out = append(out, asynq.ProcessIn(o.ProcessIn))
+	}
+	return out
+}

--- a/internal/queue/driver/asynqdriver/redis.go
+++ b/internal/queue/driver/asynqdriver/redis.go
@@ -1,0 +1,39 @@
+// Package asynqdriver implements queue/driver against the asynq
+// (github.com/hibiken/asynq) library. It is the historical default
+// driver for mk-go and preserves the exact retry/scheduling
+// semantics callers were used to before the driver abstraction
+// landed.
+package asynqdriver
+
+import (
+	"fmt"
+
+	"github.com/hibiken/asynq"
+
+	"github.com/shiroha-a/mk/internal/config"
+)
+
+// BuildRedisOpt converts mk-go's config.RedisOptions into an
+// asynq.RedisClientOpt. Hosts that look like a UNIX socket path
+// ("/" prefix) flip the Network to "unix"; all other hosts use
+// classic host:port TCP.
+//
+// 旧 server.buildAsynqRedisOpt をそのまま移植したもので、admin/queue
+// stats の挙動を含めて従来と完全に同じ接続を生成する。
+func BuildRedisOpt(opts config.RedisOptions) asynq.RedisClientOpt {
+	if config.IsUnixSocketPath(opts.Host) {
+		return asynq.RedisClientOpt{
+			Network:  "unix",
+			Addr:     opts.Host,
+			Password: opts.Pass,
+			DB:       opts.DB,
+			Username: opts.Username,
+		}
+	}
+	return asynq.RedisClientOpt{
+		Addr:     fmt.Sprintf("%s:%d", opts.Host, opts.Port),
+		Password: opts.Pass,
+		DB:       opts.DB,
+		Username: opts.Username,
+	}
+}

--- a/internal/queue/driver/asynqdriver/scheduler.go
+++ b/internal/queue/driver/asynqdriver/scheduler.go
@@ -1,0 +1,39 @@
+package asynqdriver
+
+import (
+	"github.com/hibiken/asynq"
+
+	"github.com/shiroha-a/mk/internal/queue/driver"
+)
+
+// Scheduler implements driver.Scheduler over *asynq.Scheduler.
+type Scheduler struct {
+	inner *asynq.Scheduler
+}
+
+// NewScheduler constructs a Scheduler bound to the given Redis.
+//
+// asynq.Scheduler は redis 上のロックで重複起動を防ぐので、複数 process
+// で起動しても同時刻に同じジョブを 2 回 enqueue することはない。
+func NewScheduler(redisOpt asynq.RedisClientOpt) *Scheduler {
+	return &Scheduler{
+		inner: asynq.NewScheduler(redisOpt, &asynq.SchedulerOpts{}),
+	}
+}
+
+// Register schedules the named task to fire on every cron tick.
+// Options follow the EnqueueOption set; ProcessIn is ignored (cron
+// already controls when the task fires).
+func (s *Scheduler) Register(cronspec, taskType string, payload []byte, opts ...driver.EnqueueOption) error {
+	o := driver.ApplyEnqueueOptions(opts)
+	task := asynq.NewTask(taskType, payload)
+	asynqOpts := toAsynqOptions(o)
+	_, err := s.inner.Register(cronspec, task, asynqOpts...)
+	return err
+}
+
+// Start launches the scheduler in the background. Returns immediately.
+func (s *Scheduler) Start() error { return s.inner.Start() }
+
+// Shutdown stops the scheduler and releases its Redis connection.
+func (s *Scheduler) Shutdown() { s.inner.Shutdown() }

--- a/internal/queue/driver/asynqdriver/server.go
+++ b/internal/queue/driver/asynqdriver/server.go
@@ -1,0 +1,84 @@
+package asynqdriver
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/hibiken/asynq"
+
+	"github.com/shiroha-a/mk/internal/queue/driver"
+)
+
+// ServerConfig configures the asynq-backed worker.
+type ServerConfig struct {
+	// Concurrency is the number of worker goroutines. Zero falls
+	// back to 16 to match the historical default.
+	Concurrency int
+	// Queues maps queue name → relative priority weight. asynq
+	// uses these as scheduling weights; if empty, the asynq driver
+	// fills in the queue list expected by mk-go (deliver / push /
+	// export / webhook / maintenance).
+	Queues map[string]int
+}
+
+// Server implements driver.Server over *asynq.Server + ServeMux.
+type Server struct {
+	inner *asynq.Server
+	mux   *asynq.ServeMux
+}
+
+// NewServer constructs the worker side of the asynq driver bound to
+// the given Redis connection.
+func NewServer(redisOpt asynq.RedisClientOpt, cfg ServerConfig) *Server {
+	concurrency := cfg.Concurrency
+	if concurrency <= 0 {
+		concurrency = 16
+	}
+	queues := cfg.Queues
+	if len(queues) == 0 {
+		// Misskey-go の従来 wiring と同じ queue set を埋め直す。
+		// 新しい queue を増やすときはここと queue.QueueName 等の
+		// 定数追加を同時に行う。
+		queues = map[string]int{
+			"deliver":     1,
+			"push":        1,
+			"export":      1,
+			"webhook":     1,
+			"maintenance": 1,
+		}
+	}
+	inner := asynq.NewServer(redisOpt, asynq.Config{
+		Concurrency: concurrency,
+		Queues:      queues,
+	})
+	return &Server{inner: inner, mux: asynq.NewServeMux()}
+}
+
+// Handle registers a HandlerFunc for the given task type. The
+// handler receives a driver.Task adapter wrapping the underlying
+// *asynq.Task.
+//
+// Errors wrapping driver.SkipRetry are translated to
+// asynq.SkipRetry so the asynq runtime drops the job from the retry
+// queue exactly as it did before the driver indirection.
+func (s *Server) Handle(taskType string, h driver.HandlerFunc) {
+	s.mux.HandleFunc(taskType, func(ctx context.Context, t *asynq.Task) error {
+		err := h(ctx, asynqTask{t: t})
+		if err != nil && errors.Is(err, driver.SkipRetry) {
+			// 既存挙動: handler が SkipRetry を wrap した error を
+			// 返すと、asynq の retry を抑止する。元の error message
+			// は %w 連鎖でそのまま保持する。
+			return fmt.Errorf("%w: %w", err, asynq.SkipRetry)
+		}
+		return err
+	})
+}
+
+// Start launches the asynq worker in the background. Returns
+// immediately once the worker goroutines are up.
+func (s *Server) Start() error { return s.inner.Start(s.mux) }
+
+// Shutdown gracefully stops the worker, waiting for in-flight jobs
+// to finish.
+func (s *Server) Shutdown() { s.inner.Shutdown() }

--- a/internal/queue/driver/asynqdriver/task.go
+++ b/internal/queue/driver/asynqdriver/task.go
@@ -1,0 +1,19 @@
+package asynqdriver
+
+import (
+	"github.com/hibiken/asynq"
+)
+
+// asynqTask wraps *asynq.Task to satisfy driver.Task. It preserves
+// the original asynq.Task pointer so callers that need to escape
+// back into asynq-specific behavior can type-assert if absolutely
+// required (none currently do).
+type asynqTask struct {
+	t *asynq.Task
+}
+
+// Type returns the task's type identifier.
+func (a asynqTask) Type() string { return a.t.Type() }
+
+// Payload returns the task's payload bytes.
+func (a asynqTask) Payload() []byte { return a.t.Payload() }

--- a/internal/queue/driver/driver.go
+++ b/internal/queue/driver/driver.go
@@ -1,0 +1,102 @@
+package driver
+
+import (
+	"context"
+	"time"
+)
+
+// HandlerFunc processes a single task. Returning an error wrapping
+// SkipRetry tells the driver not to retry even if attempts remain.
+type HandlerFunc func(ctx context.Context, t Task) error
+
+// Client enqueues tasks. Drivers translate the (taskType, payload,
+// opts) tuple into their native enqueue call.
+type Client interface {
+	Enqueue(ctx context.Context, taskType string, payload []byte, opts ...EnqueueOption) error
+	Close() error
+}
+
+// Server is the worker-side runtime: register handlers, then Start
+// to begin consuming jobs. Shutdown stops accepting new jobs and
+// waits for in-flight ones.
+type Server interface {
+	Handle(taskType string, h HandlerFunc)
+	Start() error
+	Shutdown()
+}
+
+// InspectorInfo is the per-queue summary returned by Inspector.GetQueueInfo.
+// Field names mirror asynq.QueueInfo so the admin UI mapping stays
+// straightforward.
+type InspectorInfo struct {
+	Queue     string
+	Size      int
+	Active    int
+	Pending   int
+	Completed int
+	Failed    int
+	Scheduled int
+	Retry     int
+}
+
+// TaskSummary is the driver-neutral projection of a task used by the
+// admin/queue list APIs.
+type TaskSummary struct {
+	ID            string
+	Queue         string
+	Type          string
+	State         string
+	Payload       []byte
+	Retried       int
+	MaxRetry      int
+	LastErr       string
+	LastFailedAt  time.Time
+	NextProcessAt time.Time
+	EnqueuedAt    time.Time
+	ScheduledAt   time.Time
+	CompletedAt   time.Time
+}
+
+// Inspector exposes admin-level queue introspection used by the
+// admin/queue endpoints.
+type Inspector interface {
+	Queues() ([]string, error)
+	GetQueueInfo(qname string) (*InspectorInfo, error)
+
+	DeleteTask(qname, taskID string) error
+	DeleteAllPendingTasks(qname string) (int, error)
+	RunTask(qname, taskID string) error
+
+	ListPendingTasks(qname string, page, pageSize int) ([]*TaskSummary, error)
+	ListActiveTasks(qname string, page, pageSize int) ([]*TaskSummary, error)
+	ListScheduledTasks(qname string, page, pageSize int) ([]*TaskSummary, error)
+	ListRetryTasks(qname string, page, pageSize int) ([]*TaskSummary, error)
+
+	GetTaskInfo(qname, taskID string) (*TaskSummary, error)
+
+	Close() error
+}
+
+// Scheduler registers cron-driven recurring tasks. cronspec follows
+// the underlying driver's cron syntax (asynq accepts standard 5-field
+// cron expressions).
+type Scheduler interface {
+	Register(cronspec, taskType string, payload []byte, opts ...EnqueueOption) error
+	Start() error
+	Shutdown()
+}
+
+// Driver bundles the per-deployment queue driver factory. A single
+// Driver instance owns the underlying connection / runtime; callers
+// obtain Client / Server / Inspector / Scheduler from it.
+//
+// Close releases the resources owned by the driver. Sub-components
+// (Client, Inspector etc.) do not need to be Close'd individually
+// when the parent Driver is Closed.
+type Driver interface {
+	Client() Client
+	Server() Server
+	Inspector() Inspector
+	Scheduler() Scheduler
+	Close() error
+}

--- a/internal/queue/driver/driver_test.go
+++ b/internal/queue/driver/driver_test.go
@@ -1,0 +1,59 @@
+package driver
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+	"time"
+)
+
+func TestRawTask(t *testing.T) {
+	body := []byte("hello")
+	rt := RawTask{TypeName: "x", Body: body}
+	if rt.Type() != "x" {
+		t.Fatalf("Type: got %q", rt.Type())
+	}
+	if string(rt.Payload()) != "hello" {
+		t.Fatalf("Payload: got %q", string(rt.Payload()))
+	}
+}
+
+func TestSkipRetryIdentity(t *testing.T) {
+	wrapped := fmt.Errorf("decode: %w: %w", errors.New("boom"), SkipRetry)
+	if !errors.Is(wrapped, SkipRetry) {
+		t.Fatalf("errors.Is should match SkipRetry")
+	}
+}
+
+func TestApplyEnqueueOptions(t *testing.T) {
+	got := ApplyEnqueueOptions([]EnqueueOption{
+		WithQueue("deliver"),
+		WithMaxRetry(3),
+		WithUnique(time.Hour),
+		WithProcessIn(5 * time.Second),
+	})
+	want := EnqueueOptions{
+		Queue:       "deliver",
+		MaxRetry:    3,
+		MaxRetrySet: true,
+		UniqueTTL:   time.Hour,
+		ProcessIn:   5 * time.Second,
+	}
+	if got != want {
+		t.Fatalf("got %#v want %#v", got, want)
+	}
+}
+
+func TestApplyEnqueueOptionsZeroSentinel(t *testing.T) {
+	// MaxRetrySet must distinguish "explicit 0" from "default" so
+	// drivers can decide between "use default" vs "no retries".
+	got := ApplyEnqueueOptions([]EnqueueOption{WithMaxRetry(0)})
+	if got.MaxRetry != 0 || !got.MaxRetrySet {
+		t.Fatalf("explicit zero not recorded: %#v", got)
+	}
+
+	def := ApplyEnqueueOptions(nil)
+	if def.MaxRetrySet {
+		t.Fatalf("default options must not record MaxRetrySet")
+	}
+}

--- a/internal/queue/driver/errors.go
+++ b/internal/queue/driver/errors.go
@@ -1,0 +1,13 @@
+package driver
+
+import "errors"
+
+// SkipRetry is a sentinel returned by a HandlerFunc to tell the driver
+// the job must not be retried even if attempts remain. Drivers map
+// this to their native skip-retry semantics (asynq.SkipRetry,
+// mkq.ErrUnrecoverable, etc.).
+//
+// Handlers typically wrap it with fmt.Errorf("%w: %w", err, driver.SkipRetry)
+// so callers can both inspect the underlying cause and observe the skip
+// signal via errors.Is.
+var SkipRetry = errors.New("queue driver: skip retry")

--- a/internal/queue/driver/option.go
+++ b/internal/queue/driver/option.go
@@ -1,0 +1,65 @@
+package driver
+
+import "time"
+
+// EnqueueOptions captures driver-neutral parameters for enqueueing a
+// single task. Concrete drivers translate these into native options.
+//
+// Zero-valued fields mean "use the driver default":
+//   - Queue ""           : driver decides (often the default queue name)
+//   - MaxRetry 0         : driver default retry count
+//   - UniqueTTL 0        : no unique-key dedup
+//   - ProcessIn 0        : process immediately
+type EnqueueOptions struct {
+	Queue     string
+	MaxRetry  int
+	UniqueTTL time.Duration
+	ProcessIn time.Duration
+
+	// MaxRetrySet distinguishes "MaxRetry left at default" from
+	// "MaxRetry explicitly set to 0". asynq treats MaxRetry=0 as
+	// no-retries which differs from "use default", so callers like
+	// the cleanRemoteNotes job that want zero retries must opt in
+	// explicitly.
+	MaxRetrySet bool
+}
+
+// EnqueueOption mutates EnqueueOptions; pass via Client.Enqueue.
+type EnqueueOption func(*EnqueueOptions)
+
+// WithQueue routes the task to the named queue.
+func WithQueue(name string) EnqueueOption {
+	return func(o *EnqueueOptions) { o.Queue = name }
+}
+
+// WithMaxRetry sets the maximum number of retries for the task. Use
+// zero to disable retries entirely (callers should be aware that
+// driver defaults differ — asynq defaults to 25).
+func WithMaxRetry(n int) EnqueueOption {
+	return func(o *EnqueueOptions) {
+		o.MaxRetry = n
+		o.MaxRetrySet = true
+	}
+}
+
+// WithUnique sets a uniqueness TTL: the driver suppresses duplicate
+// enqueues with the same task type + payload within the window.
+func WithUnique(ttl time.Duration) EnqueueOption {
+	return func(o *EnqueueOptions) { o.UniqueTTL = ttl }
+}
+
+// WithProcessIn delays processing of the task by the given duration.
+func WithProcessIn(d time.Duration) EnqueueOption {
+	return func(o *EnqueueOptions) { o.ProcessIn = d }
+}
+
+// ApplyEnqueueOptions folds the variadic options into a single
+// EnqueueOptions. Drivers call this to obtain a populated struct
+// before mapping to their native API.
+func ApplyEnqueueOptions(opts []EnqueueOption) EnqueueOptions {
+	var o EnqueueOptions
+	for _, fn := range opts {
+		fn(&o)
+	}
+	return o
+}

--- a/internal/queue/driver/task.go
+++ b/internal/queue/driver/task.go
@@ -1,0 +1,25 @@
+// Package driver defines the queue driver abstraction. Concrete
+// drivers (asynq, mkq) implement these interfaces; the queue facade
+// and processors depend only on this package.
+package driver
+
+// Task represents a queueable unit of work, decoupled from any
+// specific driver. Drivers wrap their native task representation in
+// an adapter that implements this interface.
+type Task interface {
+	Type() string
+	Payload() []byte
+}
+
+// RawTask is a minimal Task implementation useful for tests and for
+// constructing tasks at API boundaries where no driver is involved.
+type RawTask struct {
+	TypeName string
+	Body     []byte
+}
+
+// Type returns the task type identifier.
+func (t RawTask) Type() string { return t.TypeName }
+
+// Payload returns the task payload bytes.
+func (t RawTask) Payload() []byte { return t.Body }

--- a/internal/queue/inspector.go
+++ b/internal/queue/inspector.go
@@ -1,54 +1,32 @@
 package queue
 
 import (
-	"time"
-
-	"github.com/hibiken/asynq"
+	"github.com/shiroha-a/mk/internal/queue/driver"
 )
 
-// Inspector wraps asynq.Inspector to provide queue management.
+// InspectorInfo aliases driver.InspectorInfo so callers depend on
+// the queue package without pulling driver into their imports.
+type InspectorInfo = driver.InspectorInfo
+
+// TaskSummary aliases driver.TaskSummary for the same reason.
+type TaskSummary = driver.TaskSummary
+
+// Inspector is the driver-neutral facade over driver.Inspector.
 type Inspector struct {
-	inner *asynq.Inspector
+	inner driver.Inspector
 }
 
-// NewInspector creates a new Inspector.
-func NewInspector(redisOpt asynq.RedisClientOpt) *Inspector {
-	return &Inspector{inner: asynq.NewInspector(redisOpt)}
+// NewInspector wraps the driver's inspector.
+func NewInspector(d driver.Driver) *Inspector {
+	return &Inspector{inner: d.Inspector()}
 }
 
-// InspectorInfo holds basic queue statistics.
-type InspectorInfo struct {
-	Queue     string
-	Size      int
-	Active    int
-	Pending   int
-	Completed int
-	Failed    int
-	Scheduled int
-	Retry     int
-}
+// Queues returns the list of queue names known to the inspector.
+func (i *Inspector) Queues() ([]string, error) { return i.inner.Queues() }
 
-// Queues returns the list of queue names.
-func (i *Inspector) Queues() ([]string, error) {
-	return i.inner.Queues()
-}
-
-// GetQueueInfo returns statistics for a specific queue.
+// GetQueueInfo returns aggregated counters for the named queue.
 func (i *Inspector) GetQueueInfo(qname string) (*InspectorInfo, error) {
-	info, err := i.inner.GetQueueInfo(qname)
-	if err != nil {
-		return nil, err
-	}
-	return &InspectorInfo{
-		Queue:     info.Queue,
-		Size:      info.Size,
-		Active:    info.Active,
-		Pending:   info.Pending,
-		Completed: info.Completed,
-		Failed:    info.Failed,
-		Scheduled: info.Scheduled,
-		Retry:     info.Retry,
-	}, nil
+	return i.inner.GetQueueInfo(qname)
 }
 
 // DeleteTask deletes a task by queue and ID.
@@ -61,105 +39,36 @@ func (i *Inspector) DeleteAllPendingTasks(qname string) (int, error) {
 	return i.inner.DeleteAllPendingTasks(qname)
 }
 
-// RunTask promotes a scheduled/retry task to run immediately.
+// RunTask promotes a scheduled / retry task to run immediately.
 func (i *Inspector) RunTask(qname, taskID string) error {
 	return i.inner.RunTask(qname, taskID)
 }
 
 // Close releases the underlying inspector.
-func (i *Inspector) Close() error {
-	return i.inner.Close()
-}
+func (i *Inspector) Close() error { return i.inner.Close() }
 
-// TaskSummary is a lightweight projection of asynq.TaskInfo for admin list APIs.
-type TaskSummary struct {
-	ID            string
-	Queue         string
-	Type          string
-	State         string
-	Payload       []byte
-	Retried       int
-	MaxRetry      int
-	LastErr       string
-	LastFailedAt  time.Time
-	NextProcessAt time.Time
-	EnqueuedAt    time.Time
-	ScheduledAt   time.Time
-	CompletedAt   time.Time
-}
-
-// ListPendingTasks returns up to pageSize pending tasks in qname starting at
-// page (1-indexed).
+// ListPendingTasks returns up to pageSize pending tasks in qname,
+// starting at the given page (1-indexed).
 func (i *Inspector) ListPendingTasks(qname string, page, pageSize int) ([]*TaskSummary, error) {
-	return i.listTasks(qname, "pending", page, pageSize)
+	return i.inner.ListPendingTasks(qname, page, pageSize)
 }
 
-// ListActiveTasks returns up to pageSize tasks currently being processed.
+// ListActiveTasks returns up to pageSize active tasks.
 func (i *Inspector) ListActiveTasks(qname string, page, pageSize int) ([]*TaskSummary, error) {
-	return i.listTasks(qname, "active", page, pageSize)
+	return i.inner.ListActiveTasks(qname, page, pageSize)
 }
 
-// ListScheduledTasks returns tasks scheduled for a future time.
+// ListScheduledTasks returns up to pageSize scheduled tasks.
 func (i *Inspector) ListScheduledTasks(qname string, page, pageSize int) ([]*TaskSummary, error) {
-	return i.listTasks(qname, "scheduled", page, pageSize)
+	return i.inner.ListScheduledTasks(qname, page, pageSize)
 }
 
-// ListRetryTasks returns tasks waiting to be retried.
+// ListRetryTasks returns up to pageSize retry tasks.
 func (i *Inspector) ListRetryTasks(qname string, page, pageSize int) ([]*TaskSummary, error) {
-	return i.listTasks(qname, "retry", page, pageSize)
+	return i.inner.ListRetryTasks(qname, page, pageSize)
 }
 
 // GetTaskInfo returns full info for a single task.
 func (i *Inspector) GetTaskInfo(qname, taskID string) (*TaskSummary, error) {
-	info, err := i.inner.GetTaskInfo(qname, taskID)
-	if err != nil {
-		return nil, err
-	}
-	return taskInfoToSummary(info), nil
-}
-
-func (i *Inspector) listTasks(qname, state string, page, pageSize int) ([]*TaskSummary, error) {
-	if page < 1 {
-		page = 1
-	}
-	if pageSize <= 0 || pageSize > 100 {
-		pageSize = 30
-	}
-	opts := []asynq.ListOption{asynq.Page(page), asynq.PageSize(pageSize)}
-	var tasks []*asynq.TaskInfo
-	var err error
-	switch state {
-	case "pending":
-		tasks, err = i.inner.ListPendingTasks(qname, opts...)
-	case "active":
-		tasks, err = i.inner.ListActiveTasks(qname, opts...)
-	case "scheduled":
-		tasks, err = i.inner.ListScheduledTasks(qname, opts...)
-	case "retry":
-		tasks, err = i.inner.ListRetryTasks(qname, opts...)
-	}
-	if err != nil {
-		return nil, err
-	}
-	out := make([]*TaskSummary, 0, len(tasks))
-	for _, t := range tasks {
-		out = append(out, taskInfoToSummary(t))
-	}
-	return out, nil
-}
-
-func taskInfoToSummary(t *asynq.TaskInfo) *TaskSummary {
-	return &TaskSummary{
-		ID:            t.ID,
-		Queue:         t.Queue,
-		Type:          t.Type,
-		State:         t.State.String(),
-		Payload:       t.Payload,
-		Retried:       t.Retried,
-		MaxRetry:      t.MaxRetry,
-		LastErr:       t.LastErr,
-		LastFailedAt:  t.LastFailedAt,
-		NextProcessAt: t.NextProcessAt,
-		CompletedAt:   t.CompletedAt,
-	}
+	return i.inner.GetTaskInfo(qname, taskID)
 }

--- a/internal/queue/processors/chart.go
+++ b/internal/queue/processors/chart.go
@@ -4,13 +4,13 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/hibiken/asynq"
 	"github.com/shiroha-a/mk/internal/core/chart"
+	"github.com/shiroha-a/mk/internal/queue/driver"
 )
 
 // ChartProcessor implements the periodic tick / resync / clean handlers
 // that mirror Misskey upstream's tickCharts / resyncCharts / cleanCharts
-// queue processors. それぞれ asynq.Scheduler の cron pattern で起動される。
+// queue processors. それぞれ driver.Scheduler の cron pattern で起動される。
 type ChartProcessor struct {
 	// charts is the ordered list of every chart engine that should be
 	// ticked / resynced / cleaned. Caller passes them in the same order
@@ -28,7 +28,7 @@ func NewChartProcessor(charts []*chart.Chart) *ChartProcessor {
 // charts only — grouped charts (per-user / per-host) cannot be enumerated
 // without an external driver and are skipped, matching the upstream
 // TickChartsProcessorService.process behaviour.
-func (p *ChartProcessor) HandleTick(ctx context.Context, _ *asynq.Task) error {
+func (p *ChartProcessor) HandleTick(ctx context.Context, _ driver.Task) error {
 	return p.runTick(ctx, false)
 }
 
@@ -36,13 +36,13 @@ func (p *ChartProcessor) HandleTick(ctx context.Context, _ *asynq.Task) error {
 // TickFunc returns nil for major are no-ops; per-group charts that
 // require enumeration are skipped (TODO: per-user/per-host resync, same
 // as upstream).
-func (p *ChartProcessor) HandleResync(ctx context.Context, _ *asynq.Task) error {
+func (p *ChartProcessor) HandleResync(ctx context.Context, _ driver.Task) error {
 	return p.runTick(ctx, true)
 }
 
 // HandleClean clears expired uniqueIncrement temp arrays on every
 // registered chart.
-func (p *ChartProcessor) HandleClean(ctx context.Context, _ *asynq.Task) error {
+func (p *ChartProcessor) HandleClean(ctx context.Context, _ driver.Task) error {
 	for _, c := range p.charts {
 		if err := c.Clean(ctx); err != nil {
 			return fmt.Errorf("chart clean %s: %w", c.Name(), err)

--- a/internal/queue/processors/chart_test.go
+++ b/internal/queue/processors/chart_test.go
@@ -8,8 +8,8 @@ import (
 	"testing"
 	"time"
 
-	"github.com/hibiken/asynq"
 	"github.com/shiroha-a/mk/internal/core/chart"
+	"github.com/shiroha-a/mk/internal/queue/driver"
 	"github.com/shiroha-a/mk/internal/queue/processors"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -153,7 +153,7 @@ func TestChartProcessor_HandleClean(t *testing.T) {
 	plain, repo2 := makeChart(t, schemaPlain(), nil)
 	p := processors.NewChartProcessor([]*chart.Chart{withUnique, plain})
 
-	require.NoError(t, p.HandleClean(context.Background(), asynq.NewTask("x", nil)))
+	require.NoError(t, p.HandleClean(context.Background(), driver.RawTask{TypeName: "x"}))
 	// withUnique chart は span hour + day で 2 回 ResetUniqueTempColumns が呼ばれる
 	assert.Equal(t, int64(2), repo1.resetN.Load())
 	// plain chart は uniqueColumn が無いので ResetUniqueTempColumns は呼ばれない
@@ -170,7 +170,7 @@ func TestChartProcessor_HandleTick_SkipsGrouped(t *testing.T) {
 	grouped, _ := makeChart(t, schemaGrouped(), tickFn)
 	p := processors.NewChartProcessor([]*chart.Chart{plain, grouped})
 
-	require.NoError(t, p.HandleTick(context.Background(), asynq.NewTask("x", nil)))
+	require.NoError(t, p.HandleTick(context.Background(), driver.RawTask{TypeName: "x"}))
 	// grouped chart は skip される
 	assert.Equal(t, int64(1), called.Load())
 }
@@ -184,7 +184,7 @@ func TestChartProcessor_HandleResync_PassesMajorTrue(t *testing.T) {
 	plain, _ := makeChart(t, schemaPlain(), tickFn)
 	p := processors.NewChartProcessor([]*chart.Chart{plain})
 
-	require.NoError(t, p.HandleResync(context.Background(), asynq.NewTask("x", nil)))
+	require.NoError(t, p.HandleResync(context.Background(), driver.RawTask{TypeName: "x"}))
 	assert.True(t, gotMajor.Load())
 }
 
@@ -198,13 +198,13 @@ func TestChartProcessor_HandleTick_PassesMajorFalse(t *testing.T) {
 	plain, _ := makeChart(t, schemaPlain(), tickFn)
 	p := processors.NewChartProcessor([]*chart.Chart{plain})
 
-	require.NoError(t, p.HandleTick(context.Background(), asynq.NewTask("x", nil)))
+	require.NoError(t, p.HandleTick(context.Background(), driver.RawTask{TypeName: "x"}))
 	assert.False(t, gotMajor.Load())
 }
 
 func TestChartProcessor_HandleTick_NilTickFuncIsNoop(t *testing.T) {
 	plain, _ := makeChart(t, schemaPlain(), nil)
 	p := processors.NewChartProcessor([]*chart.Chart{plain})
-	require.NoError(t, p.HandleTick(context.Background(), asynq.NewTask("x", nil)))
-	require.NoError(t, p.HandleResync(context.Background(), asynq.NewTask("x", nil)))
+	require.NoError(t, p.HandleTick(context.Background(), driver.RawTask{TypeName: "x"}))
+	require.NoError(t, p.HandleResync(context.Background(), driver.RawTask{TypeName: "x"}))
 }

--- a/internal/queue/processors/clean_remote_notes.go
+++ b/internal/queue/processors/clean_remote_notes.go
@@ -5,7 +5,7 @@ import (
 	"log/slog"
 	"time"
 
-	"github.com/hibiken/asynq"
+	"github.com/shiroha-a/mk/internal/queue/driver"
 	"github.com/shiroha-a/mk/internal/repository"
 )
 
@@ -27,9 +27,9 @@ func NewCleanRemoteNotesProcessor(noteRepo repository.NoteRepository, cfg CleanR
 	return &CleanRemoteNotesProcessor{noteRepo: noteRepo, cfg: cfg}
 }
 
-// Handle implements asynq.Handler. バッチ削除を maxProcessingMinutes の範囲で
-// 繰り返し実行する。100件/バッチで DB 負荷を平準化。
-func (p *CleanRemoteNotesProcessor) Handle(ctx context.Context, _ *asynq.Task) error {
+// Handle implements driver.HandlerFunc. バッチ削除を maxProcessingMinutes の
+// 範囲で繰り返し実行する。100件/バッチで DB 負荷を平準化。
+func (p *CleanRemoteNotesProcessor) Handle(ctx context.Context, _ driver.Task) error {
 	if !p.cfg.Enabled {
 		slog.Debug("clean-remote-notes: disabled, skipping")
 		return nil

--- a/internal/queue/processors/clean_remote_notes_test.go
+++ b/internal/queue/processors/clean_remote_notes_test.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"testing"
 
-	"github.com/hibiken/asynq"
+	"github.com/shiroha-a/mk/internal/queue/driver"
 	"github.com/shiroha-a/mk/internal/testutil"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -13,7 +13,7 @@ import (
 func TestCleanRemoteNotes_Disabled(t *testing.T) {
 	noteRepo := testutil.NewMockNoteRepository()
 	p := NewCleanRemoteNotesProcessor(noteRepo, CleanRemoteNotesConfig{Enabled: false})
-	err := p.Handle(context.Background(), asynq.NewTask("test", nil))
+	err := p.Handle(context.Background(), driver.RawTask{TypeName: "test"})
 	require.NoError(t, err)
 }
 
@@ -24,7 +24,7 @@ func TestCleanRemoteNotes_Enabled(t *testing.T) {
 		ExpiryDays:           90,
 		MaxProcessingMinutes: 1,
 	})
-	err := p.Handle(context.Background(), asynq.NewTask("test", nil))
+	err := p.Handle(context.Background(), driver.RawTask{TypeName: "test"})
 	require.NoError(t, err)
 }
 
@@ -35,7 +35,7 @@ func TestCleanRemoteNotes_DefaultValues(t *testing.T) {
 		ExpiryDays:           0,
 		MaxProcessingMinutes: 0,
 	})
-	err := p.Handle(context.Background(), asynq.NewTask("test", nil))
+	err := p.Handle(context.Background(), driver.RawTask{TypeName: "test"})
 	require.NoError(t, err)
 }
 
@@ -48,6 +48,6 @@ func TestCleanRemoteNotes_CancelledContext(t *testing.T) {
 	})
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel()
-	err := p.Handle(ctx, asynq.NewTask("test", nil))
+	err := p.Handle(ctx, driver.RawTask{TypeName: "test"})
 	assert.NoError(t, err)
 }

--- a/internal/queue/processors/delete_account.go
+++ b/internal/queue/processors/delete_account.go
@@ -6,8 +6,8 @@ import (
 	"log/slog"
 	"time"
 
-	"github.com/hibiken/asynq"
 	"github.com/shiroha-a/mk/internal/queue"
+	"github.com/shiroha-a/mk/internal/queue/driver"
 	"github.com/shiroha-a/mk/internal/repository"
 )
 
@@ -34,28 +34,28 @@ func NewDeleteAccountProcessor(noteRepo repository.NoteRepository, driveFileRepo
 }
 
 // deleteAccountNoteBatchSize controls how many notes are deleted per loop
-// iteration. Kept small enough that one batch finishes well within asynq's
-// default per-task timeout and the processor can check ctx.Err() between
-// batches.
+// iteration. Kept small enough that one batch finishes well within the
+// driver's default per-task timeout and the processor can check
+// ctx.Err() between batches.
 const deleteAccountNoteBatchSize = 100
 
 // deleteAccountBatchSleep throttles DB I/O between note batches to avoid
 // saturating the write path for accounts with very large note histories.
 const deleteAccountBatchSleep = 250 * time.Millisecond
 
-// Handle implements asynq.Handler.
+// Handle implements driver.HandlerFunc.
 //
-// 部分実行 (notes だけ消えた等) の状態で nil を返すと asynq は task 成功扱い
+// 部分実行 (notes だけ消えた等) の状態で nil を返すと driver は task 成功扱い
 // で MaxRetry が効かず、さらに Unique(24h) によって admin も 24 時間再エンキュー
 // できない。操作はすべて冪等 (既に消えた行は 0 件影響) なので、ctx 切れ / repo
-// エラーはそのまま返して asynq の retry に任せる。
-func (p *DeleteAccountProcessor) Handle(ctx context.Context, t *asynq.Task) error {
+// エラーはそのまま返して driver の retry に任せる。
+func (p *DeleteAccountProcessor) Handle(ctx context.Context, t driver.Task) error {
 	payload, err := queue.DecodeDeleteAccountPayload(t.Payload())
 	if err != nil {
-		return fmt.Errorf("decode delete-account payload: %w: %w", err, asynq.SkipRetry)
+		return fmt.Errorf("decode delete-account payload: %w: %w", err, driver.SkipRetry)
 	}
 	if payload.UserID == "" {
-		return fmt.Errorf("delete-account: userId is required: %w", asynq.SkipRetry)
+		return fmt.Errorf("delete-account: userId is required: %w", driver.SkipRetry)
 	}
 
 	if err := p.deleteNotes(ctx, payload.UserID); err != nil {
@@ -99,7 +99,7 @@ func (p *DeleteAccountProcessor) Handle(ctx context.Context, t *asynq.Task) erro
 // deleteNotes loops DeleteByUserBatch so that cancellation checkpoints and
 // throttling live here instead of in the repository. 大量ノート保有ユーザー
 // (10万件規模) に備えて各 batch の後で ctx.Err() を確認し、途中終了した場合は
-// その error を返して asynq に retry させる。
+// その error を返して driver に retry させる。
 func (p *DeleteAccountProcessor) deleteNotes(ctx context.Context, userID string) error {
 	if p.noteRepo == nil {
 		return nil

--- a/internal/queue/processors/delete_account_test.go
+++ b/internal/queue/processors/delete_account_test.go
@@ -6,20 +6,20 @@ import (
 	"errors"
 	"testing"
 
-	"github.com/hibiken/asynq"
 	"github.com/shiroha-a/mk/internal/model"
 	"github.com/shiroha-a/mk/internal/queue"
+	"github.com/shiroha-a/mk/internal/queue/driver"
 	"github.com/shiroha-a/mk/internal/queue/processors"
 	"github.com/shiroha-a/mk/internal/testutil"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
-func deleteAccountTask(t *testing.T, payload queue.DeleteAccountPayload) *asynq.Task {
+func deleteAccountTask(t *testing.T, payload queue.DeleteAccountPayload) driver.Task {
 	t.Helper()
 	body, err := json.Marshal(payload)
 	require.NoError(t, err)
-	return asynq.NewTask(queue.TaskTypeDeleteAccount, body)
+	return driver.RawTask{TypeName: queue.TaskTypeDeleteAccount, Body: body}
 }
 
 func TestDeleteAccountProcessor_DeletesAcrossRepos(t *testing.T) {
@@ -60,15 +60,15 @@ func TestDeleteAccountProcessor_EmptyUserIDSkipsRetry(t *testing.T) {
 	task := deleteAccountTask(t, queue.DeleteAccountPayload{})
 	err := p.Handle(context.Background(), task)
 	require.Error(t, err)
-	assert.ErrorIs(t, err, asynq.SkipRetry)
+	assert.ErrorIs(t, err, driver.SkipRetry)
 }
 
 func TestDeleteAccountProcessor_MalformedPayloadSkipsRetry(t *testing.T) {
 	p := processors.NewDeleteAccountProcessor(testutil.NewMockNoteRepository(), testutil.NewMockDriveFileRepository(), testutil.NewMockFollowingRepository())
-	task := asynq.NewTask(queue.TaskTypeDeleteAccount, []byte(`not-json`))
+	task := driver.RawTask{TypeName: queue.TaskTypeDeleteAccount, Body: []byte(`not-json`)}
 	err := p.Handle(context.Background(), task)
 	require.Error(t, err)
-	assert.ErrorIs(t, err, asynq.SkipRetry)
+	assert.ErrorIs(t, err, driver.SkipRetry)
 }
 
 func TestDeleteAccountProcessor_NilReposAreSkipped(t *testing.T) {
@@ -78,7 +78,7 @@ func TestDeleteAccountProcessor_NilReposAreSkipped(t *testing.T) {
 	require.NoError(t, p.Handle(context.Background(), task))
 }
 
-// CanceledContext は asynq に retry させるため ctx.Err() を返す (部分実行で
+// CanceledContext は driver に retry させるため ctx.Err() を返す (部分実行で
 // 成功扱いにしない)。handle が error を返せば MaxRetry 設定が効いて再試行
 // されるので孤立した drive_file / following 行が残り続けない。
 func TestDeleteAccountProcessor_CanceledContextReturnsError(t *testing.T) {

--- a/internal/queue/processors/deliver.go
+++ b/internal/queue/processors/deliver.go
@@ -1,4 +1,6 @@
-// Package processors contains asynq task handlers used by the queue worker.
+// Package processors contains task handlers used by the queue worker.
+// Handlers are driver-neutral: they accept a driver.Task and return
+// driver.SkipRetry to suppress retries.
 package processors
 
 import (
@@ -10,9 +12,9 @@ import (
 	"net/http"
 	"net/url"
 
-	"github.com/hibiken/asynq"
 	"github.com/shiroha-a/mk/internal/activitypub"
 	"github.com/shiroha-a/mk/internal/queue"
+	"github.com/shiroha-a/mk/internal/queue/driver"
 )
 
 // HTTPSigner abstracts the signed POST capability of activitypub.Client so
@@ -105,19 +107,19 @@ func (p *DeliverProcessor) recordError(inbox string) {
 	}
 }
 
-// Handle dispatches a single deliver task. The asynq runtime invokes this for
-// every dequeued task.
-func (p *DeliverProcessor) Handle(_ context.Context, t *asynq.Task) error {
+// Handle dispatches a single deliver task. The driver runtime invokes
+// this for every dequeued task.
+func (p *DeliverProcessor) Handle(_ context.Context, t driver.Task) error {
 	payload, err := queue.DecodeDeliverPayload(t.Payload())
 	if err != nil {
 		// payload が壊れているジョブは何度リトライしても無意味なのでスキップ。
-		return fmt.Errorf("decode deliver payload: %w: %w", err, asynq.SkipRetry)
+		return fmt.Errorf("decode deliver payload: %w: %w", err, driver.SkipRetry)
 	}
 
 	key, err := activitypub.NewPrivateKey(payload.KeyID, payload.KeyPEM)
 	if err != nil {
 		// 鍵が壊れているジョブも同様にスキップする。
-		return fmt.Errorf("parse private key: %w: %w", err, asynq.SkipRetry)
+		return fmt.Errorf("parse private key: %w: %w", err, driver.SkipRetry)
 	}
 
 	// deliverSuspendedSoftware: 対象インスタンスの software がリストに該当すればスキップ
@@ -153,14 +155,14 @@ func (p *DeliverProcessor) Handle(_ context.Context, t *asynq.Task) error {
 		slog.Info("ap deliver: target gone",
 			"inbox", payload.Inbox, "status", resp.StatusCode)
 		p.recordSuccess(payload.Inbox)
-		return fmt.Errorf("target gone (%d): %w", resp.StatusCode, asynq.SkipRetry)
+		return fmt.Errorf("target gone (%d): %w", resp.StatusCode, driver.SkipRetry)
 	case resp.StatusCode >= 400 && resp.StatusCode < 500:
 		// その他の4xxは受信側の不正リクエスト扱い。HTTP として応答が返って
 		// きているので isNotResponding 状態は解除する。
 		slog.Warn("ap deliver: client error",
 			"inbox", payload.Inbox, "status", resp.StatusCode)
 		p.recordSuccess(payload.Inbox)
-		return fmt.Errorf("client error (%d): %w", resp.StatusCode, asynq.SkipRetry)
+		return fmt.Errorf("client error (%d): %w", resp.StatusCode, driver.SkipRetry)
 	default:
 		// 5xx は受信側の一時的な障害。リトライさせる + 不調状態としてマーク。
 		slog.Warn("ap deliver: server error",

--- a/internal/queue/processors/deliver_test.go
+++ b/internal/queue/processors/deliver_test.go
@@ -12,9 +12,9 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/hibiken/asynq"
 	"github.com/shiroha-a/mk/internal/activitypub"
 	"github.com/shiroha-a/mk/internal/queue"
+	"github.com/shiroha-a/mk/internal/queue/driver"
 	"github.com/shiroha-a/mk/internal/queue/processors"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -52,7 +52,7 @@ func generateTestKey(t *testing.T) string {
 	return string(pem.EncodeToMemory(block))
 }
 
-func makeTask(t *testing.T, payload queue.DeliverPayload) *asynq.Task {
+func makeTask(t *testing.T, payload queue.DeliverPayload) driver.Task {
 	t.Helper()
 	return queue.NewDeliverTask(payload)
 }
@@ -98,7 +98,7 @@ func TestDeliverProcessor_Gone_SkipsRetry(t *testing.T) {
 	p := processors.NewDeliverProcessor(signer)
 	err := p.Handle(context.Background(), makeTask(t, makePayload(t)))
 	require.Error(t, err)
-	assert.ErrorIs(t, err, asynq.SkipRetry)
+	assert.ErrorIs(t, err, driver.SkipRetry)
 }
 
 func TestDeliverProcessor_NotFound_SkipsRetry(t *testing.T) {
@@ -106,7 +106,7 @@ func TestDeliverProcessor_NotFound_SkipsRetry(t *testing.T) {
 	p := processors.NewDeliverProcessor(signer)
 	err := p.Handle(context.Background(), makeTask(t, makePayload(t)))
 	require.Error(t, err)
-	assert.ErrorIs(t, err, asynq.SkipRetry)
+	assert.ErrorIs(t, err, driver.SkipRetry)
 }
 
 func TestDeliverProcessor_Forbidden_SkipsRetry(t *testing.T) {
@@ -114,7 +114,7 @@ func TestDeliverProcessor_Forbidden_SkipsRetry(t *testing.T) {
 	p := processors.NewDeliverProcessor(signer)
 	err := p.Handle(context.Background(), makeTask(t, makePayload(t)))
 	require.Error(t, err)
-	assert.ErrorIs(t, err, asynq.SkipRetry)
+	assert.ErrorIs(t, err, driver.SkipRetry)
 }
 
 func TestDeliverProcessor_ServerError_RetriesByReturningError(t *testing.T) {
@@ -122,7 +122,7 @@ func TestDeliverProcessor_ServerError_RetriesByReturningError(t *testing.T) {
 	p := processors.NewDeliverProcessor(signer)
 	err := p.Handle(context.Background(), makeTask(t, makePayload(t)))
 	require.Error(t, err)
-	assert.NotErrorIs(t, err, asynq.SkipRetry)
+	assert.NotErrorIs(t, err, driver.SkipRetry)
 }
 
 func TestDeliverProcessor_NetworkError_Retries(t *testing.T) {
@@ -132,15 +132,15 @@ func TestDeliverProcessor_NetworkError_Retries(t *testing.T) {
 	err := p.Handle(context.Background(), makeTask(t, makePayload(t)))
 	require.Error(t, err)
 	assert.ErrorIs(t, err, netErr)
-	assert.NotErrorIs(t, err, asynq.SkipRetry)
+	assert.NotErrorIs(t, err, driver.SkipRetry)
 }
 
 func TestDeliverProcessor_BadPayload_SkipsRetry(t *testing.T) {
 	p := processors.NewDeliverProcessor(&stubSigner{})
-	task := asynq.NewTask(queue.TaskTypeDeliver, []byte(`{not json`))
+	task := driver.RawTask{TypeName: queue.TaskTypeDeliver, Body: []byte(`{not json`)}
 	err := p.Handle(context.Background(), task)
 	require.Error(t, err)
-	assert.ErrorIs(t, err, asynq.SkipRetry)
+	assert.ErrorIs(t, err, driver.SkipRetry)
 }
 
 func TestDeliverProcessor_BadKey_SkipsRetry(t *testing.T) {
@@ -153,7 +153,7 @@ func TestDeliverProcessor_BadKey_SkipsRetry(t *testing.T) {
 	}
 	err := p.Handle(context.Background(), makeTask(t, payload))
 	require.Error(t, err)
-	assert.ErrorIs(t, err, asynq.SkipRetry)
+	assert.ErrorIs(t, err, driver.SkipRetry)
 }
 
 // stubResponseHook captures host events for assertions.

--- a/internal/queue/processors/emoji_import.go
+++ b/internal/queue/processors/emoji_import.go
@@ -5,9 +5,9 @@ import (
 	"errors"
 	"fmt"
 
-	"github.com/hibiken/asynq"
 	"github.com/shiroha-a/mk/internal/core/emojiimport"
 	"github.com/shiroha-a/mk/internal/queue"
+	"github.com/shiroha-a/mk/internal/queue/driver"
 )
 
 // ImportCustomEmojisProcessor handles `importCustomEmojis` tasks by delegating
@@ -23,16 +23,16 @@ func NewImportCustomEmojisProcessor(importer *emojiimport.Importer) *ImportCusto
 }
 
 // Handle dispatches a single emoji-zip import task.
-func (p *ImportCustomEmojisProcessor) Handle(ctx context.Context, t *asynq.Task) error {
+func (p *ImportCustomEmojisProcessor) Handle(ctx context.Context, t driver.Task) error {
 	if p.importer == nil {
-		return fmt.Errorf("import custom emojis processor not configured: %w", asynq.SkipRetry)
+		return fmt.Errorf("import custom emojis processor not configured: %w", driver.SkipRetry)
 	}
 	payload, err := queue.DecodeImportCustomEmojisPayload(t.Payload())
 	if err != nil {
-		return fmt.Errorf("decode import custom emojis payload: %w: %w", err, asynq.SkipRetry)
+		return fmt.Errorf("decode import custom emojis payload: %w: %w", err, driver.SkipRetry)
 	}
 	if payload.UserID == "" || payload.FileID == "" {
-		return fmt.Errorf("import custom emojis payload missing fields: %w", asynq.SkipRetry)
+		return fmt.Errorf("import custom emojis payload missing fields: %w", driver.SkipRetry)
 	}
 	if _, err := p.importer.Run(ctx, payload.UserID, payload.FileID); err != nil {
 		// ZIP 破損・meta.json 不在 など恒久的エラーは再試行してもムダ。
@@ -41,7 +41,7 @@ func (p *ImportCustomEmojisProcessor) Handle(ctx context.Context, t *asynq.Task)
 			errors.Is(err, emojiimport.ErrMalformedMeta) ||
 			errors.Is(err, emojiimport.ErrUserNotFound) ||
 			errors.Is(err, emojiimport.ErrDriveFileNotFound) {
-			return fmt.Errorf("%w: %w", err, asynq.SkipRetry)
+			return fmt.Errorf("%w: %w", err, driver.SkipRetry)
 		}
 		return err
 	}

--- a/internal/queue/processors/emoji_import_test.go
+++ b/internal/queue/processors/emoji_import_test.go
@@ -11,12 +11,12 @@ import (
 	"image/png"
 	"testing"
 
-	"github.com/hibiken/asynq"
 	"github.com/shiroha-a/mk/internal/core/drive"
 	"github.com/shiroha-a/mk/internal/core/emojiimport"
 	"github.com/shiroha-a/mk/internal/misc/id"
 	"github.com/shiroha-a/mk/internal/model"
 	"github.com/shiroha-a/mk/internal/queue"
+	"github.com/shiroha-a/mk/internal/queue/driver"
 	"github.com/shiroha-a/mk/internal/queue/processors"
 	"github.com/shiroha-a/mk/internal/testutil"
 	"github.com/stretchr/testify/assert"
@@ -90,16 +90,16 @@ func TestImportCustomEmojisProcessor_NotConfigured(t *testing.T) {
 	task := queue.NewImportCustomEmojisTask(queue.ImportCustomEmojisPayload{UserID: "admin", FileID: "f1"})
 	err := p.Handle(context.Background(), task)
 	require.Error(t, err)
-	assert.ErrorIs(t, err, asynq.SkipRetry)
+	assert.ErrorIs(t, err, driver.SkipRetry)
 }
 
 func TestImportCustomEmojisProcessor_BadPayload(t *testing.T) {
 	imp := newEmojiImporter(t, &fakeEmojiDriveReader{body: buildEmojiZip(t)})
 	p := processors.NewImportCustomEmojisProcessor(imp)
-	task := asynq.NewTask(queue.TaskTypeImportCustomEmojis, []byte("not json"))
+	task := driver.RawTask{TypeName: queue.TaskTypeImportCustomEmojis, Body: []byte("not json")}
 	err := p.Handle(context.Background(), task)
 	require.Error(t, err)
-	assert.ErrorIs(t, err, asynq.SkipRetry)
+	assert.ErrorIs(t, err, driver.SkipRetry)
 }
 
 func TestImportCustomEmojisProcessor_MissingFields(t *testing.T) {
@@ -114,7 +114,7 @@ func TestImportCustomEmojisProcessor_MissingFields(t *testing.T) {
 		task := queue.NewImportCustomEmojisTask(c)
 		err := p.Handle(context.Background(), task)
 		require.Error(t, err)
-		assert.ErrorIs(t, err, asynq.SkipRetry)
+		assert.ErrorIs(t, err, driver.SkipRetry)
 	}
 }
 
@@ -131,7 +131,7 @@ func TestImportCustomEmojisProcessor_InvalidZip_SkipRetry(t *testing.T) {
 	task := queue.NewImportCustomEmojisTask(queue.ImportCustomEmojisPayload{UserID: "admin", FileID: "f1"})
 	err := p.Handle(context.Background(), task)
 	require.Error(t, err)
-	assert.ErrorIs(t, err, asynq.SkipRetry)
+	assert.ErrorIs(t, err, driver.SkipRetry)
 	assert.ErrorIs(t, err, emojiimport.ErrInvalidZip)
 }
 
@@ -141,7 +141,7 @@ func TestImportCustomEmojisProcessor_UserNotFound_SkipRetry(t *testing.T) {
 	task := queue.NewImportCustomEmojisTask(queue.ImportCustomEmojisPayload{UserID: "ghost", FileID: "f1"})
 	err := p.Handle(context.Background(), task)
 	require.Error(t, err)
-	assert.ErrorIs(t, err, asynq.SkipRetry)
+	assert.ErrorIs(t, err, driver.SkipRetry)
 	assert.ErrorIs(t, err, emojiimport.ErrUserNotFound)
 }
 
@@ -151,6 +151,6 @@ func TestImportCustomEmojisProcessor_DriveError_SkipRetry(t *testing.T) {
 	task := queue.NewImportCustomEmojisTask(queue.ImportCustomEmojisPayload{UserID: "admin", FileID: "f1"})
 	err := p.Handle(context.Background(), task)
 	require.Error(t, err)
-	assert.ErrorIs(t, err, asynq.SkipRetry)
+	assert.ErrorIs(t, err, driver.SkipRetry)
 	assert.ErrorIs(t, err, emojiimport.ErrDriveFileNotFound)
 }

--- a/internal/queue/processors/instance_refresh.go
+++ b/internal/queue/processors/instance_refresh.go
@@ -5,7 +5,7 @@ import (
 	"log/slog"
 	"time"
 
-	"github.com/hibiken/asynq"
+	"github.com/shiroha-a/mk/internal/queue/driver"
 	"github.com/shiroha-a/mk/internal/repository"
 )
 
@@ -64,8 +64,8 @@ func (p *InstanceRefreshProcessor) SetClock(now func() time.Time) {
 	}
 }
 
-// Handle implements the asynq handler contract.
-func (p *InstanceRefreshProcessor) Handle(ctx context.Context, _ *asynq.Task) error {
+// Handle implements the driver handler contract.
+func (p *InstanceRefreshProcessor) Handle(ctx context.Context, _ driver.Task) error {
 	if p.repo == nil || p.fetcher == nil {
 		return nil
 	}
@@ -94,7 +94,7 @@ func (p *InstanceRefreshProcessor) Handle(ctx context.Context, _ *asynq.Task) er
 	var refreshed, failed int
 	for _, inst := range rows {
 		if err := ctx.Err(); err != nil {
-			// ctx cancellation (shutdown / deadline) は呼び出し側 asynq が
+			// ctx cancellation (shutdown / deadline) は呼び出し側 driver が
 			// リトライするので、ここで中断しても safe。これまでの成果を log。
 			slog.Info("instance refresh: interrupted",
 				"processed", refreshed+failed, "total", len(rows))

--- a/internal/queue/processors/instance_refresh_test.go
+++ b/internal/queue/processors/instance_refresh_test.go
@@ -6,8 +6,8 @@ import (
 	"testing"
 	"time"
 
-	"github.com/hibiken/asynq"
 	"github.com/shiroha-a/mk/internal/model"
+	"github.com/shiroha-a/mk/internal/queue/driver"
 	"github.com/shiroha-a/mk/internal/queue/processors"
 	"github.com/shiroha-a/mk/internal/testutil"
 	"github.com/stretchr/testify/assert"
@@ -51,7 +51,7 @@ func TestInstanceRefreshProcessor_Handle_WalksStaleHosts(t *testing.T) {
 	})
 	p.SetClock(func() time.Time { return now })
 
-	require.NoError(t, p.Handle(context.Background(), &asynq.Task{}))
+	require.NoError(t, p.Handle(context.Background(), driver.RawTask{}))
 	// 2 hosts fetched (a and b, in infoUpdatedAt ASC NULLS FIRST order)
 	assert.Len(t, fetcher.calls, 2)
 	assert.Contains(t, fetcher.calls, "a.example")
@@ -70,13 +70,13 @@ func TestInstanceRefreshProcessor_Handle_FetchErrorDoesNotAbort(t *testing.T) {
 		FetchDelay: 1,
 	})
 	p.SetClock(func() time.Time { return now })
-	require.NoError(t, p.Handle(context.Background(), &asynq.Task{}))
+	require.NoError(t, p.Handle(context.Background(), driver.RawTask{}))
 	assert.Len(t, fetcher.calls, 2)
 }
 
 func TestInstanceRefreshProcessor_Handle_NilArgsNoOp(t *testing.T) {
 	p := processors.NewInstanceRefreshProcessor(nil, nil, processors.InstanceRefreshConfig{})
-	assert.NoError(t, p.Handle(context.Background(), &asynq.Task{}))
+	assert.NoError(t, p.Handle(context.Background(), driver.RawTask{}))
 }
 
 func TestInstanceRefreshProcessor_Handle_ContextCancellationInterrupts(t *testing.T) {
@@ -93,6 +93,6 @@ func TestInstanceRefreshProcessor_Handle_ContextCancellationInterrupts(t *testin
 
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel() // 即座に cancel → ctx.Err() でループを抜ける
-	err := p.Handle(ctx, &asynq.Task{})
+	err := p.Handle(ctx, driver.RawTask{})
 	assert.ErrorIs(t, err, context.Canceled)
 }

--- a/internal/queue/processors/reaction_flush.go
+++ b/internal/queue/processors/reaction_flush.go
@@ -3,8 +3,8 @@ package processors
 import (
 	"context"
 
-	"github.com/hibiken/asynq"
 	"github.com/shiroha-a/mk/internal/core/reaction"
+	"github.com/shiroha-a/mk/internal/queue/driver"
 )
 
 // ReactionFlushProcessor handles the periodic reaction buffer flush task.
@@ -18,6 +18,6 @@ func NewReactionFlushProcessor(writer reaction.ReactionCountWriter) *ReactionFlu
 }
 
 // Handle flushes all buffered reaction counts to the database.
-func (p *ReactionFlushProcessor) Handle(ctx context.Context, _ *asynq.Task) error {
+func (p *ReactionFlushProcessor) Handle(ctx context.Context, _ driver.Task) error {
 	return p.writer.Flush(ctx)
 }

--- a/internal/queue/processors/reaction_flush_test.go
+++ b/internal/queue/processors/reaction_flush_test.go
@@ -4,8 +4,8 @@ import (
 	"context"
 	"testing"
 
-	"github.com/hibiken/asynq"
 	"github.com/shiroha-a/mk/internal/core/reaction"
+	"github.com/shiroha-a/mk/internal/queue/driver"
 	"github.com/shiroha-a/mk/internal/testutil"
 	"github.com/stretchr/testify/require"
 )
@@ -14,5 +14,5 @@ func TestReactionFlushProcessor_Handle(t *testing.T) {
 	noteRepo := testutil.NewMockNoteRepository()
 	writer := reaction.NewDirectWriter(noteRepo)
 	p := NewReactionFlushProcessor(writer)
-	require.NoError(t, p.Handle(context.Background(), asynq.NewTask("test", nil)))
+	require.NoError(t, p.Handle(context.Background(), driver.RawTask{TypeName: "test"}))
 }

--- a/internal/queue/processors/retention.go
+++ b/internal/queue/processors/retention.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"log/slog"
 
-	"github.com/hibiken/asynq"
+	"github.com/shiroha-a/mk/internal/queue/driver"
 )
 
 // RetentionAggregator is the narrow interface the daily retention job needs.
@@ -15,7 +15,7 @@ type RetentionAggregator interface {
 
 // RetentionAggregateProcessor delegates to the retention aggregation
 // service on each scheduled fire (#421)。失敗はログだけ残してジョブとしては
-// success 扱いにする (asynq の retry に任せて雪崩らせる利点が無い)。
+// success 扱いにする (driver の retry に任せて雪崩らせる利点が無い)。
 type RetentionAggregateProcessor struct {
 	svc RetentionAggregator
 }
@@ -26,14 +26,14 @@ func NewRetentionAggregateProcessor(svc RetentionAggregator) *RetentionAggregate
 	return &RetentionAggregateProcessor{svc: svc}
 }
 
-// Handle implements the asynq handler contract.
-func (p *RetentionAggregateProcessor) Handle(ctx context.Context, _ *asynq.Task) error {
+// Handle implements the driver handler contract.
+func (p *RetentionAggregateProcessor) Handle(ctx context.Context, _ driver.Task) error {
 	if p.svc == nil {
 		return nil
 	}
 	if err := p.svc.Aggregate(ctx); err != nil {
 		// 失敗時も nil を返してジョブを success 扱いにする。MaxRetry(0) で
-		// asynq に retry させない方針なので err を返すと dead queue が肥大
+		// driver に retry させない方針なので err を返すと dead queue が肥大
 		// するだけで利点が無い。次回 cron (翌日 0:00 UTC) を待てば自然に
 		// 再アグリゲートされる。
 		slog.Warn("retention aggregate: failed", "err", err)

--- a/internal/queue/processors/retention_test.go
+++ b/internal/queue/processors/retention_test.go
@@ -5,7 +5,7 @@ import (
 	"errors"
 	"testing"
 
-	"github.com/hibiken/asynq"
+	"github.com/shiroha-a/mk/internal/queue/driver"
 	"github.com/shiroha-a/mk/internal/queue/processors"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -24,7 +24,7 @@ func (s *stubAggregator) Aggregate(_ context.Context) error {
 func TestRetentionAggregateProcessor_Handle_Success(t *testing.T) {
 	agg := &stubAggregator{}
 	p := processors.NewRetentionAggregateProcessor(agg)
-	require.NoError(t, p.Handle(context.Background(), asynq.NewTask("x", nil)))
+	require.NoError(t, p.Handle(context.Background(), driver.RawTask{TypeName: "x"}))
 	assert.Equal(t, 1, agg.called)
 }
 
@@ -34,7 +34,7 @@ func TestRetentionAggregateProcessor_Handle_SwallowsError(t *testing.T) {
 	wantErr := errors.New("db boom")
 	agg := &stubAggregator{err: wantErr}
 	p := processors.NewRetentionAggregateProcessor(agg)
-	err := p.Handle(context.Background(), asynq.NewTask("x", nil))
+	err := p.Handle(context.Background(), driver.RawTask{TypeName: "x"})
 	assert.NoError(t, err, "aggregation failures must not surface as job errors")
 	assert.Equal(t, 1, agg.called)
 }
@@ -43,5 +43,5 @@ func TestRetentionAggregateProcessor_Handle_SwallowsError(t *testing.T) {
 // the service is ready in some bootstrap orderings.
 func TestRetentionAggregateProcessor_Handle_NilSvcIsNoop(t *testing.T) {
 	p := processors.NewRetentionAggregateProcessor(nil)
-	require.NoError(t, p.Handle(context.Background(), asynq.NewTask("x", nil)))
+	require.NoError(t, p.Handle(context.Background(), driver.RawTask{TypeName: "x"}))
 }

--- a/internal/queue/processors/transfer.go
+++ b/internal/queue/processors/transfer.go
@@ -5,9 +5,9 @@ import (
 	"errors"
 	"fmt"
 
-	"github.com/hibiken/asynq"
 	"github.com/shiroha-a/mk/internal/core/transfer"
 	"github.com/shiroha-a/mk/internal/queue"
+	"github.com/shiroha-a/mk/internal/queue/driver"
 )
 
 // ExportProcessor handles `export` tasks by delegating to transfer.Exporter.
@@ -21,21 +21,21 @@ func NewExportProcessor(exporter *transfer.Exporter) *ExportProcessor {
 }
 
 // Handle dispatches a single export task.
-func (p *ExportProcessor) Handle(ctx context.Context, t *asynq.Task) error {
+func (p *ExportProcessor) Handle(ctx context.Context, t driver.Task) error {
 	if p.exporter == nil {
-		return fmt.Errorf("export processor not configured: %w", asynq.SkipRetry)
+		return fmt.Errorf("export processor not configured: %w", driver.SkipRetry)
 	}
 	payload, err := queue.DecodeExportPayload(t.Payload())
 	if err != nil {
-		return fmt.Errorf("decode export payload: %w: %w", err, asynq.SkipRetry)
+		return fmt.Errorf("decode export payload: %w: %w", err, driver.SkipRetry)
 	}
 	if payload.UserID == "" || payload.Type == "" {
-		return fmt.Errorf("export payload missing fields: %w", asynq.SkipRetry)
+		return fmt.Errorf("export payload missing fields: %w", driver.SkipRetry)
 	}
 	if _, err := p.exporter.Export(ctx, payload.UserID, payload.Type); err != nil {
 		// 未対応typeはリトライしても通らないので SkipRetry。
 		if errors.Is(err, transfer.ErrUnsupportedType) {
-			return fmt.Errorf("%w: %w", err, asynq.SkipRetry)
+			return fmt.Errorf("%w: %w", err, driver.SkipRetry)
 		}
 		return err
 	}
@@ -53,20 +53,20 @@ func NewImportProcessor(importer *transfer.Importer) *ImportProcessor {
 }
 
 // Handle dispatches a single import task.
-func (p *ImportProcessor) Handle(ctx context.Context, t *asynq.Task) error {
+func (p *ImportProcessor) Handle(ctx context.Context, t driver.Task) error {
 	if p.importer == nil {
-		return fmt.Errorf("import processor not configured: %w", asynq.SkipRetry)
+		return fmt.Errorf("import processor not configured: %w", driver.SkipRetry)
 	}
 	payload, err := queue.DecodeImportPayload(t.Payload())
 	if err != nil {
-		return fmt.Errorf("decode import payload: %w: %w", err, asynq.SkipRetry)
+		return fmt.Errorf("decode import payload: %w: %w", err, driver.SkipRetry)
 	}
 	if payload.UserID == "" || payload.Type == "" || payload.FileID == "" {
-		return fmt.Errorf("import payload missing fields: %w", asynq.SkipRetry)
+		return fmt.Errorf("import payload missing fields: %w", driver.SkipRetry)
 	}
 	if _, err := p.importer.Import(ctx, payload.UserID, payload.Type, payload.FileID); err != nil {
 		if errors.Is(err, transfer.ErrUnsupportedType) {
-			return fmt.Errorf("%w: %w", err, asynq.SkipRetry)
+			return fmt.Errorf("%w: %w", err, driver.SkipRetry)
 		}
 		return err
 	}

--- a/internal/queue/processors/transfer_test.go
+++ b/internal/queue/processors/transfer_test.go
@@ -5,13 +5,13 @@ import (
 	"testing"
 	"time"
 
-	"github.com/hibiken/asynq"
 	"github.com/shiroha-a/mk/internal/core/drive"
 	"github.com/shiroha-a/mk/internal/core/notification"
 	"github.com/shiroha-a/mk/internal/core/transfer"
 	"github.com/shiroha-a/mk/internal/misc/id"
 	"github.com/shiroha-a/mk/internal/model"
 	"github.com/shiroha-a/mk/internal/queue"
+	"github.com/shiroha-a/mk/internal/queue/driver"
 	"github.com/shiroha-a/mk/internal/queue/processors"
 	"github.com/shiroha-a/mk/internal/testutil"
 	"github.com/stretchr/testify/assert"
@@ -112,16 +112,16 @@ func TestExportProcessor_Handle_NilExporter(t *testing.T) {
 	task := queue.NewExportTask(queue.ExportPayload{UserID: "u1", Type: transfer.ExportNotes})
 	err := p.Handle(context.Background(), task)
 	require.Error(t, err)
-	assert.ErrorIs(t, err, asynq.SkipRetry)
+	assert.ErrorIs(t, err, driver.SkipRetry)
 }
 
 func TestExportProcessor_Handle_InvalidPayload(t *testing.T) {
 	exporter := newTestExporter(t)
 	p := processors.NewExportProcessor(exporter)
-	task := asynq.NewTask(queue.TaskTypeExport, []byte("not json"))
+	task := driver.RawTask{TypeName: queue.TaskTypeExport, Body: []byte("not json")}
 	err := p.Handle(context.Background(), task)
 	require.Error(t, err)
-	assert.ErrorIs(t, err, asynq.SkipRetry)
+	assert.ErrorIs(t, err, driver.SkipRetry)
 }
 
 func TestExportProcessor_Handle_MissingFields(t *testing.T) {
@@ -130,7 +130,7 @@ func TestExportProcessor_Handle_MissingFields(t *testing.T) {
 	task := queue.NewExportTask(queue.ExportPayload{UserID: "", Type: ""})
 	err := p.Handle(context.Background(), task)
 	require.Error(t, err)
-	assert.ErrorIs(t, err, asynq.SkipRetry)
+	assert.ErrorIs(t, err, driver.SkipRetry)
 }
 
 func TestExportProcessor_Handle_UnsupportedType(t *testing.T) {
@@ -139,7 +139,7 @@ func TestExportProcessor_Handle_UnsupportedType(t *testing.T) {
 	task := queue.NewExportTask(queue.ExportPayload{UserID: "u1", Type: "nope"})
 	err := p.Handle(context.Background(), task)
 	require.Error(t, err)
-	assert.ErrorIs(t, err, asynq.SkipRetry)
+	assert.ErrorIs(t, err, driver.SkipRetry)
 }
 
 func TestExportProcessor_Handle_ExporterError(t *testing.T) {
@@ -167,16 +167,16 @@ func TestImportProcessor_Handle_NilImporter(t *testing.T) {
 	task := queue.NewImportTask(queue.ImportPayload{UserID: "u1", Type: transfer.ImportBlocking, FileID: "f"})
 	err := p.Handle(context.Background(), task)
 	require.Error(t, err)
-	assert.ErrorIs(t, err, asynq.SkipRetry)
+	assert.ErrorIs(t, err, driver.SkipRetry)
 }
 
 func TestImportProcessor_Handle_InvalidPayload(t *testing.T) {
 	imp := newTestImporter(t, nil)
 	p := processors.NewImportProcessor(imp)
-	task := asynq.NewTask(queue.TaskTypeImport, []byte("not json"))
+	task := driver.RawTask{TypeName: queue.TaskTypeImport, Body: []byte("not json")}
 	err := p.Handle(context.Background(), task)
 	require.Error(t, err)
-	assert.ErrorIs(t, err, asynq.SkipRetry)
+	assert.ErrorIs(t, err, driver.SkipRetry)
 }
 
 func TestImportProcessor_Handle_MissingFields(t *testing.T) {
@@ -185,7 +185,7 @@ func TestImportProcessor_Handle_MissingFields(t *testing.T) {
 	task := queue.NewImportTask(queue.ImportPayload{UserID: "u1", Type: "", FileID: ""})
 	err := p.Handle(context.Background(), task)
 	require.Error(t, err)
-	assert.ErrorIs(t, err, asynq.SkipRetry)
+	assert.ErrorIs(t, err, driver.SkipRetry)
 }
 
 func TestImportProcessor_Handle_UnsupportedType(t *testing.T) {
@@ -194,7 +194,7 @@ func TestImportProcessor_Handle_UnsupportedType(t *testing.T) {
 	task := queue.NewImportTask(queue.ImportPayload{UserID: "u1", Type: "nope", FileID: "f"})
 	err := p.Handle(context.Background(), task)
 	require.Error(t, err)
-	assert.ErrorIs(t, err, asynq.SkipRetry)
+	assert.ErrorIs(t, err, driver.SkipRetry)
 }
 
 func TestImportProcessor_Handle_ImporterError(t *testing.T) {

--- a/internal/queue/processors/webhook.go
+++ b/internal/queue/processors/webhook.go
@@ -10,8 +10,8 @@ import (
 	"net/http"
 	"time"
 
-	"github.com/hibiken/asynq"
 	"github.com/shiroha-a/mk/internal/queue"
+	"github.com/shiroha-a/mk/internal/queue/driver"
 	"github.com/shiroha-a/mk/internal/repository"
 )
 
@@ -64,34 +64,34 @@ func NewWebhookProcessor(
 }
 
 // HandleUser dispatches a user webhook task.
-func (p *WebhookProcessor) HandleUser(ctx context.Context, t *asynq.Task) error {
+func (p *WebhookProcessor) HandleUser(ctx context.Context, t driver.Task) error {
 	return p.handle(ctx, t, true)
 }
 
 // HandleSystem dispatches a system webhook task.
-func (p *WebhookProcessor) HandleSystem(ctx context.Context, t *asynq.Task) error {
+func (p *WebhookProcessor) HandleSystem(ctx context.Context, t driver.Task) error {
 	return p.handle(ctx, t, false)
 }
 
 // handle is the shared delivery implementation. user==true uses user webhooks,
 // user==false uses system webhooks.
-func (p *WebhookProcessor) handle(ctx context.Context, t *asynq.Task, user bool) error {
+func (p *WebhookProcessor) handle(ctx context.Context, t driver.Task, user bool) error {
 	payload, err := queue.DecodeWebhookPayload(t.Payload())
 	if err != nil {
-		return fmt.Errorf("decode webhook payload: %w: %w", err, asynq.SkipRetry)
+		return fmt.Errorf("decode webhook payload: %w: %w", err, driver.SkipRetry)
 	}
 	if payload.WebhookID == "" {
-		return fmt.Errorf("webhook payload missing webhookId: %w", asynq.SkipRetry)
+		return fmt.Errorf("webhook payload missing webhookId: %w", driver.SkipRetry)
 	}
 
 	url, secret, err := p.resolveTarget(payload.WebhookID, user)
 	if err != nil {
-		return fmt.Errorf("resolve webhook %s: %w: %w", payload.WebhookID, err, asynq.SkipRetry)
+		return fmt.Errorf("resolve webhook %s: %w: %w", payload.WebhookID, err, driver.SkipRetry)
 	}
 
 	req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, bytes.NewReader(payload.Body))
 	if err != nil {
-		return fmt.Errorf("build webhook request: %w: %w", err, asynq.SkipRetry)
+		return fmt.Errorf("build webhook request: %w: %w", err, driver.SkipRetry)
 	}
 	req.Header.Set("Content-Type", "application/json")
 	req.Header.Set("User-Agent", p.userAgent)
@@ -123,7 +123,7 @@ func (p *WebhookProcessor) handle(ctx context.Context, t *asynq.Task, user bool)
 		return nil
 	case resp.StatusCode >= 400 && resp.StatusCode < 500:
 		// 4xx は受信側の不正リクエスト扱いでリトライしない。
-		return fmt.Errorf("webhook client error (%d): %w", resp.StatusCode, asynq.SkipRetry)
+		return fmt.Errorf("webhook client error (%d): %w", resp.StatusCode, driver.SkipRetry)
 	default:
 		// 5xx 等は一時的障害としてリトライ。
 		return errors.New("webhook server error: " + resp.Status)

--- a/internal/queue/processors/webhook_test.go
+++ b/internal/queue/processors/webhook_test.go
@@ -10,9 +10,9 @@ import (
 	"testing"
 	"time"
 
-	"github.com/hibiken/asynq"
 	"github.com/shiroha-a/mk/internal/model"
 	"github.com/shiroha-a/mk/internal/queue"
+	"github.com/shiroha-a/mk/internal/queue/driver"
 	"github.com/shiroha-a/mk/internal/queue/processors"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -176,7 +176,7 @@ func TestWebhookProcessor_User_4xxSkipsRetry(t *testing.T) {
 	task := queue.NewUserWebhookTask(queue.WebhookPayload{WebhookID: "h1", EventType: "note", Body: []byte(`{}`)})
 	err := p.HandleUser(context.Background(), task)
 	require.Error(t, err)
-	assert.ErrorIs(t, err, asynq.SkipRetry)
+	assert.ErrorIs(t, err, driver.SkipRetry)
 	assert.Equal(t, http.StatusBadRequest, repo.statusCalled["h1"])
 }
 
@@ -188,7 +188,7 @@ func TestWebhookProcessor_User_5xxRetries(t *testing.T) {
 	task := queue.NewUserWebhookTask(queue.WebhookPayload{WebhookID: "h1", EventType: "note", Body: []byte(`{}`)})
 	err := p.HandleUser(context.Background(), task)
 	require.Error(t, err)
-	assert.NotErrorIs(t, err, asynq.SkipRetry)
+	assert.NotErrorIs(t, err, driver.SkipRetry)
 	assert.Equal(t, http.StatusInternalServerError, repo.statusCalled["h1"])
 }
 
@@ -200,7 +200,7 @@ func TestWebhookProcessor_User_NetworkError(t *testing.T) {
 	task := queue.NewUserWebhookTask(queue.WebhookPayload{WebhookID: "h1", EventType: "note", Body: []byte(`{}`)})
 	err := p.HandleUser(context.Background(), task)
 	require.Error(t, err)
-	assert.NotErrorIs(t, err, asynq.SkipRetry)
+	assert.NotErrorIs(t, err, driver.SkipRetry)
 	// ネットワークエラーは status=0 で記録
 	assert.Equal(t, 0, repo.statusCalled["h1"])
 }
@@ -211,15 +211,15 @@ func TestWebhookProcessor_User_NotFoundSkipsRetry(t *testing.T) {
 	task := queue.NewUserWebhookTask(queue.WebhookPayload{WebhookID: "h1", EventType: "note", Body: []byte(`{}`)})
 	err := p.HandleUser(context.Background(), task)
 	require.Error(t, err)
-	assert.ErrorIs(t, err, asynq.SkipRetry)
+	assert.ErrorIs(t, err, driver.SkipRetry)
 }
 
 func TestWebhookProcessor_User_InvalidPayloadSkipsRetry(t *testing.T) {
 	p, _, _ := newTestWebhookProcessor(t, &stubHTTPClient{}, nil, nil)
-	task := asynq.NewTask(queue.TaskTypeUserWebhook, []byte("not json"))
+	task := driver.RawTask{TypeName: queue.TaskTypeUserWebhook, Body: []byte("not json")}
 	err := p.HandleUser(context.Background(), task)
 	require.Error(t, err)
-	assert.ErrorIs(t, err, asynq.SkipRetry)
+	assert.ErrorIs(t, err, driver.SkipRetry)
 }
 
 func TestWebhookProcessor_User_MissingWebhookID(t *testing.T) {
@@ -227,7 +227,7 @@ func TestWebhookProcessor_User_MissingWebhookID(t *testing.T) {
 	task := queue.NewUserWebhookTask(queue.WebhookPayload{})
 	err := p.HandleUser(context.Background(), task)
 	require.Error(t, err)
-	assert.ErrorIs(t, err, asynq.SkipRetry)
+	assert.ErrorIs(t, err, driver.SkipRetry)
 }
 
 func TestWebhookProcessor_System_Success(t *testing.T) {
@@ -248,7 +248,7 @@ func TestWebhookProcessor_UserRepoMissing(t *testing.T) {
 	task := queue.NewUserWebhookTask(queue.WebhookPayload{WebhookID: "h1", EventType: "note", Body: []byte(`{}`)})
 	err := p.HandleUser(context.Background(), task)
 	require.Error(t, err)
-	assert.ErrorIs(t, err, asynq.SkipRetry)
+	assert.ErrorIs(t, err, driver.SkipRetry)
 }
 
 func TestWebhookProcessor_SystemRepoMissing(t *testing.T) {
@@ -256,7 +256,7 @@ func TestWebhookProcessor_SystemRepoMissing(t *testing.T) {
 	task := queue.NewSystemWebhookTask(queue.WebhookPayload{WebhookID: "sh1", EventType: "userCreated", Body: []byte(`{}`)})
 	err := p.HandleSystem(context.Background(), task)
 	require.Error(t, err)
-	assert.ErrorIs(t, err, asynq.SkipRetry)
+	assert.ErrorIs(t, err, driver.SkipRetry)
 }
 
 func TestNewWebhookProcessor_DefaultClient(t *testing.T) {

--- a/internal/queue/processors/webpush.go
+++ b/internal/queue/processors/webpush.go
@@ -11,10 +11,10 @@ import (
 	"time"
 
 	webpushlib "github.com/SherClockHolmes/webpush-go"
-	"github.com/hibiken/asynq"
 	"github.com/shiroha-a/mk/internal/core/webpush"
 	"github.com/shiroha-a/mk/internal/model"
 	"github.com/shiroha-a/mk/internal/queue"
+	"github.com/shiroha-a/mk/internal/queue/driver"
 	"github.com/shiroha-a/mk/internal/repository"
 )
 
@@ -68,13 +68,13 @@ func NewWebPushProcessor(
 // Handle dispatches a Web Push task to all subscribers of the target user.
 // Errors are logged but never propagated unless the task payload itself is
 // malformed (which makes the task unrecoverable — SkipRetry).
-func (p *WebPushProcessor) Handle(ctx context.Context, t *asynq.Task) error {
+func (p *WebPushProcessor) Handle(ctx context.Context, t driver.Task) error {
 	payload, err := queue.DecodeWebPushPayload(t.Payload())
 	if err != nil {
-		return fmt.Errorf("decode webpush payload: %w: %w", err, asynq.SkipRetry)
+		return fmt.Errorf("decode webpush payload: %w: %w", err, driver.SkipRetry)
 	}
 	if payload.UserID == "" {
-		return fmt.Errorf("webpush payload missing userId: %w", asynq.SkipRetry)
+		return fmt.Errorf("webpush payload missing userId: %w", driver.SkipRetry)
 	}
 
 	// VAPID 鍵が未設定 / enableServiceWorker=false ならそもそも配信しない
@@ -104,7 +104,7 @@ func (p *WebPushProcessor) Handle(ctx context.Context, t *asynq.Task) error {
 		DateTime: nowMillis(),
 	})
 	if err != nil {
-		return fmt.Errorf("marshal push envelope: %w: %w", err, asynq.SkipRetry)
+		return fmt.Errorf("marshal push envelope: %w: %w", err, driver.SkipRetry)
 	}
 
 	invalidate := false

--- a/internal/queue/processors/webpush_test.go
+++ b/internal/queue/processors/webpush_test.go
@@ -11,10 +11,10 @@ import (
 	"testing"
 
 	webpushlib "github.com/SherClockHolmes/webpush-go"
-	"github.com/hibiken/asynq"
 	"github.com/shiroha-a/mk/internal/core/webpush"
 	"github.com/shiroha-a/mk/internal/model"
 	"github.com/shiroha-a/mk/internal/queue"
+	"github.com/shiroha-a/mk/internal/queue/driver"
 	"github.com/shiroha-a/mk/internal/queue/processors"
 	"github.com/shiroha-a/mk/internal/testutil"
 	"github.com/stretchr/testify/assert"
@@ -116,7 +116,7 @@ func metaWithVAPID() *model.Meta {
 	return &model.Meta{EnableServiceWorker: true, SwPublicKey: &pub, SwPrivateKey: &priv}
 }
 
-func taskFromPayload(t *testing.T, p queue.WebPushPayload) *asynq.Task {
+func taskFromPayload(t *testing.T, p queue.WebPushPayload) driver.Task {
 	t.Helper()
 	return queue.NewWebPushTask(p)
 }
@@ -290,19 +290,19 @@ func TestWebPushProcessor_ServerError(t *testing.T) {
 
 func TestWebPushProcessor_InvalidPayloadSkipsRetry(t *testing.T) {
 	p, _ := newProcessor(t, &stubWebPushSender{}, metaWithVAPID(), nil)
-	task := asynq.NewTask(queue.TaskTypeWebPush, []byte("not json"))
+	task := driver.RawTask{TypeName: queue.TaskTypeWebPush, Body: []byte("not json")}
 	err := p.Handle(context.Background(), task)
 	require.Error(t, err)
-	assert.ErrorIs(t, err, asynq.SkipRetry)
+	assert.ErrorIs(t, err, driver.SkipRetry)
 }
 
 func TestWebPushProcessor_MissingUserID(t *testing.T) {
 	p, _ := newProcessor(t, &stubWebPushSender{}, metaWithVAPID(), nil)
 	body, _ := json.Marshal(queue.WebPushPayload{Type: webpush.TypeNotification})
-	task := asynq.NewTask(queue.TaskTypeWebPush, body)
+	task := driver.RawTask{TypeName: queue.TaskTypeWebPush, Body: body}
 	err := p.Handle(context.Background(), task)
 	require.Error(t, err)
-	assert.ErrorIs(t, err, asynq.SkipRetry)
+	assert.ErrorIs(t, err, driver.SkipRetry)
 }
 
 func TestNewWebPushProcessor_DefaultSender(t *testing.T) {

--- a/internal/queue/queue.go
+++ b/internal/queue/queue.go
@@ -1,31 +1,51 @@
-// Package queue provides a thin wrapper around asynq for the AP delivery
-// pipeline. The wrapper exposes an Enqueuer interface so that callers
-// (DeliverService) can be unit-tested with mocks.
+// Package queue is the driver-neutral facade for mk-go's job queue.
+// Callers depend on this package (Enqueuer, Server, Inspector,
+// Scheduler) without taking a compile-time dependency on the
+// underlying queue runtime — that lives behind queue/driver.
+//
+// AP delivery, webhooks, web push, and maintenance / chart cron
+// jobs all flow through this package. Driver swaps (asynq → mkq)
+// touch only the wiring code that constructs the driver.Driver in
+// internal/server.
 package queue
 
 import (
 	"context"
+	"encoding/json"
 	"time"
 
-	"github.com/hibiken/asynq"
+	"github.com/shiroha-a/mk/internal/queue/driver"
 )
 
-// QueueName is the asynq queue used for AP delivery jobs.
+// mustMarshal serializes a payload via json.Marshal. mk-go の queue
+// payload は string / []byte / 単純な struct のみで構成されている
+// ため Marshal は失敗しない。エラー戻り値を呼び出し側に伝播させる
+// より panic で wiring バグを早期発見できる方を選んでいる。
+func mustMarshal(v any) []byte {
+	body, err := json.Marshal(v)
+	if err != nil {
+		panic("queue: marshal payload: " + err.Error())
+	}
+	return body
+}
+
+// QueueName is the queue used for AP delivery jobs.
 const QueueName = "deliver"
 
-// ExportQueueName is the asynq queue for export/import jobs.
+// ExportQueueName is the queue for export/import jobs.
 const ExportQueueName = "export"
 
-// PushQueueName is the asynq queue for Web Push delivery jobs.
+// PushQueueName is the queue for Web Push delivery jobs.
 const PushQueueName = "push"
 
-// WebhookQueueName is the asynq queue for user + system webhook delivery jobs.
+// WebhookQueueName is the queue for user + system webhook delivery jobs.
 const WebhookQueueName = "webhook"
 
-// Enqueuer abstracts the asynq client for callers that only need to enqueue
-// tasks. テスト用にmock可能。
+// Enqueuer abstracts task enqueueing for callers (DeliverService,
+// admin handlers, etc.). The interface is driver-neutral so callers
+// can be unit-tested with mocks.
 type Enqueuer interface {
-	EnqueueDeliver(payload DeliverPayload, opts ...asynq.Option) error
+	EnqueueDeliver(payload DeliverPayload, opts ...driver.EnqueueOption) error
 	EnqueueExport(payload ExportPayload) error
 	EnqueueImport(payload ImportPayload) error
 	EnqueueWebPush(ctx context.Context, payload WebPushPayload) error
@@ -34,170 +54,141 @@ type Enqueuer interface {
 	Close() error
 }
 
-// Client wraps asynq.Client and implements Enqueuer.
+// Client wraps a driver.Client and implements Enqueuer.
 type Client struct {
-	inner *asynq.Client
+	inner driver.Client
 }
 
-// NewClient constructs a Client backed by Redis. 渡された RedisClientOpt は
-// asynqがそのまま使う。
-func NewClient(redisOpt asynq.RedisClientOpt) *Client {
-	return &Client{inner: asynq.NewClient(redisOpt)}
+// NewClient constructs a Client backed by the supplied driver.
+func NewClient(d driver.Driver) *Client {
+	return &Client{inner: d.Client()}
 }
 
-// EnqueueDeliver puts a deliver task on the queue. opts には asynq の通常の
-// オプション (MaxRetry, Timeout, ProcessIn 等) を渡せる。Queueは内部で固定。
-func (c *Client) EnqueueDeliver(payload DeliverPayload, opts ...asynq.Option) error {
-	task := NewDeliverTask(payload)
-	// 呼び出し側のオプションを優先しつつ、必ずQueueNameに入れる。
-	merged := append([]asynq.Option{asynq.Queue(QueueName)}, opts...)
-	if _, err := c.inner.Enqueue(task, merged...); err != nil {
-		return err
-	}
-	return nil
+// EnqueueDeliver puts a deliver task on the queue. opts override the
+// default queue selection if they include WithQueue, but normal
+// callers should pass payload-only and let the queue routing stay
+// fixed.
+func (c *Client) EnqueueDeliver(payload DeliverPayload, opts ...driver.EnqueueOption) error {
+	body := mustMarshal(payload)
+	merged := append([]driver.EnqueueOption{driver.WithQueue(QueueName)}, opts...)
+	return c.inner.Enqueue(context.Background(), TaskTypeDeliver, body, merged...)
 }
 
 // EnqueueExport puts an export task on the queue.
 func (c *Client) EnqueueExport(payload ExportPayload) error {
-	task := NewExportTask(payload)
-	_, err := c.inner.Enqueue(task, asynq.Queue(ExportQueueName))
-	return err
+	body := mustMarshal(payload)
+	return c.inner.Enqueue(context.Background(), TaskTypeExport, body,
+		driver.WithQueue(ExportQueueName),
+	)
 }
 
 // EnqueueImport puts an import task on the queue.
 func (c *Client) EnqueueImport(payload ImportPayload) error {
-	task := NewImportTask(payload)
-	_, err := c.inner.Enqueue(task, asynq.Queue(ExportQueueName))
-	return err
+	body := mustMarshal(payload)
+	return c.inner.Enqueue(context.Background(), TaskTypeImport, body,
+		driver.WithQueue(ExportQueueName),
+	)
 }
 
 // EnqueueImportCustomEmojis puts an admin emoji-zip import task on the
 // export queue. Misskey 本家も同じ "dbQueue" (低優先) に積んでいる。
 func (c *Client) EnqueueImportCustomEmojis(payload ImportCustomEmojisPayload) error {
-	task := NewImportCustomEmojisTask(payload)
-	_, err := c.inner.Enqueue(task, asynq.Queue(ExportQueueName))
-	return err
+	body := mustMarshal(payload)
+	return c.inner.Enqueue(context.Background(), TaskTypeImportCustomEmojis, body,
+		driver.WithQueue(ExportQueueName),
+	)
 }
 
 // EnqueueWebPush puts a Web Push delivery task on the push queue.
 func (c *Client) EnqueueWebPush(ctx context.Context, payload WebPushPayload) error {
-	task := NewWebPushTask(payload)
-	_, err := c.inner.EnqueueContext(ctx, task, asynq.Queue(PushQueueName))
-	return err
+	body := mustMarshal(payload)
+	return c.inner.Enqueue(ctx, TaskTypeWebPush, body,
+		driver.WithQueue(PushQueueName),
+	)
 }
 
-// EnqueueUserWebhook puts a user webhook delivery task on the webhook queue.
-// Retry policy: asynq のデフォルト (25 attempts, exponential backoff) を使う。
-// 4xx は processor 側で SkipRetry として扱うため実際のリトライ対象は 5xx と
-// ネットワークエラーに限られる。
+// EnqueueUserWebhook puts a user webhook delivery task on the webhook
+// queue. Retry policy: 4 attempts (4xx は processor 側で SkipRetry と
+// して扱うため実際のリトライ対象は 5xx とネットワークエラーに限られる)。
 func (c *Client) EnqueueUserWebhook(ctx context.Context, payload WebhookPayload) error {
-	task := NewUserWebhookTask(payload)
-	_, err := c.inner.EnqueueContext(ctx, task,
-		asynq.Queue(WebhookQueueName),
-		asynq.MaxRetry(4),
+	body := mustMarshal(payload)
+	return c.inner.Enqueue(ctx, TaskTypeUserWebhook, body,
+		driver.WithQueue(WebhookQueueName),
+		driver.WithMaxRetry(4),
 	)
-	return err
 }
 
 // EnqueueSystemWebhook puts a system webhook delivery task on the webhook queue.
 func (c *Client) EnqueueSystemWebhook(ctx context.Context, payload WebhookPayload) error {
-	task := NewSystemWebhookTask(payload)
-	_, err := c.inner.EnqueueContext(ctx, task,
-		asynq.Queue(WebhookQueueName),
-		asynq.MaxRetry(4),
+	body := mustMarshal(payload)
+	return c.inner.Enqueue(ctx, TaskTypeSystemWebhook, body,
+		driver.WithQueue(WebhookQueueName),
+		driver.WithMaxRetry(4),
 	)
-	return err
 }
 
 // EnqueueCleanRemoteNotes puts a remote notes cleaning task on the queue.
-// ペイロードなし (processor が meta から設定を読む)。重複排除のため UniqueFor を設定。
+// 重複排除のため UniqueFor を設定。
 func (c *Client) EnqueueCleanRemoteNotes() error {
-	task := asynq.NewTask(TaskTypeCleanRemoteNotes, nil)
-	_, err := c.inner.Enqueue(task,
-		asynq.Queue(QueueName),
-		asynq.MaxRetry(0),
-		asynq.Unique(6*time.Hour),
+	return c.inner.Enqueue(context.Background(), TaskTypeCleanRemoteNotes, nil,
+		driver.WithQueue(QueueName),
+		driver.WithMaxRetry(0),
+		driver.WithUnique(6*time.Hour),
 	)
-	return err
 }
 
 // EnqueueReactionFlush puts a reaction flush task on the queue.
 func (c *Client) EnqueueReactionFlush() error {
-	task := asynq.NewTask(TaskTypeReactionFlush, nil)
-	_, err := c.inner.Enqueue(task,
-		asynq.Queue(QueueName),
-		asynq.MaxRetry(0),
-		asynq.Unique(25*time.Second),
+	return c.inner.Enqueue(context.Background(), TaskTypeReactionFlush, nil,
+		driver.WithQueue(QueueName),
+		driver.WithMaxRetry(0),
+		driver.WithUnique(25*time.Second),
 	)
-	return err
 }
 
-// EnqueueDeleteAccount schedules a cascade deletion of the user's related
-// rows. Uniqueness over a 24h window prevents duplicate jobs if the admin
-// clicks delete multiple times while the previous run is still processing.
+// EnqueueDeleteAccount schedules a cascade deletion of the user's
+// related rows. Uniqueness over a 24h window prevents duplicate jobs
+// if the admin clicks delete multiple times while the previous run is
+// still processing.
 func (c *Client) EnqueueDeleteAccount(payload DeleteAccountPayload) error {
-	task := NewDeleteAccountTask(payload)
-	_, err := c.inner.Enqueue(task,
-		asynq.Queue(QueueName),
-		asynq.MaxRetry(2),
-		asynq.Unique(24*time.Hour),
+	body := mustMarshal(payload)
+	return c.inner.Enqueue(context.Background(), TaskTypeDeleteAccount, body,
+		driver.WithQueue(QueueName),
+		driver.WithMaxRetry(2),
+		driver.WithUnique(24*time.Hour),
 	)
-	return err
 }
 
 // Close releases the underlying client connection.
-func (c *Client) Close() error {
-	return c.inner.Close()
+func (c *Client) Close() error { return c.inner.Close() }
+
+// Server is the worker side facade. It registers HandlerFuncs by
+// task type and starts/stops the worker loop.
+type Server struct {
+	inner driver.Server
 }
 
-// ServerConfig configures the worker process.
+// ServerConfig is kept for backward compatibility with callers that
+// pass a Concurrency value via internal/server. The driver itself
+// gets its own concrete config (e.g. asynqdriver.ServerConfig)
+// at construction time.
 type ServerConfig struct {
-	// Concurrency is the number of worker goroutines.
 	Concurrency int
 }
 
-// Server wraps asynq.Server and a ServeMux. ハンドラの登録を行ってから
-// Start するスタイル。
-type Server struct {
-	inner *asynq.Server
-	mux   *asynq.ServeMux
-}
-
-// NewServer constructs a worker server bound to the given Redis connection
-// options.
-func NewServer(redisOpt asynq.RedisClientOpt, cfg ServerConfig) *Server {
-	concurrency := cfg.Concurrency
-	if concurrency <= 0 {
-		concurrency = 16
-	}
-	inner := asynq.NewServer(redisOpt, asynq.Config{
-		Concurrency: concurrency,
-		// Queue priorities: deliver/push が同重み、export は低優先。
-		// map のキーが登録済み queue として扱われ、未登録の queue は
-		// processor を実行しないので新しい TaskType 追加時は忘れずに足す。
-		Queues: map[string]int{
-			QueueName:            1,
-			PushQueueName:        1,
-			ExportQueueName:      1,
-			WebhookQueueName:     1,
-			MaintenanceQueueName: 1,
-		},
-	})
-	return &Server{inner: inner, mux: asynq.NewServeMux()}
+// NewServer wraps the driver's Server. The driver must already be
+// configured with the desired concurrency / queue weights.
+func NewServer(d driver.Driver) *Server {
+	return &Server{inner: d.Server()}
 }
 
 // Handle registers a handler for the given task type.
-func (s *Server) Handle(taskType string, handler asynq.HandlerFunc) {
-	s.mux.HandleFunc(taskType, handler)
+func (s *Server) Handle(taskType string, handler driver.HandlerFunc) {
+	s.inner.Handle(taskType, handler)
 }
 
-// Start launches the worker in the background. asynq.Server.Start は
-// goroutineで起動するので呼び出し側はブロックされない。
-func (s *Server) Start() error {
-	return s.inner.Start(s.mux)
-}
+// Start launches the worker in the background.
+func (s *Server) Start() error { return s.inner.Start() }
 
 // Shutdown gracefully stops the worker, waiting for in-flight jobs to finish.
-func (s *Server) Shutdown() {
-	s.inner.Shutdown()
-}
+func (s *Server) Shutdown() { s.inner.Shutdown() }

--- a/internal/queue/queue_test.go
+++ b/internal/queue/queue_test.go
@@ -13,6 +13,8 @@ import (
 
 	"github.com/hibiken/asynq"
 	"github.com/shiroha-a/mk/internal/queue"
+	"github.com/shiroha-a/mk/internal/queue/driver"
+	"github.com/shiroha-a/mk/internal/queue/driver/asynqdriver"
 	"github.com/shiroha-a/mk/internal/testutil"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -34,6 +36,13 @@ func TestMain(m *testing.M) {
 
 func redisOpt() asynq.RedisClientOpt {
 	return asynq.RedisClientOpt{Addr: testRedis.Addr}
+}
+
+// newDriver constructs a fresh asynq-backed driver bound to the test
+// Redis. Each call returns an independent driver instance so tests can
+// Close() one without affecting the others.
+func newDriver() driver.Driver {
+	return asynqdriver.New(redisOpt(), asynqdriver.ServerConfig{Concurrency: 2})
 }
 
 func TestNewDeliverTask_RoundTrip(t *testing.T) {
@@ -60,7 +69,7 @@ func TestClient_EnqueueDeliver(t *testing.T) {
 	testutil.SkipIfNoDocker(t)
 	flushTestRedis(t)
 
-	c := queue.NewClient(redisOpt())
+	c := queue.NewClient(newDriver())
 	defer func() { _ = c.Close() }()
 
 	payload := queue.DeliverPayload{
@@ -69,7 +78,7 @@ func TestClient_EnqueueDeliver(t *testing.T) {
 		KeyID:  "k1",
 		KeyPEM: "PEM",
 	}
-	require.NoError(t, c.EnqueueDeliver(payload, asynq.MaxRetry(3)))
+	require.NoError(t, c.EnqueueDeliver(payload, driver.WithMaxRetry(3)))
 
 	// inspector で実際にキューに入っていることを確認
 	insp := asynq.NewInspector(redisOpt())
@@ -89,7 +98,7 @@ func TestClient_EnqueueDeliver_ClosedClientFails(t *testing.T) {
 	testutil.SkipIfNoDocker(t)
 	flushTestRedis(t)
 
-	c := queue.NewClient(redisOpt())
+	c := queue.NewClient(newDriver())
 	require.NoError(t, c.Close())
 
 	err := c.EnqueueDeliver(queue.DeliverPayload{Inbox: "x", Body: []byte(`{}`)})
@@ -100,7 +109,7 @@ func TestServer_HandleAndProcess(t *testing.T) {
 	testutil.SkipIfNoDocker(t)
 	flushTestRedis(t)
 
-	srv := queue.NewServer(redisOpt(), queue.ServerConfig{Concurrency: 2})
+	srv := queue.NewServer(newDriver())
 
 	var (
 		wg         sync.WaitGroup
@@ -109,7 +118,7 @@ func TestServer_HandleAndProcess(t *testing.T) {
 		mu         sync.Mutex
 	)
 	wg.Add(1)
-	srv.Handle(queue.TaskTypeDeliver, func(_ context.Context, t *asynq.Task) error {
+	srv.Handle(queue.TaskTypeDeliver, func(_ context.Context, t driver.Task) error {
 		defer wg.Done()
 		atomic.AddInt32(&received, 1)
 		p, err := queue.DecodeDeliverPayload(t.Payload())
@@ -124,7 +133,7 @@ func TestServer_HandleAndProcess(t *testing.T) {
 	require.NoError(t, srv.Start())
 	defer srv.Shutdown()
 
-	c := queue.NewClient(redisOpt())
+	c := queue.NewClient(newDriver())
 	defer func() { _ = c.Close() }()
 
 	payload := queue.DeliverPayload{
@@ -147,12 +156,13 @@ func TestServer_HandleAndProcess(t *testing.T) {
 
 func TestServer_DefaultConcurrency(t *testing.T) {
 	// Concurrency<=0 のとき内部デフォルト16にフォールバックする経路を確認。
-	// asynq Server を作って即 Shutdown するだけで十分。
-	srv := queue.NewServer(redisOpt(), queue.ServerConfig{Concurrency: 0})
-	srv.Handle(queue.TaskTypeDeliver, func(_ context.Context, _ *asynq.Task) error {
+	// driver Server を作って即 Shutdown するだけで十分。
+	d := asynqdriver.New(redisOpt(), asynqdriver.ServerConfig{Concurrency: 0})
+	srv := queue.NewServer(d)
+	srv.Handle(queue.TaskTypeDeliver, func(_ context.Context, _ driver.Task) error {
 		return nil
 	})
-	// Startせずに Shutdownしても asynq は安全に no-op になる。
+	// Startせずに Shutdownしても driver は安全に no-op になる。
 	srv.Shutdown()
 }
 
@@ -227,7 +237,7 @@ func TestClient_EnqueueExport(t *testing.T) {
 	testutil.SkipIfNoDocker(t)
 	flushTestRedis(t)
 
-	c := queue.NewClient(redisOpt())
+	c := queue.NewClient(newDriver())
 	defer func() { _ = c.Close() }()
 
 	require.NoError(t, c.EnqueueExport(queue.ExportPayload{UserID: "u1", Type: "notes"}))
@@ -245,7 +255,7 @@ func TestClient_EnqueueImport(t *testing.T) {
 	testutil.SkipIfNoDocker(t)
 	flushTestRedis(t)
 
-	c := queue.NewClient(redisOpt())
+	c := queue.NewClient(newDriver())
 	defer func() { _ = c.Close() }()
 
 	require.NoError(t, c.EnqueueImport(queue.ImportPayload{UserID: "u1", Type: "following", FileID: "f1"}))
@@ -263,7 +273,7 @@ func TestClient_EnqueueImportCustomEmojis(t *testing.T) {
 	testutil.SkipIfNoDocker(t)
 	flushTestRedis(t)
 
-	c := queue.NewClient(redisOpt())
+	c := queue.NewClient(newDriver())
 	defer func() { _ = c.Close() }()
 
 	require.NoError(t, c.EnqueueImportCustomEmojis(queue.ImportCustomEmojisPayload{UserID: "admin1", FileID: "f1"}))
@@ -282,11 +292,11 @@ func TestInspector_QueuesAndInfo(t *testing.T) {
 	flushTestRedis(t)
 
 	// エンキューしてキューを作成
-	c := queue.NewClient(redisOpt())
+	c := queue.NewClient(newDriver())
 	defer func() { _ = c.Close() }()
 	require.NoError(t, c.EnqueueDeliver(queue.DeliverPayload{Inbox: "x", Body: []byte(`{}`), KeyID: "k", KeyPEM: "p"}))
 
-	insp := queue.NewInspector(redisOpt())
+	insp := queue.NewInspector(newDriver())
 	defer func() { _ = insp.Close() }()
 
 	queues, err := insp.Queues()
@@ -303,7 +313,7 @@ func TestInspector_GetQueueInfo_NotFound(t *testing.T) {
 	testutil.SkipIfNoDocker(t)
 	flushTestRedis(t)
 
-	insp := queue.NewInspector(redisOpt())
+	insp := queue.NewInspector(newDriver())
 	defer func() { _ = insp.Close() }()
 
 	_, err := insp.GetQueueInfo("nonexistent")
@@ -314,13 +324,13 @@ func TestInspector_ListPendingTasksAndGetTaskInfo(t *testing.T) {
 	testutil.SkipIfNoDocker(t)
 	flushTestRedis(t)
 
-	c := queue.NewClient(redisOpt())
+	c := queue.NewClient(newDriver())
 	defer func() { _ = c.Close() }()
 	require.NoError(t, c.EnqueueDeliver(queue.DeliverPayload{
 		Inbox: "https://remote.example/inbox", Body: []byte(`{}`), KeyID: "k", KeyPEM: "p",
 	}))
 
-	insp := queue.NewInspector(redisOpt())
+	insp := queue.NewInspector(newDriver())
 	defer func() { _ = insp.Close() }()
 
 	pending, err := insp.ListPendingTasks(queue.QueueName, 1, 30)
@@ -341,13 +351,13 @@ func TestInspector_ListActiveScheduledRetry_EmptyByDefault(t *testing.T) {
 	flushTestRedis(t)
 
 	// enqueue 後即 list。active/scheduled/retry は空でも err にならない。
-	c := queue.NewClient(redisOpt())
+	c := queue.NewClient(newDriver())
 	defer func() { _ = c.Close() }()
 	require.NoError(t, c.EnqueueDeliver(queue.DeliverPayload{
 		Inbox: "https://remote.example/inbox", Body: []byte(`{}`), KeyID: "k", KeyPEM: "p",
 	}))
 
-	insp := queue.NewInspector(redisOpt())
+	insp := queue.NewInspector(newDriver())
 	defer func() { _ = insp.Close() }()
 
 	active, err := insp.ListActiveTasks(queue.QueueName, 1, 30)
@@ -367,11 +377,11 @@ func TestInspector_ListTasks_DefaultsClamped(t *testing.T) {
 	testutil.SkipIfNoDocker(t)
 	flushTestRedis(t)
 
-	insp := queue.NewInspector(redisOpt())
+	insp := queue.NewInspector(newDriver())
 	defer func() { _ = insp.Close() }()
 
 	// page/pageSize が 0 以下でも default に丸められてエラーにならない。
-	c := queue.NewClient(redisOpt())
+	c := queue.NewClient(newDriver())
 	defer func() { _ = c.Close() }()
 	require.NoError(t, c.EnqueueDeliver(queue.DeliverPayload{
 		Inbox: "https://remote.example/inbox", Body: []byte(`{}`), KeyID: "k", KeyPEM: "p",
@@ -390,7 +400,7 @@ func TestInspector_GetTaskInfo_NotFound(t *testing.T) {
 	testutil.SkipIfNoDocker(t)
 	flushTestRedis(t)
 
-	insp := queue.NewInspector(redisOpt())
+	insp := queue.NewInspector(newDriver())
 	defer func() { _ = insp.Close() }()
 
 	_, err := insp.GetTaskInfo(queue.QueueName, "nonexistent-id")
@@ -422,7 +432,7 @@ func TestClient_EnqueueWebPush(t *testing.T) {
 	testutil.SkipIfNoDocker(t)
 	flushTestRedis(t)
 
-	c := queue.NewClient(redisOpt())
+	c := queue.NewClient(newDriver())
 	defer func() { _ = c.Close() }()
 
 	require.NoError(t, c.EnqueueWebPush(context.Background(), queue.WebPushPayload{
@@ -442,7 +452,7 @@ func TestClient_EnqueueWebPush_ClosedClientFails(t *testing.T) {
 	testutil.SkipIfNoDocker(t)
 	flushTestRedis(t)
 
-	c := queue.NewClient(redisOpt())
+	c := queue.NewClient(newDriver())
 	require.NoError(t, c.Close())
 	err := c.EnqueueWebPush(context.Background(), queue.WebPushPayload{UserID: "u1", Type: "notification"})
 	assert.Error(t, err)
@@ -490,7 +500,7 @@ func TestClient_EnqueueUserWebhook(t *testing.T) {
 	testutil.SkipIfNoDocker(t)
 	flushTestRedis(t)
 
-	c := queue.NewClient(redisOpt())
+	c := queue.NewClient(newDriver())
 	defer func() { _ = c.Close() }()
 
 	require.NoError(t, c.EnqueueUserWebhook(context.Background(), queue.WebhookPayload{
@@ -509,7 +519,7 @@ func TestClient_EnqueueUserWebhook(t *testing.T) {
 func TestClient_EnqueueUserWebhook_ClosedClientFails(t *testing.T) {
 	testutil.SkipIfNoDocker(t)
 	flushTestRedis(t)
-	c := queue.NewClient(redisOpt())
+	c := queue.NewClient(newDriver())
 	require.NoError(t, c.Close())
 	err := c.EnqueueUserWebhook(context.Background(), queue.WebhookPayload{WebhookID: "h1"})
 	assert.Error(t, err)
@@ -519,7 +529,7 @@ func TestClient_EnqueueSystemWebhook(t *testing.T) {
 	testutil.SkipIfNoDocker(t)
 	flushTestRedis(t)
 
-	c := queue.NewClient(redisOpt())
+	c := queue.NewClient(newDriver())
 	defer func() { _ = c.Close() }()
 
 	require.NoError(t, c.EnqueueSystemWebhook(context.Background(), queue.WebhookPayload{
@@ -538,7 +548,7 @@ func TestClient_EnqueueSystemWebhook(t *testing.T) {
 func TestClient_EnqueueSystemWebhook_ClosedClientFails(t *testing.T) {
 	testutil.SkipIfNoDocker(t)
 	flushTestRedis(t)
-	c := queue.NewClient(redisOpt())
+	c := queue.NewClient(newDriver())
 	require.NoError(t, c.Close())
 	err := c.EnqueueSystemWebhook(context.Background(), queue.WebhookPayload{WebhookID: "sh1"})
 	assert.Error(t, err)
@@ -548,7 +558,7 @@ func TestClient_EnqueueCleanRemoteNotes(t *testing.T) {
 	testutil.SkipIfNoDocker(t)
 	flushTestRedis(t)
 
-	c := queue.NewClient(redisOpt())
+	c := queue.NewClient(newDriver())
 	defer func() { _ = c.Close() }()
 
 	require.NoError(t, c.EnqueueCleanRemoteNotes())
@@ -558,7 +568,7 @@ func TestClient_EnqueueReactionFlush(t *testing.T) {
 	testutil.SkipIfNoDocker(t)
 	flushTestRedis(t)
 
-	c := queue.NewClient(redisOpt())
+	c := queue.NewClient(newDriver())
 	defer func() { _ = c.Close() }()
 
 	require.NoError(t, c.EnqueueReactionFlush())
@@ -568,7 +578,7 @@ func TestClient_EnqueueDeleteAccount(t *testing.T) {
 	testutil.SkipIfNoDocker(t)
 	flushTestRedis(t)
 
-	c := queue.NewClient(redisOpt())
+	c := queue.NewClient(newDriver())
 	defer func() { _ = c.Close() }()
 
 	require.NoError(t, c.EnqueueDeleteAccount(queue.DeleteAccountPayload{UserID: "u1"}))

--- a/internal/queue/scheduler.go
+++ b/internal/queue/scheduler.go
@@ -3,30 +3,25 @@ package queue
 import (
 	"time"
 
-	"github.com/hibiken/asynq"
+	"github.com/shiroha-a/mk/internal/queue/driver"
 )
 
-// MaintenanceQueueName is the asynq queue used for low-priority
-// maintenance jobs (chart tick / resync / clean etc). Kept separate
-// from the latency-sensitive deliver queue so a long aggregation does
-// not stall federation traffic.
+// MaintenanceQueueName is the queue used for low-priority maintenance
+// jobs (chart tick / resync / clean etc). Kept separate from the
+// latency-sensitive deliver queue so a long aggregation does not stall
+// federation traffic.
 const MaintenanceQueueName = "maintenance"
 
-// Scheduler wraps asynq.Scheduler. It registers cron-style entries
-// once at startup and continuously enqueues tasks per their schedule
-// onto the standard worker queues.
-//
-// asynq.Scheduler は redis 上のロックで重複起動を防ぐので、複数 process
-// で起動しても同時刻に同じジョブを 2 回 enqueue することはない。
+// Scheduler is the driver-neutral facade over driver.Scheduler. It
+// registers cron-style entries once at startup and continuously
+// enqueues tasks per their schedule onto the standard worker queues.
 type Scheduler struct {
-	inner *asynq.Scheduler
+	inner driver.Scheduler
 }
 
-// NewScheduler constructs a Scheduler backed by the given Redis.
-func NewScheduler(redisOpt asynq.RedisClientOpt) *Scheduler {
-	return &Scheduler{
-		inner: asynq.NewScheduler(redisOpt, &asynq.SchedulerOpts{}),
-	}
+// NewScheduler wraps the driver's scheduler.
+func NewScheduler(d driver.Driver) *Scheduler {
+	return &Scheduler{inner: d.Scheduler()}
 }
 
 // RegisterChartJobs registers the 3 chart-related cron jobs.
@@ -36,8 +31,8 @@ func NewScheduler(redisOpt asynq.RedisClientOpt) *Scheduler {
 //   - cleanCharts : 毎日 00:00 UTC
 //
 // 重複 enqueue 防止のため Unique TTL を cron 周期と合わせる。前回の
-// 同種ジョブが処理中のまま次回 cron が発火しても、TTL 内であれば asynq が
-// 重複 enqueue を弾く。
+// 同種ジョブが処理中のまま次回 cron が発火しても、TTL 内であれば
+// driver が重複 enqueue を弾く。
 func (s *Scheduler) RegisterChartJobs() error {
 	jobs := []struct {
 		cron      string
@@ -49,11 +44,10 @@ func (s *Scheduler) RegisterChartJobs() error {
 		{"0 0 * * *", TaskTypeChartClean, 24 * time.Hour},
 	}
 	for _, j := range jobs {
-		task := asynq.NewTask(j.taskType, nil)
-		if _, err := s.inner.Register(j.cron, task,
-			asynq.Queue(MaintenanceQueueName),
-			asynq.MaxRetry(0),
-			asynq.Unique(j.uniqueTTL),
+		if err := s.inner.Register(j.cron, j.taskType, nil,
+			driver.WithQueue(MaintenanceQueueName),
+			driver.WithMaxRetry(0),
+			driver.WithUnique(j.uniqueTTL),
 		); err != nil {
 			return err
 		}
@@ -65,34 +59,26 @@ func (s *Scheduler) RegisterChartJobs() error {
 // refresh cron (#393) at 03:00 UTC. The actual walk + fetch is implemented
 // by processors.InstanceRefreshProcessor.
 func (s *Scheduler) RegisterInstanceRefreshJob() error {
-	task := asynq.NewTask(TaskTypeInstanceRefresh, nil)
-	_, err := s.inner.Register("0 3 * * *", task,
-		asynq.Queue(MaintenanceQueueName),
-		asynq.MaxRetry(0),
-		asynq.Unique(24*time.Hour),
+	return s.inner.Register("0 3 * * *", TaskTypeInstanceRefresh, nil,
+		driver.WithQueue(MaintenanceQueueName),
+		driver.WithMaxRetry(0),
+		driver.WithUnique(24*time.Hour),
 	)
-	return err
 }
 
 // RegisterRetentionJob registers the daily retention aggregation cron
 // (#421) at 00:00 UTC. The actual computation is implemented by
 // processors.RetentionAggregateProcessor.
 func (s *Scheduler) RegisterRetentionJob() error {
-	task := asynq.NewTask(TaskTypeRetentionAggregate, nil)
-	_, err := s.inner.Register("0 0 * * *", task,
-		asynq.Queue(MaintenanceQueueName),
-		asynq.MaxRetry(0),
-		asynq.Unique(24*time.Hour),
+	return s.inner.Register("0 0 * * *", TaskTypeRetentionAggregate, nil,
+		driver.WithQueue(MaintenanceQueueName),
+		driver.WithMaxRetry(0),
+		driver.WithUnique(24*time.Hour),
 	)
-	return err
 }
 
 // Start launches the scheduler in the background. Returns immediately.
-func (s *Scheduler) Start() error {
-	return s.inner.Start()
-}
+func (s *Scheduler) Start() error { return s.inner.Start() }
 
-// Shutdown stops the scheduler and releases its Redis connection.
-func (s *Scheduler) Shutdown() {
-	s.inner.Shutdown()
-}
+// Shutdown stops the scheduler and releases its connection.
+func (s *Scheduler) Shutdown() { s.inner.Shutdown() }

--- a/internal/queue/scheduler_test.go
+++ b/internal/queue/scheduler_test.go
@@ -6,26 +6,34 @@ import (
 	"github.com/hibiken/asynq"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/shiroha-a/mk/internal/queue/driver/asynqdriver"
 )
 
+// newSchedulerForTest constructs a Scheduler against a driver that
+// does not require a live Redis (asynq.Scheduler is constructed lazily
+// in NewScheduler — Register validates cron syntax client-side).
+func newSchedulerForTest(t *testing.T) *Scheduler {
+	t.Helper()
+	d := asynqdriver.New(asynq.RedisClientOpt{Addr: "127.0.0.1:6379"}, asynqdriver.ServerConfig{})
+	s := NewScheduler(d)
+	t.Cleanup(s.Shutdown)
+	return s
+}
+
 // TestNewScheduler_NotNil is a simple smoke test that the Scheduler
-// wrapper builds without touching Redis. asynq.Scheduler does not
-// connect on construction, so this can run without a Redis instance.
+// wrapper builds without touching Redis.
 func TestNewScheduler_NotNil(t *testing.T) {
-	s := NewScheduler(asynq.RedisClientOpt{Addr: "127.0.0.1:6379"})
+	s := newSchedulerForTest(t)
 	require.NotNil(t, s)
 	require.NotNil(t, s.inner)
-	// Shutdown を呼んでも Start していなければ no-op で安全。
-	s.Shutdown()
 }
 
 // TestScheduler_RegisterChartJobs_NoErr verifies the cron syntax + queue
-// options are accepted by asynq. Register does not enqueue — it simply
-// records the schedule — so no Redis is required.
+// options are accepted. Register does not enqueue — it simply records
+// the schedule — so no Redis is required.
 func TestScheduler_RegisterChartJobs_NoErr(t *testing.T) {
-	s := NewScheduler(asynq.RedisClientOpt{Addr: "127.0.0.1:6379"})
-	defer s.Shutdown()
-
+	s := newSchedulerForTest(t)
 	require.NoError(t, s.RegisterChartJobs())
 }
 

--- a/internal/queue/tasks.go
+++ b/internal/queue/tasks.go
@@ -3,68 +3,67 @@ package queue
 import (
 	"encoding/json"
 
-	"github.com/hibiken/asynq"
+	"github.com/shiroha-a/mk/internal/queue/driver"
 )
 
-// TaskTypeDeliver is the asynq task type used for outbound ActivityPub
+// TaskTypeDeliver is the task type used for outbound ActivityPub
 // delivery jobs.
 const TaskTypeDeliver = "ap:deliver"
 
-// TaskTypeExport is the asynq task type for data export jobs.
+// TaskTypeExport is the task type for data export jobs.
 const TaskTypeExport = "export"
 
-// TaskTypeImport is the asynq task type for data import jobs.
+// TaskTypeImport is the task type for data import jobs.
 const TaskTypeImport = "import"
 
-// TaskTypeWebPush is the asynq task type for Web Push delivery jobs.
+// TaskTypeWebPush is the task type for Web Push delivery jobs.
 const TaskTypeWebPush = "webpush:notify"
 
-// TaskTypeImportCustomEmojis is the asynq task type for admin/emoji/import-zip
+// TaskTypeImportCustomEmojis is the task type for admin/emoji/import-zip
 // processing jobs. 本家 Misskey の importCustomEmojis queue job と同名。
 const TaskTypeImportCustomEmojis = "importCustomEmojis"
 
-// TaskTypeUserWebhook is the asynq task type for user webhook delivery jobs.
+// TaskTypeUserWebhook is the task type for user webhook delivery jobs.
 const TaskTypeUserWebhook = "webhook:user"
 
-// TaskTypeSystemWebhook is the asynq task type for system webhook delivery jobs.
+// TaskTypeSystemWebhook is the task type for system webhook delivery jobs.
 const TaskTypeSystemWebhook = "webhook:system"
 
-// TaskTypeCleanRemoteNotes is the asynq task type for the periodic remote
+// TaskTypeCleanRemoteNotes is the task type for the periodic remote
 // notes cleaning job. ペイロードなし (meta から設定を読む)。
 const TaskTypeCleanRemoteNotes = "maintenance:cleanRemoteNotes"
 
-// TaskTypeReactionFlush is the asynq task type for flushing buffered
+// TaskTypeReactionFlush is the task type for flushing buffered
 // reaction counts from Redis to the database.
 const TaskTypeReactionFlush = "maintenance:reactionFlush"
 
-// TaskTypeChartTick is the asynq task type for the hourly tick-charts
-// job. Mirrors upstream `tickCharts` (cron `55 * * * *`).
+// TaskTypeChartTick is the task type for the hourly tick-charts job.
+// Mirrors upstream `tickCharts` (cron `55 * * * *`).
 const TaskTypeChartTick = "chart:tick"
 
-// TaskTypeChartResync is the asynq task type for the daily resync-charts
-// job. Mirrors upstream `resyncCharts` (cron `0 0 * * *`).
+// TaskTypeChartResync is the task type for the daily resync-charts job.
+// Mirrors upstream `resyncCharts` (cron `0 0 * * *`).
 const TaskTypeChartResync = "chart:resync"
 
-// TaskTypeChartClean is the asynq task type for the daily clean-charts
-// job. Mirrors upstream `cleanCharts` (cron `0 0 * * *`).
+// TaskTypeChartClean is the task type for the daily clean-charts job.
+// Mirrors upstream `cleanCharts` (cron `0 0 * * *`).
 const TaskTypeChartClean = "chart:clean"
 
-// TaskTypeDeleteAccount is the asynq task type for the background cascade
-// deletion of a user account's related rows (notes / drive files / follow
-// graph entries etc.). Mirrors upstream `deleteAccount` queue job.
+// TaskTypeDeleteAccount is the task type for the background cascade
+// deletion of a user account's related rows. Mirrors upstream
+// `deleteAccount` queue job.
 const TaskTypeDeleteAccount = "maintenance:deleteAccount"
 
-// TaskTypeInstanceRefresh is the asynq task type for the periodic
+// TaskTypeInstanceRefresh is the task type for the periodic
 // remote-instance metadata refresh (#393). Registered by
 // `Scheduler.RegisterInstanceRefreshJob` at `0 3 * * *` UTC and handled by
 // `processors.InstanceRefreshProcessor`.
 const TaskTypeInstanceRefresh = "maintenance:instanceRefresh"
 
-// TaskTypeRetentionAggregate is the asynq task type for the daily
-// retention aggregation (#421). Registered by
-// `Scheduler.RegisterRetentionJob` at `0 0 * * *` UTC and handled by
-// `processors.RetentionAggregateProcessor`. Mirrors upstream
-// AggregateRetentionProcessorService.
+// TaskTypeRetentionAggregate is the task type for the daily retention
+// aggregation (#421). Registered by `Scheduler.RegisterRetentionJob`
+// at `0 0 * * *` UTC and handled by
+// `processors.RetentionAggregateProcessor`.
 const TaskTypeRetentionAggregate = "maintenance:retentionAggregate"
 
 // DeliverPayload is the body of a deliver task. すべてJSONで安全に
@@ -81,13 +80,13 @@ type DeliverPayload struct {
 	KeyPEM string `json:"keyPem"`
 }
 
-// NewDeliverTask serializes the payload into an asynq.Task ready to enqueue.
-// DeliverPayload はすべて marshal 可能な型 (string と []byte) のみで構成される
-// ため json.Marshal は失敗しない。エラー戻り値を取らない方が呼び出し側を簡潔
-// にできる。
-func NewDeliverTask(payload DeliverPayload) *asynq.Task {
+// NewDeliverTask serializes the payload into a driver.Task ready to
+// pass into a HandlerFunc (used in tests). DeliverPayload はすべて
+// marshal 可能な型 (string と []byte) のみで構成されるため
+// json.Marshal は失敗しない。
+func NewDeliverTask(payload DeliverPayload) driver.Task {
 	body, _ := json.Marshal(payload)
-	return asynq.NewTask(TaskTypeDeliver, body)
+	return driver.RawTask{TypeName: TaskTypeDeliver, Body: body}
 }
 
 // DecodeDeliverPayload extracts a DeliverPayload from a task body.
@@ -105,10 +104,10 @@ type ExportPayload struct {
 	Type   string `json:"type"` // notes, following, blocking, mute, favorites, user-lists, antennas, clips
 }
 
-// NewExportTask creates an asynq.Task for data export.
-func NewExportTask(payload ExportPayload) *asynq.Task {
+// NewExportTask creates a driver.Task for data export.
+func NewExportTask(payload ExportPayload) driver.Task {
 	body, _ := json.Marshal(payload)
-	return asynq.NewTask(TaskTypeExport, body)
+	return driver.RawTask{TypeName: TaskTypeExport, Body: body}
 }
 
 // DecodeExportPayload extracts an ExportPayload from a task body.
@@ -127,10 +126,10 @@ type ImportPayload struct {
 	FileID string `json:"fileId"`
 }
 
-// NewImportTask creates an asynq.Task for data import.
-func NewImportTask(payload ImportPayload) *asynq.Task {
+// NewImportTask creates a driver.Task for data import.
+func NewImportTask(payload ImportPayload) driver.Task {
 	body, _ := json.Marshal(payload)
-	return asynq.NewTask(TaskTypeImport, body)
+	return driver.RawTask{TypeName: TaskTypeImport, Body: body}
 }
 
 // DecodeImportPayload extracts an ImportPayload from a task body.
@@ -149,10 +148,10 @@ type ImportCustomEmojisPayload struct {
 	FileID string `json:"fileId"`
 }
 
-// NewImportCustomEmojisTask creates an asynq.Task for emoji-zip imports.
-func NewImportCustomEmojisTask(payload ImportCustomEmojisPayload) *asynq.Task {
+// NewImportCustomEmojisTask creates a driver.Task for emoji-zip imports.
+func NewImportCustomEmojisTask(payload ImportCustomEmojisPayload) driver.Task {
 	body, _ := json.Marshal(payload)
-	return asynq.NewTask(TaskTypeImportCustomEmojis, body)
+	return driver.RawTask{TypeName: TaskTypeImportCustomEmojis, Body: body}
 }
 
 // DecodeImportCustomEmojisPayload extracts an ImportCustomEmojisPayload.
@@ -164,19 +163,19 @@ func DecodeImportCustomEmojisPayload(body []byte) (ImportCustomEmojisPayload, er
 	return p, nil
 }
 
-// WebPushPayload is the body of a Web Push delivery task. The Body field holds
-// the already-truncated notification payload; the processor does not inspect
-// it and simply forwards it to subscribers.
+// WebPushPayload is the body of a Web Push delivery task. The Body
+// field holds the already-truncated notification payload; the
+// processor does not inspect it and simply forwards it to subscribers.
 type WebPushPayload struct {
 	UserID string          `json:"userId"`
 	Type   string          `json:"type"`
 	Body   json.RawMessage `json:"body,omitempty"`
 }
 
-// NewWebPushTask serializes the payload into an asynq.Task ready to enqueue.
-func NewWebPushTask(payload WebPushPayload) *asynq.Task {
+// NewWebPushTask serializes the payload into a driver.Task.
+func NewWebPushTask(payload WebPushPayload) driver.Task {
 	body, _ := json.Marshal(payload)
-	return asynq.NewTask(TaskTypeWebPush, body)
+	return driver.RawTask{TypeName: TaskTypeWebPush, Body: body}
 }
 
 // DecodeWebPushPayload extracts a WebPushPayload from a task body.
@@ -189,9 +188,9 @@ func DecodeWebPushPayload(body []byte) (WebPushPayload, error) {
 }
 
 // WebhookPayload carries a single webhook delivery job. Body is the
-// pre-marshalled event payload envelope (see core/webhook for the exact
-// Misskey-compatible structure); the processor forwards it to the endpoint
-// URL without further interpretation.
+// pre-marshalled event payload envelope (see core/webhook for the
+// exact Misskey-compatible structure); the processor forwards it to
+// the endpoint URL without further interpretation.
 type WebhookPayload struct {
 	WebhookID string          `json:"webhookId"`
 	UserID    string          `json:"userId,omitempty"` // user webhooks only
@@ -199,23 +198,23 @@ type WebhookPayload struct {
 	Body      json.RawMessage `json:"body"`
 }
 
-// NewUserWebhookTask serializes the payload into an asynq.Task for user
-// webhook delivery.
-func NewUserWebhookTask(payload WebhookPayload) *asynq.Task {
+// NewUserWebhookTask serializes the payload into a driver.Task for
+// user webhook delivery.
+func NewUserWebhookTask(payload WebhookPayload) driver.Task {
 	body, _ := json.Marshal(payload)
-	return asynq.NewTask(TaskTypeUserWebhook, body)
+	return driver.RawTask{TypeName: TaskTypeUserWebhook, Body: body}
 }
 
-// NewSystemWebhookTask serializes the payload into an asynq.Task for system
-// webhook delivery.
-func NewSystemWebhookTask(payload WebhookPayload) *asynq.Task {
+// NewSystemWebhookTask serializes the payload into a driver.Task for
+// system webhook delivery.
+func NewSystemWebhookTask(payload WebhookPayload) driver.Task {
 	body, _ := json.Marshal(payload)
-	return asynq.NewTask(TaskTypeSystemWebhook, body)
+	return driver.RawTask{TypeName: TaskTypeSystemWebhook, Body: body}
 }
 
-// DecodeWebhookPayload extracts a WebhookPayload from a task body. The same
-// encoder/decoder is reused for both user and system webhook tasks since the
-// wire format is identical.
+// DecodeWebhookPayload extracts a WebhookPayload from a task body. The
+// same encoder/decoder is reused for both user and system webhook tasks
+// since the wire format is identical.
 func DecodeWebhookPayload(body []byte) (WebhookPayload, error) {
 	var p WebhookPayload
 	if err := json.Unmarshal(body, &p); err != nil {
@@ -230,10 +229,10 @@ type DeleteAccountPayload struct {
 	UserID string `json:"userId"`
 }
 
-// NewDeleteAccountTask serializes a DeleteAccountPayload into an asynq.Task.
-func NewDeleteAccountTask(payload DeleteAccountPayload) *asynq.Task {
+// NewDeleteAccountTask serializes a DeleteAccountPayload into a driver.Task.
+func NewDeleteAccountTask(payload DeleteAccountPayload) driver.Task {
 	body, _ := json.Marshal(payload)
-	return asynq.NewTask(TaskTypeDeleteAccount, body)
+	return driver.RawTask{TypeName: TaskTypeDeleteAccount, Body: body}
 }
 
 // DecodeDeleteAccountPayload extracts a DeleteAccountPayload from a task body.

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -7,13 +7,14 @@ import (
 	"log/slog"
 	"net/http"
 
-	"github.com/hibiken/asynq"
 	"github.com/labstack/echo/v4"
 	echomw "github.com/labstack/echo/v4/middleware"
 	"github.com/shiroha-a/mk/internal/config"
 	"github.com/shiroha-a/mk/internal/core/cache"
 	"github.com/shiroha-a/mk/internal/core/chart"
 	"github.com/shiroha-a/mk/internal/queue"
+	"github.com/shiroha-a/mk/internal/queue/driver"
+	"github.com/shiroha-a/mk/internal/queue/driver/asynqdriver"
 	"github.com/shiroha-a/mk/internal/repository"
 	mksentry "github.com/shiroha-a/mk/internal/sentry"
 	"github.com/shiroha-a/mk/internal/server/middleware"
@@ -27,6 +28,7 @@ type Server struct {
 	db             *gorm.DB
 	redis          *cache.RedisClients
 	auth           *middleware.AuthMiddleware
+	queueDriver    driver.Driver
 	queueClient    *queue.Client
 	queueServer    *queue.Server
 	queueScheduler *queue.Scheduler
@@ -80,19 +82,21 @@ func New(cfg *config.Config, db *gorm.DB, redis *cache.RedisClients) *Server {
 	auth := middleware.NewAuthMiddleware(userRepo, accessTokenRepo)
 	e.Use(auth.Authenticate())
 
-	// asynq セットアップ: redisForJobQueue にぶら下げる。
+	// queue driver セットアップ: redisForJobQueue にぶら下げる。
 	// Host が UNIX domain socket パス ("/" 始まり) なら Network を "unix" に
-	// 切り替える。asynq.RedisClientOpt はそのまま go-redis v9 に渡されるので
-	// cache 側の buildRedisOptions と同じ判定ルールで十分。
-	redisOpt := buildAsynqRedisOpt(cfg.RedisForJobQueue)
+	// 切り替える (asynqdriver.BuildRedisOpt が判定する)。
 	concurrency := 16
 	if cfg.DeliverJobConcurrency != nil && *cfg.DeliverJobConcurrency > 0 {
 		concurrency = *cfg.DeliverJobConcurrency
 	}
-	queueClient := queue.NewClient(redisOpt)
-	queueServer := queue.NewServer(redisOpt, queue.ServerConfig{Concurrency: concurrency})
-	queueScheduler := queue.NewScheduler(redisOpt)
-	queueInspector := queue.NewInspector(redisOpt)
+	queueDriver := asynqdriver.New(
+		asynqdriver.BuildRedisOpt(cfg.RedisForJobQueue),
+		asynqdriver.ServerConfig{Concurrency: concurrency},
+	)
+	queueClient := queue.NewClient(queueDriver)
+	queueServer := queue.NewServer(queueDriver)
+	queueScheduler := queue.NewScheduler(queueDriver)
+	queueInspector := queue.NewInspector(queueDriver)
 
 	s := &Server{
 		echo:           e,
@@ -100,6 +104,7 @@ func New(cfg *config.Config, db *gorm.DB, redis *cache.RedisClients) *Server {
 		db:             db,
 		redis:          redis,
 		auth:           auth,
+		queueDriver:    queueDriver,
 		queueClient:    queueClient,
 		queueServer:    queueServer,
 		queueScheduler: queueScheduler,
@@ -192,28 +197,6 @@ func (s *Server) Shutdown(ctx context.Context) error {
 		slog.Warn("failed to remove socket file", "socket", s.config.Socket, "err", rmErr)
 	}
 	return err
-}
-
-// buildAsynqRedisOpt constructs an asynq.RedisClientOpt that understands UNIX
-// domain socket paths. When the host string looks like an absolute path the
-// Network field is set to "unix" so that go-redis (via asynq) dials the socket
-// directly; otherwise the classic host:port TCP form is used.
-func buildAsynqRedisOpt(opts config.RedisOptions) asynq.RedisClientOpt {
-	if config.IsUnixSocketPath(opts.Host) {
-		return asynq.RedisClientOpt{
-			Network:  "unix",
-			Addr:     opts.Host,
-			Password: opts.Pass,
-			DB:       opts.DB,
-			Username: opts.Username,
-		}
-	}
-	return asynq.RedisClientOpt{
-		Addr:     fmt.Sprintf("%s:%d", opts.Host, opts.Port),
-		Password: opts.Pass,
-		DB:       opts.DB,
-		Username: opts.Username,
-	}
 }
 
 // setChartManagement registers the chart management service so its


### PR DESCRIPTION
## Summary

- `internal/queue/` の asynq 結合を解消し、driver interface 経由に変更
- 後続の mkq driver 追加 (#448) に向けた土台
- 挙動は完全維持 (asynq driver で従来通り動作)

## 主な変更点

- **`internal/queue/driver/`** (新規): Task / HandlerFunc / Client / Server / Inspector / Scheduler / Driver interface と SkipRetry sentinel を定義 (coverage 100%)
- **`internal/queue/driver/asynqdriver/`** (新規): 既存 asynq 実装を driver に適合 (coverage 95%)。`SkipRetry` を `asynq.SkipRetry` に変換する Server.Handle bridge、`buildAsynqRedisOpt` を `BuildRedisOpt` としてパッケージ内に移動
- **`internal/queue/queue.go` / `inspector.go` / `scheduler.go`**: 公開 API は維持しつつ内部を driver 経由化。`Enqueuer.EnqueueDeliver` の `asynq.Option` を `driver.EnqueueOption` に変更 (呼び出し側が opts を渡している箇所はないので互換性あり)
- **11 processors**: `*asynq.Task` → `driver.Task`、`asynq.SkipRetry` → `driver.SkipRetry` に書き換え (テストも追従)
- **`internal/server/server.go`**: `queueDriver` フィールド追加、`asynqdriver.New` で 1 箇所構築

## テスト

- `make fmt && make lint && make test` 通過
- `go test -race -count=1 ./...` 全パッケージ通過
- 新規パッケージのカバレッジ:
  - `internal/queue/driver`: 100%
  - `internal/queue/driver/asynqdriver`: 95.1%

実行コマンド:
```bash
make fmt && make lint && make test
go test -race -count=1 -timeout 10m ./...
```

## Closes

Closes #447

## 関連

- 親 issue: #377 (BullMQ-compatible job queue library design)
- 後続 PR: mkq driver 実装 + config 切替 (#448 / 別 PR、本 PR にスタック)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/shiroha-a/mk/pull/449" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
