### PR TITLE
ci: Playwright nightly workflow を追加 (#744 関連)

### DIFF
--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -34,35 +34,42 @@ jobs:
 
     strategy:
       fail-fast: false
+      # matrix.include で backend 固有の make target / compose 引数 /
+      # prepull コマンドを variables 化する。各 step は条件分岐なしで
+      # `${{ matrix.* }}` を展開するだけになり DRY を担保する。
       matrix:
-        backend: [mk-go, ts]
+        include:
+          - backend: mk-go
+            up_target: playwright-up
+            test_target: playwright-test
+            down_target: playwright-down
+            compose_args: -f docker-compose.playwright.yml
+            # 本 repo Dockerfile を使うので外部 image pre-pull 不要。
+            prepull: ""
+          - backend: ts
+            up_target: playwright-ts-up
+            test_target: playwright-ts-test
+            down_target: playwright-ts-down
+            compose_args: -f docker-compose.playwright.yml -f docker-compose.playwright.ts.yml
+            # upstream image は build 並列で pre-pull すると wallclock が
+            # 短縮できる (= compose up 内の pull 開始前に dedupe される)。
+            # version は docker-compose.playwright.ts.yml と sync。
+            prepull: docker pull misskey/misskey:2026.3.2 &
 
     steps:
       - uses: actions/checkout@v4
         with:
           ref: ${{ inputs.ref || 'develop' }}
 
-      # TS backend job のみ upstream image を pre-pull (= build と並列)。
-      # mk-go job は本 repo Dockerfile を使うので不要。
-      - name: Pre-pull Misskey TS image
-        if: matrix.backend == 'ts'
-        run: docker pull misskey/misskey:2026.3.2 &
+      - name: Pre-pull image (TS only)
+        if: matrix.prepull != ''
+        run: ${{ matrix.prepull }}
 
       - name: Bring up stack
-        run: |
-          if [ "${{ matrix.backend }}" = "ts" ]; then
-            make playwright-ts-up
-          else
-            make playwright-up
-          fi
+        run: make ${{ matrix.up_target }}
 
       - name: Run Playwright
-        run: |
-          if [ "${{ matrix.backend }}" = "ts" ]; then
-            make playwright-ts-test
-          else
-            make playwright-test
-          fi
+        run: make ${{ matrix.test_target }}
 
       # 失敗時のみ playwright test-results (trace / screenshot 含む) を保存。
       - name: Upload test-results on failure
@@ -80,13 +87,8 @@ jobs:
         if: failure()
         run: |
           mkdir -p /tmp/playwright-logs
-          if [ "${{ matrix.backend }}" = "ts" ]; then
-            docker compose -f docker-compose.playwright.yml -f docker-compose.playwright.ts.yml logs \
-              > /tmp/playwright-logs/compose.log 2>&1 || true
-          else
-            docker compose -f docker-compose.playwright.yml logs \
-              > /tmp/playwright-logs/compose.log 2>&1 || true
-          fi
+          docker compose ${{ matrix.compose_args }} logs \
+            > /tmp/playwright-logs/compose.log 2>&1 || true
 
       - name: Upload logs artifact on failure
         if: failure()
@@ -99,9 +101,4 @@ jobs:
 
       - name: Final teardown
         if: always()
-        run: |
-          if [ "${{ matrix.backend }}" = "ts" ]; then
-            make playwright-ts-down >/dev/null 2>&1 || true
-          else
-            make playwright-down >/dev/null 2>&1 || true
-          fi
+        run: make ${{ matrix.down_target }} >/dev/null 2>&1 || true

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -1,0 +1,107 @@
+name: Playwright (nightly)
+
+# #744 Phase 1 の Playwright spec を nightly で TS image + mk-go の両 backend
+# に対して実行し、drop-in shape drift / 連動 endpoint の regression を自動
+# 検知する。
+#
+# - schedule: 毎日 17:00 UTC (≒ JST 02:00)。dropin-e2e (18:00 UTC) /
+#   dropin-frontend-e2e (19:00 UTC) と被らせない
+# - workflow_dispatch: 任意の ref に対して手動実行可能
+# - PR の required check には**入れない**。spec 数が増えれば実行時間が伸び
+#   るのと、外部 image pull (TS image) が flaky 要素になる可能性があるため
+# - matrix: backend = [mk-go, ts] で並列実行。片方が失敗しても他方は完走
+# - 失敗時は playwright test-results + docker compose logs を artifact 化
+
+on:
+  schedule:
+    # 毎日 17:00 UTC (= JST 02:00)。develop ブランチに対して走る。
+    - cron: "0 17 * * *"
+  workflow_dispatch:
+    inputs:
+      ref:
+        description: "Branch / tag / SHA to test"
+        required: false
+        default: "develop"
+
+permissions:
+  contents: read
+
+jobs:
+  spec:
+    name: spec (${{ matrix.backend }})
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+
+    strategy:
+      fail-fast: false
+      matrix:
+        backend: [mk-go, ts]
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.ref || 'develop' }}
+
+      # TS backend job のみ upstream image を pre-pull (= build と並列)。
+      # mk-go job は本 repo Dockerfile を使うので不要。
+      - name: Pre-pull Misskey TS image
+        if: matrix.backend == 'ts'
+        run: docker pull misskey/misskey:2026.3.2 &
+
+      - name: Bring up stack
+        run: |
+          if [ "${{ matrix.backend }}" = "ts" ]; then
+            make playwright-ts-up
+          else
+            make playwright-up
+          fi
+
+      - name: Run Playwright
+        run: |
+          if [ "${{ matrix.backend }}" = "ts" ]; then
+            make playwright-ts-test
+          else
+            make playwright-test
+          fi
+
+      # 失敗時のみ playwright test-results (trace / screenshot 含む) を保存。
+      - name: Upload test-results on failure
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: playwright-results-${{ matrix.backend }}
+          path: tests/playwright/test-results/
+          if-no-files-found: ignore
+          retention-days: 14
+
+      # 失敗時のみ docker compose logs を artifact 化して原因調査できる
+      # ようにする。
+      - name: Capture docker compose logs on failure
+        if: failure()
+        run: |
+          mkdir -p /tmp/playwright-logs
+          if [ "${{ matrix.backend }}" = "ts" ]; then
+            docker compose -f docker-compose.playwright.yml -f docker-compose.playwright.ts.yml logs \
+              > /tmp/playwright-logs/compose.log 2>&1 || true
+          else
+            docker compose -f docker-compose.playwright.yml logs \
+              > /tmp/playwright-logs/compose.log 2>&1 || true
+          fi
+
+      - name: Upload logs artifact on failure
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: playwright-logs-${{ matrix.backend }}
+          path: /tmp/playwright-logs/
+          if-no-files-found: ignore
+          retention-days: 14
+
+      - name: Final teardown
+        if: always()
+        run: |
+          if [ "${{ matrix.backend }}" = "ts" ]; then
+            make playwright-ts-down >/dev/null 2>&1 || true
+          else
+            make playwright-down >/dev/null 2>&1 || true
+          fi

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -51,10 +51,14 @@ jobs:
             test_target: playwright-ts-test
             down_target: playwright-ts-down
             compose_args: -f docker-compose.playwright.yml -f docker-compose.playwright.ts.yml
