### PR TITLE
Fix #692: チャット連合 (CherryPick 互換) と未読/許可設定の修正

### DIFF
--- a/internal/activitypub/renderer.go
+++ b/internal/activitypub/renderer.go
@@ -261,6 +261,12 @@ func (r *Renderer) RenderPerson(u *model.User, profile *model.UserProfile, publi
 	p.MisskeyRequireSigninToViewContents = u.RequireSigninToViewContents
 	p.MisskeyMakeNotesFollowersOnlyBefore = u.MakeNotesFollowersOnlyBefore
 	p.MisskeyMakeNotesHiddenBefore = u.MakeNotesHiddenBefore
+	// `_misskey_canChat` は CherryPick 互換の chat 連合 capability flag。
+	// chatScope == "none" 以外なら true (everyone/followers/following/mutual)
+	// と公開する。granular な scope は受信側で local 強制されるので AP には
+	// boolean だけ流す (#692)。
+	canChat := u.ChatScope != "none"
+	p.MisskeyCanChat = &canChat
 
 	// profile から追加フィールドを埋める
 	if profile != nil {
@@ -871,24 +877,47 @@ func (r *Renderer) RenderMove(src *model.User, dstURI string) *Move {
 	return m
 }
 
-// RenderChatMessage returns a CherryPick-compatible Misskey:ChatMessage
-// activity for 1-on-1 DM federation. Only used when the recipient is a remote
-// user. The activity type is `Misskey:ChatMessage` (not a standard AS type).
-func (r *Renderer) RenderChatMessage(msg *model.ChatMessage, senderURI, recipientURI string) *ChatMessageActivity {
-	cm := &ChatMessageActivity{
+// RenderChatMessage returns a CherryPick-compatible Create activity wrapping
+// a Note flagged with `_misskey_talk: true`. ApRendererService.renderChatMessage
+// と同じ wire format を出すことで CherryPick / レガシー Misskey との 1-on-1
+// DM 連合互換性を確保する (#692)。
+//
+// 受け手側 (cherrypick の ApInboxService) は Note.`_misskey_talk` flag を見て
+// chat_messages テーブルに保存する。chat 専用 type ではなく標準 Note を
+// 使う設計なので、未対応の受信実装でも単なる note の Create として黙殺
+// (致命的なエラーは起きない) のが利点。
+func (r *Renderer) RenderChatMessage(msg *model.ChatMessage, senderURI, recipientURI string, published string) *Create {
+	noteURI := r.urls.ChatMessageURI(msg.ID)
+	note := &Note{
 		Object: Object{
-			ID:   r.urls.ChatMessageURI(msg.ID),
-			Type: "Misskey:ChatMessage",
+			ID:   noteURI,
+			Type: "Note",
 		},
-		Actor:        senderURI,
 		AttributedTo: senderURI,
-		To:           recipientURI,
+		Published:    published,
+		To:           []string{recipientURI},
+		MisskeyTalk:  true,
 	}
 	if msg.Text != nil {
-		cm.Content = *msg.Text
+		note.Content = *msg.Text
 	}
-	AddContext(cm)
-	return cm
+	c := &Create{
+		Activity: Activity{
+			Object: Object{
+				// Create activity の id は Note URI に "/activity" を付与した
+				// 派生 URI とする (cherrypick も同様に renderActivity 系で
+				// Create id を Note id から派生させる慣習)。
+				ID:   noteURI + "/activity",
+				Type: "Create",
+			},
+			Actor:     senderURI,
+			Published: published,
+			To:        []string{recipientURI},
+		},
+		Object: note,
+	}
+	AddContext(c)
+	return c
 }
 
 // addressing computes to/cc lists for a note based on visibility.

--- a/internal/activitypub/renderer_test.go
+++ b/internal/activitypub/renderer_test.go
@@ -76,6 +76,31 @@ func TestRenderer_RenderPerson_NoOptionalFields(t *testing.T) {
 	assert.False(t, p.ManuallyApproves)
 }
 
+func TestRenderer_RenderPerson_MisskeyCanChat(t *testing.T) {
+	// chatScope=='none' の local user は AP 上 `_misskey_canChat: false` を
+	// expose し、それ以外は true。pointer なので両ケースで non-nil (#692)。
+	cases := []struct {
+		scope string
+		want  bool
+	}{
+		{"", true},
+		{"everyone", true},
+		{"followers", true},
+		{"following", true},
+		{"mutual", true},
+		{"none", false},
+	}
+	r := newRenderer()
+	for _, tc := range cases {
+		t.Run(tc.scope, func(t *testing.T) {
+			u := &model.User{ID: "u1", Username: "alice", ChatScope: tc.scope}
+			p := r.RenderPerson(u, nil, "PUBKEY")
+			require.NotNil(t, p.MisskeyCanChat)
+			assert.Equal(t, tc.want, *p.MisskeyCanChat)
+		})
+	}
+}
+
 func newIDGen(t *testing.T) id.Generator {
 	t.Helper()
 	g, _ := id.NewGenerator("aidx")

--- a/internal/activitypub/types.go
+++ b/internal/activitypub/types.go
@@ -91,8 +91,12 @@ type Person struct {
 	MisskeyRequireSigninToViewContents  bool      `json:"_misskey_requireSigninToViewContents,omitempty"`
 	MisskeyMakeNotesFollowersOnlyBefore *int      `json:"_misskey_makeNotesFollowersOnlyBefore,omitempty"`
 	MisskeyMakeNotesHiddenBefore        *int      `json:"_misskey_makeNotesHiddenBefore,omitempty"`
-	MovedTo                             string    `json:"movedTo,omitempty"`
-	AlsoKnownAs                         []string  `json:"alsoKnownAs,omitempty"`
+	// MisskeyCanChat は CherryPick の chat 連合 capability flag (#692)。
+	// 受信側 instance が DM を受け付けるか (false なら拒絶) を表す boolean。
+	// pointer で持つことで「未指定 (= 旧実装 / 互換) → 許可」を区別する。
+	MisskeyCanChat *bool    `json:"_misskey_canChat,omitempty"`
+	MovedTo        string   `json:"movedTo,omitempty"`
+	AlsoKnownAs    []string `json:"alsoKnownAs,omitempty"`
 }
 
 // Note represents a note object (microblog post).
@@ -112,6 +116,10 @@ type Note struct {
 	MisskeyContent string   `json:"_misskey_content,omitempty"`
 	MisskeyQuote   string   `json:"_misskey_quote,omitempty"`
 	QuoteURL       string   `json:"quoteUrl,omitempty"`
+	// MisskeyTalk は CherryPick / レガシー Misskey のチャット連合 flag (#692)。
+	// `_misskey_talk: true` が立った Note は ApInboxService で chat message
+	// として処理される (notes テーブルではなく chat_messages テーブルに保存)。
+	MisskeyTalk bool `json:"_misskey_talk,omitempty"`
 	// Name は AP poll vote (Question への投票) で choice 名を運ぶ field。
 	// Misskey TS の vote AP payload は `{type: "Note", name: "<choice>",
 	// inReplyTo: <poll URI>}` 形式で、ApNoteService が name + inReplyTo の
@@ -296,20 +304,6 @@ type Move struct {
 	Target string `json:"target"`
 }
 
-// ChatMessageActivity represents a CherryPick-compatible `Misskey:ChatMessage`
-// activity used for 1-on-1 DM federation with Misskey v12 and compatible forks.
-// ActivityではなくObjectを埋め込みつつ、Actorを独立フィールドで持つ。
-// To はCherryPick互換のため string (配列ではない)。
-type ChatMessageActivity struct {
-	Object
-	Actor        string `json:"actor"`
-	AttributedTo string `json:"attributedTo"`
-	To           string `json:"to"`
-	Content      string `json:"content,omitempty"`
-	Tag          []any  `json:"tag,omitempty"`
-	Attachment   []any  `json:"attachment,omitempty"`
-}
-
 // MisskeyContext は Misskey/Mastodon/schema.org 拡張語彙を含むコンテキストオブジェクト。
 // TS版 contexts.ts と同等。
 var MisskeyContext = map[string]any{
@@ -330,6 +324,8 @@ var MisskeyContext = map[string]any{
 	"_misskey_content":                      "misskey:_misskey_content",
 	"_misskey_quote":                        "misskey:_misskey_quote",
 	"_misskey_reaction":                     "misskey:_misskey_reaction",
+	"_misskey_talk":                         "misskey:_misskey_talk",
+	"_misskey_canChat":                      "misskey:_misskey_canChat",
 	"_misskey_votes":                        "misskey:_misskey_votes",
 	"_misskey_summary":                      "misskey:_misskey_summary",
 	"_misskey_followedMessage":              "misskey:_misskey_followedMessage",
@@ -382,8 +378,6 @@ func AddContext(o any) {
 	case *Flag:
 		v.Context = ctx
 	case *Move:
-		v.Context = ctx
-	case *ChatMessageActivity:
 		v.Context = ctx
 	}
 }

--- a/internal/api/chat/handler.go
+++ b/internal/api/chat/handler.go
@@ -2,6 +2,7 @@ package chat
 
 import (
 	"errors"
+	"log/slog"
 	"net/http"
 	"time"
 
@@ -46,6 +47,11 @@ func (h *Handler) mapChatErr(c echo.Context, err error) error {
 		return c.JSON(http.StatusForbidden, apierr.Error("ACCESS_DENIED", "Access denied.", "1fb7cb09-d46a-4fff-b8df-057708cce513"))
 	case errors.Is(err, corechat.ErrInvalidTarget):
 		return c.JSON(http.StatusBadRequest, apierr.Error("INVALID_PARAM", "toUserId or toRoomId is required.", "ed1d7571-a3ac-4370-899c-0dbe5e230cc8"))
+	case errors.Is(err, corechat.ErrChatScopeViolation):
+		// CherryPick の `recipient is cannot chat (...)` 相当 (#692)。
+		// upstream は ApiError を持たず単なる Error を投げるので mk-go 固有
+		// code (RECIPIENT_CANNOT_CHAT) で返す。frontend の対応は別 issue。
+		return c.JSON(http.StatusForbidden, apierr.Error("RECIPIENT_CANNOT_CHAT", "Recipient does not allow chat from you.", "5e1fa6e8-1d2f-49a3-9c20-7a09be7b4c43"))
 	}
 	return c.JSON(http.StatusInternalServerError, apierr.Error("INTERNAL_ERROR", "Internal error.", "5d37dbcb-891e-41ca-a3d6-e690c97775ac"))
 }
@@ -74,8 +80,69 @@ func packMessage(m *model.ChatMessage) map[string]any {
 	return result
 }
 
+// packMessageWithCreatedAt augments packMessage with createdAt parsed from the
+// message ID. createdAt 欠落だと FE 側の MkTime が `Invalid Date` を表示し、
+// 一覧では NaN/NaN になる (#692)。
+func (h *Handler) packMessageWithCreatedAt(m *model.ChatMessage) map[string]any {
+	result := packMessage(m)
+	if h.idGen != nil {
+		if t, err := h.idGen.ParseTime(m.ID); err == nil {
+			result["createdAt"] = t.UTC().Format("2006-01-02T15:04:05.000Z")
+		}
+	}
+	return result
+}
+
+// packMessageDetailed builds the upstream-compatible ChatMessage payload
+// expected by MkChatHistories.vue: createdAt (ID から派生)、fromUser、
+// toUser (DM の時)、toRoom (room の時)。upstream の
+// ChatEntityService.packMessageDetailed 相当 (#692)。
+//
+// FE は createdAt を `new Date(m.createdAt).getTime()` で sort key に使う
+// ので、欠損していると `NaN` になりリストが空になる。room メッセージは
+// `'room' in m` で判定して "other" のかわりに room を表示する。
+func (h *Handler) packMessageDetailed(m *model.ChatMessage) map[string]any {
+	result := h.packMessageWithCreatedAt(m)
+	if m.ToUser != nil {
+		result["toUser"] = packUser(m.ToUser)
+	}
+	if m.ToRoom != nil {
+		result["toRoom"] = packRoom(m.ToRoom)
+		// upstream の `'room' in m` 判定に合わせて `room` alias も入れる。
+		// 旧 chat 実装ではこの key で判定していた残存 client がある。
+		result["room"] = packRoom(m.ToRoom)
+	}
+	return result
+}
+
+// packUser produces the UserLite shape consumed by FE chat components.
+// FE の MkAvatar / MkUserName が `avatarUrl` / `avatarBlurhash` を読むため、
+// 含めないとアイコンが空のまま表示される (#692)。
+//
+// avatarUrl 未設定時は upstream Misskey TS と同様に `/identicon/<username>`
+// (リモートなら `<username>@<host>`) を fallback として返す。frontend は
+// `null` を受けるとデフォルト identicon URL を組み立てない実装が一部に
+// あるため、サーバ側で確実に URL を埋めておく。
 func packUser(u *model.User) map[string]any {
-	return map[string]any{"id": u.ID, "username": u.Username, "name": u.Name, "host": u.Host}
+	avatarURL := u.AvatarURL
+	if avatarURL == nil || *avatarURL == "" {
+		host := ""
+		if u.Host != nil {
+			host = "@" + *u.Host
+		}
+		identicon := "/identicon/" + u.Username + host
+		avatarURL = &identicon
+	}
+	return map[string]any{
+		"id":             u.ID,
+		"username":       u.Username,
+		"name":           u.Name,
+		"host":           u.Host,
+		"avatarUrl":      avatarURL,
+		"avatarBlurhash": u.AvatarBlurhash,
+		"isBot":          u.IsBot,
+		"isCat":          u.IsCat,
+	}
 }
 
 // --- Rooms ---
@@ -291,7 +358,7 @@ func (h *Handler) MessagesCreate(c echo.Context) error {
 	if err != nil {
 		return h.mapChatErr(c, err)
 	}
-	return c.JSON(http.StatusOK, packMessage(msg))
+	return c.JSON(http.StatusOK, h.packMessageWithCreatedAt(msg))
 }
 
 // messagesCreateLegacy preserves pre-Phase-9.8 behaviour for callers that
@@ -306,7 +373,7 @@ func (h *Handler) messagesCreateLegacy(c echo.Context, user *model.User, text, t
 	if err := h.repo.CreateMessage(msg); err != nil {
 		return c.JSON(http.StatusInternalServerError, apierr.Error("INTERNAL_ERROR", "Internal error.", "5d37dbcb-891e-41ca-a3d6-e690c97775ac"))
 	}
-	return c.JSON(http.StatusOK, packMessage(msg))
+	return c.JSON(http.StatusOK, h.packMessageWithCreatedAt(msg))
 }
 
 // MessagesShow handles POST /api/chat/messages/show.
@@ -321,7 +388,7 @@ func (h *Handler) MessagesShow(c echo.Context) error {
 	if err != nil {
 		return c.JSON(http.StatusNotFound, apierr.Error("NO_SUCH_MESSAGE", "No such message.", "006d73c9-dada-5b5d-a0f5-00b01f70bc3c"))
 	}
-	return c.JSON(http.StatusOK, packMessage(msg))
+	return c.JSON(http.StatusOK, h.packMessageWithCreatedAt(msg))
 }
 
 // MessagesUpdate handles POST /api/chat/messages/update.
@@ -417,7 +484,7 @@ func (h *Handler) Messages(c echo.Context) error {
 	}
 	result := make([]map[string]any, len(msgs))
 	for i, m := range msgs {
-		result[i] = packMessage(m)
+		result[i] = h.packMessageWithCreatedAt(m)
 	}
 	return c.JSON(http.StatusOK, result)
 }
@@ -435,7 +502,7 @@ func (h *Handler) MessagesSearch(c echo.Context) error {
 	msgs, _ := h.repo.SearchMessages(user.ID, req.Query, req.Limit)
 	result := make([]map[string]any, len(msgs))
 	for i, m := range msgs {
-		result[i] = packMessage(m)
+		result[i] = h.packMessageWithCreatedAt(m)
 	}
 	return c.JSON(http.StatusOK, result)
 }
@@ -600,6 +667,11 @@ func (h *Handler) MessagesCreateToRoom(c echo.Context) error {
 }
 
 // UserTimeline handles POST /api/chat/messages/user-timeline.
+//
+// upstream の readUserChatMessage 相当: チャット画面を開いた瞬間に「相手 →
+// 自分」の DM をすべて既読としてマークする。FE は新着メッセージにしか
+// 'read' イベントを送らないので、initial load 時点の既読化はサーバ側で
+// やらないと unread badge がリロードのたびに復活する (#692)。
 func (h *Handler) UserTimeline(c echo.Context) error {
 	user := middleware.GetUser(c)
 	var req struct {
@@ -619,15 +691,22 @@ func (h *Handler) UserTimeline(c echo.Context) error {
 	if err != nil {
 		return apierr.JSONInternalError(c)
 	}
+	// 既読マーク (best effort; 失敗しても timeline 表示は継続)。
+	if err := h.repo.MarkAllReadFromUser(user.ID, req.UserID); err != nil {
+		slog.Warn("chat: MarkAllReadFromUser failed", "readerId", user.ID, "fromUserId", req.UserID, "err", err)
+	}
 	out := make([]map[string]any, 0, len(msgs))
 	for _, m := range msgs {
-		out = append(out, packMessage(m))
+		out = append(out, h.packMessageWithCreatedAt(m))
 	}
 	return c.JSON(http.StatusOK, out)
 }
 
 // RoomTimeline handles POST /api/chat/messages/room-timeline.
+//
+// upstream の readRoomChatMessage 相当 (#692)。
 func (h *Handler) RoomTimeline(c echo.Context) error {
+	user := middleware.GetUser(c)
 	var req struct {
 		RoomID string `json:"roomId"`
 		Limit  int    `json:"limit"`
@@ -645,9 +724,12 @@ func (h *Handler) RoomTimeline(c echo.Context) error {
 	if err != nil {
 		return apierr.JSONInternalError(c)
 	}
+	if err := h.repo.MarkAllReadInRoom(user.ID, req.RoomID); err != nil {
+		slog.Warn("chat: MarkAllReadInRoom failed", "readerId", user.ID, "roomId", req.RoomID, "err", err)
+	}
 	out := make([]map[string]any, 0, len(msgs))
 	for _, m := range msgs {
-		out = append(out, packMessage(m))
+		out = append(out, h.packMessageWithCreatedAt(m))
 	}
 	return c.JSON(http.StatusOK, out)
 }
@@ -781,10 +863,17 @@ func (h *Handler) RoomsMembers(c echo.Context) error {
 // --- Other ---
 
 // History handles POST /api/chat/history.
+//
+// upstream `chat/history` は `room: bool` parameter を取り、true の時は
+// chat ルーム内の最新メッセージ、false (デフォルト) の時は 1-on-1 DM の
+// 最新メッセージを返す。FE の MkChatHistories.vue は両方を並行に呼んで
+// マージするため、room パラメータを正しくハンドリングしないと chat home
+// で何も描画されない (#692)。
 func (h *Handler) History(c echo.Context) error {
 	user := middleware.GetUser(c)
 	var req struct {
-		Limit int `json:"limit"`
+		Limit int  `json:"limit"`
+		Room  bool `json:"room"`
 	}
 	_ = c.Bind(&req)
 	if req.Limit <= 0 {
@@ -793,13 +882,21 @@ func (h *Handler) History(c echo.Context) error {
 	if req.Limit > 100 {
 		req.Limit = 100
 	}
-	msgs, err := h.repo.ListHistory(user.ID, req.Limit)
+	var (
+		msgs []*model.ChatMessage
+		err  error
+	)
+	if req.Room {
+		msgs, err = h.repo.ListRoomHistory(user.ID, req.Limit)
+	} else {
+		msgs, err = h.repo.ListUserHistory(user.ID, req.Limit)
+	}
 	if err != nil {
 		return apierr.JSONInternalError(c)
 	}
 	out := make([]map[string]any, 0, len(msgs))
 	for _, m := range msgs {
-		out = append(out, packMessage(m))
+		out = append(out, h.packMessageDetailed(m))
 	}
 	return c.JSON(http.StatusOK, out)
 }

--- a/internal/api/chat/handler.go
+++ b/internal/api/chat/handler.go
@@ -9,6 +9,7 @@ import (
 	"github.com/labstack/echo/v4"
 	"github.com/shiroha-a/mk/internal/api/apierr"
 	corechat "github.com/shiroha-a/mk/internal/core/chat"
+	"github.com/shiroha-a/mk/internal/entity"
 	"github.com/shiroha-a/mk/internal/misc/id"
 	"github.com/shiroha-a/mk/internal/model"
 	"github.com/shiroha-a/mk/internal/repository"
@@ -52,6 +53,11 @@ func (h *Handler) mapChatErr(c echo.Context, err error) error {
 		// upstream は ApiError を持たず単なる Error を投げるので mk-go 固有
 		// code (RECIPIENT_CANNOT_CHAT) で返す。frontend の対応は別 issue。
 		return c.JSON(http.StatusForbidden, apierr.Error("RECIPIENT_CANNOT_CHAT", "Recipient does not allow chat from you.", "5e1fa6e8-1d2f-49a3-9c20-7a09be7b4c43"))
+	case errors.Is(err, corechat.ErrChatScopeUnconfigured):
+		// followingRepo 未配線。production では起きてはいけないので 500 と
+		// log で運用者に気付かせる (silent allow するより安全側)。
+		slog.Error("chat: followingRepo missing; chatScope granular check failed closed", "err", err)
+		return apierr.JSONInternalError(c)
 	}
 	return c.JSON(http.StatusInternalServerError, apierr.Error("INTERNAL_ERROR", "Internal error.", "5d37dbcb-891e-41ca-a3d6-e690c97775ac"))
 }
@@ -117,28 +123,16 @@ func (h *Handler) packMessageDetailed(m *model.ChatMessage) map[string]any {
 
 // packUser produces the UserLite shape consumed by FE chat components.
 // FE の MkAvatar / MkUserName が `avatarUrl` / `avatarBlurhash` を読むため、
-// 含めないとアイコンが空のまま表示される (#692)。
-//
-// avatarUrl 未設定時は upstream Misskey TS と同様に `/identicon/<username>`
-// (リモートなら `<username>@<host>`) を fallback として返す。frontend は
-// `null` を受けるとデフォルト identicon URL を組み立てない実装が一部に
-// あるため、サーバ側で確実に URL を埋めておく。
+// 含めないとアイコンが空のまま表示される (#692)。avatarUrl 未設定時は
+// `entity.IdenticonURL` 経由で identicon URL に fallback する (TS upstream
+// `getIdenticonUrl` 相当)。
 func packUser(u *model.User) map[string]any {
-	avatarURL := u.AvatarURL
-	if avatarURL == nil || *avatarURL == "" {
-		host := ""
-		if u.Host != nil {
-			host = "@" + *u.Host
-		}
-		identicon := "/identicon/" + u.Username + host
-		avatarURL = &identicon
-	}
 	return map[string]any{
 		"id":             u.ID,
 		"username":       u.Username,
 		"name":           u.Name,
 		"host":           u.Host,
-		"avatarUrl":      avatarURL,
+		"avatarUrl":      entity.IdenticonURL(u),
 		"avatarBlurhash": u.AvatarBlurhash,
 		"isBot":          u.IsBot,
 		"isCat":          u.IsCat,

--- a/internal/api/chat/handler_test.go
+++ b/internal/api/chat/handler_test.go
@@ -140,7 +140,15 @@ func (m *mockChatRepo) UpdateDeliveryStatus(_ string, _, _ bool) error { return 
 func (m *mockChatRepo) ListHistory(_ string, _ int) ([]*model.ChatMessage, error) {
 	return nil, nil
 }
+func (m *mockChatRepo) ListUserHistory(_ string, _ int) ([]*model.ChatMessage, error) {
+	return nil, nil
+}
+func (m *mockChatRepo) ListRoomHistory(_ string, _ int) ([]*model.ChatMessage, error) {
+	return nil, nil
+}
 func (m *mockChatRepo) MarkAllRead(_ string) error                         { return nil }
+func (m *mockChatRepo) MarkAllReadFromUser(_, _ string) error              { return nil }
+func (m *mockChatRepo) MarkAllReadInRoom(_, _ string) error                { return nil }
 func (m *mockChatRepo) AddReaction(_, _ string) error                      { return nil }
 func (m *mockChatRepo) RemoveReaction(_, _ string) error                   { return nil }
 func (m *mockChatRepo) UpdateInvitation(_ *model.ChatRoomInvitation) error { return nil }

--- a/internal/api/chat/handler_test.go
+++ b/internal/api/chat/handler_test.go
@@ -7,6 +7,7 @@ import (
 	"net/http/httptest"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/labstack/echo/v4"
 	"github.com/lib/pq"
@@ -773,10 +774,74 @@ func TestMembersUpdateMembership(t *testing.T) {
 
 func TestHistory(t *testing.T) {
 	h, _ := newTestHandler()
+	// default (room=false) → ListUserHistory に dispatch
 	rec := post(h.History, `{}`, u1)
 	assert.Equal(t, http.StatusOK, rec.Code)
 	rec2 := post(h.History, `{"limit":5}`, u1)
 	assert.Equal(t, http.StatusOK, rec2.Code)
+	// room=true → ListRoomHistory に dispatch (#692)
+	rec3 := post(h.History, `{"room":true,"limit":3}`, u1)
+	assert.Equal(t, http.StatusOK, rec3.Code)
+	// limit clamp: 0 → 10, 9999 → 100 (内部分岐の coverage 確保)
+	assert.Equal(t, http.StatusOK, post(h.History, `{"limit":0}`, u1).Code)
+	assert.Equal(t, http.StatusOK, post(h.History, `{"limit":9999}`, u1).Code)
+}
+
+// #692 review #7: UserTimeline / RoomTimeline がそれぞれ
+// MarkAllReadFromUser / MarkAllReadInRoom を呼んでチャット画面を開いた瞬間に
+// 既読化することを assert する (handler 側の wiring を guard)。
+type readMarkSpyRepo struct {
+	*mockChatRepo
+	markFromUserCalled struct{ reader, fromUser string }
+	markInRoomCalled   struct{ reader, room string }
+}
+
+func (m *readMarkSpyRepo) MarkAllReadFromUser(reader, fromUser string) error {
+	m.markFromUserCalled.reader = reader
+	m.markFromUserCalled.fromUser = fromUser
+	return nil
+}
+
+func (m *readMarkSpyRepo) MarkAllReadInRoom(reader, room string) error {
+	m.markInRoomCalled.reader = reader
+	m.markInRoomCalled.room = room
+	return nil
+}
+
+func TestUserTimeline_MarksReadOnOpen(t *testing.T) {
+	spy := &readMarkSpyRepo{mockChatRepo: newMock()}
+	idGen, _ := id.NewGenerator("aidx")
+	h := NewHandler(spy, idGen)
+	rec := post(h.UserTimeline, `{"userId":"u_other"}`, u1)
+	assert.Equal(t, http.StatusOK, rec.Code)
+	assert.Equal(t, "u1", spy.markFromUserCalled.reader)
+	assert.Equal(t, "u_other", spy.markFromUserCalled.fromUser)
+}
+
+func TestRoomTimeline_MarksReadOnOpen(t *testing.T) {
+	spy := &readMarkSpyRepo{mockChatRepo: newMock()}
+	idGen, _ := id.NewGenerator("aidx")
+	h := NewHandler(spy, idGen)
+	rec := post(h.RoomTimeline, `{"roomId":"r_x"}`, u1)
+	assert.Equal(t, http.StatusOK, rec.Code)
+	assert.Equal(t, "u1", spy.markInRoomCalled.reader)
+	assert.Equal(t, "r_x", spy.markInRoomCalled.room)
+}
+
+// MarkAllRead* が err を返しても timeline 自体は 200 を返す (best-effort)。
+type readMarkErrRepo struct {
+	*mockChatRepo
+}
+
+func (m *readMarkErrRepo) MarkAllReadFromUser(_, _ string) error { return errMock }
+func (m *readMarkErrRepo) MarkAllReadInRoom(_, _ string) error   { return errMock }
+
+func TestTimeline_BestEffortReadMark(t *testing.T) {
+	r := &readMarkErrRepo{mockChatRepo: newMock()}
+	idGen, _ := id.NewGenerator("aidx")
+	h := NewHandler(r, idGen)
+	assert.Equal(t, http.StatusOK, post(h.UserTimeline, `{"userId":"u2"}`, u1).Code)
+	assert.Equal(t, http.StatusOK, post(h.RoomTimeline, `{"roomId":"r1"}`, u1).Code)
 }
 
 func TestUnreadCount(t *testing.T) {
@@ -826,6 +891,59 @@ func TestReadAll(t *testing.T) {
 	h, _ := newTestHandler()
 	rec := post(h.ReadAll, `{}`, u1)
 	assert.Equal(t, http.StatusNoContent, rec.Code)
+}
+
+// #692: mapChatErr が ErrChatScopeViolation / ErrChatScopeUnconfigured を
+// それぞれ 403 / 500 にマップする。新規 error path の wiring guard。
+func TestMapChatErr_ChatScopeBranches(t *testing.T) {
+	h, _ := newTestHandler()
+	e := echo.New()
+	for _, tc := range []struct {
+		name string
+		err  error
+		want int
+	}{
+		{"violation", corechat.ErrChatScopeViolation, http.StatusForbidden},
+		{"unconfigured", corechat.ErrChatScopeUnconfigured, http.StatusInternalServerError},
+		{"unknown", errors.New("?"), http.StatusInternalServerError},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			rec := httptest.NewRecorder()
+			c := e.NewContext(httptest.NewRequest(http.MethodPost, "/", nil), rec)
+			_ = h.mapChatErr(c, tc.err)
+			assert.Equal(t, tc.want, rec.Code)
+		})
+	}
+}
+
+// #692: packMessageDetailed は createdAt + toUser + toRoom を含めて返す。
+func TestPackMessageDetailed_FieldsPresent(t *testing.T) {
+	h, _ := newTestHandler()
+	idGen, _ := id.NewGenerator("aidx")
+	now := idGen.Generate(time.Now())
+	host := "remote.example"
+	roomID := "r1"
+	toUserID := "u_to"
+	msg := &model.ChatMessage{
+		ID:         now,
+		FromUserID: "u_from",
+		ToUserID:   &toUserID,
+		ToRoomID:   &roomID,
+		FromUser:   &model.User{ID: "u_from", Username: "from", Host: &host},
+		ToUser:     &model.User{ID: "u_to", Username: "to"},
+		ToRoom:     &model.ChatRoom{ID: roomID, Name: "Room"},
+		Reads:      pq.StringArray{},
+		Reactions:  pq.StringArray{},
+	}
+	out := h.packMessageDetailed(msg)
+	assert.NotEmpty(t, out["createdAt"], "createdAt が ID から派生して埋まること")
+	assert.NotNil(t, out["toUser"])
+	assert.NotNil(t, out["toRoom"])
+	// upstream FE 互換のため `room` alias も入る
+	assert.NotNil(t, out["room"])
+	// fromUser に avatarUrl の identicon fallback が入る
+	from := out["fromUser"].(map[string]any)
+	assert.Equal(t, "/identicon/from@remote.example", from["avatarUrl"])
 }
 
 func TestInvitationsIgnore(t *testing.T) {

--- a/internal/api/chat/handler_test.go
+++ b/internal/api/chat/handler_test.go
@@ -941,7 +941,9 @@ func TestPackMessageDetailed_FieldsPresent(t *testing.T) {
 	assert.NotNil(t, out["toRoom"])
 	// upstream FE 互換のため `room` alias も入る
 	assert.NotNil(t, out["room"])
-	// fromUser に avatarUrl の identicon fallback が入る
+	// fromUser に avatarUrl の identicon fallback が入る (assertion 失敗時は
+	// require.IsType がテスト終了させるので panic せずに見やすいエラーになる)。
+	require.IsType(t, map[string]any{}, out["fromUser"])
 	from := out["fromUser"].(map[string]any)
 	assert.Equal(t, "/identicon/from@remote.example", from["avatarUrl"])
 }

--- a/internal/api/i/handler.go
+++ b/internal/api/i/handler.go
@@ -636,6 +636,9 @@ type UpdateRequest struct {
 	AutoSensitive     *bool   `json:"autoSensitive"`
 	NoCrawle          *bool   `json:"noCrawle"`
 	PreventAiLearning *bool   `json:"preventAiLearning"`
+	// ChatScope は 1-on-1 DM の受信許可レベル (#692)。
+	// upstream paramDef enum: everyone / followers / following / mutual / none
+	ChatScope *string `json:"chatScope"`
 	// Room は frontend の「部屋」機能用の任意スキーマ jsonb。
 	// 本家も object をそのまま受け取って上書き保存する (部分マージはしない)。
 	Room json.RawMessage `json:"room"`
@@ -783,6 +786,17 @@ func (h *Handler) Update(c echo.Context) error {
 			return c.JSON(apiErr.status, apiErr.body)
 		}
 		in.AvatarDecorations = &normalized
+	}
+	if req.ChatScope != nil {
+		// upstream paramDef と同じ enum のみ受け付ける (#692)。
+		// 不正値を弾かないと cherrypick の chatScope 判定 (none/followers/...)
+		// から漏れて "誰からも受信不能" のような壊れた状態を作りうる。
+		switch *req.ChatScope {
+		case "everyone", "followers", "following", "mutual", "none":
+			in.ChatScope = req.ChatScope
+		default:
+			return apierr.JSONInvalidParam(c)
+		}
 	}
 
 	bundle, err := h.userService.UpdateProfile(me.ID, in)

--- a/internal/api/i/handler_test.go
+++ b/internal/api/i/handler_test.go
@@ -584,6 +584,40 @@ func TestUpdate_InvalidJSON(t *testing.T) {
 	assert.Equal(t, http.StatusBadRequest, rec.Code)
 }
 
+// #692: chatScope を i/update で受け付け、user テーブルに反映する。
+func TestUpdate_ChatScope_Persisted(t *testing.T) {
+	cases := []string{"everyone", "followers", "following", "mutual", "none"}
+	for _, scope := range cases {
+		t.Run(scope, func(t *testing.T) {
+			h, repo, _, _ := newTestHandler(t)
+			user := &model.User{ID: "user1", Username: "user1", ChatScope: "mutual", AvatarDecorations: datatypes.JSON([]byte("[]"))}
+			repo.Users["user1"] = user
+			rec := post(h.Update, `{"chatScope":"`+scope+`"}`, user)
+			assert.Equal(t, http.StatusOK, rec.Code)
+			assert.Equal(t, scope, repo.Users["user1"].ChatScope)
+		})
+	}
+}
+
+func TestUpdate_ChatScope_InvalidValue(t *testing.T) {
+	h, repo, _, _ := newTestHandler(t)
+	user := &model.User{ID: "user1", Username: "user1", ChatScope: "mutual", AvatarDecorations: datatypes.JSON([]byte("[]"))}
+	repo.Users["user1"] = user
+	rec := post(h.Update, `{"chatScope":"NEVER_VALID"}`, user)
+	assert.Equal(t, http.StatusBadRequest, rec.Code)
+	assert.Equal(t, "mutual", repo.Users["user1"].ChatScope, "不正値で update されないこと")
+}
+
+func TestUpdate_ChatScope_OmittedIsNoop(t *testing.T) {
+	// JSON に chatScope が含まれない update は ChatScope を変更しない。
+	h, repo, _, _ := newTestHandler(t)
+	user := &model.User{ID: "user1", Username: "user1", ChatScope: "followers", AvatarDecorations: datatypes.JSON([]byte("[]"))}
+	repo.Users["user1"] = user
+	rec := post(h.Update, `{"name":"new"}`, user)
+	assert.Equal(t, http.StatusOK, rec.Code)
+	assert.Equal(t, "followers", repo.Users["user1"].ChatScope)
+}
+
 func TestUpdate_UserNotFound(t *testing.T) {
 	h, _, _, _ := newTestHandler(t)
 	user := &model.User{ID: "ghost"}

--- a/internal/core/chat/ap_delivery_test.go
+++ b/internal/core/chat/ap_delivery_test.go
@@ -49,8 +49,14 @@ func TestCreateMessageToUser_DeliversToRemoteUser(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, msg)
 	assert.Equal(t, 1, deliverer.called)
-	assert.Contains(t, string(deliverer.lastBody), "Misskey:ChatMessage")
-	assert.Contains(t, string(deliverer.lastBody), "hello remote")
+	body := string(deliverer.lastBody)
+	// CherryPick 互換 wire format: Create + Note(_misskey_talk:true) (#692)。
+	// 旧 `Misskey:ChatMessage` 独自 type は廃止。
+	assert.Contains(t, body, `"type":"Create"`)
+	assert.Contains(t, body, `"type":"Note"`)
+	assert.Contains(t, body, `"_misskey_talk":true`)
+	assert.Contains(t, body, "hello remote")
+	assert.NotContains(t, body, "Misskey:ChatMessage", "旧独自 activity type は廃止されたこと")
 }
 
 func TestCreateMessageToUser_SkipsLocalRecipient(t *testing.T) {
@@ -103,4 +109,134 @@ func TestCreateMessageViaAP_InvalidTarget(t *testing.T) {
 
 	_, err = svc.CreateMessageViaAP(context.Background(), "", &model.User{ID: "x"}, "", "hi")
 	assert.Error(t, err)
+}
+
+// --- chatScope (#692) ---
+//
+// recipient.chatScope 別に CreateMessageToUser / CreateMessageViaAP が
+// CherryPick の `recipient is cannot chat (...)` 相当の判定を行うことを確認。
+
+func newScopeService(t *testing.T) (*corechat.Service, *testutil.MockUserRepository, *testutil.MockFollowingRepository) {
+	t.Helper()
+	chatRepo := newFakeRepo()
+	idGen, _ := id.NewGenerator("aidx")
+	svc := corechat.NewService(chatRepo, idGen)
+	userRepo := testutil.NewMockUserRepository()
+	followingRepo := testutil.NewMockFollowingRepository()
+	urls := activitypub.NewURLBuilder("https://local.example")
+	renderer := activitypub.NewRenderer(urls)
+	svc.SetAPDelivery(userRepo, renderer, urls, &fakeAPDeliverer{})
+	svc.SetFollowingRepo(followingRepo)
+	return svc, userRepo, followingRepo
+}
+
+func TestCreateMessageToUser_ScopeNone_Rejected(t *testing.T) {
+	svc, userRepo, _ := newScopeService(t)
+	userRepo.Users["alice"] = &model.User{ID: "alice", Username: "alice"}
+	userRepo.Users["bob"] = &model.User{ID: "bob", Username: "bob", ChatScope: "none"}
+
+	_, err := svc.CreateMessageToUser(context.Background(), "alice", "bob", "blocked", "")
+	require.ErrorIs(t, err, corechat.ErrChatScopeViolation)
+}
+
+func TestCreateMessageToUser_ScopeEveryone_Allowed(t *testing.T) {
+	svc, userRepo, _ := newScopeService(t)
+	userRepo.Users["alice"] = &model.User{ID: "alice", Username: "alice"}
+	userRepo.Users["bob"] = &model.User{ID: "bob", Username: "bob", ChatScope: "everyone"}
+
+	_, err := svc.CreateMessageToUser(context.Background(), "alice", "bob", "ok", "")
+	require.NoError(t, err)
+}
+
+func TestCreateMessageToUser_ScopeFollowers_OnlyFollowers(t *testing.T) {
+	svc, userRepo, followingRepo := newScopeService(t)
+	userRepo.Users["alice"] = &model.User{ID: "alice", Username: "alice"}
+	userRepo.Users["bob"] = &model.User{ID: "bob", Username: "bob", ChatScope: "followers"}
+	// alice is NOT a follower of bob → rejected
+	_, err := svc.CreateMessageToUser(context.Background(), "alice", "bob", "x", "")
+	require.ErrorIs(t, err, corechat.ErrChatScopeViolation)
+	// alice follows bob (i.e., alice is a follower of bob) → allowed
+	require.NoError(t, followingRepo.Create(&model.Following{ID: "f1", FollowerID: "alice", FolloweeID: "bob"}))
+	_, err = svc.CreateMessageToUser(context.Background(), "alice", "bob", "ok", "")
+	require.NoError(t, err)
+}
+
+func TestCreateMessageToUser_ScopeFollowing_OnlyFollowing(t *testing.T) {
+	svc, userRepo, followingRepo := newScopeService(t)
+	userRepo.Users["alice"] = &model.User{ID: "alice", Username: "alice"}
+	userRepo.Users["bob"] = &model.User{ID: "bob", Username: "bob", ChatScope: "following"}
+	// bob does NOT follow alice → rejected
+	_, err := svc.CreateMessageToUser(context.Background(), "alice", "bob", "x", "")
+	require.ErrorIs(t, err, corechat.ErrChatScopeViolation)
+	// bob follows alice → allowed
+	require.NoError(t, followingRepo.Create(&model.Following{ID: "f1", FollowerID: "bob", FolloweeID: "alice"}))
+	_, err = svc.CreateMessageToUser(context.Background(), "alice", "bob", "ok", "")
+	require.NoError(t, err)
+}
+
+func TestCreateMessageToUser_ScopeMutual(t *testing.T) {
+	svc, userRepo, followingRepo := newScopeService(t)
+	userRepo.Users["alice"] = &model.User{ID: "alice", Username: "alice"}
+	userRepo.Users["bob"] = &model.User{ID: "bob", Username: "bob", ChatScope: "mutual"}
+
+	// 0 directions → rejected
+	_, err := svc.CreateMessageToUser(context.Background(), "alice", "bob", "x", "")
+	require.ErrorIs(t, err, corechat.ErrChatScopeViolation)
+	// 1 direction → still rejected
+	require.NoError(t, followingRepo.Create(&model.Following{ID: "f1", FollowerID: "alice", FolloweeID: "bob"}))
+	_, err = svc.CreateMessageToUser(context.Background(), "alice", "bob", "x", "")
+	require.ErrorIs(t, err, corechat.ErrChatScopeViolation)
+	// 2 directions → allowed
+	require.NoError(t, followingRepo.Create(&model.Following{ID: "f2", FollowerID: "bob", FolloweeID: "alice"}))
+	_, err = svc.CreateMessageToUser(context.Background(), "alice", "bob", "ok", "")
+	require.NoError(t, err)
+}
+
+func TestCreateMessageToUser_RemoteRecipient_ScopeNone_Rejected(t *testing.T) {
+	// remote recipient の `_misskey_canChat: false` は resolver で
+	// chatScope = "none" に翻訳されるため、mk-go 側で事前 reject される (#692)。
+	svc, userRepo, _ := newScopeService(t)
+	remoteHost := "remote.example"
+	remoteURI := "https://remote.example/users/bob"
+	userRepo.Users["alice"] = &model.User{ID: "alice", Username: "alice"}
+	userRepo.Users["bob"] = &model.User{ID: "bob", Username: "bob", ChatScope: "none", Host: &remoteHost, URI: &remoteURI}
+
+	_, err := svc.CreateMessageToUser(context.Background(), "alice", "bob", "x", "")
+	require.ErrorIs(t, err, corechat.ErrChatScopeViolation)
+}
+
+func TestCreateMessageToUser_RemoteRecipient_ScopeEveryone_Allowed(t *testing.T) {
+	// remote recipient で chatScope == "everyone" (`_misskey_canChat: true`
+	// 由来) なら mk-go 側は通過させ、granular な判定は remote 側に委ねる。
+	svc, userRepo, _ := newScopeService(t)
+	remoteHost := "remote.example"
+	remoteURI := "https://remote.example/users/bob"
+	userRepo.Users["alice"] = &model.User{ID: "alice", Username: "alice"}
+	userRepo.Users["bob"] = &model.User{ID: "bob", Username: "bob", ChatScope: "everyone", Host: &remoteHost, URI: &remoteURI}
+
+	_, err := svc.CreateMessageToUser(context.Background(), "alice", "bob", "ok", "")
+	require.NoError(t, err)
+}
+
+func TestCreateMessageToUser_RemoteRecipient_StaleMutualScope_NotRejected(t *testing.T) {
+	// 過去に作成された remote user は chatScope の DB default (= "mutual") の
+	// ままだが、followingRepo に follow 関係が無くても reject してはいけない。
+	// 「mk-go では remote の granular scope を判定しない」契約 (#692)。
+	svc, userRepo, _ := newScopeService(t)
+	remoteHost := "remote.example"
+	remoteURI := "https://remote.example/users/bob"
+	userRepo.Users["alice"] = &model.User{ID: "alice", Username: "alice"}
+	userRepo.Users["bob"] = &model.User{ID: "bob", Username: "bob", ChatScope: "mutual", Host: &remoteHost, URI: &remoteURI}
+
+	_, err := svc.CreateMessageToUser(context.Background(), "alice", "bob", "ok", "")
+	require.NoError(t, err, "remote の granular scope は無視され、'none' 以外は通過する")
+}
+
+func TestCreateMessageViaAP_ScopeEnforced(t *testing.T) {
+	svc, userRepo, _ := newScopeService(t)
+	userRepo.Users["bob"] = &model.User{ID: "bob", Username: "bob", ChatScope: "none"}
+	sender := &model.User{ID: "remote-alice", Username: "alice"}
+
+	_, err := svc.CreateMessageViaAP(context.Background(), "https://remote.example/cm/1", sender, "bob", "x")
+	require.ErrorIs(t, err, corechat.ErrChatScopeViolation)
 }

--- a/internal/core/chat/ap_delivery_test.go
+++ b/internal/core/chat/ap_delivery_test.go
@@ -240,3 +240,43 @@ func TestCreateMessageViaAP_ScopeEnforced(t *testing.T) {
 	_, err := svc.CreateMessageViaAP(context.Background(), "https://remote.example/cm/1", sender, "bob", "x")
 	require.ErrorIs(t, err, corechat.ErrChatScopeViolation)
 }
+
+// followingRepo 未配線で granular scope が設定されている場合は fail-closed
+// (`ErrChatScopeUnconfigured`) になる。production wiring 忘れが silent に
+// open relay 化するのを防ぐ (#708 review #2)。
+func TestCreateMessageToUser_GranularScope_NoFollowingRepo_FailClosed(t *testing.T) {
+	chatRepo := newFakeRepo()
+	idGen, _ := id.NewGenerator("aidx")
+	svc := corechat.NewService(chatRepo, idGen)
+	userRepo := testutil.NewMockUserRepository()
+	urls := activitypub.NewURLBuilder("https://local.example")
+	renderer := activitypub.NewRenderer(urls)
+	svc.SetAPDelivery(userRepo, renderer, urls, &fakeAPDeliverer{})
+	// SetFollowingRepo は意図的に呼ばない
+
+	userRepo.Users["alice"] = &model.User{ID: "alice", Username: "alice"}
+	for _, scope := range []string{"followers", "following", "mutual"} {
+		t.Run(scope, func(t *testing.T) {
+			userRepo.Users["bob"] = &model.User{ID: "bob", Username: "bob", ChatScope: scope}
+			_, err := svc.CreateMessageToUser(context.Background(), "alice", "bob", "x", "")
+			require.ErrorIs(t, err, corechat.ErrChatScopeUnconfigured)
+		})
+	}
+}
+
+// followingRepo 未配線でも "everyone" / "none" 判定は granular check 不要
+// なので通過する (none は ErrChatScopeViolation, everyone は OK)。
+func TestCreateMessageToUser_NonGranularScope_NoFollowingRepoOK(t *testing.T) {
+	chatRepo := newFakeRepo()
+	idGen, _ := id.NewGenerator("aidx")
+	svc := corechat.NewService(chatRepo, idGen)
+	userRepo := testutil.NewMockUserRepository()
+	urls := activitypub.NewURLBuilder("https://local.example")
+	renderer := activitypub.NewRenderer(urls)
+	svc.SetAPDelivery(userRepo, renderer, urls, &fakeAPDeliverer{})
+
+	userRepo.Users["alice"] = &model.User{ID: "alice", Username: "alice"}
+	userRepo.Users["bob"] = &model.User{ID: "bob", Username: "bob", ChatScope: "everyone"}
+	_, err := svc.CreateMessageToUser(context.Background(), "alice", "bob", "ok", "")
+	require.NoError(t, err)
+}

--- a/internal/core/chat/service.go
+++ b/internal/core/chat/service.go
@@ -73,6 +73,7 @@ type Service struct {
 	idGen               id.Generator
 	publisher           StreamingPublisher
 	userRepo            repository.UserRepository
+	followingRepo       repository.FollowingRepository
 	renderer            *activitypub.Renderer
 	urls                *activitypub.URLBuilder
 	deliverer           APDeliverer
@@ -107,14 +108,102 @@ func (s *Service) SetAPDelivery(userRepo repository.UserRepository, renderer *ac
 	s.deliverer = deliverer
 }
 
+// SetFollowingRepo wires the following repository so chatScope=followers /
+// following / mutual checks can be enforced (#692). 未配線時は scope check
+// が skip され、結果として "everyone" 相当に降格する (デフォルトの "mutual"
+// より緩いので、配線忘れは production で意図しない open relay を作る点に
+// 注意。Wire 側で必須配線にしておくこと)。
+func (s *Service) SetFollowingRepo(repo repository.FollowingRepository) {
+	s.followingRepo = repo
+}
+
+// ErrChatScopeViolation is returned when a chat message is rejected because
+// the recipient's chatScope does not allow the sender. CherryPick の
+// `Error('recipient is cannot chat (...)')` 相当 (#692)。
+var ErrChatScopeViolation = errors.New("chat scope violation")
+
+// canChat reports whether `sender` is allowed to send a 1-on-1 chat to
+// `recipient` based on recipient.chatScope. Returns nil when allowed.
+//
+// scope semantics (CherryPick / Misskey TS と一致):
+//   - "everyone": 誰からでも受信
+//   - "followers": 受信者を follow している人だけ (sender が recipient の follower)
+//   - "following": 受信者が follow している人だけ (recipient が sender を follow)
+//   - "mutual": 双方向
+//   - "none": 完全拒否
+//
+// remote recipient の場合は、AP に expose されるのは `_misskey_canChat`
+// (boolean) だけなので chatScope は "everyone" / "none" の二値しか取り得ない
+// (resolver で翻訳済み, #692)。granular な判定は受信側 instance に委ねる。
+//
+// followingRepo 未配線時は緩く everyone 相当 (production では必ず wire する想定)。
+func (s *Service) canChat(sender, recipient *model.User) error {
+	if recipient == nil || sender == nil {
+		return nil
+	}
+	if recipient.ChatScope == "none" {
+		return ErrChatScopeViolation
+	}
+	if !recipient.IsLocal() {
+		// 連合先のスコープは "everyone" / "none" の二値。connection grain の
+		// followers/following/mutual は remote 側で評価されるので mk-go では
+		// 'none' だけ事前 reject すれば十分。
+		return nil
+	}
+	switch recipient.ChatScope {
+	case "", "everyone":
+		return nil
+	}
+	if s.followingRepo == nil {
+		return nil
+	}
+	switch recipient.ChatScope {
+	case "followers":
+		ok, err := s.followingRepo.Exists(sender.ID, recipient.ID)
+		if err == nil && ok {
+			return nil
+		}
+		return ErrChatScopeViolation
+	case "following":
+		ok, err := s.followingRepo.Exists(recipient.ID, sender.ID)
+		if err == nil && ok {
+			return nil
+		}
+		return ErrChatScopeViolation
+	case "mutual":
+		ok1, e1 := s.followingRepo.Exists(sender.ID, recipient.ID)
+		ok2, e2 := s.followingRepo.Exists(recipient.ID, sender.ID)
+		if e1 == nil && e2 == nil && ok1 && ok2 {
+			return nil
+		}
+		return ErrChatScopeViolation
+	}
+	return nil
+}
+
 // --- Message lifecycle ---
 
 // CreateMessageToUser persists a direct-message row and fires the
 // `message` event on both conversation directions so that either user's
 // connected WebSocket subscribers see the message immediately.
+//
+// chatScope を強制する (#692)。recipient が local なら granular な
+// followers/following/mutual まで判定し、remote なら `_misskey_canChat`
+// 由来の "none" だけ事前 reject する (canChat() が分岐)。
 func (s *Service) CreateMessageToUser(ctx context.Context, fromUserID, toUserID, text, fileID string) (*model.ChatMessage, error) {
 	if fromUserID == "" || toUserID == "" {
 		return nil, ErrInvalidTarget
+	}
+	if s.userRepo != nil {
+		recipient, err := s.userRepo.FindByID(toUserID)
+		if err == nil {
+			sender, err := s.userRepo.FindByID(fromUserID)
+			if err == nil {
+				if err := s.canChat(sender, recipient); err != nil {
+					return nil, err
+				}
+			}
+		}
 	}
 	msg := &model.ChatMessage{
 		ID:         s.idGen.Generate(time.Now()),
@@ -131,14 +220,14 @@ func (s *Service) CreateMessageToUser(ctx context.Context, fromUserID, toUserID,
 		return nil, fmt.Errorf("create user message: %w", err)
 	}
 	if s.publisher != nil {
-		s.publisher.PublishUserMessage(ctx, fromUserID, toUserID, EventMessage, packMessage(msg))
+		s.publisher.PublishUserMessage(ctx, fromUserID, toUserID, EventMessage, s.packMessageStream(msg))
 	}
 	// Misskey 本家の ChatService.createMessageToUser は、3 秒後に未読判定して
 	// newChatMessage を publishMainStream する。本実装では未読判定を省略し、
 	// 作成と同時に recipient (toUserID) の main に emit する (sender には
 	// 送らない: TS と同じ fan-out 方針)。
 	if s.mainStreamPublisher != nil {
-		s.mainStreamPublisher.PublishMainEvent(toUserID, "newChatMessage", packMessage(msg))
+		s.mainStreamPublisher.PublishMainEvent(toUserID, "newChatMessage", s.packMessageStream(msg))
 	}
 	// リモートユーザー宛ならAP配送 (best-effort)
 	s.tryDeliverToRemoteUser(msg, fromUserID, toUserID)
@@ -169,7 +258,13 @@ func (s *Service) tryDeliverToRemoteUser(msg *model.ChatMessage, fromUserID, toU
 		return
 	}
 	_ = s.repo.UpdateDeliveryStatus(msg.ID, true, false)
-	cm := s.renderer.RenderChatMessage(msg, senderURI, recipientURI)
+	// CherryPick 互換 wire format: Create + Note(_misskey_talk:true) (#692)。
+	// published は ChatMessage.ID (ULID/aidx) のタイムスタンプから導出する。
+	published := time.Now().UTC().Format(time.RFC3339)
+	if t, err := s.idGen.ParseTime(msg.ID); err == nil {
+		published = t.UTC().Format(time.RFC3339)
+	}
+	cm := s.renderer.RenderChatMessage(msg, senderURI, recipientURI, published)
 	body, err := json.Marshal(cm)
 	if err != nil {
 		_ = s.repo.UpdateDeliveryStatus(msg.ID, false, true)
@@ -187,6 +282,10 @@ func (s *Service) tryDeliverToRemoteUser(msg *model.ChatMessage, fromUserID, toU
 // CreateMessageViaAP persists a chat message received via ActivityPub from a
 // remote user. The uri parameter is the activity's canonical ID. AP retries
 // are common so URI-based dedup is performed (IngestNote と同じパターン).
+//
+// recipient の chatScope を必ず強制する (#692)。連合受信時は AP retry でこの
+// path が複数回踏まれるが、scope 違反は最初の試行で拒絶し、retry でも同じ
+// 結果になるので peer 側は dead letter で処理する。
 func (s *Service) CreateMessageViaAP(ctx context.Context, uri string, fromUser *model.User, toUserID, text string) (*model.ChatMessage, error) {
 	if fromUser == nil || toUserID == "" {
 		return nil, ErrInvalidTarget
@@ -195,6 +294,13 @@ func (s *Service) CreateMessageViaAP(ctx context.Context, uri string, fromUser *
 	if uri != "" {
 		if existing, err := s.repo.FindMessageByURI(uri); err == nil {
 			return existing, nil
+		}
+	}
+	if s.userRepo != nil {
+		if recipient, err := s.userRepo.FindByID(toUserID); err == nil && recipient.IsLocal() {
+			if err := s.canChat(fromUser, recipient); err != nil {
+				return nil, err
+			}
 		}
 	}
 	msg := &model.ChatMessage{
@@ -218,7 +324,7 @@ func (s *Service) CreateMessageViaAP(ctx context.Context, uri string, fromUser *
 	// recipient の main チャネルに newChatMessage を emit してフロントの
 	// 未読インジケータを更新させる。sender は remote なので emit 対象外。
 	if s.mainStreamPublisher != nil {
-		s.mainStreamPublisher.PublishMainEvent(toUserID, "newChatMessage", packMessage(msg))
+		s.mainStreamPublisher.PublishMainEvent(toUserID, "newChatMessage", s.packMessageStream(msg))
 	}
 	return msg, nil
 }
@@ -257,7 +363,7 @@ func (s *Service) CreateMessageToRoom(ctx context.Context, fromUserID, roomID, t
 		return nil, fmt.Errorf("create room message: %w", err)
 	}
 	if s.publisher != nil {
-		s.publisher.PublishRoomMessage(ctx, roomID, EventMessage, packMessage(msg))
+		s.publisher.PublishRoomMessage(ctx, roomID, EventMessage, s.packMessageStream(msg))
 	}
 	// Room 宛も同様に、sender 以外の全 member (owner 含む) の main に
 	// newChatMessage を emit する。Misskey 本家 ChatService
@@ -291,7 +397,7 @@ func (s *Service) emitRoomNewChatMessage(room *model.ChatRoom, fromUserID string
 		slog.Warn("chat: ListMembersByRoom failed, skipping newChatMessage emit", "roomID", room.ID, "err", err)
 		return
 	}
-	packed := packMessage(msg)
+	packed := s.packMessageStream(msg)
 	// 重複 emit を防ぐため set 相当で ID を管理する (membership + owner)。
 	emitted := make(map[string]bool, len(members)+1)
 	if room.OwnerID != fromUserID {
@@ -346,7 +452,7 @@ func (s *Service) UpdateMessage(ctx context.Context, userID, messageID, text str
 		return nil, fmt.Errorf("update message: %w", err)
 	}
 	if s.publisher != nil {
-		body := packMessage(msg)
+		body := s.packMessageStream(msg)
 		if msg.ToRoomID != nil {
 			s.publisher.PublishRoomMessage(ctx, *msg.ToRoomID, EventEdited, body)
 		} else if msg.ToUserID != nil {
@@ -396,7 +502,8 @@ func (s *Service) IsRoomMember(userID, roomID string) (bool, error) {
 
 // packMessage produces a JSON-serializable projection of a ChatMessage for
 // outbound WebSocket events. フロント互換のため本家 ChatMessageLite と同じ
-// 主要フィールドを含める。
+// 主要フィールドを含める。createdAt は idGen の初期化未完了時 (テスト等)
+// に欠落することがあるが、上位の Service.packMessage 経由なら必ず付く (#692)。
 func packMessage(msg *model.ChatMessage) map[string]any {
 	out := map[string]any{
 		"id":         msg.ID,
@@ -424,4 +531,49 @@ func packMessage(msg *model.ChatMessage) map[string]any {
 		out["reactions"] = []string(msg.Reactions)
 	}
 	return out
+}
+
+// packMessageStream is the service-level packer that adds createdAt + fromUser
+// on top of packMessage. WebSocket streaming や mainStream の `newChatMessage`
+// 配信に使う。createdAt 欠落だと FE 側の MkTime が NaN/NaN を表示する (#692)。
+func (s *Service) packMessageStream(msg *model.ChatMessage) map[string]any {
+	out := packMessage(msg)
+	if s.idGen != nil {
+		if t, err := s.idGen.ParseTime(msg.ID); err == nil {
+			out["createdAt"] = t.UTC().Format("2006-01-02T15:04:05.000Z")
+		}
+	}
+	if msg.FromUser != nil {
+		out["fromUser"] = packUserStream(msg.FromUser)
+	}
+	if msg.ToUser != nil {
+		out["toUser"] = packUserStream(msg.ToUser)
+	}
+	return out
+}
+
+// packUserStream is a UserLite-shaped projection for stream payloads.
+// FE の MkAvatar / chat 一覧が avatarUrl / avatarBlurhash を読むため、
+// fromUser / toUser に含める。avatarUrl 未設定時は identicon URL に
+// fallback する (api/chat/handler.go の packUser と同じ規則, #692)。
+func packUserStream(u *model.User) map[string]any {
+	avatarURL := u.AvatarURL
+	if avatarURL == nil || *avatarURL == "" {
+		host := ""
+		if u.Host != nil {
+			host = "@" + *u.Host
+		}
+		identicon := "/identicon/" + u.Username + host
+		avatarURL = &identicon
+	}
+	return map[string]any{
+		"id":             u.ID,
+		"username":       u.Username,
+		"name":           u.Name,
+		"host":           u.Host,
+		"avatarUrl":      avatarURL,
+		"avatarBlurhash": u.AvatarBlurhash,
+		"isBot":          u.IsBot,
+		"isCat":          u.IsCat,
+	}
 }

--- a/internal/core/chat/service.go
+++ b/internal/core/chat/service.go
@@ -16,6 +16,7 @@ import (
 	"time"
 
 	"github.com/shiroha-a/mk/internal/activitypub"
+	"github.com/shiroha-a/mk/internal/entity"
 	"github.com/shiroha-a/mk/internal/misc/id"
 	"github.com/shiroha-a/mk/internal/model"
 	"github.com/shiroha-a/mk/internal/repository"
@@ -109,10 +110,10 @@ func (s *Service) SetAPDelivery(userRepo repository.UserRepository, renderer *ac
 }
 
 // SetFollowingRepo wires the following repository so chatScope=followers /
-// following / mutual checks can be enforced (#692). 未配線時は scope check
-// が skip され、結果として "everyone" 相当に降格する (デフォルトの "mutual"
-// より緩いので、配線忘れは production で意図しない open relay を作る点に
-// 注意。Wire 側で必須配線にしておくこと)。
+// following / mutual checks can be enforced (#692). 未配線のままで granular
+// scope を持つ recipient へ送信しようとすると `canChat` が fail-closed で
+// reject する (旧実装の silent allow は意図しない open relay を作るため
+// PR #708 review で改めた)。production では必ず配線する。
 func (s *Service) SetFollowingRepo(repo repository.FollowingRepository) {
 	s.followingRepo = repo
 }
@@ -121,6 +122,12 @@ func (s *Service) SetFollowingRepo(repo repository.FollowingRepository) {
 // the recipient's chatScope does not allow the sender. CherryPick の
 // `Error('recipient is cannot chat (...)')` 相当 (#692)。
 var ErrChatScopeViolation = errors.New("chat scope violation")
+
+// ErrChatScopeUnconfigured is returned when canChat() needs to consult the
+// following graph (chatScope = followers / following / mutual) but no
+// FollowingRepository was wired. Treated as fail-closed (= reject) instead
+// of silently degrading to everyone, which would be an open relay (#708 review)。
+var ErrChatScopeUnconfigured = errors.New("chat scope check unconfigured: followingRepo missing")
 
 // canChat reports whether `sender` is allowed to send a 1-on-1 chat to
 // `recipient` based on recipient.chatScope. Returns nil when allowed.
@@ -136,7 +143,10 @@ var ErrChatScopeViolation = errors.New("chat scope violation")
 // (boolean) だけなので chatScope は "everyone" / "none" の二値しか取り得ない
 // (resolver で翻訳済み, #692)。granular な判定は受信側 instance に委ねる。
 //
-// followingRepo 未配線時は緩く everyone 相当 (production では必ず wire する想定)。
+// followingRepo 未配線で granular scope を判定しないといけない局面では
+// `ErrChatScopeUnconfigured` を返して fail-closed する (#708 review #2)。
+// silent に everyone 降格すると production の wiring 忘れが open relay に
+// なり、chatScope 設定が黙って無効化される。
 func (s *Service) canChat(sender, recipient *model.User) error {
 	if recipient == nil || sender == nil {
 		return nil
@@ -154,8 +164,10 @@ func (s *Service) canChat(sender, recipient *model.User) error {
 	case "", "everyone":
 		return nil
 	}
+	// granular scope (followers / following / mutual) は follow graph 必須。
+	// 未配線なら fail-closed する。
 	if s.followingRepo == nil {
-		return nil
+		return ErrChatScopeUnconfigured
 	}
 	switch recipient.ChatScope {
 	case "followers":
@@ -554,24 +566,15 @@ func (s *Service) packMessageStream(msg *model.ChatMessage) map[string]any {
 
 // packUserStream is a UserLite-shaped projection for stream payloads.
 // FE の MkAvatar / chat 一覧が avatarUrl / avatarBlurhash を読むため、
-// fromUser / toUser に含める。avatarUrl 未設定時は identicon URL に
-// fallback する (api/chat/handler.go の packUser と同じ規則, #692)。
+// fromUser / toUser に含める。avatarUrl 未設定時は `entity.IdenticonURL`
+// 経由で identicon URL に fallback する (#692)。
 func packUserStream(u *model.User) map[string]any {
-	avatarURL := u.AvatarURL
-	if avatarURL == nil || *avatarURL == "" {
-		host := ""
-		if u.Host != nil {
-			host = "@" + *u.Host
-		}
-		identicon := "/identicon/" + u.Username + host
-		avatarURL = &identicon
-	}
 	return map[string]any{
 		"id":             u.ID,
 		"username":       u.Username,
 		"name":           u.Name,
 		"host":           u.Host,
-		"avatarUrl":      avatarURL,
+		"avatarUrl":      entity.IdenticonURL(u),
 		"avatarBlurhash": u.AvatarBlurhash,
 		"isBot":          u.IsBot,
 		"isCat":          u.IsCat,

--- a/internal/core/chat/service_test.go
+++ b/internal/core/chat/service_test.go
@@ -152,7 +152,15 @@ func (r *fakeChatRepo) UpdateDeliveryStatus(_ string, _, _ bool) error { return 
 func (r *fakeChatRepo) ListHistory(_ string, _ int) ([]*model.ChatMessage, error) {
 	return nil, nil
 }
+func (r *fakeChatRepo) ListUserHistory(_ string, _ int) ([]*model.ChatMessage, error) {
+	return nil, nil
+}
+func (r *fakeChatRepo) ListRoomHistory(_ string, _ int) ([]*model.ChatMessage, error) {
+	return nil, nil
+}
 func (r *fakeChatRepo) MarkAllRead(_ string) error                         { return nil }
+func (r *fakeChatRepo) MarkAllReadFromUser(_, _ string) error              { return nil }
+func (r *fakeChatRepo) MarkAllReadInRoom(_, _ string) error                { return nil }
 func (r *fakeChatRepo) AddReaction(_, _ string) error                      { return nil }
 func (r *fakeChatRepo) RemoveReaction(_, _ string) error                   { return nil }
 func (r *fakeChatRepo) UpdateInvitation(_ *model.ChatRoomInvitation) error { return nil }

--- a/internal/core/federation/processor.go
+++ b/internal/core/federation/processor.go
@@ -600,10 +600,29 @@ func (p *Processor) handleAccept(act genericActivity) error {
 // Question (投票) はNote同様にIngestNoteで処理され、Pollレコードが自動作成される。
 // ノート取込み成功後、fanoutHookが配線されていればタイムライン/ストリーミングに
 // 配信する (#330)。
+//
+// `_misskey_talk: true` flag が立った Note は CherryPick / レガシー Misskey の
+// 1-on-1 chat federation。notes テーブルではなく chat_messages として処理する
+// ため IngestNote をスキップして chatService にルートする (#692)。
 func (p *Processor) handleCreate(act genericActivity) error {
 	actor, err := p.resolver.ResolveActor(act.Actor)
 	if err != nil {
 		return err
+	}
+	// Note の `_misskey_talk` を覗き見て chat か通常 note かを分岐する。
+	// IngestNote が走る前に短絡しないと chat message が notes テーブルに
+	// 流れ込んでタイムラインを汚す。
+	if p.chatService != nil {
+		var probe struct {
+			Type        string          `json:"type"`
+			ID          string          `json:"id"`
+			Content     string          `json:"content"`
+			MisskeyTalk bool            `json:"_misskey_talk"`
+			To          json.RawMessage `json:"to"`
+		}
+		if err := json.Unmarshal(act.Object, &probe); err == nil && probe.MisskeyTalk && probe.Type == "Note" {
+			return p.handleChatCreate(actor, probe.ID, probe.Content, probe.To)
+		}
 	}
 	note, err := p.resolver.IngestNote(act.Object)
 	if err != nil {
@@ -1199,6 +1218,68 @@ func readActorString(act genericActivity) (string, error) {
 		return act.Actor, nil
 	}
 	return "", errors.New("inner activity missing actor")
+}
+
+// handleChatCreate processes a Note flagged with `_misskey_talk: true`
+// inside a Create activity (CherryPick / レガシー Misskey の 1-on-1 chat
+// federation, #692)。
+//
+// `to` は CherryPick の renderChatMessage が string[] で出すが、互換性のため
+// 単一文字列 / 配列の両方を受け付ける。配列の場合は先頭エントリを recipient
+// として扱う (1-on-1 DM 前提なので残りは無視)。複数 recipient (group chat)
+// は別 issue で対応。
+func (p *Processor) handleChatCreate(sender *model.User, noteURI, content string, toRaw json.RawMessage) error {
+	if noteURI == "" {
+		return fmt.Errorf("chat create: missing note id")
+	}
+	if sender.IsLocal() {
+		return fmt.Errorf("chat create: sender %s is local (loopback?)", sender.ID)
+	}
+	to, err := readRecipientURI(toRaw)
+	if err != nil {
+		return fmt.Errorf("chat create: %w", err)
+	}
+	recipient, err := p.userRepo.FindByURI(to)
+	if err != nil {
+		if localID := p.resolver.ExtractLocalUserID(to); localID != "" {
+			recipient, err = p.userRepo.FindByID(localID)
+		}
+		if err != nil {
+			return fmt.Errorf("chat create: resolve recipient: %w", err)
+		}
+	}
+	if !recipient.IsLocal() {
+		return fmt.Errorf("chat create: recipient %s is not local", to)
+	}
+	_, err = p.chatService.CreateMessageViaAP(context.Background(), noteURI, sender, recipient.ID, content)
+	return err
+}
+
+// readRecipientURI extracts the first recipient URI from a `to` field that
+// may be either a JSON string or a JSON array of strings. Empty / missing
+// values produce an error so the caller can distinguish "malformed" from
+// "valid but addressed to public".
+func readRecipientURI(raw json.RawMessage) (string, error) {
+	if len(raw) == 0 {
+		return "", errors.New("missing 'to' field")
+	}
+	var single string
+	if err := json.Unmarshal(raw, &single); err == nil {
+		if single == "" {
+			return "", errors.New("'to' is empty")
+		}
+		return single, nil
+	}
+	var multi []string
+	if err := json.Unmarshal(raw, &multi); err == nil {
+		for _, s := range multi {
+			if s != "" {
+				return s, nil
+			}
+		}
+		return "", errors.New("'to' has no usable recipient")
+	}
+	return "", errors.New("'to' is neither string nor array")
 }
 
 // handleChatMessage processes an inbound Misskey:ChatMessage activity

--- a/internal/core/federation/processor_test.go
+++ b/internal/core/federation/processor_test.go
@@ -1285,6 +1285,93 @@ func TestProcess_CreateChat_FlagFalseFallsThroughToIngest(t *testing.T) {
 	assert.Equal(t, 0, chatSvc.called, "chat service must NOT be hit for non-chat notes")
 }
 
+// #692: handleChatCreate / readRecipientURI のエッジケース。
+
+func TestProcess_CreateChat_EmptyTo(t *testing.T) {
+	p, _, _, _ := newProcessor(t, aliceActor)
+	chatSvc := &stubChatReceiver{}
+	p.SetChatService(chatSvc)
+	body := []byte(`{
+		"type": "Create",
+		"actor": "https://remote.example/users/alice",
+		"object": {
+			"id": "https://remote.example/chat-messages/cm-empty",
+			"type": "Note",
+			"attributedTo": "https://remote.example/users/alice",
+			"content": "no recipient",
+			"to": "",
+			"_misskey_talk": true
+		}
+	}`)
+	err := p.Process(body)
+	assert.Error(t, err)
+	assert.Equal(t, 0, chatSvc.called)
+}
+
+func TestProcess_CreateChat_ToNumber_Rejected(t *testing.T) {
+	p, _, _, _ := newProcessor(t, aliceActor)
+	chatSvc := &stubChatReceiver{}
+	p.SetChatService(chatSvc)
+	body := []byte(`{
+		"type": "Create",
+		"actor": "https://remote.example/users/alice",
+		"object": {
+			"id": "https://remote.example/chat-messages/cm-num",
+			"type": "Note",
+			"attributedTo": "https://remote.example/users/alice",
+			"content": "weird",
+			"to": 42,
+			"_misskey_talk": true
+		}
+	}`)
+	err := p.Process(body)
+	assert.Error(t, err)
+	assert.Equal(t, 0, chatSvc.called)
+}
+
+func TestProcess_CreateChat_EmptyArrayTo(t *testing.T) {
+	p, _, _, _ := newProcessor(t, aliceActor)
+	chatSvc := &stubChatReceiver{}
+	p.SetChatService(chatSvc)
+	body := []byte(`{
+		"type": "Create",
+		"actor": "https://remote.example/users/alice",
+		"object": {
+			"id": "https://remote.example/chat-messages/cm-empty-arr",
+			"type": "Note",
+			"attributedTo": "https://remote.example/users/alice",
+			"content": "no recipient",
+			"to": [""],
+			"_misskey_talk": true
+		}
+	}`)
+	err := p.Process(body)
+	assert.Error(t, err)
+	assert.Equal(t, 0, chatSvc.called)
+}
+
+func TestProcess_CreateChat_RecipientNotFound(t *testing.T) {
+	// FindByURI が err、ExtractLocalUserID も local URI でない → resolve 失敗。
+	p, _, _, _ := newProcessor(t, aliceActor)
+	chatSvc := &stubChatReceiver{}
+	p.SetChatService(chatSvc)
+	body := []byte(`{
+		"type": "Create",
+		"actor": "https://remote.example/users/alice",
+		"object": {
+			"id": "https://remote.example/chat-messages/cm-no-recip",
+			"type": "Note",
+			"attributedTo": "https://remote.example/users/alice",
+			"content": "x",
+			"to": "https://other.example/users/unknown",
+			"_misskey_talk": true
+		}
+	}`)
+	err := p.Process(body)
+	assert.Error(t, err)
+	assert.Equal(t, 0, chatSvc.called)
+}
+
 func TestProcess_CreateChat_RecipientNotLocal(t *testing.T) {
 	// recipient が remote 解決されると loopback delivery として拒絶する。
 	p, repo, _, _ := newProcessor(t, aliceActor)

--- a/internal/core/federation/processor_test.go
+++ b/internal/core/federation/processor_test.go
@@ -1204,6 +1204,114 @@ func TestProcess_ChatMessage_MissingTo(t *testing.T) {
 	assert.Error(t, err)
 }
 
+// --- Chat federation (CherryPick: Create + Note(_misskey_talk:true), #692) ---
+//
+// CherryPick / レガシー Misskey の chat 連合 wire format。Create に Note を
+// 包んで `_misskey_talk: true` flag を立てる形。to は string[] で、handleCreate
+// が IngestNote の前に分岐して chatService にルートする。
+
+func TestProcess_CreateChat_HappyPath_ToArray(t *testing.T) {
+	p, repo, _, _ := newProcessor(t, aliceActor)
+	repo.Users["bob"] = &model.User{ID: "bob", Username: "bob"}
+	chatSvc := &stubChatReceiver{}
+	p.SetChatService(chatSvc)
+
+	body := []byte(`{
+		"id": "https://remote.example/activities/create-chat-1",
+		"type": "Create",
+		"actor": "https://remote.example/users/alice",
+		"object": {
+			"id": "https://remote.example/chat-messages/cm1",
+			"type": "Note",
+			"attributedTo": "https://remote.example/users/alice",
+			"content": "yo via cherrypick",
+			"to": ["https://example.com/users/bob"],
+			"_misskey_talk": true
+		}
+	}`)
+	require.NoError(t, p.Process(body))
+	assert.Equal(t, 1, chatSvc.called)
+	assert.Equal(t, "https://remote.example/chat-messages/cm1", chatSvc.lastURI)
+	assert.Equal(t, "bob", chatSvc.lastTo)
+	assert.Equal(t, "yo via cherrypick", chatSvc.lastText)
+}
+
+func TestProcess_CreateChat_HappyPath_ToString(t *testing.T) {
+	// to が array でなく単一 string でも受け付ける (legacy 実装互換)。
+	p, repo, _, _ := newProcessor(t, aliceActor)
+	repo.Users["bob"] = &model.User{ID: "bob", Username: "bob"}
+	chatSvc := &stubChatReceiver{}
+	p.SetChatService(chatSvc)
+
+	body := []byte(`{
+		"id": "https://remote.example/activities/create-chat-2",
+		"type": "Create",
+		"actor": "https://remote.example/users/alice",
+		"object": {
+			"id": "https://remote.example/chat-messages/cm2",
+			"type": "Note",
+			"attributedTo": "https://remote.example/users/alice",
+			"content": "single recipient",
+			"to": "https://example.com/users/bob",
+			"_misskey_talk": true
+		}
+	}`)
+	require.NoError(t, p.Process(body))
+	assert.Equal(t, 1, chatSvc.called)
+	assert.Equal(t, "single recipient", chatSvc.lastText)
+}
+
+func TestProcess_CreateChat_FlagFalseFallsThroughToIngest(t *testing.T) {
+	// `_misskey_talk` flag が false / 無い場合は chat 経路に分岐せず通常の
+	// IngestNote 処理に流れる。chatService は呼ばれないことだけを assert。
+	// IngestNote の実 persist 動作は newFullProcessor 経由の既存
+	// TestProcess_CreateNote でカバーしている。
+	p, _, _, _ := newProcessor(t, aliceActor)
+	chatSvc := &stubChatReceiver{}
+	p.SetChatService(chatSvc)
+	body := []byte(`{
+		"id": "https://remote.example/activities/create-note-1",
+		"type": "Create",
+		"actor": "https://remote.example/users/alice",
+		"object": {
+			"id": "https://remote.example/notes/n1",
+			"type": "Note",
+			"attributedTo": "https://remote.example/users/alice",
+			"content": "regular post",
+			"to": ["https://www.w3.org/ns/activitystreams#Public"]
+		}
+	}`)
+	_ = p.Process(body)
+	assert.Equal(t, 0, chatSvc.called, "chat service must NOT be hit for non-chat notes")
+}
+
+func TestProcess_CreateChat_RecipientNotLocal(t *testing.T) {
+	// recipient が remote 解決されると loopback delivery として拒絶する。
+	p, repo, _, _ := newProcessor(t, aliceActor)
+	remoteURI := "https://remote2.example/users/charlie"
+	remoteHost := "remote2.example"
+	repo.Users["charlie"] = &model.User{ID: "charlie", Username: "charlie", URI: &remoteURI, Host: &remoteHost}
+	chatSvc := &stubChatReceiver{}
+	p.SetChatService(chatSvc)
+
+	body := []byte(`{
+		"id": "https://remote.example/activities/create-chat-3",
+		"type": "Create",
+		"actor": "https://remote.example/users/alice",
+		"object": {
+			"id": "https://remote.example/chat-messages/cm3",
+			"type": "Note",
+			"attributedTo": "https://remote.example/users/alice",
+			"content": "wrong recipient",
+			"to": ["https://remote2.example/users/charlie"],
+			"_misskey_talk": true
+		}
+	}`)
+	err := p.Process(body)
+	assert.Error(t, err)
+	assert.Equal(t, 0, chatSvc.called)
+}
+
 // --- FanoutHook ---
 
 // fakeFanoutHook records OnNoteCreated calls for assertion. #569 で

--- a/internal/core/federation/resolver.go
+++ b/internal/core/federation/resolver.go
@@ -318,8 +318,9 @@ func (r *Resolver) resolveActorOnce(uri string) (*model.User, error) {
 	// chat service の canChat() が remote 相手でも正しく判定できる。
 	//
 	// 新規 fetch 時 (ここ) は flag 欠落 = everyone 扱い。`_misskey_canChat`
-	// 未対応の連合先 (Mastodon 等) はそもそも chat 連合できないので、誤って
-	// "none" に倒すと local 側で送信前 reject されて UX が悪化する。
+	// を export しない実装 (Mastodon / 古い Misskey / 一般的な AP 実装) は
+	// そもそも chat 連合できないので、誤って "none" に倒すと local 側で
+	// 送信前 reject されて UX が悪化するだけ。
 	// refresh 経路 (refreshActor) は flag 欠落 = 既存値保持 (連合先 server が
 	// フィールドを一時的に消した場合に scope を上書きしない安全策) で挙動が
 	// 異なる点に注意。

--- a/internal/core/federation/resolver.go
+++ b/internal/core/federation/resolver.go
@@ -316,6 +316,13 @@ func (r *Resolver) resolveActorOnce(uri string) (*model.User, error) {
 	// を AP に expose しないため、boolean (everyone/none) しか取れない。
 	// chatScope が "none" / "everyone" のどちらかになることを保証することで、
 	// chat service の canChat() が remote 相手でも正しく判定できる。
+	//
+	// 新規 fetch 時 (ここ) は flag 欠落 = everyone 扱い。`_misskey_canChat`
+	// 未対応の連合先 (Mastodon 等) はそもそも chat 連合できないので、誤って
+	// "none" に倒すと local 側で送信前 reject されて UX が悪化する。
+	// refresh 経路 (refreshActor) は flag 欠落 = 既存値保持 (連合先 server が
+	// フィールドを一時的に消した場合に scope を上書きしない安全策) で挙動が
+	// 異なる点に注意。
 	if actor.MisskeyCanChat != nil && !*actor.MisskeyCanChat {
 		user.ChatScope = "none"
 	} else {

--- a/internal/core/federation/resolver.go
+++ b/internal/core/federation/resolver.go
@@ -311,6 +311,16 @@ func (r *Resolver) resolveActorOnce(uri string) (*model.User, error) {
 	if name := actor.Name; name != "" {
 		user.Name = &name
 	}
+	// remote actor の `_misskey_canChat` を chatScope に翻訳する (#692)。
+	// CherryPick / 連合先は granular な scope (followers/following/mutual)
+	// を AP に expose しないため、boolean (everyone/none) しか取れない。
+	// chatScope が "none" / "everyone" のどちらかになることを保証することで、
+	// chat service の canChat() が remote 相手でも正しく判定できる。
+	if actor.MisskeyCanChat != nil && !*actor.MisskeyCanChat {
+		user.ChatScope = "none"
+	} else {
+		user.ChatScope = "everyone"
+	}
 	if actor.Endpoints.SharedInbox != "" {
 		user.SharedInbox = &actor.Endpoints.SharedInbox
 	}
@@ -440,6 +450,17 @@ func (r *Resolver) refreshActor(existing *model.User, uri string) {
 		bannerURL := actor.Image.URL
 		fields["bannerUrl"] = &bannerURL
 		existing.BannerURL = &bannerURL
+	}
+	// `_misskey_canChat` の更新を chatScope に反映 (#692)。flag 欠落時は
+	// 既存値を保持する (連合先がフィールドを export していない場合に上書き
+	// しないため)。
+	if actor.MisskeyCanChat != nil {
+		newScope := "everyone"
+		if !*actor.MisskeyCanChat {
+			newScope = "none"
+		}
+		fields["chatScope"] = newScope
+		existing.ChatScope = newScope
 	}
 	// AP Person Tag配列からカスタム絵文字を抽出してDBにupsert
 	if existing.Host != nil {

--- a/internal/core/federation/resolver_test.go
+++ b/internal/core/federation/resolver_test.go
@@ -1500,6 +1500,9 @@ func TestRefreshActor_UpdatesChatScopeFromCanChat(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			repo := testutil.NewMockUserRepository()
 			uri := "https://remote.example/users/x"
+			// LastFetchedAt を TTL より十分過去にして shouldRefreshActor →
+			// refreshActor 経路を強制発火させる (resolveActorOnce の cold path
+			// 内で refresh が実際に走らないと canChat の取込みが行われない)。
 			stale := time.Now().Add(-48 * time.Hour)
 			repo.Users["existing"] = &model.User{
 				ID:            "existing",

--- a/internal/core/federation/resolver_test.go
+++ b/internal/core/federation/resolver_test.go
@@ -81,6 +81,35 @@ func TestResolveActor_NewUser(t *testing.T) {
 	assert.Contains(t, pem, "FAKE")
 }
 
+// #692: 新規 fetch で `_misskey_canChat` を chatScope に翻訳する。
+// 欠落 / true は "everyone"、false は "none" にマップ。
+func TestResolveActor_NewUserCanChatTranslation(t *testing.T) {
+	cases := []struct {
+		name     string
+		bodyFlag string
+		want     string
+	}{
+		{"missing", "", "everyone"},
+		{"true", `, "_misskey_canChat": true`, "everyone"},
+		{"false", `, "_misskey_canChat": false`, "none"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			body := `{
+				"id": "https://remote.example/users/alice",
+				"type": "Person",
+				"preferredUsername": "alice",
+				"inbox": "https://remote.example/users/alice/inbox",
+				"publicKey": {"publicKeyPem": "FAKE"}` + tc.bodyFlag + `
+			}`
+			r, _ := newResolver(t, body, nil)
+			user, err := r.ResolveActor("https://remote.example/users/alice")
+			require.NoError(t, err)
+			assert.Equal(t, tc.want, user.ChatScope)
+		})
+	}
+}
+
 func TestResolveActor_NewUserIngestsIconBanner(t *testing.T) {
 	// actor.icon / actor.image があれば avatarUrl / bannerUrl に取り込む。
 	body := `{
@@ -1451,6 +1480,50 @@ func TestResolveActor_OrganizationTypeDoesNotSetIsBot(t *testing.T) {
 	user, err := r.ResolveActor("https://remote.example/users/x")
 	require.NoError(t, err)
 	assert.False(t, user.IsBot)
+}
+
+// #692: refresh で `_misskey_canChat: false` を受け取ったら chatScope を
+// "none" に書き換える (DB / メモリ両方)。flag 欠落時は既存 chatScope を
+// 保持する (連合先が一時的に field を消した場合の保護)。
+func TestRefreshActor_UpdatesChatScopeFromCanChat(t *testing.T) {
+	cases := []struct {
+		name         string
+		bodyFlag     string
+		initialScope string
+		want         string
+	}{
+		{"false_flag_sets_none", `, "_misskey_canChat": false`, "everyone", "none"},
+		{"true_flag_sets_everyone", `, "_misskey_canChat": true`, "none", "everyone"},
+		{"missing_keeps_existing", "", "everyone", "everyone"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			repo := testutil.NewMockUserRepository()
+			uri := "https://remote.example/users/x"
+			stale := time.Now().Add(-48 * time.Hour)
+			repo.Users["existing"] = &model.User{
+				ID:            "existing",
+				Username:      "x",
+				URI:           &uri,
+				ChatScope:     tc.initialScope,
+				LastFetchedAt: &stale,
+			}
+			body := `{
+				"id": "https://remote.example/users/x",
+				"type": "Person",
+				"preferredUsername": "x",
+				"inbox": "https://remote.example/users/x/inbox",
+				"publicKey": {"publicKeyPem": "FAKE"}` + tc.bodyFlag + `
+			}`
+			noteRepo := testutil.NewMockNoteRepository()
+			urls := activitypub.NewURLBuilder("https://example.com")
+			idGen, _ := id.NewGenerator("aidx")
+			r := federation.NewResolver(repo, noteRepo, urls, &stubFetcher{body: []byte(body)}, idGen)
+			user, err := r.ResolveActor(uri)
+			require.NoError(t, err)
+			assert.Equal(t, tc.want, user.ChatScope)
+		})
+	}
 }
 
 func TestRefreshActor_UpdatesIsBotOnTypeChange(t *testing.T) {

--- a/internal/core/user/user_service.go
+++ b/internal/core/user/user_service.go
@@ -272,6 +272,10 @@ type UpdateInput struct {
 	AutoSensitive     *bool
 	NoCrawle          *bool
 	PreventAiLearning *bool
+	// ChatScope は誰からのチャットを許可するか (1-on-1 DM 用)。
+	// 受け付けるのは "everyone" / "followers" / "following" / "mutual" / "none"
+	// (CherryPick / Misskey TS と同じ enum)。検証は呼び出し側 (#692)。
+	ChatScope *string
 	// Room は jsonb 列に書き込む生バイト列。nil の場合は更新しない。
 	// 呼び出し側で JSON として妥当であることを保証する必要がある。
 	Room *json.RawMessage
@@ -349,6 +353,9 @@ func (s *Service) UpdateProfile(userID string, in UpdateInput) (*UserWithProfile
 	}
 	if in.PreventAiLearning != nil {
 		profileFields["preventAiLearning"] = *in.PreventAiLearning
+	}
+	if in.ChatScope != nil {
+		userFields["chatScope"] = *in.ChatScope
 	}
 	if in.Room != nil {
 		// GORM は map で渡された値を jsonb 列に直接書き込む。

--- a/internal/entity/user.go
+++ b/internal/entity/user.go
@@ -107,6 +107,24 @@ type InstanceLite struct {
 	ThemeColor      *string `json:"themeColor"`
 }
 
+// IdenticonURL returns the avatar URL for u, falling back to the local
+// `/identicon/<username>(@<host>)` route when the user has no explicit
+// avatarUrl. Mirrors upstream Misskey TS の identicon URL 規則。
+//
+// 共有 helper として切り出してあるので、UserLite 以外のレスポンス
+// (e.g. internal/api/chat の packUser / internal/core/chat の packUserStream)
+// も同じ規則を使える (#692 / #708 review)。
+func IdenticonURL(u *model.User) string {
+	if u.AvatarURL != nil && *u.AvatarURL != "" {
+		return *u.AvatarURL
+	}
+	host := ""
+	if u.Host != nil {
+		host = "@" + *u.Host
+	}
+	return "/identicon/" + u.Username + host
+}
+
 // PackUserLite converts a model.User to a UserLite DTO.
 // Instance (nested remote instance info) must be pre-fetched by the caller
 // via InstanceRepository and assigned to the returned UserLite.Instance.
@@ -117,16 +135,8 @@ type InstanceLite struct {
 // DB を叩かない。cache miss / TTL 切れでのみ admin catalog の List を 1 回
 // 引く (#521 / #524 review)。
 func PackUserLite(u *model.User) UserLite {
-	avatarURL := u.AvatarURL
-	// avatarUrlがnullの場合、identiconを生成
-	if avatarURL == nil || *avatarURL == "" {
-		host := ""
-		if u.Host != nil {
-			host = "@" + *u.Host
-		}
-		identicon := "/identicon/" + u.Username + host
-		avatarURL = &identicon
-	}
+	resolved := IdenticonURL(u)
+	avatarURL := &resolved
 	out := UserLite{
 		ID:                u.ID,
 		Name:              u.Name,

--- a/internal/entity/user.go
+++ b/internal/entity/user.go
@@ -135,14 +135,13 @@ func IdenticonURL(u *model.User) string {
 // DB を叩かない。cache miss / TTL 切れでのみ admin catalog の List を 1 回
 // 引く (#521 / #524 review)。
 func PackUserLite(u *model.User) UserLite {
-	resolved := IdenticonURL(u)
-	avatarURL := &resolved
+	avatarURL := IdenticonURL(u)
 	out := UserLite{
 		ID:                u.ID,
 		Name:              u.Name,
 		Username:          u.Username,
 		Host:              u.Host,
-		AvatarURL:         avatarURL,
+		AvatarURL:         &avatarURL,
 		AvatarBlurhash:    u.AvatarBlurhash,
 		AvatarDecorations: resolveAvatarDecorations(u.AvatarDecorations),
 		IsBot:             u.IsBot,

--- a/internal/entity/user.go
+++ b/internal/entity/user.go
@@ -23,6 +23,13 @@ type UserLite struct {
 	Emojis            map[string]string      `json:"emojis"`
 	OnlineStatus      string                 `json:"onlineStatus"`
 	BadgeRoles        []any                  `json:"badgeRoles"`
+	// CanChat は upstream Misskey TS の boolean field (#692)。FE の
+	// /chat/room.vue が `!user.canChat` で「DM 受け付け不可」warning を
+	// 出すので、出さないと local user 同士で DM できないと誤表示される。
+	// mk-go では chatScope!='none' を簡易判定として使う (upstream は
+	// roleService.policy.chatAvailability を参照するが、mk-go は role
+	// policy がまだ chat に対応していないため chatScope 由来で代替)。
+	CanChat bool `json:"canChat"`
 	// Optional TS-compat fields (Phase 7-5a)。
 	// TS側は `requireSigninToViewContents: user.x === false ? undefined : true`
 	// なので、値が true のときのみ expose する (*bool を &true に設定、
@@ -56,12 +63,17 @@ type UserDetailed struct {
 	NotesCount          int            `json:"notesCount"`
 	FollowersVisibility string         `json:"followersVisibility"`
 	FollowingVisibility string         `json:"followingVisibility"`
-	CreatedAt           string         `json:"createdAt"`
-	UpdatedAt           *string        `json:"updatedAt"`
-	URI                 *string        `json:"uri"`
-	URL                 *string        `json:"url"`
-	PinnedNoteIDs       []string       `json:"pinnedNoteIds"`
-	PinnedNotes         []any          `json:"pinnedNotes"`
+	// ChatScope は 1-on-1 チャットの受信許可レベル (#692)。FE の
+	// /settings/privacy が `i/update` レスポンスから直接 `$i.chatScope` に
+	// 反映するため、この field を expose しないと UI が保存後に古い値で
+	// 再描画される (DB は更新されているのに UI が "保存されない" と見える)。
+	ChatScope     string   `json:"chatScope"`
+	CreatedAt     string   `json:"createdAt"`
+	UpdatedAt     *string  `json:"updatedAt"`
+	URI           *string  `json:"uri"`
+	URL           *string  `json:"url"`
+	PinnedNoteIDs []string `json:"pinnedNoteIds"`
+	PinnedNotes   []any    `json:"pinnedNotes"`
 	// PinnedPageID is the user_profile.pinnedPageId. PinnedPage is the fully
 	// packed page object corresponding to that id (nil when the user has no
 	// pinned page or the page has been deleted). Both are populated by the
@@ -128,6 +140,7 @@ func PackUserLite(u *model.User) UserLite {
 		Emojis:            make(map[string]string),
 		OnlineStatus:      "unknown",
 		BadgeRoles:        []any{},
+		CanChat:           u.ChatScope != "none",
 	}
 	// requireSigninToViewContents: true のときだけ出す (TS は false→undefined)
 	if u.RequireSigninToViewContents {
@@ -161,6 +174,7 @@ func PackUserDetailed(u *model.User, profile *model.UserProfile, idGens ...id.Ge
 		VerifiedLinks:       []string{},
 		FollowersVisibility: "public",
 		FollowingVisibility: "public",
+		ChatScope:           u.ChatScope,
 		URI:                 u.URI,
 		PinnedNoteIDs:       []string{},
 		PinnedNotes:         []any{},

--- a/internal/entity/user_test.go
+++ b/internal/entity/user_test.go
@@ -187,6 +187,25 @@ func TestPackUserDetailed_DefaultValues(t *testing.T) {
 	assert.Empty(t, detailed.VerifiedLinks)
 }
 
+// #692: chatScope を含めることで FE の /settings/privacy が `i/update` の
+// レスポンスから現在値を取り戻せる。expose を忘れると DB は更新されている
+// のに UI が "保存されない" 表示になる退行を防ぐ。
+func TestPackUserDetailed_ExposesChatScope(t *testing.T) {
+	cases := []string{"everyone", "followers", "following", "mutual", "none"}
+	for _, scope := range cases {
+		t.Run(scope, func(t *testing.T) {
+			u := &model.User{
+				ID:                "u",
+				Username:          "u",
+				ChatScope:         scope,
+				AvatarDecorations: datatypes.JSON([]byte("[]")),
+			}
+			detailed := PackUserDetailed(u, nil)
+			assert.Equal(t, scope, detailed.ChatScope)
+		})
+	}
+}
+
 func TestPackUserDetailed_NilProfile(t *testing.T) {
 	u := &model.User{
 		ID:                "user4",

--- a/internal/repository/chat.go
+++ b/internal/repository/chat.go
@@ -55,8 +55,28 @@ type ChatRepository interface {
 	// involving userID, ordered by recency.
 	ListHistory(userID string, limit int) ([]*model.ChatMessage, error)
 
+	// ListUserHistory is the DM-only variant: 1-on-1 conversations only,
+	// rooms excluded. Mirrors upstream ChatService.userHistory (#692)。
+	ListUserHistory(userID string, limit int) ([]*model.ChatMessage, error)
+
+	// ListRoomHistory is the room-only variant: per-room latest message,
+	// for rooms the user owns or has membership in. Mirrors upstream
+	// ChatService.roomHistory (#692)。
+	ListRoomHistory(userID string, limit int) ([]*model.ChatMessage, error)
+
 	// Mark all as read
 	MarkAllRead(userID string) error
+
+	// MarkAllReadFromUser bulk-marks all DM messages from `fromUserID` to
+	// `readerID` as read (appends readerID to `reads`). Used by user-timeline
+	// to clear the unread badge on chat open (#692, upstream
+	// ChatService.readUserChatMessage 相当)。
+	MarkAllReadFromUser(readerID, fromUserID string) error
+
+	// MarkAllReadInRoom bulk-marks all room messages in `roomID` (excluding
+	// reader's own) as read. Used by room-timeline (#692, upstream
+	// ChatService.readRoomChatMessage 相当)。
+	MarkAllReadInRoom(readerID, roomID string) error
 
 	// Reactions
 	AddReaction(messageID, reaction string) error
@@ -312,7 +332,81 @@ func (r *chatRepository) ListHistory(userID string, limit int) ([]*model.ChatMes
 		return nil, nil
 	}
 	var msgs []*model.ChatMessage
-	if err := r.db.Preload("FromUser").Where("id IN ?", ids).Order("id DESC").Find(&msgs).Error; err != nil {
+	if err := r.db.Preload("FromUser").Preload("ToUser").Preload("ToRoom").Where("id IN ?", ids).Order("id DESC").Find(&msgs).Error; err != nil {
+		return nil, err
+	}
+	return msgs, nil
+}
+
+// ListUserHistory returns the latest DM (1-on-1) message per peer, ordered
+// by recency. Mirrors upstream ChatService.userHistory (#692)。room messages
+// (toRoomId IS NOT NULL) は対象外。
+func (r *chatRepository) ListUserHistory(userID string, limit int) ([]*model.ChatMessage, error) {
+	if limit <= 0 {
+		limit = 10
+	}
+	if limit > 100 {
+		limit = 100
+	}
+	var ids []string
+	err := r.db.Raw(`
+		SELECT id FROM (
+			SELECT DISTINCT ON (conversation_key) *
+			FROM (
+				SELECT *, LEAST("fromUserId","toUserId") || '-' || GREATEST("fromUserId","toUserId") AS conversation_key
+				FROM "chat_message"
+				WHERE ("fromUserId" = ? OR "toUserId" = ?) AND "toRoomId" IS NULL
+			) sub
+			ORDER BY conversation_key, id DESC
+		) conversations
+		ORDER BY id DESC
+		LIMIT ?
+	`, userID, userID, limit).Pluck("id", &ids).Error
+	if err != nil {
+		return nil, err
+	}
+	if len(ids) == 0 {
+		return nil, nil
+	}
+	var msgs []*model.ChatMessage
+	if err := r.db.Preload("FromUser").Preload("ToUser").Where("id IN ?", ids).Order("id DESC").Find(&msgs).Error; err != nil {
+		return nil, err
+	}
+	return msgs, nil
+}
+
+// ListRoomHistory returns the latest message per room that userID owns or
+// is a member of. Mirrors upstream ChatService.roomHistory (#692)。
+func (r *chatRepository) ListRoomHistory(userID string, limit int) ([]*model.ChatMessage, error) {
+	if limit <= 0 {
+		limit = 10
+	}
+	if limit > 100 {
+		limit = 100
+	}
+	var ids []string
+	err := r.db.Raw(`
+		SELECT id FROM (
+			SELECT DISTINCT ON ("toRoomId") cm.*
+			FROM "chat_message" cm
+			WHERE cm."toRoomId" IS NOT NULL
+			AND (
+				EXISTS (SELECT 1 FROM "chat_room_membership" m WHERE m."roomId" = cm."toRoomId" AND m."userId" = ?)
+				OR EXISTS (SELECT 1 FROM "chat_room" cr WHERE cr."id" = cm."toRoomId" AND cr."ownerId" = ?)
+			)
+			ORDER BY "toRoomId", cm.id DESC
+		) conversations
+		ORDER BY id DESC
+		LIMIT ?
+	`, userID, userID, limit).Pluck("id", &ids).Error
+	if err != nil {
+		return nil, err
+	}
+	if len(ids) == 0 {
+		return nil, nil
+	}
+	var msgs []*model.ChatMessage
+	if err := r.db.Preload("FromUser").Preload("ToRoom").Where("id IN ?", ids).Order("id DESC").Find(&msgs).Error; err != nil {
 		return nil, err
 	}
 	return msgs, nil
@@ -321,6 +415,24 @@ func (r *chatRepository) ListHistory(userID string, limit int) ([]*model.ChatMes
 func (r *chatRepository) MarkAllRead(userID string) error {
 	return r.db.Exec(`UPDATE "chat_message" SET "reads" = array_append("reads", ?) WHERE "toUserId" = ? AND NOT ("reads" @> ARRAY[?]::varchar[])`,
 		userID, userID, userID).Error
+}
+
+// MarkAllReadFromUser appends readerID to `reads` for every unread DM
+// where fromUserID -> readerID. Idempotent via NOT (reads @> ...) guard.
+func (r *chatRepository) MarkAllReadFromUser(readerID, fromUserID string) error {
+	return r.db.Exec(
+		`UPDATE "chat_message" SET "reads" = array_append("reads", ?) WHERE "fromUserId" = ? AND "toUserId" = ? AND NOT ("reads" @> ARRAY[?]::varchar[])`,
+		readerID, fromUserID, readerID, readerID,
+	).Error
+}
+
+// MarkAllReadInRoom appends readerID to `reads` for every unread room
+// message in roomID, except messages authored by readerID itself.
+func (r *chatRepository) MarkAllReadInRoom(readerID, roomID string) error {
+	return r.db.Exec(
+		`UPDATE "chat_message" SET "reads" = array_append("reads", ?) WHERE "toRoomId" = ? AND "fromUserId" <> ? AND NOT ("reads" @> ARRAY[?]::varchar[])`,
+		readerID, roomID, readerID, readerID,
+	).Error
 }
 
 func (r *chatRepository) AddReaction(messageID, reaction string) error {

--- a/internal/repository/chat_test.go
+++ b/internal/repository/chat_test.go
@@ -1,6 +1,7 @@
 package repository
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/lib/pq"
@@ -305,6 +306,208 @@ func TestChatRepository_ListHistory(t *testing.T) {
 	histDef, err := repo.ListHistory(me.ID, 0)
 	require.NoError(t, err)
 	assert.Len(t, histDef, 3)
+}
+
+// #692: 履歴ゼロ件 → 空 slice (nil) を返す経路。limit clamp と異なり ids
+// 空の早期 return ブランチをカバー。
+func TestChatRepository_ListHistory_Variants_NoMessages(t *testing.T) {
+	repo := NewChatRepository(testDB)
+
+	uh, err := repo.ListUserHistory("nope_user_id", 10)
+	require.NoError(t, err)
+	assert.Empty(t, uh)
+	rh, err := repo.ListRoomHistory("nope_user_id", 10)
+	require.NoError(t, err)
+	assert.Empty(t, rh)
+}
+
+// #692: ListUserHistory は DM 限定 (toRoomId NULL) で per-peer 最新を返す。
+func TestChatRepository_ListUserHistory(t *testing.T) {
+	repo := NewChatRepository(testDB)
+	me := insertTestUser(t, "u_chat_uh1", "chatuh1")
+	other1 := insertTestUser(t, "u_chat_uh2", "chatuh2")
+	other2 := insertTestUser(t, "u_chat_uh3", "chatuh3")
+	defer cleanupUser(t, me.ID)
+	defer cleanupUser(t, other1.ID)
+	defer cleanupUser(t, other2.ID)
+	room := &model.ChatRoom{ID: "cr_uh1", Name: "Room", OwnerID: me.ID}
+	require.NoError(t, repo.CreateRoom(room))
+	defer testDB.Exec(`DELETE FROM "chat_room" WHERE id = ?`, room.ID)
+
+	text := "msg"
+	// DM 2 件 (me<->other1)
+	for _, id := range []string{"cm_uh1", "cm_uh2"} {
+		m := &model.ChatMessage{
+			ID: id, FromUserID: me.ID, ToUserID: &other1.ID, Text: &text,
+			Reads: pq.StringArray{}, Reactions: pq.StringArray{}, Emojis: pq.StringArray{},
+		}
+		require.NoError(t, repo.CreateMessage(m))
+		defer testDB.Exec(`DELETE FROM "chat_message" WHERE id = ?`, id)
+	}
+	dm3 := &model.ChatMessage{
+		ID: "cm_uh3", FromUserID: me.ID, ToUserID: &other2.ID, Text: &text,
+		Reads: pq.StringArray{}, Reactions: pq.StringArray{}, Emojis: pq.StringArray{},
+	}
+	require.NoError(t, repo.CreateMessage(dm3))
+	defer testDB.Exec(`DELETE FROM "chat_message" WHERE id = ?`, dm3.ID)
+	// room メッセージ → ListUserHistory では除外されるはず
+	rm := &model.ChatMessage{
+		ID: "cm_uh4", FromUserID: me.ID, ToRoomID: &room.ID, Text: &text,
+		Reads: pq.StringArray{}, Reactions: pq.StringArray{}, Emojis: pq.StringArray{},
+	}
+	require.NoError(t, repo.CreateMessage(rm))
+	defer testDB.Exec(`DELETE FROM "chat_message" WHERE id = ?`, rm.ID)
+
+	hist, err := repo.ListUserHistory(me.ID, 10)
+	require.NoError(t, err)
+	// 2 つの DM 会話 (me-other1, me-other2)。room は除外。
+	assert.Len(t, hist, 2)
+	for _, h := range hist {
+		assert.Nil(t, h.ToRoomID, "room メッセージが混入してはいけない")
+	}
+
+	// limit clamp: 0 -> 10, 大きすぎる値 -> 100
+	defHist, _ := repo.ListUserHistory(me.ID, 0)
+	assert.Len(t, defHist, 2)
+	clampHist, _ := repo.ListUserHistory(me.ID, 9999)
+	assert.Len(t, clampHist, 2)
+}
+
+// #692: ListRoomHistory は room 限定 (toRoomId NOT NULL かつ owner / member) で
+// per-room 最新を返す。
+func TestChatRepository_ListRoomHistory(t *testing.T) {
+	repo := NewChatRepository(testDB)
+	owner := insertTestUser(t, "u_chat_rh1", "chatrh1")
+	other := insertTestUser(t, "u_chat_rh2", "chatrh2")
+	defer cleanupUser(t, owner.ID)
+	defer cleanupUser(t, other.ID)
+	r1 := &model.ChatRoom{ID: "cr_rh1", Name: "R1", OwnerID: owner.ID}
+	r2 := &model.ChatRoom{ID: "cr_rh2", Name: "R2", OwnerID: owner.ID}
+	require.NoError(t, repo.CreateRoom(r1))
+	require.NoError(t, repo.CreateRoom(r2))
+	defer testDB.Exec(`DELETE FROM "chat_room" WHERE id IN (?, ?)`, r1.ID, r2.ID)
+
+	text := "rmsg"
+	// r1 に 2 件、r2 に 1 件
+	for _, msg := range []*model.ChatMessage{
+		{ID: "cm_rh1", FromUserID: owner.ID, ToRoomID: &r1.ID, Text: &text, Reads: pq.StringArray{}, Reactions: pq.StringArray{}, Emojis: pq.StringArray{}},
+		{ID: "cm_rh2", FromUserID: owner.ID, ToRoomID: &r1.ID, Text: &text, Reads: pq.StringArray{}, Reactions: pq.StringArray{}, Emojis: pq.StringArray{}},
+		{ID: "cm_rh3", FromUserID: owner.ID, ToRoomID: &r2.ID, Text: &text, Reads: pq.StringArray{}, Reactions: pq.StringArray{}, Emojis: pq.StringArray{}},
+	} {
+		require.NoError(t, repo.CreateMessage(msg))
+		defer testDB.Exec(`DELETE FROM "chat_message" WHERE id = ?`, msg.ID)
+	}
+	// 1on1 DM は除外される
+	dm := &model.ChatMessage{
+		ID: "cm_rh4", FromUserID: owner.ID, ToUserID: &other.ID, Text: &text,
+		Reads: pq.StringArray{}, Reactions: pq.StringArray{}, Emojis: pq.StringArray{},
+	}
+	require.NoError(t, repo.CreateMessage(dm))
+	defer testDB.Exec(`DELETE FROM "chat_message" WHERE id = ?`, dm.ID)
+
+	// owner は r1 / r2 のオーナーなので両方含む
+	hist, err := repo.ListRoomHistory(owner.ID, 10)
+	require.NoError(t, err)
+	assert.Len(t, hist, 2)
+	for _, h := range hist {
+		require.NotNil(t, h.ToRoomID)
+	}
+
+	// other はメンバーシップ無し → 空
+	histOther, err := repo.ListRoomHistory(other.ID, 10)
+	require.NoError(t, err)
+	assert.Empty(t, histOther)
+
+	// limit clamp
+	defHist, _ := repo.ListRoomHistory(owner.ID, 0)
+	assert.Len(t, defHist, 2)
+	clampHist, _ := repo.ListRoomHistory(owner.ID, 9999)
+	assert.Len(t, clampHist, 2)
+}
+
+// #692: MarkAllReadFromUser は (sender→reader) の DM だけを既読化し、
+// 他人発の DM や room メッセージには触らない。
+func TestChatRepository_MarkAllReadFromUser(t *testing.T) {
+	repo := NewChatRepository(testDB)
+	reader := insertTestUser(t, "u_chat_mrf1", "chatmrf1")
+	sender := insertTestUser(t, "u_chat_mrf2", "chatmrf2")
+	stranger := insertTestUser(t, "u_chat_mrf3", "chatmrf3")
+	defer cleanupUser(t, reader.ID)
+	defer cleanupUser(t, sender.ID)
+	defer cleanupUser(t, stranger.ID)
+
+	text := "x"
+	// sender → reader (DM, 2 件)
+	for _, id := range []string{"cm_mrf_s1", "cm_mrf_s2"} {
+		m := &model.ChatMessage{
+			ID: id, FromUserID: sender.ID, ToUserID: &reader.ID, Text: &text,
+			Reads: pq.StringArray{}, Reactions: pq.StringArray{}, Emojis: pq.StringArray{},
+		}
+		require.NoError(t, repo.CreateMessage(m))
+		defer testDB.Exec(`DELETE FROM "chat_message" WHERE id = ?`, id)
+	}
+	// stranger → reader (別人発、対象外)
+	mStranger := &model.ChatMessage{
+		ID: "cm_mrf_x", FromUserID: stranger.ID, ToUserID: &reader.ID, Text: &text,
+		Reads: pq.StringArray{}, Reactions: pq.StringArray{}, Emojis: pq.StringArray{},
+	}
+	require.NoError(t, repo.CreateMessage(mStranger))
+	defer testDB.Exec(`DELETE FROM "chat_message" WHERE id = ?`, mStranger.ID)
+
+	require.NoError(t, repo.MarkAllReadFromUser(reader.ID, sender.ID))
+
+	// sender 発のものは reads に reader が入る
+	mS1, err := repo.FindMessageByID("cm_mrf_s1")
+	require.NoError(t, err)
+	assert.Contains(t, []string(mS1.Reads), reader.ID)
+	// stranger 発のものは触られない
+	mX, err := repo.FindMessageByID("cm_mrf_x")
+	require.NoError(t, err)
+	assert.NotContains(t, []string(mX.Reads), reader.ID)
+
+	// 冪等性: 2 回呼んでもエラーにならず、reads が膨らまない
+	require.NoError(t, repo.MarkAllReadFromUser(reader.ID, sender.ID))
+	mAfter, err := repo.FindMessageByID("cm_mrf_s1")
+	require.NoError(t, err)
+	assert.Equal(t, 1, strings.Count(strings.Join([]string(mAfter.Reads), ","), reader.ID))
+}
+
+// #692: MarkAllReadInRoom は同じ部屋の他人発メッセージを既読化、自分発は触らない。
+func TestChatRepository_MarkAllReadInRoom(t *testing.T) {
+	repo := NewChatRepository(testDB)
+	owner := insertTestUser(t, "u_chat_mrr1", "chatmrr1")
+	other := insertTestUser(t, "u_chat_mrr2", "chatmrr2")
+	defer cleanupUser(t, owner.ID)
+	defer cleanupUser(t, other.ID)
+	room := &model.ChatRoom{ID: "cr_mrr", Name: "R", OwnerID: owner.ID}
+	require.NoError(t, repo.CreateRoom(room))
+	defer testDB.Exec(`DELETE FROM "chat_room" WHERE id = ?`, room.ID)
+
+	text := "y"
+	// other 発 (reader=owner にとって既読対象)
+	mOther := &model.ChatMessage{
+		ID: "cm_mrr_o1", FromUserID: other.ID, ToRoomID: &room.ID, Text: &text,
+		Reads: pq.StringArray{}, Reactions: pq.StringArray{}, Emojis: pq.StringArray{},
+	}
+	require.NoError(t, repo.CreateMessage(mOther))
+	defer testDB.Exec(`DELETE FROM "chat_message" WHERE id = ?`, mOther.ID)
+	// owner 自身発 (既読化対象外)
+	mSelf := &model.ChatMessage{
+		ID: "cm_mrr_self", FromUserID: owner.ID, ToRoomID: &room.ID, Text: &text,
+		Reads: pq.StringArray{}, Reactions: pq.StringArray{}, Emojis: pq.StringArray{},
+	}
+	require.NoError(t, repo.CreateMessage(mSelf))
+	defer testDB.Exec(`DELETE FROM "chat_message" WHERE id = ?`, mSelf.ID)
+
+	require.NoError(t, repo.MarkAllReadInRoom(owner.ID, room.ID))
+
+	mOtherAfter, err := repo.FindMessageByID("cm_mrr_o1")
+	require.NoError(t, err)
+	assert.Contains(t, []string(mOtherAfter.Reads), owner.ID)
+
+	mSelfAfter, err := repo.FindMessageByID("cm_mrr_self")
+	require.NoError(t, err)
+	assert.NotContains(t, []string(mSelfAfter.Reads), owner.ID, "自分発メッセージは既読化対象外")
 }
 
 func TestChatRepository_ListInvitationsByUserAndRoom(t *testing.T) {

--- a/internal/server/router.go
+++ b/internal/server/router.go
@@ -1598,8 +1598,10 @@ func (s *Server) setupRoutes() {
 	chatService := corechat.NewService(chatRepo, idGen)
 	chatService.SetStreamingPublisher(chatPublisher)
 	chatService.SetMainStreamPublisher(mainStreamPublisher)
-	// CherryPick互換AP連合: リモートユーザー宛DMをMisskey:ChatMessageで配送
+	// CherryPick 互換 AP 連合: 1-on-1 DM を Create+Note(_misskey_talk:true) で配送 (#692)。
 	chatService.SetAPDelivery(userRepo, apRenderer, apURLs, deliverService)
+	// chatScope=followers/following/mutual 判定用に following repo を渡す (#692)。
+	chatService.SetFollowingRepo(followingRepo)
 	streamRegistry.Register("chatRoom", channels.NewChatRoomFactory(chatService).New)
 	streamRegistry.Register("chatUser", channels.NewChatUserFactory(chatService).New)
 	// Phase 9.7: federation processor / reversi handler に reversi 依存を注入。

--- a/internal/stream/channels/chat_room_test.go
+++ b/internal/stream/channels/chat_room_test.go
@@ -95,7 +95,15 @@ func (r *chatFakeRepo) UpdateDeliveryStatus(_ string, _, _ bool) error { return 
 func (r *chatFakeRepo) ListHistory(_ string, _ int) ([]*model.ChatMessage, error) {
 	return nil, nil
 }
+func (r *chatFakeRepo) ListUserHistory(_ string, _ int) ([]*model.ChatMessage, error) {
+	return nil, nil
+}
+func (r *chatFakeRepo) ListRoomHistory(_ string, _ int) ([]*model.ChatMessage, error) {
+	return nil, nil
+}
 func (r *chatFakeRepo) MarkAllRead(_ string) error                         { return nil }
+func (r *chatFakeRepo) MarkAllReadFromUser(_, _ string) error              { return nil }
+func (r *chatFakeRepo) MarkAllReadInRoom(_, _ string) error                { return nil }
 func (r *chatFakeRepo) AddReaction(_, _ string) error                      { return nil }
 func (r *chatFakeRepo) RemoveReaction(_, _ string) error                   { return nil }
 func (r *chatFakeRepo) UpdateInvitation(_ *model.ChatRoomInvitation) error { return nil }

--- a/internal/testutil/mock_repository.go
+++ b/internal/testutil/mock_repository.go
@@ -449,6 +449,10 @@ func applyUserFields(u *model.User, fields map[string]any) {
 			if b, ok := v.(bool); ok {
 				u.HideOnlineStatus = b
 			}
+		case "chatScope":
+			if s, ok := v.(string); ok {
+				u.ChatScope = s
+			}
 		case "isSuspended":
 			if b, ok := v.(bool); ok {
 				u.IsSuspended = b


### PR DESCRIPTION
## Summary

UDS 上で動かなかったチャット周りを CherryPick の chat 連合実装に揃える。issue 本文には「チャットが使えない」とだけあったので UDS 検証で症状を細分化し、見つかった backend 側の問題を全て本 PR でまとめて修正。

検証: UDS スタックで以下シナリオを確認済み。
- chatScope 設定が保存・反映される
- CherryPick (上流互換) との 1-on-1 DM 送受信が往復で動く
- リモート相手の chatScope ('none') が正しく事前 reject される
- 履歴一覧でアバター / 日時 / 名前が表示される (identicon fallback 含む)
- 未読バッジがリロードで復活しない

## 主な変更点

### 1. chatScope (DM 受信許可)

- `i/update` で `chatScope` を enum 検証付きで受付・保存
- `entity.UserDetailed` に `chatScope` を expose — FE が `i/update` レスポンスから直接 `\$i.chatScope` に反映するため、無いと UI が古い値で再描画される
- `entity.UserLite` に `canChat` (`chatScope != \"none\"` から導出) を追加 — FE の chat/room.vue で「DM 不可」warning を出し分けるため
- `chat.Service.canChat` を実装。local は granular (followers / following / mutual)、remote は `_misskey_canChat` 由来の `none` だけ事前 reject (granular 判定は連合先に委ねる)
- `CreateMessageToUser` / `CreateMessageViaAP` で canChat 強制

### 2. CherryPick 互換 wire format

- `RenderChatMessage` を `Misskey:ChatMessage` 独自 type から **Create + Note(`_misskey_talk:true`)** に切替。CherryPick / レガシー Misskey と完全 wire 互換
- `handleCreate` で Note の `_misskey_talk: true` を検出して IngestNote の前に chat service にルート。`to` は string / string[] 両対応
- 旧 `Misskey:ChatMessage` 経路は `handleChatMessage` として残し既存 mk-go peer との後方互換を維持

### 3. 連合 actor の `_misskey_canChat` (#692)

- `Person.MisskeyCanChat *bool` を追加し resolver で取り込み (`true → chatScope=everyone`, `false → chatScope=none`)。refresh actor でも追従
- 自分の actor render で `_misskey_canChat: chatScope != \"none\"` を expose

### 4. チャット履歴 / メッセージ表示

- `chat/history` が upstream 互換の `room: bool` parameter を受付 (FE は false / true で 2 回呼ぶ)
- repo に `ListUserHistory` / `ListRoomHistory` を新設
- `packMessage` 系を全パスで createdAt + fromUser / toUser / toRoom 込みに統一 (`packMessageWithCreatedAt` / `packMessageDetailed` / `packMessageStream`)。createdAt 欠落で FE が `NaN/NaN` を出す現象を解消
- `packUser` で avatarUrl 未設定時に `/identicon/<username>(@<host>)` に fallback

### 5. 未読バッジが reload で復活する問題

- `user-timeline` / `room-timeline` を開いた瞬間に「相手 → 自分」/「ルーム内他人発」のメッセージを bulk で既読化。upstream の `readUserChatMessage` / `readRoomChatMessage` 相当を per-message `reads[]` モデルに移植 (`MarkAllReadFromUser` / `MarkAllReadInRoom`)

## 既知の cosmetic limitation

upstream Misskey TS の chat/room.vue は `user.host !== null` (= remote user) で問答無用に「DM 不可」warning を出す。CherryPick はこの check を取り除いているが、mk-go は upstream FE を bundle するため remote 相手では warning が消えない。**チャット送受信自体は動作する**。frontend には触らない方針なので follow-up issue として残す。

## テスト

- chatScope save / enum 検証 / 強制 (TOTP / backup-code 経路含む)
- `Create + Note(_misskey_talk:true)` inbound (to=array / to=string / non-chat fallthrough / remote recipient guard)
- `_misskey_canChat` の往復 (RenderPerson / resolver 取り込み)
- canChat の local granular + remote 二値判定
- `entity.UserDetailed` の chatScope expose / UserLite の canChat

実行方法:
\`\`\`bash
go test ./internal/api/i/... ./internal/api/chat/... ./internal/core/chat/... ./internal/core/federation/... ./internal/core/user/... ./internal/activitypub/... ./internal/entity/... ./internal/repository/... -count=1 -race
\`\`\`

## Related

Closes #692

🤖 Generated with [Claude Code](https://claude.com/claude-code)