### PR TITLE
#860 PR-D: chat packMessageDetailed の me 伝搬 + create response の file eager load

### DIFF
--- a/internal/api/chat/handler.go
+++ b/internal/api/chat/handler.go
@@ -456,15 +456,7 @@ func (h *Handler) MessagesCreate(c echo.Context) error {
 	if err != nil {
 		return h.mapChatErr(c, err)
 	}
-	// CreateMessage は File を eager load しないので、fileId 付き message は
-	// File を post-fetch して response の `file` field を含めるようにする
-	// (#860)。reload に失敗した場合は fall through で file 不在のまま返す。
-	if msg.FileID != nil && msg.File == nil {
-		if reloaded, err := h.repo.FindMessageByID(msg.ID); err == nil {
-			msg = reloaded
-		}
-	}
-	return c.JSON(http.StatusOK, h.packMessageDetailed(msg, user.ID))
+	return c.JSON(http.StatusOK, h.packMessageDetailed(h.reloadIfFilePending(msg), user.ID))
 }
 
 // messagesCreateLegacy preserves pre-Phase-9.8 behaviour for callers that
@@ -479,12 +471,23 @@ func (h *Handler) messagesCreateLegacy(c echo.Context, user *model.User, text, t
 	if err := h.repo.CreateMessage(msg); err != nil {
 		return c.JSON(http.StatusInternalServerError, apierr.Error("INTERNAL_ERROR", "Internal error.", "5d37dbcb-891e-41ca-a3d6-e690c97775ac"))
 	}
-	if msg.FileID != nil && msg.File == nil {
-		if reloaded, err := h.repo.FindMessageByID(msg.ID); err == nil {
-			msg = reloaded
-		}
+	return c.JSON(http.StatusOK, h.packMessageDetailed(h.reloadIfFilePending(msg), user.ID))
+}
+
+// reloadIfFilePending re-fetches the message via FindMessageByID (which
+// preloads File) when the message has a fileId but no eager-loaded File
+// yet. CreateMessage 経路は File を Preload しないので、create response の
+// `file` field を upstream packMessageDetailed と同 shape にするための
+// post-fetch helper (#860 PR-D)。reload に失敗した場合は元の msg をその
+// まま返す (= file 不在で fall-through)。
+func (h *Handler) reloadIfFilePending(msg *model.ChatMessage) *model.ChatMessage {
+	if msg == nil || msg.FileID == nil || msg.File != nil {
+		return msg
 	}
-	return c.JSON(http.StatusOK, h.packMessageDetailed(msg, user.ID))
+	if reloaded, err := h.repo.FindMessageByID(msg.ID); err == nil {
+		return reloaded
+	}
+	return msg
 }
 
 // MessagesShow handles POST /api/chat/messages/show.

--- a/internal/api/chat/handler.go
+++ b/internal/api/chat/handler.go
@@ -195,16 +195,24 @@ func (h *Handler) packRoomDetailed(r *model.ChatRoom, meID string) map[string]an
 // FE は createdAt を `new Date(m.createdAt).getTime()` で sort key に使う
 // ので、欠損していると `NaN` になりリストが空になる。room メッセージは
 // `'room' in m` で判定して "other" のかわりに room を表示する。
-func (h *Handler) packMessageDetailed(m *model.ChatMessage) map[string]any {
+//
+// meID は viewer (request 主体) の user ID。toRoom の `isMuted` /
+// `invitationExists` を viewer 視点で計算する (#860 PR-D)。空文字列を渡した
+// 場合は packRoomDetailed が lookup を skip して両 false 固定。
+//
+// 注: upstream の packMessageDetailed は `isRead` を返さない (json-schema
+// 上 optional)。mk-go も同様に含めない。`isRead` は packMessageLite 系で
+// 返される設計と推定されるが、追加は別 issue (#860 残 scope) で扱う。
+func (h *Handler) packMessageDetailed(m *model.ChatMessage, meID string) map[string]any {
 	result := h.packMessageWithCreatedAt(m)
 	if m.ToUser != nil {
 		result["toUser"] = packUser(m.ToUser)
 	}
 	if m.ToRoom != nil {
-		result["toRoom"] = h.packRoomWithCreatedAt(m.ToRoom)
+		result["toRoom"] = h.packRoomDetailed(m.ToRoom, meID)
 		// upstream の `'room' in m` 判定に合わせて `room` alias も入れる。
 		// 旧 chat 実装ではこの key で判定していた残存 client がある。
-		result["room"] = h.packRoomWithCreatedAt(m.ToRoom)
+		result["room"] = h.packRoomDetailed(m.ToRoom, meID)
 	}
 	return result
 }
@@ -448,7 +456,15 @@ func (h *Handler) MessagesCreate(c echo.Context) error {
 	if err != nil {
 		return h.mapChatErr(c, err)
 	}
-	return c.JSON(http.StatusOK, h.packMessageWithCreatedAt(msg))
+	// CreateMessage は File を eager load しないので、fileId 付き message は
+	// File を post-fetch して response の `file` field を含めるようにする
+	// (#860)。reload に失敗した場合は fall through で file 不在のまま返す。
+	if msg.FileID != nil && msg.File == nil {
+		if reloaded, err := h.repo.FindMessageByID(msg.ID); err == nil {
+			msg = reloaded
+		}
+	}
+	return c.JSON(http.StatusOK, h.packMessageDetailed(msg, user.ID))
 }
 
 // messagesCreateLegacy preserves pre-Phase-9.8 behaviour for callers that
@@ -463,11 +479,17 @@ func (h *Handler) messagesCreateLegacy(c echo.Context, user *model.User, text, t
 	if err := h.repo.CreateMessage(msg); err != nil {
 		return c.JSON(http.StatusInternalServerError, apierr.Error("INTERNAL_ERROR", "Internal error.", "5d37dbcb-891e-41ca-a3d6-e690c97775ac"))
 	}
-	return c.JSON(http.StatusOK, h.packMessageWithCreatedAt(msg))
+	if msg.FileID != nil && msg.File == nil {
+		if reloaded, err := h.repo.FindMessageByID(msg.ID); err == nil {
+			msg = reloaded
+		}
+	}
+	return c.JSON(http.StatusOK, h.packMessageDetailed(msg, user.ID))
 }
 
 // MessagesShow handles POST /api/chat/messages/show.
 func (h *Handler) MessagesShow(c echo.Context) error {
+	user := middleware.GetUser(c)
 	var req struct {
 		MessageID string `json:"messageId"`
 	}
@@ -478,7 +500,7 @@ func (h *Handler) MessagesShow(c echo.Context) error {
 	if err != nil {
 		return c.JSON(http.StatusNotFound, apierr.Error("NO_SUCH_MESSAGE", "No such message.", "006d73c9-dada-5b5d-a0f5-00b01f70bc3c"))
 	}
-	return c.JSON(http.StatusOK, h.packMessageWithCreatedAt(msg))
+	return c.JSON(http.StatusOK, h.packMessageDetailed(msg, user.ID))
 }
 
 // MessagesUpdate handles POST /api/chat/messages/update.
@@ -574,7 +596,7 @@ func (h *Handler) Messages(c echo.Context) error {
 	}
 	result := make([]map[string]any, len(msgs))
 	for i, m := range msgs {
-		result[i] = h.packMessageWithCreatedAt(m)
+		result[i] = h.packMessageDetailed(m, user.ID)
 	}
 	return c.JSON(http.StatusOK, result)
 }
@@ -592,7 +614,7 @@ func (h *Handler) MessagesSearch(c echo.Context) error {
 	msgs, _ := h.repo.SearchMessages(user.ID, req.Query, req.Limit)
 	result := make([]map[string]any, len(msgs))
 	for i, m := range msgs {
-		result[i] = h.packMessageWithCreatedAt(m)
+		result[i] = h.packMessageDetailed(m, user.ID)
 	}
 	return c.JSON(http.StatusOK, result)
 }
@@ -787,7 +809,7 @@ func (h *Handler) UserTimeline(c echo.Context) error {
 	}
 	out := make([]map[string]any, 0, len(msgs))
 	for _, m := range msgs {
-		out = append(out, h.packMessageWithCreatedAt(m))
+		out = append(out, h.packMessageDetailed(m, user.ID))
 	}
 	return c.JSON(http.StatusOK, out)
 }
@@ -819,7 +841,7 @@ func (h *Handler) RoomTimeline(c echo.Context) error {
 	}
 	out := make([]map[string]any, 0, len(msgs))
 	for _, m := range msgs {
-		out = append(out, h.packMessageWithCreatedAt(m))
+		out = append(out, h.packMessageDetailed(m, user.ID))
 	}
 	return c.JSON(http.StatusOK, out)
 }
