### PR TITLE
Fix #745: Go 1.25 → 1.26.2 アップグレード

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/devcontainers/go:1.25
+FROM mcr.microsoft.com/devcontainers/go:1.26
 
 # /go の所有権を vscode ユーザーに変更 (go mod download の権限エラー回避)
 RUN chown -R vscode:vscode /go

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -12,7 +12,7 @@
 
 | Component | Library | 用途 |
 |-----------|---------|------|
-| 言語 | **Go 1.25** | `go.mod`でバージョン管理 |
+| 言語 | **Go 1.26** | `go.mod`でバージョン管理 |
 | Webフレームワーク | **Echo v4** (`labstack/echo/v4`) | HTTPルーティング、ミドルウェア、WebSocket |
 | ORM | **GORM** (`gorm.io/gorm`) | PostgreSQLアクセス |
 | Migration | **golang-migrate** (`golang-migrate/migrate/v4`) | SQLベースのマイグレーション |

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@
 # runner) でも default frontend が 1.5+ になる現代では `1.7` で問題なし。
 
 # Stage 1: Build Go binary
-FROM golang:1.25-alpine AS builder
+FROM golang:1.26-alpine AS builder
 
 # Step 2 (#618) で chai2010/webp → gen2brain/webp (libwebp on wazero/WASM) に
 # 切替えたので cgo 依存はゼロ。build-base (gcc + musl libc) は不要になった。

--- a/deploy/uds/Dockerfile.mkgo
+++ b/deploy/uds/Dockerfile.mkgo
@@ -9,7 +9,7 @@
 #
 # Build context must be the repository root.
 # `# syntax=` directive は BuildKit の cache mount を有効化するため必要 (#432)。
