### PR TITLE
Sub #613 Step 3 (#619): Dockerfile を CGO_ENABLED=0 + -tags nodynamic で static binary 化

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,9 +7,10 @@
 # Stage 1: Build Go binary
 FROM golang:1.25-alpine AS builder
 
-# build-base は chai2010/webp などの cgo 依存をリンクするのに必要。
-# git は go mod download 時の private module fetch に使う。
-RUN apk add --no-cache git build-base
+# Step 2 (#618) で chai2010/webp → gen2brain/webp (libwebp on wazero/WASM) に
+# 切替えたので cgo 依存はゼロ。build-base (gcc + musl libc) は不要になった。
+# git は go mod download 時の private module fetch に使うので残す。
+RUN apk add --no-cache git
 
 WORKDIR /app
 
@@ -37,10 +38,16 @@ RUN test -f third_party/misskey/packages/backend/node_modules/@discordapp/twemoj
 # Go の build cache (`$GOCACHE` = /root/.cache/go-build) と module cache を
 # BuildKit cache mount として永続化する。再ビルド時に変更の無いパッケージは
 # 再コンパイルされずに layer 完成までが秒単位になる (#432)。
+#
+# CGO_ENABLED=0 + `-tags nodynamic` で static binary を生成する (#619)。
+# - CGO_ENABLED=0: gen2brain/webp に切替えた今、cgo に依存するコードは無い。
+# - -tags nodynamic: gen2brain/webp は default で purego (dlopen) 経由の
+#   shared lib fallback を試みるため、これを切って WASM (wazero) 一本に
+#   固定する。これがないと dlopen を呼ぶ層が残り完全 static にならない。
 RUN --mount=type=cache,target=/go/pkg/mod \
     --mount=type=cache,target=/root/.cache/go-build \
-    go build -trimpath -ldflags="-s -w" -o /app/built/misskey ./cmd/misskey && \
-    go build -trimpath -ldflags="-s -w" -o /app/built/migrate ./cmd/migrate
+    CGO_ENABLED=0 go build -tags nodynamic -trimpath -ldflags="-s -w" -o /app/built/misskey ./cmd/misskey && \
+    CGO_ENABLED=0 go build -tags nodynamic -trimpath -ldflags="-s -w" -o /app/built/migrate ./cmd/migrate
 
 # Stage 2: Runtime
 FROM alpine:3.21


### PR DESCRIPTION
## Summary

#613 のロードマップ Step 3。Step 2 (#618) で WebP encoder を `gen2brain/webp` (libwebp on wazero/WASM) に切替えて cgo 依存が消えたので、Dockerfile builder stage を slim 化して runtime distroless 化 (Step 4) の前段を整える。**本 PR では runtime stage はまだ `alpine:3.21` のまま**。

## 主な変更点 (Dockerfile のみ)

- builder stage の `apk add` から **`build-base` (gcc + musl libc) を削除**。cgo binding を持つコードは無くなったので不要。`git` は `go mod download` の private module fetch でまだ必要なので残す。
- `go build` に **`CGO_ENABLED=0` と `-tags nodynamic` を追加**:
  - `CGO_ENABLED=0`: cgo 経路を完全に無効化
  - `-tags nodynamic`: `gen2brain/webp` が default で `purego` (dlopen) 経由の shared lib fallback を試みるのを切り、WASM (wazero) 一本に固定する。これがないと dlopen 呼出が残って完全 static binary にならない (`ldd` で `libdl.so.2` / `libc.so.6` が見える)

## 検証

```
$ CGO_ENABLED=0 go build -tags nodynamic ./...
(success)

$ CGO_ENABLED=0 go test -tags nodynamic ./internal/core/drive/ ./internal/core/mediaproxy/
ok  github.com/shiroha-a/mk/internal/core/drive  8.2s
ok  github.com/shiroha-a/mk/internal/core/mediaproxy  1.4s

$ make docker-build
... #27 unpacking to docker.io/library/misskey-go:latest 1.7s done

$ docker run --rm --entrypoint=sh misskey-go:latest -c 'apk add file >/dev/null; file /app/misskey'
/app/misskey: ELF 64-bit LSB executable, x86-64, version 1 (SYSV), statically linked, ...

$ docker images misskey-go:latest --format '{{.Size}}'
112MB
```

`make fmt` / `make lint` クリーン。本 PR は production code 変更ゼロ (Dockerfile のみ) なので Step 1 で固めたテストも継続して通る。

## Image size

- 本 PR 前 (alpine + cgo): 比較のため後で計測 (Step 4 PR で纏めて記録)
- 本 PR 後 (alpine + static): **112MB**
- Step 4 後 (distroless/static-debian13): さらに縮む見込み

## Closes

Closes #619

(親 issue #613 は Step 5 完了まで open のまま)