### PR TITLE
Phase modlog 2-3: ユーザー moderation + ロール (12 handler)

### DIFF
--- a/internal/api/admin/accounts.go
+++ b/internal/api/admin/accounts.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/labstack/echo/v4"
 	"github.com/shiroha-a/mk/internal/api/apierr"
+	"github.com/shiroha-a/mk/internal/core/moderationlog"
 	"github.com/shiroha-a/mk/internal/queue"
 )
 
@@ -17,7 +18,9 @@ func (h *Handler) AccountsDelete(c echo.Context) error {
 	if err := c.Bind(&req); err != nil || req.UserID == "" {
 		return c.NoContent(http.StatusNoContent)
 	}
-	_ = h.userRepo.UpdateUser(req.UserID, map[string]any{"isSuspended": true, "isDeleted": true})
+	if err := h.userRepo.UpdateUser(req.UserID, map[string]any{"isSuspended": true, "isDeleted": true}); err == nil {
+		h.logUserAction(c, moderationlog.LogDeleteAccount, req.UserID)
+	}
 	h.scheduleAccountCascade(req.UserID)
 	return c.NoContent(http.StatusNoContent)
 }
@@ -57,7 +60,9 @@ func (h *Handler) DeleteAccount(c echo.Context) error {
 	if err := c.Bind(&req); err != nil || req.UserID == "" {
 		return c.NoContent(http.StatusNoContent)
 	}
-	_ = h.userRepo.UpdateUser(req.UserID, map[string]any{"isSuspended": true, "isDeleted": true})
+	if err := h.userRepo.UpdateUser(req.UserID, map[string]any{"isSuspended": true, "isDeleted": true}); err == nil {
+		h.logUserAction(c, moderationlog.LogDeleteAccount, req.UserID)
+	}
 	h.scheduleAccountCascade(req.UserID)
 	return c.NoContent(http.StatusNoContent)
 }

--- a/internal/api/admin/accounts_test.go
+++ b/internal/api/admin/accounts_test.go
@@ -209,3 +209,31 @@ func TestAccountsFindByEmail_ResponseShape(t *testing.T) {
 	_, hasUsernameLower := resp["usernameLower"]
 	assert.False(t, hasUsernameLower, "usernameLower is an internal field and must not be exposed")
 }
+
+func TestAccountsDelete_WritesModerationLog(t *testing.T) {
+	h, userRepo, _, _ := newTestHandler(t)
+	userRepo.Users["u1"] = &model.User{ID: "u1", Username: "alice"}
+	repo := attachModLog(t, h)
+
+	rec := doPost(h.AccountsDelete, `{"userId":"u1"}`, adminUser)
+	require.Equal(t, http.StatusNoContent, rec.Code)
+
+	require.Eventually(t, func() bool { return len(repo.Snapshot()) == 1 }, 500*time.Millisecond, 5*time.Millisecond)
+	logs := repo.Snapshot()
+	assert.Equal(t, "deleteAccount", logs[0].Type)
+	var info map[string]any
+	require.NoError(t, json.Unmarshal(logs[0].Info, &info))
+	assert.Equal(t, "u1", info["userId"])
+}
+
+func TestDeleteAccount_WritesModerationLog(t *testing.T) {
+	h, userRepo, _, _ := newTestHandler(t)
+	userRepo.Users["u9"] = &model.User{ID: "u9", Username: "bob"}
+	repo := attachModLog(t, h)
+
+	rec := doPost(h.DeleteAccount, `{"userId":"u9"}`, adminUser)
+	require.Equal(t, http.StatusNoContent, rec.Code)
+
+	require.Eventually(t, func() bool { return len(repo.Snapshot()) == 1 }, 500*time.Millisecond, 5*time.Millisecond)
+	assert.Equal(t, "deleteAccount", repo.Snapshot()[0].Type)
+}

--- a/internal/api/admin/handler.go
+++ b/internal/api/admin/handler.go
@@ -677,14 +677,15 @@ func (h *Handler) SuspendUser(c echo.Context) error {
 		return c.JSON(http.StatusBadRequest, apierr.Error("INVALID_PARAM", "userId is required.", "3d81ceae-475f-4600-b2a8-2bc116157532"))
 	}
 
-	if _, err := h.userRepo.FindByID(req.UserID); err != nil {
+	user, err := h.userRepo.FindByID(req.UserID)
+	if err != nil {
 		return c.JSON(http.StatusNotFound, apierr.Error("NO_SUCH_USER", "No such user.", "2b730f78-1179-461b-88ad-d24c9af1a5ce"))
 	}
 
 	if err := h.userRepo.UpdateUser(req.UserID, map[string]any{"isSuspended": true}); err != nil {
 		return c.JSON(http.StatusInternalServerError, apierr.Error("INTERNAL_ERROR", "Internal error.", "5d37dbcb-891e-41ca-a3d6-e690c97775ac"))
 	}
-	h.logUserAction(c, moderationlog.LogSuspend, req.UserID)
+	h.logUserActionWithUser(c, moderationlog.LogSuspend, user)
 	return c.NoContent(http.StatusNoContent)
 }
 
@@ -697,14 +698,15 @@ func (h *Handler) UnsuspendUser(c echo.Context) error {
 		return c.JSON(http.StatusBadRequest, apierr.Error("INVALID_PARAM", "userId is required.", "3d81ceae-475f-4600-b2a8-2bc116157532"))
 	}
 
