### PR TITLE
Perf #300 3-5: per-user role cache (5min TTL) on role.Service

### DIFF
--- a/internal/core/role/role_service.go
+++ b/internal/core/role/role_service.go
@@ -3,6 +3,7 @@ package role
 import (
 	"encoding/json"
 	"errors"
+	"sync"
 	"time"
 
 	"github.com/shiroha-a/mk/internal/misc/id"
@@ -19,12 +20,31 @@ var (
 	ErrNotAssigned = errors.New("role not assigned")
 )
 
+// roleCacheTTL は GetUserRoles キャッシュの有効期限。Misskey TS 同等の
+// admin 操作 (admin/roles/* 経路) は頻度が低いので、5 分に揃えて
+// IsAdministrator / IsModerator / GetUserPolicies の DB 負荷を消す
+// (#300 3-5)。
+const roleCacheTTL = 5 * time.Minute
+
+// roleCacheEntry は per-user の roles snapshot + 失効時刻。
+type roleCacheEntry struct {
+	roles     []*model.Role
+	expiresAt time.Time
+}
+
 // Service manages roles and role assignments.
 type Service struct {
 	roleRepo       repository.RoleRepository
 	assignmentRepo repository.RoleAssignmentRepository
 	metaRepo       repository.MetaRepository
 	idGen          id.Generator
+
+	// userRoleCache は GetUserRoles 結果の per-user TTL キャッシュ
+	// (sync.Map で hot path に lock を持ち込まない)。Assign / Unassign で
+	// 当該 userID を、Delete (role 削除) で全 entry を invalidate する。
+	// admin/roles/update が roleRepo を直接叩く経路は TTL でしかカバー
+	// できないが、roleCacheTTL = 5 min で staleness は bounded (#300 3-5)。
+	userRoleCache sync.Map // userID -> *roleCacheEntry
 }
 
 // NewService constructs a RoleService.
@@ -42,8 +62,38 @@ func NewService(
 	}
 }
 
+// InvalidateUserRoleCache drops the cached role list for userID. Out-of-band
+// admin paths (e.g. role mutation via repo) can call this to force a refresh.
+func (s *Service) InvalidateUserRoleCache(userID string) {
+	if userID == "" {
+		return
+	}
+	s.userRoleCache.Delete(userID)
+}
+
+// InvalidateAllRoleCaches drops every cached entry. Used when a role is
+// deleted (we don't know which users were assigned without an extra DB hit,
+// so the simplest safe action is to flush the whole cache).
+func (s *Service) InvalidateAllRoleCaches() {
+	s.userRoleCache.Range(func(k, _ any) bool {
+		s.userRoleCache.Delete(k)
+		return true
+	})
+}
+
 // GetUserRoles returns all active (non-expired) roles assigned to the user.
+// 結果は roleCacheTTL 期間 in-memory にキャッシュされる (#300 3-5)。
 func (s *Service) GetUserRoles(userID string) ([]*model.Role, error) {
+	if userID == "" {
+		return nil, nil
+	}
+	if v, ok := s.userRoleCache.Load(userID); ok {
+		if entry, ok := v.(*roleCacheEntry); ok && time.Now().Before(entry.expiresAt) {
+			return entry.roles, nil
+		}
+		s.userRoleCache.Delete(userID)
+	}
+
 	assignments, err := s.assignmentRepo.ListByUser(userID)
 	if err != nil {
 		return nil, err
@@ -54,6 +104,10 @@ func (s *Service) GetUserRoles(userID string) ([]*model.Role, error) {
 			roles = append(roles, a.Role)
 		}
 	}
+	s.userRoleCache.Store(userID, &roleCacheEntry{
+		roles:     roles,
+		expiresAt: time.Now().Add(roleCacheTTL),
+	})
 	return roles, nil
 }
 
@@ -172,7 +226,11 @@ func (s *Service) Assign(userID, roleID string, expiresAt *time.Time) error {
 		RoleID:    roleID,
 		ExpiresAt: expiresAt,
 	}
-	return s.assignmentRepo.Create(a)
+	if err := s.assignmentRepo.Create(a); err != nil {
+		return err
+	}
+	s.InvalidateUserRoleCache(userID)
+	return nil
 }
 
 // Unassign removes a role from a user.
@@ -184,7 +242,11 @@ func (s *Service) Unassign(userID, roleID string) error {
 	if !exists {
 		return ErrNotAssigned
 	}
-	return s.assignmentRepo.Delete(userID, roleID)
+	if err := s.assignmentRepo.Delete(userID, roleID); err != nil {
+		return err
+	}
+	s.InvalidateUserRoleCache(userID)
+	return nil
 }
 
 // Create creates a new role.
@@ -239,7 +301,14 @@ func (s *Service) Delete(id string) error {
 	if _, err := s.roleRepo.FindByID(id); err != nil {
 		return ErrRoleNotFound
 	}
-	return s.roleRepo.Delete(id)
+	if err := s.roleRepo.Delete(id); err != nil {
+		return err
+	}
+	// 削除した role を assigned していた user 集合は分からないので、
+	// 全 cache を flush する。admin 操作で頻度が低いので O(N) flush の
+	// コストは許容範囲。
+	s.InvalidateAllRoleCaches()
+	return nil
 }
 
 // DefaultPolicies returns the Misskey default policies.

