### PR TITLE
video-thumb をデフォルト無効化 (opt-in 化)

### DIFF
--- a/.config/docker.yml.example
+++ b/.config/docker.yml.example
@@ -180,11 +180,14 @@ proxyBypassHosts:
 
 #mediaProxy: https://example.com/proxy
 
-# Video thumbnail generator. The bundled docker-compose ships a `video-thumb`
-# service (nekonoverse/video-thumb, listens on 8005). Default wire mode
-# "post" forwards multipart bytes — see default.yml.example for the "get"
-# Misskey TS-compat alternative.
-videoThumbnailGenerator: http://video-thumb:8005
+# Video thumbnail generator. docker-compose.yml に `video-thumb` service
+# (nekonoverse/video-thumb) を同梱しているが default では disabled。
+# 動画サムネを生成したい operator は docker-compose.yml の `video-thumb`
+# block と以下の行を両方コメントアウト解除する。
+# 設定が無ければ mk-go は video request に dummy PNG を返すだけで外部
+# generator を呼ばない。default wire mode "post" は multipart bytes 転送、
+# Misskey TS 互換の "get" 経路は default.yml.example を参照。
+#videoThumbnailGenerator: http://video-thumb:8005
 #videoThumbnailGeneratorMode: post
 
 #allowedPrivateNetworks:

--- a/compose.uds.yaml.example
+++ b/compose.uds.yaml.example
@@ -59,23 +59,28 @@ services:
     restart: unless-stopped
 
   # Video thumbnail generator (#637 M2). UDS-only stack 全体に揃えて TCP は
-  # 開かず named volume 経由の socket だけで mk-go と通信する。mk-go 側は
-  # `videoThumbnailGenerator: unix:///run/video-thumb/sock` を設定すれば
-  # 自動で UDS dialer 経由で接続する。
+  # 開かず named volume 経由の socket だけで mk-go と通信する。
+  #
+  # default では disabled。動画サムネを生成したい operator は本 service と
+  # 下の `mkgo` service の `video_thumb_sock` volume mount、および
+  # volumes セクションの `video_thumb_sock` 定義をコメントアウト解除し、
+  # config に `videoThumbnailGenerator: unix:///run/video-thumb/sock` を
+  # 設定する。設定が無ければ mk-go は video request に dummy PNG を返す
+  # だけで外部 generator を呼ばない。
   #
   # nekonoverse/video-thumb は `UDS_PATH` env で UDS listen に切替えられる
   # 仕様。default の wire mode "post" (multipart POST) と互換。Misskey TS
   # 互換の GET 経路に切替えたい場合は mk-go 側で
   # `videoThumbnailGeneratorMode: get` を設定し、対応 image に差し替える。
-  video-thumb:
-    image: ghcr.io/nekonoverse/video-thumb:unstable
-    environment:
-      UDS_PATH: /run/video-thumb/sock
-    volumes:
-      - video_thumb_sock:/run/video-thumb
-    networks:
-      - mkgo-uds
-    restart: unless-stopped
+  #video-thumb:
+  #  image: ghcr.io/nekonoverse/video-thumb:unstable
+  #  environment:
+  #    UDS_PATH: /run/video-thumb/sock
+  #  volumes:
+  #    - video_thumb_sock:/run/video-thumb
+  #  networks:
+  #    - mkgo-uds
+  #  restart: unless-stopped
 
   mkgo:
     build:
@@ -107,7 +112,9 @@ services:
       - mkgo_sock:/run/mkgo
       # video thumbnail generator socket (#637 M2)。read-only で良い:
       # mk-go は connect するだけで、socket 自体は video-thumb 側が作る。
-      - video_thumb_sock:/run/video-thumb
+      # default 無効化に伴いコメントアウト。video-thumb を使うときは
+      # 本行と上の video-thumb service block の両方を有効化する。
+      #- video_thumb_sock:/run/video-thumb
     healthcheck:
       # UDS 経由なので curl --unix-socket を使う (wget は UDS 非対応)。
       # /healthz は router.go で公開している health check エンドポイント。
@@ -155,4 +162,5 @@ volumes:
   pg_sock:
   valkey_sock:
   mkgo_sock:
-  video_thumb_sock:
+  # video-thumb service と組で有効化する。
+  #video_thumb_sock:

--- a/deploy/uds/config/default.yml.example
+++ b/deploy/uds/config/default.yml.example
@@ -240,10 +240,13 @@ proxyBypassHosts:
 #mediaProxy: https://example.com/proxy
 #mediaProxySecret: change-me
 
