### PR TITLE
Fix #707: パスキー登録 + 検証 + UI 反映を修正

### DIFF
--- a/internal/api/i/handler_2fa.go
+++ b/internal/api/i/handler_2fa.go
@@ -4,12 +4,14 @@ import (
 	"bytes"
 	"encoding/json"
 	"io"
+	"log/slog"
 	"net/http"
 
 	"github.com/labstack/echo/v4"
 	"github.com/lib/pq"
 	"github.com/shiroha-a/mk/internal/api/apierr"
 	"github.com/shiroha-a/mk/internal/core/twofactor"
+	"github.com/shiroha-a/mk/internal/entity"
 	"github.com/shiroha-a/mk/internal/model"
 	"github.com/shiroha-a/mk/internal/server/middleware"
 	"golang.org/x/crypto/bcrypt"
@@ -290,6 +292,7 @@ func (h *Handler) TwoFAKeyDone(c echo.Context) error {
 	}
 	cred, err := h.webauthnSvc.FinishRegistration(c.Request().Context(), user, existing, httpReq)
 	if err != nil {
+		slog.Warn("2fa: webauthn FinishRegistration failed", "userId", user.ID, "err", err)
 		return c.JSON(http.StatusForbidden, apierr.RegistrationFailed())
 	}
 
@@ -303,10 +306,32 @@ func (h *Handler) TwoFAKeyDone(c echo.Context) error {
 		"securityKeysAvailable": true,
 	})
 
+	// upstream Misskey TS と同じく `meUpdated` を publish して frontend の
+	// `$i` (current user 状態) を即時更新する (#707)。これが無いと UI の
+	// 設定→セキュリティ→パスキー一覧に登録直後の鍵が出ず、ユーザーは
+	// 「登録できなかった」と誤認する。
+	h.publishMeUpdated(user.ID)
+
 	return c.JSON(http.StatusOK, map[string]any{
 		"id":   key.ID,
 		"name": key.Name,
 	})
+}
+
+// publishMeUpdated は upstream `meUpdated` event を main stream に流す。
+// 失敗は best-effort で握り潰す (publishing は副次的なので main flow を
+// 止めない)。userService.ShowByID で User + Profile を 1 度に取得する。
+func (h *Handler) publishMeUpdated(userID string) {
+	if h.mainStreamPublisher == nil {
+		return
+	}
+	bundle, err := h.userService.ShowByID(userID)
+	if err != nil {
+		slog.Warn("2fa: meUpdated: load user failed", "userId", userID, "err", err)
+		return
+	}
+	packed := entity.PackUserDetailed(bundle.User, bundle.Profile, h.idGen)
+	h.mainStreamPublisher.PublishMainEvent(userID, "meUpdated", packed)
 }
 
 // TwoFARemoveKey handles POST /api/i/2fa/remove-key.
@@ -334,6 +359,8 @@ func (h *Handler) TwoFARemoveKey(c echo.Context) error {
 			"usePasswordLessLogin":  false,
 		})
 	}
+	// upstream 互換: 削除でも `meUpdated` を publish して frontend UI を即時更新 (#707)。
+	h.publishMeUpdated(user.ID)
 	return c.NoContent(http.StatusNoContent)
 }
 
@@ -355,6 +382,8 @@ func (h *Handler) TwoFAUpdateKey(c echo.Context) error {
 	if err := h.securityKeyRepo.UpdateName(req.CredentialID, user.ID, req.Name); err != nil {
 		return c.JSON(http.StatusNotFound, apierr.NoSuchKey())
 	}
+	// 表示名変更も meUpdated で UI 反映 (#707)。
+	h.publishMeUpdated(user.ID)
 	return c.NoContent(http.StatusNoContent)
 }
 

--- a/internal/api/signin/handler.go
+++ b/internal/api/signin/handler.go
@@ -267,6 +267,11 @@ func (h *Handler) SigninFlow(c echo.Context) error {
 		}
 		cred, werr := h.webauthnSvc.FinishLogin(c.Request().Context(), user, keys, httpReq)
 		if werr != nil {
+			// 失敗の root cause (challenge mismatch / origin / credential format
+			// 等) は webauthn library 内部で発生する。frontend には汎用 403 を
+			// 返すが backend log には何で落ちたかを残しておくと #707 系の
+			// 「パスキーの検証に失敗しました」報告の調査に役立つ。
+			slog.Warn("signin: webauthn FinishLogin failed", "userId", user.ID, "err", werr)
 			return c.JSON(http.StatusForbidden, errBody("93b86c4b-72f9-40eb-9815-798928603d1e"))
 		}
 		// counter 更新 (clone 検出用)

