### PR TITLE
#855 PR-C: chat packMessage に file 追加 (Preload + DriveFile pack)

### DIFF
--- a/internal/api/chat/handler.go
+++ b/internal/api/chat/handler.go
@@ -120,13 +120,24 @@ func packMessage(m *model.ChatMessage) map[string]any {
 }
 
 // packMessageWithCreatedAt augments packMessage with createdAt parsed from the
-// message ID. createdAt 欠落だと FE 側の MkTime が `Invalid Date` を表示し、
-// 一覧では NaN/NaN になる (#692)。
+// message ID and the eager-loaded file (if any). createdAt 欠落だと FE 側の
+// MkTime が `Invalid Date` を表示し、一覧では NaN/NaN になる (#692)。
+//
+// file field は upstream packedChatMessageSchema の `file: optional/nullable
+// (DriveFile)` に対応し、m.File が Preload で eager load されている場合のみ
+// pack する (#855 PR-C)。chat repository の主要 list/find query で
+// Preload("File") を行う前提。create-to-user 直後の response は CreateMessage
+// が file を eager load しないため、file field 不在となる現状制約あり (= TS
+// upstream とは差分、follow-up issue で create response も file を含めるよう
+// 修正予定)。
 func (h *Handler) packMessageWithCreatedAt(m *model.ChatMessage) map[string]any {
 	result := packMessage(m)
 	if h.idGen != nil {
 		if t, err := h.idGen.ParseTime(m.ID); err == nil {
 			result["createdAt"] = t.UTC().Format("2006-01-02T15:04:05.000Z")
+		}
+		if m.File != nil {
+			result["file"] = entity.PackDriveFile(m.File, h.idGen)
 		}
 	}
 	return result

--- a/internal/model/chat.go
+++ b/internal/model/chat.go
@@ -30,9 +30,10 @@ type ChatMessage struct {
 	IsDelivering    bool           `gorm:"column:isDelivering;default:false" json:"isDelivering"`
 	IsDeliverFailed bool           `gorm:"column:isDeliverFailed;default:false" json:"isDeliverFailed"`
 
-	FromUser *User     `gorm:"foreignKey:FromUserID" json:"fromUser,omitempty"`
-	ToUser   *User     `gorm:"foreignKey:ToUserID" json:"toUser,omitempty"`
-	ToRoom   *ChatRoom `gorm:"foreignKey:ToRoomID" json:"toRoom,omitempty"`
+	FromUser *User      `gorm:"foreignKey:FromUserID" json:"fromUser,omitempty"`
+	ToUser   *User      `gorm:"foreignKey:ToUserID" json:"toUser,omitempty"`
+	ToRoom   *ChatRoom  `gorm:"foreignKey:ToRoomID" json:"toRoom,omitempty"`
+	File     *DriveFile `gorm:"foreignKey:FileID" json:"file,omitempty"`
 }
 
 func (ChatMessage) TableName() string { return "chat_message" }

--- a/internal/repository/chat.go
+++ b/internal/repository/chat.go
@@ -136,7 +136,7 @@ func (r *chatRepository) CreateMessage(msg *model.ChatMessage) error {
 
 func (r *chatRepository) FindMessageByID(id string) (*model.ChatMessage, error) {
 	var msg model.ChatMessage
-	if err := r.db.Preload("FromUser").Where(`"id" = ?`, id).First(&msg).Error; err != nil {
+	if err := r.db.Preload("FromUser").Preload("File").Where(`"id" = ?`, id).First(&msg).Error; err != nil {
 		return nil, err
 	}
 	return &msg, nil
@@ -144,7 +144,7 @@ func (r *chatRepository) FindMessageByID(id string) (*model.ChatMessage, error) 
 
 func (r *chatRepository) FindMessageByURI(uri string) (*model.ChatMessage, error) {
 	var msg model.ChatMessage
-	if err := r.db.Preload("FromUser").Where(`"uri" = ?`, uri).First(&msg).Error; err != nil {
+	if err := r.db.Preload("FromUser").Preload("File").Where(`"uri" = ?`, uri).First(&msg).Error; err != nil {
 		return nil, err
 	}
 	return &msg, nil
@@ -163,7 +163,7 @@ func (r *chatRepository) ListMessagesByRoom(roomID string, limit int) ([]*model.
 		limit = 20
 	}
 	var msgs []*model.ChatMessage
-	if err := r.db.Preload("FromUser").Where(`"toRoomId" = ?`, roomID).
+	if err := r.db.Preload("FromUser").Preload("File").Where(`"toRoomId" = ?`, roomID).
 		Order(`"id" DESC`).Limit(limit).Find(&msgs).Error; err != nil {
 		return nil, err
 	}
@@ -175,7 +175,7 @@ func (r *chatRepository) ListMessagesByUser(userID, otherUserID string, limit in
 		limit = 20
 	}
 	var msgs []*model.ChatMessage
-	if err := r.db.Preload("FromUser").
+	if err := r.db.Preload("FromUser").Preload("File").
 		Where(`("fromUserId" = ? AND "toUserId" = ?) OR ("fromUserId" = ? AND "toUserId" = ?)`,
 			userID, otherUserID, otherUserID, userID).
 		Order(`"id" DESC`).Limit(limit).Find(&msgs).Error; err != nil {
@@ -189,7 +189,7 @@ func (r *chatRepository) SearchMessages(userID, query string, limit int) ([]*mod
 		limit = 20
 	}
 	var msgs []*model.ChatMessage
-	if err := r.db.Preload("FromUser").
+	if err := r.db.Preload("FromUser").Preload("File").
 		Where(`("fromUserId" = ? OR "toUserId" = ?) AND "text" ILIKE ?`, userID, userID, "%"+query+"%").
 		Order(`"id" DESC`).Limit(limit).Find(&msgs).Error; err != nil {
 		return nil, err
@@ -332,7 +332,7 @@ func (r *chatRepository) ListHistory(userID string, limit int) ([]*model.ChatMes
 		return nil, nil
 	}
 	var msgs []*model.ChatMessage
-	if err := r.db.Preload("FromUser").Preload("ToUser").Preload("ToRoom").Where("id IN ?", ids).Order("id DESC").Find(&msgs).Error; err != nil {
+	if err := r.db.Preload("FromUser").Preload("ToUser").Preload("ToRoom").Preload("File").Where("id IN ?", ids).Order("id DESC").Find(&msgs).Error; err != nil {
 		return nil, err
 	}
 	return msgs, nil
@@ -369,7 +369,7 @@ func (r *chatRepository) ListUserHistory(userID string, limit int) ([]*model.Cha
 		return nil, nil
 	}
 	var msgs []*model.ChatMessage
-	if err := r.db.Preload("FromUser").Preload("ToUser").Where("id IN ?", ids).Order("id DESC").Find(&msgs).Error; err != nil {
+	if err := r.db.Preload("FromUser").Preload("ToUser").Preload("File").Where("id IN ?", ids).Order("id DESC").Find(&msgs).Error; err != nil {
 		return nil, err
 	}
 	return msgs, nil
@@ -406,7 +406,7 @@ func (r *chatRepository) ListRoomHistory(userID string, limit int) ([]*model.Cha
 		return nil, nil
 	}
 	var msgs []*model.ChatMessage
-	if err := r.db.Preload("FromUser").Preload("ToRoom").Where("id IN ?", ids).Order("id DESC").Find(&msgs).Error; err != nil {
+	if err := r.db.Preload("FromUser").Preload("ToRoom").Preload("File").Where("id IN ?", ids).Order("id DESC").Find(&msgs).Error; err != nil {
 		return nil, err
 	}
 	return msgs, nil

--- a/tests/playwright/fixtures/files.ts
+++ b/tests/playwright/fixtures/files.ts
@@ -12,3 +12,14 @@ export const tinyPNG = Buffer.from(
   'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNkYAAAAAYAAjCB0C8AAAAASUVORK5CYII=',
   'base64',
 );
+
+// drive/files/* response の最小 shape。upstream の packedDriveFileSchema
+// で必須 field のうち identity + 基本 metadata のみ含む。md5 / blurhash /
+// url / createdAt 等の詳細 field を assert する spec は本 interface を
+// extends で拡張する (#855 PR-C で chat 添付 spec から共有開始)。
+export interface DriveFile {
+  id: string;
+  name: string;
+  type: string;
+  size: number;
+}

--- a/tests/playwright/specs/chat/messages_dm_file.spec.ts
+++ b/tests/playwright/specs/chat/messages_dm_file.spec.ts
@@ -1,0 +1,120 @@
+// #855 PR-C: chat DM with file attachment の round-trip。
+//
+// upstream Misskey TS の packedChatMessageSchema は `file: optional/nullable
+// (DriveFile)` を持ち、ChatEntityService.packMessageDetailed は fileId が
+// set されている message に対し file object を eager pack する。
+//
+// 本 spec は両 backend 共通で:
+//   1. sender + receiver signup
+//   2. receiver の chatScope を `everyone` に開放
+//   3. sender が drive/files/create で tinyPNG upload (= fileId 確定)
+//   4. sender が chat/messages/create-to-user で fileId 付き DM 送信
+//   5. receiver の user-timeline で取得した message が `file` field を含み、
+//      DriveFile shape (id / name / type / size) が upload と整合する
+//
+// 注: upstream / mk-go ともに create-to-user response 自体は file を含む
+// (= packMessageDetailed が同 endpoint で使われている) が、mk-go の
+// CreateMessage 経路は file を eager load しないため create response 直後の
+// `file` 不在となる drift がある。本 spec は user-timeline (= Preload("File")
+// 済み) 経路で file shape を確認する。create response の file 包含は
+// follow-up (#855 完結後の別 issue) で扱う。
+
+import { expect, test } from '@playwright/test';
+import { callApi } from '../../fixtures/api';
+import { randomUsername, signupUser } from '../../fixtures/auth';
+import { type ChatMessage } from '../../fixtures/chat';
+import { tinyPNG } from '../../fixtures/files';
+import { resetRateLimit } from '../../fixtures/rate_limit';
+
+const baseURL = process.env.MK_BASE_URL ?? 'https://mkgo.local';
+
+interface DriveFile {
+  id: string;
+  name: string;
+  type: string;
+  size: number;
+}
+
+interface ChatMessageWithFile extends ChatMessage {
+  fileId?: string;
+  file?: DriveFile;
+}
+
+test.describe('chat: DM with file attachment', () => {
+  test.beforeAll(() => {
+    resetRateLimit();
+  });
+
+  test('A uploads a file then sends DM with fileId; B receives file shape via user-timeline', async ({
+    request,
+  }) => {
+    const sender = await signupUser(request, randomUsername('dmfA'));
+    const receiver = await signupUser(request, randomUsername('dmfB'));
+
+    // receiver の chatScope を `everyone` に開放 (#822 PR-A と同根拠)。
+    const scopeResp = await callApi(request, 'i/update', {
+      i: receiver.token,
+      chatScope: 'everyone',
+    });
+    expect(scopeResp.status()).toBeGreaterThanOrEqual(200);
+    expect(scopeResp.status()).toBeLessThan(300);
+
+    // sender が tinyPNG を drive/files/create で upload。
+    const uploadResp = await request.post(`${baseURL}/api/drive/files/create`, {
+      multipart: {
+        i: sender.token,
+        file: {
+          name: 'chat-attach.png',
+          mimeType: 'image/png',
+          buffer: tinyPNG,
+        },
+      },
+      failOnStatusCode: false,
+    });
+    expect(uploadResp.status()).toBe(200);
+    const file = (await uploadResp.json()) as DriveFile;
+    expect(typeof file.id).toBe('string');
+    expect(file.name).toBe('chat-attach.png');
+    expect(file.type).toBe('image/png');
+    expect(file.size).toBe(tinyPNG.length);
+
+    // sender が file 添付 DM 送信。
+    const text = 'attach ' + Math.random().toString(16).slice(2, 8);
+    const sendResp = await callApi(request, 'chat/messages/create-to-user', {
+      i: sender.token,
+      toUserId: receiver.id,
+      text,
+      fileId: file.id,
+    });
+    expect(sendResp.status()).toBe(200);
+    const sent = (await sendResp.json()) as ChatMessageWithFile;
+    expect(sent.fileId).toBe(file.id);
+
+    // receiver の user-timeline で取得 → file field が DriveFile shape で
+    // 含まれていることを確認 (Preload("File") 経路で eager load される)。
+    const tlResp = await callApi(request, 'chat/messages/user-timeline', {
+      i: receiver.token,
+      userId: sender.id,
+      limit: 10,
+    });
+    expect(tlResp.status()).toBe(200);
+    const tl = (await tlResp.json()) as ChatMessageWithFile[];
+
+    const found = tl.find((m) => m.id === sent.id);
+    if (!found) {
+      throw new Error(`user-timeline did not contain sent message (id=${sent.id})`);
+    }
+    expect(found.fileId).toBe(file.id);
+    // file field が DriveFile shape を持つ。upstream / mk-go (#855 PR-C) で
+    // 揃う minimal field (id / name / type / size) を strict assert。
+    if (!found.file) {
+      throw new Error(
+        `user-timeline message (id=${sent.id}) did not include file field despite fileId set`,
+      );
+    }
+    expect(found.file.id).toBe(file.id);
+    expect(found.file.name).toBe('chat-attach.png');
+    expect(found.file.type).toBe('image/png');
+    expect(found.file.size).toBe(tinyPNG.length);
+  });
+});

--- a/tests/playwright/specs/chat/messages_dm_file.spec.ts
+++ b/tests/playwright/specs/chat/messages_dm_file.spec.ts
@@ -23,17 +23,10 @@ import { expect, test } from '@playwright/test';
 import { callApi } from '../../fixtures/api';
 import { randomUsername, signupUser } from '../../fixtures/auth';
 import { type ChatMessage } from '../../fixtures/chat';
-import { tinyPNG } from '../../fixtures/files';
+import { type DriveFile, tinyPNG } from '../../fixtures/files';
 import { resetRateLimit } from '../../fixtures/rate_limit';
 
 const baseURL = process.env.MK_BASE_URL ?? 'https://mkgo.local';
-
-interface DriveFile {
-  id: string;
-  name: string;
-  type: string;
-  size: number;
-}
 
 interface ChatMessageWithFile extends ChatMessage {
   fileId?: string;


### PR DESCRIPTION
## Summary

- #855 (chat shape の field set drift) の PR-C として、\`packMessage\` に \`file\` (DriveFile object) を追加。
- chat repository の主要 query で \`Preload("File")\` を追加し、user-timeline / room-timeline 等の list endpoint で file shape を eager load する。
- 残 \`isRead\` field と create-to-user 直後の file 不在は follow-up scope。

## 主な変更点

- \`internal/model/chat.go\`
  - \`ChatMessage\` に \`File *DriveFile\` gorm relation を追加。
- \`internal/repository/chat.go\`
  - 主要 list / find query (\`FindMessageByID\` / \`FindMessageByURI\` / \`ListMessagesByRoom\` / \`ListMessagesByUser\` / \`SearchMessages\` / \`ListUserHistory\` / \`ListRoomHistory\`) に \`Preload("File")\` を追加。
- \`internal/api/chat/handler.go\`
  - \`packMessageWithCreatedAt\` で \`m.File\` が non-nil なら \`entity.PackDriveFile(m.File, h.idGen)\` で pack し \`file\` field を含める。\`packMessage\` 自体は素のまま、idGen 依存 / file pack は wrapper 側に集約 (createdAt と同 pattern)。
- \`tests/playwright/specs/chat/messages_dm_file.spec.ts\` (new):
  - drive upload → DM with \`fileId\` → user-timeline で \`file\` shape (\`id\` / \`name\` / \`type\` / \`size\`) を strict assert する round-trip spec。

## 設計上の注意点

- **create-to-user 直後の response は file 不在**: mk-go の \`CreateMessage\` が \`File\` を eager load しないため、create 応答時点では \`file\` field が含まれない。upstream は packMessageDetailed で eager pack するが mk-go の同期 path との差分は follow-up で扱う。本 spec は user-timeline 経路 (\`Preload("File")\` 済み) で file shape を確認する。
- **isRead は scope 外**: upstream の \`packedChatMessageSchema\` には \`isRead\` (optional/non-nullable) が定義されているが、\`ChatEntityService.packMessageDetailed\` では返していない。実装場面が \`packMessageLiteFor1on1\` 等の lite 系 schema の可能性があり、再調査が必要なため follow-up scope。

## Testing

- \`make playwright-up && make playwright-test\` (mk-go backend, 4 chat specs): **4 passed (2.8s)**
- \`make playwright-ts-up && make playwright-ts-test\` (TS backend, 4 chat specs): **4 passed (2.3s)**
- \`go test ./internal/api/chat/... ./internal/core/chat/... ./internal/repository/...\`: pass

## Scope 外 (follow-up issue で別途扱う)

- \`packMessage\` の \`isRead\` field 追加 (upstream の packMessageLiteFor1on1 等の lite schema 系を再調査要)
- \`create-to-user\` / \`create-to-room\` の create response 直後で file を eager load して含める path
- \`packMessageDetailed\` の \`toRoom\` に me を伝搬する path (#858 の packRoomDetailed と同 semantics)

## Related

- Refs #855 (chat shape drift)
- 先行: #856 (null/false omit fix), #857 (PR-A: createdAt + reads), #858 (PR-B: isMuted + invitationExists)

🤖 Generated with [Claude Code](https://claude.com/claude-code)