### PR TITLE
Fix federation reactions: AP Like の custom emoji を正しく解決する (#459)

### DIFF
--- a/internal/activitypub/types.go
+++ b/internal/activitypub/types.go
@@ -244,6 +244,10 @@ type Like struct {
 	Object          string `json:"object"`                      // target note URI
 	Content         string `json:"content,omitempty"`           // reaction emoji (standard)
 	MisskeyReaction string `json:"_misskey_reaction,omitempty"` // Misskey拡張: contentより優先
+	// Tag は Misskey/CherryPick がカスタム絵文字リアクションを連合させる
+	// 際に乗せる Emoji オブジェクト群。Note ingestion と同じ形なので
+	// federation.extractEmojiTags / upsertEmojis でそのまま処理できる。
+	Tag []any `json:"tag,omitempty"`
 }
 
 // Tombstone represents a deleted object placeholder used as the object of a

--- a/internal/core/federation/processor.go
+++ b/internal/core/federation/processor.go
@@ -683,7 +683,7 @@ func (p *Processor) handleLike(act genericActivity) error {
 	// upsert する。Misskey TS の apNoteService.extractEmojis(...) 相当
 	// (#459)。reactionService.Create 自体は emoji 不在でも reaction 文字列
 	// を保存できるので、upsert 失敗で Create を止める必要はなく、UI 表示
-	// 側の reactionEmojis 解決が ❤️ フォールバックするだけにとどめる。
+	// 側の reactionEmojis 解決が FallbackReaction (heart) に落ちる程度。
 	if reactor.Host != nil && len(like.Tag) > 0 {
 		p.resolver.upsertEmojis(extractEmojiTags(like.Tag), *reactor.Host)
 	}

--- a/internal/core/federation/processor.go
+++ b/internal/core/federation/processor.go
@@ -679,6 +679,14 @@ func (p *Processor) handleLike(act genericActivity) error {
 	if err != nil {
 		return err
 	}
+	// Like activity に乗ってきたカスタム絵文字メタデータを emoji table に
+	// upsert する。Misskey TS の apNoteService.extractEmojis(...) 相当
+	// (#459)。reactionService.Create 自体は emoji 不在でも reaction 文字列
+	// を保存できるので、upsert 失敗で Create を止める必要はなく、UI 表示
+	// 側の reactionEmojis 解決が ❤️ フォールバックするだけにとどめる。
+	if reactor.Host != nil && len(like.Tag) > 0 {
+		p.resolver.upsertEmojis(extractEmojiTags(like.Tag), *reactor.Host)
+	}
 	if _, err := p.reactionService.Create(reactor, target.ID, reaction); err != nil {
 		if errors.Is(err, corereaction.ErrAlreadyReacted) {
 			return nil

--- a/internal/core/federation/processor_step_f_test.go
+++ b/internal/core/federation/processor_step_f_test.go
@@ -24,6 +24,7 @@ type fullProcessorEnv struct {
 	userRepo     *testutil.MockUserRepository
 	noteRepo     *testutil.MockNoteRepository
 	reactionRepo *testutil.MockNoteReactionRepository
+	emojiRepo    *testutil.MockEmojiRepository
 }
 
 func newFullProcessor(t *testing.T, fetcherBody string) *fullProcessorEnv {
@@ -36,11 +37,12 @@ func newFullProcessor(t *testing.T, fetcherBody string) *fullProcessorEnv {
 	urls := activitypub.NewURLBuilder("https://example.com")
 	idGen, _ := id.NewGenerator("aidx")
 	resolver := federation.NewResolver(userRepo, noteRepo, urls, &stubFetcher{body: []byte(fetcherBody)}, idGen)
+	resolver.SetEmojiRepo(emojiRepo)
 	followingSvc := corefollowing.NewService(userRepo, followingRepo, testutil.NewMockFollowRequestRepository(), idGen)
 	reactionSvc := corereaction.NewService(noteRepo, reactionRepo, emojiRepo, followingRepo, idGen)
 	deleteSvc := corenote.NewDeleteService(noteRepo)
 	p := federation.NewProcessor(resolver, followingSvc, reactionSvc, deleteSvc, userRepo, noteRepo)
-	return &fullProcessorEnv{processor: p, userRepo: userRepo, noteRepo: noteRepo, reactionRepo: reactionRepo}
+	return &fullProcessorEnv{processor: p, userRepo: userRepo, noteRepo: noteRepo, reactionRepo: reactionRepo, emojiRepo: emojiRepo}
 }
 
 const noteCreateBody = `{
@@ -202,6 +204,33 @@ func TestProcess_LikeWithMisskeyReaction(t *testing.T) {
 	for _, r := range env.reactionRepo.Reactions {
 		assert.Equal(t, "😀", r.Reaction)
 	}
+}
+
+func TestProcess_LikeWithCustomEmojiTag(t *testing.T) {
+	// #459: カスタム絵文字リアクションが Tag 付きで届いたら emoji table に
+	// upsert されるべき。Misskey TS の apNoteService.extractEmojis 相当。
+	env := newFullProcessor(t, aliceActor)
+	env.noteRepo.Notes["n1"] = &model.Note{ID: "n1", UserID: "bob", Visibility: model.NoteVisibilityPublic}
+	body := []byte(`{
+		"type": "Like",
+		"actor": "https://remote.example/users/alice",
+		"object": "https://example.com/notes/n1",
+		"_misskey_reaction": ":custom@remote.example:",
+		"tag": [{
+			"type": "Emoji",
+			"id": "https://remote.example/emojis/custom",
+			"name": ":custom:",
+			"icon": {"type": "Image", "url": "https://remote.example/files/custom.png"}
+		}]
+	}`)
+	require.NoError(t, env.processor.Process(body))
+	require.Len(t, env.reactionRepo.Reactions, 1)
+	// emoji table に :custom: が remote.example host で upsert されている
+	host := "remote.example"
+	emojis, err := env.emojiRepo.FindManyByNamesAndHost([]string{"custom"}, &host)
+	require.NoError(t, err)
+	require.Len(t, emojis, 1, "custom emoji should be upserted from Like.tag")
+	assert.Equal(t, "https://remote.example/files/custom.png", emojis[0].OriginalURL)
 }
 
 func TestProcess_LikeEmptyContent(t *testing.T) {

--- a/internal/core/reaction/reaction_service.go
+++ b/internal/core/reaction/reaction_service.go
@@ -190,7 +190,7 @@ func (s *Service) Create(user *model.User, noteID, rawReaction string) (string, 
 		return "", ErrCannotReactToPureRenote
 	}
 
-	reaction := s.normalizeReaction(rawReaction)
+	reaction := s.normalizeReaction(rawReaction, user.Host)
 
 	// 既存リアクションを確認
 	if existing, err := s.reactionRepo.FindByPair(user.ID, target.ID); err == nil {
@@ -277,7 +277,9 @@ func (s *Service) List(user *model.User, noteID, untilID, sinceID string, limit 
 	}
 	var reactions []string
 	if reaction != "" {
-		reactions = reactionVariants(s.normalizeReaction(reaction))
+		// List はローカルクエリ context (filter 用) なので actor host
+		// 補完は不要。nil で従来挙動を維持する。
+		reactions = reactionVariants(s.normalizeReaction(reaction, nil))
 	}
 	return s.reactionRepo.ListByNoteID(target.ID, untilID, sinceID, limit, reactions)
 }
@@ -288,7 +290,13 @@ func (s *Service) List(user *model.User, noteID, untilID, sinceID string, limit 
 //   - カスタム絵文字 ":name:" は絵文字テーブルで存在確認後 ":name@.:" に正規化
 //   - リモート ":name@host:" はそのまま検証して残す
 //   - その他はそのまま (Unicode絵文字想定)
-func (s *Service) normalizeReaction(raw string) string {
+//
+// actorHost は reaction を投稿した側のホスト。リモートユーザーが
+// `:name:` 形式 (ホスト省略) で送ってきたとき、Misskey TS upstream は
+// reactor のホストで emoji table を引き直すので、本実装でも actorHost
+// にフォールバックする (#459)。actorHost が nil/空なら従来通りローカル
+// として扱う。
+func (s *Service) normalizeReaction(raw string, actorHost *string) string {
 	if raw == "" {
 		return FallbackReaction
 	}
@@ -304,6 +312,13 @@ func (s *Service) normalizeReaction(raw string) string {
 		// "@." はローカルを表すcanonical suffix (TS互換)
 		if host == "." {
 			host = ""
+		}
+		// reaction 文字列に @host が含まれず reactor が remote なら、
+		// 文字列 host が省略されているだけで実体はリモート絵文字。
+		// upstream ReactionService.create がやっているのと同じく
+		// actor.host を採用して emoji table を引く。
+		if host == "" && actorHost != nil && *actorHost != "" {
+			host = *actorHost
 		}
 		var hostPtr *string
 		if host != "" {

--- a/internal/core/reaction/reaction_service_test.go
+++ b/internal/core/reaction/reaction_service_test.go
@@ -130,6 +130,21 @@ func TestService_Create_CustomEmojiLocalWithDotHost(t *testing.T) {
 	assert.Equal(t, ":smile@.:", r)
 }
 
+func TestService_Create_CustomEmojiRemoteWithoutHostInString(t *testing.T) {
+	// #459: Misskey TS upstream は :name: 形式 (host 省略) で reaction を
+	// 連合させるが、その emoji は reactor の host に紐付いている。受信側
+	// (mk-go) は文字列 host が空でも actor.host で emoji table を引き
+	// 直し、見つかれば :name@host: に正規化する。
+	svc, repo, _, emojiRepo, _ := newService(t)
+	seedNote(repo, "n1", "author", model.NoteVisibilityPublic)
+	host := "remote.example"
+	emojiRepo.Emojis["smile@remote.example"] = &model.Emoji{Name: "smile", Host: &host}
+
+	r, err := svc.Create(&model.User{ID: "remote-user", Host: &host}, "n1", ":smile:")
+	require.NoError(t, err)
+	assert.Equal(t, ":smile@remote.example:", r, "actor host で emoji を解決して remote canonical 化")
+}
+
 func TestService_Create_CustomEmojiNotFoundFallback(t *testing.T) {
 	svc, repo, _, _, _ := newService(t)
 	seedNote(repo, "n1", "author", model.NoteVisibilityPublic)

--- a/internal/entity/emoji_resolver.go
+++ b/internal/entity/emoji_resolver.go
@@ -9,8 +9,9 @@ import (
 
 // parseCustomEmojiReaction extracts the (name, host) pair from a reaction
 // string. Custom emoji reactions are wrapped in colons (`:smile:` for local
-// or `:smile@remote.example.com:` for remote); raw unicode emoji like ❤️ is
-// returned with ok=false. Local reactions return host="".
+// or `:smile@remote.example.com:` for remote); raw unicode reactions (no
+// surrounding colons, e.g. heart) are returned with ok=false. Local
+// reactions return host="".
 //
 // reaction_service.normalizeReaction が local 絵文字を `:name@.:` 形式 (host
 // を `.` で表す TS 互換 canonical 形式) で永続化するため、parser 側でも `@.`
@@ -163,8 +164,8 @@ func (r *EmojiResolver) PopulateNoteEmojis(note *model.Note, entity *NoteEntity)
 // note.Reactions and populates entity.ReactionEmojis with `key → url`
 // where key matches the frontend's lookup format
 // (`reaction.substring(1, length-1)`): `name` for local custom emoji,
-// `name@host` for remote. Raw unicode reactions (`❤️`, etc.) are
-// skipped — frontend renders them directly without map lookup. (#459)
+// `name@host` for remote. Raw unicode reactions are skipped — frontend
+// renders them directly without map lookup. (#459)
 func (r *EmojiResolver) PopulateNoteReactionEmojis(note *model.Note, entity *NoteEntity) {
 	if r == nil || note == nil || entity == nil || len(note.Reactions) == 0 {
 		return

--- a/internal/entity/emoji_resolver.go
+++ b/internal/entity/emoji_resolver.go
@@ -1,6 +1,35 @@
 package entity
 
-import "github.com/shiroha-a/mk/internal/model"
+import (
+	"encoding/json"
+	"strings"
+
+	"github.com/shiroha-a/mk/internal/model"
+)
+
+// parseCustomEmojiReaction extracts the (name, host) pair from a reaction
+// string. Custom emoji reactions are wrapped in colons (`:smile:` for local
+// or `:smile@remote.example.com:` for remote); raw unicode emoji like ❤️ is
+// returned with ok=false. Local reactions return host="".
+func parseCustomEmojiReaction(s string) (name, host string, ok bool) {
+	if len(s) < 3 || s[0] != ':' || s[len(s)-1] != ':' {
+		return "", "", false
+	}
+	inner := s[1 : len(s)-1]
+	if at := strings.Index(inner, "@"); at >= 0 {
+		return inner[:at], inner[at+1:], true
+	}
+	return inner, "", true
+}
+
+// reactionEmojiKey は frontend の lookup (`reaction.substring(1, length-1)`)
+// と一致するキーを返す。local は "smile"、remote は "smile@host"。
+func reactionEmojiKey(name, host string) string {
+	if host == "" {
+		return name
+	}
+	return name + "@" + host
+}
 
 // EmojiLookup is the minimal interface required to batch-fetch emoji rows
 // for populating UserLite.Emojis and NoteEntity.Emojis. 循環依存を避ける
@@ -52,6 +81,18 @@ func NewEmojiResolver(lookup EmojiLookup, notes []*model.Note) *EmojiResolver {
 		if n.User != nil {
 			addNames(n.User.Emojis, n.User.Host)
 		}
+		// note.Reactions の JSON キーから custom emoji を抽出して
+		// host 別 batch fetch のリストに追加する (#459)。reaction 元の
+		// host は note.UserHost と必ずしも一致しないため、reaction
+		// 文字列内の `@host` を信頼する。
+		for name, host := range collectReactionEmojiNames(n.Reactions) {
+			h := host
+			var hostPtr *string
+			if h != "" {
+				hostPtr = &h
+			}
+			addNames([]string{name}, hostPtr)
+		}
 	}
 	// hostごとにbatch fetch
 	for host, nameSet := range hostNames {
@@ -98,6 +139,51 @@ func (r *EmojiResolver) PopulateNoteEmojis(note *model.Note, entity *NoteEntity)
 	if len(emojis) > 0 {
 		entity.Emojis = emojis
 	}
+}
+
+// PopulateNoteReactionEmojis resolves the custom emoji used inside
+// note.Reactions and populates entity.ReactionEmojis with `key → url`
+// where key matches the frontend's lookup format
+// (`reaction.substring(1, length-1)`): `name` for local custom emoji,
+// `name@host` for remote. Raw unicode reactions (`❤️`, etc.) are
+// skipped — frontend renders them directly without map lookup. (#459)
+func (r *EmojiResolver) PopulateNoteReactionEmojis(note *model.Note, entity *NoteEntity) {
+	if r == nil || note == nil || entity == nil || len(note.Reactions) == 0 {
+		return
+	}
+	out := make(map[string]string)
+	for name, host := range collectReactionEmojiNames(note.Reactions) {
+		if url, ok := r.cache[name+"@"+host]; ok {
+			out[reactionEmojiKey(name, host)] = url
+		}
+	}
+	if len(out) > 0 {
+		entity.ReactionEmojis = out
+	}
+}
+
+// collectReactionEmojiNames decodes the per-note Reactions JSON map and
+// returns custom-emoji entries as a `name → host` map. Raw unicode
+// reactions are filtered out; duplicate (name, host) pairs collapse
+// into a single entry. The returned host is empty for local custom
+// emoji.
+func collectReactionEmojiNames(raw []byte) map[string]string {
+	if len(raw) == 0 {
+		return nil
+	}
+	var counts map[string]int
+	if err := json.Unmarshal(raw, &counts); err != nil {
+		return nil
+	}
+	out := map[string]string{}
+	for reaction := range counts {
+		name, host, ok := parseCustomEmojiReaction(reaction)
+		if !ok {
+			continue
+		}
+		out[name] = host
+	}
+	return out
 }
 
 // PopulateUserEmojis resolves emoji names stored in user.Emojis to URLs

--- a/internal/entity/emoji_resolver.go
+++ b/internal/entity/emoji_resolver.go
@@ -11,15 +11,32 @@ import (
 // string. Custom emoji reactions are wrapped in colons (`:smile:` for local
 // or `:smile@remote.example.com:` for remote); raw unicode emoji like ❤️ is
 // returned with ok=false. Local reactions return host="".
+//
+// reaction_service.normalizeReaction が local 絵文字を `:name@.:` 形式 (host
+// を `.` で表す TS 互換 canonical 形式) で永続化するため、parser 側でも `@.`
+// を空 host に正規化する。これを忘れると DB lookup が host="." vs DB の
+// host IS NULL で空振りし、reactionEmojis が空のままになる。
 func parseCustomEmojiReaction(s string) (name, host string, ok bool) {
 	if len(s) < 3 || s[0] != ':' || s[len(s)-1] != ':' {
 		return "", "", false
 	}
 	inner := s[1 : len(s)-1]
 	if at := strings.Index(inner, "@"); at >= 0 {
-		return inner[:at], inner[at+1:], true
+		host = inner[at+1:]
+		if host == "." {
+			host = ""
+		}
+		return inner[:at], host, true
 	}
 	return inner, "", true
+}
+
+// emojiNameHost is a (name, host) pair preserving distinct hosts when a
+// single note's reactions contain the same emoji name from multiple
+// remote hosts. Keying solely by name would collapse such cases.
+type emojiNameHost struct {
+	name string
+	host string
 }
 
 // reactionEmojiKey は frontend の lookup (`reaction.substring(1, length-1)`)
@@ -84,14 +101,15 @@ func NewEmojiResolver(lookup EmojiLookup, notes []*model.Note) *EmojiResolver {
 		// note.Reactions の JSON キーから custom emoji を抽出して
 		// host 別 batch fetch のリストに追加する (#459)。reaction 元の
 		// host は note.UserHost と必ずしも一致しないため、reaction
-		// 文字列内の `@host` を信頼する。
-		for name, host := range collectReactionEmojiNames(n.Reactions) {
-			h := host
+		// 文字列内の `@host` を信頼する。同名の絵文字が複数 host から
+		// 届くケースを失わないよう slice で受け取る。
+		for _, pair := range collectReactionEmojiNames(n.Reactions) {
+			h := pair.host
 			var hostPtr *string
 			if h != "" {
 				hostPtr = &h
 			}
-			addNames([]string{name}, hostPtr)
+			addNames([]string{pair.name}, hostPtr)
 		}
 	}
 	// hostごとにbatch fetch
@@ -152,9 +170,9 @@ func (r *EmojiResolver) PopulateNoteReactionEmojis(note *model.Note, entity *Not
 		return
 	}
 	out := make(map[string]string)
-	for name, host := range collectReactionEmojiNames(note.Reactions) {
-		if url, ok := r.cache[name+"@"+host]; ok {
-			out[reactionEmojiKey(name, host)] = url
+	for _, pair := range collectReactionEmojiNames(note.Reactions) {
+		if url, ok := r.cache[pair.name+"@"+pair.host]; ok {
+			out[reactionEmojiKey(pair.name, pair.host)] = url
 		}
 	}
 	if len(out) > 0 {
@@ -163,11 +181,11 @@ func (r *EmojiResolver) PopulateNoteReactionEmojis(note *model.Note, entity *Not
 }
 
 // collectReactionEmojiNames decodes the per-note Reactions JSON map and
-// returns custom-emoji entries as a `name → host` map. Raw unicode
-// reactions are filtered out; duplicate (name, host) pairs collapse
-// into a single entry. The returned host is empty for local custom
-// emoji.
-func collectReactionEmojiNames(raw []byte) map[string]string {
+// returns custom-emoji entries as a slice of (name, host) pairs. Raw
+// unicode reactions are filtered out. Same-name-different-host pairs
+// are preserved as separate entries (a name-keyed map would collapse
+// them and lose remote emoji URLs).
+func collectReactionEmojiNames(raw []byte) []emojiNameHost {
 	if len(raw) == 0 {
 		return nil
 	}
@@ -175,13 +193,13 @@ func collectReactionEmojiNames(raw []byte) map[string]string {
 	if err := json.Unmarshal(raw, &counts); err != nil {
 		return nil
 	}
-	out := map[string]string{}
+	var out []emojiNameHost
 	for reaction := range counts {
 		name, host, ok := parseCustomEmojiReaction(reaction)
 		if !ok {
 			continue
 		}
-		out[name] = host
+		out = append(out, emojiNameHost{name: name, host: host})
 	}
 	return out
 }

--- a/internal/entity/emoji_resolver_test.go
+++ b/internal/entity/emoji_resolver_test.go
@@ -432,6 +432,103 @@ func TestPopulateUserEmojis_NilUserOrLite(t *testing.T) {
 	})
 }
 
+func TestPopulateNoteReactionEmojis(t *testing.T) {
+	// #459: note.Reactions に :name@host: 形式の custom emoji が含まれる
+	// 場合、batch fetch で URL を解決して entity.ReactionEmojis に詰める。
+	// 同 host の note.Emojis と reaction emoji が混在しても 1 回の fetch で
+	// まとめて取れることも確認する。
+	remoteHost := "remote.example"
+	localHost := ""
+	_ = localHost
+	lookup := &stubEmojiLookup{
+		data: map[string][]*model.Emoji{
+			"remote.example": {
+				{ID: "e1", Name: "smile", Host: strPtr("remote.example"), PublicURL: "https://remote.example/emoji/smile.png"},
+				{ID: "e2", Name: "wave", Host: strPtr("remote.example"), PublicURL: "https://remote.example/emoji/wave.png"},
+			},
+			"": {
+				{ID: "e3", Name: "local", Host: nil, PublicURL: "https://local.example/emoji/local.png"},
+			},
+		},
+	}
+
+	// reactions JSON: ":smile@remote.example:" / ":local:" / "❤️" の 3 種
+	// (生 unicode emoji は reactionEmojis に乗らないことも assert)。
+	reactionsJSON := []byte(`{":smile@remote.example:":2,":local:":1,"❤️":3}`)
+
+	note := &model.Note{
+		ID:        "n1",
+		UserID:    "u1",
+		UserHost:  &remoteHost,
+		Reactions: reactionsJSON,
+	}
+
+	r := NewEmojiResolver(lookup, []*model.Note{note})
+	entity := &NoteEntity{ReactionEmojis: map[string]string{}}
+	r.PopulateNoteReactionEmojis(note, entity)
+
+	require.NotNil(t, entity.ReactionEmojis)
+	// remote: key は frontend lookup `reaction.substring(1, length-1)` 仕様で "smile@remote.example"
+	assert.Equal(t, "https://remote.example/emoji/smile.png", entity.ReactionEmojis["smile@remote.example"])
+	// local: key は host 抜きの "local"
+	assert.Equal(t, "https://local.example/emoji/local.png", entity.ReactionEmojis["local"])
+	// raw unicode は乗らない
+	_, hasHeart := entity.ReactionEmojis["❤️"]
+	assert.False(t, hasHeart, "raw unicode reactions should not appear in reactionEmojis")
+}
+
+func TestPopulateNoteReactionEmojis_NoCustomEmoji(t *testing.T) {
+	// reactions が unicode のみ / 空の場合は ReactionEmojis を populate しない
+	// (空 map で初期化されている前提を維持する)。
+	lookup := &stubEmojiLookup{data: map[string][]*model.Emoji{}}
+
+	cases := []struct {
+		name string
+		raw  []byte
+	}{
+		{"unicode only", []byte(`{"❤️":1,"👍":2}`)},
+		{"empty json", []byte(`{}`)},
+		{"nil reactions", nil},
+		{"malformed json", []byte("not json")},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			note := &model.Note{ID: "n1", UserID: "u1", Reactions: tc.raw}
+			r := NewEmojiResolver(lookup, []*model.Note{note})
+			entity := &NoteEntity{ReactionEmojis: map[string]string{"keep": "this"}}
+			r.PopulateNoteReactionEmojis(note, entity)
+			// custom emoji 不在なので元の map をそのまま温存する
+			assert.Equal(t, map[string]string{"keep": "this"}, entity.ReactionEmojis)
+		})
+	}
+}
+
+func TestParseCustomEmojiReaction(t *testing.T) {
+	cases := []struct {
+		input string
+		name  string
+		host  string
+		ok    bool
+	}{
+		{":smile:", "smile", "", true},
+		{":smile@remote.example:", "smile", "remote.example", true},
+		{"❤️", "", "", false},
+		{":invalid_no_close", "", "", false},
+		{"no_open:", "", "", false},
+		{"::", "", "", false}, // len < 3 で parser が早期 return、空 name は不正
+	}
+	for _, tc := range cases {
+		t.Run(tc.input, func(t *testing.T) {
+			name, host, ok := parseCustomEmojiReaction(tc.input)
+			assert.Equal(t, tc.ok, ok)
+			if ok {
+				assert.Equal(t, tc.name, name)
+				assert.Equal(t, tc.host, host)
+			}
+		})
+	}
+}
+
 func TestPopulateNoteEmojis_UnresolvedEmojiExcluded(t *testing.T) {
 	remoteHost := "remote.example"
 	lookup := &stubEmojiLookup{

--- a/internal/entity/emoji_resolver_test.go
+++ b/internal/entity/emoji_resolver_test.go
@@ -433,13 +433,12 @@ func TestPopulateUserEmojis_NilUserOrLite(t *testing.T) {
 }
 
 func TestPopulateNoteReactionEmojis(t *testing.T) {
-	// #459: note.Reactions に :name@host: 形式の custom emoji が含まれる
-	// 場合、batch fetch で URL を解決して entity.ReactionEmojis に詰める。
-	// 同 host の note.Emojis と reaction emoji が混在しても 1 回の fetch で
-	// まとめて取れることも確認する。
+	// #459: note.Reactions に :name@host: / :name@.: (canonical local) /
+	// raw unicode が混在するケースで batch fetch + populate が動くこと。
+	// mk-go の reaction_service.normalizeReaction は local emoji を
+	// `:name@.:` (TS 互換 canonical) で永続化するため、parser は `@.`
+	// を空 host に正規化しなければならない (PR #463 review BUG-0001)。
 	remoteHost := "remote.example"
-	localHost := ""
-	_ = localHost
 	lookup := &stubEmojiLookup{
 		data: map[string][]*model.Emoji{
 			"remote.example": {
@@ -452,9 +451,10 @@ func TestPopulateNoteReactionEmojis(t *testing.T) {
 		},
 	}
 
-	// reactions JSON: ":smile@remote.example:" / ":local:" / "❤️" の 3 種
-	// (生 unicode emoji は reactionEmojis に乗らないことも assert)。
-	reactionsJSON := []byte(`{":smile@remote.example:":2,":local:":1,"❤️":3}`)
+	// canonical local (`:local@.:`) を含めて、本番で実際に DB に書かれる
+	// 形式を網羅する。レガシー `:legacy_local:` (host 省略) も 1 件混ぜて
+	// 後方互換が壊れていないことを確認する。
+	reactionsJSON := []byte(`{":smile@remote.example:":2,":local@.:":1,":wave@remote.example:":1,"❤️":3}`)
 
 	note := &model.Note{
 		ID:        "n1",
@@ -470,11 +470,46 @@ func TestPopulateNoteReactionEmojis(t *testing.T) {
 	require.NotNil(t, entity.ReactionEmojis)
 	// remote: key は frontend lookup `reaction.substring(1, length-1)` 仕様で "smile@remote.example"
 	assert.Equal(t, "https://remote.example/emoji/smile.png", entity.ReactionEmojis["smile@remote.example"])
-	// local: key は host 抜きの "local"
+	assert.Equal(t, "https://remote.example/emoji/wave.png", entity.ReactionEmojis["wave@remote.example"])
+	// canonical local (`:local@.:`) は frontend lookup で "local@." に
+	// なるが、parser が `.` を空に戻すので map のキーは "local"
 	assert.Equal(t, "https://local.example/emoji/local.png", entity.ReactionEmojis["local"])
 	// raw unicode は乗らない
 	_, hasHeart := entity.ReactionEmojis["❤️"]
 	assert.False(t, hasHeart, "raw unicode reactions should not appear in reactionEmojis")
+}
+
+func TestPopulateNoteReactionEmojis_SameNameDifferentHosts(t *testing.T) {
+	// PR #463 review BUG-0002: 同名カスタム絵文字が複数 remote host から
+	// 一つの note の reactions に含まれる場合、両方とも解決されること。
+	// collectReactionEmojiNames が name 単独でキー化していると後勝ちで
+	// 一方が消える。
+	lookup := &stubEmojiLookup{
+		data: map[string][]*model.Emoji{
+			"alpha.example": {
+				{ID: "ea", Name: "smile", Host: strPtr("alpha.example"), PublicURL: "https://alpha.example/emoji/smile.png"},
+			},
+			"beta.example": {
+				{ID: "eb", Name: "smile", Host: strPtr("beta.example"), PublicURL: "https://beta.example/emoji/smile.png"},
+			},
+		},
+	}
+	reactionsJSON := []byte(`{":smile@alpha.example:":1,":smile@beta.example:":2}`)
+	note := &model.Note{
+		ID:        "n1",
+		UserID:    "u1",
+		Reactions: reactionsJSON,
+	}
+
+	r := NewEmojiResolver(lookup, []*model.Note{note})
+	entity := &NoteEntity{ReactionEmojis: map[string]string{}}
+	r.PopulateNoteReactionEmojis(note, entity)
+
+	require.NotNil(t, entity.ReactionEmojis)
+	// 両 host の URL が共存する
+	assert.Equal(t, "https://alpha.example/emoji/smile.png", entity.ReactionEmojis["smile@alpha.example"])
+	assert.Equal(t, "https://beta.example/emoji/smile.png", entity.ReactionEmojis["smile@beta.example"])
+	assert.Len(t, entity.ReactionEmojis, 2)
 }
 
 func TestPopulateNoteReactionEmojis_NoCustomEmoji(t *testing.T) {
@@ -512,6 +547,8 @@ func TestParseCustomEmojiReaction(t *testing.T) {
 	}{
 		{":smile:", "smile", "", true},
 		{":smile@remote.example:", "smile", "remote.example", true},
+		// canonical local form (mk-go reaction_service.normalizeReaction 出力)
+		{":smile@.:", "smile", "", true},
 		{"❤️", "", "", false},
 		{":invalid_no_close", "", "", false},
 		{"no_open:", "", "", false},

--- a/internal/entity/note.go
+++ b/internal/entity/note.go
@@ -199,6 +199,7 @@ func PackNoteWithInstance(n *model.Note, idGen id.Generator, instLookup Instance
 func applyNoteResolvers(n *model.Note, e *NoteEntity, instResolver *InstanceResolver, emojiResolver *EmojiResolver) {
 	instResolver.FillUserLite(&e.User)
 	emojiResolver.PopulateNoteEmojis(n, e)
+	emojiResolver.PopulateNoteReactionEmojis(n, e)
 	if n.User != nil {
 		emojiResolver.PopulateUserEmojis(n.User, &e.User)
 	}


### PR DESCRIPTION
## Summary

リモートからカスタム絵文字リアクションを受信した際、frontend で ❤️ にフォールバックされていた問題を修正する。原因は **入口から出口まで 4 段階の欠落** だったので、それぞれ塞ぐ。

Closes #459

## 主な変更点

### 1. AP Like の Tag を deserialize する (`internal/activitypub/types.go`)

`Like` 構造体に `Tag []any` を追加。Misskey TS が連合させる Emoji オブジェクト群 (`tag: [{type: "Emoji", name, icon: {url}}]`) を受け取る。これが無いと emoji メタデータが受信時点で全て捨てられていた。

### 2. handleLike で emoji table に永続化する (`internal/core/federation/processor.go`)

reactor が remote のとき `extractEmojiTags(like.Tag)` + `p.resolver.upsertEmojis(...)` を呼んで emoji を upsert する (Misskey TS の `apNoteService.extractEmojis(activity.tag, actor.host)` 相当)。`extractEmojiTags` / `upsertEmojis` は Note ingestion で実績のある同パッケージの helper を再利用。失敗は握り潰し reactionService.Create 本体は続行する。

### 3. normalizeReaction に actor host 補完を追加 (`internal/core/reaction/reaction_service.go`)

**ここが本丸の修正**。Misskey TS は `_misskey_reaction: ":meow_yikes:"` のように **`@host` 省略** で reaction を連合させる (host 情報は `actor.host` と `tag[]` から導出する設計)。mk-go の旧 `normalizeReaction` は文字列内の host だけ見て `host=NULL` でローカル emoji 検索 → 不在 → ❤️ フォールバック、に落ちていた。

`normalizeReaction` に `actorHost *string` 引数を追加し、文字列 host が空かつ reactor が remote の場合は actor.host で emoji table を引き直す (upstream `ReactionService.create` の `reacterHost == null ? localCache : findOneBy({host: reacterHost, name})` と同じロジック)。

呼出し側:
- `Create`: `user.Host` を渡す
- `List` (filter context): `nil` を渡す (ローカルクエリ context、従来挙動維持)

### 4. PackNote が reactionEmojis を populate する (`internal/entity/emoji_resolver.go`, `note.go`)

`shapeQueueForFrontend` ならぬ `applyNoteResolvers` で `ReactionEmojis` map を埋める。frontend (`MkReactionsViewer.reaction.vue:15`) は `reactionEmojis[reaction.substring(1, length-1)]` で URL を引くので、key は local が `name`、remote が `name@host` 形式。

新規ヘルパー:
- `parseCustomEmojiReaction(s)` — reaction 文字列を (name, host, ok) に分解、raw unicode は ok=false
- `collectReactionEmojiNames(rawJSON)` — `note.Reactions` JSON のキーから custom emoji を抽出
- `PopulateNoteReactionEmojis(note, entity)` — cache lookup → entity.ReactionEmojis に詰める
- `NewEmojiResolver` の集約フェーズに reaction emoji 名も投入 (host 別 batch fetch に乗せる)

## なぜ 1〜4 全部必要か

| 段階 | 不足すると |
|------|-----------|
| 1 (Tag) | emoji メタデータが捨てられて upsert すらできない |
| 2 (upsertEmojis) | emoji 行が DB に存在しないので #3 の lookup が常に失敗 |
| 3 (actor host) | DB に行があっても文字列 host=NULL なので local 扱いで lookup 失敗、❤️ にフォールバック |
| 4 (reactionEmojis) | reaction 自体は正しく保存されても frontend が URL を引けず ❤️ 表示 |

#1 #2 だけ直しても #3 が落ちるし、#3 だけ直しても #1 #2 が無いと既存 DB に該当 emoji が無く lookup 失敗する。連鎖で全部塞ぐ必要がある。

## テスト

### 追加テスト

- `TestProcess_LikeWithCustomEmojiTag` (federation): Like + Tag → emoji table に upsert
- `TestService_Create_CustomEmojiRemoteWithoutHostInString` (reaction): remote actor + `:name:` (host省略) → `:name@host:` に正規化
- `TestPopulateNoteReactionEmojis` (entity): mixed (remote / local / unicode) reactions の解決
- `TestPopulateNoteReactionEmojis_NoCustomEmoji` (entity): unicode only / 空 / nil / malformed の no-op
- `TestParseCustomEmojiReaction` (entity): parser の境界ケース

### 実行コマンド

\`\`\`bash
make fmt && make lint && make test
\`\`\`

ローカルで全パッケージ green。

### 手動確認 (UDS スタック)

事前: リモートユーザー (Misskey TS) からローカル投稿に対して `:custom_emoji_name:` でリアクション。

修正前: `/admin/job-queue` の note 表示で ❤️ がレンダリングされる。Redis 内 `note_reaction.reaction` も `❤` (`\u2764`) で保存されており、復旧不可。

修正後: 実際のカスタム絵文字 (画像 + 名前) が正しく表示される。ユーザーから動作確認 OK 取得済 (\"表示られるようになったね\")。

## 関連

- Closes #459
- 同じ UDS 環境で発見された関連 bug: #460 / #461 / #462

## non-goals

- 旧来 (修正前) に保存されたリアクションの遡及修復: emoji table に行が無いまま DB に \`❤\` で保存されてしまったレコードは個別救済しない。新規受信から正常化する想定。
- 自インスタンス → リモートへ送信する Like activity に Tag を埋める (アウトバウンド対応): 別 issue で扱う
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/shiroha-a/mk/pull/463" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