--- a/internal/api/signin/passkey.go
+++ b/internal/api/signin/passkey.go
@@ -4,6 +4,7 @@ import (
 	"crypto/rand"
 	"encoding/hex"
 	"encoding/json"
+	"log/slog"
 	"net/http"
 
 	"github.com/go-webauthn/webauthn/webauthn"
@@ -66,6 +67,10 @@ func (h *Handler) SigninWithPasskey(c echo.Context) error {
 
 	user, cred, err := h.webauthnSvc.FinishPasskeyLogin(c.Request().Context(), req.Context, httpReq, h.resolvePasskeyUser)
 	if err != nil {
+		// frontend には汎用 403 を返すが backend log には何で落ちたかを残す
+		// (#707 の調査用)。原因例: challenge mismatch / origin / RPID 不一致 /
+		// credential format problem / user_handle 解決失敗。
+		slog.Warn("signin: webauthn FinishPasskeyLogin failed", "context", req.Context, "err", err)
 		return c.JSON(http.StatusForbidden, errBody("b18c89a7-5b5e-4cec-bb5b-0419f332d430"))
 	}
 	return h.finishPasskeySignin(c, user, cred)

--- a/internal/core/twofactor/webauthn.go
+++ b/internal/core/twofactor/webauthn.go
@@ -116,6 +116,21 @@ func (u *userAdapter) WebAuthnCredentials() []webauthn.Credential {
 				SignCount: uint32(k.Counter),
 			},
 		}
+		// BackupEligible / BackupState フラグを DB から復元する (#707)。
+		// 登録時の credentialDeviceType / credentialBackedUp 列に upstream
+		// Misskey TS と同じ規約で保存している (singleDevice = BE=false、
+		// multiDevice = BE=true)。Cloud sync passkey の認証時に go-webauthn
+		// が Flags.BackupEligible を AuthenticatorData の BE flag と比較する
+		// ので、復元せずに default false のままだと必ず mismatch エラー
+		// ("Backup Eligible flag inconsistency") になる。
+		// NULL (#707 修正前の登録データ) は default false で復元する: 該当
+		// passkey は再登録が必要。
+		if k.CredentialDeviceType != nil && *k.CredentialDeviceType == "multiDevice" {
+			cred.Flags.BackupEligible = true
+		}
+		if k.CredentialBackedUp != nil {
+			cred.Flags.BackupState = *k.CredentialBackedUp
+		}
 		for _, t := range k.Transports {
 			cred.Transport = append(cred.Transport, protocol.AuthenticatorTransport(t))
 		}
@@ -420,5 +435,18 @@ func CredentialToModel(cred *webauthn.Credential, userID, name string) *model.Us
 	if len(transports) > 0 {
 		out.Transports = pq.StringArray(transports)
 	}
+	// BackupEligible / BackupState フラグを upstream Misskey TS 互換の
+	// credentialDeviceType / credentialBackedUp 列に保存する (#707)。
+	// これを保存していないと WebAuthnCredentials() の復元時に
+	// Flags.BackupEligible が default false になり、Cloud sync passkey
+	// (登録時 BE=true) の認証時に go-webauthn の整合性チェックで mismatch
+	// エラーになる。
+	deviceType := "singleDevice"
+	if cred.Flags.BackupEligible {
+		deviceType = "multiDevice"
+	}
+	out.CredentialDeviceType = &deviceType
+	backedUp := cred.Flags.BackupState
+	out.CredentialBackedUp = &backedUp
 	return out
 }

--- a/internal/core/twofactor/webauthn_test.go
+++ b/internal/core/twofactor/webauthn_test.go
@@ -324,6 +324,60 @@ func TestUserAdapter_CredentialsRoundtrip(t *testing.T) {
 	assert.Len(t, creds[0].Transport, 2)
 }
 
