### PR TITLE
Fix #649: reversi packGame に winner UserLite を追加

### DIFF
--- a/internal/api/reversi/handler.go
+++ b/internal/api/reversi/handler.go
@@ -143,6 +143,17 @@ func packGame(g *model.ReversiGame, idGen id.Generator) map[string]any {
 	if g.User2 != nil {
 		result["user2"] = entity.PackUserLite(g.User2)
 	}
+	// winner は upstream Misskey TS の ReversiGameEntityService.packDetail と
+	// 同じく winnerId から UserLite を派生させる (#649)。frontend は
+	// `v-if="game.winner"` で勝敗表示を切り替えるため、winnerId だけでは
+	// draw に倒れる。
+	if g.WinnerID != nil {
+		if g.User1 != nil && g.User1.ID == *g.WinnerID {
+			result["winner"] = entity.PackUserLite(g.User1)
+		} else if g.User2 != nil && g.User2.ID == *g.WinnerID {
+			result["winner"] = entity.PackUserLite(g.User2)
+		}
+	}
 	return result
 }
 

--- a/internal/api/reversi/handler_test.go
+++ b/internal/api/reversi/handler_test.go
@@ -8,10 +8,12 @@ import (
 	"strconv"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/labstack/echo/v4"
 	"github.com/lib/pq"
 	corereversi "github.com/shiroha-a/mk/internal/core/reversi"
+	"github.com/shiroha-a/mk/internal/entity"
 	"github.com/shiroha-a/mk/internal/misc/id"
 	"github.com/shiroha-a/mk/internal/model"
 	"github.com/shiroha-a/mk/internal/server/middleware"
@@ -718,3 +720,54 @@ func TestMatch_EmptyUserIDIsRandomMatch(t *testing.T) {
 	assert.Len(t, repo.games, 1)
 	assert.Equal(t, 0, d.calls)
 }
+
+// TestPackGame_WinnerField guards that REST packGame derives a `winner`
+// UserLite from winnerId. The frontend (game.board.vue) drives its
+// `won/draw` display via `v-if="game.winner"` — without this field the
+// game result is rendered as a draw on every viewer (#649).
+func TestPackGame_WinnerField(t *testing.T) {
+	idGen, _ := id.NewGenerator("aidx")
+	gid := idGen.Generate(timeRef())
+	user1 := &model.User{ID: "alice", Username: "alice"}
+	user2 := &model.User{ID: "bob", Username: "bob"}
+
+	t.Run("user1 wins", func(t *testing.T) {
+		winnerID := "alice"
+		g := &model.ReversiGame{
+			ID: gid, User1ID: "alice", User2ID: "bob",
+			User1: user1, User2: user2, WinnerID: &winnerID,
+		}
+		out := packGame(g, idGen)
+		w, ok := out["winner"].(entity.UserLite)
+		require.True(t, ok, "winner must be present and be a UserLite")
+		assert.Equal(t, "alice", w.ID)
+		assert.Equal(t, &winnerID, out["winnerId"])
+	})
+
+	t.Run("user2 wins", func(t *testing.T) {
+		winnerID := "bob"
+		g := &model.ReversiGame{
+			ID: gid, User1ID: "alice", User2ID: "bob",
+			User1: user1, User2: user2, WinnerID: &winnerID,
+		}
+		out := packGame(g, idGen)
+		w, ok := out["winner"].(entity.UserLite)
+		require.True(t, ok)
+		assert.Equal(t, "bob", w.ID)
+	})
+
+	t.Run("draw (winnerId nil)", func(t *testing.T) {
+		g := &model.ReversiGame{
+			ID: gid, User1ID: "alice", User2ID: "bob",
+			User1: user1, User2: user2,
+		}
+		out := packGame(g, idGen)
+		_, has := out["winner"]
+		assert.False(t, has, "winner must be omitted when WinnerID is nil")
+	})
+}
+
+// timeRef returns a fixed deterministic time for aidx Generate calls in
+// pack tests — keeps id generation reproducible even though the actual
+// timestamp value is irrelevant.
+func timeRef() time.Time { return time.Unix(1_700_000_000, 0).UTC() }

--- a/internal/core/reversi/service.go
+++ b/internal/core/reversi/service.go
@@ -959,6 +959,17 @@ func packGame(game *model.ReversiGame) map[string]any {
 	if game.User2 != nil {
 		out["user2"] = userLiteMap(game.User2)
 	}
+	// winner は upstream Misskey TS の ReversiGameEntityService.packDetail と
+	// 同じく winnerId から派生させて UserLite として埋める。frontend
+	// (game.board.vue) は `v-if="game.winner"` で勝敗表示を切り替えるため、
+	// winnerId だけでは draw に倒れて #649 の症状になる。
+	if game.WinnerID != nil {
+		if game.User1 != nil && game.User1.ID == *game.WinnerID {
+			out["winner"] = userLiteMap(game.User1)
+		} else if game.User2 != nil && game.User2.ID == *game.WinnerID {
+			out["winner"] = userLiteMap(game.User2)
+		}
+	}
 	return out
 }
 

--- a/internal/core/reversi/service_wire_test.go
+++ b/internal/core/reversi/service_wire_test.go
@@ -485,6 +485,63 @@ func TestPackGame_EmbedsUserLiteMaps(t *testing.T) {
 	assert.Equal(t, "bob", u2["id"])
 }
 
+// TestPackGame_WinnerField は winnerId から winner UserLite が派生することを
+// guard する。frontend (game.board.vue) の `v-if="game.winner"` 判定が
+// winner 欠落で常に draw 表示になる #649 の regression 検知用。
+func TestPackGame_WinnerField(t *testing.T) {
+	user1 := &model.User{ID: "alice", Username: "alice"}
+	user2 := &model.User{ID: "bob", Username: "bob"}
+	winnerID := "alice"
+
+	t.Run("user1 wins", func(t *testing.T) {
+		g := &model.ReversiGame{
+			ID: "g1", User1ID: "alice", User2ID: "bob",
+			User1: user1, User2: user2,
+			WinnerID: &winnerID,
+		}
+		out := packGame(g)
+		w, ok := out["winner"].(map[string]any)
+		require.True(t, ok, "winner must be present")
+		assert.Equal(t, "alice", w["id"])
+	})
+
+	t.Run("user2 wins", func(t *testing.T) {
+		bobID := "bob"
+		g := &model.ReversiGame{
+			ID: "g1", User1ID: "alice", User2ID: "bob",
+			User1: user1, User2: user2,
+			WinnerID: &bobID,
+		}
+		out := packGame(g)
+		w, ok := out["winner"].(map[string]any)
+		require.True(t, ok)
+		assert.Equal(t, "bob", w["id"])
+	})
+
+	t.Run("draw (winnerId nil)", func(t *testing.T) {
+		g := &model.ReversiGame{
+			ID: "g1", User1ID: "alice", User2ID: "bob",
+			User1: user1, User2: user2,
+		}
+		out := packGame(g)
+		_, has := out["winner"]
+		assert.False(t, has, "winner must be omitted when WinnerID is nil")
+	})
+
+	t.Run("user objects not preloaded", func(t *testing.T) {
+		// User1/User2 が preload されていない場合でも winnerId は出る
+		// (UserLite は出せないので winner だけ省略する fallback 挙動)
+		g := &model.ReversiGame{
+			ID: "g1", User1ID: "alice", User2ID: "bob",
+			WinnerID: &winnerID,
+		}
+		out := packGame(g)
+		_, has := out["winner"]
+		assert.False(t, has)
+		assert.Equal(t, &winnerID, out["winnerId"])
+	})
+}
+
 // sessionID が与えられれば random でも両サイドで一致する決定論的な値を返す。
 func TestPickBlack_FederatedDeterministic(t *testing.T) {
 	// 同じ session で複数回呼んでも同じ値


### PR DESCRIPTION
## Summary

UDS 環境 (mk-go バックエンド + Misskey TS フロント) でリバーシ対局後、勝者・観戦者視点で対局結果が「引き分け」と表示されてしまう問題 (#649) の修正。敗者視点だけ正常に表示されるのは、敗者の最終手で local engine が即終局判定を出して \`checkEnd()\` が走るタイミング差によるもので、**WS \`ended\` イベントの \`game\` payload に \`winner\` (UserLite) が欠落しているのが根本原因**。

upstream Misskey TS の [\`ReversiGameEntityService.packDetail\`](https://github.com/misskey-dev/misskey/blob/develop/packages/backend/src/core/entities/ReversiGameEntityService.ts#L60-L61) は \`winnerId\` から \`[user1, user2].find(u => u.id === winnerId)\` で UserLite を派生させており、frontend [\`game.board.vue:28\`](https://github.com/misskey-dev/misskey/blob/develop/packages/frontend/src/pages/reversi/game.board.vue#L28) の \`v-if=\"game.winner\"\` がこれに依存している。

## 主な変更点

- **\`internal/core/reversi/service.go:packGame\`** に \`winner\` を追加。WinnerID から User1/User2 を引いて \`userLiteMap\` として埋める。User1/User2 が未 preload な場合は \`winner\` だけ省略する fallback (\`winnerId\` は維持)。
- **\`internal/api/reversi/handler.go:packGame\`** にも同じ派生を追加。\`entity.PackUserLite\` を経由するので avatar / decoration 等 frontend が必要とする UserLite フィールドが揃う。
- 既存 publish 経路 (PutStone 終局 / Surrender / CheckTimeout) は全て \`Get(gameID)\` → \`repo.FindByID\` 経由で User1/User2 が preload されるため、追加の preload 改修は不要。

## テスト

両 \`packGame\` のカバレッジ **100%** を維持。両ファイルに以下のサブテスト追加:

- \`user1 wins\` — winnerId が User1 を指すとき winner が user1 UserLite になる
- \`user2 wins\` — winnerId が User2 を指すとき winner が user2 UserLite になる
- \`draw (winnerId nil)\` — winnerId 未設定なら winner は省略される
- \`user objects not preloaded\` (core 側のみ) — User1/User2 未 preload なら winner 省略 + winnerId は残る fallback

実行方法:
\`\`\`
go test -coverprofile=cov.out ./internal/api/reversi/... ./internal/core/reversi/...
\`\`\`

## 関連タスク

Closes #649
Part of UDS bug 報告 (#649 / #654 / #655 / #656 / #681 群の最後の 1 件)

## その他

- フロントエンド側修正は不要 (mk-go が upstream TS と同じ shape を返すようになるだけ)
- 連合対戦で相手側 (mk-go 同士 or mk-go ↔ TS) の表示も同じパスを通るため、サーバ間 federation 経由でも自動的に修正される

🤖 Generated with [Claude Code](https://claude.com/claude-code)