### PR TITLE
Fix #894: timeline mute filter を muting subquery で実装する

### DIFF
--- a/internal/core/timeline/timeline_service.go
+++ b/internal/core/timeline/timeline_service.go
@@ -207,10 +207,14 @@ func toDBFilter(f TimelineFilter, viewerID string) model.TimelineDBFilter {
 		IncludeLocalRenotes:   f.IncludeLocalRenotes,
 		ViewerID:              viewerID,
 		MutedChannelIDs:       f.MutedChannelIDs,
-		// MutedUserIDs を SQL push-down に伝搬する (#892)。Redis path の
-		// post-fetch ApplyFilter は依然 MutedUserIDs を見るので、cache hit
-		// と DB fallback の両経路で同 semantics になる。
-		MutedUserIDs: f.MutedUserIDs,
+		// production の SQL 経路では muting テーブルへの subquery で filter
+		// する (#894)。viewer 単位で bind parameter 数が固定 (2) なので
+		// heavy-mute viewer (>1000 mute) でも planning コストが膨らまない。
+		// Redis cache 経路 (in-memory ApplyFilter) は引き続き
+		// TimelineFilter.MutedUserIDs (loadMutedUserIDs で事前取得) を使う。
+		// MutedUserIDs literal は test override 用に残す (本 toDBFilter から
+		// は伝搬しない)。
+		UseMutingSubquery: viewerID != "",
 	}
 }
 

--- a/internal/core/timeline/timeline_service_test.go
+++ b/internal/core/timeline/timeline_service_test.go
@@ -346,3 +346,28 @@ func TestMergeIDs_LimitClamping(t *testing.T) {
 	assert.Equal(t, "d", out[0])
 	assert.Equal(t, "c", out[1])
 }
+
+// toDBFilter は viewerID が non-empty のとき UseMutingSubquery=true を set
+// する production 経路を担保する (#894)。anonymous viewer (= "") では
+// subquery 経路を使わず literal MutedUserIDs もそのまま 0 件で SQL filter
+// は no-op になる。
+func TestToDBFilter_UseMutingSubquery(t *testing.T) {
+	out := toDBFilter(TimelineFilter{}, "viewer1")
+	assert.True(t, out.UseMutingSubquery, "viewerID 有なら subquery を使う")
+	assert.Equal(t, "viewer1", out.ViewerID)
+	assert.Empty(t, out.MutedUserIDs, "literal は伝搬しない")
+
+	out = toDBFilter(TimelineFilter{}, "")
+	assert.False(t, out.UseMutingSubquery, "anonymous viewer では subquery off")
+	assert.Equal(t, "", out.ViewerID)
+
+	// MutedChannelIDs / その他 filter はそのまま伝搬する (regression guard)。
+	withReplies := true
+	out = toDBFilter(TimelineFilter{
+		MutedChannelIDs: []string{"ch1"},
+		WithReplies:     &withReplies,
+	}, "viewer2")
+	assert.Equal(t, []string{"ch1"}, out.MutedChannelIDs)
+	assert.NotNil(t, out.WithReplies)
+	assert.True(t, *out.WithReplies)
+}

--- a/internal/core/timeline/timeline_service_test.go
+++ b/internal/core/timeline/timeline_service_test.go
@@ -355,18 +355,23 @@ func TestToDBFilter_UseMutingSubquery(t *testing.T) {
 	out := toDBFilter(TimelineFilter{}, "viewer1")
 	assert.True(t, out.UseMutingSubquery, "viewerID 有なら subquery を使う")
 	assert.Equal(t, "viewer1", out.ViewerID)
-	assert.Empty(t, out.MutedUserIDs, "literal は伝搬しない")
 
 	out = toDBFilter(TimelineFilter{}, "")
 	assert.False(t, out.UseMutingSubquery, "anonymous viewer では subquery off")
 	assert.Equal(t, "", out.ViewerID)
+
+	// MutedUserIDs literal は SQL 経路に**伝搬しない**ことを明示的に
+	// 検証する (#894)。subquery 経路が production の SQL 経路で、literal
+	// は test override 専用の design intent を regression guard として固定。
+	out = toDBFilter(TimelineFilter{MutedUserIDs: []string{"u1", "u2"}}, "viewer2")
+	assert.Empty(t, out.MutedUserIDs, "literal は意図的に drop し subquery に委譲する")
 
 	// MutedChannelIDs / その他 filter はそのまま伝搬する (regression guard)。
 	withReplies := true
 	out = toDBFilter(TimelineFilter{
 		MutedChannelIDs: []string{"ch1"},
 		WithReplies:     &withReplies,
-	}, "viewer2")
+	}, "viewer3")
 	assert.Equal(t, []string{"ch1"}, out.MutedChannelIDs)
 	assert.NotNil(t, out.WithReplies)
 	assert.True(t, *out.WithReplies)

