### PR TITLE
Fix #634: outbound Like activity に custom emoji Tag を乗せる

### DIFF
--- a/internal/activitypub/renderer.go
+++ b/internal/activitypub/renderer.go
@@ -599,6 +599,14 @@ func (r *Renderer) RenderReject(actorID string, inner any) *Reject {
 // RenderLike returns a Like activity for the given reaction.
 // targetURI は対象ノートの canonical URI (リモートなら note.URI、ローカルなら
 // urls.NoteURI(note.ID))。
+//
+// reaction が custom emoji 形式 (`:name:` / `:name@.:` / `:name@host:`) の
+// 場合は addEmojiTags で Like.Tag に Emoji オブジェクトを 1 件詰める。
+// 連合相手側 (mk-go 受信側 / Misskey TS / CherryPick) は extractEmojiTags
+// で Tag を拾って icon URL を local emoji table に upsert する設計なので、
+// ここで Tag を出さないと remote 側で custom emoji 解決できず、heart
+// fallback / 表示なしになる (#634)。Unicode 絵文字や fallback heart は
+// `:` で囲まれていないので Tag 不要。
 func (r *Renderer) RenderLike(reactor *model.User, targetURI string, reaction string, likeID string) *Like {
 	l := &Like{
 		Activity: Activity{
@@ -612,8 +620,39 @@ func (r *Renderer) RenderLike(reactor *model.User, targetURI string, reaction st
 		Content:         reaction,
 		MisskeyReaction: reaction,
 	}
+	if name, host, ok := parseCustomEmojiReactionForTag(reaction); ok {
+		var hostPtr *string
+		if host != "" {
+			h := host
+			hostPtr = &h
+		}
+		r.addEmojiTags(&l.Tag, []string{name}, hostPtr)
+	}
 	AddContext(l)
 	return l
+}
+
+// parseCustomEmojiReactionForTag extracts (name, host) from a canonical
+// reaction string for emoji Tag emission. Returns ok=false for unicode
+// (no surrounding colons) and fallback reactions. Local canonical "@."
+// suffix is normalised to host="".
+//
+// activitypub 層に entity.parseCustomEmojiReaction と等価のミニ実装を持
+// たせる: layer 規則上 activitypub → entity の依存は禁止 (entity →
+// activitypub.Renderer の逆向き依存は許容) なので、両側で別々に持つ。
+func parseCustomEmojiReactionForTag(s string) (name, host string, ok bool) {
+	if len(s) < 3 || s[0] != ':' || s[len(s)-1] != ':' {
+		return "", "", false
+	}
+	inner := s[1 : len(s)-1]
+	if at := strings.Index(inner, "@"); at >= 0 {
+		host = inner[at+1:]
+		if host == "." {
+			host = ""
+		}
+		return inner[:at], host, true
+	}
+	return inner, "", true
 }
 
 // RenderUndoLike wraps a previously emitted Like in an Undo activity.

--- a/internal/activitypub/renderer_test.go
+++ b/internal/activitypub/renderer_test.go
@@ -349,6 +349,81 @@ func TestRenderer_RenderLike_MisskeyReactionField(t *testing.T) {
 	assert.Equal(t, "⭐", l.MisskeyReaction)
 }
 
+// Custom emoji リアクションは Like.Tag に Emoji オブジェクトを 1 件詰めて
+// 連合先で icon URL を解決させる必要がある (#634)。
+func TestRenderer_RenderLike_LocalCustomEmojiTag(t *testing.T) {
+	r := newRenderer()
+	r.SetEmojiResolver(&stubEmojiResolver{emojis: map[string]*model.Emoji{
+		"smile": {Name: "smile", PublicURL: "https://example.com/files/smile.webp"},
+	}})
+	reactor := &model.User{ID: "alice"}
+	// canonical local form (TS が `:name@.:` で送るのを mk-go も再現)
+	l := r.RenderLike(reactor, "https://remote.example/notes/n1", ":smile@.:", "https://example.com/likes/l3")
+	require.Len(t, l.Tag, 1)
+	et, ok := l.Tag[0].(EmojiTag)
+	require.True(t, ok)
+	assert.Equal(t, "Emoji", et.Type)
+	assert.Equal(t, ":smile:", et.Name)
+	assert.Equal(t, "https://example.com/files/smile.webp", et.Icon.URL)
+}
+
+func TestRenderer_RenderLike_RemoteCustomEmojiTag(t *testing.T) {
+	r := newRenderer()
+	r.SetEmojiResolver(&stubEmojiResolver{emojis: map[string]*model.Emoji{
+		"foo": {Name: "foo", PublicURL: "https://remote.example/emojis/foo.webp"},
+	}})
+	reactor := &model.User{ID: "alice"}
+	l := r.RenderLike(reactor, "https://remote.example/notes/n1", ":foo@remote.example:", "https://example.com/likes/l4")
+	require.Len(t, l.Tag, 1)
+	et, ok := l.Tag[0].(EmojiTag)
+	require.True(t, ok)
+	assert.Equal(t, ":foo:", et.Name)
+	assert.Equal(t, "https://remote.example/emojis/foo.webp", et.Icon.URL)
+}
+
+func TestRenderer_RenderLike_LegacyLocalNoSuffix(t *testing.T) {
+	r := newRenderer()
+	r.SetEmojiResolver(&stubEmojiResolver{emojis: map[string]*model.Emoji{
+		"legacy": {Name: "legacy", PublicURL: "https://example.com/files/legacy.webp"},
+	}})
+	reactor := &model.User{ID: "alice"}
+	// `:name:` (no `@.` suffix) — TS 旧形式の reaction 文字列がたまたま渡ってきても tag を出せること
+	l := r.RenderLike(reactor, "https://remote.example/notes/n1", ":legacy:", "https://example.com/likes/l5")
+	require.Len(t, l.Tag, 1)
+	et, ok := l.Tag[0].(EmojiTag)
+	require.True(t, ok)
+	assert.Equal(t, ":legacy:", et.Name)
+}
+
+func TestRenderer_RenderLike_UnicodeEmojiNoTag(t *testing.T) {
+	// Unicode 絵文字は Tag 不要 (MFM 上で `:` で囲まれていない)。
+	r := newRenderer()
+	reactor := &model.User{ID: "alice"}
+	l := r.RenderLike(reactor, "https://remote.example/notes/n1", "🎉", "https://example.com/likes/l6")
+	assert.Empty(t, l.Tag)
+}
+
+func TestRenderer_RenderLike_UnknownCustomEmojiNoTag(t *testing.T) {
+	// emojiResolver にヒットしない名前は Tag に何も詰まらない (silent skip)。
+	// 連合相手は icon URL なしで text fallback、reaction 文字列だけは Content
+	// に残すので heart fallback には落ちない。
+	r := newRenderer()
+	r.SetEmojiResolver(&stubEmojiResolver{emojis: map[string]*model.Emoji{}})
+	reactor := &model.User{ID: "alice"}
+	l := r.RenderLike(reactor, "https://remote.example/notes/n1", ":missing@.:", "https://example.com/likes/l7")
+	assert.Empty(t, l.Tag)
+	assert.Equal(t, ":missing@.:", l.Content)
+}
+
+func TestRenderer_RenderLike_NoEmojiResolverNoTag(t *testing.T) {
+	// emojiResolver 未配線時 (テスト simplification 等) は Tag を出さない。
+	// existing TestRenderer_RenderLike (unicode) のロジックを壊さない確認。
+	r := newRenderer()
+	reactor := &model.User{ID: "alice"}
+	l := r.RenderLike(reactor, "https://remote.example/notes/n1", ":any@.:", "https://example.com/likes/l8")
+	assert.Empty(t, l.Tag)
+}
+
 func TestRenderer_RenderUndoLike(t *testing.T) {
 	r := newRenderer()
 	reactor := &model.User{ID: "alice"}


### PR DESCRIPTION
## Summary

mk-go (alice@mk-go) からリモートインスタンス (bob@misskey-ts 等) のノートに **custom emoji でリアクション** すると相手側で icon URL が解決できず heart fallback / 表示なしになる症状の修正 (#634)。

## 原因

\`internal/activitypub/renderer.go::Renderer.RenderLike()\` (line 602) が Like activity の \`Content\` / \`MisskeyReaction\` だけセットして **\`Tag\` を空のまま** 送信していた。

\`internal/activitypub/types.go::Like\` struct (line 252) には \`Tag []any\` フィールドがあり、コメント (line 257-260) に「Misskey/CherryPick がカスタム絵文字を連合させる際に乗せる Emoji オブジェクト群。Note ingestion と同じ形なので federation.extractEmojiTags / upsertEmojis でそのまま処理できる」と明記されていたが、**送信側が出していなかった**。

mk-go の **受信** 側 (\`internal/core/federation/processor.go::handleLike\` line 739-741) は \`like.Tag\` を \`extractEmojiTags\` で拾って \`upsertEmojis\` する設計なので、送信側がそれに応えるよう Tag を出す。Note 配信時の emoji 抜けバグ (#629 / PR #630) と同じパターン。

## 主な変更点

- **\`internal/activitypub/renderer.go::RenderLike\`**
  reaction 文字列が custom emoji 形式 (\`:name:\` / \`:name@.:\` / \`:name@host:\`) なら parse して、既存の \`addEmojiTags\` ヘルパで \`l.Tag\` に \`Emoji\` オブジェクトを 1 件詰める。Unicode 絵文字や fallback heart (\`:\`で囲まれていない) は Tag 不要なのでスキップ。
- **\`parseCustomEmojiReactionForTag\`** (新規 private)
  \`entity.parseCustomEmojiReaction\` と同等のミニ実装。layer 規則上 \`activitypub → entity\` の依存は禁止 (entity → activitypub.Renderer の逆向きは許容) なので、両側で別々に持つ。
- **\`internal/activitypub/renderer_test.go\`**
  - \`TestRenderer_RenderLike_LocalCustomEmojiTag\` (\`:smile@.:\`)
  - \`TestRenderer_RenderLike_RemoteCustomEmojiTag\` (\`:foo@remote.example:\`)
  - \`TestRenderer_RenderLike_LegacyLocalNoSuffix\` (\`:legacy:\` 旧形式)
  - \`TestRenderer_RenderLike_UnicodeEmojiNoTag\` (\`🎉\` は Tag 不要)
  - \`TestRenderer_RenderLike_UnknownCustomEmojiNoTag\` (resolver 不在は silent skip、Content は残す)
  - \`TestRenderer_RenderLike_NoEmojiResolverNoTag\` (resolver 未配線時)

## 検証

```
$ go test -race -count=1 -coverprofile=... ./internal/activitypub/
ok  github.com/shiroha-a/mk/internal/activitypub  5.05s  coverage: 94.2%

$ go test -count=1 ./internal/activitypub/ -run TestRenderer_RenderLike
PASS  (8 件、新規 6 件 + 既存 2 件)
```

\`make fmt\` / \`make lint\` クリーン。

## 別 issue (作業未着手)

ユーザー報告の **「mk-go が受信したリアクションが timeline note の reactionEmojis に出ない (通知では出る)」** は code reading では原因が絞れず本 PR では触らない。本 PR の \`Tag\` 構築は **送信側** の修正なのでそちらに直接効かない。受信側の repro 情報 (\`/api/notes/show\` レスポンス、reaction 文字列、reactor が local/remote か) を集めてから別 issue 化する。

## Closes

Closes #634