### PR TITLE
Fix admin/emoji: 旧画面のリスト描画 + 無限ループ + v2 検索 filter (#466)

### DIFF
--- a/internal/api/admin/drive_emoji_test.go
+++ b/internal/api/admin/drive_emoji_test.go
@@ -382,6 +382,57 @@ func TestEmojiListV2_QueryFilter(t *testing.T) {
 	assert.EqualValues(t, 2, resp["allCount"])
 }
 
+// #466: frontend が remote emoji 検索ボックスから uri / publicUrl /
+// originalUrl filter を渡してくる。handler / model / repo がこれらを
+// 受けないと silent ignore で「検索しても全件出る」状態になる。
+func TestEmojiListV2_URIFilter(t *testing.T) {
+	h, _, _, _ := newTestHandler(t)
+	repo := testutil.NewMockEmojiRepository()
+	hostA := "alpha.example"
+	hostB := "beta.example"
+	uriA := "https://alpha.example/emojis/x"
+	uriB := "https://beta.example/emojis/y"
+	require.NoError(t, repo.Create(&model.Emoji{
+		ID: "e1", Name: "x", Host: &hostA, URI: &uriA,
+		OriginalURL: "https://alpha-cdn.example/x.png",
+		PublicURL:   "https://alpha-cdn.example/x.png",
+	}))
+	require.NoError(t, repo.Create(&model.Emoji{
+		ID: "e2", Name: "y", Host: &hostB, URI: &uriB,
+		OriginalURL: "https://beta-cdn.example/y.png",
+		PublicURL:   "https://beta-cdn.example/y.png",
+	}))
+	h.SetEmojiRepo(repo)
+
+	t.Run("uri filter narrows to alpha", func(t *testing.T) {
+		rec := doPost(h.EmojiListV2, `{"query":{"uri":"alpha.example"}}`, adminUser)
+		assert.Equal(t, http.StatusOK, rec.Code)
+		var resp map[string]any
+		require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+		emojis := resp["emojis"].([]any)
+		require.Len(t, emojis, 1)
+		assert.Equal(t, "e1", emojis[0].(map[string]any)["id"])
+	})
+	t.Run("publicUrl filter narrows to beta", func(t *testing.T) {
+		rec := doPost(h.EmojiListV2, `{"query":{"publicUrl":"beta-cdn"}}`, adminUser)
+		assert.Equal(t, http.StatusOK, rec.Code)
+		var resp map[string]any
+		require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+		emojis := resp["emojis"].([]any)
+		require.Len(t, emojis, 1)
+		assert.Equal(t, "e2", emojis[0].(map[string]any)["id"])
+	})
+	t.Run("originalUrl filter narrows to alpha", func(t *testing.T) {
+		rec := doPost(h.EmojiListV2, `{"query":{"originalUrl":"alpha-cdn"}}`, adminUser)
+		assert.Equal(t, http.StatusOK, rec.Code)
+		var resp map[string]any
+		require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+		emojis := resp["emojis"].([]any)
+		require.Len(t, emojis, 1)
+		assert.Equal(t, "e1", emojis[0].(map[string]any)["id"])
+	})
+}
+
 func TestEmojiListV2_Pagination(t *testing.T) {
 	h, _, _, _ := newTestHandler(t)
 	repo := testutil.NewMockEmojiRepository()

--- a/internal/api/admin/handler.go
+++ b/internal/api/admin/handler.go
@@ -1088,6 +1088,8 @@ func (h *Handler) EmojiList(c echo.Context) error {
 	var req struct {
 		Query    string `json:"query"`
 		Category string `json:"category"`
+		SinceID  string `json:"sinceId"`
+		UntilID  string `json:"untilId"`
 		Limit    int    `json:"limit"`
 		Offset   int    `json:"offset"`
 	}
@@ -1097,7 +1099,7 @@ func (h *Handler) EmojiList(c echo.Context) error {
 	if h.emojiRepo == nil {
 		return c.JSON(http.StatusOK, []any{})
 	}
-	emojis, err := h.emojiRepo.ListWithFilter(req.Query, req.Category, true, req.Limit, req.Offset)
+	emojis, err := h.emojiRepo.ListWithFilter(req.Query, req.Category, true, req.SinceID, req.UntilID, req.Limit, req.Offset)
 	if err != nil {
 		return c.JSON(http.StatusInternalServerError, apierr.Error("INTERNAL_ERROR", "Internal error.", "5d37dbcb-891e-41ca-a3d6-e690c97775ac"))
 	}
@@ -1156,6 +1158,9 @@ func (h *Handler) EmojiListV2(c echo.Context) error {
 			UpdatedAtFrom: req.Query.UpdatedAtFrom,
 			UpdatedAtTo:   req.Query.UpdatedAtTo,
 			RoleIDs:       req.Query.RoleIDs,
+			URI:           req.Query.URI,
+			PublicURL:     req.Query.PublicURL,
+			OriginalURL:   req.Query.OriginalURL,
 		}
 	}
 
@@ -1196,6 +1201,13 @@ type emojiV2QueryReq struct {
 	UpdatedAtFrom string   `json:"updatedAtFrom"`
 	UpdatedAtTo   string   `json:"updatedAtTo"`
 	RoleIDs       []string `json:"roleIds"`
+	// URI / PublicURL / OriginalURL は upstream Misskey の v2 検索 schema
+	// で受け付けている filter (#466)。frontend (custom-emojis-manager.remote
+	// .vue) の検索ボックスから送られてくるため、handler 側で受けないと
+	// silently 無視される。受信したら repo の WHERE 句に展開する。
+	URI         string `json:"uri"`
+	PublicURL   string `json:"publicUrl"`
+	OriginalURL string `json:"originalUrl"`
 }
 
 type emojiListV2Response struct {

--- a/internal/api/admin/handler_stubs.go
+++ b/internal/api/admin/handler_stubs.go
@@ -638,23 +638,31 @@ func (h *Handler) EmojiListRemote(c echo.Context) error {
 		return c.JSON(http.StatusOK, []any{})
 	}
 	var req struct {
-		Query  string `json:"query"`
-		Host   string `json:"host"`
-		Limit  int    `json:"limit"`
-		Offset int    `json:"offset"`
+		Query   string `json:"query"`
+		Host    string `json:"host"`
+		SinceID string `json:"sinceId"`
+		UntilID string `json:"untilId"`
+		Limit   int    `json:"limit"`
+		Offset  int    `json:"offset"`
 	}
 	_ = c.Bind(&req)
 	if req.Limit <= 0 || req.Limit > 100 {
 		req.Limit = 30
 	}
-	emojis, err := h.emojiRepo.ListRemoteWithFilter(req.Query, req.Host, req.Limit, req.Offset)
+	emojis, err := h.emojiRepo.ListRemoteWithFilter(req.Query, req.Host, req.SinceID, req.UntilID, req.Limit, req.Offset)
 	if err != nil {
 		return c.JSON(http.StatusInternalServerError, apierr.Error("INTERNAL_ERROR", "Internal error.", "00000000-0000-0000-0000-000000000000"))
 	}
 	if emojis == nil {
 		return c.JSON(http.StatusOK, []any{})
 	}
-	return c.JSON(http.StatusOK, emojis)
+	// upstream Misskey の admin/emoji/list-remote は EmojiDetailed schema を
+	// 返す (= `url` field、`publicUrl` ではない)。frontend の旧
+	// custom-emojis-manager.vue は emoji.url を読み込んで <img> を組み立てる
+	// ため、raw model.Emoji (publicUrl / originalUrl 持ち、url 無し) を返すと
+	// 画像が壊れて表示そのものが空に見える (#466)。entity.PackEmojiDetailedList
+	// で publicUrl → url 変換した shape にする。
+	return c.JSON(http.StatusOK, entity.PackEmojiDetailedList(emojis))
 }
 
 // EmojiRemoveAliasesBulk handles POST /api/admin/emoji/remove-aliases-bulk.

--- a/internal/api/admin/handler_test.go
+++ b/internal/api/admin/handler_test.go
@@ -972,7 +972,7 @@ type failingListEmojiRepo struct {
 	*testutil.MockEmojiRepository
 }
 
-func (f *failingListEmojiRepo) ListWithFilter(_, _ string, _ bool, _, _ int) ([]*model.Emoji, error) {
+func (f *failingListEmojiRepo) ListWithFilter(_, _ string, _ bool, _, _ string, _, _ int) ([]*model.Emoji, error) {
 	return nil, assert.AnError
 }
 

--- a/internal/core/emojiimport/coverage_boost_test.go
+++ b/internal/core/emojiimport/coverage_boost_test.go
@@ -172,8 +172,8 @@ func (r *failingEmojiRepo) UpdateFields(id string, fields map[string]any) error 
 
 func (r *failingEmojiRepo) Delete(id string) error { return r.inner.Delete(id) }
 
-func (r *failingEmojiRepo) ListWithFilter(q, c string, l bool, lim, off int) ([]*model.Emoji, error) {
-	return r.inner.ListWithFilter(q, c, l, lim, off)
+func (r *failingEmojiRepo) ListWithFilter(q, c string, l bool, sinceID, untilID string, lim, off int) ([]*model.Emoji, error) {
+	return r.inner.ListWithFilter(q, c, l, sinceID, untilID, lim, off)
 }
 
 func (r *failingEmojiRepo) ListLocal() ([]*model.Emoji, error) { return r.inner.ListLocal() }
@@ -190,8 +190,8 @@ func (r *failingEmojiRepo) DeleteMany(ids []string) error {
 	return r.inner.DeleteMany(ids)
 }
 
-func (r *failingEmojiRepo) ListRemoteWithFilter(q, host string, limit, offset int) ([]*model.Emoji, error) {
-	return r.inner.ListRemoteWithFilter(q, host, limit, offset)
+func (r *failingEmojiRepo) ListRemoteWithFilter(q, host, sinceID, untilID string, limit, offset int) ([]*model.Emoji, error) {
+	return r.inner.ListRemoteWithFilter(q, host, sinceID, untilID, limit, offset)
 }
 
 func (r *failingEmojiRepo) ListV2(filter model.EmojiV2Filter) ([]*model.Emoji, error) {

--- a/internal/model/emoji.go
+++ b/internal/model/emoji.go
@@ -50,4 +50,10 @@ type EmojiV2Query struct {
 	UpdatedAtFrom string
 	UpdatedAtTo   string
 	RoleIDs       []string
+	// URI / PublicURL / OriginalURL は admin v2 emoji 検索の追加 filter
+	// (#466)。frontend が remote emoji 一覧の検索ボックスから渡してくる
+	// ので、空文字列でなければ ILIKE 部分一致で WHERE に展開する。
+	URI         string
+	PublicURL   string
+	OriginalURL string
 }

--- a/internal/repository/coverage_complete_test.go
+++ b/internal/repository/coverage_complete_test.go
@@ -201,7 +201,7 @@ func TestErrorPaths_CancelledContext(t *testing.T) {
 	// emoji
 	_, err = NewEmojiRepository(db).FindManyByIDs([]string{"x"})
 	assert.Error(t, err)
-	_, err = NewEmojiRepository(db).ListRemoteWithFilter("", "x", 10, 0)
+	_, err = NewEmojiRepository(db).ListRemoteWithFilter("", "x", "", "", 10, 0)
 	assert.Error(t, err)
 
 	// following

--- a/internal/repository/coverage_final_test.go
+++ b/internal/repository/coverage_final_test.go
@@ -119,9 +119,9 @@ func TestDriveFileRepository_ListForAdmin_Branches(t *testing.T) {
 
 func TestEmojiRepository_ListRemoteWithFilter_Clamp(t *testing.T) {
 	r := NewEmojiRepository(testDB)
-	_, err := r.ListRemoteWithFilter("", "remote.example", 0, 0)
+	_, err := r.ListRemoteWithFilter("", "remote.example", "", "", 0, 0)
 	require.NoError(t, err)
-	_, err = r.ListRemoteWithFilter("", "remote.example", 999, 0)
+	_, err = r.ListRemoteWithFilter("", "remote.example", "", "", 999, 0)
 	require.NoError(t, err)
 }
 
@@ -399,7 +399,7 @@ func TestChatRepository_ListHistory_WithData(t *testing.T) {
 // emoji.ListRemoteWithFilter: querystring指定 (substring filter) 分岐
 func TestEmojiRepository_ListRemoteWithFilter_Query(t *testing.T) {
 	r := NewEmojiRepository(testDB)
-	_, err := r.ListRemoteWithFilter("cat", "remote.example", 10, 0)
+	_, err := r.ListRemoteWithFilter("cat", "remote.example", "", "", 10, 0)
 	require.NoError(t, err)
 }
 
@@ -468,7 +468,7 @@ func TestMetaRepository_EnsureInitial_DBError(t *testing.T) {
 // emoji.ListRemoteWithFilter: offset > 0 分岐
 func TestEmojiRepository_ListRemoteWithFilter_Offset(t *testing.T) {
 	r := NewEmojiRepository(testDB)
-	_, err := r.ListRemoteWithFilter("", "remote.example", 10, 5)
+	_, err := r.ListRemoteWithFilter("", "remote.example", "", "", 10, 5)
 	require.NoError(t, err)
 }
 

--- a/internal/repository/emoji.go
+++ b/internal/repository/emoji.go
@@ -24,13 +24,15 @@ type EmojiRepository interface {
 	// DeleteMany removes rows matching any id in ids.
 	DeleteMany(ids []string) error
 	// ListWithFilter returns emojis matching search/category/host filters.
-	ListWithFilter(query, category string, local bool, limit, offset int) ([]*model.Emoji, error)
+	// sinceID / untilID は cursor-based pagination 用で、空文字列なら無視。
+	// frontend Paginator (cursor 方式) と offset 方式の両方を受け付ける。
+	ListWithFilter(query, category string, local bool, sinceID, untilID string, limit, offset int) ([]*model.Emoji, error)
 	// FindManyByNamesAndHost returns emojis matching any of the given names for
 	// a specific host. host=nil searches local emojis (host IS NULL).
 	FindManyByNamesAndHost(names []string, host *string) ([]*model.Emoji, error)
 	// ListRemoteWithFilter mirrors ListWithFilter for remote emojis. host empty
 	// matches any remote host.
-	ListRemoteWithFilter(query, host string, limit, offset int) ([]*model.Emoji, error)
+	ListRemoteWithFilter(query, host, sinceID, untilID string, limit, offset int) ([]*model.Emoji, error)
 	// ListV2 returns emojis matching v2 filters with sorting + pagination.
 	ListV2(filter model.EmojiV2Filter) ([]*model.Emoji, error)
 	// CountV2 returns total count of emojis matching v2 filters (pagination ignored).
@@ -116,13 +118,19 @@ func (r *emojiRepository) FindManyByNamesAndHost(names []string, host *string) (
 	return emojis, nil
 }
 
-func (r *emojiRepository) ListRemoteWithFilter(query, host string, limit, offset int) ([]*model.Emoji, error) {
+func (r *emojiRepository) ListRemoteWithFilter(query, host, sinceID, untilID string, limit, offset int) ([]*model.Emoji, error) {
 	q := r.db.Where("host IS NOT NULL").Order("id DESC")
 	if query != "" {
 		q = q.Where("name ILIKE ?", "%"+query+"%")
 	}
 	if host != "" {
 		q = q.Where("host = ?", host)
+	}
+	if sinceID != "" {
+		q = q.Where("id > ?", sinceID)
+	}
+	if untilID != "" {
+		q = q.Where("id < ?", untilID)
 	}
 	if limit <= 0 {
 		limit = 30
@@ -141,7 +149,7 @@ func (r *emojiRepository) ListRemoteWithFilter(query, host string, limit, offset
 	return emojis, nil
 }
 
-func (r *emojiRepository) ListWithFilter(query, category string, local bool, limit, offset int) ([]*model.Emoji, error) {
+func (r *emojiRepository) ListWithFilter(query, category string, local bool, sinceID, untilID string, limit, offset int) ([]*model.Emoji, error) {
 	q := r.db.Order("id ASC")
 	if local {
 		q = q.Where("host IS NULL")
@@ -151,6 +159,12 @@ func (r *emojiRepository) ListWithFilter(query, category string, local bool, lim
 	}
 	if category != "" {
 		q = q.Where("category = ?", category)
+	}
+	if sinceID != "" {
+		q = q.Where("id > ?", sinceID)
+	}
+	if untilID != "" {
+		q = q.Where("id < ?", untilID)
 	}
 	if limit <= 0 {
 		limit = 50
@@ -213,6 +227,15 @@ func (r *emojiRepository) buildV2Query(filter model.EmojiV2Filter) *gorm.DB {
 		}
 		if fq.License != "" {
 			q = q.Where("license ILIKE ?", "%"+fq.License+"%")
+		}
+		if fq.URI != "" {
+			q = q.Where("uri ILIKE ?", "%"+fq.URI+"%")
+		}
+		if fq.PublicURL != "" {
+			q = q.Where(`"publicUrl" ILIKE ?`, "%"+fq.PublicURL+"%")
+		}
+		if fq.OriginalURL != "" {
+			q = q.Where(`"originalUrl" ILIKE ?`, "%"+fq.OriginalURL+"%")
 		}
 		if fq.IsSensitive != nil {
 			q = q.Where(`"isSensitive" = ?`, *fq.IsSensitive)

--- a/internal/repository/emoji_test.go
+++ b/internal/repository/emoji_test.go
@@ -95,45 +95,45 @@ func TestEmojiRepository_ListWithFilter(t *testing.T) {
 	require.NoError(t, repo.Create(e))
 	defer cleanupEmoji(t, e.ID)
 
-	emojis, err := repo.ListWithFilter("filter", "", true, 10, 0)
+	emojis, err := repo.ListWithFilter("filter", "", true, "", "", 10, 0)
 	require.NoError(t, err)
 	assert.NotEmpty(t, emojis)
 
 	// category filter
-	emojis, err = repo.ListWithFilter("", "nonexistent", true, 10, 0)
+	emojis, err = repo.ListWithFilter("", "nonexistent", true, "", "", 10, 0)
 	require.NoError(t, err)
 	assert.Empty(t, emojis)
 
 	// pagination
-	emojis, err = repo.ListWithFilter("", "", true, 1, 0)
+	emojis, err = repo.ListWithFilter("", "", true, "", "", 1, 0)
 	require.NoError(t, err)
 	assert.LessOrEqual(t, len(emojis), 1)
 }
 
 func TestEmojiRepository_ListWithFilter_DefaultLimit(t *testing.T) {
 	repo := NewEmojiRepository(testDB)
-	emojis, err := repo.ListWithFilter("", "", true, 0, 0) // limit=0 → default 50
+	emojis, err := repo.ListWithFilter("", "", true, "", "", 0, 0) // limit=0 → default 50
 	require.NoError(t, err)
 	_ = emojis
 }
 
 func TestEmojiRepository_ListWithFilter_LimitCap(t *testing.T) {
 	repo := NewEmojiRepository(testDB)
-	emojis, err := repo.ListWithFilter("", "", true, 999, 0)
+	emojis, err := repo.ListWithFilter("", "", true, "", "", 999, 0)
 	require.NoError(t, err)
 	assert.LessOrEqual(t, len(emojis), 500)
 }
 
 func TestEmojiRepository_ListWithFilter_Offset(t *testing.T) {
 	repo := NewEmojiRepository(testDB)
-	emojis, err := repo.ListWithFilter("", "", true, 10, 99999)
+	emojis, err := repo.ListWithFilter("", "", true, "", "", 10, 99999)
 	require.NoError(t, err)
 	assert.Empty(t, emojis)
 }
 
 func TestEmojiRepository_ListWithFilter_NonLocal(t *testing.T) {
 	repo := NewEmojiRepository(testDB)
-	emojis, err := repo.ListWithFilter("", "", false, 10, 0)
+	emojis, err := repo.ListWithFilter("", "", false, "", "", 10, 0)
 	require.NoError(t, err)
 	_ = emojis // ローカルフィルタなし
 }
@@ -142,7 +142,7 @@ func TestEmojiRepository_ListWithFilter_Error(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel()
 	repo := NewEmojiRepository(testDB.WithContext(ctx))
-	_, err := repo.ListWithFilter("", "", true, 10, 0)
+	_, err := repo.ListWithFilter("", "", true, "", "", 10, 0)
 	assert.Error(t, err)
 }
 
@@ -269,19 +269,19 @@ func TestEmojiRepository_ListRemoteWithFilter(t *testing.T) {
 	defer cleanupEmoji(t, e1.ID)
 	defer cleanupEmoji(t, e2.ID)
 
-	rows, err := repo.ListRemoteWithFilter("", host, 10, 0)
+	rows, err := repo.ListRemoteWithFilter("", host, "", "", 10, 0)
 	require.NoError(t, err)
 	assert.GreaterOrEqual(t, len(rows), 2)
 
-	filtered, err := repo.ListRemoteWithFilter("cat", host, 10, 0)
+	filtered, err := repo.ListRemoteWithFilter("cat", host, "", "", 10, 0)
 	require.NoError(t, err)
 	assert.Len(t, filtered, 1)
 	assert.Equal(t, e1.ID, filtered[0].ID)
 
 	// limit default / cap
-	_, err = repo.ListRemoteWithFilter("", host, 0, 0) // default 30
+	_, err = repo.ListRemoteWithFilter("", host, "", "", 0, 0) // default 30
 	require.NoError(t, err)
-	_, err = repo.ListRemoteWithFilter("", host, 1000, 0) // clamped to 100
+	_, err = repo.ListRemoteWithFilter("", host, "", "", 1000, 0) // clamped to 100
 	require.NoError(t, err)
 }
 

--- a/internal/testutil/mock_repository.go
+++ b/internal/testutil/mock_repository.go
@@ -1260,10 +1260,16 @@ func (m *MockEmojiRepository) Delete(id string) error {
 	return nil
 }
 
-func (m *MockEmojiRepository) ListWithFilter(query, category string, local bool, limit, offset int) ([]*model.Emoji, error) {
+func (m *MockEmojiRepository) ListWithFilter(query, category string, local bool, sinceID, untilID string, limit, offset int) ([]*model.Emoji, error) {
 	var result []*model.Emoji
 	for _, e := range m.Emojis {
 		if local && e.Host != nil {
+			continue
+		}
+		if sinceID != "" && e.ID <= sinceID {
+			continue
+		}
+		if untilID != "" && e.ID >= untilID {
 			continue
 		}
 		result = append(result, e)
@@ -1367,7 +1373,7 @@ func (m *MockEmojiRepository) DeleteMany(ids []string) error {
 	return nil
 }
 
-func (m *MockEmojiRepository) ListRemoteWithFilter(query, host string, limit, offset int) ([]*model.Emoji, error) {
+func (m *MockEmojiRepository) ListRemoteWithFilter(query, host, sinceID, untilID string, limit, offset int) ([]*model.Emoji, error) {
 	out := make([]*model.Emoji, 0)
 	seen := make(map[string]bool)
 	for _, e := range m.Emojis {
@@ -1381,6 +1387,12 @@ func (m *MockEmojiRepository) ListRemoteWithFilter(query, host string, limit, of
 			continue
 		}
 		if query != "" && !strings.Contains(strings.ToLower(e.Name), strings.ToLower(query)) {
+			continue
+		}
+		if sinceID != "" && e.ID <= sinceID {
+			continue
+		}
+		if untilID != "" && e.ID >= untilID {
 			continue
 		}
 		seen[e.ID] = true
@@ -1481,6 +1493,17 @@ func (m *MockEmojiRepository) filterV2(filter model.EmojiV2Filter) []*model.Emoj
 				if e.License == nil || !mockILIKE(*e.License, fq.License) {
 					continue
 				}
+			}
+			if fq.URI != "" {
+				if e.URI == nil || !mockILIKE(*e.URI, fq.URI) {
+					continue
+				}
+			}
+			if fq.PublicURL != "" && !mockILIKE(e.PublicURL, fq.PublicURL) {
+				continue
+			}
+			if fq.OriginalURL != "" && !mockILIKE(e.OriginalURL, fq.OriginalURL) {
+				continue
 			}
 			if fq.IsSensitive != nil && e.IsSensitive != *fq.IsSensitive {
 				continue


### PR DESCRIPTION
## Summary

UDS スタックでコントロールパネル → カスタム絵文字 (旧画面) でリモート絵文字一覧が表示されず、検索もできない問題を修正する。原因は **3つ** あり、それぞれを塞ぐ。

Closes #466

## 1. `EmojiListRemote` の response field 名ずれ (root cause)

upstream Misskey の `admin/emoji/list-remote` は `EmojiDetailed` schema (field 名は `url`) を返す。一方 mk-go の handler は raw `model.Emoji` を直接 `c.JSON` で返していたため、JSON は `publicUrl` / `originalUrl` のみで **`url` field 不在**。frontend 旧画面 (`custom-emojis-manager.vue`) は `emoji.url` を読んで `<img>` を組み立てるため、undefined → 画像読込失敗 → list が空に見える状態だった。

修正: `entity.PackEmojiDetailedList(emojis)` 経由で `publicUrl → url` 変換した shape を返す (v1 `admin/emoji/list` と同じ packing パス)。

## 2. cursor-based pagination 未対応 → 無限スクロールループ

frontend の Paginator は `untilId` / `sinceId` で cursor 方式のページングを行う。mk-go の v1 handler は offset 方式のみ受けて `untilId` を silent ignore していたため、`loadOlder` が呼ばれるたびに同じ first-page を返す → Paginator は dedup で空配列を取得 → `canFetchOlder=true` のまま → 延々と再 fetch する無限ループ状態だった。

修正:
- `ListWithFilter` / `ListRemoteWithFilter` の signature に `sinceID` / `untilID` を追加
- repo の `WHERE id > sinceID` / `WHERE id < untilID` を WHERE 句に展開
- handler 側で `req.SinceID` / `req.UntilID` を bind して repo に渡す

## 3. v2 (β 画面) の検索 filter 漏れ

新画面 (`v2/admin/emoji/list` 経由) では `uri` / `publicUrl` / `originalUrl` で絞り込む検索ボックスがあるが、handler の `emojiV2QueryReq` 構造体にこれらの field が無く silently 無視されていた。

修正:
- `emojiV2QueryReq` に `URI` / `PublicURL` / `OriginalURL` を追加
- `model.EmojiV2Query` にも同 field 追加
- `buildV2Query` で `ILIKE` 句に展開

## テスト

### 追加テスト

- `TestEmojiListV2_URIFilter` の 3 サブケース: `uri` / `publicUrl` / `originalUrl` の各 filter で remote emoji が絞り込めること

### 修正テスト

- 既存 `ListWithFilter` / `ListRemoteWithFilter` 系テストの signature を `sinceID` / `untilID` 引数追加に合わせて全 call site 更新
- mock の `filterV2` / `ListWithFilter` / `ListRemoteWithFilter` にも cursor + URI 系 filter 対応

### 実行

\`\`\`bash
make fmt && make lint && make test
\`\`\`

ローカルで全パッケージ green。

### 手動検証 (UDS スタック)

\`\`\`
$ curl -X POST .../api/admin/emoji/list-remote -d '{"limit":3}'
[{"id":"...", "url":"https://...", ...}]   # url field が含まれる

$ curl -X POST .../api/admin/emoji/list-remote -d '{"limit":3,"untilId":"<oldest_seen>"}'
[{"id":"<older_id>", ...}]   # cursor pagination が動作
\`\`\`

ブラウザで `/admin/emojis` (旧画面) を開いてリスト表示・検索・無限スクロール解消を動作確認 OK 取得済。

## non-goals

- frontend 側の表示崩れ調査 (gridItems の `uri` / `publicUrl` 欠如等は upstream 由来で本 PR scope 外)
- pagination の `sinceDate` / `untilDate`: 現 frontend 経路では使われないので skip。必要になったら別 issue で
- v1 endpoint への hostType / category 等の v2 相当 filter 移植 (新画面で済むため backport しない)

## 関連

- Closes #466
- 同じ UDS バッチで報告された他 bug: #468 / #469 / #470 / #471 / #472 / #473
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/shiroha-a/mk/pull/479" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
