### PR TITLE
Perf #300 2-3: batch follower / followee user fetch in users/followers + following

### DIFF
--- a/internal/api/users/handler.go
+++ b/internal/api/users/handler.go
@@ -502,41 +502,7 @@ func (h *Handler) collectFollowers(req FollowersRequest) ([]relationItem, error)
 	if err != nil {
 		return nil, err
 	}
-	// 一旦 bundle を全件集めてから resolver を 1 度構築する。ShowByID は
-	// N+1 のままだが、instance は batch 1 回に集約できる (#277)。
-	type resolved struct {
-		f      *model.Following
-		bundle *user.UserWithProfile
-	}
-	pending := make([]resolved, 0, len(rows))
-	remoteUsers := make([]*model.User, 0, len(rows))
-	for _, f := range rows {
-		if req.SinceID != "" && f.ID <= req.SinceID {
-			continue
-		}
-		if req.UntilID != "" && f.ID >= req.UntilID {
-			continue
-		}
-		r := resolved{f: f}
-		if b, err := h.userService.ShowByID(f.FollowerID); err == nil {
-			r.bundle = b
-			remoteUsers = append(remoteUsers, b.User)
-		}
-		pending = append(pending, r)
-	}
-	resolver := entity.NewInstanceResolver(h.instanceLookup(), remoteUsers...)
-	out := make([]relationItem, 0, len(pending))
-	for _, r := range pending {
-		item := relationItem{ID: r.f.ID, FollowerID: r.f.FollowerID, FolloweeID: r.f.FolloweeID}
-		if r.bundle != nil {
-			d := entity.PackUserDetailed(r.bundle.User, r.bundle.Profile, h.idGen)
-			resolver.FillUserLite(&d.UserLite)
-			h.populateUserEmojis(r.bundle.User, &d.UserLite)
-			item.Follower = &d
-		}
-		out = append(out, item)
-	}
-	return out, nil
+	return h.packRelationItems(rows, req, true), nil
 }
 
 func (h *Handler) collectFollowing(req FollowersRequest) ([]relationItem, error) {
@@ -544,12 +510,22 @@ func (h *Handler) collectFollowing(req FollowersRequest) ([]relationItem, error)
 	if err != nil {
 		return nil, err
 	}
-	type resolved struct {
-		f      *model.Following
-		bundle *user.UserWithProfile
-	}
-	pending := make([]resolved, 0, len(rows))
-	remoteUsers := make([]*model.User, 0, len(rows))
+	return h.packRelationItems(rows, req, false), nil
+}
+
+// packRelationItems builds the response slice for users/followers and
+// users/following. followers=true means embed the follower side, false means
+// embed the followee side. cursor (sinceId/untilId) で filter したあとに
+// ShowManyByIDs (#503) で 1 batch query にまとめ、map で O(1) 解決して
+// 旧 ShowByID per-row N+1 を解消する (#300 2-3)。instance は引き続き
+// batch 1 回で resolve する (#277)。
+func (h *Handler) packRelationItems(
+	rows []*model.Following,
+	req FollowersRequest,
+	followers bool,
+) []relationItem {
+	filtered := make([]*model.Following, 0, len(rows))
+	idSet := make(map[string]struct{}, len(rows))
 	for _, f := range rows {
 		if req.SinceID != "" && f.ID <= req.SinceID {
 			continue
@@ -557,26 +533,59 @@ func (h *Handler) collectFollowing(req FollowersRequest) ([]relationItem, error)
 		if req.UntilID != "" && f.ID >= req.UntilID {
 			continue
 		}
-		r := resolved{f: f}
-		if b, err := h.userService.ShowByID(f.FolloweeID); err == nil {
-			r.bundle = b
-			remoteUsers = append(remoteUsers, b.User)
+		filtered = append(filtered, f)
+		var target string
+		if followers {
+			target = f.FollowerID
+		} else {
+			target = f.FolloweeID
 		}
-		pending = append(pending, r)
+		if target != "" {
+			idSet[target] = struct{}{}
+		}
+	}
+
+	bundleByID := make(map[string]*user.UserWithProfile, len(idSet))
+	if len(idSet) > 0 {
+		ids := make([]string, 0, len(idSet))
+		for id := range idSet {
+			ids = append(ids, id)
+		}
+		if bundles, err := h.userService.ShowManyByIDs(ids); err == nil {
+			for _, b := range bundles {
+				bundleByID[b.User.ID] = b
+			}
+		}
+	}
+
+	remoteUsers := make([]*model.User, 0, len(bundleByID))
+	for _, b := range bundleByID {
+		remoteUsers = append(remoteUsers, b.User)
 	}
 	resolver := entity.NewInstanceResolver(h.instanceLookup(), remoteUsers...)
-	out := make([]relationItem, 0, len(pending))
-	for _, r := range pending {
-		item := relationItem{ID: r.f.ID, FollowerID: r.f.FollowerID, FolloweeID: r.f.FolloweeID}
-		if r.bundle != nil {
-			d := entity.PackUserDetailed(r.bundle.User, r.bundle.Profile, h.idGen)
+
+	out := make([]relationItem, 0, len(filtered))
+	for _, f := range filtered {
+		item := relationItem{ID: f.ID, FollowerID: f.FollowerID, FolloweeID: f.FolloweeID}
+		var target string
+		if followers {
+			target = f.FollowerID
+		} else {
+			target = f.FolloweeID
+		}
+		if b, ok := bundleByID[target]; ok {
+			d := entity.PackUserDetailed(b.User, b.Profile, h.idGen)
 			resolver.FillUserLite(&d.UserLite)
-			h.populateUserEmojis(r.bundle.User, &d.UserLite)
-			item.Followee = &d
+			h.populateUserEmojis(b.User, &d.UserLite)
+			if followers {
+				item.Follower = &d
+			} else {
+				item.Followee = &d
+			}
 		}
 		out = append(out, item)
 	}
-	return out, nil
+	return out
 }
 
 // fillPinned populates PinnedNoteIDs / PinnedNotes / PinnedPageID / PinnedPage

--- a/internal/api/users/handler_test.go
+++ b/internal/api/users/handler_test.go
@@ -646,6 +646,97 @@ func TestFollowers_Success(t *testing.T) {
 	assert.Len(t, out, 1)
 }
 
+// users/followers が follower user の取得を per-row ShowByID で叩いて
+// いた N+1 を ShowManyByIDs 1 batch に置換した (#300 2-3)。
+// 5 follower 検証で per-row FindByID + FindProfileByUserID が 0 回、
+// FindManyByIDs / FindProfilesByUserIDs が 1 回ずつだけ呼ばれることを担保。
+type countingFollowerUserRepo struct {
+	*testutil.MockUserRepository
+	findByIDCalls            int
+	findProfileByUserIDCalls int
+	findManyByIDsCalls       int
+	findProfilesByUserIDs    int
+	findManyByIDsCallSize    int
+}
+
+func (c *countingFollowerUserRepo) FindByID(id string) (*model.User, error) {
+	c.findByIDCalls++
+	return c.MockUserRepository.FindByID(id)
+}
+
+func (c *countingFollowerUserRepo) FindProfileByUserID(id string) (*model.UserProfile, error) {
+	c.findProfileByUserIDCalls++
+	return c.MockUserRepository.FindProfileByUserID(id)
+}
+
+func (c *countingFollowerUserRepo) FindManyByIDs(ids []string) ([]*model.User, error) {
+	c.findManyByIDsCalls++
+	c.findManyByIDsCallSize += len(ids)
+	return c.MockUserRepository.FindManyByIDs(ids)
+}
+
+func (c *countingFollowerUserRepo) FindProfilesByUserIDs(ids []string) ([]*model.UserProfile, error) {
+	c.findProfilesByUserIDs++
+	return c.MockUserRepository.FindProfilesByUserIDs(ids)
+}
+
+func TestFollowers_BatchFetchesUsers(t *testing.T) {
+	repo := &countingFollowerUserRepo{MockUserRepository: testutil.NewMockUserRepository()}
+	noteRepo := testutil.NewMockNoteRepository()
+	piningRepo := testutil.NewMockUserNotePiningRepository()
+	fRepo := testutil.NewMockFollowingRepository()
+	frRepo := testutil.NewMockFollowRequestRepository()
+	idGen, _ := id.NewGenerator("aidx")
+	svc := coreuser.NewService(repo, noteRepo, piningRepo, idGen)
+	fSvc := corefollowing.NewService(repo, fRepo, frRepo, idGen)
+	h := NewHandler(svc, fSvc, noteRepo, idGen)
+
+	// target user (followee)
+	repo.Users["target"] = &model.User{
+		ID: "target", Username: "target", UsernameLower: "target",
+		AvatarDecorations: datatypes.JSON([]byte("[]")),
+	}
+	for i := 0; i < 5; i++ {
+		uid := fmt.Sprintf("rel-f-%d", i)
+		repo.Users[uid] = &model.User{
+			ID: uid, Username: uid, UsernameLower: uid,
+			AvatarDecorations: datatypes.JSON([]byte("[]")),
+		}
+		_, err := fSvc.Follow(uid, "target")
+		require.NoError(t, err)
+	}
+
+	// `followingService.Follow` が内部で repo.FindByID 経由でユーザー存在
+	// 確認するため、handler 直前に call counter をリセットして listRelations
+	// 経由の query 数だけを観測する。
+	repo.findByIDCalls = 0
+	repo.findProfileByUserIDCalls = 0
+	repo.findManyByIDsCalls = 0
+	repo.findManyByIDsCallSize = 0
+	repo.findProfilesByUserIDs = 0
+
+	rec := post(h.Followers, `{"userId":"target","limit":10}`)
+	require.Equal(t, http.StatusOK, rec.Code)
+	var resp []map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+	require.Len(t, resp, 5)
+
+	// listRelations の冒頭で ShowByID(req.UserID) を呼んで target 存在確認
+	// するため、FindByID と FindProfileByUserID が 1 回ずつ走るのは
+	// 想定どおり。重要なのは follower 5 件の解決で per-row 経路に落ちて
+	// いないこと = listRelations の N+1 が解消されていること。
+	assert.Equal(t, 1, repo.findByIDCalls,
+		"only target existence check should call FindByID; per-row must use batch")
+	assert.Equal(t, 1, repo.findProfileByUserIDCalls,
+		"only target existence check should call FindProfileByUserID; per-row must use batch")
+	assert.Equal(t, 1, repo.findManyByIDsCalls,
+		"FindManyByIDs should be called exactly once per request for the 5 followers")
+	assert.Equal(t, 5, repo.findManyByIDsCallSize,
+		"all 5 follower IDs should be coalesced into a single batch")
+	assert.Equal(t, 1, repo.findProfilesByUserIDs,
+		"FindProfilesByUserIDs should be called exactly once per request")
+}
+
 func TestFollowers_LimitClamp(t *testing.T) {
 	h, repo := newTestHandler(t)
 	addTestUser(repo)


### PR DESCRIPTION
## Summary

\`users/followers\` / \`users/following\` で target user 1 件ごとに \`ShowByID\` (= \`FindByID\` + \`FindProfileByUserID\` = 2 query) を呼ぶ N+1 になっていた (#300 2-3)。\`ShowManyByIDs\` (#503) で 1 batch query にまとめる。

クエリ削減 (limit 100 件想定): **200 query (per-row × 2) → 2 query (batch)**。

## 主な変更点

| ファイル | 内容 |
|---------|------|
| \`internal/api/users/handler.go\` | \`collectFollowers\` / \`collectFollowing\` の重複ロジックを \`packRelationItems(rows, req, followers bool)\` に統合。filter 後の ID set を \`ShowManyByIDs\` で fetch、map で O(1) 解決して \`relationItem\` に embed。instance resolve は batch 1 回のまま (#277 互換) |
| \`internal/api/users/handler_test.go\` | \`countingFollowerUserRepo\` wrapper で 5 follower ケース。target 存在確認の \`FindByID\` + \`FindProfileByUserID\` は各 1 回 (許容)、follower 5 件は per-row 0 / \`FindManyByIDs\` 1 回 + size 5 / \`FindProfilesByUserIDs\` 1 回で解決されることを担保 |

## テスト

```sh
go test -count=1 -run 'TestFollowers|TestFollowing' ./internal/api/users/
ok  	internal/api/users    0.037s
```

\`go vet ./...\` クリーン、\`gofmt -s -d .\` 差分なし、\`go build ./...\` クリーン。

## 関連 / 残

- 親 tracker: #300 (2-3)
- 同種完了: 1-1 / 1-2 / 1-3 / 1-4 / 2-1 / 2-2 / 3-1 / 3-4 / 4-1
- 残: 1-5 mention 解決ループ、2-4 timeline fanout 二重ループ、2-5、3-2/3-3/3-5/3-6 各種キャッシュ、3-7 singleflight

Refs #300
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/shiroha-a/mk/pull/540" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
