### PR TITLE
Fix #698: パスキー登録の wire format を upstream Misskey TS に合わせる

### DIFF
--- a/internal/api/apierr/errors.go
+++ b/internal/api/apierr/errors.go
@@ -58,6 +58,27 @@ const (
 
 	// UUID for users/show (third_party/misskey/.../endpoints/users/show.ts).
 	UUIDFailedToResolveRemoteUser = "ef7b9be4-9cba-4e6f-ab41-90ed171c7d3c"
+
+	// UUIDInvalidToken は 2FA token 検証失敗 (i/2fa/{done,register-key,key-done})。
+	// upstream は plain `Error('authentication failed')` で UUID 無しなので
+	// mk-go 固有の安定 UUID を発番する (#673 Phase B / #698)。
+	UUIDInvalidToken = "f0fc0d2f-9805-432e-a69e-9898a4251660"
+
+	// UUIDRegistrationFailed は WebAuthn 登録失敗 (i/2fa/key-done)。
+	// upstream は verifyRegistration の throw を ApiError でなく素の Error で
+	// 投げる (UUID 無し) ので mk-go 固有 UUID。
+	UUIDRegistrationFailed = "1ddd78c8-1c1b-4077-a202-a64b16cebca1"
+
+	// UUIDNoSuchKey は upstream `i/2fa/update-key` の `noSuchKey` UUID。
+	// note: upstream の文字列 (`f9c5467f-d492-4d3c-9a8g-a70dacc86512`) は
+	// 4 セグメント目に `g` を含んでおり厳密には valid UUID ではないが、
+	// frontend / クライアントが文字列マッチで lookup する可能性があるので
+	// upstream の typo をそのまま採用する (mk-go 側で勝手に矯正しない)。
+	UUIDNoSuchKey = "f9c5467f-d492-4d3c-9a8g-a70dacc86512"
+
+	// UUIDNoSecurityKey は upstream `i/2fa/password-less` の `noKey` UUID。
+	// upstream typo (`9a8g`) を保持する理由は UUIDNoSuchKey と同じ。
+	UUIDNoSecurityKey = "f9c54d7f-d4c2-4d3c-9a8g-a70daac86512"
 )
 
 // InvalidParam returns a 400 INVALID_PARAM error response. The optional
