### PR TITLE
Fix #610: PromotePending tx 周辺の重複統合 + error 細分化 + mirror コメント

### DIFF
--- a/internal/api/signup/handler.go
+++ b/internal/api/signup/handler.go
@@ -216,6 +216,9 @@ func (h *Handler) SignupPending(c echo.Context) error {
 			return c.JSON(http.StatusConflict, apierr.Error("USERNAME_ALREADY_EXISTS", "Username already exists.", "0a504947-b888-4a99-9f62-8c4a0f3a3dab"))
 		case coresignup.ErrInvitationAlreadyUsed:
 			return c.JSON(http.StatusConflict, apierr.Error("INVITATION_ALREADY_USED", "Invitation already used.", "5b81b5e2-2c0b-4d8a-9b71-1a3e1d4d3f6a"))
+		case coresignup.ErrInvitationRevoked:
+			// admin が ticket を削除した状態 (#610 item 2)。AlreadyUsed と区別。
+			return c.JSON(http.StatusGone, apierr.Error("INVITATION_REVOKED", "Invitation has been revoked.", "9b1aa3e7-f8e7-4c92-8d7c-2c0e5b9d8a4b"))
 		default:
 			return c.JSON(http.StatusInternalServerError, apierr.Error("INTERNAL_ERROR", "Internal error.", "5d37dbcb-891e-41ca-a3d6-e690c97775ac"))
 		}

