### PR TITLE
Fix #758: パスワードレスログイン設定の password 不要化 + UI 即時反映

### DIFF
--- a/internal/api/i/handler_2fa.go
+++ b/internal/api/i/handler_2fa.go
@@ -390,25 +390,53 @@ func (h *Handler) TwoFAUpdateKey(c echo.Context) error {
 // TwoFAPasswordLess handles POST /api/i/2fa/password-less.
 // `usePasswordLessLogin` フラグを切り替える。WebAuthn 鍵が登録されていないと
 // 有効化できない (パスワードレスログインの前提が成立しないため)。
+//
+// upstream Misskey TS は paramDef を `{value: boolean}` (required: ['value'])
+// で password を要求しない (#758)。secure endpoint なので RequireAuth
+// middleware で session ベース認証が済んでいる前提。mk-go も合わせて
+// password 必須を撤回する。
 func (h *Handler) TwoFAPasswordLess(c echo.Context) error {
 	var req struct {
-		Password string `json:"password"`
-		Value    bool   `json:"value"`
+		Value bool `json:"value"`
 	}
-	if err := c.Bind(&req); err != nil || req.Password == "" {
-		return c.JSON(http.StatusBadRequest, apierr.Error("INVALID_PARAM", "password is required.", "ed1d7571-a3ac-4370-899c-0dbe5e230cc8"))
+	if err := c.Bind(&req); err != nil {
+		return c.JSON(http.StatusBadRequest, apierr.Error("INVALID_PARAM", "invalid request body.", "ed1d7571-a3ac-4370-899c-0dbe5e230cc8"))
 	}
-	user, _, ok := h.requireWebAuthn(c, req.Password)
-	if !ok {
-		return nil
+	user := middleware.GetUser(c)
+	if user == nil {
+		return c.JSON(http.StatusForbidden, apierr.Error("ACCESS_DENIED", "Access denied.", "1fb7cb09-d46a-4fff-b8df-057708cce513"))
 	}
 	if req.Value {
-		if n, err := h.securityKeyRepo.CountByUser(user.ID); err != nil || n == 0 {
+		// security key が無いと passwordless 有効化不可。upstream は同じ
+		// branch で profile を `usePasswordLessLogin=false` に巻き戻して
+		// から error を返すので mk-go も合わせる。WebAuthn 未配線
+		// (securityKeyRepo == nil) は鍵 0 件と等価扱い。
+		hasKey := false
+		if h.securityKeyRepo != nil {
+			if n, err := h.securityKeyRepo.CountByUser(user.ID); err == nil && n > 0 {
+				hasKey = true
+			}
+		}
+		if !hasKey {
+			_ = h.userService.UpdateProfileFields(user.ID, map[string]any{
+				"usePasswordLessLogin": false,
+			})
 			return c.JSON(http.StatusBadRequest, apierr.NoSecurityKey())
 		}
 	}
 	_ = h.userService.UpdateProfileFields(user.ID, map[string]any{
 		"usePasswordLessLogin": req.Value,
 	})
+	// frontend の main-boot.ts は `meUpdated` payload を
+	// updateCurrentAccountPartial で部分 merge する。usePasswordLessLogin は
+	// /api/i 経路の private profile field 群に属し、entity.PackUserDetailed が
+	// 含まないため publishMeUpdated (UserDetailed publish) では更新が
+	// 反映されない (#758 / #707 follow-up)。partial payload で当該 field
+	// だけ送って frontend の $i を更新する。
+	if h.mainStreamPublisher != nil {
+		h.mainStreamPublisher.PublishMainEvent(user.ID, "meUpdated", map[string]any{
+			"usePasswordLessLogin": req.Value,
+		})
+	}
 	return c.NoContent(http.StatusNoContent)
 }

--- a/internal/api/i/handler_2fa.go
+++ b/internal/api/i/handler_2fa.go
@@ -321,6 +321,13 @@ func (h *Handler) TwoFAKeyDone(c echo.Context) error {
 // publishMeUpdated は upstream `meUpdated` event を main stream に流す。
 // 失敗は best-effort で握り潰す (publishing は副次的なので main flow を
 // 止めない)。userService.ShowByID で User + Profile を 1 度に取得する。
+//
+// frontend (main-boot.ts) は payload を updateCurrentAccountPartial で
+// 部分 merge するので、本 helper が送る UserDetailed の field がそのまま
+// `$i` に反映される。ただし entity.PackUserDetailed は private profile
+// field (usePasswordLessLogin / autoAcceptFollowed 等) を含まないため、
+// それらを更新する endpoint は publishMeUpdatedPartial で当該 field
+// だけ送る (#758)。
 func (h *Handler) publishMeUpdated(userID string) {
 	if h.mainStreamPublisher == nil {
 		return
@@ -332,6 +339,18 @@ func (h *Handler) publishMeUpdated(userID string) {
 	}
 	packed := entity.PackUserDetailed(bundle.User, bundle.Profile, h.idGen)
 	h.mainStreamPublisher.PublishMainEvent(userID, "meUpdated", packed)
+}
+
+// publishMeUpdatedPartial は specific field のみを `meUpdated` payload と
+// して送る。frontend は updateCurrentAccountPartial で部分 merge する
+// ので、entity.PackUserDetailed が含まない private profile field を
+// 更新した endpoint がこの helper で当該 field だけ publish できる
+// (#758)。fields が空 / mainStreamPublisher 未配線なら no-op。
+func (h *Handler) publishMeUpdatedPartial(userID string, fields map[string]any) {
+	if h.mainStreamPublisher == nil || len(fields) == 0 {
+		return
+	}
+	h.mainStreamPublisher.PublishMainEvent(userID, "meUpdated", fields)
 }
 
 // TwoFARemoveKey handles POST /api/i/2fa/remove-key.
@@ -427,16 +446,12 @@ func (h *Handler) TwoFAPasswordLess(c echo.Context) error {
 	_ = h.userService.UpdateProfileFields(user.ID, map[string]any{
 		"usePasswordLessLogin": req.Value,
 	})
-	// frontend の main-boot.ts は `meUpdated` payload を
-	// updateCurrentAccountPartial で部分 merge する。usePasswordLessLogin は
-	// /api/i 経路の private profile field 群に属し、entity.PackUserDetailed が
-	// 含まないため publishMeUpdated (UserDetailed publish) では更新が
-	// 反映されない (#758 / #707 follow-up)。partial payload で当該 field
-	// だけ送って frontend の $i を更新する。
-	if h.mainStreamPublisher != nil {
-		h.mainStreamPublisher.PublishMainEvent(user.ID, "meUpdated", map[string]any{
-			"usePasswordLessLogin": req.Value,
-		})
-	}
+	// usePasswordLessLogin は /api/i 経路の private profile field 群に属し、
+	// entity.PackUserDetailed が含まないため publishMeUpdated (UserDetailed
+	// publish) では frontend の $i に反映されない (#758)。partial helper で
+	// 当該 field だけ送る。
+	h.publishMeUpdatedPartial(user.ID, map[string]any{
+		"usePasswordLessLogin": req.Value,
+	})
 	return c.NoContent(http.StatusNoContent)
 }

--- a/internal/api/i/handler_2fa_flow_test.go
+++ b/internal/api/i/handler_2fa_flow_test.go
@@ -178,7 +178,10 @@ func TestTwoFAUpdateKey(t *testing.T) {
 	assert.Equal(t, http.StatusBadRequest, postExtra(h.TwoFAUpdateKey, `{}`, stubUser).Code)
 }
 
+// upstream Misskey TS は paramDef で password を要求しないので、空 body でも
+// value=false 扱いで no-content 成功する (#758)。詳細な branch の test は
+// handler_webauthn_test.go の TestTwoFAPasswordLess_* 群を参照。
 func TestTwoFAPasswordLess(t *testing.T) {
 	h, _ := newExtraHandler(t)
-	assert.Equal(t, http.StatusBadRequest, postExtra(h.TwoFAPasswordLess, `{}`, stubUser).Code)
+	assert.Equal(t, http.StatusNoContent, postExtra(h.TwoFAPasswordLess, `{}`, stubUser).Code)
 }

--- a/internal/api/i/handler_webauthn_test.go
+++ b/internal/api/i/handler_webauthn_test.go
@@ -344,25 +344,40 @@ func TestTwoFAUpdateKey_Success(t *testing.T) {
 }
 
 // --- TwoFAPasswordLess ---
+//
+// upstream Misskey TS は paramDef を `{value: boolean}` で password を
+// 要求しない (#758)。本 endpoint は session で認証済み前提なので mk-go も
+// 合わせている。
 
-func TestTwoFAPasswordLess_NoPassword(t *testing.T) {
-	h, _, _ := newWebAuthnHandler(t)
-	rec := postExtra(h.TwoFAPasswordLess, `{}`, &model.User{ID: "u1"})
-	assert.Equal(t, http.StatusBadRequest, rec.Code)
+// value 未指定 (空 body) は default false 扱いで no-content 成功する。
+// upstream の paramDef は required:['value'] だが mk-go の echo Bind は
+// JSON body 欠落を default 値で埋めるので、ここで bad request にしない。
+func TestTwoFAPasswordLess_EmptyBodyDefaultsFalse(t *testing.T) {
+	h, repo, _ := newWebAuthnHandler(t)
+	user := setupUserWithPassword(repo, "u1", "pass")
+	repo.Profiles["u1"].UsePasswordLessLogin = true
+	rec := postExtra(h.TwoFAPasswordLess, `{}`, user)
+	assert.Equal(t, http.StatusNoContent, rec.Code)
+	assert.False(t, repo.Profiles["u1"].UsePasswordLessLogin)
 }
 
+// value=true で security key 0 件 → noKey error + profile が
+// usePasswordLessLogin=false に巻き戻される (upstream 互換)。
 func TestTwoFAPasswordLess_EnableNoKeys(t *testing.T) {
 	h, repo, _ := newWebAuthnHandler(t)
 	user := setupUserWithPassword(repo, "u1", "pass")
-	rec := postExtra(h.TwoFAPasswordLess, `{"password":"pass","value":true}`, user)
+	repo.Profiles["u1"].UsePasswordLessLogin = true
+	rec := postExtra(h.TwoFAPasswordLess, `{"value":true}`, user)
 	assert.Equal(t, http.StatusBadRequest, rec.Code)
+	assert.False(t, repo.Profiles["u1"].UsePasswordLessLogin,
+		"upstream rolls back the flag before throwing noKey")
 }
 
 func TestTwoFAPasswordLess_EnableWithKey(t *testing.T) {
 	h, repo, skRepo := newWebAuthnHandler(t)
 	user := setupUserWithPassword(repo, "u1", "pass")
 	require.NoError(t, skRepo.Create(&model.UserSecurityKey{ID: "k1", UserID: "u1"}))
-	rec := postExtra(h.TwoFAPasswordLess, `{"password":"pass","value":true}`, user)
+	rec := postExtra(h.TwoFAPasswordLess, `{"value":true}`, user)
 	assert.Equal(t, http.StatusNoContent, rec.Code)
 	assert.True(t, repo.Profiles["u1"].UsePasswordLessLogin)
 }
@@ -371,7 +386,7 @@ func TestTwoFAPasswordLess_Disable(t *testing.T) {
 	h, repo, _ := newWebAuthnHandler(t)
 	user := setupUserWithPassword(repo, "u1", "pass")
 	repo.Profiles["u1"].UsePasswordLessLogin = true
-	rec := postExtra(h.TwoFAPasswordLess, `{"password":"pass","value":false}`, user)
+	rec := postExtra(h.TwoFAPasswordLess, `{"value":false}`, user)
 	assert.Equal(t, http.StatusNoContent, rec.Code)
 	assert.False(t, repo.Profiles["u1"].UsePasswordLessLogin)
 }

--- a/internal/api/i/handler_webauthn_test.go
+++ b/internal/api/i/handler_webauthn_test.go
@@ -390,3 +390,74 @@ func TestTwoFAPasswordLess_Disable(t *testing.T) {
 	assert.Equal(t, http.StatusNoContent, rec.Code)
 	assert.False(t, repo.Profiles["u1"].UsePasswordLessLogin)
 }
+
+// publishMeUpdatedPartial 経由で frontend の $i に partial merge される
+// payload が main stream に送られていることを assert する (#758)。
+func TestTwoFAPasswordLess_PublishesPartialMeUpdated(t *testing.T) {
+	h, repo, skRepo := newWebAuthnHandler(t)
+	user := setupUserWithPassword(repo, "u1", "pass")
+	require.NoError(t, skRepo.Create(&model.UserSecurityKey{ID: "k1", UserID: "u1"}))
+	pub := &stubIMainStreamPublisher{}
+	h.SetMainStreamPublisher(pub)
+
+	rec := postExtra(h.TwoFAPasswordLess, `{"value":true}`, user)
+	require.Equal(t, http.StatusNoContent, rec.Code)
+
+	require.Len(t, pub.calls, 1)
+	assert.Equal(t, "u1", pub.calls[0].userID)
+	assert.Equal(t, "meUpdated", pub.calls[0].eventType)
+	body, ok := pub.calls[0].body.(map[string]any)
+	require.True(t, ok)
+	assert.Equal(t, true, body["usePasswordLessLogin"])
+}
+
+// publishMeUpdatedPartial: mainStreamPublisher が wire されていない場合は
+// no-op (production の fallback path 確保 + test の panic 防止)。
+func TestPublishMeUpdatedPartial_NoPublisherIsNoop(t *testing.T) {
+	h, _, _ := newWebAuthnHandler(t)
+	// SetMainStreamPublisher を呼ばずそのまま invoke しても panic しない。
+	h.publishMeUpdatedPartial("u1", map[string]any{"x": 1})
+}
+
+// publishMeUpdatedPartial: 空 fields は publish しない (no-op)。
+func TestPublishMeUpdatedPartial_EmptyFieldsIsNoop(t *testing.T) {
+	h, _, _ := newWebAuthnHandler(t)
+	pub := &stubIMainStreamPublisher{}
+	h.SetMainStreamPublisher(pub)
+	h.publishMeUpdatedPartial("u1", nil)
+	h.publishMeUpdatedPartial("u1", map[string]any{})
+	assert.Empty(t, pub.calls, "no PublishMainEvent for empty fields")
+}
+
+// publishMeUpdated (full UserDetailed): publisher が wire されていれば
+// userService.ShowByID 経由で User+Profile を packed publish する。
+func TestPublishMeUpdated_FullPublishWhenWired(t *testing.T) {
+	h, repo, _ := newWebAuthnHandler(t)
+	setupUserWithPassword(repo, "u1", "pass")
+	pub := &stubIMainStreamPublisher{}
+	h.SetMainStreamPublisher(pub)
+
+	h.publishMeUpdated("u1")
+	require.Len(t, pub.calls, 1)
+	assert.Equal(t, "u1", pub.calls[0].userID)
+	assert.Equal(t, "meUpdated", pub.calls[0].eventType)
+	assert.NotNil(t, pub.calls[0].body)
+}
+
+// publishMeUpdated: 存在しない userID は ShowByID で err → publish せず
+// log だけ残す。
+func TestPublishMeUpdated_UnknownUserIsNoop(t *testing.T) {
+	h, _, _ := newWebAuthnHandler(t)
+	pub := &stubIMainStreamPublisher{}
+	h.SetMainStreamPublisher(pub)
+
+	h.publishMeUpdated("nonexistent")
+	assert.Empty(t, pub.calls, "no publish for unknown user")
+}
+
+// publishMeUpdated: publisher 未配線は no-op (production の fallback path)。
+func TestPublishMeUpdated_NoPublisherIsNoop(t *testing.T) {
+	h, _, _ := newWebAuthnHandler(t)
+	// SetMainStreamPublisher を呼ばずに invoke しても panic しない。
+	h.publishMeUpdated("u1")
+}


### PR DESCRIPTION
## Summary

issue #758: 設定→セキュリティ→パスワードレスログインのチェックを ON にすると \`{"code":"INVALID_PARAM","message":"password is required."}\` エラーが返って設定できない。

## Root cause

mk-go の handler が独自に \`req.Password\` 必須にしていたが、upstream Misskey TS の paramDef は \`{value: boolean}\` のみで password を要求しない (secure endpoint なので RequireAuth middleware の session 認証が済んでいる前提)。frontend は password を送らないので mk-go 側で常に 400 になっていた。

## 主な変更点

### handler password 要求の撤回
- request struct から \`Password\` field を削除、\`Value (bool)\` のみ受け付ける
- \`requireWebAuthn\` (password 認証付き) を撤回、\`middleware.GetUser\` で session ベース認証に統一
- security key 0 件の場合は profile を \`usePasswordLessLogin=false\` にロールバックしてから \`NoSecurityKey\` error を返す (upstream 互換)
- \`securityKeyRepo == nil\` (WebAuthn 未配線) は鍵 0 件と等価扱い (test setup 互換)

### UI 即時反映 (#707 follow-up)

frontend の \`main-boot.ts\` は \`meUpdated\` payload を \`updateCurrentAccountPartial\` で **部分 merge** する。\`usePasswordLessLogin\` は \`/api/i\` 経路の private profile field 群に属し、\`entity.PackUserDetailed\` が含まないため \`publishMeUpdated\` (UserDetailed full publish) では更新が反映されない。partial payload で当該 field だけ送って frontend の \`$i\` を更新する:

\`\`\`go
h.mainStreamPublisher.PublishMainEvent(user.ID, "meUpdated", map[string]any{
    "usePasswordLessLogin": req.Value,
})
\`\`\`

## テスト

旧 \`TestTwoFAPasswordLess_NoPassword\` は password 必須前提だったので削除。代替として:
- \`TestTwoFAPasswordLess_EmptyBodyDefaultsFalse\`: 空 body で \`value=false\` 動作
- \`TestTwoFAPasswordLess_EnableNoKeys\`: 鍵 0 件で \`noKey\` + flag rollback
- \`TestTwoFAPasswordLess_EnableWithKey\` / \`Disable\`: 通常経路

\`handler_2fa_flow_test.go\` の \`TestTwoFAPasswordLess\` も 400→204 期待に更新。

\`go test ./internal/api/i/...\` 全 pass、\`make fmt\` クリーン。UDS 環境で動作確認: パスワードレスログインのチェック ON/OFF が即時 UI 反映 (リロード不要)。

## Closes

Closes #758

🤖 Generated with [Claude Code](https://claude.com/claude-code)