### PR TITLE
Fix #703: UDS 経由で signin / user_ip の IP が空文字で記録されるバグ

### DIFF
--- a/internal/server/ip_extractor_test.go
+++ b/internal/server/ip_extractor_test.go
@@ -104,3 +104,51 @@ func TestExtractIPFallback_XFFAllUnparseableFallbackToRealIP(t *testing.T) {
 	got := extractIPFallback(req, trusted)
 	assert.Equal(t, "203.0.113.99", got)
 }
+
+// 通常の TCP listen 経路 (RemoteAddr あり) では inner extractor の結果を
+// そのまま返し fallback は走らない。wire path の regression を防ぐ。
+func TestBuildIPExtractor_TCPDirectPath(t *testing.T) {
+	extractor := buildIPExtractor(parseTrustedDefault(t))
+	req, _ := http.NewRequest(http.MethodGet, "/", nil)
+	// 通常 TCP では net.SplitHostPort で取れる形式
+	req.RemoteAddr = "203.0.113.42:54321"
+
+	got := extractor(req)
+	assert.Equal(t, "203.0.113.42", got)
+}
+
+// inner extractor が untrusted な valid IP を返した場合そのまま返す。
+// trustProxy 越しに正規にアクセスされたケース。
+func TestBuildIPExtractor_TrustedProxyXFF(t *testing.T) {
+	extractor := buildIPExtractor(parseTrustedDefault(t))
+	req, _ := http.NewRequest(http.MethodGet, "/", nil)
+	req.RemoteAddr = "172.21.0.5:12345" // trusted (private)
+	req.Header.Set("X-Forwarded-For", "203.0.113.7, 172.21.0.1")
+
+	got := extractor(req)
+	assert.Equal(t, "203.0.113.7", got)
+}
+
+// UDS 経由 (RemoteAddr="") で inner が空を返すケースを fallback が拾う。
+// 本 PR の regression を直接 lock down する critical path。
+func TestBuildIPExtractor_UDSFallbackPath(t *testing.T) {
+	extractor := buildIPExtractor(parseTrustedDefault(t))
+	req, _ := http.NewRequest(http.MethodGet, "/", nil)
+	req.RemoteAddr = "" // UDS
+	req.Header.Set("X-Forwarded-For", "2405:6585:d720:e4:a090:d3d9:7372:f96a, 172.21.0.1")
+
+	got := extractor(req)
+	assert.Equal(t, "2405:6585:d720:e4:a090:d3d9:7372:f96a", got)
+}
+
+// trusted 引数が nil/空でも buildIPExtractor 自体は構築できる
+// (router 側では len(nets) > 0 で配線するため通常は呼ばれないが、
+// API として nil-safe であることの保険)。
+func TestBuildIPExtractor_NoTrustedRanges(t *testing.T) {
+	extractor := buildIPExtractor(nil)
+	req, _ := http.NewRequest(http.MethodGet, "/", nil)
+	req.RemoteAddr = "203.0.113.42:54321"
+
+	got := extractor(req)
+	assert.Equal(t, "203.0.113.42", got)
+}

