### PR TITLE
Perf #300 2-5: parallelize Reply/Renote target fetch in note create

### DIFF
--- a/internal/core/note/note_create_service.go
+++ b/internal/core/note/note_create_service.go
@@ -6,6 +6,7 @@ import (
 	"log/slog"
 	"regexp"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/shiroha-a/mk/internal/entity"
@@ -323,12 +324,38 @@ func (s *CreateService) Create(in CreateInput) (*model.Note, error) {
 
 	// reply/renote先のノートを取得し、閲覧権限を確認する。
 	// 取得したノートは、後段のカウンタ更新と非正規化フィールドの埋め込みに使う。
-	var replyTarget, renoteTarget *model.Note
+	// ReplyID と RenoteID の DB fetch は完全に独立しているので並列に走らせて
+	// 1 round-trip ぶん latency を削る (#300 2-5)。validation は fetch 後に
+	// 直列で走らせ、エラー報告順 (reply → renote) は変えない。
+	var (
+		replyTarget, renoteTarget *model.Note
+		replyFetchErr             error
+		renoteFetchErr            error
+	)
+	{
+		var wg sync.WaitGroup
+		if in.ReplyID != nil {
+			wg.Add(1)
+			go func() {
+				defer wg.Done()
+				replyTarget, replyFetchErr = s.noteRepo.FindByIDWithUser(*in.ReplyID)
+			}()
+		}
+		if in.RenoteID != nil {
+			wg.Add(1)
+			go func() {
+				defer wg.Done()
+				renoteTarget, renoteFetchErr = s.noteRepo.FindByIDWithUser(*in.RenoteID)
+			}()
+		}
+		wg.Wait()
+	}
+
 	if in.ReplyID != nil {
-		t, err := s.noteRepo.FindByIDWithUser(*in.ReplyID)
-		if err != nil {
+		if replyFetchErr != nil {
 			return nil, ErrReplyTargetNotFound
 		}
+		t := replyTarget
 		// 可視性チェックを先に行う。FindByIDWithUserは無条件に行を返すため、
 		// 不可視noteに対して別error (pure renote 等) を返すと「対象noteが
 		// 何であるか」を攻撃者が推測できる情報漏洩になる。Devin review #270。
@@ -349,13 +376,12 @@ func (s *CreateService) Create(in CreateInput) (*model.Note, error) {
 				return nil, err
 			}
 		}
-		replyTarget = t
 	}
 	if in.RenoteID != nil {
-		t, err := s.noteRepo.FindByIDWithUser(*in.RenoteID)
-		if err != nil {
+		if renoteFetchErr != nil {
 			return nil, ErrRenoteTargetNotFound
 		}
+		t := renoteTarget
 		// 可視性チェックを先に行う (Devin review #270 — 情報漏洩防止)。
 		if !CanSeeNote(in.User, t, s.followingRepo) {
 			return nil, ErrCannotRenoteInvisibleNote
@@ -378,7 +404,6 @@ func (s *CreateService) Create(in CreateInput) (*model.Note, error) {
 				return nil, err
 			}
 		}
-		renoteTarget = t
 	}
 
 	now := time.Now()


### PR DESCRIPTION
## Summary

\`note.CreateService\` で Reply target と Renote target の \`FindByIDWithUser\` fetch は完全に独立しているが直列に発行されていた (#300 2-5)。両方指定 (= 引用 reply 等) のとき DB round-trip を **2 → 1 に並列化**できる。

## 主な変更点

| ファイル | 内容 |
|---------|------|
| \`internal/core/note/note_create_service.go\` | \`sync.WaitGroup\` で 2 fetch を並列実行する block を導入。validation 段は逐次のまま (\`replyTarget\` / \`renoteTarget\` が揃ってから順番に検証)。エラー報告順 (reply → renote) は維持。片方だけ指定のときは 1 goroutine しか起動しない (overhead 最小) |

## 互換性

- 既存テスト (\`note_create_service_test.go\`) はそのまま pass。エラー優先順 / Validation rules / 戻り値はすべて従来挙動と同じ
- 片方だけ指定 (純粋な reply / renote / quote) は実質変化なし (1 goroutine)
- 両方指定 (引用 reply) のときに 1 round-trip ぶん速くなる

## テスト

```sh
go test -count=1 -race ./internal/core/note/
ok  	internal/core/note    1.090s
```

\`go vet ./...\` クリーン、\`gofmt -s -d .\` 差分なし、\`go build ./...\` クリーン。

## 関連 / 残

- 親 tracker: #300 (2-5)
- 同種完了: 2-1 ノート作成フック並列化 (#304)、2-2 users/show viewer field 並列化 (#304)
- 残: 1-5 mention 解決ループ、2-3 followers/followings (#540 で完了)、2-4 timeline fanout 二重ループ、3-3 user profile cache、3-7 singleflight

Refs #300
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/shiroha-a/mk/pull/544" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
