### PR TITLE
Refs #571 (item 1): デフォルト jobQueueDriver を asynq → mkq に変更

### DIFF
--- a/.config/default.yml.example
+++ b/.config/default.yml.example
@@ -151,17 +151,24 @@ redis:
 
 # mk-go specific: select the job queue runtime.
 #
-#   - 'asynq' (default): historical hibiken/asynq based runtime.
-#                        Battle-tested with mk-go since day one.
-#   - 'mkq':              shiroha-a/mkq based runtime. BullMQ wire-
-#                         compatible, makes the admin queue dashboard
-#                         render correctly under the upstream Misskey
-#                         TS frontend (which assumes BullMQ).
+#   - 'mkq' (default, recommended): shiroha-a/mkq based runtime.
+#                        BullMQ wire-compatible — admin queue dashboard
+#                        renders correctly under the upstream Misskey
+#                        TS frontend (which assumes BullMQ). Supports
+#                        per-queue concurrency / rate-limit knobs (see
+#                        `<queue>JobConcurrency` / `<queue>JobPerSec`).
+#   - 'asynq': legacy hibiken/asynq based runtime. Kept for migration
+#                        path. **Future-deprecation candidate** — once
+#                        mkq is fully battle-tested in production we
+#                        plan to remove asynq entirely. New deploys
+#                        should use 'mkq'. Note that `inboxJobConcurrency`
+#                        and per-queue rate-limit settings only partially
+#                        apply under asynq (see docs/configuration.md).
 #
 # Switching between drivers does not migrate in-flight jobs; flush
 # the queue or wait for completion before changing.
 #
-#jobQueueDriver: asynq
+#jobQueueDriver: mkq
 
 #   ┌───────────────────────────────┐
 #───┘ Fulltext search configuration └─────────────────────────────

--- a/.config/docker.yml.example
+++ b/.config/docker.yml.example
@@ -96,13 +96,16 @@ redis:
 
 # mk-go specific: select the job queue runtime.
 #
-#   - 'asynq' (default): hibiken/asynq based runtime.
-#   - 'mkq':              shiroha-a/mkq based, BullMQ wire-compatible
-#                         (makes the admin queue dashboard render
-#                          correctly under the upstream Misskey TS
-#                          frontend).
+#   - 'mkq' (default, recommended): shiroha-a/mkq based, BullMQ wire-
+#                         compatible (makes the admin queue dashboard
+#                         render correctly under the upstream Misskey
+#                         TS frontend) + supports per-queue concurrency
+#                         and rate-limit knobs.
+#   - 'asynq': legacy hibiken/asynq based runtime. **Future-deprecation
+#                         candidate** — once mkq is fully battle-tested
+#                         we plan to remove asynq entirely.
 #
-#jobQueueDriver: asynq
+#jobQueueDriver: mkq
 
 #   ┌───────────────────────────────┐
 #───┘ Fulltext search configuration └─────────────────────────────

--- a/deploy/uds/config/default.yml.example
+++ b/deploy/uds/config/default.yml.example
@@ -146,13 +146,16 @@ redis:
 
 # mk-go specific: select the job queue runtime.
 #
-#   - 'asynq' (default): hibiken/asynq based runtime.
-#   - 'mkq':              shiroha-a/mkq based, BullMQ wire-compatible
-#                         (makes the admin queue dashboard render
-#                          correctly under the upstream Misskey TS
-#                          frontend).
+#   - 'mkq' (default, recommended): shiroha-a/mkq based, BullMQ wire-
+#                         compatible (makes the admin queue dashboard
+#                         render correctly under the upstream Misskey
+#                         TS frontend) + supports per-queue concurrency
+#                         and rate-limit knobs.
+#   - 'asynq': legacy hibiken/asynq based runtime. **Future-deprecation
+#                         candidate** — once mkq is fully battle-tested
+#                         we plan to remove asynq entirely.
 #
