### PR TITLE
Fix federation: remote attachment thumbnail / aspect ratio / streaming files (#460 #461)

### DIFF
--- a/internal/activitypub/types.go
+++ b/internal/activitypub/types.go
@@ -156,12 +156,22 @@ type Source struct {
 }
 
 // Document represents an attached file (image/video/audio/...) in a Note.
+//
+// Width / Height は `as:width` / `as:height` (ActivityStreams 拡張)。
+// Icon は Document を表示する際のサムネイル候補で、Misskey TS 系が
+// 連合させる。Blurhash は Misskey の `_misskey_blurhash` カスタム拡張で、
+// frontend がメディアロード前にぼかし背景を表示するために使う。
+// いずれも欠落している remote 実装も多いので omitempty で受ける。
 type Document struct {
 	Type      string `json:"type"` // "Document"
 	MediaType string `json:"mediaType"`
 	URL       string `json:"url"`
 	Name      string `json:"name,omitempty"`
 	Sensitive bool   `json:"sensitive,omitempty"`
+	Width     int    `json:"width,omitempty"`
+	Height    int    `json:"height,omitempty"`
+	Icon      *Image `json:"icon,omitempty"`
+	Blurhash  string `json:"_misskey_blurhash,omitempty"`
 }
 
 // PropertyValue represents a profile field (schema.org PropertyValue).

--- a/internal/core/federation/image_dimensions.go
+++ b/internal/core/federation/image_dimensions.go
@@ -86,10 +86,20 @@ func fetchImageDimensions(ctx context.Context, httpClient *http.Client, rawURL s
 
 // probeImageDimensions wraps fetchImageDimensions with logging at WARN
 // for failed probes (operator visibility) and DEBUG for success.
-// Returns zero values on any failure, never panics. ctx を Background
-// にした内側で timeout を貼る。
-func probeImageDimensions(rawURL string) (width, height int, ok bool) {
-	w, h, err := fetchImageDimensions(context.Background(), http.DefaultClient, rawURL)
+// Returns zero values on any failure, never panics.
+//
+// httpClient は SSRF-safe transport を持つ *http.Client (典型的には
+// resolver.imageProbeClient = router.go で safehttp.NewSSRFSafeTransport
+// を適用したもの) を渡すこと。 untrusted な URL を fetch する経路なので
+// http.DefaultClient で呼ぶと SSRF 脆弱性になる (#464 review)。nil 渡しは
+// 呼び出し側で gate されている前提だが、安全側に倒して probe 自体を
+// 止める。
+func probeImageDimensions(httpClient *http.Client, rawURL string) (width, height int, ok bool) {
+	if httpClient == nil {
+		// SSRF 対策: 未配線時は probe しない (defaultClient フォールバック禁止)
+		return 0, 0, false
+	}
+	w, h, err := fetchImageDimensions(context.Background(), httpClient, rawURL)
 	if err != nil {
 		slog.Warn("federation: image dimension probe failed",
 			"url", rawURL, "err", err)

--- a/internal/core/federation/image_dimensions.go
+++ b/internal/core/federation/image_dimensions.go
@@ -39,11 +39,16 @@ const imageFetchMaxBytes int64 = 64 * 1024
 // surfaced so callers can decide whether to log; in this package the
 // upsertAttachments call site simply skips the property update.
 //
-// httpClient is taken as a parameter so tests can inject a mock client
-// without touching package globals. Pass http.DefaultClient in
-// production.
+// httpClient is taken as a parameter so tests can inject a mock client.
+// In production, callers MUST pass an SSRF-safe *http.Client (see
+// probeImageDimensions / router.go's safehttp.NewSSRFSafeTransport
+// wiring). nil は test convenience として http.DefaultClient に
+// フォールバックするのみで、production 経路は probeImageDimensions が
+// nil を弾くので到達しない。
 func fetchImageDimensions(ctx context.Context, httpClient *http.Client, rawURL string) (width, height int, err error) {
 	if httpClient == nil {
+		// nil fallback は test convenience のみ。production の SSRF
+		// 経路は probeImageDimensions の nil-guard で塞がれている。
 		httpClient = http.DefaultClient
 	}
 	ctx, cancel := context.WithTimeout(ctx, imageFetchTimeout)

--- a/internal/core/federation/image_dimensions.go
+++ b/internal/core/federation/image_dimensions.go
@@ -1,0 +1,99 @@
+package federation
+
+import (
+	"context"
+	"fmt"
+	"image"
+	"io"
+	"log/slog"
+	"net/http"
+	"strings"
+	"time"
+
+	// Standard library decoders for jpeg / png / gif.
+	_ "image/gif"
+	_ "image/jpeg"
+	_ "image/png"
+
+	// WebP support via golang.org/x/image (already in go.mod via other
+	// transitive deps).
+	_ "golang.org/x/image/webp"
+)
+
+// imageFetchTimeout は AP Document attachment の dimension probe に
+// 使うタイムアウト。inbox processor 経由で同期実行されるため、ジョブ
+// 全体を遅延させすぎないよう短めに設定する。失敗時は properties が
+// 空のまま残るが、表示破綻 (#461 stretch) するよりは ingestion 完走を
+// 優先する best-effort 方針。
+const imageFetchTimeout = 3 * time.Second
+
+// imageFetchMaxBytes は dimension decode に必要十分な先頭バイト数。
+// JPEG / PNG / GIF / WebP いずれも 64KiB あればヘッダから dimensions を
+// 復元できるので、サーバが Range を許可しない (= フル GET になる) 場合
+// でも LimitReader で読み込み上限を切って早期 close する。
+const imageFetchMaxBytes int64 = 64 * 1024
+
+// fetchImageDimensions issues a best-effort HTTP GET against rawURL,
+// decodes only the image header bytes, and returns width / height in
+// pixels. Errors (non-200, decode failure, timeout, non-image MIME) are
+// surfaced so callers can decide whether to log; in this package the
+// upsertAttachments call site simply skips the property update.
+//
+// httpClient is taken as a parameter so tests can inject a mock client
+// without touching package globals. Pass http.DefaultClient in
+// production.
+func fetchImageDimensions(ctx context.Context, httpClient *http.Client, rawURL string) (width, height int, err error) {
+	if httpClient == nil {
+		httpClient = http.DefaultClient
+	}
+	ctx, cancel := context.WithTimeout(ctx, imageFetchTimeout)
+	defer cancel()
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, rawURL, nil)
+	if err != nil {
+		return 0, 0, fmt.Errorf("federation: build image request: %w", err)
+	}
+	// User-Agent を付けないと Cloudflare 等の WAF に弾かれることが
+	// あるので明示する。Accept は AP fetcher と違い image/* を要求。
+	req.Header.Set("User-Agent", "mk-go (+image-dimension-probe)")
+	req.Header.Set("Accept", "image/*")
+
+	resp, err := httpClient.Do(req)
+	if err != nil {
+		return 0, 0, fmt.Errorf("federation: image fetch: %w", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return 0, 0, fmt.Errorf("federation: image fetch: unexpected status %d", resp.StatusCode)
+	}
+	// MIME 確認 (Content-Type が image/* でない場合は decode 試行を
+	// 諦める。HTML エラーページが 200 で返ってくるケースを想定)。
+	if ct := resp.Header.Get("Content-Type"); ct != "" && !strings.HasPrefix(ct, "image/") {
+		return 0, 0, fmt.Errorf("federation: image fetch: non-image content-type %q", ct)
+	}
+
+	limited := io.LimitReader(resp.Body, imageFetchMaxBytes)
+	cfg, _, err := image.DecodeConfig(limited)
+	if err != nil {
+		return 0, 0, fmt.Errorf("federation: decode image header: %w", err)
+	}
+	if cfg.Width <= 0 || cfg.Height <= 0 {
+		return 0, 0, fmt.Errorf("federation: decoded zero dimensions")
+	}
+	return cfg.Width, cfg.Height, nil
+}
+
+// probeImageDimensions wraps fetchImageDimensions with logging at WARN
+// for failed probes (operator visibility) and DEBUG for success.
+// Returns zero values on any failure, never panics. ctx を Background
+// にした内側で timeout を貼る。
+func probeImageDimensions(rawURL string) (width, height int, ok bool) {
+	w, h, err := fetchImageDimensions(context.Background(), http.DefaultClient, rawURL)
+	if err != nil {
+		slog.Warn("federation: image dimension probe failed",
+			"url", rawURL, "err", err)
+		return 0, 0, false
+	}
+	return w, h, true
+}

--- a/internal/core/federation/image_dimensions_test.go
+++ b/internal/core/federation/image_dimensions_test.go
@@ -88,6 +88,34 @@ func TestProbeImageDimensions_NilClientReturnsFalse(t *testing.T) {
 	assert.Equal(t, 0, h)
 }
 
+func TestProbeImageDimensions_Success(t *testing.T) {
+	body := renderTestPNG(t, 800, 600)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "image/png")
+		_, _ = w.Write(body)
+	}))
+	defer server.Close()
+
+	w, h, ok := probeImageDimensions(server.Client(), server.URL+"/cat.png")
+	require.True(t, ok)
+	assert.Equal(t, 800, w)
+	assert.Equal(t, 600, h)
+}
+
+func TestProbeImageDimensions_FailureReturnsFalse(t *testing.T) {
+	// HTTP error 経路 → fetchImageDimensions が err を返し probe は
+	// WARN ログを残して (0, 0, false) を返す。
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "boom", http.StatusInternalServerError)
+	}))
+	defer server.Close()
+
+	w, h, ok := probeImageDimensions(server.Client(), server.URL+"/x.png")
+	assert.False(t, ok)
+	assert.Equal(t, 0, w)
+	assert.Equal(t, 0, h)
+}
+
 func TestFetchImageDimensions_NilClientUsesDefault(t *testing.T) {
 	body := renderTestPNG(t, 10, 20)
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/internal/core/federation/image_dimensions_test.go
+++ b/internal/core/federation/image_dimensions_test.go
@@ -77,6 +77,17 @@ func TestFetchImageDimensions_BadURL(t *testing.T) {
 	require.Error(t, err)
 }
 
+// SSRF 対策 (PR #464 review): probeImageDimensions に nil client を渡すと
+// http.DefaultClient へフォールバックせず即座に skip する。fetchImageDimensions
+// 単体は test 用に DefaultClient フォールバックを残しているが、production
+// 経路の probeImageDimensions では required にする。
+func TestProbeImageDimensions_NilClientReturnsFalse(t *testing.T) {
+	w, h, ok := probeImageDimensions(nil, "https://attacker.example/x.png")
+	assert.False(t, ok, "nil client should not perform any HTTP request")
+	assert.Equal(t, 0, w)
+	assert.Equal(t, 0, h)
+}
+
 func TestFetchImageDimensions_NilClientUsesDefault(t *testing.T) {
 	body := renderTestPNG(t, 10, 20)
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/internal/core/federation/image_dimensions_test.go
+++ b/internal/core/federation/image_dimensions_test.go
@@ -1,0 +1,92 @@
+package federation
+
+import (
+	"bytes"
+	"context"
+	"image"
+	"image/png"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// renderTestPNG returns a minimal valid PNG of the given dimensions so
+// the dimension probe can decode real image bytes (rather than relying
+// on a hand-rolled fixture).
+func renderTestPNG(t *testing.T, width, height int) []byte {
+	t.Helper()
+	img := image.NewRGBA(image.Rect(0, 0, width, height))
+	var buf bytes.Buffer
+	require.NoError(t, png.Encode(&buf, img))
+	return buf.Bytes()
+}
+
+func TestFetchImageDimensions_Success(t *testing.T) {
+	body := renderTestPNG(t, 1280, 720)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "image/png")
+		_, _ = w.Write(body)
+	}))
+	defer server.Close()
+
+	w, h, err := fetchImageDimensions(context.Background(), server.Client(), server.URL+"/cat.png")
+	require.NoError(t, err)
+	assert.Equal(t, 1280, w)
+	assert.Equal(t, 720, h)
+}
+
+func TestFetchImageDimensions_NonImageContentType(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/html")
+		_, _ = w.Write([]byte("<html>error page</html>"))
+	}))
+	defer server.Close()
+
+	_, _, err := fetchImageDimensions(context.Background(), server.Client(), server.URL+"/x.png")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "non-image content-type")
+}
+
+func TestFetchImageDimensions_HTTPError(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "not found", http.StatusNotFound)
+	}))
+	defer server.Close()
+
+	_, _, err := fetchImageDimensions(context.Background(), server.Client(), server.URL+"/x.png")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "404")
+}
+
+func TestFetchImageDimensions_DecodeFailure(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "image/png")
+		_, _ = w.Write([]byte("not actually a png"))
+	}))
+	defer server.Close()
+
+	_, _, err := fetchImageDimensions(context.Background(), server.Client(), server.URL+"/x.png")
+	require.Error(t, err)
+}
+
+func TestFetchImageDimensions_BadURL(t *testing.T) {
+	_, _, err := fetchImageDimensions(context.Background(), http.DefaultClient, "://invalid")
+	require.Error(t, err)
+}
+
+func TestFetchImageDimensions_NilClientUsesDefault(t *testing.T) {
+	body := renderTestPNG(t, 10, 20)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "image/png")
+		_, _ = w.Write(body)
+	}))
+	defer server.Close()
+	// nil client は http.DefaultClient にフォールバックする
+	w, h, err := fetchImageDimensions(context.Background(), nil, server.URL+"/x.png")
+	require.NoError(t, err)
+	assert.Equal(t, 10, w)
+	assert.Equal(t, 20, h)
+}

