### PR TITLE
#821 PR-C: 違う reaction での置き換え挙動 spec + emoji 正規化 drift 検出 (#864)

### DIFF
--- a/tests/playwright/specs/reactions/reactions_different.spec.ts
+++ b/tests/playwright/specs/reactions/reactions_different.spec.ts
@@ -1,0 +1,82 @@
+// #821 PR-C reactions spec: 違う reaction を 2 度目に送ったときの挙動。
+//
+// PR-B (#863) で同じ reaction を 2 度送ると ALREADY_REACTED で reject される
+// ことを spec 化した。本 spec はその延長として、違う reaction (例: `👍` の
+// 後に `❤️`) を送った時の挙動を両 backend で観察し共通仕様を確認した:
+//
+//   - 両 backend ともに 204 で受け入れ (= 置き換え挙動)
+//   - 1 個目の reaction (`👍`) は unset され、2 個目 (heart) のみ残る
+//   - reactions object は 1 key / count=1 になる
+//
+// 観察した drift (両 backend で挙動はほぼ同じだが reaction 文字列が
+// variation selector の有無で揃わない):
+//   - mk-go: `'❤️'` (variation selector `\ufe0f` 付きで保存)
+//   - upstream TS: `'❤'` (variation selector を strip して normalize)
+//
+// 本 spec は両 backend での「置き換え」挙動を strict 確認しつつ、heart の
+// variation selector drift は emoji 正規化の別 issue として切り出して trace
+// する。本 spec の assertion は variation selector を吸収する形 (= heart
+// から始まる key を 1 件確認) に整える。
+
+// variation selector drift は #864 で別途 fix 予定。fix 完了後は本 spec の
+// `startsWith('❤')` を strict (`'❤'` 固定) に置き換える。
+
+import { expect, test } from '@playwright/test';
+import { callApi } from '../../fixtures/api';
+import { randomUsername, signupUser } from '../../fixtures/auth';
+import { createNote } from '../../fixtures/notes';
+import { resetRateLimit } from '../../fixtures/rate_limit';
+
+test.describe('reactions: different-reaction replay (replaced, not duplicated)', () => {
+  test.beforeAll(() => {
+    resetRateLimit();
+  });
+
+  test('B reacts with thumbs-up then heart; first is unset, only heart remains', async ({
+    request,
+  }) => {
+    const author = await signupUser(request, randomUsername('rdA'));
+    const reactor = await signupUser(request, randomUsername('rdB'));
+
+    const note = await createNote(request, author.token, {
+      text: 'react diff',
+      visibility: 'public',
+    });
+
+    // 1 個目: `👍` 付与 → 204。
+    const first = await callApi(request, 'notes/reactions/create', {
+      i: reactor.token,
+      noteId: note.id,
+      reaction: '👍',
+    });
+    expect(first.status()).toBeGreaterThanOrEqual(200);
+    expect(first.status()).toBeLessThan(300);
+
+    // 2 個目: 違う `❤️` を送る → 両 backend で 204 で受け入れ (置き換え)。
+    const second = await callApi(request, 'notes/reactions/create', {
+      i: reactor.token,
+      noteId: note.id,
+      reaction: '❤️',
+    });
+    expect(second.status()).toBeGreaterThanOrEqual(200);
+    expect(second.status()).toBeLessThan(300);
+
+    // 最終 state: 1 個目の `👍` は unset、2 個目の heart のみ残る。
+    const showResp = await callApi(request, 'notes/show', {
+      i: author.token,
+      noteId: note.id,
+    });
+    expect(showResp.status()).toBe(200);
+    const shown = (await showResp.json()) as { reactions: Record<string, number> };
+    // 1 reactor / 1 reaction なので reactions object は 1 key のみ。
+    expect(Object.keys(shown.reactions)).toHaveLength(1);
+    // 1 個目の reaction (`👍`) は置き換えで unset されているので存在しない。
+    expect(shown.reactions['👍']).toBeUndefined();
+    // 2 個目の heart は variation selector の drift がある (mk-go: `❤️`,
+    // TS: `❤`)。emoji 正規化の drift fix は別 issue で扱う scope のため、
+    // 本 spec では heart の prefix で吸収して count = 1 を strict 確認。
+    const newKey = Object.keys(shown.reactions)[0];
+    expect(newKey.startsWith('❤')).toBe(true);
+    expect(shown.reactions[newKey]).toBe(1);
+  });
+});

