### PR TITLE
Fix admin: admin/announcements/list honors userId filter (#472)

### DIFF
--- a/internal/api/announcements/handler.go
+++ b/internal/api/announcements/handler.go
@@ -212,13 +212,13 @@ func (h *Handler) AdminDelete(c echo.Context) error {
 
 // AdminList handles POST /api/admin/announcements/list.
 //
-// upstream Misskey TS の semantics:
-//   - userId 指定時: announcement.userId = ? のみ返す (ユーザーモデレーション
-//     画面の「お知らせ」タブはこのルート)
-//   - userId 未指定時: announcement.userId IS NULL のみ返す (全体お知らせ
-//     管理 UI)
-//   - status: "active" / "archived" / "all" (default "active")
-//   - 各 row に reads (announcement_read の対応行数) を埋める
+// Mirrors upstream Misskey TS semantics:
+//   - When userId is set, returns only announcements with that userId
+//     (the "announcements" tab on the admin user moderation page).
+//   - When userId is empty, returns only global announcements
+//     (userId IS NULL).
+//   - status: "active" / "archived" / "all" (default "active").
+//   - Each row carries a reads count (announcement_read row count).
 func (h *Handler) AdminList(c echo.Context) error {
 	var req struct {
 		Limit   int    `json:"limit"`

--- a/internal/api/announcements/handler.go
+++ b/internal/api/announcements/handler.go
@@ -211,21 +211,46 @@ func (h *Handler) AdminDelete(c echo.Context) error {
 }
 
 // AdminList handles POST /api/admin/announcements/list.
+//
+// upstream Misskey TS の semantics:
+//   - userId 指定時: announcement.userId = ? のみ返す (ユーザーモデレーション
+//     画面の「お知らせ」タブはこのルート)
+//   - userId 未指定時: announcement.userId IS NULL のみ返す (全体お知らせ
+//     管理 UI)
+//   - status: "active" / "archived" / "all" (default "active")
+//   - 各 row に reads (announcement_read の対応行数) を埋める
 func (h *Handler) AdminList(c echo.Context) error {
 	var req struct {
 		Limit   int    `json:"limit"`
 		Offset  int    `json:"offset"`
 		SinceID string `json:"sinceId"`
 		UntilID string `json:"untilId"`
+		UserID  string `json:"userId"`
+		Status  string `json:"status"`
 	}
 	if err := c.Bind(&req); err != nil {
 		return c.JSON(http.StatusBadRequest, apierr.Error("INVALID_PARAM", "Invalid parameters.", "3d81ceae-475f-4600-b2a8-2bc116157532"))
 	}
-	items, err := h.repo.List(false, req.Limit, req.Offset, req.SinceID, req.UntilID)
+	items, err := h.repo.ListForAdmin(req.UserID, req.Status, req.Limit, req.Offset, req.SinceID, req.UntilID)
 	if err != nil {
 		return c.JSON(http.StatusInternalServerError, apierr.Error("INTERNAL_ERROR", "Internal error.", "5d37dbcb-891e-41ca-a3d6-e690c97775ac"))
 	}
-	return c.JSON(http.StatusOK, items)
+	ids := make([]string, 0, len(items))
+	for _, a := range items {
+		ids = append(ids, a.ID)
+	}
+	reads, err := h.repo.CountReadsByAnnouncementIDs(ids)
+	if err != nil {
+		return c.JSON(http.StatusInternalServerError, apierr.Error("INTERNAL_ERROR", "Internal error.", "5d37dbcb-891e-41ca-a3d6-e690c97775ac"))
+	}
+	out := make([]map[string]any, 0, len(items))
+	for _, a := range items {
+		row := packAnnouncement(a, h.idGen)
+		row["userId"] = a.UserID
+		row["reads"] = reads[a.ID]
+		out = append(out, row)
+	}
+	return c.JSON(http.StatusOK, out)
 }
 
 // packAnnouncement wraps entity.PackAnnouncement for handler use. isRead

--- a/internal/api/announcements/handler_test.go
+++ b/internal/api/announcements/handler_test.go
@@ -339,9 +339,73 @@ func TestAdminDelete_InvalidParam(t *testing.T) {
 
 func TestAdminList_Success(t *testing.T) {
 	h, repo := newTestHandler(t)
-	repo.Items["a1"] = &model.Announcement{ID: "a1"}
+	repo.Items["a1"] = &model.Announcement{ID: "a1", IsActive: true}
 	rec := doPost(h.AdminList, `{}`, nil)
 	assert.Equal(t, http.StatusOK, rec.Code)
+}
+
+// /admin/user/<id> のお知らせタブが userId で narrow したときに、対象
+// ユーザー宛 announcement のみ返り、サーバー全体 announcement (userId
+// IS NULL) が混ざらないこと (#472)。
+func TestAdminList_UserScopeExcludesGlobal(t *testing.T) {
+	h, repo := newTestHandler(t)
+	target := "u_target"
+	other := "u_other"
+	repo.Items["a_global"] = &model.Announcement{ID: "a_global", IsActive: true}
+	repo.Items["a_target"] = &model.Announcement{ID: "a_target", IsActive: true, UserID: &target}
+	repo.Items["a_other"] = &model.Announcement{ID: "a_other", IsActive: true, UserID: &other}
+
+	rec := doPost(h.AdminList, `{"userId":"u_target","status":"active"}`, nil)
+	require.Equal(t, http.StatusOK, rec.Code)
+	var rows []map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &rows))
+	require.Len(t, rows, 1)
+	assert.Equal(t, "a_target", rows[0]["id"])
+	assert.Equal(t, "u_target", rows[0]["userId"])
+}
+
+// userId 未指定なら upstream 通り userId IS NULL の global only を返す。
+func TestAdminList_NoUserIDReturnsGlobalOnly(t *testing.T) {
+	h, repo := newTestHandler(t)
+	target := "u_target"
+	repo.Items["a_global"] = &model.Announcement{ID: "a_global", IsActive: true}
+	repo.Items["a_target"] = &model.Announcement{ID: "a_target", IsActive: true, UserID: &target}
+
+	rec := doPost(h.AdminList, `{"status":"active"}`, nil)
+	require.Equal(t, http.StatusOK, rec.Code)
+	var rows []map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &rows))
+	require.Len(t, rows, 1)
+	assert.Equal(t, "a_global", rows[0]["id"])
+}
+
+// status="archived" を指定すると isActive=false のみ返る。
+func TestAdminList_StatusArchived(t *testing.T) {
+	h, repo := newTestHandler(t)
+	repo.Items["a_active"] = &model.Announcement{ID: "a_active", IsActive: true}
+	repo.Items["a_archived"] = &model.Announcement{ID: "a_archived", IsActive: false}
+
+	rec := doPost(h.AdminList, `{"status":"archived"}`, nil)
+	require.Equal(t, http.StatusOK, rec.Code)
+	var rows []map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &rows))
+	require.Len(t, rows, 1)
+	assert.Equal(t, "a_archived", rows[0]["id"])
+}
+
+// reads count が announcement_read 行数で埋まること。
+func TestAdminList_ReadsCount(t *testing.T) {
+	h, repo := newTestHandler(t)
+	repo.Items["a1"] = &model.Announcement{ID: "a1", IsActive: true}
+	require.NoError(t, repo.MarkRead(&model.AnnouncementRead{ID: "r1", UserID: "u1", AnnouncementID: "a1"}))
+	require.NoError(t, repo.MarkRead(&model.AnnouncementRead{ID: "r2", UserID: "u2", AnnouncementID: "a1"}))
+
+	rec := doPost(h.AdminList, `{"status":"active"}`, nil)
+	require.Equal(t, http.StatusOK, rec.Code)
+	var rows []map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &rows))
+	require.Len(t, rows, 1)
+	assert.EqualValues(t, 2, rows[0]["reads"])
 }
 
 func TestAdminList_InvalidJSON(t *testing.T) {
@@ -365,6 +429,10 @@ func (f *failingListAnnouncementRepo) ListGlobal(_ bool, _, _ int, _, _ string) 
 }
 
 func (f *failingListAnnouncementRepo) ListForUser(_ string, _ bool, _, _ int, _, _ string) ([]*model.Announcement, error) {
+	return nil, assert.AnError
+}
+
+func (f *failingListAnnouncementRepo) ListForAdmin(_, _ string, _, _ int, _, _ string) ([]*model.Announcement, error) {
 	return nil, assert.AnError
 }
 

