### PR TITLE
#828 Playwright Phase 2: search spec (notes/search + users/search + search-by-tag)

### DIFF
--- a/tests/playwright/specs/search/notes_search.spec.ts
+++ b/tests/playwright/specs/search/notes_search.spec.ts
@@ -1,0 +1,84 @@
+// Phase 2 #828: notes/search の text 検索 round-trip。
+//
+// upstream Misskey TS と mk-go は両方とも:
+//   - notes/search { query } で text 検索を実行
+//   - 空 query は 400 INVALID_PARAM で reject
+//
+// drop-in capability drift (= 後続 issue で揃える方向):
+//   - upstream Misskey TS は meilisearch / sonic 等の external search backend
+//     を必須とし、未配備時は 400 UNAVAILABLE を返す
+//   - mk-go は SQL LIKE による fallback path を持つので search backend 無しでも
+//     200 + 結果を返す
+//   playwright stack には search backend を組み込まない方針なので、本 spec は:
+//     - 200 (mk-go の SQL LIKE 結果) → hit を strict assert
+//     - 400 UNAVAILABLE (TS 側) → backend 不在として許容
+//   両 case を許容する。capability gap の解消 (= mk-go SQL LIKE は upstream
+//   非互換、または playwright stack に meilisearch 相当を組み込み) は
+//   別 issue で扱う scope。
+//
+// 本 spec は両 backend 共通で:
+//   1. user signup
+//   2. unique 文字列を含む public note を投稿
+//   3. notes/search で 200 なら hit を、400 なら UNAVAILABLE を確認
+//   4. 空 query は 400
+
+import { expect, test } from '@playwright/test';
+import { callApi } from '../../fixtures/api';
+import { randomUsername, signupUser } from '../../fixtures/auth';
+import { createNote } from '../../fixtures/notes';
+import { resetRateLimit } from '../../fixtures/rate_limit';
+
+interface SearchedNote {
+  id: string;
+  text?: string | null;
+}
+
+test.describe('search: notes/search text round-trip', () => {
+  test.beforeAll(() => {
+    resetRateLimit();
+  });
+
+  test('search by unique substring returns the matching note', async ({
+    request,
+  }) => {
+    const author = await signupUser(request, randomUsername('nsA'));
+    // 衝突しないように user prefix と timestamp 由来の suffix を combine
+    // (= 既存 stack 上に同 query で hit する note があっても本 test note は
+    // 必ず単独で識別できる文字列にする)。
+    const unique = `pwsearch_${Date.now()}`;
+    const note = await createNote(request, author.token, {
+      text: `hello ${unique} world`,
+      visibility: 'public',
+    });
+
+    const resp = await callApi(request, 'notes/search', {
+      i: author.token,
+      query: unique,
+      limit: 10,
+    });
+    if (resp.status() === 200) {
+      // mk-go SQL LIKE fallback 等、search backend が動く場合
+      // unique 文字列で必ず hit する。
+      const list = (await resp.json()) as SearchedNote[];
+      expect(Array.isArray(list)).toBe(true);
+      const hit = list.find((n) => n.id === note.id);
+      expect(hit).toBeDefined();
+    } else {
+      // upstream Misskey TS 等 external search backend 必須環境では
+      // 400 UNAVAILABLE を返す (= playwright stack に meilisearch 不在)。
+      expect(resp.status()).toBe(400);
+      const body = await resp.json();
+      expect(body.error?.code).toBe('UNAVAILABLE');
+    }
+  });
+
+  test('empty query is rejected with 400', async ({ request }) => {
+    const me = await signupUser(request, randomUsername('nsB'));
+    const resp = await callApi(request, 'notes/search', {
+      i: me.token,
+      query: '',
+      limit: 10,
+    });
+    expect(resp.status()).toBe(400);
+  });
+});

