### PR TITLE
Fix #406: NSFW sensitive media detection を外部 detector URL 接続で対応

### DIFF
--- a/.config/default.yml.example
+++ b/.config/default.yml.example
@@ -300,6 +300,24 @@ proxyBypassHosts:
 #videoThumbnailGenerator: unix:///run/video-thumb/sock
 #videoThumbnailGeneratorMode: post
 
+# NSFW sensitive media detection. mk-go は backend に ML runtime を抱えない
+# 方針 (#406)。動画サムネと同じく default 無効で、operator が外部 detector
+# service の URL を指定したときのみ自動 isSensitive 付与が動く。動作モード
+# (検出範囲 / 閾値 / 動画対象 / silenced hosts) は admin 設定 (meta) 経由で
+# upstream Misskey TS 互換に制御する。
+#
+# Wire (mk-go が呼ぶ仕様):
+#   POST <url> with raw image/video bytes
+#   Content-Type: <MIME>
+#   Response: JSON {"score": float64}  (0.0=safe ~ 1.0=NSFW)
+#
+# 参考の互換 image (operator が選択):
+#   - andresribeiro/nsfwjs-docker (TypeScript / nsfwjs)
+#   - germesdev/nsfw_detector / nikos-glikis/nsfw-docker (Yahoo OpenNSFW)
+#   - SaaS: Cloudflare Workers AI / AWS Rekognition / Google Vision SafeSearch
+# wire format が違う場合は operator 側で thin proxy を被せて合わせる。
+#nsfwDetectorUrl: http://nsfw-detector:8080/score
+
 # For security reasons, uploading attachments from the intranet is
 # prohibited; exceptions can be allowed here. Default is empty.
 #allowedPrivateNetworks:

--- a/.config/docker.yml.example
+++ b/.config/docker.yml.example
@@ -190,6 +190,11 @@ proxyBypassHosts:
 #videoThumbnailGenerator: http://video-thumb:8005
 #videoThumbnailGeneratorMode: post
 
+# NSFW sensitive media detection (#406)。default 無効。operator が好きな
+# 互換 service を立てて URL を指定する。default.yml.example の同セクション
+# に wire 仕様と互換 image 候補を記載している。
+#nsfwDetectorUrl: http://nsfw-detector:8080/score
+
 #allowedPrivateNetworks:
 #  - '127.0.0.1/32'
 

--- a/deploy/uds/config/default.yml.example
+++ b/deploy/uds/config/default.yml.example
@@ -252,6 +252,13 @@ proxyBypassHosts:
 # generator to fetch).
 #videoThumbnailGeneratorMode: post
 
