### PR TITLE
Feat #498: fulltextSearch.provider=sqlPgroonga 実装

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -127,7 +127,7 @@ cp .config/docker.yml.example .config/docker.yml
 
 | キー | 型 | 説明 |
 |---|---|---|
-| `fulltextSearch.provider` | string | 検索プロバイダ名 |
+| `fulltextSearch.provider` | string | 検索プロバイダ名。`sqlLike` (デフォルト) / `sqlPgroonga` / `meilisearch` |
 | `meilisearch.host` | string | Meilisearchホスト |
 | `meilisearch.port` | int | Meilisearchポート |
 | `meilisearch.apiKey` | string | APIキー |
@@ -135,7 +135,25 @@ cp .config/docker.yml.example .config/docker.yml
 | `meilisearch.index` | string | インデックス名 |
 | `meilisearch.scope` | string | 検索スコープ |
 
-Meilisearch未設定時はSQL ILIKE検索にフォールバック。
+provider 別の挙動:
+
+- `sqlLike` (デフォルト) — `text ILIKE '%q%'` で全文検索する。追加の DB 拡張は不要だが、note 行数が増えると線形スキャンになるため大規模インスタンスでは遅くなる。
+- `sqlPgroonga` — PGroonga の `&@~` 演算子で全文検索する。日本語を含む高速な転置 index 検索が利用可能。**事前に PostgreSQL 側で pgroonga 拡張のインストールと note.text への index 作成が必要** (下記)。
+- `meilisearch` — 別プロセスの Meilisearch にノートを index する。`meilisearch.host` 必須。未設定時は自動的に `sqlLike` にフォールバックする。
+
+#### PGroonga セットアップ
+
+`sqlPgroonga` を使うには PostgreSQL に PGroonga 拡張が導入されている必要がある (公式 image には含まれていない)。インストール手順は [pgroonga.github.io](https://pgroonga.github.io/install/) を参照。導入後、各データベースで一度だけ拡張を有効化し、note.text に index を貼る:
+
+```sql
+-- DB ごとに 1 回だけ
+CREATE EXTENSION IF NOT EXISTS pgroonga;
+
+-- note.text 用の全文検索 index
+CREATE INDEX IF NOT EXISTS pgroonga_note_text_idx ON note USING pgroonga (text);
+```
+
+mk-go 側のマイグレーションには含めていない。pgroonga 拡張の有無は運用環境依存のため、operator が明示的に install/index 作成する責務とする (upstream Misskey TS と同じ方針)。
 
 ### パフォーマンス
 

--- a/internal/core/search/sqllike_provider.go
+++ b/internal/core/search/sqllike_provider.go
@@ -11,11 +11,16 @@ import (
 // over public/home notes and supports the same filter options as the
 // Meilisearch backend (userId / channelId / host).
 //
+// When pgroonga is true the underlying query uses PGroonga's `&@~` operator
+// instead of ILIKE — upstream Misskey TS keeps both providers in the same
+// code path and only swaps the WHERE clause.
+//
 // Index / Unindex are no-ops because the canonical store is the database
 // itself; nothing extra has to happen on note creation / deletion.
 type SQLLikeProvider struct {
 	noteRepo      repository.NoteRepository
 	followingRepo repository.FollowingRepository
+	pgroonga      bool
 }
 
 // NewSQLLikeProvider returns a Provider backed by SearchByFilter on the
@@ -23,6 +28,13 @@ type SQLLikeProvider struct {
 // (note.CanSeeNote) で followers 可視性のチェックに使う。nil 可。
 func NewSQLLikeProvider(noteRepo repository.NoteRepository, followingRepo repository.FollowingRepository) *SQLLikeProvider {
 	return &SQLLikeProvider{noteRepo: noteRepo, followingRepo: followingRepo}
+}
+
+// NewSQLPgroongaProvider returns a Provider that uses the PGroonga `&@~`
+// match operator instead of ILIKE. PGroonga 拡張がインストールされ
+// note.text に対する pgroonga index が貼られていることを前提とする。
+func NewSQLPgroongaProvider(noteRepo repository.NoteRepository, followingRepo repository.FollowingRepository) *SQLLikeProvider {
+	return &SQLLikeProvider{noteRepo: noteRepo, followingRepo: followingRepo, pgroonga: true}
 }
 
 // IndexNote is a no-op for the SQL backend (the database is the index).
@@ -49,6 +61,7 @@ func (p *SQLLikeProvider) SearchNote(viewer *model.User, query string, opts Sear
 		UntilID:   page.UntilID,
 		SinceID:   page.SinceID,
 		Limit:     limit,
+		Pgroonga:  p.pgroonga,
 	})
 	if err != nil {
 		return nil, err

--- a/internal/core/search/sqllike_provider.go
+++ b/internal/core/search/sqllike_provider.go
@@ -43,8 +43,9 @@ func (p *SQLLikeProvider) IndexNote(_ *model.Note) error { return nil }
 // UnindexNote is a no-op for the SQL backend.
 func (p *SQLLikeProvider) UnindexNote(_ *model.Note) error { return nil }
 
-// SearchNote runs an ILIKE-based search and post-filters the result for
-// viewer visibility.
+// SearchNote runs the configured SQL backend search (ILIKE substring match
+// by default, or PGroonga `&@~` when the provider was constructed via
+// NewSQLPgroongaProvider) and post-filters the result for viewer visibility.
 func (p *SQLLikeProvider) SearchNote(viewer *model.User, query string, opts SearchOpts, page Pagination) ([]*model.Note, error) {
 	if query == "" {
 		return nil, ErrEmptyQuery

--- a/internal/core/search/sqllike_provider.go
+++ b/internal/core/search/sqllike_provider.go
@@ -31,8 +31,9 @@ func NewSQLLikeProvider(noteRepo repository.NoteRepository, followingRepo reposi
 }
 
 // NewSQLPgroongaProvider returns a Provider that uses the PGroonga `&@~`
-// match operator instead of ILIKE. PGroonga 拡張がインストールされ
-// note.text に対する pgroonga index が貼られていることを前提とする。
+// match operator instead of ILIKE. The PGroonga extension must be installed
+// on the target database and a pgroonga index must exist on note.text;
+// extension installation is the operator's responsibility.
 func NewSQLPgroongaProvider(noteRepo repository.NoteRepository, followingRepo repository.FollowingRepository) *SQLLikeProvider {
 	return &SQLLikeProvider{noteRepo: noteRepo, followingRepo: followingRepo, pgroonga: true}
 }

--- a/internal/core/search/sqllike_provider_test.go
+++ b/internal/core/search/sqllike_provider_test.go
@@ -85,6 +85,36 @@ func TestSQLLikeProvider_RepoErrorPropagated(t *testing.T) {
 	require.Error(t, err)
 }
 
+// stubFilterCapturingNoteRepo records the last NoteSearchFilter passed to
+// SearchByFilter so that tests can verify provider → filter wiring without
+// depending on the underlying SQL backend.
+type stubFilterCapturingNoteRepo struct {
+	*testutil.MockNoteRepository
+	lastFilter model.NoteSearchFilter
+}
+
+func (s *stubFilterCapturingNoteRepo) SearchByFilter(f model.NoteSearchFilter) ([]*model.Note, error) {
+	s.lastFilter = f
+	return s.MockNoteRepository.SearchByFilter(f)
+}
+
+func TestSQLPgroongaProvider_PropagatesPgroongaFlag(t *testing.T) {
+	repo := &stubFilterCapturingNoteRepo{MockNoteRepository: testutil.NewMockNoteRepository()}
+	p := NewSQLPgroongaProvider(repo, nil)
+	_, err := p.SearchNote(nil, "hello", SearchOpts{}, Pagination{Limit: 10})
+	require.NoError(t, err)
+	assert.True(t, p.pgroonga, "constructor should mark provider as pgroonga")
+	assert.True(t, repo.lastFilter.Pgroonga, "Pgroonga flag must reach the repository filter")
+}
+
+func TestSQLLikeProvider_DoesNotSetPgroongaFlag(t *testing.T) {
+	repo := &stubFilterCapturingNoteRepo{MockNoteRepository: testutil.NewMockNoteRepository()}
+	p := NewSQLLikeProvider(repo, nil)
+	_, err := p.SearchNote(nil, "hello", SearchOpts{}, Pagination{Limit: 10})
+	require.NoError(t, err)
+	assert.False(t, repo.lastFilter.Pgroonga)
+}
+
 func TestSQLLikeProvider_VisibilityFilterDropsHidden(t *testing.T) {
 	p, repo := newSQLLikeProviderForTest()
 	hello := "hello"

--- a/internal/model/note.go
+++ b/internal/model/note.go
@@ -75,6 +75,10 @@ type NoteSearchFilter struct {
 	UntilID   string
 	SinceID   string
 	Limit     int
+	// Pgroonga が true のときは ILIKE ではなく PGroonga の `&@~` 演算子で
+	// 全文検索する。upstream Misskey TS の SearchService.searchNoteByLike が
+	// fulltextSearch.provider == "sqlPgroonga" でクエリを差し替えるのと同じ動き。
+	Pgroonga bool
 }
 
 // ReplyTargetCount is a (userID, count) pair returned by

--- a/internal/model/note.go
+++ b/internal/model/note.go
@@ -75,9 +75,10 @@ type NoteSearchFilter struct {
 	UntilID   string
 	SinceID   string
 	Limit     int
-	// Pgroonga が true のときは ILIKE ではなく PGroonga の `&@~` 演算子で
-	// 全文検索する。upstream Misskey TS の SearchService.searchNoteByLike が
-	// fulltextSearch.provider == "sqlPgroonga" でクエリを差し替えるのと同じ動き。
+	// Pgroonga, when true, switches the WHERE clause from ILIKE to the
+	// PGroonga `&@~` full-text match operator. Mirrors upstream Misskey TS
+	// SearchService.searchNoteByLike, which swaps the predicate when
+	// fulltextSearch.provider == "sqlPgroonga".
 	Pgroonga bool
 }
 

--- a/internal/repository/note.go
+++ b/internal/repository/note.go
@@ -321,8 +321,9 @@ func (r *noteRepository) ListChildrenOf(noteID string, untilID, sinceID string, 
 
 // SearchByFilter returns notes matching the filter criteria.
 // 検索バックエンド (core/search.SQLLikeProvider) から呼ばれる。
-// f.Pgroonga が true の場合は PGroonga の `&@~` 全文検索演算子を使い、
-// それ以外は ILIKE による部分一致で検索する。可視性は public/home に限定する。
+// When f.Pgroonga is true the predicate uses the PGroonga `&@~` full-text
+// operator; otherwise it falls back to ILIKE substring match. Visibility is
+// always limited to public/home.
 func (r *noteRepository) SearchByFilter(f model.NoteSearchFilter) ([]*model.Note, error) {
 	var notes []*model.Note
 	q := preloadNoteRelations(r.db)

--- a/internal/repository/note.go
+++ b/internal/repository/note.go
@@ -321,15 +321,22 @@ func (r *noteRepository) ListChildrenOf(noteID string, untilID, sinceID string, 
 
 // SearchByFilter returns notes matching the filter criteria.
 // 検索バックエンド (core/search.SQLLikeProvider) から呼ばれる。
-// テキストは ILIKE 部分一致、可視性は public/home に限定する。
+// f.Pgroonga が true の場合は PGroonga の `&@~` 全文検索演算子を使い、
+// それ以外は ILIKE による部分一致で検索する。可視性は public/home に限定する。
 func (r *noteRepository) SearchByFilter(f model.NoteSearchFilter) ([]*model.Note, error) {
 	var notes []*model.Note
-	q := preloadNoteRelations(r.db).
-		Where("text ILIKE ?", "%"+f.Query+"%").
-		Where("visibility IN ?", []string{
-			string(model.NoteVisibilityPublic),
-			string(model.NoteVisibilityHome),
-		})
+	q := preloadNoteRelations(r.db)
+	if f.Pgroonga {
+		// upstream TS では `note.text &@~ :q` を使用。`&@~` は PGroonga の
+		// "クエリ文字列モード" マッチで、空白区切りの AND/OR 等が解釈される。
+		q = q.Where("text &@~ ?", f.Query)
+	} else {
+		q = q.Where("text ILIKE ?", "%"+f.Query+"%")
+	}
+	q = q.Where("visibility IN ?", []string{
+		string(model.NoteVisibilityPublic),
+		string(model.NoteVisibilityHome),
+	})
 	if f.UserID != "" {
 		q = q.Where("\"userId\" = ?", f.UserID)
 	}

--- a/internal/repository/note_test.go
+++ b/internal/repository/note_test.go
@@ -673,6 +673,17 @@ func TestNoteRepository_SearchByFilter(t *testing.T) {
 	assert.Len(t, out, 4)
 }
 
+func TestNoteRepository_SearchByFilter_PgroongaOperator(t *testing.T) {
+	repo := NewNoteRepository(testDB)
+	// pgroonga 拡張は CI / testcontainers の素の Postgres には存在しない。
+	// そこで `&@~` 演算子が解決されない (=エラーメッセージに `&@~` が
+	// 含まれる) ことを以て「Pgroonga ブランチが選択されその SQL が
+	// 実際に発行された」ことを検証する。
+	_, err := repo.SearchByFilter(model.NoteSearchFilter{Query: "hello", Pgroonga: true, Limit: 10})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "&@~")
+}
+
 // idsOf is a tiny helper to extract note IDs for assertion comparisons.
 func idsOf(notes []*model.Note) []string {
 	out := make([]string, 0, len(notes))

--- a/internal/server/search.go
+++ b/internal/server/search.go
@@ -14,10 +14,9 @@ import (
 // fulltextSearch.provider config key. Provider 選択は起動時に一度だけ走る。
 //
 //   - meilisearch (with meilisearch host configured) → MeilisearchProvider
-//   - sqlLike / pgroonga / unset (with no meilisearch host) → SQLLikeProvider
-//
-// pgroonga は将来的にネイティブの `&@~` 演算子を使う予定だが、Phase 4.6 では
-// SQLLike と同じ ILIKE 経路で動かす。
+//   - sqlPgroonga                                    → SQLLikeProvider with
+//     PGroonga `&@~` 演算子 (要 pgroonga 拡張)
+//   - sqlLike / unset (with no meilisearch host)     → SQLLikeProvider (ILIKE)
 func buildSearchProvider(
 	cfg *config.Config,
 	noteRepo repository.NoteRepository,
@@ -43,7 +42,10 @@ func buildSearchProvider(
 		_ = mp.ApplyDefaultSettings()
 		return mp
 	}
-	// fulltextSearch.provider が "sqlLike" / "pgroonga" / 未設定 の場合は
+	if provider == "sqlpgroonga" {
+		return coresearch.NewSQLPgroongaProvider(noteRepo, followingRepo)
+	}
+	// fulltextSearch.provider が "sqlLike" / 未設定 / 不明な値の場合は
 	// SQL ILIKE フォールバック。
 	return coresearch.NewSQLLikeProvider(noteRepo, followingRepo)
 }

--- a/internal/server/search.go
+++ b/internal/server/search.go
@@ -14,8 +14,8 @@ import (
 // fulltextSearch.provider config key. Provider 選択は起動時に一度だけ走る。
 //
 //   - meilisearch (with meilisearch host configured) → MeilisearchProvider
-//   - sqlPgroonga                                    → SQLLikeProvider with
-//     PGroonga `&@~` 演算子 (要 pgroonga 拡張)
+//   - sqlPgroonga                                    → SQLLikeProvider using
+//     the PGroonga `&@~` operator (requires the pgroonga extension)
 //   - sqlLike / unset (with no meilisearch host)     → SQLLikeProvider (ILIKE)
 func buildSearchProvider(
 	cfg *config.Config,

--- a/internal/server/search_test.go
+++ b/internal/server/search_test.go
@@ -1,0 +1,143 @@
+package server
+
+import (
+	"testing"
+
+	"github.com/shiroha-a/mk/internal/config"
+	coresearch "github.com/shiroha-a/mk/internal/core/search"
+	"github.com/shiroha-a/mk/internal/misc/id"
+	"github.com/shiroha-a/mk/internal/model"
+	"github.com/shiroha-a/mk/internal/testutil"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// pgroongaCapturingRepo records the last NoteSearchFilter so that tests can
+// assert the Pgroonga flag wired by buildSearchProvider reaches the repository
+// without depending on actual SQL execution.
+type pgroongaCapturingRepo struct {
+	*testutil.MockNoteRepository
+	lastFilter model.NoteSearchFilter
+}
+
+func (r *pgroongaCapturingRepo) SearchByFilter(f model.NoteSearchFilter) ([]*model.Note, error) {
+	r.lastFilter = f
+	return r.MockNoteRepository.SearchByFilter(f)
+}
+
+func newRepoAndIDGen(t *testing.T) (*pgroongaCapturingRepo, id.Generator) {
+	t.Helper()
+	idGen, err := id.NewGenerator("aidx")
+	require.NoError(t, err)
+	return &pgroongaCapturingRepo{MockNoteRepository: testutil.NewMockNoteRepository()}, idGen
+}
+
+func TestBuildSearchProvider_SQLLikeWhenUnset(t *testing.T) {
+	repo, idGen := newRepoAndIDGen(t)
+	p := buildSearchProvider(&config.Config{}, repo, nil, idGen)
+	require.IsType(t, &coresearch.SQLLikeProvider{}, p)
+
+	_, err := p.SearchNote(nil, "hello", coresearch.SearchOpts{}, coresearch.Pagination{Limit: 10})
+	require.NoError(t, err)
+	assert.False(t, repo.lastFilter.Pgroonga, "default provider must not use pgroonga")
+}
+
+func TestBuildSearchProvider_SQLLikeExplicit(t *testing.T) {
+	repo, idGen := newRepoAndIDGen(t)
+	cfg := &config.Config{FulltextSearch: &config.FulltextSearchOptions{Provider: "sqlLike"}}
+	p := buildSearchProvider(cfg, repo, nil, idGen)
+	require.IsType(t, &coresearch.SQLLikeProvider{}, p)
+
+	_, err := p.SearchNote(nil, "hello", coresearch.SearchOpts{}, coresearch.Pagination{Limit: 10})
+	require.NoError(t, err)
+	assert.False(t, repo.lastFilter.Pgroonga)
+}
+
+func TestBuildSearchProvider_Pgroonga(t *testing.T) {
+	repo, idGen := newRepoAndIDGen(t)
+	cfg := &config.Config{FulltextSearch: &config.FulltextSearchOptions{Provider: "sqlPgroonga"}}
+	p := buildSearchProvider(cfg, repo, nil, idGen)
+	require.IsType(t, &coresearch.SQLLikeProvider{}, p)
+
+	_, err := p.SearchNote(nil, "hello", coresearch.SearchOpts{}, coresearch.Pagination{Limit: 10})
+	require.NoError(t, err)
+	assert.True(t, repo.lastFilter.Pgroonga, "Pgroonga flag must be set when provider is sqlPgroonga")
+}
+
+func TestBuildSearchProvider_PgroongaCaseInsensitive(t *testing.T) {
+	repo, idGen := newRepoAndIDGen(t)
+	// upstream の YAML 表記は "sqlPgroonga"。strings.ToLower + TrimSpace で
+	// 正規化されることを確認する。
+	cfg := &config.Config{FulltextSearch: &config.FulltextSearchOptions{Provider: "  sqlPgroonga  "}}
+	p := buildSearchProvider(cfg, repo, nil, idGen)
+
+	_, err := p.SearchNote(nil, "hello", coresearch.SearchOpts{}, coresearch.Pagination{Limit: 10})
+	require.NoError(t, err)
+	assert.True(t, repo.lastFilter.Pgroonga)
+}
+
+func TestBuildSearchProvider_UnknownProviderFallsBackToSQLLike(t *testing.T) {
+	repo, idGen := newRepoAndIDGen(t)
+	cfg := &config.Config{FulltextSearch: &config.FulltextSearchOptions{Provider: "elasticsearch"}}
+	p := buildSearchProvider(cfg, repo, nil, idGen)
+	require.IsType(t, &coresearch.SQLLikeProvider{}, p)
+
+	_, err := p.SearchNote(nil, "hello", coresearch.SearchOpts{}, coresearch.Pagination{Limit: 10})
+	require.NoError(t, err)
+	assert.False(t, repo.lastFilter.Pgroonga)
+}
+
+func TestBuildSearchProvider_MeilisearchSelected(t *testing.T) {
+	repo, idGen := newRepoAndIDGen(t)
+	cfg := &config.Config{
+		FulltextSearch: &config.FulltextSearchOptions{Provider: "meilisearch"},
+		Meilisearch:    &config.MeilisearchOptions{Host: "meili.local", Port: "7700"},
+	}
+	p := buildSearchProvider(cfg, repo, nil, idGen)
+	require.IsType(t, &coresearch.MeilisearchProvider{}, p)
+}
+
+func TestBuildSearchProvider_MeilisearchWithoutHostFallsBack(t *testing.T) {
+	repo, idGen := newRepoAndIDGen(t)
+	cfg := &config.Config{
+		FulltextSearch: &config.FulltextSearchOptions{Provider: "meilisearch"},
+		Meilisearch:    &config.MeilisearchOptions{}, // host 未設定
+	}
+	p := buildSearchProvider(cfg, repo, nil, idGen)
+	// Host 空なら sqlLike にフォールバック。
+	require.IsType(t, &coresearch.SQLLikeProvider{}, p)
+}
+
+func TestBuildMeilisearchHost(t *testing.T) {
+	cases := []struct {
+		name string
+		opts *config.MeilisearchOptions
+		want string
+	}{
+		{
+			name: "host with scheme is left untouched",
+			opts: &config.MeilisearchOptions{Host: "http://meili.local:7700"},
+			want: "http://meili.local:7700",
+		},
+		{
+			name: "host without scheme picks http and includes port",
+			opts: &config.MeilisearchOptions{Host: "meili.local", Port: "7700"},
+			want: "http://meili.local:7700",
+		},
+		{
+			name: "ssl flag promotes to https",
+			opts: &config.MeilisearchOptions{Host: "meili.local", Port: "7700", SSL: true},
+			want: "https://meili.local:7700",
+		},
+		{
+			name: "missing port omits trailing colon",
+			opts: &config.MeilisearchOptions{Host: "meili.local"},
+			want: "http://meili.local",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, buildMeilisearchHost(tc.opts))
+		})
+	}
+}


### PR DESCRIPTION
## Summary

`fulltextSearch.provider=sqlPgroonga` を選択しても ILIKE フォールバックしていた silent no-op を解消し、PGroonga の `&@~` 演算子で全文検索する経路を実装する。

upstream Misskey TS の `SearchService.searchNoteByLike` と同じく、provider 分岐は WHERE 節の演算子の差し替えだけで、それ以外のフィルタ・visibility 処理は sqlLike と共通とした。

## 主な変更点

- `model.NoteSearchFilter` に `Pgroonga bool` フィールドを追加
- `repository.SearchByFilter` で `f.Pgroonga` を見て `text &@~ ?` と `text ILIKE ?` を切替
- `core/search.SQLLikeProvider` に `pgroonga` フィールドと `NewSQLPgroongaProvider` コンストラクタを追加 (TS と同じ単一クラス方式)
- `server.buildSearchProvider` が `provider == "sqlpgroonga"` のとき `NewSQLPgroongaProvider` を選択
- `docs/configuration.md` に provider ごとの挙動説明と `CREATE EXTENSION pgroonga` / `CREATE INDEX ... USING pgroonga (text)` の手順を追記。pgroonga 拡張 install と index 作成は **運用者責務** (upstream Misskey TS と同じ方針、migration には含めていない)

## テスト

`make test` 全 pass。閾値も維持:

- `internal/core/search`: 100% (provider が `Pgroonga` フラグを repository filter に伝播することを stub repo で検証)
- `internal/repository`: SearchByFilter は 100% カバー
- `internal/server`: 既存通り 0% 例外 (router wire 層中心、CLAUDE.md #462)、ただし `search.go` 単体は新規 `search_test.go` で behavior test を追加

新規テスト:
- `repository/note_test.go::TestNoteRepository_SearchByFilter_PgroongaOperator` — CI postgres に pgroonga が無い性質を逆手に取り、`&@~` 演算子の解決失敗 (`operator does not exist: text &@~ ...`) で「Pgroonga ブランチが選択され実 SQL が発行された」ことを検証
- `core/search/sqllike_provider_test.go::TestSQLPgroongaProvider_PropagatesPgroongaFlag` / `TestSQLLikeProvider_DoesNotSetPgroongaFlag` — provider 種別ごとに `Pgroonga` フラグが filter に伝播することを stub repo で検証
- `server/search_test.go` — `buildSearchProvider` の各 provider 分岐 (sqlLike default / sqlLike explicit / sqlPgroonga / case-insensitive / unknown / meilisearch with-host / meilisearch without-host) と `buildMeilisearchHost` を behavior test

実行:

```bash
make fmt && make lint && make test
```

## 動作確認方法 (運用者向け)

PGroonga 拡張入りの PostgreSQL を用意し、対象 DB で:

```sql
CREATE EXTENSION IF NOT EXISTS pgroonga;
CREATE INDEX IF NOT EXISTS pgroonga_note_text_idx ON note USING pgroonga (text);
```

`default.yml` で:

```yaml
fulltextSearch:
  provider: sqlPgroonga
```

として mk-go 起動。`/api/notes/search` が `&@~` 演算子で発行されることを `EXPLAIN` などで確認可能。

## Closes

Closes #498
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/shiroha-a/mk/pull/559" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
