### PR TITLE
Fix #877 + #878: search 系 drop-in shape drift をまとめて修正

### DIFF
--- a/internal/api/notes/handler.go
+++ b/internal/api/notes/handler.go
@@ -468,6 +468,11 @@ func (h *Handler) Search(c echo.Context) error {
 		if errors.Is(err, search.ErrEmptyQuery) {
 			return apierr.JSONInvalidParam(c)
 		}
+		// fulltextSearch.provider="none" 時は ErrUnavailable を 400
+		// UNAVAILABLE に翻訳する (= upstream Misskey TS と同 shape、#877)。
+		if errors.Is(err, search.ErrUnavailable) {
+			return c.JSON(http.StatusBadRequest, apierr.Error("UNAVAILABLE", "Search of notes unavailable.", "0b44998d-77aa-4427-80d0-d2c9b8523011"))
+		}
 		return apierr.JSONInternalError(c)
 	}
 	return c.JSON(http.StatusOK, h.packMany(c.Request().Context(), notes, viewer))

--- a/internal/api/notes/handler_query_test.go
+++ b/internal/api/notes/handler_query_test.go
@@ -182,6 +182,28 @@ func TestSearch_InvalidJSON(t *testing.T) {
 	assert.Equal(t, http.StatusBadRequest, rec.Code)
 }
 