--- a/internal/core/federation/resolver.go
+++ b/internal/core/federation/resolver.go
@@ -1061,15 +1061,60 @@ func extractAttachments(rawAttachments []any) []activitypub.Document {
 		mediaType, _ := m["mediaType"].(string)
 		name, _ := m["name"].(string)
 		sensitive, _ := m["sensitive"].(bool)
+		// width / height / blurhash / icon は省略実装が多いので欠落時は
+		// zero value のまま。upsertAttachments 側で 0/空チェックして
+		// DriveFile に書き込むかを判断する (#460/#461)。
+		width := numberAsInt(m["width"])
+		height := numberAsInt(m["height"])
+		blurhash, _ := m["_misskey_blurhash"].(string)
+		var icon *activitypub.Image
+		if iconMap, ok := m["icon"].(map[string]any); ok {
+			iconURL, _ := iconMap["url"].(string)
+			iconType, _ := iconMap["type"].(string)
+			if iconURL != "" {
+				icon = &activitypub.Image{Type: iconType, URL: iconURL}
+			}
+		}
 		out = append(out, activitypub.Document{
 			Type:      typ,
 			MediaType: mediaType,
 			URL:       urlStr,
 			Name:      name,
 			Sensitive: sensitive,
+			Width:     width,
+			Height:    height,
+			Icon:      icon,
+			Blurhash:  blurhash,
 		})
 	}
 	return out
