### PR TITLE
Fix #711: chat_message に (fromUserId, toUserId) 複合 index を追加

### DIFF
--- a/migration/000045_chat_message_compound_index.down.sql
+++ b/migration/000045_chat_message_compound_index.down.sql
@@ -1,0 +1,1 @@
+DROP INDEX IF EXISTS "IDX_chat_message_fromUserId_toUserId";

--- a/migration/000045_chat_message_compound_index.up.sql
+++ b/migration/000045_chat_message_compound_index.up.sql
@@ -1,0 +1,20 @@
+-- chat_message の (fromUserId, toUserId) 複合 index 追加 (#711)。
+--
+-- 用途:
+--   1. MarkAllReadFromUser (DM unread 一括既読化) — timeline open のたびに
+--      実行される high-traffic path。WHERE "fromUserId" = ? AND "toUserId" = ?
+--      で絞り込む。
+--   2. ListMessagesByUser — 1-on-1 conversation の message 一覧。
+--      WHERE ("fromUserId" = ? AND "toUserId" = ?) OR ("fromUserId" = ? AND
+--      "toUserId" = ?) を 2 回走らせる plan を高速化。
+--   3. SearchMessages — text ILIKE と組み合わせた DM 検索。
+--
+-- 既存の単一 index "IDX_chat_message_fromUserId" は他クエリ
+-- (例: ListHistory の DISTINCT ON 経路で fromUserId だけで絞るパス) で
+-- 引き続き有効なので残す。複合 index と prefix で重複するが index size の
+-- overhead より plan 安定性を優先する。
+--
+-- 否定 array containment (NOT (reads @> ARRAY[?]::varchar[])) は GIN でも
+-- 高速化できないため reads 用 index は追加しない。
+CREATE INDEX IF NOT EXISTS "IDX_chat_message_fromUserId_toUserId"
+    ON "chat_message" ("fromUserId", "toUserId");

--- a/migration/000045_chat_message_compound_index.up.sql
+++ b/migration/000045_chat_message_compound_index.up.sql
@@ -6,15 +6,28 @@
 --      で絞り込む。
 --   2. ListMessagesByUser — 1-on-1 conversation の message 一覧。
 --      WHERE ("fromUserId" = ? AND "toUserId" = ?) OR ("fromUserId" = ? AND
---      "toUserId" = ?) を 2 回走らせる plan を高速化。
+--      "toUserId" = ?) を 2 回走らせる plan を高速化 (production volume で
+--      BitmapOr Scan に切り替わる plan)。
 --   3. SearchMessages — text ILIKE と組み合わせた DM 検索。
 --
 -- 既存の単一 index "IDX_chat_message_fromUserId" は他クエリ
 -- (例: ListHistory の DISTINCT ON 経路で fromUserId だけで絞るパス) で
 -- 引き続き有効なので残す。複合 index と prefix で重複するが index size の
--- overhead より plan 安定性を優先する。
+-- overhead より plan 安定性を優先する。これは upstream Misskey TS にも存在
+-- する既存 index で、drop-in 互換のため touch しない。
+--
+-- upstream Misskey TS には複合 index は無い (本 PR で mk-go 独自に追加する
+-- 最適化)。drop-in で TS DB を引き継いだ環境でも IF NOT EXISTS で安全に
+-- 適用できる。逆方向 (mk-go で立てた DB を TS に戻す) も TS 側がこの index
+-- を知らないだけで害なし。
 --
 -- 否定 array containment (NOT (reads @> ARRAY[?]::varchar[])) は GIN でも
 -- 高速化できないため reads 用 index は追加しない。
+--
+-- production (大規模 chat_message table) に適用する場合、本 CREATE INDEX
+-- は ACCESS EXCLUSIVE lock を取って書き込みを一時 block する。golang-migrate
+-- が transaction 内で実行するため CREATE INDEX CONCURRENTLY は使えない
+-- (transaction 外実行が必須)。lock 期間は table size に依存するが、運用上
+-- は深夜帯メンテで適用する想定。
 CREATE INDEX IF NOT EXISTS "IDX_chat_message_fromUserId_toUserId"
     ON "chat_message" ("fromUserId", "toUserId");


### PR DESCRIPTION
## Summary

#708 で追加した \`MarkAllReadFromUser\` / \`MarkAllReadInRoom\` の bulk UPDATE は timeline open のたびに走る high-traffic path だが、production volume で seq scan していないか未確認だった。本 PR で必要な複合 index を追加する。

## 既存 index 確認

\`\`\`sql
SELECT indexname FROM pg_indexes WHERE tablename='chat_message';
-- IDX_chat_message_fromUserId  (単一)
-- IDX_chat_message_toUserId    (単一)
-- IDX_chat_message_toRoomId    (単一)
-- chat_message_pkey
\`\`\`

足りていなかった \`(fromUserId, toUserId)\` 複合 index を追加。

## EXPLAIN 結果 (UDS PostgreSQL、\`SET enable_seqscan=off\`)

| クエリ | 使われる index | 評価 |
|---|---|---|
| \`MarkAllReadFromUser\` | **新規** \`IDX_chat_message_fromUserId_toUserId\` | O(log N) ✓ |
| \`MarkAllReadInRoom\` | 既存 \`IDX_chat_message_toRoomId\` | O(log N) ✓ |
| \`ListMessagesByUser\` | PK 逆スキャン (LIMIT 最適化) | OK |

production volume では \`ListMessagesByUser\` は数万行で BitmapOr Scan に切り替わる可能性があり、その場合も新複合 index が活用される。

## reads GIN index を追加しない理由

\`NOT (reads @> ARRAY[?]::varchar[])\` の **否定 array containment** は GIN index でも使えず post-filter になるため index 化の意味なし。否定条件は seq scan で plan される PostgreSQL 仕様 (positive containment と異なり)。

## Migration

- \`migration/000045_chat_message_compound_index.up.sql\`: 複合 index を追加
- \`.down.sql\`: rollback で複合 index を削除

## 既存単一 index を残す判断

\`IDX_chat_message_fromUserId\` (単一) は新複合 index と prefix で redundant だが、\`ListHistory\` の DISTINCT ON 経路で fromUserId 単独で絞るパス等で引き続き使われる可能性がある。index size の overhead より plan 安定性を優先して残す。

## 検証

- \`make uds-build\` / \`make uds-up\` で migration 適用、\`pg_indexes\` に新 index が出現
- \`SET enable_seqscan=off; EXPLAIN ...\` で 3 クエリ全て index 利用 plan を確認
- production volume での実測は別途運用後に \`pg_stat_user_indexes\` で監視

## Closes

Closes #711

🤖 Generated with [Claude Code](https://claude.com/claude-code)