### PR TITLE
Fix drive: Update / Delete を owner-only に戻して moderator privilege escalation を解消 (#499)

### DIFF
--- a/internal/core/drive/drive_service.go
+++ b/internal/core/drive/drive_service.go
@@ -376,6 +376,13 @@ func (s *Service) processImage(body []byte, mimeType string) *generateAltsResult
 // (when a roleChecker is wired) can read any file. Matches upstream Misskey
 // drive/files/show.ts semantics so admin moderation surfaces and remote-media
 // detail views work without 403.
+//
+// 注意: write 経路 (Update / Delete) では moderator bypass を意図的に
+// 適用しない。他ユーザーの file への moderator 経由の write/delete を
+// 許してしまう privilege escalation を避けるため、それらは
+// findOwnedFile() を使って owner-only ガードする (#499)。moderator が
+// 他ユーザーの file を編集 / 削除する正規経路は admin/drive/* 側に
+// 別途存在する。
 func (s *Service) Show(user *model.User, id string) (*model.DriveFile, error) {
 	if user == nil {
 		return nil, errors.New("user is required")
@@ -387,6 +394,23 @@ func (s *Service) Show(user *model.User, id string) (*model.DriveFile, error) {
 	owner := f.UserID != nil && *f.UserID == user.ID
 	moderator := s.roleChecker != nil && s.roleChecker.IsModerator(user.ID)
 	if !owner && !moderator {
+		return nil, ErrAccessDenied
+	}
+	return f, nil
+}
+
+// findOwnedFile is the strict owner-only equivalent of Show, used by write
+// paths (Update / Delete). It never honours the moderator bypass so that
+// drive write/delete operations can never escalate via moderator role.
+func (s *Service) findOwnedFile(user *model.User, id string) (*model.DriveFile, error) {
+	if user == nil {
+		return nil, errors.New("user is required")
+	}
+	f, err := s.fileRepo.FindByID(id)
+	if err != nil {
+		return nil, ErrFileNotFound
+	}
+	if f.UserID == nil || *f.UserID != user.ID {
 		return nil, ErrAccessDenied
 	}
 	return f, nil
@@ -413,8 +437,10 @@ type UpdateInput struct {
 }
 
 // Update applies the non-nil fields to a drive file owned by the user.
+// Owner-only: moderator が他ユーザーの file を編集できないよう
+// findOwnedFile() を使う (#499)。
 func (s *Service) Update(user *model.User, id string, in UpdateInput) (*model.DriveFile, error) {
-	f, err := s.Show(user, id)
+	f, err := s.findOwnedFile(user, id)
 	if err != nil {
 		return nil, err
 	}
@@ -453,8 +479,10 @@ func (s *Service) Update(user *model.User, id string, in UpdateInput) (*model.Dr
 }
 
 // Delete removes a file from storage and the database.
+// Owner-only: moderator が他ユーザーの file を削除できないよう
+// findOwnedFile() を使う (#499)。
 func (s *Service) Delete(user *model.User, id string) error {
-	f, err := s.Show(user, id)
+	f, err := s.findOwnedFile(user, id)
 	if err != nil {
 		return err
 	}

--- a/internal/core/drive/drive_service_test.go
+++ b/internal/core/drive/drive_service_test.go
@@ -644,8 +644,9 @@ func TestDelete_FiresChartHook(t *testing.T) {
 }
 
 // failingFindByIDRepo wraps the mock to make FindByID fail when called the
-// second time (after the initial create succeeds in Update). 1 回目の Show ()
-// は成功させ、2 回目 (Update 後の reload) で失敗させる。
+// second time (after the initial create succeeds in Update). 1 回目の
+// findOwnedFile() (#499 で Show() から差し替え済) は成功させ、2 回目
+// (Update 後の reload) で失敗させる。
 type failingFindByIDRepo struct {
 	*testutil.MockDriveFileRepository
 	calls int

--- a/internal/core/drive/drive_service_test.go
+++ b/internal/core/drive/drive_service_test.go
@@ -273,6 +273,31 @@ func TestUpdate_NotFound(t *testing.T) {
 	require.ErrorIs(t, err, drive.ErrFileNotFound)
 }
 
+// moderator は他ユーザーの file を Update できない (#499 privilege
+// escalation 回帰防止)。Show() は moderator bypass を許す一方で、
+// write 経路は owner-only に保たれていることを保証する。
+func TestUpdate_ModeratorCannotEditOthersFile(t *testing.T) {
+	svc, fileRepo, _ := newSvc(t)
+	other := "other"
+	fileRepo.Files["f1"] = &model.DriveFile{ID: "f1", UserID: &other}
+	svc.SetRoleChecker(&fakeMod{moderators: map[string]bool{"u1": true}})
+
+	newName := "renamed.png"
+	_, err := svc.Update(&model.User{ID: "u1"}, "f1", drive.UpdateInput{Name: &newName})
+	require.ErrorIs(t, err, drive.ErrAccessDenied)
+}
+
+// 同様に Delete も moderator bypass の対象外。
+func TestDelete_ModeratorCannotDeleteOthersFile(t *testing.T) {
+	svc, fileRepo, _ := newSvc(t)
+	other := "other"
+	fileRepo.Files["f1"] = &model.DriveFile{ID: "f1", UserID: &other}
+	svc.SetRoleChecker(&fakeMod{moderators: map[string]bool{"u1": true}})
+
+	err := svc.Delete(&model.User{ID: "u1"}, "f1")
+	require.ErrorIs(t, err, drive.ErrAccessDenied)
+}
+
 func TestUpdate_FolderNotFound(t *testing.T) {
 	svc, fileRepo, _ := newSvc(t)
 	uid := "u1"


### PR DESCRIPTION
## Severity

🔴 **Privilege escalation hotfix** for the regression introduced in #491.

## Root cause

#491 で \`internal/core/drive/drive_service.go\` の \`Show()\` に moderator bypass を追加した際、\`Update()\` / \`Delete()\` も owner check のために \`Show()\` を呼んでいたため、moderator が他ユーザーの \`drive_file\` を:

- rename / comment 変更
- isSensitive 変更
- フォルダ移動
- 削除 (storage の access key も含めて)

できる状態になっていた。Devin review (PR #491 ポストマージ) で指摘。

## Fix

- 内部関数 \`findOwnedFile(user, id)\` を追加。\`f.UserID == user.ID\` のみを確認し、moderator bypass を意図的に持たない
- \`Update()\` / \`Delete()\` を \`findOwnedFile()\` 経由に切り替え
- \`Show()\` (read-only) は引き続き moderator bypass を持つ。リモートメディア詳細表示の正規ユースケースを残す
- 回帰テスト 2 本を追加:
  - \`TestUpdate_ModeratorCannotEditOthersFile\`
  - \`TestDelete_ModeratorCannotDeleteOthersFile\`
- \`Show()\` の moderator bypass docstring に「write 経路には適用しない」旨を明記

moderator が他ユーザーの file を編集 / 削除する正規経路は \`admin/drive/*\` 側に既に存在する (\`router.go:1638\`)。

## Testing

- \`go test ./... -count=1\` 全パッケージ通過
- \`make fmt && make lint\` clean
- 既存 \`TestShow_ModeratorBypass\` (#491 で追加した read 経路の正常系) は引き続き pass

Closes #499

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/shiroha-a/mk/pull/502" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
