### PR TITLE
Phase modlog 4 + #650: カスタム絵文字 (modlog 配線 + import/edit バグ修正)

### DIFF
--- a/internal/api/admin/drive_emoji_test.go
+++ b/internal/api/admin/drive_emoji_test.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"net/http"
 	"testing"
+	"time"
 
 	"github.com/shiroha-a/mk/internal/model"
 	"github.com/shiroha-a/mk/internal/queue"
@@ -184,12 +185,14 @@ func TestEmojiListRemote_FilterByQuery(t *testing.T) {
 }
 
 func TestEmojiCopy_DuplicateNameReturns400(t *testing.T) {
+	// Misskey TS 互換 (#650 問題 1): copy は元 name のまま local 化するため、
+	// 同名の local emoji が既存だと DUPLICATE_NAME を返す。
 	h, _, _, _ := newTestHandler(t)
 	repo := testutil.NewMockEmojiRepository()
-	// MockEmojiRepository は name@host をキーとして保存するので、既存の
-	// smile と、衝突先となる smile_copy の 2 件を入れる。
-	require.NoError(t, repo.Create(&model.Emoji{ID: "e1", Name: "smile", OriginalURL: "https://x"}))
-	require.NoError(t, repo.Create(&model.Emoji{ID: "e_dup", Name: "smile_copy", OriginalURL: "https://y"}))
+	remoteHost := "remote.example"
+	// remote の "smile" を copy しようとするが、local にも同名 "smile" 存在。
+	require.NoError(t, repo.Create(&model.Emoji{ID: "e1", Name: "smile", Host: &remoteHost, OriginalURL: "https://x"}))
+	require.NoError(t, repo.Create(&model.Emoji{ID: "e_local", Name: "smile", OriginalURL: "https://y"}))
 	h.SetEmojiRepo(repo)
 
 	rec := doPost(h.EmojiCopy, `{"emojiId":"e1"}`, adminUser)
@@ -211,9 +214,12 @@ func findEmojiByID(t *testing.T, repo *testutil.MockEmojiRepository, id string) 
 }
 
 func TestEmojiCopy_Success(t *testing.T) {
+	// remote → local copy: copy 先が host=nil で同名 local emoji が無い
+	// ので 200 を返す (Misskey TS 互換、#650 問題 1)。
 	h, _, _, _ := newTestHandler(t)
 	repo := testutil.NewMockEmojiRepository()
-	require.NoError(t, repo.Create(&model.Emoji{ID: "e1", Name: "unique", OriginalURL: "https://x"}))
+	remoteHost := "remote.example"
+	require.NoError(t, repo.Create(&model.Emoji{ID: "e1", Name: "unique", Host: &remoteHost, OriginalURL: "https://x"}))
 	h.SetEmojiRepo(repo)
 
 	rec := doPost(h.EmojiCopy, `{"emojiId":"e1"}`, adminUser)
@@ -221,6 +227,10 @@ func TestEmojiCopy_Success(t *testing.T) {
 	var body map[string]any
 	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &body))
 	assert.NotEmpty(t, body["id"])
