### PR TITLE
Fix #700: noteStream に reacted/unreacted/deleted を publish

### DIFF
--- a/internal/core/note/note_delete_service.go
+++ b/internal/core/note/note_delete_service.go
@@ -109,6 +109,13 @@ func (s *DeleteService) Delete(user *model.User, noteID string) error {
 		return ErrNoteAccessDenied
 	}
 
+	// 上流 NoteDeleteService が Delete 冒頭で deletedAt を確定させ publish と
+	// federation の Delete activity 両方に渡しているのに合わせ、ここで一度
+	// 取得して noteStream publish に使う。federation 側は別途自分で時刻を
+	// 決めるが、本実装でも publish 直前に再取得すると noteStream の
+	// deletedAt と federation activity の timestamp に不要な差が出るため。
+	deletedAt := time.Now()
+
 	if err := s.noteRepo.Delete(note); err != nil {
 		return err
 	}
@@ -137,7 +144,7 @@ func (s *DeleteService) Delete(user *model.User, noteID string) error {
 	// noteStream に deleted を publish して subNote 購読中の WebSocket
 	// クライアントへ即時反映する (#700)。失敗はベストエフォート。
 	if s.noteStreamHook != nil {
-		s.noteStreamHook.OnNoteDeleted(note.ID, time.Now())
+		s.noteStreamHook.OnNoteDeleted(note.ID, deletedAt)
 	}
 	return nil
 }