@@ -203,4 +224,29 @@ func FailedToResolveRemoteUser() map[string]any {
 // RateLimitExceeded returns a 429 RATE_LIMIT_EXCEEDED error response.
 func RateLimitExceeded() map[string]any {
 	return Error("RATE_LIMIT_EXCEEDED", "Rate limit exceeded. Please try again later.", UUIDRateLimitExceeded)
+}
+
+// InvalidToken returns a 403 INVALID_TOKEN error response. Used by 2FA flows
+// when the supplied TOTP / backup code does not authenticate the user.
+func InvalidToken() map[string]any {
+	return Error("INVALID_TOKEN", "Invalid token.", UUIDInvalidToken)
+}
+
+// RegistrationFailed returns a 403 REGISTRATION_FAILED response. Used by
+// /api/i/2fa/key-done when the WebAuthn attestation does not verify.
+func RegistrationFailed() map[string]any {
+	return Error("REGISTRATION_FAILED", "Failed to finish registration.", UUIDRegistrationFailed)
+}
+
+// NoSuchKey returns a 404 NO_SUCH_KEY error response. Used by 2FA security
+// key management endpoints when the credentialId is not owned by the caller.
+func NoSuchKey() map[string]any {
+	return Error("NO_SUCH_KEY", "No such key.", UUIDNoSuchKey)
+}
+
+// NoSecurityKey returns a 400 NO_SECURITY_KEY response. Used by
+// /api/i/2fa/password-less when the user has no security key registered yet.
+// Upstream uses the singular `NO_SECURITY_KEY` code (not plural).
+func NoSecurityKey() map[string]any {
+	return Error("NO_SECURITY_KEY", "No security key.", UUIDNoSecurityKey)
 }

--- a/internal/api/apierr/errors_test.go
+++ b/internal/api/apierr/errors_test.go
@@ -181,3 +181,36 @@ func TestFailedToResolveRemoteUser(t *testing.T) {
 	assert.Equal(t, "FAILED_TO_RESOLVE_REMOTE_USER", errObj["code"])
 	assert.Equal(t, UUIDFailedToResolveRemoteUser, errObj["id"])
 }
+
+// #698 で追加したヘルパー: 2FA フロー (register-key / key-done /
+// remove-key / update-key / password-less / done) で利用される。
+// upstream に対応 ApiError が無い code (INVALID_TOKEN /
+// REGISTRATION_FAILED) は mk-go 固有 UUID、NO_SUCH_KEY /
+// NO_SECURITY_KEY は upstream UUID (typo 含む) を流用する。
+
+func TestInvalidToken(t *testing.T) {
+	errObj := InvalidToken()["error"].(map[string]any)
+	assert.Equal(t, "INVALID_TOKEN", errObj["code"])
+	assert.Equal(t, UUIDInvalidToken, errObj["id"])
+	assert.Equal(t, "Invalid token.", errObj["message"])
+}
+
+func TestRegistrationFailed(t *testing.T) {
+	errObj := RegistrationFailed()["error"].(map[string]any)
+	assert.Equal(t, "REGISTRATION_FAILED", errObj["code"])
+	assert.Equal(t, UUIDRegistrationFailed, errObj["id"])
+}
+
+func TestNoSuchKey(t *testing.T) {
+	errObj := NoSuchKey()["error"].(map[string]any)
+	assert.Equal(t, "NO_SUCH_KEY", errObj["code"])
+	assert.Equal(t, UUIDNoSuchKey, errObj["id"])
+}
+
+func TestNoSecurityKey(t *testing.T) {
+	// upstream は singular `NO_SECURITY_KEY` (#698)。
+	// 旧 mk-go の `NO_SECURITY_KEYS` (plural) からのリネームを guard する。
+	errObj := NoSecurityKey()["error"].(map[string]any)
+	assert.Equal(t, "NO_SECURITY_KEY", errObj["code"])
+	assert.Equal(t, UUIDNoSecurityKey, errObj["id"])
+}

--- a/internal/api/apierr/zero_uuid_lint_test.go
+++ b/internal/api/apierr/zero_uuid_lint_test.go
@@ -31,7 +31,14 @@ func TestZeroUUIDLint(t *testing.T) {
 	}
 
 	pendingExceptions := map[string]int{
-		"api/i/handler_2fa.go":        5, // INVALID_TOKEN / REGISTRATION_FAILED / NO_SUCH_KEY x2 / NO_SECURITY_KEYS
+		// TwoFADone INVALID_TOKEN / TwoFARegisterKey INVALID_TOKEN /
+		// TwoFAKeyDone INVALID_TOKEN / TwoFAKeyDone REGISTRATION_FAILED /
+		// TwoFARemoveKey NO_SUCH_KEY / TwoFAUpdateKey NO_SUCH_KEY /
+		// TwoFAPasswordLess NO_SECURITY_KEYS。upstream の register-key /
+		// key-done は 2FA 失敗時に `new Error('authentication failed')` を
+		// 投げる (ApiError でないので UUID 無し) ので、こちら側でも
+		// upstream UUID と紐づける素材が無い (#698)。
+		"api/i/handler_2fa.go":        7,
 		"api/notes/handler_drafts.go": 1, // NO_SUCH_DRAFT
 	}
 

--- a/internal/api/apierr/zero_uuid_lint_test.go
+++ b/internal/api/apierr/zero_uuid_lint_test.go
@@ -15,12 +15,11 @@ import (
 // NOT_FOUND) flow through apierr helpers with stable UUIDs; this lint
 // keeps regressions from sneaking back in.
 //
-// Endpoint-specific codes still pending #673 Phase B (NO_SUCH_KEY /
-// REGISTRATION_FAILED / NO_SUCH_DRAFT / NO_SECURITY_KEYS / INVALID_TOKEN)
-// are listed in pendingZeroUUIDOccurrences below as exceptions that this
-// test tolerates until each gets its proper upstream UUID. **DO NOT add
-// new entries** — instead pick the right Misskey TS UUID and use the
-// apierr helper.
+// Endpoint-specific codes still pending #673 Phase B (NO_SUCH_DRAFT) are
+// listed in pendingZeroUUIDOccurrences below as exceptions that this test
+// tolerates until each gets its proper upstream UUID. **DO NOT add new
+// entries** — instead pick the right Misskey TS UUID and use the apierr
+// helper.
 func TestZeroUUIDLint(t *testing.T) {
 	const placeholder = "00000000-0000-0000-0000-000000000000"
 
@@ -31,14 +30,6 @@ func TestZeroUUIDLint(t *testing.T) {
 	}
 
 	pendingExceptions := map[string]int{
-		// TwoFADone INVALID_TOKEN / TwoFARegisterKey INVALID_TOKEN /
-		// TwoFAKeyDone INVALID_TOKEN / TwoFAKeyDone REGISTRATION_FAILED /
-		// TwoFARemoveKey NO_SUCH_KEY / TwoFAUpdateKey NO_SUCH_KEY /
-		// TwoFAPasswordLess NO_SECURITY_KEYS。upstream の register-key /
-		// key-done は 2FA 失敗時に `new Error('authentication failed')` を
-		// 投げる (ApiError でないので UUID 無し) ので、こちら側でも
-		// upstream UUID と紐づける素材が無い (#698)。
-		"api/i/handler_2fa.go":        7,
 		"api/notes/handler_drafts.go": 1, // NO_SUCH_DRAFT
 	}
 

--- a/internal/api/i/handler_2fa.go
+++ b/internal/api/i/handler_2fa.go
@@ -171,58 +171,95 @@ func (h *Handler) requireWebAuthn(c echo.Context, password string) (*model.User,
 	return user, profile, true
 }
 
+// verify2FAToken validates a TOTP token (or single-use backup code) against
+// the given profile. Backup codes are consumed in-place via UpdateProfileFields.
+// Returns true if the token authenticates the user.
+//
+// Misskey TS upstream の UserAuthService.twoFactorAuthenticate と同じ挙動:
+// backup code に hit したら使い捨てで消費し、それ以外は TOTP として検証する。
+func (h *Handler) verify2FAToken(profile *model.UserProfile, token string) bool {
+	if token == "" {
+		return false
+	}
+	if remaining, err := twofactor.ConsumeBackupCode([]string(profile.TwoFactorBackupSecret), token); err == nil {
+		_ = h.userService.UpdateProfileFields(profile.UserID, map[string]any{
+			"twoFactorBackupSecret": pq.StringArray(remaining),
+		})
+		return true
+	}
+	if profile.TwoFactorSecret == nil {
+		return false
+	}
+	return twofactor.Validate(token, *profile.TwoFactorSecret)
+}
+
 // TwoFARegisterKey handles POST /api/i/2fa/register-key.
-// 1 段階目: パスワード認証 + WebAuthn registration challenge を返す。
-// レスポンスには Cypress / フロントエンドが finish 呼出時に必要な
-// `sessionId` (mk-go 内部の Redis セッション ID) と
-// `creation` (browser に渡す PublicKeyCredentialCreationOptions) が入る。
+// 1 段階目: パスワード + 2FA token 認証 + WebAuthn registration challenge を返す。
+// レスポンスは Misskey TS upstream と同じく PublicKeyCredentialCreationOptions
+// そのもの (frontend は `{publicKey: ...}` で wrap して使う) (#698)。
+//
+// 前提: ユーザーは既に TOTP で 2FA を有効化済みであること。security key は
+// 2FA の上に重ねる factor なので未有効化なら TWO_FACTOR_NOT_ENABLED を返す。
 func (h *Handler) TwoFARegisterKey(c echo.Context) error {
 	var req struct {
 		Password string `json:"password"`
+		Token    string `json:"token"`
 	}
 	if err := c.Bind(&req); err != nil || req.Password == "" {
 		return c.JSON(http.StatusBadRequest, apierr.Error("INVALID_PARAM", "password is required.", "ed1d7571-a3ac-4370-899c-0dbe5e230cc8"))
 	}
-	user, _, ok := h.requireWebAuthn(c, req.Password)
+	user, profile, ok := h.requireWebAuthn(c, req.Password)
 	if !ok {
 		return nil
+	}
+	if profile.TwoFactorEnabled && !h.verify2FAToken(profile, req.Token) {
+		return c.JSON(http.StatusForbidden, apierr.Error("INVALID_TOKEN", "Invalid 2FA token.", "00000000-0000-0000-0000-000000000000"))
+	}
+	if !profile.TwoFactorEnabled {
+		return c.JSON(http.StatusForbidden, apierr.Error("TWO_FACTOR_NOT_ENABLED", "2fa not enabled.", "bf32b864-449b-47b8-974e-f9a5468546f1"))
 	}
 
 	existing, err := h.securityKeyRepo.ListByUser(user.ID)
 	if err != nil {
 		return c.JSON(http.StatusInternalServerError, apierr.Error("INTERNAL_ERROR", "Internal error.", "5d37dbcb-891e-41ca-a3d6-e690c97775ac"))
 	}
-	creation, sessionID, err := h.webauthnSvc.BeginRegistration(c.Request().Context(), user, existing)
+	creation, err := h.webauthnSvc.BeginRegistrationPrimary(c.Request().Context(), user, existing)
 	if err != nil {
 		return c.JSON(http.StatusInternalServerError, apierr.Error("INTERNAL_ERROR", "Failed to begin registration.", "5d37dbcb-891e-41ca-a3d6-e690c97775ac"))
 	}
-	return c.JSON(http.StatusOK, map[string]any{
-		"sessionId": sessionID,
-		"creation":  creation,
-	})
+	// frontend は `parseCreationOptionsFromJSON({publicKey: <res>})` で読むので、
+	// 内側の PublicKeyCredentialCreationOptions だけを返す。
+	return c.JSON(http.StatusOK, creation.Response)
 }
 
 // TwoFAKeyDone handles POST /api/i/2fa/key-done.
 // 2 段階目: ブラウザから返ってきた attestation response を検証して
-// UserSecurityKey 行を作成する。リクエストボディは `{ password, name,
-// sessionId, response }` で、`response` は browser の認証器 attestation オブジェクト
-// (ParsedCredentialCreationData フォーマット)。
+// UserSecurityKey 行を作成する。リクエストボディは upstream 互換の
+// `{ password, token, name, credential }`。`credential` は browser の
+// `PublicKeyCredential.toJSON()` 出力 (ParsedCredentialCreationData フォーマット)。
+// session は user 単位の primary slot に保存されているので sessionId は不要 (#698)。
 func (h *Handler) TwoFAKeyDone(c echo.Context) error {
 	var req struct {
-		Password  string          `json:"password"`
-		Name      string          `json:"name"`
-		SessionID string          `json:"sessionId"`
-		Response  json.RawMessage `json:"response"`
+		Password   string          `json:"password"`
+		Token      string          `json:"token"`
+		Name       string          `json:"name"`
+		Credential json.RawMessage `json:"credential"`
 	}
-	if err := c.Bind(&req); err != nil || req.Password == "" || req.SessionID == "" || len(req.Response) == 0 {
-		return c.JSON(http.StatusBadRequest, apierr.Error("INVALID_PARAM", "password / sessionId / response are required.", "ed1d7571-a3ac-4370-899c-0dbe5e230cc8"))
+	if err := c.Bind(&req); err != nil || req.Password == "" || len(req.Credential) == 0 {
+		return c.JSON(http.StatusBadRequest, apierr.Error("INVALID_PARAM", "password / credential are required.", "ed1d7571-a3ac-4370-899c-0dbe5e230cc8"))
 	}
 	if req.Name == "" {
 		req.Name = "Security Key"
 	}
-	user, _, ok := h.requireWebAuthn(c, req.Password)
+	user, profile, ok := h.requireWebAuthn(c, req.Password)
 	if !ok {
 		return nil
+	}
+	if profile.TwoFactorEnabled && !h.verify2FAToken(profile, req.Token) {
+		return c.JSON(http.StatusForbidden, apierr.Error("INVALID_TOKEN", "Invalid 2FA token.", "00000000-0000-0000-0000-000000000000"))
+	}
+	if !profile.TwoFactorEnabled {
+		return c.JSON(http.StatusForbidden, apierr.Error("TWO_FACTOR_NOT_ENABLED", "2fa not enabled.", "798d6847-b1ed-4f9c-b1f9-163c42655995"))
 	}
 
 	existing, err := h.securityKeyRepo.ListByUser(user.ID)
@@ -231,12 +268,12 @@ func (h *Handler) TwoFAKeyDone(c echo.Context) error {
 	}
 
 	// go-webauthn の FinishRegistration は *http.Request からボディを読むので、
-	// JSON-RPC 経由で受け取った response を新しい http.Request にラップして渡す。
-	httpReq, err := wrapWebAuthnRequest(c.Request(), req.Response)
+	// JSON-RPC 経由で受け取った credential を新しい http.Request にラップして渡す。
+	httpReq, err := wrapWebAuthnRequest(c.Request(), req.Credential)
 	if err != nil {
-		return c.JSON(http.StatusBadRequest, apierr.Error("INVALID_PARAM", "invalid response payload.", "ed1d7571-a3ac-4370-899c-0dbe5e230cc8"))
+		return c.JSON(http.StatusBadRequest, apierr.Error("INVALID_PARAM", "invalid credential payload.", "ed1d7571-a3ac-4370-899c-0dbe5e230cc8"))
 	}
-	cred, err := h.webauthnSvc.FinishRegistration(c.Request().Context(), user, existing, req.SessionID, httpReq)
+	cred, err := h.webauthnSvc.FinishRegistrationPrimary(c.Request().Context(), user, existing, httpReq)
 	if err != nil {
 		return c.JSON(http.StatusForbidden, apierr.Error("REGISTRATION_FAILED", "Failed to finish registration.", "00000000-0000-0000-0000-000000000000"))
 	}
@@ -246,11 +283,9 @@ func (h *Handler) TwoFAKeyDone(c echo.Context) error {
 		return c.JSON(http.StatusInternalServerError, apierr.Error("INTERNAL_ERROR", "Failed to persist key.", "5d37dbcb-891e-41ca-a3d6-e690c97775ac"))
 	}
 
-	// 1 つ以上の鍵が登録されたら user_profile.securityKeysAvailable +
-	// twoFactorEnabled を true にする。本家 Misskey と同じ挙動。
+	// security key 1 つ以上 → securityKeysAvailable=true。本家と同じ挙動。
 	_ = h.userService.UpdateProfileFields(user.ID, map[string]any{
 		"securityKeysAvailable": true,
-		"twoFactorEnabled":      true,
 	})
 
 	return c.JSON(http.StatusOK, map[string]any{

--- a/internal/api/i/handler_2fa.go
+++ b/internal/api/i/handler_2fa.go
@@ -90,7 +90,7 @@ func (h *Handler) TwoFADone(c echo.Context) error {
 	}
 
 	if !twofactor.Validate(req.Token, *profile.TwoFactorTempSecret) {
-		return c.JSON(http.StatusForbidden, apierr.Error("INVALID_TOKEN", "Invalid token.", "00000000-0000-0000-0000-000000000000"))
+		return c.JSON(http.StatusForbidden, apierr.InvalidToken())
 	}
 
 	// バックアップコードを生成。crypto/rand 失敗は実質起きないが、起きた場合は
@@ -193,6 +193,11 @@ func (h *Handler) verify2FAToken(profile *model.UserProfile, token string) bool 
 	return twofactor.Validate(token, *profile.TwoFactorSecret)
 }
 
+// twoFAKeyNameMaxLen mirrors upstream の paramDef `name: { minLength: 1,
+// maxLength: 30 }`。frontend (`os.inputText`) も 30 文字制限を掛けているが、
+// API 直叩き経路の defense-in-depth として backend でも enforce する。
+const twoFAKeyNameMaxLen = 30
+
 // TwoFARegisterKey handles POST /api/i/2fa/register-key.
 // 1 段階目: パスワード + 2FA token 認証 + WebAuthn registration challenge を返す。
 // レスポンスは Misskey TS upstream と同じく PublicKeyCredentialCreationOptions
@@ -200,6 +205,11 @@ func (h *Handler) verify2FAToken(profile *model.UserProfile, token string) bool 
 //
 // 前提: ユーザーは既に TOTP で 2FA を有効化済みであること。security key は
 // 2FA の上に重ねる factor なので未有効化なら TWO_FACTOR_NOT_ENABLED を返す。
+//
+// 認証順序: requireWebAuthn で password を先に検証してから 2FA token を verify
+// する。upstream は逆順 (token → password) だが、片方だけ正しい状態の検出可否は
+// 対称なので情報リーク的に等価。`requireWebAuthn` を共有する都合で password 先に
+// 揃えている。
 func (h *Handler) TwoFARegisterKey(c echo.Context) error {
 	var req struct {
 		Password string `json:"password"`
@@ -213,7 +223,7 @@ func (h *Handler) TwoFARegisterKey(c echo.Context) error {
 		return nil
 	}
 	if profile.TwoFactorEnabled && !h.verify2FAToken(profile, req.Token) {
-		return c.JSON(http.StatusForbidden, apierr.Error("INVALID_TOKEN", "Invalid 2FA token.", "00000000-0000-0000-0000-000000000000"))
+		return c.JSON(http.StatusForbidden, apierr.InvalidToken())
 	}
 	if !profile.TwoFactorEnabled {
 		return c.JSON(http.StatusForbidden, apierr.Error("TWO_FACTOR_NOT_ENABLED", "2fa not enabled.", "bf32b864-449b-47b8-974e-f9a5468546f1"))
@@ -223,7 +233,7 @@ func (h *Handler) TwoFARegisterKey(c echo.Context) error {
 	if err != nil {
 		return c.JSON(http.StatusInternalServerError, apierr.Error("INTERNAL_ERROR", "Internal error.", "5d37dbcb-891e-41ca-a3d6-e690c97775ac"))
 	}
-	creation, err := h.webauthnSvc.BeginRegistrationPrimary(c.Request().Context(), user, existing)
+	creation, err := h.webauthnSvc.BeginRegistration(c.Request().Context(), user, existing)
 	if err != nil {
 		return c.JSON(http.StatusInternalServerError, apierr.Error("INTERNAL_ERROR", "Failed to begin registration.", "5d37dbcb-891e-41ca-a3d6-e690c97775ac"))
 	}
@@ -237,7 +247,9 @@ func (h *Handler) TwoFARegisterKey(c echo.Context) error {
 // UserSecurityKey 行を作成する。リクエストボディは upstream 互換の
 // `{ password, token, name, credential }`。`credential` は browser の
 // `PublicKeyCredential.toJSON()` 出力 (ParsedCredentialCreationData フォーマット)。
-// session は user 単位の primary slot に保存されているので sessionId は不要 (#698)。
+// session は user 単位で 1 件保持されているので sessionId は不要 (#698)。
+//
+// 認証順序は TwoFARegisterKey と同じ (password → 2FA token)。
 func (h *Handler) TwoFAKeyDone(c echo.Context) error {
 	var req struct {
 		Password   string          `json:"password"`
@@ -251,12 +263,15 @@ func (h *Handler) TwoFAKeyDone(c echo.Context) error {
 	if req.Name == "" {
 		req.Name = "Security Key"
 	}
+	if len(req.Name) > twoFAKeyNameMaxLen {
+		return c.JSON(http.StatusBadRequest, apierr.Error("INVALID_PARAM", "name is too long.", "ed1d7571-a3ac-4370-899c-0dbe5e230cc8"))
+	}
 	user, profile, ok := h.requireWebAuthn(c, req.Password)
 	if !ok {
 		return nil
 	}
 	if profile.TwoFactorEnabled && !h.verify2FAToken(profile, req.Token) {
-		return c.JSON(http.StatusForbidden, apierr.Error("INVALID_TOKEN", "Invalid 2FA token.", "00000000-0000-0000-0000-000000000000"))
+		return c.JSON(http.StatusForbidden, apierr.InvalidToken())
 	}
 	if !profile.TwoFactorEnabled {
 		return c.JSON(http.StatusForbidden, apierr.Error("TWO_FACTOR_NOT_ENABLED", "2fa not enabled.", "798d6847-b1ed-4f9c-b1f9-163c42655995"))
@@ -273,9 +288,9 @@ func (h *Handler) TwoFAKeyDone(c echo.Context) error {
 	if err != nil {
 		return c.JSON(http.StatusBadRequest, apierr.Error("INVALID_PARAM", "invalid credential payload.", "ed1d7571-a3ac-4370-899c-0dbe5e230cc8"))
 	}
-	cred, err := h.webauthnSvc.FinishRegistrationPrimary(c.Request().Context(), user, existing, httpReq)
+	cred, err := h.webauthnSvc.FinishRegistration(c.Request().Context(), user, existing, httpReq)
 	if err != nil {
-		return c.JSON(http.StatusForbidden, apierr.Error("REGISTRATION_FAILED", "Failed to finish registration.", "00000000-0000-0000-0000-000000000000"))
+		return c.JSON(http.StatusForbidden, apierr.RegistrationFailed())
 	}
 
 	key := twofactor.CredentialToModel(cred, user.ID, req.Name)
@@ -310,7 +325,7 @@ func (h *Handler) TwoFARemoveKey(c echo.Context) error {
 	}
 
 	if err := h.securityKeyRepo.Delete(req.CredentialID, user.ID); err != nil {
-		return c.JSON(http.StatusNotFound, apierr.Error("NO_SUCH_KEY", "Key not found.", "00000000-0000-0000-0000-000000000000"))
+		return c.JSON(http.StatusNotFound, apierr.NoSuchKey())
 	}
 
 	if remaining, err := h.securityKeyRepo.CountByUser(user.ID); err == nil && remaining == 0 {
@@ -338,7 +353,7 @@ func (h *Handler) TwoFAUpdateKey(c echo.Context) error {
 		return nil
 	}
 	if err := h.securityKeyRepo.UpdateName(req.CredentialID, user.ID, req.Name); err != nil {
-		return c.JSON(http.StatusNotFound, apierr.Error("NO_SUCH_KEY", "Key not found.", "00000000-0000-0000-0000-000000000000"))
+		return c.JSON(http.StatusNotFound, apierr.NoSuchKey())
 	}
 	return c.NoContent(http.StatusNoContent)
 }
@@ -360,7 +375,7 @@ func (h *Handler) TwoFAPasswordLess(c echo.Context) error {
 	}
 	if req.Value {
 		if n, err := h.securityKeyRepo.CountByUser(user.ID); err != nil || n == 0 {
-			return c.JSON(http.StatusBadRequest, apierr.Error("NO_SECURITY_KEYS", "Register at least one security key first.", "00000000-0000-0000-0000-000000000000"))
+			return c.JSON(http.StatusBadRequest, apierr.NoSecurityKey())
 		}
 	}
 	_ = h.userService.UpdateProfileFields(user.ID, map[string]any{

--- a/internal/api/i/handler_webauthn_test.go
+++ b/internal/api/i/handler_webauthn_test.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"testing"
 
+	"github.com/lib/pq"
 	"github.com/shiroha-a/mk/internal/core/twofactor"
 	"github.com/shiroha-a/mk/internal/model"
 	"github.com/shiroha-a/mk/internal/repository"
@@ -14,6 +15,16 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+// enableTOTP marks 2FA as enabled and registers a single backup code so test
+// callers can pass `"backup1"` as the 2FA token without dealing with the
+// time-window-dependent TOTP code path. (#698 で register-key / key-done が
+// 2FA token を要求するようになったため。)
+func enableTOTP(repo *testutil.MockUserRepository, uid string) {
+	p := repo.Profiles[uid]
+	p.TwoFactorEnabled = true
+	p.TwoFactorBackupSecret = pq.StringArray{"backup1", "backup2"}
+}
 
 // この test file は WebAuthn 関連 5 ハンドラの validation / wiring を網羅する。
 // FinishRegistration / FinishLogin の本物の attestation 検証は
@@ -158,13 +169,38 @@ func TestTwoFARegisterKey_NoProfile(t *testing.T) {
 	assert.Equal(t, http.StatusForbidden, rec.Code)
 }
 
+func TestTwoFARegisterKey_TwoFactorNotEnabled(t *testing.T) {
+	h, repo, _ := newWebAuthnHandler(t)
+	user := setupUserWithPassword(repo, "u1", "pass")
+	// 2FA 未有効化なら upstream と同じく TWO_FACTOR_NOT_ENABLED で 403
+	rec := postExtra(h.TwoFARegisterKey, `{"password":"pass"}`, user)
+	assert.Equal(t, http.StatusForbidden, rec.Code)
+	assert.Contains(t, rec.Body.String(), "TWO_FACTOR_NOT_ENABLED")
+}
+
+func TestTwoFARegisterKey_InvalidToken(t *testing.T) {
+	h, repo, _ := newWebAuthnHandler(t)
+	user := setupUserWithPassword(repo, "u1", "pass")
+	enableTOTP(repo, "u1")
+	rec := postExtra(h.TwoFARegisterKey, `{"password":"pass","token":"wrong"}`, user)
+	assert.Equal(t, http.StatusForbidden, rec.Code)
+	assert.Contains(t, rec.Body.String(), "INVALID_TOKEN")
+}
+
 func TestTwoFARegisterKey_Success(t *testing.T) {
 	h, repo, _ := newWebAuthnHandler(t)
 	user := setupUserWithPassword(repo, "u1", "pass")
-	rec := postExtra(h.TwoFARegisterKey, `{"password":"pass"}`, user)
+	enableTOTP(repo, "u1")
+	rec := postExtra(h.TwoFARegisterKey, `{"password":"pass","token":"backup1"}`, user)
 	assert.Equal(t, http.StatusOK, rec.Code)
-	assert.Contains(t, rec.Body.String(), "sessionId")
-	assert.Contains(t, rec.Body.String(), "creation")
+	// upstream 互換: PublicKeyCredentialCreationOptions そのものを返す
+	// (challenge / rp / pubKeyCredParams が top-level に並ぶ)
+	assert.Contains(t, rec.Body.String(), "challenge")
+	assert.Contains(t, rec.Body.String(), "pubKeyCredParams")
+	// sessionId / creation という旧フィールドが残っていないこと
+	assert.NotContains(t, rec.Body.String(), "sessionId")
+	// backup code が消費されている
+	assert.Equal(t, pq.StringArray{"backup2"}, repo.Profiles["u1"].TwoFactorBackupSecret)
 }
 
 // --- TwoFAKeyDone ---
@@ -179,15 +215,33 @@ func TestTwoFAKeyDone_MissingFields(t *testing.T) {
 func TestTwoFAKeyDone_WrongPassword(t *testing.T) {
 	h, repo, _ := newWebAuthnHandler(t)
 	user := setupUserWithPassword(repo, "u1", "correct")
-	rec := postExtra(h.TwoFAKeyDone, `{"password":"wrong","sessionId":"s","response":{}}`, user)
+	rec := postExtra(h.TwoFAKeyDone, `{"password":"wrong","credential":{}}`, user)
 	assert.Equal(t, http.StatusForbidden, rec.Code)
+}
+
+func TestTwoFAKeyDone_TwoFactorNotEnabled(t *testing.T) {
+	h, repo, _ := newWebAuthnHandler(t)
+	user := setupUserWithPassword(repo, "u1", "pass")
+	rec := postExtra(h.TwoFAKeyDone, `{"password":"pass","credential":{"id":"x"}}`, user)
+	assert.Equal(t, http.StatusForbidden, rec.Code)
+	assert.Contains(t, rec.Body.String(), "TWO_FACTOR_NOT_ENABLED")
+}
+
+func TestTwoFAKeyDone_InvalidToken(t *testing.T) {
+	h, repo, _ := newWebAuthnHandler(t)
+	user := setupUserWithPassword(repo, "u1", "pass")
+	enableTOTP(repo, "u1")
+	rec := postExtra(h.TwoFAKeyDone, `{"password":"pass","token":"wrong","credential":{"id":"x"}}`, user)
+	assert.Equal(t, http.StatusForbidden, rec.Code)
+	assert.Contains(t, rec.Body.String(), "INVALID_TOKEN")
 }
 
 func TestTwoFAKeyDone_FailureBranch(t *testing.T) {
 	h, repo, _ := newWebAuthnHandler(t)
 	user := setupUserWithPassword(repo, "u1", "pass")
-	// 存在しない sessionId + 不正な response → FinishRegistration が失敗 → 403
-	rec := postExtra(h.TwoFAKeyDone, `{"password":"pass","sessionId":"ghost","response":{"id":"x","rawId":"x","type":"public-key","response":{"attestationObject":"","clientDataJSON":""}}}`, user)
+	enableTOTP(repo, "u1")
+	// 不正な attestation → primary session も無いので FinishRegistration が失敗 → 403
+	rec := postExtra(h.TwoFAKeyDone, `{"password":"pass","token":"backup1","credential":{"id":"x","rawId":"x","type":"public-key","response":{"attestationObject":"","clientDataJSON":""}}}`, user)
 	assert.Equal(t, http.StatusForbidden, rec.Code)
 }
 

--- a/internal/api/i/handler_webauthn_test.go
+++ b/internal/api/i/handler_webauthn_test.go
@@ -6,8 +6,10 @@ import (
 	"net/http"
 	"os"
 	"testing"
+	"time"
 
 	"github.com/lib/pq"
+	"github.com/pquerna/otp/totp"
 	"github.com/shiroha-a/mk/internal/core/twofactor"
 	"github.com/shiroha-a/mk/internal/model"
 	"github.com/shiroha-a/mk/internal/repository"
@@ -16,14 +18,30 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// enableTOTP marks 2FA as enabled and registers a single backup code so test
-// callers can pass `"backup1"` as the 2FA token without dealing with the
-// time-window-dependent TOTP code path. (#698 で register-key / key-done が
-// 2FA token を要求するようになったため。)
-func enableTOTP(repo *testutil.MockUserRepository, uid string) {
+// enableTwoFactorWithBackupCodes marks 2FA as enabled and registers a known
+// backup code list so test callers can pass `"backup1"` as the 2FA token
+// without dealing with TOTP (which depends on real time windows). For tests
+// that need to exercise the TOTP code path specifically, use
+// enableTwoFactorWithTOTP instead. (#698)
+func enableTwoFactorWithBackupCodes(repo *testutil.MockUserRepository, uid string) {
 	p := repo.Profiles[uid]
 	p.TwoFactorEnabled = true
 	p.TwoFactorBackupSecret = pq.StringArray{"backup1", "backup2"}
+}
+
+// enableTwoFactorWithTOTP generates a fresh TOTP secret, stores it on the
+// profile, and returns it so the caller can compute valid codes via
+// totp.GenerateCode. backup codes are not populated, so the verify path is
+// guaranteed to go through TOTP.Validate (no backup-code shortcut).
+func enableTwoFactorWithTOTP(t *testing.T, repo *testutil.MockUserRepository, uid string) string {
+	t.Helper()
+	secret, _, err := twofactor.GenerateSecret("Misskey", uid)
+	require.NoError(t, err)
+	p := repo.Profiles[uid]
+	p.TwoFactorEnabled = true
+	p.TwoFactorSecret = &secret
+	p.TwoFactorBackupSecret = nil
+	return secret
 }
 
 // この test file は WebAuthn 関連 5 ハンドラの validation / wiring を網羅する。
@@ -181,7 +199,7 @@ func TestTwoFARegisterKey_TwoFactorNotEnabled(t *testing.T) {
 func TestTwoFARegisterKey_InvalidToken(t *testing.T) {
 	h, repo, _ := newWebAuthnHandler(t)
 	user := setupUserWithPassword(repo, "u1", "pass")
-	enableTOTP(repo, "u1")
+	enableTwoFactorWithBackupCodes(repo, "u1")
 	rec := postExtra(h.TwoFARegisterKey, `{"password":"pass","token":"wrong"}`, user)
 	assert.Equal(t, http.StatusForbidden, rec.Code)
 	assert.Contains(t, rec.Body.String(), "INVALID_TOKEN")
@@ -190,7 +208,7 @@ func TestTwoFARegisterKey_InvalidToken(t *testing.T) {
 func TestTwoFARegisterKey_Success(t *testing.T) {
 	h, repo, _ := newWebAuthnHandler(t)
 	user := setupUserWithPassword(repo, "u1", "pass")
-	enableTOTP(repo, "u1")
+	enableTwoFactorWithBackupCodes(repo, "u1")
 	rec := postExtra(h.TwoFARegisterKey, `{"password":"pass","token":"backup1"}`, user)
 	assert.Equal(t, http.StatusOK, rec.Code)
 	// upstream 互換: PublicKeyCredentialCreationOptions そのものを返す
@@ -201,6 +219,18 @@ func TestTwoFARegisterKey_Success(t *testing.T) {
 	assert.NotContains(t, rec.Body.String(), "sessionId")
 	// backup code が消費されている
 	assert.Equal(t, pq.StringArray{"backup2"}, repo.Profiles["u1"].TwoFactorBackupSecret)
+}
+
+func TestTwoFARegisterKey_TOTPSuccess(t *testing.T) {
+	// TOTP 直接検証経路 (verify2FAToken の non-backup-code 分岐) のカバレッジを確保。
+	h, repo, _ := newWebAuthnHandler(t)
+	user := setupUserWithPassword(repo, "u1", "pass")
+	secret := enableTwoFactorWithTOTP(t, repo, "u1")
+	code, err := totp.GenerateCode(secret, time.Now())
+	require.NoError(t, err)
+	rec := postExtra(h.TwoFARegisterKey, `{"password":"pass","token":"`+code+`"}`, user)
+	assert.Equal(t, http.StatusOK, rec.Code)
+	assert.Contains(t, rec.Body.String(), "challenge")
 }
 
 // --- TwoFAKeyDone ---
@@ -230,7 +260,7 @@ func TestTwoFAKeyDone_TwoFactorNotEnabled(t *testing.T) {
 func TestTwoFAKeyDone_InvalidToken(t *testing.T) {
 	h, repo, _ := newWebAuthnHandler(t)
 	user := setupUserWithPassword(repo, "u1", "pass")
-	enableTOTP(repo, "u1")
+	enableTwoFactorWithBackupCodes(repo, "u1")
 	rec := postExtra(h.TwoFAKeyDone, `{"password":"pass","token":"wrong","credential":{"id":"x"}}`, user)
 	assert.Equal(t, http.StatusForbidden, rec.Code)
 	assert.Contains(t, rec.Body.String(), "INVALID_TOKEN")
@@ -239,10 +269,22 @@ func TestTwoFAKeyDone_InvalidToken(t *testing.T) {
 func TestTwoFAKeyDone_FailureBranch(t *testing.T) {
 	h, repo, _ := newWebAuthnHandler(t)
 	user := setupUserWithPassword(repo, "u1", "pass")
-	enableTOTP(repo, "u1")
-	// 不正な attestation → primary session も無いので FinishRegistration が失敗 → 403
+	enableTwoFactorWithBackupCodes(repo, "u1")
+	// 不正な attestation → registration session も無いので FinishRegistration が失敗 → 403
 	rec := postExtra(h.TwoFAKeyDone, `{"password":"pass","token":"backup1","credential":{"id":"x","rawId":"x","type":"public-key","response":{"attestationObject":"","clientDataJSON":""}}}`, user)
 	assert.Equal(t, http.StatusForbidden, rec.Code)
+}
+
+func TestTwoFAKeyDone_NameTooLong(t *testing.T) {
+	// upstream は paramDef で maxLength=30 を強制している。defense-in-depth で
+	// API 直叩き経路でも backend 側が拒否することを確認。
+	h, repo, _ := newWebAuthnHandler(t)
+	user := setupUserWithPassword(repo, "u1", "pass")
+	longName := "this-name-is-far-longer-than-the-maximum-allowed-30-chars"
+	body := `{"password":"pass","token":"backup1","name":"` + longName + `","credential":{"id":"x"}}`
+	rec := postExtra(h.TwoFAKeyDone, body, user)
+	assert.Equal(t, http.StatusBadRequest, rec.Code)
+	assert.Contains(t, rec.Body.String(), "INVALID_PARAM")
 }
 
 // --- TwoFARemoveKey ---

--- a/internal/core/twofactor/webauthn.go
+++ b/internal/core/twofactor/webauthn.go
@@ -126,26 +126,27 @@ func (u *userAdapter) WebAuthnCredentials() []webauthn.Credential {
 
 // --- session storage ------------------------------------------------------
 
-// sessionKey returns the Redis key used to stash a SessionData blob between
-// begin and finish. The user id binds the session to one account so a stolen
-// sessionID alone cannot be replayed against a different victim.
-func sessionKey(userID, sessionID string) string {
+// loginSessionKey returns the Redis key used to stash a SessionData blob
+// between BeginLogin and FinishLogin. The user id binds the session to one
+// account so a stolen sessionID alone cannot be replayed against a different
+// victim. Login flow needs a sessionID round-trip because the same user may
+// have multiple in-flight assertion challenges (e.g., browser tab + mobile).
+func loginSessionKey(userID, sessionID string) string {
 	return "twofa:webauthn:" + userID + ":" + sessionID
 }
 
-// primarySessionKey is the Redis key for the upstream-compatible
+// registrationSessionKey is the Redis key for the upstream-compatible
 // single-in-flight-per-user mode used by /api/i/2fa/{register-key,key-done}.
 // Misskey TS の WebAuthnService と同じく client は session id を round-trip
 // しないため user 単位で 1 件の challenge だけ保持する。新規 challenge は
-// 既存を上書きする (#698)。login flow など session id round-trip が必要な
-// 経路は引き続き sessionKey() の方を使う。
-func primarySessionKey(userID string) string {
-	return "twofa:webauthn:" + userID + ":primary"
+// 既存を上書きする (#698)。
+func registrationSessionKey(userID string) string {
+	return "twofa:webauthn:" + userID + ":registration"
 }
 
-// putSession serializes the SessionData and stores it under a freshly generated
-// random session id with TTL.
-func (s *WebAuthnService) putSession(ctx context.Context, userID string, sd *webauthn.SessionData) (string, error) {
+// putLoginSession serializes the SessionData and stores it under a freshly
+// generated random session id with TTL.
+func (s *WebAuthnService) putLoginSession(ctx context.Context, userID string, sd *webauthn.SessionData) (string, error) {
 	if s == nil || s.redis == nil {
 		return "", ErrWebAuthnNotConfigured
 	}
@@ -157,18 +158,18 @@ func (s *WebAuthnService) putSession(ctx context.Context, userID string, sd *web
 	if err != nil {
 		return "", err
 	}
-	if err := s.redis.Set(ctx, sessionKey(userID, id), raw, webAuthnSessionTTL).Err(); err != nil {
+	if err := s.redis.Set(ctx, loginSessionKey(userID, id), raw, webAuthnSessionTTL).Err(); err != nil {
 		return "", err
 	}
 	return id, nil
 }
 
-// takeSession loads-and-deletes a SessionData blob (single-use).
-func (s *WebAuthnService) takeSession(ctx context.Context, userID, sessionID string) (*webauthn.SessionData, error) {
+// takeLoginSession loads-and-deletes a SessionData blob (single-use).
+func (s *WebAuthnService) takeLoginSession(ctx context.Context, userID, sessionID string) (*webauthn.SessionData, error) {
 	if s == nil || s.redis == nil {
 		return nil, ErrWebAuthnNotConfigured
 	}
-	key := sessionKey(userID, sessionID)
+	key := loginSessionKey(userID, sessionID)
 	raw, err := s.redis.GetDel(ctx, key).Bytes()
 	if err != nil {
 		if errors.Is(err, redis.Nil) {
@@ -199,37 +200,15 @@ var readRandom = cryptorand.Read
 
 // --- public API -----------------------------------------------------------
 
-// BeginRegistration starts a new credential registration. Returns the
-// CredentialCreation options (to be JSON-marshalled and shipped to the
-// browser) and a sessionID that the caller must round-trip back on the
-// finish step.
-func (s *WebAuthnService) BeginRegistration(ctx context.Context, user *model.User, existing []*model.UserSecurityKey) (*protocol.CredentialCreation, string, error) {
-	if s == nil || s.wa == nil {
-		return nil, "", ErrWebAuthnNotConfigured
-	}
-	adapter := &userAdapter{user: user, keys: existing}
-	creation, sd, err := s.wa.BeginRegistration(adapter)
-	if err != nil {
-		return nil, "", err
-	}
-	sid, err := s.putSession(ctx, user.ID, sd)
-	if err != nil {
-		return nil, "", err
-	}
-	return creation, sid, nil
-}
-
-// BeginRegistrationPrimary is the upstream-compatible variant of
-// BeginRegistration that stores the SessionData under a fixed per-user key
-// (no session id round-trip). Used by /api/i/2fa/register-key (#698).
-// Returns only the CredentialCreation options; no opaque sessionID for the
-// caller to track.
+// BeginRegistration starts a new credential registration. The SessionData
+// is stored under a fixed per-user key (no session id round-trip), matching
+// Misskey TS upstream の WebAuthnService.initiateRegistration (#698)。
 //
 // authenticatorSelection は Misskey TS upstream (`@simplewebauthn/server`) と
 // 同じく residentKey=required / userVerification=preferred を要求する。これが
 // 無いと一部の authenticator + browser 組合せ (特に passkey 経由の platform
 // authenticator) でダイアログは表示されるが credential が返らないケースがある。
-func (s *WebAuthnService) BeginRegistrationPrimary(ctx context.Context, user *model.User, existing []*model.UserSecurityKey) (*protocol.CredentialCreation, error) {
+func (s *WebAuthnService) BeginRegistration(ctx context.Context, user *model.User, existing []*model.UserSecurityKey) (*protocol.CredentialCreation, error) {
 	if s == nil || s.wa == nil {
 		return nil, ErrWebAuthnNotConfigured
 	}
@@ -241,21 +220,21 @@ func (s *WebAuthnService) BeginRegistrationPrimary(ctx context.Context, user *mo
 	if err != nil {
 		return nil, err
 	}
-	if err := s.putPrimarySession(ctx, user.ID, sd); err != nil {
+	if err := s.putRegistrationSession(ctx, user.ID, sd); err != nil {
 		return nil, err
 	}
 	return creation, nil
 }
 
-// FinishRegistrationPrimary completes the upstream-compatible registration
-// flow started by BeginRegistrationPrimary. The SessionData is loaded by
-// user id alone (no client-supplied sessionID), matching Misskey TS
-// WebAuthnService (#698).
-func (s *WebAuthnService) FinishRegistrationPrimary(ctx context.Context, user *model.User, existing []*model.UserSecurityKey, req *http.Request) (*webauthn.Credential, error) {
+// FinishRegistration verifies the registration response from the browser and
+// returns a Credential ready to be persisted as a UserSecurityKey row. The
+// SessionData is loaded by user id alone (no client-supplied sessionID),
+// matching Misskey TS WebAuthnService.verifyRegistration (#698).
+func (s *WebAuthnService) FinishRegistration(ctx context.Context, user *model.User, existing []*model.UserSecurityKey, req *http.Request) (*webauthn.Credential, error) {
 	if s == nil || s.wa == nil {
 		return nil, ErrWebAuthnNotConfigured
 	}
-	sd, err := s.takePrimarySession(ctx, user.ID)
+	sd, err := s.takeRegistrationSession(ctx, user.ID)
 	if err != nil {
 		return nil, err
 	}
@@ -267,9 +246,9 @@ func (s *WebAuthnService) FinishRegistrationPrimary(ctx context.Context, user *m
 	return cred, nil
 }
 
-// putPrimarySession overwrites any existing primary challenge so a fresh
-// register-key call after an abandoned attempt always works.
-func (s *WebAuthnService) putPrimarySession(ctx context.Context, userID string, sd *webauthn.SessionData) error {
+// putRegistrationSession overwrites any existing registration challenge so a
+// fresh register-key call after an abandoned attempt always works.
+func (s *WebAuthnService) putRegistrationSession(ctx context.Context, userID string, sd *webauthn.SessionData) error {
 	if s == nil || s.redis == nil {
 		return ErrWebAuthnNotConfigured
 	}
@@ -277,15 +256,16 @@ func (s *WebAuthnService) putPrimarySession(ctx context.Context, userID string, 
 	if err != nil {
 		return err
 	}
-	return s.redis.Set(ctx, primarySessionKey(userID), raw, webAuthnSessionTTL).Err()
+	return s.redis.Set(ctx, registrationSessionKey(userID), raw, webAuthnSessionTTL).Err()
 }
 
-// takePrimarySession loads-and-deletes the primary session blob (single-use).
-func (s *WebAuthnService) takePrimarySession(ctx context.Context, userID string) (*webauthn.SessionData, error) {
+// takeRegistrationSession loads-and-deletes the registration session blob
+// (single-use).
+func (s *WebAuthnService) takeRegistrationSession(ctx context.Context, userID string) (*webauthn.SessionData, error) {
 	if s == nil || s.redis == nil {
 		return nil, ErrWebAuthnNotConfigured
 	}
-	raw, err := s.redis.GetDel(ctx, primarySessionKey(userID)).Bytes()
+	raw, err := s.redis.GetDel(ctx, registrationSessionKey(userID)).Bytes()
 	if err != nil {
 		if errors.Is(err, redis.Nil) {
 			return nil, ErrWebAuthnSessionNotFound
@@ -297,24 +277,6 @@ func (s *WebAuthnService) takePrimarySession(ctx context.Context, userID string)
 		return nil, err
 	}
 	return &sd, nil
-}
-
-// FinishRegistration verifies the registration response from the browser and
-// returns a Credential ready to be persisted as a UserSecurityKey row.
-func (s *WebAuthnService) FinishRegistration(ctx context.Context, user *model.User, existing []*model.UserSecurityKey, sessionID string, req *http.Request) (*webauthn.Credential, error) {
-	if s == nil || s.wa == nil {
-		return nil, ErrWebAuthnNotConfigured
-	}
-	sd, err := s.takeSession(ctx, user.ID, sessionID)
-	if err != nil {
-		return nil, err
-	}
-	adapter := &userAdapter{user: user, keys: existing}
-	cred, err := s.wa.FinishRegistration(adapter, *sd, req)
-	if err != nil {
-		return nil, err
-	}
-	return cred, nil
 }
 
 // BeginLogin starts an authentication assertion challenge for the given user.
@@ -329,7 +291,7 @@ func (s *WebAuthnService) BeginLogin(ctx context.Context, user *model.User, exis
 	if err != nil {
 		return nil, "", err
 	}
-	sid, err := s.putSession(ctx, user.ID, sd)
+	sid, err := s.putLoginSession(ctx, user.ID, sd)
 	if err != nil {
 		return nil, "", err
 	}
@@ -343,7 +305,7 @@ func (s *WebAuthnService) FinishLogin(ctx context.Context, user *model.User, exi
 	if s == nil || s.wa == nil {
 		return nil, ErrWebAuthnNotConfigured
 	}
-	sd, err := s.takeSession(ctx, user.ID, sessionID)
+	sd, err := s.takeLoginSession(ctx, user.ID, sessionID)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/core/twofactor/webauthn.go
+++ b/internal/core/twofactor/webauthn.go
@@ -133,6 +133,16 @@ func sessionKey(userID, sessionID string) string {
 	return "twofa:webauthn:" + userID + ":" + sessionID
 }
 
+// primarySessionKey is the Redis key for the upstream-compatible
+// single-in-flight-per-user mode used by /api/i/2fa/{register-key,key-done}.
+// Misskey TS の WebAuthnService と同じく client は session id を round-trip
+// しないため user 単位で 1 件の challenge だけ保持する。新規 challenge は
+// 既存を上書きする (#698)。login flow など session id round-trip が必要な
+// 経路は引き続き sessionKey() の方を使う。
+func primarySessionKey(userID string) string {
+	return "twofa:webauthn:" + userID + ":primary"
+}
+
 // putSession serializes the SessionData and stores it under a freshly generated
 // random session id with TTL.
 func (s *WebAuthnService) putSession(ctx context.Context, userID string, sd *webauthn.SessionData) (string, error) {
@@ -207,6 +217,86 @@ func (s *WebAuthnService) BeginRegistration(ctx context.Context, user *model.Use
 		return nil, "", err
 	}
 	return creation, sid, nil
+}
+
+// BeginRegistrationPrimary is the upstream-compatible variant of
+// BeginRegistration that stores the SessionData under a fixed per-user key
+// (no session id round-trip). Used by /api/i/2fa/register-key (#698).
+// Returns only the CredentialCreation options; no opaque sessionID for the
+// caller to track.
+//
+// authenticatorSelection は Misskey TS upstream (`@simplewebauthn/server`) と
+// 同じく residentKey=required / userVerification=preferred を要求する。これが
+// 無いと一部の authenticator + browser 組合せ (特に passkey 経由の platform
+// authenticator) でダイアログは表示されるが credential が返らないケースがある。
+func (s *WebAuthnService) BeginRegistrationPrimary(ctx context.Context, user *model.User, existing []*model.UserSecurityKey) (*protocol.CredentialCreation, error) {
+	if s == nil || s.wa == nil {
+		return nil, ErrWebAuthnNotConfigured
+	}
+	adapter := &userAdapter{user: user, keys: existing}
+	creation, sd, err := s.wa.BeginRegistration(adapter, webauthn.WithAuthenticatorSelection(protocol.AuthenticatorSelection{
+		ResidentKey:      protocol.ResidentKeyRequirementRequired,
+		UserVerification: protocol.VerificationPreferred,
+	}))
+	if err != nil {
+		return nil, err
+	}
+	if err := s.putPrimarySession(ctx, user.ID, sd); err != nil {
+		return nil, err
+	}
+	return creation, nil
+}
+
+// FinishRegistrationPrimary completes the upstream-compatible registration
+// flow started by BeginRegistrationPrimary. The SessionData is loaded by
+// user id alone (no client-supplied sessionID), matching Misskey TS
+// WebAuthnService (#698).
+func (s *WebAuthnService) FinishRegistrationPrimary(ctx context.Context, user *model.User, existing []*model.UserSecurityKey, req *http.Request) (*webauthn.Credential, error) {
+	if s == nil || s.wa == nil {
+		return nil, ErrWebAuthnNotConfigured
+	}
+	sd, err := s.takePrimarySession(ctx, user.ID)
+	if err != nil {
+		return nil, err
+	}
+	adapter := &userAdapter{user: user, keys: existing}
+	cred, err := s.wa.FinishRegistration(adapter, *sd, req)
+	if err != nil {
+		return nil, err
+	}
+	return cred, nil
+}
+
+// putPrimarySession overwrites any existing primary challenge so a fresh
+// register-key call after an abandoned attempt always works.
+func (s *WebAuthnService) putPrimarySession(ctx context.Context, userID string, sd *webauthn.SessionData) error {
+	if s == nil || s.redis == nil {
+		return ErrWebAuthnNotConfigured
+	}
+	raw, err := json.Marshal(sd)
+	if err != nil {
+		return err
+	}
+	return s.redis.Set(ctx, primarySessionKey(userID), raw, webAuthnSessionTTL).Err()
+}
+
+// takePrimarySession loads-and-deletes the primary session blob (single-use).
+func (s *WebAuthnService) takePrimarySession(ctx context.Context, userID string) (*webauthn.SessionData, error) {
+	if s == nil || s.redis == nil {
+		return nil, ErrWebAuthnNotConfigured
+	}
+	raw, err := s.redis.GetDel(ctx, primarySessionKey(userID)).Bytes()
+	if err != nil {
+		if errors.Is(err, redis.Nil) {
+			return nil, ErrWebAuthnSessionNotFound
+		}
+		return nil, err
+	}
+	var sd webauthn.SessionData
+	if err := json.Unmarshal(raw, &sd); err != nil {
+		return nil, err
+	}
+	return &sd, nil
 }
 
 // FinishRegistration verifies the registration response from the browser and

--- a/internal/core/twofactor/webauthn_test.go
+++ b/internal/core/twofactor/webauthn_test.go
@@ -67,7 +67,7 @@ func TestNewWebAuthnService_OK(t *testing.T) {
 
 // --- session helpers (real Redis) ---
 
-func TestPutAndTakeSession_Roundtrip(t *testing.T) {
+func TestPutAndTakeLoginSession_Roundtrip(t *testing.T) {
 	requireRedis(t)
 	twofaTestRedis.FlushAll(context.Background())
 	svc, err := NewWebAuthnService("https://example.com", "Misskey", twofaTestRedis.Client)
@@ -75,32 +75,32 @@ func TestPutAndTakeSession_Roundtrip(t *testing.T) {
 
 	// fake SessionData
 	sd := makeFakeSessionData()
-	sid, err := svc.putSession(context.Background(), "alice", sd)
+	sid, err := svc.putLoginSession(context.Background(), "alice", sd)
 	require.NoError(t, err)
 	assert.NotEmpty(t, sid)
 
-	got, err := svc.takeSession(context.Background(), "alice", sid)
+	got, err := svc.takeLoginSession(context.Background(), "alice", sid)
 	require.NoError(t, err)
 	assert.Equal(t, sd.Challenge, got.Challenge)
 }
 
-func TestTakeSession_Missing(t *testing.T) {
+func TestTakeLoginSession_Missing(t *testing.T) {
 	requireRedis(t)
 	svc, err := NewWebAuthnService("https://example.com", "Misskey", twofaTestRedis.Client)
 	require.NoError(t, err)
-	_, err = svc.takeSession(context.Background(), "alice", "ghost")
+	_, err = svc.takeLoginSession(context.Background(), "alice", "ghost")
 	assert.ErrorIs(t, err, ErrWebAuthnSessionNotFound)
 }
 
-func TestTakeSession_NilRedis(t *testing.T) {
+func TestTakeLoginSession_NilRedis(t *testing.T) {
 	svc := &WebAuthnService{wa: nil, redis: nil}
-	_, err := svc.takeSession(context.Background(), "alice", "x")
+	_, err := svc.takeLoginSession(context.Background(), "alice", "x")
 	assert.ErrorIs(t, err, ErrWebAuthnNotConfigured)
 }
 
-func TestPutSession_NilRedis(t *testing.T) {
+func TestPutLoginSession_NilRedis(t *testing.T) {
 	svc := &WebAuthnService{wa: nil, redis: nil}
-	_, err := svc.putSession(context.Background(), "alice", makeFakeSessionData())
+	_, err := svc.putLoginSession(context.Background(), "alice", makeFakeSessionData())
 	assert.ErrorIs(t, err, ErrWebAuthnNotConfigured)
 }
 
@@ -111,11 +111,14 @@ func TestBeginRegistration(t *testing.T) {
 	twofaTestRedis.FlushAll(context.Background())
 	svc, err := NewWebAuthnService("https://example.com", "Misskey", twofaTestRedis.Client)
 	require.NoError(t, err)
-	creation, sid, err := svc.BeginRegistration(context.Background(), &model.User{ID: "alice", Username: "alice"}, nil)
+	creation, err := svc.BeginRegistration(context.Background(), &model.User{ID: "alice", Username: "alice"}, nil)
 	require.NoError(t, err)
-	assert.NotEmpty(t, sid)
-	assert.NotNil(t, creation)
+	require.NotNil(t, creation)
 	assert.NotEmpty(t, creation.Response.Challenge)
+	// registration session が user 単位 1 件で保存されていること
+	got, err := svc.takeRegistrationSession(context.Background(), "alice")
+	require.NoError(t, err)
+	assert.NotEmpty(t, got.Challenge)
 }
 
 func TestBeginLogin(t *testing.T) {
@@ -135,7 +138,7 @@ func TestBeginLogin(t *testing.T) {
 
 func TestBeginRegistration_NotConfigured(t *testing.T) {
 	svc := &WebAuthnService{}
-	_, _, err := svc.BeginRegistration(context.Background(), &model.User{ID: "x"}, nil)
+	_, err := svc.BeginRegistration(context.Background(), &model.User{ID: "x"}, nil)
 	assert.ErrorIs(t, err, ErrWebAuthnNotConfigured)
 }
 
@@ -148,7 +151,7 @@ func TestBeginLogin_NotConfigured(t *testing.T) {
 func TestFinishRegistration_NotConfigured(t *testing.T) {
 	svc := &WebAuthnService{}
 	req := httptest.NewRequest("POST", "/", strings.NewReader(""))
-	_, err := svc.FinishRegistration(context.Background(), &model.User{ID: "x"}, nil, "sid", req)
+	_, err := svc.FinishRegistration(context.Background(), &model.User{ID: "x"}, nil, req)
 	assert.ErrorIs(t, err, ErrWebAuthnNotConfigured)
 }
 
@@ -165,7 +168,7 @@ func TestFinishRegistration_SessionMissing(t *testing.T) {
 	svc, err := NewWebAuthnService("https://example.com", "Misskey", twofaTestRedis.Client)
 	require.NoError(t, err)
 	req := httptest.NewRequest("POST", "/", strings.NewReader(""))
-	_, err = svc.FinishRegistration(context.Background(), &model.User{ID: "alice"}, nil, "ghost", req)
+	_, err = svc.FinishRegistration(context.Background(), &model.User{ID: "alice"}, nil, req)
 	assert.ErrorIs(t, err, ErrWebAuthnSessionNotFound)
 }
 
@@ -270,8 +273,8 @@ func TestNewSessionID_RandError(t *testing.T) {
 
 // --- key helper ---
 
-func TestSessionKey(t *testing.T) {
-	assert.Equal(t, "twofa:webauthn:alice:sid1", sessionKey("alice", "sid1"))
+func TestLoginSessionKey(t *testing.T) {
+	assert.Equal(t, "twofa:webauthn:alice:sid1", loginSessionKey("alice", "sid1"))
 }
 
 // --- BeginRegistration / BeginLogin Redis error paths ---
@@ -283,20 +286,7 @@ func TestBeginRegistration_PutSessionFails(t *testing.T) {
 	require.NoError(t, c.Close())
 	svc, err := NewWebAuthnService("https://example.com", "Misskey", c)
 	require.NoError(t, err)
-	_, _, err = svc.BeginRegistration(context.Background(), &model.User{ID: "alice", Username: "alice"}, nil)
-	assert.Error(t, err)
-}
-
-// putSession の rand 失敗経路もカバーする (newSessionID が err を返す)
-func TestBeginRegistration_RandError(t *testing.T) {
-	requireRedis(t)
-	twofaTestRedis.FlushAll(context.Background())
-	svc, err := NewWebAuthnService("https://example.com", "Misskey", twofaTestRedis.Client)
-	require.NoError(t, err)
-	old := readRandom
-	defer func() { readRandom = old }()
-	readRandom = func(b []byte) (int, error) { return 0, errors.New("entropy depleted") }
-	_, _, err = svc.BeginRegistration(context.Background(), &model.User{ID: "alice", Username: "alice"}, nil)
+	_, err = svc.BeginRegistration(context.Background(), &model.User{ID: "alice", Username: "alice"}, nil)
 	assert.Error(t, err)
 }
 
@@ -336,11 +326,11 @@ func TestTakeSession_RedisError(t *testing.T) {
 	require.NoError(t, err)
 	// 一旦正常に PUT
 	sd := makeFakeSessionData()
-	sid, err := svc.putSession(context.Background(), "alice", sd)
+	sid, err := svc.putLoginSession(context.Background(), "alice", sd)
 	require.NoError(t, err)
 	// クライアント閉じてから take → connection closed エラー
 	require.NoError(t, c.Close())
-	_, err = svc.takeSession(context.Background(), "alice", sid)
+	_, err = svc.takeLoginSession(context.Background(), "alice", sid)
 	assert.Error(t, err)
 	assert.NotErrorIs(t, err, ErrWebAuthnSessionNotFound)
 }
@@ -375,11 +365,10 @@ func TestFinishRegistration_Success(t *testing.T) {
 		UserID:     []byte("test-user-id"),
 		CredParams: []protocol.CredentialParameter{{Type: protocol.PublicKeyCredentialType, Algorithm: webauthncose.AlgES256}},
 	}
-	sid, err := svc.putSession(context.Background(), "test-user-id", sd)
-	require.NoError(t, err)
+	require.NoError(t, svc.putRegistrationSession(context.Background(), "test-user-id", sd))
 
 	httpReq := httptest.NewRequest("POST", "/", bytes.NewReader(body))
-	cred, err := svc.FinishRegistration(context.Background(), &model.User{ID: "test-user-id", Username: "test"}, nil, sid, httpReq)
+	cred, err := svc.FinishRegistration(context.Background(), &model.User{ID: "test-user-id", Username: "test"}, nil, httpReq)
 	require.NoError(t, err)
 	require.NotNil(t, cred)
 	expectedCredID := decodeHex(t, credentialIDHex)
@@ -418,34 +407,34 @@ func buildAttestationResponse(t *testing.T, attObjectHex, clientDataJSONHex, cre
 	return body
 }
 
-// --- BeginRegistrationPrimary / FinishRegistrationPrimary (#698) ---
+// --- registration session helpers (#698) ---
 //
 // upstream-compat な single-in-flight-per-user 経路。session id round-trip が
-// 無いので primary slot 1 つだけ Redis に保持する。
+// 無いので user 単位で 1 件だけ Redis に保持する。
 
-func TestPrimarySessionKey(t *testing.T) {
-	assert.Equal(t, "twofa:webauthn:alice:primary", primarySessionKey("alice"))
+func TestRegistrationSessionKey(t *testing.T) {
+	assert.Equal(t, "twofa:webauthn:alice:registration", registrationSessionKey("alice"))
 }
 
-func TestPutAndTakePrimarySession_Roundtrip(t *testing.T) {
+func TestPutAndTakeRegistrationSession_Roundtrip(t *testing.T) {
 	requireRedis(t)
 	twofaTestRedis.FlushAll(context.Background())
 	svc, err := NewWebAuthnService("https://example.com", "Misskey", twofaTestRedis.Client)
 	require.NoError(t, err)
 
 	sd := makeFakeSessionData()
-	require.NoError(t, svc.putPrimarySession(context.Background(), "alice", sd))
+	require.NoError(t, svc.putRegistrationSession(context.Background(), "alice", sd))
 
-	got, err := svc.takePrimarySession(context.Background(), "alice")
+	got, err := svc.takeRegistrationSession(context.Background(), "alice")
 	require.NoError(t, err)
 	assert.Equal(t, sd.Challenge, got.Challenge)
 
 	// take は single-use: 2 回目は ErrWebAuthnSessionNotFound
-	_, err = svc.takePrimarySession(context.Background(), "alice")
+	_, err = svc.takeRegistrationSession(context.Background(), "alice")
 	assert.ErrorIs(t, err, ErrWebAuthnSessionNotFound)
 }
 
-func TestPutPrimarySession_Overwrites(t *testing.T) {
+func TestPutRegistrationSession_Overwrites(t *testing.T) {
 	requireRedis(t)
 	twofaTestRedis.FlushAll(context.Background())
 	svc, err := NewWebAuthnService("https://example.com", "Misskey", twofaTestRedis.Client)
@@ -456,115 +445,36 @@ func TestPutPrimarySession_Overwrites(t *testing.T) {
 	second := makeFakeSessionData()
 	second.Challenge = "second"
 
-	require.NoError(t, svc.putPrimarySession(context.Background(), "alice", first))
-	require.NoError(t, svc.putPrimarySession(context.Background(), "alice", second))
+	require.NoError(t, svc.putRegistrationSession(context.Background(), "alice", first))
+	require.NoError(t, svc.putRegistrationSession(context.Background(), "alice", second))
 
-	got, err := svc.takePrimarySession(context.Background(), "alice")
+	got, err := svc.takeRegistrationSession(context.Background(), "alice")
 	require.NoError(t, err)
 	assert.Equal(t, "second", got.Challenge)
 }
 
-func TestPutPrimarySession_NilRedis(t *testing.T) {
+func TestPutRegistrationSession_NilRedis(t *testing.T) {
 	svc := &WebAuthnService{}
-	err := svc.putPrimarySession(context.Background(), "alice", makeFakeSessionData())
+	err := svc.putRegistrationSession(context.Background(), "alice", makeFakeSessionData())
 	assert.ErrorIs(t, err, ErrWebAuthnNotConfigured)
 }
 
-func TestTakePrimarySession_NilRedis(t *testing.T) {
+func TestTakeRegistrationSession_NilRedis(t *testing.T) {
 	svc := &WebAuthnService{}
-	_, err := svc.takePrimarySession(context.Background(), "alice")
+	_, err := svc.takeRegistrationSession(context.Background(), "alice")
 	assert.ErrorIs(t, err, ErrWebAuthnNotConfigured)
 }
 
-func TestTakePrimarySession_RedisError(t *testing.T) {
+func TestTakeRegistrationSession_RedisError(t *testing.T) {
 	requireRedis(t)
 	c := redis.NewClient(&redis.Options{Addr: twofaTestRedis.Client.Options().Addr})
 	svc, err := NewWebAuthnService("https://example.com", "Misskey", c)
 	require.NoError(t, err)
-	require.NoError(t, svc.putPrimarySession(context.Background(), "alice", makeFakeSessionData()))
+	require.NoError(t, svc.putRegistrationSession(context.Background(), "alice", makeFakeSessionData()))
 	require.NoError(t, c.Close())
-	_, err = svc.takePrimarySession(context.Background(), "alice")
+	_, err = svc.takeRegistrationSession(context.Background(), "alice")
 	assert.Error(t, err)
 	assert.NotErrorIs(t, err, ErrWebAuthnSessionNotFound)
-}
-
-func TestBeginRegistrationPrimary_NotConfigured(t *testing.T) {
-	svc := &WebAuthnService{}
-	_, err := svc.BeginRegistrationPrimary(context.Background(), &model.User{ID: "x"}, nil)
-	assert.ErrorIs(t, err, ErrWebAuthnNotConfigured)
-}
-
-func TestFinishRegistrationPrimary_NotConfigured(t *testing.T) {
-	svc := &WebAuthnService{}
-	req := httptest.NewRequest("POST", "/", strings.NewReader(""))
-	_, err := svc.FinishRegistrationPrimary(context.Background(), &model.User{ID: "x"}, nil, req)
-	assert.ErrorIs(t, err, ErrWebAuthnNotConfigured)
-}
-
-func TestBeginRegistrationPrimary_Success(t *testing.T) {
-	requireRedis(t)
-	twofaTestRedis.FlushAll(context.Background())
-	svc, err := NewWebAuthnService("https://example.com", "Misskey", twofaTestRedis.Client)
-	require.NoError(t, err)
-	creation, err := svc.BeginRegistrationPrimary(context.Background(), &model.User{ID: "alice", Username: "alice"}, nil)
-	require.NoError(t, err)
-	require.NotNil(t, creation)
-	assert.NotEmpty(t, creation.Response.Challenge)
-	// primary slot に SessionData が入っていること
-	got, err := svc.takePrimarySession(context.Background(), "alice")
-	require.NoError(t, err)
-	assert.NotEmpty(t, got.Challenge)
-}
-
-func TestBeginRegistrationPrimary_PutSessionFails(t *testing.T) {
-	requireRedis(t)
-	c := redis.NewClient(&redis.Options{Addr: twofaTestRedis.Client.Options().Addr})
-	require.NoError(t, c.Close())
-	svc, err := NewWebAuthnService("https://example.com", "Misskey", c)
-	require.NoError(t, err)
-	_, err = svc.BeginRegistrationPrimary(context.Background(), &model.User{ID: "alice", Username: "alice"}, nil)
-	assert.Error(t, err)
-}
-
-func TestFinishRegistrationPrimary_SessionMissing(t *testing.T) {
-	requireRedis(t)
-	twofaTestRedis.FlushAll(context.Background())
-	svc, err := NewWebAuthnService("https://example.com", "Misskey", twofaTestRedis.Client)
-	require.NoError(t, err)
-	req := httptest.NewRequest("POST", "/", strings.NewReader(""))
-	_, err = svc.FinishRegistrationPrimary(context.Background(), &model.User{ID: "alice"}, nil, req)
-	assert.ErrorIs(t, err, ErrWebAuthnSessionNotFound)
-}
-
-func TestFinishRegistrationPrimary_Success(t *testing.T) {
-	requireRedis(t)
-	twofaTestRedis.FlushAll(context.Background())
-
-	// TestFinishRegistration_Success と同じ W3C ベクタを再利用
-	const (
-		attestationObjectHex = "a363666d74646e6f6e656761747453746d74a068617574684461746158a4bfabc37432958b063360d3ad6461c9c4735ae7f8edd46592a5e0f01452b2e4b559000000008446ccb9ab1db374750b2367ff6f3a1f0020f91f391db4c9b2fde0ea70189cba3fb63f579ba6122b33ad94ff3ec330084be4a5010203262001215820afefa16f97ca9b2d23eb86ccb64098d20db90856062eb249c33a9b672f26df61225820930a56b87a2fca66334b03458abf879717c12cc68ed73290af2e2664796b9220"
-		clientDataJSONHex    = "7b2274797065223a22776562617574686e2e637265617465222c226368616c6c656e6765223a22414d4d507434557878475453746e63647134313759447742466938767049612d7077386f4f755657345441222c226f726967696e223a2268747470733a2f2f6578616d706c652e6f7267222c2263726f73734f726967696e223a66616c73652c22657874726144617461223a22636c69656e74446174614a534f4e206d617920626520657874656e6465642077697468206164646974696f6e616c206669656c647320696e20746865206675747572652c207375636820617320746869733a20426b5165446a646354427258426941774a544c453551227d"
-		credentialIDHex      = "f91f391db4c9b2fde0ea70189cba3fb63f579ba6122b33ad94ff3ec330084be4"
-		challengeHex         = "00c30fb78531c464d2b6771dab8d7b603c01162f2fa486bea70f283ae556e130"
-	)
-	body := buildAttestationResponse(t, attestationObjectHex, clientDataJSONHex, credentialIDHex)
-	challenge := encodeBase64URL(decodeHex(t, challengeHex))
-
-	svc, err := NewWebAuthnService("https://example.org", "Misskey", twofaTestRedis.Client)
-	require.NoError(t, err)
-
-	sd := &webauthn.SessionData{
-		Challenge:  challenge,
-		UserID:     []byte("test-user-id"),
-		CredParams: []protocol.CredentialParameter{{Type: protocol.PublicKeyCredentialType, Algorithm: webauthncose.AlgES256}},
-	}
-	require.NoError(t, svc.putPrimarySession(context.Background(), "test-user-id", sd))
-
-	httpReq := httptest.NewRequest("POST", "/", bytes.NewReader(body))
-	cred, err := svc.FinishRegistrationPrimary(context.Background(), &model.User{ID: "test-user-id", Username: "test"}, nil, httpReq)
-	require.NoError(t, err)
-	require.NotNil(t, cred)
-	assert.Equal(t, decodeHex(t, credentialIDHex), cred.ID)
 }
 
 // --- ensure unused imports stay tidy ---

--- a/internal/core/twofactor/webauthn_test.go
+++ b/internal/core/twofactor/webauthn_test.go
@@ -418,6 +418,155 @@ func buildAttestationResponse(t *testing.T, attObjectHex, clientDataJSONHex, cre
 	return body
 }
 
+// --- BeginRegistrationPrimary / FinishRegistrationPrimary (#698) ---
+//
+// upstream-compat な single-in-flight-per-user 経路。session id round-trip が
+// 無いので primary slot 1 つだけ Redis に保持する。
+
+func TestPrimarySessionKey(t *testing.T) {
+	assert.Equal(t, "twofa:webauthn:alice:primary", primarySessionKey("alice"))
+}
+
+func TestPutAndTakePrimarySession_Roundtrip(t *testing.T) {
+	requireRedis(t)
+	twofaTestRedis.FlushAll(context.Background())
+	svc, err := NewWebAuthnService("https://example.com", "Misskey", twofaTestRedis.Client)
+	require.NoError(t, err)
+
+	sd := makeFakeSessionData()
+	require.NoError(t, svc.putPrimarySession(context.Background(), "alice", sd))
+
+	got, err := svc.takePrimarySession(context.Background(), "alice")
+	require.NoError(t, err)
+	assert.Equal(t, sd.Challenge, got.Challenge)
+
+	// take は single-use: 2 回目は ErrWebAuthnSessionNotFound
+	_, err = svc.takePrimarySession(context.Background(), "alice")
+	assert.ErrorIs(t, err, ErrWebAuthnSessionNotFound)
+}
+
+func TestPutPrimarySession_Overwrites(t *testing.T) {
+	requireRedis(t)
+	twofaTestRedis.FlushAll(context.Background())
+	svc, err := NewWebAuthnService("https://example.com", "Misskey", twofaTestRedis.Client)
+	require.NoError(t, err)
+
+	first := makeFakeSessionData()
+	first.Challenge = "first"
+	second := makeFakeSessionData()
+	second.Challenge = "second"
+
+	require.NoError(t, svc.putPrimarySession(context.Background(), "alice", first))
+	require.NoError(t, svc.putPrimarySession(context.Background(), "alice", second))
+
+	got, err := svc.takePrimarySession(context.Background(), "alice")
+	require.NoError(t, err)
+	assert.Equal(t, "second", got.Challenge)
+}
+
+func TestPutPrimarySession_NilRedis(t *testing.T) {
+	svc := &WebAuthnService{}
+	err := svc.putPrimarySession(context.Background(), "alice", makeFakeSessionData())
+	assert.ErrorIs(t, err, ErrWebAuthnNotConfigured)
+}
+
+func TestTakePrimarySession_NilRedis(t *testing.T) {
+	svc := &WebAuthnService{}
+	_, err := svc.takePrimarySession(context.Background(), "alice")
+	assert.ErrorIs(t, err, ErrWebAuthnNotConfigured)
+}
+
+func TestTakePrimarySession_RedisError(t *testing.T) {
+	requireRedis(t)
+	c := redis.NewClient(&redis.Options{Addr: twofaTestRedis.Client.Options().Addr})
+	svc, err := NewWebAuthnService("https://example.com", "Misskey", c)
+	require.NoError(t, err)
+	require.NoError(t, svc.putPrimarySession(context.Background(), "alice", makeFakeSessionData()))
+	require.NoError(t, c.Close())
+	_, err = svc.takePrimarySession(context.Background(), "alice")
+	assert.Error(t, err)
+	assert.NotErrorIs(t, err, ErrWebAuthnSessionNotFound)
+}
+
+func TestBeginRegistrationPrimary_NotConfigured(t *testing.T) {
+	svc := &WebAuthnService{}
+	_, err := svc.BeginRegistrationPrimary(context.Background(), &model.User{ID: "x"}, nil)
+	assert.ErrorIs(t, err, ErrWebAuthnNotConfigured)
+}
+
+func TestFinishRegistrationPrimary_NotConfigured(t *testing.T) {
+	svc := &WebAuthnService{}
+	req := httptest.NewRequest("POST", "/", strings.NewReader(""))
+	_, err := svc.FinishRegistrationPrimary(context.Background(), &model.User{ID: "x"}, nil, req)
+	assert.ErrorIs(t, err, ErrWebAuthnNotConfigured)
+}
+
+func TestBeginRegistrationPrimary_Success(t *testing.T) {
+	requireRedis(t)
+	twofaTestRedis.FlushAll(context.Background())
+	svc, err := NewWebAuthnService("https://example.com", "Misskey", twofaTestRedis.Client)
+	require.NoError(t, err)
+	creation, err := svc.BeginRegistrationPrimary(context.Background(), &model.User{ID: "alice", Username: "alice"}, nil)
+	require.NoError(t, err)
+	require.NotNil(t, creation)
+	assert.NotEmpty(t, creation.Response.Challenge)
+	// primary slot に SessionData が入っていること
+	got, err := svc.takePrimarySession(context.Background(), "alice")
+	require.NoError(t, err)
+	assert.NotEmpty(t, got.Challenge)
+}
+
+func TestBeginRegistrationPrimary_PutSessionFails(t *testing.T) {
+	requireRedis(t)
+	c := redis.NewClient(&redis.Options{Addr: twofaTestRedis.Client.Options().Addr})
+	require.NoError(t, c.Close())
+	svc, err := NewWebAuthnService("https://example.com", "Misskey", c)
+	require.NoError(t, err)
+	_, err = svc.BeginRegistrationPrimary(context.Background(), &model.User{ID: "alice", Username: "alice"}, nil)
+	assert.Error(t, err)
+}
+
+func TestFinishRegistrationPrimary_SessionMissing(t *testing.T) {
+	requireRedis(t)
+	twofaTestRedis.FlushAll(context.Background())
+	svc, err := NewWebAuthnService("https://example.com", "Misskey", twofaTestRedis.Client)
+	require.NoError(t, err)
+	req := httptest.NewRequest("POST", "/", strings.NewReader(""))
+	_, err = svc.FinishRegistrationPrimary(context.Background(), &model.User{ID: "alice"}, nil, req)
+	assert.ErrorIs(t, err, ErrWebAuthnSessionNotFound)
+}
+
+func TestFinishRegistrationPrimary_Success(t *testing.T) {
+	requireRedis(t)
+	twofaTestRedis.FlushAll(context.Background())
+
+	// TestFinishRegistration_Success と同じ W3C ベクタを再利用
+	const (
+		attestationObjectHex = "a363666d74646e6f6e656761747453746d74a068617574684461746158a4bfabc37432958b063360d3ad6461c9c4735ae7f8edd46592a5e0f01452b2e4b559000000008446ccb9ab1db374750b2367ff6f3a1f0020f91f391db4c9b2fde0ea70189cba3fb63f579ba6122b33ad94ff3ec330084be4a5010203262001215820afefa16f97ca9b2d23eb86ccb64098d20db90856062eb249c33a9b672f26df61225820930a56b87a2fca66334b03458abf879717c12cc68ed73290af2e2664796b9220"
+		clientDataJSONHex    = "7b2274797065223a22776562617574686e2e637265617465222c226368616c6c656e6765223a22414d4d507434557878475453746e63647134313759447742466938767049612d7077386f4f755657345441222c226f726967696e223a2268747470733a2f2f6578616d706c652e6f7267222c2263726f73734f726967696e223a66616c73652c22657874726144617461223a22636c69656e74446174614a534f4e206d617920626520657874656e6465642077697468206164646974696f6e616c206669656c647320696e20746865206675747572652c207375636820617320746869733a20426b5165446a646354427258426941774a544c453551227d"
+		credentialIDHex      = "f91f391db4c9b2fde0ea70189cba3fb63f579ba6122b33ad94ff3ec330084be4"
+		challengeHex         = "00c30fb78531c464d2b6771dab8d7b603c01162f2fa486bea70f283ae556e130"
+	)
+	body := buildAttestationResponse(t, attestationObjectHex, clientDataJSONHex, credentialIDHex)
+	challenge := encodeBase64URL(decodeHex(t, challengeHex))
+
+	svc, err := NewWebAuthnService("https://example.org", "Misskey", twofaTestRedis.Client)
+	require.NoError(t, err)
+
+	sd := &webauthn.SessionData{
+		Challenge:  challenge,
+		UserID:     []byte("test-user-id"),
+		CredParams: []protocol.CredentialParameter{{Type: protocol.PublicKeyCredentialType, Algorithm: webauthncose.AlgES256}},
+	}
+	require.NoError(t, svc.putPrimarySession(context.Background(), "test-user-id", sd))
+
+	httpReq := httptest.NewRequest("POST", "/", bytes.NewReader(body))
+	cred, err := svc.FinishRegistrationPrimary(context.Background(), &model.User{ID: "test-user-id", Username: "test"}, nil, httpReq)
+	require.NoError(t, err)
+	require.NotNil(t, cred)
+	assert.Equal(t, decodeHex(t, credentialIDHex), cred.ID)
+}
+
 // --- ensure unused imports stay tidy ---
 
 var _ = redis.Nil


### PR DESCRIPTION
## Summary

`/api/i/2fa/register-key` と `/api/i/2fa/key-done` のリクエスト/レスポンス形式が upstream Misskey TS (`@simplewebauthn/server` ベース) と非互換だったため、frontend (`third_party/misskey/...settings/2fa.vue`) からのパスキー登録が silently 失敗していた問題を修正。

検証: UDS スタックで実機ブラウザからパスキー登録が完了することを確認済み。

## 主な変更点

### handler 側 (`internal/api/i/handler_2fa.go`)

- `TwoFARegisterKey`: `{password, token}` を受けて、`PublicKeyCredentialCreationOptions` を直接返すように変更 (旧 `{sessionId, creation}` ラップを廃止)
- `TwoFAKeyDone`: `{password, token, name, credential}` を受けるように変更 (旧 `{sessionId, response}`)
- どちらも `profile.twoFactorEnabled = true` を必須化 (upstream と同じ)。未有効化時は `TWO_FACTOR_NOT_ENABLED`
- 2FA token 検証 (TOTP + backup code consume) の helper `verify2FAToken` を追加

### service 側 (`internal/core/twofactor/webauthn.go`)

- `BeginRegistrationPrimary` / `FinishRegistrationPrimary` を追加 — upstream 互換の per-user single-in-flight session (sessionId round-trip 不要、Misskey TS の `WebAuthnService.initiateRegistration` / `verifyRegistration` 相当)
- `BeginRegistrationPrimary` で `authenticatorSelection.residentKey = required` / `userVerification = preferred` を明示指定 — 一部 authenticator + browser 組合せ (passkey 経由 platform authenticator など) で指定が無いとブラウザダイアログは出るが credential が返らない silent failure を防ぐ

### lint 例外更新 (`internal/api/apierr/zero_uuid_lint_test.go`)

- handler_2fa.go の zero-UUID 例外数を 5 → 7 に更新 (TwoFARegisterKey / TwoFAKeyDone の `INVALID_TOKEN` で 2 件追加。upstream は 2FA 失敗時に `new Error('authentication failed')` を投げる ApiError 非経由なので UUID 紐付け不可)

## テスト

- `internal/api/i/handler_webauthn_test.go`: 新 wire format への追従 + 2FA 必須化 / token 検証 (TOTP enabled / disabled / invalid / backup consume) / sessionId 廃止確認
- `internal/core/twofactor/webauthn_test.go`: `BeginRegistrationPrimary` / `FinishRegistrationPrimary` / `putPrimarySession` / `takePrimarySession` のフルカバー (NotConfigured / Redis err / overwrite / take after take / W3C 仕様ベクタ Success path)

カバレッジ: `internal/api/i` 90.4% / `internal/core/twofactor` 90.9% (90% 閾値クリア)

実行方法:
```bash
go test ./internal/api/i/... ./internal/core/twofactor/... ./internal/api/apierr/... -count=1 -race
```

## 検証手順

1. UDS スタック (`make uds-up`) でユーザー登録 → TOTP で 2FA 有効化
2. 設定 → セキュリティとプライバシー → セキュリティキー追加
3. password + 2FA token を入力 (1 回目)
4. キーの名前を入力
5. ブラウザの passkey ダイアログで authenticator (Touch ID / 物理キー / etc.) を承認
6. password + 2FA token を再入力 (upstream FE が 2 段で要求)
7. 登録完了

## Related

Closes #698

🤖 Generated with [Claude Code](https://claude.com/claude-code)