+	// copied emoji は元 name "unique" で local 化されている
+	copied := findEmojiByID(t, repo, body["id"].(string))
+	assert.Equal(t, "unique", copied.Name)
+	assert.Nil(t, copied.Host)
 }
 
 func TestEmojiCopy_NotFound(t *testing.T) {
@@ -676,4 +686,123 @@ func TestEmojiImportZip_EnqueueFailure(t *testing.T) {
 	h.SetEmojiImportEnqueuer(&stubEmojiImportEnqueuer{err: assertError{}})
 	rec := doPost(h.EmojiImportZip, `{"fileId":"f1"}`, adminUser)
 	assert.Equal(t, http.StatusInternalServerError, rec.Code)
+}
+
+// --- moderation log assertions (#661 + #650) ---
+
+func TestEmojiAdd_WritesModerationLog(t *testing.T) {
+	h, _, _, _ := newTestHandler(t)
+	h.SetEmojiRepo(testutil.NewMockEmojiRepository())
+	repo := attachModLog(t, h)
+
+	rec := doPost(h.EmojiAdd, `{"name":"smile","url":"https://example/smile.png"}`, adminUser)
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	require.Eventually(t, func() bool { return len(repo.Snapshot()) == 1 }, 500*time.Millisecond, 5*time.Millisecond)
+	logs := repo.Snapshot()
+	assert.Equal(t, "addCustomEmoji", logs[0].Type)
+	var info map[string]any
+	require.NoError(t, json.Unmarshal(logs[0].Info, &info))
+	assert.NotEmpty(t, info["emojiId"])
+	assert.NotNil(t, info["emoji"])
+}
+
+func TestEmojiUpdate_WritesModerationLog_WithExtendedFields(t *testing.T) {
+	// #650 問題 2 + #661: Misskey 互換の license/isSensitive/localOnly が
+	// 永続化されること、updateCustomEmoji log に before/after が入ること。
+	h, _, _, _ := newTestHandler(t)
+	emojiRepo := testutil.NewMockEmojiRepository()
+	require.NoError(t, emojiRepo.Create(&model.Emoji{ID: "e1", Name: "smile"}))
+	h.SetEmojiRepo(emojiRepo)
+	repo := attachModLog(t, h)
+
+	body := `{"id":"e1","name":"smile2","license":"CC0","isSensitive":true,"localOnly":true}`
+	rec := doPost(h.EmojiUpdate, body, adminUser)
+	require.Equal(t, http.StatusNoContent, rec.Code)
+
+	// DB 更新の検証
+	updated, err := emojiRepo.FindByID("e1")
+	require.NoError(t, err)
+	assert.Equal(t, "smile2", updated.Name)
+	require.NotNil(t, updated.License)
+	assert.Equal(t, "CC0", *updated.License)
+	assert.True(t, updated.IsSensitive)
+	assert.True(t, updated.LocalOnly)
+
+	require.Eventually(t, func() bool { return len(repo.Snapshot()) == 1 }, 500*time.Millisecond, 5*time.Millisecond)
+	logs := repo.Snapshot()
+	assert.Equal(t, "updateCustomEmoji", logs[0].Type)
+	var info map[string]any
+	require.NoError(t, json.Unmarshal(logs[0].Info, &info))
+	assert.Equal(t, "e1", info["emojiId"])
+	require.NotNil(t, info["before"])
+	require.NotNil(t, info["after"])
+}
+
+func TestEmojiUpdate_NoSuchEmojiOnMissingID(t *testing.T) {
+	// #650 問題 2: id が DB に無いケースは NO_SUCH_EMOJI を返す。以前は
+	// UpdateFields が RowsAffected を見ずに常に nil 返却で 204 になっていた。
+	h, _, _, _ := newTestHandler(t)
+	h.SetEmojiRepo(testutil.NewMockEmojiRepository())
+	rec := doPost(h.EmojiUpdate, `{"id":"ghost","name":"x"}`, adminUser)
+	assert.Equal(t, http.StatusNotFound, rec.Code)
+	var body map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &body))
+	errField, ok := body["error"].(map[string]any)
+	require.True(t, ok)
+	assert.Equal(t, "NO_SUCH_EMOJI", errField["code"])
+}
+
+func TestEmojiDelete_WritesModerationLog(t *testing.T) {
+	h, _, _, _ := newTestHandler(t)
+	emojiRepo := testutil.NewMockEmojiRepository()
+	require.NoError(t, emojiRepo.Create(&model.Emoji{ID: "e1", Name: "doomed"}))
+	h.SetEmojiRepo(emojiRepo)
+	repo := attachModLog(t, h)
+
+	rec := doPost(h.EmojiDelete, `{"id":"e1"}`, adminUser)
+	require.Equal(t, http.StatusNoContent, rec.Code)
+
+	require.Eventually(t, func() bool { return len(repo.Snapshot()) == 1 }, 500*time.Millisecond, 5*time.Millisecond)
+	logs := repo.Snapshot()
+	assert.Equal(t, "deleteCustomEmoji", logs[0].Type)
+	var info map[string]any
+	require.NoError(t, json.Unmarshal(logs[0].Info, &info))
+	assert.Equal(t, "e1", info["emojiId"])
+	assert.NotNil(t, info["emoji"])
+}
+
+func TestEmojiCopy_WritesModerationLog(t *testing.T) {
+	h, _, _, _ := newTestHandler(t)
+	emojiRepo := testutil.NewMockEmojiRepository()
+	remoteHost := "remote.example"
+	require.NoError(t, emojiRepo.Create(&model.Emoji{ID: "e1", Name: "wave", Host: &remoteHost}))
+	h.SetEmojiRepo(emojiRepo)
+	repo := attachModLog(t, h)
+
+	rec := doPost(h.EmojiCopy, `{"emojiId":"e1"}`, adminUser)
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	require.Eventually(t, func() bool { return len(repo.Snapshot()) == 1 }, 500*time.Millisecond, 5*time.Millisecond)
+	assert.Equal(t, "addCustomEmoji", repo.Snapshot()[0].Type)
+}
+
+func TestEmojiDeleteBulk_WritesPerEmojiLog(t *testing.T) {
+	// Misskey TS 互換: delete-bulk は対象絵文字数だけ deleteCustomEmoji
+	// log を出す (CustomEmojiService.deleteBulk の for ループ相当)。
+	h, _, _, _ := newTestHandler(t)
+	emojiRepo := testutil.NewMockEmojiRepository()
+	require.NoError(t, emojiRepo.Create(&model.Emoji{ID: "e1", Name: "a"}))
+	require.NoError(t, emojiRepo.Create(&model.Emoji{ID: "e2", Name: "b"}))
+	require.NoError(t, emojiRepo.Create(&model.Emoji{ID: "e3", Name: "c"}))
+	h.SetEmojiRepo(emojiRepo)
+	repo := attachModLog(t, h)
+
+	rec := doPost(h.EmojiDeleteBulk, `{"ids":["e1","e2","e3"]}`, adminUser)
+	require.Equal(t, http.StatusNoContent, rec.Code)
+
+	require.Eventually(t, func() bool { return len(repo.Snapshot()) == 3 }, 500*time.Millisecond, 5*time.Millisecond)
+	for _, l := range repo.Snapshot() {
+		assert.Equal(t, "deleteCustomEmoji", l.Type)
+	}
 }

