### PR TITLE
#822 Phase 2 PR-A: chat DM round-trip spec (create-to-user + user-timeline)

### DIFF
--- a/tests/playwright/specs/chat/messages_dm.spec.ts
+++ b/tests/playwright/specs/chat/messages_dm.spec.ts
@@ -89,10 +89,16 @@ test.describe('chat: DM messages', () => {
     const tl = (await tlResp.json()) as ChatMessage[];
     expect(Array.isArray(tl)).toBe(true);
 
+    // `find` の return が undefined なら spec の前提 (= sent message が
+    // receiver の user-timeline で見える) が崩れているので明示 throw で
+    // fail させる。!-assertion ではなく guard で型を narrow する pattern は
+    // pollForNotification (#848) / pollUnread (#850) と揃える。
     const found = tl.find((m) => m.id === sent.id);
-    expect(found).toBeDefined();
-    expect(found!.fromUserId).toBe(sender.id);
-    expect(found!.toUserId).toBe(receiver.id);
-    expect(found!.text).toBe(text);
+    if (!found) {
+      throw new Error(`user-timeline did not contain sent message (id=${sent.id})`);
+    }
+    expect(found.fromUserId).toBe(sender.id);
+    expect(found.toUserId).toBe(receiver.id);
+    expect(found.text).toBe(text);
   });
 });

--- a/tests/playwright/specs/chat/messages_dm.spec.ts
+++ b/tests/playwright/specs/chat/messages_dm.spec.ts
@@ -1,0 +1,98 @@
+// #822 Phase 2 chat spec: DM (user-to-user message) の round-trip。
+//
+// upstream Misskey TS と mk-go は両方とも:
+//   - chat/messages/create-to-user で sender が receiver に DM を送ると
+//     ChatMessage object (id / fromUserId / toUserId / text / createdAt 等)
+//     が 200 OK で返る
+//   - receiver は chat/messages/user-timeline { userId: <sender> } で
+//     対話相手の DM 一覧を取得できる
+//   - user-timeline 側は initial load で「相手→自分」の DM をすべて
+//     既読マークする副作用を持つ (#692, upstream の readUserChatMessage 相当)
+//
+// 本 spec は両 backend 共通で:
+//   1. user A + user B signup
+//   2. A → B に chat/messages/create-to-user で text 付き DM 送信
+//   3. response shape (id / fromUserId / toUserId / text / createdAt) を assert
+//   4. B 側で chat/messages/user-timeline { userId: A.id } 取得
+//   5. timeline list 内に送信した message が含まれることを確認
+//
+// 注: room / membership / chatMessage notification は別 PR で扱う (scope 分割)。
+
+import { expect, test } from '@playwright/test';
+import { callApi } from '../../fixtures/api';
+import { randomUsername, signupUser } from '../../fixtures/auth';
+import { resetRateLimit } from '../../fixtures/rate_limit';
+
+interface ChatMessage {
+  id: string;
+  fromUserId: string;
+  toUserId: string | null;
+  toRoomId: string | null;
+  text: string | null;
+  createdAt: string;
+}
+
+test.describe('chat: DM messages', () => {
+  test.beforeAll(() => {
+    resetRateLimit();
+  });
+
+  test('A sends DM to B; B can read it back via user-timeline', async ({ request }) => {
+    const sender = await signupUser(request, randomUsername('dmA'));
+    const receiver = await signupUser(request, randomUsername('dmB'));
+
+    // receiver の chatScope は default が "mutual" (相互フォロー必須) のため、
+    // signup 直後の 2 user 間では DM が reject される (#692)。spec の意図は
+    // chatScope policy ではなく DM round-trip 自体なので、receiver 側で
+    // "everyone" に開放してから送る。chatScope 別の policy は専用 spec で扱う。
+    const scopeResp = await callApi(request, 'i/update', {
+      i: receiver.token,
+      chatScope: 'everyone',
+    });
+    expect(scopeResp.status()).toBeGreaterThanOrEqual(200);
+    expect(scopeResp.status()).toBeLessThan(300);
+
+    const text = 'hello DM ' + Math.random().toString(16).slice(2, 8);
+
+    // sender が receiver に DM 送信。
+    const sendResp = await callApi(request, 'chat/messages/create-to-user', {
+      i: sender.token,
+      toUserId: receiver.id,
+      text,
+    });
+    expect(sendResp.status()).toBe(200);
+    const sent = (await sendResp.json()) as ChatMessage;
+
+    // response shape strict assert (id / fromUser / toUser / text / createdAt)。
+    // upstream / mk-go で揃っていなければ drop-in 互換 regression。
+    expect(typeof sent.id).toBe('string');
+    expect(sent.id.length).toBeGreaterThan(0);
+    expect(sent.fromUserId).toBe(sender.id);
+    expect(sent.toUserId).toBe(receiver.id);
+    // upstream TS は null の field を omit する (= undefined)、mk-go は
+    // 明示的に null を返す drift がある (#851)。本 spec の主眼は room では
+    // ないことなので、両表現を falsy として吸収。#851 fix 後に `toBeNull()`
+    // で strict 化する。
+    expect(sent.toRoomId ?? null).toBeNull();
+    expect(sent.text).toBe(text);
+    // createdAt は ISO 8601 (`YYYY-MM-DDTHH:MM:SS.sssZ`)。Date.parse で
+    // 有効な timestamp として読めることだけ確認 (秒精度の drift は許容)。
+    expect(Number.isFinite(Date.parse(sent.createdAt))).toBe(true);
+
+    // receiver 側で user-timeline 取得 → 対象 DM が含まれる。
+    const tlResp = await callApi(request, 'chat/messages/user-timeline', {
+      i: receiver.token,
+      userId: sender.id,
+      limit: 10,
+    });
+    expect(tlResp.status()).toBe(200);
+    const tl = (await tlResp.json()) as ChatMessage[];
+    expect(Array.isArray(tl)).toBe(true);
+
+    const found = tl.find((m) => m.id === sent.id);
+    expect(found).toBeDefined();
+    expect(found!.fromUserId).toBe(sender.id);
+    expect(found!.toUserId).toBe(receiver.id);
+    expect(found!.text).toBe(text);
+  });
+});


