### PR TITLE
Chore: TestShow_NoQueryServiceRejects の GoDoc を英語化 (#510)

### DIFF
--- a/internal/api/notes/handler_query_test.go
+++ b/internal/api/notes/handler_query_test.go
@@ -396,7 +396,8 @@ func TestShow_NoQueryServiceRejects(t *testing.T) {
 	// 過去はここで fallback 経路が走り、followers / specified visibility の
 	// ノートが任意の閲覧者に漏洩する security regression risk があった。
 	// fallback を消したので、queryService nil なら public note でも
-	// NO_SUCH_NOTE で蹴られる。production でこの経路を踏むことは無い。
+	// NO_SUCH_NOTE で蹴られる。production でこの経路を踏むことは無いが、
+	// wiring 不整合に対する防御として安全側に倒す。
 	noteRepo := testutil.NewMockNoteRepository()
 	pollRepo := testutil.NewMockPollRepository()
 	idGen, _ := id.NewGenerator("aidx")

--- a/internal/api/notes/handler_query_test.go
+++ b/internal/api/notes/handler_query_test.go
@@ -389,12 +389,14 @@ func TestCreate_RenoteTargetInvisible(t *testing.T) {
 	assert.Equal(t, apierr.UUIDCannotRenoteDueToVisibility, errObj["id"])
 }
 
-// TestShow_NoQueryServiceRejects は queryService が wire されていない
-// (= production の wiring が壊れた) 状態で Show が visibility check を
-// バイパスせず NO_SUCH_NOTE を返すことを保証する (#445)。過去はここで
-// fallback 経路が走り followers / specified visibility のノートが
-// 任意の閲覧者に漏洩する security regression risk があった。
+// TestShow_NoQueryServiceRejects verifies Show returns NO_SUCH_NOTE when
+// queryService is not wired, ensuring the visibility check is never
+// bypassed (#445).
 func TestShow_NoQueryServiceRejects(t *testing.T) {
+	// 過去はここで fallback 経路が走り、followers / specified visibility の
+	// ノートが任意の閲覧者に漏洩する security regression risk があった。
+	// fallback を消したので、queryService nil なら public note でも
+	// NO_SUCH_NOTE で蹴られる。production でこの経路を踏むことは無い。
 	noteRepo := testutil.NewMockNoteRepository()
 	pollRepo := testutil.NewMockPollRepository()
 	idGen, _ := id.NewGenerator("aidx")
@@ -405,9 +407,6 @@ func TestShow_NoQueryServiceRejects(t *testing.T) {
 	seedPublicNote(noteRepo, "n1")
 	c, rec := newJSONRequest(t, "/api/notes/show", `{"noteId":"n1"}`)
 	require.NoError(t, h.Show(c))
-	// fallback を消したので、queryService nil なら public note でも
-	// NO_SUCH_NOTE で蹴られる。production でこの経路を踏むことは無い
-	// が、wiring 不整合に対する防御として安全側に倒す。
 	assert.Equal(t, http.StatusNotFound, rec.Code)
 	assert.Contains(t, rec.Body.String(), "NO_SUCH_NOTE")
 }


### PR DESCRIPTION
## Summary

PR #505 で追加した \`TestShow_NoQueryServiceRejects\` の GoDoc が日本語で書かれており、CLAUDE.md の「GoDoc は英語、インラインコメントは日本語」ルールに違反していた (Devin review #505 で指摘)。

## 変更点

\`internal/api/notes/handler_query_test.go\`:

- \`TestShow_NoQueryServiceRejects\` の GoDoc を英語サマリーに書き換え (同 file 内の \`TestSearch_NoSearchService\` 等と同じ形式)
- 背景説明 (fallback 経路の security regression risk) は関数本体内のインライン日本語コメントに移動
- 関数末尾にあった重複コメントを削除

## Testing

- \`go test ./internal/api/notes/ -run TestShow_NoQueryServiceRejects\` 通過
- \`make fmt\` clean

Closes #510

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/shiroha-a/mk/pull/511" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
