### PR TITLE
Refs #571 (item 3): rateLimitFactor の stale TODO を削除

### DIFF
--- a/internal/server/middleware/ratelimit_defs.go
+++ b/internal/server/middleware/ratelimit_defs.go
@@ -7,7 +7,8 @@ import "time"
 //
 // Source: third_party/misskey/packages/backend/src/server/api/endpoints/
 //
-// TODO: Support rateLimitFactor from user role policies.
+// rateLimitFactor (role policies) は RateLimiter.SetPolicyProvider 経由で
+// runtime に反映される (PR #617 / #606 item 4)。
 var DefaultEndpointLimits = map[string]*EndpointLimit{
 	// ── AP ─────────────────────────────────────────────
 	"ap/get":  {Duration: time.Hour, Max: 30},


### PR DESCRIPTION
## Summary

#571 audit で見つかった stale TODO comment を削除。1 行変更の trivial cleanup。

## 背景

#571 item 3 (\`user role policies の rateLimitFactor\`) は **#606 item 4 として PR #617 で実装済**:
- \`middleware.RateLimiter.SetPolicyProvider\` で role-aware factor 注入
- \`userFactor\` で \`rateLimitFactor\` 抽出 + clamp
- \`scaledMax\` で base Max を scale

しかし \`internal/server/middleware/ratelimit_defs.go:10\` の
\`// TODO: Support rateLimitFactor from user role policies.\`
コメントが #617 で消し忘れたまま残っていた。

## 変更

```go
- // TODO: Support rateLimitFactor from user role policies.
+ // rateLimitFactor (role policies) は RateLimiter.SetPolicyProvider 経由で
+ // runtime に反映される (PR #617 / #606 item 4)。
```

実装済の事実を pointer として残す形に書き換え。

## Refs

Refs #571 — item 3 が完了済であることを反映 (close は item 1, 2 の処遇判断後)。

🤖 Generated with [Claude Code](https://claude.com/claude-code)