### PR TITLE
Implement #587: 残存 stub 4 件を本実装 + vestigial /ap/notes 削除

### DIFF
--- a/internal/api/admin/federation_admin.go
+++ b/internal/api/admin/federation_admin.go
@@ -5,16 +5,31 @@ import (
 	"net/http"
 
 	"github.com/labstack/echo/v4"
+	"github.com/shiroha-a/mk/internal/api/apierr"
 	"github.com/shiroha-a/mk/internal/model"
+	"github.com/shiroha-a/mk/internal/queue"
 )
 
 // FederationDeleteAllFiles handles POST /api/admin/federation/delete-all-files.
+//
+// 指定ホストの DriveFile (= リモート user の上げた添付) を一括削除する。
+// 旧実装は no-op だったが #587 で本実装化。Misskey TS 本家の挙動と等価:
+// packages/backend/src/server/api/endpoints/admin/federation/delete-all-files.ts。
+//
+// host が空または driveFileRepo 未配線の場合は no-op で 204 を返す。S3 等の
+// 物理オブジェクト削除は drive_file の deletion hook 経由 (別経路、本家と同じく
+// row 削除で hook が起動する)。
 func (h *Handler) FederationDeleteAllFiles(c echo.Context) error {
 	var req struct {
 		Host string `json:"host"`
 	}
 	_ = c.Bind(&req)
-	// リモートファイル削除は将来対応 (DriveFileRepoのリモートファイル一括削除が必要)
+	if req.Host == "" || h.driveFileRepo == nil {
+		return c.NoContent(http.StatusNoContent)
+	}
+	if _, err := h.driveFileRepo.DeleteByHost(req.Host); err != nil {
+		return apierr.JSONInternalError(c)
+	}
 	return c.NoContent(http.StatusNoContent)
 }
 
@@ -39,12 +54,59 @@ func (h *Handler) FederationRefreshRemoteInstanceMetadata(c echo.Context) error 
 }
 
 // FederationRemoveAllFollowing handles POST /api/admin/federation/remove-all-following.
+//
+// 指定ホストの Follower (= 当インスタンスのローカル user を follow している
+// リモート user) を全員 unfollow させる。followerHost = req.Host の Following
+// 行を列挙し、各 (followerID, followeeID) ペアごとに per-pair Unfollow ジョブを
+// キューに enqueue する。実際の row 削除と Reject(Follow) 配送は worker
+// (processors.UnfollowProcessor) が core/following.Service.Unfollow を呼んで
+// 行うので、HTTP request はブロックされない。
+//
+// 旧実装は no-op だったが #587 で本実装化。Misskey TS 本家
+// (packages/backend/src/server/api/endpoints/admin/federation/remove-all-following.ts
+// が queueService.createUnfollowJob 経由で per-pair queueing する) と挙動を
+// 揃える。host 未指定 / 依存未配線の場合は no-op で 204 を返す。
+//
+// Worker 側で処理されるため、enumeration 中に row 削除は発生しない。よって
+// offset ベースの pagination で安全に列挙できる (sync 版で必要だった seen-set
+// は不要)。
 func (h *Handler) FederationRemoveAllFollowing(c echo.Context) error {
 	var req struct {
 		Host string `json:"host"`
 	}
 	_ = c.Bind(&req)
-	// リモートフォロー一括削除は将来対応
+	if req.Host == "" || h.followingRepo == nil || h.unfollowEnqueuer == nil {
+		return c.NoContent(http.StatusNoContent)
+	}
+	const pageSize = 100
+	const maxBatches = 1000 // safety cap: 100k pairs / request
+	for batch := 0; batch < maxBatches; batch++ {
+		rows, err := h.followingRepo.ListFollowersByHost(req.Host, pageSize, batch*pageSize)
+		if err != nil {
+			return apierr.JSONInternalError(c)
+		}
+		if len(rows) == 0 {
+			break
+		}
+		for _, f := range rows {
+			if err := h.unfollowEnqueuer.EnqueueUnfollow(queue.UnfollowPayload{
+				FollowerID: f.FollowerID,
+				FolloweeID: f.FolloweeID,
+			}); err != nil {
+				// enqueue 失敗は個別ペアで握りつぶす - admin 操作の best-effort
+				// として残りの enqueue を妨げない。Worker retry が効かないため
+				// ログには残しておく。
+				slog.Warn("admin: federation/remove-all-following: enqueue failed",
+					"host", req.Host,
+					"follower", f.FollowerID,
+					"followee", f.FolloweeID,
+					"err", err)
+			}
+		}
+		if len(rows) < pageSize {
+			break
+		}
+	}
 	return c.NoContent(http.StatusNoContent)
 }
 

