### PR TITLE
Fix federation: 厳格な MIME 解釈をする AP 実装の instance metadata / アイコンが取れない (#474)

### DIFF
--- a/internal/activitypub/client.go
+++ b/internal/activitypub/client.go
@@ -138,6 +138,37 @@ func (c *Client) FetchUnsigned(url string) ([]byte, error) {
 	return safehttp.ReadAllLimit(resp.Body, MaxBodyBytes)
 }
 
+// FetchUnsignedJSON performs an unsigned GET with `Accept: application/json, */*`.
+// Used for non-AP discovery endpoints that speak plain JSON (notably
+// `/.well-known/nodeinfo` and the nodeinfo 2.x documents themselves).
+//
+// Sending the AP-only Accept (`application/activity+json, application/ld+json`)
+// works for Misskey TS but is rejected by stricter implementations like
+// Iceshrimp.NET, which return a 406 Not Acceptable JSON envelope (#474).
+// Splitting this into a separate method keeps FetchUnsigned (= AP object
+// fetch) free of fallback logic and makes the request semantics explicit
+// at the call site.
+func (c *Client) FetchUnsignedJSON(url string) ([]byte, error) {
+	req, err := http.NewRequest(http.MethodGet, url, nil)
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("Accept", "application/json, */*")
+	if c.userAgent != "" {
+		req.Header.Set("User-Agent", c.userAgent)
+	}
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		drainBody(resp)
+		return nil, &StatusError{StatusCode: resp.StatusCode, Status: resp.Status, URL: url}
+	}
+	return safehttp.ReadAllLimit(resp.Body, MaxBodyBytes)
+}
+
 // drainBodyLimit caps how many bytes `drainBody` is willing to read from
 // a non-2xx response before giving up on connection reuse. Most error
 // payloads (Misskey/Mastodon JSON error envelope, plain-text 4xx page) fit

--- a/internal/activitypub/client_test.go
+++ b/internal/activitypub/client_test.go
@@ -271,6 +271,37 @@ func TestClient_FetchUnsigned_BadURL(t *testing.T) {
 	assert.Error(t, err)
 }
 
