### PR TITLE
Test #781: WebSocket stream channel test client + reversi 3 case (#435 完成)

### DIFF
--- a/test/e2e_federation/reversi_test.go
+++ b/test/e2e_federation/reversi_test.go
@@ -346,7 +346,7 @@ func TestReversi_PutStonePropagates(t *testing.T) {
 // /api/reversi/surrender を呼ぶと AP Leave が B に飛び、両 server で
 // IsEnded=true / WinnerID=bob になる (#435 case 4)。
 func TestReversi_SurrenderEndsBothSides(t *testing.T) {
-	alice, bob, gameAID, gameBID, _, _ := readyAndStart(t)
+	alice, _, gameAID, gameBID, _, _ := readyAndStart(t)
 
 	resp := srvAPIPost(t, serverA, "reversi/surrender", map[string]any{
 		"i":      alice.Token,
@@ -369,17 +369,16 @@ func TestReversi_SurrenderEndsBothSides(t *testing.T) {
 		time.Sleep(50 * time.Millisecond)
 	}
 
-	// 最終 assertion: 両 DB の row が IsEnded=true で、winner はそれぞれ
-	// 自分から見て相手 (bob).
+	// 最終 assertion: 両 DB の row が IsEnded=true。winner ID は server 間で
+	// cached remote user の ID が異なるので strict 比較せず、終局フラグのみ
+	// を見る (alice surrender → 勝者は bob、両 server で同じ semantics)。
 	for _, ck := range []struct {
-		db        *gorm.DB
-		id        string
-		expectWin string
+		db *gorm.DB
+		id string
 	}{
-		{dbAGlobal, gameAID, bob.ID}, // A 側 bob は cached remote user
-		{dbBGlobal, gameBID, bob.ID},
+		{dbAGlobal, gameAID},
+		{dbBGlobal, gameBID},
 	} {
-		_ = ck.expectWin // winner ID は server 間で異なる cached user ID なので strict 比較しない
 		var ended bool
 		require.NoError(t, ck.db.Raw(
 			`SELECT "isEnded" FROM reversi_game WHERE id = ?`, ck.id,

--- a/test/e2e_federation/reversi_test.go
+++ b/test/e2e_federation/reversi_test.go
@@ -25,6 +25,7 @@ import (
 	corereversi "github.com/shiroha-a/mk/internal/core/reversi"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"gorm.io/gorm"
 )
 
 // preCacheReversiFederationVersion は reversi/match の federation availability
@@ -186,6 +187,205 @@ func TestReversi_CancelMatchUndoesPreStart(t *testing.T) {
 
 	// B 側の invitations から alice が消えるまで poll
 	pollInvitationGone(t, serverB, bob, "alice", 10*time.Second)
+}
+
+// inviteAndAccept は alice@A → bob@B の招待 + 受諾フローを 1 つの helper に
+// まとめる (#781 系の test 用)。reset-db → signup → warm cache → match →
+// match-back の flow をまとめて、両 server で reversi_game 行が存在し
+// federation で session id が紐付いた状態を確立する。
+//
+// (federation deliver は main_test.go で wired した sync hook 経由)
+//
+// 戻り値: alice / bob の userToken と、A 側 game.ID / B 側 game.ID。
+func inviteAndAccept(t *testing.T) (alice, bob *userToken, gameAID, gameBID string) {
+	t.Helper()
+	resetDB(t, serverA)
+	resetDB(t, serverB)
+	alice = signup(t, serverA, "alice", nil)
+	bob = signup(t, serverB, "bob", nil)
+
+	aliceURI := userURI(serverA, alice.ID)
+	warmRemoteUserCache(t, serverB, bob, aliceURI)
+	bobURI := userURI(serverB, bob.ID)
+	warmRemoteUserCache(t, serverA, alice, bobURI)
+	preCacheReversiFederationVersion(t, 0, serverB.Host)
+	preCacheReversiFederationVersion(t, 1, serverA.Host)
+
+	// alice が bob を招待
+	bobAcct := "@bob@" + serverB.Host
+	resp := srvAPIPost(t, serverA, "reversi/match", map[string]any{
+		"i":      alice.Token,
+		"userId": bobAcct,
+	})
+	require.NoError(t, resp.Body.Close())
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+	// 招待が B 側に着弾するまで待つ
+	pollInvitationContains(t, serverB, bob, "alice", 10*time.Second)
+
+	// bob が match で accept → A 側に Join 通知
+	aliceAcct := "@alice@" + serverA.Host
+	rec := srvAPICall(t, serverB, "reversi/match", map[string]any{
+		"i":      bob.Token,
+		"userId": aliceAcct,
+	})
+	gameBID, _ = rec["id"].(string)
+	require.NotEmpty(t, gameBID, "bob's match response should contain game id")
+
+	// A 側の game ID は DB 直接で latest を引く (handler 経路は配列を返す
+	// ので srvAPICall の map 期待と合わず簡素化)。
+	type rgRow struct{ ID string }
+	var row rgRow
+	require.NoError(t, dbAGlobal.Raw(
+		`SELECT id FROM reversi_game WHERE "user1Id" = ? ORDER BY id DESC LIMIT 1`, alice.ID,
+	).Scan(&row).Error)
+	gameAID = row.ID
+	require.NotEmpty(t, gameAID, "alice should own a reversi_game row")
+
+	return alice, bob, gameAID, gameBID
+}
+
+// TestReversi_ReadyPropagatesAndStarts: alice@A と bob@B が WebSocket 経由で
+// Ready 通知を出すと AP federation で双方の row に user1Ready / user2Ready が
+// 反映され、IsStarted=true が両側で観測される (#435 case 2 の subset)。
+//
+// upstream は updateSettings / putStone も WebSocket 経由だが、本 test は
+// Ready / Started 伝播の最小ループだけを検証する。残 case (Settings /
+// PutStone / Surrender) は別 follow-up で。
+func TestReversi_ReadyPropagatesAndStarts(t *testing.T) {
+	alice, bob, gameAID, gameBID := inviteAndAccept(t)
+
+	// 両 server で reversi-game channel に subscribe
+	wsA := connectChannel(t, serverA, alice, "reversiGame", map[string]any{"gameId": gameAID})
+	wsB := connectChannel(t, serverB, bob, "reversiGame", map[string]any{"gameId": gameBID})
+
+	// alice ready=true
+	wsA.SendChannel("ready", true)
+	// bob ready=true
+	wsB.SendChannel("ready", true)
+
+	// 両 channel で `started` event を受信できること
+	wsA.WaitForEvent("started", 10*time.Second)
+	wsB.WaitForEvent("started", 10*time.Second)
+
+	// DB 層でも IsStarted=true を確認
+	for _, ck := range []struct {
+		db *gorm.DB
+		id string
+	}{{dbAGlobal, gameAID}, {dbBGlobal, gameBID}} {
+		var started bool
+		require.NoError(t, ck.db.Raw(
+			`SELECT "isStarted" FROM reversi_game WHERE id = ?`, ck.id,
+		).Scan(&started).Error)
+		assert.True(t, started, "game %s should be started", ck.id)
+	}
+}
+
+// readyAndStart は inviteAndAccept の後、両 server で Ready=true を送って
+// game を Started 状態にし、両 channel client を返す helper (#781)。後続の
+// PutStone / Surrender test で使う。
+func readyAndStart(t *testing.T) (alice, bob *userToken, gameAID, gameBID string, wsA, wsB *streamingClient) {
+	t.Helper()
+	alice, bob, gameAID, gameBID = inviteAndAccept(t)
+	wsA = connectChannel(t, serverA, alice, "reversiGame", map[string]any{"gameId": gameAID})
+	wsB = connectChannel(t, serverB, bob, "reversiGame", map[string]any{"gameId": gameBID})
+	wsA.SendChannel("ready", true)
+	wsB.SendChannel("ready", true)
+	wsA.WaitForEvent("started", 10*time.Second)
+	wsB.WaitForEvent("started", 10*time.Second)
+	return alice, bob, gameAID, gameBID, wsA, wsB
+}
+
+// blackUser は Started 後の game.Black (1 | 2) を見て黒番のユーザーを返す。
+// game.BW="random" + session id 由来で決まるので、test ごとに alice が
+// 黒のことも bob が黒のこともある。turn 駆動の test ではこの helper で
+// 動的に切り替える。
+func blackUser(t *testing.T, gameID string, alice, bob *userToken, wsA, wsB *streamingClient) (token *userToken, ws *streamingClient) {
+	t.Helper()
+	var blackVal int
+	require.NoError(t, dbAGlobal.Raw(
+		`SELECT black FROM reversi_game WHERE id = ?`, gameID,
+	).Scan(&blackVal).Error)
+	require.NotZero(t, blackVal, "game.Black should be 1 or 2 after Started")
+	if blackVal == 1 {
+		return alice, wsA
+	}
+	return bob, wsB
+}
+
+// TestReversi_PutStonePropagates: started game で 黒番 (= bw=random で
+// session id から決まる) が putStone を送ると AP federation で相手 server
+// の game にも turn が反映される。両 channel が `log` event を受信すること、
+// 両 DB の logs が同期することを確認 (#435 case 3)。
+func TestReversi_PutStonePropagates(t *testing.T) {
+	alice, bob, gameAID, gameBID, wsA, wsB := readyAndStart(t)
+
+	// 黒番が先手。session id 由来で alice / bob どちらが黒か決まるので、
+	// 黒の token + ws を動的に解決して putStone を送る。defaultMap の
+	// 8x8 標準配置で (2, 3) = pos=19 は黒の合法手 (先手で必ず flip 可能)。
+	_, blackWS := blackUser(t, gameAID, alice, bob, wsA, wsB)
+	blackWS.SendChannel("putStone", map[string]any{"pos": 19})
+
+	// 両 channel で log event を受信
+	wsA.WaitForEvent("log", 10*time.Second)
+	wsB.WaitForEvent("log", 10*time.Second)
+
+	// DB 層で logs が空でない (= 1 turn 進んだ) ことを両側で確認
+	for _, ck := range []struct {
+		db *gorm.DB
+		id string
+	}{{dbAGlobal, gameAID}, {dbBGlobal, gameBID}} {
+		var logsRaw string
+		require.NoError(t, ck.db.Raw(
+			`SELECT logs FROM reversi_game WHERE id = ?`, ck.id,
+		).Scan(&logsRaw).Error)
+		assert.NotEqual(t, "[]", logsRaw, "game %s should have at least 1 log entry", ck.id)
+	}
+}
+
+// TestReversi_SurrenderEndsBothSides: started game で alice が
+// /api/reversi/surrender を呼ぶと AP Leave が B に飛び、両 server で
+// IsEnded=true / WinnerID=bob になる (#435 case 4)。
+func TestReversi_SurrenderEndsBothSides(t *testing.T) {
+	alice, bob, gameAID, gameBID, _, _ := readyAndStart(t)
+
+	resp := srvAPIPost(t, serverA, "reversi/surrender", map[string]any{
+		"i":      alice.Token,
+		"gameId": gameAID,
+	})
+	require.NoError(t, resp.Body.Close())
+	require.Equal(t, http.StatusNoContent, resp.StatusCode)
+
+	// federation deliver が同期 (sync hook) なので即座に B 側にも反映する。
+	// 念のため short poll で B 側 row が IsEnded=true になるまで待つ。
+	deadline := time.Now().Add(10 * time.Second)
+	for time.Now().Before(deadline) {
+		var ended bool
+		require.NoError(t, dbBGlobal.Raw(
+			`SELECT "isEnded" FROM reversi_game WHERE id = ?`, gameBID,
+		).Scan(&ended).Error)
+		if ended {
+			break
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
+
+	// 最終 assertion: 両 DB の row が IsEnded=true で、winner はそれぞれ
+	// 自分から見て相手 (bob).
+	for _, ck := range []struct {
+		db        *gorm.DB
+		id        string
+		expectWin string
+	}{
+		{dbAGlobal, gameAID, bob.ID},  // A 側 bob は cached remote user
+		{dbBGlobal, gameBID, bob.ID},
+	} {
+		_ = ck.expectWin // winner ID は server 間で異なる cached user ID なので strict 比較しない
+		var ended bool
+		require.NoError(t, ck.db.Raw(
+			`SELECT "isEnded" FROM reversi_game WHERE id = ?`, ck.id,
+		).Scan(&ended).Error)
+		assert.True(t, ended, "game %s should be ended", ck.id)
+	}
 }
 
 // TestReversi_ReactionURIAcked: B から A の reversi session URI に対する

--- a/test/e2e_federation/reversi_test.go
+++ b/test/e2e_federation/reversi_test.go
@@ -376,7 +376,7 @@ func TestReversi_SurrenderEndsBothSides(t *testing.T) {
 		id        string
 		expectWin string
 	}{
-		{dbAGlobal, gameAID, bob.ID},  // A 側 bob は cached remote user
+		{dbAGlobal, gameAID, bob.ID}, // A 側 bob は cached remote user
 		{dbBGlobal, gameBID, bob.ID},
 	} {
 		_ = ck.expectWin // winner ID は server 間で異なる cached user ID なので strict 比較しない

--- a/test/e2e_federation/streaming_helpers_test.go
+++ b/test/e2e_federation/streaming_helpers_test.go
@@ -1,0 +1,189 @@
+// streaming_helpers_test.go: WebSocket /streaming テスト用クライアント (#781)。
+//
+// reversi-game 等の channel 駆動シナリオを e2e_federation で検証するため、
+// gorilla/websocket で /streaming に接続し、Misskey の "channel" envelope
+// プロトコル (connect / ch / disconnect) をやり取りする最小限の helper を
+// 提供する。WebSocket 経路は production と同じ stream.Dispatcher 配下を
+// 経由するので、認証 / channel registry / pubsub すべて実環境と等価。
+package e2e_federation
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/gorilla/websocket"
+	"github.com/stretchr/testify/require"
+)
+
+// channelMessage は server → client の channel envelope を unwrap した形。
+// `{"type":"channel","body":{"id":"<channel-id>","type":"<event>","body":...}}`
+// から body 部分を取り出す。
+type channelMessage struct {
+	ChannelID string
+	EventType string
+	Body      json.RawMessage
+}
+
+// streamingClient は test 用の最小 WebSocket client。channel 1 つを subscribe
+// した状態で送受信を行う。複数 channel を貼りたい場合は別 instance を作る。
+type streamingClient struct {
+	t         *testing.T
+	conn      *websocket.Conn
+	channelID string
+	mu        sync.Mutex
+	queue     []channelMessage
+	cond      *sync.Cond
+	closed    bool
+	closeOnce sync.Once
+}
+
+// dialStreaming は token 付きで /streaming に WebSocket 接続を確立する。
+// token=nil なら未認証 (一部 channel のみ動く)。
+func dialStreaming(t *testing.T, srv *testServer, token *userToken) *websocket.Conn {
+	t.Helper()
+	url := strings.Replace(srv.BaseURL, "http://", "ws://", 1) + "/streaming"
+	if token != nil {
+		url += "?i=" + token.Token
+	}
+	conn, _, err := websocket.DefaultDialer.Dial(url, nil)
+	require.NoError(t, err, "dial %s", url)
+	return conn
+}
+
+// connectChannel は dialStreaming の上で `connect` envelope を送って channel
+// を購読し、receive goroutine を立ち上げて queue にイベントを溜める client
+// を返す。t.Cleanup で disconnect + close を保証する。
+func connectChannel(t *testing.T, srv *testServer, token *userToken, channelName string, params map[string]any) *streamingClient {
+	t.Helper()
+	conn := dialStreaming(t, srv, token)
+
+	channelID := fmt.Sprintf("ch-%s-%d", channelName, time.Now().UnixNano())
+	c := &streamingClient{t: t, conn: conn, channelID: channelID}
+	c.cond = sync.NewCond(&c.mu)
+
+	// connect envelope を送出
+	connectMsg := map[string]any{
+		"type": "connect",
+		"body": map[string]any{
+			"id":      channelID,
+			"channel": channelName,
+			"params":  params,
+		},
+	}
+	require.NoError(t, conn.WriteJSON(connectMsg))
+
+	// receive goroutine
+	go c.readLoop()
+
+	t.Cleanup(c.Close)
+	return c
+}
+
+// readLoop は WebSocket からの "channel" envelope を queue に積む。それ以外
+// (connected / api 応答等) は無視する。
+func (c *streamingClient) readLoop() {
+	for {
+		_, raw, err := c.conn.ReadMessage()
+		if err != nil {
+			c.mu.Lock()
+			c.closed = true
+			c.cond.Broadcast()
+			c.mu.Unlock()
+			return
+		}
+		var env struct {
+			Type string `json:"type"`
+			Body struct {
+				ID   string          `json:"id"`
+				Type string          `json:"type"`
+				Body json.RawMessage `json:"body"`
+			} `json:"body"`
+		}
+		if err := json.Unmarshal(raw, &env); err != nil {
+			continue
+		}
+		if env.Type != "channel" {
+			continue
+		}
+		c.mu.Lock()
+		c.queue = append(c.queue, channelMessage{
+			ChannelID: env.Body.ID,
+			EventType: env.Body.Type,
+			Body:      env.Body.Body,
+		})
+		c.cond.Broadcast()
+		c.mu.Unlock()
+	}
+}
+
+// SendChannel は `ch` envelope (channel への in-band message) を送る。
+// (Misskey TS の channel.api.send 相当)。
+func (c *streamingClient) SendChannel(msgType string, body any) {
+	c.t.Helper()
+	require.NoError(c.t, c.conn.WriteJSON(map[string]any{
+		"type": "ch",
+		"body": map[string]any{
+			"id":   c.channelID,
+			"type": msgType,
+			"body": body,
+		},
+	}))
+}
+
+// WaitForEvent は queue から指定 eventType の最初の message を timeout 内に
+// 取り出す。見つからなければ test を fail させる。queue 内で順序を保ち、
+// 既に消費した message は再度返さない (テスト間で混線しない)。
+func (c *streamingClient) WaitForEvent(eventType string, timeout time.Duration) channelMessage {
+	c.t.Helper()
+	deadline := time.Now().Add(timeout)
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	for {
+		for i, m := range c.queue {
+			if m.EventType == eventType {
+				// 取り出して残りを slide
+				c.queue = append(c.queue[:i], c.queue[i+1:]...)
+				return m
+			}
+		}
+		if c.closed {
+			c.t.Fatalf("connection closed while waiting for event %q (queue=%+v)", eventType, c.queue)
+		}
+		remain := time.Until(deadline)
+		if remain <= 0 {
+			c.t.Fatalf("timed out waiting for event %q (queue=%+v)", eventType, c.queue)
+		}
+		// cond.Wait に timeout を持たせるための小工夫: Goroutine で
+		// 一定時間後 Broadcast を投げる。
+		notified := make(chan struct{})
+		go func() {
+			ctx, cancel := context.WithTimeout(context.Background(), remain)
+			defer cancel()
+			<-ctx.Done()
+			c.mu.Lock()
+			c.cond.Broadcast()
+			c.mu.Unlock()
+			close(notified)
+		}()
+		c.cond.Wait()
+		// notified goroutine は cleanup される
+		_ = notified
+	}
+}
+
+// Close は disconnect envelope を送出して WebSocket を閉じる。t.Cleanup で
+// 自動呼び出し。複数回呼んでも no-op。
+func (c *streamingClient) Close() {
+	c.closeOnce.Do(func() {
+		_ = c.conn.WriteJSON(map[string]any{
+			"type": "disconnect",
+			"body": map[string]any{"id": c.channelID},
+		})
+		_ = c.conn.Close()
+	})
+}


### PR DESCRIPTION
## Summary

#435 follow-up #781。reversi の Ready / PutStone / Surrender は WebSocket stream channel 経由で動く設計のため、e2e_federation 用に **WebSocket test client** を整備し残 3 case を実装する。本 PR で **#435 の全 6 case が test として動作**する状態に。

## 追加 helper

### \`test/e2e_federation/streaming_helpers_test.go\` (新規)

WebSocket /streaming への接続 + Misskey の channel envelope プロトコル (\`connect\` / \`ch\` / \`disconnect\`) を扱う最小 client:

- \`dialStreaming\`: token 付き /streaming への WebSocket dial
- \`connectChannel\`: connect envelope 送出 + receive goroutine + queue 蓄積
- \`streamingClient.SendChannel\`: channel に in-band message を送る
- \`streamingClient.WaitForEvent\`: queue から指定 eventType を timeout 付きで取り出す
- \`streamingClient.Close\`: disconnect envelope + WebSocket close (\`t.Cleanup\` で自動)

reversi 以外の channel (note / chat 等) test にも流用可能な汎用 helper。

### \`test/e2e_federation/reversi_test.go\` (拡充)

- \`inviteAndAccept\`: 招待 + 受諾フロー (reset-db / signup / warm cache / match / match-back) を 1 関数に集約。両 server の game ID を返す
- \`readyAndStart\`: inviteAndAccept の上で両 channel subscribe → Ready 双方送出 → \`started\` event 受信まで自動化
- \`blackUser\`: \`game.Black\` (1 or 2) を見て黒番の token/ws を解決 (\`bw=random\` は session id 由来なので動的解決が必要)

## 追加 test (#435 残 3 case)

| Test | 検証内容 |
|---|---|
| \`TestReversi_ReadyPropagatesAndStarts\` | 両 server の WebSocket で Ready=true → \`started\` event を両 ws で受信 + DB の \`IsStarted=true\` を両側で確認 |
| \`TestReversi_PutStonePropagates\` | started 後、黒番が putStone → 両 channel で \`log\` event を受信 + 両 DB の logs が空でないことを確認 |
| \`TestReversi_SurrenderEndsBothSides\` | started 後、HTTP /surrender → 両 server の \`IsEnded=true\` を確認 (federation Leave で B 側にも反映) |

## #435 全体の状態

| Case | 元 test 設計 | 実装 |
|---|---|---|
| 1. LocalInviteRoundTrip | HTTP only | PASS (#779/#782) |
| 2. SettingsAndReadyPropagate | WebSocket | PASS (Ready 部分のみ) |
| 3. PutStonePropagates | WebSocket | PASS |
| 4. SurrenderEndsBothSides | HTTP + WebSocket setup | PASS |
| 5. CancelMatchUndoesPreStart | HTTP only | PASS (#782) |
| 6. ReactionURIInboxNoCrash | inbox direct | PASS (#779) |

**全 6 case が test として動作**。reversi 連合の regression を CI で検出できる状態に。

## scope guard

- **updateSettings の federation propagation** は reversi 側挙動が flaky で本 PR scope 外。元 issue body の case 2 のうち "Settings 部分" は割愛し、Ready propagation だけで Started まで持っていく形に簡素化
- **mkq queue worker pickup** は依然未解決だが、sync hook (#782) で federation deliver を inline 駆動できるので test infra としては問題なし。production 経路 (queue 駆動 deliver) は別途 follow-up で root cause 修正

## テスト

- \`go test ./test/e2e_federation/... -count=1\` 全 pass (reversi 6 case + 既存 note/user 系)
- production code 変更なし (test 専用 helper の追加のみ)

## Closes

#781

🤖 Generated with [Claude Code](https://claude.com/claude-code)