### PR TITLE
Fix #798: signup duplicate username を 400 DUPLICATED_USERNAME に

### DIFF
--- a/internal/api/signup/handler.go
+++ b/internal/api/signup/handler.go
@@ -150,7 +150,11 @@ func (h *Handler) Signup(c echo.Context) error {
 		pending, perr := h.signupService.CreatePending(req.Username, req.EmailAddress, req.Password, ticketID)
 		if perr != nil {
 			if perr == coresignup.ErrUsernameAlreadyExists {
-				return c.JSON(http.StatusConflict, apierr.Error("USERNAME_ALREADY_EXISTS", "Username already exists.", "0a504947-b888-4a99-9f62-8c4a0f3a3dab"))
+				// upstream Misskey TS は username 重複を 400 + DUPLICATED_USERNAME で
+				// 返す (#798)。mk-go も同 status / code に揃える。UUID は mk-go 内部の
+				// identifier として既存値を保持 (= TS は UUID を返さない / frontend は
+				// code でハンドリングするので互換性に影響なし)。
+				return c.JSON(http.StatusBadRequest, apierr.Error("DUPLICATED_USERNAME", "Username already exists.", "0a504947-b888-4a99-9f62-8c4a0f3a3dab"))
 			}
 			if perr == coresignup.ErrInvalidUsername {
 				return c.JSON(http.StatusBadRequest, apierr.Error("INVALID_PARAM", "Invalid username.", "3d81ceae-475f-4600-b2a8-2bc116157532"))
@@ -187,7 +191,11 @@ func (h *Handler) Signup(c echo.Context) error {
 	result, err := h.signupService.Signup(req.Username, req.Password, false)
 	if err != nil {
 		if err == coresignup.ErrUsernameAlreadyExists {
-			return c.JSON(http.StatusConflict, apierr.Error("USERNAME_ALREADY_EXISTS", "Username already exists.", "0a504947-b888-4a99-9f62-8c4a0f3a3dab"))
+			// upstream Misskey TS は username 重複を 400 + DUPLICATED_USERNAME で
+			// 返す (#798)。mk-go も同 status / code に揃える。UUID は mk-go 内部の
+			// identifier として既存値を保持 (= TS は UUID を返さない / frontend は
+			// code でハンドリングするので互換性に影響なし)。
+			return c.JSON(http.StatusBadRequest, apierr.Error("DUPLICATED_USERNAME", "Username already exists.", "0a504947-b888-4a99-9f62-8c4a0f3a3dab"))
 		}
 		if err == coresignup.ErrInvalidUsername {
 			return c.JSON(http.StatusBadRequest, apierr.Error("INVALID_PARAM", "Invalid username.", "3d81ceae-475f-4600-b2a8-2bc116157532"))
@@ -223,7 +231,11 @@ func (h *Handler) SignupPending(c echo.Context) error {
 		case coresignup.ErrPendingExpired:
 			return c.JSON(http.StatusGone, apierr.Error("EXPIRED", "Pending registration has expired.", "9c2bc685-fa0a-4e6f-bf6f-5f4f8c0c3a3a"))
 		case coresignup.ErrUsernameAlreadyExists:
-			return c.JSON(http.StatusConflict, apierr.Error("USERNAME_ALREADY_EXISTS", "Username already exists.", "0a504947-b888-4a99-9f62-8c4a0f3a3dab"))
+			// upstream Misskey TS は username 重複を 400 + DUPLICATED_USERNAME で
+			// 返す (#798)。mk-go も同 status / code に揃える。UUID は mk-go 内部の
+			// identifier として既存値を保持 (= TS は UUID を返さない / frontend は
+			// code でハンドリングするので互換性に影響なし)。
+			return c.JSON(http.StatusBadRequest, apierr.Error("DUPLICATED_USERNAME", "Username already exists.", "0a504947-b888-4a99-9f62-8c4a0f3a3dab"))
 		case coresignup.ErrInvitationAlreadyUsed:
 			return c.JSON(http.StatusConflict, apierr.Error("INVITATION_ALREADY_USED", "Invitation already used.", "5b81b5e2-2c0b-4d8a-9b71-1a3e1d4d3f6a"))
 		case coresignup.ErrInvitationRevoked:

--- a/internal/api/signup/handler.go
+++ b/internal/api/signup/handler.go
@@ -95,6 +95,24 @@ type signupRequest struct {
 	TestcaptchaResponse string `json:"testcaptcha-response"`
 }
 
+// duplicatedUsernameError は username 重複時の error response を返す。
+//
+// upstream Misskey TS は \`/api/signup\` の username 重複を 400 +
+// DUPLICATED_USERNAME で返す (third_party の SignupApiService.ts:174)。
+// mk-go も同 status / code に揃える (#798)。UUID は mk-go 内部の identifier
+// として既存値を保持 (= TS は UUID を返さない / frontend は code で
+// switch するので互換性に影響なし)。
+//
+// signup-pending 経路 / 通常 signup / signup-pending promote の 3 箇所から
+// 参照されるので helper 化している。
+func duplicatedUsernameError(c echo.Context) error {
+	return c.JSON(http.StatusBadRequest, apierr.Error(
+		"DUPLICATED_USERNAME",
+		"Username already exists.",
+		"0a504947-b888-4a99-9f62-8c4a0f3a3dab",
+	))
+}
+
 // Signup handles POST /api/signup.
 func (h *Handler) Signup(c echo.Context) error {
 	var req signupRequest
@@ -150,11 +168,7 @@ func (h *Handler) Signup(c echo.Context) error {
 		pending, perr := h.signupService.CreatePending(req.Username, req.EmailAddress, req.Password, ticketID)
 		if perr != nil {
 			if perr == coresignup.ErrUsernameAlreadyExists {
-				// upstream Misskey TS は username 重複を 400 + DUPLICATED_USERNAME で
-				// 返す (#798)。mk-go も同 status / code に揃える。UUID は mk-go 内部の
-				// identifier として既存値を保持 (= TS は UUID を返さない / frontend は
-				// code でハンドリングするので互換性に影響なし)。
-				return c.JSON(http.StatusBadRequest, apierr.Error("DUPLICATED_USERNAME", "Username already exists.", "0a504947-b888-4a99-9f62-8c4a0f3a3dab"))
+				return duplicatedUsernameError(c)
 			}
 			if perr == coresignup.ErrInvalidUsername {
 				return c.JSON(http.StatusBadRequest, apierr.Error("INVALID_PARAM", "Invalid username.", "3d81ceae-475f-4600-b2a8-2bc116157532"))
@@ -191,11 +205,7 @@ func (h *Handler) Signup(c echo.Context) error {
 	result, err := h.signupService.Signup(req.Username, req.Password, false)
 	if err != nil {
 		if err == coresignup.ErrUsernameAlreadyExists {
-			// upstream Misskey TS は username 重複を 400 + DUPLICATED_USERNAME で
-			// 返す (#798)。mk-go も同 status / code に揃える。UUID は mk-go 内部の
-			// identifier として既存値を保持 (= TS は UUID を返さない / frontend は
-			// code でハンドリングするので互換性に影響なし)。
-			return c.JSON(http.StatusBadRequest, apierr.Error("DUPLICATED_USERNAME", "Username already exists.", "0a504947-b888-4a99-9f62-8c4a0f3a3dab"))
+			return duplicatedUsernameError(c)
 		}
 		if err == coresignup.ErrInvalidUsername {
 			return c.JSON(http.StatusBadRequest, apierr.Error("INVALID_PARAM", "Invalid username.", "3d81ceae-475f-4600-b2a8-2bc116157532"))
@@ -231,11 +241,7 @@ func (h *Handler) SignupPending(c echo.Context) error {
 		case coresignup.ErrPendingExpired:
 			return c.JSON(http.StatusGone, apierr.Error("EXPIRED", "Pending registration has expired.", "9c2bc685-fa0a-4e6f-bf6f-5f4f8c0c3a3a"))
 		case coresignup.ErrUsernameAlreadyExists:
-			// upstream Misskey TS は username 重複を 400 + DUPLICATED_USERNAME で
-			// 返す (#798)。mk-go も同 status / code に揃える。UUID は mk-go 内部の
-			// identifier として既存値を保持 (= TS は UUID を返さない / frontend は
-			// code でハンドリングするので互換性に影響なし)。
-			return c.JSON(http.StatusBadRequest, apierr.Error("DUPLICATED_USERNAME", "Username already exists.", "0a504947-b888-4a99-9f62-8c4a0f3a3dab"))
+			return duplicatedUsernameError(c)
 		case coresignup.ErrInvitationAlreadyUsed:
 			return c.JSON(http.StatusConflict, apierr.Error("INVITATION_ALREADY_USED", "Invitation already used.", "5b81b5e2-2c0b-4d8a-9b71-1a3e1d4d3f6a"))
 		case coresignup.ErrInvitationRevoked:

--- a/internal/api/signup/handler_test.go
+++ b/internal/api/signup/handler_test.go
@@ -131,11 +131,12 @@ func TestSignup_DuplicateUsername(t *testing.T) {
 	h, userRepo, _ := newTestHandler(t)
 	userRepo.Users["u1"] = &model.User{ID: "u1", Username: "taken", UsernameLower: "taken"}
 	rec := doPost(h.Signup, `{"username":"taken","password":"pass"}`)
-	assert.Equal(t, http.StatusConflict, rec.Code)
+	// upstream Misskey TS と整合 (#798): 400 + DUPLICATED_USERNAME
+	assert.Equal(t, http.StatusBadRequest, rec.Code)
 
 	resp := parseResp(t, rec)
 	errObj := resp["error"].(map[string]any)
-	assert.Equal(t, "USERNAME_ALREADY_EXISTS", errObj["code"])
+	assert.Equal(t, "DUPLICATED_USERNAME", errObj["code"])
 }
 
 func TestSignup_ReservedUsername(t *testing.T) {
@@ -218,7 +219,8 @@ func TestSignup_EmailRequired_DuplicateUsername(t *testing.T) {
 	h := apisignup.NewHandler(svc, metaRepo, idGen)
 
 	rec := doPost(h.Signup, `{"username":"alice","password":"pass","emailAddress":"a@example.com"}`)
-	assert.Equal(t, http.StatusConflict, rec.Code)
+	// upstream 整合 (#798): duplicate は 400 + DUPLICATED_USERNAME。
+	assert.Equal(t, http.StatusBadRequest, rec.Code)
 	assert.Empty(t, pendingRepo.Rows)
 }
 
@@ -499,7 +501,8 @@ func TestSignupPending_UsernameClash(t *testing.T) {
 	require.NoError(t, userRepo.Create(&model.User{ID: "u_c2", Username: "Clash2", UsernameLower: "clash2"}))
 
 	rec := doPost(h.SignupPending, `{"code":"`+row.Code+`"}`)
-	assert.Equal(t, http.StatusConflict, rec.Code)
+	// upstream 整合 (#798): duplicate は 400 + DUPLICATED_USERNAME。
+	assert.Equal(t, http.StatusBadRequest, rec.Code)
 }
 
 // emailSender が未設定でも pending row 自体は作られて 204 を返す (テスト用 setup)

--- a/tests/playwright/specs/auth/signup.spec.ts
+++ b/tests/playwright/specs/auth/signup.spec.ts
@@ -41,12 +41,15 @@ test.describe('auth: signup-flow', () => {
     const username = randomUsername('dupe');
     await signupUser(request, username, 'password1234');
 
-    // 同 username で 2 度目の signup は client error (4xx) で reject。
-    // 注: 具体 status code は upstream Misskey TS (= 400) と mk-go (= 409
-    // USERNAME_ALREADY_EXISTS) で drift している (#798 で別途 tracking)。
-    // 本 spec は両者で pass するよう 4xx 範囲で assert する。
+    // upstream Misskey TS と mk-go (#798 fix 後) は status 400 + code
+    // DUPLICATED_USERNAME を返す。ただし error response の body shape は
+    // upstream (Fastify) = `{statusCode, error, message: "Error: DUPLICATED_USERNAME"}`、
+    // mk-go = `{error: {code: "DUPLICATED_USERNAME", id, message}}` と
+    // drift がある (#802 で別途 tracking)。本 spec は両者で pass するよう
+    // body 全文中に DUPLICATED_USERNAME 文字列が含まれることだけ確認する。
     const resp = await callApi(request, 'signup', { username, password: 'password1234' });
-    expect(resp.status()).toBeGreaterThanOrEqual(400);
-    expect(resp.status()).toBeLessThan(500);
+    expect(resp.status()).toBe(400);
+    const text = await resp.text();
+    expect(text).toContain('DUPLICATED_USERNAME');
   });
 });


### PR DESCRIPTION
## Summary

upstream Misskey TS の \`/api/signup\` は username 重複時に \`400 DUPLICATED_USERNAME\` を返す (\`third_party/misskey/.../SignupApiService.ts:174\`)。mk-go は \`409 USERNAME_ALREADY_EXISTS\` で drift していた。drop-in 互換のため status / code を upstream に揃える。

## 変更

- \`internal/api/signup/handler.go\`: 3 箇所 (signup-pending 経路 / 通常 signup / signup-pending promote) を 409→400、\`USERNAME_ALREADY_EXISTS\`→\`DUPLICATED_USERNAME\`
- error UUID は既存の \`0a504947-...\` を保持 (TS は UUID 返さない、frontend は code で switch するので互換性に影響なし)
- \`internal/api/signup/handler_test.go\`: 該当 3 test を新挙動に更新
- \`tests/playwright/specs/auth/signup.spec.ts\`: tolerant 4xx だった duplicate spec を strict 400 + \`DUPLICATED_USERNAME\` 文字列 contain に変更

## 動作確認

\`\`\`
$ go test ./internal/api/signup/...    # pass

$ make playwright-ts-up && make playwright-ts-test
14 passed, 2 skipped (TS image)

$ make playwright-down && make playwright-up && make playwright-test
14 passed, 2 skipped (mk-go)
\`\`\`

両 backend で 14 pass = status code レベルで drop-in 互換回復。

## 副次発見: body shape drift (#802)

検証中、error response の body shape も drift していることを発見:

| target | shape |
|---|---|
| TS (Fastify) | \`{statusCode: 400, error: "Bad Request", message: "Error: DUPLICATED_USERNAME"}\` |
| mk-go (Misskey misc) | \`{error: {code: "DUPLICATED_USERNAME", id, message}}\` |

これは別 issue として #802 で tracking。本 PR の Playwright spec は body 全文中 \`DUPLICATED_USERNAME\` を contain する形に緩和し両者 pass。

## scope 外

\`admin/accounts/create\` (\`internal/api/admin/handler.go:435\`) も同 code を使うが別 endpoint。本 PR は \`/api/signup\` のみ修正、admin は別 issue で対応する想定。

## Closes

#798

🤖 Generated with [Claude Code](https://claude.com/claude-code)