### PR TITLE
Fix #802 (Phase 1): signup endpoint の username/captcha error を Fastify shape に揃える

### DIFF
--- a/internal/api/apierr/fastify.go
+++ b/internal/api/apierr/fastify.go
@@ -1,0 +1,45 @@
+// Fastify-style error response helper. upstream Misskey TS の signup /
+// signin 系 endpoint (= ApiServerService 経由ではなく Fastify post で直接
+// register され、`throw new FastifyReplyError(status, code)` で error を
+// 投げる経路) が返す reply shape を再現する。
+//
+// shape 例 (DUPLICATED_USERNAME):
+//
+//	{"statusCode":400,"error":"Bad Request","message":"Error: DUPLICATED_USERNAME"}
+//
+// `error` は status code に対する http.StatusText、`message` は Node.js
+// `Error.toString()` の output (= "Error: <message>") を反映するため
+// `"Error: " + code` で組み立てる。
+//
+// 対応 endpoint は #802 で確定した 4 つ:
+//   - POST /api/signup
+//   - POST /api/signup-pending
+//   - POST /api/signin-flow
+//   - POST /api/signin-with-passkey
+//
+// それ以外の `/api/*` endpoint は upstream 上流でも Misskey misc 形式を
+// 返すため、引き続き Error()/ErrorEcho() を使うこと。
+
+package apierr
+
+import (
+	"net/http"
+
+	"github.com/labstack/echo/v4"
+)
+
+// FastifyReply writes a Fastify-style error reply to the given context.
+// `code` is the upstream error code string (e.g. "DUPLICATED_USERNAME").
+func FastifyReply(c echo.Context, status int, code string) error {
+	return c.JSON(status, fastifyReplyBody{
+		StatusCode: status,
+		Error:      http.StatusText(status),
+		Message:    "Error: " + code,
+	})
+}
+
+type fastifyReplyBody struct {
+	StatusCode int    `json:"statusCode"`
+	Error      string `json:"error"`
+	Message    string `json:"message"`
+}

--- a/internal/api/apierr/fastify.go
+++ b/internal/api/apierr/fastify.go
@@ -11,11 +11,11 @@
 // `Error.toString()` の output (= "Error: <message>") を反映するため
 // `"Error: " + code` で組み立てる。
 //
-// 対応 endpoint は #802 で確定した 4 つ:
-//   - POST /api/signup
-//   - POST /api/signup-pending
-//   - POST /api/signin-flow
-//   - POST /api/signin-with-passkey
+// drop-in 互換上、Fastify-style 化が必要な endpoint 候補は 4 つ:
+//   - POST /api/signup            ← #802 Phase 1 で対応済 (= 本ファイルの初版)
+//   - POST /api/signup-pending    ← Phase 2 (status drift も並行で別途整理)
+//   - POST /api/signin-flow       ← Phase 3 (rate-limit / captcha 等の混在 shape を整理)
+//   - POST /api/signin-with-passkey ← Phase 3
 //
 // それ以外の `/api/*` endpoint は upstream 上流でも Misskey misc 形式を
 // 返すため、引き続き Error()/ErrorEcho() を使うこと。

