### PR TITLE
Fix #600 (item 1, 6): broken UUID 清掃 + テストリネーム

### DIFF
--- a/internal/api/admin/accounts.go
+++ b/internal/api/admin/accounts.go
@@ -34,11 +34,11 @@ func (h *Handler) AccountsFindByEmail(c echo.Context) error {
 	}
 	profile, err := h.userRepo.FindProfileByEmail(req.Email)
 	if err != nil {
-		return c.JSON(http.StatusNotFound, apierr.Error("USER_NOT_FOUND", "User not found.", "a504947-b888-4a99-9f62-8c4a0f3a3dab"))
+		return c.JSON(http.StatusNotFound, apierr.Error("USER_NOT_FOUND", "User not found.", "cb865949-8af5-4062-a88c-ef55e8786d1d"))
 	}
 	user, err := h.userRepo.FindByID(profile.UserID)
 	if err != nil {
-		return c.JSON(http.StatusNotFound, apierr.Error("USER_NOT_FOUND", "User not found.", "a504947-b888-4a99-9f62-8c4a0f3a3dab"))
+		return c.JSON(http.StatusNotFound, apierr.Error("USER_NOT_FOUND", "User not found.", "cb865949-8af5-4062-a88c-ef55e8786d1d"))
 	}
 	// 他の admin エンドポイント (ShowUser 等) と同じ packAdminUser を通して
 	// Misskey 本家互換のレスポンス整形をする。生 model.User を返すと

