### PR TITLE
Fix #523: make S3 Put body io.Seeker for SigV4 payload hash

### DIFF
--- a/internal/core/drive/s3_storage.go
+++ b/internal/core/drive/s3_storage.go
@@ -1,6 +1,7 @@
 package drive
 
 import (
+	"bytes"
 	"context"
 	"fmt"
 	"io"
@@ -65,20 +66,30 @@ func (s *S3Storage) publicURL(accessKey string) string {
 }
 
 // Put uploads the body to S3 and returns the public URL.
+//
+// aws-sdk-go-v2 は SigV4 payload hash を計算するため Body が io.Seeker
+// を満たす必要がある。以前は MIME 判定のために `io.MultiReader` で wrap
+// していたが、MultiReader は Seeker を実装しないので SDK が
+// "failed to seek body to start, request stream is not seekable" で即 fail し、
+// HTTP リクエストすら送出されず drive/files/create が常に 500 になっていた
+// (#523)。一度 []byte に集めて bytes.Reader (Seeker 実装) を渡すことで解消。
 func (s *S3Storage) Put(accessKey string, body io.Reader) (string, error) {
 	key := s.objectKey(accessKey)
 
-	// MIME type を判定するため先頭を読む
-	buf := make([]byte, 512)
-	n, _ := io.ReadAtLeast(body, buf, 1)
-	contentType := http.DetectContentType(buf[:n])
-	// 読んだ分を body の先頭に戻す
-	combined := io.MultiReader(strings.NewReader(string(buf[:n])), body)
+	data, err := io.ReadAll(body)
+	if err != nil {
+		return "", fmt.Errorf("s3 read body for %s: %w", key, err)
+	}
+	sniff := data
+	if len(sniff) > 512 {
+		sniff = sniff[:512]
+	}
+	contentType := http.DetectContentType(sniff)
 
 	input := &s3.PutObjectInput{
 		Bucket:       aws.String(s.bucket),
 		Key:          aws.String(key),
-		Body:         combined,
+		Body:         bytes.NewReader(data),
 		ContentType:  aws.String(contentType),
 		CacheControl: aws.String("max-age=31536000, immutable"),
 	}

--- a/internal/core/drive/s3_storage_test.go
+++ b/internal/core/drive/s3_storage_test.go
@@ -184,6 +184,48 @@ func TestS3Storage_Delete_Error(t *testing.T) {
 	assert.Contains(t, err.Error(), "s3 delete")
 }
 
+// S3 SDK は SigV4 payload hash 計算で Body を seek する。Body が
+// io.Seeker を満たしていなかった旧実装では SDK が即 fail していた (#523)。
+// 修正後の Put が PutObjectInput.Body に bytes.Reader (= io.Seeker 実装) を
+// 渡すこと、そして body 全文がそのまま伝わることを担保する。
+func TestS3Storage_Put_BodyIsSeekable(t *testing.T) {
+	mock := &mockS3API{}
+	st := NewS3Storage(S3StorageConfig{
+		Client: mock,
+		Bucket: "bucket",
+	})
+	payload := []byte("hello world payload >= 11 bytes")
+	// 渡す側は Seeker 非対応な io.Reader にして、Put 内部で seekable に
+	// 変換されることを確認する。
+	_, err := st.Put("k1", io.MultiReader(bytes.NewReader(payload)))
+	require.NoError(t, err)
+	require.NotNil(t, mock.putInput)
+
+	body, ok := mock.putInput.Body.(io.Seeker)
+	require.True(t, ok, "PutObjectInput.Body must implement io.Seeker for SigV4 payload hash")
+
+	// Body 内容が body 全文と一致すること
+	got, err := io.ReadAll(mock.putInput.Body)
+	require.NoError(t, err)
+	assert.Equal(t, payload, got)
+
+	// seek し直しても再読み込みできる (SDK の retry middleware が seek する)
+	_, err = body.Seek(0, io.SeekStart)
+	require.NoError(t, err)
+	again, _ := io.ReadAll(mock.putInput.Body)
+	assert.Equal(t, payload, again)
+}
+
+// 512 byte 未満の小さい body でも正しく MIME 判定されて upload されること。
+func TestS3Storage_Put_SmallBody(t *testing.T) {
+	mock := &mockS3API{}
+	st := NewS3Storage(S3StorageConfig{Client: mock, Bucket: "bucket"})
+	_, err := st.Put("k", bytes.NewReader([]byte("tiny")))
+	require.NoError(t, err)
+	require.NotNil(t, mock.putInput)
+	assert.NotEmpty(t, *mock.putInput.ContentType)
+}
+
 func TestS3Storage_ObjectKey(t *testing.T) {
 	st := NewS3Storage(S3StorageConfig{Prefix: "uploads/"})
 	assert.Equal(t, "uploads/abc", st.objectKey("abc"))


### PR DESCRIPTION
## Summary

aws-sdk-go-v2 は SigV4 payload hash を計算するため `PutObjectInput.Body` が `io.Seeker` を満たす必要がある。`S3Storage.Put` が body を `io.MultiReader` (Seeker 不実装) で wrap していたため、SDK が即 fail し \`drive/files/create\` が常に 500 を返していた。S3 endpoint には HTTP リクエストすら送られず、operator から見ると原因不明 (#523)。

```
operation error S3: PutObject,
failed to compute payload hash:
failed to seek body to start, request stream is not seekable
```

## 主な変更点

| ファイル | 内容 |
|---------|------|
| `internal/core/drive/s3_storage.go` | `io.MultiReader` 撤廃。`io.ReadAll` で `[]byte` に集めてから `bytes.NewReader` を Body に渡す (Seeker 実装)。MIME 判定は同じ `[]byte` の先頭最大 512 byte で行う。`bytes` import 追加 |
| `internal/core/drive/s3_storage_test.go` | `PutObjectInput.Body` が `io.Seeker` を満たすこと / body 全文が伝わること / SDK の retry middleware が seek し直しても再読込できること、512 byte 未満の小さい body でも MIME 付きで upload されることを担保 |

## 影響

- S3 互換ストレージ (MinIO 含む) を使っている全運用で drive upload が回復する
- mk → TS / mk → mk drop-in 切替で objectStorage を有効にしている場合の必須修正

## メモリ消費

`io.ReadAll` で body 全体をメモリに載せるが、SDK 自体が SigV4 hash 計算で同じことをするため実質変わらない。drive_file は `maxFileSize` (デフォルト数十 MB) で gating されているので問題なし。

## テスト

```sh
go test -count=1 -run 'TestS3Storage_Put' ./internal/core/drive/
ok  	internal/core/drive    0.039s
```

`go vet ./...` クリーン、`gofmt -s -d .` 差分なし、`go build ./...` クリーン。

## 関連

- 同じ `s3_storage.go` の objectKey/separator 欠落バグは別 PR (#526) で修正中
- 両方 merge 後に objectStorage 経由のアップロード/読み出しが完全に動く

Closes #523
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/shiroha-a/mk/pull/527" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
