### PR TITLE
#829 PR-B: drive/folders CRUD + nest spec

### DIFF
--- a/tests/playwright/specs/drive/folders.spec.ts
+++ b/tests/playwright/specs/drive/folders.spec.ts
@@ -6,12 +6,13 @@
 //     `{ id, createdAt, name, parentId }`
 //   - /api/drive/folders/show: detail mode = default 4 field +
 //     `{ foldersCount, filesCount, parent? }` (upstream のみ、mk-go は
-//     default mode のまま = drift、別 issue 候補)
+//     default mode のまま = drift、#845 で tracking)
 //   - /api/drive/folders/delete: 204 NoContent
 //
 // 本 spec は両 backend pass のため **default 4 field のみ strict assert**。
 // detail mode の追加 field (foldersCount / filesCount / parent) drift は
-// 後続 issue で個別検証する。
+// #845 で fix する。fix 後は本 spec の show response で detail field の
+// strict assert を追加する想定。
 //
 // 検証する round-trip:
 //   1. folder create → 4 field shape assert

--- a/tests/playwright/specs/drive/folders.spec.ts
+++ b/tests/playwright/specs/drive/folders.spec.ts
@@ -1,0 +1,125 @@
+// #829 drive 拡張 PR-B: drive/folders CRUD + nest 表示。
+//
+// upstream Misskey TS と mk-go (一部 drift) は drive/folders の各 endpoint
+// で以下の shape を返す:
+//   - /api/drive/folders/create / update / find: default mode
+//     `{ id, createdAt, name, parentId }`
+//   - /api/drive/folders/show: detail mode = default 4 field +
+//     `{ foldersCount, filesCount, parent? }` (upstream のみ、mk-go は
+//     default mode のまま = drift、別 issue 候補)
+//   - /api/drive/folders/delete: 204 NoContent
+//
+// 本 spec は両 backend pass のため **default 4 field のみ strict assert**。
+// detail mode の追加 field (foldersCount / filesCount / parent) drift は
+// 後続 issue で個別検証する。
+//
+// 検証する round-trip:
+//   1. folder create → 4 field shape assert
+//   2. show → 同 shape (= 永続化確認)
+//   3. update (rename) → name 反映 + show で再確認
+//   4. delete → 204 + show が 4xx で削除確定
+//   5. nest: parent folder 内に child folder を作り parentId が一致
+
+import { expect, test } from '@playwright/test';
+import { callApi } from '../../fixtures/api';
+import { randomUsername, signupUser } from '../../fixtures/auth';
+import { resetRateLimit } from '../../fixtures/rate_limit';
+
+test.describe('drive: folders CRUD', () => {
+  test.beforeAll(() => {
+    resetRateLimit();
+  });
+
+  test('create / show / update / delete round-trip', async ({ request }) => {
+    const me = await signupUser(request, randomUsername('drvFc'));
+
+    // create
+    const createResp = await callApi(request, 'drive/folders/create', {
+      i: me.token,
+      name: 'CRUD-folder',
+    });
+    expect(createResp.status()).toBe(200);
+    const created = await createResp.json();
+    expect(typeof created.id).toBe('string');
+    expect(created.name).toBe('CRUD-folder');
+    expect(created.parentId).toBeNull();
+    expect(typeof created.createdAt).toBe('string');
+
+    // show (= default 4 field のみ strict assert、detail field は drift で別 issue)
+    const showResp = await callApi(request, 'drive/folders/show', {
+      i: me.token,
+      folderId: created.id,
+    });
+    expect(showResp.status()).toBe(200);
+    const got = await showResp.json();
+    expect(got.id).toBe(created.id);
+    expect(got.name).toBe('CRUD-folder');
+    expect(got.parentId).toBeNull();
+
+    // update: rename
+    const updateResp = await callApi(request, 'drive/folders/update', {
+      i: me.token,
+      folderId: created.id,
+      name: 'CRUD-folder-renamed',
+    });
+    expect(updateResp.status()).toBe(200);
+    const updated = await updateResp.json();
+    expect(updated.id).toBe(created.id);
+    expect(updated.name).toBe('CRUD-folder-renamed');
+
+    // delete + show が 4xx で削除確定
+    const delResp = await callApi(request, 'drive/folders/delete', {
+      i: me.token,
+      folderId: created.id,
+    });
+    expect(delResp.status()).toBe(204);
+
+    // delete も async DB 削除の race を考慮、polling で 4xx を待つ
+    // (drive/files/delete spec #843 と同じ pattern)。
+    await expect
+      .poll(
+        async () => {
+          const resp = await callApi(request, 'drive/folders/show', {
+            i: me.token,
+            folderId: created.id,
+          });
+          const s = resp.status();
+          return s >= 400 && s < 500;
+        },
+        { timeout: 5000, intervals: [100, 200, 500, 1000] },
+      )
+      .toBe(true);
+  });
+
+  test('nested folder reflects parentId', async ({ request }) => {
+    const me = await signupUser(request, randomUsername('drvFn'));
+
+    // 親 folder
+    const parentResp = await callApi(request, 'drive/folders/create', {
+      i: me.token,
+      name: 'parent',
+    });
+    expect(parentResp.status()).toBe(200);
+    const parent = await parentResp.json();
+    expect(parent.parentId).toBeNull();
+
+    // 子 folder (parentId 指定)
+    const childResp = await callApi(request, 'drive/folders/create', {
+      i: me.token,
+      name: 'child',
+      parentId: parent.id,
+    });
+    expect(childResp.status()).toBe(200);
+    const child = await childResp.json();
+    expect(child.parentId).toBe(parent.id);
+
+    // show でも parentId が一致
+    const showResp = await callApi(request, 'drive/folders/show', {
+      i: me.token,
+      folderId: child.id,
+    });
+    expect(showResp.status()).toBe(200);
+    const got = await showResp.json();
+    expect(got.parentId).toBe(parent.id);
+  });
+});


