### PR TITLE
Fix #496: outbound 通信 config (proxySmtp / outgoingAddress / Family) を wire

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -116,12 +116,12 @@ cp .config/docker.yml.example .config/docker.yml
 
 | キー | 型 | デフォルト | 説明 |
 |---|---|---|---|
-| `proxy` | string | - | HTTPプロキシURL |
-| `proxySmtp` | string | - | SMTPプロキシURL |
-| `proxyBypassHosts` | []string | - | プロキシを迂回するホスト |
+| `proxy` | string | - | 外向き HTTP のプロキシ URL (PR #485) |
+| `proxySmtp` | string | - | SMTP 配送のプロキシ URL。`http://host:port` (HTTP CONNECT)、`https://host:port`、`socks5://[user:pass@]host:port` (#496) |
+| `proxyBypassHosts` | []string | - | プロキシを迂回するホスト (HTTP のみ) |
 | `allowedPrivateNetworks` | []string | - | AP fetchで許可するプライベートネットワーク |
-| `outgoingAddress` | string | - | 送信元IPアドレス |
-| `outgoingAddressFamily` | string | - | アドレスファミリー (`"ipv4"`, `"ipv6"`, `"dual"`) |
+| `outgoingAddress` | string | - | 外向き HTTP の送信元 IP として bind するアドレス。複数 NIC 環境で federation 配信の source IP を固定する用途 (#496)。不正値は警告のみで kernel auto-pick に fallback |
+| `outgoingAddressFamily` | string | `dual` | DNS 解決後の IP family 制限。`"ipv4"` / `"ipv6"` 指定で該当 family のみで dial、`"dual"` または空で両方 (#496) |
 
 ### 検索
 

--- a/internal/api/admin/handler.go
+++ b/internal/api/admin/handler.go
@@ -87,6 +87,7 @@ type Handler struct {
 	noteFinder              NoteFinder
 	resetReqRepo            repository.PasswordResetRequestRepository
 	emailSender             EmailSender
+	smtpProxyURL            string
 	serverURL               string
 	idGen                   id.Generator
 	configSetupPassword     string
@@ -167,6 +168,11 @@ func (h *Handler) SetPasswordResetRepo(r repository.PasswordResetRequestReposito
 // reset emails. If nil, admin/reset-password falls back to returning a
 // temporary password.
 func (h *Handler) SetEmailSender(s EmailSender) { h.emailSender = s }
+
+// SetSMTPProxyURL forwards admin/send-email TCP connections through the
+// configured proxy (cfg.ProxySmtp). Empty string disables the proxy and
+// falls back to direct dial. See internal/misc/smtp.SendWithOptions.
+func (h *Handler) SetSMTPProxyURL(u string) { h.smtpProxyURL = u }
 
 // SetServerURL sets the base URL used inside password-reset email bodies.
 func (h *Handler) SetServerURL(u string) { h.serverURL = u }

--- a/internal/api/admin/handler_stubs.go
+++ b/internal/api/admin/handler_stubs.go
@@ -307,7 +307,7 @@ func (h *Handler) SendEmail(c echo.Context) error {
 			if m.SmtpPort != nil {
 				port = *m.SmtpPort
 			}
-			go smtp.Send(*m.SmtpHost, port, m.SmtpUser, m.SmtpPass, *m.Email, req.To, req.Subject, req.Text)
+			go smtp.SendWithOptions(*m.SmtpHost, port, m.SmtpUser, m.SmtpPass, *m.Email, req.To, req.Subject, req.Text, smtp.Options{ProxyURL: h.smtpProxyURL})
 		}
 	}
 	return c.NoContent(http.StatusNoContent)

--- a/internal/misc/smtp/smtp.go
+++ b/internal/misc/smtp/smtp.go
@@ -6,6 +6,7 @@
 package smtp
 
 import (
+	"bufio"
 	"context"
 	"crypto/tls"
 	"encoding/base64"
@@ -168,6 +169,13 @@ func dialSOCKS5(u *url.URL, addr string, timeout time.Duration) (net.Conn, error
 // CONNECT request to tunnel through to addr. TLS over HTTP CONNECT (https://
 // proxy) は proxy への接続を TLS で包んでから CONNECT を送る; SMTP server
 // 側の StartTLS とは独立。
+//
+// 重要: 実 proxy (Squid / nginx 等) は target に先に接続して greeting を
+// バッファし、200 応答とまとめて 1 TCP segment で push する場合がある。
+// 単純な conn.Read だと SMTP banner まで読み込んで捨ててしまうため、
+// bufio.Reader で CONNECT 応答だけを正確に消費し、残った bytes は
+// 接続に noticed させて caller (gosmtp.NewClient) に届ける必要がある。
+// readCONNECTResponse + bufferedConn でこれを実装する。
 func dialHTTPConnect(u *url.URL, addr string, timeout time.Duration) (net.Conn, error) {
 	proxyHost := u.Host
 	if _, _, splitErr := net.SplitHostPort(proxyHost); splitErr != nil {
@@ -208,42 +216,58 @@ func dialHTTPConnect(u *url.URL, addr string, timeout time.Duration) (net.Conn, 
 		return nil, fmt.Errorf("write CONNECT: %w", err)
 	}
 
-	// CONNECT 応答 1 行目のみで判定。"HTTP/1.1 200" を含めば OK、それ以外は
-	// fail。残りの header 行は捨て (空行 or EOF まで読み進めても良いが、
-	// SMTP 用途では proxy 応答後すぐに smtp プロトコルが流れ始めるので
-	// 単純実装で十分)。
-	if err := readCONNECTResponse(conn); err != nil {
+	// bufio.Reader で CONNECT 応答 (status line + 空行までの header) を
+	// line-by-line で読む。Read 1 回で SMTP banner まで巻き込まないこと、
+	// それでも buffer に残ったバイトは bufferedConn 経由で gosmtp.NewClient
+	// に届くことを保証する。
+	br := bufio.NewReader(conn)
+	if err := readCONNECTResponse(conn, br); err != nil {
 		_ = conn.Close()
 		return nil, err
 	}
-	return conn, nil
+	return &bufferedConn{Conn: conn, r: br}, nil
 }
 
-// readCONNECTResponse parses the proxy's HTTP/1.1 CONNECT response. Returns
-// nil on 2xx (tunnel established), error otherwise.
-func readCONNECTResponse(conn net.Conn) error {
-	buf := make([]byte, 4096)
+// bufferedConn wraps net.Conn so subsequent Reads draw from a bufio.Reader
+// buffer first (consumed bytes that were left over after CONNECT response
+// parsing). Writes / Close / Deadline 系は素 conn にそのまま委譲する。
+type bufferedConn struct {
+	net.Conn
+	r *bufio.Reader
+}
+
+func (b *bufferedConn) Read(p []byte) (int, error) { return b.r.Read(p) }
+
+// readCONNECTResponse parses the proxy's HTTP/1.1 CONNECT response from a
+// bufio.Reader. Returns nil on 2xx, error otherwise. Header 行は status の
+// 後ろの空行まで読み捨てる。実 proxy が buffer した SMTP banner は br に
+// 残し、後段の bufferedConn で gosmtp に渡す。
+func readCONNECTResponse(conn net.Conn, br *bufio.Reader) error {
 	if err := conn.SetReadDeadline(time.Now().Add(10 * time.Second)); err != nil {
 		return fmt.Errorf("set read deadline: %w", err)
 	}
 	defer func() { _ = conn.SetReadDeadline(time.Time{}) }()
 
-	n, err := conn.Read(buf)
-	if err != nil && n == 0 {
-		return fmt.Errorf("read CONNECT response: %w", err)
+	statusLine, err := br.ReadString('\n')
+	if err != nil {
+		return fmt.Errorf("read CONNECT status line: %w", err)
 	}
-	resp := string(buf[:n])
-	// 1 行目: "HTTP/1.1 200 Connection established"
-	idx := strings.Index(resp, "\r\n")
-	if idx < 0 {
-		return fmt.Errorf("malformed CONNECT response: %q", resp)
-	}
-	statusLine := resp[:idx]
+	statusLine = strings.TrimRight(statusLine, "\r\n")
 	parts := strings.SplitN(statusLine, " ", 3)
 	if len(parts) < 2 || !strings.HasPrefix(parts[1], "2") {
 		return fmt.Errorf("CONNECT failed: %s", statusLine)
 	}
-	return nil
+	// header 行を空行まで消費する。Header line を超えた bytes は bufio
+	// の buffer に残り、bufferedConn 経由で次の Read に渡る。
+	for {
+		line, err := br.ReadString('\n')
+		if err != nil {
+			return fmt.Errorf("read CONNECT headers: %w", err)
+		}
+		if line == "\r\n" || line == "\n" {
+			return nil
+		}
+	}
 }
 
 // encodeBasicAuth returns the base64 form of "user:pass" for the

--- a/internal/misc/smtp/smtp.go
+++ b/internal/misc/smtp/smtp.go
@@ -6,14 +6,30 @@
 package smtp
 
 import (
+	"context"
 	"crypto/tls"
+	"encoding/base64"
+	"errors"
 	"fmt"
 	"log/slog"
 	"net"
 	gosmtp "net/smtp"
+	"net/url"
 	"strings"
 	"time"
+
+	"golang.org/x/net/proxy"
 )
+
+// Options holds optional configuration for Send. Future flags (TLS mode,
+// timeouts, etc) live here. Zero-value is "no overrides".
+type Options struct {
+	// ProxyURL routes the SMTP TCP connection through a forward proxy.
+	// 形式は upstream Misskey の `proxySmtp` と同じく URL (scheme で
+	// プロトコルを指定): `socks5://user:pass@host:1080` または
+	// `http://host:3128` (HTTP CONNECT)。空文字なら direct dial。
+	ProxyURL string
+}
 
 // sanitizeHeaderValue strips CR and LF characters to prevent SMTP header
 // injection.
@@ -24,8 +40,15 @@ func sanitizeHeaderValue(s string) string {
 	return r.Replace(s)
 }
 
-// Send sends a plain-text email via SMTP.
+// Send sends a plain-text email via SMTP. Direct dial; equivalent to
+// SendWithOptions(.., Options{}).
 func Send(host string, port int, user, pass *string, from, to, subject, body string) {
+	SendWithOptions(host, port, user, pass, from, to, subject, body, Options{})
+}
+
+// SendWithOptions is Send + functional options. Currently only ProxyURL is
+// supported; mismatched scheme falls back to direct dial with a warning.
+func SendWithOptions(host string, port int, user, pass *string, from, to, subject, body string, opts Options) {
 	addr := net.JoinHostPort(host, fmt.Sprintf("%d", port))
 
 	// ヘッダーフィールドのCRLFインジェクション対策
@@ -42,9 +65,9 @@ func Send(host string, port int, user, pass *string, from, to, subject, body str
 		from, to, subject, body)
 
 	tlsConfig := &tls.Config{ServerName: host}
-	conn, err := net.DialTimeout("tcp", addr, 10*time.Second)
+	conn, err := dialSMTP(addr, opts.ProxyURL, 10*time.Second)
 	if err != nil {
-		slog.Warn("email: dial failed", "error", err)
+		slog.Warn("email: dial failed", "error", err, "proxyConfigured", opts.ProxyURL != "")
 		return
 	}
 
@@ -86,3 +109,151 @@ func Send(host string, port int, user, pass *string, from, to, subject, body str
 
 	slog.Info("email sent", "to", to, "subject", subject)
 }
+
+// dialSMTP opens a TCP connection to addr (SMTP server). When proxyURL is
+// set, the connection is tunnelled via the named proxy:
+//
+//   - socks5://[user:pass@]host:port → SOCKS5 (golang.org/x/net/proxy)
+//   - socks5h:// は socks5 と同じ扱い (Go 標準では区別しない)
+//   - http://host:port / https://host:port → HTTP CONNECT tunnel
+//
+// 不明な scheme / parse 失敗時は warn ログを出して direct dial にフォール
+// バックする (proxy 設定ミスでメール送信全停止になるよりは、direct で
+// 送れる経路があれば送る方を優先する)。
+func dialSMTP(addr, proxyURL string, timeout time.Duration) (net.Conn, error) {
+	if proxyURL == "" {
+		return net.DialTimeout("tcp", addr, timeout)
+	}
+	u, err := url.Parse(proxyURL)
+	if err != nil || u.Host == "" {
+		slog.Warn("email: invalid proxySmtp URL, falling back to direct dial",
+			"proxySmtp", proxyURL, "err", err)
+		return net.DialTimeout("tcp", addr, timeout)
+	}
+	switch strings.ToLower(u.Scheme) {
+	case "socks5", "socks5h":
+		return dialSOCKS5(u, addr, timeout)
+	case "http", "https":
+		return dialHTTPConnect(u, addr, timeout)
+	default:
+		slog.Warn("email: unsupported proxySmtp scheme, falling back to direct dial",
+			"scheme", u.Scheme)
+		return net.DialTimeout("tcp", addr, timeout)
+	}
+}
+
+// dialSOCKS5 wraps golang.org/x/net/proxy.SOCKS5 with the configured
+// timeout. user/pass は URL の userinfo から取り出す (空なら認証無し)。
+func dialSOCKS5(u *url.URL, addr string, timeout time.Duration) (net.Conn, error) {
+	var auth *proxy.Auth
+	if u.User != nil {
+		pw, _ := u.User.Password()
+		auth = &proxy.Auth{User: u.User.Username(), Password: pw}
+	}
+	d, err := proxy.SOCKS5("tcp", u.Host, auth, &net.Dialer{Timeout: timeout})
+	if err != nil {
+		return nil, fmt.Errorf("socks5 setup: %w", err)
+	}
+	// proxy.Dialer.Dial は context をサポートしないが、x/net/proxy の
+	// SOCKS5 内部 Dialer に Timeout を渡しているので接続全体に伝播する。
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	defer cancel()
+	if cd, ok := d.(proxy.ContextDialer); ok {
+		return cd.DialContext(ctx, "tcp", addr)
+	}
+	return d.Dial("tcp", addr)
+}
+
+// dialHTTPConnect opens a TCP connection to the HTTP proxy and issues a
+// CONNECT request to tunnel through to addr. TLS over HTTP CONNECT (https://
+// proxy) は proxy への接続を TLS で包んでから CONNECT を送る; SMTP server
+// 側の StartTLS とは独立。
+func dialHTTPConnect(u *url.URL, addr string, timeout time.Duration) (net.Conn, error) {
+	proxyHost := u.Host
+	if _, _, splitErr := net.SplitHostPort(proxyHost); splitErr != nil {
+		port := "80"
+		if strings.EqualFold(u.Scheme, "https") {
+			port = "443"
+		}
+		proxyHost = net.JoinHostPort(u.Hostname(), port)
+	}
+
+	dialer := &net.Dialer{Timeout: timeout}
+	var conn net.Conn
+	var err error
+	if strings.EqualFold(u.Scheme, "https") {
+		conn, err = tls.DialWithDialer(dialer, "tcp", proxyHost, &tls.Config{ServerName: u.Hostname()})
+	} else {
+		conn, err = dialer.Dial("tcp", proxyHost)
+	}
+	if err != nil {
+		return nil, fmt.Errorf("dial proxy %s: %w", proxyHost, err)
+	}
+
+	req := fmt.Sprintf("CONNECT %s HTTP/1.1\r\nHost: %s\r\n", addr, addr)
+	if u.User != nil {
+		// Basic auth — RFC 7617 base64(user:pass). 空 user / 空 pass は省略。
+		username := u.User.Username()
+		password, _ := u.User.Password()
+		if username != "" || password != "" {
+			creds := username + ":" + password
+			encoded := encodeBasicAuth(creds)
+			req += "Proxy-Authorization: Basic " + encoded + "\r\n"
+		}
+	}
+	req += "\r\n"
+
+	if _, err := conn.Write([]byte(req)); err != nil {
+		_ = conn.Close()
+		return nil, fmt.Errorf("write CONNECT: %w", err)
+	}
+
+	// CONNECT 応答 1 行目のみで判定。"HTTP/1.1 200" を含めば OK、それ以外は
+	// fail。残りの header 行は捨て (空行 or EOF まで読み進めても良いが、
+	// SMTP 用途では proxy 応答後すぐに smtp プロトコルが流れ始めるので
+	// 単純実装で十分)。
+	if err := readCONNECTResponse(conn); err != nil {
+		_ = conn.Close()
+		return nil, err
+	}
+	return conn, nil
+}
+
+// readCONNECTResponse parses the proxy's HTTP/1.1 CONNECT response. Returns
+// nil on 2xx (tunnel established), error otherwise.
+func readCONNECTResponse(conn net.Conn) error {
+	buf := make([]byte, 4096)
+	if err := conn.SetReadDeadline(time.Now().Add(10 * time.Second)); err != nil {
+		return fmt.Errorf("set read deadline: %w", err)
+	}
+	defer func() { _ = conn.SetReadDeadline(time.Time{}) }()
+
+	n, err := conn.Read(buf)
+	if err != nil && n == 0 {
+		return fmt.Errorf("read CONNECT response: %w", err)
+	}
+	resp := string(buf[:n])
+	// 1 行目: "HTTP/1.1 200 Connection established"
+	idx := strings.Index(resp, "\r\n")
+	if idx < 0 {
+		return fmt.Errorf("malformed CONNECT response: %q", resp)
+	}
+	statusLine := resp[:idx]
+	parts := strings.SplitN(statusLine, " ", 3)
+	if len(parts) < 2 || !strings.HasPrefix(parts[1], "2") {
+		return fmt.Errorf("CONNECT failed: %s", statusLine)
+	}
+	return nil
+}
+
+// encodeBasicAuth returns the base64 form of "user:pass" for the
+// Proxy-Authorization header.
+func encodeBasicAuth(s string) string {
+	return base64.StdEncoding.EncodeToString([]byte(s))
+}
+
+// errProxyTunnelFailed is exported for tests. (Currently dial errors are
+// wrapped via fmt.Errorf, but a sentinel kept as an extension point.)
+var errProxyTunnelFailed = errors.New("proxy tunnel failed")
+
+var _ = errProxyTunnelFailed

--- a/internal/misc/smtp/smtp_test.go
+++ b/internal/misc/smtp/smtp_test.go
@@ -302,8 +302,10 @@ func TestSend_DialFailureIsBestEffort(t *testing.T) {
 }
 
 // #496: HTTP CONNECT proxy 経由で SMTP サーバに接続できることを確認する。
-// proxy は CONNECT を受けた後そのまま target SMTP との bidirectional pipe
-// になる minimum 実装。target SMTP は fakeSMTP を流用。
+// 実 proxy (Squid 等) の挙動を真似て、target SMTP に先に接続して banner を
+// バッファし、HTTP 200 応答 + banner を 1 write で client に push する。
+// 旧実装の readCONNECTResponse は raw conn.Read で over-read していたため
+// このシナリオで SMTP banner を握り潰して接続が hang していた (#553 review)。
 func TestSendWithOptions_HTTPConnectProxy(t *testing.T) {
 	srv := newFakeSMTP(t, false)
 	targetAddr := fmt.Sprintf("127.0.0.1:%d", srv.port())
@@ -320,7 +322,8 @@ func TestSendWithOptions_HTTPConnectProxy(t *testing.T) {
 			return
 		}
 		defer client.Close()
-		// CONNECT request を読み捨てて 200 を返し、target に pipe する。
+
+		// 1) CONNECT request を読み捨て
 		r := bufio.NewReader(client)
 		for {
 			line, err := r.ReadString('\n')
@@ -331,22 +334,28 @@ func TestSendWithOptions_HTTPConnectProxy(t *testing.T) {
 				break
 			}
 		}
-		fmt.Fprint(client, "HTTP/1.1 200 Connection established\r\n\r\n")
+		// 2) 先に target に dial して banner を 1 行読む (実 proxy 動作の
+		//    模倣)。fakeSMTP は accept 後即 "220 localhost ESMTP\r\n" を送る。
 		target, err := net.Dial("tcp", targetAddr)
 		if err != nil {
 			return
 		}
 		defer target.Close()
-		// pipe both directions
+		bannerBuf := make([]byte, 256)
+		_ = target.SetReadDeadline(time.Now().Add(2 * time.Second))
+		n, _ := target.Read(bannerBuf)
+		_ = target.SetReadDeadline(time.Time{})
+
+		// 3) 200 応答 + banner を 1 write で push (TCP coalescing simulation)。
+		_, _ = client.Write(append(
+			[]byte("HTTP/1.1 200 Connection established\r\n\r\n"),
+			bannerBuf[:n]...,
+		))
+
+		// 4) 以降は通常 pipe。
 		done := make(chan struct{}, 2)
-		go func() {
-			_, _ = copyConn(target, r)
-			done <- struct{}{}
-		}()
-		go func() {
-			_, _ = copyConn(client, target)
-			done <- struct{}{}
-		}()
+		go func() { _, _ = copyConn(target, r); done <- struct{}{} }()
+		go func() { _, _ = copyConn(client, target); done <- struct{}{} }()
 		<-done
 	}()
 

--- a/internal/misc/smtp/smtp_test.go
+++ b/internal/misc/smtp/smtp_test.go
@@ -300,3 +300,399 @@ func TestSend_DialFailureIsBestEffort(t *testing.T) {
 	_ = ln.Close()
 	Send("127.0.0.1", port, nil, nil, "from@example.com", "to@example.com", "subj", "body")
 }
+
+// #496: HTTP CONNECT proxy 経由で SMTP サーバに接続できることを確認する。
+// proxy は CONNECT を受けた後そのまま target SMTP との bidirectional pipe
+// になる minimum 実装。target SMTP は fakeSMTP を流用。
+func TestSendWithOptions_HTTPConnectProxy(t *testing.T) {
+	srv := newFakeSMTP(t, false)
+	targetAddr := fmt.Sprintf("127.0.0.1:%d", srv.port())
+
+	proxyLn, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen proxy: %v", err)
+	}
+	t.Cleanup(func() { _ = proxyLn.Close() })
+
+	go func() {
+		client, err := proxyLn.Accept()
+		if err != nil {
+			return
+		}
+		defer client.Close()
+		// CONNECT request を読み捨てて 200 を返し、target に pipe する。
+		r := bufio.NewReader(client)
+		for {
+			line, err := r.ReadString('\n')
+			if err != nil {
+				return
+			}
+			if line == "\r\n" {
+				break
+			}
+		}
+		fmt.Fprint(client, "HTTP/1.1 200 Connection established\r\n\r\n")
+		target, err := net.Dial("tcp", targetAddr)
+		if err != nil {
+			return
+		}
+		defer target.Close()
+		// pipe both directions
+		done := make(chan struct{}, 2)
+		go func() {
+			_, _ = copyConn(target, r)
+			done <- struct{}{}
+		}()
+		go func() {
+			_, _ = copyConn(client, target)
+			done <- struct{}{}
+		}()
+		<-done
+	}()
+
+	proxyURL := fmt.Sprintf("http://%s", proxyLn.Addr().String())
+	SendWithOptions("127.0.0.1", srv.port(), nil, nil,
+		"from@example.com", "to@example.com", "subj", "body",
+		Options{ProxyURL: proxyURL})
+
+	msgs := waitForMessages(srv, 3)
+	if len(msgs) < 3 {
+		t.Fatalf("expected ≥3 SMTP exchanges via proxy, got %d: %v", len(msgs), msgs)
+	}
+}
+
+// 不正な proxy URL が指定された場合は warn ログを出して direct dial に
+// fallback する。SMTP 配送そのものは止まらない (best-effort 方針)。
+func TestSendWithOptions_InvalidProxyFallsBackToDirect(t *testing.T) {
+	srv := newFakeSMTP(t, false)
+	SendWithOptions("127.0.0.1", srv.port(), nil, nil,
+		"from@example.com", "to@example.com", "subj", "body",
+		Options{ProxyURL: "://not-a-url"})
+	if len(waitForMessages(srv, 3)) < 3 {
+		t.Fatalf("expected SMTP delivery via direct fallback")
+	}
+}
+
+// 未対応 scheme (例: ftp) も direct fallback する。
+func TestSendWithOptions_UnsupportedSchemeFallsBackToDirect(t *testing.T) {
+	srv := newFakeSMTP(t, false)
+	SendWithOptions("127.0.0.1", srv.port(), nil, nil,
+		"from@example.com", "to@example.com", "subj", "body",
+		Options{ProxyURL: "ftp://127.0.0.1:21"})
+	if len(waitForMessages(srv, 3)) < 3 {
+		t.Fatalf("expected SMTP delivery via direct fallback")
+	}
+}
+
+// HTTP CONNECT が non-2xx で返してきた場合は接続失敗扱いで panic せず
+// 終了する。
+func TestSendWithOptions_HTTPConnectRejected(t *testing.T) {
+	proxyLn, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen proxy: %v", err)
+	}
+	t.Cleanup(func() { _ = proxyLn.Close() })
+
+	go func() {
+		client, err := proxyLn.Accept()
+		if err != nil {
+			return
+		}
+		defer client.Close()
+		r := bufio.NewReader(client)
+		for {
+			line, err := r.ReadString('\n')
+			if err != nil {
+				return
+			}
+			if line == "\r\n" {
+				break
+			}
+		}
+		fmt.Fprint(client, "HTTP/1.1 403 Forbidden\r\n\r\n")
+	}()
+
+	defer func() {
+		if r := recover(); r != nil {
+			t.Fatalf("Send panicked on proxy 403: %v", r)
+		}
+	}()
+	SendWithOptions("127.0.0.1", 25, nil, nil,
+		"from@example.com", "to@example.com", "subj", "body",
+		Options{ProxyURL: "http://" + proxyLn.Addr().String()})
+}
+
+func TestEncodeBasicAuth(t *testing.T) {
+	if got := encodeBasicAuth("alice:secret"); got != "YWxpY2U6c2VjcmV0" {
+		t.Errorf("encodeBasicAuth: got %q", got)
+	}
+}
+
+// HTTP CONNECT proxy で Proxy-Authorization Basic ヘッダが付与されることを
+// 確認する。proxy 側で受信した CONNECT request 全体を録画してアサート。
+func TestSendWithOptions_HTTPConnectBasicAuth(t *testing.T) {
+	srv := newFakeSMTP(t, false)
+	targetAddr := fmt.Sprintf("127.0.0.1:%d", srv.port())
+
+	proxyLn, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen proxy: %v", err)
+	}
+	t.Cleanup(func() { _ = proxyLn.Close() })
+
+	var capturedReq strings.Builder
+	go func() {
+		client, err := proxyLn.Accept()
+		if err != nil {
+			return
+		}
+		defer client.Close()
+		r := bufio.NewReader(client)
+		for {
+			line, err := r.ReadString('\n')
+			if err != nil {
+				return
+			}
+			capturedReq.WriteString(line)
+			if line == "\r\n" {
+				break
+			}
+		}
+		fmt.Fprint(client, "HTTP/1.1 200 Connection established\r\n\r\n")
+		target, err := net.Dial("tcp", targetAddr)
+		if err != nil {
+			return
+		}
+		defer target.Close()
+		done := make(chan struct{}, 2)
+		go func() { _, _ = copyConn(target, r); done <- struct{}{} }()
+		go func() { _, _ = copyConn(client, target); done <- struct{}{} }()
+		<-done
+	}()
+
+	proxyURL := fmt.Sprintf("http://alice:secret@%s", proxyLn.Addr().String())
+	SendWithOptions("127.0.0.1", srv.port(), nil, nil,
+		"from@example.com", "to@example.com", "subj", "body",
+		Options{ProxyURL: proxyURL})
+	_ = waitForMessages(srv, 3)
+
+	got := capturedReq.String()
+	if !strings.Contains(got, "Proxy-Authorization: Basic YWxpY2U6c2VjcmV0") {
+		t.Errorf("Proxy-Authorization header missing or wrong: %q", got)
+	}
+}
+
+// SOCKS5 with username/password auth: x/net/proxy が Auth method 0x02 を
+// negotiate するので fake server も対応する。
+func TestSendWithOptions_SOCKS5WithAuth(t *testing.T) {
+	srv := newFakeSMTP(t, false)
+	targetPort := srv.port()
+
+	proxyLn, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen socks5: %v", err)
+	}
+	t.Cleanup(func() { _ = proxyLn.Close() })
+
+	go func() {
+		client, err := proxyLn.Accept()
+		if err != nil {
+			return
+		}
+		defer client.Close()
+		// Greeting: read VER + NMETHODS
+		hdr := make([]byte, 2)
+		if _, err := client.Read(hdr); err != nil {
+			return
+		}
+		methods := make([]byte, int(hdr[1]))
+		_, _ = client.Read(methods)
+		// Select user/pass auth (0x02)
+		_, _ = client.Write([]byte{0x05, 0x02})
+
+		// Read sub-negotiation: VER=1, ULEN, UNAME, PLEN, PASSWD
+		auth := make([]byte, 256)
+		n, _ := client.Read(auth)
+		_ = n
+		// 認証成功: VER=1, STATUS=0
+		_, _ = client.Write([]byte{0x01, 0x00})
+
+		// CONNECT (VER+CMD+RSV+ATYP+ADDR+PORT = 10 bytes for IPv4)
+		req := make([]byte, 10)
+		_, _ = client.Read(req)
+		_, _ = client.Write([]byte{0x05, 0x00, 0x00, 0x01, 0, 0, 0, 0, 0, 0})
+
+		target, err := net.Dial("tcp", fmt.Sprintf("127.0.0.1:%d", targetPort))
+		if err != nil {
+			return
+		}
+		defer target.Close()
+		done := make(chan struct{}, 2)
+		go func() { _, _ = copyConn(target, client); done <- struct{}{} }()
+		go func() { _, _ = copyConn(client, target); done <- struct{}{} }()
+		<-done
+	}()
+
+	proxyURL := fmt.Sprintf("socks5://alice:secret@%s", proxyLn.Addr().String())
+	SendWithOptions("127.0.0.1", targetPort, nil, nil,
+		"from@example.com", "to@example.com", "subj", "body",
+		Options{ProxyURL: proxyURL})
+	if len(waitForMessages(srv, 3)) < 3 {
+		t.Fatalf("expected SMTP delivery via authenticated SOCKS5")
+	}
+}
+
+// CONNECT 応答が malformed (CRLF 無し) のとき接続は close される。
+func TestSendWithOptions_HTTPConnectMalformedResponse(t *testing.T) {
+	proxyLn, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen proxy: %v", err)
+	}
+	t.Cleanup(func() { _ = proxyLn.Close() })
+	go func() {
+		client, err := proxyLn.Accept()
+		if err != nil {
+			return
+		}
+		defer client.Close()
+		// Read CONNECT (until empty line) then return malformed (no CRLF)
+		r := bufio.NewReader(client)
+		for {
+			line, err := r.ReadString('\n')
+			if err != nil {
+				return
+			}
+			if line == "\r\n" {
+				break
+			}
+		}
+		fmt.Fprint(client, "BLOB-NOT-HTTP")
+	}()
+
+	defer func() {
+		if r := recover(); r != nil {
+			t.Fatalf("Send panicked: %v", r)
+		}
+	}()
+	SendWithOptions("127.0.0.1", 25, nil, nil,
+		"from@example.com", "to@example.com", "subj", "body",
+		Options{ProxyURL: "http://" + proxyLn.Addr().String()})
+}
+
+// proxy URL に port 省略 → scheme 既定 (http=80) を補う経路。port 80 への
+// 接続は dial timeout か connection refused になるが、SendWithOptions は
+// best-effort で panic せず終了する。
+func TestSendWithOptions_HTTPProxyDefaultPort(t *testing.T) {
+	defer func() {
+		if r := recover(); r != nil {
+			t.Fatalf("Send panicked on default port path: %v", r)
+		}
+	}()
+	SendWithOptions("127.0.0.1", 25, nil, nil,
+		"from@example.com", "to@example.com", "subj", "body",
+		Options{ProxyURL: "http://127.0.0.1"}) // no port → default 80
+}
+
+// HTTPS proxy URL は tls.DialWithDialer 経路に入る。proxy 側に TLS 立てる
+// テストは大変なので、TLS handshake 失敗 (= proxy が plain TCP) で
+// 想定通り dial error になることを確認する (= HTTPS branch コード実行
+// 確認のみ、実 SMTP は届かない)。
+func TestSendWithOptions_HTTPSProxyTLSHandshakeFails(t *testing.T) {
+	proxyLn, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen proxy: %v", err)
+	}
+	t.Cleanup(func() { _ = proxyLn.Close() })
+	go func() {
+		c, _ := proxyLn.Accept()
+		if c != nil {
+			c.Close()
+		}
+	}()
+	defer func() {
+		if r := recover(); r != nil {
+			t.Fatalf("Send panicked: %v", r)
+		}
+	}()
+	SendWithOptions("127.0.0.1", 25, nil, nil,
+		"from@example.com", "to@example.com", "subj", "body",
+		Options{ProxyURL: "https://" + proxyLn.Addr().String()})
+}
+
+// SOCKS5 proxy 経由の dial 経路を確認。fake SOCKS5 server が CONNECT を
+// 受けて target SMTP に proxy する。
+func TestSendWithOptions_SOCKS5Proxy(t *testing.T) {
+	srv := newFakeSMTP(t, false)
+	targetPort := srv.port()
+
+	proxyLn, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen socks5: %v", err)
+	}
+	t.Cleanup(func() { _ = proxyLn.Close() })
+
+	go func() {
+		client, err := proxyLn.Accept()
+		if err != nil {
+			return
+		}
+		defer client.Close()
+		// SOCKS5 hand-shake (no-auth)
+		hdr := make([]byte, 2)
+		if _, err := client.Read(hdr); err != nil {
+			return
+		}
+		nMethods := int(hdr[1])
+		methods := make([]byte, nMethods)
+		_, _ = client.Read(methods)
+		// 0x05 0x00 = no-auth selected
+		_, _ = client.Write([]byte{0x05, 0x00})
+
+		// CONNECT request: VER=5, CMD=1 (CONNECT), RSV=0, ATYP=1 (IPv4),
+		// DST.ADDR=4 bytes, DST.PORT=2 bytes
+		req := make([]byte, 10)
+		if _, err := client.Read(req); err != nil {
+			return
+		}
+		// Reply: VER=5, REP=0 (success), RSV=0, ATYP=1, BND.ADDR=0.0.0.0, BND.PORT=0
+		_, _ = client.Write([]byte{0x05, 0x00, 0x00, 0x01, 0, 0, 0, 0, 0, 0})
+
+		// Pipe to target SMTP server.
+		target, err := net.Dial("tcp", fmt.Sprintf("127.0.0.1:%d", targetPort))
+		if err != nil {
+			return
+		}
+		defer target.Close()
+		done := make(chan struct{}, 2)
+		go func() { _, _ = copyConn(target, client); done <- struct{}{} }()
+		go func() { _, _ = copyConn(client, target); done <- struct{}{} }()
+		<-done
+	}()
+
+	proxyURL := fmt.Sprintf("socks5://%s", proxyLn.Addr().String())
+	SendWithOptions("127.0.0.1", targetPort, nil, nil,
+		"from@example.com", "to@example.com", "subj", "body",
+		Options{ProxyURL: proxyURL})
+	if len(waitForMessages(srv, 3)) < 3 {
+		t.Fatalf("expected SMTP delivery via SOCKS5 proxy")
+	}
+}
+
+// copyConn shuttles bytes from src to dst. Local helper for the proxy test
+// (avoids pulling in io.Copy's interface dance).
+func copyConn(dst net.Conn, src interface{ Read([]byte) (int, error) }) (int64, error) {
+	buf := make([]byte, 4096)
+	var total int64
+	for {
+		n, err := src.Read(buf)
+		if n > 0 {
+			if _, werr := dst.Write(buf[:n]); werr != nil {
+				return total, werr
+			}
+			total += int64(n)
+		}
+		if err != nil {
+			return total, err
+		}
+	}
+}

--- a/internal/safehttp/ssrf.go
+++ b/internal/safehttp/ssrf.go
@@ -10,6 +10,7 @@ import (
 	"net"
 	"net/http"
 	"net/url"
+	"strings"
 	"time"
 )
 
@@ -52,8 +53,10 @@ var ErrSSRFBlocked = fmt.Errorf("safehttp: connection to private IP blocked")
 
 // transportOptions accumulates state from functional Option values.
 type transportOptions struct {
-	proxyURL    string
-	bypassHosts []string
+	proxyURL      string
+	bypassHosts   []string
+	localAddr     string
+	addressFamily string
 }
 
 // Option configures NewSSRFSafeTransport. Use WithProxy to enable forward
@@ -70,6 +73,23 @@ func WithProxy(proxyURL string, bypassHosts []string) Option {
 		o.proxyURL = proxyURL
 		o.bypassHosts = bypassHosts
 	}
+}
+
+// WithOutgoingAddress binds outbound TCP connections to the given local IP
+// (cfg.OutgoingAddress) — useful on multi-NIC hosts where federation should
+// originate from a specific source. Empty string is a no-op (kernel picks).
+// Invalid IP は warn ログを出してそのまま no-op (起動時 fail-fast より
+// best-effort 起動を優先する)。
+func WithOutgoingAddress(addr string) Option {
+	return func(o *transportOptions) { o.localAddr = addr }
+}
+
+// WithAddressFamily restricts DNS resolution / dial path to one address
+// family. Accepts "ipv4" / "ipv6" / "dual" (or empty = dual). 不正値は
+// dual にフォールバック。upstream Misskey の `outgoingAddressFamily` と
+// 同じ semantics で、IPv6 障害のリモートを IPv4 強制で迂回する用途。
+func WithAddressFamily(family string) Option {
+	return func(o *transportOptions) { o.addressFamily = family }
 }
 
 // NewSSRFSafeTransport returns an *http.Transport with a custom DialContext
@@ -125,6 +145,17 @@ func NewSSRFSafeTransport(allowedCIDRs []string, opts ...Option) *http.Transport
 		Timeout:   10 * time.Second,
 		KeepAlive: 30 * time.Second,
 	}
+	// outgoingAddress: 指定があれば本ホストの該当 IP を source として bind
+	// する。parse 失敗は warn のみ (操作ミスで全 outbound を止めない方針)。
+	if o.localAddr != "" {
+		if ip := net.ParseIP(o.localAddr); ip != nil {
+			dialer.LocalAddr = &net.TCPAddr{IP: ip}
+		}
+	}
+
+	// outgoingAddressFamily: ipv4/ipv6/dual (空文字 = dual と同義)。
+	// resolved IPs を family で絞る dial 側 helper を closure に閉じ込める。
+	familyFilter := normalizeFamily(o.addressFamily)
 
 	tr := &http.Transport{
 		DialContext: func(ctx context.Context, network, addr string) (net.Conn, error) {
@@ -147,6 +178,23 @@ func NewSSRFSafeTransport(allowedCIDRs []string, opts ...Option) *http.Transport
 			ips, err := net.DefaultResolver.LookupIPAddr(ctx, host)
 			if err != nil {
 				return nil, fmt.Errorf("safehttp: DNS lookup failed for %q: %w", host, err)
+			}
+
+			// outgoingAddressFamily が ipv4/ipv6 指定なら該当 family で
+			// 絞り込み (#496)。dual / 空文字なら全 IP を維持。filter 結果が
+			// 0 件になった場合は明示的にエラーを返して曖昧な fallback を
+			// 避ける (operator が ipv4 強制したのに AAAA しか無い host 等)。
+			if familyFilter != "" {
+				filtered := ips[:0]
+				for _, ipAddr := range ips {
+					if matchFamily(ipAddr.IP, familyFilter) {
+						filtered = append(filtered, ipAddr)
+					}
+				}
+				if len(filtered) == 0 {
+					return nil, fmt.Errorf("safehttp: no %s address resolved for %q", familyFilter, host)
+				}
+				ips = filtered
 			}
 
 			// 全解決IPがプライベートでないか検証
@@ -187,6 +235,29 @@ func NewSSRFSafeTransport(allowedCIDRs []string, opts ...Option) *http.Transport
 		}
 	}
 	return tr
+}
+
+// normalizeFamily lowercases and validates the family string. Returns
+// "ipv4" / "ipv6" for valid filters, or "" for dual / empty / unrecognized
+// values (treat as no-filter, matching upstream Misskey behaviour).
+func normalizeFamily(s string) string {
+	switch strings.ToLower(strings.TrimSpace(s)) {
+	case "ipv4":
+		return "ipv4"
+	case "ipv6":
+		return "ipv6"
+	}
+	return ""
+}
+
+// matchFamily reports whether ip belongs to the requested address family.
+// IPv4-mapped IPv6 (::ffff:x.x.x.x) は IPv4 として扱う (Go の resolver は
+// 4-in-6 形式で返すことがあり、operator の意図に合致するように)。
+func matchFamily(ip net.IP, family string) bool {
+	if v4 := ip.To4(); v4 != nil {
+		return family == "ipv4"
+	}
+	return family == "ipv6"
 }
 
 // isPrivateIP returns true if ip falls within a private/reserved range

--- a/internal/safehttp/ssrf.go
+++ b/internal/safehttp/ssrf.go
@@ -7,6 +7,7 @@ package safehttp
 import (
 	"context"
 	"fmt"
+	"log/slog"
 	"net"
 	"net/http"
 	"net/url"
@@ -150,6 +151,9 @@ func NewSSRFSafeTransport(allowedCIDRs []string, opts ...Option) *http.Transport
 	if o.localAddr != "" {
 		if ip := net.ParseIP(o.localAddr); ip != nil {
 			dialer.LocalAddr = &net.TCPAddr{IP: ip}
+		} else {
+			slog.Warn("safehttp: invalid outgoingAddress, falling back to kernel auto-pick",
+				"addr", o.localAddr)
 		}
 	}
 
@@ -185,6 +189,10 @@ func NewSSRFSafeTransport(allowedCIDRs []string, opts ...Option) *http.Transport
 			// 0 件になった場合は明示的にエラーを返して曖昧な fallback を
 			// 避ける (operator が ipv4 強制したのに AAAA しか無い host 等)。
 			if familyFilter != "" {
+				// in-place slice filter: ips[:0] が underlying array を共有する
+				// が、この closure 内では ips は LookupIPAddr の戻り (毎回新規)
+				// で書き込み index は読み込み index 以下、かつ goroutine
+				// 共有もしないので safe。
 				filtered := ips[:0]
 				for _, ipAddr := range ips {
 					if matchFamily(ipAddr.IP, familyFilter) {

--- a/internal/safehttp/ssrf_test.go
+++ b/internal/safehttp/ssrf_test.go
@@ -241,6 +241,108 @@ func TestNewSSRFSafeTransport_EmptyProxyURLNoOp(t *testing.T) {
 // ErrSSRFBlocked が返らない (= proxy 一致判定が機能している) ことで
 // 間接的に検証する。dial 自体はループバック上の閉じた port なので
 // "connection refused" 系のエラーになるが、それは bug fix の対象外。
+// #496: WithOutgoingAddress / WithAddressFamily の挙動を確認する。
+// LocalAddr は実 bind しないと kernel が valid 検証しないので、Transport
+// 構築 + Dialer 経由で「不正値は無視」「正常値が反映される」だけ確認。
+
+// 不正な IP 文字列を渡しても panic せず Transport は使えるまま。
+// (内部 Dialer.LocalAddr は nil のまま = kernel auto-pick)。
+func TestNewSSRFSafeTransport_OutgoingAddressInvalidIgnored(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer ts.Close()
+
+	tr := NewSSRFSafeTransport([]string{"127.0.0.0/8"}, WithOutgoingAddress("not-an-ip"))
+	client := &http.Client{Transport: tr}
+	resp, err := client.Get(ts.URL)
+	require.NoError(t, err)
+	resp.Body.Close()
+}
+
+// 正常な loopback IP を LocalAddr に指定してもループバック宛なら通る
+// (実 bind を kernel が許可する経路)。
+func TestNewSSRFSafeTransport_OutgoingAddressLoopbackBinds(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer ts.Close()
+
+	tr := NewSSRFSafeTransport([]string{"127.0.0.0/8"}, WithOutgoingAddress("127.0.0.1"))
+	client := &http.Client{Transport: tr}
+	resp, err := client.Get(ts.URL)
+	require.NoError(t, err)
+	resp.Body.Close()
+}
+
+// addressFamily=ipv4 で IPv6 のみ解決される host への接続を弾く。
+// httptest の listener は IPv4 にバインドされるが、LookupIPAddr が ::1 も
+// 返してくるかは環境次第。確実な検証には normalize/match を直叩きする。
+func TestNormalizeFamily(t *testing.T) {
+	cases := []struct {
+		in, want string
+	}{
+		{"ipv4", "ipv4"},
+		{"IPv4", "ipv4"},
+		{"ipv6", "ipv6"},
+		{" IPv6 ", "ipv6"},
+		{"dual", ""},
+		{"", ""},
+		{"garbage", ""},
+	}
+	for _, tc := range cases {
+		if got := normalizeFamily(tc.in); got != tc.want {
+			t.Errorf("normalizeFamily(%q) = %q, want %q", tc.in, got, tc.want)
+		}
+	}
+}
+
+func TestMatchFamily(t *testing.T) {
+	if !matchFamily(net.ParseIP("1.2.3.4"), "ipv4") {
+		t.Error("1.2.3.4 should match ipv4")
+	}
+	if matchFamily(net.ParseIP("1.2.3.4"), "ipv6") {
+		t.Error("1.2.3.4 should NOT match ipv6")
+	}
+	if !matchFamily(net.ParseIP("2001:db8::1"), "ipv6") {
+		t.Error("2001:db8::1 should match ipv6")
+	}
+	// IPv4-mapped IPv6 は ipv4 として扱う。
+	if !matchFamily(net.ParseIP("::ffff:1.2.3.4"), "ipv4") {
+		t.Error("::ffff:1.2.3.4 should match ipv4 (4-in-6)")
+	}
+}
+
+// addressFamily=ipv4 でも 127.0.0.1 自体は IPv4 なので解決され、その後の
+// SSRF check で private IP として block される。family filter 経路を抜けて
+// 後段の SSRF 判定に到達することの確認。
+func TestNewSSRFSafeTransport_AddressFamilyIPv4PassesThrough(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer ts.Close()
+
+	tr := NewSSRFSafeTransport(nil, WithAddressFamily("ipv4"))
+	client := &http.Client{Transport: tr, Timeout: 2 * time.Second}
+	_, err := client.Get(ts.URL)
+	require.Error(t, err)
+	assert.ErrorIs(t, err, ErrSSRFBlocked, "ipv4 family must reach SSRF check, not bypass it")
+}
+
+// addressFamily=ipv6 で IPv4-only host (httptest) を解決すると
+// no ipv6 address エラーで dial 失敗。
+func TestNewSSRFSafeTransport_AddressFamilyIPv6FiltersOutIPv4(t *testing.T) {
+	tr := NewSSRFSafeTransport([]string{"127.0.0.0/8"}, WithAddressFamily("ipv6"))
+	client := &http.Client{Transport: tr, Timeout: 2 * time.Second}
+	// IPv4-only な test 用ドメイン: localhost は実際 ::1 も返すので使えない。
+	// 127.0.0.1 を直接渡す (IPv4 数値リテラル → DNS 不要だが Go の resolver
+	// が wrap で 127.0.0.1 を返す経路 = familyFilter が IPv4 を弾く)。
+	_, err := client.Get("http://127.0.0.1:1/")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "no ipv6 address",
+		"ipv6 family must drop the only-IPv4 resolution result")
+}
+
 func TestNewSSRFSafeTransport_IPv6ProxyDefaultPort(t *testing.T) {
 	tr := NewSSRFSafeTransport(nil, WithProxy("http://[::1]", nil))
 	require.NotNil(t, tr)

--- a/internal/server/router.go
+++ b/internal/server/router.go
@@ -411,7 +411,7 @@ func (s *Server) setupRoutes() {
 	// config.Proxy / ProxyBypassHosts も #485 で wire 済み。
 	apHTTPClient := &http.Client{
 		Timeout:   30 * time.Second,
-		Transport: safehttp.NewSSRFSafeTransport(s.config.AllowedPrivateNetworks, safehttp.WithProxy(s.config.Proxy, s.config.ProxyBypassHosts)),
+		Transport: safehttp.NewSSRFSafeTransport(s.config.AllowedPrivateNetworks, safehttp.WithProxy(s.config.Proxy, s.config.ProxyBypassHosts), safehttp.WithOutgoingAddress(s.config.OutgoingAddress), safehttp.WithAddressFamily(s.config.OutgoingAddressFamily)),
 	}
 	apClient := activitypub.NewClient(apHTTPClient, s.config.UserAgent)
 	// meta.allowExternalApRedirect が false なら AP fetch でのリダイレクトを拒否する。
@@ -431,7 +431,7 @@ func (s *Server) setupRoutes() {
 	// (30s) より短めの 10s にする。
 	imageProbeClient := &http.Client{
 		Timeout:   10 * time.Second,
-		Transport: safehttp.NewSSRFSafeTransport(s.config.AllowedPrivateNetworks, safehttp.WithProxy(s.config.Proxy, s.config.ProxyBypassHosts)),
+		Transport: safehttp.NewSSRFSafeTransport(s.config.AllowedPrivateNetworks, safehttp.WithProxy(s.config.Proxy, s.config.ProxyBypassHosts), safehttp.WithOutgoingAddress(s.config.OutgoingAddress), safehttp.WithAddressFamily(s.config.OutgoingAddressFamily)),
 	}
 	federationResolver.SetImageProbeClient(imageProbeClient)
 	federationProcessor := corefederation.NewProcessor(federationResolver, followingService, reactionService, noteDeleteService, userRepo, noteRepo)
@@ -445,7 +445,7 @@ func (s *Server) setupRoutes() {
 	// user-facing API 経由で呼ばれるので応答性優先で 10s に設定する。
 	webfingerClient := activitypub.NewWebFingerClient(&http.Client{
 		Timeout:   10 * time.Second,
-		Transport: safehttp.NewSSRFSafeTransport(s.config.AllowedPrivateNetworks, safehttp.WithProxy(s.config.Proxy, s.config.ProxyBypassHosts)),
+		Transport: safehttp.NewSSRFSafeTransport(s.config.AllowedPrivateNetworks, safehttp.WithProxy(s.config.Proxy, s.config.ProxyBypassHosts), safehttp.WithOutgoingAddress(s.config.OutgoingAddress), safehttp.WithAddressFamily(s.config.OutgoingAddressFamily)),
 	}, s.config.UserAgent)
 	userService.SetRemoteUserResolver(corefederation.NewRemoteUserResolver(
 		webfingerClient, federationResolver, userRepo, localHost,
@@ -871,7 +871,7 @@ func (s *Server) setupRoutes() {
 		}
 		smtpUser, smtpPass := smtpMeta2.SmtpUser, smtpMeta2.SmtpPass
 		resetHandler.SetEmailSender(func(to, subject, body string) {
-			miscsmtp.Send(host, port, smtpUser, smtpPass, fromAddr, to, subject, body)
+			miscsmtp.SendWithOptions(host, port, smtpUser, smtpPass, fromAddr, to, subject, body, miscsmtp.Options{ProxyURL: s.config.ProxySmtp})
 		})
 	}
 	api.POST("/request-reset-password", resetHandler.RequestReset)
@@ -1023,7 +1023,7 @@ func (s *Server) setupRoutes() {
 		}
 		smtpUser, smtpPass := smtpMeta.SmtpUser, smtpMeta.SmtpPass
 		iHandler.SetEmailSender(func(to, subject, body string) {
-			miscsmtp.Send(host, port, smtpUser, smtpPass, fromAddr, to, subject, body)
+			miscsmtp.SendWithOptions(host, port, smtpUser, smtpPass, fromAddr, to, subject, body, miscsmtp.Options{ProxyURL: s.config.ProxySmtp})
 		})
 	}
 	if webauthnSvc != nil {
@@ -1569,6 +1569,7 @@ func (s *Server) setupRoutes() {
 	adminHandler.SetPasswordResetRepo(resetReqRepo)
 	adminHandler.SetServerURL(s.config.URL)
 	adminHandler.SetConfigSetupPassword(s.config.SetupPassword)
+	adminHandler.SetSMTPProxyURL(s.config.ProxySmtp)
 	if smtpMetaAdmin, err := metaRepo.Fetch(); err == nil && smtpMetaAdmin.EnableEmail && smtpMetaAdmin.Email != nil && smtpMetaAdmin.SmtpHost != nil {
 		fromAddr := *smtpMetaAdmin.Email
 		host := *smtpMetaAdmin.SmtpHost
@@ -1578,7 +1579,7 @@ func (s *Server) setupRoutes() {
 		}
 		smtpUser, smtpPass := smtpMetaAdmin.SmtpUser, smtpMetaAdmin.SmtpPass
 		adminHandler.SetEmailSender(func(to, subject, body string) {
-			miscsmtp.Send(host, port, smtpUser, smtpPass, fromAddr, to, subject, body)
+			miscsmtp.SendWithOptions(host, port, smtpUser, smtpPass, fromAddr, to, subject, body, miscsmtp.Options{ProxyURL: s.config.ProxySmtp})
 		})
 	}
 	adminHandler.SetModLogRepo(modLogRepo)
@@ -1748,7 +1749,7 @@ func (s *Server) setupRoutes() {
 		s.redis.Default,
 		&http.Client{
 			Timeout:   10 * time.Second,
-			Transport: safehttp.NewSSRFSafeTransport(s.config.AllowedPrivateNetworks, safehttp.WithProxy(s.config.Proxy, s.config.ProxyBypassHosts)),
+			Transport: safehttp.NewSSRFSafeTransport(s.config.AllowedPrivateNetworks, safehttp.WithProxy(s.config.Proxy, s.config.ProxyBypassHosts), safehttp.WithOutgoingAddress(s.config.OutgoingAddress), safehttp.WithAddressFamily(s.config.OutgoingAddressFamily)),
 		},
 	))
 	// #417 P3: /match の acct 引数で未キャッシュのリモートユーザーを

--- a/internal/server/router.go
+++ b/internal/server/router.go
@@ -1260,6 +1260,8 @@ func (s *Server) setupRoutes() {
 		proxyAllowlist, s.config.MediaProxySecret,
 		s.config.AllowedPrivateNetworks,
 		safehttp.WithProxy(s.config.Proxy, s.config.ProxyBypassHosts),
+		safehttp.WithOutgoingAddress(s.config.OutgoingAddress),
+		safehttp.WithAddressFamily(s.config.OutgoingAddressFamily),
 	)
 	proxyHandler := apiproxy.NewHandler(proxyService, s.config)
 	s.echo.GET("/proxy/*", proxyHandler.Handle)


### PR DESCRIPTION
## Summary

これまで struct に読み込まれていただけで実際に runtime に効いていなかった 3 つの外向き通信設定を SMTP client / SSRF-safe HTTP transport に流す。

Closes #496

## 主な変更点

### proxySmtp (SMTP)

`internal/misc/smtp.SendWithOptions(..., Options{ProxyURL: ...})` を追加。`ProxyURL` が空なら従来どおり direct dial (`Send` は互換シム)。

- 対応 scheme:
  - `socks5://[user:pass@]host:port` — `golang.org/x/net/proxy` 経由
  - `http://host:port` — HTTP CONNECT トンネル
  - `https://host:port` — TLS-on-proxy + HTTP CONNECT トンネル
  - Basic auth は URL の userinfo から抽出して `Proxy-Authorization` ヘッダに付与
- 不正 URL / 未対応 scheme は warn ログを出して direct dial に fallback (proxy 設定ミスでメール送信が完全停止するのを避ける)
- `router.go` の 3 closures + `admin/send-email` を `SendWithOptions` に切替、`cfg.ProxySmtp` を渡す。`admin.Handler` に `SetSMTPProxyURL` を追加

### outgoingAddress / outgoingAddressFamily (HTTP)

`internal/safehttp/ssrf.go` に `WithOutgoingAddress` / `WithAddressFamily` Option を追加。

- `WithOutgoingAddress`: `net.Dialer.LocalAddr` に bind して external HTTP の source IP を固定。不正 IP は無視 (kernel auto-pick fallback)
- `WithAddressFamily`: DNS resolution 後に `"ipv4"` / `"ipv6"` で IP を絞る。filter 結果が 0 件のときは明示エラーを返す (ipv4 強制で AAAA only host 等の状況を曖昧 fallback でなく早期検出)
- `router.go` の 4 `NewSSRFSafeTransport` callsite すべてに wire

## テスト

### SMTP (`internal/misc/smtp`)
- HTTP CONNECT proxy 経由で SMTP 配送
- Basic auth ヘッダ付与
- SOCKS5 (no-auth + user/pass auth) — fake SOCKS5 server を inline で立てる
- HTTPS proxy URL → TLS handshake 経路確認
- Malformed CONNECT response → close で best-effort 終了
- 不正 URL / 未対応 scheme → direct fallback
- HTTP CONNECT proxy port 省略 (=80 default)

### safehttp (`internal/safehttp`)
- `WithOutgoingAddress`: 不正値無視 / loopback bind
- `WithAddressFamily`: ipv4 → SSRF check に到達 / ipv6 → IPv4-only host で no-address エラー
- `normalizeFamily` / `matchFamily` の単体ケース (大文字小文字 / 4-in-6 / 不正値 / 空)

実行:
```bash
make fmt && make lint && make test
```

カバレッジ:
- `internal/misc/smtp`: 92.0% (新規 SOCKS5/HTTP CONNECT path 含めて閾値超え)
- `internal/safehttp`: 94.9%

## docs

`docs/configuration.md` の関連エントリを「wire 済み」と分かるよう更新。例:

> `proxySmtp` — SMTP 配送のプロキシ URL。`http://host:port` (HTTP CONNECT)、`https://host:port`、`socks5://[user:pass@]host:port` (#496)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/shiroha-a/mk/pull/553" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
