### PR TITLE
Fix modlog: response に createdAt を含めて時刻表示を復旧

### DIFF
--- a/internal/api/admin/aidx_helpers.go
+++ b/internal/api/admin/aidx_helpers.go
@@ -1,0 +1,31 @@
+package admin
+
+import (
+	"errors"
+
+	"github.com/shiroha-a/mk/internal/misc/id"
+)
+
+// ErrIDGenMissing is returned when aidxCreatedAtString is called with a nil
+// generator. Distinguishing this from a parse error lets callers decide
+// whether to log (parse failure on a non-aidx ID is debug-worthy, missing
+// generator usually means the handler was wired without an idGen and the
+// log noise would be redundant).
+var ErrIDGenMissing = errors.New("admin: idGen not configured")
+
+// aidxCreatedAtString derives a Misskey-format ISO timestamp string from an
+// aidx ID. mk-go の幾つかの table (user, registration_ticket, moderation_log
+// 等) は created_at カラムを持たず aidx ID 先頭 8 文字に ms timestamp を
+// 埋め込んでいる。frontend の `<MkTime :time="..."/>` は Date.parse できる
+// ISO 文字列を要求するため "2006-01-02T15:04:05.000Z" 形式 (Misskey 標準)
+// に揃えて返す。
+func aidxCreatedAtString(idGen id.Generator, aidx string) (string, error) {
+	if idGen == nil {
+		return "", ErrIDGenMissing
+	}
+	t, err := idGen.ParseTime(aidx)
+	if err != nil {
+		return "", err
+	}
+	return t.UTC().Format("2006-01-02T15:04:05.000Z"), nil
+}

--- a/internal/api/admin/aidx_helpers_test.go
+++ b/internal/api/admin/aidx_helpers_test.go
@@ -1,0 +1,42 @@
+package admin
+
+import (
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/shiroha-a/mk/internal/misc/id"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestAidxCreatedAtString_NilGenerator(t *testing.T) {
+	s, err := aidxCreatedAtString(nil, "anything")
+	assert.Equal(t, "", s)
+	assert.True(t, errors.Is(err, ErrIDGenMissing))
+}
+
+func TestAidxCreatedAtString_ValidAidx(t *testing.T) {
+	gen, err := id.NewGenerator("aidx")
+	require.NoError(t, err)
+
+	fixed := time.Date(2026, 5, 1, 12, 0, 0, 0, time.UTC)
+	aidx := gen.Generate(fixed)
+
+	s, err := aidxCreatedAtString(gen, aidx)
+	require.NoError(t, err)
+	parsed, err := time.Parse("2006-01-02T15:04:05.000Z", s)
+	require.NoError(t, err)
+	assert.WithinDuration(t, fixed, parsed, time.Millisecond)
+}
+
+func TestAidxCreatedAtString_InvalidID(t *testing.T) {
+	gen, err := id.NewGenerator("aidx")
+	require.NoError(t, err)
+
+	// base36 として読めない記号を含む ID は ParseTime が err を返す
+	s, err := aidxCreatedAtString(gen, "!!!notaidx")
+	assert.Equal(t, "", s)
+	assert.Error(t, err)
+	assert.False(t, errors.Is(err, ErrIDGenMissing), "non-aidx parse failure must not be reported as ErrIDGenMissing")
+}

--- a/internal/api/admin/handler.go
+++ b/internal/api/admin/handler.go
@@ -1636,6 +1636,12 @@ func (h *Handler) ResolveAbuseReport(c echo.Context) error {
 }
 
 // ShowModerationLogs handles POST /api/admin/show-moderation-logs.
