### PR TITLE
Test #780: e2e_federation で AP deliver queue を bypass する sync hook

### DIFF
--- a/internal/core/federation/deliver_service.go
+++ b/internal/core/federation/deliver_service.go
@@ -44,6 +44,11 @@ type DeliverService struct {
 	keypairRepo   repository.UserKeypairRepository
 	urls          *activitypub.URLBuilder
 	hostBlocker   HostBlockChecker
+	// syncDeliverHook, when non-nil, replaces the asynq enqueue with an
+	// inline call to the hook. test 専用で federation deliver の queue 経路
+	// を bypass し、sign + HTTP POST を同期実行する e2e_federation 用。
+	// production code から SetSyncDeliverHook を呼ばないこと (#780)。
+	syncDeliverHook func(payload queue.DeliverPayload) error
 }
 
 // NewDeliverService constructs a DeliverService.
@@ -67,6 +72,16 @@ func NewDeliverService(
 // 呼ばれ、ブロック対象ホストの inbox にはエンキューしない。
 func (s *DeliverService) SetHostBlockChecker(c HostBlockChecker) {
 	s.hostBlocker = c
+}
+
+// SetSyncDeliverHookForTest replaces the asynq enqueue with an inline
+// synchronous call. Used by e2e_federation tests to bypass the queue layer
+// and exercise the sign + POST + inbox handling path directly. Not for
+// production use (#780).
+//
+// fn=nil restores the default (queue) path.
+func (s *DeliverService) SetSyncDeliverHookForTest(fn func(payload queue.DeliverPayload) error) {
+	s.syncDeliverHook = fn
 }
 
 // DeliverActivity enqueues a deliver job for each unique inbox in inboxes.
@@ -97,6 +112,13 @@ func (s *DeliverService) DeliverActivity(signerUserID string, body []byte, inbox
 			Body:   body,
 			KeyID:  keyID,
 			KeyPEM: keyPEM,
+		}
+		if s.syncDeliverHook != nil {
+			// test 経路 (#780): queue を経由せず inline で sign + POST。
+			if err := s.syncDeliverHook(payload); err != nil {
+				return fmt.Errorf("sync deliver to %s: %w", inbox, err)
+			}
+			continue
 		}
 		if err := s.enqueuer.EnqueueDeliver(payload); err != nil {
 			return fmt.Errorf("enqueue deliver to %s: %w", inbox, err)

--- a/internal/server/router.go
+++ b/internal/server/router.go
@@ -512,6 +512,9 @@ func (s *Server) setupRoutes() {
 	// AP delivery: DeliverService + フック登録 + asynq processor 登録
 	deliverService := corefederation.NewDeliverService(s.queueClient, userRepo, followingRepo, keypairRepo, apURLs)
 	deliverService.SetHostBlockChecker(instanceService)
+	// test (#780) で queue を bypass して同期 deliver する hook を後付けで
+	// 差し替えられるよう、Server から参照を保持する。
+	s.deliverSvc = deliverService
 
 	// poll federation hook: ローカル user が remote poll に投票したら AP Note
 	// (with name + inReplyTo) を author の inbox に配信する (#690)。

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -241,18 +241,6 @@ func (s *Server) Handler() http.Handler {
 // 部分だけ抽出する。
 //
 // production code から呼ばないこと。
-// SetSyncDeliverHookForTest replaces the asynq deliver enqueue with the
-// supplied synchronous hook. e2e_federation 系テストで queue worker 経由の
-// deliver が動かない/動かしたくないシナリオで、sign + HTTP POST を inline
-// で実行する用途。fn=nil で本番経路 (queue) に戻る。
-//
-// production code から呼ばないこと (#780)。
-func (s *Server) SetSyncDeliverHookForTest(fn func(payload queue.DeliverPayload) error) {
-	if s.deliverSvc != nil {
-		s.deliverSvc.SetSyncDeliverHookForTest(fn)
-	}
-}
-
 func (s *Server) StartBackgroundForTest() error {
 	if err := s.queueServer.Start(); err != nil {
 		return fmt.Errorf("start queue worker: %w", err)
@@ -274,6 +262,18 @@ func (s *Server) StartBackgroundForTest() error {
 		}
 	}
 	return nil
+}
+
+// SetSyncDeliverHookForTest replaces the asynq deliver enqueue with the
+// supplied synchronous hook. e2e_federation 系テストで queue worker 経由の
+// deliver が動かない/動かしたくないシナリオで、sign + HTTP POST を inline
+// で実行する用途。fn=nil で本番経路 (queue) に戻る。
+//
+// production code から呼ばないこと (#780)。
+func (s *Server) SetSyncDeliverHookForTest(fn func(payload queue.DeliverPayload) error) {
+	if s.deliverSvc != nil {
+		s.deliverSvc.SetSyncDeliverHookForTest(fn)
+	}
 }
 
 // Start begins listening on the configured port (or UNIX domain socket) and

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -15,6 +15,7 @@ import (
 	"github.com/shiroha-a/mk/internal/config"
 	"github.com/shiroha-a/mk/internal/core/cache"
 	"github.com/shiroha-a/mk/internal/core/chart"
+	corefederation "github.com/shiroha-a/mk/internal/core/federation"
 	"github.com/shiroha-a/mk/internal/queue"
 	"github.com/shiroha-a/mk/internal/queue/driver"
 	"github.com/shiroha-a/mk/internal/repository"
@@ -40,6 +41,10 @@ type Server struct {
 	queueScheduler *queue.Scheduler
 	queueInspector *queue.Inspector
 	chartMgmt      *chart.ManagementService
+	// deliverSvc は federation deliver service への参照。本番では asynq
+	// 経由で deliver を enqueue するが、test (#780) で queue を bypass する
+	// ための SetSyncDeliverHookForTest を呼べるよう参照を保持する。
+	deliverSvc *corefederation.DeliverService
 
 	// shutdownHooks は Shutdown() 時に queue / HTTP echo より先に呼ばれる。
 	// ctx-aware にすることで graceful drain (例: hashtag service の
@@ -236,6 +241,18 @@ func (s *Server) Handler() http.Handler {
 // 部分だけ抽出する。
 //
 // production code から呼ばないこと。
+// SetSyncDeliverHookForTest replaces the asynq deliver enqueue with the
+// supplied synchronous hook. e2e_federation 系テストで queue worker 経由の
+// deliver が動かない/動かしたくないシナリオで、sign + HTTP POST を inline
+// で実行する用途。fn=nil で本番経路 (queue) に戻る。
+//
+// production code から呼ばないこと (#780)。
+func (s *Server) SetSyncDeliverHookForTest(fn func(payload queue.DeliverPayload) error) {
+	if s.deliverSvc != nil {
+		s.deliverSvc.SetSyncDeliverHookForTest(fn)
+	}
+}
+
 func (s *Server) StartBackgroundForTest() error {
 	if err := s.queueServer.Start(); err != nil {
 		return fmt.Errorf("start queue worker: %w", err)

--- a/test/e2e_federation/helpers_test.go
+++ b/test/e2e_federation/helpers_test.go
@@ -49,6 +49,11 @@ func signup(t *testing.T, srv *testServer, username string, admin *userToken) *u
 }
 
 // resetDB は指定サーバーの /api/reset-db を呼んでDBをリセットする。
+//
+// reset-db は meta テーブルを TRUNCATE して default 値で再 INSERT するので
+// federation = 'none' (全 host deny) に戻ってしまう。e2e_federation は
+// localhost↔localhost で federation を駆動するので 'all' (制限なし) に
+// 上書きしてから返す (#780)。
 func resetDB(t *testing.T, srv *testServer) {
 	t.Helper()
 	resp := srvAPIPost(t, srv, "reset-db", nil)
@@ -58,6 +63,14 @@ func resetDB(t *testing.T, srv *testServer) {
 		require.Failf(t, "reset-db failed", "server=%s status=%d body=%s",
 			srv.Host, resp.StatusCode, string(body))
 	}
+	// reset-db 後に federation を relax する。CachedMetaRepository は
+	// EnsureInitial で cache invalidate されるので、次の Fetch で 'all' を
+	// 拾える。
+	db := dbAGlobal
+	if srv == serverB {
+		db = dbBGlobal
+	}
+	require.NoError(t, db.Exec(`UPDATE meta SET "federation" = 'all'`).Error)
 }
 
 // srvAPIPost は POST /api/<path> を指定サーバーに送る。

--- a/test/e2e_federation/main_test.go
+++ b/test/e2e_federation/main_test.go
@@ -14,16 +14,45 @@ import (
 	"net/http/httptest"
 	"os"
 	"testing"
+	"time"
 
 	goredis "github.com/redis/go-redis/v9"
+	"github.com/shiroha-a/mk/internal/activitypub"
 	"github.com/shiroha-a/mk/internal/config"
 	"github.com/shiroha-a/mk/internal/core/cache"
+	"github.com/shiroha-a/mk/internal/queue"
 	"github.com/shiroha-a/mk/internal/server"
 	"github.com/shiroha-a/mk/internal/testutil"
 	"gorm.io/driver/postgres"
 	"gorm.io/gorm"
 	"gorm.io/gorm/logger"
 )
+
+// makeSyncDeliverHook builds a synchronous AP deliver function for tests
+// (#780). 本番経路は asynq queue 経由だが test では queue worker pickup
+// が確認できないので、sign + HTTP POST を inline 実行する。
+//
+// HTTP client は SSRF transport を含めない (e2e は loopback で localhost
+// のみ POST するため)。失敗時 (非 2xx / 接続エラー) は error を返すので
+// DeliverService 側で deliver 経路の error として扱われる。
+func makeSyncDeliverHook() func(queue.DeliverPayload) error {
+	apClient := activitypub.NewClient(&http.Client{Timeout: 10 * time.Second}, "mk-go-e2e-test")
+	return func(p queue.DeliverPayload) error {
+		key, err := activitypub.NewPrivateKey(p.KeyID, p.KeyPEM)
+		if err != nil {
+			return fmt.Errorf("parse key: %w", err)
+		}
+		resp, err := apClient.PostSigned(p.Inbox, p.Body, key)
+		if err != nil {
+			return fmt.Errorf("post signed to %s: %w", p.Inbox, err)
+		}
+		defer resp.Body.Close()
+		if resp.StatusCode >= 400 {
+			return fmt.Errorf("inbox %s returned %d", p.Inbox, resp.StatusCode)
+		}
+		return nil
+	}
+}
 
 // testServer はテスト用サーバーの接続情報を保持する。
 type testServer struct {
@@ -40,6 +69,11 @@ var (
 	// federation check 用 cache key を直接 pre-populate するなど、test 側で
 	// Redis を直接触る必要があるシナリオ (#435) で使う。
 	redisAddr string
+	// dbAGlobal / dbBGlobal は両 server の gorm.DB。reset-db 後に
+	// meta.federation を上書きする等、test 側で DB を直接触る必要が
+	// あるシナリオ (#780) で使う。
+	dbAGlobal *gorm.DB
+	dbBGlobal *gorm.DB
 )
 
 func TestMain(m *testing.M) {
@@ -94,6 +128,10 @@ func TestMain(m *testing.M) {
 	}
 
 	redisAddr = fmt.Sprintf("%s:%d", testRedis.Host(), testRedis.Port())
+	// 後続の resetDB / 個別 test から meta.federation を 'all' に上書きする
+	// ために両 DB を package-level variable に export する (#780)。
+	dbAGlobal = testDB.DB
+	dbBGlobal = dbB
 
 	// サーバーA: Redis DB 0
 	redisOptsA := config.RedisOptions{
@@ -149,6 +187,10 @@ func TestMain(m *testing.M) {
 		fmt.Fprintf(os.Stderr, "e2e_federation: queue worker A start: %v\n", err)
 		os.Exit(1)
 	}
+	// queue 経由の deliver が test 環境で動かないので sync deliver hook で
+	// bypass する (#780)。inbox 受信側 (= 相手 server) は sign POST を 200/202
+	// で受けて federation processor を回す。
+	srvA.SetSyncDeliverHookForTest(makeSyncDeliverHook())
 
 	// サーバーB: Redis DB 1
 	redisOptsB := config.RedisOptions{
@@ -199,6 +241,7 @@ func TestMain(m *testing.M) {
 		fmt.Fprintf(os.Stderr, "e2e_federation: queue worker B start: %v\n", err)
 		os.Exit(1)
 	}
+	srvB.SetSyncDeliverHookForTest(makeSyncDeliverHook())
 
 	os.Exit(m.Run())
 }

--- a/test/e2e_federation/reversi_test.go
+++ b/test/e2e_federation/reversi_test.go
@@ -110,14 +110,10 @@ func warmRemoteUserCache(t *testing.T, srv *testServer, fromUser *userToken, rem
 // /api/reversi/match を呼ぶと、B 側の bob の invitations 一覧に alice が
 // 表示される (= AP Invite が federation 経由で処理された)。
 //
-// 現状 SKIP: e2e_federation harness は同期的な /api/ap/show 経路 (server-to-
-// server pull) のみ動作検証されており、async deliver queue 経由の push 経路
-// (asynq job → signed POST → 相手 inbox 処理) を駆動する wiring が存在
-// しない。Server.StartBackgroundForTest で queue worker は起動するが、
-// deliver 実体が実 inbox に着弾する所までは現状の test infra では追えない。
-// 本格的な round-trip 確認は別 issue (federation queue test infra) で対応。
+// deliver queue 経路は test 環境で動かないので main_test.go で
+// SetSyncDeliverHookForTest を wire し、sign + HTTP POST を inline 実行
+// する形で round-trip を駆動する (#780)。
 func TestReversi_LocalInviteRoundTrip(t *testing.T) {
-	t.Skip("federation deliver queue test infra is out of scope for #435 — see PR body")
 	resetDB(t, serverA)
 	resetDB(t, serverB)
 
@@ -156,10 +152,9 @@ func TestReversi_LocalInviteRoundTrip(t *testing.T) {
 // /api/reversi/cancel-match を呼ぶと AP Leave が相手に飛んで、B 側の row が
 // 消える (= bob の invitations から alice が消える)。
 //
-// 現状 SKIP: TestReversi_LocalInviteRoundTrip と同じ理由で deliver queue の
-// 駆動が test harness 上で未対応。
+// sync deliver hook (main_test.go の SetSyncDeliverHookForTest) で AP
+// deliver を inline で駆動する (#780)。
 func TestReversi_CancelMatchUndoesPreStart(t *testing.T) {
-	t.Skip("federation deliver queue test infra is out of scope for #435 — see PR body")
 	resetDB(t, serverA)
 	resetDB(t, serverB)
 


### PR DESCRIPTION
## Summary

#435 follow-up #780。e2e_federation harness では mkq queue worker が deliver job を pickup しない問題があり、PR #779 で 2 case を \`t.Skip\` していた。**queue 駆動部分を test scope から外し、sign + HTTP POST だけ inline 実行する synchronous deliver hook** を整備して inbox 受信側のロジック (signature verify + 連合 processor 実行 + state 行作成) を end-to-end で検証できるようにする。

## 結果

| Test | Before | After |
|---|---|---|
| \`TestReversi_LocalInviteRoundTrip\` | SKIP | **PASS** |
| \`TestReversi_CancelMatchUndoesPreStart\` | SKIP | **PASS** |
| \`TestReversi_ReactionURIInboxNoCrash\` | PASS | PASS |

\`/api/reversi/match\` で alice@A が @bob@B を招待すると、AP signed POST 経由で B 側 inbox に Invite が着弾し、B 側に reversi_game 行が作成される。Cancel-Match 経由の Leave も同様に伝播して B 側 row が消える。

## 変更点

### \`corefederation.DeliverService\`
- \`SetSyncDeliverHookForTest(fn func(payload queue.DeliverPayload) error)\` を追加
- \`DeliverActivity\` 内で \`syncDeliverHook != nil\` なら \`EnqueueDeliver\` の代わりに inline 呼び出し
- production 経路 (queue) は無変更

### \`internal/server/server.go\`
- \`Server\` struct に \`deliverSvc *corefederation.DeliverService\` reference を保持
- \`Server.SetSyncDeliverHookForTest\` を expose (内部で \`deliverSvc.SetSyncDeliverHookForTest\` を呼ぶ)
- 命名に \`ForTest\` を含めて production 経路から誤呼び出し防止

### \`internal/server/router.go\`
- \`setupRoutes\` 内で \`deliverService\` を \`s.deliverSvc\` に assign

### \`test/e2e_federation/main_test.go\`
- \`makeSyncDeliverHook\` で \`activitypub.Client.PostSigned\` を内側に持つ deliver function を構築
- A/B 両 server に \`SetSyncDeliverHookForTest\` で wire
- 両 server の \`*gorm.DB\` を \`dbAGlobal\` / \`dbBGlobal\` で expose

### \`test/e2e_federation/helpers_test.go\`
- \`resetDB\` ヘルパーで \`UPDATE meta SET federation = 'all'\` を実行
- 理由: fresh DB / reset-db 後の \`meta.federation\` default は \`'none'\` で localhost↔localhost が deny されるため。 \`CachedMetaRepository\` は \`EnsureInitial\` で invalidate されるので、その後の SQL UPDATE は次回 Fetch から拾える

### \`test/e2e_federation/reversi_test.go\`
- \`TestReversi_LocalInviteRoundTrip\` / \`TestReversi_CancelMatchUndoesPreStart\` の \`t.Skip\` を削除

## 調査メモ

PR #779 の段階で \`Server.StartBackgroundForTest\` 経由で mkq queue worker は起動するが、enqueue した deliver job が Handle まで到達しない (\`DEBUG-deliver-sync called\` を仕込んで確認)。debug の過程で:

1. \`DeliverToUser\` は err nil で return (enqueue 成功)
2. \`DeliverProcessor.Handle\` 冒頭の slog 未発火 (worker dispatch せず)
3. mkq library 内部の blocking polling / KeyPrefix / Queue handle 整合性が原因と推定

queue worker pickup の根本修正は別途調査が必要なので本 PR では **test 用に queue を bypass する単純な hook** を追加する pragmatic な解決を採る。production 経路 (asynq enqueue → DeliverProcessor.Handle) は **無変更**。

## scope guard

- production の \`Server.Start\` 経路からは sync hook は呼ばれない (\`...ForTest\` API のみ)
- mkq queue worker pickup 自体の修復は本 PR の対象外。reversi だけでなく **将来 federation regression test を増やす際にも sync hook で十分カバーできる** ので、queue infra 修復は中長期での task として残す
- WebSocket 経路 (UpdateSettings / PutStone / Surrender = #435 残 3 case) は別 issue #781 で対応

## テスト

- \`go test ./test/e2e_federation/... -count=1\` 全 pass (reversi 3 件 + 既存 note / user)
- \`go test ./internal/core/federation/... ./internal/core/instance/... ./internal/server/...\` 全 pass
- production 経路 (queue 駆動 deliver) は無変更

## Closes

#780

🤖 Generated with [Claude Code](https://claude.com/claude-code)