### PR TITLE
#817 part2: 2FA Passkey (WebAuthn) Playwright spec + HTTPS 環境整備

### DIFF
--- a/docker-compose.playwright.yml
+++ b/docker-compose.playwright.yml
@@ -62,6 +62,24 @@ services:
       redis: {condition: service_healthy}
     networks: [playwright]
 
+  # nginx TLS proxy (#817 part2)。
+  # Browser の WebAuthn API は secure context (HTTPS) を要求するため、
+  # mk-go (HTTP 3000) の前に nginx を立てて self-signed cert で HTTPS
+  # terminate する。Playwright runner は `ignoreHTTPSErrors: true` で
+  # cert chain の validation を bypass する。
+  # `mkgo.local` alias を nginx に付与して、WebAuthn の RPID 検証も
+  # 同時に通す (= `.` を含む hostname、go-webauthn が要求)。
+  nginx-tls:
+    build:
+      context: ./tests/playwright/nginx
+      dockerfile: Dockerfile
+    depends_on:
+      mkgo: {condition: service_healthy}
+    networks:
+      playwright:
+        aliases:
+          - mkgo.local
+
   # Playwright runner. profiles: [test] で `up -d` の対象から外し、
   # 明示的に `--profile test run` で起動する (cypress runner と同 pattern)。
   playwright-runner:
@@ -71,7 +89,14 @@ services:
       dockerfile: Dockerfile.runner
     environment:
       # mkgo backend への接続先。spec から fixtures 経由で参照する。
-      MK_BASE_URL: http://mkgo:3000
+      # nginx TLS proxy (`mkgo.local` alias) 経由で HTTPS で叩く (#817 part2)。
+      # WebAuthn は secure context が必須なため。`ignoreHTTPSErrors` を
+      # playwright config 側で立て、self-signed cert を accept する。
+      MK_BASE_URL: https://mkgo.local
+      # Node global WebSocket (streaming spec が使う) は WHATWG 準拠で
+      # `rejectUnauthorized` option がない。env で TLS verify を bypass
+      # する (= test 環境のみ、self-signed cert を accept する目的)。
+      NODE_TLS_REJECT_UNAUTHORIZED: "0"
     volumes:
       # spec ファイルと playwright.config.ts は test 実行時に変更されること
       # があるので bind mount で読み込む。生成物 (test-results/) は host に
@@ -84,6 +109,8 @@ services:
     working_dir: /work
     depends_on:
       mkgo: {condition: service_healthy}
+      # nginx-tls は MK_BASE_URL=https://mkgo.local の解決先。
+      nginx-tls: {condition: service_started}
     networks: [playwright]
 
 networks:

--- a/tests/playwright/Dockerfile.runner
+++ b/tests/playwright/Dockerfile.runner
@@ -5,9 +5,10 @@
 # 理由は、後続 PR で page.goto ベース spec を追加するときに browser が
 # 即座に使えるよう構成を固定しておきたいため。
 #
-# 公式 v1.49 を pin。Playwright は upstream リリースで API 微調整するので
-# 後続 PR で必要に応じて bump する。
-FROM mcr.microsoft.com/playwright:v1.49.1-jammy
+# 公式 v1.59 を pin。package.json の @playwright/test と base image の
+# version は両方を sync する必要がある (caret 範囲で npm install が新版
+# に切り替わると base image の browser binary と不一致になる)。
+FROM mcr.microsoft.com/playwright:v1.59.1-jammy
 
 # globalSetup から redis-cli を呼んで rate limit counter を flush する
 # (#744 PR-2): mk-go の signup endpoint は IP base で 1h 5 回 hardcoded で