--- a/internal/model/timeline_filter.go
+++ b/internal/model/timeline_filter.go
@@ -16,5 +16,16 @@ type TimelineDBFilter struct {
 	// check する (= upstream Misskey TS QueryService の muting JOIN と同
 	// semantics)。Redis fanout 経路 (post-fetch) では in-memory 版
 	// ApplyFilter が同等処理を担う。
+	//
+	// production code path では UseMutingSubquery=true で subquery 経路を
+	// 使うので本フィールドは空のまま。test と非 viewer 駆動経路では literal
+	// list を直接渡す override path として残す。
 	MutedUserIDs []string
+	// UseMutingSubquery が true の場合、ViewerID を使って muting テーブルへ
+	// の subquery で muted user filter を適用する (#894)。MutedUserIDs を
+	// literal IN (...) で渡す方式に対し、bind parameter 数が viewer の
+	// mute 件数に比例しないため heavy-mute viewer (>1000 mute) でも
+	// PostgreSQL の planning コスト / parameter limit に達しない。
+	// MutedUserIDs より優先 (両方 set されたら subquery が勝つ)。
+	UseMutingSubquery bool
 }

--- a/internal/repository/note.go
+++ b/internal/repository/note.go
@@ -534,21 +534,32 @@ func applyTimelineFilter(q *gorm.DB, f model.TimelineDBFilter) *gorm.DB {
 		q = q.Where(`("channelId" IS NULL OR "channelId" NOT IN ?)`, f.MutedChannelIDs)
 	}
 	// muted user filter は 2 経路を持つ (#892 / #894):
-	//   1. UseMutingSubquery=true: muting テーブルへの subquery (production)。
+	//   1. UseMutingSubquery=true: muting テーブルへの NOT EXISTS (production)。
 	//      bind parameter が viewer 単位で 2 つ ($viewerID を 2 度) のみで、
 	//      mute 件数に比例しないので heavy-mute viewer でも planning コスト
 	//      が膨らまない。
 	//   2. MutedUserIDs literal: 既存テスト互換のための override path
 	//      (test や非 viewer 駆動経路で muteeID 集合を直接指定したいとき)。
 	//      Subquery が使えるなら 1. を優先。
