### PR TITLE
Perf #413 #7: capture pprof profiles during bench run

### DIFF
--- a/docs/bench-pprof.md
+++ b/docs/bench-pprof.md
@@ -1,0 +1,71 @@
+# Bench profiling (pprof)
+
+`tests/bench/docker-compose.bench.yml` で `make bench-up && make bench-run` を実行すると、
+k6 シナリオと並走して mk-go の pprof profile が `tests/bench/results/profiles/` に
+書き出される。`#413` チューニングロードマップの実測根拠として使う。
+
+Misskey TS 側はここでは取らない (Node.js は別ツール、本ロードマップは Go 側が対象)。
+
+## 仕組み
+
+| Component | 役割 |
+|-----------|------|
+| `app-mkgo` (`MK_ENABLEPPROF=true`) | `internal/server/router.go` の `/debug/pprof/*` を bench 限定で公開 |
+| `profile-collector-mkgo` | k6-mkgo と同時に起動し、pprof endpoint を curl で叩いて保存 |
+| `compare` | `report.md` に profile ファイル一覧と `go tool pprof` 起動例を追記 |
+
+`profile-collector.sh` は k6 が ramp-up した直後から、6 シナリオ各々の steady-state
+(`PROFILE_SECONDS=25` 秒) を CPU profile として撮る。前後で heap / allocs /
+goroutine snapshot も取得する。
+
+## 出力ファイル
+
+| File | 内容 |
+|------|------|
+| `cpu-<scenario>.pb.gz` | 各 k6 シナリオ steady-state 25 秒の CPU profile |
+| `heap-pre.pb.gz` / `heap-post.pb.gz` | ベンチ前後の heap snapshot |
+| `allocs-post.pb.gz` | ベンチ全体の累積 allocation |
+| `goroutine-pre.pb.gz` / `goroutine-post.pb.gz` | goroutine 状態 (leak 検出) |
+
+## 使い方
+
+```sh
+make bench-up
+make bench-run
+ls tests/bench/results/profiles/
+
+# scenario ごとの CPU hot path を見る
+go tool pprof -http :8080 tests/bench/results/profiles/cpu-users-show.pb.gz
+
+# heap の steady-state allocation を見る
+go tool pprof -http :8080 tests/bench/results/profiles/heap-post.pb.gz
+
+# allocator の累積 hot path
+go tool pprof -http :8080 tests/bench/results/profiles/allocs-post.pb.gz
+
+make bench-down
+```
+
+`-http :8080` で起動するとブラウザで flame graph / top / source view を切り替えられる。
+
+## 環境変数
+
+`profile-collector-mkgo` で上書き可能:
+
+| 変数 | 既定 | 用途 |
+|------|------|------|
+| `HOST` | `app-mkgo:3000` | pprof endpoint の host:port |
+| `SCENARIO_DURATION` | `31` | k6 シナリオ 1 つの長さ (秒)。`tests/bench/k6/lib/config.js` と一致させる |
+| `PROFILE_SECONDS` | `25` | 1 シナリオあたりの CPU profile 採取秒数 |
+| `SCENARIOS` | `ping meta local-timeline users-show i notes-create` | profile 名に使うシナリオ列 |
+
+## 本番では絶対に有効化しないこと
+
+`MK_ENABLEPPROF=true` は profile を取るために `/debug/pprof/*` を公開する。
+本番設定ファイル (`.config/default.yml`) では `enablePprof` を設定しない (= false)。
+config 読み込み時に有効だと警告ログが出る:
+
+```
+config: EnablePprof is enabled; /debug/pprof/* endpoints expose runtime internals.
+DO NOT enable this in production.
+```

--- a/tests/bench/common/compare.py
+++ b/tests/bench/common/compare.py
@@ -77,7 +77,64 @@ def fmt(v, decimals=1) -> str:
     return f"{v:.{decimals}f}"
 
 