--- a/internal/api/apierr/fastify_test.go
+++ b/internal/api/apierr/fastify_test.go
@@ -1,0 +1,47 @@
+package apierr
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/labstack/echo/v4"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func invokeFastify(t *testing.T, fn func(echo.Context) error) (int, map[string]any) {
+	t.Helper()
+	e := echo.New()
+	req := httptest.NewRequest(http.MethodPost, "/", nil)
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+	_ = fn(c)
+	var body map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &body))
+	return rec.Code, body
+}
+
+func TestFastifyReply_400DuplicatedUsername(t *testing.T) {
+	code, body := invokeFastify(t, func(c echo.Context) error {
+		return FastifyReply(c, http.StatusBadRequest, "DUPLICATED_USERNAME")
+	})
+	assert.Equal(t, http.StatusBadRequest, code)
+	assert.EqualValues(t, http.StatusBadRequest, body["statusCode"])
+	assert.Equal(t, "Bad Request", body["error"])
+	assert.Equal(t, "Error: DUPLICATED_USERNAME", body["message"])
+	// nested {error:{code,id,message}} 形式が混入していないことも確認 (drift 防止)
+	_, hasNestedError := body["error"].(map[string]any)
+	assert.False(t, hasNestedError, "Fastify shape の error は string のはず")
+}
+
+func TestFastifyReply_410Expired(t *testing.T) {
+	code, body := invokeFastify(t, func(c echo.Context) error {
+		return FastifyReply(c, http.StatusGone, "EXPIRED")
+	})
+	assert.Equal(t, http.StatusGone, code)
+	assert.EqualValues(t, http.StatusGone, body["statusCode"])
+	assert.Equal(t, "Gone", body["error"])
+	assert.Equal(t, "Error: EXPIRED", body["message"])
+}

--- a/internal/api/signup/handler.go
+++ b/internal/api/signup/handler.go
@@ -97,20 +97,17 @@ type signupRequest struct {
 
 // duplicatedUsernameError は username 重複時の error response を返す。
 //
-// upstream Misskey TS は \`/api/signup\` の username 重複を 400 +
-// DUPLICATED_USERNAME で返す (third_party の SignupApiService.ts:174)。
-// mk-go も同 status / code に揃える (#798)。UUID は mk-go 内部の identifier
-// として既存値を保持 (= TS は UUID を返さない / frontend は code で
-// switch するので互換性に影響なし)。
+// upstream Misskey TS は \`/api/signup\` の username 重複を Fastify-style
+// reply error 形式 \`{statusCode:400, error:"Bad Request",
+// message:"Error: DUPLICATED_USERNAME"}\` で返す (third_party の
+// SignupApiService.ts:174 で \`throw new FastifyReplyError(400,
+// 'DUPLICATED_USERNAME')\`)。mk-go も同 status / shape に揃える
+// (#798 で status / code、#802 で body shape)。
 //
 // signup-pending 経路 / 通常 signup / signup-pending promote の 3 箇所から
 // 参照されるので helper 化している。
 func duplicatedUsernameError(c echo.Context) error {
-	return c.JSON(http.StatusBadRequest, apierr.Error(
-		"DUPLICATED_USERNAME",
-		"Username already exists.",
-		"0a504947-b888-4a99-9f62-8c4a0f3a3dab",
-	))
+	return apierr.FastifyReply(c, http.StatusBadRequest, "DUPLICATED_USERNAME")
 }
 
 // Signup handles POST /api/signup.
@@ -145,7 +142,10 @@ func (h *Handler) Signup(c echo.Context) error {
 			Testcaptcha: req.TestcaptchaResponse,
 		}
 		if err := h.captchaSvc.Verify(c.Request().Context(), tokens); err != nil {
-			return c.JSON(http.StatusBadRequest, apierr.Error("CAPTCHA_FAILED", "Captcha verification failed.", "bdc32ef5-b0f4-40c0-b767-673b2e3e1f5a"))
+			// upstream は captcha verify 失敗時に Fastify-style reply error
+			// (`throw new FastifyReplyError(400, err)`) を返す (SignupApiService.ts:81)。
+			// shape を揃えて drop-in 互換を担保する (#802)。
+			return apierr.FastifyReply(c, http.StatusBadRequest, "CAPTCHA_FAILED")
 		}
 	}
 