--- a/internal/api/admin/emoji.go
+++ b/internal/api/admin/emoji.go
@@ -1,6 +1,7 @@
 package admin
 
 import (
+	"log/slog"
 	"net/http"
 	"time"
 
@@ -95,8 +96,13 @@ func (h *Handler) EmojiDeleteBulk(c echo.Context) error {
 		return c.NoContent(http.StatusNoContent)
 	}
 	// per-emoji log のため削除前に snapshot を取得。失敗しても削除自体は
-	// 続行する (snapshot 失敗で監査が落ちるより操作完遂が優先)。
-	snapshots, _ := h.emojiRepo.FindManyByIDs(req.IDs)
+	// 続行する (snapshot 失敗で監査が落ちるより操作完遂が優先)。エラー時は
+	// log が出ない理由を debug-level で残して運用時の追跡を可能にする。
+	snapshots, err := h.emojiRepo.FindManyByIDs(req.IDs)
+	if err != nil {
+		slog.DebugContext(c.Request().Context(), "moderation log: snapshot lookup failed before delete-bulk",
+			"ids", req.IDs, "err", err)
+	}
 	if err := h.emojiRepo.DeleteMany(req.IDs); err != nil {
 		return c.JSON(http.StatusInternalServerError, apierr.Error("INTERNAL_ERROR", "Internal error.", "00000000-0000-0000-0000-000000000000"))
 	}

--- a/internal/api/admin/emoji.go
+++ b/internal/api/admin/emoji.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/labstack/echo/v4"
 	"github.com/shiroha-a/mk/internal/api/apierr"
+	"github.com/shiroha-a/mk/internal/core/moderationlog"
 	"github.com/shiroha-a/mk/internal/entity"
 	"github.com/shiroha-a/mk/internal/queue"
 	"github.com/shiroha-a/mk/internal/server/middleware"
@@ -41,8 +42,12 @@ func (h *Handler) EmojiAddAliasesBulk(c echo.Context) error {
 
 // EmojiCopy handles POST /api/admin/emoji/copy.
 //
-// Misskey 本家は対象 name が既存ならば DUPLICATE_NAME を返す。サフィックス
-// _copy を付けても既存に衝突する可能性があるため、明示チェックを入れる。
+// Misskey TS 本家 (admin/emoji/copy.ts) は元の name のまま local emoji を
+// 追加し、同名の local emoji が既に存在する場合のみ DUPLICATE_NAME を
+// 返す。以前の mk-go 実装は `_copy` suffix を勝手に付与していたが、
+// これは TS 仕様違反 (#650 問題 1) なのでサフィックスを除去した。
+//
+// ref: third_party/misskey/packages/backend/src/server/api/endpoints/admin/emoji/copy.ts
 func (h *Handler) EmojiCopy(c echo.Context) error {
 	var req struct {
 		EmojiID string `json:"emojiId"`
@@ -57,21 +62,28 @@ func (h *Handler) EmojiCopy(c echo.Context) error {
 	if err != nil {
 		return c.JSON(http.StatusNotFound, apierr.Error("NO_SUCH_EMOJI", "No such emoji.", "e2785b66-dca3-4087-9cac-b93c541cc425"))
 	}
-	newName := src.Name + "_copy"
-	if existing, err := h.emojiRepo.FindByNameAndHost(newName, nil); err == nil && existing != nil {
-		return c.JSON(http.StatusBadRequest, apierr.Error("DUPLICATE_NAME", "Duplicate name.", "5abef7f4-b3d6-4be4-a08f-4c4b7cf4f5b0"))
+	if existing, err := h.emojiRepo.FindByNameAndHost(src.Name, nil); err == nil && existing != nil {
+		return c.JSON(http.StatusBadRequest, apierr.Error("DUPLICATE_NAME", "Duplicate name.", "f7a3462c-4e6e-4069-8421-b9bd4f4c3975"))
 	}
 	copied := *src
 	copied.ID = h.idGen.Generate(time.Now())
-	copied.Name = newName
 	copied.Host = nil
 	if err := h.emojiRepo.Create(&copied); err != nil {
 		return c.JSON(http.StatusInternalServerError, apierr.Error("INTERNAL_ERROR", "Internal error.", "00000000-0000-0000-0000-000000000000"))
 	}
+	h.logModeration(c, moderationlog.LogAddCustomEmoji, map[string]any{
+		"emojiId": copied.ID,
+		"emoji":   &copied,
+	})
 	return c.JSON(http.StatusOK, map[string]any{"id": copied.ID})
 }
 
 // EmojiDeleteBulk handles POST /api/admin/emoji/delete-bulk.
+//
+// Misskey TS の CustomEmojiService.deleteBulk() は削除対象を for ループで
+// 一件ずつ処理し、絵文字ごとに deleteCustomEmoji moderation log を書く。
+// 互換性のため mk-go も削除前の snapshot を取得して per-emoji log を出力
+// する。bulk 削除自体は 1 SQL (DeleteMany) で完結。
 func (h *Handler) EmojiDeleteBulk(c echo.Context) error {
 	var req struct {
 		IDs []string `json:"ids"`
@@ -82,8 +94,17 @@ func (h *Handler) EmojiDeleteBulk(c echo.Context) error {
 	if h.emojiRepo == nil {
 		return c.NoContent(http.StatusNoContent)
 	}
+	// per-emoji log のため削除前に snapshot を取得。失敗しても削除自体は
+	// 続行する (snapshot 失敗で監査が落ちるより操作完遂が優先)。
+	snapshots, _ := h.emojiRepo.FindManyByIDs(req.IDs)
 	if err := h.emojiRepo.DeleteMany(req.IDs); err != nil {
 		return c.JSON(http.StatusInternalServerError, apierr.Error("INTERNAL_ERROR", "Internal error.", "00000000-0000-0000-0000-000000000000"))
+	}
+	for _, e := range snapshots {
+		h.logModeration(c, moderationlog.LogDeleteCustomEmoji, map[string]any{
+			"emojiId": e.ID,
+			"emoji":   e,
+		})
 	}
 	return c.NoContent(http.StatusNoContent)
 }

--- a/internal/api/admin/handler.go
+++ b/internal/api/admin/handler.go
@@ -1347,6 +1347,12 @@ func (h *Handler) EmojiAdd(c echo.Context) error {
 // Misskey TS の admin/emoji/update は name/category/aliases に加え license/
 // isSensitive/localOnly も受け付ける。フロントの編集ダイアログがこれら全部
 // 送信するため Request struct を Misskey 互換に拡張する (#650 問題 2)。
+//
+// Aliases は []string なので nil (省略) と [] (空配列) が型で区別できない。
+// Misskey TS 側も optional `?` で undefined と空配列を区別しないため、
+// nil != 空配列でない場合に "aliases を全削除" として扱う。実装上は
+// `req.Aliases != nil` で「フロントが aliases フィールドを明示送信した」
+// と判定しており、空配列送信なら全削除、フィールド欠落なら現状維持。
 func (h *Handler) EmojiUpdate(c echo.Context) error {
 	var req struct {
 		ID          string   `json:"id"`

--- a/internal/api/admin/handler.go
+++ b/internal/api/admin/handler.go
@@ -1335,22 +1335,40 @@ func (h *Handler) EmojiAdd(c echo.Context) error {
 	if err := h.emojiRepo.Create(e); err != nil {
 		return c.JSON(http.StatusInternalServerError, apierr.Error("INTERNAL_ERROR", "Internal error.", "5d37dbcb-891e-41ca-a3d6-e690c97775ac"))
 	}
+	h.logModeration(c, moderationlog.LogAddCustomEmoji, map[string]any{
+		"emojiId": e.ID,
+		"emoji":   e,
+	})
 	return c.JSON(http.StatusOK, e)
 }
 
 // EmojiUpdate handles POST /api/admin/emoji/update.
+//
+// Misskey TS の admin/emoji/update は name/category/aliases に加え license/
+// isSensitive/localOnly も受け付ける。フロントの編集ダイアログがこれら全部
+// 送信するため Request struct を Misskey 互換に拡張する (#650 問題 2)。
 func (h *Handler) EmojiUpdate(c echo.Context) error {
 	var req struct {
-		ID       string   `json:"id"`
-		Name     *string  `json:"name"`
-		Category *string  `json:"category"`
-		Aliases  []string `json:"aliases"`
+		ID          string   `json:"id"`
+		Name        *string  `json:"name"`
+		Category    *string  `json:"category"`
+		Aliases     []string `json:"aliases"`
+		License     *string  `json:"license"`
+		IsSensitive *bool    `json:"isSensitive"`
+		LocalOnly   *bool    `json:"localOnly"`
 	}
 	if err := c.Bind(&req); err != nil || req.ID == "" {
 		return c.JSON(http.StatusBadRequest, apierr.Error("INVALID_PARAM", "id is required.", "3d81ceae-475f-4600-b2a8-2bc116157532"))
 	}
 	if h.emojiRepo == nil {
 		return c.JSON(http.StatusInternalServerError, apierr.Error("INTERNAL_ERROR", "Internal error.", "5d37dbcb-891e-41ca-a3d6-e690c97775ac"))
+	}
+	// before snapshot for moderation log (also used to gate NO_SUCH_EMOJI when
+	// the row is missing — UpdateFields の RowsAffected==0 経路は repo 側で
+	// ErrRecordNotFound に昇格済み (#650 問題 2)).
+	before, err := h.emojiRepo.FindByID(req.ID)
+	if err != nil {
+		return c.JSON(http.StatusNotFound, apierr.Error("NO_SUCH_EMOJI", "No such emoji.", "684b7e7e-7e91-4e4c-a5cc-8050e4b8e0d8"))
 	}
 	fields := map[string]any{}
 	if req.Name != nil {
@@ -1362,9 +1380,33 @@ func (h *Handler) EmojiUpdate(c echo.Context) error {
 	if req.Aliases != nil {
 		fields["aliases"] = req.Aliases
 	}
+	if req.License != nil {
+		fields["license"] = *req.License
+	}
+	if req.IsSensitive != nil {
+		fields["isSensitive"] = *req.IsSensitive
+	}
+	if req.LocalOnly != nil {
+		fields["localOnly"] = *req.LocalOnly
+	}
+	if len(fields) == 0 {
+		// 何も変更しないリクエストは log を書かずに 204 で返す。
+		return c.NoContent(http.StatusNoContent)
+	}
 	if err := h.emojiRepo.UpdateFields(req.ID, fields); err != nil {
 		return c.JSON(http.StatusNotFound, apierr.Error("NO_SUCH_EMOJI", "No such emoji.", "684b7e7e-7e91-4e4c-a5cc-8050e4b8e0d8"))
 	}
+	after, err := h.emojiRepo.FindByID(req.ID)
+	if err != nil {
+		// ここに到達するのは UpdateFields 直後の row 消失 (race) のみ。
+		// 操作自体は成功しているので 204 を返す。
+		return c.NoContent(http.StatusNoContent)
+	}
+	h.logModeration(c, moderationlog.LogUpdateCustomEmoji, map[string]any{
+		"emojiId": req.ID,
+		"before":  before,
+		"after":   after,
+	})
 	return c.NoContent(http.StatusNoContent)
 }
 
@@ -1379,9 +1421,18 @@ func (h *Handler) EmojiDelete(c echo.Context) error {
 	if h.emojiRepo == nil {
 		return c.JSON(http.StatusInternalServerError, apierr.Error("INTERNAL_ERROR", "Internal error.", "5d37dbcb-891e-41ca-a3d6-e690c97775ac"))
 	}
+	// log info に snapshot を含めるため削除前に取得。取得失敗は NO_SUCH_EMOJI。
+	snapshot, err := h.emojiRepo.FindByID(req.ID)
+	if err != nil {
+		return c.JSON(http.StatusNotFound, apierr.Error("NO_SUCH_EMOJI", "No such emoji.", "684b7e7e-7e91-4e4c-a5cc-8050e4b8e0d8"))
+	}
 	if err := h.emojiRepo.Delete(req.ID); err != nil {
 		return c.JSON(http.StatusNotFound, apierr.Error("NO_SUCH_EMOJI", "No such emoji.", "684b7e7e-7e91-4e4c-a5cc-8050e4b8e0d8"))
 	}
+	h.logModeration(c, moderationlog.LogDeleteCustomEmoji, map[string]any{
+		"emojiId": req.ID,
+		"emoji":   snapshot,
+	})
 	return c.NoContent(http.StatusNoContent)
 }
 

--- a/internal/api/admin/handler_test.go
+++ b/internal/api/admin/handler_test.go
@@ -1511,6 +1511,21 @@ func TestRolesAssign_WritesModerationLog(t *testing.T) {
 	assert.Equal(t, "Mod", info["roleName"])
 }
 
+func TestRolesUpdate_NoFieldsReturnsNoContentWithoutLog(t *testing.T) {
+	// 全 optional pointer が nil のリクエストは log を書かずに 204 で帰る
+	// (#668 review minor #2)。
+	h, _, _, roleRepo := newTestHandler(t)
+	roleRepo.Roles["r1"] = &model.Role{ID: "r1", Name: "Stay"}
+	repo := attachModLog(t, h)
+
+	rec := doPost(h.RolesUpdate, `{"roleId":"r1"}`, adminUser)
+	require.Equal(t, http.StatusNoContent, rec.Code)
+
+	require.Never(t, func() bool {
+		return len(repo.Snapshot()) > 0
+	}, 100*time.Millisecond, 10*time.Millisecond, "empty fields → log must not be written")
+}
+
 func TestRolesUnassign_WritesModerationLog(t *testing.T) {
 	h, userRepo, _, roleRepo := newTestHandler(t)
 	userRepo.Users["u1"] = &model.User{ID: "u1", Username: "alice"}

--- a/internal/api/admin/modlog_helpers_internal_test.go
+++ b/internal/api/admin/modlog_helpers_internal_test.go
@@ -1,0 +1,42 @@
+package admin
+
+// Internal (package admin) test for modlog helpers. Lets us hit the
+// nil-target defensive branch of logUserActionWithUser directly without
+// going through a handler. Phase 1 review iter 2 #1 follow-up.
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/labstack/echo/v4"
+	"github.com/shiroha-a/mk/internal/core/moderationlog"
+	"github.com/shiroha-a/mk/internal/misc/id"
+	"github.com/shiroha-a/mk/internal/testutil"
+)
+
+// newCtx builds a minimal echo.Context for helper invocation. The
+// helpers only touch c.Request().Context() so a stub request is enough.
+func newCtx() echo.Context {
+	e := echo.New()
+	req := httptest.NewRequest(http.MethodPost, "/", strings.NewReader(`{}`))
+	rec := httptest.NewRecorder()
+	return e.NewContext(req, rec)
+}
+
+func TestLogUserActionWithUser_NilTargetIsNoop(t *testing.T) {
+	repo := testutil.NewMockModerationLogRepository()
+	gen, err := id.NewGenerator("aidx")
+	if err != nil {
+		t.Fatalf("idgen: %v", err)
+	}
+	h := &Handler{modLogService: moderationlog.New(repo, gen)}
+
+	// nil target — must early-return without writing anything.
+	h.logUserActionWithUser(newCtx(), moderationlog.LogSuspend, nil)
+
+	if got := repo.Snapshot(); len(got) != 0 {
+		t.Errorf("expected no log writes, got %d", len(got))
+	}
+}

--- a/internal/repository/emoji.go
+++ b/internal/repository/emoji.go
@@ -69,7 +69,17 @@ func (r *emojiRepository) FindByID(id string) (*model.Emoji, error) {
 }
 
 func (r *emojiRepository) UpdateFields(id string, fields map[string]any) error {
-	return r.db.Model(&model.Emoji{}).Where("id = ?", id).Updates(fields).Error
+	res := r.db.Model(&model.Emoji{}).Where("id = ?", id).Updates(fields)
+	if res.Error != nil {
+		return res.Error
+	}
+	// GORM の Updates は対象 row が存在しなくても Error を返さない。
+	// admin/emoji/update が "No such emoji" を正しく返すために
+	// RowsAffected==0 を ErrRecordNotFound に昇格する (#650 問題 2)。
+	if res.RowsAffected == 0 {
+		return gorm.ErrRecordNotFound
+	}
+	return nil
 }
 
 func (r *emojiRepository) FindManyByIDs(ids []string) ([]*model.Emoji, error) {

--- a/internal/repository/emoji_test.go
+++ b/internal/repository/emoji_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/shiroha-a/mk/internal/model"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"gorm.io/gorm"
 )
 
 func cleanupEmoji(t *testing.T, id string) {
@@ -211,6 +212,31 @@ func TestEmojiRepository_FindManyByIDs(t *testing.T) {
 	empty, err := repo.FindManyByIDs(nil)
 	require.NoError(t, err)
 	assert.Empty(t, empty)
+}
+
+func TestEmojiRepository_UpdateFields_NotFound(t *testing.T) {
+	// #650 問題 2: 存在しない id への UpdateFields は GORM の Updates が
+	// 何も更新せずに Error=nil を返すため、以前は呼び出し側で「成功」と
+	// 誤認していた。RowsAffected==0 を gorm.ErrRecordNotFound に昇格する。
+	repo := NewEmojiRepository(testDB)
+
+	err := repo.UpdateFields("nonexistent_id_xyz", map[string]any{"category": "x"})
+	require.Error(t, err)
+	assert.ErrorIs(t, err, gorm.ErrRecordNotFound)
+}
+
+func TestEmojiRepository_UpdateFields_Success(t *testing.T) {
+	repo := NewEmojiRepository(testDB)
+
+	e := &model.Emoji{ID: "em_uf1", Name: "upd_target", OriginalURL: "https://x"}
+	require.NoError(t, repo.Create(e))
+	defer cleanupEmoji(t, e.ID)
+
+	require.NoError(t, repo.UpdateFields(e.ID, map[string]any{"category": "happy"}))
+	after, err := repo.FindByID(e.ID)
+	require.NoError(t, err)
+	require.NotNil(t, after.Category)
+	assert.Equal(t, "happy", *after.Category)
 }
 
 func TestEmojiRepository_UpdateFieldsMany(t *testing.T) {

--- a/internal/testutil/mock_repository.go
+++ b/internal/testutil/mock_repository.go
@@ -1298,6 +1298,10 @@ func (m *MockEmojiRepository) UpdateFields(id string, fields map[string]any) err
 					if b, ok := v.(bool); ok {
 						e.IsSensitive = b
 					}
+				case "localOnly":
+					if b, ok := v.(bool); ok {
+						e.LocalOnly = b
+					}
 				case "updatedAt":
 					if ts, ok := v.(time.Time); ok {
 						e.UpdatedAt = &ts


### PR DESCRIPTION
## Summary

#651 Phase modlog 4 (#661) と #650 (絵文字 import/edit バグ) を統合 PR で対応。スコープが「カスタム絵文字 admin」で重なるため 1 PR にまとめ、レビュー負荷を抑えつつ #650 の Request struct 拡張と #661 の before/after log 取得を共通化。

合計 **5 handler** に modlog を配線、**2 件のバグ修正**、**3 件の review minor** を取り込み。

Closes #661
Closes #650

## #650 修正

### 問題 1: EmojiCopy が常に \`_copy\` suffix を付ける
Misskey TS 上流 (\`admin/emoji/copy.ts\`) を確認した結果、本家は **元 name のまま local 化し、同名 local emoji 衝突時に \`DUPLICATE_NAME\`** を返す。mk-go の独自仕様 (\`newName := src.Name + \"_copy\"\`) を撤去して TS 互換に揃えた。

### 問題 2: EmojiUpdate が \`NO_SUCH_EMOJI\` エラーを返す
原因 2 つ:
1. Request struct が \`name/category/aliases\` のみ受け、フロントが送る \`license/isSensitive/localOnly\` を落とす → 拡張
2. \`internal/repository/emoji.go\` の \`UpdateFields\` が \`RowsAffected\` を見ずに常に \`nil\` 返却 → \`RowsAffected==0\` を \`gorm.ErrRecordNotFound\` に昇格

## #661 modlog 配線 (5 handler)

Misskey TS 上流の log 呼び出しを精査した結果、log を書くのは以下のみ。互換性のため aliases/category/license bulk と import-zip は **skip**。

| handler | type | info |
|---|---|---|
| EmojiAdd | addCustomEmoji | \`{emojiId, emoji}\` |
| EmojiUpdate | updateCustomEmoji | \`{emojiId, before, after}\` |
| EmojiDelete | deleteCustomEmoji | \`{emojiId, emoji}\` |
| EmojiCopy | addCustomEmoji | \`{emojiId, emoji}\` |
| EmojiDeleteBulk | deleteCustomEmoji | **絵文字ごとに 1 log** (TS の \`CustomEmojiService.deleteBulk\` for ループ互換) |

## #668 review minor 取り込み

- **#1**: \`logUserActionWithUser\` の nil-target branch を \`package admin\` の internal test (\`modlog_helpers_internal_test.go\` 新設) で直接カバー
- **#2**: \`TestRolesUpdate_NoFieldsReturnsNoContentWithoutLog\` 追加。空 fields リクエストで 204 + log なしを \`require.Never\` で検証

## テスト

\`\`\`bash
make fmt && make lint
go test ./internal/api/admin/... ./internal/repository/... -race -cover
\`\`\`

新規テスト:
- \`TestEmoji{Add,Update,Delete,Copy,DeleteBulk}_WritesModerationLog\` (5 件)
- \`TestEmojiUpdate_WritesModerationLog_WithExtendedFields\` (license/isSensitive/localOnly 永続化 + before/after log)
- \`TestEmojiUpdate_NoSuchEmojiOnMissingID\` (#650 問題 2 verify)
- \`TestEmojiCopy_{DuplicateNameReturns400,Success}\` を Misskey TS 互換 (remote → local copy) に書き換え
- \`TestEmojiRepository_UpdateFields_{NotFound,Success}\` (testcontainers 経由)
- \`TestLogUserActionWithUser_NilTargetIsNoop\` (internal)
- \`TestRolesUpdate_NoFieldsReturnsNoContentWithoutLog\`

## カバレッジ

- \`internal/api/admin\`: **84.7%** (CI 閾値 80% 維持)
- \`internal/repository\`: 90.0% → **90.1%** (CI 閾値 90% クリア)

## non-goals (別 issue 候補)

- \`EmojiCopy\` の drive 経由 upload (Misskey TS の \`driveService.uploadFromUrl\` 相当): 現状は src の URL を直接 copy。完全な互換にはリモート画像を local drive に保存する処理が必要だが scope 拡大過剰
- \`roleIdsThatCanBeUsedThisEmojiAsReaction\` / \`fileId\` の Request 受け入れ: model 側に対応フィールド未実装のため別途新設が必要

🤖 Generated with [Claude Code](https://claude.com/claude-code)