### PR TITLE
#833 Playwright Phase 3: antennas CRUD + renote-mute spec の整備

### DIFF
--- a/tests/playwright/specs/antennas/antennas.spec.ts
+++ b/tests/playwright/specs/antennas/antennas.spec.ts
@@ -1,0 +1,128 @@
+// Phase 3 #833: antennas CRUD round-trip。
+//
+// upstream Misskey TS と mk-go は両方とも:
+//   - antennas/create で antenna 設定 (name, src, keywords, etc) を送る
+//   - antennas/show で antennaId 指定で取得
+//   - antennas/list で自分の antenna 一覧
+//   - antennas/update で部分更新 (name / keywords / etc)
+//   - antennas/delete で削除
+//
+// antennas/notes (= timeline 経路) は #819 で別 cover 済。本 spec は CRUD
+// 部分に集中する。
+//
+// keywords は [[group_a_kw1, group_a_kw2], [group_b_kw1]] の形で AND-of-OR
+// 構造。spec では deterministic な単純 keyword で round-trip のみ確認する。
+
+import { expect, test } from '@playwright/test';
+import { callApi } from '../../fixtures/api';
+import { randomUsername, signupUser } from '../../fixtures/auth';
+import { resetRateLimit } from '../../fixtures/rate_limit';
+
+interface Antenna {
+  id: string;
+  userId: string;
+  name: string;
+  src: string;
+  keywords?: string[][];
+  excludeKeywords?: string[][];
+  caseSensitive?: boolean;
+  withReplies?: boolean;
+  withFile?: boolean;
+  localOnly?: boolean;
+  isActive?: boolean;
+}
+
+test.describe('antennas: CRUD round-trip', () => {
+  test.beforeAll(() => {
+    resetRateLimit();
+  });
+
+  test('create / show / list / update / delete round-trip', async ({ request }) => {
+    const me = await signupUser(request, randomUsername('antA'));
+    const name = `antenna_${Math.random().toString(16).slice(2, 8)}`;
+
+    // create
+    const createResp = await callApi(request, 'antennas/create', {
+      i: me.token,
+      name,
+      src: 'all',
+      keywords: [['hello']],
+      excludeKeywords: [],
+      users: [],
+      caseSensitive: false,
+      withReplies: false,
+      withFile: false,
+      localOnly: false,
+    });
+    expect(createResp.status()).toBe(200);
+    const created = (await createResp.json()) as Antenna;
+    expect(typeof created.id).toBe('string');
+    // userId は upstream TS の packed antenna shape では不在 (= antenna は
+    // 自分専用なので owner field を返さない設計)、mk-go は `userId` を含む。
+    // 両 backend で共通する identity (id / name / src / keywords) のみ assert
+    // する LCD pattern にする。
+    expect(created.name).toBe(name);
+    expect(created.src).toBe('all');
+    expect(created.keywords).toEqual([['hello']]);
+
+    // show
+    const showResp = await callApi(request, 'antennas/show', {
+      i: me.token,
+      antennaId: created.id,
+    });
+    expect(showResp.status()).toBe(200);
+    const shown = (await showResp.json()) as Antenna;
+    expect(shown.id).toBe(created.id);
+    expect(shown.name).toBe(name);
+
+    // list で自分の antenna が含まれる
+    const listResp = await callApi(request, 'antennas/list', { i: me.token });
+    expect(listResp.status()).toBe(200);
+    const list = (await listResp.json()) as Antenna[];
+    expect(Array.isArray(list)).toBe(true);
+    expect(list.find((a) => a.id === created.id)).toBeTruthy();
+
+    // update — name + keywords を変更、空 keywords / users で同 drift 経路も touch
+    const newName = `${name}_updated`;
+    const updateResp = await callApi(request, 'antennas/update', {
+      i: me.token,
+      antennaId: created.id,
+      name: newName,
+      keywords: [['hi', 'world']],
+      // empty users で antenna_service.go::Update の pq.StringArray wrap path
+      // を実行 (#896 の同 anti-pattern を fix 済 = NOT NULL 違反にならない)。
+      users: [],
+    });
+    expect([200, 204]).toContain(updateResp.status());
+
+    const showAfterUpdate = await callApi(request, 'antennas/show', {
+      i: me.token,
+      antennaId: created.id,
+    });
+    expect(showAfterUpdate.status()).toBe(200);
+    const updated = (await showAfterUpdate.json()) as Antenna;
+    expect(updated.name).toBe(newName);
+    expect(updated.keywords).toEqual([['hi', 'world']]);
+
+    // delete
+    const deleteResp = await callApi(request, 'antennas/delete', {
+      i: me.token,
+      antennaId: created.id,
+    });
+    expect([200, 204]).toContain(deleteResp.status());
+
+    // delete 後の show は 4xx (NO_SUCH_ANTENNA)
+    const showAfterDelete = await callApi(request, 'antennas/show', {
+      i: me.token,
+      antennaId: created.id,
+    });
+    expect(showAfterDelete.status()).toBeGreaterThanOrEqual(400);
+    expect(showAfterDelete.status()).toBeLessThan(500);
+
+    // list からも消える
+    const listAfterDelete = await callApi(request, 'antennas/list', { i: me.token });
+    expect(listAfterDelete.status()).toBe(200);
+    const listAfter = (await listAfterDelete.json()) as Antenna[];
+    expect(listAfter.find((a) => a.id === created.id)).toBeFalsy();
+  });
+});