--- a/internal/server/ip_extractor_test.go
+++ b/internal/server/ip_extractor_test.go
@@ -1,0 +1,106 @@
+package server
+
+import (
+	"net"
+	"net/http"
+	"testing"
+
+	"github.com/shiroha-a/mk/internal/config"
+	"github.com/stretchr/testify/assert"
+)
+
+// parseTrustedDefault は extractIPFallback / IPExtractor wrap のテスト用に
+// DefaultTrustProxy を *net.IPNet 配列に展開するヘルパ。
+func parseTrustedDefault(t *testing.T) []*net.IPNet {
+	t.Helper()
+	return config.ParseTrustProxy(config.DefaultTrustProxy)
+}
+
+// UDS 経由 (RemoteAddr 空 + nginx が XFF を埋めるケース) で client IP が
+// 抽出できることを確認する。Echo 標準 extractor が壊れる #703 の根本原因
+// に対応する fallback の主目的。
+func TestExtractIPFallback_UDSWithXFF(t *testing.T) {
+	trusted := parseTrustedDefault(t)
+	req, _ := http.NewRequest(http.MethodGet, "/", nil)
+	// nginx -> mkgo (UDS) では RemoteAddr は "" のまま、XFF に
+	// Cloudflare → nginx の経路が積まれる。
+	req.RemoteAddr = ""
+	req.Header.Set("X-Forwarded-For", "2405:6585:d720:e4:a090:d3d9:7372:f96a, 172.21.0.1")
+
+	got := extractIPFallback(req, trusted)
+	assert.Equal(t, "2405:6585:d720:e4:a090:d3d9:7372:f96a", got)
+}
+
+// 角括弧付き IPv6 (Cloudflare が時々送る形式) も剥がして parse できる。
+func TestExtractIPFallback_BracketedIPv6(t *testing.T) {
+	trusted := parseTrustedDefault(t)
+	req, _ := http.NewRequest(http.MethodGet, "/", nil)
+	req.Header.Set("X-Forwarded-For", "[2405:6585:d720:e4:a090:d3d9:7372:f96a], 172.21.0.1")
+
+	got := extractIPFallback(req, trusted)
+	assert.Equal(t, "2405:6585:d720:e4:a090:d3d9:7372:f96a", got)
+}
+
+// XFF が無く X-Real-IP のみ来るケース (一部 proxy / Cloudflare 単独) でも
+// 取れる。
+func TestExtractIPFallback_RealIPOnly(t *testing.T) {
+	trusted := parseTrustedDefault(t)
+	req, _ := http.NewRequest(http.MethodGet, "/", nil)
+	req.Header.Set("X-Real-IP", "203.0.113.7")
+
+	got := extractIPFallback(req, trusted)
+	assert.Equal(t, "203.0.113.7", got)
+}
+
+// XFF / X-Real-IP どちらも無い場合 (例: 内部ヘルスチェック等) は空文字を
+// 返す。これは fallback 経路として正しい挙動 (Echo 標準も同じ振る舞い)。
+func TestExtractIPFallback_NoHeaders(t *testing.T) {
+	trusted := parseTrustedDefault(t)
+	req, _ := http.NewRequest(http.MethodGet, "/", nil)
+
+	got := extractIPFallback(req, trusted)
+	assert.Equal(t, "", got)
+}
+
+// XFF 中に解析不能な値が混じっていても、その後ろの解析可能な untrusted IP
+// を拾える (Echo 標準は早期 return で directIP を返してしまう)。
+func TestExtractIPFallback_SkipsUnparseableEntries(t *testing.T) {
+	trusted := parseTrustedDefault(t)
+	req, _ := http.NewRequest(http.MethodGet, "/", nil)
+	req.Header.Set("X-Forwarded-For", "203.0.113.42, garbage, 172.21.0.1")
+
+	got := extractIPFallback(req, trusted)
+	assert.Equal(t, "203.0.113.42", got)
+}
+
+// 全 IP が trusted ranges 内なら left-most の parseable IP を返す。
+// 内部だけで完結する request 用の best-effort fallback。
+func TestExtractIPFallback_AllTrustedReturnsLeftmost(t *testing.T) {
+	trusted := parseTrustedDefault(t)
+	req, _ := http.NewRequest(http.MethodGet, "/", nil)
+	req.Header.Set("X-Forwarded-For", "10.1.2.3, 172.16.0.5")
+
+	got := extractIPFallback(req, trusted)
+	assert.Equal(t, "10.1.2.3", got)
+}
+
+// X-Real-IP に角括弧付き IPv6 が来てもそのまま剥がす。
+func TestExtractIPFallback_RealIPBracketedIPv6(t *testing.T) {
+	trusted := parseTrustedDefault(t)
+	req, _ := http.NewRequest(http.MethodGet, "/", nil)
+	req.Header.Set("X-Real-IP", "[2001:db8::1]")
+
+	got := extractIPFallback(req, trusted)
+	assert.Equal(t, "2001:db8::1", got)
+}
+
+// XFF 全部解析不能なら X-Real-IP に fallback する。
+func TestExtractIPFallback_XFFAllUnparseableFallbackToRealIP(t *testing.T) {
+	trusted := parseTrustedDefault(t)
+	req, _ := http.NewRequest(http.MethodGet, "/", nil)
+	req.Header.Set("X-Forwarded-For", "garbage1, garbage2")
+	req.Header.Set("X-Real-IP", "203.0.113.99")
+
+	got := extractIPFallback(req, trusted)
+	assert.Equal(t, "203.0.113.99", got)
+}

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -52,6 +52,30 @@ func (s *Server) registerShutdownHook(fn func()) {
 	s.shutdownHooks = append(s.shutdownHooks, fn)
 }
 