@@ -988,7 +1010,7 @@ func (h *Handler) History(c echo.Context) error {
 	}
 	out := make([]map[string]any, 0, len(msgs))
 	for _, m := range msgs {
-		out = append(out, h.packMessageDetailed(m))
+		out = append(out, h.packMessageDetailed(m, user.ID))
 	}
 	return c.JSON(http.StatusOK, out)
 }

--- a/internal/api/chat/handler_test.go
+++ b/internal/api/chat/handler_test.go
@@ -800,7 +800,7 @@ func TestPackMessageDetailed_FieldsPresent(t *testing.T) {
 		Reads:      pq.StringArray{},
 		Reactions:  pq.StringArray{},
 	}
-	out := h.packMessageDetailed(msg)
+	out := h.packMessageDetailed(msg, "u_from")
 	assert.NotEmpty(t, out["createdAt"], "createdAt が ID から派生して埋まること")
 	assert.NotNil(t, out["toUser"])
 	assert.NotNil(t, out["toRoom"])

--- a/tests/playwright/fixtures/chat.ts
+++ b/tests/playwright/fixtures/chat.ts
@@ -7,6 +7,7 @@
 // `toUserId` / `toRoomId` / `text` / `fileId` は optional として定義する。
 // upstream / mk-go ともに値が無い場合は JSON response から field を omit する
 // (#851 fix 後)。
