### PR TITLE
Fix #818: drive/files/find / find-by-hash の packMany self path shape を upstream に揃える

### DIFF
--- a/internal/api/drive/handler.go
+++ b/internal/api/drive/handler.go
@@ -122,6 +122,24 @@ func (h *Handler) packDriveFileFull(f *model.DriveFile) entity.DriveFileEntity {
 	return entity.PackDriveFileWithRelations(f, h.idGen, folder, user)
 }
 
+// packDriveFileSelfList packs a drive file for the "self list" path used by
+// drive/files/find と drive/files/find-by-hash.
+//
+// upstream Misskey TS は `packMany(files, { self: true })` 経由で
+// `packNullable` を呼び、`folder=null` / `user=null` / `userId=owner ID`
+// を返す (DriveFileEntityService.ts:225-261, withUser/detail デフォルト
+// false)。mk-go は packDriveFileFull が常に folder / user を resolve する
+// ため、helper で post-fixup して shape を整合させる (#818)。
+//
+// drive/files/create の self path (#812) とは異なり userId は **owner ID
+// を維持** する点に注意 (= packNullable は userId を常時返す)。
+func (h *Handler) packDriveFileSelfList(f *model.DriveFile) entity.DriveFileEntity {
+	e := h.packDriveFileFull(f)
+	e.Folder = nil
+	e.User = nil
+	return e
+}
+
 // readMultipartFile extracts the uploaded file's bytes and original filename.
 // テスト用に差し替え可能な変数として定義する。Open()/ReadAll()はechoの
 // multipartパース後ではメモリまたはtempfile由来のreaderしか返さないため
@@ -278,7 +296,8 @@ func (h *Handler) FilesFindByHash(c echo.Context) error {
 	if err != nil {
 		return mapFileError(c, err)
 	}
-	return c.JSON(http.StatusOK, []entity.DriveFileEntity{h.packDriveFileFull(f)})
+	// upstream `packMany(files, { self: true })` 経路 (#818)。
+	return c.JSON(http.StatusOK, []entity.DriveFileEntity{h.packDriveFileSelfList(f)})
 }
 
 // FoldersCreateRequest is the body for drive/folders/create.
@@ -456,7 +475,8 @@ func (h *Handler) FilesFind(c echo.Context) error {
 	}
 	out := make([]entity.DriveFileEntity, 0, len(files))
 	for _, f := range files {
-		out = append(out, h.packDriveFileFull(f))
+		// upstream `packMany(files, { self: true })` 経路 (#818)。
+		out = append(out, h.packDriveFileSelfList(f))
 	}
 	return c.JSON(http.StatusOK, out)
 }

