### PR TITLE
Phase 14-Playwright PR-2 (#744): auth spec (signin / signup-flow / signin reject)

### DIFF
--- a/tests/playwright/.gitignore
+++ b/tests/playwright/.gitignore
@@ -3,3 +3,5 @@ node_modules/
 test-results/
 playwright-report/
 package-lock.json
+# globalSetup が root credentials を書き出す fixture ディレクトリ (#744 PR-2)。
+.auth/

--- a/tests/playwright/Dockerfile.runner
+++ b/tests/playwright/Dockerfile.runner
@@ -9,6 +9,13 @@
 # 後続 PR で必要に応じて bump する。
 FROM mcr.microsoft.com/playwright:v1.49.1-jammy
 
+# globalSetup から redis-cli を呼んで rate limit counter を flush する
+# (#744 PR-2): mk-go の signup endpoint は IP base で 1h 5 回 hardcoded で
+# spec 累積で 429 になる。test 開始時に Redis を空にすれば毎回 fresh。
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends redis-tools \
+    && rm -rf /var/lib/apt/lists/*
+
 WORKDIR /work
 
 # package.json と package-lock.json を先 copy して node_modules を image に

--- a/tests/playwright/fixtures/api.ts
+++ b/tests/playwright/fixtures/api.ts
@@ -23,21 +23,3 @@ export async function callApi(
     failOnStatusCode: false,
   });
 }
-
-// admin/accounts/create は root 作成時のみ通る。upstream Misskey TS は
-// 1 回目の signup で root を作成、2 回目以降の同 endpoint は 403。
-// signup helper として「最初の呼び出しなら root が作成される」前提。
-export async function createRootAccount(
-  request: APIRequestContext,
-  username: string,
-  password: string,
-): Promise<{ id: string; token: string }> {
-  const resp = await callApi(request, 'admin/accounts/create', { username, password });
-  if (resp.status() !== 200) {
-    throw new Error(
-      `admin/accounts/create failed: ${resp.status()} ${await resp.text()}`,
-    );
-  }
-  const body = await resp.json();
-  return { id: body.id, token: body.token };
-}

--- a/tests/playwright/fixtures/auth.ts
+++ b/tests/playwright/fixtures/auth.ts
@@ -1,9 +1,14 @@
-// #744 Phase 1: signup helper.
+// #744 Phase 1: signup / signin helper.
 // upstream Misskey TS の signup-flow / signin-flow と互換な request を投げ、
 // 取得した access token を spec から再利用できる形にする。
+//
+// 注: root account (admin/accounts/create) の作成と
+// disableRegistration=false の切替は globalSetup で行う (spec 開始前に
+// 1 度だけ)。本 fixture では signup-flow / signin-flow の通常経路のみ
+// 提供する。
 
 import type { APIRequestContext } from '@playwright/test';
-import { createRootAccount } from './api';
+import { callApi } from './api';
 
 export interface Principal {
   id: string;
@@ -11,20 +16,44 @@ export interface Principal {
   username: string;
 }
 
-// signupRoot creates the very first account on the freshly-bootstrapped
-// instance via admin/accounts/create. upstream Misskey TS と互換挙動で、
-// 2 回目以降の同 endpoint は 403。
+// signupUser creates a regular (non-root) account via /api/signup. Phase 1
+// では captcha / email 認証は disabled な instance config を使うので
+// username + password だけで通る。複数回呼んでも username が違えば成功。
 //
-// **冪等性の前提**: 本 helper を 2 回呼ぶには間に DB volume の clean が
-// 必要 (= `make playwright-down` → `make playwright-up`)。Phase 1 では
-// stack を毎回 fresh で立てる前提なので問題ない。複数 spec が同一 stack
-// で走る後続 PR では globalSetup で DB reset を組み込むか、signup-flow
-// 経路 (= 通常 user 作成) の helper を追加する想定。
-export async function signupRoot(
+// 同 instance で並列に user を作る spec はこの helper を使う (root 1 人
+// しか作れない signupRoot と違って複数 user が必要な test に対応する)。
+export async function signupUser(
   request: APIRequestContext,
-  username = 'alice',
+  username: string,
   password = 'password1234',
 ): Promise<Principal> {
-  const created = await createRootAccount(request, username, password);
-  return { ...created, username };
+  const resp = await callApi(request, 'signup', { username, password });
+  if (resp.status() !== 200) {
+    throw new Error(`signup failed: ${resp.status()} ${await resp.text()}`);
+  }
+  const body = await resp.json();
+  return { id: body.id, token: body.token, username };
+}
+
+// signin posts /api/signin-flow and returns the access token. upstream
+// Misskey TS は #705 で本家準拠化されており、レスポンスは
+// `{finished: true, i: <token>}`。
+//
+// signin-flow が 2FA / passkey 経路に分岐するアカウント (= step 1 で
+// `next: 'totp' | 'passkey'`) は本 helper では扱わない。Phase 1 では
+// password のみの signin path を test する。
+export async function signin(
+  request: APIRequestContext,
+  username: string,
+  password: string,
+): Promise<string> {
+  const resp = await callApi(request, 'signin-flow', { username, password });
+  if (resp.status() !== 200) {
+    throw new Error(`signin-flow failed: ${resp.status()} ${await resp.text()}`);
+  }
+  const body = await resp.json();
+  if (!body.i) {
+    throw new Error(`signin-flow returned no token: ${JSON.stringify(body)}`);
+  }
+  return body.i as string;
 }

--- a/tests/playwright/fixtures/auth.ts
+++ b/tests/playwright/fixtures/auth.ts
@@ -1,11 +1,11 @@
 // #744 Phase 1: signup / signin helper.
-// upstream Misskey TS の signup-flow / signin-flow と互換な request を投げ、
+// upstream Misskey TS と互換な /api/signup と /api/signin-flow を叩き、
 // 取得した access token を spec から再利用できる形にする。
 //
 // 注: root account (admin/accounts/create) の作成と
 // disableRegistration=false の切替は globalSetup で行う (spec 開始前に
-// 1 度だけ)。本 fixture では signup-flow / signin-flow の通常経路のみ
-// 提供する。
+// 1 度だけ)。本 fixture では signup endpoint と signin-flow の通常経路
+// のみ提供する。
 
 import type { APIRequestContext } from '@playwright/test';
 import { callApi } from './api';
@@ -20,8 +20,8 @@ export interface Principal {
 // では captcha / email 認証は disabled な instance config を使うので
 // username + password だけで通る。複数回呼んでも username が違えば成功。
 //
-// 同 instance で並列に user を作る spec はこの helper を使う (root 1 人
-// しか作れない signupRoot と違って複数 user が必要な test に対応する)。
+// 同 instance で複数 user が必要な spec はこの helper を使う
+// (admin/accounts/create は 1 度しか通らないので root 専用)。
 export async function signupUser(
   request: APIRequestContext,
   username: string,

--- a/tests/playwright/fixtures/rate_limit.ts
+++ b/tests/playwright/fixtures/rate_limit.ts
@@ -1,0 +1,25 @@
+// #744 Phase 1: rate limit reset helper.
+//
+// mk-go の signup endpoint は IP base 1h 5 回 hardcoded
+// (internal/server/middleware/ratelimit_defs.go)。spec 累積で 429 になる
+// のを防ぐため、test の境界で Redis を flush して counter をゼロから
+// 始める。後続 PR で signup endpoint を更に使う spec が増えても、各 spec
+// の beforeAll で `resetRateLimit()` を呼べば独立性が保たれる。
+//
+// `redis-cli` は Dockerfile.runner で apt 経由で install 済み。
+// child_process.execFileSync で同期的に発行する (Playwright fixture は
+// async OK だが redis-cli が ms オーダーで終わるので sync で十分)。
+
+import { execFileSync } from 'node:child_process';
+
+const REDIS_HOST = process.env.MK_REDIS_HOST ?? 'redis';
+
+// resetRateLimit issues `redis-cli FLUSHDB` against the test stack's redis.
+// Throws when the command is unreachable so callers fail fast (= globalSetup
+// or a spec's beforeAll) instead of letting later 429s mask the root cause.
+export function resetRateLimit(): void {
+  execFileSync('redis-cli', ['-h', REDIS_HOST, 'FLUSHDB'], {
+    stdio: 'pipe',
+    timeout: 5_000,
+  });
+}

--- a/tests/playwright/global-setup.ts
+++ b/tests/playwright/global-setup.ts
@@ -16,25 +16,18 @@
 // root の credentials は `.auth/root.json` に書き出して spec から読める
 // ようにする。複数 spec で root token を再利用するための fixture。
 
-import { execFileSync } from 'node:child_process';
 import { mkdirSync, writeFileSync } from 'node:fs';
 import { request as createRequest } from '@playwright/test';
+import { resetRateLimit } from './fixtures/rate_limit';
 
 const baseURL = process.env.MK_BASE_URL ?? 'http://mkgo:3000';
 
 export default async function globalSetup(): Promise<void> {
-  // 1. Redis flush
-  try {
-    execFileSync('redis-cli', ['-h', 'redis', 'FLUSHDB'], {
-      stdio: 'pipe',
-      timeout: 5_000,
-    });
-    // eslint-disable-next-line no-console
-    console.log('[globalSetup] redis FLUSHDB done');
-  } catch (err) {
-    // eslint-disable-next-line no-console
-    console.warn('[globalSetup] redis FLUSHDB failed (continuing):', err);
-  }
+  // 1. Redis flush (#744 PR-2). 失敗は throw して fail-fast にする —
+  // silent warn だと後段の signup spec が 429 で fail して原因が見えない。
+  resetRateLimit();
+  // eslint-disable-next-line no-console
+  console.log('[globalSetup] redis FLUSHDB done');
 
   const ctx = await createRequest.newContext();
   try {

--- a/tests/playwright/global-setup.ts
+++ b/tests/playwright/global-setup.ts
@@ -1,0 +1,79 @@
+// #744 Phase 1 PR-2: Playwright globalSetup.
+//
+// 全 spec が start する前に 1 度だけ実行される。本 globalSetup は instance
+// を test runnable な状態に整える 3 つの仕事を行う:
+//
+//   1. Redis FLUSHDB — mk-go の signup endpoint は IP base 1h 5 回の rate
+//      limit が hardcoded (internal/server/middleware/ratelimit_defs.go)
+//      で、test 累積で 429 になるため毎 run で counter をゼロから始める
+//   2. admin/accounts/create で root (alice) を作成 — admin/update-meta
+//      など admin 専用 API を叩くために必須
+//   3. admin/update-meta で disableRegistration=false に切替 — model/meta.go
+//      の default は true で、initial state の signup endpoint は invitation
+//      コード必須。Phase 1 spec は signup-flow で fresh user を作るので
+//      registration を open にしておく
+//
+// root の credentials は `.auth/root.json` に書き出して spec から読める
+// ようにする。複数 spec で root token を再利用するための fixture。
+
+import { execFileSync } from 'node:child_process';
+import { mkdirSync, writeFileSync } from 'node:fs';
+import { request as createRequest } from '@playwright/test';
+
+const baseURL = process.env.MK_BASE_URL ?? 'http://mkgo:3000';
+
+export default async function globalSetup(): Promise<void> {
+  // 1. Redis flush
+  try {
+    execFileSync('redis-cli', ['-h', 'redis', 'FLUSHDB'], {
+      stdio: 'pipe',
+      timeout: 5_000,
+    });
+    // eslint-disable-next-line no-console
+    console.log('[globalSetup] redis FLUSHDB done');
+  } catch (err) {
+    // eslint-disable-next-line no-console
+    console.warn('[globalSetup] redis FLUSHDB failed (continuing):', err);
+  }
+
+  const ctx = await createRequest.newContext();
+  try {
+    // 2. Root 作成 (admin/accounts/create は 1 回目だけ通る)
+    const createResp = await ctx.post(`${baseURL}/api/admin/accounts/create`, {
+      data: { username: 'alice', password: 'password1234' },
+      failOnStatusCode: false,
+    });
+    if (createResp.status() !== 200) {
+      throw new Error(
+        `globalSetup admin/accounts/create failed: ${createResp.status()} ${await createResp.text()}`,
+      );
+    }
+    const root = await createResp.json();
+
+    // 3. disableRegistration=false に切り替え
+    const metaResp = await ctx.post(`${baseURL}/api/admin/update-meta`, {
+      data: { i: root.token, disableRegistration: false },
+      failOnStatusCode: false,
+    });
+    if (metaResp.status() !== 200 && metaResp.status() !== 204) {
+      throw new Error(
+        `globalSetup admin/update-meta failed: ${metaResp.status()} ${await metaResp.text()}`,
+      );
+    }
+
+    // root credentials を spec から読めるように file 出力
+    mkdirSync('.auth', { recursive: true });
+    writeFileSync(
+      '.auth/root.json',
+      JSON.stringify({
+        id: root.id,
+        token: root.token,
+        username: 'alice',
+      }),
+    );
+    // eslint-disable-next-line no-console
+    console.log('[globalSetup] root account ready, registration opened');
+  } finally {
+    await ctx.dispose();
+  }
+}

--- a/tests/playwright/playwright.config.ts
+++ b/tests/playwright/playwright.config.ts
@@ -4,6 +4,10 @@ import { defineConfig } from '@playwright/test';
 // projects / use.storageState を拡張する。
 export default defineConfig({
   testDir: './specs',
+  // globalSetup: Redis を flush して rate limit counter をゼロから始める
+  // (#744 PR-2)。signup endpoint の 1h 5 回制限が test 累積で 429 になる
+  // のを防ぐ。詳細は global-setup.ts のコメント参照。
+  globalSetup: './global-setup.ts',
   // 各 spec はタイムアウト 30s を上限。signup / signin など API レイテンシ
   // しか伴わないので余裕を持たせて 30s で十分。
   timeout: 30_000,

--- a/tests/playwright/specs/auth/signin.spec.ts
+++ b/tests/playwright/specs/auth/signin.spec.ts
@@ -8,8 +8,15 @@
 import { expect, test } from '@playwright/test';
 import { callApi } from '../../fixtures/api';
 import { signin, signupUser } from '../../fixtures/auth';
+import { resetRateLimit } from '../../fixtures/rate_limit';
 
 test.describe('auth: signin-flow', () => {
+  test.beforeAll(() => {
+    // signup endpoint の 1h 5 回 rate limit (#744) を毎 spec 開始前に
+    // ゼロから始める。複数 spec で連続して signup する設計を支える。
+    resetRateLimit();
+  });
+
   test('signin returns a working access token', async ({ request }) => {
     // signup で fresh user を作る。username は時間 uniq で他 spec / 並列実行と
     // 衝突しないようにする (`workers: 1` でも安全側)。
@@ -18,16 +25,13 @@ test.describe('auth: signin-flow', () => {
     expect(created.id).toBeTruthy();
     expect(created.token).toBeTruthy();
 
-    // 取得した user で signin-flow を叩いて別の token を取得する。signin が
-    // 通れば「username + password で auth できる」ことが確認できる。
+    // 取得した user で signin-flow を叩いて access token を取得し、その
+    // token で /api/i が hydrate できることを確認する。signup が返す
+    // token と signin が返す token の同一性は upstream 仕様の動く部分
+    // (= mk-go / TS で異なる可能性) なので assert しない。
     const token = await signin(request, username, 'password1234');
     expect(token).toBeTruthy();
-    // signin token と signup の戻り token は同じか別かは upstream 仕様次第。
-    // mk-go では signup が作る token と signin が取り出す token は別物
-    // (= signin は新しい access_token を発行する) ので、ここでは「いずれの
-    // token も /api/i に対して valid であること」だけ assert する。
 
-    // /api/i で hydrate して username を確認する。
     const me = await callApi(request, 'i', { i: token });
     expect(me.status()).toBe(200);
     const body = await me.json();

--- a/tests/playwright/specs/auth/signin.spec.ts
+++ b/tests/playwright/specs/auth/signin.spec.ts
@@ -1,0 +1,37 @@
+// #744 Phase 1 PR-2: signin-flow の正常系。
+// signupUser で通常 user を作成 → signin-flow で access token を取得 →
+// /api/i で自分の user 情報が取れる ことを確認する。
+//
+// upstream Misskey TS と互換な API shape を期待するので、mk-go の signin
+// レスポンスが上流から drift したら本 spec が fail する。
+
+import { expect, test } from '@playwright/test';
+import { callApi } from '../../fixtures/api';
+import { signin, signupUser } from '../../fixtures/auth';
+
+test.describe('auth: signin-flow', () => {
+  test('signin returns a working access token', async ({ request }) => {
+    // signup で fresh user を作る。username は時間 uniq で他 spec / 並列実行と
+    // 衝突しないようにする (`workers: 1` でも安全側)。
+    const username = `signin_${Date.now()}`;
+    const created = await signupUser(request, username, 'password1234');
+    expect(created.id).toBeTruthy();
+    expect(created.token).toBeTruthy();
+
+    // 取得した user で signin-flow を叩いて別の token を取得する。signin が
+    // 通れば「username + password で auth できる」ことが確認できる。
+    const token = await signin(request, username, 'password1234');
+    expect(token).toBeTruthy();
+    // signin token と signup の戻り token は同じか別かは upstream 仕様次第。
+    // mk-go では signup が作る token と signin が取り出す token は別物
+    // (= signin は新しい access_token を発行する) ので、ここでは「いずれの
+    // token も /api/i に対して valid であること」だけ assert する。
+
+    // /api/i で hydrate して username を確認する。
+    const me = await callApi(request, 'i', { i: token });
+    expect(me.status()).toBe(200);
+    const body = await me.json();
+    expect(body.id).toBe(created.id);
+    expect(body.username).toBe(username);
+  });
+});

--- a/tests/playwright/specs/auth/signin_invalid.spec.ts
+++ b/tests/playwright/specs/auth/signin_invalid.spec.ts
@@ -8,8 +8,13 @@
 import { expect, test } from '@playwright/test';
 import { callApi } from '../../fixtures/api';
 import { signupUser } from '../../fixtures/auth';
+import { resetRateLimit } from '../../fixtures/rate_limit';
 
 test.describe('auth: signin-flow rejects invalid credentials', () => {
+  test.beforeAll(() => {
+    resetRateLimit();
+  });
+
   test('wrong password is rejected without a token', async ({ request }) => {
     const username = `signin_invalid_${Date.now()}`;
     await signupUser(request, username, 'correct-password');

--- a/tests/playwright/specs/auth/signin_invalid.spec.ts
+++ b/tests/playwright/specs/auth/signin_invalid.spec.ts
@@ -1,0 +1,41 @@
+// #744 Phase 1 PR-2: signin-flow の失敗系。
+// 不正 password / 存在しない user / 空 password に対して 4xx で reject する
+// ことを確認する。upstream Misskey TS は password 不一致時に 400 + error
+// id を返す挙動を取るので、mk-go も同じ shape を返すことを assert する。
+//
+// 本 spec は negative path のみで token が発行されないことを確認する。
+
+import { expect, test } from '@playwright/test';
+import { callApi } from '../../fixtures/api';
+import { signupUser } from '../../fixtures/auth';
+
+test.describe('auth: signin-flow rejects invalid credentials', () => {
+  test('wrong password is rejected without a token', async ({ request }) => {
+    const username = `signin_invalid_${Date.now()}`;
+    await signupUser(request, username, 'correct-password');
+
+    // 違う password で signin-flow を叩く。upstream の signin-flow は password
+    // mismatch を 400 系で返す (具体 status code は upstream 仕様で 400 / 403
+    // の揺らぎがあるので status 範囲で assert)。
+    const resp = await callApi(request, 'signin-flow', {
+      username,
+      password: 'wrong-password',
+    });
+    expect(resp.status()).toBeGreaterThanOrEqual(400);
+    expect(resp.status()).toBeLessThan(500);
+
+    // token が発行されていないこと。`finished: true, i: ...` の shape では
+    // ない (= 失敗 response)。
+    const body = await resp.json().catch(() => ({}));
+    expect(body.i).toBeFalsy();
+  });
+
+  test('non-existent username is rejected without a token', async ({ request }) => {
+    const resp = await callApi(request, 'signin-flow', {
+      username: `ghost_${Date.now()}`,
+      password: 'whatever',
+    });
+    expect(resp.status()).toBeGreaterThanOrEqual(400);
+    expect(resp.status()).toBeLessThan(500);
+  });
+});

--- a/tests/playwright/specs/auth/signup.spec.ts
+++ b/tests/playwright/specs/auth/signup.spec.ts
@@ -9,8 +9,13 @@
 import { expect, test } from '@playwright/test';
 import { callApi } from '../../fixtures/api';
 import { signupUser } from '../../fixtures/auth';
+import { resetRateLimit } from '../../fixtures/rate_limit';
 
 test.describe('auth: signup-flow', () => {
+  test.beforeAll(() => {
+    resetRateLimit();
+  });
+
   test('multiple users can sign up and each gets a working token', async ({ request }) => {
     const stamp = Date.now();
     const usernames = [`user_a_${stamp}`, `user_b_${stamp}`];
@@ -33,8 +38,15 @@ test.describe('auth: signup-flow', () => {
     }
   });
 
-  // 注: duplicate username の test は signup endpoint を 2 連続で叩くため、
-  // mk-go の signup rate limit (1h 5 回) と signin_invalid spec / signin
-  // spec の signup と合わせて 6 回目で 429 になる。後続 PR で beforeEach
-  // の Redis flush helper を整備してから duplicate spec を追加する。
+  test('duplicate username is rejected', async ({ request }) => {
+    const username = `dupe_${Date.now()}`;
+    await signupUser(request, username, 'password1234');
+
+    // 同 username で 2 度目の signup は USERNAME_ALREADY_EXISTS で 409。
+    // upstream Misskey TS と同じ error code / status を返す shape 互換。
+    const resp = await callApi(request, 'signup', { username, password: 'password1234' });
+    expect(resp.status()).toBe(409);
+    const body = await resp.json();
+    expect(body.error?.code).toBe('USERNAME_ALREADY_EXISTS');
+  });
 });

--- a/tests/playwright/specs/auth/signup.spec.ts
+++ b/tests/playwright/specs/auth/signup.spec.ts
@@ -1,0 +1,40 @@
+// #744 Phase 1 PR-2: signup-flow で複数 user を作成できることを確認する。
+// admin/accounts/create と違って /api/signup は 2 人目以降も通る (= captcha /
+// invitation などの制限がない default config を前提)。
+//
+// 本 spec は drop-in 互換の重要 path: mk-go が upstream Misskey TS と同じ
+// signup endpoint を提供し、token / id を期待 shape で返すことを assert
+// する。
+
+import { expect, test } from '@playwright/test';
+import { callApi } from '../../fixtures/api';
+import { signupUser } from '../../fixtures/auth';
+
+test.describe('auth: signup-flow', () => {
+  test('multiple users can sign up and each gets a working token', async ({ request }) => {
+    const stamp = Date.now();
+    const usernames = [`user_a_${stamp}`, `user_b_${stamp}`];
+
+    const principals = await Promise.all(
+      usernames.map((u) => signupUser(request, u, 'password1234')),
+    );
+
+    // それぞれ別 id / 別 token を持つこと。
+    expect(principals[0].id).not.toBe(principals[1].id);
+    expect(principals[0].token).not.toBe(principals[1].token);
+
+    // 各 token が /api/i で正しい user を返すこと。
+    for (const p of principals) {
+      const resp = await callApi(request, 'i', { i: p.token });
+      expect(resp.status()).toBe(200);
+      const body = await resp.json();
+      expect(body.id).toBe(p.id);
+      expect(body.username).toBe(p.username);
+    }
+  });
+
+  // 注: duplicate username の test は signup endpoint を 2 連続で叩くため、
+  // mk-go の signup rate limit (1h 5 回) と signin_invalid spec / signin
+  // spec の signup と合わせて 6 回目で 429 になる。後続 PR で beforeEach
+  // の Redis flush helper を整備してから duplicate spec を追加する。
+});

--- a/tests/playwright/specs/smoke/signup.spec.ts
+++ b/tests/playwright/specs/smoke/signup.spec.ts
@@ -1,27 +1,33 @@
-// #744 Phase 1 smoke: 最初の root signup が通り、取得した token で /api/i が
-// 自分の user 情報を返すことを確認する。本 spec は upstream Misskey TS の
-// API 規約を期待値とし、mk-go が同じ shape のレスポンスを返すか検証する。
+// #744 Phase 1 smoke: globalSetup が root を用意した状態で /api/i が
+// upstream Misskey TS と同じ shape を返すことを確認する。
 //
-// API 互換が崩れたら本 spec が fail する (= drop-in 互換 regression を
-// 検出)。
+// PR-1 の構成では本 spec が直接 admin/accounts/create を叩いていたが、
+// PR-2 で globalSetup に admin 系 setup を集約した (= 複数 spec が rate
+// limit や disableRegistration の制約に引っかからないように)。本 spec は
+// globalSetup の動作確認も兼ねる: root credentials が `.auth/root.json` に
+// 書き出され、それを使って /api/i が valid response を返せること。
 
+import { readFileSync } from 'node:fs';
 import { expect, test } from '@playwright/test';
 import { callApi } from '../../fixtures/api';
-import { signupRoot } from '../../fixtures/auth';
 
-test.describe('smoke: signup + i', () => {
-  test('first signup creates a root user and /api/i returns it', async ({ request }) => {
-    const me = await signupRoot(request, 'alice', 'password1234');
-    expect(me.id).toBeTruthy();
-    expect(me.token).toBeTruthy();
-    expect(me.username).toBe('alice');
+interface RootFixture {
+  id: string;
+  token: string;
+  username: string;
+}
 
-    // /api/i は token を body.i に乗せて取得。upstream Misskey TS と同 shape:
-    // { id, username, isAdmin?, ... } を期待する。
-    const resp = await callApi(request, 'i', { i: me.token });
+test.describe('smoke: root via globalSetup + /api/i', () => {
+  test('root credentials persist and hydrate via /api/i', async ({ request }) => {
+    const root: RootFixture = JSON.parse(readFileSync('.auth/root.json', 'utf-8'));
+    expect(root.id).toBeTruthy();
+    expect(root.token).toBeTruthy();
+    expect(root.username).toBe('alice');
+
+    const resp = await callApi(request, 'i', { i: root.token });
     expect(resp.status()).toBe(200);
     const body = await resp.json();
-    expect(body.id).toBe(me.id);
+    expect(body.id).toBe(root.id);
     expect(body.username).toBe('alice');
   });
 });


### PR DESCRIPTION
## Summary

Phase 1 PR-2: 認証系 spec を 4 本追加。signup-flow / signin-flow の正常系と、不正 password / 不存在 user の reject を upstream Misskey TS API 互換挙動として assert する。

## 主な変更

### globalSetup の強化

PR-1 では smoke spec が直接 \`admin/accounts/create\` を叩いていたが、複数 spec が同一 stack で動く本 PR では rate limit / disableRegistration の制約に当たるので setup を 1 箇所に集約した:

1. \`redis-cli FLUSHDB\` — signup の 1h 5 回 hardcoded rate limit (\`internal/server/middleware/ratelimit_defs.go\`) の counter をゼロから
2. \`admin/accounts/create\` で root (alice) を作成
3. \`admin/update-meta\` で \`disableRegistration: false\` に切替 (\`model/meta.go\` default は \`true\`)
4. root credentials を \`.auth/root.json\` に書き出し spec から再利用

\`Dockerfile.runner\` に \`redis-tools\` を追加。\`.auth/\` は gitignore。

### fixtures

- \`createRootAccount\` / \`signupRoot\` を削除 (globalSetup 経由になり dead helper 化)
- \`signupUser\` 新設 — \`/api/signup\` で通常 user 作成
- \`signin\` 新設 — \`/api/signin-flow\` で access token 取得

### 新規 spec

| spec | 内容 |
|---|---|
| \`auth/signin.spec.ts\` | signupUser → signin → \`/api/i\` で hydrate |
| \`auth/signin_invalid.spec.ts\` | 不正 password / 不存在 user で 4xx |
| \`auth/signup.spec.ts\` | 複数 user signup-flow で各々別 token valid |

### 既存 smoke spec を pivot

\`smoke/signup.spec.ts\` は globalSetup の root credentials を読んで \`/api/i\` の shape を確認する形に変更。globalSetup 動作確認も兼ねる。

## 動作確認

\`\`\`
$ make playwright-down && make playwright-up && make playwright-test
[globalSetup] redis FLUSHDB done
[globalSetup] root account ready, registration opened

Running 5 tests using 1 worker
  ✓  signin_invalid › wrong password rejected (330ms)
  ✓  signin_invalid › non-existent username rejected (13ms)
  ✓  signin › signin returns working token (162ms)
  ✓  signup › multiple users can sign up (203ms)
  ✓  smoke › root credentials persist (11ms)

  5 passed (1.6s)
\`\`\`

## 範囲外 (後続 PR)

- duplicate username spec — signup endpoint の 1h 5 回 rate limit 制約のため、後続 PR で \`beforeEach\` の Redis flush helper を整備してから追加
- 2FA / passkey signin path
- notes / streaming / drive (PR-3 以降)
- CI nightly workflow

## 関連

- Refs #744 (Phase 1 完了は spec 拡充 + CI 統合 PR で satisfy する想定)
- Phase 1 PR-1 (#795): 基盤 + smoke 1 本

🤖 Generated with [Claude Code](https://claude.com/claude-code)