@@ -167,16 +167,22 @@ func (h *Handler) Signup(c echo.Context) error {
 		}
 		pending, perr := h.signupService.CreatePending(req.Username, req.EmailAddress, req.Password, ticketID)
 		if perr != nil {
+			// upstream は username 系 error を Fastify-style reply error
+			// で投げる (SignupApiService.ts:174-184)。mk-go も同 shape に揃える
+			// (#802)。INVALID_PARAM は upstream 上流に対応 code が無いが
+			// (= signupService 内部の generic catch で error.toString() を
+			// message に詰める形) drop-in でも shape を揃える方が consumer 側
+			// で 1 経路に統一できるので Fastify-style にする。
 			if perr == coresignup.ErrUsernameAlreadyExists {
 				return duplicatedUsernameError(c)
 			}
 			if perr == coresignup.ErrInvalidUsername {
-				return c.JSON(http.StatusBadRequest, apierr.Error("INVALID_PARAM", "Invalid username.", "3d81ceae-475f-4600-b2a8-2bc116157532"))
+				return apierr.FastifyReply(c, http.StatusBadRequest, "INVALID_PARAM")
 			}
 			if perr == coresignup.ErrUsernameReserved {
-				return c.JSON(http.StatusBadRequest, apierr.Error("USED_USERNAME", "That username is reserved.", "4b54bee6-2c25-42c3-a10f-7d0d1fbd91f9"))
+				return apierr.FastifyReply(c, http.StatusBadRequest, "USED_USERNAME")
 			}
-			return c.JSON(http.StatusInternalServerError, apierr.Error("INTERNAL_ERROR", "Internal error.", "5d37dbcb-891e-41ca-a3d6-e690c97775ac"))
+			return apierr.FastifyReply(c, http.StatusInternalServerError, "INTERNAL_ERROR")
 		}
 		if h.emailSender != nil {
 			siteName := "Misskey"
@@ -204,16 +210,18 @@ func (h *Handler) Signup(c echo.Context) error {
 
 	result, err := h.signupService.Signup(req.Username, req.Password, false)
 	if err != nil {
+		// upstream の `/api/signup` は username 系 error を Fastify-style
+		// reply error で投げる (SignupApiService.ts)。shape を揃える (#802)。
 		if err == coresignup.ErrUsernameAlreadyExists {
 			return duplicatedUsernameError(c)
 		}
 		if err == coresignup.ErrInvalidUsername {
-			return c.JSON(http.StatusBadRequest, apierr.Error("INVALID_PARAM", "Invalid username.", "3d81ceae-475f-4600-b2a8-2bc116157532"))
+			return apierr.FastifyReply(c, http.StatusBadRequest, "INVALID_PARAM")
 		}
 		if err == coresignup.ErrUsernameReserved {
-			return c.JSON(http.StatusBadRequest, apierr.Error("USED_USERNAME", "That username is reserved.", "4b54bee6-2c25-42c3-a10f-7d0d1fbd91f9"))
+			return apierr.FastifyReply(c, http.StatusBadRequest, "USED_USERNAME")
 		}
-		return c.JSON(http.StatusInternalServerError, apierr.Error("INTERNAL_ERROR", "Internal error.", "5d37dbcb-891e-41ca-a3d6-e690c97775ac"))
+		return apierr.FastifyReply(c, http.StatusInternalServerError, "INTERNAL_ERROR")
 	}
 
 	// invitation code使用済みにする

--- a/internal/api/signup/handler_test.go
+++ b/internal/api/signup/handler_test.go
@@ -80,6 +80,19 @@ func parseResp(t *testing.T, rec *httptest.ResponseRecorder) map[string]any {
 	return resp
 }
 
+// assertFastifyError は upstream Misskey TS の Fastify-style reply error
+// shape (= {statusCode, error, message}) を expectations に対して assert
+// する。#802 で signup endpoint の username / captcha 系 error を upstream
+// に揃えたため、対応 test はこの helper を使う。
+func assertFastifyError(t *testing.T, rec *httptest.ResponseRecorder, status int, code string) {
+	t.Helper()
+	require.Equal(t, status, rec.Code)
+	resp := parseResp(t, rec)
+	require.EqualValues(t, status, resp["statusCode"])
+	require.Equal(t, http.StatusText(status), resp["error"])
+	require.Equal(t, "Error: "+code, resp["message"])
+}
+
 // --- Success ---
 
 func TestSignup_Success(t *testing.T) {
@@ -131,23 +144,16 @@ func TestSignup_DuplicateUsername(t *testing.T) {
 	h, userRepo, _ := newTestHandler(t)
 	userRepo.Users["u1"] = &model.User{ID: "u1", Username: "taken", UsernameLower: "taken"}
 	rec := doPost(h.Signup, `{"username":"taken","password":"pass"}`)
-	// upstream Misskey TS と整合 (#798): 400 + DUPLICATED_USERNAME
-	assert.Equal(t, http.StatusBadRequest, rec.Code)
-
-	resp := parseResp(t, rec)
-	errObj := resp["error"].(map[string]any)
-	assert.Equal(t, "DUPLICATED_USERNAME", errObj["code"])
+	// upstream Misskey TS と整合 (#798 status, #802 shape): 400 +
+	// Fastify-style reply error の `Error: DUPLICATED_USERNAME` message。
+	assertFastifyError(t, rec, http.StatusBadRequest, "DUPLICATED_USERNAME")
 }
 
 func TestSignup_ReservedUsername(t *testing.T) {
 	h, _, metaRepo := newTestHandler(t)
 	metaRepo.Meta.PreservedUsernames = []string{"admin", "root"}
 	rec := doPost(h.Signup, `{"username":"admin","password":"pass"}`)
-	assert.Equal(t, http.StatusBadRequest, rec.Code)
-
-	resp := parseResp(t, rec)
-	errObj := resp["error"].(map[string]any)
-	assert.Equal(t, "USED_USERNAME", errObj["code"])
+	assertFastifyError(t, rec, http.StatusBadRequest, "USED_USERNAME")
 }
 
 // --- Meta errors ---
@@ -356,11 +362,8 @@ func TestSignup_CaptchaFailed(t *testing.T) {
 
 	// testcaptcha-response が空 → 検証失敗
 	rec := doPost(h.Signup, `{"username":"alice","password":"pass"}`)
-	assert.Equal(t, http.StatusBadRequest, rec.Code)
-
-	resp := parseResp(t, rec)
-	errObj := resp["error"].(map[string]any)
-	assert.Equal(t, "CAPTCHA_FAILED", errObj["code"])
+	// upstream は captcha 失敗を Fastify-style reply error で返す (#802)。
+	assertFastifyError(t, rec, http.StatusBadRequest, "CAPTCHA_FAILED")
 }
 
 func TestSignup_CaptchaSuccess(t *testing.T) {
@@ -598,10 +601,7 @@ func TestSignup_EmailRequired_ReservedUsername(t *testing.T) {
 	metaRepo.Meta.EmailRequiredForSignup = true
 	metaRepo.Meta.PreservedUsernames = []string{"admin"}
 	rec := doPost(h.Signup, `{"username":"admin","password":"pass","emailAddress":"x@example.com"}`)
-	assert.Equal(t, http.StatusBadRequest, rec.Code)
-	resp := parseResp(t, rec)
-	errField, _ := resp["error"].(map[string]any)
-	assert.Equal(t, "USED_USERNAME", errField["code"])
+	assertFastifyError(t, rec, http.StatusBadRequest, "USED_USERNAME")
 }
 
 // 注: SignupPending の ErrInvitationAlreadyUsed / ErrInvitationRevoked は

--- a/tests/playwright/specs/auth/signup.spec.ts
+++ b/tests/playwright/specs/auth/signup.spec.ts
@@ -41,15 +41,15 @@ test.describe('auth: signup-flow', () => {
     const username = randomUsername('dupe');
     await signupUser(request, username, 'password1234');
 
-    // upstream Misskey TS と mk-go (#798 fix 後) は status 400 + code
-    // DUPLICATED_USERNAME を返す。ただし error response の body shape は
-    // upstream (Fastify) = `{statusCode, error, message: "Error: DUPLICATED_USERNAME"}`、
-    // mk-go = `{error: {code: "DUPLICATED_USERNAME", id, message}}` と
-    // drift がある (#802 で別途 tracking)。本 spec は両者で pass するよう
-    // body 全文中に DUPLICATED_USERNAME 文字列が含まれることだけ確認する。
+    // upstream Misskey TS と mk-go (#798 status / #802 shape fix 後) は
+    // status 400 + Fastify-style reply error
+    // `{statusCode:400, error:"Bad Request", message:"Error: DUPLICATED_USERNAME"}`
+    // を返す。本 spec は両者の strict shape を assert する。
     const resp = await callApi(request, 'signup', { username, password: 'password1234' });
     expect(resp.status()).toBe(400);
-    const text = await resp.text();
-    expect(text).toContain('DUPLICATED_USERNAME');
+    const body = await resp.json();
+    expect(body.statusCode).toBe(400);
+    expect(body.error).toBe('Bad Request');
+    expect(body.message).toBe('Error: DUPLICATED_USERNAME');
   });
 });


### PR DESCRIPTION
## Summary

upstream Misskey TS の `/api/signup` は username 衝突 / 予約名 / captcha 失敗等の error を Fastify-style reply error 形式 `{statusCode:400, error:\"Bad Request\", message:\"Error: <CODE>\"}` で返す (`SignupApiService.ts` の `throw new FastifyReplyError(400, code)`)。mk-go は同 endpoint で Misskey misc 形式 `{error:{code,id,message}}` を返していて drop-in shape drift があった (#802)。

本 PR は **scope を `/api/signup` の Fastify-error 経路に限定** して shape を揃える Phase 1。

## 主な変更

- **`internal/api/apierr/fastify.go`** (新規): 共有 helper `FastifyReply(c, status, code)` を追加。`message` は upstream Node の `Error.toString()` の output を反映するため `\"Error: \" + code` で組み立てる。
- **`internal/api/signup/handler.go`**: signup endpoint の username 系 error (DUPLICATED_USERNAME / USED_USERNAME / INVALID_PARAM) と CAPTCHA_FAILED、および generic INTERNAL_ERROR を `FastifyReply` 経由に置換。`duplicatedUsernameError` helper も Fastify shape に切替。
- **`tests/playwright/specs/auth/signup.spec.ts`**: duplicate signup の assert を `body.statusCode / body.error / body.message` の strict shape に戻す。
- **unit test**: `assertFastifyError` helper を追加し、対応 4 case を集約。

## scope 外 (= 後続 PR / 別 issue で対応)

- `/api/signup-pending` の error path
  - upstream 400 / mk-go 404 (NO_SUCH_CODE) / 410 (EXPIRED) / 409 (INVITATION_ALREADY_USED) / 410 (INVITATION_REVOKED) と **status drift も並行** するため shape だけ揃えると中途半端な状態になる
- `/api/signin-flow` / `/api/signin-with-passkey` の error path
  - upstream 自身が rate limit / 入力 validation / captcha で 3 種類の shape を混在させているため、整理に scope が要る
- email 系 / invitation 系の empty-body 400 path
  - upstream は `reply.code(400); return;` で body 空。mk-go は misc 形式維持

## 検証

- \`go test ./internal/api/apierr/... ./internal/api/signup/...\`
  - apierr: 96.7% coverage
  - signup: 94.8% coverage
- Playwright TS image: 16/16 pass (\`make playwright-ts-test\`、strict shape assert で)
- Playwright mk-go: 16/16 pass (\`make playwright-test\`、strict shape assert で)

## Closes (partial)

#802 (Phase 1 のみ; 残りは別 PR)