+//
 export interface ChatMessage {
   id: string;
   fromUserId: string;

--- a/tests/playwright/fixtures/chat.ts
+++ b/tests/playwright/fixtures/chat.ts
@@ -7,7 +7,6 @@
 // `toUserId` / `toRoomId` / `text` / `fileId` は optional として定義する。
 // upstream / mk-go ともに値が無い場合は JSON response から field を omit する
 // (#851 fix 後)。
-//
 export interface ChatMessage {
   id: string;
   fromUserId: string;

--- a/tests/playwright/specs/chat/messages_dm_file.spec.ts
+++ b/tests/playwright/specs/chat/messages_dm_file.spec.ts
@@ -12,12 +12,11 @@
 //   5. receiver の user-timeline で取得した message が `file` field を含み、
 //      DriveFile shape (id / name / type / size) が upload と整合する
 //
-// 注: upstream / mk-go ともに create-to-user response 自体は file を含む
-// (= packMessageDetailed が同 endpoint で使われている) が、mk-go の
-// CreateMessage 経路は file を eager load しないため create response 直後の
-// `file` 不在となる drift がある。本 spec は user-timeline (= Preload("File")
-// 済み) 経路で file shape を確認する。create response の file 包含は
-// follow-up (#855 完結後の別 issue) で扱う。
+// upstream / mk-go ともに create-to-user response 自体に file を含める
+// (= packMessageDetailed 経由)。mk-go は #860 PR-D で create response 後に
+// File を post-fetch する形に整え、両 backend で同 shape を返すようにした。
+// 本 spec は create response と user-timeline 両方で file shape を strict
+// assert する。
 
 import { expect, test } from '@playwright/test';
 import { callApi } from '../../fixtures/api';
@@ -82,6 +81,15 @@ test.describe('chat: DM with file attachment', () => {
     expect(sendResp.status()).toBe(200);
     const sent = (await sendResp.json()) as ChatMessageWithFile;
     expect(sent.fileId).toBe(file.id);
+    // create response 直後でも file field が含まれることを strict assert
+    // (#860 PR-D で post-fetch するように修正)。
+    if (!sent.file) {
+      throw new Error(`create response (id=${sent.id}) did not include file field despite fileId set`);
+    }
+    expect(sent.file.id).toBe(file.id);
+    expect(sent.file.name).toBe('chat-attach.png');
+    expect(sent.file.type).toBe('image/png');
+    expect(sent.file.size).toBe(tinyPNG.length);
 
     // receiver の user-timeline で取得 → file field が DriveFile shape で
     // 含まれていることを確認 (Preload("File") 経路で eager load される)。


### PR DESCRIPTION
## Summary

- #860 (chat shape の残 drift) の handler 経路改修 2 件をまとめて扱う:
  1. \`packMessageDetailed\` の signature を \`(m, meID)\` に拡張し、\`toRoom\` を \`packRoomDetailed(toRoom, meID)\` 経由に置換。
  2. \`create-to-user\` / \`create-to-room\` の create response 直後で \`m.File\` が nil なら post-fetch して \`file\` field を含める。
- \`isRead\` field 追加は upstream の packMessageDetailed が返していないため scope 外、別 PR で扱う。

## 主な変更点

- \`internal/api/chat/handler.go\`
  - \`packMessageDetailed(m, meID string)\`: signature 拡張。\`toRoom\` / \`room\` (alias) を \`h.packRoomDetailed(toRoom, meID)\` 経由に。
  - 全 packMessageWithCreatedAt 直接 caller (\`MessagesShow\` / \`MessagesCreate\` / \`messagesCreateLegacy\` / \`UserTimeline\` / \`RoomTimeline\` / \`MessagesSearch\` / \`ListHistory\`) を \`packMessageDetailed(m, user.ID)\` 経由に統一。
  - \`MessagesShow\` に \`middleware.GetUser\` を追加 (meID を渡すため)。
  - \`MessagesCreate\` / \`messagesCreateLegacy\`: \`m.FileID != nil && m.File == nil\` なら \`h.repo.FindMessageByID(m.ID)\` で再 fetch (= Preload("File") 済み handler 経路を再利用) してから return。reload 失敗時は file 不在のまま fall-through。
- \`tests/playwright/specs/chat/messages_dm_file.spec.ts\`
  - create response の \`file\` shape (\`id\` / \`name\` / \`type\` / \`size\`) を strict assert (#860 PR-D で post-fetch が効くようになった)。
  - header コメントを drift 解消後の表現に更新。

## 設計上の注意点

- **\`isRead\` を本 PR で含めない**: upstream の \`packMessageDetailed\` は json-schema 上 \`isRead: optional\` だが実装側で返していない。実装場所は \`packMessageLiteFor1on1\` 系と推定されるが、mk-go のどの response path で含めるか再調査要。本 PR では mk-go 側に \`isRead\` を追加すると TS との shape drift が発生するため、見送って #860 の残 scope に維持。
- **packMessageDetailed 統一**: 既存 packMessageWithCreatedAt 直接 caller (= 7 endpoint) を packMessageDetailed 経由に切り替えたため、room を含む message shape が viewer 視点で一貫する。
- **MessagesCreate の reload 戦略**: 専用の Preload を追加するより既存の \`FindMessageByID\` (= Preload("File") 済み, #859 で更新) を再利用する方が DRY。fileId なし message では reload を skip するので overhead は file 添付時のみ。

## Testing

- \`make playwright-up && make playwright-test\` (mk-go backend, 4 chat specs): **4 passed (2.8s)**
- \`make playwright-ts-up && make playwright-ts-test\` (TS backend, 4 chat specs): **4 passed (2.2s)**
- \`go test ./internal/api/chat/...\`: pass

## Related

- Refs #860 (chat packMessage 残 shape drift)
- 残 scope (\`isRead\` 追加) は #860 に維持
- 先行: #859 (PR-C: file 追加 + Preload)

🤖 Generated with [Claude Code](https://claude.com/claude-code)