--- a/tests/playwright/specs/search/notes_search.spec.ts
+++ b/tests/playwright/specs/search/notes_search.spec.ts
@@ -58,11 +58,13 @@ test.describe('search: notes/search text round-trip', () => {
     });
     if (resp.status() === 200) {
       // mk-go SQL LIKE fallback 等、search backend が動く場合
-      // unique 文字列で必ず hit する。
+      // unique 文字列で必ず hit し、text shape も regression guard する
+      // (= packNote が text を含む shape を返すこと)。
       const list = (await resp.json()) as SearchedNote[];
       expect(Array.isArray(list)).toBe(true);
       const hit = list.find((n) => n.id === note.id);
       expect(hit).toBeDefined();
+      expect(hit?.text).toContain(unique);
     } else {
       // upstream Misskey TS 等 external search backend 必須環境では
       // 400 UNAVAILABLE を返す (= playwright stack に meilisearch 不在)。

--- a/tests/playwright/specs/search/notes_search_by_tag.spec.ts
+++ b/tests/playwright/specs/search/notes_search_by_tag.spec.ts
@@ -1,0 +1,79 @@
+// Phase 2 #828: notes/search-by-tag の round-trip。
+//
+// upstream Misskey TS と mk-go は両方とも:
+//   - notes/search-by-tag { tag } で note.tags 列に tag を含む note を返す
+//   - tag 抽出は note 作成時に sync で text/cw から `#tag` を拾い tags 列に
+//     格納される (= mk-go では NoteCreateService の hashtag.Extract、
+//     #655)。よって poll 不要で post 直後に検索可能。
+//   - tag が空または query 配列が空のときは 400 INVALID_PARAM
+//
+// 本 spec は両 backend 共通で:
+//   1. user signup
+//   2. unique tag を含む public note を投稿 (text に `#tag` 形式)
+//   3. notes/search-by-tag { tag: <unique> } で hit、note.id が一致
+//   4. 不存在 tag は空配列
+//
+// 関連: hashtags/search (= hashtag テーブル経由の prefix 検索) は
+// hashtagHook が async (fire-and-forget goroutine) で populate するため
+// flaky 化リスクあり、別 spec PR scope。
+
+import { expect, test } from '@playwright/test';
+import { callApi } from '../../fixtures/api';
+import { randomUsername, signupUser } from '../../fixtures/auth';
+import { createNote } from '../../fixtures/notes';
+import { resetRateLimit } from '../../fixtures/rate_limit';
+
+interface SearchedNote {
+  id: string;
+}
+
+test.describe('search: notes/search-by-tag round-trip', () => {
+  test.beforeAll(() => {
+    resetRateLimit();
+  });
+
+  test('search by hashtag returns the tagged note', async ({ request }) => {
+    const author = await signupUser(request, randomUsername('btA'));
+    // tag は既存 stack の他 note と衝突しないよう uniq 化。
+    // hashtag.Extract は alphanumeric / underscore を許容、ms timestamp の
+    // base36 representation で十分 short かつ uniq。
+    const tag = `pwtag${Date.now().toString(36)}`;
+    const note = await createNote(request, author.token, {
+      text: `tag this note with #${tag} please`,
+      visibility: 'public',
+    });
+
+    const resp = await callApi(request, 'notes/search-by-tag', {
+      i: author.token,
+      tag,
+      limit: 10,
+    });
+    expect(resp.status()).toBe(200);
+    const list = (await resp.json()) as SearchedNote[];
+    expect(Array.isArray(list)).toBe(true);
+    const hit = list.find((n) => n.id === note.id);
+    expect(hit).toBeDefined();
+  });
+
+  test('non-existent tag returns empty array', async ({ request }) => {
+    const me = await signupUser(request, randomUsername('btB'));
+    const resp = await callApi(request, 'notes/search-by-tag', {
+      i: me.token,
+      tag: `noexist_${Date.now().toString(36)}`,
+      limit: 10,
+    });
+    expect(resp.status()).toBe(200);
+    const list = (await resp.json()) as SearchedNote[];
+    expect(list).toEqual([]);
+  });
+
+  test('empty tag is rejected with 400', async ({ request }) => {
+    const me = await signupUser(request, randomUsername('btC'));
+    const resp = await callApi(request, 'notes/search-by-tag', {
+      i: me.token,
+      tag: '',
+      limit: 10,
+    });
+    expect(resp.status()).toBe(400);
+  });
+});

--- a/tests/playwright/specs/search/users_search.spec.ts
+++ b/tests/playwright/specs/search/users_search.spec.ts
@@ -1,0 +1,49 @@
+// Phase 2 #828: users/search の round-trip。
+//
+// upstream Misskey TS と mk-go は両方とも:
+//   - users/search { query } で username / displayName を partial match
+//   - response は UserDetailed array
+//   - origin (local / remote / combined) で scope を絞れる (#763)
+//
+// 本 spec は両 backend 共通で:
+//   1. unique username で user A signup
+//   2. users/search { query: <unique prefix> } で hit、id が A.id と一致
+//
+// 注意: users/search-by-username-and-host は本 spec scope から外す。
+// playwright stack で TS/mk-go 間の input 解釈に drift (= 同 username で
+// TS は空配列、mk-go は hit) があるため、shape 互換 spec として round-trip
+// 化が難しい。drift は別 issue で揃える方向 (= host=null の semantics
+// 整合)。
+
+import { expect, test } from '@playwright/test';
+import { callApi } from '../../fixtures/api';
+import { randomUsername, signupUser } from '../../fixtures/auth';
+import { resetRateLimit } from '../../fixtures/rate_limit';
+
+interface SearchedUser {
+  id: string;
+  username: string;
+}
+
+test.describe('search: users/search round-trip', () => {
+  test.beforeAll(() => {
+    resetRateLimit();
+  });
+
+  test('search by username substring returns the user', async ({ request }) => {
+    const me = await signupUser(request, randomUsername('usA'));
+
+    const resp = await callApi(request, 'users/search', {
+      i: me.token,
+      query: me.username,
+      limit: 10,
+    });
+    expect(resp.status()).toBe(200);
+    const list = (await resp.json()) as SearchedUser[];
+    expect(Array.isArray(list)).toBe(true);
+    const hit = list.find((u) => u.id === me.id);
+    expect(hit).toBeDefined();
+    expect(hit!.username).toBe(me.username);
+  });
+
+});

--- a/tests/playwright/specs/search/users_search.spec.ts
+++ b/tests/playwright/specs/search/users_search.spec.ts
@@ -45,5 +45,4 @@ test.describe('search: users/search round-trip', () => {
     expect(hit).toBeDefined();
     expect(hit!.username).toBe(me.username);
   });
-
 });


