### PR TITLE
Fix #722: DeleteOrphans が emoji 参照の system 所有 drive_file を巻き込まない

### DIFF
--- a/internal/api/admin/drive_emoji_test.go
+++ b/internal/api/admin/drive_emoji_test.go
@@ -188,6 +188,26 @@ func TestDriveCleanup_InvokesDeleteOrphans(t *testing.T) {
 	assert.Contains(t, repo.Files, "kept", "user-owned file should be kept")
 }
 
+// TestDriveCleanup_PreservesEmojiReferencedSystemFiles は #722 の handler 層
+// regression guard。emoji が参照する system 所有 drive_file は cleanup で
+// 巻き込まれないこと (= mock の EmojiReferencedURLs が ON だと該当 URL の
+// file は保持される) を assert する。SQL 層の guard は repository test で
+// 別途検証 (TestDriveFileRepository_DeleteOrphans_PreservesEmojiReferenced)。
+func TestDriveCleanup_PreservesEmojiReferencedSystemFiles(t *testing.T) {
+	h, _, _, _ := newTestHandler(t)
+	repo := testutil.NewMockDriveFileRepository()
+	emojiRefURL := "http://test/system_emoji.png"
+	require.NoError(t, repo.Create(&model.DriveFile{ID: "pure_orph", UserID: nil, URL: "http://test/pure.bin"}))
+	require.NoError(t, repo.Create(&model.DriveFile{ID: "emoji_sys", UserID: nil, URL: emojiRefURL}))
+	repo.EmojiReferencedURLs = map[string]bool{emojiRefURL: true}
+	h.SetDriveFileRepo(repo)
+
+	rec := doPost(h.DriveCleanup, `{}`, adminUser)
+	assert.Equal(t, http.StatusNoContent, rec.Code)
+	assert.NotContains(t, repo.Files, "pure_orph", "pure orphan should be deleted")
+	assert.Contains(t, repo.Files, "emoji_sys", "emoji-referenced system file must be preserved")
+}
+
 func TestDriveCleanRemoteFiles_InvokesDeleteRemoteCache(t *testing.T) {
 	h, _, _, _ := newTestHandler(t)
 	repo := testutil.NewMockDriveFileRepository()

--- a/internal/api/admin/emoji.go
+++ b/internal/api/admin/emoji.go
@@ -90,6 +90,12 @@ func (h *Handler) EmojiCopy(c echo.Context) error {
 				"srcId", src.ID, "url", src.OriginalURL, "err", err)
 			return c.JSON(http.StatusInternalServerError, apierr.Error("INTERNAL_ERROR", "Failed to fetch emoji image.", "0a4e0b9e-2d7c-4d6f-8f6b-1f9c2e9b4d83"))
 		}
