### PR TITLE
Perf #300 1-1 残: batch notifier user / note in notifications/show

### DIFF
--- a/internal/api/notifications/handler.go
+++ b/internal/api/notifications/handler.go
@@ -116,9 +116,16 @@ func (h *Handler) Show(c echo.Context) error {
 		excludeSet[t] = true
 	}
 
-	// 1 ページ分の通知を filter してから entity.PackNotifications に渡し、
-	// InstanceResolver / EmojiResolver を 1 回だけ構築する (#428 N+1 解消)。
-	items := make([]entity.NotificationItem, 0, len(rows))
+	// 2-pass で組み立てる:
+	//   pass 1: cursor / type / followReq filter を通して残った rows と、
+	//           その notifierID / noteID を集約
+	//   pass 2: userRepo.FindManyByIDs / noteRepo.FindManyByIDsWithUser で
+	//           まとめて引き、map で O(1) 解決して PackNotifications に渡す
+	// (旧実装は 1 通知ごとに FindByID + FindByIDWithRelations を呼んで最大
+	// 600 round-trip の N+1 を出していた。#515)。
+	filtered := make([]*notification.Notification, 0, len(rows))
+	notifierIDSet := make(map[string]struct{})
+	noteIDSet := make(map[string]struct{})
 	for _, n := range rows {
 		// カーソルベースページネーション
 		if req.SinceID != "" && n.ID <= req.SinceID {
@@ -142,21 +149,47 @@ func (h *Handler) Show(c echo.Context) error {
 				continue
 			}
 		}
-		// user/note 取得は handler 側で repo が wire されていれば best-effort。
-		// 外側の認証ユーザー (`user`) を shadow しないよう notifier 名で受ける。
-		var notifier *model.User
-		if h.userRepo != nil && n.NotifierID != "" {
-			if u, err := h.userRepo.FindByID(n.NotifierID); err == nil {
-				notifier = u
+		filtered = append(filtered, n)
+		if n.NotifierID != "" {
+			notifierIDSet[n.NotifierID] = struct{}{}
+		}
+		if n.NoteID != "" {
+			noteIDSet[n.NoteID] = struct{}{}
+		}
+	}
+
+	notifierByID := make(map[string]*model.User, len(notifierIDSet))
+	if h.userRepo != nil && len(notifierIDSet) > 0 {
+		ids := make([]string, 0, len(notifierIDSet))
+		for id := range notifierIDSet {
+			ids = append(ids, id)
+		}
+		if users, err := h.userRepo.FindManyByIDs(ids); err == nil {
+			for _, u := range users {
+				notifierByID[u.ID] = u
 			}
 		}
-		var note *model.Note
-		if h.noteRepo != nil && n.NoteID != "" {
-			if nn, err := h.noteRepo.FindByIDWithRelations(n.NoteID); err == nil {
-				note = nn
+	}
+	noteByID := make(map[string]*model.Note, len(noteIDSet))
+	if h.noteRepo != nil && len(noteIDSet) > 0 {
+		ids := make([]string, 0, len(noteIDSet))
+		for id := range noteIDSet {
+			ids = append(ids, id)
+		}
+		if notes, err := h.noteRepo.FindManyByIDsWithUser(ids); err == nil {
+			for _, nn := range notes {
+				noteByID[nn.ID] = nn
 			}
 		}
-		items = append(items, entity.NotificationItem{N: n, User: notifier, Note: note})
+	}
+
+	items := make([]entity.NotificationItem, 0, len(filtered))
+	for _, n := range filtered {
+		items = append(items, entity.NotificationItem{
+			N:    n,
+			User: notifierByID[n.NotifierID],
+			Note: noteByID[n.NoteID],
+		})
 	}
 	out := entity.PackNotifications(items, h.idGen, h.instanceLookup(), h.emojiLookup())
 	// 本家 i/notifications と互換: markAsRead 未指定または true なら通知一覧

--- a/internal/api/notifications/handler_test.go
+++ b/internal/api/notifications/handler_test.go
@@ -3,6 +3,7 @@ package notifications
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"log"
 	"net/http"
 	"net/http/httptest"
@@ -400,4 +401,89 @@ func TestShow_CursorPagination(t *testing.T) {
 	var resp []map[string]any
 	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
 	assert.Empty(t, resp)
+}
+
+// countingNotifRepos wraps the mock user / note repos to count single-row
+// FindByID-style calls. After #515 the bulk path must use FindManyByIDs /
+// FindManyByIDsWithUser so single-row callers should be 0.
+type countingNotifUserRepo struct {
+	*testutil.MockUserRepository
+	findByIDCalls         int
+	findManyByIDsCalls    int
+	findManyByIDsCallSize int
+}
+
+func (c *countingNotifUserRepo) FindByID(id string) (*model.User, error) {
+	c.findByIDCalls++
+	return c.MockUserRepository.FindByID(id)
+}
+
+func (c *countingNotifUserRepo) FindManyByIDs(ids []string) ([]*model.User, error) {
+	c.findManyByIDsCalls++
+	c.findManyByIDsCallSize += len(ids)
+	return c.MockUserRepository.FindManyByIDs(ids)
+}
+
+type countingNotifNoteRepo struct {
+	*testutil.MockNoteRepository
+	findByIDWithRelationsCalls int
+	findManyByIDsWithUserCalls int
+}
+
+func (c *countingNotifNoteRepo) FindByIDWithRelations(id string) (*model.Note, error) {
+	c.findByIDWithRelationsCalls++
+	return c.MockNoteRepository.FindByIDWithRelations(id)
+}
+
+func (c *countingNotifNoteRepo) FindManyByIDsWithUser(ids []string) ([]*model.Note, error) {
+	c.findManyByIDsWithUserCalls++
+	return c.MockNoteRepository.FindManyByIDsWithUser(ids)
+}
+
+// 通知 5 件 (異なる notifier / note) を返すケースで、user と note が batch
+// 1 回ずつだけ DB に問い合わされ、per-row FindByID 経路が使われていないこと
+// を担保する (#515 N+1 解消)。
+func TestShow_BatchFetchesNotifierAndNote(t *testing.T) {
+	h, svc := newTestHandler(t)
+	userRepo := &countingNotifUserRepo{MockUserRepository: testutil.NewMockUserRepository()}
+	noteRepo := &countingNotifNoteRepo{MockNoteRepository: testutil.NewMockNoteRepository()}
+	for i := 0; i < 5; i++ {
+		uid := fmt.Sprintf("notifier-%d", i)
+		nid := fmt.Sprintf("note-%d", i)
+		userRepo.Users[uid] = &model.User{ID: uid, Username: uid}
+		noteRepo.Notes[nid] = &model.Note{ID: nid, UserID: uid, Visibility: "public",
+			User: &model.User{ID: uid, Username: uid}}
+	}
+	h.SetRepos(userRepo, noteRepo)
+
+	ctx := context.Background()
+	for i := 0; i < 5; i++ {
+		_, err := svc.Create(ctx, notification.CreateInput{
+			NotifieeID: "alice",
+			NotifierID: fmt.Sprintf("notifier-%d", i),
+			Type:       notification.TypeMention,
+			NoteID:     fmt.Sprintf("note-%d", i),
+		})
+		require.NoError(t, err)
+	}
+
+	c, rec := newJSONRequest(t, "/api/i/notifications", `{}`)
+	setAuth(c, &model.User{ID: "alice"})
+	require.NoError(t, h.Show(c))
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	var resp []map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+	require.Len(t, resp, 5)
+
+	assert.Equal(t, 0, userRepo.findByIDCalls,
+		"user の per-row FindByID は呼ばれてはならない (N+1 解消)")
+	assert.Equal(t, 1, userRepo.findManyByIDsCalls,
+		"user は batch FindManyByIDs を 1 回だけ呼ぶこと")
+	assert.Equal(t, 5, userRepo.findManyByIDsCallSize,
+		"5 通知すべての notifierID が 1 回の batch にまとまっていること")
+	assert.Equal(t, 0, noteRepo.findByIDWithRelationsCalls,
+		"note の per-row FindByIDWithRelations は呼ばれてはならない")
+	assert.Equal(t, 1, noteRepo.findManyByIDsWithUserCalls,
+		"note は batch FindManyByIDsWithUser を 1 回だけ呼ぶこと")
 }

--- a/internal/api/notifications/handler_test.go
+++ b/internal/api/notifications/handler_test.go
@@ -477,15 +477,15 @@ func TestShow_BatchFetchesNotifierAndNote(t *testing.T) {
 	require.Len(t, resp, 5)
 
 	assert.Equal(t, 0, userRepo.findByIDCalls,
-		"user の per-row FindByID は呼ばれてはならない (N+1 解消)")
+		"per-row userRepo.FindByID must not be called (N+1 must be eliminated)")
 	assert.Equal(t, 1, userRepo.findManyByIDsCalls,
-		"user は batch FindManyByIDs を 1 回だけ呼ぶこと")
+		"userRepo.FindManyByIDs should be called exactly once per request")
 	assert.Equal(t, 5, userRepo.findManyByIDsCallSize,
-		"5 通知すべての notifierID が 1 回の batch にまとまっていること")
+		"all 5 notifier IDs should be coalesced into a single batch")
 	assert.Equal(t, 0, noteRepo.findByIDWithRelationsCalls,
-		"note の per-row FindByIDWithRelations は呼ばれてはならない")
+		"per-row noteRepo.FindByIDWithRelations must not be called")
 	assert.Equal(t, 1, noteRepo.findManyByIDsWithUserCalls,
-		"note は batch FindManyByIDsWithUser を 1 回だけ呼ぶこと")
+		"noteRepo.FindManyByIDsWithUser should be called exactly once per request")
 
 	// Devin #516 INFO-3: batch fetch しても resolved user / note が response
 	// に正しく入ることを self-contained で担保する。

