### PR TITLE
Phase 686: admin drive UI で system 所有 drive file を可視化する経路を追加

### DIFF
--- a/internal/api/admin/drive.go
+++ b/internal/api/admin/drive.go
@@ -27,6 +27,13 @@ func (h *Handler) DriveCleanup(c echo.Context) error {
 	return c.NoContent(http.StatusNoContent)
 }
 
+// SystemUserIDToken は `/api/admin/drive/files` の `userId` パラメータで
+// 「system 所有 (UserID IS NULL) の drive file」を一覧する特殊値。custom
+// emoji の copy / import zip 経路で蓄積される system file (#670 で導入)
+// を admin UI から可視化する経路 (#686)。`@` 接頭辞は実 user ID と衝突
+// しない (aidx ID は英数字のみ) ため安全。
+const SystemUserIDToken = "@system"
+
 // DriveFiles handles POST /api/admin/drive/files.
 func (h *Handler) DriveFiles(c echo.Context) error {
 	if h.driveFileRepo == nil {
@@ -45,6 +52,20 @@ func (h *Handler) DriveFiles(c echo.Context) error {
 	_ = c.Bind(&req)
 	if req.Limit <= 0 || req.Limit > 100 {
 		req.Limit = 30
+	}
+	// userId に @system が指定されたら system file 専用 listing を返す。
+	// origin / host filter は意味を持たない (system file はユーザーに紐付か
+	// ないので) ので、type と pagination のみを取り回す。
+	if req.UserID == SystemUserIDToken {
+		files, err := h.driveFileRepo.ListSystemFiles(req.Type, req.UntilID, req.SinceID, req.Limit)
+		if err != nil {
+			return c.JSON(http.StatusInternalServerError, apierr.InternalError())
+		}
+		out := make([]entity.DriveFileEntity, 0, len(files))
+		for _, f := range files {
+			out = append(out, h.packDriveFileAdmin(f))
+		}
+		return c.JSON(http.StatusOK, out)
 	}
 	switch req.Origin {
 	case "", "combined", "local", "remote":

--- a/internal/api/admin/drive_emoji_test.go
+++ b/internal/api/admin/drive_emoji_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 	"time"
 
+	apiadmin "github.com/shiroha-a/mk/internal/api/admin"
 	"github.com/shiroha-a/mk/internal/model"
 	"github.com/shiroha-a/mk/internal/queue"
 	"github.com/shiroha-a/mk/internal/testutil"
@@ -120,7 +121,10 @@ func TestDriveFiles_FiltersBySystemToken(t *testing.T) {
 	require.NoError(t, repo.Create(&model.DriveFile{ID: "d_remote", UserID: &remoteUser, UserHost: &host, Type: "image/png"}))
 	h.SetDriveFileRepo(repo)
 
-	rec := doPost(h.DriveFiles, `{"userId":"@system","limit":10}`, adminUser)
+	// const apiadmin.SystemUserIDToken を直接参照することで、token 値を後で変更しても
+	// このテストが追従するようにする (文字列直書きを避ける)。
+	body := fmt.Sprintf(`{"userId":%q,"limit":10}`, apiadmin.SystemUserIDToken)
+	rec := doPost(h.DriveFiles, body, adminUser)
 	assert.Equal(t, http.StatusOK, rec.Code)
 	var rows []map[string]any
 	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &rows))
@@ -143,7 +147,8 @@ func TestDriveFiles_SystemTokenWithTypeFilter(t *testing.T) {
 	require.NoError(t, repo.Create(&model.DriveFile{ID: "d_sys_zip", UserID: nil, Type: "application/zip"}))
 	h.SetDriveFileRepo(repo)
 
-	rec := doPost(h.DriveFiles, `{"userId":"@system","type":"image/","limit":10}`, adminUser)
+	body := fmt.Sprintf(`{"userId":%q,"type":"image/","limit":10}`, apiadmin.SystemUserIDToken)
+	rec := doPost(h.DriveFiles, body, adminUser)
 	assert.Equal(t, http.StatusOK, rec.Code)
 	var rows []map[string]any
 	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &rows))

--- a/internal/api/admin/drive_emoji_test.go
+++ b/internal/api/admin/drive_emoji_test.go
@@ -105,6 +105,52 @@ func TestDriveFiles_FiltersByTypePrefix(t *testing.T) {
 	assert.Equal(t, "d1", rows[0]["id"])
 }
 
+func TestDriveFiles_FiltersBySystemToken(t *testing.T) {
+	// #686: userId="@system" 指定時は system 所有 (UserID IS NULL) の drive
+	// file のみを返す。emoji copy / import zip 経路で蓄積される system file
+	// を admin UI から可視化するための経路。
+	h, _, _, _ := newTestHandler(t)
+	repo := testutil.NewMockDriveFileRepository()
+	u := "u1"
+	remoteUser := "u_remote"
+	host := "remote.example"
+	require.NoError(t, repo.Create(&model.DriveFile{ID: "d_sys1", UserID: nil, Type: "image/png"}))
+	require.NoError(t, repo.Create(&model.DriveFile{ID: "d_sys2", UserID: nil, Type: "image/jpeg"}))
+	require.NoError(t, repo.Create(&model.DriveFile{ID: "d_user", UserID: &u, Type: "image/png"}))
+	require.NoError(t, repo.Create(&model.DriveFile{ID: "d_remote", UserID: &remoteUser, UserHost: &host, Type: "image/png"}))
+	h.SetDriveFileRepo(repo)
+
+	rec := doPost(h.DriveFiles, `{"userId":"@system","limit":10}`, adminUser)
+	assert.Equal(t, http.StatusOK, rec.Code)
+	var rows []map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &rows))
+	gotIDs := make(map[string]bool, len(rows))
+	for _, r := range rows {
+		gotIDs[r["id"].(string)] = true
+	}
+	assert.True(t, gotIDs["d_sys1"], "system file should be listed")
+	assert.True(t, gotIDs["d_sys2"], "system file should be listed")
+	assert.False(t, gotIDs["d_user"], "user-owned file must not appear")
+	assert.False(t, gotIDs["d_remote"], "remote-owned file must not appear")
+}
+
+func TestDriveFiles_SystemTokenWithTypeFilter(t *testing.T) {
+	// #686: @system token は type prefix filter と組み合わせ可能。MIME 種別で
+	// system file を絞り込めることを保証する (image/* だけ見たい等)。
+	h, _, _, _ := newTestHandler(t)
+	repo := testutil.NewMockDriveFileRepository()
+	require.NoError(t, repo.Create(&model.DriveFile{ID: "d_sys_img", UserID: nil, Type: "image/png"}))
+	require.NoError(t, repo.Create(&model.DriveFile{ID: "d_sys_zip", UserID: nil, Type: "application/zip"}))
+	h.SetDriveFileRepo(repo)
+
+	rec := doPost(h.DriveFiles, `{"userId":"@system","type":"image/","limit":10}`, adminUser)
+	assert.Equal(t, http.StatusOK, rec.Code)
+	var rows []map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &rows))
+	require.Len(t, rows, 1)
+	assert.Equal(t, "d_sys_img", rows[0]["id"])
+}
+
 func TestDriveShowFile_MissingBothFileIDAndURL(t *testing.T) {
 	h, _, _, _ := newTestHandler(t)
 	h.SetDriveFileRepo(testutil.NewMockDriveFileRepository())

--- a/internal/core/transfer/drive_reader_test.go
+++ b/internal/core/transfer/drive_reader_test.go
@@ -83,6 +83,9 @@ func (f *fakeDriveFileRepo) UpdateBulkFolder(_ []string, _ *string) error       
 func (f *fakeDriveFileRepo) ListForAdmin(_, _, _, _, _, _ string, _ int) ([]*model.DriveFile, error) {
 	return nil, nil
 }
+func (f *fakeDriveFileRepo) ListSystemFiles(_, _, _ string, _ int) ([]*model.DriveFile, error) {
+	return nil, nil
+}
 func (f *fakeDriveFileRepo) DeleteOrphans() (int64, error)     { return 0, nil }
 func (f *fakeDriveFileRepo) DeleteRemoteCache() (int64, error) { return 0, nil }
 func (f *fakeDriveFileRepo) DeleteByUser(_ string) (int64, error) {

--- a/internal/repository/drive_file.go
+++ b/internal/repository/drive_file.go
@@ -24,6 +24,12 @@ type DriveFileRepository interface {
 	// origin is "local" / "remote" / "combined" ("combined" is the
 	// default). Empty host / type are no-ops.
 	ListForAdmin(userID, origin, host, fileType, untilID, sinceID string, limit int) ([]*model.DriveFile, error)
+	// ListSystemFiles returns drive files that are not owned by any user
+	// (userId IS NULL). #670 で導入した emoji copy / import zip の保管先
+	// system file を admin UI から可視化するための一覧 API (#686)。
+	// fileType は MIME prefix match (空なら無制約)、ID 範囲は他の admin
+	// listing と同一の semantics。
+	ListSystemFiles(fileType, untilID, sinceID string, limit int) ([]*model.DriveFile, error)
 	FindByName(userID, name string, folderID *string) ([]*model.DriveFile, error)
 	ExistsByMD5(userID, md5 string) (bool, error)
 	ListByFileIDs(fileIDs []string) ([]*model.DriveFile, error)
@@ -217,6 +223,32 @@ func (r *driveFileRepository) ListForAdmin(userID, origin, host, fileType, until
 	}
 	if fileType != "" {
 		// type is mimetype prefix match (e.g. "image/" matches image/png)
+		q = q.Where(`"type" LIKE ?`, fileType+"%")
+	}
+	if untilID != "" {
+		q = q.Where("id < ?", untilID)
+	}
+	if sinceID != "" {
+		q = q.Where("id > ?", sinceID)
+	}
+	if limit <= 0 {
+		limit = 30
+	}
+	if limit > 100 {
+		limit = 100
+	}
+	var rows []*model.DriveFile
+	if err := q.Order(paginationOrder(sinceID, untilID, "id")).Limit(limit).Find(&rows).Error; err != nil {
+		return nil, err
+	}
+	return rows, nil
+}
+
+func (r *driveFileRepository) ListSystemFiles(fileType, untilID, sinceID string, limit int) ([]*model.DriveFile, error) {
+	q := r.db.Model(&model.DriveFile{}).Where(`"userId" IS NULL`)
+	if fileType != "" {
+		// MIME prefix match: ListForAdmin と semantics 統一 (e.g. "image/" で
+		// image/* を全部拾う)。
 		q = q.Where(`"type" LIKE ?`, fileType+"%")
 	}
 	if untilID != "" {

--- a/internal/repository/drive_file_test.go
+++ b/internal/repository/drive_file_test.go
@@ -253,8 +253,9 @@ func TestDriveFileRepository_ListSystemFiles(t *testing.T) {
 	_, err = repo.ListSystemFiles("", "", "", 1000)
 	require.NoError(t, err)
 
-	// pagination: untilId と sinceId で範囲指定
-	rows, err = repo.ListSystemFiles("", sysZip.ID, "", 10) // sysZip より前 (= ID < sysZip)
+	// pagination untilId: id < untilId (exclusive boundary)。sysZip より前
+	// なら sysImg が出て sysZip は出ない。
+	rows, err = repo.ListSystemFiles("", sysZip.ID, "", 10)
 	require.NoError(t, err)
 	gotIDs := make(map[string]bool, len(rows))
 	for _, r := range rows {
@@ -262,6 +263,18 @@ func TestDriveFileRepository_ListSystemFiles(t *testing.T) {
 	}
 	assert.True(t, gotIDs[sysImg.ID], "sysImg has smaller ID, should be included")
 	assert.False(t, gotIDs[sysZip.ID], "sysZip is the cutoff and should be excluded")
+
+	// pagination sinceId: id > sinceId (exclusive boundary)。sysImg より後
+	// なら sysZip が出て sysImg は出ない。境界の semantics と sort 方向が
+	// untilId 経路と対称であることを保証する。
+	rows, err = repo.ListSystemFiles("", "", sysImg.ID, 10)
+	require.NoError(t, err)
+	gotIDs = make(map[string]bool, len(rows))
+	for _, r := range rows {
+		gotIDs[r.ID] = true
+	}
+	assert.True(t, gotIDs[sysZip.ID], "sysZip has larger ID, should be included")
+	assert.False(t, gotIDs[sysImg.ID], "sysImg is the cutoff and should be excluded")
 }
 
 func TestDriveFileRepository_DeleteOrphansAndRemoteCache(t *testing.T) {

--- a/internal/repository/drive_file_test.go
+++ b/internal/repository/drive_file_test.go
@@ -199,6 +199,71 @@ func TestDriveFileRepository_ListForAdmin(t *testing.T) {
 	require.NoError(t, err)
 }
 
+func TestDriveFileRepository_ListSystemFiles(t *testing.T) {
+	// #686: UserID IS NULL の system file (custom emoji copy / import zip 経路で
+	// 蓄積される) を一覧する経路。type prefix と pagination が効くこと、
+	// user 所有 / remote 所有のファイルが混ざらないことを保証する。
+	repo := NewDriveFileRepository(testDB)
+	user := insertTestUser(t, "u_sys_lst", "syslst")
+	defer cleanupUser(t, user.ID)
+
+	// system file 2 件 (image/png + application/zip)、user 所有 1 件、remote 所有 1 件
+	sysImg := newTestDriveFile("sys_img1", user.ID, "md5sysimg", nil)
+	sysImg.UserID = nil
+	sysImg.Type = "image/png"
+	sysZip := newTestDriveFile("sys_zip1", user.ID, "md5syszip", nil)
+	sysZip.UserID = nil
+	sysZip.Type = "application/zip"
+	userFile := newTestDriveFile("u_sys_uf", user.ID, "md5user", nil)
+	userFile.Type = "image/png"
+	remoteHost := "remote.example"
+	remoteFile := newTestDriveFile("u_sys_rf", user.ID, "md5remote", nil)
+	remoteFile.UserHost = &remoteHost
+	remoteFile.Type = "image/png"
+	require.NoError(t, repo.Create(sysImg))
+	require.NoError(t, repo.Create(sysZip))
+	require.NoError(t, repo.Create(userFile))
+	require.NoError(t, repo.Create(remoteFile))
+	defer cleanupDriveFile(t, sysImg.ID)
+	defer cleanupDriveFile(t, sysZip.ID)
+	defer cleanupDriveFile(t, userFile.ID)
+	defer cleanupDriveFile(t, remoteFile.ID)
+
+	// type 無指定: system file 2 件のみ
+	rows, err := repo.ListSystemFiles("", "", "", 10)
+	require.NoError(t, err)
+	ids := make(map[string]bool, len(rows))
+	for _, r := range rows {
+		ids[r.ID] = true
+	}
+	assert.True(t, ids[sysImg.ID])
+	assert.True(t, ids[sysZip.ID])
+	assert.False(t, ids[userFile.ID], "user-owned file must not appear")
+	assert.False(t, ids[remoteFile.ID], "remote-owned file must not appear")
+
+	// type=image/ で絞り込み: image/png のみ
+	rows, err = repo.ListSystemFiles("image/", "", "", 10)
+	require.NoError(t, err)
+	require.Len(t, rows, 1)
+	assert.Equal(t, sysImg.ID, rows[0].ID)
+
+	// limit 範囲外 (0 / 過大) でも error にならず default / clamp が効く
+	_, err = repo.ListSystemFiles("", "", "", 0)
+	require.NoError(t, err)
+	_, err = repo.ListSystemFiles("", "", "", 1000)
+	require.NoError(t, err)
+
+	// pagination: untilId と sinceId で範囲指定
+	rows, err = repo.ListSystemFiles("", sysZip.ID, "", 10) // sysZip より前 (= ID < sysZip)
+	require.NoError(t, err)
+	gotIDs := make(map[string]bool, len(rows))
+	for _, r := range rows {
+		gotIDs[r.ID] = true
+	}
+	assert.True(t, gotIDs[sysImg.ID], "sysImg has smaller ID, should be included")
+	assert.False(t, gotIDs[sysZip.ID], "sysZip is the cutoff and should be excluded")
+}
+
 func TestDriveFileRepository_DeleteOrphansAndRemoteCache(t *testing.T) {
 	repo := NewDriveFileRepository(testDB)
 	user := insertTestUser(t, "u_del_src", "dels")

--- a/internal/testutil/mock_drive.go
+++ b/internal/testutil/mock_drive.go
@@ -356,6 +356,40 @@ func (m *MockDriveFileRepository) ListForAdmin(userID, origin, host, fileType, u
 	return rows[:limit], nil
 }
 
+func (m *MockDriveFileRepository) ListSystemFiles(fileType, untilID, sinceID string, limit int) ([]*model.DriveFile, error) {
+	rows := make([]*model.DriveFile, 0, len(m.Files))
+	for _, f := range m.Files {
+		if f.UserID != nil {
+			continue
+		}
+		if fileType != "" && !strings.HasPrefix(f.Type, fileType) {
+			continue
+		}
+		if untilID != "" && f.ID >= untilID {
+			continue
+		}
+		if sinceID != "" && f.ID <= sinceID {
+			continue
+		}
+		rows = append(rows, f)
+	}
+	// id DESC
+	for i := 0; i < len(rows); i++ {
+		for j := i + 1; j < len(rows); j++ {
+			if rows[i].ID < rows[j].ID {
+				rows[i], rows[j] = rows[j], rows[i]
+			}
+		}
+	}
+	if limit <= 0 {
+		limit = 30
+	}
+	if limit > len(rows) {
+		limit = len(rows)
+	}
+	return rows[:limit], nil
+}
+
 func (m *MockDriveFileRepository) DeleteOrphans() (int64, error) {
 	n := int64(0)
 	for id, f := range m.Files {


### PR DESCRIPTION
## Summary

#670 で custom emoji の copy / import zip 経路は system 所有 (`UserID IS NULL`) の drive file に保存するようになったが、admin drive UI 側に `UserID IS NULL` を一覧する経路が無く、emoji 画像が増えてきたときに operator が個別ファイルを可視化できないのが運用上の盲点になっていた。

`/api/admin/drive/files` の `userId` パラメータに特殊値 `@system` を許容して、system file 専用の listing を返す経路を追加する (issue 案 A: 既存 endpoint 拡張)。

## 主な変更点

- **`internal/repository/drive_file.go`**: `ListSystemFiles(fileType, untilID, sinceID, limit) ([]*model.DriveFile, error)` を新設。`UserID IS NULL` で絞り込み、MIME prefix filter と ID 範囲 pagination を `ListForAdmin` と統一した semantics で提供。
- **`internal/api/admin/drive.go`**:
  - `SystemUserIDToken = "@system"` 定数を公開。`@` 接頭辞は aidx ID (英数字のみ) と衝突しないので user ID として誤解釈される心配なし。
  - `DriveFiles` ハンドラで `req.UserID == "@system"` を検出して `ListSystemFiles` に dispatch。`origin` / `host` filter は system file (ユーザー紐付け無し) には意味を持たないので無視。
- **mock 追加**: `internal/testutil/mock_drive.go` の `MockDriveFileRepository` と `internal/core/transfer/drive_reader_test.go` の `fakeDriveFileRepo` に `ListSystemFiles` 実装を追加して interface を満たす。

## Frontend 互換

mk-go は backend project なので third_party/misskey の frontend には触らない。Misskey TS 側で system file タブを追加するかは別議論。`@system` token は backend で API として用意するだけ。

## テスト

- `internal/api/admin/drive_emoji_test.go`:
  - `TestDriveFiles_FiltersBySystemToken`: `@system` 指定で system file のみ返り、user/remote 所有が混ざらない
  - `TestDriveFiles_SystemTokenWithTypeFilter`: `@system` と type=image/ の併用
- `internal/repository/drive_file_test.go`:
  - `TestDriveFileRepository_ListSystemFiles`: 実 PostgreSQL で UserID IS NULL 抽出、type prefix filter、pagination (untilId)、limit clamp を検証

```
make fmt && make lint && go test ./...
```

CI 全 shard pass 想定。

## Scope 外で気付いた点

実装中に気付いたが、`/api/admin/drive/cleanup` が呼ぶ `DeleteOrphans` は `userId IS NULL` を無条件に削除するため、#670 後は **system emoji 画像が cleanup で消える** リスクがある。`#686` の scope は visibility 経路の追加なので別 issue として follow-up する予定。

## Closes

Closes #686

🤖 Generated with [Claude Code](https://claude.com/claude-code)