-	// 共通の WHERE は: userId NOT IN (mutees) AND
-	//                  (renoteUserId IS NULL OR renoteUserId NOT IN (mutees))
+	// 共通の WHERE は: userId が active mute されておらず、かつ renoteUserId
+	// が NULL でなければ renoteUserId も active mute されていないこと。
 	if f.UseMutingSubquery && f.ViewerID != "" {
-		// muting subquery: active mute (= ExpiresAt NULL or future) のみ拾う。
-		// mutingRepository.ListMuteeIDs と同じ semantics を SQL 内で表現。
-		mutingSub := `SELECT "muteeId" FROM "muting" WHERE "muterId" = ? AND ("expiresAt" IS NULL OR "expiresAt" > NOW())`
+		// NOT EXISTS による anti-join (Postgres planner が semi-join 相当に
+		// 最適化、IDX_muting_muterId_muteeId 複合 index で seek)。NOT IN
+		// subquery より NULL 取り扱いがロバストかつ index 使用が明確。
+		// active mute = expiresAt nil or future、mutingRepository.ListMuteeIDs
+		// と同 semantics を SQL 内で表現。
+		//
+		// Postgres NOW() は transaction 開始時刻 (= query 内で constant)。
+		// in-memory ApplyFilter (Redis cache 経路) は Go time.Now() を使う
+		// が、mutingRepo.ListMuteeIDs と timeline 取得は同一 request 内 (=
+		// サブ秒) で連続実行されるため、境界 expiresAt の片方に倒れて 2
+		// 経路で挙動が分岐する race window は無視できる。
+		notExistsForCol := func(col string) string {
+			return `NOT EXISTS (SELECT 1 FROM "muting" m WHERE m."muterId" = ? AND m."muteeId" = ` + col + ` AND (m."expiresAt" IS NULL OR m."expiresAt" > NOW()))`
+		}
 		q = q.Where(
-			`"userId" NOT IN (`+mutingSub+`) AND ("renoteUserId" IS NULL OR "renoteUserId" NOT IN (`+mutingSub+`))`,
+			notExistsForCol(`"note"."userId"`)+` AND ("renoteUserId" IS NULL OR `+notExistsForCol(`"note"."renoteUserId"`)+`)`,
 			f.ViewerID, f.ViewerID,
 		)
 	} else if len(f.MutedUserIDs) > 0 {

--- a/internal/repository/note.go
+++ b/internal/repository/note.go
@@ -533,14 +533,25 @@ func applyTimelineFilter(q *gorm.DB, f model.TimelineDBFilter) *gorm.DB {
 		// バイパスしてしまう (SQL優先順位: AND > OR)。
 		q = q.Where(`("channelId" IS NULL OR "channelId" NOT IN ?)`, f.MutedChannelIDs)
 	}
-	if len(f.MutedUserIDs) > 0 {
-		// muted user の note を SQL 段階で除外する (#892)。post-fetch filter
-		// と異なり limit ぶん fill された non-muted note を 1 query で取得
-		// できるので、heavy-mute viewer (例: 数千 mutee) でも timeline 件数
-		// が一時的に limit 未満になる UX regression を回避できる。
-		// renote 元 user が muted のケースもここで一緒に弾く (= upstream
-		// Misskey TS QueryService の muting JOIN と同 semantics)。
-		// 2 条件を 1 つの Where にまとめて intent を 1 行で読めるようにする。
+	// muted user filter は 2 経路を持つ (#892 / #894):
+	//   1. UseMutingSubquery=true: muting テーブルへの subquery (production)。
+	//      bind parameter が viewer 単位で 2 つ ($viewerID を 2 度) のみで、
+	//      mute 件数に比例しないので heavy-mute viewer でも planning コスト
+	//      が膨らまない。
+	//   2. MutedUserIDs literal: 既存テスト互換のための override path
+	//      (test や非 viewer 駆動経路で muteeID 集合を直接指定したいとき)。
+	//      Subquery が使えるなら 1. を優先。
+	// 共通の WHERE は: userId NOT IN (mutees) AND
+	//                  (renoteUserId IS NULL OR renoteUserId NOT IN (mutees))
+	if f.UseMutingSubquery && f.ViewerID != "" {
+		// muting subquery: active mute (= ExpiresAt NULL or future) のみ拾う。
+		// mutingRepository.ListMuteeIDs と同じ semantics を SQL 内で表現。
+		mutingSub := `SELECT "muteeId" FROM "muting" WHERE "muterId" = ? AND ("expiresAt" IS NULL OR "expiresAt" > NOW())`
+		q = q.Where(
+			`"userId" NOT IN (`+mutingSub+`) AND ("renoteUserId" IS NULL OR "renoteUserId" NOT IN (`+mutingSub+`))`,
+			f.ViewerID, f.ViewerID,
+		)
+	} else if len(f.MutedUserIDs) > 0 {
 		q = q.Where(`"userId" NOT IN ? AND ("renoteUserId" IS NULL OR "renoteUserId" NOT IN ?)`, f.MutedUserIDs, f.MutedUserIDs)
 	}
 	return q

--- a/internal/repository/note_test.go
+++ b/internal/repository/note_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/lib/pq"
 	"github.com/shiroha-a/mk/internal/model"
@@ -1016,6 +1017,93 @@ func TestNoteRepository_ListLocalTimeline_MutedUsersFilter(t *testing.T) {
 	})
 	require.NoError(t, err)
 	assert.Len(t, rows, 2, "SQL push-down で limit ぶん non-muted note が fill されること (#892)")
+}
+
+// TestNoteRepository_ListLocalTimeline_MutedUsersSubquery は production
+// 経路 (UseMutingSubquery=true + ViewerID) で muting テーブルへ subquery
+// する filter が正しく動作することを確認する (#894)。muting row の
+// expiresAt が NULL / 未来 / 過去の 3 ケースで active mute だけ filter
+// に効くこと、renote 元 user の mute も同時に弾かれることを担保する。
+func TestNoteRepository_ListLocalTimeline_MutedUsersSubquery(t *testing.T) {
+	repo := NewNoteRepository(testDB)
+	mutingRepo := NewMutingRepository(testDB)
+	viewer := insertTestUser(t, "u_mus_v", "musv")
+	defer cleanupUser(t, viewer.ID)
+	mutedAuthor := insertTestUser(t, "u_mus_m", "musm")
+	defer cleanupUser(t, mutedAuthor.ID)
+	expiredMutedAuthor := insertTestUser(t, "u_mus_e", "muse")
+	defer cleanupUser(t, expiredMutedAuthor.ID)
+	mutedRenoteSrc := insertTestUser(t, "u_mus_rs", "musrs")
+	defer cleanupUser(t, mutedRenoteSrc.ID)
+	okAuthor := insertTestUser(t, "u_mus_o", "muso")
+	defer cleanupUser(t, okAuthor.ID)
+
+	// active mute (expiresAt nil)
+	activeMute := &model.Muting{ID: "mute_us_a", MuterID: viewer.ID, MuteeID: mutedAuthor.ID}
+	require.NoError(t, mutingRepo.Create(activeMute))
+	defer cleanupMuting(t, activeMute.ID)
+
+	// active mute (renote 元)
+	renoteMute := &model.Muting{ID: "mute_us_r", MuterID: viewer.ID, MuteeID: mutedRenoteSrc.ID}
+	require.NoError(t, mutingRepo.Create(renoteMute))
+	defer cleanupMuting(t, renoteMute.ID)
+
+	// expired mute (subquery で除外されるべき = 該当 user の note は filter 通過する)
+	pastTime := time.Now().Add(-1 * time.Hour)
+	expiredMute := &model.Muting{ID: "mute_us_e", MuterID: viewer.ID, MuteeID: expiredMutedAuthor.ID, ExpiresAt: &pastTime}
+	require.NoError(t, mutingRepo.Create(expiredMute))
+	defer cleanupMuting(t, expiredMute.ID)
+
+	mkPlain := func(id, uid string) *model.Note {
+		text := "x"
+		return &model.Note{
+			ID: id, UserID: uid, Text: &text,
+			Visibility: model.NoteVisibilityPublic,
+			Reactions:  datatypes.JSON([]byte("{}")),
+		}
+	}
+
+	// muted active author の note (除外)
+	mutedNote := mkPlain("n_mus_m", mutedAuthor.ID)
+	require.NoError(t, repo.Create(mutedNote))
+	defer cleanupNote(t, mutedNote.ID)
+
+	// expired mute author の note (含まれる = subquery が NOW() フィルタを尊重)
+	expiredAuthorNote := mkPlain("n_mus_e", expiredMutedAuthor.ID)
+	require.NoError(t, repo.Create(expiredAuthorNote))
+	defer cleanupNote(t, expiredAuthorNote.ID)
+
+	// renote (= ok author が mutedRenoteSrc を renote。renoteUserId が active
+	// mute なので除外)
+	renoteSrc := mkPlain("n_mus_src", mutedRenoteSrc.ID)
+	require.NoError(t, repo.Create(renoteSrc))
+	defer cleanupNote(t, renoteSrc.ID)
+	renote := &model.Note{
+		ID: "n_mus_renote", UserID: okAuthor.ID,
+		RenoteID: &renoteSrc.ID, RenoteUserID: &mutedRenoteSrc.ID,
+		Visibility: model.NoteVisibilityPublic,
+		Reactions:  datatypes.JSON([]byte("{}")),
+	}
+	require.NoError(t, repo.Create(renote))
+	defer cleanupNote(t, renote.ID)
+
+	// ok plain note (含まれる)
+	okNote := mkPlain("n_mus_ok", okAuthor.ID)
+	require.NoError(t, repo.Create(okNote))
+	defer cleanupNote(t, okNote.ID)
+
+	// production 経路: UseMutingSubquery=true / MutedUserIDs 空
+	rows, err := repo.ListLocalTimeline(100, "", "", model.TimelineDBFilter{
+		ViewerID:          viewer.ID,
+		UseMutingSubquery: true,
+	})
+	require.NoError(t, err)
+	ids := idsOf(rows)
+	assert.NotContains(t, ids, mutedNote.ID, "active mute author の note は除外")
+	assert.NotContains(t, ids, renoteSrc.ID, "active mute author の plain note (renote 元) も除外")
+	assert.NotContains(t, ids, renote.ID, "renoteUserId が active mute の renote も除外")
+	assert.Contains(t, ids, expiredAuthorNote.ID, "expired mute は subquery で除外され filter 通過")
+	assert.Contains(t, ids, okNote.ID, "ok author の note は含まれる")
 }
 
 // TestNoteRepository_ListHomeTimeline_MutedUsersWithFollowFilter は HomeTimeline