--- a/internal/api/notifications/handler_test.go
+++ b/internal/api/notifications/handler_test.go
@@ -486,4 +486,11 @@ func TestShow_BatchFetchesNotifierAndNote(t *testing.T) {
 		"note の per-row FindByIDWithRelations は呼ばれてはならない")
 	assert.Equal(t, 1, noteRepo.findManyByIDsWithUserCalls,
 		"note は batch FindManyByIDsWithUser を 1 回だけ呼ぶこと")
+
+	// Devin #516 INFO-3: batch fetch しても resolved user / note が response
+	// に正しく入ることを self-contained で担保する。
+	for i, item := range resp {
+		assert.NotNilf(t, item["user"], "item[%d].user must be present", i)
+		assert.NotNilf(t, item["note"], "item[%d].note must be present", i)
+	}
 }


### PR DESCRIPTION
## Summary

#300 で挙げた N+1 のうち 1-1 は #443 で `entity.PackNotifications` の InstanceResolver / EmojiResolver batch 化が入った。だが handler 側で notifier user / note を 1 件ずつ `FindByID` で引いている部分は残っていた (#515)。本 PR で完全解消する。

`/api/i/notifications` で 300 件 (本家 limit) を返すケースで **最大 600 query → 2 query**。

## 主な変更点