-# Video thumbnail generator. The bundled UDS stack runs nekonoverse/video-thumb
-# listening on /run/video-thumb/sock; the POST multipart wire is the default
-# (see videoThumbnailGeneratorMode below).
-videoThumbnailGenerator: unix:///run/video-thumb/sock
+# Video thumbnail generator. compose.uds.yaml.example に nekonoverse/
+# video-thumb service を同梱しているが default では disabled。動画サムネを
+# 生成したい operator は compose.uds.yaml の `video-thumb` block / socket
+# mount / `video_thumb_sock` volume を全て有効化し、以下も有効化する。
+# 設定が無ければ mk-go は video request に dummy PNG を返すだけで外部
+# generator を呼ばない。
+#videoThumbnailGenerator: unix:///run/video-thumb/sock
 # "post" (default, mk-go style — forwards multipart bytes) or "get"
 # (Misskey TS-compat — sends the source URL via query string for the
 # generator to fetch).

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -59,17 +59,19 @@ services:
   # を返してもらう。app コンテナとは Docker network 内で通信し、公開
   # ポートは持たない (origin 側は mk-go の /proxy 経由でしか到達しない)。
   #
-  # mk-go 側で `videoThumbnailGenerator: http://video-thumb:8005` を設定
-  # することで wire される。UDS deployment では compose.uds.yaml.example
-  # の video-thumb service が socket mount で接続する。
+  # default では disabled。動画サムネを生成したい operator は以下を
+  # コメントアウト解除し、加えて .config/docker.yml の
+  # `videoThumbnailGenerator: http://video-thumb:8005` も有効化する。
+  # 設定が無ければ mk-go は video request に dummy PNG を返すだけで
+  # 外部 generator を呼ばない。
   #
   # 互換 image: ghcr.io/nekonoverse/video-thumb (POST /thumbnail multipart)。
   # Misskey TS 互換の GET 経路を使いたい場合は
   # `videoThumbnailGeneratorMode: get` を設定し、対応 image
   # (`GET /thumbnail.webp?thumbnail=1&url=<URL>`) に差し替える。
-  video-thumb:
-    image: ghcr.io/nekonoverse/video-thumb:unstable
-    restart: unless-stopped
+  #video-thumb:
+  #  image: ghcr.io/nekonoverse/video-thumb:unstable
+  #  restart: unless-stopped
 
 volumes:
   db_data:


### PR DESCRIPTION
## Summary

PR #646 で導入した nekonoverse/video-thumb sidecar の依存をデフォルトで切り、動画サムネ生成は operator が明示的に有効化したときだけ動くようにする。

mk-go は \`videoThumbnailGenerator\` 未設定時に dummy PNG を返す挙動が既に \`internal/core/mediaproxy/service.go:482\` に実装済み (#637 M2 / PR #646)。よって設定 / compose ファイル側で default を disabled に倒すだけで opt-in 化が完成する。production code の変更ゼロ。

## 主な変更点

operator が \`cp\` して使う example および同梱 compose の 4 ファイル:

| ファイル | 変更 |
|---|---|
| \`docker-compose.yml\` | \`video-thumb\` service block を全行コメントアウト |
| \`compose.uds.yaml.example\` | \`video-thumb\` service + \`mkgo\` の socket mount + \`video_thumb_sock\` volume 定義の 3 箇所をコメントアウト |
| \`.config/docker.yml.example\` | \`videoThumbnailGenerator: http://video-thumb:8005\` をコメントアウト |
| \`deploy/uds/config/default.yml.example\` | \`videoThumbnailGenerator: unix:///run/video-thumb/sock\` をコメントアウト |

各 example のコメントに以下を明記:
- 動画サムネを生成したい operator は **両方** (compose service と config) を有効化する必要がある
- 設定が無ければ mk-go は video request に dummy PNG を返すだけで外部 generator を呼ばない

これで opt-in 解放時の組み合わせ漏れ (例: compose だけ有効化して config 忘れ) を防ぐ。

## 既存 operator 影響

- 既に \`operator-local\` の \`compose.uds.yaml\` / \`.config/docker.yml\` / \`default.yml\` をコピー済みの環境は変更なし (これらは gitignored)
- 新規セットアップでは default で video-thumb 無効、必要なら opt-in で有効化

## upstream Misskey TS との比較

| 設定 | upstream | 本 PR 後 |
|---|---|---|
| 設定あり | 外部 generator へ 301 redirect | 外部 generator へ POST/GET |
| 設定なし | backend 内 fluent-ffmpeg で生成 | dummy PNG (mk-go は cgo-free 方針で local ffmpeg を持たない) |

「設定なし fallback」の挙動は mk-go 独自だが、cgo-free / static binary 方針 (#618-620) と整合する。

## テスト

- \`docker compose config\` / \`docker compose -f compose.uds.yaml.example config\` で syntax 検証 OK
- ローカル UDS 環境で mkgo container にマウントされる config から \`videoThumbnailGenerator\` 行が消えていることを確認
- code path 上 \`videoThumbClient == nil\` が確定 → dummy PNG fallback (PR #646 で test 済み)

🤖 Generated with [Claude Code](https://claude.com/claude-code)