-def generate_report(mkgo: dict, misskey: dict) -> str:
+def collect_profiles(profiles_dir: str | None) -> list[Path]:
+    """Return sorted .pb.gz pprof files written by profile-collector.
+
+    profile-collector.sh writes per-scenario CPU profiles plus heap / allocs /
+    goroutine snapshots into $OUT (defaults to /output/profiles in compose).
+    存在しない or 空のディレクトリは静かにスキップ (#413 #7)。
+    """
+    if not profiles_dir:
+        return []
+    p = Path(profiles_dir)
+    if not p.is_dir():
+        return []
+    return sorted(p.glob("*.pb.gz"))
+
+
+def render_profiles_section(profiles: list[Path], profiles_dir: str | None) -> list[str]:
+    if not profiles:
+        return []
+    rel_dir = Path(profiles_dir).name if profiles_dir else "profiles"
+    lines = [
+        "",
+        "## pprof profiles (mk-go)",
+        "",
+        f"`profile-collector` が k6-mkgo と並走して採取した profile (場所: `{rel_dir}/`)。",
+        "",
+        "| File | Size | 用途 |",
+        "|------|------|------|",
+    ]
+    purpose = {
+        "heap-pre": "ベンチ開始直前の heap snapshot (baseline)",
+        "heap-post": "ベンチ終了直後の heap (leak / steady-state を見る)",
+        "allocs-post": "ベンチ全体の累積 allocation (alloc hot path)",
+        "goroutine-pre": "ベンチ開始直前の goroutine 状態",
+        "goroutine-post": "ベンチ終了直後の goroutine 状態 (leak 検出)",
+    }
+    for f in profiles:
+        size = f.stat().st_size
+        stem = f.name.removesuffix(".pb.gz")
+        if stem.startswith("cpu-"):
+            scenario = stem[len("cpu-"):]
+            note = f"`{scenario}` シナリオ steady-state 25s の CPU profile"
+        else:
+            note = purpose.get(stem, "")
+        lines.append(f"| `{f.name}` | {size:,} B | {note} |")
+    lines.extend([
+        "",
+        "解析例:",
+        "",
+        "```sh",
+        f"go tool pprof -http :8080 tests/bench/results/{rel_dir}/cpu-users-show.pb.gz",
+        f"go tool pprof -http :8080 tests/bench/results/{rel_dir}/heap-post.pb.gz",
+        "```",
+    ])
+    return lines
+
+
+def generate_report(mkgo: dict, misskey: dict, profiles: list[Path] | None = None,
+                    profiles_dir: str | None = None) -> str:
     lines = [
         "# Benchmark: mk-go vs Misskey (TypeScript)",
         "",
@@ -128,6 +185,9 @@ def generate_report(mkgo: dict, misskey: dict) -> str:
         "- Results may vary depending on host machine load",
     ])
 
+    if profiles:
+        lines.extend(render_profiles_section(profiles, profiles_dir))
+
     return "\n".join(lines)
 
 
@@ -136,12 +196,15 @@ def main() -> None:
     parser.add_argument("--mkgo", required=True, help="Path to mk-go summary JSON")
     parser.add_argument("--misskey", required=True, help="Path to Misskey summary JSON")
     parser.add_argument("--output", default="/output/report.md", help="Output markdown path")
+    parser.add_argument("--profiles-dir", default=None,
+                        help="Directory containing pprof .pb.gz files captured during the bench")
     args = parser.parse_args()
 
     mkgo_metrics = extract_metrics(load_summary(args.mkgo))
     misskey_metrics = extract_metrics(load_summary(args.misskey))
 
-    report = generate_report(mkgo_metrics, misskey_metrics)
+    profiles = collect_profiles(args.profiles_dir)
+    report = generate_report(mkgo_metrics, misskey_metrics, profiles, args.profiles_dir)
 
     Path(args.output).parent.mkdir(parents=True, exist_ok=True)
     with open(args.output, "w") as f:

--- a/tests/bench/common/profile-collector.sh
+++ b/tests/bench/common/profile-collector.sh
@@ -9,6 +9,10 @@
 #   goroutine-pre.pb.gz / goroutine-post.pb.gz
 #   cpu-<scenario>.pb.gz                    — CPU profile for each k6 scenario
 #
+# busybox の wget だけで動かす (alpine:3.21 に最初から入っている)。
+# `apk add curl` を経由しないので、ネット越しのパッケージ取得失敗で bench
+# パイプライン全体が block する事故を避ける (Devin #501 FLAG-2)。
+#
 # Misskey TS 側はここでは取らない (Node.js は別ツール、本ロードマップ #413 は
 # Go 側のみが対象)。
 set -eu
@@ -19,6 +23,13 @@ SCENARIO_DURATION=${SCENARIO_DURATION:-31}
 PROFILE_SECONDS=${PROFILE_SECONDS:-25}
 SCENARIOS=${SCENARIOS:-"ping meta local-timeline users-show i notes-create"}
 