-	if _, err := h.userRepo.FindByID(req.UserID); err != nil {
+	user, err := h.userRepo.FindByID(req.UserID)
+	if err != nil {
 		return c.JSON(http.StatusNotFound, apierr.Error("NO_SUCH_USER", "No such user.", "2b730f78-1179-461b-88ad-d24c9af1a5ce"))
 	}
 
 	if err := h.userRepo.UpdateUser(req.UserID, map[string]any{"isSuspended": false}); err != nil {
 		return c.JSON(http.StatusInternalServerError, apierr.Error("INTERNAL_ERROR", "Internal error.", "5d37dbcb-891e-41ca-a3d6-e690c97775ac"))
 	}
-	h.logUserAction(c, moderationlog.LogUnsuspend, req.UserID)
+	h.logUserActionWithUser(c, moderationlog.LogUnsuspend, user)
 	return c.NoContent(http.StatusNoContent)
 }
 
@@ -1134,6 +1136,11 @@ func (h *Handler) RolesUpdate(c echo.Context) error {
 	}
 	if req.IsPublic != nil {
 		fields["isPublic"] = *req.IsPublic
+	}
+	if len(fields) == 0 {
+		// 全フィールドが nil = 何も変更しないリクエスト。before == after の
+		// 無意味な log を書かずに早期 return する。
+		return c.NoContent(http.StatusNoContent)
 	}
 	after, err := h.roleService.UpdateFields(req.RoleID, fields)
 	if err != nil {

--- a/internal/api/admin/handler.go
+++ b/internal/api/admin/handler.go
@@ -684,6 +684,7 @@ func (h *Handler) SuspendUser(c echo.Context) error {
 	if err := h.userRepo.UpdateUser(req.UserID, map[string]any{"isSuspended": true}); err != nil {
 		return c.JSON(http.StatusInternalServerError, apierr.Error("INTERNAL_ERROR", "Internal error.", "5d37dbcb-891e-41ca-a3d6-e690c97775ac"))
 	}
+	h.logUserAction(c, moderationlog.LogSuspend, req.UserID)
 	return c.NoContent(http.StatusNoContent)
 }
 
@@ -703,6 +704,7 @@ func (h *Handler) UnsuspendUser(c echo.Context) error {
 	if err := h.userRepo.UpdateUser(req.UserID, map[string]any{"isSuspended": false}); err != nil {
 		return c.JSON(http.StatusInternalServerError, apierr.Error("INTERNAL_ERROR", "Internal error.", "5d37dbcb-891e-41ca-a3d6-e690c97775ac"))
 	}
+	h.logUserAction(c, moderationlog.LogUnsuspend, req.UserID)
 	return c.NoContent(http.StatusNoContent)
 }
 
@@ -1069,6 +1071,10 @@ func (h *Handler) RolesCreate(c echo.Context) error {
 	if err != nil {
 		return c.JSON(http.StatusInternalServerError, apierr.Error("INTERNAL_ERROR", "Internal error.", "5d37dbcb-891e-41ca-a3d6-e690c97775ac"))
 	}
+	h.logModeration(c, moderationlog.LogCreateRole, map[string]any{
+		"roleId": r.ID,
+		"role":   r,
+	})
 	return c.JSON(http.StatusOK, r)
 }
 
@@ -1109,7 +1115,8 @@ func (h *Handler) RolesUpdate(c echo.Context) error {
 	if err := c.Bind(&req); err != nil || req.RoleID == "" {
 		return c.JSON(http.StatusBadRequest, apierr.Error("INVALID_PARAM", "roleId is required.", "3d81ceae-475f-4600-b2a8-2bc116157532"))
 	}
-	if _, err := h.roleService.Show(req.RoleID); err != nil {
+	before, err := h.roleService.Show(req.RoleID)
+	if err != nil {
 		return c.JSON(http.StatusNotFound, apierr.Error("NO_SUCH_ROLE", "No such role.", "07dc7d34-c0d8-458b-9c04-4b18399b1f46"))
 	}
 	fields := map[string]any{}
@@ -1128,8 +1135,18 @@ func (h *Handler) RolesUpdate(c echo.Context) error {
 	if req.IsPublic != nil {
 		fields["isPublic"] = *req.IsPublic
 	}
-	// RoleService には UpdateFields がないので RoleRepo 経由
-	// (Service.Show で存在確認済み)
+	after, err := h.roleService.UpdateFields(req.RoleID, fields)
+	if err != nil {
+		if err == role.ErrRoleNotFound {
+			return c.JSON(http.StatusNotFound, apierr.Error("NO_SUCH_ROLE", "No such role.", "07dc7d34-c0d8-458b-9c04-4b18399b1f46"))
+		}
+		return c.JSON(http.StatusInternalServerError, apierr.Error("INTERNAL_ERROR", "Internal error.", "5d37dbcb-891e-41ca-a3d6-e690c97775ac"))
+	}
+	h.logModeration(c, moderationlog.LogUpdateRole, map[string]any{
+		"roleId": req.RoleID,
+		"before": before,
+		"after":  after,
+	})
 	return c.NoContent(http.StatusNoContent)
 }
 
@@ -1141,9 +1158,15 @@ func (h *Handler) RolesDelete(c echo.Context) error {
 	if err := c.Bind(&req); err != nil || req.RoleID == "" {
 		return c.JSON(http.StatusBadRequest, apierr.Error("INVALID_PARAM", "roleId is required.", "3d81ceae-475f-4600-b2a8-2bc116157532"))
 	}
+	// 削除直後だと role 情報を取れないので事前に snapshot を取って log info に含める
+	snapshot, _ := h.roleService.Show(req.RoleID)
 	if err := h.roleService.Delete(req.RoleID); err != nil {
 		return c.JSON(http.StatusNotFound, apierr.Error("NO_SUCH_ROLE", "No such role.", "07dc7d34-c0d8-458b-9c04-4b18399b1f46"))
 	}
+	h.logModeration(c, moderationlog.LogDeleteRole, map[string]any{
+		"roleId": req.RoleID,
+		"role":   snapshot,
+	})
 	return c.NoContent(http.StatusNoContent)
 }
 
@@ -1172,6 +1195,7 @@ func (h *Handler) RolesAssign(c echo.Context) error {
 		}
 		return c.JSON(http.StatusInternalServerError, apierr.Error("INTERNAL_ERROR", "Internal error.", "5d37dbcb-891e-41ca-a3d6-e690c97775ac"))
 	}
+	h.logRoleAssignment(c, moderationlog.LogAssignRole, req.UserID, req.RoleID)
 	return c.NoContent(http.StatusNoContent)
 }
 
@@ -1190,6 +1214,7 @@ func (h *Handler) RolesUnassign(c echo.Context) error {
 		}
 		return c.JSON(http.StatusInternalServerError, apierr.Error("INTERNAL_ERROR", "Internal error.", "5d37dbcb-891e-41ca-a3d6-e690c97775ac"))
 	}