--- a/internal/core/signup/signup_service.go
+++ b/internal/core/signup/signup_service.go
@@ -4,6 +4,7 @@ import (
 	"crypto/rand"
 	"encoding/hex"
 	"errors"
+	"log/slog"
 	"strings"
 	"time"
 
@@ -34,6 +35,11 @@ var (
 	// 経路で SELECT FOR UPDATE 後に usedById を確認することで concurrent burst
 	// の race を完全に閉じる (#604)。
 	ErrInvitationAlreadyUsed = errors.New("invitation already used")
+	// ErrInvitationRevoked is returned when the invitation ticket linked to a
+	// pending signup has been deleted (typically by an admin) before the user
+	// completed the email verification. AlreadyUsed と区別することで frontend
+	// が「使用済」「失効」をローカライズで分けられる (#610 item 2)。
+	ErrInvitationRevoked = errors.New("invitation revoked")
 )
 
 // PendingSignupTTL is the default lifetime of a pending signup row. Misskey TS
@@ -293,6 +299,13 @@ func (s *Service) PromotePending(code string) (*SignupResult, error) {
 
 // promotePendingTx は db.Transaction 内で user 作成 / ticket 消費 / pending
 // 削除を atomic に行う本番経路。
+//
+// IMPORTANT: promotePendingTx と promotePendingNoTx は **mirror で維持** する。
+// username collision check / user-profile create / keypair gen / webhook hook /
+// SignupResult build の順序や意味が両者でずれると挙動が divergence する。
+// 片方を変更したら必ずもう片方も同じ shape に揃えること (#610 item 3)。
+// tx 経路は raw GORM (tx.Create, tx.Where 等) を直接呼び、noTx 経路は repo
+// 経由 (mock 互換のため)。
 func (s *Service) promotePendingTx(pending *model.UserPending) (*SignupResult, error) {
 	lower := strings.ToLower(pending.Username)
 	token := generateToken()
@@ -308,8 +321,16 @@ func (s *Service) promotePendingTx(pending *model.UserPending) (*SignupResult, e
 		if pending.InvitationTicketID != nil {
 			ticket, err := s.ticketRepo.FindByIDForUpdateTx(tx, *pending.InvitationTicketID)
 			if err != nil {
-				// ticket が消えている等 — pending 経由の登録は成立させない
-				return ErrInvitationAlreadyUsed
+				// gorm.ErrRecordNotFound は admin が ticket を revoke したケース
+				// なので "Revoked" として明示。それ以外 (DB error) は internal
+				// として上に伝える (handler が 500 を返す)。
+				// 観測用 slog.Warn で運用側に signal を出す (#610 item 2)。
+				if errors.Is(err, gorm.ErrRecordNotFound) {
+					slog.Warn("promote pending: invitation ticket missing",
+						"pendingId", pending.ID, "ticketId", *pending.InvitationTicketID)
+					return ErrInvitationRevoked
+				}
+				return err
 			}
 			if ticket.UsedByID != nil {
 				return ErrInvitationAlreadyUsed
@@ -407,6 +428,12 @@ func (s *Service) promotePendingTx(pending *model.UserPending) (*SignupResult, e
 
 // promotePendingNoTx は db 未配線の mock テスト経路 (transaction 無し)。
 // production では使わない (router 配線時に SetDB 必須)。
+//
+// IMPORTANT: promotePendingTx と mirror で維持すること。詳細は
+// promotePendingTx の doc コメント参照 (#610 item 3)。
+// invitation ticket の lock / consume は tx 経路でしか行えないため、本経路
+// では InvitationTicketID を SignupResult に伝搬するだけで MarkUsed しない
+// (handler が non-tx 経路と判定して fallback consume する)。
 func (s *Service) promotePendingNoTx(pending *model.UserPending) (*SignupResult, error) {
 	lower := strings.ToLower(pending.Username)
 	if _, err := s.userRepo.FindByUsernameLower(lower, nil); err == nil {

--- a/internal/core/signup/signup_service_integration_test.go
+++ b/internal/core/signup/signup_service_integration_test.go
@@ -1,6 +1,7 @@
 package signup_test
 
 import (
+	"errors"
 	"sync"
 	"testing"
 	"time"
@@ -261,8 +262,8 @@ type integrationHook struct{ calls int }
 func (h *integrationHook) OnUserCreated(_ *model.User) { h.calls++ }
 
 // pending row 作成後に ticket を delete すると、PromotePending tx 内の
-// FindByIDForUpdateTx が NotFound になり ErrInvitationAlreadyUsed として
-// 返る (defensive な race / admin-side ticket revoke 対応)。
+// FindByIDForUpdateTx が NotFound になり ErrInvitationRevoked として返る
+// (#610 item 2: AlreadyUsed と区別)。
 func TestPromotePending_TxTicketRevoked(t *testing.T) {
 	db := integrationDB(t)
 	const prefix = "itrev_"
@@ -283,5 +284,51 @@ func TestPromotePending_TxTicketRevoked(t *testing.T) {
 	require.NoError(t, db.Where("id = ?", ticket.ID).Delete(&model.RegistrationTicket{}).Error)
 
 	_, err = svc.PromotePending(row.Code)
-	assert.ErrorIs(t, err, signup.ErrInvitationAlreadyUsed)
+	assert.ErrorIs(t, err, signup.ErrInvitationRevoked)
+	// AlreadyUsed と混同しないこと (#610 item 2)
+	assert.NotErrorIs(t, err, signup.ErrInvitationAlreadyUsed)
+}
+
+// FindByIDForUpdateTx が NotFound 以外の DB error を返した場合は、Service が
+// ErrInvitationRevoked にすり替えず生 error を返して handler が 500 を出せる
+// ようにする (#610 item 2)。
+func TestPromotePending_TxTicketRepoGenericError(t *testing.T) {
+	db := integrationDB(t)
+	const prefix = "iterr_"
+	defer cleanupSignupRows(t, db, prefix)
+
+	// real DB + 故意に error を返す ticket repo を組み合わせる
+	idGen, _ := id.NewGenerator("aidx")
+	userRepo := repository.NewUserRepository(db)
+	pendingRepo := repository.NewUserPendingRepository(db)
+	metaRepo := testutil.NewMockMetaRepository()
+	metaRepo.Meta = &model.Meta{ID: "x"}
+
+	svc := signup.NewService(userRepo, metaRepo, idGen)
+	svc.SetUserPendingRepo(pendingRepo)
+	svc.SetTicketRepo(&errorTicketRepo{
+		err: errors.New("simulated DB error"),
+	})
+	svc.SetDB(db)
+
+	tid := prefix + "tid"
+	row, err := svc.CreatePending(prefix+"err", "err@it.example", "pw", &tid)
+	require.NoError(t, err)
+
+	_, err = svc.PromotePending(row.Code)
+	require.Error(t, err)
+	// NotFound 以外の error は ErrInvitationRevoked にすり替えない
+	assert.NotErrorIs(t, err, signup.ErrInvitationRevoked)
+	assert.NotErrorIs(t, err, signup.ErrInvitationAlreadyUsed)
+}
+
+// errorTicketRepo は FindByIDForUpdateTx で常に指定 error を返す test double。
+// Create / List / Delete 等は本テストで使わないので最小実装。
+type errorTicketRepo struct {
+	repository.RegistrationTicketRepository
+	err error
+}
+
+func (r *errorTicketRepo) FindByIDForUpdateTx(_ *gorm.DB, _ string) (*model.RegistrationTicket, error) {
+	return nil, r.err
 }

--- a/internal/server/router.go
+++ b/internal/server/router.go
@@ -112,7 +112,6 @@ import (
 	"github.com/shiroha-a/mk/internal/server/middleware"
 	"github.com/shiroha-a/mk/internal/stream"
 	"github.com/shiroha-a/mk/internal/stream/channels"
-	"gorm.io/gorm"
 	"log/slog"
 )
 
@@ -868,7 +867,10 @@ func (s *Server) setupRoutes() {
 	if captchaSvc != nil {
 		signupHandler.SetCaptcha(captchaSvc)
 	}
-	signupHandler.SetTicketStore(&gormTicketStore{db: s.db})
+	// signupTicketRepo は repository.RegistrationTicketRepository で、
+	// apisignup.TicketStore (FindByCode + MarkUsed) を superset として満たす。
+	// 旧 gormTicketStore wrapper を直接 repo に置き換え (#610 item 1)。
+	signupHandler.SetTicketStore(signupTicketRepo)
 	signupHandler.SetTestMode(s.config.TestMode)
 	// emailRequiredForSignup フローの確認メール送信。SMTP infra が enabled の
 	// ときのみ closure を渡す (reset-password と同じパターン)。
@@ -2280,27 +2282,6 @@ func generateInviteCode() string {
 		b[i] = chars[b[i]%byte(len(chars))]
 	}
 	return string(b)
-}
-
-// gormTicketStore implements apisignup.TicketStore using GORM.
-type gormTicketStore struct {
-	db *gorm.DB
-}
-
-func (s *gormTicketStore) FindByCode(code string) (*model.RegistrationTicket, error) {
-	var ticket model.RegistrationTicket
-	if err := s.db.Where(`"code" = ?`, code).First(&ticket).Error; err != nil {
-		return nil, err
-	}
-	return &ticket, nil
-}
-
-func (s *gormTicketStore) MarkUsed(ticketID, userID string) error {
-	now := time.Now()
-	return s.db.Model(&model.RegistrationTicket{}).Where(`"id" = ?`, ticketID).Updates(map[string]any{
-		"usedById": userID,
-		"usedAt":   now,
-	}).Error
 }
 
 // notifReaderAdapter bridges stream.NotificationReader to


### PR DESCRIPTION
## Summary

#609 (PromotePending transaction 化 PR) self-review で挙げた **3 項目を 1 PR で一括対応**。すべて低リスク cleanup なので統合。

## 主な変更点

### (1) \`gormTicketStore\` (router.go) を repository に統合

router.go の \`gormTicketStore\` wrapper (FindByCode / MarkUsed) は #609 で \`RegistrationTicketRepository\` に同等メソッドを追加した時点で重複実装になっていた。

- \`signupTicketRepo\` (= \`repository.RegistrationTicketRepository\`) を \`signupHandler.SetTicketStore\` に直接渡す
- \`apisignup.TicketStore\` interface は repo の superset なので satisfaction で素通り
- \`gormTicketStore\` 構造体 + 2 メソッド + \`gorm.io/gorm\` import を router.go から削除 (18 行減)

### (2) \`ErrInvitationRevoked\` を分離 + 観測ログ

\`promotePendingTx\` で \`FindByIDForUpdateTx\` の error が「ticket 不存在」「DB error」を区別せず一律 \`ErrInvitationAlreadyUsed\` で返していたのを修正:

\`\`\`go
ticket, err := s.ticketRepo.FindByIDForUpdateTx(tx, *pending.InvitationTicketID)
if err != nil {
    if errors.Is(err, gorm.ErrRecordNotFound) {
        slog.Warn("promote pending: invitation ticket missing", ...)
        return ErrInvitationRevoked  // ← 新規
    }
    return err  // DB error → 500
}
\`\`\`

handler のマッピング:
- \`ErrInvitationRevoked\` → 410 \`INVITATION_REVOKED\` (UUID: \`9b1aa3e7-f8e7-4c92-8d7c-2c0e5b9d8a4b\`)
- \`ErrInvitationAlreadyUsed\` → 409 (既存)

frontend がローカライズで「使用済」と「失効/取り消し済」を分けられる + \`slog.Warn\` で運用 signal。

### (3) \`promotePendingTx\` / \`promotePendingNoTx\` の mirror コメント

両 method の doc 先頭に **「IMPORTANT: must be mirror で維持」** 注意書きを追加 (#610 option a)。option b (interface 共通化) / option c (noTx 廃止) はコストに対する benefit が薄いため見送り。片方変更時にもう片方も揃える運用ルールをドキュメントで保証する形。

## Testing

- \`make fmt && make lint\`: 緑
- \`go test -race\`:
  - core/signup: **90.6%** (>90%)
  - api/signup: **90.4%** (>90%)
  - 全 \`make test\` 緑

新規テスト:
- \`TxTicketRepoGenericError\`: \`FindByIDForUpdateTx\` が NotFound 以外の DB error を返した場合に \`ErrInvitationRevoked\` にすり替えず生 error を伝播することを確認 (\`errorTicketRepo\` test double を embed で実装)

更新:
- \`TxTicketRevoked\`: \`ErrInvitationRevoked\` を期待する形に変更 + \`NotErrorIs(ErrInvitationAlreadyUsed)\` で混同しないことも assert

## 後方互換

- \`apisignup.TicketStore\` interface は変更なし、wiring のみ更新
- \`ErrInvitationRevoked\` は新規エラーで既存 caller には影響なし
- handler の error mapping 追加のみで既存 endpoint shape に変更なし

## Closes

Closes #610

🤖 Generated with [Claude Code](https://claude.com/claude-code)