### PR TITLE
Fix #743 (part 1): test 用 Dockerfile の Go base image を 1.25 → 1.26 bump

### DIFF
--- a/tests/federation/common/Dockerfile.mkgo
+++ b/tests/federation/common/Dockerfile.mkgo
@@ -6,7 +6,7 @@
 #
 # Build context must be the repository root.
 # `# syntax=` directive は BuildKit cache mount 用 (#432)。
-FROM golang:1.25-alpine AS builder
+FROM golang:1.26-alpine AS builder
 
 RUN apk add --no-cache git build-base
 

--- a/tests/queue-bench/blackhole/Dockerfile
+++ b/tests/queue-bench/blackhole/Dockerfile
@@ -1,5 +1,5 @@
 # syntax=docker/dockerfile:1.7
-FROM golang:1.25-alpine AS builder
+FROM golang:1.26-alpine AS builder
 WORKDIR /src
 COPY go.mod go.sum ./
 RUN --mount=type=cache,target=/go/pkg/mod go mod download

--- a/tests/queue-bench/faker/Dockerfile
+++ b/tests/queue-bench/faker/Dockerfile
@@ -1,5 +1,5 @@
 # syntax=docker/dockerfile:1.7
-FROM golang:1.25-alpine AS builder
+FROM golang:1.26-alpine AS builder
 WORKDIR /src
 COPY go.mod go.sum ./
 RUN --mount=type=cache,target=/go/pkg/mod go mod download


### PR DESCRIPTION
## Summary

#743 の調査で判明した dropin-e2e nightly の 5/5 失敗原因を解消する。PR #746 (Go 1.25 → 1.26.2 アップグレード) で go.mod の \`go\` directive が \`1.26.2\` に bump されたが、test 用 Dockerfile (drop-in / queue-bench) の base image が \`golang:1.25-alpine\` のまま放置されていた。

## 直近の失敗ログ

\`\`\`
#18 [builder 5/7] RUN --mount=type=cache,target=/go/pkg/mod     go mod download
#18 0.125 go: go.mod requires go >= 1.26.2 (running go 1.25.9; GOTOOLCHAIN=local)
#18 ERROR: process \"/bin/sh -c go mod download\" did not complete successfully: exit code: 1
\`\`\`

## 変更点

3 つの test 用 Dockerfile の \`FROM\` 行を \`golang:1.26-alpine\` に bump:

- \`tests/federation/common/Dockerfile.mkgo\` — drop-in compose (dropin-e2e / dropin-frontend-e2e の swap phase で使用)
- \`tests/queue-bench/faker/Dockerfile\` — queue-bench 補助 (現状 nightly に乗っていないが将来的影響あり)
- \`tests/queue-bench/blackhole/Dockerfile\` — 同上

main \`Dockerfile\` と \`deploy/uds/Dockerfile.mkgo\` は #746 で更新済み。

## ローカル検証

\`make dropin-swap-test\` で build phase が通過することを確認。

## scope guard / 残課題

ローカル実行で test_swap_verify (mk-A 切替後) が **別の error で連続失敗** することが判明:

\`\`\`
RuntimeError: POST /api/admin/update-meta failed (403):
  {\"error\":{\"code\":\"ROLE_PERMISSION_DENIED\",
    \"message\":\"You are not an administrator.\"}}
\`\`\`

TS-A で root 作成された alice が mk-A 切替後に admin として認識されない drop-in 互換性 regression。本 PR では **Go version bump のみ** を対象とし、admin role 認識問題は別 issue / 別 PR で対応する。

## 関連

- #743 (part 1)
- #745 / #746 (Go 1.26.2 アップグレード PR、Dockerfile 更新漏れの上流)

🤖 Generated with [Claude Code](https://claude.com/claude-code)