### PR TITLE
Sub #613 Step 4 (#621): runtime stage を gcr.io/distroless/static-debian13 化

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -50,9 +50,17 @@ RUN --mount=type=cache,target=/go/pkg/mod \
     CGO_ENABLED=0 go build -tags nodynamic -trimpath -ldflags="-s -w" -o /app/built/migrate ./cmd/migrate
 
 # Stage 2: Runtime
-FROM alpine:3.21
-
-RUN apk add --no-cache ca-certificates tzdata
+#
+# distroless/static-debian13 (#621) を採用。Step 3 で binary が完全 static に
+# なったので、shell / pkg manager / wget / coreutils 等を持たない最小 image
+# でも起動できる。ca-certificates / tzdata は distroless に同梱されている
+# ので apk add は不要。
+#
+# 注意: distroless は shell も wget も持たないので、healthcheck は
+# `/app/misskey -healthcheck` で binary 自身に叩かせる (cmd/misskey/main.go
+# の -healthcheck フラグ)。docker-compose.dropin*.mk.yml /
+# docker-compose.federation.misskey.yml で使用。
+FROM gcr.io/distroless/static-debian13
 
 WORKDIR /app
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -94,5 +94,13 @@ COPY .config/docker.yml.example /app/.config/default.yml
 
 EXPOSE 3000
 
+# Misskey TS の Dockerfile が `useradd -u 991 -g 991 misskey` で UID/GID 991
+# を採用しているので、drop-in 互換 (host volume `./files` の所有権が両者で
+# 一致する) のため mk-go も同じ UID 991 で起動する (#621)。distroless static
+# には UID 991 の /etc/passwd エントリは無いが、mk-go は os/user.Current()
+# を呼ばないので numeric UID で問題なく動く。`:nonroot` tag (UID 65532) は
+# drop-in 互換を壊すので使わない。
+USER 991:991
+
 ENTRYPOINT ["/app/misskey"]
 CMD ["-config", ".config/default.yml"]

--- a/cmd/misskey/main.go
+++ b/cmd/misskey/main.go
@@ -5,9 +5,11 @@ import (
 	"flag"
 	"fmt"
 	"log/slog"
+	"net/http"
 	"os"
 	"os/signal"
 	"syscall"
+	"time"
 
 	"github.com/shiroha-a/mk/internal/config"
 	"github.com/shiroha-a/mk/internal/core/cache"
@@ -16,9 +18,18 @@ import (
 	"github.com/shiroha-a/mk/internal/server"
 )
 
+// healthcheckTimeout is the maximum time the -healthcheck mode waits for
+// the local /healthz endpoint to respond.
+const healthcheckTimeout = 3 * time.Second
+
 func main() {
 	configPath := flag.String("config", ".config/default.yml", "path to configuration file")
+	healthcheckMode := flag.Bool("healthcheck", false, "perform a healthcheck (GET /healthz against the configured port) and exit 0/1")
 	flag.Parse()
+
+	if *healthcheckMode {
+		os.Exit(runHealthcheck(*configPath))
+	}
 
 	// ロガーの初期化
 	slog.SetDefault(slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{
@@ -95,4 +106,29 @@ func main() {
 	}
 
 	fmt.Println("Misskey stopped.")
+}
+
+// runHealthcheck performs a single HTTP GET against http://127.0.0.1:<port>/healthz
+// using the port resolved from the same config the running server uses.
+// distroless image には wget/curl が無いので、healthcheck をこの binary
+// 自身で完結させるための専用モード (#621)。
+func runHealthcheck(configPath string) int {
+	cfg, err := config.Load(configPath)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "healthcheck: failed to load config: %v\n", err)
+		return 1
+	}
+	url := fmt.Sprintf("http://127.0.0.1:%d/healthz", cfg.Port)
+	client := &http.Client{Timeout: healthcheckTimeout}
+	resp, err := client.Get(url)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "healthcheck: %v\n", err)
+		return 1
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		fmt.Fprintf(os.Stderr, "healthcheck: status %d\n", resp.StatusCode)
+		return 1
+	}
+	return 0
 }

--- a/docker-compose.dropin-frontend.mk.yml
+++ b/docker-compose.dropin-frontend.mk.yml
@@ -30,8 +30,10 @@ services:
       - ./tests/dropin_frontend/instance_a_mk.yml:/app/.config/default.yml:ro
       - certs:/certs:ro
     # mk-go の healthcheck は GET /healthz (TS は POST /api/ping)。
