### PR TITLE
Fix #497: write pidFile on startup with double-start guard

### DIFF
--- a/cmd/misskey/main.go
+++ b/cmd/misskey/main.go
@@ -34,6 +34,16 @@ func main() {
 		os.Exit(1)
 	}
 
+	// pidFile が設定されていれば PID を書き込み、終了時に削除する。
+	// 既存ファイルが生存中の他プロセスを指す場合は ErrAlreadyRunning で
+	// 起動を拒否して二重起動を防ぐ (#497)。
+	cleanupPid, err := server.WritePidFile(cfg.PidFile)
+	if err != nil {
+		slog.Error("failed to write pid file", "error", err)
+		os.Exit(1)
+	}
+	defer cleanupPid()
+
 	// Sentry init は他のサービスより前に走らせ、以降の起動エラーも捕捉対象にする。
 	flushSentry, err := mksentry.Init(cfg)
 	if err != nil {

--- a/internal/server/pidfile.go
+++ b/internal/server/pidfile.go
@@ -15,11 +15,11 @@ import (
 var ErrAlreadyRunning = errors.New("server: another instance appears to be running")
 
 // WritePidFile writes the current PID to path. If path is empty it returns
-// (nil, nil) — pidFile is an opt-in feature.
+// a no-op cleanup function and nil error — pidFile is an opt-in feature.
 //
 // Returns a cleanup function that removes the file (best effort) on
-// shutdown. Cleanup is also nil when path is empty so callers can defer it
-// unconditionally.
+// shutdown. When path is empty the cleanup function is a no-op, so callers
+// can defer it unconditionally.
 //
 // 既存 PID ファイルが live なプロセスを指しているときは ErrAlreadyRunning
 // を返して起動を拒否する。stale なファイル (PID は dead) なら上書きする

--- a/internal/server/pidfile.go
+++ b/internal/server/pidfile.go
@@ -1,0 +1,71 @@
+package server
+
+import (
+	"errors"
+	"fmt"
+	"log/slog"
+	"os"
+	"strconv"
+	"strings"
+	"syscall"
+)
+
+// ErrAlreadyRunning is returned by WritePidFile when the existing PID file
+// names a process that is still alive — likely another mk instance.
+var ErrAlreadyRunning = errors.New("server: another instance appears to be running")
+
+// WritePidFile writes the current PID to path. If path is empty it returns
+// (nil, nil) — pidFile is an opt-in feature.
+//
+// Returns a cleanup function that removes the file (best effort) on
+// shutdown. Cleanup is also nil when path is empty so callers can defer it
+// unconditionally.
+//
+// 既存 PID ファイルが live なプロセスを指しているときは ErrAlreadyRunning
+// を返して起動を拒否する。stale なファイル (PID は dead) なら上書きする
+// (#497)。
+func WritePidFile(path string) (func(), error) {
+	return writePidFileWithProcCheck(path, defaultProcessAlive)
+}
+
+// writePidFileWithProcCheck is WritePidFile with the liveness probe injected
+// for tests.
+func writePidFileWithProcCheck(path string, alive func(pid int) bool) (func(), error) {
+	if path == "" {
+		return func() {}, nil
+	}
+	if data, err := os.ReadFile(path); err == nil {
+		if pid, perr := parsePID(data); perr == nil && pid > 0 && pid != os.Getpid() && alive(pid) {
+			return nil, fmt.Errorf("%w: %s -> pid %d", ErrAlreadyRunning, path, pid)
+		}
+	}
+	pid := os.Getpid()
+	if err := os.WriteFile(path, []byte(strconv.Itoa(pid)+"\n"), 0o644); err != nil {
+		return nil, fmt.Errorf("write pid file %s: %w", path, err)
+	}
+	cleanup := func() {
+		if err := os.Remove(path); err != nil && !errors.Is(err, os.ErrNotExist) {
+			slog.Warn("pidfile: cleanup failed", "path", path, "err", err)
+		}
+	}
+	return cleanup, nil
+}
+
+func parsePID(data []byte) (int, error) {
+	return strconv.Atoi(strings.TrimSpace(string(data)))
+}
+
+// defaultProcessAlive uses syscall.Kill(pid, 0) which sends no signal but
+// returns ESRCH if the process doesn't exist (Linux/POSIX semantics). This
+// distinguishes a stale pid file (PID recycled by another process is
+// theoretically possible but extremely rare in practice for a daemon
+// scenario, matching the Misskey TS approach).
+func defaultProcessAlive(pid int) bool {
+	if pid <= 0 {
+		return false
+	}
+	if err := syscall.Kill(pid, 0); err != nil {
+		return !errors.Is(err, syscall.ESRCH)
+	}
+	return true
+}

--- a/internal/server/pidfile_test.go
+++ b/internal/server/pidfile_test.go
@@ -1,0 +1,112 @@
+package server
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"strconv"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestWritePidFile_EmptyPathSkips(t *testing.T) {
+	cleanup, err := WritePidFile("")
+	require.NoError(t, err)
+	require.NotNil(t, cleanup)
+	cleanup() // must be safe to call
+}
+
+func TestWritePidFile_WritesAndCleansUp(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "mk.pid")
+
+	cleanup, err := WritePidFile(path)
+	require.NoError(t, err)
+	defer cleanup()
+
+	data, err := os.ReadFile(path)
+	require.NoError(t, err)
+	pid, err := parsePID(data)
+	require.NoError(t, err)
+	assert.Equal(t, os.Getpid(), pid)
+
+	cleanup()
+	_, err = os.Stat(path)
+	assert.True(t, os.IsNotExist(err), "pidfile should be removed by cleanup")
+}
+
+// 死んだ PID を指す pidfile (= stale) があるときは上書き起動を許す。
+func TestWritePidFile_StaleFileIsOverwritten(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "mk.pid")
+	require.NoError(t, os.WriteFile(path, []byte("99999\n"), 0o644))
+
+	// 99999 を「存在しないプロセス」として扱う probe 注入
+	cleanup, err := writePidFileWithProcCheck(path, func(pid int) bool { return pid == os.Getpid() })
+	require.NoError(t, err)
+	defer cleanup()
+
+	data, _ := os.ReadFile(path)
+	pid, err := parsePID(data)
+	require.NoError(t, err)
+	assert.Equal(t, os.Getpid(), pid)
+}
+
+// 生存中の他プロセスを指す pidfile があると ErrAlreadyRunning で起動拒否。
+func TestWritePidFile_LiveOtherProcessRejects(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "mk.pid")
+	otherPID := os.Getpid() + 1
+	require.NoError(t, os.WriteFile(path, []byte(strconv.Itoa(otherPID)+"\n"), 0o644))
+
+	_, err := writePidFileWithProcCheck(path, func(pid int) bool {
+		return pid == otherPID // any pid considered alive
+	})
+	require.Error(t, err)
+	assert.True(t, errors.Is(err, ErrAlreadyRunning),
+		"must reject double-start when existing pidfile points at a live process; got %v", err)
+}
+
+// 自分自身の PID を含む pidfile (= 再起動 / fast-restart 直後など) は上書き
+// で受け入れる。これがないと shutdown 中に書き残った行で次回起動が詰まる。
+func TestWritePidFile_OwnPIDIsOverwritten(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "mk.pid")
+	require.NoError(t, os.WriteFile(path, []byte(strconv.Itoa(os.Getpid())+"\n"), 0o644))
+
+	cleanup, err := writePidFileWithProcCheck(path, func(pid int) bool {
+		return true // probe says alive but we should still allow self-reuse
+	})
+	require.NoError(t, err)
+	defer cleanup()
+}
+
+func TestWritePidFile_GarbledFileIsOverwritten(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "mk.pid")
+	require.NoError(t, os.WriteFile(path, []byte("not-a-number"), 0o644))
+
+	cleanup, err := writePidFileWithProcCheck(path, func(int) bool { return true })
+	require.NoError(t, err, "non-numeric pidfile should be treated as stale and overwritten")
+	defer cleanup()
+}
+
+func TestWritePidFile_UnwritableDirectoryReturnsError(t *testing.T) {
+	dir := t.TempDir()
+	require.NoError(t, os.Chmod(dir, 0o500))
+	t.Cleanup(func() { _ = os.Chmod(dir, 0o700) })
+	path := filepath.Join(dir, "mk.pid")
+	_, err := WritePidFile(path)
+	require.Error(t, err)
+	assert.NotErrorIs(t, err, ErrAlreadyRunning)
+}
+
+// defaultProcessAlive は自プロセス (= 生存) で true、不可能な PID 値で
+// false になることだけ確認する (細かい挙動は OS 依存なので深追いしない)。
+func TestDefaultProcessAlive(t *testing.T) {
+	assert.True(t, defaultProcessAlive(os.Getpid()))
+	assert.False(t, defaultProcessAlive(0))
+	assert.False(t, defaultProcessAlive(-1))
+}


