### PR TITLE
#826 Playwright Phase 2: admin spec (user / role / meta)

### DIFF
--- a/tests/playwright/specs/admin/admin_meta.spec.ts
+++ b/tests/playwright/specs/admin/admin_meta.spec.ts
@@ -1,0 +1,75 @@
+// Phase 2 #826: admin/update-meta + /api/meta round-trip。
+//
+// upstream Misskey TS と mk-go は両方とも:
+//   - /api/meta (auth 不要) で instance meta (name, description, ...) を返す
+//   - admin/update-meta { ... } で admin 権限で meta を更新 (204)
+//   - 更新後 /api/meta に新値が反映される
+//
+// 本 spec は両 backend 共通で:
+//   1. /api/meta で初期 name を取得
+//   2. admin/update-meta で name を unique 値に変更
+//   3. /api/meta 再取得で新 name 反映を確認
+//   4. afterEach で元の name に restore (= 後続 spec の noise を防ぐ)
+//
+// admin/update-meta は instance global state を変更するため、cleanup を
+// 慎重に行う (= settings spec / emoji_lifecycle spec と同 pattern)。
+
+import { readFileSync } from 'node:fs';
+import { expect, test } from '@playwright/test';
+import { callApi } from '../../fixtures/api';
+import { resetRateLimit } from '../../fixtures/rate_limit';
+
+interface RootFixture {
+  id: string;
+  token: string;
+  username: string;
+}
+
+test.describe('admin: update-meta + /api/meta round-trip', () => {
+  let rootToken: string | undefined;
+  let originalName: string | null | undefined;
+
+  test.beforeAll(() => {
+    resetRateLimit();
+  });
+
+  test.afterEach(async ({ request }) => {
+    if (rootToken && originalName !== undefined) {
+      // restore (instance global state を test 前に戻す)。null は upstream
+      // の "未設定" を表す可能性があるため、空文字 / null どちらでも復元
+      // できるよう conditional payload で送る。
+      const body: Record<string, unknown> = { i: rootToken };
+      body.name = originalName;
+      await callApi(request, 'admin/update-meta', body);
+    }
+    rootToken = undefined;
+    originalName = undefined;
+  });
+
+  test('admin updates meta name and /api/meta reflects', async ({
+    request,
+  }) => {
+    const root: RootFixture = JSON.parse(readFileSync('.auth/root.json', 'utf-8'));
+    rootToken = root.token;
+
+    // 初期 /api/meta を取得 (auth 不要)
+    const before = await callApi(request, 'meta', {});
+    expect(before.status()).toBe(200);
+    const beforeBody = await before.json();
+    originalName = beforeBody.name ?? null;
+
+    // unique な name を設定
+    const newName = 'spec-meta-' + Math.random().toString(16).slice(2, 8);
+    const updResp = await callApi(request, 'admin/update-meta', {
+      i: root.token,
+      name: newName,
+    });
+    expect(updResp.status()).toBe(204);
+
+    // /api/meta 再取得で反映確認
+    const after = await callApi(request, 'meta', {});
+    expect(after.status()).toBe(200);
+    const afterBody = await after.json();
+    expect(afterBody.name).toBe(newName);
+  });
+});

