### PR TITLE
Perf #413 #3: in-memory cache for auth token resolution

### DIFF
--- a/internal/server/middleware/auth.go
+++ b/internal/server/middleware/auth.go
@@ -270,7 +270,13 @@ func (a *AuthMiddleware) resolveUser(token string) (*model.User, error) {
 		return nil, err
 	}
 
-	a.tokenCache.put(token, accessToken.User)
+	// orphaned access_token (User 行が削除済み) のとき GORM の Preload は
+	// User を nil にする。nil を 30 秒間キャッシュすると後続リクエストでも
+	// 同じ orphan を参照してしまうので、cache に積まないだけにして既存の
+	// 戻り値挙動はそのまま保つ (Devin #514 INFO-3 / 既存挙動互換)。
+	if accessToken.User != nil {
+		a.tokenCache.put(token, accessToken.User)
+	}
 	return accessToken.User, nil
 }
 

--- a/internal/server/middleware/auth.go
+++ b/internal/server/middleware/auth.go
@@ -31,6 +31,11 @@ type AuthMiddleware struct {
 	userRepo        repository.UserRepository
 	accessTokenRepo repository.AccessTokenRepository
 
+	// tokenCache は token → resolved user の短命キャッシュ (#512 / #413 #3)。
+	// 認証要リクエストの DB hit を 30 秒 TTL で消す。logout/token revoke の
+	// 反映遅延は許容範囲内 (TTL 以内)。
+	tokenCache *tokenCache
+
 	// lastActiveSeen はユーザー ID → 直近で lastActiveDate を更新した時刻。
 	// 認証済みリクエストごとに DB に書き込むと負荷が高くなるので、
 	// lastActiveUpdateInterval で gating する (#421)。
@@ -43,6 +48,7 @@ func NewAuthMiddleware(userRepo repository.UserRepository, accessTokenRepo repos
 	return &AuthMiddleware{
 		userRepo:        userRepo,
 		accessTokenRepo: accessTokenRepo,
+		tokenCache:      newTokenCache(),
 		lastActiveSeen:  make(map[string]time.Time),
 	}
 }
@@ -242,9 +248,15 @@ func extractToken(c echo.Context) string {
 }
 
 func (a *AuthMiddleware) resolveUser(token string) (*model.User, error) {
+	// hot path: TTL 内なら DB を引かずに cached user を返す (#512)。
+	if u, ok := a.tokenCache.get(token); ok {
+		return u, nil
+	}
+
 	// まずnative tokenで検索
 	user, err := a.userRepo.FindByToken(token)
 	if err == nil {
+		a.tokenCache.put(token, user)
 		return user, nil
 	}
 
@@ -252,9 +264,13 @@ func (a *AuthMiddleware) resolveUser(token string) (*model.User, error) {
 	hash := sha256Hash(token)
 	accessToken, err := a.accessTokenRepo.FindByHash(hash)
 	if err != nil {
+		// not-found 系は cache に積まない: 失効後 30 秒間 stale を返さない
+		// ようにするのと、未知 token 連打への DDoS を rate limiter 側に任せる
+		// 設計のため (#512 scope)。
 		return nil, err
 	}
 
+	a.tokenCache.put(token, accessToken.User)
 	return accessToken.User, nil
 }
 

--- a/internal/server/middleware/auth.go
+++ b/internal/server/middleware/auth.go
@@ -5,6 +5,7 @@ import (
 	"crypto/sha256"
 	"encoding/hex"
 	"encoding/json"
+	"errors"
 	"io"
 	"log/slog"
 	"net/http"
@@ -16,6 +17,12 @@ import (
 	"github.com/shiroha-a/mk/internal/model"
 	"github.com/shiroha-a/mk/internal/repository"
 )
+
+// errOrphanedAccessToken は access_token 行は残っているが Preload した
+// User が nil (= ユーザー削除済み) のケース。Authenticate はこれを「認証
+// 失敗扱い」(anonymous request 継続) として扱い、後続 dereference panic
+// を避ける (Devin #514 FLAG-1)。
+var errOrphanedAccessToken = errors.New("auth: access_token references a deleted user")
 
 type contextKey string
 
@@ -271,12 +278,13 @@ func (a *AuthMiddleware) resolveUser(token string) (*model.User, error) {
 	}
 
 	// orphaned access_token (User 行が削除済み) のとき GORM の Preload は
-	// User を nil にする。nil を 30 秒間キャッシュすると後続リクエストでも
-	// 同じ orphan を参照してしまうので、cache に積まないだけにして既存の
-	// 戻り値挙動はそのまま保つ (Devin #514 INFO-3 / 既存挙動互換)。
-	if accessToken.User != nil {
-		a.tokenCache.put(token, accessToken.User)
+	// User を nil にする。そのまま (nil, nil) を返すと Authenticate 側で
+	// user.ID dereference panic になるので、専用 error を返して anonymous
+	// request 扱いに落とす (Devin #514 FLAG-1)。cache にも積まない。
+	if accessToken.User == nil {
+		return nil, errOrphanedAccessToken
 	}
+	a.tokenCache.put(token, accessToken.User)
 	return accessToken.User, nil
 }
 

--- a/internal/server/middleware/auth_test.go
+++ b/internal/server/middleware/auth_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/shiroha-a/mk/internal/model"
 	"github.com/shiroha-a/mk/internal/testutil"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestAuthenticate_NoToken(t *testing.T) {
@@ -127,6 +128,36 @@ func TestAuthenticate_TokenCacheAvoidsDBOnRepeatedHit(t *testing.T) {
 	}
 	assert.Equal(t, 1, repo.findByTokenCalls,
 		"FindByToken should be called only on the cache miss; subsequent hits use the in-memory cache")
+}
+
+// orphaned access_token (User 削除済み) は anonymous request 扱いに落ちて
+// dereference panic を起こさないこと (Devin #514 FLAG-1)。
+func TestAuthenticate_OrphanedAccessTokenFallsBackToAnonymous(t *testing.T) {
+	repo := testutil.NewMockUserRepository()
+	tokenRepo := testutil.NewMockAccessTokenRepository()
+	const tok = "orphan-tok"
+	tokenRepo.Tokens[sha256Hash(tok)] = &model.AccessToken{
+		ID: "at_orphan",
+		// User intentionally nil to simulate the orphaned row.
+	}
+
+	auth := NewAuthMiddleware(repo, tokenRepo)
+	e := echo.New()
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	req.Header.Set("Authorization", "Bearer "+tok)
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+
+	// 旧実装ではここで panic していた。Authenticate が anonymous で next に
+	// 渡すこと、ハンドラ内 GetUser が nil を返すことを確認する。
+	require.NotPanics(t, func() {
+		err := auth.Authenticate()(func(c echo.Context) error {
+			assert.Nil(t, GetUser(c), "orphaned access_token must not produce a user")
+			return c.String(http.StatusOK, "ok")
+		})(c)
+		assert.NoError(t, err)
+	})
+	assert.Equal(t, http.StatusOK, rec.Code)
 }
 
 func TestAuthenticate_TokenCacheNotFoundIsNotPoisoned(t *testing.T) {

--- a/internal/server/middleware/auth_test.go
+++ b/internal/server/middleware/auth_test.go
@@ -86,6 +86,73 @@ func TestAuthenticate_QueryParam(t *testing.T) {
 	assert.NoError(t, err)
 }
 
+// countingUserRepo wraps the mock to count FindByToken calls so we can
+// assert that the resolved user came from the in-memory cache and not DB
+// on the second hit (#512).
+type countingUserRepo struct {
+	*testutil.MockUserRepository
+	findByTokenCalls int
+}
+
+func (c *countingUserRepo) FindByToken(token string) (*model.User, error) {
+	c.findByTokenCalls++
+	return c.MockUserRepository.FindByToken(token)
+}
+
+func TestAuthenticate_TokenCacheAvoidsDBOnRepeatedHit(t *testing.T) {
+	repo := &countingUserRepo{MockUserRepository: testutil.NewMockUserRepository()}
+	tokenRepo := testutil.NewMockAccessTokenRepository()
+	user := &model.User{ID: "u_cache_1", Username: "cacheuser"}
+	const tok = "cache-tok-aaaa"
+	repo.Tokens[tok] = user
+
+	auth := NewAuthMiddleware(repo, tokenRepo)
+	e := echo.New()
+	send := func() *httptest.ResponseRecorder {
+		req := httptest.NewRequest(http.MethodGet, "/", nil)
+		req.Header.Set("Authorization", "Bearer "+tok)
+		rec := httptest.NewRecorder()
+		c := e.NewContext(req, rec)
+		_ = auth.Authenticate()(func(c echo.Context) error {
+			u := GetUser(c)
+			assert.NotNil(t, u)
+			assert.Equal(t, "u_cache_1", u.ID)
+			return c.String(http.StatusOK, "ok")
+		})(c)
+		return rec
+	}
+
+	for i := 0; i < 5; i++ {
+		assert.Equal(t, http.StatusOK, send().Code)
+	}
+	assert.Equal(t, 1, repo.findByTokenCalls,
+		"FindByToken should be called only on the cache miss; subsequent hits use the in-memory cache")
+}
+
+func TestAuthenticate_TokenCacheNotFoundIsNotPoisoned(t *testing.T) {
+	repo := &countingUserRepo{MockUserRepository: testutil.NewMockUserRepository()}
+	tokenRepo := testutil.NewMockAccessTokenRepository()
+	auth := NewAuthMiddleware(repo, tokenRepo)
+
+	send := func() {
+		e := echo.New()
+		req := httptest.NewRequest(http.MethodGet, "/", nil)
+		req.Header.Set("Authorization", "Bearer ghost-tok")
+		rec := httptest.NewRecorder()
+		c := e.NewContext(req, rec)
+		_ = auth.Authenticate()(func(c echo.Context) error {
+			assert.Nil(t, GetUser(c))
+			return c.String(http.StatusOK, "ok")
+		})(c)
+	}
+
+	send()
+	send()
+	// 不在 token は cache に積まないので 2 回とも DB を引くこと。
+	assert.Equal(t, 2, repo.findByTokenCalls,
+		"not-found tokens must not be cached so token revoke / DB recovery is reflected immediately")
+}
+
 func TestAuthenticate_InvalidToken(t *testing.T) {
 	userRepo := testutil.NewMockUserRepository()
 	tokenRepo := testutil.NewMockAccessTokenRepository()

--- a/internal/server/middleware/token_cache.go
+++ b/internal/server/middleware/token_cache.go
@@ -27,7 +27,7 @@ type cachedAuthEntry struct {
 // tokenCache is a sync.Map-backed cache for token → resolved user, with
 // lazy TTL eviction on read and probabilistic full sweep on write. Negative
 // results (token not found) are *not* cached: not-found queries should fail
-// fast through DB so token revoke takes effect immediately (#512)。
+// fast through DB so token revoke takes effect immediately (#512).
 type tokenCache struct {
 	m          sync.Map // string → *cachedAuthEntry
 	storeCount atomic.Uint64

--- a/internal/server/middleware/token_cache.go
+++ b/internal/server/middleware/token_cache.go
@@ -1,0 +1,105 @@
+package middleware
+
+import (
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"github.com/shiroha-a/mk/internal/model"
+)
+
+// authCacheTTL は token → User を hot path でキャッシュする寿命。
+// 短い TTL は logout / token revoke の反映遅延を 30 秒以内に抑えつつ、
+// 高頻度の認証リクエストで DB の `FindByToken` 呼び出しをほぼ消す (#512 / #413 #3)。
+const authCacheTTL = 30 * time.Second
+
+// authCacheSweepEvery はキャッシュ growth が unbounded にならないように
+// `put` 1 回ごとに sweep を掛ける確率の分母 (1/N の確率で full sweep)。
+// hot path での余分な O(N) 走査を抑える妥協値。
+const authCacheSweepEvery uint64 = 64
+
+// cachedAuthEntry holds a resolved user and its cache expiry time.
+type cachedAuthEntry struct {
+	user      *model.User
+	expiresAt time.Time
+}
+
+// tokenCache is a sync.Map-backed cache for token → resolved user, with
+// lazy TTL eviction on read and probabilistic full sweep on write. Negative
+// results (token not found) are *not* cached: not-found queries should fail
+// fast through DB so token revoke takes effect immediately (#512)。
+type tokenCache struct {
+	m          sync.Map // string → *cachedAuthEntry
+	storeCount atomic.Uint64
+	ttl        time.Duration
+	sweepEvery uint64
+	now        func() time.Time // injected clock for test
+}
+
+// newTokenCache returns a tokenCache with default TTL / sweep cadence and
+// the wall clock as the now function.
+func newTokenCache() *tokenCache {
+	return &tokenCache{
+		ttl:        authCacheTTL,
+		sweepEvery: authCacheSweepEvery,
+		now:        time.Now,
+	}
+}
+
+// get returns the cached user if present and not expired. Expired entries
+// are deleted lazily on read.
+func (c *tokenCache) get(token string) (*model.User, bool) {
+	v, ok := c.m.Load(token)
+	if !ok {
+		return nil, false
+	}
+	entry, ok := v.(*cachedAuthEntry)
+	if !ok || c.now().After(entry.expiresAt) {
+		c.m.Delete(token)
+		return nil, false
+	}
+	return entry.user, true
+}
+
+// put stores token → user with TTL. Triggers a full sweep every sweepEvery
+// stores so the cache size stays bounded by "active tokens within the TTL
+// window" rather than "every token ever seen".
+func (c *tokenCache) put(token string, user *model.User) {
+	c.m.Store(token, &cachedAuthEntry{
+		user:      user,
+		expiresAt: c.now().Add(c.ttl),
+	})
+	if c.sweepEvery > 0 && c.storeCount.Add(1)%c.sweepEvery == 0 {
+		c.sweep()
+	}
+}
+
+// invalidate removes a single entry. Useful when an explicit logout /
+// token revoke needs to drop a cached user immediately.
+func (c *tokenCache) invalidate(token string) {
+	c.m.Delete(token)
+}
+
+// sweep walks the entire cache and removes expired entries. Cheap when the
+// cache is small (which is the steady state thanks to the periodic sweep
+// cadence on `put`).
+func (c *tokenCache) sweep() {
+	now := c.now()
+	c.m.Range(func(k, v any) bool {
+		if entry, ok := v.(*cachedAuthEntry); ok && now.After(entry.expiresAt) {
+			c.m.Delete(k)
+		}
+		return true
+	})
+}
+
+// len returns the current number of entries (test-only). The returned
+// value is a snapshot and may be stale immediately under concurrent access.
+func (c *tokenCache) len() int {
+	n := 0
+	c.m.Range(func(_, _ any) bool {
+		n++
+		return true
+	})
+	return n
+}

--- a/internal/server/middleware/token_cache_test.go
+++ b/internal/server/middleware/token_cache_test.go
@@ -1,0 +1,92 @@
+package middleware
+
+import (
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/shiroha-a/mk/internal/model"
+	"github.com/stretchr/testify/assert"
+)
+
+// fakeClock returns a stub `now` function whose value can be advanced from
+// the test. Used to drive TTL expiry without sleeping.
+type fakeClock struct {
+	t atomic.Int64 // unix nanoseconds
+}
+
+func newFakeClock(start time.Time) *fakeClock {
+	c := &fakeClock{}
+	c.t.Store(start.UnixNano())
+	return c
+}
+
+func (c *fakeClock) Now() time.Time { return time.Unix(0, c.t.Load()) }
+func (c *fakeClock) Advance(d time.Duration) {
+	c.t.Add(int64(d))
+}
+
+func TestTokenCache_GetMiss(t *testing.T) {
+	c := newTokenCache()
+	_, ok := c.get("ghost")
+	assert.False(t, ok)
+}
+
+func TestTokenCache_PutGet(t *testing.T) {
+	c := newTokenCache()
+	u := &model.User{ID: "u1"}
+	c.put("tok", u)
+	got, ok := c.get("tok")
+	assert.True(t, ok)
+	assert.Same(t, u, got)
+}
+
+func TestTokenCache_TTLExpired(t *testing.T) {
+	clock := newFakeClock(time.Unix(1_700_000_000, 0))
+	c := newTokenCache()
+	c.now = clock.Now
+	c.put("tok", &model.User{ID: "u1"})
+
+	clock.Advance(authCacheTTL + time.Second)
+	_, ok := c.get("tok")
+	assert.False(t, ok, "expired entry must be evicted on get")
+	assert.Equal(t, 0, c.len(), "expired entry should be deleted from map")
+}
+
+func TestTokenCache_Sweep(t *testing.T) {
+	clock := newFakeClock(time.Unix(1_700_000_000, 0))
+	c := newTokenCache()
+	c.now = clock.Now
+	c.sweepEvery = 0 // disable auto-sweep so we can call it explicitly
+	c.put("a", &model.User{ID: "ua"})
+	c.put("b", &model.User{ID: "ub"})
+	clock.Advance(authCacheTTL + time.Second)
+	c.put("c", &model.User{ID: "uc"}) // c is fresh
+	c.sweep()
+
+	assert.Equal(t, 1, c.len(), "only c should survive sweep")
+	_, ok := c.get("c")
+	assert.True(t, ok)
+}
+
+func TestTokenCache_AutoSweepOnPut(t *testing.T) {
+	clock := newFakeClock(time.Unix(1_700_000_000, 0))
+	c := newTokenCache()
+	c.now = clock.Now
+	c.sweepEvery = 4
+	for i := 0; i < 3; i++ {
+		c.put("stale-"+string(rune('a'+i)), &model.User{ID: "u"})
+	}
+	clock.Advance(authCacheTTL + time.Second)
+	// 4th put should hit the sweep threshold and clean the 3 stale entries.
+	c.put("fresh", &model.User{ID: "fresh"})
+	assert.Equal(t, 1, c.len(), "only the fresh entry should remain after auto-sweep")
+}
+
+func TestTokenCache_Invalidate(t *testing.T) {
+	c := newTokenCache()
+	c.put("tok", &model.User{ID: "u1"})
+	c.invalidate("tok")
+	_, ok := c.get("tok")
+	assert.False(t, ok)
+}


### PR DESCRIPTION
## Summary

#413 Phase 1 #3。認証要リクエストごとに `AuthMiddleware.resolveUser` が `userRepo.FindByToken` (+ access token なら `accessTokenRepo.FindByHash`) を毎回 DB に投げており、ベンチで p95 variance / DB プール枯渇の主要因の一つになっていた。

30 秒 TTL の in-memory cache で **DB 負荷 90%+ 削減** + p95 variance 半減を狙う (#413 ベンチ参照)。

## 主な変更点

| ファイル | 内容 |
|---------|------|
| `internal/server/middleware/token_cache.go` | sync.Map ベースの token → User キャッシュ。30s TTL、`get` で lazy expire、`put` 64 回ごとに full sweep で unbounded growth 抑止。`now func()` 注入で test しやすい設計 |
| `internal/server/middleware/auth.go` | `AuthMiddleware` に `tokenCache` フィールド追加。`resolveUser` の hot path で cache hit → DB を引かずに return。`NewAuthMiddleware` のシグネチャは維持 |
| `internal/server/middleware/token_cache_test.go` | get/put/TTL 期限/sweep/auto-sweep/invalidate の 6 ケース。`fakeClock` で時間を進めて deterministic に検証 |
| `internal/server/middleware/auth_test.go` | `countingUserRepo` wrapper で 5 連続リクエストでも `FindByToken` が 1 回しか呼ばれないこと、不在 token は cache されないことを担保 |

## 設計

- **TTL = 30s**: logout / token revoke の反映遅延を 30 秒以内に抑える妥協値 (#413 spec)
- **not-found を積まない**: 失効後 30 秒間 stale を返さないため。未知 token 連打への DDoS 緩和は rate limiter 側の責務 (scope 外)
- **sweep 64-store ごと**: hot path での O(N) sweep を抑制。steady state では cache size = "active token within TTL window" に収束
- **lazy expire on get**: 期限切れ entry は次の lookup で確実に削除される

## テスト

```sh
go test -count=1 ./internal/server/middleware/
ok  	internal/server/middleware    4.180s
```

`go vet ./...` クリーン、`gofmt -s -d .` 差分なし、`go build ./...` クリーン。

## bench 実測

PR merge 後に `make bench-run` で計測し、`/api/i` / `/api/users/show` 等の認証要 endpoint で p95 / variance 改善を #413 に記録する。#500 で導入した pprof で `FindByToken` の hot spot が消えることも併せて確認可能。

## スコープ外 (許容する trade-off)

- 30s 以内のログアウト / token revoke の反映遅延 (許容範囲、TTL spec)
- Negative result (404 token) のキャッシュ (DDoS 緩和は rate limit 側)
- Profile / role / mute 等の付随情報キャッシュ — 別 issue (#413 Phase 2 で別途扱う)

Closes #512
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/shiroha-a/mk/pull/514" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
