### PR TITLE
Fix #904 + #903: antennas userId drift 削除 + renote-mute timeline filter 実装

### DIFF
--- a/internal/api/antennas/handler.go
+++ b/internal/api/antennas/handler.go
@@ -290,10 +290,12 @@ func (h *Handler) Notes(c echo.Context) error {
 }
 
 func antennaToMap(a *model.Antenna) map[string]any {
+	// upstream Misskey TS の packAntenna は userId field を embed しない
+	// (= antenna は user-scoped で frontend が呼出 user の id を別経路で持つ
+	// 設計、#904)。drop-in 互換維持のため mk-go も同 shape に揃える。
 	return map[string]any{
 		"id":              a.ID,
 		"createdAt":       a.LastUsedAt,
-		"userId":          a.UserID,
 		"name":            a.Name,
 		"src":             a.Src,
 		"userListId":      a.UserListID,

--- a/internal/api/antennas/handler_test.go
+++ b/internal/api/antennas/handler_test.go
@@ -2,6 +2,7 @@ package antennas
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"log"
@@ -71,6 +72,24 @@ func TestCreate_Success(t *testing.T) {
 	setUser(c, "alice")
 	require.NoError(t, h.Create(c))
 	assert.Equal(t, http.StatusOK, rec.Code)
+}
+
+// TestCreate_NoUserIdInResponse は #904 で fix した shape drift の
+// regression guard。upstream Misskey TS の packAntenna は userId を
+// embed しないので、mk-go も同 shape (= userId field なし) で揃える。
+func TestCreate_NoUserIdInResponse(t *testing.T) {
+	h, _, _ := newHandler(t)
+	c, rec := newReq(t, `{"name":"alpha","src":"all","keywords":[["foo"]]}`)
+	setUser(c, "alice")
+	require.NoError(t, h.Create(c))
+	require.Equal(t, http.StatusOK, rec.Code)
+	var body map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &body))
+	_, ok := body["userId"]
+	assert.False(t, ok, "antennaToMap response must not include userId (#904)")
+	// 必須 field の existence は念のため touch しておく (drift で吸い込ま
+	// れないように reverse の guard)。
+	assert.Equal(t, "alpha", body["name"])
 }
 
 func TestCreate_BadJSON(t *testing.T) {

--- a/internal/api/notes/handler.go
+++ b/internal/api/notes/handler.go
@@ -40,6 +40,7 @@ type Handler struct {
 	channelRepo       repository.ChannelRepository
 	channelMutingRepo repository.ChannelMutingRepository
 	mutingRepo        repository.MutingRepository
+	renoteMutingRepo  repository.RenoteMutingRepository
 	instanceRepo      repository.InstanceRepository
 	emojiRepo         repository.EmojiRepository
 	driveFolderRepo   repository.DriveFolderRepository
@@ -63,6 +64,13 @@ func (h *Handler) SetChannelMutingRepo(r repository.ChannelMutingRepository) {
 // TS の muting JOIN と同 semantics、#874)。
 func (h *Handler) SetMutingRepo(r repository.MutingRepository) {
 	h.mutingRepo = r
+}
+
+// SetRenoteMutingRepo attaches a RenoteMutingRepository so timeline handlers
+// can exclude pure renotes by users the viewer has renote-muted (#903)。
+// upstream Misskey TS の generateMutedUserRelatedRenotesQuery と同 semantics。
+func (h *Handler) SetRenoteMutingRepo(r repository.RenoteMutingRepository) {
+	h.renoteMutingRepo = r
 }
 
 // SetTranslator attaches a DeepL translator for /api/notes/translate.

--- a/internal/api/notes/timeline_handler.go
+++ b/internal/api/notes/timeline_handler.go
@@ -49,6 +49,7 @@ func (h *Handler) Timeline(c echo.Context) error {
 			AllowPartial:          req.AllowPartial,
 			MutedChannelIDs:       h.loadMutedChannelIDs(viewer),
 			MutedUserIDs:          h.loadMutedUserIDs(viewer),
+			RenoteMutedUserIDs:    h.loadRenoteMutedUserIDs(viewer),
 		}
 		return h.timelineService.HomeTimeline(c.Request().Context(), viewer, req.UntilID, req.SinceID, req.Limit, f)
 	}, true)
@@ -58,12 +59,13 @@ func (h *Handler) Timeline(c echo.Context) error {
 func (h *Handler) LocalTimeline(c echo.Context) error {
 	return h.serveTimeline(c, func(viewer *model.User, req TimelineRequest) ([]*model.Note, error) {
 		f := timeline.TimelineFilter{
-			WithFiles:       req.WithFiles,
-			WithRenotes:     req.WithRenotes,
-			WithReplies:     req.WithReplies,
-			AllowPartial:    req.AllowPartial,
-			MutedChannelIDs: h.loadMutedChannelIDs(viewer),
-			MutedUserIDs:    h.loadMutedUserIDs(viewer),
+			WithFiles:          req.WithFiles,
+			WithRenotes:        req.WithRenotes,
+			WithReplies:        req.WithReplies,
+			AllowPartial:       req.AllowPartial,
+			MutedChannelIDs:    h.loadMutedChannelIDs(viewer),
+			MutedUserIDs:       h.loadMutedUserIDs(viewer),
+			RenoteMutedUserIDs: h.loadRenoteMutedUserIDs(viewer),
 		}
 		return h.timelineService.LocalTimeline(c.Request().Context(), viewer, req.UntilID, req.SinceID, req.Limit, f)
 	}, false)
@@ -73,11 +75,12 @@ func (h *Handler) LocalTimeline(c echo.Context) error {
 func (h *Handler) GlobalTimeline(c echo.Context) error {
 	return h.serveTimeline(c, func(viewer *model.User, req TimelineRequest) ([]*model.Note, error) {
 		f := timeline.TimelineFilter{
-			WithFiles:       req.WithFiles,
-			WithRenotes:     req.WithRenotes,
-			AllowPartial:    req.AllowPartial,
-			MutedChannelIDs: h.loadMutedChannelIDs(viewer),
-			MutedUserIDs:    h.loadMutedUserIDs(viewer),
+			WithFiles:          req.WithFiles,
+			WithRenotes:        req.WithRenotes,
+			AllowPartial:       req.AllowPartial,
+			MutedChannelIDs:    h.loadMutedChannelIDs(viewer),
+			MutedUserIDs:       h.loadMutedUserIDs(viewer),
+			RenoteMutedUserIDs: h.loadRenoteMutedUserIDs(viewer),
 		}
 		return h.timelineService.GlobalTimeline(c.Request().Context(), viewer, req.UntilID, req.SinceID, req.Limit, f)
 	}, false)
@@ -96,6 +99,7 @@ func (h *Handler) HybridTimeline(c echo.Context) error {
 			AllowPartial:          req.AllowPartial,
 			MutedChannelIDs:       h.loadMutedChannelIDs(viewer),
 			MutedUserIDs:          h.loadMutedUserIDs(viewer),
+			RenoteMutedUserIDs:    h.loadRenoteMutedUserIDs(viewer),
 		}
 		return h.timelineService.HybridTimeline(c.Request().Context(), viewer, req.UntilID, req.SinceID, req.Limit, f)
 	}, true)
@@ -135,6 +139,22 @@ func (h *Handler) loadMutedUserIDs(viewer *model.User) []string {
 	ids, err := h.mutingRepo.ListMuteeIDs(viewer.ID)
 	if err != nil {
 		slog.Warn("timeline: failed to load muted users", "userId", viewer.ID, "err", err)
+		return nil
+	}
+	return ids
+}
+
+// loadRenoteMutedUserIDs returns userIDs that viewer has renote-muted.
+// nil for anonymous viewers or when the repo is not wired (#903)。
+// MutedUserIDs と異なり投稿者の plain note は除外せず、pure renote のみ
+// filter する (logic は ApplyFilter / applyTimelineFilter 側で実装)。
+func (h *Handler) loadRenoteMutedUserIDs(viewer *model.User) []string {
+	if viewer == nil || h.renoteMutingRepo == nil {
+		return nil
+	}
+	ids, err := h.renoteMutingRepo.ListMuteeIDs(viewer.ID)
+	if err != nil {
+		slog.Warn("timeline: failed to load renote-muted users", "userId", viewer.ID, "err", err)
 		return nil
 	}
 	return ids

--- a/internal/api/notes/timeline_mute_test.go
+++ b/internal/api/notes/timeline_mute_test.go
@@ -39,3 +39,38 @@ func TestLoadMutedChannelIDs_EmptyResultReturnsNil(t *testing.T) {
 	h.SetChannelMutingRepo(repo)
 	assert.Nil(t, h.loadMutedChannelIDs(&model.User{ID: "viewer"}))
 }
+
+// loadRenoteMutedUserIDs は viewer の renote-mute mutee 一覧を返す (#903)。
+// MutedChannelIDs と同 pattern で 4 case (基本 / anonymous / repo nil /
+// 空結果) を guard する。internal/api/notes の coverage 90% threshold を
+// 維持するために必須。
+func TestLoadRenoteMutedUserIDs(t *testing.T) {
+	h, _ := newTestHandler(t)
+	repo := testutil.NewMockRenoteMutingRepository()
+	require.NoError(t, repo.Create(&model.RenoteMuting{ID: "rm1", MuterID: "viewer", MuteeID: "muted-1"}))
+	require.NoError(t, repo.Create(&model.RenoteMuting{ID: "rm2", MuterID: "viewer", MuteeID: "muted-2"}))
+	require.NoError(t, repo.Create(&model.RenoteMuting{ID: "rm3", MuterID: "other", MuteeID: "other-mute"}))
+	h.SetRenoteMutingRepo(repo)
+
+	viewer := &model.User{ID: "viewer"}
+	ids := h.loadRenoteMutedUserIDs(viewer)
+	assert.ElementsMatch(t, []string{"muted-1", "muted-2"}, ids)
+}
+
+func TestLoadRenoteMutedUserIDs_AnonymousReturnsNil(t *testing.T) {
+	h, _ := newTestHandler(t)
+	h.SetRenoteMutingRepo(testutil.NewMockRenoteMutingRepository())
+	assert.Nil(t, h.loadRenoteMutedUserIDs(nil))
+}
+
+func TestLoadRenoteMutedUserIDs_RepoUnsetReturnsNil(t *testing.T) {
+	h, _ := newTestHandler(t)
+	assert.Nil(t, h.loadRenoteMutedUserIDs(&model.User{ID: "viewer"}))
+}
+
+func TestLoadRenoteMutedUserIDs_EmptyResultReturnsNil(t *testing.T) {
+	h, _ := newTestHandler(t)
+	repo := testutil.NewMockRenoteMutingRepository()
+	h.SetRenoteMutingRepo(repo)
+	assert.Nil(t, h.loadRenoteMutedUserIDs(&model.User{ID: "viewer"}))
+}

--- a/internal/core/timeline/timeline_filter.go
+++ b/internal/core/timeline/timeline_filter.go
@@ -23,6 +23,13 @@ type TimelineFilter struct {
 	// MutedUserIDs が toDBFilter 経由で SQL の NOT IN として push-down
 	// されるので、両経路で同 semantics に保たれる (#892)。
 	MutedUserIDs []string
+	// RenoteMutedUserIDs は viewer が renote-mute した user の **pure renote**
+	// だけを除外する filter (#903)。MutedUserIDs と異なり:
+	//   - 投稿者の plain note (= text あり / file 付き / quote renote 含む) は
+	//     **そのまま表示**
+	//   - pure renote (= text なし / file なし / renoteId あり) のみ skip
+	// upstream Misskey TS の generateMutedUserRelatedRenotesQuery と同 semantics。
+	RenoteMutedUserIDs []string
 }
 
 // boolDefault returns *b if non-nil, else def.
@@ -63,6 +70,14 @@ func ApplyFilter(notes []*model.Note, viewerID string, f TimelineFilter) []*mode
 		}
 	}
 
+	var renoteMutedUsers map[string]struct{}
+	if len(f.RenoteMutedUserIDs) > 0 {
+		renoteMutedUsers = make(map[string]struct{}, len(f.RenoteMutedUserIDs))
+		for _, id := range f.RenoteMutedUserIDs {
+			renoteMutedUsers[id] = struct{}{}
+		}
+	}
+
 	out := make([]*model.Note, 0, len(notes))
 	for _, n := range notes {
 		if f.WithFiles && len(n.FileIDs) == 0 {
@@ -87,6 +102,15 @@ func ApplyFilter(notes []*model.Note, viewerID string, f TimelineFilter) []*mode
 				if _, muted := mutedUsers[*n.RenoteUserID]; muted {
 					continue
 				}
+			}
+		}
+		// renote-mute filter: 投稿者が renote-muted で **かつ** pure renote
+		// の場合のみ除外する (= upstream の generateMutedUserRelatedRenotesQuery
+		// と同 semantics、#903)。投稿者の plain note / quote renote はそのまま
+		// 通す。renote 元の userId は対象外 (= renote-mute は renoter 視点)。
+		if renoteMutedUsers != nil && isPureRenote(n) {
+			if _, muted := renoteMutedUsers[n.UserID]; muted {
+				continue
 			}
 		}
 		// withReplies=false: 他人への返信を除外 (自分への返信は残す)

--- a/internal/core/timeline/timeline_filter_test.go
+++ b/internal/core/timeline/timeline_filter_test.go
@@ -232,3 +232,47 @@ func TestApplyFilter_MutedUsersEmptyIsNoop(t *testing.T) {
 	out2 := ApplyFilter(notes, "viewer", TimelineFilter{MutedUserIDs: []string{}})
 	assert.Len(t, out2, 2)
 }
+
+// renote-mute は投稿者が renote-muted で **かつ** pure renote の場合のみ
+// 除外 (#903)。投稿者の plain note / quote renote はそのまま通る。
+func TestApplyFilter_RenoteMutedPureRenoteExcluded(t *testing.T) {
+	notes := []*model.Note{
+		makeNote("1", withUser("muted-renoter"), withRenote),
+		makeNote("2", withUser("ok-renoter"), withRenote),
+	}
+	out := ApplyFilter(notes, "viewer", TimelineFilter{
+		RenoteMutedUserIDs: []string{"muted-renoter"},
+	})
+	assert.Len(t, out, 1)
+	assert.Equal(t, "2", out[0].ID)
+}
+
+// renote-mute は **plain note は通す** (regular mute との違い、#903)。
+// 投稿者が renote-mute されていても、その人の plain な note は表示する。
+func TestApplyFilter_RenoteMutedPlainNoteKept(t *testing.T) {
+	notes := []*model.Note{
+		makeNote("1", withUser("muted-renoter"), withText),   // plain note
+		makeNote("2", withUser("muted-renoter"), withRenote), // pure renote → skip
+	}
+	out := ApplyFilter(notes, "viewer", TimelineFilter{
+		RenoteMutedUserIDs: []string{"muted-renoter"},
+	})
+	assert.Len(t, out, 1)
+	assert.Equal(t, "1", out[0].ID, "plain note (text 付き) は renote-mute 対象外")
+}
+
+// renote-mute は **quote renote (text 付き / file 付き renote) も通す**
+// (#903、isPureRenote が false なので skip 対象外)。
+func TestApplyFilter_RenoteMutedQuoteRenoteKept(t *testing.T) {
+	notes := []*model.Note{
+		makeNote("1", withUser("muted-renoter"), withRenote, withText),  // quote renote
+		makeNote("2", withUser("muted-renoter"), withRenote, withFiles), // file 付き renote
+		makeNote("3", withUser("muted-renoter"), withRenote),            // pure renote → skip
+	}
+	out := ApplyFilter(notes, "viewer", TimelineFilter{
+		RenoteMutedUserIDs: []string{"muted-renoter"},
+	})
+	assert.Len(t, out, 2)
+	assert.Equal(t, "1", out[0].ID)
+	assert.Equal(t, "2", out[1].ID)
+}

--- a/internal/core/timeline/timeline_service.go
+++ b/internal/core/timeline/timeline_service.go
@@ -215,6 +215,9 @@ func toDBFilter(f TimelineFilter, viewerID string) model.TimelineDBFilter {
 		// MutedUserIDs literal は test override 用に残す (本 toDBFilter から
 		// は伝搬しない)。
 		UseMutingSubquery: viewerID != "",
+		// renote-mute も同様に subquery 経路を使う (#903)。pure renote 条件
+		// は applyTimelineFilter 側で組み立てる。
+		UseRenoteMutingSubquery: viewerID != "",
 	}
 }
 

--- a/internal/model/timeline_filter.go
+++ b/internal/model/timeline_filter.go
@@ -28,4 +28,10 @@ type TimelineDBFilter struct {
 	// PostgreSQL の planning コスト / parameter limit に達しない。
 	// MutedUserIDs より優先 (両方 set されたら subquery が勝つ)。
 	UseMutingSubquery bool
+	// UseRenoteMutingSubquery が true の場合、ViewerID を使って
+	// renote_muting テーブルへの subquery で **pure renote のみ** を除外
+	// する filter を適用する (#903)。MutedUserIDs と異なり投稿者の plain
+	// note は通す。upstream Misskey TS の
+	// generateMutedUserRelatedRenotesQuery と同 semantics。
+	UseRenoteMutingSubquery bool
 }

--- a/internal/repository/muting.go
+++ b/internal/repository/muting.go
@@ -104,6 +104,10 @@ type RenoteMutingRepository interface {
 	Exists(muterID, muteeID string) (bool, error)
 	// ListByMuter supports cursor (sinceID/untilID) and offset pagination.
 	ListByMuter(muterID, sinceID, untilID string, limit, offset int) ([]*model.RenoteMuting, error)
+	// ListMuteeIDs returns the muteeIDs of renote-mute rows for muterID.
+	// timeline endpoint で renote-mute されたユーザーの pure renote を
+	// 除外する filter 用 (#903)。MutingRepository.ListMuteeIDs と同 shape。
+	ListMuteeIDs(muterID string) ([]string, error)
 }
 
 type renoteMutingRepository struct {
@@ -139,6 +143,22 @@ func (r *renoteMutingRepository) Exists(muterID, muteeID string) (bool, error) {
 		return false, err
 	}
 	return count > 0, nil
+}
+
+// ListMuteeIDs returns muteeIDs of all renote-mute rows for muterID.
+// renote_muting には expiresAt が無いので active filter は不要 (= 解除は
+// row delete で完結)。MutingRepository.ListMuteeIDs と同 shape (#903)。
+func (r *renoteMutingRepository) ListMuteeIDs(muterID string) ([]string, error) {
+	if muterID == "" {
+		return nil, nil
+	}
+	var ids []string
+	if err := r.db.Model(&model.RenoteMuting{}).
+		Where(`"muterId" = ?`, muterID).
+		Pluck(`"muteeId"`, &ids).Error; err != nil {
+		return nil, err
+	}
+	return ids, nil
 }
 
 func (r *renoteMutingRepository) ListByMuter(muterID, sinceID, untilID string, limit, offset int) ([]*model.RenoteMuting, error) {

--- a/internal/repository/muting_test.go
+++ b/internal/repository/muting_test.go
@@ -160,4 +160,35 @@ func TestRenoteMutingRepository_QueryErrors(t *testing.T) {
 	assert.Error(t, err)
 	_, err = repo.ListByMuter("a", "", "", 10, 0)
 	assert.Error(t, err)
+	_, err = repo.ListMuteeIDs("a")
+	assert.Error(t, err)
+}
+
+// ListMuteeIDs は muterID の renote-mute 全 muteeID を返す (#903 timeline
+// filter 用)。renote_muting には expiresAt が無いので active filter は不要、
+// 空 muterID は nil を返す。
+func TestRenoteMutingRepository_ListMuteeIDs(t *testing.T) {
+	repo := NewRenoteMutingRepository(testDB)
+	u1 := insertTestUser(t, "u_rmlm_1", "rmlm1")
+	u2 := insertTestUser(t, "u_rmlm_2", "rmlm2")
+	u3 := insertTestUser(t, "u_rmlm_3", "rmlm3")
+	defer cleanupUser(t, u1.ID)
+	defer cleanupUser(t, u2.ID)
+	defer cleanupUser(t, u3.ID)
+
+	rec1 := &model.RenoteMuting{ID: "rmlm_1", MuterID: u1.ID, MuteeID: u2.ID}
+	require.NoError(t, repo.Create(rec1))
+	defer cleanupRenoteMuting(t, rec1.ID)
+	rec2 := &model.RenoteMuting{ID: "rmlm_2", MuterID: u1.ID, MuteeID: u3.ID}
+	require.NoError(t, repo.Create(rec2))
+	defer cleanupRenoteMuting(t, rec2.ID)
+
+	ids, err := repo.ListMuteeIDs(u1.ID)
+	require.NoError(t, err)
+	assert.ElementsMatch(t, []string{u2.ID, u3.ID}, ids)
+
+	// muterID 空は nil 返却 (viewer==nil の short-circuit と整合)
+	ids, err = repo.ListMuteeIDs("")
+	require.NoError(t, err)
+	assert.Nil(t, ids)
 }

--- a/internal/repository/note.go
+++ b/internal/repository/note.go
@@ -565,6 +565,20 @@ func applyTimelineFilter(q *gorm.DB, f model.TimelineDBFilter) *gorm.DB {
 	} else if len(f.MutedUserIDs) > 0 {
 		q = q.Where(`"userId" NOT IN ? AND ("renoteUserId" IS NULL OR "renoteUserId" NOT IN ?)`, f.MutedUserIDs, f.MutedUserIDs)
 	}
+	// renote-mute filter (#903): 投稿者が renote-muted で **かつ** pure
+	// renote の note のみ除外する。投稿者の plain note / quote renote は
+	// そのまま通す。upstream Misskey TS の
+	// generateMutedUserRelatedRenotesQuery と同 semantics。
+	//   - subquery 経路 (UseRenoteMutingSubquery=true): renote_muting への
+	//     NOT EXISTS で bind parameter を viewer 単位に固定 (#894 と同 pattern)
+	//   - literal 経路: test override 用、現 production からは未使用
+	// pure renote condition: text IS NULL AND fileIds = '{}' AND renoteId IS NOT NULL
+	if f.UseRenoteMutingSubquery && f.ViewerID != "" {
+		q = q.Where(
+			`NOT (EXISTS (SELECT 1 FROM "renote_muting" rm WHERE rm."muterId" = ? AND rm."muteeId" = "note"."userId") AND text IS NULL AND "fileIds" = '{}' AND "renoteId" IS NOT NULL)`,
+			f.ViewerID,
+		)
+	}
 	return q
 }
 

--- a/internal/repository/note.go
+++ b/internal/repository/note.go
@@ -569,9 +569,13 @@ func applyTimelineFilter(q *gorm.DB, f model.TimelineDBFilter) *gorm.DB {
 	// renote の note のみ除外する。投稿者の plain note / quote renote は
 	// そのまま通す。upstream Misskey TS の
 	// generateMutedUserRelatedRenotesQuery と同 semantics。
-	//   - subquery 経路 (UseRenoteMutingSubquery=true): renote_muting への
-	//     NOT EXISTS で bind parameter を viewer 単位に固定 (#894 と同 pattern)
-	//   - literal 経路: test override 用、現 production からは未使用
+	//
+	// SQL は subquery 経路のみ実装 (UseRenoteMutingSubquery=true 必須):
+	// renote_muting への NOT EXISTS で bind parameter を viewer 単位に固定
+	// (#894 user-mute subquery と同 pattern)。user-mute のような literal
+	// path (RenoteMutedUserIDs を直接 IN) は現状 test/production とも未使用
+	// なので未実装。必要になったら同 file の MutedUserIDs literal 分岐と
+	// 同 pattern で追加可能。
 	// pure renote condition: text IS NULL AND fileIds = '{}' AND renoteId IS NOT NULL
 	if f.UseRenoteMutingSubquery && f.ViewerID != "" {
 		q = q.Where(

--- a/internal/repository/note_test.go
+++ b/internal/repository/note_test.go
@@ -1106,6 +1106,79 @@ func TestNoteRepository_ListLocalTimeline_MutedUsersSubquery(t *testing.T) {
 	assert.Contains(t, ids, okNote.ID, "ok author の note は含まれる")
 }
 
+// TestNoteRepository_ListLocalTimeline_RenoteMutedSubquery は production
+// 経路 (UseRenoteMutingSubquery=true + ViewerID) で renote_muting への
+// NOT EXISTS subquery が pure renote のみ除外し、plain note / quote
+// renote は通すことを直接 verify する (#903)。
+func TestNoteRepository_ListLocalTimeline_RenoteMutedSubquery(t *testing.T) {
+	repo := NewNoteRepository(testDB)
+	renoteMutingRepo := NewRenoteMutingRepository(testDB)
+	viewer := insertTestUser(t, "u_rms_v", "rmsv")
+	defer cleanupUser(t, viewer.ID)
+	mutedRenoter := insertTestUser(t, "u_rms_m", "rmsm")
+	defer cleanupUser(t, mutedRenoter.ID)
+	srcAuthor := insertTestUser(t, "u_rms_s", "rmss")
+	defer cleanupUser(t, srcAuthor.ID)
+
+	// viewer renote-mutes mutedRenoter
+	rmRec := &model.RenoteMuting{ID: "rms_mute", MuterID: viewer.ID, MuteeID: mutedRenoter.ID}
+	require.NoError(t, renoteMutingRepo.Create(rmRec))
+	defer cleanupRenoteMuting(t, rmRec.ID)
+
+	// mutedRenoter の plain note (= renote ではない、含まれるべき)
+	plainText := "plain"
+	plainNote := &model.Note{
+		ID: "n_rms_plain", UserID: mutedRenoter.ID, Text: &plainText,
+		Visibility: model.NoteVisibilityPublic,
+		Reactions:  datatypes.JSON([]byte("{}")),
+	}
+	require.NoError(t, repo.Create(plainNote))
+	defer cleanupNote(t, plainNote.ID)
+
+	// srcAuthor の original note (renote 元)
+	srcText := "src"
+	srcNote := &model.Note{
+		ID: "n_rms_src", UserID: srcAuthor.ID, Text: &srcText,
+		Visibility: model.NoteVisibilityPublic,
+		Reactions:  datatypes.JSON([]byte("{}")),
+	}
+	require.NoError(t, repo.Create(srcNote))
+	defer cleanupNote(t, srcNote.ID)
+
+	// mutedRenoter の pure renote (除外されるべき)
+	pureRenote := &model.Note{
+		ID: "n_rms_pure", UserID: mutedRenoter.ID,
+		RenoteID: &srcNote.ID, RenoteUserID: &srcAuthor.ID,
+		Visibility: model.NoteVisibilityPublic,
+		Reactions:  datatypes.JSON([]byte("{}")),
+	}
+	require.NoError(t, repo.Create(pureRenote))
+	defer cleanupNote(t, pureRenote.ID)
+
+	// mutedRenoter の quote renote (text 付き、含まれるべき)
+	quoteText := "quote!"
+	quoteRenote := &model.Note{
+		ID: "n_rms_quote", UserID: mutedRenoter.ID, Text: &quoteText,
+		RenoteID: &srcNote.ID, RenoteUserID: &srcAuthor.ID,
+		Visibility: model.NoteVisibilityPublic,
+		Reactions:  datatypes.JSON([]byte("{}")),
+	}
+	require.NoError(t, repo.Create(quoteRenote))
+	defer cleanupNote(t, quoteRenote.ID)
+
+	rows, err := repo.ListLocalTimeline(100, "", "", model.TimelineDBFilter{
+		ViewerID:                viewer.ID,
+		UseRenoteMutingSubquery: true,
+	})
+	require.NoError(t, err)
+	ids := idsOf(rows)
+
+	assert.Contains(t, ids, plainNote.ID, "plain note は renote-mute 対象外")
+	assert.Contains(t, ids, srcNote.ID, "src author の note は対象外 (= viewer は src を mute していない)")
+	assert.Contains(t, ids, quoteRenote.ID, "quote renote (text 付き) は通る")
+	assert.NotContains(t, ids, pureRenote.ID, "muted renoter の pure renote のみ除外")
+}
+
 // TestNoteRepository_ListHomeTimeline_MutedUsersWithFollowFilter は HomeTimeline
 // で MutedUserIDs と follow 制約が両立することを確認する (#892)。muted user は
 // follow していても home から除外されるべき、かつ MutedUserIDs の OR 節バグで

--- a/internal/server/router.go
+++ b/internal/server/router.go
@@ -1048,6 +1048,10 @@ func (s *Server) setupRoutes() {
 	// 未配線だと user mute は read 時に効かず、cache のみ DB 整合の状態
 	// になる security/UX regression が残る。production では必ず wire する。
 	notesHandler.SetMutingRepo(mutingRepo)
+	// timeline endpoint で renote-muted user の pure renote を除外する
+	// filter (#903)。未配線だと renote-mute は read 時に効かず、frontend
+	// で消えるべき renote が表示され続ける。production では必ず wire する。
+	notesHandler.SetRenoteMutingRepo(renoteMutingRepo)
 	notesHandler.SetInstanceRepo(instanceRepo)
 	notesHandler.SetEmojiRepo(emojiRepo)
 	notesHandler.SetReactionReader(reactionCountWriter)

--- a/internal/testutil/mock_block_mute.go
+++ b/internal/testutil/mock_block_mute.go
@@ -168,6 +168,23 @@ func (m *MockRenoteMutingRepository) Exists(muterID, muteeID string) (bool, erro
 	return err == nil, nil
 }
 
+// ListMuteeIDs returns muteeIDs of all renote-mute rows for muterID.
+// timeline endpoint で renote-mute された user の pure renote を除外する
+// filter 用 (#903)。renote_muting には expiresAt が無いので active filter 不要。
+func (m *MockRenoteMutingRepository) ListMuteeIDs(muterID string) ([]string, error) {
+	if muterID == "" {
+		return nil, nil
+	}
+	var ids []string
+	for _, r := range m.Mutings {
+		if r.MuterID != muterID {
+			continue
+		}
+		ids = append(ids, r.MuteeID)
+	}
+	return ids, nil
+}
+
 func (m *MockRenoteMutingRepository) ListByMuter(muterID, sinceID, untilID string, limit, offset int) ([]*model.RenoteMuting, error) {
 	var rows []*model.RenoteMuting
 	for _, r := range m.Mutings {

--- a/tests/playwright/specs/antennas/antennas.spec.ts
+++ b/tests/playwright/specs/antennas/antennas.spec.ts
@@ -18,9 +18,11 @@ import { callApi } from '../../fixtures/api';
 import { randomUsername, signupUser } from '../../fixtures/auth';
 import { resetRateLimit } from '../../fixtures/rate_limit';
 
+// Antenna の packed shape (upstream Misskey TS と mk-go #904 fix 後で
+// 一致)。userId field は両 backend で **含まない** (= antenna は user-scoped、
+// frontend が呼出主の id を別経路で持つ設計)。
 interface Antenna {
   id: string;
-  userId: string;
   name: string;
   src: string;
   keywords?: string[][];
@@ -73,13 +75,13 @@ test.describe('antennas: CRUD round-trip', () => {
       localOnly: false,
     });
     expect(createResp.status()).toBe(200);
-    const created = (await createResp.json()) as Antenna;
+    // packed antenna は upstream Misskey TS / mk-go (#904 fix 後) いずれも
+    // userId を含まない。両 backend の shape を strict に揃えた regression
+    // guard として userId 不在を直接 assert する。
+    const created = (await createResp.json()) as Record<string, unknown>;
     expect(typeof created.id).toBe('string');
-    createdAntennaId = created.id;
-    // userId は upstream TS の packed antenna shape では不在 (= antenna は
-    // 自分専用なので owner field を返さない設計)、mk-go は `userId` を含む
-    // drift がある (#904 で追跡)。両 backend で共通する identity (id / name
-    // / src / keywords) のみ assert する LCD pattern にする。
+    createdAntennaId = created.id as string;
+    expect(created.userId).toBeUndefined();
     expect(created.name).toBe(name);
     expect(created.src).toBe('all');
     expect(created.keywords).toEqual([['hello']]);

--- a/tests/playwright/specs/renote_mute/timeline_filter.spec.ts
+++ b/tests/playwright/specs/renote_mute/timeline_filter.spec.ts
@@ -1,0 +1,88 @@
+// Phase 3 #903: renote-mute timeline filter integration spec。
+//
+// upstream Misskey TS と mk-go (本 PR で実装) は両方とも:
+//   - renote-mute は **pure renote のみ** を timeline から除外する
+//   - 投稿者の plain note / quote renote (text or file 付き) は通す
+//
+// scenario:
+//   - A が B を renote-mute
+//   - C が public note を作成
+//   - B が C の note を pure renote (text なし)
+//   - B が plain note (= renote 以外) を作成
+//   - A の local timeline:
+//       * C の元 note → 含まれる
+//       * B の plain note → 含まれる
+//       * B の pure renote → **含まれない**
+//
+// upstream Misskey TS の generateMutedUserRelatedRenotesQuery と同 semantics。
+
+import { expect, test } from '@playwright/test';
+import { callApi } from '../../fixtures/api';
+import { randomUsername, signupUser } from '../../fixtures/auth';
+import { createNote } from '../../fixtures/notes';
+import { resetRateLimit } from '../../fixtures/rate_limit';
+
+interface TimelineNote {
+  id: string;
+  userId: string;
+  text: string | null;
+  renoteId?: string | null;
+}
+
+test.describe('renote-mute: timeline filter integration', () => {
+  test.beforeAll(() => {
+    resetRateLimit();
+  });
+
+  test('pure renote by renote-muted user is filtered, plain note is kept', async ({
+    request,
+  }) => {
+    const A = await signupUser(request, randomUsername('rmtA'));
+    const B = await signupUser(request, randomUsername('rmtB'));
+    const C = await signupUser(request, randomUsername('rmtC'));
+
+    // A renote-mutes B
+    const rmCreate = await callApi(request, 'renote-mute/create', {
+      i: A.token,
+      userId: B.id,
+    });
+    expect([200, 204]).toContain(rmCreate.status());
+
+    // C creates a public note
+    const cNote = await createNote(request, C.token, {
+      text: 'note from C',
+      visibility: 'public',
+    });
+
+    // B pure-renotes C's note (text なし、file なし、renoteId のみ)
+    const bRenote = await createNote(request, B.token, {
+      visibility: 'public',
+      renoteId: cNote.id,
+    });
+
+    // B creates a plain note (= renote-mute 対象外であるべき)
+    const bPlain = await createNote(request, B.token, {
+      text: 'B plain note',
+      visibility: 'public',
+    });
+
+    // A の local timeline を取得
+    const tlResp = await callApi(request, 'notes/local-timeline', {
+      i: A.token,
+      limit: 100,
+    });
+    expect(tlResp.status()).toBe(200);
+    const tl = (await tlResp.json()) as TimelineNote[];
+
+    const ids = new Set(tl.map((n) => n.id));
+    expect(ids.has(cNote.id)).toBe(true);
+    expect(ids.has(bPlain.id)).toBe(true);
+    expect(ids.has(bRenote.id)).toBe(false);
+
+    // cleanup: A の renote-mute を解除 (assertion 失敗時の orphan 防止)
+    await callApi(request, 'renote-mute/delete', {
+      i: A.token,
+      userId: B.id,
+    });
+  });
+});


### PR DESCRIPTION
## Summary

#833 spec PR (#902) で発覚した 2 件の Phase 3 issue を 1 PR で対応:

- **#904**: \`antennas/*\` response の userId field drift 削除 (TS shape に揃える)
- **#903**: renote-mute timeline filter 実装 (mk-go 未実装だった機能を upstream parity で追加) + integration spec

## #904: antennas userId drift fix

### 主な変更点

- \`internal/api/antennas/handler.go::antennaToMap\`: userId field を packed shape から除外
- \`internal/api/antennas/handler_test.go\`: \`TestCreate_NoUserIdInResponse\` で response に userId が含まれないことを直接 guard
- \`tests/playwright/specs/antennas/antennas.spec.ts\`: type 定義を fix 後 shape に更新、userId 不在を strict assert する regression guard 追加

## #903: renote-mute timeline filter 実装

#874 user-mute filter と同 architecture pattern で renote-mute を実装。投稿者が renote-muted で **かつ** pure renote (text なし / file なし / renoteId あり) の note のみ skip する upstream Misskey TS の \`generateMutedUserRelatedRenotesQuery\` 互換 semantics。

### 主な変更点

- \`internal/repository/muting.go\`: \`RenoteMutingRepository.ListMuteeIDs\` を追加 (renote_muting には expiresAt が無いので active filter 不要)
- \`internal/testutil/mock_block_mute.go\`: \`MockRenoteMutingRepository.ListMuteeIDs\`
- \`internal/core/timeline/timeline_filter.go\`: \`TimelineFilter.RenoteMutedUserIDs\` + \`ApplyFilter\` で pure renote 判定 + skip
- \`internal/model/timeline_filter.go\`: \`TimelineDBFilter.UseRenoteMutingSubquery\` (= #894 と同 pattern)
- \`internal/repository/note.go::applyTimelineFilter\`: NOT EXISTS subquery + pure renote condition (\`text IS NULL AND "fileIds" = '{}' AND "renoteId" IS NOT NULL\`)
- \`internal/core/timeline/timeline_service.go::toDBFilter\`: viewerID 有のとき \`UseRenoteMutingSubquery=true\`
- \`internal/api/notes/handler.go\`: \`renoteMutingRepo\` field + \`SetRenoteMutingRepo\` setter
- \`internal/api/notes/timeline_handler.go\`: \`loadRenoteMutedUserIDs\` helper を 4 timeline endpoint に注入
- \`internal/server/router.go\`: \`notesHandler.SetRenoteMutingRepo\` wire
- \`tests/playwright/specs/renote_mute/timeline_filter.spec.ts\`: A renote-mutes B → B の pure renote が A の local timeline から除外、B の plain note はそのまま通る integration spec

## テスト

- \`make test\` (api/notes / api/antennas / core/timeline / repository 全 pass)
- mk-go Playwright: \`make playwright-test\` → **77 / 77 pass** (既存 75 + 新 2)
- TS Playwright: \`make playwright-ts-test\` → **76 pass + 1 skip** (import-zip)

## Closes

- Closes #904
- Closes #903

🤖 Generated with [Claude Code](https://claude.com/claude-code)