### PR TITLE
docs: CLAUDE.md UA 形式と README.md Go バージョン表記を更新

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -247,7 +247,7 @@ func (s *Service) CreateNote(ctx context.Context, input CreateInput) (*model.Not
 
 - **API互換性が最優先**。レスポンスのフィールド名・型・エラーコードはオリジナルMisskeyと一致させる。
 - バージョン文字列は`internal/config/config.go`の`Version`定数で管理し、対応するMisskeyバージョンに合わせる（現在: `2026.3.2`）。
-- User-Agentは`Misskey/<version> (<url>)`形式。
+- User-Agentは`mk-go/<version> (<url>)`形式 (#774 で `Misskey-Go/<ver>` から rename)。
 
 ### ID生成
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Misskey互換のGoバックエンド実装。TypeScript/NestJS製の[Misskey](ht
 
 ## 特徴
 
-- Go 1.25 / Echo v4 / GORM + pgx / go-redis v9 / asynq
+- Go 1.26 / Echo v4 / GORM + pgx / go-redis v9 / asynq
 - Misskeyフロントエンド(SPA)をそのまま配信
 - TypeScript版と同じPostgreSQL/Redisを共有、無停止で移行可能
 - ActivityPub連合対応（HTTP Signatures、リモートオブジェクト解決、配信キュー）
@@ -28,7 +28,7 @@ docker compose up -d
 
 ## ローカルビルド
 
-前提: Go 1.25+、PostgreSQL 16+、Redis 7+、Docker (テスト用)
+前提: Go 1.26+、PostgreSQL 16+、Redis 7+、Docker (テスト用)
 
 ```bash
 git clone --recursive https://github.com/shiroha-a/mk.git


### PR DESCRIPTION
## Summary

#774 のフォローアップで、PR では拾えなかった 2 件のドキュメント表記揺れを修正する。Issue 化せず直接 PR で対応 (trivial doc fix)。

## 主な変更点

### CLAUDE.md Section 6.1: User-Agent 形式

- 旧: \`User-Agentは\\\`Misskey/<version> (<url>)\\\`形式。\`
- 新: \`User-Agentは\\\`mk-go/<version> (<url>)\\\`形式 (#774 で \\\`Misskey-Go/<ver>\\\` から rename)。\`

もとから code は \`Misskey-Go/<ver>\` を出力していたので CLAUDE.md の記述と乖離していた。#774 で code 側を \`mk-go/<ver>\` に rename したのに合わせて CLAUDE.md も追いつかせる。

### README.md: Go バージョン

- 「特徴」: \`Go 1.25\` → \`Go 1.26\`
- 「ローカルビルド」: \`Go 1.25+\` → \`Go 1.26+\`

\`go.mod\` (\`go 1.26.2\`) と CLAUDE.md Section 1 (\`Go 1.26\`) に整合。

### Touch しなかった箇所

- \`docs/mediaproxy-govips-evaluation.md\` の \`Go 1.25\` 言及: 過去の benchmark 計測時の環境記録 (historical fact) なので維持
- \`.github/workflows/ci.yml\` の \`Go 1.25/1.26\` コメント: toolchain 互換性 note (両 version で同じ挙動を確認した、という履歴) なので維持

## テスト

- doc-only 変更、code への影響なし
- \`make build\` / \`go test\` 影響なし

## 関連

- #774 (PR #775) — \`Misskey-Go\` → \`mk-go\` rename

🤖 Generated with [Claude Code](https://claude.com/claude-code)