### PR TITLE
Fix #876 + #888 + #889 + #874: admin / userlists / timeline 系 drop-in shape drift をまとめて修正

### DIFF
--- a/internal/api/admin/handler.go
+++ b/internal/api/admin/handler.go
@@ -700,9 +700,14 @@ func (h *Handler) packAdminUser(u *model.User, profile *model.UserProfile) map[s
 		resp["isAdmin"] = h.roleService.IsAdministrator(u.ID)
 		resp["isModerator"] = h.roleService.IsModerator(u.ID)
 		// roles: GetUserRoles は assigned + expired 除外済 list を返す
-		// (= 即時 active な role の minimal shape)。
+		// (= 即時 active な role の minimal shape)。err 時は frontend が
+		// `user.roles.map(...)` で例外を吐かないよう空配列に fallback し
+		// slog.Warn で観測する (= signins / roleAssigns の空配列扱いと揃え)。
 		if userRoles, rerr := h.roleService.GetUserRoles(u.ID); rerr == nil {
 			resp["roles"] = userRoles
+		} else {
+			slog.Warn("admin/show-user: failed to load roles", "userId", u.ID, "err", rerr)
+			resp["roles"] = []any{}
 		}
 		// policies: assigned roles を merge した user-specific policy
 		// (= upstream の RolePolicies 互換)。default override だけでなく
@@ -1170,11 +1175,7 @@ func (h *Handler) RolesCreate(c echo.Context) error {
 		req.Policies == nil {
 		return c.JSON(http.StatusBadRequest, apierr.Error("INVALID_PARAM", "Required parameters missing.", "3d81ceae-475f-4600-b2a8-2bc116157532"))
 	}
-	description := ""
-	if req.Description != nil {
-		description = *req.Description
-	}
-	r, err := h.roleService.Create(*req.Name, description, role.CreateOptions{
+	r, err := h.roleService.Create(*req.Name, *req.Description, role.CreateOptions{
 		IsModerator:     *req.IsModerator,
 		IsAdministrator: *req.IsAdministrator,
 		IsPublic:        *req.IsPublic,

--- a/internal/api/admin/handler.go
+++ b/internal/api/admin/handler.go
@@ -691,10 +691,35 @@ func (h *Handler) packAdminUser(u *model.User, profile *model.UserProfile) map[s
 	if t, err := h.idGen.ParseTime(u.ID); err == nil {
 		resp["createdAt"] = t.UTC().Format("2006-01-02T15:04:05.000Z")
 	}
-	// RoleService integration
+	// RoleService integration (#888): isAdmin / isModerator に加え、
+	// upstream Misskey TS の admin/show-user response shape では
+	// `roles` / `policies` も top-level で expected。frontend admin
+	// moderation view は user.roles / user.policies を直接参照するので
+	// 埋めないと UI が正しく動かない。
 	if h.roleService != nil {
 		resp["isAdmin"] = h.roleService.IsAdministrator(u.ID)
 		resp["isModerator"] = h.roleService.IsModerator(u.ID)
+		// roles: GetUserRoles は assigned + expired 除外済 list を返す
+		// (= 即時 active な role の minimal shape)。
+		if userRoles, rerr := h.roleService.GetUserRoles(u.ID); rerr == nil {
+			resp["roles"] = userRoles
+		}
+		// policies: assigned roles を merge した user-specific policy
+		// (= upstream の RolePolicies 互換)。default override だけでなく
+		// user の役割に基づいて差し替わる。
+		resp["policies"] = h.roleService.GetUserPolicies(u.ID)
+	}
+	// signins / roleAssigns / isHibernated / lastActiveDate は upstream
+	// admin/show-user shape の必須 field (#888)。mk-go では signin 履歴と
+	// role assignment 詳細を別 endpoint で取得する設計なので空配列 / null
+	// で填めて shape compat を保つ (full integration は別 issue scope)。
+	resp["signins"] = []any{}
+	resp["roleAssigns"] = []any{}
+	resp["isHibernated"] = false
+	if u.LastActiveDate != nil {
+		resp["lastActiveDate"] = u.LastActiveDate.UTC().Format("2006-01-02T15:04:05.000Z")
+	} else {
+		resp["lastActiveDate"] = nil
 	}
 	return resp
 }
@@ -1094,27 +1119,68 @@ func coerceMetaArrayFields(fields map[string]any) {
 // --- Role endpoints ---
 
 // RolesCreate handles POST /api/admin/roles/create.
+//
+// upstream Misskey TS の paramDef は 13 field を required で要求する
+// (name / description / color / iconUrl / target / condFormula / isPublic /
+// isModerator / isAdministrator / asBadge / canEditMembersByModerator /
+// displayOrder / policies)。drop-in 互換のため mk-go も同 field を accept
+// し、`name` 以外も非 nil 必須に揃える (#889)。
+//
+// なお model.Role の現 schema に存在しない field (color / iconUrl / target /
+// condFormula / canEditMembersByModerator / policies) は payload として受け
+// 取るが現 model に persist しない (= 将来 migration で col 追加するまで
+// payload acceptance のみ)。frontend からの "all 13 fields supplied" 要件は
+// これで満たせる。
 func (h *Handler) RolesCreate(c echo.Context) error {
 	var req struct {
-		Name            string `json:"name"`
-		Description     string `json:"description"`
-		IsModerator     bool   `json:"isModerator"`
-		IsAdministrator bool   `json:"isAdministrator"`
-		IsPublic        bool   `json:"isPublic"`
-		AsBadge         bool   `json:"asBadge"`
-		IsExplorable    bool   `json:"isExplorable"`
-		DisplayOrder    int    `json:"displayOrder"`
+		Name                      *string         `json:"name"`
+		Description               *string         `json:"description"`
+		Color                     *string         `json:"color"`
+		IconURL                   *string         `json:"iconUrl"`
+		Target                    *string         `json:"target"`
+		CondFormula               *map[string]any `json:"condFormula"`
+		IsPublic                  *bool           `json:"isPublic"`
+		IsModerator               *bool           `json:"isModerator"`
+		IsAdministrator           *bool           `json:"isAdministrator"`
+		IsExplorable              *bool           `json:"isExplorable"` // optional (TS も default false)
+		AsBadge                   *bool           `json:"asBadge"`
+		CanEditMembersByModerator *bool           `json:"canEditMembersByModerator"`
+		DisplayOrder              *int            `json:"displayOrder"`
+		Policies                  *map[string]any `json:"policies"`
 	}
-	if err := c.Bind(&req); err != nil || req.Name == "" {
-		return c.JSON(http.StatusBadRequest, apierr.Error("INVALID_PARAM", "name is required.", "3d81ceae-475f-4600-b2a8-2bc116157532"))
+	if err := c.Bind(&req); err != nil {
+		return c.JSON(http.StatusBadRequest, apierr.Error("INVALID_PARAM", "Invalid parameters.", "3d81ceae-475f-4600-b2a8-2bc116157532"))
 	}
-	r, err := h.roleService.Create(req.Name, req.Description, role.CreateOptions{
-		IsModerator:     req.IsModerator,
-		IsAdministrator: req.IsAdministrator,
-		IsPublic:        req.IsPublic,
-		AsBadge:         req.AsBadge,
-		IsExplorable:    req.IsExplorable,
-		DisplayOrder:    req.DisplayOrder,
+	// upstream paramDef の required field を非 nil で要求する (= partial
+	// payload を 400 で reject、TS 互換、#889)。
+	// color / iconUrl は upstream paramDef で nullable: true。JSON で null
+	// 送出時に Go の `*string` が nil になり「field 不在」と区別できない
+	// ため required check から除外する (= TS は `null` 可で accept、mk-go
+	// では実 require は省略するが TS frontend の payload は通る)。
+	if req.Name == nil || *req.Name == "" ||
+		req.Description == nil ||
+		req.Target == nil ||
+		req.CondFormula == nil ||
+		req.IsPublic == nil ||
+		req.IsModerator == nil ||
+		req.IsAdministrator == nil ||
+		req.AsBadge == nil ||
+		req.CanEditMembersByModerator == nil ||
+		req.DisplayOrder == nil ||
+		req.Policies == nil {
+		return c.JSON(http.StatusBadRequest, apierr.Error("INVALID_PARAM", "Required parameters missing.", "3d81ceae-475f-4600-b2a8-2bc116157532"))
+	}
+	description := ""
+	if req.Description != nil {
+		description = *req.Description
+	}
+	r, err := h.roleService.Create(*req.Name, description, role.CreateOptions{
+		IsModerator:     *req.IsModerator,
+		IsAdministrator: *req.IsAdministrator,
+		IsPublic:        *req.IsPublic,
+		AsBadge:         *req.AsBadge,
+		IsExplorable:    req.IsExplorable != nil && *req.IsExplorable,
+		DisplayOrder:    *req.DisplayOrder,
 	})
 	if err != nil {
 		return c.JSON(http.StatusInternalServerError, apierr.Error("INTERNAL_ERROR", "Internal error.", "5d37dbcb-891e-41ca-a3d6-e690c97775ac"))

--- a/internal/api/admin/handler_test.go
+++ b/internal/api/admin/handler_test.go
@@ -734,16 +734,60 @@ func TestUpdateMeta_InvalidJSON(t *testing.T) {
 
 // --- Roles endpoints ---
 
+// fullRoleCreatePayload は upstream Misskey TS が paramDef で required と
+// する 13 field を満たした最小 payload (#889)。新 field のうち model.Role
+// に未対応なもの (color / iconUrl / target / condFormula /
+// canEditMembersByModerator / policies) は payload としては受け付けるが
+// persist しない。
+const fullRoleCreatePayload = `{
+	"name": "Admin",
+	"description": "",
+	"color": null,
+	"iconUrl": null,
+	"target": "manual",
+	"condFormula": {},
+	"isPublic": true,
+	"isModerator": false,
+	"isAdministrator": true,
+	"asBadge": false,
+	"canEditMembersByModerator": false,
+	"displayOrder": 0,
+	"policies": {}
+}`
+
 func TestRolesCreate_Success(t *testing.T) {
 	h, _, _, roleRepo := newTestHandler(t)
-	rec := doPost(h.RolesCreate, `{"name":"Admin","isAdministrator":true}`, nil)
+	rec := doPost(h.RolesCreate, fullRoleCreatePayload, nil)
 	assert.Equal(t, http.StatusOK, rec.Code)
 	assert.Len(t, roleRepo.Roles, 1)
 }
 
 func TestRolesCreate_InvalidParam(t *testing.T) {
 	h, _, _, _ := newTestHandler(t)
+	// 空 payload → 13 required field 不足で 400 (#889)
 	rec := doPost(h.RolesCreate, `{}`, nil)
+	assert.Equal(t, http.StatusBadRequest, rec.Code)
+}
+
+// upstream paramDef で required な field が一部欠けると 400 (#889)。
+// description だけ欠けたケースを代表として検証する。
+func TestRolesCreate_PartialPayloadRejected(t *testing.T) {
+	h, _, _, _ := newTestHandler(t)
+	// description を抜いた payload
+	rec := doPost(h.RolesCreate, `{
+		"name": "X",
+		"color": null,
+		"iconUrl": null,
+		"target": "manual",
+		"condFormula": {},
+		"isPublic": true,
+		"isModerator": false,
+		"isAdministrator": false,
+		"asBadge": false,
+		"canEditMembersByModerator": false,
+		"displayOrder": 0,
+		"policies": {}
+	}`, nil)
 	assert.Equal(t, http.StatusBadRequest, rec.Code)
 }
 
@@ -1053,7 +1097,9 @@ func TestRolesCreate_ErrorFromService(t *testing.T) {
 	roleSvc := role.NewService(failRepo, assignRepo, metaRepo, idGen)
 	userRepo := testutil.NewMockUserRepository()
 	h := apiadmin.NewHandler(signup.NewService(userRepo, metaRepo, idGen), roleSvc, metaRepo, userRepo, idGen)
-	rec := doPost(h.RolesCreate, `{"name":"Test"}`, nil)
+	// #889 fullRoleCreatePayload で 13 required field を満たして 500 path
+	// (= service error) を test する。
+	rec := doPost(h.RolesCreate, fullRoleCreatePayload, nil)
 	assert.Equal(t, http.StatusInternalServerError, rec.Code)
 }
 
@@ -1566,7 +1612,8 @@ func TestRolesCreate_WritesModerationLog(t *testing.T) {
 	h, _, _, _ := newTestHandler(t)
 	repo := attachModLog(t, h)
 
-	rec := doPost(h.RolesCreate, `{"name":"Mod"}`, adminUser)
+	// #889 fullRoleCreatePayload で 13 required field を満たす。
+	rec := doPost(h.RolesCreate, fullRoleCreatePayload, adminUser)
 	require.Equal(t, http.StatusOK, rec.Code)
 
 	require.Eventually(t, func() bool { return len(repo.Snapshot()) == 1 }, 500*time.Millisecond, 5*time.Millisecond)

--- a/internal/api/notes/handler.go
+++ b/internal/api/notes/handler.go
@@ -39,6 +39,7 @@ type Handler struct {
 	noteReactionRepo  repository.NoteReactionRepository
 	channelRepo       repository.ChannelRepository
 	channelMutingRepo repository.ChannelMutingRepository
+	mutingRepo        repository.MutingRepository
 	instanceRepo      repository.InstanceRepository
 	emojiRepo         repository.EmojiRepository
 	driveFolderRepo   repository.DriveFolderRepository
@@ -55,6 +56,13 @@ type Handler struct {
 // can exclude notes posted to channels the viewer has muted.
 func (h *Handler) SetChannelMutingRepo(r repository.ChannelMutingRepository) {
 	h.channelMutingRepo = r
+}
+
+// SetMutingRepo attaches a MutingRepository so timeline handlers can exclude
+// notes whose author / renote-source the viewer has muted (= upstream Misskey
+// TS の muting JOIN と同 semantics、#874)。
+func (h *Handler) SetMutingRepo(r repository.MutingRepository) {
+	h.mutingRepo = r
 }
 
 // SetTranslator attaches a DeepL translator for /api/notes/translate.

--- a/internal/api/notes/timeline_handler.go
+++ b/internal/api/notes/timeline_handler.go
@@ -63,6 +63,7 @@ func (h *Handler) LocalTimeline(c echo.Context) error {
 			WithReplies:     req.WithReplies,
 			AllowPartial:    req.AllowPartial,
 			MutedChannelIDs: h.loadMutedChannelIDs(viewer),
+			MutedUserIDs:    h.loadMutedUserIDs(viewer),
 		}
 		return h.timelineService.LocalTimeline(c.Request().Context(), viewer, req.UntilID, req.SinceID, req.Limit, f)
 	}, false)
@@ -76,6 +77,7 @@ func (h *Handler) GlobalTimeline(c echo.Context) error {
 			WithRenotes:     req.WithRenotes,
 			AllowPartial:    req.AllowPartial,
 			MutedChannelIDs: h.loadMutedChannelIDs(viewer),
+			MutedUserIDs:    h.loadMutedUserIDs(viewer),
 		}
 		return h.timelineService.GlobalTimeline(c.Request().Context(), viewer, req.UntilID, req.SinceID, req.Limit, f)
 	}, false)

--- a/internal/api/notes/timeline_handler.go
+++ b/internal/api/notes/timeline_handler.go
@@ -48,6 +48,7 @@ func (h *Handler) Timeline(c echo.Context) error {
 			IncludeLocalRenotes:   req.IncludeLocalRenotes,
 			AllowPartial:          req.AllowPartial,
 			MutedChannelIDs:       h.loadMutedChannelIDs(viewer),
+			MutedUserIDs:          h.loadMutedUserIDs(viewer),
 		}
 		return h.timelineService.HomeTimeline(c.Request().Context(), viewer, req.UntilID, req.SinceID, req.Limit, f)
 	}, true)
@@ -92,6 +93,7 @@ func (h *Handler) HybridTimeline(c echo.Context) error {
 			IncludeLocalRenotes:   req.IncludeLocalRenotes,
 			AllowPartial:          req.AllowPartial,
 			MutedChannelIDs:       h.loadMutedChannelIDs(viewer),
+			MutedUserIDs:          h.loadMutedUserIDs(viewer),
 		}
 		return h.timelineService.HybridTimeline(c.Request().Context(), viewer, req.UntilID, req.SinceID, req.Limit, f)
 	}, true)
@@ -116,6 +118,22 @@ func (h *Handler) loadMutedChannelIDs(viewer *model.User) []string {
 	ids := make([]string, 0, len(rows))
 	for _, m := range rows {
 		ids = append(ids, m.ChannelID)
+	}
+	return ids
+}
+
+// loadMutedUserIDs returns userIDs that viewer has muted (active mutes only,
+// non-expired). nil for anonymous viewers or when the repo is not wired.
+// repository error は best-effort で nil 扱いにし slog.Warn で観測する
+// (= channel mute 同様の pattern、#874)。
+func (h *Handler) loadMutedUserIDs(viewer *model.User) []string {
+	if viewer == nil || h.mutingRepo == nil {
+		return nil
+	}
+	ids, err := h.mutingRepo.ListMuteeIDs(viewer.ID)
+	if err != nil {
+		slog.Warn("timeline: failed to load muted users", "userId", viewer.ID, "err", err)
+		return nil
 	}
 	return ids
 }

--- a/internal/api/userlists/handler.go
+++ b/internal/api/userlists/handler.go
@@ -29,18 +29,29 @@ func NewHandler(repo repository.UserListRepository, idGen id.Generator) *Handler
 // List handles POST /api/users/lists/list.
 //
 // upstream Misskey TS と同じ packed shape ({id, createdAt, name, userIds,
-// isPublic}) で返す (#871)。userIds は ListMembers で fetch して埋める。
-// 旧 mk-go は model.UserList の生 JSON を返しており createdAt / userIds が
-// 欠落していた。
+// isPublic}) で返す (#871)。userIds は ListMembersByListIDs で 1 query batch
+// fetch する (= per-list N+1 を回避、#876)。
 func (h *Handler) List(c echo.Context) error {
 	user := middleware.GetUser(c)
 	lists, err := h.repo.ListByUser(user.ID)
 	if err != nil {
 		return c.JSON(http.StatusInternalServerError, apierr.Error("INTERNAL_ERROR", "Internal error.", "5d37dbcb-891e-41ca-a3d6-e690c97775ac"))
 	}
+	listIDs := make([]string, 0, len(lists))
+	for _, l := range lists {
+		listIDs = append(listIDs, l.ID)
+	}
+	membersByList, err := h.repo.ListMembersByListIDs(listIDs)
+	if err != nil {
+		// repo error は best-effort で空 map にフォールバックして shape を保つ
+		// (= memberIDs helper と同 pattern、entity.PackUserList が [] で
+		// serialize する)。観測のため slog.Warn は残す。
+		slog.Warn("users/lists/list: failed to batch fetch members", "userId", user.ID, "error", err)
+		membersByList = map[string][]string{}
+	}
 	out := make([]entity.UserList, 0, len(lists))
 	for _, l := range lists {
-		out = append(out, entity.PackUserList(l, h.memberIDs(l.ID), h.idGen))
+		out = append(out, entity.PackUserList(l, membersByList[l.ID], h.idGen))
 	}
 	return c.JSON(http.StatusOK, out)
 }

--- a/internal/core/antenna/antenna_service_test.go
+++ b/internal/core/antenna/antenna_service_test.go
@@ -880,6 +880,9 @@ func (r *failingUserListRepo) RemoveMember(_, _ string) error                 { 
 func (r *failingUserListRepo) ListMembers(_ string) ([]*model.UserListMembership, error) {
 	return nil, errors.New("list members error")
 }
+func (r *failingUserListRepo) ListMembersByListIDs(_ []string) (map[string][]string, error) {
+	return nil, errors.New("list members by ids error")
+}
 func (r *failingUserListRepo) UpdateList(_ string, _ map[string]any) error { return nil }
 func (r *failingUserListRepo) UpdateMembership(_, _ string, _ bool) error  { return nil }
 func (r *failingUserListRepo) ListIDsByMember(_ string) ([]string, error)  { return nil, nil }

--- a/internal/core/timeline/timeline_filter.go
+++ b/internal/core/timeline/timeline_filter.go
@@ -13,6 +13,11 @@ type TimelineFilter struct {
 	IncludeLocalRenotes   *bool    // nil=true。home/hybridのみ
 	AllowPartial          bool     // trueならRedis結果が不足でもDBフォールバックしない
 	MutedChannelIDs       []string // 指定があれば channelId が一致するノートを除外
+	// MutedUserIDs は viewer が mute した user の note を除外する filter
+	// 用 (#874)。nil なら filter 無効、空 slice なら filter 有効だが除外
+	// 対象なし。renote の場合は renoteUserId も check する (= upstream
+	// Misskey TS の muting JOIN と同 semantics)。
+	MutedUserIDs []string
 }
 
 // boolDefault returns *b if non-nil, else def.
@@ -45,6 +50,14 @@ func ApplyFilter(notes []*model.Note, viewerID string, f TimelineFilter) []*mode
 		}
 	}
 
+	var mutedUsers map[string]struct{}
+	if len(f.MutedUserIDs) > 0 {
+		mutedUsers = make(map[string]struct{}, len(f.MutedUserIDs))
+		for _, id := range f.MutedUserIDs {
+			mutedUsers[id] = struct{}{}
+		}
+	}
+
 	out := make([]*model.Note, 0, len(notes))
 	for _, n := range notes {
 		if f.WithFiles && len(n.FileIDs) == 0 {
@@ -56,6 +69,19 @@ func ApplyFilter(notes []*model.Note, viewerID string, f TimelineFilter) []*mode
 		if mutedChannels != nil && n.ChannelID != nil {
 			if _, muted := mutedChannels[*n.ChannelID]; muted {
 				continue
+			}
+		}
+		// user mute filter: 投稿者が muted user なら除外。renote の場合は
+		// renote 元 user も check する (= upstream Misskey TS の muting JOIN
+		// と同 semantics、#874)。
+		if mutedUsers != nil {
+			if _, muted := mutedUsers[n.UserID]; muted {
+				continue
+			}
+			if n.RenoteUserID != nil {
+				if _, muted := mutedUsers[*n.RenoteUserID]; muted {
+					continue
+				}
 			}
 		}
 		// withReplies=false: 他人への返信を除外 (自分への返信は残す)

--- a/internal/core/timeline/timeline_filter_test.go
+++ b/internal/core/timeline/timeline_filter_test.go
@@ -191,3 +191,44 @@ func TestApplyFilter_MutedChannelsEmptyIsNoop(t *testing.T) {
 	out := ApplyFilter(notes, "", TimelineFilter{})
 	assert.Len(t, out, 2)
 }
+
+func TestApplyFilter_MutedUsersExcluded(t *testing.T) {
+	// author = note 投稿者。muted-author の note は除外される (#874)。
+	notes := []*model.Note{
+		makeNote("1", withUser("normal")),
+		makeNote("2", withUser("muted-author")),
+		makeNote("3", withUser("normal2")),
+	}
+	out := ApplyFilter(notes, "viewer", TimelineFilter{
+		MutedUserIDs: []string{"muted-author"},
+	})
+	assert.Len(t, out, 2)
+	assert.Equal(t, "1", out[0].ID)
+	assert.Equal(t, "3", out[1].ID)
+}
+
+func TestApplyFilter_MutedRenoteSourceExcluded(t *testing.T) {
+	// renote 元 user が muted の場合、renote note 自体も除外する
+	// (= upstream Misskey TS の muting JOIN と同 semantics、#874)。
+	notes := []*model.Note{
+		makeNote("1", withUser("normal"), withRenote, withRenoteUser("muted-source")),
+		makeNote("2", withUser("normal"), withRenote, withRenoteUser("ok-source")),
+	}
+	out := ApplyFilter(notes, "viewer", TimelineFilter{
+		MutedUserIDs: []string{"muted-source"},
+	})
+	assert.Len(t, out, 1)
+	assert.Equal(t, "2", out[0].ID)
+}
+
+func TestApplyFilter_MutedUsersEmptyIsNoop(t *testing.T) {
+	notes := []*model.Note{
+		makeNote("1", withUser("any")),
+		makeNote("2", withUser("any2")),
+	}
+	// nil / 空 slice は filter 無効 (= 従来挙動)
+	out := ApplyFilter(notes, "viewer", TimelineFilter{MutedUserIDs: nil})
+	assert.Len(t, out, 2)
+	out2 := ApplyFilter(notes, "viewer", TimelineFilter{MutedUserIDs: []string{}})
+	assert.Len(t, out2, 2)
+}

--- a/internal/repository/muting.go
+++ b/internal/repository/muting.go
@@ -16,6 +16,10 @@ type MutingRepository interface {
 	// ListByMuter supports cursor (sinceID/untilID) and offset pagination.
 	// Cursor 指定時は offset を無視 (upstream makePaginationQuery と一致)。
 	ListByMuter(muterID, sinceID, untilID string, limit, offset int) ([]*model.Muting, error)
+	// ListMuteeIDs returns the muteeIDs of active (non-expired) mute rows
+	// for muterID. timeline endpoint で muted user の note を除外する
+	// filter 用 (#874)。
+	ListMuteeIDs(muterID string) ([]string, error)
 }
 
 type mutingRepository struct {
@@ -73,6 +77,23 @@ func (r *mutingRepository) ListByMuter(muterID, sinceID, untilID string, limit, 
 		return nil, err
 	}
 	return rows, nil
+}
+
+// ListMuteeIDs returns muteeIDs where muterID has an active (non-expired)
+// mute. timeline endpoint で muted user の note を除外する filter 用 (#874)。
+func (r *mutingRepository) ListMuteeIDs(muterID string) ([]string, error) {
+	if muterID == "" {
+		return nil, nil
+	}
+	var ids []string
+	now := time.Now()
+	if err := r.db.Model(&model.Muting{}).
+		Where(`"muterId" = ?`, muterID).
+		Where(`"expiresAt" IS NULL OR "expiresAt" > ?`, now).
+		Pluck(`"muteeId"`, &ids).Error; err != nil {
+		return nil, err
+	}
+	return ids, nil
 }
 
 // RenoteMutingRepository provides data access for the `renote_muting` table.

--- a/internal/repository/muting_test.go
+++ b/internal/repository/muting_test.go
@@ -75,6 +75,48 @@ func TestMutingRepository_QueryErrors(t *testing.T) {
 	assert.Error(t, err)
 	_, err = repo.ListByMuter("a", "", "", 10, 0)
 	assert.Error(t, err)
+	_, err = repo.ListMuteeIDs("a")
+	assert.Error(t, err)
+}
+
+// ListMuteeIDs は active (非 expired) な mute だけを返すこと、空 muterID は
+// nil を返すことを確認する (#874 timeline filter 用)。
+func TestMutingRepository_ListMuteeIDs(t *testing.T) {
+	repo := NewMutingRepository(testDB)
+	u1 := insertTestUser(t, "u_mlmid_1", "mlmid1")
+	u2 := insertTestUser(t, "u_mlmid_2", "mlmid2")
+	u3 := insertTestUser(t, "u_mlmid_3", "mlmid3")
+	u4 := insertTestUser(t, "u_mlmid_4", "mlmid4")
+	defer cleanupUser(t, u1.ID)
+	defer cleanupUser(t, u2.ID)
+	defer cleanupUser(t, u3.ID)
+	defer cleanupUser(t, u4.ID)
+
+	// active (no expiry)
+	active := &model.Muting{ID: "mlm_active", MuterID: u1.ID, MuteeID: u2.ID}
+	require.NoError(t, repo.Create(active))
+	defer cleanupMuting(t, active.ID)
+
+	// active (future expiry)
+	future := time.Now().Add(1 * time.Hour)
+	activeFuture := &model.Muting{ID: "mlm_active_future", MuterID: u1.ID, MuteeID: u3.ID, ExpiresAt: &future}
+	require.NoError(t, repo.Create(activeFuture))
+	defer cleanupMuting(t, activeFuture.ID)
+
+	// expired
+	past := time.Now().Add(-1 * time.Hour)
+	expired := &model.Muting{ID: "mlm_expired", MuterID: u1.ID, MuteeID: u4.ID, ExpiresAt: &past}
+	require.NoError(t, repo.Create(expired))
+	defer cleanupMuting(t, expired.ID)
+
+	ids, err := repo.ListMuteeIDs(u1.ID)
+	require.NoError(t, err)
+	assert.ElementsMatch(t, []string{u2.ID, u3.ID}, ids)
+
+	// muterID 空は nil 返却 (#874 viewer==nil の short-circuit と整合)
+	ids, err = repo.ListMuteeIDs("")
+	require.NoError(t, err)
+	assert.Nil(t, ids)
 }
 
 func TestRenoteMutingRepository_CRUD(t *testing.T) {

--- a/internal/repository/user_list.go
+++ b/internal/repository/user_list.go
@@ -22,6 +22,9 @@ type UserListRepository interface {
 	AddMember(m *model.UserListMembership) error
 	RemoveMember(listID, userID string) error
 	ListMembers(listID string) ([]*model.UserListMembership, error)
+	// ListMembersByListIDs returns userIDs grouped by listID in 1 query
+	// (= users/lists/list の N+1 を消す batch fetch、#876)。
+	ListMembersByListIDs(listIDs []string) (map[string][]string, error)
 	UpdateList(id string, fields map[string]any) error
 	UpdateMembership(listID, userID string, withReplies bool) error
 	// ListsContainingMember returns lists owned by ownerID that include
@@ -116,6 +119,31 @@ func (r *userListRepository) ListIDsByMember(userID string) ([]string, error) {
 		return nil, err
 	}
 	return ids, nil
+}
+
+// ListMembersByListIDs returns userIDs grouped by listID in a single SELECT.
+// users/lists/list の per-list N+1 query を消すための batch fetch (#876)。
+// listIDs が空なら空 map を返す。row 順は保証しないので caller 側で並び順
+// に依存しないこと。
+func (r *userListRepository) ListMembersByListIDs(listIDs []string) (map[string][]string, error) {
+	out := make(map[string][]string)
+	if len(listIDs) == 0 {
+		return out, nil
+	}
+	type row struct {
+		UserListID string `gorm:"column:userListId"`
+		UserID     string `gorm:"column:userId"`
+	}
+	var rows []row
+	if err := r.db.Model(&model.UserListMembership{}).
+		Where(`"userListId" IN ?`, listIDs).
+		Find(&rows).Error; err != nil {
+		return nil, err
+	}
+	for _, r := range rows {
+		out[r.UserListID] = append(out[r.UserListID], r.UserID)
+	}
+	return out, nil
 }
 
 func (r *userListRepository) ListsContainingMember(ownerID, memberUserID string) ([]*model.UserList, error) {

--- a/internal/repository/user_list_test.go
+++ b/internal/repository/user_list_test.go
@@ -78,7 +78,15 @@ func TestUserListRepository_ListMembers_Error(t *testing.T) {
 	repo := NewUserListRepository(testDB.WithContext(ctx))
 	_, err := repo.ListMembers("x")
 	assert.Error(t, err)
-	_, err = repo.ListMembersByListIDs([]string{"x"})
+}
+
+// cancel 済 context で ListMembersByListIDs が err を伝播することを確認する
+// (handler 側 best-effort fallback の発動経路担保、#876)。
+func TestUserListRepository_ListMembersByListIDs_Error(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	repo := NewUserListRepository(testDB.WithContext(ctx))
+	_, err := repo.ListMembersByListIDs([]string{"x"})
 	assert.Error(t, err)
 }
 

--- a/internal/repository/user_list_test.go
+++ b/internal/repository/user_list_test.go
@@ -78,6 +78,52 @@ func TestUserListRepository_ListMembers_Error(t *testing.T) {
 	repo := NewUserListRepository(testDB.WithContext(ctx))
 	_, err := repo.ListMembers("x")
 	assert.Error(t, err)
+	_, err = repo.ListMembersByListIDs([]string{"x"})
+	assert.Error(t, err)
+}
+
+// users/lists/list の N+1 を消す batch fetch (#876)。空 input は空 map、
+// 複数 list 跨ぎは listID -> userIDs に正しく分配されることを確認する。
+func TestUserListRepository_ListMembersByListIDs(t *testing.T) {
+	repo := NewUserListRepository(testDB)
+	createTestUser(t, "ul_b_o")
+	createTestUser(t, "ul_b_m1")
+	createTestUser(t, "ul_b_m2")
+
+	// 空 input → 空 map (query を発行しない short-circuit)
+	out, err := repo.ListMembersByListIDs(nil)
+	require.NoError(t, err)
+	assert.Empty(t, out)
+	out, err = repo.ListMembersByListIDs([]string{})
+	require.NoError(t, err)
+	assert.Empty(t, out)
+
+	// list A: m1 + m2、list B: m1 のみ
+	listA := &model.UserList{ID: "ul_b_a", UserID: "ul_b_o", Name: "A"}
+	require.NoError(t, repo.Create(listA))
+	defer cleanupUserList(t, listA.ID)
+	listB := &model.UserList{ID: "ul_b_b", UserID: "ul_b_o", Name: "B"}
+	require.NoError(t, repo.Create(listB))
+	defer cleanupUserList(t, listB.ID)
+
+	require.NoError(t, repo.AddMember(&model.UserListMembership{ID: "ulm_b_1", UserListID: listA.ID, UserID: "ul_b_m1"}))
+	require.NoError(t, repo.AddMember(&model.UserListMembership{ID: "ulm_b_2", UserListID: listA.ID, UserID: "ul_b_m2"}))
+	require.NoError(t, repo.AddMember(&model.UserListMembership{ID: "ulm_b_3", UserListID: listB.ID, UserID: "ul_b_m1"}))
+
+	out, err = repo.ListMembersByListIDs([]string{listA.ID, listB.ID})
+	require.NoError(t, err)
+	assert.ElementsMatch(t, []string{"ul_b_m1", "ul_b_m2"}, out[listA.ID])
+	assert.ElementsMatch(t, []string{"ul_b_m1"}, out[listB.ID])
+
+	// member の居ない list は map に key が出ない (caller 側で nil slice
+	// として扱う前提、entity.PackUserList は [] で serialize)。
+	listEmpty := &model.UserList{ID: "ul_b_empty", UserID: "ul_b_o", Name: "E"}
+	require.NoError(t, repo.Create(listEmpty))
+	defer cleanupUserList(t, listEmpty.ID)
+	out, err = repo.ListMembersByListIDs([]string{listEmpty.ID})
+	require.NoError(t, err)
+	_, ok := out[listEmpty.ID]
+	assert.False(t, ok)
 }
 
 // TestUserListRepository_AddMember_Duplicate verifies the (userListId, userId)

--- a/internal/server/router.go
+++ b/internal/server/router.go
@@ -1044,6 +1044,10 @@ func (s *Server) setupRoutes() {
 	notesHandler.SetNoteReactionRepo(reactionRepo)
 	notesHandler.SetChannelRepo(channelRepo)
 	notesHandler.SetChannelMutingRepo(channelMutingRepo)
+	// timeline endpoint で muted user の note を除外する filter (#874)。
+	// 未配線だと user mute は read 時に効かず、cache のみ DB 整合の状態
+	// になる security/UX regression が残る。production では必ず wire する。
+	notesHandler.SetMutingRepo(mutingRepo)
 	notesHandler.SetInstanceRepo(instanceRepo)
 	notesHandler.SetEmojiRepo(emojiRepo)
 	notesHandler.SetReactionReader(reactionCountWriter)

--- a/internal/testutil/mock_block_mute.go
+++ b/internal/testutil/mock_block_mute.go
@@ -114,6 +114,27 @@ func (m *MockMutingRepository) ListByMuter(muterID, sinceID, untilID string, lim
 	return paginateMutings(rows, sinceID, untilID, limit, offset), nil
 }
 
+// ListMuteeIDs returns muteeIDs for muterID where the mute is active
+// (= ExpiresAt nil or in future). production の挙動と同じ filter logic で
+// timeline test の user mute 経路を担保する (#874)。
+func (m *MockMutingRepository) ListMuteeIDs(muterID string) ([]string, error) {
+	if muterID == "" {
+		return nil, nil
+	}
+	var ids []string
+	now := time.Now()
+	for _, r := range m.Mutings {
+		if r.MuterID != muterID {
+			continue
+		}
+		if r.ExpiresAt != nil && !r.ExpiresAt.After(now) {
+			continue
+		}
+		ids = append(ids, r.MuteeID)
+	}
+	return ids, nil
+}
+
 // MockRenoteMutingRepository is a test double for repository.RenoteMutingRepository.
 type MockRenoteMutingRepository struct {
 	Mutings map[string]*model.RenoteMuting

--- a/internal/testutil/mock_repository.go
+++ b/internal/testutil/mock_repository.go
@@ -4245,6 +4245,26 @@ func (m *MockUserListRepository) ListMembers(listID string) ([]*model.UserListMe
 	return result, nil
 }
 
+// ListMembersByListIDs returns userIDs grouped by listID. Mirrors the
+// production batch fetch (#876) but iterates the in-memory slice.
+func (m *MockUserListRepository) ListMembersByListIDs(listIDs []string) (map[string][]string, error) {
+	out := make(map[string][]string)
+	if len(listIDs) == 0 {
+		return out, nil
+	}
+	want := make(map[string]struct{}, len(listIDs))
+	for _, id := range listIDs {
+		want[id] = struct{}{}
+	}
+	for _, mem := range m.Members {
+		if _, ok := want[mem.UserListID]; !ok {
+			continue
+		}
+		out[mem.UserListID] = append(out[mem.UserListID], mem.UserID)
+	}
+	return out, nil
+}
+
 func (m *MockUserListRepository) UpdateList(id string, fields map[string]any) error {
 	list, ok := m.Lists[id]
 	if !ok {


### PR DESCRIPTION
## Summary

Playwright 検証で観測されていた以下 4 件の drop-in shape drift を 1 PR でバンドル修正。

- **#876**: `users/lists/list` の per-list N+1 を batch fetch に置き換え
- **#888**: `admin/show-user` の packed shape に `roles` / `policies` / `signins` / `roleAssigns` / `isHibernated` / `lastActiveDate` を追加
- **#889**: `admin/roles/create` の paramDef を required field 厳格化
- **#874**: `notes/{home,local,global,hybrid}-timeline` で active mute (= `expiresAt` フィルタ込) の `muteeId` を timeline filter に注入

## 主な変更点

- `internal/repository/user_list.go`: `ListMembersByListIDs(listIDs []string) (map[string][]string, error)` を `UserListRepository` interface に追加。1 query で `IN ?` で batch 取得し `map[listID][]userID` に詰める。
- `internal/api/userlists/handler.go::List`: 旧 `memberIDs(listID)` 呼び出しを batch fetch に置換。repo error は best-effort で空 map にフォールバックして shape を維持し `slog.Warn` で観測。
- `internal/api/admin/handler.go::packAdminUser`: `roles` / `policies` を `roleService` 経由で hydrate、`signins` / `roleAssigns` を空配列で固定 (将来 hydrate 余地)、`isHibernated` (false 固定) / `lastActiveDate` を追加。
- `internal/api/admin/handler.go::RolesCreate`: paramDef を `*pointer` 型 13 field に変更。`color` / `iconUrl` は upstream で `nullable: true` のため Go JSON unmarshal の制約 (absent と null を区別不能) で required check から除外し、それ以外 11 field を必須化。
- `internal/repository/muting.go`: `ListMuteeIDs(muterID string) ([]string, error)` を `MutingRepository` interface に追加。`expiresAt IS NULL OR expiresAt > now` を WHERE で引いて `Pluck("muteeId")` する production と mock 両実装。
- `internal/core/timeline/timeline_filter.go`: `TimelineFilter.MutedUserIDs []string` を追加。`ApplyFilter` 内で `n.UserID` AND `n.RenoteUserID` を見て skip。
- `internal/api/notes/handler.go` / `timeline_handler.go`: `mutingRepo` field と `SetMutingRepo` setter、`loadMutedUserIDs(viewer)` helper を追加。4 timeline handler 全てで `MutedUserIDs` を filter に渡す。
- `internal/server/router.go`: `notesHandler.SetMutingRepo(mutingRepo)` で wire。
- `internal/testutil/mock_block_mute.go` / `mock_repository.go`: 上記 interface 拡張に追従。
- `internal/core/antenna/antenna_service_test.go::failingUserListRepo`: stub を新 interface に追従。

## テスト

- ローカル単体テスト: `make test`
- Playwright (mk-go backend): `make playwright-test` → **67/67 pass**
- Playwright (TS backend): `make playwright-ts-test` → **67/67 pass**

## Closes

- Closes #876
- Closes #888
- Closes #889
- Closes #874

🤖 Generated with [Claude Code](https://claude.com/claude-code)