+    # distroless image (#621) には wget が無いので binary 自身に -healthcheck
+    # フラグを通して叩かせる (cmd/misskey の -healthcheck mode)。
     healthcheck:
-      test: ["CMD", "wget", "-qO-", "http://localhost:3000/healthz"]
+      test: ["CMD", "/app/misskey", "-healthcheck", "-config", ".config/default.yml"]
       interval: 5s
       timeout: 5s
       retries: 30

--- a/docker-compose.dropin.mk.yml
+++ b/docker-compose.dropin.mk.yml
@@ -36,8 +36,10 @@ services:
       - certs:/certs:ro
     # mk-go の /healthz は GET なので TS の healthcheck (POST /api/ping) と
     # 命令が違う。差し替え後は GET /healthz で healthy を判定する。
+    # distroless image (#621) には wget が無いので binary 自身に -healthcheck
+    # フラグを通して叩かせる (cmd/misskey の -healthcheck mode)。
     healthcheck:
-      test: ["CMD", "wget", "-qO-", "http://localhost:3000/healthz"]
+      test: ["CMD", "/app/misskey", "-healthcheck", "-config", ".config/default.yml"]
       interval: 5s
       timeout: 5s
       retries: 30

--- a/docker-compose.federation.misskey.yml
+++ b/docker-compose.federation.misskey.yml
@@ -52,8 +52,10 @@ services:
     volumes:
       - certs:/certs:ro
       - ./tests/federation/common/mkgo.yml:/app/.config/default.yml:ro
+    # distroless image (#621) には wget が無いので binary 自身に -healthcheck
+    # フラグを通して叩かせる (cmd/misskey の -healthcheck mode)。
     healthcheck:
-      test: ["CMD", "wget", "-qO-", "http://localhost:3000/healthz"]
+      test: ["CMD", "/app/misskey", "-healthcheck", "-config", ".config/default.yml"]
       interval: 3s
       timeout: 5s
       retries: 20

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,6 +17,10 @@ services:
       # MISSKEY_REPO_ASSETS_DIR: /app/repo-assets
       TZ: Asia/Tokyo
     volumes:
+      # コンテナは UID/GID 991 (Misskey TS 互換) で起動するので、
+      # ./files は UID 991 が書き込める所有権でなければならない (#621)。
+      # 旧 root 構成から upgrade する場合は一度
+      # `sudo chown -R 991:991 ./files` を実行すること。
       - ./files:/app/drive-files
       # 設定ファイルを上書きする場合 (cp .config/docker.yml.example
       # .config/docker.yml して編集後にコメントを外す):

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -36,6 +36,8 @@ docker compose up -d
 
 ファイルストレージは`./files`にマウントされる。
 
+> **注意**: コンテナは **UID/GID 991** (Misskey TS と同じ) で起動するため、ホスト側の `./files` ディレクトリは UID 991 が書き込めるパーミッションでなければならない。Misskey TS から移行する場合は既に 991 所有なのでそのままで OK。**今まで mk-go の旧 root 構成で運用していて初めて 991 化に追従する場合は、一度だけ `sudo chown -R 991:991 ./files` で所有権を揃える必要がある**。
+
 ### prebuilt imageについて
 
 `ghcr.io/shiroha-a/mk:latest`等のprebuilt imageにはGoバイナリとマイグレーションSQLのみが含まれ、フロントエンドアセットは同梱されていない。prebuilt imageを使用する場合は以下の環境変数でアセットディレクトリを指定する必要がある:

--- a/docs/migration-from-ts.md
+++ b/docs/migration-from-ts.md
@@ -125,6 +125,13 @@ docker compose up -d
 
 Misskey-GoがPostgreSQLおよびRedisと共に起動する。詳細は `docker-compose.yml` を参照。
 
