### PR TITLE
Fix #809 / #810: signup-pending 全 error path と signin-flow captcha を Fastify shape に揃える

### DIFF
--- a/internal/api/signin/handler.go
+++ b/internal/api/signin/handler.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/labstack/echo/v4"
 	"github.com/lib/pq"
+	"github.com/shiroha-a/mk/internal/api/apierr"
 	"github.com/shiroha-a/mk/internal/core/captcha"
 	"github.com/shiroha-a/mk/internal/core/twofactor"
 	"github.com/shiroha-a/mk/internal/entity"
@@ -212,7 +213,10 @@ func (h *Handler) SigninFlow(c echo.Context) error {
 			Testcaptcha: req.TestcaptchaResponse,
 		}
 		if err := h.captchaSvc.Verify(c.Request().Context(), tokens); err != nil {
-			return c.JSON(http.StatusBadRequest, errBody("ed1d7571-a3ac-4370-899c-0dbe5e230cc8"))
+			// upstream は captcha 失敗時に Fastify-style reply error を返す
+			// (SigninApiService.ts:186-213 の 5 provider どれも `throw new
+			// FastifyReplyError(400, err)`)。mk-go も同 shape に揃える (#810)。
+			return apierr.FastifyReply(c, http.StatusBadRequest, "CAPTCHA_FAILED")
 		}
 	}
 

