### PR TITLE
Fix #714: MockInstanceRepository に isSuspended / isBlocked / isSilenced 分岐を追加

### DIFF
--- a/internal/testutil/mock_repository.go
+++ b/internal/testutil/mock_repository.go
@@ -2444,6 +2444,29 @@ func applyInstanceFields(i *model.Instance, fields map[string]any) {
 			if s, ok := v.(string); ok {
 				i.ModerationNote = s
 			}
+		// admin/federation/update-instance handler が送る boolean key を
+		// mock 上で受けたときの挙動 (#714)。
+		//
+		// isSuspended は upstream Misskey TS の旧 schema 由来の boolean key。
+		// mk-go では SuspensionState enum で管理しているので、mock 上では
+		// handler の意図を mirror して boolean → SuspensionState 変換を行う
+		// (true → ManuallySuspended、false → None)。
+		// production の handler 側 bug (existence しない列に UPDATE 試行) は
+		// #724 で別途修正される。
+		case "isSuspended":
+			if b, ok := v.(bool); ok {
+				if b {
+					i.SuspensionState = model.SuspensionStateManuallySuspended
+				} else {
+					i.SuspensionState = model.SuspensionStateNone
+				}
+			}
+		// isBlocked / isSilenced は model.Instance に対応 field が無く DB
+		// schema にも存在しない (#715 で二重カラム統合議論中)。mock では
+		// 明示的に case を持つことで「silently drop されている」状態を
+		// visible にし、将来 model 拡張で field が増えたら修正点が明確になる。
+		case "isBlocked", "isSilenced":
+			_ = v
 		}
 	}
 }

--- a/internal/testutil/mock_repository.go
+++ b/internal/testutil/mock_repository.go
@@ -2462,11 +2462,11 @@ func applyInstanceFields(i *model.Instance, fields map[string]any) {
 				}
 			}
 		// isBlocked / isSilenced は model.Instance に対応 field が無く DB
-		// schema にも存在しない (#715 で二重カラム統合議論中)。mock では
-		// 明示的に case を持つことで「silently drop されている」状態を
-		// visible にし、将来 model 拡張で field が増えたら修正点が明確になる。
+		// schema にも存在しない (#715 で二重カラム統合議論中)。明示的に
+		// case を持つことで「silently drop されている」状態を visible に
+		// し、将来 model 拡張で field が増えたら修正点が明確になる。
+		// 空 body は意図的: 受け取って何もしない。
 		case "isBlocked", "isSilenced":
-			_ = v
 		}
 	}
 }

--- a/internal/testutil/mock_repository_test.go
+++ b/internal/testutil/mock_repository_test.go
@@ -88,3 +88,63 @@ func TestMockMeta_Update_RejectsInvalidArrayValue(t *testing.T) {
 		assert.Equal(t, []string{"ok.example"}, []string(repo.Meta.BlockedHosts))
 	})
 }
+
+// admin/federation/update-instance handler が送る boolean key (isSuspended /
+// isBlocked / isSilenced) を mock 上で受けたときの挙動を確認する (#714)。
+//
+//   - isSuspended は SuspensionState enum に変換される
+//   - isBlocked / isSilenced は対応 model field が無いので silently drop
+//     (case を明示的に持つことで「未対応」を visible 化)
+func TestApplyInstanceFields_SuspendedBoolean(t *testing.T) {
+	repo := NewMockInstanceRepository()
+	const host = "remote.example"
+	require.NoError(t, repo.Create(&model.Instance{
+		ID:              "inst1",
+		Host:            host,
+		SuspensionState: model.SuspensionStateNone,
+	}))
+
+	t.Run("isSuspended true → SuspensionState ManuallySuspended", func(t *testing.T) {
+		require.NoError(t, repo.UpdateFields(host, map[string]any{
+			"isSuspended": true,
+		}))
+		got, err := repo.FindByHost(host)
+		require.NoError(t, err)
+		assert.Equal(t, model.SuspensionStateManuallySuspended, got.SuspensionState)
+	})
+
+	t.Run("isSuspended false → SuspensionState None", func(t *testing.T) {
+		require.NoError(t, repo.UpdateFields(host, map[string]any{
+			"isSuspended": false,
+		}))
+		got, err := repo.FindByHost(host)
+		require.NoError(t, err)
+		assert.Equal(t, model.SuspensionStateNone, got.SuspensionState)
+	})
+}
+
+// isBlocked / isSilenced は model 側に対応 field が無いので silently drop
+// される。case を明示的に追加した目的は「未対応」を visible にすること
+// なので、UpdateFields 呼び出しが panic / error にならず、SuspensionState
+// 等の他 field が壊れないことを確認する (#714)。
+func TestApplyInstanceFields_BlockedSilencedNoOp(t *testing.T) {
+	repo := NewMockInstanceRepository()
+	const host = "remote.example"
+	require.NoError(t, repo.Create(&model.Instance{
+		ID:              "inst2",
+		Host:            host,
+		SuspensionState: model.SuspensionStateManuallySuspended,
+		ModerationNote:  "before",
+	}))
+
+	require.NoError(t, repo.UpdateFields(host, map[string]any{
+		"isBlocked":  true,
+		"isSilenced": true,
+	}))
+
+	got, err := repo.FindByHost(host)
+	require.NoError(t, err)
+	// 既存 field は保持される。
+	assert.Equal(t, model.SuspensionStateManuallySuspended, got.SuspensionState)
+	assert.Equal(t, "before", got.ModerationNote)
+}


### PR DESCRIPTION
## Summary

#713 review #2 で指摘された improvement。\`testutil.MockInstanceRepository\` の \`applyInstanceFields\` が \`admin/federation/update-instance\` handler の送る boolean key (\`isSuspended\` / \`isBlocked\` / \`isSilenced\`) を silently drop していた問題を解消。

## 調査結果

| 観点 | 状態 |
|---|---|
| \`model.Instance\` 構造体 | \`IsSuspended\` / \`IsBlocked\` / \`IsSilenced\` field **無し**、\`SuspensionState\` enum で管理 |
| DB schema (\`\d instance\`) | 同列 **無し**、\`suspensionState\` のみ |
| handler (\`federation_admin.go\`) | boolean key を \`UpdateFields\` に渡す (production 側 bug は #724 で別途) |
| 関連 issue | #715 (二重カラム統合議論中)、#724 (handler bug) |

## 実装

\`internal/testutil/mock_repository.go\` の \`applyInstanceFields\`:

\`\`\`go
case "isSuspended":
    // handler 意図を mirror: true → ManuallySuspended、false → None
    if b, ok := v.(bool); ok {
        if b {
            i.SuspensionState = model.SuspensionStateManuallySuspended
        } else {
            i.SuspensionState = model.SuspensionStateNone
        }
    }
case "isBlocked", "isSilenced":
    // model 対応 field 無し (#715 で議論中)。silently drop だが
    // case を明示することで「未対応」を visible 化。
    _ = v
\`\`\`

## テスト

- \`TestApplyInstanceFields_SuspendedBoolean\`: \`isSuspended\` true/false 双方向変換 (`SuspensionState` enum への mapping)
- \`TestApplyInstanceFields_BlockedSilencedNoOp\`: silently drop 確認、既存 \`SuspensionState\` / \`ModerationNote\` が壊れないことを assert

## 検証

- \`go test ./internal/testutil/...\` 全 pass
- \`make fmt\` / \`make lint\` クリーン
- \`go test -count=1 -short ./...\` 全 pass (regression 無し)

## Closes

Closes #714

🤖 Generated with [Claude Code](https://claude.com/claude-code)