### PR TITLE
Fix #636: reaction を target 作者だけでなく reactor の followers / specified にも fanout

### DIFF
--- a/internal/core/federation/reaction_delivery_hook.go
+++ b/internal/core/federation/reaction_delivery_hook.go
@@ -12,12 +12,21 @@ import (
 )
 
 // ReactionDeliveryHook implements core/reaction.FederationHook by emitting
-// Like / Undo Like activities to the inbox of remote note authors.
+// Like / Undo Like activities so the reaction reaches every instance that
+// observed the original note.
 //
-// 配信ルール:
-//   - reactor がローカル & target の作者がリモート → Like を作者へ送る
+// 配信ルール (Misskey TS の ReactionService.create と一致 / drop-in 互換):
+//   - reactor がローカル & note が localOnly でない:
+//   - note 作者が remote → 作者の inbox に DirectRecipe
+//   - visibility public / home / followers → reactor の remote followers
+//     に fanout
+//   - visibility specified → visible な remote user 全員に DirectRecipe
 //   - reactor がリモート → 配信不要 (どこかからの取り込み済みリアクション)
-//   - target 作者がローカル → 配信不要 (受け側で fan-out する)
+//   - localOnly note → 配信不要
+//
+// note 作者がローカル user の場合でも followers fanout は実行する。これに
+// より「自分の public note に自分でリアクションした」場合に remote
+// followers のタイムラインに反映される (#636)。
 type ReactionDeliveryHook struct {
 	deliver  *DeliverService
 	renderer *activitypub.Renderer
@@ -43,54 +52,113 @@ func NewReactionDeliveryHook(
 	}
 }
 
