### PR TITLE
Fix #637 followup: videoThumbnailGenerator に POST multipart wire を追加 + GET と両対応

### DIFF
--- a/.config/default.yml.example
+++ b/.config/default.yml.example
@@ -284,12 +284,21 @@ proxyBypassHosts:
 #mediaProxy: https://example.com/proxy
 #mediaProxySecret: change-me
 
-# Movie thumbnail generation URL. mk-go calls this service for video/* MIME
-# in /proxy. Misskey TS-compatible API: `<base>/thumbnail.webp?thumbnail=1&url=<URL>`.
-# Recommended deployment is the bundled `video-thumb` Compose service
-# (docker-compose.yml). For UDS-only stacks use `unix:///path/to/socket`.
-#videoThumbnailGenerator: http://video-thumb:8080
+# Movie thumbnail generator. mk-go calls this service for video/* MIME in
+# /proxy/. Two wire modes are supported via `videoThumbnailGeneratorMode`:
+#   - "post" (default) — POST <base>/thumbnail with multipart/form-data
+#                        (`file` field). Compatible with the bundled
+#                        `nekonoverse/video-thumb` Compose service. mk-go
+#                        forwards the already-downloaded video bytes, so the
+#                        generator does not need network access to the
+#                        source URL.
+#   - "get"            — GET <base>/thumbnail.webp?thumbnail=1&url=<URL>.
+#                        Misskey TS' videoThumbnailGenerator API. The
+#                        generator must be able to reach the source URL.
+# For UDS-only stacks use `unix:///path/to/socket` for the URL.
+#videoThumbnailGenerator: http://video-thumb:8005
 #videoThumbnailGenerator: unix:///run/video-thumb/sock
+#videoThumbnailGeneratorMode: post
 
 # For security reasons, uploading attachments from the intranet is
 # prohibited; exceptions can be allowed here. Default is empty.

--- a/.config/docker.yml.example
+++ b/.config/docker.yml.example
@@ -181,8 +181,11 @@ proxyBypassHosts:
 #mediaProxy: https://example.com/proxy
 
 # Video thumbnail generator. The bundled docker-compose ships a `video-thumb`
-# service reachable at this address inside the Compose network.
-videoThumbnailGenerator: http://video-thumb:8080
+# service (nekonoverse/video-thumb, listens on 8005). Default wire mode
+# "post" forwards multipart bytes — see default.yml.example for the "get"
+# Misskey TS-compat alternative.
+videoThumbnailGenerator: http://video-thumb:8005
+#videoThumbnailGeneratorMode: post
 
 #allowedPrivateNetworks:
 #  - '127.0.0.1/32'

--- a/compose.uds.yaml.example
+++ b/compose.uds.yaml.example
@@ -61,17 +61,16 @@ services:
   # Video thumbnail generator (#637 M2). UDS-only stack 全体に揃えて TCP は
   # 開かず named volume 経由の socket だけで mk-go と通信する。mk-go 側は
   # `videoThumbnailGenerator: unix:///run/video-thumb/sock` を設定すれば
-  # 自動で UDS dialer 経由で GET する。
+  # 自動で UDS dialer 経由で接続する。
   #
-  # 注意: `nekonoverse/video-thumb` は placeholder image。Misskey TS の
-  # videoThumbnailGenerator API (`GET /thumbnail.webp?thumbnail=1&url=<URL>`)
-  # に互換であれば任意の image / 自前ビルドに差し替えて構わない。さらに
-  # この UDS overlay では image が `/run/video-thumb/sock` に listen する
-  # 前提。HTTP TCP listen しかできない場合は `networks: mkgo-uds` だけ
-  # 残し socket mount を消して `http://video-thumb:PORT` 指定にフォール
-  # バックする。
+  # nekonoverse/video-thumb は `UDS_PATH` env で UDS listen に切替えられる
+  # 仕様。default の wire mode "post" (multipart POST) と互換。Misskey TS
+  # 互換の GET 経路に切替えたい場合は mk-go 側で
+  # `videoThumbnailGeneratorMode: get` を設定し、対応 image に差し替える。
   video-thumb:
-    image: nekonoverse/video-thumb:latest
+    image: ghcr.io/nekonoverse/video-thumb:unstable
+    environment:
+      UDS_PATH: /run/video-thumb/sock
     volumes:
       - video_thumb_sock:/run/video-thumb
     networks:

--- a/deploy/uds/config/default.yml.example
+++ b/deploy/uds/config/default.yml.example
@@ -240,7 +240,14 @@ proxyBypassHosts:
 #mediaProxy: https://example.com/proxy
 #mediaProxySecret: change-me
 
-#videoThumbnailGenerator: https://example.com
+# Video thumbnail generator. The bundled UDS stack runs nekonoverse/video-thumb
+# listening on /run/video-thumb/sock; the POST multipart wire is the default
+# (see videoThumbnailGeneratorMode below).
+videoThumbnailGenerator: unix:///run/video-thumb/sock
+# "post" (default, mk-go style — forwards multipart bytes) or "get"
+# (Misskey TS-compat — sends the source URL via query string for the
+# generator to fetch).
+#videoThumbnailGeneratorMode: post
 
 #allowedPrivateNetworks:
 #  - '127.0.0.1/32'

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -54,21 +54,21 @@ services:
     restart: unless-stopped
 
   # Video thumbnail generator (#637 M2). mk-go の media proxy が video/* を
-  # 受けたとき、設定 `videoThumbnailGenerator` で指定した URL に GET を投げて
-  # 静止画 thumbnail を取得する。app コンテナとは Docker network 内で通信し、
-  # 公開ポートは持たない (origin 側は mk-go の /proxy 経由でしか到達しない)。
+  # 受けたとき、設定 `videoThumbnailGenerator` で指定した URL に対して
+  # multipart POST (default mode) で video bytes を送り、静止画 thumbnail
+  # を返してもらう。app コンテナとは Docker network 内で通信し、公開
+  # ポートは持たない (origin 側は mk-go の /proxy 経由でしか到達しない)。
   #
-  # mk-go 側で `videoThumbnailGenerator: http://video-thumb:8080` を設定する
-  # ことで wire される。UDS deployment では compose.uds.yaml.example の
-  # video-thumb service が socket mount で接続する。
+  # mk-go 側で `videoThumbnailGenerator: http://video-thumb:8005` を設定
+  # することで wire される。UDS deployment では compose.uds.yaml.example
+  # の video-thumb service が socket mount で接続する。
   #
