### PR TITLE
Fix #598: admin/roles/users follow-up (dangling 警告 / limit clamp 強化 / コメント)

### DIFF
--- a/internal/api/admin/handler.go
+++ b/internal/api/admin/handler.go
@@ -1210,6 +1210,8 @@ func (h *Handler) RolesUsers(c echo.Context) error {
 			ids = append(ids, a.User.ID)
 		}
 	}
+	// Profile fetch 失敗は handler 全体の致命扱いではないので、空 map で
+	// fallback する (各 user は profile=nil で pack される)。ShowUsers と同方針。
 	profiles, _ := h.userRepo.FindProfilesByUserIDs(ids)
 	profileByUser := make(map[string]*model.UserProfile, len(profiles))
 	for _, p := range profiles {
@@ -1223,6 +1225,11 @@ func (h *Handler) RolesUsers(c echo.Context) error {
 	result := make([]map[string]any, 0, len(assignments))
 	for _, a := range assignments {
 		if a.User == nil {
+			// role_assignment は残っているのに user 行が消えているデータ不整合。
+			// 結果件数だけ silent に減らすと debug が困難なので警告ログを出して
+			// admin tooling 側で清掃の signal にする (#598 review item 1)。
+			slog.Warn("admin/roles/users: dangling role assignment",
+				"assignmentId", a.ID, "userId", a.UserID, "roleId", a.RoleID)
 			continue
 		}
 		createdAt := ""

--- a/internal/api/admin/handler_test.go
+++ b/internal/api/admin/handler_test.go
@@ -3,6 +3,7 @@ package admin_test
 import (
 	"encoding/json"
 	"fmt"
+	"log/slog"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -902,17 +903,55 @@ func TestRolesUsers_LimitClamping(t *testing.T) {
 		aid := fmt.Sprintf("9c2bw9q5fa%016d", i)
 		require.NoError(t, assignRepo.Create(&model.RoleAssignment{ID: aid, UserID: uid, RoleID: "r1"}))
 	}
-	// limit=2 で 2 件のみ
+	// limit=2 で 2 件のみ。Mock 経由で repo に渡された limit も検証 (#598 review item 2)。
 	rec := doPost(h.RolesUsers, `{"roleId":"r1","limit":2}`, nil)
 	var resp []map[string]any
 	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
 	assert.Len(t, resp, 2)
+	assert.Equal(t, 2, assignRepo.LastListByRoleLimit, "limit=2 がそのまま repo に伝わる")
 
-	// limit=999 → 100 にクランプ。ここでは seed 3 件なので 3 件返るだけだが、
-	// クランプ自体は handler の if limit > 100 分岐をカバーする。
+	// limit=999 → 100 にクランプ。Mock の LastListByRoleLimit を見て
+	// repo 側が 100 で受け取ったことを直接 assert (件数だけだと seed=3 で見えない)。
 	rec = doPost(h.RolesUsers, `{"roleId":"r1","limit":999}`, nil)
 	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
 	assert.Len(t, resp, 3)
+	assert.Equal(t, 100, assignRepo.LastListByRoleLimit, "limit>100 は 100 にクランプされる")
+
+	// limit=0 (未指定) → default 10
+	rec = doPost(h.RolesUsers, `{"roleId":"r1"}`, nil)
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+	assert.Equal(t, 10, assignRepo.LastListByRoleLimit, "limit 未指定は default 10")
+}
+
+// dangling assignment (a.User == nil) は結果から落とされる + 警告ログが出る。
+// ログ出力の有無は slog テスト用 handler を差し替えて捕捉する (#598 review item 1)。
+func TestRolesUsers_DanglingAssignmentSkipped(t *testing.T) {
+	h, userRepo, roleRepo, assignRepo := rolesUsersFixture(t)
+	roleRepo.Roles["r1"] = &model.Role{ID: "r1"}
+	// alive user + dangling assignment (UserID は存在しない user を指す)
+	require.NoError(t, userRepo.Create(&model.User{ID: "alive", Username: "alive"}))
+	require.NoError(t, assignRepo.Create(&model.RoleAssignment{ID: "9c2bw9q5fa0000000000000001", UserID: "alive", RoleID: "r1"}))
+	require.NoError(t, assignRepo.Create(&model.RoleAssignment{ID: "9c2bw9q5fa0000000000000002", UserID: "ghost", RoleID: "r1"}))
+
+	// Test 用に slog handler を差し替えて Warn が出るかを観測。
+	var buf strings.Builder
+	prev := slog.Default()
+	slog.SetDefault(slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelDebug})))
+	defer slog.SetDefault(prev)
+
+	rec := doPost(h.RolesUsers, `{"roleId":"r1"}`, nil)
+	assert.Equal(t, http.StatusOK, rec.Code)
+
+	var resp []map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+	require.Len(t, resp, 1, "dangling assignment は結果から除外される")
+	user, _ := resp[0]["user"].(map[string]any)
+	assert.Equal(t, "alive", user["id"])
+
+	// dangling 検知の警告ログが出ている
+	logged := buf.String()
+	assert.Contains(t, logged, "dangling role assignment")
+	assert.Contains(t, logged, "userId=ghost")
 }
 
 func TestRolesUsers_NotFound(t *testing.T) {

--- a/internal/testutil/mock_repository.go
+++ b/internal/testutil/mock_repository.go
@@ -4601,6 +4601,9 @@ type MockRoleAssignmentRepository struct {
 	// セットするので、admin/roles/users の handler テストで User を直接
 	// 参照するパスが組める。
 	UserRepo *MockUserRepository
+	// LastListByRoleLimit は最後に ListByRole に渡された limit を保持する。
+	// handler 側の limit clamping (>100 → 100) を直接 assert したいテスト用。
+	LastListByRoleLimit int
 }
 
 func NewMockRoleAssignmentRepository(roleRepo *MockRoleRepository) *MockRoleAssignmentRepository {
@@ -4642,6 +4645,7 @@ func (m *MockRoleAssignmentRepository) ListByUser(userID string) ([]*model.RoleA
 }
 
 func (m *MockRoleAssignmentRepository) ListByRole(roleID string, untilID, sinceID string, limit int) ([]*model.RoleAssignment, error) {
+	m.LastListByRoleLimit = limit
 	var result []*model.RoleAssignment
 	now := time.Now()
 	for _, a := range m.Assignments {


### PR DESCRIPTION
## Summary

#594 (PR #597) の self-review で挙げた 3 項目を一括対応。

## 主な変更点

### 1. dangling RoleAssignment 警告ログ

\`internal/api/admin/handler.go:RolesUsers\` で role_assignment 行は残っているが対応 user 行が消えているデータ不整合 (\`a.User == nil\`) を silent skip するだけだったのを、\`slog.Warn\` で警告ログを出して admin tooling 側の清掃 signal にする。

\`\`\`go
slog.Warn("admin/roles/users: dangling role assignment",
    "assignmentId", a.ID, "userId", a.UserID, "roleId", a.RoleID)
\`\`\`

### 2. Profile fetch silent swallow にコメント追加

\`profiles, _ := h.userRepo.FindProfilesByUserIDs(ids)\` の意図 (致命扱いせず空 map で fallback) を ShowUsers と同方針として明記。

### 3. limit clamping テスト強化

\`MockRoleAssignmentRepository\` に \`LastListByRoleLimit\` フィールドを追加。handler の \`if limit > 100 { limit = 100 }\` 分岐を「3 件しか seed していないので返却件数だけだと clamping を直接検証できない」状態だったのを、repo に渡された limit 値を直接 assert する形に強化:

\`\`\`go
rec = doPost(h.RolesUsers, \`{"roleId":"r1","limit":999}\`, nil)
assert.Equal(t, 100, assignRepo.LastListByRoleLimit)
\`\`\`

加えて dangling skip & 警告ログ確認の専用テスト (\`TestRolesUsers_DanglingAssignmentSkipped\`) を追加。slog handler を \`strings.Builder\` に差し替えて Warn ログ出力を assert。

## Testing

- \`make fmt && make lint\`: 緑
- \`go test -race\`:
  - \`internal/api/admin\`: 84.2% (>80% 閾値)
  - \`internal/testutil\`: ok
  - 全 \`make test\` 緑

新規テスト:
- \`TestRolesUsers_LimitClamping\`: 既存 + repo 引数レベル assert (3 ケース: 指定値 / clamp / default)
- \`TestRolesUsers_DanglingAssignmentSkipped\`: dangling 行除外 + 警告ログ検出

## Closes

Closes #598

🤖 Generated with [Claude Code](https://claude.com/claude-code)