-// OnReactionAdded emits a Like activity to the remote note author.
+// OnReactionAdded emits a Like activity to all instances that should observe
+// the reaction (note author + reactor's followers / specified recipients).
 func (h *ReactionDeliveryHook) OnReactionAdded(reactor *model.User, target *model.Note, reaction string) {
-	author, ok := h.resolveTargetAuthor(reactor, target)
-	if !ok {
+	if !h.shouldDeliver(reactor, target) {
 		return
 	}
 	like := h.buildLike(reactor, target, reaction)
 	body, _ := json.Marshal(like)
-	if err := h.deliver.DeliverToUser(reactor.ID, author, body); err != nil {
-		slog.Warn("reaction delivery: like failed",
-			"reactor", reactor.ID, "noteId", target.ID, "err", err)
-	}
+	h.fanout(reactor, target, body, "like")
 }
 
-// OnReactionRemoved emits an Undo Like activity to the remote note author.
+// OnReactionRemoved emits an Undo Like activity with the same recipient set.
 func (h *ReactionDeliveryHook) OnReactionRemoved(reactor *model.User, target *model.Note, reaction string) {
-	author, ok := h.resolveTargetAuthor(reactor, target)
-	if !ok {
+	if !h.shouldDeliver(reactor, target) {
 		return
 	}
 	like := h.buildLike(reactor, target, reaction)
 	undo := h.renderer.RenderUndoLike(reactor, like)
 	body, _ := json.Marshal(undo)
-	if err := h.deliver.DeliverToUser(reactor.ID, author, body); err != nil {
-		slog.Warn("reaction delivery: undo like failed",
-			"reactor", reactor.ID, "noteId", target.ID, "err", err)
+	h.fanout(reactor, target, body, "undo like")
+}
+
+// shouldDeliver returns false when the reaction is a no-op for federation
+// (remote reactor, localOnly note, missing args).
+func (h *ReactionDeliveryHook) shouldDeliver(reactor *model.User, target *model.Note) bool {
+	if reactor == nil || target == nil {
+		return false
+	}
+	if !reactor.IsLocal() {
+		return false
+	}
+	if target.LocalOnly {
+		return false
+	}
+	return true
+}
+
+// fanout collects DirectRecipe inboxes (note author + specified recipients)
+// and follower inboxes per the note visibility, then enqueues the activity
+// body to each. visibility に応じて TS の DeliverManager と同じ recipient
+// 集合になるよう揃える。
+//
+// kind は失敗ログ識別用 ("like" / "undo like")。
+func (h *ReactionDeliveryHook) fanout(reactor *model.User, target *model.Note, body []byte, kind string) {
+	directInboxes := h.directInboxes(target)
+	if len(directInboxes) > 0 {
+		if err := h.deliver.DeliverActivity(reactor.ID, body, directInboxes); err != nil {
+			slog.Warn("reaction delivery: direct failed",
+				"kind", kind, "reactor", reactor.ID, "noteId", target.ID, "err", err)
+		}
+	}
+	if h.shouldFanoutToFollowers(target) {
+		// DeliverToFollowers が内部で followingRepo から remote follower
+		// inbox を fetch して DeliverActivity に渡す。directInboxes と
+		// 重複する inbox があった場合は別 batch なので enqueue が 2 回
+		// 走るが、Like ID 同一なので相手側で idempotent (already-reacted
+		// 扱い)。TS DeliverManager のように完全 dedup したい場合は
+		// followingRepo を hook 側に持つ必要があり、今回はコストに見合
+		// わないので分離 batch のまま許容する。
+		if err := h.deliver.DeliverToFollowers(reactor.ID, body); err != nil {
+			slog.Warn("reaction delivery: followers fanout failed",
+				"kind", kind, "reactor", reactor.ID, "noteId", target.ID, "err", err)
+		}
 	}
 }
 
-// resolveTargetAuthor returns the remote target author user, or false if no
-// delivery is required.
-func (h *ReactionDeliveryHook) resolveTargetAuthor(reactor *model.User, target *model.Note) (*model.User, bool) {
-	if reactor == nil || target == nil {
-		return nil, false
-	}
-	if !reactor.IsLocal() {
-		return nil, false
-	}
-	author, err := h.userRepo.FindByID(target.UserID)
-	if err != nil {
+// directInboxes returns the explicit DirectRecipe inboxes: note author (if
+// remote) + visible specified users (if remote). 作者が local の場合は省く
+// (TS と同じ条件)。
+func (h *ReactionDeliveryHook) directInboxes(target *model.Note) []string {
+	var inboxes []string
+	if author, err := h.userRepo.FindByID(target.UserID); err == nil {
+		if !author.IsLocal() {
+			if inbox := preferredInbox(author); inbox != "" {
+				inboxes = append(inboxes, inbox)
+			}
+		}
+	} else {
 		slog.Warn("reaction delivery: author not found",
 			"noteId", target.ID, "userId", target.UserID, "err", err)
-		return nil, false
 	}
-	if author.IsLocal() {
-		return nil, false
+	if target.Visibility == model.NoteVisibilitySpecified {
+		for _, uid := range target.VisibleUserIDs {
+			u, err := h.userRepo.FindByID(uid)
+			if err != nil || u == nil {
+				continue
+			}
+			if u.IsLocal() {
+				continue
+			}
+			if inbox := preferredInbox(u); inbox != "" {
+				inboxes = append(inboxes, inbox)
+			}
+		}
 	}
-	return author, true
+	return inboxes
+}
+
+// shouldFanoutToFollowers reports whether the note visibility triggers
+// follower fanout. specified の場合は DirectRecipe で済ませる (TS と一致)。
+func (h *ReactionDeliveryHook) shouldFanoutToFollowers(target *model.Note) bool {
+	switch target.Visibility {
+	case model.NoteVisibilityPublic, model.NoteVisibilityHome, model.NoteVisibilityFollowers:
+		return true
+	default:
+		return false
+	}
 }
 
 // buildLike constructs the Like activity used both for create and undo paths.

--- a/internal/core/federation/reaction_delivery_hook_test.go
+++ b/internal/core/federation/reaction_delivery_hook_test.go
@@ -160,3 +160,168 @@ func TestReactionHook_DeliverErrorDoesNotPanic(t *testing.T) {
 	hook.OnReactionAdded(reactor, target, "🎉")
 	hook.OnReactionRemoved(reactor, target, "🎉")
 }
+
+// ---------------------------------------------------------------------------
+// #636 Fanout coverage
+// ---------------------------------------------------------------------------
+
+// newReactionHookWithFollowers wires a follower inbox list onto the same
+// repo set used elsewhere so per-test fanout assertions stay terse.
+func newReactionHookWithFollowers(t *testing.T, reactorID string, followerInboxes []string) (
+	*federation.ReactionDeliveryHook,
+	*stubEnqueuer,
+	*testutil.MockUserRepository,
+	*testutil.MockUserKeypairRepository,
+	*testutil.MockFollowingRepository,
+) {
+	t.Helper()
+	enq := &stubEnqueuer{}
+	userRepo := testutil.NewMockUserRepository()
+	followingRepo := testutil.NewMockFollowingRepository()
+	keypairRepo := testutil.NewMockUserKeypairRepository()
+	urls := activitypub.NewURLBuilder("https://example.com")
+	deliver := federation.NewDeliverService(enq, userRepo, followingRepo, keypairRepo, urls)
+	renderer := activitypub.NewRenderer(urls)
+	idGen, _ := id.NewGenerator("aidx")
+	hook := federation.NewReactionDeliveryHook(deliver, renderer, urls, idGen, userRepo)
+	if len(followerInboxes) > 0 {
+		followingRepo.RemoteInboxes[reactorID] = followerInboxes
+	}
+	return hook, enq, userRepo, keypairRepo, followingRepo
+}
+
+func collectInboxes(enq *stubEnqueuer) []string {
+	out := make([]string, 0, len(enq.calls))
+	for _, c := range enq.calls {
+		out = append(out, c.Inbox)
+	}
+	return out
+}
+
+// public note へのリアクションは note 作者 (remote) + reactor の remote
+// followers 全員に Like が届くこと (#636)。
+func TestReactionHook_Added_PublicNote_FanoutToFollowers(t *testing.T) {
+	hook, enq, userRepo, keypairRepo, _ := newReactionHookWithFollowers(t, "alice", []string{
+		"https://c.example/users/charlie/inbox",
+		"https://d.example/inbox",
+	})
+	reactor := setupReactor(t, userRepo, keypairRepo)
+	_, target := remoteAuthor(userRepo)
+	target.Visibility = model.NoteVisibilityPublic
+
+	hook.OnReactionAdded(reactor, target, "🎉")
+	inboxes := collectInboxes(enq)
+	assert.Contains(t, inboxes, "https://remote.example/users/bob/inbox")
+	assert.Contains(t, inboxes, "https://c.example/users/charlie/inbox")
+	assert.Contains(t, inboxes, "https://d.example/inbox")
+	assert.Len(t, inboxes, 3)
+}
+
+// 自分の public note へのリアクションでも remote followers にだけは fanout
+// する (target 作者 local なので DirectRecipe は無し)。TS の DeliverManager
+// と同じ条件 (#636)。
+func TestReactionHook_Added_LocalAuthorPublicNote_FanoutToFollowersOnly(t *testing.T) {
+	hook, enq, userRepo, keypairRepo, _ := newReactionHookWithFollowers(t, "alice", []string{
+		"https://c.example/users/charlie/inbox",
+	})
+	reactor := setupReactor(t, userRepo, keypairRepo)
+	userRepo.Users["bob"] = &model.User{ID: "bob", Username: "bob"} // local author
+	target := &model.Note{ID: "n1", UserID: "bob", Visibility: model.NoteVisibilityPublic}
+
+	hook.OnReactionAdded(reactor, target, "🎉")
+	inboxes := collectInboxes(enq)
+	assert.Equal(t, []string{"https://c.example/users/charlie/inbox"}, inboxes)
+}
+
+// followers / home visibility も public と同じく follower fanout 対象。
+func TestReactionHook_Added_FollowersVisibility_FanoutsToFollowers(t *testing.T) {
+	hook, enq, userRepo, keypairRepo, _ := newReactionHookWithFollowers(t, "alice", []string{
+		"https://c.example/users/charlie/inbox",
+	})
+	reactor := setupReactor(t, userRepo, keypairRepo)
+	userRepo.Users["bob"] = &model.User{ID: "bob", Username: "bob"}
+	target := &model.Note{ID: "n1", UserID: "bob", Visibility: model.NoteVisibilityFollowers}
+
+	hook.OnReactionAdded(reactor, target, "🎉")
+	assert.Equal(t, []string{"https://c.example/users/charlie/inbox"}, collectInboxes(enq))
+}
+
+func TestReactionHook_Added_HomeVisibility_FanoutsToFollowers(t *testing.T) {
+	hook, enq, userRepo, keypairRepo, _ := newReactionHookWithFollowers(t, "alice", []string{
+		"https://c.example/users/charlie/inbox",
+	})
+	reactor := setupReactor(t, userRepo, keypairRepo)
+	userRepo.Users["bob"] = &model.User{ID: "bob", Username: "bob"}
+	target := &model.Note{ID: "n1", UserID: "bob", Visibility: model.NoteVisibilityHome}
+
+	hook.OnReactionAdded(reactor, target, "🎉")
+	assert.Equal(t, []string{"https://c.example/users/charlie/inbox"}, collectInboxes(enq))
+}
+
+// specified visibility は follower fanout 無しで visibleUserIds のうち
+// remote な user 全員に DirectRecipe (#636)。
+func TestReactionHook_Added_SpecifiedNote_DirectToVisibleRemoteUsers(t *testing.T) {
+	hook, enq, userRepo, keypairRepo, _ := newReactionHookWithFollowers(t, "alice", []string{
+		// 来てはいけない follower inbox。
+		"https://c.example/users/charlie/inbox",
+	})
+	reactor := setupReactor(t, userRepo, keypairRepo)
+	bob, _ := remoteAuthor(userRepo)
+	host2 := "remote2.example"
+	uri2 := "https://remote2.example/users/dave"
+	inbox2 := "https://remote2.example/users/dave/inbox"
+	dave := &model.User{ID: "dave", Username: "dave", Host: &host2, URI: &uri2, Inbox: &inbox2}
+	userRepo.Users["dave"] = dave
+	// bob ローカル user (visibleUserIds に local が混じっても skip)
+	userRepo.Users["eve"] = &model.User{ID: "eve", Username: "eve"}
+
+	target := &model.Note{
+		ID:             "n1",
+		UserID:         bob.ID,
+		Visibility:     model.NoteVisibilitySpecified,
+		VisibleUserIDs: []string{"dave", "eve"},
+	}
+	noteURI := "https://remote.example/notes/n1"
+	target.URI = &noteURI
+
+	hook.OnReactionAdded(reactor, target, "🎉")
+	inboxes := collectInboxes(enq)
+	assert.Contains(t, inboxes, "https://remote.example/users/bob/inbox")
+	assert.Contains(t, inboxes, "https://remote2.example/users/dave/inbox")
+	assert.NotContains(t, inboxes, "https://c.example/users/charlie/inbox", "specified は follower fanout 不要")
+	assert.Len(t, inboxes, 2)
+}
+
+// localOnly な note に対してリアクションした場合は何も配信しない。
+func TestReactionHook_Added_LocalOnlySkipped(t *testing.T) {
+	hook, enq, userRepo, keypairRepo, _ := newReactionHookWithFollowers(t, "alice", []string{
+		"https://c.example/users/charlie/inbox",
+	})
+	reactor := setupReactor(t, userRepo, keypairRepo)
+	_, target := remoteAuthor(userRepo)
+	target.Visibility = model.NoteVisibilityPublic
+	target.LocalOnly = true
+
+	hook.OnReactionAdded(reactor, target, "🎉")
+	assert.Empty(t, enq.calls)
+}
+
+// Undo Like も同じ recipient 集合に届く (#636)。
+func TestReactionHook_Removed_PublicNote_FanoutToFollowers(t *testing.T) {
+	hook, enq, userRepo, keypairRepo, _ := newReactionHookWithFollowers(t, "alice", []string{
+		"https://c.example/users/charlie/inbox",
+	})
+	reactor := setupReactor(t, userRepo, keypairRepo)
+	_, target := remoteAuthor(userRepo)
+	target.Visibility = model.NoteVisibilityPublic
+
+	hook.OnReactionRemoved(reactor, target, "🎉")
+	inboxes := collectInboxes(enq)
+	assert.Contains(t, inboxes, "https://remote.example/users/bob/inbox")
+	assert.Contains(t, inboxes, "https://c.example/users/charlie/inbox")
+
+	// 中身が Undo であることも軽く確認
+	var got map[string]any
+	require.NoError(t, json.Unmarshal(enq.calls[0].Body, &got))
+	assert.Equal(t, "Undo", got["type"])
+}


### PR DESCRIPTION
## Summary

mk-go から (alice@mk-go) public note にリアクションすると、note 作者の instance には届くが **alice の他の連合先 (alice の remote follower がいる instance) には届かない** バグの修正 (#636)。Misskey TS の \`ReactionService.create\` と recipient 集合を揃えて drop-in 互換を確保する。

## 経緯 / 根本原因

\`internal/core/federation/reaction_delivery_hook.go::OnReactionAdded\` (旧) は \`DeliverToUser(reactor, target.author)\` を 1 発呼ぶだけで、**reactor の follower fanout が完全欠落** していた。さらに「target 作者が local なら何もしない」という分岐も、TS 仕様 (\`ReactionService.ts:266-283\`) と異なる:

| 条件 | TS | mk-go (旧) | mk-go (本 PR) |
|---|---|---|---|
| reactor が local & note は localOnly でない | ✅ 進む | ✅ 進む | ✅ 進む |
| 作者が remote → 作者宛て | ✅ DirectRecipe | ✅ DirectRecipe | ✅ DirectRecipe |
| 作者が local | (DirectRecipe スキップ) | ❌ 全配信 skip (バグ) | ✅ 配信は続行 |
| visibility public/home/followers | ✅ Followers fanout | ❌ 無し (バグ) | ✅ Followers fanout |
| visibility specified | ✅ visible remote 全員 DirectRecipe | ❌ 無し (バグ) | ✅ visible remote 全員 DirectRecipe |
| localOnly | ❌ skip | ❌ skip (副作用的に) | ❌ 明示 skip |

## 主な変更点

- \`OnReactionAdded\` / \`OnReactionRemoved\` を rewriting:
  - \`shouldDeliver(reactor, target)\` で reactor が local かつ note が localOnly でないかをチェック
  - \`buildLike\` を 1 度だけ呼んで body を marshal、これを複数 inbox に配信
  - \`directInboxes(target)\`: note 作者 (remote のみ) + specified visible remote users
  - \`shouldFanoutToFollowers(target)\`: public/home/followers なら true → \`deliver.DeliverToFollowers\` で reactor の remote followers に配信
- DirectRecipe と Follower fanout は別 batch (\`DeliverActivity\` / \`DeliverToFollowers\`)。両者で重複する inbox があれば 2 通送られるが Like ID 同一なので相手側で idempotent (already-reacted 扱い)。完全 dedup は followingRepo を hook に持たせれば可能だが今回は cost に見合わないと判断。

## テスト

新規 7 ケース追加 (visibility 別 fanout 範囲を網羅):

- \`TestReactionHook_Added_PublicNote_FanoutToFollowers\` (作者 + followers 全員)
- \`TestReactionHook_Added_LocalAuthorPublicNote_FanoutToFollowersOnly\` (作者 local でも followers fanout)
- \`TestReactionHook_Added_FollowersVisibility_FanoutsToFollowers\`
- \`TestReactionHook_Added_HomeVisibility_FanoutsToFollowers\`
- \`TestReactionHook_Added_SpecifiedNote_DirectToVisibleRemoteUsers\` (specified は follower fanout 不要)
- \`TestReactionHook_Added_LocalOnlySkipped\` (localOnly は完全スキップ)
- \`TestReactionHook_Removed_PublicNote_FanoutToFollowers\` (Undo Like も同じ recipient 集合)

既存 7 ケースも全部 pass を維持。

```
$ go test -race -count=1 -coverprofile=... ./internal/core/federation/
ok  github.com/shiroha-a/mk/internal/core/federation  4.0s  coverage: 90.1%
```

\`make fmt\` / \`make lint\` クリーン。

## drop-in 互換

修正前: TS-A → mk-A 切替後 alice@A のリアクションが remote follower の charlie@C で観測できない (drop-in 互換崩壊)。
修正後: TS と同じ recipient 集合に配信されるので charlie@C のタイムラインでも alice のリアクションが反映される。

## 関連

- TS reference: \`third_party/misskey/packages/backend/src/core/ReactionService.ts:266-283\`
- 関連 fix: outbound Like の Tag 抜けは別 issue で fix 済 (#634 / PR #635)

## Closes

Closes #636