### PR DESCRIPTION
## Summary

#892 で SQL push-down 化した際は \`MutedUserIDs\` literal を \`IN (?, ?, ..., ?)\` で渡す方式だったが、heavy-mute viewer (>1000 mute) では bind parameter が mute 件数に比例して PostgreSQL の planning コスト + parameter limit (32k) に近付くスケーラビリティ問題があった。muting テーブルへの subquery で filter することで bind parameter を viewer 単位 2 個に固定する。

## 主な変更点

- \`internal/model/timeline_filter.go\`: \`TimelineDBFilter.UseMutingSubquery bool\` 追加。
- \`internal/repository/note.go::applyTimelineFilter\`: \`UseMutingSubquery=true\` 時 \`SELECT "muteeId" FROM "muting" WHERE "muterId" = ? AND ("expiresAt" IS NULL OR "expiresAt" > NOW())\` の subquery で filter する経路を実装。\`MutedUserIDs\` literal path は test override として残す。
- \`internal/core/timeline/timeline_service.go::toDBFilter\`: \`viewerID != ""\` のとき \`UseMutingSubquery: true\` を set。\`MutedUserIDs\` literal の伝搬は drop (= production の SQL 経路は subquery のみを使う)。
- \`internal/repository/note_test.go\`: \`TestNoteRepository_ListLocalTimeline_MutedUsersSubquery\` を追加。muting row 直接 insert で active mute (\`expiresAt nil\`) / expired mute / renote 元 mute の subquery 挙動を検証。
- handler は in-memory \`ApplyFilter\` (Redis cache 経路) のため \`loadMutedUserIDs\` を継続使用 (TimelineFilter.MutedUserIDs)。SQL 経路と in-memory 経路の役割分担はコメントで明示。

## scope 外

- \`loadMutedUserIDs\` を service 層に移して cache hit 時のみ lazy 取得する re-architect は別 issue。本 PR は SQL bind parameter scalability の解消を主目的とする。

## テスト

- \`make test\` (timeline / repository / api/notes 全 pass)
- mk-go Playwright 67/67 pass

## Closes

- Closes #894

🤖 Generated with [Claude Code](https://claude.com/claude-code)