+# シナリオ数を $SCENARIOS から動的に算出する。
+# SCENARIOS を上書きしても sleep / log のロジックがそのまま動くようにする
+# (Devin #501 BUG-1 / INFO-3)。
+# shellcheck disable=SC2086 # word-splitting is intentional here
+set -- $SCENARIOS
+SCENARIO_COUNT=$#
+
 mkdir -p "$OUT"
 rm -f "$OUT"/*.pb.gz 2>/dev/null || true
 
@@ -28,36 +39,47 @@ log() { echo "[$(ts)] profile-collector: $*"; }
 snap() {
   endpoint=$1
   outfile=$2
-  if curl -fsS --max-time 30 "http://${HOST}/debug/pprof/${endpoint}" -o "$outfile"; then
+  if wget -q -T 30 -O "$outfile" "http://${HOST}/debug/pprof/${endpoint}"; then
     log "saved $(basename "$outfile") ($(wc -c < "$outfile") bytes)"
   else
     log "WARN: failed to fetch /debug/pprof/${endpoint}"
+    rm -f "$outfile"
+  fi
+}
+
+cpu_snap() {
+  scenario=$1
+  outfile=$2
+  if wget -q -T $((PROFILE_SECONDS + 10)) -O "$outfile" \
+    "http://${HOST}/debug/pprof/profile?seconds=${PROFILE_SECONDS}"; then
+    log "saved $(basename "$outfile") ($(wc -c < "$outfile") bytes)"
+  else
+    log "WARN: CPU profile failed for ${scenario}"
+    rm -f "$outfile"
   fi
 }
 
 # k6 が ramp-up を始めるまで少し待つ。k6-mkgo と本コンテナは
 # seed-mkgo が success した直後に同時起動するので、3秒で十分。
-log "waiting 3s for k6 ramp-up (host=${HOST})"
+log "waiting 3s for k6 ramp-up (host=${HOST}, scenarios=${SCENARIO_COUNT})"
 sleep 3
 
+# Pre-bench snapshots は ~1-2s 程度で完了するので、後続の per-scenario CPU
+# profile は k6 の startTime 基準から数秒遅れる。default (31s scenario, 25s
+# profile) なら steady-state 内に収まるが、PROFILE_SECONDS を SCENARIO_DURATION
+# に近づけると次シナリオの ramp-up に食い込みうる (Devin #501 INFO-1)。
 snap heap "$OUT/heap-pre.pb.gz"
 snap goroutine "$OUT/goroutine-pre.pb.gz"
 
 i=0
 for s in $SCENARIOS; do
   i=$((i + 1))
-  log "scenario ${i}/6 (${s}): capturing CPU profile for ${PROFILE_SECONDS}s"
-  if curl -fsS --max-time $((PROFILE_SECONDS + 10)) \
-    "http://${HOST}/debug/pprof/profile?seconds=${PROFILE_SECONDS}" \
-    -o "$OUT/cpu-${s}.pb.gz"; then
-    log "saved cpu-${s}.pb.gz ($(wc -c < "$OUT/cpu-${s}.pb.gz") bytes)"
-  else
-    log "WARN: CPU profile failed for ${s}"
-  fi
+  log "scenario ${i}/${SCENARIO_COUNT} (${s}): capturing CPU profile for ${PROFILE_SECONDS}s"
+  cpu_snap "$s" "$OUT/cpu-${s}.pb.gz"
   # Sleep through the remainder of the scenario block (ramp-down + buffer)
   # so that the next CPU profile aligns with the next scenario's steady state.
   remaining=$((SCENARIO_DURATION - PROFILE_SECONDS - 1))
-  if [ "$remaining" -gt 0 ] && [ "$i" -lt 6 ]; then
+  if [ "$remaining" -gt 0 ] && [ "$i" -lt "$SCENARIO_COUNT" ]; then
     sleep "$remaining"
   fi
 done

--- a/tests/bench/common/profile-collector.sh
+++ b/tests/bench/common/profile-collector.sh
@@ -1,0 +1,70 @@
+#!/bin/sh
+# Capture pprof profiles from the mk-go app container while k6 is running
+# the per-scenario load. See `tests/bench/docker-compose.bench.yml` for how
+# this is wired into the bench profile.
+#
+# Output layout (under $OUT, default /output/profiles):
+#   heap-pre.pb.gz / heap-post.pb.gz       — heap snapshots before & after
+#   allocs-post.pb.gz                       — total alloc samples after run
+#   goroutine-pre.pb.gz / goroutine-post.pb.gz
+#   cpu-<scenario>.pb.gz                    — CPU profile for each k6 scenario
+#
+# Misskey TS 側はここでは取らない (Node.js は別ツール、本ロードマップ #413 は
+# Go 側のみが対象)。
+set -eu
+
+HOST=${HOST:-app-mkgo:3000}
+OUT=${OUT:-/output/profiles}
+SCENARIO_DURATION=${SCENARIO_DURATION:-31}
+PROFILE_SECONDS=${PROFILE_SECONDS:-25}
+SCENARIOS=${SCENARIOS:-"ping meta local-timeline users-show i notes-create"}
+
+mkdir -p "$OUT"
+rm -f "$OUT"/*.pb.gz 2>/dev/null || true
+
+ts() { date -Is; }
+log() { echo "[$(ts)] profile-collector: $*"; }
+
+snap() {
+  endpoint=$1
+  outfile=$2
+  if curl -fsS --max-time 30 "http://${HOST}/debug/pprof/${endpoint}" -o "$outfile"; then
+    log "saved $(basename "$outfile") ($(wc -c < "$outfile") bytes)"
+  else
+    log "WARN: failed to fetch /debug/pprof/${endpoint}"
+  fi
+}
+
+# k6 が ramp-up を始めるまで少し待つ。k6-mkgo と本コンテナは
+# seed-mkgo が success した直後に同時起動するので、3秒で十分。
+log "waiting 3s for k6 ramp-up (host=${HOST})"
+sleep 3
+
+snap heap "$OUT/heap-pre.pb.gz"
+snap goroutine "$OUT/goroutine-pre.pb.gz"
+
+i=0
+for s in $SCENARIOS; do
+  i=$((i + 1))
+  log "scenario ${i}/6 (${s}): capturing CPU profile for ${PROFILE_SECONDS}s"
+  if curl -fsS --max-time $((PROFILE_SECONDS + 10)) \
+    "http://${HOST}/debug/pprof/profile?seconds=${PROFILE_SECONDS}" \
+    -o "$OUT/cpu-${s}.pb.gz"; then
+    log "saved cpu-${s}.pb.gz ($(wc -c < "$OUT/cpu-${s}.pb.gz") bytes)"
+  else
+    log "WARN: CPU profile failed for ${s}"
+  fi
+  # Sleep through the remainder of the scenario block (ramp-down + buffer)
+  # so that the next CPU profile aligns with the next scenario's steady state.
+  remaining=$((SCENARIO_DURATION - PROFILE_SECONDS - 1))
+  if [ "$remaining" -gt 0 ] && [ "$i" -lt 6 ]; then
+    sleep "$remaining"
+  fi
+done
+
+snap heap "$OUT/heap-post.pb.gz"
+snap allocs "$OUT/allocs-post.pb.gz"
+snap goroutine "$OUT/goroutine-post.pb.gz"
+
+log "done. profiles in $OUT:"
+ls -la "$OUT"

--- a/tests/bench/docker-compose.bench.yml
+++ b/tests/bench/docker-compose.bench.yml
@@ -50,6 +50,8 @@ services:
       TZ: Asia/Tokyo
       # レートリミット実装時(#273)にベンチが壊れないよう無効化しておく
       MK_ENABLEIPRATELIMIT: "false"
+      # bench で profile-collector が /debug/pprof/* に到達できるようにする (#500 / #413 #7)
+      MK_ENABLEPPROF: "true"
     depends_on:
       postgres-mkgo: { condition: service_healthy }
       redis-mkgo: { condition: service_healthy }
@@ -223,6 +225,26 @@ services:
       k6-mkgo: { condition: service_completed_successfully }
     networks: [bench]
 
+  # ── Profile Collector (mk-go only, #413 #7) ────────────────
+  # k6-mkgo と並走して /debug/pprof/* を curl で取得する。
+  # k6-misskey は別シナリオで走るため、CPU profile が混ざらないように
+  # mk-go run window 内に閉じ込める。
+  profile-collector-mkgo:
+    profiles: [bench]
+    image: alpine:3.21
+    environment:
+      HOST: app-mkgo:3000
+      SCENARIO_DURATION: "31"
+      PROFILE_SECONDS: "25"
+    volumes:
+      - ./common/profile-collector.sh:/profile-collector.sh:ro
+      - ./results:/output
+    command: sh -c "apk add --no-cache curl >/dev/null 2>&1 && sh /profile-collector.sh"
+    depends_on:
+      seed-mkgo: { condition: service_completed_successfully }
+      app-mkgo: { condition: service_healthy }
+    networks: [bench]
+
   # ── Report Generator ──────────────────────────────────────
   compare:
     profiles: [bench]
@@ -236,8 +258,10 @@ services:
         --mkgo /results/mkgo-summary.json
         --misskey /results/misskey-summary.json
         --output /output/report.md
+        --profiles-dir /output/profiles
     depends_on:
       k6-misskey: { condition: service_completed_successfully }
+      profile-collector-mkgo: { condition: service_completed_successfully }
 
 volumes:
   certs:

--- a/tests/bench/docker-compose.bench.yml
+++ b/tests/bench/docker-compose.bench.yml
@@ -236,10 +236,16 @@ services:
       HOST: app-mkgo:3000
       SCENARIO_DURATION: "31"
       PROFILE_SECONDS: "25"
+      # k6/all-scenarios.js のシナリオ列と一致させる。
+      # script 側で SCENARIO_COUNT は dynamic に算出するので、ここを変えれば
+      # 何個でも対応できる (Devin #501 INFO-3)。
+      SCENARIOS: "ping meta local-timeline users-show i notes-create"
     volumes:
       - ./common/profile-collector.sh:/profile-collector.sh:ro
       - ./results:/output
-    command: sh -c "apk add --no-cache curl >/dev/null 2>&1 && sh /profile-collector.sh"
+    # busybox wget で済ませて apk add を避ける。ネット失敗で bench 全体が
+    # block しないようにする (Devin #501 FLAG-2)。
+    command: sh /profile-collector.sh
     depends_on:
       seed-mkgo: { condition: service_completed_successfully }
       app-mkgo: { condition: service_healthy }


### PR DESCRIPTION
## Summary

#413 のチューニングロードマップで「最初の 1 PR に推奨」とされている **pprof profiling を bench に組み込む** を実装。他の最適化対策はすべて「仮説」であり、実測 profile が無いと当てずっぽうになるための基盤整備。

- `app-mkgo` の `/debug/pprof/*` を bench limited で公開
- k6 と並走する `profile-collector-mkgo` container が curl で profile を採取
- `compare.py` が `report.md` に profile 一覧 + `go tool pprof` コマンド例を追記

## 主な変更点

| ファイル | 内容 |
|---------|------|
| `tests/bench/docker-compose.bench.yml` | `app-mkgo` に `MK_ENABLEPPROF=true`、`profile-collector-mkgo` container を追加 (alpine + curl) |
| `tests/bench/common/profile-collector.sh` | k6 シナリオ steady-state 25s ずつ CPU profile を撮り、前後で heap/allocs/goroutine snapshot |
| `tests/bench/common/compare.py` | `--profiles-dir` を受け取り、`report.md` に profile セクション追加 |
| `docs/bench-pprof.md` | 取得 + 解析手順 (新規) |

## 出力ファイル

`make bench-up && make bench-run` 後に `tests/bench/results/profiles/`:

| File | 用途 |
|------|------|
| `cpu-<scenario>.pb.gz` | 各 k6 シナリオ steady-state 25 秒の CPU profile |
| `heap-pre.pb.gz` / `heap-post.pb.gz` | ベンチ前後の heap snapshot |
| `allocs-post.pb.gz` | ベンチ全体の累積 allocation |
| `goroutine-pre.pb.gz` / `goroutine-post.pb.gz` | goroutine 状態 (leak 検出) |

## テスト

- `compare.py` の `collect_profiles` / `render_profiles_section` を smoke test (空 dir / 非存在 / ファイル有り) で確認、PASS
- `go build ./...` クリーン、`gofmt -s -d .` 差分なし、`go vet ./...` クリーン
- bench compose 自体の起動検証は host docker 環境必要なため CI に委ねる (本ロードマップ #500 の完了条件で手動確認)

## セキュリティ

`MK_ENABLEPPROF=true` は profile 採取のため `/debug/pprof/*` を公開する。

- bench compose 限定で env 上書き
- 既存の `EnablePprof` config (#283 で導入) を経由するので有効時は warning ログを出す
- 本番設定 (`.config/default.yml`) では未設定 (= false)
- `docs/bench-pprof.md` に「本番では絶対に有効化しないこと」と明記

## 期待効果

これ自体は perf 改善 PR ではないが、後続の Phase 1 各項目 (User bulk fetch N+1 / JSON encoder 差し替え / Auth token cache / sync.Pool) の hot path 特定と検証に必須。**想定外のホットスポット** が見つかる可能性も高い。

Closes #500
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/shiroha-a/mk/pull/501" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
