### PR TITLE
#829 PR-C: drive/files/find + find-by-hash の Playwright spec を追加

### DIFF
--- a/tests/playwright/fixtures/files.ts
+++ b/tests/playwright/fixtures/files.ts
@@ -1,0 +1,14 @@
+// #829 PR-C: drive 系 spec で共有する fixture file。
+//
+// drive/files/create / find / find-by-hash / 等の spec で同じ test image を
+// upload するため、binary を 1 か所に集約する。test 内で動的生成すると
+// node の Sharp/Canvas 依存が増えるので、固定の minimal PNG を base64 で
+// 持つ方が deterministic + 軽量。
+
+// 1x1 transparent PNG, 67 bytes。base64 decode 結果も deterministic で
+// md5 (= file content hash) も常に同じになる = find-by-hash spec で
+// 検証 anchor として使える。
+export const tinyPNG = Buffer.from(
+  'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNkYAAAAAYAAjCB0C8AAAAASUVORK5CYII=',
+  'base64',
+);

--- a/tests/playwright/specs/drive/create.spec.ts
+++ b/tests/playwright/specs/drive/create.spec.ts
@@ -21,17 +21,10 @@
 import { expect, test } from '@playwright/test';
 import { callApi } from '../../fixtures/api';
 import { randomUsername, signupUser } from '../../fixtures/auth';
+import { tinyPNG } from '../../fixtures/files';
 import { resetRateLimit } from '../../fixtures/rate_limit';
 
