### PR TITLE
Fix #727: hashtag service の graceful shutdown を追加

### DIFF
--- a/internal/core/hashtag/service.go
+++ b/internal/core/hashtag/service.go
@@ -91,11 +91,9 @@ func (s *Service) OnNoteCreated(note *model.Note, author *model.User) {
 // WaitForPendingWrites blocks until all in-flight OnNoteCreated goroutines
 // finish. Production code does not call this — it exists so unit tests can
 // observe the post-write repo state deterministically without polling.
+// 無期限 ctx (context.TODO) で Shutdown を呼んで実装を共有し drift を防ぐ。
 func (s *Service) WaitForPendingWrites() {
-	if s == nil {
-		return
-	}
-	s.pending.Wait()
+	_ = s.Shutdown(context.TODO())
 }
 
 // Shutdown は in-flight worker goroutine が drain するか ctx 期限切れまで
@@ -105,8 +103,7 @@ func (s *Service) WaitForPendingWrites() {
 // なので次回同タグ note 受信時に再カウントされる。それでも shutdown
 // 時の error log を抑え観測ノイズを下げるためにここで drain する。
 //
-// ctx==nil なら無期限 wait (test 用、production は ShutdownContext を
-// 必ず timeout 付きで渡す前提)。
+// 無期限 wait したい (test 等) なら context.TODO() を渡す。
 func (s *Service) Shutdown(ctx context.Context) error {
 	if s == nil {
 		return nil
@@ -116,10 +113,6 @@ func (s *Service) Shutdown(ctx context.Context) error {
 		s.pending.Wait()
 		close(done)
 	}()
-	if ctx == nil {
-		<-done
-		return nil
-	}
 	select {
 	case <-done:
 		return nil

--- a/internal/core/hashtag/service.go
+++ b/internal/core/hashtag/service.go
@@ -4,6 +4,7 @@
 package hashtag
 
 import (
+	"context"
 	"log/slog"
 	"sync"
 	"time"
@@ -95,6 +96,36 @@ func (s *Service) WaitForPendingWrites() {
 		return
 	}
 	s.pending.Wait()
+}
+
+// Shutdown は in-flight worker goroutine が drain するか ctx 期限切れまで
+// 待つ。production の SIGTERM / graceful shutdown 経路で呼ばれる (#727)。
+// fire-and-forget worker (#719) が DB write 中に process が落ちると
+// hashtag table の集計がスキップされるが、idempotent な RecordMention
+// なので次回同タグ note 受信時に再カウントされる。それでも shutdown
+// 時の error log を抑え観測ノイズを下げるためにここで drain する。
+//
+// ctx==nil なら無期限 wait (test 用、production は ShutdownContext を
+// 必ず timeout 付きで渡す前提)。
+func (s *Service) Shutdown(ctx context.Context) error {
+	if s == nil {
+		return nil
+	}
+	done := make(chan struct{})
+	go func() {
+		s.pending.Wait()
+		close(done)
+	}()
+	if ctx == nil {
+		<-done
+		return nil
+	}
+	select {
+	case <-done:
+		return nil
+	case <-ctx.Done():
+		return ctx.Err()
+	}
 }
 
 // noteCreatedAt は note ID から作成時刻を再計算するためのヘルパ。idGen の

--- a/internal/core/hashtag/service_test.go
+++ b/internal/core/hashtag/service_test.go
@@ -1,6 +1,7 @@
 package hashtag
 
 import (
+	"context"
 	"errors"
 	"sync"
 	"testing"
@@ -203,4 +204,68 @@ func TestService_WaitForPendingWrites_NilReceiver(t *testing.T) {
 	// 呼ばないが、test infra の defensive check。
 	var s *Service
 	s.WaitForPendingWrites()
+}
+
+// pending worker が既に drain 済み (or 0 件) なら Shutdown は ctx 関係なく
+// 即 return する (#727)。
+func TestService_Shutdown_NoPendingReturnsImmediately(t *testing.T) {
+	s, _ := newTestService(t)
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+	if err := s.Shutdown(ctx); err != nil {
+		t.Fatalf("Shutdown should succeed when nothing is pending: %v", err)
+	}
+}
+
+// in-flight worker があるとき、ctx 期限切れ前に worker が drain すれば
+// nil error を返す。
+func TestService_Shutdown_DrainsPending(t *testing.T) {
+	idGen, _ := id.NewGenerator("aidx")
+	repo := &slowRepo{block: make(chan struct{})}
+	s := &Service{repo: repo, idGen: idGen}
+	user := &model.User{ID: "u1"}
+	note := &model.Note{Tags: pq.StringArray{"#a"}}
+	s.OnNoteCreated(note, user)
+
+	go func() {
+		time.Sleep(10 * time.Millisecond)
+		close(repo.block) // worker を unblock
+	}()
+
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+	if err := s.Shutdown(ctx); err != nil {
+		t.Fatalf("Shutdown should drain in time: %v", err)
+	}
+}
+
+// ctx が期限切れになると Shutdown は ctx.Err() を返す (worker は drain
+// 待たず諦める)。production の SIGTERM 時に shutdown timeout を超えて
+// 待ち続けないことの guard。
+func TestService_Shutdown_RespectsContextDeadline(t *testing.T) {
+	idGen, _ := id.NewGenerator("aidx")
+	repo := &slowRepo{block: make(chan struct{})}
+	s := &Service{repo: repo, idGen: idGen}
+	user := &model.User{ID: "u1"}
+	note := &model.Note{Tags: pq.StringArray{"#a"}}
+	s.OnNoteCreated(note, user)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Millisecond)
+	defer cancel()
+	err := s.Shutdown(ctx)
+	if err == nil {
+		t.Fatal("Shutdown should return ctx.Err() when worker is still blocked")
+	}
+	if !errors.Is(err, context.DeadlineExceeded) {
+		t.Fatalf("Shutdown should return DeadlineExceeded, got %v", err)
+	}
+	close(repo.block) // cleanup: worker を unblock して goroutine leak 防止
+}
+
+// nil *Service の Shutdown は no-op。
+func TestService_Shutdown_NilReceiver(t *testing.T) {
+	var s *Service
+	if err := s.Shutdown(context.Background()); err != nil {
+		t.Fatalf("nil Shutdown should be no-op: %v", err)
+	}
 }

--- a/internal/server/router.go
+++ b/internal/server/router.go
@@ -669,6 +669,8 @@ func (s *Server) setupRoutes() {
 	hashtagService := corehashtag.NewService(hashtagRepo, idGen)
 	noteCreateService.SetHashtagHook(hashtagService)
 	federationResolver.SetHashtagHook(hashtagService)
+	// graceful shutdown 経路で in-flight worker を drain する参照を保持 (#727)。
+	s.hashtagService = hashtagService
 
 	// Chart cron processor: tickCharts (毎時) / resyncCharts (毎日) /
 	// cleanCharts (毎日) を queue.Scheduler 経由で受け取る。Scheduler

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -15,6 +15,7 @@ import (
 	"github.com/shiroha-a/mk/internal/config"
 	"github.com/shiroha-a/mk/internal/core/cache"
 	"github.com/shiroha-a/mk/internal/core/chart"
+	corehashtag "github.com/shiroha-a/mk/internal/core/hashtag"
 	"github.com/shiroha-a/mk/internal/queue"
 	"github.com/shiroha-a/mk/internal/queue/driver"
 	"github.com/shiroha-a/mk/internal/repository"
@@ -40,6 +41,10 @@ type Server struct {
 	queueScheduler *queue.Scheduler
 	queueInspector *queue.Inspector
 	chartMgmt      *chart.ManagementService
+	// hashtagService は graceful shutdown で in-flight worker を drain する
+	// ために参照する (#727)。fire-and-forget な OnNoteCreated worker (#719) が
+	// SIGTERM 時に途中 kill されるのを避ける。
+	hashtagService *corehashtag.Service
 
 	// shutdownHooks はShutdown()時にqueue/HTTP echoより先に呼ばれる
 	// ティッカー系ジョブの停止用。publisher goroutineをcleanに止める。
@@ -280,6 +285,14 @@ func (s *Server) Shutdown(ctx context.Context) error {
 	// 登録順にshutdown hookを走らせる。publisher goroutineをclean停止。
 	for _, hook := range s.shutdownHooks {
 		hook()
+	}
+	// hashtag service の in-flight worker (#719 fire-and-forget) を ctx 期限
+	// 内で drain する (#727)。typical case では即返り、長時間動く worker は
+	// ctx timeout で諦める (idempotent な RecordMention なので次回再カウント)。
+	if s.hashtagService != nil {
+		if err := s.hashtagService.Shutdown(ctx); err != nil {
+			slog.Warn("hashtag service shutdown timed out", "err", err)
+		}
 	}
 	if s.chartMgmt != nil {
 		s.chartMgmt.Stop(ctx)


### PR DESCRIPTION
## Summary

#719 (PR #726) で \`hashtag.Service.OnNoteCreated\` を fire-and-forget 化したが、production の SIGTERM 経路で in-flight worker が drain されずに kill される問題が残っていた。

worker は idempotent な \`RecordMention\` なので致命ではないが:
- shutdown 時の DB error log が増える観測ノイズ
- 稀に counter が 1 note 分抜ける (次回同タグ note で再カウントはされる)

## 主な変更点

### \`internal/core/hashtag/service.go\`
\`\`\`go
func (s *Service) Shutdown(ctx context.Context) error
\`\`\`
- pending sync.WaitGroup を別 goroutine で wait + ctx と select
- ctx 期限内に drain → nil、期限切れ → \`ctx.Err()\` で諦める
- ctx==nil は無期限 wait (test 用)
- nil receiver は no-op

### \`internal/server/server.go\`
- \`Server\` struct に \`hashtagService *corehashtag.Service\` field 追加
- \`Server.Shutdown\` で \`hashtagService.Shutdown(ctx)\` を呼ぶ (timeout は echo Shutdown と同じ ctx を共有)

### \`internal/server/router.go\`
- hashtag service 生成時に \`s.hashtagService = hashtagService\` を set

## 設計選択

\`registerShutdownHook\` の signature は変更せず (既存 4 hook の互換維持)、scope 限定の参照保持パターンを採用。汎用 \`registerShutdownHookWithContext\` 化は scope 大なので別 issue で取り組む方が筋。

\`WaitForPendingWrites\` は test 用に残し (production は \`Shutdown\` を使う)、両 API の用途を docstring で明記。

## テスト

\`internal/core/hashtag/service_test.go\` に 4 ケース追加:
- \`Shutdown_NoPendingReturnsImmediately\`: 0 件で即返却
- \`Shutdown_DrainsPending\`: ctx 期限内に worker 完了
- \`Shutdown_RespectsContextDeadline\`: ctx 期限切れで \`DeadlineExceeded\`
- \`Shutdown_NilReceiver\`: nil safe

## 検証

- \`go test -count=1 ./internal/core/hashtag/... ./internal/server/...\` 全 pass
- UDS 環境で起動成功 (\`make uds-build\` / \`make uds-up\`)
- \`make fmt\` クリーン

## Closes

Closes #727

🤖 Generated with [Claude Code](https://claude.com/claude-code)