### PR TITLE
Fix #800: username validation を upstream Misskey TS と整合 (1-20 char + alphanumeric/_)

### DIFF
--- a/internal/core/signup/signup_service.go
+++ b/internal/core/signup/signup_service.go
@@ -21,15 +21,25 @@ import (
 // (= third_party の models/User.ts:319) に整合する username 検証 regex。
 // `^\w{1,20}$` 相当で `\w` = [a-zA-Z0-9_]、length 1-20。
 //
+// Go の regexp は RE2 default で `\w` が ASCII の [0-9A-Za-z_] に限定されるため
+// upstream JS の `\w` と挙動が一致する。意図を明示するため明示的に文字クラスを
+// 書き下している (Unicode property を含めない契約をコード上に固定する目的)。
+//
 // 旧 mk-go は length 128 文字まで許容していて drop-in で TS instance に
 // 引き継いだ後 frontend (= TS の username schema) で reject される
 // regression があった (#800)。
 var localUsernamePattern = regexp.MustCompile(`^[a-zA-Z0-9_]{1,20}$`)
 
-// isValidLocalUsername reports whether the given username is acceptable
-// as a local user's account name. upstream Misskey TS と同じ制約。
-func isValidLocalUsername(username string) bool {
-	return localUsernamePattern.MatchString(username)
+// normalizeAndValidateUsername trims surrounding whitespace and validates
+// the username against upstream Misskey TS の `localUsernameSchema`. 返り値
+// の username は trim 済みなので、caller はそのまま小文字化や DB 永続化に
+// 利用してよい。validation 失敗時は ErrInvalidUsername を返す。
+func normalizeAndValidateUsername(username string) (string, error) {
+	username = strings.TrimSpace(username)
+	if !localUsernamePattern.MatchString(username) {
+		return "", ErrInvalidUsername
+	}
+	return username, nil
 }
 
 var (
@@ -140,9 +150,9 @@ type SignupResult struct {
 // Signup creates a new local user with the given username and password.
 // isInitialSetup=true の場合、作成したユーザーを rootUser に設定する。
 func (s *Service) Signup(username, password string, isInitialSetup bool) (*SignupResult, error) {
-	username = strings.TrimSpace(username)
-	if !isValidLocalUsername(username) {
-		return nil, ErrInvalidUsername
+	username, err := normalizeAndValidateUsername(username)
+	if err != nil {
+		return nil, err
 	}
 
 	// ユーザー名の重複チェック
@@ -252,9 +262,9 @@ func generatePendingCode() string {
 // 成功時に SignupResult.InvitationTicketID 経由で handler に伝える
 // (招待制 + email 確認制併用時の MarkUsed 用)。
 func (s *Service) CreatePending(username, email, password string, invitationTicketID *string) (*model.UserPending, error) {
-	username = strings.TrimSpace(username)
-	if !isValidLocalUsername(username) {
-		return nil, ErrInvalidUsername
+	username, err := normalizeAndValidateUsername(username)
+	if err != nil {
+		return nil, err
 	}
 	lower := strings.ToLower(username)
 

--- a/internal/core/signup/signup_service.go
+++ b/internal/core/signup/signup_service.go
@@ -5,6 +5,7 @@ import (
 	"encoding/hex"
 	"errors"
 	"log/slog"
+	"regexp"
 	"strings"
 	"time"
 
@@ -15,6 +16,21 @@ import (
 	"golang.org/x/crypto/bcrypt"
 	"gorm.io/gorm"
 )
+
+// localUsernamePattern は upstream Misskey TS の `localUsernameSchema`
+// (= third_party の models/User.ts:319) に整合する username 検証 regex。
+// `^\w{1,20}$` 相当で `\w` = [a-zA-Z0-9_]、length 1-20。
+//
+// 旧 mk-go は length 128 文字まで許容していて drop-in で TS instance に
+// 引き継いだ後 frontend (= TS の username schema) で reject される
+// regression があった (#800)。
+var localUsernamePattern = regexp.MustCompile(`^[a-zA-Z0-9_]{1,20}$`)
+
+// isValidLocalUsername reports whether the given username is acceptable
+// as a local user's account name. upstream Misskey TS と同じ制約。
+func isValidLocalUsername(username string) bool {
+	return localUsernamePattern.MatchString(username)
+}
 
 var (
 	// ErrUsernameAlreadyExists is returned when the username is taken.
@@ -125,7 +141,7 @@ type SignupResult struct {
 // isInitialSetup=true の場合、作成したユーザーを rootUser に設定する。
 func (s *Service) Signup(username, password string, isInitialSetup bool) (*SignupResult, error) {
 	username = strings.TrimSpace(username)
-	if username == "" || len(username) > 128 {
+	if !isValidLocalUsername(username) {
 		return nil, ErrInvalidUsername
 	}
 
@@ -237,7 +253,7 @@ func generatePendingCode() string {
 // (招待制 + email 確認制併用時の MarkUsed 用)。
 func (s *Service) CreatePending(username, email, password string, invitationTicketID *string) (*model.UserPending, error) {
 	username = strings.TrimSpace(username)
-	if username == "" || len(username) > 128 {
+	if !isValidLocalUsername(username) {
 		return nil, ErrInvalidUsername
 	}
 	lower := strings.ToLower(username)

--- a/internal/core/signup/signup_service_test.go
+++ b/internal/core/signup/signup_service_test.go
@@ -1,6 +1,7 @@
 package signup_test
 
 import (
+	"strings"
 	"testing"
 	"time"
 
@@ -83,23 +84,33 @@ func TestSignup_TooLongUsername(t *testing.T) {
 }
 
 // upstream Misskey TS の `localUsernameSchema` は `^\w{1,20}$` (#800)。
-// 境界 (= 20 char OK / 21 char NG) と character set (= alphanumeric +
-// underscore のみ) を明確に担保する。
-func TestSignup_UsernameBoundary20Chars(t *testing.T) {
-	svc, _, _ := newTestService(t)
-	// 20 char ちょうど (= 上限) は通る
-	r, err := svc.Signup("a234567890123456789a", "pass", false)
-	require.NoError(t, err)
-	assert.Equal(t, "a234567890123456789a", r.User.Username)
+// 境界 (= 20 char OK / 21 char NG) を明示する。リテラルではなく
+// strings.Repeat で長さを構築することで、境界値が一目で判別できるよう
+// にしている。
+func TestSignup_UsernameLengthBoundary(t *testing.T) {
+	cases := []struct {
+		desc    string
+		length  int
+		wantErr error
+	}{
+		{"max_20_chars_accepted", 20, nil},
+		{"over_21_chars_rejected", 21, signup.ErrInvalidUsername},
+	}
+	for _, tc := range cases {
+		t.Run(tc.desc, func(t *testing.T) {
+			svc, _, _ := newTestService(t)
+			username := strings.Repeat("a", tc.length)
+			_, err := svc.Signup(username, "pass", false)
+			if tc.wantErr == nil {
+				require.NoError(t, err)
+			} else {
+				assert.ErrorIs(t, err, tc.wantErr)
+			}
+		})
+	}
 }
 
-func TestSignup_Username21CharsRejected(t *testing.T) {
-	svc, _, _ := newTestService(t)
-	// 21 char (= 上限超過) は ErrInvalidUsername
-	_, err := svc.Signup("a234567890123456789ab", "pass", false)
-	assert.ErrorIs(t, err, signup.ErrInvalidUsername)
-}
-
+// `\w` 外の character (= [a-zA-Z0-9_] 以外) はすべて reject される。
 func TestSignup_UsernameIllegalCharsRejected(t *testing.T) {
 	cases := []struct {
 		desc     string

--- a/internal/core/signup/signup_service_test.go
+++ b/internal/core/signup/signup_service_test.go
@@ -101,16 +101,22 @@ func TestSignup_Username21CharsRejected(t *testing.T) {
 }
 
 func TestSignup_UsernameIllegalCharsRejected(t *testing.T) {
-	svc, _, _ := newTestService(t)
-	for _, name := range []string{
-		"alice-bob", // hyphen 不可
-		"alice.bob", // dot 不可
-		"alice@bob", // @ 不可
-		"alice bob", // space 不可 (TrimSpace で trim されない middle space)
-		"アリス",       // 非 ASCII 不可
-	} {
-		_, err := svc.Signup(name, "pass", false)
-		assert.ErrorIs(t, err, signup.ErrInvalidUsername, "name=%q", name)
+	cases := []struct {
+		desc     string
+		username string
+	}{
+		{"hyphen", "alice-bob"},
+		{"dot", "alice.bob"},
+		{"at_sign", "alice@bob"},
+		{"middle_space", "alice bob"},
+		{"non_ascii_japanese", "アリス"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.desc, func(t *testing.T) {
+			svc, _, _ := newTestService(t)
+			_, err := svc.Signup(tc.username, "pass", false)
+			assert.ErrorIs(t, err, signup.ErrInvalidUsername)
+		})
 	}
 }
 

--- a/internal/core/signup/signup_service_test.go
+++ b/internal/core/signup/signup_service_test.go
@@ -82,6 +82,38 @@ func TestSignup_TooLongUsername(t *testing.T) {
 	assert.ErrorIs(t, err, signup.ErrInvalidUsername)
 }
 
+// upstream Misskey TS の `localUsernameSchema` は `^\w{1,20}$` (#800)。
+// 境界 (= 20 char OK / 21 char NG) と character set (= alphanumeric +
+// underscore のみ) を明確に担保する。
+func TestSignup_UsernameBoundary20Chars(t *testing.T) {
+	svc, _, _ := newTestService(t)
+	// 20 char ちょうど (= 上限) は通る
+	r, err := svc.Signup("a234567890123456789a", "pass", false)
+	require.NoError(t, err)
+	assert.Equal(t, "a234567890123456789a", r.User.Username)
+}
+
+func TestSignup_Username21CharsRejected(t *testing.T) {
+	svc, _, _ := newTestService(t)
+	// 21 char (= 上限超過) は ErrInvalidUsername
+	_, err := svc.Signup("a234567890123456789ab", "pass", false)
+	assert.ErrorIs(t, err, signup.ErrInvalidUsername)
+}
+
+func TestSignup_UsernameIllegalCharsRejected(t *testing.T) {
+	svc, _, _ := newTestService(t)
+	for _, name := range []string{
+		"alice-bob", // hyphen 不可
+		"alice.bob", // dot 不可
+		"alice@bob", // @ 不可
+		"alice bob", // space 不可 (TrimSpace で trim されない middle space)
+		"アリス",       // 非 ASCII 不可
+	} {
+		_, err := svc.Signup(name, "pass", false)
+		assert.ErrorIs(t, err, signup.ErrInvalidUsername, "name=%q", name)
+	}
+}
+
 func TestSignup_PreservedUsernameRejected(t *testing.T) {
 	svc, _, metaRepo := newTestService(t)
 	// meta.preservedUsernames に "admin" が入っている想定。


### PR DESCRIPTION
## Summary

mk-go の signup endpoint は username の **length check が 128 char**、character set check も無く、upstream Misskey TS の \`localUsernameSchema\` (\`third_party/misskey/.../models/User.ts:319\` の \`^\\w{1,20}$\`) と drift していた。drop-in 互換のため upstream に揃える。

## 変更

- \`internal/core/signup/signup_service.go\`:
  - \`localUsernamePattern\` regex (\`^[a-zA-Z0-9_]{1,20}$\`) と \`isValidLocalUsername()\` helper を追加
  - \`Signup()\` / \`CreatePending()\` の length check を helper 経由の validation に置換
- \`internal/core/signup/signup_service_test.go\`: 境界 test 3 ケース追加 (20 char OK / 21 char NG / illegal char NG)

## 影響

- 旧 mk-go で 21+ char username を持つ既存ユーザーがいた場合、その user が再 signup を試みても reject される (新規 signup のみ影響、既存 user は引き続き login 可能)
- character set 外 (e.g. \`alice-bob\`、\`alice@bob\`、\`アリス\`) は新規 signup で reject

## scope

- 本 PR は Service 層 (signup-flow / pending) のみ。\`admin/accounts/create\` 経由の root 作成も同 helper で揃えるべきだが別 endpoint なので scope 外
- 既存 DB の >20 char username は migration 対象外 (= 残す)

## 動作確認

\`\`\`
$ go test ./internal/core/signup/...    # 5 個の新 test 含めて全 pass

$ make playwright-up && make playwright-test
16 passed (mk-go)

$ make playwright-ts-up && make playwright-ts-test
16 passed (TS image)
\`\`\`

Playwright spec は \`randomUsername()\` で 20 char 以内 / alphanumeric+underscore のみ生成しており、本 fix の影響を受けない (= 既存 spec は意図通り両 backend で valid と判断される)。

## Closes

#800

🤖 Generated with [Claude Code](https://claude.com/claude-code)