### PR TITLE
Fix #670: emoji copy で remote 画像を local drive (system 所有) に保存

### DIFF
--- a/internal/api/admin/drive_emoji_test.go
+++ b/internal/api/admin/drive_emoji_test.go
@@ -1,6 +1,7 @@
 package admin_test
 
 import (
+	"context"
 	"encoding/json"
 	"net/http"
 	"testing"
@@ -238,6 +239,164 @@ func TestEmojiCopy_NotFound(t *testing.T) {
 	h.SetEmojiRepo(testutil.NewMockEmojiRepository())
 	assert.Equal(t, http.StatusNotFound,
 		doPost(h.EmojiCopy, `{"emojiId":"missing"}`, adminUser).Code)
+}
+
+// fakeEmojiImageFetcher captures FetchAndStore arguments and returns a
+// scripted response so tests can verify EmojiCopy plumbs the fetcher
+// correctly (#670).
+type fakeEmojiImageFetcher struct {
+	calls []struct {
+		URL  string
+		Name string
+		User *model.User
+	}
+	returnDF  *model.DriveFile
+	returnErr error
+}
+
+func (f *fakeEmojiImageFetcher) FetchAndStore(_ context.Context, url string, user *model.User, name string) (*model.DriveFile, error) {
+	f.calls = append(f.calls, struct {
+		URL  string
+		Name string
+		User *model.User
+	}{url, name, user})
+	if f.returnErr != nil {
+		return nil, f.returnErr
+	}
+	return f.returnDF, nil
+}
+
+// TestEmojiCopy_StoresInDrive verifies that a wired fetcher is invoked and
+// the returned drive URL replaces the source's OriginalURL/PublicURL on the
+// new local emoji (#670). Without this rewrite the local copy stays bound to
+// the remote server's URL and breaks when that server deletes the file.
+func TestEmojiCopy_StoresInDrive(t *testing.T) {
+	h, _, _, _ := newTestHandler(t)
+	repo := testutil.NewMockEmojiRepository()
+	remoteHost := "remote.example"
+	require.NoError(t, repo.Create(&model.Emoji{
+		ID: "src1", Name: "happy", Host: &remoteHost,
+		OriginalURL: "https://remote.example/emoji/happy.png",
+		PublicURL:   "https://remote.example/emoji/happy.png",
+	}))
+	h.SetEmojiRepo(repo)
+
+	webpub := "https://local.example/files/webpub.png"
+	webpubType := "image/webp"
+	fetcher := &fakeEmojiImageFetcher{
+		returnDF: &model.DriveFile{
+			ID:            "df1",
+			URL:           "https://local.example/files/orig.png",
+			WebpublicURL:  &webpub,
+			WebpublicType: &webpubType,
+			Type:          "image/png",
+		},
+	}
+	h.SetEmojiImageFetcher(fetcher)
+
+	rec := doPost(h.EmojiCopy, `{"emojiId":"src1"}`, adminUser)
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	var body map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &body))
+	copied := findEmojiByID(t, repo, body["id"].(string))
+
+	// fetcher was called exactly once with the source's OriginalURL, the
+	// emoji name (used as drive file name), and a nil user (system-owned
+	// drive file, matching Misskey TS uploadFromUrl({user: null}) — see
+	// emoji.go EmojiCopy comment).
+	require.Len(t, fetcher.calls, 1)
+	assert.Equal(t, "https://remote.example/emoji/happy.png", fetcher.calls[0].URL)
+	assert.Equal(t, "happy", fetcher.calls[0].Name)
+	assert.Nil(t, fetcher.calls[0].User, "drive file must be system-owned (user nil)")
+
+	// New emoji's URLs point at the drive file, not the remote source.
+	assert.Equal(t, "https://local.example/files/orig.png", copied.OriginalURL)
+	assert.Equal(t, "https://local.example/files/webpub.png", copied.PublicURL)
+	require.NotNil(t, copied.Type)
+	// Webpublic type is preferred when present (matches Misskey TS behaviour).
+	assert.Equal(t, "image/webp", *copied.Type)
+}
+
+// TestEmojiCopy_StoresInDrive_NoWebpublic falls back to df.URL / df.Type
+// when the drive file has no webpublic variant (e.g. small images).
+func TestEmojiCopy_StoresInDrive_NoWebpublic(t *testing.T) {
+	h, _, _, _ := newTestHandler(t)
+	repo := testutil.NewMockEmojiRepository()
+	remoteHost := "remote.example"
+	require.NoError(t, repo.Create(&model.Emoji{
+		ID: "src1", Name: "tiny", Host: &remoteHost,
+		OriginalURL: "https://remote.example/emoji/tiny.png",
+	}))
+	h.SetEmojiRepo(repo)
+
+	fetcher := &fakeEmojiImageFetcher{
+		returnDF: &model.DriveFile{
+			ID:   "df1",
+			URL:  "https://local.example/files/tiny.png",
+			Type: "image/png",
+		},
+	}
+	h.SetEmojiImageFetcher(fetcher)
+
+	rec := doPost(h.EmojiCopy, `{"emojiId":"src1"}`, adminUser)
+	require.Equal(t, http.StatusOK, rec.Code)
+	var body map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &body))
+	copied := findEmojiByID(t, repo, body["id"].(string))
+
+	assert.Equal(t, "https://local.example/files/tiny.png", copied.OriginalURL)
+	assert.Equal(t, "https://local.example/files/tiny.png", copied.PublicURL)
+	require.NotNil(t, copied.Type)
+	assert.Equal(t, "image/png", *copied.Type)
+}
+
+// TestEmojiCopy_FetcherErrorReturns500 verifies that a fetch failure aborts
+// the copy (no row created) instead of silently falling back to the remote
+// URL — falling back would re-introduce the #670 symptom.
+func TestEmojiCopy_FetcherErrorReturns500(t *testing.T) {
+	h, _, _, _ := newTestHandler(t)
+	repo := testutil.NewMockEmojiRepository()
+	remoteHost := "remote.example"
+	require.NoError(t, repo.Create(&model.Emoji{
+		ID: "src1", Name: "happy", Host: &remoteHost,
+		OriginalURL: "https://remote.example/emoji/happy.png",
+	}))
+	h.SetEmojiRepo(repo)
+
+	fetcher := &fakeEmojiImageFetcher{returnErr: assert.AnError}
+	h.SetEmojiImageFetcher(fetcher)
+
+	rec := doPost(h.EmojiCopy, `{"emojiId":"src1"}`, adminUser)
+	assert.Equal(t, http.StatusInternalServerError, rec.Code)
+
+	// fetcher が失敗したら row は作られない (#670 fallback regression 防止)。
+	// 元 src が 1 件だけ残っており、host=nil の copy が増えていないことを
+	// repo の内部 map から直接確認する。
+	assert.Len(t, repo.Emojis, 1, "no new emoji row should have been created on fetch failure")
+}
+
+// TestEmojiCopy_FetcherUnsetUsesLegacyURL keeps the pre-#670 behaviour for
+// environments that have not wired a fetcher (test handlers, deployments
+// before the upgrade, etc). Without this fallback every test handler would
+// have to wire a drive stub.
+func TestEmojiCopy_FetcherUnsetUsesLegacyURL(t *testing.T) {
+	h, _, _, _ := newTestHandler(t)
+	repo := testutil.NewMockEmojiRepository()
+	remoteHost := "remote.example"
+	require.NoError(t, repo.Create(&model.Emoji{
+		ID: "src1", Name: "happy", Host: &remoteHost,
+		OriginalURL: "https://remote.example/emoji/happy.png",
+		PublicURL:   "https://remote.example/emoji/happy.png",
+	}))
+	h.SetEmojiRepo(repo)
+
+	rec := doPost(h.EmojiCopy, `{"emojiId":"src1"}`, adminUser)
+	require.Equal(t, http.StatusOK, rec.Code)
+	var body map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &body))
+	copied := findEmojiByID(t, repo, body["id"].(string))
+	assert.Equal(t, "https://remote.example/emoji/happy.png", copied.OriginalURL)
 }
 
 func TestEmojiSetCategoryBulk_BatchUpdate(t *testing.T) {

--- a/internal/api/admin/emoji.go
+++ b/internal/api/admin/emoji.go
@@ -48,6 +48,12 @@ func (h *Handler) EmojiAddAliasesBulk(c echo.Context) error {
 // 返す。以前の mk-go 実装は `_copy` suffix を勝手に付与していたが、
 // これは TS 仕様違反 (#650 問題 1) なのでサフィックスを除去した。
 //
+// 画像については upstream の driveService.uploadFromUrl 相当に対応するため、
+// emojiImageFetcher が wire 済みなら src.OriginalURL を local drive に
+// 保存し、新 emoji の OriginalURL/PublicURL を drive 経由の URL に差し替える
+// (#670)。fetcher 未配線時は src の URL をそのまま継承する legacy 挙動を
+// 維持する (テスト容易性 + 未配線環境での graceful degradation 用)。
+//
 // ref: third_party/misskey/packages/backend/src/server/api/endpoints/admin/emoji/copy.ts
 func (h *Handler) EmojiCopy(c echo.Context) error {
 	var req struct {
@@ -69,6 +75,35 @@ func (h *Handler) EmojiCopy(c echo.Context) error {
 	copied := *src
 	copied.ID = h.idGen.Generate(time.Now())
 	copied.Host = nil
+
+	// fetcher が wire され src.OriginalURL があれば drive に保存して URL
+	// を切り替える。drive file は upstream Misskey TS の uploadFromUrl
+	// ({user: null}) と同じく **system 所有 (user nil)** で作成する。
+	// custom emoji はインスタンス管理アセットであり、操作者個人の drive に
+	// 紐付けるとロール変更や削除で巻き込まれて表示が壊れる。失敗時は
+	// INTERNAL_ERROR を返して emoji 作成自体を中止する (URL 引き継ぎだけで
+	// 作成すると #670 の症状に逆戻りするため)。
+	if h.emojiImageFetcher != nil && src.OriginalURL != "" {
+		df, err := h.emojiImageFetcher.FetchAndStore(c.Request().Context(), src.OriginalURL, nil, src.Name)
+		if err != nil {
+			slog.WarnContext(c.Request().Context(), "emoji copy: drive fetch failed",
+				"srcId", src.ID, "url", src.OriginalURL, "err", err)
+			return c.JSON(http.StatusInternalServerError, apierr.Error("INTERNAL_ERROR", "Failed to fetch emoji image.", "0a4e0b9e-2d7c-4d6f-8f6b-1f9c2e9b4d83"))
+		}
+		copied.OriginalURL = df.URL
+		if df.WebpublicURL != nil && *df.WebpublicURL != "" {
+			copied.PublicURL = *df.WebpublicURL
+		} else {
+			copied.PublicURL = df.URL
+		}
+		if df.WebpublicType != nil && *df.WebpublicType != "" {
+			copied.Type = df.WebpublicType
+		} else if df.Type != "" {
+			t := df.Type
+			copied.Type = &t
+		}
+	}
+
 	if err := h.emojiRepo.Create(&copied); err != nil {
 		return c.JSON(http.StatusInternalServerError, apierr.Error("INTERNAL_ERROR", "Internal error.", "00000000-0000-0000-0000-000000000000"))
 	}

--- a/internal/api/admin/emoji.go
+++ b/internal/api/admin/emoji.go
@@ -96,8 +96,12 @@ func (h *Handler) EmojiCopy(c echo.Context) error {
 		} else {
 			copied.PublicURL = df.URL
 		}
+		// webpublic / fallback いずれの経路も defensive copy で *string を
+		// 作って df のポインタを共有しない (df 側を後から触る経路は無いが、
+		// 型 (*string) を扱う読み手のメンタルモデルを揃えるため)。
 		if df.WebpublicType != nil && *df.WebpublicType != "" {
-			copied.Type = df.WebpublicType
+			t := *df.WebpublicType
+			copied.Type = &t
 		} else if df.Type != "" {
 			t := df.Type
 			copied.Type = &t

--- a/internal/api/admin/emoji_image_fetcher.go
+++ b/internal/api/admin/emoji_image_fetcher.go
@@ -1,0 +1,103 @@
+package admin
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/url"
+	"path"
+
+	"github.com/shiroha-a/mk/internal/core/drive"
+	"github.com/shiroha-a/mk/internal/model"
+	"github.com/shiroha-a/mk/internal/safehttp"
+)
+
+// MaxEmojiImageBytes caps the response read from a remote emoji image so a
+// hostile / misconfigured server cannot drown the drive backend in arbitrary
+// bytes. Real-world custom emoji rarely exceed a few hundred KB; 8 MiB leaves
+// generous headroom for animated PNG / APNG / WebP.
+const MaxEmojiImageBytes int64 = 8 << 20
+
+// DefaultEmojiCopyAccept matches the headers Misskey TS sends when fetching
+// emoji images via DriveService.uploadFromUrl. */* fallback is required since
+// some CDN-fronted emoji use generic image/* responses.
+const DefaultEmojiCopyAccept = "image/*, */*"
+
+// EmojiImageFetcherImpl is the default EmojiImageFetcher used by router.go.
+// httpClient must be wired with safehttp.NewSSRFSafeTransport(...) so private
+// IPs and non-http(s) schemes never leak through this fetch path.
+type EmojiImageFetcherImpl struct {
+	httpClient *http.Client
+	driveSvc   *drive.Service
+	userAgent  string
+}
+
+// NewEmojiImageFetcher builds a fetcher bound to an SSRF-safe HTTP client and
+// the local drive service. userAgent should normally be cfg.UserAgent so feed
+// servers see the same `Misskey-Go/<ver>` identification used everywhere else.
+func NewEmojiImageFetcher(httpClient *http.Client, driveSvc *drive.Service, userAgent string) *EmojiImageFetcherImpl {
+	return &EmojiImageFetcherImpl{
+		httpClient: httpClient,
+		driveSvc:   driveSvc,
+		userAgent:  userAgent,
+	}
+}
+
+// FetchAndStore downloads the image at imageURL and stores it as a drive file.
+// Errors are wrapped so the caller can log a redacted reason while returning
+// a generic INTERNAL_ERROR to the client. SSRF / dial / parse / oversized
+// failures all collapse into a single error here — the SSRF-safe transport
+// blocks redirects to private IPs as well, so this layer does not need its
+// own redirect handling.
+func (f *EmojiImageFetcherImpl) FetchAndStore(ctx context.Context, imageURL string, user *model.User, name string) (*model.DriveFile, error) {
+	if f.httpClient == nil || f.driveSvc == nil {
+		return nil, fmt.Errorf("emoji image fetcher not wired")
+	}
+	u, err := url.Parse(imageURL)
+	if err != nil || u.Host == "" || (u.Scheme != "http" && u.Scheme != "https") {
+		return nil, fmt.Errorf("invalid image url")
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, u.String(), nil)
+	if err != nil {
+		return nil, fmt.Errorf("build request: %w", err)
+	}
+	req.Header.Set("Accept", DefaultEmojiCopyAccept)
+	if f.userAgent != "" {
+		req.Header.Set("User-Agent", f.userAgent)
+	}
+
+	resp, err := f.httpClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("fetch image: %w", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode >= 400 {
+		return nil, fmt.Errorf("upstream status %d", resp.StatusCode)
+	}
+
+	body, err := safehttp.ReadAllLimit(resp.Body, MaxEmojiImageBytes)
+	if err != nil {
+		return nil, fmt.Errorf("read body: %w", err)
+	}
+
+	// Misskey TS は uploadFromUrl で `name = path.basename(url) || randomString()`
+	// 相当を行う。ここでは emoji name (例: "smile") を渡しているのでそのまま
+	// drive file 名として使うが、空なら URL の最終 path セグメントを fallback
+	// に取って TS と挙動を揃える。
+	driveName := name
+	if driveName == "" {
+		driveName = path.Base(u.Path)
+	}
+
+	df, err := f.driveSvc.Upload(drive.UploadInput{
+		User:  user,
+		Body:  body,
+		Name:  driveName,
+		Force: true,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("upload to drive: %w", err)
+	}
+	return df, nil
+}

--- a/internal/api/admin/emoji_image_fetcher.go
+++ b/internal/api/admin/emoji_image_fetcher.go
@@ -90,6 +90,11 @@ func (f *EmojiImageFetcherImpl) FetchAndStore(ctx context.Context, imageURL stri
 		driveName = path.Base(u.Path)
 	}
 
+	// Force: true は upstream Misskey TS の uploadFromUrl({force: true}) と
+	// 同じく明示的に指定する。EmojiCopy 経路では user==nil が渡されるため
+	// drive.Service.Upload は md5 dedup を既に skip していて Force は no-op
+	// になるが、user 付きで本 fetcher を再利用する将来経路 (例: emoji 単発
+	// 追加 UI) で「重複しても新しいファイルを作る」契約を読み手に明示する。
 	df, err := f.driveSvc.Upload(drive.UploadInput{
 		User:  user,
 		Body:  body,

--- a/internal/api/admin/emoji_image_fetcher_test.go
+++ b/internal/api/admin/emoji_image_fetcher_test.go
@@ -1,0 +1,177 @@
+package admin
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/shiroha-a/mk/internal/core/drive"
+	"github.com/shiroha-a/mk/internal/misc/id"
+	"github.com/shiroha-a/mk/internal/model"
+	"github.com/shiroha-a/mk/internal/testutil"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// recordingStorage implements drive.Storage with deterministic URLs and an
+// in-memory blob store. Used to give Upload a real backing storage in tests
+// without spinning up the LocalStorage filesystem path.
+type recordingStorage struct {
+	objects map[string][]byte
+}
+
+func newRecordingStorage() *recordingStorage {
+	return &recordingStorage{objects: map[string][]byte{}}
+}
+
+func (r *recordingStorage) Put(accessKey string, body io.Reader) (string, error) {
+	b, err := io.ReadAll(body)
+	if err != nil {
+		return "", err
+	}
+	r.objects[accessKey] = b
+	return fmt.Sprintf("https://drive.local/%s", accessKey), nil
+}
+
+func (r *recordingStorage) Get(accessKey string) (io.ReadCloser, error) {
+	b, ok := r.objects[accessKey]
+	if !ok {
+		return nil, drive.ErrObjectNotFound
+	}
+	return io.NopCloser(bytes.NewReader(b)), nil
+}
+
+func (r *recordingStorage) Delete(accessKey string) error {
+	delete(r.objects, accessKey)
+	return nil
+}
+
+// We need a drive.Storage interface; use a minimal embedding fake. Build a
+// real drive.Service with mock repositories so Upload exercises the full
+// path including row creation.
+func newDriveService(t *testing.T) (*drive.Service, *testutil.MockDriveFileRepository) {
+	t.Helper()
+	idGen, err := id.NewGenerator("aidx")
+	require.NoError(t, err)
+	fileRepo := testutil.NewMockDriveFileRepository()
+	folderRepo := testutil.NewMockDriveFolderRepository()
+	return drive.NewService(fileRepo, folderRepo, newRecordingStorage(), idGen), fileRepo
+}
+
+func TestEmojiImageFetcher_FetchAndStore_Success(t *testing.T) {
+	const pixel = "\x89PNG\r\n\x1a\n" // PNG magic so AnalyseFile detects image/png
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Contains(t, r.Header.Get("Accept"), "image/")
+		assert.Equal(t, "Misskey-Go/test", r.Header.Get("User-Agent"))
+		w.Header().Set("Content-Type", "image/png")
+		_, _ = w.Write([]byte(pixel))
+	}))
+	t.Cleanup(srv.Close)
+
+	driveSvc, fileRepo := newDriveService(t)
+	f := NewEmojiImageFetcher(&http.Client{Timeout: 5 * time.Second, Transport: srv.Client().Transport}, driveSvc, "Misskey-Go/test")
+
+	// nil user で「system 所有 drive file」として upload する (#670)。
+	// Misskey TS uploadFromUrl({user: null}) と等価。
+	df, err := f.FetchAndStore(context.Background(), srv.URL+"/x.png", nil, "happy")
+	require.NoError(t, err)
+	require.NotNil(t, df)
+	assert.NotEmpty(t, df.URL)
+	// drive レコードが永続化されており、UserID は nil (system-owned)
+	require.Len(t, fileRepo.Files, 1)
+	for _, file := range fileRepo.Files {
+		assert.Nil(t, file.UserID, "system drive file must have UserID=nil")
+		assert.Nil(t, file.UserHost, "system drive file must have UserHost=nil")
+	}
+}
+
+func TestEmojiImageFetcher_InvalidScheme(t *testing.T) {
+	driveSvc, _ := newDriveService(t)
+	f := NewEmojiImageFetcher(&http.Client{}, driveSvc, "")
+	_, err := f.FetchAndStore(context.Background(), "file:///etc/passwd", &model.User{ID: "u"}, "x")
+	assert.Error(t, err)
+}
+
+func TestEmojiImageFetcher_EmptyURL(t *testing.T) {
+	driveSvc, _ := newDriveService(t)
+	f := NewEmojiImageFetcher(&http.Client{}, driveSvc, "")
+	_, err := f.FetchAndStore(context.Background(), "", &model.User{ID: "u"}, "x")
+	assert.Error(t, err)
+}
+
+func TestEmojiImageFetcher_NotWired(t *testing.T) {
+	f := &EmojiImageFetcherImpl{} // both nil
+	_, err := f.FetchAndStore(context.Background(), "https://x", &model.User{ID: "u"}, "x")
+	assert.Error(t, err)
+}
+
+func TestEmojiImageFetcher_UpstreamError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	t.Cleanup(srv.Close)
+
+	driveSvc, _ := newDriveService(t)
+	f := NewEmojiImageFetcher(&http.Client{Transport: srv.Client().Transport}, driveSvc, "")
+	_, err := f.FetchAndStore(context.Background(), srv.URL, &model.User{ID: "u"}, "x")
+	assert.Error(t, err)
+}
+
+func TestEmojiImageFetcher_OversizedBody(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		// MaxEmojiImageBytes = 8 MiB; send 9 MiB to trigger the cap.
+		_, _ = w.Write(make([]byte, 9<<20))
+	}))
+	t.Cleanup(srv.Close)
+
+	driveSvc, _ := newDriveService(t)
+	f := NewEmojiImageFetcher(&http.Client{Transport: srv.Client().Transport}, driveSvc, "")
+	_, err := f.FetchAndStore(context.Background(), srv.URL, &model.User{ID: "u"}, "x")
+	assert.Error(t, err)
+}
+
+func TestEmojiImageFetcher_DialFails(t *testing.T) {
+	failingClient := &http.Client{Transport: roundTripperFunc(func(_ *http.Request) (*http.Response, error) {
+		return nil, errors.New("ssrf block: connection to private IP refused")
+	})}
+	driveSvc, _ := newDriveService(t)
+	f := NewEmojiImageFetcher(failingClient, driveSvc, "")
+	_, err := f.FetchAndStore(context.Background(), "http://10.0.0.1/img.png", &model.User{ID: "u"}, "x")
+	assert.Error(t, err)
+	// 内部詳細はそのまま返す (caller である EmojiCopy 側が log + 静的 message に丸める)
+	assert.Contains(t, err.Error(), "fetch image")
+}
+
+// TestEmojiImageFetcher_EmptyNameFallsBackToURLPath は name="" のとき URL の
+// 最終 path セグメントが drive file 名として使われる Misskey TS 互換 fallback
+// を guard する。
+func TestEmojiImageFetcher_EmptyNameFallsBackToURLPath(t *testing.T) {
+	const pixel = "\x89PNG\r\n\x1a\n"
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "image/png")
+		_, _ = w.Write([]byte(pixel))
+	}))
+	t.Cleanup(srv.Close)
+
+	driveSvc, fileRepo := newDriveService(t)
+	f := NewEmojiImageFetcher(&http.Client{Timeout: 5 * time.Second, Transport: srv.Client().Transport}, driveSvc, "")
+
+	df, err := f.FetchAndStore(context.Background(), srv.URL+"/path/to/x.png", &model.User{ID: "u"}, "")
+	require.NoError(t, err)
+	require.NotNil(t, df)
+	// drive レコードが name="x.png" で作成される
+	require.Len(t, fileRepo.Files, 1)
+	for _, file := range fileRepo.Files {
+		assert.Equal(t, "x.png", file.Name)
+	}
+}
+
+type roundTripperFunc func(*http.Request) (*http.Response, error)
+
+func (f roundTripperFunc) RoundTrip(r *http.Request) (*http.Response, error) { return f(r) }

