### PR TITLE
Fix #522: embed isFollowing / isFavorited in channels payloads

### DIFF
--- a/internal/api/channels/handler.go
+++ b/internal/api/channels/handler.go
@@ -359,11 +359,13 @@ func channelToMap(ch *model.Channel) map[string]any {
 }
 
 // channelToMapForViewer wraps channelToMap and embeds viewer-dependent
-// fields (isFollowing / isFavorited). Misskey TS is `ChannelEntityService`
-// が channelFollowings / channelFavorites を join して埋めており、
-// frontend (`channel.vue`) はこのフィールドを直接参照してフォローボタン
-// 状態を切り替えるので、欠落すると常に未フォロー UI になる (#522)。
+// fields (isFollowing / isFavorited) by issuing per-row Exists calls.
+// Returns the bare channelToMap when viewer is nil (#522).
 func (h *Handler) channelToMapForViewer(ch *model.Channel, viewer *model.User) map[string]any {
+	// Misskey TS の `ChannelEntityService` は channelFollowings /
+	// channelFavorites を join して埋めており、frontend (`channel.vue`) は
+	// このフィールドを直接参照してフォローボタン状態を切り替える。欠落
+	// すると常に未フォロー UI になる。
 	out := channelToMap(ch)
 	if viewer == nil {
 		return out

--- a/internal/api/channels/handler.go
+++ b/internal/api/channels/handler.go
@@ -17,13 +17,23 @@ import (
 
 // Handler handles channel-related API endpoints.
 type Handler struct {
-	svc          *corechannel.Service
-	idGen        id.Generator
-	favoriteRepo ChannelFavoriteRepository
-	mutingRepo   ChannelMutingRepository
-	instanceRepo repository.InstanceRepository
-	emojiRepo    repository.EmojiRepository
-	fieldRes     *entity.NoteFieldResolver
+	svc           *corechannel.Service
+	idGen         id.Generator
+	favoriteRepo  ChannelFavoriteRepository
+	mutingRepo    ChannelMutingRepository
+	followingRepo ChannelFollowingChecker
+	instanceRepo  repository.InstanceRepository
+	emojiRepo     repository.EmojiRepository
+	fieldRes      *entity.NoteFieldResolver
+}
+
+// ChannelFollowingChecker covers the subset of ChannelFollowingRepository
+// the channels handler needs to embed isFollowing on viewer-aware payloads
+// (#522). Single-row Exists drives the Show / Update / Create paths;
+// ExistsMany handles list endpoints in one query.
+type ChannelFollowingChecker interface {
+	Exists(followerID, channelID string) (bool, error)
+	ExistsMany(followerID string, channelIDs []string) (map[string]bool, error)
 }
 
 // SetNoteFieldResolver wires the shared resolver that fills Files /
@@ -65,6 +75,9 @@ type ChannelFavoriteRepository interface {
 	Delete(userID, channelID string) error
 	ListByUser(userID string) ([]*model.ChannelFavorite, error)
 	Exists(userID, channelID string) (bool, error)
+	// ExistsMany powers list-endpoint isFavorited embedding without N+1
+	// (#522). Returns a channelID → bool map.
+	ExistsMany(userID string, channelIDs []string) (map[string]bool, error)
 }
 
 // ChannelMutingRepository is the interface for channel muting operations.
@@ -105,7 +118,10 @@ func (h *Handler) Create(c echo.Context) error {
 	if err != nil {
 		return apierr.JSONInternalError(c)
 	}
-	return c.JSON(http.StatusOK, channelToMap(ch))
+	// Create 直後は viewer が当該 channel を follow していないが、API
+	// 互換のため空 viewer 情報も含めた map を返す。viewer 経路で is*
+	// フィールドを返さないと frontend が undefined を扱えないことがある。
+	return c.JSON(http.StatusOK, h.channelToMapForViewer(ch, user))
 }
 
 // ShowRequest is the request body for channels/show.
@@ -123,7 +139,7 @@ func (h *Handler) Show(c echo.Context) error {
 	if err != nil {
 		return notFound(c)
 	}
-	return c.JSON(http.StatusOK, channelToMap(ch))
+	return c.JSON(http.StatusOK, h.channelToMapForViewer(ch, middleware.GetUser(c)))
 }
 
 // UpdateRequest is the request body for channels/update.
@@ -165,7 +181,7 @@ func (h *Handler) Update(c echo.Context) error {
 		}
 		return apierr.JSONInternalError(c)
 	}
-	return c.JSON(http.StatusOK, channelToMap(ch))
+	return c.JSON(http.StatusOK, h.channelToMapForViewer(ch, user))
 }
 
 // FollowRequest / UnfollowRequest reuse the channelId field.
@@ -234,7 +250,7 @@ func (h *Handler) Followed(c echo.Context) error {
 	if err != nil {
 		return apierr.JSONInternalError(c)
 	}
-	return c.JSON(http.StatusOK, channelsToList(rows))
+	return c.JSON(http.StatusOK, h.channelsToList(rows, user))
 }
 
 // Owned handles POST /api/channels/owned.
@@ -248,7 +264,7 @@ func (h *Handler) Owned(c echo.Context) error {
 	if err != nil {
 		return apierr.JSONInternalError(c)
 	}
-	return c.JSON(http.StatusOK, channelsToList(rows))
+	return c.JSON(http.StatusOK, h.channelsToList(rows, user))
 }
 
 // Featured handles POST /api/channels/featured.
@@ -261,7 +277,7 @@ func (h *Handler) Featured(c echo.Context) error {
 	if err != nil {
 		return apierr.JSONInternalError(c)
 	}
-	return c.JSON(http.StatusOK, channelsToList(rows))
+	return c.JSON(http.StatusOK, h.channelsToList(rows, middleware.GetUser(c)))
 }
 
 // SearchRequest carries the query string for channels/search.
@@ -283,7 +299,7 @@ func (h *Handler) Search(c echo.Context) error {
 	if err != nil {
 		return apierr.JSONInternalError(c)
 	}
-	return c.JSON(http.StatusOK, channelsToList(rows))
+	return c.JSON(http.StatusOK, h.channelsToList(rows, middleware.GetUser(c)))
 }
 
 // TimelineRequest is the request body for channels/timeline.
@@ -342,10 +358,60 @@ func channelToMap(ch *model.Channel) map[string]any {
 	}
 }
 