--- a/internal/api/admin/handler.go
+++ b/internal/api/admin/handler.go
@@ -384,7 +384,7 @@ func (h *Handler) AccountsCreate(c echo.Context) error {
 	result, err := h.signupService.Signup(req.Username, req.Password, isInitialSetup)
 	if err != nil {
 		if err == signup.ErrUsernameAlreadyExists {
-			return c.JSON(http.StatusConflict, apierr.Error("USERNAME_ALREADY_EXISTS", "Username already exists.", "a]504947-b888-4a99-9f62-8c4a0f3a3dab"))
+			return c.JSON(http.StatusConflict, apierr.Error("USERNAME_ALREADY_EXISTS", "Username already exists.", "0a504947-b888-4a99-9f62-8c4a0f3a3dab"))
 		}
 		if err == signup.ErrInvalidUsername {
 			return c.JSON(http.StatusBadRequest, apierr.Error("INVALID_PARAM", "Invalid username.", "3d81ceae-475f-4600-b2a8-2bc116157532"))
@@ -516,7 +516,7 @@ func (h *Handler) ShowUser(c echo.Context) error {
 
 	user, err := h.userRepo.FindByID(req.UserID)
 	if err != nil {
-		return c.JSON(http.StatusNotFound, apierr.Error("NO_SUCH_USER", "No such user.", "a]504947-b888-4a99-9f62-8c4a0f3a3dab"))
+		return c.JSON(http.StatusNotFound, apierr.Error("NO_SUCH_USER", "No such user.", "2b730f78-1179-461b-88ad-d24c9af1a5ce"))
 	}
 
 	profile, _ := h.userRepo.FindProfileByUserID(user.ID)
@@ -661,7 +661,7 @@ func (h *Handler) SuspendUser(c echo.Context) error {
 	}
 
 	if _, err := h.userRepo.FindByID(req.UserID); err != nil {
-		return c.JSON(http.StatusNotFound, apierr.Error("NO_SUCH_USER", "No such user.", "a]504947-b888-4a99-9f62-8c4a0f3a3dab"))
+		return c.JSON(http.StatusNotFound, apierr.Error("NO_SUCH_USER", "No such user.", "2b730f78-1179-461b-88ad-d24c9af1a5ce"))
 	}
 
 	if err := h.userRepo.UpdateUser(req.UserID, map[string]any{"isSuspended": true}); err != nil {
@@ -680,7 +680,7 @@ func (h *Handler) UnsuspendUser(c echo.Context) error {
 	}
 
 	if _, err := h.userRepo.FindByID(req.UserID); err != nil {
-		return c.JSON(http.StatusNotFound, apierr.Error("NO_SUCH_USER", "No such user.", "a]504947-b888-4a99-9f62-8c4a0f3a3dab"))
+		return c.JSON(http.StatusNotFound, apierr.Error("NO_SUCH_USER", "No such user.", "2b730f78-1179-461b-88ad-d24c9af1a5ce"))
 	}
 
 	if err := h.userRepo.UpdateUser(req.UserID, map[string]any{"isSuspended": false}); err != nil {

--- a/internal/api/i/email_update.go
+++ b/internal/api/i/email_update.go
@@ -75,7 +75,7 @@ func (h *Handler) UpdateEmail(c echo.Context) error {
 			if m, err := h.metaRepo.Fetch(); err == nil {
 				svc := coreemail.NewService(m)
 				if verr := svc.Validate(c.Request().Context(), addr); verr != nil {
-					return c.JSON(http.StatusBadRequest, apierr.Error("UNAVAILABLE", "Email is not available.", "a]504947-b888-4a99-9f62-8c4a0f3a3dab"))
+					return c.JSON(http.StatusBadRequest, apierr.Error("UNAVAILABLE", "Email is not available.", "a2defefb-f220-8849-0af6-17f816099323"))
 				}
 			}
 		}

--- a/internal/api/signup/handler.go
+++ b/internal/api/signup/handler.go
@@ -130,7 +130,7 @@ func (h *Handler) Signup(c echo.Context) error {
 		pending, perr := h.signupService.CreatePending(req.Username, req.EmailAddress, req.Password)
 		if perr != nil {
 			if perr == coresignup.ErrUsernameAlreadyExists {
-				return c.JSON(http.StatusConflict, apierr.Error("USERNAME_ALREADY_EXISTS", "Username already exists.", "a504947-b888-4a99-9f62-8c4a0f3a3dab"))
+				return c.JSON(http.StatusConflict, apierr.Error("USERNAME_ALREADY_EXISTS", "Username already exists.", "0a504947-b888-4a99-9f62-8c4a0f3a3dab"))
 			}
 			if perr == coresignup.ErrInvalidUsername {
 				return c.JSON(http.StatusBadRequest, apierr.Error("INVALID_PARAM", "Invalid username.", "3d81ceae-475f-4600-b2a8-2bc116157532"))
@@ -161,7 +161,7 @@ func (h *Handler) Signup(c echo.Context) error {
 	result, err := h.signupService.Signup(req.Username, req.Password, false)
 	if err != nil {
 		if err == coresignup.ErrUsernameAlreadyExists {
-			return c.JSON(http.StatusConflict, apierr.Error("USERNAME_ALREADY_EXISTS", "Username already exists.", "a504947-b888-4a99-9f62-8c4a0f3a3dab"))
+			return c.JSON(http.StatusConflict, apierr.Error("USERNAME_ALREADY_EXISTS", "Username already exists.", "0a504947-b888-4a99-9f62-8c4a0f3a3dab"))
 		}
 		if err == coresignup.ErrInvalidUsername {
 			return c.JSON(http.StatusBadRequest, apierr.Error("INVALID_PARAM", "Invalid username.", "3d81ceae-475f-4600-b2a8-2bc116157532"))
@@ -197,7 +197,7 @@ func (h *Handler) SignupPending(c echo.Context) error {
 		case coresignup.ErrPendingExpired:
 			return c.JSON(http.StatusGone, apierr.Error("EXPIRED", "Pending registration has expired.", "9c2bc685-fa0a-4e6f-bf6f-5f4f8c0c3a3a"))
 		case coresignup.ErrUsernameAlreadyExists:
-			return c.JSON(http.StatusConflict, apierr.Error("USERNAME_ALREADY_EXISTS", "Username already exists.", "a504947-b888-4a99-9f62-8c4a0f3a3dab"))
+			return c.JSON(http.StatusConflict, apierr.Error("USERNAME_ALREADY_EXISTS", "Username already exists.", "0a504947-b888-4a99-9f62-8c4a0f3a3dab"))
 		default:
 			return c.JSON(http.StatusInternalServerError, apierr.Error("INTERNAL_ERROR", "Internal error.", "5d37dbcb-891e-41ca-a3d6-e690c97775ac"))
 		}

--- a/internal/core/signup/signup_service_test.go
+++ b/internal/core/signup/signup_service_test.go
@@ -281,11 +281,10 @@ func TestPromotePending_UsernameClash(t *testing.T) {
 	assert.ErrorIs(t, err, signup.ErrUsernameAlreadyExists)
 }
 
-func TestPromotePending_ExpiredViaTTLBypass(t *testing.T) {
+func TestPromotePending_Expired(t *testing.T) {
 	// PendingSignupTTL = 24h と十分長く、ParseTime も成功するため通常 path で
-	// expired を再現するのは難しい。idGen が ParseTime に失敗する ID を強制
-	// 注入してフォールスルーする経路を踏ませる代わりに、Create 後に row.ID を
-	// 24h+ 前の ULID に書き換える。
+	// expired を再現するのは難しい。Create 後に row.ID を 24h+ 前の ULID に
+	// 書き換えて expired path を踏ませる。
 	svc, _, _ := newTestService(t)
 	pendingRepo := testutil.NewMockUserPendingRepository()
 	svc.SetUserPendingRepo(pendingRepo)


### PR DESCRIPTION
## Summary

#600 follow-up tracker から軽い 2 項目をまとめて対応。migration 不要、cleanup-only。

## 主な変更点

### (1) broken UUID 清掃

\`a]504947-...\` (角括弧入りタイポ) と \`a504947-...\` (先頭 0 欠落) が混在し、異なる error code が同一の broken UUID を共有していた。frontend ローカライズ key として一意性が必要なので各 error code に固有の正しい UUID を割り当て:

| Error code | Old (broken) | New | Source |
|---|---|---|---|
| USERNAME_ALREADY_EXISTS | \`a504947-...\` / \`a]504947-...\` | \`0a504947-b888-4a99-9f62-8c4a0f3a3dab\` | typo 修正 (先頭 0 補完) |
| UNAVAILABLE (i/email_update) | \`a]504947-...\` | \`a2defefb-f220-8849-0af6-17f816099323\` | Misskey TS canonical |
| NO_SUCH_USER (admin) | \`a]504947-...\` | \`2b730f78-1179-461b-88ad-d24c9af1a5ce\` | Misskey TS canonical |
| USER_NOT_FOUND (admin/accounts find-by-email) | \`a504947-...\` | \`cb865949-8af5-4062-a88c-ef55e8786d1d\` | Misskey TS canonical |

修正対象: \`api/signup/handler.go\` x3、\`api/admin/handler.go\` x4、\`api/admin/accounts.go\` x2、\`api/i/email_update.go\` x1。

### (6) テスト命名修正

\`TestPromotePending_ExpiredViaTTLBypass\` → \`TestPromotePending_Expired\`。"Bypass" だと TTL を回避するテストに読めて誤解を招くため。

## Testing

- \`make fmt && make lint\`: 緑
- \`make test\`: 全 package 緑 (broken UUID に直接依存するテストは存在しなかったので regression なし)

## Refs

Refs #600 — items 1 & 6。残り (2/3/4/5) は別 PR に分割予定 (rate-limit / invitation 関連付け / partial failure transaction / メールテンプレート)。

🤖 Generated with [Claude Code](https://claude.com/claude-code)