--- a/tests/playwright/specs/reactions/reactions_different.spec.ts
+++ b/tests/playwright/specs/reactions/reactions_different.spec.ts
@@ -8,18 +8,11 @@
 //   - 1 個目の reaction (`👍`) は unset され、2 個目 (heart) のみ残る
 //   - reactions object は 1 key / count=1 になる
 //
-// 観察した drift (両 backend で挙動はほぼ同じだが reaction 文字列が
-// variation selector の有無で揃わない):
-//   - mk-go: `'❤️'` (variation selector `\ufe0f` 付きで保存)
-//   - upstream TS: `'❤'` (variation selector を strip して normalize)
-//
-// 本 spec は両 backend での「置き換え」挙動を strict 確認しつつ、heart の
-// variation selector drift は emoji 正規化の別 issue として切り出して trace
-// する。本 spec の assertion は variation selector を吸収する形 (= heart
-// から始まる key を 1 件確認) に整える。
-
-// variation selector drift は #864 で別途 fix 予定。fix 完了後は本 spec の
-// `startsWith('❤')` を strict (`'❤'` 固定) に置き換える。
+// 同時に検出した drift (#864 で fix 予定): mk-go は `❤️` (variation selector
+// `\ufe0f` 付き) を保存、upstream TS は `❤` に normalize する。本 spec は
+// `startsWith('❤')` で variation selector の有無を吸収して「置き換え」挙動
+// 自体を strict 確認する。#864 fix 完了後は strict 文字列比較 (`'❤'` 固定)
+// に置き換える follow-up を予定。
 
 import { expect, test } from '@playwright/test';
 import { callApi } from '../../fixtures/api';


### PR DESCRIPTION
## Summary

- #821 PR-A (#862) / PR-B (#863) に続き、違う reaction を 2 度目に送ったときの両 backend 挙動を実機観察 + spec 化。
- **両 backend ともに置き換え挙動** (= 1 個目を unset、2 個目を set) で 204 受け入れが共通仕様であることを spec で担保。
- 観察過程で variation selector 正規化 drift を検出、別 issue (#864) として切り出し。

## 実機観察結果

| step | mk-go | upstream TS |
|---|---|---|
| 1st create (\`👍\`) | 204 | 204 |
| 2nd create (\`❤️\`) | 204 (置き換え) | 204 (置き換え) |
| notes/show \`reactions\` | \`{ '❤️': 1 }\` | \`{ '❤': 1 }\` |

**drift**: heart の reaction key の variation selector (\`\ufe0f\`) が mk-go では保持、TS では strip されて normalize される。emoji 正規化の drift として **#864** で別途 fix 予定。

## 主な変更点

- \`tests/playwright/specs/reactions/reactions_different.spec.ts\` (new):
  - 1 個目 \`👍\` 付与 → 204
  - 2 個目 \`❤️\` 付与 → 204 (置き換え)
  - notes/show で 1 key / count 1 / \`👍\` 不在 / heart prefix を strict 確認
  - heart の variation selector drift は \`startsWith('❤')\` で吸収 (#864 fix 後に strict 化)

## Testing

- \`make playwright-up && make playwright-test\` (mk-go backend, 3 reactions specs): **3 passed (1.9s)**
- \`make playwright-ts-up && make playwright-ts-test\` (TS backend, 3 reactions specs): **3 passed (1.7s)**

## Related

- Refs #821 (reactions Playwright spec)
- 先行: #862 (PR-A: CRUD), #863 (PR-B: same-reaction lifecycle)
- 検出 drift: #864 (emoji 正規化、variation selector の strip)

🤖 Generated with [Claude Code](https://claude.com/claude-code)