### PR DESCRIPTION
## Summary

Phase 2 #829 の PR-B として drive/folders CRUD + parent-child nest の Playwright spec を追加。両 backend で default 4 field shape (id / createdAt / name / parentId) と round-trip を担保。本 PR で #829 (drive 拡張) は PR-A / PR-B / PR-C 全完了 → close。

## 主な変更

\`tests/playwright/specs/drive/folders.spec.ts\` (新規 2 test):

1. **CRUD round-trip**: create → show → update (rename) → delete → show が 4xx
   - default 4 field shape を strict assert
   - 削除確定は \`expect.poll\` で polling (= drive/files/delete spec #843 と同 pattern)
2. **nest**: parent + child folder の parentId 一致確認

## 設計判断

- **default 4 field のみ assert**: upstream の folders/show は detail mode で \`foldersCount / filesCount / parent (recursive)\` を返すが mk-go の \`DriveFolderEntity\` は default 4 field のみ = drift。本 PR scope は両 backend pass の spec で、drift fix (= mk-go entity 拡張 + counter 計算 + parent recursive pack) は scope 拡大で別 issue 候補
- **expect.poll 流用**: PR #843 で導入した polling pattern を folder 削除でも採用、async 削除 race を robust に吸収

## 検証

- Playwright TS image: 27/27 pass (\`make playwright-ts-test\`)
- Playwright mk-go: 27/27 pass (\`make playwright-test\`)

## Closes

#829 (drive 拡張: PR-A #843 / PR-B 本 PR / PR-C #842 で全完了)

## scope 外 (= 別 issue 候補)

- folders/show detail mode drift (foldersCount / filesCount / parent)
- folders/find spec (= name 検索)
- drive endpoint で残る self path drift 検証 (FilesList / FilesMoveBulk 等)