### PR TITLE
config: UDS deploy default.yml.example を Misskey 本家フォーマットに揃える (#453)

### DIFF
--- a/deploy/uds/config/default.yml.example
+++ b/deploy/uds/config/default.yml.example
@@ -1,33 +1,252 @@
-# mk-go config for the UDS-only stack (compose.uds.yaml).
+#━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+# Misskey-Go configuration (UDS-only stack)
 #
-# HTTP / PostgreSQL / Redis すべて UNIX domain socket で接続する。
-# TCP を使わないので host から直接触れるのは nginx の 80 番だけ。
+# このファイルは `deploy/uds/config/default.yml.example` です。
+# `compose.uds.yaml` 系列スタック (HTTP / PostgreSQL / Redis すべて
+# UNIX domain socket で接続) で使用します。初回は以下を実行して
+# default.yml を作成してください:
+#   cp deploy/uds/config/default.yml.example deploy/uds/config/default.yml
+#
+# Misskey 本家 .config/example.yml をベースに、Go 実装 (misskey-go)
+# 固有の項目と UDS スタック特有の設定を加えています。
+#━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+#   ┌──────────────────────────────┐
+#───┘ a boring but important thing └────────────────────────────
+
+# Misskey is licensed under the AGPLv3 license. mk-go also adheres
+# to this license. See the upstream Misskey example.yml for the full
+# explanation of license compliance options.
+#
+# publishTarballInsteadOfProvideRepositoryUrl: true
+
+#   ┌────────────────────────┐
+#───┘ Initial Setup Password └─────────────────────────────────────────────────────
+
+# Password to initiate setting up admin account.
+# It will not be used after the initial setup is complete.
+#
+# setupPassword: example_password_please_change_this_or_you_will_get_hacked
+
+#   ┌─────┐
+#───┘ URL └─────────────────────────────────────────────────────
 
 # ブラウザに返す URL。nginx が 80 番でリッスンしている前提。
 url: http://localhost
 
+# ONCE YOU HAVE STARTED THE INSTANCE, DO NOT CHANGE THE
+# URL SETTINGS AFTER THAT!
+
+#   ┌───────────────────────┐
+#───┘ Port and TLS settings └───────────────────────────────────
+
+# UDS スタックでは TCP listen は使わないので `port` を意図的に省略する
+# (両方設定すると "both socket and port are set" の warning が起動毎
+# に出る)。下の `socket` で UDS listen に切り替える。
+#port: 3000
+
 # HTTP listen を UNIX domain socket にする (Phase 12-1 で入った経路)。
-# nginx コンテナが同じ named volume (mkgo_sock) を /run/mkgo に mount して
-# この socket を upstream 先にする。
+# nginx コンテナが同じ named volume (mkgo_sock) を /run/mkgo に mount
+# して、この socket を upstream 先にする。
 socket: /run/mkgo/mkgo.sock
-# nginx (alpine image では uid 101, non-root) から読める必要があるので 666 にする。
+
+# nginx (alpine image では uid 101, non-root) から読める必要があるので
+# 666 にする。本番運用では nginx と mk-go を同じグループに入れて 660
+# にする方が望ましい。
 chmodSocket: "666"
 
+# Proxy trust settings.
+#
+# UDS スタックでは upstream は localhost (UDS の peer なので CIDR で
+# 識別できないが、loopback 同等として扱う)。
+#
+#trustProxy:
+#  - '127.0.0.1/32'
+#  - '::1/128'
+
+# Disable HSTS header (default: false). nginx 側で HSTS を付ける場合は
+# ここで mk-go 側を無効化する。
+#disableHsts: true
+
+# Enable internal IP-based rate limiting (default: true).
+# nginx 側で limit_req を使う場合は false にする。
+#enableIpRateLimit: true
+
+#   ┌──────────────────────────┐
+#───┘ PostgreSQL configuration └────────────────────────────────
+
 db:
-  # 絶対パス (/ で始まる) なので Phase 12-1 の IsUnixSocketPath で UDS と判定される。
-  # libpq / pgx は host=<dir> から <dir>/.s.PGSQL.<port> を組み立てるので、
-  # postgres 側が作る socket ファイル名と port を一致させる必要がある。
+  # 絶対パス (/ で始まる) なので Phase 12-1 の IsUnixSocketPath で UDS
+  # と判定される。libpq / pgx は host=<dir> から <dir>/.s.PGSQL.<port>
+  # を組み立てるので、postgres 側が作る socket ファイル名と port を
+  # 一致させる必要がある。
   host: /var/run/postgresql
   port: 5432
+
+  # Database name
   db: mkgo
+
+  # Auth — compose.uds.yaml の POSTGRES_USER / POSTGRES_PASSWORD と
+  # 整合させる。本番運用では強いパスワードに変更すること。
   user: mkgo
   pass: mkgo_dev_pass
 
+  # Whether disable Caching queries
+  #disableCache: true
+
+  # Connection pool tuning (mk-go specific)
+  #maxOpenConns: 25
+  #maxIdleConns: 5
+  #connMaxLifetime: 1800
+  #connMaxIdleTime: 300
+
+dbReplications: false
+
+# You can configure any number of read replicas here
+#dbSlaves:
+#  -
+#    host:
+#    port:
+#    db:
+#    user:
+#    pass:
+
+#   ┌─────────────────────┐
+#───┘ Redis configuration └─────────────────────────────────────
+
 redis:
-  # 同じく絶対パスなので go-redis の Network=unix 経路に入る (internal/core/cache/redis.go)。
+  # 同じく絶対パスなので go-redis の Network=unix 経路に入る
+  # (internal/core/cache/redis.go)。
   host: /run/valkey/valkey.sock
-  # UDS 接続では port は無視されるが、viper の schema 上 int が期待されるので
-  # 6379 を書いておく (実通信では使われない)。
+  # UDS 接続では port は無視されるが、viper の schema 上 int が期待
+  # されるので 6379 を書いておく (実通信では使われない)。
   port: 6379
+  #pass: example-pass
+  #db: 1
+  #poolSize: 32
+
+#redisForPubsub:
+#  host: /run/valkey/valkey.sock
+#  port: 6379
+
+#redisForJobQueue:
+#  host: /run/valkey/valkey.sock
+#  port: 6379
+
+#redisForTimelines:
+#  host: /run/valkey/valkey.sock
+#  port: 6379
+
+#redisForReactions:
+#  host: /run/valkey/valkey.sock
+#  port: 6379
+
+#   ┌───────────────────┐
+#───┘ Job queue driver └────────────────────────────────────────
+
+# mk-go specific: select the job queue runtime.
+#
+#   - 'asynq' (default): hibiken/asynq based runtime.
+#   - 'mkq':              shiroha-a/mkq based, BullMQ wire-compatible
+#                         (makes the admin queue dashboard render
+#                          correctly under the upstream Misskey TS
+#                          frontend).
+#
+#jobQueueDriver: asynq
+
+#   ┌───────────────────────────────┐
+#───┘ Fulltext search configuration └─────────────────────────────
+
+fulltextSearch:
+  # - sqlLike (default): SQL ILIKE search (no extension required).
+  # - sqlPgroonga:       Use pgroonga PostgreSQL extension.
+  # - meilisearch:       Use Meilisearch (configure under `meilisearch:`).
+  provider: sqlLike
+
+#meilisearch:
+#  host: localhost
+#  port: 7700
+#  apiKey: ''
+#  ssl: true
+#  index: ''
+#  scope: local
+
+#   ┌───────────────┐
+#───┘ ID generation └───────────────────────────────────────────
+
+# Available methods: aid, aidx, meid, ulid, objectid
+# ONCE YOU HAVE STARTED THE INSTANCE, DO NOT CHANGE.
 
 id: aidx
+
+#   ┌────────────────┐
+#───┘ Error tracking └──────────────────────────────────────────
+
+#sentryForBackend:
+#  enableNodeProfiling: true   # Node-only feature; ignored by Go backend
+#  options:
+#    dsn: 'https://examplePublicKey@o0.ingest.sentry.io/0'
+#    environment: production
+
+#sentryForFrontend:
+#  options:
+#    dsn: 'https://examplePublicKey@o0.ingest.sentry.io/0'
+
+#   ┌─────────────────────┐
+#───┘ Job queue settings └──────────────────────────────────────
+
+#deliverJobConcurrency: 128
+#inboxJobConcurrency: 16
+#relationshipJobConcurrency: 16
+
+#deliverJobPerSec: 128
+#inboxJobPerSec: 32
+#relationshipJobPerSec: 64
+
+#deliverJobMaxAttempts: 12
+#inboxJobMaxAttempts: 8
+
+#   ┌─────────────────────┐
+#───┘ Other configuration └─────────────────────────────────────
+
+#outgoingAddress: 127.0.0.1
+#outgoingAddressFamily: ipv4
+
+#proxy: http://127.0.0.1:3128
+
+proxyBypassHosts:
+  - api.deepl.com
+  - api-free.deepl.com
+  - www.recaptcha.net
+  - hcaptcha.com
+  - challenges.cloudflare.com
+
+#proxySmtp: http://127.0.0.1:3128
+
+#mediaProxy: https://example.com/proxy
+#mediaProxySecret: change-me
+
+#videoThumbnailGenerator: https://example.com
+
+#allowedPrivateNetworks:
+#  - '127.0.0.1/32'
+
+#maxFileSize: 262144000
+
+#pidFile: /tmp/misskey.pid
+
+#logging:
+#  sql:
+#    enableQueryParamLogging: false
+#    disableQueryTruncation: false
+
+#   ┌──────────────────────────────────┐
+#───┘ Test / debug (mk-go specific) └───────────────────────────
+
+# Enable destructive test endpoints such as /api/reset-db.
+# **DO NOT enable in production** — used by e2e tests only.
+#testMode: false
+
+# Mount net/http/pprof handlers at /debug/pprof/* for local
+# profiling. **DO NOT enable in production**.
+#enablePprof: false

--- a/deploy/uds/config/default.yml.example
+++ b/deploy/uds/config/default.yml.example
@@ -177,7 +177,7 @@ fulltextSearch:
 # Available methods: aid, aidx, meid, ulid, objectid
 # ONCE YOU HAVE STARTED THE INSTANCE, DO NOT CHANGE.
 
-id: aidx
+id: 'aidx'
 
 #   ┌────────────────┐
 #───┘ Error tracking └──────────────────────────────────────────

--- a/deploy/uds/config/default.yml.example
+++ b/deploy/uds/config/default.yml.example
@@ -3,12 +3,12 @@
 #
 # このファイルは `deploy/uds/config/default.yml.example` です。
 # `compose.uds.yaml` 系列スタック (HTTP / PostgreSQL / Redis すべて
-# UNIX domain socket で接続) で使用します。初回は以下を実行して
-# default.yml を作成してください:
+# UNIX domain socketで接続) で使用します。初回は以下を実行して
+# default.ymlを作成してください:
 #   cp deploy/uds/config/default.yml.example deploy/uds/config/default.yml
 #
-# Misskey 本家 .config/example.yml をベースに、Go 実装 (misskey-go)
-# 固有の項目と UDS スタック特有の設定を加えています。
+# Misskey本家 .config/example.ymlをベースに、Go実装 (misskey-go)
+# 固有の項目とUDSスタック特有の設定を加えています。
 #━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
 #   ┌──────────────────────────────┐
@@ -31,7 +31,7 @@
 #   ┌─────┐
 #───┘ URL └─────────────────────────────────────────────────────
 
-# ブラウザに返す URL。nginx が 80 番でリッスンしている前提。
+# ブラウザに返すURL。nginxが80番でリッスンしている前提。
 url: http://localhost
 
 # ONCE YOU HAVE STARTED THE INSTANCE, DO NOT CHANGE THE
@@ -40,53 +40,53 @@ url: http://localhost
 #   ┌───────────────────────┐
 #───┘ Port and TLS settings └───────────────────────────────────
 
-# UDS スタックでは TCP listen は使わないので `port` を意図的に省略する
-# (両方設定すると "both socket and port are set" の warning が起動毎
-# に出る)。下の `socket` で UDS listen に切り替える。
+# UDSスタックではTCP listenは使わないので `port` を意図的に省略する
+# (両方設定すると "both socket and port are set" のwarningが起動毎
+# に出る)。下の `socket` でUDS listenに切り替える。
 #port: 3000
 
-# HTTP listen を UNIX domain socket にする (Phase 12-1 で入った経路)。
-# nginx コンテナが同じ named volume (mkgo_sock) を /run/mkgo に mount
-# して、この socket を upstream 先にする。
+# HTTP listenをUNIX domain socketにする (Phase 12-1で入った経路)。
+# nginxコンテナが同じnamed volume (mkgo_sock) を /run/mkgoにmount
+# して、このsocketをupstream先にする。
 socket: /run/mkgo/mkgo.sock
 
-# nginx (alpine image では uid 101, non-root) から読める必要があるので
-# 666 にする。本番運用では nginx と mk-go を同じグループに入れて 660
-# にする方が望ましい。
+# nginx (alpine imageではuid 101, non-root) から読める必要があるので
+# 666にする。本番運用ではnginxとmk-goを同じグループに入れて660に
+# する方が望ましい。
 chmodSocket: "666"
 
 # Proxy trust settings.
 #
-# UDS スタックでは upstream は localhost (UDS の peer なので CIDR で
-# 識別できないが、loopback 同等として扱う)。
+# UDSスタックではupstreamはlocalhost (UDSのpeerなのでCIDRで識別
+# できないが、loopback同等として扱う)。
 #
 #trustProxy:
 #  - '127.0.0.1/32'
 #  - '::1/128'
 
-# Disable HSTS header (default: false). nginx 側で HSTS を付ける場合は
-# ここで mk-go 側を無効化する。
+# Disable HSTS header (default: false). nginx側でHSTSを付ける場合は
+# ここでmk-go側を無効化する。
 #disableHsts: true
 
 # Enable internal IP-based rate limiting (default: true).
-# nginx 側で limit_req を使う場合は false にする。
+# nginx側でlimit_reqを使う場合はfalseにする。
 #enableIpRateLimit: true
 
 #   ┌──────────────────────────┐
 #───┘ PostgreSQL configuration └────────────────────────────────
 
 db:
-  # 絶対パス (/ で始まる) なので Phase 12-1 の IsUnixSocketPath で UDS
-  # と判定される。libpq / pgx は host=<dir> から <dir>/.s.PGSQL.<port>
-  # を組み立てるので、postgres 側が作る socket ファイル名と port を
-  # 一致させる必要がある。
+  # 絶対パス (/で始まる) なのでPhase 12-1のIsUnixSocketPathでUDSと
+  # 判定される。libpq / pgxはhost=<dir>から <dir>/.s.PGSQL.<port>
+  # を組み立てるので、postgres側が作るsocketファイル名とportを一致
+  # させる必要がある。
   host: /var/run/postgresql
   port: 5432
 
   # Database name
   db: mkgo
 
-  # Auth — compose.uds.yaml の POSTGRES_USER / POSTGRES_PASSWORD と
+  # Auth — compose.uds.yamlのPOSTGRES_USER / POSTGRES_PASSWORDと
   # 整合させる。本番運用では強いパスワードに変更すること。
   user: mkgo
   pass: mkgo_dev_pass
@@ -115,11 +115,11 @@ dbReplications: false
 #───┘ Redis configuration └─────────────────────────────────────
 
 redis:
-  # 同じく絶対パスなので go-redis の Network=unix 経路に入る
+  # 同じく絶対パスなのでgo-redisのNetwork=unix経路に入る
   # (internal/core/cache/redis.go)。
   host: /run/valkey/valkey.sock
-  # UDS 接続では port は無視されるが、viper の schema 上 int が期待
-  # されるので 6379 を書いておく (実通信では使われない)。
+  # UDS接続ではportは無視されるが、viperのschema上intが期待される
+  # ので6379を書いておく (実通信では使われない)。
   port: 6379
   #pass: example-pass
   #db: 1


### PR DESCRIPTION
## Summary

#451 で `.config/default.yml.example` / `.config/docker.yml.example` を Misskey 本家 `example.yml` ベースの comprehensive テンプレートに揃えたのと同じ整理を `deploy/uds/config/default.yml.example` にも適用。

## 主な変更点

- **Misskey 本家フォーマット適用**: License header / セクション区切り / コメント網羅 (Initial Setup Password / Port and TLS / DB / Redis / fulltextSearch / Sentry / proxyBypassHosts / 等)
- **mk-go 固有項目を追記**: `jobQueueDriver` / `testMode` / `enablePprof` / `trustProxy` / Pool tuning 系
- **UDS スタック特有の設定はコメント付きで保持**:
  - `socket: /run/mkgo/mkgo.sock` + `chmodSocket: "666"` の意図解説 (nginx alpine の uid 101 から読める必要)
  - `db.host: /var/run/postgresql` (UDS path) の解説 (libpq / pgx の `<dir>/.s.PGSQL.<port>` 組立)
  - `redis.host: /run/valkey/valkey.sock` の解説 (go-redis の `Network=unix` 経路)
  - compose.uds 既定値 (`mkgo` / `mkgo_dev_pass`) との整合維持
- **`port: 3000` を意図的に省略**: socket と両方指定すると "both socket and port are set" の warning が起動毎に出るため。コメント付き `#port: 3000` で明示

## テスト

- smoke test で config parser を通過 (DB 接続は peer auth 失敗で停止するが、それ以前の YAML parse + config resolve は成功)
- 起動時 warning が `mediaProxySecret` のみで、port/socket 警告は出ない

## Closes

Closes #453

## 関連

- 親方針: #451 / PR #452 (config example 整理) と同じスタンスを UDS にも展開

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/shiroha-a/mk/pull/454" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
