### PR TITLE
hotfix: 残り全 test compose に project name を分離 (#804 follow-up)

### DIFF
--- a/docker-compose.dropin-frontend.mk.yml
+++ b/docker-compose.dropin-frontend.mk.yml
@@ -1,5 +1,8 @@
 # docker-compose.dropin-frontend.mk.yml — Phase 14-3 (#394) overlay.
 #
+# project name は base (docker-compose.dropin-frontend.yml) の
+# `name: mk-dropin-frontend` を引き継ぐ (#804 follow-up)。
+#
 # 使い方:
 #   docker compose \
 #     -f docker-compose.dropin-frontend.yml \

--- a/docker-compose.dropin-frontend.yml
+++ b/docker-compose.dropin-frontend.yml
@@ -8,6 +8,10 @@
 #   docker compose -f docker-compose.dropin-frontend.yml up -d
 #   docker compose -f docker-compose.dropin-frontend.yml --profile test run --rm cypress-runner
 
+# project name を別に分離 (#804 follow-up)。default `mk` だと UDS 本番の
+# container 群と衝突するので明示的に切る。
+name: mk-dropin-frontend
+
 services:
   # ── Certificate Generator ──────────────────────────────────
   certs:

--- a/docker-compose.dropin.mk.yml
+++ b/docker-compose.dropin.mk.yml
@@ -1,5 +1,8 @@
 # docker-compose.dropin.mk.yml — Phase 13-2 (#367) overlay.
 #
+# project name は base (docker-compose.dropin.yml) の `name: mk-dropin` を
+# 引き継ぐ (#804 follow-up)。
+#
 # 使い方:
 #   docker compose \
 #     -f docker-compose.dropin.yml \

--- a/docker-compose.dropin.yml
+++ b/docker-compose.dropin.yml
@@ -7,6 +7,11 @@
 #
 # Run via `make dropin-up` / `make dropin-test` / `make dropin-down`.
 
+# project name は repo dir 名 (default = `mk`) と衝突して UDS 本番の
+# `mk-postgres-1` 等の container を取り合うので、別 project に分離する
+# (#804 follow-up)。`down -v` でも UDS service / volume は touch されない。
+name: mk-dropin
+
 services:
   # ── Certificate Generator ──────────────────────────────────
   certs:

--- a/docker-compose.federation.misskey.yml
+++ b/docker-compose.federation.misskey.yml
@@ -1,3 +1,7 @@
+# project name を別に分離 (#804 follow-up)。default `mk` だと UDS 本番の
+# container 群と衝突するので明示的に切る。
+name: mk-federation
+
 services:
   # ── Certificate Generator ──────────────────────────────────
   certs:

--- a/tests/bench/docker-compose.bench.yml
+++ b/tests/bench/docker-compose.bench.yml
@@ -1,3 +1,7 @@
+# project name を別に分離 (#804 follow-up)。default だと UDS 本番の
+# container 群と衝突する。
+name: mk-bench
+
 services:
   # ── Certificate Generator ──────────────────────────────────
   certs:

--- a/tests/queue-bench/docker-compose.queue-bench.yml
+++ b/tests/queue-bench/docker-compose.queue-bench.yml
@@ -1,3 +1,7 @@
+# project name を別に分離 (#804 follow-up)。default だと UDS 本番の
+# container 群と衝突する。
+name: mk-queue-bench
+
 services:
   certs:
     image: alpine:3.21


### PR DESCRIPTION
## Summary

#804 で playwright のみ project name を \`mk-playwright\` に分離したが、dropin / federation / queue-bench / bench の各 compose も同じく default project name \`mk\` で起動しており、UDS 本番との衝突リスクを保持していた。本 PR で残り全 test compose を別 project に分離する。

## 影響

playwright と異なり service 名 (\`app-a\` / \`app-b\` / \`app-mkgo\` / \`faker\` / \`blackhole\` 等) は UDS の (\`app\` / \`db\` / \`redis\`) と重複しないため **即時被害はなかった**。ただし以下のリスクが残っていた:

- named volume が \`mk_certs\` のような \`mk_\` prefix を共有
- network 名も \`mk_dropin\` 等で project が \`mk\` のまま
- \`down -v\` / \`down --remove-orphans\` で UDS resource を巻き込む可能性

## 修正

base ファイルに \`name:\` を追加 (5 ファイル):

| compose | name |
|---|---|
| \`docker-compose.dropin.yml\` | \`mk-dropin\` |
| \`docker-compose.dropin-frontend.yml\` | \`mk-dropin-frontend\` |
| \`docker-compose.federation.misskey.yml\` | \`mk-federation\` |
| \`tests/queue-bench/docker-compose.queue-bench.yml\` | \`mk-queue-bench\` |
| \`tests/bench/docker-compose.bench.yml\` | \`mk-bench\` |

overlay (\`*.mk.yml\` 2 ファイル) は base の name を引き継ぐのでコメント追記のみ。

## 動作確認

\`docker compose -f <file> config\` で各 compose の name が反映されること、overlay (dropin / dropin-frontend) も base の name を継承することを確認済み:

\`\`\`
docker-compose.dropin.yml          → name: mk-dropin
docker-compose.dropin-frontend.yml → name: mk-dropin-frontend
docker-compose.federation.misskey.yml → name: mk-federation
tests/queue-bench/...              → name: mk-queue-bench
tests/bench/...                    → name: mk-bench
\`\`\`

## 関連

- #804 (playwright のみ分離した先行 hotfix)
- 本 PR で全 test compose の UDS 衝突リスクを解消

🤖 Generated with [Claude Code](https://claude.com/claude-code)