### PR TITLE
#821 PR-A: reactions create / delete + notes/show 反映の round-trip spec を追加

### DIFF
--- a/tests/playwright/specs/reactions/reactions.spec.ts
+++ b/tests/playwright/specs/reactions/reactions.spec.ts
@@ -82,10 +82,11 @@ test.describe('reactions: create / delete round-trip', () => {
     expect(listResp.status()).toBe(200);
     const list = (await listResp.json()) as ReactionListEntry[];
     expect(Array.isArray(list)).toBe(true);
-    const found = list.find((r) => r.user.id === reactor.id);
-    if (!found) {
-      throw new Error(`notes/reactions did not contain reactor (id=${reactor.id})`);
-    }
+    // 1 reactor / 1 reaction の context なので list は厳密に 1 件。両
+    // backend で余計な entry や欠落 drift があれば即 fail する。
+    expect(list.length).toBe(1);
+    const found = list[0];
+    expect(found.user.id).toBe(reactor.id);
     // type は upstream / mk-go ともに reaction string をそのまま返す。
     // unicode emoji は raw、custom emoji は `:name@.:` 形式 (本 spec では
     // unicode のみ assert)。

--- a/tests/playwright/specs/reactions/reactions.spec.ts
+++ b/tests/playwright/specs/reactions/reactions.spec.ts
@@ -1,0 +1,114 @@
+// #821 Phase 2 reactions spec: reactions create / delete + notes/show reflect の
+// round-trip。
+//
+// upstream Misskey TS と mk-go は両方とも:
+//   - notes/reactions/create { noteId, reaction } で reaction を付与 (204)
+//   - 付与後 notes/show で取得した note.reactions に reaction が反映される
+//     (= `{ "<reaction>": <count>, ... }` の object 形式)
+//   - notes/reactions { noteId } で reaction list (id / createdAt / user / type) を
+//     取得できる
+//   - notes/reactions/delete { noteId } で自分の reaction を取り消す (204)
+//   - 削除後 notes/show で reactions object から消える
+//
+// 本 spec は両 backend 共通で:
+//   1. user A + user B signup
+//   2. A が public note 投稿
+//   3. B が note に reaction 付与 (👍)
+//   4. notes/show で取得した note.reactions に `{ "👍": 1 }` が反映
+//   5. notes/reactions で reactor list に B が含まれる
+//   6. B が reaction 取り消し
+//   7. notes/show で取得した note.reactions から `👍` が消える
+//
+// reaction notification (= 受信側の WS / /api/i/notifications 反映) は
+// reaction.spec.ts (#847) で既に round-trip 検証済み。本 spec は reaction
+// 自体の create / delete / list / notes/show 反映に focus する。
+
+import { expect, test } from '@playwright/test';
+import { callApi } from '../../fixtures/api';
+import { randomUsername, signupUser } from '../../fixtures/auth';
+import { createNote } from '../../fixtures/notes';
+import { resetRateLimit } from '../../fixtures/rate_limit';
+
+interface ReactionListEntry {
+  id: string;
+  createdAt: string;
+  type: string;
+  user: { id: string };
+}
+
+test.describe('reactions: create / delete round-trip', () => {
+  test.beforeAll(() => {
+    resetRateLimit();
+  });
+
+  test('B reacts to A\'s note, listed in reactions, removed after delete', async ({
+    request,
+  }) => {
+    const author = await signupUser(request, randomUsername('rxA'));
+    const reactor = await signupUser(request, randomUsername('rxB'));
+
+    // author が public note 投稿。
+    const note = await createNote(request, author.token, {
+      text: 'react to me',
+      visibility: 'public',
+    });
+
+    // reactor が reaction 付与 (= 標準 unicode emoji で deterministic に)。
+    const reactResp = await callApi(request, 'notes/reactions/create', {
+      i: reactor.token,
+      noteId: note.id,
+      reaction: '👍',
+    });
+    expect(reactResp.status()).toBeGreaterThanOrEqual(200);
+    expect(reactResp.status()).toBeLessThan(300);
+
+    // notes/show で reactions object に反映されることを assert。
+    const showResp = await callApi(request, 'notes/show', {
+      i: author.token,
+      noteId: note.id,
+    });
+    expect(showResp.status()).toBe(200);
+    const shown = (await showResp.json()) as { reactions: Record<string, number> };
+    // reactions field は両 backend で `{ "<reaction>": <count> }` の object。
+    // unicode emoji は文字列のまま key として扱われる。
+    expect(shown.reactions['👍']).toBe(1);
+
+    // notes/reactions で reactor list 取得。
+    const listResp = await callApi(request, 'notes/reactions', {
+      i: author.token,
+      noteId: note.id,
+      limit: 10,
+    });
+    expect(listResp.status()).toBe(200);
+    const list = (await listResp.json()) as ReactionListEntry[];
+    expect(Array.isArray(list)).toBe(true);
+    const found = list.find((r) => r.user.id === reactor.id);
+    if (!found) {
+      throw new Error(`notes/reactions did not contain reactor (id=${reactor.id})`);
+    }
+    // type は upstream / mk-go ともに reaction string をそのまま返す。
+    // unicode emoji は raw、custom emoji は `:name@.:` 形式 (本 spec では
+    // unicode のみ assert)。
+    expect(found.type).toBe('👍');
+    expect(Number.isFinite(Date.parse(found.createdAt))).toBe(true);
+
+    // reactor が reaction 取り消し。
+    const delResp = await callApi(request, 'notes/reactions/delete', {
+      i: reactor.token,
+      noteId: note.id,
+    });
+    expect(delResp.status()).toBeGreaterThanOrEqual(200);
+    expect(delResp.status()).toBeLessThan(300);
+
+    // notes/show で reactions object から消えていることを assert。
+    const afterResp = await callApi(request, 'notes/show', {
+      i: author.token,
+      noteId: note.id,
+    });
+    expect(afterResp.status()).toBe(200);
+    const after = (await afterResp.json()) as { reactions: Record<string, number> };
+    // 取り消し後は reactions object に該当 key が無い。upstream / mk-go と
+    // もに 0 件 reaction の場合 key 自体を omit する想定。
+    expect(after.reactions['👍']).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## Summary

- #821 (reactions Playwright spec) の最初の PR (PR-A) として、reaction の create / delete / list / notes/show 反映の round-trip を 1 spec で検証。
- 両 backend (mk-go / Misskey TS upstream) で挙動が揃っていることを確認。
- reaction notification は #847 で round-trip 検証済みなので scope 外。

## 主な変更点

- \`tests/playwright/specs/reactions/reactions.spec.ts\` (new):
  シナリオ:
  1. author + reactor signup
  2. author が public note 投稿
  3. reactor が \`notes/reactions/create\` で reaction 付与 (\`👍\`)
  4. \`notes/show\` で取得した \`note.reactions\` に \`{ "👍": 1 }\` が反映
  5. \`notes/reactions\` で reactor list (\`id\` / \`createdAt\` / \`type\` / \`user\`) を取得し reactor が含まれることを strict assert
  6. reactor が \`notes/reactions/delete\` で reaction 取り消し
  7. \`notes/show\` で \`reactions\` object から \`👍\` key が omit される

## Testing

- \`make playwright-up && make playwright-test\` (mk-go backend, 1 reactions spec): **1 passed (1.1s)**
- \`make playwright-ts-up && make playwright-ts-test\` (TS backend, 1 reactions spec): **1 passed (1.2s)**

## Scope 外 (#821 follow-up)

- 同 user の reaction 置き換え挙動 (Misskey 仕様: 1 user 1 reaction、2 度目で 1 個目が unset)
- カスタム絵文字 reaction (\`:emoji_name@.:\` 形式) の id 解決と shape

## Related

- Refs #821 (reactions Playwright spec)
- 関連 spec: \`tests/playwright/specs/notifications/reaction.spec.ts\` (#847、reaction notification 経路)

🤖 Generated with [Claude Code](https://claude.com/claude-code)