+### Docker container の UID
+
+Misskey-Go のコンテナは Misskey-TS と同じ **UID/GID 991** で起動する。`./files` (drive ファイルストレージ) を host volume mount している場合、ホスト側ディレクトリは UID 991 が書き込めるパーミッションでなければならない。
+
+- **TS から swap する場合**: 既に `./files` の中身が UID 991 で書かれているのでそのまま動く (drop-in 互換)
+- **mk-go-only から旧 root 構成 (#621 以前) で運用していた場合**: 一度だけ `sudo chown -R 991:991 ./files` で所有権を揃える必要がある
+
 ## Misskey-TSへのロールバック
 
 Misskey-TSに戻す場合の手順:


### PR DESCRIPTION
## Summary

#613 のロードマップ Step 4。Step 3 (#620) で binary が完全 static になったので、runtime stage を `alpine:3.21` → `gcr.io/distroless/static-debian13` に切替えて shell / pkg manager / wget / coreutils 等の OS ユーティリティを取り除く。**併せて UID 991 で起動するよう `USER 991:991` を追加** (Misskey TS と同じ UID で drop-in 互換維持 + security 向上)。

## 経緯メモ: mk-go は今までずっと root で動いていた

Dockerfile 履歴を遡ると `USER` 指定が一度も入ったことが無い (`ba6d1ef56` の最初の Dockerfile から今まで)。Misskey TS は `useradd -u 991` + `USER misskey` で 991 起動なので、drop-in 互換にも security 的にもずっとズレていた。本 PR で distroless 化と同時に整える。

## 主な変更点

- **`Dockerfile`**:
  - runtime stage を `gcr.io/distroless/static-debian13` に。`ca-certificates` / `tzdata` は distroless 同梱なので `apk add` 削除。
  - `USER 991:991` を numeric で追加 (Misskey TS と同じ UID/GID)。distroless static には UID 991 の `/etc/passwd` エントリが無いが、mk-go は `os/user.Current()` を呼ばないので numeric UID で問題なく動く。`:nonroot` tag (UID 65532) は drop-in 互換を壊すので不採用。
- **`cmd/misskey/main.go`**: `-healthcheck` フラグを追加。config を読んで `http://127.0.0.1:<port>/healthz` を 3s timeout で GET し、200 OK で `exit 0`、それ以外で `exit 1`。distroless image には wget/curl が無いので healthcheck を binary 自身で完結させる。
- **`docker-compose.dropin.mk.yml`** / **`docker-compose.dropin-frontend.mk.yml`** / **`docker-compose.federation.misskey.yml`**: healthcheck を `wget` 形式から `["CMD", "/app/misskey", "-healthcheck", "-config", ".config/default.yml"]` に置換。
- **`docker-compose.yml`**: `./files` volume mount コメントに UID 991 要件 + chown 手順を注記。
- **`docs/deployment.md`** / **`docs/migration-from-ts.md`**: ファイルストレージの UID 991 要件 + 旧 root 構成からの upgrade で必要な `sudo chown -R 991:991 ./files` 手順を記載。

## 検証

```
$ make docker-build
... #26 unpacking to docker.io/library/misskey-go:latest done

$ docker images misskey-go:latest --format '{{.Size}}'
101MB                # Step 3 alpine 構成 112MB から -11MB / -10%

$ docker inspect misskey-go:latest --format '{{.Config.User}}'
991:991              # USER directive baked in

$ docker run --rm misskey-go:latest -version
Usage of /app/misskey:
  -config string ...
  -healthcheck ...   # binary 起動 OK、新フラグも登録されている

$ docker run --rm misskey-go:latest -healthcheck -config .config/default.yml
healthcheck: Get "http://127.0.0.1:3000/healthz": dial tcp 127.0.0.1:3000: connect: connection refused
exit=1               # UID 991 下でも config 読込 + HTTP get の経路は動く
```

`make fmt` / `make lint` / `go test ./cmd/...` クリーン。

## Image size 推移

| Step | Runtime base | binary | USER | Image size |
|---|---|---|---|---|
| Pre-#613 | alpine 3.21 | dynamic + cgo | root | (計測なし) |
| Step 3 (#620) | alpine 3.21 | static | root | 112MB |
| **Step 4 (this)** | **distroless/static-debian13** | **static** | **991:991** | **101MB** |

## Operator への upgrade 注記

旧 root 構成で運用していた mk-go-only operator は、`./files` ディレクトリの所有権を一度だけ揃える必要がある:

```
sudo chown -R 991:991 ./files
```

Misskey TS から swap してきた operator は元々 991 所有なのでそのまま動く (まさに drop-in 互換)。

## Closes

Closes #621

(親 issue #613 は Step 5 完了まで open のまま)