### PR TITLE
Fix admin: admin/drive/files honors userId filter (#471)

### DIFF
--- a/internal/api/admin/drive_emoji_test.go
+++ b/internal/api/admin/drive_emoji_test.go
@@ -42,6 +42,33 @@ func TestDriveFiles_FiltersByOrigin(t *testing.T) {
 	assert.Equal(t, "d2", rows[0]["id"])
 }
 
+func TestDriveFiles_FiltersByUserID(t *testing.T) {
+	// admin/user/<id> のドライブタブは userId だけを送ってくる (#471)。
+	// upstream は userId 指定時に origin / hostname を読まないので、それに
+	// 合わせて他ユーザーの remote ファイルが混ざらないことを確認する。
+	h, _, _, _ := newTestHandler(t)
+	repo := testutil.NewMockDriveFileRepository()
+	target := "u_target"
+	other := "u_other"
+	otherHost := "remote.example"
+	require.NoError(t, repo.Create(&model.DriveFile{ID: "d_t1", UserID: &target, Type: "image/png"}))
+	require.NoError(t, repo.Create(&model.DriveFile{ID: "d_t2", UserID: &target, UserHost: &otherHost, Type: "image/jpeg"}))
+	require.NoError(t, repo.Create(&model.DriveFile{ID: "d_o1", UserID: &other, UserHost: &otherHost, Type: "image/png"}))
+	h.SetDriveFileRepo(repo)
+
+	rec := doPost(h.DriveFiles, `{"userId":"u_target","limit":10}`, adminUser)
+	assert.Equal(t, http.StatusOK, rec.Code)
+	var rows []map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &rows))
+	gotIDs := make(map[string]bool, len(rows))
+	for _, r := range rows {
+		gotIDs[r["id"].(string)] = true
+	}
+	assert.True(t, gotIDs["d_t1"])
+	assert.True(t, gotIDs["d_t2"])
+	assert.False(t, gotIDs["d_o1"])
+}
+
 func TestDriveFiles_FiltersByTypePrefix(t *testing.T) {
 	h, _, _, _ := newTestHandler(t)
 	repo := testutil.NewMockDriveFileRepository()

--- a/internal/api/admin/handler_stubs.go
+++ b/internal/api/admin/handler_stubs.go
@@ -428,12 +428,14 @@ func (h *Handler) DriveFiles(c echo.Context) error {
 		return c.JSON(http.StatusOK, []any{})
 	}
 	var req struct {
-		Limit   int    `json:"limit"`
-		SinceID string `json:"sinceId"`
-		UntilID string `json:"untilId"`
-		Origin  string `json:"origin"`
-		Host    string `json:"host"`
-		Type    string `json:"type"`
+		Limit    int    `json:"limit"`
+		SinceID  string `json:"sinceId"`
+		UntilID  string `json:"untilId"`
+		UserID   string `json:"userId"`
+		Origin   string `json:"origin"`
+		Host     string `json:"host"`
+		Hostname string `json:"hostname"`
+		Type     string `json:"type"`
 	}
 	_ = c.Bind(&req)
 	if req.Limit <= 0 || req.Limit > 100 {
@@ -444,7 +446,13 @@ func (h *Handler) DriveFiles(c echo.Context) error {
 	default:
 		req.Origin = "combined"
 	}
-	files, err := h.driveFileRepo.ListForAdmin(req.Origin, req.Host, req.Type, req.UntilID, req.SinceID, req.Limit)
+	// upstream は host も hostname もどちらも受けて同じ意味で扱う。
+	// frontend (admin/instance-info) が hostname で投げるため互換上両方サポート。
+	host := req.Host
+	if host == "" {
+		host = req.Hostname
+	}
+	files, err := h.driveFileRepo.ListForAdmin(req.UserID, req.Origin, host, req.Type, req.UntilID, req.SinceID, req.Limit)
 	if err != nil {
 		return c.JSON(http.StatusInternalServerError, apierr.Error("INTERNAL_ERROR", "Internal error.", "00000000-0000-0000-0000-000000000000"))
 	}

--- a/internal/core/transfer/drive_reader_test.go
+++ b/internal/core/transfer/drive_reader_test.go
@@ -80,7 +80,7 @@ func (f *fakeDriveFileRepo) ExistsByMD5(_, _ string) (bool, error)              
 func (f *fakeDriveFileRepo) ListByFileIDs(_ []string) ([]*model.DriveFile, error) { return nil, nil }
 func (f *fakeDriveFileRepo) UsageByUser(_ string) (int64, error)                  { return 0, nil }
 func (f *fakeDriveFileRepo) UpdateBulkFolder(_ []string, _ *string) error         { return nil }
-func (f *fakeDriveFileRepo) ListForAdmin(_, _, _, _, _ string, _ int) ([]*model.DriveFile, error) {
+func (f *fakeDriveFileRepo) ListForAdmin(_, _, _, _, _, _ string, _ int) ([]*model.DriveFile, error) {
 	return nil, nil
 }
 func (f *fakeDriveFileRepo) DeleteOrphans() (int64, error)     { return 0, nil }

--- a/internal/repository/coverage_complete_test.go
+++ b/internal/repository/coverage_complete_test.go
@@ -191,7 +191,7 @@ func TestErrorPaths_CancelledContext(t *testing.T) {
 	assert.Error(t, err)
 	_, err = dfr.UsageByUser("x")
 	assert.Error(t, err)
-	_, err = dfr.ListForAdmin("local", "", "", "", "", 10)
+	_, err = dfr.ListForAdmin("", "local", "", "", "", "", 10)
 	assert.Error(t, err)
 
 	// drive_folder

--- a/internal/repository/coverage_final_test.go
+++ b/internal/repository/coverage_final_test.go
@@ -106,12 +106,15 @@ func TestDriveFileRepository_ListForAdmin_Branches(t *testing.T) {
 	r := NewDriveFileRepository(testDB)
 
 	// limit default + remote + host指定 + fileType + since/until
-	_, err := r.ListForAdmin("remote", "host.example", "image/", "since_x", "until_x", 0)
+	_, err := r.ListForAdmin("", "remote", "host.example", "image/", "since_x", "until_x", 0)
 	require.NoError(t, err)
-	_, err = r.ListForAdmin("remote", "host.example", "image/", "since_x", "until_x", 999)
+	_, err = r.ListForAdmin("", "remote", "host.example", "image/", "since_x", "until_x", 999)
 	require.NoError(t, err)
 	// origin="" (no userHost filter)
-	_, err = r.ListForAdmin("", "", "", "", "", 10)
+	_, err = r.ListForAdmin("", "", "", "", "", "", 10)
+	require.NoError(t, err)
+	// userId 指定 (origin / host が無視されるルートを通す)
+	_, err = r.ListForAdmin("nonexistent_user", "remote", "host.example", "", "", "", 10)
 	require.NoError(t, err)
 }
 

--- a/internal/repository/drive_file.go
+++ b/internal/repository/drive_file.go
@@ -17,10 +17,12 @@ type DriveFileRepository interface {
 	Update(id string, fields map[string]any) error
 	Delete(f *model.DriveFile) error
 	ListByUser(userID string, folderID *string, untilID, sinceID string, limit int) ([]*model.DriveFile, error)
-	// ListForAdmin returns drive files across all users with optional origin
-	// / host / type filters. origin is "local" / "remote" / "combined"
-	// ("combined" is the default). Empty host / type are no-ops.
-	ListForAdmin(origin, host, fileType, untilID, sinceID string, limit int) ([]*model.DriveFile, error)
+	// ListForAdmin returns drive files across all users with optional
+	// userID / origin / host / type filters. When userID is non-empty,
+	// origin / host are ignored (upstream Misskey の semantics と一致)。
+	// origin is "local" / "remote" / "combined" ("combined" is the
+	// default). Empty host / type are no-ops.
+	ListForAdmin(userID, origin, host, fileType, untilID, sinceID string, limit int) ([]*model.DriveFile, error)
 	FindByName(userID, name string, folderID *string) ([]*model.DriveFile, error)
 	ExistsByMD5(userID, md5 string) (bool, error)
 	ListByFileIDs(fileIDs []string) ([]*model.DriveFile, error)
@@ -169,16 +171,24 @@ func (r *driveFileRepository) UpdateBulkFolder(fileIDs []string, folderID *strin
 	return r.db.Model(&model.DriveFile{}).Where("id IN ?", fileIDs).Update("folderId", folderID).Error
 }
 
-func (r *driveFileRepository) ListForAdmin(origin, host, fileType, untilID, sinceID string, limit int) ([]*model.DriveFile, error) {
+func (r *driveFileRepository) ListForAdmin(userID, origin, host, fileType, untilID, sinceID string, limit int) ([]*model.DriveFile, error) {
 	q := r.db.Model(&model.DriveFile{})
-	switch origin {
-	case "local":
-		q = q.Where(`"userHost" IS NULL`)
-	case "remote":
-		q = q.Where(`"userHost" IS NOT NULL`)
-	}
-	if host != "" {
-		q = q.Where(`"userHost" = ?`, host)
+	if userID != "" {
+		// upstream は userId 指定時に origin / hostname を読まないので
+		// それに合わせる。`/admin/user/<id>` のドライブタブが userId 単独で
+		// 引いてくるが、handler 経由で origin="combined" が落ちてくると
+		// 全 remote が混ざるバグになるため (#471)。
+		q = q.Where(`"userId" = ?`, userID)
+	} else {
+		switch origin {
+		case "local":
+			q = q.Where(`"userHost" IS NULL`)
+		case "remote":
+			q = q.Where(`"userHost" IS NOT NULL`)
+		}
+		if host != "" {
+			q = q.Where(`"userHost" = ?`, host)
+		}
 	}
 	if fileType != "" {
 		// type is mimetype prefix match (e.g. "image/" matches image/png)

--- a/internal/repository/drive_file_test.go
+++ b/internal/repository/drive_file_test.go
@@ -149,7 +149,7 @@ func TestDriveFileRepository_ListForAdmin(t *testing.T) {
 	defer cleanupDriveFile(t, videoFile.ID)
 
 	// origin = remote → only the remote-host file
-	rows, err := repo.ListForAdmin("remote", "", "", "", "", 10)
+	rows, err := repo.ListForAdmin("", "remote", "", "", "", "", 10)
 	require.NoError(t, err)
 	ids := make(map[string]bool)
 	for _, r := range rows {
@@ -159,7 +159,7 @@ func TestDriveFileRepository_ListForAdmin(t *testing.T) {
 	assert.False(t, ids[localFile.ID])
 
 	// type = image/ prefix
-	rows, err = repo.ListForAdmin("", "", "image/", "", "", 10)
+	rows, err = repo.ListForAdmin("", "", "", "image/", "", "", 10)
 	require.NoError(t, err)
 	ids = make(map[string]bool)
 	for _, r := range rows {
@@ -169,7 +169,7 @@ func TestDriveFileRepository_ListForAdmin(t *testing.T) {
 	assert.False(t, ids[videoFile.ID])
 
 	// host exact match
-	rows, err = repo.ListForAdmin("", remoteHost, "", "", "", 10)
+	rows, err = repo.ListForAdmin("", "", remoteHost, "", "", "", 10)
 	require.NoError(t, err)
 	found := false
 	for _, r := range rows {
@@ -179,10 +179,23 @@ func TestDriveFileRepository_ListForAdmin(t *testing.T) {
 	}
 	assert.True(t, found)
 
-	// default limit / clamp
-	_, err = repo.ListForAdmin("", "", "", "", "", 0)
+	// userId narrows to that user's files only and ignores origin/host (#471)
+	otherUser := insertTestUser(t, "u_adm_lst2", "adlf2")
+	defer cleanupUser(t, otherUser.ID)
+	otherFile := newTestDriveFile("adl_other", otherUser.ID, "md5other", nil)
+	require.NoError(t, repo.Create(otherFile))
+	defer cleanupDriveFile(t, otherFile.ID)
+	rows, err = repo.ListForAdmin(user.ID, "remote", "", "", "", "", 10)
 	require.NoError(t, err)
-	_, err = repo.ListForAdmin("", "", "", "", "", 1000)
+	for _, r := range rows {
+		require.NotNil(t, r.UserID)
+		assert.Equal(t, user.ID, *r.UserID)
+	}
+
+	// default limit / clamp
+	_, err = repo.ListForAdmin("", "", "", "", "", "", 0)
+	require.NoError(t, err)
+	_, err = repo.ListForAdmin("", "", "", "", "", "", 1000)
 	require.NoError(t, err)
 }
 

--- a/internal/testutil/mock_drive.go
+++ b/internal/testutil/mock_drive.go
@@ -286,22 +286,28 @@ func (m *MockDriveFolderRepository) HasChildren(folderID string) (bool, error) {
 	return false, nil
 }
 
-func (m *MockDriveFileRepository) ListForAdmin(origin, host, fileType, untilID, sinceID string, limit int) ([]*model.DriveFile, error) {
+func (m *MockDriveFileRepository) ListForAdmin(userID, origin, host, fileType, untilID, sinceID string, limit int) ([]*model.DriveFile, error) {
 	rows := make([]*model.DriveFile, 0, len(m.Files))
 	for _, f := range m.Files {
-		switch origin {
-		case "local":
-			if f.UserHost != nil {
+		if userID != "" {
+			if f.UserID == nil || *f.UserID != userID {
 				continue
 			}
-		case "remote":
-			if f.UserHost == nil {
-				continue
+		} else {
+			switch origin {
+			case "local":
+				if f.UserHost != nil {
+					continue
+				}
+			case "remote":
+				if f.UserHost == nil {
+					continue
+				}
 			}
-		}
-		if host != "" {
-			if f.UserHost == nil || *f.UserHost != host {
-				continue
+			if host != "" {
+				if f.UserHost == nil || *f.UserHost != host {
+					continue
+				}
 			}
 		}
 		if fileType != "" && !strings.HasPrefix(f.Type, fileType) {


### PR DESCRIPTION
## Summary

ユーザーモデレーション画面 (\`/admin/user/<id>\`) のドライブタブで、対象ユーザー所有の drive_file ではなく全リモートメディアが一覧されていた問題を修正。

## Root cause

frontend (\`admin-user.vue:266\`) は \`admin/drive/files\` に \`userId: props.userId\` だけを送って narrow するつもりだったが、mk-go 側の handler (\`internal/api/admin/handler_stubs.go:425\`) の req struct に \`userId\` フィールドが無く JSON binding 時に silent drop されていた。さらに repository (\`internal/repository/drive_file.go:172\` の \`ListForAdmin\`) も \`userId\` 条件を持たないため origin=\"combined\" 相当で全件返ってしまっていた。

upstream Misskey TS (\`packages/backend/src/server/api/endpoints/admin/drive/files.ts:64-68\`) は \`userId\` 指定時に origin / hostname を読まずに \`file.userId = ?\` だけ適用する semantics。これに合わせる。

## 主な変更点

- \`internal/repository/drive_file.go\` \`ListForAdmin\` に userID 引数を追加。非空なら \`\"userId\" = ?\` だけ適用 (origin / host は無視)
- \`internal/testutil/mock_drive.go\` mock の \`ListForAdmin\` も同じ条件分岐を実装
- \`internal/api/admin/handler_stubs.go\` \`DriveFiles\` の req struct に \`UserID\` と \`Hostname\` を追加 (\`hostname\` パラメータも受ける upstream 互換)
- 既存の repository / coverage tests を新 signature に合わせ、\`userId\` narrow ルートを通すケースを追加
- \`internal/api/admin/drive_emoji_test.go\` 回帰防止 \`TestDriveFiles_FiltersByUserID\` を追加

## Testing

- \`go test ./... -count=1\` 全パッケージ通過
- \`make fmt && make lint\` clean
- UDS 環境再ビルド後、\`/admin/user/<id>\` のドライブタブで対象ユーザー所有の drive_file のみが表示され、他リモートユーザーのファイルが混入しないことを目視確認

Closes #471

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/shiroha-a/mk/pull/483" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
