### PR TITLE
#821 PR-D: users/reactions 本実装 + spec 追加 (#821 close)

### DIFF
--- a/internal/api/users/handler.go
+++ b/internal/api/users/handler.go
@@ -60,7 +60,12 @@ type Handler struct {
 }
 
 // SetUserRepo wires a UserRepository so users/notes filters out notes that
-// match the viewer's hardMutedWords (#787).
+// match the viewer's hardMutedWords (#787) and so users/reactions can run
+// the IS_REMOTE_USER / REACTIONS_NOT_PUBLIC access control (#821 PR-D).
+// 本番では必ず wire される (router.go で setupRoutes 時に呼ばれる)。
+// unwired の場合 users/reactions は access control を skip して
+// noteReactionRepo の有無に応じて空配列か list を返す test 互換 path に
+// 落ちる (= production 影響なし、test 用 fall-through)。
 func (h *Handler) SetUserRepo(r repository.UserRepository) {
 	h.userRepo = r
 }

--- a/internal/api/users/handler.go
+++ b/internal/api/users/handler.go
@@ -54,12 +54,21 @@ type Handler struct {
 	// userRepo は users/notes / users/search-by-username-and-host 経由で
 	// 表示する note list の hardMutedWords filter (#787) に使う。
 	userRepo repository.UserRepository
+	// noteReactionRepo は users/reactions endpoint で reactor 視点の reaction
+	// list を取得するために使う (#821 PR-D)。
+	noteReactionRepo repository.NoteReactionRepository
 }
 
 // SetUserRepo wires a UserRepository so users/notes filters out notes that
 // match the viewer's hardMutedWords (#787).
 func (h *Handler) SetUserRepo(r repository.UserRepository) {
 	h.userRepo = r
+}
+
+// SetNoteReactionRepo wires the NoteReactionRepository for users/reactions
+// (= reactor 視点の reaction list、#821 PR-D)。
+func (h *Handler) SetNoteReactionRepo(r repository.NoteReactionRepository) {
+	h.noteReactionRepo = r
 }
 
 // SetNoteFieldResolver wires the shared resolver that fills Files /

--- a/internal/api/users/handler_extra.go
+++ b/internal/api/users/handler_extra.go
@@ -98,7 +98,10 @@ func (h *Handler) Reactions(c echo.Context) error {
 		req.Limit = 100
 	}
 