+		// 不変条件 (#722): emoji.originalUrl は必ず drive_file.url と一致
+		// させる。`DriveFileRepository.DeleteOrphans` の cleanup guard が
+		// `NOT EXISTS (emoji.originalUrl = drive_file.url ...)` で system 所有
+		// emoji 画像を保護しているので、ここで df.URL 以外を入れると guard を
+		// すり抜けて cleanup で消える。webpublic 系列を直接 originalUrl に
+		// セットする変更を入れる際は cleanup 側も同時更新すること。
 		copied.OriginalURL = df.URL
 		if df.WebpublicURL != nil && *df.WebpublicURL != "" {
 			copied.PublicURL = *df.WebpublicURL

--- a/internal/core/emojiimport/service.go
+++ b/internal/core/emojiimport/service.go
@@ -252,6 +252,11 @@ func (i *Importer) replaceEmoji(record metaRecord, body []byte) error {
 
 	now := i.now()
 	aliases := pq.StringArray(append([]string(nil), record.Emoji.Aliases...))
+	// 不変条件 (#722): emoji.originalUrl は drive_file.url と一致させる。
+	// `DriveFileRepository.DeleteOrphans` の cleanup guard は
+	// `NOT EXISTS (emoji.originalUrl = drive_file.url ...)` で system 所有
+	// emoji 画像を保護しているので、別 URL (webpublic 等) を originalUrl に
+	// 入れると cleanup で消える。
 	emoji := &model.Emoji{
 		ID:          i.deps.IDGen.Generate(now),
 		UpdatedAt:   &now,

--- a/internal/repository/drive_file.go
+++ b/internal/repository/drive_file.go
@@ -270,8 +270,23 @@ func (r *driveFileRepository) ListSystemFiles(fileType, untilID, sinceID string,
 	return rows, nil
 }
 
+// DeleteOrphans removes drive_file rows whose userId is NULL **and** are not
+// referenced by any custom emoji. Pure orphan files (例: 取り込み中断で残った
+// 中間 zip) は削除対象だが、#670 で導入された system 所有 emoji 画像 file
+// (emoji.originalUrl = drive_file.url で結ばれている) は cleanup で巻き込ま
+// れないように除外する (#722)。
+//
+// upstream Misskey TS の cleanup は単純に userId NULL を全消ししており、
+// 同様に emoji 画像も巻き込む構造的バグを内包しているが、mk-go では本
+// guard で local emoji asset を保護する。
 func (r *driveFileRepository) DeleteOrphans() (int64, error) {
-	tx := r.db.Where(`"userId" IS NULL`).Delete(&model.DriveFile{})
+	tx := r.db.Where(
+		`"userId" IS NULL AND NOT EXISTS (
+			SELECT 1 FROM "emoji" e
+			WHERE e."originalUrl" = "drive_file"."url"
+			   OR e."publicUrl"   = "drive_file"."url"
+		)`,
+	).Delete(&model.DriveFile{})
 	return tx.RowsAffected, tx.Error
 }
 

--- a/internal/repository/drive_file_test.go
+++ b/internal/repository/drive_file_test.go
@@ -315,6 +315,71 @@ func TestDriveFileRepository_DeleteOrphansAndRemoteCache(t *testing.T) {
 	assert.Error(t, err)
 }
 
+// TestDriveFileRepository_DeleteOrphans_PreservesEmojiReferenced は #722
+// regression guard: emoji.originalUrl / publicUrl が参照している system 所有
+// drive_file は cleanup で巻き込まれずに保持されること。#670 で導入された
+// emoji copy / import zip の保管先が cleanup 実行で吹き飛ぶ即死バグの再発
+// 防止。
+func TestDriveFileRepository_DeleteOrphans_PreservesEmojiReferenced(t *testing.T) {
+	repo := NewDriveFileRepository(testDB)
+	emojiRepo := NewEmojiRepository(testDB)
+	user := insertTestUser(t, "u_orph_emoji", "orphemo")
+	defer cleanupUser(t, user.ID)
+
+	// orphan true (emoji 参照無し): 削除されるべき
+	pureOrphan := newTestDriveFile("orph_pure_722", user.ID, "md5o", nil)
+	pureOrphan.UserID = nil
+	pureOrphan.URL = "http://test/orph_pure_722.bin"
+
+	// emoji.originalUrl 参照あり (system file): 削除してはいけない
+	emojiOriginalRef := newTestDriveFile("emoji_orig_722", user.ID, "md5eo", nil)
+	emojiOriginalRef.UserID = nil
+	emojiOriginalRef.URL = "http://test/emoji_orig_722.png"
+
+	// emoji.publicUrl 参照あり (webpublic 経由系): 削除してはいけない
+	emojiPublicRef := newTestDriveFile("emoji_pub_722", user.ID, "md5ep", nil)
+	emojiPublicRef.UserID = nil
+	emojiPublicRef.URL = "http://test/emoji_pub_722.png"
+
+	require.NoError(t, repo.Create(pureOrphan))
+	require.NoError(t, repo.Create(emojiOriginalRef))
+	require.NoError(t, repo.Create(emojiPublicRef))
+	defer cleanupDriveFile(t, pureOrphan.ID)
+	defer cleanupDriveFile(t, emojiOriginalRef.ID)
+	defer cleanupDriveFile(t, emojiPublicRef.ID)
+
+	// 2 件 emoji 行を seed (1 件は originalUrl で参照、もう 1 件は publicUrl で参照)
+	emoOrig := &model.Emoji{
+		ID:          "e_orig_722",
+		Name:        "guard_emoji_orig_722",
+		OriginalURL: emojiOriginalRef.URL,
+		PublicURL:   emojiOriginalRef.URL,
+	}
+	emoPub := &model.Emoji{
+		ID:          "e_pub_722",
+		Name:        "guard_emoji_pub_722",
+		OriginalURL: "http://test/some_other_url.png", // originalUrl は別
+		PublicURL:   emojiPublicRef.URL,               // publicUrl で参照
+	}
+	require.NoError(t, emojiRepo.Create(emoOrig))
+	require.NoError(t, emojiRepo.Create(emoPub))
+	defer testDB.Exec(`DELETE FROM "emoji" WHERE id IN (?, ?)`, emoOrig.ID, emoPub.ID)
+
+	n, err := repo.DeleteOrphans()
+	require.NoError(t, err)
+	assert.GreaterOrEqual(t, n, int64(1), "pureOrphan should be counted in deleted rows")
+
+	// pureOrphan は消えている
+	_, err = repo.FindByID(pureOrphan.ID)
+	assert.Error(t, err, "pure orphan must be deleted")
+
+	// emojiOriginalRef / emojiPublicRef は保持されている
+	_, err = repo.FindByID(emojiOriginalRef.ID)
+	assert.NoError(t, err, "emoji.originalUrl 参照の system file は保持される")
+	_, err = repo.FindByID(emojiPublicRef.ID)
+	assert.NoError(t, err, "emoji.publicUrl 参照の system file は保持される")
+}
+
 // --- 追加テスト (#260 repository coverage) ---
 
 func TestDriveFileRepository_FindByIDs(t *testing.T) {

--- a/internal/testutil/mock_drive.go
+++ b/internal/testutil/mock_drive.go
@@ -9,6 +9,12 @@ import (
 // MockDriveFileRepository is a test double for repository.DriveFileRepository.
 type MockDriveFileRepository struct {
 	Files map[string]*model.DriveFile // keyed by ID
+	// EmojiReferencedURLs は DeleteOrphans の guard を mock するための「emoji
+	// が参照している drive_file.url 集合」。production の SQL では
+	// `NOT EXISTS (SELECT 1 FROM emoji WHERE originalUrl = drive_file.url)`
+	// で判定する経路を test 用に模倣する (#722)。空なら guard 無効 (= 旧来の
+	// userId NULL 全削除) で既存テスト互換。
+	EmojiReferencedURLs map[string]bool
 }
 
 func NewMockDriveFileRepository() *MockDriveFileRepository {
@@ -390,13 +396,21 @@ func (m *MockDriveFileRepository) ListSystemFiles(fileType, untilID, sinceID str
 	return rows[:limit], nil
 }
 
+// DeleteOrphans の mock は production SQL の semantics を model 化する:
+// userId NULL かつ EmojiReferencedURLs に URL が含まれない drive file を
+// 削除する。`EmojiReferencedURLs` を空のままにすると元来の挙動 (userId
+// NULL を全削除) と等価になるので、既存テストは無改修で通る (#722)。
 func (m *MockDriveFileRepository) DeleteOrphans() (int64, error) {
 	n := int64(0)
 	for id, f := range m.Files {
-		if f.UserID == nil {
-			delete(m.Files, id)
-			n++
+		if f.UserID != nil {
+			continue
 		}
+		if m.EmojiReferencedURLs[f.URL] {
+			continue
+		}
+		delete(m.Files, id)
+		n++
 	}
 	return n, nil
 }


### PR DESCRIPTION
## Summary

#670 で導入した「emoji copy / import zip 経路で \`UserID = nil\` の system 所有 drive_file を作る」設計は、\`/api/admin/drive/cleanup\` が内部で呼ぶ \`DeleteOrphans\` (旧: \`WHERE userId IS NULL\` を全削除) と組み合わさると **cleanup 実行で emoji 画像 drive_file ごと巻き込まれて表示が壊れる即死級バグ** になっていた。

issue #722 の案 (A) referenced check を採用して、emoji 行から参照されている drive_file は cleanup 対象から除外する。pure orphan (取り込み中断 zip 等の真の orphan) は引き続き削除対象。

## 主な変更点

### `internal/repository/drive_file.go`

\`DeleteOrphans\` に correlated subquery を追加:

\`\`\`sql
WHERE "userId" IS NULL AND NOT EXISTS (
    SELECT 1 FROM "emoji" e
    WHERE e."originalUrl" = "drive_file"."url"
       OR e."publicUrl"   = "drive_file"."url"
)
\`\`\`

\`emoji.originalUrl\` は \`EmojiCopy\` / \`emojiimport.Run\` で必ず \`drive_file.url\` で初期化されるので、これだけで全 emoji 画像が保護される。\`publicUrl\` は webpublic 経由で \`url\` と異なる場合があるが defensive guard として include。

### `internal/testutil/mock_drive.go`

\`MockDriveFileRepository.EmojiReferencedURLs map[string]bool\` を追加し、\`DeleteOrphans\` の mock も同 semantics を持つように。空のままだと旧来の「userId NULL 全削除」挙動と等価で、**既存テストは無改修で通る**。

### `internal/repository/drive_file_test.go`

\`TestDriveFileRepository_DeleteOrphans_PreservesEmojiReferenced\` を追加。実 PostgreSQL 経由で:
- pure orphan (emoji 参照無し、UserID NULL): 削除される
- emoji.originalUrl 参照あり: 保持される
- emoji.publicUrl 参照あり (originalUrl は別 URL): 保持される
の 3 ケースを seed して挙動を assert。

### `internal/api/admin/drive_emoji_test.go`

handler 層 (\`/api/admin/drive/cleanup\` 経由) でも emoji ref system file が保持されることを mock 経由で検証する \`TestDriveCleanup_PreservesEmojiReferencedSystemFiles\` を追加。

## upstream Misskey TS との関係

upstream の \`cleanup.ts\` も同じく \`userId IS NULL\` を全削除する素朴な実装で、emoji 画像も同様に巻き込む構造を持っている (確認済み)。本 PR は **mk-go 独自の guard** として local emoji asset を保護するもので、upstream に逆移植できる修正でもある (将来 upstream PR を出すかは別議論)。

## テスト

\`\`\`
go test ./internal/api/admin/... ./internal/repository/... -count=1 -timeout 4m
\`\`\`

全 shard pass。

## Closes

Closes #722

🤖 Generated with [Claude Code](https://claude.com/claude-code)