### PR TITLE
Fix /api/i/update: avatar / banner が設定できない (#467)

### DIFF
--- a/internal/api/i/handler.go
+++ b/internal/api/i/handler.go
@@ -606,6 +606,10 @@ type UpdateRequest struct {
 	// Room は frontend の「部屋」機能用の任意スキーマ jsonb。
 	// 本家も object をそのまま受け取って上書き保存する (部分マージはしない)。
 	Room json.RawMessage `json:"room"`
+	// AvatarID / BannerID — drive_file の ID。`null` / 省略は不変、空文字列
+	// は CLEAR、文字列値は SET。詳細は user.UpdateInput の docコメント参照。
+	AvatarID *string `json:"avatarId"`
+	BannerID *string `json:"bannerId"`
 }
 
 // jsonbObject normalizes a raw jsonb byte slice into map[string]any for the
@@ -719,11 +723,28 @@ func (h *Handler) Update(c echo.Context) error {
 		room := append(json.RawMessage(nil), req.Room...)
 		in.Room = &room
 	}
+	if req.AvatarID != nil {
+		in.AvatarID = req.AvatarID
+	}
+	if req.BannerID != nil {
+		in.BannerID = req.BannerID
+	}
 
 	bundle, err := h.userService.UpdateProfile(me.ID, in)
 	if err != nil {
-		if errors.Is(err, user.ErrUserNotFound) {
+		switch {
+		case errors.Is(err, user.ErrUserNotFound):
 			return c.JSON(http.StatusNotFound, apierr.Error("NO_SUCH_USER", "No such user.", "4362f8dc-731f-4ad8-a694-be5a88922a24"))
+		case errors.Is(err, user.ErrAvatarNotFound):
+			// upstream Misskey の NO_SUCH_AVATAR error UUID を流用 (frontend
+			// がコード固有の locale 表示をしているため一致が望ましい)。
+			return c.JSON(http.StatusBadRequest, apierr.Error("NO_SUCH_AVATAR", "No such avatar file.", "539f3a45-f215-4f81-a9a8-31293640207f"))
+		case errors.Is(err, user.ErrAvatarNotImage):
+			return c.JSON(http.StatusBadRequest, apierr.Error("AVATAR_NOT_AN_IMAGE", "The file specified as an avatar is not an image.", "f419f9f8-2f4d-46b1-9fb4-49d3a2fd7191"))
+		case errors.Is(err, user.ErrBannerNotFound):
+			return c.JSON(http.StatusBadRequest, apierr.Error("NO_SUCH_BANNER", "No such banner file.", "0d8f5629-f210-41c2-9433-735831a58595"))
+		case errors.Is(err, user.ErrBannerNotImage):
+			return c.JSON(http.StatusBadRequest, apierr.Error("BANNER_NOT_AN_IMAGE", "The file specified as a banner is not an image.", "75aedb19-2afd-4e6d-87fc-67941256fa60"))
 		}
 		return apierr.JSONInternalError(c)
 	}

--- a/internal/core/user/user_service.go
+++ b/internal/core/user/user_service.go
@@ -37,6 +37,15 @@ var (
 	ErrPinLimitExceeded = errors.New("pin limit exceeded")
 	// ErrPinNotFound is returned when unpinning a note that is not pinned.
 	ErrPinNotFound = errors.New("pin not found")
+	// ErrAvatarNotFound is returned when avatarId points to a missing or
+	// non-owned drive_file. Mirrors upstream Misskey's NO_SUCH_AVATAR.
+	ErrAvatarNotFound = errors.New("avatar drive file not found")
+	// ErrAvatarNotImage is returned when avatarId points to a non-image
+	// drive_file. Mirrors upstream's AVATAR_NOT_AN_IMAGE.
+	ErrAvatarNotImage = errors.New("avatar drive file is not an image")
+	// ErrBannerNotFound / ErrBannerNotImage are the banner counterparts.
+	ErrBannerNotFound = errors.New("banner drive file not found")
+	ErrBannerNotImage = errors.New("banner drive file is not an image")
 )
 
 // MainStreamPublisher emits real-time events to a single target user's `main`
@@ -63,6 +72,10 @@ type Service struct {
 	idGen               id.Generator
 	mainStreamPublisher MainStreamPublisher
 	remoteResolver      RemoteUserResolver
+	// driveFileRepo は avatar / banner SET 時に drive_file 行を引いて
+	// 所有者検証 + image MIME チェックするのに使う。未配線時は media
+	// 更新経路全体を skip して旧来挙動 (avatar / banner 不変) に戻す。
+	driveFileRepo repository.DriveFileRepository
 }
 
 // NewService creates a new user Service.
@@ -86,6 +99,16 @@ func NewService(
 // events (currently `meUpdated`). Optional — nil disables emit.
 func (s *Service) SetMainStreamPublisher(p MainStreamPublisher) {
 	s.mainStreamPublisher = p
+}
+
+// SetDriveFileRepository attaches a DriveFileRepository used by
+// UpdateProfile to resolve avatarId / bannerId into the corresponding
+// drive_file row (for ownership and image-MIME validation, plus
+// avatarUrl / avatarBlurhash population). Optional — nil leaves the
+// avatar / banner update paths inert (the input fields are silently
+// ignored, matching pre-#467 behaviour).
+func (s *Service) SetDriveFileRepository(repo repository.DriveFileRepository) {
+	s.driveFileRepo = repo
 }
 
 // SetRemoteUserResolver attaches a resolver for remote (non-local) users.
@@ -189,6 +212,17 @@ type UpdateInput struct {
 	// Room は jsonb 列に書き込む生バイト列。nil の場合は更新しない。
 	// 呼び出し側で JSON として妥当であることを保証する必要がある。
 	Room *json.RawMessage
+	// AvatarID / BannerID は drive_file の ID。
+	//   nil       → 不変 (no change)
+	//   &"<id>"   → SET (drive_file 行を引いて所有権 + image MIME 検証)
+	//   &""       → CLEAR (avatarId / avatarUrl / avatarBlurhash を NULL に)
+	//
+	// JSON `null` を CLEAR として扱う semantic はサポートしない (Go の
+	// *string では null と omitted を区別できないため #467 では空文字列
+	// を CLEAR の sentinel にする)。frontend が null clear を要求する
+	// ようになったら json.RawMessage ベースに昇格させる別 issue。
+	AvatarID *string
+	BannerID *string
 }
 
 // UpdateProfile applies the non-nil fields to the user and user_profile rows.
@@ -254,6 +288,17 @@ func (s *Service) UpdateProfile(userID string, in UpdateInput) (*UserWithProfile
 		profileFields["room"] = string(*in.Room)
 	}
 
+	// avatarId / bannerId 更新 (#467)。driveFileRepo 未配線時は media
+	// 更新経路を skip して旧 behaviour に戻す (テスト互換維持)。
+	if s.driveFileRepo != nil {
+		if err := s.applyMediaUpdate(userID, in.AvatarID, "avatar", userFields, ErrAvatarNotFound, ErrAvatarNotImage); err != nil {
+			return nil, err
+		}
+		if err := s.applyMediaUpdate(userID, in.BannerID, "banner", userFields, ErrBannerNotFound, ErrBannerNotImage); err != nil {
+			return nil, err
+		}
+	}
+
 	if err := s.userRepo.UpdateUser(userID, userFields); err != nil {
 		return nil, err
 	}
@@ -270,6 +315,52 @@ func (s *Service) UpdateProfile(userID string, in UpdateInput) (*UserWithProfile
 	// ため)。body は packed UserDetailed full object。
 	s.publishMeUpdated(bundle)
 	return bundle, nil
+}
+
+// applyMediaUpdate writes prefix+"Id" / prefix+"Url" / prefix+"Blurhash"
+// onto userFields based on idPtr's tri-state semantics:
+//
+//   - nil pointer       → no change (skip)
+//   - &""               → CLEAR: set all three columns to NULL
+//   - &"<drive_file_id>" → SET: lookup drive_file, validate ownership +
+//     image MIME, copy URL / Blurhash to user.
+//
+// `prefix` is "avatar" or "banner". notFoundErr / notImageErr are the
+// specific sentinel errors callers want surfaced (handler maps them to
+// distinct API error codes).
+func (s *Service) applyMediaUpdate(userID string, idPtr *string, prefix string, userFields map[string]any, notFoundErr, notImageErr error) error {
+	if idPtr == nil {
+		return nil
+	}
+	if *idPtr == "" {
+		// CLEAR — frontend が "" を送った想定 (JSON null は Go の *string
+		// で omitted と区別できないため空文字列を sentinel にする)。
+		userFields[prefix+"Id"] = nil
+		userFields[prefix+"Url"] = nil
+		userFields[prefix+"Blurhash"] = nil
+		return nil
+	}
+	file, err := s.driveFileRepo.FindByID(*idPtr)
+	if err != nil || file == nil {
+		return notFoundErr
+	}
+	// 他人の drive_file を avatar / banner に勝手に指定できないように
+	// 所有権を検証する (upstream Misskey と同じ)。userId が NULL
+	// (未紐付け) も拒否対象。
+	if file.UserID == nil || *file.UserID != userID {
+		return notFoundErr
+	}
+	if !strings.HasPrefix(file.Type, "image/") {
+		return notImageErr
+	}
+	userFields[prefix+"Id"] = file.ID
+	userFields[prefix+"Url"] = file.URL
+	if file.Blurhash != nil {
+		userFields[prefix+"Blurhash"] = *file.Blurhash
+	} else {
+		userFields[prefix+"Blurhash"] = nil
+	}
+	return nil
 }
 
 // publishMeUpdated emits `meUpdated` to the user's main channel with the

--- a/internal/core/user/user_service_test.go
+++ b/internal/core/user/user_service_test.go
@@ -261,6 +261,116 @@ func TestService_UpdateProfile_Success(t *testing.T) {
 	assert.True(t, bundle.User.IsBot)
 }
 
+// #467: avatarId に SET / CLEAR / 不明 ID / 他人ファイル / 非画像 MIME を
+// 与えたときの挙動を確認する。banner も同経路 (applyMediaUpdate を共有)
+// なので avatar 側で代表させる。
+func TestService_UpdateProfile_AvatarSet(t *testing.T) {
+	svc, userRepo, _, _ := newFullSvc(t)
+	userRepo.Users["u1"] = &model.User{ID: "u1", Username: "alice"}
+	driveRepo := testutil.NewMockDriveFileRepository()
+	owner := "u1"
+	bh := "L6PZfSi_.AyE_3t7t7R**0o#DgR4"
+	driveRepo.Files["f1"] = &model.DriveFile{
+		ID: "f1", UserID: &owner, Type: "image/png",
+		URL: "https://cdn.example/avatar.png", Blurhash: &bh,
+	}
+	svc.SetDriveFileRepository(driveRepo)
+
+	id := "f1"
+	bundle, err := svc.UpdateProfile("u1", user.UpdateInput{AvatarID: &id})
+	require.NoError(t, err)
+	require.NotNil(t, bundle.User.AvatarID)
+	assert.Equal(t, "f1", *bundle.User.AvatarID)
+	require.NotNil(t, bundle.User.AvatarURL)
+	assert.Equal(t, "https://cdn.example/avatar.png", *bundle.User.AvatarURL)
+	require.NotNil(t, bundle.User.AvatarBlurhash)
+	assert.Equal(t, bh, *bundle.User.AvatarBlurhash)
+}
+
+func TestService_UpdateProfile_AvatarClear(t *testing.T) {
+	svc, userRepo, _, _ := newFullSvc(t)
+	existingID := "f0"
+	existingURL := "https://cdn.example/old.png"
+	existingBh := "old"
+	userRepo.Users["u1"] = &model.User{
+		ID: "u1", Username: "alice",
+		AvatarID:       &existingID,
+		AvatarURL:      &existingURL,
+		AvatarBlurhash: &existingBh,
+	}
+	driveRepo := testutil.NewMockDriveFileRepository()
+	svc.SetDriveFileRepository(driveRepo)
+
+	empty := ""
+	bundle, err := svc.UpdateProfile("u1", user.UpdateInput{AvatarID: &empty})
+	require.NoError(t, err)
+	assert.Nil(t, bundle.User.AvatarID)
+	assert.Nil(t, bundle.User.AvatarURL)
+	assert.Nil(t, bundle.User.AvatarBlurhash)
+}
+
+func TestService_UpdateProfile_AvatarNotFound(t *testing.T) {
+	svc, userRepo, _, _ := newFullSvc(t)
+	userRepo.Users["u1"] = &model.User{ID: "u1", Username: "alice"}
+	svc.SetDriveFileRepository(testutil.NewMockDriveFileRepository())
+
+	id := "missing"
+	_, err := svc.UpdateProfile("u1", user.UpdateInput{AvatarID: &id})
+	assert.True(t, errors.Is(err, user.ErrAvatarNotFound))
+}
+
+func TestService_UpdateProfile_AvatarNotOwned(t *testing.T) {
+	svc, userRepo, _, _ := newFullSvc(t)
+	userRepo.Users["u1"] = &model.User{ID: "u1", Username: "alice"}
+	driveRepo := testutil.NewMockDriveFileRepository()
+	otherOwner := "u2"
+	driveRepo.Files["f1"] = &model.DriveFile{
+		ID: "f1", UserID: &otherOwner, Type: "image/png", URL: "https://x/x",
+	}
+	svc.SetDriveFileRepository(driveRepo)
+
+	id := "f1"
+	_, err := svc.UpdateProfile("u1", user.UpdateInput{AvatarID: &id})
+	// owner mismatch も notFound で扱う (upstream 互換 + 列挙攻撃避け)。
+	assert.True(t, errors.Is(err, user.ErrAvatarNotFound))
+}
+
+func TestService_UpdateProfile_AvatarNotImage(t *testing.T) {
+	svc, userRepo, _, _ := newFullSvc(t)
+	userRepo.Users["u1"] = &model.User{ID: "u1", Username: "alice"}
+	driveRepo := testutil.NewMockDriveFileRepository()
+	owner := "u1"
+	driveRepo.Files["f1"] = &model.DriveFile{
+		ID: "f1", UserID: &owner, Type: "video/mp4", URL: "https://x/v.mp4",
+	}
+	svc.SetDriveFileRepository(driveRepo)
+
+	id := "f1"
+	_, err := svc.UpdateProfile("u1", user.UpdateInput{AvatarID: &id})
+	assert.True(t, errors.Is(err, user.ErrAvatarNotImage))
+}
+
+func TestService_UpdateProfile_BannerSet(t *testing.T) {
+	// banner は avatar と applyMediaUpdate 共有なので smoke test 1 件のみ。
+	svc, userRepo, _, _ := newFullSvc(t)
+	userRepo.Users["u1"] = &model.User{ID: "u1", Username: "alice"}
+	driveRepo := testutil.NewMockDriveFileRepository()
+	owner := "u1"
+	driveRepo.Files["b1"] = &model.DriveFile{
+		ID: "b1", UserID: &owner, Type: "image/jpeg",
+		URL: "https://cdn.example/banner.jpg",
+	}
+	svc.SetDriveFileRepository(driveRepo)
+
+	id := "b1"
+	bundle, err := svc.UpdateProfile("u1", user.UpdateInput{BannerID: &id})
+	require.NoError(t, err)
+	require.NotNil(t, bundle.User.BannerID)
+	assert.Equal(t, "b1", *bundle.User.BannerID)
+	require.NotNil(t, bundle.User.BannerURL)
+	assert.Equal(t, "https://cdn.example/banner.jpg", *bundle.User.BannerURL)
+}
+
 func TestService_UpdateProfile_NoFields(t *testing.T) {
 	svc, repo, _, _ := newFullSvc(t)
 	repo.Users["u1"] = &model.User{ID: "u1", Username: "alice"}

--- a/internal/entity/user.go
+++ b/internal/entity/user.go
@@ -36,6 +36,8 @@ type UserLite struct {
 // UserDetailed includes additional fields for detailed user views.
 type UserDetailed struct {
 	UserLite
+	AvatarID            *string        `json:"avatarId"`
+	BannerID            *string        `json:"bannerId"`
 	BannerURL           *string        `json:"bannerUrl"`
 	BannerBlurhash      *string        `json:"bannerBlurhash"`
 	IsLocked            bool           `json:"isLocked"`
@@ -142,6 +144,8 @@ func PackUserLite(u *model.User) UserLite {
 func PackUserDetailed(u *model.User, profile *model.UserProfile, idGens ...id.Generator) UserDetailed {
 	d := UserDetailed{
 		UserLite:            PackUserLite(u),
+		AvatarID:            u.AvatarID,
+		BannerID:            u.BannerID,
 		BannerURL:           u.BannerURL,
 		BannerBlurhash:      u.BannerBlurhash,
 		IsLocked:            u.IsLocked,

--- a/internal/server/router.go
+++ b/internal/server/router.go
@@ -195,6 +195,9 @@ func (s *Server) setupRoutes() {
 	noteQueryService.SetFavoriteRepo(noteFavoriteRepo)
 	noteQueryService.SetThreadMutingRepo(noteThreadMutingRepo)
 	userService := coreuser.NewService(userRepo, noteRepo, piningRepo, idGen)
+	// /api/i/update の avatarId / bannerId 経路 (#467) で drive_file の
+	// 所有権検証 + URL コピーが必要なため、driveFileRepo を配線する。
+	userService.SetDriveFileRepository(driveFileRepo)
 	followingService := corefollowing.NewService(userRepo, followingRepo, followRequestRepo, idGen)
 
 	// Timeline services (Redis-backed fanout)

--- a/internal/testutil/mock_repository.go
+++ b/internal/testutil/mock_repository.go
@@ -326,6 +326,23 @@ func (m *MockUserRepository) UpdateProfile(userID string, fields map[string]any)
 }
 
 // applyUserFields は単純な型の代表例にだけ対応する。新しいフィールドを使う場合はここに追加する。
+// ptrOrNilString normalises a fields-map value (which can be plain
+// string, *string, or untyped nil — the production UpdateProfile call
+// site passes any of these depending on the SET / CLEAR / pre-validated
+// path) into the *string form used by model.User. Unrecognised types
+// fall through to leaving the column unchanged.
+func ptrOrNilString(v any) *string {
+	switch s := v.(type) {
+	case nil:
+		return nil
+	case string:
+		return &s
+	case *string:
+		return s
+	}
+	return nil
+}
+
 func applyUserFields(u *model.User, fields map[string]any) {
 	for k, v := range fields {
 		switch k {
@@ -402,13 +419,17 @@ func applyUserFields(u *model.User, fields map[string]any) {
 				u.AlsoKnownAs = &s
 			}
 		case "avatarUrl":
-			if s, ok := v.(*string); ok {
-				u.AvatarURL = s
-			}
+			u.AvatarURL = ptrOrNilString(v)
 		case "bannerUrl":
-			if s, ok := v.(*string); ok {
-				u.BannerURL = s
-			}
+			u.BannerURL = ptrOrNilString(v)
+		case "avatarId":
+			u.AvatarID = ptrOrNilString(v)
+		case "bannerId":
+			u.BannerID = ptrOrNilString(v)
+		case "avatarBlurhash":
+			u.AvatarBlurhash = ptrOrNilString(v)
+		case "bannerBlurhash":
+			u.BannerBlurhash = ptrOrNilString(v)
 		}
 	}
 }


### PR DESCRIPTION
## Summary

UDS で `/api/i/update` に `{avatarId / bannerId}` を送ってもアイコン / ヘッダーが反映されない問題を修正する。

Closes #467

## 根本原因

`internal/api/i/handler.go` の `UpdateRequest` に **`avatarId` / `bannerId` フィールド自体が無く**、handler / `user.UpdateInput` / `Service.UpdateProfile` すべてが avatar / banner を扱っていなかった。upstream Misskey TS の `endpoints/i/update.ts` は drive_file lookup → 所有権 + image MIME 検証 → `user.avatarUrl` / `avatarBlurhash` も同時更新するロジックを持っているが、mk-go では完全に欠落していた。

## 主な変更点

### handler (`internal/api/i/handler.go`)

- `UpdateRequest` に `AvatarID` / `BannerID` (`*string`) を追加
- `Update` から `user.UpdateInput` へパススルー
- Service が返す sentinel error を upstream 互換の error code + UUID で返す:
  - `NO_SUCH_AVATAR` (`539f3a45-f215-4f81-a9a8-31293640207f`)
  - `AVATAR_NOT_AN_IMAGE` (`f419f9f8-2f4d-46b1-9fb4-49d3a2fd7191`)
  - `NO_SUCH_BANNER` (`0d8f5629-f210-41c2-9433-735831a58595`)
  - `BANNER_NOT_AN_IMAGE` (`75aedb19-2afd-4e6d-87fc-67941256fa60`)

### user.Service (`internal/core/user/user_service.go`)

- `driveFileRepo` 依存を追加 (`SetDriveFileRepository` setter)。未配線時は avatar / banner 経路 skip して旧挙動を維持
- `UpdateInput` に `AvatarID` / `BannerID` を追加。tri-state semantic:
  - `nil` → 不変
  - `&""` → CLEAR (`avatarId` / `avatarUrl` / `avatarBlurhash` を NULL に)
  - `&"<id>"` → SET (drive_file 行を引いて所有権 + image MIME 検証)
- `applyMediaUpdate` ヘルパーで avatar / banner 共通の処理を集約

#### JSON null clear semantic (non-goal)

upstream は `{avatarId: null}` を CLEAR として扱うが、Go の `*string` では `null` と `omitted` を区別できない。本 PR は空文字列 `""` を CLEAR の sentinel にする。frontend が null clear を要求するようになったら `json.RawMessage` ベースに昇格させる別 issue で対応する。

### entity (`internal/entity/user.go`)

`UserDetailed` に `AvatarID` / `BannerID` を追加。upstream の `MeDetailed` schema と互換にして、`/api/i/update` のレスポンス JSON に正しく `avatarId` / `bannerId` が乗るようにする (これが無いと frontend が「設定したファイル ID」を取り出せず、表示状態の同期に失敗する)。

### testutil (`internal/testutil/mock_repository.go`)

`MockUserRepository.applyUserFields` の `avatarUrl` / `bannerUrl` 経路が `*string` のみ受けていたのを `ptrOrNilString` helper に切り替え、plain `string` / `*string` / `nil` の 3 パターンを受けるよう拡張。新しく `avatarId` / `bannerId` / `avatarBlurhash` / `bannerBlurhash` の column 対応も追加。

## テスト

### 追加テスト

- `TestService_UpdateProfile_AvatarSet` — drive_file から avatarId/Url/Blurhash がコピーされる
- `TestService_UpdateProfile_AvatarClear` — `&""` で 3 列とも NULL に
- `TestService_UpdateProfile_AvatarNotFound` — 不明 file_id で `ErrAvatarNotFound`
- `TestService_UpdateProfile_AvatarNotOwned` — 他ユーザー所有でも `ErrAvatarNotFound` (列挙攻撃避けで notFound 扱い)
- `TestService_UpdateProfile_AvatarNotImage` — `video/mp4` 等で `ErrAvatarNotImage`
- `TestService_UpdateProfile_BannerSet` — banner も同経路で動く smoke test

### 実行

\`\`\`bash
make fmt && make lint && make test
\`\`\`

ローカルで全パッケージ green。

### 手動検証 (UDS スタック)

修正前: `/api/i/update` の avatarId / bannerId が完全に無視され、DB は変化なし。レスポンスにも反映されない。

修正後: SET / CLEAR / 所有権違反 / 非画像 すべてのパスで期待通りの結果。frontend からアイコン / ヘッダーを変更してリモートサーバーから取得しても新しい URL が反映されることをユーザーから確認 OK 取得済。

## non-goals

- JSON `null` を clear semantic として認識する (`json.RawMessage` 化): 別 issue
- avatar decorations (`avatarDecorations` 配列): 別機能
- AP outbound `Update Person` activity への新 avatar URL 反映: 既存の Update activity 経路があれば自然にカバー、無ければ別 issue
- role policies (`canUpdateBioMedia`) による制限: 別 issue

## 関連

- Closes #467
- 同じ UDS バッチで報告された他 bug: #466 / #468 / #469 / #470 / #471 / #472 / #473
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/shiroha-a/mk/pull/478" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
