### PR TITLE
Fix channel highlight: notes/featured filters by channelId (#489)

### DIFF
--- a/internal/api/notes/handler_extra.go
+++ b/internal/api/notes/handler_extra.go
@@ -68,11 +68,17 @@ func (h *Handler) FavoritesDelete(c echo.Context) error {
 }
 
 // Featured handles POST /api/notes/featured.
+//
+// 注目ノート — renoteCount + repliesCount が高いノートを返す簡易版。
+// channelId 指定時は該当チャンネル内のノートだけを返す (channel.vue の
+// ハイライトタブから叩かれる経路)。過去はこの絞り込みが無く、無関係な
+// グローバルノートが混ざっていた (#489)。untilId は cursor pagination 用。
 func (h *Handler) Featured(c echo.Context) error {
-	// 注目ノート — renoteCount + repliesCount が高いノートを返す簡易版
 	var req struct {
-		Limit  int `json:"limit"`
-		Offset int `json:"offset"`
+		Limit     int    `json:"limit"`
+		Offset    int    `json:"offset"`
+		ChannelID string `json:"channelId"`
+		UntilID   string `json:"untilId"`
 	}
 	if err := c.Bind(&req); err != nil {
 		return c.JSON(http.StatusBadRequest, apierr.Error("INVALID_PARAM", "Invalid parameters.", "3d81ceae-475f-4600-b2a8-2bc116157532"))
@@ -80,7 +86,7 @@ func (h *Handler) Featured(c echo.Context) error {
 	if req.Limit <= 0 {
 		req.Limit = 10
 	}
-	notes, err := h.noteRepo.ListFeatured(req.Limit, req.Offset)
+	notes, err := h.noteRepo.ListFeatured(req.ChannelID, req.UntilID, req.Limit, req.Offset)
 	if err != nil {
 		return c.JSON(http.StatusInternalServerError, apierr.Error("INTERNAL_ERROR", "Internal error.", "5d37dbcb-891e-41ca-a3d6-e690c97775ac"))
 	}

--- a/internal/api/notes/handler_extra_test.go
+++ b/internal/api/notes/handler_extra_test.go
@@ -121,6 +121,23 @@ func TestFeatured_InvalidJSON(t *testing.T) {
 	assert.Equal(t, http.StatusBadRequest, rec.Code)
 }
 
+// channelId 指定時は当該チャンネルに属するノートだけが返ること (#489)。
+// handler が channelId を bind せずに repo に渡し忘れると、ハイライト
+// タブで他チャンネル / グローバルのノートが混入する。
+func TestFeatured_ChannelFilter(t *testing.T) {
+	h, noteRepo, _ := newExtraHandler(t)
+	chID := "ch1"
+	noteRepo.Notes["n_ch"] = &model.Note{ID: "n_ch", UserID: "u1", Visibility: "public", ChannelID: &chID, User: &model.User{ID: "u1"}}
+	noteRepo.Notes["n_glb"] = &model.Note{ID: "n_glb", UserID: "u1", Visibility: "public", User: &model.User{ID: "u1"}}
+
+	rec := postExtra(h.Featured, `{"channelId":"ch1"}`, nil)
+	assert.Equal(t, http.StatusOK, rec.Code)
+	var resp []map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+	require.Len(t, resp, 1)
+	assert.Equal(t, "n_ch", resp[0]["id"])
+}
+
 // --- Unrenote ---
 
 func TestUnrenote_Success(t *testing.T) {
@@ -360,7 +377,7 @@ func TestFavoritesDelete_Error(t *testing.T) {
 
 type failingFeaturedRepo struct{ *testutil.MockNoteRepository }
 
-func (f *failingFeaturedRepo) ListFeatured(_, _ int) ([]*model.Note, error) {
+func (f *failingFeaturedRepo) ListFeatured(_, _ string, _, _ int) ([]*model.Note, error) {
 	return nil, testutil.ErrNotFound
 }
 

--- a/internal/api/notes/handler_test.go
+++ b/internal/api/notes/handler_test.go
@@ -850,7 +850,7 @@ func (f *failingNoteRepo) ListChildrenOf(_ string, _, _ string, _ int) ([]*model
 func (f *failingNoteRepo) SearchByFilter(_ model.NoteSearchFilter) ([]*model.Note, error) {
 	return nil, nil
 }
-func (f *failingNoteRepo) ListFeatured(_, _ int) ([]*model.Note, error) {
+func (f *failingNoteRepo) ListFeatured(_, _ string, _, _ int) ([]*model.Note, error) {
 	return nil, nil
 }
 func (f *failingNoteRepo) FindRenoteByUser(_, _ string) (*model.Note, error) {

--- a/internal/repository/note.go
+++ b/internal/repository/note.go
@@ -61,7 +61,12 @@ type NoteRepository interface {
 	ListRepliesOf(noteID string, untilID, sinceID string, limit int) ([]*model.Note, error)
 	ListChildrenOf(noteID string, untilID, sinceID string, limit int) ([]*model.Note, error)
 	SearchByFilter(filter model.NoteSearchFilter) ([]*model.Note, error)
-	ListFeatured(limit, offset int) ([]*model.Note, error)
+	// ListFeatured returns ranked public notes (renote+reply count). When
+	// channelID is non-empty restricts to that channel, mirroring upstream
+	// FeaturedService.getInChannelNotesRanking. untilID enables cursor
+	// pagination (id < untilID). offset is honoured only when no cursor
+	// is given.
+	ListFeatured(channelID, untilID string, limit, offset int) ([]*model.Note, error)
 	FindRenoteByUser(userID, renoteID string) (*model.Note, error)
 	ListMentions(userID string, limit int, sinceID, untilID string) ([]*model.Note, error)
 	SearchByTag(tag string, limit int, sinceID, untilID string) ([]*model.Note, error)
@@ -379,15 +384,24 @@ func (r *noteRepository) FindManyByIDsWithUser(ids []string) ([]*model.Note, err
 	return ordered, nil
 }
 
-func (r *noteRepository) ListFeatured(limit, offset int) ([]*model.Note, error) {
+func (r *noteRepository) ListFeatured(channelID, untilID string, limit, offset int) ([]*model.Note, error) {
 	if limit <= 0 {
 		limit = 10
 	}
-	q := preloadNoteRelations(r.db).
-		Where("visibility = 'public'").
-		Order("(\"renoteCount\" + \"repliesCount\") DESC, id DESC").
-		Limit(limit)
-	if offset > 0 {
+	q := preloadNoteRelations(r.db).Where("visibility = 'public'")
+	if channelID != "" {
+		// チャンネル指定時は当該チャンネル内のノートだけを返す
+		// (upstream FeaturedService.getInChannelNotesRanking と一致)。
+		// 過去はこの WHERE 節が無く、グローバル featured が混ざってチャンネル
+		// ハイライトに無関係ノートが出ていた (#489)。
+		q = q.Where(`"channelId" = ?`, channelID)
+	}
+	if untilID != "" {
+		q = q.Where(`id < ?`, untilID)
+	}
+	q = q.Order(`("renoteCount" + "repliesCount") DESC, id DESC`).Limit(limit)
+	// cursor 指定時は offset を無視 (upstream makePaginationQuery と一致)
+	if untilID == "" && offset > 0 {
 		q = q.Offset(offset)
 	}
 	var notes []*model.Note

--- a/internal/repository/note_test.go
+++ b/internal/repository/note_test.go
@@ -691,26 +691,52 @@ func TestNoteRepository_ListFeatured(t *testing.T) {
 	require.NoError(t, testDB.Create(n).Error)
 	defer testDB.Exec(`DELETE FROM "note" WHERE id = ?`, n.ID)
 
-	notes, err := repo.ListFeatured(10, 0)
+	notes, err := repo.ListFeatured("", "", 10, 0)
 	require.NoError(t, err)
 	assert.NotEmpty(t, notes)
 
 	// default limit
-	notes, err = repo.ListFeatured(0, 0)
+	notes, err = repo.ListFeatured("", "", 0, 0)
 	require.NoError(t, err)
 	assert.NotEmpty(t, notes)
 
 	// offset
-	notes, err = repo.ListFeatured(10, 1)
+	notes, err = repo.ListFeatured("", "", 10, 1)
 	require.NoError(t, err)
 	_ = notes
+}
+
+// channelId 指定時は当該チャンネルに属するノートだけが返ること (#489)。
+// 過去はこの絞り込みが無く、ハイライトに無関係ノートが混入していた。
+func TestNoteRepository_ListFeatured_ChannelFilter(t *testing.T) {
+	repo := NewNoteRepository(testDB)
+	user := insertTestUser(t, "feat_chu", "featchu")
+	defer cleanupUser(t, user.ID)
+
+	chID := "feat_ch1"
+	require.NoError(t, testDB.Exec(`INSERT INTO channel (id, name, "userId") VALUES (?, ?, ?)`, chID, "feat-ch", user.ID).Error)
+	defer testDB.Exec(`DELETE FROM channel WHERE id = ?`, chID)
+
+	chPtr := chID
+	chNote := &model.Note{ID: "feat_chn1", UserID: user.ID, Visibility: "public", RenoteCount: 5, ChannelID: &chPtr}
+	require.NoError(t, testDB.Create(chNote).Error)
+	defer testDB.Exec(`DELETE FROM "note" WHERE id = ?`, chNote.ID)
+
+	otherNote := &model.Note{ID: "feat_othn", UserID: user.ID, Visibility: "public", RenoteCount: 10}
+	require.NoError(t, testDB.Create(otherNote).Error)
+	defer testDB.Exec(`DELETE FROM "note" WHERE id = ?`, otherNote.ID)
+
+	rows, err := repo.ListFeatured(chID, "", 10, 0)
+	require.NoError(t, err)
+	require.Len(t, rows, 1)
+	assert.Equal(t, chNote.ID, rows[0].ID)
 }
 
 func TestNoteRepository_ListFeatured_Error(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel()
 	repo := NewNoteRepository(testDB.WithContext(ctx))
-	_, err := repo.ListFeatured(10, 0)
+	_, err := repo.ListFeatured("", "", 10, 0)
 	assert.Error(t, err)
 }
 

--- a/internal/testutil/mock_repository.go
+++ b/internal/testutil/mock_repository.go
@@ -838,21 +838,36 @@ func (m *MockNoteRepository) FindManyByIDsWithUser(ids []string) ([]*model.Note,
 	return out, nil
 }
 
-func (m *MockNoteRepository) ListFeatured(limit, offset int) ([]*model.Note, error) {
+func (m *MockNoteRepository) ListFeatured(channelID, untilID string, limit, offset int) ([]*model.Note, error) {
 	var result []*model.Note
 	for _, n := range m.Notes {
-		if string(n.Visibility) == "public" {
-			result = append(result, n)
+		if string(n.Visibility) != "public" {
+			continue
 		}
+		if channelID != "" {
+			if n.ChannelID == nil || *n.ChannelID != channelID {
+				continue
+			}
+		}
+		if untilID != "" && n.ID >= untilID {
+			continue
+		}
+		result = append(result, n)
 	}
 	if limit <= 0 {
 		limit = 10
 	}
-	if offset >= len(result) {
-		return nil, nil
+	if untilID == "" && offset > 0 {
+		if offset >= len(result) {
+			return nil, nil
+		}
+		end := min(offset+limit, len(result))
+		return result[offset:end], nil
 	}
-	end := min(offset+limit, len(result))
-	return result[offset:end], nil
+	if limit > len(result) {
+		limit = len(result)
+	}
+	return result[:limit], nil
 }
 
 func (m *MockNoteRepository) FindRenoteByUser(userID, renoteID string) (*model.Note, error) {


### PR DESCRIPTION
## Summary

チャンネル詳細ページの「ハイライト」タブに、当該チャンネルに属さないグローバルなノートが混入していた問題を修正。

## Root cause

frontend (\`channel.vue:116\`) は \`notes/featured\` を \`{ channelId: props.channelId }\` 付きで叩くが、mk-go の handler (\`internal/api/notes/handler_extra.go:71\` \`Featured\`) は \`channelId\` を bind しておらず、\`repo.ListFeatured\` も \`channelId\` 引数を受けない (visibility=public な全 note を renote+reply 数で並べる) ため、frontend が指定したチャンネルに無関係なノートが返っていた。

upstream Misskey TS (\`notes/featured.ts:60-71\`) は \`ps.channelId\` 指定時に \`FeaturedService.getInChannelNotesRanking\` で当該チャンネル内ノートだけ ranking する。これに合わせて \`WHERE \"channelId\" = ?\` を入れる。

## 主な変更点

- \`internal/repository/note.go\` \`ListFeatured\` を \`(channelID, untilID string, limit, offset int)\` に拡張し、channelID 非空時に \`WHERE \"channelId\" = ?\` を適用。untilID で cursor pagination (\`id < untilID\` DESC)、cursor 指定時は offset 無視 (upstream \`makePaginationQuery\` と一致)
- \`internal/api/notes/handler_extra.go\` \`Featured\` の req struct に \`ChannelID\` / \`UntilID\` を追加し、repo に forward
- \`internal/testutil/mock_repository.go\` mock の \`ListFeatured\` も同条件分岐を実装
- 回帰テスト: \`TestNoteRepository_ListFeatured_ChannelFilter\` (repo), \`TestFeatured_ChannelFilter\` (handler)

\`explore.featured.vue\` (グローバル「みつける」→「注目」) は \`channelId\` 無しで叩くので従来通り全 public note を返す。

## Testing

- \`go test ./... -count=1\` 全パッケージ通過
- \`make fmt && make lint\` clean
- UDS 環境再ビルド後、チャンネル詳細「ハイライト」タブで該当チャンネルのノートだけが表示されること、グローバル「みつける」→「注目」が引き続き機能することを目視確認

Closes #489

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/shiroha-a/mk/pull/494" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