### PR DESCRIPTION
## Summary

- chat (DM / room / membership) Playwright spec の最初の PR (PR-A) として、user-to-user DM の round-trip を 1 spec で検証。
- 両 backend (mk-go / Misskey TS upstream) で挙動が揃っていることを確認。
- 過程で発見した response shape drift は別 issue (#851) に切り出し、本 spec では両表現を吸収。

## 主な変更点

- \`tests/playwright/specs/chat/messages_dm.spec.ts\` (new):
  シナリオ:
  1. user A + user B signup
  2. receiver (B) の \`chatScope\` を \`everyone\` に開放 (default \`mutual\` だと 2 user 間で reject されるため。chatScope policy 自体は専用 spec で扱う)
  3. A → B に \`chat/messages/create-to-user\` で text 付き DM 送信
  4. response shape を strict assert (id / fromUserId / toUserId / text / createdAt)
  5. B 側で \`chat/messages/user-timeline { userId: A.id }\` 取得 → 該当 message が含まれることを確認

## 検出された drift (#851)

- upstream Misskey TS は \`null\` field を JSON response から omit (= undefined)
- mk-go は明示的に \`null\` を返す
- 本 spec では \`expect(sent.toRoomId ?? null).toBeNull()\` で両表現を falsy として吸収。#851 fix 後に \`toBeNull()\` で strict 化する follow-up を予定。

## Testing

- \`make playwright-up && make playwright-test\` (mk-go backend): **1 passed (1.0s)**
- \`make playwright-ts-up && make playwright-ts-test\` (TS backend): **1 passed (1.2s)**

## Related

- Refs #822 (chat Playwright spec)
- Drift fix: #851 (packMessage の null field omit drift)
- 残 #822 scope:
  - PR-B: room CRUD / membership / room messages spec
  - PR-C: chatMessage notification spec (#823 close と一緒に)

🤖 Generated with [Claude Code](https://claude.com/claude-code)