-            # upstream image は build 並列で pre-pull すると wallclock が
-            # 短縮できる (= compose up 内の pull 開始前に dedupe される)。
-            # version は docker-compose.playwright.ts.yml と sync。
-            prepull: docker pull misskey/misskey:2026.3.2 &
+            # upstream image を先取りで pull しておく。次 step の compose up
+            # と並列化するために `&` background 化したい誘惑があるが、GitHub
+            # Actions の `run:` step は step 終了で shell が exit するため
+            # background process の継続が保証されない (= pre-pull 効果が
+            # 不確実)。foreground で完了を待ち、続く compose up 内の同
+            # image pull は docker daemon の cache hit で 0s で済む方が
+            # 確実。version は docker-compose.playwright.ts.yml と sync。
+            prepull: docker pull misskey/misskey:2026.3.2
 
     steps:
       - uses: actions/checkout@v4

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -360,6 +360,21 @@ Issueの作成・操作には`gh`コマンドを使う（`gh issue create`, `gh 
   drop-in 互換 regression は nightly で検出する運用。
 - 失敗時は docker compose logs を `dropin-logs` artifact として 14 日保持。
 
+### `playwright` workflow (nightly)
+
+- `.github/workflows/playwright.yml` で Phase 1 Playwright spec を毎日 17:00
+  UTC (= JST 02:00) に develop に対して実行する。
+- matrix で `backend = [mk-go, ts]` の 2 job を並列実行 (= 両 backend で
+  drop-in shape 互換が維持されることを担保)。`fail-fast: false` で片方失敗
+  しても他方は完走。
+- `workflow_dispatch` で任意の ref に対して手動実行も可。
+- PR の required check には**含めない** (TS image pull + spec 増加で実行
+  時間が伸びる + 外部 image flaky 要素)。drop-in shape regression は
+  nightly で検出する運用。
+- 失敗時は `tests/playwright/test-results/` (trace / screenshot 含む) と
+  docker compose logs を `playwright-results-<backend>` /
+  `playwright-logs-<backend>` artifact として 14 日保持。
+
 ### CI失敗時の対応
 
 - カバレッジ不足 → テストケースを追加してから再push。
@@ -446,6 +461,7 @@ Issueの作成・操作には`gh`コマンドを使う（`gh issue create`, `gh 
 
 本ドキュメントの主要な変更履歴。新規変更時は一番上に追記する（日付降順）。
 