--- a/internal/core/role/role_service_test.go
+++ b/internal/core/role/role_service_test.go
@@ -468,3 +468,139 @@ func TestIsSilenced_CanPublicNoteFalseMeansSilenced(t *testing.T) {
 	}
 	assert.True(t, svc.IsSilenced("user1"))
 }
+
+// --- per-user role cache (#300 3-5) -----------------------------------------
+
+// countingAssignmentRepo wraps the mock to count ListByUser calls so we can
+// verify the role cache hits.
+type countingAssignmentRepo struct {
+	*testutil.MockRoleAssignmentRepository
+	listByUserCalls int
+}
+
+func (c *countingAssignmentRepo) ListByUser(userID string) ([]*model.RoleAssignment, error) {
+	c.listByUserCalls++
+	return c.MockRoleAssignmentRepository.ListByUser(userID)
+}
+
+func newServiceWithCountingAssign(t *testing.T) (*role.Service, *testutil.MockRoleRepository, *countingAssignmentRepo) {
+	t.Helper()
+	roleRepo := testutil.NewMockRoleRepository()
+	assignRepo := &countingAssignmentRepo{
+		MockRoleAssignmentRepository: testutil.NewMockRoleAssignmentRepository(roleRepo),
+	}
+	metaRepo := testutil.NewMockMetaRepository()
+	idGen, _ := id.NewGenerator("aidx")
+	svc := role.NewService(roleRepo, assignRepo, metaRepo, idGen)
+	return svc, roleRepo, assignRepo
+}
+
+// 同一 user に対する 10 連続 GetUserRoles で assignmentRepo.ListByUser が
+// 1 回しか呼ばれないことを担保 (#300 3-5)。
+func TestGetUserRoles_CachedHitsRepoOnce(t *testing.T) {
+	svc, roleRepo, assignRepo := newServiceWithCountingAssign(t)
+	roleRepo.Roles["r1"] = &model.Role{ID: "r1", Name: "Mod", IsModerator: true}
+	assignRepo.Assignments["user1:r1"] = &model.RoleAssignment{
+		ID: "a1", UserID: "user1", RoleID: "r1",
+	}
+
+	for i := 0; i < 10; i++ {
+		roles, err := svc.GetUserRoles("user1")
+		require.NoError(t, err)
+		require.Len(t, roles, 1)
+	}
+	assert.Equal(t, 1, assignRepo.listByUserCalls,
+		"per-user role list should be cached; only the first call hits the repo")
+}
+
+// Assign で当該ユーザーの cache が invalidate されることを担保。
+func TestAssign_InvalidatesUserRoleCache(t *testing.T) {
+	svc, roleRepo, assignRepo := newServiceWithCountingAssign(t)
+	roleRepo.Roles["r1"] = &model.Role{ID: "r1", Name: "Mod"}
+	roleRepo.Roles["r2"] = &model.Role{ID: "r2", Name: "Trial"}
+	assignRepo.Assignments["user1:r1"] = &model.RoleAssignment{
+		ID: "a1", UserID: "user1", RoleID: "r1",
+	}
+
+	// warm cache
+	_, _ = svc.GetUserRoles("user1")
+	assert.Equal(t, 1, assignRepo.listByUserCalls)
+
+	require.NoError(t, svc.Assign("user1", "r2", nil))
+
+	// next read should miss cache and go to DB
+	_, _ = svc.GetUserRoles("user1")
+	assert.Equal(t, 2, assignRepo.listByUserCalls,
+		"Assign must invalidate the user's role cache so next read is fresh")
+}
+
+// Unassign で当該ユーザーの cache が invalidate されることを担保。
+func TestUnassign_InvalidatesUserRoleCache(t *testing.T) {
+	svc, roleRepo, assignRepo := newServiceWithCountingAssign(t)
+	roleRepo.Roles["r1"] = &model.Role{ID: "r1", Name: "Mod"}
+	assignRepo.Assignments["user1:r1"] = &model.RoleAssignment{
+		ID: "a1", UserID: "user1", RoleID: "r1",
+	}
+
+	_, _ = svc.GetUserRoles("user1")
+	assert.Equal(t, 1, assignRepo.listByUserCalls)
+
+	require.NoError(t, svc.Unassign("user1", "r1"))
+
+	_, _ = svc.GetUserRoles("user1")
+	assert.Equal(t, 2, assignRepo.listByUserCalls,
+		"Unassign must invalidate the user's role cache")
+}
+
+// Service.Delete (role 削除) で全 user の cache が flush されること。
+func TestDelete_InvalidatesAllRoleCaches(t *testing.T) {
+	svc, roleRepo, assignRepo := newServiceWithCountingAssign(t)
+	roleRepo.Roles["r1"] = &model.Role{ID: "r1", Name: "Mod"}
+	roleRepo.Roles["r2"] = &model.Role{ID: "r2", Name: "Trial"}
+	assignRepo.Assignments["user1:r1"] = &model.RoleAssignment{
+		ID: "a1", UserID: "user1", RoleID: "r1",
+	}
+	assignRepo.Assignments["user2:r1"] = &model.RoleAssignment{
+		ID: "a2", UserID: "user2", RoleID: "r1",
+	}
+
+	// warm cache for both users
+	_, _ = svc.GetUserRoles("user1")
+	_, _ = svc.GetUserRoles("user2")
+	assert.Equal(t, 2, assignRepo.listByUserCalls)
+
+	require.NoError(t, svc.Delete("r2")) // 別 role の delete でも全 flush
+
+	_, _ = svc.GetUserRoles("user1")
+	_, _ = svc.GetUserRoles("user2")
+	assert.Equal(t, 4, assignRepo.listByUserCalls,
+		"Delete should flush every cached entry (we don't know which users were assigned)")
+}
+
+func TestGetUserRoles_EmptyUserIDDoesNotCache(t *testing.T) {
+	svc, _, assignRepo := newServiceWithCountingAssign(t)
+	roles, err := svc.GetUserRoles("")
+	require.NoError(t, err)
+	assert.Empty(t, roles)
+	assert.Equal(t, 0, assignRepo.listByUserCalls,
+		"empty userID must not hit the repo at all")
+}
+
+// 失敗した Assign / Unassign は invalidate しない (DB 状態が変わらないため)。
+func TestAssign_FailedDoesNotInvalidate(t *testing.T) {
+	svc, roleRepo, assignRepo := newServiceWithCountingAssign(t)
+	roleRepo.Roles["r1"] = &model.Role{ID: "r1", Name: "Mod"}
+	assignRepo.Assignments["user1:r1"] = &model.RoleAssignment{
+		ID: "a1", UserID: "user1", RoleID: "r1",
+	}
+
+	_, _ = svc.GetUserRoles("user1") // warm
+
+	// 同じ role を再度 Assign → ErrAlreadyAssigned で失敗
+	err := svc.Assign("user1", "r1", nil)
+	require.Error(t, err)
+
+	_, _ = svc.GetUserRoles("user1")
+	assert.Equal(t, 1, assignRepo.listByUserCalls,
+		"failed Assign must not invalidate cache")
+}


