### PR TITLE
Perf #300 1-3: batch profile fetch in users/search

### DIFF
--- a/internal/api/users/handler.go
+++ b/internal/api/users/handler.go
@@ -381,11 +381,19 @@ func (h *Handler) Search(c echo.Context) error {
 		return apierr.JSONInternalError(c)
 	}
 
+	// users/search が検索結果 N 件ぶん per-row GetProfile を呼んでいた N+1 を
+	// 1 batch query に置換する (#517)。Profile が見つからない user は
+	// PackUserDetailed が nil profile を許容するのでそのまま渡る。
+	ids := make([]string, 0, len(users))
+	for _, u := range users {
+		ids = append(ids, u.ID)
+	}
+	profiles := h.userService.GetProfilesByUserIDs(ids)
+
 	resolver := entity.NewInstanceResolver(h.instanceLookup(), users...)
 	out := make([]entity.UserDetailed, 0, len(users))
 	for _, u := range users {
-		profile := h.userService.GetProfile(u.ID)
-		d := entity.PackUserDetailed(u, profile, h.idGen)
+		d := entity.PackUserDetailed(u, profiles[u.ID], h.idGen)
 		resolver.FillUserLite(&d.UserLite)
 		h.populateUserEmojis(u, &d.UserLite)
 		out = append(out, d)

--- a/internal/api/users/handler_test.go
+++ b/internal/api/users/handler_test.go
@@ -508,6 +508,63 @@ func TestSearch_Success(t *testing.T) {
 	assert.Len(t, out, 1)
 }
 
+// users/search bulk path is now batch (#517). Per-row FindProfileByUserID
+// must not be called and the new batch FindProfilesByUserIDs is invoked once
+// with all matched user IDs.
+type countingSearchUserRepo struct {
+	*testutil.MockUserRepository
+	findProfileByUserIDCalls   int
+	findProfilesByUserIDsCalls int
+	findProfilesByUserIDsSize  int
+}
+
+func (c *countingSearchUserRepo) FindProfileByUserID(id string) (*model.UserProfile, error) {
+	c.findProfileByUserIDCalls++
+	return c.MockUserRepository.FindProfileByUserID(id)
+}
+
+func (c *countingSearchUserRepo) FindProfilesByUserIDs(ids []string) ([]*model.UserProfile, error) {
+	c.findProfilesByUserIDsCalls++
+	c.findProfilesByUserIDsSize += len(ids)
+	return c.MockUserRepository.FindProfilesByUserIDs(ids)
+}
+
+func TestSearch_BatchFetchesProfiles(t *testing.T) {
+	repo := &countingSearchUserRepo{MockUserRepository: testutil.NewMockUserRepository()}
+	noteRepo := testutil.NewMockNoteRepository()
+	piningRepo := testutil.NewMockUserNotePiningRepository()
+	fRepo := testutil.NewMockFollowingRepository()
+	frRepo := testutil.NewMockFollowRequestRepository()
+	idGen, _ := id.NewGenerator("aidx")
+	svc := coreuser.NewService(repo, noteRepo, piningRepo, idGen)
+	fSvc := corefollowing.NewService(repo, fRepo, frRepo, idGen)
+	h := NewHandler(svc, fSvc, noteRepo, idGen)
+
+	for i := 0; i < 5; i++ {
+		uid := fmt.Sprintf("searchuser-%d", i)
+		repo.Users[uid] = &model.User{
+			ID: uid, Username: "matchu" + fmt.Sprintf("%d", i),
+			UsernameLower:     "matchu" + fmt.Sprintf("%d", i),
+			AvatarDecorations: datatypes.JSON([]byte("[]")),
+		}
+		desc := "d" + fmt.Sprintf("%d", i)
+		repo.Profiles[uid] = &model.UserProfile{UserID: uid, Description: &desc}
+	}
+
+	rec := post(h.Search, `{"query":"matchu","limit":10}`)
+	assert.Equal(t, http.StatusOK, rec.Code)
+	var out []map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &out))
+	require.Len(t, out, 5)
+
+	assert.Equal(t, 0, repo.findProfileByUserIDCalls,
+		"per-row FindProfileByUserID must not be called (N+1 must be eliminated)")
+	assert.Equal(t, 1, repo.findProfilesByUserIDsCalls,
+		"FindProfilesByUserIDs should be called exactly once per request")
+	assert.Equal(t, 5, repo.findProfilesByUserIDsSize,
+		"all 5 user IDs should be coalesced into a single batch")
+}
+
 func TestSearch_DefaultLimit(t *testing.T) {
 	h, repo := newTestHandler(t)
 	addTestUser(repo)

--- a/internal/core/user/user_service.go
+++ b/internal/core/user/user_service.go
@@ -215,6 +215,25 @@ func (s *Service) GetProfile(userID string) *model.UserProfile {
 	return profile
 }
 
+// GetProfilesByUserIDs returns a userID → profile map for the given IDs in
+// a single batch query. Missing rows are simply omitted from the map.
+// users/search 等の bulk path で per-row GetProfile loop の N+1 を消すために
+// 使う (#517)。
+func (s *Service) GetProfilesByUserIDs(ids []string) map[string]*model.UserProfile {
+	if len(ids) == 0 {
+		return map[string]*model.UserProfile{}
+	}
+	profiles, err := s.userRepo.FindProfilesByUserIDs(ids)
+	if err != nil {
+		return map[string]*model.UserProfile{}
+	}
+	out := make(map[string]*model.UserProfile, len(profiles))
+	for _, p := range profiles {
+		out[p.UserID] = p
+	}
+	return out
+}
+
 // ListRecommendations returns locally-active explorable users the viewer does
 // not already follow. Thin wrapper over UserRepository.ListUserRecommendations.
 func (s *Service) ListRecommendations(viewerID string, activeSince time.Time, limit, offset int) ([]*model.User, error) {

--- a/internal/core/user/user_service_test.go
+++ b/internal/core/user/user_service_test.go
@@ -97,6 +97,47 @@ func TestService_ShowManyByIDs_AllMissing(t *testing.T) {
 	assert.Nil(t, out)
 }
 
+func TestService_GetProfilesByUserIDs_BatchOK(t *testing.T) {
+	repo := testutil.NewMockUserRepository()
+	d1, d2 := "p1", "p2"
+	repo.Profiles["u1"] = &model.UserProfile{UserID: "u1", Description: &d1}
+	repo.Profiles["u2"] = &model.UserProfile{UserID: "u2", Description: &d2}
+	svc := user.NewService(repo, nil, nil, nil)
+
+	out := svc.GetProfilesByUserIDs([]string{"u1", "u2", "ghost"})
+	require.Len(t, out, 2)
+	require.NotNil(t, out["u1"])
+	require.NotNil(t, out["u2"])
+	assert.Equal(t, "p1", *out["u1"].Description)
+	assert.Equal(t, "p2", *out["u2"].Description)
+	assert.NotContains(t, out, "ghost", "missing profiles must not appear in the map")
+}
+
+func TestService_GetProfilesByUserIDs_EmptyInput(t *testing.T) {
+	repo := testutil.NewMockUserRepository()
+	svc := user.NewService(repo, nil, nil, nil)
+	out := svc.GetProfilesByUserIDs(nil)
+	assert.Empty(t, out)
+}
+
+// failingProfileRepo wraps the mock to make FindProfilesByUserIDs return an
+// error, so we can exercise the service-side fallback (returns empty map,
+// never nil).
+type failingProfileRepo struct {
+	*testutil.MockUserRepository
+}
+
+func (failingProfileRepo) FindProfilesByUserIDs(_ []string) ([]*model.UserProfile, error) {
+	return nil, errors.New("db error")
+}
+
+func TestService_GetProfilesByUserIDs_RepoErrorYieldsEmptyMap(t *testing.T) {
+	svc := user.NewService(failingProfileRepo{testutil.NewMockUserRepository()}, nil, nil, nil)
+	out := svc.GetProfilesByUserIDs([]string{"u1"})
+	require.NotNil(t, out, "must return a non-nil map even on repository error")
+	assert.Empty(t, out)
+}
+
 func TestService_ShowManyByIDs_NoProfileSilentlyOmitted(t *testing.T) {
 	repo := testutil.NewMockUserRepository()
 	repo.Users["u1"] = &model.User{ID: "u1", Username: "alice"}


### PR DESCRIPTION
## Summary

`/api/users/search` が検索結果 N 件ぶん per-row `userService.GetProfile` を呼ぶ N+1 になっていた (#517)。`FindProfilesByUserIDs` (#503 で追加済) を service 経由で公開して 1 batch 呼び出しに置換する。

クエリ削減 (limit 100 件想定): **101 query → 2 query**。

## 主な変更点

| ファイル | 内容 |
|---------|------|
| `internal/core/user/user_service.go` | `GetProfilesByUserIDs(ids) map[string]*model.UserProfile` を追加。既存 `repository.FindProfilesByUserIDs` 呼び出しの薄いラッパ |
| `internal/api/users/handler.go` | `Search` の per-row `GetProfile` ループを 1 batch 呼び出しに置換 |
| `internal/api/users/handler_test.go` | `countingSearchUserRepo` wrapper を追加。5 件検索ケースで per-row `FindProfileByUserID` が 0 回、`FindProfilesByUserIDs` が 1 回 + size=5 で呼ばれることを担保 |

## テスト

```sh
go test -count=1 -run 'TestSearch' ./internal/api/users/
ok  	internal/api/users    0.039s
```

`go vet ./...` クリーン、`gofmt -s -d .` 差分なし、`go build ./...` クリーン。

## スコープ外

- 1-4 admin user list — 別 PR
- 2-3 followers / followings — 別 PR
- Meilisearch エンジン側の調整

Closes #517
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/shiroha-a/mk/pull/518" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
