### PR TITLE
Perf #300 3-6: cache local emoji list with invalidation on mutation

### DIFF
--- a/internal/repository/emoji_cached.go
+++ b/internal/repository/emoji_cached.go
@@ -42,7 +42,11 @@ func NewCachedEmojiRepositoryWithTTL(inner EmojiRepository, ttl time.Duration) *
 // the slice itself).
 func (c *CachedEmojiRepository) ListLocal() ([]*model.Emoji, error) {
 	c.mu.RLock()
-	if c.local != nil && time.Since(c.at) < c.ttl {
+	// "キャッシュ済みかどうか" は c.at が non-zero かどうかで判定する。
+	// inner.ListLocal() は emoji table が空のとき GORM 由来で (nil, nil)
+	// を返す可能性があり、`c.local != nil` で判定すると空テーブルの
+	// instance で cache が永久に効かなくなる (Devin #541 BUG-1)。
+	if !c.at.IsZero() && time.Since(c.at) < c.ttl {
 		v := c.local
 		c.mu.RUnlock()
 		return v, nil
@@ -52,7 +56,7 @@ func (c *CachedEmojiRepository) ListLocal() ([]*model.Emoji, error) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 	// double-check: RUnlock〜Lock 間に別 goroutine がフェッチ済みの場合
-	if c.local != nil && time.Since(c.at) < c.ttl {
+	if !c.at.IsZero() && time.Since(c.at) < c.ttl {
 		return c.local, nil
 	}
 	list, err := c.inner.ListLocal()
@@ -69,6 +73,7 @@ func (c *CachedEmojiRepository) ListLocal() ([]*model.Emoji, error) {
 func (c *CachedEmojiRepository) Invalidate() {
 	c.mu.Lock()
 	c.local = nil
+	c.at = time.Time{}
 	c.mu.Unlock()
 }
 

--- a/internal/repository/emoji_cached.go
+++ b/internal/repository/emoji_cached.go
@@ -1,0 +1,153 @@
+package repository
+
+import (
+	"sync"
+	"time"
+
+	"github.com/shiroha-a/mk/internal/model"
+)
+
+// CachedEmojiRepository wraps an EmojiRepository with a time-based in-memory
+// cache for the ListLocal hot path. The /api/emojis endpoint is hit by every
+// timeline render (frontend caches client-side, but cold loads still flood
+// it), and ListLocal performs a full table scan with ORDER BY each time.
+// Local emoji set rarely changes (admin-only writes), so a short TTL plus
+// invalidation on mutation gives near-perfect cache hit rate while keeping
+// staleness bounded (#300 3-6).
+type CachedEmojiRepository struct {
+	inner EmojiRepository
+	ttl   time.Duration
+
+	mu    sync.RWMutex
+	local []*model.Emoji
+	at    time.Time
+}
+
+// NewCachedEmojiRepository wraps inner with a 5-minute TTL. Mutations through
+// this wrapper invalidate the cache immediately, so the TTL only matters for
+// out-of-band writes (e.g. another mk instance sharing the same DB).
+func NewCachedEmojiRepository(inner EmojiRepository) EmojiRepository {
+	return &CachedEmojiRepository{inner: inner, ttl: 5 * time.Minute}
+}
+
+// NewCachedEmojiRepositoryWithTTL is the test-friendly constructor with an
+// explicit TTL.
+func NewCachedEmojiRepositoryWithTTL(inner EmojiRepository, ttl time.Duration) *CachedEmojiRepository {
+	return &CachedEmojiRepository{inner: inner, ttl: ttl}
+}
+
+// ListLocal returns the cached local emoji slice if still valid, otherwise
+// fetches from the inner repo. The returned slice is the cache-internal
+// pointer; callers must treat it as read-only (never mutate elements or
+// the slice itself).
+func (c *CachedEmojiRepository) ListLocal() ([]*model.Emoji, error) {
+	c.mu.RLock()
+	if c.local != nil && time.Since(c.at) < c.ttl {
+		v := c.local
+		c.mu.RUnlock()
+		return v, nil
+	}
+	c.mu.RUnlock()
+
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	// double-check: RUnlock〜Lock 間に別 goroutine がフェッチ済みの場合
+	if c.local != nil && time.Since(c.at) < c.ttl {
+		return c.local, nil
+	}
+	list, err := c.inner.ListLocal()
+	if err != nil {
+		return nil, err
+	}
+	c.local = list
+	c.at = time.Now()
+	return list, nil
+}
+
+// Invalidate drops the cached ListLocal result. Public so out-of-band paths
+// (e.g. emoji import) can force a refresh without going through the wrapper.
+func (c *CachedEmojiRepository) Invalidate() {
+	c.mu.Lock()
+	c.local = nil
+	c.mu.Unlock()
+}
+
+func (c *CachedEmojiRepository) invalidate() {
+	c.Invalidate()
+}
+
+// --- mutating methods: delegate then invalidate ----------------------------
+
+func (c *CachedEmojiRepository) Create(e *model.Emoji) error {
+	if err := c.inner.Create(e); err != nil {
+		return err
+	}
+	c.invalidate()
+	return nil
+}
+
+func (c *CachedEmojiRepository) UpdateFields(id string, fields map[string]any) error {
+	if err := c.inner.UpdateFields(id, fields); err != nil {
+		return err
+	}
+	c.invalidate()
+	return nil
+}
+
+func (c *CachedEmojiRepository) UpdateFieldsMany(ids []string, fields map[string]any) error {
+	if err := c.inner.UpdateFieldsMany(ids, fields); err != nil {
+		return err
+	}
+	c.invalidate()
+	return nil
+}
+
+func (c *CachedEmojiRepository) Delete(id string) error {
+	if err := c.inner.Delete(id); err != nil {
+		return err
+	}
+	c.invalidate()
+	return nil
+}
+
+func (c *CachedEmojiRepository) DeleteMany(ids []string) error {
+	if err := c.inner.DeleteMany(ids); err != nil {
+		return err
+	}
+	c.invalidate()
+	return nil
+}
+
+// --- read-only methods: direct delegate ------------------------------------
+
+func (c *CachedEmojiRepository) FindByNameAndHost(name string, host *string) (*model.Emoji, error) {
+	return c.inner.FindByNameAndHost(name, host)
+}
+
+func (c *CachedEmojiRepository) FindByID(id string) (*model.Emoji, error) {
+	return c.inner.FindByID(id)
+}
+
+func (c *CachedEmojiRepository) FindManyByIDs(ids []string) ([]*model.Emoji, error) {
+	return c.inner.FindManyByIDs(ids)
+}
+
+func (c *CachedEmojiRepository) FindManyByNamesAndHost(names []string, host *string) ([]*model.Emoji, error) {
+	return c.inner.FindManyByNamesAndHost(names, host)
+}
+
+func (c *CachedEmojiRepository) ListWithFilter(query, category string, local bool, sinceID, untilID string, limit, offset int) ([]*model.Emoji, error) {
+	return c.inner.ListWithFilter(query, category, local, sinceID, untilID, limit, offset)
+}
+
+func (c *CachedEmojiRepository) ListRemoteWithFilter(query, host, sinceID, untilID string, limit, offset int) ([]*model.Emoji, error) {
+	return c.inner.ListRemoteWithFilter(query, host, sinceID, untilID, limit, offset)
+}
+
+func (c *CachedEmojiRepository) ListV2(filter model.EmojiV2Filter) ([]*model.Emoji, error) {
+	return c.inner.ListV2(filter)
+}
+
+func (c *CachedEmojiRepository) CountV2(filter model.EmojiV2Filter) (int64, error) {
+	return c.inner.CountV2(filter)
+}

--- a/internal/repository/emoji_cached_test.go
+++ b/internal/repository/emoji_cached_test.go
@@ -1,0 +1,175 @@
+package repository_test
+
+import (
+	"errors"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/shiroha-a/mk/internal/model"
+	"github.com/shiroha-a/mk/internal/repository"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// countingEmojiRepo wraps a slice-based fake EmojiRepository so we can both
+// observe call counts and stub mutation paths. Mock-style fake — keeps the
+// test focused on the wrapper's caching semantics.
+type countingEmojiRepo struct {
+	listLocalCalls atomic.Int64
+	emojis         []*model.Emoji
+	listErr        error
+	createErr      error
+	updateErr      error
+	deleteErr      error
+}
+
+func (c *countingEmojiRepo) ListLocal() ([]*model.Emoji, error) {
+	c.listLocalCalls.Add(1)
+	if c.listErr != nil {
+		return nil, c.listErr
+	}
+	out := make([]*model.Emoji, len(c.emojis))
+	copy(out, c.emojis)
+	return out, nil
+}
+
+func (c *countingEmojiRepo) Create(e *model.Emoji) error {
+	if c.createErr != nil {
+		return c.createErr
+	}
+	c.emojis = append(c.emojis, e)
+	return nil
+}
+
+func (c *countingEmojiRepo) UpdateFields(_ string, _ map[string]any) error { return c.updateErr }
+func (c *countingEmojiRepo) UpdateFieldsMany(_ []string, _ map[string]any) error {
+	return c.updateErr
+}
+func (c *countingEmojiRepo) Delete(_ string) error       { return c.deleteErr }
+func (c *countingEmojiRepo) DeleteMany(_ []string) error { return c.deleteErr }
+
+func (c *countingEmojiRepo) FindByNameAndHost(_ string, _ *string) (*model.Emoji, error) {
+	return nil, nil
+}
+func (c *countingEmojiRepo) FindByID(_ string) (*model.Emoji, error)          { return nil, nil }
+func (c *countingEmojiRepo) FindManyByIDs(_ []string) ([]*model.Emoji, error) { return nil, nil }
+func (c *countingEmojiRepo) FindManyByNamesAndHost(_ []string, _ *string) ([]*model.Emoji, error) {
+	return nil, nil
+}
+func (c *countingEmojiRepo) ListWithFilter(_, _ string, _ bool, _, _ string, _, _ int) ([]*model.Emoji, error) {
+	return nil, nil
+}
+func (c *countingEmojiRepo) ListRemoteWithFilter(_, _, _, _ string, _, _ int) ([]*model.Emoji, error) {
+	return nil, nil
+}
+func (c *countingEmojiRepo) ListV2(_ model.EmojiV2Filter) ([]*model.Emoji, error) { return nil, nil }
+func (c *countingEmojiRepo) CountV2(_ model.EmojiV2Filter) (int64, error)         { return 0, nil }
+
+func TestCachedEmojiRepository_ListLocalHitsInnerOnce(t *testing.T) {
+	inner := &countingEmojiRepo{
+		emojis: []*model.Emoji{{ID: "e1", Name: "smile"}, {ID: "e2", Name: "wave"}},
+	}
+	cached := repository.NewCachedEmojiRepository(inner)
+
+	for i := 0; i < 10; i++ {
+		got, err := cached.ListLocal()
+		require.NoError(t, err)
+		require.Len(t, got, 2)
+	}
+	assert.Equal(t, int64(1), inner.listLocalCalls.Load(),
+		"inner ListLocal must be called exactly once for 10 cached calls")
+}
+
+func TestCachedEmojiRepository_ListLocalRefreshesAfterTTL(t *testing.T) {
+	inner := &countingEmojiRepo{emojis: []*model.Emoji{{ID: "e1"}}}
+	cached := repository.NewCachedEmojiRepositoryWithTTL(inner, 1*time.Millisecond)
+
+	_, err := cached.ListLocal()
+	require.NoError(t, err)
+	time.Sleep(2 * time.Millisecond)
+	_, err = cached.ListLocal()
+	require.NoError(t, err)
+	assert.Equal(t, int64(2), inner.listLocalCalls.Load(),
+		"second call after TTL must hit inner again")
+}
+
+func TestCachedEmojiRepository_CreateInvalidatesCache(t *testing.T) {
+	inner := &countingEmojiRepo{emojis: []*model.Emoji{{ID: "e1"}}}
+	cached := repository.NewCachedEmojiRepository(inner)
+
+	got, _ := cached.ListLocal()
+	assert.Len(t, got, 1)
+
+	require.NoError(t, cached.Create(&model.Emoji{ID: "e2"}))
+
+	got, _ = cached.ListLocal()
+	assert.Len(t, got, 2, "create should have invalidated the cache and refetched")
+	assert.Equal(t, int64(2), inner.listLocalCalls.Load())
+}
+
+func TestCachedEmojiRepository_DeleteInvalidatesCache(t *testing.T) {
+	inner := &countingEmojiRepo{emojis: []*model.Emoji{{ID: "e1"}}}
+	cached := repository.NewCachedEmojiRepository(inner)
+
+	_, _ = cached.ListLocal() // warm
+	require.NoError(t, cached.Delete("e1"))
+	_, _ = cached.ListLocal()
+	assert.Equal(t, int64(2), inner.listLocalCalls.Load(),
+		"delete must invalidate cache so next ListLocal hits DB")
+}
+
+func TestCachedEmojiRepository_UpdateInvalidatesCache(t *testing.T) {
+	inner := &countingEmojiRepo{emojis: []*model.Emoji{{ID: "e1"}}}
+	cached := repository.NewCachedEmojiRepository(inner)
+
+	_, _ = cached.ListLocal()
+	require.NoError(t, cached.UpdateFields("e1", map[string]any{"category": "x"}))
+	_, _ = cached.ListLocal()
+	require.NoError(t, cached.UpdateFieldsMany([]string{"e1"}, map[string]any{"category": "y"}))
+	_, _ = cached.ListLocal()
+	require.NoError(t, cached.DeleteMany([]string{"e1"}))
+	_, _ = cached.ListLocal()
+	// 1 (warm) + 1 (after Update) + 1 (after UpdateMany) + 1 (after DeleteMany) = 4
+	assert.Equal(t, int64(4), inner.listLocalCalls.Load(),
+		"every mutating method should invalidate cache")
+}
+
+// 失敗した mutation はキャッシュを invalidate しない (DB 状態が変わらないため)。
+func TestCachedEmojiRepository_FailedMutationDoesNotInvalidate(t *testing.T) {
+	inner := &countingEmojiRepo{
+		emojis:    []*model.Emoji{{ID: "e1"}},
+		createErr: errors.New("db down"),
+	}
+	cached := repository.NewCachedEmojiRepository(inner)
+
+	_, _ = cached.ListLocal() // warm
+	err := cached.Create(&model.Emoji{ID: "e2"})
+	assert.Error(t, err)
+	_, _ = cached.ListLocal()
+	assert.Equal(t, int64(1), inner.listLocalCalls.Load(),
+		"failed Create must not invalidate cache")
+}
+
+func TestCachedEmojiRepository_ListLocalErrorIsNotCached(t *testing.T) {
+	inner := &countingEmojiRepo{listErr: errors.New("db down")}
+	cached := repository.NewCachedEmojiRepository(inner)
+
+	_, err := cached.ListLocal()
+	require.Error(t, err)
+	_, err = cached.ListLocal()
+	require.Error(t, err)
+	assert.Equal(t, int64(2), inner.listLocalCalls.Load(),
+		"errors must not be cached so transient failures recover on next call")
+}
+
+func TestCachedEmojiRepository_InvalidatePublic(t *testing.T) {
+	inner := &countingEmojiRepo{emojis: []*model.Emoji{{ID: "e1"}}}
+	cached := repository.NewCachedEmojiRepositoryWithTTL(inner, time.Hour)
+
+	_, _ = cached.ListLocal()
+	cached.Invalidate()
+	_, _ = cached.ListLocal()
+	assert.Equal(t, int64(2), inner.listLocalCalls.Load(),
+		"explicit Invalidate() should drop the cache")
+}

--- a/internal/repository/emoji_cached_test.go
+++ b/internal/repository/emoji_cached_test.go
@@ -163,6 +163,22 @@ func TestCachedEmojiRepository_ListLocalErrorIsNotCached(t *testing.T) {
 		"errors must not be cached so transient failures recover on next call")
 }
 
+// 空 emoji table のとき inner.ListLocal() は (nil, nil) を返すが、それでも
+// cache が効くべき。`c.local != nil` で判定すると毎回 DB を叩くバグに
+// なるので `c.at.IsZero()` で判定する (Devin #541 BUG-1)。
+func TestCachedEmojiRepository_EmptyResultIsCached(t *testing.T) {
+	inner := &countingEmojiRepo{emojis: nil}
+	cached := repository.NewCachedEmojiRepository(inner)
+
+	for i := 0; i < 5; i++ {
+		got, err := cached.ListLocal()
+		require.NoError(t, err)
+		require.Empty(t, got)
+	}
+	assert.Equal(t, int64(1), inner.listLocalCalls.Load(),
+		"empty emoji table must still be cached; only the first call should hit inner")
+}
+
 func TestCachedEmojiRepository_InvalidatePublic(t *testing.T) {
 	inner := &countingEmojiRepo{emojis: []*model.Emoji{{ID: "e1"}}}
 	cached := repository.NewCachedEmojiRepositoryWithTTL(inner, time.Hour)

--- a/internal/server/router.go
+++ b/internal/server/router.go
@@ -137,7 +137,11 @@ func (s *Server) setupRoutes() {
 	followRequestRepo := repository.NewFollowRequestRepository(s.db)
 	piningRepo := repository.NewUserNotePiningRepository(s.db)
 	reactionRepo := repository.NewNoteReactionRepository(s.db)
-	emojiRepo := repository.NewEmojiRepository(s.db)
+	// emoji の ListLocal はタイムライン描画ごとに毎回フルスキャンしていた
+	// hot path だが、絵文字テーブルの mutation は admin 経由のみで頻度が低い。
+	// 5 分 TTL の in-memory cache + mutation 時 invalidate で DB 負荷を消す
+	// (#300 3-6)。
+	emojiRepo := repository.NewCachedEmojiRepository(repository.NewEmojiRepository(s.db))
 	blockingRepo := repository.NewBlockingRepository(s.db)
 	mutingRepo := repository.NewMutingRepository(s.db)
 	renoteMutingRepo := repository.NewRenoteMutingRepository(s.db)


### PR DESCRIPTION
## Summary

\`emojis\` API はタイムライン描画ごとに \`emojiRepo.ListLocal()\` を呼び、毎回テーブルフルスキャン (ORDER BY 込み) を発行していた hot path (#300 3-6)。絵文字テーブルの mutation は admin 経由のみで頻度が低いので、5 分 TTL の in-memory cache + mutation 時 invalidate で DB 負荷を消す。

## 主な変更点

| ファイル | 内容 |
|---------|------|
| \`internal/repository/emoji_cached.go\` | \`CachedEmojiRepository\` 新設。5 分 TTL、\`ListLocal\` を \`sync.RWMutex\` で保護 + double-check locking。\`Create\` / \`UpdateFields\` / \`UpdateFieldsMany\` / \`Delete\` / \`DeleteMany\` の各 mutation で invalidate。失敗時は invalidate しない (DB 状態は変わらないため)。read-only メソッドは inner に委譲。\`Invalidate()\` は外部公開し、emoji import 等の out-of-band 経路から手動 refresh 可能 |
| \`internal/repository/emoji_cached_test.go\` | 8 ケース。10 連続 hit で inner が 1 回だけ / TTL 経過後の refetch / 各 mutation で invalidate / 失敗 mutation は invalidate しない / list error は cache しない / 手動 \`Invalidate()\` |
| \`internal/server/router.go\` | \`emojiRepo := repository.NewCachedEmojiRepository(repository.NewEmojiRepository(...))\` で wrap |

## 期待効果

- \`/api/emojis\` の DB hit が ほぼ 0 に。タイムライン cold load の主要 query 1 つ消える
- frontend は通常 emoji リストをセッション内で 1 回しか fetch しないが、3 instance / モバイル / 別ブラウザで cold load が重なる場合に効く
- 5 分 TTL により別 mk instance との DB 共有 (drop-in 切替直後等) でも staleness 上限が確定

## テスト

```sh
go vet ./...
make lint
go build ./...
```

DB-backed test は CI で実行 (testcontainers)。\`emoji_cached_test.go\` は \`package repository_test\` に置いているが、同 package の TestMain が DB 必須のためローカルでは run 不可、CI で実行。

## 関連 / 残

- 親 tracker: #300 (3-6)
- 同種完了キャッシュ: 3-1 meta (#304)、3-4 auth token (#514)
- 残: 3-2 instance block/silence cache、3-3 user profile cache、3-5 role policy cache、3-7 singleflight

Refs #300
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/shiroha-a/mk/pull/541" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