+}
+
+// numberAsInt は JSON unmarshal 後の `any` を int に丸めて返す。
+// encoding/json は数値を float64 でデコードするため、width/height の
+// ような integer 想定 field を取り出すときに毎回 type switch するのを
+// 避けるためのヘルパー。NaN / 負値は 0 として扱い、後段の `> 0`
+// ガードで弾く。
+func numberAsInt(v any) int {
+	switch x := v.(type) {
+	case float64:
+		if x <= 0 {
+			return 0
+		}
+		return int(x)
+	case int:
+		if x <= 0 {
+			return 0
+		}
+		return x
+	case int64:
+		if x <= 0 {
+			return 0
+		}
+		return int(x)
+	default:
+		return 0
+	}
 }
 
 // upsertAttachments persists each AP Document as a drive_file row (link
@@ -1121,6 +1166,49 @@ func (r *Resolver) upsertAttachments(docs []activitypub.Document, userID, host *
 			IsSensitive:    doc.Sensitive,
 			MaybeSensitive: doc.Sensitive,
 			StoredInternal: false,
+		}
+		// AP Document に乗ってきた metadata を可能な限り永続化する
+		// (#460 thumbnail / #461 properties)。link-format なので実体
+		// 画像解析はしないが、remote 側が宣言している width/height/
+		// icon/blurhash を信頼してそのまま保存する。
+		if doc.Icon != nil && doc.Icon.URL != "" {
+			thumb := doc.Icon.URL
+			f.ThumbnailURL = &thumb
+		}
+		width := doc.Width
+		height := doc.Height
+		// 上流 Misskey TS の renderDocument は width/height を AP に
+		// 載せないため、image MIME の場合は best-effort で URL を
+		// fetch して画像ヘッダから dimensions を復元する。失敗時は
+		// 0/0 のまま属性 JSON を空にしておき、表示側のフォールバック
+		// に任せる。タイムアウト 3s で inbox 全体は止めない。
+		if (width == 0 || height == 0) && strings.HasPrefix(mediaType, "image/") {
+			if w, h, ok := probeImageDimensions(doc.URL); ok {
+				if width == 0 {
+					width = w
+				}
+				if height == 0 {
+					height = h
+				}
+			}
+		}
+		if width > 0 || height > 0 {
+			// upstream Misskey は properties JSON を `{width, height}` で
+			// 持つ。orientation は EXIF 由来で AP には来ないので省略。
+			props := map[string]int{}
+			if width > 0 {
+				props["width"] = width
+			}
+			if height > 0 {
+				props["height"] = height
+			}
+			if encoded, err := json.Marshal(props); err == nil {
+				f.Properties = encoded
+			}
+		}
+		if doc.Blurhash != "" {
+			bh := doc.Blurhash
+			f.Blurhash = &bh
 		}
 		if err := r.driveFileRepo.Create(f); err != nil {
 			slog.Warn("upsertAttachments: create failed",

--- a/internal/core/federation/resolver.go
+++ b/internal/core/federation/resolver.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"net/http"
 	"net/url"
 	"slices"
 	"strings"
@@ -91,6 +92,12 @@ type Resolver struct {
 	pollRepo        repository.PollRepository      // optional: Question(投票)のPoll作成
 	emojiRepo       repository.EmojiRepository     // optional: リモート絵文字の永続化
 	driveFileRepo   repository.DriveFileRepository // optional: リモート添付の link 化
+	// imageProbeClient は image attachment の dimension probe (#461) で
+	// 使う outbound HTTP client。SSRF-safe transport (router.go で
+	// safehttp.NewSSRFSafeTransport を適用したもの) を渡す前提で、
+	// 未設定なら probe 自体をスキップする (安全側に倒す: SSRF リスクを
+	// 起こすくらいなら properties 空のまま運用)。
+	imageProbeClient *http.Client
 }
 
 // NewResolver constructs a Resolver.
@@ -158,6 +165,16 @@ func (r *Resolver) SetPollRepo(repo repository.PollRepository) {
 // remote custom emoji from AP Person/Note Tag arrays (#330).
 func (r *Resolver) SetEmojiRepo(repo repository.EmojiRepository) {
 	r.emojiRepo = repo
+}
+
+// SetImageProbeClient attaches an SSRF-safe *http.Client used by the
+// attachment dimension probe (#461). The supplied client must wrap a
+// transport with safehttp.NewSSRFSafeTransport(...) — otherwise a
+// malicious remote can point a Document URL at internal addresses
+// (cloud metadata, localhost services). nil 渡しは無効化と同義で、
+// その場合 dimension probe はスキップされ properties は空のまま。
+func (r *Resolver) SetImageProbeClient(client *http.Client) {
+	r.imageProbeClient = client
 }
 
 // SetDriveFileRepo attaches a DriveFileRepository for ingesting AP
@@ -1182,8 +1199,8 @@ func (r *Resolver) upsertAttachments(docs []activitypub.Document, userID, host *
 		// fetch して画像ヘッダから dimensions を復元する。失敗時は
 		// 0/0 のまま属性 JSON を空にしておき、表示側のフォールバック
 		// に任せる。タイムアウト 3s で inbox 全体は止めない。
-		if (width == 0 || height == 0) && strings.HasPrefix(mediaType, "image/") {
-			if w, h, ok := probeImageDimensions(doc.URL); ok {
+		if (width == 0 || height == 0) && strings.HasPrefix(mediaType, "image/") && r.imageProbeClient != nil {
+			if w, h, ok := probeImageDimensions(r.imageProbeClient, doc.URL); ok {
 				if width == 0 {
 					width = w
 				}

--- a/internal/core/federation/resolver_test.go
+++ b/internal/core/federation/resolver_test.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"net/http"
 	"testing"
 	"time"
 
@@ -2184,6 +2185,21 @@ func TestUpsertAttachments(t *testing.T) {
 		)
 		// Create が失敗した attachment は ID リストに含まれない
 		assert.Empty(t, ids)
+	})
+
+	// SetImageProbeClient setter が無 panic で呼べることを確認 (SSRF
+	// 対策 #464)。実際の probe 経路は image_dimensions_test.go で
+	// カバー済。
+	t.Run("SetImageProbeClient does not panic", func(t *testing.T) {
+		repo := testutil.NewMockUserRepository()
+		noteRepo := testutil.NewMockNoteRepository()
+		urls := activitypub.NewURLBuilder("https://example.com")
+		idGen, _ := id.NewGenerator("aidx")
+		r := federation.NewResolver(repo, noteRepo, urls, &stubFetcher{}, idGen)
+		client := &http.Client{Timeout: 1 * time.Second}
+		r.SetImageProbeClient(client)
+		// nil 渡しでも panic しない (= invalidate 相当)
+		r.SetImageProbeClient(nil)
 	})
 
 	// #460/#461: width / height / icon.url / _misskey_blurhash が AP

--- a/internal/core/federation/resolver_test.go
+++ b/internal/core/federation/resolver_test.go
@@ -2024,6 +2024,45 @@ func TestExtractAttachments(t *testing.T) {
 	}
 }
 
+// TestExtractAttachments_MetadataFields covers #460/#461: width / height /
+// icon / _misskey_blurhash が remote から届いたときに Document に展開される
+// ことを確認する。JSON unmarshal 後 width/height は float64 で来るので
+// numberAsInt 経由で int に丸められる必要がある。
+func TestExtractAttachments_MetadataFields(t *testing.T) {
+	raw := []any{
+		map[string]any{
+			"type":              "Document",
+			"mediaType":         "image/png",
+			"url":               "https://r/cat.png",
+			"width":             float64(640),
+			"height":            float64(480),
+			"_misskey_blurhash": "L6PZfSi_.AyE_3t7t7R**0o#DgR4",
+			"icon": map[string]any{
+				"type": "Image",
+				"url":  "https://r/cat-thumb.png",
+			},
+		},
+		map[string]any{
+			// width/height/icon/blurhash いずれも欠落しても zero value で
+			// 通過する (旧来 ingestion との互換)。
+			"type": "Document",
+			"url":  "https://r/no-meta.bin",
+		},
+	}
+	got := federation.ExtractAttachments(raw)
+	require.Len(t, got, 2)
+	assert.Equal(t, 640, got[0].Width)
+	assert.Equal(t, 480, got[0].Height)
+	assert.Equal(t, "L6PZfSi_.AyE_3t7t7R**0o#DgR4", got[0].Blurhash)
+	require.NotNil(t, got[0].Icon)
+	assert.Equal(t, "https://r/cat-thumb.png", got[0].Icon.URL)
+	// 欠落側
+	assert.Equal(t, 0, got[1].Width)
+	assert.Equal(t, 0, got[1].Height)
+	assert.Empty(t, got[1].Blurhash)
+	assert.Nil(t, got[1].Icon)
+}
+
 func TestUpsertAttachments(t *testing.T) {
 	t.Run("creates new drive_file as link", func(t *testing.T) {
 		repo := testutil.NewMockUserRepository()
@@ -2145,6 +2184,94 @@ func TestUpsertAttachments(t *testing.T) {
 		)
 		// Create が失敗した attachment は ID リストに含まれない
 		assert.Empty(t, ids)
+	})
+
+	// #460/#461: width / height / icon.url / _misskey_blurhash が AP
+	// Document に乗ってきた場合、drive_file の properties / thumbnailUrl
+	// / blurhash に永続化される。
+	t.Run("persists width/height/thumbnail/blurhash from AP Document", func(t *testing.T) {
+		repo := testutil.NewMockUserRepository()
+		noteRepo := testutil.NewMockNoteRepository()
+		urls := activitypub.NewURLBuilder("https://example.com")
+		idGen, _ := id.NewGenerator("aidx")
+		r := federation.NewResolver(repo, noteRepo, urls, &stubFetcher{}, idGen)
+		drive := testutil.NewMockDriveFileRepository()
+		r.SetDriveFileRepo(drive)
+
+		userID := "u1"
+		host := "remote.example"
+		ids := r.UpsertAttachments(
+			[]activitypub.Document{{
+				Type:      "Document",
+				MediaType: "image/png",
+				URL:       "https://r/cat.png",
+				Width:     1280,
+				Height:    720,
+				Icon:      &activitypub.Image{Type: "Image", URL: "https://r/cat-thumb.png"},
+				Blurhash:  "L6PZfSi_.AyE_3t7t7R**0o#DgR4",
+			}},
+			&userID, &host,
+		)
+		require.Len(t, ids, 1)
+		f, err := drive.FindByURI("https://r/cat.png")
+		require.NoError(t, err)
+		require.NotNil(t, f.ThumbnailURL)
+		assert.Equal(t, "https://r/cat-thumb.png", *f.ThumbnailURL)
+		require.NotNil(t, f.Blurhash)
+		assert.Equal(t, "L6PZfSi_.AyE_3t7t7R**0o#DgR4", *f.Blurhash)
+		assert.JSONEq(t, `{"width":1280,"height":720}`, string(f.Properties))
+	})
+
+	// metadata が一部しか乗ってこないケース (width のみ等) でも、その
+	// 部分だけ properties に入れて、抜けている方は埋めない。
+	t.Run("partial metadata: width only persists width", func(t *testing.T) {
+		repo := testutil.NewMockUserRepository()
+		noteRepo := testutil.NewMockNoteRepository()
+		urls := activitypub.NewURLBuilder("https://example.com")
+		idGen, _ := id.NewGenerator("aidx")
+		r := federation.NewResolver(repo, noteRepo, urls, &stubFetcher{}, idGen)
+		drive := testutil.NewMockDriveFileRepository()
+		r.SetDriveFileRepo(drive)
+
+		userID := "u1"
+		host := "remote.example"
+		_ = r.UpsertAttachments(
+			[]activitypub.Document{{
+				Type: "Document", URL: "https://r/half.png", Width: 100,
+			}},
+			&userID, &host,
+		)
+		f, err := drive.FindByURI("https://r/half.png")
+		require.NoError(t, err)
+		assert.JSONEq(t, `{"width":100}`, string(f.Properties))
+		assert.Nil(t, f.ThumbnailURL)
+		assert.Nil(t, f.Blurhash)
+	})
+
+	// 全 metadata 欠落 (旧来 attachment と互換) では properties 空、
+	// thumbnailUrl / blurhash 共に nil のまま。
+	t.Run("no metadata leaves properties empty and thumbnail/blurhash nil", func(t *testing.T) {
+		repo := testutil.NewMockUserRepository()
+		noteRepo := testutil.NewMockNoteRepository()
+		urls := activitypub.NewURLBuilder("https://example.com")
+		idGen, _ := id.NewGenerator("aidx")
+		r := federation.NewResolver(repo, noteRepo, urls, &stubFetcher{}, idGen)
+		drive := testutil.NewMockDriveFileRepository()
+		r.SetDriveFileRepo(drive)
+
+		userID := "u1"
+		host := "remote.example"
+		_ = r.UpsertAttachments(
+			[]activitypub.Document{{Type: "Document", URL: "https://r/bare.png"}},
+			&userID, &host,
+		)
+		f, err := drive.FindByURI("https://r/bare.png")
+		require.NoError(t, err)
+		// Properties は zero value (nil JSON) のまま、DB default の `{}`
+		// が DB 側で適用される
+		assert.Empty(t, f.Properties)
+		assert.Nil(t, f.ThumbnailURL)
+		assert.Nil(t, f.Blurhash)
 	})
 }
 

--- a/internal/entity/drive.go
+++ b/internal/entity/drive.go
@@ -116,8 +116,6 @@ func isImageMime(t string) bool {
 	return t[:6] == "image/"
 }
 
-// (resolveThumbnailURL / isImageMime are defined above.)
-
 // PackDriveFileWithRelations is PackDriveFile + optional folder/user
 // embedding. The caller is responsible for fetching the related rows (so
 // batch/cached access is possible). Pass nil for fields you do not want to

--- a/internal/entity/drive.go
+++ b/internal/entity/drive.go
@@ -70,12 +70,53 @@ func PackDriveFile(f *model.DriveFile, idGen id.Generator) DriveFileEntity {
 		Properties:   props,
 		Comment:      f.Comment,
 		URL:          f.URL,
-		ThumbnailURL: f.ThumbnailURL,
+		ThumbnailURL: resolveThumbnailURL(f),
 		WebpublicURL: f.WebpublicURL,
 		FolderID:     f.FolderID,
 		UserID:       f.UserID,
 	}
 }
+
+// resolveThumbnailURL emulates upstream Misskey's
+// DriveFileEntityService.getThumbnailUrl fallback: when the row's
+// thumbnailUrl column is NULL (typical for link-format remote files
+// since mk-go doesn't generate thumbnails for unfetched remote
+// originals), fall back to webpublicUrl, then to the original url for
+// image MIME types. Frontend (`MkMediaImage.vue:100`) accesses
+// `image.thumbnailUrl!` with a non-null assertion, so returning null
+// for an image breaks the timeline thumbnail rendering entirely
+// (#460). For non-image types we keep null — frontend skips the
+// thumbnail render path for those.
+func resolveThumbnailURL(f *model.DriveFile) *string {
+	if f.ThumbnailURL != nil && *f.ThumbnailURL != "" {
+		return f.ThumbnailURL
+	}
+	if !isImageMime(f.Type) {
+		return nil
+	}
+	if f.WebpublicURL != nil && *f.WebpublicURL != "" {
+		return f.WebpublicURL
+	}
+	if f.URL != "" {
+		u := f.URL
+		return &u
+	}
+	return nil
+}
+
+// isImageMime reports whether `type` field denotes a still image. The
+// upstream check (`isMimeImage(type, 'sharp-convertible-image')`) maps
+// to this set when ignoring server-side image processing capability —
+// for the thumbnail fallback path we just need a "browser will render
+// this as <img>" predicate.
+func isImageMime(t string) bool {
+	if len(t) < 6 {
+		return false
+	}
+	return t[:6] == "image/"
+}
+
+// (resolveThumbnailURL / isImageMime are defined above.)
 
 // PackDriveFileWithRelations is PackDriveFile + optional folder/user
 // embedding. The caller is responsible for fetching the related rows (so

--- a/internal/entity/drive_test.go
+++ b/internal/entity/drive_test.go
@@ -208,6 +208,72 @@ func TestPackDriveFileWithRelations_BothSet(t *testing.T) {
 	assert.Equal(t, "alice", out.User.Username)
 }
 
+// #460: link-format remote files have no stored thumbnailUrl. The
+// upstream frontend (`MkMediaImage.vue:100`) accesses
+// `image.thumbnailUrl!` with a non-null assertion, so a NULL value
+// breaks timeline thumbnail rendering. PackDriveFile must mirror
+// upstream's getThumbnailUrl fallback chain (thumbnailUrl ??
+// webpublicUrl ?? url) for image MIME types.
+func TestPackDriveFile_FallbackThumbnailFromURL(t *testing.T) {
+	idGen := newTestIDGen(t)
+	f := &model.DriveFile{
+		ID:   idGen.Generate(time.Now()),
+		Name: "remote.png",
+		Type: "image/png",
+		URL:  "https://r/remote.png",
+		// ThumbnailURL / WebpublicURL は nil (link-format で生成され
+		// ていない remote attachment を想定)
+	}
+	out := PackDriveFile(f, idGen)
+	require.NotNil(t, out.ThumbnailURL)
+	assert.Equal(t, "https://r/remote.png", *out.ThumbnailURL)
+}
+
+func TestPackDriveFile_FallbackThumbnailFromWebpublic(t *testing.T) {
+	idGen := newTestIDGen(t)
+	web := "https://r/remote-webpublic.webp"
+	f := &model.DriveFile{
+		ID:           idGen.Generate(time.Now()),
+		Name:         "remote.webp",
+		Type:         "image/webp",
+		URL:          "https://r/remote.webp",
+		WebpublicURL: &web,
+	}
+	out := PackDriveFile(f, idGen)
+	require.NotNil(t, out.ThumbnailURL)
+	// webpublicUrl が優先される (upstream getThumbnailUrl と一致)
+	assert.Equal(t, web, *out.ThumbnailURL)
+}
+
+func TestPackDriveFile_NoFallbackForNonImage(t *testing.T) {
+	idGen := newTestIDGen(t)
+	f := &model.DriveFile{
+		ID:   idGen.Generate(time.Now()),
+		Name: "video.mp4",
+		Type: "video/mp4",
+		URL:  "https://r/video.mp4",
+	}
+	out := PackDriveFile(f, idGen)
+	// video など非 image MIME はフォールバックさせない (frontend が
+	// thumbnail として動画を読み込んでしまうのを避ける)
+	assert.Nil(t, out.ThumbnailURL)
+}
+
+func TestPackDriveFile_PreservesExistingThumbnailUrl(t *testing.T) {
+	idGen := newTestIDGen(t)
+	thumb := "https://r/explicit-thumb.png"
+	f := &model.DriveFile{
+		ID:           idGen.Generate(time.Now()),
+		Name:         "x",
+		Type:         "image/png",
+		URL:          "https://r/x.png",
+		ThumbnailURL: &thumb,
+	}
+	out := PackDriveFile(f, idGen)
+	require.NotNil(t, out.ThumbnailURL)
+	assert.Equal(t, thumb, *out.ThumbnailURL)
+}
+
 func TestPackDriveFileWithRelations_NilRelations(t *testing.T) {
 	idGen := newTestIDGen(t)
 	f := &model.DriveFile{ID: idGen.Generate(time.Now()), Name: "a", URL: "x"}

--- a/internal/server/router.go
+++ b/internal/server/router.go
@@ -412,6 +412,15 @@ func (s *Server) setupRoutes() {
 	federationResolver.SetPollRepo(pollRepo)
 	federationResolver.SetEmojiRepo(emojiRepo)
 	federationResolver.SetDriveFileRepo(driveFileRepo)
+	// AP attachment dimension probe (#461) 用 outbound HTTP client。
+	// SSRF-safe transport で内部 IP / cloud metadata エンドポイントへの
+	// アクセスを拒否する。timeout は単発 image fetch なので apHTTPClient
+	// (30s) より短めの 10s にする。
+	imageProbeClient := &http.Client{
+		Timeout:   10 * time.Second,
+		Transport: safehttp.NewSSRFSafeTransport(s.config.AllowedPrivateNetworks),
+	}
+	federationResolver.SetImageProbeClient(imageProbeClient)
 	federationProcessor := corefederation.NewProcessor(federationResolver, followingService, reactionService, noteDeleteService, userRepo, noteRepo)
 	federationProcessor.SetLocalBaseURL(s.config.URL)
 

--- a/internal/server/router.go
+++ b/internal/server/router.go
@@ -1373,6 +1373,7 @@ func (s *Server) setupRoutes() {
 	notePublisher := stream.NewNotePublisher(streamPubSub, idGen)
 	notePublisher.SetEmojiLookup(emojiRepo)
 	notePublisher.SetInstanceLookup(instanceRepo)
+	notePublisher.SetFieldResolver(noteFieldResolver)
 	notificationPublisher := stream.NewNotificationPublisher(streamPubSub)
 	notificationPublisher.SetRepos(userRepo, noteRepo, idGen)
 	notificationPublisher.SetInstanceLookup(instanceRepo)

--- a/internal/stream/note_publisher.go
+++ b/internal/stream/note_publisher.go
@@ -106,18 +106,19 @@ func (p *NotePublisher) packNote(n *model.Note, author *model.User) []byte {
 
 	pn := entity.PackNoteWithInstance(&noteForPack, p.idGen, p.instanceLookup, p.emojiLookup)
 	// REST 経路と同じ後段 resolver を通して Files / Channel を埋める。
-	// 未配線なら no-op (従来挙動)。viewer 引数は streaming fanout の
-	// 性質上「自分宛て」が複数の subscriber に展開されるため特定不能で、
-	// MyReaction の正確な解決は subscriber 側の per-connection state
-	// に任せて、ResolveFiles のみ呼ぶ。
+	// viewer 引数は streaming fanout の性質上「自分宛て」が複数 subscriber
+	// に展開されるため特定不能。viewer=nil で Apply を呼ぶと
+	// MyReaction はスキップされ Files / Channel (= viewer-independent な
+	// fields) のみ解決される。MyReaction は subscriber 側の
+	// per-connection state に任せる。
 	//
-	// ResolveFiles は []NoteEntity (値型 slice) を受け取り内部で
-	// `&notes[i]` 経由で要素を mutate するので、いったん 1-element の
-	// slice にしてから書き戻さないと Files が pn に反映されない (Go の
-	// slice literal がコピーを作るため pn 自体は更新されない)。
+	// Apply は []NoteEntity (値型 slice) を受け取り内部で `&notes[i]`
+	// 経由で要素を mutate するので、いったん 1-element slice にして
+	// から書き戻さないと反映されない (Go の slice literal がコピーを
+	// 作るため pn 自体は更新されない)。
 	if p.fieldResolver != nil {
 		batch := []entity.NoteEntity{pn}
-		p.fieldResolver.ResolveFiles(batch)
+		p.fieldResolver.Apply(batch, nil)
 		pn = batch[0]
 	}
 

--- a/internal/stream/note_publisher.go
+++ b/internal/stream/note_publisher.go
@@ -30,6 +30,10 @@ type NotePublisher struct {
 	idGen          id.Generator
 	emojiLookup    entity.EmojiLookup
 	instanceLookup entity.InstanceLookup
+	// fieldResolver は Files / Channel など PackNoteWithInstance では
+	// 解決されない後段 field を埋める。未設定時は従来通り Files が
+	// 空配列のまま publish される (旧挙動)。SetFieldResolver で配線。
+	fieldResolver *entity.NoteFieldResolver
 
 	mu         sync.Mutex
 	cachedID   string
@@ -54,6 +58,16 @@ func (p *NotePublisher) SetEmojiLookup(lookup entity.EmojiLookup) {
 // visual flicker on page reload.
 func (p *NotePublisher) SetInstanceLookup(lookup entity.InstanceLookup) {
 	p.instanceLookup = lookup
+}
+
+// SetFieldResolver attaches a NoteFieldResolver so that streaming payloads
+// include Files / Channel / MyReaction equivalent to the REST GET path.
+// Without it, fanout payloads carry an empty `files` array and frontend
+// renders the note without attached media until the user reloads
+// (#460/#461 follow-up). The resolver is shared with the REST handler
+// path so call sites only construct one. nil 配線時は従来通り files 空。
+func (p *NotePublisher) SetFieldResolver(r *entity.NoteFieldResolver) {
+	p.fieldResolver = r
 }
 
 // PublishNote implements core/timeline.StreamingPublisher.
@@ -91,6 +105,21 @@ func (p *NotePublisher) packNote(n *model.Note, author *model.User) []byte {
 	noteForPack.User = author
 
 	pn := entity.PackNoteWithInstance(&noteForPack, p.idGen, p.instanceLookup, p.emojiLookup)
+	// REST 経路と同じ後段 resolver を通して Files / Channel を埋める。
+	// 未配線なら no-op (従来挙動)。viewer 引数は streaming fanout の
+	// 性質上「自分宛て」が複数の subscriber に展開されるため特定不能で、
+	// MyReaction の正確な解決は subscriber 側の per-connection state
+	// に任せて、ResolveFiles のみ呼ぶ。
+	//
+	// ResolveFiles は []NoteEntity (値型 slice) を受け取り内部で
+	// `&notes[i]` 経由で要素を mutate するので、いったん 1-element の
+	// slice にしてから書き戻さないと Files が pn に反映されない (Go の
+	// slice literal がコピーを作るため pn 自体は更新されない)。
+	if p.fieldResolver != nil {
+		batch := []entity.NoteEntity{pn}
+		p.fieldResolver.ResolveFiles(batch)
+		pn = batch[0]
+	}
 
 	body, err := json.Marshal(pn)
 	if err != nil {

--- a/internal/stream/note_publisher_test.go
+++ b/internal/stream/note_publisher_test.go
@@ -10,8 +10,10 @@ import (
 
 	coredrive "github.com/shiroha-a/mk/internal/core/drive"
 	corenotification "github.com/shiroha-a/mk/internal/core/notification"
+	"github.com/shiroha-a/mk/internal/entity"
 	"github.com/shiroha-a/mk/internal/misc/id"
 	"github.com/shiroha-a/mk/internal/model"
+	"github.com/shiroha-a/mk/internal/testutil"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -98,6 +100,48 @@ func TestNotePublisher_PopulatesAuthorInstance(t *testing.T) {
 	inst, ok := user["instance"].(map[string]any)
 	require.True(t, ok, "user.instance must be present on streaming payload")
 	assert.Equal(t, themeColor, inst["themeColor"])
+}
+
+// FieldResolver が配線されている場合、ストリーミング payload に Files が
+// 乗る (#460/#461 follow-up)。配線無しでは files が空配列のままなので、
+// frontend が画像を表示できずリロードが必要になる。
+func TestNotePublisher_FieldResolverPopulatesFiles(t *testing.T) {
+	pub := &stubPublisher{}
+	idGen, _ := id.NewGenerator("aidx")
+	np := NewNotePublisher(pub, idGen)
+
+	driveRepo := testutil.NewMockDriveFileRepository()
+	noteID := idGen.Generate(time.Now())
+	fileID := idGen.Generate(time.Now())
+	driveRepo.Files[fileID] = &model.DriveFile{
+		ID:   fileID,
+		Name: "remote.png",
+		Type: "image/png",
+		URL:  "https://r/remote.png",
+	}
+	resolver := entity.NewNoteFieldResolver(driveRepo, nil, nil, nil, nil, idGen)
+	np.SetFieldResolver(resolver)
+
+	n := &model.Note{
+		ID:         noteID,
+		UserID:     "u1",
+		FileIDs:    []string{fileID},
+		Visibility: model.NoteVisibilityPublic,
+	}
+	np.PublishNote("homeTimeline:u1", n, &model.User{ID: "u1", Username: "alice"})
+
+	require.Len(t, pub.payloads, 1)
+	raw := pub.payloads[0].(json.RawMessage)
+	var body map[string]any
+	require.NoError(t, json.Unmarshal(raw, &body))
+	files, ok := body["files"].([]any)
+	require.True(t, ok, "files key must be present in streaming payload")
+	require.Len(t, files, 1, "files array must contain the resolved drive file")
+	first := files[0].(map[string]any)
+	assert.Equal(t, fileID, first["id"])
+	// PackDriveFile fallback で thumbnailUrl が url にフォールバックする
+	// ことも合わせて確認する (#460)。
+	assert.Equal(t, "https://r/remote.png", first["thumbnailUrl"])
 }
 
 // n.Renote が preload 済みならストリーミング payload に renote オブジェクトが


### PR DESCRIPTION
## Summary

UDS スタックでリモート画像が:

1. **#460** タイムラインのサムネイル位置に何も表示されない
2. **#461** lightbox で開くと画面全体に引き伸ばされる
3. (調査中に判明) 新着 note が WebSocket 経由で届くと画像領域が空のまま、リロードして REST GET し直すまで表示されない

の 3 症状を全て修正する。

Closes #460
Closes #461

## 調査で判明した因果関係

| 症状 | 直接原因 | 根本原因 |
|------|---------|---------|
| #460 サムネイル非表示 | `drive_file.thumbnailUrl` が NULL → API レスポンス `thumbnailUrl: null` → frontend `MkMediaImage.vue:100` の `image.thumbnailUrl!` 非 null アサーションが失敗して `<img src="null">` |  upstream は upload 時に thumbnail を生成し DB に保存するが、mk-go の link-format remote 取込みは生成しない設計。entity packing 層で fallback を入れる必要があった |
| #461 引き伸ばし | `drive_file.properties = {}` → API レスポンス `properties: {}` → photoswipe の `Number(file.properties.width)` が NaN → 画面全体に拡大 | upstream Misskey TS の `renderDocument` (`ApRendererService.ts:169`) は width/height を AP に**乗せない**ため、ingestion 側で取れない。実画像を fetch して header から復元する必要があった |
| 画像 reload まで非表示 | streaming 経路の `NotePublisher.packNote` が REST 経路と異なり `Files` を populate しない → WS payload の `files: []` 空配列 | `entity.NoteFieldResolver.ResolveFiles` を REST handler だけが呼んでおり、streaming publisher は `PackNoteWithInstance` 直結だった |

## 主な変更点

### 1. AP Document に metadata field を追加 (`internal/activitypub/types.go`)

`Width` / `Height` / `Icon *Image` / `Blurhash` (`_misskey_blurhash`) を deserialize できるように `Document` 構造体を拡張。リモートが提供してくれた場合に取りこぼさないため。

### 2. `extractAttachments` / `upsertAttachments` で永続化 (`internal/core/federation/resolver.go`)

raw map から width / height / icon.url / _misskey_blurhash を取り出し、`drive_file` の `Properties` JSONB / `ThumbnailURL` / `Blurhash` カラムに書き込む。`numberAsInt` ヘルパーで JSON unmarshal 後の float64 → int 丸め。

### 3. dimension probe (`internal/core/federation/image_dimensions.go` 新設)

upstream Misskey TS が width/height を AP に載せない問題への対応。link-format 維持のまま、image MIME attachment は **best-effort で URL を fetch → image header から dimensions 復元**:

- timeout 3s で inbox 全体を遅らせない
- `io.LimitReader(resp.Body, 64KiB)` で読み込み上限
- Content-Type が `image/*` でなければ skip (HTML エラーページが 200 で返るケース対策)
- 失敗時は properties 空のまま ingestion 完走 (堅牢性優先)
- `golang.org/x/image/webp` を blank import して JPEG/PNG/GIF/WebP すべて decode 可能

### 4. `PackDriveFile` で thumbnailUrl フォールバック (`internal/entity/drive.go`) — **#460 直接修正**

`resolveThumbnailURL` で upstream Misskey の `getThumbnailUrl` 互換のフォールバックチェーン (`thumbnailUrl ?? webpublicUrl ?? url`) を image MIME に対して実装。非 image (動画など) は null のまま (frontend が誤って動画を thumbnail として読み込むのを防ぐ)。

これは entity packing 層の修正なので **既存 row でも即時効果** あり、再 fetch 不要。

### 5. streaming `Files` populate (`internal/stream/note_publisher.go` + `router.go`) — **WS 即時表示修正**

`NotePublisher.SetFieldResolver` を新設し、REST 経路と同じ `entity.NoteFieldResolver` を共有して `ResolveFiles` を経由する。

落とし穴: `ResolveFiles` は `[]NoteEntity` を受け取り `&notes[i]` で mutate するため、`[]entity.NoteEntity{pn}` という slice literal は **pn のコピー** を作る。slice 要素を mutate しても本体 `pn` の Files は空のまま、というバグが最初発生。1-element slice を変数に保存して `pn = batch[0]` で書き戻す形に修正。テスト `TestNotePublisher_FieldResolverPopulatesFiles` がこれを検出した。

## テスト

### 追加テスト

- `TestExtractAttachments_MetadataFields` — AP Document の width/height/icon/blurhash が deserialize される
- `TestUpsertAttachments` の 3 サブケース — metadata 完全 / 部分 / 欠落
- `TestFetchImageDimensions` の 6 ケース — 成功 / non-image MIME / HTTP error / decode failure / bad URL / nil client (httptest 経由で実 PNG を decode)
- `TestPackDriveFile` の 4 サブケース — URL fallback / webpublicUrl fallback / non-image スキップ / 既存 thumbnailUrl 維持
- `TestNotePublisher_FieldResolverPopulatesFiles` — streaming payload に files が乗ることを assert (slice copy バグの regression guard)

### 実行

\`\`\`bash
make fmt && make lint && make test
\`\`\`

ローカルで全パッケージ green。

### 手動検証 (UDS スタック)

1. **新規 URL のリモート画像投稿**: `drive_file.properties` に `{width, height}` が入ることを SQL 確認、admin UI でアスペクト比維持表示を確認
2. **WebSocket 経由の即時表示**: ホームタイムラインを開いた状態でリモートから新着画像 note を流し、リロードせずに画像が表示されることを確認

ユーザーから動作確認 OK 取得済 (最後のコメントで \"ok 治った\")。

## non-goals

- 既存 row (properties 空 / thumbnailUrl NULL) の遡及 backfill — ingestion 直すだけで前進、再 fetch されれば自然に解消
- 実体取得して local 保存する upload-from-url 相当の link-format → stored 移行 — 設計変更が大きく別 issue
- 自インスタンス → リモートへ送信する Document に width/height/icon を載せる (アウトバウンド) — `internal/activitypub/renderer/` の別 issue
- ローカル upload 時の image processing で thumbnail / blurhash を生成 — 別 issue
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/shiroha-a/mk/pull/464" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
