### PR TITLE
Perf #300 1-4: batch profile fetch in admin/show-users

### DIFF
--- a/internal/api/admin/handler.go
+++ b/internal/api/admin/handler.go
@@ -517,10 +517,26 @@ func (h *Handler) ShowUsers(c echo.Context) error {
 		return c.JSON(http.StatusInternalServerError, apierr.Error("INTERNAL_ERROR", "Internal error.", "5d37dbcb-891e-41ca-a3d6-e690c97775ac"))
 	}
 
+	// Profile を per-row FindProfileByUserID で引いていた N+1 (#300 1-4) を
+	// FindProfilesByUserIDs (#503 で追加済) の 1 batch query に置換。
+	ids := make([]string, 0, len(users))
+	for _, u := range users {
+		ids = append(ids, u.ID)
+	}
+	profiles, err := h.userRepo.FindProfilesByUserIDs(ids)
+	if err != nil {
+		// Profile fetch 失敗は ShowUsers 全体の致命扱いではないので、空 map で
+		// fallback する (各 user は profile=nil で pack される)。
+		profiles = nil
+	}
+	profileByUser := make(map[string]*model.UserProfile, len(profiles))
+	for _, p := range profiles {
+		profileByUser[p.UserID] = p
+	}
+
 	result := make([]map[string]any, 0, len(users))
 	for _, u := range users {
-		profile, _ := h.userRepo.FindProfileByUserID(u.ID)
-		result = append(result, h.packAdminUser(u, profile))
+		result = append(result, h.packAdminUser(u, profileByUser[u.ID]))
 	}
 	return c.JSON(http.StatusOK, result)
 }

--- a/internal/api/admin/handler_test.go
+++ b/internal/api/admin/handler_test.go
@@ -2,6 +2,7 @@ package admin_test
 
 import (
 	"encoding/json"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -173,6 +174,59 @@ func TestShowUsers_Success(t *testing.T) {
 	var resp []any
 	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
 	assert.Len(t, resp, 2)
+}
+
+// admin/show-users が profile 取得を per-row FindProfileByUserID で
+// 引いていた N+1 を FindProfilesByUserIDs 1 batch に置換した (#300 1-4)。
+// 5 user 検証で per-row が 0 回、batch が 1 回 + size=5 で呼ばれることを
+// 担保する。
+type countingAdminUserRepo struct {
+	*testutil.MockUserRepository
+	findProfileByUserIDCalls    int
+	findProfilesByUserIDsCalls  int
+	findProfilesByUserIDsBucket int
+}
+
+func (c *countingAdminUserRepo) FindProfileByUserID(id string) (*model.UserProfile, error) {
+	c.findProfileByUserIDCalls++
+	return c.MockUserRepository.FindProfileByUserID(id)
+}
+
+func (c *countingAdminUserRepo) FindProfilesByUserIDs(ids []string) ([]*model.UserProfile, error) {
+	c.findProfilesByUserIDsCalls++
+	c.findProfilesByUserIDsBucket += len(ids)
+	return c.MockUserRepository.FindProfilesByUserIDs(ids)
+}
+
+func TestShowUsers_BatchFetchesProfiles(t *testing.T) {
+	repo := &countingAdminUserRepo{MockUserRepository: testutil.NewMockUserRepository()}
+	for i := 0; i < 5; i++ {
+		uid := fmt.Sprintf("au%d", i)
+		repo.Users[uid] = &model.User{ID: uid, Username: uid}
+		desc := fmt.Sprintf("d%d", i)
+		repo.Profiles[uid] = &model.UserProfile{UserID: uid, Description: &desc}
+	}
+	metaRepo := testutil.NewMockMetaRepository()
+	metaRepo.Meta = &model.Meta{ID: "x"}
+	roleRepo := testutil.NewMockRoleRepository()
+	assignRepo := testutil.NewMockRoleAssignmentRepository(roleRepo)
+	idGen, _ := id.NewGenerator("aidx")
+	signupSvc := signup.NewService(repo, metaRepo, idGen)
+	roleSvc := role.NewService(roleRepo, assignRepo, metaRepo, idGen)
+	h := apiadmin.NewHandler(signupSvc, roleSvc, metaRepo, repo, idGen)
+
+	rec := doPost(h.ShowUsers, `{"limit":10}`, nil)
+	require.Equal(t, http.StatusOK, rec.Code)
+	var resp []map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+	require.Len(t, resp, 5)
+
+	assert.Equal(t, 0, repo.findProfileByUserIDCalls,
+		"per-row FindProfileByUserID must not be called (N+1 must be eliminated)")
+	assert.Equal(t, 1, repo.findProfilesByUserIDsCalls,
+		"FindProfilesByUserIDs should be called exactly once per request")
+	assert.Equal(t, 5, repo.findProfilesByUserIDsBucket,
+		"all 5 user IDs should be coalesced into a single batch")
 }
 
 func TestShowUsers_WithFilter(t *testing.T) {


### PR DESCRIPTION
## Summary

\`admin/show-users\` が検索結果 N 件ぶん per-row \`userRepo.FindProfileByUserID\` を loop で呼ぶ N+1 になっていた (#300 1-4)。1-3 (PR #518) と同じく \`FindProfilesByUserIDs\` (#503 で追加済) で 1 batch query に置換する。

クエリ削減 (limit 100 件想定): **101 query → 2 query**。

## 主な変更点

| ファイル | 内容 |
|---------|------|
| \`internal/api/admin/handler.go\` | \`ShowUsers\` で ID 集約 → \`FindProfilesByUserIDs\` で batch fetch → map で O(1) 解決 → \`packAdminUser\` に渡す。Profile fetch 失敗は非致命扱い (各 user は profile=nil で pack) |
| \`internal/api/admin/handler_test.go\` | \`countingAdminUserRepo\` wrapper で 5 件検索ケース。per-row \`FindProfileByUserID\` が 0 回、\`FindProfilesByUserIDs\` が 1 回 + size=5 で呼ばれることを担保 |

## テスト

```sh
go test -count=1 -run 'TestShowUsers' ./internal/api/admin/
ok  	internal/api/admin    0.037s
```

\`go vet ./...\` クリーン、\`gofmt -s -d .\` 差分なし、\`go build ./...\` クリーン。

## 関連 / 残

- 親 tracker: #300 (1-4)
- 同種完了: 1-1 (#516)、1-2 (#504)、1-3 (#518)
- 残: 1-5 mention 解決ループ、2-3 followers/followings ShowByID、3-2/3-3/3-5/3-6 各種キャッシュ、3-7 singleflight

Refs #300
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/shiroha-a/mk/pull/539" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
