### PR TITLE
Perf #300 1-5: batch mention resolution in note create

### DIFF
--- a/internal/api/resetpassword/handler_test.go
+++ b/internal/api/resetpassword/handler_test.go
@@ -91,6 +91,10 @@ func (m *mockUserRepo) FindManyByIDs([]string) ([]*model.User, error) {
 	return nil, nil
 }
 
+func (m *mockUserRepo) FindManyByUsernamesAndHost([]string, *string) ([]*model.User, error) {
+	return nil, nil
+}
+
 func (m *mockUserRepo) FindProfilesByUserIDs([]string) ([]*model.UserProfile, error) {
 	return nil, nil
 }

--- a/internal/core/note/note_create_service.go
+++ b/internal/core/note/note_create_service.go
@@ -448,15 +448,40 @@ func (s *CreateService) Create(in CreateInput) (*model.Note, error) {
 		if s.userRepo != nil {
 			mentions := ExtractMentionStructs(*in.Text)
 			if len(mentions) > 0 {
-				ids := make([]string, 0, len(mentions))
+				// host ごとに 1 query にまとめる (#300 1-5)。
+				// 元実装は mention 数 N に対して N 回 FindByUsernameLower を
+				// 直列に叩いていたが、host 単位で IN(?) にしてラウンドトリップ
+				// を host 種類数まで削減する。
+				byHost := make(map[string][]string)
 				for _, m := range mentions {
-					var host *string
-					if m.Host != "" {
-						h := m.Host
-						host = &h
+					byHost[m.Host] = append(byHost[m.Host], m.Username)
+				}
+				// resolved[host][usernameLower] = userID
+				resolved := make(map[string]map[string]string, len(byHost))
+				for host, names := range byHost {
+					var hostPtr *string
+					if host != "" {
+						h := host
+						hostPtr = &h
 					}
-					if u, err := s.userRepo.FindByUsernameLower(m.Username, host); err == nil {
-						ids = append(ids, u.ID)
+					users, err := s.userRepo.FindManyByUsernamesAndHost(names, hostPtr)
+					if err != nil {
+						// 1 host の lookup 失敗は当該 host の mention を
+						// 諦めて後続を続行する (元実装も err 時 skip だった)。
+						continue
+					}
+					m := make(map[string]string, len(users))
+					for _, u := range users {
+						m[u.UsernameLower] = u.ID
+					}
+					resolved[host] = m
+				}
+				ids := make([]string, 0, len(mentions))
+				for _, mn := range mentions {
+					if hostMap, ok := resolved[mn.Host]; ok {
+						if id, ok := hostMap[strings.ToLower(mn.Username)]; ok {
+							ids = append(ids, id)
+						}
 					}
 				}
 				note.Mentions = ids

--- a/internal/core/note/note_create_service_test.go
+++ b/internal/core/note/note_create_service_test.go
@@ -206,6 +206,116 @@ func TestCreateService_MentionResolution_WithUserRepo(t *testing.T) {
 	assert.ElementsMatch(t, []string{"uA", "uB"}, []string(created.Mentions))
 }
 
+// countingUserRepo wraps MockUserRepository to assert that mention resolution
+// issues at most one repo round-trip per host (#300 1-5).
+type countingUserRepo struct {
+	*testutil.MockUserRepository
+	calls atomic.Int64
+}
+
+func (c *countingUserRepo) FindManyByUsernamesAndHost(usernames []string, host *string) ([]*model.User, error) {
+	c.calls.Add(1)
+	return c.MockUserRepository.FindManyByUsernamesAndHost(usernames, host)
+}
+
+// 全 mention が local 単一 host のとき、host 種類 = 1 なので
+// FindManyByUsernamesAndHost は 1 回しか呼ばれない (#300 1-5)。
+func TestCreateService_MentionResolution_SingleQueryForLocalOnly(t *testing.T) {
+	svc, _, _ := newCreateService(t)
+	mock := testutil.NewMockUserRepository()
+	mock.Users["uA"] = &model.User{ID: "uA", UsernameLower: "alice"}
+	mock.Users["uB"] = &model.User{ID: "uB", UsernameLower: "bob"}
+	mock.Users["uC"] = &model.User{ID: "uC", UsernameLower: "carol"}
+	repo := &countingUserRepo{MockUserRepository: mock}
+	svc.SetUserRepo(repo)
+
+	author := &model.User{ID: "author1"}
+	text := "hi @alice and @bob and @carol"
+	created, err := svc.Create(note.CreateInput{User: author, Text: &text})
+	require.NoError(t, err)
+	assert.ElementsMatch(t, []string{"uA", "uB", "uC"}, []string(created.Mentions))
+	assert.Equal(t, int64(1), repo.calls.Load(),
+		"3 local mentions must be resolved with a single batch query")
+}
+
+// host 種類数だけ batch query が走る。host 内の mention 数には依存しない。
+func TestCreateService_MentionResolution_OneQueryPerHost(t *testing.T) {
+	svc, _, _ := newCreateService(t)
+	mock := testutil.NewMockUserRepository()
+	hostA := "a.example"
+	hostB := "b.example"
+	mock.Users["uLocal"] = &model.User{ID: "uLocal", UsernameLower: "alice"}
+	mock.Users["uA1"] = &model.User{ID: "uA1", UsernameLower: "bob", Host: &hostA}
+	mock.Users["uA2"] = &model.User{ID: "uA2", UsernameLower: "carol", Host: &hostA}
+	mock.Users["uB1"] = &model.User{ID: "uB1", UsernameLower: "dave", Host: &hostB}
+	repo := &countingUserRepo{MockUserRepository: mock}
+	svc.SetUserRepo(repo)
+
+	author := &model.User{ID: "author1"}
+	text := "@alice @bob@a.example @carol@a.example @dave@b.example"
+	created, err := svc.Create(note.CreateInput{User: author, Text: &text})
+	require.NoError(t, err)
+	assert.ElementsMatch(t,
+		[]string{"uLocal", "uA1", "uA2", "uB1"},
+		[]string(created.Mentions))
+	// 3 distinct hosts: local + a.example + b.example
+	assert.Equal(t, int64(3), repo.calls.Load(),
+		"4 mentions across 3 hosts must batch into 3 queries (one per host)")
+}
+
+// mention の出現順は note.Mentions の順序にそのまま反映される。
+func TestCreateService_MentionResolution_PreservesOrder(t *testing.T) {
+	svc, _, _ := newCreateService(t)
+	userRepo := testutil.NewMockUserRepository()
+	hostA := "a.example"
+	userRepo.Users["uA"] = &model.User{ID: "uA", UsernameLower: "alice"}
+	userRepo.Users["uB"] = &model.User{ID: "uB", UsernameLower: "bob", Host: &hostA}
+	userRepo.Users["uC"] = &model.User{ID: "uC", UsernameLower: "carol"}
+	svc.SetUserRepo(userRepo)
+
+	author := &model.User{ID: "author1"}
+	// alice → bob@remote → carol を期待。
+	text := "@alice then @bob@a.example then @carol"
+	created, err := svc.Create(note.CreateInput{User: author, Text: &text})
+	require.NoError(t, err)
+	assert.Equal(t, []string{"uA", "uB", "uC"}, []string(created.Mentions))
+}
+
+// FindManyByUsernamesAndHost が err を返した host は当該 mention だけ
+// drop される (元実装と同等)。他 host の解決は影響を受けない。
+func TestCreateService_MentionResolution_FailedHostIsSkipped(t *testing.T) {
+	svc, _, _ := newCreateService(t)
+	mock := testutil.NewMockUserRepository()
+	hostA := "a.example"
+	mock.Users["uLocal"] = &model.User{ID: "uLocal", UsernameLower: "alice"}
+	mock.Users["uA1"] = &model.User{ID: "uA1", UsernameLower: "bob", Host: &hostA}
+	repo := &flakyUserRepo{
+		MockUserRepository: mock,
+		failHost:           hostA,
+	}
+	svc.SetUserRepo(repo)
+
+	author := &model.User{ID: "author1"}
+	text := "@alice and @bob@a.example"
+	created, err := svc.Create(note.CreateInput{User: author, Text: &text})
+	require.NoError(t, err)
+	// hostA が err なので uA1 は drop、ローカルの uLocal だけ残る。
+	assert.Equal(t, []string{"uLocal"}, []string(created.Mentions))
+}
+
+// flakyUserRepo は指定 host の FindManyByUsernamesAndHost で err を返す。
+type flakyUserRepo struct {
+	*testutil.MockUserRepository
+	failHost string
+}
+
+func (f *flakyUserRepo) FindManyByUsernamesAndHost(usernames []string, host *string) ([]*model.User, error) {
+	if host != nil && *host == f.failHost {
+		return nil, stubError
+	}
+	return f.MockUserRepository.FindManyByUsernamesAndHost(usernames, host)
+}
+
 func TestCreateService_NoteRepoCreateError(t *testing.T) {
 	idGen, _ := id.NewGenerator("aidx")
 	noteRepo := &failingNoteRepoCreate{MockNoteRepository: testutil.NewMockNoteRepository()}

--- a/internal/core/retention/service_test.go
+++ b/internal/core/retention/service_test.go
@@ -68,7 +68,10 @@ func (s *stubUserRepo) CountLocalUsersActiveSince(time.Time) (int64, error)   { 
 func (s *stubUserRepo) ListUserRecommendations(string, time.Time, int, int) ([]*model.User, error) {
 	return nil, nil
 }
-func (s *stubUserRepo) FindManyByIDs([]string) ([]*model.User, error)                { return nil, nil }
+func (s *stubUserRepo) FindManyByIDs([]string) ([]*model.User, error) { return nil, nil }
+func (s *stubUserRepo) FindManyByUsernamesAndHost([]string, *string) ([]*model.User, error) {
+	return nil, nil
+}
 func (s *stubUserRepo) FindProfilesByUserIDs([]string) ([]*model.UserProfile, error) { return nil, nil }
 
 type stubRetentionRepo struct {

--- a/internal/repository/user.go
+++ b/internal/repository/user.go
@@ -1,6 +1,7 @@
 package repository
 
 import (
+	"strings"
 	"time"
 
 	"github.com/shiroha-a/mk/internal/model"
@@ -22,6 +23,12 @@ type UserRepository interface {
 	// FindProfilesByUserIDs returns user_profile rows for the given userId
 	// set in a single query. Order is unspecified; missing rows are skipped.
 	FindProfilesByUserIDs(userIDs []string) ([]*model.UserProfile, error)
+	// FindManyByUsernamesAndHost returns users matching any of the given
+	// (case-insensitive) usernames within a single host scope. host=nil
+	// targets local users (host IS NULL); otherwise host must equal the
+	// supplied value. Used by note-create mention resolution to batch the
+	// FindByUsernameLower per-mention loop into one query per host (#300 1-5).
+	FindManyByUsernamesAndHost(usernames []string, host *string) ([]*model.User, error)
 	IncrementFollowingCount(userID string, delta int) error
 	IncrementFollowersCount(userID string, delta int) error
 	SearchByUsername(query string, limit, offset int) ([]*model.User, error)
@@ -103,6 +110,32 @@ func (r *userRepository) FindByUsernameLower(username string, host *string) (*mo
 		return nil, err
 	}
 	return &user, nil
+}
+
+// FindManyByUsernamesAndHost batches the case-insensitive username lookup
+// for one host scope. Empty input returns nil. PostgreSQL の `lower(unnest)`
+// 比較で IN(?) 相当を 1 query にまとめる (#300 1-5)。
+func (r *userRepository) FindManyByUsernamesAndHost(usernames []string, host *string) ([]*model.User, error) {
+	if len(usernames) == 0 {
+		return nil, nil
+	}
+	// usernameLower 列に格納されている値と比較したいので、引数側を lower
+	// 化して IN マッチさせる。usernames が大文字混在でも一括で正規化される。
+	lowered := make([]string, len(usernames))
+	for i, u := range usernames {
+		lowered[i] = strings.ToLower(u)
+	}
+	q := r.db.Where(`"usernameLower" IN ?`, lowered)
+	if host != nil {
+		q = q.Where("host = ?", *host)
+	} else {
+		q = q.Where("host IS NULL")
+	}
+	var users []*model.User
+	if err := q.Find(&users).Error; err != nil {
+		return nil, err
+	}
+	return users, nil
 }
 
 func (r *userRepository) FindProfileByUserID(userID string) (*model.UserProfile, error) {

--- a/internal/repository/user_test.go
+++ b/internal/repository/user_test.go
@@ -247,6 +247,75 @@ func TestUserRepository_FindProfilesByUserIDs_Error(t *testing.T) {
 	assert.Error(t, err)
 }
 
+func TestUserRepository_FindManyByUsernamesAndHost_Local(t *testing.T) {
+	repo := NewUserRepository(testDB)
+	u1 := insertTestUser(t, "u_fmu_1", "alice")
+	u2 := insertTestUser(t, "u_fmu_2", "bob")
+	defer cleanupUser(t, u1.ID)
+	defer cleanupUser(t, u2.ID)
+
+	out, err := repo.FindManyByUsernamesAndHost([]string{"alice", "bob", "ghost"}, nil)
+	require.NoError(t, err)
+	got := map[string]bool{}
+	for _, u := range out {
+		got[u.ID] = true
+	}
+	assert.True(t, got[u1.ID])
+	assert.True(t, got[u2.ID])
+	assert.False(t, got["ghost"], "missing rows are skipped silently")
+}
+
+func TestUserRepository_FindManyByUsernamesAndHost_CaseInsensitive(t *testing.T) {
+	repo := NewUserRepository(testDB)
+	u := insertTestUser(t, "u_fmu_3", "carol")
+	defer cleanupUser(t, u.ID)
+
+	// 入力が大文字混じりでも usernameLower 列で正規化マッチする (#300 1-5)。
+	out, err := repo.FindManyByUsernamesAndHost([]string{"CAROL"}, nil)
+	require.NoError(t, err)
+	require.Len(t, out, 1)
+	assert.Equal(t, u.ID, out[0].ID)
+}
+
+func TestUserRepository_FindManyByUsernamesAndHost_RemoteScope(t *testing.T) {
+	repo := NewUserRepository(testDB)
+	hostA := "a.example.com"
+	hostB := "b.example.com"
+	uA := insertRemoteTestUser(t, "u_fmu_4", "dave", hostA)
+	uB := insertRemoteTestUser(t, "u_fmu_5", "dave", hostB)
+	uLocal := insertTestUser(t, "u_fmu_6", "dave")
+	defer cleanupUser(t, uA.ID)
+	defer cleanupUser(t, uB.ID)
+	defer cleanupUser(t, uLocal.ID)
+
+	// host=hostA のみ返る (同名だが host 違いの remote / local は除外)。
+	out, err := repo.FindManyByUsernamesAndHost([]string{"dave"}, &hostA)
+	require.NoError(t, err)
+	require.Len(t, out, 1)
+	assert.Equal(t, uA.ID, out[0].ID)
+
+	// host=nil のときは local のみ返る (remote 同名はマッチしない)。
+	out, err = repo.FindManyByUsernamesAndHost([]string{"dave"}, nil)
+	require.NoError(t, err)
+	require.Len(t, out, 1)
+	assert.Equal(t, uLocal.ID, out[0].ID)
+}
+
+func TestUserRepository_FindManyByUsernamesAndHost_Empty(t *testing.T) {
+	repo := NewUserRepository(testDB)
+	out, err := repo.FindManyByUsernamesAndHost(nil, nil)
+	require.NoError(t, err)
+	assert.Nil(t, out)
+}
+
+func TestUserRepository_FindManyByUsernamesAndHost_Error(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	repo := NewUserRepository(testDB.WithContext(ctx))
+	_, err := repo.FindManyByUsernamesAndHost([]string{"x"}, nil)
+	assert.Error(t, err)
+}
+
 func TestUserRepository_FindByUsernameLower_NotFound(t *testing.T) {
 	repo := NewUserRepository(testDB)
 

--- a/internal/testutil/mock_repository.go
+++ b/internal/testutil/mock_repository.go
@@ -79,6 +79,30 @@ func (m *MockUserRepository) FindByUsernameLower(username string, host *string) 
 	return nil, ErrNotFound
 }
 
+// FindManyByUsernamesAndHost mirrors the production repo: case-insensitive
+// match on usernameLower, scoped to a single host (nil = local-only).
+func (m *MockUserRepository) FindManyByUsernamesAndHost(usernames []string, host *string) ([]*model.User, error) {
+	if len(usernames) == 0 {
+		return nil, nil
+	}
+	want := make(map[string]struct{}, len(usernames))
+	for _, u := range usernames {
+		want[strings.ToLower(u)] = struct{}{}
+	}
+	out := make([]*model.User, 0, len(usernames))
+	for _, u := range m.Users {
+		if _, ok := want[u.UsernameLower]; !ok {
+			continue
+		}
+		if host == nil && u.Host == nil {
+			out = append(out, u)
+		} else if host != nil && u.Host != nil && *host == *u.Host {
+			out = append(out, u)
+		}
+	}
+	return out, nil
+}
+
 func (m *MockUserRepository) FindProfileByUserID(userID string) (*model.UserProfile, error) {
 	p, ok := m.Profiles[userID]
 	if !ok {


### PR DESCRIPTION
## Summary

`internal/core/note/note_create_service.go` の mention 解決ループは、テキスト中のメンション N 件に対して `FindByUsernameLower` を N 回直列で叩いていた (#547 / #300 1-5)。host 単位で 1 query にまとめる新規 batch メソッド `UserRepository.FindManyByUsernamesAndHost` を導入し、local / remote まとめて解決する。

クエリ削減: **N → host 種類数 H** (通常 1〜数件)。出現順 / dedup 挙動は `ExtractMentionStructs` のセマンティクスをそのまま維持する。

## 主な変更点

| ファイル | 内容 |
|---------|------|
| `internal/repository/user.go` | `FindManyByUsernamesAndHost` を追加。`usernameLower IN (?)` + `host IS NULL` または `host = ?` で host scope を厳密に絞る |
| `internal/core/note/note_create_service.go` | mention を `byHost` map にグルーピング → 各 host で 1 batch → `(host → usernameLower → userID)` map で解決。1 host が err でもその host 分だけ drop して後続を続行 (元実装と等価) |
| `internal/testutil/mock_repository.go` | `MockUserRepository.FindManyByUsernamesAndHost` を追加。case-insensitive / host scope を本物と同じく評価 |
| `internal/api/resetpassword/handler_test.go`, `internal/core/retention/service_test.go` | 別パッケージの mock UserRepository に no-op スタブを追加してインターフェース実装維持 |

## テスト

新規追加 (core/note):

- `TestCreateService_MentionResolution_SingleQueryForLocalOnly` — 3 local mention で repo 呼び出しが 1 回のみ
- `TestCreateService_MentionResolution_OneQueryPerHost` — local + 2 remote host で 3 回 (host 種類数)
- `TestCreateService_MentionResolution_PreservesOrder` — 出現順が `note.Mentions` に維持される
- `TestCreateService_MentionResolution_FailedHostIsSkipped` — 1 host が err でも他 host の解決は続行

新規追加 (repository):

- `TestUserRepository_FindManyByUsernamesAndHost_Local`
- `TestUserRepository_FindManyByUsernamesAndHost_CaseInsensitive`
- `TestUserRepository_FindManyByUsernamesAndHost_RemoteScope` (host=hostA / host=nil で別 user が返ることを担保)
- `TestUserRepository_FindManyByUsernamesAndHost_Empty`
- `TestUserRepository_FindManyByUsernamesAndHost_Error`

\`\`\`sh
go test -race -count=1 ./internal/core/note/ ./internal/testutil/ ./internal/api/resetpassword/ ./internal/core/retention/
ok
go vet ./... && gofmt -s -d . # clean
\`\`\`

## スコープ外

- 2-4 timeline fanout 二重ループ — 別 PR
- 3-3 user profile cache (Redis) — 別 PR
- 3-7 singleflight — 別 PR

Closes #547
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/shiroha-a/mk/pull/548" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