--- a/tests/playwright/specs/antennas/antennas.spec.ts
+++ b/tests/playwright/specs/antennas/antennas.spec.ts
@@ -77,9 +77,9 @@ test.describe('antennas: CRUD round-trip', () => {
     expect(typeof created.id).toBe('string');
     createdAntennaId = created.id;
     // userId は upstream TS の packed antenna shape では不在 (= antenna は
-    // 自分専用なので owner field を返さない設計)、mk-go は `userId` を含む。
-    // 両 backend で共通する identity (id / name / src / keywords) のみ assert
-    // する LCD pattern にする。
+    // 自分専用なので owner field を返さない設計)、mk-go は `userId` を含む
+    // drift がある (#904 で追跡)。両 backend で共通する identity (id / name
+    // / src / keywords) のみ assert する LCD pattern にする。
     expect(created.name).toBe(name);
     expect(created.src).toBe('all');
     expect(created.keywords).toEqual([['hello']]);

--- a/tests/playwright/specs/antennas/antennas.spec.ts
+++ b/tests/playwright/specs/antennas/antennas.spec.ts
@@ -33,12 +33,30 @@ interface Antenna {
 }
 
 test.describe('antennas: CRUD round-trip', () => {
+  // assertion 失敗時に DB に orphan antenna が残らないよう、test 単位で
+  // afterEach cleanup する。正規 path で delete 済の場合は idempotent に
+  // 4xx を許容する (= 削除済 antenna への delete は NO_SUCH_ANTENNA)。
+  let createdAntennaId: string | undefined;
+  let userToken: string | undefined;
+
   test.beforeAll(() => {
     resetRateLimit();
   });
 
+  test.afterEach(async ({ request }) => {
+    if (createdAntennaId && userToken) {
+      await callApi(request, 'antennas/delete', {
+        i: userToken,
+        antennaId: createdAntennaId,
+      });
+    }
+    createdAntennaId = undefined;
+    userToken = undefined;
+  });
+
   test('create / show / list / update / delete round-trip', async ({ request }) => {
     const me = await signupUser(request, randomUsername('antA'));
+    userToken = me.token;
     const name = `antenna_${Math.random().toString(16).slice(2, 8)}`;
 
     // create
@@ -57,6 +75,7 @@ test.describe('antennas: CRUD round-trip', () => {
     expect(createResp.status()).toBe(200);
     const created = (await createResp.json()) as Antenna;
     expect(typeof created.id).toBe('string');
+    createdAntennaId = created.id;
     // userId は upstream TS の packed antenna shape では不在 (= antenna は
     // 自分専用なので owner field を返さない設計)、mk-go は `userId` を含む。
     // 両 backend で共通する identity (id / name / src / keywords) のみ assert
@@ -110,6 +129,8 @@ test.describe('antennas: CRUD round-trip', () => {
       antennaId: created.id,
     });
     expect([200, 204]).toContain(deleteResp.status());
+    // 正規 path で delete 済 = afterEach cleanup の必要なし
+    createdAntennaId = undefined;
 
     // delete 後の show は 4xx (NO_SUCH_ANTENNA)
     const showAfterDelete = await callApi(request, 'antennas/show', {

--- a/tests/playwright/specs/renote_mute/renote_mute.spec.ts
+++ b/tests/playwright/specs/renote_mute/renote_mute.spec.ts
@@ -1,0 +1,83 @@
+// Phase 3 #833: renote-mute CRUD round-trip。
+//
+// upstream Misskey TS と mk-go は両方とも:
+//   - renote-mute/create { userId } で mutee を登録 (204)
+//   - renote-mute/list で自分の mutee 一覧 (= UserDetailed embed)
+//   - renote-mute/delete { userId } で削除 (204)
+//
+// 通常の mute (= 元 note ごと非表示) と区別するための実 timeline 検証は
+// 別 spec で扱う想定。本 spec は CRUD round-trip + duplicate / self-mute
+// の error path に集中する。
+
+import { expect, test } from '@playwright/test';
+import { callApi } from '../../fixtures/api';
+import { randomUsername, signupUser } from '../../fixtures/auth';
+import { resetRateLimit } from '../../fixtures/rate_limit';
+
+interface RenoteMuteEntry {
+  id: string;
+  createdAt: string;
+  muteeId: string;
+}
+
+test.describe('renote-mute: CRUD round-trip', () => {
+  test.beforeAll(() => {
+    resetRateLimit();
+  });
+
+  test('create / list / delete round-trip + error paths', async ({ request }) => {
+    const A = await signupUser(request, randomUsername('rmA'));
+    const B = await signupUser(request, randomUsername('rmB'));
+
+    // create
+    const createResp = await callApi(request, 'renote-mute/create', {
+      i: A.token,
+      userId: B.id,
+    });
+    expect([200, 204]).toContain(createResp.status());
+
+    // list で B が含まれる
+    const listResp = await callApi(request, 'renote-mute/list', { i: A.token });
+    expect(listResp.status()).toBe(200);
+    const list = (await listResp.json()) as RenoteMuteEntry[];
+    expect(Array.isArray(list)).toBe(true);
+    expect(list.find((m) => m.muteeId === B.id)).toBeTruthy();
+
+    // 重複 create は 4xx (ALREADY_MUTING)
+    const dupResp = await callApi(request, 'renote-mute/create', {
+      i: A.token,
+      userId: B.id,
+    });
+    expect(dupResp.status()).toBeGreaterThanOrEqual(400);
+    expect(dupResp.status()).toBeLessThan(500);
+
+    // self-mute は 4xx (MUTEE_IS_YOURSELF)
+    const selfResp = await callApi(request, 'renote-mute/create', {
+      i: A.token,
+      userId: A.id,
+    });
+    expect(selfResp.status()).toBeGreaterThanOrEqual(400);
+    expect(selfResp.status()).toBeLessThan(500);
+
+    // delete
+    const deleteResp = await callApi(request, 'renote-mute/delete', {
+      i: A.token,
+      userId: B.id,
+    });
+    expect([200, 204]).toContain(deleteResp.status());
+
+    // list から消える
+    const listAfter = await callApi(request, 'renote-mute/list', { i: A.token });
+    expect(listAfter.status()).toBe(200);
+    const listAfterBody = (await listAfter.json()) as RenoteMuteEntry[];
+    expect(listAfterBody.find((m) => m.muteeId === B.id)).toBeFalsy();
+
+    // 解除済の delete は 4xx (NOT_MUTING)
+    const dupDelResp = await callApi(request, 'renote-mute/delete', {
+      i: A.token,
+      userId: B.id,
+    });
+    expect(dupDelResp.status()).toBeGreaterThanOrEqual(400);
+    expect(dupDelResp.status()).toBeLessThan(500);
+  });
+});

--- a/tests/playwright/specs/renote_mute/renote_mute.spec.ts
+++ b/tests/playwright/specs/renote_mute/renote_mute.spec.ts
@@ -6,8 +6,8 @@
 //   - renote-mute/delete { userId } で削除 (204)
 //
 // 通常の mute (= 元 note ごと非表示) と区別するための実 timeline 検証は
-// 別 spec で扱う想定。本 spec は CRUD round-trip + duplicate / self-mute
-// の error path に集中する。
+// 別 spec で扱う想定 (#903 で follow-up)。本 spec は CRUD round-trip +
+// duplicate / self-mute の error path に集中する。
 
 import { expect, test } from '@playwright/test';
 import { callApi } from '../../fixtures/api';
@@ -21,13 +21,32 @@ interface RenoteMuteEntry {
 }
 
 test.describe('renote-mute: CRUD round-trip', () => {
+  // assertion 失敗時に renote_muting row が orphan として残らないよう
+  // afterEach で best-effort cleanup する。正規 path で delete 済の場合は
+  // 4xx (NOT_MUTING) が返るが idempotent に許容する。
+  let muterToken: string | undefined;
+  let muteeId: string | undefined;
+
   test.beforeAll(() => {
     resetRateLimit();
+  });
+
+  test.afterEach(async ({ request }) => {
+    if (muterToken && muteeId) {
+      await callApi(request, 'renote-mute/delete', {
+        i: muterToken,
+        userId: muteeId,
+      });
+    }
+    muterToken = undefined;
+    muteeId = undefined;
   });
 
   test('create / list / delete round-trip + error paths', async ({ request }) => {
     const A = await signupUser(request, randomUsername('rmA'));
     const B = await signupUser(request, randomUsername('rmB'));
+    muterToken = A.token;
+    muteeId = B.id;
 
     // create
     const createResp = await callApi(request, 'renote-mute/create', {
@@ -43,21 +62,24 @@ test.describe('renote-mute: CRUD round-trip', () => {
     expect(Array.isArray(list)).toBe(true);
     expect(list.find((m) => m.muteeId === B.id)).toBeTruthy();
 
-    // 重複 create は 4xx (ALREADY_MUTING)
+    // 重複 create は 400 + ALREADY_MUTING (両 backend で同 error code)。
+    // status 範囲ではなく code を直接 assert することで shape drift を guard。
     const dupResp = await callApi(request, 'renote-mute/create', {
       i: A.token,
       userId: B.id,
     });
-    expect(dupResp.status()).toBeGreaterThanOrEqual(400);
-    expect(dupResp.status()).toBeLessThan(500);
+    expect(dupResp.status()).toBe(400);
+    const dupBody = (await dupResp.json()) as { error?: { code?: string } };
+    expect(dupBody.error?.code).toBe('ALREADY_MUTING');
 
-    // self-mute は 4xx (MUTEE_IS_YOURSELF)
+    // self-mute は 400 + MUTEE_IS_YOURSELF。
     const selfResp = await callApi(request, 'renote-mute/create', {
       i: A.token,
       userId: A.id,
     });
-    expect(selfResp.status()).toBeGreaterThanOrEqual(400);
-    expect(selfResp.status()).toBeLessThan(500);
+    expect(selfResp.status()).toBe(400);
+    const selfBody = (await selfResp.json()) as { error?: { code?: string } };
+    expect(selfBody.error?.code).toBe('MUTEE_IS_YOURSELF');
 
     // delete
     const deleteResp = await callApi(request, 'renote-mute/delete', {
@@ -65,6 +87,9 @@ test.describe('renote-mute: CRUD round-trip', () => {
       userId: B.id,
     });
     expect([200, 204]).toContain(deleteResp.status());
+    // 正規 path で delete 済 = afterEach cleanup の必要なし
+    muterToken = undefined;
+    muteeId = undefined;
 
     // list から消える
     const listAfter = await callApi(request, 'renote-mute/list', { i: A.token });
@@ -72,12 +97,13 @@ test.describe('renote-mute: CRUD round-trip', () => {
     const listAfterBody = (await listAfter.json()) as RenoteMuteEntry[];
     expect(listAfterBody.find((m) => m.muteeId === B.id)).toBeFalsy();
 
-    // 解除済の delete は 4xx (NOT_MUTING)
+    // 解除済の delete は 400 + NOT_MUTING。
     const dupDelResp = await callApi(request, 'renote-mute/delete', {
       i: A.token,
       userId: B.id,
     });
-    expect(dupDelResp.status()).toBeGreaterThanOrEqual(400);
-    expect(dupDelResp.status()).toBeLessThan(500);
+    expect(dupDelResp.status()).toBe(400);
+    const dupDelBody = (await dupDelResp.json()) as { error?: { code?: string } };
+    expect(dupDelBody.error?.code).toBe('NOT_MUTING');
   });
 });


### PR DESCRIPTION
## Summary

Misskey Phase 3 の \`antennas/*\` (CRUD 5 endpoint) と \`renote-mute/*\` (3 endpoint) の Playwright spec を整備し、両 backend (mk-go / TS) で drop-in shape 互換を担保する。

## 主な変更点

- \`tests/playwright/specs/antennas/antennas.spec.ts\`: \`antennas/create\` / \`show\` / \`list\` / \`update\` / \`delete\` round-trip
- \`tests/playwright/specs/renote_mute/renote_mute.spec.ts\`: \`renote-mute/create\` / \`list\` / \`delete\` round-trip + duplicate / self-mute / not-muting error path

## 検出した drift

- **antennas/create response の userId field**: TS は不在 / mk-go は含む drift。両 backend で共通する identity (\`id\` / \`name\` / \`src\` / \`keywords\`) のみ assert する LCD pattern で吸収。

## scope 外

- \`antennas/notes\` (= timeline 経路) は #819 で別 cover 済
- renote-mute の **timeline filter integration** (= mute された renote が timeline から消えるか) は本 spec scope 外、別 PR で扱う

## 既存 fix との連携

- \`antennas/update\` で \`users: []\` を渡す path を touch (#900 で fix した antenna.Service.Update の pq.StringArray wrap が production で動くことを e2e level でも guard)

## テスト

- mk-go Playwright: \`make playwright-test\` → **76 / 76 pass** (既存 74 + 新 2)
- TS Playwright: \`make playwright-ts-test\` → **75 pass + 1 skip** (import-zip)

## Closes

- Closes #833

🤖 Generated with [Claude Code](https://claude.com/claude-code)