### PR TITLE
Fix #654: ジョブキュー widget の Process / Delayed / inbox が反映されない問題

### DIFF
--- a/internal/api/admin/queue.go
+++ b/internal/api/admin/queue.go
@@ -552,7 +552,10 @@ func (h *Handler) QueueStats(c echo.Context) error {
 			continue
 		}
 		result[qname] = map[string]any{
-			"activeSince": nil, "active": info.Active, "waiting": info.Pending, "delayed": info.Scheduled,
+			// Bull の delayed は asynq の Scheduled (未来実行予定) と
+			// Retry (失敗後再試行待ち) の両方を含む。stream/queue_stats_publisher.go
+			// の WebSocket publisher と semantics を揃える (#654)。
+			"activeSince": nil, "active": info.Active, "waiting": info.Pending, "delayed": info.Scheduled + info.Retry,
 		}
 	}
 	return c.JSON(http.StatusOK, result)

--- a/internal/api/admin/queue_test.go
+++ b/internal/api/admin/queue_test.go
@@ -491,3 +491,33 @@ func TestQueueStatsAdmin(t *testing.T) {
 	assert.Equal(t, http.StatusOK, rec.Code)
 	assert.Contains(t, rec.Body.String(), "deliver")
 }
+
+// TestQueueStats_DelayedIncludesScheduledAndRetry guards #654: Misskey
+// frontend の WidgetJobQueue は Bull 用語の delayed をグラフ化するが、
+// asynq では Scheduled (未来実行予定) と Retry (失敗後再試行待ち) の
+// 2 つに分かれる。delayed = Scheduled + Retry を返さないと再試行待ちが
+// dashboard に出ないため、この合算が REST API でも維持されることを guard。
+func TestQueueStats_DelayedIncludesScheduledAndRetry(t *testing.T) {
+	h, _, _, _ := newTestHandler(t)
+	insp := &stubQueueInspector{
+		info: map[string]*apiadmin.QueueInfoResult{
+			"deliver": {Queue: "deliver", Active: 1, Pending: 2, Scheduled: 3, Retry: 4},
+			"inbox":   {Queue: "inbox", Active: 0, Pending: 0, Scheduled: 5, Retry: 6},
+		},
+	}
+	h.SetQueueInspector(insp)
+
+	rec := doPost(h.QueueStats, `{}`, adminUser)
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	var resp map[string]map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+
+	// deliver: Scheduled 3 + Retry 4 = 7
+	assert.EqualValues(t, 1, resp["deliver"]["active"])
+	assert.EqualValues(t, 2, resp["deliver"]["waiting"])
+	assert.EqualValues(t, 7, resp["deliver"]["delayed"], "delayed must be Scheduled+Retry")
+
+	// inbox: Scheduled 5 + Retry 6 = 11
+	assert.EqualValues(t, 11, resp["inbox"]["delayed"], "delayed must be Scheduled+Retry")
+}

--- a/internal/server/queue_adapter.go
+++ b/internal/server/queue_adapter.go
@@ -24,6 +24,7 @@ func (a *queueStatsInspectorAdapter) GetQueueInfo(qname string) (*stream.QueueSt
 		Pending:   info.Pending,
 		Scheduled: info.Scheduled,
 		Retry:     info.Retry,
+		Completed: info.Completed,
 	}, nil
 }
 

--- a/internal/stream/queue_stats_publisher.go
+++ b/internal/stream/queue_stats_publisher.go
@@ -77,12 +77,18 @@ func NewQueueStatsPublisher(inspector QueueInspector, pub PubSubPublisher, inter
 }
 
 // Start begins the collection loop.
