### PR TITLE
Perf #413 #1: batch users/show bulk path to eliminate N+1

### DIFF
--- a/internal/api/resetpassword/handler_test.go
+++ b/internal/api/resetpassword/handler_test.go
@@ -87,6 +87,14 @@ func (m *mockUserRepo) FindProfileByVerifyCode(string) (*model.UserProfile, erro
 	return nil, errMock
 }
 
+func (m *mockUserRepo) FindManyByIDs([]string) ([]*model.User, error) {
+	return nil, nil
+}
+
+func (m *mockUserRepo) FindProfilesByUserIDs([]string) ([]*model.UserProfile, error) {
+	return nil, nil
+}
+
 func (m *mockUserRepo) FindProfileByEmail(string) (*model.UserProfile, error) {
 	return nil, errMock
 }

--- a/internal/api/users/handler.go
+++ b/internal/api/users/handler.go
@@ -200,13 +200,12 @@ func (h *Handler) Show(c echo.Context) error {
 		if len(req.UserIDs) > 100 {
 			req.UserIDs = req.UserIDs[:100]
 		}
-		// bulk fetch してから 1 回の batch で instance を resolve する (#277)。
-		// single-user path と同じ UserLite.instance 表示互換を維持する。
-		bundles := make([]*user.UserWithProfile, 0, len(req.UserIDs))
-		for _, uid := range req.UserIDs {
-			if bundle, err := h.userService.ShowByID(uid); err == nil {
-				bundles = append(bundles, bundle)
-			}
+		// 旧実装は ShowByID をループで呼んで最大 200 round-trip の N+1 を
+		// 出していた (#503)。ShowManyByIDs は 2 batch query で済む。
+		// instance は #277 と同じく 1 回の batch で resolve する。
+		bundles, err := h.userService.ShowManyByIDs(req.UserIDs)
+		if err != nil {
+			return apierr.JSONInternalError(c)
 		}
 		users := make([]*model.User, 0, len(bundles))
 		for _, b := range bundles {

--- a/internal/api/users/handler_test.go
+++ b/internal/api/users/handler_test.go
@@ -2,6 +2,7 @@ package users
 
 import (
 	"encoding/json"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -648,6 +649,41 @@ func TestShow_BulkUserIDs_Empty(t *testing.T) {
 	rec := post(h.Show, `{"userIds":[]}`)
 	assert.Equal(t, http.StatusOK, rec.Code)
 	assert.Equal(t, "[]\n", rec.Body.String())
+}
+
+// users/show bulk path は ShowManyByIDs に切り替えた (#503) ので、入力順が
+// レスポンスにも保持されることを担保する。
+func TestShow_BulkUserIDs_PreservesOrder(t *testing.T) {
+	h, repo := newTestHandler(t)
+	repo.Users["u1"] = &model.User{ID: "u1", Username: "alice", AvatarDecorations: datatypes.JSON([]byte("[]"))}
+	repo.Users["u2"] = &model.User{ID: "u2", Username: "bob", AvatarDecorations: datatypes.JSON([]byte("[]"))}
+	repo.Users["u3"] = &model.User{ID: "u3", Username: "carol", AvatarDecorations: datatypes.JSON([]byte("[]"))}
+
+	rec := post(h.Show, `{"userIds":["u3","ghost","u1","u2"]}`)
+	assert.Equal(t, http.StatusOK, rec.Code)
+	var out []map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &out))
+	require.Len(t, out, 3)
+	assert.Equal(t, "u3", out[0]["id"])
+	assert.Equal(t, "u1", out[1]["id"])
+	assert.Equal(t, "u2", out[2]["id"])
+}
+
+// 100 件を超えた userIds は先頭 100 件に切り捨てる動作を担保する (TS 互換)。
+func TestShow_BulkUserIDs_Truncates100(t *testing.T) {
+	h, repo := newTestHandler(t)
+	ids := make([]string, 0, 105)
+	for i := 0; i < 105; i++ {
+		uid := fmt.Sprintf("ub%03d", i)
+		repo.Users[uid] = &model.User{ID: uid, Username: uid, AvatarDecorations: datatypes.JSON([]byte("[]"))}
+		ids = append(ids, fmt.Sprintf("%q", uid))
+	}
+	body := `{"userIds":[` + strings.Join(ids, ",") + `]}`
+	rec := post(h.Show, body)
+	assert.Equal(t, http.StatusOK, rec.Code)
+	var out []map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &out))
+	assert.Len(t, out, 100, "userIds は 100 件で切り捨てられるはず")
 }
 
 // --- Internal error paths via failing repos ---

