### PR TITLE
Fix #679: ActivityPub 受信 note の hashtag 抽出

### DIFF
--- a/internal/core/federation/resolver.go
+++ b/internal/core/federation/resolver.go
@@ -19,6 +19,7 @@ import (
 	"github.com/shiroha-a/mk/internal/activitypub"
 	"github.com/shiroha-a/mk/internal/activitypub/mfm"
 	corenote "github.com/shiroha-a/mk/internal/core/note"
+	"github.com/shiroha-a/mk/internal/misc/hashtag"
 	"github.com/shiroha-a/mk/internal/misc/id"
 	"github.com/shiroha-a/mk/internal/model"
 	"github.com/shiroha-a/mk/internal/repository"
@@ -706,6 +707,20 @@ func (r *Resolver) IngestNote(body []byte) (*model.Note, error) {
 	if actor.Host != nil {
 		note.Emojis = r.upsertEmojis(extractEmojiTags(apNote.Tag), *actor.Host)
 	}
+	// hashtag は AP `tag` 配列の Hashtag entry と本文 / CW の両方から拾い、
+	// hashtag.Extract で case-insensitive dedup + 長さ truncate を一括処理
+	// する (#679)。`tag` 配列が空 / Hashtag を含まない実装 (古い Mastodon
+	// 等) でも本文 fallback で trends 集計に乗るようにする。
+	hashtagSources := extractHashtagTagNames(apNote.Tag)
+	if note.Text != nil {
+		hashtagSources = append(hashtagSources, *note.Text)
+	}
+	if note.CW != nil {
+		hashtagSources = append(hashtagSources, *note.CW)
+	}
+	if tags := hashtag.Extract(hashtagSources...); len(tags) > 0 {
+		note.Tags = pq.StringArray(tags)
+	}
 	// AP `attachment` 配列を drive_file 行に upsert (#378)。link 形式のみで
 	// 実 fetch はせず、frontend が drive_file.url 経由で remote 取得する。
 	note.FileIDs = r.upsertAttachments(extractAttachments(apNote.Attachment), &actor.ID, actor.Host)
@@ -851,6 +866,20 @@ func (r *Resolver) UpdateRemoteNote(body []byte) (*model.Note, error) {
 			fields["emojis"] = emojis
 			existing.Emojis = emojis
 		}
+	}
+	// hashtag は AP `tag` Hashtag entry + 編集後の本文 / CW から再抽出して
+	// 差分があれば更新 (#679)。IngestNote と同じ規則。
+	hashtagSources := extractHashtagTagNames(apNote.Tag)
+	if existing.Text != nil {
+		hashtagSources = append(hashtagSources, *existing.Text)
+	}
+	if existing.CW != nil {
+		hashtagSources = append(hashtagSources, *existing.CW)
+	}
+	newTags := hashtag.Extract(hashtagSources...)
+	if !slices.Equal([]string(existing.Tags), newTags) {
+		fields["tags"] = pq.StringArray(newTags)
+		existing.Tags = pq.StringArray(newTags)
 	}
 	// AP `attachment` 配列の差分を反映する (#378)。driveFileRepo 未設定時は
 	// upsertAttachments が空 slice を返すので何もしない (= 既存 fileIDs を
@@ -1019,6 +1048,35 @@ func (r *Resolver) resolveTextMentionUserIDs(mentions []corenote.Mention) []stri
 			continue
 		}
 		out = append(out, u.ID)
+	}
+	return out
+}
+
+// extractHashtagTagNames parses the Tag array of a Note and returns the
+// `name` of every Hashtag entry (type="Hashtag"). upstream Misskey の
+// renderHashtag は `name: "#" + tag` 形式で出すので、戻り値も `#tag`
+// プレフィクス付き。呼び出し側で hashtag.Extract に渡せば本文由来の
+// 抽出と統一的に dedup / 正規化される (#679)。
+//
+// `name` が空のものはスキップ。type 違いも skip。
+func extractHashtagTagNames(tags []any) []string {
+	if len(tags) == 0 {
+		return nil
+	}
+	out := make([]string, 0, len(tags))
+	for _, tag := range tags {
+		m, ok := tag.(map[string]any)
+		if !ok {
+			continue
+		}
+		if typ, _ := m["type"].(string); typ != "Hashtag" {
+			continue
+		}
+		name, _ := m["name"].(string)
+		if name == "" {
+			continue
+		}
+		out = append(out, name)
 	}
 	return out
 }

