### PR TITLE
Perf #300 3-3: per-userID in-memory cache for user / user_profile

### DIFF
--- a/internal/api/resetpassword/handler_test.go
+++ b/internal/api/resetpassword/handler_test.go
@@ -95,6 +95,8 @@ func (m *mockUserRepo) FindManyByUsernamesAndHost([]string, *string) ([]*model.U
 	return nil, nil
 }
 
+func (m *mockUserRepo) IncrementNotesCount(string, int) error { return nil }
+
 func (m *mockUserRepo) FindProfilesByUserIDs([]string) ([]*model.UserProfile, error) {
 	return nil, nil
 }

--- a/internal/core/note/note_create_service.go
+++ b/internal/core/note/note_create_service.go
@@ -571,7 +571,17 @@ func (s *CreateService) Create(in CreateInput) (*model.Note, error) {
 	// Misskey本家NoteCreateServiceと同じfan-out方針 (TS lines 792 / 809 / 935)。
 	s.publishNoteMainEvents(finalNote, in.User, replyTarget, renoteTarget)
 
-	safeGo(func() { _ = s.noteRepo.IncrementUserNotesCount(in.User.ID, 1) })
+	// notesCount の増加は user 行への直接 UPDATE。userRepo 経由で叩くこと
+	// で CachedUserRepository wrapper の invalidate が走り、stale notesCount
+	// が profile API に出続ける問題を防ぐ (Devin review #552 BUG-2)。
+	// userRepo 未配線の旧経路は noteRepo の同等メソッドにフォールバック。
+	safeGo(func() {
+		if s.userRepo != nil {
+			_ = s.userRepo.IncrementNotesCount(in.User.ID, 1)
+			return
+		}
+		_ = s.noteRepo.IncrementUserNotesCount(in.User.ID, 1)
+	})
 
 	return finalNote, nil
 }

