### PR TITLE
docs: Misskey TS 2026.3.2 → 2026.5.0 backend diff サマリー追加

### DIFF
--- a/docs/2026-5-0-diff.md
+++ b/docs/2026-5-0-diff.md
@@ -1,0 +1,258 @@
+# Misskey 2026.3.2 → 2026.5.0 backend diff
+
+mk-go (本リポジトリ) は upstream Misskey TS の `2026.3.2` ベースで動いている。`2026.5.0` までに upstream backend (`packages/backend/`) で行われた変更を、**mk-go への移植観点**で分類したサマリー。
+
+- 集計範囲: `misskey-dev/misskey` の `2026.3.2..2026.5.0` (2026.4.0 は中間リリースで CHANGELOG は 2026.5.0 セクションに統合されている)
+- 67 commits、backend 関連 146 files 変更
+- 取得方法: `gh api -H "Accept: application/vnd.github.diff" repos/misskey-dev/misskey/compare/2026.3.2...2026.5.0`
+
+## 移植優先度: 高 (動作 / 連合互換性に影響)
+
+mk-go ユーザーが踏みうる bug、または ActivityPub 連合の互換性に直接関わる変更。**個別 issue を立てて対応すべき**。
+
+### ActivityPub: `activity.actor` を string / 埋め込み object 双方で受ける
+
+- 該当: `core/activitypub/ApInboxService.ts`、`queue/processors/InboxProcessorService.ts`
+- 変更内容: `activity.actor` (これまで string 前提だった比較) を `getApId(activity.actor)` に置換。`add` / `delete` / `remove` / `undo` / `update` ハンドラ + InboxProcessor の HTTP-Signature actor 一致チェック / LD-Signature 一致チェック / エラーログすべて。
+- なぜ必要: 一部 fediverse 実装は `actor` を埋め込み object (`{ id: "https://..." , type: "Person", ... }`) で送ってくる。string 比較は ID 抽出されず常に invalid 判定になり活動が落ちる。
+- 関連 PR: misskey-dev/misskey#17340 (actor 比較)、#17294 (削除アクティビティで存在しない Actor を新規作成して削除する挙動の修正)
+- mk-go 該当箇所: `internal/activitypub/inbox.go` 周辺で actor 比較しているところを総点検
+
+### ActivityPub: `alsoKnownAs` を array / string 双方で受ける
+
+- 該当: `core/activitypub/models/ApPersonService.ts`
+- 変更: `alsoKnownAs: person.alsoKnownAs` → `alsoKnownAs: toArray(person.alsoKnownAs)` (create / update 両経路)
+- なぜ必要: 仕様上は array だが、一部実装が単一 string で送ってくる。array 前提のコードで type error
+- 関連 PR: #17275
+- mk-go 該当箇所: `internal/activitypub/resolver.go` で `alsoKnownAs` を読んでいる箇所 (#357 以降の resolver/move 系)
+
+### ActivityPub: 存在しない Actor の Delete を ignore する
+
+- 該当: `queue/processors/InboxProcessorService.ts`
+- 変更: 受信 activity が `Delete` で object が Actor 系の場合、まず DB に user が存在するかチェックし、無ければ早期 return (新規作成して削除する旧挙動の修正)
+- なぜ必要: Misskey 側で知らないリモート user の Delete 受信時、わざわざ user を新規作成して削除する旧コードが無駄
+- 関連 PR: #17294
+- mk-go 該当箇所: `internal/queue/processors/inbox.go` の Delete ハンドラ
+
+### ActivityPub: リレー経由 Announce の正しい処理
+
+- 該当: `core/activitypub/ApInboxService.ts` (`announceNote`)、`core/RelayService.ts` (`isRelayActor` 新設)
+- 変更: actor がリレーかチェックし、リレー由来の Announce では「リノートを作成せず元 note を直接 publish する」分岐を追加
+- なぜ必要: 旧コードはリレー経由の note も Announce → 自分の Renote として可視化されてしまう
+- 関連 PR: #17308
+- mk-go 該当箇所: `internal/activitypub/inbox.go` の Announce 処理 + relay 判定 helper の追加
+
+### ActivityPub: ブロック中インスタンスの inbox job で蓄積を止める
+
+- 該当: `queue/processors/InboxProcessorService.ts`
+- 変更: identifiable error `09d79f9e-64f1-4316-9cfa-e75c4d091574` (Instance is blocked) を retry 不可で打ち切る switch 分岐に追加
+- なぜ必要: ブロック解除/再ブロック中に job が無限再試行で積み上がる
+- 関連 PR: #17336
+- mk-go 該当箇所: `internal/queue/processors/inbox.go` のエラー分岐 (mk-go では blocked instance チェックの場所が異なる可能性あり、振る舞い等価かを確認)
+
+### ActivityPub: role-based validation error の retry 防止
+
+- 該当: `queue/processors/InboxProcessorService.ts`
+- 変更: identifiable error `9f466dab-c856-48cd-9e65-ff90ff750580` (mention 上限超過) も unrecoverable 扱い
+- なぜ必要: role policy 違反は retry してもどうせ失敗するので queue を圧迫しない
+- 関連 PR: #17167
+- mk-go 該当箇所: 同上
+
+### Role: getAdministratorIds の重複排除
+
+- 該当: `core/RoleService.ts`
+- 変更: 1 user に複数 admin role が付与されている場合に user.id が重複する問題を `Set` 経由 + sort で解消
+- なぜ必要: admin 通知 / メンションで同じ user に複数回送られる
+- 関連 PR: #17334
+- mk-go 該当箇所: `internal/core/role/role_service.go` で admin 一覧を返すメソッド (現状未実装かも → 該当 issue 確認)
+
+### ID 生成: ULID Crockford Base32 のパース修正
+
+- 該当: `misc/id/ulid.ts`
+- 変更: `parseBigInt32` (汎用 base32) を ULID 仕様の Crockford 字順に従う `parseBigIntCrockford` に置換
+- なぜ必要: `MK_ID=ulid` 設定で動かすと ID 後半 16 文字のパースが間違って ULID 由来 timestamp 抽出 / ID 比較が壊れる
+- 関連 PR: #17310
+- mk-go 該当箇所: `internal/misc/id/` 配下に Crockford ULID 実装があるか確認 (mk-go は `aidx` デフォルトだが ulid モードもサポートしている場合は要修正)
+
+### Note 通知: 公開範囲 (visibility) を考慮
+
+- 該当: `core/NoteCreateService.ts` (`NotificationManager`)
+- 変更: `notify()` で visibleUserIds を計算し、specified note では `visibleUserIds` に含まれる相手にしか通知しない (followers note の挙動は upstream で commented-out 中で確定していない)
+- なぜ必要: 非公開の specified note でメンション相手以外にも通知が飛ぶ漏洩
+- 関連 PR: #17335
+- mk-go 該当箇所: `internal/core/note/` の通知配信、ローカル note service の通知 hook
+
+### Search: Meilisearch 未使用時の `noteSearchableScope` 修正
+
+- 該当: `core/entities/MetaEntityService.ts`
+- 変更: `noteSearchableScope` の判定が `meilisearch == null` ベース → `fulltextSearch.provider === 'meilisearch' && meilisearch.scope === 'local'` ベースに
+- なぜ必要: 別検索プロバイダ (pgroonga 等) 利用時に meilisearch 設定残しがあると UI からリモートノート検索が無効化されてしまう
+- 関連 PR: #17341
+- mk-go 該当箇所: `internal/core/meta` で `noteSearchableScope` 計算しているところ
+
+## 移植優先度: 中 (機能追加 / API 拡張)
+
+mk-go の API 互換性 / spec 互換性を保つために将来的に必要だが、急がない。
+
+### Avatar Decoration にカテゴリ追加
+
+- 該当: 新 migration `1766652173085-add-category-to-avatar-decorations.js`、`models/AvatarDecoration.ts`、`server/api/endpoints/admin/avatar-decorations/{create,list,update}.ts`
+- 変更: `avatar_decoration.category varchar(128) NULL` を追加。endpoint レスポンスにも `category` フィールド追加
+- 関連 PR: #17034
+- mk-go 該当箇所:
+  - migration 必要
+  - `internal/model/avatar_decoration.go` に Category 追加
+  - admin/avatar-decorations 系 handler / response
+
+### CHANGELOG 由来の追加機能 (詳細未調査、実装時に upstream 確認)
+
+- アンテナで Bot 除外オプション
+- アンテナで follower-only note も検出 (フォローしていれば)
+- フォローリクエスト履歴の閲覧
+- リモートユーザー role badge 表示 (オプトイン)
+- OAuth 外部アプリのロゴ表示
+- Bull Dashboard で Relationship Queue 状態表示
+- 「もうすぐ誕生日のユーザー」ウィジェットの近接判定改善
+- 起動前疎通チェックで DB / 全 Redis を検査
+
+### CHANGELOG 由来の修正 (詳細未調査)
+
+- DeepL API キー指定方式の変更対応
+- DB レプリケーション環境でのクエリ失敗修正
+- pgroonga: 複数キーワード検索が効かない問題
+- S3 互換 storage でのアップロード失敗
+- ワードミュート文字数計算
+- センシティブファイルを含む note の非表示
+- acct の case sensitivity による mention 配送ミス
+- ローカル user mention の URL 変換
+- FTT 無効時 user list timeline
+- 招待コード残数算出のポリシー値間違い
+- baseline role policy 変更でモデログに残らない
+- ベースロール変更が UI 反映されない
+- アカウント削除モデログ (#14996)
+- inbox 処理エラーを Activity として処理してしまう問題
+- queue エラーログ簡略化
+- メール認証必須時に email 削除を許さない (signup-pending の延長で関連)
+- chart 更新の DB 同接削減
+- Retry-After ヘッダー欠落
+- DOM 解析後のリソース解放
+- `<link rel="alternate">` 追跡を OK レスポンス時のみに
+
+### CHANGELOG 由来の機能追加 (Server)
+
+- **`setupPassword` 設定**: 初期セットアップ時の管理者パスワード制御。新規 deploy 時セキュリティ向上のため、config に `setupPassword` を設定して初回 admin 作成を保護できる
+- **モデレーター: ファイル添付 note の検索**: 通常 user 不可だが mod は許可
+
+## 移植不要 (TS-specific tooling)
+
+mk-go には影響しない。**移植不要**。
+
+- **Vitest 移行** (`enhance(backend/test): Migrate tests to vitest #16935`、新 `vitest.config.*.ts`、`test/jest.setup.ts` 系廃止) — Go 標準 testing で完結しているので無関係
+- **Rolldown bundler** (#17068) — TS bundler 切り替え。Go バイナリは無関係
+- **swc/esbuild → Rolldown** — 同上
+- **`/api-doc` (OpenAPI) アクセス修正** (#17267) — mk-go の API doc 提供方式が異なれば不要、揃える方針なら #17267 と等価対応必要
+- **dev サーバー起動失敗 fix** (#17317) — TS dev server 限定
+- **flaky e2e test fix** (timeline streaming, drive folder) — TS e2e 側の flakiness、Go 側で対応する e2e があれば別途
+- **Docker ビルド失敗 fix** — TS 側 Dockerfile、mk-go の Dockerfile は別
+
+## 未対応の Open question
+
+mk-go 移植時に判断が必要:
+
+- **メール認証必須時の email 削除拒否**: PR #595 (signup email verify) で実装したが、本修正は account 設定での email 削除側の話。`/api/i/update-email` で `meta.EmailRequiredForSignup=true` のとき email クリアを拒否する logic は既に mk-go の `api/i/email_update.go:64-69` に実装済 (確認済) → **対応不要**
+- **Inbox の特定エラーで Delayed にしない**: identifiable error UUID リストの mk-go 側等価実装。mk-go の queue driver (asynq / mkq) で unrecoverable 扱いを表現する方法を確認する必要あり
+- **DB レプリケーション**: mk-go では未対応 (single-DB 前提) なので scope 外
+- **DeepL API キー方式変更**: mk-go の翻訳実装側を upstream に追従するか確認
+
+## 変更 backend ファイル (146 files)
+
+### core service
+```
+core/AiService.ts
+core/InternalStorageService.ts
+core/LoggerService.ts
+core/NoteCreateService.ts            ← 通知 visibility (要対応)
+core/RelayService.ts                 ← isRelayActor 追加 (要対応)
+core/RoleService.ts                  ← getAdministratorIds 重複排除 (要対応)
+core/SearchService.ts                ← Meilisearch → Meilisearch 改名のみ
+core/SignupService.ts                ← (空白行削除のみ)
+core/activitypub/ApInboxService.ts   ← actor 比較 + relay Announce (要対応)
+core/activitypub/models/ApPersonService.ts  ← alsoKnownAs (要対応)
+core/entities/MetaEntityService.ts   ← noteSearchableScope (要対応)
+core/entities/UserEntityService.ts
+```
+
+### queue
+```
+queue/processors/InboxProcessorService.ts  ← 多数 (要対応)
+```
+
+### model / migration
+```
+models/AvatarDecoration.ts                                  ← category 追加
+migration/1766652173085-add-category-to-avatar-decorations.js
+```
+
+### endpoints
+```
+server/api/endpoints/admin/avatar-decorations/{create,list,update}.ts
+server/api/endpoints/drive/folders/update.ts                ← await 漏れ修正
+server/api/endpoints/endpoints.ts
+server/api/endpoints/endpoint.ts
+server/api/endpoints/get-avatar-decorations.ts
+server/api/openapi/{api-doc.tsx,OpenApiServerService.ts}
+```
+
+### server / boot
+```
+boot/{common.ts,entry.ts}
+config.ts
+GlobalModule.ts
+logger.ts
+server/{FileServerService.ts,HealthServerService.ts}
+server/web/{ClientServerService.ts,HtmlTemplateService.ts}
+```
+
+### misc
+```
+misc/id/ulid.ts                  ← ULID Crockford 修正 (要対応)
+```
+
+### tooling (移植不要)
+```
+build.js, jest.config.cjs (削除), vitest.config.*.ts (新規)
+rolldown.config.ts, scripts/*, .swcrc, ormconfig.js
+test/**, test-federation/**, test-server/**
+```
+
+## backend 関連 commits (sha → 概要)
+
+```
+8169c57b  fix(backend): handle array or string in alsoKnownAs (#17275)         ← 要対応
+29cecd75  fix(backend): 存在しない Actor の Delete を無視 (#17294)              ← 要対応
+5dc50834  fix(backend): ULID を正しく処理できない問題 (#17310)                  ← 要対応
+12e590a6  fix(backend): role-based validation error で retry しない (#17167)   ← 要対応
+277a1ef3  fix(backend): リレー由来 Announce の正しい処理 (#17308)               ← 要対応
+3a3057a1  fix(backend): RoleService.getAdministratorIds 重複 (#17334)         ← 要対応
+1dc5c60b  fix(backend): meilisearch 未使用時の noteSearchableScope (#17341)    ← 要対応
+23715c64  fix: activity.actor を getApId() で正規化 (#17340)                    ← 要対応
+0f5da633  fix(backend): ブロック中インスタンスの Inbox job 蓄積 (#17336)         ← 要対応
+b45f18cd  fix(backend): note 通知で visibility 考慮 (#17335)                     ← 要対応
+360e8056  enhance: アバターデコレーションへのカテゴリ導入 (#17034)                 ← 中優先
+55b0fbd1  fix(backend): robots.txt の内容調整 (#17165)                            ← 中優先
+5361a381  fix(backend): /api-doc アクセスできない問題 (#17267)                    ← 互換性次第
+6d15fe32  enhance(backend/test): Migrate tests to vitest (#16935)               ← 移植不要
+37bfcb60  enhance(backend): bundle backend using Rolldown (#17068)              ← 移植不要
+0be3142d  fix(backend): dev サーバー起動失敗 (#17317)                             ← 移植不要
+d7ceaa9c, a5b1f839  flaky e2e test fix                                          ← 移植不要
+```
+
+## 推奨対応プラン
+
+mk-go 既存の sub-issue 切り出しパターン (#570 系) と同じく、本 diff から個別 issue を切るのが筋。優先順位:
+
+1. **連合互換性に直接関わる 8 件** (`activity.actor` 正規化 / `alsoKnownAs` array-or-string / Delete 存在チェック / リレー Announce / ブロック中 inbox / role validation retry / ULID / 通知 visibility) を 1 tracker issue にまとめ、各サブ issue で個別 PR
+2. **API spec 拡張** (avatar decoration category) は migration + model + handler の 3 セットで 1 PR
+3. **CHANGELOG にしか記載がないアイテム** は upstream commit を 1 つずつ追って個別判断 (本 doc 未調査分)
+
+upstream submodule (`third_party/misskey/`) を 2026.5.0 に bump するかは別判断。bump すると `2026.3.2` の base が失われるので、移植完了まで `2026.3.2` を pin したままで diff を頼りに作業する方が無難。


### PR DESCRIPTION
## Summary

upstream \`misskey-dev/misskey\` の \`2026.3.2..2026.5.0\` backend 変更 (67 commits / 146 files) を mk-go 移植観点で分類した doc を新規追加。

#607 (Misskey TS upstream 追従 tracker) の reference として参照する位置付け。

## 主な内容

\`docs/2026-5-0-diff.md\` (258 行):

### 移植優先度: 高 (連合互換性 / 動作 regression) — 9 項目

各項目を「該当 file / 変更内容 / なぜ必要 / 関連 PR / mk-go 該当箇所」テンプレで詳述:

1. ActivityPub: \`activity.actor\` の string / 埋め込み object 双方対応 (#17340)
2. ActivityPub: \`alsoKnownAs\` の array / string 双方対応 (#17275)
3. ActivityPub: 存在しない Actor の Delete を ignore (#17294)
4. ActivityPub: リレー由来 Announce で renote を作らず元 note を直接 publish (#17308)
5. ActivityPub: ブロック中インスタンスの inbox job 蓄積防止 (#17336)
6. ActivityPub: role validation error の retry 防止 (#17167)
7. ID 生成: ULID Crockford Base32 のパース修正 (#17310)
8. Note 通知: 公開範囲 (visibility) を考慮 (#17335)
9. Role: \`getAdministratorIds\` の重複排除 (#17334)

(+ Search の \`noteSearchableScope\` 修正 #17341 を含めて 10 項目)

### 移植優先度: 中 (機能追加 / API 拡張)

- Avatar Decoration カテゴリ追加 (#17034) — migration + model + handler セット
- CHANGELOG 由来の機能追加 / 修正リスト

### 移植不要 (TS-specific tooling)

Vitest 移行、Rolldown bundler、swc 整理、Docker ビルド、dev server fix、flaky e2e fix

### その他

- 変更 backend ファイル一覧 (146 files) を area 別グルーピング
- backend 関連 commits を SHA + 移植要否マーク付きで列挙
- 推奨対応プラン (sub-issue 切り出し方針)

## Testing

doc only。コードに変更なし、CI 影響なし。

## Refs

Refs #607

🤖 Generated with [Claude Code](https://claude.com/claude-code)