### PR TITLE
Fix #787: ワードミュート (soft + hard) を完全実装

### DIFF
--- a/internal/api/antennas/handler.go
+++ b/internal/api/antennas/handler.go
@@ -8,6 +8,7 @@ import (
 	"github.com/labstack/echo/v4"
 	"github.com/shiroha-a/mk/internal/api/apierr"
 	coreantenna "github.com/shiroha-a/mk/internal/core/antenna"
+	"github.com/shiroha-a/mk/internal/core/notesfilter"
 	"github.com/shiroha-a/mk/internal/entity"
 	"github.com/shiroha-a/mk/internal/misc/id"
 	"github.com/shiroha-a/mk/internal/model"
@@ -24,6 +25,15 @@ type Handler struct {
 	emojiRepo    repository.EmojiRepository
 	bufReader    entity.BufferedReactionsReader
 	fieldRes     *entity.NoteFieldResolver
+	// userRepo は antennas/notes の hardMutedWords filter (#787) のために
+	// viewer profile を引く。未配線時は filter skip。
+	userRepo repository.UserRepository
+}
+
+// SetUserRepo wires a UserRepository so antennas/notes filters out notes that
+// match the viewer's hardMutedWords (#787).
+func (h *Handler) SetUserRepo(r repository.UserRepository) {
+	h.userRepo = r
 }
 
 // SetNoteFieldResolver attaches the shared resolver that fills Files /
@@ -269,6 +279,7 @@ func (h *Handler) Notes(c echo.Context) error {
 	if err != nil {
 		return apierr.JSONInternalError(c)
 	}
+	notes = notesfilter.ApplyHardMute(h.userRepo, user, notes)
 	entities := entity.PackNotes(c.Request().Context(), notes, h.idGen, h.instanceLookup(), h.emojiLookup(), h.reactionReader())
 	h.fieldRes.Apply(entities, user)
 	out := make([]any, 0, len(entities))

--- a/internal/api/channels/handler.go
+++ b/internal/api/channels/handler.go
@@ -8,6 +8,7 @@ import (
 	"github.com/labstack/echo/v4"
 	"github.com/shiroha-a/mk/internal/api/apierr"
 	corechannel "github.com/shiroha-a/mk/internal/core/channel"
+	"github.com/shiroha-a/mk/internal/core/notesfilter"
 	"github.com/shiroha-a/mk/internal/entity"
 	"github.com/shiroha-a/mk/internal/misc/id"
 	"github.com/shiroha-a/mk/internal/model"
@@ -26,6 +27,14 @@ type Handler struct {
 	emojiRepo     repository.EmojiRepository
 	bufReader     entity.BufferedReactionsReader
 	fieldRes      *entity.NoteFieldResolver
+	// userRepo は channels/timeline の hardMutedWords filter (#787)。
+	userRepo repository.UserRepository
+}
+
+// SetUserRepo wires a UserRepository so channels/timeline filters out notes
+// that match the viewer's hardMutedWords (#787).
+func (h *Handler) SetUserRepo(r repository.UserRepository) {
+	h.userRepo = r
 }
 
 // ChannelFollowingChecker covers the subset of ChannelFollowingRepository
@@ -349,6 +358,7 @@ func (h *Handler) Timeline(c echo.Context) error {
 		return apierr.JSONInternalError(c)
 	}
 	viewer := middleware.GetUser(c)
+	notes = notesfilter.ApplyHardMute(h.userRepo, viewer, notes)
 	entities := entity.PackNotes(c.Request().Context(), notes, h.idGen, h.instanceLookup(), h.emojiLookup(), h.reactionReader())
 	h.fieldRes.Apply(entities, viewer)
 	out := make([]any, 0, len(entities))

--- a/internal/api/clips/handler.go
+++ b/internal/api/clips/handler.go
@@ -8,6 +8,7 @@ import (
 	"github.com/labstack/echo/v4"
 	"github.com/shiroha-a/mk/internal/api/apierr"
 	coreclip "github.com/shiroha-a/mk/internal/core/clip"
+	"github.com/shiroha-a/mk/internal/core/notesfilter"
 	"github.com/shiroha-a/mk/internal/entity"
 	"github.com/shiroha-a/mk/internal/misc/id"
 	"github.com/shiroha-a/mk/internal/model"
@@ -24,6 +25,15 @@ type Handler struct {
 	emojiRepo    repository.EmojiRepository
 	bufReader    entity.BufferedReactionsReader
 	fieldRes     *entity.NoteFieldResolver
+	// userRepo は clips/notes 経由で他人の clip を閲覧する際の hardMutedWords
+	// filter (#787) のために viewer profile を引く。未配線時は filter skip。
+	userRepo repository.UserRepository
+}
+
+// SetUserRepo wires a UserRepository so clips/notes filters out notes that
+// match the viewer's hardMutedWords (#787).
+func (h *Handler) SetUserRepo(r repository.UserRepository) {
+	h.userRepo = r
 }
 
 // SetNoteFieldResolver wires the shared resolver that fills Files /
@@ -301,6 +311,7 @@ func (h *Handler) Notes(c echo.Context) error {
 		}
 		return apierr.JSONInternalError(c)
 	}
+	notes = notesfilter.ApplyHardMute(h.userRepo, user, notes)
 	entities := entity.PackNotes(c.Request().Context(), notes, h.idGen, h.instanceLookup(), h.emojiLookup(), h.reactionReader())
 	h.fieldRes.Apply(entities, user)
 	out := make([]any, 0, len(entities))

--- a/internal/api/drive/handler.go
+++ b/internal/api/drive/handler.go
@@ -9,6 +9,7 @@ import (
 	"github.com/labstack/echo/v4"
 	"github.com/shiroha-a/mk/internal/api/apierr"
 	coredrive "github.com/shiroha-a/mk/internal/core/drive"
+	"github.com/shiroha-a/mk/internal/core/notesfilter"
 	"github.com/shiroha-a/mk/internal/entity"
 	"github.com/shiroha-a/mk/internal/misc/id"
 	"github.com/shiroha-a/mk/internal/model"
@@ -487,6 +488,7 @@ func (h *Handler) FilesAttachedNotes(c echo.Context) error {
 		return c.JSON(http.StatusOK, []any{})
 	}
 	viewer := middleware.GetUser(c)
+	notes = notesfilter.ApplyHardMute(h.userRepo, viewer, notes)
 	out := entity.PackNotes(c.Request().Context(), notes, h.idGen, h.instanceLookup(), h.emojiLookup(), h.reactionReader())
 	h.fieldRes.Apply(out, viewer)
 	return c.JSON(http.StatusOK, out)

--- a/internal/api/i/handler.go
+++ b/internal/api/i/handler.go
@@ -1,6 +1,7 @@
 package i
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"errors"
@@ -650,6 +651,15 @@ type UpdateRequest struct {
 	// `[]` (空配列) なら全外し、`[{id,...}, ...]` で上書き。各要素は
 	// avatar_decoration テーブルに登録された id を参照する。
 	AvatarDecorations *[]AvatarDecorationInput `json:"avatarDecorations"`
+	// MutedWords / HardMutedWords は ワードミュート設定 (#787)。
+	// frontend は upstream Misskey TS と同じ `[["foo"], ["bar","baz"]]` 形式
+	// (内側 array が AND、外側が OR) を JSON で送ってくるので変換せず jsonb
+	// 列にそのまま保存する。Bind が json.RawMessage に詰めた段階で内部構造
+	// (string / regex) は触らない。soft mute は frontend が `/api/i` のレス
+	// ポンスから読んで client-side filter、hard mute は backend が TL fetch
+	// 時に CheckWordMute で除外する。
+	MutedWords     json.RawMessage `json:"mutedWords"`
+	HardMutedWords json.RawMessage `json:"hardMutedWords"`
 }
 
 // AvatarDecorationInput is one entry of the avatarDecorations array on
@@ -700,6 +710,37 @@ func backupCodesStock(profile *model.UserProfile) string {
 		return "full"
 	}
 	return "partial"
+}
+
+// normalizeMutedWords validates and normalizes the mutedWords / hardMutedWords
+// payload from i/update. Returns (raw, ok, err): ok=false means "field not
+// present in request" (caller should leave the column unchanged); err != nil
+// means the payload is invalid (caller should 400 the request).
+//
+// Accepts only top-level JSON arrays (including the empty array which clears
+// the column). Internal structure (string | array of string for AND-grouping,
+// regex literals like `/foo/i`) is forwarded verbatim — frontend matches the
+// same wire format and the backend CheckWordMute helper interprets it later.
+func normalizeMutedWords(raw json.RawMessage) (json.RawMessage, bool, error) {
+	if len(raw) == 0 {
+		return nil, false, nil
+	}
+	// `null` は明示的に omit と同義 (frontend が clear 意図で送ることは無い、
+	// upstream paramDef も nullable: false)。
+	trimmed := bytes.TrimSpace(raw)
+	if bytes.Equal(trimmed, []byte("null")) {
+		return nil, false, nil
+	}
+	// top-level が配列であることだけ確認する (内側は CheckWordMute が解釈)。
+	var v any
+	if err := json.Unmarshal(trimmed, &v); err != nil {
+		return nil, false, err
+	}
+	if _, ok := v.([]any); !ok {
+		return nil, false, errors.New("mutedWords must be an array")
+	}
+	out := append(json.RawMessage(nil), trimmed...)
+	return out, true, nil
 }
 
 // containsProhibitedWord reports whether name contains any entry from words
@@ -773,6 +814,20 @@ func (h *Handler) Update(c echo.Context) error {
 		// バイト列を格納する。改変されないよう独自のスライスにコピーする。
 		room := append(json.RawMessage(nil), req.Room...)
 		in.Room = &room
+	}
+	// ワードミュート (#787)。空 byte = field 未指定 (omit) なので不変。
+	// `[]` (= 2 byte の空配列) はクリア要求として通す。validation は配列形式
+	// であることだけ。upstream paramDef も内側構造は `array of (string |
+	// string[])` で、要素 0 個も許容する。
+	if mw, ok, err := normalizeMutedWords(req.MutedWords); err != nil {
+		return apierr.JSONInvalidParam(c)
+	} else if ok {
+		in.MutedWords = &mw
+	}
+	if mw, ok, err := normalizeMutedWords(req.HardMutedWords); err != nil {
+		return apierr.JSONInvalidParam(c)
+	} else if ok {
+		in.HardMutedWords = &mw
 	}
 	if req.AvatarID != nil {
 		in.AvatarID = req.AvatarID

--- a/internal/api/i/handler_test.go
+++ b/internal/api/i/handler_test.go
@@ -733,6 +733,111 @@ func TestUpdate_ProhibitedWordEmptyListSkipped(t *testing.T) {
 	assert.Equal(t, http.StatusOK, rec.Code)
 }
 
+// #787 ワードミュート (mutedWords / hardMutedWords) の persist。
+
+func TestUpdate_MutedWordsAccepted(t *testing.T) {
+	h, repo, _, _ := newTestHandler(t)
+	user := &model.User{
+		ID:                "user1",
+		Username:          "user1",
+		AvatarDecorations: datatypes.JSON([]byte("[]")),
+	}
+	repo.Users["user1"] = user
+	repo.Profiles["user1"] = &model.UserProfile{UserID: "user1", Fields: datatypes.JSON([]byte("[]"))}
+
+	rec := post(h.Update, `{"mutedWords":[["foo"],["bar","baz"]],"hardMutedWords":["spoiler"]}`, user)
+	assert.Equal(t, http.StatusOK, rec.Code)
+
+	got := repo.Profiles["user1"]
+	require.NotNil(t, got)
+	assert.JSONEq(t, `[["foo"],["bar","baz"]]`, string(got.MutedWords))
+	assert.JSONEq(t, `["spoiler"]`, string(got.HardMutedWords))
+}
+
+func TestUpdate_MutedWordsEmptyArrayClears(t *testing.T) {
+	h, repo, _, _ := newTestHandler(t)
+	user := &model.User{
+		ID:                "user1",
+		Username:          "user1",
+		AvatarDecorations: datatypes.JSON([]byte("[]")),
+	}
+	repo.Users["user1"] = user
+	repo.Profiles["user1"] = &model.UserProfile{
+		UserID:         "user1",
+		MutedWords:     datatypes.JSON([]byte(`[["pre-existing"]]`)),
+		HardMutedWords: datatypes.JSON([]byte(`["pre-existing"]`)),
+		Fields:         datatypes.JSON([]byte("[]")),
+	}
+
+	rec := post(h.Update, `{"mutedWords":[],"hardMutedWords":[]}`, user)
+	assert.Equal(t, http.StatusOK, rec.Code)
+
+	got := repo.Profiles["user1"]
+	assert.JSONEq(t, `[]`, string(got.MutedWords))
+	assert.JSONEq(t, `[]`, string(got.HardMutedWords))
+}
+
+func TestUpdate_MutedWordsOmittedLeavesUnchanged(t *testing.T) {
+	h, repo, _, _ := newTestHandler(t)
+	user := &model.User{
+		ID:                "user1",
+		Username:          "user1",
+		AvatarDecorations: datatypes.JSON([]byte("[]")),
+	}
+	repo.Users["user1"] = user
+	repo.Profiles["user1"] = &model.UserProfile{
+		UserID:     "user1",
+		MutedWords: datatypes.JSON([]byte(`[["keep"]]`)),
+		Fields:     datatypes.JSON([]byte("[]")),
+	}
+
+	rec := post(h.Update, `{"name":"renamed"}`, user)
+	assert.Equal(t, http.StatusOK, rec.Code)
+
+	got := repo.Profiles["user1"]
+	assert.JSONEq(t, `[["keep"]]`, string(got.MutedWords))
+}
+
+func TestUpdate_MutedWordsNonArrayRejected(t *testing.T) {
+	h, repo, _, _ := newTestHandler(t)
+	user := &model.User{
+		ID:                "user1",
+		Username:          "user1",
+		AvatarDecorations: datatypes.JSON([]byte("[]")),
+	}
+	repo.Users["user1"] = user
+
+	// 文字列やオブジェクトは reject (frontend 不正実装の防御)。
+	rec := post(h.Update, `{"mutedWords":"foo"}`, user)
+	assert.Equal(t, http.StatusBadRequest, rec.Code)
+
+	rec2 := post(h.Update, `{"hardMutedWords":{"oops":true}}`, user)
+	assert.Equal(t, http.StatusBadRequest, rec2.Code)
+}
+
+func TestUpdate_MutedWordsExplicitNullIsOmit(t *testing.T) {
+	h, repo, _, _ := newTestHandler(t)
+	user := &model.User{
+		ID:                "user1",
+		Username:          "user1",
+		AvatarDecorations: datatypes.JSON([]byte("[]")),
+	}
+	repo.Users["user1"] = user
+	repo.Profiles["user1"] = &model.UserProfile{
+		UserID:     "user1",
+		MutedWords: datatypes.JSON([]byte(`[["keep"]]`)),
+		Fields:     datatypes.JSON([]byte("[]")),
+	}
+
+	// upstream paramDef は nullable: false だが、frontend 不具合で null が
+	// 来たケースは clear ではなく omit と同義に倒す (誤クリア事故防止)。
+	rec := post(h.Update, `{"mutedWords":null}`, user)
+	assert.Equal(t, http.StatusOK, rec.Code)
+
+	got := repo.Profiles["user1"]
+	assert.JSONEq(t, `[["keep"]]`, string(got.MutedWords))
+}
+
 func TestUpdate_RoomOmittedLeavesUnchanged(t *testing.T) {
 	h, repo, _, _ := newTestHandler(t)
 	user := &model.User{

--- a/internal/api/notes/handler.go
+++ b/internal/api/notes/handler.go
@@ -9,6 +9,7 @@ import (
 	"github.com/labstack/echo/v4"
 	"github.com/shiroha-a/mk/internal/api/apierr"
 	"github.com/shiroha-a/mk/internal/core/note"
+	"github.com/shiroha-a/mk/internal/core/notesfilter"
 	"github.com/shiroha-a/mk/internal/core/poll"
 	"github.com/shiroha-a/mk/internal/core/reaction"
 	"github.com/shiroha-a/mk/internal/core/search"
@@ -548,7 +549,13 @@ func (h *Handler) BulkShow(c echo.Context) error {
 // Files / MyReaction / Channel の解決は entity.NoteFieldResolver に切り出して
 // あり、他の PackNotes 利用 handler (antennas / users / pinned 等) と共通化
 // している (#426)。
+//
+// 全 list endpoint (TL / Search / Conversation / Mentions / UserList /
+// SearchByTag) が本関数を経由するので、hardMutedWords の filter (#787) は
+// PackNotes に渡す前に一括で適用する。viewer == nil / userRepo 未配線 /
+// 規則無し のいずれも no-op に倒す best-effort 設計。
 func (h *Handler) packMany(ctx context.Context, notes []*model.Note, viewer *model.User) []entity.NoteEntity {
+	notes = notesfilter.ApplyHardMute(h.userRepo, viewer, notes)
 	out := entity.PackNotes(ctx, notes, h.idGen, h.instanceLookup(), h.emojiLookup(), h.reactionReader())
 	h.fieldResolver().Apply(out, viewer)
 	return out

--- a/internal/api/notes/handler.go
+++ b/internal/api/notes/handler.go
@@ -554,6 +554,11 @@ func (h *Handler) BulkShow(c echo.Context) error {
 // SearchByTag) が本関数を経由するので、hardMutedWords の filter (#787) は
 // PackNotes に渡す前に一括で適用する。viewer == nil / userRepo 未配線 /
 // 規則無し のいずれも no-op に倒す best-effort 設計。
+//
+// 注意: filter を意図的に bypass したい admin 系 path (例: モデレーション目的で
+// 隠さず全件を見せたい / pinned notes 等) は本関数を経由せず entity.PackNotes
+// を直接呼ぶ慣習。pinned (i/show, users/show) と i/favorites は upstream に
+// 揃えて既に packMany を経由していない。
 func (h *Handler) packMany(ctx context.Context, notes []*model.Note, viewer *model.User) []entity.NoteEntity {
 	notes = notesfilter.ApplyHardMute(h.userRepo, viewer, notes)
 	out := entity.PackNotes(ctx, notes, h.idGen, h.instanceLookup(), h.emojiLookup(), h.reactionReader())

--- a/internal/api/roles/handler.go
+++ b/internal/api/roles/handler.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/labstack/echo/v4"
 	"github.com/shiroha-a/mk/internal/api/apierr"
+	"github.com/shiroha-a/mk/internal/core/notesfilter"
 	"github.com/shiroha-a/mk/internal/core/role"
 	"github.com/shiroha-a/mk/internal/entity"
 	"github.com/shiroha-a/mk/internal/misc/id"
@@ -27,6 +28,14 @@ type Handler struct {
 	emojiRepo    repository.EmojiRepository
 	bufReader    entity.BufferedReactionsReader
 	fieldRes     *entity.NoteFieldResolver
+	// userRepo は roles/notes の hardMutedWords filter (#787)。
+	userRepo repository.UserRepository
+}
+
+// SetUserRepo wires a UserRepository so roles/notes filters out notes that
+// match the viewer's hardMutedWords (#787).
+func (h *Handler) SetUserRepo(r repository.UserRepository) {
+	h.userRepo = r
 }
 
 // SetNoteFieldResolver wires the shared resolver that fills Files /
@@ -167,6 +176,7 @@ func (h *Handler) Notes(c echo.Context) error {
 	}
 
 	viewer := middleware.GetUser(c)
+	notes = notesfilter.ApplyHardMute(h.userRepo, viewer, notes)
 	entities := entity.PackNotes(c.Request().Context(), notes, h.idGen, h.instanceLookup(), h.emojiLookup(), h.reactionReader())
 	h.fieldRes.Apply(entities, viewer)
 	out := make([]any, 0, len(entities))

--- a/internal/api/users/handler.go
+++ b/internal/api/users/handler.go
@@ -9,6 +9,7 @@ import (
 	"github.com/labstack/echo/v4"
 	"github.com/shiroha-a/mk/internal/api/apierr"
 	corefollowing "github.com/shiroha-a/mk/internal/core/following"
+	"github.com/shiroha-a/mk/internal/core/notesfilter"
 	"github.com/shiroha-a/mk/internal/core/user"
 	"github.com/shiroha-a/mk/internal/entity"
 	"github.com/shiroha-a/mk/internal/misc/id"
@@ -50,6 +51,15 @@ type Handler struct {
 	pageRepo             repository.PageRepository
 	piningRepo           repository.UserNotePiningRepository
 	fieldRes             *entity.NoteFieldResolver
+	// userRepo は users/notes / users/search-by-username-and-host 経由で
+	// 表示する note list の hardMutedWords filter (#787) に使う。
+	userRepo repository.UserRepository
+}
+
+// SetUserRepo wires a UserRepository so users/notes filters out notes that
+// match the viewer's hardMutedWords (#787).
+func (h *Handler) SetUserRepo(r repository.UserRepository) {
+	h.userRepo = r
 }
 
 // SetNoteFieldResolver wires the shared resolver that fills Files /
@@ -458,6 +468,7 @@ func (h *Handler) Notes(c echo.Context) error {
 	}
 
 	viewer := middleware.GetUser(c)
+	notes = notesfilter.ApplyHardMute(h.userRepo, viewer, notes)
 	out := entity.PackNotes(c.Request().Context(), notes, h.idGen, h.instanceLookup(), h.emojiLookup(), h.reactionReader())
 	h.fieldRes.Apply(out, viewer)
 	return c.JSON(http.StatusOK, out)

--- a/internal/api/users/handler_extra.go
+++ b/internal/api/users/handler_extra.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/labstack/echo/v4"
 	"github.com/shiroha-a/mk/internal/api/apierr"
+	"github.com/shiroha-a/mk/internal/core/notesfilter"
 	"github.com/shiroha-a/mk/internal/entity"
 	"github.com/shiroha-a/mk/internal/model"
 	"github.com/shiroha-a/mk/internal/repository"
@@ -97,6 +98,7 @@ func (h *Handler) FeaturedNotes(c echo.Context) error {
 		return c.JSON(http.StatusInternalServerError, apierr.Error("INTERNAL_ERROR", "Internal error.", "5d37dbcb-891e-41ca-a3d6-e690c97775ac"))
 	}
 	viewer := middleware.GetUser(c)
+	notes = notesfilter.ApplyHardMute(h.userRepo, viewer, notes)
 	result := entity.PackNotes(c.Request().Context(), notes, h.idGen, h.instanceLookup(), h.emojiLookup(), h.reactionReader())
 	h.fieldRes.Apply(result, viewer)
 	return c.JSON(http.StatusOK, result)

--- a/internal/core/notesfilter/hardmute.go
+++ b/internal/core/notesfilter/hardmute.go
@@ -1,0 +1,76 @@
+// Package notesfilter centralises pre-pack filtering steps applied to a
+// []*model.Note before serialization. The first user is the per-viewer
+// hardMutedWords filter (#787) shared across timeline / search / channel /
+// antenna / user-notes / clip / role / drive endpoints, but the package
+// is the natural home for similar viewer-scoped filters added later
+// (e.g. per-host muting, blocked-user enforcement) so they stay together.
+package notesfilter
+
+import (
+	"github.com/shiroha-a/mk/internal/core/wordmute"
+	"github.com/shiroha-a/mk/internal/model"
+)
+
+// ProfileLookup is the minimal subset of repository.UserRepository this
+// package needs. Keeping the interface narrow lets handlers wire only the
+// methods they actually use (the production UserRepository implementation
+// satisfies it automatically) and makes test stubs trivial.
+type ProfileLookup interface {
+	FindProfileByUserID(userID string) (*model.UserProfile, error)
+}
+
+// ApplyHardMute drops notes that match the viewer's persisted
+// hardMutedWords (jsonb on user_profile) before they reach PackNotes.
+//
+// Best-effort semantics: anonymous viewer / lookup not wired / profile
+// fetch error / empty rule list all degrade to "return input untouched"
+// so a transient failure never hides legitimate timeline traffic. The
+// match target follows upstream check-word-mute.ts (cw + "\n" + text)
+// and the viewer's own posts are exempted. Caller passes a lookup the
+// handler already holds; one extra DB read per list endpoint is OK since
+// streaming hot paths use MatchOne with pre-fetched rules.
+func ApplyHardMute(lookup ProfileLookup, viewer *model.User, notes []*model.Note) []*model.Note {
+	if viewer == nil || lookup == nil || len(notes) == 0 {
+		return notes
+	}
+	profile, err := lookup.FindProfileByUserID(viewer.ID)
+	if err != nil || profile == nil || len(profile.HardMutedWords) == 0 {
+		return notes
+	}
+	rules := []byte(profile.HardMutedWords)
+	out := notes[:0]
+	for _, n := range notes {
+		var text, cw string
+		if n.Text != nil {
+			text = *n.Text
+		}
+		if n.CW != nil {
+			cw = *n.CW
+		}
+		if wordmute.MatchNote(rules, n.UserID, viewer.ID, text, cw) {
+			continue
+		}
+		out = append(out, n)
+	}
+	return out
+}
+
+// MatchOne is a single-note convenience used by streaming code paths that
+// publish per-note. Unlike ApplyHardMute the caller already holds the
+// pre-fetched rules JSON (the streaming worker keeps a per-connection
+// cache) so we don't re-fetch the profile on every published note.
+//
+// Returns true when the note should be hidden from the viewer.
+func MatchOne(rulesJSON []byte, viewerID string, n *model.Note) bool {
+	if n == nil || len(rulesJSON) == 0 {
+		return false
+	}
+	var text, cw string
+	if n.Text != nil {
+		text = *n.Text
+	}
+	if n.CW != nil {
+		cw = *n.CW
+	}
+	return wordmute.MatchNote(rulesJSON, n.UserID, viewerID, text, cw)
+}

--- a/internal/core/notesfilter/hardmute_test.go
+++ b/internal/core/notesfilter/hardmute_test.go
@@ -1,0 +1,109 @@
+package notesfilter_test
+
+import (
+	"testing"
+
+	"github.com/shiroha-a/mk/internal/core/notesfilter"
+	"github.com/shiroha-a/mk/internal/model"
+	"github.com/shiroha-a/mk/internal/testutil"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gorm.io/datatypes"
+)
+
+func mkNote(authorID, text, cw string) *model.Note {
+	var pt, pc *string
+	if text != "" {
+		t := text
+		pt = &t
+	}
+	if cw != "" {
+		c := cw
+		pc = &c
+	}
+	return &model.Note{ID: authorID + ":" + text, UserID: authorID, Text: pt, CW: pc}
+}
+
+func TestApplyHardMute_NoLookupWired(t *testing.T) {
+	notes := []*model.Note{mkNote("other", "anything", "")}
+	out := notesfilter.ApplyHardMute(nil, &model.User{ID: "viewer"}, notes)
+	assert.Len(t, out, 1)
+}
+
+func TestApplyHardMute_AnonymousViewer(t *testing.T) {
+	lookup := testutil.NewMockUserRepository()
+	notes := []*model.Note{mkNote("other", "muted text", "")}
+	out := notesfilter.ApplyHardMute(lookup, nil, notes)
+	assert.Len(t, out, 1)
+}
+
+func TestApplyHardMute_EmptyNotes(t *testing.T) {
+	lookup := testutil.NewMockUserRepository()
+	lookup.Profiles["viewer"] = &model.UserProfile{
+		UserID:         "viewer",
+		HardMutedWords: datatypes.JSON([]byte(`["x"]`)),
+	}
+	out := notesfilter.ApplyHardMute(lookup, &model.User{ID: "viewer"}, nil)
+	assert.Empty(t, out)
+}
+
+func TestApplyHardMute_FiltersMutedExemptsSelfAndKeepsClean(t *testing.T) {
+	lookup := testutil.NewMockUserRepository()
+	lookup.Profiles["viewer"] = &model.UserProfile{
+		UserID:         "viewer",
+		HardMutedWords: datatypes.JSON([]byte(`["politics","/spam[0-9]+/i"]`)),
+	}
+	viewer := &model.User{ID: "viewer"}
+	notes := []*model.Note{
+		mkNote("other", "today's politics rant", ""),
+		mkNote("other", "harmless cat photo", ""),
+		mkNote("other", "totally SPAM42 here", ""),
+		mkNote("viewer", "politics by me, should not be filtered", ""),
+	}
+	out := notesfilter.ApplyHardMute(lookup, viewer, notes)
+	require.Len(t, out, 2)
+	assert.Equal(t, "harmless cat photo", *out[0].Text)
+	assert.Equal(t, "viewer", out[1].UserID)
+}
+
+func TestApplyHardMute_MatchesCW(t *testing.T) {
+	lookup := testutil.NewMockUserRepository()
+	lookup.Profiles["viewer"] = &model.UserProfile{
+		UserID:         "viewer",
+		HardMutedWords: datatypes.JSON([]byte(`["spoiler"]`)),
+	}
+	viewer := &model.User{ID: "viewer"}
+	notes := []*model.Note{mkNote("other", "innocuous body", "spoiler ahead")}
+	out := notesfilter.ApplyHardMute(lookup, viewer, notes)
+	assert.Empty(t, out)
+}
+
+func TestApplyHardMute_EmptyRulesIsNoOp(t *testing.T) {
+	lookup := testutil.NewMockUserRepository()
+	lookup.Profiles["viewer"] = &model.UserProfile{UserID: "viewer"}
+	notes := []*model.Note{mkNote("other", "anything", "")}
+	out := notesfilter.ApplyHardMute(lookup, &model.User{ID: "viewer"}, notes)
+	assert.Len(t, out, 1)
+}
+
+func TestApplyHardMute_ProfileFetchErrorDoesNotPanic(t *testing.T) {
+	lookup := testutil.NewMockUserRepository()
+	// viewer の profile を入れない → mock は ErrNotFound を返す
+	notes := []*model.Note{mkNote("other", "any", "")}
+	out := notesfilter.ApplyHardMute(lookup, &model.User{ID: "viewer"}, notes)
+	assert.Len(t, out, 1)
+}
+
+func TestMatchOne(t *testing.T) {
+	rules := []byte(`["topic"]`)
+	n := mkNote("u2", "talking about TOPIC today", "")
+	assert.True(t, notesfilter.MatchOne(rules, "u1", n))
+
+	// viewer 自身の note は match しない
+	own := mkNote("u1", "topic by self", "")
+	assert.False(t, notesfilter.MatchOne(rules, "u1", own))
+
+	// 空 rule / nil note は false
+	assert.False(t, notesfilter.MatchOne(nil, "u1", n))
+	assert.False(t, notesfilter.MatchOne(rules, "u1", nil))
+}

--- a/internal/core/user/user_service.go
+++ b/internal/core/user/user_service.go
@@ -324,6 +324,15 @@ type UpdateInput struct {
 	// `[{id,angle,flipH,offsetX,offsetY}, ...]` で上書き。検証 (catalog
 	// 存在 / role 制限 / 個数上限) はハンドラ側で実施済 (#521)。
 	AvatarDecorations *[]byte
+	// MutedWords / HardMutedWords は jsonb 列にそのまま書き込む。upstream
+	// Misskey TS が受ける `[["foo"], ["bar","baz"]]` 形式 (= 内側配列が AND、
+	// 外側が OR) を変換せず保存する。nil = 不変、`[]` = クリア、配列値 = 上書き。
+	// JSON 構造の妥当性 (= top-level array であること) はハンドラ側で検証する。
+	// 反映: soft mute は frontend の check-word-mute.ts が `/api/i` レスポンスから
+	// 読み取って描画時 filter する。hard mute は本 service と TL handler 経由で
+	// CheckWordMute helper が note を除外する (#787)。
+	MutedWords     *json.RawMessage
+	HardMutedWords *json.RawMessage
 }
 
 // UpdateProfile applies the non-nil fields to the user and user_profile rows.
@@ -390,6 +399,12 @@ func (s *Service) UpdateProfile(userID string, in UpdateInput) (*UserWithProfile
 		// GORM は map で渡された値を jsonb 列に直接書き込む。
 		// []byte を渡すと bytea 扱いされてしまうので string にキャストする。
 		profileFields["room"] = string(*in.Room)
+	}
+	if in.MutedWords != nil {
+		profileFields["mutedWords"] = string(*in.MutedWords)
+	}
+	if in.HardMutedWords != nil {
+		profileFields["hardMutedWords"] = string(*in.HardMutedWords)
 	}
 	if in.AvatarDecorations != nil {
 		// avatarDecorations は user (not user_profile) 側の jsonb 列。

--- a/internal/core/user/user_service_test.go
+++ b/internal/core/user/user_service_test.go
@@ -356,6 +356,34 @@ func TestService_UpdateProfile_Success(t *testing.T) {
 	assert.True(t, bundle.User.IsBot)
 }
 
+// #787: ワードミュート (mutedWords / hardMutedWords) の persist。
+func TestService_UpdateProfile_MutedWords(t *testing.T) {
+	svc, repo, _, _ := newFullSvc(t)
+	repo.Users["u1"] = &model.User{ID: "u1", Username: "alice"}
+
+	mw := json.RawMessage([]byte(`[["foo"],["bar","baz"]]`))
+	hmw := json.RawMessage([]byte(`["spoiler"]`))
+	_, err := svc.UpdateProfile("u1", user.UpdateInput{
+		MutedWords:     &mw,
+		HardMutedWords: &hmw,
+	})
+	require.NoError(t, err)
+
+	got := repo.Profiles["u1"]
+	require.NotNil(t, got)
+	assert.JSONEq(t, `[["foo"],["bar","baz"]]`, string(got.MutedWords))
+	assert.JSONEq(t, `["spoiler"]`, string(got.HardMutedWords))
+
+	// 後続更新で `[]` を渡すと clear。
+	clear := json.RawMessage([]byte(`[]`))
+	_, err = svc.UpdateProfile("u1", user.UpdateInput{MutedWords: &clear})
+	require.NoError(t, err)
+	got = repo.Profiles["u1"]
+	assert.JSONEq(t, `[]`, string(got.MutedWords))
+	// hardMutedWords は omit されたので不変。
+	assert.JSONEq(t, `["spoiler"]`, string(got.HardMutedWords))
+}
+
 // #467: avatarId に SET / CLEAR / 不明 ID / 他人ファイル / 非画像 MIME を
 // 与えたときの挙動を確認する。banner も同経路 (applyMediaUpdate を共有)
 // なので avatar 側で代表させる。

--- a/internal/core/wordmute/wordmute.go
+++ b/internal/core/wordmute/wordmute.go
@@ -88,8 +88,13 @@ var regexLiteral = regexp.MustCompile(`^/(.+)/([gimsuy]*)$`)
 
 // parsedCache stores the parsed rule slice keyed by the *raw* JSON bytes.
 // Hot TL paths call Match many times with the same per-user rule set; parsing
-// once per request is cheap but parsing per-note would be wasteful. Cache size
-// is bounded by user count × tabs so a simple sync.Map is fine.
+// once per request is cheap but parsing per-note would be wasteful.
+//
+// Bound: 実質的に「(active user 数) × (各 user の rule revision)」で抑えられる。
+// rule を変更すると古い JSON byte 列に対応する entry が dangling し続けるので、
+// 大規模インスタンスで運用する場合は LRU 化を検討する (TS upstream は
+// `acCache.size > 1000` で oldest を delete している)。現状は実装簡略のため
+// 単純 sync.Map で受けている。
 var parsedCache sync.Map // string -> []rule
 
 func parse(raw []byte) []rule {
@@ -119,10 +124,25 @@ func parseEntry(e json.RawMessage) rule {
 	var s string
 	if err := json.Unmarshal(e, &s); err == nil {
 		// Misskey TS upstream allows /regex/flags literal as a string entry.
+		// Flags は upstream RE2 (TS) 仕様の i/m/s をサポートする。Go の regexp は
+		// inline flag (?ims) が必要なので prefix で組み立てる。g (global) は Go
+		// regexp の default 動作 (= 全 match) と等価なので無視。u/y は近い等価
+		// 機能が無いが、Go regexp は default で UTF-8 解釈するため u は実質的
+		// に常時 ON、y (sticky) は streaming 用途では使われないので no-op。
 		if m := regexLiteral.FindStringSubmatch(s); m != nil {
 			pattern, flags := m[1], m[2]
-			if strings.ContainsRune(flags, 'i') && !strings.HasPrefix(pattern, "(?i)") {
-				pattern = "(?i)" + pattern
+			var inline string
+			if strings.ContainsRune(flags, 'i') {
+				inline += "i"
+			}
+			if strings.ContainsRune(flags, 'm') {
+				inline += "m"
+			}
+			if strings.ContainsRune(flags, 's') {
+				inline += "s"
+			}
+			if inline != "" && !strings.HasPrefix(pattern, "(?") {
+				pattern = "(?" + inline + ")" + pattern
 			}
 			re, err := regexp.Compile(pattern)
 			if err != nil {

--- a/internal/core/wordmute/wordmute.go
+++ b/internal/core/wordmute/wordmute.go
@@ -1,0 +1,163 @@
+// Package wordmute implements Misskey TS upstream `check-word-mute.ts` for
+// hard mute filtering on the server side (#787). The wire format is the
+// jsonb array stored in user_profile.mutedWords / hardMutedWords:
+//
+//	[
+//	  "single keyword",     // case-insensitive substring match
+//	  ["a", "b"],           // AND group: text must contain every element
+//	  "/regex/i"            // RegExp literal: parsed as Go regexp
+//	]
+//
+// Frontend sends and renders the same shape, so persistence layer never
+// transforms the structure.
+package wordmute
+
+import (
+	"encoding/json"
+	"regexp"
+	"strings"
+	"sync"
+)
+
+// Match returns true if the given combined text should be muted by any of
+// the rules encoded in `rulesJSON` (the raw jsonb bytes from user_profile).
+// `rulesJSON` may be nil / empty / `null` / `[]` — all of those mean no rule.
+//
+// `text` is the already-normalized search target. Callers that want to mute
+// based on note content should pass `cw + "\n" + text` (matching upstream's
+// concatenation). When the text is empty after trim, no rule can hit so the
+// function returns false fast.
+func Match(rulesJSON []byte, text string) bool {
+	text = strings.TrimSpace(text)
+	if text == "" {
+		return false
+	}
+	rules := parse(rulesJSON)
+	if len(rules) == 0 {
+		return false
+	}
+	lowered := strings.ToLower(text)
+	for _, r := range rules {
+		switch v := r.(type) {
+		case stringRule:
+			if strings.Contains(lowered, string(v)) {
+				return true
+			}
+		case andRule:
+			hit := true
+			for _, kw := range v {
+				if !strings.Contains(lowered, kw) {
+					hit = false
+					break
+				}
+			}
+			if hit {
+				return true
+			}
+		case regexRule:
+			if v.re != nil && v.re.MatchString(text) {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// rule is one parsed entry of the muted-words array.
+type rule any
+
+// stringRule represents a single keyword. Stored already-lowercased so the
+// hot path can compare against `strings.ToLower(text)` without re-allocating.
+type stringRule string
+
+// andRule represents `["a", "b"]` — every element must appear in the text
+// (case-insensitive). Stored lowercased.
+type andRule []string
+
+// regexRule wraps a compiled `/foo/flag` literal. Compilation failure
+// silently downgrades to "never matches" to mirror upstream's try/catch
+// (caller should not fail an entire timeline because one entry is malformed).
+type regexRule struct {
+	re *regexp.Regexp
+}
+
+// regexLiteral matches Misskey's `/pattern/flags` wire syntax. Anchors are
+// required (no leading whitespace allowed) since the frontend always emits
+// the canonical form.
+var regexLiteral = regexp.MustCompile(`^/(.+)/([gimsuy]*)$`)
+
+// parsedCache stores the parsed rule slice keyed by the *raw* JSON bytes.
+// Hot TL paths call Match many times with the same per-user rule set; parsing
+// once per request is cheap but parsing per-note would be wasteful. Cache size
+// is bounded by user count × tabs so a simple sync.Map is fine.
+var parsedCache sync.Map // string -> []rule
+
+func parse(raw []byte) []rule {
+	if len(raw) == 0 {
+		return nil
+	}
+	key := string(raw)
+	if v, ok := parsedCache.Load(key); ok {
+		return v.([]rule)
+	}
+	var entries []json.RawMessage
+	if err := json.Unmarshal(raw, &entries); err != nil {
+		return nil
+	}
+	out := make([]rule, 0, len(entries))
+	for _, e := range entries {
+		r := parseEntry(e)
+		if r != nil {
+			out = append(out, r)
+		}
+	}
+	parsedCache.Store(key, out)
+	return out
+}
+
+func parseEntry(e json.RawMessage) rule {
+	var s string
+	if err := json.Unmarshal(e, &s); err == nil {
+		// Misskey TS upstream allows /regex/flags literal as a string entry.
+		if m := regexLiteral.FindStringSubmatch(s); m != nil {
+			pattern, flags := m[1], m[2]
+			if strings.ContainsRune(flags, 'i') && !strings.HasPrefix(pattern, "(?i)") {
+				pattern = "(?i)" + pattern
+			}
+			re, err := regexp.Compile(pattern)
+			if err != nil {
+				return nil
+			}
+			return regexRule{re: re}
+		}
+		return stringRule(strings.ToLower(s))
+	}
+	var arr []string
+	if err := json.Unmarshal(e, &arr); err == nil {
+		out := make(andRule, 0, len(arr))
+		for _, kw := range arr {
+			kw = strings.ToLower(kw)
+			if kw == "" {
+				continue
+			}
+			out = append(out, kw)
+		}
+		if len(out) == 0 {
+			return nil
+		}
+		return out
+	}
+	return nil
+}
+
+// MatchNote is a convenience wrapper that mirrors upstream check-word-mute.ts:
+// it builds the search text from cw + "\n" + text (both nullable) and skips
+// notes authored by the viewer. Caller passes the viewer's own user ID; an
+// empty viewerID disables the self-skip.
+func MatchNote(rulesJSON []byte, noteUserID, viewerID, noteText, noteCW string) bool {
+	if viewerID != "" && noteUserID == viewerID {
+		return false
+	}
+	combined := strings.TrimSpace(noteCW + "\n" + noteText)
+	return Match(rulesJSON, combined)
+}

--- a/internal/core/wordmute/wordmute.go
+++ b/internal/core/wordmute/wordmute.go
@@ -86,15 +86,22 @@ type regexRule struct {
 // the canonical form.
 var regexLiteral = regexp.MustCompile(`^/(.+)/([gimsuy]*)$`)
 
+// inlineFlagPrefix detects an existing `(?flags)` or `(?flags:...)` inline
+// flag group at the start of a pattern. 既に inline flag を含んでいるなら
+// 二重指定を避けるため flag 注入を skip する。`(?:...)` (non-capture) や
+// `(?P<name>...)` (named group) は flag 設定ではないので一致させない。
+var inlineFlagPrefix = regexp.MustCompile(`^\(\?[imsU]+[):]`)
+
 // parsedCache stores the parsed rule slice keyed by the *raw* JSON bytes.
 // Hot TL paths call Match many times with the same per-user rule set; parsing
 // once per request is cheap but parsing per-note would be wasteful.
 //
-// Bound: 実質的に「(active user 数) × (各 user の rule revision)」で抑えられる。
-// rule を変更すると古い JSON byte 列に対応する entry が dangling し続けるので、
-// 大規模インスタンスで運用する場合は LRU 化を検討する (TS upstream は
-// `acCache.size > 1000` で oldest を delete している)。現状は実装簡略のため
-// 単純 sync.Map で受けている。
+// 上限: 同じ rule JSON は 1 entry に dedupe されるが、ユーザーが rule を
+// 更新するたびに新しい key が増え、古い key は GC されず dangling する
+// (= rule revision に対して monotonic に grow する)。大規模インスタンスで
+// 長時間運用するなら LRU 化を検討する (TS upstream は `acCache.size > 1000`
+// で oldest を delete している)。現状は実装簡略のため単純 sync.Map で受けて
+// いる。
 var parsedCache sync.Map // string -> []rule
 
 func parse(raw []byte) []rule {
@@ -141,7 +148,10 @@ func parseEntry(e json.RawMessage) rule {
 			if strings.ContainsRune(flags, 's') {
 				inline += "s"
 			}
-			if inline != "" && !strings.HasPrefix(pattern, "(?") {
+			// 二重指定回避: pattern が既に inline flag group `(?ims)` で始まる
+			// 場合のみ skip する。`(?:...)` / `(?P<n>...)` 等の non-flag group
+			// に対しては flag を inject しないと意図した m / s 等が消えてしまう。
+			if inline != "" && !inlineFlagPrefix.MatchString(pattern) {
 				pattern = "(?" + inline + ")" + pattern
 			}
 			re, err := regexp.Compile(pattern)

--- a/internal/core/wordmute/wordmute_test.go
+++ b/internal/core/wordmute/wordmute_test.go
@@ -1,0 +1,111 @@
+package wordmute_test
+
+import (
+	"testing"
+
+	"github.com/shiroha-a/mk/internal/core/wordmute"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestMatch_EmptyRules(t *testing.T) {
+	assert.False(t, wordmute.Match(nil, "anything"))
+	assert.False(t, wordmute.Match([]byte(""), "anything"))
+	assert.False(t, wordmute.Match([]byte("[]"), "anything"))
+	assert.False(t, wordmute.Match([]byte("null"), "anything"))
+}
+
+func TestMatch_EmptyText(t *testing.T) {
+	assert.False(t, wordmute.Match([]byte(`["foo"]`), ""))
+	assert.False(t, wordmute.Match([]byte(`["foo"]`), "   "))
+}
+
+func TestMatch_StringSubstring_CaseInsensitive(t *testing.T) {
+	rules := []byte(`["FoO"]`)
+	assert.True(t, wordmute.Match(rules, "hello FOO world"))
+	assert.True(t, wordmute.Match(rules, "hello foo world"))
+	assert.False(t, wordmute.Match(rules, "hello world"))
+}
+
+func TestMatch_AndGroup(t *testing.T) {
+	rules := []byte(`[["alpha", "beta"]]`)
+	assert.True(t, wordmute.Match(rules, "say alpha then beta"))
+	assert.False(t, wordmute.Match(rules, "only alpha"))
+	assert.False(t, wordmute.Match(rules, "only beta"))
+}
+
+func TestMatch_Regex(t *testing.T) {
+	rules := []byte(`["/abc[0-9]+/"]`)
+	assert.True(t, wordmute.Match(rules, "match abc123 here"))
+	assert.False(t, wordmute.Match(rules, "match ABC here"))
+}
+
+func TestMatch_RegexCaseInsensitiveFlag(t *testing.T) {
+	rules := []byte(`["/abc[0-9]+/i"]`)
+	assert.True(t, wordmute.Match(rules, "match ABC42 here"))
+	assert.True(t, wordmute.Match(rules, "match abc42 here"))
+}
+
+func TestMatch_RegexInvalidIsIgnored(t *testing.T) {
+	rules := []byte(`["/[unclosed/"]`)
+	// Compilation failure must downgrade silently — never panic, never throw.
+	assert.False(t, wordmute.Match(rules, "anything"))
+}
+
+func TestMatch_MixedRulesOrConnective(t *testing.T) {
+	rules := []byte(`["foo", ["a", "b"], "/x[0-9]/"]`)
+	assert.True(t, wordmute.Match(rules, "FOO bar"))
+	assert.True(t, wordmute.Match(rules, "ab cd a b"))
+	assert.True(t, wordmute.Match(rules, "x9 marker"))
+	assert.False(t, wordmute.Match(rules, "nothing here"))
+}
+
+func TestMatch_AndGroupSkipsEmptyEntries(t *testing.T) {
+	rules := []byte(`[["", "foo", ""]]`)
+	// 空文字 entry は skip されるので残った "foo" の単一 AND 条件で hit する。
+	assert.True(t, wordmute.Match(rules, "foo bar"))
+}
+
+func TestMatch_AndGroupAllEmptyIsNoOp(t *testing.T) {
+	rules := []byte(`[["", ""]]`)
+	// 全 empty は rule なしと同義 (誤爆防止)。
+	assert.False(t, wordmute.Match(rules, "anything"))
+}
+
+func TestMatch_InvalidJSONReturnsFalse(t *testing.T) {
+	assert.False(t, wordmute.Match([]byte(`{"not":"array"}`), "anything"))
+	assert.False(t, wordmute.Match([]byte(`not json`), "anything"))
+}
+
+func TestMatchNote_SkipsViewerOwnNote(t *testing.T) {
+	rules := []byte(`["secret"]`)
+	// viewer 自身の note は muted word が含まれていても hit しない。
+	assert.False(t, wordmute.MatchNote(rules, "user-1", "user-1", "secret leaked", ""))
+	// 他人の note は hit。
+	assert.True(t, wordmute.MatchNote(rules, "user-2", "user-1", "secret leaked", ""))
+}
+
+func TestMatchNote_CombinesCWAndText(t *testing.T) {
+	rules := []byte(`["spoiler"]`)
+	// cw に hit、text 空でも hit。
+	assert.True(t, wordmute.MatchNote(rules, "u2", "u1", "", "spoiler ahead"))
+	// text に hit、cw 空でも hit。
+	assert.True(t, wordmute.MatchNote(rules, "u2", "u1", "spoiler ahead", ""))
+	// 両方空なら hit しない。
+	assert.False(t, wordmute.MatchNote(rules, "u2", "u1", "", ""))
+}
+
+func TestMatchNote_EmptyViewerIDDisablesSelfSkip(t *testing.T) {
+	rules := []byte(`["foo"]`)
+	// viewerID == "" は anonymous viewer を表し、author 一致による skip を無効化する。
+	assert.True(t, wordmute.MatchNote(rules, "u1", "", "foo bar", ""))
+}
+
+// 同じ rules JSON を 100 回 parse しても問題なく動作する (parseCache の
+// concurrent-safety smoke、race detector 経由で実検証)。
+func TestMatch_ConcurrentSafe(t *testing.T) {
+	rules := []byte(`["foo", ["a","b"]]`)
+	for i := 0; i < 100; i++ {
+		assert.True(t, wordmute.Match(rules, "foo"))
+		assert.True(t, wordmute.Match(rules, "a b"))
+	}
+}

--- a/internal/core/wordmute/wordmute_test.go
+++ b/internal/core/wordmute/wordmute_test.go
@@ -45,6 +45,30 @@ func TestMatch_RegexCaseInsensitiveFlag(t *testing.T) {
 	assert.True(t, wordmute.Match(rules, "match abc42 here"))
 }
 
+// upstream RE2 (TS) の m / s flag を Go の (?m) / (?s) に変換すること。
+func TestMatch_RegexMultilineFlag(t *testing.T) {
+	rules := []byte(`["/^bad/m"]`)
+	// 1行目がマッチしない場合でも、改行後の行頭にマッチすれば hit。
+	assert.True(t, wordmute.Match(rules, "ok line\nbad line"))
+}
+
+func TestMatch_RegexDotallFlag(t *testing.T) {
+	rules := []byte(`["/foo.bar/s"]`)
+	// dotall 無しでは . が \n にマッチしないが、s flag で改行をまたいで hit する。
+	assert.True(t, wordmute.Match(rules, "foo\nbar"))
+}
+
+func TestMatch_RegexCombinedFlags(t *testing.T) {
+	rules := []byte(`["/^foo.bar/ims"]`)
+	assert.True(t, wordmute.Match(rules, "header\nFOO\nBAR"))
+}
+
+// g flag は Go regexp の default 動作と同義なので prefix を組み立てなくて OK。
+func TestMatch_RegexGlobalFlagIsNoOp(t *testing.T) {
+	rules := []byte(`["/abc/g"]`)
+	assert.True(t, wordmute.Match(rules, "first abc and second abc"))
+}
+
 func TestMatch_RegexInvalidIsIgnored(t *testing.T) {
 	rules := []byte(`["/[unclosed/"]`)
 	// Compilation failure must downgrade silently — never panic, never throw.

--- a/internal/core/wordmute/wordmute_test.go
+++ b/internal/core/wordmute/wordmute_test.go
@@ -69,6 +69,29 @@ func TestMatch_RegexGlobalFlagIsNoOp(t *testing.T) {
 	assert.True(t, wordmute.Match(rules, "first abc and second abc"))
 }
 
+// non-capture group `(?:...)` で始まる pattern には flag を inject する
+// (= inline flag prefix と誤認しない)。
+func TestMatch_RegexNonCaptureGroupGetsFlagInjected(t *testing.T) {
+	// `m` flag を要求 → `(?:foo)` の前に `(?m)` が付かないと改行後の foo に hit しない。
+	rules := []byte(`["/^(?:foo)/m"]`)
+	assert.True(t, wordmute.Match(rules, "header line\nfoo body"))
+}
+
+// named group `(?P<name>...)` で始まる pattern にも flag を inject する。
+func TestMatch_RegexNamedGroupGetsFlagInjected(t *testing.T) {
+	rules := []byte(`["/(?P<head>FOO)/i"]`)
+	assert.True(t, wordmute.Match(rules, "lowercase foo here"))
+}
+
+// pattern が既に inline flag group で始まる場合は二重指定を避けて skip する。
+func TestMatch_RegexInlineFlagPrefixNotDoubled(t *testing.T) {
+	// `(?i)foo` は既に case-insensitive を指定しているので、外側で `(?i)` を
+	// 重ねても compile error にしない (Go regexp は (?i)(?i) も valid だが
+	// 意図的に skip しておく方が安全)。
+	rules := []byte(`["/(?i)foo/i"]`)
+	assert.True(t, wordmute.Match(rules, "FOO bar"))
+}
+
 func TestMatch_RegexInvalidIsIgnored(t *testing.T) {
 	rules := []byte(`["/[unclosed/"]`)
 	// Compilation failure must downgrade silently — never panic, never throw.

--- a/internal/server/router.go
+++ b/internal/server/router.go
@@ -1115,6 +1115,7 @@ func (s *Server) setupRoutes() {
 	usersHandler.SetGalleryRepo(repository.NewGalleryRepository(s.db))
 	usersHandler.SetPageRepo(pageRepo)
 	usersHandler.SetNoteFieldResolver(noteFieldResolver)
+	usersHandler.SetUserRepo(userRepo)
 	api.POST("/users/show", usersHandler.Show)
 	api.POST("/users/search", usersHandler.Search)
 	api.POST("/users/notes", usersHandler.Notes)
@@ -1536,6 +1537,7 @@ func (s *Server) setupRoutes() {
 	channelsHandler.SetEmojiRepo(emojiRepo)
 	channelsHandler.SetReactionReader(reactionCountWriter)
 	channelsHandler.SetNoteFieldResolver(noteFieldResolver)
+	channelsHandler.SetUserRepo(userRepo)
 
 	// Antennas endpoints (Phase 4.3)
 	antennasHandler := antennas.NewHandler(antennaService, noteRepo, idGen)
@@ -1543,6 +1545,7 @@ func (s *Server) setupRoutes() {
 	antennasHandler.SetEmojiRepo(emojiRepo)
 	antennasHandler.SetReactionReader(reactionCountWriter)
 	antennasHandler.SetNoteFieldResolver(noteFieldResolver)
+	antennasHandler.SetUserRepo(userRepo)
 	api.POST("/antennas/create", antennasHandler.Create, middleware.RequireAuth())
 	api.POST("/antennas/show", antennasHandler.Show, middleware.RequireAuth())
 	api.POST("/antennas/update", antennasHandler.Update, middleware.RequireAuth())
@@ -1557,6 +1560,7 @@ func (s *Server) setupRoutes() {
 	clipsHandler.SetEmojiRepo(emojiRepo)
 	clipsHandler.SetReactionReader(reactionCountWriter)
 	clipsHandler.SetNoteFieldResolver(noteFieldResolver)
+	clipsHandler.SetUserRepo(userRepo)
 	api.POST("/clips/create", clipsHandler.Create, middleware.RequireAuth())
 	api.POST("/clips/show", clipsHandler.Show)
 	api.POST("/clips/update", clipsHandler.Update, middleware.RequireAuth())
@@ -1629,6 +1633,10 @@ func (s *Server) setupRoutes() {
 	streamManager := stream.NewManager(streamRegistry, streamBus)
 	// readNotificationメッセージをnotificationServiceに橋渡しする
 	streamManager.SetNotificationReader(&notifReaderAdapter{svc: notificationService})
+	// hardMutedWords (#787) 用の rules lookup を wire。connection 確立時に
+	// 1 度だけ user_profile を引き、以降の publish では cache された rules を
+	// 各 timeline channel が参照する。
+	streamManager.SetHardMuteLookup(&hardMuteLookupAdapter{userRepo: userRepo})
 	notePublisher := stream.NewNotePublisher(streamPubSub, idGen)
 	notePublisher.SetEmojiLookup(emojiRepo)
 	notePublisher.SetInstanceLookup(instanceRepo)
@@ -1764,6 +1772,7 @@ func (s *Server) setupRoutes() {
 	rolesHandler.SetEmojiRepo(emojiRepo)
 	rolesHandler.SetReactionReader(reactionCountWriter)
 	rolesHandler.SetNoteFieldResolver(noteFieldResolver)
+	rolesHandler.SetUserRepo(userRepo)
 	api.POST("/roles/list", rolesHandler.List)
 	api.POST("/roles/show", rolesHandler.Show)
 	api.POST("/roles/users", rolesHandler.Users)
@@ -2471,6 +2480,25 @@ type notifReaderAdapter struct {
 
 func (a *notifReaderAdapter) ReadAll(userID string) error {
 	return a.svc.MarkAllAsRead(context.Background(), userID)
+}
+
+// hardMuteLookupAdapter bridges UserRepository to stream.HardMuteRulesLookup
+// so the streaming Manager can attach the persisted hardMutedWords (#787) at
+// connection setup. Returns nil on lookup failure / empty rule set so the
+// streaming filter degrades to no-op rather than dropping the connection.
+type hardMuteLookupAdapter struct {
+	userRepo repository.UserRepository
+}
+
+func (a *hardMuteLookupAdapter) HardMutedWordsForUser(userID string) []byte {
+	if a.userRepo == nil || userID == "" {
+		return nil
+	}
+	profile, err := a.userRepo.FindProfileByUserID(userID)
+	if err != nil || profile == nil || len(profile.HardMutedWords) == 0 {
+		return nil
+	}
+	return []byte(profile.HardMutedWords)
 }
 
 // reactionNoteStreamAdapter bridges core/reaction.NoteStreamHook to the

--- a/internal/stream/channel.go
+++ b/internal/stream/channel.go
@@ -54,6 +54,10 @@ type ChannelContext interface {
 	Subscribe(topic string)
 	// Unsubscribe stops listening on a topic.
 	Unsubscribe(topic string)
+	// HardMuteRules returns the viewer's persisted hardMutedWords (raw jsonb).
+	// Timeline channels use it to drop matching notes per-publish (#787).
+	// Returns nil when the connection is anonymous / has no rule set.
+	HardMuteRules() []byte
 }
 
 // PermittedChannel is an optional interface a Channel can implement to

--- a/internal/stream/channels/channel_timeline.go
+++ b/internal/stream/channels/channel_timeline.go
@@ -36,7 +36,7 @@ func (c *ChannelTimelineChannel) Init(params json.RawMessage) error {
 }
 
 func (c *ChannelTimelineChannel) OnRedisEvent(payload []byte) {
-	if !c.filter.shouldEmit(payload) {
+	if !c.filter.shouldEmit(payload, c.ctx.HardMuteRules(), viewerIDFromCtx(c.ctx)) {
 		return
 	}
 	_ = c.ctx.Send("note", json.RawMessage(payload))

--- a/internal/stream/channels/hashtag.go
+++ b/internal/stream/channels/hashtag.go
@@ -37,7 +37,7 @@ func (c *HashtagChannel) Init(params json.RawMessage) error {
 }
 
 func (c *HashtagChannel) OnRedisEvent(payload []byte) {
-	if !c.filter.shouldEmit(payload) {
+	if !c.filter.shouldEmit(payload, c.ctx.HardMuteRules(), viewerIDFromCtx(c.ctx)) {
 		return
 	}
 	_ = c.ctx.Send("note", json.RawMessage(payload))

--- a/internal/stream/channels/note_filter.go
+++ b/internal/stream/channels/note_filter.go
@@ -1,6 +1,24 @@
 package channels
 
-import "encoding/json"
+import (
+	"encoding/json"
+
+	"github.com/shiroha-a/mk/internal/core/wordmute"
+	"github.com/shiroha-a/mk/internal/model"
+	"github.com/shiroha-a/mk/internal/stream"
+)
+
+// viewerIDFromCtx extracts the authenticated user's ID from a ChannelContext.
+// Returns "" for anonymous connections so wordmute.MatchNote treats every
+// note as "not authored by self" (i.e. eligible for muting). Both the
+// notesfilter / wordmute helpers handle empty viewerID safely.
+func viewerIDFromCtx(ctx stream.ChannelContext) string {
+	u, ok := ctx.User().(*model.User)
+	if !ok || u == nil {
+		return ""
+	}
+	return u.ID
+}
 
 // noteFilter provides client-controlled filtering for timeline channels.
 // タイムラインチャンネルのconnectパラメータで指定されるフィルタ条件。
@@ -29,15 +47,22 @@ func parseNoteFilter(params json.RawMessage) noteFilter {
 }
 
 // notePayload is the minimal structure needed for filtering decisions.
+// hardMutedWords (#787) も同 struct で見るので user / cw を含める。
 type notePayload struct {
+	UserID   string   `json:"userId"`
 	Text     *string  `json:"text"`
+	CW       *string  `json:"cw"`
 	RenoteID *string  `json:"renoteId"`
 	ReplyID  *string  `json:"replyId"`
 	FileIDs  []string `json:"fileIds"`
 }
 
 // shouldEmit returns true if the note passes all filter conditions.
-func (f *noteFilter) shouldEmit(payload []byte) bool {
+//
+// hardMuteRules (#787) には viewer の user_profile.hardMutedWords (jsonb) を
+// そのまま渡す。空 / nil なら hard mute は no-op。viewerID は self skip 用、
+// streaming は authenticated path のみ呼ばれるので空文字は anonymous 扱い。
+func (f *noteFilter) shouldEmit(payload []byte, hardMuteRules []byte, viewerID string) bool {
 	var note notePayload
 	if err := json.Unmarshal(payload, &note); err != nil {
 		// パース失敗時はそのまま送信
@@ -58,6 +83,20 @@ func (f *noteFilter) shouldEmit(payload []byte) bool {
 	// ファイル付きのみモード
 	if f.WithFiles && len(note.FileIDs) == 0 {
 		return false
+	}
+
+	// hardMutedWords filter (#787)。rules 空なら no-op。
+	if len(hardMuteRules) > 0 {
+		text, cw := "", ""
+		if note.Text != nil {
+			text = *note.Text
+		}
+		if note.CW != nil {
+			cw = *note.CW
+		}
+		if wordmute.MatchNote(hardMuteRules, note.UserID, viewerID, text, cw) {
+			return false
+		}
 	}
 
 	return true

--- a/internal/stream/channels/note_filter_test.go
+++ b/internal/stream/channels/note_filter_test.go
@@ -30,55 +30,85 @@ func TestShouldEmit_PureRenoteFiltered(t *testing.T) {
 	f := noteFilter{WithRenotes: false, WithReplies: false, WithFiles: false}
 	// 純リノート: text=nil, renoteId!=nil, fileIds=[]
 	payload := []byte(`{"renoteId":"r1","fileIds":[]}`)
-	assert.False(t, f.shouldEmit(payload))
+	assert.False(t, f.shouldEmit(payload, nil, ""))
 }
 
 func TestShouldEmit_QuoteRenoteAllowed(t *testing.T) {
 	f := noteFilter{WithRenotes: false, WithReplies: false, WithFiles: false}
 	// 引用リノート: text!=nil, renoteId!=nil → 通過
 	payload := []byte(`{"text":"hello","renoteId":"r1"}`)
-	assert.True(t, f.shouldEmit(payload))
+	assert.True(t, f.shouldEmit(payload, nil, ""))
 }
 
 func TestShouldEmit_RenoteWithFilesAllowed(t *testing.T) {
 	f := noteFilter{WithRenotes: false, WithReplies: false, WithFiles: false}
 	// ファイル添付付きリノート: text=nil, renoteId!=nil, fileIds非空 → 純リノートではない
 	payload := []byte(`{"renoteId":"r1","fileIds":["f1"]}`)
-	assert.True(t, f.shouldEmit(payload))
+	assert.True(t, f.shouldEmit(payload, nil, ""))
 }
 
 func TestShouldEmit_ReplyFiltered(t *testing.T) {
 	f := noteFilter{WithRenotes: true, WithReplies: false, WithFiles: false}
 	payload := []byte(`{"text":"reply","replyId":"p1"}`)
-	assert.False(t, f.shouldEmit(payload))
+	assert.False(t, f.shouldEmit(payload, nil, ""))
 }
 
 func TestShouldEmit_ReplyAllowed(t *testing.T) {
 	f := noteFilter{WithRenotes: true, WithReplies: true, WithFiles: false}
 	payload := []byte(`{"text":"reply","replyId":"p1"}`)
-	assert.True(t, f.shouldEmit(payload))
+	assert.True(t, f.shouldEmit(payload, nil, ""))
 }
 
 func TestShouldEmit_WithFilesNoFiles(t *testing.T) {
 	f := noteFilter{WithRenotes: true, WithReplies: true, WithFiles: true}
 	payload := []byte(`{"text":"hello","fileIds":[]}`)
-	assert.False(t, f.shouldEmit(payload))
+	assert.False(t, f.shouldEmit(payload, nil, ""))
 }
 
 func TestShouldEmit_WithFilesHasFiles(t *testing.T) {
 	f := noteFilter{WithRenotes: true, WithReplies: true, WithFiles: true}
 	payload := []byte(`{"text":"hello","fileIds":["f1"]}`)
-	assert.True(t, f.shouldEmit(payload))
+	assert.True(t, f.shouldEmit(payload, nil, ""))
 }
 
 func TestShouldEmit_InvalidJSON(t *testing.T) {
 	f := noteFilter{WithRenotes: false}
 	// パース失敗時はそのまま送信
-	assert.True(t, f.shouldEmit([]byte(`{invalid`)))
+	assert.True(t, f.shouldEmit([]byte(`{invalid`), nil, ""))
 }
 
 func TestShouldEmit_NormalNote(t *testing.T) {
 	f := noteFilter{WithRenotes: true, WithReplies: false, WithFiles: false}
 	payload := []byte(`{"text":"hello"}`)
-	assert.True(t, f.shouldEmit(payload))
+	assert.True(t, f.shouldEmit(payload, nil, ""))
+}
+
+// #787: hardMutedWords による per-publish filter (streaming path)。
+func TestShouldEmit_HardMute_TextHit(t *testing.T) {
+	f := noteFilter{WithRenotes: true, WithReplies: true, WithFiles: false}
+	payload := []byte(`{"userId":"author","text":"this contains POLITICS"}`)
+	rules := []byte(`["politics"]`)
+	assert.False(t, f.shouldEmit(payload, rules, "viewer"))
+}
+
+func TestShouldEmit_HardMute_CWHit(t *testing.T) {
+	f := noteFilter{WithRenotes: true, WithReplies: true, WithFiles: false}
+	payload := []byte(`{"userId":"author","text":"clean body","cw":"spoiler ahead"}`)
+	rules := []byte(`["spoiler"]`)
+	assert.False(t, f.shouldEmit(payload, rules, "viewer"))
+}
+
+func TestShouldEmit_HardMute_ViewerOwnNoteExempt(t *testing.T) {
+	f := noteFilter{WithRenotes: true, WithReplies: true, WithFiles: false}
+	// note.userId == viewerID なので self skip で送信される
+	payload := []byte(`{"userId":"viewer","text":"politics by self"}`)
+	rules := []byte(`["politics"]`)
+	assert.True(t, f.shouldEmit(payload, rules, "viewer"))
+}
+
+func TestShouldEmit_HardMute_NoRulesIsNoOp(t *testing.T) {
+	f := noteFilter{WithRenotes: true, WithReplies: true, WithFiles: false}
+	payload := []byte(`{"userId":"author","text":"politics"}`)
+	assert.True(t, f.shouldEmit(payload, nil, "viewer"))
+	assert.True(t, f.shouldEmit(payload, []byte("[]"), "viewer"))
 }

--- a/internal/stream/channels/role_timeline.go
+++ b/internal/stream/channels/role_timeline.go
@@ -36,7 +36,7 @@ func (c *RoleTimelineChannel) Init(params json.RawMessage) error {
 }
 
 func (c *RoleTimelineChannel) OnRedisEvent(payload []byte) {
-	if !c.filter.shouldEmit(payload) {
+	if !c.filter.shouldEmit(payload, c.ctx.HardMuteRules(), viewerIDFromCtx(c.ctx)) {
 		return
 	}
 	_ = c.ctx.Send("note", json.RawMessage(payload))

--- a/internal/stream/channels/timeline.go
+++ b/internal/stream/channels/timeline.go
@@ -31,7 +31,7 @@ func (c *LocalTimelineChannel) Init(params json.RawMessage) error {
 
 // OnRedisEvent forwards a JSON-encoded note payload as a `note` event.
 func (c *LocalTimelineChannel) OnRedisEvent(payload []byte) {
-	if !c.filter.shouldEmit(payload) {
+	if !c.filter.shouldEmit(payload, c.ctx.HardMuteRules(), viewerIDFromCtx(c.ctx)) {
 		return
 	}
 	_ = c.ctx.Send("note", json.RawMessage(payload))
@@ -62,7 +62,7 @@ func (c *GlobalTimelineChannel) Init(params json.RawMessage) error {
 	return nil
 }
 func (c *GlobalTimelineChannel) OnRedisEvent(payload []byte) {
-	if !c.filter.shouldEmit(payload) {
+	if !c.filter.shouldEmit(payload, c.ctx.HardMuteRules(), viewerIDFromCtx(c.ctx)) {
 		return
 	}
 	_ = c.ctx.Send("note", json.RawMessage(payload))
@@ -100,7 +100,7 @@ func (c *HomeTimelineChannel) Init(params json.RawMessage) error {
 }
 
 func (c *HomeTimelineChannel) OnRedisEvent(payload []byte) {
-	if !c.filter.shouldEmit(payload) {
+	if !c.filter.shouldEmit(payload, c.ctx.HardMuteRules(), viewerIDFromCtx(c.ctx)) {
 		return
 	}
 	_ = c.ctx.Send("note", json.RawMessage(payload))
@@ -142,7 +142,7 @@ func (c *HybridTimelineChannel) Init(params json.RawMessage) error {
 }
 
 func (c *HybridTimelineChannel) OnRedisEvent(payload []byte) {
-	if !c.filter.shouldEmit(payload) {
+	if !c.filter.shouldEmit(payload, c.ctx.HardMuteRules(), viewerIDFromCtx(c.ctx)) {
 		return
 	}
 	_ = c.ctx.Send("note", json.RawMessage(payload))

--- a/internal/stream/channels/timeline_test.go
+++ b/internal/stream/channels/timeline_test.go
@@ -13,14 +13,15 @@ import (
 
 // stubContext implements stream.ChannelContext for tests.
 type stubContext struct {
-	mu        sync.Mutex
-	id        string
-	user      any
-	subs      []string
-	unsubs    []string
-	sentType  []string
-	sentBody  []any
-	sendError error
+	mu            sync.Mutex
+	id            string
+	user          any
+	subs          []string
+	unsubs        []string
+	sentType      []string
+	sentBody      []any
+	sendError     error
+	hardMuteRules []byte
 }
 
 func (s *stubContext) ID() string { return s.id }
@@ -42,6 +43,7 @@ func (s *stubContext) Unsubscribe(topic string) {
 	defer s.mu.Unlock()
 	s.unsubs = append(s.unsubs, topic)
 }
+func (s *stubContext) HardMuteRules() []byte { return s.hardMuteRules }
 
 func newCtx(user any) *stubContext {
 	return &stubContext{id: "ch1", user: user}

--- a/internal/stream/channels/user_list.go
+++ b/internal/stream/channels/user_list.go
@@ -46,7 +46,7 @@ func (c *UserListChannel) Init(params json.RawMessage) error {
 }
 
 func (c *UserListChannel) OnRedisEvent(payload []byte) {
-	if !c.filter.shouldEmit(payload) {
+	if !c.filter.shouldEmit(payload, c.ctx.HardMuteRules(), viewerIDFromCtx(c.ctx)) {
 		return
 	}
 	_ = c.ctx.Send("note", json.RawMessage(payload))

--- a/internal/stream/connection.go
+++ b/internal/stream/connection.go
@@ -64,6 +64,13 @@ type Connection struct {
 
 	handler      MessageHandler
 	closeHandler CloseHandler
+
+	// hardMuteRules は viewer の user_profile.hardMutedWords をそのまま保持する
+	// jsonb 由来 byte slice (#787)。streaming channel が per-note dispatch 時に
+	// notesfilter.MatchOne でこの rules と照合し、match したら send しない。
+	// 認証時に router が一度だけ fetch してセットする想定で、接続中は
+	// immutable に扱う (= 設定変更は次回 reconnect で反映)。
+	hardMuteRules []byte
 }
 
 // NewConnection wraps an upgraded WebSocket. id は呼び出し側 (Manager) が一意
@@ -92,6 +99,18 @@ func (c *Connection) ID() string { return c.id }
 
 // User returns the authenticated user, or nil for anonymous connections.
 func (c *Connection) User() *model.User { return c.user }
+
+// SetHardMuteRules attaches the viewer's persisted hardMutedWords (raw jsonb
+// from user_profile) so timeline channels can drop matching notes before
+// sending them to the client (#787). Called once after authentication.
+func (c *Connection) SetHardMuteRules(rules []byte) {
+	c.hardMuteRules = rules
+}
+
+// HardMuteRules returns the persisted hardMutedWords rules attached at
+// connection setup time. Returns nil for anonymous connections / when
+// the lookup failed / when the user has no rule set.
+func (c *Connection) HardMuteRules() []byte { return c.hardMuteRules }
 
 // SetPermissions attaches OAuth2 permission scopes for this connection.
 // トークン経由で接続された場合に、AccessToken の permission 配列を渡す想定。

--- a/internal/stream/connection.go
+++ b/internal/stream/connection.go
@@ -103,6 +103,12 @@ func (c *Connection) User() *model.User { return c.user }
 // SetHardMuteRules attaches the viewer's persisted hardMutedWords (raw jsonb
 // from user_profile) so timeline channels can drop matching notes before
 // sending them to the client (#787). Called once after authentication.
+//
+// rules は接続 lifetime の snapshot として保持される。ユーザーが i/update で
+// hardMutedWords を変更しても次回の WebSocket reconnect まで反映されない —
+// per-publish lookup を避けることで streaming hot path の DB query を 0 に
+// 保つトレードオフ。即時反映が必要になったら i/update から該当 user の
+// connection に invalidate signal を流す follow-up を別 issue で検討する。
 func (c *Connection) SetHardMuteRules(rules []byte) {
 	c.hardMuteRules = rules
 }

--- a/internal/stream/connection_test.go
+++ b/internal/stream/connection_test.go
@@ -290,3 +290,16 @@ func TestConnection_AccessorsExposeUserAndID(t *testing.T) {
 	assert.Equal(t, "c-alpha", c.ID())
 	assert.Equal(t, user, c.User())
 }
+
+// #787: SetHardMuteRules / HardMuteRules round-trip。
+func TestConnection_HardMuteRules(t *testing.T) {
+	c := NewConnection("c1", nil, nil)
+	if got := c.HardMuteRules(); got != nil {
+		t.Fatalf("default HardMuteRules = %v, want nil", got)
+	}
+	rules := []byte(`["foo"]`)
+	c.SetHardMuteRules(rules)
+	if got := c.HardMuteRules(); string(got) != string(rules) {
+		t.Fatalf("HardMuteRules = %q, want %q", got, rules)
+	}
+}

--- a/internal/stream/dispatcher.go
+++ b/internal/stream/dispatcher.go
@@ -394,6 +394,15 @@ func (c *channelContext) Send(msgType string, body any) error {
 func (c *channelContext) Subscribe(topic string)   { c.dispatcher.subscribe(c.id, topic) }
 func (c *channelContext) Unsubscribe(topic string) { c.dispatcher.unsubscribe(c.id, topic) }
 
+// HardMuteRules forwards the connection-level hardMutedWords rule set so
+// timeline channels can drop matching notes before sending (#787).
+func (c *channelContext) HardMuteRules() []byte {
+	if c.dispatcher.conn == nil {
+		return nil
+	}
+	return c.dispatcher.conn.HardMuteRules()
+}
+
 // --- readNotification / subNote / unsubNote ---
 
 // handleReadNotification marks all notifications as read for the connected user.

--- a/internal/stream/dispatcher_test.go
+++ b/internal/stream/dispatcher_test.go
@@ -878,3 +878,23 @@ func countOccurrences(slice []string, target string) int {
 	}
 	return n
 }
+
+// #787: channelContext.HardMuteRules forwards from Connection.HardMuteRules.
+func TestChannelContext_HardMuteRules(t *testing.T) {
+	conn := NewConnection("c1", nil, newFakeConn())
+	conn.SetHardMuteRules([]byte(`["foo"]`))
+	d := NewDispatcher(conn, nil, newStubBus())
+	ctx := &channelContext{dispatcher: d, id: "ch1"}
+	if got := ctx.HardMuteRules(); string(got) != `["foo"]` {
+		t.Fatalf("HardMuteRules = %q", got)
+	}
+}
+
+// nil connection (= disconnected) でも panic せず nil を返す。
+func TestChannelContext_HardMuteRules_NilConn(t *testing.T) {
+	d := &Dispatcher{}
+	ctx := &channelContext{dispatcher: d, id: "ch1"}
+	if got := ctx.HardMuteRules(); got != nil {
+		t.Fatalf("expected nil, got %q", got)
+	}
+}

--- a/internal/stream/manager.go
+++ b/internal/stream/manager.go
@@ -8,6 +8,14 @@ import (
 	"github.com/shiroha-a/mk/internal/model"
 )
 
+// HardMuteRulesLookup returns the persisted hardMutedWords (raw jsonb) for
+// the given user, or nil when the lookup fails / user has no rules. The
+// streaming Manager calls this once at connection setup so timeline channels
+// can drop matching notes per-publish (#787).
+type HardMuteRulesLookup interface {
+	HardMutedWordsForUser(userID string) []byte
+}
+
 // Manager owns the set of live streaming connections. Channel registry と
 // PubSub bus を握り、各 connection に Dispatcher を割り当てて pubsub →
 // channel のルーティングを行う。
@@ -18,6 +26,7 @@ type Manager struct {
 	registry    *Registry
 	bus         PubSubBus
 	notifReader NotificationReader
+	hardMute    HardMuteRulesLookup
 }
 
 // NewManager constructs a Manager with no live connections. registry / bus が
@@ -36,11 +45,23 @@ func (m *Manager) SetNotificationReader(nr NotificationReader) {
 	m.notifReader = nr
 }
 
+// SetHardMuteLookup wires a lookup that returns the viewer's persisted
+// hardMutedWords (#787). Called at connection setup; nil disables the
+// per-publish hard mute filter.
+func (m *Manager) SetHardMuteLookup(l HardMuteRulesLookup) {
+	m.hardMute = l
+}
+
 // Accept implements api/streaming.ConnectionAcceptor. *websocket.Conn から
 // Connection を組み立て、Dispatcher 経由で channel framework に橋渡しする。
 func (m *Manager) Accept(ws *websocket.Conn, user *model.User) {
 	id := m.allocateID()
 	c := NewConnection(id, user, ws)
+	if m.hardMute != nil && user != nil {
+		// 接続後、最初の channel publish より前に rules を attach。fetch 失敗は
+		// nil 返却で degrade — streaming は filter 無しで動き続ける (#787)。
+		c.SetHardMuteRules(m.hardMute.HardMutedWordsForUser(user.ID))
+	}
 	dispatcher := NewDispatcher(c, m.registry, m.bus)
 	if m.notifReader != nil {
 		dispatcher.SetNotificationReader(m.notifReader)

--- a/internal/testutil/mock_repository.go
+++ b/internal/testutil/mock_repository.go
@@ -639,6 +639,20 @@ func applyProfileFields(p *model.UserProfile, fields map[string]any) {
 			case []byte:
 				p.Room = val
 			}
+		case "mutedWords":
+			switch val := v.(type) {
+			case string:
+				p.MutedWords = []byte(val)
+			case []byte:
+				p.MutedWords = val
+			}
+		case "hardMutedWords":
+			switch val := v.(type) {
+			case string:
+				p.HardMutedWords = []byte(val)
+			case []byte:
+				p.HardMutedWords = val
+			}
 		case "clientData":
 			switch val := v.(type) {
 			case string:


### PR DESCRIPTION
## Summary

mk-go ではこれまで \`/api/i/update\` が \`mutedWords\` / \`hardMutedWords\` を完全に無視していたため、入力しても DB に保存されず、frontend / backend どちらの filter も機能していなかった。本 PR で保存 path と全 filter path (list endpoints + streaming) を両方修復する。

## 主な変更

### 保存 path
- \`/api/i/update\` の \`UpdateRequest\` / \`Update\` に \`mutedWords\` / \`hardMutedWords\` を追加
- \`normalizeMutedWords\` で配列形式を validate (null/省略=不変、\`[]\`=clear、配列値=上書き)
- \`core/user.UpdateInput\` / \`UpdateProfile\` を Room と同 jsonb pattern で拡張

### Hard mute filter — list endpoints (11 個)

\`internal/core/wordmute\` (upstream \`check-word-mute.ts\` の Go port: substring / AND group / \`/regex/i\`、自分 exempt、parsedCache 付き) と \`internal/core/notesfilter\` (\`ApplyHardMute\` + \`MatchOne\`) を新設し、以下 endpoint の \`PackNotes\` 直前に 1 行差し込み:

\`notes/{timeline,local-timeline,global-timeline,hybrid-timeline,search,conversation,mentions,user-list-timeline,search-by-tag,children}\` / \`users/notes\` / \`users/notes/N\` / \`antennas/notes\` / \`channels/timeline\` / \`roles/notes\` / \`clips/notes\` / \`drive/files/attached-notes\`

filter 非適用 (upstream 同等で意図的 skip): \`i/show\`/\`users/show\` の pinnedNotes、\`i/favorites\`。

### Hard mute filter — streaming (8 channel)

\`stream.Connection\` に \`hardMuteRules\` cache + setter、\`ChannelContext\` interface に \`HardMuteRules()\` を追加。\`Manager.Accept\` で接続成立時に 1 度だけ profile fetch して rules を cache し、\`channels/note_filter.go\` の \`shouldEmit\` を \`(payload, rules, viewerID)\` 形式に拡張して publish 時に hit を drop。

対象 channel: \`localTimeline\` / \`globalTimeline\` / \`homeTimeline\` / \`hybridTimeline\` / \`hashtag\` / \`roleTimeline\` / \`channelTimeline\` / \`userList\`。

### Wiring

\`clips\` / \`users\` / \`antennas\` / \`channels\` / \`roles\` の各 Handler に \`SetUserRepo\` を追加し \`router.go\` で wire。streaming Manager にも \`SetHardMuteLookup\` を追加し \`hardMuteLookupAdapter\` で \`UserRepository\` を bridge。

### Mock 拡張

\`internal/testutil/mock_repository.go\` の \`applyProfileFields\` に \`mutedWords\` / \`hardMutedWords\` case 追加 (Room と同 pattern)。

## テスト

| pkg | 内容 | カバレッジ |
|---|---|---|
| \`core/wordmute\` | 14 ケース (substring / AND / regex / 自分 skip / cw / 不正 JSON) | 98.4% |
| \`core/notesfilter\` | 8 ケース (no-op / anonymous / 自分 exempt / cw match / fetch error) | 96.0% |
| \`api/i/handler_test.go\` | MutedWords 5 ケース (accept / clear / omit / 非配列 reject / null=omit) | — |
| \`core/user/user_service_test.go\` | persist + clear シナリオ | — |
| \`stream/channels/note_filter_test.go\` | hard mute 4 ケース | 95.5% |
| \`stream/connection_test.go\` / \`dispatcher_test.go\` | rules round-trip 3 ケース | 91.5% |

影響 pkg は全て CI 閾値 90% を維持。

### 実行

\`\`\`
make test
go test ./internal/core/wordmute/... ./internal/core/notesfilter/...
\`\`\`

## 互換性

- DB column \`mutedWords\` / \`hardMutedWords\` は #001 で既に存在、migration 不要
- \`/api/i\` レスポンスは元から両 field を返していたので frontend 側変更不要 — 保存 + filter が backend で動くと自動で soft / hard どちらも機能する
- 全 setter は optional injection の慣習に従い、未配線時は filter skip (best-effort)

## Closes

Closes #787

🤖 Generated with [Claude Code](https://claude.com/claude-code)