### PR TITLE
Perf #413 Phase 3 #12: response body gzip compression

### DIFF
--- a/internal/server/gzip_test.go
+++ b/internal/server/gzip_test.go
@@ -1,0 +1,106 @@
+package server
+
+import (
+	"bytes"
+	"compress/gzip"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/labstack/echo/v4"
+	echomw "github.com/labstack/echo/v4/middleware"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// 1KB 以上の JSON body を要求すると gzip-encoded で返ってくる。
+func TestGzipMiddleware_CompressesLargeJSON(t *testing.T) {
+	e := echo.New()
+	e.Use(echomw.GzipWithConfig(gzipConfig()))
+
+	// 1KB 以上の payload。MinLength=1024 を超えさせる。
+	payload := map[string]any{"text": strings.Repeat("a", 2000)}
+	e.GET("/api/big", func(c echo.Context) error {
+		return c.JSON(http.StatusOK, payload)
+	})
+
+	req := httptest.NewRequest(http.MethodGet, "/api/big", nil)
+	req.Header.Set(echo.HeaderAcceptEncoding, "gzip")
+	rec := httptest.NewRecorder()
+	e.ServeHTTP(rec, req)
+
+	require.Equal(t, http.StatusOK, rec.Code)
+	require.Equal(t, "gzip", rec.Header().Get(echo.HeaderContentEncoding),
+		"large JSON response should be gzip-encoded")
+
+	// gzip decode して内容が一致することを確認する。
+	gr, err := gzip.NewReader(bytes.NewReader(rec.Body.Bytes()))
+	require.NoError(t, err)
+	defer gr.Close()
+	decoded, err := io.ReadAll(gr)
+	require.NoError(t, err)
+	assert.Contains(t, string(decoded), strings.Repeat("a", 2000))
+}
+
+// 1KB 未満の小さな body は gzip しない (MinLength を下回るため、
+// overhead が savings を上回る判断)。
+func TestGzipMiddleware_SkipsSmallBody(t *testing.T) {
+	e := echo.New()
+	e.Use(echomw.GzipWithConfig(gzipConfig()))
+
+	e.GET("/api/small", func(c echo.Context) error {
+		return c.JSON(http.StatusOK, map[string]string{"ok": "yes"})
+	})
+
+	req := httptest.NewRequest(http.MethodGet, "/api/small", nil)
+	req.Header.Set(echo.HeaderAcceptEncoding, "gzip")
+	rec := httptest.NewRecorder()
+	e.ServeHTTP(rec, req)
+
+	require.Equal(t, http.StatusOK, rec.Code)
+	assert.Empty(t, rec.Header().Get(echo.HeaderContentEncoding),
+		"small body should bypass gzip per MinLength config")
+}
+
+// /streaming は WebSocket upgrade 経路なので Skipper で除外する。
+// AcceptEncoding に gzip が入っていても Content-Encoding は付かない。
+func TestGzipMiddleware_SkipsStreamingRoute(t *testing.T) {
+	e := echo.New()
+	e.Use(echomw.GzipWithConfig(gzipConfig()))
+
+	// 1KB 以上の本文を返しても、/streaming パスは Skipper で gzip を
+	// 切るので Content-Encoding が付かないこと。
+	e.GET("/streaming", func(c echo.Context) error {
+		return c.String(http.StatusOK, strings.Repeat("x", 2000))
+	})
+
+	req := httptest.NewRequest(http.MethodGet, "/streaming", nil)
+	req.Header.Set(echo.HeaderAcceptEncoding, "gzip")
+	rec := httptest.NewRecorder()
+	e.ServeHTTP(rec, req)
+
+	require.Equal(t, http.StatusOK, rec.Code)
+	assert.Empty(t, rec.Header().Get(echo.HeaderContentEncoding),
+		"/streaming must bypass gzip to keep WebSocket frames intact")
+}
+
+// AcceptEncoding に gzip が含まれない client には raw body を返す
+// (Echo middleware の負荷ハンドリング)。
+func TestGzipMiddleware_DoesNotCompressWithoutAcceptEncoding(t *testing.T) {
+	e := echo.New()
+	e.Use(echomw.GzipWithConfig(gzipConfig()))
+
+	e.GET("/api/big", func(c echo.Context) error {
+		return c.String(http.StatusOK, strings.Repeat("a", 2000))
+	})
+
+	req := httptest.NewRequest(http.MethodGet, "/api/big", nil)
+	// no Accept-Encoding header
+	rec := httptest.NewRecorder()
+	e.ServeHTTP(rec, req)
+
+	require.Equal(t, http.StatusOK, rec.Code)
+	assert.Empty(t, rec.Header().Get(echo.HeaderContentEncoding))
+}

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -51,11 +51,10 @@ func (s *Server) registerShutdownHook(fn func()) {
 }
 
 // gzipConfig returns the GzipConfig used by the global middleware stack.
-// MinLength=1024 で小さい body の gzip overhead を回避し、/streaming は
-// WebSocket frame を壊さないよう Skipper で除外する。
-// テスト (gzip_test.go) からも参照して production と乖離しないよう一元化
-// する (#413 Phase 3 #12)。
+// Shared with gzip_test.go so production and tests stay in sync.
 func gzipConfig() echomw.GzipConfig {
+	// MinLength=1024 で小さい body の gzip overhead を回避し、/streaming は
+	// WebSocket frame を壊さないよう Skipper で除外する (#413 Phase 3 #12)。
 	return echomw.GzipConfig{
 		Skipper: func(c echo.Context) bool {
 			// WebSocket upgrade 経路 (/streaming) は frame 単位の bidirectional

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -1,6 +1,7 @@
 package server
 
 import (
+	"compress/gzip"
 	"context"
 	"errors"
 	"fmt"
@@ -49,6 +50,23 @@ func (s *Server) registerShutdownHook(fn func()) {
 	s.shutdownHooks = append(s.shutdownHooks, fn)
 }
 
+// gzipConfig returns the GzipConfig used by the global middleware stack.
+// MinLength=1024 で小さい body の gzip overhead を回避し、/streaming は
+// WebSocket frame を壊さないよう Skipper で除外する。
+// テスト (gzip_test.go) からも参照して production と乖離しないよう一元化
+// する (#413 Phase 3 #12)。
+func gzipConfig() echomw.GzipConfig {
+	return echomw.GzipConfig{
+		Skipper: func(c echo.Context) bool {
+			// WebSocket upgrade 経路 (/streaming) は frame 単位の bidirectional
+			// 通信で gzip すると壊れる。
+			return c.Path() == "/streaming"
+		},
+		Level:     gzip.DefaultCompression,
+		MinLength: 1024,
+	}
+}
+
 // New creates a new Server. Returns an error when the queue driver
 // fails to initialise (e.g. mkq driver failing to PING Redis at
 // startup).
@@ -83,6 +101,10 @@ func New(cfg *config.Config, db *gorm.DB, redis *cache.RedisClients) (*Server, e
 		AllowMethods: []string{http.MethodGet, http.MethodPost, http.MethodPut, http.MethodDelete, http.MethodOptions},
 		AllowHeaders: []string{echo.HeaderOrigin, echo.HeaderContentType, echo.HeaderAccept, echo.HeaderAuthorization},
 	}))
+	// gzip response compression (#413 Phase 3 #12)。Misskey TS は nginx
+	// 前段で gzip するのが定石だが、mk-go は単体運用も想定するので app 側
+	// で提供する。設定は gzipConfig() に集約してテストと共有。
+	e.Use(echomw.GzipWithConfig(gzipConfig()))
 
 	// CachedUserRepository を一度だけ構築して auth middleware と
 	// setupRoutes (services) が同じ cache を共有するようにする (#300 3-3)。


### PR DESCRIPTION
## Summary

Misskey TS は nginx 前段で gzip を当てるのが定石だが、mk-go は app 単独運用も想定するので Echo 側で gzip middleware を入れる (#557 / #413 Phase 3 #12)。1KB を超える JSON / HTML レスポンスで帯域 30-70% 削減が見込める。

## 主な変更点

| ファイル | 内容 |
|---------|------|
| \`internal/server/server.go\` | CORS middleware の直後に \`echomw.GzipWithConfig(gzipConfig())\` を仕込む。設定は \`gzipConfig()\` に切り出し production と test (gzip_test.go) で共有してドリフト防止 |
| \`internal/server/gzip_test.go\` | 単体テスト (新規) |

設定詳細:

- \`MinLength: 1024\` — 小さい body は gzip overhead (per-response ~100 バイト) が savings を上回るので skip
- \`Skipper: c.Path() == "/streaming"\` — WebSocket は frame 単位の bidirectional 通信で gzip が壊れる
- \`Level: gzip.DefaultCompression\` (=6)

## テスト

\`\`\`sh
go test -race -count=1 -run TestGzipMiddleware ./internal/server/
ok      github.com/shiroha-a/mk/internal/server
\`\`\`

新規テスト 4 本:

- \`TestGzipMiddleware_CompressesLargeJSON\` — 1KB 以上の JSON が gzip-encoded で返る (decode して中身一致)
- \`TestGzipMiddleware_SkipsSmallBody\` — 1KB 未満は MinLength で除外、Content-Encoding 付かない
- \`TestGzipMiddleware_SkipsStreamingRoute\` — \`/streaming\` は Skipper で除外、Content-Encoding 付かない
- \`TestGzipMiddleware_DoesNotCompressWithoutAcceptEncoding\` — client が gzip を accept しない場合は素通し

\`go vet ./...\` クリーン、\`gofmt -s -d .\` 差分なし、\`go build ./...\` クリーン。

## 影響範囲

- API レスポンスは Content-Encoding: gzip で返るようになる。client (Misskey-web frontend / mobile app / CLI) は標準で gzip をサポートしているので透過的。
- WebSocket 経路 (\`/streaming\`) は Skipper で除外しているので影響無し。
- ファイル / メディア配信 (drive/files inline / identicon / avatar PNG) は元々 binary (image/png 等) で gzip 効率が悪いものは echo 側が Content-Type を見てスキップする (実態は MinLength を超えても圧縮率が下がるだけで動作は壊れない)。

Closes #557
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/shiroha-a/mk/pull/558" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