+//
+// model.ModerationLog は createdAt 列を持たず aidx ID 先頭 8 文字に
+// timestamp を埋め込んでいる。frontend (modlog.ModLog.vue) は
+// `<MkTime :time="log.createdAt"/>` を直接読むため、handler 側で aidx
+// から派生した createdAt 文字列を response に注入する。invite/users 系
+// と同じく "2006-01-02T15:04:05.000Z" 形式 (Misskey の標準)。
 func (h *Handler) ShowModerationLogs(c echo.Context) error {
 	var req struct {
 		Limit  int `json:"limit"`
@@ -1648,5 +1654,23 @@ func (h *Handler) ShowModerationLogs(c echo.Context) error {
 	if err != nil {
 		return c.JSON(http.StatusInternalServerError, apierr.Error("INTERNAL_ERROR", "Internal error.", "5d37dbcb-891e-41ca-a3d6-e690c97775ac"))
 	}
-	return c.JSON(http.StatusOK, logs)
+	out := make([]map[string]any, 0, len(logs))
+	for _, l := range logs {
+		m := map[string]any{
+			"id":     l.ID,
+			"userId": l.UserID,
+			"type":   l.Type,
+			"info":   l.Info,
+		}
+		if h.idGen != nil {
+			if ts, err := h.idGen.ParseTime(l.ID); err == nil {
+				m["createdAt"] = ts.UTC().Format("2006-01-02T15:04:05.000Z")
+			}
+		}
+		if l.User != nil {
+			m["user"] = l.User
+		}
+		out = append(out, m)
+	}
+	return c.JSON(http.StatusOK, out)
 }

--- a/internal/api/admin/handler.go
+++ b/internal/api/admin/handler.go
@@ -2,6 +2,7 @@ package admin
 
 import (
 	"context"
+	"errors"
 	"log/slog"
 	"net/http"
 	"strings"
@@ -515,8 +516,8 @@ func (h *Handler) AccountsCreate(c echo.Context) error {
 	}
 
 	// createdAt は ID から復元
-	if t, err := h.idGen.ParseTime(u.ID); err == nil {
-		out["createdAt"] = t.UTC().Format("2006-01-02T15:04:05.000Z")
+	if s, err := aidxCreatedAtString(h.idGen, u.ID); err == nil {
+		out["createdAt"] = s
 	}
 
 	return c.JSON(http.StatusOK, out)
@@ -1662,10 +1663,14 @@ func (h *Handler) ShowModerationLogs(c echo.Context) error {
 			"type":   l.Type,
 			"info":   l.Info,
 		}
-		if h.idGen != nil {
-			if ts, err := h.idGen.ParseTime(l.ID); err == nil {
-				m["createdAt"] = ts.UTC().Format("2006-01-02T15:04:05.000Z")
-			}
+		if s, err := aidxCreatedAtString(h.idGen, l.ID); err == nil {
+			m["createdAt"] = s
+		} else if !errors.Is(err, ErrIDGenMissing) {
+			// idGen は wired されているのに parse 失敗した場合のみログに残す。
+			// 非 aidx 形式の legacy ID 等で createdAt が出せない時に frontend
+			// 側で「Invalid Date」が出る原因を後追いできるようにする。
+			slog.DebugContext(c.Request().Context(), "modlog: createdAt derive failed",
+				"logId", l.ID, "err", err)
 		}
 		if l.User != nil {
 			m["user"] = l.User

--- a/internal/api/admin/handler_test.go
+++ b/internal/api/admin/handler_test.go
@@ -1439,6 +1439,63 @@ func TestShowModerationLogs_IncludesCreatedAt(t *testing.T) {
 	assert.WithinDuration(t, fixedTime, parsed, time.Millisecond)
 }
 
+// TestShowModerationLogs_NonAidxIDOmitsCreatedAt は aidx として parse でき
+// ない legacy ID が紛れ込んだ場合に handler が createdAt を埋めずに response
+// から省略する (= frontend 側で「Invalid Date」を表示しない) ことを guard
+// する。
+func TestShowModerationLogs_NonAidxIDOmitsCreatedAt(t *testing.T) {
+	h, _, _, _ := newTestHandler(t)
+	modLogRepo := testutil.NewMockModerationLogRepository()
+	gen, err := id.NewGenerator("aidx")
+	require.NoError(t, err)
+
+	// aidx の base36 で扱えない文字 ("!") を混ぜて parse 失敗を強制する
+	require.NoError(t, modLogRepo.Create(&model.ModerationLog{ID: "!!!notaidx", UserID: "u1", Type: "suspend"}))
+	h.SetModLogService(moderationlog.New(modLogRepo, gen))
+
+	rec := doPost(h.ShowModerationLogs, `{}`, nil)
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	var resp []map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+	require.Len(t, resp, 1)
+	_, has := resp[0]["createdAt"]
+	assert.False(t, has, "createdAt must be omitted when ID cannot be parsed as aidx")
+}
+
+// TestShowModerationLogs_PreservesInfoJSON は datatypes.JSON で persist された
+// info が map[string]any 経由 marshal を通っても (key 順以外) 中身を保つこと
+// を guard する。frontend modlog detail dialog は info の structure を直接
+// 触るため、handler 側で誤って string 化したり再 escape するような変換を
+// 入れないようにする。
+func TestShowModerationLogs_PreservesInfoJSON(t *testing.T) {
+	h, _, _, _ := newTestHandler(t)
+	modLogRepo := testutil.NewMockModerationLogRepository()
+	gen, err := id.NewGenerator("aidx")
+	require.NoError(t, err)
+
+	infoJSON := []byte(`{"userId":"target1","userUsername":"alice","reason":"spam"}`)
+	require.NoError(t, modLogRepo.Create(&model.ModerationLog{
+		ID:     gen.Generate(time.Now()),
+		UserID: "admin1",
+		Type:   "suspend",
+		Info:   infoJSON,
+	}))
+	h.SetModLogService(moderationlog.New(modLogRepo, gen))
+
+	rec := doPost(h.ShowModerationLogs, `{}`, nil)
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	var resp []map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+	require.Len(t, resp, 1)
+	info, ok := resp[0]["info"].(map[string]any)
+	require.True(t, ok, "info must be a JSON object after round-trip")
+	assert.Equal(t, "target1", info["userId"])
+	assert.Equal(t, "alice", info["userUsername"])
+	assert.Equal(t, "spam", info["reason"])
+}
+
 // --- moderation log assertions for user moderation handlers ---
 
 func TestSuspendUser_WritesModerationLog(t *testing.T) {

--- a/internal/api/admin/handler_test.go
+++ b/internal/api/admin/handler_test.go
@@ -1407,6 +1407,38 @@ func TestShowModerationLogs_InvalidJSON(t *testing.T) {
 	assert.Equal(t, http.StatusBadRequest, rec.Code)
 }
 
+// TestShowModerationLogs_IncludesCreatedAt は frontend modlog.ModLog.vue
+// が `log.createdAt` を直接読んで MkTime に渡すため、handler が aidx ID
+// から派生した createdAt 文字列を必ず response に含めることを guard する。
+func TestShowModerationLogs_IncludesCreatedAt(t *testing.T) {
+	h, _, _, _ := newTestHandler(t)
+	modLogRepo := testutil.NewMockModerationLogRepository()
+	gen, err := id.NewGenerator("aidx")
+	require.NoError(t, err)
+
+	// 既知の固定時刻で aidx ID を生成 → response の createdAt と照合
+	fixedTime := time.Date(2026, 5, 1, 12, 0, 0, 0, time.UTC)
+	aidxID := gen.Generate(fixedTime)
+	require.NoError(t, modLogRepo.Create(&model.ModerationLog{ID: aidxID, UserID: "u1", Type: "suspend"}))
+	h.SetModLogService(moderationlog.New(modLogRepo, gen))
+
+	rec := doPost(h.ShowModerationLogs, `{}`, nil)
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	var resp []map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+	require.Len(t, resp, 1)
+
+	createdAt, ok := resp[0]["createdAt"].(string)
+	require.True(t, ok, "createdAt must be present and be a string")
+
+	// Misskey の標準 format で parse 可能であること
+	parsed, err := time.Parse("2006-01-02T15:04:05.000Z", createdAt)
+	require.NoError(t, err, "createdAt must be parseable as Misskey-format ISO string")
+	// aidx の解像度は ms なので fixedTime と完全一致するはず
+	assert.WithinDuration(t, fixedTime, parsed, time.Millisecond)
+}
+
 // --- moderation log assertions for user moderation handlers ---
 
 func TestSuspendUser_WritesModerationLog(t *testing.T) {

--- a/internal/api/admin/invite.go
+++ b/internal/api/admin/invite.go
@@ -75,11 +75,8 @@ func (h *Handler) packInviteTickets(rows []*model.RegistrationTicket) []map[stri
 	out := make([]map[string]any, 0, len(rows))
 	for _, t := range rows {
 		var createdAt *string
-		if h.idGen != nil {
-			if ts, err := h.idGen.ParseTime(t.ID); err == nil {
-				s := ts.UTC().Format("2006-01-02T15:04:05.000Z")
-				createdAt = &s
-			}
+		if s, err := aidxCreatedAtString(h.idGen, t.ID); err == nil {
+			createdAt = &s
 		}
 		var expiresAt *string
 		if t.ExpiresAt != nil {


### PR DESCRIPTION
## Summary

モデログ画面で「日時の解析に失敗」と表示されるバグの修正。

## 原因

\`model.ModerationLog\` は \`createdAt\` 列を持たず、**aidx ID 先頭 8 文字に ms timestamp が埋め込まれている** 設計だが、handler が response で派生せず raw struct を直接 marshal していたため \`createdAt\` field がそもそも存在しなかった。frontend \`modlog.ModLog.vue:131,137\` は \`<MkTime :time="log.createdAt"/>\` を直接読むため undefined → parse 失敗として表示されていた。

## 修正

\`ShowModerationLogs\` handler で aidx ID から派生した \`createdAt\` を Misskey 標準 format (\`2006-01-02T15:04:05.000Z\`) で response に注入。同パターンが既に \`invite.go:79-80\` / \`handler.go:518-519\` (packAdminUser) で採用されているのでそれに合わせた。

\`\`\`go
if h.idGen != nil {
    if ts, err := h.idGen.ParseTime(l.ID); err == nil {
        m["createdAt"] = ts.UTC().Format("2006-01-02T15:04:05.000Z")
    }
}
\`\`\`

## テスト

\`TestShowModerationLogs_IncludesCreatedAt\` を追加。固定時刻の aidx ID から生成した row に対して response の \`createdAt\` が:

- string として存在
- \`2006-01-02T15:04:05.000Z\` 形式で parse 可能
- 元の固定時刻と ms 精度で一致

を guard。

## UDS 動作確認 ✅

UDS で rebuild + reload して、モデログ画面の時刻表示が復旧することを確認済み。

🤖 Generated with [Claude Code](https://claude.com/claude-code)