### PR TITLE
Fix #509: fail-closed BulkShow when queryService is unwired

### DIFF
--- a/internal/api/notes/handler.go
+++ b/internal/api/notes/handler.go
@@ -509,9 +509,14 @@ func (h *Handler) BulkShow(c echo.Context) error {
 		return c.JSON(http.StatusOK, []any{})
 	}
 	viewer := middleware.GetUser(c)
-	if h.queryService != nil {
-		notes = h.queryService.FilterVisible(viewer, notes)
+	// queryService 未配線時は visibility filter を経ずに全 note を返してしまう
+	// と、followers / specified visibility のノートが任意の閲覧者に漏洩する。
+	// production の router.go では常に wire されるが、wiring が壊れた場合の
+	// fail-closed として空配列で返す (#509、#445 / PR #505 と同じ defensive)。
+	if h.queryService == nil {
+		return c.JSON(http.StatusOK, []any{})
 	}
+	notes = h.queryService.FilterVisible(viewer, notes)
 	return c.JSON(http.StatusOK, h.packMany(notes, viewer))
 }
 

--- a/internal/api/notes/handler_extra.go
+++ b/internal/api/notes/handler_extra.go
@@ -275,5 +275,17 @@ func (h *Handler) ShowPartialBulk(c echo.Context) error {
 	if err != nil {
 		return c.JSON(http.StatusOK, []entity.NoteEntity{})
 	}
-	return c.JSON(http.StatusOK, h.packMany(notes, middleware.GetUser(c)))
+	viewer := middleware.GetUser(c)
+	// 旧実装は visibility filter を一切経ずに全 note を packMany にかけて
+	// 返していた。ShowPartialBulk は anonymous でも叩ける endpoint
+	// (router で RequireAuth() 無し) のため、followers / specified
+	// visibility のノートが任意の閲覧者に漏洩する security risk があった。
+	// BulkShow / Show と同じく queryService が wire されていなければ
+	// fail-closed で空配列、wire されていれば FilterVisible に通す
+	// (#509、Devin #529 FLAG-1)。
+	if h.queryService == nil {
+		return c.JSON(http.StatusOK, []entity.NoteEntity{})
+	}
+	notes = h.queryService.FilterVisible(viewer, notes)
+	return c.JSON(http.StatusOK, h.packMany(notes, viewer))
 }