--- a/internal/api/drive/handler.go
+++ b/internal/api/drive/handler.go
@@ -97,11 +97,16 @@ func (h *Handler) emojiLookup() entity.EmojiLookup {
 // packDriveFileSchema which exposes both `folder` and `user`.
 //
 // 注: 戻り値は upstream の `pack(file, { detail: true, withUser: true })`
-// 相当 (= owner ID と user 込み)。upstream で `pack(file, { self: true })`
-// 経路 (= drive/files/create) を呼ぶ endpoint では userId / user / folder
-// を null にする必要があり、本関数を直接 c.JSON に渡すと drift する
-// (#812)。self path 用に新 helper を作るか、呼び出し側で post-fixup する
-// こと。
+// 相当 (= owner ID と user 込み) で drive/files/show のような detail 経路
+// で使う。それ以外の経路は対応する helper を使うこと:
+//
+//   - `drive/files/create` (= self single, `pack(file, { self: true })`):
+//     `packDriveFileSelfSingle` (#812)
+//   - `drive/files/find` / `find-by-hash` (= self list,
+//     `packMany(files, { self: true })`):
+//     `packDriveFileSelfList` (#818)
+//
+// 本関数を上記 self 経路で直接 c.JSON に渡すと shape drift する。
 func (h *Handler) packDriveFileFull(f *model.DriveFile) entity.DriveFileEntity {
 	// list loop (FilesList / FilesFind / Stream) からも呼ばれ、1ファイル
 	// 当たり最大2 DB read (O(N) queries)が発生する。1ページ上限が10-100
@@ -122,6 +127,26 @@ func (h *Handler) packDriveFileFull(f *model.DriveFile) entity.DriveFileEntity {
 	return entity.PackDriveFileWithRelations(f, h.idGen, folder, user)
 }
 
+// packDriveFileSelfSingle packs a drive file for the "self single" path used
+// by drive/files/create.
+//
+// upstream Misskey TS は `pack(file, { self: true })` (= withUser=false /
+// detail=false) を呼び、`folder=null` / `user=null` / `userId=null` を
+// 返す (DriveFileEntityService.ts:191-222)。mk-go は packDriveFileFull が
+// 常に folder / user を resolve するため、helper で post-fixup して shape
+// を整合させる (#812 / #818)。
+//
+// drive/files/find / find-by-hash の self list path とは異なり userId も
+// **null にする** 点に注意 (= pack は detail=false で userId を返さない、
+// packNullable とは別経路)。
+func (h *Handler) packDriveFileSelfSingle(f *model.DriveFile) entity.DriveFileEntity {
+	e := h.packDriveFileFull(f)
+	e.Folder = nil
+	e.UserID = nil
+	e.User = nil
+	return e
+}
+
 // packDriveFileSelfList packs a drive file for the "self list" path used by
 // drive/files/find と drive/files/find-by-hash.
 //
@@ -131,8 +156,8 @@ func (h *Handler) packDriveFileFull(f *model.DriveFile) entity.DriveFileEntity {
 // false)。mk-go は packDriveFileFull が常に folder / user を resolve する
 // ため、helper で post-fixup して shape を整合させる (#818)。
 //
-// drive/files/create の self path (#812) とは異なり userId は **owner ID
-// を維持** する点に注意 (= packNullable は userId を常時返す)。
+// drive/files/create の self single path (#812) とは異なり userId は
+// **owner ID を維持** する点に注意 (= packNullable は userId を常時返す)。
 func (h *Handler) packDriveFileSelfList(f *model.DriveFile) entity.DriveFileEntity {
 	e := h.packDriveFileFull(f)
 	e.Folder = nil
@@ -197,14 +222,11 @@ func (h *Handler) FilesCreate(c echo.Context) error {
 		}
 		return apierr.JSONInternalError(c)
 	}
-	// upstream `drive/files/create` は `pack(file, { self: true })` で
-	// userId / user を null にする (= withUser がデフォルト false)。本実装も
-	// 同 shape に揃える (#812)。show / find 等の他 endpoint は別 packing で
-	// owner ID を出すので維持。
-	out := h.packDriveFileFull(f)
-	out.UserID = nil
-	out.User = nil
-	return c.JSON(http.StatusOK, out)
+	// upstream `drive/files/create` は `pack(file, { self: true })` の
+	// self single path 経路 (#812)。helper が folder / userId / user を
+	// 一律 null 化する (旧 inline 版は folder の nil 化を見落としていて
+	// folderId 指定 upload で drift していたが、helper 化で同時に解消)。
+	return c.JSON(http.StatusOK, h.packDriveFileSelfSingle(f))
 }
 
 // FileIDRequest is the body for show/delete and similar single-file ops.

--- a/internal/api/drive/handler_test.go
+++ b/internal/api/drive/handler_test.go
@@ -339,6 +339,14 @@ func TestFilesFindByHash_Success(t *testing.T) {
 	setUser(c, "u1")
 	require.NoError(t, h.FilesFindByHash(c))
 	assert.Equal(t, http.StatusOK, rec.Code)
+	// upstream `packMany(files, { self: true })` 経路 (#818): folder / user
+	// は null、userId は owner ID 維持。
+	var resp []map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+	require.Len(t, resp, 1)
+	assert.Equal(t, "u1", resp[0]["userId"])
+	assert.Nil(t, resp[0]["folder"])
+	assert.Nil(t, resp[0]["user"])
 }
 
 func TestFilesFindByHash_InvalidParam(t *testing.T) {
@@ -605,6 +613,14 @@ func TestFilesFind_Success(t *testing.T) {
 	setUser(c, "u1")
 	require.NoError(t, h.FilesFind(c))
 	assert.Equal(t, http.StatusOK, rec.Code)
+	// upstream `packMany(files, { self: true })` 経路 (#818): folder / user
+	// は null、userId は owner ID 維持。
+	var resp []map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+	require.Len(t, resp, 1)
+	assert.Equal(t, "u1", resp[0]["userId"])
+	assert.Nil(t, resp[0]["folder"])
+	assert.Nil(t, resp[0]["user"])
 }
 
 func TestFilesFind_InvalidParam(t *testing.T) {


### PR DESCRIPTION
## Summary

upstream Misskey TS の \`drive/files/find\` および \`drive/files/find-by-hash\` は \`packMany(files, { self: true })\` 経由で \`packNullable\` を呼び、**folder=null / user=null / userId=owner ID** を返す (\`DriveFileEntityService.ts:225-261\`、withUser/detail デフォルト false)。mk-go は \`packDriveFileFull\` が常に folder と user を resolve するため drop-in shape drift があった (#818)。

## 主な変更

- **\`internal/api/drive/handler.go\`**: 新 helper \`packDriveFileSelfList(f)\` を追加。\`packDriveFileFull\` の戻り値から \`Folder\` / \`User\` を nil 化する post-fixup を提供。userId は packNullable に倣い owner ID を維持 (= \`drive/files/create\` の self path #812 とは異なる挙動)。\`FilesFindByHash\` と \`FilesFind\` の return path で本 helper を使用。
- **\`internal/api/drive/handler_test.go\`**: \`TestFilesFindByHash_Success\` / \`TestFilesFind_Success\` で response の \`userId\` / \`folder\` / \`user\` の strict assertion を追加。

## 設計判断

PR #814 (= #812 fix) で追加した \`packDriveFileFull\` GoDoc warning に「self path では post-fixup 必要」と明記済。本 PR は同 warning に従い helper 化:

- **\`drive/files/create\`** (#812 PR #814): self path = userId / user / folder **すべて null**
- **\`drive/files/find\` / find-by-hash** (本 PR): self list path = user / folder **null だが userId は owner ID 維持** (= \`packNullable\` の挙動)

両者で異なる shape のため別 helper 化 (\`packDriveFileFull\` インライン post-fixup vs \`packDriveFileSelfList\`)。

## scope 外 (= 別 issue 候補)

- \`FilesList\` / \`FilesUpdate\` / \`FilesMoveBulk\` 等の他 callsite は upstream の pack 引数が異なる可能性があり、shape drift の有無を個別に検証する必要 (本 PR の \`packDriveFileFull\` GoDoc warning は継続有効)
- properties / url の self/public 切り替え (= upstream は opts.self で internal field を露出するが mk-go は単一実装) — 別 drift

## 検証

- internal/api/drive: 全 unit test pass
- Playwright mk-go: 21/21 pass (\`make playwright-test\`)

## Closes

#818