### PR TITLE
Phase 14-Playwright PR-1 (#744): 基盤 + smoke spec 1 本

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -310,3 +310,22 @@ queue-bench-down:
 
 queue-bench-logs:
 	docker compose -f $(QUEUE_BENCH_COMPOSE) logs -f
+
+# Playwright e2e (#744 Phase 1)
+#
+# upstream Misskey TS 互換挙動を期待値に書いた spec を mk-go backend に
+# 対して走らせ、drop-in 互換 regression を検出する。Phase 1 PR-1 では
+# 基盤 + smoke 1 spec のみ。後続 PR で spec 拡充 + CI 統合する。
+PLAYWRIGHT_COMPOSE=docker-compose.playwright.yml
+
+playwright-up:
+	docker compose -f $(PLAYWRIGHT_COMPOSE) up -d --build
+
+playwright-test:
+	docker compose -f $(PLAYWRIGHT_COMPOSE) --profile test run --rm playwright-runner
+
+playwright-down:
+	docker compose -f $(PLAYWRIGHT_COMPOSE) down -v
+
+playwright-logs:
+	docker compose -f $(PLAYWRIGHT_COMPOSE) logs -f

--- a/docker-compose.playwright.yml
+++ b/docker-compose.playwright.yml
@@ -1,0 +1,85 @@
+# docker-compose.playwright.yml — #744 Phase 1 PR-1
+#
+# Playwright e2e 基盤の最小構成。mk-go 単体 + postgres + redis + Playwright
+# runner で API/streaming を target に spec を実行する。frontend は本 PR
+# では bundle しない (= cypress dropin と同じ API 中心構成、page.goto は
+# 後続 PR で frontend bundling を追加するときに導入する)。
+#
+# 使い方:
+#   docker compose -f docker-compose.playwright.yml up -d --build
+#   docker compose -f docker-compose.playwright.yml --profile test \
+#     run --rm playwright-runner
+#   docker compose -f docker-compose.playwright.yml down -v
+
+services:
+  postgres:
+    image: postgres:16-alpine
+    environment:
+      POSTGRES_DB: misskey
+      POSTGRES_USER: misskey
+      POSTGRES_PASSWORD: testpass
+    healthcheck:
+      test: pg_isready -U misskey
+      interval: 3s
+      timeout: 3s
+      retries: 10
+    networks: [playwright]
+
+  redis:
+    image: redis:7-alpine
+    healthcheck:
+      test: redis-cli ping
+      interval: 3s
+      timeout: 3s
+      retries: 10
+    networks: [playwright]
+
+  mkgo:
+    build:
+      context: .
+      # tests/federation/common/Dockerfile.mkgo は migrate + server を両方
+      # build して entrypoint で migrate up を走らせる。Playwright phase 1
+      # は federation 不要なので最小 binary 起動 + migrate up で十分。
+      dockerfile: tests/federation/common/Dockerfile.mkgo
+    environment:
+      TZ: Asia/Tokyo
+    volumes:
+      - ./tests/playwright/instance.yml:/app/.config/default.yml:ro
+    healthcheck:
+      test: ["CMD", "/app/misskey", "-healthcheck", "-config", ".config/default.yml"]
+      interval: 5s
+      timeout: 5s
+      retries: 30
+      start_period: 30s
+    depends_on:
+      postgres: {condition: service_healthy}
+      redis: {condition: service_healthy}
+    networks: [playwright]
+
+  # Playwright runner. profiles: [test] で `up -d` の対象から外し、
+  # 明示的に `--profile test run` で起動する (cypress runner と同 pattern)。
+  playwright-runner:
+    profiles: [test]
+    build:
+      context: ./tests/playwright
+      dockerfile: Dockerfile.runner
+    environment:
+      # mkgo backend への接続先。spec から fixtures 経由で参照する。
+      MK_BASE_URL: http://mkgo:3000
+    volumes:
+      # spec ファイルと playwright.config.ts は test 実行時に変更されること
+      # があるので bind mount で読み込む。生成物 (test-results/) は host に
+      # 残るので gitignore で除外する。
+      - ./tests/playwright:/work
+      # bind mount が image 焼き付けの /work/node_modules を上書きしないよう
+      # anonymous volume で保護する。これにより npm install (Dockerfile.runner)
+      # の結果が container 内で生き続ける。
+      - /work/node_modules
+    working_dir: /work
+    depends_on:
+      mkgo: {condition: service_healthy}
+    networks: [playwright]
+
+networks:
+  playwright:
+    driver: bridge

--- a/tests/playwright/.gitignore
+++ b/tests/playwright/.gitignore
@@ -1,0 +1,5 @@
+# Playwright runtime artifacts.
+node_modules/
+test-results/
+playwright-report/
+package-lock.json

--- a/tests/playwright/Dockerfile.runner
+++ b/tests/playwright/Dockerfile.runner
@@ -1,0 +1,23 @@
+# Playwright runner image for #744 Phase 1.
+#
+# 公式 Playwright image は browser を内蔵しているが本 PR では API 中心
+# spec のみ実行するので browser は使わない。それでも公式 image にしておく
+# 理由は、後続 PR で page.goto ベース spec を追加するときに browser が
+# 即座に使えるよう構成を固定しておきたいため。
+#
+# 公式 v1.49 を pin。Playwright は upstream リリースで API 微調整するので
+# 後続 PR で必要に応じて bump する。
+FROM mcr.microsoft.com/playwright:v1.49.1-jammy
+
+WORKDIR /work
+
+# package.json と package-lock.json を先 copy して node_modules を image に
+# 焼く。spec / config は volume mount で渡すので image rebuild なしで反復
+# できる (cypress runner と同 pattern)。
+COPY package.json package-lock.json* ./
+RUN npm install --no-audit --no-fund
+
+# ENTRYPOINT に npx を使うと global npx cache に playwright を再 install し
+# /work/node_modules を見落とすので、image 内の local binary を直接呼ぶ。
+ENTRYPOINT ["./node_modules/.bin/playwright"]
+CMD ["test"]

--- a/tests/playwright/README.md
+++ b/tests/playwright/README.md
@@ -1,0 +1,56 @@
+# Playwright e2e (#744)
+
+mk-go 向けの Playwright e2e。spec は upstream Misskey TS の API 互換挙動を
+期待値として書き、mk-go backend に対して走らせて drop-in 互換 regression を
+検出する。
+
+## 使い方
+
+```bash
+# stack 起動 (postgres / redis / mkgo)
+make playwright-up
+
+# Playwright runner で spec 実行
+make playwright-test
+
+# stack 停止 (volume 削除)
+make playwright-down
+```
+
+## 構成
+
+```
+[Playwright runner] → [mkgo] → [postgres / redis]
+```
+
+Phase 1 PR-1 では frontend は bundle せず API 中心 spec のみ。後続 PR で
+`page.goto` ベースの spec を追加するときに frontend asset を組み込む。
+
+## ディレクトリ構造
+
+```
+tests/playwright/
+├── playwright.config.ts        # multi-browser 設定 (現状 chromium のみ)
+├── package.json                # @playwright/test 依存
+├── Dockerfile.runner           # Playwright runner image
+├── instance.yml                # mk-go config
+├── fixtures/
+│   ├── api.ts                  # POST /api/<endpoint> ラッパ
+│   └── auth.ts                 # signup / signin helper
+└── specs/
+    └── smoke/                  # Phase 1 minimum
+        └── signup.spec.ts      # signup → /api/i 確認
+```
+
+## Phase 計画 (#744 ref)
+
+- **Phase 1 PR-1 (本 PR)**: 基盤 + smoke spec 1 本
+- **Phase 1 PR-2-N**: 残り Phase 1 spec (notes / streaming / drive ほか)
+- **Phase 1 final**: CI nightly workflow 統合
+- **Phase 2-6**: timeline / users / chat / notification / ... を段階的に追加
+
+## design 原則
+
+- spec は backend-agnostic (= TS / mk-go 両方で同 spec が pass するべき)
+- 失敗 = 非互換 / regression として issue 化する運用
+- Cypress (\`tests/dropin_frontend/\`) / pytest (\`tests/dropin/\`) は並走で残す

--- a/tests/playwright/fixtures/api.ts
+++ b/tests/playwright/fixtures/api.ts
@@ -1,0 +1,43 @@
+// #744 Phase 1: REST helper used across spec files.
+// Misskey API は POST /api/<endpoint> に JSON body を送る規約 (cy.request
+// で dropin cypress 側もそうしている)。Playwright の APIRequestContext を
+// 直接使うラッパとして書く。
+
+import type { APIRequestContext, APIResponse } from '@playwright/test';
+
+// MK_BASE_URL is the base origin for the mk-go backend. spec の playwright
+// config で baseURL を mkgo container に向けているのでここでは同 env から
+// 読む。Playwright runner container の env として供給される。
+const baseURL = process.env.MK_BASE_URL ?? 'http://mkgo:3000';
+
+// callApi は POST /api/<endpoint> を JSON body で叩く最小ラッパ。
+// failOnStatusCode を切ってあるので 4xx/5xx でも APIResponse が返る。
+// 呼び出し側で resp.status() / resp.json() を見る。
+export async function callApi(
+  request: APIRequestContext,
+  endpoint: string,
+  body: Record<string, unknown> = {},
+): Promise<APIResponse> {
+  return request.post(`${baseURL}/api/${endpoint}`, {
+    data: body,
+    failOnStatusCode: false,
+  });
+}
+
+// admin/accounts/create は root 作成時のみ通る。upstream Misskey TS は
+// 1 回目の signup で root を作成、2 回目以降の同 endpoint は 403。
+// signup helper として「最初の呼び出しなら root が作成される」前提。
+export async function createRootAccount(
+  request: APIRequestContext,
+  username: string,
+  password: string,
+): Promise<{ id: string; token: string }> {
+  const resp = await callApi(request, 'admin/accounts/create', { username, password });
+  if (resp.status() !== 200) {
+    throw new Error(
+      `admin/accounts/create failed: ${resp.status()} ${await resp.text()}`,
+    );
+  }
+  const body = await resp.json();
+  return { id: body.id, token: body.token };
+}

--- a/tests/playwright/fixtures/auth.ts
+++ b/tests/playwright/fixtures/auth.ts
@@ -1,9 +1,9 @@
-// #744 Phase 1: signup / signin helper.
+// #744 Phase 1: signup helper.
 // upstream Misskey TS の signup-flow / signin-flow と互換な request を投げ、
 // 取得した access token を spec から再利用できる形にする。
 
 import type { APIRequestContext } from '@playwright/test';
-import { callApi, createRootAccount } from './api';
+import { createRootAccount } from './api';
 
 export interface Principal {
   id: string;
@@ -11,10 +11,15 @@ export interface Principal {
   username: string;
 }
 
-// signup creates the very first account on the freshly-bootstrapped instance
-// via admin/accounts/create. mk-go が 2 回目以降に同 endpoint を 403 にする
-// ことは upstream と同じ挙動なので、複数 user が必要な spec では別経路
-// (signup-flow) を使う。Phase 1 smoke では root 1 人で十分なので最小実装。
+// signupRoot creates the very first account on the freshly-bootstrapped
+// instance via admin/accounts/create. upstream Misskey TS と互換挙動で、
+// 2 回目以降の同 endpoint は 403。
+//
+// **冪等性の前提**: 本 helper を 2 回呼ぶには間に DB volume の clean が
+// 必要 (= `make playwright-down` → `make playwright-up`)。Phase 1 では
+// stack を毎回 fresh で立てる前提なので問題ない。複数 spec が同一 stack
+// で走る後続 PR では globalSetup で DB reset を組み込むか、signup-flow
+// 経路 (= 通常 user 作成) の helper を追加する想定。
 export async function signupRoot(
   request: APIRequestContext,
   username = 'alice',
@@ -22,25 +27,4 @@ export async function signupRoot(
 ): Promise<Principal> {
   const created = await createRootAccount(request, username, password);
   return { ...created, username };
-}
-
-// signin posts /api/signin-flow with the password and returns the token.
-// /api/i で hydrate するのは fetch 側の責任 (Misskey の signin-flow は
-// `{finished: true, i: <token>}` を返すが id を含まない、 Phase 1 では
-// id まで必要なら createRootAccount の戻り値を持ち回せばよい)。
-export async function signin(
-  request: APIRequestContext,
-  username: string,
-  password: string,
-): Promise<string> {
-  const resp = await callApi(request, 'signin-flow', { username, password });
-  if (resp.status() !== 200) {
-    throw new Error(`signin-flow failed: ${resp.status()} ${await resp.text()}`);
-  }
-  const body = await resp.json();
-  const token = body.i ?? body.token;
-  if (!token) {
-    throw new Error(`signin-flow returned no token: ${JSON.stringify(body)}`);
-  }
-  return token as string;
 }

--- a/tests/playwright/fixtures/auth.ts
+++ b/tests/playwright/fixtures/auth.ts
@@ -1,0 +1,46 @@
+// #744 Phase 1: signup / signin helper.
+// upstream Misskey TS の signup-flow / signin-flow と互換な request を投げ、
+// 取得した access token を spec から再利用できる形にする。
+
+import type { APIRequestContext } from '@playwright/test';
+import { callApi, createRootAccount } from './api';
+
+export interface Principal {
+  id: string;
+  token: string;
+  username: string;
+}
+
+// signup creates the very first account on the freshly-bootstrapped instance
+// via admin/accounts/create. mk-go が 2 回目以降に同 endpoint を 403 にする
+// ことは upstream と同じ挙動なので、複数 user が必要な spec では別経路
+// (signup-flow) を使う。Phase 1 smoke では root 1 人で十分なので最小実装。
+export async function signupRoot(
+  request: APIRequestContext,
+  username = 'alice',
+  password = 'password1234',
+): Promise<Principal> {
+  const created = await createRootAccount(request, username, password);
+  return { ...created, username };
+}
+
+// signin posts /api/signin-flow with the password and returns the token.
+// /api/i で hydrate するのは fetch 側の責任 (Misskey の signin-flow は
+// `{finished: true, i: <token>}` を返すが id を含まない、 Phase 1 では
+// id まで必要なら createRootAccount の戻り値を持ち回せばよい)。
+export async function signin(
+  request: APIRequestContext,
+  username: string,
+  password: string,
+): Promise<string> {
+  const resp = await callApi(request, 'signin-flow', { username, password });
+  if (resp.status() !== 200) {
+    throw new Error(`signin-flow failed: ${resp.status()} ${await resp.text()}`);
+  }
+  const body = await resp.json();
+  const token = body.i ?? body.token;
+  if (!token) {
+    throw new Error(`signin-flow returned no token: ${JSON.stringify(body)}`);
+  }
+  return token as string;
+}

--- a/tests/playwright/instance.yml
+++ b/tests/playwright/instance.yml
@@ -1,0 +1,35 @@
+url: http://mkgo:3000/
+port: 3000
+
+db:
+  host: postgres
+  port: 5432
+  db: misskey
+  user: misskey
+  pass: testpass
+
+redis:
+  host: redis
+  port: 6379
+
+redisForPubsub:
+  host: redis
+  port: 6379
+
+redisForJobQueue:
+  host: redis
+  port: 6379
+
+redisForTimelines:
+  host: redis
+  port: 6379
+
+id: aidx
+
+# Playwright phase 1 は federation を行わないが、mk-go init で
+# allowedPrivateNetworks が空配列のときに WARN が出るので最低限を入れる。
+allowedPrivateNetworks:
+  - 127.0.0.0/8
+  - 10.0.0.0/8
+  - 172.16.0.0/12
+  - 192.168.0.0/16

--- a/tests/playwright/package.json
+++ b/tests/playwright/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "mk-playwright",
+  "version": "0.0.0",
+  "private": true,
+  "description": "Playwright e2e for mk-go (#744). Spec is written against upstream Misskey TS behaviour and run against mk-go to detect compat regressions.",
+  "scripts": {
+    "test": "playwright test",
+    "test:headed": "playwright test --headed"
+  },
+  "devDependencies": {
+    "@playwright/test": "^1.49.1",
+    "typescript": "^5.6.3"
+  }
+}

--- a/tests/playwright/playwright.config.ts
+++ b/tests/playwright/playwright.config.ts
@@ -1,0 +1,27 @@
+import { defineConfig } from '@playwright/test';
+
+// #744 Phase 1 PR-1: 基盤と smoke spec のみ。後続 PR で multi-browser /
+// projects / use.storageState を拡張する。
+export default defineConfig({
+  testDir: './specs',
+  // 各 spec はタイムアウト 30s を上限。signup / signin など API レイテンシ
+  // しか伴わないので余裕を持たせて 30s で十分。
+  timeout: 30_000,
+  expect: {
+    timeout: 10_000,
+  },
+  // CI 統合は後続 PR。本 PR はローカル make 経由で動かすので reporter は
+  // list のみ。pretty な HTML report は CI 統合時に追加する。
+  reporter: [['list']],
+  // Phase 1 では全 spec を chromium で 1 回ずつ実行。multi-browser は
+  // CI 統合 PR で `projects` を追加する。
+  use: {
+    baseURL: process.env.MK_BASE_URL ?? 'http://mkgo:3000',
+    // API テスト中心なので screenshot / trace は失敗時のみで十分。
+    screenshot: 'only-on-failure',
+    trace: 'retain-on-failure',
+  },
+  // CI 並列度の調整は CI 統合 PR で。本 PR はローカル直列実行。
+  workers: 1,
+  retries: 0,
+});

--- a/tests/playwright/specs/smoke/signup.spec.ts
+++ b/tests/playwright/specs/smoke/signup.spec.ts
@@ -1,0 +1,27 @@
+// #744 Phase 1 smoke: 最初の root signup が通り、取得した token で /api/i が
+// 自分の user 情報を返すことを確認する。本 spec は upstream Misskey TS の
+// API 規約を期待値とし、mk-go が同じ shape のレスポンスを返すか検証する。
+//
+// API 互換が崩れたら本 spec が fail する (= drop-in 互換 regression を
+// 検出)。
+
+import { expect, test } from '@playwright/test';
+import { callApi } from '../../fixtures/api';
+import { signupRoot } from '../../fixtures/auth';
+
+test.describe('smoke: signup + i', () => {
+  test('first signup creates a root user and /api/i returns it', async ({ request }) => {
+    const me = await signupRoot(request, 'alice', 'password1234');
+    expect(me.id).toBeTruthy();
+    expect(me.token).toBeTruthy();
+    expect(me.username).toBe('alice');
+
+    // /api/i は token を body.i に乗せて取得。upstream Misskey TS と同 shape:
+    // { id, username, isAdmin?, ... } を期待する。
+    const resp = await callApi(request, 'i', { i: me.token });
+    expect(resp.status()).toBe(200);
+    const body = await resp.json();
+    expect(body.id).toBe(me.id);
+    expect(body.username).toBe('alice');
+  });
+});


### PR DESCRIPTION
## Summary

Playwright e2e 基盤 (#744) の最初の PR。upstream Misskey TS の API 互換挙動を期待値として書き、mk-go backend に対して spec を実行することで drop-in 互換 regression を検出する仕組みを最小構成で導入する。

## 構成

\`\`\`
[Playwright runner] → [mkgo] → [postgres / redis]
\`\`\`

- \`docker-compose.playwright.yml\`: postgres + redis + mk-go + Playwright runner。frontend は本 PR では bundle せず API 中心で開始 (page.goto は後続 PR で frontend bundling 追加と一緒に導入)
- \`tests/playwright/Dockerfile.runner\`: 公式 Playwright image v1.49.1 で npm install を image に焼く。bind mount による \`/work/node_modules\` 上書きを anonymous volume で保護
- \`tests/playwright/playwright.config.ts\`: chromium 単一 project、API 中心なので screenshot は失敗時のみ
- \`tests/playwright/fixtures/{api,auth}.ts\`: REST helper + signup/signin
- \`tests/playwright/specs/smoke/signup.spec.ts\`: signup → \`/api/i\` で自分の user info が取れることを確認する 1 spec

## Makefile

cypress dropin 既存 target と同 pattern で:

- \`make playwright-up\` — stack 起動
- \`make playwright-test\` — runner で spec 実行
- \`make playwright-down\` — stack 停止 (volume 削除)
- \`make playwright-logs\` — stack ログ tail

## 動作確認

\`\`\`
$ make playwright-up
$ make playwright-test
Running 1 test using 1 worker

  ✓  1 specs/smoke/signup.spec.ts:13:7 › smoke: signup + i › first signup creates a root user and /api/i returns it (170ms)

  1 passed (753ms)
\`\`\`

ローカル smoke 1 spec が 170ms で pass を確認済み。

## 設計の意図

- spec は backend-agnostic (= TS / mk-go 両方で同 spec が pass するべき)
- spec が失敗した場合は **mk-go の非互換 / regression として issue 化** する運用
- Cypress (\`tests/dropin_frontend/\`) と pytest (\`tests/dropin/\`) は **並走で残す** (本 PR は新規系統の追加)
- frontend bundling / \`page.goto\` ベース spec は後続 PR で frontend asset を組み込むときに追加

## 範囲外 (後続 PR で順次)

- 残り Phase 1 spec (auth フル / notes CRUD / streaming / drive)
- frontend bundling と \`page.goto\` ベース spec
- CI nightly workflow 統合
- multi-browser (firefox / webkit)
- 失敗時 trace / HTML report の整備

各 PR は数 spec 単位で順次出す。Phase 2 以降の機能群 (timeline / chat / etc.) は本 issue 完了後に別 issue で tracking する想定。

## 関連

- \`Refs #744\` (Phase 1 完了は spec 拡充と CI 統合 PR で satisfy する想定なので本 PR では Closes しない)

🤖 Generated with [Claude Code](https://claude.com/claude-code)