### PR TITLE
Fix #600 (item 3): signup / signin / reset-password に rate-limit を適用

### DIFF
--- a/internal/server/middleware/ratelimit_defs.go
+++ b/internal/server/middleware/ratelimit_defs.go
@@ -100,6 +100,24 @@ var DefaultEndpointLimits = map[string]*EndpointLimit{
 
 	// ── Password Reset ─────────────────────────────────
 	"request-reset-password": {Duration: time.Hour, Max: 3},
+	// reset-password 自体 (トークン消費) は brute-force 対策で 1h あたり 30。
+	// 確認 link を踏んだ正当ユーザーが何度か失敗してもブロックされない程度。
+	"reset-password": {Duration: time.Hour, Max: 30},
+
+	// ── Auth (signup / signin) ─────────────────────────
+	// signup spam (大量 user_pending row 作成 + 確認メール乱発) 対策。
+	// 1h あたり 5 で十分。実運用では captcha / invitation 制が併用される
+	// 想定だが、それらが無効でも spam を抑える last-line guard。
+	"signup": {Duration: time.Hour, Max: 5},
+	// signup-pending (確認 code 入力) は brute-force 対策で 1h あたり 30
+	// (1 確認 code 試行を 30 回まで許容、TTL 内で総当たりされても 16 byte
+	// hex の探索空間 (2^128) には到底届かない)。
+	"signup-pending": {Duration: time.Hour, Max: 30},
+	// signin / signin-flow は credential brute force 対策。1h 60 回。
+	// 正当な打ち間違い (typo, password manager 不発等) をブロックしない
+	// 最低限のしきい値。
+	"signin":      {Duration: time.Hour, Max: 60},
+	"signin-flow": {Duration: time.Hour, Max: 60},
 
 	// ── Admin ──────────────────────────────────────────
 	"admin/system-webhook/test": {Duration: 15 * time.Minute, Max: 60},

--- a/internal/server/middleware/ratelimit_test.go
+++ b/internal/server/middleware/ratelimit_test.go
@@ -373,6 +373,13 @@ func TestDefaultEndpointLimits_KnownEndpoints(t *testing.T) {
 		{"drive/files/create", 120},
 		{"channels/create", 10},
 		{"ap/show", 30},
+		// Auth / password reset (#600 item 3): signup spam / brute-force 対策。
+		{"signup", 5},
+		{"signup-pending", 30},
+		{"signin", 60},
+		{"signin-flow", 60},
+		{"request-reset-password", 3},
+		{"reset-password", 30},
 	}
 	for _, tc := range cases {
 		t.Run(tc.endpoint, func(t *testing.T) {


### PR DESCRIPTION
## Summary

#600 item 3 で挙げた spam / brute-force 攻撃ベクター対策。既存の Redis sliding-window rate-limit middleware (\`DefaultEndpointLimits\`) に auth 系 5 + reset-password の合計 6 endpoint を追加。

実装は既存 middleware の定義 map に entry を足すだけで完結 — router の配線変更や新規 middleware 追加は不要。

## 主な変更点

\`internal/server/middleware/ratelimit_defs.go\` に以下を追加:

| Endpoint | Window | Max | 主目的 |
|---|---|---|---|
| \`signup\` | 1h | **5** | pending row spam + 確認メール乱発防止 (#599 で実装した email 確認制での spam 抑止) |
| \`signup-pending\` | 1h | 30 | 確認 code brute-force 防止 (16 byte hex 探索空間 2^128 で 30 回試行は無意味) |
| \`signin\` | 1h | 60 | credential brute-force 防止 (typo 許容) |
| \`signin-flow\` | 1h | 60 | 同上 |
| \`reset-password\` | 1h | 30 | reset token 消費 brute-force 防止 |

\`request-reset-password\` (要求側) は既に 1h/3 で規制済。本 PR は **token 消費 endpoint** 側を補強する。

## Testing

- \`make fmt && make lint\`: 緑
- \`make test\`: 全 package 緑
- \`internal/server/middleware\` 既存テスト (\`TestDefaultEndpointLimits_KnownEndpoints\`) に新 6 endpoint 検証ケースを追加

## 後方互換

- 既存挙動は変わらず、新規 endpoint で 1h あたりの上限を超えると 429 Too Many Requests + Retry-After header
- IP ベース fallback は \`s.config.EnableIPRateLimit\` が必要 (未認証ユーザーは設定 ON のときだけ規制)
- \`s.config.DisableEndpointRateLimits=true\` で全エンドポイント解除可能 (既存 escape hatch)

## 範囲外 (本 PR では対応しない)

- **issue body の 2 番目チェックボックス「meta 設定で閾値を調整可能に」**:
  - 現状 hard-coded で issue の主目的「spam 防止」は達成
  - Misskey TS にも meta-tunable な per-endpoint rate-limit override は存在しない
  - admin 利便性の別 scope なので別 issue で扱う
- per-user-role \`rateLimitFactor\` (既に \`DefaultPolicies\` で定義済だが middleware で参照されていない) — \`ratelimit_defs.go\` 冒頭の TODO を参照、本 PR scope 外

## Refs

Refs #600 — item 3。残り (2: partial failure transaction, 4: メールテンプレート) は別 PR。

🤖 Generated with [Claude Code](https://claude.com/claude-code)