+// buildIPExtractor returns an echo.IPExtractor that wraps Echo's standard
+// XFF extractor with a UDS-safe fallback. Echo 標準の ExtractIPFromXFFHeader
+// (echo/ip.go:252) は req.RemoteAddr が空文字 (UNIX domain socket 経由のとき
+// net.SplitHostPort が "" を返す) のとき XFF 逆順走査で net.ParseIP("") が
+// nil → directIP="" を早期 return してしまい、c.RealIP() が常に空文字を
+// 返す。signin record / user_ip 記録 / rate-limit が破壊されるため (#703)、
+// inner が空文字を返したケースのみ extractIPFallback で補う。
+//
+// 通常 (TCP listen) 経路では inner が valid IP を返すため fallback は走らず、
+// 既存挙動と完全に互換。
+func buildIPExtractor(trusted []*net.IPNet) echo.IPExtractor {
+	opts := make([]echo.TrustOption, 0, len(trusted))
+	for _, n := range trusted {
+		opts = append(opts, echo.TrustIPRange(n))
+	}
+	inner := echo.ExtractIPFromXFFHeader(opts...)
+	return func(req *http.Request) string {
+		if ip := inner(req); ip != "" {
+			return ip
+		}
+		return extractIPFallback(req, trusted)
+	}
+}
+
 // extractIPFallback recovers a client IP for requests where Echo's standard
 // extractor would return empty (typically UNIX domain socket connections
 // with no RemoteAddr, behind nginx + UDS). XFF を逆順に走査し trusted ranges
