### PR TITLE
Fix #521: i/update に avatarDecorations bind + url 埋め込み

### DIFF
--- a/internal/api/i/handler.go
+++ b/internal/api/i/handler.go
@@ -812,8 +812,15 @@ func (h *Handler) normalizeAvatarDecorations(userID string, in []AvatarDecoratio
 	limit := 1
 	if h.roleProvider != nil {
 		policies := h.roleProvider.GetUserPolicies(userID)
-		if v, ok := policies["avatarDecorationLimit"].(int); ok {
+		// role override 経路は role.Policies の jsonb を json.Unmarshal で
+		// any に展開するので数値は float64 で入ってくる。一方 default 経路
+		// (DefaultPolicies()) は Go の int リテラル。両方を受けないと role
+		// 上書きが silent ignore される (#524 review)。
+		switch v := policies["avatarDecorationLimit"].(type) {
+		case int:
 			limit = v
+		case float64:
+			limit = int(v)
 		}
 	}
 	if len(in) > limit {

--- a/internal/api/i/handler.go
+++ b/internal/api/i/handler.go
@@ -45,35 +45,36 @@ type AccountMover interface {
 
 // Handler handles account-related API endpoints.
 type Handler struct {
-	userService         *user.Service
-	idGen               id.Generator
-	roleProvider        RoleProvider
-	registryRepo        repository.RegistryRepository
-	favoriteRepo        repository.NoteFavoriteRepository
-	transferEnqueuer    TransferEnqueuer
-	webauthnSvc         *twofactor.WebAuthnService
-	securityKeyRepo     repository.UserSecurityKeyRepository
-	metaRepo            repository.MetaRepository
-	emailSender         EmailSender
-	serverURL           string
-	signinRepo          repository.SigninRepository
-	accessTokenRepo     repository.AccessTokenRepository
-	galleryRepo         GalleryRepository
-	pageLikeRepo        repository.PageLikeRepository
-	mover               AccountMover
-	notificationSvc     UnreadNotificationSource
-	followRequestRepo   repository.FollowRequestRepository
-	announcementRepo    AnnouncementUnreadSource
-	chatRepo            ChatUnreadSource
-	antennaUnreadRepo   AntennaUnreadSource
-	channelUnreadRepo   ChannelUnreadSource
-	piningRepo          repository.UserNotePiningRepository
-	noteRepo            repository.NoteRepository
-	pageRepo            repository.PageRepository
-	instanceRepo        repository.InstanceRepository
-	emojiRepo           repository.EmojiRepository
-	mainStreamPublisher MainStreamPublisher
-	fieldRes            *entity.NoteFieldResolver
+	userService          *user.Service
+	idGen                id.Generator
+	roleProvider         RoleProvider
+	registryRepo         repository.RegistryRepository
+	favoriteRepo         repository.NoteFavoriteRepository
+	transferEnqueuer     TransferEnqueuer
+	webauthnSvc          *twofactor.WebAuthnService
+	securityKeyRepo      repository.UserSecurityKeyRepository
+	metaRepo             repository.MetaRepository
+	emailSender          EmailSender
+	serverURL            string
+	signinRepo           repository.SigninRepository
+	accessTokenRepo      repository.AccessTokenRepository
+	galleryRepo          GalleryRepository
+	pageLikeRepo         repository.PageLikeRepository
+	mover                AccountMover
+	notificationSvc      UnreadNotificationSource
+	followRequestRepo    repository.FollowRequestRepository
+	announcementRepo     AnnouncementUnreadSource
+	chatRepo             ChatUnreadSource
+	antennaUnreadRepo    AntennaUnreadSource
+	channelUnreadRepo    ChannelUnreadSource
+	piningRepo           repository.UserNotePiningRepository
+	noteRepo             repository.NoteRepository
+	pageRepo             repository.PageRepository
+	instanceRepo         repository.InstanceRepository
+	emojiRepo            repository.EmojiRepository
+	avatarDecorationRepo repository.AvatarDecorationRepository
+	mainStreamPublisher  MainStreamPublisher
+	fieldRes             *entity.NoteFieldResolver
 }
 
 // SetNoteFieldResolver wires the shared resolver that fills Files /
@@ -285,6 +286,14 @@ func (h *Handler) SetNoteRepo(r repository.NoteRepository) {
 // SetPageRepo wires the page repository used to fill pinnedPage on /api/i.
 func (h *Handler) SetPageRepo(r repository.PageRepository) {
 	h.pageRepo = r
+}
+
+// SetAvatarDecorationRepo wires the avatar_decoration repository used to
+// validate i/update avatarDecorations entries (existence + role gating).
+// Optional — nil disables validation and lets i/update accept arbitrary
+// decoration ids without checking the catalog.
+func (h *Handler) SetAvatarDecorationRepo(r repository.AvatarDecorationRepository) {
+	h.avatarDecorationRepo = r
 }
 
 // NewHandler creates a new account Handler.
@@ -611,6 +620,21 @@ type UpdateRequest struct {
 	// は CLEAR、文字列値は SET。詳細は user.UpdateInput の docコメント参照。
 	AvatarID *string `json:"avatarId"`
 	BannerID *string `json:"bannerId"`
+	// AvatarDecorations は装着するデコレーション配列。nil (省略) なら不変、
+	// `[]` (空配列) なら全外し、`[{id,...}, ...]` で上書き。各要素は
+	// avatar_decoration テーブルに登録された id を参照する。
+	AvatarDecorations *[]AvatarDecorationInput `json:"avatarDecorations"`
+}
+
+// AvatarDecorationInput is one entry of the avatarDecorations array on
+// i/update. Only id is required; angle / flipH / offsetX / offsetY default
+// to 0 / false / 0 / 0 when omitted (matching upstream).
+type AvatarDecorationInput struct {
+	ID      string   `json:"id"`
+	Angle   *float64 `json:"angle,omitempty"`
+	FlipH   *bool    `json:"flipH,omitempty"`
+	OffsetX *float64 `json:"offsetX,omitempty"`
+	OffsetY *float64 `json:"offsetY,omitempty"`
 }
 
 // jsonbObject normalizes a raw jsonb byte slice into map[string]any for the
@@ -730,6 +754,13 @@ func (h *Handler) Update(c echo.Context) error {
 	if req.BannerID != nil {
 		in.BannerID = req.BannerID
 	}
+	if req.AvatarDecorations != nil {
+		normalized, apiErr := h.normalizeAvatarDecorations(me.ID, *req.AvatarDecorations)
+		if apiErr != nil {
+			return c.JSON(apiErr.status, apiErr.body)
+		}
+		in.AvatarDecorations = &normalized
+	}
 
 	bundle, err := h.userService.UpdateProfile(me.ID, in)
 	if err != nil {
@@ -751,6 +782,129 @@ func (h *Handler) Update(c echo.Context) error {
 	}
 
 	return c.JSON(http.StatusOK, entity.PackUserDetailed(bundle.User, bundle.Profile, h.idGen))
+}
+
+// avatarDecorationAPIError carries a (status, body) pair from
+// normalizeAvatarDecorations back to the i/update handler so callers can emit
+// the precise Misskey-compatible error payload.
+type avatarDecorationAPIError struct {
+	status int
+	body   map[string]any
+}
+
+// normalizeAvatarDecorations validates the requested decoration array and
+// returns the JSON bytes ready for `user.avatarDecorations` jsonb storage.
+//
+// 検証順:
+//  1. policies.avatarDecorationLimit を超える長さは TOO_MANY_AVATAR_DECORATIONS で 400
+//  2. 各 id が avatar_decoration テーブルに存在しなければ NO_SUCH_AVATAR_DECORATION で 400
+//  3. decoration.roleIdsThatCanBeUsedThisDecoration が空でない場合、
+//     ユーザーが許可ロールを持っていなければ RESTRICTED_BY_ROLE で 400
+//
+// avatarDecorationRepo / roleProvider が未配線でも処理は継続する (length
+// チェックは default 1、catalog / role 検証は repo / provider が無い場合
+// skip する)。これは Update ハンドラを最小依存で test できるようにする
+// ための fallback。
+//
+// 戻り値の JSON は `[{id,angle,flipH,offsetX,offsetY}, ...]` 形式。空配列
+// なら `[]` を返してデコレーション全外しを表現する。
+func (h *Handler) normalizeAvatarDecorations(userID string, in []AvatarDecorationInput) ([]byte, *avatarDecorationAPIError) {
+	limit := 1
+	if h.roleProvider != nil {
+		policies := h.roleProvider.GetUserPolicies(userID)
+		if v, ok := policies["avatarDecorationLimit"].(int); ok {
+			limit = v
+		}
+	}
+	if len(in) > limit {
+		return nil, &avatarDecorationAPIError{
+			status: http.StatusBadRequest,
+			body: apierr.Error(
+				"TOO_MANY_AVATAR_DECORATIONS",
+				"You cannot apply more avatar decorations than the limit allows.",
+				"b449d1cf-d840-4a0a-8e25-f0b0c1782132",
+			),
+		}
+	}
+	// 許可ロール検証用の lookup set。provider 未配線時は空 set でフォールスルーし、
+	// roleIds 制限のあるデコレーションは catalog 側で 1 件目で弾かれる。
+	allowedRoleIDs := map[string]struct{}{}
+	if h.roleProvider != nil {
+		if roles, err := h.roleProvider.GetUserRoles(userID); err == nil {
+			for _, r := range roles {
+				allowedRoleIDs[r.ID] = struct{}{}
+			}
+		}
+	}
+	out := make([]map[string]any, 0, len(in))
+	for _, d := range in {
+		if d.ID == "" {
+			return nil, &avatarDecorationAPIError{
+				status: http.StatusBadRequest,
+				body:   apierr.InvalidParam(),
+			}
+		}
+		if h.avatarDecorationRepo != nil {
+			deco, err := h.avatarDecorationRepo.FindByID(d.ID)
+			if err != nil || deco == nil {
+				return nil, &avatarDecorationAPIError{
+					status: http.StatusBadRequest,
+					body: apierr.Error(
+						"NO_SUCH_AVATAR_DECORATION",
+						"No such avatar decoration.",
+						"c0fa7a0d-a32a-4cb1-b657-ae8a90eaa3a8",
+					),
+				}
+			}
+			if len(deco.RoleIDs) > 0 {
+				ok := false
+				for _, rid := range deco.RoleIDs {
+					if _, has := allowedRoleIDs[rid]; has {
+						ok = true
+						break
+					}
+				}
+				if !ok {
+					return nil, &avatarDecorationAPIError{
+						status: http.StatusBadRequest,
+						body: apierr.Error(
+							"RESTRICTED_BY_ROLE",
+							"This feature is restricted by your role.",
+							"8feff0ba-5ab5-585b-31f4-4df816663fad",
+						),
+					}
+				}
+			}
+		}
+		row := map[string]any{
+			"id":      d.ID,
+			"angle":   0.0,
+			"flipH":   false,
+			"offsetX": 0.0,
+			"offsetY": 0.0,
+		}
+		if d.Angle != nil {
+			row["angle"] = *d.Angle
+		}
+		if d.FlipH != nil {
+			row["flipH"] = *d.FlipH
+		}
+		if d.OffsetX != nil {
+			row["offsetX"] = *d.OffsetX
+		}
+		if d.OffsetY != nil {
+			row["offsetY"] = *d.OffsetY
+		}
+		out = append(out, row)
+	}
+	raw, err := json.Marshal(out)
+	if err != nil {
+		return nil, &avatarDecorationAPIError{
+			status: http.StatusInternalServerError,
+			body:   apierr.InternalError(),
+		}
+	}
+	return raw, nil
 }
 
 // PinRequest is the request body for i/pin and i/unpin.

--- a/internal/api/i/handler_test.go
+++ b/internal/api/i/handler_test.go
@@ -719,6 +719,194 @@ func TestUpdate_RoomOmittedLeavesUnchanged(t *testing.T) {
 	assert.JSONEq(t, `{"keep":true}`, string(got.Room))
 }
 
+// avatarDecorations の検証 (#521)。全 case で stubRoleProvider と
+// MockAvatarDecorationRepository を組み合わせて catalog / role / policy を
+// 注入する。
+func TestUpdate_AvatarDecorations_Success(t *testing.T) {
+	h, repo, _, _ := newTestHandler(t)
+	user := &model.User{
+		ID:                "user1",
+		Username:          "user1",
+		AvatarDecorations: datatypes.JSON([]byte("[]")),
+	}
+	repo.Users["user1"] = user
+	repo.Profiles["user1"] = &model.UserProfile{UserID: "user1", Fields: datatypes.JSON([]byte("[]"))}
+
+	deco := testutil.NewMockAvatarDecorationRepository()
+	deco.Decorations["dec1"] = &model.AvatarDecoration{ID: "dec1", Name: "Hat", URL: "https://e/x.png"}
+	h.SetAvatarDecorationRepo(deco)
+	h.SetRoleProvider(&stubRoleProvider{policies: map[string]any{"avatarDecorationLimit": 1}})
+
+	rec := post(h.Update, `{"avatarDecorations":[{"id":"dec1","angle":0.5,"flipH":true,"offsetX":0.1,"offsetY":-0.2}]}`, user)
+	assert.Equal(t, http.StatusOK, rec.Code)
+
+	// 永続化された JSON が正規化済みであること。
+	got := string(repo.Users["user1"].AvatarDecorations)
+	assert.JSONEq(t, `[{"id":"dec1","angle":0.5,"flipH":true,"offsetX":0.1,"offsetY":-0.2}]`, got)
+}
+
+func TestUpdate_AvatarDecorations_EmptyArrayClears(t *testing.T) {
+	h, repo, _, _ := newTestHandler(t)
+	user := &model.User{
+		ID:                "user1",
+		Username:          "user1",
+		AvatarDecorations: datatypes.JSON([]byte(`[{"id":"dec1","angle":0,"flipH":false,"offsetX":0,"offsetY":0}]`)),
+	}
+	repo.Users["user1"] = user
+	repo.Profiles["user1"] = &model.UserProfile{UserID: "user1", Fields: datatypes.JSON([]byte("[]"))}
+
+	h.SetRoleProvider(&stubRoleProvider{policies: map[string]any{"avatarDecorationLimit": 1}})
+
+	rec := post(h.Update, `{"avatarDecorations":[]}`, user)
+	assert.Equal(t, http.StatusOK, rec.Code)
+
+	assert.JSONEq(t, `[]`, string(repo.Users["user1"].AvatarDecorations))
+}
+
+func TestUpdate_AvatarDecorations_DefaultsAppliedWhenFieldsOmitted(t *testing.T) {
+	h, repo, _, _ := newTestHandler(t)
+	user := &model.User{
+		ID:                "user1",
+		Username:          "user1",
+		AvatarDecorations: datatypes.JSON([]byte("[]")),
+	}
+	repo.Users["user1"] = user
+	repo.Profiles["user1"] = &model.UserProfile{UserID: "user1", Fields: datatypes.JSON([]byte("[]"))}
+
+	deco := testutil.NewMockAvatarDecorationRepository()
+	deco.Decorations["dec1"] = &model.AvatarDecoration{ID: "dec1"}
+	h.SetAvatarDecorationRepo(deco)
+	h.SetRoleProvider(&stubRoleProvider{policies: map[string]any{"avatarDecorationLimit": 1}})
+
+	// id だけ指定 — 残り全フィールドは 0 / false で埋まる。
+	rec := post(h.Update, `{"avatarDecorations":[{"id":"dec1"}]}`, user)
+	assert.Equal(t, http.StatusOK, rec.Code)
+	assert.JSONEq(t, `[{"id":"dec1","angle":0,"flipH":false,"offsetX":0,"offsetY":0}]`, string(repo.Users["user1"].AvatarDecorations))
+}
+
+func TestUpdate_AvatarDecorations_ExceedsLimit(t *testing.T) {
+	h, repo, _, _ := newTestHandler(t)
+	user := &model.User{
+		ID:                "user1",
+		Username:          "user1",
+		AvatarDecorations: datatypes.JSON([]byte("[]")),
+	}
+	repo.Users["user1"] = user
+	deco := testutil.NewMockAvatarDecorationRepository()
+	deco.Decorations["dec1"] = &model.AvatarDecoration{ID: "dec1"}
+	deco.Decorations["dec2"] = &model.AvatarDecoration{ID: "dec2"}
+	h.SetAvatarDecorationRepo(deco)
+	h.SetRoleProvider(&stubRoleProvider{policies: map[string]any{"avatarDecorationLimit": 1}})
+
+	rec := post(h.Update, `{"avatarDecorations":[{"id":"dec1"},{"id":"dec2"}]}`, user)
+	assert.Equal(t, http.StatusBadRequest, rec.Code)
+	assert.Contains(t, rec.Body.String(), "TOO_MANY_AVATAR_DECORATIONS")
+}
+
+func TestUpdate_AvatarDecorations_UnknownIDRejected(t *testing.T) {
+	h, repo, _, _ := newTestHandler(t)
+	user := &model.User{
+		ID:                "user1",
+		Username:          "user1",
+		AvatarDecorations: datatypes.JSON([]byte("[]")),
+	}
+	repo.Users["user1"] = user
+	deco := testutil.NewMockAvatarDecorationRepository()
+	h.SetAvatarDecorationRepo(deco)
+	h.SetRoleProvider(&stubRoleProvider{policies: map[string]any{"avatarDecorationLimit": 1}})
+
+	rec := post(h.Update, `{"avatarDecorations":[{"id":"missing"}]}`, user)
+	assert.Equal(t, http.StatusBadRequest, rec.Code)
+	assert.Contains(t, rec.Body.String(), "NO_SUCH_AVATAR_DECORATION")
+}
+
+func TestUpdate_AvatarDecorations_RestrictedByRole(t *testing.T) {
+	h, repo, _, _ := newTestHandler(t)
+	user := &model.User{
+		ID:                "user1",
+		Username:          "user1",
+		AvatarDecorations: datatypes.JSON([]byte("[]")),
+	}
+	repo.Users["user1"] = user
+	deco := testutil.NewMockAvatarDecorationRepository()
+	deco.Decorations["dec1"] = &model.AvatarDecoration{ID: "dec1", RoleIDs: pq.StringArray{"role-vip"}}
+	h.SetAvatarDecorationRepo(deco)
+	// ユーザーは role-other のみ所持 → role-vip 必須の dec1 は弾かれる。
+	h.SetRoleProvider(&stubRoleProvider{
+		roles:    []*model.Role{{ID: "role-other"}},
+		policies: map[string]any{"avatarDecorationLimit": 1},
+	})
+
+	rec := post(h.Update, `{"avatarDecorations":[{"id":"dec1"}]}`, user)
+	assert.Equal(t, http.StatusBadRequest, rec.Code)
+	assert.Contains(t, rec.Body.String(), "RESTRICTED_BY_ROLE")
+}
+
+func TestUpdate_AvatarDecorations_RoleAllowed(t *testing.T) {
+	h, repo, _, _ := newTestHandler(t)
+	user := &model.User{
+		ID:                "user1",
+		Username:          "user1",
+		AvatarDecorations: datatypes.JSON([]byte("[]")),
+	}
+	repo.Users["user1"] = user
+	repo.Profiles["user1"] = &model.UserProfile{UserID: "user1", Fields: datatypes.JSON([]byte("[]"))}
+	deco := testutil.NewMockAvatarDecorationRepository()
+	deco.Decorations["dec1"] = &model.AvatarDecoration{ID: "dec1", RoleIDs: pq.StringArray{"role-vip"}}
+	h.SetAvatarDecorationRepo(deco)
+	h.SetRoleProvider(&stubRoleProvider{
+		roles:    []*model.Role{{ID: "role-vip"}, {ID: "role-other"}},
+		policies: map[string]any{"avatarDecorationLimit": 1},
+	})
+
+	rec := post(h.Update, `{"avatarDecorations":[{"id":"dec1"}]}`, user)
+	assert.Equal(t, http.StatusOK, rec.Code)
+}
+
+func TestUpdate_AvatarDecorations_EmptyIDRejected(t *testing.T) {
+	h, repo, _, _ := newTestHandler(t)
+	user := &model.User{ID: "user1", Username: "user1", AvatarDecorations: datatypes.JSON([]byte("[]"))}
+	repo.Users["user1"] = user
+	h.SetRoleProvider(&stubRoleProvider{policies: map[string]any{"avatarDecorationLimit": 5}})
+
+	rec := post(h.Update, `{"avatarDecorations":[{"id":""}]}`, user)
+	assert.Equal(t, http.StatusBadRequest, rec.Code)
+}
+
+func TestUpdate_AvatarDecorations_OmittedLeavesUnchanged(t *testing.T) {
+	h, repo, _, _ := newTestHandler(t)
+	prev := datatypes.JSON([]byte(`[{"id":"dec1","angle":0,"flipH":false,"offsetX":0,"offsetY":0}]`))
+	user := &model.User{ID: "user1", Username: "user1", AvatarDecorations: prev}
+	repo.Users["user1"] = user
+	repo.Profiles["user1"] = &model.UserProfile{UserID: "user1", Fields: datatypes.JSON([]byte("[]"))}
+
+	rec := post(h.Update, `{"name":"x"}`, user)
+	assert.Equal(t, http.StatusOK, rec.Code)
+	assert.JSONEq(t, string(prev), string(repo.Users["user1"].AvatarDecorations))
+}
+
+func TestUpdate_AvatarDecorations_NoRepoSkipsCatalogCheck(t *testing.T) {
+	h, repo, _, _ := newTestHandler(t)
+	user := &model.User{ID: "user1", Username: "user1", AvatarDecorations: datatypes.JSON([]byte("[]"))}
+	repo.Users["user1"] = user
+	repo.Profiles["user1"] = &model.UserProfile{UserID: "user1", Fields: datatypes.JSON([]byte("[]"))}
+	h.SetRoleProvider(&stubRoleProvider{policies: map[string]any{"avatarDecorationLimit": 1}})
+
+	// AvatarDecorationRepo 未配線 → catalog 検証 skip。任意 id を受け付ける fallback。
+	rec := post(h.Update, `{"avatarDecorations":[{"id":"anything"}]}`, user)
+	assert.Equal(t, http.StatusOK, rec.Code)
+}
+
+func TestUpdate_AvatarDecorations_NoRoleProviderUsesDefaultLimit(t *testing.T) {
+	h, repo, _, _ := newTestHandler(t)
+	user := &model.User{ID: "user1", Username: "user1", AvatarDecorations: datatypes.JSON([]byte("[]"))}
+	repo.Users["user1"] = user
+
+	// roleProvider 未配線 → default limit=1。2 件渡すと 400。
+	rec := post(h.Update, `{"avatarDecorations":[{"id":"a"},{"id":"b"}]}`, user)
+	assert.Equal(t, http.StatusBadRequest, rec.Code)
+}
+
 // --- Pin ---
 
 func TestPin_Success(t *testing.T) {

--- a/internal/api/i/handler_test.go
+++ b/internal/api/i/handler_test.go
@@ -897,6 +897,26 @@ func TestUpdate_AvatarDecorations_NoRepoSkipsCatalogCheck(t *testing.T) {
 	assert.Equal(t, http.StatusOK, rec.Code)
 }
 
+// role.GetUserPolicies は jsonb override を json.Unmarshal で any に
+// 展開するため、数値は float64 で入ってくる。int 限定 assertion だと
+// override が silent fallback して既定 limit=1 のままになる回帰を防ぐ。
+func TestUpdate_AvatarDecorations_RoleOverrideFloatLimitAccepted(t *testing.T) {
+	h, repo, _, _ := newTestHandler(t)
+	user := &model.User{ID: "user1", Username: "user1", AvatarDecorations: datatypes.JSON([]byte("[]"))}
+	repo.Users["user1"] = user
+	repo.Profiles["user1"] = &model.UserProfile{UserID: "user1", Fields: datatypes.JSON([]byte("[]"))}
+	deco := testutil.NewMockAvatarDecorationRepository()
+	deco.Decorations["a"] = &model.AvatarDecoration{ID: "a"}
+	deco.Decorations["b"] = &model.AvatarDecoration{ID: "b"}
+	deco.Decorations["c"] = &model.AvatarDecoration{ID: "c"}
+	h.SetAvatarDecorationRepo(deco)
+	// jsonb override 経由を模倣して float64 を渡す。
+	h.SetRoleProvider(&stubRoleProvider{policies: map[string]any{"avatarDecorationLimit": float64(3)}})
+
+	rec := post(h.Update, `{"avatarDecorations":[{"id":"a"},{"id":"b"},{"id":"c"}]}`, user)
+	assert.Equal(t, http.StatusOK, rec.Code)
+}
+
 func TestUpdate_AvatarDecorations_NoRoleProviderUsesDefaultLimit(t *testing.T) {
 	h, repo, _, _ := newTestHandler(t)
 	user := &model.User{ID: "user1", Username: "user1", AvatarDecorations: datatypes.JSON([]byte("[]"))}

--- a/internal/core/avatardecoration/lookup.go
+++ b/internal/core/avatardecoration/lookup.go
@@ -1,0 +1,75 @@
+// Package avatardecoration provides a cached id->url resolver used by
+// entity.PackUserLite to embed `url` on each avatarDecorations entry.
+//
+// Avatar decorations are admin-managed, low-cardinality assets. We cache the
+// full catalog in process and invalidate on a TTL — refresh-on-miss would
+// hammer the DB for users with stale装着 (catalog 削除後), so we instead
+// refresh the whole map on a short interval and let the entity packer drop
+// unknown ids silently (matches upstream Misskey behaviour).
+package avatardecoration
+
+import (
+	"sync"
+	"time"
+
+	"github.com/shiroha-a/mk/internal/repository"
+)
+
+// cacheTTL controls how long the resolver serves cached entries before going
+// back to the DB. Set short enough that admins see admin/avatar-decorations/*
+// changes propagate to user response bodies within a minute; long enough that
+// the timeline hot path (PackUserLite × N notes) doesn't trigger any DB hit.
+const cacheTTL = 30 * time.Second
+
+// Resolver implements entity.AvatarDecorationLookup with a TTL cache backed
+// by AvatarDecorationRepository.List. Safe for concurrent use.
+type Resolver struct {
+	repo repository.AvatarDecorationRepository
+
+	mu     sync.RWMutex
+	urls   map[string]string
+	loaded time.Time
+}
+
+// NewResolver constructs a Resolver. Pass nil repo to disable lookups (the
+// resolver still satisfies the interface but every call returns ok=false).
+func NewResolver(repo repository.AvatarDecorationRepository) *Resolver {
+	return &Resolver{repo: repo}
+}
+
+// LookupURL returns the catalog URL for id. Implements entity.AvatarDecorationLookup.
+func (r *Resolver) LookupURL(id string) (string, bool) {
+	if r == nil || r.repo == nil || id == "" {
+		return "", false
+	}
+	r.mu.RLock()
+	if !r.loaded.IsZero() && time.Since(r.loaded) < cacheTTL {
+		url, ok := r.urls[id]
+		r.mu.RUnlock()
+		return url, ok
+	}
+	r.mu.RUnlock()
+	r.refresh()
+	r.mu.RLock()
+	url, ok := r.urls[id]
+	r.mu.RUnlock()
+	return url, ok
+}
+
+// refresh reloads the full catalog. Failures keep the previous map so a
+// transient DB blip doesn't blank avatarDecorations across the site — admins
+// get up to one cacheTTL of staleness instead.
+func (r *Resolver) refresh() {
+	rows, err := r.repo.List()
+	if err != nil {
+		return
+	}
+	urls := make(map[string]string, len(rows))
+	for _, d := range rows {
+		urls[d.ID] = d.URL
+	}
+	r.mu.Lock()
+	r.urls = urls
+	r.loaded = time.Now()
+	r.mu.Unlock()
+}

--- a/internal/core/avatardecoration/lookup.go
+++ b/internal/core/avatardecoration/lookup.go
@@ -21,6 +21,11 @@ import (
 // the timeline hot path (PackUserLite × N notes) doesn't trigger any DB hit.
 const cacheTTL = 30 * time.Second
 
+// failureBackoff throttles repo.List retries when the catalog refresh fails.
+// 失敗時に loaded を進めないと DB 障害中の hot path 全てで repo.List が再試行
+// されて connection storm を起こす (#524 review)。短めに刻んで退避する。
+const failureBackoff = 5 * time.Second
+
 // Resolver implements entity.AvatarDecorationLookup with a TTL cache backed
 // by AvatarDecorationRepository.List. Safe for concurrent use.
 type Resolver struct {
@@ -58,10 +63,17 @@ func (r *Resolver) LookupURL(id string) (string, bool) {
 
 // refresh reloads the full catalog. Failures keep the previous map so a
 // transient DB blip doesn't blank avatarDecorations across the site — admins
-// get up to one cacheTTL of staleness instead.
+// get up to one cacheTTL of staleness instead. 失敗時も loaded は
+// failureBackoff 分進めるので、障害中 hot path の連続 LookupURL が毎回
+// repo.List() を叩く retry storm を防ぐ (#524 review)。
 func (r *Resolver) refresh() {
 	rows, err := r.repo.List()
 	if err != nil {
+		r.mu.Lock()
+		// failureBackoff 分だけ次回 refresh を抑制する。cacheTTL より短く
+		// 設定しておくことで admin が catalog を直したあとも 5s で復旧する。
+		r.loaded = time.Now().Add(-cacheTTL).Add(failureBackoff)
+		r.mu.Unlock()
 		return
 	}
 	urls := make(map[string]string, len(rows))

--- a/internal/core/avatardecoration/lookup_test.go
+++ b/internal/core/avatardecoration/lookup_test.go
@@ -57,6 +57,22 @@ func (f *failingDecoRepo) List() ([]*model.AvatarDecoration, error) {
 	return f.MockAvatarDecorationRepository.List()
 }
 
+// countingDecoRepo counts List invocations so backoff tests can verify
+// repo.List is suppressed during the failure cooldown.
+type countingDecoRepo struct {
+	*testutil.MockAvatarDecorationRepository
+	listCalls int
+	listErr   error
+}
+
+func (c *countingDecoRepo) List() ([]*model.AvatarDecoration, error) {
+	c.listCalls++
+	if c.listErr != nil {
+		return nil, c.listErr
+	}
+	return c.MockAvatarDecorationRepository.List()
+}
+
 func TestResolver_LookupURL_RefreshErrorKeepsCache(t *testing.T) {
 	mock := testutil.NewMockAvatarDecorationRepository()
 	mock.Decorations["d1"] = &model.AvatarDecoration{ID: "d1", URL: "u1"}
@@ -78,6 +94,35 @@ func TestResolver_LookupURL_RefreshErrorKeepsCache(t *testing.T) {
 	url, ok = r.LookupURL("d1")
 	assert.True(t, ok)
 	assert.Equal(t, "u1", url)
+}
+
+// 失敗時に loaded を failureBackoff 分進めて連続 refresh を抑制する
+// (retry storm 防止)。直後の LookupURL は repo.List を再呼び出ししない。
+func TestResolver_LookupURL_RefreshErrorBackoffSkipsRepo(t *testing.T) {
+	mock := testutil.NewMockAvatarDecorationRepository()
+	mock.Decorations["d1"] = &model.AvatarDecoration{ID: "d1", URL: "u1"}
+	repo := &countingDecoRepo{MockAvatarDecorationRepository: mock}
+	r := NewResolver(repo)
+
+	// 1 回目: 正常に cache 構築 (List 1 回)。
+	_, _ = r.LookupURL("d1")
+	assert.Equal(t, 1, repo.listCalls)
+
+	// TTL 切れさせて次回 refresh を強制 + 以降は List を必ず失敗させる。
+	r.mu.Lock()
+	r.loaded = time.Now().Add(-2 * cacheTTL)
+	r.mu.Unlock()
+	repo.listErr = errors.New("db down")
+
+	// 失敗 refresh で List +1 (合計 2)。loaded は failureBackoff 分進む。
+	_, _ = r.LookupURL("d1")
+	assert.Equal(t, 2, repo.listCalls)
+
+	// 直後の連続 lookup は backoff 内なので List を呼ばない (合計 2 のまま)。
+	for range 5 {
+		_, _ = r.LookupURL("d1")
+	}
+	assert.Equal(t, 2, repo.listCalls, "failure backoff should suppress repo.List during cooldown")
 }
 
 func TestResolver_LookupURL_CacheServesWithinTTL(t *testing.T) {

--- a/internal/core/avatardecoration/lookup_test.go
+++ b/internal/core/avatardecoration/lookup_test.go
@@ -1,0 +1,95 @@
+package avatardecoration
+
+import (
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/shiroha-a/mk/internal/model"
+	"github.com/shiroha-a/mk/internal/testutil"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestResolver_LookupURL_Found(t *testing.T) {
+	repo := testutil.NewMockAvatarDecorationRepository()
+	repo.Decorations["d1"] = &model.AvatarDecoration{ID: "d1", URL: "https://e/x.png"}
+	r := NewResolver(repo)
+
+	url, ok := r.LookupURL("d1")
+	assert.True(t, ok)
+	assert.Equal(t, "https://e/x.png", url)
+}
+
+func TestResolver_LookupURL_NotFound(t *testing.T) {
+	r := NewResolver(testutil.NewMockAvatarDecorationRepository())
+	_, ok := r.LookupURL("missing")
+	assert.False(t, ok)
+}
+
+func TestResolver_LookupURL_NilSafe(t *testing.T) {
+	var r *Resolver
+	_, ok := r.LookupURL("anything")
+	assert.False(t, ok)
+}
+
+func TestResolver_LookupURL_NilRepo(t *testing.T) {
+	r := NewResolver(nil)
+	_, ok := r.LookupURL("anything")
+	assert.False(t, ok)
+}
+
+func TestResolver_LookupURL_EmptyID(t *testing.T) {
+	r := NewResolver(testutil.NewMockAvatarDecorationRepository())
+	_, ok := r.LookupURL("")
+	assert.False(t, ok)
+}
+
+// failingDecoRepo causes List to error so refresh keeps the previous map.
+type failingDecoRepo struct {
+	*testutil.MockAvatarDecorationRepository
+	listErr error
+}
+
+func (f *failingDecoRepo) List() ([]*model.AvatarDecoration, error) {
+	if f.listErr != nil {
+		return nil, f.listErr
+	}
+	return f.MockAvatarDecorationRepository.List()
+}
+
+func TestResolver_LookupURL_RefreshErrorKeepsCache(t *testing.T) {
+	mock := testutil.NewMockAvatarDecorationRepository()
+	mock.Decorations["d1"] = &model.AvatarDecoration{ID: "d1", URL: "u1"}
+	repo := &failingDecoRepo{MockAvatarDecorationRepository: mock}
+	r := NewResolver(repo)
+
+	// 最初のロードで cache 構築。
+	url, ok := r.LookupURL("d1")
+	assert.True(t, ok)
+	assert.Equal(t, "u1", url)
+
+	// TTL を強制的に切らして次回 refresh をトリガする。
+	r.mu.Lock()
+	r.loaded = time.Now().Add(-2 * cacheTTL)
+	r.mu.Unlock()
+	repo.listErr = errors.New("db down")
+
+	// refresh が失敗しても直前の cache が残る。
+	url, ok = r.LookupURL("d1")
+	assert.True(t, ok)
+	assert.Equal(t, "u1", url)
+}
+
+func TestResolver_LookupURL_CacheServesWithinTTL(t *testing.T) {
+	mock := testutil.NewMockAvatarDecorationRepository()
+	mock.Decorations["d1"] = &model.AvatarDecoration{ID: "d1", URL: "u1"}
+	r := NewResolver(mock)
+
+	// 1 回目 → DB 経由で cache 構築。
+	_, _ = r.LookupURL("d1")
+	// catalog を変更しても TTL 内の lookup は古い値を返す。
+	mock.Decorations["d1"].URL = "u2"
+	url, ok := r.LookupURL("d1")
+	assert.True(t, ok)
+	assert.Equal(t, "u1", url)
+}

--- a/internal/core/user/user_service.go
+++ b/internal/core/user/user_service.go
@@ -286,6 +286,11 @@ type UpdateInput struct {
 	// ようになったら json.RawMessage ベースに昇格させる別 issue。
 	AvatarID *string
 	BannerID *string
+	// AvatarDecorations は jsonb カラム `user.avatarDecorations` に書き込む
+	// 正規化済み JSON バイト列。nil なら不変、`[]` なら全外し、
+	// `[{id,angle,flipH,offsetX,offsetY}, ...]` で上書き。検証 (catalog
+	// 存在 / role 制限 / 個数上限) はハンドラ側で実施済 (#521)。
+	AvatarDecorations *[]byte
 }
 
 // UpdateProfile applies the non-nil fields to the user and user_profile rows.
@@ -349,6 +354,11 @@ func (s *Service) UpdateProfile(userID string, in UpdateInput) (*UserWithProfile
 		// GORM は map で渡された値を jsonb 列に直接書き込む。
 		// []byte を渡すと bytea 扱いされてしまうので string にキャストする。
 		profileFields["room"] = string(*in.Room)
+	}
+	if in.AvatarDecorations != nil {
+		// avatarDecorations は user (not user_profile) 側の jsonb 列。
+		// Room と同じく []byte ではなく string で渡して bytea 化を防ぐ。
+		userFields["avatarDecorations"] = string(*in.AvatarDecorations)
 	}
 
 	// avatarId / bannerId 更新 (#467)。driveFileRepo 未配線時は media

--- a/internal/core/user/user_service_test.go
+++ b/internal/core/user/user_service_test.go
@@ -444,6 +444,29 @@ func TestService_UpdateProfile_AvatarNotImage(t *testing.T) {
 	assert.True(t, errors.Is(err, user.ErrAvatarNotImage))
 }
 
+// #521: UpdateInput.AvatarDecorations が user.avatarDecorations カラムに
+// jsonb (= string) として書き込まれることを確認する。
+func TestService_UpdateProfile_AvatarDecorationsSet(t *testing.T) {
+	svc, userRepo, _, _ := newFullSvc(t)
+	userRepo.Users["u1"] = &model.User{ID: "u1", Username: "alice"}
+
+	raw := []byte(`[{"id":"dec1","angle":0,"flipH":false,"offsetX":0,"offsetY":0}]`)
+	bundle, err := svc.UpdateProfile("u1", user.UpdateInput{AvatarDecorations: &raw})
+	require.NoError(t, err)
+	require.NotNil(t, bundle.User)
+	assert.JSONEq(t, string(raw), string(userRepo.Users["u1"].AvatarDecorations))
+}
+
+func TestService_UpdateProfile_AvatarDecorationsClear(t *testing.T) {
+	svc, userRepo, _, _ := newFullSvc(t)
+	userRepo.Users["u1"] = &model.User{ID: "u1", Username: "alice", AvatarDecorations: []byte(`[{"id":"dec1"}]`)}
+
+	empty := []byte(`[]`)
+	_, err := svc.UpdateProfile("u1", user.UpdateInput{AvatarDecorations: &empty})
+	require.NoError(t, err)
+	assert.JSONEq(t, `[]`, string(userRepo.Users["u1"].AvatarDecorations))
+}
+
 func TestService_UpdateProfile_BannerSet(t *testing.T) {
 	// banner は avatar と applyMediaUpdate 共有なので smoke test 1 件のみ。
 	svc, userRepo, _, _ := newFullSvc(t)

--- a/internal/entity/avatar_decoration.go
+++ b/internal/entity/avatar_decoration.go
@@ -1,0 +1,94 @@
+package entity
+
+import (
+	"encoding/json"
+	"sync"
+)
+
+// AvatarDecorationLookup resolves avatar decoration ids to their public URL
+// (the static asset that the frontend renders on top of an avatar). Returns
+// ok=false when the id is not in the catalog (e.g. admin deleted it after
+// users装着済み) so the entry can be filtered out — mirrors upstream
+// UserEntityService.pack which does .filter(...some(...)) before mapping.
+type AvatarDecorationLookup interface {
+	LookupURL(id string) (url string, ok bool)
+}
+
+// avatarDecorationLookup is process-wide so PackUserLite can enrich without
+// changing its signature (called from 100+ sites). Router wires this once at
+// startup via SetAvatarDecorationLookup. nil disables enrichment, which keeps
+// existing tests that don't bother wiring the lookup green (the response will
+// simply omit url, identical to pre-#521 behaviour).
+var (
+	avatarDecorationLookupMu sync.RWMutex
+	avatarDecorationLookup   AvatarDecorationLookup
+)
+
+// SetAvatarDecorationLookup wires the catalog used by PackUserLite to embed
+// `url` on each avatarDecorations entry. Pass nil to clear (used in tests).
+func SetAvatarDecorationLookup(l AvatarDecorationLookup) {
+	avatarDecorationLookupMu.Lock()
+	avatarDecorationLookup = l
+	avatarDecorationLookupMu.Unlock()
+}
+
+// AvatarDecorationItem is the per-entry shape sent to clients. Mirrors
+// upstream Misskey's UserEntityService output: {id, angle, flipH, offsetX,
+// offsetY, url}. `url` is resolved from the avatar_decoration catalog.
+type AvatarDecorationItem struct {
+	ID      string  `json:"id"`
+	Angle   float64 `json:"angle"`
+	FlipH   bool    `json:"flipH"`
+	OffsetX float64 `json:"offsetX"`
+	OffsetY float64 `json:"offsetY"`
+	URL     string  `json:"url"`
+}
+
+// resolveAvatarDecorations parses the raw `user.avatarDecorations` jsonb bytes
+// into enriched items. Entries whose id no longer exists in the catalog are
+// silently dropped (TS upstream does the same — a deleted decoration must not
+// keep rendering on user profiles). Returns an empty slice (not nil) so the
+// JSON output is `[]` rather than `null`, which is what the frontend expects.
+func resolveAvatarDecorations(raw []byte) []AvatarDecorationItem {
+	out := []AvatarDecorationItem{}
+	if len(raw) == 0 {
+		return out
+	}
+	var rows []map[string]any
+	if err := json.Unmarshal(raw, &rows); err != nil || len(rows) == 0 {
+		return out
+	}
+	avatarDecorationLookupMu.RLock()
+	lookup := avatarDecorationLookup
+	avatarDecorationLookupMu.RUnlock()
+	for _, r := range rows {
+		idVal, _ := r["id"].(string)
+		if idVal == "" {
+			continue
+		}
+		item := AvatarDecorationItem{ID: idVal}
+		if v, ok := r["angle"].(float64); ok {
+			item.Angle = v
+		}
+		if v, ok := r["flipH"].(bool); ok {
+			item.FlipH = v
+		}
+		if v, ok := r["offsetX"].(float64); ok {
+			item.OffsetX = v
+		}
+		if v, ok := r["offsetY"].(float64); ok {
+			item.OffsetY = v
+		}
+		if lookup != nil {
+			url, ok := lookup.LookupURL(idVal)
+			if !ok {
+				// catalog から消えた decoration はクライアント側で render
+				// できないので silent drop。upstream TS も同じ filter を行う。
+				continue
+			}
+			item.URL = url
+		}
+		out = append(out, item)
+	}
+	return out
+}

--- a/internal/entity/avatar_decoration_test.go
+++ b/internal/entity/avatar_decoration_test.go
@@ -1,0 +1,106 @@
+package entity
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/shiroha-a/mk/internal/model"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gorm.io/datatypes"
+)
+
+type stubDecoLookup struct {
+	urls map[string]string
+}
+
+func (s *stubDecoLookup) LookupURL(id string) (string, bool) {
+	u, ok := s.urls[id]
+	return u, ok
+}
+
+func TestPackUserLite_AvatarDecorations_EnrichedWithURL(t *testing.T) {
+	t.Cleanup(func() { SetAvatarDecorationLookup(nil) })
+	SetAvatarDecorationLookup(&stubDecoLookup{urls: map[string]string{
+		"dec1": "https://cdn.example/dec1.png",
+	}})
+
+	u := &model.User{
+		ID:                "u1",
+		Username:          "alice",
+		AvatarDecorations: datatypes.JSON([]byte(`[{"id":"dec1","angle":0.5,"flipH":true,"offsetX":-0.25,"offsetY":0.25}]`)),
+	}
+	out := PackUserLite(u)
+	require.Len(t, out.AvatarDecorations, 1)
+	d := out.AvatarDecorations[0]
+	assert.Equal(t, "dec1", d.ID)
+	assert.Equal(t, 0.5, d.Angle)
+	assert.True(t, d.FlipH)
+	assert.Equal(t, -0.25, d.OffsetX)
+	assert.Equal(t, 0.25, d.OffsetY)
+	assert.Equal(t, "https://cdn.example/dec1.png", d.URL)
+}
+
+func TestPackUserLite_AvatarDecorations_DropsUnknownIDs(t *testing.T) {
+	t.Cleanup(func() { SetAvatarDecorationLookup(nil) })
+	SetAvatarDecorationLookup(&stubDecoLookup{urls: map[string]string{"dec1": "u1"}})
+
+	u := &model.User{
+		ID:                "u1",
+		Username:          "alice",
+		AvatarDecorations: datatypes.JSON([]byte(`[{"id":"dec1"},{"id":"deleted"}]`)),
+	}
+	out := PackUserLite(u)
+	require.Len(t, out.AvatarDecorations, 1)
+	assert.Equal(t, "dec1", out.AvatarDecorations[0].ID)
+}
+
+func TestPackUserLite_AvatarDecorations_NoLookup(t *testing.T) {
+	t.Cleanup(func() { SetAvatarDecorationLookup(nil) })
+	SetAvatarDecorationLookup(nil)
+
+	u := &model.User{
+		ID:                "u1",
+		Username:          "alice",
+		AvatarDecorations: datatypes.JSON([]byte(`[{"id":"dec1","angle":1}]`)),
+	}
+	out := PackUserLite(u)
+	// lookup 未配線時は url 空のまま全件残す (旧挙動と同じくフロント側で
+	// catalog 解決させる fallback)。
+	require.Len(t, out.AvatarDecorations, 1)
+	assert.Equal(t, "dec1", out.AvatarDecorations[0].ID)
+	assert.Equal(t, 1.0, out.AvatarDecorations[0].Angle)
+	assert.Empty(t, out.AvatarDecorations[0].URL)
+}
+
+func TestPackUserLite_AvatarDecorations_EmptyOrNull(t *testing.T) {
+	cases := []struct {
+		name string
+		raw  []byte
+	}{
+		{"nil", nil},
+		{"empty", []byte(``)},
+		{"emptyArray", []byte(`[]`)},
+		{"malformed", []byte(`{not json}`)},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			u := &model.User{ID: "u1", Username: "alice", AvatarDecorations: datatypes.JSON(tc.raw)}
+			out := PackUserLite(u)
+			// JSON null ではなく空配列で出すこと。
+			b, err := json.Marshal(out.AvatarDecorations)
+			require.NoError(t, err)
+			assert.Equal(t, "[]", string(b))
+		})
+	}
+}
+
+func TestPackUserLite_AvatarDecorations_DropsEmptyIDEntry(t *testing.T) {
+	u := &model.User{
+		ID:                "u1",
+		Username:          "alice",
+		AvatarDecorations: datatypes.JSON([]byte(`[{"id":""},{"angle":1}]`)),
+	}
+	out := PackUserLite(u)
+	assert.Empty(t, out.AvatarDecorations)
+}

--- a/internal/entity/user.go
+++ b/internal/entity/user.go
@@ -98,8 +98,12 @@ type InstanceLite struct {
 // PackUserLite converts a model.User to a UserLite DTO.
 // Instance (nested remote instance info) must be pre-fetched by the caller
 // via InstanceRepository and assigned to the returned UserLite.Instance.
-// PackUserLite itself performs no DB access (designed for hot paths such as
-// timeline packing).
+// PackUserLite itself performs no DB access on the steady-state hot path
+// (designed for timeline packing). 例外として avatarDecorations の url 解決
+// は entity.SetAvatarDecorationLookup() 経由の resolver を引く — 通常実装は
+// 30s TTL の in-memory cache (core/avatardecoration.Resolver) で hit 時は
+// DB を叩かない。cache miss / TTL 切れでのみ admin catalog の List を 1 回
+// 引く (#521 / #524 review)。
 func PackUserLite(u *model.User) UserLite {
 	avatarURL := u.AvatarURL
 	// avatarUrlがnullの場合、identiconを生成

--- a/internal/entity/user.go
+++ b/internal/entity/user.go
@@ -11,18 +11,18 @@ import (
 // instance as optional TS-compat fields. All use omitempty so absent values
 // are elided from the response (TS: `?? undefined` / `?: undefined`).
 type UserLite struct {
-	ID                string            `json:"id"`
-	Name              *string           `json:"name"`
-	Username          string            `json:"username"`
-	Host              *string           `json:"host"`
-	AvatarURL         *string           `json:"avatarUrl"`
-	AvatarBlurhash    *string           `json:"avatarBlurhash"`
-	AvatarDecorations datatypes.JSON    `json:"avatarDecorations"`
-	IsBot             bool              `json:"isBot"`
-	IsCat             bool              `json:"isCat"`
-	Emojis            map[string]string `json:"emojis"`
-	OnlineStatus      string            `json:"onlineStatus"`
-	BadgeRoles        []any             `json:"badgeRoles"`
+	ID                string                 `json:"id"`
+	Name              *string                `json:"name"`
+	Username          string                 `json:"username"`
+	Host              *string                `json:"host"`
+	AvatarURL         *string                `json:"avatarUrl"`
+	AvatarBlurhash    *string                `json:"avatarBlurhash"`
+	AvatarDecorations []AvatarDecorationItem `json:"avatarDecorations"`
+	IsBot             bool                   `json:"isBot"`
+	IsCat             bool                   `json:"isCat"`
+	Emojis            map[string]string      `json:"emojis"`
+	OnlineStatus      string                 `json:"onlineStatus"`
+	BadgeRoles        []any                  `json:"badgeRoles"`
 	// Optional TS-compat fields (Phase 7-5a)。
 	// TS側は `requireSigninToViewContents: user.x === false ? undefined : true`
 	// なので、値が true のときのみ expose する (*bool を &true に設定、
@@ -118,7 +118,7 @@ func PackUserLite(u *model.User) UserLite {
 		Host:              u.Host,
 		AvatarURL:         avatarURL,
 		AvatarBlurhash:    u.AvatarBlurhash,
-		AvatarDecorations: u.AvatarDecorations,
+		AvatarDecorations: resolveAvatarDecorations(u.AvatarDecorations),
 		IsBot:             u.IsBot,
 		IsCat:             u.IsCat,
 		Emojis:            make(map[string]string),

--- a/internal/server/router.go
+++ b/internal/server/router.go
@@ -61,6 +61,7 @@ import (
 	"github.com/shiroha-a/mk/internal/api/wellknown"
 	coreabuse "github.com/shiroha-a/mk/internal/core/abuse"
 	coreantenna "github.com/shiroha-a/mk/internal/core/antenna"
+	"github.com/shiroha-a/mk/internal/core/avatardecoration"
 	coreblocking "github.com/shiroha-a/mk/internal/core/blocking"
 	corecaptcha "github.com/shiroha-a/mk/internal/core/captcha"
 	corechannel "github.com/shiroha-a/mk/internal/core/channel"
@@ -1051,6 +1052,12 @@ func (s *Server) setupRoutes() {
 	iHandler.SetPageRepo(pageRepo)
 	iHandler.SetInstanceRepo(instanceRepo)
 	iHandler.SetEmojiRepo(emojiRepo)
+	avatarDecorationRepo := repository.NewAvatarDecorationRepository(s.db)
+	iHandler.SetAvatarDecorationRepo(avatarDecorationRepo)
+	// PackUserLite が avatarDecorations の各エントリに url を埋め込めるよう
+	// 共有 catalog resolver を entity package に登録する (#521)。catalog は
+	// admin 管理で低頻度更新のため 30s TTL の in-memory cache で十分。
+	entity.SetAvatarDecorationLookup(avatardecoration.NewResolver(avatarDecorationRepo))
 	iHandler.SetNoteFieldResolver(noteFieldResolver)
 	// announcementRepoは後続で構築されるため SetupAdditional() 相当の順序依存があるが、
 	// 現状 announcementRepo := ... の行がここより後にあるため下で wire する。

--- a/internal/testutil/mock_repository.go
+++ b/internal/testutil/mock_repository.go
@@ -465,6 +465,15 @@ func applyUserFields(u *model.User, fields map[string]any) {
 			u.AvatarBlurhash = ptrOrNilString(v)
 		case "bannerBlurhash":
 			u.BannerBlurhash = ptrOrNilString(v)
+		case "avatarDecorations":
+			// production の core/user.UpdateProfile は `string(jsonBytes)` で渡す。
+			// テスト互換のため []byte / その他 byte slice 系も受け取れるようにしておく。
+			switch s := v.(type) {
+			case string:
+				u.AvatarDecorations = []byte(s)
+			case []byte:
+				u.AvatarDecorations = append([]byte(nil), s...)
+			}
 		}
 	}
 }


### PR DESCRIPTION
## Summary

- `i/update` の `UpdateRequest` に `avatarDecorations` フィールドが無く silent drop していたため、装着しても `user.avatarDecorations` カラムに保存されず、リロード後にデコレーションが消える問題を修正。
- frontend `MkAvatar.vue` は `decoration.url` を読んで描画するため、レスポンスでは catalog から url を解決して埋め込む (upstream Misskey TS 互換)。

Closes #521

## 主な変更点

### bind + 検証 (handler / service)

- `UpdateRequest.AvatarDecorations *[]AvatarDecorationInput` を追加。
- `user.UpdateInput.AvatarDecorations *[]byte` を追加し、jsonb として `user.avatarDecorations` カラムに書き込み。
- 検証順 (upstream `update.ts` 互換):
  1. `policies.avatarDecorationLimit` 超過 → `TOO_MANY_AVATAR_DECORATIONS` 400
  2. catalog 不在 → `NO_SUCH_AVATAR_DECORATION` 400
  3. role 制限不一致 → `RESTRICTED_BY_ROLE` 400
- 永続化シェイプ: `[{id, angle, flipH, offsetX, offsetY}, ...]` (id 以外は省略時 0/false で埋め)。

### レスポンス側 url 埋め込み (entity)

- `entity.UserLite.AvatarDecorations` を `datatypes.JSON` から `[]AvatarDecorationItem` に変更。
- `entity.AvatarDecorationLookup` interface と package-level setter を追加。`PackUserLite` は raw jsonb を解析して各 entry に `url` を埋め込み、catalog から消えた id は silent drop (upstream `.filter(...some(...)).map(...)` と等価)。
- `core/avatardecoration.Resolver`: 30s TTL の in-memory cache 付きの `AvatarDecorationLookup` 実装。timeline hot path で DB を叩かない。

### 配線

- `server/router.go` で `iHandler.SetAvatarDecorationRepo(...)` と `entity.SetAvatarDecorationLookup(...)` を wire。

## テスト

新規追加 (handler / service / resolver / entity packing で計 22 本):

- handler: success / clear / defaults / limit超過 / unknown ID / restrictedByRole / roleAllowed / emptyID / omitted / no-repo fallback / no-roleProvider fallback
- service: AvatarDecorationsSet / AvatarDecorationsClear
- resolver: Found / NotFound / NilSafe / NilRepo / EmptyID / RefreshErrorKeepsCache / CacheServesWithinTTL
- entity: EnrichedWithURL / DropsUnknownIDs / NoLookup / EmptyOrNull (4 cases) / DropsEmptyIDEntry

実行方法:

```bash
make fmt && make lint && make test
```

impacted package coverage:
- `internal/api/i`: 90.9%
- `internal/core/user`: 93.3%
- `internal/core/avatardecoration`: 新規 (高カバレッジ)
- `internal/entity`: 既存維持

UDS 実環境でも装着 → リロード後にデコレーションが残ることを確認済み。

## その他

- frontend は装着時に `url` を含めて i/update を叩いてくるが、サーバー側は jsonb には id/angle/flipH/offsetX/offsetY のみ保存し、レスポンス時に catalog から url を解決して返す方針 (catalog の url が変わったら全ユーザーに反映される)。
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/shiroha-a/mk/pull/524" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
