### PR TITLE
Fix #606 (item 1, 2, 4): rate-limit 周辺改善 (operator note + IP/userID OR-bucket + rateLimitFactor)

### DIFF
--- a/.config/default.yml.example
+++ b/.config/default.yml.example
@@ -73,7 +73,10 @@ port: 3000
 #disableHsts: true
 
 # Enable internal IP-based rate limiting (default: true).
-# Set to false if you handle rate limiting in the reverse proxy.
+# Required for unauthenticated endpoints (signup / signin / reset-password)
+# to be rate-limited at all — otherwise spam / brute-force protection only
+# kicks in for authenticated users. Set to false only when you handle rate
+# limiting in the reverse proxy / WAF layer.
 #enableIpRateLimit: true
 
 #   ┌──────────────────────────┐

--- a/internal/server/middleware/ratelimit.go
+++ b/internal/server/middleware/ratelimit.go
@@ -104,11 +104,19 @@ func parseIntFromString(s string) int64 {
 	return v
 }
 
+// PolicyProvider abstracts user policy lookup so the middleware can
+// scale Max by `rateLimitFactor` from the user's role policies (#606 item 4)。
+// 循環依存を避けるため interface で受け取る (実装は core/role.Service)。
+type PolicyProvider interface {
+	GetUserPolicies(userID string) map[string]any
+}
+
 // RateLimiter provides per-endpoint rate limiting as Echo middleware.
 type RateLimiter struct {
 	store             RateLimitStore
 	enableIPRateLimit bool
 	limits            map[string]*EndpointLimit
+	policyProvider    PolicyProvider // optional, nil なら factor=1 固定
 }
 
 // NewRateLimiter creates a RateLimiter with the given store and config.