-FROM golang:1.25-alpine AS builder
+FROM golang:1.26-alpine AS builder
 
 RUN apk add --no-cache git build-base
 

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -106,7 +106,7 @@ make migrate-up
 ./built/misskey -config .config/default.yml
 ```
 
-前提条件: Go 1.25+ (ビルド時)、PostgreSQL 16+、Redis 7+。
+前提条件: Go 1.26+ (ビルド時)、PostgreSQL 16+、Redis 7+。
 
 設定ファイルの詳細は[設定リファレンス](configuration.md)を参照。
 

--- a/docs/development.md
+++ b/docs/development.md
@@ -7,7 +7,7 @@
 VS Codeの[Dev Containers](https://code.visualstudio.com/docs/devcontainers/containers)拡張をインストールして開く。
 
 `.devcontainer/`の構成:
-- Go 1.25 + PostgreSQL + Redis (network_mode: host)
+- Go 1.26 + PostgreSQL + Redis (network_mode: host)
 - golang-migrate、Node.js 22、pnpmがプリインストール
 - `postCreate.sh`で初期化
 
@@ -19,7 +19,7 @@ make dev
 ### ローカル環境
 
 前提条件:
-- Go 1.25+
+- Go 1.26+
 - PostgreSQL 16+
 - Redis 7+
 - Docker (testcontainers用、テスト実行に必要)

--- a/docs/migration-from-ts.md
+++ b/docs/migration-from-ts.md
@@ -4,7 +4,7 @@
 
 ## 前提条件
 
-- Go 1.25+
+- Go 1.26+
 - PostgreSQL 16+ (既存のMisskey-TSデータベース)
 - Redis 7+
 - git

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/shiroha-a/mk
 
-go 1.25.0
+go 1.26.2
 
 require (
 	github.com/SherClockHolmes/webpush-go v1.4.0

--- a/internal/activitypub/keypair_test.go
+++ b/internal/activitypub/keypair_test.go
@@ -98,7 +98,10 @@ func TestParseRSAPublicKey_NotRSA(t *testing.T) {
 	assert.Contains(t, err.Error(), "not an RSA")
 }
 
-// errReader is an io.Reader that always errors.
+// errReader is an io.Reader that always errors. signature_test.go の
+// TestSignRequest_RandError で randReader を差し替えるために共有する
+// (Go 1.26 で rsa.GenerateKey 系の random 引数は無視されるが、
+// rsa.SignPKCS1v15 / ed25519 経路では引き続き使われる)。
 type errReader struct{}
 
 func (errReader) Read(_ []byte) (int, error) { return 0, assertErr }
@@ -110,14 +113,3 @@ type sentinelErr struct{ msg string }
 func (e *sentinelErr) Error() string { return e.msg }
 
 func newSentinelErr(s string) error { return &sentinelErr{msg: s} }
-
-func TestGenerateRSAKeypair_RandError(t *testing.T) {
-	// Go 1.26 で crypto/rsa.GenerateKey の `random` 引数が完全に無視される
-	// 仕様に変更された (https://go.dev/doc/go1.26 crypto/rsa セクション、
-	// "The random parameter to GenerateKey ... is now ignored.") ため、
-	// SetRandReaderForTest で errReader を注入しても rsa.GenerateKey が
-	// それを消費せずに getrandom 経由で成功してしまう。entropy source 系
-	// のエラーを擬似できなくなったので skip。production の randReader 変数
-	// は ed25519.GenerateKey 経路で引き続き使われるため残す。
-	t.Skip("Go 1.26+: rsa.GenerateKey ignores random parameter (release notes)")
-}

--- a/internal/activitypub/keypair_test.go
+++ b/internal/activitypub/keypair_test.go
@@ -112,9 +112,12 @@ func (e *sentinelErr) Error() string { return e.msg }
 func newSentinelErr(s string) error { return &sentinelErr{msg: s} }
 
 func TestGenerateRSAKeypair_RandError(t *testing.T) {
-	restore := SetRandReaderForTest(errReader{})
-	defer restore()
-
-	_, _, err := GenerateRSAKeypair()
-	require.Error(t, err)
+	// Go 1.26 で crypto/rsa.GenerateKey の `random` 引数が完全に無視される
+	// 仕様に変更された (https://go.dev/doc/go1.26 crypto/rsa セクション、
+	// "The random parameter to GenerateKey ... is now ignored.") ため、
+	// SetRandReaderForTest で errReader を注入しても rsa.GenerateKey が
+	// それを消費せずに getrandom 経由で成功してしまう。entropy source 系
+	// のエラーを擬似できなくなったので skip。production の randReader 変数
+	// は ed25519.GenerateKey 経路で引き続き使われるため残す。
+	t.Skip("Go 1.26+: rsa.GenerateKey ignores random parameter (release notes)")
 }


### PR DESCRIPTION
## Summary

最新安定版 Go 1.26.2 に追従 (https://go.dev/dl/?mode=json で stable: true トップ)。1.27 は 2026-08 頃の見込みでまだ未公開なのでその前段。

## 変更点

| ファイル | 変更 |
|---|---|
| \`go.mod\` | \`go 1.25.0\` → \`go 1.26.2\` |
| \`Dockerfile\` | \`golang:1.25-alpine\` → \`golang:1.26-alpine\` |
| \`deploy/uds/Dockerfile.mkgo\` | 同上 |
| \`.devcontainer/Dockerfile\` | \`devcontainers/go:1.25\` → \`1.26\` |
| \`CLAUDE.md\` | Go 1.25 → 1.26 表記更新 |
| \`docs/{migration-from-ts,development,deployment}.md\` | Go 1.25(+) → 1.26(+) |
| \`internal/activitypub/keypair_test.go\` | breaking change 対応 (下記) |

CI workflow (\`.github/workflows/ci.yml\`) は \`go-version-file: go.mod\` 経由で 1.26.2 を pull するため変更不要。

## Go 1.26 breaking change 対応

\`TestGenerateRSAKeypair_RandError\` を skip 化:

> **crypto/rsa**: The random parameter to \`GenerateKey\`, \`GenerateMultiPrimeKey\`, and \`EncryptPKCS1v15\` is now ignored. — https://go.dev/doc/go1.26

errReader を randReader に注入して entropy エラーを擬似する従来の test 構造が、引数が無視されることで動作不能に。production の \`randReader\` 変数自体は ed25519.GenerateKey 経路で引き続き使われているのでそのまま残す。

## 検証

- \`go test -race -count=1 -timeout 5m ./...\` 全 pass
- \`make fmt\` / \`make lint\` クリーン
- \`make uds-build\` / \`make uds-up\` 成功
- \`docker exec mk-mkgo-1 strings /app/misskey | grep ^go1.\` → \`go1.26.2\`
- \`/healthz\` 200 OK 確認

## ローカル開発者影響

\`go.mod\` の \`go 1.26.2\` directive により \`GOTOOLCHAIN=auto\` (default) で 1.26.2 が自動 download される。手動 install 不要。

## Closes

Closes #745

🤖 Generated with [Claude Code](https://claude.com/claude-code)