### PR TITLE
#830 Playwright Phase 3: charts spec の整備 (12 endpoint shape)

### DIFF
--- a/tests/playwright/specs/charts/charts.spec.ts
+++ b/tests/playwright/specs/charts/charts.spec.ts
@@ -1,0 +1,132 @@
+// Phase 3 #830: charts/* response shape の round-trip。
+//
+// upstream Misskey TS と mk-go は両方とも 12 chart endpoint を提供:
+//   instance-wide:
+//     - charts/notes / users / drive / federation / ap-request / active-users
+//     - charts/instance (= host required)
+//   per-user:
+//     - charts/user/{notes, drive, following, pv, reactions} (= userId required)
+//
+// 各 endpoint は { span: 'hour'|'day', limit: N } を取り、unflatten した
+// nested object を返す:
+//   {
+//     "field1": { "subfield": [n1, n2, ..., nN] },
+//     "field2": [n1, n2, ..., nN],
+//     ...
+//   }
+// 各 leaf は length = limit の number 配列。値は集計遅延があり deterministic
+// に固定できないので、本 spec は **shape (= status / 各 leaf 配列の長さ)**
+// のみ assert する。
+
+import { expect, test } from '@playwright/test';
+import { callApi } from '../../fixtures/api';
+import { randomUsername, signupUser } from '../../fixtures/auth';
+import { resetRateLimit } from '../../fixtures/rate_limit';
+
+const LIMIT = 5;
+
+// flattenLeafArrays returns all leaf values that look like number arrays from
+// chart の unflatten 済 nested object。chart の field 構成は backend / version で
+// 変動するので key 名は固定 assert せず、すべての number[] leaf が limit 件か
+// を確認する LCD。
+function flattenLeafArrays(obj: unknown): number[][] {
+  const out: number[][] = [];
+  if (Array.isArray(obj)) {
+    if (obj.every((x) => typeof x === 'number')) {
+      out.push(obj as number[]);
+    }
+    return out;
+  }
+  if (obj && typeof obj === 'object') {
+    for (const v of Object.values(obj)) {
+      out.push(...flattenLeafArrays(v));
+    }
+  }
+  return out;
+}
+
+async function assertChartShape(
+  request: import('@playwright/test').APIRequestContext,
+  endpoint: string,
+  body: Record<string, unknown>,
+): Promise<void> {
+  const resp = await callApi(request, endpoint, body);
+  expect(resp.status(), `${endpoint} should return 200`).toBe(200);
+  const data = (await resp.json()) as Record<string, unknown>;
+  const leaves = flattenLeafArrays(data);
+  expect(leaves.length, `${endpoint} should have at least 1 number[] leaf`).toBeGreaterThan(0);
+  for (const leaf of leaves) {
+    expect(leaf.length, `${endpoint} leaf array should have length=${LIMIT}`).toBe(LIMIT);
+    for (const n of leaf) {
+      expect(typeof n).toBe('number');
+    }
+  }
+}
+
+test.describe('charts/* response shape', () => {
+  test.beforeAll(() => {
+    resetRateLimit();
+  });
+
+  test('instance-wide charts return correctly shaped number arrays', async ({ request }) => {
+    const me = await signupUser(request, randomUsername('chrA'));
+
+    // host required な instance chart は別系統 (= 自 instance を host で投げる)
+    // まず host なしの 6 endpoint を回す。
+    for (const ep of [
+      'charts/notes',
+      'charts/users',
+      'charts/drive',
+      'charts/federation',
+      'charts/ap-request',
+      'charts/active-users',
+    ]) {
+      await assertChartShape(request, ep, {
+        i: me.token,
+        span: 'hour',
+        limit: LIMIT,
+      });
+    }
+  });
+
+  test('charts/instance returns shape for own host', async ({ request }) => {
+    const me = await signupUser(request, randomUsername('chrI'));
+    // mkgo.local は test stack 内 nginx alias、TS image / mk-go どちらでも
+    // local instance host として登録されている (= 自 instance host)。
+    await assertChartShape(request, 'charts/instance', {
+      i: me.token,
+      span: 'hour',
+      limit: LIMIT,
+      host: 'mkgo.local',
+    });
+  });
+
+  test('per-user charts return correctly shaped number arrays', async ({ request }) => {
+    const me = await signupUser(request, randomUsername('chrU'));
+    for (const ep of [
+      'charts/user/notes',
+      'charts/user/drive',
+      'charts/user/following',
+      'charts/user/pv',
+      'charts/user/reactions',
+    ]) {
+      await assertChartShape(request, ep, {
+        i: me.token,
+        span: 'hour',
+        limit: LIMIT,
+        userId: me.id,
+      });
+    }
+  });
+
+  test('span=day also returns correctly shaped arrays', async ({ request }) => {
+    const me = await signupUser(request, randomUsername('chrD'));
+    // span=day path も 1 endpoint で touch する (= chart engine の day vs
+    // hour bucket logic が両 backend で同 shape を返すかの smoke)。
+    await assertChartShape(request, 'charts/notes', {
+      i: me.token,
+      span: 'day',
+      limit: LIMIT,
+    });
+  });
+});

--- a/tests/playwright/specs/charts/charts.spec.ts
+++ b/tests/playwright/specs/charts/charts.spec.ts
@@ -55,11 +55,10 @@ async function assertChartShape(
   const data = (await resp.json()) as Record<string, unknown>;
   const leaves = flattenLeafArrays(data);
   expect(leaves.length, `${endpoint} should have at least 1 number[] leaf`).toBeGreaterThan(0);
+  // flattenLeafArrays が `every typeof === 'number'` で filter 済なので
+  // 各要素の type 再 assert は不要 (= dead code 削除、length のみ確認)。
   for (const leaf of leaves) {
     expect(leaf.length, `${endpoint} leaf array should have length=${LIMIT}`).toBe(LIMIT);
-    for (const n of leaf) {
-      expect(typeof n).toBe('number');
-    }
   }
 }
 


### PR DESCRIPTION
## Summary

Misskey の chart endpoint **12 本** に対する shape compat round-trip spec を整備。両 backend (mk-go / TS) で chart response の number[] leaf shape が同等であることを担保する。

## 主な変更点

\`tests/playwright/specs/charts/charts.spec.ts\` で 12 endpoint を 4 test に整理:

1. **instance-wide 6 endpoint** (host 不要):
   - charts/notes / users / drive / federation / ap-request / active-users
2. **charts/instance** (host required = 自 instance \`mkgo.local\` を投げる)
3. **per-user 5 endpoint** (userId 必須):
   - charts/user/{notes, drive, following, pv, reactions}
4. **span=day smoke** (1 endpoint で bucket 切替 logic を touch)

各 endpoint で:
- status 200
- response (= unflatten 済 nested object) の **number[] leaf が length=limit (= 5)** で揃うこと
- number type 整合性

を assert する。

## LCD strategy

chart 値そのものは集計遅延 + Redis stream / DB 集計の race があるので **deterministic に固定できない**。本 spec は **shape (= 配列長 / 型)** のみ verify する。値自体の整合性は backend unit test で別途担保する設計。

## テスト

- mk-go Playwright: \`make playwright-test\` → **87 / 87 pass** (既存 83 + 新 4)
- TS Playwright: \`make playwright-ts-test\` → **86 pass + 1 skip** (既存 import-zip)

## Closes

- Closes #830

🤖 Generated with [Claude Code](https://claude.com/claude-code)