--- a/internal/repository/announcement.go
+++ b/internal/repository/announcement.go
@@ -22,6 +22,16 @@ type AnnouncementRepository interface {
 	// for unauthenticated /api/announcements requests so targeted
 	// announcements are never exposed.
 	ListGlobal(activeOnly bool, limit, offset int, sinceID, untilID string) ([]*model.Announcement, error)
+	// ListForAdmin returns announcements for the admin/announcements/list
+	// endpoint. When userID is non-empty, restricts to "userId" = ? (per-
+	// user announcements only). When empty, restricts to "userId" IS NULL
+	// (global only) — upstream Misskey の semantics と一致。status is one
+	// of "all" / "active" / "archived"; empty defaults to "active".
+	ListForAdmin(userID, status string, limit, offset int, sinceID, untilID string) ([]*model.Announcement, error)
+	// CountReadsByAnnouncementIDs returns reads count keyed by
+	// announcementId. IDs not present have count 0 (caller should default
+	// to 0 when absent).
+	CountReadsByAnnouncementIDs(ids []string) (map[string]int64, error)
 	UpdateFields(id string, fields map[string]any) error
 	Delete(id string) error
 	// Read management
@@ -136,6 +146,72 @@ func (r *announcementRepository) ListForUser(userID string, activeOnly bool, lim
 		return nil, err
 	}
 	return announcements, nil
+}
+
+func (r *announcementRepository) ListForAdmin(userID, status string, limit, offset int, sinceID, untilID string) ([]*model.Announcement, error) {
+	q := r.db.Order(paginationOrder(sinceID, untilID, "id"))
+	// upstream は userId 指定時に announcement.userId = ? を、未指定時に
+	// announcement.userId IS NULL を当てる。前者がユーザーモデレーション画面
+	// の「お知らせ」タブで対象ユーザー宛の announcement のみを引くルート。
+	if userID != "" {
+		q = q.Where(`"userId" = ?`, userID)
+	} else {
+		q = q.Where(`"userId" IS NULL`)
+	}
+	switch status {
+	case "archived":
+		q = q.Where(`"isActive" = false`)
+	case "all":
+		// no filter
+	default:
+		// "" / "active" / unknown は upstream と同じく active のみ
+		q = q.Where(`"isActive" = true`)
+	}
+	if limit <= 0 {
+		limit = 10
+	}
+	if limit > 100 {
+		limit = 100
+	}
+	q = q.Limit(limit)
+	if sinceID != "" {
+		q = q.Where("id > ?", sinceID)
+	}
+	if untilID != "" {
+		q = q.Where("id < ?", untilID)
+	}
+	if sinceID == "" && untilID == "" && offset > 0 {
+		q = q.Offset(offset)
+	}
+	var announcements []*model.Announcement
+	if err := q.Find(&announcements).Error; err != nil {
+		return nil, err
+	}
+	return announcements, nil
+}
+
+func (r *announcementRepository) CountReadsByAnnouncementIDs(ids []string) (map[string]int64, error) {
+	out := make(map[string]int64, len(ids))
+	if len(ids) == 0 {
+		return out, nil
+	}
+	type row struct {
+		AnnouncementID string `gorm:"column:announcementId"`
+		C              int64  `gorm:"column:c"`
+	}
+	var rows []row
+	err := r.db.Model(&model.AnnouncementRead{}).
+		Select(`"announcementId", COUNT(*) AS c`).
+		Where(`"announcementId" IN ?`, ids).
+		Group(`"announcementId"`).
+		Scan(&rows).Error
+	if err != nil {
+		return nil, err
+	}
+	for _, r := range rows {
+		out[r.AnnouncementID] = r.C
+	}
+	return out, nil
 }
 
 func (r *announcementRepository) UpdateFields(id string, fields map[string]any) error {

--- a/internal/repository/announcement.go
+++ b/internal/repository/announcement.go
@@ -208,8 +208,8 @@ func (r *announcementRepository) CountReadsByAnnouncementIDs(ids []string) (map[
 	if err != nil {
 		return nil, err
 	}
-	for _, r := range rows {
-		out[r.AnnouncementID] = r.C
+	for _, row := range rows {
+		out[row.AnnouncementID] = row.C
 	}
 	return out, nil
 }

--- a/internal/repository/announcement.go
+++ b/internal/repository/announcement.go
@@ -25,7 +25,7 @@ type AnnouncementRepository interface {
 	// ListForAdmin returns announcements for the admin/announcements/list
 	// endpoint. When userID is non-empty, restricts to "userId" = ? (per-
 	// user announcements only). When empty, restricts to "userId" IS NULL
-	// (global only) — upstream Misskey の semantics と一致。status is one
+	// (global only), matching upstream Misskey's semantics. status is one
 	// of "all" / "active" / "archived"; empty defaults to "active".
 	ListForAdmin(userID, status string, limit, offset int, sinceID, untilID string) ([]*model.Announcement, error)
 	// CountReadsByAnnouncementIDs returns reads count keyed by
@@ -150,9 +150,9 @@ func (r *announcementRepository) ListForUser(userID string, activeOnly bool, lim
 
 func (r *announcementRepository) ListForAdmin(userID, status string, limit, offset int, sinceID, untilID string) ([]*model.Announcement, error) {
 	q := r.db.Order(paginationOrder(sinceID, untilID, "id"))
-	// upstream は userId 指定時に announcement.userId = ? を、未指定時に
-	// announcement.userId IS NULL を当てる。前者がユーザーモデレーション画面
-	// の「お知らせ」タブで対象ユーザー宛の announcement のみを引くルート。
+	// upstreamはuserId指定時にannouncement.userId = ?を、未指定時に
+	// announcement.userId IS NULLを当てる。前者がユーザーモデレーション画面
+	// の「お知らせ」タブで対象ユーザー宛のannouncementのみを引くルート。
 	if userID != "" {
 		q = q.Where(`"userId" = ?`, userID)
 	} else {
@@ -164,7 +164,7 @@ func (r *announcementRepository) ListForAdmin(userID, status string, limit, offs
 	case "all":
 		// no filter
 	default:
-		// "" / "active" / unknown は upstream と同じく active のみ
+		// "" / "active" / unknownはupstreamと同じくactiveのみ
 		q = q.Where(`"isActive" = true`)
 	}
 	if limit <= 0 {

--- a/internal/repository/announcement_test.go
+++ b/internal/repository/announcement_test.go
@@ -413,3 +413,105 @@ func TestAnnouncementRepository_IsRead_Error(t *testing.T) {
 	_, err := repo.IsRead("x", "y")
 	assert.Error(t, err)
 }
+
+func TestAnnouncementRepository_ListForAdmin_FiltersByUserID(t *testing.T) {
+	repo := NewAnnouncementRepository(testDB)
+
+	// 念のため、過去 run の残骸を消してから始める。同名 fixture を使う
+	// と FK / pkey 違反になりやすい。
+	testDB.Exec(`DELETE FROM "announcement" WHERE id IN (?, ?, ?)`, "ann_lfa_g", "ann_lfa_t", "ann_lfa_o")
+
+	tu := insertTestUser(t, "u_ann_tgt", "annt")
+	defer cleanupUser(t, tu.ID)
+	ou := insertTestUser(t, "u_ann_oth", "anno")
+	defer cleanupUser(t, ou.ID)
+	global := &model.Announcement{ID: "ann_lfa_g", Title: "g", Text: "g", Icon: "info", Display: "normal", IsActive: true}
+	tUser := &model.Announcement{ID: "ann_lfa_t", Title: "t", Text: "t", Icon: "info", Display: "normal", IsActive: true, UserID: &tu.ID}
+	oUser := &model.Announcement{ID: "ann_lfa_o", Title: "o", Text: "o", Icon: "info", Display: "normal", IsActive: true, UserID: &ou.ID}
+	require.NoError(t, repo.Create(global))
+	require.NoError(t, repo.Create(tUser))
+	require.NoError(t, repo.Create(oUser))
+	defer cleanupAnnouncement(t, global.ID)
+	defer cleanupAnnouncement(t, tUser.ID)
+	defer cleanupAnnouncement(t, oUser.ID)
+
+	// userId 指定 → そのユーザー宛のみ
+	rows, err := repo.ListForAdmin(tu.ID, "active", 10, 0, "", "")
+	require.NoError(t, err)
+	ids := make(map[string]bool)
+	for _, r := range rows {
+		ids[r.ID] = true
+	}
+	assert.True(t, ids[tUser.ID])
+	assert.False(t, ids[global.ID])
+	assert.False(t, ids[oUser.ID])
+
+	// userId 未指定 → global only
+	rows, err = repo.ListForAdmin("", "active", 10, 0, "", "")
+	require.NoError(t, err)
+	ids = make(map[string]bool)
+	for _, r := range rows {
+		ids[r.ID] = true
+	}
+	assert.True(t, ids[global.ID])
+	assert.False(t, ids[tUser.ID])
+	assert.False(t, ids[oUser.ID])
+}
+
+func TestAnnouncementRepository_ListForAdmin_StatusBranches(t *testing.T) {
+	repo := NewAnnouncementRepository(testDB)
+	active := &model.Announcement{ID: "ann_lfa_act", Title: "a", Text: "a", Icon: "info", Display: "normal", IsActive: true}
+	archived := &model.Announcement{ID: "ann_lfa_arc", Title: "x", Text: "x", Icon: "info", Display: "normal", IsActive: false}
+	require.NoError(t, repo.Create(active))
+	require.NoError(t, repo.Create(archived))
+	defer cleanupAnnouncement(t, active.ID)
+	defer cleanupAnnouncement(t, archived.ID)
+
+	// archived
+	rows, err := repo.ListForAdmin("", "archived", 10, 0, "", "")
+	require.NoError(t, err)
+	for _, r := range rows {
+		assert.False(t, r.IsActive)
+	}
+	// all (両方含む)
+	rows, err = repo.ListForAdmin("", "all", 10, 0, "", "")
+	require.NoError(t, err)
+	ids := make(map[string]bool)
+	for _, r := range rows {
+		ids[r.ID] = true
+	}
+	assert.True(t, ids[active.ID])
+	assert.True(t, ids[archived.ID])
+
+	// limit / offset / since / until / clamp paths
+	_, err = repo.ListForAdmin("", "active", 0, 0, "", "")
+	require.NoError(t, err)
+	_, err = repo.ListForAdmin("", "active", 1000, 5, "", "")
+	require.NoError(t, err)
+	_, err = repo.ListForAdmin("", "active", 10, 0, "since_x", "until_x")
+	require.NoError(t, err)
+}
+
+func TestAnnouncementRepository_CountReadsByAnnouncementIDs(t *testing.T) {
+	repo := NewAnnouncementRepository(testDB)
+	u1 := insertTestUser(t, "u_ann_cr1", "annc1")
+	defer cleanupUser(t, u1.ID)
+	u2 := insertTestUser(t, "u_ann_cr2", "annc2")
+	defer cleanupUser(t, u2.ID)
+	a := &model.Announcement{ID: "ann_cnt_1", Title: "t", Text: "t", Icon: "info", Display: "normal", IsActive: true}
+	require.NoError(t, repo.Create(a))
+	defer cleanupAnnouncement(t, a.ID)
+	require.NoError(t, repo.MarkRead(&model.AnnouncementRead{ID: "ar_cnt_1", UserID: u1.ID, AnnouncementID: a.ID}))
+	require.NoError(t, repo.MarkRead(&model.AnnouncementRead{ID: "ar_cnt_2", UserID: u2.ID, AnnouncementID: a.ID}))
+
+	out, err := repo.CountReadsByAnnouncementIDs([]string{a.ID, "ann_no_such"})
+	require.NoError(t, err)
+	assert.EqualValues(t, 2, out[a.ID])
+	_, missing := out["ann_no_such"]
+	assert.False(t, missing)
+
+	// empty input は早期 return
+	out, err = repo.CountReadsByAnnouncementIDs(nil)
+	require.NoError(t, err)
+	assert.Empty(t, out)
+}

--- a/internal/repository/announcement_test.go
+++ b/internal/repository/announcement_test.go
@@ -461,18 +461,27 @@ func TestAnnouncementRepository_ListForAdmin_FiltersByUserID(t *testing.T) {
 func TestAnnouncementRepository_ListForAdmin_StatusBranches(t *testing.T) {
 	repo := NewAnnouncementRepository(testDB)
 	active := &model.Announcement{ID: "ann_lfa_act", Title: "a", Text: "a", Icon: "info", Display: "normal", IsActive: true}
-	archived := &model.Announcement{ID: "ann_lfa_arc", Title: "x", Text: "x", Icon: "info", Display: "normal", IsActive: false}
+	// GORM の `default:true` tag により bool の zero value は DB default
+	// (true) が適用される (`internal/model/announcement.go:15` 参照)。
+	// archived row を作るときは一度 true で insert してから UpdateFields
+	// で false に落とすのが既存パターン。
+	archived := &model.Announcement{ID: "ann_lfa_arc", Title: "x", Text: "x", Icon: "info", Display: "normal", IsActive: true}
 	require.NoError(t, repo.Create(active))
 	require.NoError(t, repo.Create(archived))
+	require.NoError(t, repo.UpdateFields(archived.ID, map[string]any{"isActive": false}))
 	defer cleanupAnnouncement(t, active.ID)
 	defer cleanupAnnouncement(t, archived.ID)
 
-	// archived
+	// archived: archived row が含まれ active row が含まれないこと。
 	rows, err := repo.ListForAdmin("", "archived", 10, 0, "", "")
 	require.NoError(t, err)
+	archivedIDs := make(map[string]bool)
 	for _, r := range rows {
 		assert.False(t, r.IsActive)
+		archivedIDs[r.ID] = true
 	}
+	assert.True(t, archivedIDs[archived.ID])
+	assert.False(t, archivedIDs[active.ID])
 	// all (両方含む)
 	rows, err = repo.ListForAdmin("", "all", 10, 0, "", "")
 	require.NoError(t, err)

--- a/internal/testutil/mock_repository.go
+++ b/internal/testutil/mock_repository.go
@@ -3880,6 +3880,74 @@ func (m *MockAnnouncementRepository) ListForUser(userID string, activeOnly bool,
 	return result[:limit], nil
 }
 
+func (m *MockAnnouncementRepository) ListForAdmin(userID, status string, limit, offset int, sinceID, untilID string) ([]*model.Announcement, error) {
+	var result []*model.Announcement
+	for _, a := range m.Items {
+		if userID != "" {
+			if a.UserID == nil || *a.UserID != userID {
+				continue
+			}
+		} else {
+			if a.UserID != nil {
+				continue
+			}
+		}
+		switch status {
+		case "archived":
+			if a.IsActive {
+				continue
+			}
+		case "all":
+			// no filter
+		default:
+			if !a.IsActive {
+				continue
+			}
+		}
+		if sinceID != "" && a.ID <= sinceID {
+			continue
+		}
+		if untilID != "" && a.ID >= untilID {
+			continue
+		}
+		result = append(result, a)
+	}
+	if limit <= 0 {
+		limit = 10
+	}
+	if sinceID == "" && untilID == "" {
+		if offset >= len(result) {
+			return nil, nil
+		}
+		end := min(offset+limit, len(result))
+		return result[offset:end], nil
+	}
+	if limit > len(result) {
+		limit = len(result)
+	}
+	return result[:limit], nil
+}
+
+func (m *MockAnnouncementRepository) CountReadsByAnnouncementIDs(ids []string) (map[string]int64, error) {
+	out := make(map[string]int64, len(ids))
+	idSet := make(map[string]struct{}, len(ids))
+	for _, id := range ids {
+		idSet[id] = struct{}{}
+	}
+	for key := range m.Reads {
+		// key 形式: userID + ":" + announcementID (MarkRead 参照)
+		idx := strings.LastIndex(key, ":")
+		if idx < 0 {
+			continue
+		}
+		aid := key[idx+1:]
+		if _, ok := idSet[aid]; ok {
+			out[aid]++
+		}
+	}
+	return out, nil
+}
+
 func (m *MockAnnouncementRepository) UpdateFields(id string, fields map[string]any) error {
 	a, ok := m.Items[id]
 	if !ok {


### PR DESCRIPTION
## Summary

ユーザーモデレーション画面 (\`/admin/user/<id>\`) のお知らせタブで、対象ユーザー宛 announcement ではなくサーバー全体お知らせが一覧されていた問題を修正。

## Root cause

frontend (\`admin-user.vue:284\`) は \`admin/announcements/list\` に \`{ userId, status }\` を送って narrow するつもりだったが、handler (\`internal/api/announcements/handler.go:213\`) は \`userId\` / \`status\` / reads count をどれも binding せず \`repo.List(false, ...)\` で全 announcement を返していた。

upstream Misskey TS (\`admin/announcements/list.ts:130-134\`) の semantics:
- \`ps.userId\` 指定時 → \`announcement.userId = ps.userId\` のみ (per-user)
- \`ps.userId\` 未指定時 → \`announcement.userId IS NULL\` のみ (global only)
- \`status\`: \`\"active\"\` / \`\"archived\"\` / \`\"all\"\` (default \`\"active\"\`)
- 各 row に \`announcement_read\` 行数を \`reads\` として埋める

## 主な変更点

- \`internal/repository/announcement.go\` に \`ListForAdmin(userID, status, limit, offset, sinceID, untilID)\` と \`CountReadsByAnnouncementIDs([]string) (map[string]int64, error)\` を追加
- \`internal/testutil/mock_repository.go\` mock の対応メソッドを実装
- \`internal/api/announcements/handler.go\` \`AdminList\` の req struct に \`UserID\` / \`Status\` を追加し、\`ListForAdmin\` 経由で narrow + reads count を response に埋める
- repository / handler テストで userId narrow / status / reads count を回帰検証

## Testing

- \`go test ./... -count=1\` 全パッケージ通過
- \`make fmt && make lint\` clean
- UDS 環境再ビルド後、\`/admin/user/<id>\` のお知らせタブで対象ユーザー宛 announcement のみが表示され、サーバー全体お知らせが混ざらないことを目視確認

Closes #472

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/shiroha-a/mk/pull/484" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
