### PR TITLE
Wire cfg.proxy / proxyBypassHosts into safehttp transport (#485)

### DIFF
--- a/internal/core/mediaproxy/service.go
+++ b/internal/core/mediaproxy/service.go
@@ -23,6 +23,7 @@ import (
 	_ "golang.org/x/image/webp"
 
 	coredrive "github.com/shiroha-a/mk/internal/core/drive"
+	"github.com/shiroha-a/mk/internal/safehttp"
 )
 
 // ProxyMode enumerates the image processing modes.
@@ -112,7 +113,8 @@ type Service struct {
 
 // NewService creates a new media proxy Service.
 // allowedPrivateNetworks は SSRF 保護で許可するプライベート CIDR リスト (config.AllowedPrivateNetworks)。
-func NewService(instanceURL, userAgent string, driveStorage coredrive.Storage, allowlist AllowlistChecker, hmacSecret []byte, allowedPrivateNetworks []string) *Service {
+// transportOpts は forward proxy 等の追加 transport 設定 (safehttp.WithProxy など)。
+func NewService(instanceURL, userAgent string, driveStorage coredrive.Storage, allowlist AllowlistChecker, hmacSecret []byte, allowedPrivateNetworks []string, transportOpts ...safehttp.Option) *Service {
 	return &Service{
 		instanceURL:  instanceURL,
 		driveStorage: driveStorage,
@@ -120,7 +122,7 @@ func NewService(instanceURL, userAgent string, driveStorage coredrive.Storage, a
 		hmacSecret:   hmacSecret,
 		httpClient: &http.Client{
 			Timeout:   30 * time.Second,
-			Transport: NewSSRFSafeTransport(allowedPrivateNetworks),
+			Transport: NewSSRFSafeTransport(allowedPrivateNetworks, transportOpts...),
 		},
 		userAgent: userAgent,
 	}

--- a/internal/core/mediaproxy/ssrf.go
+++ b/internal/core/mediaproxy/ssrf.go
@@ -13,6 +13,7 @@ var ErrSSRFBlocked = safehttp.ErrSSRFBlocked
 // NewSSRFSafeTransport returns an *http.Transport with a custom DialContext
 // that resolves DNS first and rejects connections to private/reserved IPs.
 // Thin wrapper over safehttp.NewSSRFSafeTransport (#323 で共通化した)。
-func NewSSRFSafeTransport(allowedCIDRs []string) *http.Transport {
-	return safehttp.NewSSRFSafeTransport(allowedCIDRs)
+// opts は forward proxy などの追加 transport 設定を渡す経路。
+func NewSSRFSafeTransport(allowedCIDRs []string, opts ...safehttp.Option) *http.Transport {
+	return safehttp.NewSSRFSafeTransport(allowedCIDRs, opts...)
 }

--- a/internal/safehttp/ssrf.go
+++ b/internal/safehttp/ssrf.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"net"
 	"net/http"
+	"net/url"
 	"time"
 )
 
@@ -49,10 +50,38 @@ func init() {
 // ErrSSRFBlocked is returned when a connection to a private/reserved IP is blocked.
 var ErrSSRFBlocked = fmt.Errorf("safehttp: connection to private IP blocked")
 
+// transportOptions accumulates state from functional Option values.
+type transportOptions struct {
+	proxyURL    string
+	bypassHosts []string
+}
+
+// Option configures NewSSRFSafeTransport. Use WithProxy to enable forward
+// proxy support; pass no options for the default SSRF-safe direct transport.
+type Option func(*transportOptions)
+
+// WithProxy wires a forward HTTP proxy and an optional bypass list. proxyURL
+// must be a full URL parseable by url.Parse (e.g. http://127.0.0.1:3128). When
+// proxyURL is empty the option is a no-op so callers can pass config values
+// straight through. bypassHosts is matched as exact case-sensitive hostname
+// equality, mirroring upstream Misskey's `proxyBypassHosts.includes(...)`.
+func WithProxy(proxyURL string, bypassHosts []string) Option {
+	return func(o *transportOptions) {
+		o.proxyURL = proxyURL
+		o.bypassHosts = bypassHosts
+	}
+}
+
 // NewSSRFSafeTransport returns an *http.Transport with a custom DialContext
 // that resolves DNS first and rejects connections to private/reserved IPs.
 // allowedCIDRs は config.AllowedPrivateNetworks に対応し、明示的に許可する CIDR リスト。
-func NewSSRFSafeTransport(allowedCIDRs []string) *http.Transport {
+// Functional opts (現状 WithProxy のみ) で外向き forward proxy 経由を有効化できる。
+func NewSSRFSafeTransport(allowedCIDRs []string, opts ...Option) *http.Transport {
+	o := transportOptions{}
+	for _, fn := range opts {
+		fn(&o)
+	}
+
 	var allowedNets []*net.IPNet
 	for _, cidr := range allowedCIDRs {
 		_, ipNet, err := net.ParseCIDR(cidr)
@@ -62,13 +91,49 @@ func NewSSRFSafeTransport(allowedCIDRs []string) *http.Transport {
 		allowedNets = append(allowedNets, ipNet)
 	}
 
+	// proxy 設定があれば事前に URL を一度だけ parse する。失敗したものは
+	// 無視 (proxy 不使用) して direct fallback。起動時に config 経由で
+	// 渡るので毎リクエスト parse する必要は無い。
+	var proxyURL *url.URL
+	var proxyAddr string // host:port 形式 (DialContext での比較用)
+	if o.proxyURL != "" {
+		if u, err := url.Parse(o.proxyURL); err == nil && u.Host != "" {
+			proxyURL = u
+			proxyAddr = u.Host
+			// URL に明示ポートが無い場合は scheme 既定を補う。後段の
+			// addr 比較で `host:80` のような正規化形と一致させるため。
+			if _, _, splitErr := net.SplitHostPort(proxyAddr); splitErr != nil {
+				if u.Scheme == "https" {
+					proxyAddr = net.JoinHostPort(u.Host, "443")
+				} else {
+					proxyAddr = net.JoinHostPort(u.Host, "80")
+				}
+			}
+		}
+	}
+	bypass := make(map[string]struct{}, len(o.bypassHosts))
+	for _, h := range o.bypassHosts {
+		if h != "" {
+			bypass[h] = struct{}{}
+		}
+	}
+
 	dialer := &net.Dialer{
 		Timeout:   10 * time.Second,
 		KeepAlive: 30 * time.Second,
 	}
 
-	return &http.Transport{
+	tr := &http.Transport{
 		DialContext: func(ctx context.Context, network, addr string) (net.Conn, error) {
+			// proxy 経由のリクエストでは Transport.Proxy callback の結果に
+			// 沿って http.Transport が proxy host:port で DialContext を
+			// 呼ぶ。proxy はオペレーターが明示設定したエンドポイントなので
+			// SSRF check (private IP 拒否) は適用しない。bypass 経路や
+			// proxy 未指定の direct dial には従来通り SSRF を適用する。
+			if proxyAddr != "" && addr == proxyAddr {
+				return dialer.DialContext(ctx, network, addr)
+			}
+
 			host, port, err := net.SplitHostPort(addr)
 			if err != nil {
 				return nil, fmt.Errorf("safehttp: invalid address %q: %w", addr, err)
@@ -107,6 +172,18 @@ func NewSSRFSafeTransport(allowedCIDRs []string) *http.Transport {
 		// HTTP/1.1 のみに退化するのを避ける (#323 Devin review)。
 		ForceAttemptHTTP2: true,
 	}
+	if proxyURL != nil {
+		// upstream Misskey の HttpRequestService.getAgentByUrl と同じく
+		// proxyBypassHosts に含まれる hostname (exact match) は proxy を
+		// 経由せず direct で出す。それ以外は proxyURL に CONNECT/forward。
+		tr.Proxy = func(req *http.Request) (*url.URL, error) {
+			if _, ok := bypass[req.URL.Hostname()]; ok {
+				return nil, nil
+			}
+			return proxyURL, nil
+		}
+	}
+	return tr
 }
 
 // isPrivateIP returns true if ip falls within a private/reserved range

--- a/internal/safehttp/ssrf.go
+++ b/internal/safehttp/ssrf.go
@@ -102,11 +102,14 @@ func NewSSRFSafeTransport(allowedCIDRs []string, opts ...Option) *http.Transport
 			proxyAddr = u.Host
 			// URL に明示ポートが無い場合は scheme 既定を補う。後段の
 			// addr 比較で `host:80` のような正規化形と一致させるため。
+			// IPv6 host は u.Host が "[::1]" のように bracket 付きで
+			// 返るため net.JoinHostPort には bracket を剥がした
+			// u.Hostname() を渡す (二重 bracket を避ける)。
 			if _, _, splitErr := net.SplitHostPort(proxyAddr); splitErr != nil {
 				if u.Scheme == "https" {
-					proxyAddr = net.JoinHostPort(u.Host, "443")
+					proxyAddr = net.JoinHostPort(u.Hostname(), "443")
 				} else {
-					proxyAddr = net.JoinHostPort(u.Host, "80")
+					proxyAddr = net.JoinHostPort(u.Hostname(), "80")
 				}
 			}
 		}

--- a/internal/safehttp/ssrf_test.go
+++ b/internal/safehttp/ssrf_test.go
@@ -4,6 +4,7 @@ import (
 	"net"
 	"net/http"
 	"net/http/httptest"
+	"net/url"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -148,4 +149,82 @@ func TestNewSSRFSafeTransport_DNSResolutionFailure(t *testing.T) {
 
 	_, err := client.Get("http://nonexistent.invalid/test")
 	assert.Error(t, err)
+}
+
+// proxy 経路で外向きリクエストが proxy server に届くこと、proxy 自体が
+// プライベート IP でも SSRF block されないこと (#485)。
+func TestNewSSRFSafeTransport_ForwardsThroughProxy(t *testing.T) {
+	hits := 0
+	// proxy 役の httptest server。HTTP の forward proxy は absolute-form
+	// URL (例: GET http://example.com/foo HTTP/1.1) を受け取るので
+	// req.URL を見て応答するだけで proxy として振る舞える。
+	proxy := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		hits++
+		// proxy は absolute-form URL を受け取る
+		assert.Equal(t, "example.com", r.URL.Host)
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("via-proxy"))
+	}))
+	defer proxy.Close()
+
+	// httptest は 127.0.0.1 で起動するので allowedCIDRs 無しでも proxy
+	// 接続自体は SSRF skip される (proxyAddr 一致)。
+	tr := NewSSRFSafeTransport(nil, WithProxy(proxy.URL, nil))
+	client := &http.Client{Transport: tr}
+
+	resp, err := client.Get("http://example.com/path")
+	require.NoError(t, err)
+	defer resp.Body.Close()
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+	assert.Equal(t, 1, hits)
+}
+
+// bypass list に列挙された host は proxy を経由せず direct dial になる。
+// direct dial は SSRF check 対象なので、loopback への bypass は CIDR 許可
+// が無い限りブロックされる。
+func TestNewSSRFSafeTransport_BypassRoutesDirectAndKeepsSSRF(t *testing.T) {
+	proxyHits := 0
+	proxy := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		proxyHits++
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer proxy.Close()
+
+	directHits := 0
+	target := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		directHits++
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer target.Close()
+
+	targetURL, err := url.Parse(target.URL)
+	require.NoError(t, err)
+	// bypass で direct dial になるが、target も loopback なので SSRF を
+	// 許可するため CIDR 127.0.0.0/8 を allowedCIDRs に入れる。
+	tr := NewSSRFSafeTransport(
+		[]string{"127.0.0.0/8"},
+		WithProxy(proxy.URL, []string{targetURL.Hostname()}),
+	)
+	client := &http.Client{Transport: tr}
+
+	resp, err := client.Get(target.URL + "/x")
+	require.NoError(t, err)
+	defer resp.Body.Close()
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+	assert.Equal(t, 0, proxyHits, "bypass-listed host must not go through proxy")
+	assert.Equal(t, 1, directHits)
+}
+
+// proxy URL が不正な場合は proxy 設定が無視され direct dial にフォール
+// バックする (起動時に panic させない)。
+func TestNewSSRFSafeTransport_InvalidProxyURLFallsBack(t *testing.T) {
+	tr := NewSSRFSafeTransport(nil, WithProxy("://not-a-url", nil))
+	assert.NotNil(t, tr)
+	assert.Nil(t, tr.Proxy, "invalid proxy URL must leave Transport.Proxy unset")
+}
+
+// WithProxy("", ...) は no-op (proxy 不使用)。
+func TestNewSSRFSafeTransport_EmptyProxyURLNoOp(t *testing.T) {
+	tr := NewSSRFSafeTransport(nil, WithProxy("", []string{"example.com"}))
+	assert.Nil(t, tr.Proxy, "empty proxy URL must not enable Transport.Proxy")
 }

--- a/internal/safehttp/ssrf_test.go
+++ b/internal/safehttp/ssrf_test.go
@@ -6,6 +6,7 @@ import (
 	"net/http/httptest"
 	"net/url"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -227,4 +228,27 @@ func TestNewSSRFSafeTransport_InvalidProxyURLFallsBack(t *testing.T) {
 func TestNewSSRFSafeTransport_EmptyProxyURLNoOp(t *testing.T) {
 	tr := NewSSRFSafeTransport(nil, WithProxy("", []string{"example.com"}))
 	assert.Nil(t, tr.Proxy, "empty proxy URL must not enable Transport.Proxy")
+}
+
+// IPv6 host の proxy URL に明示 port が無いとき、u.Host は "[::1]"
+// のように bracket 付きで返る。これを net.JoinHostPort にそのまま渡すと
+// "[[::1]]:80" の二重 bracket になり、後段の DialContext 比較で proxy
+// 一致と判定されず SSRF check が走る → loopback (::1) として block
+// されてしまう。u.Hostname() で剥がしてから net.JoinHostPort に渡す
+// ことで http.Transport が dial する正規形 ("[::1]:80") と一致する。
+//
+// 直接 proxyAddr を assert できないので、実 dial を試して
+// ErrSSRFBlocked が返らない (= proxy 一致判定が機能している) ことで
+// 間接的に検証する。dial 自体はループバック上の閉じた port なので
+// "connection refused" 系のエラーになるが、それは bug fix の対象外。
+func TestNewSSRFSafeTransport_IPv6ProxyDefaultPort(t *testing.T) {
+	tr := NewSSRFSafeTransport(nil, WithProxy("http://[::1]", nil))
+	require.NotNil(t, tr)
+	require.NotNil(t, tr.Proxy)
+
+	client := &http.Client{Transport: tr, Timeout: 2 * time.Second}
+	_, err := client.Get("http://example.com/")
+	require.Error(t, err, "dial to ::1:80 will fail (no listener) but must not be SSRF-blocked")
+	assert.NotErrorIs(t, err, ErrSSRFBlocked,
+		"proxy connection must skip SSRF check even when proxy host is IPv6 loopback without explicit port")
 }

--- a/internal/server/router.go
+++ b/internal/server/router.go
@@ -399,9 +399,10 @@ func (s *Server) setupRoutes() {
 	}
 	// AP outbound client: SSRF-safe transport を適用 (#323)。
 	// config.AllowedPrivateNetworks で開発時の self-loop を許可できる。
+	// config.Proxy / ProxyBypassHosts も #485 で wire 済み。
 	apHTTPClient := &http.Client{
 		Timeout:   30 * time.Second,
-		Transport: safehttp.NewSSRFSafeTransport(s.config.AllowedPrivateNetworks),
+		Transport: safehttp.NewSSRFSafeTransport(s.config.AllowedPrivateNetworks, safehttp.WithProxy(s.config.Proxy, s.config.ProxyBypassHosts)),
 	}
 	apClient := activitypub.NewClient(apHTTPClient, s.config.UserAgent)
 	// meta.allowExternalApRedirect が false なら AP fetch でのリダイレクトを拒否する。
@@ -421,7 +422,7 @@ func (s *Server) setupRoutes() {
 	// (30s) より短めの 10s にする。
 	imageProbeClient := &http.Client{
 		Timeout:   10 * time.Second,
-		Transport: safehttp.NewSSRFSafeTransport(s.config.AllowedPrivateNetworks),
+		Transport: safehttp.NewSSRFSafeTransport(s.config.AllowedPrivateNetworks, safehttp.WithProxy(s.config.Proxy, s.config.ProxyBypassHosts)),
 	}
 	federationResolver.SetImageProbeClient(imageProbeClient)
 	federationProcessor := corefederation.NewProcessor(federationResolver, followingService, reactionService, noteDeleteService, userRepo, noteRepo)
@@ -435,7 +436,7 @@ func (s *Server) setupRoutes() {
 	// user-facing API 経由で呼ばれるので応答性優先で 10s に設定する。
 	webfingerClient := activitypub.NewWebFingerClient(&http.Client{
 		Timeout:   10 * time.Second,
-		Transport: safehttp.NewSSRFSafeTransport(s.config.AllowedPrivateNetworks),
+		Transport: safehttp.NewSSRFSafeTransport(s.config.AllowedPrivateNetworks, safehttp.WithProxy(s.config.Proxy, s.config.ProxyBypassHosts)),
 	}, s.config.UserAgent)
 	userService.SetRemoteUserResolver(corefederation.NewRemoteUserResolver(
 		webfingerClient, federationResolver, userRepo, localHost,
@@ -1232,6 +1233,7 @@ func (s *Server) setupRoutes() {
 		s.config.URL, s.config.UserAgent, driveStorage,
 		proxyAllowlist, s.config.MediaProxySecret,
 		s.config.AllowedPrivateNetworks,
+		safehttp.WithProxy(s.config.Proxy, s.config.ProxyBypassHosts),
 	)
 	proxyHandler := apiproxy.NewHandler(proxyService, s.config)
 	s.echo.GET("/proxy/*", proxyHandler.Handle)
@@ -1719,7 +1721,7 @@ func (s *Server) setupRoutes() {
 		s.redis.Default,
 		&http.Client{
 			Timeout:   10 * time.Second,
-			Transport: safehttp.NewSSRFSafeTransport(s.config.AllowedPrivateNetworks),
+			Transport: safehttp.NewSSRFSafeTransport(s.config.AllowedPrivateNetworks, safehttp.WithProxy(s.config.Proxy, s.config.ProxyBypassHosts)),
 		},
 	))
 	// #417 P3: /match の acct 引数で未キャッシュのリモートユーザーを


### PR DESCRIPTION
## Summary

\`config.proxy\` / \`config.proxyBypassHosts\` の設定値は読み込みのみで実際の HTTP transport には渡っておらず、フォワードプロキシ設定が完全に no-op になっていた問題を修正。upstream Misskey TS の \`HttpRequestService\` と同等の挙動を入れる。

## 変更内容

### safehttp transport

- \`safehttp.NewSSRFSafeTransport\` に functional option (\`safehttp.Option\`, \`WithProxy\`) を追加
- \`proxyURL\` 非空時に \`http.Transport.Proxy\` callback を組み立て、\`proxyBypassHosts\` に列挙された hostname (exact match, upstream の \`.includes(url.hostname)\` と一致) は direct dial、それ以外は \`proxyURL\` 経由
- proxy 自体のアドレス (CGNAT / private IP も想定) への接続では SSRF check をスキップ (オペレーターが明示設定したエンドポイントを信頼)。bypass 経由 / proxy 未指定の direct dial は従来通り SSRF を適用

### Wire-up

production の 5 callsite で \`WithProxy(cfg.Proxy, cfg.ProxyBypassHosts)\` を渡す:
- \`router.go\` apHTTPClient (AP outbound)
- \`router.go\` imageProbeClient (image dimensions probe)
- \`router.go\` webfingerClient (remote user resolve)
- \`router.go\` reversi federation checker
- \`mediaproxy.NewService\`

\`mediaproxy.NewService\` と \`core/mediaproxy/ssrf.go\` のラッパーも variadic \`safehttp.Option\` を受けられるよう signature を拡張 (既存 test の call site は破壊しない)。

### Testing

- \`internal/safehttp/ssrf_test.go\` に 4 ケース追加: proxy forwarding / bypass direct + SSRF / 不正 URL fallback / 空 URL no-op
- \`go test ./... -count=1\` 全パッケージ通過
- \`make fmt && make lint\` clean
- UDS 環境再ビルド後、docker container の \`/proc/net/tcp\` に \`100.80.213.18:3128\` (= 設定 proxy) への outbound TCP 接続が記録されることを確認

## SMTP scope

\`proxySmtp\` は SMTP クライアント側の wire が必要で本 PR では未対応。別 issue / PR で切り出す方針。

Closes #485

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/shiroha-a/mk/pull/486" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
