### PR TITLE
Fix #799: notes/show を ID 指定で visibility 違反でも 200 返すように

### DIFF
--- a/internal/api/notes/handler.go
+++ b/internal/api/notes/handler.go
@@ -303,17 +303,24 @@ func (h *Handler) Show(c echo.Context) error {
 	return c.JSON(http.StatusOK, s[0])
 }
 
-// lookupVisible fetches the note via QueryService, which applies the
-// visibility check (followers / specified visibility / blocks).
-// QueryService が wire されていない場合は visibility check を経ない
-// fallback で followers/specified の note が漏洩する security regression
-// risk があるため、nil なら ErrNoteNotFound を返して安全側に倒す (#445)。
-// production では router.go で常に wire されるのでこの分岐は通らない。
+// lookupVisible fetches the note for the /api/notes/show endpoint.
+//
+// upstream Misskey TS は ID 指定の notes/show では visibility 違反でも
+// note を返す (= ID を既に知っている viewer には公開する設計、#799)。
+// drop-in 互換のため mk-go も follow-only / specified note を 200 で
+// 返す。timeline / replies / renotes 等の二次経路では引き続き
+// requireVisible (CanSeeNote) で filter するので、visibility leak は
+// "直接 ID を知っている人にだけ" に留まる。
+//
+// QueryService が wire されていない場合は ErrNoteNotFound を返して安全
+// 側に倒す (= production では router.go で常に wire される)。
 func (h *Handler) lookupVisible(viewer *model.User, noteID string) (*model.Note, error) {
+	_ = viewer // visibility filter は kicked、viewer 引数は将来の block
+	// 検査 (#TBD) のため signature に残す
 	if h.queryService == nil {
 		return nil, note.ErrNoteNotFound
 	}
-	return h.queryService.Show(viewer, noteID)
+	return h.queryService.ShowForAPI(noteID)
 }
 
 // DeleteRequest is the request body for notes/delete.

--- a/internal/api/notes/handler.go
+++ b/internal/api/notes/handler.go
@@ -292,7 +292,7 @@ func (h *Handler) Show(c echo.Context) error {
 	}
 
 	viewer := middleware.GetUser(c)
-	n, err := h.lookupVisible(viewer, req.NoteID)
+	n, err := h.lookupForShow(req.NoteID)
 	if err != nil {
 		return apierr.JSONNoSuchNote(c)
 	}
@@ -303,7 +303,7 @@ func (h *Handler) Show(c echo.Context) error {
 	return c.JSON(http.StatusOK, s[0])
 }
 
-// lookupVisible fetches the note for the /api/notes/show endpoint.
+// lookupForShow fetches the note for the /api/notes/show endpoint.
 //
 // upstream Misskey TS は ID 指定の notes/show では visibility 違反でも
 // note を返す (= ID を既に知っている viewer には公開する設計、#799)。
