### PR TITLE
Fix #883 + #884 + #885: settings 系 drop-in shape drift をまとめて修正

### DIFF
--- a/internal/api/i/email_update.go
+++ b/internal/api/i/email_update.go
@@ -51,9 +51,11 @@ func (h *Handler) UpdateEmail(c echo.Context) error {
 		return apierr.JSONInternalError(c)
 	}
 
-	// パスワード検証
+	// パスワード検証。upstream Misskey TS は ApiError(meta.errors.incorrectPassword)
+	// を framework が 400 (= client error) に変換する (#885)。mk-go も
+	// drop-in 互換のため 400 に揃える (旧 mk-go は 403)。
 	if err := bcrypt.CompareHashAndPassword([]byte(*profile.Password), []byte(req.Password)); err != nil {
-		return c.JSON(http.StatusForbidden, apierr.Error("INCORRECT_PASSWORD", "Incorrect password.", "e86c14a4-0da8-4571-8f36-8a2e9f9b3a00"))
+		return c.JSON(http.StatusBadRequest, apierr.Error("INCORRECT_PASSWORD", "Incorrect password.", "e86c14a4-0da8-4571-8f36-8a2e9f9b3a00"))
 	}
 
 	fields := map[string]any{

--- a/internal/api/i/email_update_test.go
+++ b/internal/api/i/email_update_test.go
@@ -12,8 +12,10 @@ func TestUpdateEmail_WrongPassword(t *testing.T) {
 	h, repo := newExtraHandler(t)
 	pwd := hashPassword("secret")
 	repo.Profiles["u1"] = &model.UserProfile{UserID: "u1", Password: &pwd}
-	// パスワードが間違っているので 403
-	assert.Equal(t, http.StatusForbidden, postExtra(h.UpdateEmail, `{"password":"wrong"}`, stubUser).Code)
+	// upstream Misskey TS は ApiError(meta.errors.incorrectPassword) を
+	// framework が 400 (= client error) に変換 (#885)。drop-in 互換のため
+	// mk-go も 400 に揃える (旧 mk-go は 403)。
+	assert.Equal(t, http.StatusBadRequest, postExtra(h.UpdateEmail, `{"password":"wrong"}`, stubUser).Code)
 }
 
 func TestUpdateEmail_ClearEmail(t *testing.T) {

--- a/internal/api/i/handler.go
+++ b/internal/api/i/handler.go
@@ -86,6 +86,19 @@ type Handler struct {
 	// streaming connection に reload signal を流す (#791)。未配線時は
 	// publish skip = 旧挙動 (= reconnect で反映)。
 	hardMutePublisher HardMutePublisher
+	// authInvalidator は i/regenerate-token で旧 token を auth middleware
+	// の cache から即時削除するために使う (#884)。未配線時は cache TTL
+	// (30 秒) 待ちで stale 旧 token が auth 通過する security regression が
+	// 残るので production では必ず wire する。
+	authInvalidator TokenInvalidator
+}
+
+// TokenInvalidator は i/regenerate-token / i/change-password 等の sensitive
+// 操作後に auth cache の旧 token entry を即時削除するための interface
+// (#884)。実装は internal/server/middleware/auth.go の AuthMiddleware が
+// 担当する。circular import を避けるため interface 経由で受け取る。
+type TokenInvalidator interface {
+	InvalidateToken(token string)
 }
 
 // HardMutePublisher publishes a wordmute reload event for the given user.
@@ -122,6 +135,13 @@ func (h *Handler) SetNoteFieldResolver(r *entity.NoteFieldResolver) {
 // 循環依存を避けるためinterfaceで受け取る(実装はinternal/stream)。
 type MainStreamPublisher interface {
 	PublishMainEvent(userID, eventType string, body any)
+}
+
+// SetAuthInvalidator attaches a token invalidator so RegenerateToken and
+// other sensitive endpoints can drop the old token from the auth cache
+// immediately (#884、security regression fix)。
+func (h *Handler) SetAuthInvalidator(inv TokenInvalidator) {
+	h.authInvalidator = inv
 }
 
 // SetMainStreamPublisher attaches a publisher used to emit events on

--- a/internal/api/i/handler_extra.go
+++ b/internal/api/i/handler_extra.go
@@ -31,8 +31,11 @@ func (h *Handler) ChangePassword(c echo.Context) error {
 		return c.JSON(http.StatusForbidden, apierr.Error("ACCESS_DENIED", "No password set.", "1fb7cb09-d46a-4fff-b8df-057708cce513"))
 	}
 
+	// upstream Misskey TS は raw `throw new Error('authentication failed')` を
+	// framework が 401 に変換する (#885)。mk-go も drop-in 互換のため 401
+	// に揃える (旧 mk-go は 403 を返していた)。
 	if err := bcrypt.CompareHashAndPassword([]byte(*profile.Password), []byte(req.CurrentPassword)); err != nil {
-		return c.JSON(http.StatusForbidden, apierr.Error("INCORRECT_PASSWORD", "Incorrect password.", "932c904e-9460-45b7-9ce6-7ed33be7eb2c"))
+		return c.JSON(http.StatusUnauthorized, apierr.Error("INCORRECT_PASSWORD", "Incorrect password.", "932c904e-9460-45b7-9ce6-7ed33be7eb2c"))
 	}
 
 	hash, _ := bcrypt.GenerateFromPassword([]byte(req.NewPassword), bcrypt.DefaultCost)
@@ -58,8 +61,11 @@ func (h *Handler) DeleteAccount(c echo.Context) error {
 		return c.JSON(http.StatusForbidden, apierr.Error("ACCESS_DENIED", "No password set.", "1fb7cb09-d46a-4fff-b8df-057708cce513"))
 	}
 
+	// upstream Misskey TS は raw `throw new Error('incorrect password')` を
+	// framework が 401 に変換する (#885)。mk-go も drop-in 互換のため 401
+	// に揃える (旧 mk-go は 403 を返していた)。
 	if err := bcrypt.CompareHashAndPassword([]byte(*profile.Password), []byte(req.Password)); err != nil {
-		return c.JSON(http.StatusForbidden, apierr.Error("INCORRECT_PASSWORD", "Incorrect password.", "932c904e-9460-45b7-9ce6-7ed33be7eb2c"))
+		return c.JSON(http.StatusUnauthorized, apierr.Error("INCORRECT_PASSWORD", "Incorrect password.", "932c904e-9460-45b7-9ce6-7ed33be7eb2c"))
 	}
 
 	// isSuspended + isDeleted を true に設定 (論理削除)
@@ -151,16 +157,30 @@ func (h *Handler) RegenerateToken(c echo.Context) error {
 		return c.JSON(http.StatusForbidden, apierr.Error("ACCESS_DENIED", "No password set.", "1fb7cb09-d46a-4fff-b8df-057708cce513"))
 	}
 
+	// upstream Misskey TS は raw `throw new Error('incorrect password')` を
+	// framework が 401 に変換する (#885)。mk-go も drop-in 互換のため 401
+	// に揃える (旧 mk-go は 403 を返していた)。
 	if err := bcrypt.CompareHashAndPassword([]byte(*profile.Password), []byte(req.Password)); err != nil {
-		return c.JSON(http.StatusForbidden, apierr.Error("INCORRECT_PASSWORD", "Incorrect password.", "932c904e-9460-45b7-9ce6-7ed33be7eb2c"))
+		return c.JSON(http.StatusUnauthorized, apierr.Error("INCORRECT_PASSWORD", "Incorrect password.", "932c904e-9460-45b7-9ce6-7ed33be7eb2c"))
 	}
 
 	b := make([]byte, 8)
 	_, _ = rand.Read(b)
 	newToken := hex.EncodeToString(b)
 
+	var oldToken string
+	if u.Token != nil {
+		oldToken = *u.Token
+	}
 	if err := h.userService.UpdateUserFields(u.ID, map[string]any{"token": newToken}); err != nil {
 		return c.JSON(http.StatusInternalServerError, apierr.Error("INTERNAL_ERROR", "Internal error.", "5d37dbcb-891e-41ca-a3d6-e690c97775ac"))
+	}
+	// 旧 token が auth middleware の cache で生き残ると regenerate の主目的
+	// (= 旧 token 失効) が機能しない (#884)。invalidator が wire されている
+	// 場合は old token entry を即時削除する。production では router で必ず
+	// wire される。
+	if h.authInvalidator != nil && oldToken != "" {
+		h.authInvalidator.InvalidateToken(oldToken)
 	}
 	// TS本家 regenerate-token.ts:60 と同じく、token再生成成功後にmainへ
 	// publishする。body無し(type のみで、他セッションはtoken無効化を
@@ -168,7 +188,11 @@ func (h *Handler) RegenerateToken(c echo.Context) error {
 	if h.mainStreamPublisher != nil {
 		h.mainStreamPublisher.PublishMainEvent(u.ID, "myTokenRegenerated", nil)
 	}
-	return c.JSON(http.StatusOK, map[string]any{"token": newToken})
+	// upstream Misskey TS は body なしの 204 No Content を返す (= 新 token
+	// は myTokenRegenerated WS event 経由で client に伝達する設計、#883)。
+	// 旧 mk-go は 200 + {token} で同期的に返していたが drop-in 互換のため
+	// 揃える。
+	return c.NoContent(http.StatusNoContent)
 }
 
 // ClaimAchievement handles POST /api/i/claim-achievement.

--- a/internal/api/i/handler_extra_test.go
+++ b/internal/api/i/handler_extra_test.go
@@ -79,7 +79,9 @@ func TestChangePassword_WrongPassword(t *testing.T) {
 	h, repo := newExtraHandler(t)
 	user := setupUserWithPassword(repo, "u1", "correct")
 	rec := postExtra(h.ChangePassword, `{"currentPassword":"wrong","newPassword":"x"}`, user)
-	assert.Equal(t, http.StatusForbidden, rec.Code)
+	// upstream Misskey TS は raw `throw new Error` を framework が 401 へ
+	// 変換 (#885)。drop-in 互換のため 401 に揃える (旧 mk-go は 403)。
+	assert.Equal(t, http.StatusUnauthorized, rec.Code)
 }
 
 func TestChangePassword_NoProfile(t *testing.T) {
@@ -112,7 +114,8 @@ func TestDeleteAccount_WrongPassword(t *testing.T) {
 	user := setupUserWithPassword(repo, "u1", "pass")
 	_ = user
 	rec := postExtra(h.DeleteAccount, `{"password":"wrong"}`, repo.Users["u1"])
-	assert.Equal(t, http.StatusForbidden, rec.Code)
+	// upstream Misskey TS と drop-in 互換: 401 (#885)
+	assert.Equal(t, http.StatusUnauthorized, rec.Code)
 }
 
 func TestDeleteAccount_NoProfile(t *testing.T) {
@@ -207,11 +210,8 @@ func TestRegenerateToken_Success(t *testing.T) {
 	h, repo := newExtraHandler(t)
 	user := setupUserWithPassword(repo, "u1", "pass")
 	rec := postExtra(h.RegenerateToken, `{"password":"pass"}`, user)
-	assert.Equal(t, http.StatusOK, rec.Code)
-
-	var resp map[string]any
-	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
-	assert.NotEmpty(t, resp["token"])
+	// upstream Misskey TS と drop-in 互換のため 204 No Content (#883)。
+	assert.Equal(t, http.StatusNoContent, rec.Code)
 }
 
 func TestRegenerateToken_WrongPassword(t *testing.T) {
@@ -219,7 +219,9 @@ func TestRegenerateToken_WrongPassword(t *testing.T) {
 	user := setupUserWithPassword(repo, "u1", "pass")
 	_ = user
 	rec := postExtra(h.RegenerateToken, `{"password":"wrong"}`, repo.Users["u1"])
-	assert.Equal(t, http.StatusForbidden, rec.Code)
+	// upstream Misskey TS は raw `throw new Error('incorrect password')` →
+	// framework が 401 (#885)。
+	assert.Equal(t, http.StatusUnauthorized, rec.Code)
 }
 
 func TestRegenerateToken_NoProfile(t *testing.T) {
@@ -251,13 +253,42 @@ func TestRegenerateToken_PublishesMyTokenRegenerated(t *testing.T) {
 	pub := &stubIMainStreamPublisher{}
 	h.SetMainStreamPublisher(pub)
 	rec := postExtra(h.RegenerateToken, `{"password":"pass"}`, user)
-	require.Equal(t, http.StatusOK, rec.Code)
+	// 204 No Content (= drop-in 互換、#883)
+	require.Equal(t, http.StatusNoContent, rec.Code)
 
 	require.Len(t, pub.calls, 1)
 	assert.Equal(t, "u1", pub.calls[0].userID)
 	assert.Equal(t, "myTokenRegenerated", pub.calls[0].eventType)
 	// TS本家はbody無し (type のみ) のため nil であること。
 	assert.Nil(t, pub.calls[0].body)
+}
+
+// stubTokenInvalidator captures InvalidateToken calls for assertion.
+type stubTokenInvalidator struct {
+	calls []string
+}
+
+func (s *stubTokenInvalidator) InvalidateToken(token string) {
+	s.calls = append(s.calls, token)
+}
+
+// TestRegenerateToken_InvalidatesOldToken verifies #884: the old API token
+// must be removed from the auth cache so it stops being accepted by /api/i.
+func TestRegenerateToken_InvalidatesOldToken(t *testing.T) {
+	h, repo := newExtraHandler(t)
+	user := setupUserWithPassword(repo, "u1", "pass")
+	oldToken := "old-token-value"
+	user.Token = &oldToken
+	repo.Users["u1"] = user
+
+	inv := &stubTokenInvalidator{}
+	h.SetAuthInvalidator(inv)
+
+	rec := postExtra(h.RegenerateToken, `{"password":"pass"}`, user)
+	require.Equal(t, http.StatusNoContent, rec.Code)
+
+	require.Len(t, inv.calls, 1, "old token must be invalidated exactly once")
+	assert.Equal(t, oldToken, inv.calls[0])
 }
 
 // --- Error path tests ---

--- a/internal/server/middleware/auth.go
+++ b/internal/server/middleware/auth.go
@@ -60,6 +60,17 @@ func NewAuthMiddleware(userRepo repository.UserRepository, accessTokenRepo repos
 	}
 }
 
+// InvalidateToken removes a token entry from the auth cache so the next
+// /api/i request with that token re-resolves through the DB (= will fail
+// after `users.token` was rotated by i/regenerate-token、#884 security
+// fix)。本 method は i.TokenInvalidator interface の実装。
+func (a *AuthMiddleware) InvalidateToken(token string) {
+	if token == "" {
+		return
+	}
+	a.tokenCache.invalidate(token)
+}
+
 // Authenticate is an Echo middleware that extracts and validates the user token.
 // It does NOT reject unauthenticated requests - it just sets the user if valid.
 func (a *AuthMiddleware) Authenticate() echo.MiddlewareFunc {

--- a/internal/server/router.go
+++ b/internal/server/router.go
@@ -1155,6 +1155,10 @@ func (s *Server) setupRoutes() {
 	iHandler.SetRegistryRepo(registryRepo)
 	iHandler.SetMetaRepo(metaRepo)
 	iHandler.SetServerURL(s.config.URL)
+	// i/regenerate-token で旧 token を auth cache から即時削除する (#884)。
+	// 未配線だと cache TTL 経過まで旧 token が auth 通過する security
+	// regression が残るので production では必ず wire する。
+	iHandler.SetAuthInvalidator(s.auth)
 	// i/update-email の verifymail / truemail SaaS 呼び出しも SSRF-safe
 	// transport + forward proxy 経由にする (#638)。
 	iHandler.SetEmailValidationClient(s.outboundClient(10 * time.Second))

--- a/tests/playwright/specs/settings/settings.spec.ts
+++ b/tests/playwright/specs/settings/settings.spec.ts
@@ -15,14 +15,19 @@
 // notification 設定 (notificationRecieveConfig) は mk-go では read-only で
 // 常に空 map を返しているため round-trip 化が困難 → 別 spec scope。
 //
-// drop-in shape drift (= 別 issue で揃える):
+// drift fix history (closed):
 //   - #883 i/regenerate-token return shape: TS=204 / mk-go=200+{token}
+//     → mk-go を 204 に揃え (PR fix)
 //   - #884 旧 API token invalidation: TS=即時 reject / mk-go=cache 経由で
-//     旧 token が引き続き auth 通過するセキュリティ drift
+//     旧 token が引き続き auth 通過していた security regression
+//     → mk-go の auth cache から旧 token を即時削除 (PR fix)
 //   - #885 password 検証失敗時の status: TS は endpoint ごとに 400/401 /
-//     mk-go は一律 403 で揺れる
-//   本 spec は positive path のみに絞り、status drift / 旧 token round-trip
-//   は別 spec scope。
+//     mk-go は一律 403 で揺れていた
+//     → mk-go を endpoint 別に 401 (raw Error) / 400 (ApiError) に揃え
+//
+// 本 spec は drift fix 後の strict round-trip を担保する設計に更新済。
+// 旧 token round-trip (regenerate 後の /api/i 4xx) も #884 fix の
+// regression guard として追加。
 
 import { expect, test } from '@playwright/test';
 import { callApi } from '../../fixtures/api';
@@ -66,20 +71,25 @@ test.describe('settings: security / API token / email', () => {
     expect(body.i.length).toBeGreaterThan(0);
   });
 
-  test('regenerate-token: 2xx response indicates success on both backends', async ({
+  test('regenerate-token: 204 No Content + old token immediately invalidated', async ({
     request,
   }) => {
     const me = await signupUser(request, randomUsername('rtA'));
 
-    // regenerate-token (TS=204、mk-go=200+{token} の drop-in shape drift
-    // を 2xx range で吸収。新 token を含むかは backend 依存なので strict
-    // 検査しない、新 token round-trip は別 spec で扱う想定)。
+    // upstream Misskey TS と mk-go (#883 / #884 fix 後) は両方とも 204 を
+    // 返す drop-in shape。新 token は myTokenRegenerated WS event 経由で
+    // client に通達される設計 (= body には含まない)。
     const regenResp = await callApi(request, 'i/regenerate-token', {
       i: me.token,
       password: DEFAULT_TEST_PASSWORD,
     });
-    expect(regenResp.status()).toBeGreaterThanOrEqual(200);
-    expect(regenResp.status()).toBeLessThan(300);
+    expect(regenResp.status()).toBe(204);
+
+    // 旧 token は auth cache から即時削除され、以降 /api/i で 4xx
+    // (= 401 等) で reject される (#884 security regression fix)。
+    const oldI = await callApi(request, 'i', { i: me.token });
+    expect(oldI.status()).toBeGreaterThanOrEqual(400);
+    expect(oldI.status()).toBeLessThan(500);
   });
 
   test('update-email: clearing email returns 200 + null email in response', async ({


### PR DESCRIPTION
## Summary

#827 spec で検出した settings 系 drift 3 件を 1 PR で修正。spec PR #886 の LCD は drift fix 後の strict round-trip に更新し、回帰 guard 化。両 backend で 64/64 pass。

## Drift fix 内訳

### #883: i/regenerate-token return shape (TS=204 / mk-go=200+{token})
- `RegenerateToken` の戻りを `200 + {"token": ...}` → `204 No Content` に変更
- 新 token は myTokenRegenerated WS event 経由で client が受信する upstream 設計に揃う

### #884: 旧 API token cache invalidation (security regression)
旧 mk-go は cache TTL (30 秒) 内に旧 token が auth 通過する **session security regression** だった。

- `internal/api/i/handler.go`: `TokenInvalidator` interface + `authInvalidator` field + `SetAuthInvalidator` setter
- `internal/server/middleware/auth.go`: `AuthMiddleware.InvalidateToken` を export (= TokenInvalidator interface 実装)
- `internal/server/router.go`: `iHandler.SetAuthInvalidator(s.auth)` で wire
- `RegenerateToken` で旧 token を即時 invalidate、以降 /api/i で 4xx で reject される

### #885: password 検証失敗 status を upstream parity に
upstream TS は endpoint ごとに raw `throw new Error` (= 401) と `ApiError(meta.errors.incorrectPassword)` (= 400) で使い分け。mk-go は一律 403 INCORRECT_PASSWORD で揺れていた。

- ChangePassword / DeleteAccount / RegenerateToken: 403 → **401**
- UpdateEmail: 403 → **400**

## Tests + Coverage

- `internal/api/i`: **91.6%** (`stubTokenInvalidator` で #884 の cache 削除を直接 cover、status 期待値を upstream parity に更新)
- `internal/server/middleware`: **94.7%** (既存 cache 系 test と integrated)
- 全 package で gate ≥90% クリア

### Spec 更新
- `tests/playwright/specs/settings/settings.spec.ts`:
  - regenerate-token の status を 2xx range → **204 strict**
  - 旧 token の /api/i 4xx reject (= #884 regression guard) を **strict assert に追加**
  - drift fix history を header コメントで documented

## Verification

- `make playwright-up && make playwright-test` (mk-go, 64 specs): **64 passed**
- `make playwright-ts-up && make playwright-ts-test` (TS, 64 specs): **64 passed**
- 両 backend 同 strict round-trip 通過

## Related

- Closes #883 (regenerate-token return shape)
- Closes #884 (旧 token cache invalidation = security regression)
- Closes #885 (password 検証失敗 status)
- 検出元: PR #886 (#827 settings spec)

🤖 Generated with [Claude Code](https://claude.com/claude-code)