+// DB に保存された credentialDeviceType=multiDevice / credentialBackedUp=true
+// (Cloud sync passkey) が webauthn.Credential.Flags に正しく復元される (#707)。
+// 復元しないと go-webauthn の認証時に Backup Eligible mismatch エラーになる。
+func TestUserAdapter_RestoresBackupFlags(t *testing.T) {
+	device := "multiDevice"
+	backedUp := true
+	keys := []*model.UserSecurityKey{
+		{
+			ID:                   "AAEC",
+			PublicKey:            "AwQF",
+			Counter:              1,
+			CredentialDeviceType: &device,
+			CredentialBackedUp:   &backedUp,
+		},
+	}
+	a := &userAdapter{user: &model.User{ID: "x"}, keys: keys}
+	creds := a.WebAuthnCredentials()
+	require.Len(t, creds, 1)
+	assert.True(t, creds[0].Flags.BackupEligible)
+	assert.True(t, creds[0].Flags.BackupState)
+}
+
+// device-bound (singleDevice) は BackupEligible=false で復元される。
+func TestUserAdapter_RestoresSingleDeviceFlags(t *testing.T) {
+	device := "singleDevice"
+	backedUp := false
+	keys := []*model.UserSecurityKey{
+		{
+			ID:                   "AAEC",
+			PublicKey:            "AwQF",
+			CredentialDeviceType: &device,
+			CredentialBackedUp:   &backedUp,
+		},
+	}
+	a := &userAdapter{user: &model.User{ID: "x"}, keys: keys}
+	creds := a.WebAuthnCredentials()
+	require.Len(t, creds, 1)
+	assert.False(t, creds[0].Flags.BackupEligible)
+	assert.False(t, creds[0].Flags.BackupState)
+}
+
+// 古いレコード (Flag 列が NULL、本 PR 修正前に登録された passkey) は default
+// false で復元される。Cloud sync passkey の場合は再登録が必要になる。
+func TestUserAdapter_NilFlagsDefaultFalse(t *testing.T) {
+	keys := []*model.UserSecurityKey{
+		{ID: "AAEC", PublicKey: "AwQF"},
+	}
+	a := &userAdapter{user: &model.User{ID: "x"}, keys: keys}
+	creds := a.WebAuthnCredentials()
+	require.Len(t, creds, 1)
+	assert.False(t, creds[0].Flags.BackupEligible)
+	assert.False(t, creds[0].Flags.BackupState)
+}
+
 func TestUserAdapter_SkipsBadEncoding(t *testing.T) {
 	keys := []*model.UserSecurityKey{
 		{ID: "not!base64url", PublicKey: "AwQF"},
@@ -352,6 +406,32 @@ func TestCredentialToModel_WithTransports(t *testing.T) {
 	m := CredentialToModel(cred, "alice", "Yubikey")
 	assert.Equal(t, "Yubikey", m.Name)
 	assert.Equal(t, []string{"usb", "ble"}, []string(m.Transports))
+}
+
+// BackupEligible / BackupState フラグが DB 列 (credentialDeviceType /
+// credentialBackedUp) に正しく保存される (#707)。Cloud sync passkey
+// (BE=true) を保存するときに multiDevice として記録される必要がある。
+func TestCredentialToModel_BackupEligibleSaved(t *testing.T) {
+	cred := makeFakeCredential([]byte{1}, []byte{2}, 0, nil)
+	cred.Flags.BackupEligible = true
+	cred.Flags.BackupState = true
+	m := CredentialToModel(cred, "alice", "Phone")
+	require.NotNil(t, m.CredentialDeviceType)
+	assert.Equal(t, "multiDevice", *m.CredentialDeviceType)
+	require.NotNil(t, m.CredentialBackedUp)
+	assert.True(t, *m.CredentialBackedUp)
+}
+
+// device-bound (Yubikey 等、BE=false) は singleDevice として記録される。
+func TestCredentialToModel_DeviceBoundSaved(t *testing.T) {
+	cred := makeFakeCredential([]byte{1}, []byte{2}, 0, nil)
+	cred.Flags.BackupEligible = false
+	cred.Flags.BackupState = false
+	m := CredentialToModel(cred, "alice", "Yubikey")
+	require.NotNil(t, m.CredentialDeviceType)
+	assert.Equal(t, "singleDevice", *m.CredentialDeviceType)
+	require.NotNil(t, m.CredentialBackedUp)
+	assert.False(t, *m.CredentialBackedUp)
 }
 
 // --- key helpers ---


### PR DESCRIPTION
## Summary

#705 (PR #706) 後に発覚した passkey 関連 bug 3 件を 1 PR で対応。

| # | 症状 | Root cause | Fix |
|---|---|---|---|
| 1 | Cloud sync passkey で「パスキーの検証に失敗しました」 | \`CredentialToModel\` が BE flag を保存せず、復元時も default false | DB 列保存 + 復元 |
| 2 | パスキー登録後 UI に反映されない | \`meUpdated\` event 未 publish | helper 追加 + 3 endpoint で呼び出し |
| 3 | 検証失敗の root cause が log に出ない | error path に slog なし | \`slog.Warn\` 追加 |

## 1. BE flag の保存・復元

go-webauthn は \`credential.Flags.BackupEligible\` を AuthenticatorData の BE flag と厳密に比較する:

\`\`\`go
if credential.Flags.BackupEligible != parsedResponse.Response.AuthenticatorData.Flags.HasBackupEligible() {
    return error("Backup Eligible flag inconsistency detected during login validation")
}
\`\`\`

mk-go では:
- 登録時 \`CredentialToModel\` が \`cred.Flags\` を捨てて DB に保存しなかった
- 認証時 \`WebAuthnCredentials()\` で DB から flag を復元しなかった (常に default false)

→ Cloud sync passkey (iCloud Keychain / Google Password Manager 等、BE=true) の認証で必ず mismatch エラー。

### Fix
- \`CredentialToModel\`: \`cred.Flags.BackupEligible\` を \`credentialDeviceType\` (\`multiDevice\`/\`singleDevice\`)、\`BackupState\` を \`credentialBackedUp\` に保存。upstream Misskey TS と同じ規約
- \`WebAuthnCredentials()\`: DB の上記列から \`webauthn.Credential.Flags\` を復元
- DB schema は既存 (upstream 互換) なので migration 不要

## 2. \`meUpdated\` event publish

upstream Misskey TS は登録/削除/名前変更で \`meUpdated\` を main stream に publish して frontend \`$i\` を即時更新する。mk-go の \`TwoFAKeyDone\` / \`TwoFARemoveKey\` / \`TwoFAUpdateKey\` は publish していなかった → 「登録できたけど一覧に出ない」「削除しても残ってる」という UI の lag。

### Fix
- \`handler_2fa.go\` に \`publishMeUpdated()\` helper 追加 (\`userService.ShowByID\` + \`entity.PackUserDetailed\` → main stream publish)
- 3 endpoint で呼び出し

## 3. 検証失敗の log 出力

frontend には汎用 403 を返すが backend log には何で落ちたかを残す:
- \`signin-flow\` の \`FinishLogin\` error
- \`signin-with-passkey\` の \`FinishPasskeyLogin\` error
- \`i/2fa/key-done\` の \`FinishRegistration\` error

#707 の調査で BE mismatch を即座に特定できた。今後の similar 症状で運用者が原因を切り分けられる。

## テスト

新規 5 ケース (\`internal/core/twofactor/webauthn_test.go\`):
- \`TestCredentialToModel_BackupEligibleSaved\`: BE=true → \`multiDevice\` / \`true\`
- \`TestCredentialToModel_DeviceBoundSaved\`: BE=false → \`singleDevice\` / \`false\`
- \`TestUserAdapter_RestoresBackupFlags\`: DB \`multiDevice\` → BE=true 復元
- \`TestUserAdapter_RestoresSingleDeviceFlags\`: \`singleDevice\` → BE=false 復元
- \`TestUserAdapter_NilFlagsDefaultFalse\`: NULL (旧 record) → default false

UDS 環境で動作確認:
1. 既存 passkey 削除
2. 再登録 → 一覧に即反映 (\`meUpdated\` 効果)
3. ログアウト → パスキーでログイン成功

## 既存ユーザーへの影響

本 PR 修正前に登録された passkey は \`credentialDeviceType\` / \`credentialBackedUp\` が NULL のため、復元時 default false で扱われる。

- **Cloud sync passkey (iCloud Keychain / Google Password Manager 等)**: 再登録が必要
- **device-bound (Yubikey 等)**: 既存のまま動く可能性が高い (BE=false で登録されているため復元値と一致)

## Closes

Closes #707

🤖 Generated with [Claude Code](https://claude.com/claude-code)