### PR TITLE
#855 PR-B: chat packRoom に isMuted / invitationExists 追加

### DIFF
--- a/internal/api/chat/handler.go
+++ b/internal/api/chat/handler.go
@@ -146,6 +146,36 @@ func (h *Handler) packRoomWithCreatedAt(r *model.ChatRoom) map[string]any {
 	return result
 }
 
+// packRoomDetailed augments packRoomWithCreatedAt with viewer (= meID) -
+// specific optional field `isMuted` / `invitationExists`。upstream Misskey
+// TS の ChatEntityService.packRoom と同じ semantics:
+//   - meID が空、または me === room.OwnerID の場合は lookup を skip
+//     (= owner は自身の room なので mute も invitation も無関係、両 false)
+//   - me !== owner の場合のみ membership / invitation を lookup する
+//
+// upstream packedChatRoomSchema は両 field を `optional: true` で定義する
+// が、mk-go は handler 経由 response で常に boolean を返す (= 利用側が
+// undefined / boolean のどちらか分岐を考えずに済むよう一貫させる、#855)。
+//
+// caller が meID を渡せない場面 (例: federation 経由の eager pack や
+// 内部用途) では packRoomWithCreatedAt をそのまま使う。
+func (h *Handler) packRoomDetailed(r *model.ChatRoom, meID string) map[string]any {
+	result := h.packRoomWithCreatedAt(r)
+	isMuted := false
+	invitationExists := false
+	if meID != "" && meID != r.OwnerID {
+		if mem, err := h.repo.FindMembership(meID, r.ID); err == nil && mem != nil {
+			isMuted = mem.IsMuted
+		}
+		if _, err := h.repo.FindInvitation(meID, r.ID); err == nil {
+			invitationExists = true
+		}
+	}
+	result["isMuted"] = isMuted
+	result["invitationExists"] = invitationExists
+	return result
+}
+
 // packMessageDetailed builds the upstream-compatible ChatMessage payload
 // expected by MkChatHistories.vue: createdAt (ID から派生)、fromUser、
 // toUser (DM の時)、toRoom (room の時)。upstream の
