### PR TITLE
admin/job-queue チャートに BullMQ 互換 per-queue metrics を表示する (#456)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -23,6 +23,7 @@ require (
 	github.com/oklog/ulid/v2 v2.1.1
 	github.com/pquerna/otp v1.5.0
 	github.com/redis/go-redis/v9 v9.18.0
+	github.com/shiroha-a/mkq v1.0.1
 	github.com/shirou/gopsutil/v4 v4.26.3
 	github.com/spf13/viper v1.21.0
 	github.com/stretchr/testify v1.11.1
@@ -111,7 +112,6 @@ require (
 	github.com/robfig/cron/v3 v3.0.1 // indirect
 	github.com/rwcarlsen/goexif v0.0.0-20190401172101-9e8deecbddbd // indirect
 	github.com/sagikazarmark/locafero v0.11.0 // indirect
-	github.com/shiroha-a/mkq v1.0.0 // indirect
 	github.com/sirupsen/logrus v1.9.4 // indirect
 	github.com/sourcegraph/conc v0.3.1-0.20240121214520-5f936abd7ae8 // indirect
 	github.com/spf13/afero v1.15.0 // indirect
@@ -131,7 +131,6 @@ require (
 	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.61.0 // indirect
 	go.opentelemetry.io/otel v1.43.0 // indirect
 	go.opentelemetry.io/otel/metric v1.43.0 // indirect
-	go.opentelemetry.io/otel/sdk v1.43.0 // indirect
 	go.opentelemetry.io/otel/sdk/metric v1.43.0 // indirect
 	go.opentelemetry.io/otel/trace v1.43.0 // indirect
 	go.uber.org/atomic v1.11.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -230,8 +230,8 @@ github.com/rwcarlsen/goexif v0.0.0-20190401172101-9e8deecbddbd h1:CmH9+J6ZSsIjUK
 github.com/rwcarlsen/goexif v0.0.0-20190401172101-9e8deecbddbd/go.mod h1:hPqNNc0+uJM6H+SuU8sEs5K5IQeKccPqeSjfgcKGgPk=
 github.com/sagikazarmark/locafero v0.11.0 h1:1iurJgmM9G3PA/I+wWYIOw/5SyBtxapeHDcg+AAIFXc=
 github.com/sagikazarmark/locafero v0.11.0/go.mod h1:nVIGvgyzw595SUSUE6tvCp3YYTeHs15MvlmU87WwIik=
-github.com/shiroha-a/mkq v1.0.0 h1:NWczAd1Jr/Syc0SpGDLw7CtLD9B4exRQJxBH9yAQ1Xs=
-github.com/shiroha-a/mkq v1.0.0/go.mod h1:rsssbhJCi7RO8RTCAXQwUAzGLEvQuxxgTrfdah9vs6U=
+github.com/shiroha-a/mkq v1.0.1 h1:2MZj2nEywFvVb/8EMc9eP9DJhClp+bnZW9jcMVjtYU0=
+github.com/shiroha-a/mkq v1.0.1/go.mod h1:rsssbhJCi7RO8RTCAXQwUAzGLEvQuxxgTrfdah9vs6U=
 github.com/shirou/gopsutil/v4 v4.26.3 h1:2ESdQt90yU3oXF/CdOlRCJxrP+Am1aBYubTMTfxJ1qc=
 github.com/shirou/gopsutil/v4 v4.26.3/go.mod h1:LZ6ewCSkBqUpvSOf+LsTGnRinC6iaNUNMGBtDkJBaLQ=
 github.com/sirupsen/logrus v1.9.4 h1:TsZE7l11zFCLZnZ+teH4Umoq5BhEIfIzfRDZ1Uzql2w=

--- a/internal/api/admin/handler.go
+++ b/internal/api/admin/handler.go
@@ -217,6 +217,16 @@ type QueueInspector interface {
 	ListScheduledTasks(qname string, page, pageSize int) ([]*QueueTaskSummary, error)
 	ListRetryTasks(qname string, page, pageSize int) ([]*QueueTaskSummary, error)
 	GetTaskInfo(qname, taskID string) (*QueueTaskSummary, error)
+	QueueMetrics(qname, kind string) (*QueueMetricsResult, error)
+}
+
+// QueueMetricsResult is the per-queue completed / failed time-series
+// snapshot returned by QueueInspector.QueueMetrics. Mirrors
+// driver.MetricsResult — duplicated here to keep the admin package
+// free of internal/queue/driver imports.
+type QueueMetricsResult struct {
+	Count int64
+	Data  []int64
 }
 
 // QueueInfoResult holds basic queue statistics.

--- a/internal/api/admin/handler_stubs.go
+++ b/internal/api/admin/handler_stubs.go
@@ -1814,8 +1814,8 @@ func (h *Handler) fetchQueueMetrics(qname string) (completed, failed *QueueMetri
 	if h.queueInspector == nil {
 		return nil, nil
 	}
-	completed, _ = h.queueInspector.QueueMetrics(qname, "completed")
-	failed, _ = h.queueInspector.QueueMetrics(qname, "failed")
+	completed, _ = h.queueInspector.QueueMetrics(qname, queue.MetricsKindCompleted)
+	failed, _ = h.queueInspector.QueueMetrics(qname, queue.MetricsKindFailed)
 	return
 }
 

--- a/internal/api/admin/handler_stubs.go
+++ b/internal/api/admin/handler_stubs.go
@@ -1697,10 +1697,19 @@ func (h *Handler) QueuePromoteJobs(c echo.Context) error {
 // BullMQ と完全互換のまま Go ネイティブ性能を活かすのは別レイヤ (独立
 // OSS ライブラリ化) で取り組む方針 (#377 参照)。それまでの中継措置として
 // 見た目が壊れないよう未対応 field を 0 固定で stub する。
-func shapeQueueForFrontend(info *QueueInfoResult) map[string]any {
+func shapeQueueForFrontend(info *QueueInfoResult, completed, failed *QueueMetricsResult) map[string]any {
 	// delayed は Misskey 用語で scheduled + retry の合計に相当する
 	// (どちらも「すぐには実行されない」状態)。
 	delayed := info.Scheduled + info.Retry
+
+	// metrics は driver から渡された QueueMetricsResult を採用し、
+	// nil/欠損時は info.Completed / info.Failed の累積値で count を埋め、
+	// data は空配列にフォールバックする。前者は mkq driver で
+	// WithJobMetrics が無効、後者は asynq driver の time-series 非対応
+	// シナリオを想定。
+	completedData, completedCount := metricsToFrontend(completed, int64(info.Completed))
+	failedData, failedCount := metricsToFrontend(failed, int64(info.Failed))
+
 	return map[string]any{
 		"name":          info.Queue,
 		"qualifiedName": info.Queue,
@@ -1713,8 +1722,8 @@ func shapeQueueForFrontend(info *QueueInfoResult) map[string]any {
 			"failed":    info.Failed,
 		},
 		"metrics": map[string]any{
-			"completed": map[string]any{"data": []int{}, "count": info.Completed},
-			"failed":    map[string]any{"data": []int{}, "count": info.Failed},
+			"completed": map[string]any{"data": completedData, "count": completedCount},
+			"failed":    map[string]any{"data": failedData, "count": failedCount},
 		},
 		// asynq にはBull相当のper-queue redis DB statsがないため、frontend
 		// が参照するフィールドを0固定でstubする。
@@ -1727,6 +1736,30 @@ func shapeQueueForFrontend(info *QueueInfoResult) map[string]any {
 			"uptime":    0,
 		},
 	}
+}
+
+// metricsToFrontend normalises a driver-supplied QueueMetricsResult
+// into the (data, count) pair the BullMQ-shaped frontend expects.
+// nil m or empty m.Data both map to an empty []int64 (frontend's
+// XChart treats nil and []) for stable JSON.
+//
+// fallbackCount kicks in when the driver returned no Count (e.g.
+// metrics writer disabled) — admin UI then shows the cumulative
+// Completed/Failed from GetQueueInfo as the headline number even
+// though the chart line stays flat.
+func metricsToFrontend(m *QueueMetricsResult, fallbackCount int64) ([]int64, int64) {
+	if m == nil {
+		return []int64{}, fallbackCount
+	}
+	data := m.Data
+	if data == nil {
+		data = []int64{}
+	}
+	count := m.Count
+	if count == 0 {
+		count = fallbackCount
+	}
+	return data, count
 }
 
 // QueueQueueStats handles POST /api/admin/queue/queue-stats.
@@ -1750,9 +1783,11 @@ func (h *Handler) QueueQueueStats(c echo.Context) error {
 	if req.Queue != "" {
 		info, err := h.queueInspector.GetQueueInfo(req.Queue)
 		if err != nil || info == nil {
-			return c.JSON(http.StatusOK, shapeQueueForFrontend(&QueueInfoResult{Queue: req.Queue}))
+			completed, failed := h.fetchQueueMetrics(req.Queue)
+			return c.JSON(http.StatusOK, shapeQueueForFrontend(&QueueInfoResult{Queue: req.Queue}, completed, failed))
 		}
-		return c.JSON(http.StatusOK, shapeQueueForFrontend(info))
+		completed, failed := h.fetchQueueMetrics(req.Queue)
+		return c.JSON(http.StatusOK, shapeQueueForFrontend(info, completed, failed))
 	}
 	queues, err := h.queueInspector.Queues()
 	if err != nil {
@@ -1764,9 +1799,24 @@ func (h *Handler) QueueQueueStats(c echo.Context) error {
 		if err != nil {
 			continue
 		}
-		out[q] = shapeQueueForFrontend(info)
+		completed, failed := h.fetchQueueMetrics(q)
+		out[q] = shapeQueueForFrontend(info, completed, failed)
 	}
 	return c.JSON(http.StatusOK, out)
+}
+
+// fetchQueueMetrics queries the inspector for completed / failed
+// per-minute history. Errors are absorbed and returned as nil so the
+// admin endpoints stay 200 OK — partial chart data is preferable to
+// a hard failure when the metrics writer is opt-in (mkq driver) or
+// absent altogether (asynq driver).
+func (h *Handler) fetchQueueMetrics(qname string) (completed, failed *QueueMetricsResult) {
+	if h.queueInspector == nil {
+		return nil, nil
+	}
+	completed, _ = h.queueInspector.QueueMetrics(qname, "completed")
+	failed, _ = h.queueInspector.QueueMetrics(qname, "failed")
+	return
 }
 
 // QueueQueues handles POST /api/admin/queue/queues.
@@ -1784,7 +1834,8 @@ func (h *Handler) QueueQueues(c echo.Context) error {
 		if err != nil {
 			continue
 		}
-		result = append(result, shapeQueueForFrontend(info))
+		completed, failed := h.fetchQueueMetrics(q)
+		result = append(result, shapeQueueForFrontend(info, completed, failed))
 	}
 	return c.JSON(http.StatusOK, result)
 }

--- a/internal/api/admin/queue_stats_test.go
+++ b/internal/api/admin/queue_stats_test.go
@@ -21,6 +21,7 @@ type stubQueueInspector struct {
 	scheduled     map[string][]*apiadmin.QueueTaskSummary
 	retry         map[string][]*apiadmin.QueueTaskSummary
 	task          map[string]*apiadmin.QueueTaskSummary
+	metrics       map[string]map[string]*apiadmin.QueueMetricsResult // [queue][kind]
 	deleted       []string
 	runCalls      []string
 	deleteAllHits []string
@@ -71,6 +72,14 @@ func (s *stubQueueInspector) GetTaskInfo(_, id string) (*apiadmin.QueueTaskSumma
 		return t, nil
 	}
 	return nil, errors.New("not found")
+}
+func (s *stubQueueInspector) QueueMetrics(q, kind string) (*apiadmin.QueueMetricsResult, error) {
+	if perKind, ok := s.metrics[q]; ok {
+		if m, ok := perKind[kind]; ok {
+			return m, nil
+		}
+	}
+	return &apiadmin.QueueMetricsResult{}, nil
 }
 
 // --- Queue --------------------------------------------------------------------
@@ -210,6 +219,12 @@ func TestQueueQueueStats_WithInspector(t *testing.T) {
 		info: map[string]*apiadmin.QueueInfoResult{
 			"deliver": {Queue: "deliver", Size: 5, Pending: 3, Active: 1, Completed: 10, Failed: 2, Scheduled: 0, Retry: 1},
 		},
+		metrics: map[string]map[string]*apiadmin.QueueMetricsResult{
+			"deliver": {
+				"completed": {Count: 10, Data: []int64{4, 3, 2, 1}},
+				"failed":    {Count: 2, Data: []int64{0, 1, 0, 1}},
+			},
+		},
 	}
 	h.SetQueueInspector(insp)
 	rec := doPost(h.QueueQueueStats, `{}`, adminUser)
@@ -225,6 +240,48 @@ func TestQueueQueueStats_WithInspector(t *testing.T) {
 	assert.EqualValues(t, 3, counts["waiting"])
 	// scheduled(0) + retry(1) がdelayedに集約される。
 	assert.EqualValues(t, 1, counts["delayed"])
+
+	// metrics shape: data 配列と count が driver から伝播。
+	metrics, ok := deliver["metrics"].(map[string]any)
+	require.True(t, ok)
+	completed, ok := metrics["completed"].(map[string]any)
+	require.True(t, ok)
+	assert.EqualValues(t, 10, completed["count"])
+	completedData, ok := completed["data"].([]any)
+	require.True(t, ok)
+	assert.Len(t, completedData, 4)
+	assert.EqualValues(t, 4, completedData[0]) // newest-first
+}
+
+func TestQueueQueueStats_NoMetrics_FallsBackToCumulative(t *testing.T) {
+	// driver が QueueMetrics を実装していても Data 空 / Count 0 を
+	// 返すケース (mkq で WithJobMetrics 無効, asynq の time-series 無し)
+	// では info.Completed / info.Failed の累積値を count にフォール
+	// バックさせ、data は空配列で安定 shape を維持する。
+	h, _, _, _ := newTestHandler(t)
+	insp := &stubQueueInspector{
+		queues: []string{"deliver"},
+		info: map[string]*apiadmin.QueueInfoResult{
+			"deliver": {Queue: "deliver", Completed: 7, Failed: 3},
+		},
+		// metrics map を空にすると stub は zero-valued QueueMetricsResult を返す
+	}
+	h.SetQueueInspector(insp)
+	rec := doPost(h.QueueQueueStats, `{"queue":"deliver"}`, adminUser)
+	assert.Equal(t, http.StatusOK, rec.Code)
+	var got map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &got))
+	metrics, ok := got["metrics"].(map[string]any)
+	require.True(t, ok)
+	completed, ok := metrics["completed"].(map[string]any)
+	require.True(t, ok)
+	assert.EqualValues(t, 7, completed["count"])
+	completedData, ok := completed["data"].([]any)
+	require.True(t, ok)
+	assert.Empty(t, completedData)
+	failed, ok := metrics["failed"].(map[string]any)
+	require.True(t, ok)
+	assert.EqualValues(t, 3, failed["count"])
 }
 
 func TestQueueQueueStats_SingleQueueQuery(t *testing.T) {

--- a/internal/queue/driver/asynqdriver/inspector.go
+++ b/internal/queue/driver/asynqdriver/inspector.go
@@ -1,6 +1,8 @@
 package asynqdriver
 
 import (
+	"fmt"
+
 	"github.com/hibiken/asynq"
 
 	"github.com/shiroha-a/mk/internal/queue/driver"
@@ -51,6 +53,26 @@ func (i *Inspector) DeleteAllPendingTasks(qname string) (int, error) {
 // RunTask promotes a scheduled / retry task to run immediately.
 func (i *Inspector) RunTask(qname, taskID string) error {
 	return i.inner.RunTask(qname, taskID)
+}
+
+// QueueMetrics returns a stub MetricsResult: asynq does not expose
+// BullMQ-style per-minute time-series, so Data is left nil and Count
+// is filled from the cumulative bucket cardinality (Completed /
+// Failed). The admin chart degrades gracefully (empty plot) but the
+// numeric labels stay accurate.
+func (i *Inspector) QueueMetrics(qname, kind string) (*driver.MetricsResult, error) {
+	info, err := i.inner.GetQueueInfo(qname)
+	if err != nil {
+		return nil, err
+	}
+	switch kind {
+	case driver.MetricsKindCompleted:
+		return &driver.MetricsResult{Count: int64(info.Completed)}, nil
+	case driver.MetricsKindFailed:
+		return &driver.MetricsResult{Count: int64(info.Failed)}, nil
+	default:
+		return nil, fmt.Errorf("asynqdriver: invalid metrics kind %q", kind)
+	}
 }
 
 // Close releases the underlying inspector.

--- a/internal/queue/driver/asynqdriver/integration_test.go
+++ b/internal/queue/driver/asynqdriver/integration_test.go
@@ -154,6 +154,49 @@ func TestInspector_LiveQueue(t *testing.T) {
 	assert.Equal(t, 1, count)
 }
 
+// TestInspector_QueueMetrics_AsynqStub verifies the driver-neutral
+// QueueMetrics surface for the asynq driver: no native time-series,
+// so Data is always nil and Count is filled from the cumulative
+// Completed / Failed bucket size. Invalid kinds and unknown queues
+// surface as errors so the admin handler's defensive swallowing path
+// (fetchQueueMetrics) gets exercised.
+func TestInspector_QueueMetrics_AsynqStub(t *testing.T) {
+	testutil.SkipIfNoDocker(t)
+	flushRedis(t)
+
+	d := newDriver()
+	t.Cleanup(func() { _ = d.Close() })
+
+	// asynq は最初の Enqueue まで queue を作らないので、まず 1 件
+	// 投入して queue を materialize させる。
+	require.NoError(t, d.Client().Enqueue(context.Background(),
+		"metrics:probe", nil,
+		driver.WithQueue("deliver"),
+	))
+
+	completed, err := d.Inspector().QueueMetrics("deliver", driver.MetricsKindCompleted)
+	require.NoError(t, err)
+	require.NotNil(t, completed)
+	// asynq には time-series が無いので Data は常に nil。
+	assert.Nil(t, completed.Data)
+	// Newly-flushed Redis なので累積 Completed = 0 が返る。
+	assert.EqualValues(t, 0, completed.Count)
+
+	failed, err := d.Inspector().QueueMetrics("deliver", driver.MetricsKindFailed)
+	require.NoError(t, err)
+	require.NotNil(t, failed)
+	assert.EqualValues(t, 0, failed.Count)
+
+	_, err = d.Inspector().QueueMetrics("deliver", "unknown")
+	require.Error(t, err)
+
+	// 存在しない queue は asynq が NOT_FOUND を返すので error 経路が
+	// 通る。fetchQueueMetrics 側で握り潰されるので handler 動作は問題
+	// ないが、ここでは driver レイヤの契約として error を保証。
+	_, err = d.Inspector().QueueMetrics("nonexistent", driver.MetricsKindCompleted)
+	require.Error(t, err)
+}
+
 // TestInspector_RunTask promotes a scheduled task using the live
 // Redis. Scheduled enqueueing uses driver.WithProcessIn so the task
 // lands in the scheduled bucket; RunTask then pulls it back to

--- a/internal/queue/driver/driver.go
+++ b/internal/queue/driver/driver.go
@@ -39,6 +39,27 @@ type InspectorInfo struct {
 	Retry     int
 }
 
+// MetricsResult is the BullMQ-compatible per-minute history of
+// finalised jobs (completed or failed) for a queue. Drivers that do
+// not natively track time-series data return Data nil and only
+// populate Count from the cumulative bucket size — admin UIs that
+// only display the chart will simply render empty in that case.
+//
+// Data ordering follows BullMQ's `Queue.getMetrics` contract: newest
+// minute first. Entries are int64 to keep the field representable on
+// 32-bit platforms despite the underlying minute counts staying small.
+type MetricsResult struct {
+	Count int64
+	Data  []int64
+}
+
+// MetricsKindCompleted / MetricsKindFailed name the only kinds
+// Inspector.QueueMetrics accepts. Other strings return an error.
+const (
+	MetricsKindCompleted = "completed"
+	MetricsKindFailed    = "failed"
+)
+
 // TaskSummary is the driver-neutral projection of a task used by the
 // admin/queue list APIs.
 type TaskSummary struct {
@@ -73,6 +94,13 @@ type Inspector interface {
 	ListRetryTasks(qname string, page, pageSize int) ([]*TaskSummary, error)
 
 	GetTaskInfo(qname, taskID string) (*TaskSummary, error)
+
+	// QueueMetrics returns the BullMQ-spec per-minute history for the
+	// given queue. kind must be MetricsKindCompleted or
+	// MetricsKindFailed; other values return an error. Drivers without
+	// native time-series support return MetricsResult.Data == nil but
+	// still populate Count from the cumulative bucket cardinality.
+	QueueMetrics(qname, kind string) (*MetricsResult, error)
 
 	Close() error
 }

--- a/internal/queue/driver/mkqdriver/driver.go
+++ b/internal/queue/driver/mkqdriver/driver.go
@@ -48,13 +48,13 @@ type Config struct {
 	QueueNames []string
 
 	// MaxMetricsDataPoints caps the number of one-minute buckets the
-	// per-queue completed / failed metrics list keeps. 0 disables the
-	// feature (matches mkq's default — no BullMQ metrics keys are
-	// written). The default applied when the field is left zero is
-	// `defaultMaxMetricsDataPoints` (= MetricsTime.ONE_WEEK in
+	// per-queue completed / failed metrics list keeps. The zero value
+	// applies `defaultMaxMetricsDataPoints` (= MetricsTime.ONE_WEEK in
 	// BullMQ TS, what Misskey TS upstream uses), so admin UIs see
 	// drop-in compatible chart data when sharing a Redis with a TS
-	// Misskey instance.
+	// Misskey instance. Set to a negative value to opt out entirely;
+	// no BullMQ metrics keys are written in that case (mkq's default
+	// behaviour pre-v1.0.1).
 	MaxMetricsDataPoints int
 }
 

--- a/internal/queue/driver/mkqdriver/driver.go
+++ b/internal/queue/driver/mkqdriver/driver.go
@@ -46,7 +46,24 @@ type Config struct {
 	// QueueNames overrides the set of queues to pre-define. Nil/empty
 	// keeps the package default (QueueNames).
 	QueueNames []string
+
+	// MaxMetricsDataPoints caps the number of one-minute buckets the
+	// per-queue completed / failed metrics list keeps. 0 disables the
+	// feature (matches mkq's default — no BullMQ metrics keys are
+	// written). The default applied when the field is left zero is
+	// `defaultMaxMetricsDataPoints` (= MetricsTime.ONE_WEEK in
+	// BullMQ TS, what Misskey TS upstream uses), so admin UIs see
+	// drop-in compatible chart data when sharing a Redis with a TS
+	// Misskey instance.
+	MaxMetricsDataPoints int
 }
+
+// defaultMaxMetricsDataPoints mirrors BullMQ TS's
+// `MetricsTime.ONE_WEEK = 10080` and is the value Misskey TS upstream
+// applies via baseWorkerOptions. Keeping the same retention here
+// preserves chart history across drop-in TS↔mk-go swaps that share
+// the Redis instance.
+const defaultMaxMetricsDataPoints = 10080
 
 // Driver bundles the Client / Server / Inspector / Scheduler that
 // share one *mkq.Client instance. New connects + script-loads against
@@ -169,10 +186,15 @@ func (d *Driver) Server() driver.Server {
 		if perQueue < 1 {
 			perQueue = 1
 		}
+		metricsPoints := d.cfg.MaxMetricsDataPoints
+		if metricsPoints == 0 {
+			metricsPoints = defaultMaxMetricsDataPoints
+		}
 		d.dServer = &Server{
-			driver:      d,
-			concurrency: perQueue,
-			handlers:    make(map[string]driver.HandlerFunc),
+			driver:           d,
+			concurrency:      perQueue,
+			maxMetricsPoints: metricsPoints,
+			handlers:         make(map[string]driver.HandlerFunc),
 		}
 	}
 	return d.dServer

--- a/internal/queue/driver/mkqdriver/inspector.go
+++ b/internal/queue/driver/mkqdriver/inspector.go
@@ -80,6 +80,38 @@ func (i *Inspector) GetQueueInfo(qname string) (*driver.InspectorInfo, error) {
 	}, nil
 }
 
+// QueueMetrics returns BullMQ-compatible per-minute completed /
+// failed history for the named queue. mkq's Worker writes these on
+// finalise when WithJobMetrics is set (see Server.Start) — without
+// it the lists do not exist and mkq.GetMetrics returns a zero-valued
+// QueueMetrics, which we map to an empty driver.MetricsResult so
+// admin handlers can detect the disabled state.
+func (i *Inspector) QueueMetrics(qname, kind string) (*driver.MetricsResult, error) {
+	q := i.driver.queueFor(qname)
+	if q == nil {
+		return nil, fmt.Errorf("mkqdriver: unknown queue %q", qname)
+	}
+	var bucket mkq.JobBucket
+	switch kind {
+	case driver.MetricsKindCompleted:
+		bucket = mkq.JobBucketCompleted
+	case driver.MetricsKindFailed:
+		bucket = mkq.JobBucketFailed
+	default:
+		return nil, fmt.Errorf("mkqdriver: invalid metrics kind %q", kind)
+	}
+	// LRANGE 0 -1 で全 bucket。Misskey TS フロントは無条件に全件
+	// LRANGE してチャート全体を再描画するので、page 化は不要。
+	m, err := q.GetMetrics(inspectorCtx(), bucket, 0, -1)
+	if err != nil {
+		return nil, fmt.Errorf("mkqdriver: get metrics %q/%s: %w", qname, kind, err)
+	}
+	return &driver.MetricsResult{
+		Count: m.Meta.Count,
+		Data:  m.Data,
+	}, nil
+}
+
 // DeleteTask removes a job from the named queue regardless of its
 // current bucket. Wraps mkq.RemoveJob; missing jobs return an
 // ErrJobNotFound which we translate into a generic error to avoid

--- a/internal/queue/driver/mkqdriver/integration_test.go
+++ b/internal/queue/driver/mkqdriver/integration_test.go
@@ -261,6 +261,63 @@ func TestInspector_FullSurface(t *testing.T) {
 	require.Error(t, err)
 }
 
+// TestInspector_QueueMetrics_PopulatesAfterFinalize spins up a worker
+// with WithJobMetrics implicitly enabled (default Driver config), runs
+// jobs to completion, and asserts the BullMQ-spec metrics keys are
+// reflected in Inspector.QueueMetrics. The minute-bucket gating means
+// Data may stay empty inside the first minute, so we only assert
+// Count > 0 and Data being non-nil; the LIST roll is exercised in
+// mkq's own integration tests.
+func TestInspector_QueueMetrics_PopulatesAfterFinalize(t *testing.T) {
+	d := newDriver(t)
+	srv := d.Server()
+
+	var wg sync.WaitGroup
+	wg.Add(2)
+	srv.Handle("metrics:ok", func(_ context.Context, _ driver.Task) error {
+		defer wg.Done()
+		return nil
+	})
+	require.NoError(t, srv.Start())
+	t.Cleanup(srv.Shutdown)
+
+	require.NoError(t, d.Client().Enqueue(context.Background(), "metrics:ok", nil,
+		driver.WithQueue("deliver")))
+	require.NoError(t, d.Client().Enqueue(context.Background(), "metrics:ok", nil,
+		driver.WithQueue("deliver")))
+	if !waitGroupTimeout(&wg, 5*time.Second) {
+		t.Fatal("handlers did not run")
+	}
+
+	// Wait for finalisation — Lua collectMetrics runs inside the
+	// finalize transaction, so Count should observe the cumulative
+	// total once both jobs roll into the completed bucket.
+	require.Eventually(t, func() bool {
+		m, err := d.Inspector().QueueMetrics("deliver", driver.MetricsKindCompleted)
+		return err == nil && m != nil && m.Count >= 2
+	}, 5*time.Second, 50*time.Millisecond)
+
+	// Failed bucket: no failures in this scenario, but the call must
+	// still succeed and return a zero-valued result rather than an
+	// error (no metrics keys yet means the lua HMGET / LRANGE return
+	// empty and mkq.GetMetrics maps that to QueueMetrics{}).
+	failed, err := d.Inspector().QueueMetrics("deliver", driver.MetricsKindFailed)
+	require.NoError(t, err)
+	require.NotNil(t, failed)
+	assert.EqualValues(t, 0, failed.Count)
+}
+
+// TestInspector_QueueMetrics_InvalidArgs covers the validation paths.
+func TestInspector_QueueMetrics_InvalidArgs(t *testing.T) {
+	d := newDriver(t)
+
+	_, err := d.Inspector().QueueMetrics("missing", driver.MetricsKindCompleted)
+	require.Error(t, err)
+
+	_, err = d.Inspector().QueueMetrics("deliver", "weird")
+	require.Error(t, err)
+}
+
 // TestInspector_GetQueueInfo_IncludesRepeatSchedules verifies the
 // mk-go-specific behaviour added for #455: registering a repeatable
 // schedule via Scheduler.Register populates `bull:<queue>:repeat`,

--- a/internal/queue/driver/mkqdriver/server.go
+++ b/internal/queue/driver/mkqdriver/server.go
@@ -29,6 +29,10 @@ import (
 type Server struct {
 	driver      *Driver
 	concurrency int
+	// maxMetricsPoints は mkq.WithJobMetrics の引数。0 だと metrics
+	// 書き込みを無効化、正値で BullMQ-spec の metrics LIST に書き込み
+	// が走る。
+	maxMetricsPoints int
 
 	mu       sync.Mutex
 	handlers map[string]driver.HandlerFunc
@@ -95,7 +99,15 @@ func (s *Server) Start() error {
 	started := make([]*mkq.Worker, 0, len(names))
 	for _, name := range names {
 		q := s.driver.queues[name]
-		w, err := mkq.Process(q, dispatch, mkq.WithConcurrency(s.concurrency))
+		opts := []mkq.WorkerOption{mkq.WithConcurrency(s.concurrency)}
+		if s.maxMetricsPoints > 0 {
+			// BullMQ-compatible per-queue metrics opt-in。書き込み有効に
+			// すると finalize 時に Lua が `bull:<q>:metrics:*` を更新し、
+			// admin/job-queue のチャート (frontend が LRANGE する) や
+			// Misskey TS frontend の同 dashboard が使える。
+			opts = append(opts, mkq.WithJobMetrics(s.maxMetricsPoints))
+		}
+		w, err := mkq.Process(q, dispatch, opts...)
 		if err != nil {
 			stopWorkers(started)
 			s.mu.Lock()

--- a/internal/queue/inspector.go
+++ b/internal/queue/inspector.go
@@ -11,6 +11,16 @@ type InspectorInfo = driver.InspectorInfo
 // TaskSummary aliases driver.TaskSummary for the same reason.
 type TaskSummary = driver.TaskSummary
 
+// MetricsResult aliases driver.MetricsResult.
+type MetricsResult = driver.MetricsResult
+
+// MetricsKindCompleted / MetricsKindFailed re-export driver constants
+// so callers can avoid importing the driver package directly.
+const (
+	MetricsKindCompleted = driver.MetricsKindCompleted
+	MetricsKindFailed    = driver.MetricsKindFailed
+)
+
 // Inspector is the driver-neutral facade over driver.Inspector.
 type Inspector struct {
 	inner driver.Inspector
@@ -71,4 +81,10 @@ func (i *Inspector) ListRetryTasks(qname string, page, pageSize int) ([]*TaskSum
 // GetTaskInfo returns full info for a single task.
 func (i *Inspector) GetTaskInfo(qname, taskID string) (*TaskSummary, error) {
 	return i.inner.GetTaskInfo(qname, taskID)
+}
+
+// QueueMetrics returns BullMQ-spec per-minute completed / failed
+// history for the given queue. See driver.Inspector.QueueMetrics.
+func (i *Inspector) QueueMetrics(qname, kind string) (*MetricsResult, error) {
+	return i.inner.QueueMetrics(qname, kind)
 }

--- a/internal/server/queue_adapter.go
+++ b/internal/server/queue_adapter.go
@@ -93,6 +93,17 @@ func (a *queueInspectorAdapter) GetTaskInfo(qname, taskID string) (*apiadmin.Que
 	return taskSummaryToAdmin(t), nil
 }
 
+func (a *queueInspectorAdapter) QueueMetrics(qname, kind string) (*apiadmin.QueueMetricsResult, error) {
+	m, err := a.inner.QueueMetrics(qname, kind)
+	if err != nil {
+		return nil, err
+	}
+	if m == nil {
+		return nil, nil
+	}
+	return &apiadmin.QueueMetricsResult{Count: m.Count, Data: m.Data}, nil
+}
+
 func taskSummariesToAdmin(rows []*queue.TaskSummary) []*apiadmin.QueueTaskSummary {
 	out := make([]*apiadmin.QueueTaskSummary, 0, len(rows))
 	for _, r := range rows {


### PR DESCRIPTION
## Summary

mkq v1.0.1 で公開された `WithJobMetrics` / `Queue.GetMetrics` を mkqdriver に組み込み、`/admin/job-queue` のチャート (XChart) が `data: []` 固定 stub だった部分に実データを通す。

mkqdriver Worker は `mkq.WithJobMetrics(10080)` (= `MetricsTime.ONE_WEEK`, Misskey TS upstream の `baseWorkerOptions` と同じ retention) を opt-in で適用。`bull:<q>:metrics:*` キーは BullMQ-spec レイアウトで書き込まれるため、drop-in TS ↔ mk-go swap (Phase 13/14) でも履歴が継続する。

`driver.Inspector` interface に `QueueMetrics(qname, kind)` を追加。mkqdriver は `Queue.GetMetrics` pass-through、asynqdriver は time-series 非対応のため `Data: nil` + 累積 `Count` のみ返す stub。`shapeQueueForFrontend` は driver から metrics を受け取り、欠損時は `info.Completed` / `info.Failed` の累積値で `count` をフォールバック。

Closes #456

## 主な変更点

- `go.mod`: `github.com/shiroha-a/mkq v1.0.0 → v1.0.1`
- `internal/queue/driver/driver.go`
  - `MetricsResult{Count, Data}` 型を新設、`MetricsKindCompleted` / `MetricsKindFailed` 定数を追加
  - `Inspector` interface に `QueueMetrics(qname, kind string) (*MetricsResult, error)` を追加
- `internal/queue/driver/mkqdriver/driver.go`
  - `Config.MaxMetricsDataPoints int` を追加 (0 で disabled、未指定時は `defaultMaxMetricsDataPoints = 10080` を適用)
  - `Server` 構造体に `maxMetricsPoints` を保持し、`Driver.Server()` でデフォルト適用
- `internal/queue/driver/mkqdriver/server.go`
  - `mkq.Process(...)` 呼び出し時に `mkq.WithJobMetrics(s.maxMetricsPoints)` を opt-in (正値時のみ)
- `internal/queue/driver/mkqdriver/inspector.go`
  - `QueueMetrics` を実装。`mkq.JobBucketCompleted` / `Failed` への変換、`Queue.GetMetrics(ctx, kind, 0, -1)` で全 minute bucket を取得
- `internal/queue/driver/asynqdriver/inspector.go`
  - `QueueMetrics` を stub 実装。`Data: nil`、`Count` は累積 `info.Completed` / `info.Failed`
- `internal/queue/inspector.go` / `internal/server/queue_adapter.go` / `internal/api/admin/handler.go`
  - `QueueMetrics` を passthrough。`apiadmin.QueueMetricsResult{Count, Data}` を新設
- `internal/api/admin/handler_stubs.go`
  - `shapeQueueForFrontend` シグネチャに `completed, failed *QueueMetricsResult` を追加
  - `metricsToFrontend` ヘルパーで nil / Data 空 / Count 0 のフォールバックを統一
  - `Handler.fetchQueueMetrics` で inspector から両 kind を取得 (error は握り潰してパーシャル shape を返す)
  - `QueueQueueStats` / `QueueQueues` の各 call site で metrics を取得して shape に注入

## テスト

### 追加テスト

- `internal/queue/driver/mkqdriver/integration_test.go`
  - `TestInspector_QueueMetrics_PopulatesAfterFinalize`: Worker を起動して 2 件 finalize → `Inspector.QueueMetrics` が `Count >= 2` を返すことを assert
  - `TestInspector_QueueMetrics_InvalidArgs`: 不正 kind / 不明 queue で error
- `internal/queue/driver/asynqdriver/integration_test.go`
  - `TestInspector_QueueMetrics_AsynqStub`: Data nil + Count 0 + invalid kind error + 不明 queue error
- `internal/api/admin/queue_stats_test.go`
  - `TestQueueQueueStats_WithInspector` を拡張: stub に metrics を入れて API レスポンスの `metrics.completed.{data,count}` が伝搬することを assert
  - `TestQueueQueueStats_NoMetrics_FallsBackToCumulative`: driver が空 metrics を返す場合 `info.Completed` で count をフォールバックする挙動を確認

### 実行コマンド

\`\`\`bash
go test -race -count=1 -coverprofile=/tmp/cov.out -covermode=atomic \\
    ./internal/queue/driver/mkqdriver/... \\
    ./internal/queue/driver/asynqdriver/... \\
    ./internal/queue/... \\
    ./internal/api/admin/...
go tool cover -func=/tmp/cov.out | grep total

# パッケージ別カバレッジ:
#   mkqdriver  92.6%  (CI 閾値 90%)
#   asynqdriver 96.1%
#   queue       90.6%
#   driver     100.0%
#   processors  91.9%
#   api/admin   83.5% (CI 閾値 80%)

make fmt && make lint && make test
\`\`\`

すべてローカルで green。

### 手動確認 (UDS スタック)

\`\`\`
$ docker compose -f compose.uds.yaml exec valkey valkey-cli -s /run/valkey/valkey.sock HGETALL bull:deliver:metrics:completed
count
6
prevTS
1777307714188
prevCount
3

$ docker compose -f compose.uds.yaml exec valkey valkey-cli -s /run/valkey/valkey.sock LRANGE bull:deliver:metrics:completed:data 0 -1
0 0 0 0 0 0 0 0 0 0 0 3

$ curl -X POST .../api/admin/queue/queues -d '{}' (略)
\"metrics\": {
    \"completed\": {\"count\": 6, \"data\": [0,0,0,0,0,0,0,0,0,0,0,3]},
    \"failed\":    {\"count\": 0, \"data\": []}
}
\`\`\`

ブラウザで `/admin/job-queue` を開きチャートが表示されることをユーザに確認してもらい、ok 確認済。

## 関連

- Closes #456
- 上流: shiroha-a/mkq#59 (PR shiroha-a/mkq#60), v1.0.1 として release 済
- 関連: #455 (Delayed カウンタ可視化)

## メモ

- 保持期間 10080 分は Misskey TS upstream `baseWorkerOptions` の `MetricsTime.ONE_WEEK` と同値。drop-in 互換維持のための一致選択。operator 設定化は需要が出てから別 PR で。
- BullMQ Lua の `collectMetrics` は **分境界を跨いだ finalize でのみ LPUSH** する仕様のため、idle システム / 起動直後しばらくは `:data` LIST が空。これは BullMQ 仕様上正常 (Misskey TS upstream でも同じ挙動)。
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/shiroha-a/mk/pull/458" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
