### PR TITLE
#882 Playwright Phase 2: emoji bulk operations + import-zip spec の整備

### DIFF
--- a/docker-compose.playwright.ts.yml
+++ b/docker-compose.playwright.ts.yml
@@ -39,3 +39,11 @@ services:
       timeout: 5s
       retries: 30
       start_period: 30s
+
+  # Playwright runner に「TS backend で実行中」と伝える marker。spec 側は
+  # process.env.MK_BACKEND_TYPE で TS 限定の skip 等を制御する (#882 で
+  # import-zip async download が TS の got HTTPS で self-signed cert を
+  # 弾く問題への workaround)。
+  playwright-runner:
+    environment:
+      MK_BACKEND_TYPE: ts

--- a/internal/api/admin/emoji.go
+++ b/internal/api/admin/emoji.go
@@ -42,7 +42,13 @@ func (h *Handler) EmojiAddAliasesBulk(c echo.Context) error {
 		// SQLSTATE 42804 (column type mismatch) になる drift がある
 		// (#896 と同 pattern)。pq.StringArray で wrap して
 		// `'{a,b}'` array literal として書き込ませる。
-		_ = h.emojiRepo.UpdateFields(e.ID, map[string]any{"aliases": pq.StringArray(merged)})
+		if err := h.emojiRepo.UpdateFields(e.ID, map[string]any{"aliases": pq.StringArray(merged)}); err != nil {
+			// per-emoji 失敗は bulk 操作全体を中断せず log で観測する
+			// (#882 で発覚した silent failure 防止)。複数件のうち一部が
+			// 失敗しても他の emoji は更新したい意図。
+			slog.WarnContext(c.Request().Context(), "admin/emoji/add-aliases-bulk: per-emoji update failed",
+				"emojiId", e.ID, "err", err)
+		}
 	}
 	return c.NoContent(http.StatusNoContent)
 }
@@ -286,7 +292,12 @@ func (h *Handler) EmojiRemoveAliasesBulk(c echo.Context) error {
 		}
 		// pq.StringArray wrap (#896 と同 pattern) — add-aliases-bulk と
 		// 同じ理由で plain []string では SQLSTATE 42804 になる。
-		_ = h.emojiRepo.UpdateFields(e.ID, map[string]any{"aliases": pq.StringArray(filtered)})
+		if err := h.emojiRepo.UpdateFields(e.ID, map[string]any{"aliases": pq.StringArray(filtered)}); err != nil {
+			// per-emoji 失敗は他 emoji への影響を避けるため warn log で
+			// 観測しつつ continue する (add-aliases-bulk と同 policy)。
+			slog.WarnContext(c.Request().Context(), "admin/emoji/remove-aliases-bulk: per-emoji update failed",
+				"emojiId", e.ID, "err", err)
+		}
 	}
 	return c.NoContent(http.StatusNoContent)
 }

--- a/internal/api/admin/emoji.go
+++ b/internal/api/admin/emoji.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/labstack/echo/v4"
+	"github.com/lib/pq"
 	"github.com/shiroha-a/mk/internal/api/apierr"
 	"github.com/shiroha-a/mk/internal/core/moderationlog"
 	"github.com/shiroha-a/mk/internal/entity"
@@ -36,7 +37,12 @@ func (h *Handler) EmojiAddAliasesBulk(c echo.Context) error {
 	}
 	for _, e := range rows {
 		merged := dedupe(append(append([]string{}, e.Aliases...), req.Aliases...))
-		_ = h.emojiRepo.UpdateFields(e.ID, map[string]any{"aliases": merged})
+		// model.Emoji.Aliases は pq.StringArray なので plain []string で
+		// 渡すと GORM が record literal `('a','b')` を生成して
+		// SQLSTATE 42804 (column type mismatch) になる drift がある
+		// (#896 と同 pattern)。pq.StringArray で wrap して
+		// `'{a,b}'` array literal として書き込ませる。
+		_ = h.emojiRepo.UpdateFields(e.ID, map[string]any{"aliases": pq.StringArray(merged)})
 	}
 	return c.NoContent(http.StatusNoContent)
 }
