### PR TITLE
Fix #688: 残 1 件の zero-UUID (NO_SUCH_DRAFT) を upstream UUID に置換

### DIFF
--- a/internal/api/apierr/errors.go
+++ b/internal/api/apierr/errors.go
@@ -79,6 +79,12 @@ const (
 	// UUIDNoSecurityKey は upstream `i/2fa/password-less` の `noKey` UUID。
 	// upstream typo (`9a8g`) を保持する理由は UUIDNoSuchKey と同じ。
 	UUIDNoSecurityKey = "f9c54d7f-d4c2-4d3c-9a8g-a70daac86512"
+
+	// UUIDNoSuchNoteDraft は upstream `notes/drafts/{update,delete}` 共通の
+	// `noSuchNoteDraft` UUID (third_party/misskey/.../notes/drafts/update.ts)。
+	// code は upstream に合わせて `NO_SUCH_NOTE_DRAFT` を使う (#688 / #673
+	// Phase B)。
+	UUIDNoSuchNoteDraft = "49cd6b9d-848e-41ee-b0b9-adaca711a6b1"
 )
 
 // InvalidParam returns a 400 INVALID_PARAM error response. The optional
@@ -134,6 +140,13 @@ func NoSuchNote() map[string]any {
 // NoSuchUser returns a 404 NO_SUCH_USER error response.
 func NoSuchUser() map[string]any {
 	return Error("NO_SUCH_USER", "No such user.", UUIDNoSuchUser)
+}
+
+// NoSuchNoteDraft returns a 404 NO_SUCH_NOTE_DRAFT error response (#688 /
+// #673 Phase B). upstream `notes/drafts/{update,delete}` と code / id /
+// message を完全一致させる。
+func NoSuchNoteDraft() map[string]any {
+	return Error("NO_SUCH_NOTE_DRAFT", "No such note draft.", UUIDNoSuchNoteDraft)
 }
 
 // AccessDenied returns a 403 ACCESS_DENIED error response.

--- a/internal/api/apierr/errors_test.go
+++ b/internal/api/apierr/errors_test.go
@@ -43,6 +43,16 @@ func TestNoSuchUser(t *testing.T) {
 	assert.Equal(t, UUIDNoSuchUser, errObj["id"])
 }
 
+func TestNoSuchNoteDraft(t *testing.T) {
+	// #688: upstream notes/drafts/{update,delete} 互換。code / id / message
+	// が完全一致することを保証する (frontend i18n lookup の安定性のため)。
+	result := NoSuchNoteDraft()
+	errObj := result["error"].(map[string]any)
+	assert.Equal(t, "NO_SUCH_NOTE_DRAFT", errObj["code"])
+	assert.Equal(t, UUIDNoSuchNoteDraft, errObj["id"])
+	assert.Equal(t, "No such note draft.", errObj["message"])
+}
+
 func TestAccessDenied(t *testing.T) {
 	result := AccessDenied()
 	errObj := result["error"].(map[string]any)

--- a/internal/api/apierr/zero_uuid_lint_test.go
+++ b/internal/api/apierr/zero_uuid_lint_test.go
@@ -10,16 +10,14 @@ import (
 )
 
 // TestZeroUUIDLint walks internal/api/ and fails if any non-test source
-// file still contains the zero-UUID placeholder string. Phase A of #673
-// established that all generic codes (INVALID_PARAM / INTERNAL_ERROR /
-// NOT_FOUND) flow through apierr helpers with stable UUIDs; this lint
-// keeps regressions from sneaking back in.
+// file still contains the zero-UUID placeholder string. Phase A (#673) で
+// 汎用 code (INVALID_PARAM / INTERNAL_ERROR / NOT_FOUND) を helper 経由化
+// し、Phase B (#688) で endpoint 固有の zero-UUID もすべて upstream UUID に
+// 置き換えた。本 lint は placeholder 再導入の regression を CI で塞ぐ。
 //
-// Endpoint-specific codes still pending #673 Phase B (NO_SUCH_DRAFT) are
-// listed in pendingZeroUUIDOccurrences below as exceptions that this test
-// tolerates until each gets its proper upstream UUID. **DO NOT add new
-// entries** — instead pick the right Misskey TS UUID and use the apierr
-// helper.
+// **DO NOT add entries to pendingExceptions** — 新しい endpoint 固有 code
+// が必要なら apierr helper を新設 (例: NoSuchNoteDraft) して upstream Misskey
+// TS の UUID を採用すること。
 func TestZeroUUIDLint(t *testing.T) {
 	const placeholder = "00000000-0000-0000-0000-000000000000"
 
@@ -29,9 +27,10 @@ func TestZeroUUIDLint(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	pendingExceptions := map[string]int{
-		"api/notes/handler_drafts.go": 1, // NO_SUCH_DRAFT
-	}
+	// Phase B 完了後は空。zero-UUID が無いことを保証する pure regression
+	// guard として機能する。万が一新規導入が必要になったら、ここを増やす
+	// のではなく helper / UUID を新設する。
+	pendingExceptions := map[string]int{}
 
 	violations := map[string]int{}
 	err = filepath.Walk(root, func(path string, info os.FileInfo, err error) error {

--- a/internal/api/notes/handler_drafts.go
+++ b/internal/api/notes/handler_drafts.go
@@ -117,10 +117,15 @@ func (h *Handler) DraftsDelete(c echo.Context) error {
 	// `NO_SUCH_NOTE_DRAFT` を返す。silent 204 だと frontend が削除確認 UI
 	// で「該当 draft が無い」フィードバックを出せないので、本家挙動に合わせて
 	// 404 を返すよう修正 (#688 review follow-up)。
-	if _, err := h.draftRepo.FindByIDAndUser(req.DraftID, user.ID); err != nil {
+	// Delete は RowsAffected を返すので、Find → Delete の 2 query 化を避け
+	// つつ TOCTOU race も発生しない (DB 1 文で atomic に「あれば削除」)。
+	rowsAffected, err := h.draftRepo.Delete(req.DraftID, user.ID)
+	if err != nil {
+		return c.JSON(http.StatusInternalServerError, apierr.InternalError())
+	}
+	if rowsAffected == 0 {
 		return c.JSON(http.StatusNotFound, apierr.NoSuchNoteDraft())
 	}
-	_ = h.draftRepo.Delete(req.DraftID, user.ID)
 	return c.NoContent(http.StatusNoContent)
 }
 

--- a/internal/api/notes/handler_drafts.go
+++ b/internal/api/notes/handler_drafts.go
@@ -83,7 +83,7 @@ func (h *Handler) DraftsUpdate(c echo.Context) error {
 	}
 	draft, err := h.draftRepo.FindByIDAndUser(req.DraftID, user.ID)
 	if err != nil {
-		return c.JSON(http.StatusNotFound, apierr.Error("NO_SUCH_DRAFT", "No such draft.", "00000000-0000-0000-0000-000000000000"))
+		return c.JSON(http.StatusNotFound, apierr.NoSuchNoteDraft())
 	}
 	if req.Text != nil {
 		draft.Text = req.Text

--- a/internal/api/notes/handler_drafts.go
+++ b/internal/api/notes/handler_drafts.go
@@ -46,7 +46,7 @@ func (h *Handler) DraftsCreate(c echo.Context) error {
 		FileIDs    []string `json:"fileIds"`
 	}
 	if err := c.Bind(&req); err != nil {
-		return c.JSON(http.StatusBadRequest, apierr.Error("INVALID_PARAM", "Invalid parameters.", "3d81ceae-475f-4600-b2a8-2bc116157532"))
+		return c.JSON(http.StatusBadRequest, apierr.InvalidParam("Invalid parameters."))
 	}
 	if req.Visibility == "" {
 		req.Visibility = "public"
@@ -60,7 +60,7 @@ func (h *Handler) DraftsCreate(c echo.Context) error {
 		FileIDs:    req.FileIDs,
 	}
 	if err := h.draftRepo.Create(draft); err != nil {
-		return c.JSON(http.StatusInternalServerError, apierr.Error("INTERNAL_ERROR", "Internal error.", "5d37dbcb-891e-41ca-a3d6-e690c97775ac"))
+		return c.JSON(http.StatusInternalServerError, apierr.InternalError())
 	}
 	return c.JSON(http.StatusOK, packDraft(draft, h.idGen))
 }
@@ -79,7 +79,7 @@ func (h *Handler) DraftsUpdate(c echo.Context) error {
 		FileIDs    []string `json:"fileIds"`
 	}
 	if err := c.Bind(&req); err != nil || req.DraftID == "" {
-		return c.JSON(http.StatusBadRequest, apierr.Error("INVALID_PARAM", "draftId is required.", "3d81ceae-475f-4600-b2a8-2bc116157532"))
+		return c.JSON(http.StatusBadRequest, apierr.InvalidParam("draftId is required."))
 	}
 	draft, err := h.draftRepo.FindByIDAndUser(req.DraftID, user.ID)
 	if err != nil {
@@ -111,7 +111,14 @@ func (h *Handler) DraftsDelete(c echo.Context) error {
 		DraftID string `json:"draftId"`
 	}
 	if err := c.Bind(&req); err != nil || req.DraftID == "" {
-		return c.JSON(http.StatusBadRequest, apierr.Error("INVALID_PARAM", "draftId is required.", "3d81ceae-475f-4600-b2a8-2bc116157532"))
+		return c.JSON(http.StatusBadRequest, apierr.InvalidParam("draftId is required."))
+	}
+	// upstream notes/drafts/delete.ts は存在チェックして無ければ
+	// `NO_SUCH_NOTE_DRAFT` を返す。silent 204 だと frontend が削除確認 UI
+	// で「該当 draft が無い」フィードバックを出せないので、本家挙動に合わせて
+	// 404 を返すよう修正 (#688 review follow-up)。
+	if _, err := h.draftRepo.FindByIDAndUser(req.DraftID, user.ID); err != nil {
+		return c.JSON(http.StatusNotFound, apierr.NoSuchNoteDraft())
 	}
 	_ = h.draftRepo.Delete(req.DraftID, user.ID)
 	return c.NoContent(http.StatusNoContent)

--- a/internal/api/notes/handler_drafts_test.go
+++ b/internal/api/notes/handler_drafts_test.go
@@ -206,6 +206,21 @@ func TestDraftsDelete_InvalidParam(t *testing.T) {
 	assert.Equal(t, http.StatusBadRequest, rec.Code)
 }
 
+func TestDraftsDelete_NotFound(t *testing.T) {
+	// #688 review follow-up: 存在しない draftId で削除しても upstream
+	// notes/drafts/delete.ts と同じく `NO_SUCH_NOTE_DRAFT` を返す。silent
+	// 204 だと frontend が「該当 draft が無い」を観測できないので 404 が
+	// 期待挙動。
+	h, _ := newDraftHandlerWithRepo()
+	rec := postDraft(h.DraftsDelete, `{"draftId":"ghost"}`, &model.User{ID: "u1"})
+	assert.Equal(t, http.StatusNotFound, rec.Code)
+	var resp map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+	errObj := resp["error"].(map[string]any)
+	assert.Equal(t, "NO_SUCH_NOTE_DRAFT", errObj["code"])
+	assert.Equal(t, apierr.UUIDNoSuchNoteDraft, errObj["id"])
+}
+
 // --- DraftsCount ---
 
 func TestDraftsCount_NilRepo(t *testing.T) {

--- a/internal/api/notes/handler_drafts_test.go
+++ b/internal/api/notes/handler_drafts_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	"github.com/labstack/echo/v4"
+	"github.com/shiroha-a/mk/internal/api/apierr"
 	"github.com/shiroha-a/mk/internal/misc/id"
 	"github.com/shiroha-a/mk/internal/model"
 	"github.com/shiroha-a/mk/internal/server/middleware"
@@ -165,9 +166,16 @@ func TestDraftsUpdate_Success(t *testing.T) {
 }
 
 func TestDraftsUpdate_NotFound(t *testing.T) {
+	// #688: 存在しない draftId 指定時に upstream notes/drafts/update 互換の
+	// NO_SUCH_NOTE_DRAFT (UUID 49cd6b9d-...) を返すこと。
 	h, _ := newDraftHandlerWithRepo()
 	rec := postDraft(h.DraftsUpdate, `{"draftId":"ghost"}`, &model.User{ID: "u1"})
 	assert.Equal(t, http.StatusNotFound, rec.Code)
+	var resp map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+	errObj := resp["error"].(map[string]any)
+	assert.Equal(t, "NO_SUCH_NOTE_DRAFT", errObj["code"])
+	assert.Equal(t, apierr.UUIDNoSuchNoteDraft, errObj["id"])
 }
 
 func TestDraftsUpdate_InvalidParam(t *testing.T) {

--- a/internal/api/notes/handler_drafts_test.go
+++ b/internal/api/notes/handler_drafts_test.go
@@ -73,9 +73,12 @@ func (m *mockDraftRepo) Update(d *model.NoteDraft) error {
 	m.drafts[d.ID] = d
 	return nil
 }
-func (m *mockDraftRepo) Delete(id, _ string) error {
+func (m *mockDraftRepo) Delete(id, _ string) (int64, error) {
+	if _, ok := m.drafts[id]; !ok {
+		return 0, nil
+	}
 	delete(m.drafts, id)
-	return nil
+	return 1, nil
 }
 func (m *mockDraftRepo) CountByUser(userID string) (int64, error) {
 	var count int64

--- a/internal/repository/note_draft.go
+++ b/internal/repository/note_draft.go
@@ -11,7 +11,10 @@ type NoteDraftRepository interface {
 	FindByIDAndUser(id, userID string) (*model.NoteDraft, error)
 	ListByUser(userID string, limit int) ([]*model.NoteDraft, error)
 	Update(draft *model.NoteDraft) error
-	Delete(id, userID string) error
+	// Delete returns the number of rows affected so callers can detect
+	// "no such draft" without a separate FindByIDAndUser pre-check (single
+	// SQL round-trip + no TOCTOU race)。0 = 該当 draft なし、1 = 削除成功。
+	Delete(id, userID string) (int64, error)
 	CountByUser(userID string) (int64, error)
 }
 
@@ -51,8 +54,9 @@ func (r *noteDraftRepository) Update(draft *model.NoteDraft) error {
 	return r.db.Save(draft).Error
 }
 
-func (r *noteDraftRepository) Delete(id, userID string) error {
-	return r.db.Where(`"id" = ? AND "userId" = ?`, id, userID).Delete(&model.NoteDraft{}).Error
+func (r *noteDraftRepository) Delete(id, userID string) (int64, error) {
+	tx := r.db.Where(`"id" = ? AND "userId" = ?`, id, userID).Delete(&model.NoteDraft{})
+	return tx.RowsAffected, tx.Error
 }
 
 func (r *noteDraftRepository) CountByUser(userID string) (int64, error) {

--- a/internal/repository/note_draft_test.go
+++ b/internal/repository/note_draft_test.go
@@ -56,8 +56,10 @@ func TestNoteDraftRepository_Full(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, int64(1), count)
 
-	// Delete
-	require.NoError(t, repo.Delete("draft_1", user.ID))
+	// Delete: 該当行が存在するので RowsAffected = 1
+	rows, err := repo.Delete("draft_1", user.ID)
+	require.NoError(t, err)
+	assert.Equal(t, int64(1), rows)
 	_, err = repo.FindByIDAndUser("draft_1", user.ID)
 	assert.Error(t, err)
 
@@ -65,4 +67,10 @@ func TestNoteDraftRepository_Full(t *testing.T) {
 	count, err = repo.CountByUser(user.ID)
 	require.NoError(t, err)
 	assert.Equal(t, int64(0), count)
+
+	// Delete on already-removed draft: 0 rows affected, no error。
+	// handler 側の "no such draft" 判定はこの 0 を見て 404 を返す。
+	rows, err = repo.Delete("draft_1", user.ID)
+	require.NoError(t, err)
+	assert.Equal(t, int64(0), rows)
 }


### PR DESCRIPTION
## Summary

#673 Phase B (#688) で endpoint 固有 zero-UUID として残っていた **notes/drafts/update** の `NO_SUCH_DRAFT` を upstream Misskey TS の UUID に揃える。

issue 本文では 6 件残っていたが、5 件 (`i/handler_2fa.go` の `INVALID_TOKEN` / `REGISTRATION_FAILED` / `NO_SUCH_KEY` / `NO_SECURITY_KEYS`) は既に別 PR (#702 / #704 等) で処理済みで、残るは 1 件 (notes drafts) のみだった。

## 主な変更点

### `internal/api/apierr/errors.go`

- `UUIDNoSuchNoteDraft = "49cd6b9d-848e-41ee-b0b9-adaca711a6b1"` 定数を追加 (upstream `notes/drafts/{update,delete}` 共通の `noSuchNoteDraft` UUID)。
- `NoSuchNoteDraft()` helper を追加 (code: `NO_SUCH_NOTE_DRAFT`, message: `No such note draft.`)。

### `internal/api/notes/handler_drafts.go`

- `apierr.Error("NO_SUCH_DRAFT", "No such draft.", "00000000-...")` → `apierr.NoSuchNoteDraft()`。
- code 名も upstream 互換に変更: `NO_SUCH_DRAFT` → `NO_SUCH_NOTE_DRAFT`、message: `No such draft.` → `No such note draft.`

### `internal/api/apierr/zero_uuid_lint_test.go`

- `pendingExceptions` map を **空** に。Phase B 完了後は zero-UUID placeholder の再導入を CI で reject する pure regression guard として機能する。
- 文書コメントを更新して、新しい endpoint 固有 code が必要な場合は helper 新設の方針を明示。

### テスト

- `internal/api/apierr/errors_test.go`: `TestNoSuchNoteDraft` (helper の code/id/message が完全一致)
- `internal/api/notes/handler_drafts_test.go`: 既存の `TestDraftsUpdate_NotFound` を強化し code/id 一致を assert。

## UUIDNotFound divergence 確認 (issue 完了条件)

upstream `third_party/misskey/.../error.ts` を確認した結果、汎用 `NOT_FOUND` の定義は今も無く `INTERNAL_ERROR` のみが default 定義されている。`UUIDNotFound` (mk-go 固有 `8e6f5b1d-...`) の divergence 状態は **維持** で問題なし。将来 upstream 大型 sync 時にも改めて確認する。

## Closes

Closes #688

🤖 Generated with [Claude Code](https://claude.com/claude-code)