+# NSFW sensitive media detection (#406)。default 無効。互換 service の HTTP
+# URL を指定すると自動 isSensitive 付与が動く。詳細 (wire 仕様 / 互換 image
+# 候補) は default.yml.example を参照。HTTP only (unix:// は将来拡張)、
+# UDS-only stack でも detector は overlay network 経由で 1 service のみ
+# TCP listen させる構成で対応する。
+#nsfwDetectorUrl: http://nsfw-detector:8080/score
+
 #allowedPrivateNetworks:
 #  - '127.0.0.1/32'
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -174,8 +174,14 @@ type Source struct {
 	//   "get"                   — GET <gen>/thumbnail.webp?thumbnail=1&url=<URL>
 	//                             Misskey TS の videoThumbnailGenerator 仕様
 	//                             に互換 (#637 review)。
-	VideoThumbnailGeneratorMode string          `mapstructure:"videoThumbnailGeneratorMode"`
-	Logging                     *LoggingOptions `mapstructure:"logging"`
+	VideoThumbnailGeneratorMode string `mapstructure:"videoThumbnailGeneratorMode"`
+	// NSFWDetectorURL は外部 NSFW 判定 service の endpoint。空なら自動判定
+	// disabled で手動 isSensitive フラグのみ機能する (#406)。mk-go は
+	// backend に ML runtime を抱えない方針なので、operator が任意の互換
+	// service を立てて URL を指定する。Wire: POST body=image/video bytes,
+	// Content-Type=<MIME>, response JSON `{"score": float64}` (0..1)。
+	NSFWDetectorURL string          `mapstructure:"nsfwDetectorUrl"`
+	Logging         *LoggingOptions `mapstructure:"logging"`
 
 	PerChannelMaxNoteCacheCount  *int   `mapstructure:"perChannelMaxNoteCacheCount"`
 	PerUserNotificationsMaxCount *int   `mapstructure:"perUserNotificationsMaxCount"`
@@ -279,6 +285,7 @@ type Config struct {
 	MediaProxySecret             []byte
 	VideoThumbnailGenerator      string
 	VideoThumbnailGeneratorMode  string
+	NSFWDetectorURL              string
 	UserAgent                    string
 	PerChannelMaxNoteCacheCount  int
 	PerUserNotificationsMaxCount int
@@ -499,6 +506,7 @@ func resolve(src *Source) (*Config, error) {
 		MediaProxySecret:             mediaProxySecret,
 		VideoThumbnailGenerator:      strings.TrimRight(src.VideoThumbnailGenerator, "/"),
 		VideoThumbnailGeneratorMode:  normalizeVideoThumbMode(src.VideoThumbnailGeneratorMode),
+		NSFWDetectorURL:              strings.TrimRight(src.NSFWDetectorURL, "/"),
 		UserAgent:                    fmt.Sprintf("Misskey-Go/%s (%s)", MkGoVersion, src.URL),
 		PerChannelMaxNoteCacheCount:  perChannelMaxNoteCacheCount,
 		PerUserNotificationsMaxCount: perUserNotificationsMaxCount,

--- a/internal/core/drive/sensitive_test.go
+++ b/internal/core/drive/sensitive_test.go
@@ -3,10 +3,12 @@ package drive
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"net/http"
 	"net/http/httptest"
 	"testing"
 
+	"github.com/shiroha-a/mk/internal/model"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -81,4 +83,105 @@ func TestHTTPDetector_InvalidJSON(t *testing.T) {
 	d := NewHTTPDetector(srv.URL, nil)
 	_, err := d.Detect(context.Background(), []byte("data"), "image/png")
 	assert.Error(t, err)
+}
+
+// --- detectSensitive (Service method) tests ---
+
+// stubDetector returns the configured score / err.
+type stubDetector struct {
+	score float64
+	err   error
+}
+
+func (s stubDetector) Detect(_ context.Context, _ []byte, _ string) (float64, error) {
+	if s.err != nil {
+		return 0, s.err
+	}
+	return s.score, nil
+}
+
+// detector=nil → false (no auto-detection)。
+func TestDetectSensitive_NoDetector(t *testing.T) {
+	s := &Service{}
+	s.SetSensitiveDetection(nil, SensitiveConfig{
+		Detection: "all", Sensitivity: "medium", SetFlagAutomatically: true,
+	})
+	assert.False(t, s.detectSensitive(&model.User{}, []byte("data"), "image/png"))
+}
+
+// SilencedHost match は detector を呼ばずに true を返す。
+func TestDetectSensitive_SilencedHostShortCircuit(t *testing.T) {
+	host := "bad.example.com"
+	s := &Service{}
+	s.SetSensitiveDetection(stubDetector{score: 0.0}, SensitiveConfig{
+		Detection: "all", Sensitivity: "medium",
+		SetFlagAutomatically: false, // silenced は flag 設定とは無関係
+		SilencedHosts:        []string{"bad.example.com"},
+	})
+	assert.True(t, s.detectSensitive(&model.User{Host: &host}, []byte("data"), "image/png"))
+}
+
+// SetFlagAutomatically=false なら detector は呼ばれず false。
+func TestDetectSensitive_FlagDisabled(t *testing.T) {
+	s := &Service{}
+	s.SetSensitiveDetection(stubDetector{score: 0.99}, SensitiveConfig{
+		Detection: "all", Sensitivity: "medium", SetFlagAutomatically: false,
+	})
+	assert.False(t, s.detectSensitive(&model.User{}, []byte("data"), "image/png"))
+}
+
+// Detection mode が remote で local user → detector skip → false。
+func TestDetectSensitive_DetectionModeMismatch(t *testing.T) {
+	s := &Service{}
+	s.SetSensitiveDetection(stubDetector{score: 0.99}, SensitiveConfig{
+		Detection: "remote", Sensitivity: "medium", SetFlagAutomatically: true,
+	})
+	assert.False(t, s.detectSensitive(&model.User{}, []byte("data"), "image/png"))
+}
+
+// 動画 MIME + EnableForVideos=false → detector skip → false。
+func TestDetectSensitive_VideoSkipWhenDisabled(t *testing.T) {
+	s := &Service{}
+	s.SetSensitiveDetection(stubDetector{score: 0.99}, SensitiveConfig{
+		Detection: "all", Sensitivity: "medium", SetFlagAutomatically: true,
+		EnableForVideos: false,
+	})
+	assert.False(t, s.detectSensitive(&model.User{}, []byte("data"), "video/mp4"))
+}
+
+// 動画 MIME + EnableForVideos=true + score>=threshold → true。
+func TestDetectSensitive_VideoEnabledAndAboveThreshold(t *testing.T) {
+	s := &Service{}
+	s.SetSensitiveDetection(stubDetector{score: 0.7}, SensitiveConfig{
+		Detection: "all", Sensitivity: "medium", SetFlagAutomatically: true,
+		EnableForVideos: true,
+	})
+	assert.True(t, s.detectSensitive(&model.User{}, []byte("data"), "video/mp4"))
+}
+
+// score >= threshold → true。
+func TestDetectSensitive_AboveThreshold(t *testing.T) {
+	s := &Service{}
+	s.SetSensitiveDetection(stubDetector{score: 0.7}, SensitiveConfig{
+		Detection: "all", Sensitivity: "medium", SetFlagAutomatically: true,
+	})
+	assert.True(t, s.detectSensitive(&model.User{}, []byte("data"), "image/png"))
+}
+
+// score < threshold → false。
+func TestDetectSensitive_BelowThreshold(t *testing.T) {
+	s := &Service{}
+	s.SetSensitiveDetection(stubDetector{score: 0.4}, SensitiveConfig{
+		Detection: "all", Sensitivity: "medium", SetFlagAutomatically: true,
+	})
+	assert.False(t, s.detectSensitive(&model.User{}, []byte("data"), "image/png"))
+}
+
+// detector がエラーを返したら false (best-effort)。
+func TestDetectSensitive_DetectorError(t *testing.T) {
+	s := &Service{}
+	s.SetSensitiveDetection(stubDetector{err: errors.New("net fail")}, SensitiveConfig{
+		Detection: "all", Sensitivity: "medium", SetFlagAutomatically: true,
+	})
+	assert.False(t, s.detectSensitive(&model.User{}, []byte("data"), "image/png"))
 }

--- a/internal/server/router.go
+++ b/internal/server/router.go
@@ -355,7 +355,12 @@ func (s *Server) setupRoutes() {
 	driveService.SetImageProcessor(imgProcessor)
 	driveService.SetVideoProcessor(coredrive.NewFFmpegVideoProcessor(imgProcessor, nil))
 
-	// Sensitive media detection (issue #44)
+	// Sensitive media detection (#44 / #406)。mk-go は backend に ML runtime
+	// を抱えないので、operator が任意の互換 service を立てて URL を
+	// `nsfwDetectorUrl` 設定に書く。URL が空なら detector=nil で自動付与は
+	// 走らず、手動 isSensitive フラグのみ機能する (default)。動作モード
+	// (Detection mode / Sensitivity / SetFlagAutomatically / EnableForVideos /
+	// SilencedHosts) は admin の `meta` カラム経由で TS 互換に制御。
 	if sensMeta, err := metaRepo.Fetch(); err == nil {
 		sensCfg := coredrive.SensitiveConfig{
 			Detection:            sensMeta.SensitiveMediaDetection,
@@ -364,8 +369,11 @@ func (s *Server) setupRoutes() {
 			EnableForVideos:      sensMeta.EnableSensitiveMediaDetectionForVideos,
 			SilencedHosts:        sensMeta.MediaSilencedHosts,
 		}
-		// 外部 detection URL は config に追加可能 (未設定なら detector = nil で no-op)
-		driveService.SetSensitiveDetection(nil, sensCfg)
+		var nsfwDetector coredrive.SensitiveDetector
+		if url := s.config.NSFWDetectorURL; url != "" {
+			nsfwDetector = coredrive.NewHTTPDetector(url, s.outboundClient(30*time.Second))
+		}
+		driveService.SetSensitiveDetection(nsfwDetector, sensCfg)
 	}
 
 	// Export / Import workers (Phase 9.4): drive に保存するエクスポートと


### PR DESCRIPTION
## Summary

issue #406 の方針変更: ONNX runtime + nsfwjs モデルを build tag 同梱する当初案を撤回し、**外部 detector service を URL 接続**する形 (sidecar pattern) で実装。

撤回理由:
- 自動判定の精度が当てにならない
- バイナリ肥大化 (39MB → 100MB+) が mk-go の軽量さを毀損
- メモリリーク等の運用リスク

## 設計

mk-go は backend に ML runtime を抱えない方針。operator が任意の互換 service を立てて URL を指定したときだけ自動 \`isSensitive\` 付与が動く。default 無効。

\`\`\`
mk-go ─POST bytes (Content-Type: image/...)─> <operator's NSFW detector> ─> {score: 0.0-1.0}
\`\`\`

## 実装

実は \`internal/core/drive/sensitive.go\` に \`HTTPDetector\` + \`SensitiveConfig\` + \`detectSensitive()\` が既に dead code として実装済みだった。本 PR は **その活性化のみ**。

| 変更 | 内容 |
|---|---|
| \`internal/config\` | \`NSFWDetectorURL\` (YAML: \`nsfwDetectorUrl\`) 追加 |
| \`internal/server/router.go\` | URL が空でなければ \`NewHTTPDetector\` を作って \`driveService.SetSensitiveDetection\` に渡す。空なら \`nil\` で従来挙動維持 |
| \`internal/core/drive/sensitive_test.go\` | \`detectSensitive\` 関数の挙動 test 9 ケース追加 |
| \`.config/{default,docker}.yml.example\` / \`deploy/uds/config/default.yml.example\` | opt-in コメントアウト例 + wire 仕様 + 互換 image 候補 |

動作モード (Detection mode / Sensitivity / SetFlagAutomatically / EnableForVideos / SilencedHosts) は admin の \`meta\` カラム経由で upstream TS 互換に制御。

## 互換 image (operator が選択)

mk-go は sidecar image を同梱しない。例:

| 候補 | base | 備考 |
|---|---|---|
| [andresribeiro/nsfwjs-docker](https://github.com/andresribeiro/nsfwjs-docker) | nsfwjs | 92⭐, active, Docker Hub image |
| [germesdev/nsfw_detector](https://github.com/germesdev/nsfw_detector) | Yahoo OpenNSFW | Docker 化済 |
| [nikos-glikis/nsfw-docker](https://github.com/nikos-glikis/nsfw-docker) | Yahoo OpenNSFW | Caffe |
| Cloudflare Workers AI / AWS Rekognition / Google Vision | SaaS | API key 必要 |

wire format が異なる場合は thin proxy を被せて POST body=bytes / response JSON \`{"score": float64}\` に合わせる。

## Wire format (mk-go が呼ぶ仕様)

- **Method**: POST
- **URL**: operator が config に設定した URL
- **Headers**: \`Content-Type: <image/* or video/* MIME>\`
- **Body**: 画像 / 動画の生バイト
- **Response**: JSON \`{"score": float64}\` (0.0=safe ~ 1.0=NSFW)
- **Timeout**: 30s

## テスト

- \`go test ./internal/core/drive/...\` 全 pass、coverage **99.2%** (元 99.2% を維持)
- \`detectSensitive\` 関数: **100% カバー** (新 9 ケース: no-detector / silenced host / flag disabled / detection mode mismatch / video skip+enable / above/below threshold / detector error)
- UDS 環境で \`nsfwDetectorUrl\` 未設定での起動を確認 (detector=nil で従来挙動維持)

## 保持

- DB schema (\`meta.sensitiveMediaDetection*\` 4 カラム) — drop-in 互換
- 手動 \`drive_file.isSensitive\` フラグ — upstream 互換
- admin frontend の sensitive detection 設定値表示 — TS 互換

## Out of Scope

- backend 内蔵 ML runtime (撤回済み)
- mk-go org 製 sidecar binary 配布 (operator が選ぶ)
- \`unix://\` scheme での UDS detector 接続 (HTTP のみ、UDS-only stack でも detector は overlay network 経由で 1 service だけ TCP listen させる)

## Closes

Closes #406

🤖 Generated with [Claude Code](https://claude.com/claude-code)