### PR TITLE
Fix #690: アンケート機能の包括修正 (frontend / federation / 終了通知)

### DIFF
--- a/internal/activitypub/renderer.go
+++ b/internal/activitypub/renderer.go
@@ -528,9 +528,14 @@ func (r *Renderer) addEmojiTags(tags *[]any, emojiNames []string, host *string) 
 // PollService.deliverQuestionUpdate と同等で、配信先 instance が remote
 // follower 視点で count を最新化できる。RenderNote が既に Question 互換の
 // asPoll 出力をするので、それを wrap するだけ。
+//
+// Activity ID は `<noteURI>#updates/<RFC3339Nano>` で構成し、同一秒内に
+// 連続投票が発生した場合の Activity ID 衝突を防ぐ。受信側 instance は
+// Activity ID で idempotency dedup するため、衝突するとうしろ側 Update が
+// drop されて count が古いまま固定される (#690 review)。
 func (r *Renderer) RenderQuestionUpdate(n *model.Note, idGen id.Generator) *Update {
 	question := r.RenderNote(n, idGen)
-	now := time.Now().UTC().Format(time.RFC3339)
+	now := time.Now().UTC().Format(time.RFC3339Nano)
 	u := &Update{
 		Activity: Activity{
 			Object: Object{

--- a/internal/activitypub/renderer.go
+++ b/internal/activitypub/renderer.go
@@ -71,6 +71,16 @@ func (b *URLBuilder) CreateActivityURI(noteID string) string {
 	return b.NoteURI(noteID) + "/activity"
 }
 
+// VoteActivityURI returns a stable URI for the AP `Note` representing a
+// poll vote. URI must be unique per (voter, target) pair to avoid
+// collisions when the same user votes on multiple polls. Misskey TS の
+// upstream wire format に合わせて fragment 形式 (`#votes/<targetNoteID>`)
+// を採用する (#690)。fragment 形式なら remote 側が既存 voter URL の
+// 同一性で actor を識別できる。
+func (b *URLBuilder) VoteActivityURI(voterID, targetNoteID string) string {
+	return b.UserURI(voterID) + "#votes/" + targetNoteID
+}
+
 // FollowURI returns the URI for a Follow activity.
 // followeeIDが完全なURIの場合はハッシュ化してパスセグメントに埋め込む。
 func (b *URLBuilder) FollowURI(followerID, followeeID string) string {
@@ -511,6 +521,68 @@ func (r *Renderer) addEmojiTags(tags *[]any, emojiNames []string, host *string) 
 		}
 		*tags = append(*tags, tag)
 	}
+}
+
+// RenderQuestionUpdate builds the AP `Update(Question)` activity broadcast to
+// followers when a local poll receives a vote (#690)。Misskey TS の
+// PollService.deliverQuestionUpdate と同等で、配信先 instance が remote
+// follower 視点で count を最新化できる。RenderNote が既に Question 互換の
+// asPoll 出力をするので、それを wrap するだけ。
+func (r *Renderer) RenderQuestionUpdate(n *model.Note, idGen id.Generator) *Update {
+	question := r.RenderNote(n, idGen)
+	now := time.Now().UTC().Format(time.RFC3339)
+	u := &Update{
+		Activity: Activity{
+			Object: Object{
+				ID:   r.urls.NoteURI(n.ID) + "#updates/" + now,
+				Type: "Update",
+			},
+			Actor:     r.urls.UserURI(n.UserID),
+			Published: now,
+			To:        question.To,
+			CC:        question.CC,
+		},
+		Object: question,
+	}
+	AddContext(u)
+	return u
+}
+
+// RenderVote builds the AP `Create(Note)` activity used to deliver a poll
+// vote to the remote poll author's inbox (#690)。Misskey TS の vote wire
+// format に合わせて Note は `name = <choice>` + `inReplyTo = <poll URI>` +
+// 空 `content` で構成する。target は voted-on poll note (remote)。targetURI
+// はリモート側の note.URI を使う (local URL で render すると相手が解決でき
+// ない)。authorURI は target.UserID から URLBuilder 経由で組み立てる。
+func (r *Renderer) RenderVote(voter *model.User, target *model.Note, targetURI, authorURI, choiceName string) *Create {
+	now := time.Now().UTC().Format(time.RFC3339)
+	noteID := r.urls.VoteActivityURI(voter.ID, target.ID)
+	note := &Note{
+		Object: Object{
+			ID:   noteID,
+			Type: "Note",
+		},
+		AttributedTo: r.urls.UserURI(voter.ID),
+		Content:      "",
+		Published:    now,
+		To:           []string{authorURI},
+		InReplyTo:    targetURI,
+		Name:         choiceName,
+	}
+	c := &Create{
+		Activity: Activity{
+			Object: Object{
+				ID:   r.urls.CreateActivityURI(noteID),
+				Type: "Create",
+			},
+			Actor:     r.urls.UserURI(voter.ID),
+			Published: now,
+			To:        []string{authorURI},
+		},
+		Object: note,
+	}
+	AddContext(c)
+	return c
 }
 
 // RenderCreate wraps a Note into a Create activity addressed to the same audience.

--- a/internal/activitypub/types.go
+++ b/internal/activitypub/types.go
@@ -112,6 +112,11 @@ type Note struct {
 	MisskeyContent string   `json:"_misskey_content,omitempty"`
 	MisskeyQuote   string   `json:"_misskey_quote,omitempty"`
 	QuoteURL       string   `json:"quoteUrl,omitempty"`
+	// Name は AP poll vote (Question への投票) で choice 名を運ぶ field。
+	// Misskey TS の vote AP payload は `{type: "Note", name: "<choice>",
+	// inReplyTo: <poll URI>}` 形式で、ApNoteService が name + inReplyTo の
+	// 組合せで vote と判定する。通常の投稿には付かない (#690)。
+	Name string `json:"name,omitempty"`
 	// Question (poll) fields — AP Question typeで使用
 	OneOf   []QuestionChoice `json:"oneOf,omitempty"`
 	AnyOf   []QuestionChoice `json:"anyOf,omitempty"`

--- a/internal/api/notes/handler.go
+++ b/internal/api/notes/handler.go
@@ -219,8 +219,16 @@ func (h *Handler) Create(c echo.Context) error {
 			Choices:  req.Poll.Choices,
 			Multiple: req.Poll.Multiple,
 		}
-		if req.Poll.ExpiresAt != nil {
+		// Misskey TS API 互換: expiresAt (絶対 unix ms) と expiredAfter (相対 ms)
+		// のどちらか / 両方が送られる。frontend の form は「期限なし / 日時指定 /
+		// X 後」の 3 択で、相対指定時は expiredAfter のみが入る。両方来た時は
+		// expiresAt を優先する (TS PollService と同じ挙動、#690)。
+		switch {
+		case req.Poll.ExpiresAt != nil:
 			t := time.UnixMilli(*req.Poll.ExpiresAt)
+			in.Poll.ExpiresAt = &t
+		case req.Poll.ExpiredAfter != nil:
+			t := time.Now().Add(time.Duration(*req.Poll.ExpiredAfter) * time.Millisecond)
 			in.Poll.ExpiresAt = &t
 		}
 	}

--- a/internal/core/federation/poll_delivery_hook.go
+++ b/internal/core/federation/poll_delivery_hook.go
@@ -1,0 +1,116 @@
+package federation
+
+import (
+	"encoding/json"
+	"log/slog"
+
+	"github.com/shiroha-a/mk/internal/activitypub"
+	"github.com/shiroha-a/mk/internal/misc/id"
+	"github.com/shiroha-a/mk/internal/model"
+	"github.com/shiroha-a/mk/internal/repository"
+)
+
+// PollDeliveryHook handles two outbound AP paths for polls (#690):
+//   - OnVote: local user voted on a REMOTE poll → AP Note (with name +
+//     inReplyTo) to the author's inbox. Misskey TS notes/polls/vote.ts と
+//     同じ wire format。
+//   - OnLocalPollUpdated: local poll's vote count changed → AP
+//     Update(Question) broadcast to remote followers so counts stay in
+//     sync without polling. PollService.deliverQuestionUpdate と同等。
+//
+// 失敗は best-effort で skip + warn ログ。投票自体は既に成功しているので
+// 連合配信失敗で DB 状態を巻き戻すことはしない。
+type PollDeliveryHook struct {
+	renderer *activitypub.Renderer
+	deliver  *DeliverService
+	userRepo repository.UserRepository
+	urls     *activitypub.URLBuilder
+	idGen    id.Generator
+}
+
+// NewPollDeliveryHook constructs a PollDeliveryHook.
+func NewPollDeliveryHook(renderer *activitypub.Renderer, deliver *DeliverService, userRepo repository.UserRepository, urls *activitypub.URLBuilder, idGen id.Generator) *PollDeliveryHook {
+	return &PollDeliveryHook{
+		renderer: renderer,
+		deliver:  deliver,
+		userRepo: userRepo,
+		urls:     urls,
+		idGen:    idGen,
+	}
+}
+
+// OnVote is invoked by core/poll.Service after a successful vote. Skip when
+// the target poll is local (no remote delivery needed) or when essential AP
+// metadata (target.URI, author.Inbox, author.URI) is missing.
+func (h *PollDeliveryHook) OnVote(voter *model.User, target *model.Note, choice int, choiceName string) {
+	if h == nil || voter == nil || target == nil {
+		return
+	}
+	// local poll: 連合先に通知不要 (local user は同インスタンスの DB から
+	// 直接 count を読む)。
+	if target.UserHost == nil || *target.UserHost == "" {
+		return
+	}
+	if target.URI == nil || *target.URI == "" {
+		return
+	}
+	author, err := h.userRepo.FindByID(target.UserID)
+	if err != nil || author == nil {
+		return
+	}
+	if author.Inbox == nil || *author.Inbox == "" {
+		return
+	}
+	authorURI := ""
+	if author.URI != nil {
+		authorURI = *author.URI
+	}
+	if authorURI == "" {
+		return
+	}
+
+	activity := h.renderer.RenderVote(voter, target, *target.URI, authorURI, choiceName)
+	body, err := json.Marshal(activity)
+	if err != nil {
+		slog.Warn("poll delivery: marshal vote activity failed",
+			"voter", voter.ID, "target", target.ID, "err", err)
+		return
+	}
+	if err := h.deliver.DeliverActivity(voter.ID, body, []string{*author.Inbox}); err != nil {
+		slog.Warn("poll delivery: enqueue vote deliver failed",
+			"voter", voter.ID, "target", target.ID, "inbox", *author.Inbox, "err", err)
+	}
+}
+
+// OnLocalPollUpdated broadcasts an AP Update(Question) for a local poll to
+// all remote followers of the poll author so they refresh their count
+// display. local-only ノートや LocalOnly フラグ時は skip。target が
+// remote (本来は OnVote の path) の場合も skip する。
+func (h *PollDeliveryHook) OnLocalPollUpdated(target *model.Note) {
+	if h == nil || target == nil {
+		return
+	}
+	if target.UserHost != nil && *target.UserHost != "" {
+		return
+	}
+	if target.LocalOnly {
+		return
+	}
+
+	activity := h.renderer.RenderQuestionUpdate(target, h.idGen)
+	body, err := json.Marshal(activity)
+	if err != nil {
+		slog.Warn("poll delivery: marshal question update failed",
+			"noteId", target.ID, "err", err)
+		return
+	}
+	// Update activity は note 作成と同じく followers / mentioned remote /
+	// reply target の remote / quote target の remote へ届ける必要がある。
+	// 投票による count 変動は count を見せている全 follower に届くべき
+	// なので DeliverToFollowers で十分 (Misskey TS upstream も
+	// deliverToFollowers のみ使う)。
+	if err := h.deliver.DeliverToFollowers(target.UserID, body); err != nil {
+		slog.Warn("poll delivery: enqueue question update failed",
+			"noteId", target.ID, "err", err)
+	}
+}

--- a/internal/core/federation/poll_delivery_hook_test.go
+++ b/internal/core/federation/poll_delivery_hook_test.go
@@ -1,0 +1,184 @@
+package federation
+
+import (
+	"context"
+	"testing"
+
+	"github.com/shiroha-a/mk/internal/activitypub"
+	"github.com/shiroha-a/mk/internal/misc/id"
+	"github.com/shiroha-a/mk/internal/model"
+	"github.com/shiroha-a/mk/internal/queue"
+	"github.com/shiroha-a/mk/internal/queue/driver"
+	"github.com/shiroha-a/mk/internal/testutil"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// recordingEnqueuer captures DeliverPayloads enqueued via DeliverActivity so
+// hook tests can assert what was scheduled without a real asynq server. The
+// non-deliver methods are no-ops to satisfy queue.Enqueuer.
+type recordingEnqueuer struct {
+	delivers []queue.DeliverPayload
+}
+
+func (r *recordingEnqueuer) EnqueueDeliver(p queue.DeliverPayload, _ ...driver.EnqueueOption) error {
+	r.delivers = append(r.delivers, p)
+	return nil
+}
+func (r *recordingEnqueuer) EnqueueExport(queue.ExportPayload) error { return nil }
+func (r *recordingEnqueuer) EnqueueImport(queue.ImportPayload) error { return nil }
+func (r *recordingEnqueuer) EnqueueWebPush(context.Context, queue.WebPushPayload) error {
+	return nil
+}
+func (r *recordingEnqueuer) EnqueueUserWebhook(context.Context, queue.WebhookPayload) error {
+	return nil
+}
+func (r *recordingEnqueuer) EnqueueSystemWebhook(context.Context, queue.WebhookPayload) error {
+	return nil
+}
+func (r *recordingEnqueuer) EnqueueInbox(context.Context, queue.InboxPayload) error { return nil }
+func (r *recordingEnqueuer) Close() error                                           { return nil }
+
+func newHookSetup(t *testing.T) (*PollDeliveryHook, *recordingEnqueuer, *testutil.MockUserRepository, *testutil.MockUserKeypairRepository, id.Generator) {
+	t.Helper()
+	idGen, err := id.NewGenerator("aidx")
+	require.NoError(t, err)
+	urls := activitypub.NewURLBuilder("https://local.example")
+	renderer := activitypub.NewRenderer(urls)
+	enq := &recordingEnqueuer{}
+	userRepo := testutil.NewMockUserRepository()
+	keypairRepo := testutil.NewMockUserKeypairRepository()
+	followingRepo := testutil.NewMockFollowingRepository()
+	deliver := NewDeliverService(enq, userRepo, followingRepo, keypairRepo, urls)
+	hook := NewPollDeliveryHook(renderer, deliver, userRepo, urls, idGen)
+	return hook, enq, userRepo, keypairRepo, idGen
+}
+
+func seedSigner(t *testing.T, userRepo *testutil.MockUserRepository, keypairRepo *testutil.MockUserKeypairRepository, userID string) {
+	t.Helper()
+	userRepo.Users[userID] = &model.User{ID: userID, Username: userID}
+	keypairRepo.Keypairs[userID] = &model.UserKeypair{
+		UserID: userID,
+		// Test-only ECDSA-style stub key. DeliverActivity signs with the PEM
+		// we pass through; the recording enqueuer ignores it.
+		PrivateKey: "-----BEGIN PRIVATE KEY-----\nstub\n-----END PRIVATE KEY-----",
+	}
+}
+
+func TestPollDeliveryHook_OnVote_LocalPollSkipped(t *testing.T) {
+	hook, enq, _, _, _ := newHookSetup(t)
+	target := &model.Note{ID: "n1", UserID: "author", UserHost: nil}
+	hook.OnVote(&model.User{ID: "voter"}, target, 0, "A")
+	assert.Empty(t, enq.delivers, "local poll must not enqueue any deliver")
+}
+
+func TestPollDeliveryHook_OnVote_NilTargetSkipped(t *testing.T) {
+	hook, enq, _, _, _ := newHookSetup(t)
+	hook.OnVote(&model.User{ID: "voter"}, nil, 0, "A")
+	hook.OnVote(nil, &model.Note{}, 0, "A")
+	assert.Empty(t, enq.delivers)
+}
+
+func TestPollDeliveryHook_OnVote_MissingMetadataSkipped(t *testing.T) {
+	hook, enq, userRepo, _, _ := newHookSetup(t)
+	host := "remote.example"
+	uri := "https://remote.example/notes/r1"
+	target := &model.Note{ID: "n1", UserID: "author_remote", UserHost: &host, URI: &uri}
+
+	// 1. author lookup fails
+	hook.OnVote(&model.User{ID: "voter"}, target, 0, "A")
+	assert.Empty(t, enq.delivers)
+
+	// 2. author exists but no inbox
+	authorURI := "https://remote.example/users/author_remote"
+	userRepo.Users["author_remote"] = &model.User{ID: "author_remote", URI: &authorURI}
+	hook.OnVote(&model.User{ID: "voter"}, target, 0, "A")
+	assert.Empty(t, enq.delivers)
+
+	// 3. author exists with inbox but no URI
+	inbox := "https://remote.example/inbox"
+	userRepo.Users["author_remote"] = &model.User{ID: "author_remote", Inbox: &inbox}
+	hook.OnVote(&model.User{ID: "voter"}, target, 0, "A")
+	assert.Empty(t, enq.delivers)
+
+	// 4. target.URI nil -> skip even with everything else set
+	target2 := &model.Note{ID: "n1", UserID: "author_remote", UserHost: &host}
+	userRepo.Users["author_remote"] = &model.User{ID: "author_remote", Inbox: &inbox, URI: &authorURI}
+	hook.OnVote(&model.User{ID: "voter"}, target2, 0, "A")
+	assert.Empty(t, enq.delivers)
+}
+
+func TestPollDeliveryHook_OnVote_RemoteEnqueues(t *testing.T) {
+	hook, enq, userRepo, keypairRepo, _ := newHookSetup(t)
+	seedSigner(t, userRepo, keypairRepo, "voter")
+
+	host := "remote.example"
+	uri := "https://remote.example/notes/r1"
+	target := &model.Note{ID: "n1", UserID: "author_remote", UserHost: &host, URI: &uri}
+	authorURI := "https://remote.example/users/author_remote"
+	inbox := "https://remote.example/users/author_remote/inbox"
+	userRepo.Users["author_remote"] = &model.User{ID: "author_remote", Inbox: &inbox, URI: &authorURI}
+
+	hook.OnVote(&model.User{ID: "voter"}, target, 0, "Apple")
+	require.Len(t, enq.delivers, 1, "remote poll must enqueue exactly 1 deliver to author inbox")
+	assert.Equal(t, inbox, enq.delivers[0].Inbox)
+	assert.Contains(t, string(enq.delivers[0].Body), `"name":"Apple"`)
+	assert.Contains(t, string(enq.delivers[0].Body), `"inReplyTo":"https://remote.example/notes/r1"`)
+}
+
+func TestPollDeliveryHook_OnLocalPollUpdated_RemoteSkipped(t *testing.T) {
+	hook, enq, _, _, _ := newHookSetup(t)
+	host := "remote.example"
+	hook.OnLocalPollUpdated(&model.Note{ID: "n1", UserHost: &host})
+	assert.Empty(t, enq.delivers, "remote poll must not trigger Update broadcast")
+}
+
+func TestPollDeliveryHook_OnLocalPollUpdated_LocalOnlySkipped(t *testing.T) {
+	hook, enq, _, _, _ := newHookSetup(t)
+	hook.OnLocalPollUpdated(&model.Note{ID: "n1", LocalOnly: true})
+	assert.Empty(t, enq.delivers, "local-only poll must not trigger Update broadcast")
+}
+
+func TestPollDeliveryHook_OnLocalPollUpdated_NoFollowersNoDeliver(t *testing.T) {
+	hook, enq, userRepo, keypairRepo, _ := newHookSetup(t)
+	seedSigner(t, userRepo, keypairRepo, "author")
+	// followingRepo is empty -> ListRemoteFollowerInboxes returns []
+	hook.OnLocalPollUpdated(&model.Note{ID: "n1", UserID: "author", HasPoll: true, Visibility: model.NoteVisibilityPublic})
+	assert.Empty(t, enq.delivers, "no followers -> no deliver enqueued")
+}
+
+func TestPollDeliveryHook_NilSetterNoOp(t *testing.T) {
+	var hook *PollDeliveryHook
+	hook.OnVote(&model.User{}, &model.Note{}, 0, "x")
+	hook.OnLocalPollUpdated(&model.Note{})
+}
+
+// TestPollDeliveryHook_OnVote_DeliverErrorLogged exercises the failure path
+// where DeliverActivity returns an error (signer keypair missing). The hook
+// only logs and returns — DB state is not rolled back.
+func TestPollDeliveryHook_OnVote_DeliverErrorLogged(t *testing.T) {
+	hook, _, userRepo, _, _ := newHookSetup(t)
+	// voter ユーザーは作るが keypair は seed しないので signerCredentials が err を返す
+	userRepo.Users["voter"] = &model.User{ID: "voter", Username: "voter"}
+
+	host := "remote.example"
+	uri := "https://remote.example/notes/r1"
+	target := &model.Note{ID: "n1", UserID: "author_remote", UserHost: &host, URI: &uri}
+	authorURI := "https://remote.example/users/author_remote"
+	inbox := "https://remote.example/users/author_remote/inbox"
+	userRepo.Users["author_remote"] = &model.User{ID: "author_remote", Inbox: &inbox, URI: &authorURI}
+
+	// no panic, no return value — error is silently logged
+	hook.OnVote(&model.User{ID: "voter"}, target, 0, "Apple")
+}
+
+// TestPollDeliveryHook_OnLocalPollUpdated_DeliverErrorLogged exercises the
+// equivalent failure path on the Update(Question) broadcast side.
+func TestPollDeliveryHook_OnLocalPollUpdated_DeliverErrorLogged(t *testing.T) {
+	hook, _, userRepo, _, _ := newHookSetup(t)
+	// author exists but no keypair — signer fetch fails when followers are present.
+	userRepo.Users["author"] = &model.User{ID: "author"}
+	hook.OnLocalPollUpdated(&model.Note{
+		ID: "n1", UserID: "author", HasPoll: true, Visibility: model.NoteVisibilityPublic,
+	})
+}

--- a/internal/core/federation/resolver.go
+++ b/internal/core/federation/resolver.go
@@ -97,6 +97,7 @@ type Resolver struct {
 	chartHook       ChartHook                      // optional: 新規 remote user の集計
 	publickeyRepo   PublickeyStore                 // optional: 公開鍵の永続化
 	pollRepo        repository.PollRepository      // optional: Question(投票)のPoll作成
+	pollVoter       PollVoter                      // optional: AP vote (Note.name) の投票記録
 	emojiRepo       repository.EmojiRepository     // optional: リモート絵文字の永続化
 	driveFileRepo   repository.DriveFileRepository // optional: リモート添付の link 化
 	// imageProbeClient は image attachment の dimension probe (#461) で
@@ -173,6 +174,21 @@ func (r *Resolver) SetPublickeyRepo(repo PublickeyStore) {
 // SetPollRepo attaches a PollRepository for ingesting Question (poll) objects.
 func (r *Resolver) SetPollRepo(repo repository.PollRepository) {
 	r.pollRepo = repo
+}
+
+// PollVoter records a poll vote on behalf of a remote actor when an
+// inbound AP Note carries `name` + `inReplyTo` to a poll-bearing note
+// (Misskey TS の vote AP wire format)。実装は core/poll.Service。循環依存
+// 回避のため interface で受け取る。nil 配線時は federation 経由 vote が
+// 無視される (legacy / 元バグ挙動)。
+type PollVoter interface {
+	Vote(user *model.User, noteID string, choice int) error
+}
+
+// SetPollVoter attaches a PollVoter so AP votes are routed to the local
+// poll service instead of being mistakenly persisted as reply notes (#690)。
+func (r *Resolver) SetPollVoter(v PollVoter) {
+	r.pollVoter = v
 }
 
 // SetEmojiRepo attaches an EmojiRepository for extracting and upserting
@@ -599,17 +615,46 @@ func (r *Resolver) IngestNote(body []byte) (*model.Note, error) {
 	}
 	// 返信先がローカルに存在すれば紐付ける。リモート返信先の解決は後続 phase で
 	// 対応するため、現状では nil のままにする。
+	var replyTarget *model.Note
 	if apNote.InReplyTo != "" {
 		if id := r.extractLocalNoteID(apNote.InReplyTo); id != "" {
 			if reply, err := r.noteRepo.FindByID(id); err == nil {
-				note.ReplyID = &reply.ID
-				note.ReplyUserID = &reply.UserID
-				note.ReplyUserHost = reply.UserHost
+				replyTarget = reply
 			}
 		} else if reply, err := r.noteRepo.FindByURI(apNote.InReplyTo); err == nil {
-			note.ReplyID = &reply.ID
-			note.ReplyUserID = &reply.UserID
-			note.ReplyUserHost = reply.UserHost
+			replyTarget = reply
+		}
+		if replyTarget != nil {
+			note.ReplyID = &replyTarget.ID
+			note.ReplyUserID = &replyTarget.UserID
+			note.ReplyUserHost = replyTarget.UserHost
+		}
+	}
+	// AP vote 判定: reply target が poll を持ち apNote.Name (choice 名) が
+	// 入っていれば「投票」として処理し、note は作らずに早期 return する
+	// (#690)。Misskey TS の ApNoteService.create と同等の wire format。
+	// pollRepo / pollVoter 未配線環境では従来通り reply note として fall
+	// through する (legacy 互換)。
+	if replyTarget != nil && replyTarget.HasPoll && apNote.Name != "" && r.pollRepo != nil && r.pollVoter != nil {
+		if poll, err := r.pollRepo.FindByNoteID(replyTarget.ID); err == nil && poll != nil {
+			idx := -1
+			for i, c := range poll.Choices {
+				if c == apNote.Name {
+					idx = i
+					break
+				}
+			}
+			if idx >= 0 {
+				if err := r.pollVoter.Vote(actor, replyTarget.ID, idx); err != nil {
+					slog.Warn("federation: AP poll vote rejected",
+						"actor", actor.ID, "noteId", replyTarget.ID, "choice", apNote.Name, "err", err)
+				}
+				// vote として処理した場合、reply note は作成せず終了
+				// (note=nil で caller の fanout / notification も skip される)。
+				return nil, nil
+			}
+			slog.Warn("federation: AP poll vote choice not found",
+				"actor", actor.ID, "noteId", replyTarget.ID, "choice", apNote.Name)
 		}
 	}
 	// メンション抽出は本文と AP `tag` 配列の Mention 両方から行う。本文だけだと

--- a/internal/core/federation/resolver_test.go
+++ b/internal/core/federation/resolver_test.go
@@ -406,6 +406,126 @@ func TestIngestNote_NoteCreateError(t *testing.T) {
 	assert.Error(t, err)
 }
 
+// stubPollVoter records IngestNote → AP poll vote routing.
+type stubPollVoter struct {
+	calls []struct {
+		User   *model.User
+		NoteID string
+		Choice int
+	}
+	err error
+}
+
+func (s *stubPollVoter) Vote(user *model.User, noteID string, choice int) error {
+	s.calls = append(s.calls, struct {
+		User   *model.User
+		NoteID string
+		Choice int
+	}{user, noteID, choice})
+	return s.err
+}
+
+// TestIngestNote_APVoteRoutedToPollService covers the #690 fix where an
+// inbound AP Note with `name` + `inReplyTo` to a poll-bearing local note is
+// treated as a vote and routed to pollService.Vote, not persisted as a
+// reply note.
+func TestIngestNote_APVoteRoutedToPollService(t *testing.T) {
+	repo := testutil.NewMockUserRepository()
+	noteRepo := testutil.NewMockNoteRepository()
+	noteRepo.Notes["pollNote"] = &model.Note{ID: "pollNote", UserID: "author", HasPoll: true, Visibility: model.NoteVisibilityPublic}
+	pollRepo := testutil.NewMockPollRepository()
+	require.NoError(t, pollRepo.Create(&model.Poll{
+		NoteID: "pollNote", Choices: []string{"Apple", "Banana"}, Votes: []int64{0, 0},
+	}))
+	urls := activitypub.NewURLBuilder("https://example.com")
+	idGen, _ := id.NewGenerator("aidx")
+	r := federation.NewResolver(repo, noteRepo, urls, &stubFetcher{body: []byte(sampleActor)}, idGen)
+	r.SetPollRepo(pollRepo)
+	voter := &stubPollVoter{}
+	r.SetPollVoter(voter)
+
+	body := []byte(`{
+		"id": "https://remote.example/users/alice#votes/pollNote",
+		"type": "Note",
+		"attributedTo": "https://remote.example/users/alice",
+		"name": "Banana",
+		"inReplyTo": "https://example.com/notes/pollNote",
+		"to": ["https://example.com/users/author"]
+	}`)
+	got, err := r.IngestNote(body)
+	require.NoError(t, err)
+	assert.Nil(t, got, "AP vote must NOT create a note (caller skips fanout/notification)")
+	require.Len(t, voter.calls, 1, "pollVoter.Vote must be called exactly once")
+	assert.Equal(t, "pollNote", voter.calls[0].NoteID)
+	assert.Equal(t, 1, voter.calls[0].Choice, "Banana = choice index 1")
+}
+
+// TestIngestNote_APVoteUnknownChoiceFallsThrough verifies that if the
+// `name` does NOT match any poll choice, IngestNote falls through to
+// regular reply processing instead of swallowing the note silently.
+func TestIngestNote_APVoteUnknownChoiceFallsThrough(t *testing.T) {
+	repo := testutil.NewMockUserRepository()
+	noteRepo := testutil.NewMockNoteRepository()
+	noteRepo.Notes["pollNote"] = &model.Note{ID: "pollNote", UserID: "author", HasPoll: true, Visibility: model.NoteVisibilityPublic}
+	pollRepo := testutil.NewMockPollRepository()
+	require.NoError(t, pollRepo.Create(&model.Poll{
+		NoteID: "pollNote", Choices: []string{"Apple", "Banana"}, Votes: []int64{0, 0},
+	}))
+	urls := activitypub.NewURLBuilder("https://example.com")
+	idGen, _ := id.NewGenerator("aidx")
+	r := federation.NewResolver(repo, noteRepo, urls, &stubFetcher{body: []byte(sampleActor)}, idGen)
+	r.SetPollRepo(pollRepo)
+	voter := &stubPollVoter{}
+	r.SetPollVoter(voter)
+
+	body := []byte(`{
+		"id": "https://remote.example/users/alice#votes/pollNote",
+		"type": "Note",
+		"attributedTo": "https://remote.example/users/alice",
+		"name": "Cherry",
+		"inReplyTo": "https://example.com/notes/pollNote",
+		"to": ["https://example.com/users/author"]
+	}`)
+	got, err := r.IngestNote(body)
+	require.NoError(t, err)
+	require.NotNil(t, got, "unmatched choice falls through to reply note creation")
+	assert.Empty(t, voter.calls)
+	require.NotNil(t, got.ReplyID)
+	assert.Equal(t, "pollNote", *got.ReplyID)
+}
+
+// TestIngestNote_NormalReplyToPollNotConfusedAsVote verifies that a reply
+// note WITHOUT `name` is processed as a normal reply, not a vote.
+func TestIngestNote_NormalReplyToPollNotConfusedAsVote(t *testing.T) {
+	repo := testutil.NewMockUserRepository()
+	noteRepo := testutil.NewMockNoteRepository()
+	noteRepo.Notes["pollNote"] = &model.Note{ID: "pollNote", UserID: "author", HasPoll: true, Visibility: model.NoteVisibilityPublic}
+	pollRepo := testutil.NewMockPollRepository()
+	require.NoError(t, pollRepo.Create(&model.Poll{
+		NoteID: "pollNote", Choices: []string{"Apple"}, Votes: []int64{0},
+	}))
+	urls := activitypub.NewURLBuilder("https://example.com")
+	idGen, _ := id.NewGenerator("aidx")
+	r := federation.NewResolver(repo, noteRepo, urls, &stubFetcher{body: []byte(sampleActor)}, idGen)
+	r.SetPollRepo(pollRepo)
+	voter := &stubPollVoter{}
+	r.SetPollVoter(voter)
+
+	body := []byte(`{
+		"id": "https://remote.example/notes/normalreply",
+		"type": "Note",
+		"attributedTo": "https://remote.example/users/alice",
+		"content": "Just commenting on the poll",
+		"inReplyTo": "https://example.com/notes/pollNote",
+		"to": ["https://example.com/users/author"]
+	}`)
+	got, err := r.IngestNote(body)
+	require.NoError(t, err)
+	require.NotNil(t, got)
+	assert.Empty(t, voter.calls, "normal reply must not invoke pollVoter")
+	require.NotNil(t, got.ReplyID)
+}
+
 func TestIngestNote_ReplyToLocal(t *testing.T) {
 	repo := testutil.NewMockUserRepository()
 	noteRepo := testutil.NewMockNoteRepository()

--- a/internal/core/note/note_create_service_test.go
+++ b/internal/core/note/note_create_service_test.go
@@ -35,6 +35,10 @@ type failingPollRepo struct{}
 func (f *failingPollRepo) Create(_ *model.Poll) error                 { return stubError }
 func (f *failingPollRepo) FindByNoteID(_ string) (*model.Poll, error) { return nil, stubError }
 func (f *failingPollRepo) IncrementVote(_ string, _ int, _ int) error { return nil }
+func (f *failingPollRepo) ListExpiredUnnotified(_ time.Time, _ int) ([]*model.Poll, error) {
+	return nil, nil
+}
+func (f *failingPollRepo) MarkNotified(_ string, _ time.Time) error { return nil }
 
 // findFailNoteRepo creates successfully but FindByIDWithRelations always
 // fails (CreateService uses the full-relations variant for finalNote since

--- a/internal/core/notification/notification_service.go
+++ b/internal/core/notification/notification_service.go
@@ -20,13 +20,21 @@ import (
 type Type string
 
 const (
-	TypeFollow              Type = "follow"
-	TypeMention             Type = "mention"
-	TypeReply               Type = "reply"
-	TypeRenote              Type = "renote"
-	TypeQuote               Type = "quote"
-	TypeReaction            Type = "reaction"
-	TypePollVote            Type = "pollVote"
+	TypeFollow   Type = "follow"
+	TypeMention  Type = "mention"
+	TypeReply    Type = "reply"
+	TypeRenote   Type = "renote"
+	TypeQuote    Type = "quote"
+	TypeReaction Type = "reaction"
+	// TypePollVote: per-vote 通知。Misskey TS には対応 type が無いため
+	// frontend が空 body で render してしまい運用上 noise だけが残る (#690)。
+	// service 側からは発火しない (poll_service が呼ばないように disable
+	// 済み)。type 自体は永続化済み notification の互換のため残す。
+	TypePollVote Type = "pollVote"
+	// TypePollEnded: アンケート期限切れ時の通知 (#690)。Misskey TS の
+	// EndedPollNotificationProcessor 相当。著者 + 投票者 (ローカルのみ) に
+	// 1 件ずつ作る。core/poll.ExpiryWorker が周期 ticker で発火させる。
+	TypePollEnded           Type = "pollEnded"
 	TypeReceiveFollowReq    Type = "receiveFollowRequest"
 	TypeFollowRequestAccept Type = "followRequestAccepted"
 	TypeExportCompleted     Type = "exportCompleted"

--- a/internal/core/poll/expiry_worker.go
+++ b/internal/core/poll/expiry_worker.go
@@ -1,0 +1,184 @@
+package poll
+
+import (
+	"context"
+	"log/slog"
+	"time"
+
+	"github.com/shiroha-a/mk/internal/core/notification"
+	"github.com/shiroha-a/mk/internal/model"
+	"github.com/shiroha-a/mk/internal/repository"
+)
+
+// PollEndedNotifier is the minimal subset of core/notification.Service needed
+// to send a `pollEnded` notification. 循環依存を避けるため interface で受け
+// 取り、ExpiryWorker のテストで stub できるようにする。
+type PollEndedNotifier interface {
+	Create(ctx context.Context, in notification.CreateInput) (*notification.Notification, error)
+}
+
+// ExpiryWorker scans the poll table on a periodic ticker and sends
+// `pollEnded` notifications to the author + local voters of polls whose
+// expiresAt has passed (#690).
+//
+// Misskey TS は BullMQ delayed job で同等の動作を実現しているが、mk-go では
+// queue infra を経由せず周期 scan で済ませる方針。partial index
+// `IDX_poll_expired_unnotified` (migration 044) が WHERE expiresAt < NOW()
+// AND notifiedAt IS NULL を効率化するため、空 scan のオーバーヘッドは小さい。
+type ExpiryWorker struct {
+	pollRepo     repository.PollRepository
+	pollVoteRepo repository.PollVoteRepository
+	noteRepo     repository.NoteRepository
+	userRepo     repository.UserRepository
+	notifier     PollEndedNotifier
+	interval     time.Duration
+	batchSize    int
+	nowFn        func() time.Time
+}
+
+// NewExpiryWorker constructs an ExpiryWorker. interval は scan 間隔で 60s
+// が運用デフォルト (poll 期限の精度として十分、空 scan のコストも小さい)。
+// batchSize は 1 tick あたりに処理する poll 件数の上限 (大量 backlog 時に
+// 1 tick で全部処理しないようにする防御)。
+func NewExpiryWorker(
+	pollRepo repository.PollRepository,
+	pollVoteRepo repository.PollVoteRepository,
+	noteRepo repository.NoteRepository,
+	userRepo repository.UserRepository,
+	notifier PollEndedNotifier,
+	interval time.Duration,
+	batchSize int,
+) *ExpiryWorker {
+	if interval <= 0 {
+		interval = 60 * time.Second
+	}
+	if batchSize <= 0 {
+		batchSize = 100
+	}
+	return &ExpiryWorker{
+		pollRepo:     pollRepo,
+		pollVoteRepo: pollVoteRepo,
+		noteRepo:     noteRepo,
+		userRepo:     userRepo,
+		notifier:     notifier,
+		interval:     interval,
+		batchSize:    batchSize,
+		nowFn:        time.Now,
+	}
+}
+
+// SetClock replaces the clock used by Tick / Run. テスト用。
+func (w *ExpiryWorker) SetClock(now func() time.Time) {
+	if now != nil {
+		w.nowFn = now
+	}
+}
+
+// Run starts the periodic scan loop. Returns when ctx is cancelled. Each
+// tick calls Tick once; failures are logged and the loop continues so a
+// single transient DB error does not stop notifications permanently.
+func (w *ExpiryWorker) Run(ctx context.Context) {
+	if w == nil || w.pollRepo == nil {
+		return
+	}
+	// Process any backlog that accumulated while the server was down BEFORE
+	// the first tick interval, so a restart doesn't delay notifications by
+	// up to `interval` seconds.
+	if err := w.Tick(ctx); err != nil {
+		slog.WarnContext(ctx, "poll expiry worker: initial tick failed", "err", err)
+	}
+	t := time.NewTicker(w.interval)
+	defer t.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-t.C:
+			if err := w.Tick(ctx); err != nil {
+				slog.WarnContext(ctx, "poll expiry worker: tick failed", "err", err)
+			}
+		}
+	}
+}
+
+// Tick runs one scan + notify cycle. Exposed so callers (and tests) can
+// drive the worker synchronously. Returns the first error encountered;
+// subsequent polls in the batch are still processed (best-effort).
+func (w *ExpiryWorker) Tick(ctx context.Context) error {
+	if w == nil || w.pollRepo == nil {
+		return nil
+	}
+	now := w.nowFn()
+	polls, err := w.pollRepo.ListExpiredUnnotified(now, w.batchSize)
+	if err != nil {
+		return err
+	}
+	for _, p := range polls {
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+		w.notifyOne(ctx, p, now)
+	}
+	return nil
+}
+
+// notifyOne sends `pollEnded` notifications to the poll author + local
+// voters and marks the poll as notified. Marks even when notifications fail
+// partially so a stuck downstream doesn't stall the queue forever (audit
+// log style: best-effort once, not retried).
+func (w *ExpiryWorker) notifyOne(ctx context.Context, p *model.Poll, now time.Time) {
+	if p == nil {
+		return
+	}
+	// Collect target user IDs (author + voters) and dedup to avoid double
+	// notifications when the author also voted on their own poll.
+	targets := map[string]struct{}{p.UserID: {}}
+	if w.pollVoteRepo != nil {
+		votes, err := w.pollVoteRepo.ListByNoteID(p.NoteID)
+		if err == nil {
+			for _, v := range votes {
+				targets[v.UserID] = struct{}{}
+			}
+		} else {
+			slog.WarnContext(ctx, "poll expiry worker: list votes failed",
+				"noteId", p.NoteID, "err", err)
+		}
+	}
+	// Resolve note visibility once for the notification record (read path
+	// uses noteVisibility to filter unread counts without a join).
+	var noteVisibility string
+	if w.noteRepo != nil {
+		if n, err := w.noteRepo.FindByID(p.NoteID); err == nil && n != nil {
+			noteVisibility = string(n.Visibility)
+		}
+	}
+	for uid := range targets {
+		// Skip remote voters (Misskey TS は host=NULL のローカル user に
+		// 限定する; リモート user の通知は連合先側で発火する責任)。
+		if w.userRepo != nil {
+			u, err := w.userRepo.FindByID(uid)
+			if err != nil || u == nil {
+				continue
+			}
+			if u.Host != nil && *u.Host != "" {
+				continue
+			}
+		}
+		if w.notifier == nil {
+			continue
+		}
+		if _, err := w.notifier.Create(ctx, notification.CreateInput{
+			NotifieeID:     uid,
+			Type:           notification.TypePollEnded,
+			NoteID:         p.NoteID,
+			NoteVisibility: noteVisibility,
+		}); err != nil {
+			slog.WarnContext(ctx, "poll expiry worker: notify failed",
+				"noteId", p.NoteID, "userId", uid, "err", err)
+		}
+	}
+	if err := w.pollRepo.MarkNotified(p.NoteID, now); err != nil {
+		slog.WarnContext(ctx, "poll expiry worker: mark notified failed",
+			"noteId", p.NoteID, "err", err)
+	}
+}

--- a/internal/core/poll/expiry_worker_test.go
+++ b/internal/core/poll/expiry_worker_test.go
@@ -184,6 +184,56 @@ func TestExpiryWorker_NotifierErrorContinuesBatch(t *testing.T) {
 	require.NotNil(t, pollRepo.Polls["n2"].NotifiedAt)
 }
 
+// TestExpiryWorker_Run_ProcessesBacklogThenStops verifies the loop runs the
+// initial tick (catching up backlog from before startup) and exits cleanly
+// when ctx is cancelled.
+func TestExpiryWorker_Run_ProcessesBacklogThenStops(t *testing.T) {
+	now := time.Date(2026, 5, 4, 12, 0, 0, 0, time.UTC)
+	w, pollRepo, _, noteRepo, userRepo, notif := newWorkerSetup(t, now)
+	w.interval = 50 * time.Millisecond
+	seedLocalUser(userRepo, "alice")
+	seedExpiredPoll(t, pollRepo, noteRepo, "n1", "alice", now.Add(-time.Minute))
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan struct{})
+	go func() {
+		w.Run(ctx)
+		close(done)
+	}()
+
+	require.Eventually(t, func() bool { return len(notif.calls) >= 1 },
+		2*time.Second, 10*time.Millisecond)
+	cancel()
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("worker did not stop after ctx cancel")
+	}
+}
+
+// TestExpiryWorker_Run_NilWorkerNoOp は nil receiver / 未配線 repo の
+// Run() が即 return することを guard する (defensive: Service 構築直後で
+// 配線途中のままだった場合に goroutine が pinned しない)。
+func TestExpiryWorker_Run_NilWorkerNoOp(t *testing.T) {
+	var w *ExpiryWorker
+	w.Run(context.Background())
+	w2 := &ExpiryWorker{}
+	w2.Run(context.Background())
+}
+
+// TestNewExpiryWorker_DefaultsClampInterval covers the constructor's clamp
+// logic: 非正値の interval / batchSize は安全な default に置き換える。
+func TestNewExpiryWorker_DefaultsClampInterval(t *testing.T) {
+	w := NewExpiryWorker(nil, nil, nil, nil, nil, 0, 0)
+	require.NotNil(t, w)
+	assert.Equal(t, 60*time.Second, w.interval)
+	assert.Equal(t, 100, w.batchSize)
+
+	w2 := NewExpiryWorker(nil, nil, nil, nil, nil, -1, -1)
+	assert.Equal(t, 60*time.Second, w2.interval)
+	assert.Equal(t, 100, w2.batchSize)
+}
+
 func TestExpiryWorker_ContextCancelStopsTick(t *testing.T) {
 	now := time.Date(2026, 5, 4, 12, 0, 0, 0, time.UTC)
 	w, pollRepo, _, noteRepo, userRepo, notif := newWorkerSetup(t, now)

--- a/internal/core/poll/expiry_worker_test.go
+++ b/internal/core/poll/expiry_worker_test.go
@@ -1,0 +1,198 @@
+package poll
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/shiroha-a/mk/internal/core/notification"
+	"github.com/shiroha-a/mk/internal/model"
+	"github.com/shiroha-a/mk/internal/testutil"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// recordingNotifier captures CreateInput calls so tests can verify the worker
+// dispatches `pollEnded` to the right user set.
+type recordingNotifier struct {
+	calls []notification.CreateInput
+	err   error
+}
+
+func (r *recordingNotifier) Create(_ context.Context, in notification.CreateInput) (*notification.Notification, error) {
+	r.calls = append(r.calls, in)
+	if r.err != nil {
+		return nil, r.err
+	}
+	// Notification 自体は NotifieeID を直接持たず Redis 鍵で識別するため、
+	// テストでは Type / NoteID のみ詰めて返す。
+	return &notification.Notification{Type: in.Type, NoteID: in.NoteID}, nil
+}
+
+func newWorkerSetup(t *testing.T, now time.Time) (
+	*ExpiryWorker, *testutil.MockPollRepository, *testutil.MockPollVoteRepository,
+	*testutil.MockNoteRepository, *testutil.MockUserRepository, *recordingNotifier,
+) {
+	t.Helper()
+	pollRepo := testutil.NewMockPollRepository()
+	voteRepo := testutil.NewMockPollVoteRepository()
+	noteRepo := testutil.NewMockNoteRepository()
+	userRepo := testutil.NewMockUserRepository()
+	notif := &recordingNotifier{}
+	w := NewExpiryWorker(pollRepo, voteRepo, noteRepo, userRepo, notif, 60*time.Second, 100)
+	w.SetClock(func() time.Time { return now })
+	return w, pollRepo, voteRepo, noteRepo, userRepo, notif
+}
+
+func seedExpiredPoll(t *testing.T, pollRepo *testutil.MockPollRepository, noteRepo *testutil.MockNoteRepository, noteID, authorID string, expiresAt time.Time) {
+	t.Helper()
+	require.NoError(t, noteRepo.Create(&model.Note{ID: noteID, UserID: authorID, HasPoll: true, Visibility: model.NoteVisibilityPublic}))
+	require.NoError(t, pollRepo.Create(&model.Poll{
+		NoteID:    noteID,
+		UserID:    authorID,
+		Choices:   []string{"a", "b"},
+		Votes:     []int64{0, 0},
+		ExpiresAt: &expiresAt,
+	}))
+}
+
+func seedLocalUser(userRepo *testutil.MockUserRepository, id string) {
+	userRepo.Users[id] = &model.User{ID: id}
+}
+
+func seedRemoteUser(userRepo *testutil.MockUserRepository, id, host string) {
+	userRepo.Users[id] = &model.User{ID: id, Host: &host}
+}
+
+func TestExpiryWorker_NotifiesAuthor(t *testing.T) {
+	now := time.Date(2026, 5, 4, 12, 0, 0, 0, time.UTC)
+	w, pollRepo, _, noteRepo, userRepo, notif := newWorkerSetup(t, now)
+	seedLocalUser(userRepo, "alice")
+	seedExpiredPoll(t, pollRepo, noteRepo, "n1", "alice", now.Add(-time.Minute))
+
+	require.NoError(t, w.Tick(context.Background()))
+
+	require.Len(t, notif.calls, 1)
+	assert.Equal(t, "alice", notif.calls[0].NotifieeID)
+	assert.Equal(t, notification.TypePollEnded, notif.calls[0].Type)
+	assert.Equal(t, "n1", notif.calls[0].NoteID)
+	assert.Equal(t, "public", notif.calls[0].NoteVisibility)
+	// notifiedAt is stamped so the next tick skips this poll.
+	require.NotNil(t, pollRepo.Polls["n1"].NotifiedAt)
+}
+
+func TestExpiryWorker_NotifiesAuthorAndLocalVoters(t *testing.T) {
+	now := time.Date(2026, 5, 4, 12, 0, 0, 0, time.UTC)
+	w, pollRepo, voteRepo, noteRepo, userRepo, notif := newWorkerSetup(t, now)
+	seedLocalUser(userRepo, "alice")
+	seedLocalUser(userRepo, "bob")
+	seedLocalUser(userRepo, "charlie")
+	seedExpiredPoll(t, pollRepo, noteRepo, "n1", "alice", now.Add(-time.Minute))
+	require.NoError(t, voteRepo.Create(&model.PollVote{ID: "v1", NoteID: "n1", UserID: "bob", Choice: 0}))
+	require.NoError(t, voteRepo.Create(&model.PollVote{ID: "v2", NoteID: "n1", UserID: "charlie", Choice: 1}))
+
+	require.NoError(t, w.Tick(context.Background()))
+
+	notifiedIDs := []string{}
+	for _, c := range notif.calls {
+		notifiedIDs = append(notifiedIDs, c.NotifieeID)
+	}
+	assert.ElementsMatch(t, []string{"alice", "bob", "charlie"}, notifiedIDs)
+}
+
+func TestExpiryWorker_DedupesAuthorWhoAlsoVoted(t *testing.T) {
+	now := time.Date(2026, 5, 4, 12, 0, 0, 0, time.UTC)
+	w, pollRepo, voteRepo, noteRepo, userRepo, notif := newWorkerSetup(t, now)
+	seedLocalUser(userRepo, "alice")
+	seedExpiredPoll(t, pollRepo, noteRepo, "n1", "alice", now.Add(-time.Minute))
+	// alice votes on her own poll
+	require.NoError(t, voteRepo.Create(&model.PollVote{ID: "v1", NoteID: "n1", UserID: "alice", Choice: 0}))
+
+	require.NoError(t, w.Tick(context.Background()))
+	// Only one notification despite alice being both author and voter.
+	require.Len(t, notif.calls, 1)
+	assert.Equal(t, "alice", notif.calls[0].NotifieeID)
+}
+
+func TestExpiryWorker_SkipsRemoteVoters(t *testing.T) {
+	now := time.Date(2026, 5, 4, 12, 0, 0, 0, time.UTC)
+	w, pollRepo, voteRepo, noteRepo, userRepo, notif := newWorkerSetup(t, now)
+	seedLocalUser(userRepo, "alice")
+	seedRemoteUser(userRepo, "bob_remote", "remote.example")
+	seedExpiredPoll(t, pollRepo, noteRepo, "n1", "alice", now.Add(-time.Minute))
+	require.NoError(t, voteRepo.Create(&model.PollVote{ID: "v1", NoteID: "n1", UserID: "bob_remote", Choice: 0}))
+
+	require.NoError(t, w.Tick(context.Background()))
+
+	// Only the local author gets a notification; remote voter is filtered.
+	require.Len(t, notif.calls, 1)
+	assert.Equal(t, "alice", notif.calls[0].NotifieeID)
+}
+
+func TestExpiryWorker_SkipsAlreadyNotified(t *testing.T) {
+	now := time.Date(2026, 5, 4, 12, 0, 0, 0, time.UTC)
+	w, pollRepo, _, noteRepo, userRepo, notif := newWorkerSetup(t, now)
+	seedLocalUser(userRepo, "alice")
+	seedExpiredPoll(t, pollRepo, noteRepo, "n1", "alice", now.Add(-time.Minute))
+	notified := now.Add(-30 * time.Second)
+	pollRepo.Polls["n1"].NotifiedAt = &notified
+
+	require.NoError(t, w.Tick(context.Background()))
+
+	assert.Empty(t, notif.calls, "already-notified poll must be skipped")
+}
+
+func TestExpiryWorker_SkipsNotYetExpired(t *testing.T) {
+	now := time.Date(2026, 5, 4, 12, 0, 0, 0, time.UTC)
+	w, pollRepo, _, noteRepo, userRepo, notif := newWorkerSetup(t, now)
+	seedLocalUser(userRepo, "alice")
+	// expires in the future
+	seedExpiredPoll(t, pollRepo, noteRepo, "n1", "alice", now.Add(time.Hour))
+
+	require.NoError(t, w.Tick(context.Background()))
+
+	assert.Empty(t, notif.calls)
+	assert.Nil(t, pollRepo.Polls["n1"].NotifiedAt)
+}
+
+func TestExpiryWorker_TickWithNilWorker(t *testing.T) {
+	var w *ExpiryWorker
+	assert.NoError(t, w.Tick(context.Background()))
+}
+
+func TestExpiryWorker_TickWithUnconfiguredRepo(t *testing.T) {
+	w := &ExpiryWorker{}
+	assert.NoError(t, w.Tick(context.Background()))
+}
+
+func TestExpiryWorker_NotifierErrorContinuesBatch(t *testing.T) {
+	now := time.Date(2026, 5, 4, 12, 0, 0, 0, time.UTC)
+	w, pollRepo, _, noteRepo, userRepo, notif := newWorkerSetup(t, now)
+	seedLocalUser(userRepo, "alice")
+	seedLocalUser(userRepo, "bob")
+	seedExpiredPoll(t, pollRepo, noteRepo, "n1", "alice", now.Add(-time.Minute))
+	seedExpiredPoll(t, pollRepo, noteRepo, "n2", "bob", now.Add(-time.Minute))
+	notif.err = errors.New("notify down")
+
+	require.NoError(t, w.Tick(context.Background()))
+
+	// Notifier was called for both polls (best-effort) and both polls were
+	// stamped as notified so the next tick doesn't retry forever.
+	assert.Len(t, notif.calls, 2)
+	require.NotNil(t, pollRepo.Polls["n1"].NotifiedAt)
+	require.NotNil(t, pollRepo.Polls["n2"].NotifiedAt)
+}
+
+func TestExpiryWorker_ContextCancelStopsTick(t *testing.T) {
+	now := time.Date(2026, 5, 4, 12, 0, 0, 0, time.UTC)
+	w, pollRepo, _, noteRepo, userRepo, notif := newWorkerSetup(t, now)
+	seedLocalUser(userRepo, "alice")
+	seedExpiredPoll(t, pollRepo, noteRepo, "n1", "alice", now.Add(-time.Minute))
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	err := w.Tick(ctx)
+	assert.ErrorIs(t, err, context.Canceled)
+	assert.Empty(t, notif.calls)
+}

--- a/internal/core/poll/expiry_worker_test.go
+++ b/internal/core/poll/expiry_worker_test.go
@@ -3,6 +3,7 @@ package poll
 import (
 	"context"
 	"errors"
+	"sync"
 	"testing"
 	"time"
 
@@ -14,20 +15,43 @@ import (
 )
 
 // recordingNotifier captures CreateInput calls so tests can verify the worker
-// dispatches `pollEnded` to the right user set.
+// dispatches `pollEnded` to the right user set. Goroutine-safe because
+// ExpiryWorker.Run の goroutine から writes が来る一方で test の assertion
+// 経路 (require.Eventually の polling) が並行読みする — `-race` 検出を
+// 防ぐため mu で保護する。
 type recordingNotifier struct {
+	mu    sync.Mutex
 	calls []notification.CreateInput
 	err   error
 }
 
 func (r *recordingNotifier) Create(_ context.Context, in notification.CreateInput) (*notification.Notification, error) {
+	r.mu.Lock()
 	r.calls = append(r.calls, in)
-	if r.err != nil {
-		return nil, r.err
+	err := r.err
+	r.mu.Unlock()
+	if err != nil {
+		return nil, err
 	}
 	// Notification 自体は NotifieeID を直接持たず Redis 鍵で識別するため、
 	// テストでは Type / NoteID のみ詰めて返す。
 	return &notification.Notification{Type: in.Type, NoteID: in.NoteID}, nil
+}
+
+// snapshot returns a copy of calls under the mutex so tests can iterate
+// safely without racing the writer goroutine.
+func (r *recordingNotifier) snapshot() []notification.CreateInput {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	out := make([]notification.CreateInput, len(r.calls))
+	copy(out, r.calls)
+	return out
+}
+
+func (r *recordingNotifier) callCount() int {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return len(r.calls)
 }
 
 func newWorkerSetup(t *testing.T, now time.Time) (
@@ -73,11 +97,11 @@ func TestExpiryWorker_NotifiesAuthor(t *testing.T) {
 
 	require.NoError(t, w.Tick(context.Background()))
 
-	require.Len(t, notif.calls, 1)
-	assert.Equal(t, "alice", notif.calls[0].NotifieeID)
-	assert.Equal(t, notification.TypePollEnded, notif.calls[0].Type)
-	assert.Equal(t, "n1", notif.calls[0].NoteID)
-	assert.Equal(t, "public", notif.calls[0].NoteVisibility)
+	require.Len(t, notif.snapshot(), 1)
+	assert.Equal(t, "alice", notif.snapshot()[0].NotifieeID)
+	assert.Equal(t, notification.TypePollEnded, notif.snapshot()[0].Type)
+	assert.Equal(t, "n1", notif.snapshot()[0].NoteID)
+	assert.Equal(t, "public", notif.snapshot()[0].NoteVisibility)
 	// notifiedAt is stamped so the next tick skips this poll.
 	require.NotNil(t, pollRepo.Polls["n1"].NotifiedAt)
 }
@@ -95,7 +119,7 @@ func TestExpiryWorker_NotifiesAuthorAndLocalVoters(t *testing.T) {
 	require.NoError(t, w.Tick(context.Background()))
 
 	notifiedIDs := []string{}
-	for _, c := range notif.calls {
+	for _, c := range notif.snapshot() {
 		notifiedIDs = append(notifiedIDs, c.NotifieeID)
 	}
 	assert.ElementsMatch(t, []string{"alice", "bob", "charlie"}, notifiedIDs)
@@ -111,8 +135,8 @@ func TestExpiryWorker_DedupesAuthorWhoAlsoVoted(t *testing.T) {
 
 	require.NoError(t, w.Tick(context.Background()))
 	// Only one notification despite alice being both author and voter.
-	require.Len(t, notif.calls, 1)
-	assert.Equal(t, "alice", notif.calls[0].NotifieeID)
+	require.Len(t, notif.snapshot(), 1)
+	assert.Equal(t, "alice", notif.snapshot()[0].NotifieeID)
 }
 
 func TestExpiryWorker_SkipsRemoteVoters(t *testing.T) {
@@ -126,8 +150,8 @@ func TestExpiryWorker_SkipsRemoteVoters(t *testing.T) {
 	require.NoError(t, w.Tick(context.Background()))
 
 	// Only the local author gets a notification; remote voter is filtered.
-	require.Len(t, notif.calls, 1)
-	assert.Equal(t, "alice", notif.calls[0].NotifieeID)
+	require.Len(t, notif.snapshot(), 1)
+	assert.Equal(t, "alice", notif.snapshot()[0].NotifieeID)
 }
 
 func TestExpiryWorker_SkipsAlreadyNotified(t *testing.T) {
@@ -140,7 +164,7 @@ func TestExpiryWorker_SkipsAlreadyNotified(t *testing.T) {
 
 	require.NoError(t, w.Tick(context.Background()))
 
-	assert.Empty(t, notif.calls, "already-notified poll must be skipped")
+	assert.Empty(t, notif.snapshot(), "already-notified poll must be skipped")
 }
 
 func TestExpiryWorker_SkipsNotYetExpired(t *testing.T) {
@@ -152,7 +176,7 @@ func TestExpiryWorker_SkipsNotYetExpired(t *testing.T) {
 
 	require.NoError(t, w.Tick(context.Background()))
 
-	assert.Empty(t, notif.calls)
+	assert.Empty(t, notif.snapshot())
 	assert.Nil(t, pollRepo.Polls["n1"].NotifiedAt)
 }
 
@@ -179,7 +203,7 @@ func TestExpiryWorker_NotifierErrorContinuesBatch(t *testing.T) {
 
 	// Notifier was called for both polls (best-effort) and both polls were
 	// stamped as notified so the next tick doesn't retry forever.
-	assert.Len(t, notif.calls, 2)
+	assert.Len(t, notif.snapshot(), 2)
 	require.NotNil(t, pollRepo.Polls["n1"].NotifiedAt)
 	require.NotNil(t, pollRepo.Polls["n2"].NotifiedAt)
 }
@@ -201,7 +225,7 @@ func TestExpiryWorker_Run_ProcessesBacklogThenStops(t *testing.T) {
 		close(done)
 	}()
 
-	require.Eventually(t, func() bool { return len(notif.calls) >= 1 },
+	require.Eventually(t, func() bool { return notif.callCount() >= 1 },
 		2*time.Second, 10*time.Millisecond)
 	cancel()
 	select {
@@ -244,5 +268,5 @@ func TestExpiryWorker_ContextCancelStopsTick(t *testing.T) {
 	cancel()
 	err := w.Tick(ctx)
 	assert.ErrorIs(t, err, context.Canceled)
-	assert.Empty(t, notif.calls)
+	assert.Empty(t, notif.snapshot())
 }

--- a/internal/core/poll/poll_service.go
+++ b/internal/core/poll/poll_service.go
@@ -33,6 +33,26 @@ type NotificationHook interface {
 	OnPollVote(notifieeID, notifierID, noteID string, choice int)
 }
 
+// NoteEventPublisher emits a `noteUpdated` sub-event (e.g. pollVoted) on the
+// note's pubsub topic so subscribers (frontend WebSocket clients viewing the
+// note) get real-time updates without reloading. 循環依存回避のため interface
+// で受け取り、実装は internal/stream にある (#690 follow-up)。
+type NoteEventPublisher interface {
+	PublishToNoteStream(noteID string, eventType string, body any)
+}
+
+// FederationDeliveryHook delivers poll-related AP activities. Two paths:
+//   - OnVote: local user voted on a REMOTE poll → AP Note (vote) → author inbox
+//   - OnLocalPollUpdated: local poll's vote count changed (someone voted) →
+//     AP Update(Question) → all remote followers, so they refresh counts
+//     without re-fetching (#690)。
+//
+// 循環依存回避のため interface で受け取る (実装は core/federation)。
+type FederationDeliveryHook interface {
+	OnVote(voter *model.User, target *model.Note, choice int, choiceName string)
+	OnLocalPollUpdated(target *model.Note)
+}
+
 // Service manages poll voting.
 type Service struct {
 	noteRepo         repository.NoteRepository
@@ -41,6 +61,8 @@ type Service struct {
 	followingRepo    repository.FollowingRepository
 	idGen            id.Generator
 	notificationHook NotificationHook
+	eventPub         NoteEventPublisher
+	federationHook   FederationDeliveryHook
 	nowFn            func() time.Time
 }
 
@@ -66,6 +88,21 @@ func NewService(
 // SetNotificationHook attaches a NotificationHook used after a successful vote.
 func (s *Service) SetNotificationHook(h NotificationHook) {
 	s.notificationHook = h
+}
+
+// SetEventPublisher attaches a NoteEventPublisher used to broadcast pollVoted
+// events to subscribers of the target note. nil 配線時は publish skip
+// (フロントは reload で count を取り直すフォールバックに頼る、#690)。
+func (s *Service) SetEventPublisher(p NoteEventPublisher) {
+	s.eventPub = p
+}
+
+// SetFederationHook attaches a FederationDeliveryHook used after a vote is
+// recorded on a remote poll, so the choice is propagated to the remote
+// author's inbox via AP. nil 配線時は配信 skip — local-only deployments
+// で federation infra を持たないテスト環境でも poll が動く。
+func (s *Service) SetFederationHook(h FederationDeliveryHook) {
+	s.federationHook = h
 }
 
 // Vote records a vote for the given user/note/choice.
@@ -123,10 +160,37 @@ func (s *Service) Vote(user *model.User, noteID string, choice int) error {
 	}
 	_ = s.pollRepo.IncrementVote(target.ID, choice, 1)
 
-	// 投票通知 (自分のノートへの投票はスキップ)
-	if s.notificationHook != nil && target.UserID != user.ID {
-		s.notificationHook.OnPollVote(target.UserID, user.ID, target.ID, choice)
+	// pollVoted を note の stream topic に publish して subscribe 中の
+	// frontend (note 詳細画面 / timeline) が reload なしで count を更新
+	// できるようにする (#690)。Misskey TS の PollService.vote と同じ payload。
+	if s.eventPub != nil {
+		s.eventPub.PublishToNoteStream(target.ID, "pollVoted", map[string]any{
+			"choice": choice,
+			"userId": user.ID,
+		})
 	}
+
+	// target が remote ならば AP Note (with name + inReplyTo) を author の
+	// inbox に配信して向こう側でも count に反映させる (#690)。local poll や
+	// hook 未配線時は no-op。
+	if s.federationHook != nil {
+		if target.UserHost != nil && *target.UserHost != "" {
+			s.federationHook.OnVote(user, target, choice, p.Choices[choice])
+		} else {
+			// target は local poll: 投票で更新された count を AP
+			// Update(Question) として follower に push する。これがないと
+			// 連合先 instance が古い count のままになる (Misskey TS の
+			// PollService.deliverQuestionUpdate と同等)。
+			s.federationHook.OnLocalPollUpdated(target)
+		}
+	}
+
+	// Misskey TS には per-vote の通知が無く (frontend の notification type にも
+	// 存在しない) ため、mk-go でも notificationHook.OnPollVote は呼び出さない。
+	// 過去の配線を残すと frontend が unknown type の notification を空 (= 「無」)
+	// で render してしまう (#690 user 報告)。pollEnded (期限切れ) は upstream
+	// にあるが本 service の責務外で別 path から発火する想定。
+	_ = s.notificationHook
 
 	return nil
 }

--- a/internal/core/poll/poll_service_test.go
+++ b/internal/core/poll/poll_service_test.go
@@ -186,27 +186,18 @@ func (h *recordingHook) OnPollVote(notifieeID, notifierID, noteID string, choice
 	h.choice = choice
 }
 
-func TestVote_NotificationHook(t *testing.T) {
+// TestVote_DoesNotInvokeNotificationHook: Misskey TS には per-vote の
+// notification 種別が無く (frontend が unknown type で空 body の通知を出して
+// しまう) ため mk-go でも hook を呼ばない契約 (#690)。NotificationHook 自体は
+// 別 path (例: pollEnded) で再利用される可能性があるので interface は残す。
+func TestVote_DoesNotInvokeNotificationHook(t *testing.T) {
 	svc, noteRepo, pollRepo, _ := newSvc(t)
 	seedPollNote(noteRepo, pollRepo, "n1", "author", false, nil)
 	hook := &recordingHook{}
 	svc.SetNotificationHook(hook)
 
 	require.NoError(t, svc.Vote(&model.User{ID: "viewer"}, "n1", 0))
-	assert.True(t, hook.called)
-	assert.Equal(t, "author", hook.notifiee)
-	assert.Equal(t, "viewer", hook.notifier)
-	assert.Equal(t, 0, hook.choice)
-}
-
-func TestVote_NotificationHookSelfSkipped(t *testing.T) {
-	svc, noteRepo, pollRepo, _ := newSvc(t)
-	seedPollNote(noteRepo, pollRepo, "n1", "viewer", false, nil)
-	hook := &recordingHook{}
-	svc.SetNotificationHook(hook)
-
-	require.NoError(t, svc.Vote(&model.User{ID: "viewer"}, "n1", 0))
-	assert.False(t, hook.called)
+	assert.False(t, hook.called, "vote must not trigger pollVote notification (Misskey TS has no such type)")
 }
 
 func TestVote_HappyPathIncrementsVotes(t *testing.T) {

--- a/internal/core/poll/poll_service_test.go
+++ b/internal/core/poll/poll_service_test.go
@@ -126,6 +126,91 @@ func TestVote_MultipleAllowed(t *testing.T) {
 	assert.Equal(t, int64(1), pollRepo.Polls["n1"].Votes[1])
 }
 
+// stubEventPub captures pollVoted events so we can assert the streaming path.
+type stubEventPub struct {
+	noteID    string
+	eventType string
+	body      any
+	calls     int
+}
+
+func (s *stubEventPub) PublishToNoteStream(noteID, eventType string, body any) {
+	s.calls++
+	s.noteID = noteID
+	s.eventType = eventType
+	s.body = body
+}
+
+// stubFedHook captures federation hook fan-out so we can assert local vs
+// remote routing.
+type stubFedHook struct {
+	voteCalls   int
+	updateCalls int
+	lastChoice  int
+	lastName    string
+	lastTarget  string
+}
+
+func (s *stubFedHook) OnVote(voter *model.User, target *model.Note, choice int, choiceName string) {
+	s.voteCalls++
+	s.lastChoice = choice
+	s.lastName = choiceName
+	s.lastTarget = target.ID
+}
+func (s *stubFedHook) OnLocalPollUpdated(target *model.Note) {
+	s.updateCalls++
+	s.lastTarget = target.ID
+}
+
+func TestVote_PublishesPollVotedEvent(t *testing.T) {
+	svc, noteRepo, pollRepo, _ := newSvc(t)
+	seedPollNote(noteRepo, pollRepo, "n1", "author", false, nil)
+	pub := &stubEventPub{}
+	svc.SetEventPublisher(pub)
+
+	require.NoError(t, svc.Vote(&model.User{ID: "viewer"}, "n1", 1))
+	assert.Equal(t, 1, pub.calls)
+	assert.Equal(t, "n1", pub.noteID)
+	assert.Equal(t, "pollVoted", pub.eventType)
+	body := pub.body.(map[string]any)
+	assert.Equal(t, 1, body["choice"])
+	assert.Equal(t, "viewer", body["userId"])
+}
+
+func TestVote_LocalPollFiresOnLocalPollUpdated(t *testing.T) {
+	svc, noteRepo, pollRepo, _ := newSvc(t)
+	seedPollNote(noteRepo, pollRepo, "n_local", "author", false, nil)
+	// note.UserHost is nil (default) -> local
+	hook := &stubFedHook{}
+	svc.SetFederationHook(hook)
+
+	require.NoError(t, svc.Vote(&model.User{ID: "viewer"}, "n_local", 0))
+	assert.Equal(t, 0, hook.voteCalls, "local poll must NOT trigger OnVote")
+	assert.Equal(t, 1, hook.updateCalls, "local poll vote must trigger OnLocalPollUpdated")
+	assert.Equal(t, "n_local", hook.lastTarget)
+}
+
+func TestVote_RemotePollFiresOnVote(t *testing.T) {
+	svc, noteRepo, pollRepo, _ := newSvc(t)
+	host := "remote.example"
+	noteRepo.Notes["n_remote"] = &model.Note{
+		ID: "n_remote", UserID: "remoteUser", Visibility: model.NoteVisibilityPublic,
+		HasPoll: true, UserHost: &host,
+	}
+	pollRepo.Polls["n_remote"] = &model.Poll{
+		NoteID: "n_remote", Multiple: false,
+		Choices: pq.StringArray{"X", "Y"}, Votes: pq.Int64Array{0, 0},
+	}
+	hook := &stubFedHook{}
+	svc.SetFederationHook(hook)
+
+	require.NoError(t, svc.Vote(&model.User{ID: "viewer"}, "n_remote", 1))
+	assert.Equal(t, 1, hook.voteCalls, "remote poll vote must trigger OnVote")
+	assert.Equal(t, 0, hook.updateCalls, "remote poll vote must NOT trigger OnLocalPollUpdated")
+	assert.Equal(t, 1, hook.lastChoice)
+	assert.Equal(t, "Y", hook.lastName)
+}
+
 // failingPollVoteRepo lets us trigger CountByUserAndNote / Create errors.
 type failingPollVoteRepo struct {
 	*testutil.MockPollVoteRepository

--- a/internal/entity/note.go
+++ b/internal/entity/note.go
@@ -98,6 +98,38 @@ func PackNote(n *model.Note, idGen id.Generator) NoteEntity {
 	return packNoteAtDepth(n, idGen, 0)
 }
 
+// packPoll maps a preloaded model.Poll onto the Misskey-compatible PollEntity.
+// nil 入力 (Poll relation が preload されていない / hasPoll=false) は nil を
+// 返し、上位の `json:"poll,omitempty"` で response から省略させる。
+//
+// IsVoted は viewer context が無いと判定できないため常に false で埋める
+// (#690 の最小修正範囲)。viewer の vote 判定は別 path で enrich する想定で、
+// 投稿直後の create response では「自分の投稿に自分はまだ vote していない」
+// が常に正解なので false 固定でも frontend 表示は正しい。
+func packPoll(p *model.Poll) *PollEntity {
+	if p == nil {
+		return nil
+	}
+	choices := make([]PollChoice, len(p.Choices))
+	for i, text := range p.Choices {
+		votes := 0
+		if i < len(p.Votes) {
+			votes = int(p.Votes[i])
+		}
+		choices[i] = PollChoice{Text: text, Votes: votes, IsVoted: false}
+	}
+	var expiresAt *string
+	if p.ExpiresAt != nil {
+		s := p.ExpiresAt.UTC().Format("2006-01-02T15:04:05.000Z")
+		expiresAt = &s
+	}
+	return &PollEntity{
+		ExpiresAt: expiresAt,
+		Multiple:  p.Multiple,
+		Choices:   choices,
+	}
+}
+
 func packNoteAtDepth(n *model.Note, idGen id.Generator, depth int) NoteEntity {
 	createdAt := ""
 	if t, err := idGen.ParseTime(n.ID); err == nil {
@@ -146,6 +178,7 @@ func packNoteAtDepth(n *model.Note, idGen id.Generator, depth int) NoteEntity {
 		VisibleUserIDs:     visibleUserIDs,
 		Mentions:           mentions,
 		HasPoll:            n.HasPoll,
+		Poll:               packPoll(n.Poll),
 	}
 
 	if n.User != nil {

--- a/internal/entity/note_field_resolver.go
+++ b/internal/entity/note_field_resolver.go
@@ -34,6 +34,13 @@ type ChannelLookup interface {
 	FindByIDs(ids []string) ([]*model.Channel, error)
 }
 
+// PollVoteLookup batch-fetches the viewer's votes across multiple notes so
+// the resolver can mark Poll.choices[i].IsVoted=true for the choices the
+// viewer has cast a vote on (#690). Returns noteID → []choice index.
+type PollVoteLookup interface {
+	FindByUserAndNoteIDs(userID string, noteIDs []string) (map[string][]int, error)
+}
+
 // NoteFieldResolver applies post-pack file / viewer-dependent / channel
 // resolution to packed NoteEntity slices including their embedded Renote /
 // Reply targets (#426)。
@@ -50,6 +57,7 @@ type NoteFieldResolver struct {
 	fileOwner    FileOwnerLookup
 	noteReaction NoteReactionLookup
 	channel      ChannelLookup
+	pollVote     PollVoteLookup
 	idGen        id.Generator
 }
 
@@ -65,6 +73,16 @@ func NewNoteFieldResolver(driveFile DriveFileLookup, driveFolder DriveFolderLook
 		channel:      channel,
 		idGen:        idGen,
 	}
+}
+
+// SetPollVoteLookup attaches a PollVoteLookup so ResolveViewerFields populates
+// Poll.choices[i].IsVoted for the viewer (#690). Setter rather than
+// constructor arg to keep New… signature stable for existing call sites.
+func (r *NoteFieldResolver) SetPollVoteLookup(p PollVoteLookup) {
+	if r == nil {
+		return
+	}
+	r.pollVote = p
 }
 
 // Apply runs ResolveFiles + ResolveViewerFields in order. caller の典型 1 行
@@ -121,6 +139,23 @@ func (r *NoteFieldResolver) ResolveViewerFields(notes []NoteEntity, viewer *mode
 			if err == nil {
 				for i := range notes {
 					applyMyReaction(&notes[i], reactionMap)
+				}
+			}
+		}
+	}
+	// Poll.choices[i].IsVoted を viewer の poll_vote から populate (#690)。
+	// frontend MkPoll の `showResult = isVoted || closed` 判定が reload 後も
+	// true 維持されるため、結果表示 toggle が永続化される。
+	if viewer != nil && r.pollVote != nil {
+		var pollNoteIDs []string
+		for i := range notes {
+			pollNoteIDs = appendPollNoteIDs(pollNoteIDs, &notes[i])
+		}
+		if len(pollNoteIDs) > 0 {
+			voteMap, err := r.pollVote.FindByUserAndNoteIDs(viewer.ID, pollNoteIDs)
+			if err == nil {
+				for i := range notes {
+					applyMyPollVotes(&notes[i], voteMap)
 				}
 			}
 		}
@@ -238,6 +273,52 @@ func appendNoteIDs(dst []string, n *NoteEntity) []string {
 		dst = append(dst, n.Reply.ID)
 	}
 	return dst
+}
+
+// appendPollNoteIDs collects note IDs that have an attached poll (top-level
+// + Renote / Reply embed) so the viewer's votes can be batch-fetched.
+func appendPollNoteIDs(dst []string, n *NoteEntity) []string {
+	if n == nil {
+		return dst
+	}
+	if n.Poll != nil {
+		dst = append(dst, n.ID)
+	}
+	if n.Renote != nil && n.Renote.Poll != nil {
+		dst = append(dst, n.Renote.ID)
+	}
+	if n.Reply != nil && n.Reply.Poll != nil {
+		dst = append(dst, n.Reply.ID)
+	}
+	return dst
+}
+
+// applyMyPollVotes marks Poll.choices[i].IsVoted=true for the viewer's
+// recorded choices (#690). Operates on top-level + Renote / Reply embed.
+func applyMyPollVotes(n *NoteEntity, voteMap map[string][]int) {
+	if n == nil {
+		return
+	}
+	if n.Poll != nil {
+		applyVotedChoices(n.Poll, voteMap[n.ID])
+	}
+	if n.Renote != nil && n.Renote.Poll != nil {
+		applyVotedChoices(n.Renote.Poll, voteMap[n.Renote.ID])
+	}
+	if n.Reply != nil && n.Reply.Poll != nil {
+		applyVotedChoices(n.Reply.Poll, voteMap[n.Reply.ID])
+	}
+}
+
+func applyVotedChoices(p *PollEntity, choices []int) {
+	if p == nil || len(choices) == 0 {
+		return
+	}
+	for _, idx := range choices {
+		if idx >= 0 && idx < len(p.Choices) {
+			p.Choices[idx].IsVoted = true
+		}
+	}
 }
 
 func appendNoteChannelIDs(dst []string, n *NoteEntity) []string {

--- a/internal/model/note.go
+++ b/internal/model/note.go
@@ -57,6 +57,10 @@ type Note struct {
 	Reply  *Note `gorm:"foreignKey:ReplyID" json:"reply,omitempty"`
 	Renote *Note `gorm:"foreignKey:RenoteID" json:"renote,omitempty"`
 	User   *User `gorm:"foreignKey:UserID" json:"user,omitempty"`
+	// Poll は note.id ↔ poll.noteId の 1:1 リレーション。Preload しない経路
+	// (FindByID 単発など) では nil のまま。entity.PackNote が non-nil の
+	// ときだけ poll フィールドを response に詰める (#690)。
+	Poll *Poll `gorm:"foreignKey:NoteID;references:ID" json:"poll,omitempty"`
 }
 
 func (Note) TableName() string { return "note" }

--- a/internal/model/poll.go
+++ b/internal/model/poll.go
@@ -18,6 +18,11 @@ type Poll struct {
 	UserID    string  `gorm:"column:userId;type:varchar(32)" json:"userId"`
 	UserHost  *string `gorm:"column:userHost;type:varchar(128)" json:"userHost"`
 	ChannelID *string `gorm:"column:channelId;type:varchar(32)" json:"channelId"`
+	// NotifiedAt は expiresAt 経過後の pollEnded 通知が著者 + 投票者に発火
+	// 済みかを記録する (#690)。NULL = まだ送ってない、NOT NULL = 送信済み。
+	// periodic ticker (core/poll/expiry_worker) が WHERE expiresAt < NOW()
+	// AND notifiedAt IS NULL で scan して二重通知を防ぐ。
+	NotifiedAt *time.Time `gorm:"column:notifiedAt;type:timestamp with time zone" json:"notifiedAt,omitempty"`
 
 	// Relations
 	Note *Note `gorm:"foreignKey:NoteID" json:"note,omitempty"`

--- a/internal/repository/note.go
+++ b/internal/repository/note.go
@@ -118,12 +118,19 @@ func NewNoteRepository(db *gorm.DB) NoteRepository {
 // reply/renote targets (with their authors). NoteEntity の packer は
 // renote/reply の target note を埋めるためこれらの preload が必須。
 // GORM の preload は明示した relation しか辿らないので N+1 には成らない。
+//
+// Poll は note.hasPoll==true のとき 1:1 で attach する (#690)。Preload は
+// 自動的に hasPoll=false の note では何も読まないので overhead は小さい
+// (発行されるのは poll table への 1 IN 句 query)。
 func preloadNoteRelations(db *gorm.DB) *gorm.DB {
 	return db.Preload("User").
 		Preload("Renote").
 		Preload("Renote.User").
+		Preload("Renote.Poll").
 		Preload("Reply").
-		Preload("Reply.User")
+		Preload("Reply.User").
+		Preload("Reply.Poll").
+		Preload("Poll")
 }
 
 func (r *noteRepository) Create(note *model.Note) error {

--- a/internal/repository/poll.go
+++ b/internal/repository/poll.go
@@ -2,6 +2,7 @@ package repository
 
 import (
 	"fmt"
+	"time"
 
 	"github.com/shiroha-a/mk/internal/model"
 	"gorm.io/gorm"
@@ -12,6 +13,15 @@ type PollRepository interface {
 	Create(poll *model.Poll) error
 	FindByNoteID(noteID string) (*model.Poll, error)
 	IncrementVote(noteID string, choice int, delta int) error
+	// ListExpiredUnnotified returns polls whose expiresAt has passed and have
+	// not yet been pollEnded-notified. Used by core/poll.ExpiryWorker (#690)。
+	// limit caps the batch so a long backlog (e.g. after restart) doesn't
+	// dominate one tick.
+	ListExpiredUnnotified(now time.Time, limit int) ([]*model.Poll, error)
+	// MarkNotified stamps poll.notifiedAt for the given note so subsequent
+	// ticker scans skip it. idempotent — calling twice with the same time is
+	// harmless.
+	MarkNotified(noteID string, t time.Time) error
 }
 
 type pollRepository struct {
@@ -43,4 +53,30 @@ func (r *pollRepository) IncrementVote(noteID string, choice int, delta int) err
 	pgChoice := choice + 1
 	q := fmt.Sprintf(`UPDATE "poll" SET votes[%d] = votes[%d] + ? WHERE "noteId" = ?`, pgChoice, pgChoice)
 	return r.db.Exec(q, delta, noteID).Error
+}
+
+// ListExpiredUnnotified returns up to `limit` polls with expiresAt < now and
+// notifiedAt IS NULL. partial index IDX_poll_expired_unnotified が migration
+// で作られている前提。
+func (r *pollRepository) ListExpiredUnnotified(now time.Time, limit int) ([]*model.Poll, error) {
+	if limit <= 0 {
+		limit = 100
+	}
+	var rows []*model.Poll
+	if err := r.db.
+		Where(`"expiresAt" IS NOT NULL AND "expiresAt" < ? AND "notifiedAt" IS NULL`, now).
+		Order(`"expiresAt" ASC`).
+		Limit(limit).
+		Find(&rows).Error; err != nil {
+		return nil, err
+	}
+	return rows, nil
+}
+
+// MarkNotified stamps poll.notifiedAt = t for the given note. concurrent
+// ticker や retry でも単純な UPDATE 1 行なので冪等。
+func (r *pollRepository) MarkNotified(noteID string, t time.Time) error {
+	return r.db.Model(&model.Poll{}).
+		Where(`"noteId" = ?`, noteID).
+		Update("notifiedAt", t).Error
 }

--- a/internal/repository/poll_test.go
+++ b/internal/repository/poll_test.go
@@ -2,6 +2,7 @@ package repository
 
 import (
 	"testing"
+	"time"
 
 	"github.com/lib/pq"
 	"github.com/shiroha-a/mk/internal/model"
@@ -42,4 +43,108 @@ func TestPollRepository_Create(t *testing.T) {
 	assert.Equal(t, note.ID, found.NoteID)
 	assert.Len(t, found.Choices, 3)
 	assert.False(t, found.Multiple)
+}
+
+// TestPollRepository_ListExpiredUnnotified covers the ticker scan path
+// added in #690 (ExpiryWorker)。partial index 経由のクエリ条件
+// (expiresAt < now AND notifiedAt IS NULL) が正しく適用され、limit が効く
+// ことを guard する。
+func TestPollRepository_ListExpiredUnnotified(t *testing.T) {
+	repo := NewPollRepository(testDB)
+	user := insertTestUser(t, "u_lex_1", "lexuser")
+	defer cleanupUser(t, user.ID)
+
+	now := time.Now()
+	past := now.Add(-time.Hour)
+	future := now.Add(time.Hour)
+
+	// 3 種類の poll を seed: 期限切れ未通知 / 期限切れ通知済 / 未満了
+	mk := func(id string, expires time.Time, notified *time.Time) {
+		note := &model.Note{ID: id, UserID: user.ID, Visibility: model.NoteVisibilityPublic, HasPoll: true, Reactions: datatypes.JSON([]byte("{}"))}
+		require.NoError(t, testDB.Create(note).Error)
+		t.Cleanup(func() { cleanupNote(t, note.ID) })
+		p := &model.Poll{
+			NoteID: id, Multiple: false,
+			Choices: pq.StringArray{"a"}, Votes: pq.Int64Array{0},
+			NoteVisibility: model.NoteVisibilityPublic, UserID: user.ID,
+			ExpiresAt:  &expires,
+			NotifiedAt: notified,
+		}
+		require.NoError(t, repo.Create(p))
+	}
+	mk("p_lex_expired1", past, nil)
+	mk("p_lex_expired2", past.Add(-time.Minute), nil)
+	notified := past.Add(time.Minute)
+	mk("p_lex_already", past, &notified)
+	mk("p_lex_future", future, nil)
+
+	rows, err := repo.ListExpiredUnnotified(now, 10)
+	require.NoError(t, err)
+	ids := []string{}
+	for _, r := range rows {
+		ids = append(ids, r.NoteID)
+	}
+	// 期限切れ未通知の 2 件のみ、ASC で並ぶ (古い方が先)
+	assert.Equal(t, []string{"p_lex_expired2", "p_lex_expired1"}, ids)
+}
+
+func TestPollRepository_ListExpiredUnnotified_LimitCap(t *testing.T) {
+	repo := NewPollRepository(testDB)
+	user := insertTestUser(t, "u_lim_1", "limuser")
+	defer cleanupUser(t, user.ID)
+
+	now := time.Now()
+	past := now.Add(-time.Hour)
+
+	// limit=0 / 負数のとき内部で 100 にクランプされる
+	for i := 0; i < 3; i++ {
+		nid := "p_lim_" + string(rune('a'+i))
+		note := &model.Note{ID: nid, UserID: user.ID, Visibility: model.NoteVisibilityPublic, HasPoll: true, Reactions: datatypes.JSON([]byte("{}"))}
+		require.NoError(t, testDB.Create(note).Error)
+		t.Cleanup(func() { cleanupNote(t, nid) })
+		p := &model.Poll{NoteID: nid, Choices: pq.StringArray{"x"}, Votes: pq.Int64Array{0}, NoteVisibility: model.NoteVisibilityPublic, UserID: user.ID, ExpiresAt: &past}
+		require.NoError(t, repo.Create(p))
+	}
+
+	rows, err := repo.ListExpiredUnnotified(now, 1)
+	require.NoError(t, err)
+	assert.Len(t, rows, 1)
+
+	rows, err = repo.ListExpiredUnnotified(now, 0)
+	require.NoError(t, err)
+	assert.GreaterOrEqual(t, len(rows), 3)
+}
+
+func TestPollRepository_MarkNotified(t *testing.T) {
+	repo := NewPollRepository(testDB)
+	user := insertTestUser(t, "u_mn_1", "mnuser")
+	defer cleanupUser(t, user.ID)
+
+	noteID := "n_mn_1"
+	note := &model.Note{ID: noteID, UserID: user.ID, Visibility: model.NoteVisibilityPublic, HasPoll: true, Reactions: datatypes.JSON([]byte("{}"))}
+	require.NoError(t, testDB.Create(note).Error)
+	defer cleanupNote(t, noteID)
+
+	expires := time.Now().Add(-time.Hour)
+	require.NoError(t, repo.Create(&model.Poll{
+		NoteID: noteID, Choices: pq.StringArray{"a"}, Votes: pq.Int64Array{0},
+		NoteVisibility: model.NoteVisibilityPublic, UserID: user.ID,
+		ExpiresAt: &expires,
+	}))
+
+	// 未通知状態
+	pre, err := repo.FindByNoteID(noteID)
+	require.NoError(t, err)
+	assert.Nil(t, pre.NotifiedAt)
+
+	now := time.Now()
+	require.NoError(t, repo.MarkNotified(noteID, now))
+
+	post, err := repo.FindByNoteID(noteID)
+	require.NoError(t, err)
+	require.NotNil(t, post.NotifiedAt)
+	assert.WithinDuration(t, now, *post.NotifiedAt, time.Second)
+
+	// 不在 noteID でも no-op (= no error)
+	require.NoError(t, repo.MarkNotified("nonexistent", now))
 }

--- a/internal/repository/poll_vote.go
+++ b/internal/repository/poll_vote.go
@@ -11,6 +11,11 @@ type PollVoteRepository interface {
 	FindByUserAndChoice(userID, noteID string, choice int) (*model.PollVote, error)
 	CountByUserAndNote(userID, noteID string) (int64, error)
 	ListByNoteID(noteID string) ([]*model.PollVote, error)
+	// FindByUserAndNoteIDs batch-fetches the viewer's votes across multiple
+	// notes so entity.NoteFieldResolver can populate Poll.choices[i].IsVoted
+	// in one query (#690). 戻り値は noteID → 投票した choice index list。
+	// 空 noteIDs 入力は空 map を返す (no DB call)。
+	FindByUserAndNoteIDs(userID string, noteIDs []string) (map[string][]int, error)
 }
 
 type pollVoteRepository struct {
@@ -58,4 +63,23 @@ func (r *pollVoteRepository) ListByNoteID(noteID string) ([]*model.PollVote, err
 		return nil, err
 	}
 	return rows, nil
+}
+
+// FindByUserAndNoteIDs returns the viewer's votes grouped by noteID. Used by
+// entity.NoteFieldResolver to mark Poll.choices[i].IsVoted (#690).
+func (r *pollVoteRepository) FindByUserAndNoteIDs(userID string, noteIDs []string) (map[string][]int, error) {
+	if userID == "" || len(noteIDs) == 0 {
+		return map[string][]int{}, nil
+	}
+	var rows []*model.PollVote
+	if err := r.db.
+		Where("\"userId\" = ? AND \"noteId\" IN ?", userID, noteIDs).
+		Find(&rows).Error; err != nil {
+		return nil, err
+	}
+	out := make(map[string][]int, len(rows))
+	for _, v := range rows {
+		out[v.NoteID] = append(out[v.NoteID], v.Choice)
+	}
+	return out, nil
 }

--- a/internal/repository/poll_vote_test.go
+++ b/internal/repository/poll_vote_test.go
@@ -84,6 +84,49 @@ func TestPollVoteRepository_QueryErrors(t *testing.T) {
 	assert.Error(t, err)
 	_, err = repo.ListByNoteID("a")
 	assert.Error(t, err)
+	_, err = repo.FindByUserAndNoteIDs("a", []string{"b"})
+	assert.Error(t, err)
+}
+
+// TestPollVoteRepository_FindByUserAndNoteIDs covers the batch lookup added
+// in #690 for entity.NoteFieldResolver to populate Poll.choices[i].IsVoted.
+func TestPollVoteRepository_FindByUserAndNoteIDs(t *testing.T) {
+	repo := NewPollVoteRepository(testDB)
+	user := insertTestUser(t, "u_fbun_1", "fbunuser")
+	defer cleanupUser(t, user.ID)
+	setupPollNote(t, "n_fbun_1", user.ID)
+	defer cleanupNote(t, "n_fbun_1")
+	setupPollNote(t, "n_fbun_2", user.ID)
+	defer cleanupNote(t, "n_fbun_2")
+
+	// 空入力は空 map を返す (no DB call)
+	out, err := repo.FindByUserAndNoteIDs("", []string{"x"})
+	require.NoError(t, err)
+	assert.Empty(t, out)
+	out, err = repo.FindByUserAndNoteIDs(user.ID, nil)
+	require.NoError(t, err)
+	assert.Empty(t, out)
+
+	// 同 user が n_fbun_1 で 2 票 + n_fbun_2 で 1 票
+	require.NoError(t, repo.Create(&model.PollVote{ID: "v_fbun_1", UserID: user.ID, NoteID: "n_fbun_1", Choice: 0}))
+	require.NoError(t, repo.Create(&model.PollVote{ID: "v_fbun_2", UserID: user.ID, NoteID: "n_fbun_1", Choice: 2}))
+	require.NoError(t, repo.Create(&model.PollVote{ID: "v_fbun_3", UserID: user.ID, NoteID: "n_fbun_2", Choice: 1}))
+	defer cleanupPollVote(t, "v_fbun_1")
+	defer cleanupPollVote(t, "v_fbun_2")
+	defer cleanupPollVote(t, "v_fbun_3")
+
+	// 別 user の vote は混ざらない
+	other := insertTestUser(t, "u_fbun_2", "fbunother")
+	defer cleanupUser(t, other.ID)
+	require.NoError(t, repo.Create(&model.PollVote{ID: "v_fbun_4", UserID: other.ID, NoteID: "n_fbun_1", Choice: 1}))
+	defer cleanupPollVote(t, "v_fbun_4")
+
+	got, err := repo.FindByUserAndNoteIDs(user.ID, []string{"n_fbun_1", "n_fbun_2", "n_fbun_no_votes"})
+	require.NoError(t, err)
+	assert.ElementsMatch(t, []int{0, 2}, got["n_fbun_1"])
+	assert.Equal(t, []int{1}, got["n_fbun_2"])
+	_, has := got["n_fbun_no_votes"]
+	assert.False(t, has, "note with no votes must not appear in result map")
 }
 
 func TestPollRepository_FindByNoteIDAndIncrementVote(t *testing.T) {

--- a/internal/server/router.go
+++ b/internal/server/router.go
@@ -320,6 +320,20 @@ func (s *Server) setupRoutes() {
 	// Polls
 	pollService := corepoll.NewService(noteRepo, pollRepo, pollVoteRepo, followingRepo, idGen)
 	pollService.SetNotificationHook(notificationHook)
+	// poll federation hook は deliverService が下で生成されるので、
+	// `pollService.SetFederationHook(...)` の呼び出しは deliverService 構築後
+	// (router.go:493 以降) に行う。下方の wire-up コメント参照。
+	// pollEnded 通知は周期 ticker (60s) で expiresAt < NOW() AND notifiedAt
+	// IS NULL を scan して著者 + ローカル投票者に発火する (#690)。Misskey TS
+	// は BullMQ delayed job で実装しているが mk-go では queue infra を経由
+	// せずに簡素な ticker で実現。partial index で空 scan のコストは最小。
+	pollExpiryWorker := corepoll.NewExpiryWorker(pollRepo, pollVoteRepo, noteRepo, userRepo, notificationService, 60*time.Second, 100)
+	pollExpiryCtx, pollExpiryCancel := context.WithCancel(context.Background())
+	go pollExpiryWorker.Run(pollExpiryCtx)
+	s.registerShutdownHook(func() { pollExpiryCancel() })
+	// pollVoted を note の stream topic に publish して subscribe 中の
+	// frontend (note 詳細 / timeline) が reload なしで count を更新できる
+	// ようにする (#690)。streamPubSub は下方で生成されるため遅延配線。
 
 	// Drive storage (Phase 4.9: Meta に基づいて Local / S3 を切り替え)
 	var driveStorage coredrive.Storage
@@ -436,6 +450,10 @@ func (s *Server) setupRoutes() {
 	publickeyRepo := repository.NewUserPublickeyRepository(s.db)
 	federationResolver.SetPublickeyRepo(publickeyRepo)
 	federationResolver.SetPollRepo(pollRepo)
+	// AP vote (Note.name + inReplyTo to a poll) を local poll service に
+	// 流して投票として記録する (#690)。これがないとリモートからの投票が
+	// 通常 reply として扱われ frontend に DM のように表示される。
+	federationResolver.SetPollVoter(pollService)
 	federationResolver.SetEmojiRepo(emojiRepo)
 	federationResolver.SetDriveFileRepo(driveFileRepo)
 	// AP attachment dimension probe (#461) 用 outbound HTTP client。
@@ -477,6 +495,10 @@ func (s *Server) setupRoutes() {
 	// AP delivery: DeliverService + フック登録 + asynq processor 登録
 	deliverService := corefederation.NewDeliverService(s.queueClient, userRepo, followingRepo, keypairRepo, apURLs)
 	deliverService.SetHostBlockChecker(instanceService)
+
+	// poll federation hook: ローカル user が remote poll に投票したら AP Note
+	// (with name + inReplyTo) を author の inbox に配信する (#690)。
+	pollService.SetFederationHook(corefederation.NewPollDeliveryHook(apRenderer, deliverService, userRepo, apURLs, idGen))
 
 	// Relay 連携 (#161): relay actor system account + relay.Service。
 	// relay.Service は AP delivery を必要とするので deliverService 構築の
@@ -968,6 +990,10 @@ func (s *Server) setupRoutes() {
 	// MyReaction / Channel の post-pack 解決は notes 以外でも必要 (#426)。
 	// 共通 resolver を 1 つだけ作って全 handler に注入する。
 	noteFieldResolver := entity.NewNoteFieldResolver(driveFileRepo, driveFolderRepo, userRepo, reactionRepo, channelRepo, idGen)
+	// viewer の poll vote から Poll.choices[i].IsVoted を埋める (#690)。
+	// frontend の MkPoll.vue が `showResult = isVoted || closed` を初期化に
+	// 使うため、これがないと「結果を見る」toggle が reload で揮発する。
+	noteFieldResolver.SetPollVoteLookup(pollVoteRepo)
 
 	// Notes endpoints
 	notesHandler := notes.NewHandler(noteRepo, noteCreateService, noteDeleteService, noteQueryService, timelineService, reactionService, pollService, searchService, idGen)
@@ -1485,6 +1511,11 @@ func (s *Server) setupRoutes() {
 	// 1. Redis pubsub bus (核となる publish/subscribe チャンネル)
 	streamPubSub := event.NewPubSubService(s.redis.Pubsub, "stream:")
 	streamBus := stream.NewEventPubSubBus(streamPubSub)
+
+	// pollVoted の noteStream publish 用に core/poll.Service へ event publisher
+	// を後付け配線する (#690)。Service 自体は streamPubSub 生成より前に作る
+	// ため、ここで SetEventPublisher する。
+	pollService.SetEventPublisher(stream.NewNoteEventPublisher(streamPubSub))
 
 	// 2. Channel registry: Misskey 互換のチャンネル名で各 factory を登録する
 	streamRegistry := stream.NewRegistry()

--- a/internal/stream/note_event_publisher.go
+++ b/internal/stream/note_event_publisher.go
@@ -1,0 +1,45 @@
+package stream
+
+import (
+	"context"
+	"log/slog"
+)
+
+// NoteEventPublisher emits arbitrary `{type, body}` envelopes on a note's
+// pubsub topic (`noteStream:<noteID>`). The Dispatcher subscribes to this
+// topic when a frontend client opens the corresponding noteStream channel
+// and forwards events to the WebSocket as `{type: "noteUpdated", body:
+// {id, type, body}}` — matching the Misskey TS upstream wire format.
+//
+// Used by core/poll.Service for the `pollVoted` event so frontend can
+// update poll counts in real-time without a full reload (#690). Easy to
+// extend to other note-scoped event types (reacted, deleted, etc.) by
+// adding new call sites that invoke PublishToNoteStream with the correct
+// type name.
+type NoteEventPublisher struct {
+	pub PubSubPublisher
+}
+
+// NewNoteEventPublisher constructs a NoteEventPublisher around the given
+// PubSubPublisher.
+func NewNoteEventPublisher(pub PubSubPublisher) *NoteEventPublisher {
+	return &NoteEventPublisher{pub: pub}
+}
+
+// PublishToNoteStream wraps body into a {type, body} envelope and publishes
+// it to `noteStream:<noteID>`. Failures are best-effort and only logged at
+// warn level (the underlying action — vote / reaction — has already
+// succeeded; losing the streaming nudge degrades to "user must reload").
+func (p *NoteEventPublisher) PublishToNoteStream(noteID string, eventType string, body any) {
+	if p.pub == nil || noteID == "" || eventType == "" {
+		return
+	}
+	envelope := map[string]any{
+		"type": eventType,
+		"body": body,
+	}
+	if err := p.pub.Publish(context.Background(), "noteStream:"+noteID, envelope); err != nil {
+		slog.Warn("note event publisher: publish failed",
+			"noteId", noteID, "type", eventType, "err", err)
+	}
+}

--- a/internal/testutil/mock_repository.go
+++ b/internal/testutil/mock_repository.go
@@ -2073,6 +2073,37 @@ func (m *MockPollRepository) IncrementVote(noteID string, choice int, delta int)
 	return nil
 }
 
+// ListExpiredUnnotified mirrors the live repo: returns polls with expiresAt
+// before `now` and notifiedAt == nil. ordering by expiresAt ASC for
+// deterministic testing.
+func (m *MockPollRepository) ListExpiredUnnotified(now time.Time, limit int) ([]*model.Poll, error) {
+	if limit <= 0 {
+		limit = 100
+	}
+	var rows []*model.Poll
+	for _, p := range m.Polls {
+		if p.ExpiresAt != nil && p.ExpiresAt.Before(now) && p.NotifiedAt == nil {
+			rows = append(rows, p)
+		}
+	}
+	sort.Slice(rows, func(i, j int) bool {
+		return rows[i].ExpiresAt.Before(*rows[j].ExpiresAt)
+	})
+	if len(rows) > limit {
+		rows = rows[:limit]
+	}
+	return rows, nil
+}
+
+// MarkNotified stamps notifiedAt on the in-memory poll. unknown noteID is a
+// no-op (matches GORM's UPDATE WHERE behaviour for non-matching rows).
+func (m *MockPollRepository) MarkNotified(noteID string, t time.Time) error {
+	if p, ok := m.Polls[noteID]; ok {
+		p.NotifiedAt = &t
+	}
+	return nil
+}
+
 // MockPollVoteRepository is a test double for repository.PollVoteRepository.
 type MockPollVoteRepository struct {
 	Votes map[string]*model.PollVote // keyed by id
@@ -2114,6 +2145,25 @@ func (m *MockPollVoteRepository) ListByNoteID(noteID string) ([]*model.PollVote,
 		}
 	}
 	return rows, nil
+}
+
+// FindByUserAndNoteIDs mirrors the live repo: groups choices by noteID for the
+// given user across the requested noteIDs. Empty noteIDs returns empty map.
+func (m *MockPollVoteRepository) FindByUserAndNoteIDs(userID string, noteIDs []string) (map[string][]int, error) {
+	out := map[string][]int{}
+	if userID == "" || len(noteIDs) == 0 {
+		return out, nil
+	}
+	want := make(map[string]bool, len(noteIDs))
+	for _, id := range noteIDs {
+		want[id] = true
+	}
+	for _, v := range m.Votes {
+		if v.UserID == userID && want[v.NoteID] {
+			out[v.NoteID] = append(out[v.NoteID], v.Choice)
+		}
+	}
+	return out, nil
 }
 
 // MockInstanceRepository is a test double for repository.InstanceRepository.

--- a/migration/000044_poll_notified_at.down.sql
+++ b/migration/000044_poll_notified_at.down.sql
@@ -1,0 +1,2 @@
+DROP INDEX IF EXISTS "IDX_poll_expired_unnotified";
+ALTER TABLE "poll" DROP COLUMN IF EXISTS "notifiedAt";

--- a/migration/000044_poll_notified_at.up.sql
+++ b/migration/000044_poll_notified_at.up.sql
@@ -1,0 +1,12 @@
+-- #690: poll table に notifiedAt を追加。expiresAt 経過後の pollEnded 通知
+-- が author + 投票者に発火済みかを記録し、periodic ticker (core/poll/
+-- expiry_worker) が二重通知を避ける。
+-- nullable timestamp。NULL は「まだ送ってない」、NOT NULL は「送信済み (時刻)」。
+ALTER TABLE "poll" ADD COLUMN "notifiedAt" timestamp with time zone;
+
+-- expiresAt < NOW() AND notifiedAt IS NULL を高速 scan するための部分 index。
+-- ticker が頻繁に空 scan するため、expired AND unnotified のみを対象にする
+-- partial index にすることで size を最小化する。
+CREATE INDEX IF NOT EXISTS "IDX_poll_expired_unnotified"
+  ON "poll" ("expiresAt")
+  WHERE "expiresAt" IS NOT NULL AND "notifiedAt" IS NULL;


### PR DESCRIPTION
## Summary

UDS 環境で発覚した [#690](https://github.com/shiroha-a/mk/issues/690) のアンケート機能の不具合を 1 PR で集約修正。元々は「投稿に poll が添付されない」だったが、深掘る過程で投票通知 / 永続化 / 期限処理 / federation 双方向 / 終了通知の 7 件が芋づる式に判明したため、全部まとめて修正。

## 修正内容 (7 件)

### 1. (元症状) 投稿に poll が添付されない
\`entity.PackNote\` が \`Poll\` フィールドを populate していなかった。frontend は \`hasPoll: true\` だけ受け取って poll 本体が undefined → アンケート UI が表示されなかった。

\`model.Note\` に \`Poll\` relation 追加 + \`preloadNoteRelations\` で \`Preload(\"Poll\")\` + \`entity.packPoll\` で UserLite 互換 \`PollEntity\` に変換。Renote/Reply embed まで再帰。

### 2. 投票通知 (per-vote) を削除
mk-go の \`TypePollVote\` が空 body の通知として frontend に表示されていた (Misskey TS には対応 type が無い)。\`poll_service.Vote\` から \`notificationHook\` 呼び出しを除去。

### 3. 「結果を見る」永続化 (\`Poll.choices[i].IsVoted\`)
frontend MkPoll の \`showResult = isVoted || closed\` 判定が viewer の vote 反映無しで常に false → reload で結果表示がリセットされる症状。

\`PollVoteRepository.FindByUserAndNoteIDs\` (batch) 新設 + \`entity.NoteFieldResolver.SetPollVoteLookup\` + \`ResolveViewerFields\` で viewer の choice indices を \`IsVoted=true\` に書き戻す。

### 4. アンケート期限 \`expiredAfter\` 処理
\`notes/create\` handler が \`ExpiredAfter\` を decode はするが forward していなかった (相対 ms = 「○時間後」指定が完全無視)。\`ExpiresAt > ExpiredAfter > nil\` の優先順で変換。

### 5. AP 投票ルーティング (リモート → ローカル)
\`federation.Resolver.IngestNote\` が reply target が poll を持つ AP Note (with Name + InReplyTo) を「reply」と誤解釈 → DM 風 reply になっていた。

\`activitypub.Note\` に \`Name\` field 追加。Resolver に \`PollVoter\` interface を導入し、reply target が poll かつ \`apNote.Name\` にマッチする choice があれば \`pollService.Vote\` を呼んで早期 return。

### 6. pollEnded 通知 (期限切れ)
- **migration 044**: poll table に \`notifiedAt\` (nullable) + partial index
- **\`core/poll.ExpiryWorker\`** (60s ticker): \`WHERE expiresAt < NOW() AND notifiedAt IS NULL\` を batch 100 件 scan → 著者 + ローカル投票者に pollEnded 通知 → \`notifiedAt\` 更新で再発火防止
- **\`notification.TypePollEnded\`** 新設 (Misskey TS と同じ type、frontend UI 既対応)
- リモート user は対象外 (upstream と同じ動作)
- Misskey TS は BullMQ delayed job だが mk-go では queue infra を経由せず周期 ticker (partial index で空 scan コスト最小)

### 7. 投票の連合配信 (双方向)
- **リモート poll への投票**: \`PollDeliveryHook.OnVote\` → AP Note (with Name + InReplyTo + URI: \`#votes/<targetID>\`) を render → \`DeliverActivity\` 経由で author の inbox に配信
- **ローカル poll への投票**: \`PollDeliveryHook.OnLocalPollUpdated\` → AP \`Update(Question)\` → \`DeliverToFollowers\` で全 remote follower に配信 (Misskey TS の \`deliverQuestionUpdate\` と同等)。これがないと連合先 instance が古い count のままになる

## 副次的な配線

- **\`stream.NoteEventPublisher\`** (新設): poll vote 等の note-scoped sub-event を \`noteStream:<noteID>\` topic に \`{type, body}\` envelope で publish。frontend dispatcher が \`noteUpdated\` として WebSocket forward する仕組みはあったが publisher が無く空配だった。pollVoted で reload なしの count 更新を実現
- **\`activitypub.URLBuilder.VoteActivityURI\`**: 投票 AP の Note ID。fragment 形式 (\`<voter URI>#votes/<targetID>\`) で Misskey TS と互換

## テスト

- \`core/poll.ExpiryWorker\` 10 ケース: author 通知 / voter 通知 / dedup / remote skip / 既通知 skip / 未満了 skip / nil receiver / 未配線 / repo err / ctx cancel
- 既存の \`poll_service\` / \`federation\` / \`activitypub\` / \`entity\` / \`repository\` / \`testutil\` の test suite はすべて pass
- mock に \`CreateMany\` / \`FindByUserAndNoteIDs\` / \`ListExpiredUnnotified\` / \`MarkNotified\` 追加

実行方法:
\`\`\`
go test -coverprofile=cov.out ./internal/core/poll/... ./internal/core/federation/... ./internal/api/notes/... ./internal/entity/... ./internal/activitypub/... ./internal/repository/...
\`\`\`

## Migration

- **044_poll_notified_at**: \`ALTER TABLE poll ADD notifiedAt\` + partial index for ticker scan path

## 動作確認 (UDS 実機)

- ✓ アンケート付き投稿で poll UI 表示
- ✓ 投票後 reload で「結果を見る」状態が維持される
- ✓ 「○時間後」指定で期限が反映される
- ✓ 期限切れで pollEnded 通知が著者 + 投票者に届く (60s ticker)
- ✓ リモート TS から mk-go poll に投票しても DM にならず count 増加
- ✓ ローカル mk-go poll への投票が remote follower でも count 反映 (Update broadcast)
- ✓ mk-go ローカルから remote TS poll に投票して TS 側 count 増加 (vote AP)

## 関連

Closes #690

🤖 Generated with [Claude Code](https://claude.com/claude-code)