--- a/internal/api/admin/federation_admin_test.go
+++ b/internal/api/admin/federation_admin_test.go
@@ -5,12 +5,38 @@ import (
 	"net/http"
 	"testing"
 
+	"github.com/shiroha-a/mk/internal/model"
+	"github.com/shiroha-a/mk/internal/queue"
+	"github.com/shiroha-a/mk/internal/testutil"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestFederationDeleteAllFiles(t *testing.T) {
+	// repo 未配線 / host 未指定は 204 no-op
 	h, _, _, _ := newTestHandler(t)
 	assert.Equal(t, http.StatusNoContent, doPost(h.FederationDeleteAllFiles, `{}`, adminUser).Code)
+}
+
+// host 指定 + driveFileRepo 配線時は対象ホストの DriveFile が削除される。
+// 他ホストおよびローカルファイルは残ること。本実装は #587 で追加。
+func TestFederationDeleteAllFiles_DeletesByHost(t *testing.T) {
+	h, _, _, _ := newTestHandler(t)
+	repo := testutil.NewMockDriveFileRepository()
+	host := "remote.example"
+	other := "other.example"
+	require.NoError(t, repo.Create(&model.DriveFile{ID: "f1", UserHost: &host}))
+	require.NoError(t, repo.Create(&model.DriveFile{ID: "f2", UserHost: &host}))
+	require.NoError(t, repo.Create(&model.DriveFile{ID: "f3", UserHost: &other}))
+	require.NoError(t, repo.Create(&model.DriveFile{ID: "f4"})) // local (UserHost = nil)
+	h.SetDriveFileRepo(repo)
+
+	rec := doPost(h.FederationDeleteAllFiles, `{"host":"remote.example"}`, adminUser)
+	assert.Equal(t, http.StatusNoContent, rec.Code)
+	assert.NotContains(t, repo.Files, "f1")
+	assert.NotContains(t, repo.Files, "f2")
+	assert.Contains(t, repo.Files, "f3", "他ホストのファイルは残る")
+	assert.Contains(t, repo.Files, "f4", "ローカルファイルは残る")
 }
 
 func TestFederationRefreshRemoteInstanceMetadata(t *testing.T) {
@@ -62,6 +88,68 @@ func TestFederationRefreshRemoteInstanceMetadata_FetchError_Still204(t *testing.
 func TestFederationRemoveAllFollowing(t *testing.T) {
 	h, _, _, _ := newTestHandler(t)
 	assert.Equal(t, http.StatusNoContent, doPost(h.FederationRemoveAllFollowing, `{}`, adminUser).Code)
+}
+
+// stubUnfollowEnqueuer records every Unfollow payload so tests can assert
+// which (follower, followee) pairs the admin handler scheduled. Misskey TS
+// の queueService.createUnfollowJob 相当を mock するための test double。
+type stubUnfollowEnqueuer struct {
+	pairs [][2]string
+	err   error
+}
+
+func (s *stubUnfollowEnqueuer) EnqueueUnfollow(p queue.UnfollowPayload) error {
+	s.pairs = append(s.pairs, [2]string{p.FollowerID, p.FolloweeID})
+	return s.err
+}
+
+// host 指定 + 依存全配線時、followerHost = host の Following row 全てに対して
+// Unfollow ジョブが enqueue されること。実 row 削除と Reject(Follow) 配送は
+// worker (processors.UnfollowProcessor) が担当する。本実装は #587 で追加。
+func TestFederationRemoveAllFollowing_EnqueuesAllPairs(t *testing.T) {
+	h, _, _, _ := newTestHandler(t)
+	host := "remote.example"
+	other := "other.example"
+	repo := testutil.NewMockFollowingRepository()
+	// followerHost = remote.example の row 2 件
+	repo.Followings["f1"] = &model.Following{
+		ID: "f1", FollowerID: "rA", FolloweeID: "localA", FollowerHost: &host,
+	}
+	repo.Followings["f2"] = &model.Following{
+		ID: "f2", FollowerID: "rB", FolloweeID: "localB", FollowerHost: &host,
+	}
+	// 別ホスト + ローカル follower は対象外
+	repo.Followings["f3"] = &model.Following{
+		ID: "f3", FollowerID: "rC", FolloweeID: "localC", FollowerHost: &other,
+	}
+	repo.Followings["f4"] = &model.Following{
+		ID: "f4", FollowerID: "localX", FolloweeID: "localY",
+	}
+	h.SetFollowingRepo(repo)
+
+	enq := &stubUnfollowEnqueuer{}
+	h.SetUnfollowEnqueuer(enq)
+
+	rec := doPost(h.FederationRemoveAllFollowing, `{"host":"remote.example"}`, adminUser)
+	require.Equal(t, http.StatusNoContent, rec.Code)
+
+	// 対象 host の 2 ペアに対してのみ EnqueueUnfollow が呼ばれている
+	require.Len(t, enq.pairs, 2)
+	pairsSet := map[[2]string]bool{}
+	for _, p := range enq.pairs {
+		pairsSet[p] = true
+	}
+	assert.True(t, pairsSet[[2]string{"rA", "localA"}])
+	assert.True(t, pairsSet[[2]string{"rB", "localB"}])
+}
+
+// 依存未配線 / host 未指定では no-op で 204
+func TestFederationRemoveAllFollowing_NoOpWhenUnwired(t *testing.T) {
+	h, _, _, _ := newTestHandler(t)
+	// repo は配線するが enqueuer は未配線
+	h.SetFollowingRepo(testutil.NewMockFollowingRepository())
+	rec := doPost(h.FederationRemoveAllFollowing, `{"host":"remote.example"}`, adminUser)
+	assert.Equal(t, http.StatusNoContent, rec.Code)
 }
 
 func TestFederationUpdateInstance(t *testing.T) {

--- a/internal/api/admin/handler.go
+++ b/internal/api/admin/handler.go
@@ -61,6 +61,16 @@ type SystemAccountFetcher interface {
 	Fetch(kind string) (*model.User, error)
 }
 
+// UnfollowEnqueuer schedules per-pair Unfollow background jobs, used by
+// admin/federation/remove-all-following to detach all incoming follows from
+// a host without blocking the HTTP request. The job is consumed by
+// processors.UnfollowProcessor which calls core/following.Service.Unfollow
+// (= Following row 削除 + Reject(Follow) 配送)。Misskey TS の
+// queueService.createUnfollowJob 相当。
+type UnfollowEnqueuer interface {
+	EnqueueUnfollow(payload queue.UnfollowPayload) error
+}
+
 // Handler handles admin API endpoints.
 type Handler struct {
 	signupService           *signup.Service
@@ -93,6 +103,8 @@ type Handler struct {
 	configSetupPassword     string
 	instanceMetadataFetcher InstanceMetadataFetcher
 	systemAccountFetcher    SystemAccountFetcher
+	followingRepo           repository.FollowingRepository
+	unfollowEnqueuer        UnfollowEnqueuer
 }
 
 // EmailSender sends a plain-text email (to, subject, body). Same signature
@@ -130,6 +142,20 @@ func (h *Handler) SetInstanceMetadataFetcher(f InstanceMetadataFetcher) {
 // proxy account.
 func (h *Handler) SetSystemAccountFetcher(f SystemAccountFetcher) {
 	h.systemAccountFetcher = f
+}
+
+// SetFollowingRepo attaches a FollowingRepository for admin endpoints that
+// need to enumerate Following rows by host (e.g.
+// admin/federation/remove-all-following).
+func (h *Handler) SetFollowingRepo(r repository.FollowingRepository) {
+	h.followingRepo = r
+}
+
+// SetUnfollowEnqueuer attaches the queue client used by
+// admin/federation/remove-all-following to schedule per-pair Unfollow
+// background jobs. Typically wired with the project-wide queue client.
+func (h *Handler) SetUnfollowEnqueuer(e UnfollowEnqueuer) {
+	h.unfollowEnqueuer = e
 }
 
 // SetRecipientRepo attaches an AbuseReportNotificationRecipientRepository for

--- a/internal/api/ap/handler.go
+++ b/internal/api/ap/handler.go
@@ -343,11 +343,6 @@ func packUserForAPI(u *model.User) map[string]any {
 	}
 }
 
-// APNotes handles POST /api/ap/notes — stub returning empty array.
-func (h *Handler) APNotes(c echo.Context) error {
-	return c.JSON(http.StatusOK, []any{})
-}
-
 // Note handles GET /notes/:id with ActivityPub content negotiation.
 // AP clients receive the AS Note object; browser reloads are handed
 // off to the frontend fallback so the SPA renders the note permalink.

--- a/internal/api/ap/handler_test.go
+++ b/internal/api/ap/handler_test.go
@@ -318,12 +318,6 @@ func TestSetRemote(t *testing.T) {
 	assert.NotNil(t, h.remoteFetcher)
 }
 
-func TestAPNotes(t *testing.T) {
-	h, _, _, _ := newHandler(t)
-	rec := postJSON(h.APNotes, `{}`)
-	assert.Equal(t, http.StatusOK, rec.Code)
-}
-
 func TestAPIGet_RemoteFetch(t *testing.T) {
 	h, _, _, _ := newHandler(t)
 	h.SetRemote(&mockFetcher{data: []byte(`{"type":"Note","id":"https://remote.example/notes/1"}`)}, nil)

--- a/internal/api/i/apps.go
+++ b/internal/api/i/apps.go
@@ -4,18 +4,97 @@ import (
 	"crypto/sha256"
 	"fmt"
 	"net/http"
+	"time"
 
 	"github.com/labstack/echo/v4"
 	"github.com/shiroha-a/mk/internal/api/apierr"
+	"github.com/shiroha-a/mk/internal/model"
 	"github.com/shiroha-a/mk/internal/server/middleware"
 )
 
 // Apps handles POST /api/i/apps.
-// Owned OAuth2 application registration/management は本家 Misskey でも
-// 現状未使用 (app 登録 UI が削除されている) ので常に空配列を返す。
-// OAuth owner-apps listing を復活させる場合は別 issue で扱う。
+//
+// 本家 Misskey の i/apps と同 shape (access_token + app の JOIN) を返す。
+// 旧実装は誤って空配列を返しており frontend "Apps" 一覧が常に空だったため
+// #587 で本実装化した。Misskey TS 本家 ref:
+// packages/backend/src/server/api/endpoints/i/apps.ts。
+//
+// sort 値は +/-createdAt / +/-lastUsedAt。未指定時は token.id ASC (本家 default)。
+// 各 token の name / permission / description は app へフォールバックする
+// (例: token.name が NULL なら app.name を使う、本家と同じ ?? チェーン)。
 func (h *Handler) Apps(c echo.Context) error {
-	return c.JSON(http.StatusOK, []any{})
+	if h.accessTokenRepo == nil {
+		return c.JSON(http.StatusOK, []any{})
+	}
+	u := middleware.GetUser(c)
+	var req struct {
+		Sort string `json:"sort"`
+	}
+	_ = c.Bind(&req)
+	tokens, err := h.accessTokenRepo.ListByUserIDPreloadApp(u.ID, req.Sort)
+	if err != nil {
+		return apierr.JSONInternalError(c)
+	}
+	const tsFormat = "2006-01-02T15:04:05.000Z"
+	out := make([]map[string]any, 0, len(tokens))
+	for _, t := range tokens {
+		entry := map[string]any{
+			"id":         t.ID,
+			"name":       coalesceString(t.Name, appName(t.App)),
+			"lastUsedAt": formatNullableTime(t.LastUsedAt, tsFormat),
+			"permission": []string(tokenPermission(t)),
+			"iconUrl":    t.IconURL,
+			"description": coalesceString(
+				t.Description,
+				appDescription(t.App),
+			),
+		}
+		if ct, err := h.idGen.ParseTime(t.ID); err == nil {
+			entry["createdAt"] = ct.UTC().Format(tsFormat)
+		}
+		out = append(out, entry)
+	}
+	return c.JSON(http.StatusOK, out)
+}
+
+// coalesceString は本家の `a ?? b` チェーン相当。a が nil/"" なら b を返す。
+func coalesceString(a, b *string) *string {
+	if a != nil && *a != "" {
+		return a
+	}
+	return b
+}
+
+func appName(a *model.App) *string {
+	if a == nil {
+		return nil
+	}
+	return &a.Name
+}
+
+func appDescription(a *model.App) *string {
+	if a == nil {
+		return nil
+	}
+	return &a.Description
+}
+
+// tokenPermission は本家と同じ分岐: app があれば app.permission、無ければ
+// token.permission (本家 i/apps.ts:98)。
+func tokenPermission(t *model.AccessToken) []string {
+	if t.App != nil {
+		return []string(t.App.Permission)
+	}
+	return []string(t.Permission)
+}
+
+// formatNullableTime は *time.Time が nil の場合 nil を返し、そうでなければ
+// 指定 layout で UTC 文字列に整形する。
+func formatNullableTime(t *time.Time, layout string) any {
+	if t == nil {
+		return nil
+	}
+	return t.UTC().Format(layout)
 }
 
 // AuthorizedApps handles POST /api/i/authorized-apps.

--- a/internal/api/i/apps_test.go
+++ b/internal/api/i/apps_test.go
@@ -15,7 +15,93 @@ import (
 
 func TestApps(t *testing.T) {
 	h, _ := newExtraHandler(t)
-	assert.Equal(t, http.StatusOK, postExtra(h.Apps, `{}`, stubUser).Code)
+	// accessTokenRepo 未配線時は空配列で graceful fallback
+	rec := postExtra(h.Apps, `{}`, stubUser)
+	assert.Equal(t, http.StatusOK, rec.Code)
+	assert.Equal(t, "[]\n", rec.Body.String())
+}
+
+// /i/apps は本家 Misskey 互換で access_token + app の JOIN を返す。
+// owner-app 経由 (token.appId 指定あり) と raw token (app 無し) の混在を
+// テスト。本実装化は #587 で行った (旧実装は常に空配列を返す stub)。
+func TestApps_ReturnsTokensWithApp(t *testing.T) {
+	h, _ := newExtraHandler(t)
+	tokens := testutil.NewMockAccessTokenRepository()
+	idGen, _ := id.NewGenerator("aidx")
+
+	// owner-app 経由の token: app メタを app テーブルから引く
+	appID := "app1"
+	tokens.SetApp(&model.App{
+		ID:          appID,
+		Name:        "Misskey IDE",
+		Description: "OAuth2 demo app",
+		Permission:  []string{"read:account"},
+	})
+	tApp := idGen.Generate(time.Now())
+	tokens.Tokens["h1"] = &model.AccessToken{
+		ID: tApp, Hash: "h1", UserID: stubUser.ID, AppID: &appID,
+	}
+
+	// raw token (app なし): token 自身の name / permission を使う
+	tRaw := idGen.Generate(time.Now())
+	rawName := "personal token"
+	tokens.Tokens["h2"] = &model.AccessToken{
+		ID: tRaw, Hash: "h2", UserID: stubUser.ID,
+		Name:       &rawName,
+		Permission: []string{"write:notes"},
+	}
+
+	// 別ユーザーの token は除外
+	tokens.Tokens["h3"] = &model.AccessToken{ID: "other", Hash: "h3", UserID: "other"}
+
+	h.SetAccessTokenRepo(tokens)
+
+	rec := postExtra(h.Apps, `{}`, stubUser)
+	require.Equal(t, http.StatusOK, rec.Code)
+	var got []map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &got))
+	require.Len(t, got, 2)
+
+	// default sort = id ASC のため、ID 順に並ぶ。
+	byID := map[string]map[string]any{}
+	for _, e := range got {
+		byID[e["id"].(string)] = e
+	}
+	// owner-app 経由: name は app.name、permission は app.permission
+	app := byID[tApp]
+	assert.Equal(t, "Misskey IDE", app["name"])
+	perm, _ := app["permission"].([]any)
+	require.Len(t, perm, 1)
+	assert.Equal(t, "read:account", perm[0])
+	assert.Equal(t, "OAuth2 demo app", app["description"])
+
+	// raw token: name は token.name、permission は token.permission
+	raw := byID[tRaw]
+	assert.Equal(t, "personal token", raw["name"])
+	perm2, _ := raw["permission"].([]any)
+	require.Len(t, perm2, 1)
+	assert.Equal(t, "write:notes", perm2[0])
+}
+
+// sort=+createdAt は新しい順 (ID DESC)。
+func TestApps_SortByCreatedAtDesc(t *testing.T) {
+	h, _ := newExtraHandler(t)
+	tokens := testutil.NewMockAccessTokenRepository()
+	idGen, _ := id.NewGenerator("aidx")
+	t1 := idGen.Generate(time.Now())
+	t2 := idGen.Generate(time.Now().Add(time.Second))
+	tokens.Tokens["h1"] = &model.AccessToken{ID: t1, Hash: "h1", UserID: stubUser.ID}
+	tokens.Tokens["h2"] = &model.AccessToken{ID: t2, Hash: "h2", UserID: stubUser.ID}
+	h.SetAccessTokenRepo(tokens)
+
+	rec := postExtra(h.Apps, `{"sort":"+createdAt"}`, stubUser)
+	require.Equal(t, http.StatusOK, rec.Code)
+	var got []map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &got))
+	require.Len(t, got, 2)
+	// 新しい順 = t2 が先
+	assert.Equal(t, t2, got[0]["id"])
+	assert.Equal(t, t1, got[1]["id"])
 }
 
 func TestAuthorizedApps(t *testing.T) {

--- a/internal/core/transfer/drive_reader_test.go
+++ b/internal/core/transfer/drive_reader_test.go
@@ -88,6 +88,9 @@ func (f *fakeDriveFileRepo) DeleteRemoteCache() (int64, error) { return 0, nil }
 func (f *fakeDriveFileRepo) DeleteByUser(_ string) (int64, error) {
 	return 0, nil
 }
+func (f *fakeDriveFileRepo) DeleteByHost(_ string) (int64, error) {
+	return 0, nil
+}
 
 // Ensure fakeDriveFileRepo implements the real repository interface so the
 // reader accepts it.

--- a/internal/model/access_token.go
+++ b/internal/model/access_token.go
@@ -23,6 +23,9 @@ type AccessToken struct {
 
 	// Relations
 	User *User `gorm:"foreignKey:UserID" json:"user,omitempty"`
+	// App は MiAuth で登録された OAuth2 アプリケーション。
+	// access_token.appId が NULL の場合 (= owner-app 経由の token) は nil。
+	App *App `gorm:"foreignKey:AppID" json:"app,omitempty"`
 }
 
 func (AccessToken) TableName() string { return "access_token" }

--- a/internal/queue/processors/unfollow.go
+++ b/internal/queue/processors/unfollow.go
@@ -1,0 +1,73 @@
+package processors
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/shiroha-a/mk/internal/queue"
+	"github.com/shiroha-a/mk/internal/queue/driver"
+)
+
+// Unfollower is the narrow subset of core/following.Service the processor
+// needs. パッケージ間の循環依存を避けるため interface で受け取る。
+type Unfollower interface {
+	Unfollow(followerID, followeeID string) error
+}
+
+// ErrNotFollowing is returned by Unfollower implementations when the
+// pair was already detached (= no row to delete). The processor treats
+// this as success since the desired end-state is "not following".
+//
+// 既存の core/following.ErrNotFollowing と等価。processor が core 層を
+// 直 import すると循環依存になるため、processor 側で同名 sentinel を
+// 持たせて errors.Is で照合する。本家 Misskey の queue worker も
+// "already not following" を success 扱いにしている。
+var ErrNotFollowing = errors.New("not following")
+
+// UnfollowProcessor handles per-pair Unfollow queue jobs spawned by
+// admin/federation/remove-all-following. Misskey TS の relationship
+// queue 'unfollow' job と同じ役割。
+type UnfollowProcessor struct {
+	unfollower Unfollower
+}
+
+// NewUnfollowProcessor wires the processor with the unfollow service.
+func NewUnfollowProcessor(unfollower Unfollower) *UnfollowProcessor {
+	return &UnfollowProcessor{unfollower: unfollower}
+}
+
+// Handle implements driver.HandlerFunc.
+func (p *UnfollowProcessor) Handle(_ context.Context, t driver.Task) error {
+	payload, err := queue.DecodeUnfollowPayload(t.Payload())
+	if err != nil {
+		return fmt.Errorf("decode unfollow payload: %w: %w", err, driver.SkipRetry)
+	}
+	if payload.FollowerID == "" || payload.FolloweeID == "" {
+		return fmt.Errorf("unfollow: followerId and followeeId are required: %w", driver.SkipRetry)
+	}
+	if p.unfollower == nil {
+		return fmt.Errorf("unfollow: service not wired: %w", driver.SkipRetry)
+	}
+	if err := p.unfollower.Unfollow(payload.FollowerID, payload.FolloweeID); err != nil {
+		// 既に解消済 (row 無し) は成功扱い - 冪等吸収。
+		if isNotFollowingError(err) {
+			return nil
+		}
+		return err
+	}
+	return nil
+}
+
+// isNotFollowingError detects the "already not following" sentinel from
+// any Unfollower implementation by error string match (互換用)。実装
+// が core/following.ErrNotFollowing を返したケースをここで吸収する。
+func isNotFollowingError(err error) bool {
+	if err == nil {
+		return false
+	}
+	if errors.Is(err, ErrNotFollowing) {
+		return true
+	}
+	return err.Error() == "not following"
+}

--- a/internal/queue/processors/unfollow_test.go
+++ b/internal/queue/processors/unfollow_test.go
@@ -1,0 +1,96 @@
+package processors_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/shiroha-a/mk/internal/queue"
+	"github.com/shiroha-a/mk/internal/queue/driver"
+	"github.com/shiroha-a/mk/internal/queue/processors"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type fakeUnfollower struct {
+	calls [][2]string
+	err   error
+}
+
+func (f *fakeUnfollower) Unfollow(followerID, followeeID string) error {
+	f.calls = append(f.calls, [2]string{followerID, followeeID})
+	return f.err
+}
+
+func TestUnfollowProcessor_Success(t *testing.T) {
+	uf := &fakeUnfollower{}
+	p := processors.NewUnfollowProcessor(uf)
+	task := queue.NewUnfollowTask(queue.UnfollowPayload{
+		FollowerID: "rA", FolloweeID: "localA",
+	})
+	require.NoError(t, p.Handle(context.Background(), task))
+	require.Len(t, uf.calls, 1)
+	assert.Equal(t, [2]string{"rA", "localA"}, uf.calls[0])
+}
+
+// 既に解消済の row は ErrNotFollowing を返すが、worker は冪等吸収して
+// 成功扱いにする。
+func TestUnfollowProcessor_AlreadyNotFollowing_Success(t *testing.T) {
+	uf := &fakeUnfollower{err: processors.ErrNotFollowing}
+	p := processors.NewUnfollowProcessor(uf)
+	task := queue.NewUnfollowTask(queue.UnfollowPayload{
+		FollowerID: "rA", FolloweeID: "localA",
+	})
+	assert.NoError(t, p.Handle(context.Background(), task))
+}
+
+// upstream core/following.ErrNotFollowing のような「文字列が "not following"」
+// な error も吸収できること。
+func TestUnfollowProcessor_NotFollowingByMessage_Success(t *testing.T) {
+	uf := &fakeUnfollower{err: errors.New("not following")}
+	p := processors.NewUnfollowProcessor(uf)
+	task := queue.NewUnfollowTask(queue.UnfollowPayload{
+		FollowerID: "rA", FolloweeID: "localA",
+	})
+	assert.NoError(t, p.Handle(context.Background(), task))
+}
+
+func TestUnfollowProcessor_GenericError_Retries(t *testing.T) {
+	uf := &fakeUnfollower{err: errors.New("network down")}
+	p := processors.NewUnfollowProcessor(uf)
+	task := queue.NewUnfollowTask(queue.UnfollowPayload{
+		FollowerID: "rA", FolloweeID: "localA",
+	})
+	err := p.Handle(context.Background(), task)
+	assert.Error(t, err)
+	assert.False(t, errors.Is(err, driver.SkipRetry), "transient error は retry させる")
+}
+
+func TestUnfollowProcessor_MissingFields_SkipsRetry(t *testing.T) {
+	uf := &fakeUnfollower{}
+	p := processors.NewUnfollowProcessor(uf)
+	// FollowerID 未指定
+	task := queue.NewUnfollowTask(queue.UnfollowPayload{FolloweeID: "localA"})
+	err := p.Handle(context.Background(), task)
+	require.Error(t, err)
+	assert.True(t, errors.Is(err, driver.SkipRetry))
+	assert.Empty(t, uf.calls)
+}
+
+func TestUnfollowProcessor_NoUnfollower_SkipsRetry(t *testing.T) {
+	p := processors.NewUnfollowProcessor(nil)
+	task := queue.NewUnfollowTask(queue.UnfollowPayload{
+		FollowerID: "rA", FolloweeID: "localA",
+	})
+	err := p.Handle(context.Background(), task)
+	require.Error(t, err)
+	assert.True(t, errors.Is(err, driver.SkipRetry))
+}
+
+func TestUnfollowProcessor_BadPayload_SkipsRetry(t *testing.T) {
+	p := processors.NewUnfollowProcessor(&fakeUnfollower{})
+	task := driver.RawTask{TypeName: queue.TaskTypeUnfollow, Body: []byte("not json")}
+	err := p.Handle(context.Background(), task)
+	require.Error(t, err)
+	assert.True(t, errors.Is(err, driver.SkipRetry))
+}

--- a/internal/queue/queue.go
+++ b/internal/queue/queue.go
@@ -228,6 +228,19 @@ func (c *Client) EnqueueDeleteAccount(payload DeleteAccountPayload) error {
 	)
 }
 
+// EnqueueUnfollow schedules a single Unfollow job for the given pair.
+// admin/federation/remove-all-following が大量に enqueue する想定で、
+// per-pair retry を独立に効かせるため Unique は付けない (同じペアの
+// 重複 enqueue は worker 側で冪等吸収)。MaxRetry は federation hook の
+// AP delivery 失敗を吸収できる程度に設定。
+func (c *Client) EnqueueUnfollow(payload UnfollowPayload) error {
+	body := mustMarshal(payload)
+	return c.inner.Enqueue(context.Background(), TaskTypeUnfollow, body,
+		driver.WithQueue(QueueName),
+		driver.WithMaxRetry(3),
+	)
+}
+
 // Close releases the underlying client connection.
 func (c *Client) Close() error { return c.inner.Close() }
 

--- a/internal/queue/queue_test.go
+++ b/internal/queue/queue_test.go
@@ -744,5 +744,32 @@ func TestDecodeDeleteAccountPayload_MalformedReturnsError(t *testing.T) {
 	require.Error(t, err)
 }
 
+func TestClient_EnqueueUnfollow(t *testing.T) {
+	testutil.SkipIfNoDocker(t)
+	flushTestRedis(t)
+
+	c := queue.NewClient(newDriver())
+	defer func() { _ = c.Close() }()
+
+	require.NoError(t, c.EnqueueUnfollow(queue.UnfollowPayload{
+		FollowerID: "rA", FolloweeID: "localA",
+	}))
+}
+
+func TestNewUnfollowTask_RoundTrip(t *testing.T) {
+	payload := queue.UnfollowPayload{FollowerID: "rA", FolloweeID: "localA"}
+	task := queue.NewUnfollowTask(payload)
+	require.Equal(t, queue.TaskTypeUnfollow, task.Type())
+	got, err := queue.DecodeUnfollowPayload(task.Payload())
+	require.NoError(t, err)
+	require.Equal(t, "rA", got.FollowerID)
+	require.Equal(t, "localA", got.FolloweeID)
+}
+
+func TestDecodeUnfollowPayload_MalformedReturnsError(t *testing.T) {
+	_, err := queue.DecodeUnfollowPayload([]byte(`not-json`))
+	require.Error(t, err)
+}
+
 // ensure errors package referenced for completeness in CI builds.
 var _ = errors.New

--- a/internal/queue/tasks.go
+++ b/internal/queue/tasks.go
@@ -286,3 +286,33 @@ func DecodeDeleteAccountPayload(body []byte) (DeleteAccountPayload, error) {
 	}
 	return p, nil
 }
+
+// TaskTypeUnfollow is the task type for the per-pair Unfollow queue
+// job. Misskey TS の relationshipQueue の `unfollow` job 名と一致。
+// admin/federation/remove-all-following から大量に enqueue されるため
+// 個別 row 単位で retry 可能になる (#587)。
+const TaskTypeUnfollow = "relationship:unfollow"
+
+// UnfollowPayload identifies the (follower, followee) pair to detach.
+// 本家 TS の {from: ThinUser, to: ThinUser, silent: true} に相当。
+// silent flag は notification 抑制用だが mk-go の Unfollow は元々
+// notification を出さない実装なので payload に含めない。
+type UnfollowPayload struct {
+	FollowerID string `json:"followerId"`
+	FolloweeID string `json:"followeeId"`
+}
+
+// NewUnfollowTask serializes an UnfollowPayload into a driver.Task.
+func NewUnfollowTask(payload UnfollowPayload) driver.Task {
+	body, _ := json.Marshal(payload)
+	return driver.RawTask{TypeName: TaskTypeUnfollow, Body: body}
+}
+
+// DecodeUnfollowPayload extracts an UnfollowPayload from a task body.
+func DecodeUnfollowPayload(body []byte) (UnfollowPayload, error) {
+	var p UnfollowPayload
+	if err := json.Unmarshal(body, &p); err != nil {
+		return UnfollowPayload{}, err
+	}
+	return p, nil
+}

--- a/internal/repository/access_token.go
+++ b/internal/repository/access_token.go
@@ -10,6 +10,14 @@ type AccessTokenRepository interface {
 	FindByHash(hash string) (*model.AccessToken, error)
 	FindByID(id string) (*model.AccessToken, error)
 	ListByUserID(userID string) ([]*model.AccessToken, error)
+	// ListByUserIDPreloadApp は /i/apps 用に App を JOIN し、sort で
+	// 順序を制御して返す。sort 値 (Misskey TS 互換):
+	//   "+createdAt" → token.id DESC (新しい順)
+	//   "-createdAt" → token.id ASC  (古い順)
+	//   "+lastUsedAt" → lastUsedAt DESC
+	//   "-lastUsedAt" → lastUsedAt ASC
+	//   それ以外 ("" 含む) → token.id ASC (TS の default)
+	ListByUserIDPreloadApp(userID, sort string) ([]*model.AccessToken, error)
 	DeleteByID(id string) error
 }
 
@@ -43,6 +51,31 @@ func (r *accessTokenRepository) FindByID(id string) (*model.AccessToken, error) 
 func (r *accessTokenRepository) ListByUserID(userID string) ([]*model.AccessToken, error) {
 	var tokens []*model.AccessToken
 	if err := r.db.Where(`"userId" = ?`, userID).Order(`"id" DESC`).Find(&tokens).Error; err != nil {
+		return nil, err
+	}
+	return tokens, nil
+}
+
+// ListByUserIDPreloadApp は /i/apps 用。Preload("App") で MiAuth app メタを
+// 同時取得し、sort パラメータで本家互換の順序付けを行う。
+func (r *accessTokenRepository) ListByUserIDPreloadApp(userID, sort string) ([]*model.AccessToken, error) {
+	q := r.db.Where(`"userId" = ?`, userID).Preload("App")
+	switch sort {
+	case "+createdAt":
+		q = q.Order(`"id" DESC`)
+	case "-createdAt":
+		q = q.Order(`"id" ASC`)
+	case "+lastUsedAt":
+		q = q.Order(`"lastUsedAt" DESC`)
+	case "-lastUsedAt":
+		q = q.Order(`"lastUsedAt" ASC`)
+	default:
+		// TS の default は token.id ASC (古い順)。Misskey TS 本家:
+		// packages/backend/src/server/api/endpoints/i/apps.ts:88
+		q = q.Order(`"id" ASC`)
+	}
+	var tokens []*model.AccessToken
+	if err := q.Find(&tokens).Error; err != nil {
 		return nil, err
 	}
 	return tokens, nil

--- a/internal/repository/drive_file.go
+++ b/internal/repository/drive_file.go
@@ -36,6 +36,10 @@ type DriveFileRepository interface {
 	// DeleteByUser removes every drive_file owned by userID. Returns affected
 	// count. Used by admin/delete-all-files-of-a-user.
 	DeleteByUser(userID string) (int64, error)
+	// DeleteByHost removes every drive_file whose userHost matches the given
+	// remote instance host. Returns affected count. Used by
+	// admin/federation/delete-all-files (#587)。
+	DeleteByHost(host string) (int64, error)
 }
 
 type driveFileRepository struct {
@@ -228,5 +232,15 @@ func (r *driveFileRepository) DeleteByUser(userID string) (int64, error) {
 		return 0, nil
 	}
 	tx := r.db.Where(`"userId" = ?`, userID).Delete(&model.DriveFile{})
+	return tx.RowsAffected, tx.Error
+}
+
+func (r *driveFileRepository) DeleteByHost(host string) (int64, error) {
+	if host == "" {
+		return 0, nil
+	}
+	// userHost が remote のリモートユーザーアップロード分のみ削除。
+	// ローカル user (userHost IS NULL) は誤って巻き込まないよう明示一致のみ。
+	tx := r.db.Where(`"userHost" = ?`, host).Delete(&model.DriveFile{})
 	return tx.RowsAffected, tx.Error
 }

--- a/internal/server/router.go
+++ b/internal/server/router.go
@@ -554,6 +554,12 @@ func (s *Server) setupRoutes() {
 	// バックグラウンド処理。note / drive_file / following 関連行を掃除する。
 	deleteAccountProcessor := processors.NewDeleteAccountProcessor(noteRepo, driveFileRepo, followingRepo)
 	s.queueServer.Handle(queue.TaskTypeDeleteAccount, deleteAccountProcessor.Handle)
+
+	// Per-pair Unfollow job (#587): admin/federation/remove-all-following
+	// が enqueue するペアごとに Service.Unfollow を呼んで row 削除 + Reject
+	// 配送を行う。Misskey TS の relationshipQueue 'unfollow' job 相当。
+	unfollowProcessor := processors.NewUnfollowProcessor(followingService)
+	s.queueServer.Handle(queue.TaskTypeUnfollow, unfollowProcessor.Handle)
 	if bufMeta, err := metaRepo.Fetch(); err == nil && bufMeta.EnableReactionsBuffering {
 		go func() {
 			ticker := time.NewTicker(30 * time.Second)
@@ -1629,6 +1635,13 @@ func (s *Server) setupRoutes() {
 	}
 	adminHandler.SetInstanceMetadataFetcher(metadataFetcher)
 	adminHandler.SetSystemAccountFetcher(sysAcctSvc)
+	// admin/federation/remove-all-following が host 単位で全 follower を
+	// detach するために followingRepo + Unfollow enqueuer が必要 (#587)。
+	// 実 row 削除と Reject(Follow) 配送は worker (UnfollowProcessor) が
+	// followingService.Unfollow を呼んで行う。本家 TS の queueService.
+	// createUnfollowJob と等価。
+	adminHandler.SetFollowingRepo(followingRepo)
+	adminHandler.SetUnfollowEnqueuer(s.queueClient)
 	api.POST("/admin/accounts/create", adminHandler.AccountsCreate)
 	api.POST("/admin/show-user", adminHandler.ShowUser, middleware.RequireModerator(roleService))
 	api.POST("/admin/show-users", adminHandler.ShowUsers, middleware.RequireModerator(roleService))
@@ -1754,9 +1767,10 @@ func (s *Server) setupRoutes() {
 	api.POST("/my/apps", appHandler.MyApps, middleware.RequireAuth())
 
 	// ap/* — ActivityPub API lookup (実データ: ローカルオブジェクト解決)
+	// /api/ap/notes は upstream Misskey にも存在しない vestigial route だった
+	// ため #587 で削除済 (旧実装は常に空配列返却の stub)。
 	api.POST("/ap/get", apHandler.APIGet, middleware.RequireAdmin(roleService))
 	api.POST("/ap/show", apHandler.APIShow, middleware.RequireAuth())
-	api.POST("/ap/notes", apHandler.APNotes)
 
 	// sw/* — Service Worker push notifications (実データ)
 	swHandler := apisw.NewHandler(swSubRepo, metaRepo, idGen)

--- a/internal/testutil/mock_drive.go
+++ b/internal/testutil/mock_drive.go
@@ -373,3 +373,17 @@ func (m *MockDriveFileRepository) DeleteByUser(userID string) (int64, error) {
 	}
 	return n, nil
 }
+
+func (m *MockDriveFileRepository) DeleteByHost(host string) (int64, error) {
+	if host == "" {
+		return 0, nil
+	}
+	n := int64(0)
+	for id, f := range m.Files {
+		if f.UserHost != nil && *f.UserHost == host {
+			delete(m.Files, id)
+			n++
+		}
+	}
+	return n, nil
+}

--- a/internal/testutil/mock_repository.go
+++ b/internal/testutil/mock_repository.go
@@ -1791,10 +1791,25 @@ func (m *MockMetaRepository) EnsureInitial(id string) error {
 // MockAccessTokenRepository is a test double for repository.AccessTokenRepository.
 type MockAccessTokenRepository struct {
 	Tokens map[string]*model.AccessToken // keyed by hash
+	// Apps は ListByUserIDPreloadApp 用の App map。テスト側で SetApp 経由で
+	// 埋めると、AppID 経由で Token に Preload された状態のコピーが返る。
+	Apps map[string]*model.App
 }
 
 func NewMockAccessTokenRepository() *MockAccessTokenRepository {
-	return &MockAccessTokenRepository{Tokens: make(map[string]*model.AccessToken)}
+	return &MockAccessTokenRepository{
+		Tokens: make(map[string]*model.AccessToken),
+		Apps:   make(map[string]*model.App),
+	}
+}
+
+// SetApp wires an App into the mock so ListByUserIDPreloadApp は AppID 経由
+// で Token に App を埋めて返す。
+func (m *MockAccessTokenRepository) SetApp(app *model.App) {
+	if m.Apps == nil {
+		m.Apps = make(map[string]*model.App)
+	}
+	m.Apps[app.ID] = app
 }
 
 func (m *MockAccessTokenRepository) FindByHash(hash string) (*model.AccessToken, error) {
@@ -1822,6 +1837,56 @@ func (m *MockAccessTokenRepository) ListByUserID(userID string) ([]*model.Access
 		}
 	}
 	return out, nil
+}
+
+// ListByUserIDPreloadApp は実 repo の Preload("App") + sort 順を再現する。
+// sort 値は Misskey TS 互換 (+/-createdAt, +/-lastUsedAt, default は id ASC)。
+func (m *MockAccessTokenRepository) ListByUserIDPreloadApp(userID, sort string) ([]*model.AccessToken, error) {
+	out := make([]*model.AccessToken, 0)
+	for _, t := range m.Tokens {
+		if t.UserID != userID {
+			continue
+		}
+		// shallow copy + AppID で App を埋める。元の Token を mutate しないため。
+		c := *t
+		if c.AppID != nil {
+			if app, ok := m.Apps[*c.AppID]; ok {
+				c.App = app
+			}
+		}
+		out = append(out, &c)
+	}
+	mockSortAccessTokens(out, sort)
+	return out, nil
+}
+
+// mockSortAccessTokens は実 repo の Order を簡易 insertion sort で再現する。
+func mockSortAccessTokens(out []*model.AccessToken, sort string) {
+	less := func(i, j int) bool { return out[i].ID < out[j].ID } // default = id ASC
+	switch sort {
+	case "+createdAt":
+		less = func(i, j int) bool { return out[i].ID > out[j].ID }
+	case "+lastUsedAt":
+		less = func(i, j int) bool {
+			return mockLastUsedAtNS(out[i]) > mockLastUsedAtNS(out[j])
+		}
+	case "-lastUsedAt":
+		less = func(i, j int) bool {
+			return mockLastUsedAtNS(out[i]) < mockLastUsedAtNS(out[j])
+		}
+	}
+	for i := 1; i < len(out); i++ {
+		for j := i; j > 0 && less(j, j-1); j-- {
+			out[j], out[j-1] = out[j-1], out[j]
+		}
+	}
+}
+
+func mockLastUsedAtNS(t *model.AccessToken) int64 {
+	if t == nil || t.LastUsedAt == nil {
+		return 0
+	}
+	return t.LastUsedAt.UnixNano()
 }
 
 func (m *MockAccessTokenRepository) DeleteByID(id string) error {


### PR DESCRIPTION
## Summary

#574 / #575 / #576 / #577 / #578 で handler_stubs.go ファイル名は消滅したが、disassembly は pure file move だったため、内部が空配列 / no-op の handler が 4 件残っていた。本 PR で本実装化 + 不要 endpoint の削除を行う。

これで #573 トラッカーで残っていた **真の stub が完全消滅**。

## 主な変更点

### 1. \`/i/apps\` 本実装 ★★
旧実装は常に \`[]\` を返しており、frontend admin/settings の "Apps" 一覧が空 = bug 同等だった。Misskey TS の \`i/apps\` と同 shape (= access_token + app JOIN) を返すよう書き換え。

- \`AccessTokenRepository.ListByUserIDPreloadApp(userID, sort)\` を追加 (\`Preload("App")\` + sort 対応 \`+/-createdAt\` / \`+/-lastUsedAt\`、default は token.id ASC)
- \`model.AccessToken\` に \`App\` 関連 (foreignKey:AppID) を追加
- \`testutil.MockAccessTokenRepository\` も新メソッド対応 + \`SetApp\` helper
- 本家と同じ \`??\` チェーン: name / permission / description のフォールバック

### 2. \`/ap/notes\` 削除 ★★
#587 起票時に「ActivityPub outbox 系で本実装が必要」と書いていたが、**再調査の結果 Misskey TS には \`ap/notes\` endpoint が存在しないことを確認** (\`third_party/misskey/.../endpoints/ap/\` には \`get.ts\` / \`show.ts\` のみ)。vestigial route だったため handler / route / test 全削除。

### 3. \`/admin/federation/delete-all-files\` 本実装 ★
旧実装は no-op (将来対応)。Misskey TS と等価に DriveFile を一括削除。

- \`DriveFileRepository.DeleteByHost(host)\` を新設、\`userHost = host\` の row を全削除
- \`testutil.MockDriveFileRepository\` および既存 \`fakeDriveFileRepo\` (transfer test) も interface 満たすよう更新

### 4. \`/admin/federation/remove-all-following\` 本実装 ★ (queue 非同期)
旧実装は no-op。\`followerHost = req.Host\` の Following row を列挙し、各 (followerID, followeeID) ペアごとに **per-pair Unfollow ジョブを queue に enqueue** する。実 row 削除と Reject(Follow) 配送は worker (\`processors.UnfollowProcessor\`) が \`core/following.Service.Unfollow\` を呼んで行う。**Misskey TS の \`queueService.createUnfollowJob\` と完全に同じ非同期 queue 戦略**。

- \`queue.TaskTypeUnfollow\` + \`UnfollowPayload\` + \`NewUnfollowTask\` / \`DecodeUnfollowPayload\` を新設
- \`queue.Client.EnqueueUnfollow(payload)\` を追加 (MaxRetry=3、Unique なしで per-pair 独立 retry)
- \`processors.UnfollowProcessor\` を新設。\`ErrNotFollowing\` は冪等吸収して成功扱い、generic error は retry
- admin.Handler に \`UnfollowEnqueuer\` interface (narrow) と \`followingRepo\` を追加 + setter (\`SetFollowingRepo\` / \`SetUnfollowEnqueuer\`)
- router 配線: \`adminHandler\` に \`followingRepo\` + \`queueClient\` を渡し、\`queueServer\` に \`UnfollowProcessor\` を Handle 登録

## テスト

\`\`\`
make fmt   ✓
make lint  ✓
go test -race -count=1 -coverprofile=... ./...
  internal/api/admin:           84.0%
  internal/api/i:               91.0%
  internal/api/ap:              100.0%
  internal/repository:          90.3%
  internal/queue:               93.0% (EnqueueUnfollow 100%)
  internal/queue/processors:    91.2%
go build ./...  ✓
\`\`\`

全 package で coverage 閾値クリア。プロジェクト全体 (\`./...\`) でも全テスト緑、e2e + e2e_federation 含む。

新規テスト:
- \`TestApps_ReturnsTokensWithApp\` — owner-app + raw token 混在シナリオ、本家 \`??\` チェーン挙動
- \`TestApps_SortByCreatedAtDesc\` — sort パラメータ
- \`TestFederationDeleteAllFiles_DeletesByHost\` — host filter で対象のみ削除
- \`TestFederationRemoveAllFollowing_EnqueuesAllPairs\` — per-pair enqueue を \`stubUnfollowEnqueuer\` で検証
- \`TestFederationRemoveAllFollowing_NoOpWhenUnwired\`
- \`TestUnfollowProcessor_*\` 6 件 — success / 既解消 / generic error retry / missing fields / no service / bad payload
- \`TestClient_EnqueueUnfollow\` + \`TestNewUnfollowTask_RoundTrip\` + \`TestDecodeUnfollowPayload_MalformedReturnsError\`

## CLAUDE.md Coding Style 遵守

- 絵文字: 0 hit
- \`// TODO\` / \`// XXX\` 新規追加: 0
- 日本語内不要半角スペース新規追加: 0
- GoDoc 英語先頭: 維持

## Closes

Closes #587

🤖 Generated with [Claude Code](https://claude.com/claude-code)