### PR TITLE
Fix #864: reaction emoji の variation selector を normalize で strip

### DIFF
--- a/internal/core/reaction/reaction_service.go
+++ b/internal/core/reaction/reaction_service.go
@@ -4,6 +4,7 @@ package reaction
 import (
 	"errors"
 	"regexp"
+	"strings"
 	"time"
 
 	"github.com/shiroha-a/mk/internal/core/note"
@@ -369,7 +370,19 @@ func (s *Service) normalizeReaction(raw string, actorHost *string) string {
 		// 見つからなければFallbackにする
 		return FallbackReaction
 	}
-	return raw
+	// Unicode emoji は variation selector (U+FE0F) を strip して upstream
+	// Misskey TS と同じ canonical form に揃える (#864)。同じ emoji の異なる
+	// encode (例: U+2764 と U+2764 + U+FE0F) を 1 つの key として扱う。
+	return stripVariationSelector(raw)
+}
+
+// stripVariationSelector removes Unicode emoji variation selector (U+FE0F)
+// from the input. emoji-style 表示用の variation selector は実体の emoji
+// codepoint を変えないため、reaction key の正規化として safe に削除できる。
+// upstream Misskey TS は同様の正規化を行うため、両 backend の reaction
+// 文字列を揃えるのに必要 (#864)。
+func stripVariationSelector(s string) string {
+	return strings.ReplaceAll(s, "\ufe0f", "")
 }
 
 // localCanonicalPattern matches the canonical local emoji form `:name@.:`.

--- a/internal/core/reaction/reaction_service_test.go
+++ b/internal/core/reaction/reaction_service_test.go
@@ -82,6 +82,25 @@ func TestService_Create_LegacyTranslation(t *testing.T) {
 	assert.Equal(t, "👍", r)
 }
 
+// TestService_Create_VariationSelectorStripped covers the #864 fix where
+// Unicode emoji variation selector (U+FE0F) is stripped during normalization
+// so that mk-go saves the same canonical form as upstream Misskey TS.
+func TestService_Create_VariationSelectorStripped(t *testing.T) {
+	svc, repo, reactRepo, _, _ := newService(t)
+	seedNote(repo, "n1", "author", model.NoteVisibilityPublic)
+	// "\u2764\ufe0f" (= "❤️" with variation selector) should be normalized
+	// to "\u2764" (= "❤" without VS-16).
+	r, err := svc.Create(&model.User{ID: "viewer"}, "n1", "\u2764\ufe0f")
+	require.NoError(t, err)
+	assert.Equal(t, "\u2764", r)
+	require.Len(t, reactRepo.Reactions, 1)
+	// reactRepo.Reactions は id-keyed map なので、唯一の entry の Reaction
+	// 文字列が strip 後の `❤` (= U+2764) になっていることを確認。
+	for _, rec := range reactRepo.Reactions {
+		assert.Equal(t, "\u2764", rec.Reaction)
+	}
+}
+
 func TestService_Create_AlreadyReactedSame(t *testing.T) {
 	svc, repo, _, _, _ := newService(t)
 	seedNote(repo, "n1", "author", model.NoteVisibilityPublic)

--- a/tests/playwright/specs/reactions/reactions_different.spec.ts
+++ b/tests/playwright/specs/reactions/reactions_different.spec.ts
@@ -8,11 +8,9 @@
 //   - 1 個目の reaction (`👍`) は unset され、2 個目 (heart) のみ残る
 //   - reactions object は 1 key / count=1 になる
 //
-// 同時に検出した drift (#864 で fix 予定): mk-go は `❤️` (variation selector
-// `\ufe0f` 付き) を保存、upstream TS は `❤` に normalize する。本 spec は
-// `startsWith('❤')` で variation selector の有無を吸収して「置き換え」挙動
-// 自体を strict 確認する。#864 fix 完了後は strict 文字列比較 (`'❤'` 固定)
-// に置き換える follow-up を予定。
+// emoji variation selector の正規化 (#864 で fix 済) により、両 backend
+// ともに reaction 文字列を `'❤'` (variation selector strip) で保存する。
+// 本 spec は heart の reaction key を `'❤'` で strict 比較する。
 
 import { expect, test } from '@playwright/test';
 import { callApi } from '../../fixtures/api';
@@ -62,14 +60,10 @@ test.describe('reactions: different-reaction replay (replaced, not duplicated)',
     expect(showResp.status()).toBe(200);
     const shown = (await showResp.json()) as { reactions: Record<string, number> };
     // 1 reactor / 1 reaction なので reactions object は 1 key のみ。
-    expect(Object.keys(shown.reactions)).toHaveLength(1);
-    // 1 個目の reaction (`👍`) は置き換えで unset されているので存在しない。
-    expect(shown.reactions['👍']).toBeUndefined();
-    // 2 個目の heart は variation selector の drift がある (mk-go: `❤️`,
-    // TS: `❤`)。emoji 正規化の drift fix は別 issue で扱う scope のため、
-    // 本 spec では heart の prefix で吸収して count = 1 を strict 確認。
-    const newKey = Object.keys(shown.reactions)[0];
-    expect(newKey.startsWith('❤')).toBe(true);
-    expect(shown.reactions[newKey]).toBe(1);
+    // 両 backend で variation selector を strip した `'❤'` で保存される
+    // (#864 fix 後)。Object.keys 全体を strict 比較することで余計な key の
+    // drift と heart の表記揺れを同時に検出する。
+    expect(Object.keys(shown.reactions)).toEqual(['❤']);
+    expect(shown.reactions['❤']).toBe(1);
   });
 });


### PR DESCRIPTION
## Summary

- #821 PR-C (#865) で検出した emoji variation selector 正規化 drift を fix。
- upstream Misskey TS は reaction string 保存時に variation selector (\`\ufe0f\`) を strip するが、mk-go は raw のまま保存していたため、\`❤️\` と \`❤\` が別 reaction として扱われる drift があった。
- 関連 spec の \`startsWith('❤')\` 吸収を strict 文字列比較 (\`'❤'\`) に置き換え。

## 主な変更点

- \`internal/core/reaction/reaction_service.go\`
  - \`normalizeReaction\` の Unicode emoji path で \`stripVariationSelector\` を呼んで variation selector を削除。
  - \`stripVariationSelector\` helper を新設。\`strings.ReplaceAll(s, "\ufe0f", "")\` のシンプルな実装で、emoji codepoint そのものは変えない (=表示意味は保持)。
  - custom emoji 経路 (\`:name@host:\`) は touch しない (= variation selector を含まないため)。
- \`tests/playwright/specs/reactions/reactions_different.spec.ts\`
  - heart の reaction key を \`'❤'\` で strict 文字列比較に置き換え。\`Object.keys(shown.reactions).toEqual(['❤'])\` で余計な key と表記揺れを同時検出。
  - header docstring を fix 済の表現に更新。

## Testing

- \`make playwright-up && make playwright-test\` (mk-go backend, 3 reactions specs): **3 passed (1.9s)**
- \`make playwright-ts-up && make playwright-ts-test\` (TS backend, 3 reactions specs): **3 passed (1.9s)**
- \`go test ./internal/core/reaction/... ./internal/api/notes/...\`: pass

## Related

- Closes #864 (emoji variation selector 正規化 drift)
- 検出 PR: #865 (#821 PR-C)

🤖 Generated with [Claude Code](https://claude.com/claude-code)