### PR TITLE
#744 Phase 1 残: streaming localTimeline channel の Playwright spec 追加

### DIFF
--- a/tests/playwright/specs/streaming/local_timeline.spec.ts
+++ b/tests/playwright/specs/streaming/local_timeline.spec.ts
@@ -1,0 +1,89 @@
+// #744 Phase 1 残: streaming WebSocket の local timeline channel。
+//
+// upstream Misskey TS と mk-go は `/streaming?i=<token>` で WebSocket を提供
+// し、クライアントが `connect` で channel を subscribe したあと該当 event を
+// push する。本 spec は localTimeline channel で:
+//
+//   1. signup user → WS connect → localTimeline subscribe
+//   2. 同 user で public note を投稿 (HTTP POST /api/notes/create)
+//   3. WS message として `{type:"channel", body:{id:<subId>, type:"note", body:<note>}}`
+//      が届く
+//   4. event の note.id が POST 結果の note.id と一致
+//
+// を assert する。streaming は Phase 1 残 spec の中で WebSocket 経路を担保
+// する重要 path。channel の payload 形式 / id round-trip / event push 経路
+// が両 backend で揃うことを担保する。
+//
+// 注: subscribe → publish の race を避けるため subscribe 後に短時間 sleep
+// を入れている。upstream は subscribe ack を返さないので message 受信の
+// timeout 内に event が届くかで成否を判定する。
+//
+// Phase 1 残のもう一つ (2FA-passkey) は別 spec。
+
+import { expect, test } from '@playwright/test';
+import { randomUsername, signupUser } from '../../fixtures/auth';
+import { createNote } from '../../fixtures/notes';
+import { resetRateLimit } from '../../fixtures/rate_limit';
+
+const baseURL = process.env.MK_BASE_URL ?? 'http://mkgo:3000';
+const wsURL = baseURL.replace(/^http/, 'ws');
+
+test.describe('streaming: localTimeline', () => {
+  test.beforeAll(() => {
+    resetRateLimit();
+  });
+
+  test('subscribed user receives a note event for a local public note', async ({ request }) => {
+    const me = await signupUser(request, randomUsername('strm'));
+    const ws = new WebSocket(`${wsURL}/streaming?i=${me.token}`);
+
+    // WS open を待つ。失敗時は test timeout に任せる。
+    await new Promise<void>((resolve, reject) => {
+      ws.addEventListener('open', () => resolve(), { once: true });
+      ws.addEventListener('error', () => reject(new Error('ws connection failed')), { once: true });
+    });
+
+    // localTimeline channel を subscribe。subId は client 任意で event の
+    // round-trip 確認に使う。
+    const subId = 'sub-' + Math.random().toString(16).slice(2);
+    ws.send(JSON.stringify({
+      type: 'connect',
+      body: { channel: 'localTimeline', id: subId, params: {} },
+    }));
+
+    // 投稿 event 受信用の Promise を先に登録 (= 投稿 → 受信の race を防ぐ)。
+    const noteEventPromise = new Promise<{ id: string; text?: string }>((resolve, reject) => {
+      const handler = (ev: MessageEvent) => {
+        let msg: { type?: string; body?: { id?: string; type?: string; body?: { id: string; text?: string } } };
+        try {
+          msg = JSON.parse(typeof ev.data === 'string' ? ev.data : '');
+        } catch {
+          return;
+        }
+        if (msg.type === 'channel' && msg.body?.id === subId && msg.body.type === 'note' && msg.body.body) {
+          ws.removeEventListener('message', handler);
+          resolve(msg.body.body);
+        }
+      };
+      ws.addEventListener('message', handler);
+      setTimeout(() => {
+        ws.removeEventListener('message', handler);
+        reject(new Error('did not receive note event within timeout'));
+      }, 5000);
+    });
+
+    // subscribe 確定までの短時間バッファ。upstream は ack を返さないので
+    // 厳密に待つ手段はなく、200ms で実用上十分。
+    await new Promise((resolve) => setTimeout(resolve, 200));
+
+    const note = await createNote(request, me.token, {
+      text: 'streaming hello',
+      visibility: 'public',
+    });
+
+    const evNote = await noteEventPromise;
+    expect(evNote.id).toBe(note.id);
+
+    ws.close();
+  });
+});

--- a/tests/playwright/specs/streaming/local_timeline.spec.ts
+++ b/tests/playwright/specs/streaming/local_timeline.spec.ts
@@ -37,10 +37,17 @@ test.describe('streaming: localTimeline', () => {
     const me = await signupUser(request, randomUsername('strm'));
     const ws = new WebSocket(`${wsURL}/streaming?i=${me.token}`);
 
-    // WS open を待つ。失敗時は test timeout に任せる。
+    // WS open を待つ。close (= server 側 reject) も即 fail として
+    // 報告する (= test の 5s timeout 待ちを避け、原因を message に
+    // 反映できる)。
     await new Promise<void>((resolve, reject) => {
       ws.addEventListener('open', () => resolve(), { once: true });
-      ws.addEventListener('error', () => reject(new Error('ws connection failed')), { once: true });
+      ws.addEventListener('error', () => reject(new Error('ws connection error')), { once: true });
+      ws.addEventListener(
+        'close',
+        (ev) => reject(new Error(`ws closed before open: code=${ev.code} reason=${ev.reason || '(empty)'}`)),
+        { once: true },
+      );
     });
 
     // localTimeline channel を subscribe。subId は client 任意で event の


### PR DESCRIPTION
## Summary

#744 Phase 1 残 spec の 2 本目 (drive PR #813 に続いて)。WebSocket streaming endpoint (\`/streaming?i=<token>\`) に対して localTimeline channel を subscribe し、自分が public note を投稿すると \`{type:\"channel\", body:{id:<subId>, type:\"note\", body:<note>}}\` event が push される動作を両 backend 共通で strict assert する。

## 主な変更

- \`tests/playwright/specs/streaming/local_timeline.spec.ts\` (新規):
  1. signup user → WS connect → localTimeline subscribe
  2. event handler を先に登録 (= 投稿 → 受信の race 防止)
  3. subscribe 確定までの 200ms バッファ (upstream は subscribe ack を返さない)
  4. 同 user で public note 投稿
  5. WS event 受信 → \`event.body.id === note.id\` を assert

## 設計判断

- **Node 22 native WebSocket API**: Playwright 1.49 image (Node 22 LTS) で global WebSocket が使える。外部 \`ws\` package は不要 (依存追加なし)
- **subscribe ack 不在の handling**: upstream は ack を返さないので 200ms バッファで実用上十分。厳密化は subscribe 確認 endpoint があれば改善可だが現状は YAGNI
- **5s timeout**: event push が遅延する場合の test timeout。実測 mk-go ~400ms / TS ~340ms で margin 十分

## 検証

- Playwright TS image: 19/19 pass (\`make playwright-ts-test\`)
- Playwright mk-go: 19/19 pass (\`make playwright-test\`)

## scope 外 (= 後続 PR)

- 2FA-passkey spec (WebAuthn mock が必要、別 PR)
- 他 channel (homeTimeline / hybridTimeline / globalTimeline) の spec
- WS reconnect / disconnect / heartbeat 等のエラー path

## 関連

- #744 (umbrella: Playwright Phase 1)