@@ -278,7 +284,9 @@ func (h *Handler) EmojiRemoveAliasesBulk(c echo.Context) error {
 				filtered = append(filtered, a)
 			}
 		}
-		_ = h.emojiRepo.UpdateFields(e.ID, map[string]any{"aliases": filtered})
+		// pq.StringArray wrap (#896 と同 pattern) — add-aliases-bulk と
+		// 同じ理由で plain []string では SQLSTATE 42804 になる。
+		_ = h.emojiRepo.UpdateFields(e.ID, map[string]any{"aliases": pq.StringArray(filtered)})
 	}
 	return c.NoContent(http.StatusNoContent)
 }
@@ -298,7 +306,9 @@ func (h *Handler) EmojiSetAliasesBulk(c echo.Context) error {
 	if h.emojiRepo == nil {
 		return c.NoContent(http.StatusNoContent)
 	}
-	if err := h.emojiRepo.UpdateFieldsMany(req.IDs, map[string]any{"aliases": req.Aliases}); err != nil {
+	// pq.StringArray wrap (#896 と同 pattern) — UpdateFieldsMany 経由でも
+	// 同 drift が発生するので caller 側で wrap する。
+	if err := h.emojiRepo.UpdateFieldsMany(req.IDs, map[string]any{"aliases": pq.StringArray(req.Aliases)}); err != nil {
 		return c.JSON(http.StatusInternalServerError, apierr.InternalError())
 	}
 	return c.NoContent(http.StatusNoContent)

--- a/internal/repository/emoji_test.go
+++ b/internal/repository/emoji_test.go
@@ -296,6 +296,38 @@ func TestEmojiRepository_UpdateFieldsMany(t *testing.T) {
 	require.NoError(t, repo.UpdateFieldsMany([]string{e1.ID}, map[string]any{}))
 }
 
+// TestEmojiRepository_UpdateFieldsMany_AliasesPqStringArray は #882 で
+// 発覚した bulk drift の regression guard。core/api/admin の bulk handler
+// は plain []string を渡すと GORM が record literal `('a','b')` を生成
+// して SQLSTATE 42804 (column type mismatch) になっていた。pq.StringArray
+// で wrap した場合に array literal `'{a,b}'` として正しく serialize され
+// ることを確認する (UpdateFields_AliasesEmptySlice の bulk 版)。
+func TestEmojiRepository_UpdateFieldsMany_AliasesPqStringArray(t *testing.T) {
+	repo := NewEmojiRepository(testDB)
+	e1 := &model.Emoji{ID: "em_ufm_a1", Name: "ufm_a1", OriginalURL: "https://x"}
+	e2 := &model.Emoji{ID: "em_ufm_a2", Name: "ufm_a2", OriginalURL: "https://y"}
+	require.NoError(t, repo.Create(e1))
+	require.NoError(t, repo.Create(e2))
+	defer cleanupEmoji(t, e1.ID)
+	defer cleanupEmoji(t, e2.ID)
+
+	// 通常の値: pq.StringArray wrap で 2 emoji 同時 update
+	require.NoError(t, repo.UpdateFieldsMany([]string{e1.ID, e2.ID}, map[string]any{
+		"aliases": pq.StringArray{"alpha", "beta"},
+	}))
+	a1, _ := repo.FindByID(e1.ID)
+	a2, _ := repo.FindByID(e2.ID)
+	assert.Equal(t, []string{"alpha", "beta"}, []string(a1.Aliases))
+	assert.Equal(t, []string{"alpha", "beta"}, []string(a2.Aliases))
+
+	// 空 slice: NOT NULL 制約に当たらず '{}' として保存される
+	require.NoError(t, repo.UpdateFieldsMany([]string{e1.ID, e2.ID}, map[string]any{
+		"aliases": pq.StringArray{},
+	}))
+	a1, _ = repo.FindByID(e1.ID)
+	assert.Empty(t, []string(a1.Aliases))
+}
+
 func TestEmojiRepository_DeleteMany(t *testing.T) {
 	repo := NewEmojiRepository(testDB)
 

--- a/internal/testutil/mock_repository.go
+++ b/internal/testutil/mock_repository.go
@@ -1538,7 +1538,12 @@ func (m *MockEmojiRepository) UpdateFieldsMany(ids []string, fields map[string]a
 					e.License = &s
 				}
 			case "aliases":
-				if arr, ok := v.([]string); ok {
+				// production 経路は pq.StringArray で wrap して渡す (#882
+				// で発覚した character varying[] vs record drift を回避)。
+				// test/legacy で plain []string を渡す呼び出しもあるので両対応。
+				if arr, ok := v.(pq.StringArray); ok {
+					e.Aliases = []string(arr)
+				} else if arr, ok := v.([]string); ok {
 					e.Aliases = arr
 				}
 			case "updatedAt":

--- a/tests/playwright/fixtures/files.ts
+++ b/tests/playwright/fixtures/files.ts
@@ -23,3 +23,130 @@ export interface DriveFile {
   type: string;
   size: number;
 }
+
+// CRC32 lookup table for ZIP fixture builder (#882). standard polynomial
+// 0xEDB88320 (= reflected 0x04C11DB7)。一度だけ計算して以降は table 参照。
+const CRC32_TABLE = (() => {
+  const table = new Uint32Array(256);
+  for (let i = 0; i < 256; i++) {
+    let c = i;
+    for (let j = 0; j < 8; j++) {
+      c = c & 1 ? 0xedb88320 ^ (c >>> 1) : c >>> 1;
+    }
+    table[i] = c >>> 0;
+  }
+  return table;
+})();
+
+function crc32(buf: Buffer): number {
+  let crc = 0xffffffff;
+  for (const b of buf) {
+    crc = (crc >>> 8) ^ CRC32_TABLE[(crc ^ b) & 0xff];
+  }
+  return (crc ^ 0xffffffff) >>> 0;
+}
+
+// buildZip constructs a minimal valid ZIP archive (STORED, no compression)
+// from the given entries. emoji import-zip 用 fixture (#882) の生成器。
+// jszip 依存を増やさず、固定 entry 数 (meta.json + small PNG) なので
+// CRC32 + LFH/CD/EOCD を手書きで組む。Go の archive/zip と stdlib unzip 両方で
+// 読めることをローカルで確認している。
+export function buildZip(entries: { name: string; content: Buffer }[]): Buffer {
+  const localBlocks: Buffer[] = [];
+  const centralBlocks: Buffer[] = [];
+  let offset = 0;
+
+  for (const e of entries) {
+    const nameBuf = Buffer.from(e.name, 'utf-8');
+    const crc = crc32(e.content);
+    const size = e.content.length;
+
+    // Local File Header (signature 0x04034b50, version 20 = ZIP 2.0)。
+    const lfh = Buffer.alloc(30);
+    lfh.writeUInt32LE(0x04034b50, 0);
+    lfh.writeUInt16LE(20, 4); // version needed
+    lfh.writeUInt16LE(0, 6); // general purpose bit flag
+    lfh.writeUInt16LE(0, 8); // compression method (STORED)
+    lfh.writeUInt16LE(0, 10); // mod time
+    lfh.writeUInt16LE(0, 12); // mod date
+    lfh.writeUInt32LE(crc, 14);
+    lfh.writeUInt32LE(size, 18); // compressed size
+    lfh.writeUInt32LE(size, 22); // uncompressed size
+    lfh.writeUInt16LE(nameBuf.length, 26);
+    lfh.writeUInt16LE(0, 28); // extra length
+    localBlocks.push(lfh, nameBuf, e.content);
+
+    // Central Directory Entry (signature 0x02014b50)。
+    const cd = Buffer.alloc(46);
+    cd.writeUInt32LE(0x02014b50, 0);
+    cd.writeUInt16LE(20, 4); // version made by
+    cd.writeUInt16LE(20, 6); // version needed
+    cd.writeUInt16LE(0, 8); // flags
+    cd.writeUInt16LE(0, 10); // compression
+    cd.writeUInt16LE(0, 12); // mod time
+    cd.writeUInt16LE(0, 14); // mod date
+    cd.writeUInt32LE(crc, 16);
+    cd.writeUInt32LE(size, 20);
+    cd.writeUInt32LE(size, 24);
+    cd.writeUInt16LE(nameBuf.length, 28);
+    cd.writeUInt16LE(0, 30); // extra length
+    cd.writeUInt16LE(0, 32); // comment length
+    cd.writeUInt16LE(0, 34); // disk number start
+    cd.writeUInt16LE(0, 36); // internal file attrs
+    cd.writeUInt32LE(0, 38); // external file attrs
+    cd.writeUInt32LE(offset, 42); // local header offset
+    centralBlocks.push(cd, nameBuf);
+
+    offset += 30 + nameBuf.length + size;
+  }
+
+  const cdBuf = Buffer.concat(centralBlocks);
+  const cdSize = cdBuf.length;
+  const cdOffset = offset;
+
+  // End of Central Directory Record (signature 0x06054b50)。
+  const eocd = Buffer.alloc(22);
+  eocd.writeUInt32LE(0x06054b50, 0);
+  eocd.writeUInt16LE(0, 4); // disk number
+  eocd.writeUInt16LE(0, 6); // disk with central dir
+  eocd.writeUInt16LE(entries.length, 8);
+  eocd.writeUInt16LE(entries.length, 10);
+  eocd.writeUInt32LE(cdSize, 12);
+  eocd.writeUInt32LE(cdOffset, 16);
+  eocd.writeUInt16LE(0, 20); // comment length
+
+  return Buffer.concat([...localBlocks, cdBuf, eocd]);
+}
+
+// buildEmojiImportZip constructs a Misskey-compatible custom-emoji import ZIP
+// (= meta.json + per-emoji PNG)。upstream の
+// ExportCustomEmojisProcessorService が出力する metaDoc 構造に従う (#882)。
+export function buildEmojiImportZip(
+  emojis: { name: string; image?: Buffer }[],
+): Buffer {
+  const meta = {
+    metaVersion: 2,
+    host: null,
+    exportedAt: new Date().toISOString(),
+    emojis: emojis.map((e) => ({
+      fileName: `${e.name}.png`,
+      downloaded: true,
+      emoji: {
+        name: e.name,
+        category: null,
+        aliases: [],
+        license: null,
+        isSensitive: false,
+        localOnly: false,
+      },
+    })),
+  };
+  const entries = [
+    { name: 'meta.json', content: Buffer.from(JSON.stringify(meta), 'utf-8') },
+    ...emojis.map((e) => ({
+      name: `${e.name}.png`,
+      content: e.image ?? tinyPNG,
+    })),
+  ];
+  return buildZip(entries);
+}

--- a/tests/playwright/specs/emoji/emoji_bulk.spec.ts
+++ b/tests/playwright/specs/emoji/emoji_bulk.spec.ts
@@ -1,0 +1,195 @@
+// Phase 2 #882: admin/emoji bulk operations の round-trip。
+//
+// upstream Misskey TS と mk-go は両方とも:
+//   - admin/emoji/add-aliases-bulk { ids, aliases }: 各 emoji の alias に
+//     新規 alias を merge (重複は dedupe)
+//   - admin/emoji/remove-aliases-bulk { ids, aliases }: 各 emoji の alias
+//     から指定 alias を除外
+//   - admin/emoji/set-aliases-bulk { ids, aliases }: 全 ids の alias を
+//     同じ aliases に上書き
+//   - admin/emoji/set-category-bulk { ids, category }: 全 ids の category
+//     を同じ category に上書き
+//   - admin/emoji/set-license-bulk { ids, license }: 全 ids の license を
+//     同じ license に上書き
+//   - admin/emoji/delete-bulk { ids }: 全 ids を delete
+//
+// 本 spec は 2 emoji を作成し、上記 6 endpoint の round-trip を 1 test で
+// 順次走らせる (= setup の重複を避けて test 全体の所要時間を抑える)。
+
+import { readFileSync } from 'node:fs';
+import { expect, test } from '@playwright/test';
+import { callApi } from '../../fixtures/api';
+import { tinyPNG } from '../../fixtures/files';
+import { resetRateLimit } from '../../fixtures/rate_limit';
+
+const baseURL = process.env.MK_BASE_URL ?? 'https://mkgo.local';
+
+interface RootFixture {
+  id: string;
+  token: string;
+  username: string;
+}
+
+interface AdminEmoji {
+  id: string;
+  name: string;
+  category?: string | null;
+  aliases?: string[];
+  license?: string | null;
+}
+
+async function uploadEmoji(
+  request: import('@playwright/test').APIRequestContext,
+  token: string,
+  name: string,
+): Promise<string> {
+  const upload = await request.post(`${baseURL}/api/drive/files/create`, {
+    multipart: {
+      i: token,
+      file: { name: `${name}.png`, mimeType: 'image/png', buffer: tinyPNG },
+    },
+    failOnStatusCode: false,
+  });
+  expect(upload.status()).toBe(200);
+  const uploaded = (await upload.json()) as { id: string };
+  const add = await callApi(request, 'admin/emoji/add', {
+    i: token,
+    name,
+    fileId: uploaded.id,
+  });
+  expect(add.status()).toBe(200);
+  const added = (await add.json()) as { id: string };
+  return added.id;
+}
+
+async function findEmojiByName(
+  request: import('@playwright/test').APIRequestContext,
+  token: string,
+  name: string,
+): Promise<AdminEmoji | undefined> {
+  const list = await callApi(request, 'admin/emoji/list', {
+    i: token,
+    query: name,
+    limit: 10,
+  });
+  expect(list.status()).toBe(200);
+  const body = (await list.json()) as AdminEmoji[];
+  return body.find((e) => e.name === name);
+}
+
+test.describe('emoji: admin bulk operations', () => {
+  let createdIds: string[] = [];
+  let rootToken: string | undefined;
+
+  test.beforeAll(() => {
+    resetRateLimit();
+  });
+
+  test.afterEach(async ({ request }) => {
+    if (rootToken && createdIds.length > 0) {
+      await callApi(request, 'admin/emoji/delete-bulk', {
+        i: rootToken,
+        ids: createdIds,
+      });
+    }
+    createdIds = [];
+    rootToken = undefined;
+  });
+
+  test('bulk alias / category / license / delete round-trip', async ({
+    request,
+  }) => {
+    const root: RootFixture = JSON.parse(readFileSync('.auth/root.json', 'utf-8'));
+    rootToken = root.token;
+    const suffix = Math.random().toString(16).slice(2, 8);
+    const name1 = `bulk1_${suffix}`;
+    const name2 = `bulk2_${suffix}`;
+
+    // 2 emoji を作成 (upload + add)。
+    const id1 = await uploadEmoji(request, root.token, name1);
+    const id2 = await uploadEmoji(request, root.token, name2);
+    createdIds = [id1, id2];
+
+    // add-aliases-bulk → 両 emoji に "alpha" / "beta" alias が merge される
+    {
+      const resp = await callApi(request, 'admin/emoji/add-aliases-bulk', {
+        i: root.token,
+        ids: [id1, id2],
+        aliases: ['alpha', 'beta'],
+      });
+      expect([200, 204]).toContain(resp.status());
+      const e1 = await findEmojiByName(request, root.token, name1);
+      const e2 = await findEmojiByName(request, root.token, name2);
+      expect(e1?.aliases).toEqual(expect.arrayContaining(['alpha', 'beta']));
+      expect(e2?.aliases).toEqual(expect.arrayContaining(['alpha', 'beta']));
+    }
+
+    // remove-aliases-bulk → "alpha" だけ除外、"beta" は残る
+    {
+      const resp = await callApi(request, 'admin/emoji/remove-aliases-bulk', {
+        i: root.token,
+        ids: [id1, id2],
+        aliases: ['alpha'],
+      });
+      expect([200, 204]).toContain(resp.status());
+      const e1 = await findEmojiByName(request, root.token, name1);
+      expect(e1?.aliases).not.toContain('alpha');
+      expect(e1?.aliases).toContain('beta');
+    }
+
+    // set-aliases-bulk → alias を ["gamma"] で上書き (= 既存 "beta" は消える)
+    {
+      const resp = await callApi(request, 'admin/emoji/set-aliases-bulk', {
+        i: root.token,
+        ids: [id1, id2],
+        aliases: ['gamma'],
+      });
+      expect([200, 204]).toContain(resp.status());
+      const e1 = await findEmojiByName(request, root.token, name1);
+      expect(e1?.aliases).toEqual(['gamma']);
+    }
+
+    // set-category-bulk → 全件同じ category に上書き
+    {
+      const cat = `bulk-cat-${suffix}`;
+      const resp = await callApi(request, 'admin/emoji/set-category-bulk', {
+        i: root.token,
+        ids: [id1, id2],
+        category: cat,
+      });
+      expect([200, 204]).toContain(resp.status());
+      const e1 = await findEmojiByName(request, root.token, name1);
+      const e2 = await findEmojiByName(request, root.token, name2);
+      expect(e1?.category).toBe(cat);
+      expect(e2?.category).toBe(cat);
+    }
+
+    // set-license-bulk → 全件同じ license に上書き
+    {
+      const lic = `CC-BY-${suffix}`;
+      const resp = await callApi(request, 'admin/emoji/set-license-bulk', {
+        i: root.token,
+        ids: [id1, id2],
+        license: lic,
+      });
+      expect([200, 204]).toContain(resp.status());
+      const e1 = await findEmojiByName(request, root.token, name1);
+      expect(e1?.license).toBe(lic);
+    }
+
+    // delete-bulk → 一覧から消える
+    {
+      const resp = await callApi(request, 'admin/emoji/delete-bulk', {
+        i: root.token,
+        ids: [id1, id2],
+      });
+      expect([200, 204]).toContain(resp.status());
+      // delete 済 = afterEach の cleanup は不要
+      createdIds = [];
+      const e1 = await findEmojiByName(request, root.token, name1);
+      const e2 = await findEmojiByName(request, root.token, name2);
+      expect(e1).toBeUndefined();
+      expect(e2).toBeUndefined();
+    }
+  });
+});

--- a/tests/playwright/specs/emoji/emoji_import_zip.spec.ts
+++ b/tests/playwright/specs/emoji/emoji_import_zip.spec.ts
@@ -1,0 +1,141 @@
+// Phase 2 #882: admin/emoji/import-zip の async round-trip。
+//
+// upstream Misskey TS と mk-go は両方とも:
+//   1. ZIP を drive/files/create で upload (= fileId 取得)
+//   2. admin/emoji/import-zip { fileId } で job を enqueue (204)
+//   3. queue worker が ZIP を展開し meta.json に従って各 emoji を
+//      admin/emoji/add 相当で local custom emoji に登録
+//   4. admin/emoji/list の query で各 emoji が現れる
+//
+// 即時反映ではないので polling で最大 30 秒待つ。notification spec の
+// pollForNotification と同型で、queue 処理時間 + drive store + emoji
+// repo write を見込んで余裕を持つ。
+
+import { readFileSync } from 'node:fs';
+import { expect, test } from '@playwright/test';
+import { callApi } from '../../fixtures/api';
+import { buildEmojiImportZip } from '../../fixtures/files';
+import { resetRateLimit } from '../../fixtures/rate_limit';
+
+const baseURL = process.env.MK_BASE_URL ?? 'https://mkgo.local';
+
+interface RootFixture {
+  id: string;
+  token: string;
+  username: string;
+}
+
+interface AdminEmoji {
+  id: string;
+  name: string;
+}
+
+async function findEmojiByName(
+  request: import('@playwright/test').APIRequestContext,
+  token: string,
+  name: string,
+): Promise<AdminEmoji | undefined> {
+  const list = await callApi(request, 'admin/emoji/list', {
+    i: token,
+    query: name,
+    limit: 10,
+  });
+  expect(list.status()).toBe(200);
+  const body = (await list.json()) as AdminEmoji[];
+  return body.find((e) => e.name === name);
+}
+
+// pollForEmoji waits until the named emoji appears in admin/emoji/list, with
+// a bounded retry loop. queue 処理 + drive write + emoji repo insert で
+// 数秒かかるため最大 30 秒で 0.5 秒間隔の polling とする (notification の
+// 5 秒より長め推奨、issue #882 の指示通り)。
+async function pollForEmoji(
+  request: import('@playwright/test').APIRequestContext,
+  token: string,
+  name: string,
+): Promise<AdminEmoji | undefined> {
+  const deadline = Date.now() + 30_000;
+  while (Date.now() < deadline) {
+    const e = await findEmojiByName(request, token, name);
+    if (e) return e;
+    await new Promise((resolve) => setTimeout(resolve, 500));
+  }
+  return undefined;
+}
+
+test.describe('emoji: admin import-zip async round-trip', () => {
+  // TS backend は queue worker が drive URL を got で fetch するが
+  // got は NODE_TLS_REJECT_UNAUTHORIZED env を honor せず self-signed cert を
+  // 拒否するため、このスタックでは ZIP の download phase で常に失敗する。
+  // mk-go の HTTP fetch は InsecureSkipVerify を尊重するので動作する。
+  // backend 改修とは無関係な test infra の constraint なので、TS では skip。
+  test.skip(
+    process.env.MK_BACKEND_TYPE === 'ts',
+    'TS の queue worker は self-signed HTTPS から drive を fetch できない (test infra constraint)',
+  );
+
+  let createdIds: string[] = [];
+  let rootToken: string | undefined;
+
+  test.beforeAll(() => {
+    resetRateLimit();
+  });
+
+  test.afterEach(async ({ request }) => {
+    if (rootToken && createdIds.length > 0) {
+      await callApi(request, 'admin/emoji/delete-bulk', {
+        i: rootToken,
+        ids: createdIds,
+      });
+    }
+    createdIds = [];
+    rootToken = undefined;
+  });
+
+  test('import-zip enqueues job, queue worker registers emojis, list reflects', async ({
+    request,
+  }) => {
+    test.setTimeout(60_000);
+
+    const root: RootFixture = JSON.parse(readFileSync('.auth/root.json', 'utf-8'));
+    rootToken = root.token;
+    const suffix = Math.random().toString(16).slice(2, 8);
+    const name1 = `imp1_${suffix}`;
+    const name2 = `imp2_${suffix}`;
+
+    // 2 emoji を含む ZIP を構築 (= meta.json + 2 PNG)。
+    const zipBuf = buildEmojiImportZip([{ name: name1 }, { name: name2 }]);
+
+    // ZIP を drive/files/create で upload。
+    const upload = await request.post(`${baseURL}/api/drive/files/create`, {
+      multipart: {
+        i: root.token,
+        file: {
+          name: `emoji_import_${suffix}.zip`,
+          mimeType: 'application/zip',
+          buffer: zipBuf,
+        },
+      },
+      failOnStatusCode: false,
+    });
+    expect(upload.status()).toBe(200);
+    const uploaded = (await upload.json()) as { id: string };
+    expect(typeof uploaded.id).toBe('string');
+
+    // import-zip → 204 No Content (= job enqueue 成功)
+    const importResp = await callApi(request, 'admin/emoji/import-zip', {
+      i: root.token,
+      fileId: uploaded.id,
+    });
+    expect([200, 204]).toContain(importResp.status());
+
+    // queue worker が両 emoji を登録するまで polling
+    const e1 = await pollForEmoji(request, root.token, name1);
+    const e2 = await pollForEmoji(request, root.token, name2);
+    expect(e1).toBeDefined();
+    expect(e2).toBeDefined();
+    expect(e1!.name).toBe(name1);
+    expect(e2!.name).toBe(name2);
+    createdIds = [e1!.id, e2!.id];
+  });
+});


### PR DESCRIPTION
## Summary

Misskey 残 advanced 系 emoji endpoint の Playwright spec を整備し、両 backend (mk-go / TS) で drop-in shape 互換を担保する。

## 主な変更点

- \`tests/playwright/specs/emoji/emoji_bulk.spec.ts\`: \`admin/emoji\` の bulk operations 6 endpoint round-trip
  - add-aliases-bulk / remove-aliases-bulk / set-aliases-bulk / set-category-bulk / set-license-bulk / delete-bulk
- \`tests/playwright/specs/emoji/emoji_import_zip.spec.ts\`: ZIP upload → \`import-zip\` enqueue → queue worker による emoji 登録の async polling (最大 30 秒)
- \`tests/playwright/fixtures/files.ts\`: 最小 ZIP builder (CRC32 + LFH/CD/EOCD) を **依存ライブラリなし** で実装、\`buildEmojiImportZip\` helper で Misskey の \`metaDoc\` 構造に従った emoji import ZIP を構築
- \`docker-compose.playwright.ts.yml\`: TS overlay で \`MK_BACKEND_TYPE=ts\` を runner に注入

## 検出した drift を本 PR で修正

#896 と同じ pq.StringArray anti-pattern を bulk handler でも検出、同 PR で fix:

- \`internal/api/admin/emoji.go::EmojiAddAliasesBulk\` / \`RemoveAliasesBulk\` / \`SetAliasesBulk\`: aliases field に plain \`[]string\` を渡すと GORM が record literal \`('a','b')\` を生成して SQLSTATE 42804 (column type mismatch) になる drift。\`pq.StringArray()\` で wrap して array literal \`'{a,b}'\` にする
- \`internal/testutil/mock_repository.go::MockEmojiRepository.UpdateFieldsMany\`: 上記 wrap に伴い \`aliases\` の type assertion を \`pq.StringArray\` と \`[]string\` 両対応化

## scope 外

- \`admin/emoji/copy\` / \`admin/emoji/list-remote\` (federation 系) → Phase 3 federation spec (#831) で扱う。本 PR scope 外
- TS backend での \`import-zip\` spec は **skip**: TS queue worker は \`got\` を使い \`NODE_TLS_REJECT_UNAUTHORIZED\` env を honor しないため、self-signed HTTPS proxy 越しに drive ZIP を fetch できない (test infra constraint、backend bug ではない)

## テスト

- mk-go Playwright: \`make playwright-test\` → **74 / 74 pass** (既存 72 + 新 2)
- TS Playwright: \`make playwright-ts-test\` → **73 pass + 1 skip** (import-zip)

## Closes

- Closes #882

🤖 Generated with [Claude Code](https://claude.com/claude-code)