### PR TITLE
Auto-generate VAPID keys when Service Worker is enabled (#492)

### DIFF
--- a/internal/api/admin/handler.go
+++ b/internal/api/admin/handler.go
@@ -11,6 +11,7 @@ import (
 	"github.com/shiroha-a/mk/internal/api/apierr"
 	"github.com/shiroha-a/mk/internal/core/role"
 	"github.com/shiroha-a/mk/internal/core/signup"
+	"github.com/shiroha-a/mk/internal/core/webpush"
 	"github.com/shiroha-a/mk/internal/entity"
 	"github.com/shiroha-a/mk/internal/misc/id"
 	"github.com/shiroha-a/mk/internal/model"
@@ -796,10 +797,78 @@ func (h *Handler) UpdateMeta(c echo.Context) error {
 	// alias が frontend から来たら DB カラム名に translate して渡す。
 	renameUpdateMetaFields(fields)
 
+	// VAPID 鍵 auto-generate (#492): Service Worker 有効化時に
+	// swPublicKey / swPrivateKey が両方空のとき backend で生成して詰める。
+	// 既存鍵 (片方だけ欠けの中途状態 含む) は触らないことで、運用者が
+	// 外部生成した鍵を保持できるようにする。
+	if err := h.maybeAutoGenerateVAPID(fields); err != nil {
+		return c.JSON(http.StatusInternalServerError, apierr.Error("INTERNAL_ERROR", "Internal error.", "5d37dbcb-891e-41ca-a3d6-e690c97775ac"))
+	}
+
 	if err := h.metaRepo.Update(fields); err != nil {
 		return c.JSON(http.StatusInternalServerError, apierr.Error("INTERNAL_ERROR", "Internal error.", "5d37dbcb-891e-41ca-a3d6-e690c97775ac"))
 	}
 	return c.NoContent(http.StatusNoContent)
+}
+
+// maybeAutoGenerateVAPID は update-meta の field map を見て、Service
+// Worker が有効化される (= 既存有効 or 今 true に切り替わる) かつ
+// 公開鍵 / 秘密鍵が両方空のときに新規 VAPID 鍵対を生成して fields に
+// 詰め直す。生成しない条件:
+//   - SW が無効化される / 元から無効 で keys も空のまま (no-op)
+//   - 片方の key が既に設定済 (運用者が外部生成した鍵を尊重)
+func (h *Handler) maybeAutoGenerateVAPID(fields map[string]any) error {
+	current, err := h.metaRepo.Fetch()
+	if err != nil {
+		return err
+	}
+	enable := metaBoolAfterUpdate(fields, "enableServiceWorker", current.EnableServiceWorker)
+	if !enable {
+		return nil
+	}
+	pub := metaStringAfterUpdate(fields, "swPublicKey", strDeref(current.SwPublicKey))
+	priv := metaStringAfterUpdate(fields, "swPrivateKey", strDeref(current.SwPrivateKey))
+	if pub != "" || priv != "" {
+		return nil
+	}
+	newPub, newPriv, err := webpush.GenerateVAPIDKeys()
+	if err != nil {
+		return err
+	}
+	fields["swPublicKey"] = newPub
+	fields["swPrivateKey"] = newPriv
+	return nil
+}
+
+// metaBoolAfterUpdate returns the effective bool value of key after the
+// update would be applied — incoming value if present and bool-typed,
+// otherwise the current DB value.
+func metaBoolAfterUpdate(fields map[string]any, key string, current bool) bool {
+	if v, ok := fields[key]; ok {
+		if b, ok := v.(bool); ok {
+			return b
+		}
+	}
+	return current
+}
+
+// metaStringAfterUpdate returns the effective string value of key after the
+// update would be applied. Empty string and absence are equivalent for the
+// purpose of "should we auto-generate".
+func metaStringAfterUpdate(fields map[string]any, key, current string) string {
+	if v, ok := fields[key]; ok {
+		if s, ok := v.(string); ok {
+			return s
+		}
+	}
+	return current
+}
+
+func strDeref(p *string) string {
+	if p == nil {
+		return ""
+	}
+	return *p
 }
 
 // updateMetaFieldAliases maps frontend API names to DB column names for

--- a/internal/api/admin/handler.go
+++ b/internal/api/admin/handler.go
@@ -811,12 +811,12 @@ func (h *Handler) UpdateMeta(c echo.Context) error {
 	return c.NoContent(http.StatusNoContent)
 }
 
-// maybeAutoGenerateVAPID は update-meta の field map を見て、Service
-// Worker が有効化される (= 既存有効 or 今 true に切り替わる) かつ
-// 公開鍵 / 秘密鍵が両方空のときに新規 VAPID 鍵対を生成して fields に
-// 詰め直す。生成しない条件:
-//   - SW が無効化される / 元から無効 で keys も空のまま (no-op)
-//   - 片方の key が既に設定済 (運用者が外部生成した鍵を尊重)
+// maybeAutoGenerateVAPID inspects the update-meta field map and, when
+// Service Worker is being enabled (or is already enabled) and both the
+// public and private VAPID keys would end up empty, generates a fresh
+// key pair and injects it into fields. Skips key generation when:
+//   - SW is being disabled or is already disabled (no-op)
+//   - at least one key is already set (respects operator-supplied keys)
 func (h *Handler) maybeAutoGenerateVAPID(fields map[string]any) error {
 	current, err := h.metaRepo.Fetch()
 	if err != nil {
@@ -853,12 +853,17 @@ func metaBoolAfterUpdate(fields map[string]any, key string, current bool) bool {
 }
 
 // metaStringAfterUpdate returns the effective string value of key after the
-// update would be applied. Empty string and absence are equivalent for the
-// purpose of "should we auto-generate".
+// update would be applied. Empty string, JSON null, and absence are all
+// treated as "empty" so that an admin clearing a key with null still
+// triggers the auto-generate path.
 func metaStringAfterUpdate(fields map[string]any, key, current string) string {
 	if v, ok := fields[key]; ok {
-		if s, ok := v.(string); ok {
+		switch s := v.(type) {
+		case string:
 			return s
+		case nil:
+			// JSON null は明示的に空にしたい意図と解釈する
+			return ""
 		}
 	}
 	return current

--- a/internal/api/admin/handler_test.go
+++ b/internal/api/admin/handler_test.go
@@ -342,6 +342,26 @@ func TestUpdateMeta_VAPIDDoesNotOverwriteExistingKeys(t *testing.T) {
 	assert.Equal(t, existingPriv, *metaRepo.Meta.SwPrivateKey)
 }
 
+// 明示的な JSON null で既存鍵をクリアしつつ enable=true を送ってきた
+// 場合も auto-generate を発火させる (= null も "" と同じく empty 扱い)。
+func TestUpdateMeta_VAPIDAutoGenerateOnNullClear(t *testing.T) {
+	h, _, metaRepo, _ := newTestHandler(t)
+	existingPub := "old_pub"
+	existingPriv := "old_priv"
+	metaRepo.Meta.EnableServiceWorker = true
+	metaRepo.Meta.SwPublicKey = &existingPub
+	metaRepo.Meta.SwPrivateKey = &existingPriv
+
+	rec := doPost(h.UpdateMeta, `{"enableServiceWorker":true,"swPublicKey":null,"swPrivateKey":null}`, nil)
+	require.Equal(t, http.StatusNoContent, rec.Code)
+	require.NotNil(t, metaRepo.Meta.SwPublicKey)
+	require.NotNil(t, metaRepo.Meta.SwPrivateKey)
+	pub, priv := *metaRepo.Meta.SwPublicKey, *metaRepo.Meta.SwPrivateKey
+	assert.NotEqual(t, "old_pub", pub)
+	assert.NotEqual(t, "old_priv", priv)
+	assert.GreaterOrEqual(t, len(pub), 80)
+}
+
 // SW 無効のまま (enable=false) で keys が空でも何も生成しない
 // (= 不要な鍵をぶら下げない)。
 func TestUpdateMeta_VAPIDSkipWhenSWDisabled(t *testing.T) {

--- a/internal/api/admin/handler_test.go
+++ b/internal/api/admin/handler_test.go
@@ -305,6 +305,53 @@ func TestUpdateMeta_SwPublickeyAliasIsTranslated(t *testing.T) {
 	assert.Equal(t, "KEY", *metaRepo.Meta.SwPublicKey)
 }
 
+// Service Worker を有効化する request で keys が空なら backend が
+// auto-generate して DB に persist すること (#492)。frontend からは
+// toggle ON + 空欄保存で完結し、リロードすると生成済の鍵が表示される
+// 想定。
+func TestUpdateMeta_VAPIDAutoGenerateOnEnable(t *testing.T) {
+	h, _, metaRepo, _ := newTestHandler(t)
+	rec := doPost(h.UpdateMeta, `{"enableServiceWorker":true,"swPublicKey":"","swPrivateKey":""}`, nil)
+	require.Equal(t, http.StatusNoContent, rec.Code)
+	require.NotNil(t, metaRepo.Meta.SwPublicKey)
+	require.NotNil(t, metaRepo.Meta.SwPrivateKey)
+	pub, priv := *metaRepo.Meta.SwPublicKey, *metaRepo.Meta.SwPrivateKey
+	assert.NotEmpty(t, pub)
+	assert.NotEmpty(t, priv)
+	// VAPID public key は base64url(65 byte) ≒ 87 文字。少なくとも
+	// 「なんらかの長い rand 値」になっていることを sanity check する。
+	assert.GreaterOrEqual(t, len(pub), 80)
+	assert.GreaterOrEqual(t, len(priv), 40)
+	assert.NotEqual(t, pub, priv)
+}
+
+// 既に運用者が外部生成した鍵を持っている場合は触らないこと
+// (上書きすると push subscription が無効化されるため)。
+func TestUpdateMeta_VAPIDDoesNotOverwriteExistingKeys(t *testing.T) {
+	h, _, metaRepo, _ := newTestHandler(t)
+	existingPub := "EXISTING_PUB"
+	existingPriv := "EXISTING_PRIV"
+	metaRepo.Meta.EnableServiceWorker = true
+	metaRepo.Meta.SwPublicKey = &existingPub
+	metaRepo.Meta.SwPrivateKey = &existingPriv
+
+	rec := doPost(h.UpdateMeta, `{"enableServiceWorker":true}`, nil)
+	require.Equal(t, http.StatusNoContent, rec.Code)
+	require.NotNil(t, metaRepo.Meta.SwPublicKey)
+	assert.Equal(t, existingPub, *metaRepo.Meta.SwPublicKey)
+	assert.Equal(t, existingPriv, *metaRepo.Meta.SwPrivateKey)
+}
+
+// SW 無効のまま (enable=false) で keys が空でも何も生成しない
+// (= 不要な鍵をぶら下げない)。
+func TestUpdateMeta_VAPIDSkipWhenSWDisabled(t *testing.T) {
+	h, _, metaRepo, _ := newTestHandler(t)
+	rec := doPost(h.UpdateMeta, `{"enableServiceWorker":false}`, nil)
+	require.Equal(t, http.StatusNoContent, rec.Code)
+	assert.Nil(t, metaRepo.Meta.SwPublicKey)
+	assert.Nil(t, metaRepo.Meta.SwPrivateKey)
+}
+
 func TestAccountsCreate_EmptyUsername(t *testing.T) {
 	h, _, _, _ := newTestHandler(t)
 	rec := doPost(h.AccountsCreate, `{"username":"","password":"pass"}`, nil)

--- a/internal/core/webpush/vapid.go
+++ b/internal/core/webpush/vapid.go
@@ -14,12 +14,11 @@ import (
 //
 // Public key is the uncompressed P-256 point (65 bytes, leading 0x04)
 // base64url-encoded. Private key is the 32-byte raw scalar.
-//
-// crypto/ecdh の P256 を使う。crypto/ecdsa + elliptic.Marshal は Go 1.22 で
-// deprecated になっているが、ecdh.PublicKey.Bytes() / PrivateKey.Bytes()
-// が同じ wire format (65 byte uncompressed point / 32 byte scalar) を
-// 返してくれるのでそのまま web push 用途に使える。
 func GenerateVAPIDKeys() (publicKey, privateKey string, err error) {
+	// crypto/ecdh の P256 を使う。crypto/ecdsa + elliptic.Marshal は Go 1.22
+	// で deprecated になっているが、ecdh.PublicKey.Bytes() /
+	// PrivateKey.Bytes() が同じ wire format (65 byte uncompressed point /
+	// 32 byte scalar) を返してくれるのでそのまま web push 用途に使える。
 	priv, err := ecdh.P256().GenerateKey(rand.Reader)
 	if err != nil {
 		return "", "", fmt.Errorf("webpush: generate ECDH P-256 key: %w", err)

--- a/internal/core/webpush/vapid.go
+++ b/internal/core/webpush/vapid.go
@@ -1,0 +1,29 @@
+package webpush
+
+import (
+	"crypto/ecdh"
+	"crypto/rand"
+	"encoding/base64"
+	"fmt"
+)
+
+// GenerateVAPIDKeys returns a fresh VAPID key pair encoded as base64
+// url-safe strings (no padding), matching the wire format expected by
+// browser push subscriptions (RFC 8291) and the upstream Misskey TS
+// `web-push.generateVAPIDKeys()` output.
+//
+// Public key is the uncompressed P-256 point (65 bytes, leading 0x04)
+// base64url-encoded. Private key is the 32-byte raw scalar.
+//
+// crypto/ecdh の P256 を使う。crypto/ecdsa + elliptic.Marshal は Go 1.22 で
+// deprecated になっているが、ecdh.PublicKey.Bytes() / PrivateKey.Bytes()
+// が同じ wire format (65 byte uncompressed point / 32 byte scalar) を
+// 返してくれるのでそのまま web push 用途に使える。
+func GenerateVAPIDKeys() (publicKey, privateKey string, err error) {
+	priv, err := ecdh.P256().GenerateKey(rand.Reader)
+	if err != nil {
+		return "", "", fmt.Errorf("webpush: generate ECDH P-256 key: %w", err)
+	}
+	enc := base64.RawURLEncoding
+	return enc.EncodeToString(priv.PublicKey().Bytes()), enc.EncodeToString(priv.Bytes()), nil
+}

--- a/internal/core/webpush/vapid_test.go
+++ b/internal/core/webpush/vapid_test.go
@@ -1,0 +1,34 @@
+package webpush
+
+import (
+	"encoding/base64"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestGenerateVAPIDKeys(t *testing.T) {
+	pub, priv, err := GenerateVAPIDKeys()
+	require.NoError(t, err)
+
+	pubBytes, err := base64.RawURLEncoding.DecodeString(pub)
+	require.NoError(t, err)
+	// P-256 uncompressed point: 0x04 || X(32) || Y(32) = 65 bytes
+	assert.Len(t, pubBytes, 65)
+	assert.Equal(t, byte(0x04), pubBytes[0])
+
+	privBytes, err := base64.RawURLEncoding.DecodeString(priv)
+	require.NoError(t, err)
+	assert.Len(t, privBytes, 32)
+}
+
+// 2 回生成して必ず別の鍵が返ること (= 乱数源が固定でない)。
+func TestGenerateVAPIDKeys_RandomEachCall(t *testing.T) {
+	pub1, priv1, err := GenerateVAPIDKeys()
+	require.NoError(t, err)
+	pub2, priv2, err := GenerateVAPIDKeys()
+	require.NoError(t, err)
+	assert.NotEqual(t, pub1, pub2)
+	assert.NotEqual(t, priv1, priv2)
+}

--- a/internal/testutil/mock_repository.go
+++ b/internal/testutil/mock_repository.go
@@ -1690,6 +1690,14 @@ func (m *MockMetaRepository) Update(fields map[string]any) error {
 			if s, ok := v.(string); ok {
 				m.Meta.SwPublicKey = &s
 			}
+		case "swPrivateKey":
+			if s, ok := v.(string); ok {
+				m.Meta.SwPrivateKey = &s
+			}
+		case "enableServiceWorker":
+			if b, ok := v.(bool); ok {
+				m.Meta.EnableServiceWorker = b
+			}
 		case "name":
 			if s, ok := v.(string); ok {
 				m.Meta.Name = &s


### PR DESCRIPTION
## Summary

コントロールパネル → 全般 → サービスワーカーで push 通知を有効化する際、これまで管理者が外部ツールで VAPID 鍵対を生成して text 欄に貼り付ける必要があった。mk-go 独自の UX 改善として、**有効化時に鍵が両方空であれば backend が自動生成して DB に保存** する挙動を入れる。

## 主な変更点

### \`internal/core/webpush/vapid.go\` (新規)

\`GenerateVAPIDKeys()\` を追加。ECDH P-256 鍵対を生成し base64 url-safe (RFC 8291 / 元 \`web-push.generateVAPIDKeys()\` と同じ wire format) で返す。\`crypto/ecdh.P256()\` を使用 (\`crypto/ecdsa\` + \`elliptic.Marshal\` は Go 1.22 で deprecated のため modern API に統一)。

### \`internal/api/admin/handler.go\`

\`UpdateMeta\` に \`maybeAutoGenerateVAPID()\` を挿入。条件:
1. update 後の effective \`enableServiceWorker\` が true
2. update 後の effective \`swPublicKey\` と \`swPrivateKey\` が両方空

既存鍵 (片方 / 両方ある) は触らない (運用者が外部生成した鍵を尊重)。SW 無効のままなら何も生成しない。

### Tests

- \`internal/core/webpush/vapid_test.go\`: P-256 65 byte 公開鍵 / 32 byte 秘密鍵 / 毎回 random
- \`internal/api/admin/handler_test.go\`:
  - \`TestUpdateMeta_VAPIDAutoGenerateOnEnable\`
  - \`TestUpdateMeta_VAPIDDoesNotOverwriteExistingKeys\`
  - \`TestUpdateMeta_VAPIDSkipWhenSWDisabled\`
- mock MetaRepository.Update に \`enableServiceWorker\` / \`swPrivateKey\` の case を追加

## Frontend 挙動

frontend (\`settings.vue\`) は \`useForm\` の state を init 値 (= meta snapshot) で固定する仕様のため、**保存直後の text 欄は空欄表示のまま、ページリロード後に新規鍵が表示される**。CLAUDE.md フロントパッチ禁止ルールに従って frontend は無変更。push 配信機能としては DB / meta API に鍵が入った時点で機能するので運用上問題なし。

## Testing

- \`go test ./... -count=1\` 全パッケージ通過
- \`make fmt && make lint\` clean
- UDS 環境で動作確認済:
  1. 既存設定を空に (enable=false, keys=NULL)
  2. \`/admin/settings\` で SW を有効化 → 保存
  3. DB を見ると \`swPublicKey\` / \`swPrivateKey\` に valid な base64url 鍵が auto-generate されている
  4. ページリロードで text 欄に表示される

Closes #492

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/shiroha-a/mk/pull/506" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
