### PR TITLE
Fix #525: insert / between S3 prefix and accessKey

### DIFF
--- a/internal/core/drive/s3_storage.go
+++ b/internal/core/drive/s3_storage.go
@@ -26,7 +26,7 @@ type S3API interface {
 // prefix is normalised at construction so that operators can enter either
 // "files" or "files/" in the admin UI; objectKey always emits
 // "<prefix>/<accessKey>". This matches Misskey TS which always joins prefix
-// and accessKey with a "/" (#525)。
+// and accessKey with a "/" (#525).
 type S3Storage struct {
 	client        S3API
 	bucket        string
@@ -61,10 +61,11 @@ func NewS3Storage(cfg S3StorageConfig) *S3Storage {
 }
 
 // objectKey returns the full S3 object key for the given accessKey.
-// prefix と accessKey の間に必ず "/" を入れる。Misskey TS の objectKey
-// 生成 (`${prefix}/${accessKey}`) と一致させて、同じ DB に対する
-// drop-in 切替で互いの書き込みが読めるようにする (#525)。
+// Empty prefix returns just accessKey; otherwise emits "<prefix>/<accessKey>".
 func (s *S3Storage) objectKey(accessKey string) string {
+	// prefix と accessKey の間に必ず "/" を入れる。Misskey TS の objectKey
+	// 生成 (`${prefix}/${accessKey}`) と一致させて、同じ DB に対する
+	// drop-in 切替で互いの書き込みが読めるようにする (#525)。
 	if s.prefix == "" {
 		return accessKey
 	}

--- a/internal/core/drive/s3_storage.go
+++ b/internal/core/drive/s3_storage.go
@@ -22,10 +22,15 @@ type S3API interface {
 }
 
 // S3Storage implements Storage using an S3-compatible object storage backend.
+//
+// prefix is normalised at construction so that operators can enter either
+// "files" or "files/" in the admin UI; objectKey always emits
+// "<prefix>/<accessKey>". This matches Misskey TS which always joins prefix
+// and accessKey with a "/" (#525)。
 type S3Storage struct {
 	client        S3API
 	bucket        string
-	prefix        string // オブジェクトキーのプリフィックス (e.g. "files/")
+	prefix        string // 末尾 / を取り除いた状態で保持。空なら prefix なし。
 	baseURL       string // 公開 URL のベース (e.g. "https://cdn.example.com")
 	setPublicRead bool
 }
@@ -42,17 +47,28 @@ type S3StorageConfig struct {
 // NewS3Storage creates a new S3Storage instance.
 func NewS3Storage(cfg S3StorageConfig) *S3Storage {
 	return &S3Storage{
-		client:        cfg.Client,
-		bucket:        cfg.Bucket,
-		prefix:        cfg.Prefix,
+		client: cfg.Client,
+		bucket: cfg.Bucket,
+		// Misskey TS の admin UI は placeholder が "files" (末尾 / 無し) で、
+		// 既存 operator はそのままの値を DB に入れている。一方で末尾 / 付きで
+		// 入れている運用も実在するので、ここで一度だけ正規化して保持する。
+		// "files/" でも "files" でも、最終的な objectKey は
+		// "files/<accessKey>" に揃う (#525)。
+		prefix:        strings.TrimRight(cfg.Prefix, "/"),
 		baseURL:       strings.TrimRight(cfg.BaseURL, "/"),
 		setPublicRead: cfg.SetPublicRead,
 	}
 }
 
 // objectKey returns the full S3 object key for the given accessKey.
+// prefix と accessKey の間に必ず "/" を入れる。Misskey TS の objectKey
+// 生成 (`${prefix}/${accessKey}`) と一致させて、同じ DB に対する
+// drop-in 切替で互いの書き込みが読めるようにする (#525)。
 func (s *S3Storage) objectKey(accessKey string) string {
-	return s.prefix + accessKey
+	if s.prefix == "" {
+		return accessKey
+	}
+	return s.prefix + "/" + accessKey
 }
 
 // publicURL returns the public URL for the given accessKey.

--- a/internal/core/drive/s3_storage_test.go
+++ b/internal/core/drive/s3_storage_test.go
@@ -233,3 +233,36 @@ func TestS3Storage_ObjectKey(t *testing.T) {
 	st2 := NewS3Storage(S3StorageConfig{})
 	assert.Equal(t, "abc", st2.objectKey("abc"))
 }
+
+// Misskey TS の admin UI placeholder は "files" (末尾 / なし) なので、
+// operator がそのまま入れた値でも `<prefix>/<accessKey>` が生成されること。
+// これが破れると drop-in 互換が永続的に壊れる (#525)。
+func TestS3Storage_ObjectKey_PrefixWithoutTrailingSlash(t *testing.T) {
+	st := NewS3Storage(S3StorageConfig{Prefix: "files"})
+	assert.Equal(t, "files/abc123", st.objectKey("abc123"),
+		"prefix without trailing slash must still produce 'files/abc123' (TS-compat)")
+}
+
+func TestS3Storage_ObjectKey_PrefixWithMultipleTrailingSlashes(t *testing.T) {
+	// "files///" のような誤入力でも separator は 1 個だけになる
+	st := NewS3Storage(S3StorageConfig{Prefix: "files///"})
+	assert.Equal(t, "files/abc", st.objectKey("abc"))
+}
+
+// publicURL が prefix の末尾 / 有無に依らず "<base>/files/<key>" の形に
+// なることを担保する。
+func TestS3Storage_PublicURL_PrefixWithoutTrailingSlash(t *testing.T) {
+	mock := &mockS3API{}
+	st := NewS3Storage(S3StorageConfig{
+		Client:  mock,
+		Bucket:  "my-bucket",
+		Prefix:  "files",
+		BaseURL: "https://cdn.example.com",
+	})
+	url, err := st.Put("abc123", bytes.NewReader([]byte("x")))
+	require.NoError(t, err)
+	assert.Equal(t, "https://cdn.example.com/files/abc123", url)
+	require.NotNil(t, mock.putInput)
+	assert.Equal(t, "files/abc123", *mock.putInput.Key,
+		"S3 PutObject Key must be 'files/abc123' even when operator omits the trailing slash")
+}

--- a/internal/core/drive/storage_factory_test.go
+++ b/internal/core/drive/storage_factory_test.go
@@ -58,7 +58,10 @@ func TestNewStorageFromMeta_S3(t *testing.T) {
 	s3st, ok := st.(*S3Storage)
 	assert.True(t, ok, "should return S3Storage")
 	assert.Equal(t, "my-bucket", s3st.bucket)
-	assert.Equal(t, "files/", s3st.prefix)
+	// NewS3Storage normalises the prefix by trimming trailing "/", so "files/"
+	// is stored as "files" (#525). objectKey re-inserts the separator so the
+	// final S3 key is still "files/<accessKey>".
+	assert.Equal(t, "files", s3st.prefix)
 	assert.Equal(t, "https://cdn.example.com", s3st.baseURL)
 	assert.True(t, s3st.setPublicRead)
 }

--- a/internal/core/drive/storage_factory_test.go
+++ b/internal/core/drive/storage_factory_test.go
@@ -58,9 +58,9 @@ func TestNewStorageFromMeta_S3(t *testing.T) {
 	s3st, ok := st.(*S3Storage)
 	assert.True(t, ok, "should return S3Storage")
 	assert.Equal(t, "my-bucket", s3st.bucket)
-	// NewS3Storage normalises the prefix by trimming trailing "/", so "files/"
-	// is stored as "files" (#525). objectKey re-inserts the separator so the
-	// final S3 key is still "files/<accessKey>".
+	// NewS3Storage は末尾の "/" を正規化するため、"files/" は "files" として
+	// 保持される (#525)。objectKey が separator を再挿入するので最終的な
+	// S3 キーは "files/<accessKey>" のまま変わらない。
 	assert.Equal(t, "files", s3st.prefix)
 	assert.Equal(t, "https://cdn.example.com", s3st.baseURL)
 	assert.True(t, s3st.setPublicRead)


### PR DESCRIPTION
## Summary

`S3Storage` が prefix と accessKey を separator 無しで連結 (`prefix + accessKey`) していたため、Misskey TS の admin UI placeholder どおり `files` (末尾 / なし) を入れている operator の DB を mk が引き継ぐと、objectKey が `filesXXXX` 形式となって TS が書いた既存ファイルがすべて NoSuchKey 404 になる (#525)。

mk → TS 切替方向でも、mk が `files<accessKey>` で書いたオブジェクトを TS は `files/<accessKey>` で読みに行くので 404、しかも `drive_file.url` カラムに mk が壊れた URL を永続化するので TS 側の修正では救済不可。

## 主な変更点

| ファイル | 内容 |
|---------|------|
| `internal/core/drive/s3_storage.go` | `NewS3Storage` で `strings.TrimRight(prefix, "/")` で正規化。`objectKey` は `s.prefix + "/" + accessKey` で必ず separator を入れる (空 prefix はそのまま accessKey のみ返す) |
| `internal/core/drive/s3_storage_test.go` | `Prefix: "files"` (末尾 / なし) で `files/<key>` が出ること、`Prefix: "files///"` でも `/` 1 個に正規化されること、`PutObject` の `Key` と `publicURL` の両方で正しく出ることを担保する 3 ケース追加 |

## クエリ例 (修正前 → 修正後)

`prefix = "files"` のとき:

```
- before: GET /<bucket>/filesf6130b05-... → NoSuchKey 404
- after : GET /<bucket>/files/f6130b05-... → 200 OK
```

## 互換性

- `"files"` / `"files/"` / `"files///"` のいずれを入れても結果は同じ `files/<accessKey>` に揃う
- 既存の `"uploads/"` (末尾 / 付き) で動いていた構成は引き続き同じキーを生成 (互換維持)
- 空 prefix は accessKey のみ (リーディング `/` を入れない)

## 派生 (本 PR 範囲外)

修正後、過去に mk が壊れたキーで書き込んでしまった分は DB を触らない限り救済不可。drop-in 互換最重視の方針に従い migration は提供せず、changelog で operator に "mk で書き込んだ drive_file 行は手動削除推奨" とのみ告知する想定 (#525 issue 末尾参照)。

## テスト

```sh
go test -count=1 -run 'TestS3Storage' ./internal/core/drive/
ok  	internal/core/drive    0.035s
```

`go vet ./...` クリーン、`gofmt -s -d .` 差分なし、`go build ./...` クリーン。

Closes #525
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/shiroha-a/mk/pull/526" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
