### PR TITLE
Fix #715 / #724: instance suspend を suspensionState 経由で正しく書き込む

### DIFF
--- a/internal/api/admin/federation_admin.go
+++ b/internal/api/admin/federation_admin.go
@@ -117,6 +117,12 @@ func (h *Handler) FederationRemoveAllFollowing(c echo.Context) error {
 // json.Unmarshal は欠落 field を nil pointer のまま残すので、両者を JSON
 // decode 境界で正しく分離できる。string 型だと "" がデフォルト値と区別でき
 // ず空文字列で note を消す操作が無視される (元バグ)。
+//
+// IsBlocked / IsSilenced は upstream Misskey TS の wire 互換のため受信する
+// が、対応 DB 列が無く mk-go schema にも upstream にも存在しないため
+// updates() で silently drop される (#715 / #724)。frontend がスイッチを
+// 操作しても効果なし、将来 schema 拡張で対応 column が増えたら updates()
+// に変換 case を足す。
 type federationUpdateInstanceRequest struct {
 	Host           string  `json:"host"`
 	IsSuspended    *bool   `json:"isSuspended"`

--- a/internal/api/admin/federation_admin.go
+++ b/internal/api/admin/federation_admin.go
@@ -129,16 +129,27 @@ type federationUpdateInstanceRequest struct {
 // fields explicitly sent in the request are included so the caller can
 // "clear" string fields by sending "" (and not "leave unchanged" via
 // omitting the field).
+//
+// upstream Misskey TS の admin/federation/update-instance は wire 上では
+// `isSuspended bool` を受けるが、mk-go の `instance` table は
+// `suspensionState varchar` enum (`none` / `manuallySuspended` / 等) で
+// 管理しており `isSuspended` 列は存在しない (#715 / #724)。boolean を
+// enum に変換して GORM Updates 用 map に詰める。
+//
+// `isBlocked` / `isSilenced` は upstream にも対応 column が無く、mk-go
+// schema にも存在しない。silently drop。将来 schema 拡張で対応 column が
+// 増えたら本関数で変換を足す。
 func (req federationUpdateInstanceRequest) updates() map[string]any {
 	out := map[string]any{}
 	if req.IsSuspended != nil {
-		out["isSuspended"] = *req.IsSuspended
-	}
-	if req.IsBlocked != nil {
-		out["isBlocked"] = *req.IsBlocked
-	}
-	if req.IsSilenced != nil {
-		out["isSilenced"] = *req.IsSilenced
+		// admin が「suspend する」を選んだら manuallySuspended、解除は none。
+		// auto-suspend (goneSuspended / autoSuspendedForNotResponding) はこの
+		// 経路では生成されず、別 path で発生する。
+		if *req.IsSuspended {
+			out["suspensionState"] = string(model.SuspensionStateManuallySuspended)
+		} else {
+			out["suspensionState"] = string(model.SuspensionStateNone)
+		}
 	}
 	if req.ModerationNote != nil {
 		// pointer != nil なら明示的に送信されたので空文字列でも反映する。
@@ -183,7 +194,12 @@ func (h *Handler) FederationUpdateInstance(c echo.Context) error {
 	// 時は deep copy への昇格を検討。
 	before := *beforePtr
 	if updates := req.updates(); len(updates) > 0 {
-		_ = h.instanceRepo.UpdateFields(req.Host, updates)
+		if err := h.instanceRepo.UpdateFields(req.Host, updates); err != nil {
+			// silently 握り潰すと #724 のように DB 列ミスマッチで NO-OP に
+			// なって moderation log だけ書き込まれる症状が再発する。warn
+			// で残すことで運用者が気付ける。
+			slog.Warn("admin: instance UpdateFields failed", "host", req.Host, "err", err)
+		}
 	}
 	// suspend / unsuspend と moderationNote 変更で個別 log を出す。
 	// SuspensionState != "none" を「suspended」と扱う。

--- a/internal/api/admin/federation_admin_integration_test.go
+++ b/internal/api/admin/federation_admin_integration_test.go
@@ -179,7 +179,54 @@ func TestFederationUpdateInstance_IntegrationClearsModerationNoteToEmpty(t *test
 	assert.Equal(t, instID, parsed["id"])
 }
 
-// suspend / unsuspend 経路の integration test は #724 (handler が
-// instance.isSuspended という存在しない列に UPDATE 試行する別バグ) を
-// 修正してから追加する。本 issue (#696) のスコープは moderationNote guard
-// のみ。
+// TestFederationUpdateInstance_IntegrationSuspendsInstance は #715 / #724
+// 修正の regression guard。handler が `isSuspended bool` を `suspensionState`
+// enum に変換して GORM Updates に渡し、実 DB の suspensionState 列が更新
+// されることを確認する。修正前は `out["isSuspended"] = bool` が存在しない
+// 列への UPDATE になり silently NO-OP だった。
+func TestFederationUpdateInstance_IntegrationSuspendsInstance(t *testing.T) {
+	h, admin := newIntegrationHandler(t)
+	host := "remote-int-suspend.example"
+	instID := seedTestInstance(t, host, "", model.SuspensionStateNone)
+
+	// suspend
+	rec := doPost(h.FederationUpdateInstance,
+		`{"host":"`+host+`","isSuspended":true}`, admin)
+	require.Equal(t, http.StatusNoContent, rec.Code)
+
+	var got model.Instance
+	require.NoError(t, integrationDB.First(&got, "host = ?", host).Error)
+	assert.Equal(t, model.SuspensionStateManuallySuspended, got.SuspensionState,
+		"suspensionState column should be updated by handler conversion")
+	assert.Equal(t, instID, got.ID)
+
+	// moderation log
+	require.Eventually(t, func() bool {
+		var c int64
+		integrationDB.Raw(
+			`SELECT COUNT(*) FROM "moderation_log" WHERE "userId" = ? AND "type" = ?`,
+			admin.ID, "suspendRemoteInstance",
+		).Scan(&c)
+		return c == 1
+	}, 500*time.Millisecond, 5*time.Millisecond,
+		"suspendRemoteInstance log should be persisted")
+
+	// unsuspend
+	rec = doPost(h.FederationUpdateInstance,
+		`{"host":"`+host+`","isSuspended":false}`, admin)
+	require.Equal(t, http.StatusNoContent, rec.Code)
+
+	require.NoError(t, integrationDB.First(&got, "host = ?", host).Error)
+	assert.Equal(t, model.SuspensionStateNone, got.SuspensionState,
+		"suspensionState should be reset to none on unsuspend")
+
+	require.Eventually(t, func() bool {
+		var c int64
+		integrationDB.Raw(
+			`SELECT COUNT(*) FROM "moderation_log" WHERE "userId" = ? AND "type" = ?`,
+			admin.ID, "unsuspendRemoteInstance",
+		).Scan(&c)
+		return c == 1
+	}, 500*time.Millisecond, 5*time.Millisecond,
+		"unsuspendRemoteInstance log should be persisted")
+}

--- a/internal/api/admin/federation_admin_internal_test.go
+++ b/internal/api/admin/federation_admin_internal_test.go
@@ -42,9 +42,13 @@ func TestFederationUpdateInstanceRequest_NotePointerSemantics(t *testing.T) {
 }
 
 // TestFederationUpdateInstanceRequest_UpdatesIncludesAllSentFields は他の
-// pointer fields (isSuspended/isBlocked/isSilenced) が送信されたときだけ
-// updates に含まれる契約を guard する。partial update 互換のため同じ
-// pointer-vs-default 区別が必要。
+// pointer fields が送信されたときだけ updates に含まれる契約を guard する。
+// partial update 互換のため同じ pointer-vs-default 区別が必要。
+//
+// #715 / #724: isSuspended は SQL 列に存在しないので suspensionState enum に
+// 変換する。isBlocked / isSilenced は対応 DB 列が無く mk-go schema にも無い
+// ため updates から落とす (silently dropped、存在しない列への UPDATE で
+// SQL エラーになるのを防ぐ)。
 func TestFederationUpdateInstanceRequest_UpdatesIncludesAllSentFields(t *testing.T) {
 	tt := true
 	ff := false
@@ -60,19 +64,24 @@ func TestFederationUpdateInstanceRequest_UpdatesIncludesAllSentFields(t *testing
 			want: map[string]any{},
 		},
 		{
-			name: "isSuspended true",
+			name: "isSuspended true → suspensionState manuallySuspended",
 			req:  federationUpdateInstanceRequest{IsSuspended: &tt},
-			want: map[string]any{"isSuspended": true},
+			want: map[string]any{"suspensionState": "manuallySuspended"},
 		},
 		{
-			name: "isBlocked false",
+			name: "isSuspended false → suspensionState none",
+			req:  federationUpdateInstanceRequest{IsSuspended: &ff},
+			want: map[string]any{"suspensionState": "none"},
+		},
+		{
+			name: "isBlocked dropped (no column)",
 			req:  federationUpdateInstanceRequest{IsBlocked: &ff},
-			want: map[string]any{"isBlocked": false},
+			want: map[string]any{},
 		},
 		{
-			name: "isSilenced true",
+			name: "isSilenced dropped (no column)",
 			req:  federationUpdateInstanceRequest{IsSilenced: &tt},
-			want: map[string]any{"isSilenced": true},
+			want: map[string]any{},
 		},
 		{
 			name: "moderationNote set",
@@ -86,8 +95,8 @@ func TestFederationUpdateInstanceRequest_UpdatesIncludesAllSentFields(t *testing
 				ModerationNote: &note,
 			},
 			want: map[string]any{
-				"isSuspended": true, "isBlocked": false, "isSilenced": true,
-				"moderationNote": "n",
+				"suspensionState": "manuallySuspended",
+				"moderationNote":  "n",
 			},
 		},
 	}

--- a/internal/testutil/mock_repository.go
+++ b/internal/testutil/mock_repository.go
@@ -2437,36 +2437,19 @@ func applyInstanceFields(i *model.Instance, fields map[string]any) {
 				i.NotRespondingSince = t
 			}
 		case "suspensionState":
-			if s, ok := v.(model.SuspensionState); ok {
+			// production の handler は `string(model.SuspensionState...)` を渡す
+			// (#715 / #724 で整理) ので string も受け付ける。直接 enum 型で
+			// 渡す内部 caller の互換も維持。
+			switch s := v.(type) {
+			case model.SuspensionState:
 				i.SuspensionState = s
+			case string:
+				i.SuspensionState = model.SuspensionState(s)
 			}
 		case "moderationNote":
 			if s, ok := v.(string); ok {
 				i.ModerationNote = s
 			}
-		// admin/federation/update-instance handler が送る boolean key を
-		// mock 上で受けたときの挙動 (#714)。
-		//
-		// isSuspended は upstream Misskey TS の旧 schema 由来の boolean key。
-		// mk-go では SuspensionState enum で管理しているので、mock 上では
-		// handler の意図を mirror して boolean → SuspensionState 変換を行う
-		// (true → ManuallySuspended、false → None)。
-		// production の handler 側 bug (existence しない列に UPDATE 試行) は
-		// #724 で別途修正される。
-		case "isSuspended":
-			if b, ok := v.(bool); ok {
-				if b {
-					i.SuspensionState = model.SuspensionStateManuallySuspended
-				} else {
-					i.SuspensionState = model.SuspensionStateNone
-				}
-			}
-		// isBlocked / isSilenced は model.Instance に対応 field が無く DB
-		// schema にも存在しない (#715 で二重カラム統合議論中)。明示的に
-		// case を持つことで「silently drop されている」状態を visible に
-		// し、将来 model 拡張で field が増えたら修正点が明確になる。
-		// 空 body は意図的: 受け取って何もしない。
-		case "isBlocked", "isSilenced":
 		}
 	}
 }

--- a/internal/testutil/mock_repository_test.go
+++ b/internal/testutil/mock_repository_test.go
@@ -89,13 +89,12 @@ func TestMockMeta_Update_RejectsInvalidArrayValue(t *testing.T) {
 	})
 }
 
-// admin/federation/update-instance handler が送る boolean key (isSuspended /
-// isBlocked / isSilenced) を mock 上で受けたときの挙動を確認する (#714)。
-//
-//   - isSuspended は SuspensionState enum に変換される
-//   - isBlocked / isSilenced は対応 model field が無いので silently drop
-//     (case を明示的に持つことで「未対応」を visible 化)
-func TestApplyInstanceFields_SuspendedBoolean(t *testing.T) {
+// admin/federation/update-instance handler は #715 / #724 で
+// boolean (isSuspended) → enum (suspensionState) 変換を service 層で
+// 行うようになった。mock の applyInstanceFields も string で渡された
+// suspensionState を受け取れることを確認する (production handler の
+// `out["suspensionState"] = string(...)` 経路と一致)。
+func TestApplyInstanceFields_SuspensionStateString(t *testing.T) {
 	repo := NewMockInstanceRepository()
 	const host = "remote.example"
 	require.NoError(t, repo.Create(&model.Instance{
@@ -104,47 +103,30 @@ func TestApplyInstanceFields_SuspendedBoolean(t *testing.T) {
 		SuspensionState: model.SuspensionStateNone,
 	}))
 
-	t.Run("isSuspended true → SuspensionState ManuallySuspended", func(t *testing.T) {
+	t.Run("string manuallySuspended", func(t *testing.T) {
 		require.NoError(t, repo.UpdateFields(host, map[string]any{
-			"isSuspended": true,
+			"suspensionState": "manuallySuspended",
 		}))
 		got, err := repo.FindByHost(host)
 		require.NoError(t, err)
 		assert.Equal(t, model.SuspensionStateManuallySuspended, got.SuspensionState)
 	})
 
-	t.Run("isSuspended false → SuspensionState None", func(t *testing.T) {
+	t.Run("string none clears state", func(t *testing.T) {
 		require.NoError(t, repo.UpdateFields(host, map[string]any{
-			"isSuspended": false,
+			"suspensionState": "none",
 		}))
 		got, err := repo.FindByHost(host)
 		require.NoError(t, err)
 		assert.Equal(t, model.SuspensionStateNone, got.SuspensionState)
 	})
-}
 
-// isBlocked / isSilenced は model 側に対応 field が無いので silently drop
-// される。case を明示的に追加した目的は「未対応」を visible にすること
-// なので、UpdateFields 呼び出しが panic / error にならず、SuspensionState
-// 等の他 field が壊れないことを確認する (#714)。
-func TestApplyInstanceFields_BlockedSilencedNoOp(t *testing.T) {
-	repo := NewMockInstanceRepository()
-	const host = "remote.example"
-	require.NoError(t, repo.Create(&model.Instance{
-		ID:              "inst2",
-		Host:            host,
-		SuspensionState: model.SuspensionStateManuallySuspended,
-		ModerationNote:  "before",
-	}))
-
-	require.NoError(t, repo.UpdateFields(host, map[string]any{
-		"isBlocked":  true,
-		"isSilenced": true,
-	}))
-
-	got, err := repo.FindByHost(host)
-	require.NoError(t, err)
-	// 既存 field は保持される。
-	assert.Equal(t, model.SuspensionStateManuallySuspended, got.SuspensionState)
-	assert.Equal(t, "before", got.ModerationNote)
+	t.Run("typed enum value still works", func(t *testing.T) {
+		require.NoError(t, repo.UpdateFields(host, map[string]any{
+			"suspensionState": model.SuspensionStateGoneSuspended,
+		}))
+		got, err := repo.FindByHost(host)
+		require.NoError(t, err)
+		assert.Equal(t, model.SuspensionStateGoneSuspended, got.SuspensionState)
+	})
 }


### PR DESCRIPTION
## Summary

issue #715 (「二重カラム統合」) と issue #724 (「FederationUpdateInstance: isSuspended が SQL UPDATE で反映されない」) を 1 PR でまとめて修正。

issue #715 の前提 (二重カラム) は誤認で、実際 \`instance\` テーブルには \`isSuspended\` 列が無く \`suspensionState\` (varchar enum) のみ存在する。issue #724 が正確に整理していた「handler が存在しない \`isSuspended\` 列に UPDATE 試行する bug」が実体。

## 主な変更点

### handler の boolean → enum 変換 (\`internal/api/admin/federation_admin.go\`)

\`req.updates()\` で:
- \`isSuspended: true\`  → \`suspensionState: "manuallySuspended"\`
- \`isSuspended: false\` → \`suspensionState: "none"\`
- \`isBlocked\` / \`isSilenced\` は対応 DB 列が無いので silently drop

これで GORM Updates が \`UPDATE instance SET "suspensionState" = ?\` を正しく発行し、admin の suspend/unsuspend 操作が effective になる。

### error 握り潰しの改善

\`_ = h.instanceRepo.UpdateFields(...)\` を \`if err != nil { slog.Warn }\` に変更。silent NO-OP で moderation log だけ書き込まれる症状を再発した時に検知できる (#724 案 C 部分対応)。

### mock 整理 (\`internal/testutil/mock_repository.go\`)

PR #755 (#714) で追加した \`case "isSuspended" / "isBlocked" / "isSilenced"\` 互換変換は handler 修正で不要 (handler が直接 \`suspensionState\` を送るため) → 削除。\`case "suspensionState"\` を string と enum 型の両方を受け付けるよう拡張 (production handler の \`string(model.SuspensionState...)\` 経路と互換)。

## テスト

### unit (\`federation_admin_internal_test.go\`)
\`updates()\` の変換を網羅:
- \`isSuspended: true\` → \`suspensionState: "manuallySuspended"\`
- \`isSuspended: false\` → \`suspensionState: "none"\`
- \`isBlocked\` / \`isSilenced\` は dropped
- 4 fields 同時送信 → \`suspensionState\` + \`moderationNote\` のみ map に入る

### integration (\`federation_admin_integration_test.go\`)
旧 #724 placeholder コメントを実 testcontainer ベース integration test に置き換え:
- suspend → DB \`suspensionState\` 列更新 + \`suspendRemoteInstance\` log
- unsuspend → \`none\` 復帰 + \`unsuspendRemoteInstance\` log

### mock (\`mock_repository_test.go\`)
PR #755 で追加した \`isSuspended\` ケースを \`suspensionState\` string ケースに置き換え。string / enum 両方受け取れることを assert。

## 既存ユーザーへの影響

なし。修正前は admin が suspend ボタンを押しても DB が更新されない silent failure 状態だったので、本 PR で初めて suspend が effective になる。modlog だけ既に書き込まれているケースは admin/instance/show で state mismatch が解消する方向。

## 検証

- \`go test ./internal/api/admin/... ./internal/testutil/...\` 全 pass
- \`make fmt\` / \`make lint\` クリーン
- UDS 環境で起動成功

## Closes

- Closes #715
- Closes #724

🤖 Generated with [Claude Code](https://claude.com/claude-code)