### PR TITLE
Fix pagination & response shape sweep across cursor-mode endpoints (#493)

### DIFF
--- a/internal/api/blocking/handler.go
+++ b/internal/api/blocking/handler.go
@@ -8,17 +8,24 @@ import (
 	"github.com/labstack/echo/v4"
 	"github.com/shiroha-a/mk/internal/api/apierr"
 	coreblocking "github.com/shiroha-a/mk/internal/core/blocking"
+	"github.com/shiroha-a/mk/internal/entity"
+	"github.com/shiroha-a/mk/internal/misc/id"
+	"github.com/shiroha-a/mk/internal/repository"
 	"github.com/shiroha-a/mk/internal/server/middleware"
 )
 
 // Handler handles blocking-related API endpoints.
 type Handler struct {
-	svc *coreblocking.Service
+	svc      *coreblocking.Service
+	userRepo repository.UserRepository
+	idGen    id.Generator
 }
 
 // NewHandler creates a new blocking Handler.
-func NewHandler(svc *coreblocking.Service) *Handler {
-	return &Handler{svc: svc}
+// userRepo / idGen are required by blocking/list to embed the
+// `blockee` user object that the upstream Misskey frontend renders.
+func NewHandler(svc *coreblocking.Service, userRepo repository.UserRepository, idGen id.Generator) *Handler {
+	return &Handler{svc: svc, userRepo: userRepo, idGen: idGen}
 }
 
 // PairRequest is the request body for blocking/create and blocking/delete.
@@ -69,11 +76,16 @@ func (h *Handler) Delete(c echo.Context) error {
 
 // ListRequest is the request body for blocking/list.
 type ListRequest struct {
-	Limit  int `json:"limit"`
-	Offset int `json:"offset"`
+	Limit   int    `json:"limit"`
+	Offset  int    `json:"offset"`
+	SinceID string `json:"sinceId"`
+	UntilID string `json:"untilId"`
 }
 
 // List handles POST /api/blocking/list.
+//
+// frontend Paginator (cursor mode) は untilId / sinceId を forward する。
+// 本 endpoint は #493 で cursor 対応に切り替えた。
 func (h *Handler) List(c echo.Context) error {
 	user := middleware.GetUser(c)
 	var req ListRequest
@@ -86,16 +98,32 @@ func (h *Handler) List(c echo.Context) error {
 	if req.Limit > 100 {
 		req.Limit = 100
 	}
-	rows, err := h.svc.List(user.ID, req.Limit, req.Offset)
+	rows, err := h.svc.List(user.ID, req.SinceID, req.UntilID, req.Limit, req.Offset)
 	if err != nil {
 		return apierr.JSONInternalError(c)
 	}
+	const tsFormat = "2006-01-02T15:04:05.000Z"
 	out := make([]map[string]any, 0, len(rows))
 	for _, b := range rows {
-		out = append(out, map[string]any{
+		createdAt := ""
+		if h.idGen != nil {
+			if t, err := h.idGen.ParseTime(b.ID); err == nil {
+				createdAt = t.UTC().Format(tsFormat)
+			}
+		}
+		entry := map[string]any{
 			"id":        b.ID,
+			"createdAt": createdAt,
 			"blockeeId": b.BlockeeID,
-		})
+		}
+		// upstream frontend が item.blockee で MkUserCardMini を描画する。
+		if h.userRepo != nil {
+			if u, err := h.userRepo.FindByID(b.BlockeeID); err == nil {
+				profile, _ := h.userRepo.FindProfileByUserID(u.ID)
+				entry["blockee"] = entity.PackUserDetailed(u, profile)
+			}
+		}
+		out = append(out, entry)
 	}
 	return c.JSON(http.StatusOK, out)
 }

--- a/internal/api/blocking/handler.go
+++ b/internal/api/blocking/handler.go
@@ -3,6 +3,7 @@ package blocking
 
 import (
 	"errors"
+	"log/slog"
 	"net/http"
 
 	"github.com/labstack/echo/v4"
@@ -147,7 +148,11 @@ func (h *Handler) fetchBlockeeMap(rows []*model.Blocking) map[string]entity.User
 	if err != nil {
 		return nil
 	}
-	profiles, _ := h.userRepo.FindProfilesByUserIDs(ids)
+	profiles, profErr := h.userRepo.FindProfilesByUserIDs(ids)
+	if profErr != nil {
+		// 部分結果を返す graceful degradation だが、log は残しておく。
+		slog.Warn("blocking/list: failed to fetch profiles", "error", profErr)
+	}
 	profileByUser := make(map[string]*model.UserProfile, len(profiles))
 	for _, p := range profiles {
 		profileByUser[p.UserID] = p

--- a/internal/api/blocking/handler.go
+++ b/internal/api/blocking/handler.go
@@ -10,6 +10,7 @@ import (
 	coreblocking "github.com/shiroha-a/mk/internal/core/blocking"
 	"github.com/shiroha-a/mk/internal/entity"
 	"github.com/shiroha-a/mk/internal/misc/id"
+	"github.com/shiroha-a/mk/internal/model"
 	"github.com/shiroha-a/mk/internal/repository"
 	"github.com/shiroha-a/mk/internal/server/middleware"
 )
@@ -102,6 +103,9 @@ func (h *Handler) List(c echo.Context) error {
 	if err != nil {
 		return apierr.JSONInternalError(c)
 	}
+	// upstream frontend が item.blockee で MkUserCardMini を描画するので
+	// batch fetch で N+1 を回避しつつ user object を embed する。
+	blockeeMap := h.fetchBlockeeMap(rows)
 	const tsFormat = "2006-01-02T15:04:05.000Z"
 	out := make([]map[string]any, 0, len(rows))
 	for _, b := range rows {
@@ -116,14 +120,41 @@ func (h *Handler) List(c echo.Context) error {
 			"createdAt": createdAt,
 			"blockeeId": b.BlockeeID,
 		}
-		// upstream frontend が item.blockee で MkUserCardMini を描画する。
-		if h.userRepo != nil {
-			if u, err := h.userRepo.FindByID(b.BlockeeID); err == nil {
-				profile, _ := h.userRepo.FindProfileByUserID(u.ID)
-				entry["blockee"] = entity.PackUserDetailed(u, profile)
-			}
+		if blockee, ok := blockeeMap[b.BlockeeID]; ok {
+			entry["blockee"] = blockee
 		}
 		out = append(out, entry)
 	}
 	return c.JSON(http.StatusOK, out)
+}
+
+// fetchBlockeeMap batches user + profile lookups for the blockee IDs in
+// rows so the response build loop performs zero per-row DB queries.
+func (h *Handler) fetchBlockeeMap(rows []*model.Blocking) map[string]entity.UserDetailed {
+	if h.userRepo == nil || len(rows) == 0 {
+		return nil
+	}
+	ids := make([]string, 0, len(rows))
+	seen := make(map[string]struct{}, len(rows))
+	for _, b := range rows {
+		if _, ok := seen[b.BlockeeID]; ok {
+			continue
+		}
+		seen[b.BlockeeID] = struct{}{}
+		ids = append(ids, b.BlockeeID)
+	}
+	users, err := h.userRepo.FindManyByIDs(ids)
+	if err != nil {
+		return nil
+	}
+	profiles, _ := h.userRepo.FindProfilesByUserIDs(ids)
+	profileByUser := make(map[string]*model.UserProfile, len(profiles))
+	for _, p := range profiles {
+		profileByUser[p.UserID] = p
+	}
+	out := make(map[string]entity.UserDetailed, len(users))
+	for _, u := range users {
+		out[u.ID] = entity.PackUserDetailed(u, profileByUser[u.ID], h.idGen)
+	}
+	return out
 }

--- a/internal/api/blocking/handler_test.go
+++ b/internal/api/blocking/handler_test.go
@@ -22,7 +22,7 @@ func newHandler(t *testing.T) (*Handler, *testutil.MockUserRepository) {
 	blockingRepo := testutil.NewMockBlockingRepository()
 	idGen, _ := id.NewGenerator("aidx")
 	svc := coreblocking.NewService(userRepo, blockingRepo, nil, idGen)
-	return NewHandler(svc, nil, nil), userRepo
+	return NewHandler(svc, userRepo, idGen), userRepo
 }
 
 func newReq(t *testing.T, body string) (echo.Context, *httptest.ResponseRecorder) {

--- a/internal/api/blocking/handler_test.go
+++ b/internal/api/blocking/handler_test.go
@@ -22,7 +22,7 @@ func newHandler(t *testing.T) (*Handler, *testutil.MockUserRepository) {
 	blockingRepo := testutil.NewMockBlockingRepository()
 	idGen, _ := id.NewGenerator("aidx")
 	svc := coreblocking.NewService(userRepo, blockingRepo, nil, idGen)
-	return NewHandler(svc), userRepo
+	return NewHandler(svc, nil, nil), userRepo
 }
 
 func newReq(t *testing.T, body string) (echo.Context, *httptest.ResponseRecorder) {
@@ -116,7 +116,7 @@ func TestCreate_RepoError(t *testing.T) {
 	addUser(userRepo, "bob")
 	idGen, _ := id.NewGenerator("aidx")
 	svc := coreblocking.NewService(userRepo, &failingBlockingRepo{MockBlockingRepository: testutil.NewMockBlockingRepository()}, nil, idGen)
-	h := NewHandler(svc)
+	h := NewHandler(svc, nil, nil)
 
 	c, rec := newReq(t, `{"userId":"bob"}`)
 	setUser(c, "alice")
@@ -179,7 +179,7 @@ func TestDelete_RepoError(t *testing.T) {
 	mock.Blockings["b1"] = &model.Blocking{ID: "b1", BlockerID: "alice", BlockeeID: "bob"}
 	idGen, _ := id.NewGenerator("aidx")
 	svc := coreblocking.NewService(userRepo, &failingDeleteBlockingRepo{MockBlockingRepository: mock}, nil, idGen)
-	h := NewHandler(svc)
+	h := NewHandler(svc, nil, nil)
 
 	c, rec := newReq(t, `{"userId":"bob"}`)
 	setUser(c, "alice")
@@ -222,7 +222,7 @@ type failingListBlockingRepo struct {
 	*testutil.MockBlockingRepository
 }
 
-func (f *failingListBlockingRepo) ListByBlocker(_ string, _, _ int) ([]*model.Blocking, error) {
+func (f *failingListBlockingRepo) ListByBlocker(_, _, _ string, _, _ int) ([]*model.Blocking, error) {
 	return nil, testutil.ErrNotFound
 }
 
@@ -230,7 +230,7 @@ func TestList_RepoError(t *testing.T) {
 	userRepo := testutil.NewMockUserRepository()
 	idGen, _ := id.NewGenerator("aidx")
 	svc := coreblocking.NewService(userRepo, &failingListBlockingRepo{MockBlockingRepository: testutil.NewMockBlockingRepository()}, nil, idGen)
-	h := NewHandler(svc)
+	h := NewHandler(svc, nil, nil)
 
 	c, rec := newReq(t, `{}`)
 	setUser(c, "alice")

--- a/internal/api/channels/handler.go
+++ b/internal/api/channels/handler.go
@@ -209,20 +209,25 @@ func (h *Handler) Unfollow(c echo.Context) error {
 }
 
 // PaginatedListRequest is shared by followed / owned / featured / search /
-// timeline endpoints.
+// timeline endpoints. frontend Paginator は cursor mode で sinceId / untilId
+// を投げてくる (#493)。
 type PaginatedListRequest struct {
-	Limit  int `json:"limit"`
-	Offset int `json:"offset"`
+	Limit   int    `json:"limit"`
+	Offset  int    `json:"offset"`
+	SinceID string `json:"sinceId"`
+	UntilID string `json:"untilId"`
 }
 
 // Followed handles POST /api/channels/followed.
+//
+// channel_following.id を cursor として frontend Paginator から受ける。
 func (h *Handler) Followed(c echo.Context) error {
 	user := middleware.GetUser(c)
 	var req PaginatedListRequest
 	if err := c.Bind(&req); err != nil {
 		return apierr.JSONInvalidParam(c)
 	}
-	rows, err := h.svc.ListFollowed(user.ID, req.Limit, req.Offset)
+	rows, err := h.svc.ListFollowed(user.ID, req.SinceID, req.UntilID, req.Limit, req.Offset)
 	if err != nil {
 		return apierr.JSONInternalError(c)
 	}
@@ -236,7 +241,7 @@ func (h *Handler) Owned(c echo.Context) error {
 	if err := c.Bind(&req); err != nil {
 		return apierr.JSONInvalidParam(c)
 	}
-	rows, err := h.svc.ListOwned(user.ID, req.Limit, req.Offset)
+	rows, err := h.svc.ListOwned(user.ID, req.SinceID, req.UntilID, req.Limit, req.Offset)
 	if err != nil {
 		return apierr.JSONInternalError(c)
 	}
@@ -249,7 +254,7 @@ func (h *Handler) Featured(c echo.Context) error {
 	if err := c.Bind(&req); err != nil {
 		return apierr.JSONInvalidParam(c)
 	}
-	rows, err := h.svc.ListFeatured(req.Limit, req.Offset)
+	rows, err := h.svc.ListFeatured(req.SinceID, req.UntilID, req.Limit, req.Offset)
 	if err != nil {
 		return apierr.JSONInternalError(c)
 	}
@@ -258,9 +263,11 @@ func (h *Handler) Featured(c echo.Context) error {
 
 // SearchRequest carries the query string for channels/search.
 type SearchRequest struct {
-	Query  string `json:"query"`
-	Limit  int    `json:"limit"`
-	Offset int    `json:"offset"`
+	Query   string `json:"query"`
+	Limit   int    `json:"limit"`
+	Offset  int    `json:"offset"`
+	SinceID string `json:"sinceId"`
+	UntilID string `json:"untilId"`
 }
 
 // Search handles POST /api/channels/search.
@@ -269,7 +276,7 @@ func (h *Handler) Search(c echo.Context) error {
 	if err := c.Bind(&req); err != nil {
 		return apierr.JSONInvalidParam(c)
 	}
-	rows, err := h.svc.Search(req.Query, req.Limit, req.Offset)
+	rows, err := h.svc.Search(req.Query, req.SinceID, req.UntilID, req.Limit, req.Offset)
 	if err != nil {
 		return apierr.JSONInternalError(c)
 	}

--- a/internal/api/channels/handler.go
+++ b/internal/api/channels/handler.go
@@ -220,7 +220,10 @@ type PaginatedListRequest struct {
 
 // Followed handles POST /api/channels/followed.
 //
-// channel_following.id を cursor として frontend Paginator から受ける。
+// frontend Paginator は response item の id (= channel.id = followeeId)
+// を cursor として送ってくる。repository.ListFollowed 側で followeeId を
+// cursor 列として使うことで domain mismatch を避けている。詳細は
+// channel_following.go:ListFollowed の comment 参照。
 func (h *Handler) Followed(c echo.Context) error {
 	user := middleware.GetUser(c)
 	var req PaginatedListRequest

--- a/internal/api/channels/handler_test.go
+++ b/internal/api/channels/handler_test.go
@@ -342,7 +342,7 @@ type listFailFollowRepo struct {
 	*testutil.MockChannelFollowingRepository
 }
 
-func (r *listFailFollowRepo) ListFollowed(_ string, _, _ int) ([]*model.ChannelFollowing, error) {
+func (r *listFailFollowRepo) ListFollowed(_, _, _ string, _, _ int) ([]*model.ChannelFollowing, error) {
 	return nil, errors.New("boom")
 }
 

--- a/internal/api/federation/handler.go
+++ b/internal/api/federation/handler.go
@@ -57,9 +57,13 @@ type InstancesRequest struct {
 	Sort          string `json:"sort"`
 	Limit         int    `json:"limit"`
 	Offset        int    `json:"offset"`
+	SinceID       string `json:"sinceId"`
+	UntilID       string `json:"untilId"`
 }
 
 // Instances handles POST /api/federation/instances.
+//
+// frontend Paginator (cursor mode) は untilId / sinceId を forward する (#493)。
 func (h *Handler) Instances(c echo.Context) error {
 	var req InstancesRequest
 	if err := c.Bind(&req); err != nil {
@@ -75,6 +79,8 @@ func (h *Handler) Instances(c echo.Context) error {
 		SortBy:        req.Sort,
 		Limit:         req.Limit,
 		Offset:        req.Offset,
+		SinceID:       req.SinceID,
+		UntilID:       req.UntilID,
 	}
 	rows, err := h.svc.List(filter)
 	if err != nil {

--- a/internal/api/flash/handler.go
+++ b/internal/api/flash/handler.go
@@ -308,11 +308,15 @@ func flashToMap(f *model.Flash) map[string]any {
 func (h *Handler) flashWithKnownUser(f *model.Flash, owner *model.User) map[string]any {
 	const tsFormat = "2006-01-02T15:04:05.000Z"
 	entry := flashToMap(f)
+	createdAt := ""
 	if h.idGen != nil {
 		if t, err := h.idGen.ParseTime(f.ID); err == nil {
-			entry["createdAt"] = t.UTC().Format(tsFormat)
+			createdAt = t.UTC().Format(tsFormat)
 		}
 	}
+	// flashesToListWithUser と同じく nil/error 時も "" でフィールドを必ず
+	// 残す。frontend が `if (item.createdAt)` する場合のため (#520 review)。
+	entry["createdAt"] = createdAt
 	if owner != nil && owner.ID == f.UserID {
 		entry["user"] = entity.PackUserLite(owner)
 	}

--- a/internal/api/flash/handler.go
+++ b/internal/api/flash/handler.go
@@ -57,7 +57,7 @@ func (h *Handler) Create(c echo.Context) error {
 	if err != nil {
 		return apierr.JSONInternalError(c)
 	}
-	return c.JSON(http.StatusOK, flashToMap(f))
+	return c.JSON(http.StatusOK, h.flashesToListWithUser([]*model.Flash{f})[0])
 }
 
 // ShowRequest is the request body for flash/show.
@@ -128,7 +128,7 @@ func (h *Handler) Update(c echo.Context) error {
 		}
 		return apierr.JSONInternalError(c)
 	}
-	return c.JSON(http.StatusOK, flashToMap(f))
+	return c.JSON(http.StatusOK, h.flashesToListWithUser([]*model.Flash{f})[0])
 }
 
 // DeleteRequest is the request body for flash/delete.

--- a/internal/api/flash/handler.go
+++ b/internal/api/flash/handler.go
@@ -288,9 +288,10 @@ func (h *Handler) MyLikes(c echo.Context) error {
 }
 
 func flashToMap(f *model.Flash) map[string]any {
+	const tsFormat = "2006-01-02T15:04:05.000Z"
 	return map[string]any{
 		"id":          f.ID,
-		"updatedAt":   f.UpdatedAt,
+		"updatedAt":   f.UpdatedAt.UTC().Format(tsFormat),
 		"title":       f.Title,
 		"summary":     f.Summary,
 		"userId":      f.UserID,
@@ -305,9 +306,11 @@ func flashToMap(f *model.Flash) map[string]any {
 // (UserLite) and ISO-formatted `createdAt`, matching upstream Misskey TS
 // FlashEntityService output. The frontend Play page reads `flash.user`
 // for display so a missing user object causes empty card render.
+//
+// User lookups are deduped by author and fetched in a single FindManyByIDs
+// call to avoid the N+1 pattern.
 func (h *Handler) flashesToListWithUser(rows []*model.Flash) []map[string]any {
 	const tsFormat = "2006-01-02T15:04:05.000Z"
-	// Avoid N+1 by batching user lookups.
 	userIDs := make([]string, 0, len(rows))
 	seen := make(map[string]struct{}, len(rows))
 	for _, f := range rows {
@@ -318,10 +321,10 @@ func (h *Handler) flashesToListWithUser(rows []*model.Flash) []map[string]any {
 		userIDs = append(userIDs, f.UserID)
 	}
 	userByID := make(map[string]*model.User, len(userIDs))
-	if h.userRepo != nil {
-		for _, uid := range userIDs {
-			if u, err := h.userRepo.FindByID(uid); err == nil {
-				userByID[uid] = u
+	if h.userRepo != nil && len(userIDs) > 0 {
+		if users, err := h.userRepo.FindManyByIDs(userIDs); err == nil {
+			for _, u := range users {
+				userByID[u.ID] = u
 			}
 		}
 	}
@@ -335,7 +338,6 @@ func (h *Handler) flashesToListWithUser(rows []*model.Flash) []map[string]any {
 			}
 		}
 		entry["createdAt"] = createdAt
-		entry["updatedAt"] = f.UpdatedAt.UTC().Format(tsFormat)
 		if u, ok := userByID[f.UserID]; ok {
 			entry["user"] = entity.PackUserLite(u)
 		}

--- a/internal/api/flash/handler.go
+++ b/internal/api/flash/handler.go
@@ -8,18 +8,26 @@ import (
 	"github.com/labstack/echo/v4"
 	"github.com/shiroha-a/mk/internal/api/apierr"
 	coreflash "github.com/shiroha-a/mk/internal/core/flash"
+	"github.com/shiroha-a/mk/internal/entity"
+	"github.com/shiroha-a/mk/internal/misc/id"
 	"github.com/shiroha-a/mk/internal/model"
+	"github.com/shiroha-a/mk/internal/repository"
 	"github.com/shiroha-a/mk/internal/server/middleware"
 )
 
 // Handler handles flash-related API endpoints.
 type Handler struct {
-	svc *coreflash.Service
+	svc      *coreflash.Service
+	userRepo repository.UserRepository
+	idGen    id.Generator
 }
 
 // NewHandler creates a new flash Handler.
-func NewHandler(svc *coreflash.Service) *Handler {
-	return &Handler{svc: svc}
+// userRepo / idGen are required by list endpoints to embed the
+// `user` (UserLite) and `createdAt` fields that the upstream Misskey
+// frontend expects when rendering Play (Flash) cards.
+func NewHandler(svc *coreflash.Service, userRepo repository.UserRepository, idGen id.Generator) *Handler {
+	return &Handler{svc: svc, userRepo: userRepo, idGen: idGen}
 }
 
 // CreateRequest is the request body for flash/create.
@@ -58,6 +66,9 @@ type ShowRequest struct {
 }
 
 // Show handles POST /api/flash/show.
+//
+// frontend MkPlay.vue は user / createdAt / isLiked を読んでカード描画
+// および「いいね」ボタン状態を決めるので、handler 側で embed する。
 func (h *Handler) Show(c echo.Context) error {
 	user := middleware.GetUser(c)
 	var req ShowRequest
@@ -72,7 +83,14 @@ func (h *Handler) Show(c echo.Context) error {
 	if err != nil {
 		return notFound(c)
 	}
-	return c.JSON(http.StatusOK, flashToMap(f))
+	resp := h.flashesToListWithUser([]*model.Flash{f})[0]
+	if user != nil {
+		liked, err := h.svc.IsLikedBy(user.ID, f.ID)
+		if err == nil {
+			resp["isLiked"] = liked
+		}
+	}
+	return c.JSON(http.StatusOK, resp)
 }
 
 // UpdateRequest is the request body for flash/update.
@@ -139,29 +157,35 @@ func (h *Handler) Delete(c echo.Context) error {
 
 // PaginationRequest is the shared body for list-style endpoints.
 type PaginationRequest struct {
-	Limit  int `json:"limit"`
-	Offset int `json:"offset"`
+	Limit   int    `json:"limit"`
+	Offset  int    `json:"offset"`
+	SinceID string `json:"sinceId"`
+	UntilID string `json:"untilId"`
 }
 
 // SearchRequest is the request body for flash/search.
 type SearchRequest struct {
-	Query  string `json:"query"`
-	Limit  int    `json:"limit"`
-	Offset int    `json:"offset"`
+	Query   string `json:"query"`
+	Limit   int    `json:"limit"`
+	Offset  int    `json:"offset"`
+	SinceID string `json:"sinceId"`
+	UntilID string `json:"untilId"`
 }
 
 // My handles POST /api/i/flashs and POST /api/flash/my (own list).
+//
+// frontend Paginator (cursor mode) は untilId / sinceId を forward する (#493)。
 func (h *Handler) My(c echo.Context) error {
 	user := middleware.GetUser(c)
 	var req PaginationRequest
 	if err := c.Bind(&req); err != nil {
 		return apierr.JSONInvalidParam(c)
 	}
-	rows, err := h.svc.My(user.ID, req.Limit, req.Offset)
+	rows, err := h.svc.My(user.ID, req.SinceID, req.UntilID, req.Limit, req.Offset)
 	if err != nil {
 		return apierr.JSONInternalError(c)
 	}
-	return c.JSON(http.StatusOK, flashesToList(rows))
+	return c.JSON(http.StatusOK, h.flashesToListWithUser(rows))
 }
 
 // Featured handles POST /api/flash/featured.
@@ -170,11 +194,11 @@ func (h *Handler) Featured(c echo.Context) error {
 	if err := c.Bind(&req); err != nil {
 		return apierr.JSONInvalidParam(c)
 	}
-	rows, err := h.svc.Featured(req.Limit, req.Offset)
+	rows, err := h.svc.Featured(req.SinceID, req.UntilID, req.Limit, req.Offset)
 	if err != nil {
 		return apierr.JSONInternalError(c)
 	}
-	return c.JSON(http.StatusOK, flashesToList(rows))
+	return c.JSON(http.StatusOK, h.flashesToListWithUser(rows))
 }
 
 // Search handles POST /api/flash/search.
@@ -183,11 +207,11 @@ func (h *Handler) Search(c echo.Context) error {
 	if err := c.Bind(&req); err != nil || req.Query == "" {
 		return apierr.JSONInvalidParam(c)
 	}
-	rows, err := h.svc.Search(req.Query, req.Limit, req.Offset)
+	rows, err := h.svc.Search(req.Query, req.SinceID, req.UntilID, req.Limit, req.Offset)
 	if err != nil {
 		return apierr.JSONInternalError(c)
 	}
-	return c.JSON(http.StatusOK, flashesToList(rows))
+	return c.JSON(http.StatusOK, h.flashesToListWithUser(rows))
 }
 
 // LikeRequest is the request body for flash/like and flash/unlike.
@@ -233,26 +257,34 @@ func (h *Handler) Unlike(c echo.Context) error {
 	return c.NoContent(http.StatusNoContent)
 }
 
-// MyLikes handles POST /api/i/flashs/likes.
+// MyLikes handles POST /api/flash/my-likes.
+//
+// upstream Misskey TS は `{id, flash: Flash}` を返す (id = flash_like
+// row id, frontend は it.flash で MkPlayPreview を描画)。mk-go は元々
+// flatten された Flash 配列を返しており frontend が空表示になっていた。
 func (h *Handler) MyLikes(c echo.Context) error {
 	user := middleware.GetUser(c)
 	var req PaginationRequest
 	if err := c.Bind(&req); err != nil {
 		return apierr.JSONInvalidParam(c)
 	}
-	rows, err := h.svc.MyLikes(user.ID, req.Limit, req.Offset)
+	pairs, err := h.svc.MyLikes(user.ID, req.SinceID, req.UntilID, req.Limit, req.Offset)
 	if err != nil {
 		return apierr.JSONInternalError(c)
 	}
-	return c.JSON(http.StatusOK, flashesToList(rows))
-}
-
-func flashesToList(rows []*model.Flash) []map[string]any {
-	out := make([]map[string]any, 0, len(rows))
-	for _, f := range rows {
-		out = append(out, flashToMap(f))
+	flashes := make([]*model.Flash, 0, len(pairs))
+	for _, p := range pairs {
+		flashes = append(flashes, p.Flash)
 	}
-	return out
+	packed := h.flashesToListWithUser(flashes)
+	out := make([]map[string]any, 0, len(pairs))
+	for i, p := range pairs {
+		out = append(out, map[string]any{
+			"id":    p.LikeID,
+			"flash": packed[i],
+		})
+	}
+	return c.JSON(http.StatusOK, out)
 }
 
 func flashToMap(f *model.Flash) map[string]any {
@@ -267,6 +299,49 @@ func flashToMap(f *model.Flash) map[string]any {
 		"likedCount":  f.LikedCount,
 		"visibility":  f.Visibility,
 	}
+}
+
+// flashesToListWithUser packs flashes including the embedded `user`
+// (UserLite) and ISO-formatted `createdAt`, matching upstream Misskey TS
+// FlashEntityService output. The frontend Play page reads `flash.user`
+// for display so a missing user object causes empty card render.
+func (h *Handler) flashesToListWithUser(rows []*model.Flash) []map[string]any {
+	const tsFormat = "2006-01-02T15:04:05.000Z"
+	// Avoid N+1 by batching user lookups.
+	userIDs := make([]string, 0, len(rows))
+	seen := make(map[string]struct{}, len(rows))
+	for _, f := range rows {
+		if _, ok := seen[f.UserID]; ok {
+			continue
+		}
+		seen[f.UserID] = struct{}{}
+		userIDs = append(userIDs, f.UserID)
+	}
+	userByID := make(map[string]*model.User, len(userIDs))
+	if h.userRepo != nil {
+		for _, uid := range userIDs {
+			if u, err := h.userRepo.FindByID(uid); err == nil {
+				userByID[uid] = u
+			}
+		}
+	}
+	out := make([]map[string]any, 0, len(rows))
+	for _, f := range rows {
+		entry := flashToMap(f)
+		createdAt := ""
+		if h.idGen != nil {
+			if t, err := h.idGen.ParseTime(f.ID); err == nil {
+				createdAt = t.UTC().Format(tsFormat)
+			}
+		}
+		entry["createdAt"] = createdAt
+		entry["updatedAt"] = f.UpdatedAt.UTC().Format(tsFormat)
+		if u, ok := userByID[f.UserID]; ok {
+			entry["user"] = entity.PackUserLite(u)
+		}
+		out = append(out, entry)
+	}
+	return out
 }
 
 func notFound(c echo.Context) error {

--- a/internal/api/flash/handler.go
+++ b/internal/api/flash/handler.go
@@ -57,7 +57,7 @@ func (h *Handler) Create(c echo.Context) error {
 	if err != nil {
 		return apierr.JSONInternalError(c)
 	}
-	return c.JSON(http.StatusOK, h.flashesToListWithUser([]*model.Flash{f})[0])
+	return c.JSON(http.StatusOK, h.flashWithKnownUser(f, user))
 }
 
 // ShowRequest is the request body for flash/show.
@@ -128,7 +128,7 @@ func (h *Handler) Update(c echo.Context) error {
 		}
 		return apierr.JSONInternalError(c)
 	}
-	return c.JSON(http.StatusOK, h.flashesToListWithUser([]*model.Flash{f})[0])
+	return c.JSON(http.StatusOK, h.flashWithKnownUser(f, user))
 }
 
 // DeleteRequest is the request body for flash/delete.
@@ -300,6 +300,23 @@ func flashToMap(f *model.Flash) map[string]any {
 		"likedCount":  f.LikedCount,
 		"visibility":  f.Visibility,
 	}
+}
+
+// flashWithKnownUser packs a single flash whose author is already in scope
+// (typically the authenticated user from middleware on Create / Update).
+// Saves one FindManyByIDs round-trip vs flashesToListWithUser.
+func (h *Handler) flashWithKnownUser(f *model.Flash, owner *model.User) map[string]any {
+	const tsFormat = "2006-01-02T15:04:05.000Z"
+	entry := flashToMap(f)
+	if h.idGen != nil {
+		if t, err := h.idGen.ParseTime(f.ID); err == nil {
+			entry["createdAt"] = t.UTC().Format(tsFormat)
+		}
+	}
+	if owner != nil && owner.ID == f.UserID {
+		entry["user"] = entity.PackUserLite(owner)
+	}
+	return entry
 }
 
 // flashesToListWithUser packs flashes including the embedded `user`

--- a/internal/api/flash/handler_test.go
+++ b/internal/api/flash/handler_test.go
@@ -23,7 +23,7 @@ func newHandler(t *testing.T) (*Handler, *testutil.MockFlashRepository, *testuti
 	likeRepo := testutil.NewMockFlashLikeRepository()
 	idGen, _ := id.NewGenerator("aidx")
 	svc := coreflash.NewService(repo, likeRepo, idGen)
-	return NewHandler(svc), repo, likeRepo
+	return NewHandler(svc, nil, nil), repo, likeRepo
 }
 
 func newReq(t *testing.T, body string) (echo.Context, *httptest.ResponseRecorder) {
@@ -85,7 +85,7 @@ func TestCreate_RepoError(t *testing.T) {
 	repo := &failingFlashRepo{MockFlashRepository: mock}
 	idGen, _ := id.NewGenerator("aidx")
 	svc := coreflash.NewService(repo, testutil.NewMockFlashLikeRepository(), idGen)
-	h := NewHandler(svc)
+	h := NewHandler(svc, nil, nil)
 	c, rec := newReq(t, `{"title":"t","script":"x"}`)
 	setUser(c, "alice")
 	require.NoError(t, h.Create(c))
@@ -185,7 +185,7 @@ func TestUpdate_RepoError(t *testing.T) {
 	repo := &failingUpdateRepo{MockFlashRepository: mock}
 	idGen, _ := id.NewGenerator("aidx")
 	svc := coreflash.NewService(repo, testutil.NewMockFlashLikeRepository(), idGen)
-	h := NewHandler(svc)
+	h := NewHandler(svc, nil, nil)
 	c, rec := newReq(t, `{"flashId":"f1","title":"x"}`)
 	setUser(c, "alice")
 	require.NoError(t, h.Update(c))
@@ -241,7 +241,7 @@ func TestDelete_RepoError(t *testing.T) {
 	repo := &failingDeleteRepo{MockFlashRepository: mock}
 	idGen, _ := id.NewGenerator("aidx")
 	svc := coreflash.NewService(repo, testutil.NewMockFlashLikeRepository(), idGen)
-	h := NewHandler(svc)
+	h := NewHandler(svc, nil, nil)
 	c, rec := newReq(t, `{"flashId":"f1"}`)
 	setUser(c, "alice")
 	require.NoError(t, h.Delete(c))
@@ -273,7 +273,7 @@ type listFailRepo struct {
 	*testutil.MockFlashRepository
 }
 
-func (r *listFailRepo) ListByUser(_ string, _, _ int) ([]*model.Flash, error) {
+func (r *listFailRepo) ListByUser(_, _, _ string, _, _ int) ([]*model.Flash, error) {
 	return nil, errors.New("boom")
 }
 
@@ -281,7 +281,7 @@ func TestMy_RepoError(t *testing.T) {
 	repo := &listFailRepo{MockFlashRepository: testutil.NewMockFlashRepository()}
 	idGen, _ := id.NewGenerator("aidx")
 	svc := coreflash.NewService(repo, testutil.NewMockFlashLikeRepository(), idGen)
-	h := NewHandler(svc)
+	h := NewHandler(svc, nil, nil)
 	c, rec := newReq(t, `{}`)
 	setUser(c, "alice")
 	require.NoError(t, h.My(c))
@@ -310,7 +310,7 @@ type featuredFailRepo struct {
 	*testutil.MockFlashRepository
 }
 
-func (r *featuredFailRepo) ListFeatured(_, _ int) ([]*model.Flash, error) {
+func (r *featuredFailRepo) ListFeatured(_, _ string, _, _ int) ([]*model.Flash, error) {
 	return nil, errors.New("boom")
 }
 
@@ -318,7 +318,7 @@ func TestFeatured_RepoError(t *testing.T) {
 	repo := &featuredFailRepo{MockFlashRepository: testutil.NewMockFlashRepository()}
 	idGen, _ := id.NewGenerator("aidx")
 	svc := coreflash.NewService(repo, testutil.NewMockFlashLikeRepository(), idGen)
-	h := NewHandler(svc)
+	h := NewHandler(svc, nil, nil)
 	c, rec := newReq(t, `{}`)
 	require.NoError(t, h.Featured(c))
 	assert.Equal(t, http.StatusInternalServerError, rec.Code)
@@ -353,7 +353,7 @@ type searchFailRepo struct {
 	*testutil.MockFlashRepository
 }
 
-func (r *searchFailRepo) Search(_ string, _, _ int) ([]*model.Flash, error) {
+func (r *searchFailRepo) Search(_, _, _ string, _, _ int) ([]*model.Flash, error) {
 	return nil, errors.New("boom")
 }
 
@@ -361,7 +361,7 @@ func TestSearch_RepoError(t *testing.T) {
 	repo := &searchFailRepo{MockFlashRepository: testutil.NewMockFlashRepository()}
 	idGen, _ := id.NewGenerator("aidx")
 	svc := coreflash.NewService(repo, testutil.NewMockFlashLikeRepository(), idGen)
-	h := NewHandler(svc)
+	h := NewHandler(svc, nil, nil)
 	c, rec := newReq(t, `{"query":"x"}`)
 	require.NoError(t, h.Search(c))
 	assert.Equal(t, http.StatusInternalServerError, rec.Code)
@@ -421,7 +421,7 @@ func TestLike_RepoError(t *testing.T) {
 	likeRepo := &failingCreateLikeRepo{MockFlashLikeRepository: testutil.NewMockFlashLikeRepository()}
 	idGen, _ := id.NewGenerator("aidx")
 	svc := coreflash.NewService(repo, likeRepo, idGen)
-	h := NewHandler(svc)
+	h := NewHandler(svc, nil, nil)
 	c, rec := newReq(t, `{"flashId":"f1"}`)
 	setUser(c, "bob")
 	require.NoError(t, h.Like(c))
@@ -484,7 +484,7 @@ func TestUnlike_RepoError(t *testing.T) {
 	likeRepo := &failingDeleteLikeRepo{MockFlashLikeRepository: mock}
 	idGen, _ := id.NewGenerator("aidx")
 	svc := coreflash.NewService(repo, likeRepo, idGen)
-	h := NewHandler(svc)
+	h := NewHandler(svc, nil, nil)
 	c, rec := newReq(t, `{"flashId":"f1"}`)
 	setUser(c, "bob")
 	require.NoError(t, h.Unlike(c))
@@ -520,7 +520,7 @@ type myLikesFailRepo struct {
 	*testutil.MockFlashLikeRepository
 }
 
-func (r *myLikesFailRepo) ListByUser(_ string, _, _ int) ([]*model.FlashLike, error) {
+func (r *myLikesFailRepo) ListByUser(_, _, _ string, _, _ int) ([]*model.FlashLike, error) {
 	return nil, errors.New("boom")
 }
 
@@ -529,7 +529,7 @@ func TestMyLikes_RepoError(t *testing.T) {
 	likeRepo := &myLikesFailRepo{MockFlashLikeRepository: testutil.NewMockFlashLikeRepository()}
 	idGen, _ := id.NewGenerator("aidx")
 	svc := coreflash.NewService(repo, likeRepo, idGen)
-	h := NewHandler(svc)
+	h := NewHandler(svc, nil, nil)
 	c, rec := newReq(t, `{}`)
 	setUser(c, "bob")
 	require.NoError(t, h.MyLikes(c))

--- a/internal/api/gallery/handler.go
+++ b/internal/api/gallery/handler.go
@@ -55,6 +55,9 @@ func (h *Handler) Posts(c echo.Context) error {
 	if req.Limit <= 0 {
 		req.Limit = 10
 	}
+	if req.Limit > 100 {
+		req.Limit = 100
+	}
 	q := h.db.Preload("User")
 	if req.SinceID != "" {
 		q = q.Where("id > ?", req.SinceID)

--- a/internal/api/gallery/handler.go
+++ b/internal/api/gallery/handler.go
@@ -39,10 +39,15 @@ func (h *Handler) Popular(c echo.Context) error {
 }
 
 // Posts handles POST /api/gallery/posts.
+//
+// frontend Paginator (cursor mode) は untilId / sinceId を投げてくる。
+// id 範囲フィルタ + paginationOrder 同等の ASC/DESC を直接組み立てる。
 func (h *Handler) Posts(c echo.Context) error {
 	var req struct {
-		Limit  int `json:"limit"`
-		Offset int `json:"offset"`
+		Limit   int    `json:"limit"`
+		Offset  int    `json:"offset"`
+		SinceID string `json:"sinceId"`
+		UntilID string `json:"untilId"`
 	}
 	if err := c.Bind(&req); err != nil {
 		return c.JSON(http.StatusBadRequest, apierr.Error("INVALID_PARAM", "Invalid parameters.", "3d81ceae-475f-4600-b2a8-2bc116157532"))
@@ -50,8 +55,20 @@ func (h *Handler) Posts(c echo.Context) error {
 	if req.Limit <= 0 {
 		req.Limit = 10
 	}
-	q := h.db.Preload("User").Order("id DESC").Limit(req.Limit)
-	if req.Offset > 0 {
+	q := h.db.Preload("User")
+	if req.SinceID != "" {
+		q = q.Where("id > ?", req.SinceID)
+	}
+	if req.UntilID != "" {
+		q = q.Where("id < ?", req.UntilID)
+	}
+	if req.SinceID != "" && req.UntilID == "" {
+		q = q.Order("id ASC")
+	} else {
+		q = q.Order("id DESC")
+	}
+	q = q.Limit(req.Limit)
+	if req.SinceID == "" && req.UntilID == "" && req.Offset > 0 {
 		q = q.Offset(req.Offset)
 	}
 	var posts []*model.GalleryPost

--- a/internal/api/i/handler.go
+++ b/internal/api/i/handler.go
@@ -161,8 +161,9 @@ type ChatUnreadSource interface {
 // the i/gallery/* endpoints. Kept as a handler-local alias so we can
 // swap implementations in tests without pulling the full repository.
 type GalleryRepository interface {
-	ListByUser(userID string, limit, offset int) ([]*model.GalleryPost, error)
-	ListLikesByUser(userID string, limit, offset int) ([]*model.GalleryLike, error)
+	ListByUser(userID, sinceID, untilID string, limit, offset int) ([]*model.GalleryPost, error)
+	ListLikesByUser(userID, sinceID, untilID string, limit, offset int) ([]*model.GalleryLike, error)
+	FindPostsByIDs(ids []string) ([]*model.GalleryPost, error)
 }
 
 // SetAccessTokenRepo wires the access_token repo for i/authorized-apps and

--- a/internal/api/i/handler_stubs.go
+++ b/internal/api/i/handler_stubs.go
@@ -410,11 +410,17 @@ func (h *Handler) GalleryLikes(c echo.Context) error {
 	}
 	out := make([]map[string]any, 0, len(likes))
 	for _, l := range likes {
-		entry := map[string]any{"id": l.ID}
-		if p, ok := postByID[l.PostID]; ok {
-			entry["post"] = packGalleryPost(p, h.idGen)
+		// upstream Misskey TS は post が削除済の like row を Promise.all
+		// + pack の null フィルタで弾く。frontend の MkGalleryPostPreview
+		// も it.post 必須なので、ここで skip して整合させる。
+		p, ok := postByID[l.PostID]
+		if !ok {
+			continue
 		}
-		out = append(out, entry)
+		out = append(out, map[string]any{
+			"id":   l.ID,
+			"post": packGalleryPost(p, h.idGen),
+		})
 	}
 	return c.JSON(http.StatusOK, out)
 }
@@ -462,25 +468,7 @@ func (h *Handler) GalleryPosts(c echo.Context) error {
 	}
 	out := make([]map[string]any, 0, len(posts))
 	for _, p := range posts {
-		entry := map[string]any{
-			"id":          p.ID,
-			"updatedAt":   p.UpdatedAt,
-			"title":       p.Title,
-			"description": p.Description,
-			"userId":      p.UserID,
-			"fileIds":     []string(p.FileIDs),
-			// files は既存の gallery packOne と揃えて空配列を返す
-			// (フロントが post.files を前提にするため undefined を避ける)。
-			// 将来 gallery/posts と同じ展開ロジックを共通化する可能性あり。
-			"files":       []any{},
-			"isSensitive": p.IsSensitive,
-			"likedCount":  p.LikedCount,
-			"tags":        []string(p.Tags),
-		}
-		if t, err := h.idGen.ParseTime(p.ID); err == nil {
-			entry["createdAt"] = t.UTC().Format("2006-01-02T15:04:05.000Z")
-		}
-		out = append(out, entry)
+		out = append(out, packGalleryPost(p, h.idGen))
 	}
 	return c.JSON(http.StatusOK, out)
 }

--- a/internal/api/i/handler_stubs.go
+++ b/internal/api/i/handler_stubs.go
@@ -397,7 +397,12 @@ func (h *Handler) GalleryLikes(c echo.Context) error {
 		return apierr.JSONInternalError(c)
 	}
 	postIDs := make([]string, 0, len(likes))
+	seen := make(map[string]struct{}, len(likes))
 	for _, l := range likes {
+		if _, ok := seen[l.PostID]; ok {
+			continue
+		}
+		seen[l.PostID] = struct{}{}
 		postIDs = append(postIDs, l.PostID)
 	}
 	posts, err := h.galleryRepo.FindPostsByIDs(postIDs)

--- a/internal/api/i/handler_stubs.go
+++ b/internal/api/i/handler_stubs.go
@@ -12,6 +12,9 @@ import (
 	"github.com/shiroha-a/mk/internal/api/apierr"
 	coreemail "github.com/shiroha-a/mk/internal/core/email"
 	"github.com/shiroha-a/mk/internal/core/move"
+	"github.com/shiroha-a/mk/internal/entity"
+	"github.com/shiroha-a/mk/internal/misc/id"
+	"github.com/shiroha-a/mk/internal/model"
 	"github.com/shiroha-a/mk/internal/server/middleware"
 	"golang.org/x/crypto/bcrypt"
 )
@@ -347,12 +350,16 @@ func (h *Handler) Move(c echo.Context) error {
 	}
 }
 
-// paginationFromRequest reads optional limit / offset JSON fields, with
-// Misskey-friendly defaults (limit=10, offset=0, limit clamped to 100).
-func paginationFromRequest(c echo.Context) (limit, offset int) {
+// paginationFromRequest reads optional limit / offset / sinceId / untilId
+// JSON fields, with Misskey-friendly defaults (limit=10, offset=0,
+// limit clamped to 100). Cursor 指定時は frontend Paginator が untilId
+// / sinceId を投げてくる経路 (#493)。
+func paginationFromRequest(c echo.Context) (limit, offset int, sinceID, untilID string) {
 	var req struct {
-		Limit  *int `json:"limit"`
-		Offset *int `json:"offset"`
+		Limit   *int   `json:"limit"`
+		Offset  *int   `json:"offset"`
+		SinceID string `json:"sinceId"`
+		UntilID string `json:"untilId"`
 	}
 	_ = c.Bind(&req)
 	limit = 10
@@ -368,29 +375,77 @@ func paginationFromRequest(c echo.Context) (limit, offset int) {
 	if req.Offset != nil && *req.Offset > 0 {
 		offset = *req.Offset
 	}
-	return limit, offset
+	return limit, offset, req.SinceID, req.UntilID
 }
 
 // GalleryLikes handles POST /api/i/gallery/likes.
 // 自分が like した gallery_post を返却する。
+//
+// upstream Misskey TS は `{id, post: GalleryPost}` を返し、frontend は
+// `item.post` で MkGalleryPostPreview を描画する。mk-go は元々 `postId`
+// しか返しておらず frontend が空表示になっていた (#493 関連)。
+// 同じ shape に揃えるため like 行ごとに対応する gallery_post を fetch
+// して埋める。
 func (h *Handler) GalleryLikes(c echo.Context) error {
 	if h.galleryRepo == nil {
 		return c.JSON(http.StatusOK, []any{})
 	}
 	u := middleware.GetUser(c)
-	limit, offset := paginationFromRequest(c)
-	likes, err := h.galleryRepo.ListLikesByUser(u.ID, limit, offset)
+	limit, offset, sinceID, untilID := paginationFromRequest(c)
+	likes, err := h.galleryRepo.ListLikesByUser(u.ID, sinceID, untilID, limit, offset)
 	if err != nil {
 		return apierr.JSONInternalError(c)
 	}
+	postIDs := make([]string, 0, len(likes))
+	for _, l := range likes {
+		postIDs = append(postIDs, l.PostID)
+	}
+	posts, err := h.galleryRepo.FindPostsByIDs(postIDs)
+	if err != nil {
+		return apierr.JSONInternalError(c)
+	}
+	postByID := make(map[string]*model.GalleryPost, len(posts))
+	for _, p := range posts {
+		postByID[p.ID] = p
+	}
 	out := make([]map[string]any, 0, len(likes))
 	for _, l := range likes {
-		out = append(out, map[string]any{
-			"id":     l.ID,
-			"postId": l.PostID,
-		})
+		entry := map[string]any{"id": l.ID}
+		if p, ok := postByID[l.PostID]; ok {
+			entry["post"] = packGalleryPost(p, h.idGen)
+		}
+		out = append(out, entry)
 	}
 	return c.JSON(http.StatusOK, out)
+}
+
+// packGalleryPost は upstream の GalleryPost shape (createdAt / user 含む)
+// に揃えてレスポンス用の map を返す。
+func packGalleryPost(p *model.GalleryPost, idGen id.Generator) map[string]any {
+	const tsFormat = "2006-01-02T15:04:05.000Z"
+	createdAt := ""
+	if idGen != nil {
+		if t, err := idGen.ParseTime(p.ID); err == nil {
+			createdAt = t.UTC().Format(tsFormat)
+		}
+	}
+	resp := map[string]any{
+		"id":          p.ID,
+		"createdAt":   createdAt,
+		"updatedAt":   p.UpdatedAt.UTC().Format(tsFormat),
+		"title":       p.Title,
+		"description": p.Description,
+		"userId":      p.UserID,
+		"fileIds":     []string(p.FileIDs),
+		"files":       []any{},
+		"isSensitive": p.IsSensitive,
+		"likedCount":  p.LikedCount,
+		"tags":        []string(p.Tags),
+	}
+	if p.User != nil {
+		resp["user"] = entity.PackUserLite(p.User)
+	}
+	return resp
 }
 
 // GalleryPosts handles POST /api/i/gallery/posts.
@@ -400,8 +455,8 @@ func (h *Handler) GalleryPosts(c echo.Context) error {
 		return c.JSON(http.StatusOK, []any{})
 	}
 	u := middleware.GetUser(c)
-	limit, offset := paginationFromRequest(c)
-	posts, err := h.galleryRepo.ListByUser(u.ID, limit, offset)
+	limit, offset, sinceID, untilID := paginationFromRequest(c)
+	posts, err := h.galleryRepo.ListByUser(u.ID, sinceID, untilID, limit, offset)
 	if err != nil {
 		return apierr.JSONInternalError(c)
 	}
@@ -437,7 +492,7 @@ func (h *Handler) PageLikes(c echo.Context) error {
 		return c.JSON(http.StatusOK, []any{})
 	}
 	u := middleware.GetUser(c)
-	limit, offset := paginationFromRequest(c)
+	limit, offset, _, _ := paginationFromRequest(c)
 	likes, err := h.pageLikeRepo.ListByUser(u.ID, limit, offset)
 	if err != nil {
 		return apierr.JSONInternalError(c)

--- a/internal/api/i/handler_stubs_test.go
+++ b/internal/api/i/handler_stubs_test.go
@@ -292,11 +292,14 @@ type stubGalleryRepo struct {
 	err   error
 }
 
-func (s *stubGalleryRepo) ListByUser(_ string, _, _ int) ([]*model.GalleryPost, error) {
+func (s *stubGalleryRepo) ListByUser(_, _, _ string, _, _ int) ([]*model.GalleryPost, error) {
 	return s.posts, s.err
 }
-func (s *stubGalleryRepo) ListLikesByUser(_ string, _, _ int) ([]*model.GalleryLike, error) {
+func (s *stubGalleryRepo) ListLikesByUser(_, _, _ string, _, _ int) ([]*model.GalleryLike, error) {
 	return s.likes, s.err
+}
+func (s *stubGalleryRepo) FindPostsByIDs(_ []string) ([]*model.GalleryPost, error) {
+	return s.posts, s.err
 }
 
 // --- P4-6 (#166): i/gallery/* ---
@@ -318,15 +321,25 @@ func TestGalleryPosts_WithRepo(t *testing.T) {
 
 func TestGalleryLikes_WithRepo(t *testing.T) {
 	h, _ := newExtraHandler(t)
-	h.SetGalleryRepo(&stubGalleryRepo{likes: []*model.GalleryLike{
-		{ID: "l1", PostID: "p1", UserID: stubUser.ID},
-	}})
+	// upstream の `{id, post: GalleryPost}` shape を返す経路 (#493)。
+	// stubGalleryRepo.FindPostsByIDs は posts スライスをそのまま返すので
+	// PostID が一致するエントリを posts にも入れておく。
+	h.SetGalleryRepo(&stubGalleryRepo{
+		likes: []*model.GalleryLike{
+			{ID: "l1", PostID: "p1", UserID: stubUser.ID},
+		},
+		posts: []*model.GalleryPost{
+			{ID: "p1", Title: "t", UserID: stubUser.ID},
+		},
+	})
 	rec := postExtra(h.GalleryLikes, `{}`, stubUser)
 	assert.Equal(t, http.StatusOK, rec.Code)
 	var got []map[string]any
 	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &got))
 	require.Len(t, got, 1)
-	assert.Equal(t, "p1", got[0]["postId"])
+	post, ok := got[0]["post"].(map[string]any)
+	require.True(t, ok, "expected post object embedded")
+	assert.Equal(t, "p1", post["id"])
 }
 
 // --- P4-6 (#166): i/page-likes ---

--- a/internal/api/i/handler_test.go
+++ b/internal/api/i/handler_test.go
@@ -1221,15 +1221,19 @@ type stubPageRepo struct {
 	err  error
 }
 
-func (s *stubPageRepo) Create(*model.Page) error                                 { return nil }
-func (s *stubPageRepo) FindByID(id string) (*model.Page, error)                  { return s.page, s.err }
-func (s *stubPageRepo) FindByUserAndName(string, string) (*model.Page, error)    { return nil, nil }
-func (s *stubPageRepo) UpdateFields(string, map[string]any) error                { return nil }
-func (s *stubPageRepo) Delete(*model.Page) error                                 { return nil }
-func (s *stubPageRepo) ListByUser(string, int, int) ([]*model.Page, error)       { return nil, nil }
-func (s *stubPageRepo) ListPublicByUser(string, int, int) ([]*model.Page, error) { return nil, nil }
-func (s *stubPageRepo) ListFeatured(int, int) ([]*model.Page, error)             { return nil, nil }
-func (s *stubPageRepo) IncrementCount(string, string, int) error                 { return nil }
+func (s *stubPageRepo) Create(*model.Page) error                              { return nil }
+func (s *stubPageRepo) FindByID(id string) (*model.Page, error)               { return s.page, s.err }
+func (s *stubPageRepo) FindByUserAndName(string, string) (*model.Page, error) { return nil, nil }
+func (s *stubPageRepo) UpdateFields(string, map[string]any) error             { return nil }
+func (s *stubPageRepo) Delete(*model.Page) error                              { return nil }
+func (s *stubPageRepo) ListByUser(string, string, string, int, int) ([]*model.Page, error) {
+	return nil, nil
+}
+func (s *stubPageRepo) ListPublicByUser(string, string, string, int, int) ([]*model.Page, error) {
+	return nil, nil
+}
+func (s *stubPageRepo) ListFeatured(string, string, int, int) ([]*model.Page, error) { return nil, nil }
+func (s *stubPageRepo) IncrementCount(string, string, int) error                     { return nil }
 
 func TestMe_PinnedPage_Populated(t *testing.T) {
 	h, userRepo, _, _ := newTestHandler(t)

--- a/internal/api/mute/handler.go
+++ b/internal/api/mute/handler.go
@@ -9,17 +9,26 @@ import (
 	"github.com/labstack/echo/v4"
 	"github.com/shiroha-a/mk/internal/api/apierr"
 	coremuting "github.com/shiroha-a/mk/internal/core/muting"
+	"github.com/shiroha-a/mk/internal/entity"
+	"github.com/shiroha-a/mk/internal/misc/id"
+	"github.com/shiroha-a/mk/internal/repository"
 	"github.com/shiroha-a/mk/internal/server/middleware"
 )
 
 // Handler handles mute-related API endpoints.
 type Handler struct {
-	svc *coremuting.Service
+	svc      *coremuting.Service
+	userRepo repository.UserRepository
+	idGen    id.Generator
 }
 
 // NewHandler creates a new mute Handler.
-func NewHandler(svc *coremuting.Service) *Handler {
-	return &Handler{svc: svc}
+// userRepo / idGen are required by mute/list to pack the embedded
+// `mutee` user object that the upstream Misskey frontend uses for
+// rendering. They are optional (nil) only in legacy tests; production
+// must wire them.
+func NewHandler(svc *coremuting.Service, userRepo repository.UserRepository, idGen id.Generator) *Handler {
+	return &Handler{svc: svc, userRepo: userRepo, idGen: idGen}
 }
 
 // CreateRequest is the request body for mute/create.
@@ -82,11 +91,17 @@ func (h *Handler) Delete(c echo.Context) error {
 
 // ListRequest is the request body for mute/list.
 type ListRequest struct {
-	Limit  int `json:"limit"`
-	Offset int `json:"offset"`
+	Limit   int    `json:"limit"`
+	Offset  int    `json:"offset"`
+	SinceID string `json:"sinceId"`
+	UntilID string `json:"untilId"`
 }
 
 // List handles POST /api/mute/list.
+//
+// frontend Paginator (cursor mode) は untilId / sinceId を投げてくるので
+// それを repo まで forward する (#493)。bind 漏れだと無限スクロールに
+// なる。
 func (h *Handler) List(c echo.Context) error {
 	user := middleware.GetUser(c)
 	var req ListRequest
@@ -99,18 +114,37 @@ func (h *Handler) List(c echo.Context) error {
 	if req.Limit > 100 {
 		req.Limit = 100
 	}
-	rows, err := h.svc.List(user.ID, req.Limit, req.Offset)
+	rows, err := h.svc.List(user.ID, req.SinceID, req.UntilID, req.Limit, req.Offset)
 	if err != nil {
 		return apierr.JSONInternalError(c)
 	}
+	const tsFormat = "2006-01-02T15:04:05.000Z"
 	out := make([]map[string]any, 0, len(rows))
 	for _, m := range rows {
+		createdAt := ""
+		if h.idGen != nil {
+			if t, err := h.idGen.ParseTime(m.ID); err == nil {
+				createdAt = t.UTC().Format(tsFormat)
+			}
+		}
 		entry := map[string]any{
-			"id":      m.ID,
-			"muteeId": m.MuteeID,
+			"id":        m.ID,
+			"createdAt": createdAt,
+			"muteeId":   m.MuteeID,
 		}
 		if m.ExpiresAt != nil {
-			entry["expiresAt"] = m.ExpiresAt.UnixMilli()
+			entry["expiresAt"] = m.ExpiresAt.UTC().Format(tsFormat)
+		} else {
+			entry["expiresAt"] = nil
+		}
+		// upstream frontend (mute-block.vue) は item.mutee を使って
+		// MkUserCardMini を描画する。userRepo が wire されていない
+		// (legacy test) 場合は muteeId だけ返してフォールバック。
+		if h.userRepo != nil {
+			if u, err := h.userRepo.FindByID(m.MuteeID); err == nil {
+				profile, _ := h.userRepo.FindProfileByUserID(u.ID)
+				entry["mutee"] = entity.PackUserDetailed(u, profile)
+			}
 		}
 		out = append(out, entry)
 	}

--- a/internal/api/mute/handler.go
+++ b/internal/api/mute/handler.go
@@ -11,6 +11,7 @@ import (
 	coremuting "github.com/shiroha-a/mk/internal/core/muting"
 	"github.com/shiroha-a/mk/internal/entity"
 	"github.com/shiroha-a/mk/internal/misc/id"
+	"github.com/shiroha-a/mk/internal/model"
 	"github.com/shiroha-a/mk/internal/repository"
 	"github.com/shiroha-a/mk/internal/server/middleware"
 )
@@ -118,6 +119,11 @@ func (h *Handler) List(c echo.Context) error {
 	if err != nil {
 		return apierr.JSONInternalError(c)
 	}
+	// upstream frontend (mute-block.vue) は item.mutee を使って
+	// MkUserCardMini を描画する。userRepo が wire されていない場合は
+	// muteeId だけ返してフォールバック (legacy test)。本番ルートでは
+	// 必ず wire されるので batch fetch で N+1 を回避する。
+	muteeMap := h.fetchMuteeMap(rows)
 	const tsFormat = "2006-01-02T15:04:05.000Z"
 	out := make([]map[string]any, 0, len(rows))
 	for _, m := range rows {
@@ -137,16 +143,41 @@ func (h *Handler) List(c echo.Context) error {
 		} else {
 			entry["expiresAt"] = nil
 		}
-		// upstream frontend (mute-block.vue) は item.mutee を使って
-		// MkUserCardMini を描画する。userRepo が wire されていない
-		// (legacy test) 場合は muteeId だけ返してフォールバック。
-		if h.userRepo != nil {
-			if u, err := h.userRepo.FindByID(m.MuteeID); err == nil {
-				profile, _ := h.userRepo.FindProfileByUserID(u.ID)
-				entry["mutee"] = entity.PackUserDetailed(u, profile)
-			}
+		if mutee, ok := muteeMap[m.MuteeID]; ok {
+			entry["mutee"] = mutee
 		}
 		out = append(out, entry)
 	}
 	return c.JSON(http.StatusOK, out)
+}
+
+// fetchMuteeMap batches user + profile lookups for the muteeIds in rows so
+// the response build loop performs zero per-row DB queries.
+func (h *Handler) fetchMuteeMap(rows []*model.Muting) map[string]entity.UserDetailed {
+	if h.userRepo == nil || len(rows) == 0 {
+		return nil
+	}
+	ids := make([]string, 0, len(rows))
+	seen := make(map[string]struct{}, len(rows))
+	for _, m := range rows {
+		if _, ok := seen[m.MuteeID]; ok {
+			continue
+		}
+		seen[m.MuteeID] = struct{}{}
+		ids = append(ids, m.MuteeID)
+	}
+	users, err := h.userRepo.FindManyByIDs(ids)
+	if err != nil {
+		return nil
+	}
+	profiles, _ := h.userRepo.FindProfilesByUserIDs(ids)
+	profileByUser := make(map[string]*model.UserProfile, len(profiles))
+	for _, p := range profiles {
+		profileByUser[p.UserID] = p
+	}
+	out := make(map[string]entity.UserDetailed, len(users))
+	for _, u := range users {
+		out[u.ID] = entity.PackUserDetailed(u, profileByUser[u.ID], h.idGen)
+	}
+	return out
 }

--- a/internal/api/mute/handler.go
+++ b/internal/api/mute/handler.go
@@ -3,6 +3,7 @@ package mute
 
 import (
 	"errors"
+	"log/slog"
 	"net/http"
 	"time"
 
@@ -170,7 +171,10 @@ func (h *Handler) fetchMuteeMap(rows []*model.Muting) map[string]entity.UserDeta
 	if err != nil {
 		return nil
 	}
-	profiles, _ := h.userRepo.FindProfilesByUserIDs(ids)
+	profiles, profErr := h.userRepo.FindProfilesByUserIDs(ids)
+	if profErr != nil {
+		slog.Warn("mute/list: failed to fetch profiles", "error", profErr)
+	}
 	profileByUser := make(map[string]*model.UserProfile, len(profiles))
 	for _, p := range profiles {
 		profileByUser[p.UserID] = p

--- a/internal/api/mute/handler_test.go
+++ b/internal/api/mute/handler_test.go
@@ -22,7 +22,7 @@ func newHandler(t *testing.T) (*Handler, *testutil.MockUserRepository) {
 	mutingRepo := testutil.NewMockMutingRepository()
 	idGen, _ := id.NewGenerator("aidx")
 	svc := coremuting.NewService(userRepo, mutingRepo, idGen)
-	return NewHandler(svc), userRepo
+	return NewHandler(svc, nil, nil), userRepo
 }
 
 func newReq(t *testing.T, body string) (echo.Context, *httptest.ResponseRecorder) {
@@ -125,7 +125,7 @@ func TestCreate_RepoError(t *testing.T) {
 	addUser(userRepo, "bob")
 	idGen, _ := id.NewGenerator("aidx")
 	svc := coremuting.NewService(userRepo, &failingMutingRepo{MockMutingRepository: testutil.NewMockMutingRepository()}, idGen)
-	h := NewHandler(svc)
+	h := NewHandler(svc, nil, nil)
 
 	c, rec := newReq(t, `{"userId":"bob"}`)
 	setUser(c, "alice")
@@ -188,7 +188,7 @@ func TestDelete_RepoError(t *testing.T) {
 	mock.Mutings["m1"] = &model.Muting{ID: "m1", MuterID: "alice", MuteeID: "bob"}
 	idGen, _ := id.NewGenerator("aidx")
 	svc := coremuting.NewService(userRepo, &failingDeleteMutingRepo{MockMutingRepository: mock}, idGen)
-	h := NewHandler(svc)
+	h := NewHandler(svc, nil, nil)
 
 	c, rec := newReq(t, `{"userId":"bob"}`)
 	setUser(c, "alice")
@@ -231,7 +231,7 @@ type failingListMutingRepo struct {
 	*testutil.MockMutingRepository
 }
 
-func (f *failingListMutingRepo) ListByMuter(_ string, _, _ int) ([]*model.Muting, error) {
+func (f *failingListMutingRepo) ListByMuter(_, _, _ string, _, _ int) ([]*model.Muting, error) {
 	return nil, testutil.ErrNotFound
 }
 
@@ -239,7 +239,7 @@ func TestList_RepoError(t *testing.T) {
 	userRepo := testutil.NewMockUserRepository()
 	idGen, _ := id.NewGenerator("aidx")
 	svc := coremuting.NewService(userRepo, &failingListMutingRepo{MockMutingRepository: testutil.NewMockMutingRepository()}, idGen)
-	h := NewHandler(svc)
+	h := NewHandler(svc, nil, nil)
 
 	c, rec := newReq(t, `{}`)
 	setUser(c, "alice")

--- a/internal/api/mute/handler_test.go
+++ b/internal/api/mute/handler_test.go
@@ -22,7 +22,7 @@ func newHandler(t *testing.T) (*Handler, *testutil.MockUserRepository) {
 	mutingRepo := testutil.NewMockMutingRepository()
 	idGen, _ := id.NewGenerator("aidx")
 	svc := coremuting.NewService(userRepo, mutingRepo, idGen)
-	return NewHandler(svc, nil, nil), userRepo
+	return NewHandler(svc, userRepo, idGen), userRepo
 }
 
 func newReq(t *testing.T, body string) (echo.Context, *httptest.ResponseRecorder) {

--- a/internal/api/pages/handler.go
+++ b/internal/api/pages/handler.go
@@ -235,18 +235,22 @@ func (h *Handler) Delete(c echo.Context) error {
 
 // MyRequest is the request body for i/pages (own pages list).
 type MyRequest struct {
-	Limit  int `json:"limit"`
-	Offset int `json:"offset"`
+	Limit   int    `json:"limit"`
+	Offset  int    `json:"offset"`
+	SinceID string `json:"sinceId"`
+	UntilID string `json:"untilId"`
 }
 
 // My handles POST /api/i/pages.
+//
+// frontend Paginator (cursor mode) は untilId / sinceId を forward する (#493)。
 func (h *Handler) My(c echo.Context) error {
 	user := middleware.GetUser(c)
 	var req MyRequest
 	if err := c.Bind(&req); err != nil {
 		return apierr.JSONInvalidParam(c)
 	}
-	rows, err := h.svc.ListByUser(user.ID, req.Limit, req.Offset)
+	rows, err := h.svc.ListByUser(user.ID, req.SinceID, req.UntilID, req.Limit, req.Offset)
 	if err != nil {
 		return apierr.JSONInternalError(c)
 	}
@@ -255,8 +259,10 @@ func (h *Handler) My(c echo.Context) error {
 
 // FeaturedRequest is the request body for pages/featured.
 type FeaturedRequest struct {
-	Limit  int `json:"limit"`
-	Offset int `json:"offset"`
+	Limit   int    `json:"limit"`
+	Offset  int    `json:"offset"`
+	SinceID string `json:"sinceId"`
+	UntilID string `json:"untilId"`
 }
 
 // Featured handles POST /api/pages/featured.
@@ -265,7 +271,7 @@ func (h *Handler) Featured(c echo.Context) error {
 	if err := c.Bind(&req); err != nil {
 		return apierr.JSONInvalidParam(c)
 	}
-	rows, err := h.svc.Featured(req.Limit, req.Offset)
+	rows, err := h.svc.Featured(req.SinceID, req.UntilID, req.Limit, req.Offset)
 	if err != nil {
 		return apierr.JSONInternalError(c)
 	}

--- a/internal/api/pages/handler_test.go
+++ b/internal/api/pages/handler_test.go
@@ -316,7 +316,7 @@ type listFailRepo struct {
 	*testutil.MockPageRepository
 }
 
-func (r *listFailRepo) ListByUser(_ string, _, _ int) ([]*model.Page, error) {
+func (r *listFailRepo) ListByUser(_, _, _ string, _, _ int) ([]*model.Page, error) {
 	return nil, errors.New("boom")
 }
 
@@ -353,7 +353,7 @@ type featuredFailRepo struct {
 	*testutil.MockPageRepository
 }
 
-func (r *featuredFailRepo) ListFeatured(_, _ int) ([]*model.Page, error) {
+func (r *featuredFailRepo) ListFeatured(_, _ string, _, _ int) ([]*model.Page, error) {
 	return nil, errors.New("boom")
 }
 

--- a/internal/api/renotemute/handler.go
+++ b/internal/api/renotemute/handler.go
@@ -10,6 +10,7 @@ import (
 	coremuting "github.com/shiroha-a/mk/internal/core/muting"
 	"github.com/shiroha-a/mk/internal/entity"
 	"github.com/shiroha-a/mk/internal/misc/id"
+	"github.com/shiroha-a/mk/internal/model"
 	"github.com/shiroha-a/mk/internal/repository"
 	"github.com/shiroha-a/mk/internal/server/middleware"
 )
@@ -101,6 +102,7 @@ func (h *Handler) List(c echo.Context) error {
 	if err != nil {
 		return apierr.JSONInternalError(c)
 	}
+	muteeMap := h.fetchMuteeMap(rows)
 	const tsFormat = "2006-01-02T15:04:05.000Z"
 	out := make([]map[string]any, 0, len(rows))
 	for _, m := range rows {
@@ -115,14 +117,41 @@ func (h *Handler) List(c echo.Context) error {
 			"createdAt": createdAt,
 			"muteeId":   m.MuteeID,
 		}
-		// upstream frontend が item.mutee で MkUserCardMini を描画する。
-		if h.userRepo != nil {
-			if u, err := h.userRepo.FindByID(m.MuteeID); err == nil {
-				profile, _ := h.userRepo.FindProfileByUserID(u.ID)
-				entry["mutee"] = entity.PackUserDetailed(u, profile)
-			}
+		if mutee, ok := muteeMap[m.MuteeID]; ok {
+			entry["mutee"] = mutee
 		}
 		out = append(out, entry)
 	}
 	return c.JSON(http.StatusOK, out)
+}
+
+// fetchMuteeMap batches user + profile lookups for the muteeIds in rows so
+// the response build loop performs zero per-row DB queries.
+func (h *Handler) fetchMuteeMap(rows []*model.RenoteMuting) map[string]entity.UserDetailed {
+	if h.userRepo == nil || len(rows) == 0 {
+		return nil
+	}
+	ids := make([]string, 0, len(rows))
+	seen := make(map[string]struct{}, len(rows))
+	for _, m := range rows {
+		if _, ok := seen[m.MuteeID]; ok {
+			continue
+		}
+		seen[m.MuteeID] = struct{}{}
+		ids = append(ids, m.MuteeID)
+	}
+	users, err := h.userRepo.FindManyByIDs(ids)
+	if err != nil {
+		return nil
+	}
+	profiles, _ := h.userRepo.FindProfilesByUserIDs(ids)
+	profileByUser := make(map[string]*model.UserProfile, len(profiles))
+	for _, p := range profiles {
+		profileByUser[p.UserID] = p
+	}
+	out := make(map[string]entity.UserDetailed, len(users))
+	for _, u := range users {
+		out[u.ID] = entity.PackUserDetailed(u, profileByUser[u.ID], h.idGen)
+	}
+	return out
 }

--- a/internal/api/renotemute/handler.go
+++ b/internal/api/renotemute/handler.go
@@ -8,17 +8,24 @@ import (
 	"github.com/labstack/echo/v4"
 	"github.com/shiroha-a/mk/internal/api/apierr"
 	coremuting "github.com/shiroha-a/mk/internal/core/muting"
+	"github.com/shiroha-a/mk/internal/entity"
+	"github.com/shiroha-a/mk/internal/misc/id"
+	"github.com/shiroha-a/mk/internal/repository"
 	"github.com/shiroha-a/mk/internal/server/middleware"
 )
 
 // Handler handles renote-mute endpoints.
 type Handler struct {
-	svc *coremuting.RenoteService
+	svc      *coremuting.RenoteService
+	userRepo repository.UserRepository
+	idGen    id.Generator
 }
 
 // NewHandler creates a new Handler.
-func NewHandler(svc *coremuting.RenoteService) *Handler {
-	return &Handler{svc: svc}
+// userRepo / idGen are required by renote-mute/list to embed the
+// `mutee` user object that the upstream Misskey frontend renders.
+func NewHandler(svc *coremuting.RenoteService, userRepo repository.UserRepository, idGen id.Generator) *Handler {
+	return &Handler{svc: svc, userRepo: userRepo, idGen: idGen}
 }
 
 // PairRequest is the body for create/delete.
@@ -68,11 +75,16 @@ func (h *Handler) Delete(c echo.Context) error {
 
 // ListRequest is the body for renote-mute/list.
 type ListRequest struct {
-	Limit  int `json:"limit"`
-	Offset int `json:"offset"`
+	Limit   int    `json:"limit"`
+	Offset  int    `json:"offset"`
+	SinceID string `json:"sinceId"`
+	UntilID string `json:"untilId"`
 }
 
 // List handles POST /api/renote-mute/list.
+//
+// frontend Paginator (cursor mode) は untilId / sinceId を forward する。
+// 本 endpoint は #493 で cursor 対応に切り替えた。
 func (h *Handler) List(c echo.Context) error {
 	user := middleware.GetUser(c)
 	var req ListRequest
@@ -85,16 +97,32 @@ func (h *Handler) List(c echo.Context) error {
 	if req.Limit > 100 {
 		req.Limit = 100
 	}
-	rows, err := h.svc.List(user.ID, req.Limit, req.Offset)
+	rows, err := h.svc.List(user.ID, req.SinceID, req.UntilID, req.Limit, req.Offset)
 	if err != nil {
 		return apierr.JSONInternalError(c)
 	}
+	const tsFormat = "2006-01-02T15:04:05.000Z"
 	out := make([]map[string]any, 0, len(rows))
 	for _, m := range rows {
-		out = append(out, map[string]any{
-			"id":      m.ID,
-			"muteeId": m.MuteeID,
-		})
+		createdAt := ""
+		if h.idGen != nil {
+			if t, err := h.idGen.ParseTime(m.ID); err == nil {
+				createdAt = t.UTC().Format(tsFormat)
+			}
+		}
+		entry := map[string]any{
+			"id":        m.ID,
+			"createdAt": createdAt,
+			"muteeId":   m.MuteeID,
+		}
+		// upstream frontend が item.mutee で MkUserCardMini を描画する。
+		if h.userRepo != nil {
+			if u, err := h.userRepo.FindByID(m.MuteeID); err == nil {
+				profile, _ := h.userRepo.FindProfileByUserID(u.ID)
+				entry["mutee"] = entity.PackUserDetailed(u, profile)
+			}
+		}
+		out = append(out, entry)
 	}
 	return c.JSON(http.StatusOK, out)
 }

--- a/internal/api/renotemute/handler.go
+++ b/internal/api/renotemute/handler.go
@@ -3,6 +3,7 @@ package renotemute
 
 import (
 	"errors"
+	"log/slog"
 	"net/http"
 
 	"github.com/labstack/echo/v4"
@@ -144,7 +145,10 @@ func (h *Handler) fetchMuteeMap(rows []*model.RenoteMuting) map[string]entity.Us
 	if err != nil {
 		return nil
 	}
-	profiles, _ := h.userRepo.FindProfilesByUserIDs(ids)
+	profiles, profErr := h.userRepo.FindProfilesByUserIDs(ids)
+	if profErr != nil {
+		slog.Warn("renote-mute/list: failed to fetch profiles", "error", profErr)
+	}
 	profileByUser := make(map[string]*model.UserProfile, len(profiles))
 	for _, p := range profiles {
 		profileByUser[p.UserID] = p

--- a/internal/api/renotemute/handler_test.go
+++ b/internal/api/renotemute/handler_test.go
@@ -22,7 +22,7 @@ func newHandler(t *testing.T) (*Handler, *testutil.MockUserRepository) {
 	repo := testutil.NewMockRenoteMutingRepository()
 	idGen, _ := id.NewGenerator("aidx")
 	svc := coremuting.NewRenoteService(userRepo, repo, idGen)
-	return NewHandler(svc, nil, nil), userRepo
+	return NewHandler(svc, userRepo, idGen), userRepo
 }
 
 func newReq(t *testing.T, body string) (echo.Context, *httptest.ResponseRecorder) {

--- a/internal/api/renotemute/handler_test.go
+++ b/internal/api/renotemute/handler_test.go
@@ -22,7 +22,7 @@ func newHandler(t *testing.T) (*Handler, *testutil.MockUserRepository) {
 	repo := testutil.NewMockRenoteMutingRepository()
 	idGen, _ := id.NewGenerator("aidx")
 	svc := coremuting.NewRenoteService(userRepo, repo, idGen)
-	return NewHandler(svc), userRepo
+	return NewHandler(svc, nil, nil), userRepo
 }
 
 func newReq(t *testing.T, body string) (echo.Context, *httptest.ResponseRecorder) {
@@ -114,7 +114,7 @@ func TestCreate_RepoError(t *testing.T) {
 	addUser(userRepo, "bob")
 	idGen, _ := id.NewGenerator("aidx")
 	svc := coremuting.NewRenoteService(userRepo, &failingRenoteMutingRepo{MockRenoteMutingRepository: testutil.NewMockRenoteMutingRepository()}, idGen)
-	h := NewHandler(svc)
+	h := NewHandler(svc, nil, nil)
 
 	c, rec := newReq(t, `{"userId":"bob"}`)
 	setUser(c, "alice")
@@ -177,7 +177,7 @@ func TestDelete_RepoError(t *testing.T) {
 	mock.Mutings["m1"] = &model.RenoteMuting{ID: "m1", MuterID: "alice", MuteeID: "bob"}
 	idGen, _ := id.NewGenerator("aidx")
 	svc := coremuting.NewRenoteService(userRepo, &failingDeleteRenoteMutingRepo{MockRenoteMutingRepository: mock}, idGen)
-	h := NewHandler(svc)
+	h := NewHandler(svc, nil, nil)
 
 	c, rec := newReq(t, `{"userId":"bob"}`)
 	setUser(c, "alice")
@@ -220,7 +220,7 @@ type failingListRenoteMutingRepo struct {
 	*testutil.MockRenoteMutingRepository
 }
 
-func (f *failingListRenoteMutingRepo) ListByMuter(_ string, _, _ int) ([]*model.RenoteMuting, error) {
+func (f *failingListRenoteMutingRepo) ListByMuter(_, _, _ string, _, _ int) ([]*model.RenoteMuting, error) {
 	return nil, testutil.ErrNotFound
 }
 
@@ -228,7 +228,7 @@ func TestList_RepoError(t *testing.T) {
 	userRepo := testutil.NewMockUserRepository()
 	idGen, _ := id.NewGenerator("aidx")
 	svc := coremuting.NewRenoteService(userRepo, &failingListRenoteMutingRepo{MockRenoteMutingRepository: testutil.NewMockRenoteMutingRepository()}, idGen)
-	h := NewHandler(svc)
+	h := NewHandler(svc, nil, nil)
 
 	c, rec := newReq(t, `{}`)
 	setUser(c, "alice")

--- a/internal/api/users/handler_stubs.go
+++ b/internal/api/users/handler_stubs.go
@@ -134,11 +134,24 @@ func (h *Handler) Flashs(c echo.Context) error {
 	if err != nil {
 		return apierr.JSONInternalError(c)
 	}
+	// flash/* endpoint と shape を揃える: createdAt / updatedAt は
+	// ISO 8601 (.000Z) 固定、user (UserLite) を embed する (#520 review)。
+	// 全 row が同一 user (= req.UserID) なので fetch は 1 回で済む。
+	const tsFormat = "2006-01-02T15:04:05.000Z"
+	var packedUser any
+	if bundle, err := h.userService.ShowByID(req.UserID); err == nil && bundle != nil {
+		packedUser = entity.PackUserLite(bundle.User)
+	}
 	out := make([]map[string]any, 0, len(rows))
 	for _, f := range rows {
-		out = append(out, map[string]any{
+		createdAt := ""
+		if t, err := h.idGen.ParseTime(f.ID); err == nil {
+			createdAt = t.UTC().Format(tsFormat)
+		}
+		entry := map[string]any{
 			"id":          f.ID,
-			"updatedAt":   f.UpdatedAt,
+			"createdAt":   createdAt,
+			"updatedAt":   f.UpdatedAt.UTC().Format(tsFormat),
 			"title":       f.Title,
 			"summary":     f.Summary,
 			"userId":      f.UserID,
@@ -146,7 +159,11 @@ func (h *Handler) Flashs(c echo.Context) error {
 			"permissions": []string(f.Permissions),
 			"likedCount":  f.LikedCount,
 			"visibility":  f.Visibility,
-		})
+		}
+		if packedUser != nil {
+			entry["user"] = packedUser
+		}
+		out = append(out, entry)
 	}
 	return c.JSON(http.StatusOK, out)
 }

--- a/internal/api/users/handler_stubs.go
+++ b/internal/api/users/handler_stubs.go
@@ -105,11 +105,15 @@ func (h *Handler) Clips(c echo.Context) error {
 }
 
 // Flashs handles POST /api/users/flashs.
+//
+// frontend Paginator (cursor mode) は untilId / sinceId を forward する (#493)。
 func (h *Handler) Flashs(c echo.Context) error {
 	var req struct {
-		UserID string `json:"userId"`
-		Limit  int    `json:"limit"`
-		Offset int    `json:"offset"`
+		UserID  string `json:"userId"`
+		Limit   int    `json:"limit"`
+		Offset  int    `json:"offset"`
+		SinceID string `json:"sinceId"`
+		UntilID string `json:"untilId"`
 	}
 	if err := c.Bind(&req); err != nil || req.UserID == "" {
 		return apierr.JSONInvalidParam(c)
@@ -123,9 +127,9 @@ func (h *Handler) Flashs(c echo.Context) error {
 	var rows []*model.Flash
 	var err error
 	if isSelf {
-		rows, err = h.flashRepo.ListByUser(req.UserID, req.Limit, req.Offset)
+		rows, err = h.flashRepo.ListByUser(req.UserID, req.SinceID, req.UntilID, req.Limit, req.Offset)
 	} else {
-		rows, err = h.flashRepo.ListPublicByUser(req.UserID, req.Limit, req.Offset)
+		rows, err = h.flashRepo.ListPublicByUser(req.UserID, req.SinceID, req.UntilID, req.Limit, req.Offset)
 	}
 	if err != nil {
 		return apierr.JSONInternalError(c)
@@ -148,11 +152,15 @@ func (h *Handler) Flashs(c echo.Context) error {
 }
 
 // GalleryPosts handles POST /api/users/gallery/posts.
+//
+// frontend Paginator (cursor mode) は untilId / sinceId を forward する (#493)。
 func (h *Handler) GalleryPosts(c echo.Context) error {
 	var req struct {
-		UserID string `json:"userId"`
-		Limit  int    `json:"limit"`
-		Offset int    `json:"offset"`
+		UserID  string `json:"userId"`
+		Limit   int    `json:"limit"`
+		Offset  int    `json:"offset"`
+		SinceID string `json:"sinceId"`
+		UntilID string `json:"untilId"`
 	}
 	if err := c.Bind(&req); err != nil || req.UserID == "" {
 		return apierr.JSONInvalidParam(c)
@@ -161,7 +169,7 @@ func (h *Handler) GalleryPosts(c echo.Context) error {
 		return c.JSON(http.StatusOK, []any{})
 	}
 	clampListLimit(&req.Limit)
-	rows, err := h.galleryRepo.ListByUser(req.UserID, req.Limit, req.Offset)
+	rows, err := h.galleryRepo.ListByUser(req.UserID, req.SinceID, req.UntilID, req.Limit, req.Offset)
 	if err != nil {
 		return apierr.JSONInternalError(c)
 	}
@@ -185,11 +193,15 @@ func (h *Handler) GalleryPosts(c echo.Context) error {
 }
 
 // Pages handles POST /api/users/pages.
+//
+// frontend Paginator (cursor mode) は untilId / sinceId を forward する (#493)。
 func (h *Handler) Pages(c echo.Context) error {
 	var req struct {
-		UserID string `json:"userId"`
-		Limit  int    `json:"limit"`
-		Offset int    `json:"offset"`
+		UserID  string `json:"userId"`
+		Limit   int    `json:"limit"`
+		Offset  int    `json:"offset"`
+		SinceID string `json:"sinceId"`
+		UntilID string `json:"untilId"`
 	}
 	if err := c.Bind(&req); err != nil || req.UserID == "" {
 		return apierr.JSONInvalidParam(c)
@@ -203,9 +215,9 @@ func (h *Handler) Pages(c echo.Context) error {
 	var rows []*model.Page
 	var err error
 	if isSelf {
-		rows, err = h.pageRepo.ListByUser(req.UserID, req.Limit, req.Offset)
+		rows, err = h.pageRepo.ListByUser(req.UserID, req.SinceID, req.UntilID, req.Limit, req.Offset)
 	} else {
-		rows, err = h.pageRepo.ListPublicByUser(req.UserID, req.Limit, req.Offset)
+		rows, err = h.pageRepo.ListPublicByUser(req.UserID, req.SinceID, req.UntilID, req.Limit, req.Offset)
 	}
 	if err != nil {
 		return apierr.JSONInternalError(c)

--- a/internal/api/users/handler_stubs.go
+++ b/internal/api/users/handler_stubs.go
@@ -192,6 +192,8 @@ func (h *Handler) GalleryPosts(c echo.Context) error {
 	}
 	// GalleryPost に visibility 概念はなく常に公開扱い。
 	// updatedAt / createdAt は i/gallery/posts と format を揃える (#520 review)。
+	// galleryRepo.ListByUser が Preload("User") を行うので g.User を読んで
+	// user (UserLite) を embed できる。i/gallery/posts と同 shape。
 	const tsFormat = "2006-01-02T15:04:05.000Z"
 	out := make([]map[string]any, 0, len(rows))
 	for _, g := range rows {
@@ -199,7 +201,7 @@ func (h *Handler) GalleryPosts(c echo.Context) error {
 		if t, err := h.idGen.ParseTime(g.ID); err == nil {
 			createdAt = t.UTC().Format(tsFormat)
 		}
-		out = append(out, map[string]any{
+		entry := map[string]any{
 			"id":          g.ID,
 			"createdAt":   createdAt,
 			"updatedAt":   g.UpdatedAt.UTC().Format(tsFormat),
@@ -211,7 +213,11 @@ func (h *Handler) GalleryPosts(c echo.Context) error {
 			"isSensitive": g.IsSensitive,
 			"likedCount":  g.LikedCount,
 			"files":       []any{},
-		})
+		}
+		if g.User != nil {
+			entry["user"] = entity.PackUserLite(g.User)
+		}
+		out = append(out, entry)
 	}
 	return c.JSON(http.StatusOK, out)
 }

--- a/internal/api/users/handler_stubs.go
+++ b/internal/api/users/handler_stubs.go
@@ -191,11 +191,18 @@ func (h *Handler) GalleryPosts(c echo.Context) error {
 		return apierr.JSONInternalError(c)
 	}
 	// GalleryPost に visibility 概念はなく常に公開扱い。
+	// updatedAt / createdAt は i/gallery/posts と format を揃える (#520 review)。
+	const tsFormat = "2006-01-02T15:04:05.000Z"
 	out := make([]map[string]any, 0, len(rows))
 	for _, g := range rows {
+		createdAt := ""
+		if t, err := h.idGen.ParseTime(g.ID); err == nil {
+			createdAt = t.UTC().Format(tsFormat)
+		}
 		out = append(out, map[string]any{
 			"id":          g.ID,
-			"updatedAt":   g.UpdatedAt,
+			"createdAt":   createdAt,
+			"updatedAt":   g.UpdatedAt.UTC().Format(tsFormat),
 			"userId":      g.UserID,
 			"title":       g.Title,
 			"description": g.Description,

--- a/internal/api/users/handler_test.go
+++ b/internal/api/users/handler_test.go
@@ -800,12 +800,16 @@ func (s *stubPageRepoForPin) FindByID(string) (*model.Page, error)              
 func (s *stubPageRepoForPin) FindByUserAndName(string, string) (*model.Page, error) { return nil, nil }
 func (s *stubPageRepoForPin) UpdateFields(string, map[string]any) error             { return nil }
 func (s *stubPageRepoForPin) Delete(*model.Page) error                              { return nil }
-func (s *stubPageRepoForPin) ListByUser(string, int, int) ([]*model.Page, error)    { return nil, nil }
-func (s *stubPageRepoForPin) ListPublicByUser(string, int, int) ([]*model.Page, error) {
+func (s *stubPageRepoForPin) ListByUser(string, string, string, int, int) ([]*model.Page, error) {
 	return nil, nil
 }
-func (s *stubPageRepoForPin) ListFeatured(int, int) ([]*model.Page, error) { return nil, nil }
-func (s *stubPageRepoForPin) IncrementCount(string, string, int) error     { return nil }
+func (s *stubPageRepoForPin) ListPublicByUser(string, string, string, int, int) ([]*model.Page, error) {
+	return nil, nil
+}
+func (s *stubPageRepoForPin) ListFeatured(string, string, int, int) ([]*model.Page, error) {
+	return nil, nil
+}
+func (s *stubPageRepoForPin) IncrementCount(string, string, int) error { return nil }
 
 func TestShow_PinnedNotes_Populated(t *testing.T) {
 	h, userRepo := newTestHandler(t)

--- a/internal/api/users/profile_stubs_test.go
+++ b/internal/api/users/profile_stubs_test.go
@@ -20,10 +20,13 @@ type stubGalleryRepo struct {
 	posts []*model.GalleryPost
 }
 
-func (s *stubGalleryRepo) ListByUser(_ string, _, _ int) ([]*model.GalleryPost, error) {
+func (s *stubGalleryRepo) ListByUser(_, _, _ string, _, _ int) ([]*model.GalleryPost, error) {
 	return s.posts, nil
 }
-func (s *stubGalleryRepo) ListLikesByUser(_ string, _, _ int) ([]*model.GalleryLike, error) {
+func (s *stubGalleryRepo) ListLikesByUser(_, _, _ string, _, _ int) ([]*model.GalleryLike, error) {
+	return nil, nil
+}
+func (s *stubGalleryRepo) FindPostsByIDs(_ []string) ([]*model.GalleryPost, error) {
 	return nil, nil
 }
 

--- a/internal/core/blocking/blocking_service.go
+++ b/internal/core/blocking/blocking_service.go
@@ -98,12 +98,13 @@ func (s *Service) IsBlocked(blockerID, blockeeID string) (bool, error) {
 	return s.blockingRepo.Exists(blockerID, blockeeID)
 }
 
-// List returns the user's blockings.
-func (s *Service) List(blockerID string, limit, offset int) ([]*model.Blocking, error) {
+// List returns the user's blockings with cursor (sinceID/untilID) or offset
+// pagination. Cursor 指定時は offset 無視 (upstream makePaginationQuery と一致)。
+func (s *Service) List(blockerID, sinceID, untilID string, limit, offset int) ([]*model.Blocking, error) {
 	if limit <= 0 {
 		limit = 10
 	}
-	return s.blockingRepo.ListByBlocker(blockerID, limit, offset)
+	return s.blockingRepo.ListByBlocker(blockerID, sinceID, untilID, limit, offset)
 }
 
 // removeFollowing deletes a follow edge if it exists and adjusts counters.

--- a/internal/core/blocking/blocking_service_test.go
+++ b/internal/core/blocking/blocking_service_test.go
@@ -154,11 +154,11 @@ func TestIsBlockedAndList(t *testing.T) {
 	require.NoError(t, err)
 	assert.True(t, yes)
 
-	rows, err := svc.List("a", 0, 0)
+	rows, err := svc.List("a", "", "", 0, 0)
 	require.NoError(t, err)
 	assert.Len(t, rows, 1)
 
-	rows, err = svc.List("a", 5, 0)
+	rows, err = svc.List("a", "", "", 5, 0)
 	require.NoError(t, err)
 	assert.Len(t, rows, 1)
 }

--- a/internal/core/channel/channel_service.go
+++ b/internal/core/channel/channel_service.go
@@ -195,8 +195,10 @@ func (s *Service) Unfollow(userID, channelID string) error {
 
 // ListFollowed returns the channels followed by the user. 結果には channel の
 // 実体を解決して返す (followingRepo の戻り値は中間テーブル)。
-func (s *Service) ListFollowed(userID string, limit, offset int) ([]*model.Channel, error) {
-	rows, err := s.followingRepo.ListFollowed(userID, limit, offset)
+// frontend Paginator は channel_following.id ベースの cursor で叩いてくる
+// ので sinceID / untilID もそのまま forward する。
+func (s *Service) ListFollowed(userID, sinceID, untilID string, limit, offset int) ([]*model.Channel, error) {
+	rows, err := s.followingRepo.ListFollowed(userID, sinceID, untilID, limit, offset)
 	if err != nil {
 		return nil, err
 	}
@@ -211,27 +213,38 @@ func (s *Service) ListFollowed(userID string, limit, offset int) ([]*model.Chann
 	return out, nil
 }
 
-// ListOwned returns channels owned by the user. クエリ / アーカイブ条件は
-// repository に丸投げする。
-func (s *Service) ListOwned(userID string, limit, offset int) ([]*model.Channel, error) {
-	return s.repo.List(model.ChannelListFilter{OwnerID: userID, Limit: limit, Offset: offset})
+// ListOwned returns channels owned by the user with cursor (sinceID/untilID)
+// or offset pagination.
+func (s *Service) ListOwned(userID, sinceID, untilID string, limit, offset int) ([]*model.Channel, error) {
+	return s.repo.List(model.ChannelListFilter{
+		OwnerID: userID,
+		Limit:   limit,
+		Offset:  offset,
+		SinceID: sinceID,
+		UntilID: untilID,
+	})
 }
 
-// ListFeatured returns the most active channels (notes count desc).
-func (s *Service) ListFeatured(limit, offset int) ([]*model.Channel, error) {
+// ListFeatured returns the most active channels (notes count desc), or by
+// id when cursor is supplied (frontend Paginator対応)。
+func (s *Service) ListFeatured(sinceID, untilID string, limit, offset int) ([]*model.Channel, error) {
 	return s.repo.List(model.ChannelListFilter{
-		SortBy: "-notesCount",
-		Limit:  limit,
-		Offset: offset,
+		SortBy:  "-notesCount",
+		Limit:   limit,
+		Offset:  offset,
+		SinceID: sinceID,
+		UntilID: untilID,
 	})
 }
 
 // Search returns channels whose name matches the query.
-func (s *Service) Search(query string, limit, offset int) ([]*model.Channel, error) {
+func (s *Service) Search(query, sinceID, untilID string, limit, offset int) ([]*model.Channel, error) {
 	return s.repo.List(model.ChannelListFilter{
-		Query:  query,
-		Limit:  limit,
-		Offset: offset,
+		Query:   query,
+		Limit:   limit,
+		Offset:  offset,
+		SinceID: sinceID,
+		UntilID: untilID,
 	})
 }
 

--- a/internal/core/channel/channel_service.go
+++ b/internal/core/channel/channel_service.go
@@ -197,18 +197,35 @@ func (s *Service) Unfollow(userID, channelID string) error {
 // 実体を解決して返す (followingRepo の戻り値は中間テーブル)。
 // frontend Paginator は channel_following.id ベースの cursor で叩いてくる
 // ので sinceID / untilID もそのまま forward する。
+//
+// 各 follow row の channel 実体は FindByIDs で一括解決して N+1 を回避する。
+// 元 followings の order は frontend cursor 整合のため保持する必要があるため
+// channelByID map を介して並び順を保つ。
 func (s *Service) ListFollowed(userID, sinceID, untilID string, limit, offset int) ([]*model.Channel, error) {
 	rows, err := s.followingRepo.ListFollowed(userID, sinceID, untilID, limit, offset)
 	if err != nil {
 		return nil, err
 	}
+	if len(rows) == 0 {
+		return nil, nil
+	}
+	ids := make([]string, 0, len(rows))
+	for _, f := range rows {
+		ids = append(ids, f.FolloweeID)
+	}
+	channels, err := s.repo.FindByIDs(ids)
+	if err != nil {
+		return nil, err
+	}
+	channelByID := make(map[string]*model.Channel, len(channels))
+	for _, c := range channels {
+		channelByID[c.ID] = c
+	}
 	out := make([]*model.Channel, 0, len(rows))
 	for _, f := range rows {
-		c, err := s.repo.FindByID(f.FolloweeID)
-		if err != nil {
-			continue
+		if c, ok := channelByID[f.FolloweeID]; ok {
+			out = append(out, c)
 		}
-		out = append(out, c)
 	}
 	return out, nil
 }

--- a/internal/core/channel/channel_service_test.go
+++ b/internal/core/channel/channel_service_test.go
@@ -264,16 +264,22 @@ func TestListFollowed(t *testing.T) {
 	assert.Len(t, rows, 2)
 }
 
-// brokenChannelRepo makes FindByID fail so ListFollowed skips entries.
+// brokenChannelRepo makes FindByIDs fail so ListFollowed propagates the
+// error instead of returning a partial list.
 type brokenChannelRepo struct {
 	*testutil.MockChannelRepository
 }
 
-func (r *brokenChannelRepo) FindByID(_ string) (*model.Channel, error) {
+func (r *brokenChannelRepo) FindByIDs(_ []string) ([]*model.Channel, error) {
 	return nil, errors.New("boom")
 }
 
-func TestListFollowed_FindByIDFailure(t *testing.T) {
+// TestListFollowed_FindByIDsFailure verifies that ListFollowed propagates
+// the FindByIDs error (not silent skip). 8th-pass refactor switched from
+// per-row FindByID with continue-on-error to batch FindByIDs, so the
+// failure mode now surfaces to the caller (more correct than hiding DB
+// errors).
+func TestListFollowed_FindByIDsFailure(t *testing.T) {
 	mock := testutil.NewMockChannelRepository()
 	repo := &brokenChannelRepo{MockChannelRepository: mock}
 	followRepo := testutil.NewMockChannelFollowingRepository()
@@ -281,9 +287,27 @@ func TestListFollowed_FindByIDFailure(t *testing.T) {
 	idGen, _ := id.NewGenerator("aidx")
 	svc := channel.NewService(repo, followRepo, testutil.NewMockNoteRepository(), idGen)
 
+	_, err := svc.ListFollowed("u1", "", "", 10, 0)
+	require.Error(t, err)
+}
+
+// TestListFollowed_MissingChannelSkipped verifies that channels missing
+// from the FindByIDs result (e.g., deleted) are silently skipped while
+// other rows are returned normally.
+func TestListFollowed_MissingChannelSkipped(t *testing.T) {
+	repo := testutil.NewMockChannelRepository()
+	repo.Channels["c1"] = &model.Channel{ID: "c1", Name: "alpha"}
+	// c_missing is followed but not in repo (deleted)
+	followRepo := testutil.NewMockChannelFollowingRepository()
+	followRepo.Followings["f1"] = &model.ChannelFollowing{ID: "f1", FollowerID: "u1", FolloweeID: "c1"}
+	followRepo.Followings["f2"] = &model.ChannelFollowing{ID: "f2", FollowerID: "u1", FolloweeID: "c_missing"}
+	idGen, _ := id.NewGenerator("aidx")
+	svc := channel.NewService(repo, followRepo, testutil.NewMockNoteRepository(), idGen)
+
 	rows, err := svc.ListFollowed("u1", "", "", 10, 0)
 	require.NoError(t, err)
-	assert.Empty(t, rows)
+	require.Len(t, rows, 1)
+	assert.Equal(t, "c1", rows[0].ID)
 }
 
 // listFailFollowRepo causes ListFollowed to fail.

--- a/internal/core/channel/channel_service_test.go
+++ b/internal/core/channel/channel_service_test.go
@@ -259,7 +259,7 @@ func TestListFollowed(t *testing.T) {
 	require.NoError(t, svc.Follow("u1", "c1"))
 	require.NoError(t, svc.Follow("u1", "c2"))
 
-	rows, err := svc.ListFollowed("u1", 10, 0)
+	rows, err := svc.ListFollowed("u1", "", "", 10, 0)
 	require.NoError(t, err)
 	assert.Len(t, rows, 2)
 }
@@ -281,7 +281,7 @@ func TestListFollowed_FindByIDFailure(t *testing.T) {
 	idGen, _ := id.NewGenerator("aidx")
 	svc := channel.NewService(repo, followRepo, testutil.NewMockNoteRepository(), idGen)
 
-	rows, err := svc.ListFollowed("u1", 10, 0)
+	rows, err := svc.ListFollowed("u1", "", "", 10, 0)
 	require.NoError(t, err)
 	assert.Empty(t, rows)
 }
@@ -291,7 +291,7 @@ type listFailFollowRepo struct {
 	*testutil.MockChannelFollowingRepository
 }
 
-func (r *listFailFollowRepo) ListFollowed(_ string, _, _ int) ([]*model.ChannelFollowing, error) {
+func (r *listFailFollowRepo) ListFollowed(_, _, _ string, _, _ int) ([]*model.ChannelFollowing, error) {
 	return nil, errors.New("list boom")
 }
 
@@ -300,7 +300,7 @@ func TestListFollowed_ListError(t *testing.T) {
 	followRepo := &listFailFollowRepo{MockChannelFollowingRepository: testutil.NewMockChannelFollowingRepository()}
 	idGen, _ := id.NewGenerator("aidx")
 	svc := channel.NewService(repo, followRepo, testutil.NewMockNoteRepository(), idGen)
-	_, err := svc.ListFollowed("u1", 10, 0)
+	_, err := svc.ListFollowed("u1", "", "", 10, 0)
 	assert.Error(t, err)
 }
 
@@ -309,7 +309,7 @@ func TestListOwned(t *testing.T) {
 	owner := "u1"
 	repo.Channels["c1"] = &model.Channel{ID: "c1", UserID: &owner}
 	repo.Channels["c2"] = &model.Channel{ID: "c2", UserID: &owner}
-	rows, err := svc.ListOwned("u1", 10, 0)
+	rows, err := svc.ListOwned("u1", "", "", 10, 0)
 	require.NoError(t, err)
 	assert.Len(t, rows, 2)
 }
@@ -317,7 +317,7 @@ func TestListOwned(t *testing.T) {
 func TestListFeatured(t *testing.T) {
 	svc, repo, _, _ := newSvc(t)
 	repo.Channels["c1"] = &model.Channel{ID: "c1"}
-	rows, err := svc.ListFeatured(10, 0)
+	rows, err := svc.ListFeatured("", "", 10, 0)
 	require.NoError(t, err)
 	assert.Len(t, rows, 1)
 }
@@ -326,7 +326,7 @@ func TestSearch(t *testing.T) {
 	svc, repo, _, _ := newSvc(t)
 	repo.Channels["c1"] = &model.Channel{ID: "c1", Name: "alpha"}
 	repo.Channels["c2"] = &model.Channel{ID: "c2", Name: "beta"}
-	rows, err := svc.Search("alp", 10, 0)
+	rows, err := svc.Search("alp", "", "", 10, 0)
 	require.NoError(t, err)
 	assert.Len(t, rows, 1)
 }

--- a/internal/core/flash/flash_service.go
+++ b/internal/core/flash/flash_service.go
@@ -169,19 +169,21 @@ func (s *Service) Delete(ownerID, flashID string) error {
 	return s.repo.Delete(f)
 }
 
-// My returns the flashes owned by userID, ordered by updatedAt desc.
-func (s *Service) My(userID string, limit, offset int) ([]*model.Flash, error) {
-	return s.repo.ListByUser(userID, limit, offset)
+// My returns the flashes owned by userID with cursor (sinceID/untilID) or
+// offset pagination. Cursor 指定時は offset 無視。
+func (s *Service) My(userID, sinceID, untilID string, limit, offset int) ([]*model.Flash, error) {
+	return s.repo.ListByUser(userID, sinceID, untilID, limit, offset)
 }
 
-// Featured returns the flashes ordered by likedCount desc.
-func (s *Service) Featured(limit, offset int) ([]*model.Flash, error) {
-	return s.repo.ListFeatured(limit, offset)
+// Featured returns the flashes ordered by likedCount desc, or by id when
+// cursor is supplied (frontend Paginator対応)。
+func (s *Service) Featured(sinceID, untilID string, limit, offset int) ([]*model.Flash, error) {
+	return s.repo.ListFeatured(sinceID, untilID, limit, offset)
 }
 
 // Search performs a substring search across title and summary.
-func (s *Service) Search(query string, limit, offset int) ([]*model.Flash, error) {
-	return s.repo.Search(query, limit, offset)
+func (s *Service) Search(query, sinceID, untilID string, limit, offset int) ([]*model.Flash, error) {
+	return s.repo.Search(query, sinceID, untilID, limit, offset)
 }
 
 // Like attaches a Like row from userID to flashID.
@@ -229,20 +231,36 @@ func (s *Service) Unlike(userID, flashID string) error {
 	return nil
 }
 
-// MyLikes returns the flashes that userID has liked, newest first.
-func (s *Service) MyLikes(userID string, limit, offset int) ([]*model.Flash, error) {
-	likes, err := s.likeRepo.ListByUser(userID, limit, offset)
+// IsLikedBy reports whether userID has liked flashID. Used by flash/show
+// to set `isLiked` on the response so the frontend's like button reflects
+// the current state.
+func (s *Service) IsLikedBy(userID, flashID string) (bool, error) {
+	return s.likeRepo.Exists(userID, flashID)
+}
+
+// LikedFlash pairs a flash_like row id with the flash it points to. Used by
+// flash/my-likes to match upstream's `{id, flash: Flash}` response shape
+// (id = flash_like row id, NOT flash id).
+type LikedFlash struct {
+	LikeID string
+	Flash  *model.Flash
+}
+
+// MyLikes returns the flashes that userID has liked, newest first, paired
+// with the flash_like row id used for cursor pagination.
+func (s *Service) MyLikes(userID, sinceID, untilID string, limit, offset int) ([]LikedFlash, error) {
+	likes, err := s.likeRepo.ListByUser(userID, sinceID, untilID, limit, offset)
 	if err != nil {
 		return nil, err
 	}
-	out := make([]*model.Flash, 0, len(likes))
+	out := make([]LikedFlash, 0, len(likes))
 	for _, l := range likes {
 		f, err := s.repo.FindByID(l.FlashID)
 		if err != nil {
 			// 削除されていたり権限が変わった Flash はスキップする。
 			continue
 		}
-		out = append(out, f)
+		out = append(out, LikedFlash{LikeID: l.ID, Flash: f})
 	}
 	return out, nil
 }

--- a/internal/core/flash/flash_service_test.go
+++ b/internal/core/flash/flash_service_test.go
@@ -173,7 +173,7 @@ func TestMy(t *testing.T) {
 	svc, repo, _ := newSvc(t)
 	repo.Flashes["f1"] = &model.Flash{ID: "f1", UserID: "u1"}
 	repo.Flashes["f2"] = &model.Flash{ID: "f2", UserID: "u1"}
-	rows, err := svc.My("u1", 10, 0)
+	rows, err := svc.My("u1", "", "", 10, 0)
 	require.NoError(t, err)
 	assert.Len(t, rows, 2)
 }
@@ -182,7 +182,7 @@ func TestFeatured(t *testing.T) {
 	svc, repo, _ := newSvc(t)
 	repo.Flashes["f1"] = &model.Flash{ID: "f1", UserID: "u1", LikedCount: 5}
 	repo.Flashes["f2"] = &model.Flash{ID: "f2", UserID: "u1", LikedCount: 10}
-	rows, err := svc.Featured(10, 0)
+	rows, err := svc.Featured("", "", 10, 0)
 	require.NoError(t, err)
 	require.Len(t, rows, 2)
 	assert.Equal(t, "f2", rows[0].ID)
@@ -193,7 +193,7 @@ func TestSearch(t *testing.T) {
 	svc, repo, _ := newSvc(t)
 	repo.Flashes["f1"] = &model.Flash{ID: "f1", UserID: "u1", Title: "alpha calc"}
 	repo.Flashes["f2"] = &model.Flash{ID: "f2", UserID: "u1", Title: "beta game"}
-	rows, err := svc.Search("calc", 10, 0)
+	rows, err := svc.Search("calc", "", "", 10, 0)
 	require.NoError(t, err)
 	assert.Len(t, rows, 1)
 }
@@ -320,7 +320,7 @@ func TestMyLikes_HappyPath(t *testing.T) {
 	repo.Flashes["f2"] = &model.Flash{ID: "f2", UserID: "u1"}
 	require.NoError(t, svc.Like("u2", "f1"))
 	require.NoError(t, svc.Like("u2", "f2"))
-	rows, err := svc.MyLikes("u2", 10, 0)
+	rows, err := svc.MyLikes("u2", "", "", 10, 0)
 	require.NoError(t, err)
 	assert.Len(t, rows, 2)
 }
@@ -331,7 +331,7 @@ func TestMyLikes_SkipsMissingFlashes(t *testing.T) {
 	require.NoError(t, svc.Like("u2", "f1"))
 	// Insert a stale like pointing to a non-existent flash.
 	likeRepo.Likes["stale"] = &model.FlashLike{ID: "stale", UserID: "u2", FlashID: "missing"}
-	rows, err := svc.MyLikes("u2", 10, 0)
+	rows, err := svc.MyLikes("u2", "", "", 10, 0)
 	require.NoError(t, err)
 	assert.Len(t, rows, 1)
 }
@@ -341,7 +341,7 @@ type failingListLikeRepo struct {
 	*testutil.MockFlashLikeRepository
 }
 
-func (r *failingListLikeRepo) ListByUser(_ string, _, _ int) ([]*model.FlashLike, error) {
+func (r *failingListLikeRepo) ListByUser(_, _, _ string, _, _ int) ([]*model.FlashLike, error) {
 	return nil, errors.New("boom")
 }
 
@@ -350,7 +350,7 @@ func TestMyLikes_RepoError(t *testing.T) {
 	likeRepo := &failingListLikeRepo{MockFlashLikeRepository: testutil.NewMockFlashLikeRepository()}
 	idGen, _ := id.NewGenerator("aidx")
 	svc := flash.NewService(repo, likeRepo, idGen)
-	_, err := svc.MyLikes("u2", 10, 0)
+	_, err := svc.MyLikes("u2", "", "", 10, 0)
 	assert.Error(t, err)
 }
 

--- a/internal/core/muting/muting_service.go
+++ b/internal/core/muting/muting_service.go
@@ -82,12 +82,13 @@ func (s *Service) IsMuted(muterID, muteeID string) (bool, error) {
 	return s.mutingRepo.Exists(muterID, muteeID)
 }
 
-// List returns the user's mutings.
-func (s *Service) List(muterID string, limit, offset int) ([]*model.Muting, error) {
+// List returns the user's mutings with cursor (sinceID/untilID) or offset
+// pagination. Cursor 指定時は offset 無視 (upstream makePaginationQuery と一致)。
+func (s *Service) List(muterID, sinceID, untilID string, limit, offset int) ([]*model.Muting, error) {
 	if limit <= 0 {
 		limit = 10
 	}
-	return s.mutingRepo.ListByMuter(muterID, limit, offset)
+	return s.mutingRepo.ListByMuter(muterID, sinceID, untilID, limit, offset)
 }
 
 // RenoteService manages renote-only mutes (the mutee can still post original
@@ -149,10 +150,11 @@ func (s *RenoteService) IsRenoteMuted(muterID, muteeID string) (bool, error) {
 	return s.renoteMutingRepo.Exists(muterID, muteeID)
 }
 
-// List returns the user's renote mutings.
-func (s *RenoteService) List(muterID string, limit, offset int) ([]*model.RenoteMuting, error) {
+// List returns the user's renote mutings with cursor (sinceID/untilID) or
+// offset pagination.
+func (s *RenoteService) List(muterID, sinceID, untilID string, limit, offset int) ([]*model.RenoteMuting, error) {
 	if limit <= 0 {
 		limit = 10
 	}
-	return s.renoteMutingRepo.ListByMuter(muterID, limit, offset)
+	return s.renoteMutingRepo.ListByMuter(muterID, sinceID, untilID, limit, offset)
 }

--- a/internal/core/muting/muting_service_test.go
+++ b/internal/core/muting/muting_service_test.go
@@ -132,10 +132,10 @@ func TestIsMutedAndList(t *testing.T) {
 	require.NoError(t, err)
 	assert.True(t, yes)
 
-	rows, err := svc.List("a", 0, 0)
+	rows, err := svc.List("a", "", "", 0, 0)
 	require.NoError(t, err)
 	assert.Len(t, rows, 1)
-	rows, err = svc.List("a", 5, 0)
+	rows, err = svc.List("a", "", "", 5, 0)
 	require.NoError(t, err)
 	assert.Len(t, rows, 1)
 }
@@ -225,10 +225,10 @@ func TestRenoteIsMutedAndList(t *testing.T) {
 	yes, err := svc.IsRenoteMuted("a", "b")
 	require.NoError(t, err)
 	assert.True(t, yes)
-	rows, err := svc.List("a", 0, 0)
+	rows, err := svc.List("a", "", "", 0, 0)
 	require.NoError(t, err)
 	assert.Len(t, rows, 1)
-	rows, err = svc.List("a", 5, 0)
+	rows, err = svc.List("a", "", "", 5, 0)
 	require.NoError(t, err)
 	assert.Len(t, rows, 1)
 }

--- a/internal/core/page/page_service.go
+++ b/internal/core/page/page_service.go
@@ -258,14 +258,16 @@ func (s *Service) Delete(ownerID, pageID string) error {
 	return s.repo.Delete(p)
 }
 
-// ListByUser returns the pages owned by userID.
-func (s *Service) ListByUser(userID string, limit, offset int) ([]*model.Page, error) {
-	return s.repo.ListByUser(userID, limit, offset)
+// ListByUser returns the pages owned by userID with cursor (sinceID/untilID)
+// or offset pagination. Cursor 指定時は offset を無視。
+func (s *Service) ListByUser(userID, sinceID, untilID string, limit, offset int) ([]*model.Page, error) {
+	return s.repo.ListByUser(userID, sinceID, untilID, limit, offset)
 }
 
-// Featured returns the public pages ordered by likedCount desc.
-func (s *Service) Featured(limit, offset int) ([]*model.Page, error) {
-	return s.repo.ListFeatured(limit, offset)
+// Featured returns the public pages ordered by likedCount desc, or by id
+// when cursor (sinceID/untilID) is supplied (frontend Paginator対応)。
+func (s *Service) Featured(sinceID, untilID string, limit, offset int) ([]*model.Page, error) {
+	return s.repo.ListFeatured(sinceID, untilID, limit, offset)
 }
 
 // Like attaches a Like row from userID to pageID. Public pages can be liked

--- a/internal/core/page/page_service_test.go
+++ b/internal/core/page/page_service_test.go
@@ -302,7 +302,7 @@ func TestListByUser(t *testing.T) {
 	svc, repo, _ := newSvc(t)
 	repo.Pages["p1"] = &model.Page{ID: "p1", UserID: "u1"}
 	repo.Pages["p2"] = &model.Page{ID: "p2", UserID: "u1"}
-	rows, err := svc.ListByUser("u1", 10, 0)
+	rows, err := svc.ListByUser("u1", "", "", 10, 0)
 	require.NoError(t, err)
 	assert.Len(t, rows, 2)
 }
@@ -312,7 +312,7 @@ func TestFeatured(t *testing.T) {
 	repo.Pages["p1"] = &model.Page{ID: "p1", UserID: "u1", Visibility: model.PageVisibilityPublic, LikedCount: 5}
 	repo.Pages["p2"] = &model.Page{ID: "p2", UserID: "u1", Visibility: model.PageVisibilityPublic, LikedCount: 10}
 	repo.Pages["p3"] = &model.Page{ID: "p3", UserID: "u1", Visibility: model.PageVisibilityFollowers, LikedCount: 100}
-	rows, err := svc.Featured(10, 0)
+	rows, err := svc.Featured("", "", 10, 0)
 	require.NoError(t, err)
 	require.Len(t, rows, 2)
 	assert.Equal(t, "p2", rows[0].ID)

--- a/internal/core/transfer/errors_test.go
+++ b/internal/core/transfer/errors_test.go
@@ -27,7 +27,7 @@ type failingBlockingRepo struct {
 	*testutil.MockBlockingRepository
 }
 
-func (f *failingBlockingRepo) ListByBlocker(_ string, _, _ int) ([]*model.Blocking, error) {
+func (f *failingBlockingRepo) ListByBlocker(_, _, _ string, _, _ int) ([]*model.Blocking, error) {
 	return nil, errors.New("db boom")
 }
 
@@ -36,7 +36,7 @@ type failingMutingRepo struct {
 	*testutil.MockMutingRepository
 }
 
-func (f *failingMutingRepo) ListByMuter(_ string, _, _ int) ([]*model.Muting, error) {
+func (f *failingMutingRepo) ListByMuter(_, _, _ string, _, _ int) ([]*model.Muting, error) {
 	return nil, errors.New("db boom")
 }
 

--- a/internal/core/transfer/export_csv.go
+++ b/internal/core/transfer/export_csv.go
@@ -43,7 +43,7 @@ func (e *Exporter) exportBlocking(userID string) ([]byte, error) {
 	var buf bytes.Buffer
 	offset := 0
 	for {
-		rows, err := e.deps.BlockingRepo.ListByBlocker(userID, csvBatchSize, offset)
+		rows, err := e.deps.BlockingRepo.ListByBlocker(userID, "", "", csvBatchSize, offset)
 		if err != nil {
 			return nil, err
 		}
@@ -71,7 +71,7 @@ func (e *Exporter) exportMuting(userID string) ([]byte, error) {
 	var buf bytes.Buffer
 	offset := 0
 	for {
-		rows, err := e.deps.MutingRepo.ListByMuter(userID, csvBatchSize, offset)
+		rows, err := e.deps.MutingRepo.ListByMuter(userID, "", "", csvBatchSize, offset)
 		if err != nil {
 			return nil, err
 		}

--- a/internal/model/channel.go
+++ b/internal/model/channel.go
@@ -45,4 +45,8 @@ type ChannelListFilter struct {
 	SortBy     string // "+lastNotedAt" / "-lastNotedAt" / "+name" / "-notesCount" 等
 	Limit      int
 	Offset     int
+	// Cursor pagination (frontend Paginator). 指定時は SortBy を id 順に
+	// 上書きして cursor 一貫性を保つ。Offset は無視する。
+	SinceID string
+	UntilID string
 }

--- a/internal/model/instance.go
+++ b/internal/model/instance.go
@@ -54,4 +54,8 @@ type InstanceListFilter struct {
 	SortBy        string
 	Limit         int
 	Offset        int
+	// Cursor pagination (frontend Paginator). 指定時は SortBy を id 順に
+	// 上書きして cursor 一貫性を保つ。Offset は無視する。
+	SinceID string
+	UntilID string
 }

--- a/internal/repository/blocking.go
+++ b/internal/repository/blocking.go
@@ -11,7 +11,8 @@ type BlockingRepository interface {
 	Delete(b *model.Blocking) error
 	FindByPair(blockerID, blockeeID string) (*model.Blocking, error)
 	Exists(blockerID, blockeeID string) (bool, error)
-	ListByBlocker(blockerID string, limit, offset int) ([]*model.Blocking, error)
+	// ListByBlocker supports cursor (sinceID/untilID) and offset pagination.
+	ListByBlocker(blockerID, sinceID, untilID string, limit, offset int) ([]*model.Blocking, error)
 }
 
 type blockingRepository struct {
@@ -49,13 +50,20 @@ func (r *blockingRepository) Exists(blockerID, blockeeID string) (bool, error) {
 	return count > 0, nil
 }
 
-func (r *blockingRepository) ListByBlocker(blockerID string, limit, offset int) ([]*model.Blocking, error) {
+func (r *blockingRepository) ListByBlocker(blockerID, sinceID, untilID string, limit, offset int) ([]*model.Blocking, error) {
+	q := r.db.Where(`"blockerId" = ?`, blockerID)
+	if sinceID != "" {
+		q = q.Where("id > ?", sinceID)
+	}
+	if untilID != "" {
+		q = q.Where("id < ?", untilID)
+	}
+	q = q.Order(paginationOrder(sinceID, untilID, "id")).Limit(limit)
+	if sinceID == "" && untilID == "" && offset > 0 {
+		q = q.Offset(offset)
+	}
 	var rows []*model.Blocking
-	if err := r.db.Where("\"blockerId\" = ?", blockerID).
-		Order("id DESC").
-		Limit(limit).
-		Offset(offset).
-		Find(&rows).Error; err != nil {
+	if err := q.Find(&rows).Error; err != nil {
 		return nil, err
 	}
 	return rows, nil

--- a/internal/repository/blocking_test.go
+++ b/internal/repository/blocking_test.go
@@ -37,7 +37,7 @@ func TestBlockingRepository_CRUD(t *testing.T) {
 	require.NoError(t, err)
 	assert.False(t, exists)
 
-	rows, err := repo.ListByBlocker(u1.ID, 10, 0)
+	rows, err := repo.ListByBlocker(u1.ID, "", "", 10, 0)
 	require.NoError(t, err)
 	assert.Len(t, rows, 1)
 
@@ -57,6 +57,6 @@ func TestBlockingRepository_QueryErrors(t *testing.T) {
 	assert.Error(t, err)
 	_, err = repo.Exists("a", "b")
 	assert.Error(t, err)
-	_, err = repo.ListByBlocker("a", 10, 0)
+	_, err = repo.ListByBlocker("a", "", "", 10, 0)
 	assert.Error(t, err)
 }

--- a/internal/repository/channel.go
+++ b/internal/repository/channel.go
@@ -65,6 +65,8 @@ func (r *channelRepository) IncrementCount(channelID, column string, delta int) 
 }
 
 // List returns channels matching the filter, ordered by the requested sort.
+// Cursor (SinceID / UntilID) 指定時は id 順 + WHERE id 範囲で frontend
+// Paginator に対応する。Offset は無視。
 func (r *channelRepository) List(filter model.ChannelListFilter) ([]*model.Channel, error) {
 	q := r.db.Model(&model.Channel{})
 	if filter.OwnerID != "" {
@@ -76,25 +78,36 @@ func (r *channelRepository) List(filter model.ChannelListFilter) ([]*model.Chann
 	if filter.IsArchived != nil {
 		q = q.Where("\"isArchived\" = ?", *filter.IsArchived)
 	}
-	switch filter.SortBy {
-	case "+lastNotedAt":
-		q = q.Order("\"lastNotedAt\" ASC NULLS LAST")
-	case "-lastNotedAt":
-		q = q.Order("\"lastNotedAt\" DESC NULLS LAST")
-	case "+name":
-		q = q.Order("name ASC")
-	case "-name":
-		q = q.Order("name DESC")
-	case "+notesCount":
-		q = q.Order("\"notesCount\" ASC")
-	case "-notesCount":
-		q = q.Order("\"notesCount\" DESC")
-	case "+usersCount":
-		q = q.Order("\"usersCount\" ASC")
-	case "-usersCount":
-		q = q.Order("\"usersCount\" DESC")
-	default:
-		q = q.Order("\"lastNotedAt\" DESC NULLS LAST")
+	cursor := filter.SinceID != "" || filter.UntilID != ""
+	if filter.SinceID != "" {
+		q = q.Where("id > ?", filter.SinceID)
+	}
+	if filter.UntilID != "" {
+		q = q.Where("id < ?", filter.UntilID)
+	}
+	if cursor {
+		q = q.Order(paginationOrder(filter.SinceID, filter.UntilID, "id"))
+	} else {
+		switch filter.SortBy {
+		case "+lastNotedAt":
+			q = q.Order("\"lastNotedAt\" ASC NULLS LAST")
+		case "-lastNotedAt":
+			q = q.Order("\"lastNotedAt\" DESC NULLS LAST")
+		case "+name":
+			q = q.Order("name ASC")
+		case "-name":
+			q = q.Order("name DESC")
+		case "+notesCount":
+			q = q.Order("\"notesCount\" ASC")
+		case "-notesCount":
+			q = q.Order("\"notesCount\" DESC")
+		case "+usersCount":
+			q = q.Order("\"usersCount\" ASC")
+		case "-usersCount":
+			q = q.Order("\"usersCount\" DESC")
+		default:
+			q = q.Order("\"lastNotedAt\" DESC NULLS LAST")
+		}
 	}
 	limit := filter.Limit
 	if limit <= 0 {
@@ -103,7 +116,10 @@ func (r *channelRepository) List(filter model.ChannelListFilter) ([]*model.Chann
 	if limit > 100 {
 		limit = 100
 	}
-	q = q.Limit(limit).Offset(filter.Offset)
+	q = q.Limit(limit)
+	if !cursor && filter.Offset > 0 {
+		q = q.Offset(filter.Offset)
+	}
 	var rows []*model.Channel
 	if err := q.Find(&rows).Error; err != nil {
 		return nil, err

--- a/internal/repository/channel_following.go
+++ b/internal/repository/channel_following.go
@@ -12,7 +12,9 @@ type ChannelFollowingRepository interface {
 	Delete(f *model.ChannelFollowing) error
 	FindByPair(followerID, channelID string) (*model.ChannelFollowing, error)
 	Exists(followerID, channelID string) (bool, error)
-	ListFollowed(userID string, limit, offset int) ([]*model.ChannelFollowing, error)
+	// ListFollowed returns channel_following rows for userID with cursor
+	// (sinceID/untilID) or offset pagination. Cursor 指定時は offset 無視。
+	ListFollowed(userID, sinceID, untilID string, limit, offset int) ([]*model.ChannelFollowing, error)
 	// ListFollowerIDsPage returns a batch of follower userIds for a channel,
 	// ordered by row id ASC. afterRowID は前ページの nextCursor を渡す
 	// (空なら先頭から)。返り値の nextCursor は次回 call にそのまま渡せる
@@ -91,20 +93,27 @@ func (r *channelFollowingRepository) ListFollowerIDsPage(channelID, afterRowID s
 }
 
 // ListFollowed returns the channel followings for a given user, ordered by id
-// descending (newest first).
-func (r *channelFollowingRepository) ListFollowed(userID string, limit, offset int) ([]*model.ChannelFollowing, error) {
+// descending (newest first), with cursor or offset pagination support.
+func (r *channelFollowingRepository) ListFollowed(userID, sinceID, untilID string, limit, offset int) ([]*model.ChannelFollowing, error) {
 	if limit <= 0 {
 		limit = 30
 	}
 	if limit > 100 {
 		limit = 100
 	}
+	q := r.db.Where(`"followerId" = ?`, userID)
+	if sinceID != "" {
+		q = q.Where("id > ?", sinceID)
+	}
+	if untilID != "" {
+		q = q.Where("id < ?", untilID)
+	}
+	q = q.Order(paginationOrder(sinceID, untilID, "id")).Limit(limit)
+	if sinceID == "" && untilID == "" && offset > 0 {
+		q = q.Offset(offset)
+	}
 	var rows []*model.ChannelFollowing
-	if err := r.db.Where("\"followerId\" = ?", userID).
-		Order("id DESC").
-		Limit(limit).
-		Offset(offset).
-		Find(&rows).Error; err != nil {
+	if err := q.Find(&rows).Error; err != nil {
 		return nil, err
 	}
 	return rows, nil

--- a/internal/repository/channel_following.go
+++ b/internal/repository/channel_following.go
@@ -92,8 +92,15 @@ func (r *channelFollowingRepository) ListFollowerIDsPage(channelID, afterRowID s
 	return ids, rows[len(rows)-1].ID, nil
 }
 
-// ListFollowed returns the channel followings for a given user, ordered by id
-// descending (newest first), with cursor or offset pagination support.
+// ListFollowed returns the channel followings for a given user, ordered by
+// followeeId DESC by default with cursor or offset pagination support.
+//
+// 注意: cursor (sinceID/untilID) は **followeeId** (= channel.id) を基準に
+// する。frontend Paginator は response の `id` (= channel.id を返している)
+// を次ページの cursor として送ってくるので、ここで channel_following.id
+// を使うと domain mismatch で次ページが空になる (#520 review 指摘)。
+// upstream Misskey の channels/followed.ts も makePaginationQuery の 6 番目
+// 引数に 'followeeId' を渡して同じ列で paginate している。
 func (r *channelFollowingRepository) ListFollowed(userID, sinceID, untilID string, limit, offset int) ([]*model.ChannelFollowing, error) {
 	if limit <= 0 {
 		limit = 30
@@ -103,12 +110,12 @@ func (r *channelFollowingRepository) ListFollowed(userID, sinceID, untilID strin
 	}
 	q := r.db.Where(`"followerId" = ?`, userID)
 	if sinceID != "" {
-		q = q.Where("id > ?", sinceID)
+		q = q.Where(`"followeeId" > ?`, sinceID)
 	}
 	if untilID != "" {
-		q = q.Where("id < ?", untilID)
+		q = q.Where(`"followeeId" < ?`, untilID)
 	}
-	q = q.Order(paginationOrder(sinceID, untilID, "id")).Limit(limit)
+	q = q.Order(paginationOrder(sinceID, untilID, `"followeeId"`)).Limit(limit)
 	if sinceID == "" && untilID == "" && offset > 0 {
 		q = q.Offset(offset)
 	}

--- a/internal/repository/channel_following_test.go
+++ b/internal/repository/channel_following_test.go
@@ -30,7 +30,7 @@ func TestChannelFollowingRepository_LifeCycle(t *testing.T) {
 	require.NoError(t, err)
 	assert.True(t, exists)
 
-	rows, err := repo.ListFollowed(user.ID, 10, 0)
+	rows, err := repo.ListFollowed(user.ID, "", "", 10, 0)
 	require.NoError(t, err)
 	assert.Len(t, rows, 1)
 
@@ -48,10 +48,10 @@ func TestChannelFollowingRepository_FindByPair_NotFound(t *testing.T) {
 
 func TestChannelFollowingRepository_ListFollowed_LimitClamp(t *testing.T) {
 	repo := NewChannelFollowingRepository(testDB)
-	rows, err := repo.ListFollowed("nobody", 9999, 0)
+	rows, err := repo.ListFollowed("nobody", "", "", 9999, 0)
 	require.NoError(t, err)
 	assert.Empty(t, rows)
-	rows, err = repo.ListFollowed("nobody", -1, 0)
+	rows, err = repo.ListFollowed("nobody", "", "", -1, 0)
 	require.NoError(t, err)
 	assert.Empty(t, rows)
 }
@@ -108,7 +108,7 @@ func TestChannelFollowingRepository_QueryErrors(t *testing.T) {
 	repo := NewChannelFollowingRepository(db)
 	_, err := repo.Exists("a", "b")
 	assert.Error(t, err)
-	_, err = repo.ListFollowed("a", 10, 0)
+	_, err = repo.ListFollowed("a", "", "", 10, 0)
 	assert.Error(t, err)
 	_, _, err = repo.ListFollowerIDsPage("a", "", 10)
 	assert.Error(t, err)

--- a/internal/repository/coverage_batch_test.go
+++ b/internal/repository/coverage_batch_test.go
@@ -141,14 +141,14 @@ func TestFlashRepository_ListPublicByUser(t *testing.T) {
 	).Error)
 	defer testDB.Exec(`DELETE FROM "flash" WHERE id IN (?, ?)`, "fl_pub_1", "fl_priv_1")
 
-	rows, err := repo.ListPublicByUser(u.ID, 10, 0)
+	rows, err := repo.ListPublicByUser(u.ID, "", "", 10, 0)
 	require.NoError(t, err)
 	assert.Len(t, rows, 1)
 	assert.Equal(t, "fl_pub_1", rows[0].ID)
 
-	_, err = repo.ListPublicByUser(u.ID, 0, 0)
+	_, err = repo.ListPublicByUser(u.ID, "", "", 0, 0)
 	require.NoError(t, err)
-	_, err = repo.ListPublicByUser(u.ID, 999, 0)
+	_, err = repo.ListPublicByUser(u.ID, "", "", 999, 0)
 	require.NoError(t, err)
 }
 
@@ -167,7 +167,7 @@ func TestPageRepository_ListPublicByUser(t *testing.T) {
 	).Error)
 	defer testDB.Exec(`DELETE FROM "page" WHERE id IN (?, ?)`, "pg_pub_1", "pg_priv_1")
 
-	rows, err := repo.ListPublicByUser(u.ID, 10, 0)
+	rows, err := repo.ListPublicByUser(u.ID, "", "", 10, 0)
 	require.NoError(t, err)
 	assert.Len(t, rows, 1)
 	assert.Equal(t, "pg_pub_1", rows[0].ID)

--- a/internal/repository/coverage_complete_test.go
+++ b/internal/repository/coverage_complete_test.go
@@ -174,9 +174,9 @@ func TestErrorPaths_CancelledContext(t *testing.T) {
 	// clip / flash / page (ListPublicByUser)
 	_, err = NewClipRepository(db).ListPublicByUser("x", "", "", 10, 0)
 	assert.Error(t, err)
-	_, err = NewFlashRepository(db).ListPublicByUser("x", 10, 0)
+	_, err = NewFlashRepository(db).ListPublicByUser("x", "", "", 10, 0)
 	assert.Error(t, err)
-	_, err = NewPageRepository(db).ListPublicByUser("x", 10, 0)
+	_, err = NewPageRepository(db).ListPublicByUser("x", "", "", 10, 0)
 	assert.Error(t, err)
 
 	// drive_file
@@ -211,9 +211,9 @@ func TestErrorPaths_CancelledContext(t *testing.T) {
 	assert.Error(t, err)
 
 	// gallery
-	_, err = NewGalleryRepository(db).ListByUser("x", 10, 0)
+	_, err = NewGalleryRepository(db).ListByUser("x", "", "", 10, 0)
 	assert.Error(t, err)
-	_, err = NewGalleryRepository(db).ListLikesByUser("x", 10, 0)
+	_, err = NewGalleryRepository(db).ListLikesByUser("x", "", "", 10, 0)
 	assert.Error(t, err)
 
 	// note

--- a/internal/repository/coverage_final_test.go
+++ b/internal/repository/coverage_final_test.go
@@ -84,9 +84,9 @@ func TestUserListRepository_UpdateMembership_NotFound(t *testing.T) {
 
 func TestPageRepository_ListPublicByUser_Clamp(t *testing.T) {
 	r := NewPageRepository(testDB)
-	_, err := r.ListPublicByUser("x", 0, 0)
+	_, err := r.ListPublicByUser("x", "", "", 0, 0)
 	require.NoError(t, err)
-	_, err = r.ListPublicByUser("x", 999, 0)
+	_, err = r.ListPublicByUser("x", "", "", 999, 0)
 	require.NoError(t, err)
 }
 

--- a/internal/repository/flash.go
+++ b/internal/repository/flash.go
@@ -11,12 +11,18 @@ type FlashRepository interface {
 	FindByID(id string) (*model.Flash, error)
 	UpdateFields(flashID string, fields map[string]any) error
 	Delete(f *model.Flash) error
-	ListByUser(userID string, limit, offset int) ([]*model.Flash, error)
+	// ListByUser returns flashes owned by userID with cursor (sinceID/untilID)
+	// or offset pagination. Cursor 指定時は offset 無視。
+	ListByUser(userID, sinceID, untilID string, limit, offset int) ([]*model.Flash, error)
 	// ListPublicByUser returns only public flashes (visibility='public') owned
 	// by userID, used by users/flashs when viewer is not the owner.
-	ListPublicByUser(userID string, limit, offset int) ([]*model.Flash, error)
-	ListFeatured(limit, offset int) ([]*model.Flash, error)
-	Search(query string, limit, offset int) ([]*model.Flash, error)
+	ListPublicByUser(userID, sinceID, untilID string, limit, offset int) ([]*model.Flash, error)
+	// ListFeatured returns the most-liked flashes (offset mode) or id-ordered
+	// (cursor mode).
+	ListFeatured(sinceID, untilID string, limit, offset int) ([]*model.Flash, error)
+	// Search performs a substring search across title and summary, with
+	// cursor or offset pagination.
+	Search(query, sinceID, untilID string, limit, offset int) ([]*model.Flash, error)
 	IncrementCount(flashID, column string, delta int) error
 }
 
@@ -52,78 +58,119 @@ func (r *flashRepository) Delete(f *model.Flash) error {
 	return r.db.Delete(f).Error
 }
 
-// ListByUser returns the flashes owned by userID, ordered by updatedAt desc.
-func (r *flashRepository) ListByUser(userID string, limit, offset int) ([]*model.Flash, error) {
+// ListByUser returns the flashes owned by userID with cursor (sinceID/untilID)
+// or offset pagination. cursor mode は upstream `makePaginationQuery` 同様
+// id 基準で sort + filter する (元実装の `updatedAt DESC` は frontend
+// Paginator の untilId/sinceId と整合しないため変更)。
+func (r *flashRepository) ListByUser(userID, sinceID, untilID string, limit, offset int) ([]*model.Flash, error) {
 	if limit <= 0 {
 		limit = 30
 	}
 	if limit > 100 {
 		limit = 100
 	}
+	q := r.db.Where(`"userId" = ?`, userID)
+	if sinceID != "" {
+		q = q.Where("id > ?", sinceID)
+	}
+	if untilID != "" {
+		q = q.Where("id < ?", untilID)
+	}
+	q = q.Order(paginationOrder(sinceID, untilID, "id")).Limit(limit)
+	if sinceID == "" && untilID == "" && offset > 0 {
+		q = q.Offset(offset)
+	}
 	var rows []*model.Flash
-	if err := r.db.Where("\"userId\" = ?", userID).
-		Order("\"updatedAt\" DESC").
-		Limit(limit).
-		Offset(offset).
-		Find(&rows).Error; err != nil {
+	if err := q.Find(&rows).Error; err != nil {
 		return nil, err
 	}
 	return rows, nil
 }
 
-func (r *flashRepository) ListPublicByUser(userID string, limit, offset int) ([]*model.Flash, error) {
+func (r *flashRepository) ListPublicByUser(userID, sinceID, untilID string, limit, offset int) ([]*model.Flash, error) {
 	if limit <= 0 {
 		limit = 30
 	}
 	if limit > 100 {
 		limit = 100
 	}
+	q := r.db.Where(`"userId" = ? AND visibility = 'public'`, userID)
+	if sinceID != "" {
+		q = q.Where("id > ?", sinceID)
+	}
+	if untilID != "" {
+		q = q.Where("id < ?", untilID)
+	}
+	q = q.Order(paginationOrder(sinceID, untilID, "id")).Limit(limit)
+	if sinceID == "" && untilID == "" && offset > 0 {
+		q = q.Offset(offset)
+	}
 	var rows []*model.Flash
-	if err := r.db.Where("\"userId\" = ? AND visibility = 'public'", userID).
-		Order("\"updatedAt\" DESC").
-		Limit(limit).
-		Offset(offset).
-		Find(&rows).Error; err != nil {
+	if err := q.Find(&rows).Error; err != nil {
 		return nil, err
 	}
 	return rows, nil
 }
 
-// ListFeatured returns the most-liked flashes overall.
-func (r *flashRepository) ListFeatured(limit, offset int) ([]*model.Flash, error) {
+// ListFeatured returns the most-liked flashes (offset mode), or id-ordered
+// when cursor is supplied (frontend Paginator対応)。
+func (r *flashRepository) ListFeatured(sinceID, untilID string, limit, offset int) ([]*model.Flash, error) {
 	if limit <= 0 {
 		limit = 30
 	}
 	if limit > 100 {
 		limit = 100
 	}
+	q := r.db.Session(&gorm.Session{})
+	if sinceID != "" {
+		q = q.Where("id > ?", sinceID)
+	}
+	if untilID != "" {
+		q = q.Where("id < ?", untilID)
+	}
+	if sinceID != "" || untilID != "" {
+		q = q.Order(paginationOrder(sinceID, untilID, "id"))
+	} else {
+		q = q.Order(`"likedCount" DESC`)
+	}
+	q = q.Limit(limit)
+	if sinceID == "" && untilID == "" && offset > 0 {
+		q = q.Offset(offset)
+	}
 	var rows []*model.Flash
-	if err := r.db.
-		Order("\"likedCount\" DESC").
-		Limit(limit).
-		Offset(offset).
-		Find(&rows).Error; err != nil {
+	if err := q.Find(&rows).Error; err != nil {
 		return nil, err
 	}
 	return rows, nil
 }
 
-// Search performs a substring search across title and summary, ordered by
-// updatedAt desc.
-func (r *flashRepository) Search(query string, limit, offset int) ([]*model.Flash, error) {
+// Search performs a substring search across title and summary. cursor 指定時
+// は id 順、未指定時は updatedAt DESC で従来通り。
+func (r *flashRepository) Search(query, sinceID, untilID string, limit, offset int) ([]*model.Flash, error) {
 	if limit <= 0 {
 		limit = 30
 	}
 	if limit > 100 {
 		limit = 100
 	}
+	q := r.db.Where("title ILIKE ? OR summary ILIKE ?", "%"+query+"%", "%"+query+"%")
+	if sinceID != "" {
+		q = q.Where("id > ?", sinceID)
+	}
+	if untilID != "" {
+		q = q.Where("id < ?", untilID)
+	}
+	if sinceID != "" || untilID != "" {
+		q = q.Order(paginationOrder(sinceID, untilID, "id"))
+	} else {
+		q = q.Order(`"updatedAt" DESC`)
+	}
+	q = q.Limit(limit)
+	if sinceID == "" && untilID == "" && offset > 0 {
+		q = q.Offset(offset)
+	}
 	var rows []*model.Flash
-	if err := r.db.
-		Where("title ILIKE ? OR summary ILIKE ?", "%"+query+"%", "%"+query+"%").
-		Order("\"updatedAt\" DESC").
-		Limit(limit).
-		Offset(offset).
-		Find(&rows).Error; err != nil {
+	if err := q.Find(&rows).Error; err != nil {
 		return nil, err
 	}
 	return rows, nil

--- a/internal/repository/flash_like.go
+++ b/internal/repository/flash_like.go
@@ -11,7 +11,9 @@ type FlashLikeRepository interface {
 	Delete(l *model.FlashLike) error
 	FindByPair(userID, flashID string) (*model.FlashLike, error)
 	Exists(userID, flashID string) (bool, error)
-	ListByUser(userID string, limit, offset int) ([]*model.FlashLike, error)
+	// ListByUser supports cursor (sinceID/untilID) and offset pagination on
+	// flash_like.id (newest first). Cursor 指定時は offset 無視。
+	ListByUser(userID, sinceID, untilID string, limit, offset int) ([]*model.FlashLike, error)
 }
 
 type flashLikeRepository struct {
@@ -51,19 +53,26 @@ func (r *flashLikeRepository) Exists(userID, flashID string) (bool, error) {
 
 // ListByUser returns the flash_like rows owned by userID newest first
 // (id desc), used by Misskey 互換 i/flashs/likes endpoint.
-func (r *flashLikeRepository) ListByUser(userID string, limit, offset int) ([]*model.FlashLike, error) {
+func (r *flashLikeRepository) ListByUser(userID, sinceID, untilID string, limit, offset int) ([]*model.FlashLike, error) {
 	if limit <= 0 {
 		limit = 30
 	}
 	if limit > 100 {
 		limit = 100
 	}
+	q := r.db.Where(`"userId" = ?`, userID)
+	if sinceID != "" {
+		q = q.Where("id > ?", sinceID)
+	}
+	if untilID != "" {
+		q = q.Where("id < ?", untilID)
+	}
+	q = q.Order(paginationOrder(sinceID, untilID, "id")).Limit(limit)
+	if sinceID == "" && untilID == "" && offset > 0 {
+		q = q.Offset(offset)
+	}
 	var rows []*model.FlashLike
-	if err := r.db.Where("\"userId\" = ?", userID).
-		Order("id DESC").
-		Limit(limit).
-		Offset(offset).
-		Find(&rows).Error; err != nil {
+	if err := q.Find(&rows).Error; err != nil {
 		return nil, err
 	}
 	return rows, nil

--- a/internal/repository/flash_like_test.go
+++ b/internal/repository/flash_like_test.go
@@ -31,7 +31,7 @@ func TestFlashLikeRepository_LifeCycle(t *testing.T) {
 	require.NoError(t, err)
 	assert.True(t, exists)
 
-	rows, err := repo.ListByUser(user.ID, 10, 0)
+	rows, err := repo.ListByUser(user.ID, "", "", 10, 0)
 	require.NoError(t, err)
 	assert.Len(t, rows, 1)
 
@@ -64,9 +64,9 @@ func TestFlashLikeRepository_Exists_QueryError(t *testing.T) {
 
 func TestFlashLikeRepository_ListByUser_LimitClamp(t *testing.T) {
 	repo := NewFlashLikeRepository(testDB)
-	_, err := repo.ListByUser("nobody", 9999, 0)
+	_, err := repo.ListByUser("nobody", "", "", 9999, 0)
 	require.NoError(t, err)
-	_, err = repo.ListByUser("nobody", -1, 0)
+	_, err = repo.ListByUser("nobody", "", "", -1, 0)
 	require.NoError(t, err)
 }
 
@@ -75,6 +75,6 @@ func TestFlashLikeRepository_ListByUser_QueryError(t *testing.T) {
 	cancel()
 	db := testDB.WithContext(ctx)
 	repo := NewFlashLikeRepository(db)
-	_, err := repo.ListByUser("nobody", 10, 0)
+	_, err := repo.ListByUser("nobody", "", "", 10, 0)
 	assert.Error(t, err)
 }

--- a/internal/repository/flash_test.go
+++ b/internal/repository/flash_test.go
@@ -115,17 +115,17 @@ func TestFlashRepository_ListByUser(t *testing.T) {
 		defer cleanupFlash(t, f.ID)
 	}
 
-	rows, err := repo.ListByUser(user.ID, 10, 0)
+	rows, err := repo.ListByUser(user.ID, "", "", 10, 0)
 	require.NoError(t, err)
 	assert.Len(t, rows, 3)
 }
 
 func TestFlashRepository_ListByUser_LimitClamp(t *testing.T) {
 	repo := NewFlashRepository(testDB)
-	rows, err := repo.ListByUser("nobody", 9999, 0)
+	rows, err := repo.ListByUser("nobody", "", "", 9999, 0)
 	require.NoError(t, err)
 	assert.Empty(t, rows)
-	rows, err = repo.ListByUser("nobody", -1, 0)
+	rows, err = repo.ListByUser("nobody", "", "", -1, 0)
 	require.NoError(t, err)
 	assert.Empty(t, rows)
 }
@@ -135,7 +135,7 @@ func TestFlashRepository_ListByUser_QueryError(t *testing.T) {
 	cancel()
 	db := testDB.WithContext(ctx)
 	repo := NewFlashRepository(db)
-	_, err := repo.ListByUser("nobody", 10, 0)
+	_, err := repo.ListByUser("nobody", "", "", 10, 0)
 	assert.Error(t, err)
 }
 
@@ -154,7 +154,7 @@ func TestFlashRepository_ListFeatured(t *testing.T) {
 		require.NoError(t, repo.Create(f))
 		defer cleanupFlash(t, f.ID)
 	}
-	rows, err := repo.ListFeatured(10, 0)
+	rows, err := repo.ListFeatured("", "", 10, 0)
 	require.NoError(t, err)
 	var found []*model.Flash
 	for _, f := range rows {
@@ -169,9 +169,9 @@ func TestFlashRepository_ListFeatured(t *testing.T) {
 
 func TestFlashRepository_ListFeatured_LimitClamp(t *testing.T) {
 	repo := NewFlashRepository(testDB)
-	_, err := repo.ListFeatured(9999, 0)
+	_, err := repo.ListFeatured("", "", 9999, 0)
 	require.NoError(t, err)
-	_, err = repo.ListFeatured(-1, 0)
+	_, err = repo.ListFeatured("", "", -1, 0)
 	require.NoError(t, err)
 }
 
@@ -180,7 +180,7 @@ func TestFlashRepository_ListFeatured_QueryError(t *testing.T) {
 	cancel()
 	db := testDB.WithContext(ctx)
 	repo := NewFlashRepository(db)
-	_, err := repo.ListFeatured(10, 0)
+	_, err := repo.ListFeatured("", "", 10, 0)
 	assert.Error(t, err)
 }
 
@@ -200,7 +200,7 @@ func TestFlashRepository_Search(t *testing.T) {
 		defer cleanupFlash(t, f.ID)
 	}
 
-	rows, err := repo.Search("calc", 10, 0)
+	rows, err := repo.Search("calc", "", "", 10, 0)
 	require.NoError(t, err)
 	var found []*model.Flash
 	for _, f := range rows {
@@ -213,9 +213,9 @@ func TestFlashRepository_Search(t *testing.T) {
 
 func TestFlashRepository_Search_LimitClamp(t *testing.T) {
 	repo := NewFlashRepository(testDB)
-	_, err := repo.Search("anything", 9999, 0)
+	_, err := repo.Search("anything", "", "", 9999, 0)
 	require.NoError(t, err)
-	_, err = repo.Search("anything", -1, 0)
+	_, err = repo.Search("anything", "", "", -1, 0)
 	require.NoError(t, err)
 }
 
@@ -224,6 +224,6 @@ func TestFlashRepository_Search_QueryError(t *testing.T) {
 	cancel()
 	db := testDB.WithContext(ctx)
 	repo := NewFlashRepository(db)
-	_, err := repo.Search("any", 10, 0)
+	_, err := repo.Search("any", "", "", 10, 0)
 	assert.Error(t, err)
 }

--- a/internal/repository/gallery.go
+++ b/internal/repository/gallery.go
@@ -9,8 +9,14 @@ import (
 // scoped to a single user. i/gallery/posts と i/gallery/likes の
 // per-user 一覧で利用する。
 type GalleryRepository interface {
-	ListByUser(userID string, limit, offset int) ([]*model.GalleryPost, error)
-	ListLikesByUser(userID string, limit, offset int) ([]*model.GalleryLike, error)
+	// ListByUser supports cursor (sinceID/untilID) and offset pagination.
+	// Cursor 指定時は offset 無視。
+	ListByUser(userID, sinceID, untilID string, limit, offset int) ([]*model.GalleryPost, error)
+	// ListLikesByUser same cursor semantics.
+	ListLikesByUser(userID, sinceID, untilID string, limit, offset int) ([]*model.GalleryLike, error)
+	// FindPostsByIDs returns the posts whose id is in ids. Used by
+	// i/gallery/likes to embed the full GalleryPost in each like row.
+	FindPostsByIDs(ids []string) ([]*model.GalleryPost, error)
 }
 
 type galleryRepository struct {
@@ -32,10 +38,17 @@ func clampLimit(limit int) int {
 	return limit
 }
 
-func (r *galleryRepository) ListByUser(userID string, limit, offset int) ([]*model.GalleryPost, error) {
+func (r *galleryRepository) ListByUser(userID, sinceID, untilID string, limit, offset int) ([]*model.GalleryPost, error) {
 	limit = clampLimit(limit)
-	q := r.db.Where(`"userId" = ?`, userID).Order(`"id" DESC`).Limit(limit)
-	if offset > 0 {
+	q := r.db.Where(`"userId" = ?`, userID)
+	if sinceID != "" {
+		q = q.Where("id > ?", sinceID)
+	}
+	if untilID != "" {
+		q = q.Where("id < ?", untilID)
+	}
+	q = q.Order(paginationOrder(sinceID, untilID, "id")).Limit(limit)
+	if sinceID == "" && untilID == "" && offset > 0 {
 		q = q.Offset(offset)
 	}
 	var posts []*model.GalleryPost
@@ -45,10 +58,28 @@ func (r *galleryRepository) ListByUser(userID string, limit, offset int) ([]*mod
 	return posts, nil
 }
 
-func (r *galleryRepository) ListLikesByUser(userID string, limit, offset int) ([]*model.GalleryLike, error) {
+func (r *galleryRepository) FindPostsByIDs(ids []string) ([]*model.GalleryPost, error) {
+	if len(ids) == 0 {
+		return nil, nil
+	}
+	var posts []*model.GalleryPost
+	if err := r.db.Preload("User").Where("id IN ?", ids).Find(&posts).Error; err != nil {
+		return nil, err
+	}
+	return posts, nil
+}
+
+func (r *galleryRepository) ListLikesByUser(userID, sinceID, untilID string, limit, offset int) ([]*model.GalleryLike, error) {
 	limit = clampLimit(limit)
-	q := r.db.Where(`"userId" = ?`, userID).Order(`"id" DESC`).Limit(limit)
-	if offset > 0 {
+	q := r.db.Where(`"userId" = ?`, userID)
+	if sinceID != "" {
+		q = q.Where("id > ?", sinceID)
+	}
+	if untilID != "" {
+		q = q.Where("id < ?", untilID)
+	}
+	q = q.Order(paginationOrder(sinceID, untilID, "id")).Limit(limit)
+	if sinceID == "" && untilID == "" && offset > 0 {
 		q = q.Offset(offset)
 	}
 	var likes []*model.GalleryLike

--- a/internal/repository/gallery.go
+++ b/internal/repository/gallery.go
@@ -40,7 +40,11 @@ func clampLimit(limit int) int {
 
 func (r *galleryRepository) ListByUser(userID, sinceID, untilID string, limit, offset int) ([]*model.GalleryPost, error) {
 	limit = clampLimit(limit)
-	q := r.db.Where(`"userId" = ?`, userID)
+	// packGalleryPost が p.User を読んで user フィールドを埋めるので、
+	// FindPostsByIDs と揃えて User を Preload する。Preload なしだと
+	// i/gallery/posts のレスポンスから user が抜け落ちて i/gallery/likes
+	// との shape 不整合になる (#520 review)。
+	q := r.db.Preload("User").Where(`"userId" = ?`, userID)
 	if sinceID != "" {
 		q = q.Where("id > ?", sinceID)
 	}

--- a/internal/repository/gallery_test.go
+++ b/internal/repository/gallery_test.go
@@ -20,22 +20,22 @@ func TestGalleryRepository_ListByUser(t *testing.T) {
 		}).Error)
 	}
 
-	posts, err := repo.ListByUser("gp_u1", 10, 0)
+	posts, err := repo.ListByUser("gp_u1", "", "", 10, 0)
 	require.NoError(t, err)
 	assert.Len(t, posts, 3)
 
 	// pagination: offset > 0
-	posts, err = repo.ListByUser("gp_u1", 10, 1)
+	posts, err = repo.ListByUser("gp_u1", "", "", 10, 1)
 	require.NoError(t, err)
 	assert.Len(t, posts, 2)
 
 	// clampLimit: 0 -> 10 (but only 3 rows so limit is not the limiting factor)
-	posts, err = repo.ListByUser("gp_u1", 0, 0)
+	posts, err = repo.ListByUser("gp_u1", "", "", 0, 0)
 	require.NoError(t, err)
 	assert.Len(t, posts, 3)
 
 	// clampLimit: >100 -> 100
-	posts, err = repo.ListByUser("gp_u1", 9999, 0)
+	posts, err = repo.ListByUser("gp_u1", "", "", 9999, 0)
 	require.NoError(t, err)
 	assert.Len(t, posts, 3)
 }
@@ -52,23 +52,23 @@ func TestGalleryRepository_ListLikesByUser(t *testing.T) {
 
 	require.NoError(t, testDB.Create(&model.GalleryLike{ID: "gl_l1", UserID: "gl_u1", PostID: "gl_p1"}).Error)
 
-	likes, err := repo.ListLikesByUser("gl_u1", 10, 0)
+	likes, err := repo.ListLikesByUser("gl_u1", "", "", 10, 0)
 	require.NoError(t, err)
 	assert.Len(t, likes, 1)
 
 	// offset > 0
-	likes, err = repo.ListLikesByUser("gl_u1", 10, 1)
+	likes, err = repo.ListLikesByUser("gl_u1", "", "", 10, 1)
 	require.NoError(t, err)
 	assert.Empty(t, likes)
 }
 
 func TestGalleryRepository_EmptyList(t *testing.T) {
 	repo := NewGalleryRepository(testDB)
-	posts, err := repo.ListByUser("gp_nonexistent", 10, 0)
+	posts, err := repo.ListByUser("gp_nonexistent", "", "", 10, 0)
 	require.NoError(t, err)
 	assert.Empty(t, posts)
 
-	likes, err := repo.ListLikesByUser("gp_nonexistent", 10, 0)
+	likes, err := repo.ListLikesByUser("gp_nonexistent", "", "", 10, 0)
 	require.NoError(t, err)
 	assert.Empty(t, likes)
 }

--- a/internal/repository/instance.go
+++ b/internal/repository/instance.go
@@ -148,32 +148,43 @@ func (r *instanceRepository) List(filter model.InstanceListFilter) ([]*model.Ins
 			q = q.Where("\"followingCount\" = 0")
 		}
 	}
-	switch filter.SortBy {
-	case "+host":
-		q = q.Order("host ASC")
-	case "-host":
-		q = q.Order("host DESC")
-	case "+notes":
-		q = q.Order("\"notesCount\" ASC")
-	case "-notes":
-		q = q.Order("\"notesCount\" DESC")
-	case "+users":
-		q = q.Order("\"usersCount\" ASC")
-	case "-users":
-		q = q.Order("\"usersCount\" DESC")
-	case "+following":
-		q = q.Order("\"followingCount\" ASC")
-	case "-following":
-		q = q.Order("\"followingCount\" DESC")
-	case "+followers":
-		q = q.Order("\"followersCount\" ASC")
-	case "-followers":
-		q = q.Order("\"followersCount\" DESC")
-	case "+firstRetrievedAt":
-		q = q.Order("\"firstRetrievedAt\" ASC")
-	default:
-		// デフォルトは新しい順
-		q = q.Order("\"firstRetrievedAt\" DESC")
+	cursor := filter.SinceID != "" || filter.UntilID != ""
+	if filter.SinceID != "" {
+		q = q.Where("id > ?", filter.SinceID)
+	}
+	if filter.UntilID != "" {
+		q = q.Where("id < ?", filter.UntilID)
+	}
+	if cursor {
+		q = q.Order(paginationOrder(filter.SinceID, filter.UntilID, "id"))
+	} else {
+		switch filter.SortBy {
+		case "+host":
+			q = q.Order("host ASC")
+		case "-host":
+			q = q.Order("host DESC")
+		case "+notes":
+			q = q.Order("\"notesCount\" ASC")
+		case "-notes":
+			q = q.Order("\"notesCount\" DESC")
+		case "+users":
+			q = q.Order("\"usersCount\" ASC")
+		case "-users":
+			q = q.Order("\"usersCount\" DESC")
+		case "+following":
+			q = q.Order("\"followingCount\" ASC")
+		case "-following":
+			q = q.Order("\"followingCount\" DESC")
+		case "+followers":
+			q = q.Order("\"followersCount\" ASC")
+		case "-followers":
+			q = q.Order("\"followersCount\" DESC")
+		case "+firstRetrievedAt":
+			q = q.Order("\"firstRetrievedAt\" ASC")
+		default:
+			// デフォルトは新しい順
+			q = q.Order("\"firstRetrievedAt\" DESC")
+		}
 	}
 	limit := filter.Limit
 	if limit <= 0 {
@@ -182,7 +193,10 @@ func (r *instanceRepository) List(filter model.InstanceListFilter) ([]*model.Ins
 	if limit > 100 {
 		limit = 100
 	}
-	q = q.Limit(limit).Offset(filter.Offset)
+	q = q.Limit(limit)
+	if !cursor && filter.Offset > 0 {
+		q = q.Offset(filter.Offset)
+	}
 	var rows []*model.Instance
 	if err := q.Find(&rows).Error; err != nil {
 		return nil, err

--- a/internal/repository/muting.go
+++ b/internal/repository/muting.go
@@ -13,7 +13,9 @@ type MutingRepository interface {
 	Delete(m *model.Muting) error
 	FindByPair(muterID, muteeID string) (*model.Muting, error)
 	Exists(muterID, muteeID string) (bool, error)
-	ListByMuter(muterID string, limit, offset int) ([]*model.Muting, error)
+	// ListByMuter supports cursor (sinceID/untilID) and offset pagination.
+	// Cursor 指定時は offset を無視 (upstream makePaginationQuery と一致)。
+	ListByMuter(muterID, sinceID, untilID string, limit, offset int) ([]*model.Muting, error)
 }
 
 type mutingRepository struct {
@@ -54,13 +56,20 @@ func (r *mutingRepository) Exists(muterID, muteeID string) (bool, error) {
 	return count > 0, nil
 }
 
-func (r *mutingRepository) ListByMuter(muterID string, limit, offset int) ([]*model.Muting, error) {
+func (r *mutingRepository) ListByMuter(muterID, sinceID, untilID string, limit, offset int) ([]*model.Muting, error) {
+	q := r.db.Where(`"muterId" = ?`, muterID)
+	if sinceID != "" {
+		q = q.Where("id > ?", sinceID)
+	}
+	if untilID != "" {
+		q = q.Where("id < ?", untilID)
+	}
+	q = q.Order(paginationOrder(sinceID, untilID, "id")).Limit(limit)
+	if sinceID == "" && untilID == "" && offset > 0 {
+		q = q.Offset(offset)
+	}
 	var rows []*model.Muting
-	if err := r.db.Where("\"muterId\" = ?", muterID).
-		Order("id DESC").
-		Limit(limit).
-		Offset(offset).
-		Find(&rows).Error; err != nil {
+	if err := q.Find(&rows).Error; err != nil {
 		return nil, err
 	}
 	return rows, nil
@@ -72,7 +81,8 @@ type RenoteMutingRepository interface {
 	Delete(m *model.RenoteMuting) error
 	FindByPair(muterID, muteeID string) (*model.RenoteMuting, error)
 	Exists(muterID, muteeID string) (bool, error)
-	ListByMuter(muterID string, limit, offset int) ([]*model.RenoteMuting, error)
+	// ListByMuter supports cursor (sinceID/untilID) and offset pagination.
+	ListByMuter(muterID, sinceID, untilID string, limit, offset int) ([]*model.RenoteMuting, error)
 }
 
 type renoteMutingRepository struct {
@@ -110,13 +120,20 @@ func (r *renoteMutingRepository) Exists(muterID, muteeID string) (bool, error) {
 	return count > 0, nil
 }
 
-func (r *renoteMutingRepository) ListByMuter(muterID string, limit, offset int) ([]*model.RenoteMuting, error) {
+func (r *renoteMutingRepository) ListByMuter(muterID, sinceID, untilID string, limit, offset int) ([]*model.RenoteMuting, error) {
+	q := r.db.Where(`"muterId" = ?`, muterID)
+	if sinceID != "" {
+		q = q.Where("id > ?", sinceID)
+	}
+	if untilID != "" {
+		q = q.Where("id < ?", untilID)
+	}
+	q = q.Order(paginationOrder(sinceID, untilID, "id")).Limit(limit)
+	if sinceID == "" && untilID == "" && offset > 0 {
+		q = q.Offset(offset)
+	}
 	var rows []*model.RenoteMuting
-	if err := r.db.Where("\"muterId\" = ?", muterID).
-		Order("id DESC").
-		Limit(limit).
-		Offset(offset).
-		Find(&rows).Error; err != nil {
+	if err := q.Find(&rows).Error; err != nil {
 		return nil, err
 	}
 	return rows, nil

--- a/internal/repository/muting_test.go
+++ b/internal/repository/muting_test.go
@@ -53,7 +53,7 @@ func TestMutingRepository_CRUDExpiry(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, "m_active", found.ID)
 
-	rows, err := repo.ListByMuter(u1.ID, 10, 0)
+	rows, err := repo.ListByMuter(u1.ID, "", "", 10, 0)
 	require.NoError(t, err)
 	assert.Len(t, rows, 2)
 
@@ -73,7 +73,7 @@ func TestMutingRepository_QueryErrors(t *testing.T) {
 	assert.Error(t, err)
 	_, err = repo.Exists("a", "b")
 	assert.Error(t, err)
-	_, err = repo.ListByMuter("a", 10, 0)
+	_, err = repo.ListByMuter("a", "", "", 10, 0)
 	assert.Error(t, err)
 }
 
@@ -96,7 +96,7 @@ func TestRenoteMutingRepository_CRUD(t *testing.T) {
 	require.NoError(t, err)
 	assert.True(t, exists)
 
-	rows, err := repo.ListByMuter(u1.ID, 10, 0)
+	rows, err := repo.ListByMuter(u1.ID, "", "", 10, 0)
 	require.NoError(t, err)
 	assert.Len(t, rows, 1)
 
@@ -116,6 +116,6 @@ func TestRenoteMutingRepository_QueryErrors(t *testing.T) {
 	assert.Error(t, err)
 	_, err = repo.Exists("a", "b")
 	assert.Error(t, err)
-	_, err = repo.ListByMuter("a", 10, 0)
+	_, err = repo.ListByMuter("a", "", "", 10, 0)
 	assert.Error(t, err)
 }

--- a/internal/repository/page.go
+++ b/internal/repository/page.go
@@ -12,11 +12,15 @@ type PageRepository interface {
 	FindByUserAndName(userID, name string) (*model.Page, error)
 	UpdateFields(pageID string, fields map[string]any) error
 	Delete(p *model.Page) error
-	ListByUser(userID string, limit, offset int) ([]*model.Page, error)
+	// ListByUser returns pages owned by userID with cursor (sinceID/untilID)
+	// or offset pagination. Cursor 指定時は offset 無視。
+	ListByUser(userID, sinceID, untilID string, limit, offset int) ([]*model.Page, error)
 	// ListPublicByUser returns only public pages owned by userID, used by
-	// users/pages when viewer is not the owner.
-	ListPublicByUser(userID string, limit, offset int) ([]*model.Page, error)
-	ListFeatured(limit, offset int) ([]*model.Page, error)
+	// users/pages when viewer is not the owner. Same cursor semantics.
+	ListPublicByUser(userID, sinceID, untilID string, limit, offset int) ([]*model.Page, error)
+	// ListFeatured returns the most-liked public pages with cursor or
+	// offset pagination.
+	ListFeatured(sinceID, untilID string, limit, offset int) ([]*model.Page, error)
 	IncrementCount(pageID, column string, delta int) error
 }
 
@@ -62,57 +66,87 @@ func (r *pageRepository) Delete(p *model.Page) error {
 	return r.db.Delete(p).Error
 }
 
-// ListByUser returns the pages owned by userID, ordered by updatedAt desc.
-func (r *pageRepository) ListByUser(userID string, limit, offset int) ([]*model.Page, error) {
+// ListByUser returns the pages owned by userID with cursor (sinceID/untilID)
+// or offset pagination. cursor mode はupstream `makePaginationQuery` 同様
+// `id` で sort + filter する (元実装の `updatedAt DESC` は frontend
+// Paginator の untilId/sinceId と整合しないため変更)。
+func (r *pageRepository) ListByUser(userID, sinceID, untilID string, limit, offset int) ([]*model.Page, error) {
 	if limit <= 0 {
 		limit = 30
 	}
 	if limit > 100 {
 		limit = 100
 	}
+	q := r.db.Where(`"userId" = ?`, userID)
+	if sinceID != "" {
+		q = q.Where("id > ?", sinceID)
+	}
+	if untilID != "" {
+		q = q.Where("id < ?", untilID)
+	}
+	q = q.Order(paginationOrder(sinceID, untilID, "id")).Limit(limit)
+	if sinceID == "" && untilID == "" && offset > 0 {
+		q = q.Offset(offset)
+	}
 	var rows []*model.Page
-	if err := r.db.Where("\"userId\" = ?", userID).
-		Order("\"updatedAt\" DESC").
-		Limit(limit).
-		Offset(offset).
-		Find(&rows).Error; err != nil {
+	if err := q.Find(&rows).Error; err != nil {
 		return nil, err
 	}
 	return rows, nil
 }
 
-func (r *pageRepository) ListPublicByUser(userID string, limit, offset int) ([]*model.Page, error) {
+func (r *pageRepository) ListPublicByUser(userID, sinceID, untilID string, limit, offset int) ([]*model.Page, error) {
 	if limit <= 0 {
 		limit = 30
 	}
 	if limit > 100 {
 		limit = 100
 	}
+	q := r.db.Where(`"userId" = ? AND visibility = ?`, userID, string(model.PageVisibilityPublic))
+	if sinceID != "" {
+		q = q.Where("id > ?", sinceID)
+	}
+	if untilID != "" {
+		q = q.Where("id < ?", untilID)
+	}
+	q = q.Order(paginationOrder(sinceID, untilID, "id")).Limit(limit)
+	if sinceID == "" && untilID == "" && offset > 0 {
+		q = q.Offset(offset)
+	}
 	var rows []*model.Page
-	if err := r.db.Where("\"userId\" = ? AND visibility = ?", userID, string(model.PageVisibilityPublic)).
-		Order("\"updatedAt\" DESC").
-		Limit(limit).
-		Offset(offset).
-		Find(&rows).Error; err != nil {
+	if err := q.Find(&rows).Error; err != nil {
 		return nil, err
 	}
 	return rows, nil
 }
 
-// ListFeatured returns the most-liked public pages.
-func (r *pageRepository) ListFeatured(limit, offset int) ([]*model.Page, error) {
+// ListFeatured returns the most-liked public pages. cursor (sinceID/untilID)
+// 指定時はそれを優先。指定なしは likedCount DESC + offset で従来通り。
+func (r *pageRepository) ListFeatured(sinceID, untilID string, limit, offset int) ([]*model.Page, error) {
 	if limit <= 0 {
 		limit = 30
 	}
 	if limit > 100 {
 		limit = 100
 	}
+	q := r.db.Where("visibility = ?", string(model.PageVisibilityPublic))
+	if sinceID != "" {
+		q = q.Where("id > ?", sinceID)
+	}
+	if untilID != "" {
+		q = q.Where("id < ?", untilID)
+	}
+	if sinceID != "" || untilID != "" {
+		q = q.Order(paginationOrder(sinceID, untilID, "id"))
+	} else {
+		q = q.Order(`"likedCount" DESC`)
+	}
+	q = q.Limit(limit)
+	if sinceID == "" && untilID == "" && offset > 0 {
+		q = q.Offset(offset)
+	}
 	var rows []*model.Page
-	if err := r.db.Where("visibility = ?", string(model.PageVisibilityPublic)).
-		Order("\"likedCount\" DESC").
-		Limit(limit).
-		Offset(offset).
-		Find(&rows).Error; err != nil {
+	if err := q.Find(&rows).Error; err != nil {
 		return nil, err
 	}
 	return rows, nil

--- a/internal/repository/page_test.go
+++ b/internal/repository/page_test.go
@@ -137,17 +137,17 @@ func TestPageRepository_ListByUser(t *testing.T) {
 		defer cleanupPage(t, p.ID)
 	}
 
-	rows, err := repo.ListByUser(user.ID, 10, 0)
+	rows, err := repo.ListByUser(user.ID, "", "", 10, 0)
 	require.NoError(t, err)
 	assert.Len(t, rows, 3)
 }
 
 func TestPageRepository_ListByUser_LimitClamp(t *testing.T) {
 	repo := NewPageRepository(testDB)
-	rows, err := repo.ListByUser("nobody", 9999, 0)
+	rows, err := repo.ListByUser("nobody", "", "", 9999, 0)
 	require.NoError(t, err)
 	assert.Empty(t, rows)
-	rows, err = repo.ListByUser("nobody", -1, 0)
+	rows, err = repo.ListByUser("nobody", "", "", -1, 0)
 	require.NoError(t, err)
 	assert.Empty(t, rows)
 }
@@ -157,7 +157,7 @@ func TestPageRepository_ListByUser_QueryError(t *testing.T) {
 	cancel()
 	db := testDB.WithContext(ctx)
 	repo := NewPageRepository(db)
-	_, err := repo.ListByUser("nobody", 10, 0)
+	_, err := repo.ListByUser("nobody", "", "", 10, 0)
 	assert.Error(t, err)
 }
 
@@ -180,7 +180,7 @@ func TestPageRepository_ListFeatured(t *testing.T) {
 		defer cleanupPage(t, p.ID)
 	}
 
-	rows, err := repo.ListFeatured(10, 0)
+	rows, err := repo.ListFeatured("", "", 10, 0)
 	require.NoError(t, err)
 	// 他テストの残骸が混ざる可能性があるので、この3件が降順で含まれることだけ検証する。
 	var found []*model.Page
@@ -197,10 +197,10 @@ func TestPageRepository_ListFeatured(t *testing.T) {
 
 func TestPageRepository_ListFeatured_LimitClamp(t *testing.T) {
 	repo := NewPageRepository(testDB)
-	rows, err := repo.ListFeatured(9999, 0)
+	rows, err := repo.ListFeatured("", "", 9999, 0)
 	require.NoError(t, err)
 	_ = rows
-	rows, err = repo.ListFeatured(-1, 0)
+	rows, err = repo.ListFeatured("", "", -1, 0)
 	require.NoError(t, err)
 	_ = rows
 }
@@ -210,6 +210,6 @@ func TestPageRepository_ListFeatured_QueryError(t *testing.T) {
 	cancel()
 	db := testDB.WithContext(ctx)
 	repo := NewPageRepository(db)
-	_, err := repo.ListFeatured(10, 0)
+	_, err := repo.ListFeatured("", "", 10, 0)
 	assert.Error(t, err)
 }

--- a/internal/server/router.go
+++ b/internal/server/router.go
@@ -1166,19 +1166,19 @@ func (s *Server) setupRoutes() {
 	api.POST("/gallery/posts/unlike", galleryHandler.PostsUnlike, middleware.RequireAuth())
 
 	// Blocking endpoints
-	blockingHandler := blocking.NewHandler(blockingService)
+	blockingHandler := blocking.NewHandler(blockingService, userRepo, idGen)
 	api.POST("/blocking/create", blockingHandler.Create, middleware.RequireAuth())
 	api.POST("/blocking/delete", blockingHandler.Delete, middleware.RequireAuth())
 	api.POST("/blocking/list", blockingHandler.List, middleware.RequireAuth())
 
 	// Mute endpoints
-	muteHandler := mute.NewHandler(mutingService)
+	muteHandler := mute.NewHandler(mutingService, userRepo, idGen)
 	api.POST("/mute/create", muteHandler.Create, middleware.RequireAuth())
 	api.POST("/mute/delete", muteHandler.Delete, middleware.RequireAuth())
 	api.POST("/mute/list", muteHandler.List, middleware.RequireAuth())
 
 	// Renote mute endpoints
-	renoteMuteHandler := renotemute.NewHandler(renoteMutingService)
+	renoteMuteHandler := renotemute.NewHandler(renoteMutingService, userRepo, idGen)
 	api.POST("/renote-mute/create", renoteMuteHandler.Create, middleware.RequireAuth())
 	api.POST("/renote-mute/delete", renoteMuteHandler.Delete, middleware.RequireAuth())
 	api.POST("/renote-mute/list", renoteMuteHandler.List, middleware.RequireAuth())
@@ -1347,7 +1347,7 @@ func (s *Server) setupRoutes() {
 	api.POST("/i/pages", pagesHandler.My, middleware.RequireAuth())
 
 	// Flash endpoints (Phase 4.5)
-	flashHandler := apiflash.NewHandler(flashService)
+	flashHandler := apiflash.NewHandler(flashService, userRepo, idGen)
 	api.POST("/flash/create", flashHandler.Create, middleware.RequireAuth())
 	api.POST("/flash/show", flashHandler.Show)
 	api.POST("/flash/update", flashHandler.Update, middleware.RequireAuth())

--- a/internal/testutil/mock_block_mute.go
+++ b/internal/testutil/mock_block_mute.go
@@ -39,14 +39,21 @@ func (m *MockBlockingRepository) Exists(blockerID, blockeeID string) (bool, erro
 	return err == nil, nil
 }
 
-func (m *MockBlockingRepository) ListByBlocker(blockerID string, limit, offset int) ([]*model.Blocking, error) {
+func (m *MockBlockingRepository) ListByBlocker(blockerID, sinceID, untilID string, limit, offset int) ([]*model.Blocking, error) {
 	var rows []*model.Blocking
 	for _, b := range m.Blockings {
-		if b.BlockerID == blockerID {
-			rows = append(rows, b)
+		if b.BlockerID != blockerID {
+			continue
 		}
+		if sinceID != "" && b.ID <= sinceID {
+			continue
+		}
+		if untilID != "" && b.ID >= untilID {
+			continue
+		}
+		rows = append(rows, b)
 	}
-	return paginateBlockings(rows, limit, offset), nil
+	return paginateBlockings(rows, sinceID, untilID, limit, offset), nil
 }
 
 // MockMutingRepository is a test double for repository.MutingRepository.
@@ -90,14 +97,21 @@ func (m *MockMutingRepository) Exists(muterID, muteeID string) (bool, error) {
 	return false, nil
 }
 
-func (m *MockMutingRepository) ListByMuter(muterID string, limit, offset int) ([]*model.Muting, error) {
+func (m *MockMutingRepository) ListByMuter(muterID, sinceID, untilID string, limit, offset int) ([]*model.Muting, error) {
 	var rows []*model.Muting
 	for _, r := range m.Mutings {
-		if r.MuterID == muterID {
-			rows = append(rows, r)
+		if r.MuterID != muterID {
+			continue
 		}
+		if sinceID != "" && r.ID <= sinceID {
+			continue
+		}
+		if untilID != "" && r.ID >= untilID {
+			continue
+		}
+		rows = append(rows, r)
 	}
-	return paginateMutings(rows, limit, offset), nil
+	return paginateMutings(rows, sinceID, untilID, limit, offset), nil
 }
 
 // MockRenoteMutingRepository is a test double for repository.RenoteMutingRepository.
@@ -133,36 +147,101 @@ func (m *MockRenoteMutingRepository) Exists(muterID, muteeID string) (bool, erro
 	return err == nil, nil
 }
 
-func (m *MockRenoteMutingRepository) ListByMuter(muterID string, limit, offset int) ([]*model.RenoteMuting, error) {
+func (m *MockRenoteMutingRepository) ListByMuter(muterID, sinceID, untilID string, limit, offset int) ([]*model.RenoteMuting, error) {
 	var rows []*model.RenoteMuting
 	for _, r := range m.Mutings {
-		if r.MuterID == muterID {
-			rows = append(rows, r)
+		if r.MuterID != muterID {
+			continue
+		}
+		if sinceID != "" && r.ID <= sinceID {
+			continue
+		}
+		if untilID != "" && r.ID >= untilID {
+			continue
+		}
+		rows = append(rows, r)
+	}
+	return paginateRenoteMutings(rows, sinceID, untilID, limit, offset), nil
+}
+
+// applyCursorPagination applies the same ordering / limit / cursor-vs-offset
+// rules as the real repositories so mock tests exercise upstream
+// makePaginationQuery semantics. ASC ordering kicks in when sinceID is set
+// without untilID (matches paginationOrder in repository package).
+func paginateBlockings(rows []*model.Blocking, sinceID, untilID string, limit, offset int) []*model.Blocking {
+	asc := sinceID != "" && untilID == ""
+	for i := 0; i < len(rows); i++ {
+		for j := i + 1; j < len(rows); j++ {
+			less := rows[i].ID < rows[j].ID
+			if (asc && !less) || (!asc && less) {
+				rows[i], rows[j] = rows[j], rows[i]
+			}
 		}
 	}
-	return paginateRenoteMutings(rows, limit, offset), nil
+	if limit <= 0 {
+		limit = 30
+	}
+	if sinceID == "" && untilID == "" {
+		if offset >= len(rows) {
+			return nil
+		}
+		end := min(offset+limit, len(rows))
+		return rows[offset:end]
+	}
+	if limit > len(rows) {
+		limit = len(rows)
+	}
+	return rows[:limit]
 }
 
-func paginateBlockings(rows []*model.Blocking, limit, offset int) []*model.Blocking {
-	if offset >= len(rows) {
-		return nil
+func paginateMutings(rows []*model.Muting, sinceID, untilID string, limit, offset int) []*model.Muting {
+	asc := sinceID != "" && untilID == ""
+	for i := 0; i < len(rows); i++ {
+		for j := i + 1; j < len(rows); j++ {
+			less := rows[i].ID < rows[j].ID
+			if (asc && !less) || (!asc && less) {
+				rows[i], rows[j] = rows[j], rows[i]
+			}
+		}
 	}
-	end := min(offset+limit, len(rows))
-	return rows[offset:end]
+	if limit <= 0 {
+		limit = 30
+	}
+	if sinceID == "" && untilID == "" {
+		if offset >= len(rows) {
+			return nil
+		}
+		end := min(offset+limit, len(rows))
+		return rows[offset:end]
+	}
+	if limit > len(rows) {
+		limit = len(rows)
+	}
+	return rows[:limit]
 }
 
-func paginateMutings(rows []*model.Muting, limit, offset int) []*model.Muting {
-	if offset >= len(rows) {
-		return nil
+func paginateRenoteMutings(rows []*model.RenoteMuting, sinceID, untilID string, limit, offset int) []*model.RenoteMuting {
+	asc := sinceID != "" && untilID == ""
+	for i := 0; i < len(rows); i++ {
+		for j := i + 1; j < len(rows); j++ {
+			less := rows[i].ID < rows[j].ID
+			if (asc && !less) || (!asc && less) {
+				rows[i], rows[j] = rows[j], rows[i]
+			}
+		}
 	}
-	end := min(offset+limit, len(rows))
-	return rows[offset:end]
-}
-
-func paginateRenoteMutings(rows []*model.RenoteMuting, limit, offset int) []*model.RenoteMuting {
-	if offset >= len(rows) {
-		return nil
+	if limit <= 0 {
+		limit = 30
 	}
-	end := min(offset+limit, len(rows))
-	return rows[offset:end]
+	if sinceID == "" && untilID == "" {
+		if offset >= len(rows) {
+			return nil
+		}
+		end := min(offset+limit, len(rows))
+		return rows[offset:end]
+	}
+	if limit > len(rows) {
+		limit = len(rows)
+	}
+	return rows[:limit]
 }

--- a/internal/testutil/mock_repository.go
+++ b/internal/testutil/mock_repository.go
@@ -3233,10 +3233,11 @@ func (m *MockChannelFollowingRepository) ListFollowed(userID, sinceID, untilID s
 		if f.FollowerID != userID {
 			continue
 		}
-		if sinceID != "" && f.ID <= sinceID {
+		// cursor は followeeId (= channel.id) で絞る (#520 review)。
+		if sinceID != "" && f.FolloweeID <= sinceID {
 			continue
 		}
-		if untilID != "" && f.ID >= untilID {
+		if untilID != "" && f.FolloweeID >= untilID {
 			continue
 		}
 		rows = append(rows, f)
@@ -3244,7 +3245,7 @@ func (m *MockChannelFollowingRepository) ListFollowed(userID, sinceID, untilID s
 	asc := sinceID != "" && untilID == ""
 	for i := 0; i < len(rows); i++ {
 		for j := i + 1; j < len(rows); j++ {
-			less := rows[i].ID < rows[j].ID
+			less := rows[i].FolloweeID < rows[j].FolloweeID
 			if (asc && !less) || (!asc && less) {
 				rows[i], rows[j] = rows[j], rows[i]
 			}

--- a/internal/testutil/mock_repository.go
+++ b/internal/testutil/mock_repository.go
@@ -2432,50 +2432,58 @@ func (m *MockPageRepository) Delete(p *model.Page) error {
 	return nil
 }
 
-func (m *MockPageRepository) ListByUser(userID string, limit, offset int) ([]*model.Page, error) {
+func (m *MockPageRepository) ListByUser(userID, sinceID, untilID string, limit, offset int) ([]*model.Page, error) {
 	var rows []*model.Page
 	for _, p := range m.Pages {
-		if p.UserID == userID {
-			rows = append(rows, p)
+		if p.UserID != userID {
+			continue
 		}
-	}
-	// updatedAt 降順だが、テストの安定性のため updatedAt が同じ場合は ID 降順で解決する。
-	for i := 0; i < len(rows); i++ {
-		for j := i + 1; j < len(rows); j++ {
-			if rows[i].UpdatedAt.Before(rows[j].UpdatedAt) ||
-				(rows[i].UpdatedAt.Equal(rows[j].UpdatedAt) && rows[i].ID < rows[j].ID) {
-				rows[i], rows[j] = rows[j], rows[i]
-			}
+		if sinceID != "" && p.ID <= sinceID {
+			continue
 		}
+		if untilID != "" && p.ID >= untilID {
+			continue
+		}
+		rows = append(rows, p)
 	}
-	return paginatePages(rows, limit, offset), nil
+	return paginatePages(rows, sinceID, untilID, limit, offset), nil
 }
 
-func (m *MockPageRepository) ListPublicByUser(userID string, limit, offset int) ([]*model.Page, error) {
+func (m *MockPageRepository) ListPublicByUser(userID, sinceID, untilID string, limit, offset int) ([]*model.Page, error) {
 	var rows []*model.Page
 	for _, p := range m.Pages {
-		if p.UserID == userID && p.Visibility == model.PageVisibilityPublic {
-			rows = append(rows, p)
+		if p.UserID != userID || p.Visibility != model.PageVisibilityPublic {
+			continue
 		}
-	}
-	for i := 0; i < len(rows); i++ {
-		for j := i + 1; j < len(rows); j++ {
-			if rows[i].UpdatedAt.Before(rows[j].UpdatedAt) ||
-				(rows[i].UpdatedAt.Equal(rows[j].UpdatedAt) && rows[i].ID < rows[j].ID) {
-				rows[i], rows[j] = rows[j], rows[i]
-			}
+		if sinceID != "" && p.ID <= sinceID {
+			continue
 		}
+		if untilID != "" && p.ID >= untilID {
+			continue
+		}
+		rows = append(rows, p)
 	}
-	return paginatePages(rows, limit, offset), nil
+	return paginatePages(rows, sinceID, untilID, limit, offset), nil
 }
 
-func (m *MockPageRepository) ListFeatured(limit, offset int) ([]*model.Page, error) {
+func (m *MockPageRepository) ListFeatured(sinceID, untilID string, limit, offset int) ([]*model.Page, error) {
 	var rows []*model.Page
 	for _, p := range m.Pages {
-		if p.Visibility == model.PageVisibilityPublic {
-			rows = append(rows, p)
+		if p.Visibility != model.PageVisibilityPublic {
+			continue
 		}
+		if sinceID != "" && p.ID <= sinceID {
+			continue
+		}
+		if untilID != "" && p.ID >= untilID {
+			continue
+		}
+		rows = append(rows, p)
 	}
+	if sinceID != "" || untilID != "" {
+		return paginatePages(rows, sinceID, untilID, limit, offset), nil
+	}
+	// offset mode: 元実装と同じく likedCount DESC で sort
 	for i := 0; i < len(rows); i++ {
 		for j := i + 1; j < len(rows); j++ {
 			if rows[i].LikedCount < rows[j].LikedCount ||
@@ -2484,7 +2492,7 @@ func (m *MockPageRepository) ListFeatured(limit, offset int) ([]*model.Page, err
 			}
 		}
 	}
-	return paginatePages(rows, limit, offset), nil
+	return paginatePages(rows, "", "", limit, offset), nil
 }
 
 func (m *MockPageRepository) IncrementCount(pageID, column string, delta int) error {
@@ -2498,15 +2506,30 @@ func (m *MockPageRepository) IncrementCount(pageID, column string, delta int) er
 	return nil
 }
 
-func paginatePages(rows []*model.Page, limit, offset int) []*model.Page {
+func paginatePages(rows []*model.Page, sinceID, untilID string, limit, offset int) []*model.Page {
+	asc := sinceID != "" && untilID == ""
+	for i := 0; i < len(rows); i++ {
+		for j := i + 1; j < len(rows); j++ {
+			less := rows[i].ID < rows[j].ID
+			if (asc && !less) || (!asc && less) {
+				rows[i], rows[j] = rows[j], rows[i]
+			}
+		}
+	}
 	if limit <= 0 || limit > 100 {
 		limit = 30
 	}
-	if offset >= len(rows) {
-		return nil
+	if sinceID == "" && untilID == "" {
+		if offset >= len(rows) {
+			return nil
+		}
+		end := min(offset+limit, len(rows))
+		return rows[offset:end]
 	}
-	end := min(offset+limit, len(rows))
-	return rows[offset:end]
+	if limit > len(rows) {
+		limit = len(rows)
+	}
+	return rows[:limit]
 }
 
 func applyPageFields(p *model.Page, fields map[string]any) {
@@ -2612,32 +2635,53 @@ func (m *MockFlashRepository) Delete(f *model.Flash) error {
 	return nil
 }
 
-func (m *MockFlashRepository) ListByUser(userID string, limit, offset int) ([]*model.Flash, error) {
+func (m *MockFlashRepository) ListByUser(userID, sinceID, untilID string, limit, offset int) ([]*model.Flash, error) {
 	var rows []*model.Flash
 	for _, f := range m.Flashes {
-		if f.UserID == userID {
-			rows = append(rows, f)
+		if f.UserID != userID {
+			continue
 		}
-	}
-	sortFlashesByUpdatedDesc(rows)
-	return paginateFlashes(rows, limit, offset), nil
-}
-
-func (m *MockFlashRepository) ListPublicByUser(userID string, limit, offset int) ([]*model.Flash, error) {
-	var rows []*model.Flash
-	for _, f := range m.Flashes {
-		if f.UserID == userID && f.Visibility == "public" {
-			rows = append(rows, f)
+		if sinceID != "" && f.ID <= sinceID {
+			continue
 		}
-	}
-	sortFlashesByUpdatedDesc(rows)
-	return paginateFlashes(rows, limit, offset), nil
-}
-
-func (m *MockFlashRepository) ListFeatured(limit, offset int) ([]*model.Flash, error) {
-	var rows []*model.Flash
-	for _, f := range m.Flashes {
+		if untilID != "" && f.ID >= untilID {
+			continue
+		}
 		rows = append(rows, f)
+	}
+	return paginateFlashes(rows, sinceID, untilID, limit, offset), nil
+}
+
+func (m *MockFlashRepository) ListPublicByUser(userID, sinceID, untilID string, limit, offset int) ([]*model.Flash, error) {
+	var rows []*model.Flash
+	for _, f := range m.Flashes {
+		if f.UserID != userID || f.Visibility != "public" {
+			continue
+		}
+		if sinceID != "" && f.ID <= sinceID {
+			continue
+		}
+		if untilID != "" && f.ID >= untilID {
+			continue
+		}
+		rows = append(rows, f)
+	}
+	return paginateFlashes(rows, sinceID, untilID, limit, offset), nil
+}
+
+func (m *MockFlashRepository) ListFeatured(sinceID, untilID string, limit, offset int) ([]*model.Flash, error) {
+	var rows []*model.Flash
+	for _, f := range m.Flashes {
+		if sinceID != "" && f.ID <= sinceID {
+			continue
+		}
+		if untilID != "" && f.ID >= untilID {
+			continue
+		}
+		rows = append(rows, f)
+	}
+	if sinceID != "" || untilID != "" {
+		return paginateFlashes(rows, sinceID, untilID, limit, offset), nil
 	}
 	for i := 0; i < len(rows); i++ {
 		for j := i + 1; j < len(rows); j++ {
@@ -2647,20 +2691,30 @@ func (m *MockFlashRepository) ListFeatured(limit, offset int) ([]*model.Flash, e
 			}
 		}
 	}
-	return paginateFlashes(rows, limit, offset), nil
+	return paginateFlashes(rows, "", "", limit, offset), nil
 }
 
-func (m *MockFlashRepository) Search(query string, limit, offset int) ([]*model.Flash, error) {
+func (m *MockFlashRepository) Search(query, sinceID, untilID string, limit, offset int) ([]*model.Flash, error) {
 	var rows []*model.Flash
 	q := strings.ToLower(query)
 	for _, f := range m.Flashes {
-		if strings.Contains(strings.ToLower(f.Title), q) ||
-			strings.Contains(strings.ToLower(f.Summary), q) {
-			rows = append(rows, f)
+		if !(strings.Contains(strings.ToLower(f.Title), q) ||
+			strings.Contains(strings.ToLower(f.Summary), q)) {
+			continue
 		}
+		if sinceID != "" && f.ID <= sinceID {
+			continue
+		}
+		if untilID != "" && f.ID >= untilID {
+			continue
+		}
+		rows = append(rows, f)
+	}
+	if sinceID != "" || untilID != "" {
+		return paginateFlashes(rows, sinceID, untilID, limit, offset), nil
 	}
 	sortFlashesByUpdatedDesc(rows)
-	return paginateFlashes(rows, limit, offset), nil
+	return paginateFlashes(rows, "", "", limit, offset), nil
 }
 
 func (m *MockFlashRepository) IncrementCount(flashID, column string, delta int) error {
@@ -2685,15 +2739,34 @@ func sortFlashesByUpdatedDesc(rows []*model.Flash) {
 	}
 }
 
-func paginateFlashes(rows []*model.Flash, limit, offset int) []*model.Flash {
+func paginateFlashes(rows []*model.Flash, sinceID, untilID string, limit, offset int) []*model.Flash {
+	asc := sinceID != "" && untilID == ""
+	if sinceID != "" || untilID != "" {
+		// cursor mode は id 順に並べ替える (offset mode の updatedAt 順
+		// は既に呼び出し側で sort 済み)。
+		for i := 0; i < len(rows); i++ {
+			for j := i + 1; j < len(rows); j++ {
+				less := rows[i].ID < rows[j].ID
+				if (asc && !less) || (!asc && less) {
+					rows[i], rows[j] = rows[j], rows[i]
+				}
+			}
+		}
+	}
 	if limit <= 0 || limit > 100 {
 		limit = 30
 	}
-	if offset >= len(rows) {
-		return nil
+	if sinceID == "" && untilID == "" {
+		if offset >= len(rows) {
+			return nil
+		}
+		end := min(offset+limit, len(rows))
+		return rows[offset:end]
 	}
-	end := min(offset+limit, len(rows))
-	return rows[offset:end]
+	if limit > len(rows) {
+		limit = len(rows)
+	}
+	return rows[:limit]
 }
 
 func applyFlashFields(f *model.Flash, fields map[string]any) {
@@ -2761,22 +2834,37 @@ func (m *MockFlashLikeRepository) Exists(userID, flashID string) (bool, error) {
 	return err == nil, nil
 }
 
-func (m *MockFlashLikeRepository) ListByUser(userID string, limit, offset int) ([]*model.FlashLike, error) {
+func (m *MockFlashLikeRepository) ListByUser(userID, sinceID, untilID string, limit, offset int) ([]*model.FlashLike, error) {
 	var rows []*model.FlashLike
 	for _, l := range m.Likes {
-		if l.UserID == userID {
-			rows = append(rows, l)
+		if l.UserID != userID {
+			continue
 		}
+		if sinceID != "" && l.ID <= sinceID {
+			continue
+		}
+		if untilID != "" && l.ID >= untilID {
+			continue
+		}
+		rows = append(rows, l)
 	}
+	asc := sinceID != "" && untilID == ""
 	for i := 0; i < len(rows); i++ {
 		for j := i + 1; j < len(rows); j++ {
-			if rows[i].ID < rows[j].ID {
+			less := rows[i].ID < rows[j].ID
+			if (asc && !less) || (!asc && less) {
 				rows[i], rows[j] = rows[j], rows[i]
 			}
 		}
 	}
 	if limit <= 0 || limit > 100 {
 		limit = 30
+	}
+	if sinceID != "" || untilID != "" {
+		if limit > len(rows) {
+			limit = len(rows)
+		}
+		return rows[:limit], nil
 	}
 	if offset >= len(rows) {
 		return nil, nil
@@ -3139,16 +3227,25 @@ func (m *MockChannelFollowingRepository) Exists(followerID, channelID string) (b
 	return err == nil, nil
 }
 
-func (m *MockChannelFollowingRepository) ListFollowed(userID string, limit, offset int) ([]*model.ChannelFollowing, error) {
+func (m *MockChannelFollowingRepository) ListFollowed(userID, sinceID, untilID string, limit, offset int) ([]*model.ChannelFollowing, error) {
 	var rows []*model.ChannelFollowing
 	for _, f := range m.Followings {
-		if f.FollowerID == userID {
-			rows = append(rows, f)
+		if f.FollowerID != userID {
+			continue
 		}
+		if sinceID != "" && f.ID <= sinceID {
+			continue
+		}
+		if untilID != "" && f.ID >= untilID {
+			continue
+		}
+		rows = append(rows, f)
 	}
+	asc := sinceID != "" && untilID == ""
 	for i := 0; i < len(rows); i++ {
 		for j := i + 1; j < len(rows); j++ {
-			if rows[i].ID < rows[j].ID {
+			less := rows[i].ID < rows[j].ID
+			if (asc && !less) || (!asc && less) {
 				rows[i], rows[j] = rows[j], rows[i]
 			}
 		}
@@ -3156,14 +3253,20 @@ func (m *MockChannelFollowingRepository) ListFollowed(userID string, limit, offs
 	if limit <= 0 || limit > 100 {
 		limit = 30
 	}
-	if offset >= len(rows) {
-		return nil, nil
+	if sinceID == "" && untilID == "" {
+		if offset >= len(rows) {
+			return nil, nil
+		}
+		end := offset + limit
+		if end > len(rows) {
+			end = len(rows)
+		}
+		return rows[offset:end], nil
 	}
-	end := offset + limit
-	if end > len(rows) {
-		end = len(rows)
+	if limit > len(rows) {
+		limit = len(rows)
 	}
-	return rows[offset:end], nil
+	return rows[:limit], nil
 }
 
 // ListFollowerIDsPage returns a page of followerIds for a given channel,


### PR DESCRIPTION
## Summary

#491 で残していた frontend Paginator (cursor mode) と handler の binding ミスマッチを横断的に解消し、合わせて response shape の missing field 群 (\`user\` / \`createdAt\` / 関連 entity の埋め込み) も upstream Misskey TS に揃える。UDS 環境で報告された無限スクロール / 空表示 / 個別ページ無表示の各種 regression を全て解消。

## cursor pagination 対応 endpoint

- \`mute/list\` / \`blocking/list\` / \`renote-mute/list\`
- \`users/flashs\` / \`users/pages\` / \`users/gallery/posts\`
- \`channels/featured\` / \`owned\` / \`followed\` / \`search\`
- \`flash/my\` / \`my-likes\` / \`featured\` / \`search\`
- \`pages/featured\` / \`i/pages\`
- \`gallery/posts\` (最近の投稿)
- \`federation/instances\`
- \`i/gallery/posts\` / \`i/gallery/likes\`

## response shape 修正 (frontend が空表示になっていた原因)

- \`mute/list\`: \`createdAt\` + \`mutee\` (UserDetailed) を embed
- \`blocking/list\`: \`createdAt\` + \`blockee\` を embed
- \`renote-mute/list\`: \`createdAt\` + \`mutee\` を embed
- \`flash/show\`: \`user\` (UserLite) + \`createdAt\` + \`isLiked\` を追加 (個別 Play 画面が描画されない問題を解消)
- \`flash/my\` / \`featured\` / \`search\`: \`user\` + \`createdAt\` を embed
- \`flash/my-likes\`: upstream の \`{id, flash: Flash}\` shape に揃える (元は flatten した Flash 配列で frontend が \`item.flash\` を読めず空表示)
- \`i/gallery/likes\`: \`{id, post: GalleryPost}\` shape に揃える (#493 兄弟ケース)

## repo / model 変更

- \`ListByMuter\` / \`ListByBlocker\` / \`ListByUser\` / \`ListPublicByUser\` / \`ListFeatured\` / \`Search\` / \`ListByFileID\` / \`ListFollowed\` に \`sinceID\` / \`untilID\` を追加し \`paginationOrder\` + \`WHERE id\` 範囲、cursor 指定時は offset 無視
- \`ChannelListFilter\` / \`InstanceListFilter\` に \`SinceID\` / \`UntilID\` を追加
- \`flash_like\` / \`channel_following\` にも cursor 対応を追加
- \`GalleryRepository.FindPostsByIDs\` を追加 (i/gallery/likes で post を batch fetch するため)

## handler signature 変更

\`mute\` / \`blocking\` / \`renote-mute\` / \`flash\` の \`NewHandler\` に \`userRepo\` / \`idGen\` を受け取らせて router で wire。これらは list 系 endpoint で関連 user object を embed するために必要。

## Testing

- \`go test ./... -count=1\` 全パッケージ通過
- \`make fmt && make lint\` clean
- UDS 環境で各画面 (settings/mute-block, ユーザープロフィール, channels タブ, Play 一覧 / 詳細 / お気に入り, ギャラリー, 連合インスタンス一覧) の挙動を確認:
  - 無限スクロール解消
  - mute/blocking/renote-mute 一覧が表示される
  - Play 個別ページが描画される / いいねボタンが動作する
  - Play お気に入りリストが表示される
  - ギャラリー最近の投稿 / お気に入りが正常動作

Closes #493

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/shiroha-a/mk/pull/520" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
