### PR TITLE
Fix #644: reaction delivery hook の minor 改善 (#1, #2, #3, #4, #5, #7)

### DIFF
--- a/internal/core/federation/reaction_delivery_hook.go
+++ b/internal/core/federation/reaction_delivery_hook.go
@@ -2,8 +2,11 @@ package federation
 
 import (
 	"encoding/json"
+	"errors"
 	"log/slog"
 	"time"
+
+	"gorm.io/gorm"
 
 	"github.com/shiroha-a/mk/internal/activitypub"
 	"github.com/shiroha-a/mk/internal/misc/id"
@@ -121,29 +124,64 @@ func (h *ReactionDeliveryHook) fanout(reactor *model.User, target *model.Note, b
 // directInboxes returns the explicit DirectRecipe inboxes: note author (if
 // remote) + visible specified users (if remote). 作者が local の場合は省く
 // (TS と同じ条件)。
+//
+// gorm.ErrRecordNotFound (= 削除済み user) と DB transient error を分けて
+// log する (#644)。VisibleUserIDs に target.UserID が含まれているケースは
+// skip して FindManyByIDs の N+1 を避ける。
 func (h *ReactionDeliveryHook) directInboxes(target *model.Note) []string {
 	var inboxes []string
-	if author, err := h.userRepo.FindByID(target.UserID); err == nil {
+	author, err := h.userRepo.FindByID(target.UserID)
+	switch {
+	case err == nil:
 		if !author.IsLocal() {
 			if inbox := preferredInbox(author); inbox != "" {
 				inboxes = append(inboxes, inbox)
 			}
 		}
-	} else {
-		slog.Warn("reaction delivery: author not found",
+	case errors.Is(err, gorm.ErrRecordNotFound):
+		// 投稿時点で著者が消えているケース。ログ過剰を避けて debug 止まり。
+		slog.Debug("reaction delivery: author no longer exists",
+			"noteId", target.ID, "userId", target.UserID)
+	default:
+		slog.Warn("reaction delivery: author lookup failed",
 			"noteId", target.ID, "userId", target.UserID, "err", err)
 	}
-	if target.Visibility == model.NoteVisibilitySpecified {
+
+	if target.Visibility == model.NoteVisibilitySpecified && len(target.VisibleUserIDs) > 0 {
+		// 著者は上で済んでいるので uid == target.UserID は除外して bulk
+		// fetch する (#644 #5 / #7)。
+		uniqueIDs := make([]string, 0, len(target.VisibleUserIDs))
+		seen := make(map[string]struct{}, len(target.VisibleUserIDs))
 		for _, uid := range target.VisibleUserIDs {
-			u, err := h.userRepo.FindByID(uid)
-			if err != nil || u == nil {
+			if uid == "" || uid == target.UserID {
 				continue
 			}
-			if u.IsLocal() {
+			if _, dup := seen[uid]; dup {
 				continue
 			}
-			if inbox := preferredInbox(u); inbox != "" {
-				inboxes = append(inboxes, inbox)
+			seen[uid] = struct{}{}
+			uniqueIDs = append(uniqueIDs, uid)
+		}
+		if len(uniqueIDs) > 0 {
+			users, err := h.userRepo.FindManyByIDs(uniqueIDs)
+			if err != nil {
+				slog.Warn("reaction delivery: visible users lookup failed",
+					"noteId", target.ID, "count", len(uniqueIDs), "err", err)
+			} else {
+				// missing rows は repo 側で silent skip される。debug log
+				// で skip 件数だけ残しておく (#644 #2)。
+				if len(users) < len(uniqueIDs) {
+					slog.Debug("reaction delivery: some visible users missing",
+						"noteId", target.ID, "requested", len(uniqueIDs), "found", len(users))
+				}
+				for _, u := range users {
+					if u == nil || u.IsLocal() {
+						continue
+					}
+					if inbox := preferredInbox(u); inbox != "" {
+						inboxes = append(inboxes, inbox)
+					}
+				}
 			}
 		}
 	}

--- a/internal/core/federation/reaction_delivery_hook_test.go
+++ b/internal/core/federation/reaction_delivery_hook_test.go
@@ -306,6 +306,76 @@ func TestReactionHook_Added_LocalOnlySkipped(t *testing.T) {
 	assert.Empty(t, enq.calls)
 }
 
+// direct と follower fanout で同じ inbox が重複した場合は別 batch なので
+// 2 通 enqueue される (Like ID 同一なので receiver 側で idempotent)。
+// PR #640 docstring の挙動を回帰検出する目的の test (#644 #3)。
+func TestReactionHook_Added_DuplicateInbox_EmitsTwice(t *testing.T) {
+	// bob = remote 作者 / inbox A、follower inbox にも同じ A を仕込む。
+	hook, enq, userRepo, keypairRepo, _ := newReactionHookWithFollowers(t, "alice", []string{
+		"https://remote.example/users/bob/inbox", // 作者と完全一致
+	})
+	reactor := setupReactor(t, userRepo, keypairRepo)
+	_, target := remoteAuthor(userRepo)
+	target.Visibility = model.NoteVisibilityPublic
+
+	hook.OnReactionAdded(reactor, target, "🎉")
+	require.Len(t, enq.calls, 2, "direct と follower で別 batch なので 2 通 enqueue される")
+	for _, c := range enq.calls {
+		assert.Equal(t, "https://remote.example/users/bob/inbox", c.Inbox)
+	}
+}
+
+// VisibleUserIDs に存在しない user ID が混ざっていても残りの remote user
+// にだけ DirectRecipe が配信される。FindManyByIDs は missing rows を silent
+// skip するので、遭遇するのは稀だが drop-in 復帰時 / 遅延 federation で
+// 起こり得る (#644 #4)。
+func TestReactionHook_Added_SpecifiedNote_UnknownVisibleUserSkipped(t *testing.T) {
+	hook, enq, userRepo, keypairRepo, _ := newReactionHookWithFollowers(t, "alice", nil)
+	reactor := setupReactor(t, userRepo, keypairRepo)
+	bob, _ := remoteAuthor(userRepo)
+	host2 := "remote2.example"
+	uri2 := "https://remote2.example/users/dave"
+	inbox2 := "https://remote2.example/users/dave/inbox"
+	dave := &model.User{ID: "dave", Username: "dave", Host: &host2, URI: &uri2, Inbox: &inbox2}
+	userRepo.Users["dave"] = dave
+
+	target := &model.Note{
+		ID:             "n1",
+		UserID:         bob.ID,
+		Visibility:     model.NoteVisibilitySpecified,
+		VisibleUserIDs: []string{"dave", "ghost", "missing"}, // ghost / missing は user table に無い
+	}
+	noteURI := "https://remote.example/notes/n1"
+	target.URI = &noteURI
+
+	hook.OnReactionAdded(reactor, target, "🎉")
+	inboxes := collectInboxes(enq)
+	assert.Contains(t, inboxes, "https://remote.example/users/bob/inbox")
+	assert.Contains(t, inboxes, "https://remote2.example/users/dave/inbox")
+	assert.Len(t, inboxes, 2, "missing user は silent skip して残りに配信を続ける")
+}
+
+// VisibleUserIDs に target.UserID 自身が含まれていても重複 lookup せず、
+// 結果として作者 inbox を 1 度しか積まない (#644 #7 dedup)。
+func TestReactionHook_Added_SpecifiedNote_AuthorInVisibleListDeduped(t *testing.T) {
+	hook, enq, userRepo, keypairRepo, _ := newReactionHookWithFollowers(t, "alice", nil)
+	reactor := setupReactor(t, userRepo, keypairRepo)
+	bob, _ := remoteAuthor(userRepo)
+
+	target := &model.Note{
+		ID:             "n1",
+		UserID:         bob.ID,
+		Visibility:     model.NoteVisibilitySpecified,
+		VisibleUserIDs: []string{bob.ID, bob.ID, ""}, // 重複 + 空文字は skip
+	}
+	noteURI := "https://remote.example/notes/n1"
+	target.URI = &noteURI
+
+	hook.OnReactionAdded(reactor, target, "🎉")
+	inboxes := collectInboxes(enq)
+	assert.Equal(t, []string{"https://remote.example/users/bob/inbox"}, inboxes)
+}
+
 // Undo Like も同じ recipient 集合に届く (#636)。
 func TestReactionHook_Removed_PublicNote_FanoutToFollowers(t *testing.T) {
 	hook, enq, userRepo, keypairRepo, _ := newReactionHookWithFollowers(t, "alice", []string{


### PR DESCRIPTION
## Summary

PR #640 (reaction fanout fix) review で挙がった follow-up を反映 (#644)。挙動変更は無く、log + test + 内部リファクタのみ。**#6 (fanout の kind string → enum 化) は最も低優先で見送り**。

## 主な変更点

### \`internal/core/federation/reaction_delivery_hook.go::directInboxes\`

- **#1 author lookup err と record-not-found の分岐**
  \`errors.Is(err, gorm.ErrRecordNotFound)\` で:
  - record-not-found (= 削除済み user 等) → \`slog.Debug\`
  - DB transient error → \`slog.Warn\`
  メッセージも "not found" → "author lookup failed" に修正 (DB error と not-found を混同しない命名)。

- **#2 VisibleUserIDs の silent skip ログ化**
  \`FindManyByIDs\` は missing rows を silent skip するので、要求件数より実取得件数が少ない場合に \`slog.Debug\` で skip 件数を残す。本番で何が落ちているか debug 時に追跡可能になる。

- **#5 specified の N+1 lookup 解消**
  \`for _, uid := range target.VisibleUserIDs\` の N 回 \`FindByID\` を **1 回の \`FindManyByIDs\`** に置換。typical な specified note は recipients < 10 だが、bulk API が既に存在 (\`UserRepository.FindManyByIDs\` line 22) するので採用。

- **#7 VisibleUserIDs 内の重複 / 著者 ID 除外**
  fetch 前に \`uid == target.UserID\` と空文字、重複 ID を除外して unique 化。著者が VisibleUserIDs に含まれているケースで意味のない 2 重 lookup が消える。可読性も向上。

### \`internal/core/federation/reaction_delivery_hook_test.go\`

- **#3 \`TestReactionHook_Added_DuplicateInbox_EmitsTwice\`**
  direct (作者) と follower fanout で同じ inbox が重複した場合に **2 通** enqueue されることを assert。PR #640 docstring の挙動を回帰検出する目的。将来 dedup 実装に変更すれば赤くなる。

- **#4 \`TestReactionHook_Added_SpecifiedNote_UnknownVisibleUserSkipped\`**
  VisibleUserIDs に存在しない user ID (例: 削除済み / 遅延 federation) が混ざっても、残りの remote user に配信を続けることを assert。

- **(補強) \`TestReactionHook_Added_SpecifiedNote_AuthorInVisibleListDeduped\`**
  VisibleUserIDs に target.UserID 自身や空文字、重複 ID が混入しても dedup されて作者 inbox が **1 度しか** 積まれないことを assert (#7)。

## 検証

```
$ go test -race -count=1 -coverprofile=... ./internal/core/federation/
ok  github.com/shiroha-a/mk/internal/core/federation  3.92s  coverage: 90.0%
```

- 既存 9 件 + 新規 10 件 (#636 で 7 件 + 本 PR で 3 件) のテスト全 pass
- coverage 90.0% (推奨ライン 90% 維持)
- \`make fmt\` / \`make lint\` クリーン

## スコープ外

- **#6** (fanout の \`kind string\` 引数 → enum or body の type field 抽出): 可読性メリットが小さい割に touched line が増えるので未対応。将来必要になれば separate refactor PR で。

## Closes

Closes #644