### PR TITLE
Fix #655: hashtags/trend で chart 配列を実数で返す

### DIFF
--- a/internal/api/hashtags/handler.go
+++ b/internal/api/hashtags/handler.go
@@ -1,10 +1,16 @@
 package hashtags
 
 import (
+	"fmt"
 	"net/http"
+	"sort"
+	"strconv"
+	"time"
 
 	"github.com/labstack/echo/v4"
+	"github.com/lib/pq"
 	"github.com/shiroha-a/mk/internal/api/apierr"
+	"github.com/shiroha-a/mk/internal/misc/id"
 	"github.com/shiroha-a/mk/internal/model"
 	"gorm.io/gorm"
 )
@@ -89,20 +95,157 @@ func (h *Handler) Show(c echo.Context) error {
 }
 
 // Trend handles POST /api/hashtags/trend.
+//
+// Misskey TS 互換: 直近 200 分 (10 分 × 20 bucket) の note 数を hashtag
+// 別に集計し、frontend の MkMiniChart が描画できる時系列を返す。
+//
+// TS 上流 (HashtagService.getCharts) は Redis HyperLogLog で users 単位
+// のユニーク数を count するが、mk-go では HLL を維持せず note テーブル
+// から動的に集計する。
+//
+// mk-go の note テーブルは createdAt 列を持たず、aidx ID 先頭 8 文字に
+// ms timestamp が埋め込まれている (`internal/misc/id/id.go` 参照)。
+// 200 分前の cutoff prefix を生成して `id > cutoffID` で範囲フィルタを
+// かける。tags 配列 (varchar(128)[]) には migration 000043 で GIN index
+// を張ったので `<>` フィルタも index で効く。
+//
+// 取得した row は Go 側で aidx parse → bucket idx 計算 → tag/bucket 別
+// の unique users を集計する。直近 200 分の対象 note 数は中規模インス
+// タンスなら数千件オーダーで、Go 側の集計コストは無視できる。
+//
+// chart の bucket は新しいもの順 (index 0 = 直近 10 分、index 19 = 200 分前)。
+// usersCount は TS と同じく `max(chart)` で算出する。
 func (h *Handler) Trend(c echo.Context) error {
-	var tags []*model.Hashtag
-	if err := h.db.Order("\"mentionedUsersCount\" DESC").Limit(10).Find(&tags).Error; err != nil {
+	const (
+		bucketSeconds = 600 // 10 分
+		bucketCount   = 20  // 過去 200 分
+		topN          = 10
+	)
+
+	cutoff := time.Now().Add(-time.Duration(bucketSeconds*bucketCount) * time.Second)
+	cutoffID := aidxCutoffPrefix(cutoff)
+
+	type row struct {
+		ID     string         `gorm:"column:id"`
+		UserID string         `gorm:"column:userId"`
+		Tags   pq.StringArray `gorm:"column:tags;type:varchar(128)[]"`
+	}
+	var rows []row
+	if err := h.db.Raw(`
+		SELECT "id", "userId", "tags"
+		FROM "note"
+		WHERE "id" > ?
+		  AND "tags" <> ARRAY[]::varchar[]
+	`, cutoffID).Scan(&rows).Error; err != nil {
 		return c.JSON(http.StatusInternalServerError, apierr.Error("INTERNAL_ERROR", "Internal error.", "5d37dbcb-891e-41ca-a3d6-e690c97775ac"))
 	}
-	result := make([]map[string]any, 0, len(tags))
-	for _, t := range tags {
+
+	gen, err := id.NewGenerator("aidx")
+	if err != nil {
+		return c.JSON(http.StatusInternalServerError, apierr.Error("INTERNAL_ERROR", "Internal error.", "5d37dbcb-891e-41ca-a3d6-e690c97775ac"))
+	}
+	parser, ok := gen.(interface {
+		ParseTime(string) (time.Time, error)
+	})
+	if !ok {
+		return c.JSON(http.StatusInternalServerError, apierr.Error("INTERNAL_ERROR", "Internal error.", "5d37dbcb-891e-41ca-a3d6-e690c97775ac"))
+	}
+
+	// bucketUsers[tag][bucketIdx] = set of unique userId
+	bucketUsers := make(map[string][bucketCount]map[string]struct{})
+	totalUsers := make(map[string]map[string]struct{})
+
+	now := time.Now()
+	for _, r := range rows {
+		ts, perr := parser.ParseTime(r.ID)
+		if perr != nil {
+			continue
+		}
+		secsAgo := now.Sub(ts).Seconds()
+		if secsAgo < 0 || secsAgo >= float64(bucketSeconds*bucketCount) {
+			continue
+		}
+		bucketIdx := int(secsAgo) / bucketSeconds
+		for _, tag := range r.Tags {
+			if tag == "" {
+				continue
+			}
+			buckets, exists := bucketUsers[tag]
+			if !exists {
+				for i := range buckets {
+					buckets[i] = map[string]struct{}{}
+				}
+				bucketUsers[tag] = buckets
+			}
+			bucketUsers[tag][bucketIdx][r.UserID] = struct{}{}
+
+			if _, exists := totalUsers[tag]; !exists {
+				totalUsers[tag] = map[string]struct{}{}
+			}
+			totalUsers[tag][r.UserID] = struct{}{}
+		}
+	}
+
+	// ranking: total users 降順、同点は tag name 昇順 (deterministic)
+	type ranked struct {
+		tag   string
+		total int
+	}
+	rankings := make([]ranked, 0, len(totalUsers))
+	for tag, users := range totalUsers {
+		rankings = append(rankings, ranked{tag: tag, total: len(users)})
+	}
+	sort.Slice(rankings, func(i, j int) bool {
+		if rankings[i].total != rankings[j].total {
+			return rankings[i].total > rankings[j].total
+		}
+		return rankings[i].tag < rankings[j].tag
+	})
+	if len(rankings) > topN {
+		rankings = rankings[:topN]
+	}
+
+	result := make([]map[string]any, 0, len(rankings))
+	for _, rk := range rankings {
+		chart := make([]int, bucketCount)
+		buckets := bucketUsers[rk.tag]
+		maxUsers := 0
+		for i := 0; i < bucketCount; i++ {
+			n := len(buckets[i])
+			chart[i] = n
+			if n > maxUsers {
+				maxUsers = n
+			}
+		}
 		result = append(result, map[string]any{
-			"tag":        t.Name,
-			"chart":      []int{},
-			"usersCount": t.MentionedUsersCount,
+			"tag":        rk.tag,
+			"chart":      chart,
+			"usersCount": maxUsers,
 		})
 	}
 	return c.JSON(http.StatusOK, result)
+}
+
+// aidxCutoffPrefix builds the smallest aidx-style ID at the given time
+// for use as a `WHERE id > ?` cutoff in note range scans. mk-go の note
+// は created_at 列を持たず aidx ID 先頭 8 文字に ms timestamp を埋め込
+// んでいるので、prefix だけ生成すれば lexicographic に正しく比較できる。
+//
+// time2000 と base36 padding の生成は internal/misc/id/id.go の aidxGen
+// と同じ規約。Generate() を再利用するとカウンタが 1 進んでしまうため
+// ここでは独自に prefix のみ作る。
+func aidxCutoffPrefix(t time.Time) string {
+	const time2000 int64 = 946684800000
+	ms := t.UnixMilli() - time2000
+	if ms < 0 {
+		ms = 0
+	}
+	timePart := fmt.Sprintf("%08s", strconv.FormatInt(ms, 36))
+	if len(timePart) > 8 {
+		timePart = timePart[len(timePart)-8:]
+	}
+	// 後続 8 文字 (nodeID + counter) は最小値で揃え、当該時刻の最小 ID を作る
+	return timePart + "00000000"
 }
 
 // Users handles POST /api/hashtags/users.

--- a/internal/api/hashtags/handler.go
+++ b/internal/api/hashtags/handler.go
@@ -1,10 +1,8 @@
 package hashtags
 
 import (
-	"fmt"
 	"net/http"
 	"sort"
-	"strconv"
 	"time"
 
 	"github.com/labstack/echo/v4"
@@ -104,10 +102,15 @@ func (h *Handler) Show(c echo.Context) error {
 // から動的に集計する。
 //
 // mk-go の note テーブルは createdAt 列を持たず、aidx ID 先頭 8 文字に
-// ms timestamp が埋め込まれている (`internal/misc/id/id.go` 参照)。
-// 200 分前の cutoff prefix を生成して `id > cutoffID` で範囲フィルタを
-// かける。tags 配列 (varchar(128)[]) には migration 000043 で GIN index
-// を張ったので `<>` フィルタも index で効く。
+// ms timestamp が埋め込まれている (`internal/misc/id`)。200 分前の
+// cutoff prefix を生成して `id > cutoffID` で範囲フィルタをかける。
+// tags 配列 (varchar(128)[]) には migration 000043 で GIN index を張った
+// ので `<>` フィルタも index で効く。
+//
+// visibility フィルタ: TS の HashtagService.updateHashtag は public /
+// home の note のみ集計対象にする。followers / specified を含めると
+// 公開トレンドに非公開タグが現れてプライバシー上の問題になるため、
+// SQL の WHERE で同じ条件を強制する。
 //
 // 取得した row は Go 側で aidx parse → bucket idx 計算 → tag/bucket 別
 // の unique users を集計する。直近 200 分の対象 note 数は中規模インス
@@ -122,32 +125,46 @@ func (h *Handler) Trend(c echo.Context) error {
 		topN          = 10
 	)
 
-	cutoff := time.Now().Add(-time.Duration(bucketSeconds*bucketCount) * time.Second)
-	cutoffID := aidxCutoffPrefix(cutoff)
-
-	type row struct {
-		ID     string         `gorm:"column:id"`
-		UserID string         `gorm:"column:userId"`
-		Tags   pq.StringArray `gorm:"column:tags;type:varchar(128)[]"`
-	}
-	var rows []row
-	if err := h.db.Raw(`
-		SELECT "id", "userId", "tags"
-		FROM "note"
-		WHERE "id" > ?
-		  AND "tags" <> ARRAY[]::varchar[]
-	`, cutoffID).Scan(&rows).Error; err != nil {
-		return c.JSON(http.StatusInternalServerError, apierr.Error("INTERNAL_ERROR", "Internal error.", "5d37dbcb-891e-41ca-a3d6-e690c97775ac"))
-	}
-
 	gen, err := id.NewGenerator("aidx")
 	if err != nil {
 		return c.JSON(http.StatusInternalServerError, apierr.Error("INTERNAL_ERROR", "Internal error.", "5d37dbcb-891e-41ca-a3d6-e690c97775ac"))
 	}
-	parser, ok := gen.(interface {
-		ParseTime(string) (time.Time, error)
-	})
-	if !ok {
+
+	cutoff := time.Now().Add(-time.Duration(bucketSeconds*bucketCount) * time.Second)
+	cutoffID := id.AidxCutoffPrefix(cutoff)
+
+	// pq.StringArray を含む struct を Scan(&rows) に渡すと GORM の
+	// schema reflection が `unsupported data type: &[]` を warn-log する
+	// (pq.StringArray の Scanner で runtime には正しく動くが、初期 type
+	// infer で躓く)。Rows().Scan() で個別に scan するとこの noise を回避
+	// できるので、本 handler では明示的なループ scan を採用する。
+	type row struct {
+		ID     string
+		UserID string
+		Tags   []string
+	}
+	var rows []row
+	sqlRows, err := h.db.Raw(`
+		SELECT "id", "userId", "tags"
+		FROM "note"
+		WHERE "id" > ?
+		  AND "tags" <> ARRAY[]::varchar[]
+		  AND "visibility" IN ('public', 'home')
+	`, cutoffID).Rows()
+	if err != nil {
+		return c.JSON(http.StatusInternalServerError, apierr.Error("INTERNAL_ERROR", "Internal error.", "5d37dbcb-891e-41ca-a3d6-e690c97775ac"))
+	}
+	defer sqlRows.Close()
+	for sqlRows.Next() {
+		var r row
+		var tags pq.StringArray
+		if err := sqlRows.Scan(&r.ID, &r.UserID, &tags); err != nil {
+			return c.JSON(http.StatusInternalServerError, apierr.Error("INTERNAL_ERROR", "Internal error.", "5d37dbcb-891e-41ca-a3d6-e690c97775ac"))
+		}
+		r.Tags = []string(tags)
+		rows = append(rows, r)
+	}
+	if err := sqlRows.Err(); err != nil {
 		return c.JSON(http.StatusInternalServerError, apierr.Error("INTERNAL_ERROR", "Internal error.", "5d37dbcb-891e-41ca-a3d6-e690c97775ac"))
 	}
 
@@ -157,7 +174,7 @@ func (h *Handler) Trend(c echo.Context) error {
 
 	now := time.Now()
 	for _, r := range rows {
-		ts, perr := parser.ParseTime(r.ID)
+		ts, perr := gen.ParseTime(r.ID)
 		if perr != nil {
 			continue
 		}
@@ -224,28 +241,6 @@ func (h *Handler) Trend(c echo.Context) error {
 		})
 	}
 	return c.JSON(http.StatusOK, result)
-}
-
-// aidxCutoffPrefix builds the smallest aidx-style ID at the given time
-// for use as a `WHERE id > ?` cutoff in note range scans. mk-go の note
-// は created_at 列を持たず aidx ID 先頭 8 文字に ms timestamp を埋め込
-// んでいるので、prefix だけ生成すれば lexicographic に正しく比較できる。
-//
-// time2000 と base36 padding の生成は internal/misc/id/id.go の aidxGen
-// と同じ規約。Generate() を再利用するとカウンタが 1 進んでしまうため
-// ここでは独自に prefix のみ作る。
-func aidxCutoffPrefix(t time.Time) string {
-	const time2000 int64 = 946684800000
-	ms := t.UnixMilli() - time2000
-	if ms < 0 {
-		ms = 0
-	}
-	timePart := fmt.Sprintf("%08s", strconv.FormatInt(ms, 36))
-	if len(timePart) > 8 {
-		timePart = timePart[len(timePart)-8:]
-	}
-	// 後続 8 文字 (nodeID + counter) は最小値で揃え、当該時刻の最小 ID を作る
-	return timePart + "00000000"
 }
 
 // Users handles POST /api/hashtags/users.

--- a/internal/api/hashtags/handler_test.go
+++ b/internal/api/hashtags/handler_test.go
@@ -145,12 +145,19 @@ func ensureUser(t *testing.T, userID string) {
 // model.Note 経由だと validation が重いので raw SQL で軽く済ます。
 func insertNote(t *testing.T, gen id.Generator, userID string, tags []string, createdAt time.Time) {
 	t.Helper()
+	insertNoteWithVisibility(t, gen, userID, tags, createdAt, "public")
+}
+
+// insertNoteWithVisibility: visibility (public/home/followers/specified)
+// を制御できる挿入ヘルパー。trend 集計の visibility フィルタ検証用。
+func insertNoteWithVisibility(t *testing.T, gen id.Generator, userID string, tags []string, createdAt time.Time, visibility string) {
+	t.Helper()
 	ensureUser(t, userID)
 	noteID := gen.Generate(createdAt)
 	require.NoError(t, testDB.Exec(
 		`INSERT INTO "note" ("id", "userId", "tags", "visibility", "text")
-		 VALUES (?, ?, ?, 'public', '')`,
-		noteID, userID, pq.StringArray(tags),
+		 VALUES (?, ?, ?, ?::note_visibility_enum, '')`,
+		noteID, userID, pq.StringArray(tags), visibility,
 	).Error)
 }
 
@@ -207,6 +214,36 @@ func TestTrend_AggregatesRecentNotes(t *testing.T) {
 
 func TestTrend_DBError(t *testing.T) {
 	assert.Equal(t, http.StatusInternalServerError, doPost(brokenHandler().Trend, `{}`).Code)
+}
+
+// TestTrend_VisibilityFilterExcludesPrivate guards #678 review:
+// followers / specified の note は trend 集計対象外。
+func TestTrend_VisibilityFilterExcludesPrivate(t *testing.T) {
+	cleanupNotes()
+	defer cleanupNotes()
+
+	gen, err := id.NewGenerator("aidx")
+	require.NoError(t, err)
+
+	now := time.Now()
+	// public + home は集計対象、followers + specified は除外。
+	insertNoteWithVisibility(t, gen, "tu_p", []string{"public_tag"}, now.Add(-5*time.Minute), "public")
+	insertNoteWithVisibility(t, gen, "tu_h", []string{"home_tag"}, now.Add(-5*time.Minute), "home")
+	insertNoteWithVisibility(t, gen, "tu_f", []string{"followers_tag"}, now.Add(-5*time.Minute), "followers")
+	insertNoteWithVisibility(t, gen, "tu_s", []string{"specified_tag"}, now.Add(-5*time.Minute), "specified")
+
+	rec := doPost(newHandler().Trend, `{}`)
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	body := rec.Body.String()
+	// public_tag / home_tag は出る。
+	assert.Contains(t, body, `"public_tag"`)
+	assert.Contains(t, body, `"home_tag"`)
+	// followers_tag / specified_tag は trend に出てはいけない (プライバシー保護)。
+	assert.NotContains(t, body, `"followers_tag"`,
+		"followers visibility は集計対象外であるべき")
+	assert.NotContains(t, body, `"specified_tag"`,
+		"specified visibility は集計対象外であるべき")
 }
 
 // --- Users ---

--- a/internal/api/hashtags/handler_test.go
+++ b/internal/api/hashtags/handler_test.go
@@ -1,16 +1,21 @@
 package hashtags_test
 
 import (
+	"encoding/json"
 	"net/http"
 	"net/http/httptest"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/labstack/echo/v4"
+	"github.com/lib/pq"
 	"github.com/shiroha-a/mk/internal/api/hashtags"
+	"github.com/shiroha-a/mk/internal/misc/id"
 	"github.com/shiroha-a/mk/internal/model"
 	"github.com/shiroha-a/mk/internal/testutil"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"gorm.io/gorm"
 )
 
@@ -118,13 +123,86 @@ func TestShow_InvalidParam(t *testing.T) {
 
 // --- Trend ---
 
-func TestTrend_Success(t *testing.T) {
-	cleanup()
-	testDB.Create(&model.Hashtag{ID: "ht4", Name: "trending", MentionedUsersCount: 100})
-	defer cleanup()
+// cleanupNotes は Trend 関連 test の前後で note と user (FK) を掃除する。
+func cleanupNotes() {
+	testDB.Exec(`DELETE FROM "note"`)
+	testDB.Exec(`DELETE FROM "user" WHERE "id" LIKE 'tu_%'`)
+}
+
+// ensureUser は note の userId FK を満たすための最小限の user row を
+// 用意する。同 id が既存の場合は no-op。
+func ensureUser(t *testing.T, userID string) {
+	t.Helper()
+	testDB.Exec(`
+		INSERT INTO "user" ("id", "username", "usernameLower")
+		VALUES (?, ?, ?)
+		ON CONFLICT DO NOTHING
+	`, userID, userID, userID)
+}
+
+// insertNote: Trend test 用の最小限 note row を作る。aidx ID を
+// createdAt として埋め込み、note.tags に集計対象タグを入れる。
+// model.Note 経由だと validation が重いので raw SQL で軽く済ます。
+func insertNote(t *testing.T, gen id.Generator, userID string, tags []string, createdAt time.Time) {
+	t.Helper()
+	ensureUser(t, userID)
+	noteID := gen.Generate(createdAt)
+	require.NoError(t, testDB.Exec(
+		`INSERT INTO "note" ("id", "userId", "tags", "visibility", "text")
+		 VALUES (?, ?, ?, 'public', '')`,
+		noteID, userID, pq.StringArray(tags),
+	).Error)
+}
+
+func TestTrend_EmptyReturnsEmptyArray(t *testing.T) {
+	cleanupNotes()
 	rec := doPost(newHandler().Trend, `{}`)
 	assert.Equal(t, http.StatusOK, rec.Code)
-	assert.Contains(t, rec.Body.String(), "trending")
+	var resp []map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+	assert.Empty(t, resp, "no notes → empty trend list")
+}
+
+func TestTrend_AggregatesRecentNotes(t *testing.T) {
+	cleanupNotes()
+	defer cleanupNotes()
+
+	gen, err := id.NewGenerator("aidx")
+	require.NoError(t, err)
+
+	now := time.Now()
+	// alpha: 2 distinct users (tu_1@bucket0, tu_2@bucket1)
+	insertNote(t, gen, "tu_1", []string{"alpha"}, now.Add(-5*time.Minute))
+	insertNote(t, gen, "tu_2", []string{"alpha"}, now.Add(-15*time.Minute))
+	// beta: 1 user (tu_1@bucket0)
+	insertNote(t, gen, "tu_1", []string{"beta"}, now.Add(-5*time.Minute))
+	// gamma: 1 note だが 200 分超 → bucket 範囲外、cutoff で除外
+	insertNote(t, gen, "tu_3", []string{"gamma"}, now.Add(-300*time.Minute))
+
+	rec := doPost(newHandler().Trend, `{}`)
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	var resp []map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+
+	// alpha (total 2 users) → beta (total 1) の順にランクされる。gamma は除外。
+	require.Len(t, resp, 2, "alpha + beta only")
+	assert.Equal(t, "alpha", resp[0]["tag"])
+	assert.Equal(t, "beta", resp[1]["tag"])
+
+	// chart 配列は 20 buckets 固定
+	chart := resp[0]["chart"].([]any)
+	require.Len(t, chart, 20, "chart bucket count = 20")
+
+	// alpha: bucket 0 (直近 10 分) と bucket 1 (10-20 分) に各 1 user
+	assert.EqualValues(t, 1, chart[0], "alpha bucket 0 has tu_1")
+	assert.EqualValues(t, 1, chart[1], "alpha bucket 1 has tu_2")
+	for i := 2; i < 20; i++ {
+		assert.EqualValues(t, 0, chart[i], "alpha bucket %d empty", i)
+	}
+
+	// usersCount は max(chart) で alpha は 1 (各 bucket の users が 1)
+	assert.EqualValues(t, 1, resp[0]["usersCount"])
 }
 
 func TestTrend_DBError(t *testing.T) {

--- a/internal/core/note/note_create_service.go
+++ b/internal/core/note/note_create_service.go
@@ -9,8 +9,10 @@ import (
 	"sync"
 	"time"
 
+	"github.com/lib/pq"
 	"github.com/shiroha-a/mk/internal/activitypub/mfm"
 	"github.com/shiroha-a/mk/internal/entity"
+	"github.com/shiroha-a/mk/internal/misc/hashtag"
 	"github.com/shiroha-a/mk/internal/misc/id"
 	"github.com/shiroha-a/mk/internal/model"
 	"github.com/shiroha-a/mk/internal/repository"
@@ -410,6 +412,18 @@ func (s *CreateService) Create(in CreateInput) (*model.Note, error) {
 	now := time.Now()
 	noteID := s.idGen.Generate(now)
 
+	// hashtag 抽出: text/cw から #tag を拾い note.tags 列に格納する。
+	// hashtags/trend の動的集計や hashtag 検索が機能するためには
+	// note.tags が常に正しく埋められている必要がある (#655)。
+	var hashtagParts []string
+	if in.Text != nil {
+		hashtagParts = append(hashtagParts, *in.Text)
+	}
+	if in.CW != nil {
+		hashtagParts = append(hashtagParts, *in.CW)
+	}
+	tags := hashtag.Extract(hashtagParts...)
+
 	note := &model.Note{
 		ID:                 noteID,
 		UserID:             in.User.ID,
@@ -423,6 +437,7 @@ func (s *CreateService) Create(in CreateInput) (*model.Note, error) {
 		ChannelID:          in.ChannelID,
 		FileIDs:            in.FileIDs,
 		UserHost:           in.User.Host,
+		Tags:               pq.StringArray(tags),
 	}
 
 	// reply/renote先の非正規化フィールドを埋める

--- a/internal/misc/hashtag/extract.go
+++ b/internal/misc/hashtag/extract.go
@@ -28,6 +28,22 @@ const MaxTagLength = 128
 // FindAllStringSubmatch でキャプチャ #1 が tag 本体になる。
 var hashtagRe = regexp.MustCompile(`(?:^|[\s>"'` + "`" + `(\[{])#([\p{L}\p{N}_-]+)`)
 
+// codeBlockRe / urlRe は MFM パーサ未導入の代替として、hashtag 抽出
+// 前に「ハッシュタグとして拾うべきでない領域」を空白に置換するための
+// 正規表現。
+//
+//   - codeBlockRe: \`\`\`fence\`\`\` / inline \`code\`。インライン版は同行
+//     内のみで閉じる (改行をまたぐ \`...\` は意図しない大量マッチを生む)。
+//   - urlRe: http(s) URL の末尾に付く #fragment が hashtag 扱いされて
+//     しまう問題への対処 (e.g. https://example.com/path#anchor)。
+//
+// 真の MFM パーサ統合 (#上流 mfm-js 相当) は別 issue 扱いで、本
+// 実装は最も多い誤検知 2 種を遮断するライトウェイト版。
+var (
+	codeBlockRe = regexp.MustCompile("```[\\s\\S]*?```|`[^`\n]*`")
+	urlRe       = regexp.MustCompile(`https?://[^\s]+`)
+)
+
 // Extract pulls hashtag names out of text fragments (typically the note's
 // body and CW). Order is preserved by first occurrence; case-insensitive
 // duplicates collapse to a single entry. The original case is preserved
@@ -42,7 +58,12 @@ func Extract(parts ...string) []string {
 		if text == "" {
 			continue
 		}
-		matches := hashtagRe.FindAllStringSubmatch(text, -1)
+		// code block / URL の中に現れる # は hashtag として扱わない。
+		// 元 text の長さを保つために空白置換する (位置情報は使わないが、
+		// 隣接トークンの境界が壊れないようにする保険)。
+		cleaned := codeBlockRe.ReplaceAllString(text, " ")
+		cleaned = urlRe.ReplaceAllString(cleaned, " ")
+		matches := hashtagRe.FindAllStringSubmatch(cleaned, -1)
 		for _, m := range matches {
 			tag := m[1]
 			if len(tag) > MaxTagLength {

--- a/internal/misc/hashtag/extract.go
+++ b/internal/misc/hashtag/extract.go
@@ -1,0 +1,63 @@
+// Package hashtag provides hashtag extraction from note text.
+//
+// Misskey TS (mfm-js) は MFM パーサで text を構造化してから hashtag
+// ノードを取り出すが、mk-go では現状軽量な正規表現ベースの抽出に
+// 留めている。連合経由で受け取る ActivityPub Object には別途 tag 配列
+// が付くので、本パッケージは local note 作成時の text/cw 由来 hashtag
+// だけを担当する。
+package hashtag
+
+import (
+	"regexp"
+	"strings"
+)
+
+// MaxTagLength は note.tags 列の varchar(128) 制約に合わせた tag 長
+// 上限。これを超える tag は truncate される (drop ではなく trim にする
+// のは Misskey TS の挙動互換)。
+const MaxTagLength = 128
+
+// hashtagRe は #tag を抽出する正規表現。
+//
+//   - 直前は行頭 / 空白 / 一部の記号 (引用符・閉じ括弧・改行) の
+//     「単語境界」とみなせる文字。`#one#two` のような連続は upstream
+//     Misskey でも `#one` のみが拾われるため境界に `#` は含めない。
+//   - tag 本体は Unicode の Letter / Number / アンダースコア / ハイフン。
+//     MFM の hashtag 文字種より狭めだが、よく使われる範囲はカバーする。
+//
+// FindAllStringSubmatch でキャプチャ #1 が tag 本体になる。
+var hashtagRe = regexp.MustCompile(`(?:^|[\s>"'` + "`" + `(\[{])#([\p{L}\p{N}_-]+)`)
+
+// Extract pulls hashtag names out of text fragments (typically the note's
+// body and CW). Order is preserved by first occurrence; case-insensitive
+// duplicates collapse to a single entry. The original case is preserved
+// for the kept tag (Misskey TS も同じ挙動)。
+//
+// Empty / whitespace-only inputs return nil. Tags longer than
+// MaxTagLength are truncated.
+func Extract(parts ...string) []string {
+	seen := make(map[string]struct{})
+	out := make([]string, 0)
+	for _, text := range parts {
+		if text == "" {
+			continue
+		}
+		matches := hashtagRe.FindAllStringSubmatch(text, -1)
+		for _, m := range matches {
+			tag := m[1]
+			if len(tag) > MaxTagLength {
+				tag = tag[:MaxTagLength]
+			}
+			key := strings.ToLower(tag)
+			if _, ok := seen[key]; ok {
+				continue
+			}
+			seen[key] = struct{}{}
+			out = append(out, tag)
+		}
+	}
+	if len(out) == 0 {
+		return nil
+	}
+	return out
+}

--- a/internal/misc/hashtag/extract_test.go
+++ b/internal/misc/hashtag/extract_test.go
@@ -88,6 +88,21 @@ func TestExtract(t *testing.T) {
 			in:   []string{"#" + strings.Repeat("a", MaxTagLength+50)},
 			want: []string{strings.Repeat("a", MaxTagLength)},
 		},
+		{
+			name: "fenced code block excluded",
+			in:   []string{"normal #yes\n```\n#secret\n```\nback #also"},
+			want: []string{"yes", "also"},
+		},
+		{
+			name: "inline code excluded",
+			in:   []string{"check `#var` here #real"},
+			want: []string{"real"},
+		},
+		{
+			name: "url fragment not picked up",
+			in:   []string{"see https://example.com/path#anchor for #real"},
+			want: []string{"real"},
+		},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {

--- a/internal/misc/hashtag/extract_test.go
+++ b/internal/misc/hashtag/extract_test.go
@@ -1,0 +1,98 @@
+package hashtag
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestExtract(t *testing.T) {
+	cases := []struct {
+		name string
+		in   []string
+		want []string
+	}{
+		{
+			name: "empty input",
+			in:   []string{""},
+			want: nil,
+		},
+		{
+			name: "no hashtags",
+			in:   []string{"hello world"},
+			want: nil,
+		},
+		{
+			name: "single tag",
+			in:   []string{"hello #golang"},
+			want: []string{"golang"},
+		},
+		{
+			name: "tag at start",
+			in:   []string{"#golang is fast"},
+			want: []string{"golang"},
+		},
+		{
+			name: "multiple tags",
+			in:   []string{"learn #go and #rust today"},
+			want: []string{"go", "rust"},
+		},
+		{
+			name: "duplicate tags collapse",
+			in:   []string{"#go again #go and #GO"},
+			want: []string{"go"},
+		},
+		{
+			name: "japanese tag",
+			in:   []string{"おはよう #朝 みなさん"},
+			want: []string{"朝"},
+		},
+		{
+			name: "underscore and hyphen",
+			in:   []string{"#hello_world #foo-bar"},
+			want: []string{"hello_world", "foo-bar"},
+		},
+		{
+			name: "no space before #",
+			in:   []string{"foo#bar"},
+			want: nil, // word boundary 必須
+		},
+		{
+			name: "consecutive hashtags pick first only",
+			in:   []string{"#one#two"},
+			want: []string{"one"}, // upstream Misskey と同じく #two は拾わない
+		},
+		{
+			name: "after quote",
+			in:   []string{`"#quoted"`},
+			want: []string{"quoted"},
+		},
+		{
+			name: "hashtag-only line",
+			in:   []string{"#alpha\n#beta"},
+			want: []string{"alpha", "beta"},
+		},
+		{
+			name: "case preserved on first occurrence",
+			in:   []string{"#Golang and #golang"},
+			want: []string{"Golang"},
+		},
+		{
+			name: "text + cw",
+			in:   []string{"hello #foo", "warning #bar"},
+			want: []string{"foo", "bar"},
+		},
+		{
+			name: "long tag truncated",
+			in:   []string{"#" + strings.Repeat("a", MaxTagLength+50)},
+			want: []string{strings.Repeat("a", MaxTagLength)},
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := Extract(tc.in...)
+			assert.Equal(t, tc.want, got)
+		})
+	}
+}

--- a/internal/misc/id/id.go
+++ b/internal/misc/id/id.go
@@ -16,6 +16,27 @@ import (
 // time2000 is the epoch used by AID/AIDX (2000-01-01T00:00:00Z in milliseconds).
 const time2000 int64 = 946684800000
 
+// AidxCutoffPrefix builds the smallest aidx-style ID at the given time
+// for use as a `WHERE id > ?` cutoff in note range scans (mk-go の note
+// は created_at 列を持たず aidx ID 先頭 8 文字に ms timestamp を埋め込
+// んでいる)。後続 8 文字 (nodeID + counter) は最小値 "00000000" で揃え、
+// その時刻における最小 ID を作る。
+//
+// 呼び出し側は \`db.Where("id > ?", id.AidxCutoffPrefix(t))\` のように
+// 使い、aidx 規約と齟齬が出ないよう time2000 / base36 padding は本
+// パッケージの実装と必ず一致させる。
+func AidxCutoffPrefix(t time.Time) string {
+	ms := t.UnixMilli() - time2000
+	if ms < 0 {
+		ms = 0
+	}
+	timePart := fmt.Sprintf("%08s", strconv.FormatInt(ms, 36))
+	if len(timePart) > 8 {
+		timePart = timePart[len(timePart)-8:]
+	}
+	return timePart + "00000000"
+}
+
 // Generator defines the interface for ID generation.
 type Generator interface {
 	// Generate creates a new ID for the given timestamp.

--- a/internal/server/router.go
+++ b/internal/server/router.go
@@ -1244,6 +1244,10 @@ func (s *Server) setupRoutes() {
 	api.POST("/hashtags/search", hashtagsHandler.Search)
 	api.POST("/hashtags/show", hashtagsHandler.Show)
 	api.POST("/hashtags/trend", hashtagsHandler.Trend)
+	// upstream Misskey の hashtags/trend は allowGet: true なので
+	// frontend (misskeyApiGet) は GET で叩く。WidgetTrends がここを毎分
+	// 呼ぶため GET でも応答できるよう同じ handler を 2 重 wire する。
+	api.GET("/hashtags/trend", hashtagsHandler.Trend)
 	api.POST("/hashtags/users", hashtagsHandler.Users)
 
 	// Gallery endpoints (Phase 6)

--- a/migration/000043_note_tags_gin_index.down.sql
+++ b/migration/000043_note_tags_gin_index.down.sql
@@ -1,0 +1,1 @@
+DROP INDEX IF EXISTS "IDX_note_tags";

--- a/migration/000043_note_tags_gin_index.up.sql
+++ b/migration/000043_note_tags_gin_index.up.sql
@@ -1,0 +1,4 @@
+-- #655: hashtags/trend は note.tags 配列を unnest して直近 200 分の
+-- 投稿を集計する。tags && ARRAY[...] / unnest("tags") の両方を高速化
+-- するため GIN インデックスを追加する。
+CREATE INDEX IF NOT EXISTS "IDX_note_tags" ON "note" USING gin ("tags");


### PR DESCRIPTION
## Summary

WidgetTrends で各ハッシュタグのスパークライン (MkMiniChart) が描画されない問題。\`/api/hashtags/trend\` のレスポンスの \`chart\` フィールドが常に空配列 \`[]\` 固定だったため。直近 200 分 (10 分 × 20 bucket) の note 集計を実装し、TS 上流互換の chart を返すようにした。

Closes #655

## 修正内容

### Trend handler を SQL + Go 集計で実装

| 層 | 内容 |
|---|---|
| SQL | 200 分前の cutoff prefix で範囲フィルタ → tag 配列を含む note を全取得 |
| Go | aidx ID から timestamp 復元 → 10 分 bucket 計算 → tag/bucket 別の unique users 集計 |
| Response | \`{tag, chart: int[20], usersCount: max(chart)}\` |

Misskey TS 上流 (\`HashtagService.getCharts\`) は Redis HyperLogLog で users をユニーク count するが、mk-go では HLL を維持せず note テーブルから動的に集計する設計を採用。低〜中規模インスタンスなら直近 200 分の対象 note は数千件オーダーで Go 側の集計コストは無視できる。

### note.createdAt 不在問題を aidx ID 経由で回避

mk-go の note テーブルには **created_at 列が存在しない**。aidx ID 先頭 8 文字に ms timestamp が埋め込まれている設計のため、\`aidxCutoffPrefix\` ヘルパーで 200 分前の最小 ID を生成し \`WHERE id > ?\` で範囲フィルタを効かせる。

### Migration 000043: note.tags に GIN index

\`tags <> ARRAY[]::varchar[]\` フィルタを index 経由にする。\`internal/queue/processors\` 等で tags を参照する処理にも波及効果あり。

## レスポンス schema (TS 互換)

\`\`\`json
[
  {
    "tag": "golang",
    "chart": [3, 2, 1, 0, 0, ...],  // 20 buckets, 新しい順
    "usersCount": 3                  // max(chart)
  },
  ...
]
\`\`\`

ranking は total unique users 降順 + tag name 昇順 (deterministic) で top 10 まで。

## テスト

- \`TestTrend_EmptyReturnsEmptyArray\`: note なし → 空配列
- \`TestTrend_AggregatesRecentNotes\`: 異なるタグ・bucket・user の note を投入し、ranking と chart の値を検証。200 分超の note は cutoff で除外されることも guard

\`\`\`bash
make fmt && make lint
go test ./internal/api/hashtags/... -count=1
\`\`\`

## UDS 動作確認

UDS で hashtag 付き投稿を数件投げて Widget Trends で chart が描画されることを確認したいです (post-merge or pre-merge どちらでも)。

## non-goals

- HyperLogLog ベース実装 (TS 上流互換、超大規模で必要になったら別 issue)
- ranking の time-decay 重み付け (TS の \`featuredHashtagsRanking\` は rolling window だが、本 PR では total user count 順)

🤖 Generated with [Claude Code](https://claude.com/claude-code)