+//
+// Stop()→Start() による再起動時は前 publisher の prevCompleted を捨て、
+// 新規 loop の初回 tick で activeSincePrevTick=0 を出す。これは asynq の
+// Completed が 1 日 rolling な性質と整合 (再起動またぎで delta を取って
+// も意味のある値にならない)。
 func (p *QueueStatsPublisher) Start() {
 	p.mu.Lock()
 	defer p.mu.Unlock()
 	if p.started || p.pub == nil || p.inspector == nil {
 		return
 	}
+	p.prevCompleted = make(map[string]int)
 	p.started = true
 	p.wg.Add(1)
 	go p.loop()
@@ -135,8 +141,8 @@ type queueStatsEntry struct {
 
 func (p *QueueStatsPublisher) tick() {
 	body := queueStatsBody{
-		Deliver: p.queueEntry(deliverQueueName),
-		Inbox:   p.queueEntry(inboxQueueName),
+		Deliver: p.entryForQueue(deliverQueueName),
+		Inbox:   p.entryForQueue(inboxQueueName),
 	}
 	raw, err := json.Marshal(body)
 	if err != nil {
@@ -164,7 +170,7 @@ var (
 	inboxQueueName   = "inbox"
 )
 
-// queueEntry queries one asynq queue and translates its depth into the
+// entryForQueue queries one asynq queue and translates its depth into the
 // Bull-shaped queueStatsEntry the frontend WidgetJobQueue consumes.
 //
 // activeSincePrevTick は前 tick 以降に処理完了したジョブ数の delta で、
@@ -175,7 +181,7 @@ var (
 //
 // 初回 tick (prevCompleted に該当 queue の値が無い) は 0 を出して、
 // 次 tick から実数の delta を出す。
-func (p *QueueStatsPublisher) queueEntry(qname string) queueStatsEntry {
+func (p *QueueStatsPublisher) entryForQueue(qname string) queueStatsEntry {
 	info, err := p.inspector.GetQueueInfo(qname)
 	if err != nil || info == nil {
 		return queueStatsEntry{}

--- a/internal/stream/queue_stats_publisher.go
+++ b/internal/stream/queue_stats_publisher.go
@@ -18,20 +18,25 @@ type QueueInspector interface {
 // this package does not have to import internal/queue. 循環依存防止。
 // Delayed は Bull 用語で asynq の Scheduled + Retry 合計に対応するので
 // 両方の field を保持する。
+//
+// Completed は「累計の処理完了数」(asynq では 1 日 rolling、mkq では
+// 同等のカウンタ)。前 tick との差分で activeSincePrevTick (=tick 間に
+// 処理された数) を計算するために保持する (#654)。
 type QueueStatsInfo struct {
 	Active    int
 	Pending   int
 	Scheduled int
 	Retry     int
+	Completed int
 }
 
 // QueueStatsPublisher periodically queries asynq queue depths and publishes
 // them to the `queueStats` PubSub topic for the admin dashboard / widget.
 //
-// 本家Misskey QueueStatsServiceは `deliver` と `inbox` の2キーを出すが、
-// mk-goのinbox処理はHTTP同期で asynq queue を持たない。そのため inbox は
-// 互換性のためにゼロ固定で出力し、`deliver` には実数を入れる。他のasynq
-// queue (push / webhook等) は出さない (frontendが見ていないため)。
+// 本家Misskey QueueStatsServiceは `deliver` と `inbox` の2キーを出す。
+// mk-go では #534 で inbox を asynq queue 化、#565 で HTTP handler を
+// verify-in-worker 化したため、`deliver` と同じく実数を出力する。
+// 他のasynq queue (push / webhook等) は出さない (frontendが見ていない)。
 type QueueStatsPublisher struct {
 	inspector QueueInspector
 	pub       PubSubPublisher
@@ -44,6 +49,12 @@ type QueueStatsPublisher struct {
 	// logBuf: server_stats と同等の O(1) circular buffer (新しい順、
 	// 最大 QueueStatsLogMax 件)。requestLog 応答用。
 	logBuf *statsRingBuffer
+
+	// prevCompleted は前 tick 時点の Completed 累計を queue 名別に保持
+	// する。次 tick で current - prev を activeSincePrevTick として
+	// 送信し、Misskey TS の Bull `active` event count 互換にする (#654)。
+	// loop goroutine 単独で書き込むので mutex 不要。
+	prevCompleted map[string]int
 }
 
 // QueueStatsLogMax は requestLog 応答で返す最大件数。TS 本家と同じ 200。
@@ -56,11 +67,12 @@ func NewQueueStatsPublisher(inspector QueueInspector, pub PubSubPublisher, inter
 		interval = 3 * time.Second
 	}
 	return &QueueStatsPublisher{
-		inspector: inspector,
-		pub:       pub,
-		interval:  interval,
-		stopCh:    make(chan struct{}),
-		logBuf:    newStatsRingBuffer(QueueStatsLogMax),
+		inspector:     inspector,
+		pub:           pub,
+		interval:      interval,
+		stopCh:        make(chan struct{}),
+		logBuf:        newStatsRingBuffer(QueueStatsLogMax),
+		prevCompleted: make(map[string]int),
 	}
 }
 
@@ -123,9 +135,8 @@ type queueStatsEntry struct {
 
 func (p *QueueStatsPublisher) tick() {
 	body := queueStatsBody{
-		Deliver: p.deliverEntry(),
-		// inboxは mk-go では queue を持たないので全て0固定 (frontend互換)。
-		Inbox: queueStatsEntry{},
+		Deliver: p.queueEntry(deliverQueueName),
+		Inbox:   p.queueEntry(inboxQueueName),
 	}
 	raw, err := json.Marshal(body)
 	if err != nil {
@@ -145,17 +156,41 @@ func (p *QueueStatsPublisher) Log(maxLen int) []json.RawMessage {
 	return p.logBuf.Log(maxLen)
 }
 
-// deliverQueueName は本番のasynq queue名。テストで差し替えられるように
-// 変数化する。
-var deliverQueueName = "deliver"
+// deliverQueueName / inboxQueueName は本番のasynq queue名。テストで差し
+// 替えられるように変数化する。internal/queue の InboxQueueName / queue
+// 定義と一致させること。
+var (
+	deliverQueueName = "deliver"
+	inboxQueueName   = "inbox"
+)
 
-func (p *QueueStatsPublisher) deliverEntry() queueStatsEntry {
-	info, err := p.inspector.GetQueueInfo(deliverQueueName)
+// queueEntry queries one asynq queue and translates its depth into the
+// Bull-shaped queueStatsEntry the frontend WidgetJobQueue consumes.
+//
+// activeSincePrevTick は前 tick 以降に処理完了したジョブ数の delta で、
+// Bull の active event count (= worker が pick up した瞬間に発火する
+// counter) と意味的には完全互換ではないが、widget の Process 列が
+// 「前 tick から処理された量」を表示する仕様には合致する。snapshot 時
+// の Active 数より低トラフィック環境で観測しやすい。
+//
+// 初回 tick (prevCompleted に該当 queue の値が無い) は 0 を出して、
+// 次 tick から実数の delta を出す。
+func (p *QueueStatsPublisher) queueEntry(qname string) queueStatsEntry {
+	info, err := p.inspector.GetQueueInfo(qname)
 	if err != nil || info == nil {
 		return queueStatsEntry{}
 	}
+	var processed int
+	if prev, ok := p.prevCompleted[qname]; ok {
+		// asynq の Completed は 1 日 rolling なので深夜にリセットされ
+		// て負値になり得る。負値は 0 にクランプ。
+		if d := info.Completed - prev; d > 0 {
+			processed = d
+		}
+	}
+	p.prevCompleted[qname] = info.Completed
 	return queueStatsEntry{
-		ActiveSincePrevTick: info.Active,
+		ActiveSincePrevTick: processed,
 		Active:              info.Active,
 		Waiting:             info.Pending,
 		// Bull の delayed は asynq の Scheduled (未来実行予定) と Retry

--- a/internal/stream/queue_stats_publisher_test.go
+++ b/internal/stream/queue_stats_publisher_test.go
@@ -51,9 +51,10 @@ func TestQueueStatsPublisher_PublishesDeliverAndInboxDepths(t *testing.T) {
 				ActiveSincePrevTick int `json:"activeSincePrevTick"`
 			} `json:"deliver"`
 			Inbox struct {
-				Active  int `json:"active"`
-				Waiting int `json:"waiting"`
-				Delayed int `json:"delayed"`
+				Active              int `json:"active"`
+				Waiting             int `json:"waiting"`
+				Delayed             int `json:"delayed"`
+				ActiveSincePrevTick int `json:"activeSincePrevTick"`
 			} `json:"inbox"`
 		}
 		require.NoError(t, json.Unmarshal(c.payload, &body))
@@ -66,7 +67,112 @@ func TestQueueStatsPublisher_PublishesDeliverAndInboxDepths(t *testing.T) {
 		assert.Equal(t, 5, body.Inbox.Active)
 		assert.Equal(t, 11, body.Inbox.Waiting)
 		assert.Equal(t, 4, body.Inbox.Delayed)
+		// stub は Completed を 0 で返し続けるので delta も 0 で安定。
+		assert.Equal(t, 0, body.Inbox.ActiveSincePrevTick)
 	}
+}
+
+// seqCompletedInspector は queue 名ごとに Completed 累計のシーケンスを
+// 返す stub。tick を進めるたびに次の値を返す。activeSincePrevTick が
+// 前 tick との差分で計算されることを決定的に検証するため (#654)。
+type seqCompletedInspector struct {
+	deliver, inbox []int
+	deliverIdx     int
+	inboxIdx       int
+}
+
+func (s *seqCompletedInspector) GetQueueInfo(qname string) (*QueueStatsInfo, error) {
+	var seq []int
+	var idx *int
+	switch qname {
+	case "deliver":
+		seq, idx = s.deliver, &s.deliverIdx
+	case "inbox":
+		seq, idx = s.inbox, &s.inboxIdx
+	default:
+		return &QueueStatsInfo{}, nil
+	}
+	if len(seq) == 0 {
+		return &QueueStatsInfo{}, nil
+	}
+	i := *idx
+	if i >= len(seq) {
+		i = len(seq) - 1 // 末尾以降は最終値で固定
+	} else {
+		*idx++
+	}
+	return &QueueStatsInfo{Completed: seq[i]}, nil
+}
+
+// TestQueueStatsPublisher_ActiveSincePrevTickIsCompletedDelta は
+// activeSincePrevTick が Completed の前 tick との差分で計算され、
+// asynq の rolling reset (Completed が 1 日 0 にリセットされる挙動) で
+// 負値になっても 0 にクランプされることを guard する (#654 review)。
+//
+// tick() を直接駆動する internal test。Start()/Stop() の goroutine 経由
+// だと tick タイミングが非決定的なので避ける。
+func TestQueueStatsPublisher_ActiveSincePrevTickIsCompletedDelta(t *testing.T) {
+	insp := &seqCompletedInspector{
+		// deliver: 10 → 15 (+5) → 3 (rolling reset、負値 clamp) → 8 (+5)
+		deliver: []int{10, 15, 3, 8},
+		// inbox は固定 0 で「他 queue の delta が deliver のみで動く」
+		// ことを示す。
+		inbox: []int{0, 0, 0, 0},
+	}
+	pub := &capturePubSub{}
+	p := NewQueueStatsPublisher(insp, pub, 0)
+
+	// 各 tick で activeSincePrevTick の期待値を assert。
+	expected := []int{
+		0, // 初回: prev なし
+		5, // 10 → 15
+		0, // 15 → 3 (負値 clamp)
+		5, // 3 → 8
+	}
+	for i, want := range expected {
+		p.tick()
+		calls := pub.snapshot()
+		require.Len(t, calls, i+1, "expected one publish per tick")
+		var body struct {
+			Deliver struct {
+				ActiveSincePrevTick int `json:"activeSincePrevTick"`
+			} `json:"deliver"`
+		}
+		require.NoError(t, json.Unmarshal(calls[i].payload, &body))
+		assert.Equalf(t, want, body.Deliver.ActiveSincePrevTick,
+			"tick %d: deliver activeSincePrevTick", i)
+	}
+}
+
+// Start() → Stop() → Start() の再起動で prevCompleted が reset され、
+// 新 publisher の初回 tick が 0 を出すことを確認 (#654 review)。
+func TestQueueStatsPublisher_RestartResetsPrevCompleted(t *testing.T) {
+	insp := &seqCompletedInspector{
+		deliver: []int{100, 105}, // restart 後 1 回目 = 100、2 回目 = 105
+		inbox:   []int{0, 0},
+	}
+	pub := &capturePubSub{}
+	p := NewQueueStatsPublisher(insp, pub, 0)
+
+	// 1 サイクル目: tick で prevCompleted=100 が記録される
+	p.tick()
+
+	// prevCompleted が外から見えないので Start/Stop 経由で reset を起こす
+	p.Start()
+	p.Stop()
+
+	// 2 サイクル目: restart 後の最初の tick は prev なし扱いで 0
+	p.tick()
+	calls := pub.snapshot()
+	require.NotEmpty(t, calls)
+	var body struct {
+		Deliver struct {
+			ActiveSincePrevTick int `json:"activeSincePrevTick"`
+		} `json:"deliver"`
+	}
+	require.NoError(t, json.Unmarshal(calls[len(calls)-1].payload, &body))
+	assert.Equal(t, 0, body.Deliver.ActiveSincePrevTick,
+		"restart 後の初回 tick は prev なし扱いで 0")
 }
 
 // perQueueInspector returns a different QueueStatsInfo per queue name so

--- a/internal/stream/queue_stats_publisher_test.go
+++ b/internal/stream/queue_stats_publisher_test.go
@@ -25,9 +25,15 @@ func (s *stubQueueInspector) GetQueueInfo(_ string) (*QueueStatsInfo, error) {
 	return s.info, nil
 }
 
-func TestQueueStatsPublisher_PublishesDeliverDepths(t *testing.T) {
+func TestQueueStatsPublisher_PublishesDeliverAndInboxDepths(t *testing.T) {
+	// stub は queue 名で値を切り替えられるようにする (deliver / inbox で
+	// 同じ inspector を共有するため)。
+	infos := map[string]*QueueStatsInfo{
+		"deliver": {Active: 3, Pending: 7, Scheduled: 2, Retry: 1},
+		"inbox":   {Active: 5, Pending: 11, Scheduled: 0, Retry: 4},
+	}
+	insp := &perQueueInspector{infos: infos}
 	pub := &capturePubSub{}
-	insp := &stubQueueInspector{info: &QueueStatsInfo{Active: 3, Pending: 7, Scheduled: 2, Retry: 1}}
 	p := NewQueueStatsPublisher(insp, pub, 30*time.Millisecond)
 	p.Start()
 	time.Sleep(60 * time.Millisecond)
@@ -45,7 +51,9 @@ func TestQueueStatsPublisher_PublishesDeliverDepths(t *testing.T) {
 				ActiveSincePrevTick int `json:"activeSincePrevTick"`
 			} `json:"deliver"`
 			Inbox struct {
-				Active int `json:"active"`
+				Active  int `json:"active"`
+				Waiting int `json:"waiting"`
+				Delayed int `json:"delayed"`
 			} `json:"inbox"`
 		}
 		require.NoError(t, json.Unmarshal(c.payload, &body))
@@ -53,9 +61,22 @@ func TestQueueStatsPublisher_PublishesDeliverDepths(t *testing.T) {
 		assert.Equal(t, 7, body.Deliver.Waiting)
 		// Bull delayed = asynq Scheduled + Retry
 		assert.Equal(t, 3, body.Deliver.Delayed)
-		// inbox is a compatibility zero stub (mk-go has no inbox queue).
-		assert.Equal(t, 0, body.Inbox.Active)
+		// inbox は #534 で asynq queue 化、#565 で worker 化されたので
+		// 実数を出す (#654)。
+		assert.Equal(t, 5, body.Inbox.Active)
+		assert.Equal(t, 11, body.Inbox.Waiting)
+		assert.Equal(t, 4, body.Inbox.Delayed)
 	}
+}
+
+// perQueueInspector returns a different QueueStatsInfo per queue name so
+// tests can verify deliver / inbox are queried independently.
+type perQueueInspector struct {
+	infos map[string]*QueueStatsInfo
+}
+
+func (s *perQueueInspector) GetQueueInfo(qname string) (*QueueStatsInfo, error) {
+	return s.infos[qname], nil
 }
 
 func TestQueueStatsPublisher_InspectorErrorPublishesZeros(t *testing.T) {


### PR DESCRIPTION
## Summary

UDS 環境で WidgetJobQueue が「動いていない」 ように見える問題 (#654)。元の課題は \`delayed\` の retry 不足でしたが、調査の過程で **3 つの独立した不具合** が複合していたことが判明したので根本対応しました。

Closes #654

## 問題と修正 (3 件)

### 1. \`delayed\` フィールドに Retry が含まれない (元の #654)

\`internal/api/admin/queue.go\` の \`/api/admin/queue/stats\` で \`delayed = info.Scheduled\` のみ。Bull の delayed は **Scheduled (未来実行予定) + Retry (失敗後再試行待ち)** の合算。

WebSocket publisher 側は既に正しく実装されていたので REST API のみ修正。

### 2. inbox queue が 0 固定で送信されていた

\`internal/stream/queue_stats_publisher.go\` の inbox 部分が古いコメント (\`mk-go の inbox は HTTP 同期で queue を持たない\`) と共に \`queueStatsEntry{}\` 0 固定。

実際は **#534 で asynq queue 化、#565 で worker 化済み**なので deliver と同じく実数を出力すべき。\`queueEntry\` helper を共通化して両 queue を処理するように変更。

### 3. \`activeSincePrevTick\` が Active snapshot で代用されていた

ユーザー観察: 「ジョブ処理が速すぎて tick の瞬間に Active=0 になり Process 列が常に 0 に見える」

Misskey TS の Bull \`activeSincePrevTick\` は「前 tick 以降に処理した累計」だが、asynq には直接対応する API がない → **\`Completed\` (1 日 rolling 累計) の差分で代替**。

- 初回 tick は prev 値が無いので 0
- 深夜 rolling reset で負値になり得るので 0 クランプ
- queue 名別に \`prevCompleted\` map で保持 (loop 単独 write で mutex 不要)

\`QueueStatsInfo\` に \`Completed\` フィールドを追加、\`queue_adapter\` で mapping。

## UDS 動作確認 ✅

| 状態 | 結果 |
|---|---|
| 修正前 | 全数値が 0 で更新されず「動いていない」 |
| **修正後** | inbox の Process が tick 間の処理数を反映 (**実観測 1 を確認**) |

## テスト

\`\`\`bash
make fmt && make lint
go test ./internal/api/admin/... ./internal/stream/... ./internal/server/... -race -cover
\`\`\`

新規テスト:
- \`TestQueueStats_DelayedIncludesScheduledAndRetry\` (REST API: deliver/inbox の delayed 合算検証)
- \`TestQueueStatsPublisher_PublishesDeliverAndInboxDepths\` (WS publisher: deliver と inbox 両方の queue を別々に query して実数出力)

## 変更ファイル

- \`internal/api/admin/queue.go\` (delayed = Scheduled + Retry)
- \`internal/api/admin/queue_test.go\` (新規 test)
- \`internal/server/queue_adapter.go\` (Completed フィールドの mapping 追加)
- \`internal/stream/queue_stats_publisher.go\` (inbox 0 固定撤廃 + Completed delta)
- \`internal/stream/queue_stats_publisher_test.go\` (test 更新)

🤖 Generated with [Claude Code](https://claude.com/claude-code)