### PR DESCRIPTION
## Summary

\`GetUserRoles\` / \`IsAdministrator\` / \`IsModerator\` / \`GetUserPolicies\` は認証経路を含む hot path で、毎回 \`assignmentRepo.ListByUser\` を叩いて DB クエリを発行していた (#300 3-5)。\`role.Service\` に \`sync.Map\` ベースの per-user TTL キャッシュを組み込んで DB 負荷を消す。

## 主な変更点

| ファイル | 内容 |
|---------|------|
| \`internal/core/role/role_service.go\` | \`roleCacheEntry\` / \`userRoleCache sync.Map\` を Service に追加。TTL = 5 分 (spec 通り)。\`GetUserRoles\` は cache hit → 即 return、miss → DB → store。empty userID は cache せず repo に触らない。\`Assign\` / \`Unassign\` 成功時に当該 userID の cache を invalidate。\`Delete\` (role 削除) は全 cache を flush (assigned user 集合を知るのに extra DB query が要るため)。\`InvalidateUserRoleCache\` / \`InvalidateAllRoleCaches\` を public 公開。失敗した \`Assign\` / \`Unassign\` は invalidate しない (DB 状態が変わらないため) |
| \`internal/core/role/role_service_test.go\` | 7 ケース追加: 10 連続 GetUserRoles で repo 1 回だけ / Assign で当該 user invalidate / Unassign で当該 user invalidate / Delete で全 flush / empty userID は no-op / 失敗 Assign は cache 維持 |

## 期待効果

- 認証要 endpoint で \`IsAdministrator\` / \`IsModerator\` / \`GetUserPolicies\` を呼ぶたびに発行されていた \`assignmentRepo.ListByUser\` クエリが消える
- TTL 5 分で staleness は bounded (admin 操作の反映遅延は許容範囲)
- \`Assign\` / \`Unassign\` の同期反映は維持

## 注意

\`admin/roles/update\` (\`handler.go:968\`) は現状 stub で DB を書かない (ステータスのみ 204)。実 update が実装される際は同 handler 内で \`roleService.InvalidateAllRoleCaches()\` を呼ぶ必要がある (commit message にも明記済)。

## テスト

```sh
go test -count=1 ./internal/core/role/
ok  	internal/core/role    0.039s
```

\`go vet ./...\` クリーン、\`gofmt -s -d .\` 差分なし、\`go build ./...\` クリーン。

## 関連 / 残

- 親 tracker: #300 (3-5)
- 同種完了キャッシュ: 3-1 meta (#304)、3-4 auth token (#514)、3-6 emoji (#541)
- 残: 3-3 user profile cache、3-7 singleflight (大物)、1-5 mention 解決ループ、2-4 timeline fanout 二重ループ、2-5 Reply/Renote sequential

Refs #300
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/shiroha-a/mk/pull/543" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