-#jobQueueDriver: asynq
+#jobQueueDriver: mkq
 
 #   ┌───────────────────────────────┐
 #───┘ Fulltext search configuration └─────────────────────────────

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -39,7 +39,7 @@ cp .config/docker.yml.example .config/docker.yml
 | `disableEndpointRateLimits` | bool | `false` | per-endpoint rate limit table 全体を無効化。Misskey TS の `NODE_ENV=development` 相当で、ベンチマーク等で公正比較する用途専用。**本番で絶対に使わない** |
 | `pidFile` | string | - | PIDファイルパス |
 | `testMode` | bool | `false` | テスト用エンドポイント(/api/reset-db)を有効化。**本番で絶対に使わない** |
-| `jobQueueDriver` | string | `"asynq"` | ジョブキュー実装の選択。`asynq` (デフォルト) または `mkq` (BullMQ互換)。`mkq`にすると admin queue 画面が BullMQ 前提の Misskey TS frontend と wire-compatible になる。`MK_JOBQUEUEDRIVER`で上書き可。 |
+| `jobQueueDriver` | string | `"mkq"` | ジョブキュー実装の選択。`mkq` (デフォルト、推奨) または `asynq` (legacy)。`mkq` は BullMQ wire-compatible で admin queue 画面が Misskey TS frontend 前提のまま動く + per-queue concurrency / rate-limit が効く。`asynq` は **将来削除予定** (mkq の安定性確保後) のため新規 deploy は `mkq` 推奨。`MK_JOBQUEUEDRIVER`で上書き可。 |
 
 ### データベース (`db.*`)
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -629,17 +629,22 @@ func resolveRedisOrDefault(opts *RedisOptions, fallback RedisOptions, host strin
 }
 
 // resolveJobQueueDriver normalises the jobQueueDriver config value.
