### PR TITLE
Fix #892: timeline mute filter を SQL push-down 化

### DIFF
--- a/internal/core/timeline/timeline_filter.go
+++ b/internal/core/timeline/timeline_filter.go
@@ -17,6 +17,11 @@ type TimelineFilter struct {
 	// 用 (#874)。nil なら filter 無効、空 slice なら filter 有効だが除外
 	// 対象なし。renote の場合は renoteUserId も check する (= upstream
 	// Misskey TS の muting JOIN と同 semantics)。
+	//
+	// この in-memory ApplyFilter は Redis fanout 経路 (cached note ID から
+	// 解決した note slice) で動作する。DB fallback path では同じ
+	// MutedUserIDs が toDBFilter 経由で SQL の NOT IN として push-down
+	// されるので、両経路で同 semantics に保たれる (#892)。
 	MutedUserIDs []string
 }
 

--- a/internal/core/timeline/timeline_service.go
+++ b/internal/core/timeline/timeline_service.go
@@ -207,6 +207,10 @@ func toDBFilter(f TimelineFilter, viewerID string) model.TimelineDBFilter {
 		IncludeLocalRenotes:   f.IncludeLocalRenotes,
 		ViewerID:              viewerID,
 		MutedChannelIDs:       f.MutedChannelIDs,
+		// MutedUserIDs を SQL push-down に伝搬する (#892)。Redis path の
+		// post-fetch ApplyFilter は依然 MutedUserIDs を見るので、cache hit
+		// と DB fallback の両経路で同 semantics になる。
+		MutedUserIDs: f.MutedUserIDs,
 	}
 }
 

--- a/internal/model/timeline_filter.go
+++ b/internal/model/timeline_filter.go
@@ -11,4 +11,10 @@ type TimelineDBFilter struct {
 	IncludeLocalRenotes   *bool    // nil=true
 	ViewerID              string   // home/hybridフィルタで使用
 	MutedChannelIDs       []string // 指定があれば channelId が IN (...) のノートを除外
+	// MutedUserIDs は viewer が mute した user の note を SQL 段階で除外
+	// する filter (#892 / #874 follow-up)。userId AND renoteUserId 両方を
+	// check する (= upstream Misskey TS QueryService の muting JOIN と同
+	// semantics)。Redis fanout 経路 (post-fetch) では in-memory 版
+	// ApplyFilter が同等処理を担う。
+	MutedUserIDs []string
 }

--- a/internal/repository/note.go
+++ b/internal/repository/note.go
@@ -533,6 +533,16 @@ func applyTimelineFilter(q *gorm.DB, f model.TimelineDBFilter) *gorm.DB {
 		// バイパスしてしまう (SQL優先順位: AND > OR)。
 		q = q.Where(`("channelId" IS NULL OR "channelId" NOT IN ?)`, f.MutedChannelIDs)
 	}
+	if len(f.MutedUserIDs) > 0 {
+		// muted user の note を SQL 段階で除外する (#892)。post-fetch filter
+		// と異なり limit ぶん fill された non-muted note を 1 query で取得
+		// できるので、heavy-mute viewer (例: 数千 mutee) でも timeline 件数
+		// が一時的に limit 未満になる UX regression を回避できる。
+		// renote 元 user が muted のケースもここで一緒に弾く (= upstream
+		// Misskey TS QueryService の muting JOIN と同 semantics)。
+		q = q.Where(`"userId" NOT IN ?`, f.MutedUserIDs)
+		q = q.Where(`("renoteUserId" IS NULL OR "renoteUserId" NOT IN ?)`, f.MutedUserIDs)
+	}
 	return q
 }
 

--- a/internal/repository/note.go
+++ b/internal/repository/note.go
@@ -540,8 +540,8 @@ func applyTimelineFilter(q *gorm.DB, f model.TimelineDBFilter) *gorm.DB {
 		// が一時的に limit 未満になる UX regression を回避できる。
 		// renote 元 user が muted のケースもここで一緒に弾く (= upstream
 		// Misskey TS QueryService の muting JOIN と同 semantics)。
-		q = q.Where(`"userId" NOT IN ?`, f.MutedUserIDs)
-		q = q.Where(`("renoteUserId" IS NULL OR "renoteUserId" NOT IN ?)`, f.MutedUserIDs)
+		// 2 条件を 1 つの Where にまとめて intent を 1 行で読めるようにする。
+		q = q.Where(`"userId" NOT IN ? AND ("renoteUserId" IS NULL OR "renoteUserId" NOT IN ?)`, f.MutedUserIDs, f.MutedUserIDs)
 	}
 	return q
 }

--- a/internal/repository/note_test.go
+++ b/internal/repository/note_test.go
@@ -935,6 +935,89 @@ func TestNoteRepository_ListHomeTimeline_MutedChannelsRespectedWithPrecedence(t 
 		"follow + mute フィルタが OR で短絡されていない (SQL precedence バグのリグレッション)")
 }
 
