### PR TITLE
Perf #300 3-7: singleflight on ResolveActor / ResolveNote / WebFinger

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -34,6 +34,7 @@ require (
 	golang.org/x/crypto v0.50.0
 	golang.org/x/image v0.38.0
 	golang.org/x/net v0.52.0
+	golang.org/x/sync v0.20.0
 	golang.org/x/time v0.14.0
 	gorm.io/datatypes v1.2.7
 	gorm.io/driver/postgres v1.6.0
@@ -137,7 +138,6 @@ require (
 	go.opentelemetry.io/otel/trace v1.43.0 // indirect
 	go.uber.org/atomic v1.11.0 // indirect
 	go.yaml.in/yaml/v3 v3.0.4 // indirect
-	golang.org/x/sync v0.20.0 // indirect
 	golang.org/x/sys v0.43.0 // indirect
 	golang.org/x/text v0.36.0 // indirect
 	google.golang.org/protobuf v1.36.11 // indirect

--- a/internal/activitypub/webfinger.go
+++ b/internal/activitypub/webfinger.go
@@ -83,6 +83,8 @@ func (c *WebFingerClient) LookupActorURI(username, host string) (string, error) 
 	return v.(string), nil
 }
 
+// lookupActorURIOnce is the body of LookupActorURI, invoked once per
+// resource by singleflight.Do.
 func (c *WebFingerClient) lookupActorURIOnce(host, resource string) (string, error) {
 	endpoint := c.endpoint(host) + "?resource=" + url.QueryEscape(resource)
 

--- a/internal/activitypub/webfinger.go
+++ b/internal/activitypub/webfinger.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 
 	"github.com/shiroha-a/mk/internal/safehttp"
+	"golang.org/x/sync/singleflight"
 )
 
 // WebFingerLink models a single link entry in an RFC 7033 response.
@@ -34,6 +35,9 @@ type WebFingerClient struct {
 	// endpointOverride is used by tests to redirect the default
 	// https://<host>/.well-known/webfinger URL to an httptest server.
 	endpointOverride func(host string) string
+	// lookupGroup は同一 (username, host) への並行 LookupActorURI 呼び出しを
+	// 1 つの HTTP リクエストに collapse する (#300 3-7)。
+	lookupGroup singleflight.Group
 }
 
 // NewWebFingerClient constructs a WebFingerClient. Pass nil for httpClient to
@@ -66,7 +70,20 @@ func (c *WebFingerClient) LookupActorURI(username, host string) (string, error) 
 	if username == "" || host == "" {
 		return "", errors.New("webfinger: username and host are required")
 	}
+	// 同一 acct への並行 lookup は singleflight で collapse (#300 3-7)。
+	// inbox / 検索画面で同じ remote handle が連続して resolve されるケース
+	// で WebFinger HTTP fan-out を抑える。
 	resource := "acct:" + username + "@" + host
+	v, err, _ := c.lookupGroup.Do(resource, func() (any, error) {
+		return c.lookupActorURIOnce(host, resource)
+	})
+	if err != nil {
+		return "", err
+	}
+	return v.(string), nil
+}
+
+func (c *WebFingerClient) lookupActorURIOnce(host, resource string) (string, error) {
 	endpoint := c.endpoint(host) + "?resource=" + url.QueryEscape(resource)
 
 	req, err := http.NewRequest(http.MethodGet, endpoint, nil)

--- a/internal/activitypub/webfinger_test.go
+++ b/internal/activitypub/webfinger_test.go
@@ -7,6 +7,8 @@ import (
 	"net/http/httptest"
 	"net/url"
 	"strings"
+	"sync"
+	"sync/atomic"
 	"testing"
 
 	"github.com/shiroha-a/mk/internal/safehttp"
@@ -169,6 +171,50 @@ func TestWebFingerClient_ResourceIsURLEncoded(t *testing.T) {
 	uri, err := c.LookupActorURI("edge", "ex.example")
 	require.NoError(t, err)
 	assert.Equal(t, "https://ex.example/users/edge", uri)
+}
+
+// 同一 acct への並行 lookup は 1 つの HTTP リクエストに collapse される
+// (#300 3-7)。サーバ側で in-flight な状態を作って 16 並行呼び出しが全部
+// 同じ結果を受け取り、HTTP は 1 度しか叩かれないことを担保する。
+func TestWebFingerClient_LookupActorURI_DedupesConcurrentCalls(t *testing.T) {
+	var calls atomic.Int64
+	gate := make(chan struct{})
+	c, _ := newTestWebFingerClient(t, func(w http.ResponseWriter, _ *http.Request) {
+		calls.Add(1)
+		<-gate // すべての呼び出しが singleflight 集約待ちになるまで blockする
+		fmt.Fprint(w, `{
+			"subject": "acct:alice@example.com",
+			"links": [{"rel": "self", "type": "application/activity+json", "href": "https://example.com/users/alice"}]
+		}`)
+	})
+
+	const N = 16
+	var wg sync.WaitGroup
+	results := make([]string, N)
+	errs := make([]error, N)
+	for i := 0; i < N; i++ {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			results[i], errs[i] = c.LookupActorURI("alice", "example.com")
+		}(i)
+	}
+	// 並行呼び出しが singleflight に登録される時間を稼ぐ。
+	// gate を閉じることで初めてサーバ側 handler が return する。
+	close(gate)
+	wg.Wait()
+
+	for i := 0; i < N; i++ {
+		require.NoError(t, errs[i], "call %d", i)
+		assert.Equal(t, "https://example.com/users/alice", results[i])
+	}
+	// singleflight が 16 並行を 1 リクエストに collapse しているので、
+	// HTTP は最大でも数回 (singleflight が in-flight をまだ登録できていない
+	// 隙に通った分) しか走らない。実装上は厳密に 1 を期待してよいが、Go
+	// runtime の goroutine スケジューリング次第で先行 leader が完了して
+	// 次の wave が新たに leader になることはあり得るので寛容な上限を取る。
+	assert.LessOrEqual(t, calls.Load(), int64(2),
+		"singleflight must collapse concurrent same-acct lookups to ~1 HTTP fetch")
 }
 
 func TestIsActivityPubLinkType(t *testing.T) {

--- a/internal/core/federation/resolver.go
+++ b/internal/core/federation/resolver.go
@@ -247,8 +247,8 @@ func (r *Resolver) ResolveActor(uri string) (*model.User, error) {
 	return v.(*model.User), nil
 }
 
-// resolveActorOnce は ResolveActor の本体。singleflight.Do から 1 度だけ
-// 呼ばれる前提。
+// resolveActorOnce is the body of ResolveActor, invoked once per URI by
+// singleflight.Do.
 func (r *Resolver) resolveActorOnce(uri string) (*model.User, error) {
 	if existing, err := r.userRepo.FindByURI(uri); err == nil {
 		if r.shouldRefreshActor(existing) {
@@ -519,6 +519,8 @@ func (r *Resolver) ResolveNote(uri string) (*model.Note, error) {
 	return v.(*model.Note), nil
 }
 
+// resolveNoteOnce is the body of ResolveNote, invoked once per URI by
+// singleflight.Do.
 func (r *Resolver) resolveNoteOnce(uri string) (*model.Note, error) {
 	if r.noteRepo == nil {
 		return nil, ErrInvalidNote

--- a/internal/core/federation/resolver.go
+++ b/internal/core/federation/resolver.go
@@ -21,6 +21,7 @@ import (
 	"github.com/shiroha-a/mk/internal/misc/id"
 	"github.com/shiroha-a/mk/internal/model"
 	"github.com/shiroha-a/mk/internal/repository"
+	"golang.org/x/sync/singleflight"
 )
 
 // HTTPFetcher abstracts the HTTP client used for fetching remote AP objects.
@@ -98,6 +99,13 @@ type Resolver struct {
 	// 未設定なら probe 自体をスキップする (安全側に倒す: SSRF リスクを
 	// 起こすくらいなら properties 空のまま運用)。
 	imageProbeClient *http.Client
+
+	// resolveActorGroup / resolveNoteGroup は同一 URI への並行 ResolveActor /
+	// ResolveNote 呼び出しを 1 度の DB lookup + HTTP fetch に collapse する
+	// (#300 3-7)。inbox 受信時に同じ remote actor / note を参照する activity
+	// が連続して届く現実的なケースで thundering herd を抑える。
+	resolveActorGroup singleflight.Group
+	resolveNoteGroup  singleflight.Group
 }
 
 // NewResolver constructs a Resolver.
@@ -210,6 +218,25 @@ func (r *Resolver) PublicKeyForActor(actorID string) (string, error) {
 // が actorTTL を超えていたら fetch しなおして name / inbox / sharedInbox /
 // publicKey を更新する。fetch 失敗時はベストエフォートで既存値を返す。
 func (r *Resolver) ResolveActor(uri string) (*model.User, error) {
+	// 同一 URI への並行呼び出しは singleflight で 1 つに collapse する
+	// (#300 3-7)。cache hit 経路は微秒なので serialize の影響は無視でき、
+	// cold な fetch + Create で発生する HTTP fan-out + UNIQUE 衝突を抑える
+	// 効果が大きい。
+	v, err, _ := r.resolveActorGroup.Do(uri, func() (any, error) {
+		return r.resolveActorOnce(uri)
+	})
+	if err != nil {
+		return nil, err
+	}
+	if v == nil {
+		return nil, ErrInvalidActor
+	}
+	return v.(*model.User), nil
+}
+
+// resolveActorOnce は ResolveActor の本体。singleflight.Do から 1 度だけ
+// 呼ばれる前提。
+func (r *Resolver) resolveActorOnce(uri string) (*model.User, error) {
 	if existing, err := r.userRepo.FindByURI(uri); err == nil {
 		if r.shouldRefreshActor(existing) {
 			r.refreshActor(existing, uri)
@@ -457,6 +484,22 @@ func (r *Resolver) ResolveActorByKeyID(keyID string) (*model.User, error) {
 //   - リモート URI で既に取り込み済みなら noteRepo.FindByURI で返す
 //   - 未知のリモート URI なら fetcher で取得して IngestNote で永続化
 func (r *Resolver) ResolveNote(uri string) (*model.Note, error) {
+	// 同一 URI への並行呼び出しは singleflight で collapse (#300 3-7)。
+	// ResolveActor と同じく cold path の HTTP fetch + IngestNote を重複
+	// 実行しないことが目的。
+	v, err, _ := r.resolveNoteGroup.Do(uri, func() (any, error) {
+		return r.resolveNoteOnce(uri)
+	})
+	if err != nil {
+		return nil, err
+	}
+	if v == nil {
+		return nil, ErrInvalidNote
+	}
+	return v.(*model.Note), nil
+}
+
+func (r *Resolver) resolveNoteOnce(uri string) (*model.Note, error) {
 	if r.noteRepo == nil {
 		return nil, ErrInvalidNote
 	}

--- a/internal/core/federation/resolver.go
+++ b/internal/core/federation/resolver.go
@@ -10,6 +10,7 @@ import (
 	"net/url"
 	"slices"
 	"strings"
+	"sync"
 	"time"
 
 	"log/slog"
@@ -79,11 +80,16 @@ type PublickeyStore interface {
 // する。エントリは actorTTL を超えると miss として扱い、次回 ResolveActor 時
 // にリフレッシュされる。
 type Resolver struct {
-	userRepo        repository.UserRepository
-	noteRepo        repository.NoteRepository
-	urls            *activitypub.URLBuilder
-	fetcher         HTTPFetcher
-	idGen           id.Generator
+	userRepo repository.UserRepository
+	noteRepo repository.NoteRepository
+	urls     *activitypub.URLBuilder
+	fetcher  HTTPFetcher
+	idGen    id.Generator
+	// keysMu は keys map (userID → publicKey + fetchedAt) の concurrent
+	// access を保護する。queue worker や inbox handler は別 actor を並行
+	// 処理するため、ロック無しの map read/write は runtime panic を起こす
+	// (Devin review #555 FLAG-1)。
+	keysMu          sync.RWMutex
 	keys            map[string]publicKeyEntry      // userID → publicKey + fetchedAt
 	clock           func() time.Time               // テストで差し替える時計
 	actorTTL        time.Duration                  // アクター情報の最大寿命
@@ -197,16 +203,23 @@ func (r *Resolver) SetDriveFileRepo(repo repository.DriveFileRepository) {
 // 側が ResolveActor を再実行することで refresh をトリガできる。
 func (r *Resolver) PublicKeyForActor(actorID string) (string, error) {
 	// 1. in-memory cache (TTL内)
-	if entry, ok := r.keys[actorID]; ok {
+	r.keysMu.RLock()
+	entry, ok := r.keys[actorID]
+	r.keysMu.RUnlock()
+	if ok {
 		if r.clock().Sub(entry.fetchedAt) <= r.actorTTL {
 			return entry.pem, nil
 		}
+		r.keysMu.Lock()
 		delete(r.keys, actorID)
+		r.keysMu.Unlock()
 	}
 	// 2. DB fallback
 	if r.publickeyRepo != nil {
 		if pk, err := r.publickeyRepo.FindByUserID(actorID); err == nil {
+			r.keysMu.Lock()
 			r.keys[actorID] = publicKeyEntry{pem: pk.KeyPEM, fetchedAt: r.clock()}
+			r.keysMu.Unlock()
 			return pk.KeyPEM, nil
 		}
 	}
@@ -240,10 +253,15 @@ func (r *Resolver) resolveActorOnce(uri string) (*model.User, error) {
 	if existing, err := r.userRepo.FindByURI(uri); err == nil {
 		if r.shouldRefreshActor(existing) {
 			r.refreshActor(existing, uri)
-		} else if _, cached := r.keys[existing.ID]; !cached {
-			// TTL 内であっても publicKey キャッシュが空 (再起動直後など) なら
-			// 取り直す。
-			r.refreshPublicKey(existing.ID, uri)
+		} else {
+			r.keysMu.RLock()
+			_, cached := r.keys[existing.ID]
+			r.keysMu.RUnlock()
+			if !cached {
+				// TTL 内であっても publicKey キャッシュが空 (再起動直後など)
+				// なら取り直す。
+				r.refreshPublicKey(existing.ID, uri)
+			}
 		}
 		return existing, nil
 	}
@@ -459,7 +477,9 @@ func (r *Resolver) refreshPublicKey(userID, uri string) {
 // cachePublicKey stores a PEM in the in-memory cache and optionally persists
 // it to the user_publickey table.
 func (r *Resolver) cachePublicKey(userID, keyID, pem string) {
+	r.keysMu.Lock()
 	r.keys[userID] = publicKeyEntry{pem: pem, fetchedAt: r.clock()}
+	r.keysMu.Unlock()
 	if r.publickeyRepo != nil && keyID != "" {
 		if err := r.publickeyRepo.Upsert(&model.UserPublickey{
 			UserID: userID,

--- a/internal/core/federation/resolver_test.go
+++ b/internal/core/federation/resolver_test.go
@@ -5,6 +5,8 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
+	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -27,6 +29,21 @@ type stubFetcher struct {
 
 func (s *stubFetcher) FetchObject(_ string) ([]byte, error) {
 	return s.body, s.err
+}
+
+// blockingFetcher counts FetchObject calls and blocks until gate is closed.
+// 並行呼び出しが singleflight に集約される瞬間を観測するためのテスト用 fetcher
+// (#300 3-7)。
+type blockingFetcher struct {
+	body  []byte
+	gate  chan struct{}
+	calls atomic.Int64
+}
+
+func (b *blockingFetcher) FetchObject(_ string) ([]byte, error) {
+	b.calls.Add(1)
+	<-b.gate
+	return b.body, nil
 }
 
 const sampleActor = `{
@@ -2673,3 +2690,101 @@ func TestUpdateRemoteNote_MentionsRecomputed(t *testing.T) {
 	require.NotNil(t, got)
 	assert.Equal(t, []string{"alice"}, []string(got.Mentions))
 }
+
+// 同一 URI への並行 ResolveActor 呼び出しは singleflight で 1 回の HTTP
+// fetch に collapse される (#300 3-7)。inbox 受信が同じ remote actor の
+// activity を連続して取り込むケースを想定。
+func TestResolveActor_DedupesConcurrentCalls(t *testing.T) {
+	repo := testutil.NewMockUserRepository()
+	noteRepo := testutil.NewMockNoteRepository()
+	urls := activitypub.NewURLBuilder("https://example.com")
+	idGen, _ := id.NewGenerator("aidx")
+	fetcher := &blockingFetcher{body: []byte(sampleActor), gate: make(chan struct{})}
+	r := federation.NewResolver(repo, noteRepo, urls, fetcher, idGen)
+
+	const N = 16
+	var wg sync.WaitGroup
+	results := make([]*model.User, N)
+	errs := make([]error, N)
+	for i := 0; i < N; i++ {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			results[i], errs[i] = r.ResolveActor("https://remote.example/users/alice")
+		}(i)
+	}
+	close(fetcher.gate)
+	wg.Wait()
+
+	for i := 0; i < N; i++ {
+		require.NoError(t, errs[i], "call %d", i)
+		require.NotNil(t, results[i])
+		assert.Equal(t, "alice", results[i].Username)
+	}
+	// 16 並行 → 1 fetch に集約されることが目標。leader が 1 回完了すると
+	// 別の wave の leader が立ち得るので寛容な上限を取る。
+	assert.LessOrEqual(t, fetcher.calls.Load(), int64(2),
+		"singleflight must collapse concurrent same-URI ResolveActor to ~1 fetch")
+	// DB 上は単一 user 行になることも担保する (UNIQUE 衝突が発生しない)。
+	assert.Len(t, repo.Users, 1)
+}
+
+// blockingNoteFetcher は FetchObject の calls を atomic で数える Note 用 fetcher。
+// FetchObject の戻り値はユニコードな Note JSON である必要があるので、actor
+// JSON を流用する resolver test のヘルパとは別に持つ。
+type blockingNoteFetcher struct {
+	body  []byte
+	gate  chan struct{}
+	calls atomic.Int64
+}
+
+func (b *blockingNoteFetcher) FetchObject(_ string) ([]byte, error) {
+	b.calls.Add(1)
+	<-b.gate
+	return b.body, nil
+}
+
+// 同一 URI への並行 ResolveNote 呼び出しも同様に collapse される (#300 3-7)。
+func TestResolveNote_DedupesConcurrentCalls(t *testing.T) {
+	repo := testutil.NewMockUserRepository()
+	repo.Users["uA"] = &model.User{
+		ID:       "uA",
+		Username: "alice",
+		Host:     ptrString("remote.example"),
+		URI:      ptrString("https://remote.example/users/alice"),
+	}
+	noteRepo := testutil.NewMockNoteRepository()
+	urls := activitypub.NewURLBuilder("https://example.com")
+	idGen, _ := id.NewGenerator("aidx")
+	body := []byte(`{
+		"id": "https://remote.example/notes/n1",
+		"type": "Note",
+		"attributedTo": "https://remote.example/users/alice",
+		"content": "hello"
+	}`)
+	fetcher := &blockingNoteFetcher{body: body, gate: make(chan struct{})}
+	r := federation.NewResolver(repo, noteRepo, urls, fetcher, idGen)
+
+	const N = 16
+	var wg sync.WaitGroup
+	results := make([]*model.Note, N)
+	errs := make([]error, N)
+	for i := 0; i < N; i++ {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			results[i], errs[i] = r.ResolveNote("https://remote.example/notes/n1")
+		}(i)
+	}
+	close(fetcher.gate)
+	wg.Wait()
+
+	for i := 0; i < N; i++ {
+		require.NoError(t, errs[i], "call %d", i)
+		require.NotNil(t, results[i])
+	}
+	assert.LessOrEqual(t, fetcher.calls.Load(), int64(2),
+		"singleflight must collapse concurrent same-URI ResolveNote to ~1 fetch")
+}
+
+func ptrString(s string) *string { return &s }

--- a/internal/core/federation/resolver_test.go
+++ b/internal/core/federation/resolver_test.go
@@ -2788,3 +2788,64 @@ func TestResolveNote_DedupesConcurrentCalls(t *testing.T) {
 }
 
 func ptrString(s string) *string { return &s }
+
+// stubPublickeyRepo は keys map race test 用の minimal な PublickeyStore
+// 実装。本物の publickey_repo は GORM 経由なのでテストでは差し替える。
+type stubPublickeyRepo struct {
+	mu      sync.RWMutex
+	entries map[string]*model.UserPublickey
+}
+
+func (s *stubPublickeyRepo) FindByUserID(userID string) (*model.UserPublickey, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	if pk, ok := s.entries[userID]; ok {
+		return pk, nil
+	}
+	return nil, errors.New("not found")
+}
+
+func (s *stubPublickeyRepo) Upsert(pk *model.UserPublickey) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.entries == nil {
+		s.entries = make(map[string]*model.UserPublickey)
+	}
+	s.entries[pk.UserID] = pk
+	return nil
+}
+
+// 複数 goroutine が異なる actor の PublicKeyForActor を並行に呼ぶと、内部
+// keys map が無ロックだと race detector / 実行時 panic が発火する。
+// Devin review #555 FLAG-1 への対策として keysMu を入れたので、並行アクセス
+// が clean に動くことを race detector で担保する。本テストは r.keys のみを
+// 対象にして mock userRepo の race を巻き込まないように、PublickeyForActor
+// 経路だけを叩く (DB fallback で r.keys 書き込みを発火させる)。
+func TestResolver_KeysMapConcurrentAccessIsRaceFree(t *testing.T) {
+	repo := testutil.NewMockUserRepository()
+	noteRepo := testutil.NewMockNoteRepository()
+	urls := activitypub.NewURLBuilder("https://example.com")
+	idGen, _ := id.NewGenerator("aidx")
+	r := federation.NewResolver(repo, noteRepo, urls, &stubFetcher{body: []byte(sampleActor)}, idGen)
+
+	pkRepo := &stubPublickeyRepo{entries: map[string]*model.UserPublickey{}}
+	for i := 0; i < 4; i++ {
+		uid := fmt.Sprintf("u%d", i)
+		_ = pkRepo.Upsert(&model.UserPublickey{UserID: uid, KeyID: "k" + uid, KeyPEM: "pem" + uid})
+	}
+	r.SetPublickeyRepo(pkRepo)
+
+	// 8 並行で異なる userID の PublicKeyForActor を呼ぶ。in-memory cache
+	// miss → DB fallback → r.keys 書き込み が並行で走る。
+	var wg sync.WaitGroup
+	for i := 0; i < 8; i++ {
+		uid := fmt.Sprintf("u%d", i%4)
+		wg.Add(1)
+		go func(uid string) {
+			defer wg.Done()
+			_, _ = r.PublicKeyForActor(uid)
+		}(uid)
+	}
+	wg.Wait()
+	// 検証ポイントは race detector が黙ること。
+}


### PR DESCRIPTION
## Summary

inbox 受信や検索画面で同一 remote actor / note / acct への参照が並行して走るケースでは、cache miss 時に同じ DB lookup + HTTP fetch + Create が複数 goroutine から重複実行されていた (#554 / #300 3-7)。`golang.org/x/sync/singleflight` を 3 ヶ所に導入して collapse する。

| 対象 | キー | 効果 |
|------|-----|------|
| `Resolver.ResolveActor` | actor URI | 同一 URI N 並行 → 1 fetch + 1 Create (UNIQUE 衝突も消える) |
| `Resolver.ResolveNote` | note URI | 同一 URI N 並行 → 1 fetch + 1 Create |
| `WebFingerClient.LookupActorURI` | `acct:<user>@<host>` | 同一 acct N 並行 → 1 HTTP リクエスト |

## 主な変更点

| ファイル | 内容 |
|---------|------|
| `internal/core/federation/resolver.go` | `Resolver` に `resolveActorGroup` / `resolveNoteGroup` を追加。`ResolveActor` / `ResolveNote` の本体を `resolveActorOnce` / `resolveNoteOnce` に分離して singleflight.Do 経由で呼ぶ |
| `internal/activitypub/webfinger.go` | `WebFingerClient` に `lookupGroup` を追加。`LookupActorURI` 本体を `lookupActorURIOnce` に分離して singleflight.Do 経由で呼ぶ |
| `*_test.go` | 16 並行呼び出しが 1 fetch に collapse されることを担保する単体テストを 3 ヶ所に追加 (`blockingFetcher` / `blockingNoteFetcher` / WebFinger handler を gate でブロックして並行集約のタイミングを観測) |
| `go.mod` | `golang.org/x/sync` を indirect → direct に昇格 |

## テスト

\`\`\`sh
go test -race -count=1 -cover ./internal/core/federation/ ./internal/activitypub/
ok      github.com/shiroha-a/mk/internal/core/federation    coverage: 90.1% of statements
ok      github.com/shiroha-a/mk/internal/activitypub        coverage: 94.0% of statements
\`\`\`

`go vet ./...` クリーン、`gofmt -s -d .` 差分なし、`go build ./...` クリーン。

## 設計メモ

- cache hit 経路 (DB に actor/note があり TTL 内) は微秒なので serialize の影響は無視できる。狙いは cold path の HTTP fetch + UNIQUE constraint 衝突を抑えること。
- singleflight の `shared` 戻り値は無視している (テスト観点では fetch 回数で集約を確認している)。

Closes #554
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/shiroha-a/mk/pull/555" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
