### PR TITLE
Fix pagination: cursor support for clips/list, drive/files/attached-notes, users/clips + drive/files/show moderator bypass (#487 #488)

### DIFF
--- a/internal/api/clips/handler.go
+++ b/internal/api/clips/handler.go
@@ -178,18 +178,23 @@ func (h *Handler) Delete(c echo.Context) error {
 
 // ListRequest is the request body for clips/list.
 type ListRequest struct {
-	Limit  int `json:"limit"`
-	Offset int `json:"offset"`
+	Limit   int    `json:"limit"`
+	Offset  int    `json:"offset"`
+	SinceID string `json:"sinceId"`
+	UntilID string `json:"untilId"`
 }
 
 // List handles POST /api/clips/list.
+//
+// frontend Paginator は cursor mode (untilId / sinceId) で叩いてくる。
+// upstream Misskey TS と同じく cursor 指定時は offset を無視する。
 func (h *Handler) List(c echo.Context) error {
 	user := middleware.GetUser(c)
 	var req ListRequest
 	if err := c.Bind(&req); err != nil {
 		return apierr.JSONInvalidParam(c)
 	}
-	rows, err := h.svc.ListByUser(user.ID, req.Limit, req.Offset)
+	rows, err := h.svc.ListByUser(user.ID, req.SinceID, req.UntilID, req.Limit, req.Offset)
 	if err != nil {
 		return apierr.JSONInternalError(c)
 	}

--- a/internal/api/clips/handler_test.go
+++ b/internal/api/clips/handler_test.go
@@ -277,12 +277,40 @@ func TestList_BadJSON(t *testing.T) {
 	assert.Equal(t, http.StatusBadRequest, rec.Code)
 }
 
+// frontend Paginator (cursor mode) が untilId / sinceId を渡した時に
+// 行が絞り込まれること (#487 回帰防止)。bind 漏れだと無限スクロールに
+// なるので、untilId 未満 / sinceId 超過の row だけ返ることを assert する。
+func TestList_CursorPagination(t *testing.T) {
+	h, repo, _, _ := newHandler(t)
+	repo.Clips["c1"] = &model.Clip{ID: "c1", UserID: "alice", Name: "alpha"}
+	repo.Clips["c2"] = &model.Clip{ID: "c2", UserID: "alice", Name: "bravo"}
+	repo.Clips["c3"] = &model.Clip{ID: "c3", UserID: "alice", Name: "charlie"}
+
+	// untilId=c3 → id < "c3" を DESC = [c2, c1]
+	c, rec := newReq(t, `{"untilId":"c3","limit":10}`)
+	setUser(c, "alice")
+	require.NoError(t, h.List(c))
+	assert.Equal(t, http.StatusOK, rec.Code)
+	assert.Contains(t, rec.Body.String(), `"c2"`)
+	assert.Contains(t, rec.Body.String(), `"c1"`)
+	assert.NotContains(t, rec.Body.String(), `"c3"`)
+
+	// sinceId=c1 → id > "c1" を ASC = [c2, c3]
+	c, rec = newReq(t, `{"sinceId":"c1","limit":10}`)
+	setUser(c, "alice")
+	require.NoError(t, h.List(c))
+	assert.Equal(t, http.StatusOK, rec.Code)
+	assert.Contains(t, rec.Body.String(), `"c2"`)
+	assert.Contains(t, rec.Body.String(), `"c3"`)
+	assert.NotContains(t, rec.Body.String(), `"c1"`)
+}
+
 // listFailRepo causes ListByUser to fail.
 type listFailRepo struct {
 	*testutil.MockClipRepository
 }
 
-func (r *listFailRepo) ListByUser(_ string, _, _ int) ([]*model.Clip, error) {
+func (r *listFailRepo) ListByUser(_, _, _ string, _, _ int) ([]*model.Clip, error) {
 	return nil, errors.New("boom")
 }
 

--- a/internal/api/drive/handler.go
+++ b/internal/api/drive/handler.go
@@ -452,9 +452,17 @@ func (h *Handler) FilesCheckExistence(c echo.Context) error {
 }
 
 // FilesAttachedNotes handles POST /api/drive/files/attached-notes.
+//
+// frontend Paginator (cursor mode) は { sinceId / untilId / limit } を投げて
+// くる。upstream Misskey TS と同じく cursor で keyset pagination する。
+// 過去はページング非対応で同じ note を返し続ける無限スクロール bug が
+// 出ていた (#488)。
 func (h *Handler) FilesAttachedNotes(c echo.Context) error {
 	var req struct {
-		FileID string `json:"fileId"`
+		FileID  string `json:"fileId"`
+		Limit   int    `json:"limit"`
+		SinceID string `json:"sinceId"`
+		UntilID string `json:"untilId"`
 	}
 	if err := c.Bind(&req); err != nil || req.FileID == "" {
 		return apierr.JSONInvalidParam(c)
@@ -463,7 +471,7 @@ func (h *Handler) FilesAttachedNotes(c echo.Context) error {
 	if h.noteRepo == nil {
 		return c.JSON(http.StatusOK, []any{})
 	}
-	notes, err := h.noteRepo.ListByFileID(req.FileID)
+	notes, err := h.noteRepo.ListByFileID(req.FileID, req.SinceID, req.UntilID, req.Limit)
 	if err != nil {
 		return c.JSON(http.StatusOK, []any{})
 	}

--- a/internal/api/drive/handler_test.go
+++ b/internal/api/drive/handler_test.go
@@ -679,6 +679,40 @@ func TestFilesAttachedNotes_NilRepo(t *testing.T) {
 	assert.Equal(t, http.StatusOK, rec.Code)
 }
 
+// frontend Paginator から渡される sinceId / untilId / limit が
+// noteRepo.ListByFileID に正しく forward されることを確認 (#488 回帰
+// 防止)。bind 漏れがあると同じ note が無限スクロールで何度も返る。
+type spyNoteRepo struct {
+	*testutil.MockNoteRepository
+	gotFileID  string
+	gotSinceID string
+	gotUntilID string
+	gotLimit   int
+}
+
+func (s *spyNoteRepo) ListByFileID(fileID, sinceID, untilID string, limit int) ([]*model.Note, error) {
+	s.gotFileID = fileID
+	s.gotSinceID = sinceID
+	s.gotUntilID = untilID
+	s.gotLimit = limit
+	return nil, nil
+}
+
+func TestFilesAttachedNotes_ForwardsCursorParams(t *testing.T) {
+	h, fileRepo, folderRepo := newHandler(t)
+	spy := &spyNoteRepo{MockNoteRepository: testutil.NewMockNoteRepository()}
+	h.SetRepos(fileRepo, folderRepo, spy)
+
+	c, rec := newJSONReq(t, `{"fileId":"f1","untilId":"u_xxx","limit":7}`)
+	setUser(c, "u1")
+	require.NoError(t, h.FilesAttachedNotes(c))
+	assert.Equal(t, http.StatusOK, rec.Code)
+	assert.Equal(t, "f1", spy.gotFileID)
+	assert.Equal(t, "u_xxx", spy.gotUntilID)
+	assert.Equal(t, "", spy.gotSinceID)
+	assert.Equal(t, 7, spy.gotLimit)
+}
+
 func TestFilesAttachedChatMessages(t *testing.T) {
 	h, _, _ := newHandler(t)
 	c, rec := newJSONReq(t, `{"fileId":"f1"}`)

--- a/internal/api/notes/handler_test.go
+++ b/internal/api/notes/handler_test.go
@@ -862,7 +862,9 @@ func (f *failingNoteRepo) ListMentions(_ string, _ int, _, _ string) ([]*model.N
 func (f *failingNoteRepo) SearchByTag(_ string, _ int, _, _ string) ([]*model.Note, error) {
 	return nil, nil
 }
-func (f *failingNoteRepo) ListByFileID(_ string) ([]*model.Note, error)  { return nil, nil }
+func (f *failingNoteRepo) ListByFileID(_, _, _ string, _ int) ([]*model.Note, error) {
+	return nil, nil
+}
 func (f *failingNoteRepo) IncrementUserNotesCount(_ string, _ int) error { return nil }
 func (f *failingNoteRepo) ListHomeTimeline(_ string, _ int, _, _ string, _ model.TimelineDBFilter) ([]*model.Note, error) {
 	return nil, nil

--- a/internal/api/users/handler_stubs.go
+++ b/internal/api/users/handler_stubs.go
@@ -58,11 +58,17 @@ func (h *Handler) Achievements(c echo.Context) error {
 // 非所有者視点では public のみ返す。LIMIT は絞り込み後に適用されるよう SQL
 // 側で WHERE isPublic = true を通す (ListPublicByUser) — 古い post-fetch
 // filter 方式だと private が多いユーザーで空の結果を返してしまう bug になる。
+//
+// frontend Paginator が cursor mode で投げてくる sinceId / untilId を
+// 拾って repo に渡し、Paginator が次ページ取得で同じ row 集合を返さない
+// ようにする (#487 兄弟ケース)。
 func (h *Handler) Clips(c echo.Context) error {
 	var req struct {
-		UserID string `json:"userId"`
-		Limit  int    `json:"limit"`
-		Offset int    `json:"offset"`
+		UserID  string `json:"userId"`
+		Limit   int    `json:"limit"`
+		Offset  int    `json:"offset"`
+		SinceID string `json:"sinceId"`
+		UntilID string `json:"untilId"`
 	}
 	if err := c.Bind(&req); err != nil || req.UserID == "" {
 		return apierr.JSONInvalidParam(c)
@@ -76,9 +82,9 @@ func (h *Handler) Clips(c echo.Context) error {
 	var rows []*model.Clip
 	var err error
 	if isSelf {
-		rows, err = h.clipRepo.ListByUser(req.UserID, req.Limit, req.Offset)
+		rows, err = h.clipRepo.ListByUser(req.UserID, req.SinceID, req.UntilID, req.Limit, req.Offset)
 	} else {
-		rows, err = h.clipRepo.ListPublicByUser(req.UserID, req.Limit, req.Offset)
+		rows, err = h.clipRepo.ListPublicByUser(req.UserID, req.SinceID, req.UntilID, req.Limit, req.Offset)
 	}
 	if err != nil {
 		return apierr.JSONInternalError(c)

--- a/internal/core/clip/clip_service.go
+++ b/internal/core/clip/clip_service.go
@@ -153,9 +153,10 @@ func (s *Service) Delete(ownerID, clipID string) error {
 	return s.repo.Delete(c)
 }
 
-// ListByUser returns the clips owned by userID.
-func (s *Service) ListByUser(userID string, limit, offset int) ([]*model.Clip, error) {
-	return s.repo.ListByUser(userID, limit, offset)
+// ListByUser returns the clips owned by userID with cursor (sinceID/untilID)
+// or offset pagination. cursor 指定時は offset 無視。
+func (s *Service) ListByUser(userID, sinceID, untilID string, limit, offset int) ([]*model.Clip, error) {
+	return s.repo.ListByUser(userID, sinceID, untilID, limit, offset)
 }
 
 // AddNote attaches a note to the clip. ownerID 以外は AccessDenied。

--- a/internal/core/clip/clip_service_test.go
+++ b/internal/core/clip/clip_service_test.go
@@ -158,7 +158,7 @@ func TestListByUser(t *testing.T) {
 	svc, repo, _, _ := newSvc(t)
 	repo.Clips["c1"] = &model.Clip{ID: "c1", UserID: "u1"}
 	repo.Clips["c2"] = &model.Clip{ID: "c2", UserID: "u1"}
-	rows, err := svc.ListByUser("u1", 10, 0)
+	rows, err := svc.ListByUser("u1", "", "", 10, 0)
 	require.NoError(t, err)
 	assert.Len(t, rows, 2)
 }

--- a/internal/core/drive/drive_service.go
+++ b/internal/core/drive/drive_service.go
@@ -55,6 +55,13 @@ type ChartHook interface {
 	OnFileDeleted(file *model.DriveFile)
 }
 
+// RoleChecker abstracts moderator-role lookup so Show can match upstream
+// Misskey's "moderators can view any file" semantics without taking a
+// hard dep on core/role (avoids circular imports).
+type RoleChecker interface {
+	IsModerator(userID string) bool
+}
+
 // Service manages drive files and folders.
 type Service struct {
 	fileRepo            repository.DriveFileRepository
@@ -69,7 +76,15 @@ type Service struct {
 	// Sensitive media detection
 	sensitiveDetector SensitiveDetector
 	sensitiveCfg      SensitiveConfig
+	// Optional moderator bypass for Show. Nil keeps the default "owner-only"
+	// guard.
+	roleChecker RoleChecker
 }
+
+// SetRoleChecker wires a moderator role lookup so Show allows moderators to
+// inspect any file (matching upstream Misskey's drive/files/show behaviour).
+// Nil keeps the existing owner-only check.
+func (s *Service) SetRoleChecker(rc RoleChecker) { s.roleChecker = rc }
 
 // SetSensitiveDetection attaches the sensitive media detector and config.
 func (s *Service) SetSensitiveDetection(detector SensitiveDetector, cfg SensitiveConfig) {
@@ -357,7 +372,10 @@ func (s *Service) processImage(body []byte, mimeType string) *generateAltsResult
 	return result
 }
 
-// Show returns the file with id, ensuring the requesting user owns it.
+// Show returns the file with id. Owners can read their own files; moderators
+// (when a roleChecker is wired) can read any file. Matches upstream Misskey
+// drive/files/show.ts semantics so admin moderation surfaces and remote-media
+// detail views work without 403.
 func (s *Service) Show(user *model.User, id string) (*model.DriveFile, error) {
 	if user == nil {
 		return nil, errors.New("user is required")
@@ -366,7 +384,9 @@ func (s *Service) Show(user *model.User, id string) (*model.DriveFile, error) {
 	if err != nil {
 		return nil, ErrFileNotFound
 	}
-	if f.UserID == nil || *f.UserID != user.ID {
+	owner := f.UserID != nil && *f.UserID == user.ID
+	moderator := s.roleChecker != nil && s.roleChecker.IsModerator(user.ID)
+	if !owner && !moderator {
 		return nil, ErrAccessDenied
 	}
 	return f, nil

--- a/internal/core/drive/drive_service_test.go
+++ b/internal/core/drive/drive_service_test.go
@@ -198,6 +198,34 @@ func TestShow_OtherUserDenied(t *testing.T) {
 	require.ErrorIs(t, err, drive.ErrAccessDenied)
 }
 
+// moderator なら所有者でなくても見られる (upstream Misskey と一致)。
+// リモート添付メディアの詳細表示は file.userId が remote user ID 固定
+// になるので、この経路がないと管理者でも 403 で見られない。
+type fakeMod struct{ moderators map[string]bool }
+
+func (f *fakeMod) IsModerator(userID string) bool { return f.moderators[userID] }
+
+func TestShow_ModeratorBypass(t *testing.T) {
+	svc, fileRepo, _ := newSvc(t)
+	other := "other"
+	fileRepo.Files["f1"] = &model.DriveFile{ID: "f1", UserID: &other}
+	svc.SetRoleChecker(&fakeMod{moderators: map[string]bool{"u1": true}})
+	got, err := svc.Show(&model.User{ID: "u1"}, "f1")
+	require.NoError(t, err)
+	assert.Equal(t, "f1", got.ID)
+}
+
+// moderator でない一般ユーザーは roleChecker が wire されていても
+// 引き続き 403。
+func TestShow_NonModeratorStillDenied(t *testing.T) {
+	svc, fileRepo, _ := newSvc(t)
+	other := "other"
+	fileRepo.Files["f1"] = &model.DriveFile{ID: "f1", UserID: &other}
+	svc.SetRoleChecker(&fakeMod{moderators: map[string]bool{}})
+	_, err := svc.Show(&model.User{ID: "u1"}, "f1")
+	require.ErrorIs(t, err, drive.ErrAccessDenied)
+}
+
 func TestFindByHash_NilUser(t *testing.T) {
 	svc, _, _ := newSvc(t)
 	_, err := svc.FindByHash(nil, "x")

--- a/internal/core/transfer/errors_test.go
+++ b/internal/core/transfer/errors_test.go
@@ -54,7 +54,7 @@ type failingClipRepo struct {
 	*testutil.MockClipRepository
 }
 
-func (f *failingClipRepo) ListByUser(_ string, _, _ int) ([]*model.Clip, error) {
+func (f *failingClipRepo) ListByUser(_, _, _ string, _, _ int) ([]*model.Clip, error) {
 	return nil, errors.New("db boom")
 }
 

--- a/internal/core/transfer/export_json.go
+++ b/internal/core/transfer/export_json.go
@@ -89,7 +89,7 @@ func (e *Exporter) exportAntennas(userID string) ([]byte, error) {
 // exportClips emits a JSON array of the user's clips, each with the packed
 // notes contained in the clip. 各 clip 内の note は単純な配列 (本家互換)。
 func (e *Exporter) exportClips(userID string) ([]byte, error) {
-	clips, err := e.deps.ClipRepo.ListByUser(userID, 1000, 0)
+	clips, err := e.deps.ClipRepo.ListByUser(userID, "", "", 1000, 0)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/repository/clip.go
+++ b/internal/repository/clip.go
@@ -11,11 +11,13 @@ type ClipRepository interface {
 	FindByID(id string) (*model.Clip, error)
 	UpdateFields(clipID string, fields map[string]any) error
 	Delete(c *model.Clip) error
-	ListByUser(userID string, limit, offset int) ([]*model.Clip, error)
+	// ListByUser returns clips owned by userID with cursor (sinceID/untilID)
+	// or offset pagination. Empty cursors fall back to offset.
+	ListByUser(userID string, sinceID, untilID string, limit, offset int) ([]*model.Clip, error)
 	// ListPublicByUser returns only public clips owned by userID. Used by
 	// users/clips when the viewer is not the owner so LIMIT applies to the
-	// already-filtered set.
-	ListPublicByUser(userID string, limit, offset int) ([]*model.Clip, error)
+	// already-filtered set. Same cursor semantics as ListByUser.
+	ListPublicByUser(userID string, sinceID, untilID string, limit, offset int) ([]*model.Clip, error)
 	IncrementCount(clipID, column string, delta int) error
 }
 
@@ -51,38 +53,53 @@ func (r *clipRepository) Delete(c *model.Clip) error {
 	return r.db.Delete(c).Error
 }
 
-// ListByUser returns clips owned by userID, ordered by id desc.
-func (r *clipRepository) ListByUser(userID string, limit, offset int) ([]*model.Clip, error) {
+// ListByUser returns clips owned by userID with cursor or offset pagination.
+func (r *clipRepository) ListByUser(userID, sinceID, untilID string, limit, offset int) ([]*model.Clip, error) {
 	if limit <= 0 {
 		limit = 30
 	}
 	if limit > 100 {
 		limit = 100
 	}
+	q := r.db.Where(`"userId" = ?`, userID)
+	if sinceID != "" {
+		q = q.Where("id > ?", sinceID)
+	}
+	if untilID != "" {
+		q = q.Where("id < ?", untilID)
+	}
+	q = q.Order(paginationOrder(sinceID, untilID, "id")).Limit(limit)
+	// cursor 指定時は offset 無視 (本家 makePaginationQuery と同じ)
+	if sinceID == "" && untilID == "" && offset > 0 {
+		q = q.Offset(offset)
+	}
 	var rows []*model.Clip
-	if err := r.db.Where("\"userId\" = ?", userID).
-		Order("id DESC").
-		Limit(limit).
-		Offset(offset).
-		Find(&rows).Error; err != nil {
+	if err := q.Find(&rows).Error; err != nil {
 		return nil, err
 	}
 	return rows, nil
 }
 
-func (r *clipRepository) ListPublicByUser(userID string, limit, offset int) ([]*model.Clip, error) {
+func (r *clipRepository) ListPublicByUser(userID, sinceID, untilID string, limit, offset int) ([]*model.Clip, error) {
 	if limit <= 0 {
 		limit = 30
 	}
 	if limit > 100 {
 		limit = 100
 	}
+	q := r.db.Where(`"userId" = ? AND "isPublic" = true`, userID)
+	if sinceID != "" {
+		q = q.Where("id > ?", sinceID)
+	}
+	if untilID != "" {
+		q = q.Where("id < ?", untilID)
+	}
+	q = q.Order(paginationOrder(sinceID, untilID, "id")).Limit(limit)
+	if sinceID == "" && untilID == "" && offset > 0 {
+		q = q.Offset(offset)
+	}
 	var rows []*model.Clip
-	if err := r.db.Where("\"userId\" = ? AND \"isPublic\" = true", userID).
-		Order("id DESC").
-		Limit(limit).
-		Offset(offset).
-		Find(&rows).Error; err != nil {
+	if err := q.Find(&rows).Error; err != nil {
 		return nil, err
 	}
 	return rows, nil

--- a/internal/repository/clip_test.go
+++ b/internal/repository/clip_test.go
@@ -107,17 +107,17 @@ func TestClipRepository_ListByUser(t *testing.T) {
 		defer cleanupClip(t, c.ID)
 	}
 
-	rows, err := repo.ListByUser(user.ID, 10, 0)
+	rows, err := repo.ListByUser(user.ID, "", "", 10, 0)
 	require.NoError(t, err)
 	assert.Len(t, rows, 3)
 }
 
 func TestClipRepository_ListByUser_LimitClamp(t *testing.T) {
 	repo := NewClipRepository(testDB)
-	rows, err := repo.ListByUser("nobody", 9999, 0)
+	rows, err := repo.ListByUser("nobody", "", "", 9999, 0)
 	require.NoError(t, err)
 	assert.Empty(t, rows)
-	rows, err = repo.ListByUser("nobody", -1, 0)
+	rows, err = repo.ListByUser("nobody", "", "", -1, 0)
 	require.NoError(t, err)
 	assert.Empty(t, rows)
 }
@@ -127,6 +127,35 @@ func TestClipRepository_ListByUser_QueryError(t *testing.T) {
 	cancel()
 	db := testDB.WithContext(ctx)
 	repo := NewClipRepository(db)
-	_, err := repo.ListByUser("nobody", 10, 0)
+	_, err := repo.ListByUser("nobody", "", "", 10, 0)
 	assert.Error(t, err)
+}
+
+// frontend Paginator (cursor mode) との互換性確認: untilID < clip ID 群
+// のうち、id < untilID で DESC で limit 件返ること、sinceID 単独だと ASC
+// (paginationOrder の挙動)。#487 回帰防止。
+func TestClipRepository_ListByUser_CursorPagination(t *testing.T) {
+	repo := NewClipRepository(testDB)
+	user := insertTestUser(t, "u_clr_pag", "clippag")
+	defer cleanupUser(t, user.ID)
+
+	for _, id := range []string{"clp_pg_a", "clp_pg_b", "clp_pg_c", "clp_pg_d"} {
+		c := newTestClip(id, user.ID, id)
+		require.NoError(t, repo.Create(c))
+		defer cleanupClip(t, c.ID)
+	}
+
+	// untilID="clp_pg_c" → id < "clp_pg_c" を DESC 2 件 = [b, a]
+	rows, err := repo.ListByUser(user.ID, "", "clp_pg_c", 2, 0)
+	require.NoError(t, err)
+	require.Len(t, rows, 2)
+	assert.Equal(t, "clp_pg_b", rows[0].ID)
+	assert.Equal(t, "clp_pg_a", rows[1].ID)
+
+	// sinceID="clp_pg_b" → id > "clp_pg_b" を ASC 2 件 = [c, d]
+	rows, err = repo.ListByUser(user.ID, "clp_pg_b", "", 2, 0)
+	require.NoError(t, err)
+	require.Len(t, rows, 2)
+	assert.Equal(t, "clp_pg_c", rows[0].ID)
+	assert.Equal(t, "clp_pg_d", rows[1].ID)
 }

--- a/internal/repository/coverage_batch_test.go
+++ b/internal/repository/coverage_batch_test.go
@@ -114,15 +114,15 @@ func TestClipRepository_ListPublicByUser(t *testing.T) {
 	).Error)
 	defer testDB.Exec(`DELETE FROM "clip" WHERE id IN (?, ?)`, "cl_pub_1", "cl_priv_1")
 
-	rows, err := repo.ListPublicByUser(u.ID, 10, 0)
+	rows, err := repo.ListPublicByUser(u.ID, "", "", 10, 0)
 	require.NoError(t, err)
 	assert.Len(t, rows, 1)
 	assert.Equal(t, "cl_pub_1", rows[0].ID)
 
 	// limit=0 → default, limit>100 → cap
-	_, err = repo.ListPublicByUser(u.ID, 0, 0)
+	_, err = repo.ListPublicByUser(u.ID, "", "", 0, 0)
 	require.NoError(t, err)
-	_, err = repo.ListPublicByUser(u.ID, 999, 0)
+	_, err = repo.ListPublicByUser(u.ID, "", "", 999, 0)
 	require.NoError(t, err)
 }
 

--- a/internal/repository/coverage_complete_test.go
+++ b/internal/repository/coverage_complete_test.go
@@ -172,7 +172,7 @@ func TestErrorPaths_CancelledContext(t *testing.T) {
 	assert.Error(t, err)
 
 	// clip / flash / page (ListPublicByUser)
-	_, err = NewClipRepository(db).ListPublicByUser("x", 10, 0)
+	_, err = NewClipRepository(db).ListPublicByUser("x", "", "", 10, 0)
 	assert.Error(t, err)
 	_, err = NewFlashRepository(db).ListPublicByUser("x", 10, 0)
 	assert.Error(t, err)
@@ -218,7 +218,7 @@ func TestErrorPaths_CancelledContext(t *testing.T) {
 
 	// note
 	nr := NewNoteRepository(db)
-	_, err = nr.ListByFileID("x")
+	_, err = nr.ListByFileID("x", "", "", 10)
 	assert.Error(t, err)
 	_, err = nr.ListHomeTimeline("x", 10, "", "", model.TimelineDBFilter{})
 	assert.Error(t, err)

--- a/internal/repository/note.go
+++ b/internal/repository/note.go
@@ -65,7 +65,10 @@ type NoteRepository interface {
 	FindRenoteByUser(userID, renoteID string) (*model.Note, error)
 	ListMentions(userID string, limit int, sinceID, untilID string) ([]*model.Note, error)
 	SearchByTag(tag string, limit int, sinceID, untilID string) ([]*model.Note, error)
-	ListByFileID(fileID string) ([]*model.Note, error)
+	// ListByFileID returns notes whose fileIds array contains fileID, with
+	// cursor (sinceID/untilID) pagination matching upstream Misskey's
+	// makePaginationQuery. limit <= 0 defaults to 10.
+	ListByFileID(fileID, sinceID, untilID string, limit int) ([]*model.Note, error)
 	IncrementUserNotesCount(userID string, delta int) error
 	ListHomeTimeline(userID string, limit int, sinceID, untilID string, filter model.TimelineDBFilter) ([]*model.Note, error)
 	ListLocalTimeline(limit int, sinceID, untilID string, filter model.TimelineDBFilter) ([]*model.Note, error)
@@ -443,9 +446,22 @@ func (r *noteRepository) SearchByTag(tag string, limit int, sinceID, untilID str
 	return notes, nil
 }
 
-func (r *noteRepository) ListByFileID(fileID string) ([]*model.Note, error) {
+func (r *noteRepository) ListByFileID(fileID, sinceID, untilID string, limit int) ([]*model.Note, error) {
+	if limit <= 0 {
+		limit = 10
+	}
+	if limit > 100 {
+		limit = 100
+	}
+	q := preloadNoteRelations(r.db).Where(`"fileIds" @> ARRAY[?]::varchar[]`, fileID)
+	if sinceID != "" {
+		q = q.Where(`"id" > ?`, sinceID)
+	}
+	if untilID != "" {
+		q = q.Where(`"id" < ?`, untilID)
+	}
 	var notes []*model.Note
-	if err := preloadNoteRelations(r.db).Where(`"fileIds" @> ARRAY[?]::varchar[]`, fileID).Order(`"id" DESC`).Limit(20).Find(&notes).Error; err != nil {
+	if err := q.Order(paginationOrder(sinceID, untilID, `"id"`)).Limit(limit).Find(&notes).Error; err != nil {
 		return nil, err
 	}
 	return notes, nil

--- a/internal/repository/note_test.go
+++ b/internal/repository/note_test.go
@@ -966,13 +966,49 @@ func TestNoteRepository_ListByFileID(t *testing.T) {
 	require.NoError(t, repo.Create(n))
 	defer cleanupNote(t, n.ID)
 
-	got, err := repo.ListByFileID("file_abc")
+	got, err := repo.ListByFileID("file_abc", "", "", 10)
 	require.NoError(t, err)
 	assert.NotEmpty(t, got)
 
-	empty, err := repo.ListByFileID("file_nonexistent")
+	empty, err := repo.ListByFileID("file_nonexistent", "", "", 10)
 	require.NoError(t, err)
 	assert.Empty(t, empty)
+}
+
+// frontend Paginator (cursor mode) との互換性確認: untilID 指定で
+// id < untilID DESC, sinceID 指定で id > sinceID ASC を返すこと (#488)。
+func TestNoteRepository_ListByFileID_Cursor(t *testing.T) {
+	repo := NewNoteRepository(testDB)
+	user := insertTestUser(t, "u_lbfi_2", "lbfiuser2")
+	defer cleanupUser(t, user.ID)
+
+	text := "with file cursor"
+	for _, id := range []string{"n_lbfi_a", "n_lbfi_b", "n_lbfi_c", "n_lbfi_d"} {
+		n := &model.Note{
+			ID:         id,
+			UserID:     user.ID,
+			Text:       &text,
+			Visibility: model.NoteVisibilityPublic,
+			Reactions:  datatypes.JSON([]byte("{}")),
+			FileIDs:    pq.StringArray{"file_pg"},
+		}
+		require.NoError(t, repo.Create(n))
+		defer cleanupNote(t, n.ID)
+	}
+
+	// untilID="n_lbfi_c" → id < "n_lbfi_c" を DESC 2 件 = [b, a]
+	rows, err := repo.ListByFileID("file_pg", "", "n_lbfi_c", 2)
+	require.NoError(t, err)
+	require.Len(t, rows, 2)
+	assert.Equal(t, "n_lbfi_b", rows[0].ID)
+	assert.Equal(t, "n_lbfi_a", rows[1].ID)
+
+	// sinceID="n_lbfi_b" → id > "n_lbfi_b" を ASC 2 件 = [c, d]
+	rows, err = repo.ListByFileID("file_pg", "n_lbfi_b", "", 2)
+	require.NoError(t, err)
+	require.Len(t, rows, 2)
+	assert.Equal(t, "n_lbfi_c", rows[0].ID)
+	assert.Equal(t, "n_lbfi_d", rows[1].ID)
 }
 
 func TestNoteRepository_IncrementUserNotesCount(t *testing.T) {

--- a/internal/server/router.go
+++ b/internal/server/router.go
@@ -308,6 +308,10 @@ func (s *Server) setupRoutes() {
 		driveStorage = coredrive.NewLocalStorage("./drive-files", s.config.DriveURL)
 	}
 	driveService := coredrive.NewService(driveFileRepo, driveFolderRepo, driveStorage, idGen)
+	// drive/files/show は moderator なら他人 / リモートユーザー所有の file
+	// も返せるようにする (upstream Misskey の roleService.isModerator 経路
+	// と一致)。リモート添付メディアの詳細閲覧に必要。
+	driveService.SetRoleChecker(roleService)
 
 	// Image processing (Phase 4.8)
 	imgProcessor := coredrive.NewDefaultImageProcessor()

--- a/internal/testutil/mock_repository.go
+++ b/internal/testutil/mock_repository.go
@@ -892,7 +892,9 @@ func (m *MockNoteRepository) SearchByTag(tag string, limit int, sinceID, untilID
 	}, untilID, sinceID, limit), nil
 }
 
-func (m *MockNoteRepository) ListByFileID(_ string) ([]*model.Note, error)  { return nil, nil }
+func (m *MockNoteRepository) ListByFileID(_, _, _ string, _ int) ([]*model.Note, error) {
+	return nil, nil
+}
 func (m *MockNoteRepository) IncrementUserNotesCount(_ string, _ int) error { return nil }
 
 // ListHomeTimeline / ListLocalTimeline / ListGlobalTimeline return public or
@@ -2155,43 +2157,50 @@ func (m *MockClipRepository) Delete(c *model.Clip) error {
 	return nil
 }
 
-func (m *MockClipRepository) ListByUser(userID string, limit, offset int) ([]*model.Clip, error) {
+func (m *MockClipRepository) ListByUser(userID, sinceID, untilID string, limit, offset int) ([]*model.Clip, error) {
 	var rows []*model.Clip
 	for _, c := range m.Clips {
-		if c.UserID == userID {
-			rows = append(rows, c)
+		if c.UserID != userID {
+			continue
 		}
-	}
-	for i := 0; i < len(rows); i++ {
-		for j := i + 1; j < len(rows); j++ {
-			if rows[i].ID < rows[j].ID {
-				rows[i], rows[j] = rows[j], rows[i]
-			}
+		if sinceID != "" && c.ID <= sinceID {
+			continue
 		}
+		if untilID != "" && c.ID >= untilID {
+			continue
+		}
+		rows = append(rows, c)
 	}
-	if limit <= 0 || limit > 100 {
-		limit = 30
-	}
-	if offset >= len(rows) {
-		return nil, nil
-	}
-	end := offset + limit
-	if end > len(rows) {
-		end = len(rows)
-	}
-	return rows[offset:end], nil
+	return paginateClips(rows, sinceID, untilID, limit, offset), nil
 }
 
-func (m *MockClipRepository) ListPublicByUser(userID string, limit, offset int) ([]*model.Clip, error) {
+func (m *MockClipRepository) ListPublicByUser(userID, sinceID, untilID string, limit, offset int) ([]*model.Clip, error) {
 	var rows []*model.Clip
 	for _, c := range m.Clips {
-		if c.UserID == userID && c.IsPublic {
-			rows = append(rows, c)
+		if c.UserID != userID || !c.IsPublic {
+			continue
 		}
+		if sinceID != "" && c.ID <= sinceID {
+			continue
+		}
+		if untilID != "" && c.ID >= untilID {
+			continue
+		}
+		rows = append(rows, c)
 	}
+	return paginateClips(rows, sinceID, untilID, limit, offset), nil
+}
+
+// paginateClips applies the same ordering / limit / cursor-vs-offset rules as
+// the real clipRepository so mock-based tests exercise the upstream
+// makePaginationQuery semantics. ASC ordering kicks in when sinceID is set
+// without untilID (matches paginationOrder helper in repository package).
+func paginateClips(rows []*model.Clip, sinceID, untilID string, limit, offset int) []*model.Clip {
+	asc := sinceID != "" && untilID == ""
 	for i := 0; i < len(rows); i++ {
 		for j := i + 1; j < len(rows); j++ {
-			if rows[i].ID < rows[j].ID {
+			less := rows[i].ID < rows[j].ID
+			if (asc && !less) || (!asc && less) {
 				rows[i], rows[j] = rows[j], rows[i]
 			}
 		}
@@ -2199,14 +2208,17 @@ func (m *MockClipRepository) ListPublicByUser(userID string, limit, offset int) 
 	if limit <= 0 || limit > 100 {
 		limit = 30
 	}
-	if offset >= len(rows) {
-		return nil, nil
+	if sinceID == "" && untilID == "" {
+		if offset >= len(rows) {
+			return nil
+		}
+		end := min(offset+limit, len(rows))
+		return rows[offset:end]
 	}
-	end := offset + limit
-	if end > len(rows) {
-		end = len(rows)
+	if limit > len(rows) {
+		limit = len(rows)
 	}
-	return rows[offset:end], nil
+	return rows[:limit]
 }
 
 func (m *MockClipRepository) IncrementCount(clipID, column string, delta int) error {


### PR DESCRIPTION
## Summary

#487 (クリップ一覧の無限ロード) / #488 (ドライブのファイル詳細・添付ノートの無限ロード) を中心に、frontend Paginator (cursor mode) と mk-go handler の binding ミスマッチで起きていた pagination 無限ループを修正。あわせて作業中に発覚した \`drive/files/show\` の moderator bypass 漏れ (リモートメディア詳細を見ようとすると 403) も同時修正。

## Root cause

frontend Paginator は cursor mode (デフォルト) で \`{ untilId / sinceId / limit }\` を投げてくるが、対象 handler が:

- \`clips/list\` (#487): handler の req struct に \`sinceId\` / \`untilId\` 不在、repo / service も offset のみ
- \`drive/files/attached-notes\` (#488): handler は \`fileId\` のみ binding、repo \`ListByFileID\` も pagination 非対応 (固定 \`LIMIT 20\`)
- \`users/clips\` (#487 兄弟): handler の req struct に cursor 不在 (clip repo 経由なので #487 と一緒に修正)

このため次ページ取得で同じ row 集合を返し続け、Paginator が永遠に末尾に到達せず無限スクロールになっていた。同種 bug は #384 / #424 でも踏んでおり、今回も同じ \`paginationOrder\` 経路で揃える。

\`drive/files/show\` の方は別件。upstream Misskey TS は \`if (!isModerator(me) && file.userId !== me.id)\` で 403 を返すが、mk-go では owner チェックのみで moderator bypass が抜けていた。リモートユーザー所有の添付メディア詳細を管理者でも 403 で見られない pre-existing bug。

## 主な変更点

### Pagination

- \`internal/repository/clip.go\` \`ListByUser\` / \`ListPublicByUser\` に \`sinceID\` / \`untilID\` を追加し \`paginationOrder\` + \`WHERE id < / id >\` を適用。cursor 指定時は offset 無視 (upstream \`makePaginationQuery\` と一致)
- \`internal/repository/note.go\` \`ListByFileID\` を \`(fileID, sinceID, untilID string, limit int)\` に拡張し同様に cursor pagination
- \`internal/core/clip/clip_service.go\` \`ListByUser\` を新 signature に
- \`internal/api/clips/handler.go\` \`ListRequest\` に \`SinceID\` / \`UntilID\` を追加
- \`internal/api/drive/handler.go\` \`FilesAttachedNotes\` の req struct に \`Limit\` / \`SinceID\` / \`UntilID\` を追加
- \`internal/api/users/handler_stubs.go\` \`Clips\` handler に同様の cursor 対応
- mock の \`ListByUser\` / \`ListPublicByUser\` / \`ListByFileID\` を新 signature + cursor 挙動 (paginateClips helper) に
- 回帰防止: \`TestClipRepository_ListByUser_CursorPagination\`, \`TestNoteRepository_ListByFileID_Cursor\`, \`TestList_CursorPagination\` (clips), \`TestFilesAttachedNotes_ForwardsCursorParams\` (drive)

### Drive show moderator bypass

- \`internal/core/drive/drive_service.go\` に \`RoleChecker\` interface と \`SetRoleChecker\` setter を追加し、\`Show\` で moderator なら他人の file も返す (upstream の \`drive/files/show.ts\` と一致)
- \`internal/server/router.go\` で \`driveService.SetRoleChecker(roleService)\` を wire
- 回帰防止: \`TestShow_ModeratorBypass\`, \`TestShow_NonModeratorStillDenied\`

## Out of scope (follow-up)

同パターン (frontend cursor Paginator vs offset-only handler) は他にも残っている可能性があり、本 PR では explicit な #487 / #488 + 兄弟 endpoint (\`users/clips\`) に絞った。残り対象として確認済の endpoint:
- \`users/flashs\`, \`users/pages\`, \`users/gallery/posts\`
- \`mute/list\`, \`blocking/list\`, \`renote-mute/list\`
- \`channels/featured\`, \`channels/owned\`, \`channels/followed\`, \`channels/my-favorites\`
- \`flash/my\`, \`flash/my-likes\`, \`flash/featured\`, \`flash/search\`
- \`pages/featured\`
- \`gallery/featured\`
- \`hashtags/users\`
- \`federation/instances\`

これらは別 issue で順次 sweep する。

## Testing

- \`go test ./... -count=1\` 全パッケージ通過
- \`make fmt && make lint\` clean
- UDS 環境再ビルド後:
  - クリップ一覧 / ユーザープロフィールのクリップタブで無限スクロール解消
  - ドライブのファイル詳細「添付されているノート」が重複なくページングされる
  - リモートメディアの詳細閲覧 (drive/files/show) が moderator で 200 を返す

Closes #487
Closes #488

🤖 Generated with [Claude Code](https://claude.com/claude-code)