--- a/internal/core/note/note_delete_service.go
+++ b/internal/core/note/note_delete_service.go
@@ -2,6 +2,7 @@ package note
 
 import (
 	"errors"
+	"time"
 
 	"github.com/shiroha-a/mk/internal/model"
 	"github.com/shiroha-a/mk/internal/repository"
@@ -38,6 +39,14 @@ type DeleteTimelineHook interface {
 	OnNoteDeleted(note *model.Note, author *model.User)
 }
 
+// DeleteNoteStreamHook is invoked after a note is deleted so the stream
+// layer can publish a `deleted` event to `noteStream:<noteID>` for any
+// WebSocket clients that have called subNote on this note (#700)。
+// 失敗はベストエフォート扱いなので戻り値を持たない。
+type DeleteNoteStreamHook interface {
+	OnNoteDeleted(noteID string, deletedAt time.Time)
+}
+
 // DeleteService provides note deletion logic.
 type DeleteService struct {
 	noteRepo       repository.NoteRepository
@@ -45,6 +54,7 @@ type DeleteService struct {
 	indexHook      IndexHook
 	chartHook      DeleteChartHook
 	timelineHook   DeleteTimelineHook
+	noteStreamHook DeleteNoteStreamHook
 }
 
 // NewDeleteService creates a new DeleteService.
@@ -73,6 +83,13 @@ func (s *DeleteService) SetChartHook(h DeleteChartHook) {
 // Redis fanout timelines can be purged of the note ID (#379)。
 func (s *DeleteService) SetTimelineHook(h DeleteTimelineHook) {
 	s.timelineHook = h
+}
+
+// SetNoteStreamHook attaches a DeleteNoteStreamHook invoked after Delete so
+// the stream layer can publish `deleted` events on `noteStream:<noteID>`
+// (#700)。
+func (s *DeleteService) SetNoteStreamHook(h DeleteNoteStreamHook) {
+	s.noteStreamHook = h
 }
 
 // Delete removes a note authored by the given user. It returns
@@ -116,6 +133,11 @@ func (s *DeleteService) Delete(user *model.User, noteID string) error {
 	// Redis fanout timeline 残留を防ぐ (#379)。ベストエフォート。
 	if s.timelineHook != nil {
 		s.timelineHook.OnNoteDeleted(note, user)
+	}
+	// noteStream に deleted を publish して subNote 購読中の WebSocket
+	// クライアントへ即時反映する (#700)。失敗はベストエフォート。
+	if s.noteStreamHook != nil {
+		s.noteStreamHook.OnNoteDeleted(note.ID, time.Now())
 	}
 	return nil
 }

--- a/internal/core/note/note_delete_service_test.go
+++ b/internal/core/note/note_delete_service_test.go
@@ -3,6 +3,7 @@ package note_test
 import (
 	"errors"
 	"testing"
+	"time"
 
 	"github.com/shiroha-a/mk/internal/core/note"
 	"github.com/shiroha-a/mk/internal/model"
@@ -187,4 +188,49 @@ func TestDeleteService_TimelineHookInvoked(t *testing.T) {
 	assert.Equal(t, "n1", hook.note.ID)
 	require.NotNil(t, hook.author)
 	assert.Equal(t, "user1", hook.author.ID)
+}
+
+// recordingDeleteNoteStreamHook captures noteStream publish hook calls (#700)。
+type recordingDeleteNoteStreamHook struct {
+	called    bool
+	noteID    string
+	deletedAt time.Time
+}
+
+func (h *recordingDeleteNoteStreamHook) OnNoteDeleted(noteID string, deletedAt time.Time) {
+	h.called = true
+	h.noteID = noteID
+	h.deletedAt = deletedAt
+}
+
+// 削除に成功すると `noteStream:<id>` 用の hook が `deleted` payload を
+// 1 度だけ受け取ることを確認する。
+func TestDeleteService_NoteStreamHookInvoked(t *testing.T) {
+	noteRepo := testutil.NewMockNoteRepository()
+	noteRepo.Notes["n1"] = &model.Note{ID: "n1", UserID: "user1"}
+	svc := note.NewDeleteService(noteRepo)
+	hook := &recordingDeleteNoteStreamHook{}
+	svc.SetNoteStreamHook(hook)
+
+	before := time.Now()
+	require.NoError(t, svc.Delete(&model.User{ID: "user1"}, "n1"))
+	after := time.Now()
+	assert.True(t, hook.called)
+	assert.Equal(t, "n1", hook.noteID)
+	// deletedAt は呼び出し前後の time.Now() の間に収まる。
+	assert.False(t, hook.deletedAt.Before(before))
+	assert.False(t, hook.deletedAt.After(after))
+}
+
+// 削除が失敗 (権限なし) した場合 noteStream hook は呼ばれない。
+func TestDeleteService_NoteStreamHookNotFiredOnFailure(t *testing.T) {
+	noteRepo := testutil.NewMockNoteRepository()
+	noteRepo.Notes["n1"] = &model.Note{ID: "n1", UserID: "owner"}
+	svc := note.NewDeleteService(noteRepo)
+	hook := &recordingDeleteNoteStreamHook{}
+	svc.SetNoteStreamHook(hook)
+
+	err := svc.Delete(&model.User{ID: "intruder"}, "n1")
+	require.Error(t, err)
+	assert.False(t, hook.called)
 }

--- a/internal/core/reaction/reaction_service.go
+++ b/internal/core/reaction/reaction_service.go
@@ -85,6 +85,24 @@ type WebhookHook interface {
 	OnReactionCreated(note *model.Note, reactor *model.User, reaction string)
 }
 
+// NoteStreamEmoji is the custom-emoji descriptor included in the
+// `reacted` payload published to `noteStream:<noteID>`. Name は TS upstream の
+// wire format に合わせて `<short>@<host>` または `<short>@.` (local) 形式。
+type NoteStreamEmoji struct {
+	Name string
+	URL  string
+}
+
+// NoteStreamHook is invoked after a reaction is created or removed so the
+// stream layer can publish `reacted` / `unreacted` events to the per-note
+// `noteStream:<noteID>` topic. This drives real-time WebSocket updates for
+// clients that have called `subNote` / `sn` (#700)。実装は server 配線層で
+// stream.NoteEventPublisher を注入する adapter として与える。
+type NoteStreamHook interface {
+	OnReacted(noteID, userID, reaction string, emoji *NoteStreamEmoji)
+	OnUnreacted(noteID, userID, reaction string)
+}
+
 // Service manages note reactions.
 type Service struct {
 	noteRepo         repository.NoteRepository
@@ -97,6 +115,7 @@ type Service struct {
 	federationHook   FederationHook
 	chartHook        ChartHook
 	webhookHook      WebhookHook
+	noteStreamHook   NoteStreamHook
 	countWriter      ReactionCountWriter
 }
 
@@ -154,6 +173,13 @@ func (s *Service) SetChartHook(h ChartHook) {
 // created so that user webhooks subscribed to the reaction event can fire.
 func (s *Service) SetWebhookHook(h WebhookHook) {
 	s.webhookHook = h
+}
+
+// SetNoteStreamHook attaches a NoteStreamHook invoked after a reaction is
+// created or removed so the stream layer can publish reacted/unreacted
+// events to the per-note pubsub topic (#700)。
+func (s *Service) SetNoteStreamHook(h NoteStreamHook) {
+	s.noteStreamHook = h
 }
 
 // Create attaches a reaction by user to the target note.
@@ -236,6 +262,11 @@ func (s *Service) Create(user *model.User, noteID, rawReaction string) (string, 
 	if s.webhookHook != nil {
 		s.webhookHook.OnReactionCreated(target, user, reaction)
 	}
+	// noteStream に reacted を publish して subNote 購読中の WebSocket
+	// クライアントへ即時反映する (#700)。
+	if s.noteStreamHook != nil {
+		s.noteStreamHook.OnReacted(target.ID, user.ID, decodeReactionForStream(reaction), s.resolveStreamEmoji(reaction))
+	}
 
 	return reaction, nil
 }
@@ -259,6 +290,11 @@ func (s *Service) Delete(user *model.User, noteID string) error {
 	_ = s.countWriter.Increment(target.ID, existing.Reaction, -1)
 	if s.federationHook != nil {
 		s.federationHook.OnReactionRemoved(user, target, existing.Reaction)
+	}
+	// noteStream に unreacted を publish して subNote 購読中の WebSocket
+	// クライアントへ即時反映する (#700)。
+	if s.noteStreamHook != nil {
+		s.noteStreamHook.OnUnreacted(target.ID, user.ID, decodeReactionForStream(existing.Reaction))
 	}
 	return nil
 }
@@ -347,6 +383,63 @@ func reactionVariants(normalized string) []string {
 		return []string{normalized, ":" + m[1] + ":"}
 	}
 	return []string{normalized}
+}
+
+// decodeReactionForStream returns the canonical wire form of a reaction
+// string for noteStream payload (`:name@host:` / `:name@.:` for custom emoji,
+// raw string for unicode/legacy). 上流 ReactionService.ts の decodeReaction と
+// 同形式で、ホスト省略時 `.` を補う。normalizeReaction と違い emoji 存在検証
+// やフォールバックは行わない (DB に既に保存された値をそのまま wire 化する用途)。
+func decodeReactionForStream(raw string) string {
+	m := customEmojiPattern.FindStringSubmatch(raw)
+	if m == nil {
+		return raw
+	}
+	name := m[1]
+	host := "."
+	if len(m) >= 3 && m[2] != "" && m[2] != "." {
+		host = m[2]
+	}
+	return ":" + name + "@" + host + ":"
+}
+
+// resolveStreamEmoji returns the NoteStreamEmoji descriptor for a custom
+// reaction, looking up the emoji in the repository. Returns nil for
+// unicode / legacy reactions or when the emoji is unknown. URL は
+// publicUrl 優先で originalUrl に fallback する (上流互換)。
+func (s *Service) resolveStreamEmoji(reaction string) *NoteStreamEmoji {
+	m := customEmojiPattern.FindStringSubmatch(reaction)
+	if m == nil {
+		return nil
+	}
+	name := m[1]
+	host := ""
+	if len(m) >= 3 {
+		host = m[2]
+	}
+	if host == "." {
+		host = ""
+	}
+	var hostPtr *string
+	if host != "" {
+		hostPtr = &host
+	}
+	emoji, err := s.emojiRepo.FindByNameAndHost(name, hostPtr)
+	if err != nil || emoji == nil {
+		return nil
+	}
+	url := emoji.PublicURL
+	if url == "" {
+		url = emoji.OriginalURL
+	}
+	suffix := host
+	if suffix == "" {
+		suffix = "."
+	}
+	return &NoteStreamEmoji{
+		Name: name + "@" + suffix,
+		URL:  url,
+	}
 }
 
 // isPureRenote reports whether the given note is a pure renote (no text/cw/files/poll).

--- a/internal/core/reaction/reaction_service_test.go
+++ b/internal/core/reaction/reaction_service_test.go
@@ -511,3 +511,160 @@ func TestService_ChartHook_OnCreate(t *testing.T) {
 	require.Len(t, hook.created, 1)
 	assert.Equal(t, [2]string{"viewer", "n1"}, hook.created[0])
 }
+
+// recordingNoteStreamHook captures noteStream publish hook calls (#700)。
+type recordingNoteStreamHook struct {
+	reacted   []reactedCall
+	unreacted []unreactedCall
+}
+
+type reactedCall struct {
+	noteID, userID, reaction string
+	emoji                    *reaction.NoteStreamEmoji
+}
+
+type unreactedCall struct {
+	noteID, userID, reaction string
+}
+
+func (h *recordingNoteStreamHook) OnReacted(noteID, userID, rx string, emoji *reaction.NoteStreamEmoji) {
+	h.reacted = append(h.reacted, reactedCall{noteID, userID, rx, emoji})
+}
+
+func (h *recordingNoteStreamHook) OnUnreacted(noteID, userID, rx string) {
+	h.unreacted = append(h.unreacted, unreactedCall{noteID, userID, rx})
+}
+
+// 通常 (Unicode) リアクション付与で `reacted` が emoji=nil で publish される。
+func TestService_NoteStreamHook_OnCreate_Unicode(t *testing.T) {
+	svc, repo, _, _, _ := newService(t)
+	seedNote(repo, "n1", "author", model.NoteVisibilityPublic)
+	hook := &recordingNoteStreamHook{}
+	svc.SetNoteStreamHook(hook)
+
+	_, err := svc.Create(&model.User{ID: "viewer"}, "n1", "👍")
+	require.NoError(t, err)
+	require.Len(t, hook.reacted, 1)
+	assert.Equal(t, "n1", hook.reacted[0].noteID)
+	assert.Equal(t, "viewer", hook.reacted[0].userID)
+	assert.Equal(t, "👍", hook.reacted[0].reaction)
+	assert.Nil(t, hook.reacted[0].emoji)
+	assert.Empty(t, hook.unreacted)
+}
+
+// ローカルカスタム絵文字なら emoji 名 `name@.` と publicUrl が wire 化される。
+func TestService_NoteStreamHook_OnCreate_LocalCustomEmoji(t *testing.T) {
+	svc, repo, _, emojiRepo, _ := newService(t)
+	seedNote(repo, "n1", "author", model.NoteVisibilityPublic)
+	emojiRepo.Emojis["smile@"] = &model.Emoji{
+		Name:        "smile",
+		PublicURL:   "https://example.test/emoji/smile.webp",
+		OriginalURL: "https://example.test/emoji/smile-orig.webp",
+	}
+	hook := &recordingNoteStreamHook{}
+	svc.SetNoteStreamHook(hook)
+
+	_, err := svc.Create(&model.User{ID: "viewer"}, "n1", ":smile:")
+	require.NoError(t, err)
+	require.Len(t, hook.reacted, 1)
+	assert.Equal(t, ":smile@.:", hook.reacted[0].reaction)
+	require.NotNil(t, hook.reacted[0].emoji)
+	assert.Equal(t, "smile@.", hook.reacted[0].emoji.Name)
+	assert.Equal(t, "https://example.test/emoji/smile.webp", hook.reacted[0].emoji.URL)
+}
+
+// publicUrl 空なら originalUrl にフォールバックする (TS upstream 互換)。
+func TestService_NoteStreamHook_OnCreate_PublicURLFallbackToOriginal(t *testing.T) {
+	svc, repo, _, emojiRepo, _ := newService(t)
+	seedNote(repo, "n1", "author", model.NoteVisibilityPublic)
+	emojiRepo.Emojis["smile@"] = &model.Emoji{
+		Name:        "smile",
+		PublicURL:   "",
+		OriginalURL: "https://example.test/emoji/smile-orig.webp",
+	}
+	hook := &recordingNoteStreamHook{}
+	svc.SetNoteStreamHook(hook)
+
+	_, err := svc.Create(&model.User{ID: "viewer"}, "n1", ":smile:")
+	require.NoError(t, err)
+	require.Len(t, hook.reacted, 1)
+	require.NotNil(t, hook.reacted[0].emoji)
+	assert.Equal(t, "https://example.test/emoji/smile-orig.webp", hook.reacted[0].emoji.URL)
+}
+
+// リモートカスタム絵文字は `name@host` で wire 化される。
+func TestService_NoteStreamHook_OnCreate_RemoteCustomEmoji(t *testing.T) {
+	svc, repo, _, emojiRepo, _ := newService(t)
+	seedNote(repo, "n1", "author", model.NoteVisibilityPublic)
+	host := "remote.example"
+	emojiRepo.Emojis["smile@remote.example"] = &model.Emoji{
+		Name:      "smile",
+		Host:      &host,
+		PublicURL: "https://remote.example/emoji/smile.webp",
+	}
+	hook := &recordingNoteStreamHook{}
+	svc.SetNoteStreamHook(hook)
+
+	_, err := svc.Create(&model.User{ID: "viewer"}, "n1", ":smile@remote.example:")
+	require.NoError(t, err)
+	require.Len(t, hook.reacted, 1)
+	assert.Equal(t, ":smile@remote.example:", hook.reacted[0].reaction)
+	require.NotNil(t, hook.reacted[0].emoji)
+	assert.Equal(t, "smile@remote.example", hook.reacted[0].emoji.Name)
+}
+
+// Delete 経路で `unreacted` が `:name@.:` 形式で publish される。
+func TestService_NoteStreamHook_OnDelete(t *testing.T) {
+	svc, repo, _, emojiRepo, _ := newService(t)
+	seedNote(repo, "n1", "author", model.NoteVisibilityPublic)
+	emojiRepo.Emojis["smile@"] = &model.Emoji{Name: "smile"}
+	hook := &recordingNoteStreamHook{}
+	svc.SetNoteStreamHook(hook)
+
+	_, err := svc.Create(&model.User{ID: "viewer"}, "n1", ":smile:")
+	require.NoError(t, err)
+	require.NoError(t, svc.Delete(&model.User{ID: "viewer"}, "n1"))
+	require.Len(t, hook.unreacted, 1)
+	assert.Equal(t, "n1", hook.unreacted[0].noteID)
+	assert.Equal(t, "viewer", hook.unreacted[0].userID)
+	assert.Equal(t, ":smile@.:", hook.unreacted[0].reaction)
+}
+
+// 同じ user が別 reaction に置き換えた場合は upstream 互換で reacted のみ
+// 1 度だけ発火、unreacted は走らない。
+func TestService_NoteStreamHook_OnReplace_NoUnreacted(t *testing.T) {
+	svc, repo, _, _, _ := newService(t)
+	seedNote(repo, "n1", "author", model.NoteVisibilityPublic)
+	hook := &recordingNoteStreamHook{}
+	svc.SetNoteStreamHook(hook)
+
+	_, err := svc.Create(&model.User{ID: "viewer"}, "n1", "👍")
+	require.NoError(t, err)
+	_, err = svc.Create(&model.User{ID: "viewer"}, "n1", "🎉")
+	require.NoError(t, err)
+	require.Len(t, hook.reacted, 2)
+	assert.Equal(t, "👍", hook.reacted[0].reaction)
+	assert.Equal(t, "🎉", hook.reacted[1].reaction)
+	assert.Empty(t, hook.unreacted, "置き換え経路では unreacted は呼ばない (upstream 挙動)")
+}
+
+// 古い `:name:` 形式 (TS-era DB レコード) で保存された reaction を Delete
+// した場合も canonical `:name@.:` で wire 化される。
+func TestService_NoteStreamHook_OnDelete_LegacyShortForm(t *testing.T) {
+	svc, noteRepo, reactRepo, _, _ := newService(t)
+	seedNote(noteRepo, "n1", "author", model.NoteVisibilityPublic)
+	// Delete 経路は reactRepo.FindByPair で legacy `:smile:` 形式の record を
+	// 拾う想定。canonical 化は decodeReactionForStream が担う。
+	reactRepo.Reactions["legacy"] = &model.NoteReaction{
+		ID:       "legacy",
+		UserID:   "viewer",
+		NoteID:   "n1",
+		Reaction: ":smile:",
+	}
+	hook := &recordingNoteStreamHook{}
+	svc.SetNoteStreamHook(hook)
+
+	require.NoError(t, svc.Delete(&model.User{ID: "viewer"}, "n1"))
+	require.Len(t, hook.unreacted, 1)
+	assert.Equal(t, ":smile@.:", hook.unreacted[0].reaction)
+}

--- a/internal/server/router.go
+++ b/internal/server/router.go
@@ -1564,10 +1564,15 @@ func (s *Server) setupRoutes() {
 	streamPubSub := event.NewPubSubService(s.redis.Pubsub, "stream:")
 	streamBus := stream.NewEventPubSubBus(streamPubSub)
 
-	// pollVoted の noteStream publish 用に core/poll.Service へ event publisher
-	// を後付け配線する (#690)。Service 自体は streamPubSub 生成より前に作る
-	// ため、ここで SetEventPublisher する。
-	pollService.SetEventPublisher(stream.NewNoteEventPublisher(streamPubSub))
+	// pollVoted / reacted / unreacted / deleted を noteStream:<id> に publish
+	// する共通 publisher。subNote / sn メッセージで購読しているクライアントへ
+	// リアクション・削除イベントが流れる (#690 / #700)。pollService /
+	// reactionService / noteDeleteService は streamPubSub 生成より前に作るため、
+	// ここで後付け配線する。
+	noteEventPub := stream.NewNoteEventPublisher(streamPubSub)
+	pollService.SetEventPublisher(noteEventPub)
+	reactionService.SetNoteStreamHook(&reactionNoteStreamAdapter{pub: noteEventPub})
+	noteDeleteService.SetNoteStreamHook(&noteDeleteStreamAdapter{pub: noteEventPub})
 
 	// 2. Channel registry: Misskey 互換のチャンネル名で各 factory を登録する
 	streamRegistry := stream.NewRegistry()
@@ -2433,6 +2438,45 @@ type notifReaderAdapter struct {
 
 func (a *notifReaderAdapter) ReadAll(userID string) error {
 	return a.svc.MarkAllAsRead(context.Background(), userID)
+}
+
+// reactionNoteStreamAdapter bridges core/reaction.NoteStreamHook to the
+// shared stream.NoteEventPublisher. Misskey TS upstream の wire format に
+// 揃え、`{type: "reacted"|"unreacted", body: {reaction, emoji?, userId}}`
+// を `noteStream:<noteID>` に publish する (#700)。
+type reactionNoteStreamAdapter struct {
+	pub *stream.NoteEventPublisher
+}
+
+func (a *reactionNoteStreamAdapter) OnReacted(noteID, userID, reaction string, emoji *corereaction.NoteStreamEmoji) {
+	body := map[string]any{
+		"reaction": reaction,
+		"userId":   userID,
+		"emoji":    nil,
+	}
+	if emoji != nil {
+		body["emoji"] = map[string]any{"name": emoji.Name, "url": emoji.URL}
+	}
+	a.pub.PublishToNoteStream(noteID, "reacted", body)
+}
+
+func (a *reactionNoteStreamAdapter) OnUnreacted(noteID, userID, reaction string) {
+	a.pub.PublishToNoteStream(noteID, "unreacted", map[string]any{
+		"reaction": reaction,
+		"userId":   userID,
+	})
+}
+
+// noteDeleteStreamAdapter bridges core/note.DeleteNoteStreamHook to the
+// shared stream.NoteEventPublisher (#700)。
+type noteDeleteStreamAdapter struct {
+	pub *stream.NoteEventPublisher
+}
+
+func (a *noteDeleteStreamAdapter) OnNoteDeleted(noteID string, deletedAt time.Time) {
+	a.pub.PublishToNoteStream(noteID, "deleted", map[string]any{
+		"deletedAt": deletedAt.UTC().Format(time.RFC3339Nano),
+	})
 }
 
 // instanceActorSigner is the SignerProvider used by APFetcher to sign


### PR DESCRIPTION
## Summary

WebSocket の `subNote` / `sn` で購読したクライアントへ note 単位のイベントを
push する仕組みは dispatcher 側で実装済みだったが、publish 側が `pollVoted`
(#690) のみで `reacted` / `unreacted` / `deleted` が欠落していた。結果として
note 詳細ページや subNote 購読中の TL ではリアクション付与/削除や note 削除が
リロード無しで反映されなかった (UDS でも再現確認済)。

## upstream の publishNoteStream 呼び出し点

`third_party/misskey/packages/backend/src/core` を grep:

| File:Line | event | payload |
|---|---|---|
| ReactionService.ts:247 | reacted | `{reaction, emoji: {name, url} \| null, userId}` |
| ReactionService.ts:321 | unreacted | `{reaction, userId}` |
| NoteDeleteService.ts:71 | deleted | `{deletedAt}` |
| PollService.ts:86 | pollVoted | (実装済み #690) |

## 主な変更点

### `internal/core/reaction/reaction_service.go`

- `NoteStreamHook` interface 追加 (既存の FederationHook / ChartHook と同じ設計)
- `Service.Create` 成功後に `OnReacted`、`Service.Delete` 成功後に `OnUnreacted` を発火
- emoji 解決ヘルパー `resolveStreamEmoji` を追加。reaction service 既存の
  `emojiRepo` を流用、URL は `publicUrl || originalUrl` (upstream 互換)
- reaction 文字列を `decodeReactionForStream` で `:name@host:` / `:name@.:` に
  正規化してから wire 化 → TS-era の legacy `:name:` 形式 record でも
  frontend 互換

### `internal/core/note/note_delete_service.go`

- `DeleteNoteStreamHook` interface 追加
- `DeleteService.Delete` 成功後に `OnNoteDeleted(noteID, deletedAt)` を発火

### `internal/server/router.go`

- pollService と同じ `noteEventPub := stream.NewNoteEventPublisher(streamPubSub)`
  を共通化し、reaction/noteDelete 用の adapter 2 つを追加して配線
- adapter は wire format (`{type, body}`) を構築して `noteStream:<id>` に publish

federation processor 経由の inbound Like / Undo Like も同じ Service.Create /
Delete を通るため、リモートからの reaction も自動で stream へ流れる
(upstream 互換)。

## テスト

- `reaction_service_test.go`: hook 発火を unicode / local custom / remote custom /
  publicUrl fallback / 置き換え時 (unreacted 不発火) / legacy short form の 6 ケースで網羅
- `note_delete_service_test.go`: hook 発火 / 失敗時不発火 の 2 ケース
- `make test` 全 pass、`make lint` / `make fmt` クリーン
- カバレッジ: reaction 93.2%, note 93.5% (90% 閾値クリア)

```
go test -race -count=1 ./internal/core/reaction/... ./internal/core/note/... ./internal/server/...
```

## UDS 動作確認

- reacted: 他人のリアクション付与がリロード無しで反映 ✓
- unreacted: 取り消しがリロード無しで反映 ✓
- deleted: 削除がリロード無しで反映 ✓

## Closes

Closes #700

🤖 Generated with [Claude Code](https://claude.com/claude-code)