-	// target user lookup + remote / publicReactions check
+	// target user lookup + remote / publicReactions check.
+	// production では userRepo が必ず wire されるが、既存の handler test
+	// (TestReactions_Success 等) は userRepo を wire しないので nil guard で
+	// fall-through する (= test compat、production 影響なし)。
 	if h.userRepo != nil {
 		target, err := h.userRepo.FindByID(req.UserID)
 		if err != nil || target == nil {
@@ -118,6 +121,9 @@ func (h *Handler) Reactions(c echo.Context) error {
 	}
 
 	// reactor の reaction list を取得 (User / Note を Preload 済み)。
+	// userRepo と同じく test stub では noteReactionRepo を wire しないので、
+	// nil guard で空配列を返して既存 handler test の挙動を維持する
+	// (= 本 PR で stub から本実装に書き換えたが test 互換は保つ、#821 PR-D)。
 	if h.noteReactionRepo == nil {
 		return c.JSON(http.StatusOK, []any{})
 	}

--- a/internal/api/users/handler_extra.go
+++ b/internal/api/users/handler_extra.go
@@ -108,10 +108,14 @@ func (h *Handler) Reactions(c echo.Context) error {
 			return c.JSON(http.StatusNotFound, apierr.Error("NO_SUCH_USER", "No such user.", "27e494ba-2ac2-48e8-893b-10d4d8c2387b"))
 		}
 		// remote user は upstream でも display を制限している。
-		if target.Host != nil && *target.Host != "" {
+		// upstream TS は `host !== null` で判定するので mk-go も nil 判定に
+		// 揃える (host="" の row は実際には DB に書かれないが、揺らぎ抑止)。
+		if target.Host != nil {
 			return c.JSON(http.StatusBadRequest, apierr.Error("IS_REMOTE_USER", "Currently unavailable to display reactions of remote users.", "6b95fa98-8cf9-2350-e284-f0ffdb54a805"))
 		}
 		// self view 以外は publicReactions check。
+		// profile 行が無い (= nil) 場合は DB 列 default の `true` 扱いで
+		// fall-through する (upstream TS の getUserPolicies と同 semantics)。
 		if viewer == nil || viewer.ID != req.UserID {
 			profile := h.userService.GetProfile(req.UserID)
 			if profile != nil && !profile.PublicReactions {

--- a/internal/api/users/handler_extra.go
+++ b/internal/api/users/handler_extra.go
@@ -68,17 +68,89 @@ func (h *Handler) ReportAbuse(c echo.Context) error {
 }
 
 // Reactions handles POST /api/users/reactions.
-// ユーザーのリアクション一覧。
+//
+// upstream Misskey TS の users/reactions と同 semantics:
+//   - target user の publicReactions が false で viewer ≠ target なら
+//     403 REACTIONS_NOT_PUBLIC (= reaction history は private)。
+//   - target user が remote なら 400 IS_REMOTE_USER (mk-go では現状 local
+//     のみ対応、upstream と同じ制限)。
+//   - それ以外 (public か self view) なら reactor の reaction list を
+//     id / createdAt / type / user / note の minimal shape で返す。
+//
+// note pack は upstream の packManyWithNote (= 完全 note shape) ではなく
+// 最小 shape (id / userId / text) で start。drop-in 互換性は両 backend で
+// 同 endpoint が動くことを spec で担保する (#821 PR-D)。
 func (h *Handler) Reactions(c echo.Context) error {
+	viewer := middleware.GetUser(c)
 	var req struct {
-		UserID string `json:"userId"`
-		Limit  int    `json:"limit"`
+		UserID  string `json:"userId"`
+		Limit   int    `json:"limit"`
+		SinceID string `json:"sinceId"`
+		UntilID string `json:"untilId"`
 	}
 	if err := c.Bind(&req); err != nil || req.UserID == "" {
 		return c.JSON(http.StatusBadRequest, apierr.Error("INVALID_PARAM", "userId is required.", "3d81ceae-475f-4600-b2a8-2bc116157532"))
 	}
-	// 簡易版: 空配列を返す (リアクション履歴クエリは重いため後続で最適化)
-	return c.JSON(http.StatusOK, []any{})
+	if req.Limit <= 0 {
+		req.Limit = 10
+	}
+	if req.Limit > 100 {
+		req.Limit = 100
+	}
+
+	// target user lookup + remote / publicReactions check
+	if h.userRepo != nil {
+		target, err := h.userRepo.FindByID(req.UserID)
+		if err != nil || target == nil {
+			return c.JSON(http.StatusNotFound, apierr.Error("NO_SUCH_USER", "No such user.", "27e494ba-2ac2-48e8-893b-10d4d8c2387b"))
+		}
+		// remote user は upstream でも display を制限している。
+		if target.Host != nil && *target.Host != "" {
+			return c.JSON(http.StatusBadRequest, apierr.Error("IS_REMOTE_USER", "Currently unavailable to display reactions of remote users.", "6b95fa98-8cf9-2350-e284-f0ffdb54a805"))
+		}
+		// self view 以外は publicReactions check。
+		if viewer == nil || viewer.ID != req.UserID {
+			profile := h.userService.GetProfile(req.UserID)
+			if profile != nil && !profile.PublicReactions {
+				return c.JSON(http.StatusForbidden, apierr.Error("REACTIONS_NOT_PUBLIC", "Reactions of the user is not public.", "673a7dd2-6924-1093-e0c0-e68456ceae5c"))
+			}
+		}
+	}
+
+	// reactor の reaction list を取得 (User / Note を Preload 済み)。
+	if h.noteReactionRepo == nil {
+		return c.JSON(http.StatusOK, []any{})
+	}
+	rows, err := h.noteReactionRepo.ListByUserID(req.UserID, req.UntilID, req.SinceID, req.Limit)
+	if err != nil {
+		return c.JSON(http.StatusInternalServerError, apierr.Error("INTERNAL_ERROR", "Internal error.", "5d37dbcb-891e-41ca-a3d6-e690c97775ac"))
+	}
+
+	out := make([]map[string]any, 0, len(rows))
+	for _, r := range rows {
+		entry := map[string]any{
+			"id":   r.ID,
+			"type": r.Reaction,
+		}
+		if t, err := h.idGen.ParseTime(r.ID); err == nil {
+			entry["createdAt"] = t.UTC().Format("2006-01-02T15:04:05.000Z")
+		}
+		if r.User != nil {
+			entry["user"] = entity.PackUserLite(r.User)
+		}
+		if r.Note != nil {
+			noteEntry := map[string]any{
+				"id":     r.Note.ID,
+				"userId": r.Note.UserID,
+			}
+			if r.Note.Text != nil {
+				noteEntry["text"] = *r.Note.Text
+			}
+			entry["note"] = noteEntry
+		}
+		out = append(out, entry)
+	}
+	return c.JSON(http.StatusOK, out)
 }
 
 // FeaturedNotes handles POST /api/users/featured-notes.

--- a/internal/api/users/handler_extra_test.go
+++ b/internal/api/users/handler_extra_test.go
@@ -133,7 +133,9 @@ func TestReactions_NoSuchUser(t *testing.T) {
 	assert.Equal(t, http.StatusNotFound, rec.Code)
 }
 
-// target が remote user (host が non-empty) → 400 IS_REMOTE_USER。
+// target が remote user (host が non-nil) → 400 IS_REMOTE_USER。
+// upstream TS は `host !== null` で判定するので、host=="" の row も remote
+// 扱いになる (= mk-go も nil 判定のみ)。
 func TestReactions_RemoteUser(t *testing.T) {
 	h, userRepo, _ := newReactionsHandler(t)
 	host := "remote.example"

--- a/internal/api/users/handler_extra_test.go
+++ b/internal/api/users/handler_extra_test.go
@@ -107,6 +107,138 @@ func TestReactions_InvalidParam(t *testing.T) {
 	assert.Equal(t, http.StatusBadRequest, rec.Code)
 }
 
+// 以下 #821 PR-D で stub から本実装に書き換えた users/reactions の各 path
+// を cover する。userRepo / noteReactionRepo を wire するので
+// newExtraHandler とは別の構築 helper を使う。
+
+func newReactionsHandler(t *testing.T) (*users.Handler, *testutil.MockUserRepository, *testutil.MockNoteReactionRepository) {
+	t.Helper()
+	userRepo := testutil.NewMockUserRepository()
+	noteRepo := testutil.NewMockNoteRepository()
+	piningRepo := testutil.NewMockUserNotePiningRepository()
+	idGen, _ := id.NewGenerator("aidx")
+	userSvc := coreuser.NewService(userRepo, noteRepo, piningRepo, idGen)
+	h := users.NewHandler(userSvc, nil, noteRepo, idGen)
+	h.SetUserRepo(userRepo)
+	rxRepo := testutil.NewMockNoteReactionRepository()
+	h.SetNoteReactionRepo(rxRepo)
+	return h, userRepo, rxRepo
+}
+
+// target user が存在しない → 404 NO_SUCH_USER。
+func TestReactions_NoSuchUser(t *testing.T) {
+	h, _, _ := newReactionsHandler(t)
+	rec := postExtra(h.Reactions, `{"userId":"missing"}`, nil)
+	assert.Equal(t, http.StatusNotFound, rec.Code)
+}
+
+// target が remote user (host が non-empty) → 400 IS_REMOTE_USER。
+func TestReactions_RemoteUser(t *testing.T) {
+	h, userRepo, _ := newReactionsHandler(t)
+	host := "remote.example"
+	userRepo.Users["u_remote"] = &model.User{ID: "u_remote", Host: &host}
+	rec := postExtra(h.Reactions, `{"userId":"u_remote"}`, nil)
+	assert.Equal(t, http.StatusBadRequest, rec.Code)
+}
+
+// publicReactions=false で viewer != target → 403 REACTIONS_NOT_PUBLIC。
+func TestReactions_NotPublic(t *testing.T) {
+	h, userRepo, _ := newReactionsHandler(t)
+	userRepo.Users["u_target"] = &model.User{ID: "u_target"}
+	userRepo.Profiles["u_target"] = &model.UserProfile{UserID: "u_target", PublicReactions: false}
+	rec := postExtra(h.Reactions, `{"userId":"u_target"}`, &model.User{ID: "u_viewer"})
+	assert.Equal(t, http.StatusForbidden, rec.Code)
+}
+
+// self view (viewer == target) なら publicReactions=false でも取得可能。
+func TestReactions_SelfViewBypassesPublicReactions(t *testing.T) {
+	h, userRepo, rxRepo := newReactionsHandler(t)
+	userRepo.Users["u_self"] = &model.User{ID: "u_self"}
+	userRepo.Profiles["u_self"] = &model.UserProfile{UserID: "u_self", PublicReactions: false}
+	// reactor self の reaction を 1 件投入。User / Note を Preload 相当で
+	// セットする (mock は静的に詰めるだけ)。
+	noteText := "hi"
+	rxRepo.Reactions["rx1"] = &model.NoteReaction{
+		ID:       "rx1",
+		UserID:   "u_self",
+		NoteID:   "n1",
+		Reaction: "👍",
+		User:     &model.User{ID: "u_self", Username: "self"},
+		Note:     &model.Note{ID: "n1", UserID: "u_other", Text: &noteText},
+	}
+	rec := postExtra(h.Reactions, `{"userId":"u_self","limit":150}`, &model.User{ID: "u_self"})
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	var list []map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &list))
+	require.Len(t, list, 1)
+	entry := list[0]
+	assert.Equal(t, "rx1", entry["id"])
+	assert.Equal(t, "👍", entry["type"])
+	require.NotNil(t, entry["user"])
+	require.NotNil(t, entry["note"])
+	note, _ := entry["note"].(map[string]any)
+	assert.Equal(t, "n1", note["id"])
+	assert.Equal(t, "u_other", note["userId"])
+	assert.Equal(t, "hi", note["text"])
+}
+
+// publicReactions=true (default) で viewer != target → list を返す。
+func TestReactions_PublicReactions(t *testing.T) {
+	h, userRepo, rxRepo := newReactionsHandler(t)
+	userRepo.Users["u_pub"] = &model.User{ID: "u_pub"}
+	userRepo.Profiles["u_pub"] = &model.UserProfile{UserID: "u_pub", PublicReactions: true}
+	rxRepo.Reactions["rx2"] = &model.NoteReaction{
+		ID:       "rx2",
+		UserID:   "u_pub",
+		NoteID:   "n2",
+		Reaction: "❤",
+	}
+	rec := postExtra(h.Reactions, `{"userId":"u_pub"}`, &model.User{ID: "u_viewer"})
+	require.Equal(t, http.StatusOK, rec.Code)
+	var list []map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &list))
+	require.Len(t, list, 1)
+}
+
+// noteReactionRepo が wire されていない (= test stub 構成) なら空配列を
+// 返す互換 path を維持する。
+func TestReactions_NoteReactionRepoNotWired(t *testing.T) {
+	userRepo := testutil.NewMockUserRepository()
+	noteRepo := testutil.NewMockNoteRepository()
+	piningRepo := testutil.NewMockUserNotePiningRepository()
+	idGen, _ := id.NewGenerator("aidx")
+	userSvc := coreuser.NewService(userRepo, noteRepo, piningRepo, idGen)
+	h := users.NewHandler(userSvc, nil, noteRepo, idGen)
+	h.SetUserRepo(userRepo)
+	userRepo.Users["u_x"] = &model.User{ID: "u_x"}
+	userRepo.Profiles["u_x"] = &model.UserProfile{UserID: "u_x", PublicReactions: true}
+	// noteReactionRepo を SetNoteReactionRepo していない状態。
+	rec := postExtra(h.Reactions, `{"userId":"u_x"}`, &model.User{ID: "u_x"})
+	require.Equal(t, http.StatusOK, rec.Code)
+	var list []map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &list))
+	assert.Len(t, list, 0)
+}
+
+// noteReactionRepo.ListByUserID がエラー → 500 INTERNAL_ERROR。
+type failingListByUserIDRepo struct {
+	*testutil.MockNoteReactionRepository
+}
+
+func (f *failingListByUserIDRepo) ListByUserID(_ string, _, _ string, _ int) ([]*model.NoteReaction, error) {
+	return nil, assert.AnError
+}
+
+func TestReactions_ListError(t *testing.T) {
+	h, userRepo, _ := newReactionsHandler(t)
+	userRepo.Users["u_e"] = &model.User{ID: "u_e"}
+	userRepo.Profiles["u_e"] = &model.UserProfile{UserID: "u_e", PublicReactions: true}
+	h.SetNoteReactionRepo(&failingListByUserIDRepo{testutil.NewMockNoteReactionRepository()})
+	rec := postExtra(h.Reactions, `{"userId":"u_e"}`, &model.User{ID: "u_e"})
+	assert.Equal(t, http.StatusInternalServerError, rec.Code)
+}
+
 // --- FeaturedNotes ---
 
 func TestFeaturedNotes_Success(t *testing.T) {

--- a/internal/api/users/handler_extra_test.go
+++ b/internal/api/users/handler_extra_test.go
@@ -6,6 +6,7 @@ import (
 	"net/http/httptest"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/labstack/echo/v4"
 	"github.com/shiroha-a/mk/internal/api/users"
@@ -151,15 +152,18 @@ func TestReactions_NotPublic(t *testing.T) {
 }
 
 // self view (viewer == target) なら publicReactions=false でも取得可能。
+// あわせて Preload された User / Note が出力 entry に詰まること、
+// idGen.ParseTime で createdAt が ISO8601 形式に整形されることも check。
 func TestReactions_SelfViewBypassesPublicReactions(t *testing.T) {
 	h, userRepo, rxRepo := newReactionsHandler(t)
 	userRepo.Users["u_self"] = &model.User{ID: "u_self"}
 	userRepo.Profiles["u_self"] = &model.UserProfile{UserID: "u_self", PublicReactions: false}
-	// reactor self の reaction を 1 件投入。User / Note を Preload 相当で
-	// セットする (mock は静的に詰めるだけ)。
+	// createdAt の format check のため real aidx を使う (= ParseTime が成功)。
+	idGen, _ := id.NewGenerator("aidx")
+	rxID := idGen.Generate(time.Date(2026, 5, 7, 12, 0, 0, 0, time.UTC))
 	noteText := "hi"
-	rxRepo.Reactions["rx1"] = &model.NoteReaction{
-		ID:       "rx1",
+	rxRepo.Reactions[rxID] = &model.NoteReaction{
+		ID:       rxID,
 		UserID:   "u_self",
 		NoteID:   "n1",
 		Reaction: "👍",
@@ -173,7 +177,7 @@ func TestReactions_SelfViewBypassesPublicReactions(t *testing.T) {
 	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &list))
 	require.Len(t, list, 1)
 	entry := list[0]
-	assert.Equal(t, "rx1", entry["id"])
+	assert.Equal(t, rxID, entry["id"])
 	assert.Equal(t, "👍", entry["type"])
 	require.NotNil(t, entry["user"])
 	require.NotNil(t, entry["note"])
@@ -181,6 +185,12 @@ func TestReactions_SelfViewBypassesPublicReactions(t *testing.T) {
 	assert.Equal(t, "n1", note["id"])
 	assert.Equal(t, "u_other", note["userId"])
 	assert.Equal(t, "hi", note["text"])
+	// createdAt は ISO8601 ms 精度で出る (= 2026-05-07T12:00:00.000Z)。
+	createdAt, ok := entry["createdAt"].(string)
+	require.True(t, ok, "createdAt should be a string")
+	parsed, err := time.Parse("2006-01-02T15:04:05.000Z", createdAt)
+	require.NoError(t, err, "createdAt=%q should be ISO8601 ms", createdAt)
+	assert.Equal(t, 2026, parsed.Year())
 }
 
 // publicReactions=true (default) で viewer != target → list を返す。

--- a/internal/repository/note_reaction.go
+++ b/internal/repository/note_reaction.go
@@ -21,6 +21,10 @@ type NoteReactionRepository interface {
 	// noteIDをキーとしたmapを返す。
 	FindByUserAndNoteIDs(userID string, noteIDs []string) (map[string]*model.NoteReaction, error)
 	ListByNoteID(noteID string, untilID, sinceID string, limit int, reactions []string) ([]*model.NoteReaction, error)
+	// ListByUserID returns reactions made by the given user, with User and Note
+	// preloaded for packing. upstream Misskey TS の users/reactions endpoint
+	// 用 (reactor 視点の reaction list)。
+	ListByUserID(userID, untilID, sinceID string, limit int) ([]*model.NoteReaction, error)
 }
 
 type noteReactionRepository struct {
@@ -82,6 +86,25 @@ func (r *noteReactionRepository) ListByNoteID(noteID string, untilID, sinceID st
 	} else if len(reactions) > 1 {
 		q = q.Where("reaction IN ?", reactions)
 	}
+	if untilID != "" {
+		q = q.Where("id < ?", untilID)
+	}
+	if sinceID != "" {
+		q = q.Where("id > ?", sinceID)
+	}
+	if err := q.Order(paginationOrder(sinceID, untilID, "id")).Limit(limit).Find(&rows).Error; err != nil {
+		return nil, err
+	}
+	return rows, nil
+}
+
+// ListByUserID returns reactions made by the given user. upstream Misskey TS
+// の users/reactions endpoint で使う reactor 視点の list。User / Note を
+// preload して pack 時に追加 query が走らないようにする。pagination は
+// ListByNoteID と同じ keyset 方式 (paginationOrder で DESC 既定)。
+func (r *noteReactionRepository) ListByUserID(userID, untilID, sinceID string, limit int) ([]*model.NoteReaction, error) {
+	var rows []*model.NoteReaction
+	q := r.db.Preload("User").Preload("Note").Where("\"userId\" = ?", userID)
 	if untilID != "" {
 		q = q.Where("id < ?", untilID)
 	}

--- a/internal/repository/note_reaction_test.go
+++ b/internal/repository/note_reaction_test.go
@@ -137,6 +137,79 @@ func TestNoteReactionRepository_ListByNoteID(t *testing.T) {
 	assert.Len(t, out, 1)
 }
 
+// TestNoteReactionRepository_ListByUserID covers the #821 PR-D path used by
+// users/reactions endpoint: reactor 視点の reaction list を取得し、User /
+// Note を Preload して pack 時の N+1 を avoid する。
+func TestNoteReactionRepository_ListByUserID(t *testing.T) {
+	repo := NewNoteReactionRepository(testDB)
+	user1 := insertTestUser(t, "u_nr_6", "rxuser6")
+	user2 := insertTestUser(t, "u_nr_7", "rxuser7")
+	defer cleanupUser(t, user1.ID)
+	defer cleanupUser(t, user2.ID)
+
+	noteRepo := NewNoteRepository(testDB)
+	note1 := &model.Note{
+		ID:         "n_nr_5",
+		UserID:     user1.ID,
+		Visibility: model.NoteVisibilityPublic,
+		Reactions:  datatypes.JSON([]byte("{}")),
+	}
+	note2 := &model.Note{
+		ID:         "n_nr_6",
+		UserID:     user1.ID,
+		Visibility: model.NoteVisibilityPublic,
+		Reactions:  datatypes.JSON([]byte("{}")),
+	}
+	require.NoError(t, noteRepo.Create(note1))
+	require.NoError(t, noteRepo.Create(note2))
+	defer cleanupNote(t, note1.ID)
+	defer cleanupNote(t, note2.ID)
+
+	// user2 が note1 / note2 に reaction、user1 は note2 のみに reaction。
+	// ListByUserID(user2) で 2 件、ListByUserID(user1) で 1 件返ることを check。
+	for _, r := range []struct {
+		id, uid, nid, rx string
+	}{
+		{"rx_u1", user2.ID, note1.ID, "👍"},
+		{"rx_u2", user2.ID, note2.ID, "❤"},
+		{"rx_u3", user1.ID, note2.ID, "🎉"},
+	} {
+		rec := &model.NoteReaction{ID: r.id, UserID: r.uid, NoteID: r.nid, Reaction: r.rx}
+		require.NoError(t, repo.Create(rec))
+		defer cleanupReaction(t, rec.ID)
+	}
+
+	// user2 視点で 2 件、Preload("User") / Preload("Note") が効いていることも
+	// 確認する。
+	out, err := repo.ListByUserID(user2.ID, "", "", 10)
+	require.NoError(t, err)
+	require.Len(t, out, 2)
+	for _, rec := range out {
+		assert.Equal(t, user2.ID, rec.UserID)
+		require.NotNil(t, rec.User, "User should be preloaded")
+		assert.Equal(t, user2.ID, rec.User.ID)
+		require.NotNil(t, rec.Note, "Note should be preloaded")
+	}
+
+	// user1 視点で 1 件 (= note2 のみ)。
+	out, err = repo.ListByUserID(user1.ID, "", "", 10)
+	require.NoError(t, err)
+	require.Len(t, out, 1)
+	assert.Equal(t, "rx_u3", out[0].ID)
+
+	// untilID で絞り込み (rx_u2 より前 → rx_u1 の 1 件)。
+	out, err = repo.ListByUserID(user2.ID, "rx_u2", "", 10)
+	require.NoError(t, err)
+	require.Len(t, out, 1)
+	assert.Equal(t, "rx_u1", out[0].ID)
+
+	// sinceID で絞り込み (rx_u1 より後 → rx_u2 の 1 件)。
+	out, err = repo.ListByUserID(user2.ID, "", "rx_u1", 10)
+	require.NoError(t, err)
+	require.Len(t, out, 1)
+	assert.Equal(t, "rx_u2", out[0].ID)
+}
+
 func TestNoteReactionRepository_QueryErrors(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel()

--- a/internal/server/router.go
+++ b/internal/server/router.go
@@ -1116,6 +1116,7 @@ func (s *Server) setupRoutes() {
 	usersHandler.SetPageRepo(pageRepo)
 	usersHandler.SetNoteFieldResolver(noteFieldResolver)
 	usersHandler.SetUserRepo(userRepo)
+	usersHandler.SetNoteReactionRepo(reactionRepo)
 	api.POST("/users/show", usersHandler.Show)
 	api.POST("/users/search", usersHandler.Search)
 	api.POST("/users/notes", usersHandler.Notes)

--- a/internal/testutil/mock_repository.go
+++ b/internal/testutil/mock_repository.go
@@ -1281,6 +1281,42 @@ func (m *MockNoteReactionRepository) ListByNoteID(noteID, untilID, sinceID strin
 	return rows, nil
 }
 
+// ListByUserID returns reactions made by a user. paginationOrder と同じく
+// sinceID 単独指定時のみ ASC、それ以外 DESC (ListByNoteID と同 logic)。
+func (m *MockNoteReactionRepository) ListByUserID(userID, untilID, sinceID string, limit int) ([]*model.NoteReaction, error) {
+	var rows []*model.NoteReaction
+	for _, r := range m.Reactions {
+		if r.UserID != userID {
+			continue
+		}
+		if untilID != "" && r.ID >= untilID {
+			continue
+		}
+		if sinceID != "" && r.ID <= sinceID {
+			continue
+		}
+		rows = append(rows, r)
+	}
+	asc := sinceID != "" && untilID == ""
+	for i := 0; i < len(rows); i++ {
+		for j := i + 1; j < len(rows); j++ {
+			if asc {
+				if rows[i].ID > rows[j].ID {
+					rows[i], rows[j] = rows[j], rows[i]
+				}
+			} else {
+				if rows[i].ID < rows[j].ID {
+					rows[i], rows[j] = rows[j], rows[i]
+				}
+			}
+		}
+	}
+	if limit > 0 && len(rows) > limit {
+		rows = rows[:limit]
+	}
+	return rows, nil
+}
+
 // MockEmojiRepository is a test double for repository.EmojiRepository.
 type MockEmojiRepository struct {
 	// keyed by "name@host" (host="" for local)

--- a/tests/playwright/specs/reactions/users_reactions.spec.ts
+++ b/tests/playwright/specs/reactions/users_reactions.spec.ts
@@ -1,0 +1,80 @@
+// #821 PR-D reactions spec: users/reactions で reactor 視点の reaction list
+// round-trip。
+//
+// upstream Misskey TS と mk-go (#821 PR-D で本実装に修正) は両方とも:
+//   - users/reactions { userId } で指定 user が付けた reaction の list を
+//     返す
+//   - target user の publicReactions が false で viewer ≠ target なら
+//     403 REACTIONS_NOT_PUBLIC
+//   - self view (viewer === target) なら publicReactions に関わらず取得可能
+//   - response の各 entry は { id, createdAt, type, user, note } の minimal
+//     shape
+//
+// 本 spec は両 backend 共通で:
+//   1. user A + user B signup
+//   2. A が public note 投稿
+//   3. B が note に `👍` reaction 付与
+//   4. B が users/reactions { userId: B.id } で self view 取得
+//   5. list 1 件 / type / user.id / note.id を strict assert
+//
+// 注: viewer ≠ target 視点の publicReactions check は別 spec で扱う scope
+// (本 spec は self view round-trip にフォーカス)。
+
+import { expect, test } from '@playwright/test';
+import { callApi } from '../../fixtures/api';
+import { randomUsername, signupUser } from '../../fixtures/auth';
+import { createNote } from '../../fixtures/notes';
+import { resetRateLimit } from '../../fixtures/rate_limit';
+
+interface UsersReactionsEntry {
+  id: string;
+  createdAt: string;
+  type: string;
+  user: { id: string };
+  note: { id: string };
+}
+
+test.describe('reactions: users/reactions self view round-trip', () => {
+  test.beforeAll(() => {
+    resetRateLimit();
+  });
+
+  test('B reacts to A\'s note then sees the reaction in B\'s users/reactions (self view)', async ({
+    request,
+  }) => {
+    const author = await signupUser(request, randomUsername('urA'));
+    const reactor = await signupUser(request, randomUsername('urB'));
+
+    const note = await createNote(request, author.token, {
+      text: 'react for users/reactions',
+      visibility: 'public',
+    });
+
+    // reactor が `👍` 付与。
+    const reactResp = await callApi(request, 'notes/reactions/create', {
+      i: reactor.token,
+      noteId: note.id,
+      reaction: '👍',
+    });
+    expect(reactResp.status()).toBeGreaterThanOrEqual(200);
+    expect(reactResp.status()).toBeLessThan(300);
+
+    // reactor が自分の users/reactions を取得 (self view なので
+    // publicReactions に関わらず取得可能)。
+    const listResp = await callApi(request, 'users/reactions', {
+      i: reactor.token,
+      userId: reactor.id,
+      limit: 10,
+    });
+    expect(listResp.status()).toBe(200);
+    const list = (await listResp.json()) as UsersReactionsEntry[];
+    expect(Array.isArray(list)).toBe(true);
+    // self の reaction は 1 件のみ (= 直前に付けた `👍`)。
+    expect(list.length).toBe(1);
+    const entry = list[0];
+    expect(entry.type).toBe('👍');
+    expect(entry.user.id).toBe(reactor.id);
+    expect(entry.note.id).toBe(note.id);
+    expect(Number.isFinite(Date.parse(entry.createdAt))).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary

- mk-go の \`users/reactions\` handler は stub (= 空配列) のままだったので、upstream Misskey TS と同 semantics の本実装に修正。
- reactor 視点の reaction list を返す endpoint で、\`publicReactions\` check + \`IS_REMOTE_USER\` + minimal note shape pack を実装。
- 本 PR で #821 全 scope (CRUD / 1 user 1 reaction / 違う reaction の置き換え / custom emoji / users/reactions) を完了し close。

## 主な変更点

- \`internal/repository/note_reaction.go\`
  - \`NoteReactionRepository\` interface に \`ListByUserID(userID, untilID, sinceID, limit)\` を追加。User / Note を Preload して pack 時の query を省く。pagination は \`ListByNoteID\` と同じ keyset 方式。
- \`internal/testutil/mock_repository.go\`
  - \`MockNoteReactionRepository\` に同 method を追加 (production 同様の sinceID/untilID/limit semantics)。
- \`internal/api/users/handler.go\`
  - \`Handler\` に \`noteReactionRepo\` dependency 追加 + \`SetNoteReactionRepo()\`。
- \`internal/api/users/handler_extra.go\`
  - \`Reactions\` handler を stub から本実装に書き換え:
    - target user の存在 / Host nil check (= local only、\`IS_REMOTE_USER\`)
    - viewer ≠ target で \`publicReactions = false\` なら 403 \`REACTIONS_NOT_PUBLIC\` (upstream error code/id 互換)
    - \`h.noteReactionRepo.ListByUserID\` で reaction list 取得
    - \`id\` / \`createdAt\` / \`type\` / \`user\` / \`note\` の minimal shape で pack
- \`internal/server/router.go\`
  - \`usersHandler.SetNoteReactionRepo(reactionRepo)\` で wire。
- \`tests/playwright/specs/reactions/users_reactions.spec.ts\` (new)
  - reactor が note に \`👍\` 付与 → 自分の \`users/reactions\` で list 取得 (self view) → 1 件 / type / user.id / note.id を strict assert。

## 設計上の制約

- **note pack は minimal**: upstream の \`packManyWithNote\` (= 完全 note shape) ではなく minimal (\`id\` / \`userId\` / \`text\`) で start。drop-in 互換性は両 backend で endpoint が動くことを spec で担保し、shape strict 化は別 issue で扱う。
- **self view 1 path のみ**: 本 spec は self view 1 path のみ。viewer ≠ target の \`publicReactions\` check の round-trip は別 spec に分割可能 (= scope 外として今回は skip、handler 側の logic は実装済)。

## Testing

- \`make playwright-up && make playwright-test\` (mk-go backend, 1 spec): **1 passed (1.2s)**
- \`make playwright-ts-up && make playwright-ts-test\` (TS backend, 1 spec): **1 passed (1.1s)**
- \`go test ./internal/api/users/... ./internal/repository/... ./internal/core/reaction/...\`: pass

## Related

- Closes #821 (reactions Playwright spec、全 scope 完了)
- 先行: #862 (PR-A), #863 (PR-B), #865 (PR-C), #867 (custom emoji 派生)

🤖 Generated with [Claude Code](https://claude.com/claude-code)