--- a/tests/playwright/specs/admin/admin_role.spec.ts
+++ b/tests/playwright/specs/admin/admin_role.spec.ts
@@ -1,0 +1,163 @@
+// Phase 2 #826: admin/roles CRUD + assign / unassign + /api/i roles 反映。
+//
+// upstream Misskey TS と mk-go は両方とも:
+//   - admin/roles/create { name, description?, isModerator?, isAdministrator?,
+//     isPublic?, ... } で role を作成し entity を返す
+//   - admin/roles/list で全 role を返す
+//   - admin/roles/show { roleId } で single role を返す
+//   - admin/roles/assign { userId, roleId } で role を付与 (204)
+//   - 付与後 /api/i の `roles` array に role が反映される
+//   - admin/roles/unassign で取り外し (204)
+//   - admin/roles/delete で role を削除 (204)
+//
+// 本 spec は両 backend 共通で 1 role の lifecycle を round-trip:
+//   1. admin が role 作成 → list / show で確認
+//   2. target user に assign → target の /api/i で roles 反映
+//   3. unassign → target の /api/i から消える
+//   4. role delete → list から消える
+//
+// afterEach で role / role assignment を best-effort cleanup する。
+
+import { readFileSync } from 'node:fs';
+import { expect, test } from '@playwright/test';
+import { callApi } from '../../fixtures/api';
+import { randomUsername, signupUser } from '../../fixtures/auth';
+import { resetRateLimit } from '../../fixtures/rate_limit';
+
+interface RootFixture {
+  id: string;
+  token: string;
+  username: string;
+}
+
+interface AdminRole {
+  id: string;
+  name: string;
+}
+
+interface RoleRef {
+  id?: string;
+  name?: string;
+}
+
+test.describe('admin: role CRUD + assign + /api/i roles reflection', () => {
+  let createdRoleID: string | undefined;
+  let assignedUserID: string | undefined;
+  let rootToken: string | undefined;
+
+  test.beforeEach(() => {
+    resetRateLimit();
+  });
+
+  test.afterEach(async ({ request }) => {
+    if (rootToken && assignedUserID && createdRoleID) {
+      await callApi(request, 'admin/roles/unassign', {
+        i: rootToken,
+        userId: assignedUserID,
+        roleId: createdRoleID,
+      });
+    }
+    if (rootToken && createdRoleID) {
+      await callApi(request, 'admin/roles/delete', {
+        i: rootToken,
+        roleId: createdRoleID,
+      });
+    }
+    createdRoleID = undefined;
+    assignedUserID = undefined;
+    rootToken = undefined;
+  });
+
+  test('admin creates, assigns, unassigns, then deletes a role', async ({
+    request,
+  }) => {
+    const root: RootFixture = JSON.parse(readFileSync('.auth/root.json', 'utf-8'));
+    rootToken = root.token;
+    const target = await signupUser(request, randomUsername('arA'));
+    assignedUserID = target.id;
+
+    // create role。upstream Misskey TS は paramDef で多くの field を required
+    // にしている (color / iconUrl / target / condFormula / asBadge /
+    // canEditMembersByModerator / displayOrder / policies)。mk-go はこれら
+    // を optional として受け付けるが、TS と round-trip するには full payload
+    // が必要 (#889 で paramDef を揃える方向)。
+    const roleName = 'spec_role_' + Math.random().toString(16).slice(2, 8);
+    const createResp = await callApi(request, 'admin/roles/create', {
+      i: root.token,
+      name: roleName,
+      description: 'playwright spec role',
+      color: null,
+      iconUrl: null,
+      target: 'manual',
+      condFormula: {},
+      isPublic: true,
+      isModerator: false,
+      isAdministrator: false,
+      asBadge: false,
+      canEditMembersByModerator: false,
+      displayOrder: 0,
+      policies: {},
+    });
+    expect(createResp.status()).toBe(200);
+    const role = (await createResp.json()) as AdminRole;
+    expect(role.id).toBeTruthy();
+    expect(role.name).toBe(roleName);
+    createdRoleID = role.id;
+
+    // list で含むこと
+    const listResp = await callApi(request, 'admin/roles/list', {
+      i: root.token,
+    });
+    expect(listResp.status()).toBe(200);
+    const list = (await listResp.json()) as AdminRole[];
+    expect(list.some((r) => r.id === role.id)).toBe(true);
+
+    // assign
+    const assignResp = await callApi(request, 'admin/roles/assign', {
+      i: root.token,
+      userId: target.id,
+      roleId: role.id,
+    });
+    expect(assignResp.status()).toBe(204);
+
+    // target の /api/i で roles array に role が含まれること
+    const meAfterAssign = await callApi(request, 'i', { i: target.token });
+    expect(meAfterAssign.status()).toBe(200);
+    const meBody = (await meAfterAssign.json()) as { roles: RoleRef[] };
+    expect(Array.isArray(meBody.roles)).toBe(true);
+    expect(meBody.roles.some((r) => r.id === role.id)).toBe(true);
+
+    // unassign
+    const unassign = await callApi(request, 'admin/roles/unassign', {
+      i: root.token,
+      userId: target.id,
+      roleId: role.id,
+    });
+    expect(unassign.status()).toBe(204);
+    // afterEach の re-unassign を skip するために一旦解除済み state にする。
+    assignedUserID = undefined;
+
+    // target の /api/i から role が消えること
+    const meAfterUnassign = await callApi(request, 'i', { i: target.token });
+    expect(meAfterUnassign.status()).toBe(200);
+    const meBody2 = (await meAfterUnassign.json()) as { roles: RoleRef[] };
+    expect(meBody2.roles.some((r) => r.id === role.id)).toBe(false);
+
+    // delete
+    const deleteResp = await callApi(request, 'admin/roles/delete', {
+      i: root.token,
+      roleId: role.id,
+    });
+    expect(deleteResp.status()).toBe(204);
+    // afterEach の re-delete を skip。
+    createdRoleID = undefined;
+
+    // list から消えていること
+    const listAfterDelete = await callApi(request, 'admin/roles/list', {
+      i: root.token,
+    });
+    expect(listAfterDelete.status()).toBe(200);
+    const listAfter = (await listAfterDelete.json()) as AdminRole[];
+    expect(listAfter.some((r) => r.id === role.id)).toBe(false);
+  });
+});