--- a/tests/playwright/global-setup.ts
+++ b/tests/playwright/global-setup.ts
@@ -29,7 +29,10 @@ export default async function globalSetup(): Promise<void> {
   // eslint-disable-next-line no-console
   console.log('[globalSetup] redis FLUSHDB done');
 
-  const ctx = await createRequest.newContext();
+  // self-signed cert を accept する。playwright.config.ts の use 設定は
+  // spec scope のみなので globalSetup には届かない (= globalSetup は
+  // request context を独立に作るため明示指定が必要、#817 part2 で HTTPS 化)。
+  const ctx = await createRequest.newContext({ ignoreHTTPSErrors: true });
   try {
     // 2. Root 作成 (admin/accounts/create は 1 回目だけ通る)
     const createResp = await ctx.post(`${baseURL}/api/admin/accounts/create`, {

--- a/tests/playwright/instance.yml
+++ b/tests/playwright/instance.yml
@@ -1,4 +1,9 @@
-url: http://mkgo:3000/
+# `https://mkgo.local` (= nginx tls proxy alias) 経由で叩く。WebAuthn の
+# RPID は URL の hostname (= `mkgo.local`) を使うため `.` を含む host が
+# 必須 (go-webauthn が単一ラベルを reject)。詳細は
+# docker-compose.playwright.yml の nginx-tls service コメント参照
+# (#817 part2)。
+url: https://mkgo.local/
 port: 3000
 
 db:

--- a/tests/playwright/nginx/Dockerfile
+++ b/tests/playwright/nginx/Dockerfile
@@ -1,0 +1,20 @@
+# #817 part2: TLS proxy for Playwright stack。
+#
+# Browser の WebAuthn API は secure context (HTTPS) を要求するため、
+# mk-go (HTTP 3000) の前に nginx を立てて HTTPS terminate する。
+# self-signed cert は build 時に生成し、Playwright runner は
+# `ignoreHTTPSErrors: true` で受け入れる。
+FROM nginx:alpine
+
+# self-signed cert 生成。CN=mkgo.local で 10 年有効。
+RUN apk add --no-cache openssl \
+    && mkdir -p /etc/ssl/private \
+    && openssl req -x509 -nodes -newkey rsa:2048 \
+        -keyout /etc/ssl/private/mkgo.key \
+        -out /etc/ssl/certs/mkgo.crt \
+        -subj "/CN=mkgo.local" \
+        -addext "subjectAltName=DNS:mkgo.local" \
+        -days 3650 \
+    && apk del openssl
+
+COPY default.conf /etc/nginx/conf.d/default.conf

--- a/tests/playwright/nginx/default.conf
+++ b/tests/playwright/nginx/default.conf
@@ -1,0 +1,33 @@
+# #817 part2: HTTPS terminate → mkgo:3000 (HTTP) proxy。
+# WebSocket (= /streaming) は Upgrade header を中継する必要があるため
+# Connection / Upgrade を明示的に伝播する。
+server {
+    listen 443 ssl;
+    server_name mkgo.local;
+
+    ssl_certificate /etc/ssl/certs/mkgo.crt;
+    ssl_certificate_key /etc/ssl/private/mkgo.key;
+
+    # Playwright runner が multipart upload (drive/files/create) を送る
+    # ため body size は緩めに (= mk-go 自体は 100MB 上限)。
+    client_max_body_size 100m;
+
+    location / {
+        proxy_pass http://mkgo:3000;
+        proxy_http_version 1.1;
+        proxy_set_header Host $host;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-Proto https;
+        # WebSocket support (streaming spec)
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection $connection_upgrade;
+        proxy_read_timeout 600s;
+    }
+}
+
+# WebSocket Upgrade map (= http_upgrade ≠ "" のとき "upgrade")
+map $http_upgrade $connection_upgrade {
+    default upgrade;
+    "" close;
+}

--- a/tests/playwright/nginx/default.conf
+++ b/tests/playwright/nginx/default.conf
@@ -1,6 +1,14 @@
 # #817 part2: HTTPS terminate → mkgo:3000 (HTTP) proxy。
 # WebSocket (= /streaming) は Upgrade header を中継する必要があるため
 # Connection / Upgrade を明示的に伝播する。
+
+# WebSocket Upgrade map (= http_upgrade ≠ "" のとき "upgrade")。
+# server より前に置いて使用箇所と定義位置を慣用順に並べる。
+map $http_upgrade $connection_upgrade {
+    default upgrade;
+    "" close;
+}
+
 server {
     listen 443 ssl;
     server_name mkgo.local;
@@ -24,10 +32,4 @@ server {
         proxy_set_header Connection $connection_upgrade;
         proxy_read_timeout 600s;
     }
-}
-
-# WebSocket Upgrade map (= http_upgrade ≠ "" のとき "upgrade")
-map $http_upgrade $connection_upgrade {
-    default upgrade;
-    "" close;
 }

--- a/tests/playwright/package.json
+++ b/tests/playwright/package.json
@@ -8,7 +8,7 @@
     "test:headed": "playwright test --headed"
   },
   "devDependencies": {
-    "@playwright/test": "^1.49.1",
+    "@playwright/test": "^1.59.1",
     "otplib": "^12.0.1",
     "typescript": "^5.6.3"
   }

--- a/tests/playwright/playwright.config.ts
+++ b/tests/playwright/playwright.config.ts
@@ -20,10 +20,14 @@ export default defineConfig({
   // Phase 1 では全 spec を chromium で 1 回ずつ実行。multi-browser は
   // CI 統合 PR で `projects` を追加する。
   use: {
-    baseURL: process.env.MK_BASE_URL ?? 'http://mkgo:3000',
+    baseURL: process.env.MK_BASE_URL ?? 'https://mkgo.local',
     // API テスト中心なので screenshot / trace は失敗時のみで十分。
     screenshot: 'only-on-failure',
     trace: 'retain-on-failure',
+    // nginx tls proxy が self-signed cert を提供する (#817 part2)。
+    // Playwright はそれを accept できる必要がある。`request` fixture と
+    // `page` fixture の両方に効く。
+    ignoreHTTPSErrors: true,
   },
   // CI 並列度の調整は CI 統合 PR で。本 PR はローカル直列実行。
   workers: 1,

--- a/tests/playwright/specs/auth/twofa_passkey.spec.ts
+++ b/tests/playwright/specs/auth/twofa_passkey.spec.ts
@@ -1,0 +1,196 @@
+// #817 part2: 2FA (WebAuthn passkey) signin path。
+//
+// upstream Misskey TS と mk-go は 2FA + security key 登録済ユーザの
+// signin-flow で step 1 (= username + password) に対し
+// `next: 'passkey'` + `authRequest` (PublicKeyCredentialRequestOptionsJSON)
+// を返し、step 2 で `credential` を送って `finished: true, i: <token>`
+// を返す (#705 で TS 互換化、cypress webauthn.cy.ts も同 pattern を cover)。
+//
+// 本 spec は両 backend 共通で:
+//   1. signup user → 2FA (TOTP) を enable (= security key 登録の前提条件)
+//   2. /api/i/2fa/register-key で WebAuthn challenge (creationOptions) を取得
+//   3. Browser + CDP Virtual Authenticator で credential を作成
+//   4. /api/i/2fa/key-done で credential を送信、key 登録完了
+//   5. /api/signin-flow step 1 (username + password) →
+//      next: 'passkey' + authRequest assert
+//   6. Browser で navigator.credentials.get で assertion を取得
+//   7. /api/signin-flow step 2 (with credential) →
+//      finished: true, i: <token> assert
+//
+// を strict に検証する。
+//
+// 設計判断: 既存 Phase 1 spec は API-only だが、本 spec は WebAuthn の
+// 特殊性 (= attestation/assertion を programmatically 生成するには
+// browser API or 重い emulator が必要) のため、Browser + Chrome DevTools
+// Protocol の Virtual Authenticator を使う唯一の exception とする。
+// Playwright runner image は browser 内蔵で追加コストなし。
+// cypress webauthn.cy.ts と同じ pattern の Playwright 翻訳。
+
+import { expect, test } from '@playwright/test';
+import { authenticator } from 'otplib';
+import { callApi } from '../../fixtures/api';
+import { randomUsername, signupUser } from '../../fixtures/auth';
+import { resetRateLimit } from '../../fixtures/rate_limit';
+
+test.describe('auth: 2FA (WebAuthn passkey)', () => {
+  test.beforeAll(() => {
+    resetRateLimit();
+  });
+
+  test('signin-flow returns next:passkey for security-key-enabled user and finishes with credential', async ({ page, request }) => {
+    // browser の page は CDP Virtual Authenticator を使うために必要。
+    // `about:blank` は origin が null で navigator.credentials が undefined
+    // になるため、実 instance origin (= MK_BASE_URL = https://mkgo.local)
+    // を navigate して secure context を確立する。`/api/ping` は軽量
+    // endpoint で 200 + JSON を返し、frontend SPA を load せず origin
+    // context だけ確立できる。
+    const baseURL = process.env.MK_BASE_URL ?? 'https://mkgo.local';
+    await page.goto(`${baseURL}/api/ping`, { waitUntil: 'commit' });
+
+    // CDP Virtual Authenticator 有効化。ctap2 + resident key + UV verified
+    // で実 USB key を再現する。spec 終了時に page が close されると
+    // authenticator も破棄される。
+    const cdp = await page.context().newCDPSession(page);
+    await cdp.send('WebAuthn.enable');
+    await cdp.send('WebAuthn.addVirtualAuthenticator', {
+      options: {
+        protocol: 'ctap2',
+        transport: 'usb',
+        hasResidentKey: true,
+        hasUserVerification: true,
+        isUserVerified: true,
+      },
+    });
+
+    // signup + 2FA (TOTP) enable。security key 登録は 2FA enabled が前提。
+    const username = randomUsername('pkey');
+    const password = 'password1234';
+    const me = await signupUser(request, username, password);
+
+    const regResp = await callApi(request, 'i/2fa/register', { i: me.token, password });
+    expect(regResp.status()).toBe(200);
+    const regBody = await regResp.json();
+    // TOTP code を 1 回生成して全 verify で再利用 (#839 と同じ理由)。
+    const totpToken = authenticator.generate(regBody.secret);
+    const doneResp = await callApi(request, 'i/2fa/done', { i: me.token, token: totpToken });
+    expect(doneResp.status()).toBe(200);
+
+    // /api/i/2fa/register-key で WebAuthn creationOptions を取得。
+    // upstream は #705 fix 後 PublicKeyCredentialCreationOptions を直返し
+    // (publicKey wrapper / sessionId なし)。
+    const regKeyResp = await callApi(request, 'i/2fa/register-key', {
+      i: me.token,
+      password,
+      token: totpToken,
+    });
+    expect(regKeyResp.status()).toBe(200);
+    const creationOpts = await regKeyResp.json();
+    expect(creationOpts).toHaveProperty('challenge');
+    expect(creationOpts).toHaveProperty('rp');
+
+    // Browser で navigator.credentials.create を呼んで credential を作成。
+    // base64url ↔ Uint8Array 変換は page.evaluate 内で手書き (= browser
+    // context にも util を import せず closure で完結)。
+    const createdCred = await page.evaluate(async (opts) => {
+      const b64uDecode = (s: string) =>
+        Uint8Array.from(atob(s.replace(/-/g, '+').replace(/_/g, '/')), (c) => c.charCodeAt(0));
+      const b64uEncode = (buf: ArrayBuffer) =>
+        btoa(String.fromCharCode(...new Uint8Array(buf)))
+          .replace(/\+/g, '-')
+          .replace(/\//g, '_')
+          .replace(/=+$/, '');
+      const publicKey: PublicKeyCredentialCreationOptions = {
+        ...(opts as any),
+        challenge: b64uDecode((opts as any).challenge),
+        user: { ...(opts as any).user, id: b64uDecode((opts as any).user.id) },
+        excludeCredentials: ((opts as any).excludeCredentials ?? []).map((c: any) => ({
+          ...c,
+          id: b64uDecode(c.id),
+        })),
+      };
+      const cred = (await navigator.credentials.create({ publicKey })) as PublicKeyCredential;
+      const att = cred.response as AuthenticatorAttestationResponse;
+      return {
+        id: cred.id,
+        rawId: b64uEncode(cred.rawId),
+        type: cred.type,
+        response: {
+          clientDataJSON: b64uEncode(att.clientDataJSON),
+          attestationObject: b64uEncode(att.attestationObject),
+        },
+      };
+    }, creationOpts);
+
+    // /api/i/2fa/key-done で credential 登録。
+    const keyDoneResp = await callApi(request, 'i/2fa/key-done', {
+      i: me.token,
+      password,
+      token: totpToken,
+      name: 'virtual-key',
+      credential: createdCred,
+    });
+    expect(keyDoneResp.status()).toBe(200);
+
+    // signin rate limit (minInterval 1000ms) を避けるため 1.1s 待機。
+    await new Promise((resolve) => setTimeout(resolve, 1100));
+
+    // signin-flow step 1: 2FA + key 登録済 → next: 'passkey' + authRequest。
+    const step1Resp = await callApi(request, 'signin-flow', { username, password });
+    expect(step1Resp.status()).toBe(200);
+    const step1Body = await step1Resp.json();
+    expect(step1Body.finished).toBe(false);
+    expect(step1Body.next).toBe('passkey');
+    expect(step1Body).toHaveProperty('authRequest');
+    const authRequest = step1Body.authRequest;
+    expect(typeof authRequest.challenge).toBe('string');
+
+    // Browser で navigator.credentials.get を呼んで assertion を取得。
+    const assertionCred = await page.evaluate(async (req) => {
+      const b64uDecode = (s: string) =>
+        Uint8Array.from(atob(s.replace(/-/g, '+').replace(/_/g, '/')), (c) => c.charCodeAt(0));
+      const b64uEncode = (buf: ArrayBuffer) =>
+        btoa(String.fromCharCode(...new Uint8Array(buf)))
+          .replace(/\+/g, '-')
+          .replace(/\//g, '_')
+          .replace(/=+$/, '');
+      const publicKey: PublicKeyCredentialRequestOptions = {
+        challenge: b64uDecode((req as any).challenge),
+        rpId: (req as any).rpId,
+        allowCredentials: ((req as any).allowCredentials ?? []).map((c: any) => ({
+          ...c,
+          id: b64uDecode(c.id),
+        })),
+        timeout: (req as any).timeout,
+        userVerification: (req as any).userVerification,
+      };
+      const cred = (await navigator.credentials.get({ publicKey })) as PublicKeyCredential;
+      const ass = cred.response as AuthenticatorAssertionResponse;
+      return {
+        id: cred.id,
+        rawId: b64uEncode(cred.rawId),
+        type: cred.type,
+        response: {
+          authenticatorData: b64uEncode(ass.authenticatorData),
+          clientDataJSON: b64uEncode(ass.clientDataJSON),
+          signature: b64uEncode(ass.signature),
+          userHandle: ass.userHandle ? b64uEncode(ass.userHandle) : null,
+        },
+      };
+    }, authRequest);
+
+    // signin rate limit (minInterval 1000ms) 回避。
+    await new Promise((resolve) => setTimeout(resolve, 1100));
+
+    // signin-flow step 2: credential 送信 → finished: true。
+    const step2Resp = await callApi(request, 'signin-flow', {
+      username,
+      password,
+      credential: assertionCred,
+    });
+    expect(step2Resp.status()).toBe(200);
+    const step2Body = await step2Resp.json();
+    expect(step2Body.finished).toBe(true);
+    expect(typeof step2Body.i).toBe('string');
+    expect(step2Body.i.length).toBeGreaterThan(0);
+  });
+});


### PR DESCRIPTION
## Summary

#817 part1 (TOTP, #839) で完結できなかった残り **passkey (WebAuthn) 経路** を本 PR で実装。WebAuthn は Browser の secure context (= HTTPS) を要求するため、Playwright stack を **nginx tls proxy + self-signed cert** で HTTPS 化し、Browser + CDP Virtual Authenticator で credential round-trip を両 backend で strict assert する。

これで #817 (TOTP + Passkey 両方) 完了 → Phase 1 残作業 (Playwright 基盤) はゼロに。

## 主な変更

### 環境整備 (HTTPS 化)

- **\`tests/playwright/nginx/{Dockerfile,default.conf}\`** (新規): nginx alpine + openssl で self-signed cert (CN=mkgo.local, 10 年有効) を build 時生成、443 SSL → mkgo:3000 HTTP proxy + WebSocket Upgrade header 中継
- **\`docker-compose.playwright.yml\`**: nginx-tls service 追加、\`mkgo.local\` alias を nginx に付与、\`MK_BASE_URL=https://mkgo.local\` に変更、\`NODE_TLS_REJECT_UNAUTHORIZED=0\` 追加 (= Node global WebSocket の self-signed cert accept)
- **\`tests/playwright/instance.yml\`**: \`url: https://mkgo.local/\` に変更
- **\`tests/playwright/playwright.config.ts\`**: baseURL https + \`ignoreHTTPSErrors: true\`
- **\`tests/playwright/global-setup.ts\`**: \`createRequest.newContext\` に \`ignoreHTTPSErrors\` 明示

### Playwright runner image bump

- **\`tests/playwright/Dockerfile.runner\`**: base を \`v1.59.1-jammy\` に bump
- **\`tests/playwright/package.json\`**: \`@playwright/test\` を \`^1.59.1\` (Chromium 147 同梱)

### passkey spec

- **\`tests/playwright/specs/auth/twofa_passkey.spec.ts\`** (新規):
  1. signup → 2FA (TOTP) enable (key 登録の前提条件)
  2. \`/api/i/2fa/register-key\` で WebAuthn challenge 取得
  3. Browser + CDP Virtual Authenticator で credential 作成 (page.goto \`/api/ping\` で origin 確立)
  4. \`/api/i/2fa/key-done\` で credential 送信
  5. signin-flow step 1 → \`next: 'passkey'\` + authRequest assert
  6. \`navigator.credentials.get\` で assertion 取得
  7. signin-flow step 2 (with credential) → \`finished: true, i: <token>\`

## 設計判断

- **HTTPS 化を選択**: \`--unsafely-treat-insecure-origin-as-secure\` flag が Chromium 147 で効かなくなっていることを debug で確認 (= \`isSecureContext: false\`)。HTTPS が確実な解決
- **nginx proxy で TLS terminate**: mk-go binary 自体に TLS listen 設定を追加するより、proxy で terminate する方が compose-only な変更で済む
- **\`mkgo.local\` alias を nginx に**: WebAuthn の RPID は URL hostname を使い、go-webauthn は単一ラベル host を reject するため \`.\` 必須
- **本 spec のみ Browser 起動**: 既存 Phase 1 spec (notes / drive / streaming 等) は API-only。WebAuthn の特殊性のため例外として page を使う

## 検証

- Playwright TS image: 21/21 pass (\`make playwright-ts-test\`)
- Playwright mk-go: 21/21 pass (\`make playwright-test\`)

## Closes

#817