### PR TITLE
#855 PR-A: chat packRoom に createdAt 追加 + packMessage から reads 削除

### DIFF
--- a/internal/api/chat/handler.go
+++ b/internal/api/chat/handler.go
@@ -62,10 +62,11 @@ func (h *Handler) mapChatErr(c echo.Context, err error) error {
 	return c.JSON(http.StatusInternalServerError, apierr.Error("INTERNAL_ERROR", "Internal error.", "5d37dbcb-891e-41ca-a3d6-e690c97775ac"))
 }
 
-// packRoom returns the bare ChatRoom shape without createdAt.
-// 多くの endpoint は createdAt 付きで返す必要があるので、通常は
-// packRoomWithCreatedAt 経由で呼ぶ。本関数を直接使うのは createdAt が
-// 不要な内部用途だけ。
+// packRoom returns the bare ChatRoom shape used by packRoomWithCreatedAt.
+// createdAt は wrapper 側で ID 派生で付与するため、本関数は packRoom*
+// helper の内部実装として packRoomWithCreatedAt 経由でのみ呼ぶこと。
+// 直接 caller として使うと createdAt が抜けて upstream 互換 contract を
+// 破る (= packedChatRoomSchema は createdAt 必須)。
 //
 // upstream Misskey TS の packedChatRoomSchema は `isArchived` を返さない。
 // mk-go も互換のため field を出力しない (#851)。archived state は別経路で

--- a/internal/api/chat/handler.go
+++ b/internal/api/chat/handler.go
@@ -62,10 +62,15 @@ func (h *Handler) mapChatErr(c echo.Context, err error) error {
 	return c.JSON(http.StatusInternalServerError, apierr.Error("INTERNAL_ERROR", "Internal error.", "5d37dbcb-891e-41ca-a3d6-e690c97775ac"))
 }
 