--- a/internal/api/notes/handler_extra_test.go
+++ b/internal/api/notes/handler_extra_test.go
@@ -311,11 +311,25 @@ func TestTranslate_InvalidParam(t *testing.T) {
 
 // --- ShowPartialBulk ---
 
+// queryService が wire されているとき、public note は visibility filter を
+// 通って返ること。
 func TestShowPartialBulk_Success(t *testing.T) {
-	h, noteRepo, _ := newExtraHandler(t)
-	noteRepo.Notes["n1"] = &model.Note{ID: "n1", UserID: "u1", User: &model.User{ID: "u1"}}
+	noteRepo := testutil.NewMockNoteRepository()
+	pollRepo := testutil.NewMockPollRepository()
+	idGen, _ := id.NewGenerator("aidx")
+	createSvc := corenote.NewCreateService(noteRepo, pollRepo, idGen, nil)
+	deleteSvc := corenote.NewDeleteService(noteRepo)
+	querySvc := corenote.NewQueryService(noteRepo, nil)
+	h := NewHandler(noteRepo, createSvc, deleteSvc, querySvc, nil, nil, nil, nil, idGen)
+
+	noteRepo.Notes["n1"] = &model.Note{
+		ID: "n1", UserID: "u1", Visibility: model.NoteVisibilityPublic,
+		User: &model.User{ID: "u1"},
+	}
 	rec := postExtra(h.ShowPartialBulk, `{"noteIds":["n1"]}`, nil)
-	assert.Equal(t, http.StatusOK, rec.Code)
+	require.Equal(t, http.StatusOK, rec.Code)
+	assert.Contains(t, rec.Body.String(), `"id":"n1"`,
+		"public note must be returned when queryService is wired")
 }
 
 func TestShowPartialBulk_Empty(t *testing.T) {
@@ -341,6 +355,23 @@ func TestShowPartialBulk_InvalidParam(t *testing.T) {
 	h, _, _ := newExtraHandler(t)
 	rec := postExtra(h.ShowPartialBulk, `invalid`, nil)
 	assert.Equal(t, http.StatusBadRequest, rec.Code)
+}
+
+// queryService 未配線時は note 行があっても空配列を返す fail-closed 挙動
+// を担保する (Devin #529 FLAG-1、Show / BulkShow と同種の defensive)。
+// router.go で RequireAuth() 無しに公開している endpoint なので、
+// followers / specified visibility のノートを匿名閲覧者に漏らさないため
+// に重要。
+func TestShowPartialBulk_NoQueryServiceRejects(t *testing.T) {
+	h, noteRepo, _ := newExtraHandler(t) // newExtraHandler は queryService=nil
+	noteRepo.Notes["n1"] = &model.Note{
+		ID: "n1", UserID: "u1", Visibility: model.NoteVisibilityPublic,
+		User: &model.User{ID: "u1"},
+	}
+	rec := postExtra(h.ShowPartialBulk, `{"noteIds":["n1"]}`, nil)
+	require.Equal(t, http.StatusOK, rec.Code)
+	assert.Equal(t, "[]\n", rec.Body.String(),
+		"ShowPartialBulk must return [] when queryService is unwired so notes never bypass visibility filtering")
 }
 
 // --- Failing repo tests ---

--- a/internal/api/notes/handler_query_test.go
+++ b/internal/api/notes/handler_query_test.go
@@ -389,6 +389,31 @@ func TestCreate_RenoteTargetInvisible(t *testing.T) {
 	assert.Equal(t, apierr.UUIDCannotRenoteDueToVisibility, errObj["id"])
 }
 
+// TestBulkShow_NoQueryServiceRejects verifies BulkShow returns an empty
+// array when queryService is not wired, ensuring the visibility filter is
+// never bypassed (#509, sibling of #445 / TestShow_NoQueryServiceRejects).
+func TestBulkShow_NoQueryServiceRejects(t *testing.T) {
+	// 過去はここで fallback 経路が走り、followers / specified visibility の
+	// ノートが任意の閲覧者に漏洩する security regression risk があった。
+	// fallback を消したので、queryService nil なら note 行が引けても
+	// 空配列で返す。production でこの経路を踏むことは無いが、wiring 不整合
+	// に対する defensive 措置。
+	noteRepo := testutil.NewMockNoteRepository()
+	pollRepo := testutil.NewMockPollRepository()
+	idGen, _ := id.NewGenerator("aidx")
+	createSvc := corenote.NewCreateService(noteRepo, pollRepo, idGen, nil)
+	deleteSvc := corenote.NewDeleteService(noteRepo)
+	h := NewHandler(noteRepo, createSvc, deleteSvc, nil, nil, nil, nil, nil, idGen)
+
+	seedPublicNote(noteRepo, "n1")
+	seedPublicNote(noteRepo, "n2")
+	c, rec := newJSONRequest(t, "/api/notes", `{"noteIds":["n1","n2"]}`)
+	require.NoError(t, h.BulkShow(c))
+	assert.Equal(t, http.StatusOK, rec.Code)
+	assert.Equal(t, "[]\n", rec.Body.String(),
+		"BulkShow must return [] when queryService is unwired so notes never bypass visibility filtering")
+}
+
 // TestShow_NoQueryServiceRejects verifies Show returns NO_SUCH_NOTE when
 // queryService is not wired, ensuring the visibility check is never
 // bypassed (#445).


### PR DESCRIPTION
## Summary

PR #505 で \`notes/show\` を fail-closed (queryService nil → NO_SUCH_NOTE) に直したのと同じ visibility bypass パターンが \`BulkShow\` (\`internal/api/notes/handler.go:509-514\`) に残っていた (#509、#505 Devin review 指摘)。

production では \`router.go\` で常に wire されるので実害は無いが、wiring が壊れた / テスト経路で nil のまま叩く場合に followers / specified visibility のノートが任意の閲覧者に漏洩する defensive security risk。

## 主な変更点

| ファイル | 内容 |
|---------|------|
| \`internal/api/notes/handler.go\` | \`BulkShow\` で \`queryService == nil\` なら空配列を返す。Show 側の fail-closed と同じく安全側に倒す |
| \`internal/api/notes/handler_query_test.go\` | \`TestBulkShow_NoQueryServiceRejects\` を追加し、queryService 未配線で noteRepo に note があっても \`[]\` が返ることを担保 |

## テスト

```sh
go test -count=1 -run 'TestBulkShow' ./internal/api/notes/
ok  	internal/api/notes    1.519s
```

\`go vet ./...\` クリーン、\`gofmt -s -d .\` 差分なし、\`go build ./...\` クリーン。

Closes #509
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/shiroha-a/mk/pull/529" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
