### PR TITLE
#823 Phase 2: notification reaction event の Playwright spec を追加

### DIFF
--- a/tests/playwright/fixtures/streaming.ts
+++ b/tests/playwright/fixtures/streaming.ts
@@ -1,0 +1,88 @@
+// Misskey の streaming WebSocket helper。streaming spec (#815) と
+// notifications spec (#823, #847) で共有する。
+//
+// 主な責務:
+//   - openMainStream / openTimelineStream: WS connect + open 待ち + close
+//     (server reject) も即 fail として報告
+//   - subscribeChannel: subscribe message 送信 (= ack 不在のため fire and
+//     forget、200ms バッファは caller が制御)
+//   - awaitChannelEvent: 指定 channel + event type の最初の 1 通を待ち、
+//     timeout で reject。spec 上で 5s 既定。
+
+const baseURL = process.env.MK_BASE_URL ?? 'https://mkgo.local';
+const wsURL = baseURL.replace(/^http/, 'ws');
+
+// openStream connects to /streaming?i=<token> and resolves once `open`.
+// `error` / `close` (before open) は即 fail として reject。
+export async function openStream(token: string): Promise<WebSocket> {
+  const ws = new WebSocket(`${wsURL}/streaming?i=${token}`);
+  await new Promise<void>((resolve, reject) => {
+    ws.addEventListener('open', () => resolve(), { once: true });
+    ws.addEventListener('error', () => reject(new Error('ws connection error')), { once: true });
+    ws.addEventListener(
+      'close',
+      (ev) =>
+        reject(
+          new Error(
+            `ws closed before open: code=${ev.code} reason=${ev.reason || '(empty)'}`,
+          ),
+        ),
+      { once: true },
+    );
+  });
+  return ws;
+}
+
+// subscribeChannel sends a `connect` message to the given WS to subscribe
+// the named channel. Returns the random subId used so callers can match
+// channel events.
+export function subscribeChannel(ws: WebSocket, channel: string, params: Record<string, unknown> = {}): string {
+  const subId = 'sub-' + Math.random().toString(16).slice(2);
+  ws.send(
+    JSON.stringify({
+      type: 'connect',
+      body: { channel, id: subId, params },
+    }),
+  );
+  return subId;
+}
+
+// ChannelEvent は `{type:"channel", body:{id, type, body}}` の body 部分
+// (= channel-specific payload)。caller は予期する shape に narrow する。
+export interface ChannelEvent<T> {
+  id: string;
+  type: string;
+  body: T;
+}
+
+// awaitChannelEvent registers a message listener and resolves with the
+// first matching `{type:"channel"}` envelope's `body`. Caller-supplied
+// `match` decides whether the event is the target. Rejects on timeout.
+//
+// 投稿 / reaction 等の trigger 前に呼んで promise を保持しておくのが
+// 正しい使い方 (= race 回避)。
+export function awaitChannelEvent<T>(
+  ws: WebSocket,
+  match: (envelope: ChannelEvent<T>) => boolean,
+  timeoutMs = 5000,
+): Promise<T> {
+  return new Promise<T>((resolve, reject) => {
+    const handler = (ev: MessageEvent) => {
+      let msg: { type?: string; body?: ChannelEvent<T> };
+      try {
+        msg = JSON.parse(typeof ev.data === 'string' ? ev.data : '');
+      } catch {
+        return;
+      }
+      if (msg.type === 'channel' && msg.body && match(msg.body)) {
+        ws.removeEventListener('message', handler);
+        resolve(msg.body.body);
+      }
+    };
+    ws.addEventListener('message', handler);
+    setTimeout(() => {
+      ws.removeEventListener('message', handler);
+      reject(new Error('channel event not received within timeout'));
+    }, timeoutMs);
+  });
+}

