### PR TITLE
Fix #519: accept ioredis-style redis.path as UDS alias for redis.host

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -23,7 +23,14 @@ var MisskeyVersion = "2026.3.2"
 
 // RedisOptions represents Redis connection configuration.
 type RedisOptions struct {
-	Host     string `mapstructure:"host"`
+	Host string `mapstructure:"host"`
+	// Path is an ioredis-style alias for connecting via a UNIX domain socket.
+	// Misskey TS は内部で ioredis を使っており、`example.yml` の "You can
+	// specify more ioredis options..." 経由で `redis.path: /run/valkey.sock`
+	// を書いている operator が一定数いる。同じ config を mk と共有する drop-in
+	// 切替で詰まらないよう、Path が指定されていれば Host より優先して unix
+	// socket 接続にする (#519)。
+	Path     string `mapstructure:"path"`
 	Port     int    `mapstructure:"port"`
 	Family   int    `mapstructure:"family"`
 	Pass     string `mapstructure:"pass"`
@@ -322,15 +329,15 @@ func bindEnvKeys(v *viper.Viper) {
 	keys := []string{
 		"url", "port", "socket",
 		"db.host", "db.port", "db.db", "db.user", "db.pass",
-		"redis.host", "redis.port", "redis.pass", "redis.db", "redis.username",
+		"redis.host", "redis.path", "redis.port", "redis.pass", "redis.db", "redis.username",
 		"redis.family", "redis.prefix",
-		"redisForPubsub.host", "redisForPubsub.port", "redisForPubsub.pass",
+		"redisForPubsub.host", "redisForPubsub.path", "redisForPubsub.port", "redisForPubsub.pass",
 		"redisForPubsub.family", "redisForPubsub.prefix", "redisForPubsub.db", "redisForPubsub.username",
-		"redisForJobQueue.host", "redisForJobQueue.port", "redisForJobQueue.pass",
+		"redisForJobQueue.host", "redisForJobQueue.path", "redisForJobQueue.port", "redisForJobQueue.pass",
 		"redisForJobQueue.family", "redisForJobQueue.prefix", "redisForJobQueue.db", "redisForJobQueue.username",
-		"redisForTimelines.host", "redisForTimelines.port", "redisForTimelines.pass",
+		"redisForTimelines.host", "redisForTimelines.path", "redisForTimelines.port", "redisForTimelines.pass",
 		"redisForTimelines.family", "redisForTimelines.prefix", "redisForTimelines.db", "redisForTimelines.username",
-		"redisForReactions.host", "redisForReactions.port", "redisForReactions.pass",
+		"redisForReactions.host", "redisForReactions.path", "redisForReactions.port", "redisForReactions.pass",
 		"redisForReactions.family", "redisForReactions.prefix", "redisForReactions.db", "redisForReactions.username",
 		"db.maxOpenConns", "db.maxIdleConns", "db.connMaxLifetime", "db.connMaxIdleTime",
 		"redis.poolSize",

--- a/internal/core/cache/cache_test.go
+++ b/internal/core/cache/cache_test.go
@@ -97,6 +97,32 @@ func TestBuildRedisOptions_UnixSocket(t *testing.T) {
 	assert.Equal(t, 0, opts.PoolSize) // 未指定時はgo-redisデフォルト
 }
 
+// `redis.path: /run/...` (ioredis 流) を mk が UNIX domain socket として
+// 解釈すること (#519)。同じ config を TS と共有する drop-in 切替で
+// 詰まらないようにするための互換 alias。
+func TestBuildRedisOptions_PathAliasIsUnixSocket(t *testing.T) {
+	opts := buildRedisOptions(config.RedisOptions{
+		Path: "/var/run/valkey/valkey.sock",
+		// ioredis 互換: host: "127.0.0.1" / port: 6379 が同居していても
+		// Path が優先されること (TS の ioredis path 優先と同じ挙動)。
+		Host: "127.0.0.1",
+		Port: 6379,
+		Pass: "secret",
+	})
+	assert.Equal(t, "unix", opts.Network)
+	assert.Equal(t, "/var/run/valkey/valkey.sock", opts.Addr,
+		"redis.path must take precedence over redis.host for UDS")
+	assert.Equal(t, "secret", opts.Password)
+}
+
+func TestBuildRedisOptions_PathEmptyFallsBackToHost(t *testing.T) {
+	opts := buildRedisOptions(config.RedisOptions{
+		Host: "/var/run/redis/redis.sock", // 旧来 mk の書き方
+	})
+	assert.Equal(t, "unix", opts.Network)
+	assert.Equal(t, "/var/run/redis/redis.sock", opts.Addr)
+}
+
 func TestBuildRedisOptions_PoolSize(t *testing.T) {
 	poolSize := 50
 	opts := buildRedisOptions(config.RedisOptions{

--- a/internal/core/cache/redis.go
+++ b/internal/core/cache/redis.go
@@ -33,8 +33,8 @@ func NewRedisClients(cfg *config.Config) (*RedisClients, error) {
 		return nil, fmt.Errorf("failed to connect to Redis: %w", err)
 	}
 
-	if config.IsUnixSocketPath(cfg.Redis.Host) {
-		slog.Info("connected to Redis", "socket", cfg.Redis.Host)
+	if sock := unixSocketPath(cfg.Redis); sock != "" {
+		slog.Info("connected to Redis", "socket", sock)
 	} else {
 		slog.Info("connected to Redis",
 			"host", cfg.Redis.Host,
@@ -49,10 +49,25 @@ func newClient(opts config.RedisOptions) *redis.Client {
 	return redis.NewClient(buildRedisOptions(opts))
 }
 
+// unixSocketPath は config から UNIX domain socket パスを取り出す。
+// `redis.path` (ioredis 流) を最優先し、未指定時は `redis.host` が socket
+// パス ("/" 始まり) のときに限ってそれを採用する。それ以外は "" を返す
+// (= TCP 接続にフォールバック)。
+func unixSocketPath(opts config.RedisOptions) string {
+	if opts.Path != "" {
+		return opts.Path
+	}
+	if config.IsUnixSocketPath(opts.Host) {
+		return opts.Host
+	}
+	return ""
+}
+
 // buildRedisOptions maps mk-go の config.RedisOptions を go-redis の
-// redis.Options に変換する。Host が UNIX domain socket パス ("/" 始まり) の
-// ときは Network を "unix" に切り替え、Addr にはパスをそのまま入れる。
-// そうでなければ従来どおり host:port 形式の TCP 接続にする。
+// redis.Options に変換する。`redis.path` (ioredis 互換 alias) もしくは
+// Host が UNIX domain socket パス ("/" 始まり) のときは Network を "unix"
+// に切り替え、Addr にはパスをそのまま入れる。そうでなければ従来どおり
+// host:port 形式の TCP 接続にする (#519)。
 func buildRedisOptions(opts config.RedisOptions) *redis.Options {
 	// go-redisのデフォルトPoolSizeはruntime.GOMAXPROCS * 10。
 	// 明示的に指定された場合のみ上書きする（0はgo-redisデフォルトを意味する）。
@@ -61,10 +76,10 @@ func buildRedisOptions(opts config.RedisOptions) *redis.Options {
 		poolSize = *opts.PoolSize
 	}
 
-	if config.IsUnixSocketPath(opts.Host) {
+	if sock := unixSocketPath(opts); sock != "" {
 		return &redis.Options{
 			Network:  "unix",
-			Addr:     opts.Host,
+			Addr:     sock,
 			Password: opts.Pass,
 			DB:       opts.DB,
 			Username: opts.Username,


### PR DESCRIPTION
## Summary

Misskey TS は ioredis を使っており、`redis.path: /run/valkey.sock` (ioredis の UDS 指定) でそのまま UNIX domain socket 接続が成立する。`example.yml` の "You can specify more ioredis options..." 経由で operator がこの形式で書いていることがある。

mk は `path:` を解釈せず、host も空のため `dial tcp :0: connect: connection refused` で起動失敗していた (#519)。同じ config ファイルを TS と共有する drop-in 切替で詰まる。

## 主な変更点

| ファイル | 内容 |
|---------|------|
| `internal/config/config.go` | `RedisOptions.Path string` フィールド追加 (mapstructure: "path")。`bindEnvKeys` に `redis.path` / `redisFor*.path` を追加して env override も対応 |
| `internal/core/cache/redis.go` | `unixSocketPath(opts)` helper を追加し、`Path > IsUnixSocketPath(Host)` の優先順で UDS パスを決める。`buildRedisOptions` / `NewRedisClients` の log は helper 経由で統一 |
| `internal/core/cache/cache_test.go` | `path` が `host` より優先されること、`path` 空で `host` が UDS パスのときは従来通り fallback することを担保する 2 ケース追加 |

## 互換性

- 旧来 mk の `host: /var/run/redis/redis.sock` 書き方は引き続き動作 (`unixSocketPath` の fallback)
- `path:` も `host:` も空 → 従来通り `host:port` で TCP 接続 (Behavior unchanged)
- TS-style と mk-style が両方同じ config で動くようになり drop-in 互換が回復

## テスト

```sh
go test -count=1 -run 'TestBuildRedisOptions' ./internal/core/cache/
ok  	internal/core/cache    1.569s
```

`go vet ./...` クリーン、`gofmt -s -d .` 差分なし、`go build ./...` クリーン。

## 派生

エラーログが `dial tcp :0` のままだと operator から見て原因が分かりにくいが、本 PR の修正で `path:` も認識されるようになるので、誤指定で詰まった場合のメッセージ改善は scope 外。

Closes #519
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/shiroha-a/mk/pull/528" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