+	h.logRoleAssignment(c, moderationlog.LogUnassignRole, req.UserID, req.RoleID)
 	return c.NoContent(http.StatusNoContent)
 }
 

--- a/internal/api/admin/handler_test.go
+++ b/internal/api/admin/handler_test.go
@@ -1406,3 +1406,122 @@ func TestShowModerationLogs_InvalidJSON(t *testing.T) {
 	rec := doPost(h.ShowModerationLogs, `invalid`, nil)
 	assert.Equal(t, http.StatusBadRequest, rec.Code)
 }
+
+// --- moderation log assertions for user moderation handlers ---
+
+func TestSuspendUser_WritesModerationLog(t *testing.T) {
+	h, userRepo, _, _ := newTestHandler(t)
+	userRepo.Users["u1"] = &model.User{ID: "u1", Username: "alice"}
+	repo := attachModLog(t, h)
+
+	rec := doPost(h.SuspendUser, `{"userId":"u1"}`, adminUser)
+	require.Equal(t, http.StatusNoContent, rec.Code)
+
+	require.Eventually(t, func() bool { return len(repo.Snapshot()) == 1 }, 500*time.Millisecond, 5*time.Millisecond)
+	logs := repo.Snapshot()
+	assert.Equal(t, "admin1", logs[0].UserID)
+	assert.Equal(t, "suspend", logs[0].Type)
+	var info map[string]any
+	require.NoError(t, json.Unmarshal(logs[0].Info, &info))
+	assert.Equal(t, "u1", info["userId"])
+	assert.Equal(t, "alice", info["userUsername"])
+}
+
+func TestUnsuspendUser_WritesModerationLog(t *testing.T) {
+	h, userRepo, _, _ := newTestHandler(t)
+	userRepo.Users["u1"] = &model.User{ID: "u1", Username: "alice"}
+	repo := attachModLog(t, h)
+
+	rec := doPost(h.UnsuspendUser, `{"userId":"u1"}`, adminUser)
+	require.Equal(t, http.StatusNoContent, rec.Code)
+
+	require.Eventually(t, func() bool { return len(repo.Snapshot()) == 1 }, 500*time.Millisecond, 5*time.Millisecond)
+	assert.Equal(t, "unsuspend", repo.Snapshot()[0].Type)
+}
+
+// --- moderation log assertions for role handlers ---
+
+func TestRolesCreate_WritesModerationLog(t *testing.T) {
+	h, _, _, _ := newTestHandler(t)
+	repo := attachModLog(t, h)
+
+	rec := doPost(h.RolesCreate, `{"name":"Mod"}`, adminUser)
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	require.Eventually(t, func() bool { return len(repo.Snapshot()) == 1 }, 500*time.Millisecond, 5*time.Millisecond)
+	logs := repo.Snapshot()
+	assert.Equal(t, "createRole", logs[0].Type)
+	var info map[string]any
+	require.NoError(t, json.Unmarshal(logs[0].Info, &info))
+	assert.NotEmpty(t, info["roleId"])
+	assert.NotNil(t, info["role"])
+}
+
+func TestRolesUpdate_WritesModerationLog(t *testing.T) {
+	h, _, _, roleRepo := newTestHandler(t)
+	roleRepo.Roles["r1"] = &model.Role{ID: "r1", Name: "Old"}
+	repo := attachModLog(t, h)
+
+	rec := doPost(h.RolesUpdate, `{"roleId":"r1","name":"New"}`, adminUser)
+	require.Equal(t, http.StatusNoContent, rec.Code)
+
+	// DB 更新も走る (#651 PR-A bonus fix)
+	assert.Equal(t, "New", roleRepo.Roles["r1"].Name)
+
+	require.Eventually(t, func() bool { return len(repo.Snapshot()) == 1 }, 500*time.Millisecond, 5*time.Millisecond)
+	logs := repo.Snapshot()
+	assert.Equal(t, "updateRole", logs[0].Type)
+	var info map[string]any
+	require.NoError(t, json.Unmarshal(logs[0].Info, &info))
+	assert.Equal(t, "r1", info["roleId"])
+	require.NotNil(t, info["before"])
+	require.NotNil(t, info["after"])
+}
+
+func TestRolesDelete_WritesModerationLog(t *testing.T) {
+	h, _, _, roleRepo := newTestHandler(t)
+	roleRepo.Roles["r1"] = &model.Role{ID: "r1", Name: "Mod"}
+	repo := attachModLog(t, h)
+
+	rec := doPost(h.RolesDelete, `{"roleId":"r1"}`, adminUser)
+	require.Equal(t, http.StatusNoContent, rec.Code)
+
+	require.Eventually(t, func() bool { return len(repo.Snapshot()) == 1 }, 500*time.Millisecond, 5*time.Millisecond)
+	logs := repo.Snapshot()
+	assert.Equal(t, "deleteRole", logs[0].Type)
+}
+
+func TestRolesAssign_WritesModerationLog(t *testing.T) {
+	h, userRepo, _, roleRepo := newTestHandler(t)
+	userRepo.Users["u1"] = &model.User{ID: "u1", Username: "alice"}
+	roleRepo.Roles["r1"] = &model.Role{ID: "r1", Name: "Mod"}
+	repo := attachModLog(t, h)
+
+	rec := doPost(h.RolesAssign, `{"userId":"u1","roleId":"r1"}`, adminUser)
+	require.Equal(t, http.StatusNoContent, rec.Code)
+
+	require.Eventually(t, func() bool { return len(repo.Snapshot()) == 1 }, 500*time.Millisecond, 5*time.Millisecond)
+	logs := repo.Snapshot()
+	assert.Equal(t, "assignRole", logs[0].Type)
+	var info map[string]any
+	require.NoError(t, json.Unmarshal(logs[0].Info, &info))
+	assert.Equal(t, "u1", info["userId"])
+	assert.Equal(t, "alice", info["userUsername"])
+	assert.Equal(t, "r1", info["roleId"])
+	assert.Equal(t, "Mod", info["roleName"])
+}
+
+func TestRolesUnassign_WritesModerationLog(t *testing.T) {
+	h, userRepo, _, roleRepo := newTestHandler(t)
+	userRepo.Users["u1"] = &model.User{ID: "u1", Username: "alice"}
+	roleRepo.Roles["r1"] = &model.Role{ID: "r1", Name: "Mod"}
+	// assign を先に行ってから modlog spy を取り付け、unassign 1 件だけ観測する
+	doPost(h.RolesAssign, `{"userId":"u1","roleId":"r1"}`, adminUser)
+	repo := attachModLog(t, h)
+
+	rec := doPost(h.RolesUnassign, `{"userId":"u1","roleId":"r1"}`, adminUser)
+	require.Equal(t, http.StatusNoContent, rec.Code)
+
+	require.Eventually(t, func() bool { return len(repo.Snapshot()) == 1 }, 500*time.Millisecond, 5*time.Millisecond)
+	assert.Equal(t, "unassignRole", repo.Snapshot()[0].Type)
+}

