### PR TITLE
Fix charts: GetChart returns newest-first ordering (#470 #473)

### DIFF
--- a/internal/core/chart/core.go
+++ b/internal/core/chart/core.go
@@ -486,13 +486,20 @@ func (c *Chart) GetChart(ctx context.Context, span Span, amount int, cursor *tim
 		}
 	}
 
-	// バケット時刻 (=希望する時刻列) を生成。oldest-first の順序で詰める。
+	// バケット時刻 (=希望する時刻列) を生成。upstream Misskey TS の
+	// `getChartRaw` は `for i := amount-1; i >= 0; i--` + `chart.unshift`
+	// で **newest-first** (index 0 = 最新, 末尾 = 最古) の配列を組み立てる。
+	// frontend (`MkChart.vue` の `data.slice().reverse()`) はその newest-first
+	// 配列を反転して oldest-first labels に揃えるため、API レスポンスが
+	// oldest-first で返ると最新値が左端 (90 日前側) に流れて X 軸末端
+	// (現在時刻) に届かない症状になる (#470 / #473)。
 	out := make(Result, len(c.schema.Columns))
 	for _, col := range c.schema.Columns {
 		out[col.Name] = make([]int64, amount)
 	}
 	for i := 0; i < amount; i++ {
-		bucket := stepBack(end, amount-1-i, span)
+		// i=0 → end (最新), i=amount-1 → end-(amount-1)*span (最古)
+		bucket := stepBack(end, i, span)
 		row := pickRowAt(rows, bucket.Unix())
 		if row == nil {
 			row = pickFallback(rows, bucket.Unix())

--- a/internal/core/chart/core.go
+++ b/internal/core/chart/core.go
@@ -451,7 +451,9 @@ func filterByGroup(diffs []bufferedDiff, group string) []bufferedDiff {
 //   - Missing buckets are interpolated from the most recent prior log
 //     so accumulate columns appear continuous.
 //   - The result is keyed by dot-notation column names; values are
-//     ordered oldest-first.
+//     ordered newest-first (index 0 = end, last index = oldest), matching
+//     upstream Misskey TS so the frontend's `data.slice().reverse()` lines
+//     up with its oldest-first axis labels.
 func (c *Chart) GetChart(ctx context.Context, span Span, amount int, cursor *time.Time, group string) (Result, error) {
 	if amount <= 0 {
 		amount = 1

--- a/internal/core/chart/core_test.go
+++ b/internal/core/chart/core_test.go
@@ -291,7 +291,9 @@ func TestGetChart_BasicWindow(t *testing.T) {
 
 	out, err := c.GetChart(context.Background(), SpanHour, 3, nil, "")
 	require.NoError(t, err)
-	assert.Equal(t, []int64{1, 2, 3}, out["local.inc"])
+	// upstream の getChartRaw と同じく newest-first で返す (#470 / #473)。
+	// hour12=3 → idx0, hour11=2 → idx1, hour10=1 → idx2。
+	assert.Equal(t, []int64{3, 2, 1}, out["local.inc"])
 }
 
 func TestGetChart_InterpolatesGapsForAccumulate(t *testing.T) {
@@ -346,7 +348,8 @@ func TestGetChart_SpanDay(t *testing.T) {
 	clk.set(time.Date(2026, 4, 9, 12, 0, 0, 0, time.UTC))
 	out, err := c.GetChart(context.Background(), SpanDay, 3, nil, "")
 	require.NoError(t, err)
-	assert.Equal(t, []int64{10, 11, 12}, out["local.inc"])
+	// newest-first: 04-09=12 → idx0, 04-08=11 → idx1, 04-07=10 → idx2。
+	assert.Equal(t, []int64{12, 11, 10}, out["local.inc"])
 }
 
 func TestGetChart_RepoErrorBubbles(t *testing.T) {
@@ -705,10 +708,11 @@ func TestGetChart_FindBeforeAnchorAppended(t *testing.T) {
 	clk.set(time.Date(2026, 4, 9, 12, 0, 0, 0, time.UTC))
 	out, err := c.GetChart(context.Background(), SpanHour, 3, nil, "")
 	require.NoError(t, err)
-	// hour10 (interpolated from anchor) → 4
-	// hour11 (real)                       → 4 + 7 = 11
-	// hour12 (interpolated, accumulate keeps 11)
-	assert.Equal(t, []int64{4, 11, 11}, out["local.total"])
+	// newest-first:
+	//   idx0 = hour12 (interpolated, accumulate keeps 11)
+	//   idx1 = hour11 (real)                         → 4 + 7 = 11
+	//   idx2 = hour10 (interpolated from anchor)     → 4
+	assert.Equal(t, []int64{11, 11, 4}, out["local.total"])
 }
 
 func TestGetChart_FindLatestNotFoundLeavesEmpty(t *testing.T) {

--- a/internal/core/chart/schema.go
+++ b/internal/core/chart/schema.go
@@ -181,7 +181,8 @@ func SQLTypeOf(r ColRange) string {
 type Diff map[string]any
 
 // Result is the response shape returned by GetChart(). Each dot-notation
-// key maps to a slice of length `amount` ordered oldest-first.
+// key maps to a slice of length `amount` ordered newest-first
+// (index 0 = the most recent bucket, last index = the oldest).
 type Result map[string][]int64
 
 // ErrSchemaName is returned when a Schema is constructed with an empty


### PR DESCRIPTION
## Summary

連合 / リモートサーバー / ユーザー単位のチャートで「直近90日」レンジを選んだ際に、最新データが X 軸の左端 (90日前側) に張り付き、右端 (現在時刻) まで届かない症状を修正。

## Root cause

upstream Misskey TS の \`Chart.getChartRaw\` (`packages/backend/src/core/chart/core.ts:617-718`) は \`for i := amount-1; i >= 0; i--\` + \`chart.unshift\` で **newest-first** (index 0 = 最新, 末尾 = 最古) の配列を組み立てて返す。frontend (\`MkChart.vue:171\` の \`data.slice().reverse()\`) はその newest-first 配列を反転して oldest-first labels (`getDate(i).reverse()` で生成) に揃える前提になっている。

mk-go の \`GetChart\` (\`internal/core/chart/core.go:455\`) は反対に oldest-first で詰めていたため、frontend の reverse 後に最新値が axis の左端 (=90日前側) に流れて、右端 (=今日) には常に古い値か 0 が表示されていた。

データ層 (claimCurrentLog / Save / chart_day テーブルへの書き込み) は upstream と同じ挙動で、bug は GetChart の出力順序のみ。

## 主な変更点

- \`internal/core/chart/core.go\` GetChart の bucket loop を \`stepBack(end, i, span)\` に変更し、index 0 = end (最新), index amount-1 = end-(amount-1)*span (最古) と upstream に合わせて newest-first で詰める
- \`internal/core/chart/core_test.go\` 出力順序の反転に伴い既存 3 テスト (BasicWindow / SpanDay / FindBeforeAnchorAppended) の期待値を反転

## Testing

- \`go test ./internal/core/chart/... -count=1\` 通過
- \`go test ./... -count=1\` 全パッケージ通過
- \`make fmt && make lint\` clean
- UDS 環境再ビルド後、\`/api/charts/instance?span=day&limit=90&host=...\` の返り値で非ゼロ値が index 0 (newest) に来ることを確認、frontend のチャート画面で X 軸右端まで線が伸びることを目視確認

Closes #470
Closes #473

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/shiroha-a/mk/pull/482" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
