### PR TITLE
Fix #600 (item 5): invitation code を pending row と関連付ける

### DIFF
--- a/internal/api/signup/handler.go
+++ b/internal/api/signup/handler.go
@@ -127,7 +127,13 @@ func (h *Handler) Signup(c echo.Context) error {
 		if verr := validateEmailWithMeta(c.Request().Context(), meta, req.EmailAddress); verr != nil {
 			return c.JSON(http.StatusBadRequest, apierr.Error("UNAVAILABLE", "Email is not available.", "a25440a9-451e-41de-b291-00a8f29fbca6"))
 		}
-		pending, perr := h.signupService.CreatePending(req.Username, req.EmailAddress, req.Password)
+		// 招待制併用時は ticket.ID を pending row に保存しておき、
+		// PromotePending 完了時に MarkUsed で消費する (#600 item 5)。
+		var ticketID *string
+		if ticket != nil {
+			ticketID = &ticket.ID
+		}
+		pending, perr := h.signupService.CreatePending(req.Username, req.EmailAddress, req.Password, ticketID)
 		if perr != nil {
 			if perr == coresignup.ErrUsernameAlreadyExists {
 				return c.JSON(http.StatusConflict, apierr.Error("USERNAME_ALREADY_EXISTS", "Username already exists.", "0a504947-b888-4a99-9f62-8c4a0f3a3dab"))
@@ -140,11 +146,6 @@ func (h *Handler) Signup(c echo.Context) error {
 			}
 			return c.JSON(http.StatusInternalServerError, apierr.Error("INTERNAL_ERROR", "Internal error.", "5d37dbcb-891e-41ca-a3d6-e690c97775ac"))
 		}
-		// invitation code は本登録 (signup-pending) 完了時に消費したいが、
-		// pending row との結びつけ schema が無い。ここで消費せず後続 PromotePending
-		// では code を再投入させずに再発行は許さないだけに留める (既存挙動と同じ
-		// best-effort)。
-		_ = ticket
 		if h.emailSender != nil {
 			siteName := "Misskey"
 			if meta.Name != nil && *meta.Name != "" {
@@ -201,6 +202,11 @@ func (h *Handler) SignupPending(c echo.Context) error {
 		default:
 			return c.JSON(http.StatusInternalServerError, apierr.Error("INTERNAL_ERROR", "Internal error.", "5d37dbcb-891e-41ca-a3d6-e690c97775ac"))
 		}
+	}
+	// 招待コード消費 (招待制 + email 確認制併用時)。Signup 直接 path
+	// と同様 best-effort で MarkUsed する (#600 item 5)。
+	if result.InvitationTicketID != nil && h.ticketStore != nil {
+		_ = h.ticketStore.MarkUsed(*result.InvitationTicketID, result.User.ID)
 	}
 	return c.JSON(http.StatusOK, map[string]any{
 		"id": result.User.ID,

--- a/internal/api/signup/handler_test.go
+++ b/internal/api/signup/handler_test.go
@@ -230,7 +230,7 @@ func TestSignupPending_Success(t *testing.T) {
 	svc.SetUserPendingRepo(pendingRepo)
 	h := apisignup.NewHandler(svc, metaRepo, idGen)
 
-	row, err := svc.CreatePending("bob", "bob@example.com", "secret")
+	row, err := svc.CreatePending("bob", "bob@example.com", "secret", nil)
 	require.NoError(t, err)
 
 	rec := doPost(h.SignupPending, `{"code":"`+row.Code+`"}`)
@@ -467,7 +467,7 @@ func TestSignupPending_Expired(t *testing.T) {
 	svc.SetUserPendingRepo(pendingRepo)
 	h := apisignup.NewHandler(svc, metaRepo, idGen)
 
-	row, err := svc.CreatePending("expu", "exp@example.com", "pw")
+	row, err := svc.CreatePending("expu", "exp@example.com", "pw", nil)
 	require.NoError(t, err)
 	// 25h 前の ULID に書き換えて expired path を踏ませる
 	old := idGen.Generate(time.Now().Add(-25 * time.Hour))
@@ -490,7 +490,7 @@ func TestSignupPending_UsernameClash(t *testing.T) {
 	svc.SetUserPendingRepo(pendingRepo)
 	h := apisignup.NewHandler(svc, metaRepo, idGen)
 
-	row, err := svc.CreatePending("clash2", "c2@example.com", "pw")
+	row, err := svc.CreatePending("clash2", "c2@example.com", "pw", nil)
 	require.NoError(t, err)
 	require.NoError(t, userRepo.Create(&model.User{ID: "u_c2", Username: "Clash2", UsernameLower: "clash2"}))
 
@@ -521,4 +521,45 @@ func TestSetTestMode(t *testing.T) {
 	h.SetTestMode(true)
 	rec := doPost(h.Signup, `{"username":"alice","password":"pass1234"}`)
 	assert.Equal(t, http.StatusOK, rec.Code)
+}
+
+// 招待制 + email 確認制の併用: signup で ticket.ID が pending row に保存され、
+// SignupPending 経由で本登録時に MarkUsed が呼ばれて消費されることを検証
+// (#600 item 5)。
+func TestSignupPending_MarksInvitationTicketUsed(t *testing.T) {
+	userRepo := testutil.NewMockUserRepository()
+	metaRepo := testutil.NewMockMetaRepository()
+	// 招待制 + email 確認制を同時に有効化
+	metaRepo.Meta = &model.Meta{ID: "x", EmailRequiredForSignup: true, DisableRegistration: true}
+	pendingRepo := testutil.NewMockUserPendingRepository()
+	idGen, _ := id.NewGenerator("aidx")
+	svc := coresignup.NewService(userRepo, metaRepo, idGen)
+	svc.SetUserPendingRepo(pendingRepo)
+	h := apisignup.NewHandler(svc, metaRepo, idGen)
+
+	tickets := newMockTicketStore()
+	tickets.tickets["INV1"] = &model.RegistrationTicket{ID: "ticket_inv1"}
+	h.SetTicketStore(tickets)
+
+	// signup → email 確認待ちに pending 作成
+	rec := doPost(h.Signup, `{"username":"invu","password":"pw","emailAddress":"inv@example.com","invitationCode":"INV1"}`)
+	require.Equal(t, http.StatusNoContent, rec.Code)
+	require.Len(t, pendingRepo.Rows, 1)
+	// pending row に ticket.ID が保存されている
+	var stored *model.UserPending
+	for _, p := range pendingRepo.Rows {
+		stored = p
+	}
+	require.NotNil(t, stored.InvitationTicketID)
+	assert.Equal(t, "ticket_inv1", *stored.InvitationTicketID)
+
+	// signup-pending → user 確定 + ticket 消費
+	rec = doPost(h.SignupPending, `{"code":"`+stored.Code+`"}`)
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	resp := parseResp(t, rec)
+	userID, _ := resp["id"].(string)
+	require.NotEmpty(t, userID)
+	// MarkUsed が呼ばれて ticket.ID → user.ID が記録される
+	assert.Equal(t, userID, tickets.markUsed["ticket_inv1"])
 }

--- a/internal/core/signup/signup_service.go
+++ b/internal/core/signup/signup_service.go
@@ -81,6 +81,10 @@ func (s *Service) SetWebhookHook(h WebhookHook) {
 type SignupResult struct {
 	User  *model.User
 	Token string
+	// InvitationTicketID は PromotePending 経路で pending row から復元した
+	// 招待コード ticket ID。handler はこれを受けて TicketStore.MarkUsed を
+	// 呼び消費を確定させる。通常 Signup や非招待 PromotePending では nil。
+	InvitationTicketID *string
 }
 
 // Signup creates a new local user with the given username and password.
@@ -188,7 +192,11 @@ func generatePendingCode() string {
 // CreatePending stores a pending signup row and returns it. Username重複と
 // 予約名チェックは通常 Signup と揃え、password は bcrypt で hash 済を保管
 // (PromotePending 時に再 hash しない)。emailRequiredForSignup=true 用。
-func (s *Service) CreatePending(username, email, password string) (*model.UserPending, error) {
+//
+// invitationTicketID が non-nil なら pending row に保存し、PromotePending
+// 成功時に SignupResult.InvitationTicketID 経由で handler に伝える
+// (招待制 + email 確認制併用時の MarkUsed 用)。
+func (s *Service) CreatePending(username, email, password string, invitationTicketID *string) (*model.UserPending, error) {
 	username = strings.TrimSpace(username)
 	if username == "" || len(username) > 128 {
 		return nil, ErrInvalidUsername
@@ -207,11 +215,12 @@ func (s *Service) CreatePending(username, email, password string) (*model.UserPe
 	hash, _ := bcrypt.GenerateFromPassword([]byte(password), bcrypt.DefaultCost)
 	now := time.Now()
 	row := &model.UserPending{
-		ID:       s.idGen.Generate(now),
-		Code:     generatePendingCode(),
-		Username: username,
-		Email:    email,
-		Password: string(hash),
+		ID:                 s.idGen.Generate(now),
+		Code:               generatePendingCode(),
+		Username:           username,
+		Email:              email,
+		Password:           string(hash),
+		InvitationTicketID: invitationTicketID,
 	}
 	if err := s.pendingRepo.Create(row); err != nil {
 		return nil, err
@@ -291,7 +300,11 @@ func (s *Service) PromotePending(code string) (*SignupResult, error) {
 	if s.webhookHook != nil {
 		s.webhookHook.OnUserCreated(user)
 	}
-	return &SignupResult{User: user, Token: token}, nil
+	return &SignupResult{
+		User:               user,
+		Token:              token,
+		InvitationTicketID: pending.InvitationTicketID,
+	}, nil
 }
 
 // isReservedUsername reports whether lower (already lowercased) matches any

--- a/internal/core/signup/signup_service_test.go
+++ b/internal/core/signup/signup_service_test.go
@@ -193,7 +193,7 @@ func TestCreatePending_Success(t *testing.T) {
 	pendingRepo := testutil.NewMockUserPendingRepository()
 	svc.SetUserPendingRepo(pendingRepo)
 
-	row, err := svc.CreatePending("alice", "alice@example.com", "secret123")
+	row, err := svc.CreatePending("alice", "alice@example.com", "secret123", nil)
 	require.NoError(t, err)
 	assert.Equal(t, "alice", row.Username)
 	assert.Equal(t, "alice@example.com", row.Email)
@@ -209,7 +209,7 @@ func TestCreatePending_DuplicateUsername(t *testing.T) {
 	svc.SetUserPendingRepo(pendingRepo)
 	require.NoError(t, userRepo.Create(&model.User{ID: "u1", Username: "alice", UsernameLower: "alice"}))
 
-	_, err := svc.CreatePending("Alice", "a@example.com", "pw")
+	_, err := svc.CreatePending("Alice", "a@example.com", "pw", nil)
 	assert.ErrorIs(t, err, signup.ErrUsernameAlreadyExists)
 }
 
@@ -219,7 +219,7 @@ func TestCreatePending_ReservedUsername(t *testing.T) {
 	pendingRepo := testutil.NewMockUserPendingRepository()
 	svc.SetUserPendingRepo(pendingRepo)
 
-	_, err := svc.CreatePending("admin", "a@example.com", "pw")
+	_, err := svc.CreatePending("admin", "a@example.com", "pw", nil)
 	assert.ErrorIs(t, err, signup.ErrUsernameReserved)
 }
 
@@ -228,7 +228,7 @@ func TestCreatePending_InvalidUsername(t *testing.T) {
 	pendingRepo := testutil.NewMockUserPendingRepository()
 	svc.SetUserPendingRepo(pendingRepo)
 
-	_, err := svc.CreatePending("", "a@example.com", "pw")
+	_, err := svc.CreatePending("", "a@example.com", "pw", nil)
 	assert.ErrorIs(t, err, signup.ErrInvalidUsername)
 }
 
@@ -237,7 +237,7 @@ func TestPromotePending_Success(t *testing.T) {
 	pendingRepo := testutil.NewMockUserPendingRepository()
 	svc.SetUserPendingRepo(pendingRepo)
 
-	row, err := svc.CreatePending("bob", "bob@example.com", "pw123")
+	row, err := svc.CreatePending("bob", "bob@example.com", "pw123", nil)
 	require.NoError(t, err)
 
 	result, err := svc.PromotePending(row.Code)
@@ -271,7 +271,7 @@ func TestPromotePending_UsernameClash(t *testing.T) {
 	pendingRepo := testutil.NewMockUserPendingRepository()
 	svc.SetUserPendingRepo(pendingRepo)
 
-	row, err := svc.CreatePending("clash", "c@example.com", "pw")
+	row, err := svc.CreatePending("clash", "c@example.com", "pw", nil)
 	require.NoError(t, err)
 
 	// pending 確定前に同名 user が登録されたケースを再現
@@ -289,7 +289,7 @@ func TestPromotePending_Expired(t *testing.T) {
 	pendingRepo := testutil.NewMockUserPendingRepository()
 	svc.SetUserPendingRepo(pendingRepo)
 
-	row, err := svc.CreatePending("expuser", "exp@example.com", "pw")
+	row, err := svc.CreatePending("expuser", "exp@example.com", "pw", nil)
 	require.NoError(t, err)
 
 	// ULID を 25h 前の時刻で再生成 (idGen は newTestService で aidx 固定)。
@@ -310,7 +310,7 @@ func TestPromotePending_WithKeypair(t *testing.T) {
 	keypairRepo := testutil.NewMockUserKeypairRepository()
 	svc.SetKeypairRepo(keypairRepo)
 
-	row, err := svc.CreatePending("kpuser", "kp@example.com", "pw")
+	row, err := svc.CreatePending("kpuser", "kp@example.com", "pw", nil)
 	require.NoError(t, err)
 
 	result, err := svc.PromotePending(row.Code)
@@ -326,7 +326,7 @@ func TestPromotePending_WebhookHookFires(t *testing.T) {
 	hook := &recordingHook{}
 	svc.SetWebhookHook(hook)
 
-	row, err := svc.CreatePending("hookuser", "hook@example.com", "pw")
+	row, err := svc.CreatePending("hookuser", "hook@example.com", "pw", nil)
 	require.NoError(t, err)
 
 	_, err = svc.PromotePending(row.Code)
@@ -338,3 +338,45 @@ func TestPromotePending_WebhookHookFires(t *testing.T) {
 type recordingHook struct{ calls int }
 
 func (r *recordingHook) OnUserCreated(_ *model.User) { r.calls++ }
+
+// invitationTicketID を渡すと pending row に保存され、PromotePending
+// 完了時に SignupResult.InvitationTicketID として伝搬される (#600 item 5)。
+func TestCreatePending_StoresInvitationTicketID(t *testing.T) {
+	svc, _, _ := newTestService(t)
+	pendingRepo := testutil.NewMockUserPendingRepository()
+	svc.SetUserPendingRepo(pendingRepo)
+
+	tid := "ticket_abc"
+	row, err := svc.CreatePending("inv", "inv@example.com", "pw", &tid)
+	require.NoError(t, err)
+	require.NotNil(t, row.InvitationTicketID)
+	assert.Equal(t, "ticket_abc", *row.InvitationTicketID)
+}
+
+func TestPromotePending_PropagatesInvitationTicketID(t *testing.T) {
+	svc, _, _ := newTestService(t)
+	pendingRepo := testutil.NewMockUserPendingRepository()
+	svc.SetUserPendingRepo(pendingRepo)
+
+	tid := "ticket_xyz"
+	row, err := svc.CreatePending("invuser", "invu@example.com", "pw", &tid)
+	require.NoError(t, err)
+
+	result, err := svc.PromotePending(row.Code)
+	require.NoError(t, err)
+	require.NotNil(t, result.InvitationTicketID)
+	assert.Equal(t, "ticket_xyz", *result.InvitationTicketID)
+}
+
+func TestPromotePending_NoTicketIDReturnsNil(t *testing.T) {
+	svc, _, _ := newTestService(t)
+	pendingRepo := testutil.NewMockUserPendingRepository()
+	svc.SetUserPendingRepo(pendingRepo)
+
+	row, err := svc.CreatePending("noinv", "noinv@example.com", "pw", nil)
+	require.NoError(t, err)
+
+	result, err := svc.PromotePending(row.Code)
+	require.NoError(t, err)
+	assert.Nil(t, result.InvitationTicketID, "non-invitation pending では nil で伝搬する")
+}

--- a/internal/model/chat.go
+++ b/internal/model/chat.go
@@ -84,6 +84,10 @@ type UserPending struct {
 	Username string `gorm:"column:username;type:varchar(128);not null" json:"username"`
 	Email    string `gorm:"column:email;type:varchar(128);not null" json:"email"`
 	Password string `gorm:"column:password;type:varchar(128);not null" json:"-"`
+	// InvitationTicketID は招待制 + email 確認制の併用時に消費した
+	// registration_ticket の ID。PromotePending 完了時に MarkUsed する。
+	// 通常 (招待制無効) signup では nil。
+	InvitationTicketID *string `gorm:"column:invitationTicketId;type:varchar(32)" json:"invitationTicketId,omitempty"`
 }
 
 func (UserPending) TableName() string { return "user_pending" }

--- a/migration/000042_user_pending_invitation_ticket.down.sql
+++ b/migration/000042_user_pending_invitation_ticket.down.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "user_pending" DROP COLUMN IF EXISTS "invitationTicketId";

--- a/migration/000042_user_pending_invitation_ticket.up.sql
+++ b/migration/000042_user_pending_invitation_ticket.up.sql
@@ -1,0 +1,4 @@
+-- user_pending: 招待制 + email 確認制の併用運用で「1 招待で複数 pending を
+-- 作って全部 promote すると複数アカウント作れる」 gap を塞ぐため、pending
+-- 行に invitation_ticket_id を持たせて PromotePending 時に MarkUsed する。
+ALTER TABLE "user_pending" ADD COLUMN IF NOT EXISTS "invitationTicketId" varchar(32);


### PR DESCRIPTION
## Summary

招待制 (\`DisableRegistration\`) + email 確認制 (\`EmailRequiredForSignup\`) を同時運用すると、PR #599 の email 確認フロー実装時点では pending row と ticket の結びつけ schema が無かったため、**1 招待で複数 pending を作成 → 全 promote すると複数アカウント作れる** gap が残っていた (#600 item 5)。

本 PR で pending row に \`invitationTicketId\` を持たせて \`PromotePending\` 完了時に \`MarkUsed\` で消費する。

## 主な変更点

### Migration

\`migration/000042_user_pending_invitation_ticket.{up,down}.sql\`:

\`\`\`sql
ALTER TABLE "user_pending" ADD COLUMN IF NOT EXISTS "invitationTicketId" varchar(32);
\`\`\`

### Model

\`internal/model/chat.go\`:

\`\`\`go
type UserPending struct {
    // ...
    InvitationTicketID *string \`gorm:"column:invitationTicketId;type:varchar(32)"\`
}
\`\`\`

### Service

- \`Service.CreatePending(username, email, password, invitationTicketID *string)\` にパラメータ追加。non-nil のとき pending row に保存する。
- \`SignupResult.InvitationTicketID *string\` を追加。\`PromotePending\` が pending row から復元して handler に伝える。

### Handler

- \`Signup\` (email-required path): 招待 ticket が validate 済なら \`&ticket.ID\` を \`CreatePending\` に渡す。
- \`SignupPending\`: 戻りの \`result.InvitationTicketID\` が non-nil なら \`ticketStore.MarkUsed\` を呼ぶ (best-effort、Signup 直接 path と同じ扱い)。

## Testing

- \`make fmt && make lint\`: 緑
- \`go test -race\`:
  - core/signup: 93.2%
  - api/signup: 92.1%
  - 全 \`make test\` 緑

新規テスト:
- service: \`CreatePending\` で ticket ID 保存 / \`PromotePending\` で propagate / nil 伝搬 (3 件)
- handler: 招待制 + email 確認制併用の e2e — signup → pending row の \`InvitationTicketID\` 検証 → signup-pending → \`tickets.markUsed\` の確認 (1 件)

## 後方互換

- 既存の \`CreatePending\` 呼び出し (テスト 9 箇所 + handler 1 箇所) は \`nil\` 付きに更新済。production の通常 Signup 直接 path と非招待 PromotePending では \`InvitationTicketID = nil\` で伝搬し、既存挙動は維持される。

## Refs

Refs #600 — item 5。残り (3: rate-limit, 2: partial failure transaction, 4: メールテンプレート) は別 PR に分割。

🤖 Generated with [Claude Code](https://claude.com/claude-code)