--- a/internal/api/signin/handler_test.go
+++ b/internal/api/signin/handler_test.go
@@ -266,12 +266,7 @@ func TestSigninFlow_CaptchaBlocksMissingToken(t *testing.T) {
 	// `throw new FastifyReplyError(400, err)` を投げる (SigninApiService.ts)
 	// ため、mk-go も #810 で同 Fastify shape に揃える。
 	rec := doPost(h.SigninFlow, `{"username":"capuser2","password":"pass"}`)
-	require.Equal(t, http.StatusBadRequest, rec.Code)
-	var body map[string]any
-	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &body))
-	require.EqualValues(t, http.StatusBadRequest, body["statusCode"])
-	require.Equal(t, "Bad Request", body["error"])
-	require.Equal(t, "Error: CAPTCHA_FAILED", body["message"])
+	testutil.AssertFastifyError(t, rec, http.StatusBadRequest, "CAPTCHA_FAILED")
 }
 
 func TestSigninFlow_CaptchaSkippedFor2FAUsers(t *testing.T) {

--- a/internal/api/signin/handler_test.go
+++ b/internal/api/signin/handler_test.go
@@ -262,10 +262,16 @@ func TestSigninFlow_CaptchaBlocksMissingToken(t *testing.T) {
 	captchaSvc := captcha.NewService(&model.Meta{EnableTestcaptcha: true})
 	h.SetCaptcha(captchaSvc)
 
-	// testcaptcha-response を送らないので CAPTCHA 検証失敗。
-	// TS upstream は 400 を返す (#705)。
+	// testcaptcha-response を送らないので CAPTCHA 検証失敗。upstream は
+	// `throw new FastifyReplyError(400, err)` を投げる (SigninApiService.ts)
+	// ため、mk-go も #810 で同 Fastify shape に揃える。
 	rec := doPost(h.SigninFlow, `{"username":"capuser2","password":"pass"}`)
-	assert.Equal(t, http.StatusBadRequest, rec.Code)
+	require.Equal(t, http.StatusBadRequest, rec.Code)
+	var body map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &body))
+	require.EqualValues(t, http.StatusBadRequest, body["statusCode"])
+	require.Equal(t, "Bad Request", body["error"])
+	require.Equal(t, "Error: CAPTCHA_FAILED", body["message"])
 }
 
 func TestSigninFlow_CaptchaSkippedFor2FAUsers(t *testing.T) {

--- a/internal/api/signup/handler.go
+++ b/internal/api/signup/handler.go
@@ -234,29 +234,39 @@ func (h *Handler) Signup(c echo.Context) error {
 
 // SignupPending handles POST /api/signup-pending. Misskey TS 互換: code を
 // 受け取り、対応する user_pending を本登録に昇格して { id, i: token } を返す。
+//
+// upstream `SignupApiService.signupPending` は handler 全体を try-catch で
+// 囲み catch 節で `throw new FastifyReplyError(400, ...)` を投げるため、
+// 既知 error も unknown error も status 400 + Fastify shape で返る。
+// mk-go も #809 で status/shape を upstream に揃える (旧 mk-go は
+// NO_SUCH_CODE=404 / EXPIRED=410 / INVITATION_ALREADY_USED=409 /
+// INVITATION_REVOKED=410 と独自 status を返していて drop-in 互換が崩れて
+// いた)。INTERNAL_ERROR (default catch) のみ server-side error として 500
+// を維持する (upstream の 400 を再現すると true internal failure が 400 に
+// 丸まり sanity check 上望ましくないため意図的 drift)。
 func (h *Handler) SignupPending(c echo.Context) error {
 	var req struct {
 		Code string `json:"code"`
 	}
 	if err := c.Bind(&req); err != nil || req.Code == "" {
-		return c.JSON(http.StatusBadRequest, apierr.Error("INVALID_PARAM", "code is required.", "3d81ceae-475f-4600-b2a8-2bc116157532"))
+		return apierr.FastifyReply(c, http.StatusBadRequest, "INVALID_PARAM")
 	}
 	result, err := h.signupService.PromotePending(req.Code)
 	if err != nil {
 		switch err {
 		case coresignup.ErrPendingNotFound:
-			return c.JSON(http.StatusNotFound, apierr.Error("NO_SUCH_CODE", "No such pending registration.", "1e53842e-b7f4-4e1c-8f1e-8d0a2d9b0c7e"))
+			return apierr.FastifyReply(c, http.StatusBadRequest, "NO_SUCH_CODE")
 		case coresignup.ErrPendingExpired:
-			return c.JSON(http.StatusGone, apierr.Error("EXPIRED", "Pending registration has expired.", "9c2bc685-fa0a-4e6f-bf6f-5f4f8c0c3a3a"))
+			return apierr.FastifyReply(c, http.StatusBadRequest, "EXPIRED")
 		case coresignup.ErrUsernameAlreadyExists:
 			return duplicatedUsernameError(c)
 		case coresignup.ErrInvitationAlreadyUsed:
-			return c.JSON(http.StatusConflict, apierr.Error("INVITATION_ALREADY_USED", "Invitation already used.", "5b81b5e2-2c0b-4d8a-9b71-1a3e1d4d3f6a"))
+			return apierr.FastifyReply(c, http.StatusBadRequest, "INVITATION_ALREADY_USED")
 		case coresignup.ErrInvitationRevoked:
 			// admin が ticket を削除した状態 (#610 item 2)。AlreadyUsed と区別。
-			return c.JSON(http.StatusGone, apierr.Error("INVITATION_REVOKED", "Invitation has been revoked.", "9b1aa3e7-f8e7-4c92-8d7c-2c0e5b9d8a4b"))
+			return apierr.FastifyReply(c, http.StatusBadRequest, "INVITATION_REVOKED")
 		default:
-			return c.JSON(http.StatusInternalServerError, apierr.Error("INTERNAL_ERROR", "Internal error.", "5d37dbcb-891e-41ca-a3d6-e690c97775ac"))
+			return apierr.FastifyReply(c, http.StatusInternalServerError, "INTERNAL_ERROR")
 		}
 	}
 	// 招待コード消費 — Service の tx 経路では tx 内で MarkUsed 済 (#604)。

--- a/internal/api/signup/handler_test.go
+++ b/internal/api/signup/handler_test.go
@@ -80,19 +80,6 @@ func parseResp(t *testing.T, rec *httptest.ResponseRecorder) map[string]any {
 	return resp
 }
 
-// assertFastifyError は upstream Misskey TS の Fastify-style reply error
-// shape (= {statusCode, error, message}) を expectations に対して assert
-// する。#802 で signup endpoint の username / captcha 系 error を upstream
-// に揃えたため、対応 test はこの helper を使う。
-func assertFastifyError(t *testing.T, rec *httptest.ResponseRecorder, status int, code string) {
-	t.Helper()
-	require.Equal(t, status, rec.Code)
-	resp := parseResp(t, rec)
-	require.EqualValues(t, status, resp["statusCode"])
-	require.Equal(t, http.StatusText(status), resp["error"])
-	require.Equal(t, "Error: "+code, resp["message"])
-}
-
 // --- Success ---
 
 func TestSignup_Success(t *testing.T) {
@@ -146,14 +133,14 @@ func TestSignup_DuplicateUsername(t *testing.T) {
 	rec := doPost(h.Signup, `{"username":"taken","password":"pass"}`)
 	// upstream Misskey TS と整合 (#798 status, #802 shape): 400 +
 	// Fastify-style reply error の `Error: DUPLICATED_USERNAME` message。
-	assertFastifyError(t, rec, http.StatusBadRequest, "DUPLICATED_USERNAME")
+	testutil.AssertFastifyError(t, rec, http.StatusBadRequest, "DUPLICATED_USERNAME")
 }
 
 func TestSignup_ReservedUsername(t *testing.T) {
 	h, _, metaRepo := newTestHandler(t)
 	metaRepo.Meta.PreservedUsernames = []string{"admin", "root"}
 	rec := doPost(h.Signup, `{"username":"admin","password":"pass"}`)
-	assertFastifyError(t, rec, http.StatusBadRequest, "USED_USERNAME")
+	testutil.AssertFastifyError(t, rec, http.StatusBadRequest, "USED_USERNAME")
 }
 
 // --- Meta errors ---
@@ -259,7 +246,7 @@ func TestSignupPending_InvalidParam(t *testing.T) {
 	rec := doPost(h.SignupPending, `{}`)
 	// upstream は handler 全体が try-catch で囲まれていて status 400 +
 	// Fastify shape を返す (#809)。code が空の場合も同 shape に揃える。
-	assertFastifyError(t, rec, http.StatusBadRequest, "INVALID_PARAM")
+	testutil.AssertFastifyError(t, rec, http.StatusBadRequest, "INVALID_PARAM")
 }
 
 func TestSignupPending_NotFound(t *testing.T) {
@@ -275,7 +262,7 @@ func TestSignupPending_NotFound(t *testing.T) {
 	rec := doPost(h.SignupPending, `{"code":"ghost"}`)
 	// upstream に揃えて 400 + NO_SUCH_CODE (旧 mk-go は 404)。#809 で
 	// status drift も解消。
-	assertFastifyError(t, rec, http.StatusBadRequest, "NO_SUCH_CODE")
+	testutil.AssertFastifyError(t, rec, http.StatusBadRequest, "NO_SUCH_CODE")
 }
 
 // --- Registration disabled (invitation code) ---
@@ -367,7 +354,7 @@ func TestSignup_CaptchaFailed(t *testing.T) {
 	// testcaptcha-response が空 → 検証失敗
 	rec := doPost(h.Signup, `{"username":"alice","password":"pass"}`)
 	// upstream は captcha 失敗を Fastify-style reply error で返す (#802)。
-	assertFastifyError(t, rec, http.StatusBadRequest, "CAPTCHA_FAILED")
+	testutil.AssertFastifyError(t, rec, http.StatusBadRequest, "CAPTCHA_FAILED")
 }
 
 func TestSignup_CaptchaSuccess(t *testing.T) {
@@ -491,7 +478,7 @@ func TestSignupPending_Expired(t *testing.T) {
 	rec := doPost(h.SignupPending, `{"code":"`+row.Code+`"}`)
 	// upstream に揃えて 400 + EXPIRED (旧 mk-go は 410)。#809 で status
 	// drift も解消。
-	assertFastifyError(t, rec, http.StatusBadRequest, "EXPIRED")
+	testutil.AssertFastifyError(t, rec, http.StatusBadRequest, "EXPIRED")
 }
 
 // SignupPending: username clash 後の Conflict
@@ -512,7 +499,7 @@ func TestSignupPending_UsernameClash(t *testing.T) {
 	rec := doPost(h.SignupPending, `{"code":"`+row.Code+`"}`)
 	// upstream 整合 (#798 status, #802/#809 shape): duplicate は 400 +
 	// Fastify shape DUPLICATED_USERNAME。
-	assertFastifyError(t, rec, http.StatusBadRequest, "DUPLICATED_USERNAME")
+	testutil.AssertFastifyError(t, rec, http.StatusBadRequest, "DUPLICATED_USERNAME")
 }
 
 // emailSender が未設定でも pending row 自体は作られて 204 を返す (テスト用 setup)
@@ -608,7 +595,7 @@ func TestSignup_EmailRequired_ReservedUsername(t *testing.T) {
 	metaRepo.Meta.EmailRequiredForSignup = true
 	metaRepo.Meta.PreservedUsernames = []string{"admin"}
 	rec := doPost(h.Signup, `{"username":"admin","password":"pass","emailAddress":"x@example.com"}`)
-	assertFastifyError(t, rec, http.StatusBadRequest, "USED_USERNAME")
+	testutil.AssertFastifyError(t, rec, http.StatusBadRequest, "USED_USERNAME")
 }
 
 // 注: SignupPending の ErrInvitationAlreadyUsed / ErrInvitationRevoked は

--- a/internal/api/signup/handler_test.go
+++ b/internal/api/signup/handler_test.go
@@ -257,7 +257,9 @@ func TestSignupPending_Success(t *testing.T) {
 func TestSignupPending_InvalidParam(t *testing.T) {
 	h, _, _ := newTestHandler(t)
 	rec := doPost(h.SignupPending, `{}`)
-	assert.Equal(t, http.StatusBadRequest, rec.Code)
+	// upstream は handler 全体が try-catch で囲まれていて status 400 +
+	// Fastify shape を返す (#809)。code が空の場合も同 shape に揃える。
+	assertFastifyError(t, rec, http.StatusBadRequest, "INVALID_PARAM")
 }
 
 func TestSignupPending_NotFound(t *testing.T) {
@@ -271,7 +273,9 @@ func TestSignupPending_NotFound(t *testing.T) {
 	h := apisignup.NewHandler(svc, metaRepo, idGen)
 
 	rec := doPost(h.SignupPending, `{"code":"ghost"}`)
-	assert.Equal(t, http.StatusNotFound, rec.Code)
+	// upstream に揃えて 400 + NO_SUCH_CODE (旧 mk-go は 404)。#809 で
+	// status drift も解消。
+	assertFastifyError(t, rec, http.StatusBadRequest, "NO_SUCH_CODE")
 }
 
 // --- Registration disabled (invitation code) ---
@@ -485,7 +489,9 @@ func TestSignupPending_Expired(t *testing.T) {
 	pendingRepo.Rows[old] = row
 
 	rec := doPost(h.SignupPending, `{"code":"`+row.Code+`"}`)
-	assert.Equal(t, http.StatusGone, rec.Code)
+	// upstream に揃えて 400 + EXPIRED (旧 mk-go は 410)。#809 で status
+	// drift も解消。
+	assertFastifyError(t, rec, http.StatusBadRequest, "EXPIRED")
 }
 
 // SignupPending: username clash 後の Conflict
@@ -504,8 +510,9 @@ func TestSignupPending_UsernameClash(t *testing.T) {
 	require.NoError(t, userRepo.Create(&model.User{ID: "u_c2", Username: "Clash2", UsernameLower: "clash2"}))
 
 	rec := doPost(h.SignupPending, `{"code":"`+row.Code+`"}`)
-	// upstream 整合 (#798): duplicate は 400 + DUPLICATED_USERNAME。
-	assert.Equal(t, http.StatusBadRequest, rec.Code)
+	// upstream 整合 (#798 status, #802/#809 shape): duplicate は 400 +
+	// Fastify shape DUPLICATED_USERNAME。
+	assertFastifyError(t, rec, http.StatusBadRequest, "DUPLICATED_USERNAME")
 }
 
 // emailSender が未設定でも pending row 自体は作られて 204 を返す (テスト用 setup)

--- a/internal/testutil/api_asserts.go
+++ b/internal/testutil/api_asserts.go
@@ -1,0 +1,30 @@
+package testutil
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// AssertFastifyError verifies that the recorder body is the upstream
+// Misskey TS Fastify-style reply error shape:
+//
+//	{"statusCode": <status>, "error": <http.StatusText(status)>, "message": "Error: <code>"}
+//
+// 対応する production helper は internal/api/apierr.FastifyReply。drop-in
+// 互換 fix (#802 / #809 / #810) の handler_test 群が共有する assertion で、
+// signup / signin endpoint をまたいで重複定義していた assertion を集約する。
+//
+// 失敗時は require 経由で fail-fast (= subtest 単位で打ち切り)。
+func AssertFastifyError(t *testing.T, rec *httptest.ResponseRecorder, status int, code string) {
+	t.Helper()
+	require.Equal(t, status, rec.Code)
+	var body map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &body))
+	require.EqualValues(t, status, body["statusCode"])
+	require.Equal(t, http.StatusText(status), body["error"])
+	require.Equal(t, "Error: "+code, body["message"])
+}

--- a/internal/testutil/api_asserts_test.go
+++ b/internal/testutil/api_asserts_test.go
@@ -1,0 +1,52 @@
+package testutil
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+// AssertFastifyError の happy-path test。helper が require ベースなので
+// 失敗時は fail-fast、ここまで戻ってこれた = assertion を通過した、と
+// いうのが test の意味。complementary な fail path は require/testify
+// 標準動作に依拠 (= helper 自身ではなく testify の責務) ので test しない。
+
+func TestAssertFastifyError_400DuplicatedUsername(t *testing.T) {
+	rec := httptest.NewRecorder()
+	rec.Code = http.StatusBadRequest
+	body, _ := json.Marshal(map[string]any{
+		"statusCode": http.StatusBadRequest,
+		"error":      "Bad Request",
+		"message":    "Error: DUPLICATED_USERNAME",
+	})
+	_, _ = rec.Body.Write(body)
+
+	AssertFastifyError(t, rec, http.StatusBadRequest, "DUPLICATED_USERNAME")
+}
+
+func TestAssertFastifyError_410Expired(t *testing.T) {
+	rec := httptest.NewRecorder()
+	rec.Code = http.StatusGone
+	body, _ := json.Marshal(map[string]any{
+		"statusCode": http.StatusGone,
+		"error":      "Gone",
+		"message":    "Error: EXPIRED",
+	})
+	_, _ = rec.Body.Write(body)
+
+	AssertFastifyError(t, rec, http.StatusGone, "EXPIRED")
+}
+
+func TestAssertFastifyError_500Internal(t *testing.T) {
+	rec := httptest.NewRecorder()
+	rec.Code = http.StatusInternalServerError
+	body, _ := json.Marshal(map[string]any{
+		"statusCode": http.StatusInternalServerError,
+		"error":      "Internal Server Error",
+		"message":    "Error: INTERNAL_ERROR",
+	})
+	_, _ = rec.Body.Write(body)
+
+	AssertFastifyError(t, rec, http.StatusInternalServerError, "INTERNAL_ERROR")
+}

--- a/tests/playwright/specs/auth/signup_pending.spec.ts
+++ b/tests/playwright/specs/auth/signup_pending.spec.ts
@@ -1,0 +1,48 @@
+// #809 / #810 Phase 2: signup-pending error response shape.
+//
+// upstream Misskey TS の `/api/signup-pending` は handler 全体を try-catch
+// で囲み、catch 節で `throw new FastifyReplyError(400, ...)` を投げる
+// (third_party の SignupApiService.ts:285-287)。既知 error も unknown error
+// も **status 400 + Fastify-style reply error shape** で返る:
+//
+//   {"statusCode":400,"error":"Bad Request","message":<string>}
+//
+// mk-go は #809 で同 status / shape に揃えた (旧 mk-go は NO_SUCH_CODE=404
+// / EXPIRED=410 / INVITATION_ALREADY_USED=409 と独自 status を返していて
+// drop-in 互換が崩れていた)。
+//
+// 注: message の **本文** は upstream と mk-go で異なる:
+//   - upstream: typeORM の `EntityNotFoundError` を toString した生文字列
+//     (= "EntityNotFoundError: Could not find any entity of type ...")
+//   - mk-go: 安定 code "NO_SUCH_CODE" を含む Fastify shape
+//     (= "Error: NO_SUCH_CODE")
+// upstream は generic catch で漏れた未整理 error をそのまま返しているだけで
+// frontend 側で意味のある classification ができないため、mk-go は安定 code を
+// 出す方を選んだ (= shape 互換 + frontend 親和性 > 完全な message 一致)。
+//
+// 本 spec は両 backend で共通する status/shape (statusCode + error 文字列)
+// と message が string であることだけ確認する。expired / invitation 系は
+// spec 上で再現困難 (= 25h 前の pending row 操作 / invitation ticket DB
+// 操作が必要) なので unit test 側で cover する。
+
+import { expect, test } from '@playwright/test';
+import { callApi } from '../../fixtures/api';
+import { resetRateLimit } from '../../fixtures/rate_limit';
+
+test.describe('auth: signup-pending error shape', () => {
+  test.beforeEach(() => {
+    resetRateLimit();
+  });
+
+  test('non-existent code returns 400 + Fastify-style reply error', async ({ request }) => {
+    const resp = await callApi(request, 'signup-pending', { code: 'notexistcode' });
+    expect(resp.status()).toBe(400);
+    const body = await resp.json();
+    expect(body.statusCode).toBe(400);
+    expect(body.error).toBe('Bad Request');
+    // message の本文は backend ごとに異なる (上記 file header 注を参照) ので
+    // 本 spec では string 型と非空であることだけ確認する。
+    expect(typeof body.message).toBe('string');
+    expect(body.message.length).toBeGreaterThan(0);
+  });
+});


### PR DESCRIPTION
## Summary

#802 Phase 1 (#808) で \`/api/signup\` の error response shape を Fastify-style reply error 形式に揃えた残りを 1 PR で完了させる。

- **#809 Phase 2**: \`/api/signup-pending\` の 6 error path を \`apierr.FastifyReply\` 経由に置換 + status drift も解消 (404/410/409 → 400 統一)。INTERNAL_ERROR のみ 500 維持
- **#810 Phase 3**: \`/api/signin-flow\` の captcha 失敗 1 path を Fastify shape 化 (他 path は upstream と shape 一致のため現状維持)
- \`/api/signin-with-passkey\` は upstream に \`FastifyReplyError\` 経路が無く drift なし = scope 外

## 主な変更

- **\`internal/api/signup/handler.go\`** \`SignupPending\`: 6 error path (INVALID_PARAM / NO_SUCH_CODE / EXPIRED / DUPLICATED_USERNAME / INVITATION_ALREADY_USED / INVITATION_REVOKED / INTERNAL_ERROR) を \`apierr.FastifyReply\` に置換。status は upstream に揃え 400 統一 (INTERNAL_ERROR のみ 500 維持)。
- **\`internal/api/signin/handler.go\`** \`SigninFlow\`: captcha verify 失敗 1 path を \`apierr.FastifyReply(c, 400, \"CAPTCHA_FAILED\")\` に置換。\`apierr\` import 追加
- **\`internal/api/signup/handler_test.go\`**: 4 test を \`assertFastifyError\` helper で書き換え (TestSignupPending_InvalidParam / TestSignupPending_NotFound / TestSignupPending_Expired / TestSignupPending_UsernameClash)
- **\`internal/api/signin/handler_test.go\`** TestSigninFlow_CaptchaBlocksMissingToken: Fastify shape を inline で strict assert
- **\`tests/playwright/specs/auth/signup_pending.spec.ts\`** (新規): \`notexistcode\` に対して 400 + Fastify-style shape を両 backend で assert。message 本文は upstream/mk-go で異なるため string 型 + 非空のみ確認

## 設計判断

### status drift の解消方針 (signup-pending)

upstream の generic catch は **全 error を 400 に丸める** (try-catch で囲んで FastifyReplyError 400 で再投げ)。一方 mk-go は path 毎に sane な status (404 / 410 / 409) を返していた。drop-in 互換のため status も 400 に揃えるが、**INTERNAL_ERROR (default catch) のみ 500 を維持**。理由: true server-side error を 400 に丸めると frontend / monitoring 側で「ユーザー入力 error」と「server-side error」を区別できず false-negative になる。

### message 本文の drift

- **mk-go**: 安定した code 文字列 (\`\"Error: NO_SUCH_CODE\"\` 等)
- **upstream**: generic catch で漏れた typeORM の \`EntityNotFoundError\` を \`toString()\` した生文字列 (\`\"EntityNotFoundError: Could not find any entity of type ...\"\`)

upstream は frontend 側で意味のある classification ができない状態。mk-go は安定 code を返す方を選んだ (= shape 互換 + frontend 親和性 > 完全な message 一致)。Playwright spec は両者で pass するよう本文を assert しない。

## 検証

- \`go test ./internal/api/signup/... ./internal/api/signin/...\`
  - signup: 94.8% coverage
  - signin: 94.4% coverage
- Playwright TS image: 17/17 pass (\`make playwright-ts-test\`)
- Playwright mk-go: 17/17 pass (\`make playwright-test\`)

## Closes

- Closes #809
- Closes #810