### PR TITLE
Fix #657: PackNotes / PackNoteWithInstance に ctx を伝播

### DIFF
--- a/cmd/dbgtimeline/main.go
+++ b/cmd/dbgtimeline/main.go
@@ -17,6 +17,7 @@
 package main
 
 import (
+	"context"
 	stdjson "encoding/json"
 	"flag"
 	"fmt"
@@ -90,7 +91,7 @@ func main() {
 	notes = hydrated
 	fmt.Printf("Loaded %d notes\n", len(notes))
 
-	packed := entity.PackNotes(notes, idGen, instanceRepo, emojiRepo, nil)
+	packed := entity.PackNotes(context.Background(), notes, idGen, instanceRepo, emojiRepo, nil)
 	// PackNotes は notes 1 件ごとに必ず 1 件の packed entity を append する
 	// 契約 (内部実装は internal/entity/note.go の PackNotes を参照)。後続
 	// ループで notes[i] と packed[i] を 1:1 対応で参照するため、契約破綻時

--- a/internal/api/antennas/handler.go
+++ b/internal/api/antennas/handler.go
@@ -263,7 +263,7 @@ func (h *Handler) Notes(c echo.Context) error {
 	if err != nil {
 		return apierr.JSONInternalError(c)
 	}
-	entities := entity.PackNotes(notes, h.idGen, h.instanceLookup(), h.emojiLookup(), h.reactionReader())
+	entities := entity.PackNotes(c.Request().Context(), notes, h.idGen, h.instanceLookup(), h.emojiLookup(), h.reactionReader())
 	h.fieldRes.Apply(entities, user)
 	out := make([]any, 0, len(entities))
 	for _, pn := range entities {

--- a/internal/api/channels/handler.go
+++ b/internal/api/channels/handler.go
@@ -349,7 +349,7 @@ func (h *Handler) Timeline(c echo.Context) error {
 		return apierr.JSONInternalError(c)
 	}
 	viewer := middleware.GetUser(c)
-	entities := entity.PackNotes(notes, h.idGen, h.instanceLookup(), h.emojiLookup(), h.reactionReader())
+	entities := entity.PackNotes(c.Request().Context(), notes, h.idGen, h.instanceLookup(), h.emojiLookup(), h.reactionReader())
 	h.fieldRes.Apply(entities, viewer)
 	out := make([]any, 0, len(entities))
 	for _, pn := range entities {

--- a/internal/api/clips/handler.go
+++ b/internal/api/clips/handler.go
@@ -301,7 +301,7 @@ func (h *Handler) Notes(c echo.Context) error {
 		}
 		return apierr.JSONInternalError(c)
 	}
-	entities := entity.PackNotes(notes, h.idGen, h.instanceLookup(), h.emojiLookup(), h.reactionReader())
+	entities := entity.PackNotes(c.Request().Context(), notes, h.idGen, h.instanceLookup(), h.emojiLookup(), h.reactionReader())
 	h.fieldRes.Apply(entities, user)
 	out := make([]any, 0, len(entities))
 	for _, pn := range entities {

--- a/internal/api/drive/handler.go
+++ b/internal/api/drive/handler.go
@@ -487,7 +487,7 @@ func (h *Handler) FilesAttachedNotes(c echo.Context) error {
 		return c.JSON(http.StatusOK, []any{})
 	}
 	viewer := middleware.GetUser(c)
-	out := entity.PackNotes(notes, h.idGen, h.instanceLookup(), h.emojiLookup(), h.reactionReader())
+	out := entity.PackNotes(c.Request().Context(), notes, h.idGen, h.instanceLookup(), h.emojiLookup(), h.reactionReader())
 	h.fieldRes.Apply(out, viewer)
 	return c.JSON(http.StatusOK, out)
 }

--- a/internal/api/i/handler.go
+++ b/internal/api/i/handler.go
@@ -583,7 +583,7 @@ func (h *Handler) Me(c echo.Context) error {
 	// 未wireのものは false/0/[] にフォールバックする (テスト互換)。
 	// antenna / channel / specifiedNotes は別issueで追跡中のためここでは false 固定。
 	h.fillUnreadFields(c.Request().Context(), u, resp)
-	h.fillPinnedFields(u, profile, resp)
+	h.fillPinnedFields(c.Request().Context(), u, profile, resp)
 	resp["policies"] = userPolicies
 	resp["roles"] = userRoles
 	// securityKeysList: WebAuthnキーの一覧
@@ -1066,7 +1066,7 @@ func (h *Handler) fillUnreadFields(ctx context.Context, u *model.User, resp map[
 // fillPinnedFields populates pinnedNoteIds / pinnedNotes / pinnedPageId /
 // pinnedPage onto resp using the wired repos. Missing repos fall back to
 // default empty / nil (tests that skip wiring keep passing).
-func (h *Handler) fillPinnedFields(u *model.User, profile *model.UserProfile, resp map[string]any) {
+func (h *Handler) fillPinnedFields(ctx context.Context, u *model.User, profile *model.UserProfile, resp map[string]any) {
 	// Defaults
 	resp["pinnedNoteIds"] = []string{}
 	resp["pinnedNotes"] = []any{}
@@ -1086,7 +1086,7 @@ func (h *Handler) fillPinnedFields(u *model.User, profile *model.UserProfile, re
 
 			if h.noteRepo != nil {
 				if notes, err := h.noteRepo.FindManyByIDsWithUser(ids); err == nil {
-					entities := entity.PackNotes(notes, h.idGen, h.instanceLookup(), h.emojiLookup(), h.reactionReader())
+					entities := entity.PackNotes(ctx, notes, h.idGen, h.instanceLookup(), h.emojiLookup(), h.reactionReader())
 					// /api/i は認証された自身を返す path なので u 自身を viewer
 					// として渡し、pinned note の myReaction も含めて埋める (#426)。
 					h.fieldRes.Apply(entities, u)

--- a/internal/api/i/handler_extra.go
+++ b/internal/api/i/handler_extra.go
@@ -103,7 +103,7 @@ func (h *Handler) Favorites(c echo.Context) error {
 			notes = append(notes, f.Note)
 		}
 	}
-	packed := entity.PackNotes(notes, h.idGen, h.instanceLookup(), h.emojiLookup(), h.reactionReader())
+	packed := entity.PackNotes(c.Request().Context(), notes, h.idGen, h.instanceLookup(), h.emojiLookup(), h.reactionReader())
 	// /api/i/favorites は認証 path なので u が viewer。pinned notes と同じく
 	// 自分の myReaction / Channel / Files を埋める (#426)。
 	h.fieldRes.Apply(packed, u)

--- a/internal/api/notes/handler.go
+++ b/internal/api/notes/handler.go
@@ -1,6 +1,7 @@
 package notes
 
 import (
+	"context"
 	"errors"
 	"net/http"
 	"time"
@@ -261,7 +262,7 @@ func (h *Handler) Create(c echo.Context) error {
 		return apierr.JSONInternalError(c)
 	}
 
-	packed := entity.PackNoteWithInstance(created, h.idGen, h.instanceLookup(), h.emojiLookup(), h.reactionReader())
+	packed := entity.PackNoteWithInstance(c.Request().Context(), created, h.idGen, h.instanceLookup(), h.emojiLookup(), h.reactionReader())
 	s := []entity.NoteEntity{packed}
 	h.fieldResolver().Apply(s, user)
 	return c.JSON(http.StatusOK, map[string]any{
@@ -287,7 +288,7 @@ func (h *Handler) Show(c echo.Context) error {
 		return apierr.JSONNoSuchNote(c)
 	}
 
-	packed := entity.PackNoteWithInstance(n, h.idGen, h.instanceLookup(), h.emojiLookup(), h.reactionReader())
+	packed := entity.PackNoteWithInstance(c.Request().Context(), n, h.idGen, h.instanceLookup(), h.emojiLookup(), h.reactionReader())
 	s := []entity.NoteEntity{packed}
 	h.fieldResolver().Apply(s, viewer)
 	return c.JSON(http.StatusOK, s[0])
@@ -387,7 +388,7 @@ func (h *Handler) serveList(c echo.Context, fn func(*model.User, listRequest) ([
 		}
 		return apierr.JSONInternalError(c)
 	}
-	return c.JSON(http.StatusOK, h.packMany(notes, viewer))
+	return c.JSON(http.StatusOK, h.packMany(c.Request().Context(), notes, viewer))
 }
 
 // SearchRequest is the request body for notes/search.
@@ -455,7 +456,7 @@ func (h *Handler) Search(c echo.Context) error {
 		}
 		return apierr.JSONInternalError(c)
 	}
-	return c.JSON(http.StatusOK, h.packMany(notes, viewer))
+	return c.JSON(http.StatusOK, h.packMany(c.Request().Context(), notes, viewer))
 }
 
 // State handles POST /api/notes/state.
@@ -498,7 +499,7 @@ func (h *Handler) Conversation(c echo.Context) error {
 		// 現状QueryService.ConversationはErrNoteNotFound以外を返さない
 		return apierr.JSONNoSuchNote(c)
 	}
-	return c.JSON(http.StatusOK, h.packMany(notes, viewer))
+	return c.JSON(http.StatusOK, h.packMany(c.Request().Context(), notes, viewer))
 }
 
 // BulkShow handles POST /api/notes — bulk note lookup by noteIds.
@@ -529,7 +530,7 @@ func (h *Handler) BulkShow(c echo.Context) error {
 		return c.JSON(http.StatusOK, []any{})
 	}
 	notes = h.queryService.FilterVisible(viewer, notes)
-	return c.JSON(http.StatusOK, h.packMany(notes, viewer))
+	return c.JSON(http.StatusOK, h.packMany(c.Request().Context(), notes, viewer))
 }
 
 // packMany serializes a list of notes into NoteEntity objects.
@@ -539,8 +540,8 @@ func (h *Handler) BulkShow(c echo.Context) error {
 // Files / MyReaction / Channel の解決は entity.NoteFieldResolver に切り出して
 // あり、他の PackNotes 利用 handler (antennas / users / pinned 等) と共通化
 // している (#426)。
-func (h *Handler) packMany(notes []*model.Note, viewer *model.User) []entity.NoteEntity {
-	out := entity.PackNotes(notes, h.idGen, h.instanceLookup(), h.emojiLookup(), h.reactionReader())
+func (h *Handler) packMany(ctx context.Context, notes []*model.Note, viewer *model.User) []entity.NoteEntity {
+	out := entity.PackNotes(ctx, notes, h.idGen, h.instanceLookup(), h.emojiLookup(), h.reactionReader())
 	h.fieldResolver().Apply(out, viewer)
 	return out
 }

--- a/internal/api/notes/handler_extra.go
+++ b/internal/api/notes/handler_extra.go
@@ -90,7 +90,7 @@ func (h *Handler) Featured(c echo.Context) error {
 	if err != nil {
 		return c.JSON(http.StatusInternalServerError, apierr.Error("INTERNAL_ERROR", "Internal error.", "5d37dbcb-891e-41ca-a3d6-e690c97775ac"))
 	}
-	return c.JSON(http.StatusOK, h.packMany(notes, middleware.GetUser(c)))
+	return c.JSON(http.StatusOK, h.packMany(c.Request().Context(), notes, middleware.GetUser(c)))
 }
 
 // Unrenote handles POST /api/notes/unrenote.
@@ -146,7 +146,7 @@ func (h *Handler) Mentions(c echo.Context) error {
 			}
 		}
 	}
-	return c.JSON(http.StatusOK, h.packMany(filtered, user))
+	return c.JSON(http.StatusOK, h.packMany(c.Request().Context(), filtered, user))
 }
 
 // UserListTimeline handles POST /api/notes/user-list-timeline.
@@ -181,7 +181,7 @@ func (h *Handler) UserListTimeline(c echo.Context) error {
 	if err != nil {
 		return c.JSON(http.StatusInternalServerError, apierr.Error("INTERNAL_ERROR", "Internal error.", "5d37dbcb-891e-41ca-a3d6-e690c97775ac"))
 	}
-	return c.JSON(http.StatusOK, h.packMany(notes, me))
+	return c.JSON(http.StatusOK, h.packMany(c.Request().Context(), notes, me))
 }
 
 // SearchByTag handles POST /api/notes/search-by-tag.
@@ -218,7 +218,7 @@ func (h *Handler) SearchByTag(c echo.Context) error {
 	if err != nil {
 		return c.JSON(http.StatusOK, []entity.NoteEntity{})
 	}
-	return c.JSON(http.StatusOK, h.packMany(notes, middleware.GetUser(c)))
+	return c.JSON(http.StatusOK, h.packMany(c.Request().Context(), notes, middleware.GetUser(c)))
 }
 
 // Clips handles POST /api/notes/clips.
@@ -287,5 +287,5 @@ func (h *Handler) ShowPartialBulk(c echo.Context) error {
 		return c.JSON(http.StatusOK, []entity.NoteEntity{})
 	}
 	notes = h.queryService.FilterVisible(viewer, notes)
-	return c.JSON(http.StatusOK, h.packMany(notes, viewer))
+	return c.JSON(http.StatusOK, h.packMany(c.Request().Context(), notes, viewer))
 }

--- a/internal/api/notes/timeline_handler.go
+++ b/internal/api/notes/timeline_handler.go
@@ -158,5 +158,5 @@ func (h *Handler) serveTimeline(
 		// ErrUnauthenticatedはここには到達しない。残りはRedis等の障害のみ。
 		return apierr.JSONInternalError(c)
 	}
-	return c.JSON(http.StatusOK, h.packMany(notes, viewer))
+	return c.JSON(http.StatusOK, h.packMany(c.Request().Context(), notes, viewer))
 }

--- a/internal/api/roles/handler.go
+++ b/internal/api/roles/handler.go
@@ -167,7 +167,7 @@ func (h *Handler) Notes(c echo.Context) error {
 	}
 
 	viewer := middleware.GetUser(c)
-	entities := entity.PackNotes(notes, h.idGen, h.instanceLookup(), h.emojiLookup(), h.reactionReader())
+	entities := entity.PackNotes(c.Request().Context(), notes, h.idGen, h.instanceLookup(), h.emojiLookup(), h.reactionReader())
 	h.fieldRes.Apply(entities, viewer)
 	out := make([]any, 0, len(entities))
 	for _, pn := range entities {

--- a/internal/api/users/handler.go
+++ b/internal/api/users/handler.go
@@ -1,6 +1,7 @@
 package users
 
 import (
+	"context"
 	"errors"
 	"net/http"
 	"sync"
@@ -292,7 +293,7 @@ func (h *Handler) Show(c echo.Context) error {
 
 	// Phase 7-3 (#245): ピン止めnote / ピン止めpage を埋める。viewer は
 	// pinned note の myReaction を埋めるのに使う (#426)。
-	h.fillPinned(viewer, bundle.User, bundle.Profile, &detailed)
+	h.fillPinned(c.Request().Context(), viewer, bundle.User, bundle.Profile, &detailed)
 
 	// viewerがログインしている場合、viewer依存フィールドを並列取得する。
 	// 各リポジトリへのクエリは完全に独立しているためgoroutineで並列実行し、
@@ -443,7 +444,7 @@ func (h *Handler) Notes(c echo.Context) error {
 	}
 
 	viewer := middleware.GetUser(c)
-	out := entity.PackNotes(notes, h.idGen, h.instanceLookup(), h.emojiLookup(), h.reactionReader())
+	out := entity.PackNotes(c.Request().Context(), notes, h.idGen, h.instanceLookup(), h.emojiLookup(), h.reactionReader())
 	h.fieldRes.Apply(out, viewer)
 	return c.JSON(http.StatusOK, out)
 }
@@ -605,7 +606,7 @@ func (h *Handler) packRelationItems(
 //
 // viewer は users/show を叩いている認証ユーザー (匿名なら nil)。pinned note
 // の myReaction を埋めるために fieldRes.Apply に流す (#426)。
-func (h *Handler) fillPinned(viewer *model.User, u *model.User, profile *model.UserProfile, detailed *entity.UserDetailed) {
+func (h *Handler) fillPinned(ctx context.Context, viewer *model.User, u *model.User, profile *model.UserProfile, detailed *entity.UserDetailed) {
 	if h.piningRepo != nil {
 		if pinings, err := h.piningRepo.ListByUser(u.ID); err == nil && len(pinings) > 0 {
 			ids := make([]string, 0, len(pinings))
@@ -615,7 +616,7 @@ func (h *Handler) fillPinned(viewer *model.User, u *model.User, profile *model.U
 			detailed.PinnedNoteIDs = ids
 			if h.noteRepo != nil {
 				if notes, err := h.noteRepo.FindManyByIDsWithUser(ids); err == nil {
-					entities := entity.PackNotes(notes, h.idGen, h.instanceLookup(), h.emojiLookup(), h.reactionReader())
+					entities := entity.PackNotes(ctx, notes, h.idGen, h.instanceLookup(), h.emojiLookup(), h.reactionReader())
 					h.fieldRes.Apply(entities, viewer)
 					packed := make([]any, 0, len(entities))
 					for _, pn := range entities {

--- a/internal/api/users/handler_extra.go
+++ b/internal/api/users/handler_extra.go
@@ -97,7 +97,7 @@ func (h *Handler) FeaturedNotes(c echo.Context) error {
 		return c.JSON(http.StatusInternalServerError, apierr.Error("INTERNAL_ERROR", "Internal error.", "5d37dbcb-891e-41ca-a3d6-e690c97775ac"))
 	}
 	viewer := middleware.GetUser(c)
-	result := entity.PackNotes(notes, h.idGen, h.instanceLookup(), h.emojiLookup(), h.reactionReader())
+	result := entity.PackNotes(c.Request().Context(), notes, h.idGen, h.instanceLookup(), h.emojiLookup(), h.reactionReader())
 	h.fieldRes.Apply(result, viewer)
 	return c.JSON(http.StatusOK, result)
 }

--- a/internal/entity/instance_resolver_test.go
+++ b/internal/entity/instance_resolver_test.go
@@ -1,6 +1,7 @@
 package entity
 
 import (
+	"context"
 	"errors"
 	"testing"
 
@@ -123,7 +124,7 @@ func TestPackNotes_PopulatesRemoteUserInstance(t *testing.T) {
 		{ID: "n2", UserID: "u2", User: &model.User{ID: "u2", Username: "bob"}}, // local
 	}
 
-	out := PackNotes(notes, idGen, lookup, nil, nil)
+	out := PackNotes(context.Background(), notes, idGen, lookup, nil, nil)
 	require.Len(t, out, 2)
 	require.NotNil(t, out[0].User.Instance)
 	assert.Equal(t, "Remote HQ", *out[0].User.Instance.Name)
@@ -139,7 +140,7 @@ func TestPackNotes_NilLookup_InstanceRemainsNil(t *testing.T) {
 	notes := []*model.Note{
 		{ID: "n1", UserID: "u1", User: &model.User{ID: "u1", Username: "alice", Host: &host}},
 	}
-	out := PackNotes(notes, idGen, nil, nil, nil)
+	out := PackNotes(context.Background(), notes, idGen, nil, nil, nil)
 	require.Len(t, out, 1)
 	assert.Nil(t, out[0].User.Instance)
 }
@@ -154,7 +155,7 @@ func TestPackNoteWithInstance(t *testing.T) {
 	host := "solo.example"
 	n := &model.Note{ID: "n1", UserID: "u1", User: &model.User{ID: "u1", Username: "alice", Host: &host}}
 
-	packed := PackNoteWithInstance(n, idGen, lookup, nil, nil)
+	packed := PackNoteWithInstance(context.Background(), n, idGen, lookup, nil, nil)
 	require.NotNil(t, packed.User.Instance)
 	assert.Equal(t, "Solo", *packed.User.Instance.Name)
 }

--- a/internal/entity/note.go
+++ b/internal/entity/note.go
@@ -179,15 +179,16 @@ func packNoteAtDepth(n *model.Note, idGen id.Generator, depth int) NoteEntity {
 // flat 内の各 note.Reactions に in-place merge してから resolver を構築する
 // (#647)。これにより enableReactionsBuffering=true でも timeline / show
 // レスポンスで最新 reaction count / emoji が返る。reader が nil なら
-// 旧挙動 (DB のみ) で動く。
+// 旧挙動 (DB のみ) で動く。ctx は reader.GetBufferedMany に渡され、
+// handler 側の deadline / cancellation / tracing が下流に伝播する (#657)。
 //
 // flattenNotesPlusRelations で top-level + Renote/Reply の target note を
 // 1 まとめにしてから resolver を作る。CollectNoteAuthors も flatten 済みの
 // スライスから author を拾うので、埋め込み note の remote user にも Instance /
 // emoji が正しく載る。
-func PackNotes(notes []*model.Note, idGen id.Generator, instLookup InstanceLookup, emojiLookup EmojiLookup, reactionReader BufferedReactionsReader) []NoteEntity {
+func PackNotes(ctx context.Context, notes []*model.Note, idGen id.Generator, instLookup InstanceLookup, emojiLookup EmojiLookup, reactionReader BufferedReactionsReader) []NoteEntity {
 	flat := flattenNotesPlusRelations(notes)
-	mergeBufferedReactions(flat, reactionReader)
+	mergeBufferedReactions(ctx, flat, reactionReader)
 	instResolver := NewInstanceResolver(instLookup, CollectNoteAuthors(flat)...)
 	emojiResolver := NewEmojiResolver(emojiLookup, flat)
 	out := make([]NoteEntity, 0, len(notes))
@@ -205,10 +206,10 @@ func PackNotes(notes []*model.Note, idGen id.Generator, instLookup InstanceLooku
 // query via lookup.FindManyByHosts). For a slice of notes, call `PackNotes`
 // instead — calling this in a loop produces N+1 queries.
 //
-// reactionReader 引数の意味は PackNotes と同じ (#647)。
-func PackNoteWithInstance(n *model.Note, idGen id.Generator, instLookup InstanceLookup, emojiLookup EmojiLookup, reactionReader BufferedReactionsReader) NoteEntity {
+// reactionReader / ctx 引数の意味は PackNotes と同じ (#647 / #657)。
+func PackNoteWithInstance(ctx context.Context, n *model.Note, idGen id.Generator, instLookup InstanceLookup, emojiLookup EmojiLookup, reactionReader BufferedReactionsReader) NoteEntity {
 	flat := flattenNotesPlusRelations([]*model.Note{n})
-	mergeBufferedReactions(flat, reactionReader)
+	mergeBufferedReactions(ctx, flat, reactionReader)
 	packed := PackNote(n, idGen)
 	instResolver := NewInstanceResolver(instLookup, CollectNoteAuthors(flat)...)
 	emojiResolver := NewEmojiResolver(emojiLookup, flat)
@@ -221,10 +222,14 @@ func PackNoteWithInstance(n *model.Note, idGen id.Generator, instLookup Instance
 // data transform; receiver-side mutation is intentional (#647) so that
 // downstream EmojiResolver / PackNote pick up the merged map automatically.
 //
-// reader が nil または notes が空ならば no-op。
-func mergeBufferedReactions(notes []*model.Note, reader BufferedReactionsReader) {
+// reader が nil または notes が空ならば no-op。ctx は reader への伝播用
+// (#657)。
+func mergeBufferedReactions(ctx context.Context, notes []*model.Note, reader BufferedReactionsReader) {
 	if reader == nil || len(notes) == 0 {
 		return
+	}
+	if ctx == nil {
+		ctx = context.Background()
 	}
 	ids := make([]string, 0, len(notes))
 	seen := make(map[string]struct{}, len(notes))
@@ -241,7 +246,7 @@ func mergeBufferedReactions(notes []*model.Note, reader BufferedReactionsReader)
 	if len(ids) == 0 {
 		return
 	}
-	deltas, err := reader.GetBufferedMany(context.Background(), ids)
+	deltas, err := reader.GetBufferedMany(ctx, ids)
 	if err != nil || len(deltas) == 0 {
 		// reader 失敗時は stale な DB 値を返す (旧挙動と同等)。
 		return

--- a/internal/entity/note_test.go
+++ b/internal/entity/note_test.go
@@ -336,7 +336,7 @@ func TestPackNotes_EmbeddedRenoteHasInstanceAndEmoji(t *testing.T) {
 		remoteHost: {{Name: "wave", PublicURL: "https://remote.example/emoji/wave.png"}},
 	}}
 
-	out := PackNotes([]*model.Note{note}, idGen, instLookup, emojiLookup, nil)
+	out := PackNotes(context.Background(), []*model.Note{note}, idGen, instLookup, emojiLookup, nil)
 	require.Len(t, out, 1)
 	require.NotNil(t, out[0].Renote)
 	require.NotNil(t, out[0].Renote.User.Instance)
@@ -376,7 +376,7 @@ func TestPackNoteWithInstance_EmbeddedRenote(t *testing.T) {
 		remoteHost: {Host: remoteHost, Name: strPtr("Remote")},
 	}}
 
-	out := PackNoteWithInstance(note, idGen, instLookup, nil, nil)
+	out := PackNoteWithInstance(context.Background(), note, idGen, instLookup, nil, nil)
 	require.NotNil(t, out.Renote)
 	require.NotNil(t, out.Renote.User.Instance)
 	assert.Equal(t, strPtr("Remote"), out.Renote.User.Instance.Name)
@@ -422,7 +422,7 @@ func TestPackNotes_MergesBufferedReactions(t *testing.T) {
 		noteID: {":yikes@" + remoteHost + ":": 1},
 	}}
 
-	out := PackNotes([]*model.Note{note}, idGen, nil, emojiLookup, reader)
+	out := PackNotes(context.Background(), []*model.Note{note}, idGen, nil, emojiLookup, reader)
 	require.Len(t, out, 1)
 	// merged reactions JSON は両方のキーを含む
 	var got map[string]int
@@ -450,7 +450,7 @@ func TestPackNotes_BufferedNegativeDelta_RemovesKey(t *testing.T) {
 		noteID: {":foo@.:": -1},
 	}}
 
-	out := PackNotes([]*model.Note{note}, idGen, nil, nil, reader)
+	out := PackNotes(context.Background(), []*model.Note{note}, idGen, nil, nil, reader)
 	require.Len(t, out, 1)
 	var got map[string]int
 	if len(out[0].Reactions) > 0 {
@@ -472,7 +472,7 @@ func TestPackNotes_NilReader_NoMerge(t *testing.T) {
 		Reactions:  datatypes.JSON([]byte(`{":foo@.:": 3}`)),
 		User:       &model.User{ID: "user1", Username: "alice", AvatarDecorations: datatypes.JSON([]byte("[]"))},
 	}
-	out := PackNotes([]*model.Note{note}, idGen, nil, nil, nil)
+	out := PackNotes(context.Background(), []*model.Note{note}, idGen, nil, nil, nil)
 	require.Len(t, out, 1)
 	assert.Equal(t, 3, out[0].ReactionCount)
 }
@@ -491,7 +491,7 @@ func TestPackNotes_ReaderError_FallsBackToDB(t *testing.T) {
 	}
 	reader := &stubBufferedReader{err: errors.New("redis down")}
 
-	out := PackNotes([]*model.Note{note}, idGen, nil, nil, reader)
+	out := PackNotes(context.Background(), []*model.Note{note}, idGen, nil, nil, reader)
 	require.Len(t, out, 1)
 	assert.Equal(t, 2, out[0].ReactionCount, "reader error 時は DB 値で続行")
 }
@@ -522,7 +522,7 @@ func TestPackNotes_MergesBufferedReactions_OnEmbeddedRenote(t *testing.T) {
 		renoteID: {":heart@.:": 5},
 	}}
 
-	out := PackNotes([]*model.Note{note}, idGen, nil, nil, reader)
+	out := PackNotes(context.Background(), []*model.Note{note}, idGen, nil, nil, reader)
 	require.Len(t, out, 1)
 	require.NotNil(t, out[0].Renote)
 	assert.Equal(t, 5, out[0].Renote.ReactionCount)
@@ -554,7 +554,7 @@ func TestPackNotes_MergesBufferedReactions_OnEmbeddedReply(t *testing.T) {
 		replyID: {":heart@.:": 3},
 	}}
 
-	out := PackNotes([]*model.Note{note}, idGen, nil, nil, reader)
+	out := PackNotes(context.Background(), []*model.Note{note}, idGen, nil, nil, reader)
 	require.Len(t, out, 1)
 	require.NotNil(t, out[0].Reply)
 	assert.Equal(t, 4, out[0].Reply.ReactionCount, "embed reply の DB(1) + buffered(3) が merge される")

--- a/internal/stream/note_publisher.go
+++ b/internal/stream/note_publisher.go
@@ -112,7 +112,11 @@ func (p *NotePublisher) packNote(n *model.Note, author *model.User) []byte {
 	noteForPack := *n
 	noteForPack.User = author
 
-	pn := entity.PackNoteWithInstance(&noteForPack, p.idGen, p.instanceLookup, p.emojiLookup, p.reactionReader)
+	// streaming publish は fanout/background 経路で request-scoped context を
+	// 持たない。reactionReader への Redis call は短命なので
+	// context.Background() で進める (#657)。将来 PublishNote signature に
+	// ctx を追加するなら一緒に伝播させる。
+	pn := entity.PackNoteWithInstance(context.Background(), &noteForPack, p.idGen, p.instanceLookup, p.emojiLookup, p.reactionReader)
 	// REST 経路と同じ後段 resolver を通して Files / Channel を埋める。
 	// viewer 引数は streaming fanout の性質上「自分宛て」が複数 subscriber
 	// に展開されるため特定不能。viewer=nil で Apply を呼ぶと


### PR DESCRIPTION
## Summary

#647 / PR #648 で導入した \`reactionReader\` 経由の Redis call が \`context.Background()\` 固定だった問題を修正 (#657)。\`PackNotes\` / \`PackNoteWithInstance\` のシグネチャに \`ctx context.Context\` を 1st 引数で追加し、handler 側 (\`echo.Context.Request().Context()\`) / streaming publisher (\`context.Background()\` 明示) / \`cmd/dbgtimeline\` (\`context.Background()\`) から伝播させる。これで request の deadline / cancellation / distributed tracing が下流の Redis pipeline まで届く。

## 主な変更点

### \`internal/entity/note.go\`

- \`PackNotes(ctx, notes, idGen, instLookup, emojiLookup, reactionReader) []NoteEntity\`
- \`PackNoteWithInstance(ctx, n, ...) NoteEntity\`
- \`mergeBufferedReactions(ctx, notes, reader)\` — nil ctx は \`context.Background()\` に fallback (defensive、legacy caller を壊さない)

### Caller 13 箇所

- \`api/notes/\`: \`Create\` / \`Show\` で \`c.Request().Context()\`、\`packMany\` ヘルパに \`ctx\` 引数追加 (5 caller を update)
- \`api/i/\`: \`fillPinnedFields\` に \`ctx\` 引数追加、\`Favorites\` で \`c.Request().Context()\`
- \`api/users/\`: \`fillPinned\` に \`ctx\` 引数追加、\`Notes\` / \`FeaturedNotes\` で \`c.Request().Context()\`
- \`api/antennas\` / \`channels\` / \`clips\` / \`drive\` / \`roles\`: 各 \`Notes\` / \`Timeline\` で \`c.Request().Context()\`
- \`stream/note_publisher.go\`: \`publish\` は fanout/background 経路で request ctx を持たないので \`context.Background()\` を明示的に渡す (コメントで「将来 \`PublishNote\` signature に ctx を追加するなら一緒に伝播」と注記)
- \`cmd/dbgtimeline\`: \`context.Background()\` を渡す
- \`internal/entity/\` のテスト caller も \`ctx\` 引数を埋める (\`context.Background()\` で済む)

## 検証

```
$ go test -race -count=1 -timeout 10m ./internal/entity/ ./internal/stream/ ./internal/api/notes/ ./internal/api/i/ ./internal/api/users/
ok  github.com/shiroha-a/mk/internal/entity        1.07s
ok  github.com/shiroha-a/mk/internal/stream        1.85s
ok  github.com/shiroha-a/mk/internal/api/notes     2.81s
ok  github.com/shiroha-a/mk/internal/api/i         6.14s
ok  github.com/shiroha-a/mk/internal/api/users     1.19s
```

\`make fmt\` / \`make lint\` / \`go vet ./...\` クリーン。

## Closes

Closes #657