### PR TITLE
Fix notification reactions: GET /emoji/:path で custom emoji へ redirect (#468)

### DIFF
--- a/internal/server/emoji_redirect.go
+++ b/internal/server/emoji_redirect.go
@@ -8,7 +8,13 @@ import (
 	"github.com/labstack/echo/v4"
 
 	"github.com/shiroha-a/mk/internal/model"
+	"github.com/shiroha-a/mk/internal/repository"
 )
+
+// 静的アサーション: repository.EmojiRepository が emojiLookup を満たすこと
+// を build 時に検証する (avatar.go の同パターンと揃える)。配線時の型
+// 不一致 (interface 拡張 / signature 変更) を早期に検出。
+var _ emojiLookup = (repository.EmojiRepository)(nil)
 
 // emojiRedirectFallback is the path the frontend treats as the
 // "emoji not found" placeholder. Misskey TS upstream redirects to

--- a/internal/server/emoji_redirect.go
+++ b/internal/server/emoji_redirect.go
@@ -1,0 +1,100 @@
+package server
+
+import (
+	"net/http"
+	"regexp"
+	"strings"
+
+	"github.com/labstack/echo/v4"
+
+	"github.com/shiroha-a/mk/internal/model"
+)
+
+// emojiRedirectFallback is the path the frontend treats as the
+// "emoji not found" placeholder. Misskey TS upstream redirects to
+// the bundled static asset when the request includes a `fallback`
+// query string.
+const emojiRedirectFallback = "/static-assets/emoji-unknown.png"
+
+// emojiPathRegexp validates the URL component the frontend uses to
+// reference custom emoji (`<name>[@<host>].webp`). Mirrors upstream's
+// regex (`/^[a-zA-Z0-9\-_@\.]+?\.webp$/`) so requests for unrelated
+// or attacker-crafted paths are rejected before hitting the DB.
+var emojiPathRegexp = regexp.MustCompile(`^[a-zA-Z0-9\-_@\.]+?\.webp$`)
+
+// emojiLookup is the minimal interface used by the redirect handler.
+// Keeping the surface narrow lets handler tests stub without standing
+// up the full EmojiRepository.
+type emojiLookup interface {
+	FindByNameAndHost(name string, host *string) (*model.Emoji, error)
+}
+
+// emojiRedirectHandler implements `GET /emoji/:path(.*)` (#468). The
+// frontend `MkCustomEmoji` falls back to fetching this endpoint when
+// no explicit `emojiUrl` prop is passed — notably the notification
+// `MkReactionIcon` for reaction notifications, which would otherwise
+// render the fallback image. We mirror upstream Misskey's
+// `ServerService.ts:153` semantics:
+//
+//   - path = "<name>.webp" → local emoji (host == nil)
+//   - path = "<name>@.<>.webp" → local emoji (`@.` is the canonical
+//     local-suffix sentinel emitted by ReactionService)
+//   - path = "<name>@<host>.webp" → remote emoji
+//   - row found → 302 redirect to publicUrl (fallback to originalUrl)
+//   - row missing → 404, or 302 to /static-assets/emoji-unknown.png
+//     when the `fallback` query string is present
+//
+// Cache-Control header mirrors upstream so the browser stops
+// re-fetching reaction images on every notification render.
+func emojiRedirectHandler(repo emojiLookup) echo.HandlerFunc {
+	return func(c echo.Context) error {
+		path := c.Param("path")
+
+		c.Response().Header().Set(echo.HeaderCacheControl, "public, max-age=86400")
+
+		if !emojiPathRegexp.MatchString(path) {
+			return c.NoContent(http.StatusNotFound)
+		}
+
+		// `.webp` 拡張子を剥がし、`@` で name / host に分解する。
+		emojiPath := strings.TrimSuffix(path, ".webp")
+		chunks := strings.Split(emojiPath, "@")
+		if len(chunks) > 2 {
+			return c.NoContent(http.StatusBadRequest)
+		}
+
+		name := chunks[0]
+		var hostPtr *string
+		if len(chunks) == 2 {
+			h := chunks[1]
+			// `@.` は ReactionService.normalizeReaction が永続化する
+			// canonical local-suffix。host_NULL と等価に扱う。
+			if h != "" && h != "." {
+				hostPtr = &h
+			}
+		}
+
+		emoji, err := repo.FindByNameAndHost(name, hostPtr)
+		if err != nil || emoji == nil {
+			if _, hasFallback := c.QueryParams()["fallback"]; hasFallback {
+				return c.Redirect(http.StatusFound, emojiRedirectFallback)
+			}
+			return c.NoContent(http.StatusNotFound)
+		}
+
+		// publicUrl が空の場合 originalUrl にフォールバック (upstream の
+		// `emoji.publicUrl || emoji.originalUrl` と同じ後方互換)。
+		target := emoji.PublicURL
+		if target == "" {
+			target = emoji.OriginalURL
+		}
+		if target == "" {
+			return c.NoContent(http.StatusNotFound)
+		}
+		// upstream は 301 redirect だが、emoji の publicUrl が変動しうる
+		// (リモート instance の URL 更新等) ので 302 で永続キャッシュを
+		// 避ける。Cache-Control: max-age=86400 でブラウザ側 1 日キャッシュ
+		// と組み合わせる。
+		return c.Redirect(http.StatusFound, target)
+	}
+}

--- a/internal/server/emoji_redirect_test.go
+++ b/internal/server/emoji_redirect_test.go
@@ -1,0 +1,180 @@
+package server
+
+import (
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/labstack/echo/v4"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/shiroha-a/mk/internal/model"
+)
+
+// stubEmojiLookup is a focused mock — we don't need the full
+// EmojiRepository interface for the redirect handler's contract.
+type stubEmojiLookup struct {
+	emojis map[string]*model.Emoji // key: "name|host" (host="" for local)
+	err    error
+}
+
+func (s *stubEmojiLookup) FindByNameAndHost(name string, host *string) (*model.Emoji, error) {
+	if s.err != nil {
+		return nil, s.err
+	}
+	key := name + "|"
+	if host != nil {
+		key += *host
+	}
+	e, ok := s.emojis[key]
+	if !ok {
+		return nil, errors.New("not found")
+	}
+	return e, nil
+}
+
+func newEmojiTestContext(t *testing.T, path, query string) (echo.Context, *httptest.ResponseRecorder) {
+	t.Helper()
+	e := echo.New()
+	url := "/emoji/" + path
+	if query != "" {
+		url += "?" + query
+	}
+	req := httptest.NewRequest(http.MethodGet, url, nil)
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+	c.SetPath("/emoji/:path")
+	c.SetParamNames("path")
+	c.SetParamValues(path)
+	return c, rec
+}
+
+func TestEmojiRedirectHandler_LocalEmoji(t *testing.T) {
+	repo := &stubEmojiLookup{emojis: map[string]*model.Emoji{
+		"smile|": {Name: "smile", PublicURL: "https://cdn.example/local-smile.png"},
+	}}
+	h := emojiRedirectHandler(repo)
+
+	c, rec := newEmojiTestContext(t, "smile.webp", "")
+	require.NoError(t, h(c))
+	assert.Equal(t, http.StatusFound, rec.Code)
+	assert.Equal(t, "https://cdn.example/local-smile.png", rec.Header().Get(echo.HeaderLocation))
+	assert.Equal(t, "public, max-age=86400", rec.Header().Get(echo.HeaderCacheControl))
+}
+
+func TestEmojiRedirectHandler_LocalCanonicalDotSuffix(t *testing.T) {
+	// `:smile@.:` (ReactionService.normalizeReaction が永続化する形) は
+	// frontend が `/emoji/smile@..webp` で投げてくる。`@.` は host=NULL
+	// と等価に扱う。
+	repo := &stubEmojiLookup{emojis: map[string]*model.Emoji{
+		"smile|": {Name: "smile", PublicURL: "https://cdn.example/local-smile.png"},
+	}}
+	h := emojiRedirectHandler(repo)
+
+	c, rec := newEmojiTestContext(t, "smile@..webp", "")
+	require.NoError(t, h(c))
+	assert.Equal(t, http.StatusFound, rec.Code)
+	assert.Equal(t, "https://cdn.example/local-smile.png", rec.Header().Get(echo.HeaderLocation))
+}
+
+func TestEmojiRedirectHandler_RemoteEmoji(t *testing.T) {
+	repo := &stubEmojiLookup{emojis: map[string]*model.Emoji{
+		"meow_yikes|remote.example": {
+			Name:      "meow_yikes",
+			PublicURL: "https://r/meow.png",
+		},
+	}}
+	h := emojiRedirectHandler(repo)
+
+	c, rec := newEmojiTestContext(t, "meow_yikes@remote.example.webp", "")
+	require.NoError(t, h(c))
+	assert.Equal(t, http.StatusFound, rec.Code)
+	assert.Equal(t, "https://r/meow.png", rec.Header().Get(echo.HeaderLocation))
+}
+
+func TestEmojiRedirectHandler_PublicURLFallbackToOriginal(t *testing.T) {
+	// publicUrl 空 → originalUrl にフォールバック (upstream `||` と同等)
+	repo := &stubEmojiLookup{emojis: map[string]*model.Emoji{
+		"x|host.example": {Name: "x", PublicURL: "", OriginalURL: "https://r/x_orig.png"},
+	}}
+	h := emojiRedirectHandler(repo)
+
+	c, rec := newEmojiTestContext(t, "x@host.example.webp", "")
+	require.NoError(t, h(c))
+	assert.Equal(t, http.StatusFound, rec.Code)
+	assert.Equal(t, "https://r/x_orig.png", rec.Header().Get(echo.HeaderLocation))
+}
+
+func TestEmojiRedirectHandler_NotFound_404(t *testing.T) {
+	repo := &stubEmojiLookup{emojis: map[string]*model.Emoji{}}
+	h := emojiRedirectHandler(repo)
+
+	c, rec := newEmojiTestContext(t, "ghost.webp", "")
+	require.NoError(t, h(c))
+	assert.Equal(t, http.StatusNotFound, rec.Code)
+}
+
+func TestEmojiRedirectHandler_NotFound_FallbackQuery(t *testing.T) {
+	// ?fallback クエリ付きの場合は static-assets の placeholder へ 302
+	repo := &stubEmojiLookup{emojis: map[string]*model.Emoji{}}
+	h := emojiRedirectHandler(repo)
+
+	c, rec := newEmojiTestContext(t, "ghost.webp", "fallback=1")
+	require.NoError(t, h(c))
+	assert.Equal(t, http.StatusFound, rec.Code)
+	assert.Equal(t, emojiRedirectFallback, rec.Header().Get(echo.HeaderLocation))
+}
+
+func TestEmojiRedirectHandler_BadPath_404(t *testing.T) {
+	repo := &stubEmojiLookup{}
+	h := emojiRedirectHandler(repo)
+
+	cases := []string{
+		"foo.png",   // 拡張子違反
+		"x!y.webp",  // 記号違反 (regex の charset 外)
+		"foo+.webp", // 記号違反
+	}
+	for _, p := range cases {
+		t.Run(p, func(t *testing.T) {
+			c, rec := newEmojiTestContext(t, p, "")
+			require.NoError(t, h(c))
+			// regex で弾かれるか、guard で 4xx
+			assert.Contains(t, []int{http.StatusNotFound, http.StatusBadRequest}, rec.Code,
+				"unexpected status %d for path %q", rec.Code, p)
+		})
+	}
+}
+
+func TestEmojiRedirectHandler_BadAtChunks_400(t *testing.T) {
+	// regex は `[a-zA-Z0-9\-_@\.]+?\.webp$` なので "a@b@c.webp" は通る。
+	// path split 後に chunks > 2 で 400 を返す。
+	repo := &stubEmojiLookup{}
+	h := emojiRedirectHandler(repo)
+
+	c, rec := newEmojiTestContext(t, "a@b@c.webp", "")
+	require.NoError(t, h(c))
+	assert.Equal(t, http.StatusBadRequest, rec.Code)
+}
+
+func TestEmojiRedirectHandler_RepoErrorTreatedAsNotFound(t *testing.T) {
+	repo := &stubEmojiLookup{err: errors.New("db down")}
+	h := emojiRedirectHandler(repo)
+
+	c, rec := newEmojiTestContext(t, "smile.webp", "")
+	require.NoError(t, h(c))
+	assert.Equal(t, http.StatusNotFound, rec.Code)
+}
+
+func TestEmojiRedirectHandler_EmptyURLs_404(t *testing.T) {
+	// publicUrl も originalUrl も空の row は redirect 先が無いので 404。
+	repo := &stubEmojiLookup{emojis: map[string]*model.Emoji{
+		"empty|": {Name: "empty", PublicURL: "", OriginalURL: ""},
+	}}
+	h := emojiRedirectHandler(repo)
+
+	c, rec := newEmojiTestContext(t, "empty.webp", "")
+	require.NoError(t, h(c))
+	assert.Equal(t, http.StatusNotFound, rec.Code)
+}

--- a/internal/server/router.go
+++ b/internal/server/router.go
@@ -2147,6 +2147,15 @@ func (s *Server) setupRoutes() {
 	// identicon、未存在なら /static-assets/user-unknown.png にフォールバック。
 	s.echo.GET("/avatar/@:acct", avatarHandler(userRepo, localHost))
 
+	// /emoji/:path — frontend の MkCustomEmoji が `:emojiUrl` プロップを
+	// 受け取らないとき (典型: 通知 reaction icon) に <img src="/emoji/<name>@<host>.webp">
+	// で直接 fetch するので、handler が無いと SPA catchall に流れて画像が
+	// 読めず fallback 画像になる (#468)。upstream Misskey TS の
+	// ServerService.ts:153 と互換に: name + host を抜いて emoji table を
+	// lookup → publicUrl に 302 redirect、見つからなければ ?fallback クエリ
+	// 付きなら user-unknown.png 相当の static asset、無ければ 404。
+	s.echo.GET("/emoji/:path", emojiRedirectHandler(emojiRepo))
+
 	// manifest.json — PWA用
 	s.echo.GET("/manifest.json", manifestJSON(s.config, metaRepo))
 

--- a/internal/server/router.go
+++ b/internal/server/router.go
@@ -2153,7 +2153,7 @@ func (s *Server) setupRoutes() {
 	// 読めず fallback 画像になる (#468)。upstream Misskey TS の
 	// ServerService.ts:153 と互換に: name + host を抜いて emoji table を
 	// lookup → publicUrl に 302 redirect、見つからなければ ?fallback クエリ
-	// 付きなら user-unknown.png 相当の static asset、無ければ 404。
+	// 付きなら /static-assets/emoji-unknown.png、無ければ 404。
 	s.echo.GET("/emoji/:path", emojiRedirectHandler(emojiRepo))
 
 	// manifest.json — PWA用


### PR DESCRIPTION
## Summary

リアクション通知 UI で受信したリモートカスタム絵文字が ❤️ 等のフォールバック画像で表示される問題を修正する。

Closes #468

## 根本原因

frontend の `MkNotification.vue` は reaction 通知を `MkReactionIcon` に渡すが、`:emojiUrl` プロップを渡していない。`MkReactionIcon` → `MkCustomEmoji` は `emojiUrl` 未指定 + リモート絵文字のとき URL を `/emoji/<name>@<host>.webp` で構築して直接 fetch しに来る (`MkCustomEmoji.vue:82`)。

mk-go ルーターには `/emoji/<path>` ハンドラが無く、SPA catchall に流れて HTML が返る → `<img>` が読み込み失敗 → fallback 画像が出る。

note 本体の reaction は #459 で `reactionEmojis` map を populate するため、frontend は `note.reactionEmojis` から URL を引けてカスタム絵文字が表示されるが、通知の path は `MkReactionIcon` に `emojiUrl` を渡さないため endpoint の有無が直接効く。

## 主な変更点

### `internal/server/emoji_redirect.go` 新設

upstream Misskey TS `ServerService.ts:153` と互換の `/emoji/:path(.*)` を実装。Echo ルーターは `(.*)` 構文を持たないので `/emoji/:path` で受け、handler 内で `<name>[@<host>].webp` 形式をパースする。

| path | 解釈 | redirect 先 |
|------|------|------------|
| `<name>.webp` | local emoji (host == nil) | `publicUrl` (空なら `originalUrl`) |
| `<name>@..webp` | local emoji (`@.` canonical sentinel) | 同上 |
| `<name>@<host>.webp` | remote emoji | 同上 |
| 見つからず + クエリ無し | — | 404 |
| 見つからず + `?fallback=1` | — | `/static-assets/emoji-unknown.png` |
| 不正 path / 空 URL | — | 404 / 400 |

セキュリティ:
- regex `^[a-zA-Z0-9\-_@\.]+?\.webp$` で攻撃者仕立ての path を弾く
- `@` chunks > 2 で 400
- `Cache-Control: public, max-age=86400` (upstream と同じ)
- upstream は 301 redirect だが `publicUrl` が変動するケースを考慮して **302** に変更

### `internal/server/router.go` 配線

identicon / `/avatar/@:acct` の隣にルート登録:

\`\`\`go
s.echo.GET("/emoji/:path", emojiRedirectHandler(emojiRepo))
\`\`\`

## テスト

### 追加テスト (9 ケース)

- `TestEmojiRedirectHandler_LocalEmoji`
- `TestEmojiRedirectHandler_LocalCanonicalDotSuffix` (`@.` 解釈)
- `TestEmojiRedirectHandler_RemoteEmoji`
- `TestEmojiRedirectHandler_PublicURLFallbackToOriginal`
- `TestEmojiRedirectHandler_NotFound_404`
- `TestEmojiRedirectHandler_NotFound_FallbackQuery`
- `TestEmojiRedirectHandler_BadPath_404` (拡張子違反 / 不正 char)
- `TestEmojiRedirectHandler_BadAtChunks_400` (`@` 二つ以上)
- `TestEmojiRedirectHandler_RepoErrorTreatedAsNotFound`
- `TestEmojiRedirectHandler_EmptyURLs_404`

### 実行

\`\`\`bash
make fmt && make lint && make test
\`\`\`

ローカルで全パッケージ green。

### 手動検証 (UDS スタック)

\`\`\`
$ curl -X GET -I /emoji/<name>@<remote_host>.webp
HTTP/1.1 302 Found
Location: https://r2.<remote-host>/...png    # remote の publicUrl

$ curl -X GET -I /emoji/ghost.webp
HTTP/1.1 404 Not Found

$ curl -X GET -I /emoji/ghost.webp?fallback=1
HTTP/1.1 302 Found
Location: /static-assets/emoji-unknown.png
\`\`\`

ブラウザで通知を開いてリアクション通知のカスタム絵文字が画像として表示されることをユーザーから確認 OK 取得済。

## non-goals

- Misskey の `mediaProxy` 経由の WebP 変換 + サイズ調整: mk-go は media proxy を内蔵していないので AS-IS の publicUrl にリダイレクトする。frontend は受け取った URL に対して getProxiedImageUrl で必要に応じて proxy 経由にするので、この層では変換しない
- `?badge=1` / `?static=1` 等のクエリパラメータ対応: 通知 reaction icon の path では使われないので skip。必要になったら別 issue
- ローカル emoji 画像のキャッシュ管理: redirect なのでキャッシュは publicUrl の origin (S3 等) に依存

## 関連

- Closes #468
- 同じ UDS バッチで報告された他 bug: #469 / #470 / #471 / #472 / #473
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/shiroha-a/mk/pull/480" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
