### PR TITLE
Fix #676: FederationUpdateInstance を repository 経由に refactor + log type 分岐 test

### DIFF
--- a/internal/api/admin/federation_admin.go
+++ b/internal/api/admin/federation_admin.go
@@ -154,8 +154,11 @@ func (req federationUpdateInstanceRequest) updates() map[string]any {
 // `updateRemoteInstanceNote` の moderation_log を **個別に** 出力する。1 リクエ
 // ストで両方変更されれば 2 ログ。`isBlocked` / `isSilenced` は TS 仕様に該当
 // type が無いので skip。
+//
+// instance 行の lookup / 更新は `InstanceRepository` (#676 で DI 化) を経由する。
+// 未配線時は no-op で 204 を返す (元の挙動と一貫)。
 func (h *Handler) FederationUpdateInstance(c echo.Context) error {
-	if h.adminDB == nil {
+	if h.instanceRepo == nil {
 		return c.NoContent(http.StatusNoContent)
 	}
 	var req federationUpdateInstanceRequest
@@ -166,12 +169,16 @@ func (h *Handler) FederationUpdateInstance(c echo.Context) error {
 	// `moderationNote` の before/after)。lookup 失敗は instance 不在として
 	// no-op で 204 を返す (元の挙動は単純 Updates 1 回だけだったので失敗時
 	// silent と一貫)。
-	var before model.Instance
-	if err := h.adminDB.Where(`"host" = ?`, req.Host).First(&before).Error; err != nil {
+	beforePtr, err := h.instanceRepo.FindByHost(req.Host)
+	if err != nil {
 		return c.NoContent(http.StatusNoContent)
 	}
+	// 値コピーで snapshot を凍結する: UpdateFields の実装によっては同じ struct
+	// を mutate することがあり (例: in-memory mock)、後段の moderation log diff
+	// で before/after が両方 after 値になる退行を防ぐ。
+	before := *beforePtr
 	if updates := req.updates(); len(updates) > 0 {
-		h.adminDB.Model(&model.Instance{}).Where(`"host" = ?`, req.Host).Updates(updates)
+		_ = h.instanceRepo.UpdateFields(req.Host, updates)
 	}
 	// suspend / unsuspend と moderationNote 変更で個別 log を出す。
 	// SuspensionState != "none" を「suspended」と扱う。

--- a/internal/api/admin/federation_admin.go
+++ b/internal/api/admin/federation_admin.go
@@ -176,6 +176,11 @@ func (h *Handler) FederationUpdateInstance(c echo.Context) error {
 	// 値コピーで snapshot を凍結する: UpdateFields の実装によっては同じ struct
 	// を mutate することがあり (例: in-memory mock)、後段の moderation log diff
 	// で before/after が両方 after 値になる退行を防ぐ。
+	//
+	// 注意: 浅 copy なので *string 等の pointer field は参照先を共有する。
+	// 現状 log で参照する `SuspensionState string` / `ModerationNote string`
+	// は scalar なので問題なし。pointer field を log に含める拡張が入った
+	// 時は deep copy への昇格を検討。
 	before := *beforePtr
 	if updates := req.updates(); len(updates) > 0 {
 		_ = h.instanceRepo.UpdateFields(req.Host, updates)

--- a/internal/api/admin/federation_admin_test.go
+++ b/internal/api/admin/federation_admin_test.go
@@ -1,9 +1,11 @@
 package admin_test
 
 import (
+	"encoding/json"
 	"errors"
 	"net/http"
 	"testing"
+	"time"
 
 	"github.com/shiroha-a/mk/internal/model"
 	"github.com/shiroha-a/mk/internal/queue"
@@ -155,4 +157,156 @@ func TestFederationRemoveAllFollowing_NoOpWhenUnwired(t *testing.T) {
 func TestFederationUpdateInstance(t *testing.T) {
 	h, _, _, _ := newTestHandler(t)
 	assert.Equal(t, http.StatusNoContent, doPost(h.FederationUpdateInstance, `{}`, adminUser).Code)
+}
+
+// #676: instanceRepo 未配線なら request body の有無に関わらず 204 で no-op。
+func TestFederationUpdateInstance_NoOpWithoutInstanceRepo(t *testing.T) {
+	h, _, _, _ := newTestHandler(t)
+	repo := attachModLog(t, h)
+	rec := doPost(h.FederationUpdateInstance, `{"host":"remote.example","isSuspended":true}`, adminUser)
+	assert.Equal(t, http.StatusNoContent, rec.Code)
+	// 200ms 待っても log は出ないこと (instanceRepo 未配線なので before lookup
+	// 段階で early return している)。
+	time.Sleep(50 * time.Millisecond)
+	assert.Empty(t, repo.Snapshot(), "instanceRepo 未配線時は moderation log を書かない")
+}
+
+// #676: instance 行が存在しない host への update は no-op (FindByHost が err)。
+func TestFederationUpdateInstance_HostNotFound(t *testing.T) {
+	h, _, _, _ := newTestHandler(t)
+	instRepo := testutil.NewMockInstanceRepository()
+	h.SetInstanceRepo(instRepo)
+	repo := attachModLog(t, h)
+	rec := doPost(h.FederationUpdateInstance, `{"host":"ghost.example","isSuspended":true}`, adminUser)
+	assert.Equal(t, http.StatusNoContent, rec.Code)
+	time.Sleep(50 * time.Millisecond)
+	assert.Empty(t, repo.Snapshot(), "instance 不在なら何もログしない")
+}
+
+// #676: isSuspended=true への遷移で suspendRemoteInstance 1 件だけ書く。
+func TestFederationUpdateInstance_WritesSuspendLog(t *testing.T) {
+	h, _, _, _ := newTestHandler(t)
+	instRepo := testutil.NewMockInstanceRepository()
+	require.NoError(t, instRepo.Create(&model.Instance{
+		ID:              "inst-1",
+		Host:            "remote.example",
+		SuspensionState: model.SuspensionStateNone, // before: 未停止
+	}))
+	h.SetInstanceRepo(instRepo)
+	repo := attachModLog(t, h)
+
+	rec := doPost(h.FederationUpdateInstance, `{"host":"remote.example","isSuspended":true}`, adminUser)
+	require.Equal(t, http.StatusNoContent, rec.Code)
+	require.Eventually(t, func() bool { return len(repo.Snapshot()) == 1 }, 500*time.Millisecond, 5*time.Millisecond)
+
+	logs := repo.Snapshot()
+	assert.Equal(t, "suspendRemoteInstance", logs[0].Type)
+	var info map[string]any
+	require.NoError(t, json.Unmarshal(logs[0].Info, &info))
+	assert.Equal(t, "inst-1", info["id"])
+	assert.Equal(t, "remote.example", info["host"])
+}
+
+// #676: suspended → unsuspended 遷移で unsuspendRemoteInstance を書く。
+func TestFederationUpdateInstance_WritesUnsuspendLog(t *testing.T) {
+	h, _, _, _ := newTestHandler(t)
+	instRepo := testutil.NewMockInstanceRepository()
+	require.NoError(t, instRepo.Create(&model.Instance{
+		ID:              "inst-2",
+		Host:            "remote.example",
+		SuspensionState: model.SuspensionStateManuallySuspended, // before: 停止中
+	}))
+	h.SetInstanceRepo(instRepo)
+	repo := attachModLog(t, h)
+
+	rec := doPost(h.FederationUpdateInstance, `{"host":"remote.example","isSuspended":false}`, adminUser)
+	require.Equal(t, http.StatusNoContent, rec.Code)
+	require.Eventually(t, func() bool { return len(repo.Snapshot()) == 1 }, 500*time.Millisecond, 5*time.Millisecond)
+	assert.Equal(t, "unsuspendRemoteInstance", repo.Snapshot()[0].Type)
+}
+
+// #676: isSuspended が状態と一致 (no-change) なら log を書かない。
+func TestFederationUpdateInstance_SuspendNoChange_NoLog(t *testing.T) {
+	h, _, _, _ := newTestHandler(t)
+	instRepo := testutil.NewMockInstanceRepository()
+	require.NoError(t, instRepo.Create(&model.Instance{
+		ID:              "inst-3",
+		Host:            "remote.example",
+		SuspensionState: model.SuspensionStateNone,
+	}))
+	h.SetInstanceRepo(instRepo)
+	repo := attachModLog(t, h)
+
+	rec := doPost(h.FederationUpdateInstance, `{"host":"remote.example","isSuspended":false}`, adminUser)
+	assert.Equal(t, http.StatusNoContent, rec.Code)
+	time.Sleep(50 * time.Millisecond)
+	assert.Empty(t, repo.Snapshot(), "状態が変わらない場合は log 不要")
+}
+
+// #676: moderationNote の before/after 差分で updateRemoteInstanceNote を書く。
+func TestFederationUpdateInstance_WritesModerationNoteLog(t *testing.T) {
+	h, _, _, _ := newTestHandler(t)
+	instRepo := testutil.NewMockInstanceRepository()
+	require.NoError(t, instRepo.Create(&model.Instance{
+		ID:             "inst-4",
+		Host:           "remote.example",
+		ModerationNote: "old note",
+	}))
+	h.SetInstanceRepo(instRepo)
+	repo := attachModLog(t, h)
+
+	rec := doPost(h.FederationUpdateInstance, `{"host":"remote.example","moderationNote":"new note"}`, adminUser)
+	require.Equal(t, http.StatusNoContent, rec.Code)
+	require.Eventually(t, func() bool { return len(repo.Snapshot()) == 1 }, 500*time.Millisecond, 5*time.Millisecond)
+
+	logs := repo.Snapshot()
+	assert.Equal(t, "updateRemoteInstanceNote", logs[0].Type)
+	var info map[string]any
+	require.NoError(t, json.Unmarshal(logs[0].Info, &info))
+	assert.Equal(t, "old note", info["before"])
+	assert.Equal(t, "new note", info["after"])
+	assert.Equal(t, "inst-4", info["id"])
+}
+
+// #676: moderationNote が同じ値なら log 無し (空文字列で clear のケースを除く)。
+func TestFederationUpdateInstance_NoteSameValue_NoLog(t *testing.T) {
+	h, _, _, _ := newTestHandler(t)
+	instRepo := testutil.NewMockInstanceRepository()
+	require.NoError(t, instRepo.Create(&model.Instance{
+		ID:             "inst-5",
+		Host:           "remote.example",
+		ModerationNote: "same",
+	}))
+	h.SetInstanceRepo(instRepo)
+	repo := attachModLog(t, h)
+
+	rec := doPost(h.FederationUpdateInstance, `{"host":"remote.example","moderationNote":"same"}`, adminUser)
+	assert.Equal(t, http.StatusNoContent, rec.Code)
+	time.Sleep(50 * time.Millisecond)
+	assert.Empty(t, repo.Snapshot())
+}
+
+// #676: 1 リクエストで suspend + note を両方変更すると 2 log が出る。
+func TestFederationUpdateInstance_WritesBothLogs(t *testing.T) {
+	h, _, _, _ := newTestHandler(t)
+	instRepo := testutil.NewMockInstanceRepository()
+	require.NoError(t, instRepo.Create(&model.Instance{
+		ID:              "inst-6",
+		Host:            "remote.example",
+		SuspensionState: model.SuspensionStateNone,
+		ModerationNote:  "old",
+	}))
+	h.SetInstanceRepo(instRepo)
+	repo := attachModLog(t, h)
+
+	body := `{"host":"remote.example","isSuspended":true,"moderationNote":"new"}`
+	rec := doPost(h.FederationUpdateInstance, body, adminUser)
+	require.Equal(t, http.StatusNoContent, rec.Code)
+	require.Eventually(t, func() bool { return len(repo.Snapshot()) == 2 }, 500*time.Millisecond, 5*time.Millisecond)
+
+	types := []string{}
+	for _, l := range repo.Snapshot() {
+		types = append(types, l.Type)
+	}
+	assert.ElementsMatch(t, []string{"suspendRemoteInstance", "updateRemoteInstanceNote"}, types)
 }

--- a/internal/api/admin/federation_admin_test.go
+++ b/internal/api/admin/federation_admin_test.go
@@ -159,16 +159,22 @@ func TestFederationUpdateInstance(t *testing.T) {
 	assert.Equal(t, http.StatusNoContent, doPost(h.FederationUpdateInstance, `{}`, adminUser).Code)
 }
 
+// assertNoLogWritten は「指定期間内に log が 1 件も書かれない」ことを assert
+// する。time.Sleep + assert.Empty より flaky になりにくい (期間中ずっと empty
+// であることを poll する)。
+func assertNoLogWritten(t *testing.T, repo *testutil.MockModerationLogRepository) {
+	t.Helper()
+	assert.Never(t, func() bool { return len(repo.Snapshot()) > 0 }, 100*time.Millisecond, 5*time.Millisecond,
+		"moderation log を書いてはいけない")
+}
+
 // #676: instanceRepo 未配線なら request body の有無に関わらず 204 で no-op。
 func TestFederationUpdateInstance_NoOpWithoutInstanceRepo(t *testing.T) {
 	h, _, _, _ := newTestHandler(t)
 	repo := attachModLog(t, h)
 	rec := doPost(h.FederationUpdateInstance, `{"host":"remote.example","isSuspended":true}`, adminUser)
 	assert.Equal(t, http.StatusNoContent, rec.Code)
-	// 200ms 待っても log は出ないこと (instanceRepo 未配線なので before lookup
-	// 段階で early return している)。
-	time.Sleep(50 * time.Millisecond)
-	assert.Empty(t, repo.Snapshot(), "instanceRepo 未配線時は moderation log を書かない")
+	assertNoLogWritten(t, repo)
 }
 
 // #676: instance 行が存在しない host への update は no-op (FindByHost が err)。
@@ -179,8 +185,7 @@ func TestFederationUpdateInstance_HostNotFound(t *testing.T) {
 	repo := attachModLog(t, h)
 	rec := doPost(h.FederationUpdateInstance, `{"host":"ghost.example","isSuspended":true}`, adminUser)
 	assert.Equal(t, http.StatusNoContent, rec.Code)
-	time.Sleep(50 * time.Millisecond)
-	assert.Empty(t, repo.Snapshot(), "instance 不在なら何もログしない")
+	assertNoLogWritten(t, repo)
 }
 
 // #676: isSuspended=true への遷移で suspendRemoteInstance 1 件だけ書く。
@@ -239,8 +244,7 @@ func TestFederationUpdateInstance_SuspendNoChange_NoLog(t *testing.T) {
 
 	rec := doPost(h.FederationUpdateInstance, `{"host":"remote.example","isSuspended":false}`, adminUser)
 	assert.Equal(t, http.StatusNoContent, rec.Code)
-	time.Sleep(50 * time.Millisecond)
-	assert.Empty(t, repo.Snapshot(), "状態が変わらない場合は log 不要")
+	assertNoLogWritten(t, repo)
 }
 
 // #676: moderationNote の before/after 差分で updateRemoteInstanceNote を書く。
@@ -282,8 +286,7 @@ func TestFederationUpdateInstance_NoteSameValue_NoLog(t *testing.T) {
 
 	rec := doPost(h.FederationUpdateInstance, `{"host":"remote.example","moderationNote":"same"}`, adminUser)
 	assert.Equal(t, http.StatusNoContent, rec.Code)
-	time.Sleep(50 * time.Millisecond)
-	assert.Empty(t, repo.Snapshot())
+	assertNoLogWritten(t, repo)
 }
 
 // #676: 1 リクエストで suspend + note を両方変更すると 2 log が出る。

--- a/internal/api/admin/handler.go
+++ b/internal/api/admin/handler.go
@@ -109,6 +109,11 @@ type Handler struct {
 	systemAccountFetcher    SystemAccountFetcher
 	followingRepo           repository.FollowingRepository
 	unfollowEnqueuer        UnfollowEnqueuer
+	// instanceRepo は admin/federation/* の instance lookup / update を
+	// inject 可能にするための DI 口 (#676)。FederationUpdateInstance の
+	// log type 分岐をテストするため、`adminDB` 直叩きから repository 経由
+	// に剥がしている。未配線時は `adminDB` フォールバックは持たず no-op。
+	instanceRepo repository.InstanceRepository
 	// webhookTestClient は admin/system-webhook/test の fire-and-forget POST
 	// に使う SSRF-safe HTTP client。router.go で safehttp.WithProxy など共通
 	// outbound 設定を適用したものを差し込む (#638)。nil のときは default の
@@ -164,6 +169,13 @@ func (h *Handler) SetSystemAccountFetcher(f SystemAccountFetcher) {
 // SetFollowingRepo attaches a FollowingRepository for admin endpoints that
 // need to enumerate Following rows by host (e.g.
 // admin/federation/remove-all-following).
+// SetInstanceRepo wires an InstanceRepository for admin/federation handlers
+// to use when reading/updating instance rows. Without it,
+// FederationUpdateInstance early-returns 204 (#676)。
+func (h *Handler) SetInstanceRepo(r repository.InstanceRepository) {
+	h.instanceRepo = r
+}
+
 func (h *Handler) SetFollowingRepo(r repository.FollowingRepository) {
 	h.followingRepo = r
 }

--- a/internal/api/admin/handler.go
+++ b/internal/api/admin/handler.go
@@ -166,9 +166,6 @@ func (h *Handler) SetSystemAccountFetcher(f SystemAccountFetcher) {
 	h.systemAccountFetcher = f
 }
 
-// SetFollowingRepo attaches a FollowingRepository for admin endpoints that
-// need to enumerate Following rows by host (e.g.
-// admin/federation/remove-all-following).
 // SetInstanceRepo wires an InstanceRepository for admin/federation handlers
 // to use when reading/updating instance rows. Without it,
 // FederationUpdateInstance early-returns 204 (#676)。
@@ -176,6 +173,9 @@ func (h *Handler) SetInstanceRepo(r repository.InstanceRepository) {
 	h.instanceRepo = r
 }
 
+// SetFollowingRepo attaches a FollowingRepository for admin endpoints that
+// need to enumerate Following rows by host (e.g.
+// admin/federation/remove-all-following).
 func (h *Handler) SetFollowingRepo(r repository.FollowingRepository) {
 	h.followingRepo = r
 }

--- a/internal/server/router.go
+++ b/internal/server/router.go
@@ -1703,6 +1703,7 @@ func (s *Server) setupRoutes() {
 	modLogRepo := repository.NewModerationLogRepository(s.db)
 	recipientRepo := repository.NewAbuseReportNotificationRecipientRepository(s.db)
 	adminHandler := apiadmin.NewHandler(signupService, roleService, metaRepo, userRepo, idGen)
+	adminHandler.SetInstanceRepo(instanceRepo)
 	adminHandler.SetAbuseRepo(abuseReportRepo)
 	adminHandler.SetAbuseForwarder(coreabuse.NewForwarder(abuseReportRepo, sysAcctSvc, apRenderer, deliverService))
 	adminHandler.SetDeleteAccountEnqueuer(s.queueClient)


### PR DESCRIPTION
## Summary

PR #674 で \`FederationUpdateInstance\` に moderation log 配線 (suspend / unsuspend / updateRemoteInstanceNote) を追加したが、handler が \`adminDB\` を直接叩く設計のため log type 分岐が unit test で覆えていなかった。

本 PR では handler を **InstanceRepository 経由** に refactor して mock 注入を可能にし、4 種類の log type 分岐すべてに test を追加する。

## 主な変更点

### handler refactor (依存反転)

- \`Handler\` に \`instanceRepo repository.InstanceRepository\` field を追加 + \`SetInstanceRepo\` setter
- \`FederationUpdateInstance\` が \`h.adminDB.Where(...).First(...)\` / \`h.adminDB.Updates(...)\` から repo の \`FindByHost\` / \`UpdateFields\` 経由に変更
- 早期 return 条件も \`adminDB == nil\` から \`instanceRepo == nil\` に置換
- before snapshot を pointer から値コピー (\`before := *beforePtr\`) に変更 — mock の \`UpdateFields\` 実装が同じ struct を mutate するケースで before/after diff が壊れないように

### router wire

- \`adminHandler.SetInstanceRepo(instanceRepo)\` を追加 (既存の \`instanceRepo := repository.NewInstanceRepository(s.db)\` を流用)

### テスト追加

| Test | カバー対象 |
|---|---|
| \`TestFederationUpdateInstance_NoOpWithoutInstanceRepo\` | repo 未配線時の early return |
| \`TestFederationUpdateInstance_HostNotFound\` | instance 不在 → 204 / log なし |
| \`TestFederationUpdateInstance_WritesSuspendLog\` | none → suspended で \`suspendRemoteInstance\` |
| \`TestFederationUpdateInstance_WritesUnsuspendLog\` | suspended → none で \`unsuspendRemoteInstance\` |
| \`TestFederationUpdateInstance_SuspendNoChange_NoLog\` | 同状態で log 無し |
| \`TestFederationUpdateInstance_WritesModerationNoteLog\` | note before/after diff |
| \`TestFederationUpdateInstance_NoteSameValue_NoLog\` | note 同値で log 無し |
| \`TestFederationUpdateInstance_WritesBothLogs\` | 1 リクエスト suspend + note → 2 log |

実行:
\`\`\`bash
go test ./internal/api/admin/... -count=1 -race
\`\`\`

## Related

Closes #676 (PR #674 follow-up)

🤖 Generated with [Claude Code](https://claude.com/claude-code)