### PR TITLE
Add cmd/dbgtimeline: timeline JSON encoder panic 切り分けツール

### DIFF
--- a/cmd/dbgtimeline/README.md
+++ b/cmd/dbgtimeline/README.md
@@ -1,0 +1,85 @@
+# dbgtimeline
+
+タイムライン経路の JSON encoder panic を切り分けるためのデバッグ用ツール。
+本番には焼かない (`go build ./cmd/dbgtimeline` 経由で開発者がローカルで使う想定)。
+
+## 何が出来るか
+
+1. mk-go と同じ DSN で PostgreSQL に接続して **read-only** で最近の note を取得
+2. `entity.PackNotes` + `NoteFieldResolver.Apply` を実 timeline 経路と同じ手順で適用
+3. 各 packed `NoteEntity` を goccy/go-json `Encoder.Encode` に流して panic / fatal を recover
+4. `-bisect` で panic 範囲を二分探索、`-dump` で原因 entity を stdlib で pretty-print
+
+DB は `SELECT` のみ。書き込み一切なし。production-like UDS DB に向けても安全。
+
+## 由来
+
+[#542](https://github.com/shiroha-a/mk/issues/542) (goccy 0.10.6 の `ptrToString` panic) を
+追跡するために作った。トリガー note を特定したあと、汎用デバッグ ツールとして残してある。
+将来「特定の timeline で encoder panic が出る」報告が来たら、同じ手順で切り分けられる。
+
+## 使い方
+
+### ローカルビルド
+
+```bash
+go build -o /tmp/dbgtimeline ./cmd/dbgtimeline
+/tmp/dbgtimeline -config .config/default.yml -limit 200 -viewer your-username
+```
+
+ローカルで mk-go を立てている場合は `-config` を実 config に向ければそのまま使える。
+
+### Docker 内で実行 (UDS 環境向け)
+
+UDS 環境はホストから DB 直接アクセスできないので、`mkgo` コンテナ内に
+バイナリを `docker cp` してから実行する:
+
+```bash
+CGO_ENABLED=0 GOOS=linux GOARCH=amd64 \
+  go build -o /tmp/dbgtimeline ./cmd/dbgtimeline
+docker cp /tmp/dbgtimeline mk-mkgo-1:/tmp/dbgtimeline
+docker compose -f compose.uds.yaml exec mkgo \
+  /tmp/dbgtimeline -limit 500 -viewer your-username -bisect -dump
+```
+
+### フラグ
+
+| フラグ | デフォルト | 説明 |
+|---|---|---|
+| `-config` | `/app/.config/default.yml` | mk-go config の path (DB credentials を取る) |
+| `-limit` | `200` | 走査する note の最大件数 (`ORDER BY id DESC LIMIT N`) |
+| `-viewer` | `""` | viewer-dependent field (MyReaction 等) を埋めるための `username_lower`。空 = nil viewer (production の未ログイン timeline と同等) |
+| `-bisect` | `false` | panic を起こす note の slice 範囲を二分探索する |
+| `-dump` | `false` | 最初に panic を起こした note の packed entity を stdlib JSON で deep-dump する |
+
+## 出力例
+
+```
+Loaded 200 notes
+Using viewer: alice (id=al9hjjx4b0ey0002)
+PANIC at index=1 note.id=alng2ov5ffpp0007 userHost=remote.example visibility=public renoteId=0xc0003c58e0
+PANIC at index=85 note.id=alm00w90sjj8000w userHost=remote.example visibility=public renoteId=0xc000463e90
+...
+Total panicking notes: 5
+
+--- Slice bisect (find smallest panicking range) ---
+[bisect lo=0 mid=100 hi=200] left err=panic / right err=<nil>
+[bisect lo=0 mid=50 hi=100] left err=panic / right err=<nil>
+...
+[single index=1] err=panic id=alng2ov5ffpp0007
+```
+
+## 既知の制約
+
+- **fatal error は recover できない**: goccy が出す `runtime.fatal` (sigsegv) は `defer recover()`
+  では掴めず、プロセスが死ぬ。複数 note 連続で encode を試みると goccy 内部 cache が
+  汚染されて後続呼び出しで fatal に昇格することがある。`-bisect` 中にプロセスが落ちたら、
+  `-limit` を絞って再実行する。
+- **synthetic な reproducer は再現性が低い**: 手で同じ shape の `entity.NoteEntity` を組み立てても
+  panic しないケースがある (#542 調査結果)。実 DB の packed entity を経由する必要がある。
+
+## 削除条件
+
+`internal/server/json_serializer.go` が goccy 以外 (例: jsoniter / encoding/json 永続) に
+切り替わって、本ツールが追う対象 (= goccy 静的コンパイルバグ) が消えたら削除して良い。
+それまでは似た encoder バグの triage に再利用できる。

--- a/cmd/dbgtimeline/README.md
+++ b/cmd/dbgtimeline/README.md
@@ -80,6 +80,12 @@ Total panicking notes: 5
 
 ## 削除条件
 
-`internal/server/json_serializer.go` が goccy 以外 (例: jsoniter / encoding/json 永続) に
-切り替わって、本ツールが追う対象 (= goccy 静的コンパイルバグ) が消えたら削除して良い。
-それまでは似た encoder バグの triage に再利用できる。
+現状 (#546 マージ後) production の `internal/server/json_serializer.go` は **stdlib `encoding/json` に巻き戻し済**で、本ツールが直接 goccy を import するのは「将来 goccy / jsoniter 等の高速 encoder に再度乗り換える時に同じバグを踏まないか確認する」用途。
+
+以下のいずれかが起きたら削除候補:
+
+- 高速 encoder への乗り換えが検討対象から完全に外れて、stdlib `encoding/json` 永続使用が確定した
+- 別 issue で encoder bug triage 用の永続的な仕組み (e.g., entity 単体テストでの fuzz) が整備された
+- ツールの import 先 (`gojson`) を別の候補 encoder (jsoniter 等) に置き換えても trigger が再現しないことが確認された
+
+つまり「production が現状 stdlib」即削除ではない。encoder swap の意思決定が固まるまで triage 道具として温存する想定。

--- a/cmd/dbgtimeline/README.md
+++ b/cmd/dbgtimeline/README.md
@@ -15,7 +15,7 @@ DB は `SELECT` のみ。書き込み一切なし。production-like UDS DB に�
 ## 由来
 
 [#542](https://github.com/shiroha-a/mk/issues/542) (goccy 0.10.6 の `ptrToString` panic) を
-追跡するために作った。トリガー note を特定したあと、汎用デバッグ ツールとして残してある。
+追跡するために作った。トリガー note を特定したあと、汎用デバッグツールとして残してある。
 将来「特定の timeline で encoder panic が出る」報告が来たら、同じ手順で切り分けられる。
 
 ## 使い方
@@ -57,8 +57,8 @@ docker compose -f compose.uds.yaml exec mkgo \
 ```
 Loaded 200 notes
 Using viewer: alice (id=al9hjjx4b0ey0002)
-PANIC at index=1 note.id=alng2ov5ffpp0007 userHost=remote.example visibility=public renoteId=0xc0003c58e0
-PANIC at index=85 note.id=alm00w90sjj8000w userHost=remote.example visibility=public renoteId=0xc000463e90
+PANIC at index=1 note.id=alng2ov5ffpp0007 userHost=remote.example visibility=public renoteId=alng2ov5ffpp0003
+PANIC at index=85 note.id=alm00w90sjj8000w userHost=remote.example visibility=public renoteId=alm00w90sjj80005
 ...
 Total panicking notes: 5
 

--- a/cmd/dbgtimeline/main.go
+++ b/cmd/dbgtimeline/main.go
@@ -1,0 +1,191 @@
+// Command dbgtimeline is a debug helper that reproduces (or hunts for)
+// JSON-encoder panics on the home/global timeline path. It loads recent
+// notes from a live PostgreSQL DB, packs them through `entity.PackNotes`
+// + `entity.NoteFieldResolver` exactly as the timeline endpoint does,
+// then attempts to encode the result via goccy/go-json — recovering each
+// panic so the offending note can be identified.
+//
+// Originally written to track down the goccy 0.10.6 ptrToString crash on
+// remote Renote-with-Files notes (see docs/dbg-timeline.md and #542).
+// Kept around as a generic debug tool: any future "encoder panics on
+// timeline" report can be triaged with this same flow.
+//
+// Read-only: only SELECT queries via gorm.Find / repository read methods
+// are issued. Safe to point at a production-like DB. Never writes.
+//
+// See cmd/dbgtimeline/README.md for invocation examples.
+package main
+
+import (
+	stdjson "encoding/json"
+	"flag"
+	"fmt"
+	"os"
+
+	gojson "github.com/goccy/go-json"
+	"github.com/shiroha-a/mk/internal/config"
+	"github.com/shiroha-a/mk/internal/entity"
+	"github.com/shiroha-a/mk/internal/misc/id"
+	"github.com/shiroha-a/mk/internal/model"
+	"github.com/shiroha-a/mk/internal/repository"
+	"gorm.io/driver/postgres"
+	"gorm.io/gorm"
+)
+
+func main() {
+	cfgPath := flag.String("config", "/app/.config/default.yml", "path to mk-go config file")
+	limit := flag.Int("limit", 200, "max notes to scan")
+	viewerName := flag.String("viewer", "", "username (lowercased) used to populate viewer-dependent fields like MyReaction; empty = nil viewer")
+	bisect := flag.Bool("bisect", false, "binary-search the slice to narrow down the panic-triggering index range")
+	dump := flag.Bool("dump", false, "deep-dump packed entity for the first panicking note (stdlib JSON, never touches goccy)")
+	flag.Parse()
+
+	cfg, err := config.Load(*cfgPath)
+	if err != nil {
+		die("load config: %v", err)
+	}
+	dsn := fmt.Sprintf("host=%s port=%d user=%s password=%s dbname=%s sslmode=disable",
+		cfg.DB.Host, cfg.DB.Port, cfg.DB.User, cfg.DB.Pass, cfg.DB.DB)
+	db, err := gorm.Open(postgres.Open(dsn), &gorm.Config{})
+	if err != nil {
+		die("open db: %v", err)
+	}
+	idGen, err := id.NewGenerator("aidx")
+	if err != nil {
+		die("idGen: %v", err)
+	}
+
+	noteRepo := repository.NewNoteRepository(db)
+	userRepo := repository.NewUserRepository(db)
+	instanceRepo := repository.NewInstanceRepository(db)
+	emojiRepo := repository.NewEmojiRepository(db)
+	driveFileRepo := repository.NewDriveFileRepository(db)
+	driveFolderRepo := repository.NewDriveFolderRepository(db)
+	noteReactionRepo := repository.NewNoteReactionRepository(db)
+	channelRepo := repository.NewChannelRepository(db)
+
+	// 全 visibility / 全 host を含む幅広いサンプル。実際の global timeline は
+	// public + channel=null だが、bug は home (followers / specified) でも
+	// 出る報告があるので幅広く取る。read-only な Find のみ。
+	var notes []*model.Note
+	if err := db.Order(`"id" DESC`).Limit(*limit).Find(&notes).Error; err != nil {
+		die("load notes: %v", err)
+	}
+
+	// Hydrate via repo so preload chain matches timeline path
+	// (NoteFieldResolver.Apply は preload された Renote.User 等を頼る)。
+	hydrated := make([]*model.Note, 0, len(notes))
+	for _, n := range notes {
+		h, err := noteRepo.FindByIDWithRelations(n.ID)
+		if err != nil || h == nil {
+			continue
+		}
+		hydrated = append(hydrated, h)
+	}
+	notes = hydrated
+	fmt.Printf("Loaded %d notes\n", len(notes))
+
+	packed := entity.PackNotes(notes, idGen, instanceRepo, emojiRepo)
+	resolver := entity.NewNoteFieldResolver(driveFileRepo, driveFolderRepo, userRepo, noteReactionRepo, channelRepo, idGen)
+
+	var viewer *model.User
+	if *viewerName != "" {
+		if u, err := userRepo.FindByUsernameLower(*viewerName, nil); err == nil {
+			viewer = u
+			fmt.Printf("Using viewer: %s (id=%s)\n", u.Username, u.ID)
+		} else {
+			fmt.Printf("Viewer %q not found, encoding with nil viewer\n", *viewerName)
+		}
+	}
+	resolver.Apply(packed, viewer)
+
+	// Per-note encode で panic 起こす index を列挙。tryEncode は recover する
+	// が、goccy の VM 状態が後続呼び出しで悪化することがあるので fatal で
+	// プロセス死ぬケースに備えて発見都度 print する。
+	failed := []int{}
+	for i := range packed {
+		one := packed[i : i+1]
+		if err := tryEncode(one); err != nil {
+			failed = append(failed, i)
+			fmt.Printf("PANIC at index=%d note.id=%s userHost=%s visibility=%s renoteId=%v\n",
+				i, notes[i].ID, derefStr(notes[i].UserHost), notes[i].Visibility, notes[i].RenoteID)
+		}
+	}
+	if len(failed) == 0 {
+		fmt.Println("No panic detected on per-note encode")
+	} else {
+		fmt.Printf("Total panicking notes: %d\n", len(failed))
+	}
+
+	if *bisect && len(failed) > 0 {
+		fmt.Println("\n--- Slice bisect (find smallest panicking range) ---")
+		bisectSlice(packed, 0, len(packed))
+	}
+
+	if *dump && len(failed) > 0 {
+		fmt.Println("\n--- Deep dump of first panicking note (stdlib) ---")
+		fmt.Println(spew(packed[failed[0]]))
+	}
+}
+
+// tryEncode runs gojson.Encode on v (matching the production
+// json_serializer.go fast path) and converts panics to errors so the
+// caller can keep iterating across many candidates. NOTE: goccy panics
+// occasionally escalate to runtime.fatal which recover() cannot catch —
+// the caller should be prepared for the process to die mid-loop.
+func tryEncode(v any) (err error) {
+	defer func() {
+		if r := recover(); r != nil {
+			err = fmt.Errorf("panic: %v", r)
+		}
+	}()
+	return gojson.NewEncoder(devNull{}).Encode(v)
+}
+
+type devNull struct{}
+
+func (devNull) Write(p []byte) (int, error) { return len(p), nil }
+
+// bisectSlice narrows down which contiguous range of `s` triggers a
+// goccy panic. Recurses into halves that fail. Single-element ranges
+// are reported with their note id for further investigation.
+func bisectSlice(s []entity.NoteEntity, lo, hi int) {
+	if hi-lo <= 1 {
+		one := s[lo : lo+1]
+		err := tryEncode(one)
+		fmt.Printf("[single index=%d] err=%v id=%s\n", lo, err, s[lo].ID)
+		return
+	}
+	mid := (lo + hi) / 2
+	leftErr := tryEncode(s[lo:mid])
+	rightErr := tryEncode(s[mid:hi])
+	fmt.Printf("[bisect lo=%d mid=%d hi=%d] left err=%v / right err=%v\n", lo, mid, hi, leftErr, rightErr)
+	if leftErr != nil {
+		bisectSlice(s, lo, mid)
+	}
+	if rightErr != nil {
+		bisectSlice(s, mid, hi)
+	}
+}
+
+// spew pretty-prints v via the standard library encoder. Intentionally
+// avoids goccy so the dump is safe even when goccy is what's panicking.
+func spew(v any) string {
+	b, err := stdjson.MarshalIndent(v, "", "  ")
+	if err != nil {
+		return fmt.Sprintf("ERR: %v", err)
+	}
+	return string(b)
+}
+
+func derefStr(p *string) string {
+	if p == nil {
+		return "<nil>"
+	}
+	return *p
+}
+
+func die(format string, args ...any) {
+	fmt.Fprintf(os.Stderr, format+"\n", args...)
+	os.Exit(1)
+}

--- a/cmd/dbgtimeline/main.go
+++ b/cmd/dbgtimeline/main.go
@@ -44,9 +44,10 @@ func main() {
 	if err != nil {
 		die("load config: %v", err)
 	}
-	dsn := fmt.Sprintf("host=%s port=%d user=%s password=%s dbname=%s sslmode=disable",
-		cfg.DB.Host, cfg.DB.Port, cfg.DB.User, cfg.DB.Pass, cfg.DB.DB)
-	db, err := gorm.Open(postgres.Open(dsn), &gorm.Config{})
+	// cfg.DSN() は UDS path / SSL extra も honoring する production と
+	// 同じ DSN 構築経路。本ツールが production-shape の config を
+	// そのまま受け取れるようにこれに揃える (#545 review)。
+	db, err := gorm.Open(postgres.Open(cfg.DSN()), &gorm.Config{})
 	if err != nil {
 		die("open db: %v", err)
 	}

--- a/cmd/dbgtimeline/main.go
+++ b/cmd/dbgtimeline/main.go
@@ -90,6 +90,13 @@ func main() {
 	fmt.Printf("Loaded %d notes\n", len(notes))
 
 	packed := entity.PackNotes(notes, idGen, instanceRepo, emojiRepo)
+	// PackNotes は notes 1 件ごとに必ず 1 件の packed entity を append する
+	// 契約 (内部実装は internal/entity/note.go の PackNotes を参照)。後続
+	// ループで notes[i] と packed[i] を 1:1 対応で参照するため、契約破綻時
+	// は静かに index ずれを起こすより die で早期検出する (#545 review)。
+	if len(packed) != len(notes) {
+		die("invariant broken: len(packed)=%d != len(notes)=%d (PackNotes filtered entries?)", len(packed), len(notes))
+	}
 	resolver := entity.NewNoteFieldResolver(driveFileRepo, driveFolderRepo, userRepo, noteReactionRepo, channelRepo, idGen)
 
 	var viewer *model.User

--- a/cmd/dbgtimeline/main.go
+++ b/cmd/dbgtimeline/main.go
@@ -6,7 +6,7 @@
 // panic so the offending note can be identified.
 //
 // Originally written to track down the goccy 0.10.6 ptrToString crash on
-// remote Renote-with-Files notes (see docs/dbg-timeline.md and #542).
+// remote Renote-with-Files notes (see cmd/dbgtimeline/README.md and #542).
 // Kept around as a generic debug tool: any future "encoder panics on
 // timeline" report can be triaged with this same flow.
 //
@@ -50,9 +50,13 @@ func main() {
 	if err != nil {
 		die("open db: %v", err)
 	}
-	idGen, err := id.NewGenerator("aidx")
+	idType := cfg.ID
+	if idType == "" {
+		idType = "aidx"
+	}
+	idGen, err := id.NewGenerator(idType)
 	if err != nil {
-		die("idGen: %v", err)
+		die("idGen (%q): %v", idType, err)
 	}
 
 	noteRepo := repository.NewNoteRepository(db)
@@ -107,8 +111,8 @@ func main() {
 		one := packed[i : i+1]
 		if err := tryEncode(one); err != nil {
 			failed = append(failed, i)
-			fmt.Printf("PANIC at index=%d note.id=%s userHost=%s visibility=%s renoteId=%v\n",
-				i, notes[i].ID, derefStr(notes[i].UserHost), notes[i].Visibility, notes[i].RenoteID)
+			fmt.Printf("PANIC at index=%d note.id=%s userHost=%s visibility=%s renoteId=%s\n",
+				i, notes[i].ID, derefStr(notes[i].UserHost), notes[i].Visibility, derefStr(notes[i].RenoteID))
 		}
 	}
 	if len(failed) == 0 {

--- a/cmd/dbgtimeline/main.go
+++ b/cmd/dbgtimeline/main.go
@@ -76,7 +76,7 @@ func main() {
 		die("load notes: %v", err)
 	}
 
-	// Hydrate via repo so preload chain matches timeline path
+	// repo 経由で hydrate して timeline 経路と同じ preload chain を再現する
 	// (NoteFieldResolver.Apply は preload された Renote.User 等を頼る)。
 	hydrated := make([]*model.Note, 0, len(notes))
 	for _, n := range notes {


### PR DESCRIPTION
## Summary

#542 (goccy 0.10.6 の `ptrToString` panic on home/global timeline) を追跡するために作ったデバッグヘルパー。今回の調査でトリガー note を特定したあと、汎用の triage ツールとして残しておく。将来「特定の timeline で encoder panic が出る」報告が来たら、同じ手順で切り分けに使える。

Refs #542

## 主な内容

### `cmd/dbgtimeline/main.go`

- mk-go と同じ DSN で PostgreSQL に接続して **read-only** で最近の note を取得
- `entity.PackNotes` + `NoteFieldResolver.Apply` を実 timeline 経路と同じ手順で適用
- 各 packed `NoteEntity` を goccy/go-json `Encoder.Encode` に流して panic / fatal を recover、どの note で発火したか列挙
- `-bisect`: 二分探索で panic 範囲を絞る
- `-dump`: 原因 entity を stdlib JSON で deep-print

DB 操作は `SELECT` のみ (gorm `Find` / repository read methods)。production-like UDS DB に向けても安全。

### `cmd/dbgtimeline/README.md`

- 何が出来るか / 由来 (#542)
- ローカル & Docker 経由 (UDS 環境向け) の使い方
- フラグ (`-config` / `-limit` / `-viewer` / `-bisect` / `-dump`)
- 出力例
- 既知の制約 (goccy fatal は recover 不可 / synthetic な reproducer は再現性低い)
- 削除条件 (`internal/server/json_serializer.go` が goccy 以外に切り替わったら不要)

## テスト

production binary とは無関係の debug 用ツールなので unit test は付けていません。`go build ./cmd/dbgtimeline/...` / `go vet ./cmd/dbgtimeline/...` は pass。

## その他

`internal/server/json_serializer.go` を stdlib `encoding/json` に戻す暫定対応 (#542 暫定 fix) は本 PR には含めず、別 PR で出す予定。本 PR は読み取り専用ツールの追加だけ。
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/shiroha-a/mk/pull/545" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
