### PR TITLE
Fix #763: users/search に origin filter (local/remote/combined) を追加

### DIFF
--- a/internal/api/resetpassword/handler_test.go
+++ b/internal/api/resetpassword/handler_test.go
@@ -39,7 +39,7 @@ func (m *mockUserRepo) FindByURI(string) (*model.User, error)     { return nil, 
 func (m *mockUserRepo) FindByToken(string) (*model.User, error)   { return nil, errMock }
 func (m *mockUserRepo) IncrementFollowingCount(string, int) error { return nil }
 func (m *mockUserRepo) IncrementFollowersCount(string, int) error { return nil }
-func (m *mockUserRepo) SearchByUsername(string, int, int) ([]*model.User, error) {
+func (m *mockUserRepo) SearchByUsername(string, int, int, string) ([]*model.User, error) {
 	return nil, nil
 }
 func (m *mockUserRepo) UpdateUser(string, map[string]any) error               { return nil }

--- a/internal/api/users/handler.go
+++ b/internal/api/users/handler.go
@@ -373,8 +373,11 @@ func (h *Handler) Show(c echo.Context) error {
 
 // SearchRequest is the request body for users/search.
 type SearchRequest struct {
-	Query  string `json:"query"`
-	Limit  int    `json:"limit"`
+	Query string `json:"query"`
+	Limit int    `json:"limit"`
+	// Origin は upstream Misskey TS と同じ enum: "local" / "remote" /
+	// "combined" (default)。空 / 不明値は "combined" 扱い (#763)。
+	Origin string `json:"origin"`
 	Offset int    `json:"offset"`
 }
 
@@ -388,7 +391,7 @@ func (h *Handler) Search(c echo.Context) error {
 		req.Limit = 10
 	}
 
-	users, err := h.userService.Search(req.Query, req.Limit, req.Offset)
+	users, err := h.userService.Search(req.Query, req.Limit, req.Offset, req.Origin)
 	if err != nil {
 		return apierr.JSONInternalError(c)
 	}

--- a/internal/api/users/handler.go
+++ b/internal/api/users/handler.go
@@ -390,6 +390,17 @@ func (h *Handler) Search(c echo.Context) error {
 	if req.Limit <= 0 {
 		req.Limit = 10
 	}
+	// origin の enum 検証 (#763)。upstream Misskey TS は paramDef の
+	// JSON schema で 不正値を 400 reject する。mk-go も同等にする。
+	// 空文字列は default (combined) として許容。
+	switch req.Origin {
+	case "":
+		req.Origin = repository.SearchOriginCombined
+	case repository.SearchOriginLocal, repository.SearchOriginRemote, repository.SearchOriginCombined:
+		// OK
+	default:
+		return apierr.JSONInvalidParam(c)
+	}
 
 	users, err := h.userService.Search(req.Query, req.Limit, req.Offset, req.Origin)
 	if err != nil {

--- a/internal/api/users/handler_extra.go
+++ b/internal/api/users/handler_extra.go
@@ -115,7 +115,10 @@ func (h *Handler) SearchByUsernameAndHost(c echo.Context) error {
 	if req.Limit <= 0 {
 		req.Limit = 10
 	}
-	users, err := h.userService.Search(req.Username, req.Limit, 0)
+	// search-by-username-and-host は host を自前 filter する想定の endpoint
+	// だが、現状 host filter していない (#763 以前からの状態)。本 PR では
+	// origin filter を導入するが、このパスは "" (combined) で従来挙動を維持。
+	users, err := h.userService.Search(req.Username, req.Limit, 0, "")
 	if err != nil {
 		return c.JSON(http.StatusInternalServerError, apierr.Error("INTERNAL_ERROR", "Internal error.", "5d37dbcb-891e-41ca-a3d6-e690c97775ac"))
 	}

--- a/internal/api/users/handler_extra_test.go
+++ b/internal/api/users/handler_extra_test.go
@@ -190,7 +190,7 @@ type failingSearchRepo struct {
 	*testutil.MockUserRepository
 }
 
-func (f *failingSearchRepo) SearchByUsername(_ string, _, _ int) ([]*model.User, error) {
+func (f *failingSearchRepo) SearchByUsername(_ string, _, _ int, _ string) ([]*model.User, error) {
 	return nil, assert.AnError
 }
 

--- a/internal/api/users/handler_test.go
+++ b/internal/api/users/handler_test.go
@@ -596,6 +596,32 @@ func TestSearch_InvalidJSON(t *testing.T) {
 	assert.Equal(t, http.StatusBadRequest, rec.Code)
 }
 
+// origin enum validation (#763): upstream paramDef enum と一致しない値は
+// 400 で reject。空 / local / remote / combined は OK。
+func TestSearch_OriginEnumValidation(t *testing.T) {
+	h, _ := newTestHandler(t)
+	tt := []struct {
+		origin string
+		want   int
+	}{
+		{"", http.StatusOK},              // default → combined
+		{"local", http.StatusOK},         // upstream enum
+		{"remote", http.StatusOK},        // upstream enum
+		{"combined", http.StatusOK},      // upstream enum
+		{"all", http.StatusBadRequest},   // typo
+		{"LOCAL", http.StatusBadRequest}, // case mismatch (upstream は lower-case 厳格)
+		{"none", http.StatusBadRequest},  // 別 enum 由来
+		{"foo", http.StatusBadRequest},   // garbage
+	}
+	for _, tc := range tt {
+		t.Run(tc.origin, func(t *testing.T) {
+			body := `{"query":"test","origin":"` + tc.origin + `"}`
+			rec := post(h.Search, body)
+			assert.Equal(t, tc.want, rec.Code, "origin=%q expected %d", tc.origin, tc.want)
+		})
+	}
+}
+
 // --- Notes ---
 
 func TestNotes_Success(t *testing.T) {

--- a/internal/api/users/handler_test.go
+++ b/internal/api/users/handler_test.go
@@ -865,7 +865,7 @@ type failingUserRepo struct {
 	*testutil.MockUserRepository
 }
 
-func (f *failingUserRepo) SearchByUsername(_ string, _, _ int) ([]*model.User, error) {
+func (f *failingUserRepo) SearchByUsername(_ string, _, _ int, _ string) ([]*model.User, error) {
 	return nil, assertErr
 }
 

--- a/internal/core/retention/service_test.go
+++ b/internal/core/retention/service_test.go
@@ -52,12 +52,14 @@ func (s *stubUserRepo) FindByUsernameLower(string, *string) (*model.User, error)
 func (s *stubUserRepo) FindProfileByUserID(string) (*model.UserProfile, error)   { return nil, nil }
 func (s *stubUserRepo) IncrementFollowingCount(string, int) error                { return nil }
 func (s *stubUserRepo) IncrementFollowersCount(string, int) error                { return nil }
-func (s *stubUserRepo) SearchByUsername(string, int, int) ([]*model.User, error) { return nil, nil }
-func (s *stubUserRepo) UpdateUser(string, map[string]any) error                  { return nil }
-func (s *stubUserRepo) UpdateProfile(string, map[string]any) error               { return nil }
-func (s *stubUserRepo) CreateProfile(*model.UserProfile) error                   { return nil }
-func (s *stubUserRepo) ListUsers(model.UserListFilter) ([]*model.User, error)    { return nil, nil }
-func (s *stubUserRepo) ListRemoteInboxes() ([]string, error)                     { return nil, nil }
+func (s *stubUserRepo) SearchByUsername(string, int, int, string) ([]*model.User, error) {
+	return nil, nil
+}
+func (s *stubUserRepo) UpdateUser(string, map[string]any) error               { return nil }
+func (s *stubUserRepo) UpdateProfile(string, map[string]any) error            { return nil }
+func (s *stubUserRepo) CreateProfile(*model.UserProfile) error                { return nil }
+func (s *stubUserRepo) ListUsers(model.UserListFilter) ([]*model.User, error) { return nil, nil }
+func (s *stubUserRepo) ListRemoteInboxes() ([]string, error)                  { return nil, nil }
 func (s *stubUserRepo) FindProfileByVerifyCode(string) (*model.UserProfile, error) {
 	return nil, nil
 }

--- a/internal/core/user/user_service.go
+++ b/internal/core/user/user_service.go
@@ -242,7 +242,12 @@ func (s *Service) ListRecommendations(viewerID string, activeSince time.Time, li
 
 // Search returns users whose username matches the prefix query.
 // 空のクエリは空のリストを返す。
-func (s *Service) Search(query string, limit, offset int) ([]*model.User, error) {
+//
+// origin は upstream Misskey TS の users/search の `origin` param 互換 (#763)。
+//   - "local"    → host IS NULL のみ
+//   - "remote"   → host IS NOT NULL のみ
+//   - "combined" / 空 → filter なし (default)
+func (s *Service) Search(query string, limit, offset int, origin string) ([]*model.User, error) {
 	q := strings.TrimSpace(strings.TrimPrefix(query, "@"))
 	if q == "" {
 		return nil, nil
@@ -250,7 +255,7 @@ func (s *Service) Search(query string, limit, offset int) ([]*model.User, error)
 	if limit <= 0 {
 		limit = 10
 	}
-	return s.userRepo.SearchByUsername(strings.ToLower(q), limit, offset)
+	return s.userRepo.SearchByUsername(strings.ToLower(q), limit, offset, origin)
 }
 
 // UpdateInput represents the editable fields of a user profile.

--- a/internal/core/user/user_service_test.go
+++ b/internal/core/user/user_service_test.go
@@ -306,7 +306,7 @@ func TestService_GetProfile_Missing(t *testing.T) {
 
 func TestService_Search_Empty(t *testing.T) {
 	svc, _, _, _ := newFullSvc(t)
-	out, err := svc.Search("   ", 10, 0)
+	out, err := svc.Search("   ", 10, 0, "")
 	require.NoError(t, err)
 	assert.Empty(t, out)
 }
@@ -314,7 +314,7 @@ func TestService_Search_Empty(t *testing.T) {
 func TestService_Search_AtPrefix(t *testing.T) {
 	svc, repo, _, _ := newFullSvc(t)
 	repo.Users["u1"] = &model.User{ID: "u1", Username: "alice", UsernameLower: "alice"}
-	out, err := svc.Search("@al", 10, 0)
+	out, err := svc.Search("@al", 10, 0, "")
 	require.NoError(t, err)
 	assert.Len(t, out, 1)
 }
@@ -322,7 +322,7 @@ func TestService_Search_AtPrefix(t *testing.T) {
 func TestService_Search_DefaultLimit(t *testing.T) {
 	svc, repo, _, _ := newFullSvc(t)
 	repo.Users["u1"] = &model.User{ID: "u1", Username: "alice", UsernameLower: "alice"}
-	out, err := svc.Search("a", 0, 0)
+	out, err := svc.Search("a", 0, 0, "")
 	require.NoError(t, err)
 	assert.Len(t, out, 1)
 }

--- a/internal/repository/user.go
+++ b/internal/repository/user.go
@@ -8,6 +8,14 @@ import (
 	"gorm.io/gorm"
 )
 
+// SearchOrigin は users/search の origin 引数の enum。upstream Misskey TS の
+// paramDef enum (`local` / `remote` / `combined`) に揃える (#763)。
+const (
+	SearchOriginLocal    = "local"
+	SearchOriginRemote   = "remote"
+	SearchOriginCombined = "combined"
+)
+
 // UserRepository provides data access for users.
 type UserRepository interface {
 	Create(u *model.User) error
@@ -37,11 +45,9 @@ type UserRepository interface {
 	// 通すため userRepo 経由に統一する (Devin review #552 BUG-2)。
 	IncrementNotesCount(userID string, delta int) error
 	// SearchByUsername は usernameLower の prefix で user を検索する。
-	// origin は upstream Misskey TS と同じ semantics:
-	//   "local"    → host IS NULL のみ
-	//   "remote"   → host IS NOT NULL のみ
-	//   "combined" / 空文字列 / その他 → filter なし
-	// (#763)。
+	// origin は upstream Misskey TS と同じ semantics (#763)。値は
+	// SearchOriginLocal / SearchOriginRemote / SearchOriginCombined を使う。
+	// 空文字列 / 未知値は SearchOriginCombined と同等扱い。
 	SearchByUsername(query string, limit, offset int, origin string) ([]*model.User, error)
 	UpdateUser(userID string, fields map[string]any) error
 	UpdateProfile(userID string, fields map[string]any) error
@@ -211,9 +217,9 @@ func (r *userRepository) SearchByUsername(query string, limit, offset int, origi
 	var users []*model.User
 	q := r.db.Where("\"usernameLower\" LIKE ?", query+"%")
 	switch origin {
-	case "local":
+	case SearchOriginLocal:
 		q = q.Where("\"host\" IS NULL")
-	case "remote":
+	case SearchOriginRemote:
 		q = q.Where("\"host\" IS NOT NULL")
 	}
 	if err := q.

--- a/internal/repository/user.go
+++ b/internal/repository/user.go
@@ -36,7 +36,13 @@ type UserRepository interface {
 	// UPDATE していたが、CachedUserRepository wrapper の invalidate を
 	// 通すため userRepo 経由に統一する (Devin review #552 BUG-2)。
 	IncrementNotesCount(userID string, delta int) error
-	SearchByUsername(query string, limit, offset int) ([]*model.User, error)
+	// SearchByUsername は usernameLower の prefix で user を検索する。
+	// origin は upstream Misskey TS と同じ semantics:
+	//   "local"    → host IS NULL のみ
+	//   "remote"   → host IS NOT NULL のみ
+	//   "combined" / 空文字列 / その他 → filter なし
+	// (#763)。
+	SearchByUsername(query string, limit, offset int, origin string) ([]*model.User, error)
 	UpdateUser(userID string, fields map[string]any) error
 	UpdateProfile(userID string, fields map[string]any) error
 	CreateProfile(profile *model.UserProfile) error
@@ -199,10 +205,18 @@ func (r *userRepository) IncrementNotesCount(userID string, delta int) error {
 
 // SearchByUsername returns users whose usernameLower starts with the given query.
 // Phase 4でMeilisearch統合予定だが、現状は単純なLIKE検索のみ。
-func (r *userRepository) SearchByUsername(query string, limit, offset int) ([]*model.User, error) {
+//
+// origin で host filter を切り替える (#763)。
+func (r *userRepository) SearchByUsername(query string, limit, offset int, origin string) ([]*model.User, error) {
 	var users []*model.User
-	if err := r.db.
-		Where("\"usernameLower\" LIKE ?", query+"%").
+	q := r.db.Where("\"usernameLower\" LIKE ?", query+"%")
+	switch origin {
+	case "local":
+		q = q.Where("\"host\" IS NULL")
+	case "remote":
+		q = q.Where("\"host\" IS NOT NULL")
+	}
+	if err := q.
 		Order("\"followersCount\" DESC, id ASC").
 		Limit(limit).
 		Offset(offset).

--- a/internal/repository/user_test.go
+++ b/internal/repository/user_test.go
@@ -352,7 +352,7 @@ func TestUserRepository_SearchByUsername_OriginFilter(t *testing.T) {
 	defer cleanupUser(t, remote.ID)
 
 	t.Run("local only excludes remote", func(t *testing.T) {
-		out, err := repo.SearchByUsername("origin", 10, 0, "local")
+		out, err := repo.SearchByUsername("origin", 10, 0, SearchOriginLocal)
 		require.NoError(t, err)
 		ids := make(map[string]bool, len(out))
 		for _, u := range out {
@@ -363,7 +363,7 @@ func TestUserRepository_SearchByUsername_OriginFilter(t *testing.T) {
 	})
 
 	t.Run("remote only excludes local", func(t *testing.T) {
-		out, err := repo.SearchByUsername("origin", 10, 0, "remote")
+		out, err := repo.SearchByUsername("origin", 10, 0, SearchOriginRemote)
 		require.NoError(t, err)
 		ids := make(map[string]bool, len(out))
 		for _, u := range out {
@@ -374,7 +374,7 @@ func TestUserRepository_SearchByUsername_OriginFilter(t *testing.T) {
 	})
 
 	t.Run("combined returns both", func(t *testing.T) {
-		out, err := repo.SearchByUsername("origin", 10, 0, "combined")
+		out, err := repo.SearchByUsername("origin", 10, 0, SearchOriginCombined)
 		require.NoError(t, err)
 		ids := make(map[string]bool, len(out))
 		for _, u := range out {

--- a/internal/repository/user_test.go
+++ b/internal/repository/user_test.go
@@ -334,9 +334,66 @@ func TestUserRepository_SearchByUsername(t *testing.T) {
 	b := insertTestUser(t, "u_sb_2", "searchbeta")
 	defer cleanupUser(t, b.ID)
 
-	out, err := repo.SearchByUsername("search", 10, 0)
+	out, err := repo.SearchByUsername("search", 10, 0, "")
 	require.NoError(t, err)
 	assert.GreaterOrEqual(t, len(out), 2)
+}
+
+// origin filter (#763): "local" は host IS NULL のみ、"remote" は IS NOT NULL
+// のみ返す。"combined" / "" は両方返す。
+func TestUserRepository_SearchByUsername_OriginFilter(t *testing.T) {
+	repo := NewUserRepository(testDB)
+	local := insertTestUser(t, "u_so_local", "originlocal")
+	defer cleanupUser(t, local.ID)
+	remoteHost := "remote.example"
+	remote := insertTestUser(t, "u_so_remote", "originremote")
+	// host を後付けで設定 (insertTestUser は host=nil で作る前提)。
+	require.NoError(t, repo.UpdateUser(remote.ID, map[string]any{"host": remoteHost}))
+	defer cleanupUser(t, remote.ID)
+
+	t.Run("local only excludes remote", func(t *testing.T) {
+		out, err := repo.SearchByUsername("origin", 10, 0, "local")
+		require.NoError(t, err)
+		ids := make(map[string]bool, len(out))
+		for _, u := range out {
+			ids[u.ID] = true
+		}
+		assert.True(t, ids[local.ID], "local user should appear")
+		assert.False(t, ids[remote.ID], "remote user should NOT appear in local-only search")
+	})
+
+	t.Run("remote only excludes local", func(t *testing.T) {
+		out, err := repo.SearchByUsername("origin", 10, 0, "remote")
+		require.NoError(t, err)
+		ids := make(map[string]bool, len(out))
+		for _, u := range out {
+			ids[u.ID] = true
+		}
+		assert.False(t, ids[local.ID], "local user should NOT appear in remote-only search")
+		assert.True(t, ids[remote.ID], "remote user should appear")
+	})
+
+	t.Run("combined returns both", func(t *testing.T) {
+		out, err := repo.SearchByUsername("origin", 10, 0, "combined")
+		require.NoError(t, err)
+		ids := make(map[string]bool, len(out))
+		for _, u := range out {
+			ids[u.ID] = true
+		}
+		assert.True(t, ids[local.ID])
+		assert.True(t, ids[remote.ID])
+	})
+
+	t.Run("empty origin treated as combined", func(t *testing.T) {
+		out, err := repo.SearchByUsername("origin", 10, 0, "")
+		require.NoError(t, err)
+		ids := make(map[string]bool, len(out))
+		for _, u := range out {
+			ids[u.ID] = true
+		}
+		assert.True(t, ids[local.ID])
+		assert.True(t, ids[remote.ID])
+	})
 }
 
 func TestUserRepository_UpdateUser(t *testing.T) {
@@ -358,7 +415,7 @@ func TestUserRepository_SearchByUsername_QueryError(t *testing.T) {
 	db := testDB.WithContext(ctx)
 	repo := NewUserRepository(db)
 
-	_, err := repo.SearchByUsername("anything", 10, 0)
+	_, err := repo.SearchByUsername("anything", 10, 0, "")
 	assert.Error(t, err)
 }
 

--- a/internal/testutil/mock_repository.go
+++ b/internal/testutil/mock_repository.go
@@ -181,7 +181,7 @@ func (m *MockUserRepository) IncrementFollowersCount(userID string, delta int) e
 	return nil
 }
 
-func (m *MockUserRepository) SearchByUsername(query string, limit, offset int) ([]*model.User, error) {
+func (m *MockUserRepository) SearchByUsername(query string, limit, offset int, origin string) ([]*model.User, error) {
 	var matches []*model.User
 	for _, u := range m.Users {
 		if len(u.UsernameLower) >= len(query) && u.UsernameLower[:len(query)] == query {


### PR DESCRIPTION
## Summary

issue #763: 設定→ユーザー検索のローカルタブでリモートユーザーが混入する。

## Root cause

upstream Misskey TS の \`users/search\` の paramDef は \`origin: 'local' | 'remote' | 'combined'\` を受け取り host=NULL / host!=NULL で SQL filter する。mk-go の handler は origin field を実装しておらず、frontend が \`origin: 'local'\` を送っても無視して全 user を返していた (combined 相当)。

## Fix

層別に \`origin string\` を伝播:

| 層 | 変更 |
|---|---|
| \`repository.UserRepository.SearchByUsername\` | 第 4 引数 \`origin string\` 追加。SQL に \`WHERE "host" IS NULL\` / \`IS NOT NULL\` を origin で切り替え。"combined" / 空 / 未知値は filter なし |
| \`core/user.Service.Search\` | 引数を repo に伝播 |
| \`api/users.SearchRequest\` | \`Origin string\` field 追加 (upstream paramDef enum 互換) |
| \`api/users.SearchByUsernameAndHost\` | host filter していない既存挙動維持のため \`""\` (combined) で渡す |

## テスト

\`internal/repository/user_test.go\` に \`SearchByUsername_OriginFilter\` を追加。4 ケース網羅:
- local only (excludes remote)
- remote only (excludes local)
- combined (returns both)
- empty origin (combined と等価)

mock / fake / failing repo の signature を一律拡張。

## 検証

- \`go test -count=1 -short ./...\` 全 pass
- \`make fmt\` / \`make lint\` クリーン
- UDS 環境で frontend「ユーザー検索」ローカルタブからリモート user が混入しないことを確認

## 既存 user への影響

なし。修正前は origin が無視されて combined 動作になっていただけなので、修正後は frontend 指定通りに filter が効く方向。

## Closes

Closes #763

🤖 Generated with [Claude Code](https://claude.com/claude-code)