@@ -205,11 +235,12 @@ func (h *Handler) RoomsCreate(c echo.Context) error {
 	if err := h.repo.CreateRoom(room); err != nil {
 		return c.JSON(http.StatusInternalServerError, apierr.Error("INTERNAL_ERROR", "Internal error.", "5d37dbcb-891e-41ca-a3d6-e690c97775ac"))
 	}
-	return c.JSON(http.StatusOK, h.packRoomWithCreatedAt(room))
+	return c.JSON(http.StatusOK, h.packRoomDetailed(room, user.ID))
 }
 
 // RoomsShow handles POST /api/chat/rooms/show.
 func (h *Handler) RoomsShow(c echo.Context) error {
+	user := middleware.GetUser(c)
 	var req struct {
 		RoomID string `json:"roomId"`
 	}
@@ -220,7 +251,7 @@ func (h *Handler) RoomsShow(c echo.Context) error {
 	if err != nil {
 		return c.JSON(http.StatusNotFound, apierr.Error("NO_SUCH_ROOM", "No such room.", "6ab4d7df-5043-57b9-bd5d-ff9908288473"))
 	}
-	return c.JSON(http.StatusOK, h.packRoomWithCreatedAt(room))
+	return c.JSON(http.StatusOK, h.packRoomDetailed(room, user.ID))
 }
 
 // RoomsUpdate handles POST /api/chat/rooms/update.
@@ -247,7 +278,7 @@ func (h *Handler) RoomsUpdate(c echo.Context) error {
 	if err := h.repo.UpdateRoom(room); err != nil {
 		return c.JSON(http.StatusInternalServerError, apierr.Error("INTERNAL_ERROR", "Internal error.", "5d37dbcb-891e-41ca-a3d6-e690c97775ac"))
 	}
-	return c.JSON(http.StatusOK, h.packRoomWithCreatedAt(room))
+	return c.JSON(http.StatusOK, h.packRoomDetailed(room, user.ID))
 }
 
 // RoomsDelete handles POST /api/chat/rooms/delete.
@@ -273,7 +304,10 @@ func (h *Handler) RoomsOwned(c echo.Context) error {
 	rooms, _ := h.repo.ListRoomsByOwner(user.ID)
 	result := make([]map[string]any, len(rooms))
 	for i, r := range rooms {
-		result[i] = h.packRoomWithCreatedAt(r)
+		// 全 room の owner = user.ID (= 一覧の filter 条件)。packRoomDetailed は
+		// 内部で me === owner check で lookup を skip し isMuted/invitationExists
+		// を false に固定する。
+		result[i] = h.packRoomDetailed(r, user.ID)
 	}
 	return c.JSON(http.StatusOK, result)
 }
@@ -284,7 +318,11 @@ func (h *Handler) RoomsJoined(c echo.Context) error {
 	rooms, _ := h.repo.ListJoinedRooms(user.ID)
 	result := make([]map[string]any, len(rooms))
 	for i, r := range rooms {
-		result[i] = h.packRoomWithCreatedAt(r)
+		// joined 一覧は本人が member の room なので room ごとに membership
+		// lookup が走る (= isMuted を返すため)。upstream は packRooms hint で
+		// bulk fetch するが、本実装は per-room lookup (= 件数 N の clean fetch)。
+		// hint cache 化は別 issue で扱う。
+		result[i] = h.packRoomDetailed(r, user.ID)
 	}
 	return c.JSON(http.StatusOK, result)
 }
@@ -811,7 +849,9 @@ func (h *Handler) InvitationsInbox(c echo.Context) error {
 	for _, inv := range rows {
 		entry := map[string]any{"id": inv.ID, "roomId": inv.RoomID, "userId": inv.UserID}
 		if inv.Room != nil {
-			entry["room"] = h.packRoomWithCreatedAt(inv.Room)
+			// inbox は本人が invitee (= owner ではない)。lookup で
+			// invitationExists = true、isMuted = false (まだ非 member) になる。
+			entry["room"] = h.packRoomDetailed(inv.Room, user.ID)
 		}
 		out = append(out, entry)
 	}

--- a/tests/playwright/fixtures/chat.ts
+++ b/tests/playwright/fixtures/chat.ts
@@ -22,10 +22,17 @@ export interface ChatMessage {
 //
 // `createdAt` は upstream 必須 field (ID から派生)、mk-go も #855 PR-A
 // 以降で全 chat/rooms/* endpoint が含めて返す。
+//
+// `isMuted` / `invitationExists` は upstream optional だが、mk-go は
+// handler 経由 response で常に boolean を返す (#855 PR-B 以降)。
+// owner === me の場合は両方 false (= owner は自身の room なので mute も
+// invitation も無関係)、それ以外は membership / invitation lookup の結果。
 export interface ChatRoom {
   id: string;
   createdAt: string;
   name: string;
   ownerId: string;
   description: string;
+  isMuted: boolean;
+  invitationExists: boolean;
 }

--- a/tests/playwright/specs/chat/room.spec.ts
+++ b/tests/playwright/specs/chat/room.spec.ts
@@ -103,11 +103,17 @@ test.describe('chat: rooms', () => {
     // me !== owner なので membership / invitation lookup が走り、
     // invitationExists = true (= 招待が pending)、isMuted = false (まだ
     // member ではないので mute 状態なし) になる (#855 PR-B)。
-    if (inv.room) {
-      expect(inv.room.id).toBe(room.id);
-      expect(inv.room.invitationExists).toBe(true);
-      expect(inv.room.isMuted).toBe(false);
+    // 両 backend で `room` field が必ず付く前提なので、不在は contract 違反
+    // として明示 throw で fail させる (pollForNotification / tl.find と同
+    // guard pattern)。
+    if (!inv.room) {
+      throw new Error(
+        `invitations/inbox entry for room ${room.id} did not include room field`,
+      );
     }
+    expect(inv.room.id).toBe(room.id);
+    expect(inv.room.invitationExists).toBe(true);
+    expect(inv.room.isMuted).toBe(false);
 
     // invitee が rooms/join { roomId } で room に join (= membership 確立)。
     // upstream Misskey TS は invitations/accept endpoint を持たず、invite

--- a/tests/playwright/specs/chat/room.spec.ts
+++ b/tests/playwright/specs/chat/room.spec.ts
@@ -65,6 +65,11 @@ test.describe('chat: rooms', () => {
     // 派生する必須 field、mk-go は #855 PR-A 以降で同 pattern。Date.parse で
     // 有効な timestamp として読めることを check (秒精度の drift は許容)。
     expect(Number.isFinite(Date.parse(room.createdAt))).toBe(true);
+    // owner === me で room を作成した直後なので、upstream / mk-go (#855 PR-B
+    // 以降) ともに isMuted / invitationExists は false。owner check で repo
+    // lookup が skip される設計。
+    expect(room.isMuted).toBe(false);
+    expect(room.invitationExists).toBe(false);
     // upstream の packedChatRoomSchema には `isArchived` が無いため
     // mk-go も #851 fix 以降は返さない。本 spec では archived state は
     // assert しない (= field 不在を許容)。
@@ -85,10 +90,23 @@ test.describe('chat: rooms', () => {
       i: invitee.token,
     });
     expect(inboxResp.status()).toBe(200);
-    const inbox = (await inboxResp.json()) as { id: string; roomId: string }[];
+    const inbox = (await inboxResp.json()) as {
+      id: string;
+      roomId: string;
+      room?: ChatRoom;
+    }[];
     const inv = inbox.find((x) => x.roomId === room.id);
     if (!inv) {
       throw new Error(`invitations/inbox did not contain invitation for room ${room.id}`);
+    }
+    // inbox の `room` field で invitee 視点の packRoomDetailed shape を確認:
+    // me !== owner なので membership / invitation lookup が走り、
+    // invitationExists = true (= 招待が pending)、isMuted = false (まだ
+    // member ではないので mute 状態なし) になる (#855 PR-B)。
+    if (inv.room) {
+      expect(inv.room.id).toBe(room.id);
+      expect(inv.room.invitationExists).toBe(true);
+      expect(inv.room.isMuted).toBe(false);
     }
 
     // invitee が rooms/join { roomId } で room に join (= membership 確立)。


### PR DESCRIPTION
## Summary

- #855 (chat shape の field set drift) の PR-B として、\`packRoom\` に viewer (me) 依存の \`isMuted\` / \`invitationExists\` field を追加。
- upstream の \`ChatEntityService.packRoom\` と同じ semantics: me === owner なら lookup skip + 両 false、me !== owner なら membership / invitation を eager load して値計算。
- 残 drift (\`packMessage\` の \`file\` / \`isRead\`) は PR-C で扱う。

## 主な変更点

- \`internal/api/chat/handler.go\`
  - \`packRoomDetailed(r, meID)\` method を新設。\`packRoomWithCreatedAt\` の結果に me 情報依存 field を付与。
  - \`chat/rooms/{create,show,update,owned,joined}\` と \`invitations/inbox\` の room field を \`packRoomDetailed\` 経由に置換 (me 情報がある handler 内のみ)。\`RoomsShow\` に \`middleware.GetUser\` を追加。
  - 注: list endpoint (\`RoomsOwned\` / \`RoomsJoined\` / \`InvitationsInbox\`) は per-room lookup で N 回 query が走る。upstream の hint cache 化は別 issue で扱う。
  - 注: \`packMessageDetailed\` の \`toRoom\` は eager pack 経路で \`packRoomWithCreatedAt\` のまま。room timeline message の room shape 互換は別 PR で。
- \`tests/playwright/fixtures/chat.ts\`
  - \`ChatRoom\` interface に \`isMuted: boolean\` / \`invitationExists: boolean\` を追加。
- \`tests/playwright/specs/chat/room.spec.ts\`
  - room creation 直後 (owner === me) で両 false を strict assert。
  - \`invitations/inbox\` の \`room\` field で invitee 視点 (me !== owner) の \`invitationExists = true\` / \`isMuted = false\` を strict assert。owner / invitee 両 path をカバー。

## Testing

- \`make playwright-up && make playwright-test\` (mk-go backend, 3 chat specs): **3 passed (2.2s)**
- \`make playwright-ts-up && make playwright-ts-test\` (TS backend, 3 chat specs): **3 passed (2.2s)**
- \`go test ./internal/api/chat/... ./internal/core/chat/...\`: pass

## Scope 外 (#855 PR-C で扱う)

- \`packMessage\` の \`file\` (DriveFile pack 要)
- \`packMessage\` の \`isRead\` (hint 経由 computed)
- \`packMessageDetailed\` の \`toRoom\` に me を伝搬する path

## Related

- Refs #855 (chat shape drift)
- 先行: #856 (null/false omit fix), #857 (PR-A: createdAt 追加 / reads 削除)

🤖 Generated with [Claude Code](https://claude.com/claude-code)