--- a/internal/core/retention/service_test.go
+++ b/internal/core/retention/service_test.go
@@ -72,6 +72,7 @@ func (s *stubUserRepo) FindManyByIDs([]string) ([]*model.User, error) { return n
 func (s *stubUserRepo) FindManyByUsernamesAndHost([]string, *string) ([]*model.User, error) {
 	return nil, nil
 }
+func (s *stubUserRepo) IncrementNotesCount(string, int) error                        { return nil }
 func (s *stubUserRepo) FindProfilesByUserIDs([]string) ([]*model.UserProfile, error) { return nil, nil }
 
 type stubRetentionRepo struct {

--- a/internal/repository/user.go
+++ b/internal/repository/user.go
@@ -31,7 +31,7 @@ type UserRepository interface {
 	FindManyByUsernamesAndHost(usernames []string, host *string) ([]*model.User, error)
 	IncrementFollowingCount(userID string, delta int) error
 	IncrementFollowersCount(userID string, delta int) error
-	// IncrementNotesCount は user.notesCount を delta だけ増減する。
+	// IncrementNotesCount atomically adjusts user.notesCount by delta.
 	// 旧来は noteRepository.IncrementUserNotesCount が直接 user 行を
 	// UPDATE していたが、CachedUserRepository wrapper の invalidate を
 	// 通すため userRepo 経由に統一する (Devin review #552 BUG-2)。

--- a/internal/repository/user.go
+++ b/internal/repository/user.go
@@ -31,6 +31,11 @@ type UserRepository interface {
 	FindManyByUsernamesAndHost(usernames []string, host *string) ([]*model.User, error)
 	IncrementFollowingCount(userID string, delta int) error
 	IncrementFollowersCount(userID string, delta int) error
+	// IncrementNotesCount は user.notesCount を delta だけ増減する。
+	// 旧来は noteRepository.IncrementUserNotesCount が直接 user 行を
+	// UPDATE していたが、CachedUserRepository wrapper の invalidate を
+	// 通すため userRepo 経由に統一する (Devin review #552 BUG-2)。
+	IncrementNotesCount(userID string, delta int) error
 	SearchByUsername(query string, limit, offset int) ([]*model.User, error)
 	UpdateUser(userID string, fields map[string]any) error
 	UpdateProfile(userID string, fields map[string]any) error
@@ -184,6 +189,12 @@ func (r *userRepository) IncrementFollowersCount(userID string, delta int) error
 	return r.db.Model(&model.User{}).
 		Where("id = ?", userID).
 		UpdateColumn("followersCount", gorm.Expr("\"followersCount\" + ?", delta)).Error
+}
+
+func (r *userRepository) IncrementNotesCount(userID string, delta int) error {
+	return r.db.Model(&model.User{}).
+		Where("id = ?", userID).
+		UpdateColumn("notesCount", gorm.Expr("\"notesCount\" + ?", delta)).Error
 }
 
 // SearchByUsername returns users whose usernameLower starts with the given query.

--- a/internal/repository/user_cached.go
+++ b/internal/repository/user_cached.go
@@ -30,6 +30,10 @@ import (
 type CachedUserRepository struct {
 	UserRepository
 	ttl time.Duration
+	// maxEntries は users / profiles map それぞれの soft cap。size がこれを
+	// 超えたタイミングの insert で expired entry を一括削除する。0 なら
+	// userCacheMaxEntries が使われる。
+	maxEntries int
 
 	mu       sync.RWMutex
 	users    map[string]userCacheEntry
@@ -57,6 +61,14 @@ type profileCacheEntry struct {
 // 単一プロセス運用では TTL で守る必要は無いが、保守的に 5 分を採用する。
 const userCacheTTL = 5 * time.Minute
 
+// userCacheMaxEntries は per-map (users / profiles) のエントリ上限。
+// 連合インスタンスでは reachable な remote user 数だけ unique ID lookup が
+// 走り得るので、エントリは monotonically に増え続ける。しきい値超過時に
+// 期限切れエントリの一括 sweep を走らせて O(1) amortized で抑える。
+// しきい値 50000 は per-entry ~256B 想定で ~12MB を上限に取る (Devin
+// review #552: unbounded growth 対策)。
+const userCacheMaxEntries = 50000
+
 // NewCachedUserRepository wraps inner with the default TTL.
 func NewCachedUserRepository(inner UserRepository) *CachedUserRepository {
 	return NewCachedUserRepositoryWithTTL(inner, userCacheTTL)
@@ -64,12 +76,34 @@ func NewCachedUserRepository(inner UserRepository) *CachedUserRepository {
 
 // NewCachedUserRepositoryWithTTL is the test-friendly constructor.
 func NewCachedUserRepositoryWithTTL(inner UserRepository, ttl time.Duration) *CachedUserRepository {
+	return newCachedUserRepository(inner, ttl, userCacheMaxEntries)
+}
+
+// newCachedUserRepository is the internal constructor that exposes maxEntries.
+// Test-only entry point so the eviction path can be exercised without
+// inserting 50k synthetic rows.
+func newCachedUserRepository(inner UserRepository, ttl time.Duration, maxEntries int) *CachedUserRepository {
+	if maxEntries <= 0 {
+		maxEntries = userCacheMaxEntries
+	}
 	return &CachedUserRepository{
 		UserRepository: inner,
 		ttl:            ttl,
+		maxEntries:     maxEntries,
 		users:          make(map[string]userCacheEntry),
 		profiles:       make(map[string]profileCacheEntry),
 	}
+}
+
+// SetMaxEntriesForTest overrides the soft cap. Tests only.
+func (c *CachedUserRepository) SetMaxEntriesForTest(n int) {
+	c.mu.Lock()
+	if n <= 0 {
+		c.maxEntries = userCacheMaxEntries
+	} else {
+		c.maxEntries = n
+	}
+	c.mu.Unlock()
 }
 
 // invalidate drops both user and profile entries for the given userID.
@@ -152,26 +186,58 @@ func (c *CachedUserRepository) FindProfileByUserID(userID string) (*model.UserPr
 
 func (c *CachedUserRepository) storeUser(id string, u *model.User) {
 	c.mu.Lock()
+	c.evictExpiredUsersLocked()
 	c.users[id] = userCacheEntry{user: u, expiresAt: time.Now().Add(c.ttl)}
 	c.mu.Unlock()
 }
 
 func (c *CachedUserRepository) storeUserMissing(id string) {
 	c.mu.Lock()
+	c.evictExpiredUsersLocked()
 	c.users[id] = userCacheEntry{missing: true, expiresAt: time.Now().Add(c.ttl)}
 	c.mu.Unlock()
 }
 
 func (c *CachedUserRepository) storeProfile(userID string, p *model.UserProfile) {
 	c.mu.Lock()
+	c.evictExpiredProfilesLocked()
 	c.profiles[userID] = profileCacheEntry{profile: p, expiresAt: time.Now().Add(c.ttl)}
 	c.mu.Unlock()
 }
 
 func (c *CachedUserRepository) storeProfileMissing(userID string) {
 	c.mu.Lock()
+	c.evictExpiredProfilesLocked()
 	c.profiles[userID] = profileCacheEntry{missing: true, expiresAt: time.Now().Add(c.ttl)}
 	c.mu.Unlock()
+}
+
+// evictExpiredUsersLocked は users map のサイズが userCacheMaxEntries を
+// 超えていたら、期限切れエントリを一括削除して memory growth を抑える。
+// 呼び出し側で c.mu.Lock 済みである必要がある。Devin #552: unbounded
+// growth 対策。
+func (c *CachedUserRepository) evictExpiredUsersLocked() {
+	if len(c.users) < c.maxEntries {
+		return
+	}
+	now := time.Now()
+	for k, e := range c.users {
+		if now.After(e.expiresAt) {
+			delete(c.users, k)
+		}
+	}
+}
+
+func (c *CachedUserRepository) evictExpiredProfilesLocked() {
+	if len(c.profiles) < c.maxEntries {
+		return
+	}
+	now := time.Now()
+	for k, e := range c.profiles {
+		if now.After(e.expiresAt) {
+			delete(c.profiles, k)
+		}
+	}
 }
 
 // --- mutating methods: delegate then invalidate -----------------------------
@@ -216,4 +282,50 @@ func (c *CachedUserRepository) IncrementFollowersCount(userID string, delta int)
 	}
 	c.invalidate(userID)
 	return nil
+}
+
+// FindManyByIDs delegates to the inner repo and warms the per-userID cache
+// with the returned rows. これにより users/show バルク経路 (#503) の結果が
+// 直後の ShowByID / FindByID で hit するようになる (Devin review #552 FLAG-1)。
+// missing rows は inner が silently skip するため negative-cache は付けない
+// (どの ID が抜けたかは戻り値からは判別できないため、別 round-trip での
+// FindByID が走った時に negative-cache する経路に任せる)。
+func (c *CachedUserRepository) FindManyByIDs(ids []string) ([]*model.User, error) {
+	users, err := c.UserRepository.FindManyByIDs(ids)
+	if err != nil {
+		return nil, err
+	}
+	if len(users) > 0 {
+		c.mu.Lock()
+		c.evictExpiredUsersLocked()
+		expiry := time.Now().Add(c.ttl)
+		for _, u := range users {
+			if u != nil && u.ID != "" {
+				c.users[u.ID] = userCacheEntry{user: u, expiresAt: expiry}
+			}
+		}
+		c.mu.Unlock()
+	}
+	return users, nil
+}
+
+// FindProfilesByUserIDs is the profile counterpart of FindManyByIDs:
+// バルクで返ってきた行を per-userID cache に warm する。
+func (c *CachedUserRepository) FindProfilesByUserIDs(userIDs []string) ([]*model.UserProfile, error) {
+	profiles, err := c.UserRepository.FindProfilesByUserIDs(userIDs)
+	if err != nil {
+		return nil, err
+	}
+	if len(profiles) > 0 {
+		c.mu.Lock()
+		c.evictExpiredProfilesLocked()
+		expiry := time.Now().Add(c.ttl)
+		for _, p := range profiles {
+			if p != nil && p.UserID != "" {
+				c.profiles[p.UserID] = profileCacheEntry{profile: p, expiresAt: expiry}
+			}
+		}
+		c.mu.Unlock()
+	}
+	return profiles, nil
 }

--- a/internal/repository/user_cached.go
+++ b/internal/repository/user_cached.go
@@ -284,6 +284,14 @@ func (c *CachedUserRepository) IncrementFollowersCount(userID string, delta int)
 	return nil
 }
 
+func (c *CachedUserRepository) IncrementNotesCount(userID string, delta int) error {
+	if err := c.UserRepository.IncrementNotesCount(userID, delta); err != nil {
+		return err
+	}
+	c.invalidate(userID)
+	return nil
+}
+
 // FindManyByIDs delegates to the inner repo and warms the per-userID cache
 // with the returned rows. これにより users/show バルク経路 (#503) の結果が
 // 直後の ShowByID / FindByID で hit するようになる (Devin review #552 FLAG-1)。

--- a/internal/repository/user_cached.go
+++ b/internal/repository/user_cached.go
@@ -1,0 +1,219 @@
+package repository
+
+import (
+	"errors"
+	"sync"
+	"time"
+
+	"github.com/shiroha-a/mk/internal/model"
+	"gorm.io/gorm"
+)
+
+// CachedUserRepository wraps a UserRepository with a time-based per-userID
+// cache for FindByID + FindProfileByUserID. ShowByID 経路はタイムライン描画
+// で大量に呼ばれるが、user / user_profile 行の更新頻度は低いので、5 分 TTL
+// + 全 mutation で per-userID invalidate するだけで hit 率がほぼ 100% に
+// 張り付く (#300 3-3)。
+//
+// In-memory wrapper を選択した理由:
+//   - role / emoji / meta cache (#300 3-5 / 3-6 / 3-1) と同じ既存パターンに
+//     揃えるため。Redis 越しの user cache はインスタンス間共有という別の
+//     利点があるが、out-of-band write が無い前提では in-memory で十分。
+//   - 全 user 系 mutation が `userRepo` 経由 (admin, federation processor,
+//     following service, signin, resetpassword 等) なので wrapper 層で
+//     invalidate を保証できる。DB 直接 UPDATE の経路は無い。
+//
+// 注意: cached value はポインタ参照を直接返す。caller が User / UserProfile
+// を mutate すると他の caller の view を破壊するので **read-only として扱う**。
+// 既存実装も `FindByID` / `FindProfileByUserID` の戻り値を mutate していない
+// (mutation は UpdateUser / UpdateProfile を介する) ので不変条件は保たれる。
+type CachedUserRepository struct {
+	UserRepository
+	ttl time.Duration
+
+	mu       sync.RWMutex
+	users    map[string]userCacheEntry
+	profiles map[string]profileCacheEntry
+}
+
+type userCacheEntry struct {
+	user      *model.User
+	expiresAt time.Time
+	// missing=true は "DB に存在しない" を表す negative cache。pos は
+	// nil pointer と区別したいので別フラグで持つ。
+	missing bool
+}
+
+type profileCacheEntry struct {
+	profile   *model.UserProfile
+	expiresAt time.Time
+	missing   bool
+}
+
+// userCacheTTL は CachedUserRepository のデフォルト TTL。短すぎると
+// timeline 描画で hit 率が落ち、長すぎると out-of-band の (例: 別の mk
+// プロセスが共有 DB に書き込む) write が反映されるまで lag が出る。
+// admin / federation processor / signin はすべて当該 wrapper 経由なので、
+// 単一プロセス運用では TTL で守る必要は無いが、保守的に 5 分を採用する。
+const userCacheTTL = 5 * time.Minute
+
+// NewCachedUserRepository wraps inner with the default TTL.
+func NewCachedUserRepository(inner UserRepository) *CachedUserRepository {
+	return NewCachedUserRepositoryWithTTL(inner, userCacheTTL)
+}
+
+// NewCachedUserRepositoryWithTTL is the test-friendly constructor.
+func NewCachedUserRepositoryWithTTL(inner UserRepository, ttl time.Duration) *CachedUserRepository {
+	return &CachedUserRepository{
+		UserRepository: inner,
+		ttl:            ttl,
+		users:          make(map[string]userCacheEntry),
+		profiles:       make(map[string]profileCacheEntry),
+	}
+}
+
+// invalidate drops both user and profile entries for the given userID.
+// Mutation 系メソッドの末尾で呼ぶ。
+func (c *CachedUserRepository) invalidate(userID string) {
+	if userID == "" {
+		return
+	}
+	c.mu.Lock()
+	delete(c.users, userID)
+	delete(c.profiles, userID)
+	c.mu.Unlock()
+}
+
+// Invalidate is the public counterpart of invalidate. Out-of-band code paths
+// that bypass this wrapper (例: テスト) can call it to force a refresh.
+func (c *CachedUserRepository) Invalidate(userID string) {
+	c.invalidate(userID)
+}
+
+// FindByID returns the cached user for id, falling through to the inner repo
+// on miss / expiry. Errors other than not-found are returned unchanged and
+// **never cached** so transient DB errors recover on the next call.
+func (c *CachedUserRepository) FindByID(id string) (*model.User, error) {
+	if id == "" {
+		return c.UserRepository.FindByID(id)
+	}
+	c.mu.RLock()
+	if e, ok := c.users[id]; ok && time.Now().Before(e.expiresAt) {
+		c.mu.RUnlock()
+		if e.missing {
+			return nil, gorm.ErrRecordNotFound
+		}
+		return e.user, nil
+	}
+	c.mu.RUnlock()
+
+	u, err := c.UserRepository.FindByID(id)
+	if err != nil {
+		// 「見つからない」は negative-cache する。timeline 描画で
+		// 削除済みユーザーへの参照が大量に来る可能性に備える。それ
+		// 以外の err は cache せず caller に返して上位で扱わせる。
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			c.storeUserMissing(id)
+			return nil, err
+		}
+		return nil, err
+	}
+	c.storeUser(id, u)
+	return u, nil
+}
+
+// FindProfileByUserID returns the cached profile for userID with the same
+// negative-cache semantics as FindByID.
+func (c *CachedUserRepository) FindProfileByUserID(userID string) (*model.UserProfile, error) {
+	if userID == "" {
+		return c.UserRepository.FindProfileByUserID(userID)
+	}
+	c.mu.RLock()
+	if e, ok := c.profiles[userID]; ok && time.Now().Before(e.expiresAt) {
+		c.mu.RUnlock()
+		if e.missing {
+			return nil, gorm.ErrRecordNotFound
+		}
+		return e.profile, nil
+	}
+	c.mu.RUnlock()
+
+	p, err := c.UserRepository.FindProfileByUserID(userID)
+	if err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			c.storeProfileMissing(userID)
+			return nil, err
+		}
+		return nil, err
+	}
+	c.storeProfile(userID, p)
+	return p, nil
+}
+
+func (c *CachedUserRepository) storeUser(id string, u *model.User) {
+	c.mu.Lock()
+	c.users[id] = userCacheEntry{user: u, expiresAt: time.Now().Add(c.ttl)}
+	c.mu.Unlock()
+}
+
+func (c *CachedUserRepository) storeUserMissing(id string) {
+	c.mu.Lock()
+	c.users[id] = userCacheEntry{missing: true, expiresAt: time.Now().Add(c.ttl)}
+	c.mu.Unlock()
+}
+
+func (c *CachedUserRepository) storeProfile(userID string, p *model.UserProfile) {
+	c.mu.Lock()
+	c.profiles[userID] = profileCacheEntry{profile: p, expiresAt: time.Now().Add(c.ttl)}
+	c.mu.Unlock()
+}
+
+func (c *CachedUserRepository) storeProfileMissing(userID string) {
+	c.mu.Lock()
+	c.profiles[userID] = profileCacheEntry{missing: true, expiresAt: time.Now().Add(c.ttl)}
+	c.mu.Unlock()
+}
+
+// --- mutating methods: delegate then invalidate -----------------------------
+
+func (c *CachedUserRepository) UpdateUser(userID string, fields map[string]any) error {
+	if err := c.UserRepository.UpdateUser(userID, fields); err != nil {
+		return err
+	}
+	c.invalidate(userID)
+	return nil
+}
+
+func (c *CachedUserRepository) UpdateProfile(userID string, fields map[string]any) error {
+	if err := c.UserRepository.UpdateProfile(userID, fields); err != nil {
+		return err
+	}
+	c.invalidate(userID)
+	return nil
+}
+
+func (c *CachedUserRepository) CreateProfile(profile *model.UserProfile) error {
+	if err := c.UserRepository.CreateProfile(profile); err != nil {
+		return err
+	}
+	if profile != nil {
+		c.invalidate(profile.UserID)
+	}
+	return nil
+}
+
+func (c *CachedUserRepository) IncrementFollowingCount(userID string, delta int) error {
+	if err := c.UserRepository.IncrementFollowingCount(userID, delta); err != nil {
+		return err
+	}
+	c.invalidate(userID)
+	return nil
+}
+
+func (c *CachedUserRepository) IncrementFollowersCount(userID string, delta int) error {
+	if err := c.UserRepository.IncrementFollowersCount(userID, delta); err != nil {
+		return err
+	}
+	c.invalidate(userID)
+	return nil
+}

--- a/internal/repository/user_cached_test.go
+++ b/internal/repository/user_cached_test.go
@@ -85,6 +85,10 @@ func (c *countingUserRepo) IncrementFollowersCount(_ string, _ int) error {
 	return c.incFollowersErr
 }
 
+func (c *countingUserRepo) IncrementNotesCount(_ string, _ int) error {
+	return nil
+}
+
 func (c *countingUserRepo) FindManyByIDs(ids []string) ([]*model.User, error) {
 	out := make([]*model.User, 0, len(ids))
 	for _, id := range ids {
@@ -273,6 +277,21 @@ func TestCachedUserRepository_IncrementFollowingCountInvalidates(t *testing.T) {
 
 	_, _ = cached.FindByID("u1")
 	require.NoError(t, cached.IncrementFollowingCount("u1", 1))
+	_, _ = cached.FindByID("u1")
+	assert.Equal(t, int64(2), inner.findByIDCalls.Load())
+}
+
+// notesCount は note 作成のたびに userRepo.IncrementNotesCount で増減
+// される (旧経路の noteRepo.IncrementUserNotesCount は cache を bypass
+// していた)。CachedUserRepository が invalidate を取りこぼすと profile
+// 表示で stale notesCount が出続けるので必ず飛ぶこと (Devin #552 BUG-2)。
+func TestCachedUserRepository_IncrementNotesCountInvalidates(t *testing.T) {
+	inner := newCountingUserRepo()
+	inner.users["u1"] = &model.User{ID: "u1"}
+	cached := repository.NewCachedUserRepository(inner)
+
+	_, _ = cached.FindByID("u1")
+	require.NoError(t, cached.IncrementNotesCount("u1", 1))
 	_, _ = cached.FindByID("u1")
 	assert.Equal(t, int64(2), inner.findByIDCalls.Load())
 }

--- a/internal/repository/user_cached_test.go
+++ b/internal/repository/user_cached_test.go
@@ -85,6 +85,26 @@ func (c *countingUserRepo) IncrementFollowersCount(_ string, _ int) error {
 	return c.incFollowersErr
 }
 
+func (c *countingUserRepo) FindManyByIDs(ids []string) ([]*model.User, error) {
+	out := make([]*model.User, 0, len(ids))
+	for _, id := range ids {
+		if u, ok := c.users[id]; ok {
+			out = append(out, u)
+		}
+	}
+	return out, nil
+}
+
+func (c *countingUserRepo) FindProfilesByUserIDs(ids []string) ([]*model.UserProfile, error) {
+	out := make([]*model.UserProfile, 0, len(ids))
+	for _, id := range ids {
+		if p, ok := c.profiles[id]; ok {
+			out = append(out, p)
+		}
+	}
+	return out, nil
+}
+
 func TestCachedUserRepository_FindByIDHitsInnerOnce(t *testing.T) {
 	inner := newCountingUserRepo()
 	inner.users["u1"] = &model.User{ID: "u1", Username: "alice"}
@@ -277,6 +297,116 @@ func TestCachedUserRepository_PublicInvalidate(t *testing.T) {
 	cached.Invalidate("u1")
 	_, _ = cached.FindByID("u1")
 	assert.Equal(t, int64(2), inner.findByIDCalls.Load())
+}
+
+// FindManyByIDs / FindProfilesByUserIDs はバルク結果で per-userID cache を
+// warm する。直後の FindByID / FindProfileByUserID は inner を再度叩かない
+// (Devin review #552 FLAG-1)。
+func TestCachedUserRepository_FindManyByIDsWarmsPerKeyCache(t *testing.T) {
+	inner := newCountingUserRepo()
+	inner.users["u1"] = &model.User{ID: "u1"}
+	inner.users["u2"] = &model.User{ID: "u2"}
+	cached := repository.NewCachedUserRepository(inner)
+
+	out, err := cached.FindManyByIDs([]string{"u1", "u2"})
+	require.NoError(t, err)
+	require.Len(t, out, 2)
+
+	// per-key cache が warm されているので FindByID は inner を叩かない。
+	_, err = cached.FindByID("u1")
+	require.NoError(t, err)
+	_, err = cached.FindByID("u2")
+	require.NoError(t, err)
+	assert.Equal(t, int64(0), inner.findByIDCalls.Load(),
+		"bulk fetch must populate per-key cache")
+}
+
+func TestCachedUserRepository_FindProfilesByUserIDsWarmsPerKeyCache(t *testing.T) {
+	inner := newCountingUserRepo()
+	desc := "p"
+	inner.profiles["u1"] = &model.UserProfile{UserID: "u1", Description: &desc}
+	inner.profiles["u2"] = &model.UserProfile{UserID: "u2", Description: &desc}
+	cached := repository.NewCachedUserRepository(inner)
+
+	out, err := cached.FindProfilesByUserIDs([]string{"u1", "u2"})
+	require.NoError(t, err)
+	require.Len(t, out, 2)
+
+	_, err = cached.FindProfileByUserID("u1")
+	require.NoError(t, err)
+	_, err = cached.FindProfileByUserID("u2")
+	require.NoError(t, err)
+	assert.Equal(t, int64(0), inner.findProfileByUserIDCalls.Load(),
+		"bulk profile fetch must populate per-key cache")
+}
+
+// users map のサイズが maxEntries を超えたら、insert 時に期限切れエントリ
+// を一括削除する (Devin review #552: unbounded growth 対策)。
+//
+// 検証戦略: cap=3 / TTL=10ms で 3 件 warm → 期限切れ待機 → 4 件目を insert
+// → 期限切れ 3 件は map から消えるので、それらを再取得すると inner を
+// 叩く回数が増える (cache miss に戻る)。新しい entry は live なので
+// cache hit のまま。
+func TestCachedUserRepository_EvictsExpiredEntriesOnInsertOverCap(t *testing.T) {
+	inner := newCountingUserRepo()
+	for _, id := range []string{"u1", "u2", "u3", "u4"} {
+		inner.users[id] = &model.User{ID: id}
+	}
+	cached := repository.NewCachedUserRepositoryWithTTL(inner, 10*time.Millisecond)
+	cached.SetMaxEntriesForTest(3)
+
+	// 3 件 warm。inner は 3 回叩かれる。
+	for _, id := range []string{"u1", "u2", "u3"} {
+		_, err := cached.FindByID(id)
+		require.NoError(t, err)
+	}
+	require.Equal(t, int64(3), inner.findByIDCalls.Load())
+
+	// TTL 失効を待つ。
+	time.Sleep(15 * time.Millisecond)
+
+	// 4 件目を insert: len == cap(3) で eviction 発火 → expired 3 件削除。
+	_, err := cached.FindByID("u4")
+	require.NoError(t, err)
+	// u4 lookup で +1
+	require.Equal(t, int64(4), inner.findByIDCalls.Load())
+
+	// 期限切れだった u1/u2/u3 は map から消えているので、再 lookup は
+	// inner を叩く (cache miss)。
+	for _, id := range []string{"u1", "u2", "u3"} {
+		_, _ = cached.FindByID(id)
+	}
+	assert.Equal(t, int64(7), inner.findByIDCalls.Load(),
+		"expired entries must be evicted on insert when over cap, forcing inner re-fetch")
+}
+
+// profile 側の同 eviction 挙動。
+func TestCachedUserRepository_EvictsExpiredProfilesOnInsertOverCap(t *testing.T) {
+	inner := newCountingUserRepo()
+	desc := "p"
+	for _, id := range []string{"u1", "u2", "u3", "u4"} {
+		inner.profiles[id] = &model.UserProfile{UserID: id, Description: &desc}
+	}
+	cached := repository.NewCachedUserRepositoryWithTTL(inner, 10*time.Millisecond)
+	cached.SetMaxEntriesForTest(3)
+
+	for _, id := range []string{"u1", "u2", "u3"} {
+		_, err := cached.FindProfileByUserID(id)
+		require.NoError(t, err)
+	}
+	require.Equal(t, int64(3), inner.findProfileByUserIDCalls.Load())
+
+	time.Sleep(15 * time.Millisecond)
+
+	_, err := cached.FindProfileByUserID("u4")
+	require.NoError(t, err)
+	require.Equal(t, int64(4), inner.findProfileByUserIDCalls.Load())
+
+	for _, id := range []string{"u1", "u2", "u3"} {
+		_, _ = cached.FindProfileByUserID(id)
+	}
+	assert.Equal(t, int64(7), inner.findProfileByUserIDCalls.Load(),
+		"expired profile entries must be evicted on insert when over cap")
 }
 
 // 空 ID は no-op で inner にだけ任せる (lookup error がそのまま返る)。

--- a/internal/repository/user_cached_test.go
+++ b/internal/repository/user_cached_test.go
@@ -1,0 +1,294 @@
+package repository_test
+
+import (
+	"errors"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/shiroha-a/mk/internal/model"
+	"github.com/shiroha-a/mk/internal/repository"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gorm.io/gorm"
+)
+
+// countingUserRepo wraps a stub UserRepository and exposes call counts on
+// the methods we cache or invalidate around. それ以外は zero-value pass-
+// through で十分 (caching とは無関係なので)。
+type countingUserRepo struct {
+	repository.UserRepository
+
+	users    map[string]*model.User
+	profiles map[string]*model.UserProfile
+
+	findByIDCalls            atomic.Int64
+	findProfileByUserIDCalls atomic.Int64
+
+	updateUserErr      error
+	updateProfileErr   error
+	createProfileErr   error
+	incFollowingErr    error
+	incFollowersErr    error
+	updateUserCalls    atomic.Int64
+	updateProfileCalls atomic.Int64
+}
+
+func newCountingUserRepo() *countingUserRepo {
+	return &countingUserRepo{
+		users:    make(map[string]*model.User),
+		profiles: make(map[string]*model.UserProfile),
+	}
+}
+
+func (c *countingUserRepo) FindByID(id string) (*model.User, error) {
+	c.findByIDCalls.Add(1)
+	if u, ok := c.users[id]; ok {
+		return u, nil
+	}
+	return nil, gorm.ErrRecordNotFound
+}
+
+func (c *countingUserRepo) FindProfileByUserID(userID string) (*model.UserProfile, error) {
+	c.findProfileByUserIDCalls.Add(1)
+	if p, ok := c.profiles[userID]; ok {
+		return p, nil
+	}
+	return nil, gorm.ErrRecordNotFound
+}
+
+func (c *countingUserRepo) UpdateUser(userID string, _ map[string]any) error {
+	c.updateUserCalls.Add(1)
+	return c.updateUserErr
+}
+
+func (c *countingUserRepo) UpdateProfile(userID string, _ map[string]any) error {
+	c.updateProfileCalls.Add(1)
+	return c.updateProfileErr
+}
+
+func (c *countingUserRepo) CreateProfile(p *model.UserProfile) error {
+	if c.createProfileErr != nil {
+		return c.createProfileErr
+	}
+	if p != nil {
+		c.profiles[p.UserID] = p
+	}
+	return nil
+}
+
+func (c *countingUserRepo) IncrementFollowingCount(_ string, _ int) error {
+	return c.incFollowingErr
+}
+
+func (c *countingUserRepo) IncrementFollowersCount(_ string, _ int) error {
+	return c.incFollowersErr
+}
+
+func TestCachedUserRepository_FindByIDHitsInnerOnce(t *testing.T) {
+	inner := newCountingUserRepo()
+	inner.users["u1"] = &model.User{ID: "u1", Username: "alice"}
+	cached := repository.NewCachedUserRepository(inner)
+
+	for i := 0; i < 10; i++ {
+		got, err := cached.FindByID("u1")
+		require.NoError(t, err)
+		assert.Equal(t, "alice", got.Username)
+	}
+	assert.Equal(t, int64(1), inner.findByIDCalls.Load(),
+		"10 cached lookups must hit inner exactly once")
+}
+
+func TestCachedUserRepository_FindProfileByUserIDHitsInnerOnce(t *testing.T) {
+	inner := newCountingUserRepo()
+	desc := "hi"
+	inner.profiles["u1"] = &model.UserProfile{UserID: "u1", Description: &desc}
+	cached := repository.NewCachedUserRepository(inner)
+
+	for i := 0; i < 5; i++ {
+		got, err := cached.FindProfileByUserID("u1")
+		require.NoError(t, err)
+		assert.Equal(t, "hi", *got.Description)
+	}
+	assert.Equal(t, int64(1), inner.findProfileByUserIDCalls.Load())
+}
+
+func TestCachedUserRepository_NotFoundIsNegativeCached(t *testing.T) {
+	inner := newCountingUserRepo()
+	cached := repository.NewCachedUserRepository(inner)
+
+	for i := 0; i < 5; i++ {
+		_, err := cached.FindByID("ghost")
+		require.ErrorIs(t, err, gorm.ErrRecordNotFound)
+	}
+	assert.Equal(t, int64(1), inner.findByIDCalls.Load(),
+		"missing rows must be negative-cached so timeline ghost lookups don't reflood inner")
+}
+
+// ErrNotFound 以外の error は cache されない。transient な DB 障害が次回
+// 呼び出しで自動回復することを担保する。
+type erroringUserRepo struct {
+	repository.UserRepository
+	calls atomic.Int64
+}
+
+func (e *erroringUserRepo) FindByID(_ string) (*model.User, error) {
+	e.calls.Add(1)
+	return nil, errors.New("db down")
+}
+
+func (e *erroringUserRepo) FindProfileByUserID(_ string) (*model.UserProfile, error) {
+	e.calls.Add(1)
+	return nil, errors.New("db down")
+}
+
+func TestCachedUserRepository_TransientErrorIsNotCached(t *testing.T) {
+	inner := &erroringUserRepo{}
+	cached := repository.NewCachedUserRepository(inner)
+
+	_, err := cached.FindByID("u1")
+	require.Error(t, err)
+	_, err = cached.FindByID("u1")
+	require.Error(t, err)
+	assert.Equal(t, int64(2), inner.calls.Load(),
+		"non-NotFound errors must not be cached")
+
+	_, err = cached.FindProfileByUserID("u1")
+	require.Error(t, err)
+	_, err = cached.FindProfileByUserID("u1")
+	require.Error(t, err)
+	assert.Equal(t, int64(4), inner.calls.Load())
+}
+
+func TestCachedUserRepository_RefreshesAfterTTL(t *testing.T) {
+	inner := newCountingUserRepo()
+	inner.users["u1"] = &model.User{ID: "u1"}
+	cached := repository.NewCachedUserRepositoryWithTTL(inner, 1*time.Millisecond)
+
+	_, err := cached.FindByID("u1")
+	require.NoError(t, err)
+	time.Sleep(2 * time.Millisecond)
+	_, err = cached.FindByID("u1")
+	require.NoError(t, err)
+	assert.Equal(t, int64(2), inner.findByIDCalls.Load())
+}
+
+func TestCachedUserRepository_UpdateUserInvalidates(t *testing.T) {
+	inner := newCountingUserRepo()
+	inner.users["u1"] = &model.User{ID: "u1", Username: "alice"}
+	cached := repository.NewCachedUserRepository(inner)
+
+	_, _ = cached.FindByID("u1") // warm
+	require.NoError(t, cached.UpdateUser("u1", map[string]any{"name": "x"}))
+	_, _ = cached.FindByID("u1")
+	assert.Equal(t, int64(2), inner.findByIDCalls.Load(),
+		"UpdateUser must invalidate so the next FindByID re-reads")
+}
+
+func TestCachedUserRepository_UpdateUserErrDoesNotInvalidate(t *testing.T) {
+	inner := newCountingUserRepo()
+	inner.users["u1"] = &model.User{ID: "u1"}
+	inner.updateUserErr = errors.New("db down")
+	cached := repository.NewCachedUserRepository(inner)
+
+	_, _ = cached.FindByID("u1") // warm
+	err := cached.UpdateUser("u1", map[string]any{"name": "x"})
+	require.Error(t, err)
+	_, _ = cached.FindByID("u1")
+	assert.Equal(t, int64(1), inner.findByIDCalls.Load(),
+		"failed UpdateUser must not invalidate (DB state unchanged)")
+}
+
+func TestCachedUserRepository_UpdateProfileInvalidatesProfile(t *testing.T) {
+	inner := newCountingUserRepo()
+	desc := "hi"
+	inner.profiles["u1"] = &model.UserProfile{UserID: "u1", Description: &desc}
+	cached := repository.NewCachedUserRepository(inner)
+
+	_, _ = cached.FindProfileByUserID("u1")
+	require.NoError(t, cached.UpdateProfile("u1", map[string]any{"desc": "y"}))
+	_, _ = cached.FindProfileByUserID("u1")
+	assert.Equal(t, int64(2), inner.findProfileByUserIDCalls.Load())
+}
+
+// UpdateProfile (例: lastActiveDate / password) が user 行も同 ID で
+// 共有されているケースに備え、profile 更新時は user 側 cache も飛ばす。
+// (現状は同 userID で削除しているので user 側エントリも消える挙動。)
+func TestCachedUserRepository_UpdateProfileInvalidatesUserAlso(t *testing.T) {
+	inner := newCountingUserRepo()
+	inner.users["u1"] = &model.User{ID: "u1"}
+	desc := "hi"
+	inner.profiles["u1"] = &model.UserProfile{UserID: "u1", Description: &desc}
+	cached := repository.NewCachedUserRepository(inner)
+
+	_, _ = cached.FindByID("u1")
+	_, _ = cached.FindProfileByUserID("u1")
+	require.NoError(t, cached.UpdateProfile("u1", map[string]any{"desc": "y"}))
+	_, _ = cached.FindByID("u1")
+	assert.Equal(t, int64(2), inner.findByIDCalls.Load(),
+		"UpdateProfile invalidates both user and profile entries for the same ID")
+}
+
+func TestCachedUserRepository_CreateProfileInvalidates(t *testing.T) {
+	inner := newCountingUserRepo()
+	cached := repository.NewCachedUserRepository(inner)
+
+	// 最初は profile なし → negative cache に乗る
+	_, err := cached.FindProfileByUserID("u1")
+	require.ErrorIs(t, err, gorm.ErrRecordNotFound)
+	require.Equal(t, int64(1), inner.findProfileByUserIDCalls.Load())
+
+	// CreateProfile 後は negative cache を飛ばして再取得する
+	require.NoError(t, cached.CreateProfile(&model.UserProfile{UserID: "u1"}))
+	got, err := cached.FindProfileByUserID("u1")
+	require.NoError(t, err)
+	assert.Equal(t, "u1", got.UserID)
+	assert.Equal(t, int64(2), inner.findProfileByUserIDCalls.Load())
+}
+
+func TestCachedUserRepository_IncrementFollowingCountInvalidates(t *testing.T) {
+	inner := newCountingUserRepo()
+	inner.users["u1"] = &model.User{ID: "u1", FollowingCount: 0}
+	cached := repository.NewCachedUserRepository(inner)
+
+	_, _ = cached.FindByID("u1")
+	require.NoError(t, cached.IncrementFollowingCount("u1", 1))
+	_, _ = cached.FindByID("u1")
+	assert.Equal(t, int64(2), inner.findByIDCalls.Load())
+}
+
+func TestCachedUserRepository_IncrementFollowersCountInvalidates(t *testing.T) {
+	inner := newCountingUserRepo()
+	inner.users["u1"] = &model.User{ID: "u1"}
+	cached := repository.NewCachedUserRepository(inner)
+
+	_, _ = cached.FindByID("u1")
+	require.NoError(t, cached.IncrementFollowersCount("u1", 1))
+	_, _ = cached.FindByID("u1")
+	assert.Equal(t, int64(2), inner.findByIDCalls.Load())
+}
+
+func TestCachedUserRepository_PublicInvalidate(t *testing.T) {
+	inner := newCountingUserRepo()
+	inner.users["u1"] = &model.User{ID: "u1"}
+	cached := repository.NewCachedUserRepositoryWithTTL(inner, time.Hour)
+
+	_, _ = cached.FindByID("u1")
+	cached.Invalidate("u1")
+	_, _ = cached.FindByID("u1")
+	assert.Equal(t, int64(2), inner.findByIDCalls.Load())
+}
+
+// 空 ID は no-op で inner にだけ任せる (lookup error がそのまま返る)。
+// 空 ID を cache key にすると意図しない衝突を起こすので意図的に bypass する。
+func TestCachedUserRepository_EmptyIDIsBypassed(t *testing.T) {
+	inner := newCountingUserRepo()
+	cached := repository.NewCachedUserRepository(inner)
+
+	for i := 0; i < 3; i++ {
+		_, _ = cached.FindByID("")
+		_, _ = cached.FindProfileByUserID("")
+	}
+	assert.Equal(t, int64(3), inner.findByIDCalls.Load())
+	assert.Equal(t, int64(3), inner.findProfileByUserIDCalls.Load())
+}

--- a/internal/server/router.go
+++ b/internal/server/router.go
@@ -123,7 +123,10 @@ func (s *Server) setupRoutes() {
 	}
 
 	// Repositories
-	userRepo := repository.NewUserRepository(s.db)
+	// userRepo は server.New で構築した CachedUserRepository を再利用する。
+	// auth middleware と service 層が同じ cache を共有することで mutation
+	// 時の invalidate が両方に反映される (#300 3-3)。
+	userRepo := s.userRepo
 	noteRepo := repository.NewNoteRepository(s.db)
 	metaRepo := repository.NewCachedMetaRepository(repository.NewMetaRepository(s.db))
 	// Seed the singleton meta row on first boot so that fresh installs

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -22,7 +22,11 @@ import (
 
 // Server represents the HTTP server.
 type Server struct {
-	echo           *echo.Echo
+	echo *echo.Echo
+	// userRepo は CachedUserRepository でラップ済みの共有 instance。
+	// auth middleware と setupRoutes の両方からこれを使うことで、片側の
+	// mutation で他方の cache が stale 化するのを防ぐ (#300 3-3)。
+	userRepo       repository.UserRepository
 	config         *config.Config
 	db             *gorm.DB
 	redis          *cache.RedisClients
@@ -80,7 +84,9 @@ func New(cfg *config.Config, db *gorm.DB, redis *cache.RedisClients) (*Server, e
 		AllowHeaders: []string{echo.HeaderOrigin, echo.HeaderContentType, echo.HeaderAccept, echo.HeaderAuthorization},
 	}))
 
-	userRepo := repository.NewUserRepository(db)
+	// CachedUserRepository を一度だけ構築して auth middleware と
+	// setupRoutes (services) が同じ cache を共有するようにする (#300 3-3)。
+	userRepo := repository.NewCachedUserRepository(repository.NewUserRepository(db))
 	accessTokenRepo := repository.NewAccessTokenRepository(db)
 
 	auth := middleware.NewAuthMiddleware(userRepo, accessTokenRepo)
@@ -101,6 +107,7 @@ func New(cfg *config.Config, db *gorm.DB, redis *cache.RedisClients) (*Server, e
 
 	s := &Server{
 		echo:           e,
+		userRepo:       userRepo,
 		config:         cfg,
 		db:             db,
 		redis:          redis,

--- a/internal/testutil/mock_repository.go
+++ b/internal/testutil/mock_repository.go
@@ -166,6 +166,13 @@ func (m *MockUserRepository) IncrementFollowingCount(userID string, delta int) e
 	return nil
 }
 
+func (m *MockUserRepository) IncrementNotesCount(userID string, delta int) error {
+	if u, ok := m.Users[userID]; ok {
+		u.NotesCount += delta
+	}
+	return nil
+}
+
 func (m *MockUserRepository) IncrementFollowersCount(userID string, delta int) error {
 	if u, ok := m.Users[userID]; ok {
 		u.FollowersCount += delta


### PR DESCRIPTION
## Summary

`ShowByID` 経路は毎回 `userRepo.FindByID` + `userRepo.FindProfileByUserID` の 2 query を直列で叩いており、タイムライン描画 (per-note の author / mention 解決経由) で大量に呼ばれる (#551 / #300 3-3)。`CachedUserRepository` (in-memory wrapper) で per-userID に TTL=5 min cache を導入する。

クエリ削減: ShowByID のホット経路で **2 query/call → 0 query/call (cache hit 時)**。

## 主な変更点

| ファイル | 内容 |
|---------|------|
| `internal/repository/user_cached.go` | 新規実装。`UserRepository` を embed して全 25 メソッドを自動 delegate しつつ、`FindByID` / `FindProfileByUserID` を cache する。負例 (gorm.ErrRecordNotFound) は negative-cache、それ以外の transient err は cache せず透過。`UpdateUser` / `UpdateProfile` / `CreateProfile` / `IncrementFollowing/FollowersCount` で per-userID invalidate |
| `internal/server/server.go` | `Server` 構造体に `userRepo` フィールドを追加。`server.New` で `NewCachedUserRepository(NewUserRepository(db))` を一度だけ構築して保持 |
| `internal/server/router.go` | `setupRoutes` 側で `s.userRepo` を再利用。auth middleware と service 層が同じ cache を共有することで片側の mutation が他方の cache を stale 化しない |
| `internal/repository/user_cached_test.go` | 単体テスト網羅 |

## 既存パターンとの整合

- meta cache (#300 3-1) → `CachedMetaRepository`
- emoji cache (#300 3-6) → `CachedEmojiRepository`
- role cache (#300 3-5) → `role.Service.userRoleCache`
- 今回 (3-3) → `CachedUserRepository`

ロードマップは Redis を提案していたが、in-memory に統一する方が上記 3 件と整合し、out-of-band write (別 mk プロセスが同 DB に書く等) が前提されない単一プロセス運用では十分。

## テスト

\`\`\`sh
go test -race -count=1 -cover ./internal/repository/
ok      github.com/shiroha-a/mk/internal/repository    coverage: 91.0% of statements
\`\`\`

新規テスト: hit (10 calls → 1 inner call) / negative cache (5 NotFound → 1 inner call) / transient err 非 cache / TTL 失効 / `UpdateUser` invalidate / 失敗 `UpdateUser` は invalidate しない / `UpdateProfile` で user 側 cache も飛ぶ / `CreateProfile` で negative cache を踏み消す / increment 系 invalidate / public `Invalidate(userID)` / 空 ID bypass。

`go vet ./...` クリーン、`gofmt -s -d .` 差分なし、`go build ./...` クリーン、`./internal/core/user/` と `./internal/server/middleware/` の既存テストも全 pass。

## スコープ外

- 3-7 singleflight — 別 PR

Closes #551
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/shiroha-a/mk/pull/552" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