### PR DESCRIPTION
## Summary

- Playwright Phase 2 #828 として search 系 spec を整備。
- 検出した 2 件の drop-in drift は別 issue (#877 / #878) として fix を切り出し、spec 側は LCD 抽象化 / scope 外しで両 backend pass を確保。

## 主な変更点

### Spec 追加
- `tests/playwright/specs/search/notes_search.spec.ts`: 200 + hit (mk-go SQL LIKE) と 400 UNAVAILABLE (TS) を両許容で text 検索 round-trip
- `tests/playwright/specs/search/users_search.spec.ts`: users/search を username partial match で round-trip
- `tests/playwright/specs/search/notes_search_by_tag.spec.ts`: notes/search-by-tag round-trip + non-existent tag = `[]` + 空 tag = 400

### scope 外
- **hashtags/search**: hashtag table populate が async (HashtagHook の fire-and-forget goroutine) で flaky リスクあり、polling pattern の別 spec PR で扱う
- **users/search-by-username-and-host**: TS / mk-go で host 未指定 / null 時の semantics drift (#878)、別 fix issue 後に spec 復活

### 検出 drift (= 後続 issue で揃える方針)
- **#877**: notes/search の external search backend 必須要件
  - TS=400 `UNAVAILABLE` (search backend 未配備時) / mk-go=200 (SQL LIKE fallback)
  - spec は 200/400 両許容で吸収
- **#878**: users/search-by-username-and-host の host=null semantics
  - TS=`[]` / mk-go=local user hit (#766 fix の実装)
  - spec scope 外

## Testing

- `make playwright-up && make playwright-test` (mk-go, 60 specs): **60 passed**
- `make playwright-ts-up && make playwright-ts-test` (TS, 59 specs): **59 passed**
  (mk-go 60 - TS 59 の差分は users/search-by-username-and-host test を本 PR で含めなかったため。なお search/_diag.spec.ts は merge 前に削除済)

## Related

- Closes #828
- Spawns: #877, #878 (drift fix issues)

🤖 Generated with [Claude Code](https://claude.com/claude-code)