--- a/tests/playwright/specs/admin/admin_user.spec.ts
+++ b/tests/playwright/specs/admin/admin_user.spec.ts
@@ -1,0 +1,107 @@
+// Phase 2 #826: admin/show-user + suspend / unsuspend round-trip。
+//
+// upstream Misskey TS と mk-go は両方とも:
+//   - admin/show-user (mod 必須) で対象 user の admin-only fields
+//     (email / isModerator / isSuspended / signins / policies / roles 等)
+//     を返す
+//   - admin/suspend-user で isSuspended=true → 該当 user は signin 不可
+//   - admin/unsuspend-user で isSuspended=false に戻し signin 可
+//
+// drop-in shape drift (= #888 で揃える方向):
+//   - admin/show-user の top-level shape は backend 間で異なる (TS は admin
+//     specific fields のみ / mk-go は UserDetailed + admin fields)。本 spec
+//     は両 backend 共通の `isSuspended` boolean のみを strict assert し、
+//     id / username の top-level field は scope 外。
+//
+// 本 spec は両 backend 共通で:
+//   1. globalSetup root を admin として読み込み
+//   2. 対象 user を signupUser で作成
+//   3. admin/show-user で 200 + isSuspended=false を確認
+//   4. admin/suspend-user → 204、対象が default password で signin 不可 (4xx)
+//   5. admin/show-user で isSuspended=true 反映を確認
+//   6. admin/unsuspend-user → 204、再度 signin 可 (200)
+//
+// signin-flow の rate limit が複数 signin で消費されるので、test 内で
+// resetRateLimit を挟む (= 既存 settings spec と同 pattern)。
+
+import { readFileSync } from 'node:fs';
+import { expect, test } from '@playwright/test';
+import { callApi } from '../../fixtures/api';
+import { DEFAULT_TEST_PASSWORD, randomUsername, signupUser } from '../../fixtures/auth';
+import { resetRateLimit } from '../../fixtures/rate_limit';
+
+interface RootFixture {
+  id: string;
+  token: string;
+  username: string;
+}
+
+test.describe('admin: show-user / suspend / unsuspend round-trip', () => {
+  test.beforeEach(() => {
+    resetRateLimit();
+  });
+
+  test('admin shows user, suspends signin, then unsuspends', async ({
+    request,
+  }) => {
+    const root: RootFixture = JSON.parse(readFileSync('.auth/root.json', 'utf-8'));
+    const target = await signupUser(request, randomUsername('auA'));
+
+    // admin/show-user で対象 user を取得。両 backend 共通で確実に出る
+    // field は admin-only の `isSuspended` (= TS 側は `id` / `username`
+    // を含まない、mk-go は含むが drift)。本 spec は drop-in 共通な部分だけ
+    // strict assert する。
+    const showResp = await callApi(request, 'admin/show-user', {
+      i: root.token,
+      userId: target.id,
+    });
+    expect(showResp.status()).toBe(200);
+    const shown = await showResp.json();
+    expect(shown.isSuspended).toBe(false);
+
+    // suspend
+    const susp = await callApi(request, 'admin/suspend-user', {
+      i: root.token,
+      userId: target.id,
+    });
+    expect(susp.status()).toBe(204);
+
+    // suspend 後 admin/show-user で isSuspended=true 反映確認
+    const showAfterSusp = await callApi(request, 'admin/show-user', {
+      i: root.token,
+      userId: target.id,
+    });
+    expect(showAfterSusp.status()).toBe(200);
+    const shownSusp = await showAfterSusp.json();
+    expect(shownSusp.isSuspended).toBe(true);
+
+    // signin-flow が ratelimit を消費している可能性があるので reset。
+    resetRateLimit();
+
+    // suspended user は signin できない (= 4xx range で reject)。
+    const blocked = await callApi(request, 'signin-flow', {
+      username: target.username,
+      password: DEFAULT_TEST_PASSWORD,
+    });
+    expect(blocked.status()).toBeGreaterThanOrEqual(400);
+    expect(blocked.status()).toBeLessThan(500);
+
+    // unsuspend
+    const unsusp = await callApi(request, 'admin/unsuspend-user', {
+      i: root.token,
+      userId: target.id,
+    });
+    expect(unsusp.status()).toBe(204);
+
+    resetRateLimit();
+
+    // 再度 signin → 200 + token
+    const ok = await callApi(request, 'signin-flow', {
+      username: target.username,
+      password: DEFAULT_TEST_PASSWORD,
+    });
+    expect(ok.status()).toBe(200);
+    const okBody = await ok.json();
+    expect(typeof okBody.i).toBe('string');
+  });
+});


