### PR TITLE
Fix #693: アンテナの paging に sinceId / untilId を実装

### DIFF
--- a/internal/api/antennas/handler.go
+++ b/internal/api/antennas/handler.go
@@ -237,9 +237,15 @@ func (h *Handler) List(c echo.Context) error {
 }
 
 // NotesRequest is the request body for antennas/notes.
+//
+// SinceID / UntilID は upstream Misskey TS と同じ paging key (#693)。
+// 設定しないと FE が無限スクロールするたびに同じ最新 N 件を取り続けて
+// 「同じノートが何度も表示される」現象になる。
 type NotesRequest struct {
 	AntennaID string `json:"antennaId"`
 	Limit     int    `json:"limit"`
+	SinceID   string `json:"sinceId"`
+	UntilID   string `json:"untilId"`
 }
 
 // Notes handles POST /api/antennas/notes.
@@ -249,7 +255,7 @@ func (h *Handler) Notes(c echo.Context) error {
 	if err := c.Bind(&req); err != nil || req.AntennaID == "" {
 		return apierr.JSONInvalidParam(c)
 	}
-	ids, err := h.svc.Notes(c.Request().Context(), user.ID, req.AntennaID, req.Limit)
+	ids, err := h.svc.Notes(c.Request().Context(), user.ID, req.AntennaID, req.Limit, req.SinceID, req.UntilID)
 	if err != nil {
 		switch {
 		case errors.Is(err, coreantenna.ErrAntennaNotFound):

--- a/internal/api/antennas/handler_test.go
+++ b/internal/api/antennas/handler_test.go
@@ -3,12 +3,14 @@ package antennas
 import (
 	"context"
 	"errors"
+	"fmt"
 	"log"
 	"net/http"
 	"net/http/httptest"
 	"os"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/labstack/echo/v4"
 	"github.com/redis/go-redis/v9"
@@ -377,6 +379,46 @@ type failingNoteRepo struct {
 
 func (r *failingNoteRepo) FindManyByIDsWithUser(_ []string) ([]*model.Note, error) {
 	return nil, errors.New("boom")
+}
+
+// #693: handler が untilId / sinceId を service 層に渡し、結果として
+// stream の paging が効くこと。strictly older / newer な区切りで挙動が変わる
+// ことを e2e (redis 経由) で確認する。
+func TestNotes_PagingUntilId(t *testing.T) {
+	h, repo, noteRepo := newHandler(t)
+	// stream ID 衝突を避けるため antenna ID を test 専用に分ける。
+	repo.Antennas["a693u"] = &model.Antenna{ID: "a693u", UserID: "alice"}
+
+	t1 := time.Now()
+	idA := idGen.Generate(t1)
+	idB := idGen.Generate(t1.Add(time.Millisecond))
+	idC := idGen.Generate(t1.Add(2 * time.Millisecond))
+	entries := []struct {
+		noteID string
+		ms     int64
+	}{
+		{idA, t1.UnixMilli()},
+		{idB, t1.Add(time.Millisecond).UnixMilli()},
+		{idC, t1.Add(2 * time.Millisecond).UnixMilli()},
+	}
+	for _, e := range entries {
+		require.NoError(t, testRedis.Client.XAdd(context.Background(), &redis.XAddArgs{
+			Stream: "antennaTimeline:a693u",
+			ID:     fmt.Sprintf("%d-0", e.ms),
+			Values: map[string]any{"noteId": e.noteID},
+		}).Err())
+		noteRepo.Notes[e.noteID] = &model.Note{ID: e.noteID, UserID: "alice"}
+	}
+
+	// untilId = idC → strictly older
+	body := fmt.Sprintf(`{"antennaId":"a693u","untilId":%q}`, idC)
+	c, rec := newReq(t, body)
+	setUser(c, "alice")
+	require.NoError(t, h.Notes(c))
+	assert.Equal(t, http.StatusOK, rec.Code)
+	assert.Contains(t, rec.Body.String(), idA)
+	assert.Contains(t, rec.Body.String(), idB)
+	assert.NotContains(t, rec.Body.String(), idC, "untilId 自身は含まれてはいけない")
 }
 
 func TestNotes_NoteRepoError(t *testing.T) {

--- a/internal/core/antenna/antenna_service.go
+++ b/internal/core/antenna/antenna_service.go
@@ -289,6 +289,12 @@ func (s *Service) Notes(ctx context.Context, ownerID, antennaID string, limit in
 	}
 	end := "+"
 	start := "-"
+	// `(<ms>-0` exclusive bound は entry id >= "<ms>-0" を全て除外する。
+	// pushNote が `<ms>-*` で seq を自動採番するので同 ms に複数 entry が
+	// 並びうるが、それらは boundary note と「タイ」とみなしてまとめて除外
+	// する (untilID の場合: 厳密に "古い" のみ返す; sinceID の場合は逆)。
+	// FE は最後に表示した note の id を渡してくるので、その note 自身を
+	// 含めると無限ループするのを避ける重要な不変条件。
 	if untilID != "" {
 		if t, err := s.idGen.ParseTime(untilID); err == nil {
 			end = fmt.Sprintf("(%d-0", t.UnixMilli())
@@ -346,8 +352,15 @@ func (s *Service) OnNoteCreated(n *model.Note, author *model.User) {
 }
 
 // pushNote appends a note id to the antenna's Redis stream with MAXLEN trim.
+//
+// Stream entry id は `<unix_ms>-*` 形式で発番する: ms 部分は note の作成時刻
+// から派生させて時系列順序を保ち、seq 部分は Redis に auto-increment させる。
+// 旧実装の `<unix_ms>-0` 固定だと同一 ms に同じアンテナへ複数 note を push
+// した際に Redis Stream の monotonic 制約に違反して XADD が失敗していた
+// (#693 PR review #1)。`*` を使うと同 ms 内で seq=0,1,2,... と自動採番されて
+// 衝突しない。
 func (s *Service) pushNote(ctx context.Context, antennaID, noteID string, now time.Time) error {
-	streamID := fmt.Sprintf("%d-0", now.UnixMilli())
+	streamID := fmt.Sprintf("%d-*", now.UnixMilli())
 	return s.client.XAdd(ctx, &redis.XAddArgs{
 		Stream: streamKey(antennaID),
 		MaxLen: MaxNotesPerAntenna,

--- a/internal/core/antenna/antenna_service.go
+++ b/internal/core/antenna/antenna_service.go
@@ -265,9 +265,19 @@ func (s *Service) ListByUser(userID string) ([]*model.Antenna, error) {
 	return s.repo.ListByUser(userID)
 }
 
-// Notes returns the most recent note ids matched by the antenna, newest first.
+// Notes returns note ids matched by the antenna, newest first, optionally
+// constrained by `untilID` (strict upper bound — return notes strictly older)
+// or `sinceID` (strict lower bound — return notes strictly newer)。
 // limit <= 0 ならデフォルト 10、上限 100。
-func (s *Service) Notes(ctx context.Context, ownerID, antennaID string, limit int) ([]string, error) {
+//
+// Redis Stream の entry id は `<unix_ms>-<seq>` 形式で、pushNote が note の
+// 作成時刻 (= idGen.ParseTime で取れる) から派生させて発番している。よって
+// untilID / sinceID で渡された noteID を ParseTime → unix_ms に変換し、Redis
+// Stream の exclusive range syntax (`(<id>`) で上限/下限を指定できる。
+//
+// untilID / sinceID が空なら全 range を見て最新 N 件を返す (旧挙動互換)。
+// パース失敗時は安全側に bound を緩める (= 全 range)。
+func (s *Service) Notes(ctx context.Context, ownerID, antennaID string, limit int, sinceID, untilID string) ([]string, error) {
 	if _, err := s.Show(ownerID, antennaID); err != nil {
 		return nil, err
 	}
@@ -277,7 +287,19 @@ func (s *Service) Notes(ctx context.Context, ownerID, antennaID string, limit in
 	if limit > 100 {
 		limit = 100
 	}
-	res, err := s.client.XRevRangeN(ctx, streamKey(antennaID), "+", "-", int64(limit)).Result()
+	end := "+"
+	start := "-"
+	if untilID != "" {
+		if t, err := s.idGen.ParseTime(untilID); err == nil {
+			end = fmt.Sprintf("(%d-0", t.UnixMilli())
+		}
+	}
+	if sinceID != "" {
+		if t, err := s.idGen.ParseTime(sinceID); err == nil {
+			start = fmt.Sprintf("(%d-0", t.UnixMilli())
+		}
+	}
+	res, err := s.client.XRevRangeN(ctx, streamKey(antennaID), end, start, int64(limit)).Result()
 	if err != nil {
 		return nil, err
 	}

--- a/internal/core/antenna/antenna_service_test.go
+++ b/internal/core/antenna/antenna_service_test.go
@@ -326,6 +326,20 @@ func TestNotes_PagingSinceID(t *testing.T) {
 	assert.Equal(t, []string{id3, id2}, rows)
 }
 
+// #693 review #1: 同一 ms に同じアンテナへ複数回 pushNote しても XADD が
+// 失敗せず、両方が stream に格納されて一覧取得できる (旧 `<ms>-0` 固定実装は
+// monotonic 違反で 2 件目を drop していた)。
+func TestPushNote_SameMsDoesNotCollide(t *testing.T) {
+	svc, repo := newSvc(t)
+	repo.Antennas["a1"] = &model.Antenna{ID: "a1", UserID: "u1"}
+	now := time.Now()
+	require.NoError(t, svc.pushNote(context.Background(), "a1", "n1", now))
+	require.NoError(t, svc.pushNote(context.Background(), "a1", "n2", now), "同 ms でも 2 件目が成功すること")
+	rows, err := svc.Notes(context.Background(), "u1", "a1", 10, "", "")
+	require.NoError(t, err)
+	assert.ElementsMatch(t, []string{"n1", "n2"}, rows)
+}
+
 // #693: 不正な ID (ParseTime 失敗) は無視されて全範囲が返る (安全側 fallback)。
 func TestNotes_PagingInvalidID(t *testing.T) {
 	svc, repo := newSvc(t)

--- a/internal/core/antenna/antenna_service_test.go
+++ b/internal/core/antenna/antenna_service_test.go
@@ -252,7 +252,7 @@ func TestNotes_HappyPath(t *testing.T) {
 	repo.Antennas["a1"] = &model.Antenna{ID: "a1", UserID: "u1"}
 	require.NoError(t, svc.pushNote(context.Background(), "a1", "n1", time.Now()))
 	require.NoError(t, svc.pushNote(context.Background(), "a1", "n2", time.Now().Add(time.Millisecond)))
-	rows, err := svc.Notes(context.Background(), "u1", "a1", 10)
+	rows, err := svc.Notes(context.Background(), "u1", "a1", 10, "", "")
 	require.NoError(t, err)
 	assert.Len(t, rows, 2)
 }
@@ -260,17 +260,17 @@ func TestNotes_HappyPath(t *testing.T) {
 func TestNotes_LimitClamping(t *testing.T) {
 	svc, repo := newSvc(t)
 	repo.Antennas["a1"] = &model.Antenna{ID: "a1", UserID: "u1"}
-	rows, err := svc.Notes(context.Background(), "u1", "a1", -1)
+	rows, err := svc.Notes(context.Background(), "u1", "a1", -1, "", "")
 	require.NoError(t, err)
 	assert.Empty(t, rows)
-	rows, err = svc.Notes(context.Background(), "u1", "a1", 9999)
+	rows, err = svc.Notes(context.Background(), "u1", "a1", 9999, "", "")
 	require.NoError(t, err)
 	assert.Empty(t, rows)
 }
 
 func TestNotes_NotFound(t *testing.T) {
 	svc, _ := newSvc(t)
-	_, err := svc.Notes(context.Background(), "u1", "missing", 10)
+	_, err := svc.Notes(context.Background(), "u1", "missing", 10, "", "")
 	assert.ErrorIs(t, err, ErrAntennaNotFound)
 }
 
@@ -278,8 +278,62 @@ func TestNotes_RedisError(t *testing.T) {
 	repo := testutil.NewMockAntennaRepository()
 	repo.Antennas["a1"] = &model.Antenna{ID: "a1", UserID: "u1"}
 	svc := NewService(repo, testutil.NewMockUserRepository(), closedClient(t), idGen)
-	_, err := svc.Notes(context.Background(), "u1", "a1", 10)
+	_, err := svc.Notes(context.Background(), "u1", "a1", 10, "", "")
 	assert.Error(t, err)
+}
+
+// #693: untilID で渡した noteID より strictly old なエントリだけ返ること。
+// FE の無限スクロールが「次のページ」を取りに来た時にこれが効かないと、
+// 同じ最新 N 件を毎回返してしまう。
+func TestNotes_PagingUntilID(t *testing.T) {
+	svc, repo := newSvc(t)
+	repo.Antennas["a1"] = &model.Antenna{ID: "a1", UserID: "u1"}
+	// 3 件: 古→新の順 (idGen.Generate は時間 monotonic)
+	t1 := time.Now()
+	id1 := idGen.Generate(t1)
+	id2 := idGen.Generate(t1.Add(time.Millisecond))
+	id3 := idGen.Generate(t1.Add(2 * time.Millisecond))
+	require.NoError(t, svc.pushNote(context.Background(), "a1", id1, t1))
+	require.NoError(t, svc.pushNote(context.Background(), "a1", id2, t1.Add(time.Millisecond)))
+	require.NoError(t, svc.pushNote(context.Background(), "a1", id3, t1.Add(2*time.Millisecond)))
+
+	// untilID = id3 → strictly older だけ → id2, id1 (newest first)
+	rows, err := svc.Notes(context.Background(), "u1", "a1", 10, "", id3)
+	require.NoError(t, err)
+	assert.Equal(t, []string{id2, id1}, rows)
+
+	// untilID = id1 (= 一番古い) → さらに古いものは無いので空
+	rows, err = svc.Notes(context.Background(), "u1", "a1", 10, "", id1)
+	require.NoError(t, err)
+	assert.Empty(t, rows)
+}
+
+// #693: sinceID で渡した noteID より strictly new なエントリだけ返ること。
+func TestNotes_PagingSinceID(t *testing.T) {
+	svc, repo := newSvc(t)
+	repo.Antennas["a1"] = &model.Antenna{ID: "a1", UserID: "u1"}
+	t1 := time.Now()
+	id1 := idGen.Generate(t1)
+	id2 := idGen.Generate(t1.Add(time.Millisecond))
+	id3 := idGen.Generate(t1.Add(2 * time.Millisecond))
+	require.NoError(t, svc.pushNote(context.Background(), "a1", id1, t1))
+	require.NoError(t, svc.pushNote(context.Background(), "a1", id2, t1.Add(time.Millisecond)))
+	require.NoError(t, svc.pushNote(context.Background(), "a1", id3, t1.Add(2*time.Millisecond)))
+
+	// sinceID = id1 → strictly newer → id3, id2 (newest first)
+	rows, err := svc.Notes(context.Background(), "u1", "a1", 10, id1, "")
+	require.NoError(t, err)
+	assert.Equal(t, []string{id3, id2}, rows)
+}
+
+// #693: 不正な ID (ParseTime 失敗) は無視されて全範囲が返る (安全側 fallback)。
+func TestNotes_PagingInvalidID(t *testing.T) {
+	svc, repo := newSvc(t)
+	repo.Antennas["a1"] = &model.Antenna{ID: "a1", UserID: "u1"}
+	require.NoError(t, svc.pushNote(context.Background(), "a1", "n1", time.Now()))
+	rows, err := svc.Notes(context.Background(), "u1", "a1", 10, "", "not-an-id")
+	require.NoError(t, err)
+	assert.Len(t, rows, 1, "ParseTime 失敗時は全 range にフォールバックして既存挙動を維持")
 }
 
 func TestNotes_SkipsBadValue(t *testing.T) {
@@ -291,7 +345,7 @@ func TestNotes_SkipsBadValue(t *testing.T) {
 		ID:     "1-0",
 		Values: map[string]any{"other": "x"},
 	}).Err())
-	rows, err := svc.Notes(context.Background(), "u1", "a1", 10)
+	rows, err := svc.Notes(context.Background(), "u1", "a1", 10, "", "")
 	require.NoError(t, err)
 	assert.Empty(t, rows)
 }
@@ -330,7 +384,7 @@ func TestOnNoteCreated_HappyPath(t *testing.T) {
 	author := &model.User{ID: "author", Username: "alice"}
 	svc.OnNoteCreated(n, author)
 
-	rows, err := svc.Notes(context.Background(), "u1", "a1", 10)
+	rows, err := svc.Notes(context.Background(), "u1", "a1", 10, "", "")
 	require.NoError(t, err)
 	assert.Equal(t, []string{"n1"}, rows)
 }
@@ -400,7 +454,7 @@ func TestOnNoteCreated_NoMatchSkipped(t *testing.T) {
 		&model.User{ID: "author", Username: "alice"},
 	)
 
-	rows, err := svc.Notes(context.Background(), "u1", "a1", 10)
+	rows, err := svc.Notes(context.Background(), "u1", "a1", 10, "", "")
 	require.NoError(t, err)
 	assert.Empty(t, rows)
 }
@@ -688,7 +742,7 @@ func TestOnNoteCreated_ListSource_OnlyMemberNotesAppear(t *testing.T) {
 	n4 := &model.Note{ID: "n4", UserID: "dave", Text: &text4}
 	svc.OnNoteCreated(n4, &model.User{ID: "dave", Username: "dave"})
 
-	rows, err := svc.Notes(context.Background(), "owner", "ant1", 100)
+	rows, err := svc.Notes(context.Background(), "owner", "ant1", 100, "", "")
 	require.NoError(t, err)
 	// alice と carol のノートだけが含まれ、bob と dave のノートは含まれない
 	assert.Len(t, rows, 2)
@@ -737,7 +791,7 @@ func TestOnNoteCreated_ListSource_WithKeywords(t *testing.T) {
 		&model.User{ID: "bob", Username: "bob"},
 	)
 
-	rows, err := svc.Notes(context.Background(), "owner", "ant2", 100)
+	rows, err := svc.Notes(context.Background(), "owner", "ant2", 100, "", "")
 	require.NoError(t, err)
 	assert.Equal(t, []string{"n1"}, rows)
 }
@@ -850,7 +904,7 @@ func TestOnNoteCreated_ListSource_MemberRemoved(t *testing.T) {
 		&model.User{ID: "bob", Username: "bob"},
 	)
 
-	rows, err := svc.Notes(context.Background(), "owner", "ant-rm", 100)
+	rows, err := svc.Notes(context.Background(), "owner", "ant-rm", 100, "", "")
 	require.NoError(t, err)
 	assert.Equal(t, []string{"n-alice"}, rows)
 }

--- a/internal/core/antenna/note_hook_test.go
+++ b/internal/core/antenna/note_hook_test.go
@@ -21,7 +21,7 @@ func TestNoteCreateHook_OnNoteCreatedForwards(t *testing.T) {
 		&model.User{ID: "u2", Username: "alice"},
 	)
 
-	rows, err := svc.Notes(context.Background(), "u1", "a1", 10)
+	rows, err := svc.Notes(context.Background(), "u1", "a1", 10, "", "")
 	require.NoError(t, err)
 	assert.Equal(t, []string{"n1"}, rows)
 }


### PR DESCRIPTION
## Summary

\`/api/antennas/notes\` API が \`limit\` しか受け取らず \`sinceId\` / \`untilId\` を無視していたため、frontend の無限スクロールが「次のページ」を取りに来ても毎回同じ最新 N 件を返していた。結果として **同じノートが何度も表示される** 現象が起きていた。

## 主な変更点

### \`internal/api/antennas/handler.go\`

- \`NotesRequest\` に \`SinceID\` / \`UntilID\` を追加 (upstream Misskey TS の paramDef と同じ)

### \`internal/core/antenna/antenna_service.go\`

- \`Service.Notes\` が両 paging key を受け取り、Redis Stream の exclusive range syntax (\`(<unix_ms>-0\`) で stream を絞り込む
- noteID → unix_ms の変換は \`idGen.ParseTime\` で行う (Stream entry ID は note 作成時刻から派生して発番されているため、note ID から逆算可能)
- パース失敗時は安全側に bound を緩めて旧挙動 (全 range) にフォールバック

## 検証

UDS スタックで以下を確認:
- アンテナタイムラインを開く → 一覧表示 OK
- 下スクロール → 古いノートが追加で表示され、同じノートが繰り返されない

## テスト

- \`TestNotes_PagingUntilID\` / \`TestNotes_PagingSinceID\` / \`TestNotes_PagingInvalidID\` (service 単位、Redis 経由)
- \`TestNotes_PagingUntilId\` (handler 経由 e2e)
- 既存 \`TestNotes_*\` を新シグネチャに追従

\`\`\`bash
go test ./internal/core/antenna/... ./internal/api/antennas/... -count=1 -race
\`\`\`

## Related

Closes #693

🤖 Generated with [Claude Code](https://claude.com/claude-code)