### PR TITLE
hotfix: Playwright compose を別 project (mk-playwright) に分離 — UDS 本番衝突対策

### DIFF
--- a/docker-compose.playwright.ts.yml
+++ b/docker-compose.playwright.ts.yml
@@ -1,5 +1,8 @@
 # docker-compose.playwright.ts.yml — #744 Phase 1 TS validation overlay.
 #
+# project name は base (docker-compose.playwright.yml) の `name: mk-playwright`
+# を引き継ぐ。overlay 単独で起動することはないので明示は不要。
+#
 # spec は upstream Misskey TS の API 互換挙動を期待値として書いている。
 # 本 overlay は backend を `misskey/misskey:2026.3.2` に置き換えて、上流の
 # 真の挙動で spec が pass することを baseline として確認する。

--- a/docker-compose.playwright.yml
+++ b/docker-compose.playwright.yml
@@ -11,6 +11,12 @@
 #     run --rm playwright-runner
 #   docker compose -f docker-compose.playwright.yml down -v
 
+# project name は repo dir 名 (default = `mk`) と衝突して UDS 本番の
+# `mk-postgres-1` / `mk-redis-1` / `mk-mkgo-1` container を取り合うので、
+# 明示的に別 project に分離する。これにより `make playwright-down -v` でも
+# UDS service は touch されない。
+name: mk-playwright
+
 services:
   postgres:
     image: postgres:16-alpine


### PR DESCRIPTION
## 緊急

\`docker-compose.playwright.yml\` が default project name \`mk\` で起動しており、**UDS 本番環境と service 名 (postgres / redis / mkgo) が衝突**していた。\`make playwright-up\` / \`make playwright-down\` で UDS の同名 container を hijack / 停止していた。

## 被害確認

- UDS app が **停止** (= 本番停止状態)
- UDS の named volume (\`mk_pg_data\` / \`mk_valkey_data\` / \`mk_mkgo_files\` 等) は別 prefix で保護されており **データは無事**
- container 名衝突のみ (= UDS docker compose で \`up -d\` で復旧可能)

## 修正

\`docker-compose.playwright.yml\` の top-level に \`name: mk-playwright\` を追加。

\`\`\`yaml
name: mk-playwright

services:
  postgres:
    ...
\`\`\`

これにより container 名は \`mk-playwright-postgres-1\` 等になり、UDS の \`mk-postgres-1\` と完全分離。\`make playwright-{up,down}\` で UDS service を一切 touch しない。

\`docker-compose.playwright.ts.yml\` overlay は base の name を引き継ぐので明示不要 (コメントのみ追記)。

## scope 外 (follow-up)

dropin / federation 系 compose も同 project name \`mk\` で起動するが、service 名 (\`app-a\` / \`app-b\` / \`app-mkgo\`) は UDS (\`app\` / \`db\` / \`redis\`) と重複しないため即時被害はない。将来の衝突リスク回避は別 follow-up issue で対応する想定。

## 動作確認

修正前: \`docker compose -f docker-compose.playwright.yml ps\` で UDS の \`mk-nginx-1\` 等が orphan として表示、\`postgres\` / \`redis\` / \`mkgo\` は UDS と衝突していた

修正後:

\`\`\`
$ docker compose -f docker-compose.playwright.yml config | grep -E "^name:"
name: mk-playwright
\`\`\`

## マージ後の運用

UDS 復旧手順 (operator):

\`\`\`
# UDS の docker-compose ディレクトリで
docker compose up -d
\`\`\`

UDS の named volume はそのまま使われるので DB / Redis state は保持される。

🤖 Generated with [Claude Code](https://claude.com/claude-code)