### PR TITLE
Fix #542: revert echo JSON serializer to stdlib encoding/json

### DIFF
--- a/internal/server/json_serializer.go
+++ b/internal/server/json_serializer.go
@@ -1,27 +1,25 @@
 package server
 
 import (
+	"encoding/json"
 	"errors"
 	"fmt"
 	"net/http"
 
-	gojson "github.com/goccy/go-json"
 	"github.com/labstack/echo/v4"
 )
 
-// fastJSONSerializer is the echo.JSONSerializer implementation backed by
-// goccy/go-json. echo の `c.JSON()` / `c.Bind()` 経路を全て差し替えるため、
-// ハンドラ側のコードはそのまま動かしつつ encoding/json の reflection cost を
-// 減らせる (#507 / #413 #2)。
-//
-// stdlib の DefaultJSONSerializer と同じく、Decode 時の TypeError /
-// SyntaxError を 400 BadRequest に翻訳して echo の error pipeline に流す。
+// fastJSONSerializer was previously backed by goccy/go-json (#507) but
+// goccy v0.10.6 panics with `ptrToString` nil-deref on certain hot path
+// payloads (timeline notes containing remote users). 一旦 stdlib
+// `encoding/json` に戻して安定運用、performance 改善は別 issue で
+// goccy 上げ or 別 encoder 検討。
 type fastJSONSerializer struct{}
 
 // Serialize writes i as JSON to the response. indent が空でなければ
 // pretty-print する (echo 標準と同じセマンティクス)。
 func (fastJSONSerializer) Serialize(c echo.Context, i interface{}, indent string) error {
-	enc := gojson.NewEncoder(c.Response())
+	enc := json.NewEncoder(c.Response())
 	if indent != "" {
 		enc.SetIndent("", indent)
 	}
@@ -31,17 +29,14 @@ func (fastJSONSerializer) Serialize(c echo.Context, i interface{}, indent string
 // Deserialize parses request body JSON into i. 不正な JSON は echo の
 // HTTPError(400) に翻訳し、そのまま返すと echo の error handler に渡る。
 func (fastJSONSerializer) Deserialize(c echo.Context, i interface{}) error {
-	if err := gojson.NewDecoder(c.Request().Body).Decode(i); err != nil {
-		// goccy/go-json は stdlib 互換の errorタイプを返すので、
-		// errors.As で TypeError / SyntaxError を取り出して echo HTTPError
-		// に整形する。stdlib DefaultJSONSerializer と同じ挙動。
-		var ute *gojson.UnmarshalTypeError
+	if err := json.NewDecoder(c.Request().Body).Decode(i); err != nil {
+		var ute *json.UnmarshalTypeError
 		if errors.As(err, &ute) {
 			return echo.NewHTTPError(http.StatusBadRequest,
 				fmt.Sprintf("Unmarshal type error: expected=%v, got=%v, field=%v, offset=%v",
 					ute.Type, ute.Value, ute.Field, ute.Offset)).SetInternal(err)
 		}
-		var se *gojson.SyntaxError
+		var se *json.SyntaxError
 		if errors.As(err, &se) {
 			return echo.NewHTTPError(http.StatusBadRequest,
 				fmt.Sprintf("Syntax error: offset=%v, error=%v", se.Offset, se.Error())).SetInternal(err)

--- a/internal/server/json_serializer_test.go
+++ b/internal/server/json_serializer_test.go
@@ -12,8 +12,10 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// withSerializer prepares an echo.Context with the goccy-backed serializer
-// installed, mimicking what server.New does at boot.
+// withSerializer prepares an echo.Context with the fastJSONSerializer
+// installed, mimicking what server.New does at boot. Currently backed by
+// stdlib encoding/json (#542 で goccy 0.10.x の VM compile bug が
+// timeline 経路で踏まれたため一時的に巻き戻し)。
 func withSerializer(body string) (echo.Context, *httptest.ResponseRecorder) {
 	e := echo.New()
 	e.JSONSerializer = fastJSONSerializer{}


### PR DESCRIPTION
## Summary

home / global / hybrid timeline (`/api/notes/timeline` 等) が goccy/go-json 0.10.x の VM compile bug で panic していた問題の暫定 fix。echo の `JSONSerializer` を stdlib `encoding/json` に戻す。

Closes #542 (暫定対応)

## 背景

`git bisect` で **goccy 切替コミット (003cd7a / PR #507) が直接の引き金**と確定済。バージョンを v0.10.6 → v0.10.5 → v0.10.4 → v0.10.3 と段階的に下げても再現したため、goccy 系全体で同じ静的コンパイルバグを踏んでいる。

引き金 shape は #542 コメントで特定済:

```
NoteEntity
└── Renote *NoteEntity
    └── Files [df]
        └── DriveFileEntity
            └── User *UserLite
                ├── AvatarDecorations []AvatarDecorationItem  ← 非 nil 空 slice
                └── Emojis            map[string]string       ← 非 nil 空 map
```

= **画像付きリモート投稿を Renote した時** に発火する深い nest 構造で、mk-go の data shape では避けようがない。

## 主な変更点

- `internal/server/json_serializer.go`: `gojson.NewEncoder` / `gojson.NewDecoder` を stdlib `encoding/json` に置換。`fastJSONSerializer` 型名は維持して差分を最小化。
- `internal/server/json_serializer_test.go`: doc comment を「goccy-backed」→「stdlib」に更新。

`go.mod` / `go.sum` は触っていない (本 PR 後にマージ予定の #545 (dbgtimeline) が goccy を import するため、direct dep として残しておく)。`go mod tidy` を後で回せば再評価できる。

## テスト

- `make fmt && make lint && go test ./internal/server/...` 全 pass
- UDS で home/global timeline が panic せず正常に表示される (#542 reproduction が消えた) ことを確認済

## Perf 影響

#413 #2 で測った encoding/json → goccy の 1.2-1.5x perf 改善は本 PR で巻き戻る。代替 encoder (jsoniter 等) への乗り換え or goccy upstream fix 待ち or `MarshalJSON()` 個別実装で回避、のいずれかで perf を取り戻す方針 (別 issue で議論)。

## 関連

- #542 (本 issue, root cause analysis あり)
- PR #507 / commit 003cd7a (goccy 切替 = 引き金)
- PR #545 (dbgtimeline 切り分けツール、本 fix の調査で作成)
- #413 #2 (元の perf 改善ロードマップ)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/shiroha-a/mk/pull/546" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
