### PR TITLE
Fix bench nginx: enable upstream keepalive to prevent port exhaustion

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -51,6 +51,7 @@ drive-files/
 # Benchmark results
 tests/bench/results/*.json
 tests/bench/results/*.md
+tests/bench/results/profiles/
 !tests/bench/results/.gitkeep
 
 # Claude Code local state

--- a/tests/federation/common/nginx-mkgo-ssl.conf
+++ b/tests/federation/common/nginx-mkgo-ssl.conf
@@ -3,8 +3,19 @@ events {
 }
 
 http {
+    # WebSocket (Upgrade ヘッダ有り) は "upgrade" を、REST は空文字列を渡し
+    # HTTP/1.1 のデフォルト keepalive を有効にする。空文字列を渡すことで
+    # nginx は upstream への Connection ヘッダを送らず、upstream block の
+    # keepalive 64 と組み合わさってコネクションが再利用される。bench 等の
+    # 高 RPS で TIME_WAIT による source port 枯渇 (errno 99) を防ぐため。
+    map $http_upgrade $connection_upgrade {
+        default upgrade;
+        ''      "";
+    }
+
     upstream mkgo_backend {
         server app-mkgo:3000;
+        keepalive 64;
     }
 
     server {
@@ -23,7 +34,7 @@ http {
             proxy_set_header X-Forwarded-Proto https;
             proxy_http_version 1.1;
             proxy_set_header Upgrade $http_upgrade;
-            proxy_set_header Connection "upgrade";
+            proxy_set_header Connection $connection_upgrade;
         }
     }
 }

--- a/tests/federation/misskey/nginx-misskey-ssl.conf
+++ b/tests/federation/misskey/nginx-misskey-ssl.conf
@@ -3,8 +3,19 @@ events {
 }
 
 http {
+    # WebSocket (Upgrade ヘッダ有り) は "upgrade" を、REST は空文字列を渡し
+    # HTTP/1.1 のデフォルト keepalive を有効にする。空文字列を渡すことで
+    # nginx は upstream への Connection ヘッダを送らず、upstream block の
+    # keepalive 64 と組み合わさってコネクションが再利用される。bench 等の
+    # 高 RPS で TIME_WAIT による source port 枯渇 (errno 99) を防ぐため。
+    map $http_upgrade $connection_upgrade {
+        default upgrade;
+        ''      "";
+    }
+
     upstream misskey_backend {
         server misskey-app:3000;
+        keepalive 64;
     }
 
     server {
@@ -23,7 +34,7 @@ http {
             proxy_set_header X-Forwarded-Proto https;
             proxy_http_version 1.1;
             proxy_set_header Upgrade $http_upgrade;
-            proxy_set_header Connection "upgrade";
+            proxy_set_header Connection $connection_upgrade;
         }
     }
 }


### PR DESCRIPTION
## Summary

ベンチ環境の nginx (mk-go / Misskey TS 両 reverse proxy) が upstream へ HTTP keepalive を張らず、毎リクエスト新規 TCP 接続を作っていたため、高 RPS で ephemeral source port が TIME_WAIT で枯渇し \`connect() ... failed (99: Address not available)\` で 502 を返していた。

これにより前回 #560 の bench 結果は **application 性能ではなく nginx の retry 待ち時間** を測ってしまっていた。本 PR で nginx 設定を修正し、bench が application 本来の性能を計測できる状態に戻す。

## 主な変更点

両 nginx 設定 (\`tests/federation/common/nginx-mkgo-ssl.conf\` と \`tests/federation/misskey/nginx-misskey-ssl.conf\`) に対して同じパッチ:

1. \`upstream\` ブロックに \`keepalive 64;\` を追加 — nginx が upstream への persistent connection を最大 64 本までプールする
2. http レベルに \`map \$http_upgrade \$connection_upgrade { default upgrade; '' \"\"; }\` を追加 — WebSocket (Upgrade ヘッダ有り) は \"upgrade\" を渡し、REST (空) は空文字列を渡して HTTP/1.1 default keepalive を有効化
3. \`location /\` の \`proxy_set_header Connection \"upgrade\";\` を \`proxy_set_header Connection \$connection_upgrade;\` に変更

加えて \`.gitignore\` に \`tests/bench/results/profiles/\` を追加 (bench 実行ごとに上書きされる pprof 成果物)。

## 効果 (bench 数値)

| Endpoint | mk-go p95 (修正前) | mk-go p95 (修正後) | mk-go err% (修正前→後) | TS p95 修正前→後 |
|---|---|---|---|---|
| ping | 90.0 ms | **3.3 ms** | 0% → 0% | 84.6 → 4.7 |
| meta | 179.3 ms | **9.7 ms** | **85.59% → 0%** | 179.2 → 47.5 (err 100% → 0%) |
| local-timeline | 97.4 ms | **28.9 ms** | 0% → 0% | 422.2 → 445.9 |
| users-show | 183.9 ms | **15.0 ms** | **57.82% → 0%** | 117.7 → 86.5 |
| i | 98.1 ms | **68.1 ms** | 2.55% → 0% | 213.1 → 202.0 |
| notes-create | 72.6 ms | **4.4 ms** | 78.19% → 97.75% (per-user rate limit) | 142.2 → 144.9 |

修正後の mk-go vs TS p95 比較:

- ping: **1.44x mk-go**
- meta: **4.89x mk-go**
- local-timeline: **15.43x mk-go**
- users-show: **5.76x mk-go** (前回 0.64x = TS 1.56x 速 から大逆転、実は計測エラー)
- i: **2.97x mk-go**
- notes-create: 32.66x mk-go (※ rate limit 起因の 429 込み参考値)

注意: **mk-go application コード自体は無変更**。今回の数値変動は計測ノイズの除去によるもの。本来の application 性能はずっと修正後の数字だった。

## production への影響

無し。本 PR で触ったのは federation tests / bench 用の nginx fixture のみで、mk-go は production nginx 設定を同梱していない。production 環境で reverse proxy を運用する operator は通常 keepalive を設定しているため、ユーザー体験への影響もなし。

## テスト

- \`make bench-up && make bench-run\` で再 bench を実施。全エンドポイント err 率 0% (notes-create 除く)、レイテンシも application 本来の値に
- federation tests への影響は keepalive 追加のみで動作変更なし。upstream keepalive は nginx の upstream pool 最適化であり、HTTP signature や JSON-LD 等の federation 動作には透過的

\`\`\`bash
make bench-up
make bench-run
cat tests/bench/results/report.md
make bench-down
\`\`\`

## 残課題 (別 issue 候補)

- notes-create の per-user rate limit (\`notes/create: 300/hour\`、\`internal/server/middleware/ratelimit_defs.go:84\`) が bench で 97.75% を 429 にしている。Misskey TS は \`NODE_ENV=development\` で per-route rate limit ごと無効化しているため公正比較できない。bench 用の env flag (\`MK_DISABLEPERROUTERATELIMIT\` 的なもの) を新設するか、bench seed で大量 user を作って分散するか
- #413 のロードマップ Phase 1 の前提が崩れた件 — \`users-show N+1 排除\` 等は実は不要だった可能性が高い。pprof profile で再評価が必要

## 関連

- #560 (再 bench 結果 issue) — 数値解釈の誤りを発見した発端
- #413 (パフォーマンス改善ロードマップ、トラッカー)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/shiroha-a/mk/pull/561" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
