### PR TITLE
Fix #845: drive/folders/show を upstream detail mode shape に揃える

### DIFF
--- a/internal/api/drive/handler.go
+++ b/internal/api/drive/handler.go
@@ -354,6 +354,10 @@ type FolderIDRequest struct {
 }
 
 // FoldersShow handles POST /api/drive/folders/show.
+//
+// upstream Misskey TS は `pack(folder, { detail: true })` で foldersCount /
+// filesCount / parent (recursive) を埋めて返す。本実装も同 shape に揃える
+// (#845)。default mode (= create / update / find) は影響なし。
 func (h *Handler) FoldersShow(c echo.Context) error {
 	user := middleware.GetUser(c)
 	var req FolderIDRequest
@@ -364,7 +368,40 @@ func (h *Handler) FoldersShow(c echo.Context) error {
 	if err != nil {
 		return mapFolderError(c, err)
 	}
-	return c.JSON(http.StatusOK, entity.PackDriveFolder(f, h.idGen))
+	return c.JSON(http.StatusOK, h.packDriveFolderDetail(f))
+}
+
+// packDriveFolderDetail packs a folder in upstream "detail" mode for
+// drive/folders/show. Adds foldersCount / filesCount / parent (recursive
+// detail pack) to the default 4 field. count は best-effort で取れない
+// ときは 0 を返す (= upstream も Promise が reject されると 0 相当)。
+//
+// repository が wired されていない (= 旧 test handler) と count は 0、
+// parent は nil。これは production runtime には影響しない (= router で
+// 必ず wired される)。
+func (h *Handler) packDriveFolderDetail(f *model.DriveFolder) entity.DriveFolderEntity {
+	e := entity.PackDriveFolder(f, h.idGen)
+	foldersCount := 0
+	filesCount := 0
+	if h.folderRepo != nil {
+		if n, err := h.folderRepo.CountChildFolders(f.ID); err == nil {
+			foldersCount = n
+		}
+	}
+	if h.fileRepo != nil {
+		if n, err := h.fileRepo.CountByFolder(f.ID); err == nil {
+			filesCount = n
+		}
+	}
+	e.FoldersCount = &foldersCount
+	e.FilesCount = &filesCount
+	if f.ParentID != nil && h.folderRepo != nil {
+		if parent, err := h.folderRepo.FindByID(*f.ParentID); err == nil {
+			parentPacked := h.packDriveFolderDetail(parent)
+			e.Parent = &parentPacked
+		}
+	}
+	return e
 }
 
 // FoldersUpdateRequest is the body for drive/folders/update.

--- a/internal/api/drive/handler.go
+++ b/internal/api/drive/handler.go
@@ -4,6 +4,7 @@ package drive
 import (
 	"errors"
 	"io"
+	"log/slog"
 	"net/http"
 
 	"github.com/labstack/echo/v4"
@@ -384,12 +385,19 @@ func (h *Handler) packDriveFolderDetail(f *model.DriveFolder) entity.DriveFolder
 	foldersCount := 0
 	filesCount := 0
 	if h.folderRepo != nil {
-		if n, err := h.folderRepo.CountChildFolders(f.ID); err == nil {
+		if n, err := h.folderRepo.CountChildFolders(f.ID); err != nil {
+			// silent 0 を返すと真の DB error と空 state が区別できないので
+			// 運用 debug 用に Warn で記録する。frontend には response が
+			// 0 で返るので影響なし。
+			slog.Warn("packDriveFolderDetail: CountChildFolders failed", "folderID", f.ID, "err", err)
+		} else {
 			foldersCount = n
 		}
 	}
 	if h.fileRepo != nil {
-		if n, err := h.fileRepo.CountByFolder(f.ID); err == nil {
+		if n, err := h.fileRepo.CountByFolder(f.ID); err != nil {
+			slog.Warn("packDriveFolderDetail: CountByFolder failed", "folderID", f.ID, "err", err)
+		} else {
 			filesCount = n
 		}
 	}
@@ -399,6 +407,9 @@ func (h *Handler) packDriveFolderDetail(f *model.DriveFolder) entity.DriveFolder
 		if parent, err := h.folderRepo.FindByID(*f.ParentID); err == nil {
 			parentPacked := h.packDriveFolderDetail(parent)
 			e.Parent = &parentPacked
+		} else {
+			// parent FindByID error は recursion 切断の原因。同上で Warn。
+			slog.Warn("packDriveFolderDetail: parent FindByID failed", "folderID", f.ID, "parentID", *f.ParentID, "err", err)
 		}
 	}
 	return e

--- a/internal/api/drive/handler_test.go
+++ b/internal/api/drive/handler_test.go
@@ -442,13 +442,54 @@ func TestFoldersCreate_RepoError(t *testing.T) {
 // --- FoldersShow ---
 
 func TestFoldersShow_Success(t *testing.T) {
-	h, _, folderRepo := newHandler(t)
+	h, _, folderRepo := newHandlerWithRepos(t)
 	uid := "u1"
 	folderRepo.Folders["p"] = &model.DriveFolder{ID: "p", Name: "Test", UserID: &uid}
 	c, rec := newJSONReq(t, `{"folderId":"p"}`)
 	setUser(c, "u1")
 	require.NoError(t, h.FoldersShow(c))
 	assert.Equal(t, http.StatusOK, rec.Code)
+	// upstream `pack(folder, { detail: true })` (#845): foldersCount /
+	// filesCount は 0 (= 子なし)、parent は parentId=nil なので nil。
+	var resp map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+	assert.EqualValues(t, 0, resp["foldersCount"])
+	assert.EqualValues(t, 0, resp["filesCount"])
+	assert.Nil(t, resp["parent"])
+}
+
+// detail mode: 親 folder + 子 folder + 子内の file を持つ shape の確認 (#845)。
+func TestFoldersShow_DetailWithChildren(t *testing.T) {
+	h, fileRepo, folderRepo := newHandlerWithRepos(t)
+	uid := "u1"
+	parentID := "p"
+	childID := "c"
+	folderRepo.Folders[parentID] = &model.DriveFolder{ID: parentID, Name: "P", UserID: &uid}
+	folderRepo.Folders[childID] = &model.DriveFolder{ID: childID, Name: "C", UserID: &uid, ParentID: &parentID}
+	fileRepo.Files["f1"] = &model.DriveFile{ID: "f1", UserID: &uid, FolderID: &parentID}
+	fileRepo.Files["f2"] = &model.DriveFile{ID: "f2", UserID: &uid, FolderID: &parentID}
+
+	c, rec := newJSONReq(t, `{"folderId":"`+parentID+`"}`)
+	setUser(c, "u1")
+	require.NoError(t, h.FoldersShow(c))
+	require.Equal(t, http.StatusOK, rec.Code)
+	var resp map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+	assert.EqualValues(t, 1, resp["foldersCount"])
+	assert.EqualValues(t, 2, resp["filesCount"])
+	assert.Nil(t, resp["parent"])
+
+	// 子 folder show: parent (= 親) が recursive に埋まる。
+	c2, rec2 := newJSONReq(t, `{"folderId":"`+childID+`"}`)
+	setUser(c2, "u1")
+	require.NoError(t, h.FoldersShow(c2))
+	require.Equal(t, http.StatusOK, rec2.Code)
+	var resp2 map[string]any
+	require.NoError(t, json.Unmarshal(rec2.Body.Bytes(), &resp2))
+	parent, ok := resp2["parent"].(map[string]any)
+	require.True(t, ok)
+	assert.Equal(t, parentID, parent["id"])
+	assert.EqualValues(t, 1, parent["foldersCount"])
 }
 
 func TestFoldersShow_InvalidParam(t *testing.T) {

--- a/internal/core/transfer/drive_reader_test.go
+++ b/internal/core/transfer/drive_reader_test.go
@@ -77,6 +77,7 @@ func (f *fakeDriveFileRepo) FindByName(_, _ string, _ *string) ([]*model.DriveFi
 	return nil, nil
 }
 func (f *fakeDriveFileRepo) ExistsByMD5(_, _ string) (bool, error)                { return false, nil }
+func (f *fakeDriveFileRepo) CountByFolder(_ string) (int, error)                  { return 0, nil }
 func (f *fakeDriveFileRepo) ListByFileIDs(_ []string) ([]*model.DriveFile, error) { return nil, nil }
 func (f *fakeDriveFileRepo) UsageByUser(_ string) (int64, error)                  { return 0, nil }
 func (f *fakeDriveFileRepo) UpdateBulkFolder(_ []string, _ *string) error         { return nil }

--- a/internal/entity/drive.go
+++ b/internal/entity/drive.go
@@ -142,9 +142,18 @@ type DriveFolderEntity struct {
 	CreatedAt string  `json:"createdAt"`
 	Name      string  `json:"name"`
 	ParentID  *string `json:"parentId"`
+	// detail mode (= drive/folders/show) で埋まる field 群 (#845)。
+	// upstream Misskey TS は `pack(folder, { detail: true })` で返す。
+	// default mode (= folders/create / update / find) では omitempty で
+	// 省略され、shape は default 4 field のまま。
+	FoldersCount *int               `json:"foldersCount,omitempty"`
+	FilesCount   *int               `json:"filesCount,omitempty"`
+	Parent       *DriveFolderEntity `json:"parent,omitempty"`
 }
 
-// PackDriveFolder converts a model.DriveFolder to a DriveFolderEntity.
+// PackDriveFolder converts a model.DriveFolder to a DriveFolderEntity in
+// **default mode** (= 4 field のみ)。folders/create / update / find /
+// (file pack 内の embedded folder) で使う。
 func PackDriveFolder(f *model.DriveFolder, idGen id.Generator) DriveFolderEntity {
 	createdAt := ""
 	if t, err := idGen.ParseTime(f.ID); err == nil {

--- a/internal/repository/drive_file.go
+++ b/internal/repository/drive_file.go
@@ -31,6 +31,9 @@ type DriveFileRepository interface {
 	// listing と同一の semantics。
 	ListSystemFiles(fileType, untilID, sinceID string, limit int) ([]*model.DriveFile, error)
 	FindByName(userID, name string, folderID *string) ([]*model.DriveFile, error)
+	// CountByFolder は drive/folders/show の detail mode pack 用に、
+	// 指定 folder 内に直下で属する file 数を返す (#845)。
+	CountByFolder(folderID string) (int, error)
 	ExistsByMD5(userID, md5 string) (bool, error)
 	ListByFileIDs(fileIDs []string) ([]*model.DriveFile, error)
 	UsageByUser(userID string) (int64, error)
@@ -177,6 +180,15 @@ func (r *driveFileRepository) ExistsByMD5(userID, md5 string) (bool, error) {
 		return false, err
 	}
 	return count > 0, nil
+}
+
+// CountByFolder returns the number of files directly in the given folder.
+func (r *driveFileRepository) CountByFolder(folderID string) (int, error) {
+	var n int64
+	if err := r.db.Model(&model.DriveFile{}).Where(`"folderId" = ?`, folderID).Count(&n).Error; err != nil {
+		return 0, err
+	}
+	return int(n), nil
 }
 
 func (r *driveFileRepository) ListByFileIDs(fileIDs []string) ([]*model.DriveFile, error) {

--- a/internal/repository/drive_folder.go
+++ b/internal/repository/drive_folder.go
@@ -13,6 +13,10 @@ type DriveFolderRepository interface {
 	Delete(f *model.DriveFolder) error
 	ListByUser(userID string, parentID *string, untilID, sinceID string, limit int) ([]*model.DriveFolder, error)
 	HasChildren(folderID string) (bool, error)
+	// CountChildFolders は detail mode pack 用に「直下の sub-folder 数」を
+	// 返す (#845)。HasChildren は exists check で folder + file を兼ねるが、
+	// 本 method は folder のみ厳密に count する。
+	CountChildFolders(parentID string) (int, error)
 	FindByName(userID, name string, parentID *string) ([]*model.DriveFolder, error)
 }
 
@@ -68,6 +72,15 @@ func (r *driveFolderRepository) ListByUser(userID string, parentID *string, unti
 		return nil, err
 	}
 	return rows, nil
+}
+
+// CountChildFolders returns the number of immediate sub-folders.
+func (r *driveFolderRepository) CountChildFolders(parentID string) (int, error) {
+	var n int64
+	if err := r.db.Model(&model.DriveFolder{}).Where(`"parentId" = ?`, parentID).Count(&n).Error; err != nil {
+		return 0, err
+	}
+	return int(n), nil
 }
 
 // HasChildren reports whether the folder has any nested folders or files.

--- a/internal/testutil/mock_drive.go
+++ b/internal/testutil/mock_drive.go
@@ -117,6 +117,16 @@ func (m *MockDriveFileRepository) ExistsByMD5(userID, md5 string) (bool, error) 
 	return false, nil
 }
 
+func (m *MockDriveFileRepository) CountByFolder(folderID string) (int, error) {
+	n := 0
+	for _, f := range m.Files {
+		if f.FolderID != nil && *f.FolderID == folderID {
+			n++
+		}
+	}
+	return n, nil
+}
+
 func (m *MockDriveFileRepository) ListByFileIDs(ids []string) ([]*model.DriveFile, error) {
 	return m.FindByIDs(ids)
 }
@@ -308,6 +318,16 @@ func (m *MockDriveFolderRepository) HasChildren(folderID string) (bool, error) {
 		}
 	}
 	return false, nil
+}
+
+func (m *MockDriveFolderRepository) CountChildFolders(parentID string) (int, error) {
+	n := 0
+	for _, f := range m.Folders {
+		if f.ParentID != nil && *f.ParentID == parentID {
+			n++
+		}
+	}
+	return n, nil
 }
 
 func (m *MockDriveFileRepository) ListForAdmin(userID, origin, host, fileType, untilID, sinceID string, limit int) ([]*model.DriveFile, error) {

--- a/tests/playwright/specs/drive/folders.spec.ts
+++ b/tests/playwright/specs/drive/folders.spec.ts
@@ -1,18 +1,12 @@
 // #829 drive 拡張 PR-B: drive/folders CRUD + nest 表示。
 //
-// upstream Misskey TS と mk-go (一部 drift) は drive/folders の各 endpoint
+// upstream Misskey TS と mk-go (#845 fix 後) は drive/folders の各 endpoint
 // で以下の shape を返す:
 //   - /api/drive/folders/create / update / find: default mode
 //     `{ id, createdAt, name, parentId }`
 //   - /api/drive/folders/show: detail mode = default 4 field +
-//     `{ foldersCount, filesCount, parent? }` (upstream のみ、mk-go は
-//     default mode のまま = drift、#845 で tracking)
+//     `{ foldersCount, filesCount, parent? }` (両 backend で揃う、#845 fix 済)
 //   - /api/drive/folders/delete: 204 NoContent
-//
-// 本 spec は両 backend pass のため **default 4 field のみ strict assert**。
-// detail mode の追加 field (foldersCount / filesCount / parent) drift は
-// #845 で fix する。fix 後は本 spec の show response で detail field の
-// strict assert を追加する想定。
 //
 // 検証する round-trip:
 //   1. folder create → 4 field shape assert
@@ -46,7 +40,8 @@ test.describe('drive: folders CRUD', () => {
     expect(created.parentId).toBeNull();
     expect(typeof created.createdAt).toBe('string');
 
-    // show (= default 4 field のみ strict assert、detail field は drift で別 issue)
+    // show: default 4 field + detail field (foldersCount/filesCount/parent)
+    // を strict assert (#845 で両 backend で揃った)。
     const showResp = await callApi(request, 'drive/folders/show', {
       i: me.token,
       folderId: created.id,
@@ -56,6 +51,10 @@ test.describe('drive: folders CRUD', () => {
     expect(got.id).toBe(created.id);
     expect(got.name).toBe('CRUD-folder');
     expect(got.parentId).toBeNull();
+    // detail field (子なし state なので 0、parentId=nil なので parent なし)。
+    expect(got.foldersCount).toBe(0);
+    expect(got.filesCount).toBe(0);
+    expect(got.parent).toBeUndefined();
 
     // update: rename
     const updateResp = await callApi(request, 'drive/folders/update', {
@@ -114,7 +113,8 @@ test.describe('drive: folders CRUD', () => {
     const child = await childResp.json();
     expect(child.parentId).toBe(parent.id);
 
-    // show でも parentId が一致
+    // show でも parentId が一致 + detail field の parent (recursive pack)
+    // が親 folder を埋める (#845)。
     const showResp = await callApi(request, 'drive/folders/show', {
       i: me.token,
       folderId: child.id,
@@ -122,5 +122,13 @@ test.describe('drive: folders CRUD', () => {
     expect(showResp.status()).toBe(200);
     const got = await showResp.json();
     expect(got.parentId).toBe(parent.id);
+    expect(got.foldersCount).toBe(0);
+    expect(got.filesCount).toBe(0);
+    // parent recursive detail pack: 親 folder の id / foldersCount=1 (= 子
+    // を 1 個持つ) を確認。
+    expect(got.parent).toBeDefined();
+    expect(got.parent.id).toBe(parent.id);
+    expect(got.parent.foldersCount).toBe(1);
+    expect(got.parent.filesCount).toBe(0);
   });
 });


### PR DESCRIPTION
## Summary

upstream Misskey TS の \`drive/folders/show\` は \`pack(folder, { detail: true })\` を呼び、default 4 field (id / createdAt / name / parentId) に加えて detail field を返す:

| field | 内容 |
|---|---|
| foldersCount | 直下の sub-folder 数 |
| filesCount | 直下の file 数 |
| parent | 親 folder の recursive detail pack (parentId 非 null 時のみ) |

mk-go の \`DriveFolderEntity\` は default 4 field のみで drift していた (#845)。本 PR で entity 拡張 + Repository count helper + handler の detail pack 実装。

## 主な変更

- **\`internal/entity/drive.go\`** \`DriveFolderEntity\`: optional field 3 つ追加 (FoldersCount / FilesCount / Parent、すべて omitempty で default mode shape は不変)
- **\`internal/repository/drive_folder.go\`** \`CountChildFolders\`: 直下 sub-folder 数
- **\`internal/repository/drive_file.go\`** \`CountByFolder\`: 直下 file 数
- **\`internal/api/drive/handler.go\`** 新 helper \`packDriveFolderDetail\`: count + parent recursive pack。FoldersShow で使用 (= default mode の他 callsite は無影響)
- **\`internal/testutil/mock_drive.go\`** Mock に CountByFolder / CountChildFolders 追加
- **\`internal/core/transfer/drive_reader_test.go\`** \`fakeDriveFileRepo\`: interface 充足のため CountByFolder 追加
- **unit test**: TestFoldersShow_Success に detail field 0/null assert、TestFoldersShow_DetailWithChildren 新規 (= 親+子+file 状態で count + parent recursive を strict assert)
- **Playwright spec** (drive/folders.spec.ts): detail field strict assert を有効化 (CRUD test の show / nest test の child show)

## 検証

- \`go test ./...\` 全 package pass
- Playwright TS image: 27/27 pass (\`make playwright-ts-test\`)
- Playwright mk-go: 27/27 pass (\`make playwright-test\`)

## 設計判断

- **omitempty で default mode 不変**: folders/create / update / find は \`PackDriveFolder\` (default mode) を使い続ける。entity に追加 field を加えても omitempty で省略され、shape は 4 field のまま。folders/show だけ新 helper \`packDriveFolderDetail\` で detail field を埋める
- **parent recursive pack**: 単純再帰で N 段親まで埋める。folder 親子は tree (= cycle 不在) なので safety 確保
- **count は best-effort**: repo error / nil 時は 0 を返す。production runtime では必ず wired される
- **#812 / #818 PR と同じ pattern**: helper を選択する形で self path / detail mode の各経路を分離

## Closes

#845

これで drive 関連の drift は本日確認済範囲では全て解消。drift table が 全 closed の状態を維持。