### PR TITLE
Perf #300 2-4: merge follower fanout + streaming into a single pass

### DIFF
--- a/internal/core/timeline/fanout_hook.go
+++ b/internal/core/timeline/fanout_hook.go
@@ -188,7 +188,8 @@ func resolveCap(limits CacheLimits, kind TimelineKind) int {
 }
 
 // publishNote forwards the note to the StreamingPublisher when set. Best-
-// effort wrapper used by OnNoteCreated and fanoutToFollowers.
+// effort wrapper used by OnNoteCreated for non-follower topics; the per-
+// follower streaming publish is inlined in fanoutToFollowersAndStream.
 func (h *FanoutHook) publishNote(topic string, n *model.Note, author *model.User) {
 	if h.publisher == nil {
 		return
@@ -222,7 +223,7 @@ func (h *FanoutHook) fanoutToFollowersAndStream(ctx context.Context, authorID st
 	for {
 		rows, err := h.followingRepo.ListFollowers(authorID, pageSize, offset)
 		if err != nil {
-			slog.Warn("fanoutToFollowers: list followers failed", "err", err, "author", authorID)
+			slog.Warn("fanoutToFollowersAndStream: list followers failed", "err", err, "author", authorID)
 			return
 		}
 		if len(rows) == 0 {
@@ -304,8 +305,8 @@ func (h *FanoutHook) removeBestEffort(ctx context.Context, name Name, noteID str
 	}
 }
 
-// removeFromFollowerHomes mirrors fanoutToFollowers: page through followers and
-// LREM the note ID from each follower's home timeline list.
+// removeFromFollowerHomes mirrors fanoutToFollowersAndStream: page through
+// followers and LREM the note ID from each follower's home timeline list.
 func (h *FanoutHook) removeFromFollowerHomes(ctx context.Context, authorID, noteID string) {
 	const pageSize = 200
 	offset := 0

--- a/internal/core/timeline/fanout_hook.go
+++ b/internal/core/timeline/fanout_hook.go
@@ -112,8 +112,7 @@ func (h *FanoutHook) OnNoteCreated(n *model.Note, author *model.User) {
 	h.pushWithLimit(ctx, HomeTimelineName(author.ID), n.ID, homeCap)
 	h.publishNote("homeTimeline:"+author.ID, n, author)
 	if h.followingRepo != nil && shouldFanoutToFollowers(n) {
-		h.fanoutToFollowers(ctx, author.ID, n.ID, homeCap)
-		h.fanoutStreamingToFollowers(author.ID, n, author)
+		h.fanoutToFollowersAndStream(ctx, author.ID, n, author, homeCap)
 	}
 
 	// 3. ローカルタイムライン: ローカル投稿でvisibility=publicのみ。
@@ -207,10 +206,17 @@ func shouldFanoutToFollowers(n *model.Note) bool {
 	return false
 }
 
-// fanoutToFollowers iterates the author's followers in pages and pushes the
-// note id onto each follower's home timeline. homeCap は OnNoteCreated 側で
-// meta から取得済みのものを再利用する (per-follower で fetch しない)。
-func (h *FanoutHook) fanoutToFollowers(ctx context.Context, authorID, noteID string, homeCap int) {
+// fanoutToFollowersAndStream walks the author's followers once and, for each
+// follower, both pushes the note id onto the home timeline list and publishes
+// the note to the per-follower streaming topic.
+//
+// 旧実装は同じ followers ページネーションを Redis push 用と streaming publish
+// 用で 2 回繰り返しており、フォロワー数 N に対して `ListFollowers` の DB
+// クエリが 2N/pageSize 回走っていた (#300 2-4)。両者の per-row 操作はどちら
+// もベストエフォートで失敗が他方に波及しないため、1 ループに畳む方が安全か
+// つ DB 負荷半減になる。publisher 不在の場合だけ streaming step を skip する。
+// homeCap は OnNoteCreated 側で meta から取得済みのものを再利用する。
+func (h *FanoutHook) fanoutToFollowersAndStream(ctx context.Context, authorID string, n *model.Note, author *model.User, homeCap int) {
 	const pageSize = 200
 	offset := 0
 	for {
@@ -223,36 +229,10 @@ func (h *FanoutHook) fanoutToFollowers(ctx context.Context, authorID, noteID str
 			return
 		}
 		for _, f := range rows {
-			h.pushWithLimit(ctx, HomeTimelineName(f.FollowerID), noteID, homeCap)
-		}
-		if len(rows) < pageSize {
-			return
-		}
-		offset += pageSize
-	}
-}
-
-// fanoutStreamingToFollowers publishes the note to the per-follower
-// homeTimeline streaming topic. 別ループにすると DB を 2 回見る無駄があるが、
-// publish は best-effort で fan-out が成功した後に走らせる方が安全 (publish
-// 失敗が fan-out を巻き込まない)。フォロワー数が多い場合は将来 channel topic
-// の broadcast を 1 つに統合する余地あり。
-func (h *FanoutHook) fanoutStreamingToFollowers(authorID string, n *model.Note, author *model.User) {
-	if h.publisher == nil || h.followingRepo == nil {
-		return
-	}
-	const pageSize = 200
-	offset := 0
-	for {
-		rows, err := h.followingRepo.ListFollowers(authorID, pageSize, offset)
-		if err != nil {
-			return
-		}
-		if len(rows) == 0 {
-			return
-		}
-		for _, f := range rows {
-			h.publisher.PublishNote("homeTimeline:"+f.FollowerID, n, author)
+			h.pushWithLimit(ctx, HomeTimelineName(f.FollowerID), n.ID, homeCap)
+			if h.publisher != nil {
+				h.publisher.PublishNote("homeTimeline:"+f.FollowerID, n, author)
+			}
 		}
 		if len(rows) < pageSize {
 			return

--- a/internal/core/timeline/fanout_hook_test.go
+++ b/internal/core/timeline/fanout_hook_test.go
@@ -2,10 +2,12 @@ package timeline
 
 import (
 	"context"
+	"sync/atomic"
 	"testing"
 	"time"
 
 	"github.com/shiroha-a/mk/internal/model"
+	"github.com/shiroha-a/mk/internal/repository"
 	"github.com/shiroha-a/mk/internal/testutil"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -298,6 +300,87 @@ func TestFanoutHook_StreamingFanoutAcrossPages(t *testing.T) {
 	h.OnNoteCreated(n, &model.User{ID: "author"})
 	// 201 人 + 自分 + local + global = 204 トピック以上
 	assert.GreaterOrEqual(t, len(pub.topics), 201+1+1+1)
+}
+
+// countingFollowingRepo wraps MockFollowingRepository to count ListFollowers
+// calls. 旧実装は Redis push と streaming publish で同じ followers ページネ
+// ーションを 2 回繰り返していた。マージ後は 1 ページにつき 1 call で済む
+// ことを担保する (#300 2-4)。
+type countingFollowingRepo struct {
+	*testutil.MockFollowingRepository
+	listFollowersCalls atomic.Int64
+}
+
+func (c *countingFollowingRepo) ListFollowers(userID string, limit, offset int) ([]*model.Following, error) {
+	c.listFollowersCalls.Add(1)
+	return c.MockFollowingRepository.ListFollowers(userID, limit, offset)
+}
+
+// インターフェース実装は完全に MockFollowingRepository に委譲するための
+// コンパイル時アサート。
+var _ repository.FollowingRepository = (*countingFollowingRepo)(nil)
+
+func TestFanoutHook_FollowersFanoutSinglePassListsFollowersOnce(t *testing.T) {
+	testRedis.FlushAll(context.Background())
+	fanout := NewFanoutTimelineService(testRedis.Client, idGen, "")
+	fanout.randFn = func() float64 { return 1.0 }
+	mock := testutil.NewMockFollowingRepository()
+	for i := range 3 {
+		fid := "f-" + idGen.Generate(time.Now().Add(time.Duration(i)*time.Microsecond))
+		mock.Followings[fid] = &model.Following{
+			ID:         fid,
+			FollowerID: "follower-" + fid,
+			FolloweeID: "author",
+		}
+	}
+	following := &countingFollowingRepo{MockFollowingRepository: mock}
+	h := NewFanoutHook(fanout, following)
+	pub := &stubStreamingPublisher{}
+	h.SetStreamingPublisher(pub)
+
+	noteID := idGen.Generate(time.Now())
+	n := &model.Note{ID: noteID, UserID: "author", Visibility: model.NoteVisibilityPublic}
+	h.OnNoteCreated(n, &model.User{ID: "author"})
+
+	// 3 followers, pageSize=200 なので 1 page で読み切る → 1 call が期待値。
+	// 旧実装は Redis push 用 + streaming publish 用で 2 page をフェッチ。
+	assert.Equal(t, int64(1), following.listFollowersCalls.Load(),
+		"merged loop must list followers exactly once per page (perf #300 2-4)")
+	// Redis push と streaming publish が両方届く。
+	for fid := range mock.Followings {
+		topic := "homeTimeline:" + mock.Followings[fid].FollowerID
+		assert.Contains(t, pub.topics, topic)
+	}
+}
+
+// pageSize=200 を超えるフォロワー数でも、1 ページにつき 1 call で済む
+// (旧実装では 2 ページ x 2 ループ = 4 call、新実装は 2 page = 2 call)。
+func TestFanoutHook_FollowersFanoutSinglePassAcrossPages(t *testing.T) {
+	testRedis.FlushAll(context.Background())
+	fanout := NewFanoutTimelineService(testRedis.Client, idGen, "")
+	fanout.randFn = func() float64 { return 1.0 }
+	mock := testutil.NewMockFollowingRepository()
+	for i := range 250 { // 200 + 50, 2 pages
+		fid := "f-" + idGen.Generate(time.Now().Add(time.Duration(i)*time.Microsecond))
+		mock.Followings[fid] = &model.Following{
+			ID:         fid,
+			FollowerID: "follower-" + fid,
+			FolloweeID: "author",
+		}
+	}
+	following := &countingFollowingRepo{MockFollowingRepository: mock}
+	h := NewFanoutHook(fanout, following)
+	pub := &stubStreamingPublisher{}
+	h.SetStreamingPublisher(pub)
+
+	noteID := idGen.Generate(time.Now())
+	n := &model.Note{ID: noteID, UserID: "author", Visibility: model.NoteVisibilityPublic}
+	h.OnNoteCreated(n, &model.User{ID: "author"})
+
+	// 250 followers / pageSize=200 = 2 pages → 2 calls (新実装)。
+	// 旧実装なら 4 calls。
+	assert.Equal(t, int64(2), following.listFollowersCalls.Load(),
+		"merged loop on 250 followers must take 2 page calls (was 4 before #300 2-4)")
 }
 
 func TestFanoutHook_StreamingPublisherNilFollowingRepo(t *testing.T) {

--- a/internal/core/timeline/fanout_hook_test.go
+++ b/internal/core/timeline/fanout_hook_test.go
@@ -261,8 +261,8 @@ func TestFanoutHook_StreamingPublisherUnsetIsNoOp(t *testing.T) {
 }
 
 func TestFanoutHook_StreamingFanoutErrorPath(t *testing.T) {
-	// failingFollowingRepo は ListFollowers でエラーを返す → fanoutStreamingToFollowers
-	// は早期 return する
+	// failingFollowingRepo は ListFollowers でエラーを返す → fanoutToFollowersAndStream
+	// は早期 return し、follower への streaming publish は届かない
 	testRedis.FlushAll(context.Background())
 	fanout := NewFanoutTimelineService(testRedis.Client, idGen, "")
 	fanout.randFn = func() float64 { return 1.0 }


### PR DESCRIPTION
## Summary

`OnNoteCreated` の followers 処理は Redis home timeline への push と `homeTimeline:<followerID>` streaming publish を別々の関数 (`fanoutToFollowers` / `fanoutStreamingToFollowers`) で実装しており、それぞれが `followingRepo.ListFollowers` を `pageSize=200` でページネーションしていた。フォロワー数 N に対して **2 * ceil(N/200)** 回 DB を叩いていたところを 1 ループに畳んで **ceil(N/200)** 回に削減する (#549 / #300 2-4)。

per-row の操作 (Redis push と streaming publish) は元実装と同じくベストエフォートで、片方の失敗が他方を巻き込まない。`publisher == nil` のときは streaming step だけ skip して Redis push は変わらず実行する。

## 主な変更点

| ファイル | 内容 |
|---------|------|
| `internal/core/timeline/fanout_hook.go` | `fanoutToFollowers` と `fanoutStreamingToFollowers` を統合した `fanoutToFollowersAndStream` に置き換え。`OnNoteCreated` 側の呼び出しも 2 行 → 1 行に |
| `internal/core/timeline/fanout_hook_test.go` | `countingFollowingRepo` で `ListFollowers` 呼び出し回数を観測。3 followers で 1 call / 250 followers で 2 call (旧実装はそれぞれ 2 / 4 call) を担保する新規テストを追加 |

## テスト

\`\`\`sh
go test -race -count=1 -cover ./internal/core/timeline/
ok      github.com/shiroha-a/mk/internal/core/timeline    coverage: 96.6% of statements
\`\`\`

既存の fanout / streaming テスト (across-pages / err path / publisher unset / nil following repo / SpecifiedDoesNotFanout など) はすべて挙動互換でそのまま pass。

`go vet ./...` クリーン、`gofmt -s -d .` 差分なし、`go build ./...` クリーン。

## スコープ外

- 3-3 user profile cache (Redis) — 別 PR
- 3-7 singleflight — 別 PR

Closes #549
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/shiroha-a/mk/pull/550" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
