### PR TITLE
Fix #729+#730+#731: 3 件の絵文字バグ統合修正 (UDS で再現確認済み)

### DIFF
--- a/deploy/uds/nginx/mkgo.conf
+++ b/deploy/uds/nginx/mkgo.conf
@@ -26,6 +26,23 @@ http {
         listen [::]:80 default_server;
         server_name _;
 
+        # /files/<accessKey> は mk-go LocalStorage の生バイナリ配信。nginx
+        # proxy buffering の default (8 x 4k or 8k) では大きい animated
+        # WebP / GIF が ~32KB 付近で truncate される事象 (#730) を回避する
+        # ため buffering を off にして mk-go の Stream をそのまま流す。
+        # WebSocket は使わない経路なので Upgrade ヘッダも不要。
+        location /files/ {
+            proxy_pass http://mkgo;
+            proxy_http_version 1.1;
+            proxy_buffering off;
+            proxy_request_buffering off;
+            proxy_set_header Host $host;
+            proxy_set_header X-Real-IP $remote_addr;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header X-Forwarded-Proto http;
+            proxy_redirect off;
+        }
+
         # 静的ファイルも API も全部 mk-go に委譲する。nginx 側でパスを二重管理しない。
         # WebSocket upgrade も同じ location で拾う。
         location / {

--- a/internal/activitypub/renderer.go
+++ b/internal/activitypub/renderer.go
@@ -525,6 +525,12 @@ func (r *Renderer) addEmojiTags(tags *[]any, emojiNames []string, host *string) 
 		if emoji.URI != nil {
 			tag.ID = *emoji.URI
 		}
+		// #731: upstream Misskey TS の renderEmoji と同じく `_misskey_license`
+		// を出力する。受信側 mk-go / Misskey TS は wrapper を見て license を
+		// 取り込む (extractEmojiTags)。emoji.License が nil でも、wrapper を
+		// 出力して FreeText: null を明示することで「license 未設定」を
+		// 連合先に伝える (upstream renderer の挙動と一致)。
+		tag.License = &MisskeyLicense{FreeText: emoji.License}
 		*tags = append(*tags, tag)
 	}
 }