### PR DESCRIPTION
## Summary

config の \`pidFile\` は struct field として読み込まれていたが起動時の書き込みが未実装だったため、systemd / daemontools 等の PID-based 監視が機能しなかった (#497)。本 PR で TS と同等の挙動 (書き込み + 二重起動防止 + 終了時 cleanup) を実装する。

## 主な変更点

| ファイル | 内容 |
|---------|------|
| \`internal/server/pidfile.go\` | \`WritePidFile(path) (cleanup, error)\` を新設。空 path は no-op、既存ファイルが live 他プロセスを指すなら \`ErrAlreadyRunning\` で拒否、stale (PID dead) / 自 PID / 非数値ゴミは上書き受け入れ。返値 cleanup は終了時に best-effort remove |
| \`cmd/misskey/main.go\` | config 読み込み直後に \`server.WritePidFile(cfg.PidFile)\` を呼び、\`defer cleanup()\` |
| \`internal/server/pidfile_test.go\` | 8 ケース (empty path skip / 書き込み + cleanup / stale 上書き / live 他プロセス拒否 / 自 PID 上書き / garbled 上書き / 書き込み不可 dir のエラー / defaultProcessAlive smoke)。テストでは \`syscall.Kill\` ではなく injection した probe で OS 依存を排除 |

## 互換性

- \`pidFile\` 未設定 (空文字) のときは何もしない既存挙動を維持
- \`syscall.Kill(pid, 0)\` で liveness 判定 (POSIX 標準、Linux 既定)
- 終了時の \`os.Remove\` は \`os.ErrNotExist\` を握りつぶして best-effort

## テスト

```sh
go test -count=1 -run 'TestWritePidFile|TestDefaultProcessAlive' ./internal/server/
ok  	internal/server    0.009s
```

\`go vet ./...\` クリーン、\`gofmt -s -d .\` 差分なし、\`go build ./...\` クリーン。

Closes #497
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/shiroha-a/mk/pull/535" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