+- **2026-05-07**: Playwright nightly CI workflow (#744 関連) を追加。`.github/workflows/playwright.yml` で Phase 1 spec を毎日 17:00 UTC に develop で実行する。matrix で `backend = [mk-go, ts]` の 2 job を並列実行し、`fail-fast: false` で両 backend の drop-in shape regression を独立に監視する。失敗時は `tests/playwright/test-results/` (trace/screenshot 含む) と docker compose logs を artifact 化 (14 日保持)。dropin-e2e (18:00 UTC) / dropin-frontend-e2e (19:00 UTC) と被らない時刻に scheduling。
 - **2026-05-04**: Signin の TOTP / passkey フローを Misskey TS upstream と再互換化 (#705)。`/api/signin-flow` で 2FA + security key ユーザに対して `next: 'passkey'` + `authRequest` (PublicKeyCredentialRequestOptionsJSON) を返すよう修正 (旧: `'captcha-keys'` + `assertion` 2 段ラップ + クライアント sessionId 要求)、challenge を Redis に user-keyed で保存して sessionId round-trip を撤廃、TOTP / WebAuthn 失敗時のエラー ID を本家準拠に揃え (`cdf1235b-...` / `93b86c4b-...`)、step 1 の `next` を 2FA 無効ユーザに常に `'captcha'` を返すよう変更。新たに `/api/signin-with-passkey` (passwordless passkey login の init+verify 2 段) を実装し `BeginPasskeyLogin`/`FinishPasskeyLogin` を `WebAuthnService` に追加。E2E (`e2e/cypress/e2e/webauthn.cy.ts`) も新プロトコルに更新し、TS 互換 spec をローカル spec パスに含めるよう `cypress.config.ts` を拡張。
 - **2026-05-01**: inbox worker drain time 短縮 (#569)。\`MarkRequestReceived\` を per-host で 1s buffer に集約する \`InstanceTouchBuffer\` 導入、federation processor の \`handleCreate\` で Reply/Renote 関係が無い fresh note への redundant \`hydrateNoteForFanout\` (DB SELECT) を skip、fanoutHook / notificationHook を local note service と同じく \`safeGo\` で async 化。queue-bench で **asynq drain 29.3s → 22.4s (-24%)、mkq 45.7s → 34.0s (-26%)**。worker concurrency / mkq 上流 Lua 最適化は scope 外 (公正比較維持のため)。
 - **2026-05-01**: inbox handler を verify-in-worker 化 (#565)。HTTP handler は body+signature 関連 header を payload に詰めて 202 即返し、signature verify / host block / instance touch / chart hook は inbox worker (queue/processors) 側で実行する Misskey TS 互換アーキテクチャに変更。queue-bench で mk-go の inbound HTTP 受信 rps が **684/685 → 2812/3017 (4.1-4.4x)** に改善し、TS-BullMQ (1064 rps) を **2.6-2.8x 上回る**。これにより mk-go 全 endpoint が TS 同等以上を達成。security trade-off: unsigned/malformed activity は worker で drop されるため queue が一時的に膨らむ可能性あり (CDN/WAF 層で粗い filter を入れる前提)。


### PR DESCRIPTION
## Summary

#744 Phase 1 で Playwright spec が 19 テストに拡大、PR ごとに手動で両 backend (TS image / mk-go) を verify するコストが上がっていたため、nightly workflow を整備して drop-in shape regression を自動検知する。

## 主な変更

- \`.github/workflows/playwright.yml\` (新規):
  - schedule: 毎日 17:00 UTC (= JST 02:00)、dropin-e2e (18:00) / dropin-frontend (19:00) と被らない
  - matrix で \`backend = [mk-go, ts]\` の 2 job を並列実行 (\`fail-fast: false\`)
  - workflow_dispatch で任意 ref 手動実行可
  - 失敗時に \`tests/playwright/test-results/\` (trace/screenshot) と docker compose logs を artifact 化 (14 日保持)
- \`CLAUDE.md\`:
  - 8. CI/CD セクションに本 workflow の運用方針を追記
  - 更新記録に 1 行追加

## 設計判断

- **PR required check には含めない**: TS image pull (~ 数分) + spec 増加で実行時間が伸びるため。drop-in 互換 regression は nightly + 手動 verify で検出する運用 (dropin-e2e / dropin-frontend と同じ pattern)
- **matrix \`fail-fast: false\`**: 各 backend の状況を独立に観察したい。片方の image 不具合で他方の job が cancel されると drop-in regression の片側だけ見えなくなる
- **時間帯 17:00 UTC**: dropin-e2e (18:00) / dropin-frontend (19:00) と被らせず、JST 02:00 と運用観点でも自然

## 検証

- YAML syntax: \`python3 -c "import yaml; yaml.safe_load(...)"\` で validate
- 実 run はマージ後 \`gh workflow run playwright.yml\` で workflow_dispatch trigger して動作確認予定

## 関連

- #744 (umbrella: Playwright Phase 1)
- 既存 nightly: dropin-e2e (18:00 UTC) / dropin-frontend (19:00 UTC)