@@ -314,9 +314,7 @@ func (h *Handler) Show(c echo.Context) error {
 //
 // QueryService が wire されていない場合は ErrNoteNotFound を返して安全
 // 側に倒す (= production では router.go で常に wire される)。
-func (h *Handler) lookupVisible(viewer *model.User, noteID string) (*model.Note, error) {
-	_ = viewer // visibility filter は kicked、viewer 引数は将来の block
-	// 検査 (#TBD) のため signature に残す
+func (h *Handler) lookupForShow(noteID string) (*model.Note, error) {
 	if h.queryService == nil {
 		return nil, note.ErrNoteNotFound
 	}

--- a/internal/core/note/note_query_service.go
+++ b/internal/core/note/note_query_service.go
@@ -34,12 +34,33 @@ func (s *QueryService) SetThreadMutingRepo(r repository.NoteThreadMutingReposito
 // Show returns the requested note if it exists and the viewer can see it.
 // viewerはnil可 (未認証ユーザー)。返り値は handler 側で pack されるため、
 // Renote / Reply embed まで full preload する (#425 重量経路)。
+//
+// **visibility check 込み**。federation 経路 (= internal/api/ap で AP
+// 経由 lookup する用) では使うが、HTTP API の notes/show は ID 指定なら
+// visibility 違反でも note を返す upstream 仕様 (#799) なので、そちらは
+// ShowForAPI を使うこと。
 func (s *QueryService) Show(viewer *model.User, noteID string) (*model.Note, error) {
 	n, err := s.noteRepo.FindByIDWithRelations(noteID)
 	if err != nil {
 		return nil, ErrNoteNotFound
 	}
 	if !CanSeeNote(viewer, n, s.followingRepo) {
+		return nil, ErrNoteNotFound
+	}
+	return n, nil
+}
+
+// ShowForAPI returns the requested note for the HTTP /api/notes/show
+// endpoint without applying the followers-only / specified visibility
+// check. upstream Misskey TS が「ID を既に知っている viewer には公開する」
+// 設計を採るため (#799) — drop-in 互換のために合わせる。
+//
+// timeline / replies / renotes / children 等の二次経路は引き続き
+// CanSeeNote (= requireVisible) で filter する。federation 経路 (Show)
+// も visibility check 維持で leak しない。
+func (s *QueryService) ShowForAPI(noteID string) (*model.Note, error) {
+	n, err := s.noteRepo.FindByIDWithRelations(noteID)
+	if err != nil {
 		return nil, ErrNoteNotFound
 	}
 	return n, nil

--- a/internal/core/note/note_query_service.go
+++ b/internal/core/note/note_query_service.go
@@ -56,8 +56,8 @@ func (s *QueryService) Show(viewer *model.User, noteID string) (*model.Note, err
 // 設計を採るため (#799) — drop-in 互換のために合わせる。
 //
 // timeline / replies / renotes / children 等の二次経路は引き続き
-// CanSeeNote (= requireVisible) で filter する。federation 経路 (Show)
-// も visibility check 維持で leak しない。
+// CanSeeNote (= requireVisible) で filter する。federation 経路
+// (= ap/handler の Show callsite) も visibility check 維持で leak しない。
 func (s *QueryService) ShowForAPI(noteID string) (*model.Note, error) {
 	n, err := s.noteRepo.FindByIDWithRelations(noteID)
 	if err != nil {

--- a/internal/core/note/note_query_service_test.go
+++ b/internal/core/note/note_query_service_test.go
@@ -40,6 +40,31 @@ func TestQueryService_Show_Visible(t *testing.T) {
 	assert.Equal(t, "n1", got.ID)
 }
 
+// ShowForAPI は upstream Misskey TS の notes/show 互換挙動 (#799)。
+// visibility 違反でも note を返す (= ID 指定の lookup は公開する設計)。
+func TestQueryService_ShowForAPI_ReturnsFollowersNoteToStranger(t *testing.T) {
+	svc, noteRepo, _ := newQueryService(t)
+	noteRepo.Notes["n1"] = &model.Note{ID: "n1", UserID: "author", Visibility: model.NoteVisibilityFollowers}
+	got, err := svc.ShowForAPI("n1")
+	require.NoError(t, err)
+	assert.Equal(t, "n1", got.ID)
+}
+
+func TestQueryService_ShowForAPI_ReturnsSpecifiedNoteToStranger(t *testing.T) {
+	svc, noteRepo, _ := newQueryService(t)
+	noteRepo.Notes["n1"] = &model.Note{ID: "n1", UserID: "author", Visibility: model.NoteVisibilitySpecified}
+	got, err := svc.ShowForAPI("n1")
+	require.NoError(t, err)
+	assert.Equal(t, "n1", got.ID)
+}
+
+// 不存在は ShowForAPI でも ErrNoteNotFound (= 404 path)。
+func TestQueryService_ShowForAPI_NotFound(t *testing.T) {
+	svc, _, _ := newQueryService(t)
+	_, err := svc.ShowForAPI("missing")
+	require.ErrorIs(t, err, note.ErrNoteNotFound)
+}
+
 func TestQueryService_ListRenotes(t *testing.T) {
 	svc, noteRepo, _ := newQueryService(t)
 	noteRepo.Notes["parent"] = &model.Note{ID: "parent", UserID: "a", Visibility: model.NoteVisibilityPublic}

--- a/tests/playwright/specs/notes/visibility.spec.ts
+++ b/tests/playwright/specs/notes/visibility.spec.ts
@@ -40,20 +40,42 @@ test.describe('notes: visibility boundary', () => {
     expect(resp.status()).toBe(200);
   });
 
-  // 注: followers-only / specified note の `notes/show` 経路は upstream
-  // Misskey TS と mk-go で挙動が drift している (#799 で tracking):
+  // upstream Misskey TS と mk-go (#799 fix 後) は、`notes/show` で直接 ID
+  // 指定された note は visibility 違反でも 200 で返す (= "ID を既に知って
+  // いる viewer には公開する" 設計)。timeline / replies / renotes 等の
+  // 二次経路は引き続き visibility filter で除外される。
   //
-  //   - upstream TS: 直接 ID 指定の `notes/show` は visibility 違反でも 200
-  //     を返す (= visibility filter は timeline 経路のみで適用、note ID を
-  //     既に知っている viewer には公開する設計)
-  //   - mk-go: `notes/show` で visibility 違反を 4xx で reject (TS より strict)
-  //
-  // どちらが "正解" かは drop-in 互換性の方針次第だが、ひとまず本 spec は
-  // skip し、本来の visibility 検証は notes/timeline 経路 (= follow graph と
-  // visibility filter の組み合わせ) で別 PR にて行う。
-  // test.fixme で「後で書き直す予定」を semantic に表現する (= test.skip
-  // が "永続的 skip" の意なので、issue close 後に unblock する意図には
-  // fixme が適切)。
-  test.fixme('followers-only note is hidden from stranger (TS=200/mk-go=4xx drift)', async () => {});
-  test.fixme('specified note is hidden from non-listed user (TS=200/mk-go=4xx drift)', async () => {});
+  // 本 spec は「stranger でも `notes/show` で 200 を返す」のを assert する。
+  // visibility filter が壊れる方向の regression は timeline 系 spec (Phase
+  // 1 残作業の home/local/global timeline) で別途 cover する。
+  test('followers-only note is returned by notes/show even to stranger', async ({ request }) => {
+    const author = await signupUser(request, randomUsername('vFoA'));
+    const stranger = await signupUser(request, randomUsername('vFoS'));
+    const note = await createNote(request, author.token, {
+      text: 'followers only',
+      visibility: 'followers',
+    });
+
+    const resp = await showNoteRaw(request, stranger.token, note.id);
+    expect(resp.status()).toBe(200);
+    const body = await resp.json();
+    expect(body.id).toBe(note.id);
+    expect(body.visibility).toBe('followers');
+  });
+
+  test('specified note is returned by notes/show even to non-listed user', async ({ request }) => {
+    const author = await signupUser(request, randomUsername('vSpA'));
+    const stranger = await signupUser(request, randomUsername('vSpS'));
+    const note = await createNote(request, author.token, {
+      text: 'private DM',
+      visibility: 'specified',
+      visibleUserIds: [author.id],
+    });
+
+    const resp = await showNoteRaw(request, stranger.token, note.id);
+    expect(resp.status()).toBe(200);
+    const body = await resp.json();
+    expect(body.id).toBe(note.id);
+    expect(body.visibility).toBe('specified');
+  });
 });


### PR DESCRIPTION
## Summary

upstream Misskey TS の \`/api/notes/show\` は直接 ID 指定された note を visibility 違反でも 200 で返す (= "ID を既に知っている viewer には公開する" 設計、visibility filter は timeline 経路のみで適用)。mk-go は visibility check を strict に enforce して 4xx を返していたため drop-in 非互換となっていた。drop-in 互換を取るため upstream に揃える。

## 変更

- \`internal/core/note/note_query_service.go\`: 既存 \`Show()\` (visibility check 込み) は federation 経路 (\`internal/api/ap\`) からの leak 防止のため維持し、HTTP API 用に新規 \`ShowForAPI(noteID)\` を追加。後者は \`CanSeeNote\` を経ずに note を返す
- \`internal/api/notes/handler.go\`: \`lookupVisible\` を \`ShowForAPI\` ベースに切替 (= notes/show のみ visibility filter を bypass)
- \`internal/core/note/note_query_service_test.go\`: \`ShowForAPI\` 3 ケース追加 (followers / specified / not-found)
- \`tests/playwright/specs/notes/visibility.spec.ts\`: 前 PR で \`test.fixme\` だった 2 ケースを正規 test に戻し、stranger でも 200 を返すこと + body の visibility field を assert

## scope と security

federation 経路 (\`internal/api/ap/handler.go\` の \`queryService.Show\` 3 callsite) は引き続き visibility check 込みなので、AP 経由の leak は **防げる**。HTTP API 経由のみ緩和する設計 (= upstream と同 設計)。

timeline / replies / renotes / children 等の二次経路は引き続き \`requireVisible\` (= \`CanSeeNote\`) で filter するので、ID を知らない viewer に visibility 違反 note が漏洩することはない。

## 動作確認

\`\`\`
$ go test ./internal/core/note/... ./internal/api/notes/... ./internal/api/ap/...
all pass

$ make playwright-ts-up && make playwright-ts-test
16 passed (TS image)

$ make playwright-down && make playwright-up && make playwright-test
16 passed (mk-go)
\`\`\`

**両 backend で 16/16 全 pass** (前 PR の 2 fixme が解消)。

## Closes

#799

🤖 Generated with [Claude Code](https://claude.com/claude-code)