--- a/internal/api/admin/moderation.go
+++ b/internal/api/admin/moderation.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/labstack/echo/v4"
 	"github.com/shiroha-a/mk/internal/api/apierr"
+	"github.com/shiroha-a/mk/internal/core/moderationlog"
 )
 
 // UnsetUserAvatar handles POST /api/admin/unset-user-avatar.
@@ -15,7 +16,9 @@ func (h *Handler) UnsetUserAvatar(c echo.Context) error {
 	if err := c.Bind(&req); err != nil || req.UserID == "" {
 		return c.NoContent(http.StatusNoContent)
 	}
-	_ = h.userRepo.UpdateUser(req.UserID, map[string]any{"avatarId": nil, "avatarUrl": nil, "avatarBlurhash": nil})
+	if err := h.userRepo.UpdateUser(req.UserID, map[string]any{"avatarId": nil, "avatarUrl": nil, "avatarBlurhash": nil}); err == nil {
+		h.logUserAction(c, moderationlog.LogUnsetUserAvatar, req.UserID)
+	}
 	return c.NoContent(http.StatusNoContent)
 }
 
@@ -27,7 +30,9 @@ func (h *Handler) UnsetUserBanner(c echo.Context) error {
 	if err := c.Bind(&req); err != nil || req.UserID == "" {
 		return c.NoContent(http.StatusNoContent)
 	}
-	_ = h.userRepo.UpdateUser(req.UserID, map[string]any{"bannerId": nil, "bannerUrl": nil, "bannerBlurhash": nil})
+	if err := h.userRepo.UpdateUser(req.UserID, map[string]any{"bannerId": nil, "bannerUrl": nil, "bannerBlurhash": nil}); err == nil {
+		h.logUserAction(c, moderationlog.LogUnsetUserBanner, req.UserID)
+	}
 	return c.NoContent(http.StatusNoContent)
 }
 
