### PR TITLE
#824 PR-A: admin/emoji/add + custom emoji reaction round-trip spec を追加 (drift fix 含む)

### DIFF
--- a/internal/api/admin/handler.go
+++ b/internal/api/admin/handler.go
@@ -1361,10 +1361,18 @@ func (h *Handler) RolesUpdateDefaultPolicies(c echo.Context) error {
 func (h *Handler) SetEmojiRepo(r repository.EmojiRepository) { h.emojiRepo = r }
 
 // EmojiAdd handles POST /api/admin/emoji/add.
+//
+// upstream Misskey TS は `fileId` を必須として drive 経由でしか emoji を
+// 登録できない設計だが、mk-go は legacy で `url` 直接受けも維持する。両 path
+// をサポートして drop-in 互換を保つ:
+//   - `fileId` 指定時: drive_file から URL を resolve して保存 (= upstream 互換)
+//   - `url` 直接指定時: そのまま保存 (legacy)
+//   - 両方なし: 400 INVALID_PARAM
 func (h *Handler) EmojiAdd(c echo.Context) error {
 	var req struct {
-		Name string `json:"name"`
-		URL  string `json:"url"`
+		Name   string `json:"name"`
+		URL    string `json:"url"`
+		FileID string `json:"fileId"`
 	}
 	if err := c.Bind(&req); err != nil || req.Name == "" {
 		return c.JSON(http.StatusBadRequest, apierr.Error("INVALID_PARAM", "name is required.", "3d81ceae-475f-4600-b2a8-2bc116157532"))
@@ -1372,11 +1380,22 @@ func (h *Handler) EmojiAdd(c echo.Context) error {
 	if h.emojiRepo == nil {
 		return c.JSON(http.StatusInternalServerError, apierr.Error("INTERNAL_ERROR", "Internal error.", "5d37dbcb-891e-41ca-a3d6-e690c97775ac"))
 	}
+	url := req.URL
+	if url == "" && req.FileID != "" && h.driveFileRepo != nil {
+		f, err := h.driveFileRepo.FindByID(req.FileID)
+		if err != nil {
+			return c.JSON(http.StatusNotFound, apierr.Error("NO_SUCH_FILE", "No such file.", "fc46b5a4-6b92-4c33-ac66-b806659bb5cf"))
+		}
+		url = f.URL
+	}
+	if url == "" {
+		return c.JSON(http.StatusBadRequest, apierr.Error("INVALID_PARAM", "url or fileId is required.", "3d81ceae-475f-4600-b2a8-2bc116157532"))
+	}
 	e := &model.Emoji{
 		ID:          h.idGen.Generate(time.Now()),
 		Name:        req.Name,
-		OriginalURL: req.URL,
-		PublicURL:   req.URL,
+		OriginalURL: url,
+		PublicURL:   url,
 	}
 	if err := h.emojiRepo.Create(e); err != nil {
 		return c.JSON(http.StatusInternalServerError, apierr.Error("INTERNAL_ERROR", "Internal error.", "5d37dbcb-891e-41ca-a3d6-e690c97775ac"))

--- a/tests/playwright/specs/emoji/custom_emoji_reaction.spec.ts
+++ b/tests/playwright/specs/emoji/custom_emoji_reaction.spec.ts
@@ -56,7 +56,8 @@ test.describe('emoji: custom emoji add + reaction round-trip', () => {
 
     // upstream Misskey TS は admin/emoji/add で fileId を必須とするため、
     // 先に drive/files/create で image を upload して fileId を取得する。
-    // mk-go も #864 同 PR で fileId 受け付けに対応。
+    // mk-go も #824 PR-A で fileId 受け付けに対応 (= 本 spec と同 PR で
+    // handler 拡張)。
     const uploadResp = await request.post(`${baseURL}/api/drive/files/create`, {
       multipart: {
         i: root.token,

--- a/tests/playwright/specs/emoji/custom_emoji_reaction.spec.ts
+++ b/tests/playwright/specs/emoji/custom_emoji_reaction.spec.ts
@@ -1,0 +1,115 @@
+// #824 PR-A emoji spec: admin/emoji/add で custom emoji を登録し、
+// その emoji を note に reaction として付与する round-trip。
+//
+// upstream Misskey TS と mk-go は両方とも:
+//   - admin/emoji/add (admin only) で custom emoji を登録、200 + 登録 emoji
+//     を return
+//   - 登録した emoji は notes/reactions/create で `:name:` (host 省略) で
+//     付与でき、サーバーは `:name@.:` (canonical local form) に normalize
+//   - notes/show で取得した note.reactions object の key も canonical form
+//     `:name@.:`、value は付与数
+//
+// upstream は admin/emoji/add で `fileId` (drive 経由) を必須としている。
+// mk-go は legacy で `url` 直接受けも維持しつつ、本 PR で `fileId` 受け付け
+// path を追加して両 backend で同じ flow が動く。
+//
+// 本 spec は両 backend 共通で:
+//   1. globalSetup が用意した root (admin) credentials を読み込む
+//   2. root が drive/files/create で tinyPNG を upload (= fileId 取得)
+//   3. admin が `fileId` 経由で custom emoji を登録
+//   4. reactor user signup
+//   5. root が public note 投稿
+//   6. reactor が note に `:<name>:` reaction → サーバー normalize
+//   7. notes/show で reactions に `:<name>@.:` が 1 件反映
+//
+// これで #821 残 scope (カスタム絵文字 reaction の id 解決と shape 確認) も
+// 派生でカバーされる。
+
+import { readFileSync } from 'node:fs';
+import { expect, test } from '@playwright/test';
+import { callApi } from '../../fixtures/api';
+import { randomUsername, signupUser } from '../../fixtures/auth';
+import { tinyPNG } from '../../fixtures/files';
+import { createNote } from '../../fixtures/notes';
+import { resetRateLimit } from '../../fixtures/rate_limit';
+
+const baseURL = process.env.MK_BASE_URL ?? 'https://mkgo.local';
+
+interface RootFixture {
+  id: string;
+  token: string;
+  username: string;
+}
+
+test.describe('emoji: custom emoji add + reaction round-trip', () => {
+  test.beforeAll(() => {
+    resetRateLimit();
+  });
+
+  test('admin adds custom emoji and reactor uses :name: which normalizes to :name@.:', async ({
+    request,
+  }) => {
+    const root: RootFixture = JSON.parse(readFileSync('.auth/root.json', 'utf-8'));
+
+    // global で衝突しないよう random suffix 付き name を生成。
+    const emojiName = 'spec_emoji_' + Math.random().toString(16).slice(2, 8);
+
+    // upstream Misskey TS は admin/emoji/add で fileId を必須とするため、
+    // 先に drive/files/create で image を upload して fileId を取得する。
+    // mk-go も #864 同 PR で fileId 受け付けに対応。
+    const uploadResp = await request.post(`${baseURL}/api/drive/files/create`, {
+      multipart: {
+        i: root.token,
+        file: {
+          name: emojiName + '.png',
+          mimeType: 'image/png',
+          buffer: tinyPNG,
+        },
+      },
+      failOnStatusCode: false,
+    });
+    expect(uploadResp.status()).toBe(200);
+    const uploaded = (await uploadResp.json()) as { id: string };
+
+    // admin が fileId 経由で custom emoji を追加。
+    const addResp = await callApi(request, 'admin/emoji/add', {
+      i: root.token,
+      name: emojiName,
+      fileId: uploaded.id,
+    });
+    expect(addResp.status()).toBe(200);
+    const emoji = (await addResp.json()) as { id: string };
+    expect(typeof emoji.id).toBe('string');
+    expect(emoji.id.length).toBeGreaterThan(0);
+
+    const reactor = await signupUser(request, randomUsername('emR'));
+
+    // root が public note 投稿。
+    const note = await createNote(request, root.token, {
+      text: 'react with custom',
+      visibility: 'public',
+    });
+
+    // reactor が `:name:` (host 省略) で reaction 付与 → サーバーで
+    // `:name@.:` に normalize される。
+    const reactResp = await callApi(request, 'notes/reactions/create', {
+      i: reactor.token,
+      noteId: note.id,
+      reaction: ':' + emojiName + ':',
+    });
+    expect(reactResp.status()).toBeGreaterThanOrEqual(200);
+    expect(reactResp.status()).toBeLessThan(300);
+
+    // notes/show で取得した reactions object に canonical form
+    // `:<name>@.:` が 1 件反映されている。
+    const showResp = await callApi(request, 'notes/show', {
+      i: root.token,
+      noteId: note.id,
+    });
+    expect(showResp.status()).toBe(200);
+    const shown = (await showResp.json()) as { reactions: Record<string, number> };
+    const canonicalKey = ':' + emojiName + '@.:';
+    expect(Object.keys(shown.reactions)).toEqual([canonicalKey]);
+    expect(shown.reactions[canonicalKey]).toBe(1);
+  });
+});


### PR DESCRIPTION
## Summary

- #824 (emoji Playwright spec) の最初の PR (PR-A) として、admin/emoji/add で custom emoji を登録し、その emoji を note に reaction として付与する round-trip を検証。
- 両 backend (mk-go / Misskey TS upstream) で同 flow が動くよう mk-go の handler を拡張 (drift fix 同梱)。
- これで #821 残 scope (カスタム絵文字 reaction の id 解決と shape 確認) も派生でカバー。

## 検出した drift と fix

upstream Misskey TS は \`admin/emoji/add\` で \`fileId\` (drive upload 経由) を必須とするが、mk-go は legacy で \`url\` 直接受けの構造で \`fileId\` 受けを持っていなかった。本 PR で mk-go の handler を拡張し両 path をサポート:

- \`fileId\` 指定時: \`driveFileRepo.FindByID\` で URL を resolve して保存 (= upstream 互換)
- \`url\` 直接指定時: そのまま保存 (legacy 互換)
- 両方なし: 400 \`INVALID_PARAM\`
- \`fileId\` 指定で drive 不在: 404 \`NO_SUCH_FILE\` (= upstream 互換 error code)

## 主な変更点

- \`internal/api/admin/handler.go\` の \`EmojiAdd\`:
  - request struct に \`FileID string\` を追加。
  - \`fileId\` 指定時の drive resolve logic + 不在 error path。
  - docstring で「両 path サポート」と「上流互換性の意図」を明示。
- \`tests/playwright/specs/emoji/custom_emoji_reaction.spec.ts\` (new):
  - root が \`drive/files/create\` で tinyPNG upload → \`fileId\` 取得
  - root が \`admin/emoji/add\` で fileId 経由登録
  - reactor signup → root が public note 投稿
  - reactor が \`:name:\` reaction → server で \`:name@.:\` normalize
  - \`notes/show\` で \`Object.keys(reactions).toEqual([':name@.:'])\` strict 確認

## Testing

- \`make playwright-up && make playwright-test\` (mk-go backend, 1 emoji spec): **1 passed (1.4s)**
- \`make playwright-ts-up && make playwright-ts-test\` (TS backend, 1 emoji spec): **1 passed (1.0s)**
- \`go test ./internal/api/admin/...\`: pass

## Related

- Refs #824 (emoji Playwright spec)
- 派生 cover: #821 残 scope (custom emoji reaction)

🤖 Generated with [Claude Code](https://claude.com/claude-code)