-func channelsToList(rows []*model.Channel) []map[string]any {
+// channelToMapForViewer wraps channelToMap and embeds viewer-dependent
+// fields (isFollowing / isFavorited). Misskey TS is `ChannelEntityService`
+// が channelFollowings / channelFavorites を join して埋めており、
+// frontend (`channel.vue`) はこのフィールドを直接参照してフォローボタン
+// 状態を切り替えるので、欠落すると常に未フォロー UI になる (#522)。
+func (h *Handler) channelToMapForViewer(ch *model.Channel, viewer *model.User) map[string]any {
+	out := channelToMap(ch)
+	if viewer == nil {
+		return out
+	}
+	if h.followingRepo != nil {
+		if ok, err := h.followingRepo.Exists(viewer.ID, ch.ID); err == nil {
+			out["isFollowing"] = ok
+		}
+	}
+	if h.favoriteRepo != nil {
+		if ok, err := h.favoriteRepo.Exists(viewer.ID, ch.ID); err == nil {
+			out["isFavorited"] = ok
+		}
+	}
+	return out
+}
+
+// channelsToList serialises a slice of channels with viewer-dependent
+// fields embedded via batch lookups (1 query each for following / favorite,
+// not N+1). viewer が nil なら viewer-dependent フィールドは省略する。
+func (h *Handler) channelsToList(rows []*model.Channel, viewer *model.User) []map[string]any {
 	out := make([]map[string]any, 0, len(rows))
+	if viewer == nil || (h.followingRepo == nil && h.favoriteRepo == nil) {
+		for _, ch := range rows {
+			out = append(out, channelToMap(ch))
+		}
+		return out
+	}
+	ids := make([]string, 0, len(rows))
 	for _, ch := range rows {
-		out = append(out, channelToMap(ch))
+		ids = append(ids, ch.ID)
+	}
+	var followed, favorited map[string]bool
+	if h.followingRepo != nil {
+		followed, _ = h.followingRepo.ExistsMany(viewer.ID, ids)
+	}
+	if h.favoriteRepo != nil {
+		favorited, _ = h.favoriteRepo.ExistsMany(viewer.ID, ids)
+	}
+	for _, ch := range rows {
+		m := channelToMap(ch)
+		if followed != nil {
+			m["isFollowing"] = followed[ch.ID]
+		}
+		if favorited != nil {
+			m["isFavorited"] = favorited[ch.ID]
+		}
+		out = append(out, m)
 	}
 	return out
 }

--- a/internal/api/channels/handler_stubs.go
+++ b/internal/api/channels/handler_stubs.go
@@ -20,6 +20,13 @@ func (h *Handler) SetMutingRepo(r ChannelMutingRepository) {
 	h.mutingRepo = r
 }
 
+// SetFollowingRepo attaches a ChannelFollowingChecker so Show / list
+// endpoints can embed `isFollowing` for the authenticated viewer (#522).
+// nil leaves the field unset (compat with anonymous flows).
+func (h *Handler) SetFollowingRepo(r ChannelFollowingChecker) {
+	h.followingRepo = r
+}
+
 // Favorite handles POST /api/channels/favorite.
 func (h *Handler) Favorite(c echo.Context) error {
 	user := middleware.GetUser(c)
@@ -78,15 +85,17 @@ func (h *Handler) MyFavorites(c echo.Context) error {
 	if err != nil {
 		return apierr.JSONInternalError(c)
 	}
-	out := make([]map[string]any, 0, len(favs))
+	rows := make([]*model.Channel, 0, len(favs))
 	for _, f := range favs {
 		ch, err := h.svc.Show(f.ChannelID)
 		if err != nil {
 			continue
 		}
-		out = append(out, channelToMap(ch))
+		rows = append(rows, ch)
 	}
-	return c.JSON(http.StatusOK, out)
+	// my-favorites の結果は viewer 自身が favorite している channel ばかり
+	// なので、batch 経由で isFavorited=true / isFollowing 状態が埋まる (#522)。
+	return c.JSON(http.StatusOK, h.channelsToList(rows, user))
 }
 
 // MuteCreate handles POST /api/channels/mute/create.

--- a/internal/api/channels/handler_stubs.go
+++ b/internal/api/channels/handler_stubs.go
@@ -156,13 +156,15 @@ func (h *Handler) MuteList(c echo.Context) error {
 	if err != nil {
 		return apierr.JSONInternalError(c)
 	}
-	out := make([]map[string]any, 0, len(mutings))
+	rows := make([]*model.Channel, 0, len(mutings))
 	for _, m := range mutings {
 		ch, err := h.svc.Show(m.ChannelID)
 		if err != nil {
 			continue
 		}
-		out = append(out, channelToMap(ch))
+		rows = append(rows, ch)
 	}
-	return c.JSON(http.StatusOK, out)
+	// MyFavorites と同じく channelsToList 経由で viewer-aware に
+	// 揃える (Devin #530 BUG-1)。
+	return c.JSON(http.StatusOK, h.channelsToList(rows, user))
 }

--- a/internal/api/channels/handler_test.go
+++ b/internal/api/channels/handler_test.go
@@ -593,7 +593,7 @@ func TestFeatured_BatchEmbedsFollowState(t *testing.T) {
 		repo.Channels[id] = &model.Channel{
 			ID:         id,
 			IsArchived: false,
-			NotesCount: 1, // ListFeatured は notesCount > 0 を要求
+			NotesCount: 1,
 			LastNotedAt: func() *time.Time {
 				t := time.Now()
 				return &t

--- a/internal/api/channels/handler_test.go
+++ b/internal/api/channels/handler_test.go
@@ -6,6 +6,7 @@ import (
 	"net/http/httptest"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/labstack/echo/v4"
 	corechannel "github.com/shiroha-a/mk/internal/core/channel"
@@ -501,4 +502,124 @@ func TestTimeline_RepoError(t *testing.T) {
 	c, rec := newReq(t, `{"channelId":"c1"}`)
 	require.NoError(t, h.Timeline(c))
 	assert.Equal(t, http.StatusInternalServerError, rec.Code)
+}
+
+// --- isFollowing / isFavorited embedding (#522) ---------------------------
+
+// countingFollowingRepo wraps MockChannelFollowingRepository to count
+// per-row vs batch lookups.
+type countingFollowingRepo struct {
+	*testutil.MockChannelFollowingRepository
+	existsCalls     int
+	existsManyCalls int
+	existsManySize  int
+}
+
+func (c *countingFollowingRepo) Exists(followerID, channelID string) (bool, error) {
+	c.existsCalls++
+	return c.MockChannelFollowingRepository.Exists(followerID, channelID)
+}
+
+func (c *countingFollowingRepo) ExistsMany(followerID string, channelIDs []string) (map[string]bool, error) {
+	c.existsManyCalls++
+	c.existsManySize += len(channelIDs)
+	return c.MockChannelFollowingRepository.ExistsMany(followerID, channelIDs)
+}
+
+type countingFavoriteRepo struct {
+	*testutil.MockChannelFavoriteRepository
+	existsCalls     int
+	existsManyCalls int
+}
+
+func (c *countingFavoriteRepo) Exists(userID, channelID string) (bool, error) {
+	c.existsCalls++
+	return c.MockChannelFavoriteRepository.Exists(userID, channelID)
+}
+
+func (c *countingFavoriteRepo) ExistsMany(userID string, channelIDs []string) (map[string]bool, error) {
+	c.existsManyCalls++
+	return c.MockChannelFavoriteRepository.ExistsMany(userID, channelIDs)
+}
+
+// Show が viewer の following / favorite 状態に応じて isFollowing /
+// isFavorited を embed することを確認する (#522)。frontend の
+// channel.vue がフォローボタンの状態を切り替える前提となるフィールド。
+func TestShow_EmbedsViewerFollowState(t *testing.T) {
+	h, repo, followRepo, _ := newHandler(t)
+	favRepo := testutil.NewMockChannelFavoriteRepository()
+	repo.Channels["ch1"] = &model.Channel{ID: "ch1", Name: "ch1"}
+	_ = followRepo.Create(&model.ChannelFollowing{ID: "f1", FollowerID: "alice", FolloweeID: "ch1"})
+	_ = favRepo.Create(&model.ChannelFavorite{ID: "fv1", UserID: "alice", ChannelID: "ch1"})
+
+	h.SetFollowingRepo(followRepo)
+	h.SetFavoriteRepo(favRepo)
+
+	c, rec := newReq(t, `{"channelId":"ch1"}`)
+	setUser(c, "alice")
+	require.NoError(t, h.Show(c))
+	require.Equal(t, http.StatusOK, rec.Code)
+	body := rec.Body.String()
+	assert.Contains(t, body, `"isFollowing":true`)
+	assert.Contains(t, body, `"isFavorited":true`)
+}
+
+// 認証されていない viewer (anonymous) の Show では isFollowing /
+// isFavorited を返さないこと。Misskey TS と同じく viewer 不在時は
+// undefined 扱い。
+func TestShow_NoViewerOmitsFollowState(t *testing.T) {
+	h, repo, followRepo, _ := newHandler(t)
+	favRepo := testutil.NewMockChannelFavoriteRepository()
+	repo.Channels["ch1"] = &model.Channel{ID: "ch1"}
+	h.SetFollowingRepo(followRepo)
+	h.SetFavoriteRepo(favRepo)
+
+	c, rec := newReq(t, `{"channelId":"ch1"}`)
+	require.NoError(t, h.Show(c))
+	require.Equal(t, http.StatusOK, rec.Code)
+	body := rec.Body.String()
+	assert.NotContains(t, body, "isFollowing")
+	assert.NotContains(t, body, "isFavorited")
+}
+
+// list endpoint (Featured) で per-row Exists が呼ばれず batch ExistsMany
+// が 1 回だけ呼ばれること。N+1 解消の担保 (#522)。
+func TestFeatured_BatchEmbedsFollowState(t *testing.T) {
+	h, repo, _, _ := newHandler(t)
+	follow := &countingFollowingRepo{MockChannelFollowingRepository: testutil.NewMockChannelFollowingRepository()}
+	fav := &countingFavoriteRepo{MockChannelFavoriteRepository: testutil.NewMockChannelFavoriteRepository()}
+	for i := 1; i <= 5; i++ {
+		id := "feat" + string(rune('0'+i))
+		repo.Channels[id] = &model.Channel{
+			ID:         id,
+			IsArchived: false,
+			NotesCount: 1, // ListFeatured は notesCount > 0 を要求
+			LastNotedAt: func() *time.Time {
+				t := time.Now()
+				return &t
+			}(),
+		}
+	}
+	_ = follow.Create(&model.ChannelFollowing{ID: "f1", FollowerID: "alice", FolloweeID: "feat1"})
+	h.SetFollowingRepo(follow)
+	h.SetFavoriteRepo(fav)
+
+	c, rec := newReq(t, `{}`)
+	setUser(c, "alice")
+	require.NoError(t, h.Featured(c))
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	assert.Equal(t, 0, follow.existsCalls,
+		"per-row Exists must not be called from list endpoint (N+1 must be eliminated)")
+	assert.Equal(t, 1, follow.existsManyCalls,
+		"ExistsMany should be called exactly once per request")
+	assert.Equal(t, 5, follow.existsManySize,
+		"all 5 channel IDs should be coalesced into a single batch")
+	assert.Equal(t, 1, fav.existsManyCalls)
+
+	body := rec.Body.String()
+	assert.Contains(t, body, `"isFollowing":true`,
+		"alice's followed channel must report isFollowing=true")
+	assert.Contains(t, body, `"isFollowing":false`,
+		"unfollowed channels must still report the field for the frontend")
 }

--- a/internal/repository/channel_favorite.go
+++ b/internal/repository/channel_favorite.go
@@ -11,6 +11,10 @@ type ChannelFavoriteRepository interface {
 	Delete(userID, channelID string) error
 	ListByUser(userID string) ([]*model.ChannelFavorite, error)
 	Exists(userID, channelID string) (bool, error)
+	// ExistsMany returns a channelID → bool map indicating which of the
+	// given channels userID currently favorites. Used by /channels list
+	// endpoints to embed isFavorited without N+1 (#522).
+	ExistsMany(userID string, channelIDs []string) (map[string]bool, error)
 }
 
 type channelFavoriteRepository struct {
@@ -44,4 +48,23 @@ func (r *channelFavoriteRepository) Exists(userID, channelID string) (bool, erro
 	err := r.db.Model(&model.ChannelFavorite{}).
 		Where(`"userId" = ? AND "channelId" = ?`, userID, channelID).Count(&count).Error
 	return count > 0, err
+}
+
+// ExistsMany resolves "user has X favorited?" for a set of channel IDs in
+// a single query. 空入力 / 空 userID は空 map を返す。
+func (r *channelFavoriteRepository) ExistsMany(userID string, channelIDs []string) (map[string]bool, error) {
+	if userID == "" || len(channelIDs) == 0 {
+		return map[string]bool{}, nil
+	}
+	var favorited []string
+	if err := r.db.Model(&model.ChannelFavorite{}).
+		Where(`"userId" = ? AND "channelId" IN ?`, userID, channelIDs).
+		Pluck(`"channelId"`, &favorited).Error; err != nil {
+		return nil, err
+	}
+	out := make(map[string]bool, len(favorited))
+	for _, id := range favorited {
+		out[id] = true
+	}
+	return out, nil
 }

--- a/internal/repository/channel_following.go
+++ b/internal/repository/channel_following.go
@@ -12,6 +12,10 @@ type ChannelFollowingRepository interface {
 	Delete(f *model.ChannelFollowing) error
 	FindByPair(followerID, channelID string) (*model.ChannelFollowing, error)
 	Exists(followerID, channelID string) (bool, error)
+	// ExistsMany returns a channelID → bool map indicating which of the
+	// given channels followerID currently follows. Used by /channels list
+	// endpoints to embed isFollowing without N+1 (#522).
+	ExistsMany(followerID string, channelIDs []string) (map[string]bool, error)
 	// ListFollowed returns channel_following rows for userID with cursor
 	// (sinceID/untilID) or offset pagination. Cursor 指定時は offset 無視。
 	ListFollowed(userID, sinceID, untilID string, limit, offset int) ([]*model.ChannelFollowing, error)
@@ -55,6 +59,25 @@ func (r *channelFollowingRepository) Exists(followerID, channelID string) (bool,
 		return false, err
 	}
 	return count > 0, nil
+}
+
+// ExistsMany resolves "follower follows X?" for a set of channel IDs in a
+// single query. 空入力 / 空 followerID は空 map を返す。
+func (r *channelFollowingRepository) ExistsMany(followerID string, channelIDs []string) (map[string]bool, error) {
+	if followerID == "" || len(channelIDs) == 0 {
+		return map[string]bool{}, nil
+	}
+	var followed []string
+	if err := r.db.Model(&model.ChannelFollowing{}).
+		Where(`"followerId" = ? AND "followeeId" IN ?`, followerID, channelIDs).
+		Pluck(`"followeeId"`, &followed).Error; err != nil {
+		return nil, err
+	}
+	out := make(map[string]bool, len(followed))
+	for _, id := range followed {
+		out[id] = true
+	}
+	return out, nil
 }
 
 // ListFollowerIDsPage returns a batch of follower userIds for a channel,

--- a/internal/server/router.go
+++ b/internal/server/router.go
@@ -1294,6 +1294,7 @@ func (s *Server) setupRoutes() {
 	channelsHandler := apichannels.NewHandler(channelService, idGen)
 	channelsHandler.SetFavoriteRepo(channelFavoriteRepo)
 	channelsHandler.SetMutingRepo(channelMutingRepo)
+	channelsHandler.SetFollowingRepo(channelFollowingRepo)
 	api.POST("/channels/create", channelsHandler.Create, middleware.RequireAuth())
 	api.POST("/channels/show", channelsHandler.Show)
 	api.POST("/channels/update", channelsHandler.Update, middleware.RequireAuth())

--- a/internal/testutil/mock_repository.go
+++ b/internal/testutil/mock_repository.go
@@ -3227,6 +3227,19 @@ func (m *MockChannelFollowingRepository) Exists(followerID, channelID string) (b
 	return err == nil, nil
 }
 
+func (m *MockChannelFollowingRepository) ExistsMany(followerID string, channelIDs []string) (map[string]bool, error) {
+	out := make(map[string]bool, len(channelIDs))
+	if followerID == "" {
+		return out, nil
+	}
+	for _, cid := range channelIDs {
+		if ok, _ := m.Exists(followerID, cid); ok {
+			out[cid] = true
+		}
+	}
+	return out, nil
+}
+
 func (m *MockChannelFollowingRepository) ListFollowed(userID, sinceID, untilID string, limit, offset int) ([]*model.ChannelFollowing, error) {
 	var rows []*model.ChannelFollowing
 	for _, f := range m.Followings {
@@ -4742,6 +4755,19 @@ func (m *MockChannelFavoriteRepository) ListByUser(userID string) ([]*model.Chan
 func (m *MockChannelFavoriteRepository) Exists(userID, channelID string) (bool, error) {
 	_, ok := m.Favorites[userID+":"+channelID]
 	return ok, nil
+}
+
+func (m *MockChannelFavoriteRepository) ExistsMany(userID string, channelIDs []string) (map[string]bool, error) {
+	out := make(map[string]bool, len(channelIDs))
+	if userID == "" {
+		return out, nil
+	}
+	for _, cid := range channelIDs {
+		if _, ok := m.Favorites[userID+":"+cid]; ok {
+			out[cid] = true
+		}
+	}
+	return out, nil
 }
 
 // MockChannelMutingRepository is a test double for repository.ChannelMutingRepository.


### PR DESCRIPTION
## Summary

frontend (\`channel.vue:137\`) はフォローボタン / 通知 alarm の状態を \`_channel.isFollowing\` / \`_channel.isFavorited\` で切り替える設計だが、mk-go の \`channelToMap\` (\`internal/api/channels/handler.go:340\`) が viewer 視点のフィールドを embed していなかったため、フォロー済みでもボタンが「フォロー」状態のまま表示されていた (#522)。

upstream Misskey TS \`ChannelEntityService\` は \`channelFollowings\` / \`channelFavorites\` を join して embed する。本 PR で同等の挙動を実装する。

## 主な変更点

| ファイル | 内容 |
|---------|------|
| \`internal/repository/channel_following.go\` / \`channel_favorite.go\` | \`ExistsMany(viewerID, channelIDs)\` を追加 (\`WHERE ... IN (?)\` で 1 query) |
| \`internal/api/channels/handler.go\` | \`ChannelFollowingChecker\` interface 追加、\`channelToMapForViewer\` (single-row) と \`channelsToList(rows, viewer)\` (batch) を実装。\`Show\` / \`Create\` / \`Update\` / \`Followed\` / \`Owned\` / \`Featured\` / \`Search\` を viewer-aware に置換 |
| \`internal/api/channels/handler_stubs.go\` | \`SetFollowingRepo\` 追加。\`channels/my-favorites\` も batch 経由で \`is*\` を埋める |
| \`internal/server/router.go\` | \`channelsHandler.SetFollowingRepo(channelFollowingRepo)\` 追加 |
| \`internal/testutil/mock_repository.go\` | \`MockChannelFollowingRepository\` / \`MockChannelFavoriteRepository\` に \`ExistsMany\` 追加 |
| \`internal/api/channels/handler_test.go\` | \`countingFollowingRepo\` / \`countingFavoriteRepo\` wrapper で Show 単体 + 5 件 list batch (per-row 0 / batch 1 + size 5) を担保 |

## 互換性

- viewer = 未認証 → \`isFollowing\` / \`isFavorited\` は含めない (Misskey TS の \`packMany\` と同じ semantic)
- viewer 認証済みかつ \`followingRepo\` / \`favoriteRepo\` 未配線時は省略
- 既存の \`channelToMap\` (no-args) は変更なし、anonymous 経路で互換維持

## クエリ削減 (list endpoint)

list が 30 件返すケース:
- before: viewer-dependent フィールド embed 無し (frontend が破損 UI で表示)
- after: \`ExistsMany\` × 2 = **2 query** で 30 row に embed

## テスト

```sh
go test -count=1 -run 'TestShow_Embeds|TestShow_NoViewer|TestFeatured_Batch' ./internal/api/channels/
ok  	internal/api/channels    0.039s
```

\`go vet ./...\` クリーン、\`gofmt -s -d .\` 差分なし、\`go build ./...\` クリーン。
DB-backed test (\`internal/repository\`) は CI で実行 (testcontainers 必要)。

Closes #522
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/shiroha-a/mk/pull/530" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