--- a/internal/activitypub/renderer_test.go
+++ b/internal/activitypub/renderer_test.go
@@ -766,8 +766,9 @@ func (s *stubEmojiResolver) FindByNameAndHost(name string, _ *string) (*model.Em
 func TestRenderer_RenderNote_EmojiTag(t *testing.T) {
 	r := newRenderer()
 	emojiURI := "https://example.com/emojis/blobcat"
+	licenseText := "CC0"
 	r.SetEmojiResolver(&stubEmojiResolver{emojis: map[string]*model.Emoji{
-		"blobcat": {Name: "blobcat", PublicURL: "https://example.com/files/blobcat.webp", URI: &emojiURI},
+		"blobcat": {Name: "blobcat", PublicURL: "https://example.com/files/blobcat.webp", URI: &emojiURI, License: &licenseText},
 	}})
 	idGen := newIDGen(t)
 	n := &model.Note{
@@ -785,6 +786,11 @@ func TestRenderer_RenderNote_EmojiTag(t *testing.T) {
 	assert.Equal(t, ":blobcat:", et.Name)
 	assert.Equal(t, "https://example.com/files/blobcat.webp", et.Icon.URL)
 	assert.Equal(t, emojiURI, et.ID)
+	// #731: license は upstream Misskey TS と同じく `_misskey_license` wrapper で
+	// federation 出力する。受信側 instance はこれを拾って emoji.license に取り込む。
+	require.NotNil(t, et.License, "_misskey_license wrapper should be emitted")
+	require.NotNil(t, et.License.FreeText)
+	assert.Equal(t, "CC0", *et.License.FreeText)
 }
 
 func TestRenderer_RenderPerson_EmojiTag(t *testing.T) {

--- a/internal/activitypub/types.go
+++ b/internal/activitypub/types.go
@@ -208,6 +208,19 @@ type EmojiTag struct {
 	Icon    Image  `json:"icon"`
 	ID      string `json:"id,omitempty"`
 	Updated string `json:"updated,omitempty"`
+	// License は upstream Misskey TS の AP renderer (renderEmoji) が
+	// `_misskey_license: { freeText: ... }` 構造で federate する license 情報
+	// (#731)。AP 標準には emoji license 概念が無いので Misskey 拡張として
+	// 送受信する。nil = 受信時 license フィールド無し / 送信時は wrapper を
+	// 出さない、non-nil = wrapper を出力 (FreeText が空でも対称性のため
+	// オブジェクトは出す)。`,omitempty` はポインタ nil でフィールド省略する。
+	License *MisskeyLicense `json:"_misskey_license,omitempty"`
+}
+
+// MisskeyLicense is the upstream `_misskey_license` AP extension wrapper.
+// Misskey TS の renderEmoji 互換 (`{freeText: emoji.license}`)。
+type MisskeyLicense struct {
+	FreeText *string `json:"freeText"`
 }
 
 // Activity is the base type embedded by all activity types.

--- a/internal/api/admin/drive_emoji_test.go
+++ b/internal/api/admin/drive_emoji_test.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	apiadmin "github.com/shiroha-a/mk/internal/api/admin"
+	"github.com/shiroha-a/mk/internal/api/apierr"
 	"github.com/shiroha-a/mk/internal/model"
 	"github.com/shiroha-a/mk/internal/queue"
 	"github.com/shiroha-a/mk/internal/testutil"
@@ -973,6 +974,8 @@ func TestEmojiUpdate_WritesModerationLog_WithExtendedFields(t *testing.T) {
 func TestEmojiUpdate_NoSuchEmojiOnMissingID(t *testing.T) {
 	// #650 問題 2: id が DB に無いケースは NO_SUCH_EMOJI を返す。以前は
 	// UpdateFields が RowsAffected を見ずに常に nil 返却で 204 になっていた。
+	// #729: UUID は upstream `684dec9d-...` (mk-go の旧 typo `684b7e7e-...`
+	// から修正) と完全一致することも assert する。
 	h, _, _, _ := newTestHandler(t)
 	h.SetEmojiRepo(testutil.NewMockEmojiRepository())
 	rec := doPost(h.EmojiUpdate, `{"id":"ghost","name":"x"}`, adminUser)
@@ -982,6 +985,8 @@ func TestEmojiUpdate_NoSuchEmojiOnMissingID(t *testing.T) {
 	errField, ok := body["error"].(map[string]any)
 	require.True(t, ok)
 	assert.Equal(t, "NO_SUCH_EMOJI", errField["code"])
+	assert.Equal(t, apierr.UUIDNoSuchEmoji, errField["id"])
+	assert.Equal(t, "684dec9d-a8c2-4364-9aa8-456c49cb1dc8", errField["id"], "UUID matches upstream noSuchEmoji")
 }
 
 func TestEmojiDelete_WritesModerationLog(t *testing.T) {

--- a/internal/api/admin/handler.go
+++ b/internal/api/admin/handler.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"log/slog"
 	"net/http"
+	"sort"
 	"strings"
 	"time"
 
@@ -1419,7 +1420,12 @@ func (h *Handler) EmojiUpdate(c echo.Context) error {
 	// ErrRecordNotFound に昇格済み (#650 問題 2)).
 	before, err := h.emojiRepo.FindByID(req.ID)
 	if err != nil {
-		return c.JSON(http.StatusNotFound, apierr.Error("NO_SUCH_EMOJI", "No such emoji.", "684b7e7e-7e91-4e4c-a5cc-8050e4b8e0d8"))
+		// #729: 再現報告のため request 側 id と原因 (find vs update path) を
+		// log に残す。frontend 側で stale id を握っているのか、repo 側で
+		// 何か起きているのか切り分けに使う。
+		slog.WarnContext(c.Request().Context(), "EmojiUpdate: NO_SUCH_EMOJI on FindByID",
+			"id", req.ID, "err", err)
+		return c.JSON(http.StatusNotFound, apierr.NoSuchEmoji())
 	}
 	fields := map[string]any{}
 	if req.Name != nil {
@@ -1429,7 +1435,12 @@ func (h *Handler) EmojiUpdate(c echo.Context) error {
 		fields["category"] = *req.Category
 	}
 	if req.Aliases != nil {
-		fields["aliases"] = req.Aliases
+		// `[]string` を直接 GORM に渡すと PostgreSQL の varchar[] 列に対して
+		// NULL として serialize される (#729)。`pq.StringArray` で wrap する
+		// と空 slice 含めて `'{}'` PostgreSQL array リテラルに正しく変換さ
+		// れる。Aliases 列は NOT NULL DEFAULT '{}' なので NULL 書き込みは
+		// 即制約違反でエラーになっていた。
+		fields["aliases"] = pq.StringArray(req.Aliases)
 	}
 	if req.License != nil {
 		fields["license"] = *req.License
@@ -1445,7 +1456,11 @@ func (h *Handler) EmojiUpdate(c echo.Context) error {
 		return c.NoContent(http.StatusNoContent)
 	}
 	if err := h.emojiRepo.UpdateFields(req.ID, fields); err != nil {
-		return c.JSON(http.StatusNotFound, apierr.Error("NO_SUCH_EMOJI", "No such emoji.", "684b7e7e-7e91-4e4c-a5cc-8050e4b8e0d8"))
+		// #729: FindByID 直後の RowsAffected==0 はほぼ起こらない (concurrent
+		// delete 等のレース) ので診断 log で気付けるようにする。
+		slog.WarnContext(c.Request().Context(), "EmojiUpdate: NO_SUCH_EMOJI on UpdateFields",
+			"id", req.ID, "fields", fieldKeys(fields), "err", err)
+		return c.JSON(http.StatusNotFound, apierr.NoSuchEmoji())
 	}
 	after, err := h.emojiRepo.FindByID(req.ID)
 	if err != nil {
@@ -1459,6 +1474,18 @@ func (h *Handler) EmojiUpdate(c echo.Context) error {
 		"after":   after,
 	})
 	return c.NoContent(http.StatusNoContent)
+}
+
+// fieldKeys は map のキー一覧を sort 済み slice で返す診断 log 用 helper。
+// log 行に value を直接含めると long string が混じって読みにくいので key
+// のみ列挙する。
+func fieldKeys(m map[string]any) []string {
+	out := make([]string, 0, len(m))
+	for k := range m {
+		out = append(out, k)
+	}
+	sort.Strings(out)
+	return out
 }
 
 // EmojiDelete handles POST /api/admin/emoji/delete.

--- a/internal/api/apierr/errors.go
+++ b/internal/api/apierr/errors.go
@@ -37,6 +37,12 @@ const (
 	UUIDNoSuchUser   = "4362f8dc-731f-4ad8-a694-be5a88922a24"
 	UUIDAccessDenied = "1fb7cb09-d46a-4fff-b8df-057708cce513"
 
+	// UUIDNoSuchEmoji は upstream `admin/emoji/update` の `noSuchEmoji` UUID
+	// (third_party/misskey/.../endpoints/admin/emoji/update.ts:24)。mk-go の
+	// 旧実装は `684b7e7e-...` という typo'd 値を返していた regression を
+	// upstream に揃え直す (#729)。
+	UUIDNoSuchEmoji = "684dec9d-a8c2-4364-9aa8-456c49cb1dc8"
+
 	// UUIDs for notes/create errors (third_party/misskey/.../endpoints/notes/create.ts).
 	UUIDNoSuchRenoteTarget                                         = "b5c90186-4ab0-49c8-9bba-a1f76c282ba4"
 	UUIDCannotRenoteToAPureRenote                                  = "fd4cc33e-2a37-48dd-99cc-9b806eb2031a"
@@ -140,6 +146,13 @@ func NoSuchNote() map[string]any {
 // NoSuchUser returns a 404 NO_SUCH_USER error response.
 func NoSuchUser() map[string]any {
 	return Error("NO_SUCH_USER", "No such user.", UUIDNoSuchUser)
+}
+
+// NoSuchEmoji returns a 404 NO_SUCH_EMOJI error response (#729). upstream
+// `admin/emoji/update.ts` / `admin/emoji/copy.ts` の noSuchEmoji と code /
+// id / message を完全一致させる。
+func NoSuchEmoji() map[string]any {
+	return Error("NO_SUCH_EMOJI", "No such emoji.", UUIDNoSuchEmoji)
 }
 
 // NoSuchNoteDraft returns a 404 NO_SUCH_NOTE_DRAFT error response (#688 /

--- a/internal/api/apierr/errors_test.go
+++ b/internal/api/apierr/errors_test.go
@@ -53,6 +53,17 @@ func TestNoSuchNoteDraft(t *testing.T) {
 	assert.Equal(t, "No such note draft.", errObj["message"])
 }
 
+func TestNoSuchEmoji(t *testing.T) {
+	// #729: upstream admin/emoji/update.ts (id `684dec9d-...`) 互換。
+	// mk-go の旧 typo `684b7e7e-...` ではないことの guard も兼ねる。
+	result := NoSuchEmoji()
+	errObj := result["error"].(map[string]any)
+	assert.Equal(t, "NO_SUCH_EMOJI", errObj["code"])
+	assert.Equal(t, "684dec9d-a8c2-4364-9aa8-456c49cb1dc8", errObj["id"])
+	assert.Equal(t, UUIDNoSuchEmoji, errObj["id"])
+	assert.Equal(t, "No such emoji.", errObj["message"])
+}
+
 func TestAccessDenied(t *testing.T) {
 	result := AccessDenied()
 	errObj := result["error"].(map[string]any)

--- a/internal/core/federation/resolver.go
+++ b/internal/core/federation/resolver.go
@@ -1183,12 +1183,19 @@ func extractEmojiTags(tags []any) []activitypub.EmojiTag {
 		id, _ := m["id"].(string)
 		updated, _ := m["updated"].(string)
 		// upstream Misskey TS の renderEmoji は license を `_misskey_license`
-		// オブジェクト (`{freeText: string}`) で federate する (#731)。
-		// 欠落 / 不正型は nil で残し、明示的な "" との区別を保つ。
+		// オブジェクト (`{freeText: string|null}`) で federate する (#731)。
+		// 3 状態を区別して保存する:
+		//   - wrapper 欠落 → License = nil ("license 情報が federate されて
+		//     いない" = 上書きしない)
+		//   - wrapper あり + freeText=null → FreeText = nil ("license は明示的
+		//     に未設定" = NULL 上書き OK)
+		//   - wrapper あり + freeText=string → FreeText = &string (具体値)
 		var license *activitypub.MisskeyLicense
 		if lic, ok := m["_misskey_license"].(map[string]any); ok {
-			free, _ := lic["freeText"].(string)
-			license = &activitypub.MisskeyLicense{FreeText: &free}
+			license = &activitypub.MisskeyLicense{}
+			if free, ok := lic["freeText"].(string); ok {
+				license.FreeText = &free
+			}
 		}
 		out = append(out, activitypub.EmojiTag{
 			Type:    "Emoji",

--- a/internal/core/federation/resolver.go
+++ b/internal/core/federation/resolver.go
@@ -987,6 +987,19 @@ func (r *Resolver) extractLocalNoteID(uri string) string {
 	return rest
 }
 
+// pointerStringsEqual returns true if both *string point to equal values
+// (nil/nil 同士も等しい)。upsertEmojis の license diff など、`*string` で
+// 「未指定」と「明示空文字列」を区別する経路で使う。
+func pointerStringsEqual(a, b *string) bool {
+	if a == nil && b == nil {
+		return true
+	}
+	if a == nil || b == nil {
+		return false
+	}
+	return *a == *b
+}
+
 // mergeMentionIDs merges two ordered ID slices preserving order and removing
 // duplicates. text 由来 mention と AP `tag` Mention 由来 mention を合算する
 // (#397) ために使う。両方空なら nil ではなく非 nil 空 (pq の '{}' 既定値と
@@ -1169,12 +1182,21 @@ func extractEmojiTags(tags []any) []activitypub.EmojiTag {
 		}
 		id, _ := m["id"].(string)
 		updated, _ := m["updated"].(string)
+		// upstream Misskey TS の renderEmoji は license を `_misskey_license`
+		// オブジェクト (`{freeText: string}`) で federate する (#731)。
+		// 欠落 / 不正型は nil で残し、明示的な "" との区別を保つ。
+		var license *activitypub.MisskeyLicense
+		if lic, ok := m["_misskey_license"].(map[string]any); ok {
+			free, _ := lic["freeText"].(string)
+			license = &activitypub.MisskeyLicense{FreeText: &free}
+		}
 		out = append(out, activitypub.EmojiTag{
 			Type:    "Emoji",
 			Name:    name,
 			Icon:    activitypub.Image{Type: "Image", URL: iconURL},
 			ID:      id,
 			Updated: updated,
+			License: license,
 		})
 	}
 	return out
@@ -1230,6 +1252,17 @@ func (r *Resolver) upsertEmojis(tags []activitypub.EmojiTag, host string) pq.Str
 			if tag.ID != "" && (existing.URI == nil || *existing.URI != tag.ID) {
 				updates["uri"] = &tag.ID
 			}
+			// AP `_misskey_license.freeText` の差分も追従する (#731)。
+			// nil wrapper = AP tag に license フィールド無し → 既存値を温存
+			// (連合先が一時的に license export を停止した場合に上書きしない)。
+			// FreeText nil 内部 = wrapper はあるが空 → 明示的に空 license で上書き。
+			if tag.License != nil {
+				newLicense := tag.License.FreeText
+				existingLicense := existing.License
+				if !pointerStringsEqual(newLicense, existingLicense) {
+					updates["license"] = newLicense
+				}
+			}
 			if len(updates) > 0 {
 				if err := r.emojiRepo.UpdateFields(existing.ID, updates); err != nil {
 					// updateに失敗してもrow自体は存在するので名前は返してよい
@@ -1249,6 +1282,12 @@ func (r *Resolver) upsertEmojis(tags []activitypub.EmojiTag, host string) pq.Str
 			Host:        &host,
 			OriginalURL: tag.Icon.URL,
 			PublicURL:   tag.Icon.URL,
+		}
+		// #731: AP `_misskey_license` 経由で federation 直後に保存。
+		// wrapper があれば FreeText (nil 含む) を取り込む、wrapper 自体が
+		// nil なら model.Emoji.License は nil のまま。
+		if tag.License != nil {
+			emoji.License = tag.License.FreeText
 		}
 		if uri != "" {
 			emoji.URI = &uri

--- a/internal/core/federation/resolver_test.go
+++ b/internal/core/federation/resolver_test.go
@@ -1868,6 +1868,56 @@ func TestExtractEmojiTags(t *testing.T) {
 		assert.Equal(t, "https://remote.example/emojis/blobcat.webp", got[0].Icon.URL)
 		assert.Equal(t, "https://remote.example/emojis/blobcat", got[0].ID)
 		assert.Equal(t, "2025-01-01T00:00:00Z", got[0].Updated)
+		// #731: AP tag に `_misskey_license` が無いケースは License = nil
+		assert.Nil(t, got[0].License, "no license wrapper → nil")
+	})
+
+	t.Run("emoji tag with _misskey_license", func(t *testing.T) {
+		// #731: upstream renderEmoji は `_misskey_license: {freeText: ...}` で
+		// license を federate する。mk-go の extractEmojiTags はこれを拾って
+		// EmojiTag.License に non-nil の wrapper を入れる。
+		tags := []any{
+			map[string]any{
+				"type": "Emoji",
+				"name": ":licensed:",
+				"icon": map[string]any{
+					"type": "Image",
+					"url":  "https://remote.example/emojis/licensed.webp",
+				},
+				"_misskey_license": map[string]any{
+					"freeText": "CC-BY-4.0",
+				},
+			},
+		}
+		got := federation.ExtractEmojiTags(tags)
+		require.Len(t, got, 1)
+		require.NotNil(t, got[0].License)
+		require.NotNil(t, got[0].License.FreeText)
+		assert.Equal(t, "CC-BY-4.0", *got[0].License.FreeText)
+	})
+
+	t.Run("emoji tag with _misskey_license but null freeText", func(t *testing.T) {
+		// upstream renderEmoji は emoji.license=null でも wrapper を出す。
+		// FreeText が JSON null の時は string assertion が失敗して空文字列に
+		// なるので、FreeText は &"" として残る (license 情報あり、内容は空)。
+		tags := []any{
+			map[string]any{
+				"type": "Emoji",
+				"name": ":no_license:",
+				"icon": map[string]any{
+					"type": "Image",
+					"url":  "https://remote.example/emojis/no_license.webp",
+				},
+				"_misskey_license": map[string]any{
+					"freeText": nil,
+				},
+			},
+		}
+		got := federation.ExtractEmojiTags(tags)
+		require.Len(t, got, 1)
+		require.NotNil(t, got[0].License, "wrapper present even when freeText is null")
+		require.NotNil(t, got[0].License.FreeText)
+		assert.Equal(t, "", *got[0].License.FreeText, "JSON null freeText → empty string in struct")
 	})
 
 	t.Run("non-emoji tags filtered out", func(t *testing.T) {
@@ -1997,6 +2047,71 @@ func TestUpsertEmojis(t *testing.T) {
 		assert.Equal(t, "https://remote.example/emojis/blobcat", *e.URI)
 		require.NotNil(t, e.Host)
 		assert.Equal(t, "remote.example", *e.Host)
+	})
+
+	t.Run("populates license from _misskey_license", func(t *testing.T) {
+		// #731: upstream Misskey TS が AP `_misskey_license.freeText` で
+		// federate する license を新規 emoji 取り込み時に保存する。
+		repo := testutil.NewMockUserRepository()
+		noteRepo := testutil.NewMockNoteRepository()
+		urls := activitypub.NewURLBuilder("https://example.com")
+		idGen, _ := id.NewGenerator("aidx")
+		r := federation.NewResolver(repo, noteRepo, urls, &stubFetcher{}, idGen)
+		emojiRepo := testutil.NewMockEmojiRepository()
+		r.SetEmojiRepo(emojiRepo)
+
+		licenseText := "CC-BY-4.0"
+		tags := []activitypub.EmojiTag{
+			{
+				Type:    "Emoji",
+				Name:    ":licensed:",
+				Icon:    activitypub.Image{Type: "Image", URL: "https://remote.example/licensed.webp"},
+				License: &activitypub.MisskeyLicense{FreeText: &licenseText},
+			},
+		}
+		r.UpsertEmojis(tags, "remote.example")
+
+		e, err := emojiRepo.FindByNameAndHost("licensed", strPtr("remote.example"))
+		require.NoError(t, err)
+		require.NotNil(t, e.License, "license should be populated from AP _misskey_license")
+		assert.Equal(t, "CC-BY-4.0", *e.License)
+	})
+
+	t.Run("preserves existing license when AP tag has no _misskey_license wrapper", func(t *testing.T) {
+		// #731: AP tag の `_misskey_license` が欠落している場合、既存 emoji の
+		// license は温存する (連合先が一時的に license export を停止しても
+		// 上書きしない)。
+		repo := testutil.NewMockUserRepository()
+		noteRepo := testutil.NewMockNoteRepository()
+		urls := activitypub.NewURLBuilder("https://example.com")
+		idGen, _ := id.NewGenerator("aidx")
+		r := federation.NewResolver(repo, noteRepo, urls, &stubFetcher{}, idGen)
+		emojiRepo := testutil.NewMockEmojiRepository()
+		r.SetEmojiRepo(emojiRepo)
+
+		host := "remote.example"
+		old := "old-license"
+		emojiRepo.Emojis["preserved@remote.example"] = &model.Emoji{
+			ID: "existing", Name: "preserved", Host: &host,
+			OriginalURL: "https://remote.example/preserved.webp",
+			PublicURL:   "https://remote.example/preserved.webp",
+			License:     &old,
+		}
+
+		// License: nil の AP tag (= wrapper 欠落)
+		tags := []activitypub.EmojiTag{
+			{
+				Type: "Emoji",
+				Name: ":preserved:",
+				Icon: activitypub.Image{Type: "Image", URL: "https://remote.example/preserved.webp"},
+			},
+		}
+		r.UpsertEmojis(tags, host)
+
+		e, err := emojiRepo.FindByNameAndHost("preserved", &host)
+		require.NoError(t, err)
+		require.NotNil(t, e.License)
+		assert.Equal(t, "old-license", *e.License, "existing license must be preserved when wrapper is missing")
 	})
 
 	t.Run("updates existing emoji URL", func(t *testing.T) {

--- a/internal/core/federation/resolver_test.go
+++ b/internal/core/federation/resolver_test.go
@@ -2081,6 +2081,118 @@ func TestUpsertEmojis(t *testing.T) {
 		assert.Equal(t, "CC-BY-4.0", *e.License)
 	})
 
+	t.Run("updates existing license when AP tag has different value", func(t *testing.T) {
+		// #731: AP tag に新しい license が来たら既存値を上書きする経路。
+		// pointerStringsEqual の "1 つ nil / 値変化" 分岐をカバー。
+		repo := testutil.NewMockUserRepository()
+		noteRepo := testutil.NewMockNoteRepository()
+		urls := activitypub.NewURLBuilder("https://example.com")
+		idGen, _ := id.NewGenerator("aidx")
+		r := federation.NewResolver(repo, noteRepo, urls, &stubFetcher{}, idGen)
+		emojiRepo := testutil.NewMockEmojiRepository()
+		r.SetEmojiRepo(emojiRepo)
+
+		host := "remote.example"
+		oldLicense := "old"
+		emojiRepo.Emojis["chg@remote.example"] = &model.Emoji{
+			ID: "ex", Name: "chg", Host: &host,
+			OriginalURL: "https://remote.example/chg.webp",
+			PublicURL:   "https://remote.example/chg.webp",
+			License:     &oldLicense,
+		}
+
+		newLicense := "new-license"
+		tags := []activitypub.EmojiTag{
+			{
+				Type:    "Emoji",
+				Name:    ":chg:",
+				Icon:    activitypub.Image{Type: "Image", URL: "https://remote.example/chg.webp"},
+				License: &activitypub.MisskeyLicense{FreeText: &newLicense},
+			},
+		}
+		r.UpsertEmojis(tags, host)
+
+		e, err := emojiRepo.FindByNameAndHost("chg", &host)
+		require.NoError(t, err)
+		require.NotNil(t, e.License)
+		assert.Equal(t, "new-license", *e.License, "license should be updated to new value")
+	})
+
+	t.Run("no-op when license unchanged", func(t *testing.T) {
+		// #731: 同じ license が再 federate されても update 不要。
+		// pointerStringsEqual が true を返す経路をカバー。
+		repo := testutil.NewMockUserRepository()
+		noteRepo := testutil.NewMockNoteRepository()
+		urls := activitypub.NewURLBuilder("https://example.com")
+		idGen, _ := id.NewGenerator("aidx")
+		r := federation.NewResolver(repo, noteRepo, urls, &stubFetcher{}, idGen)
+		emojiRepo := testutil.NewMockEmojiRepository()
+		r.SetEmojiRepo(emojiRepo)
+
+		host := "remote.example"
+		same := "same-license"
+		emojiRepo.Emojis["nop@remote.example"] = &model.Emoji{
+			ID: "ex", Name: "nop", Host: &host,
+			OriginalURL: "https://remote.example/nop.webp",
+			PublicURL:   "https://remote.example/nop.webp",
+			License:     &same,
+		}
+
+		// 同じ license 値で再 federate
+		sameAgain := "same-license"
+		tags := []activitypub.EmojiTag{
+			{
+				Type:    "Emoji",
+				Name:    ":nop:",
+				Icon:    activitypub.Image{Type: "Image", URL: "https://remote.example/nop.webp"},
+				License: &activitypub.MisskeyLicense{FreeText: &sameAgain},
+			},
+		}
+		r.UpsertEmojis(tags, host)
+
+		e, err := emojiRepo.FindByNameAndHost("nop", &host)
+		require.NoError(t, err)
+		require.NotNil(t, e.License)
+		assert.Equal(t, "same-license", *e.License, "value unchanged")
+	})
+
+	t.Run("clears existing license when AP tag explicitly federates null freeText", func(t *testing.T) {
+		// #731: wrapper あり + freeText=null は "license を明示的に解除" の
+		// シグナル。既存 license を NULL で上書きする経路。pointerStringsEqual
+		// の "片方 nil" 分岐をカバー。
+		repo := testutil.NewMockUserRepository()
+		noteRepo := testutil.NewMockNoteRepository()
+		urls := activitypub.NewURLBuilder("https://example.com")
+		idGen, _ := id.NewGenerator("aidx")
+		r := federation.NewResolver(repo, noteRepo, urls, &stubFetcher{}, idGen)
+		emojiRepo := testutil.NewMockEmojiRepository()
+		r.SetEmojiRepo(emojiRepo)
+
+		host := "remote.example"
+		oldLicense := "to-clear"
+		emojiRepo.Emojis["clr@remote.example"] = &model.Emoji{
+			ID: "ex", Name: "clr", Host: &host,
+			OriginalURL: "https://remote.example/clr.webp",
+			PublicURL:   "https://remote.example/clr.webp",
+			License:     &oldLicense,
+		}
+
+		// freeText=nil (= JSON null 受信) で wrapper あり
+		tags := []activitypub.EmojiTag{
+			{
+				Type:    "Emoji",
+				Name:    ":clr:",
+				Icon:    activitypub.Image{Type: "Image", URL: "https://remote.example/clr.webp"},
+				License: &activitypub.MisskeyLicense{FreeText: nil},
+			},
+		}
+		r.UpsertEmojis(tags, host)
+
+		e, err := emojiRepo.FindByNameAndHost("clr", &host)
+		require.NoError(t, err)
+		assert.Nil(t, e.License, "explicit null freeText should clear existing license")
+	})
+
 	t.Run("preserves existing license when AP tag has no _misskey_license wrapper", func(t *testing.T) {
 		// #731: AP tag の `_misskey_license` が欠落している場合、既存 emoji の
 		// license は温存する (連合先が一時的に license export を停止しても

--- a/internal/core/federation/resolver_test.go
+++ b/internal/core/federation/resolver_test.go
@@ -1896,10 +1896,15 @@ func TestExtractEmojiTags(t *testing.T) {
 		assert.Equal(t, "CC-BY-4.0", *got[0].License.FreeText)
 	})
 
-	t.Run("emoji tag with _misskey_license but null freeText", func(t *testing.T) {
+	t.Run("emoji tag _misskey_license null freeText keeps FreeText nil", func(t *testing.T) {
 		// upstream renderEmoji は emoji.license=null でも wrapper を出す。
-		// FreeText が JSON null の時は string assertion が失敗して空文字列に
-		// なるので、FreeText は &"" として残る (license 情報あり、内容は空)。
+		// 3 状態を区別する設計 (#731):
+		//   - wrapper 欠落 → License = nil ("license 情報が federate されて
+		//     いない", 既存値温存)
+		//   - wrapper あり + freeText=null → FreeText = nil ("license は明示
+		//     的に未設定", NULL 上書き OK)
+		//   - wrapper あり + freeText=string → 具体値
+		// JSON null は string assertion が失敗するので FreeText は nil のまま。
 		tags := []any{
 			map[string]any{
 				"type": "Emoji",
@@ -1916,8 +1921,7 @@ func TestExtractEmojiTags(t *testing.T) {
 		got := federation.ExtractEmojiTags(tags)
 		require.Len(t, got, 1)
 		require.NotNil(t, got[0].License, "wrapper present even when freeText is null")
-		require.NotNil(t, got[0].License.FreeText)
-		assert.Equal(t, "", *got[0].License.FreeText, "JSON null freeText → empty string in struct")
+		assert.Nil(t, got[0].License.FreeText, "JSON null freeText → FreeText nil (explicit no license)")
 	})
 
 	t.Run("non-emoji tags filtered out", func(t *testing.T) {

--- a/internal/repository/emoji_test.go
+++ b/internal/repository/emoji_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"testing"
 
+	"github.com/lib/pq"
 	"github.com/shiroha-a/mk/internal/model"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -237,6 +238,37 @@ func TestEmojiRepository_UpdateFields_Success(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, after.Category)
 	assert.Equal(t, "happy", *after.Category)
+}
+
+// TestEmojiRepository_UpdateFields_AliasesEmptySlice は #729 regression
+// guard。`pq.StringArray{}` (空 slice) で aliases 列を更新する経路が
+// PostgreSQL の NOT NULL DEFAULT '{}' 制約と整合することを確認する。
+//
+// 旧 EmojiUpdate handler は `[]string` を直接 GORM に渡していて、空 slice
+// が NULL として serialize され "null value in column \"aliases\" violates
+// not-null constraint" で UpdateFields が失敗していた (frontend が
+// aliases:[] で送るたびに NO_SUCH_EMOJI が返る病状)。本 test は
+// `pq.StringArray` 経由の UpdateFields が成功することを保証する。
+func TestEmojiRepository_UpdateFields_AliasesEmptySlice(t *testing.T) {
+	repo := NewEmojiRepository(testDB)
+	e := &model.Emoji{
+		ID: "em_uf_alias", Name: "alias_target", OriginalURL: "https://x",
+		Aliases: pq.StringArray{"old"},
+	}
+	require.NoError(t, repo.Create(e))
+	defer cleanupEmoji(t, e.ID)
+
+	// 空 slice の pq.StringArray は SQL の '{}' に変換される
+	require.NoError(t, repo.UpdateFields(e.ID, map[string]any{"aliases": pq.StringArray{}}))
+	after, err := repo.FindByID(e.ID)
+	require.NoError(t, err)
+	assert.Empty(t, []string(after.Aliases), "empty pq.StringArray should clear aliases without NULL constraint violation")
+
+	// 通常の値も問題なく更新できる
+	require.NoError(t, repo.UpdateFields(e.ID, map[string]any{"aliases": pq.StringArray{"a", "b"}}))
+	after, err = repo.FindByID(e.ID)
+	require.NoError(t, err)
+	assert.Equal(t, []string{"a", "b"}, []string(after.Aliases))
 }
 
 func TestEmojiRepository_UpdateFieldsMany(t *testing.T) {

--- a/internal/server/router.go
+++ b/internal/server/router.go
@@ -1367,8 +1367,18 @@ func (s *Server) setupRoutes() {
 		// 互換性のため type assertion で seekable かを確認し、非対応 (将来
 		// S3 等の non-seekable storage を増やした場合) なら全 body を memory
 		// に読み込む fallback にフォールバックする。
+		// modtime も *os.File なら Stat() から取得して If-Modified-Since の
+		// 304 経路を有効にする。それ以外は零値で http.ServeContent が
+		// Last-Modified を出さない (Cache-Control: immutable で代替)。
+		var modtime time.Time
 		seeker, ok := body.(io.ReadSeeker)
-		if !ok {
+		if ok {
+			if f, isFile := body.(*os.File); isFile {
+				if st, err := f.Stat(); err == nil {
+					modtime = st.ModTime()
+				}
+			}
+		} else {
 			data, rerr := io.ReadAll(body)
 			if rerr != nil {
 				return c.NoContent(http.StatusInternalServerError)
@@ -1392,10 +1402,9 @@ func (s *Server) setupRoutes() {
 		c.Response().Header().Set("Cache-Control", "max-age=31536000, immutable, no-transform")
 		c.Response().Header().Set(echo.HeaderContentType, contentType)
 		// http.ServeContent が Content-Length / Range / If-Modified-Since を
-		// 適切に処理する。modtime 不明なので零値を渡し ETag/Last-Modified は
-		// emit しないが、Cache-Control: immutable でクライアント側 cache は
-		// 効く。
-		http.ServeContent(c.Response(), c.Request(), key, time.Time{}, seeker)
+		// 適切に処理する。modtime 取得できれば Last-Modified を発行して
+		// 304 経路も活きる。
+		http.ServeContent(c.Response(), c.Request(), key, modtime, seeker)
 		return nil
 	})
 

--- a/internal/server/router.go
+++ b/internal/server/router.go
@@ -1348,7 +1348,13 @@ func (s *Server) setupRoutes() {
 	// Phase 7.4: drive/* — 全て実データハンドラに移行済み
 
 	// Static file serving for LocalStorage
-	// MIME type はファイル内容の先頭から自動判定する。
+	// MIME type はファイル内容の先頭から自動判定し、`http.ServeContent` で
+	// Range / If-Modified-Since / Content-Length 対応の正しい応答を返す。
+	//
+	// 旧実装は echo の `c.Stream` + `io.MultiReader` で chunked transfer に
+	// 倒していたが、Cloudflare Tunnel 経由のデプロイで bigger-than-buffer
+	// (33KB 程度) なファイルが truncate される問題があった (#730)。明示
+	// Content-Length + Cache-Control: no-transform でこれを回避する。
 	s.echo.GET("/files/:accessKey", func(c echo.Context) error {
 		key := c.Param("accessKey")
 		body, err := driveStorage.Get(key)
@@ -1357,13 +1363,40 @@ func (s *Server) setupRoutes() {
 		}
 		defer body.Close()
 
-		// 先頭512バイトを読んでMIME typeを判定
+		// LocalStorage は *os.File を返すので io.ReadSeeker として扱える。
+		// 互換性のため type assertion で seekable かを確認し、非対応 (将来
+		// S3 等の non-seekable storage を増やした場合) なら全 body を memory
+		// に読み込む fallback にフォールバックする。
+		seeker, ok := body.(io.ReadSeeker)
+		if !ok {
+			data, rerr := io.ReadAll(body)
+			if rerr != nil {
+				return c.NoContent(http.StatusInternalServerError)
+			}
+			seeker = bytes.NewReader(data)
+		}
+
+		// 先頭 512 バイト読んで MIME type を判定 → 元位置に戻す
 		buf := make([]byte, 512)
-		n, _ := body.Read(buf)
+		n, _ := seeker.Read(buf)
 		contentType := http.DetectContentType(buf[:n])
-		// 読んだ分 + 残りを連結して配信
-		mr := io.MultiReader(bytes.NewReader(buf[:n]), body)
-		return c.Stream(http.StatusOK, contentType, mr)
+		if _, err := seeker.Seek(0, io.SeekStart); err != nil {
+			return c.NoContent(http.StatusInternalServerError)
+		}
+
+		// `Cache-Control: no-transform` で Cloudflare Polish 等 CDN 中間層
+		// による画像再エンコードを抑止する (#730)。Polish は animated WebP
+		// を別 size で出力するため UDS デプロイ環境で「絵文字がチカチカ
+		// する + サイズが切れる」現象を起こす。`immutable` で長期 cache 化、
+		// `no-transform` で binary 1:1 配信を契約する。
+		c.Response().Header().Set("Cache-Control", "max-age=31536000, immutable, no-transform")
+		c.Response().Header().Set(echo.HeaderContentType, contentType)
+		// http.ServeContent が Content-Length / Range / If-Modified-Since を
+		// 適切に処理する。modtime 不明なので零値を渡し ETag/Last-Modified は
+		// emit しないが、Cache-Control: immutable でクライアント側 cache は
+		// 効く。
+		http.ServeContent(c.Response(), c.Request(), key, time.Time{}, seeker)
+		return nil
 	})
 
 	// Media proxy endpoint

--- a/internal/testutil/mock_repository.go
+++ b/internal/testutil/mock_repository.go
@@ -1291,11 +1291,23 @@ func (m *MockEmojiRepository) UpdateFields(id string, fields map[string]any) err
 						e.Category = &s
 					}
 				case "license":
-					if s, ok := v.(string); ok {
+					// resolver の license diff path (#731) は *string を直接
+					// fields["license"] に入れる。handler 経路は string 値を
+					// 入れるので両方受ける (nil pointer は明示 NULL 化を表す)。
+					switch s := v.(type) {
+					case string:
 						e.License = &s
+					case *string:
+						e.License = s
 					}
 				case "aliases":
-					if arr, ok := v.([]string); ok {
+					// EmojiUpdate handler は pq.StringArray でラップして渡す
+					// (#729)。resolver / 旧 caller は []string を渡すので両方
+					// 受ける (PostgreSQL は同じ varchar[] に変換される)。
+					switch arr := v.(type) {
+					case pq.StringArray:
+						e.Aliases = arr
+					case []string:
 						e.Aliases = arr
 					}
 				case "isSensitive":


### PR DESCRIPTION
## Summary

UDS 検証環境で発見された 3 件の絵文字バグを統合 PR で対応。実環境で再現 → 真因特定 → 修正 → UDS で再検証の流れで全て確認済み。

## #729: EmojiUpdate が NO_SUCH_EMOJI を返す

**真因**: handler が \`req.Aliases\` (\`[]string\`) を GORM の \`Updates(map)\` に直接渡すと、空 slice が PostgreSQL の \`varchar[]\` 列に **NULL として serialize** され、\`emoji.aliases\` 列の \`NOT NULL DEFAULT '{}'\` 制約違反で \`UpdateFields\` が失敗。`RowsAffected==0` 経路で NO_SUCH_EMOJI を返していた。frontend が空 aliases を送るたびに編集できない病状。

server log に診断 slog を追加した結果:
\`\`\`
EmojiUpdate: NO_SUCH_EMOJI on UpdateFields
fields=[aliases isSensitive localOnly name]
err="ERROR: null value in column \"aliases\" of relation \"emoji\" violates not-null constraint (SQLSTATE 23502)"
\`\`\`

修正:
- \`pq.StringArray(req.Aliases)\` で wrap して空 slice を \`'{}'\` に正規化
- NO_SUCH_EMOJI UUID を upstream 互換 \`684dec9d-...\` に修正 (旧 typo \`684b7e7e-...\`)
- \`apierr.NoSuchEmoji()\` helper 化
- diagnostic slog で FindByID 失敗 / UpdateFields 失敗を区別 (本 bug 特定の決定打)
- 実 PostgreSQL 経由の regression test \`TestEmojiRepository_UpdateFields_AliasesEmptySlice\` で空 slice 経路を guard

## #730: 絵文字画像が flicker / truncated

**真因**: \`/files/<accessKey>\` handler が \`echo.Stream\` + chunked transfer encoding で配信していて Content-Length 無し。Cloudflare Tunnel 経由のデプロイで ~33KB 超のレスポンスが truncate されていた (animated WebP / GIF emoji が壊れて見える)。

調査の流れ:
1. 元画像 44KB / 配信版 33KB で md5 不一致 → 配信側で truncation
2. UDS socket 直接 fetch → 44KB ✓ (mk-go は正しい)
3. docker nginx 経由 → 44KB ✓ (nginx は正しい)
4. Cloudflare 経由 → 33KB ✗ (tunnel/CDN で truncation)

修正:
- \`/files/\` handler を \`http.ServeContent\` ベースに refactor。Content-Length を明示し、Range / If-Modified-Since も同時対応
- \`Cache-Control: no-transform\` を出して Cloudflare Polish 等の中間 CDN による画像再エンコードを抑止
- nginx config (\`deploy/uds/nginx/mkgo.conf\`) の \`/files/\` location で \`proxy_buffering off\` にして将来 buffer 起因の truncation を予防

## #731: AP 経由で license が federation で取り込まれない

**真因**: mk-go の AP emoji tag parser が upstream Misskey TS の \`_misskey_license\` wrapper を無視。リモート instance がノートに付けた emoji の license が local DB に保存されず、emoji copy 時にも空のままだった。

upstream \`ApRendererService.renderEmoji\`:
\`\`\`typescript
{ ..., _misskey_license: { freeText: emoji.license } }
\`\`\`

修正:
- \`activitypub.EmojiTag\` に \`MisskeyLicense{FreeText *string}\` wrapper を追加
- \`federation/resolver.extractEmojiTags\` で \`_misskey_license.freeText\` を抽出して \`EmojiTag.License\` に保持
- \`upsertEmojis\` で新規 emoji 作成時 / 既存 emoji 更新時 (wrapper あり + 値変化時のみ) に \`model.Emoji.License\` を populate。wrapper 欠落時は既存値温存 (連合先が一時的に export 停止しても上書きしない)
- 送信側 \`addEmojiTags\` で自インスタンス emoji 出力時にも wrapper を付与 (相互運用性)

## UDS 検証

UDS 環境 (\`https://go.k7a.org\`) で 3 件全て修正確認:
- **#729**: \`meow_yikes_copy\` / \`apng\` 編集成功
- **#730**: \`resonyance\` 絵文字 20 リロード flicker 再現せず
- **#731**: リモート絵文字の license が DB に保存されることを確認

## テスト

\`\`\`
make fmt && make lint
go test ./... -count=1 -timeout 5m
\`\`\`

新規テスト:
- \`TestNoSuchEmoji\` (apierr): UUID 完全一致 + helper response shape
- \`TestEmojiUpdate_NoSuchEmojiOnMissingID\`: UUID assert 強化
- \`TestExtractEmojiTags / *_misskey_license / *null_freeText\`: AP tag parser
- \`TestUpsertEmojis / populates_license / preserves_existing\`: federation upsert
- \`TestRenderer_RenderNote_EmojiTag\`: outbound license output
- \`TestEmojiRepository_UpdateFields_AliasesEmptySlice\`: 実 DB regression guard

## Closes

Closes #729
Closes #730
Closes #731

🤖 Generated with [Claude Code](https://claude.com/claude-code)