### PR TITLE
#820 Playwright Phase 2: users spec (profile/follow/mute/block/user_list)

### DIFF
--- a/tests/playwright/fixtures/timeline.ts
+++ b/tests/playwright/fixtures/timeline.ts
@@ -48,16 +48,21 @@ export async function fetchTimelineNotes(
 // or the timeout elapses. timeline fanout は async (Redis) なので note 投稿
 // 直後は反映が遅れる可能性があり、5s 範囲で段階的に retry する (notification
 // 用 pollForNotification と同 pattern)。見つからなければ assertion 失敗。
+//
+// body は endpoint 固有の追加 param (= 例: user-list-timeline の listId、
+// channel-timeline の channelId) を渡したい場合に使う。fetchTimelineNotes
+// と同じく body.i / body.limit は helper 管理。
 export async function pollForTimelineNote(
   request: APIRequestContext,
   endpoint: string,
   token: string | null,
   noteId: string,
+  body: Record<string, unknown> = {},
 ): Promise<void> {
   await expect
     .poll(
       async () => {
-        const notes = await fetchTimelineNotes(request, endpoint, token);
+        const notes = await fetchTimelineNotes(request, endpoint, token, body);
         return notes.some((n) => n.id === noteId);
       },
       { timeout: 5000, intervals: [100, 200, 500, 1000] },

--- a/tests/playwright/specs/users/block.spec.ts
+++ b/tests/playwright/specs/users/block.spec.ts
@@ -1,0 +1,100 @@
+// Phase 2 #820: block CRUD round-trip + 副作用 (= blocked user の follow
+// reject)。
+//
+// upstream Misskey TS と mk-go は両方とも:
+//   - blocking/create { userId } で block 関係を作成 (返却 status は backend 間
+//     で drift あり、本 spec は 2xx range で許容)
+//   - blocking/list で blockee 一覧を取得 ({ id, blockeeId, blockee? } 配列)
+//   - blockee からの following/create は 403 BLOCKED で reject される
+//   - blocking/delete で関係解除 (= 同じく 2xx range)
+//   - 解除後は再 follow 可能
+//
+// drop-in shape drift (= 後続 issue で揃える方向):
+//   - blocking/create / blocking/delete の return shape (#870):
+//     TS=200 + UserDetailed / mk-go=204 No Content
+//   - blocked → following/create の reject status (#872):
+//     TS=400 / mk-go=403
+//   本 spec は 2xx / 4xx range で抽象化し、両 backend で同じ機能性
+//   (= block + follow reject) を提供することにフォーカスする。
+//
+// 本 spec は両 backend 共通で:
+//   1. A / B signup
+//   2. A が B を block → blocking/list に B が出る
+//   3. B が A を follow しようとして 403 BLOCKED で reject されること
+//   4. A が B を unblock → blocking/list から B が消え、B は A を follow
+//      できる
+
+import { expect, test } from '@playwright/test';
+import { callApi } from '../../fixtures/api';
+import { randomUsername, signupUser } from '../../fixtures/auth';
+import { resetRateLimit } from '../../fixtures/rate_limit';
+
+interface BlockEntry {
+  id: string;
+  blockeeId: string;
+}
+
+test.describe('users: block CRUD + follow reject side-effect', () => {
+  test.beforeAll(() => {
+    resetRateLimit();
+  });
+
+  test('block prevents follow; unblock allows follow again', async ({
+    request,
+  }) => {
+    const blocker = await signupUser(request, randomUsername('bkA'));
+    const blockee = await signupUser(request, randomUsername('bkB'));
+
+    // create block → 2xx (status の drift を吸収)。
+    const createResp = await callApi(request, 'blocking/create', {
+      i: blocker.token,
+      userId: blockee.id,
+    });
+    expect(createResp.status()).toBeGreaterThanOrEqual(200);
+    expect(createResp.status()).toBeLessThan(300);
+
+    // list で blockee が出ること。
+    const listAfterCreate = await callApi(request, 'blocking/list', {
+      i: blocker.token,
+      limit: 100,
+    });
+    expect(listAfterCreate.status()).toBe(200);
+    const listed = (await listAfterCreate.json()) as BlockEntry[];
+    expect(listed.some((e) => e.blockeeId === blockee.id)).toBe(true);
+
+    // blockee 視点の follow は reject される (= 4xx)。
+    // status は backend 間で drift あり (TS=400 / mk-go=403)。本 spec は
+    // 「reject されること」のみを保証し、具体的 status は後続 issue で
+    // 揃える方向。
+    const blockedFollow = await callApi(request, 'following/create', {
+      i: blockee.token,
+      userId: blocker.id,
+    });
+    expect(blockedFollow.status()).toBeGreaterThanOrEqual(400);
+    expect(blockedFollow.status()).toBeLessThan(500);
+
+    // delete block → 2xx (status の drift を吸収)。
+    const deleteResp = await callApi(request, 'blocking/delete', {
+      i: blocker.token,
+      userId: blockee.id,
+    });
+    expect(deleteResp.status()).toBeGreaterThanOrEqual(200);
+    expect(deleteResp.status()).toBeLessThan(300);
+
+    // list から消えていること。
+    const listAfterDelete = await callApi(request, 'blocking/list', {
+      i: blocker.token,
+      limit: 100,
+    });
+    expect(listAfterDelete.status()).toBe(200);
+    const listed2 = (await listAfterDelete.json()) as BlockEntry[];
+    expect(listed2.some((e) => e.blockeeId === blockee.id)).toBe(false);
+
+    // 解除後は blockee → blocker の follow が成功する。
+    const allowedFollow = await callApi(request, 'following/create', {
+      i: blockee.token,
+      userId: blocker.id,
+    });
+    expect(allowedFollow.status()).toBe(200);
+  });
+});

--- a/tests/playwright/specs/users/block.spec.ts
+++ b/tests/playwright/specs/users/block.spec.ts
@@ -5,7 +5,8 @@
 //   - blocking/create { userId } で block 関係を作成 (返却 status は backend 間
 //     で drift あり、本 spec は 2xx range で許容)
 //   - blocking/list で blockee 一覧を取得 ({ id, blockeeId, blockee? } 配列)
-//   - blockee からの following/create は 403 BLOCKED で reject される
+//   - blockee からの following/create は reject される (= 4xx、具体 status は
+//     backend 間で異なるが error code は両者 BLOCKED)
 //   - blocking/delete で関係解除 (= 同じく 2xx range)
 //   - 解除後は再 follow 可能
 //
@@ -20,7 +21,7 @@
 // 本 spec は両 backend 共通で:
 //   1. A / B signup
 //   2. A が B を block → blocking/list に B が出る
-//   3. B が A を follow しようとして 403 BLOCKED で reject されること
+//   3. B が A を follow しようとして 4xx で reject されること
 //   4. A が B を unblock → blocking/list から B が消え、B は A を follow
 //      できる
 

--- a/tests/playwright/specs/users/follow.spec.ts
+++ b/tests/playwright/specs/users/follow.spec.ts
@@ -3,7 +3,7 @@
 // upstream Misskey TS と mk-go は両方とも:
 //   - following/create { userId } で follow 関係を確立し、対象 user の
 //     UserDetailed entity を返す
-//   - users/following { userId } で fhollower 視点の following list を取得
+//   - users/following { userId } で follower 視点の following list を取得
 //     (response は { id, followerId, followeeId, follower?, followee? } の
 //     relation array)
 //   - following/delete { userId } で関係を解除し、users/following list から

--- a/tests/playwright/specs/users/follow.spec.ts
+++ b/tests/playwright/specs/users/follow.spec.ts
@@ -1,0 +1,78 @@
+// Phase 2 #820: follow CRUD と users/following の round-trip。
+//
+// upstream Misskey TS と mk-go は両方とも:
+//   - following/create { userId } で follow 関係を確立し、対象 user の
+//     UserDetailed entity を返す
+//   - users/following { userId } で fhollower 視点の following list を取得
+//     (response は { id, followerId, followeeId, follower?, followee? } の
+//     relation array)
+//   - following/delete { userId } で関係を解除し、users/following list から
+//     対象 user が消える
+//
+// 本 spec は両 backend 共通で:
+//   1. follower (A) / followee (B) signup
+//   2. A が B を follow → response の id check
+//   3. A の users/following が B を含むことを確認
+//   4. A が B を unfollow
+//   5. A の users/following から B が消えていることを確認
+
+import { expect, test } from '@playwright/test';
+import { callApi } from '../../fixtures/api';
+import { randomUsername, signupUser } from '../../fixtures/auth';
+import { resetRateLimit } from '../../fixtures/rate_limit';
+
+interface FollowingEntry {
+  id: string;
+  followerId: string;
+  followeeId: string;
+}
+
+test.describe('users: follow CRUD + users/following round-trip', () => {
+  test.beforeAll(() => {
+    resetRateLimit();
+  });
+
+  test('A follows then unfollows B; users/following reflects both transitions', async ({
+    request,
+  }) => {
+    const follower = await signupUser(request, randomUsername('fwA'));
+    const followee = await signupUser(request, randomUsername('fwB'));
+
+    // create follow。response は followee の UserDetailed (id 一致を確認)。
+    const createResp = await callApi(request, 'following/create', {
+      i: follower.token,
+      userId: followee.id,
+    });
+    expect(createResp.status()).toBe(200);
+    const created = await createResp.json();
+    expect(created.id).toBe(followee.id);
+
+    // users/following で follower の following list を取得し、followee を
+    // 含むこと。
+    const listAfterCreate = await callApi(request, 'users/following', {
+      i: follower.token,
+      userId: follower.id,
+      limit: 100,
+    });
+    expect(listAfterCreate.status()).toBe(200);
+    const listed = (await listAfterCreate.json()) as FollowingEntry[];
+    expect(listed.some((e) => e.followeeId === followee.id)).toBe(true);
+
+    // delete follow。response は同じく followee の UserDetailed。
+    const deleteResp = await callApi(request, 'following/delete', {
+      i: follower.token,
+      userId: followee.id,
+    });
+    expect(deleteResp.status()).toBe(200);
+
+    // users/following から followee が消えていること。
+    const listAfterDelete = await callApi(request, 'users/following', {
+      i: follower.token,
+      userId: follower.id,
+      limit: 100,
+    });
+    expect(listAfterDelete.status()).toBe(200);
+    const listed2 = (await listAfterDelete.json()) as FollowingEntry[];
+    expect(listed2.some((e) => e.followeeId === followee.id)).toBe(false);
+  });
+});

--- a/tests/playwright/specs/users/mute.spec.ts
+++ b/tests/playwright/specs/users/mute.spec.ts
@@ -1,0 +1,66 @@
+// Phase 2 #820: mute CRUD round-trip。
+//
+// upstream Misskey TS と mk-go は両方とも:
+//   - mute/create { userId } で mute 関係を作成 (204)
+//   - mute/list で mute 中の user 一覧を取得 ({ id, muteeId, mutee? } 配列)
+//   - mute/delete { userId } で mute を解除 (204)
+//   - mute/list 再取得で対象 user が消える
+//
+// 本 spec は両 backend 共通で CRUD round-trip のみ cover する。timeline
+// filter 連動 (= mute 後に対象 user の note が timeline から除外) は
+// 両 backend で挙動が分散しており別 spec scope (本 PR では扱わない)。
+
+import { expect, test } from '@playwright/test';
+import { callApi } from '../../fixtures/api';
+import { randomUsername, signupUser } from '../../fixtures/auth';
+import { resetRateLimit } from '../../fixtures/rate_limit';
+
+interface MuteEntry {
+  id: string;
+  muteeId: string;
+}
+
+test.describe('users: mute CRUD round-trip', () => {
+  test.beforeAll(() => {
+    resetRateLimit();
+  });
+
+  test('A mutes then unmutes B; mute/list reflects both transitions', async ({
+    request,
+  }) => {
+    const me = await signupUser(request, randomUsername('mtA'));
+    const target = await signupUser(request, randomUsername('mtB'));
+
+    // create mute → 204。
+    const createResp = await callApi(request, 'mute/create', {
+      i: me.token,
+      userId: target.id,
+    });
+    expect(createResp.status()).toBe(204);
+
+    // list で対象 user を含むこと。
+    const listAfterCreate = await callApi(request, 'mute/list', {
+      i: me.token,
+      limit: 100,
+    });
+    expect(listAfterCreate.status()).toBe(200);
+    const listed = (await listAfterCreate.json()) as MuteEntry[];
+    expect(listed.some((e) => e.muteeId === target.id)).toBe(true);
+
+    // delete mute → 204。
+    const deleteResp = await callApi(request, 'mute/delete', {
+      i: me.token,
+      userId: target.id,
+    });
+    expect(deleteResp.status()).toBe(204);
+
+    // list から消えていること。
+    const listAfterDelete = await callApi(request, 'mute/list', {
+      i: me.token,
+      limit: 100,
+    });
+    expect(listAfterDelete.status()).toBe(200);
+    const listed2 = (await listAfterDelete.json()) as MuteEntry[];
+    expect(listed2.some((e) => e.muteeId === target.id)).toBe(false);
+  });
+});

--- a/tests/playwright/specs/users/mute.spec.ts
+++ b/tests/playwright/specs/users/mute.spec.ts
@@ -8,7 +8,11 @@
 //
 // 本 spec は両 backend 共通で CRUD round-trip のみ cover する。timeline
 // filter 連動 (= mute 後に対象 user の note が timeline から除外) は
-// 両 backend で挙動が分散しており別 spec scope (本 PR では扱わない)。
+// 両 backend で挙動が分散しており本 PR の scope 外:
+//   - upstream Misskey TS は timeline endpoint で muting JOIN を使い filter 済
+//   - mk-go は現状 timeline endpoint 側に user mute filter 未実装
+//     (internal/core/timeline/timeline_filter.go は channel mute のみ)
+// 後続 spec / drift fix issue で別途整備する。
 
 import { expect, test } from '@playwright/test';
 import { callApi } from '../../fixtures/api';

--- a/tests/playwright/specs/users/profile.spec.ts
+++ b/tests/playwright/specs/users/profile.spec.ts
@@ -1,0 +1,57 @@
+// Phase 2 #820: users/show + i/update の round-trip。
+//
+// upstream Misskey TS と mk-go は両方とも:
+//   - i/update で `name` / `description` 等の自プロフィール field を更新
+//   - users/show { userId } で更新後の値が反映される (= 同 transaction で
+//     即可視)
+//
+// 本 spec は両 backend 共通で:
+//   1. user signup
+//   2. users/show 初期状態 → name=null / description=null を確認
+//   3. i/update で name + description を設定
+//   4. users/show 再取得 → 更新値が反映されること
+//
+// avatar / banner 等の file 系 field 更新は別 spec (drive 系) で扱う。
+
+import { expect, test } from '@playwright/test';
+import { callApi } from '../../fixtures/api';
+import { randomUsername, signupUser } from '../../fixtures/auth';
+import { resetRateLimit } from '../../fixtures/rate_limit';
+
+test.describe('users: profile show / i/update round-trip', () => {
+  test.beforeAll(() => {
+    resetRateLimit();
+  });
+
+  test('i/update reflects via users/show', async ({ request }) => {
+    const me = await signupUser(request, randomUsername('upA'));
+
+    // 初期状態は name / description ともに未設定 (null)。
+    const before = await callApi(request, 'users/show', { userId: me.id });
+    expect(before.status()).toBe(200);
+    const beforeBody = await before.json();
+    expect(beforeBody.id).toBe(me.id);
+    // 未設定 field は null (= upstream TS と mk-go の packUserDetailed shape)
+    expect(beforeBody.name).toBeNull();
+    expect(beforeBody.description).toBeNull();
+
+    // 更新を投げる。i/update は 200 で更新後の self entity を返す。
+    const updateResp = await callApi(request, 'i/update', {
+      i: me.token,
+      name: 'Alice',
+      description: 'hello playwright',
+    });
+    expect(updateResp.status()).toBe(200);
+    const updated = await updateResp.json();
+    expect(updated.name).toBe('Alice');
+    expect(updated.description).toBe('hello playwright');
+
+    // users/show 再取得で更新が反映されていること。
+    const after = await callApi(request, 'users/show', { userId: me.id });
+    expect(after.status()).toBe(200);
+    const afterBody = await after.json();
+    expect(afterBody.id).toBe(me.id);
+    expect(afterBody.name).toBe('Alice');
+    expect(afterBody.description).toBe('hello playwright');
+  });
+});

--- a/tests/playwright/specs/users/user_list.spec.ts
+++ b/tests/playwright/specs/users/user_list.spec.ts
@@ -1,0 +1,115 @@
+// Phase 2 #820: users/lists CRUD + push/pull member + user-list-timeline。
+//
+// upstream Misskey TS と mk-go は両方とも:
+//   - users/lists/create { name } で UserList を作成し entity (id/name/userId)
+//     を返す
+//   - users/lists/list で自分の list 一覧
+//   - users/lists/push { listId, userId } / pull で member 操作 (204)
+//   - users/lists/show { listId } で list を返す
+//   - users/lists/delete { listId } で削除 (204)
+//   - notes/user-list-timeline { listId } で member の note を timeline 形式
+//     で取得 (= upstream は user_list_membership と JOIN、mk-go も同様)
+//
+// 本 spec は両 backend 共通で:
+//   1. owner / member signup
+//   2. owner が user list を作成 / list 一覧で含むこと
+//   3. owner が member を push
+//   4. member が public note 投稿
+//   5. owner の user-list-timeline で note を pollForTimelineNote (fanout
+//      が settle するまで poll)
+//   6. owner が member を pull → 削除確認
+//   7. owner が list を delete → users/lists/list から消える
+
+import { expect, test } from '@playwright/test';
+import { callApi } from '../../fixtures/api';
+import { randomUsername, signupUser } from '../../fixtures/auth';
+import { createNote } from '../../fixtures/notes';
+import { resetRateLimit } from '../../fixtures/rate_limit';
+import { pollForTimelineNote } from '../../fixtures/timeline';
+
+// drop-in shape drift (= #871 で揃える方向):
+//   - TS の users/lists/create は { id, createdAt, name, userIds[], isPublic }
+//   - mk-go は { id, userId, name }
+//   両者で確実に存在するのは id / name のみなので spec 側はそこだけ assert
+//   する。
+interface UserList {
+  id: string;
+  name: string;
+}
+
+test.describe('users: list CRUD + member ops + user-list-timeline', () => {
+  test.beforeAll(() => {
+    resetRateLimit();
+  });
+
+  test('owner creates list, pushes member, sees their note in user-list-timeline, then pulls and deletes', async ({
+    request,
+  }) => {
+    const owner = await signupUser(request, randomUsername('ulA'));
+    const member = await signupUser(request, randomUsername('ulB'));
+
+    // create list。
+    const createResp = await callApi(request, 'users/lists/create', {
+      i: owner.token,
+      name: 'spec-list',
+    });
+    expect(createResp.status()).toBe(200);
+    const list = (await createResp.json()) as UserList;
+    expect(list.name).toBe('spec-list');
+    // userId / userIds 等の owner 情報 field は backend 間で形が違うので
+    // 本 spec では含まず、所有権は users/lists/list の自分視点取得で
+    // 間接的に check する (= owner の list 一覧で含まれる = 自分の list)。
+
+    // owner の list 一覧で含むこと。
+    const listsResp = await callApi(request, 'users/lists/list', {
+      i: owner.token,
+    });
+    expect(listsResp.status()).toBe(200);
+    const lists = (await listsResp.json()) as UserList[];
+    expect(lists.some((l) => l.id === list.id)).toBe(true);
+
+    // member を push → 204。
+    const pushResp = await callApi(request, 'users/lists/push', {
+      i: owner.token,
+      listId: list.id,
+      userId: member.id,
+    });
+    expect(pushResp.status()).toBe(204);
+
+    // member が public note 投稿、user-list-timeline で出ることを poll で確認。
+    const note = await createNote(request, member.token, {
+      text: 'list timeline check',
+      visibility: 'public',
+    });
+    await pollForTimelineNote(
+      request,
+      'notes/user-list-timeline',
+      owner.token,
+      note.id,
+      { listId: list.id },
+    );
+
+    // member を pull → 204。
+    const pullResp = await callApi(request, 'users/lists/pull', {
+      i: owner.token,
+      listId: list.id,
+      userId: member.id,
+    });
+    expect(pullResp.status()).toBe(204);
+
+    // list を delete → 204。
+    const deleteResp = await callApi(request, 'users/lists/delete', {
+      i: owner.token,
+      listId: list.id,
+    });
+    expect(deleteResp.status()).toBe(204);
+
+    // owner の list 一覧から消えていること。
+    const listsAfter = await callApi(request, 'users/lists/list', {
+      i: owner.token,
+    });
+    expect(listsAfter.status()).toBe(200);
+    const listsRemaining = (await listsAfter.json()) as UserList[];
+    expect(listsRemaining.some((l) => l.id === list.id)).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary

- Playwright Phase 2 #820 として users 系 5 spec を 1 PR で整備。
- 検出した 3 件の drop-in shape drift は別 issue (#870 / #871 / #872) として fix を切り出し、spec 側は LCD 抽象化で両 backend pass を確保。

## 主な変更点

### Spec 追加
- `tests/playwright/specs/users/profile.spec.ts`: i/update + users/show round-trip
- `tests/playwright/specs/users/follow.spec.ts`: following/create + delete + users/following round-trip
- `tests/playwright/specs/users/mute.spec.ts`: mute/create + delete + list の CRUD
- `tests/playwright/specs/users/block.spec.ts`: blocking/create + delete + list + blocked → follow reject 副作用
- `tests/playwright/specs/users/user_list.spec.ts`: users/lists CRUD + push/pull + user-list-timeline 反映

### Helper 拡張
- `tests/playwright/fixtures/timeline.ts`: `pollForTimelineNote` に endpoint 固有 param (= listId 等) を渡せる body 引数を追加。

### 検出 drift (= 後続 issue で揃える方針)
- **#870** blocking/create / delete return shape: TS=200+UserDetailed / mk-go=204 No Content → spec は 2xx range で吸収
- **#871** users/lists/create response shape: TS=`{id,createdAt,name,userIds,isPublic}` / mk-go=`{id,userId,name}` → spec は `{id, name}` のみ assert
- **#872** blocked → following/create reject status: TS=400 / mk-go=403 → spec は 4xx range で吸収

## Testing

- `make playwright-up && make playwright-test` (mk-go backend, 53 specs): **53 passed**
- `make playwright-ts-up && make playwright-ts-test` (TS backend, 53 specs): **53 passed**

## Related

- Closes #820
- Spawns: #870, #871, #872 (drift fix issues)

🤖 Generated with [Claude Code](https://claude.com/claude-code)