### PR TITLE
Fix #785: drop-in 互換 — TS root user (user.isRoot) を mk-go でも認識

### DIFF
--- a/internal/core/role/role_service.go
+++ b/internal/core/role/role_service.go
@@ -3,12 +3,14 @@ package role
 import (
 	"encoding/json"
 	"errors"
+	"log/slog"
 	"sync"
 	"time"
 
 	"github.com/shiroha-a/mk/internal/misc/id"
 	"github.com/shiroha-a/mk/internal/model"
 	"github.com/shiroha-a/mk/internal/repository"
+	"gorm.io/gorm"
 )
 
 var (
@@ -74,6 +76,9 @@ func NewService(
 // user.isRoot column for drop-in compatibility with Misskey TS DBs that
 // don't populate meta.rootUserId (#785). Optional; when nil the service
 // behaves as before (meta.rootUserId-only check).
+//
+// 想定は wire-time only (server.setupRoutes 経由)。HTTP リスナー起動後の
+// 再代入は isRootUser 側の concurrent read と race するので呼ばないこと。
 func (s *Service) SetUserRepo(r repository.UserRepository) {
 	s.userRepo = r
 }
@@ -139,8 +144,19 @@ func (s *Service) isRootUser(userID string) bool {
 		return true
 	}
 	if s.userRepo != nil {
-		if u, err := s.userRepo.FindByID(userID); err == nil && u != nil && u.IsRoot {
-			return true
+		u, err := s.userRepo.FindByID(userID)
+		switch {
+		case err == nil:
+			if u != nil && u.IsRoot {
+				return true
+			}
+		case errors.Is(err, gorm.ErrRecordNotFound):
+			// 削除済みユーザー / 不正な userID は root ではない、ログ不要。
+		default:
+			// 接続不良などの transient な障害は観測したい (admin path 限定で
+			// 頻度が低いのでログコストは無視できる)。
+			slog.Warn("role.isRootUser: userRepo.FindByID failed",
+				"userID", userID, "err", err)
 		}
 	}
 	return false

--- a/internal/core/role/role_service.go
+++ b/internal/core/role/role_service.go
@@ -38,6 +38,14 @@ type Service struct {
 	assignmentRepo repository.RoleAssignmentRepository
 	metaRepo       repository.MetaRepository
 	idGen          id.Generator
+	// userRepo は drop-in 互換 (#785) のため optional に注入される。
+	// Misskey TS upstream で signup された root user は user.isRoot=true で
+	// 識別され meta.rootUserId は set されない。drop-in で TS DB を引き継いだ
+	// mk-go は meta.rootUserId が nil → isRootUser false → admin path で 403
+	// となる regression を防ぐため、user.isRoot フラグを fallback として
+	// 確認する。本番経路 (mk-go pure) では meta.rootUserId が常に set される
+	// ので setter で wire しなくても挙動は変わらない (= 後方互換性は保たれる)。
+	userRepo repository.UserRepository
 
 	// userRoleCache は GetUserRoles 結果の per-user TTL キャッシュ
 	// (sync.Map で hot path に lock を持ち込まない)。Assign / Unassign で
@@ -60,6 +68,14 @@ func NewService(
 		metaRepo:       metaRepo,
 		idGen:          idGen,
 	}
+}
+
+// SetUserRepo wires a UserRepository so isRootUser can fall back to the
+// user.isRoot column for drop-in compatibility with Misskey TS DBs that
+// don't populate meta.rootUserId (#785). Optional; when nil the service
+// behaves as before (meta.rootUserId-only check).
+func (s *Service) SetUserRepo(r repository.UserRepository) {
+	s.userRepo = r
 }
 
 // InvalidateUserRoleCache drops the cached role list for userID. Out-of-band
@@ -111,13 +127,23 @@ func (s *Service) GetUserRoles(userID string) ([]*model.Role, error) {
 	return roles, nil
 }
 
-// isRootUser checks if the user is the root user (meta.rootUserId).
+// isRootUser checks if the user is the root user.
+//
+//  1. meta.rootUserId と一致 (mk-go native パス)
+//  2. user.isRoot=true (drop-in 互換、Misskey TS DB から引き継いだ場合の
+//     fallback。userRepo が SetUserRepo で wire 済みのときのみ確認、#785)
+//
+// userRepo 未配線でも (1) のみで動作するので既存テスト互換性は保たれる。
 func (s *Service) isRootUser(userID string) bool {
-	meta, err := s.metaRepo.Fetch()
-	if err != nil {
-		return false
+	if meta, err := s.metaRepo.Fetch(); err == nil && meta.RootUserID != nil && *meta.RootUserID == userID {
+		return true
 	}
-	return meta.RootUserID != nil && *meta.RootUserID == userID
+	if s.userRepo != nil {
+		if u, err := s.userRepo.FindByID(userID); err == nil && u != nil && u.IsRoot {
+			return true
+		}
+	}
+	return false
 }
 
 // IsAdministrator checks if the user has any administrator role or is root.

--- a/internal/core/role/role_service_test.go
+++ b/internal/core/role/role_service_test.go
@@ -64,6 +64,56 @@ func TestIsAdministrator_RootUser(t *testing.T) {
 	assert.True(t, svc.IsAdministrator("root1"))
 }
 
+// drop-in 互換 (#785): TS DB を引き継いだ場合は meta.rootUserId が nil の
+// まま user.isRoot=true で root が記録されるので、SetUserRepo 経由で
+// fallback できる必要がある。
+func TestIsAdministrator_DropInRoot_UserIsRootFallback(t *testing.T) {
+	svc, _, _, metaRepo := newTestService(t)
+	metaRepo.Meta = &model.Meta{ID: "x"} // RootUserID は nil
+	userRepo := testutil.NewMockUserRepository()
+	require.NoError(t, userRepo.Create(&model.User{ID: "alice", Username: "alice", IsRoot: true}))
+	svc.SetUserRepo(userRepo)
+
+	assert.True(t, svc.IsAdministrator("alice"))
+}
+
+// user.isRoot=false のユーザーを fallback で誤って root 判定しないこと。
+func TestIsAdministrator_DropIn_NonRootUser_NotPromoted(t *testing.T) {
+	svc, _, _, metaRepo := newTestService(t)
+	metaRepo.Meta = &model.Meta{ID: "x"}
+	userRepo := testutil.NewMockUserRepository()
+	require.NoError(t, userRepo.Create(&model.User{ID: "bob", Username: "bob", IsRoot: false}))
+	svc.SetUserRepo(userRepo)
+
+	assert.False(t, svc.IsAdministrator("bob"))
+}
+
+// SetUserRepo 未配線時は従来どおり meta.rootUserId のみで判定する
+// (後方互換性 regression guard)。
+func TestIsAdministrator_NoUserRepoWired_BehavesAsBefore(t *testing.T) {
+	svc, _, _, metaRepo := newTestService(t)
+	rootID := "root1"
+	metaRepo.Meta = &model.Meta{ID: "x", RootUserID: &rootID}
+	// SetUserRepo は呼ばない
+
+	assert.True(t, svc.IsAdministrator("root1"))
+	assert.False(t, svc.IsAdministrator("other"))
+}
+
+// userRepo.FindByID が transient error (RecordNotFound 以外) を返した場合は
+// silent に false 扱い (admin 昇格に倒さない方が安全)。slog.Warn は出すが
+// 現状 logger を inject しないので副作用のみ確認。
+func TestIsAdministrator_UserRepoTransientError_FallsThrough(t *testing.T) {
+	svc, _, _, metaRepo := newTestService(t)
+	metaRepo.Meta = &model.Meta{ID: "x"}
+	svc.SetUserRepo(&errorUserRepo{
+		MockUserRepository: testutil.NewMockUserRepository(),
+		err:                assert.AnError,
+	})
+
+	assert.False(t, svc.IsAdministrator("alice"))
+}
+
 func TestIsAdministrator_AdminRole(t *testing.T) {
 	svc, roleRepo, assignRepo, metaRepo := newTestService(t)
 	metaRepo.Meta = &model.Meta{ID: "x"}
@@ -640,6 +690,20 @@ func TestListByRole_RepoError(t *testing.T) {
 
 	_, err := svc.ListByRole("r1", "", "", 10)
 	assert.Error(t, err)
+}
+
+// errorUserRepo は FindByID で任意の error を返す UserRepository stub。
+// ErrRecordNotFound 以外の transient な error 経路 (#785 fallback の
+// silent failure 動作) を検証するために MockUserRepository を embed する
+// (他のメソッドが将来呼ばれても nil deref しないよう必ず初期化済みの mock
+// をセットすること)。
+type errorUserRepo struct {
+	*testutil.MockUserRepository
+	err error
+}
+
+func (e *errorUserRepo) FindByID(_ string) (*model.User, error) {
+	return nil, e.err
 }
 
 // failingListByRoleAssignRepo は ListByRole で error を返す stub。

--- a/internal/core/signup/signup_service.go
+++ b/internal/core/signup/signup_service.go
@@ -159,6 +159,11 @@ func (s *Service) Signup(username, password string, isInitialSetup bool) (*Signu
 		Token:             &token,
 		IsExplorable:      true,
 		AvatarDecorations: []byte("[]"),
+		// drop-in 互換 (#785): Misskey TS と同じ意味で初回 signup user を
+		// isRoot=true でマークしておく。mk-go pure 経路では meta.rootUserId
+		// で root を判定するので冗長だが、TS との bidirectional drop-in を
+		// 担保するためマーカーを揃える。
+		IsRoot: isInitialSetup,
 	}
 	if err := s.userRepo.Create(user); err != nil {
 		return nil, err

--- a/internal/model/user.go
+++ b/internal/model/user.go
@@ -10,13 +10,19 @@ import (
 // User represents the `user` table.
 // Misskey互換のカラム名・型を維持する
 type User struct {
-	ID                           string         `gorm:"column:id;type:varchar(32);primaryKey" json:"id"`
-	UpdatedAt                    *time.Time     `gorm:"column:updatedAt;type:timestamp with time zone" json:"updatedAt"`
-	LastFetchedAt                *time.Time     `gorm:"column:lastFetchedAt;type:timestamp with time zone" json:"lastFetchedAt"`
-	LastActiveDate               *time.Time     `gorm:"column:lastActiveDate;type:timestamp with time zone" json:"lastActiveDate"`
-	HideOnlineStatus             bool           `gorm:"column:hideOnlineStatus;default:false" json:"hideOnlineStatus"`
-	Username                     string         `gorm:"column:username;type:varchar(128);not null" json:"username"`
-	UsernameLower                string         `gorm:"column:usernameLower;type:varchar(128);not null" json:"usernameLower"`
+	ID               string     `gorm:"column:id;type:varchar(32);primaryKey" json:"id"`
+	UpdatedAt        *time.Time `gorm:"column:updatedAt;type:timestamp with time zone" json:"updatedAt"`
+	LastFetchedAt    *time.Time `gorm:"column:lastFetchedAt;type:timestamp with time zone" json:"lastFetchedAt"`
+	LastActiveDate   *time.Time `gorm:"column:lastActiveDate;type:timestamp with time zone" json:"lastActiveDate"`
+	HideOnlineStatus bool       `gorm:"column:hideOnlineStatus;default:false" json:"hideOnlineStatus"`
+	Username         string     `gorm:"column:username;type:varchar(128);not null" json:"username"`
+	UsernameLower    string     `gorm:"column:usernameLower;type:varchar(128);not null" json:"usernameLower"`
+	// IsRoot: Misskey TS upstream の "instance root" マーカー。drop-in 互換
+	// (TS で signup した最初のユーザーは isRoot=true 行を持つが mk-go の
+	// rootUserId フィールドは set されていない) のため、本フィールドを読み
+	// 取って role.Service.IsAdministrator が true を返すよう fallback する
+	// (#785)。mk-go signup でも同時に true を書く (forward compat)。
+	IsRoot                       bool           `gorm:"column:isRoot;default:false" json:"isRoot"`
 	Name                         *string        `gorm:"column:name;type:varchar(128)" json:"name"`
 	FollowersCount               int            `gorm:"column:followersCount;default:0" json:"followersCount"`
 	FollowingCount               int            `gorm:"column:followingCount;default:0" json:"followingCount"`

--- a/internal/server/router.go
+++ b/internal/server/router.go
@@ -190,6 +190,11 @@ func (s *Server) setupRoutes() {
 
 	// Core services
 	roleService := corerole.NewService(roleRepo, roleAssignmentRepo, metaRepo, idGen)
+	// drop-in 互換 (#785): Misskey TS は signup root user を user.isRoot=true で
+	// マークし meta.rootUserId は set しない。TS DB を引き継いだ mk-go では
+	// meta.rootUserId=nil となり admin paths で 403 が返る regression を防ぐ
+	// ため、role.Service に userRepo を渡して user.isRoot fallback を有効化する。
+	roleService.SetUserRepo(userRepo)
 	signupService := coresignup.NewService(userRepo, metaRepo, idGen)
 	// ActivityPub 配信のためにローカルユーザーは RSA 鍵対を必要とする。
 	signupService.SetKeypairRepo(keypairRepo)

--- a/migration/000046_user_is_root.down.sql
+++ b/migration/000046_user_is_root.down.sql
@@ -1,4 +1,5 @@
 -- 000046 の rollback。drop-in 経路で TS が同名 column を持っていた場合に
--- DROP すると TS への切り戻しでデータ損失するため、本番 DB では down は実質
--- no-op に近い (DROP IF EXISTS は実行するが TS が再起動時に再作成する)。
+-- DROP すると TS への切り戻しで isRoot 値が失われるため、運用上 down は
+-- 慎重に。DROP IF EXISTS は実行するが、TS に切り戻す際は TS の migration
+-- が同 column を再作成する (ただし isRoot=true は復元されない)。
 ALTER TABLE "user" DROP COLUMN IF EXISTS "isRoot";

--- a/migration/000046_user_is_root.down.sql
+++ b/migration/000046_user_is_root.down.sql
@@ -1,0 +1,4 @@
+-- 000046 の rollback。drop-in 経路で TS が同名 column を持っていた場合に
+-- DROP すると TS への切り戻しでデータ損失するため、本番 DB では down は実質
+-- no-op に近い (DROP IF EXISTS は実行するが TS が再起動時に再作成する)。
+ALTER TABLE "user" DROP COLUMN IF EXISTS "isRoot";

--- a/migration/000046_user_is_root.up.sql
+++ b/migration/000046_user_is_root.up.sql
@@ -1,0 +1,13 @@
+-- user.isRoot column を追加 (#785)。
+--
+-- Misskey TS upstream は signup された最初のユーザー (= instance owner) を
+-- user.isRoot=true でマークする。一方 mk-go は meta.rootUserId で root 判別
+-- していたため、TS DB を引き継いだ drop-in 環境では root が認識されず admin
+-- path で 403 (ROLE_PERMISSION_DENIED) になる regression があった。
+--
+-- 本 migration で mk-go pure に build した DB にも isRoot column を持たせ、
+-- role.Service.isRootUser が user.isRoot を fallback として読めるようにする。
+-- 既に TS 由来の DB (drop-in 経路で TS が schema を作ったケース) には column
+-- が存在しているので IF NOT EXISTS で idempotent に。
+ALTER TABLE "user"
+    ADD COLUMN IF NOT EXISTS "isRoot" boolean NOT NULL DEFAULT false;


### PR DESCRIPTION
## Summary

#743 (drop-in nightly 修復) part 2。\`make dropin-swap-test\` が完全 green に戻る core fix。

Misskey TS upstream は signup された最初のユーザー (= instance owner) を \`user.isRoot=true\` でマークするが、mk-go は \`meta.rootUserId\` で root を判別していたため、TS DB を引き継いだ drop-in 環境で root 認識が壊れていた。

## 失敗していた経路

\`\`\`
POST /api/admin/update-meta failed (403):
{
  \"error\": {
    \"code\": \"ROLE_PERMISSION_DENIED\",
    \"id\": \"c3d38592-54c0-429d-bfe8-f1571e00eb14\",
    \"message\": \"You are not an administrator.\"
  }
}
\`\`\`

DB inspect で確認:

\`\`\`sql
-- TS-A の DB (alice signup 後)
SELECT id, \"rootUserId\" FROM meta;
-- ERROR: column \"rootUserId\" does not exist  ← TS は持たない

SELECT id, username, \"isRoot\" FROM \"user\" WHERE username = 'alice';
-- alxcrqh6mk7q0001 | alice | t  ← TS は user.isRoot で記録
\`\`\`

## 変更点

### Model / 永続化

- \`model.User\` に \`IsRoot bool\` field を追加 (\`column:isRoot;default:false\`)
- 新規 migration \`000046_user_is_root.up.sql\` で \`ALTER TABLE \"user\" ADD COLUMN IF NOT EXISTS \"isRoot\"\`。\`IF NOT EXISTS\` で idempotent (TS 由来の DB は既に column を持っているので no-op)

### role.Service

- \`SetUserRepo(repository.UserRepository)\` setter を追加 (optional 注入)
- \`isRootUser\` を 2 段階 fallback に拡張:
  1. \`meta.rootUserId == userID\` (mk-go native)
  2. \`user.isRoot == true\` (drop-in 互換、TS DB 由来)

### signup

- \`user.IsRoot = isInitialSetup\` を同時に書き込み (forward compat: mk-go pure 経路で signup された root も TS で root として認識される)

### server wiring

- \`router.go\` で \`roleService.SetUserRepo(userRepo)\` を wire

## ローカル検証

\`\`\`
$ make dropin-swap-test
test_swap_setup.py:: 6 passed
test_swap_verify.py:: 8 passed  ← 直前まで 0/8
===> all stages PASS
\`\`\`

\`go test ./internal/core/role/... ./internal/core/signup/...\` も全 pass。

## 互換性

| シナリオ | 動作 |
|---|---|
| mk-go pure (本番) | \`meta.rootUserId\` 経路で従来どおり判定 (既存動作不変) |
| drop-in (TS → mk-go) | \`user.isRoot\` fallback で root 認識 (本 PR の目的) |
| drop-in (mk-go → TS) | mk-go signup でも \`user.isRoot\` を書くので TS 切替後の TS 側 RoleService が root を認識 |
| 後方互換 (\`SetUserRepo\` 未配線) | 従来どおり \`meta.rootUserId\` のみで判定、安全 |

## Closes

#785

## 関連

- #743 part 2 (nightly 修復、本 PR で test_swap_verify 経路 green)
- #784 part 1 (Dockerfile Go bump、build phase 修復)

🤖 Generated with [Claude Code](https://claude.com/claude-code)