### PR TITLE
ci: dropin-e2e / dropin-frontend-e2e の image pre-pull を foreground 化

### DIFF
--- a/.github/workflows/dropin-e2e.yml
+++ b/.github/workflows/dropin-e2e.yml
@@ -37,8 +37,14 @@ jobs:
           # 指定する (Devin #375 #1)。
           ref: ${{ inputs.ref || 'develop' }}
 
-      - name: Pre-pull Misskey TS image (parallel with build)
-        run: docker pull misskey/misskey:2025.2.1 &
+      - name: Pre-pull Misskey TS image
+        # 旧版は `&` で background 化していたが、GitHub Actions の `run:`
+        # step は step 終了で shell process が exit するため background
+        # process の継続が runner 環境で保証されない (= pre-pull 効果が
+        # 不確実)。foreground で完了を待ち、続く `make dropin-swap-test`
+        # 内の同 image pull は docker daemon の cache hit で 0s で済む方が
+        # 確実。playwright.yml (#816) と同じ判断。
+        run: docker pull misskey/misskey:2025.2.1
 
       # bash orchestrator + pytest を実行する。stage ログは標準出力に流れる。
       - name: Run dropin swap test

--- a/.github/workflows/dropin-frontend-e2e.yml
+++ b/.github/workflows/dropin-frontend-e2e.yml
@@ -42,10 +42,16 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
-      - name: Pre-pull heavy images in background
+      - name: Pre-pull heavy images
+        # 旧版は `&` で background 化していたが、GitHub Actions の `run:`
+        # step は step 終了で shell process が exit するため background
+        # process の継続が runner 環境で保証されない (= pre-pull 効果が
+        # 不確実)。foreground で完了を待ち、続く `make dropin-frontend-*`
+        # 内の同 image pull は docker daemon の cache hit で 0s で済む方が
+        # 確実。playwright.yml (#816) と同じ判断。2 image を順次 pull。
         run: |
-          docker pull misskey/misskey:2025.2.1 &
-          docker pull cypress/included:15.11.0 &
+          docker pull misskey/misskey:2025.2.1
+          docker pull cypress/included:15.11.0
 
       - name: Run dropin frontend e2e
         # DROPIN_LOG_DIR をセットして orchestrator の cleanup trap に失敗時


### PR DESCRIPTION
## Summary

#816 で playwright nightly workflow を導入した際の判断と同じ理由で、既存の dropin nightly workflow 2 つの \`docker pull ... &\` background 化を foreground 化する。

## 背景

GitHub Actions の \`run:\` step は step 終了で shell process が exit するため、\`&\` で background 化したコマンドの継続が runner 環境で保証されない (= pre-pull の wallclock 短縮効果が不確実)。foreground で完了を待ち、続く \`make dropin-*\` 内の同 image pull は docker daemon の cache hit で 0s で済む素直な flow にする。

## 主な変更

- \`.github/workflows/dropin-e2e.yml\`: \`docker pull misskey/misskey:2025.2.1 &\` から \`&\` 削除 + コメントで理由を pin
- \`.github/workflows/dropin-frontend-e2e.yml\`: 2 image (misskey + cypress) の \`&\` 削除 + コメントで理由を pin

## scope 外

- trigger 頻度・required check 設定は **変えない** (= 引き続き nightly + \`workflow_dispatch\`、PR の required check には含めない)
- playwright.yml (#816) は導入時から foreground なので touch 不要

## 検証

- YAML syntax: \`python3 -c "import yaml; yaml.safe_load(...)"\` で validate
- 実 run はマージ後 \`gh workflow run dropin-e2e.yml\` / \`dropin-frontend-e2e.yml\` で workflow_dispatch trigger して動作確認予定

## 関連

- #816 (playwright nightly workflow、本 PR と同じ判断を採用済)
- 既存 nightly: dropin-e2e (18:00 UTC) / dropin-frontend-e2e (19:00 UTC)