+// TestClient_FetchUnsignedJSON_AcceptHeader pins the Accept header used
+// for non-AP discovery endpoints (#474). Iceshrimp.NET returns a 406
+// envelope when the AP MIME types are sent, so plain JSON Accept must
+// be preserved.
+func TestClient_FetchUnsignedJSON_AcceptHeader(t *testing.T) {
+	var seenAccept string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		seenAccept = r.Header.Get("Accept")
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"links":[]}`))
+	}))
+	defer srv.Close()
+
+	c := NewClient(nil, "")
+	_, err := c.FetchUnsignedJSON(srv.URL + "/.well-known/nodeinfo")
+	require.NoError(t, err)
+	assert.Equal(t, "application/json, */*", seenAccept,
+		"plain JSON Accept must be sent so strict implementations like Iceshrimp.NET do not 406")
+}
+
+func TestClient_FetchUnsignedJSON_NonOK(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	defer srv.Close()
+
+	c := NewClient(nil, "")
+	_, err := c.FetchUnsignedJSON(srv.URL)
+	assert.Error(t, err)
+}
+
 func TestClient_FetchUnsigned_NetworkError(t *testing.T) {
 	c := NewClient(nil, "")
 	_, err := c.FetchUnsigned("http://127.0.0.1:1/")

--- a/internal/core/federation/fetcher.go
+++ b/internal/core/federation/fetcher.go
@@ -93,6 +93,14 @@ func (f *APFetcher) FetchHTML(uri string) ([]byte, error) {
 	return f.client.FetchHTML(uri)
 }
 
+// FetchJSON performs an unsigned GET with Accept: application/json, */*
+// for non-AP discovery endpoints (specifically nodeinfo, #474). Iceshrimp.NET
+// 等の strict 実装は AP MIME を Accept に渡すと 406 を返すため、nodeinfo
+// パスでは plain JSON を要求する必要がある。
+func (f *APFetcher) FetchJSON(uri string) ([]byte, error) {
+	return f.client.FetchUnsignedJSON(uri)
+}
+
 // shouldFallbackToUnsigned reports whether an error from a signed fetch
 // warrants retrying without the signature. AP の authorized-fetch 系の peer
 // は鍵検証失敗で 401 / 403 を返すので、この 2 つだけフォールバック対象に

--- a/internal/core/instance/fetch_metadata.go
+++ b/internal/core/instance/fetch_metadata.go
@@ -16,10 +16,11 @@ import (
 // remote HTML. 実装は activitypub.Client の薄いラッパで十分。
 //
 // nodeinfo / .well-known は peer 認証を要求しない discovery endpoint なので
-// 署名 GET を付ける必要がない。FetchObjectUnsigned 経由で明示的に未署名
-// リクエストを投げる (#419)。
+// 署名 GET を付ける必要がない。FetchJSON 経由で plain JSON Accept を投げる
+// (#474: Iceshrimp.NET など strict な実装は AP MIME を Accept に渡すと 406)。
 type HTTPFetcher interface {
-	FetchObjectUnsigned(uri string) ([]byte, error)
+	// FetchJSON は Accept: application/json, */* で nodeinfo を取得する。
+	FetchJSON(uri string) ([]byte, error)
 	FetchHTML(uri string) ([]byte, error)
 }
 
@@ -144,36 +145,62 @@ func (s *FetchMetadataService) Fetch(host string) error {
 // 失わないため)。
 const maxInstanceURLLen = 256
 
-// fetchIcons attempts to extract iconUrl (from <link rel="icon">) and set
-// faviconUrl to the conventional /favicon.ico path. 本家Misskey の
-// FetchInstanceMetadataService と同様、faviconは実在検証せず `https://host/favicon.ico`
-// を決め打ちで保存する (frontendが404時は非表示になるだけなので害は小さい)。
+// fetchIcons extracts iconUrl (high-res, used by detailed instance views)
+// and faviconUrl (small, used by InstanceTicker) from the remote root HTML.
+//
+// Upstream Misskey distinguishes the two:
+//   - faviconUrl: prefer `<link rel="icon">`; only falls back to the
+//     conventional `/favicon.ico` when the HTML provides no link tag.
+//   - iconUrl:    prefer `<link rel="apple-touch-icon">` (high-res), then
+//     `<link rel="icon">`.
+//
+// Iceshrimp.NET serves `<link rel="icon" href="/favicon.png">` and does
+// not expose `/favicon.ico`. Hardcoding the latter as faviconUrl gives a
+// 404 in the InstanceTicker — frontend shows broken / empty image (#474).
+// Following the link tag fixes the icon for any non-Misskey-TS upstream
+// that uses a non-`.ico` favicon convention.
 func (s *FetchMetadataService) fetchIcons(host string) (iconURL, faviconURL string) {
 	rootURL := "https://" + host + "/"
-	// 画面に表示される favicon は frontend で fallback されるので、HTMLが
-	// 取得できなくても /favicon.ico は必ずセットする。
-	faviconURL = "https://" + host + "/favicon.ico"
 
 	body, err := s.fetcher.FetchHTML(rootURL)
 	if err != nil {
-		return "", faviconURL
+		// HTML 取得失敗 → 古い挙動 (`/favicon.ico` 決め打ち) でフォールバック。
+		// frontend は 404 時に非表示にするだけで害は小さい。
+		return "", "https://" + host + "/favicon.ico"
 	}
-	iconURL = parseIconFromHTML(body, rootURL)
+
+	icon, appleTouchIcon := parseIconLinks(body, rootURL)
+
+	// iconUrl (高解像度): apple-touch-icon があればそちらが綺麗なので優先。
+	iconURL = firstNonEmptyStr(appleTouchIcon, icon)
+
+	// faviconUrl: HTML の <link rel="icon"> を最優先 (Iceshrimp.NET 等の
+	// 非 .ico 慣習に追従)、無ければ /favicon.ico に決め打ちフォールバック。
+	// 256 文字超の icon URL は DB 制約で書けないので、その場合も
+	// hardcode フォールバックに落とす。
+	defaultFavicon := "https://" + host + "/favicon.ico"
+	if icon != "" && len(icon) <= maxInstanceURLLen {
+		faviconURL = icon
+	} else {
+		faviconURL = defaultFavicon
+	}
 	return iconURL, faviconURL
 }
 