| ファイル | 内容 |
|---------|------|
| `internal/api/notifications/handler.go` | `Show` を 2-pass にリファクタ。pass 1 で cursor / type / followReq filter を通った notification の `notifierID` / `noteID` を set に集約、pass 2 で `userRepo.FindManyByIDs` (#503 で追加済) と既存 `noteRepo.FindManyByIDsWithUser` で batch fetch、map で O(1) 解決して `entity.PackNotifications` に渡す |
| `internal/api/notifications/handler_test.go` | `countingNotifUserRepo` / `countingNotifNoteRepo` wrapper を追加。5 通知ケースで per-row `FindByID` が 0 回、batch `FindManyByIDs` が 1 回だけ呼ばれること、batch サイズが 5 であることを担保 |

## クエリ削減

300 件 (本家 limit) 想定:
- before: `FindByID × 300` (notifier) + `FindByIDWithRelations × ≤300` (note) = **最大 600 query**
- after: `FindManyByIDs(notifierIDs)` + `FindManyByIDsWithUser(noteIDs)` = **2 query**

## テスト

```sh
go test -count=1 ./internal/api/notifications/
ok  	internal/api/notifications    1.566s
```

`go vet ./...` クリーン、`gofmt -s -d .` 差分なし、`go build ./...` クリーン。

## 互換性

- レスポンス body は変わらず (entity.PackNotifications にそのまま渡しているだけ)
- `MarkAllAsRead` 副作用、cursor / type filter、follow request filter は既存挙動を維持
- `userRepo` / `noteRepo` 未配線時は filter 後 0 entry なので既存挙動と同じく user/note フィールド省略

## スコープ外

- Notifications 以外の N+1 (#300 1-2 〜 1-5)
- Profile キャッシュ / Auth token キャッシュは別 PR で実施済 (#503 / #514)

Closes #515
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/shiroha-a/mk/pull/516" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