--- a/internal/api/admin/handler.go
+++ b/internal/api/admin/handler.go
@@ -88,6 +88,7 @@ type Handler struct {
 	userIPRepo              repository.UserIPRepository
 	queueInspector          QueueInspector
 	emojiEnqueuer           EmojiImportEnqueuer
+	emojiImageFetcher       EmojiImageFetcher
 	relayService            RelayService
 	abuseForwarder          AbuseForwarder
 	deleteAccountEnqueuer   DeleteAccountEnqueuer
@@ -251,6 +252,22 @@ type EmojiImportEnqueuer interface {
 // import-zip endpoint.
 func (h *Handler) SetEmojiImportEnqueuer(e EmojiImportEnqueuer) {
 	h.emojiEnqueuer = e
+}
+
+// EmojiImageFetcher downloads a remote image and stores it in the local
+// drive, returning the resulting drive file. Used by admin/emoji/copy to
+// detach a copied emoji from its source server (#670). 小さい interface に
+// 切り出すことで http client / drive.Service への直接依存を持たずに済み、
+// handler 単体テストで fake を差し込める。
+type EmojiImageFetcher interface {
+	FetchAndStore(ctx context.Context, url string, user *model.User, name string) (*model.DriveFile, error)
+}
+
+// SetEmojiImageFetcher attaches an EmojiImageFetcher used by admin/emoji/copy.
+// nil のままだと EmojiCopy は src の URL をそのまま継承する legacy 挙動を
+// 維持する (テスト容易性 + 未配線環境での graceful degradation 用)。
+func (h *Handler) SetEmojiImageFetcher(f EmojiImageFetcher) {
+	h.emojiImageFetcher = f
 }
 
 // QueueInspector abstracts asynq.Inspector for queue management endpoints.

--- a/internal/core/drive/drive_service.go
+++ b/internal/core/drive/drive_service.go
@@ -297,6 +297,9 @@ func (s *Service) Upload(in UploadInput) (*model.DriveFile, error) {
 			s.mainStreamPublisher.PublishMainEvent(in.User.ID, "driveFileCreated", entity.PackDriveFile(f, s.idGen))
 		}
 	}
+	// chartHook は user nil でも発火させる: bytes / count は instance-wide
+	// stats なので custom emoji 等の system file もインスタンスストレージの
+	// 一部として計上したい (uploader UI 反映の publishEvent とは異なる扱い)。
 	if s.chartHook != nil {
 		s.chartHook.OnFileUploaded(f)
 	}

--- a/internal/core/drive/drive_service.go
+++ b/internal/core/drive/drive_service.go
@@ -159,23 +159,26 @@ type UploadInput struct {
 
 // Upload writes a file to storage and creates a drive_file row. もし同じmd5の
 // ファイルが既に存在し Force=false なら、既存レコードを返す (deduplication)。
+//
+// in.User == nil は「system 所有 drive file」を表現する (Misskey TS の
+// driveService.uploadFromUrl({user: null, ...}) と等価)。system file は
+// 特定 user に紐付かないため md5 dedup / folder 所有権チェック / sensitive
+// 検出 / stream publish はいずれも skip する。custom emoji のリモート→
+// local コピー (#670) など、誰のものでもないがインスタンスが管理する
+// アセット用。
 func (s *Service) Upload(in UploadInput) (*model.DriveFile, error) {
-	if in.User == nil {
-		return nil, errors.New("user is required")
-	}
-
 	// in.Body は []byte なので bytes.Reader 経由のAnalyseFileは失敗しない。
 	// AnalyseFile自体は io.Reader を取るがエラー経路はここでは到達しない。
 	info, _ := AnalyseFile(bytes.NewReader(in.Body))
 
-	if !in.Force {
+	if in.User != nil && !in.Force {
 		if existing, err := s.fileRepo.FindByMD5(in.User.ID, info.MD5); err == nil {
 			return existing, nil
 		}
 	}
 
-	// folderの所有権チェック
-	if in.FolderID != nil {
+	// folderの所有権チェック (system file は folder を持たない前提なので skip)
+	if in.User != nil && in.FolderID != nil {
 		folder, err := s.folderRepo.FindByID(*in.FolderID)
 		if err != nil {
 			return nil, ErrFolderNotFound
@@ -236,11 +239,17 @@ func (s *Service) Upload(in UploadInput) (*model.DriveFile, error) {
 
 	now := time.Now()
 	fileID := s.idGen.Generate(now)
-	userID := in.User.ID
+	var userIDPtr *string
+	var userHostPtr *string
+	if in.User != nil {
+		uid := in.User.ID
+		userIDPtr = &uid
+		userHostPtr = in.User.Host
+	}
 	f := &model.DriveFile{
 		ID:                 fileID,
-		UserID:             &userID,
-		UserHost:           in.User.Host,
+		UserID:             userIDPtr,
+		UserHost:           userHostPtr,
 		MD5:                info.MD5,
 		Name:               in.Name,
 		Type:               info.MimeType,
@@ -260,8 +269,8 @@ func (s *Service) Upload(in UploadInput) (*model.DriveFile, error) {
 		IsSensitive:        in.IsSensitive,
 	}
 
-	// Sensitive media detection フック
-	if !f.IsSensitive {
+	// Sensitive media detection フック (system file は user 紐付きが無いので skip)
+	if !f.IsSensitive && in.User != nil {
 		f.IsSensitive = s.detectSensitive(in.User, in.Body, info.MimeType)
 	}
 
@@ -276,12 +285,17 @@ func (s *Service) Upload(in UploadInput) (*model.DriveFile, error) {
 		}
 		return nil, err
 	}
-	s.publishEvent(in.User.ID, "fileCreated", f)
-	// Misskey本家DriveService.addFileはdrive topicに加えてmainにも
-	// driveFileCreatedをemitしてUploader自身のUI(ドロップアップロード等)
-	// を即時反映させる(TS: DriveService.ts:665)。
-	if s.mainStreamPublisher != nil {
-		s.mainStreamPublisher.PublishMainEvent(in.User.ID, "driveFileCreated", entity.PackDriveFile(f, s.idGen))
+	// system file (in.User == nil) は誰の UI にも反映する必要が無いので
+	// stream publish 系を skip する。publishEvent / mainStreamPublisher は
+	// それぞれ userID を必要とする。
+	if in.User != nil {
+		s.publishEvent(in.User.ID, "fileCreated", f)
+		// Misskey本家DriveService.addFileはdrive topicに加えてmainにも
+		// driveFileCreatedをemitしてUploader自身のUI(ドロップアップロード等)
+		// を即時反映させる(TS: DriveService.ts:665)。
+		if s.mainStreamPublisher != nil {
+			s.mainStreamPublisher.PublishMainEvent(in.User.ID, "driveFileCreated", entity.PackDriveFile(f, s.idGen))
+		}
 	}
 	if s.chartHook != nil {
 		s.chartHook.OnFileUploaded(f)

--- a/internal/core/drive/drive_service_test.go
+++ b/internal/core/drive/drive_service_test.go
@@ -46,10 +46,18 @@ func newSvc(t *testing.T) (*drive.Service, *testutil.MockDriveFileRepository, *t
 
 // --- Upload ---
 
-func TestUpload_NilUser(t *testing.T) {
-	svc, _, _ := newSvc(t)
-	_, err := svc.Upload(drive.UploadInput{Body: []byte("x")})
-	assert.Error(t, err)
+// TestUpload_NilUserSystemFile guards that Upload accepts User == nil and
+// produces a system-owned drive file (UserID/UserHost both nil), matching
+// Misskey TS uploadFromUrl({user: null}). Used by EmojiCopy (#670) to store
+// remote emoji images without binding them to the operator's account.
+func TestUpload_NilUserSystemFile(t *testing.T) {
+	svc, fileRepo, _ := newSvc(t)
+	f, err := svc.Upload(drive.UploadInput{Body: []byte("hello"), Name: "x.bin"})
+	require.NoError(t, err)
+	require.NotNil(t, f)
+	assert.Nil(t, f.UserID)
+	assert.Nil(t, f.UserHost)
+	assert.Len(t, fileRepo.Files, 1)
 }
 
 func TestUpload_HappyPath(t *testing.T) {

--- a/internal/core/emojiimport/service.go
+++ b/internal/core/emojiimport/service.go
@@ -223,8 +223,12 @@ func (i *Importer) replaceEmoji(user *model.User, record metaRecord, body []byte
 		_ = i.deps.EmojiRepo.Delete(existing.ID)
 	}
 
+	// emoji import zip で展開された画像は upstream Misskey TS と同じく
+	// system 所有 drive file (User: nil) として保存する (#670)。custom emoji
+	// はインスタンス管理アセットであり、import を実行した admin 個人の drive
+	// に紐付けると ロール変更 / アカウント削除 で巻き込まれて表示が壊れる。
+	_ = user // user は moderation-log 経路だけで使う (将来の log 配線想定)。Upload には渡さない。
 	uploaded, err := i.deps.Uploader.Upload(drive.UploadInput{
-		User:  user,
 		Body:  body,
 		Name:  record.FileName,
 		Force: true,

--- a/internal/core/emojiimport/service.go
+++ b/internal/core/emojiimport/service.go
@@ -193,7 +193,7 @@ func (i *Importer) Run(ctx context.Context, userID, fileID string) (*Result, err
 			continue
 		}
 
-		if err := i.replaceEmoji(user, record, imgBody); err != nil {
+		if err := i.replaceEmoji(record, imgBody); err != nil {
 			slog.Warn("emoji import: replace failed", "name", record.Emoji.Name, "err", err)
 			result.Skipped++
 			continue
@@ -215,8 +215,11 @@ func readZipEntry(f *zip.File) ([]byte, error) {
 }
 
 // replaceEmoji deletes any existing local emoji with the same name, uploads the
-// image to Drive as a new DriveFile, and creates a fresh emoji row.
-func (i *Importer) replaceEmoji(user *model.User, record metaRecord, body []byte) error {
+// image to Drive as a new DriveFile, and creates a fresh emoji row. Run still
+// resolves the requesting user up front to fail-fast on missing accounts, but
+// the user is *not* propagated here because the resulting drive file is
+// system-owned (see Upload comment below for #670 rationale).
+func (i *Importer) replaceEmoji(record metaRecord, body []byte) error {
 	// 既存 local 絵文字 (同名) は上書きのために先に削除する。
 	// 本家 Misskey では emojisRepository.delete({ name, host: IsNull() }) 相当。
 	if existing, err := i.deps.EmojiRepo.FindByNameAndHost(record.Emoji.Name, nil); err == nil && existing != nil {
@@ -227,7 +230,8 @@ func (i *Importer) replaceEmoji(user *model.User, record metaRecord, body []byte
 	// system 所有 drive file (User: nil) として保存する (#670)。custom emoji
 	// はインスタンス管理アセットであり、import を実行した admin 個人の drive
 	// に紐付けると ロール変更 / アカウント削除 で巻き込まれて表示が壊れる。
-	_ = user // user は moderation-log 経路だけで使う (将来の log 配線想定)。Upload には渡さない。
+	// User: nil の経路では drive.Service.Upload が md5 dedup を skip するため
+	// Force: true は実質 no-op だが、明示性のため残す。
 	uploaded, err := i.deps.Uploader.Upload(drive.UploadInput{
 		Body:  body,
 		Name:  record.FileName,

--- a/internal/server/router.go
+++ b/internal/server/router.go
@@ -1699,6 +1699,10 @@ func (s *Server) setupRoutes() {
 	adminHandler.SetAdminDB(s.db)
 	adminHandler.SetUserIPRepo(userIPRepo)
 	adminHandler.SetEmojiImportEnqueuer(s.queueClient)
+	// admin/emoji/copy で remote 画像を local drive に保存するための fetcher
+	// を wire する (#670)。outboundClient 経由なので SSRF / proxy / outgoing
+	// address が他の outbound 経路と同じ設定で適用される。
+	adminHandler.SetEmojiImageFetcher(apiadmin.NewEmojiImageFetcher(s.outboundClient(10*time.Second), driveService, s.config.UserAgent))
 	adminHandler.SetRelayService(relaySvc)
 	adminHandler.SetSystemWebhookRepo(systemWebhookRepo)
 	// admin/system-webhook/test の fire-and-forget POST も SSRF-safe transport


### PR DESCRIPTION
## Summary

mk-go の \`admin/emoji/copy\` は src の URL をそのまま継承していたため、連合先サーバーが画像を消すと local 化したはずの emoji も表示が壊れる ([#670](https://github.com/shiroha-a/mk/issues/670))。upstream Misskey TS は \`driveService.uploadFromUrl({url, user: null, force: true})\` で remote 画像を local drive に保存し、その drive file URL を新 emoji の \`originalUrl\` / \`publicUrl\` に書き戻す。本 PR は同等挙動を実装し、さらに **drive file を system 所有 (user nil)** で永続化する (custom emoji は「インスタンス管理アセット」であり、操作者個人の drive に紐付けるとロール変更 / アカウント削除で巻き込まれて表示が壊れるため)。

## 主な変更点

### コア改修
- **\`internal/core/drive/drive_service.go\`**: \`Upload\` を \`User: nil\` 許容に拡張。system file (User nil) は md5 dedup / folder 所有権 / sensitive 検出 / stream publish をすべて skip し、\`DriveFile.UserID\` / \`UserHost\` は nil で永続化。
- **\`internal/core/emojiimport/service.go\`**: emoji import zip 経路の Upload も \`User: nil\` で system 所有保存に変更 (#670 と同じ理由)。

### EmojiCopy
- **\`internal/api/admin/emoji.go\`**: fetcher 配線時に \`src.OriginalURL\` → drive 保存 → 新 emoji の \`OriginalURL\` / \`PublicURL\` / \`Type\` を drive 経由値に書き換え。fetch 失敗時は \`INTERNAL_ERROR\` で row 自体を作らない (URL fallback で #670 症状に逆戻りしない設計)。fetcher 未配線環境では従来挙動を維持 (graceful degradation)。
- **\`internal/api/admin/handler.go\`**: \`EmojiImageFetcher\` interface + \`SetEmojiImageFetcher\` setter を追加。

### Fetcher 実装
- **\`internal/api/admin/emoji_image_fetcher.go\`** 新規:
  - \`safehttp.NewSSRFSafeTransport\` 経由 client + \`drive.Service\` を組み合わせて URL から drive file を作る実装
  - 8 MiB body cap (\`safehttp.ReadAllLimit\`)
  - 10s timeout (\`outboundClient(10s)\`)
  - \`Accept: image/*, */*\` + \`User-Agent: Misskey-Go/<ver>\` (#682 と同じ運用)
  - \`url.Parse\` で http(s) のみ許可、空 / Host 無し / その他 scheme は弾く
  - redirect 経由 SSRF も safehttp transport の DialContext gate で防がれる (handler doc に明記)

### 配線
- **\`internal/server/router.go\`**: \`EmojiImageFetcherImpl\` を \`s.outboundClient(10s)\` + \`driveService\` + \`s.config.UserAgent\` で wire。

## テスト

- \`drive.Service.TestUpload_NilUserSystemFile\`: nil User で system file が作成され \`UserID\` / \`UserHost\` が nil になることを guard
- \`EmojiImageFetcher\` 8 種: 成功 (system 所有 drive file の永続化検証含む) / scheme 不正 / 空 URL / 未配線 / upstream 5xx / 9 MiB oversized / dial fail (SSRF) / name 空時 URL fallback
- \`EmojiCopy\` 4 種: drive 経路成功 / webpublic 無し / fetch 失敗で 500 + row 未作成 / fetcher 未配線で legacy URL 継承

カバレッジ: drive **96.5%** / emojiimport **91.8%** / admin **85.2%** (全閾値クリア)

実行方法:
\`\`\`
go test -coverprofile=cov.out ./internal/core/drive/... ./internal/core/emojiimport/... ./internal/api/admin/...
\`\`\`

## 関連

Closes #670
Part of #650 (custom emoji 親 issue)、#669 (modlog 配線) の続編

## その他

- TS との挙動差異:
  - TS は emoji copy 経路のみ \`user: null\`、import zip 経路は \`me\` (操作者) を渡す
  - 本 PR では **両方とも \`user: nil\`** に揃えた。理由は本文上部の通り (custom emoji はインスタンス管理アセット)
- \`drive.Service.Upload\` の API 互換: 既存 caller (\`transfer/transfer.go\` 等) は \`User: user\` を明示的に渡すため挙動変化なし

🤖 Generated with [Claude Code](https://claude.com/claude-code)