### PR TITLE
Fix #709: testutil.MockChatRepository に chat repo stub を集約

### DIFF
--- a/internal/api/chat/handler_test.go
+++ b/internal/api/chat/handler_test.go
@@ -15,150 +15,15 @@ import (
 	"github.com/shiroha-a/mk/internal/misc/id"
 	"github.com/shiroha-a/mk/internal/model"
 	"github.com/shiroha-a/mk/internal/server/middleware"
+	"github.com/shiroha-a/mk/internal/testutil"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
 var errMock = assert.AnError
 
-type mockChatRepo struct {
-	rooms       map[string]*model.ChatRoom
-	messages    map[string]*model.ChatMessage
-	memberships map[string]*model.ChatRoomMembership
-	invitations map[string]*model.ChatRoomInvitation
-	createErr   error
-}
-
-func newMock() *mockChatRepo {
-	return &mockChatRepo{
-		rooms:       make(map[string]*model.ChatRoom),
-		messages:    make(map[string]*model.ChatMessage),
-		memberships: make(map[string]*model.ChatRoomMembership),
-		invitations: make(map[string]*model.ChatRoomInvitation),
-	}
-}
-
-func (m *mockChatRepo) CreateRoom(r *model.ChatRoom) error {
-	if m.createErr != nil {
-		return m.createErr
-	}
-	m.rooms[r.ID] = r
-	return nil
-}
-func (m *mockChatRepo) FindRoomByID(id string) (*model.ChatRoom, error) {
-	if r, ok := m.rooms[id]; ok {
-		return r, nil
-	}
-	return nil, errMock
-}
-func (m *mockChatRepo) UpdateRoom(r *model.ChatRoom) error { m.rooms[r.ID] = r; return nil }
-func (m *mockChatRepo) DeleteRoom(id string) error         { delete(m.rooms, id); return nil }
-func (m *mockChatRepo) ListRoomsByOwner(ownerID string) ([]*model.ChatRoom, error) {
-	var result []*model.ChatRoom
-	for _, r := range m.rooms {
-		if r.OwnerID == ownerID {
-			result = append(result, r)
-		}
-	}
-	return result, nil
-}
-func (m *mockChatRepo) ListJoinedRooms(_ string) ([]*model.ChatRoom, error) {
-	return []*model.ChatRoom{}, nil
-}
-func (m *mockChatRepo) CreateMessage(msg *model.ChatMessage) error {
-	if m.createErr != nil {
-		return m.createErr
-	}
-	m.messages[msg.ID] = msg
-	return nil
-}
-func (m *mockChatRepo) FindMessageByID(id string) (*model.ChatMessage, error) {
-	if msg, ok := m.messages[id]; ok {
-		return msg, nil
-	}
-	return nil, errMock
-}
-func (m *mockChatRepo) UpdateMessage(msg *model.ChatMessage) error {
-	m.messages[msg.ID] = msg
-	return nil
-}
-func (m *mockChatRepo) DeleteMessage(id string) error { delete(m.messages, id); return nil }
-func (m *mockChatRepo) ListMessagesByRoom(_ string, _ int) ([]*model.ChatMessage, error) {
-	return []*model.ChatMessage{}, nil
-}
-func (m *mockChatRepo) ListMessagesByUser(_, _ string, _ int) ([]*model.ChatMessage, error) {
-	return []*model.ChatMessage{}, nil
-}
-func (m *mockChatRepo) SearchMessages(_, _ string, _ int) ([]*model.ChatMessage, error) {
-	return []*model.ChatMessage{}, nil
-}
-func (m *mockChatRepo) CreateMembership(mem *model.ChatRoomMembership) error {
-	m.memberships[mem.UserID+":"+mem.RoomID] = mem
-	return nil
-}
-func (m *mockChatRepo) FindMembership(userID, roomID string) (*model.ChatRoomMembership, error) {
-	if mem, ok := m.memberships[userID+":"+roomID]; ok {
-		return mem, nil
-	}
-	return nil, errMock
-}
-func (m *mockChatRepo) UpdateMembership(mem *model.ChatRoomMembership) error {
-	m.memberships[mem.UserID+":"+mem.RoomID] = mem
-	return nil
-}
-func (m *mockChatRepo) DeleteMembership(userID, roomID string) error {
-	delete(m.memberships, userID+":"+roomID)
-	return nil
-}
-func (m *mockChatRepo) ListMembersByRoom(_ string) ([]*model.ChatRoomMembership, error) {
-	return []*model.ChatRoomMembership{}, nil
-}
-func (m *mockChatRepo) CreateInvitation(inv *model.ChatRoomInvitation) error {
-	if m.createErr != nil {
-		return m.createErr
-	}
-	m.invitations[inv.ID] = inv
-	return nil
-}
-func (m *mockChatRepo) DeleteInvitation(id string) error { delete(m.invitations, id); return nil }
-func (m *mockChatRepo) FindInvitation(userID, roomID string) (*model.ChatRoomInvitation, error) {
-	for _, inv := range m.invitations {
-		if inv.UserID == userID && inv.RoomID == roomID {
-			return inv, nil
-		}
-	}
-	return nil, errMock
-}
-func (m *mockChatRepo) CountUnread(_ string) (int64, error) { return 0, nil }
-func (m *mockChatRepo) MarkRead(_, _ string) error          { return nil }
-func (m *mockChatRepo) ListInvitationsByUser(_ string, _ bool) ([]*model.ChatRoomInvitation, error) {
-	return nil, nil
-}
-func (m *mockChatRepo) ListInvitationsByRoom(_ string) ([]*model.ChatRoomInvitation, error) {
-	return nil, nil
-}
-func (m *mockChatRepo) UpdateDeliveryStatus(_ string, _, _ bool) error { return nil }
-func (m *mockChatRepo) ListHistory(_ string, _ int) ([]*model.ChatMessage, error) {
-	return nil, nil
-}
-func (m *mockChatRepo) ListUserHistory(_ string, _ int) ([]*model.ChatMessage, error) {
-	return nil, nil
-}
-func (m *mockChatRepo) ListRoomHistory(_ string, _ int) ([]*model.ChatMessage, error) {
-	return nil, nil
-}
-func (m *mockChatRepo) MarkAllRead(_ string) error                         { return nil }
-func (m *mockChatRepo) MarkAllReadFromUser(_, _ string) error              { return nil }
-func (m *mockChatRepo) MarkAllReadInRoom(_, _ string) error                { return nil }
-func (m *mockChatRepo) AddReaction(_, _ string) error                      { return nil }
-func (m *mockChatRepo) RemoveReaction(_, _ string) error                   { return nil }
-func (m *mockChatRepo) UpdateInvitation(_ *model.ChatRoomInvitation) error { return nil }
-func (m *mockChatRepo) FindMessageByURI(_ string) (*model.ChatMessage, error) {
-	return nil, errors.New("not found")
-}
-
-func newTestHandler() (*Handler, *mockChatRepo) {
-	repo := newMock()
+func newTestHandler() (*Handler, *testutil.MockChatRepository) {
+	repo := testutil.NewMockChatRepository()
 	idGen, _ := id.NewGenerator("aidx")
 	return NewHandler(repo, idGen), repo
 }
@@ -185,7 +50,7 @@ func TestRoomsCreate_Success(t *testing.T) {
 	h, repo := newTestHandler()
 	rec := post(h.RoomsCreate, `{"name":"test room"}`, u1)
 	assert.Equal(t, http.StatusOK, rec.Code)
-	assert.Len(t, repo.rooms, 1)
+	assert.Len(t, repo.Rooms, 1)
 }
 
 func TestRoomsCreate_InvalidParam(t *testing.T) {
@@ -196,14 +61,14 @@ func TestRoomsCreate_InvalidParam(t *testing.T) {
 
 func TestRoomsCreate_Error(t *testing.T) {
 	h, repo := newTestHandler()
-	repo.createErr = errMock
+	repo.CreateErr = errMock
 	rec := post(h.RoomsCreate, `{"name":"x"}`, u1)
 	assert.Equal(t, http.StatusInternalServerError, rec.Code)
 }
 
 func TestRoomsShow_Success(t *testing.T) {
 	h, repo := newTestHandler()
-	repo.rooms["r1"] = &model.ChatRoom{ID: "r1", Name: "room", OwnerID: "u1", Owner: u1}
+	repo.Rooms["r1"] = &model.ChatRoom{ID: "r1", Name: "room", OwnerID: "u1", Owner: u1}
 	rec := post(h.RoomsShow, `{"roomId":"r1"}`, u1)
 	assert.Equal(t, http.StatusOK, rec.Code)
 }
@@ -222,7 +87,7 @@ func TestRoomsShow_InvalidParam(t *testing.T) {
 
 func TestRoomsUpdate_Success(t *testing.T) {
 	h, repo := newTestHandler()
-	repo.rooms["r1"] = &model.ChatRoom{ID: "r1", Name: "old", OwnerID: "u1"}
+	repo.Rooms["r1"] = &model.ChatRoom{ID: "r1", Name: "old", OwnerID: "u1"}
 	rec := post(h.RoomsUpdate, `{"roomId":"r1","name":"new"}`, u1)
 	assert.Equal(t, http.StatusOK, rec.Code)
 	var resp map[string]any
@@ -232,7 +97,7 @@ func TestRoomsUpdate_Success(t *testing.T) {
 
 func TestRoomsUpdate_NotOwner(t *testing.T) {
 	h, repo := newTestHandler()
-	repo.rooms["r1"] = &model.ChatRoom{ID: "r1", OwnerID: "other"}
+	repo.Rooms["r1"] = &model.ChatRoom{ID: "r1", OwnerID: "other"}
 	rec := post(h.RoomsUpdate, `{"roomId":"r1"}`, u1)
 	assert.Equal(t, http.StatusNotFound, rec.Code)
 }
@@ -243,13 +108,13 @@ func TestRoomsUpdate_InvalidParam(t *testing.T) {
 	assert.Equal(t, http.StatusBadRequest, rec.Code)
 }
 
-type failUpdateRoomRepo struct{ *mockChatRepo }
+type failUpdateRoomRepo struct{ *testutil.MockChatRepository }
 
 func (f *failUpdateRoomRepo) UpdateRoom(_ *model.ChatRoom) error { return errMock }
 
 func TestRoomsUpdate_Error(t *testing.T) {
-	base := newMock()
-	base.rooms["r1"] = &model.ChatRoom{ID: "r1", Name: "x", OwnerID: "u1"}
+	base := testutil.NewMockChatRepository()
+	base.Rooms["r1"] = &model.ChatRoom{ID: "r1", Name: "x", OwnerID: "u1"}
 	idGen, _ := id.NewGenerator("aidx")
 	h := NewHandler(&failUpdateRoomRepo{base}, idGen)
 	rec := post(h.RoomsUpdate, `{"roomId":"r1","name":"y"}`, u1)
@@ -258,7 +123,7 @@ func TestRoomsUpdate_Error(t *testing.T) {
 
 func TestRoomsDelete_Success(t *testing.T) {
 	h, repo := newTestHandler()
-	repo.rooms["r1"] = &model.ChatRoom{ID: "r1", OwnerID: "u1"}
+	repo.Rooms["r1"] = &model.ChatRoom{ID: "r1", OwnerID: "u1"}
 	rec := post(h.RoomsDelete, `{"roomId":"r1"}`, u1)
 	assert.Equal(t, http.StatusNoContent, rec.Code)
 }
@@ -271,14 +136,14 @@ func TestRoomsDelete_InvalidParam(t *testing.T) {
 
 func TestRoomsDelete_NotOwner(t *testing.T) {
 	h, repo := newTestHandler()
-	repo.rooms["r1"] = &model.ChatRoom{ID: "r1", OwnerID: "other"}
+	repo.Rooms["r1"] = &model.ChatRoom{ID: "r1", OwnerID: "other"}
 	rec := post(h.RoomsDelete, `{"roomId":"r1"}`, u1)
 	assert.Equal(t, http.StatusNotFound, rec.Code)
 }
 
 func TestRoomsOwned(t *testing.T) {
 	h, repo := newTestHandler()
-	repo.rooms["r1"] = &model.ChatRoom{ID: "r1", OwnerID: "u1"}
+	repo.Rooms["r1"] = &model.ChatRoom{ID: "r1", OwnerID: "u1"}
 	rec := post(h.RoomsOwned, `{}`, u1)
 	assert.Equal(t, http.StatusOK, rec.Code)
 }
@@ -303,7 +168,7 @@ func TestRoomsLeave_InvalidParam(t *testing.T) {
 
 func TestRoomsMute(t *testing.T) {
 	h, repo := newTestHandler()
-	repo.memberships["u1:r1"] = &model.ChatRoomMembership{UserID: "u1", RoomID: "r1"}
+	repo.Memberships["u1:r1"] = &model.ChatRoomMembership{UserID: "u1", RoomID: "r1"}
 	rec := post(h.RoomsMute, `{"roomId":"r1"}`, u1)
 	assert.Equal(t, http.StatusNoContent, rec.Code)
 }
@@ -322,7 +187,7 @@ func TestRoomsMute_InvalidParam(t *testing.T) {
 
 func TestRoomsUnmute(t *testing.T) {
 	h, repo := newTestHandler()
-	repo.memberships["u1:r1"] = &model.ChatRoomMembership{UserID: "u1", RoomID: "r1", IsMuted: true}
+	repo.Memberships["u1:r1"] = &model.ChatRoomMembership{UserID: "u1", RoomID: "r1", IsMuted: true}
 	rec := post(h.RoomsUnmute, `{"roomId":"r1"}`, u1)
 	assert.Equal(t, http.StatusNoContent, rec.Code)
 }
@@ -341,15 +206,15 @@ func TestRoomsUnmute_InvalidParam(t *testing.T) {
 
 func TestRoomsTransferOwnership(t *testing.T) {
 	h, repo := newTestHandler()
-	repo.rooms["r1"] = &model.ChatRoom{ID: "r1", OwnerID: "u1"}
+	repo.Rooms["r1"] = &model.ChatRoom{ID: "r1", OwnerID: "u1"}
 	rec := post(h.RoomsTransferOwnership, `{"roomId":"r1","userId":"u2"}`, u1)
 	assert.Equal(t, http.StatusNoContent, rec.Code)
-	assert.Equal(t, "u2", repo.rooms["r1"].OwnerID)
+	assert.Equal(t, "u2", repo.Rooms["r1"].OwnerID)
 }
 
 func TestRoomsTransferOwnership_NotOwner(t *testing.T) {
 	h, repo := newTestHandler()
-	repo.rooms["r1"] = &model.ChatRoom{ID: "r1", OwnerID: "other"}
+	repo.Rooms["r1"] = &model.ChatRoom{ID: "r1", OwnerID: "other"}
 	rec := post(h.RoomsTransferOwnership, `{"roomId":"r1","userId":"u2"}`, u1)
 	assert.Equal(t, http.StatusNotFound, rec.Code)
 }
@@ -367,13 +232,13 @@ func TestMessagesCreate_Success(t *testing.T) {
 	text := "hello"
 	rec := post(h.MessagesCreate, `{"text":"hello","toRoomId":"r1"}`, u1)
 	assert.Equal(t, http.StatusOK, rec.Code)
-	assert.Len(t, repo.messages, 1)
+	assert.Len(t, repo.Messages, 1)
 	_ = text
 }
 
 func TestMessagesCreate_Error(t *testing.T) {
 	h, repo := newTestHandler()
-	repo.createErr = errMock
+	repo.CreateErr = errMock
 	rec := post(h.MessagesCreate, `{"text":"x"}`, u1)
 	assert.Equal(t, http.StatusInternalServerError, rec.Code)
 }
@@ -398,7 +263,7 @@ func TestMessagesSearch_InvalidJSON(t *testing.T) {
 
 func TestMessagesShow_WithFromUser(t *testing.T) {
 	h, repo := newTestHandler()
-	repo.messages["m1"] = &model.ChatMessage{
+	repo.Messages["m1"] = &model.ChatMessage{
 		ID: "m1", FromUserID: "u1", FromUser: u1,
 		Reads: pq.StringArray{}, Reactions: pq.StringArray{},
 	}
@@ -409,20 +274,20 @@ func TestMessagesShow_WithFromUser(t *testing.T) {
 
 func TestRoomsUpdate_WithDescription(t *testing.T) {
 	h, repo := newTestHandler()
-	repo.rooms["r1"] = &model.ChatRoom{ID: "r1", Name: "old", OwnerID: "u1"}
+	repo.Rooms["r1"] = &model.ChatRoom{ID: "r1", Name: "old", OwnerID: "u1"}
 	rec := post(h.RoomsUpdate, `{"roomId":"r1","description":"desc"}`, u1)
 	assert.Equal(t, http.StatusOK, rec.Code)
-	assert.Equal(t, "desc", repo.rooms["r1"].Description)
+	assert.Equal(t, "desc", repo.Rooms["r1"].Description)
 }
 
-type mockJoinedRepo struct{ *mockChatRepo }
+type mockJoinedRepo struct{ *testutil.MockChatRepository }
 
 func (m *mockJoinedRepo) ListJoinedRooms(_ string) ([]*model.ChatRoom, error) {
 	return []*model.ChatRoom{{ID: "r1", Name: "room", OwnerID: "u1"}}, nil
 }
 
 func TestRoomsJoined_WithRooms(t *testing.T) {
-	base := newMock()
+	base := testutil.NewMockChatRepository()
 	idGen, _ := id.NewGenerator("aidx")
 	h := NewHandler(&mockJoinedRepo{base}, idGen)
 	rec := post(h.RoomsJoined, `{}`, u1)
@@ -432,7 +297,7 @@ func TestRoomsJoined_WithRooms(t *testing.T) {
 	assert.Len(t, resp, 1)
 }
 
-type mockMsgRepo struct{ *mockChatRepo }
+type mockMsgRepo struct{ *testutil.MockChatRepository }
 
 func (m *mockMsgRepo) ListMessagesByRoom(_ string, _ int) ([]*model.ChatMessage, error) {
 	return []*model.ChatMessage{{ID: "m1", FromUserID: "u1", Reads: pq.StringArray{}, Reactions: pq.StringArray{}}}, nil
@@ -442,7 +307,7 @@ func (m *mockMsgRepo) SearchMessages(_, _ string, _ int) ([]*model.ChatMessage, 
 }
 
 func TestMessages_WithData(t *testing.T) {
-	base := newMock()
+	base := testutil.NewMockChatRepository()
 	idGen, _ := id.NewGenerator("aidx")
 	h := NewHandler(&mockMsgRepo{base}, idGen)
 	rec := post(h.Messages, `{"roomId":"r1"}`, u1)
@@ -453,7 +318,7 @@ func TestMessages_WithData(t *testing.T) {
 }
 
 func TestMessagesSearch_WithData(t *testing.T) {
-	base := newMock()
+	base := testutil.NewMockChatRepository()
 	idGen, _ := id.NewGenerator("aidx")
 	h := NewHandler(&mockMsgRepo{base}, idGen)
 	rec := post(h.MessagesSearch, `{"query":"test"}`, u1)
@@ -465,7 +330,7 @@ func TestMessagesSearch_WithData(t *testing.T) {
 
 func TestMessagesShow_Success(t *testing.T) {
 	h, repo := newTestHandler()
-	repo.messages["m1"] = &model.ChatMessage{ID: "m1", FromUserID: "u1", Reads: pq.StringArray{}, Reactions: pq.StringArray{}}
+	repo.Messages["m1"] = &model.ChatMessage{ID: "m1", FromUserID: "u1", Reads: pq.StringArray{}, Reactions: pq.StringArray{}}
 	rec := post(h.MessagesShow, `{"messageId":"m1"}`, u1)
 	assert.Equal(t, http.StatusOK, rec.Code)
 }
@@ -484,14 +349,14 @@ func TestMessagesShow_InvalidParam(t *testing.T) {
 
 func TestMessagesUpdate_Success(t *testing.T) {
 	h, repo := newTestHandler()
-	repo.messages["m1"] = &model.ChatMessage{ID: "m1", FromUserID: "u1"}
+	repo.Messages["m1"] = &model.ChatMessage{ID: "m1", FromUserID: "u1"}
 	rec := post(h.MessagesUpdate, `{"messageId":"m1","text":"updated"}`, u1)
 	assert.Equal(t, http.StatusNoContent, rec.Code)
 }
 
 func TestMessagesUpdate_NotOwner(t *testing.T) {
 	h, repo := newTestHandler()
-	repo.messages["m1"] = &model.ChatMessage{ID: "m1", FromUserID: "other"}
+	repo.Messages["m1"] = &model.ChatMessage{ID: "m1", FromUserID: "other"}
 	rec := post(h.MessagesUpdate, `{"messageId":"m1"}`, u1)
 	assert.Equal(t, http.StatusNotFound, rec.Code)
 }
@@ -504,14 +369,14 @@ func TestMessagesUpdate_InvalidParam(t *testing.T) {
 
 func TestMessagesDelete_Success(t *testing.T) {
 	h, repo := newTestHandler()
-	repo.messages["m1"] = &model.ChatMessage{ID: "m1", FromUserID: "u1"}
+	repo.Messages["m1"] = &model.ChatMessage{ID: "m1", FromUserID: "u1"}
 	rec := post(h.MessagesDelete, `{"messageId":"m1"}`, u1)
 	assert.Equal(t, http.StatusNoContent, rec.Code)
 }
 
 func TestMessagesDelete_NotOwner(t *testing.T) {
 	h, repo := newTestHandler()
-	repo.messages["m1"] = &model.ChatMessage{ID: "m1", FromUserID: "other"}
+	repo.Messages["m1"] = &model.ChatMessage{ID: "m1", FromUserID: "other"}
 	rec := post(h.MessagesDelete, `{"messageId":"m1"}`, u1)
 	assert.Equal(t, http.StatusNotFound, rec.Code)
 }
@@ -542,9 +407,9 @@ func TestMessages_List(t *testing.T) {
 
 // --- Phase 9.8: service wiring tests ---
 
-func newHandlerWithService(t *testing.T) (*Handler, *mockChatRepo) {
+func newHandlerWithService(t *testing.T) (*Handler, *testutil.MockChatRepository) {
 	t.Helper()
-	repo := newMock()
+	repo := testutil.NewMockChatRepository()
 	idGen, _ := id.NewGenerator("aidx")
 	h := NewHandler(repo, idGen)
 	svc := corechat.NewService(repo, idGen)
@@ -556,15 +421,15 @@ func TestMessagesCreate_Service_ToUser(t *testing.T) {
 	h, repo := newHandlerWithService(t)
 	rec := post(h.MessagesCreate, `{"text":"hi","toUserId":"u2"}`, u1)
 	assert.Equal(t, http.StatusOK, rec.Code)
-	assert.Len(t, repo.messages, 1)
+	assert.Len(t, repo.Messages, 1)
 }
 
 func TestMessagesCreate_Service_ToRoom(t *testing.T) {
 	h, repo := newHandlerWithService(t)
-	repo.rooms["r1"] = &model.ChatRoom{ID: "r1", OwnerID: "u1"}
+	repo.Rooms["r1"] = &model.ChatRoom{ID: "r1", OwnerID: "u1"}
 	rec := post(h.MessagesCreate, `{"text":"hi","toRoomId":"r1"}`, u1)
 	assert.Equal(t, http.StatusOK, rec.Code)
-	assert.Len(t, repo.messages, 1)
+	assert.Len(t, repo.Messages, 1)
 }
 
 func TestMessagesCreate_Service_NoTarget(t *testing.T) {
@@ -581,7 +446,7 @@ func TestMessagesCreate_Service_RoomNotFound(t *testing.T) {
 
 func TestMessagesCreate_Service_RoomForbidden(t *testing.T) {
 	h, repo := newHandlerWithService(t)
-	repo.rooms["r1"] = &model.ChatRoom{ID: "r1", OwnerID: "otherUser"}
+	repo.Rooms["r1"] = &model.ChatRoom{ID: "r1", OwnerID: "otherUser"}
 	rec := post(h.MessagesCreate, `{"text":"hi","toRoomId":"r1"}`, u1)
 	assert.Equal(t, http.StatusForbidden, rec.Code)
 }
@@ -589,7 +454,7 @@ func TestMessagesCreate_Service_RoomForbidden(t *testing.T) {
 func TestMessagesDelete_Service(t *testing.T) {
 	h, repo := newHandlerWithService(t)
 	toID := "u2"
-	repo.messages["m1"] = &model.ChatMessage{ID: "m1", FromUserID: "u1", ToUserID: &toID}
+	repo.Messages["m1"] = &model.ChatMessage{ID: "m1", FromUserID: "u1", ToUserID: &toID}
 	rec := post(h.MessagesDelete, `{"messageId":"m1"}`, u1)
 	assert.Equal(t, http.StatusNoContent, rec.Code)
 }
@@ -603,7 +468,7 @@ func TestMessagesDelete_Service_NotFound(t *testing.T) {
 func TestMessagesDelete_Service_Forbidden(t *testing.T) {
 	h, repo := newHandlerWithService(t)
 	toID := "u1"
-	repo.messages["m1"] = &model.ChatMessage{ID: "m1", FromUserID: "u2", ToUserID: &toID}
+	repo.Messages["m1"] = &model.ChatMessage{ID: "m1", FromUserID: "u2", ToUserID: &toID}
 	rec := post(h.MessagesDelete, `{"messageId":"m1"}`, u1)
 	assert.Equal(t, http.StatusForbidden, rec.Code)
 }
@@ -612,7 +477,7 @@ func TestMessagesUpdate_Service(t *testing.T) {
 	h, repo := newHandlerWithService(t)
 	toID := "u2"
 	orig := "old"
-	repo.messages["m1"] = &model.ChatMessage{ID: "m1", FromUserID: "u1", ToUserID: &toID, Text: &orig}
+	repo.Messages["m1"] = &model.ChatMessage{ID: "m1", FromUserID: "u1", ToUserID: &toID, Text: &orig}
 	rec := post(h.MessagesUpdate, `{"messageId":"m1","text":"new"}`, u1)
 	assert.Equal(t, http.StatusNoContent, rec.Code)
 }
@@ -627,7 +492,7 @@ func TestMessagesUpdate_Service_Forbidden(t *testing.T) {
 	h, repo := newHandlerWithService(t)
 	toID := "u1"
 	orig := "old"
-	repo.messages["m1"] = &model.ChatMessage{ID: "m1", FromUserID: "u2", ToUserID: &toID, Text: &orig}
+	repo.Messages["m1"] = &model.ChatMessage{ID: "m1", FromUserID: "u2", ToUserID: &toID, Text: &orig}
 	rec := post(h.MessagesUpdate, `{"messageId":"m1","text":"new"}`, u1)
 	assert.Equal(t, http.StatusForbidden, rec.Code)
 }
@@ -635,7 +500,7 @@ func TestMessagesUpdate_Service_Forbidden(t *testing.T) {
 func TestMessagesRead_Service(t *testing.T) {
 	h, repo := newHandlerWithService(t)
 	toID := "u1"
-	repo.messages["m1"] = &model.ChatMessage{ID: "m1", FromUserID: "u2", ToUserID: &toID}
+	repo.Messages["m1"] = &model.ChatMessage{ID: "m1", FromUserID: "u2", ToUserID: &toID}
 	rec := post(h.MessagesRead, `{"messageId":"m1"}`, u1)
 	assert.Equal(t, http.StatusNoContent, rec.Code)
 }
@@ -646,14 +511,14 @@ func TestMessagesRead_Service_NotFound(t *testing.T) {
 	assert.Equal(t, http.StatusNotFound, rec.Code)
 }
 
-type mockUserMsgRepo struct{ *mockChatRepo }
+type mockUserMsgRepo struct{ *testutil.MockChatRepository }
 
 func (m *mockUserMsgRepo) ListMessagesByUser(_, _ string, _ int) ([]*model.ChatMessage, error) {
 	return []*model.ChatMessage{{ID: "m2", FromUserID: "u2", Reads: pq.StringArray{}, Reactions: pq.StringArray{}}}, nil
 }
 
 func TestMessages_ListByUser(t *testing.T) {
-	base := newMock()
+	base := testutil.NewMockChatRepository()
 	idGen, _ := id.NewGenerator("aidx")
 	h := NewHandler(&mockUserMsgRepo{base}, idGen)
 	rec := post(h.Messages, `{"userId":"u2"}`, u1)
@@ -709,7 +574,7 @@ func TestInvitationsCreate_InvalidParam(t *testing.T) {
 
 func TestInvitationsCreate_Error(t *testing.T) {
 	h, repo := newTestHandler()
-	repo.createErr = errMock
+	repo.CreateErr = errMock
 	rec := post(h.InvitationsCreate, `{"roomId":"r1","userId":"u2"}`, u1)
 	assert.Equal(t, http.StatusInternalServerError, rec.Code)
 }
@@ -728,10 +593,10 @@ func TestInvitationsDelete_InvalidParam(t *testing.T) {
 
 func TestInvitationsAccept(t *testing.T) {
 	h, repo := newTestHandler()
-	repo.invitations["i1"] = &model.ChatRoomInvitation{ID: "i1", UserID: "u1", RoomID: "r1"}
+	repo.Invitations["i1"] = &model.ChatRoomInvitation{ID: "i1", UserID: "u1", RoomID: "r1"}
 	rec := post(h.InvitationsAccept, `{"roomId":"r1"}`, u1)
 	assert.Equal(t, http.StatusNoContent, rec.Code)
-	assert.Len(t, repo.memberships, 1)
+	assert.Len(t, repo.Memberships, 1)
 }
 
 func TestInvitationsAccept_InvalidParam(t *testing.T) {
@@ -742,10 +607,10 @@ func TestInvitationsAccept_InvalidParam(t *testing.T) {
 
 func TestInvitationsReject(t *testing.T) {
 	h, repo := newTestHandler()
-	repo.invitations["i1"] = &model.ChatRoomInvitation{ID: "i1", UserID: "u1", RoomID: "r1"}
+	repo.Invitations["i1"] = &model.ChatRoomInvitation{ID: "i1", UserID: "u1", RoomID: "r1"}
 	rec := post(h.InvitationsReject, `{"roomId":"r1"}`, u1)
 	assert.Equal(t, http.StatusNoContent, rec.Code)
-	assert.Empty(t, repo.invitations)
+	assert.Empty(t, repo.Invitations)
 }
 
 func TestInvitationsReject_InvalidParam(t *testing.T) {
@@ -791,7 +656,7 @@ func TestHistory(t *testing.T) {
 // MarkAllReadFromUser / MarkAllReadInRoom を呼んでチャット画面を開いた瞬間に
 // 既読化することを assert する (handler 側の wiring を guard)。
 type readMarkSpyRepo struct {
-	*mockChatRepo
+	*testutil.MockChatRepository
 	markFromUserCalled struct{ reader, fromUser string }
 	markInRoomCalled   struct{ reader, room string }
 }
@@ -809,7 +674,7 @@ func (m *readMarkSpyRepo) MarkAllReadInRoom(reader, room string) error {
 }
 
 func TestUserTimeline_MarksReadOnOpen(t *testing.T) {
-	spy := &readMarkSpyRepo{mockChatRepo: newMock()}
+	spy := &readMarkSpyRepo{MockChatRepository: testutil.NewMockChatRepository()}
 	idGen, _ := id.NewGenerator("aidx")
 	h := NewHandler(spy, idGen)
 	rec := post(h.UserTimeline, `{"userId":"u_other"}`, u1)
@@ -819,7 +684,7 @@ func TestUserTimeline_MarksReadOnOpen(t *testing.T) {
 }
 
 func TestRoomTimeline_MarksReadOnOpen(t *testing.T) {
-	spy := &readMarkSpyRepo{mockChatRepo: newMock()}
+	spy := &readMarkSpyRepo{MockChatRepository: testutil.NewMockChatRepository()}
 	idGen, _ := id.NewGenerator("aidx")
 	h := NewHandler(spy, idGen)
 	rec := post(h.RoomTimeline, `{"roomId":"r_x"}`, u1)
@@ -830,14 +695,14 @@ func TestRoomTimeline_MarksReadOnOpen(t *testing.T) {
 
 // MarkAllRead* が err を返しても timeline 自体は 200 を返す (best-effort)。
 type readMarkErrRepo struct {
-	*mockChatRepo
+	*testutil.MockChatRepository
 }
 
 func (m *readMarkErrRepo) MarkAllReadFromUser(_, _ string) error { return errMock }
 func (m *readMarkErrRepo) MarkAllReadInRoom(_, _ string) error   { return errMock }
 
 func TestTimeline_BestEffortReadMark(t *testing.T) {
-	r := &readMarkErrRepo{mockChatRepo: newMock()}
+	r := &readMarkErrRepo{MockChatRepository: testutil.NewMockChatRepository()}
 	idGen, _ := id.NewGenerator("aidx")
 	h := NewHandler(r, idGen)
 	assert.Equal(t, http.StatusOK, post(h.UserTimeline, `{"userId":"u2"}`, u1).Code)
@@ -857,14 +722,14 @@ func TestUnreadCount(t *testing.T) {
 
 func TestMessagesCreateToUser(t *testing.T) {
 	h, repo := newTestHandler()
-	repo.rooms["r1"] = &model.ChatRoom{ID: "r1", OwnerID: u1.ID}
+	repo.Rooms["r1"] = &model.ChatRoom{ID: "r1", OwnerID: u1.ID}
 	rec := post(h.MessagesCreateToUser, `{"text":"hi","toUserId":"u2"}`, u1)
 	assert.Equal(t, http.StatusOK, rec.Code)
 }
 
 func TestMessagesCreateToRoom(t *testing.T) {
 	h, repo := newTestHandler()
-	repo.rooms["r1"] = &model.ChatRoom{ID: "r1", OwnerID: u1.ID}
+	repo.Rooms["r1"] = &model.ChatRoom{ID: "r1", OwnerID: u1.ID}
 	rec := post(h.MessagesCreateToRoom, `{"text":"hi","toRoomId":"r1"}`, u1)
 	assert.Equal(t, http.StatusOK, rec.Code)
 }
@@ -951,7 +816,7 @@ func TestPackMessageDetailed_FieldsPresent(t *testing.T) {
 func TestInvitationsIgnore(t *testing.T) {
 	h, repo := newTestHandler()
 	assert.Equal(t, http.StatusBadRequest, post(h.InvitationsIgnore, `{}`, u1).Code)
-	repo.invitations["inv1"] = &model.ChatRoomInvitation{ID: "inv1", UserID: u1.ID, RoomID: "r1"}
+	repo.Invitations["inv1"] = &model.ChatRoomInvitation{ID: "inv1", UserID: u1.ID, RoomID: "r1"}
 	rec := post(h.InvitationsIgnore, `{"roomId":"r1"}`, u1)
 	assert.Equal(t, http.StatusNoContent, rec.Code)
 }
@@ -968,7 +833,7 @@ func TestInvitationsOutbox(t *testing.T) {
 	// no room → 404
 	assert.Equal(t, http.StatusNotFound, post(h.InvitationsOutbox, `{"roomId":"r1"}`, u1).Code)
 	// owner can see outbox
-	repo.rooms["r1"] = &model.ChatRoom{ID: "r1", OwnerID: u1.ID}
+	repo.Rooms["r1"] = &model.ChatRoom{ID: "r1", OwnerID: u1.ID}
 	rec := post(h.InvitationsOutbox, `{"roomId":"r1"}`, u1)
 	assert.Equal(t, http.StatusOK, rec.Code)
 	// non-owner → 404
@@ -979,7 +844,7 @@ func TestRoomsJoin(t *testing.T) {
 	h, repo := newTestHandler()
 	assert.Equal(t, http.StatusBadRequest, post(h.RoomsJoin, `{}`, u1).Code)
 	assert.Equal(t, http.StatusNotFound, post(h.RoomsJoin, `{"roomId":"ghost"}`, u1).Code)
-	repo.rooms["r1"] = &model.ChatRoom{ID: "r1", OwnerID: u2.ID}
+	repo.Rooms["r1"] = &model.ChatRoom{ID: "r1", OwnerID: u2.ID}
 	rec := post(h.RoomsJoin, `{"roomId":"r1"}`, u1)
 	assert.Equal(t, http.StatusNoContent, rec.Code)
 }
@@ -999,8 +864,8 @@ func TestRoomsMembers(t *testing.T) {
 
 func TestMembersUpdateMembership_Auth(t *testing.T) {
 	h, repo := newTestHandler()
-	repo.rooms["r1"] = &model.ChatRoom{ID: "r1", OwnerID: u1.ID}
-	repo.memberships["u2:r1"] = &model.ChatRoomMembership{ID: "m1", UserID: u2.ID, RoomID: "r1"}
+	repo.Rooms["r1"] = &model.ChatRoom{ID: "r1", OwnerID: u1.ID}
+	repo.Memberships["u2:r1"] = &model.ChatRoomMembership{ID: "m1", UserID: u2.ID, RoomID: "r1"}
 	// owner can update
 	tr := true
 	_ = tr

--- a/internal/core/chat/service_test.go
+++ b/internal/core/chat/service_test.go
@@ -10,162 +10,16 @@ import (
 	corechat "github.com/shiroha-a/mk/internal/core/chat"
 	"github.com/shiroha-a/mk/internal/misc/id"
 	"github.com/shiroha-a/mk/internal/model"
+	"github.com/shiroha-a/mk/internal/testutil"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
-// --- fake repository ---
-
-type fakeChatRepo struct {
-	mu          sync.Mutex
-	rooms       map[string]*model.ChatRoom
-	messages    map[string]*model.ChatMessage
-	memberships map[string]*model.ChatRoomMembership // key: userID:roomID
-
-	createErr error
-	updateErr error
-	deleteErr error
-}
-
-func newFakeRepo() *fakeChatRepo {
-	return &fakeChatRepo{
-		rooms:       make(map[string]*model.ChatRoom),
-		messages:    make(map[string]*model.ChatMessage),
-		memberships: make(map[string]*model.ChatRoomMembership),
-	}
-}
-
-func (r *fakeChatRepo) CreateRoom(room *model.ChatRoom) error {
-	r.mu.Lock()
-	defer r.mu.Unlock()
-	r.rooms[room.ID] = room
-	return nil
-}
-func (r *fakeChatRepo) FindRoomByID(id string) (*model.ChatRoom, error) {
-	r.mu.Lock()
-	defer r.mu.Unlock()
-	if room, ok := r.rooms[id]; ok {
-		return room, nil
-	}
-	return nil, errors.New("not found")
-}
-func (r *fakeChatRepo) UpdateRoom(_ *model.ChatRoom) error                   { return nil }
-func (r *fakeChatRepo) DeleteRoom(_ string) error                            { return nil }
-func (r *fakeChatRepo) ListRoomsByOwner(_ string) ([]*model.ChatRoom, error) { return nil, nil }
-func (r *fakeChatRepo) ListJoinedRooms(_ string) ([]*model.ChatRoom, error)  { return nil, nil }
-
-func (r *fakeChatRepo) CreateMessage(msg *model.ChatMessage) error {
-	r.mu.Lock()
-	defer r.mu.Unlock()
-	if r.createErr != nil {
-		return r.createErr
-	}
-	clone := *msg
-	r.messages[msg.ID] = &clone
-	return nil
-}
-func (r *fakeChatRepo) FindMessageByID(id string) (*model.ChatMessage, error) {
-	r.mu.Lock()
-	defer r.mu.Unlock()
-	if msg, ok := r.messages[id]; ok {
-		clone := *msg
-		return &clone, nil
-	}
-	return nil, errors.New("not found")
-}
-func (r *fakeChatRepo) UpdateMessage(msg *model.ChatMessage) error {
-	r.mu.Lock()
-	defer r.mu.Unlock()
-	if r.updateErr != nil {
-		return r.updateErr
-	}
-	clone := *msg
-	r.messages[msg.ID] = &clone
-	return nil
-}
-func (r *fakeChatRepo) DeleteMessage(id string) error {
-	r.mu.Lock()
-	defer r.mu.Unlock()
-	if r.deleteErr != nil {
-		return r.deleteErr
-	}
-	delete(r.messages, id)
-	return nil
-}
-func (r *fakeChatRepo) ListMessagesByRoom(_ string, _ int) ([]*model.ChatMessage, error) {
-	return nil, nil
-}
-func (r *fakeChatRepo) ListMessagesByUser(_, _ string, _ int) ([]*model.ChatMessage, error) {
-	return nil, nil
-}
-func (r *fakeChatRepo) SearchMessages(_, _ string, _ int) ([]*model.ChatMessage, error) {
-	return nil, nil
-}
-func (r *fakeChatRepo) CreateMembership(m *model.ChatRoomMembership) error {
-	r.mu.Lock()
-	defer r.mu.Unlock()
-	r.memberships[m.UserID+":"+m.RoomID] = m
-	return nil
-}
-func (r *fakeChatRepo) FindMembership(userID, roomID string) (*model.ChatRoomMembership, error) {
-	r.mu.Lock()
-	defer r.mu.Unlock()
-	if m, ok := r.memberships[userID+":"+roomID]; ok {
-		return m, nil
-	}
-	return nil, errors.New("not found")
-}
-func (r *fakeChatRepo) UpdateMembership(_ *model.ChatRoomMembership) error { return nil }
-func (r *fakeChatRepo) DeleteMembership(_, _ string) error                 { return nil }
-func (r *fakeChatRepo) ListMembersByRoom(roomID string) ([]*model.ChatRoomMembership, error) {
-	r.mu.Lock()
-	defer r.mu.Unlock()
-	out := make([]*model.ChatRoomMembership, 0)
-	for _, m := range r.memberships {
-		if m.RoomID == roomID {
-			out = append(out, m)
-		}
-	}
-	return out, nil
-}
-func (r *fakeChatRepo) CreateInvitation(_ *model.ChatRoomInvitation) error { return nil }
-func (r *fakeChatRepo) DeleteInvitation(_ string) error                    { return nil }
-func (r *fakeChatRepo) FindInvitation(_, _ string) (*model.ChatRoomInvitation, error) {
-	return nil, errors.New("not found")
-}
-func (r *fakeChatRepo) CountUnread(_ string) (int64, error) { return 0, nil }
-func (r *fakeChatRepo) MarkRead(userID, messageID string) error {
-	r.mu.Lock()
-	defer r.mu.Unlock()
-	if msg, ok := r.messages[messageID]; ok {
-		msg.Reads = append(msg.Reads, userID)
-	}
-	return nil
-}
-func (r *fakeChatRepo) ListInvitationsByUser(_ string, _ bool) ([]*model.ChatRoomInvitation, error) {
-	return nil, nil
-}
-func (r *fakeChatRepo) ListInvitationsByRoom(_ string) ([]*model.ChatRoomInvitation, error) {
-	return nil, nil
-}
-func (r *fakeChatRepo) UpdateDeliveryStatus(_ string, _, _ bool) error { return nil }
-func (r *fakeChatRepo) ListHistory(_ string, _ int) ([]*model.ChatMessage, error) {
-	return nil, nil
-}
-func (r *fakeChatRepo) ListUserHistory(_ string, _ int) ([]*model.ChatMessage, error) {
-	return nil, nil
-}
-func (r *fakeChatRepo) ListRoomHistory(_ string, _ int) ([]*model.ChatMessage, error) {
-	return nil, nil
-}
-func (r *fakeChatRepo) MarkAllRead(_ string) error                         { return nil }
-func (r *fakeChatRepo) MarkAllReadFromUser(_, _ string) error              { return nil }
-func (r *fakeChatRepo) MarkAllReadInRoom(_, _ string) error                { return nil }
-func (r *fakeChatRepo) AddReaction(_, _ string) error                      { return nil }
-func (r *fakeChatRepo) RemoveReaction(_, _ string) error                   { return nil }
-func (r *fakeChatRepo) UpdateInvitation(_ *model.ChatRoomInvitation) error { return nil }
-func (r *fakeChatRepo) FindMessageByURI(_ string) (*model.ChatMessage, error) {
-	return nil, errors.New("not found")
+// fakeChatRepo / newFakeRepo は testutil.MockChatRepository に集約された
+// (#709)。本ファイル / ap_delivery_test.go は newFakeRepo() のエイリアスを
+// 使い続けるが、実体は MockChatRepository。
+func newFakeRepo() *testutil.MockChatRepository {
+	return testutil.NewMockChatRepository()
 }
 
 // --- capture publisher ---
@@ -217,7 +71,7 @@ func (p *stubMainPublisher) PublishMainEvent(userID, eventType string, body any)
 
 // --- helper ---
 
-func newSvc(t *testing.T) (*corechat.Service, *fakeChatRepo, *capturePublisher) {
+func newSvc(t *testing.T) (*corechat.Service, *testutil.MockChatRepository, *capturePublisher) {
 	t.Helper()
 	repo := newFakeRepo()
 	pub := &capturePublisher{}
@@ -264,7 +118,7 @@ func TestCreateMessageToUser_EmptyRecipient(t *testing.T) {
 
 func TestCreateMessageToUser_RepoError(t *testing.T) {
 	svc, repo, pub := newSvc(t)
-	repo.createErr = errors.New("db boom")
+	repo.CreateErr = errors.New("db boom")
 	_, err := svc.CreateMessageToUser(context.Background(), "alice", "bob", "hi", "")
 	assert.Error(t, err)
 	assert.Empty(t, pub.userCalls)
@@ -272,11 +126,11 @@ func TestCreateMessageToUser_RepoError(t *testing.T) {
 
 // --- CreateMessageToRoom ---
 
-func seedRoom(t *testing.T, repo *fakeChatRepo, id string, owner string, members ...string) {
+func seedRoom(t *testing.T, repo *testutil.MockChatRepository, id string, owner string, members ...string) {
 	t.Helper()
-	repo.rooms[id] = &model.ChatRoom{ID: id, Name: "test-room", OwnerID: owner}
+	repo.Rooms[id] = &model.ChatRoom{ID: id, Name: "test-room", OwnerID: owner}
 	for _, u := range members {
-		repo.memberships[u+":"+id] = &model.ChatRoomMembership{UserID: u, RoomID: id}
+		repo.Memberships[u+":"+id] = &model.ChatRoomMembership{UserID: u, RoomID: id}
 	}
 }
 
@@ -421,7 +275,7 @@ func TestCreateMessageToRoom_WithFile(t *testing.T) {
 func TestCreateMessageToRoom_RepoError(t *testing.T) {
 	svc, repo, _ := newSvc(t)
 	seedRoom(t, repo, "r1", "alice")
-	repo.createErr = errors.New("db boom")
+	repo.CreateErr = errors.New("db boom")
 	_, err := svc.CreateMessageToRoom(context.Background(), "alice", "r1", "hi", "")
 	assert.Error(t, err)
 }
@@ -465,7 +319,7 @@ func TestDeleteMessage_NotAuthor(t *testing.T) {
 func TestDeleteMessage_RepoError(t *testing.T) {
 	svc, repo, _ := newSvc(t)
 	msg, _ := svc.CreateMessageToUser(context.Background(), "alice", "bob", "hi", "")
-	repo.deleteErr = errors.New("db boom")
+	repo.DeleteErr = errors.New("db boom")
 	err := svc.DeleteMessage(context.Background(), "alice", msg.ID)
 	assert.Error(t, err)
 }
@@ -513,7 +367,7 @@ func TestUpdateMessage_NotAuthor(t *testing.T) {
 func TestUpdateMessage_RepoError(t *testing.T) {
 	svc, repo, _ := newSvc(t)
 	msg, _ := svc.CreateMessageToUser(context.Background(), "alice", "bob", "hi", "")
-	repo.updateErr = errors.New("db boom")
+	repo.UpdateErr = errors.New("db boom")
 	_, err := svc.UpdateMessage(context.Background(), "alice", msg.ID, "edited")
 	assert.Error(t, err)
 }
@@ -589,7 +443,7 @@ func TestMarkRead_AppendsToReads(t *testing.T) {
 	svc, repo, _ := newSvc(t)
 	msg, _ := svc.CreateMessageToUser(context.Background(), "alice", "bob", "hi", "")
 	require.NoError(t, svc.MarkReadByMessageID(context.Background(), "bob", msg.ID))
-	stored := repo.messages[msg.ID]
+	stored := repo.Messages[msg.ID]
 	require.NotNil(t, stored)
 	assert.Equal(t, pq.StringArray{"bob"}, stored.Reads)
 }

--- a/internal/core/chat/service_test.go
+++ b/internal/core/chat/service_test.go
@@ -16,8 +16,11 @@ import (
 )
 
 // fakeChatRepo / newFakeRepo は testutil.MockChatRepository に集約された
-// (#709)。本ファイル / ap_delivery_test.go は newFakeRepo() のエイリアスを
-// 使い続けるが、実体は MockChatRepository。
+// (#709)。本ファイル / ap_delivery_test.go の呼び出し点を保つために alias
+// を残しているが、新規 test は testutil.NewMockChatRepository() を直接
+// 呼ぶこと。既存呼び出しも段階的に置換していく方針。
+//
+// Deprecated: use testutil.NewMockChatRepository directly.
 func newFakeRepo() *testutil.MockChatRepository {
 	return testutil.NewMockChatRepository()
 }

--- a/internal/stream/channels/chat_room_test.go
+++ b/internal/stream/channels/chat_room_test.go
@@ -2,120 +2,22 @@ package channels
 
 import (
 	"encoding/json"
-	"errors"
-	"sync"
 	"testing"
 
 	corechat "github.com/shiroha-a/mk/internal/core/chat"
 	"github.com/shiroha-a/mk/internal/misc/id"
 	"github.com/shiroha-a/mk/internal/model"
 	"github.com/shiroha-a/mk/internal/stream"
+	"github.com/shiroha-a/mk/internal/testutil"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
-// --- minimal in-memory chat repo for channel wiring ---
+// chat 用 fake repo は testutil.MockChatRepository に集約された (#709)。
 
-type chatFakeRepo struct {
-	mu          sync.Mutex
-	rooms       map[string]*model.ChatRoom
-	messages    map[string]*model.ChatMessage
-	memberships map[string]*model.ChatRoomMembership
-}
-
-func newChatFakeRepo() *chatFakeRepo {
-	return &chatFakeRepo{
-		rooms:       make(map[string]*model.ChatRoom),
-		messages:    make(map[string]*model.ChatMessage),
-		memberships: make(map[string]*model.ChatRoomMembership),
-	}
-}
-
-func (r *chatFakeRepo) CreateRoom(rm *model.ChatRoom) error { r.rooms[rm.ID] = rm; return nil }
-func (r *chatFakeRepo) FindRoomByID(id string) (*model.ChatRoom, error) {
-	if rm, ok := r.rooms[id]; ok {
-		return rm, nil
-	}
-	return nil, errors.New("not found")
-}
-func (r *chatFakeRepo) UpdateRoom(_ *model.ChatRoom) error                   { return nil }
-func (r *chatFakeRepo) DeleteRoom(_ string) error                            { return nil }
-func (r *chatFakeRepo) ListRoomsByOwner(_ string) ([]*model.ChatRoom, error) { return nil, nil }
-func (r *chatFakeRepo) ListJoinedRooms(_ string) ([]*model.ChatRoom, error)  { return nil, nil }
-func (r *chatFakeRepo) CreateMessage(msg *model.ChatMessage) error {
-	r.messages[msg.ID] = msg
-	return nil
-}
-func (r *chatFakeRepo) FindMessageByID(id string) (*model.ChatMessage, error) {
-	if m, ok := r.messages[id]; ok {
-		return m, nil
-	}
-	return nil, errors.New("not found")
-}
-func (r *chatFakeRepo) UpdateMessage(_ *model.ChatMessage) error { return nil }
-func (r *chatFakeRepo) DeleteMessage(_ string) error             { return nil }
-func (r *chatFakeRepo) ListMessagesByRoom(_ string, _ int) ([]*model.ChatMessage, error) {
-	return nil, nil
-}
-func (r *chatFakeRepo) ListMessagesByUser(_, _ string, _ int) ([]*model.ChatMessage, error) {
-	return nil, nil
-}
-func (r *chatFakeRepo) SearchMessages(_, _ string, _ int) ([]*model.ChatMessage, error) {
-	return nil, nil
-}
-func (r *chatFakeRepo) CreateMembership(m *model.ChatRoomMembership) error {
-	r.memberships[m.UserID+":"+m.RoomID] = m
-	return nil
-}
-func (r *chatFakeRepo) FindMembership(userID, roomID string) (*model.ChatRoomMembership, error) {
-	if m, ok := r.memberships[userID+":"+roomID]; ok {
-		return m, nil
-	}
-	return nil, errors.New("not found")
-}
-func (r *chatFakeRepo) UpdateMembership(_ *model.ChatRoomMembership) error { return nil }
-func (r *chatFakeRepo) DeleteMembership(_, _ string) error                 { return nil }
-func (r *chatFakeRepo) ListMembersByRoom(_ string) ([]*model.ChatRoomMembership, error) {
-	return nil, nil
-}
-func (r *chatFakeRepo) CreateInvitation(_ *model.ChatRoomInvitation) error { return nil }
-func (r *chatFakeRepo) DeleteInvitation(_ string) error                    { return nil }
-func (r *chatFakeRepo) FindInvitation(_, _ string) (*model.ChatRoomInvitation, error) {
-	return nil, errors.New("not found")
-}
-func (r *chatFakeRepo) CountUnread(_ string) (int64, error) { return 0, nil }
-func (r *chatFakeRepo) MarkRead(_, _ string) error          { return nil }
-func (r *chatFakeRepo) ListInvitationsByUser(_ string, _ bool) ([]*model.ChatRoomInvitation, error) {
-	return nil, nil
-}
-func (r *chatFakeRepo) ListInvitationsByRoom(_ string) ([]*model.ChatRoomInvitation, error) {
-	return nil, nil
-}
-func (r *chatFakeRepo) UpdateDeliveryStatus(_ string, _, _ bool) error { return nil }
-func (r *chatFakeRepo) ListHistory(_ string, _ int) ([]*model.ChatMessage, error) {
-	return nil, nil
-}
-func (r *chatFakeRepo) ListUserHistory(_ string, _ int) ([]*model.ChatMessage, error) {
-	return nil, nil
-}
-func (r *chatFakeRepo) ListRoomHistory(_ string, _ int) ([]*model.ChatMessage, error) {
-	return nil, nil
-}
-func (r *chatFakeRepo) MarkAllRead(_ string) error                         { return nil }
-func (r *chatFakeRepo) MarkAllReadFromUser(_, _ string) error              { return nil }
-func (r *chatFakeRepo) MarkAllReadInRoom(_, _ string) error                { return nil }
-func (r *chatFakeRepo) AddReaction(_, _ string) error                      { return nil }
-func (r *chatFakeRepo) RemoveReaction(_, _ string) error                   { return nil }
-func (r *chatFakeRepo) UpdateInvitation(_ *model.ChatRoomInvitation) error { return nil }
-func (r *chatFakeRepo) FindMessageByURI(_ string) (*model.ChatMessage, error) {
-	return nil, errors.New("not found")
-}
-
-// --- test helpers ---
-
-func newChatSvc(t *testing.T) (*corechat.Service, *chatFakeRepo) {
+func newChatSvc(t *testing.T) (*corechat.Service, *testutil.MockChatRepository) {
 	t.Helper()
-	repo := newChatFakeRepo()
+	repo := testutil.NewMockChatRepository()
 	idGen, _ := id.NewGenerator("aidx")
 	return corechat.NewService(repo, idGen), repo
 }
@@ -129,8 +31,8 @@ var _ stream.Channel = (*ChatUserChannel)(nil)
 
 func TestChatRoomChannel_Init_Member(t *testing.T) {
 	svc, repo := newChatSvc(t)
-	repo.rooms["r1"] = &model.ChatRoom{ID: "r1", OwnerID: "alice"}
-	repo.memberships["bob:r1"] = &model.ChatRoomMembership{UserID: "bob", RoomID: "r1"}
+	repo.Rooms["r1"] = &model.ChatRoom{ID: "r1", OwnerID: "alice"}
+	repo.Memberships["bob:r1"] = &model.ChatRoomMembership{UserID: "bob", RoomID: "r1"}
 
 	ctx := newCtx(&model.User{ID: "bob"})
 	ch := NewChatRoomFactory(svc).New(ctx)
@@ -141,7 +43,7 @@ func TestChatRoomChannel_Init_Member(t *testing.T) {
 
 func TestChatRoomChannel_Init_OwnerImplicitMember(t *testing.T) {
 	svc, repo := newChatSvc(t)
-	repo.rooms["r1"] = &model.ChatRoom{ID: "r1", OwnerID: "alice"}
+	repo.Rooms["r1"] = &model.ChatRoom{ID: "r1", OwnerID: "alice"}
 
 	ctx := newCtx(&model.User{ID: "alice"})
 	ch := NewChatRoomFactory(svc).New(ctx)
@@ -152,7 +54,7 @@ func TestChatRoomChannel_Init_OwnerImplicitMember(t *testing.T) {
 
 func TestChatRoomChannel_Init_NotMember(t *testing.T) {
 	svc, repo := newChatSvc(t)
-	repo.rooms["r1"] = &model.ChatRoom{ID: "r1", OwnerID: "alice"}
+	repo.Rooms["r1"] = &model.ChatRoom{ID: "r1", OwnerID: "alice"}
 
 	ctx := newCtx(&model.User{ID: "carol"})
 	ch := NewChatRoomFactory(svc).New(ctx)
@@ -191,7 +93,7 @@ func TestChatRoomChannel_Init_BadJSON(t *testing.T) {
 
 func TestChatRoomChannel_OnRedisEvent_Forwards(t *testing.T) {
 	svc, repo := newChatSvc(t)
-	repo.rooms["r1"] = &model.ChatRoom{ID: "r1", OwnerID: "alice"}
+	repo.Rooms["r1"] = &model.ChatRoom{ID: "r1", OwnerID: "alice"}
 	ctx := newCtx(&model.User{ID: "alice"})
 	ch := NewChatRoomFactory(svc).New(ctx)
 	ch.Init(json.RawMessage(`{"roomId":"r1"}`))
@@ -202,7 +104,7 @@ func TestChatRoomChannel_OnRedisEvent_Forwards(t *testing.T) {
 
 func TestChatRoomChannel_OnRedisEvent_Invalid(t *testing.T) {
 	svc, repo := newChatSvc(t)
-	repo.rooms["r1"] = &model.ChatRoom{ID: "r1", OwnerID: "alice"}
+	repo.Rooms["r1"] = &model.ChatRoom{ID: "r1", OwnerID: "alice"}
 	ctx := newCtx(&model.User{ID: "alice"})
 	ch := NewChatRoomFactory(svc).New(ctx)
 	ch.Init(json.RawMessage(`{"roomId":"r1"}`))
@@ -212,7 +114,7 @@ func TestChatRoomChannel_OnRedisEvent_Invalid(t *testing.T) {
 
 func TestChatRoomChannel_OnRedisEvent_NoType(t *testing.T) {
 	svc, repo := newChatSvc(t)
-	repo.rooms["r1"] = &model.ChatRoom{ID: "r1", OwnerID: "alice"}
+	repo.Rooms["r1"] = &model.ChatRoom{ID: "r1", OwnerID: "alice"}
 	ctx := newCtx(&model.User{ID: "alice"})
 	ch := NewChatRoomFactory(svc).New(ctx)
 	ch.Init(json.RawMessage(`{"roomId":"r1"}`))
@@ -222,9 +124,9 @@ func TestChatRoomChannel_OnRedisEvent_NoType(t *testing.T) {
 
 func TestChatRoomChannel_OnClientMessage_Read(t *testing.T) {
 	svc, repo := newChatSvc(t)
-	repo.rooms["r1"] = &model.ChatRoom{ID: "r1", OwnerID: "alice"}
+	repo.Rooms["r1"] = &model.ChatRoom{ID: "r1", OwnerID: "alice"}
 	textStr := "hi"
-	repo.messages["m1"] = &model.ChatMessage{
+	repo.Messages["m1"] = &model.ChatMessage{
 		ID: "m1", FromUserID: "alice", ToRoomID: strPtr("r1"), Text: &textStr,
 	}
 	ctx := newCtx(&model.User{ID: "alice"})
@@ -236,7 +138,7 @@ func TestChatRoomChannel_OnClientMessage_Read(t *testing.T) {
 
 func TestChatRoomChannel_OnClientMessage_UnknownType(t *testing.T) {
 	svc, repo := newChatSvc(t)
-	repo.rooms["r1"] = &model.ChatRoom{ID: "r1", OwnerID: "alice"}
+	repo.Rooms["r1"] = &model.ChatRoom{ID: "r1", OwnerID: "alice"}
 	ctx := newCtx(&model.User{ID: "alice"})
 	ch := NewChatRoomFactory(svc).New(ctx)
 	ch.Init(json.RawMessage(`{"roomId":"r1"}`))
@@ -246,7 +148,7 @@ func TestChatRoomChannel_OnClientMessage_UnknownType(t *testing.T) {
 
 func TestChatRoomChannel_OnClientMessage_ReadEmptyID(t *testing.T) {
 	svc, repo := newChatSvc(t)
-	repo.rooms["r1"] = &model.ChatRoom{ID: "r1", OwnerID: "alice"}
+	repo.Rooms["r1"] = &model.ChatRoom{ID: "r1", OwnerID: "alice"}
 	ctx := newCtx(&model.User{ID: "alice"})
 	ch := NewChatRoomFactory(svc).New(ctx)
 	ch.Init(json.RawMessage(`{"roomId":"r1"}`))
@@ -255,7 +157,7 @@ func TestChatRoomChannel_OnClientMessage_ReadEmptyID(t *testing.T) {
 
 func TestChatRoomChannel_OnClientMessage_ReadBadJSON(t *testing.T) {
 	svc, repo := newChatSvc(t)
-	repo.rooms["r1"] = &model.ChatRoom{ID: "r1", OwnerID: "alice"}
+	repo.Rooms["r1"] = &model.ChatRoom{ID: "r1", OwnerID: "alice"}
 	ctx := newCtx(&model.User{ID: "alice"})
 	ch := NewChatRoomFactory(svc).New(ctx)
 	ch.Init(json.RawMessage(`{"roomId":"r1"}`))
@@ -285,7 +187,7 @@ func TestChatRoomChannel_OnClientMessage_ReadServiceError(t *testing.T) {
 
 func TestChatRoomChannel_Dispose(t *testing.T) {
 	svc, repo := newChatSvc(t)
-	repo.rooms["r1"] = &model.ChatRoom{ID: "r1", OwnerID: "alice"}
+	repo.Rooms["r1"] = &model.ChatRoom{ID: "r1", OwnerID: "alice"}
 	ctx := newCtx(&model.User{ID: "alice"})
 	ch := NewChatRoomFactory(svc).New(ctx)
 	ch.Init(json.RawMessage(`{"roomId":"r1"}`))

--- a/internal/stream/channels/chat_user_test.go
+++ b/internal/stream/channels/chat_user_test.go
@@ -86,7 +86,7 @@ func TestChatUserChannel_OnClientMessage_Read(t *testing.T) {
 	svc, repo := newChatSvc(t)
 	text := "hi"
 	toID := "alice"
-	repo.messages["m1"] = &model.ChatMessage{
+	repo.Messages["m1"] = &model.ChatMessage{
 		ID: "m1", FromUserID: "bob", ToUserID: &toID, Text: &text,
 	}
 	ctx := newCtx(&model.User{ID: "alice"})

--- a/internal/testutil/mock_chat.go
+++ b/internal/testutil/mock_chat.go
@@ -1,0 +1,313 @@
+package testutil
+
+import (
+	"sync"
+
+	"github.com/shiroha-a/mk/internal/model"
+)
+
+// MockChatRepository is an in-memory implementation of repository.ChatRepository
+// shared across api/chat, core/chat and stream/channels test packages (#709).
+//
+// 各 test ファイルで重複していた mockChatRepo / fakeChatRepo / chatFakeRepo
+// を集約。ChatRepository に新メソッドを追加するたびに複数 stub に実装を生やす
+// 苦痛を解消する。
+//
+// 設計の意図:
+//   - 全 map 操作は内部 mutex 配下で行うため goroutine 並列 (例: ap_delivery
+//     のジョブ送出) でも race にならない。
+//   - メッセージ書き込み / 読み込みは clone して保持することで、呼び出し側が
+//     返り値を mutate しても store 内が壊れないようにする。
+//   - CreateErr / UpdateErr / DeleteErr で error path をテストできる。
+//   - 各 List* / FindInvitation 等 filter 操作はテストで実際に必要だった
+//     ものだけ実装している。残り (ListRoomsByOwner, ListMembersByRoom 等)
+//     は記録された state を元に予測可能な順序で返す。
+type MockChatRepository struct {
+	mu sync.Mutex
+
+	// Rooms keyed by room ID.
+	Rooms map[string]*model.ChatRoom
+	// Messages keyed by message ID. Stored as cloned copies.
+	Messages map[string]*model.ChatMessage
+	// Memberships keyed by "<userID>:<roomID>".
+	Memberships map[string]*model.ChatRoomMembership
+	// Invitations keyed by invitation ID.
+	Invitations map[string]*model.ChatRoomInvitation
+
+	// CreateErr forces Create* to return this error without persisting.
+	CreateErr error
+	// UpdateErr forces UpdateMessage to return this error without persisting.
+	UpdateErr error
+	// DeleteErr forces DeleteMessage to return this error without removing.
+	DeleteErr error
+}
+
+// NewMockChatRepository constructs an empty MockChatRepository ready for use.
+func NewMockChatRepository() *MockChatRepository {
+	return &MockChatRepository{
+		Rooms:       make(map[string]*model.ChatRoom),
+		Messages:    make(map[string]*model.ChatMessage),
+		Memberships: make(map[string]*model.ChatRoomMembership),
+		Invitations: make(map[string]*model.ChatRoomInvitation),
+	}
+}
+
+func membershipKey(userID, roomID string) string { return userID + ":" + roomID }
+
+// --- Rooms ---
+
+func (m *MockChatRepository) CreateRoom(room *model.ChatRoom) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if m.CreateErr != nil {
+		return m.CreateErr
+	}
+	m.Rooms[room.ID] = room
+	return nil
+}
+
+func (m *MockChatRepository) FindRoomByID(id string) (*model.ChatRoom, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if r, ok := m.Rooms[id]; ok {
+		return r, nil
+	}
+	return nil, ErrNotFound
+}
+
+func (m *MockChatRepository) UpdateRoom(room *model.ChatRoom) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.Rooms[room.ID] = room
+	return nil
+}
+
+func (m *MockChatRepository) DeleteRoom(id string) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	delete(m.Rooms, id)
+	return nil
+}
+
+func (m *MockChatRepository) ListRoomsByOwner(ownerID string) ([]*model.ChatRoom, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	out := make([]*model.ChatRoom, 0)
+	for _, r := range m.Rooms {
+		if r.OwnerID == ownerID {
+			out = append(out, r)
+		}
+	}
+	return out, nil
+}
+
+func (m *MockChatRepository) ListJoinedRooms(userID string) ([]*model.ChatRoom, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	out := make([]*model.ChatRoom, 0)
+	for _, mem := range m.Memberships {
+		if mem.UserID == userID {
+			if r, ok := m.Rooms[mem.RoomID]; ok {
+				out = append(out, r)
+			}
+		}
+	}
+	return out, nil
+}
+
+// --- Messages ---
+
+func (m *MockChatRepository) CreateMessage(msg *model.ChatMessage) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if m.CreateErr != nil {
+		return m.CreateErr
+	}
+	clone := *msg
+	m.Messages[msg.ID] = &clone
+	return nil
+}
+
+func (m *MockChatRepository) FindMessageByID(id string) (*model.ChatMessage, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if msg, ok := m.Messages[id]; ok {
+		clone := *msg
+		return &clone, nil
+	}
+	return nil, ErrNotFound
+}
+
+func (m *MockChatRepository) FindMessageByURI(uri string) (*model.ChatMessage, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	for _, msg := range m.Messages {
+		if msg.URI != nil && *msg.URI == uri {
+			clone := *msg
+			return &clone, nil
+		}
+	}
+	return nil, ErrNotFound
+}
+
+func (m *MockChatRepository) UpdateMessage(msg *model.ChatMessage) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if m.UpdateErr != nil {
+		return m.UpdateErr
+	}
+	clone := *msg
+	m.Messages[msg.ID] = &clone
+	return nil
+}
+
+func (m *MockChatRepository) DeleteMessage(id string) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if m.DeleteErr != nil {
+		return m.DeleteErr
+	}
+	delete(m.Messages, id)
+	return nil
+}
+
+func (m *MockChatRepository) ListMessagesByRoom(_ string, _ int) ([]*model.ChatMessage, error) {
+	return nil, nil
+}
+
+func (m *MockChatRepository) ListMessagesByUser(_, _ string, _ int) ([]*model.ChatMessage, error) {
+	return nil, nil
+}
+
+func (m *MockChatRepository) SearchMessages(_, _ string, _ int) ([]*model.ChatMessage, error) {
+	return nil, nil
+}
+
+// --- Memberships ---
+
+func (m *MockChatRepository) CreateMembership(mem *model.ChatRoomMembership) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.Memberships[membershipKey(mem.UserID, mem.RoomID)] = mem
+	return nil
+}
+
+func (m *MockChatRepository) FindMembership(userID, roomID string) (*model.ChatRoomMembership, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if mem, ok := m.Memberships[membershipKey(userID, roomID)]; ok {
+		return mem, nil
+	}
+	return nil, ErrNotFound
+}
+
+func (m *MockChatRepository) UpdateMembership(mem *model.ChatRoomMembership) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.Memberships[membershipKey(mem.UserID, mem.RoomID)] = mem
+	return nil
+}
+
+func (m *MockChatRepository) DeleteMembership(userID, roomID string) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	delete(m.Memberships, membershipKey(userID, roomID))
+	return nil
+}
+
+func (m *MockChatRepository) ListMembersByRoom(roomID string) ([]*model.ChatRoomMembership, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	out := make([]*model.ChatRoomMembership, 0)
+	for _, mem := range m.Memberships {
+		if mem.RoomID == roomID {
+			out = append(out, mem)
+		}
+	}
+	return out, nil
+}
+
+// --- Invitations ---
+
+func (m *MockChatRepository) CreateInvitation(inv *model.ChatRoomInvitation) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if m.CreateErr != nil {
+		return m.CreateErr
+	}
+	m.Invitations[inv.ID] = inv
+	return nil
+}
+
+func (m *MockChatRepository) DeleteInvitation(id string) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	delete(m.Invitations, id)
+	return nil
+}
+
+func (m *MockChatRepository) UpdateInvitation(inv *model.ChatRoomInvitation) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.Invitations[inv.ID] = inv
+	return nil
+}
+
+func (m *MockChatRepository) FindInvitation(userID, roomID string) (*model.ChatRoomInvitation, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	for _, inv := range m.Invitations {
+		if inv.UserID == userID && inv.RoomID == roomID {
+			return inv, nil
+		}
+	}
+	return nil, ErrNotFound
+}
+
+func (m *MockChatRepository) ListInvitationsByUser(_ string, _ bool) ([]*model.ChatRoomInvitation, error) {
+	return nil, nil
+}
+
+func (m *MockChatRepository) ListInvitationsByRoom(_ string) ([]*model.ChatRoomInvitation, error) {
+	return nil, nil
+}
+
+// --- Read tracking / unread count ---
+
+func (m *MockChatRepository) CountUnread(_ string) (int64, error) { return 0, nil }
+
+// MarkRead appends userID to the message's reads slice (idempotency は real
+// impl 側のクエリで担保される。テスト用なので重複防止はしない)。
+func (m *MockChatRepository) MarkRead(userID, messageID string) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if msg, ok := m.Messages[messageID]; ok {
+		msg.Reads = append(msg.Reads, userID)
+	}
+	return nil
+}
+
+func (m *MockChatRepository) MarkAllRead(_ string) error            { return nil }
+func (m *MockChatRepository) MarkAllReadFromUser(_, _ string) error { return nil }
+func (m *MockChatRepository) MarkAllReadInRoom(_, _ string) error   { return nil }
+
+// --- Delivery status / history ---
+
+func (m *MockChatRepository) UpdateDeliveryStatus(_ string, _, _ bool) error { return nil }
+
+func (m *MockChatRepository) ListHistory(_ string, _ int) ([]*model.ChatMessage, error) {
+	return nil, nil
+}
+
+func (m *MockChatRepository) ListUserHistory(_ string, _ int) ([]*model.ChatMessage, error) {
+	return nil, nil
+}
+
+func (m *MockChatRepository) ListRoomHistory(_ string, _ int) ([]*model.ChatMessage, error) {
+	return nil, nil
+}
+
+// --- Reactions ---
+
+func (m *MockChatRepository) AddReaction(_, _ string) error    { return nil }
+func (m *MockChatRepository) RemoveReaction(_, _ string) error { return nil }

--- a/internal/testutil/mock_chat_test.go
+++ b/internal/testutil/mock_chat_test.go
@@ -1,0 +1,13 @@
+package testutil
+
+import "github.com/shiroha-a/mk/internal/repository"
+
+// 集約の動機を最大化する compile-time assertion (#709)。ChatRepository に
+// 新メソッドが追加されたとき、各 test ファイルを介さず mock 自身が
+// コンパイルエラーに落ちて気付ける。
+//
+// production code ファイル (mock_chat.go) で行うと testutil → repository の
+// import が production 側に乗ってしまい、repository の test 経由で import
+// cycle になる。`_test.go` に置けば testutil package の test build 時のみ
+// repository を含み、production graph には乗らない。
+var _ repository.ChatRepository = (*MockChatRepository)(nil)


### PR DESCRIPTION
## Summary

ChatRepository interface に新メソッドを追加するたびに 4 ファイル全てに stub 実装を生やす苦痛 (#708 review #3 で指摘) を解消する。

## 集約前後

| 場所 | 集約前 | 集約後 |
|---|---|---|
| internal/api/chat/handler_test.go | mockChatRepo | testutil.MockChatRepository |
| internal/core/chat/service_test.go | fakeChatRepo | testutil.MockChatRepository |
| internal/core/chat/ap_delivery_test.go | (service_test の fake 再利用) | testutil.MockChatRepository |
| internal/stream/channels/chat_room_test.go | chatFakeRepo | testutil.MockChatRepository |

既存パターン (\`MockUserRepository\` / \`MockEmojiRepository\` 等) と同じ。

## 設計の意図

\`testutil.MockChatRepository\` は 4 つの stub の union を満たす機能を持つ:

- 内部 \`sync.Mutex\` で goroutine 並列呼び出し safe (ap_delivery のジョブ送出系で必須)
- message 書き込み / 読み込みは clone して保持 (呼び出し側 mutate 耐性)
- \`CreateErr\` / \`UpdateErr\` / \`DeleteErr\` で error path を注入できる
- \`ListRoomsByOwner\` / \`ListJoinedRooms\` / \`ListMembersByRoom\` / \`FindInvitation\` の filter 動作
- \`MarkRead\` で \`reads\` slice に append (real impl の重複防止は内部クエリで担保される前提)

## 挙動互換

- 各 test ファイルから個別 stub 削除し \`testutil.NewMockChatRepository()\` に置換
- field アクセスは公開 field \`Rooms\` / \`Messages\` / \`Memberships\` / \`Invitations\` / \`CreateErr\` / \`UpdateErr\` / \`DeleteErr\` 経由
- \`newFakeRepo()\` (service_test.go / ap_delivery_test.go) は alias として残し、同パッケージ内の他 test 呼び出しに影響を与えない
- \`failUpdateRoomRepo\` / \`readMarkSpyRepo\` / \`readMarkErrRepo\` の embed 型も \`*testutil.MockChatRepository\` に差し替え

## 差分

476 行削除 / 410 行追加 (実質 -66 行 + 重複 stub 排除)。今後 ChatRepository に新メソッドを追加するときは \`testutil.MockChatRepository\` 1 箇所に追加するだけで済む。

## テスト

\`make fmt\` / \`make lint\` / \`make test\` 全 pass。

## Closes

Closes #709

🤖 Generated with [Claude Code](https://claude.com/claude-code)