@@ -129,25 +153,9 @@ func New(cfg *config.Config, db *gorm.DB, redis *cache.RedisClients) (*Server, e
 	// reflection cost が下がって全 endpoint が広く高速化する。
 	e.JSONSerializer = fastJSONSerializer{}
 
-	// trustProxyからIPExtractorを構成。Echo 標準の ExtractIPFromXFFHeader
-	// (echo/ip.go:252) は req.RemoteAddr が空文字 (UNIX domain socket 経由
-	// のとき net.SplitHostPort が "" を返す) のとき XFF 逆順走査で
-	// net.ParseIP("") が nil → directIP="" を早期 return してしまい、結果
-	// として c.RealIP() が常に空文字を返す。signin record / user_ip 記録 /
-	// rate-limit が破壊されるため (#703)、UDS で空が返ったときの fallback
-	// を独自に被せる。
+	// trustProxyからIPExtractorを構成。詳細は buildIPExtractor のコメント。
 	if nets := config.ParseTrustProxy(cfg.TrustProxy); len(nets) > 0 {
-		var opts []echo.TrustOption
-		for _, n := range nets {
-			opts = append(opts, echo.TrustIPRange(n))
-		}
-		inner := echo.ExtractIPFromXFFHeader(opts...)
-		e.IPExtractor = func(req *http.Request) string {
-			if ip := inner(req); ip != "" {
-				return ip
-			}
-			return extractIPFallback(req, nets)
-		}
+		e.IPExtractor = buildIPExtractor(nets)
 	}
 
 	// Global middleware

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -6,7 +6,9 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
+	"net"
 	"net/http"
+	"strings"
 
 	"github.com/labstack/echo/v4"
 	echomw "github.com/labstack/echo/v4/middleware"
@@ -50,6 +52,56 @@ func (s *Server) registerShutdownHook(fn func()) {
 	s.shutdownHooks = append(s.shutdownHooks, fn)
 }
 
+// extractIPFallback recovers a client IP for requests where Echo's standard
+// extractor would return empty (typically UNIX domain socket connections
+// with no RemoteAddr, behind nginx + UDS). XFF を逆順に走査し trusted ranges
+// の外で最初に当たる解析可能な IP を返す。XFF が無ければ X-Real-IP に fallback。
+// 結果が空文字となる場合 (header が一切無い) は "" を返し、上位の機能
+// (signin record / user_ip / rate-limit) は空のまま記録する。
+func extractIPFallback(req *http.Request, trusted []*net.IPNet) string {
+	cleanCandidate := func(s string) string {
+		s = strings.TrimSpace(s)
+		s = strings.TrimPrefix(s, "[")
+		s = strings.TrimSuffix(s, "]")
+		return s
+	}
+	isTrusted := func(ip net.IP) bool {
+		for _, n := range trusted {
+			if n.Contains(ip) {
+				return true
+			}
+		}
+		return false
+	}
+
+	if xff := req.Header.Get("X-Forwarded-For"); xff != "" {
+		parts := strings.Split(xff, ",")
+		// untrusted side (client 側) を逆順走査で見つける
+		for i := len(parts) - 1; i >= 0; i-- {
+			candidate := cleanCandidate(parts[i])
+			ip := net.ParseIP(candidate)
+			if ip == nil {
+				continue
+			}
+			if !isTrusted(ip) {
+				return ip.String()
+			}
+		}
+		// 全部 trusted ranges 内 (典型: client→nginx→mkgo が全部 private) なら
+		// 一番左の解析可能な IP を返す。XFF[0] は upstream proxy が書く client IP。
+		for _, p := range parts {
+			candidate := cleanCandidate(p)
+			if net.ParseIP(candidate) != nil {
+				return candidate
+			}
+		}
+	}
+	if r := cleanCandidate(req.Header.Get("X-Real-IP")); r != "" {
+		return r
+	}
+	return ""
+}
+
 // gzipConfig returns the GzipConfig used by the global middleware stack.
 // Shared with gzip_test.go so production and tests stay in sync.
 func gzipConfig() echomw.GzipConfig {
@@ -77,13 +129,25 @@ func New(cfg *config.Config, db *gorm.DB, redis *cache.RedisClients) (*Server, e
 	// reflection cost が下がって全 endpoint が広く高速化する。
 	e.JSONSerializer = fastJSONSerializer{}
 
-	// trustProxyからIPExtractorを構成
+	// trustProxyからIPExtractorを構成。Echo 標準の ExtractIPFromXFFHeader
+	// (echo/ip.go:252) は req.RemoteAddr が空文字 (UNIX domain socket 経由
+	// のとき net.SplitHostPort が "" を返す) のとき XFF 逆順走査で
+	// net.ParseIP("") が nil → directIP="" を早期 return してしまい、結果
+	// として c.RealIP() が常に空文字を返す。signin record / user_ip 記録 /
+	// rate-limit が破壊されるため (#703)、UDS で空が返ったときの fallback
+	// を独自に被せる。
 	if nets := config.ParseTrustProxy(cfg.TrustProxy); len(nets) > 0 {
 		var opts []echo.TrustOption
 		for _, n := range nets {
 			opts = append(opts, echo.TrustIPRange(n))
 		}
-		e.IPExtractor = echo.ExtractIPFromXFFHeader(opts...)
+		inner := echo.ExtractIPFromXFFHeader(opts...)
+		e.IPExtractor = func(req *http.Request) string {
+			if ip := inner(req); ip != "" {
+				return ip
+			}
+			return extractIPFallback(req, nets)
+		}
 	}
 
 	// Global middleware


### PR DESCRIPTION
## Summary

UDS (UNIX domain socket) 経由で listen している環境で、設定→セキュリティ→ログイン履歴の IP 欄、およびモデレーション→ユーザー IP 履歴の IP 欄が空文字で記録されていた。

## Root cause

echo v4 の \`ExtractIPFromXFFHeader\` (\`echo/ip.go:252\`) の挙動:

\`\`\`go
ips := append(strings.Split(xffs, ","), directIP)
for i := len(ips) - 1; i >= 0; i-- {
    ip := net.ParseIP(ips[i])
    if ip == nil { return directIP }   // ← UDS では directIP="" になる
    ...
}
\`\`\`

UDS で listen している場合 \`http.Request.RemoteAddr\` は空文字になり、Echo が空文字を ips に append する。逆順走査で空文字を最初に見て \`net.ParseIP\` が nil → 早期 return path で directIP="" を返してしまう。結果 \`c.RealIP()\` が常に "" を返し、\`recordSignin\` / \`userIPRepo.Upsert\` / rate-limit が全部空 IP で動作していた。

実 DB 状態で確認:
\`\`\`
signin:  ip="" (5 件全て)
user_ip: ip="" (1 件)
\`\`\`

## 主な変更点

### \`internal/server/server.go\`

\`trustProxy\` 設定下で組んだ \`echo.ExtractIPFromXFFHeader(...)\` の結果を mk-go 独自 \`extractIPFallback\` で wrap:

- 空文字が返ってきた場合のみ fallback を起動 (通常経路は影響を受けない)
- X-Forwarded-For を逆順に走査し trusted ranges 外の最初の解析可能 IP を返す
- 全部 trusted なら left-most の解析可能 IP を返す (best-effort)
- XFF が無ければ X-Real-IP に fallback
- どれも取れなければ "" (Echo 標準と同じ降伏挙動)

## テスト

\`internal/server/ip_extractor_test.go\` 新設、8 ケース:

- \`UDSWithXFF\`: 本 issue の再現ケース (UDS + XFF) で client IPv6 が取れる
- \`BracketedIPv6\`: XFF 内の \`[2001:db8::1]\` 形式を剥がして parse
- \`RealIPOnly\`: XFF が無く X-Real-IP のみのケース
- \`NoHeaders\`: header 一切無しで "" を返す降伏挙動
- \`SkipsUnparseableEntries\`: garbage が混じっていても後続の untrusted IP を拾う
- \`AllTrustedReturnsLeftmost\`: 全部 trusted ranges 内なら left-most
- \`RealIPBracketedIPv6\`: X-Real-IP 内の角括弧付き IPv6 も剥がす
- \`XFFAllUnparseableFallbackToRealIP\`: XFF 全滅時に X-Real-IP に fallback

\`make fmt\` / \`make lint\` クリーン、\`go test ./internal/server/...\` 全 pass。

## 動作確認

UDS 経由で nginx + Cloudflare 構成で再ログインし、\`signin.ip\` および \`user_ip.ip\` カラムに client の実 IPv6 が記録されることを確認済み。

## 互換性

- 通常 (TCP listen) 経路は inner extractor が空文字以外を返すため影響なし
- 既存の \`signin\` / \`user_ip\` record (ip="" のもの) は backfill しない。新規ログインから正しい IP が入る

## Closes

Closes #703

🤖 Generated with [Claude Code](https://claude.com/claude-code)