+// TestNoteRepository_ListLocalTimeline_MutedUsersFilter verifies that
+// model.TimelineDBFilter.MutedUserIDs is applied at SQL level (#892),
+// excluding both notes authored by muted users AND renotes whose original
+// author is muted. heavy-mute viewer でも limit ぶん fill されることも
+// 同時に確認する (= post-fetch filter 時の UX regression 回避)。
+func TestNoteRepository_ListLocalTimeline_MutedUsersFilter(t *testing.T) {
+	repo := NewNoteRepository(testDB)
+	mutedAuthor := insertTestUser(t, "u_mu_m", "mumuted")
+	defer cleanupUser(t, mutedAuthor.ID)
+	okAuthor := insertTestUser(t, "u_mu_o", "muok")
+	defer cleanupUser(t, okAuthor.ID)
+	mutedRenoteSrc := insertTestUser(t, "u_mu_rs", "murenotesrc")
+	defer cleanupUser(t, mutedRenoteSrc.ID)
+
+	mkPlain := func(id, uid string) *model.Note {
+		text := "x"
+		return &model.Note{
+			ID: id, UserID: uid, Text: &text,
+			Visibility: model.NoteVisibilityPublic,
+			Reactions:  datatypes.JSON([]byte("{}")),
+		}
+	}
+
+	// muted author の note (除外されるべき)
+	muted1 := mkPlain("n_mu_m1", mutedAuthor.ID)
+	muted2 := mkPlain("n_mu_m2", mutedAuthor.ID)
+	require.NoError(t, repo.Create(muted1))
+	require.NoError(t, repo.Create(muted2))
+	defer cleanupNote(t, muted1.ID)
+	defer cleanupNote(t, muted2.ID)
+
+	// muted renote source (= ok author が muted user の note を renote。
+	// renoteUserId が muted なので除外されるべき)
+	renoteSrc := mkPlain("n_mu_src", mutedRenoteSrc.ID)
+	require.NoError(t, repo.Create(renoteSrc))
+	defer cleanupNote(t, renoteSrc.ID)
+	renote := &model.Note{
+		ID: "n_mu_renote", UserID: okAuthor.ID,
+		RenoteID: &renoteSrc.ID, RenoteUserID: &mutedRenoteSrc.ID,
+		Visibility: model.NoteVisibilityPublic,
+		Reactions:  datatypes.JSON([]byte("{}")),
+	}
+	require.NoError(t, repo.Create(renote))
+	defer cleanupNote(t, renote.ID)
+
+	// non-muted note (= ok author の plain note、含まれるべき)
+	ok1 := mkPlain("n_mu_ok1", okAuthor.ID)
+	ok2 := mkPlain("n_mu_ok2", okAuthor.ID)
+	ok3 := mkPlain("n_mu_ok3", okAuthor.ID)
+	require.NoError(t, repo.Create(ok1))
+	require.NoError(t, repo.Create(ok2))
+	require.NoError(t, repo.Create(ok3))
+	defer cleanupNote(t, ok1.ID)
+	defer cleanupNote(t, ok2.ID)
+	defer cleanupNote(t, ok3.ID)
+
+	rows, err := repo.ListLocalTimeline(100, "", "", model.TimelineDBFilter{
+		MutedUserIDs: []string{mutedAuthor.ID, mutedRenoteSrc.ID},
+	})
+	require.NoError(t, err)
+
+	ids := idsOf(rows)
+	// muted author の note と muted renote source は除外
+	assert.NotContains(t, ids, muted1.ID)
+	assert.NotContains(t, ids, muted2.ID)
+	assert.NotContains(t, ids, renote.ID)
+	// renoteSrc 自体は muted author の plain note として除外される
+	assert.NotContains(t, ids, renoteSrc.ID)
+	// ok author の plain note 3 件が残る
+	assert.Contains(t, ids, ok1.ID)
+	assert.Contains(t, ids, ok2.ID)
+	assert.Contains(t, ids, ok3.ID)
+
+	// heavy-mute fill: limit=2 を要求した時、SQL push-down なら non-muted note
+	// が limit 件返ることを確認する (post-fetch filter だと最大 2 → muted 除外
+	// で 0 件になり得たが、SQL 段階で除外しているので必ず 2 件返る)。
+	rows, err = repo.ListLocalTimeline(2, "", "", model.TimelineDBFilter{
+		MutedUserIDs: []string{mutedAuthor.ID, mutedRenoteSrc.ID},
+	})
+	require.NoError(t, err)
+	assert.Len(t, rows, 2, "SQL push-down で limit ぶん non-muted note が fill されること (#892)")
+}
+
 func TestNoteRepository_CountReplyTargets(t *testing.T) {
 	repo := NewNoteRepository(testDB)
 	author := insertTestUser(t, "u_crt_a", "crtA")

--- a/internal/repository/note_test.go
+++ b/internal/repository/note_test.go
@@ -1018,6 +1018,63 @@ func TestNoteRepository_ListLocalTimeline_MutedUsersFilter(t *testing.T) {
 	assert.Len(t, rows, 2, "SQL push-down で limit ぶん non-muted note が fill されること (#892)")
 }
 
+// TestNoteRepository_ListHomeTimeline_MutedUsersWithFollowFilter は HomeTimeline
+// で MutedUserIDs と follow 制約が両立することを確認する (#892)。muted user は
+// follow していても home から除外されるべき、かつ MutedUserIDs の OR 節バグで
+// 非 follower の note が漏れない (= MutedChannel と同 SQL precedence ガード)。
+func TestNoteRepository_ListHomeTimeline_MutedUsersWithFollowFilter(t *testing.T) {
+	repo := NewNoteRepository(testDB)
+	viewer := insertTestUser(t, "u_mhfu_v", "mhfuviewer")
+	defer cleanupUser(t, viewer.ID)
+	followedMuted := insertTestUser(t, "u_mhfu_fm", "mhfufollowedmuted")
+	defer cleanupUser(t, followedMuted.ID)
+	followedOK := insertTestUser(t, "u_mhfu_fo", "mhfufollowedok")
+	defer cleanupUser(t, followedOK.ID)
+	stranger := insertTestUser(t, "u_mhfu_s", "mhfustranger")
+	defer cleanupUser(t, stranger.ID)
+
+	// viewer は followedMuted と followedOK を follow するが、followedMuted は
+	// mute 済み。stranger は未 follow なので home に含まれてはいけない。
+	require.NoError(t, testDB.Exec(
+		`INSERT INTO "following" (id, "followerId", "followeeId") VALUES (?, ?, ?)`,
+		"flw_mhfu_1", viewer.ID, followedMuted.ID,
+	).Error)
+	defer testDB.Exec(`DELETE FROM "following" WHERE id = ?`, "flw_mhfu_1")
+	require.NoError(t, testDB.Exec(
+		`INSERT INTO "following" (id, "followerId", "followeeId") VALUES (?, ?, ?)`,
+		"flw_mhfu_2", viewer.ID, followedOK.ID,
+	).Error)
+	defer testDB.Exec(`DELETE FROM "following" WHERE id = ?`, "flw_mhfu_2")
+
+	mk := func(id, uid string) *model.Note {
+		text := "hi"
+		return &model.Note{
+			ID: id, UserID: uid, Text: &text,
+			Visibility: model.NoteVisibilityPublic,
+			Reactions:  datatypes.JSON([]byte("{}")),
+		}
+	}
+	muted := mk("n_mhfu_m", followedMuted.ID)
+	ok := mk("n_mhfu_o", followedOK.ID)
+	leaked := mk("n_mhfu_s", stranger.ID)
+	require.NoError(t, repo.Create(muted))
+	require.NoError(t, repo.Create(ok))
+	require.NoError(t, repo.Create(leaked))
+	defer cleanupNote(t, muted.ID)
+	defer cleanupNote(t, ok.ID)
+	defer cleanupNote(t, leaked.ID)
+
+	rows, err := repo.ListHomeTimeline(viewer.ID, 100, "", "", model.TimelineDBFilter{
+		ViewerID:     viewer.ID,
+		MutedUserIDs: []string{followedMuted.ID},
+	})
+	require.NoError(t, err)
+
+	ids := idsOf(rows)
+	assert.ElementsMatch(t, []string{ok.ID}, ids,
+		"follow + mute フィルタが両立し、stranger が漏れず muted user も除外されること (#892)")
+}
+
 func TestNoteRepository_CountReplyTargets(t *testing.T) {
 	repo := NewNoteRepository(testDB)
 	author := insertTestUser(t, "u_crt_a", "crtA")


### PR DESCRIPTION
## Summary

#874 で実装した user mute filter は post-fetch in-memory (\`ApplyFilter\`) のみで動作しており、heavy-mute viewer (例: 数千 mutee) では DB / Redis から limit 件取得 → filter 後に limit 未満 という UX regression が発生し得た。SQL push-down で limit fill を保証する (= upstream Misskey TS QueryService の muting JOIN と同 semantics)。

## 主な変更点

- \`internal/model/timeline_filter.go\`: \`TimelineDBFilter.MutedUserIDs []string\` を追加。
- \`internal/repository/note.go::applyTimelineFilter\`: \`"userId" NOT IN ?\` と \`("renoteUserId" IS NULL OR "renoteUserId" NOT IN ?)\` を SQL 段階で適用 (renote 元 user の mute も同時に弾く)。
- \`internal/core/timeline/timeline_service.go::toDBFilter\`: \`MutedUserIDs\` を SQL 経路に伝搬。
- \`internal/core/timeline/timeline_filter.go\`: 既存 \`ApplyFilter\` の \`MutedUserIDs\` 経路は Redis fanout (cached note ID から resolve した slice) で動作する旨をコメント追記。SQL / in-memory 両経路で同 semantics を保つ。
- \`internal/repository/note_test.go\`: muted user / muted renote source の SQL 除外、heavy-mute fill (limit=2 で必ず 2 件返る) を unit test 化。

## テスト

- \`make test\` (timeline / repository / api/notes 全 pass)
- mk-go Playwright 67/67 pass (\`make playwright-test\`)

## Closes

- Closes #892

🤖 Generated with [Claude Code](https://claude.com/claude-code)