### PR TITLE
#819 Playwright Phase 2: timeline spec (home/local/global/hybrid) + hybrid drift fix

### DIFF
--- a/internal/core/timeline/timeline_service.go
+++ b/internal/core/timeline/timeline_service.go
@@ -156,6 +156,11 @@ func (s *Service) HybridTimeline(ctx context.Context, viewer *model.User, untilI
 // (#819 で Playwright spec が detect)。本 helper は両 query 結果を ID 単位で
 // dedup → ID 降順 sort → limit 截断する。pagination (sinceID/untilID) は両
 // query に同じ値を渡すので merged 結果の boundary は upstream と一致する。
+//
+// 各 query は単独で limit 件まで返すので merged 後の最大件数は 2*limit、
+// dedup と truncate を経て最終的に <= limit 件。逆に両 query の和が limit
+// に届かなければ best-effort で limit 未満の結果を返す (= upstream parity、
+// pagination は keyset 方式で次 page 取得時に補完される設計)。
 func (s *Service) hybridDBFallback(viewer *model.User, untilID, sinceID string, limit int, filter TimelineFilter) ([]*model.Note, error) {
 	dbFilter := toDBFilter(filter, viewer.ID)
 	homeNotes, err := s.noteRepo.ListHomeTimeline(viewer.ID, limit, sinceID, untilID, dbFilter)

--- a/internal/core/timeline/timeline_service.go
+++ b/internal/core/timeline/timeline_service.go
@@ -3,6 +3,7 @@ package timeline
 import (
 	"context"
 	"errors"
+	"sort"
 
 	"github.com/shiroha-a/mk/internal/model"
 	"github.com/shiroha-a/mk/internal/repository"
@@ -139,11 +140,55 @@ func (s *Service) HybridTimeline(ctx context.Context, viewer *model.User, untilI
 		}
 		notes = ApplyFilter(notes, viewer.ID, filter)
 		if !filter.AllowPartial && len(notes) < limit {
-			return s.noteRepo.ListHomeTimeline(viewer.ID, limit, sinceID, untilID, toDBFilter(filter, viewer.ID))
+			return s.hybridDBFallback(viewer, untilID, sinceID, limit, filter)
 		}
 		return notes, nil
 	}
-	return s.noteRepo.ListHomeTimeline(viewer.ID, limit, sinceID, untilID, toDBFilter(filter, viewer.ID))
+	return s.hybridDBFallback(viewer, untilID, sinceID, limit, filter)
+}
+
+// hybridDBFallback queries the home and local timelines from the database and
+// merges them. upstream Misskey TS と同 semantics: hybrid (= social) timeline
+// は home (followee + 自分) と local (= 同 instance の public) の和集合を返す。
+//
+// 旧実装は ListHomeTimeline のみを呼んでおり、follow 関係が無い viewer に
+// とって local public note (= 同 instance の他 user の public) が落ちていた
+// (#819 で Playwright spec が detect)。本 helper は両 query 結果を ID 単位で
+// dedup → ID 降順 sort → limit 截断する。pagination (sinceID/untilID) は両
+// query に同じ値を渡すので merged 結果の boundary は upstream と一致する。
+func (s *Service) hybridDBFallback(viewer *model.User, untilID, sinceID string, limit int, filter TimelineFilter) ([]*model.Note, error) {
+	dbFilter := toDBFilter(filter, viewer.ID)
+	homeNotes, err := s.noteRepo.ListHomeTimeline(viewer.ID, limit, sinceID, untilID, dbFilter)
+	if err != nil {
+		return nil, err
+	}
+	localNotes, err := s.noteRepo.ListLocalTimeline(limit, sinceID, untilID, dbFilter)
+	if err != nil {
+		return nil, err
+	}
+	seen := make(map[string]struct{}, len(homeNotes)+len(localNotes))
+	out := make([]*model.Note, 0, len(homeNotes)+len(localNotes))
+	for _, n := range homeNotes {
+		if _, dup := seen[n.ID]; dup {
+			continue
+		}
+		seen[n.ID] = struct{}{}
+		out = append(out, n)
+	}
+	for _, n := range localNotes {
+		if _, dup := seen[n.ID]; dup {
+			continue
+		}
+		seen[n.ID] = struct{}{}
+		out = append(out, n)
+	}
+	// ID 降順 sort (= upstream と同じ keyset 順)。aidx は時系列で単調増加
+	// するので ID 文字列の lexicographic 比較で十分。
+	sort.Slice(out, func(i, j int) bool { return out[i].ID > out[j].ID })
+	if len(out) > limit {
+		out = out[:limit]
+	}
+	return out, nil
 }
 
 // toDBFilter converts a TimelineFilter to a model.TimelineDBFilter.

--- a/internal/core/timeline/timeline_service_test.go
+++ b/internal/core/timeline/timeline_service_test.go
@@ -181,6 +181,116 @@ func TestService_HybridTimeline_DBFallback(t *testing.T) {
 	assert.Len(t, out, 1)
 }
 
+// hybrid DB fallback の merge / dedup / sort path を直接 cover する
+// (#819 PR-fix)。home / local がそれぞれ異なる note を返す mock を用意し、
+// 結果が ID 単位で dedup され、ID 降順で並ぶことを check する。
+type splitTimelineRepo struct {
+	*testutil.MockNoteRepository
+	homeNotes  []*model.Note
+	localNotes []*model.Note
+}
+
+func (r *splitTimelineRepo) ListHomeTimeline(_ string, _ int, _, _ string, _ model.TimelineDBFilter) ([]*model.Note, error) {
+	return r.homeNotes, nil
+}
+func (r *splitTimelineRepo) ListLocalTimeline(_ int, _, _ string, _ model.TimelineDBFilter) ([]*model.Note, error) {
+	return r.localNotes, nil
+}
+
+func TestService_HybridDBFallback_DedupAndSort(t *testing.T) {
+	testRedis.FlushAll(context.Background())
+	repo := &splitTimelineRepo{
+		MockNoteRepository: testutil.NewMockNoteRepository(),
+		homeNotes: []*model.Note{
+			{ID: "n3", UserID: "viewer", Visibility: model.NoteVisibilityPublic},
+			{ID: "n1", UserID: "viewer", Visibility: model.NoteVisibilityPublic},
+		},
+		localNotes: []*model.Note{
+			{ID: "n2", UserID: "outsider", Visibility: model.NoteVisibilityPublic},
+			// n1 は home / local の両方に出現する想定 (= dedup 対象)
+			{ID: "n1", UserID: "outsider", Visibility: model.NoteVisibilityPublic},
+		},
+	}
+	fanout := NewFanoutTimelineService(testRedis.Client, idGen, "")
+	svc := NewService(fanout, repo, testutil.NewMockFollowingRepository())
+
+	out, err := svc.HybridTimeline(context.Background(), &model.User{ID: "viewer"}, "", "", 10, TimelineFilter{})
+	require.NoError(t, err)
+	require.Len(t, out, 3)
+	// dedup 後に ID 降順 sort されていること。
+	assert.Equal(t, "n3", out[0].ID)
+	assert.Equal(t, "n2", out[1].ID)
+	assert.Equal(t, "n1", out[2].ID)
+}
+
+// limit > 全件 のとき余分な truncate が走らないこと。逆に limit < 全件 の
+// truncate path は別 test で扱う想定で、本 test は merge dedup path のみを
+// fix する。
+func TestService_HybridDBFallback_LimitTruncate(t *testing.T) {
+	testRedis.FlushAll(context.Background())
+	repo := &splitTimelineRepo{
+		MockNoteRepository: testutil.NewMockNoteRepository(),
+		homeNotes: []*model.Note{
+			{ID: "n5", UserID: "viewer", Visibility: model.NoteVisibilityPublic},
+			{ID: "n4", UserID: "viewer", Visibility: model.NoteVisibilityPublic},
+		},
+		localNotes: []*model.Note{
+			{ID: "n3", UserID: "outsider", Visibility: model.NoteVisibilityPublic},
+			{ID: "n2", UserID: "outsider", Visibility: model.NoteVisibilityPublic},
+			{ID: "n1", UserID: "outsider", Visibility: model.NoteVisibilityPublic},
+		},
+	}
+	fanout := NewFanoutTimelineService(testRedis.Client, idGen, "")
+	svc := NewService(fanout, repo, testutil.NewMockFollowingRepository())
+
+	// limit=3 < 全 5 件 → ID 降順で先頭 3 件 (n5/n4/n3) のみ。
+	out, err := svc.HybridTimeline(context.Background(), &model.User{ID: "viewer"}, "", "", 3, TimelineFilter{})
+	require.NoError(t, err)
+	require.Len(t, out, 3)
+	assert.Equal(t, "n5", out[0].ID)
+	assert.Equal(t, "n4", out[1].ID)
+	assert.Equal(t, "n3", out[2].ID)
+}
+
+// hybridDBFallback の error 分岐 cover: home query / local query それぞれの
+// error を Service 層が透過することを check (#819 PR-fix)。
+type failingHybridRepo struct {
+	*testutil.MockNoteRepository
+	failHome  bool
+	failLocal bool
+}
+
+func (r *failingHybridRepo) ListHomeTimeline(_ string, _ int, _, _ string, _ model.TimelineDBFilter) ([]*model.Note, error) {
+	if r.failHome {
+		return nil, assert.AnError
+	}
+	return nil, nil
+}
+func (r *failingHybridRepo) ListLocalTimeline(_ int, _, _ string, _ model.TimelineDBFilter) ([]*model.Note, error) {
+	if r.failLocal {
+		return nil, assert.AnError
+	}
+	return nil, nil
+}
+
+func TestService_HybridDBFallback_HomeError(t *testing.T) {
+	testRedis.FlushAll(context.Background())
+	repo := &failingHybridRepo{MockNoteRepository: testutil.NewMockNoteRepository(), failHome: true}
+	fanout := NewFanoutTimelineService(testRedis.Client, idGen, "")
+	svc := NewService(fanout, repo, testutil.NewMockFollowingRepository())
+	_, err := svc.HybridTimeline(context.Background(), &model.User{ID: "viewer"}, "", "", 10, TimelineFilter{})
+	assert.Error(t, err)
+}
+
+func TestService_HybridDBFallback_LocalError(t *testing.T) {
+	testRedis.FlushAll(context.Background())
+	repo := &failingHybridRepo{MockNoteRepository: testutil.NewMockNoteRepository(), failLocal: true}
+	fanout := NewFanoutTimelineService(testRedis.Client, idGen, "")
+	svc := NewService(fanout, repo, testutil.NewMockFollowingRepository())
+	_, err := svc.HybridTimeline(context.Background(), &model.User{ID: "viewer"}, "", "", 10, TimelineFilter{})
+	assert.Error(t, err)
+}
+
 func TestService_HomeTimeline_DefaultLimit(t *testing.T) {
 	svc, _, _ := newTestServiceWithRepo(t)
 	out, err := svc.HomeTimeline(context.Background(), &model.User{ID: "u"}, "", "", 0, TimelineFilter{})

--- a/internal/core/timeline/timeline_service_test.go
+++ b/internal/core/timeline/timeline_service_test.go
@@ -223,9 +223,9 @@ func TestService_HybridDBFallback_DedupAndSort(t *testing.T) {
 	assert.Equal(t, "n1", out[2].ID)
 }
 
-// limit > 全件 のとき余分な truncate が走らないこと。逆に limit < 全件 の
-// truncate path は別 test で扱う想定で、本 test は merge dedup path のみを
-// fix する。
+// limit < 全件 のとき merged 結果が ID 降順先頭 limit 件に truncate される
+// path を直接 cover する (#819 PR-fix)。home / local 計 5 件投入、limit=3
+// で先頭 3 件だけが返ることを check。
 func TestService_HybridDBFallback_LimitTruncate(t *testing.T) {
 	testRedis.FlushAll(context.Background())
 	repo := &splitTimelineRepo{

--- a/tests/playwright/fixtures/timeline.ts
+++ b/tests/playwright/fixtures/timeline.ts
@@ -1,0 +1,62 @@
+// Phase 2 #819 timeline spec helper.
+//
+// timeline 系 endpoint (notes/timeline / local-timeline / global-timeline /
+// hybrid-timeline) で共通の fetch / poll を提供する。upstream Misskey TS と
+// mk-go は両方とも fanout を Redis 経由で行うので、note 投稿直後は該当
+// timeline に未反映なことがある。positive 側 (= 出るはず) は expect.poll
+// で 5s 範囲で retry し、negative 側 (= 出ないはず) は positive 用 poll が
+// 通った直後 (= fanout が settle した状態) に同 fetch 結果を再利用する形で
+// 確認する。
+
+import { expect, type APIRequestContext } from '@playwright/test';
+import { callApi } from './api';
+
+export interface TimelineNote {
+  id: string;
+  userId: string;
+  text?: string | null;
+  visibility: string;
+}
+
+// fetchTimelineNotes returns the timeline as an array of minimal note shapes.
+// 4 つの timeline endpoint で共通の request body を受け付けるので、endpoint
+// だけ切り替える。token は null 可 (= local / global は 未ログイン user 用
+// path もあるが、本 helper は spec から token 付きで呼ぶ前提)。
+export async function fetchTimelineNotes(
+  request: APIRequestContext,
+  endpoint: string,
+  token: string | null,
+  body: Record<string, unknown> = {},
+): Promise<TimelineNote[]> {
+  const payload: Record<string, unknown> = { ...body };
+  if (token) payload.i = token;
+  if (payload.limit === undefined) payload.limit = 100;
+  const resp = await callApi(request, endpoint, payload);
+  if (resp.status() !== 200) {
+    throw new Error(
+      `${endpoint} failed: ${resp.status()} ${await resp.text()}`,
+    );
+  }
+  return (await resp.json()) as TimelineNote[];
+}
+
+// pollForTimelineNote polls the given timeline endpoint until noteId appears
+// or the timeout elapses. timeline fanout は async (Redis) なので note 投稿
+// 直後は反映が遅れる可能性があり、5s 範囲で段階的に retry する (notification
+// 用 pollForNotification と同 pattern)。見つからなければ assertion 失敗。
+export async function pollForTimelineNote(
+  request: APIRequestContext,
+  endpoint: string,
+  token: string | null,
+  noteId: string,
+): Promise<void> {
+  await expect
+    .poll(
+      async () => {
+        const notes = await fetchTimelineNotes(request, endpoint, token);
+        return notes.some((n) => n.id === noteId);
+      },
+      { timeout: 5000, intervals: [100, 200, 500, 1000] },
+    )
+    .toBe(true);
+}

--- a/tests/playwright/fixtures/timeline.ts
+++ b/tests/playwright/fixtures/timeline.ts
@@ -22,6 +22,10 @@ export interface TimelineNote {
 // 4 つの timeline endpoint で共通の request body を受け付けるので、endpoint
 // だけ切り替える。token は null 可 (= local / global は 未ログイン user 用
 // path もあるが、本 helper は spec から token 付きで呼ぶ前提)。
+//
+// 注意: token 引数を渡すと body.i は上書きされる (= 認証 token は引数側で
+// 一元管理する設計)。一方 body.limit は明示があれば尊重し、未指定時のみ
+// default 100 を補う (= caller が limit を絞りたい spec を書ける)。
 export async function fetchTimelineNotes(
   request: APIRequestContext,
   endpoint: string,

--- a/tests/playwright/specs/timeline/global.spec.ts
+++ b/tests/playwright/specs/timeline/global.spec.ts
@@ -1,0 +1,61 @@
+// Phase 2 #819: global timeline (= /api/notes/global-timeline)。
+//
+// upstream Misskey TS と mk-go は両方とも:
+//   - 全 instance の public visibility note を返す
+//     (DB 側で `visibility = 'public' AND channelId IS NULL` で filter)
+//   - followers / specified / home visibility は出ない (= public 以外は除外)
+//
+// single-instance environment では federated remote が無いので、global は
+// 実質 local の super-set として動く (local は userHost IS NULL 制限あり)。
+// 本 spec は visibility filter の境界に focus し:
+//   1. author / viewer signup
+//   2. author が public + home の 2 種類 note を投稿
+//   3. viewer の global-timeline で public は出る、home は出ないことを check
+
+import { expect, test } from '@playwright/test';
+import { randomUsername, signupUser } from '../../fixtures/auth';
+import { createNote } from '../../fixtures/notes';
+import { resetRateLimit } from '../../fixtures/rate_limit';
+import {
+  fetchTimelineNotes,
+  pollForTimelineNote,
+} from '../../fixtures/timeline';
+
+test.describe('timeline: global', () => {
+  test.beforeEach(() => {
+    resetRateLimit();
+  });
+
+  test('global includes public but excludes home-visibility', async ({
+    request,
+  }) => {
+    const author = await signupUser(request, randomUsername('gtA'));
+    const viewer = await signupUser(request, randomUsername('gtB'));
+
+    const publicNote = await createNote(request, author.token, {
+      text: 'global: public',
+      visibility: 'public',
+    });
+    const homeNote = await createNote(request, author.token, {
+      text: 'global: home',
+      visibility: 'home',
+    });
+
+    await pollForTimelineNote(
+      request,
+      'notes/global-timeline',
+      viewer.token,
+      publicNote.id,
+    );
+
+    // home visibility は public timeline 系から除外される (upstream TS
+    // と mk-go DB 側で同 SQL filter)。fanout settle 後の同 fetch で
+    // 確認する。
+    const notes = await fetchTimelineNotes(
+      request,
+      'notes/global-timeline',
+      viewer.token,
+    );
+    expect(notes.some((n) => n.id === homeNote.id)).toBe(false);
+  });
+});

--- a/tests/playwright/specs/timeline/home.spec.ts
+++ b/tests/playwright/specs/timeline/home.spec.ts
@@ -1,0 +1,85 @@
+// Phase 2 #819: home timeline (= /api/notes/timeline) の包含 / 除外境界。
+//
+// upstream Misskey TS と mk-go は両方とも:
+//   - viewer 自身 + viewer が follow する user の note のみが home に出る
+//   - viewer が follow していない user の public note は home に出ない
+//   - auth 必須 (= viewer なしは 401 CREDENTIAL_REQUIRED)
+//
+// 本 spec は両 backend 共通で:
+//   1. follower (A) / followee (B) / outsider (C) signup
+//   2. A が B を follow
+//   3. B / C それぞれ public note を投稿
+//   4. A の home timeline で B の note は出る、C の note は出ないことを check
+//   5. 未認証 request は 401 で reject されること
+//
+// channel / list / antenna / hashtag / role timeline は別 spec scope (#819
+// issue で明記済み)。本 PR では 4 種 (home/local/global/hybrid) のみ。
+
+import { expect, test } from '@playwright/test';
+import { callApi } from '../../fixtures/api';
+import { randomUsername, signupUser } from '../../fixtures/auth';
+import { createNote } from '../../fixtures/notes';
+import { resetRateLimit } from '../../fixtures/rate_limit';
+import {
+  fetchTimelineNotes,
+  pollForTimelineNote,
+} from '../../fixtures/timeline';
+
+test.describe('timeline: home', () => {
+  // 各 test で 3 人 signup するので spec 累積で signup rate limit (1h 5回) に
+  // 引っかかる。test 境界で reset して独立性を保つ。
+  test.beforeEach(() => {
+    resetRateLimit();
+  });
+
+  test('home includes followed user but excludes outsider', async ({
+    request,
+  }) => {
+    const follower = await signupUser(request, randomUsername('htA'));
+    const followee = await signupUser(request, randomUsername('htB'));
+    const outsider = await signupUser(request, randomUsername('htC'));
+
+    // follower → followee の follow を確立 (= followee の note が
+    // follower の home fanout に乗る前提)。
+    const fResp = await callApi(request, 'following/create', {
+      i: follower.token,
+      userId: followee.id,
+    });
+    expect(fResp.status()).toBeGreaterThanOrEqual(200);
+    expect(fResp.status()).toBeLessThan(300);
+
+    const followedNote = await createNote(request, followee.token, {
+      text: 'home: followee',
+      visibility: 'public',
+    });
+    const outsiderNote = await createNote(request, outsider.token, {
+      text: 'home: outsider',
+      visibility: 'public',
+    });
+
+    // followee の note が follower の home に届くまで poll で待つ。
+    await pollForTimelineNote(
+      request,
+      'notes/timeline',
+      follower.token,
+      followedNote.id,
+    );
+
+    // poll が通った時点で fanout は settle 済み。同 fetch で outsider の
+    // note は含まれないことを check (= follow していない user の note は
+    // home に来ない、boundary regression guard)。
+    const notes = await fetchTimelineNotes(
+      request,
+      'notes/timeline',
+      follower.token,
+    );
+    expect(notes.some((n) => n.id === outsiderNote.id)).toBe(false);
+  });
+
+  test('home requires auth', async ({ request }) => {
+    // upstream Misskey TS と mk-go は両方とも notes/timeline を
+    // RequireAuth() で wrap しており、token 無しは 401 を返す。
+    const resp = await callApi(request, 'notes/timeline', {});
+    expect(resp.status()).toBe(401);
+  });
+});

--- a/tests/playwright/specs/timeline/hybrid.spec.ts
+++ b/tests/playwright/specs/timeline/hybrid.spec.ts
@@ -1,0 +1,65 @@
+// Phase 2 #819: hybrid timeline (= /api/notes/hybrid-timeline、別名 social)。
+//
+// upstream Misskey TS と mk-go は両方とも hybrid を:
+//   - home (= followee + 自分) と local (= 同 instance の public) の merge
+//   - 結果として viewer が follow していない user の public note も出る
+//     (= local part 経由)
+//   - 一方 home / followers visibility の non-followee 投稿は出ない
+//     (= home は follow 関係が無いと届かない、local は public 限定)
+//   - auth 必須 (= notes/timeline と同じく RequireAuth)
+//
+// 本 spec は両 backend 共通で:
+//   1. viewer (A) / outsider (B) signup (follow なし)
+//   2. B が public + home の 2 種類 note を投稿
+//   3. A の hybrid-timeline で B の public note は出ること (local 経由)
+//   4. 同 fetch で B の home note は出ないことを check (= follow 不在で
+//      home visibility は届かない、boundary regression guard)
+
+import { expect, test } from '@playwright/test';
+import { randomUsername, signupUser } from '../../fixtures/auth';
+import { createNote } from '../../fixtures/notes';
+import { resetRateLimit } from '../../fixtures/rate_limit';
+import {
+  fetchTimelineNotes,
+  pollForTimelineNote,
+} from '../../fixtures/timeline';
+
+test.describe('timeline: hybrid', () => {
+  test.beforeEach(() => {
+    resetRateLimit();
+  });
+
+  test('hybrid includes outsider public via local but excludes their home-visibility', async ({
+    request,
+  }) => {
+    const viewer = await signupUser(request, randomUsername('hyA'));
+    const outsider = await signupUser(request, randomUsername('hyB'));
+
+    const publicNote = await createNote(request, outsider.token, {
+      text: 'hybrid: public',
+      visibility: 'public',
+    });
+    const homeNote = await createNote(request, outsider.token, {
+      text: 'hybrid: home',
+      visibility: 'home',
+    });
+
+    // outsider の public note は viewer の hybrid に local part 経由で
+    // 出るはず (= follow 不要)。
+    await pollForTimelineNote(
+      request,
+      'notes/hybrid-timeline',
+      viewer.token,
+      publicNote.id,
+    );
+
+    // home visibility の note は follow 関係が無い viewer には届かない。
+    // local part にも (visibility=public 限定なので) 入らない。
+    const notes = await fetchTimelineNotes(
+      request,
+      'notes/hybrid-timeline',
+      viewer.token,
+    );
+    expect(notes.some((n) => n.id === homeNote.id)).toBe(false);
+  });
+});

--- a/tests/playwright/specs/timeline/local.spec.ts
+++ b/tests/playwright/specs/timeline/local.spec.ts
@@ -1,0 +1,62 @@
+// Phase 2 #819: local timeline (= /api/notes/local-timeline)。
+//
+// upstream Misskey TS と mk-go は両方とも:
+//   - 同 instance の user による public visibility note のみ返す
+//     (DB 側で `userHost IS NULL AND visibility = 'public'` で filter)
+//   - followers / specified visibility の note は出ない
+//   - home visibility の note は出ない (= local timeline は home を含めない)
+//   - channel 内 note も出ない (channelId IS NULL で除外)
+//
+// 本 spec は両 backend 共通で:
+//   1. author / viewer signup
+//   2. author が public + followers の 2 種類 note を投稿
+//   3. viewer の local-timeline で public は出る、followers は出ないことを
+//      check (visibility filter regression guard)
+
+import { expect, test } from '@playwright/test';
+import { randomUsername, signupUser } from '../../fixtures/auth';
+import { createNote } from '../../fixtures/notes';
+import { resetRateLimit } from '../../fixtures/rate_limit';
+import {
+  fetchTimelineNotes,
+  pollForTimelineNote,
+} from '../../fixtures/timeline';
+
+test.describe('timeline: local', () => {
+  test.beforeEach(() => {
+    resetRateLimit();
+  });
+
+  test('local includes public but excludes followers-only', async ({
+    request,
+  }) => {
+    const author = await signupUser(request, randomUsername('ltA'));
+    const viewer = await signupUser(request, randomUsername('ltB'));
+
+    const publicNote = await createNote(request, author.token, {
+      text: 'local: public',
+      visibility: 'public',
+    });
+    const followersNote = await createNote(request, author.token, {
+      text: 'local: followers',
+      visibility: 'followers',
+    });
+
+    // public note が viewer の local-timeline に到達するまで poll。
+    await pollForTimelineNote(
+      request,
+      'notes/local-timeline',
+      viewer.token,
+      publicNote.id,
+    );
+
+    // followers visibility の note は viewer (= follower でない 第三者)
+    // からは見えない。fanout settle 後の同 fetch で確認する。
+    const notes = await fetchTimelineNotes(
+      request,
+      'notes/local-timeline',
+      viewer.token,
+    );
+    expect(notes.some((n) => n.id === followersNote.id)).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary

- Playwright Phase 2 #819 として home / local / global / hybrid の 4 種 timeline で round-trip spec を整備。
- 検証中に hybrid の DB partial-fallback drift を検出 → 同 PR で fix (`HybridTimeline` の fallback が `ListHomeTimeline` のみで `ListLocalTimeline` を merge していなかった)。

## 主な変更点

### Spec 追加
- `tests/playwright/fixtures/timeline.ts`: `fetchTimelineNotes` / `pollForTimelineNote` 共通 helper (notification の poll pattern と同型)
- `tests/playwright/specs/timeline/home.spec.ts`: followee の note は出る / outsider の note は出ない / auth 必須 (401)
- `tests/playwright/specs/timeline/local.spec.ts`: public は出る / followers visibility は出ない
- `tests/playwright/specs/timeline/global.spec.ts`: public は出る / home visibility は出ない
- `tests/playwright/specs/timeline/hybrid.spec.ts`: outsider の public は local 経由で出る / outsider の home visibility は出ない

### Drift fix (`HybridTimeline` の DB partial-fallback)
- 旧実装は Redis fanout 結果が `len < limit` のとき `ListHomeTimeline` 単体に fallback しており、follow 関係の無い viewer に対する「local 経由の outsider public note」が落ちていた。
- 新規 `hybridDBFallback` helper を追加し、`ListHomeTimeline` + `ListLocalTimeline` を ID 単位で dedup → ID 降順 sort → limit 截断する形に修正。pagination (sinceID/untilID) は両 query に同値を渡すので keyset 順は upstream と一致。
- 同じ drift は upstream Misskey TS では起きておらず、TS backend で全 spec pass を事前確認済み。
- `internal/core/timeline` package coverage: 95.0% (≥90% threshold)

## 設計上の判断 (scope)

- 本 PR scope は home / local / global / hybrid の 4 種 (= #819 issue で明記済み)。channel / list / antenna / hashtag / role timeline は後続 PR で個別整備する想定。
- drift fix は将来は別 issue/PR に分離する方針 (今回は spec が露呈した直近の bug を同 PR 内で潰した方が clean なのでまとめた)。

## Testing

- `make playwright-up && make playwright-test` (mk-go backend, 48 specs): **48 passed**
- `make playwright-ts-up && make playwright-ts-test` (TS backend, 48 specs): **48 passed**
- `go test ./internal/core/timeline/...`: pass (coverage 95.0%)

## Related

- Closes #819
- 後続候補: channel / user-list / antenna / hashtag / role timeline spec (issue #819 のフッタで個別 PR 想定として明記)

🤖 Generated with [Claude Code](https://claude.com/claude-code)