### PR TITLE
Fix #766: users/search-by-username-and-host で host filter を実際に適用

### DIFF
--- a/internal/api/resetpassword/handler_test.go
+++ b/internal/api/resetpassword/handler_test.go
@@ -42,6 +42,9 @@ func (m *mockUserRepo) IncrementFollowersCount(string, int) error { return nil }
 func (m *mockUserRepo) SearchByUsername(string, int, int, string) ([]*model.User, error) {
 	return nil, nil
 }
+func (m *mockUserRepo) SearchByUsernameAndHost(string, *string, int) ([]*model.User, error) {
+	return nil, nil
+}
 func (m *mockUserRepo) UpdateUser(string, map[string]any) error               { return nil }
 func (m *mockUserRepo) CreateProfile(*model.UserProfile) error                { return nil }
 func (m *mockUserRepo) ListUsers(model.UserListFilter) ([]*model.User, error) { return nil, nil }

--- a/internal/api/users/handler_extra.go
+++ b/internal/api/users/handler_extra.go
@@ -115,10 +115,9 @@ func (h *Handler) SearchByUsernameAndHost(c echo.Context) error {
 	if req.Limit <= 0 {
 		req.Limit = 10
 	}
-	// search-by-username-and-host は host を自前 filter する想定の endpoint
-	// だが、現状 host filter していない (#763 以前からの状態)。本 PR では
-	// origin filter を導入するが、このパスは "" (combined) で従来挙動を維持。
-	users, err := h.userService.Search(req.Username, req.Limit, 0, "")
+	// host=nil → local user、host=*string → 当該 host のみで絞り込む
+	// (#766 fix、upstream Misskey TS の同 endpoint と同じ semantics)。
+	users, err := h.userService.SearchByUsernameAndHost(req.Username, req.Host, req.Limit)
 	if err != nil {
 		return c.JSON(http.StatusInternalServerError, apierr.Error("INTERNAL_ERROR", "Internal error.", "5d37dbcb-891e-41ca-a3d6-e690c97775ac"))
 	}

--- a/internal/api/users/handler_extra_test.go
+++ b/internal/api/users/handler_extra_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/shiroha-a/mk/internal/api/users"
 	corefollowing "github.com/shiroha-a/mk/internal/core/following"
 	coreuser "github.com/shiroha-a/mk/internal/core/user"
+	"github.com/shiroha-a/mk/internal/entity"
 	"github.com/shiroha-a/mk/internal/misc/id"
 	"github.com/shiroha-a/mk/internal/model"
 	"github.com/shiroha-a/mk/internal/server/middleware"
@@ -136,6 +137,43 @@ func TestSearchByUsernameAndHost_InvalidParam(t *testing.T) {
 	assert.Equal(t, http.StatusBadRequest, rec.Code)
 }
 
+// #766: host が指定されたら当該 host の user のみ返す。host=nil なら local
+// user (host IS NULL) のみ。"全 host のマッチを返す" 旧挙動の regression
+// guard。
+func TestSearchByUsernameAndHost_FiltersByHost(t *testing.T) {
+	h, userRepo, _ := newExtraHandler(t)
+	remote := "remote.example"
+	other := "other.example"
+	userRepo.Users["u_local"] = &model.User{ID: "u_local", Username: "alice", UsernameLower: "alice"}
+	userRepo.Users["u_remote"] = &model.User{ID: "u_remote", Username: "alice", UsernameLower: "alice", Host: &remote}
+	userRepo.Users["u_other"] = &model.User{ID: "u_other", Username: "alice", UsernameLower: "alice", Host: &other}
+
+	// host 未指定 / 空文字 → local user のみ
+	for _, body := range []string{`{"username":"alice"}`, `{"username":"alice","host":""}`} {
+		rec := postExtra(h.SearchByUsernameAndHost, body, nil)
+		require.Equal(t, http.StatusOK, rec.Code)
+		var got []entity.UserLite
+		require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &got))
+		require.Len(t, got, 1, "body=%s should return only local user", body)
+		assert.Equal(t, "u_local", got[0].ID)
+	}
+
+	// host 指定 → 当該 host の user のみ (local や別 host の user は除外)
+	rec := postExtra(h.SearchByUsernameAndHost, `{"username":"alice","host":"remote.example"}`, nil)
+	require.Equal(t, http.StatusOK, rec.Code)
+	var got []entity.UserLite
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &got))
+	require.Len(t, got, 1)
+	assert.Equal(t, "u_remote", got[0].ID)
+
+	// case-insensitive な host 比較
+	rec = postExtra(h.SearchByUsernameAndHost, `{"username":"alice","host":"REMOTE.EXAMPLE"}`, nil)
+	require.Equal(t, http.StatusOK, rec.Code)
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &got))
+	require.Len(t, got, 1)
+	assert.Equal(t, "u_remote", got[0].ID)
+}
+
 // --- UpdateMemo ---
 
 func TestUpdateMemo_Success(t *testing.T) {
@@ -190,7 +228,7 @@ type failingSearchRepo struct {
 	*testutil.MockUserRepository
 }
 
-func (f *failingSearchRepo) SearchByUsername(_ string, _, _ int, _ string) ([]*model.User, error) {
+func (f *failingSearchRepo) SearchByUsernameAndHost(_ string, _ *string, _ int) ([]*model.User, error) {
 	return nil, assert.AnError
 }
 

--- a/internal/core/retention/service_test.go
+++ b/internal/core/retention/service_test.go
@@ -55,6 +55,9 @@ func (s *stubUserRepo) IncrementFollowersCount(string, int) error               
 func (s *stubUserRepo) SearchByUsername(string, int, int, string) ([]*model.User, error) {
 	return nil, nil
 }
+func (s *stubUserRepo) SearchByUsernameAndHost(string, *string, int) ([]*model.User, error) {
+	return nil, nil
+}
 func (s *stubUserRepo) UpdateUser(string, map[string]any) error               { return nil }
 func (s *stubUserRepo) UpdateProfile(string, map[string]any) error            { return nil }
 func (s *stubUserRepo) CreateProfile(*model.UserProfile) error                { return nil }

--- a/internal/core/user/user_service.go
+++ b/internal/core/user/user_service.go
@@ -258,6 +258,30 @@ func (s *Service) Search(query string, limit, offset int, origin string) ([]*mod
 	return s.userRepo.SearchByUsername(strings.ToLower(q), limit, offset, origin)
 }
 
+// SearchByUsernameAndHost narrows username prefix matches to a specific host
+// (or local users when host is nil/empty). upstream Misskey TS の
+// users/search-by-username-and-host endpoint と同じ semantics (#766)。
+//   - host=nil or empty → host IS NULL (local users)
+//   - host=*string      → 当該 host のみ (case-insensitive)
+func (s *Service) SearchByUsernameAndHost(username string, host *string, limit int) ([]*model.User, error) {
+	q := strings.TrimSpace(strings.TrimPrefix(username, "@"))
+	if q == "" {
+		return nil, nil
+	}
+	if limit <= 0 {
+		limit = 10
+	}
+	// upstream は host="" / null を local 扱いにするので合わせる。
+	var hostNorm *string
+	if host != nil {
+		h := strings.ToLower(strings.TrimSpace(*host))
+		if h != "" {
+			hostNorm = &h
+		}
+	}
+	return s.userRepo.SearchByUsernameAndHost(strings.ToLower(q), hostNorm, limit)
+}
+
 // UpdateInput represents the editable fields of a user profile.
 // Each pointer is interpreted as "leave unchanged when nil".
 type UpdateInput struct {

--- a/internal/core/user/user_service_test.go
+++ b/internal/core/user/user_service_test.go
@@ -3,6 +3,7 @@ package user_test
 import (
 	"encoding/json"
 	"errors"
+	"fmt"
 	"testing"
 
 	"github.com/shiroha-a/mk/internal/core/user"
@@ -796,4 +797,71 @@ func TestUpdateProfileFields(t *testing.T) {
 	userRepo.Profiles["u1"] = &model.UserProfile{UserID: "u1"}
 	err := svc.UpdateProfileFields("u1", map[string]any{"description": "new"})
 	require.NoError(t, err)
+}
+
+// #766: SearchByUsernameAndHost の各分岐を service レイヤーで覆う。
+func TestService_SearchByUsernameAndHost(t *testing.T) {
+	svc, userRepo, _, _ := newFullSvc(t)
+	remoteHost := "remote.example"
+	otherHost := "other.example"
+	userRepo.Users["u_local"] = &model.User{ID: "u_local", Username: "alice", UsernameLower: "alice"}
+	userRepo.Users["u_remote"] = &model.User{ID: "u_remote", Username: "alice", UsernameLower: "alice", Host: &remoteHost}
+	userRepo.Users["u_other"] = &model.User{ID: "u_other", Username: "alice", UsernameLower: "alice", Host: &otherHost}
+
+	t.Run("empty query returns nil", func(t *testing.T) {
+		out, err := svc.SearchByUsernameAndHost("", nil, 10)
+		require.NoError(t, err)
+		assert.Nil(t, out)
+	})
+
+	t.Run("@ prefix is stripped", func(t *testing.T) {
+		out, err := svc.SearchByUsernameAndHost("@alice", nil, 10)
+		require.NoError(t, err)
+		require.Len(t, out, 1)
+		assert.Equal(t, "u_local", out[0].ID)
+	})
+
+	t.Run("host=nil filters to local", func(t *testing.T) {
+		out, err := svc.SearchByUsernameAndHost("alice", nil, 10)
+		require.NoError(t, err)
+		require.Len(t, out, 1)
+		assert.Equal(t, "u_local", out[0].ID)
+	})
+
+	t.Run("host=empty string treated as local", func(t *testing.T) {
+		empty := ""
+		out, err := svc.SearchByUsernameAndHost("alice", &empty, 10)
+		require.NoError(t, err)
+		require.Len(t, out, 1)
+		assert.Equal(t, "u_local", out[0].ID)
+	})
+
+	t.Run("host=specific narrows to that host", func(t *testing.T) {
+		out, err := svc.SearchByUsernameAndHost("alice", &remoteHost, 10)
+		require.NoError(t, err)
+		require.Len(t, out, 1)
+		assert.Equal(t, "u_remote", out[0].ID)
+	})
+
+	t.Run("host comparison is case-insensitive", func(t *testing.T) {
+		upper := "REMOTE.EXAMPLE"
+		out, err := svc.SearchByUsernameAndHost("alice", &upper, 10)
+		require.NoError(t, err)
+		require.Len(t, out, 1)
+		assert.Equal(t, "u_remote", out[0].ID)
+	})
+
+	t.Run("limit defaults to 10 when zero", func(t *testing.T) {
+		// 11 件 local user を仕込んで limit 未指定で 10 に clamp されることを確認
+		repo2 := testutil.NewMockUserRepository()
+		for i := 0; i < 11; i++ {
+			id := fmt.Sprintf("u_many_%02d", i)
+			repo2.Users[id] = &model.User{ID: id, Username: "many", UsernameLower: "many"}
+		}
+		idGen, _ := id.NewGenerator("aidx")
+		s2 := user.NewService(repo2, testutil.NewMockNoteRepository(), testutil.NewMockUserNotePiningRepository(), idGen)
+		out, err := s2.SearchByUsernameAndHost("many", nil, 0)
+		require.NoError(t, err)
+		assert.Len(t, out, 10)
+	})
 }

--- a/internal/repository/user.go
+++ b/internal/repository/user.go
@@ -49,6 +49,11 @@ type UserRepository interface {
 	// SearchOriginLocal / SearchOriginRemote / SearchOriginCombined を使う。
 	// 空文字列 / 未知値は SearchOriginCombined と同等扱い。
 	SearchByUsername(query string, limit, offset int, origin string) ([]*model.User, error)
+	// SearchByUsernameAndHost は username prefix と host を SQL で絞り込む
+	// (#766)。host=nil は local (host IS NULL)、host=*string は当該 host
+	// (case-insensitive) のみ。upstream Misskey TS の同名 endpoint と同じ
+	// semantics。caller は username / host を pre-lowercase して渡すこと。
+	SearchByUsernameAndHost(query string, host *string, limit int) ([]*model.User, error)
 	UpdateUser(userID string, fields map[string]any) error
 	UpdateProfile(userID string, fields map[string]any) error
 	CreateProfile(profile *model.UserProfile) error
@@ -226,6 +231,27 @@ func (r *userRepository) SearchByUsername(query string, limit, offset int, origi
 		Order("\"followersCount\" DESC, id ASC").
 		Limit(limit).
 		Offset(offset).
+		Find(&users).Error; err != nil {
+		return nil, err
+	}
+	return users, nil
+}
+
+// SearchByUsernameAndHost narrows username prefix matches to a specific host
+// (or local users when host is nil). #766 fix: SearchByUsername の origin
+// 軸では「特定 host への絞り込み」ができないので分離した sibling method。
+// host comparison は lower(host) = lower(?) で case-insensitive。
+func (r *userRepository) SearchByUsernameAndHost(query string, host *string, limit int) ([]*model.User, error) {
+	var users []*model.User
+	q := r.db.Where("\"usernameLower\" LIKE ?", query+"%")
+	if host != nil {
+		q = q.Where("lower(\"host\") = lower(?)", *host)
+	} else {
+		q = q.Where("\"host\" IS NULL")
+	}
+	if err := q.
+		Order("\"followersCount\" DESC, id ASC").
+		Limit(limit).
 		Find(&users).Error; err != nil {
 		return nil, err
 	}

--- a/internal/repository/user_test.go
+++ b/internal/repository/user_test.go
@@ -396,6 +396,59 @@ func TestUserRepository_SearchByUsername_OriginFilter(t *testing.T) {
 	})
 }
 
+// host filter (#766): host=nil は local (host IS NULL) のみ、host=*string
+// は当該 host のみ返す。host comparison は case-insensitive。
+// IDX_user_usernameLower_local_unique 制約があるので local user は 1 つに
+// 留め、remote 同士は host が違えば同 username でも OK な前提で組む。
+func TestUserRepository_SearchByUsernameAndHost(t *testing.T) {
+	repo := NewUserRepository(testDB)
+	local := insertTestUser(t, "u_sh_local", "hosttest")
+	defer cleanupUser(t, local.ID)
+	remoteHost := "remote.example"
+	remote := insertTestUser(t, "u_sh_remote", "hosttest_r")
+	require.NoError(t, repo.UpdateUser(remote.ID, map[string]any{"host": remoteHost}))
+	defer cleanupUser(t, remote.ID)
+	otherHost := "other.example"
+	other := insertTestUser(t, "u_sh_other", "hosttest_o")
+	require.NoError(t, repo.UpdateUser(other.ID, map[string]any{"host": otherHost}))
+	defer cleanupUser(t, other.ID)
+
+	t.Run("host=nil returns only local", func(t *testing.T) {
+		out, err := repo.SearchByUsernameAndHost("hosttest", nil, 10)
+		require.NoError(t, err)
+		ids := make(map[string]bool, len(out))
+		for _, u := range out {
+			ids[u.ID] = true
+		}
+		assert.True(t, ids[local.ID])
+		assert.False(t, ids[remote.ID])
+		assert.False(t, ids[other.ID])
+	})
+
+	t.Run("host=remote returns only that host", func(t *testing.T) {
+		out, err := repo.SearchByUsernameAndHost("hosttest", &remoteHost, 10)
+		require.NoError(t, err)
+		ids := make(map[string]bool, len(out))
+		for _, u := range out {
+			ids[u.ID] = true
+		}
+		assert.False(t, ids[local.ID])
+		assert.True(t, ids[remote.ID])
+		assert.False(t, ids[other.ID])
+	})
+
+	t.Run("host comparison is case-insensitive", func(t *testing.T) {
+		upper := "REMOTE.EXAMPLE"
+		out, err := repo.SearchByUsernameAndHost("hosttest", &upper, 10)
+		require.NoError(t, err)
+		ids := make(map[string]bool, len(out))
+		for _, u := range out {
+			ids[u.ID] = true
+		}
+		assert.True(t, ids[remote.ID])
+	})
+}
+
 func TestUserRepository_UpdateUser(t *testing.T) {
 	repo := NewUserRepository(testDB)
 	user := insertTestUser(t, "u_up_1", "updateuser1")

--- a/internal/testutil/mock_repository.go
+++ b/internal/testutil/mock_repository.go
@@ -195,6 +195,34 @@ func (m *MockUserRepository) SearchByUsername(query string, limit, offset int, o
 	return matches[offset:end], nil
 }
 
+// SearchByUsernameAndHost narrows the prefix match to a specific host (or
+// local users when host is nil). #766 fix と同じ contract で、host
+// comparison は case-insensitive。
+func (m *MockUserRepository) SearchByUsernameAndHost(query string, host *string, limit int) ([]*model.User, error) {
+	var matches []*model.User
+	for _, u := range m.Users {
+		if !(len(u.UsernameLower) >= len(query) && u.UsernameLower[:len(query)] == query) {
+			continue
+		}
+		if host == nil {
+			if u.Host == nil {
+				matches = append(matches, u)
+			}
+			continue
+		}
+		if u.Host == nil {
+			continue
+		}
+		if strings.EqualFold(*u.Host, *host) {
+			matches = append(matches, u)
+		}
+	}
+	if limit > 0 && len(matches) > limit {
+		matches = matches[:limit]
+	}
+	return matches, nil
+}
+
 func (m *MockUserRepository) UpdateUser(userID string, fields map[string]any) error {
 	u, ok := m.Users[userID]
 	if !ok {


### PR DESCRIPTION
## Summary

旧実装の \`SearchByUsernameAndHost\` は \`req.Host\` を受け取りつつ無視して \`Search(query, limit, 0, \"\")\` (全 host のマッチ) を呼んでいたため、frontend が \`{username, host}\` で特定 host のユーザーを絞り込めない状態だった。upstream Misskey TS の同 endpoint と同じ semantics に揃える。

## 主な変更点

### Repository 層

- \`UserRepository\` に \`SearchByUsernameAndHost(query string, host *string, limit int) ([]*model.User, error)\` を追加 (interface + 実装 + Mock + 各 stub テスト用 mock)
- SQL 層は \`lower(host) = lower(?)\` で case-insensitive な host 比較
- host=nil なら \`host IS NULL\` (local users) を返す

### Service 層

- \`user.Service.SearchByUsernameAndHost(username, host *string, limit int)\` を追加
- username は trim + lower + \`@\` prefix 除去 (既存 \`Search\` と同じ正規化)
- host は \`nil\` / 空文字を local 扱い (upstream 仕様)、それ以外は trim + lower

### Handler 層

- \`users.Handler.SearchByUsernameAndHost\` を新 service method に切替
- \`req.Host\` (\`*string\`) を直接 service に渡す

## 影響

- frontend のメンション補完 (\`@user@host\` 入力) / user picker UI で host 指定検索が機能するようになる
- security 影響なし (見える user の権限は変わらず、UX 改善のみ)

## テスト

### \`internal/api/users\`

- \`TestSearchByUsernameAndHost_FiltersByHost\` (新規):
  - host 未指定 / 空文字 → local user のみ返ることを確認
  - host=remote.example → 当該 host の user のみ
  - host=REMOTE.EXAMPLE → case-insensitive 比較で同じ user が返る
- \`failingSearchRepo\` を旧 \`SearchByUsername\` override → 新 \`SearchByUsernameAndHost\` override に切替 (handler が呼ぶ method が変わったため)

### \`internal/repository\`

- \`TestUserRepository_SearchByUsernameAndHost\` (新規):
  - 3 サブテスト (host=nil / host=remote / case-insensitive)
  - \`IDX_user_usernameLower_local_unique\` 制約があるので local user は 1 つに留め、remote 同士は host が違えば同 username 重複可な前提で組み立て

### Stub mocks

\`mockUserRepo\` (resetpassword) / \`stubUserRepo\` (retention) に no-op の \`SearchByUsernameAndHost\` 実装を追加して \`UserRepository\` interface を満足させる。

## 通過確認

- \`go test ./... -count=1\` 全 pass (queue / federation / repository / users 含む)
- \`make build\` 成功
- ⚠️ **UDS smoke は未実施** — operator 側で \`@user@remote.host\` 形式のメンション補完が動くことを確認お願いします (issue body の完了条件)

## Closes

#766

## 関連

- #763 (origin filter 追加 PR、本 issue の発見元)
- PR #765 で host filter 不在を明示的にコメント化していた箇所を本 PR で解消

🤖 Generated with [Claude Code](https://claude.com/claude-code)