+// TestSearch_NoopProviderReturnsUnavailable verifies that NoopProvider
+// (= fulltextSearch.provider="none") の ErrUnavailable は handler 層で
+// 400 UNAVAILABLE に翻訳されること (#877)。upstream Misskey TS の
+// notes/search 未配備時の error shape と一致。
+func TestSearch_NoopProviderReturnsUnavailable(t *testing.T) {
+	noteRepo := testutil.NewMockNoteRepository()
+	pollRepo := testutil.NewMockPollRepository()
+	idGen, _ := id.NewGenerator("aidx")
+	createSvc := corenote.NewCreateService(noteRepo, pollRepo, idGen, nil)
+	deleteSvc := corenote.NewDeleteService(noteRepo)
+	querySvc := corenote.NewQueryService(noteRepo, nil)
+	searchSvc := search.NewService(search.NewNoopProvider())
+	h := NewHandler(noteRepo, createSvc, deleteSvc, querySvc, nil, nil, nil, searchSvc, idGen)
+
+	c, rec := newJSONRequest(t, "/api/notes/search", `{"query":"hello"}`)
+	require.NoError(t, h.Search(c))
+	assert.Equal(t, http.StatusBadRequest, rec.Code)
+	body := rec.Body.String()
+	assert.Contains(t, body, `"code":"UNAVAILABLE"`)
+	assert.Contains(t, body, "0b44998d-77aa-4427-80d0-d2c9b8523011")
+}
+
 // TestSearch_NoSearchService verifies the early-out branch when search is
 // not configured at all (e.g. test handlers built without injecting one).
 func TestSearch_NoSearchService(t *testing.T) {

--- a/internal/core/search/noop_provider.go
+++ b/internal/core/search/noop_provider.go
@@ -2,13 +2,17 @@ package search
 
 import "github.com/shiroha-a/mk/internal/model"
 
-// NoopProvider is the default Provider used when search is disabled in the
-// configuration.  All operations are no-ops; SearchNote always returns an
-// empty slice.
+// NoopProvider is the Provider used when the operator opts into TS-strict
+// drop-in compat (= fulltextSearch.provider="none")。upstream Misskey TS は
+// meilisearch / sonic 等の external search backend を必須とし、未配備時は
+// notes/search が 400 UNAVAILABLE を返す。NoopProvider はその挙動を mk-go
+// で再現するために IndexNote / UnindexNote は no-op で受け、SearchNote は
+// ErrUnavailable を返す (#877)。
 type NoopProvider struct{}
 
 // NewNoopProvider returns a Provider whose operations all succeed without
-// touching any external system.
+// touching any external system. SearchNote だけは ErrUnavailable を返し、
+// ハンドラ層で 400 UNAVAILABLE に翻訳される (#877)。
 func NewNoopProvider() *NoopProvider { return &NoopProvider{} }
 
 // IndexNote is a no-op.
@@ -17,7 +21,8 @@ func (p *NoopProvider) IndexNote(_ *model.Note) error { return nil }
 // UnindexNote is a no-op.
 func (p *NoopProvider) UnindexNote(_ *model.Note) error { return nil }
 
-// SearchNote always returns an empty slice.
+// SearchNote returns ErrUnavailable so the handler can translate it to a
+// 400 UNAVAILABLE response (= upstream TS と同 shape、#877)。
 func (p *NoopProvider) SearchNote(_ *model.User, _ string, _ SearchOpts, _ Pagination) ([]*model.Note, error) {
-	return nil, nil
+	return nil, ErrUnavailable
 }

--- a/internal/core/search/noop_provider_test.go
+++ b/internal/core/search/noop_provider_test.go
@@ -8,11 +8,17 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestNoopProvider_AllOpsAreNoOps(t *testing.T) {
+func TestNoopProvider_IndexUnindexAreNoOps(t *testing.T) {
 	p := NewNoopProvider()
 	require.NoError(t, p.IndexNote(&model.Note{ID: "x"}))
 	require.NoError(t, p.UnindexNote(&model.Note{ID: "x"}))
+}
+
+// SearchNote on NoopProvider must return ErrUnavailable so the API handler can
+// translate it to upstream Misskey TS-compatible 400 UNAVAILABLE (#877)。
+func TestNoopProvider_SearchNoteReturnsUnavailable(t *testing.T) {
+	p := NewNoopProvider()
 	out, err := p.SearchNote(nil, "anything", SearchOpts{UserID: "u1"}, Pagination{Limit: 10})
-	require.NoError(t, err)
-	assert.Empty(t, out)
+	require.ErrorIs(t, err, ErrUnavailable)
+	assert.Nil(t, out)
 }

--- a/internal/core/search/provider.go
+++ b/internal/core/search/provider.go
@@ -17,6 +17,12 @@ import (
 // blank search query. ハンドラ層で 400 BadRequest に変換する想定。
 var ErrEmptyQuery = errors.New("search query is empty")
 
+// ErrUnavailable is returned by NoopProvider.SearchNote when the operator has
+// explicitly disabled note search (= fulltextSearch.provider="none")。
+// upstream Misskey TS と同 semantics で、ハンドラ層で 400 UNAVAILABLE
+// (id: 0b44998d-77aa-4427-80d0-d2c9b8523011) に変換する想定 (#877)。
+var ErrUnavailable = errors.New("search backend is not available")
+
 // NoteDocument is the projection of a model.Note that gets stored in an
 // external full-text search index (typically Meilisearch). SQL backends do not
 // use this type — they query the live `note` table directly.

--- a/internal/core/search/service_test.go
+++ b/internal/core/search/service_test.go
@@ -85,7 +85,9 @@ func TestService_NilProviderFallsBackToNoop(t *testing.T) {
 	svc := NewService(nil)
 	require.NoError(t, svc.IndexNote(&model.Note{ID: "x"}))
 	require.NoError(t, svc.UnindexNote(&model.Note{ID: "x"}))
-	out, err := svc.SearchNote(nil, "x", SearchOpts{}, Pagination{Limit: 5})
-	require.NoError(t, err)
-	assert.Empty(t, out)
+	// nil provider → NoopProvider (#877 で SearchNote は ErrUnavailable を
+	// 返すように改修)。caller (handler) 側で 400 UNAVAILABLE に翻訳する
+	// 想定。
+	_, err := svc.SearchNote(nil, "x", SearchOpts{}, Pagination{Limit: 5})
+	require.ErrorIs(t, err, ErrUnavailable)
 }

--- a/internal/repository/user.go
+++ b/internal/repository/user.go
@@ -241,9 +241,23 @@ func (r *userRepository) SearchByUsername(query string, limit, offset int, origi
 // (or local users when host is nil). #766 fix: SearchByUsername の origin
 // 軸では「特定 host への絞り込み」ができないので分離した sibling method。
 // host comparison は lower(host) = lower(?) で case-insensitive。
+//
+// upstream Misskey TS の UserSearchService.searchByUsernameAndHost も同様に
+// usernameLower prefix match + host case-insensitive prefix match を適用し、
+// `isSuspended = FALSE` で suspended user を除外する (#878)。mk-go も同 filter
+// を共有して drop-in 互換を維持する。
+//
+// なお upstream TS は logged-in caller に対して updatedAt > / <= threshold の
+// 4-query 優先順位 (followee active/inactive + non-followee active/inactive)
+// を適用する。これは新規 signup user (updatedAt = NULL) を search 結果から
+// 除外する quirk があり、brand-new user の discoverability を悪化させる。
+// mk-go では本 quirk を意図的に採用せず、followersCount DESC + id ASC の
+// 単純な sort を維持する (= 新規 user も即 search hit する)。詳細は #878。
 func (r *userRepository) SearchByUsernameAndHost(query string, host *string, limit int) ([]*model.User, error) {
 	var users []*model.User
-	q := r.db.Where("\"usernameLower\" LIKE ?", query+"%")
+	q := r.db.
+		Where("\"usernameLower\" LIKE ?", query+"%").
+		Where("\"isSuspended\" = false")
 	if host != nil {
 		q = q.Where("lower(\"host\") = lower(?)", *host)
 	} else {

--- a/internal/repository/user_test.go
+++ b/internal/repository/user_test.go
@@ -447,6 +447,23 @@ func TestUserRepository_SearchByUsernameAndHost(t *testing.T) {
 		}
 		assert.True(t, ids[remote.ID])
 	})
+
+	// upstream Misskey TS は isSuspended=TRUE の user を search 結果から
+	// 除外する。mk-go も #878 fix で同 filter を適用するので、suspend した
+	// user が hit から消えること。
+	t.Run("isSuspended user is filtered out", func(t *testing.T) {
+		require.NoError(t, repo.UpdateUser(local.ID, map[string]any{"isSuspended": true}))
+		t.Cleanup(func() {
+			_ = repo.UpdateUser(local.ID, map[string]any{"isSuspended": false})
+		})
+		out, err := repo.SearchByUsernameAndHost("hosttest", nil, 10)
+		require.NoError(t, err)
+		ids := make(map[string]bool, len(out))
+		for _, u := range out {
+			ids[u.ID] = true
+		}
+		assert.False(t, ids[local.ID], "suspended user must not appear in search")
+	})
 }
 
 func TestUserRepository_UpdateUser(t *testing.T) {

--- a/internal/server/search.go
+++ b/internal/server/search.go
@@ -16,7 +16,11 @@ import (
 //   - meilisearch (with meilisearch host configured) → MeilisearchProvider
 //   - sqlPgroonga                                    → SQLLikeProvider using
 //     the PGroonga `&@~` operator (requires the pgroonga extension)
+//   - none                                           → NoopProvider
+//     (notes/search は 400 UNAVAILABLE で reject、upstream Misskey TS と
+//     同 strict-mode、#877)
 //   - sqlLike / unset (with no meilisearch host)     → SQLLikeProvider (ILIKE)
+//     (mk-go 既定、軽量 deployment 向けの fallback)
 func buildSearchProvider(
 	cfg *config.Config,
 	noteRepo repository.NoteRepository,
@@ -45,8 +49,14 @@ func buildSearchProvider(
 	if provider == "sqlpgroonga" {
 		return coresearch.NewSQLPgroongaProvider(noteRepo, followingRepo)
 	}
+	// "none" は upstream TS strict-mode (= notes/search を 400 UNAVAILABLE
+	// で reject、#877)。SQL LIKE fallback を持たない deployment ですら
+	// drop-in compat を維持したい operator 向けの opt-in。
+	if provider == "none" {
+		return coresearch.NewNoopProvider()
+	}
 	// fulltextSearch.provider が "sqlLike" / 未設定 / 不明な値の場合は
-	// SQL ILIKE フォールバック。
+	// SQL ILIKE フォールバック (mk-go 既定)。
 	return coresearch.NewSQLLikeProvider(noteRepo, followingRepo)
 }
 

--- a/internal/server/search_test.go
+++ b/internal/server/search_test.go
@@ -108,6 +108,19 @@ func TestBuildSearchProvider_MeilisearchWithoutHostFallsBack(t *testing.T) {
 	require.IsType(t, &coresearch.SQLLikeProvider{}, p)
 }
 
+// TestBuildSearchProvider_NoneSelectsNoop verifies that fulltextSearch.provider
+// = "none" returns a NoopProvider so notes/search responds with 400
+// UNAVAILABLE (= upstream Misskey TS strict-mode、#877)。
+func TestBuildSearchProvider_NoneSelectsNoop(t *testing.T) {
+	repo, idGen := newRepoAndIDGen(t)
+	cfg := &config.Config{FulltextSearch: &config.FulltextSearchOptions{Provider: "none"}}
+	p := buildSearchProvider(cfg, repo, nil, idGen)
+	require.IsType(t, &coresearch.NoopProvider{}, p)
+
+	_, err := p.SearchNote(nil, "hello", coresearch.SearchOpts{}, coresearch.Pagination{Limit: 10})
+	require.ErrorIs(t, err, coresearch.ErrUnavailable)
+}
+
 func TestBuildMeilisearchHost(t *testing.T) {
 	cases := []struct {
 		name string


### PR DESCRIPTION
## Summary

#828 spec (PR #879) で検出した search 系 drift 2 件を 1 PR で対応。spec 側は LCD 抽象化済なので両 backend pass を維持。

## Drift fix 内訳

### #877: notes/search の external search backend 必須要件
upstream Misskey TS は meilisearch / sonic 等が未配備時 `400 UNAVAILABLE` を返す strict mode。mk-go は SQL LIKE fallback で常に 200 を返していた。

修正方針: opt-in 設定 `fulltextSearch.provider: "none"` を追加し、operator が TS-strict 互換を選べるようにする (default は SQL LIKE 維持で既存 deployment 影響なし)。

- `internal/core/search/provider.go`: 新 `ErrUnavailable` 定義
- `internal/core/search/noop_provider.go`: `SearchNote` が `ErrUnavailable` を返すよう変更
- `internal/server/search.go`: `provider: "none"` → `NoopProvider`
- `internal/api/notes/handler.go`: `ErrUnavailable` → `400 UNAVAILABLE` (id `0b44998d-77aa-4427-80d0-d2c9b8523011`)

### #878: users/search-by-username-and-host の suspend filter 不在
upstream TS は `isSuspended = FALSE` で suspend user を除外、mk-go では filter 不在で suspend user も hit していた。

修正方針: `isSuspended = FALSE` filter を追加 (= 純粋な bug fix)。

なお upstream TS の logged-in caller path は `updatedAt > / <= threshold` の 4-query 優先順位を適用し、新規 signup user (`updatedAt=NULL`) を search 結果から除外する quirk があるが、本 quirk は brand-new user の discoverability を悪化させるため **意図的に不採用**。GoDoc に divergence を明記 (#878 後段で議論可能)。

- `internal/repository/user.go`: `SearchByUsernameAndHost` に `isSuspended = FALSE` filter

## Tests + Coverage

- `internal/core/search`: **100.0%** (NoopProvider が ErrUnavailable を返すこと、provider="none" wire path を strict assert)
- `internal/api/notes`: 91.6% (Search handler で 400 UNAVAILABLE + UUID 出力を strict assert)
- `internal/server`: 9.1% (router 系の wire 層、既存 threshold 0% 例外内)
- `internal/repository`: 90.2% (suspend filter sub-test 追加)
- `internal/core/user`: 93.3%

全 package で gate ≥90% (server 例外含む) クリア。

## Verification

- `make playwright-up && make playwright-test` (mk-go, 59 specs): **59 passed**
- `make fmt && make lint`: 通過

## Notes

- spec 側 (PR #879) の `notes/search` LCD (200/400 両許容) は本 fix 後も維持。default mk-go では 200 path、`provider: "none"` 設定または upstream TS では 400 path を取る。
- spec 側 `users/search-by-username-and-host` は #879 で削除済。本 PR の `isSuspended` filter 適用後も TS の `updatedAt` quirk は残るので spec round-trip は別途検討 (= 採用しない方針なら spec も復活させない)。

## Related

- Closes #877 (notes/search backend requirement)
- Closes #878 (users/search-by-username-and-host suspend filter)
- 検出元: PR #879 (#828 search spec)

🤖 Generated with [Claude Code](https://claude.com/claude-code)