--- a/internal/core/retention/service_test.go
+++ b/internal/core/retention/service_test.go
@@ -68,6 +68,8 @@ func (s *stubUserRepo) CountLocalUsersActiveSince(time.Time) (int64, error)   { 
 func (s *stubUserRepo) ListUserRecommendations(string, time.Time, int, int) ([]*model.User, error) {
 	return nil, nil
 }
+func (s *stubUserRepo) FindManyByIDs([]string) ([]*model.User, error)                { return nil, nil }
+func (s *stubUserRepo) FindProfilesByUserIDs([]string) ([]*model.UserProfile, error) { return nil, nil }
 
 type stubRetentionRepo struct {
 	rows            map[string]*model.RetentionAggregation // dateKey -> row

--- a/internal/core/user/user_service.go
+++ b/internal/core/user/user_service.go
@@ -136,6 +136,50 @@ func (s *Service) ShowByID(id string) (*UserWithProfile, error) {
 	return &UserWithProfile{User: u, Profile: profile}, nil
 }
 
+// ShowManyByIDs returns the users (and their profiles) for the given ID set
+// in a constant number of queries (1 user batch + 1 profile batch). Order
+// matches `ids`; missing rows are skipped silently. Replaces the per-ID
+// ShowByID loop in the users/show bulk path (#503).
+func (s *Service) ShowManyByIDs(ids []string) ([]*UserWithProfile, error) {
+	if len(ids) == 0 {
+		return nil, nil
+	}
+	users, err := s.userRepo.FindManyByIDs(ids)
+	if err != nil {
+		return nil, err
+	}
+	if len(users) == 0 {
+		return nil, nil
+	}
+	foundIDs := make([]string, 0, len(users))
+	for _, u := range users {
+		foundIDs = append(foundIDs, u.ID)
+	}
+	profiles, err := s.userRepo.FindProfilesByUserIDs(foundIDs)
+	if err != nil {
+		// Profile fetch 失敗は ShowByID と挙動を合わせて非致命にする
+		// (個別 ShowByID も err を握りつぶしている)。
+		profiles = nil
+	}
+	profileByUser := make(map[string]*model.UserProfile, len(profiles))
+	for _, p := range profiles {
+		profileByUser[p.UserID] = p
+	}
+	userByID := make(map[string]*model.User, len(users))
+	for _, u := range users {
+		userByID[u.ID] = u
+	}
+	out := make([]*UserWithProfile, 0, len(ids))
+	for _, id := range ids {
+		u, ok := userByID[id]
+		if !ok {
+			continue
+		}
+		out = append(out, &UserWithProfile{User: u, Profile: profileByUser[u.ID]})
+	}
+	return out, nil
+}
+
 // ShowByUsername returns the user (and profile) for the given username and host.
 //
 // host が nil もしくは空の場合はローカルユーザーとして DB を参照するのみ。

--- a/internal/core/user/user_service_test.go
+++ b/internal/core/user/user_service_test.go
@@ -57,6 +57,59 @@ func TestService_ShowByID_NoProfile(t *testing.T) {
 	assert.Nil(t, bundle.Profile)
 }
 
+func TestService_ShowManyByIDs_PreservesOrderAndSkipsMissing(t *testing.T) {
+	repo := testutil.NewMockUserRepository()
+	repo.Users["u1"] = &model.User{ID: "u1", Username: "alice"}
+	repo.Users["u2"] = &model.User{ID: "u2", Username: "bob"}
+	d1 := "d1"
+	d2 := "d2"
+	repo.Profiles["u1"] = &model.UserProfile{UserID: "u1", Description: &d1}
+	repo.Profiles["u2"] = &model.UserProfile{UserID: "u2", Description: &d2}
+	svc := user.NewService(repo, nil, nil, nil)
+
+	out, err := svc.ShowManyByIDs([]string{"u2", "ghost", "u1"})
+	require.NoError(t, err)
+	require.Len(t, out, 2)
+	// Order should follow input list; the missing "ghost" is dropped.
+	assert.Equal(t, "u2", out[0].User.ID)
+	assert.Equal(t, "u1", out[1].User.ID)
+	require.NotNil(t, out[0].Profile)
+	assert.Equal(t, "d2", *out[0].Profile.Description)
+	require.NotNil(t, out[1].Profile)
+	assert.Equal(t, "d1", *out[1].Profile.Description)
+}
+
+func TestService_ShowManyByIDs_EmptyInput(t *testing.T) {
+	repo := testutil.NewMockUserRepository()
+	svc := user.NewService(repo, nil, nil, nil)
+
+	out, err := svc.ShowManyByIDs(nil)
+	require.NoError(t, err)
+	assert.Nil(t, out)
+}
+
+func TestService_ShowManyByIDs_AllMissing(t *testing.T) {
+	repo := testutil.NewMockUserRepository()
+	svc := user.NewService(repo, nil, nil, nil)
+
+	out, err := svc.ShowManyByIDs([]string{"x", "y"})
+	require.NoError(t, err)
+	assert.Nil(t, out)
+}
+
+func TestService_ShowManyByIDs_NoProfileSilentlyOmitted(t *testing.T) {
+	repo := testutil.NewMockUserRepository()
+	repo.Users["u1"] = &model.User{ID: "u1", Username: "alice"}
+	// Profile 行が無くても User は返る
+	svc := user.NewService(repo, nil, nil, nil)
+
+	out, err := svc.ShowManyByIDs([]string{"u1"})
+	require.NoError(t, err)
+	require.Len(t, out, 1)
+	assert.Equal(t, "u1", out[0].User.ID)
+	assert.Nil(t, out[0].Profile)
+}
+
 func TestService_ShowByUsername_Success(t *testing.T) {
 	repo := testutil.NewMockUserRepository()
 	repo.Users["u1"] = &model.User{ID: "u1", Username: "alice", UsernameLower: "alice"}

--- a/internal/repository/user.go
+++ b/internal/repository/user.go
@@ -15,6 +15,13 @@ type UserRepository interface {
 	FindByURI(uri string) (*model.User, error)
 	FindByUsernameLower(username string, host *string) (*model.User, error)
 	FindProfileByUserID(userID string) (*model.UserProfile, error)
+	// FindManyByIDs returns users for the given ID set in a single query.
+	// Order is unspecified; missing rows are skipped silently. Pair with
+	// FindProfilesByUserIDs to replace the user/show bulk N+1 (#503).
+	FindManyByIDs(ids []string) ([]*model.User, error)
+	// FindProfilesByUserIDs returns user_profile rows for the given userId
+	// set in a single query. Order is unspecified; missing rows are skipped.
+	FindProfilesByUserIDs(userIDs []string) ([]*model.UserProfile, error)
 	IncrementFollowingCount(userID string, delta int) error
 	IncrementFollowersCount(userID string, delta int) error
 	SearchByUsername(query string, limit, offset int) ([]*model.User, error)
@@ -104,6 +111,34 @@ func (r *userRepository) FindProfileByUserID(userID string) (*model.UserProfile,
 		return nil, err
 	}
 	return &profile, nil
+}
+
+// FindManyByIDs returns users for the given ID set with a single IN query.
+// Used together with FindProfilesByUserIDs by core/user.Service.ShowManyByIDs
+// to eliminate the user/show bulk N+1 (#503).
+func (r *userRepository) FindManyByIDs(ids []string) ([]*model.User, error) {
+	if len(ids) == 0 {
+		return nil, nil
+	}
+	var users []*model.User
+	if err := r.db.Where("id IN ?", ids).Find(&users).Error; err != nil {
+		return nil, err
+	}
+	return users, nil
+}
+
+// FindProfilesByUserIDs returns user_profile rows for the given userId set
+// with a single IN query. Missing profiles are skipped (the DB allows users
+// without a profile, and ShowByID treats profile lookup as best-effort).
+func (r *userRepository) FindProfilesByUserIDs(userIDs []string) ([]*model.UserProfile, error) {
+	if len(userIDs) == 0 {
+		return nil, nil
+	}
+	var profiles []*model.UserProfile
+	if err := r.db.Where(`"userId" IN ?`, userIDs).Find(&profiles).Error; err != nil {
+		return nil, err
+	}
+	return profiles, nil
 }
 
 func (r *userRepository) IncrementFollowingCount(userID string, delta int) error {

--- a/internal/repository/user_test.go
+++ b/internal/repository/user_test.go
@@ -170,6 +170,83 @@ func TestUserRepository_FindProfileByUserID_NotFound(t *testing.T) {
 	assert.Error(t, err)
 }
 
+func TestUserRepository_FindManyByIDs(t *testing.T) {
+	repo := NewUserRepository(testDB)
+	u1 := insertTestUser(t, "u_fmid_1", "fmid1")
+	u2 := insertTestUser(t, "u_fmid_2", "fmid2")
+	defer cleanupUser(t, u1.ID)
+	defer cleanupUser(t, u2.ID)
+
+	out, err := repo.FindManyByIDs([]string{u1.ID, "ghost", u2.ID})
+	require.NoError(t, err)
+	got := map[string]bool{}
+	for _, u := range out {
+		got[u.ID] = true
+	}
+	assert.True(t, got[u1.ID], "u1 should be returned")
+	assert.True(t, got[u2.ID], "u2 should be returned")
+	assert.False(t, got["ghost"], "missing rows are skipped silently")
+}
+
+func TestUserRepository_FindManyByIDs_Empty(t *testing.T) {
+	repo := NewUserRepository(testDB)
+	out, err := repo.FindManyByIDs(nil)
+	require.NoError(t, err)
+	assert.Nil(t, out)
+}
+
+func TestUserRepository_FindProfilesByUserIDs(t *testing.T) {
+	repo := NewUserRepository(testDB)
+	u1 := insertTestUser(t, "u_fpu_1", "fpu1")
+	u2 := insertTestUser(t, "u_fpu_2", "fpu2")
+	defer cleanupUser(t, u1.ID)
+	defer cleanupUser(t, u2.ID)
+
+	desc1 := "p1"
+	desc2 := "p2"
+	require.NoError(t, testDB.Create(&model.UserProfile{
+		UserID: u1.ID, Description: &desc1, Fields: datatypes.JSON([]byte("[]")),
+	}).Error)
+	require.NoError(t, testDB.Create(&model.UserProfile{
+		UserID: u2.ID, Description: &desc2, Fields: datatypes.JSON([]byte("[]")),
+	}).Error)
+
+	out, err := repo.FindProfilesByUserIDs([]string{u1.ID, "ghost", u2.ID})
+	require.NoError(t, err)
+	got := map[string]string{}
+	for _, p := range out {
+		if p.Description != nil {
+			got[p.UserID] = *p.Description
+		}
+	}
+	assert.Equal(t, "p1", got[u1.ID])
+	assert.Equal(t, "p2", got[u2.ID])
+	assert.NotContains(t, got, "ghost")
+}
+
+func TestUserRepository_FindProfilesByUserIDs_Empty(t *testing.T) {
+	repo := NewUserRepository(testDB)
+	out, err := repo.FindProfilesByUserIDs(nil)
+	require.NoError(t, err)
+	assert.Nil(t, out)
+}
+
+func TestUserRepository_FindManyByIDs_Error(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	repo := NewUserRepository(testDB.WithContext(ctx))
+	_, err := repo.FindManyByIDs([]string{"x"})
+	assert.Error(t, err)
+}
+
+func TestUserRepository_FindProfilesByUserIDs_Error(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	repo := NewUserRepository(testDB.WithContext(ctx))
+	_, err := repo.FindProfilesByUserIDs([]string{"x"})
+	assert.Error(t, err)
+}
+
 func TestUserRepository_FindByUsernameLower_NotFound(t *testing.T) {
 	repo := NewUserRepository(testDB)
 

--- a/internal/testutil/mock_repository.go
+++ b/internal/testutil/mock_repository.go
@@ -87,6 +87,36 @@ func (m *MockUserRepository) FindProfileByUserID(userID string) (*model.UserProf
 	return p, nil
 }
 
+// FindManyByIDs mirrors the production repo: missing rows are skipped silently.
+// Order is unspecified (production does not guarantee it either).
+func (m *MockUserRepository) FindManyByIDs(ids []string) ([]*model.User, error) {
+	if len(ids) == 0 {
+		return nil, nil
+	}
+	out := make([]*model.User, 0, len(ids))
+	for _, id := range ids {
+		if u, ok := m.Users[id]; ok {
+			out = append(out, u)
+		}
+	}
+	return out, nil
+}
+
+// FindProfilesByUserIDs mirrors the production repo. Missing profiles are
+// skipped (matching the DB schema where profile rows are optional).
+func (m *MockUserRepository) FindProfilesByUserIDs(userIDs []string) ([]*model.UserProfile, error) {
+	if len(userIDs) == 0 {
+		return nil, nil
+	}
+	out := make([]*model.UserProfile, 0, len(userIDs))
+	for _, id := range userIDs {
+		if p, ok := m.Profiles[id]; ok {
+			out = append(out, p)
+		}
+	}
+	return out, nil
+}
+
 func (m *MockUserRepository) FindProfileByVerifyCode(code string) (*model.UserProfile, error) {
 	for _, p := range m.Profiles {
 		if p.EmailVerifyCode != nil && *p.EmailVerifyCode == code {


### PR DESCRIPTION
## Summary

#413 Phase 1 #1。`users/show` で `userIds[]` (最大 100 件) を渡した bulk path が `ShowByID` を 1 件ずつループし、最大 **200 round-trip の N+1** を出していた (#503)。これを **2 batch query** に置換する。

ベンチ: #413 の 2026-04-23 計測で `users-show` が **mk-go p95 183ms vs Misskey 117ms (Misskey 1.56x 速)** と唯一退行している主要因の一つ。

## 主な変更点

| ファイル | 内容 |
|---------|------|
| `internal/repository/user.go` | `FindManyByIDs(ids)` / `FindProfilesByUserIDs(userIDs)` を追加。raw `*model.User` / `*model.UserProfile` を返すだけに留めて、`core/user` との型循環を回避 |
| `internal/core/user/user_service.go` | `ShowManyByIDs(ids)` を追加。2 batch query → 順序保持で `[]*UserWithProfile` を組み立てる。Profile 取得失敗は `ShowByID` と同様に非致命扱い |
| `internal/api/users/handler.go` | bulk path を `ShowManyByIDs` 1 回呼びに置換 (Show:200-225)。100 件 truncate / `InstanceResolver` / `populateUserEmojis` 互換は維持 |
| `internal/testutil/mock_repository.go` | `MockUserRepository` に 2 メソッド追加 |
| `internal/api/resetpassword/handler_test.go`, `internal/core/retention/service_test.go` | 各 local mock に 2 メソッドの no-op stub 追加 |
| `internal/repository/user_test.go` | `FindManyByIDs` / `FindProfilesByUserIDs` の 6 ケース (success / empty / context-cancelled error / missing rows skip) |
| `internal/core/user/user_service_test.go` | `ShowManyByIDs` の 4 ケース (順序保持 / empty / all-missing / no profile silently omitted) |
| `internal/api/users/handler_test.go` | bulk path に order-preservation テスト + 100 件 truncate テスト追加 |

## クエリ削減

`userIds=[100]` 想定:
- before: `FindByID × 100` + `FindProfileByUserID × 100` = **200 query**
- after: `WHERE id IN (?)` + `WHERE userId IN (?)` = **2 query**

## テスト

```sh
go test -count=1 ./internal/api/users/ ./internal/core/user/ ./internal/api/resetpassword/ ./internal/core/retention/
ok  	internal/api/users    0.056s
ok  	internal/core/user    0.048s
ok  	internal/api/resetpassword    0.103s
ok  	internal/core/retention    0.006s
```

`go vet ./...` クリーン、`gofmt -s -d .` 差分なし。`go build ./...` クリーン。
DB-backed test (`internal/repository/`) は CI で実行 (testcontainers 必要)。

## bench 実測の扱い

期待効果は数学的に明らか (200→2 query) だが、wall-clock の改善幅は #500 で
導入した pprof で別 PR にて検証する。本 PR の merge 後に bench を再走して
`users-show` p95 の改善 (期待 2-3x) を #413 に記録する運用。

## スコープ外 (別 issue)

- 1-3 search 結果プロフィール (handler.go:280 系)
- 1-4 admin user list プロフィール (admin/handler.go)
- 2-3 followers/followings の `ShowByID` ループ
- 2-1〜2-5 の他項目 (#304 で users/show viewer field は並列化済み)

Closes #503
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/shiroha-a/mk/pull/504" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