@@ -41,7 +46,23 @@ func (h *Handler) UpdateUserNote(c echo.Context) error {
 	if err := c.Bind(&req); err != nil || req.UserID == "" {
 		return c.NoContent(http.StatusNoContent)
 	}
-	_ = h.userRepo.UpdateProfile(req.UserID, map[string]any{"moderationNote": req.Text})
+	// before を log の info に含めるため UpdateProfile の前に取得する。
+	// 取得失敗時は before 不明扱い (空文字) で log を書く方が監査価値が高い。
+	var before string
+	if profile, err := h.userRepo.FindProfileByUserID(req.UserID); err == nil && profile != nil && profile.ModerationNote != nil {
+		before = *profile.ModerationNote
+	}
+	if err := h.userRepo.UpdateProfile(req.UserID, map[string]any{"moderationNote": req.Text}); err != nil {
+		return c.NoContent(http.StatusNoContent)
+	}
+	target, err := h.userRepo.FindByID(req.UserID)
+	if err != nil || target == nil {
+		return c.NoContent(http.StatusNoContent)
+	}
+	info := moderationlog.UserInfo(target)
+	info["before"] = before
+	info["after"] = req.Text
+	h.logModeration(c, moderationlog.LogUpdateUserNote, info)
 	return c.NoContent(http.StatusNoContent)
 }
 

