### PR TITLE
#824 残: Playwright Phase 2 emoji lifecycle + /api/emojis spec

### DIFF
--- a/tests/playwright/specs/emoji/emoji_lifecycle.spec.ts
+++ b/tests/playwright/specs/emoji/emoji_lifecycle.spec.ts
@@ -40,14 +40,32 @@ interface AdminEmojiListEntry {
 }
 
 test.describe('emoji: admin lifecycle (add / update / list / delete)', () => {
+  // assertion 失敗時に DB に orphan emoji が残らないよう、test 単位で
+  // afterEach cleanup する。describe scope に id を hoist して closure で
+  // capture する pattern (= /api/emojis spec の try/finally と同等の安全性)。
+  let createdEmojiId: string | undefined;
+  let rootToken: string | undefined;
+
   test.beforeAll(() => {
     resetRateLimit();
+  });
+
+  test.afterEach(async ({ request }) => {
+    if (createdEmojiId && rootToken) {
+      await callApi(request, 'admin/emoji/delete', {
+        i: rootToken,
+        id: createdEmojiId,
+      });
+    }
+    createdEmojiId = undefined;
+    rootToken = undefined;
   });
 
   test('admin adds, updates, lists, then deletes a custom emoji', async ({
     request,
   }) => {
     const root: RootFixture = JSON.parse(readFileSync('.auth/root.json', 'utf-8'));
+    rootToken = root.token;
     const emojiName = 'spec_lc_' + Math.random().toString(16).slice(2, 8);
 
     // upload tinyPNG → fileId 取得
@@ -70,18 +88,19 @@ test.describe('emoji: admin lifecycle (add / update / list / delete)', () => {
     expect(addResp.status()).toBe(200);
     const added = (await addResp.json()) as { id: string };
     expect(typeof added.id).toBe('string');
+    createdEmojiId = added.id;
 
-    // list で query 検索 → 追加 emoji が含まれること
-    const list1 = await callApi(request, 'admin/emoji/list', {
+    // add 直後 list で query 検索 → 追加 emoji が含まれること
+    const listAfterAdd = await callApi(request, 'admin/emoji/list', {
       i: root.token,
       query: emojiName,
       limit: 10,
     });
-    expect(list1.status()).toBe(200);
-    const list1Body = (await list1.json()) as AdminEmojiListEntry[];
-    const found1 = list1Body.find((e) => e.id === added.id);
-    expect(found1).toBeDefined();
-    expect(found1!.name).toBe(emojiName);
+    expect(listAfterAdd.status()).toBe(200);
+    const listAfterAddBody = (await listAfterAdd.json()) as AdminEmojiListEntry[];
+    const foundAfterAdd = listAfterAddBody.find((e) => e.id === added.id);
+    expect(foundAfterAdd).toBeDefined();
+    expect(foundAfterAdd!.name).toBe(emojiName);
 
     // update で category を設定
     const newCategory = 'spec-cat-' + Math.random().toString(16).slice(2, 6);
@@ -92,17 +111,17 @@ test.describe('emoji: admin lifecycle (add / update / list / delete)', () => {
     });
     expect(updResp.status()).toBe(204);
 
-    // 再度 list で category が反映されていること
-    const list2 = await callApi(request, 'admin/emoji/list', {
+    // update 後 list で category が反映されていること
+    const listAfterUpdate = await callApi(request, 'admin/emoji/list', {
       i: root.token,
       query: emojiName,
       limit: 10,
     });
-    expect(list2.status()).toBe(200);
-    const list2Body = (await list2.json()) as AdminEmojiListEntry[];
-    const found2 = list2Body.find((e) => e.id === added.id);
-    expect(found2).toBeDefined();
-    expect(found2!.category).toBe(newCategory);
+    expect(listAfterUpdate.status()).toBe(200);
+    const listAfterUpdateBody = (await listAfterUpdate.json()) as AdminEmojiListEntry[];
+    const foundAfterUpdate = listAfterUpdateBody.find((e) => e.id === added.id);
+    expect(foundAfterUpdate).toBeDefined();
+    expect(foundAfterUpdate!.category).toBe(newCategory);
 
     // delete
     const delResp = await callApi(request, 'admin/emoji/delete', {
@@ -110,15 +129,17 @@ test.describe('emoji: admin lifecycle (add / update / list / delete)', () => {
       id: added.id,
     });
     expect(delResp.status()).toBe(204);
+    // 正規 path で delete 済 = afterEach cleanup の必要なし。
+    createdEmojiId = undefined;
 
-    // 一覧から消えていること
-    const list3 = await callApi(request, 'admin/emoji/list', {
+    // delete 後 list から消えていること
+    const listAfterDelete = await callApi(request, 'admin/emoji/list', {
       i: root.token,
       query: emojiName,
       limit: 10,
     });
-    expect(list3.status()).toBe(200);
-    const list3Body = (await list3.json()) as AdminEmojiListEntry[];
-    expect(list3Body.some((e) => e.id === added.id)).toBe(false);
+    expect(listAfterDelete.status()).toBe(200);
+    const listAfterDeleteBody = (await listAfterDelete.json()) as AdminEmojiListEntry[];
+    expect(listAfterDeleteBody.some((e) => e.id === added.id)).toBe(false);
   });
 });

--- a/tests/playwright/specs/emoji/emoji_lifecycle.spec.ts
+++ b/tests/playwright/specs/emoji/emoji_lifecycle.spec.ts
@@ -1,0 +1,124 @@
+// Phase 2 #824 残: admin/emoji/{add, update, list, delete} の lifecycle
+// round-trip。
+//
+// upstream Misskey TS と mk-go は両方とも:
+//   - admin/emoji/add { name, fileId } で custom emoji 追加 (200 + entity)
+//   - admin/emoji/update { id, name?, category?, aliases?, ... } で
+//     name / category 等を更新 (204 No Content)
+//   - admin/emoji/list { query?, category? } で filter 一覧
+//   - admin/emoji/delete { id } で削除 (204)
+//
+// 本 spec は両 backend 共通で 1 emoji の lifecycle を round-trip:
+//   1. globalSetup root を読み込み
+//   2. drive/files/create で tinyPNG upload (= fileId 取得)
+//   3. admin/emoji/add → 登録 emoji の id を取得
+//   4. admin/emoji/list で uniq name 検索 → 含まれること
+//   5. admin/emoji/update で category 設定 → 反映 (再度 list で category 一致)
+//   6. admin/emoji/delete → 一覧から消える
+//
+// PR #867 (#824 PR-A) は add + reaction の round-trip にフォーカスしていた
+// ので、本 spec は残 lifecycle (update / list / delete) を補完する scope。
+
+import { readFileSync } from 'node:fs';
+import { expect, test } from '@playwright/test';
+import { callApi } from '../../fixtures/api';
+import { tinyPNG } from '../../fixtures/files';
+import { resetRateLimit } from '../../fixtures/rate_limit';
+
+const baseURL = process.env.MK_BASE_URL ?? 'https://mkgo.local';
+
+interface RootFixture {
+  id: string;
+  token: string;
+  username: string;
+}
+
+interface AdminEmojiListEntry {
+  id: string;
+  name: string;
+  category?: string | null;
+}
+
+test.describe('emoji: admin lifecycle (add / update / list / delete)', () => {
+  test.beforeAll(() => {
+    resetRateLimit();
+  });
+
+  test('admin adds, updates, lists, then deletes a custom emoji', async ({
+    request,
+  }) => {
+    const root: RootFixture = JSON.parse(readFileSync('.auth/root.json', 'utf-8'));
+    const emojiName = 'spec_lc_' + Math.random().toString(16).slice(2, 8);
+
+    // upload tinyPNG → fileId 取得
+    const uploadResp = await request.post(`${baseURL}/api/drive/files/create`, {
+      multipart: {
+        i: root.token,
+        file: { name: emojiName + '.png', mimeType: 'image/png', buffer: tinyPNG },
+      },
+      failOnStatusCode: false,
+    });
+    expect(uploadResp.status()).toBe(200);
+    const uploaded = (await uploadResp.json()) as { id: string };
+
+    // add
+    const addResp = await callApi(request, 'admin/emoji/add', {
+      i: root.token,
+      name: emojiName,
+      fileId: uploaded.id,
+    });
+    expect(addResp.status()).toBe(200);
+    const added = (await addResp.json()) as { id: string };
+    expect(typeof added.id).toBe('string');
+
+    // list で query 検索 → 追加 emoji が含まれること
+    const list1 = await callApi(request, 'admin/emoji/list', {
+      i: root.token,
+      query: emojiName,
+      limit: 10,
+    });
+    expect(list1.status()).toBe(200);
+    const list1Body = (await list1.json()) as AdminEmojiListEntry[];
+    const found1 = list1Body.find((e) => e.id === added.id);
+    expect(found1).toBeDefined();
+    expect(found1!.name).toBe(emojiName);
+
+    // update で category を設定
+    const newCategory = 'spec-cat-' + Math.random().toString(16).slice(2, 6);
+    const updResp = await callApi(request, 'admin/emoji/update', {
+      i: root.token,
+      id: added.id,
+      category: newCategory,
+    });
+    expect(updResp.status()).toBe(204);
+
+    // 再度 list で category が反映されていること
+    const list2 = await callApi(request, 'admin/emoji/list', {
+      i: root.token,
+      query: emojiName,
+      limit: 10,
+    });
+    expect(list2.status()).toBe(200);
+    const list2Body = (await list2.json()) as AdminEmojiListEntry[];
+    const found2 = list2Body.find((e) => e.id === added.id);
+    expect(found2).toBeDefined();
+    expect(found2!.category).toBe(newCategory);
+
+    // delete
+    const delResp = await callApi(request, 'admin/emoji/delete', {
+      i: root.token,
+      id: added.id,
+    });
+    expect(delResp.status()).toBe(204);
+
+    // 一覧から消えていること
+    const list3 = await callApi(request, 'admin/emoji/list', {
+      i: root.token,
+      query: emojiName,
+      limit: 10,
+    });
+    expect(list3.status()).toBe(200);
+    const list3Body = (await list3.json()) as AdminEmojiListEntry[];
+    expect(list3Body.some((e) => e.id === added.id)).toBe(false);
+  });
+});

--- a/tests/playwright/specs/emoji/emojis_public.spec.ts
+++ b/tests/playwright/specs/emoji/emojis_public.spec.ts
@@ -1,0 +1,90 @@
+// Phase 2 #824 残: /api/emojis (public meta endpoint) round-trip。
+//
+// upstream Misskey TS と mk-go は両方とも:
+//   - /api/emojis (auth 不要) で local custom emoji 一覧を返す
+//   - response shape は { emojis: [{ name, category, aliases, url, ... }] }
+//   - admin/emoji/add 後すぐ反映される (cache 経由でも upstream は最大数 sec)
+//
+// 本 spec は両 backend 共通で:
+//   1. globalSetup root が tinyPNG upload + admin/emoji/add で uniq emoji を登録
+//   2. /api/emojis を 認証なしで叩く
+//   3. response.emojis 配列に追加 emoji が含まれること (= name match で hit)
+//   4. cleanup として admin/emoji/delete で削除
+//
+// /api/emojis は frontend が起動時に一括 fetch する list なので drop-in
+// 互換 (= shape / cache 含む) を担保する重要な path。
+
+import { readFileSync } from 'node:fs';
+import { expect, test } from '@playwright/test';
+import { callApi } from '../../fixtures/api';
+import { tinyPNG } from '../../fixtures/files';
+import { resetRateLimit } from '../../fixtures/rate_limit';
+
+const baseURL = process.env.MK_BASE_URL ?? 'https://mkgo.local';
+
+interface RootFixture {
+  id: string;
+  token: string;
+  username: string;
+}
+
+interface PublicEmoji {
+  name: string;
+  category?: string | null;
+  url?: string | null;
+}
+
+test.describe('emoji: /api/emojis public list', () => {
+  test.beforeAll(() => {
+    resetRateLimit();
+  });
+
+  test('newly added admin emoji appears in /api/emojis without auth', async ({
+    request,
+  }) => {
+    const root: RootFixture = JSON.parse(readFileSync('.auth/root.json', 'utf-8'));
+    const emojiName = 'spec_pub_' + Math.random().toString(16).slice(2, 8);
+
+    // upload + admin add
+    const uploadResp = await request.post(`${baseURL}/api/drive/files/create`, {
+      multipart: {
+        i: root.token,
+        file: { name: emojiName + '.png', mimeType: 'image/png', buffer: tinyPNG },
+      },
+      failOnStatusCode: false,
+    });
+    expect(uploadResp.status()).toBe(200);
+    const uploaded = (await uploadResp.json()) as { id: string };
+
+    const addResp = await callApi(request, 'admin/emoji/add', {
+      i: root.token,
+      name: emojiName,
+      fileId: uploaded.id,
+    });
+    expect(addResp.status()).toBe(200);
+    const added = (await addResp.json()) as { id: string };
+
+    try {
+      // /api/emojis は auth 不要 (= frontend 起動時 fetch)。upstream / mk-go
+      // 共に cache を介する path だが、admin/emoji/add の応答後は反映済み
+      // ことが期待される。万一 cache lag があっても本 spec は固定 wait を
+      // 入れず、即時 fetch で hit を要求する (両 backend で実測 pass)。
+      const listResp = await callApi(request, 'emojis', {});
+      expect(listResp.status()).toBe(200);
+      const body = (await listResp.json()) as { emojis: PublicEmoji[] };
+      expect(Array.isArray(body.emojis)).toBe(true);
+      const hit = body.emojis.find((e) => e.name === emojiName);
+      expect(hit).toBeDefined();
+      // url は public CDN / drive URL の form。空文字でなければ OK
+      // (具体的な URL shape は backend / config 依存なので strict 比較しない)。
+      expect(typeof hit!.url).toBe('string');
+      expect((hit!.url || '').length).toBeGreaterThan(0);
+    } finally {
+      // 後続 spec の noise を防ぐため必ず cleanup する。
+      await callApi(request, 'admin/emoji/delete', {
+        i: root.token,
+        id: added.id,
+      });
+    }
+  });
+});


### PR DESCRIPTION
## Summary

- Playwright Phase 2 #824 残 として admin emoji lifecycle (add / update / list / delete) と public `/api/emojis` の round-trip spec を整備。
- PR #867 (#824 PR-A、add + reaction round-trip) と合わせて #824 全 scope 完了 → close。
- 両 backend で 61/61 pass、検出 drift なし。

## 主な変更点

### Spec 追加
- `tests/playwright/specs/emoji/emoji_lifecycle.spec.ts`: admin が drive/files/create で fileId 取得 → admin/emoji/add → admin/emoji/list で query hit → admin/emoji/update で category 設定 → 再 list で反映 → admin/emoji/delete → 一覧から消える、を 1 test で round-trip。
- `tests/playwright/specs/emoji/emojis_public.spec.ts`: /api/emojis (auth 不要、frontend 起動時 fetch) で admin 追加 local emoji が hit、url が non-empty。spec 終了時 admin/emoji/delete で cleanup。

### scope 外 (= 別 spec PR)
- **import-zip / import-aiscript**: ZIP 一括 import は async queue 経由で polling pattern が必要なので別 PR scope (= reactions の hashtag 系と同じ判断)
- **moderation log assertion**: admin/emoji/{add, update, delete} はそれぞれ moderation log を書くが、log 取得 endpoint の round-trip は admin spec (#826) で扱う想定
- **role-restricted emoji**: roleIdsThatCanBeUsedThisEmojiAsReaction は #826 admin spec scope

## Testing

- `make playwright-up && make playwright-test` (mk-go, 61 specs): **61 passed**
- `make playwright-ts-up && make playwright-ts-test` (TS, 61 specs): **61 passed**

## Related

- Closes #824
- PR #867 が PR-A (add + reaction) を担当、本 PR が残 lifecycle を担当

🤖 Generated with [Claude Code](https://claude.com/claude-code)