-// Empty / whitespace falls back to "asynq". Unknown non-empty values
-// return an error: silently swapping a typo (e.g. "mkqq") for asynq
-// hides operator intent, especially given that internal/server/
-// queue_factory.go also rejects unknown driver names — surfacing the
-// failure here keeps the two layers consistent and the boot log
-// readable.
+// Empty / whitespace falls back to "mkq" (recommended driver、#571 audit)。
+// Unknown non-empty values return an error: silently swapping a typo
+// (e.g. "mkqq") for the default hides operator intent, especially given
+// that internal/server/queue_factory.go also rejects unknown driver
+// names — surfacing the failure here keeps the two layers consistent
+// and the boot log readable.
+//
+// asynq driver は legacy / future-deprecation candidate。mkq の安定性が
+// 確保され次第削除予定なので、新規 deploy は明示的に "asynq" を選ぶ
+// 必要はない。default が mkq に変更されたが、既存運用で "asynq" を明示
+// 指定している operator は影響を受けない。
 func resolveJobQueueDriver(raw string) (string, error) {
 	v := strings.ToLower(strings.TrimSpace(raw))
 	switch v {
 	case "":
-		return "asynq", nil
+		return "mkq", nil
 	case "asynq", "mkq":
 		return v, nil
 	default:

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -852,7 +852,9 @@ func TestResolveJobQueueDriver(t *testing.T) {
 			raw  string
 			want string
 		}{
-			{"", "asynq"},
+			// 空 string の default は mkq (#571 audit で asynq → mkq に変更)。
+			// asynq は legacy / future-deprecation candidate。
+			{"", "mkq"},
 			{"asynq", "asynq"},
 			{"mkq", "mkq"},
 			{"  mkq  ", "mkq"},
@@ -888,7 +890,8 @@ func TestLoad_JobQueueDriver_Default(t *testing.T) {
 	path := writeTestConfig(t, testYAML)
 	cfg, err := Load(path)
 	require.NoError(t, err)
-	assert.Equal(t, "asynq", cfg.JobQueueDriver)
+	// #571 audit で default を asynq → mkq に変更。
+	assert.Equal(t, "mkq", cfg.JobQueueDriver)
 }
 
 func TestLoad_JobQueueDriver_Mkq(t *testing.T) {

--- a/internal/server/queue_factory.go
+++ b/internal/server/queue_factory.go
@@ -34,8 +34,12 @@ func buildQueueDriver(ctx context.Context, cfg *config.Config) (driver.Driver, e
 	queueConcurrency := perQueueConcurrencyFromConfig(cfg)
 	queueRateLimits := perQueueRatesFromConfig(cfg)
 
+	// 空 string は config.resolveJobQueueDriver で "mkq" に正規化されている
+	// 想定だが、queue_factory が直接 *config.Config を受けるテスト経由など
+	// 正規化されない経路もあるので、ここでも "" → "mkq" に倒す。
+	// asynq driver は legacy / future-deprecation candidate (#571 audit)。
 	switch cfg.JobQueueDriver {
-	case "mkq":
+	case "mkq", "":
 		dialCtx, cancel := context.WithTimeout(ctx, 10*time.Second)
 		defer cancel()
 		return mkqdriver.New(dialCtx, mkqdriver.Config{
@@ -44,7 +48,7 @@ func buildQueueDriver(ctx context.Context, cfg *config.Config) (driver.Driver, e
 			QueueConcurrency: queueConcurrency,
 			QueueRateLimits:  queueRateLimits,
 		})
-	case "asynq", "":
+	case "asynq":
 		return asynqdriver.New(
 			asynqdriver.BuildRedisOpt(cfg.RedisForJobQueue),
 			asynqdriver.ServerConfig{


### PR DESCRIPTION
## Summary

#571 audit で item 1 (asynq per-queue concurrency 化) は **mkq driver の安定性確保後に asynq 自体を削除する方針** を採用したため、active 実装は見送り。

その方針の **最初のステップ** として、デフォルト jobQueueDriver を \`asynq\` → \`mkq\` に切り替え、example yml / docs に「mkq 推奨 / asynq 将来削除予定」を明記する。

## 主な変更点

### Code
- \`internal/config/config.go\` \`resolveJobQueueDriver\`: 空 string fallback を \`"asynq"\` → \`"mkq"\`
- \`internal/server/queue_factory.go\` switch case: \`case "asynq", "":\` → \`case "mkq", "":\` (defensive、queue_factory が直接 *config.Config を受けるテスト経路でも mkq に倒す)

### Config example (3 ファイル全部更新)
- \`.config/default.yml.example\`
- \`.config/docker.yml.example\`
- \`deploy/uds/config/default.yml.example\`

各 example で:
\`\`\`yaml
#   - 'mkq' (default, recommended): ... + supports per-queue concurrency
#   - 'asynq': legacy ... **Future-deprecation candidate** — once mkq is
#                 fully battle-tested we plan to remove asynq entirely.
#jobQueueDriver: mkq
\`\`\`

### Docs
- \`docs/configuration.md\` の jobQueueDriver 説明を「\`mkq\` (デフォルト、推奨)」に更新、asynq 将来削除予定を明記

### Tests
- \`TestResolveJobQueueDriver\`: 空 string → \`"mkq"\` 期待に変更
- \`TestLoad_JobQueueDriver_Default\`: 同上

## 後方互換

- 明示的に \`jobQueueDriver: asynq\` と書いている operator は影響なし
- default に依存している環境のみ次回再起動で mkq に切り替わる
  - mkq は同 Redis を別 key prefix (\`mkq:\` / BullMQ wire) で使うので、再起動時に in-flight asynq job が一時的に未処理になる可能性
  - リリースノート / CHANGELOG で **「default 切り替え前に asynq queue を drain しておくこと」** を明記すべき

## Refs

Refs #571 (item 1) — driver 切替 step 1。残作業: mkq stabilization 観察 → asynq driver 完全削除 (将来の別 PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)