-// parseIconFromHTML finds the first <link rel="icon"> or <link rel="apple-touch-icon">
-// in doc and returns its href resolved against pageURL. 解析失敗や該当なしは空文字。
-func parseIconFromHTML(body []byte, pageURL string) string {
+// parseIconLinks walks the HTML document and returns absolute URLs for
+// the first `<link rel="icon">` and the first `<link rel="apple-touch-icon">`
+// (or their precomposed/shortcut equivalents). Either string may be empty
+// when the corresponding tag is absent. URL は pageURL を base にして解決。
+func parseIconLinks(body []byte, pageURL string) (icon, appleTouchIcon string) {
 	doc, err := html.Parse(bytes.NewReader(body))
 	if err != nil {
-		return ""
+		return "", ""
 	}
 	base, err := url.Parse(pageURL)
 	if err != nil {
-		return ""
+		return "", ""
 	}
-	var icon, appleTouchIcon string
+	var iconHref, appleHref string
 	var walk func(*html.Node)
 	walk = func(n *html.Node) {
 		if n.Type == html.ElementNode && n.Data == "link" {
@@ -182,12 +209,12 @@ func parseIconFromHTML(body []byte, pageURL string) string {
 			if href != "" {
 				switch rel {
 				case "icon", "shortcut icon":
-					if icon == "" {
-						icon = href
+					if iconHref == "" {
+						iconHref = href
 					}
 				case "apple-touch-icon", "apple-touch-icon-precomposed":
-					if appleTouchIcon == "" {
-						appleTouchIcon = href
+					if appleHref == "" {
+						appleHref = href
 					}
 				}
 			}
@@ -197,13 +224,17 @@ func parseIconFromHTML(body []byte, pageURL string) string {
 		}
 	}
 	walk(doc)
+	return resolveAgainstBase(iconHref, base), resolveAgainstBase(appleHref, base)
+}
 
-	// 本家優先順位に倣い、appleTouchIconの方が高解像度で綺麗なため優先する。
-	chosen := firstNonEmptyStr(appleTouchIcon, icon)
-	if chosen == "" {
+// resolveAgainstBase resolves href relative to base. Returns empty string
+// when href is empty or unparseable so callers can fall through to other
+// sources without having to nil-check error returns separately.
+func resolveAgainstBase(href string, base *url.URL) string {
+	if href == "" {
 		return ""
 	}
-	ref, err := url.Parse(chosen)
+	ref, err := url.Parse(href)
 	if err != nil {
 		return ""
 	}
@@ -230,7 +261,7 @@ func firstNonEmptyStr(vals ...string) string {
 
 // fetchDiscovery fetches /.well-known/nodeinfo and decodes the link list.
 func (s *FetchMetadataService) fetchDiscovery(host string) (*nodeinfoDiscovery, error) {
-	body, err := s.fetcher.FetchObjectUnsigned("https://" + host + "/.well-known/nodeinfo")
+	body, err := s.fetcher.FetchJSON("https://" + host + "/.well-known/nodeinfo")
 	if err != nil {
 		return nil, err
 	}
@@ -243,7 +274,7 @@ func (s *FetchMetadataService) fetchDiscovery(host string) (*nodeinfoDiscovery, 
 
 // fetchDocument fetches the actual nodeinfo document.
 func (s *FetchMetadataService) fetchDocument(href string) (*nodeinfoDocument, error) {
-	body, err := s.fetcher.FetchObjectUnsigned(href)
+	body, err := s.fetcher.FetchJSON(href)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/core/instance/fetch_metadata_test.go
+++ b/internal/core/instance/fetch_metadata_test.go
@@ -28,7 +28,7 @@ type scriptedFetcher struct {
 	htmlErr  error
 }
 
-func (s *scriptedFetcher) FetchObjectUnsigned(_ string) ([]byte, error) {
+func (s *scriptedFetcher) FetchJSON(_ string) ([]byte, error) {
 	if s.idx >= len(s.bodies) {
 		return nil, errors.New("no more bodies")
 	}
@@ -188,10 +188,39 @@ func TestFetch_IconFromHTML(t *testing.T) {
 
 	got := repo.Instances["remote.example"]
 	require.NotNil(t, got.IconURL)
-	// apple-touch-iconが優先され、絶対URLのまま保存される。
+	// iconUrl: 高解像度の apple-touch-icon が優先される。
 	assert.Equal(t, "https://cdn.example/apple-touch.png", *got.IconURL)
 	require.NotNil(t, got.FaviconURL)
-	assert.Equal(t, "https://remote.example/favicon.ico", *got.FaviconURL)
+	// faviconUrl (#474): HTML の <link rel="icon"> URL を優先するように
+	// 修正。Iceshrimp.NET 等が `/favicon.ico` ではなく `/favicon.png` を
+	// 提供する場合に、404 を返す hardcode URL ではなく実 URL が保存される。
+	assert.Equal(t, "https://remote.example/favicon-16.png", *got.FaviconURL)
+}
+
+// TestFetch_IconFromHTML_RelIconOnly_UsesItForFavicon: Iceshrimp.NET 風の
+// HTML (apple-touch-icon は無く `<link rel="icon">` のみ) では、両方の
+// field が同じ icon URL を指す。これが #474 の本丸。
+func TestFetch_IconFromHTML_RelIconOnly_UsesItForFavicon(t *testing.T) {
+	// Iceshrimp.NET と同じパターン: icon のみで apple-touch-icon は無い
+	htmlBody := `<html><head>
+		<link rel="icon" type="image/png" href="/favicon.png">
+	</head></html>`
+	repo := testutil.NewMockInstanceRepository()
+	repo.Instances["remote.example"] = &model.Instance{ID: "i1", Host: "remote.example"}
+	fetcher := &scriptedFetcher{
+		bodies:   [][]byte{[]byte(discoveryBody), []byte(documentBody)},
+		htmlBody: []byte(htmlBody),
+	}
+	svc := instance.NewFetchMetadataService(repo, fetcher)
+	require.NoError(t, svc.Fetch("remote.example"))
+
+	got := repo.Instances["remote.example"]
+	require.NotNil(t, got.IconURL)
+	assert.Equal(t, "https://remote.example/favicon.png", *got.IconURL)
+	require.NotNil(t, got.FaviconURL)
+	// 旧実装では `/favicon.ico` 決め打ち → 404 → frontend で表示できない。
+	// 修正後は HTML の <link rel="icon"> が両 field に使われる。
+	assert.Equal(t, "https://remote.example/favicon.png", *got.FaviconURL)
 }
 
 func TestFetch_IconFromHTML_RelativeResolved(t *testing.T) {


### PR DESCRIPTION
## Summary

UDS スタックで一部のリモートサーバー (AP MIME を strict に解釈する実装、例: Iceshrimp.NET 系) について、コントロールパネル / InstanceTicker で `softwareName` / `softwareVersion` / `iconUrl` / `faviconUrl` がすべて空のまま保存されていた問題を修正する。原因は **2 段階** で、両方を塞ぐ。

Closes #474

## 1. nodeinfo fetch の Accept header (主因)

mk-go の `FetchObjectUnsigned` は `Accept: application/activity+json, application/ld+json` を送る。AP MIME を strict に解釈する実装はこれを受け取ると `406 Not Acceptable` を JSON envelope で返してくる:

\`\`\`json
{"statusCode":406,"error":"NotAcceptable","message":"The requested Content-Type is not acceptable."}
\`\`\`

Cloudflare 経由などで HTTP status は 200 になっていても body は 406 envelope なので、JSON unmarshal は通っても `links` 配列が空で `no supported nodeinfo schema` エラーで fail していた。

upstream Misskey TS は nodeinfo に `Accept: application/json, */*` を使う (`HttpRequestService.getJson`)。同じ semantics の `Client.FetchUnsignedJSON` を `internal/activitypub/client.go` に追加し、`APFetcher.FetchJSON` → `instance.HTTPFetcher.FetchJSON` 経由で `fetch_metadata.go` の discovery / document fetch を切り替えた。

## 2. faviconUrl のハードコード

#1 修正後 nodeinfo は取れたがアイコンが表示されない症状が残った。原因は `fetchIcons` が `faviconUrl` を `https://host/favicon.ico` で **常に** 書き込んでいたこと。`/favicon.ico` を提供せず `<link rel="icon" href="/favicon.png">` のみを expose する実装で 404 になる。

frontend `MkInstanceTicker.vue:41` は **remote 用に `instance.faviconUrl` を読む** ので、404 だとアイコン領域が空になる。

upstream `fetchFaviconUrl` は HTML の `<link rel="icon">` を最優先し、無いときだけ `/favicon.ico` フォールバック。同等の semantics を mk-go に入れた:

| 状態 | iconUrl | faviconUrl |
|------|---------|------------|
| HTML に apple-touch-icon あり | apple-touch-icon | `<link rel="icon">` |
| HTML に `<link rel="icon">` のみ | icon | icon (同じ URL) |
| HTML link tag 無し | "" | `/favicon.ico` (hardcode) |
| HTML 取得失敗 | "" | `/favicon.ico` (hardcode) |
| icon URL > 256 文字 (DB 制約) | "" | `/favicon.ico` (hardcode) |

実装上は `parseIconFromHTML` を `parseIconLinks` に rename し、`icon` と `appleTouchIcon` を別々に返す形に変更。

## テスト

### 追加テスト

- `TestClient_FetchUnsignedJSON_AcceptHeader`: 新メソッドの Accept header を pin (`application/json, */*` であること)
- `TestClient_FetchUnsignedJSON_NonOK`: 非2xx で StatusError 返却
- `TestFetch_IconFromHTML_RelIconOnly_UsesItForFavicon`: apple-touch-icon が無く `<link rel="icon">` のみの HTML で faviconUrl が実 URL を指すこと
- 既存 `TestFetch_IconFromHTML` の faviconUrl assertion も hardcode `/favicon.ico` から HTML 由来の `/favicon-16.png` に更新

### 実行

\`\`\`bash
make fmt && make lint && make test
\`\`\`

ローカルで全パッケージ green。

### 手動検証 (UDS スタック)

修正前: 該当 instance の `softwareName` / `iconUrl` / `faviconUrl` / `name` がすべて NULL。

修正後 (`admin/federation/refresh-remote-instance-metadata` 経由で再 fetch): `softwareName` / `softwareVersion` / 実 URL の `iconUrl` / `faviconUrl` / `name` がすべて populate。ブラウザで InstanceTicker にアイコン + サーバー名表示されることを動作確認 OK 取得済。

## 副次的な互換性向上

- AP MIME を strict に解釈する他の実装でも同じ路線で nodeinfo が取れるようになる
- `<link rel="icon">` を `/favicon.png` 等の `.ico` 以外で提供するインスタンス全般で faviconUrl が正しく反映される

## 関連

- Closes #474
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/shiroha-a/mk/pull/477" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