--- a/tests/playwright/fixtures/streaming.ts
+++ b/tests/playwright/fixtures/streaming.ts
@@ -1,13 +1,15 @@
 // Misskey の streaming WebSocket helper。streaming spec (#815) と
 // notifications spec (#823, #847) で共有する。
 //
-// 主な責務:
-//   - openMainStream / openTimelineStream: WS connect + open 待ち + close
-//     (server reject) も即 fail として報告
-//   - subscribeChannel: subscribe message 送信 (= ack 不在のため fire and
-//     forget、200ms バッファは caller が制御)
-//   - awaitChannelEvent: 指定 channel + event type の最初の 1 通を待ち、
-//     timeout で reject。spec 上で 5s 既定。
+// 提供 API:
+//   - openStream(token): /streaming?i=<token> に WS connect + open 待ち。
+//     close (= server reject) / error は即 fail として報告
+//   - subscribeChannel(ws, channel, params?): channel subscribe message を
+//     送信し subId を返す (= ack 不在のため fire and forget、subscribe
+//     確定までの 200ms バッファは caller が制御)
+//   - awaitChannelEvent<T>(ws, match, timeoutMs?): caller-supplied match
+//     関数で channel envelope を絞り込み、最初の 1 通の body を resolve、
+//     timeout で reject。spec 上 5s 既定。
 
 const baseURL = process.env.MK_BASE_URL ?? 'https://mkgo.local';
 const wsURL = baseURL.replace(/^http/, 'ws');

--- a/tests/playwright/specs/notifications/reaction.spec.ts
+++ b/tests/playwright/specs/notifications/reaction.spec.ts
@@ -24,9 +24,7 @@ import { callApi } from '../../fixtures/api';
 import { randomUsername, signupUser } from '../../fixtures/auth';
 import { createNote } from '../../fixtures/notes';
 import { resetRateLimit } from '../../fixtures/rate_limit';
