### PR TITLE
Fix federation: admin/show-users honors hostname filter (#469)

### DIFF
--- a/internal/api/admin/handler.go
+++ b/internal/api/admin/handler.go
@@ -493,22 +493,24 @@ func (h *Handler) ShowUser(c echo.Context) error {
 // ShowUsers handles POST /api/admin/show-users.
 func (h *Handler) ShowUsers(c echo.Context) error {
 	var req struct {
-		State  string `json:"state"`
-		Origin string `json:"origin"`
-		Sort   string `json:"sort"`
-		Limit  int    `json:"limit"`
-		Offset int    `json:"offset"`
+		State    string `json:"state"`
+		Origin   string `json:"origin"`
+		Hostname string `json:"hostname"`
+		Sort     string `json:"sort"`
+		Limit    int    `json:"limit"`
+		Offset   int    `json:"offset"`
 	}
 	if err := c.Bind(&req); err != nil {
 		return c.JSON(http.StatusBadRequest, apierr.Error("INVALID_PARAM", "Invalid parameters.", "3d81ceae-475f-4600-b2a8-2bc116157532"))
 	}
 
 	users, err := h.userRepo.ListUsers(model.UserListFilter{
-		State:  req.State,
-		Origin: req.Origin,
-		Sort:   req.Sort,
-		Limit:  req.Limit,
-		Offset: req.Offset,
+		State:    req.State,
+		Origin:   req.Origin,
+		Hostname: req.Hostname,
+		Sort:     req.Sort,
+		Limit:    req.Limit,
+		Offset:   req.Offset,
 	})
 	if err != nil {
 		return c.JSON(http.StatusInternalServerError, apierr.Error("INTERNAL_ERROR", "Internal error.", "5d37dbcb-891e-41ca-a3d6-e690c97775ac"))

--- a/internal/api/admin/handler_test.go
+++ b/internal/api/admin/handler_test.go
@@ -188,6 +188,27 @@ func TestShowUsers_WithFilter(t *testing.T) {
 	assert.Len(t, resp, 1)
 }
 
+// frontend (instance-info.vue) は admin/show-users に hostname を渡して
+// 「特定リモートサーバーに属するユーザー」だけを取りに来る (#469)。
+// 過去はこのフィールドが handler の req struct に無く、無視されて全
+// remote が返るバグがあった。回帰防止に hostname narrowing を検証する。
+func TestShowUsers_FilterByHostname(t *testing.T) {
+	h, userRepo, _, _ := newTestHandler(t)
+	hostA := "a.example"
+	hostB := "b.example"
+	userRepo.Users["u1"] = &model.User{ID: "u1", Username: "alice", Host: &hostA}
+	userRepo.Users["u2"] = &model.User{ID: "u2", Username: "bob", Host: &hostB}
+	userRepo.Users["u3"] = &model.User{ID: "u3", Username: "local"}
+
+	rec := doPost(h.ShowUsers, `{"origin":"remote","hostname":"a.example","limit":10}`, nil)
+	assert.Equal(t, http.StatusOK, rec.Code)
+
+	var resp []map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+	require.Len(t, resp, 1)
+	assert.Equal(t, "alice", resp[0]["username"])
+}
+
 // --- SuspendUser / UnsuspendUser ---
 
 func TestSuspendUser_Success(t *testing.T) {

--- a/internal/testutil/mock_repository.go
+++ b/internal/testutil/mock_repository.go
@@ -170,6 +170,11 @@ func (m *MockUserRepository) ListUsers(filter model.UserListFilter) ([]*model.Us
 				continue
 			}
 		}
+		if filter.Hostname != "" {
+			if u.Host == nil || *u.Host != filter.Hostname {
+				continue
+			}
+		}
 		result = append(result, u)
 	}
 	limit := filter.Limit


### PR DESCRIPTION
## Summary

コントロールパネル → 連合 → 任意のリモートサーバー → ユーザータブで、その server に属さないユーザーまで表示されていた問題を修正。

## Root cause

frontend (`instance-info.vue:188`) は `admin/show-users` を `hostname: props.host` 付きで叩いて narrow するつもりだったが、mk-go 側の handler の req struct に `Hostname` フィールドが無く、JSON binding 時に silent drop されていた。`model.UserListFilter` と `repository.ListUsers` (host = ? の WHERE 節) は既に対応済だったため、handler の wiring 漏れだけが原因。

## 主な変更点

- `internal/api/admin/handler.go` `ShowUsers` の req struct と `model.UserListFilter` literal に `Hostname` を追加
- `internal/testutil/mock_repository.go` `MockUserRepository.ListUsers` に Hostname narrow フィルタを実装 (実 repository には既に存在)
- `internal/api/admin/handler_test.go` 回帰防止 `TestShowUsers_FilterByHostname` を追加

## Testing

- `go test ./internal/api/admin/ ./internal/testutil/ -count=1` 通過
- `make fmt && make lint` clean
- UDS 環境再ビルド後、コントロールパネル → 連合 → リモートサーバーのユーザータブで、対象 host のユーザーだけが表示されることを目視確認

Closes #469

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/shiroha-a/mk/pull/481" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