+// packRoom returns the bare ChatRoom shape without createdAt.
+// 多くの endpoint は createdAt 付きで返す必要があるので、通常は
+// packRoomWithCreatedAt 経由で呼ぶ。本関数を直接使うのは createdAt が
+// 不要な内部用途だけ。
+//
+// upstream Misskey TS の packedChatRoomSchema は `isArchived` を返さない。
+// mk-go も互換のため field を出力しない (#851)。archived state は別経路で
+// 取得する設計を踏襲する。
 func packRoom(r *model.ChatRoom) map[string]any {
-	// upstream Misskey TS の packedChatRoomSchema は `isArchived` を返さない。
-	// mk-go も互換のため field を出力しない (#851)。archived state は別経路で
-	// 取得する設計を踏襲する。
 	result := map[string]any{
 		"id": r.ID, "name": r.Name, "ownerId": r.OwnerID,
 		"description": r.Description,
@@ -84,11 +89,15 @@ func packRoom(r *model.ChatRoom) map[string]any {
 // 注: m.URI は remote chat message の AP canonical URI (federation 内部用途)
 // だが、upstream の packedChatMessageSchema には `uri` field が無いため
 // 外部 response には含めない。
+//
+// 注: m.Reads (chat_message.reads) は mk-go 独自の DB column で、upstream の
+// packedChatMessageSchema には対応 field が無い。response から omit して
+// upstream 互換に揃える (#855)。既読判定 (isRead) は別途 hint 経由で
+// computed する設計に移行予定。
 func packMessage(m *model.ChatMessage) map[string]any {
 	result := map[string]any{
 		"id":         m.ID,
 		"fromUserId": m.FromUserID,
-		"reads":      m.Reads,
 		"reactions":  m.Reactions,
 	}
 	if m.ToUserID != nil {
@@ -122,6 +131,20 @@ func (h *Handler) packMessageWithCreatedAt(m *model.ChatMessage) map[string]any 
 	return result
 }
 
+// packRoomWithCreatedAt augments packRoom with createdAt parsed from the
+// room ID. upstream の packedChatRoomSchema は createdAt を必須 field と
+// するため、room を返す全 endpoint は本 method 経由で createdAt を含める
+// (packMessageWithCreatedAt と同 pattern, #855)。
+func (h *Handler) packRoomWithCreatedAt(r *model.ChatRoom) map[string]any {
+	result := packRoom(r)
+	if h.idGen != nil {
+		if t, err := h.idGen.ParseTime(r.ID); err == nil {
+			result["createdAt"] = t.UTC().Format("2006-01-02T15:04:05.000Z")
+		}
+	}
+	return result
+}
+
 // packMessageDetailed builds the upstream-compatible ChatMessage payload
 // expected by MkChatHistories.vue: createdAt (ID から派生)、fromUser、
 // toUser (DM の時)、toRoom (room の時)。upstream の
@@ -136,10 +159,10 @@ func (h *Handler) packMessageDetailed(m *model.ChatMessage) map[string]any {
 		result["toUser"] = packUser(m.ToUser)
 	}
 	if m.ToRoom != nil {
-		result["toRoom"] = packRoom(m.ToRoom)
+		result["toRoom"] = h.packRoomWithCreatedAt(m.ToRoom)
 		// upstream の `'room' in m` 判定に合わせて `room` alias も入れる。
 		// 旧 chat 実装ではこの key で判定していた残存 client がある。
-		result["room"] = packRoom(m.ToRoom)
+		result["room"] = h.packRoomWithCreatedAt(m.ToRoom)
 	}
 	return result
 }
@@ -181,7 +204,7 @@ func (h *Handler) RoomsCreate(c echo.Context) error {
 	if err := h.repo.CreateRoom(room); err != nil {
 		return c.JSON(http.StatusInternalServerError, apierr.Error("INTERNAL_ERROR", "Internal error.", "5d37dbcb-891e-41ca-a3d6-e690c97775ac"))
 	}
-	return c.JSON(http.StatusOK, packRoom(room))
+	return c.JSON(http.StatusOK, h.packRoomWithCreatedAt(room))
 }
 
 // RoomsShow handles POST /api/chat/rooms/show.
@@ -196,7 +219,7 @@ func (h *Handler) RoomsShow(c echo.Context) error {
 	if err != nil {
 		return c.JSON(http.StatusNotFound, apierr.Error("NO_SUCH_ROOM", "No such room.", "6ab4d7df-5043-57b9-bd5d-ff9908288473"))
 	}
-	return c.JSON(http.StatusOK, packRoom(room))
+	return c.JSON(http.StatusOK, h.packRoomWithCreatedAt(room))
 }
 
 // RoomsUpdate handles POST /api/chat/rooms/update.
@@ -223,7 +246,7 @@ func (h *Handler) RoomsUpdate(c echo.Context) error {
 	if err := h.repo.UpdateRoom(room); err != nil {
 		return c.JSON(http.StatusInternalServerError, apierr.Error("INTERNAL_ERROR", "Internal error.", "5d37dbcb-891e-41ca-a3d6-e690c97775ac"))
 	}
-	return c.JSON(http.StatusOK, packRoom(room))
+	return c.JSON(http.StatusOK, h.packRoomWithCreatedAt(room))
 }
 
 // RoomsDelete handles POST /api/chat/rooms/delete.
@@ -249,7 +272,7 @@ func (h *Handler) RoomsOwned(c echo.Context) error {
 	rooms, _ := h.repo.ListRoomsByOwner(user.ID)
 	result := make([]map[string]any, len(rooms))
 	for i, r := range rooms {
-		result[i] = packRoom(r)
+		result[i] = h.packRoomWithCreatedAt(r)
 	}
 	return c.JSON(http.StatusOK, result)
 }
@@ -260,7 +283,7 @@ func (h *Handler) RoomsJoined(c echo.Context) error {
 	rooms, _ := h.repo.ListJoinedRooms(user.ID)
 	result := make([]map[string]any, len(rooms))
 	for i, r := range rooms {
-		result[i] = packRoom(r)
+		result[i] = h.packRoomWithCreatedAt(r)
 	}
 	return c.JSON(http.StatusOK, result)
 }
@@ -787,7 +810,7 @@ func (h *Handler) InvitationsInbox(c echo.Context) error {
 	for _, inv := range rows {
 		entry := map[string]any{"id": inv.ID, "roomId": inv.RoomID, "userId": inv.UserID}
 		if inv.Room != nil {
-			entry["room"] = packRoom(inv.Room)
+			entry["room"] = h.packRoomWithCreatedAt(inv.Room)
 		}
 		out = append(out, entry)
 	}

--- a/tests/playwright/fixtures/chat.ts
+++ b/tests/playwright/fixtures/chat.ts
@@ -19,8 +19,12 @@ export interface ChatMessage {
 // ChatRoom は chat/rooms/* response の最小 shape。upstream の
 // `packedChatRoomSchema` に揃え、`isArchived` は含めない (#851 fix 後)。
 // archived state は別経路で取得する設計。
+//
+// `createdAt` は upstream 必須 field (ID から派生)、mk-go も #855 PR-A
+// 以降で全 chat/rooms/* endpoint が含めて返す。
 export interface ChatRoom {
   id: string;
+  createdAt: string;
   name: string;
   ownerId: string;
   description: string;

--- a/tests/playwright/specs/chat/room.spec.ts
+++ b/tests/playwright/specs/chat/room.spec.ts
@@ -61,6 +61,10 @@ test.describe('chat: rooms', () => {
     expect(room.name).toBe(roomName);
     expect(room.ownerId).toBe(owner.id);
     expect(room.description).toBe('spec room');
+    // createdAt は ISO 8601 (`YYYY-MM-DDTHH:MM:SS.sssZ`)。upstream は ID から
+    // 派生する必須 field、mk-go は #855 PR-A 以降で同 pattern。Date.parse で
+    // 有効な timestamp として読めることを check (秒精度の drift は許容)。
+    expect(Number.isFinite(Date.parse(room.createdAt))).toBe(true);
     // upstream の packedChatRoomSchema には `isArchived` が無いため
     // mk-go も #851 fix 以降は返さない。本 spec では archived state は
     // assert しない (= field 不在を許容)。


### PR DESCRIPTION
## Summary

- #851 で null/false omit drift を fix した chat packMessage / packRoom について、残 field set drift のうち軽い 2 点 (`createdAt` 追加 / `reads` 削除) を upstream に揃える PR-A。
- 残 drift (`isMuted` / `invitationExists` / `file` / `isRead`) は eager load が必要なため別 PR (PR-B / PR-C) で扱う。

## 主な変更点

- \`internal/api/chat/handler.go\`
  - \`packRoomWithCreatedAt\` method を新設。\`packRoom\` の結果に ID 派生 \`createdAt\` (ISO 8601) を付与する wrapper。\`packMessageWithCreatedAt\` (#692) と同 pattern。
  - \`chat/rooms/{create,show,update,owned,joined}\` と \`invitations/inbox\` の room field、\`packMessageDetailed\` の toRoom/room eager pack を \`h.packRoomWithCreatedAt\` 経由に置換。
  - \`packMessage\` から \`reads\` field を削除。upstream の \`packedChatMessageSchema\` には対応 field が無く、mk-go の \`chat_message.reads\` 列は独自実装。既読判定 (isRead) は別 PR で hint 経由 computed に移行予定。
- \`tests/playwright/fixtures/chat.ts\`
  - \`ChatRoom\` interface に \`createdAt: string\` を追加。
- \`tests/playwright/specs/chat/room.spec.ts\`
  - room creation 直後に \`createdAt\` を \`Date.parse\` で strict assert 追加。

## Testing

- \`make playwright-up && make playwright-test\` (mk-go backend, 3 chat specs): **3 passed (2.0s)**
- \`make playwright-ts-up && make playwright-ts-test\` (TS backend, 3 chat specs): **3 passed (1.9s)**
- \`go test ./internal/api/chat/... ./internal/core/chat/...\`: pass

## Scope 外 (#855 PR-B / PR-C で別途扱う)

- packRoom: \`isMuted\` / \`invitationExists\` (membership / invitation の eager load 要、PR-B)
- packMessage: \`file\` (DriveFile pack 要) / \`isRead\` (hint 経由 computed) (PR-C)

## Related

- Refs #855 (chat packMessage / packRoom field set drift)
- 先行: #856 (null/false omit drift fix, merged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)