### PR TITLE
#827 Playwright Phase 2: settings spec (change-password / regenerate-token / update-email)

### DIFF
--- a/tests/playwright/fixtures/auth.ts
+++ b/tests/playwright/fixtures/auth.ts
@@ -41,6 +41,12 @@ export interface Principal {
   username: string;
 }
 
+// DEFAULT_TEST_PASSWORD is the password used by signupUser when caller does
+// not specify one. spec 側で signin-flow / i/change-password / i/update-email
+// 等を叩く際にこの定数を再利用すれば signupUser の default が変わっても
+// 同期する (= 個別 spec 内で 'password1234' を直書きしない、#827 review)。
+export const DEFAULT_TEST_PASSWORD = 'password1234';
+
 // signupUser creates a regular (non-root) account via /api/signup. Phase 1
 // では captcha / email 認証は disabled な instance config を使うので
 // username + password だけで通る。複数回呼んでも username が違えば成功。
@@ -50,7 +56,7 @@ export interface Principal {
 export async function signupUser(
   request: APIRequestContext,
   username: string,
-  password = 'password1234',
+  password = DEFAULT_TEST_PASSWORD,
 ): Promise<Principal> {
   const resp = await callApi(request, 'signup', { username, password });
   if (resp.status() !== 200) {

--- a/tests/playwright/specs/settings/settings.spec.ts
+++ b/tests/playwright/specs/settings/settings.spec.ts
@@ -1,0 +1,118 @@
+// Phase 2 #827: settings spec (security / API token / email)。
+//
+// upstream Misskey TS と mk-go は両方とも:
+//   - i/change-password { currentPassword, newPassword } で password 更新
+//     (204、failed = 403 INCORRECT_PASSWORD)
+//   - i/regenerate-token { password } で API token 再発行 (= 2xx)
+//   - i/update-email { password, email } で email 設定 (200 + Me)
+//
+// 本 spec は両 backend 共通で:
+//   1. password change の round-trip (新 password で signin 成功)
+//   2. token regenerate が 2xx で成功すること (= shape drift 抽象化)
+//   3. email クリアの round-trip (200 + /api/i で null 反映)
+//
+// 2FA 系 (TOTP / passkey) は #817 part1/part2 で別 spec にて cover 済。
+// notification 設定 (notificationRecieveConfig) は mk-go では read-only で
+// 常に空 map を返しているため round-trip 化が困難 → 別 spec scope。
+//
+// drop-in shape drift (= 別 issue で揃える):
+//   - #883 i/regenerate-token return shape: TS=204 / mk-go=200+{token}
+//   - #884 旧 API token invalidation: TS=即時 reject / mk-go=cache 経由で
+//     旧 token が引き続き auth 通過するセキュリティ drift
+//   - #885 password 検証失敗時の status: TS は endpoint ごとに 400/401 /
+//     mk-go は一律 403 で揺れる
+//   本 spec は positive path のみに絞り、status drift / 旧 token round-trip
+//   は別 spec scope。
+
+import { expect, test } from '@playwright/test';
+import { callApi } from '../../fixtures/api';
+import { randomUsername, signupUser } from '../../fixtures/auth';
+import { resetRateLimit } from '../../fixtures/rate_limit';
+
+test.describe('settings: security / API token / email', () => {
+  // change-password 後に新 password で signin-flow を呼び戻すため、
+  // 1h 5 回の signup 制限と signin 系制限を test 単位で reset する。
+  test.beforeEach(() => {
+    resetRateLimit();
+  });
+
+  test('change-password: new password succeeds via signin-flow', async ({
+    request,
+  }) => {
+    const me = await signupUser(request, randomUsername('cpA'));
+    const newPassword = 'np_' + Math.random().toString(16).slice(2, 10);
+
+    // change-password
+    const changeResp = await callApi(request, 'i/change-password', {
+      i: me.token,
+      currentPassword: 'password1234', // signupUser default
+      newPassword,
+    });
+    expect(changeResp.status()).toBe(204);
+
+    // signin-flow は per-IP の rate limit を共有しており、本 test の前段
+    // で signupUser → change-password に既に複数 call を消費しているので、
+    // 新 signin の前に counter を reset する (= 既存 spec の pattern)。
+    resetRateLimit();
+
+    // 新 password で signin → 200 + token (= drop-in shape として共通)
+    const newSignin = await callApi(request, 'signin-flow', {
+      username: me.username,
+      password: newPassword,
+    });
+    expect(newSignin.status()).toBe(200);
+    const body = await newSignin.json();
+    expect(typeof body.i).toBe('string');
+    expect(body.i.length).toBeGreaterThan(0);
+  });
+
+  test('regenerate-token: 2xx response indicates success on both backends', async ({
+    request,
+  }) => {
+    const me = await signupUser(request, randomUsername('rtA'));
+
+    // regenerate-token (TS=204、mk-go=200+{token} の drop-in shape drift
+    // を 2xx range で吸収。新 token を含むかは backend 依存なので strict
+    // 検査しない、新 token round-trip は別 spec で扱う想定)。
+    const regenResp = await callApi(request, 'i/regenerate-token', {
+      i: me.token,
+      password: 'password1234',
+    });
+    expect(regenResp.status()).toBeGreaterThanOrEqual(200);
+    expect(regenResp.status()).toBeLessThan(300);
+  });
+
+  test('update-email: clearing email returns 200 + null email in response', async ({
+    request,
+  }) => {
+    const me = await signupUser(request, randomUsername('ueA'));
+
+    // signup 直後は email 未設定 (= null)。先に何も操作せず /api/i で
+    // 初期 null を確認。
+    const before = await callApi(request, 'i', { i: me.token });
+    expect(before.status()).toBe(200);
+    const beforeBody = await before.json();
+    expect(beforeBody.email ?? null).toBeNull();
+
+    // 明示的に null を渡す path で 200 + 更新後 self entity (= Me)。
+    // upstream Misskey TS と mk-go は両方とも emailRequiredForSignup=false
+    // 設定なら null 許容、200 で更新 self を返す drop-in shape。
+    const updResp = await callApi(request, 'i/update-email', {
+      i: me.token,
+      password: 'password1234',
+      email: null,
+    });
+    expect(updResp.status()).toBe(200);
+    const updBody = await updResp.json();
+    expect(updBody.id).toBe(me.id);
+    expect(updBody.email ?? null).toBeNull();
+
+    // 別 call の /api/i でも email が null のまま反映されていること
+    // (= update path と read path が同じ state を返す regression guard)。
+    const after = await callApi(request, 'i', { i: me.token });
+    expect(after.status()).toBe(200);
+    const afterBody = await after.json();
+    expect(afterBody.email ?? null).toBeNull();
+  });
+
+});

--- a/tests/playwright/specs/settings/settings.spec.ts
+++ b/tests/playwright/specs/settings/settings.spec.ts
@@ -26,7 +26,7 @@
 
 import { expect, test } from '@playwright/test';
 import { callApi } from '../../fixtures/api';
-import { randomUsername, signupUser } from '../../fixtures/auth';
+import { DEFAULT_TEST_PASSWORD, randomUsername, signupUser } from '../../fixtures/auth';
 import { resetRateLimit } from '../../fixtures/rate_limit';
 
 test.describe('settings: security / API token / email', () => {
@@ -45,7 +45,7 @@ test.describe('settings: security / API token / email', () => {
     // change-password
     const changeResp = await callApi(request, 'i/change-password', {
       i: me.token,
-      currentPassword: 'password1234', // signupUser default
+      currentPassword: DEFAULT_TEST_PASSWORD,
       newPassword,
     });
     expect(changeResp.status()).toBe(204);
@@ -76,7 +76,7 @@ test.describe('settings: security / API token / email', () => {
     // 検査しない、新 token round-trip は別 spec で扱う想定)。
     const regenResp = await callApi(request, 'i/regenerate-token', {
       i: me.token,
-      password: 'password1234',
+      password: DEFAULT_TEST_PASSWORD,
     });
     expect(regenResp.status()).toBeGreaterThanOrEqual(200);
     expect(regenResp.status()).toBeLessThan(300);
@@ -99,7 +99,7 @@ test.describe('settings: security / API token / email', () => {
     // 設定なら null 許容、200 で更新 self を返す drop-in shape。
     const updResp = await callApi(request, 'i/update-email', {
       i: me.token,
-      password: 'password1234',
+      password: DEFAULT_TEST_PASSWORD,
       email: null,
     });
     expect(updResp.status()).toBe(200);
@@ -114,5 +114,4 @@ test.describe('settings: security / API token / email', () => {
     const afterBody = await after.json();
     expect(afterBody.email ?? null).toBeNull();
   });
-
 });


### PR DESCRIPTION
## Summary

- Playwright Phase 2 #827 として settings 系 spec を整備。
- 検出した 3 件の drop-in drift は別 issue (#883 / #884 / #885) として fix を切り出し、spec 側は positive path 抽象化で両 backend pass を確保。

## 主な変更点

### Spec 追加
- `tests/playwright/specs/settings/settings.spec.ts`: 3 test を 1 file で cover
  - **change-password**: signupUser → change-password (204) → resetRateLimit → 新 password で signin-flow → 200 + token
  - **regenerate-token**: signupUser → regenerate-token → 2xx range で成功 path 担保 (TS=204 / mk-go=200+{token} の shape drift を吸収)
  - **update-email**: signupUser → /api/i で初期 email=null → update-email with null → 200 + Me (email=null) → /api/i で再 read 確認

### scope 外
- **2FA (TOTP / passkey)**: #817 part1/part2 で既に cover 済
- **notification 設定** (`notificationRecieveConfig`): mk-go では read-only で常に空 map を返すため round-trip 化困難、別 spec scope
- **theme / visual 設定**: 大半が drive 系 (avatar / banner) で #820 と領域被り、scope 外
- **delete-account**: 論理削除 path、test 後 user 削除で stack 汚染懸念があるので別 PR scope

### 検出 drift (= 後続 issue で揃える方針)
- **#883** i/regenerate-token return shape: TS=204 No Content / mk-go=200+{token}
- **#884** 旧 API token invalidation: TS=即時 reject / mk-go=cache 経由で旧 token が引き続き auth 通過 (= **セキュリティ regression**)
- **#885** password 検証失敗時の status: TS は endpoint ごとに 400/401 / mk-go 一律 403 INCORRECT_PASSWORD

## Testing

- `make playwright-up && make playwright-test` (mk-go, 64 specs): **64 passed**
- `make playwright-ts-up && make playwright-ts-test` (TS, 64 specs): **64 passed**

## Related

- Closes #827
- Spawns: #883, #884, #885 (drift fix issues)

🤖 Generated with [Claude Code](https://claude.com/claude-code)