### PR TITLE
Fix #774: プロジェクト名を Misskey-Go から mk-go に統一 + version を 0.0.1-experimental に

### DIFF
--- a/.config/default.yml.example
+++ b/.config/default.yml.example
@@ -1,11 +1,11 @@
 #━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-# Misskey-Go configuration
+# mk-go configuration
 #
 # このファイルは `.config/default.yml.example` です。
 # 初回セットアップ時に以下を実行して default.yml を作成してください:
 #   cp .config/default.yml.example .config/default.yml
 #
-# Misskey 本家 .config/example.yml をベースに、Go 実装 (misskey-go)
+# Misskey 本家 .config/example.yml をベースに、Go 実装 (mk-go)
 # 固有の項目を追記しています。
 #━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
@@ -45,7 +45,7 @@ url: https://example.tld/
 #   ┌───────────────────────┐
 #───┘ Port and TLS settings └───────────────────────────────────
 
-# The port that your Misskey-Go server should listen on.
+# The port that your mk-go server should listen on.
 port: 3000
 
 # UNIX domain socket support (mk-go specific).

--- a/.config/docker.yml.example
+++ b/.config/docker.yml.example
@@ -1,5 +1,5 @@
 #━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-# Misskey-Go configuration (Docker)
+# mk-go configuration (Docker)
 #
 # このファイルは `.config/docker.yml.example` です。
 # Dockerfile が build 時に `.config/docker.yml.example` を image 内の

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,5 +1,5 @@
 {
-  "name": "misskey-go",
+  "name": "mk-go",
   "dockerComposeFile": "docker-compose.yml",
   "service": "app",
   "workspaceFolder": "/workspace",

--- a/.env.example
+++ b/.env.example
@@ -1,4 +1,4 @@
-# Misskey Go - Application Environment Variables
+# mk-go - Application Environment Variables
 # Copy this file to .env and adjust values for your environment.
 
 # Frontend assets directory (built Misskey frontend)

--- a/Makefile
+++ b/Makefile
@@ -16,10 +16,10 @@ BUILD_DIR=./built
 # Go parameters
 GOFLAGS=-trimpath
 
-# バージョン情報: submodule の package.json があれば Misskey バージョンを自動取得
-MKGO_VERSION ?= 0.0.1
-MISSKEY_PKG_JSON = third_party/misskey/package.json
-MISSKEY_VERSION ?= $(shell [ -f $(MISSKEY_PKG_JSON) ] && grep -o '"version": *"[^"]*"' $(MISSKEY_PKG_JSON) | head -1 | grep -o '"[^"]*"$$' | tr -d '"' || echo "2026.3.2")
+# バージョン情報。MisskeyVersion は /api/meta の version フィールド
+# (Misskey TS 互換クライアント向け) で使われる。drop-in 互換のため固定値。
+MKGO_VERSION ?= 0.0.1-experimental
+MISSKEY_VERSION ?= 2026.3.2
 LDFLAGS=-s -w \
 	-X github.com/shiroha-a/mk/internal/config.MkGoVersion=$(MKGO_VERSION) \
 	-X github.com/shiroha-a/mk/internal/config.MisskeyVersion=$(MISSKEY_VERSION)
@@ -62,7 +62,7 @@ migrate-create:
 
 # Docker
 docker-build:
-	docker build -t misskey-go .
+	docker build -t mk-go .
 
 docker-up:
 	docker compose up -d

--- a/deploy/uds/config/default.yml.example
+++ b/deploy/uds/config/default.yml.example
@@ -1,5 +1,5 @@
 #━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-# Misskey-Go configuration (UDS-only stack)
+# mk-go configuration (UDS-only stack)
 #
 # このファイルは `deploy/uds/config/default.yml.example` です。
 # `compose.uds.yaml` 系列スタック (HTTP / PostgreSQL / Redis すべて
@@ -7,7 +7,7 @@
 # default.ymlを作成してください:
 #   cp deploy/uds/config/default.yml.example deploy/uds/config/default.yml
 #
-# Misskey本家 .config/example.ymlをベースに、Go実装 (misskey-go)
+# Misskey本家 .config/example.ymlをベースに、Go実装 (mk-go)
 # 固有の項目とUDSスタック特有の設定を加えています。
 #━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 

--- a/docs/migration-from-ts.md
+++ b/docs/migration-from-ts.md
@@ -1,6 +1,6 @@
-# Misskey-TSからMisskey-Goへの移行ガイド
+# Misskey-TSからmk-goへの移行ガイド
 
-本ガイドでは、既存のMisskey-TSインスタンスのバックエンドをMisskey-Goに置き換え、同じデータベース・Redis・フロントエンド資産を共有させる手順を説明する。
+本ガイドでは、既存のMisskey-TSインスタンスのバックエンドをmk-goに置き換え、同じデータベース・Redis・フロントエンド資産を共有させる手順を説明する。
 
 ## 前提条件
 
@@ -12,8 +12,8 @@
 ## 1. クローンとビルド
 
 ```bash
-git clone --recursive https://github.com/shiroha-a/mk.git misskey-go
-cd misskey-go
+git clone --recursive https://github.com/shiroha-a/mk.git mk-go
+cd mk-go
 go build -o built/misskey ./cmd/misskey
 ```
 
@@ -21,7 +21,7 @@ go build -o built/misskey ./cmd/misskey
 
 ## 2. フロントエンド資産の準備
 
-Misskey-GoはMisskey-TSと同じフロントエンドを利用する。2つの方法がある。
+mk-goはMisskey-TSと同じフロントエンドを利用する。2つの方法がある。
 
 ### 方法A: submoduleのフロントエンドをビルド (推奨)
 
@@ -29,7 +29,7 @@ Misskey-GoはMisskey-TSと同じフロントエンドを利用する。2つの�
 make e2e-frontend-build
 ```
 
-Docker内でフロントエンドがビルドされ、成果物は `third_party/misskey/built/` 配下に配置される。Misskey-Goはデフォルトでこのパスを参照するため、環境変数の設定は不要。
+Docker内でフロントエンドがビルドされ、成果物は `third_party/misskey/built/` 配下に配置される。mk-goはデフォルトでこのパスを参照するため、環境変数の設定は不要。
 
 ### 方法B: 既存のMisskey-TSのビルド済み資産を使う
 
@@ -69,7 +69,7 @@ id: aidx             # Misskey-TS側のID生成方式と一致させること
 
 ## 4. データベースマイグレーション
 
-Misskey-Goは既存のMisskey-TSテーブルには手を加えず、独自のテーブルを追加する形で共存する。既存データは保持される。
+mk-goは既存のMisskey-TSテーブルには手を加えず、独自のテーブルを追加する形で共存する。既存データは保持される。
 
 ```bash
 # ローカルビルドの場合
@@ -81,7 +81,7 @@ docker compose exec app /app/migrate -config .config/default.yml -direction up
 
 これによりGo側で必要な追加テーブル (`app`, `auth_session`, `webhook`, `sw_subscription`, `chat_room`, `chat_message`, `bubble_game_record` 等) が作成される。
 
-> **補足:** Misskey-Goのマイグレーションは追加のみで、既存のMisskey-TSテーブルを変更しない。両バックエンドは同じデータベース上で共存できる。
+> **補足:** mk-goのマイグレーションは追加のみで、既存のMisskey-TSテーブルを変更しない。両バックエンドは同じデータベース上で共存できる。
 
 ## 5. Misskey-TSの停止
 
@@ -95,7 +95,7 @@ pm2 stop misskey
 docker compose stop web
 ```
 
-## 6. Misskey-Goの起動
+## 6. mk-goの起動
 
 ```bash
 ./built/misskey -config .config/default.yml
@@ -123,11 +123,11 @@ docker compose stop web
 docker compose up -d
 ```
 
-Misskey-GoがPostgreSQLおよびRedisと共に起動する。詳細は `docker-compose.yml` を参照。
+mk-goがPostgreSQLおよびRedisと共に起動する。詳細は `docker-compose.yml` を参照。
 
 ### Docker container の UID
 
-Misskey-Go のコンテナは Misskey-TS と同じ **UID/GID 991** で起動する。`./files` (drive ファイルストレージ) を host volume mount している場合、ホスト側ディレクトリは UID 991 が書き込めるパーミッションでなければならない。
+mk-go のコンテナは Misskey-TS と同じ **UID/GID 991** で起動する。`./files` (drive ファイルストレージ) を host volume mount している場合、ホスト側ディレクトリは UID 991 が書き込めるパーミッションでなければならない。
 
 - **TS から swap する場合**: 既に `./files` の中身が UID 991 で書かれているのでそのまま動く (drop-in 互換)
 - **mk-go-only から旧 root 構成 (#621 以前) で運用していた場合**: 一度だけ `sudo chown -R 991:991 ./files` で所有権を揃える必要がある
@@ -136,10 +136,10 @@ Misskey-Go のコンテナは Misskey-TS と同じ **UID/GID 991** で起動す�
 
 Misskey-TSに戻す場合の手順:
 
-1. Misskey-Goを停止する
+1. mk-goを停止する
 2. 従来通りMisskey-TSを起動する
 
-データベースは双方向に互換性があり、Misskey-Goが追加したテーブルはMisskey-TSからは無視される。
+データベースは双方向に互換性があり、mk-goが追加したテーブルはMisskey-TSからは無視される。
 
 ## 既知の制限
 

--- a/internal/activitypub/client_test.go
+++ b/internal/activitypub/client_test.go
@@ -27,7 +27,7 @@ func TestClient_PostSigned(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	c := NewClient(nil, "misskey-go-test")
+	c := NewClient(nil, "mk-go-test")
 	resp, err := c.PostSigned(srv.URL+"/inbox", []byte(`{"type":"Create"}`), key)
 	require.NoError(t, err)
 	defer resp.Body.Close()
@@ -79,11 +79,11 @@ func TestClient_GetSigned_WithUserAgent(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	c := NewClient(nil, "misskey-go-test/1.0")
+	c := NewClient(nil, "mk-go-test/1.0")
 	resp, err := c.GetSigned(srv.URL+"/", key, "")
 	require.NoError(t, err)
 	defer resp.Body.Close()
-	assert.Equal(t, "misskey-go-test/1.0", seenUA)
+	assert.Equal(t, "mk-go-test/1.0", seenUA)
 }
 
 func TestClient_GetSigned_AcceptOverride(t *testing.T) {

--- a/internal/api/admin/emoji_image_fetcher.go
+++ b/internal/api/admin/emoji_image_fetcher.go
@@ -34,7 +34,7 @@ type EmojiImageFetcherImpl struct {
 
 // NewEmojiImageFetcher builds a fetcher bound to an SSRF-safe HTTP client and
 // the local drive service. userAgent should normally be cfg.UserAgent so feed
-// servers see the same `Misskey-Go/<ver>` identification used everywhere else.
+// servers see the same `mk-go/<ver>` identification used everywhere else.
 func NewEmojiImageFetcher(httpClient *http.Client, driveSvc *drive.Service, userAgent string) *EmojiImageFetcherImpl {
 	return &EmojiImageFetcherImpl{
 		httpClient: httpClient,

--- a/internal/api/admin/emoji_image_fetcher_test.go
+++ b/internal/api/admin/emoji_image_fetcher_test.go
@@ -68,14 +68,14 @@ func TestEmojiImageFetcher_FetchAndStore_Success(t *testing.T) {
 	const pixel = "\x89PNG\r\n\x1a\n" // PNG magic so AnalyseFile detects image/png
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		assert.Contains(t, r.Header.Get("Accept"), "image/")
-		assert.Equal(t, "Misskey-Go/test", r.Header.Get("User-Agent"))
+		assert.Equal(t, "mk-go/test", r.Header.Get("User-Agent"))
 		w.Header().Set("Content-Type", "image/png")
 		_, _ = w.Write([]byte(pixel))
 	}))
 	t.Cleanup(srv.Close)
 
 	driveSvc, fileRepo := newDriveService(t)
-	f := NewEmojiImageFetcher(&http.Client{Timeout: 5 * time.Second, Transport: srv.Client().Transport}, driveSvc, "Misskey-Go/test")
+	f := NewEmojiImageFetcher(&http.Client{Timeout: 5 * time.Second, Transport: srv.Client().Transport}, driveSvc, "mk-go/test")
 
 	// nil user で「system 所有 drive file」として upload する (#670)。
 	// Misskey TS uploadFromUrl({user: null}) と等価。

--- a/internal/api/fetchrss/handler.go
+++ b/internal/api/fetchrss/handler.go
@@ -93,7 +93,7 @@ type cacheEntry struct {
 // string. Pass a client whose Transport is safehttp.NewSSRFSafeTransport(...)
 // so private IPs and non-http(s) schemes never leak through this endpoint.
 // userAgent should normally be cfg.UserAgent so feed servers see the same
-// `Misskey-Go/<ver>` identification used everywhere else.
+// `mk-go/<ver>` identification used everywhere else.
 func New(httpClient *http.Client, userAgent string) *Handler {
 	return &Handler{
 		httpClient: httpClient,
@@ -291,7 +291,7 @@ func (h *Handler) fetchFeed(ctx context.Context, feedURL string) (*gofeed.Feed, 
 	req.Header.Set("Accept", "application/rss+xml, */*")
 	if h.userAgent != "" {
 		// UA 必須の RSS 配信サーバ (Cloudflare 含む) で 403 にならないように
-		// するため、他の outbound 経路と同じ Misskey-Go/<ver> UA を送る。
+		// するため、他の outbound 経路と同じ mk-go/<ver> UA を送る。
 		req.Header.Set("User-Agent", h.userAgent)
 	}
 

--- a/internal/api/fetchrss/handler_test.go
+++ b/internal/api/fetchrss/handler_test.go
@@ -63,7 +63,7 @@ const sampleAtom = `<?xml version="1.0" encoding="utf-8"?>
 
 // testUserAgent is the UA string used for handler-under-test wiring. Static
 // so individual tests can assert on it without threading the value around.
-const testUserAgent = "Misskey-Go/test (https://example.test)"
+const testUserAgent = "mk-go/test (https://example.test)"
 
 // startFeedServer launches an httptest server returning the supplied body and
 // returns a Handler whose HTTP client targets that server. We bypass SSRF
@@ -85,7 +85,7 @@ func newRequestCtx(method, target string) (echo.Context, *httptest.ResponseRecor
 func TestFetchRSS_BasicRSS2(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		assert.Contains(t, r.Header.Get("Accept"), "application/rss+xml")
-		// Misskey-Go/<ver> 相当の UA が付くことを guard する。UA 必須の RSS
+		// mk-go/<ver> 相当の UA が付くことを guard する。UA 必須の RSS
 		// 配信サーバ (Cloudflare 含む) で 403 にならない契約の regression 検知。
 		assert.Equal(t, testUserAgent, r.Header.Get("User-Agent"))
 		w.Header().Set("Content-Type", "application/rss+xml")

--- a/internal/api/nodeinfo/handler.go
+++ b/internal/api/nodeinfo/handler.go
@@ -48,11 +48,6 @@ func (h *Handler) SetClock(now func() time.Time) {
 	}
 }
 
-// nodeinfoVersion builds the version string for NodeInfo.
-func nodeinfoVersion(mkgoVersion, misskeyVersion string) string {
-	return mkgoVersion + " (compatible: misskey " + misskeyVersion + ")"
-}
-
 // Version2_1 handles GET /nodeinfo/2.1.
 func (h *Handler) Version2_1(c echo.Context) error {
 	nodeName := h.cfg.Host
@@ -130,8 +125,8 @@ func (h *Handler) Version2_1(c echo.Context) error {
 	resp := map[string]any{
 		"version": "2.1",
 		"software": map[string]any{
-			"name":       "misskey-go",
-			"version":    nodeinfoVersion(config.MkGoVersion, h.cfg.Version),
+			"name":       "mk-go",
+			"version":    config.MkGoVersion,
 			"repository": "https://github.com/shiroha-a/mk",
 		},
 		"protocols": []string{"activitypub"},

--- a/internal/api/nodeinfo/handler_test.go
+++ b/internal/api/nodeinfo/handler_test.go
@@ -29,12 +29,8 @@ func TestVersion2_1(t *testing.T) {
 	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
 	assert.Equal(t, "2.1", resp["version"])
 	sw := resp["software"].(map[string]any)
-	assert.Equal(t, "misskey-go", sw["name"])
-	assert.Contains(t, sw["version"], "compatible: misskey 0.0.0")
-}
-
-func TestNodeinfoVersion(t *testing.T) {
-	assert.Equal(t, "0.0.1 (compatible: misskey 2026.3.2)", nodeinfoVersion("0.0.1", "2026.3.2"))
+	assert.Equal(t, "mk-go", sw["name"])
+	assert.Equal(t, config.MkGoVersion, sw["version"])
 }
 
 // admin で設定した Meta.Name / Description がnodeinfo.metadata に反映される

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -12,10 +12,10 @@ import (
 	"github.com/spf13/viper"
 )
 
-// MkGoVersion is the misskey-go version. Override at build time via:
+// MkGoVersion is the mk-go version. Override at build time via:
 //
 //	go build -ldflags "-X github.com/shiroha-a/mk/internal/config.MkGoVersion=1.0.0"
-var MkGoVersion = "0.0.1"
+var MkGoVersion = "0.0.1-experimental"
 
 // MisskeyVersion is the compatible Misskey version. Override at build time via:
 //
@@ -520,7 +520,7 @@ func resolve(src *Source) (*Config, error) {
 		NSFWDetectorURL:              strings.TrimRight(src.NSFWDetectorURL, "/"),
 		NSFWDetectorAuthHeader:       src.NSFWDetectorAuthHeader,
 		NSFWDetectorTimeout:          src.NSFWDetectorTimeout,
-		UserAgent:                    fmt.Sprintf("Misskey-Go/%s (%s)", MkGoVersion, src.URL),
+		UserAgent:                    fmt.Sprintf("mk-go/%s (%s)", MkGoVersion, src.URL),
 		PerChannelMaxNoteCacheCount:  perChannelMaxNoteCacheCount,
 		PerUserNotificationsMaxCount: perUserNotificationsMaxCount,
 		DeactivateAntennaThreshold:   deactivateAntennaThreshold,

--- a/internal/repository/coverage_final_test.go
+++ b/internal/repository/coverage_final_test.go
@@ -271,7 +271,7 @@ func TestUserRepository_ListRemoteInboxes_Branches(t *testing.T) {
 }
 
 // note.DeleteExpiredRemoteNotes のテスト: aidx ID cutoff でリモートノートを
-// 削除する挙動を確認する。misskey-go は note."createdAt" カラムを持たないため、
+// 削除する挙動を確認する。mk-go は note."createdAt" カラムを持たないため、
 // id 文字列の lexicographic 比較で時刻境界を判定する。
 func TestNoteRepository_DeleteExpiredRemoteNotes(t *testing.T) {
 	nr := NewNoteRepository(testDB)

--- a/internal/repository/note.go
+++ b/internal/repository/note.go
@@ -600,7 +600,7 @@ func (r *noteRepository) ListGlobalTimeline(limit int, sinceID, untilID string, 
 // 行数を返す。ループは呼び出し側 (CleanRemoteNotesProcessor) が sleep / ctx
 // cancellation 付きで回す。
 // ON DELETE CASCADE が reactions / replies 等に効く前提。
-// misskey-go の note テーブルには createdAt カラムが無い (aidx ID から時刻を
+// mk-go の note テーブルには createdAt カラムが無い (aidx ID から時刻を
 // 導出する設計) ため、ID 文字列の lexicographic 比較で時刻切り捨てを行う。
 func (r *noteRepository) DeleteExpiredRemoteNotes(expiryDays, batchSize int) (int64, error) {
 	if batchSize <= 0 {

--- a/migration/000001_initial.up.sql
+++ b/migration/000001_initial.up.sql
@@ -1,4 +1,4 @@
--- Initial schema for Misskey Go
+-- Initial schema for mk-go
 -- Compatible with existing Misskey TypeScript database schema
 
 -- Enum types

--- a/migration/000029_db_compat_misskey.up.sql
+++ b/migration/000029_db_compat_misskey.up.sql
@@ -1,7 +1,7 @@
 -- Phase: Misskey DB スキーマとの完全互換化 (issue #21)
--- 本家 Misskey (TypeScript) と misskey-go の DB 差分を埋めるための一括 migration。
+-- 本家 Misskey (TypeScript) と mk-go の DB 差分を埋めるための一括 migration。
 -- 以下 5 つのサブ変更を 1 ファイルにまとめている:
---   1. poll_vote.createdAt の除去 (misskey-go 側の余剰カラム)
+--   1. poll_vote.createdAt の除去 (mk-go 側の余剰カラム)
 --   2. user_profile に 3 カラム追加 (twoFactorBackupSecret / clientData / room)
 --   3. meta に 58 カラム追加 (branding / captcha / sensitiveMedia / urlPreview /
 --      cacheTuning / deepL / stats / reactions / singleUserMode など)
@@ -12,14 +12,14 @@
 -- =============================================================================
 -- 1. poll_vote.createdAt の除去
 -- =============================================================================
--- 本家 Misskey の PollVote エンティティには createdAt カラムが無い。misskey-go
+-- 本家 Misskey の PollVote エンティティには createdAt カラムが無い。mk-go
 -- 側で書き込みのみ行っており読み取り参照はないため、安全に除去できる。
 ALTER TABLE "poll_vote" DROP COLUMN IF EXISTS "createdAt";
 
 -- =============================================================================
 -- 2. user_profile に 3 カラム追加
 -- =============================================================================
--- 本家 Misskey UserProfile に存在するが misskey-go 側で未追加だったフィールド。
+-- 本家 Misskey UserProfile に存在するが mk-go 側で未追加だったフィールド。
 -- 機能実装 (2FA backup code / UI client data / chat room metadata) は後続
 -- issue で行う。DB レベルでの互換性のみを確保する。
 ALTER TABLE "user_profile"
@@ -200,11 +200,11 @@ CREATE UNIQUE INDEX IF NOT EXISTS "IDX_promo_read_userId_noteId" ON "promo_read"
 -- 5. TypeORM 互換 migrations テーブル
 -- =============================================================================
 -- 本家 Misskey (TypeORM) は起動時に "migrations" テーブルを参照して未実行の
--- migration を検出しようとする。misskey-go は golang-migrate の
+-- migration を検出しようとする。mk-go は golang-migrate の
 -- "schema_migrations" を使うので両者は共存できる。
 --
 -- 互換性を確保するため、本家で既知の全 migration エントリを seed することで、
--- misskey-go で動かした DB を本家 Misskey に差し替えたときに「全て適用済み」
+-- mk-go で動かした DB を本家 Misskey に差し替えたときに「全て適用済み」
 -- と認識させる。これにより DB migration 不要で両者を行き来できる。
 CREATE TABLE IF NOT EXISTS "migrations" (
     "id" SERIAL PRIMARY KEY,

--- a/tests/federation/misskey/test_federation.py
+++ b/tests/federation/misskey/test_federation.py
@@ -135,7 +135,7 @@ class TestNodeInfo:
     def test_mkgo_nodeinfo(self, mkgo: MisskeyLikeClient, alice: dict) -> None:
         info = mkgo.nodeinfo()
         assert "software" in info
-        assert info["software"]["name"].lower() in {"misskey", "misskey-go", "mkgo", "mk"}
+        assert info["software"]["name"].lower() in {"misskey", "mk-go", "mkgo", "mk"}
         assert "protocols" in info
         assert "activitypub" in info["protocols"]
 


### PR DESCRIPTION
## Summary

本家 Misskey の名前を冠する識別子 (\`Misskey-Go\` / \`misskey-go\` / \`Misskey Go\`) を仮称 \`mk-go\` に統一する。**リモートサーバーから見えるソフトウェア名 (NodeInfo / User-Agent) も含めて変更** し、\`(compatible: misskey ...)\` のような Misskey 互換マーカーを削除して独立した software identity として publish する。あわせて \`MkGoVersion\` のデフォルトを \`0.0.1-experimental\` に更新。

20 file / 53 insertions / 62 deletions。

## 外部可視 identifier の変更

| 項目 | 旧 | 新 |
|---|---|---|
| NodeInfo \`software.name\` | \`\"misskey-go\"\` | \`\"mk-go\"\` |
| NodeInfo \`software.version\` | \`\"{ver} (compatible: misskey {ts_ver})\"\` | \`\"{ver}\"\` |
| User-Agent | \`\"Misskey-Go/{ver} ({url})\"\` | \`\"mk-go/{ver} ({url})\"\` |
| \`MkGoVersion\` default | \`\"0.0.1\"\` | \`\"0.0.1-experimental\"\` |

\`internal/api/nodeinfo/handler.go\` の \`nodeinfoVersion()\` helper は不要になったため削除し、\`software.version\` フィールドに \`config.MkGoVersion\` を直接埋める。

## Makefile 簡素化

NodeInfo が compatible 接尾辞を捨てたので、\`Makefile\` で submodule \`third_party/misskey/package.json\` から \`MISSKEY_VERSION\` を grep 抽出する動的ロジックは冗長になった。固定値 \`2026.3.2\` に置き換え。

\`MisskeyVersion\` 変数自体は \`/api/meta\` の \`version\` フィールド (Misskey TS 互換クライアント向け) で引き続き使うため残す (drop-in 互換維持)。

## 内部識別子 / ドキュメント / コメントの統一

| File | 内容 |
|---|---|
| \`docs/migration-from-ts.md\` | 本文 11 + clone 例の directory 名 2 |
| \`.config/*.example\` / \`.env.example\` / \`deploy/uds/config/default.yml.example\` | ヘッダーコメント |
| \`migration/000001_initial.up.sql\` / \`migration/000029_db_compat_misskey.up.sql\` | header / 互換性説明コメント |
| \`internal/api/fetchrss/handler.go\` / \`emoji_image_fetcher.go\` | UA 関連 inline コメント |
| \`internal/repository/note.go\` / \`coverage_final_test.go\` | 実装コメント |
| \`internal/config/config.go\` | \`MkGoVersion\` package doc |
| \`.devcontainer/devcontainer.json\` | devcontainer 名 |
| \`internal/activitypub/client_test.go\` | test fixture UA |
| \`Makefile\` | \`docker build -t\` タグ |

## Test 更新

- \`internal/api/nodeinfo/handler_test.go\`: \`software.name\` + \`version\` assertion 更新、\`TestNodeinfoVersion\` 削除
- \`internal/api/fetchrss/handler_test.go\`: \`testUserAgent\` を \`mk-go/test\` に
- \`internal/api/admin/emoji_image_fetcher_test.go\`: UA assertion 更新 (2 箇所)
- \`tests/federation/misskey/test_federation.py\`: 許容 \`software.name\` 集合から \`\"misskey-go\"\` を削除し \`\"mk-go\"\` を追加

## 影響評価

### Federation drop-in 互換

- ActivityPub / WebFinger / inbox / outbox の動作には software.name / UA は使われないため **無影響**
- \`/api/meta\` の \`version\` フィールド (Misskey TS 互換) は **本 PR で touch せず** 維持

### Fediverse crawler / 統計ツール

- \`software.name\` で集計しているツールでは \`mk-go\` が独立 software として認識される
- 既に \`misskey-go\` (Misskey とは別ソフト) として扱われていたので、rename は単純な名前変更扱い (Misskey に masquerade していたわけではない)
- \`(compatible: misskey ...)\` を捨てる選択は **意図的** — 仮称段階で Misskey ファミリーへの帰属表明をやめ独立 software identity に振る

### Operator 監視 / outbound UA blocklist

- 既存 instance を持つ operator が UA で grep / alert を組んでいた場合は表記変更を周知する必要あり
- 元の \`Misskey-Go\` も非標準 UA だったため、UA blocklist による被弾の状況は変わらない

## Out of Scope

- リポジトリ名 / Go module path (\`github.com/shiroha-a/mk\` のまま)
- \`/api/meta\` の \`version\` フィールド (Misskey TS 互換、drop-in 維持)
- 正式名称の決定 (\`mk-go\` はあくまで仮称)
- README.md / CLAUDE.md の rewrite (既に \`mk-go\` 表記主体のため)

## テスト

- \`go test ./... -count=1\` 全 pass (nodeinfo / fetchrss / admin / activitypub / queue / federation 含む)
- \`make build\` 成功 (build 出力で \`MkGoVersion=0.0.1-experimental\` 確認)
- ⚠️ **UDS smoke は未実施** (operator 環境依存) — \`/.well-known/nodeinfo\` の software 情報と federation outbound UA を reviewer 側で確認お願いします

## Closes

#774

🤖 Generated with [Claude Code](https://claude.com/claude-code)