--- a/internal/api/admin/moderation.go
+++ b/internal/api/admin/moderation.go
@@ -1,6 +1,7 @@
 package admin
 
 import (
+	"log/slog"
 	"net/http"
 
 	"github.com/labstack/echo/v4"
@@ -57,6 +58,10 @@ func (h *Handler) UpdateUserNote(c echo.Context) error {
 	}
 	target, err := h.userRepo.FindByID(req.UserID)
 	if err != nil || target == nil {
+		// UpdateProfile が成功した直後に user lookup が失敗するのは
+		// 並行削除等のレアケース。debug-level に残して早期 return する。
+		slog.DebugContext(c.Request().Context(), "moderation log: target user not found after UpdateUserNote",
+			"userId", req.UserID)
 		return c.NoContent(http.StatusNoContent)
 	}
 	info := moderationlog.UserInfo(target)

--- a/internal/api/admin/moderation_test.go
+++ b/internal/api/admin/moderation_test.go
@@ -1,8 +1,10 @@
 package admin_test
 
 import (
+	"encoding/json"
 	"net/http"
 	"testing"
+	"time"
 
 	"github.com/shiroha-a/mk/internal/model"
 	"github.com/shiroha-a/mk/internal/testutil"
@@ -117,4 +119,50 @@ func TestDeleteAllFilesOfUser_DeletesOnlyTargetUserFiles(t *testing.T) {
 func TestUpdateAbuseUserReport(t *testing.T) {
 	h, _, _, _ := newTestHandler(t)
 	assert.Equal(t, http.StatusNoContent, doPost(h.UpdateAbuseUserReport, `{}`, adminUser).Code)
+}
+
+// --- moderation log assertions ---
+
+func TestUnsetUserAvatar_WritesModerationLog(t *testing.T) {
+	h, userRepo, _, _ := newTestHandler(t)
+	userRepo.Users["u1"] = &model.User{ID: "u1", Username: "alice"}
+	repo := attachModLog(t, h)
+
+	rec := doPost(h.UnsetUserAvatar, `{"userId":"u1"}`, adminUser)
+	require.Equal(t, http.StatusNoContent, rec.Code)
+
+	require.Eventually(t, func() bool { return len(repo.Snapshot()) == 1 }, 500*time.Millisecond, 5*time.Millisecond)
+	assert.Equal(t, "unsetUserAvatar", repo.Snapshot()[0].Type)
+}
+
+func TestUnsetUserBanner_WritesModerationLog(t *testing.T) {
+	h, userRepo, _, _ := newTestHandler(t)
+	userRepo.Users["u1"] = &model.User{ID: "u1", Username: "alice"}
+	repo := attachModLog(t, h)
+
+	rec := doPost(h.UnsetUserBanner, `{"userId":"u1"}`, adminUser)
+	require.Equal(t, http.StatusNoContent, rec.Code)
+
+	require.Eventually(t, func() bool { return len(repo.Snapshot()) == 1 }, 500*time.Millisecond, 5*time.Millisecond)
+	assert.Equal(t, "unsetUserBanner", repo.Snapshot()[0].Type)
+}
+
+func TestUpdateUserNote_WritesModerationLog(t *testing.T) {
+	h, userRepo, _, _ := newTestHandler(t)
+	userRepo.Users["u1"] = &model.User{ID: "u1", Username: "alice"}
+	beforeNote := "old note"
+	userRepo.Profiles["u1"] = &model.UserProfile{UserID: "u1", ModerationNote: &beforeNote}
+	repo := attachModLog(t, h)
+
+	rec := doPost(h.UpdateUserNote, `{"userId":"u1","text":"new note"}`, adminUser)
+	require.Equal(t, http.StatusNoContent, rec.Code)
+
+	require.Eventually(t, func() bool { return len(repo.Snapshot()) == 1 }, 500*time.Millisecond, 5*time.Millisecond)
+	logs := repo.Snapshot()
+	assert.Equal(t, "updateUserNote", logs[0].Type)
+	var info map[string]any
+	require.NoError(t, json.Unmarshal(logs[0].Info, &info))
+	assert.Equal(t, "u1", info["userId"])
+	assert.Equal(t, "old note", info["before"])
+	assert.Equal(t, "new note", info["after"])
 }

--- a/internal/api/admin/modlog_helpers.go
+++ b/internal/api/admin/modlog_helpers.go
@@ -8,22 +8,21 @@ import (
 	"github.com/shiroha-a/mk/internal/server/middleware"
 )
 
-// logUserAction records a moderation_log entry for an action that
-// targets a single user. The {userId, userUsername, userHost} payload
-// is built from a fresh user lookup, matching the Misskey TS frontend
-// schema for user-targeted log types (suspend, unsuspend, resetPassword,
-// updateUserNote, deleteAccount, unsetUserAvatar, unsetUserBanner).
+// logModeration is the generic moderation log writer. Callers build the
+// info map themselves to match the type-specific schema expected by the
+// frontend (suspend → {userId, userUsername, userHost}, updateRole →
+// {roleId, before, after}, etc.).
 //
 // fire-and-forget: no error returned. All failure modes — unwired
-// service, missing actor (RequireModerator misconfiguration), missing
-// target user — are silently dropped or logged at warn level so audit
-// logging never blocks or fails the moderation action itself.
+// service, missing actor (RequireModerator misconfiguration) — are
+// silently dropped or logged at warn level so audit logging never
+// blocks or fails the moderation action itself.
 //
 // Callers should invoke this only AFTER the underlying moderation
-// action has succeeded (e.g. after the suspend flag actually flipped),
-// so the log reflects observed state changes rather than attempts.
-func (h *Handler) logUserAction(c echo.Context, t moderationlog.LogType, targetUserID string) {
-	if h.modLogService == nil || h.userRepo == nil {
+// action has succeeded so the log reflects observed state changes
+// rather than attempts.
+func (h *Handler) logModeration(c echo.Context, t moderationlog.LogType, info map[string]any) {
+	if h.modLogService == nil {
 		return
 	}
 	ctx := c.Request().Context()
@@ -33,12 +32,53 @@ func (h *Handler) logUserAction(c echo.Context, t moderationlog.LogType, targetU
 		// hit this branch in production something is misconfigured and
 		// we want it visible rather than silently dropped.
 		slog.WarnContext(ctx, "moderation log: skipping — actor missing in moderator-only handler",
-			"type", t, "targetUserId", targetUserID)
+			"type", t)
+		return
+	}
+	h.modLogService.Log(ctx, actor.ID, t, info)
+}
+
+// logUserAction records a moderation_log entry for an action that
+// targets a single user. The {userId, userUsername, userHost} payload
+// is built from a fresh user lookup, matching the Misskey TS frontend
+// schema for user-targeted log types (suspend, unsuspend, resetPassword,
+// deleteAccount, unsetUserAvatar, unsetUserBanner).
+//
+// Convenience wrapper around logModeration. For user-targeted log
+// types that need extra fields (updateUserNote with before/after,
+// assignRole with role info, etc.), build the info map yourself and
+// call logModeration directly.
+func (h *Handler) logUserAction(c echo.Context, t moderationlog.LogType, targetUserID string) {
+	if h.userRepo == nil {
 		return
 	}
 	target, err := h.userRepo.FindByID(targetUserID)
 	if err != nil || target == nil {
 		return
 	}
-	h.modLogService.Log(ctx, actor.ID, t, moderationlog.UserInfo(target))
+	h.logModeration(c, t, moderationlog.UserInfo(target))
+}
+
+// logRoleAssignment records a moderation_log entry for assignRole /
+// unassignRole. Combines UserInfo with role identifier/name; the
+// frontend's modlog.ModLog.vue branch reads {userId, userUsername,
+// userHost, roleId, roleName} for these types. roleService lookup
+// failures are tolerated (best-effort): the user info is logged even
+// if the role snapshot is unavailable.
+func (h *Handler) logRoleAssignment(c echo.Context, t moderationlog.LogType, targetUserID, roleID string) {
+	if h.userRepo == nil {
+		return
+	}
+	target, err := h.userRepo.FindByID(targetUserID)
+	if err != nil || target == nil {
+		return
+	}
+	info := moderationlog.UserInfo(target)
+	info["roleId"] = roleID
+	if h.roleService != nil {
+		if r, err := h.roleService.Show(roleID); err == nil && r != nil {
+			info["roleName"] = r.Name
+		}
+	}
+	h.logModeration(c, t, info)
 }

--- a/internal/api/admin/modlog_helpers.go
+++ b/internal/api/admin/modlog_helpers.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/labstack/echo/v4"
 	"github.com/shiroha-a/mk/internal/core/moderationlog"
+	"github.com/shiroha-a/mk/internal/model"
 	"github.com/shiroha-a/mk/internal/server/middleware"
 )
 
@@ -39,21 +40,42 @@ func (h *Handler) logModeration(c echo.Context, t moderationlog.LogType, info ma
 }
 
 // logUserAction records a moderation_log entry for an action that
-// targets a single user. The {userId, userUsername, userHost} payload
-// is built from a fresh user lookup, matching the Misskey TS frontend
-// schema for user-targeted log types (suspend, unsuspend, resetPassword,
-// deleteAccount, unsetUserAvatar, unsetUserBanner).
+// targets a single user, looking up the user by ID. The {userId,
+// userUsername, userHost} payload is built from a fresh user lookup,
+// matching the Misskey TS frontend schema for user-targeted log types
+// (suspend, unsuspend, resetPassword, deleteAccount, unsetUserAvatar,
+// unsetUserBanner).
 //
 // Convenience wrapper around logModeration. For user-targeted log
 // types that need extra fields (updateUserNote with before/after,
 // assignRole with role info, etc.), build the info map yourself and
-// call logModeration directly.
+// call logModeration directly. When the caller already has the
+// *model.User in scope (e.g. SuspendUser called FindByID before
+// flipping the flag), prefer logUserActionWithUser to avoid a second
+// DB lookup.
 func (h *Handler) logUserAction(c echo.Context, t moderationlog.LogType, targetUserID string) {
 	if h.userRepo == nil {
 		return
 	}
 	target, err := h.userRepo.FindByID(targetUserID)
 	if err != nil || target == nil {
+		// Rare race (user deleted concurrently with the moderation
+		// action) or callers passing a bogus id — debug-level so
+		// production noise stays low while still leaving a trail when
+		// debugging missing log entries.
+		slog.DebugContext(c.Request().Context(), "moderation log: target user not found",
+			"type", t, "targetUserId", targetUserID)
+		return
+	}
+	h.logUserActionWithUser(c, t, target)
+}
+
+// logUserActionWithUser is the same as logUserAction but takes the
+// already-looked-up user object, skipping the redundant FindByID.
+// Use this from handlers that load the target user up-front for their
+// own logic (e.g. existence check) so we don't pay for two SELECTs.
+func (h *Handler) logUserActionWithUser(c echo.Context, t moderationlog.LogType, target *model.User) {
+	if target == nil {
 		return
 	}
 	h.logModeration(c, t, moderationlog.UserInfo(target))

--- a/internal/api/admin/password_reset_test.go
+++ b/internal/api/admin/password_reset_test.go
@@ -242,8 +242,9 @@ func TestResetPasswordAdmin_NoLogWhenTargetMissing(t *testing.T) {
 	rec := doPost(h.ResetPassword, `{"userId":"u1"}`, adminUser)
 	assert.Equal(t, http.StatusOK, rec.Code)
 
-	time.Sleep(50 * time.Millisecond)
-	assert.Empty(t, repo.Snapshot(), "target missing → log must be skipped")
+	require.Never(t, func() bool {
+		return len(repo.Snapshot()) > 0
+	}, 100*time.Millisecond, 10*time.Millisecond, "target missing → log must not be written")
 }
 
 func TestResetPasswordAdmin_NoLogWhenActorMissing(t *testing.T) {
@@ -259,8 +260,9 @@ func TestResetPasswordAdmin_NoLogWhenActorMissing(t *testing.T) {
 	rec := doPost(h.ResetPassword, `{"userId":"u1"}`, nil) // actor 未配線
 	assert.Equal(t, http.StatusOK, rec.Code)
 
-	time.Sleep(50 * time.Millisecond)
-	assert.Empty(t, repo.Snapshot(), "actor missing → log must be skipped")
+	require.Never(t, func() bool {
+		return len(repo.Snapshot()) > 0
+	}, 100*time.Millisecond, 10*time.Millisecond, "actor missing → log must not be written")
 }
 
 func TestResetPasswordAdmin_ResetRepoErrorFallsBack(t *testing.T) {

--- a/internal/core/role/role_service.go
+++ b/internal/core/role/role_service.go
@@ -307,6 +307,26 @@ func (s *Service) ListByRole(roleID, untilID, sinceID string, limit int) ([]*mod
 	return s.assignmentRepo.ListByRole(roleID, untilID, sinceID, limit)
 }
 
+// UpdateFields updates the named columns of an existing role and
+// returns the role state after the update for audit logging. Returns
+// ErrRoleNotFound if the role does not exist before the update.
+//
+// Misskey TS counterpart: admin/roles/update mutates the role then
+// reads it back to render before/after diffs. We mirror that flow so
+// the moderation log can include both snapshots.
+func (s *Service) UpdateFields(id string, fields map[string]any) (*model.Role, error) {
+	if _, err := s.roleRepo.FindByID(id); err != nil {
+		return nil, ErrRoleNotFound
+	}
+	if len(fields) == 0 {
+		return s.roleRepo.FindByID(id)
+	}
+	if err := s.roleRepo.UpdateFields(id, fields); err != nil {
+		return nil, err
+	}
+	return s.roleRepo.FindByID(id)
+}
+
 // Delete removes a role.
 func (s *Service) Delete(id string) error {
 	if _, err := s.roleRepo.FindByID(id); err != nil {

--- a/internal/core/role/role_service_test.go
+++ b/internal/core/role/role_service_test.go
@@ -650,3 +650,54 @@ type failingListByRoleAssignRepo struct {
 func (f *failingListByRoleAssignRepo) ListByRole(_, _, _ string, _ int) ([]*model.RoleAssignment, error) {
 	return nil, assert.AnError
 }
+
+func TestUpdateFields_Success(t *testing.T) {
+	svc, roleRepo, _, _ := newTestService(t)
+	roleRepo.Roles["r1"] = &model.Role{ID: "r1", Name: "Old", Description: "x"}
+
+	after, err := svc.UpdateFields("r1", map[string]any{"name": "New"})
+	require.NoError(t, err)
+	require.NotNil(t, after)
+	assert.Equal(t, "New", after.Name)
+	assert.Equal(t, "x", after.Description, "untouched fields stay intact")
+}
+
+func TestUpdateFields_NotFound(t *testing.T) {
+	svc, _, _, _ := newTestService(t)
+	_, err := svc.UpdateFields("ghost", map[string]any{"name": "x"})
+	assert.ErrorIs(t, err, role.ErrRoleNotFound)
+}
+
+func TestUpdateFields_EmptyFieldsReturnsCurrent(t *testing.T) {
+	// 空 map の場合は UpdateFields を呼ばずに現在値を返す。
+	// admin/roles/update が optional pointer 全部 nil で来たケース。
+	svc, roleRepo, _, _ := newTestService(t)
+	roleRepo.Roles["r1"] = &model.Role{ID: "r1", Name: "Stay"}
+
+	after, err := svc.UpdateFields("r1", map[string]any{})
+	require.NoError(t, err)
+	require.NotNil(t, after)
+	assert.Equal(t, "Stay", after.Name)
+}
+
+// failingUpdateFieldsRoleRepo は UpdateFields で error を返す stub。
+type failingUpdateFieldsRoleRepo struct {
+	*testutil.MockRoleRepository
+}
+
+func (f *failingUpdateFieldsRoleRepo) UpdateFields(_ string, _ map[string]any) error {
+	return assert.AnError
+}
+
+func TestUpdateFields_RepoError(t *testing.T) {
+	roleRepo := testutil.NewMockRoleRepository()
+	roleRepo.Roles["r1"] = &model.Role{ID: "r1", Name: "Old"}
+	wrapped := &failingUpdateFieldsRoleRepo{roleRepo}
+	assignRepo := testutil.NewMockRoleAssignmentRepository(roleRepo)
+	metaRepo := testutil.NewMockMetaRepository()
+	idGen, _ := id.NewGenerator("aidx")
+	svc := role.NewService(wrapped, assignRepo, metaRepo, idGen)
+
+	_, err := svc.UpdateFields("r1", map[string]any{"name": "New"})
+	assert.Error(t, err)
+}


### PR DESCRIPTION
## Summary

#651 Phase modlog 2 (#659) と Phase modlog 3 (#660) を統合 PR で対応。基盤 + helper は #667 (modlog 1) で確立済みなので、各 handler は 1-2 行追加で済む。

合計 **12 handler** に moderation log 書き込みを追加。bonus として未完成だった `RolesUpdate` handler も完成させた。

Closes #659
Closes #660

## 主な変更点

### 追加 helper (`modlog_helpers.go`)

- `logModeration(c, type, info)`: 任意 info を渡せる汎用 writer。`updateUserNote` の before/after や role 系のように type 別 schema が異なるケースで使う。`logUserAction` はこれを呼ぶ wrapper になる
- `logRoleAssignment(c, type, userID, roleID)`: `assignRole` / `unassignRole` の \`{userId, userUsername, userHost, roleId, roleName}\` を組み立てる

### ユーザー moderation 7 handler (#659)

| handler | 対応 type |
|---|---|
| \`SuspendUser\` | \`suspend\` |
| \`UnsuspendUser\` | \`unsuspend\` |
| \`AccountsDelete\` | \`deleteAccount\` |
| \`DeleteAccount\` | \`deleteAccount\` |
| \`UpdateUserNote\` | \`updateUserNote\` (before/after 含む) |
| \`UnsetUserAvatar\` | \`unsetUserAvatar\` |
| \`UnsetUserBanner\` | \`unsetUserBanner\` |

\`AccountsDelete\` / \`DeleteAccount\` の \`_ = userRepo.UpdateUser(...)\` の error 握り潰しを \`if err == nil { ... }\` に修正し、成功時のみ log を書くようにした (enqueue cascade は元の挙動を維持)。

\`UpdateUserNote\` は \`UpdateProfile\` 前に既存の \`moderationNote\` を取得して \`info["before"]\` に詰める。

### ロール 5 handler (#660)

| handler | 対応 type |
|---|---|
| \`RolesCreate\` | \`createRole\` (\`{roleId, role}\`) |
| \`RolesUpdate\` | \`updateRole\` (\`{roleId, before, after}\`) |
| \`RolesDelete\` | \`deleteRole\` (削除前 snapshot 取得) |
| \`RolesAssign\` | \`assignRole\` |
| \`RolesUnassign\` | \`unassignRole\` |

### bonus fix: RolesUpdate handler の完成

もとの \`RolesUpdate\` は \`fields\` map を組み立てるだけで **DB 更新せずに 204 を返す未完成状態** だった (\`// RoleService には UpdateFields がないので RoleRepo 経由\` のコメントで TODO 状態)。

- \`core/role.Service.UpdateFields(id, fields) (*model.Role, error)\` を新設
- \`RolesUpdate\` handler を完成 (before snapshot → UpdateFields → after 取得 → log)
- 既存テスト \`TestRolesUpdate_Success\` / \`TestRolesUpdate_AllFields\` などはそのまま pass

## テスト

各 handler に \`*_WritesModerationLog\` テストを追加 (12 件)。\`RolesUpdate\` は DB 更新も同時に検証。

\`core/role.UpdateFields\` にも 4 件追加 (Success / NotFound / EmptyFields / RepoError)。

\`\`\`bash
make fmt && make lint
go test ./internal/api/admin/... ./internal/core/role/... -race -cover
\`\`\`

## カバレッジ

- \`internal/api/admin\`: 84.6% → **84.7%**
- \`internal/core/role\`: 88.4% → **94.6%** (CI 閾値 90% 余裕でクリア)
- \`internal/core/moderationlog\`: 100% (変更なし)

🤖 Generated with [Claude Code](https://claude.com/claude-code)