-  # 注意: `nekonoverse/video-thumb` は placeholder image で、Misskey TS の
-  # videoThumbnailGenerator API (`GET /thumbnail.webp?thumbnail=1&url=<URL>`)
-  # に互換であれば任意の image / 自前ビルドに差し替えて構わない。Docker
-  # Hub に公開イメージが存在しない場合は ffmpeg ベースの一行 wrapper を
-  # 自分で組むか、別の Misskey 互換 thumbnailer を指定する。
+  # 互換 image: ghcr.io/nekonoverse/video-thumb (POST /thumbnail multipart)。
+  # Misskey TS 互換の GET 経路を使いたい場合は
+  # `videoThumbnailGeneratorMode: get` を設定し、対応 image
+  # (`GET /thumbnail.webp?thumbnail=1&url=<URL>`) に差し替える。
   video-thumb:
-    image: nekonoverse/video-thumb:latest
+    image: ghcr.io/nekonoverse/video-thumb:unstable
     restart: unless-stopped
 
 volumes:

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -163,10 +163,19 @@ type Source struct {
 	// shiroha-a/mkq library. Empty / unset = "asynq".
 	JobQueueDriver string `mapstructure:"jobQueueDriver"`
 
-	MediaProxy              string          `mapstructure:"mediaProxy"`
-	MediaProxySecret        string          `mapstructure:"mediaProxySecret"`
-	VideoThumbnailGenerator string          `mapstructure:"videoThumbnailGenerator"`
-	Logging                 *LoggingOptions `mapstructure:"logging"`
+	MediaProxy              string `mapstructure:"mediaProxy"`
+	MediaProxySecret        string `mapstructure:"mediaProxySecret"`
+	VideoThumbnailGenerator string `mapstructure:"videoThumbnailGenerator"`
+	// VideoThumbnailGeneratorMode picks the wire used to ask the generator:
+	//   "post" (default, mk-go) — POST <gen>/thumbnail with multipart/form-data
+	//                             (`file` field). nekonoverse/video-thumb と同
+	//                             仕様。SSRF surface を generator 側に持ち
+	//                             込まない。
+	//   "get"                   — GET <gen>/thumbnail.webp?thumbnail=1&url=<URL>
+	//                             Misskey TS の videoThumbnailGenerator 仕様
+	//                             に互換 (#637 review)。
+	VideoThumbnailGeneratorMode string          `mapstructure:"videoThumbnailGeneratorMode"`
+	Logging                     *LoggingOptions `mapstructure:"logging"`
 
 	PerChannelMaxNoteCacheCount  *int   `mapstructure:"perChannelMaxNoteCacheCount"`
 	PerUserNotificationsMaxCount *int   `mapstructure:"perUserNotificationsMaxCount"`
@@ -269,6 +278,7 @@ type Config struct {
 	ExternalMediaProxyEnabled    bool
 	MediaProxySecret             []byte
 	VideoThumbnailGenerator      string
+	VideoThumbnailGeneratorMode  string
 	UserAgent                    string
 	PerChannelMaxNoteCacheCount  int
 	PerUserNotificationsMaxCount int
@@ -488,6 +498,7 @@ func resolve(src *Source) (*Config, error) {
 		ExternalMediaProxyEnabled:    externalMediaProxyEnabled,
 		MediaProxySecret:             mediaProxySecret,
 		VideoThumbnailGenerator:      strings.TrimRight(src.VideoThumbnailGenerator, "/"),
+		VideoThumbnailGeneratorMode:  normalizeVideoThumbMode(src.VideoThumbnailGeneratorMode),
 		UserAgent:                    fmt.Sprintf("Misskey-Go/%s (%s)", MkGoVersion, src.URL),
 		PerChannelMaxNoteCacheCount:  perChannelMaxNoteCacheCount,
 		PerUserNotificationsMaxCount: perUserNotificationsMaxCount,
@@ -649,6 +660,20 @@ func resolveJobQueueDriver(raw string) (string, error) {
 		return v, nil
 	default:
 		return "", fmt.Errorf("config: unknown jobQueueDriver %q (expected \"asynq\" or \"mkq\")", raw)
+	}
+}
+
+// normalizeVideoThumbMode validates and lowercases the wire-mode hint for
+// the video thumbnail generator. Unknown / empty defaults to "post"
+// (nekonoverse/video-thumb compat). "get" picks the Misskey TS-style URL
+// pattern.
+func normalizeVideoThumbMode(raw string) string {
+	v := strings.ToLower(strings.TrimSpace(raw))
+	switch v {
+	case "get":
+		return "get"
+	default:
+		return "post"
 	}
 }
 

--- a/internal/core/mediaproxy/service.go
+++ b/internal/core/mediaproxy/service.go
@@ -153,7 +153,8 @@ type Service struct {
 	httpClient       *http.Client
 	userAgent        string
 	driveLookup      DriveFileLookup // optional, #637 M1
-	videoThumbGen    string          // optional, #637 M2 (Misskey TS videoThumbnailGenerator URL)
+	videoThumbGen    string          // optional, #637 M2 (videoThumbnailGenerator base URL)
+	videoThumbMode   string          // "post" (default) | "get" — wire selection
 	videoThumbClient *http.Client    // built lazily from videoThumbGen, supports unix:// scheme
 }
 
@@ -187,12 +188,11 @@ func (s *Service) SetDriveStorage(st coredrive.Storage) {
 	s.driveStorage = st
 }
 
-// SetVideoThumbnailGenerator wires an external thumbnail generator. The URL
-// follows Misskey TS' `videoThumbnailGenerator` API:
-// `<base>/thumbnail.webp?thumbnail=1&url=<original video URL>`. For UDS
-// deployments pass `unix:///path/to/socket` and the proxy will dial the
-// socket directly, ignoring the URL host. Empty disables the feature
-// (default — proxy returns dummy PNG for video MIME, #637 M2)。
+// SetVideoThumbnailGenerator wires an external thumbnail generator with the
+// default wire mode (POST multipart). For UDS deployments pass
+// `unix:///path/to/socket` and the proxy will dial the socket directly,
+// ignoring the URL host. Empty disables the feature (default — proxy
+// returns dummy PNG for video MIME, #637 M2).
 //
 // このコール先は operator-trusted endpoint (内部 sidecar / 自前 SaaS 想定)
 // のため、`config.proxy` (#638 outbound forward proxy) は意図的に経由しな
@@ -200,7 +200,21 @@ func (s *Service) SetDriveStorage(st coredrive.Storage) {
 // fetcher.go`) と同じ pattern。`config.proxy` を強制したい運用は別途
 // nginx / sidecar 側で出力経路を制御する。
 func (s *Service) SetVideoThumbnailGenerator(genURL string) {
+	s.SetVideoThumbnailGeneratorWithMode(genURL, "post")
+}
+
+// SetVideoThumbnailGeneratorWithMode is the explicit form. mode = "post"
+// (multipart upload, nekonoverse/video-thumb compat) or "get" (URL-based
+// Misskey TS videoThumbnailGenerator API). 不正値は "post" にフォール
+// バック。
+func (s *Service) SetVideoThumbnailGeneratorWithMode(genURL, mode string) {
 	s.videoThumbGen = genURL
+	switch mode {
+	case "get":
+		s.videoThumbMode = "get"
+	default:
+		s.videoThumbMode = "post"
+	}
 	s.videoThumbClient = newVideoThumbnailClient(genURL)
 }
 
@@ -420,20 +434,18 @@ const (
 // in the requested output format (WebP / AVIF). Badge と passThrough は
 // format negotiation の対象外で常に PNG / 元 MIME を返す。
 //
-// video/* MIME は image pipeline に直接乗らないので、設定済みの
-// videoThumbnailGenerator (Misskey TS 互換 API) に GET を投げて返ってきた
-// 静止画を再帰的に image pipeline に通す。generator 未設定 / 呼び出し失敗
-// / local /files/ source (generator から取り直せない) のときは dummy PNG
-// にフォールバックして frontend を壊さない (#637 M2)。
+// video/* MIME は image pipeline に直接乗らないので、download 済の bytes
+// をそのまま videoThumbnailGenerator に POST multipart で投げて静止画
+// thumbnail を取得し、再帰的に image pipeline に通す。generator 未設定 /
+// 呼び出し失敗のときは dummy PNG にフォールバックして frontend を壊さない
+// (#637 M2)。bytes 経由なので local /files/ source も remote URL も同じ
+// path で扱える。
 func (s *Service) processAndReturn(ctx context.Context, data []byte, contentType string, mode ProxyMode, out OutputFormat, sourceURL string) (*ProxyResult, error) {
 	if isVideoMIME(contentType) && isResizeMode(mode) {
-		// Generator は外部 URL を fetch する前提なので、local /files/ への
-		// 戻り迂回は避ける (M1 variant swap で既に解決済のはず)。
-		// generator 未設定 / local source なら早期に dummy PNG fallback。
-		if s.videoThumbClient == nil || strings.HasPrefix(sourceURL, s.instanceURL+"/files/") {
+		if s.videoThumbClient == nil {
 			return makeDummyPNG(), nil
 		}
-		frame, frameMIME, err := s.fetchVideoThumbnail(ctx, sourceURL)
+		frame, frameMIME, err := s.fetchVideoThumbnail(ctx, data, contentType, sourceURL)
 		if err != nil {
 			slog.Warn("mediaproxy: video thumbnail generator failed",
 				"url", sourceURL, "err", err)

--- a/internal/core/mediaproxy/service.go
+++ b/internal/core/mediaproxy/service.go
@@ -445,6 +445,13 @@ func (s *Service) processAndReturn(ctx context.Context, data []byte, contentType
 		if s.videoThumbClient == nil {
 			return makeDummyPNG(), nil
 		}
+		// GET mode は generator が sourceURL を fetch する前提なので、
+		// local /files/<key> を投げても (UDS-only stack 等の) generator
+		// から到達できないことが多い。早期 fallback で無駄な RT を省く。
+		// POST mode では bytes 直送なので skip 不要。
+		if s.videoThumbMode == "get" && strings.HasPrefix(sourceURL, s.instanceURL+"/files/") {
+			return makeDummyPNG(), nil
+		}
 		frame, frameMIME, err := s.fetchVideoThumbnail(ctx, data, contentType, sourceURL)
 		if err != nil {
 			slog.Warn("mediaproxy: video thumbnail generator failed",

--- a/internal/core/mediaproxy/video_thumbnail.go
+++ b/internal/core/mediaproxy/video_thumbnail.go
@@ -1,7 +1,6 @@
 package mediaproxy
 
 import (
-	"bytes"
 	"context"
 	"errors"
 	"fmt"
@@ -110,32 +109,47 @@ func (s *Service) fetchVideoThumbnail(ctx context.Context, body []byte, sourceMI
 // nekonoverse/video-thumb-style endpoints. Bytes are forwarded from the
 // already-downloaded `body`, so the generator does not need to reach the
 // source URL itself (no extra SSRF surface on the generator).
+//
+// multipart body は io.Pipe で streaming する: 32 MiB 級の bytes をもう一
+// 度 buffer に full コピーしないことで peak memory を半分にする (review
+// PR #646 #2)。
 func (s *Service) fetchVideoThumbnailPOST(ctx context.Context, body []byte, sourceMIME string) ([]byte, string, error) {
 	target, err := videoThumbnailRequestURL(s.videoThumbGen, "post", "")
 	if err != nil {
 		return nil, "", fmt.Errorf("%w: %v", ErrVideoThumbnailUnavailable, err)
 	}
 
-	// multipart body 構築。field name "file" は nekonoverse/video-thumb の
-	// FastAPI endpoint が期待する固定値。filename はリモート URL から
-	// 取らない (個人情報を generator に伝えない方針) — 拡張子だけ MIME
-	// から推定して generic に。
-	var buf bytes.Buffer
-	w := multipart.NewWriter(&buf)
+	pr, pw := io.Pipe()
+	w := multipart.NewWriter(pw)
+	// field name "file" は nekonoverse/video-thumb の FastAPI endpoint が
+	// 期待する固定値。filename はリモート URL から取らない (個人情報を
+	// generator に伝えない方針) — 拡張子だけ MIME から推定して generic
+	// に。
 	filename := "video" + extensionForMIME(sourceMIME)
-	part, err := w.CreateFormFile("file", filename)
-	if err != nil {
-		return nil, "", fmt.Errorf("%w: form: %v", ErrVideoThumbnailUnavailable, err)
-	}
-	if _, err := part.Write(body); err != nil {
-		return nil, "", fmt.Errorf("%w: write: %v", ErrVideoThumbnailUnavailable, err)
-	}
-	if err := w.Close(); err != nil {
-		return nil, "", fmt.Errorf("%w: close: %v", ErrVideoThumbnailUnavailable, err)
-	}
 
-	req, err := http.NewRequestWithContext(ctx, http.MethodPost, target, &buf)
+	// goroutine で part の書き込みを行い、req.Body の読み手と pipe で
+	// 接続する。エラーは pw.CloseWithError で reader 側に伝播させて、
+	// http.Client.Do() が正しく失敗を観測できるようにする。
+	go func() {
+		defer pw.Close()
+		part, err := w.CreateFormFile("file", filename)
+		if err != nil {
+			pw.CloseWithError(err)
+			return
+		}
+		if _, err := part.Write(body); err != nil {
+			pw.CloseWithError(err)
+			return
+		}
+		if err := w.Close(); err != nil {
+			pw.CloseWithError(err)
+			return
+		}
+	}()
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, target, pr)
 	if err != nil {
+		_ = pr.Close()
 		return nil, "", fmt.Errorf("%w: %v", ErrVideoThumbnailUnavailable, err)
 	}
 	req.Header.Set("User-Agent", s.userAgent)
@@ -185,6 +199,13 @@ func (s *Service) doVideoThumbnailRequest(req *http.Request) ([]byte, string, er
 	if contentType == "" {
 		contentType = http.DetectContentType(data)
 	}
+	// Generator が malicious / 設定ミスで非画像 (HTML / JSON / text) を
+	// 返した場合、processResize は non-convertible として raw bytes を
+	// そのまま frontend に流してしまう。image/* で始まらない response は
+	// 拒否して dummy PNG fallback に倒れる (review PR #646 #3)。
+	if !strings.HasPrefix(strings.ToLower(contentType), "image/") {
+		return nil, "", fmt.Errorf("%w: unexpected content-type %q", ErrVideoThumbnailUnavailable, contentType)
+	}
 	return data, contentType, nil
 }
 
@@ -208,6 +229,10 @@ func extensionForMIME(mime string) string {
 		return ".mpg"
 	case "video/ogg":
 		return ".ogv"
+	case "video/x-matroska":
+		return ".mkv"
+	case "video/mp2t":
+		return ".ts"
 	}
 	return ".bin"
 }

--- a/internal/core/mediaproxy/video_thumbnail.go
+++ b/internal/core/mediaproxy/video_thumbnail.go
@@ -149,7 +149,10 @@ func (s *Service) fetchVideoThumbnailPOST(ctx context.Context, body []byte, sour
 
 	req, err := http.NewRequestWithContext(ctx, http.MethodPost, target, pr)
 	if err != nil {
-		_ = pr.Close()
+		// io.PipeReader.Close() は stdlib doc 上必ず nil を返すので戻り
+		// 値は捨ててよい (review PR #646 #1)。defer goroutine が
+		// pw.Write 時に io.ErrClosedPipe を観測して抜けるのを保証。
+		pr.Close()
 		return nil, "", fmt.Errorf("%w: %v", ErrVideoThumbnailUnavailable, err)
 	}
 	req.Header.Set("User-Agent", s.userAgent)

--- a/internal/core/mediaproxy/video_thumbnail.go
+++ b/internal/core/mediaproxy/video_thumbnail.go
@@ -1,10 +1,12 @@
 package mediaproxy
 
 import (
+	"bytes"
 	"context"
 	"errors"
 	"fmt"
 	"io"
+	"mime/multipart"
 	"net"
 	"net/http"
 	"net/url"
@@ -59,34 +61,93 @@ func newVideoThumbnailClient(genURL string) *http.Client {
 	return &http.Client{Timeout: videoThumbnailTimeout}
 }
 
-// videoThumbnailRequestURL builds the GET URL the generator expects.
-// Misskey TS' videoThumbnailGenerator API: `<base>/thumbnail.webp?thumbnail=1&url=<encoded>`.
+// videoThumbnailRequestURL builds the request URL the generator expects.
+//
+// mode == "post" (default, nekonoverse/video-thumb): `POST <base>/thumbnail`
+// with `multipart/form-data` (`file` field). sourceURL は使われない (bytes
+// で送る)。
+//
+// mode == "get" (Misskey TS-compatible): `GET <base>/thumbnail.webp?
+// thumbnail=1&url=<encoded>`. service 側で URL を fetch する前提。
 //
 // For UDS the original URL's authority and path are the socket path itself
 // (not part of the HTTP request line), so we drop them entirely and use
 // `http://localhost` as the placeholder host. `localhost` is what the
 // upstream service is most likely to accept in its Host header.
-func videoThumbnailRequestURL(genURL, sourceURL string) (string, error) {
+func videoThumbnailRequestURL(genURL, mode, sourceURL string) (string, error) {
+	base := ""
 	if strings.HasPrefix(genURL, "unix:") {
 		// `url.Parse` is only used to validate the input; the resulting
 		// fields are intentionally ignored — see comment above.
 		if _, err := url.Parse(genURL); err != nil {
 			return "", err
 		}
-		return "http://localhost/thumbnail.webp?thumbnail=1&url=" + url.QueryEscape(sourceURL), nil
+		base = "http://localhost"
+	} else {
+		base = strings.TrimRight(genURL, "/")
 	}
-	return strings.TrimRight(genURL, "/") + "/thumbnail.webp?thumbnail=1&url=" + url.QueryEscape(sourceURL), nil
+	if mode == "get" {
+		return base + "/thumbnail.webp?thumbnail=1&url=" + url.QueryEscape(sourceURL), nil
+	}
+	return base + "/thumbnail", nil
 }
 
-// fetchVideoThumbnail asks the configured external generator for a still
-// frame thumbnail of sourceURL. The returned bytes are an image (typically
-// WebP) that the caller will pipe through processAndReturn for further
-// resizing / format negotiation.
-func (s *Service) fetchVideoThumbnail(ctx context.Context, sourceURL string) ([]byte, string, error) {
+// fetchVideoThumbnail dispatches to the POST or GET wire based on the
+// configured mode and returns the still frame thumbnail (typically WebP).
+// The caller pipes the result back through processAndReturn for resize /
+// format negotiation.
+func (s *Service) fetchVideoThumbnail(ctx context.Context, body []byte, sourceMIME, sourceURL string) ([]byte, string, error) {
 	if s.videoThumbClient == nil {
 		return nil, "", ErrVideoThumbnailUnavailable
 	}
-	target, err := videoThumbnailRequestURL(s.videoThumbGen, sourceURL)
+	if s.videoThumbMode == "get" {
+		return s.fetchVideoThumbnailGET(ctx, sourceURL)
+	}
+	return s.fetchVideoThumbnailPOST(ctx, body, sourceMIME)
+}
+
+// fetchVideoThumbnailPOST uploads the video bytes via multipart POST to
+// nekonoverse/video-thumb-style endpoints. Bytes are forwarded from the
+// already-downloaded `body`, so the generator does not need to reach the
+// source URL itself (no extra SSRF surface on the generator).
+func (s *Service) fetchVideoThumbnailPOST(ctx context.Context, body []byte, sourceMIME string) ([]byte, string, error) {
+	target, err := videoThumbnailRequestURL(s.videoThumbGen, "post", "")
+	if err != nil {
+		return nil, "", fmt.Errorf("%w: %v", ErrVideoThumbnailUnavailable, err)
+	}
+
+	// multipart body 構築。field name "file" は nekonoverse/video-thumb の
+	// FastAPI endpoint が期待する固定値。filename はリモート URL から
+	// 取らない (個人情報を generator に伝えない方針) — 拡張子だけ MIME
+	// から推定して generic に。
+	var buf bytes.Buffer
+	w := multipart.NewWriter(&buf)
+	filename := "video" + extensionForMIME(sourceMIME)
+	part, err := w.CreateFormFile("file", filename)
+	if err != nil {
+		return nil, "", fmt.Errorf("%w: form: %v", ErrVideoThumbnailUnavailable, err)
+	}
+	if _, err := part.Write(body); err != nil {
+		return nil, "", fmt.Errorf("%w: write: %v", ErrVideoThumbnailUnavailable, err)
+	}
+	if err := w.Close(); err != nil {
+		return nil, "", fmt.Errorf("%w: close: %v", ErrVideoThumbnailUnavailable, err)
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, target, &buf)
+	if err != nil {
+		return nil, "", fmt.Errorf("%w: %v", ErrVideoThumbnailUnavailable, err)
+	}
+	req.Header.Set("User-Agent", s.userAgent)
+	req.Header.Set("Content-Type", w.FormDataContentType())
+	return s.doVideoThumbnailRequest(req)
+}
+
+// fetchVideoThumbnailGET asks a Misskey TS-compatible generator to fetch
+// sourceURL itself. Unlike POST mode, the generator must be able to reach
+// sourceURL from its network namespace.
+func (s *Service) fetchVideoThumbnailGET(ctx context.Context, sourceURL string) ([]byte, string, error) {
+	target, err := videoThumbnailRequestURL(s.videoThumbGen, "get", sourceURL)
 	if err != nil {
 		return nil, "", fmt.Errorf("%w: %v", ErrVideoThumbnailUnavailable, err)
 	}
@@ -95,6 +156,13 @@ func (s *Service) fetchVideoThumbnail(ctx context.Context, sourceURL string) ([]
 		return nil, "", fmt.Errorf("%w: %v", ErrVideoThumbnailUnavailable, err)
 	}
 	req.Header.Set("User-Agent", s.userAgent)
+	return s.doVideoThumbnailRequest(req)
+}
+
+// doVideoThumbnailRequest executes the prepared request and validates the
+// response shape (status / size cap / content type). Shared between POST
+// and GET wires.
+func (s *Service) doVideoThumbnailRequest(req *http.Request) ([]byte, string, error) {
 	resp, err := s.videoThumbClient.Do(req)
 	if err != nil {
 		return nil, "", fmt.Errorf("%w: %v", ErrVideoThumbnailUnavailable, err)
@@ -118,4 +186,28 @@ func (s *Service) fetchVideoThumbnail(ctx context.Context, sourceURL string) ([]
 		contentType = http.DetectContentType(data)
 	}
 	return data, contentType, nil
+}
+
+// extensionForMIME maps a small set of common video MIME types to filename
+// extensions. Unknown / arbitrary MIMEs fall back to ".bin" — the generator
+// uses ffmpeg autodetect which doesn't care about filename, so this only
+// helps debugging.
+func extensionForMIME(mime string) string {
+	switch strings.ToLower(mime) {
+	case "video/mp4", "video/x-m4v":
+		return ".mp4"
+	case "video/webm":
+		return ".webm"
+	case "video/quicktime":
+		return ".mov"
+	case "video/3gpp":
+		return ".3gp"
+	case "video/3gpp2":
+		return ".3g2"
+	case "video/mpeg":
+		return ".mpg"
+	case "video/ogg":
+		return ".ogv"
+	}
+	return ".bin"
 }

--- a/internal/core/mediaproxy/video_thumbnail_test.go
+++ b/internal/core/mediaproxy/video_thumbnail_test.go
@@ -2,6 +2,9 @@ package mediaproxy
 
 import (
 	"context"
+	"io"
+	"mime"
+	"mime/multipart"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
@@ -40,10 +43,41 @@ func TestProcessAndReturn_VideoFallback_NoGenerator(t *testing.T) {
 	assert.Equal(t, "image/png", res.ContentType)
 }
 
-// 外部 generator が設定されている場合、proxy は GET <gen>/thumbnail.webp?...
-// に委譲する。返ってきた静止画は image pipeline (resize → WebP) を通る。
-func TestProcessAndReturn_VideoGeneratorRoundtrip(t *testing.T) {
+// POST mode (default): mk-go は download 済 bytes を multipart で投げ、返
+// ってきた静止画を image pipeline (resize → WebP) に通す。
+func TestProcessAndReturn_VideoGeneratorRoundtrip_POST(t *testing.T) {
 	gen := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodPost, r.Method)
+		assert.Equal(t, "/thumbnail", r.URL.Path)
+		// multipart body の field "file" に bytes が乗っていることを確認
+		_, params, err := mime.ParseMediaType(r.Header.Get("Content-Type"))
+		require.NoError(t, err)
+		mr := multipart.NewReader(r.Body, params["boundary"])
+		part, err := mr.NextPart()
+		require.NoError(t, err)
+		assert.Equal(t, "file", part.FormName())
+		body, _ := io.ReadAll(part)
+		assert.Equal(t, "fake video bytes", string(body))
+		w.Header().Set("Content-Type", "image/png")
+		_, _ = w.Write(makePNG())
+	}))
+	defer gen.Close()
+
+	s := testService(nil)
+	s.SetVideoThumbnailGenerator(gen.URL)
+	s.videoThumbClient = gen.Client()
+
+	res, err := s.processAndReturn(context.Background(), []byte("fake video bytes"), "video/mp4", ModePreview, FormatWebP, "https://remote.example/clip.mp4")
+	require.NoError(t, err)
+	defer res.Body.Close()
+	assert.Equal(t, "image/webp", res.ContentType, "thumbnail must be re-encoded to webp")
+}
+
+// GET mode: Misskey TS 互換。クライアントは sourceURL を query で送り、
+// generator 側が自分で fetch する。bytes は送らない。
+func TestProcessAndReturn_VideoGeneratorRoundtrip_GET(t *testing.T) {
+	gen := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodGet, r.Method)
 		assert.Equal(t, "/thumbnail.webp", r.URL.Path)
 		assert.Equal(t, "1", r.URL.Query().Get("thumbnail"))
 		assert.Equal(t, "https://remote.example/clip.mp4", r.URL.Query().Get("url"))
@@ -53,14 +87,13 @@ func TestProcessAndReturn_VideoGeneratorRoundtrip(t *testing.T) {
 	defer gen.Close()
 
 	s := testService(nil)
-	s.SetVideoThumbnailGenerator(gen.URL)
-	// httptest server の HTTP client を尊重させる (ssl 検証回避用 fake transport)
+	s.SetVideoThumbnailGeneratorWithMode(gen.URL, "get")
 	s.videoThumbClient = gen.Client()
 
-	res, err := s.processAndReturn(context.Background(), nil, "video/mp4", ModePreview, FormatWebP, "https://remote.example/clip.mp4")
+	res, err := s.processAndReturn(context.Background(), []byte("fake video bytes"), "video/mp4", ModePreview, FormatWebP, "https://remote.example/clip.mp4")
 	require.NoError(t, err)
 	defer res.Body.Close()
-	assert.Equal(t, "image/webp", res.ContentType, "thumbnail must be re-encoded to webp")
+	assert.Equal(t, "image/webp", res.ContentType)
 }
 
 // Generator が 5xx を返した場合、proxy は dummy PNG にフォールバックして
@@ -75,17 +108,20 @@ func TestProcessAndReturn_VideoGeneratorFailure(t *testing.T) {
 	s.SetVideoThumbnailGenerator(gen.URL)
 	s.videoThumbClient = gen.Client()
 
-	res, err := s.processAndReturn(context.Background(), nil, "video/mp4", ModePreview, FormatWebP, "https://remote.example/clip.mp4")
+	res, err := s.processAndReturn(context.Background(), []byte("fake video bytes"), "video/mp4", ModePreview, FormatWebP, "https://remote.example/clip.mp4")
 	require.NoError(t, err)
 	defer res.Body.Close()
 	assert.Equal(t, "image/png", res.ContentType)
 }
 
-// Local /files/ source は generator にループバックさせない (M1 swap 経路で
-// 既に解決済の前提)。
-func TestProcessAndReturn_VideoLocalSourceSkipsGenerator(t *testing.T) {
-	gen := httptest.NewServer(http.HandlerFunc(func(_ http.ResponseWriter, _ *http.Request) {
-		t.Fatal("generator must not be called for local /files/ sources")
+// POST mode は bytes を送るので local /files/ source も同じ path で扱える
+// (skip しない)。
+func TestProcessAndReturn_VideoLocalSource_POSTForwardsBytes(t *testing.T) {
+	hit := false
+	gen := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		hit = true
+		w.Header().Set("Content-Type", "image/png")
+		_, _ = w.Write(makePNG())
 	}))
 	defer gen.Close()
 
@@ -93,17 +129,27 @@ func TestProcessAndReturn_VideoLocalSourceSkipsGenerator(t *testing.T) {
 	s.SetVideoThumbnailGenerator(gen.URL)
 	s.videoThumbClient = gen.Client()
 
-	res, err := s.processAndReturn(context.Background(), nil, "video/mp4", ModePreview, FormatWebP, "https://example.com/files/abc123")
+	res, err := s.processAndReturn(context.Background(), []byte("local video bytes"), "video/mp4", ModePreview, FormatWebP, "https://example.com/files/abc123")
 	require.NoError(t, err)
 	defer res.Body.Close()
-	assert.Equal(t, "image/png", res.ContentType)
+	assert.True(t, hit, "POST mode forwards bytes regardless of source URL origin")
+	assert.Equal(t, "image/webp", res.ContentType)
 }
 
-// videoThumbnailRequestURL builds the expected target for both the plain HTTP
-// and Unix domain socket cases.
+// videoThumbnailRequestURL builds the expected target for POST / GET wires
+// over plain HTTP and UDS.
 func TestVideoThumbnailRequestURL(t *testing.T) {
-	t.Run("http", func(t *testing.T) {
-		got, err := videoThumbnailRequestURL("https://thumb.example.com", "https://video.example.com/clip.mp4")
+	t.Run("http_post", func(t *testing.T) {
+		got, err := videoThumbnailRequestURL("https://thumb.example.com", "post", "")
+		require.NoError(t, err)
+		u, err := url.Parse(got)
+		require.NoError(t, err)
+		assert.Equal(t, "thumb.example.com", u.Host)
+		assert.Equal(t, "/thumbnail", u.Path)
+		assert.Empty(t, u.RawQuery)
+	})
+	t.Run("http_get", func(t *testing.T) {
+		got, err := videoThumbnailRequestURL("https://thumb.example.com", "get", "https://video.example.com/clip.mp4")
 		require.NoError(t, err)
 		u, err := url.Parse(got)
 		require.NoError(t, err)
@@ -111,8 +157,13 @@ func TestVideoThumbnailRequestURL(t *testing.T) {
 		assert.Equal(t, "/thumbnail.webp", u.Path)
 		assert.Equal(t, "https://video.example.com/clip.mp4", u.Query().Get("url"))
 	})
-	t.Run("unix", func(t *testing.T) {
-		got, err := videoThumbnailRequestURL("unix:///run/video-thumb.sock", "https://video.example.com/clip.mp4")
+	t.Run("unix_post", func(t *testing.T) {
+		got, err := videoThumbnailRequestURL("unix:///run/video-thumb.sock", "post", "")
+		require.NoError(t, err)
+		assert.Equal(t, "http://localhost/thumbnail", got)
+	})
+	t.Run("unix_get", func(t *testing.T) {
+		got, err := videoThumbnailRequestURL("unix:///run/video-thumb.sock", "get", "https://video.example.com/clip.mp4")
 		require.NoError(t, err)
 		assert.True(t, strings.HasPrefix(got, "http://localhost/thumbnail.webp"))
 		u, err := url.Parse(got)
@@ -120,15 +171,11 @@ func TestVideoThumbnailRequestURL(t *testing.T) {
 		assert.Equal(t, "https://video.example.com/clip.mp4", u.Query().Get("url"))
 	})
 	t.Run("unix with stray query is ignored", func(t *testing.T) {
-		got, err := videoThumbnailRequestURL("unix:///run/video-thumb.sock?token=xyz", "https://video.example.com/clip.mp4")
+		got, err := videoThumbnailRequestURL("unix:///run/video-thumb.sock?token=xyz", "post", "")
 		require.NoError(t, err)
-		// Stray query on the unix:// URL must NOT leak into the request URL
-		// (regression for the TrimRight(s, "") dead-code from the previous
-		// commit).
-		assert.True(t, strings.HasPrefix(got, "http://localhost/thumbnail.webp"))
-		u, err := url.Parse(got)
-		require.NoError(t, err)
-		assert.Equal(t, "", u.Query().Get("token"))
+		// Stray query on the unix:// URL must NOT leak into the request
+		// URL (regression for the TrimRight(s, "") dead-code).
+		assert.Equal(t, "http://localhost/thumbnail", got)
 	})
 }
 
@@ -136,7 +183,7 @@ func TestVideoThumbnailRequestURL(t *testing.T) {
 // is configured.
 func TestFetchVideoThumbnail_NoClient(t *testing.T) {
 	s := testService(nil)
-	_, _, err := s.fetchVideoThumbnail(context.Background(), "https://x/clip.mp4")
+	_, _, err := s.fetchVideoThumbnail(context.Background(), []byte("x"), "video/mp4", "https://x/clip.mp4")
 	assert.ErrorIs(t, err, ErrVideoThumbnailUnavailable)
 }
 
@@ -148,6 +195,33 @@ func TestNewVideoThumbnailClient_EmptyURL(t *testing.T) {
 // videoThumbnailClient: malformed unix:// URL → nil (no panic).
 func TestNewVideoThumbnailClient_BadUnixURL(t *testing.T) {
 	assert.Nil(t, newVideoThumbnailClient("unix://"))
+}
+
+// SetVideoThumbnailGeneratorWithMode: 不正な mode は "post" に倒れる。
+func TestSetVideoThumbnailGeneratorWithMode_FallsBackToPOST(t *testing.T) {
+	s := testService(nil)
+	s.SetVideoThumbnailGeneratorWithMode("https://thumb.example", "ftp")
+	assert.Equal(t, "post", s.videoThumbMode)
+}
+
+// extensionForMIME maps known video MIME types; unknown falls back to .bin
+// (filename hint only — generator uses ffmpeg autodetect).
+func TestExtensionForMIME(t *testing.T) {
+	cases := map[string]string{
+		"video/mp4":       ".mp4",
+		"VIDEO/MP4":       ".mp4",
+		"video/webm":      ".webm",
+		"video/quicktime": ".mov",
+		"video/3gpp":      ".3gp",
+		"video/3gpp2":     ".3g2",
+		"video/mpeg":      ".mpg",
+		"video/ogg":       ".ogv",
+		"":                ".bin",
+		"image/png":       ".bin",
+	}
+	for in, want := range cases {
+		assert.Equal(t, want, extensionForMIME(in), "%q", in)
+	}
 }
 
 // TestIsResizeMode covers the predicate used to gate video thumbnail logic.

--- a/internal/core/mediaproxy/video_thumbnail_test.go
+++ b/internal/core/mediaproxy/video_thumbnail_test.go
@@ -5,11 +5,14 @@ import (
 	"io"
 	"mime"
 	"mime/multipart"
+	"net"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
+	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -208,20 +211,105 @@ func TestSetVideoThumbnailGeneratorWithMode_FallsBackToPOST(t *testing.T) {
 // (filename hint only — generator uses ffmpeg autodetect).
 func TestExtensionForMIME(t *testing.T) {
 	cases := map[string]string{
-		"video/mp4":       ".mp4",
-		"VIDEO/MP4":       ".mp4",
-		"video/webm":      ".webm",
-		"video/quicktime": ".mov",
-		"video/3gpp":      ".3gp",
-		"video/3gpp2":     ".3g2",
-		"video/mpeg":      ".mpg",
-		"video/ogg":       ".ogv",
-		"":                ".bin",
-		"image/png":       ".bin",
+		"video/mp4":        ".mp4",
+		"VIDEO/MP4":        ".mp4",
+		"video/webm":       ".webm",
+		"video/quicktime":  ".mov",
+		"video/3gpp":       ".3gp",
+		"video/3gpp2":      ".3g2",
+		"video/mpeg":       ".mpg",
+		"video/ogg":        ".ogv",
+		"video/x-matroska": ".mkv",
+		"video/mp2t":       ".ts",
+		"":                 ".bin",
+		"image/png":        ".bin",
 	}
 	for in, want := range cases {
 		assert.Equal(t, want, extensionForMIME(in), "%q", in)
 	}
+}
+
+// GET mode で local /files/ source は generator にループバックさせず dummy
+// PNG fallback (review PR #646 #1)。
+func TestProcessAndReturn_VideoLocalSource_GETSkipsGenerator(t *testing.T) {
+	gen := httptest.NewServer(http.HandlerFunc(func(_ http.ResponseWriter, _ *http.Request) {
+		t.Fatal("GET mode must NOT call generator for local /files/ sources")
+	}))
+	defer gen.Close()
+
+	s := testService(nil)
+	s.SetVideoThumbnailGeneratorWithMode(gen.URL, "get")
+	s.videoThumbClient = gen.Client()
+
+	res, err := s.processAndReturn(context.Background(), []byte("local"), "video/mp4", ModePreview, FormatWebP, "https://example.com/files/abc123")
+	require.NoError(t, err)
+	defer res.Body.Close()
+	assert.Equal(t, "image/png", res.ContentType, "must fall back to dummy PNG")
+}
+
+// POST mode + UDS の e2e roundtrip (review PR #646 #4)。tempfile unix
+// socket に net.Listen → http.Server をかぶせて、mk-go の UDS dialer
+// 経由で multipart POST が届くことを確認。
+func TestProcessAndReturn_VideoGeneratorRoundtrip_UDS_POST(t *testing.T) {
+	dir := t.TempDir()
+	sockPath := filepath.Join(dir, "video-thumb.sock")
+	ln, err := net.Listen("unix", sockPath)
+	require.NoError(t, err)
+	defer ln.Close()
+
+	hit := make(chan struct{}, 1)
+	srv := &http.Server{
+		Handler: http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			assert.Equal(t, http.MethodPost, r.Method)
+			assert.Equal(t, "/thumbnail", r.URL.Path)
+			_, params, err := mime.ParseMediaType(r.Header.Get("Content-Type"))
+			require.NoError(t, err)
+			mr := multipart.NewReader(r.Body, params["boundary"])
+			part, err := mr.NextPart()
+			require.NoError(t, err)
+			body, _ := io.ReadAll(part)
+			assert.Equal(t, "uds video bytes", string(body))
+			w.Header().Set("Content-Type", "image/png")
+			_, _ = w.Write(makePNG())
+			hit <- struct{}{}
+		}),
+	}
+	go func() { _ = srv.Serve(ln) }()
+	defer srv.Close()
+
+	s := testService(nil)
+	s.SetVideoThumbnailGenerator("unix://" + sockPath)
+	require.NotNil(t, s.videoThumbClient, "UDS client must be wired")
+
+	res, err := s.processAndReturn(context.Background(), []byte("uds video bytes"), "video/mp4", ModePreview, FormatWebP, "https://remote.example/clip.mp4")
+	require.NoError(t, err)
+	defer res.Body.Close()
+	assert.Equal(t, "image/webp", res.ContentType)
+	select {
+	case <-hit:
+	case <-time.After(2 * time.Second):
+		t.Fatal("UDS POST did not reach the generator within 2s")
+	}
+}
+
+// Generator が image/* 以外の Content-Type を返した場合は dummy PNG に
+// 倒し、raw HTML / JSON が proxy 経由で frontend に届くのを防ぐ
+// (review PR #646 #3)。
+func TestProcessAndReturn_VideoGeneratorNonImageRejected(t *testing.T) {
+	gen := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "text/html")
+		_, _ = w.Write([]byte("<html>not an image</html>"))
+	}))
+	defer gen.Close()
+
+	s := testService(nil)
+	s.SetVideoThumbnailGenerator(gen.URL)
+	s.videoThumbClient = gen.Client()
+
+	res, err := s.processAndReturn(context.Background(), []byte("video bytes"), "video/mp4", ModePreview, FormatWebP, "https://remote.example/clip.mp4")
+	require.NoError(t, err)
+	defer res.Body.Close()
+	assert.Equal(t, "image/png", res.ContentType, "non-image response must be rejected → dummy PNG")
 }
 
 // TestIsResizeMode covers the predicate used to gate video thumbnail logic.

--- a/internal/server/router.go
+++ b/internal/server/router.go
@@ -1334,8 +1334,13 @@ func (s *Server) setupRoutes() {
 	// 動画 still frame の生成は外部 service に委譲する (#637 M2 redesign)。
 	// config.videoThumbnailGenerator が空のときは disabled (proxy は dummy
 	// PNG を返す)。`unix:///path/socket` 形式で UDS deployment にも対応。
+	// videoThumbnailGeneratorMode で wire を選択 ("post" 既定 / "get" は
+	// Misskey TS 互換)。
 	if s.config.VideoThumbnailGenerator != "" {
-		proxyService.SetVideoThumbnailGenerator(s.config.VideoThumbnailGenerator)
+		proxyService.SetVideoThumbnailGeneratorWithMode(
+			s.config.VideoThumbnailGenerator,
+			s.config.VideoThumbnailGeneratorMode,
+		)
 	}
 	proxyHandler := apiproxy.NewHandler(proxyService, s.config)
 	s.echo.GET("/proxy/*", proxyHandler.Handle)


### PR DESCRIPTION
## Summary

#637 M2 で実装した videoThumbnailGenerator client を Misskey TS の GET 経路に加えて **POST multipart wire** にも対応させ、default を POST に変更する。`make uds-up` で nekonoverse/video-thumb (推奨 backend sidecar) と疎通させた際に判明した API 不整合の解消。

## 背景

#637 マージ後の運用で `nekonoverse/video-thumb` の API は GET ではなく **POST multipart** であることが判明:

- mk-go (#637 実装) → \`GET <gen>/thumbnail.webp?thumbnail=1&url=<URL>\` (Misskey TS 仕様)
- nekonoverse/video-thumb → \`POST <gen>/thumbnail\` with multipart/form-data (\`file\` field)

frontend は /proxy/* の戻り値しか観測しないので wire を変えても drop-in 互換は維持される。両方 supportable にしておけば operator が好きな backend を選べる。

## 主な変更点

### Service / config
- \`Service.videoThumbMode\` field (\"post\" | \"get\") + \`SetVideoThumbnailGeneratorWithMode(genURL, mode)\` setter を新設
- 既存 \`SetVideoThumbnailGenerator\` は default \"post\" 経路に互換維持
- \`fetchVideoThumbnail\` が mode に応じて \`fetchVideoThumbnailPOST\` / \`fetchVideoThumbnailGET\` に dispatch
- 共通レスポンス処理を \`doVideoThumbnailRequest\` に集約 (status / size cap / Content-Type)
- POST mode で local /files/ source の skip ロジック撤廃 (bytes 経由なので URL origin は問わない)
- \`internal/config/config.go\` に \`VideoThumbnailGeneratorMode\` field + \`normalizeVideoThumbMode\` helper

### POST wire 仕様
- endpoint: \`<base>/thumbnail\` (no query)
- request: \`multipart/form-data\` with \`file\` field containing video bytes
- filename: \`video.<ext>\` (拡張子は MIME から推定、\`extensionForMIME\`)
- response: image bytes (typically WebP)

### Compose / image
- \`docker-compose.yml\` / \`compose.uds.yaml.example\` を \`ghcr.io/nekonoverse/video-thumb:unstable\` に更新 (公開 image)
- UDS overlay は \`UDS_PATH=/run/video-thumb/sock\` env で listen 切替
- TCP port を 8005 (image default) に修正
- 各 YAML example で POST / GET 両 mode の使い分けを明示

## Tests

| 種別 | 内容 |
|------|------|
| \`TestProcessAndReturn_VideoGeneratorRoundtrip_POST\` | multipart body の \`file\` field と bytes が正しく投げられる |
| \`TestProcessAndReturn_VideoGeneratorRoundtrip_GET\` | TS-style query が正しく組み立てられる |
| \`TestProcessAndReturn_VideoLocalSource_POSTForwardsBytes\` | POST mode で local source も generator に転送 |
| \`TestVideoThumbnailRequestURL\` | post / get × http / unix の 4 組 + stray query 除去 |
| \`TestSetVideoThumbnailGeneratorWithMode_FallsBackToPOST\` | 不正 mode の default fallback |
| \`TestExtensionForMIME\` | 主要 video MIME → 拡張子 mapping |

## Test plan

- [x] \`make fmt && make lint\`
- [x] \`go test -count=1 -timeout 5m ./...\` 全 pass
- [x] coverage: \`internal/core/mediaproxy\` 90.4% / \`internal/config\` 96.0%
- [x] ローカル \`make uds-up\` で video-thumb (UDS listen) 含む全 service healthy 起動を確認

## 関連

- 親 tracker: #637 (M2)
- Backend image: \`ghcr.io/nekonoverse/video-thumb\` (POST multipart implementation)

🤖 Generated with [Claude Code](https://claude.com/claude-code)