-
-const baseURL = process.env.MK_BASE_URL ?? 'https://mkgo.local';
-const wsURL = baseURL.replace(/^http/, 'ws');
+import { awaitChannelEvent, openStream, subscribeChannel } from '../../fixtures/streaming';
 
 test.describe('notifications: reaction', () => {
   test.beforeAll(() => {
@@ -38,49 +36,16 @@ test.describe('notifications: reaction', () => {
     const reactor = await signupUser(request, randomUsername('ntfB'));
 
     // me が main channel を subscribe。
-    const ws = new WebSocket(`${wsURL}/streaming?i=${me.token}`);
-    await new Promise<void>((resolve, reject) => {
-      ws.addEventListener('open', () => resolve(), { once: true });
-      ws.addEventListener('error', () => reject(new Error('ws connection error')), { once: true });
-      ws.addEventListener(
-        'close',
-        (ev) => reject(new Error(`ws closed before open: code=${ev.code} reason=${ev.reason || '(empty)'}`)),
-        { once: true },
-      );
-    });
-
-    const subId = 'sub-' + Math.random().toString(16).slice(2);
-    ws.send(JSON.stringify({
-      type: 'connect',
-      body: { channel: 'main', id: subId, params: {} },
-    }));
+    const ws = await openStream(me.token);
+    const subId = subscribeChannel(ws, 'main');
 
     // notification event 受信用 Promise を投稿前に登録 (= race 回避)。
     type NotificationBody = { id: string; type: string; userId?: string; reaction?: string };
-    const notifEventPromise = new Promise<NotificationBody>((resolve, reject) => {
-      const handler = (ev: MessageEvent) => {
-        let msg: { type?: string; body?: { id?: string; type?: string; body?: NotificationBody } };
-        try {
-          msg = JSON.parse(typeof ev.data === 'string' ? ev.data : '');
-        } catch {
-          return;
-        }
-        if (
-          msg.type === 'channel' &&
-          msg.body?.id === subId &&
-          msg.body.type === 'notification' &&
-          msg.body.body?.type === 'reaction'
-        ) {
-          ws.removeEventListener('message', handler);
-          resolve(msg.body.body);
-        }
-      };
-      ws.addEventListener('message', handler);
-      setTimeout(() => {
-        ws.removeEventListener('message', handler);
-        reject(new Error('did not receive reaction notification within timeout'));
-      }, 5000);
-    });
+    const notifEventPromise = awaitChannelEvent<NotificationBody>(
+      ws,
+      (env) =>
+        env.id === subId && env.type === 'notification' && env.body?.type === 'reaction',
+    );
 
     // subscribe 確定までの短時間バッファ (streaming spec と同根拠)。
     await new Promise((resolve) => setTimeout(resolve, 200));

--- a/tests/playwright/specs/notifications/reaction.spec.ts
+++ b/tests/playwright/specs/notifications/reaction.spec.ts
@@ -1,0 +1,133 @@
+// #823 Phase 2 notification spec: reaction notification の round-trip。
+//
+// upstream Misskey TS と mk-go は両方とも:
+//   - 他 user が自分の note に reaction を付ける → /api/i/notifications
+//     で `type: 'reaction'` の notification を返す
+//   - WS streaming main channel を subscribe していると同 notification
+//     event が `{type: 'channel', body: {type: 'notification', body: <n>}}`
+//     で push される
+//
+// 本 spec は両 backend 共通で:
+//   1. user A + user B signup
+//   2. user A が main channel を WS subscribe
+//   3. user A が public note 投稿
+//   4. user B がその note に reaction 付与
+//   5. WS で notification event (type: 'reaction') 受信
+//   6. /api/i/notifications で同 notification を取得 (= persistent)
+//
+// を検証する。streaming spec (#815) の WebSocket setup pattern を流用。
+// 他 notification 種別 (mention / follow / chatMessage 等) は別 spec で
+// 個別に拡張する想定。
+
+import { expect, test } from '@playwright/test';
+import { callApi } from '../../fixtures/api';
+import { randomUsername, signupUser } from '../../fixtures/auth';
+import { createNote } from '../../fixtures/notes';
+import { resetRateLimit } from '../../fixtures/rate_limit';
+
+const baseURL = process.env.MK_BASE_URL ?? 'https://mkgo.local';
+const wsURL = baseURL.replace(/^http/, 'ws');
+
+test.describe('notifications: reaction', () => {
+  test.beforeAll(() => {
+    resetRateLimit();
+  });
+
+  test('reaction on my note triggers notification (WS push + /i/notifications)', async ({ request }) => {
+    const me = await signupUser(request, randomUsername('ntfA'));
+    const reactor = await signupUser(request, randomUsername('ntfB'));
+
+    // me が main channel を subscribe。
+    const ws = new WebSocket(`${wsURL}/streaming?i=${me.token}`);
+    await new Promise<void>((resolve, reject) => {
+      ws.addEventListener('open', () => resolve(), { once: true });
+      ws.addEventListener('error', () => reject(new Error('ws connection error')), { once: true });
+      ws.addEventListener(
+        'close',
+        (ev) => reject(new Error(`ws closed before open: code=${ev.code} reason=${ev.reason || '(empty)'}`)),
+        { once: true },
+      );
+    });
+
+    const subId = 'sub-' + Math.random().toString(16).slice(2);
+    ws.send(JSON.stringify({
+      type: 'connect',
+      body: { channel: 'main', id: subId, params: {} },
+    }));
+
+    // notification event 受信用 Promise を投稿前に登録 (= race 回避)。
+    type NotificationBody = { id: string; type: string; userId?: string; reaction?: string };
+    const notifEventPromise = new Promise<NotificationBody>((resolve, reject) => {
+      const handler = (ev: MessageEvent) => {
+        let msg: { type?: string; body?: { id?: string; type?: string; body?: NotificationBody } };
+        try {
+          msg = JSON.parse(typeof ev.data === 'string' ? ev.data : '');
+        } catch {
+          return;
+        }
+        if (
+          msg.type === 'channel' &&
+          msg.body?.id === subId &&
+          msg.body.type === 'notification' &&
+          msg.body.body?.type === 'reaction'
+        ) {
+          ws.removeEventListener('message', handler);
+          resolve(msg.body.body);
+        }
+      };
+      ws.addEventListener('message', handler);
+      setTimeout(() => {
+        ws.removeEventListener('message', handler);
+        reject(new Error('did not receive reaction notification within timeout'));
+      }, 5000);
+    });
+
+    // subscribe 確定までの短時間バッファ (streaming spec と同根拠)。
+    await new Promise((resolve) => setTimeout(resolve, 200));
+
+    // me が public note 投稿。
+    const note = await createNote(request, me.token, {
+      text: 'react to me',
+      visibility: 'public',
+    });
+
+    // reactor が note に reaction 付与。upstream / mk-go は upstream 互換の
+    // shorthand 'like' を含む custom reaction を accept するが、本 spec は
+    // 標準 unicode emoji で deterministic に。
+    const reactResp = await callApi(request, 'notes/reactions/create', {
+      i: reactor.token,
+      noteId: note.id,
+      reaction: '👍',
+    });
+    expect(reactResp.status()).toBeGreaterThanOrEqual(200);
+    expect(reactResp.status()).toBeLessThan(300);
+
+    // WS notification event を待つ。
+    const evNotif = await notifEventPromise;
+    expect(evNotif.type).toBe('reaction');
+    expect(evNotif.userId).toBe(reactor.id);
+
+    ws.close();
+
+    // /api/i/notifications でも同 notification が取得できる (= 永続化)。
+    // notification の登録は async (= queue 経由) なので polling で待つ。
+    let httpNotif: NotificationBody | undefined;
+    await expect
+      .poll(
+        async () => {
+          const resp = await callApi(request, 'i/notifications', { i: me.token });
+          if (resp.status() !== 200) return false;
+          const list = (await resp.json()) as NotificationBody[];
+          httpNotif = list.find((n) => n.type === 'reaction' && n.userId === reactor.id);
+          return httpNotif !== undefined;
+        },
+        { timeout: 5000, intervals: [100, 200, 500, 1000] },
+      )
+      .toBe(true);
+
+    // 取得した notification が WS event と整合する shape を持つ。
+    expect(httpNotif).toBeDefined();
+    expect(httpNotif!.type).toBe('reaction');
+    expect(httpNotif!.userId).toBe(reactor.id);
+  });
+});

--- a/tests/playwright/specs/streaming/local_timeline.spec.ts
+++ b/tests/playwright/specs/streaming/local_timeline.spec.ts
@@ -24,9 +24,7 @@ import { expect, test } from '@playwright/test';
 import { randomUsername, signupUser } from '../../fixtures/auth';
 import { createNote } from '../../fixtures/notes';
 import { resetRateLimit } from '../../fixtures/rate_limit';
-
-const baseURL = process.env.MK_BASE_URL ?? 'http://mkgo:3000';
-const wsURL = baseURL.replace(/^http/, 'ws');
+import { awaitChannelEvent, openStream, subscribeChannel } from '../../fixtures/streaming';
 
 test.describe('streaming: localTimeline', () => {
   test.beforeAll(() => {
@@ -35,49 +33,14 @@ test.describe('streaming: localTimeline', () => {
 
   test('subscribed user receives a note event for a local public note', async ({ request }) => {
     const me = await signupUser(request, randomUsername('strm'));
-    const ws = new WebSocket(`${wsURL}/streaming?i=${me.token}`);
-
-    // WS open を待つ。close (= server 側 reject) も即 fail として
-    // 報告する (= test の 5s timeout 待ちを避け、原因を message に
-    // 反映できる)。
-    await new Promise<void>((resolve, reject) => {
-      ws.addEventListener('open', () => resolve(), { once: true });
-      ws.addEventListener('error', () => reject(new Error('ws connection error')), { once: true });
-      ws.addEventListener(
-        'close',
-        (ev) => reject(new Error(`ws closed before open: code=${ev.code} reason=${ev.reason || '(empty)'}`)),
-        { once: true },
-      );
-    });
-
-    // localTimeline channel を subscribe。subId は client 任意で event の
-    // round-trip 確認に使う。
-    const subId = 'sub-' + Math.random().toString(16).slice(2);
-    ws.send(JSON.stringify({
-      type: 'connect',
-      body: { channel: 'localTimeline', id: subId, params: {} },
-    }));
+    const ws = await openStream(me.token);
+    const subId = subscribeChannel(ws, 'localTimeline');
 
     // 投稿 event 受信用の Promise を先に登録 (= 投稿 → 受信の race を防ぐ)。
-    const noteEventPromise = new Promise<{ id: string; text?: string }>((resolve, reject) => {
-      const handler = (ev: MessageEvent) => {
-        let msg: { type?: string; body?: { id?: string; type?: string; body?: { id: string; text?: string } } };
-        try {
-          msg = JSON.parse(typeof ev.data === 'string' ? ev.data : '');
-        } catch {
-          return;
-        }
-        if (msg.type === 'channel' && msg.body?.id === subId && msg.body.type === 'note' && msg.body.body) {
-          ws.removeEventListener('message', handler);
-          resolve(msg.body.body);
-        }
-      };
-      ws.addEventListener('message', handler);
-      setTimeout(() => {
-        ws.removeEventListener('message', handler);
-        reject(new Error('did not receive note event within timeout'));
-      }, 5000);
-    });
+    const noteEventPromise = awaitChannelEvent<{ id: string; text?: string }>(
+      ws,
+      (env) => env.id === subId && env.type === 'note',
+    );
 
     // subscribe 確定までの短時間バッファ。upstream は ack を返さないので
     // 厳密に待つ手段はなく、200ms で実用上十分。


### PR DESCRIPTION
## Summary

Phase 2 #823 として notification の最初の spec を追加。**reaction notification** の round-trip を両 backend 共通で strict assert する。WS streaming main channel 経由の event push + HTTP \`/api/i/notifications\` 経路の persistent 取得を 1 test で網羅。

## 主な変更

\`tests/playwright/specs/notifications/reaction.spec.ts\` (新規 1 test):
1. user A (投稿者) + user B (reactor) signup
2. user A が main channel WS subscribe
3. user A が public note 投稿
4. user B が note に reaction (👍) 付与
5. WS で \`{type: 'channel', body: {type: 'notification', body: {type: 'reaction', userId: <B.id>}}}\` event 受信
6. \`/api/i/notifications\` でも同 notification を取得 (\`expect.poll\` で async queue 反映を待つ)

## 設計判断

- **streaming spec (#815) の pattern 流用**: WebSocket subscribe / event handler 先登録 / 200ms バッファ / close 即 fail handling
- **expect.poll for /i/notifications**: notification の DB 永続化は async (= queue 経由)、HTTP 取得には反映 wait が必要 (= PR #843 と同 polling pattern)
- **scope を reaction に絞る**: 他 notification 種別 (mention / follow / chatMessage 等) は別 spec で個別整備 = scope 小で確実

## 検証

- Playwright TS image: 28/28 pass (\`make playwright-ts-test\`)
- Playwright mk-go: 28/28 pass (\`make playwright-test\`)

## scope 外 (= 後続 PR)

- 他 notification 種別 (mention / reply / renote / follow / followRequestReceived / chatMessage 等)
- mark-all-as-read endpoint
- unreadNotificationsCount の状態確認

## 関連

- #823 (Phase 2 umbrella: notification)
- #815 (streaming spec、WebSocket pattern の元)
- #843 (drive mutate spec、expect.poll pattern の元)