### PR TITLE
Perf #567: AP actor URI cache for inbox worker hot path

### DIFF
--- a/internal/queue/processors/inbox_test.go
+++ b/internal/queue/processors/inbox_test.go
@@ -255,6 +255,103 @@ func TestInboxProcessor_VerifyFailureDropped(t *testing.T) {
 	assert.Empty(t, stub.calls)
 }
 
+// hostBlocker が "allowed=false" を返した場合も blocked 経路と同じく
+// silently drop されること (IsBlocked=false でも IsAllowed=false なら
+// federation policy 上 reject)。
+func TestInboxProcessor_DisallowedHostDropped(t *testing.T) {
+	priv, pub, err := activitypub.GenerateRSAKeypair()
+	require.NoError(t, err)
+	key, err := activitypub.NewPrivateKey("https://remote.example/users/alice#main-key", priv)
+	require.NoError(t, err)
+	host := "remote.example"
+	verifier := &stubVerifier{actor: &model.User{ID: "alice", Host: &host}, pubKey: pub}
+	blocker := &stubBlocker{
+		blocked: func(string) bool { return false },
+		allowed: func(string) bool { return false },
+	}
+	stub := &stubFedProcessor{}
+	p := processors.NewInboxProcessor(stub)
+	p.SetSignatureVerifier(verifier)
+	p.SetHostBlockChecker(blocker)
+
+	payload := signedInboxPayload(t, key, []byte(`{}`))
+	require.NoError(t, p.Handle(context.Background(), driver.RawTask{
+		TypeName: queue.TaskTypeInbox,
+		Body:     mustEncode(t, payload),
+	}))
+	assert.Empty(t, stub.calls)
+}
+
+// host が nil な actor (= local) は blocked / tracker / chart 全て
+// no-op で素通りし Process まで到達する。
+func TestInboxProcessor_LocalActorSkipsHostDependentHooks(t *testing.T) {
+	priv, pub, err := activitypub.GenerateRSAKeypair()
+	require.NoError(t, err)
+	key, err := activitypub.NewPrivateKey("https://remote.example/users/alice#main-key", priv)
+	require.NoError(t, err)
+	verifier := &stubVerifier{actor: &model.User{ID: "alice", Host: nil}, pubKey: pub}
+	tracker := &stubInstanceTracker{}
+	chart := &stubInboxChartHook{}
+	blocker := &stubBlocker{}
+
+	stub := &stubFedProcessor{}
+	p := processors.NewInboxProcessor(stub)
+	p.SetSignatureVerifier(verifier)
+	p.SetHostBlockChecker(blocker)
+	p.SetInstanceTracker(tracker)
+	p.SetChartHook(chart)
+
+	payload := signedInboxPayload(t, key, []byte(`{}`))
+	require.NoError(t, p.Handle(context.Background(), driver.RawTask{
+		TypeName: queue.TaskTypeInbox,
+		Body:     mustEncode(t, payload),
+	}))
+	require.Len(t, stub.calls, 1)
+	assert.Empty(t, tracker.hosts, "local actor must not trigger instance tracker")
+	assert.Empty(t, chart.hosts, "local actor must not trigger chart hook")
+}
+
+// signature header が壊れていれば parse 段階で失敗 → drop。
+func TestInboxProcessor_InvalidSignatureHeaderDropped(t *testing.T) {
+	verifier := &stubVerifier{actor: &model.User{ID: "alice"}, pubKey: "x"}
+	stub := &stubFedProcessor{}
+	p := processors.NewInboxProcessor(stub)
+	p.SetSignatureVerifier(verifier)
+
+	payload := queue.InboxPayload{
+		Body:    []byte(`{}`),
+		Method:  "POST",
+		Path:    "/inbox",
+		Headers: map[string]string{"Signature": "not-a-valid-sig", "Host": "x", "Date": "today"},
+	}
+	require.NoError(t, p.Handle(context.Background(), driver.RawTask{
+		TypeName: queue.TaskTypeInbox,
+		Body:     mustEncode(t, payload),
+	}))
+	assert.Empty(t, stub.calls)
+}
+
+// resolver が actor を見つけられない (= ResolveActor error) と verify は
+// drop される (404 sender に伝えても解決しないため retry しない)。
+func TestInboxProcessor_ResolveActorErrorDropped(t *testing.T) {
+	priv, _, err := activitypub.GenerateRSAKeypair()
+	require.NoError(t, err)
+	key, err := activitypub.NewPrivateKey("https://remote.example/users/alice#main-key", priv)
+	require.NoError(t, err)
+
+	verifier := &stubVerifier{actor: nil, pubKey: ""}
+	stub := &stubFedProcessor{}
+	p := processors.NewInboxProcessor(stub)
+	p.SetSignatureVerifier(verifier)
+
+	payload := signedInboxPayload(t, key, []byte(`{}`))
+	require.NoError(t, p.Handle(context.Background(), driver.RawTask{
+		TypeName: queue.TaskTypeInbox,
+		Body:     mustEncode(t, payload),
+	}))
+	assert.Empty(t, stub.calls)
+}
+
 // Headers が空の payload (= legacy 形式 / 同期 handler 経路) では verify
 // は skip され、Process が直接走る。後方互換のため。
 func TestInboxProcessor_LegacyPayloadSkipsVerify(t *testing.T) {

--- a/internal/repository/user_cached.go
+++ b/internal/repository/user_cached.go
@@ -40,8 +40,8 @@ type CachedUserRepository struct {
 	profiles map[string]profileCacheEntry
 	// byURI は AP 由来 URI → user のキャッシュ。inbox worker の hot path
 	// (federation.Resolver.ResolveActor) が毎リクエスト FindByURI を叩く
-	// ため、これを cache せずに DB に行くと PR #565 で軽量化した HTTP
-	// 受信 fast path に対して worker drain がボトルネックになる (#xxx)。
+	// ため、これを cache せずに DB に行くと PR #566 で軽量化した HTTP
+	// 受信 fast path に対して worker drain がボトルネックになる (#567)。
 	byURI map[string]uriCacheEntry
 }
 
@@ -118,10 +118,14 @@ func (c *CachedUserRepository) SetMaxEntriesForTest(n int) {
 	c.mu.Unlock()
 }
 
-// invalidate drops both user and profile entries for the given userID.
-// Mutation 系メソッドの末尾で呼ぶ。byURI は per-userID で逆引きせず TTL に
-// 任せる (URI は actor の canonical id なので user lifetime 中は不変、
-// 古い entry が短時間残っても害は無い)。
+// invalidate drops users[userID], profiles[userID], および byURI 内の同じ
+// userID を持つ entry をすべて削除する。Mutation 系メソッドの末尾で呼ぶ。
+//
+// 当初は byURI を TTL に任せる設計だったが、Devin review #568 BUG-2 の
+// 指摘通り FindByURI が cache 経由で stale な User struct (古い
+// FollowingCount / IsSuspended 等) を最大 5 分返してしまう問題があり、
+// FindByID 経路と一貫性が取れない。byURI map walk は最悪 O(maxEntries)
+// だが mutation 経由でのみ発火するので per-request hot path には影響無し。
 func (c *CachedUserRepository) invalidate(userID string) {
 	if userID == "" {
 		return
@@ -129,6 +133,11 @@ func (c *CachedUserRepository) invalidate(userID string) {
 	c.mu.Lock()
 	delete(c.users, userID)
 	delete(c.profiles, userID)
+	for uri, e := range c.byURI {
+		if !e.missing && e.user != nil && e.user.ID == userID {
+			delete(c.byURI, uri)
+		}
+	}
 	c.mu.Unlock()
 }
 
@@ -319,6 +328,44 @@ func (c *CachedUserRepository) evictExpiredURIsLocked() {
 }
 
 // --- mutating methods: delegate then invalidate -----------------------------
+
+// Create persists a new user row. URI が指定されている場合は byURI cache の
+// 該当 entry を必ず削除する (#567 / #568 fix): federation.Resolver は
+// FindByURI miss → DB miss → 負 cache → 同 URI で remote fetch + Create
+// → 次の FindByURI で stale 負 cache hit という flow を踏むため、Create
+// 時の URI cache invalidation が無いと作ったばかりの user を 404 として
+// 返してしまう。
+func (c *CachedUserRepository) Create(u *model.User) error {
+	if err := c.UserRepository.Create(u); err != nil {
+		return err
+	}
+	if u != nil {
+		c.invalidate(u.ID)
+		if u.URI != nil && *u.URI != "" {
+			c.invalidateURI(*u.URI)
+		}
+	}
+	return nil
+}
+
+// invalidateURI drops the byURI cache entry for the given uri. URI を
+// 知っている呼び出し側専用 (例: Create / Update でリモート user を作る /
+// 更新するとき)。byURI map の負 cache が CREATE と競合して 404 を返す
+// 問題への対処 (#568)。
+func (c *CachedUserRepository) invalidateURI(uri string) {
+	if uri == "" {
+		return
+	}
+	c.mu.Lock()
+	delete(c.byURI, uri)
+	c.mu.Unlock()
+}
+
+// InvalidateURI is the public counterpart of invalidateURI for callers that
+// know they have just persisted a user with a given URI.
+func (c *CachedUserRepository) InvalidateURI(uri string) {
+	c.invalidateURI(uri)
+}
 
 func (c *CachedUserRepository) UpdateUser(userID string, fields map[string]any) error {
 	if err := c.UserRepository.UpdateUser(userID, fields); err != nil {

--- a/internal/repository/user_cached.go
+++ b/internal/repository/user_cached.go
@@ -38,6 +38,11 @@ type CachedUserRepository struct {
 	mu       sync.RWMutex
 	users    map[string]userCacheEntry
 	profiles map[string]profileCacheEntry
+	// byURI は AP 由来 URI → user のキャッシュ。inbox worker の hot path
+	// (federation.Resolver.ResolveActor) が毎リクエスト FindByURI を叩く
+	// ため、これを cache せずに DB に行くと PR #565 で軽量化した HTTP
+	// 受信 fast path に対して worker drain がボトルネックになる (#xxx)。
+	byURI map[string]uriCacheEntry
 }
 
 type userCacheEntry struct {
@@ -50,6 +55,12 @@ type userCacheEntry struct {
 
 type profileCacheEntry struct {
 	profile   *model.UserProfile
+	expiresAt time.Time
+	missing   bool
+}
+
+type uriCacheEntry struct {
+	user      *model.User
 	expiresAt time.Time
 	missing   bool
 }
@@ -92,6 +103,7 @@ func newCachedUserRepository(inner UserRepository, ttl time.Duration, maxEntries
 		maxEntries:     maxEntries,
 		users:          make(map[string]userCacheEntry),
 		profiles:       make(map[string]profileCacheEntry),
+		byURI:          make(map[string]uriCacheEntry),
 	}
 }
 
@@ -107,7 +119,9 @@ func (c *CachedUserRepository) SetMaxEntriesForTest(n int) {
 }
 
 // invalidate drops both user and profile entries for the given userID.
-// Mutation 系メソッドの末尾で呼ぶ。
+// Mutation 系メソッドの末尾で呼ぶ。byURI は per-userID で逆引きせず TTL に
+// 任せる (URI は actor の canonical id なので user lifetime 中は不変、
+// 古い entry が短時間残っても害は無い)。
 func (c *CachedUserRepository) invalidate(userID string) {
 	if userID == "" {
 		return
@@ -212,6 +226,58 @@ func (c *CachedUserRepository) storeProfileMissing(userID string) {
 	c.mu.Unlock()
 }
 
+// FindByURI returns the cached user for a remote AP URI, falling through
+// to the inner repo on miss / expiry. AP inbox worker の hot path から
+// 毎 request で呼ばれるため cache が effective: 同じ remote actor 由来の
+// activity が連続して届く federation 受信は典型的に高 hit-ratio。
+//
+// negative cache 含む semantic は FindByID と同じ。URI は actor の
+// canonical id (lifetime-stable) なので invalidate は通常 TTL 任せだが、
+// 別経路で user row が更新された場合に refresh されるよう同期 store する
+// FindByID 経路と TTL を揃える。
+func (c *CachedUserRepository) FindByURI(uri string) (*model.User, error) {
+	if uri == "" {
+		return c.UserRepository.FindByURI(uri)
+	}
+	c.mu.RLock()
+	if e, ok := c.byURI[uri]; ok && time.Now().Before(e.expiresAt) {
+		c.mu.RUnlock()
+		if e.missing {
+			return nil, gorm.ErrRecordNotFound
+		}
+		return e.user, nil
+	}
+	c.mu.RUnlock()
+
+	u, err := c.UserRepository.FindByURI(uri)
+	if err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			c.storeURIMissing(uri)
+			return nil, err
+		}
+		return nil, err
+	}
+	c.storeURI(uri, u)
+	// FindByID 経路の cache にも入れておく。worker は両方の lookup を
+	// する経路があり、片方 miss → DB → 反対側だけ updated は無駄なので。
+	c.storeUser(u.ID, u)
+	return u, nil
+}
+
+func (c *CachedUserRepository) storeURI(uri string, u *model.User) {
+	c.mu.Lock()
+	c.evictExpiredURIsLocked()
+	c.byURI[uri] = uriCacheEntry{user: u, expiresAt: time.Now().Add(c.ttl)}
+	c.mu.Unlock()
+}
+
+func (c *CachedUserRepository) storeURIMissing(uri string) {
+	c.mu.Lock()
+	c.evictExpiredURIsLocked()
+	c.byURI[uri] = uriCacheEntry{missing: true, expiresAt: time.Now().Add(c.ttl)}
+	c.mu.Unlock()
+}
+
 // evictExpiredUsersLocked は users map のサイズが userCacheMaxEntries を
 // 超えていたら、期限切れエントリを一括削除して memory growth を抑える。
 // 呼び出し側で c.mu.Lock 済みである必要がある。Devin #552: unbounded
@@ -236,6 +302,18 @@ func (c *CachedUserRepository) evictExpiredProfilesLocked() {
 	for k, e := range c.profiles {
 		if now.After(e.expiresAt) {
 			delete(c.profiles, k)
+		}
+	}
+}
+
+func (c *CachedUserRepository) evictExpiredURIsLocked() {
+	if len(c.byURI) < c.maxEntries {
+		return
+	}
+	now := time.Now()
+	for k, e := range c.byURI {
+		if now.After(e.expiresAt) {
+			delete(c.byURI, k)
 		}
 	}
 }

--- a/internal/repository/user_cached_test.go
+++ b/internal/repository/user_cached_test.go
@@ -24,6 +24,7 @@ type countingUserRepo struct {
 
 	findByIDCalls            atomic.Int64
 	findProfileByUserIDCalls atomic.Int64
+	findByURICalls           atomic.Int64
 
 	updateUserErr      error
 	updateProfileErr   error
@@ -45,6 +46,16 @@ func (c *countingUserRepo) FindByID(id string) (*model.User, error) {
 	c.findByIDCalls.Add(1)
 	if u, ok := c.users[id]; ok {
 		return u, nil
+	}
+	return nil, gorm.ErrRecordNotFound
+}
+
+func (c *countingUserRepo) FindByURI(uri string) (*model.User, error) {
+	c.findByURICalls.Add(1)
+	for _, u := range c.users {
+		if u.URI != nil && *u.URI == uri {
+			return u, nil
+		}
 	}
 	return nil, gorm.ErrRecordNotFound
 }
@@ -137,6 +148,63 @@ func TestCachedUserRepository_FindProfileByUserIDHitsInnerOnce(t *testing.T) {
 	assert.Equal(t, int64(1), inner.findProfileByUserIDCalls.Load())
 }
 
+func TestCachedUserRepository_FindByURIHitsInnerOnce(t *testing.T) {
+	inner := newCountingUserRepo()
+	uri := "https://remote.example/users/alice"
+	inner.users["u1"] = &model.User{ID: "u1", Username: "alice", URI: &uri}
+	cached := repository.NewCachedUserRepository(inner)
+
+	for range 10 {
+		got, err := cached.FindByURI(uri)
+		require.NoError(t, err)
+		assert.Equal(t, "u1", got.ID)
+	}
+	assert.Equal(t, int64(1), inner.findByURICalls.Load(),
+		"10 cached URI lookups must hit inner exactly once")
+
+	// FindByURI 経由で FindByID 側にも cache が乗ること (worker hot path)。
+	_, err := cached.FindByID("u1")
+	require.NoError(t, err)
+	assert.Equal(t, int64(0), inner.findByIDCalls.Load(),
+		"FindByID after FindByURI hit must not call inner")
+}
+
+func TestCachedUserRepository_FindByURINegativeCache(t *testing.T) {
+	inner := newCountingUserRepo()
+	cached := repository.NewCachedUserRepository(inner)
+
+	for range 5 {
+		_, err := cached.FindByURI("https://ghost/users/x")
+		require.ErrorIs(t, err, gorm.ErrRecordNotFound)
+	}
+	assert.Equal(t, int64(1), inner.findByURICalls.Load(),
+		"missing URI must be negative-cached")
+}
+
+func TestCachedUserRepository_FindByURITransientErrorNotCached(t *testing.T) {
+	inner := &erroringUserRepo{}
+	cached := repository.NewCachedUserRepository(inner)
+	_, err := cached.FindByURI("https://x/users/a")
+	require.Error(t, err)
+	_, err = cached.FindByURI("https://x/users/a")
+	require.Error(t, err)
+	assert.Equal(t, int64(2), inner.calls.Load())
+}
+
+func TestCachedUserRepository_FindByURIRefreshesAfterTTL(t *testing.T) {
+	inner := newCountingUserRepo()
+	uri := "https://r/u/a"
+	inner.users["u1"] = &model.User{ID: "u1", URI: &uri}
+	cached := repository.NewCachedUserRepositoryWithTTL(inner, 1*time.Millisecond)
+
+	_, err := cached.FindByURI(uri)
+	require.NoError(t, err)
+	time.Sleep(2 * time.Millisecond)
+	_, err = cached.FindByURI(uri)
+	require.NoError(t, err)
+	assert.Equal(t, int64(2), inner.findByURICalls.Load())
+}
+
 func TestCachedUserRepository_NotFoundIsNegativeCached(t *testing.T) {
 	inner := newCountingUserRepo()
 	cached := repository.NewCachedUserRepository(inner)
@@ -162,6 +230,11 @@ func (e *erroringUserRepo) FindByID(_ string) (*model.User, error) {
 }
 
 func (e *erroringUserRepo) FindProfileByUserID(_ string) (*model.UserProfile, error) {
+	e.calls.Add(1)
+	return nil, errors.New("db down")
+}
+
+func (e *erroringUserRepo) FindByURI(_ string) (*model.User, error) {
 	e.calls.Add(1)
 	return nil, errors.New("db down")
 }

--- a/internal/repository/user_cached_test.go
+++ b/internal/repository/user_cached_test.go
@@ -50,6 +50,14 @@ func (c *countingUserRepo) FindByID(id string) (*model.User, error) {
 	return nil, gorm.ErrRecordNotFound
 }
 
+func (c *countingUserRepo) Create(u *model.User) error {
+	if u == nil {
+		return errors.New("nil user")
+	}
+	c.users[u.ID] = u
+	return nil
+}
+
 func (c *countingUserRepo) FindByURI(uri string) (*model.User, error) {
 	c.findByURICalls.Add(1)
 	for _, u := range c.users {
@@ -189,6 +197,50 @@ func TestCachedUserRepository_FindByURITransientErrorNotCached(t *testing.T) {
 	_, err = cached.FindByURI("https://x/users/a")
 	require.Error(t, err)
 	assert.Equal(t, int64(2), inner.calls.Load())
+}
+
+// 同一 URI で先に NotFound 負 cache が乗ったあと、Create で同 URI の user
+// を作っても次回 FindByURI で 404 を返さないこと (federation.Resolver の
+// resolve → fetch → Create flow がここで詰まると pre-#568 の e2e
+// regression と同じ「直前に作った remote user が 404」になる)。
+func TestCachedUserRepository_CreateInvalidatesNegativeURICache(t *testing.T) {
+	inner := newCountingUserRepo()
+	uri := "https://r/u/late"
+	cached := repository.NewCachedUserRepository(inner)
+
+	// 1. 先に存在しない URI を引いて負 cache を作る
+	_, err := cached.FindByURI(uri)
+	require.ErrorIs(t, err, gorm.ErrRecordNotFound)
+
+	// 2. user を Create
+	require.NoError(t, cached.Create(&model.User{ID: "u1", URI: &uri}))
+
+	// 3. もう一度 FindByURI して、404 でなく作成した user が返ること
+	got, err := cached.FindByURI(uri)
+	require.NoError(t, err)
+	assert.Equal(t, "u1", got.ID)
+}
+
+// UpdateUser で URI が変わるケース (rename / move): byURI cache を userID
+// で逆引き invalidate する。
+func TestCachedUserRepository_UpdateUserInvalidatesURICache(t *testing.T) {
+	inner := newCountingUserRepo()
+	uri := "https://r/u/x"
+	inner.users["u1"] = &model.User{ID: "u1", URI: &uri}
+	cached := repository.NewCachedUserRepository(inner)
+
+	// warm cache via FindByURI
+	_, err := cached.FindByURI(uri)
+	require.NoError(t, err)
+
+	// update via cached repo (e.g. fields map で uri 変更想定)
+	require.NoError(t, cached.UpdateUser("u1", map[string]any{"uri": "https://r/u/y"}))
+
+	// FindByURI(old_uri) は inner に再度行くこと (cache hit せず)
+	prev := inner.findByURICalls.Load()
+	_, _ = cached.FindByURI(uri)
+	assert.Greater(t, inner.findByURICalls.Load(), prev,
+		"UpdateUser must invalidate URI cache for that user")
 }
 
 func TestCachedUserRepository_FindByURIRefreshesAfterTTL(t *testing.T) {


### PR DESCRIPTION
## Summary

#566 (verify-in-worker) で inbox HTTP 受信は TS の **2.7x** になったが、worker drain time は依然 28-49s (vs TS 17s)。worker 内 hot path の \`federation.Resolver.ResolveActor\` が呼ぶ \`userRepo.FindByURI\` が \`CachedUserRepository\` でキャッシュされず毎回 DB に行っていたのを Phase 2 として塞ぐ。

## 主な変更点

\`internal/repository/user_cached.go\`:
- \`byURI\` map (uri → user) を \`CachedUserRepository\` に追加
- \`FindByURI\` を override し、\`FindByID\` 同等の semantic を持たせる:
  - 5min TTL、negative cache、transient error は非キャッシュ
  - \`maxEntries\` (50000) 超で expired 一括 sweep
  - \`FindByURI\` で見つけた user は \`FindByID\` 側 cache にも入れる (worker は両 lookup する経路があるため)
  - mutation 経由の \`invalidate(userID)\` は byURI には反映しない (URI は actor canonical id で lifetime-stable、TTL に任せる)

\`internal/repository/user_cached_test.go\`:
- hit / miss / negative cache / transient error 非キャッシュ / TTL refresh / FindByID への波及 のテスト追加

## 計測結果 (queue-bench、10k inbox jobs)

| Stack | Before send_rps | After send_rps | Δ |
|---|---|---|---|
| Misskey TS | 1064.5 | 1113.6 | +5% (誤差) |
| mk-asynq | 2812.1 | **2985.6** | **+6%** |
| mk-mkq | 3017.1 | 3011.2 | ≈ |

drain time は asynq 29s / mkq 45s で改善幅小。URI cache 単体での効果は限定的で、**drain time の真のボトルネックは worker 内 \`processor.Process\` の DB writes (Note INSERT 等)** にあることが判明。これは別 issue で対応:

- worker concurrency 増 (現 default 16 → 32-64)
- \`processor.Process\` の note insert 高速化 (batch / dedup)
- mkq 上流 Lua script pipelining

## production 影響

\`CachedUserRepository\` の cache 層追加のみで semantic 互換。production の federation 受信で同一 remote actor 由来 activity が連続して届くケースで cache hit して DB hit が削減される。invalidate path は \`UpdateUser\` / \`UpdateProfile\` 等 mutation 経由で TTL より早く飛ばす形 (byURI は TTL に任せるが、URI は不変なので問題なし)。

## テスト

\`make fmt && make lint && make test\` 全 pass。新規テスト 5 件:

- \`TestCachedUserRepository_FindByURIHitsInnerOnce\`: 10 連続 lookup で inner 1 回呼び + FindByID 経路にも cache が乗ること
- \`TestCachedUserRepository_FindByURINegativeCache\`: 5 連続 NotFound で inner 1 回呼び
- \`TestCachedUserRepository_FindByURITransientErrorNotCached\`: transient error は cache せず caller に返す
- \`TestCachedUserRepository_FindByURIRefreshesAfterTTL\`: TTL 後に inner 再呼び出し
- erroringUserRepo に \`FindByURI\` を追加

## 関連

- #567 (本 PR が close する issue)
- #565 / PR #566 (Phase 1: verify-in-worker)
- #564 (queue-bench、計測基盤)
- #413 (パフォーマンス改善ロードマップ)

Closes #567
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/shiroha-a/mk/pull/568" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
