### PR TITLE
Fix #629: local note 作成時に :emoji_code: を抽出して note.Emojis に詰める

### DIFF
--- a/internal/activitypub/mfm/extract.go
+++ b/internal/activitypub/mfm/extract.go
@@ -1,0 +1,43 @@
+package mfm
+
+// CollectEmojiCodes parses each input as MFM and returns the union of
+// custom emoji names (from :code: tokens) found across all texts, dedup'd
+// and ordered by first appearance.
+//
+// 用途: note 作成 / user プロフィール更新時に text + cw 等を渡して
+// note.Emojis / user.Emojis に格納する emoji 名一覧を得る (#629)。
+// 受信側 (federation/resolver) は AP Tag から拾うが、送信側はこちらで
+// MFM AST を walk して拾う。
+//
+// 返り値の各要素は \`:\` を含まない bare name (例: "foo")。Empty input は
+// nil を返す。
+func CollectEmojiCodes(texts ...string) []string {
+	if len(texts) == 0 {
+		return nil
+	}
+	seen := make(map[string]struct{})
+	var out []string
+	var walk func(n *Node)
+	walk = func(n *Node) {
+		if n.Type == NodeEmojiCode {
+			if name, ok := n.Props["name"].(string); ok && name != "" {
+				if _, dup := seen[name]; !dup {
+					seen[name] = struct{}{}
+					out = append(out, name)
+				}
+			}
+		}
+		for _, c := range n.Children {
+			walk(c)
+		}
+	}
+	for _, t := range texts {
+		if t == "" {
+			continue
+		}
+		for _, n := range Parse(t) {
+			walk(n)
+		}
+	}
+	return out
+}

--- a/internal/activitypub/mfm/extract_test.go
+++ b/internal/activitypub/mfm/extract_test.go
@@ -1,0 +1,51 @@
+package mfm
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestCollectEmojiCodes_Empty(t *testing.T) {
+	assert.Nil(t, CollectEmojiCodes())
+	assert.Nil(t, CollectEmojiCodes(""))
+	assert.Nil(t, CollectEmojiCodes("", "", ""))
+}
+
+func TestCollectEmojiCodes_PlainText(t *testing.T) {
+	assert.Nil(t, CollectEmojiCodes("hello world"))
+}
+
+func TestCollectEmojiCodes_Single(t *testing.T) {
+	assert.Equal(t, []string{"foo"}, CollectEmojiCodes(":foo:"))
+	assert.Equal(t, []string{"foo"}, CollectEmojiCodes("hello :foo: world"))
+}
+
+func TestCollectEmojiCodes_Multiple_DedupAndOrder(t *testing.T) {
+	got := CollectEmojiCodes(":foo: :bar: :foo: :baz:")
+	assert.Equal(t, []string{"foo", "bar", "baz"}, got)
+}
+
+func TestCollectEmojiCodes_NestedInsideMarkup(t *testing.T) {
+	// MFM の bold / italic / fn 等の中にあっても拾えること
+	got := CollectEmojiCodes("**:foo:** *:bar:* $[x2 :baz:]")
+	assert.ElementsMatch(t, []string{"foo", "bar", "baz"}, got)
+}
+
+func TestCollectEmojiCodes_AcrossMultipleTexts(t *testing.T) {
+	// text + cw のような複数 source からの dedup
+	got := CollectEmojiCodes("body :foo:", "cw :bar:", "more :foo: :baz:")
+	assert.Equal(t, []string{"foo", "bar", "baz"}, got)
+}
+
+func TestCollectEmojiCodes_IgnoresUnicodeEmoji(t *testing.T) {
+	// Unicode emoji (😀) は NodeUnicodeEmoji なので含めない
+	assert.Nil(t, CollectEmojiCodes("hello 😀 world"))
+}
+
+func TestCollectEmojiCodes_IgnoresMalformed(t *testing.T) {
+	// 閉じ \`:\` が無いものは emoji code として parse されない
+	assert.Nil(t, CollectEmojiCodes("hello :foo bar"))
+	// 英数字 + _ + - 以外は emoji name として parse されない (parser.go::tryEmojiCode)
+	assert.Nil(t, CollectEmojiCodes(":foo bar:"))
+}

--- a/internal/core/note/note_create_service.go
+++ b/internal/core/note/note_create_service.go
@@ -9,6 +9,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/shiroha-a/mk/internal/activitypub/mfm"
 	"github.com/shiroha-a/mk/internal/entity"
 	"github.com/shiroha-a/mk/internal/misc/id"
 	"github.com/shiroha-a/mk/internal/model"
@@ -488,6 +489,23 @@ func (s *CreateService) Create(in CreateInput) (*model.Note, error) {
 			}
 		} else {
 			note.Mentions = ExtractMentions(*in.Text)
+		}
+	}
+
+	// Custom emoji 名抽出: text + cw を MFM parse して :code: トークンを集める
+	// (#629)。連合配信時に renderer.addEmojiTags が note.Emojis を walk して
+	// AP Note.tag に Emoji エントリを足すので、ここで埋めないと連合先で
+	// custom emoji が画像化されず文字列のまま表示される。
+	{
+		var text, cw string
+		if in.Text != nil {
+			text = *in.Text
+		}
+		if in.CW != nil {
+			cw = *in.CW
+		}
+		if names := mfm.CollectEmojiCodes(text, cw); len(names) > 0 {
+			note.Emojis = names
 		}
 	}
 