### PR DESCRIPTION
## Summary

- Playwright Phase 2 #826 として admin 系 spec を整備。
- 検出 drift 2 件は別 issue (#888 / #889) として fix を切り出し、spec 側は LCD 抽象化で両 backend pass を確保。

## 主な変更点

### Spec 追加
- `tests/playwright/specs/admin/admin_user.spec.ts`: admin/show-user → suspend → signin 4xx → show-user (isSuspended=true) → unsuspend → 再 signin 成功 の 6 段 round-trip
- `tests/playwright/specs/admin/admin_role.spec.ts`: admin/roles CRUD + assign + /api/i roles 反映 + unassign + delete (afterEach で role / assignment cleanup)
- `tests/playwright/specs/admin/admin_meta.spec.ts`: /api/meta 読み → admin/update-meta で name 変更 → /api/meta 反映確認 (afterEach で原 name 復元)

### scope 外 (= 別 PR)
- **moderation log**: admin/moderation/log は async / brittle、別 spec PR
- **announcements CRUD**: admin/announcements/* は admin spec の独立 sub scope
- **delete-account / suspend の副作用**: note 削除伝播等は scope 外

### 検出 drift (= 後続 issue で揃える方針)
- **#888** admin/show-user response shape: TS=admin-only fields のみ / mk-go=UserDetailed + admin fields 混合
- **#889** admin/roles/create paramDef required: TS=13 field 必須 / mk-go=name のみ必須

## Testing

- `make playwright-up && make playwright-test` (mk-go, 67 specs): **67 passed**
- `make playwright-ts-up && make playwright-ts-test` (TS, 67 specs): **67 passed**

## Related

- Closes #826
- Spawns: #888, #889 (drift fix issues)

🤖 Generated with [Claude Code](https://claude.com/claude-code)