### PR TITLE
Fix #624: dropin conftest で meta.federation='all' を明示的に開く

### DIFF
--- a/tests/dropin/conftest.py
+++ b/tests/dropin/conftest.py
@@ -81,3 +81,26 @@ def alice(instance_a: MisskeyLikeClient) -> dict:
 def bob(instance_b: MisskeyLikeClient) -> dict:
     """Root user on instance B."""
     return _ensure_user_id(instance_b, instance_b.create_admin("bob", "password1234"))
+
+
+@pytest.fixture(scope="session", autouse=True)
+def open_federation(alice: dict, bob: dict, instance_a: MisskeyLikeClient, instance_b: MisskeyLikeClient) -> None:
+    """Set meta.federation='all' on both instances so deliver tasks aren't dropped.
+
+    Misskey TS は migration 1754019326356 (2025-08-01) で meta.federation の
+    DEFAULT を 'all' から 'none' に下げた (admin が明示的に opt-in する設計に
+    変更)。mk-go は TS の schema をそのまま継承するので fresh install では
+    'none' で起動し、deliver_service.isBlockedInbox が IsAllowed=false で
+    silent drop してしまう (#624)。
+
+    本番 operator は /api/admin/update-meta で federation を開く想定だが、
+    dropin smoke test は clean DB から立ち上げて連合動作を期待するので、ここ
+    で同等の操作を fixture として実施する。
+
+    TS-A (misskey:2025.2.1 = 2025-08 migration 前) では DEFAULT 'all' のま
+    まなのでこの呼び出しは no-op。mk-A overlay (= clean DB から mk-go 起動)
+    では initial value 'none' を 'all' に上書きする。idempotent なので両方に
+    対して呼び出せば良い。
+    """
+    instance_a._api("admin/update-meta", {"federation": "all"})
+    instance_b._api("admin/update-meta", {"federation": "all"})


### PR DESCRIPTION
## Summary

#624 で発覚した「\`make dropin-mk-test\` の \`test_alice_follows_bob\` が timeout で fail する」問題を、test 側で federation を明示的に開くことで解消する。

## 経緯 / 根本原因

調査の結果、これは **TS と一致した挙動** で、mk-go 側に bug は無い:

1. \`third_party/misskey/packages/backend/migration/1727512908322-meta-federation.js\` (2024-09-28): \`federation\` カラム追加、DEFAULT \`'all'\`
2. \`third_party/misskey/packages/backend/migration/1754019326356-tweakDefaultFederationSettings.js\` (2025-08-01): **DEFAULT \`'all'\` → \`'none'\`** に変更 (admin が明示的に opt-in する設計に)

mk-go は TS の schema 全 migration を順番に適用するので、現状の DEFAULT は \`'none'\`。これは modern TS の fresh install と同じ。\`isBlockedInbox\` (\`internal/core/federation/deliver_service.go\`) が \`IsAllowed=false\` で deliver task を silent drop するのも TS と一致した挙動。

実本番 operator は \`/api/admin/update-meta\` で federation を opt-in することが期待されている。dropin smoke test は clean DB から立ち上げて連合動作を期待するので、**test fixture で同等の手順** を踏ませる。

## 主な変更点

- \`tests/dropin/conftest.py\` に \`open_federation\` autouse fixture を追加。\`alice\` / \`bob\` (admin) bootstrap 後に \`instance_a\` / \`instance_b\` 両方で \`admin/update-meta\` を呼んで \`federation: "all"\` を設定する。
- TS-A (\`misskey:2025.2.1\` = 2025-08 migration 前) は DEFAULT \`'all'\` のままなので no-op、mk-A overlay (clean DB から mk-go 起動) では \`'none'\` → \`'all'\` に上書きする。idempotent。

## 検証

```
$ make dropin-mk-test
======================= 20 passed, 2 warnings in 25.59s ========================
# breakdown:
# - test_smoke.py             6 件 (instance_a/b health, webfinger, follow, note delivery)
# - test_swap_setup.py        6 件
# - test_swap_verify.py       8 件
```

修正前は \`test_alice_follows_bob\` が \`TimeoutError: bob sees alice as follower\` で fail していた。

\`make dropin-swap-test\` (= nightly e2e workflow が走らせる本命) も continue to pass。

## 非対応 (別 issue 化候補)

- 本番 operator 向けに「初回起動後 \`/api/admin/update-meta\` で federation を opt-in する必要がある」を deployment.md / migration-from-ts.md に追記するのは別 PR で扱う。

## Closes

Closes #624