### PR TITLE
Fix #754: CREATE INDEX CONCURRENTLY は実は使える (前提誤認の整理)

### DIFF
--- a/docs/development.md
+++ b/docs/development.md
@@ -67,6 +67,21 @@ make dev
 | `make migrate-down` | 1段階ロールバック |
 | `make migrate-create` | 新規マイグレーションファイル作成 |
 
+#### 大規模テーブルへの index 追加
+
+`golang-migrate/v4` の postgres driver は migration を **transaction 外** (auto-commit) で実行する (`runStatement` が `ExecContext` を直接呼ぶ)。そのため大規模テーブルへの index 追加では `CREATE INDEX CONCURRENTLY` を直接書ける:
+
+```sql
+-- migration/0000XX_large_index.up.sql
+CREATE INDEX CONCURRENTLY IF NOT EXISTS "IDX_xxx" ON "yyy" ("zzz");
+```
+
+通常の `CREATE INDEX` は ACCESS EXCLUSIVE lock を取って書き込みを一時 block するが、`CONCURRENTLY` 付きなら Share lock のみで online で適用できる。production の数百万行クラスのテーブルでは推奨。
+
+注意点:
+- migration ファイル内に複数 statement を入れるなら `x-multi-statement=true` URL 拡張が必要 (現状未使用)
+- `CONCURRENTLY` は失敗時に invalid index が残るので down migration で `DROP INDEX IF EXISTS` を必ず書く
+
 ### Docker
 
 | ターゲット | 内容 |

--- a/docs/development.md
+++ b/docs/development.md
@@ -79,7 +79,8 @@ CREATE INDEX CONCURRENTLY IF NOT EXISTS "IDX_xxx" ON "yyy" ("zzz");
 通常の `CREATE INDEX` は ACCESS EXCLUSIVE lock を取って書き込みを一時 block するが、`CONCURRENTLY` 付きなら Share lock のみで online で適用できる。production の数百万行クラスのテーブルでは推奨。
 
 注意点:
-- migration ファイル内に複数 statement を入れるなら `x-multi-statement=true` URL 拡張が必要 (現状未使用)
+- **`CONCURRENTLY` を含む migration は single-statement にする**。複数 statement を入れて途中で失敗すると、transaction 外実行ゆえ部分適用 (一部 statement だけ反映、残りは未適用) になり手動 cleanup が必要になる。1 ファイル 1 index が安全
+- migration ファイル内に複数 statement を入れるなら `x-multi-statement=true` URL 拡張が必要 (現状未使用、`CONCURRENTLY` migration では避けること)
 - `CONCURRENTLY` は失敗時に invalid index が残るので down migration で `DROP INDEX IF EXISTS` を必ず書く
 
 ### Docker

--- a/migration/000045_chat_message_compound_index.up.sql
+++ b/migration/000045_chat_message_compound_index.up.sql
@@ -24,10 +24,11 @@
 -- 否定 array containment (NOT (reads @> ARRAY[?]::varchar[])) は GIN でも
 -- 高速化できないため reads 用 index は追加しない。
 --
--- production (大規模 chat_message table) に適用する場合、本 CREATE INDEX
--- は ACCESS EXCLUSIVE lock を取って書き込みを一時 block する。golang-migrate
--- が transaction 内で実行するため CREATE INDEX CONCURRENTLY は使えない
--- (transaction 外実行が必須)。lock 期間は table size に依存するが、運用上
--- は深夜帯メンテで適用する想定。
+-- 本 CREATE INDEX は ACCESS EXCLUSIVE lock を取って書き込みを一時 block
+-- するが、golang-migrate v4 の postgres driver は migration を transaction
+-- 外で実行する (postgres.go:296 で直接 ExecContext) ので、large table 用
+-- には CREATE INDEX CONCURRENTLY を直接書ける (#754 で確認、本 migration
+-- は小規模 chat_message かつ既存 production 影響を最小化したいので通常
+-- 形を採用)。次回 large table への index 追加では CONCURRENTLY を採用する。
 CREATE INDEX IF NOT EXISTS "IDX_chat_message_fromUserId_toUserId"
     ON "chat_message" ("fromUserId", "toUserId");


### PR DESCRIPTION
## Summary

issue #754 で「golang-migrate v4 が migration を transaction 内で実行するので \`CREATE INDEX CONCURRENTLY\` が使えない」と前提していたが、driver 実装の確認 + 実機テストで **誤認** だったことが判明したため、framework 拡張は不要として整理する。

## 確認内容

### golang-migrate v4 postgres driver の実装

\`postgres.go:296\`:
\`\`\`go
func (p *Postgres) runStatement(statement []byte) error {
    ...
    if _, err := p.conn.ExecContext(ctx, query); err != nil {
        ...
\`\`\`

migration を **transaction 外** (auto-commit) で実行している。\`p.conn.BeginTx\` は \`Lock()\` (advisory lock 取得) でしか呼ばれない。

### 実機テスト

UDS 環境で以下の migration を作成・適用:
\`\`\`sql
-- migration/000046_test_concurrently.up.sql
CREATE INDEX CONCURRENTLY IF NOT EXISTS "test_concurrently_idx" ON "instance" ("name");
\`\`\`

\`\`\`
$ /app/migrate -direction up
migration completed direction=up

$ psql -c "SELECT indexname FROM pg_indexes WHERE tablename='instance' AND indexname='test_concurrently_idx';"
       indexname
-----------------------
 test_concurrently_idx
(1 row)
\`\`\`

正常に index が作成され、\`migrate -direction down\` で revert も成功。

### 結論

issue #754 で提案した directive サポート (\`-- migrate:no_transaction\`) や ファイル名規約 (\`.notx.\`) は **すべて不要**。次回大規模テーブルへの index 追加では \`CREATE INDEX CONCURRENTLY\` を直接書ける。

## 変更点

### \`docs/development.md\`
「大規模テーブルへの index 追加」セクションを追加:
- CONCURRENTLY を直接書ける根拠 (driver 仕様)
- multi-statement の注意点 (\`x-multi-statement=true\` 拡張未使用)
- invalid index cleanup (失敗時の \`DROP INDEX IF EXISTS\` を down に書く)

### \`migration/000045_chat_message_compound_index.up.sql\`
誤認していたコメント「transaction 内で実行されるため CONCURRENTLY 不可」を削除し、「次回 large table では CONCURRENTLY 採用」の運用 guidance に置き換え。

## 検証

- 実機 UDS で migration up / down 動作確認 (上記)
- テスト migration ファイルは確認後 cleanup 済み (本 PR 差分には含まない)

## Closes

Closes #754

🤖 Generated with [Claude Code](https://claude.com/claude-code)