@@ -125,9 +133,21 @@ func NewRedisRateLimiter(rdb *redis.Client, enableIPRateLimit bool, limits map[s
 	return NewRateLimiter(NewRedisRateLimitStore(rdb), enableIPRateLimit, limits)
 }
 
+// SetPolicyProvider wires a PolicyProvider so authenticated user の
+// rateLimitFactor が反映される。trusted user に factor=2.0 を割り当てて
+// 実効 Max を 2 倍にする等の運用が可能 (#606 item 4)。
+func (rl *RateLimiter) SetPolicyProvider(p PolicyProvider) {
+	rl.policyProvider = p
+}
+
 // Middleware returns an Echo middleware that enforces rate limiting.
 // リミット定義のないエンドポイントはそのまま通過する。
 // Redisエラー時はfail-open（ログだけ出してリクエストを通す）。
+//
+// 認証済みリクエストでは userID と IP の両 bucket を OR で評価する
+// (#606 item 2): 攻撃者が認証して別アカウントを brute-force するケースで
+// userID bucket に逃がされず、IP bucket でも捕捉する。X-RateLimit-Remaining
+// は最も逼迫した bucket (最小値) を返す。
 func (rl *RateLimiter) Middleware() echo.MiddlewareFunc {
 	return func(next echo.HandlerFunc) echo.HandlerFunc {
 		return func(c echo.Context) error {
@@ -137,36 +157,47 @@ func (rl *RateLimiter) Middleware() echo.MiddlewareFunc {
 				return next(c)
 			}
 
-			actor := rl.resolveActor(c)
-			if actor == "" {
+			actors := rl.resolveActors(c)
+			if len(actors) == 0 {
 				return next(c)
 			}
 
 			ctx := c.Request().Context()
+			minRemaining := -1
 
-			// minIntervalチェック（設定されていれば）
-			if limit.MinInterval > 0 {
-				info, err := rl.store.Check(ctx, actor+":"+endpoint+":min", limit.MinInterval, 1)
-				if err != nil {
-					slog.Warn("rate limit store error (minInterval)", "endpoint", endpoint, "err", err)
-					return next(c)
+			for _, a := range actors {
+				effectiveMax := scaledMax(limit.Max, a.factor)
+
+				// minInterval チェック (factor は適用しない — minInterval は連投
+				// 抑止が目的なので user role で緩和する semantics ではない)
+				if limit.MinInterval > 0 {
+					info, err := rl.store.Check(ctx, a.key+":"+endpoint+":min", limit.MinInterval, 1)
+					if err != nil {
+						slog.Warn("rate limit store error (minInterval)", "endpoint", endpoint, "err", err)
+						continue
+					}
+					if info.Remaining == 0 {
+						return rl.rejectRequest(c, info)
+					}
 				}
-				if info.Remaining == 0 {
-					return rl.rejectRequest(c, info)
+
+				// duration/max チェック (factor 適用済みの effectiveMax で評価)
+				if limit.Duration > 0 && effectiveMax > 0 {
+					info, err := rl.store.Check(ctx, a.key+":"+endpoint, limit.Duration, effectiveMax)
+					if err != nil {
+						slog.Warn("rate limit store error", "endpoint", endpoint, "err", err)
+						continue
+					}
+					if info.Remaining == 0 {
+						return rl.rejectRequest(c, info)
+					}
+					if minRemaining < 0 || info.Remaining < minRemaining {
+						minRemaining = info.Remaining
+					}
 				}
 			}
-
-			// duration/maxチェック
-			if limit.Duration > 0 && limit.Max > 0 {
-				info, err := rl.store.Check(ctx, actor+":"+endpoint, limit.Duration, limit.Max)
-				if err != nil {
-					slog.Warn("rate limit store error", "endpoint", endpoint, "err", err)
-					return next(c)
-				}
-				if info.Remaining == 0 {
-					return rl.rejectRequest(c, info)
-				}
-				c.Response().Header().Set("X-RateLimit-Remaining", fmt.Sprintf("%d", info.Remaining))
+			if minRemaining >= 0 {
+				c.Response().Header().Set("X-RateLimit-Remaining", fmt.Sprintf("%d", minRemaining))
 			}
 
 			return next(c)
@@ -174,17 +205,80 @@ func (rl *RateLimiter) Middleware() echo.MiddlewareFunc {
 	}
 }
 
-// resolveActor determines the rate limit actor.
-// 認証済みユーザーのIDを使い、未認証ならIPハッシュを使う。
-// enableIPRateLimit=falseかつ未認証の場合は空文字を返す（制限スキップ）。
-func (rl *RateLimiter) resolveActor(c echo.Context) string {
+// rateLimitActor は単一 bucket を識別する key + factor のペア。
+// 認証済 user では userID 由来 actor (factor=user policy) と IP 由来 actor
+// (factor=1.0) が並ぶ。未認証では IP 由来 actor のみ。
+type rateLimitActor struct {
+	key    string  // bucket 識別子 ("u:<userID>" / "ip-<hash>" 等)
+	factor float64 // Max scaling 係数 (>0、1.0 で base、>1 で緩和、<1 で厳格)
+}
+
+// resolveActors returns all bucket actors that should be checked for this
+// request. 認証済 user は userID + IP の両方、未認証は IP のみを返す。
+// EnableIPRateLimit=false かつ未認証なら空 (= 制限スキップ、既存挙動維持)。
+func (rl *RateLimiter) resolveActors(c echo.Context) []rateLimitActor {
+	var actors []rateLimitActor
 	if user := GetUser(c); user != nil {
-		return user.ID
+		// user.ID は ULID で `ip-` prefix と衝突しないので prefix なしで
+		// そのまま bucket key にする (既存 Redis state との互換性維持)。
+		actors = append(actors, rateLimitActor{
+			key:    user.ID,
+			factor: rl.userFactor(user.ID),
+		})
+		// 認証済でも IP bucket を併用 (#606 item 2)。NAT 配下の正当ユーザーは
+		// 同一 IP で複数 user として扱われるが、auth 系 endpoint は 1h/60 程度
+		// と緩いので実害は小さい (個別 user の rate-limit は userID bucket で
+		// 守られる)。
+		if rl.enableIPRateLimit {
+			actors = append(actors, rateLimitActor{
+				key:    ipHash(c.RealIP()),
+				factor: 1.0, // IP 由来 bucket は user 単位の factor を適用しない
+			})
+		}
+		return actors
 	}
 	if !rl.enableIPRateLimit {
-		return ""
+		return nil
 	}
-	return ipHash(c.RealIP())
+	return []rateLimitActor{{key: ipHash(c.RealIP()), factor: 1.0}}
+}
+
+// userFactor returns the rateLimitFactor from the user's role policies.
+// 未配線 / 値不正 / 0 以下なら 1.0 (= 影響なし) で返す。
+func (rl *RateLimiter) userFactor(userID string) float64 {
+	if rl.policyProvider == nil {
+		return 1.0
+	}
+	policies := rl.policyProvider.GetUserPolicies(userID)
+	raw, ok := policies["rateLimitFactor"]
+	if !ok {
+		return 1.0
+	}
+	switch v := raw.(type) {
+	case float64:
+		if v > 0 {
+			return v
+		}
+	case int:
+		if v > 0 {
+			return float64(v)
+		}
+	}
+	return 1.0
+}
+
+// scaledMax applies factor to the base Max. factor=1.0 では base そのまま、
+// factor が小さすぎても 1 を下回らないようにクランプ (factor=0 等の事故で
+// 全 user が瞬時に 429 を食らうのを防ぐ)。
+func scaledMax(base int, factor float64) int {
+	if factor <= 0 || factor == 1.0 {
+		return base
+	}
+	scaled := int(float64(base) * factor)
+	if scaled < 1 {
+		return 1
+	}
+	return scaled
 }
 
 // rejectRequest returns a 429 response with appropriate headers.

--- a/internal/server/middleware/ratelimit.go
+++ b/internal/server/middleware/ratelimit.go
@@ -209,7 +209,7 @@ func (rl *RateLimiter) Middleware() echo.MiddlewareFunc {
 // 認証済 user では userID 由来 actor (factor=user policy) と IP 由来 actor
 // (factor=1.0) が並ぶ。未認証では IP 由来 actor のみ。
 type rateLimitActor struct {
-	key    string  // bucket 識別子 ("u:<userID>" / "ip-<hash>" 等)
+	key    string  // bucket 識別子 (userID そのまま / "ip-<hash>" 等)
 	factor float64 // Max scaling 係数 (>0、1.0 で base、>1 で緩和、<1 で厳格)
 }
 

--- a/internal/server/middleware/ratelimit_test.go
+++ b/internal/server/middleware/ratelimit_test.go
@@ -86,6 +86,7 @@ func TestMiddleware_WithinLimit(t *testing.T) {
 	store := &mockLimitStore{
 		results: []mockResult{
 			{Info: LimitInfo{Remaining: 5, ResetMs: time.Now().Add(time.Hour).UnixMilli()}},
+			{Info: LimitInfo{Remaining: 8, ResetMs: time.Now().Add(time.Hour).UnixMilli()}},
 		},
 	}
 	limits := map[string]*EndpointLimit{
@@ -97,9 +98,12 @@ func TestMiddleware_WithinLimit(t *testing.T) {
 	rec := doRequest(e, rl.Middleware(), h, "/api/notes/create", &model.User{ID: "user1"})
 
 	assert.Equal(t, http.StatusOK, rec.Code)
+	// 認証済 → userID + IP bucket の 2 actor (#606 item 2)。X-RateLimit-Remaining
+	// は最も逼迫した bucket (ここでは userID 側 5)。
 	assert.Equal(t, "5", rec.Header().Get("X-RateLimit-Remaining"))
-	require.Len(t, store.calls, 1)
+	require.Len(t, store.calls, 2)
 	assert.Equal(t, "user1:notes/create", store.calls[0].Key)
+	assert.Contains(t, store.calls[1].Key, "ip-")
 	assert.Equal(t, time.Hour, store.calls[0].Duration)
 	assert.Equal(t, 300, store.calls[0].Max)
 }
@@ -132,7 +136,8 @@ func TestMiddleware_ExceedsLimit(t *testing.T) {
 func TestMiddleware_AuthenticatedActor(t *testing.T) {
 	store := &mockLimitStore{
 		results: []mockResult{
-			{Info: LimitInfo{Remaining: 10}},
+			{Info: LimitInfo{Remaining: 10}}, // userID bucket
+			{Info: LimitInfo{Remaining: 20}}, // IP bucket
 		},
 	}
 	limits := map[string]*EndpointLimit{
@@ -143,8 +148,142 @@ func TestMiddleware_AuthenticatedActor(t *testing.T) {
 
 	doRequest(e, rl.Middleware(), h, "/api/notes/create", &model.User{ID: "myuserid"})
 
-	require.Len(t, store.calls, 1)
+	// userID + IP bucket の 2 つに対して check が走る (#606 item 2)
+	require.Len(t, store.calls, 2)
 	assert.Equal(t, "myuserid:notes/create", store.calls[0].Key)
+	assert.Contains(t, store.calls[1].Key, "ip-")
+}
+
+// 認証済 user の userID bucket が満杯でも IP bucket が余裕でも 429
+// (どちらかのしきい値超過で reject、OR-bucket セマンティクス)。
+func TestMiddleware_AuthenticatedActor_UserBucketExceeds(t *testing.T) {
+	resetMs := time.Now().Add(30 * time.Second).UnixMilli()
+	store := &mockLimitStore{
+		results: []mockResult{
+			{Info: LimitInfo{Remaining: 0, ResetMs: resetMs}}, // userID bucket exceeded
+		},
+	}
+	limits := map[string]*EndpointLimit{
+		"notes/create": {Duration: time.Hour, Max: 300},
+	}
+	rl := NewRateLimiter(store, true, limits)
+	e, h := setupEcho(rl)
+
+	rec := doRequest(e, rl.Middleware(), h, "/api/notes/create", &model.User{ID: "u1"})
+	assert.Equal(t, http.StatusTooManyRequests, rec.Code)
+	require.Len(t, store.calls, 1, "userID bucket で reject なら IP bucket は check しない")
+}
+
+// 認証済 user の userID bucket は OK でも IP bucket が満杯なら 429
+// (cross-account brute-force 防御 #606 item 2)。
+func TestMiddleware_AuthenticatedActor_IPBucketExceeds(t *testing.T) {
+	resetMs := time.Now().Add(30 * time.Second).UnixMilli()
+	store := &mockLimitStore{
+		results: []mockResult{
+			{Info: LimitInfo{Remaining: 50}},                  // userID bucket OK
+			{Info: LimitInfo{Remaining: 0, ResetMs: resetMs}}, // IP bucket exceeded
+		},
+	}
+	limits := map[string]*EndpointLimit{
+		"notes/create": {Duration: time.Hour, Max: 300},
+	}
+	rl := NewRateLimiter(store, true, limits)
+	e, h := setupEcho(rl)
+
+	rec := doRequest(e, rl.Middleware(), h, "/api/notes/create", &model.User{ID: "u1"})
+	assert.Equal(t, http.StatusTooManyRequests, rec.Code)
+	require.Len(t, store.calls, 2)
+}
+
+// EnableIPRateLimit=false なら認証済でも IP bucket は走らない
+// (operator 配線の意図を尊重)。
+func TestMiddleware_AuthenticatedActor_IPDisabled(t *testing.T) {
+	store := &mockLimitStore{
+		results: []mockResult{
+			{Info: LimitInfo{Remaining: 10}},
+		},
+	}
+	limits := map[string]*EndpointLimit{
+		"notes/create": {Duration: time.Hour, Max: 300},
+	}
+	rl := NewRateLimiter(store, false, limits)
+	e, h := setupEcho(rl)
+
+	doRequest(e, rl.Middleware(), h, "/api/notes/create", &model.User{ID: "u1"})
+	require.Len(t, store.calls, 1, "IP bucket は EnableIPRateLimit=false で skip")
+	assert.Equal(t, "u1:notes/create", store.calls[0].Key)
+}
+
+// PolicyProvider 経由で rateLimitFactor=2.0 が反映されると Max が
+// scale される (#606 item 4)。
+func TestMiddleware_PolicyProviderScalesMax(t *testing.T) {
+	store := &mockLimitStore{
+		results: []mockResult{
+			{Info: LimitInfo{Remaining: 100}},
+			{Info: LimitInfo{Remaining: 100}},
+		},
+	}
+	limits := map[string]*EndpointLimit{
+		"notes/create": {Duration: time.Hour, Max: 300},
+	}
+	rl := NewRateLimiter(store, true, limits)
+	rl.SetPolicyProvider(stubPolicy{factor: 2.0})
+	e, h := setupEcho(rl)
+
+	doRequest(e, rl.Middleware(), h, "/api/notes/create", &model.User{ID: "vip"})
+
+	require.Len(t, store.calls, 2)
+	// userID bucket は factor=2.0 で 600 に scale、IP bucket は factor=1.0
+	assert.Equal(t, 600, store.calls[0].Max, "userID bucket: 300 * 2.0")
+	assert.Equal(t, 300, store.calls[1].Max, "IP bucket は factor 適用外")
+}
+
+// factor が 0 / 負 / 不正型なら 1.0 (= base) に fallback
+func TestMiddleware_PolicyProviderInvalidFactor(t *testing.T) {
+	for _, tc := range []struct {
+		name   string
+		policy stubPolicy
+	}{
+		{"zero", stubPolicy{factor: 0}},
+		{"negative", stubPolicy{factor: -1}},
+		{"missing", stubPolicy{}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			store := &mockLimitStore{
+				results: []mockResult{{Info: LimitInfo{Remaining: 10}}, {Info: LimitInfo{Remaining: 10}}},
+			}
+			limits := map[string]*EndpointLimit{
+				"notes/create": {Duration: time.Hour, Max: 300},
+			}
+			rl := NewRateLimiter(store, true, limits)
+			rl.SetPolicyProvider(tc.policy)
+			e, h := setupEcho(rl)
+			doRequest(e, rl.Middleware(), h, "/api/notes/create", &model.User{ID: "u"})
+			require.GreaterOrEqual(t, len(store.calls), 1)
+			assert.Equal(t, 300, store.calls[0].Max, "不正 factor は 1.0 fallback")
+		})
+	}
+}
+
+// stubPolicy は PolicyProvider のテスト double。factor=0 なら policies map
+// に rateLimitFactor を含めない (= 「未設定」を再現)。
+type stubPolicy struct{ factor float64 }
+
+func (s stubPolicy) GetUserPolicies(_ string) map[string]any {
+	if s.factor == 0 {
+		return map[string]any{}
+	}
+	return map[string]any{"rateLimitFactor": s.factor}
+}
+
+// scaledMax の境界値テスト (factor=0.001 等で 1 を下回らずクランプ)
+func TestScaledMax(t *testing.T) {
+	assert.Equal(t, 300, scaledMax(300, 1.0))
+	assert.Equal(t, 600, scaledMax(300, 2.0))
+	assert.Equal(t, 150, scaledMax(300, 0.5))
+	assert.Equal(t, 1, scaledMax(10, 0.001), "極小 factor でも 1 にクランプ")
+	assert.Equal(t, 300, scaledMax(300, 0), "factor=0 は 1.0 扱い (= base)")
+	assert.Equal(t, 300, scaledMax(300, -1), "負数も 1.0 扱い (防御)")
 }
 
 func TestMiddleware_UnauthenticatedIPActor(t *testing.T) {
@@ -185,8 +324,10 @@ func TestMiddleware_UnauthenticatedIPDisabled(t *testing.T) {
 func TestMiddleware_MinIntervalCheckFirst(t *testing.T) {
 	store := &mockLimitStore{
 		results: []mockResult{
-			{Info: LimitInfo{Remaining: 1}},  // minInterval: OK
-			{Info: LimitInfo{Remaining: 50}}, // duration/max: OK
+			{Info: LimitInfo{Remaining: 1}},  // userID: minInterval OK
+			{Info: LimitInfo{Remaining: 50}}, // userID: duration/max OK
+			{Info: LimitInfo{Remaining: 1}},  // IP: minInterval OK
+			{Info: LimitInfo{Remaining: 50}}, // IP: duration/max OK
 		},
 	}
 	limits := map[string]*EndpointLimit{
@@ -198,15 +339,20 @@ func TestMiddleware_MinIntervalCheckFirst(t *testing.T) {
 	rec := doRequest(e, rl.Middleware(), h, "/api/notes/delete", &model.User{ID: "u1"})
 
 	assert.Equal(t, http.StatusOK, rec.Code)
-	require.Len(t, store.calls, 2)
-	// 1回目: minIntervalチェック
+	// 認証済 → userID + IP の 2 actor、各 actor で minInterval + duration の
+	// 2 チェック → 計 4 calls
+	require.Len(t, store.calls, 4)
+	// userID actor: minInterval が先、その後 duration/max
 	assert.Equal(t, "u1:notes/delete:min", store.calls[0].Key)
 	assert.Equal(t, time.Second, store.calls[0].Duration)
 	assert.Equal(t, 1, store.calls[0].Max)
-	// 2回目: duration/maxチェック
 	assert.Equal(t, "u1:notes/delete", store.calls[1].Key)
 	assert.Equal(t, time.Hour, store.calls[1].Duration)
 	assert.Equal(t, 300, store.calls[1].Max)
+	// IP actor: 同じ順序
+	assert.Contains(t, store.calls[2].Key, "ip-")
+	assert.Contains(t, store.calls[2].Key, ":notes/delete:min")
+	assert.Contains(t, store.calls[3].Key, ":notes/delete")
 }
 
 func TestMiddleware_MinIntervalBlock(t *testing.T) {

--- a/internal/server/router.go
+++ b/internal/server/router.go
@@ -711,6 +711,10 @@ func (s *Server) setupRoutes() {
 		s.config.EnableIPRateLimit,
 		rateLimitDefs,
 	)
+	// role policies の rateLimitFactor を反映できるよう roleService を inject
+	// (#606 item 4)。trusted user に factor=2.0 等を割り当てて実効 Max を緩和
+	// する運用に対応。
+	rateLimiter.SetPolicyProvider(roleService)
 	api.Use(rateLimiter.Middleware())
 
 	// Meta endpoint (public)


### PR DESCRIPTION
## Summary

#606 で挙げた周辺改善 4 項目のうち **3 項目を 1 PR で対応**。残る item 3 (meta 設定で閾値調整) は frontend / Docker 制約から **#612** に切り出した (D-4 案: config.yml + meta-backed)。

## 主な変更点

### (1) operator note (default.yml.example)

`enableIpRateLimit` のコメントを強化:
\`\`\`yaml
# Enable internal IP-based rate limiting (default: true).
# Required for unauthenticated endpoints (signup / signin / reset-password)
# to be rate-limited at all — otherwise spam / brute-force protection only
# kicks in for authenticated users. Set to false only when you handle rate
# limiting in the reverse proxy / WAF layer.
\`\`\`

PR #605 で auth 系 rate-limit を入れたが \`enableIpRateLimit=false\` だと未認証 endpoint で効かない gap を operator に周知。

### (2) IP + userID OR-bucket

\`resolveActor\` → \`resolveActors\` (複数 actor 返却) に signature 変更。認証済 request は **userID と IP の両 bucket** を check し、いずれか reject なら 429。攻撃者が認証して別アカウントを brute-force するケースで IP bucket にも捕捉される。

- userID は ULID で \`ip-\` prefix と衝突しないので prefix なしで Redis state 互換性維持
- \`EnableIPRateLimit=false\` なら認証済でも IP bucket は skip (operator 配線の意図尊重)
- \`X-RateLimit-Remaining\` は最も逼迫した bucket (最小値) を返す

### (4) rateLimitFactor (role policies) を middleware に反映

\`role.DefaultPolicies\` の \`rateLimitFactor: 1\` が定義済だったが middleware が読んでいなかった既存 TODO を解消。

\`\`\`go
type PolicyProvider interface {
    GetUserPolicies(userID string) map[string]any
}
func (rl *RateLimiter) SetPolicyProvider(p PolicyProvider)
\`\`\`

- userID bucket の Max を \`user.policies.rateLimitFactor\` で scale (factor=2.0 で 2x 緩和、factor=0.5 で半分に厳格化)
- IP bucket は factor 非適用 (user 単位の優遇は userID bucket のみ)
- factor 不正値 (0 / 負 / 不正型) は 1.0 fallback、極小値は 1 にクランプ
- router で \`rateLimiter.SetPolicyProvider(roleService)\` 配線

## Testing

- \`make fmt && make lint\`: 緑
- \`go test -race\` middleware: **95.9%** (>90% 閾値)
- 全 \`make test\` 緑

新規 9 件 + 既存 3 件 multi-actor 対応:
- userBucket / IPBucket それぞれ exceed → 429
- EnableIPRateLimit=false で IP bucket skip
- PolicyProvider で factor=2.0 → Max scale
- 不正 factor (0 / 負 / 未設定) で 1.0 fallback (3 ケース)
- scaledMax 境界 (factor=0.001 で 1 にクランプ)
- MinIntervalCheckFirst を 4 calls に対応 (userID + IP × minInterval + duration)

## 後方互換

- userID actor key prefix なしで既存 Redis state 互換維持
- \`SetPolicyProvider\` 未配線の場合は factor=1.0 固定で旧挙動と同等
- \`EnableIPRateLimit=false\` の operator は引き続き未認証 endpoint がスキップされる (ドキュメント強化のみ)

## Refs

Refs #606 — item 1, 2, 4 解決。残 item 3 は #612 で別途対応。

🤖 Generated with [Claude Code](https://claude.com/claude-code)