--- a/internal/core/note/note_create_service_test.go
+++ b/internal/core/note/note_create_service_test.go
@@ -181,6 +181,36 @@ func TestCreateService_MentionExtraction(t *testing.T) {
 	assert.Equal(t, []string{"alice", "bob"}, []string(created.Mentions))
 }
 
+// 連合配信時に renderer.addEmojiTags が note.Emojis を walk するので、
+// note 作成時点で text + cw 中の :code: トークンを抽出して埋めておく必要が
+// ある (#629)。空の場合は note.Emojis は空配列のまま。
+func TestCreateService_EmojiExtraction(t *testing.T) {
+	svc, _, _ := newCreateService(t)
+	user := &model.User{ID: "user1"}
+
+	t.Run("text only", func(t *testing.T) {
+		text := "hello :foo: and :bar: with :foo: again"
+		created, err := svc.Create(note.CreateInput{User: user, Text: &text})
+		require.NoError(t, err)
+		assert.Equal(t, []string{"foo", "bar"}, []string(created.Emojis))
+	})
+
+	t.Run("text + cw merged and dedup'd", func(t *testing.T) {
+		text := "body :foo: :baz:"
+		cw := "warning :bar: :foo:"
+		created, err := svc.Create(note.CreateInput{User: user, Text: &text, CW: &cw})
+		require.NoError(t, err)
+		assert.Equal(t, []string{"foo", "baz", "bar"}, []string(created.Emojis))
+	})
+
+	t.Run("plain text yields empty Emojis", func(t *testing.T) {
+		text := "no custom emoji here, only 😀"
+		created, err := svc.Create(note.CreateInput{User: user, Text: &text})
+		require.NoError(t, err)
+		assert.Empty(t, []string(created.Emojis))
+	})
+}
+
 func TestCreateService_MentionResolution_WithUserRepo(t *testing.T) {
 	svc, _, _ := newCreateService(t)
 	userRepo := testutil.NewMockUserRepository()


### PR DESCRIPTION
## Summary

連合先 instance で mk-go が配信したノートの custom emoji が **画像化されず文字列のまま** 表示されるバグの修正 (#629)。

## 原因

\`internal/core/note/note_create_service.go::CreateService.Create()\` の note 作成パスは Mention を \`ExtractMentions(text)\` で抽出して \`note.Mentions\` に格納しているが、**emoji の同等処理が欠けていた** ため \`note.Emojis\` が DB default \`'{}'\` のまま保存される。連合配信時の \`internal/activitypub/renderer.go::Renderer.RenderNote()\` line 361 \`r.addEmojiTags(&out.Tag, n.Emojis, nil)\` は \`n.Emojis\` を iterate して各名前を resolve するが、空配列なので AP \`Note.tag\` に \`Emoji\` エントリが付かず、受信側は icon URL が無いので custom emoji として描画できない。

逆方向 (受信時 \`internal/core/federation/resolver.go::resolveOrUpsertNote()\` line 633) は \`extractEmojiTags\` で AP \`Tag\` から拾えているので、**送信側だけが片手落ち** の状態だった。

## 主な変更点

- **\`internal/activitypub/mfm/extract.go\`** (新規)
  \`CollectEmojiCodes(texts ...string) []string\` を追加。可変長 texts を parse して \`NodeEmojiCode\` を AST walk で集め、dedup + first-seen 順で返す。\`**:foo:**\` / \`*:bar:*\` / \`$[x2 :baz:]\` のような bold / italic / fn ネストも拾えることを単体テストで確認。
- **\`internal/core/note/note_create_service.go::Create()\`**
  Mention 抽出ブロック直後で \`text + cw\` を \`mfm.CollectEmojiCodes\` に渡して \`note.Emojis\` に格納する。空ならば DB default \`'{}'\` のまま。
- **\`internal/core/note/note_create_service_test.go\`**
  \`TestCreateService_EmojiExtraction\` を追加。text のみ / text + cw dedup / plain text (Unicode emoji 込み) の 3 ケースをカバー。

## スコープ外 (別 issue 候補)

調査中に隣接で気付いた点 (本 PR では触らない):

- \`note.Tags\` (hashtag) も同じく未抽出。\`#tag\` を含むノートを連合先に流しても \`Hashtag\` tag が出ない
- \`user.Emojis\` (profile displayName / description) も未抽出 → リモートの user プロフィールで custom emoji が見えない
- file alt-text からの emoji 抽出 (TS は \`extractCustomEmojisFromMfm\` で files.comment まで walk する) も未対応

## 検証

```
$ go test -race -count=1 -coverprofile=... ./internal/core/note/ ./internal/activitypub/mfm/
ok  github.com/shiroha-a/mk/internal/core/note          1.1s  coverage: 93.4%
ok  github.com/shiroha-a/mk/internal/activitypub/mfm    1.1s  coverage: 91.5%
```

- 既存テスト全 pass
- 新規テスト: \`mfm.TestCollectEmojiCodes_*\` 8 件、\`note.TestCreateService_EmojiExtraction\` 3 sub-case
- \`make fmt\` / \`make lint\` クリーン

連合先での実描画確認は #627 (dropin conftest \`open_federation\` fixture) が merge されてから dropin-mk-test の federation note シナリオで実検証する想定 (PR CI には含まれない nightly 経路)。

## Closes

Closes #629