### PR TITLE
Fix #761 Phase 1a: abuse_report_notification_test の boilerplate を helper 化

### DIFF
--- a/internal/api/admin/abuse_report_notification_test.go
+++ b/internal/api/admin/abuse_report_notification_test.go
@@ -6,18 +6,32 @@ import (
 	"testing"
 	"time"
 
+	apiadmin "github.com/shiroha-a/mk/internal/api/admin"
 	"github.com/shiroha-a/mk/internal/model"
 	"github.com/shiroha-a/mk/internal/testutil"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
+// setupRecipientHandler returns a handler with RecipientRepo wired and
+// optional seed rows. RecipientRepo を使う test の boilerplate (handler 構築
+// + repo 生成 + seed + SetRecipientRepo) を 1 行に圧縮する (#761)。
+// 戻り値の repo を直接 mutate して CreateErr 等の error injection も可能。
+func setupRecipientHandler(t *testing.T, seed ...*model.AbuseReportNotificationRecipient) (*apiadmin.Handler, *testutil.MockAbuseReportNotificationRecipientRepository) {
+	t.Helper()
+	h, _, _, _ := newTestHandler(t)
+	repo := testutil.NewMockAbuseReportNotificationRecipientRepository()
+	for _, r := range seed {
+		require.NoError(t, repo.Create(r))
+	}
+	h.SetRecipientRepo(repo)
+	return h, repo
+}
+
 // --- AbuseReportNotificationRecipient ---
 
 func TestRecipientCreate_Success(t *testing.T) {
-	h, _, _, _ := newTestHandler(t)
-	repo := testutil.NewMockAbuseReportNotificationRecipientRepository()
-	h.SetRecipientRepo(repo)
+	h, _ := setupRecipientHandler(t)
 
 	rec := doPost(h.AbuseReportNotificationRecipientCreate,
 		`{"name":"ops","method":"email"}`, adminUser)
@@ -31,8 +45,7 @@ func TestRecipientCreate_Success(t *testing.T) {
 }
 
 func TestRecipientCreate_DefaultMethod(t *testing.T) {
-	h, _, _, _ := newTestHandler(t)
-	h.SetRecipientRepo(testutil.NewMockAbuseReportNotificationRecipientRepository())
+	h, _ := setupRecipientHandler(t)
 	rec := doPost(h.AbuseReportNotificationRecipientCreate, `{"name":"ops"}`, adminUser)
 	assert.Equal(t, http.StatusOK, rec.Code)
 	var got model.AbuseReportNotificationRecipient
@@ -41,20 +54,17 @@ func TestRecipientCreate_DefaultMethod(t *testing.T) {
 }
 
 func TestRecipientCreate_RepoError(t *testing.T) {
-	h, _, _, _ := newTestHandler(t)
-	repo := testutil.NewMockAbuseReportNotificationRecipientRepository()
+	h, repo := setupRecipientHandler(t)
 	repo.CreateErr = assertError{}
-	h.SetRecipientRepo(repo)
 	rec := doPost(h.AbuseReportNotificationRecipientCreate, `{"name":"x"}`, adminUser)
 	assert.Equal(t, http.StatusInternalServerError, rec.Code)
 }
 
 func TestRecipientList_ReturnsRows(t *testing.T) {
-	h, _, _, _ := newTestHandler(t)
-	repo := testutil.NewMockAbuseReportNotificationRecipientRepository()
-	require.NoError(t, repo.Create(&model.AbuseReportNotificationRecipient{ID: "r1", Name: "a", Method: "email"}))
-	require.NoError(t, repo.Create(&model.AbuseReportNotificationRecipient{ID: "r2", Name: "b", Method: "webhook"}))
-	h.SetRecipientRepo(repo)
+	h, _ := setupRecipientHandler(t,
+		&model.AbuseReportNotificationRecipient{ID: "r1", Name: "a", Method: "email"},
+		&model.AbuseReportNotificationRecipient{ID: "r2", Name: "b", Method: "webhook"},
+	)
 
 	rec := doPost(h.AbuseReportNotificationRecipientList, `{}`, adminUser)
 	assert.Equal(t, http.StatusOK, rec.Code)
@@ -64,10 +74,9 @@ func TestRecipientList_ReturnsRows(t *testing.T) {
 }
 
 func TestRecipientShow_FoundAndNotFound(t *testing.T) {
-	h, _, _, _ := newTestHandler(t)
-	repo := testutil.NewMockAbuseReportNotificationRecipientRepository()
-	require.NoError(t, repo.Create(&model.AbuseReportNotificationRecipient{ID: "r1", Name: "ops", Method: "email"}))
-	h.SetRecipientRepo(repo)
+	h, _ := setupRecipientHandler(t,
+		&model.AbuseReportNotificationRecipient{ID: "r1", Name: "ops", Method: "email"},
+	)
 
 	rec := doPost(h.AbuseReportNotificationRecipientShow, `{"id":"r1"}`, adminUser)
 	assert.Equal(t, http.StatusOK, rec.Code)
@@ -77,10 +86,9 @@ func TestRecipientShow_FoundAndNotFound(t *testing.T) {
 }
 
 func TestRecipientDelete_Removes(t *testing.T) {
-	h, _, _, _ := newTestHandler(t)
-	repo := testutil.NewMockAbuseReportNotificationRecipientRepository()
-	require.NoError(t, repo.Create(&model.AbuseReportNotificationRecipient{ID: "r1"}))
-	h.SetRecipientRepo(repo)
+	h, repo := setupRecipientHandler(t,
+		&model.AbuseReportNotificationRecipient{ID: "r1"},
+	)
 
 	rec := doPost(h.AbuseReportNotificationRecipientDelete, `{"id":"r1"}`, adminUser)
 	assert.Equal(t, http.StatusNoContent, rec.Code)
@@ -88,12 +96,11 @@ func TestRecipientDelete_Removes(t *testing.T) {
 }
 
 func TestRecipientUpdate_PartialFields(t *testing.T) {
-	h, _, _, _ := newTestHandler(t)
-	repo := testutil.NewMockAbuseReportNotificationRecipientRepository()
-	require.NoError(t, repo.Create(&model.AbuseReportNotificationRecipient{
-		ID: "r1", Name: "old", Method: "email", IsActive: true,
-	}))
-	h.SetRecipientRepo(repo)
+	h, repo := setupRecipientHandler(t,
+		&model.AbuseReportNotificationRecipient{
+			ID: "r1", Name: "old", Method: "email", IsActive: true,
+		},
+	)
 
 	rec := doPost(h.AbuseReportNotificationRecipientUpdate,
 		`{"id":"r1","name":"new","method":"webhook","isActive":false}`, adminUser)
@@ -104,15 +111,13 @@ func TestRecipientUpdate_PartialFields(t *testing.T) {
 }
 
 func TestRecipientUpdate_NotFound(t *testing.T) {
-	h, _, _, _ := newTestHandler(t)
-	h.SetRecipientRepo(testutil.NewMockAbuseReportNotificationRecipientRepository())
+	h, _ := setupRecipientHandler(t)
 	rec := doPost(h.AbuseReportNotificationRecipientUpdate, `{"id":"missing","name":"x"}`, adminUser)
 	assert.Equal(t, http.StatusNotFound, rec.Code)
 }
 
 func TestRecipientUpdate_MissingID(t *testing.T) {
-	h, _, _, _ := newTestHandler(t)
-	h.SetRecipientRepo(testutil.NewMockAbuseReportNotificationRecipientRepository())
+	h, _ := setupRecipientHandler(t)
 	rec := doPost(h.AbuseReportNotificationRecipientUpdate, `{}`, adminUser)
 	assert.Equal(t, http.StatusBadRequest, rec.Code)
 }
@@ -151,8 +156,7 @@ func TestAbuseReportNotificationRecipientUpdate(t *testing.T) {
 // --- moderation log assertions (#665) ---
 
 func TestRecipientCreate_WritesModerationLog(t *testing.T) {
-	h, _, _, _ := newTestHandler(t)
-	h.SetRecipientRepo(testutil.NewMockAbuseReportNotificationRecipientRepository())
+	h, _ := setupRecipientHandler(t)
 	repo := attachModLog(t, h)
 
 	rec := doPost(h.AbuseReportNotificationRecipientCreate, `{"name":"r","method":"email"}`, adminUser)
@@ -162,10 +166,9 @@ func TestRecipientCreate_WritesModerationLog(t *testing.T) {
 }
 
 func TestRecipientUpdate_WritesModerationLog(t *testing.T) {
-	h, _, _, _ := newTestHandler(t)
-	rcpRepo := testutil.NewMockAbuseReportNotificationRecipientRepository()
-	require.NoError(t, rcpRepo.Create(&model.AbuseReportNotificationRecipient{ID: "r1", Name: "old", Method: "email"}))
-	h.SetRecipientRepo(rcpRepo)
+	h, _ := setupRecipientHandler(t,
+		&model.AbuseReportNotificationRecipient{ID: "r1", Name: "old", Method: "email"},
+	)
 	repo := attachModLog(t, h)
 
 	rec := doPost(h.AbuseReportNotificationRecipientUpdate, `{"id":"r1","name":"new"}`, adminUser)
@@ -180,10 +183,9 @@ func TestRecipientUpdate_WritesModerationLog(t *testing.T) {
 }
 
 func TestRecipientDelete_WritesModerationLog(t *testing.T) {
-	h, _, _, _ := newTestHandler(t)
-	rcpRepo := testutil.NewMockAbuseReportNotificationRecipientRepository()
-	require.NoError(t, rcpRepo.Create(&model.AbuseReportNotificationRecipient{ID: "r1", Name: "doomed", Method: "email"}))
-	h.SetRecipientRepo(rcpRepo)
+	h, _ := setupRecipientHandler(t,
+		&model.AbuseReportNotificationRecipient{ID: "r1", Name: "doomed", Method: "email"},
+	)
 	repo := attachModLog(t, h)
 
 	rec := doPost(h.AbuseReportNotificationRecipientDelete, `{"id":"r1"}`, adminUser)
@@ -195,8 +197,7 @@ func TestRecipientDelete_WritesModerationLog(t *testing.T) {
 // --- moderation log assertions (#665) ---
 
 func TestAbuseReportNotificationRecipientCreate_WritesModerationLog(t *testing.T) {
-	h, _, _, _ := newTestHandler(t)
-	h.SetRecipientRepo(testutil.NewMockAbuseReportNotificationRecipientRepository())
+	h, _ := setupRecipientHandler(t)
 	repo := attachModLog(t, h)
 
 	rec := doPost(h.AbuseReportNotificationRecipientCreate, `{"name":"r1","method":"email"}`, adminUser)
@@ -206,10 +207,9 @@ func TestAbuseReportNotificationRecipientCreate_WritesModerationLog(t *testing.T
 }
 
 func TestAbuseReportNotificationRecipientUpdate_WritesModerationLog(t *testing.T) {
-	h, _, _, _ := newTestHandler(t)
-	rRepo := testutil.NewMockAbuseReportNotificationRecipientRepository()
-	require.NoError(t, rRepo.Create(&model.AbuseReportNotificationRecipient{ID: "r1", Name: "old"}))
-	h.SetRecipientRepo(rRepo)
+	h, _ := setupRecipientHandler(t,
+		&model.AbuseReportNotificationRecipient{ID: "r1", Name: "old"},
+	)
 	repo := attachModLog(t, h)
 
 	rec := doPost(h.AbuseReportNotificationRecipientUpdate, `{"id":"r1","name":"new"}`, adminUser)
@@ -219,10 +219,9 @@ func TestAbuseReportNotificationRecipientUpdate_WritesModerationLog(t *testing.T
 }
 
 func TestAbuseReportNotificationRecipientDelete_WritesModerationLog(t *testing.T) {
-	h, _, _, _ := newTestHandler(t)
-	rRepo := testutil.NewMockAbuseReportNotificationRecipientRepository()
-	require.NoError(t, rRepo.Create(&model.AbuseReportNotificationRecipient{ID: "r1"}))
-	h.SetRecipientRepo(rRepo)
+	h, _ := setupRecipientHandler(t,
+		&model.AbuseReportNotificationRecipient{ID: "r1"},
+	)
 	repo := attachModLog(t, h)
 
 	rec := doPost(h.AbuseReportNotificationRecipientDelete, `{"id":"r1"}`, adminUser)

--- a/internal/api/admin/abuse_report_notification_test.go
+++ b/internal/api/admin/abuse_report_notification_test.go
@@ -13,11 +13,11 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// setupRecipientHandler returns a handler with RecipientRepo wired and
+// setupAbuseRecipientHandler returns a handler with RecipientRepo wired and
 // optional seed rows. RecipientRepo を使う test の boilerplate (handler 構築
 // + repo 生成 + seed + SetRecipientRepo) を 1 行に圧縮する (#761)。
 // 戻り値の repo を直接 mutate して CreateErr 等の error injection も可能。
-func setupRecipientHandler(t *testing.T, seed ...*model.AbuseReportNotificationRecipient) (*apiadmin.Handler, *testutil.MockAbuseReportNotificationRecipientRepository) {
+func setupAbuseRecipientHandler(t *testing.T, seed ...*model.AbuseReportNotificationRecipient) (*apiadmin.Handler, *testutil.MockAbuseReportNotificationRecipientRepository) {
 	t.Helper()
 	h, _, _, _ := newTestHandler(t)
 	repo := testutil.NewMockAbuseReportNotificationRecipientRepository()
@@ -31,7 +31,7 @@ func setupRecipientHandler(t *testing.T, seed ...*model.AbuseReportNotificationR
 // --- AbuseReportNotificationRecipient ---
 
 func TestRecipientCreate_Success(t *testing.T) {
-	h, _ := setupRecipientHandler(t)
+	h, _ := setupAbuseRecipientHandler(t)
 
 	rec := doPost(h.AbuseReportNotificationRecipientCreate,
 		`{"name":"ops","method":"email"}`, adminUser)
@@ -45,7 +45,7 @@ func TestRecipientCreate_Success(t *testing.T) {
 }
 
 func TestRecipientCreate_DefaultMethod(t *testing.T) {
-	h, _ := setupRecipientHandler(t)
+	h, _ := setupAbuseRecipientHandler(t)
 	rec := doPost(h.AbuseReportNotificationRecipientCreate, `{"name":"ops"}`, adminUser)
 	assert.Equal(t, http.StatusOK, rec.Code)
 	var got model.AbuseReportNotificationRecipient
@@ -54,14 +54,14 @@ func TestRecipientCreate_DefaultMethod(t *testing.T) {
 }
 
 func TestRecipientCreate_RepoError(t *testing.T) {
-	h, repo := setupRecipientHandler(t)
+	h, repo := setupAbuseRecipientHandler(t)
 	repo.CreateErr = assertError{}
 	rec := doPost(h.AbuseReportNotificationRecipientCreate, `{"name":"x"}`, adminUser)
 	assert.Equal(t, http.StatusInternalServerError, rec.Code)
 }
 
 func TestRecipientList_ReturnsRows(t *testing.T) {
-	h, _ := setupRecipientHandler(t,
+	h, _ := setupAbuseRecipientHandler(t,
 		&model.AbuseReportNotificationRecipient{ID: "r1", Name: "a", Method: "email"},
 		&model.AbuseReportNotificationRecipient{ID: "r2", Name: "b", Method: "webhook"},
 	)
@@ -74,7 +74,7 @@ func TestRecipientList_ReturnsRows(t *testing.T) {
 }
 
 func TestRecipientShow_FoundAndNotFound(t *testing.T) {
-	h, _ := setupRecipientHandler(t,
+	h, _ := setupAbuseRecipientHandler(t,
 		&model.AbuseReportNotificationRecipient{ID: "r1", Name: "ops", Method: "email"},
 	)
 
@@ -86,7 +86,7 @@ func TestRecipientShow_FoundAndNotFound(t *testing.T) {
 }
 
 func TestRecipientDelete_Removes(t *testing.T) {
-	h, repo := setupRecipientHandler(t,
+	h, repo := setupAbuseRecipientHandler(t,
 		&model.AbuseReportNotificationRecipient{ID: "r1"},
 	)
 
@@ -96,7 +96,7 @@ func TestRecipientDelete_Removes(t *testing.T) {
 }
 
 func TestRecipientUpdate_PartialFields(t *testing.T) {
-	h, repo := setupRecipientHandler(t,
+	h, repo := setupAbuseRecipientHandler(t,
 		&model.AbuseReportNotificationRecipient{
 			ID: "r1", Name: "old", Method: "email", IsActive: true,
 		},
@@ -111,13 +111,13 @@ func TestRecipientUpdate_PartialFields(t *testing.T) {
 }
 
 func TestRecipientUpdate_NotFound(t *testing.T) {
-	h, _ := setupRecipientHandler(t)
+	h, _ := setupAbuseRecipientHandler(t)
 	rec := doPost(h.AbuseReportNotificationRecipientUpdate, `{"id":"missing","name":"x"}`, adminUser)
 	assert.Equal(t, http.StatusNotFound, rec.Code)
 }
 
 func TestRecipientUpdate_MissingID(t *testing.T) {
-	h, _ := setupRecipientHandler(t)
+	h, _ := setupAbuseRecipientHandler(t)
 	rec := doPost(h.AbuseReportNotificationRecipientUpdate, `{}`, adminUser)
 	assert.Equal(t, http.StatusBadRequest, rec.Code)
 }
@@ -156,7 +156,7 @@ func TestAbuseReportNotificationRecipientUpdate(t *testing.T) {
 // --- moderation log assertions (#665) ---
 
 func TestRecipientCreate_WritesModerationLog(t *testing.T) {
-	h, _ := setupRecipientHandler(t)
+	h, _ := setupAbuseRecipientHandler(t)
 	repo := attachModLog(t, h)
 
 	rec := doPost(h.AbuseReportNotificationRecipientCreate, `{"name":"r","method":"email"}`, adminUser)
@@ -166,7 +166,7 @@ func TestRecipientCreate_WritesModerationLog(t *testing.T) {
 }
 
 func TestRecipientUpdate_WritesModerationLog(t *testing.T) {
-	h, _ := setupRecipientHandler(t,
+	h, _ := setupAbuseRecipientHandler(t,
 		&model.AbuseReportNotificationRecipient{ID: "r1", Name: "old", Method: "email"},
 	)
 	repo := attachModLog(t, h)
@@ -183,7 +183,7 @@ func TestRecipientUpdate_WritesModerationLog(t *testing.T) {
 }
 
 func TestRecipientDelete_WritesModerationLog(t *testing.T) {
-	h, _ := setupRecipientHandler(t,
+	h, _ := setupAbuseRecipientHandler(t,
 		&model.AbuseReportNotificationRecipient{ID: "r1", Name: "doomed", Method: "email"},
 	)
 	repo := attachModLog(t, h)
@@ -197,7 +197,7 @@ func TestRecipientDelete_WritesModerationLog(t *testing.T) {
 // --- moderation log assertions (#665) ---
 
 func TestAbuseReportNotificationRecipientCreate_WritesModerationLog(t *testing.T) {
-	h, _ := setupRecipientHandler(t)
+	h, _ := setupAbuseRecipientHandler(t)
 	repo := attachModLog(t, h)
 
 	rec := doPost(h.AbuseReportNotificationRecipientCreate, `{"name":"r1","method":"email"}`, adminUser)
@@ -207,7 +207,7 @@ func TestAbuseReportNotificationRecipientCreate_WritesModerationLog(t *testing.T
 }
 
 func TestAbuseReportNotificationRecipientUpdate_WritesModerationLog(t *testing.T) {
-	h, _ := setupRecipientHandler(t,
+	h, _ := setupAbuseRecipientHandler(t,
 		&model.AbuseReportNotificationRecipient{ID: "r1", Name: "old"},
 	)
 	repo := attachModLog(t, h)
@@ -219,7 +219,7 @@ func TestAbuseReportNotificationRecipientUpdate_WritesModerationLog(t *testing.T
 }
 
 func TestAbuseReportNotificationRecipientDelete_WritesModerationLog(t *testing.T) {
-	h, _ := setupRecipientHandler(t,
+	h, _ := setupAbuseRecipientHandler(t,
 		&model.AbuseReportNotificationRecipient{ID: "r1"},
 	)
 	repo := attachModLog(t, h)


### PR DESCRIPTION
## Summary

#716 で federation_admin_test に導入した \`setupXxxHandler\` パターンを admin handler test 群に横展開する Phase 1 の最初の PR。本 PR では \`abuse_report_notification_test.go\` (boilerplate 出現 20 箇所) を対象に変換する。

review 単位を抑えるため、Phase 1 の残 (\`ad_invite_promo_test\` 44 箇所 / \`drive_emoji_test\` 64 箇所) は別 PR で出します。

## 主な変更点

- \`setupAbuseRecipientHandler(t, seed...)\` helper を追加 (variadic で seed 行を渡せる)
  - 「\`newTestHandler\` → \`testutil.NewMockAbuseReportNotificationRecipientRepository\` → \`repo.Create\` を seed 数だけ → \`SetRecipientRepo\`」の 4 行 boilerplate を 1 行に圧縮
  - 戻り値で \`(*Handler, *MockRepo)\` を返すので、\`CreateErr\` 等の error injection も呼び出し側で続けて指定できる
- 15 箇所の test body を helper 経由に変換
- nil-repo smoke test (5 件、recipientRepo を wire しない分岐の coverage 確認) は helper 化対象外として保持

## 行数の trade

- helper 定義: +17 行 (GoDoc 込み)
- test body 側 boilerplate: -67 行 (\`newTestHandler\` の 4 値 destructure + \`SetRecipientRepo\` 等が 15 箇所で消える)
- net: -50 行 (本 PR 全体で +50 / -51 のうち、helper コストを除いた実質効果)

## review feedback (b857f7e)

- helper 名を \`setupRecipientHandler\` → \`setupAbuseRecipientHandler\` に rename。\`admin_test\` package 内で他の "Recipient" 概念 (webhook recipient 等) と被るリスクを下げるための予防策

## テスト

- \`go test ./internal/api/admin/...\` 全 pass
- \`make fmt\` / \`go vet\` 通過

## Closes

#761 Phase 1 の一部 (Phase 1 残: \`ad_invite_promo_test\` / \`drive_emoji_test\` を別 PR で)

🤖 Generated with [Claude Code](https://claude.com/claude-code)