-const baseURL = process.env.MK_BASE_URL ?? 'http://mkgo:3000';
-
-// 1x1 transparent PNG, 67 bytes。test 内で独自 image を生成すると node の
-// Sharp/Canvas 依存が増えるので、固定の minimal PNG を base64 で持つ方が
-// 楽 + deterministic。
-const tinyPNG = Buffer.from(
-  'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNkYAAAAAYAAjCB0C8AAAAASUVORK5CYII=',
-  'base64',
-);
+const baseURL = process.env.MK_BASE_URL ?? 'https://mkgo.local';
 
 test.describe('drive: files/create', () => {
   test.beforeAll(() => {

--- a/tests/playwright/specs/drive/find.spec.ts
+++ b/tests/playwright/specs/drive/find.spec.ts
@@ -1,0 +1,105 @@
+// #829 drive 拡張 PR-C: drive/files/find と drive/files/find-by-hash の
+// 正常系。
+//
+// upstream Misskey TS と mk-go (#841 で fix 後) は両 endpoint で
+// `packMany(files, { self: true })` 経路 = `packNullable` shape を返す:
+//   - folder: null (= detail=false)
+//   - user: null (= withUser=false)
+//   - userId: owner ID 維持 (= packNullable は userId を常時返す)
+//
+// 本 spec は両 backend 共通で:
+//   1. 1x1 transparent PNG を upload (= drive/files/create)
+//   2. find-by-hash で md5 検索 → shape strict assert
+//   3. find で name 検索 → shape strict assert
+//
+// を検証する。drive/files/create の self single shape は別 spec
+// (drive/create.spec.ts) で cover、本 spec は self list path に focus。
+//
+// #818 で発見した self path drift を unit test に加えて Playwright
+// e2e でも担保 = drift 再導入を browser 経由でも catch できる。
+
+import { expect, test } from '@playwright/test';
+import { callApi } from '../../fixtures/api';
+import { randomUsername, signupUser } from '../../fixtures/auth';
+import { resetRateLimit } from '../../fixtures/rate_limit';
+
+const baseURL = process.env.MK_BASE_URL ?? 'https://mkgo.local';
+
+// 1x1 transparent PNG, 67 bytes (drive/create.spec.ts と同じ fixture)。
+const tinyPNG = Buffer.from(
+  'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNkYAAAAAYAAjCB0C8AAAAASUVORK5CYII=',
+  'base64',
+);
+
+test.describe('drive: files/find + find-by-hash', () => {
+  test.beforeAll(() => {
+    resetRateLimit();
+  });
+
+  test('find-by-hash returns the uploaded file with self list shape', async ({ request }) => {
+    const me = await signupUser(request, randomUsername('drvF'));
+
+    const fileName = `find-bh-${Math.random().toString(16).slice(2, 8)}.png`;
+    const uploadResp = await request.post(`${baseURL}/api/drive/files/create`, {
+      multipart: {
+        i: me.token,
+        file: { name: fileName, mimeType: 'image/png', buffer: tinyPNG },
+      },
+      failOnStatusCode: false,
+    });
+    expect(uploadResp.status()).toBe(200);
+    const uploaded = await uploadResp.json();
+    expect(uploaded.md5).toBeTruthy();
+
+    const findResp = await callApi(request, 'drive/files/find-by-hash', {
+      i: me.token,
+      md5: uploaded.md5,
+    });
+    expect(findResp.status()).toBe(200);
+    const list = await findResp.json();
+    expect(Array.isArray(list)).toBe(true);
+    expect(list.length).toBeGreaterThanOrEqual(1);
+
+    // upload した file が含まれる。upload と find で id 一致を確認。
+    const hit = list.find((f: { id: string }) => f.id === uploaded.id);
+    expect(hit).toBeDefined();
+
+    // self list shape: folder/user は null、userId は owner ID 維持 (#818)。
+    expect(hit.folder).toBeNull();
+    expect(hit.user).toBeNull();
+    expect(hit.userId).toBe(me.id);
+  });
+
+  test('find by name returns the uploaded file with self list shape', async ({ request }) => {
+    const me = await signupUser(request, randomUsername('drvFn'));
+
+    const fileName = `find-name-${Math.random().toString(16).slice(2, 8)}.png`;
+    const uploadResp = await request.post(`${baseURL}/api/drive/files/create`, {
+      multipart: {
+        i: me.token,
+        file: { name: fileName, mimeType: 'image/png', buffer: tinyPNG },
+      },
+      failOnStatusCode: false,
+    });
+    expect(uploadResp.status()).toBe(200);
+    const uploaded = await uploadResp.json();
+
+    const findResp = await callApi(request, 'drive/files/find', {
+      i: me.token,
+      name: fileName,
+    });
+    expect(findResp.status()).toBe(200);
+    const list = await findResp.json();
+    expect(Array.isArray(list)).toBe(true);
+    expect(list.length).toBe(1);
+
+    const hit = list[0];
+    expect(hit.id).toBe(uploaded.id);
+    expect(hit.name).toBe(fileName);
+
+    // self list shape: folder/user は null、userId は owner ID 維持 (#818)。
+    expect(hit.folder).toBeNull();
+    expect(hit.user).toBeNull();
+    expect(hit.userId).toBe(me.id);
+  });
+});

--- a/tests/playwright/specs/drive/find.spec.ts
+++ b/tests/playwright/specs/drive/find.spec.ts
@@ -21,15 +21,10 @@
 import { expect, test } from '@playwright/test';
 import { callApi } from '../../fixtures/api';
 import { randomUsername, signupUser } from '../../fixtures/auth';
+import { tinyPNG } from '../../fixtures/files';
 import { resetRateLimit } from '../../fixtures/rate_limit';
 
 const baseURL = process.env.MK_BASE_URL ?? 'https://mkgo.local';
-
-// 1x1 transparent PNG, 67 bytes (drive/create.spec.ts と同じ fixture)。
-const tinyPNG = Buffer.from(
-  'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNkYAAAAAYAAjCB0C8AAAAASUVORK5CYII=',
-  'base64',
-);
 
 test.describe('drive: files/find + find-by-hash', () => {
   test.beforeAll(() => {


### PR DESCRIPTION
## Summary

#841 (= #818 fix) で \`packDriveFileSelfList\` helper を導入し packMany self path shape を upstream に揃えたが、検証は unit test 経路のみだった。本 spec で Playwright e2e からも shape を strict assert し、drift 再導入を browser 経由でも catch できるようにする。

Phase 2 #829 の PR-C (= 3 つの drive 拡張 PR のうち find spec 部分)。

## 主な変更

- \`tests/playwright/specs/drive/find.spec.ts\` (新規): 2 test
  1. **find-by-hash**: 1x1 PNG upload → md5 で find-by-hash → list 内から自 file を取得 → folder=null / user=null / userId=owner ID assert
  2. **find by name**: 同 upload → name で find → 同 shape assert

## 検証

- Playwright TS image: 23/23 pass (\`make playwright-ts-test\`)
- Playwright mk-go: 23/23 pass (\`make playwright-test\`)

両 backend で同じ shape を返すことを e2e で確認、#818 fix を Playwright 層でも担保。

## scope 外 (= #829 の他 PR で対応)

- **PR-A**: drive/files/delete + update (CRUD 完成)
- **PR-B**: drive/folders CRUD + nest 表示
- 上記は本 PR とは独立して進める

## 関連

- #829 (umbrella: drive 拡張 spec)
- #818 (drive/files/find self path drift fix、PR #841 で merge)
- #813 (drive/files/create spec、本 spec の fixture 流用元)