--- a/internal/core/federation/resolver.go
+++ b/internal/core/federation/resolver.go
@@ -1066,8 +1066,9 @@ func (r *Resolver) resolveTextMentionUserIDs(mentions []corenote.Mention) []stri
 // 抽出と統一的に dedup / 正規化される (#679)。
 //
 // AP spec は `name` の format を厳密に規定していないため、`#` 無しで
-// 来る実装 (稀) のために defensive に prefix を補う。`name` が空のものは
-// スキップ。type 違いも skip。
+// 来る実装 (稀) のために defensive に prefix を補う。よって戻り値は
+// 必ずしも入力 `name` と完全一致しない (`"tag"` → `"#tag"` に書き換え
+// られる場合がある)。`name` が空のものはスキップ。type 違いも skip。
 func extractHashtagTagNames(tags []any) []string {
 	if len(tags) == 0 {
 		return nil

--- a/internal/core/federation/resolver.go
+++ b/internal/core/federation/resolver.go
@@ -869,6 +869,13 @@ func (r *Resolver) UpdateRemoteNote(body []byte) (*model.Note, error) {
 	}
 	// hashtag は AP `tag` Hashtag entry + 編集後の本文 / CW から再抽出して
 	// 差分があれば更新 (#679)。IngestNote と同じ規則。
+	//
+	// 順序依存に注意: 上の text 更新 (`if newText != "" { existing.Text = &newText }`)
+	// と CW 更新が既に適用済みの状態で `existing.Text` / `existing.CW` を
+	// 読むので、再抽出は更新後の値で行う。`if newText != ""` を skip した
+	// 場合は元の値を保つので、この場合も「現在の本文 + 新 tag」で再計算
+	// される。将来 text 更新ロジックを別関数に切り出す等の refactor が
+	// 入ったら、この順序依存も追従させること。
 	hashtagSources := extractHashtagTagNames(apNote.Tag)
 	if existing.Text != nil {
 		hashtagSources = append(hashtagSources, *existing.Text)
@@ -1058,7 +1065,9 @@ func (r *Resolver) resolveTextMentionUserIDs(mentions []corenote.Mention) []stri
 // プレフィクス付き。呼び出し側で hashtag.Extract に渡せば本文由来の
 // 抽出と統一的に dedup / 正規化される (#679)。
 //
-// `name` が空のものはスキップ。type 違いも skip。
+// AP spec は `name` の format を厳密に規定していないため、`#` 無しで
+// 来る実装 (稀) のために defensive に prefix を補う。`name` が空のものは
+// スキップ。type 違いも skip。
 func extractHashtagTagNames(tags []any) []string {
 	if len(tags) == 0 {
 		return nil
@@ -1075,6 +1084,12 @@ func extractHashtagTagNames(tags []any) []string {
 		name, _ := m["name"].(string)
 		if name == "" {
 			continue
+		}
+		// `#` prefix 欠落は upstream の renderHashtag では起きないが、
+		// 他実装が `name: "tag"` だけ送ってきた場合に hashtag.Extract の
+		// 正規表現にマッチさせるため補完する。
+		if !strings.HasPrefix(name, "#") {
+			name = "#" + name
 		}
 		out = append(out, name)
 	}

--- a/internal/core/federation/resolver_test.go
+++ b/internal/core/federation/resolver_test.go
@@ -496,6 +496,30 @@ func TestIngestNote_HashtagsMergeAndDedup(t *testing.T) {
 	assert.ElementsMatch(t, []string{"golang", "news"}, []string(note.Tags))
 }
 
+// #679: CW (summary) 由来の hashtag も抽出される。本文が無く CW にだけ
+// hashtag があるケース (sensitive note 等) で trends 集計に拾われないと
+// 取りこぼしになる。
+func TestIngestNote_HashtagsFromCW(t *testing.T) {
+	repo := testutil.NewMockUserRepository()
+	noteRepo := testutil.NewMockNoteRepository()
+	urls := activitypub.NewURLBuilder("https://example.com")
+	idGen, _ := id.NewGenerator("aidx")
+	r := federation.NewResolver(repo, noteRepo, urls, &stubFetcher{body: []byte(sampleActor)}, idGen)
+
+	body := `{
+		"id": "https://remote.example/notes/h-cw",
+		"type": "Note",
+		"attributedTo": "https://remote.example/users/alice",
+		"content": "no inline tag",
+		"summary": "important #news here",
+		"sensitive": true,
+		"to": ["https://www.w3.org/ns/activitystreams#Public"]
+	}`
+	note, err := r.IngestNote([]byte(body))
+	require.NoError(t, err)
+	assert.ElementsMatch(t, []string{"news"}, []string(note.Tags))
+}
+
 // #679: Hashtag 無しなら note.Tags は nil/empty で残る。
 func TestIngestNote_NoHashtags(t *testing.T) {
 	repo := testutil.NewMockUserRepository()

--- a/internal/core/federation/resolver_test.go
+++ b/internal/core/federation/resolver_test.go
@@ -425,6 +425,97 @@ func (f *failingNoteCreateRepo) Create(_ *model.Note) error {
 	return errors.New("create failed")
 }
 
+// #679: AP `tag` 配列の Hashtag entry を note.tags に取り込む。
+func TestIngestNote_HashtagsFromTagArray(t *testing.T) {
+	repo := testutil.NewMockUserRepository()
+	noteRepo := testutil.NewMockNoteRepository()
+	urls := activitypub.NewURLBuilder("https://example.com")
+	idGen, _ := id.NewGenerator("aidx")
+	r := federation.NewResolver(repo, noteRepo, urls, &stubFetcher{body: []byte(sampleActor)}, idGen)
+
+	body := `{
+		"id": "https://remote.example/notes/h1",
+		"type": "Note",
+		"attributedTo": "https://remote.example/users/alice",
+		"content": "no inline tag here",
+		"to": ["https://www.w3.org/ns/activitystreams#Public"],
+		"tag": [
+			{"type": "Hashtag", "name": "#golang", "href": "https://remote.example/tags/golang"},
+			{"type": "Hashtag", "name": "#federation"},
+			{"type": "Mention", "href": "https://remote.example/users/bob"}
+		]
+	}`
+	note, err := r.IngestNote([]byte(body))
+	require.NoError(t, err)
+	assert.ElementsMatch(t, []string{"golang", "federation"}, []string(note.Tags), "Hashtag entries の name から #prefix を剥がして格納")
+}
+
+// #679: text 由来の hashtag fallback。Mastodon 等で `tag` 配列が無い実装でも
+// 本文 / CW から拾う。
+func TestIngestNote_HashtagsFromTextFallback(t *testing.T) {
+	repo := testutil.NewMockUserRepository()
+	noteRepo := testutil.NewMockNoteRepository()
+	urls := activitypub.NewURLBuilder("https://example.com")
+	idGen, _ := id.NewGenerator("aidx")
+	r := federation.NewResolver(repo, noteRepo, urls, &stubFetcher{body: []byte(sampleActor)}, idGen)
+
+	body := `{
+		"id": "https://remote.example/notes/h2",
+		"type": "Note",
+		"attributedTo": "https://remote.example/users/alice",
+		"content": "hello #golang and #federation world",
+		"to": ["https://www.w3.org/ns/activitystreams#Public"]
+	}`
+	note, err := r.IngestNote([]byte(body))
+	require.NoError(t, err)
+	assert.ElementsMatch(t, []string{"golang", "federation"}, []string(note.Tags))
+}
+
+// #679: AP tag と text の両方に hashtag があれば case-insensitive で dedup される。
+func TestIngestNote_HashtagsMergeAndDedup(t *testing.T) {
+	repo := testutil.NewMockUserRepository()
+	noteRepo := testutil.NewMockNoteRepository()
+	urls := activitypub.NewURLBuilder("https://example.com")
+	idGen, _ := id.NewGenerator("aidx")
+	r := federation.NewResolver(repo, noteRepo, urls, &stubFetcher{body: []byte(sampleActor)}, idGen)
+
+	body := `{
+		"id": "https://remote.example/notes/h3",
+		"type": "Note",
+		"attributedTo": "https://remote.example/users/alice",
+		"content": "see #Golang and #news",
+		"to": ["https://www.w3.org/ns/activitystreams#Public"],
+		"tag": [
+			{"type": "Hashtag", "name": "#golang"}
+		]
+	}`
+	note, err := r.IngestNote([]byte(body))
+	require.NoError(t, err)
+	// "#golang" (tag 配列) と "#Golang" (text) は case-insensitive で同一視。
+	// hashtag.Extract は first-seen casing を保つので tag 配列が先で `golang`。
+	assert.ElementsMatch(t, []string{"golang", "news"}, []string(note.Tags))
+}
+
+// #679: Hashtag 無しなら note.Tags は nil/empty で残る。
+func TestIngestNote_NoHashtags(t *testing.T) {
+	repo := testutil.NewMockUserRepository()
+	noteRepo := testutil.NewMockNoteRepository()
+	urls := activitypub.NewURLBuilder("https://example.com")
+	idGen, _ := id.NewGenerator("aidx")
+	r := federation.NewResolver(repo, noteRepo, urls, &stubFetcher{body: []byte(sampleActor)}, idGen)
+
+	body := `{
+		"id": "https://remote.example/notes/h4",
+		"type": "Note",
+		"attributedTo": "https://remote.example/users/alice",
+		"content": "no tags here",
+		"to": ["https://www.w3.org/ns/activitystreams#Public"]
+	}`
+	note, err := r.IngestNote([]byte(body))
+	require.NoError(t, err)
+	assert.Empty(t, []string(note.Tags))
+}
+
 func TestIngestNote_NoteCreateError(t *testing.T) {
 	repo := testutil.NewMockUserRepository()
 	noteRepo := &failingNoteCreateRepo{MockNoteRepository: testutil.NewMockNoteRepository()}
@@ -847,6 +938,36 @@ func TestUpdateRemoteNote_HappyPath(t *testing.T) {
 	assert.Equal(t, "edited content", *got.Text)
 	require.NotNil(t, got.CW)
 	assert.Equal(t, "edited cw", *got.CW)
+}
+
+// #679: UpdateRemoteNote が note.tags を再計算する。tag 配列が変わった場合に
+// DB tags も追従すること。
+func TestUpdateRemoteNote_RecalculatesHashtags(t *testing.T) {
+	repo := testutil.NewMockUserRepository()
+	noteRepo := testutil.NewMockNoteRepository()
+	uri := "https://remote.example/notes/n1"
+	host := "remote.example"
+	noteRepo.Notes["n1"] = &model.Note{
+		ID: "n1", URI: &uri, UserID: "alice-id", UserHost: &host,
+		Tags: []string{"old"},
+	}
+	urls := activitypub.NewURLBuilder("https://example.com")
+	idGen, _ := id.NewGenerator("aidx")
+	r := federation.NewResolver(repo, noteRepo, urls, &stubFetcher{}, idGen)
+
+	body := `{
+		"id": "https://remote.example/notes/n1",
+		"type": "Note",
+		"attributedTo": "https://remote.example/users/alice",
+		"content": "edited and now tagged #news",
+		"tag": [
+			{"type": "Hashtag", "name": "#federation"}
+		]
+	}`
+	got, err := r.UpdateRemoteNote([]byte(body))
+	require.NoError(t, err)
+	require.NotNil(t, got)
+	assert.ElementsMatch(t, []string{"federation", "news"}, []string(got.Tags), "古い tags は捨て、tag 配列 + 本文 fallback で再構築")
 }
 
 func TestUpdateRemoteNote_NoNoteRepo(t *testing.T) {

--- a/internal/core/federation/resolver_test.go
+++ b/internal/core/federation/resolver_test.go
@@ -520,6 +520,31 @@ func TestIngestNote_HashtagsFromCW(t *testing.T) {
 	assert.ElementsMatch(t, []string{"news"}, []string(note.Tags))
 }
 
+// #679 review #2: `name` に `#` prefix が付いていない非標準実装からの
+// Hashtag tag も defensive 補完によって正しく拾われる。upstream Misskey の
+// renderHashtag では起きないが将来の AP 実装互換性を guard する。
+func TestIngestNote_HashtagWithoutPrefixDefensive(t *testing.T) {
+	repo := testutil.NewMockUserRepository()
+	noteRepo := testutil.NewMockNoteRepository()
+	urls := activitypub.NewURLBuilder("https://example.com")
+	idGen, _ := id.NewGenerator("aidx")
+	r := federation.NewResolver(repo, noteRepo, urls, &stubFetcher{body: []byte(sampleActor)}, idGen)
+
+	body := `{
+		"id": "https://remote.example/notes/h-noprefix",
+		"type": "Note",
+		"attributedTo": "https://remote.example/users/alice",
+		"content": "no inline tag",
+		"to": ["https://www.w3.org/ns/activitystreams#Public"],
+		"tag": [
+			{"type": "Hashtag", "name": "golang"}
+		]
+	}`
+	note, err := r.IngestNote([]byte(body))
+	require.NoError(t, err)
+	assert.Contains(t, []string(note.Tags), "golang", "name に # が無くても defensive 補完で抽出される")
+}
+
 // #679: Hashtag 無しなら note.Tags は nil/empty で残る。
 func TestIngestNote_NoHashtags(t *testing.T) {
 	repo := testutil.NewMockUserRepository()


### PR DESCRIPTION
## Summary

ローカル note は #678 で hashtag 抽出済みだが、リモート note (\`IngestNote\` / \`UpdateRemoteNote\`) は \`note.tags\` を空のまま保存していたため、連合先ユーザーの hashtag が mk-go の trends / 検索 に拾われない問題を修正。

## 主な変更点

### \`internal/core/federation/resolver.go\`

- \`extractHashtagTagNames(tags []any) []string\` を追加: AP \`tag\` 配列から type=Hashtag の \`name\` を抜き出す (upstream は \`name: \"#\" + tag\` 形式で出すので \`#tag\` プレフィクス付きで返却)
- \`IngestNote\` / \`UpdateRemoteNote\` で:
  - AP \`tag\` 配列の Hashtag 名
  - 本文 (\`note.Text\`)
  - CW (\`note.CW\`)
  
  を \`hashtag.Extract\` に渡して \`note.tags\` を構築。case-insensitive dedup + 長さ truncate は #678 で導入した既存 helper を再利用 (ローカル / リモートで同一規則)
- \`tag\` 配列が無い / Hashtag を含まない実装 (古い Mastodon, hashtag 未対応 fork など) でも本文 fallback で trends に集計される

## テスト

| Test | カバー対象 |
|---|---|
| \`TestIngestNote_HashtagsFromTagArray\` | AP \`tag\` 配列の Hashtag entry → note.Tags |
| \`TestIngestNote_HashtagsFromTextFallback\` | tag 配列無し時の本文 fallback |
| \`TestIngestNote_HashtagsMergeAndDedup\` | tag + text 両方ある + case-insensitive dedup |
| \`TestIngestNote_NoHashtags\` | hashtag 無しで note.Tags が空 |
| \`TestUpdateRemoteNote_RecalculatesHashtags\` | Update で tags 再構築 |

実行:
\`\`\`bash
go test ./internal/core/federation/... -count=1 -race
\`\`\`

## Related

Closes #679

- 親 issue #655 (ローカル note は #678 で対応済み)
- #678 で新設した \`internal/misc/hashtag.Extract\` を再利用

🤖 Generated with [Claude Code](https://claude.com/claude-code)