### PR TITLE
Fix security: notes/show fallback を削除し visibility check を必須化 (#445)

### DIFF
--- a/internal/api/notes/handler.go
+++ b/internal/api/notes/handler.go
@@ -281,14 +281,17 @@ func (h *Handler) Show(c echo.Context) error {
 	return c.JSON(http.StatusOK, s[0])
 }
 
-// lookupVisible fetches the note via QueryService when available, otherwise
-// falls back to a direct repository lookup. テストでQueryServiceなしで初期化
-// された場合の後方互換のためにフォールバックを残している。
+// lookupVisible fetches the note via QueryService, which applies the
+// visibility check (followers / specified visibility / blocks).
+// QueryService が wire されていない場合は visibility check を経ない
+// fallback で followers/specified の note が漏洩する security regression
+// risk があるため、nil なら ErrNoteNotFound を返して安全側に倒す (#445)。
+// production では router.go で常に wire されるのでこの分岐は通らない。
 func (h *Handler) lookupVisible(viewer *model.User, noteID string) (*model.Note, error) {
-	if h.queryService != nil {
-		return h.queryService.Show(viewer, noteID)
+	if h.queryService == nil {
+		return nil, note.ErrNoteNotFound
 	}
-	return h.noteRepo.FindByIDWithRelations(noteID)
+	return h.queryService.Show(viewer, noteID)
 }
 
 // DeleteRequest is the request body for notes/delete.

--- a/internal/api/notes/handler_query_test.go
+++ b/internal/api/notes/handler_query_test.go
@@ -389,18 +389,25 @@ func TestCreate_RenoteTargetInvisible(t *testing.T) {
 	assert.Equal(t, apierr.UUIDCannotRenoteDueToVisibility, errObj["id"])
 }
 
-// TestShow_FallbackNoQueryService verifies the lookupVisible nil-queryService path.
-func TestShow_FallbackNoQueryService(t *testing.T) {
+// TestShow_NoQueryServiceRejects は queryService が wire されていない
+// (= production の wiring が壊れた) 状態で Show が visibility check を
+// バイパスせず NO_SUCH_NOTE を返すことを保証する (#445)。過去はここで
+// fallback 経路が走り followers / specified visibility のノートが
+// 任意の閲覧者に漏洩する security regression risk があった。
+func TestShow_NoQueryServiceRejects(t *testing.T) {
 	noteRepo := testutil.NewMockNoteRepository()
 	pollRepo := testutil.NewMockPollRepository()
 	idGen, _ := id.NewGenerator("aidx")
 	createSvc := corenote.NewCreateService(noteRepo, pollRepo, idGen, nil)
 	deleteSvc := corenote.NewDeleteService(noteRepo)
-	// queryServiceなしで初期化することでフォールバック経路を取る
 	h := NewHandler(noteRepo, createSvc, deleteSvc, nil, nil, nil, nil, nil, idGen)
 
 	seedPublicNote(noteRepo, "n1")
 	c, rec := newJSONRequest(t, "/api/notes/show", `{"noteId":"n1"}`)
 	require.NoError(t, h.Show(c))
-	assert.Equal(t, http.StatusOK, rec.Code)
+	// fallback を消したので、queryService nil なら public note でも
+	// NO_SUCH_NOTE で蹴られる。production でこの経路を踏むことは無い
+	// が、wiring 不整合に対する防御として安全側に倒す。
+	assert.Equal(t, http.StatusNotFound, rec.Code)
+	assert.Contains(t, rec.Body.String(), "NO_SUCH_NOTE")
 }


### PR DESCRIPTION
## Severity

🟡 Defensive security hardening (production 経路には影響なし、wiring regression に対する防御)

## Root cause

\`internal/api/notes/handler.go:287-292\` の \`lookupVisible\` は \`queryService\` が nil の時に \`noteRepo.FindByIDWithRelations()\` に fallback して visibility check をスキップしていた。

\`\`\`go
func (h *Handler) lookupVisible(viewer *model.User, noteID string) (*model.Note, error) {
    if h.queryService != nil {
        return h.queryService.Show(viewer, noteID)
    }
    return h.noteRepo.FindByIDWithRelations(noteID)  // visibility check 無し!
}
\`\`\`

production では \`router.go:891\` で常に wire されるため実害は無いが、将来 wiring が壊れた場合に **followers / specified visibility のノートが任意の閲覧者に漏洩する security regression risk** が残っていた。指摘元は #444 Devin review (#425 PR の post-review コメント)。

## Fix

option 1 (issue で推奨されていた最シンプル案) を採用: fallback を削除し、\`queryService\` が nil なら \`note.ErrNoteNotFound\` (handler 側で \`NO_SUCH_NOTE\`) を返して安全側に倒す。

\`\`\`go
func (h *Handler) lookupVisible(viewer *model.User, noteID string) (*model.Note, error) {
    if h.queryService == nil {
        return nil, note.ErrNoteNotFound
    }
    return h.queryService.Show(viewer, noteID)
}
\`\`\`

## 主な変更点

- \`internal/api/notes/handler.go\` \`lookupVisible\` の fallback 経路を削除
- \`internal/api/notes/handler_query_test.go\` \`TestShow_FallbackNoQueryService\` を \`TestShow_NoQueryServiceRejects\` に置換 (queryService nil → NO_SUCH_NOTE で蹴ることを assert)

production wiring (\`router.go\`) は無変更。queryService を渡さない他のテスト (favorites / featured / mentions 等) は \`Show\` を呼ばないため影響なし。

## Testing

- \`go test ./... -count=1\` 全パッケージ通過
- \`make fmt && make lint\` clean

Closes #445

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/shiroha-a/mk/pull/505" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
