### PR TITLE
#835 Playwright Phase 3: announcements + utility root endpoint spec

### DIFF
--- a/tests/playwright/specs/announcements/announcements.spec.ts
+++ b/tests/playwright/specs/announcements/announcements.spec.ts
@@ -1,0 +1,92 @@
+// Phase 3 #835: announcements list / read round-trip。
+//
+// upstream Misskey TS と mk-go は両方とも:
+//   - admin/announcements/create で announcement を作成 (admin only)
+//   - /api/announcements (auth) で自分宛 + global の active announcement を list
+//   - i/read-announcement で既読化 (= announcement_read row 作成)
+//   - list 再取得で isRead が反映されること
+//
+// admin CRUD 自体は #826 で別 cover、本 spec は public list + read 経路に集中する。
+
+import { readFileSync } from 'node:fs';
+import { expect, test } from '@playwright/test';
+import { callApi } from '../../fixtures/api';
+import { randomUsername, signupUser } from '../../fixtures/auth';
+import { resetRateLimit } from '../../fixtures/rate_limit';
+
+interface RootFixture {
+  id: string;
+  token: string;
+  username: string;
+}
+
+interface Announcement {
+  id: string;
+  title: string;
+  text: string;
+  isRead?: boolean;
+}
+
+test.describe('announcements list + read round-trip', () => {
+  let createdAnnouncementId: string | undefined;
+  let rootToken: string | undefined;
+
+  test.beforeAll(() => {
+    resetRateLimit();
+  });
+
+  test.afterEach(async ({ request }) => {
+    if (createdAnnouncementId && rootToken) {
+      await callApi(request, 'admin/announcements/delete', {
+        i: rootToken,
+        id: createdAnnouncementId,
+      });
+    }
+    createdAnnouncementId = undefined;
+    rootToken = undefined;
+  });
+
+  test('admin creates global announcement → user lists / reads it', async ({ request }) => {
+    const root: RootFixture = JSON.parse(readFileSync('.auth/root.json', 'utf-8'));
+    rootToken = root.token;
+    const me = await signupUser(request, randomUsername('annA'));
+
+    const title = `spec_ann_${Math.random().toString(16).slice(2, 8)}`;
+    // admin が global announcement を作成
+    const createResp = await callApi(request, 'admin/announcements/create', {
+      i: root.token,
+      title,
+      text: 'spec body',
+      imageUrl: null,
+      icon: 'info',
+      display: 'normal',
+    });
+    expect(createResp.status()).toBe(200);
+    const created = (await createResp.json()) as Announcement;
+    createdAnnouncementId = created.id;
+
+    // user が announcements を list
+    const listResp = await callApi(request, 'announcements', { i: me.token });
+    expect(listResp.status()).toBe(200);
+    const list = (await listResp.json()) as Announcement[];
+    const found = list.find((a) => a.id === created.id);
+    expect(found).toBeDefined();
+    expect(found?.title).toBe(title);
+    // 初期は未読
+    expect(found?.isRead).toBeFalsy();
+
+    // i/read-announcement で既読化
+    const readResp = await callApi(request, 'i/read-announcement', {
+      i: me.token,
+      announcementId: created.id,
+    });
+    expect([200, 204]).toContain(readResp.status());
+
+    // list 再取得で isRead=true
+    const listAfter = await callApi(request, 'announcements', { i: me.token });
+    expect(listAfter.status()).toBe(200);
+    const listAfterBody = (await listAfter.json()) as Announcement[];
+    const foundAfter = listAfterBody.find((a) => a.id === created.id);
+    expect(foundAfter?.isRead).toBe(true);
+  });
+});

--- a/tests/playwright/specs/utility/utility.spec.ts
+++ b/tests/playwright/specs/utility/utility.spec.ts
@@ -1,0 +1,95 @@
+// Phase 3 #835: utility root endpoint shape の round-trip。
+//
+// Misskey root (= /api/<endpoint>) の utility 系 endpoint の shape を
+// 両 backend で固定する。値そのものは集計遅延 / 環境依存があるので
+// **status + 必須 field の存在 + 配列要素 type** のみ assert する LCD
+// strategy。
+//
+// scope:
+//   - stats: { notesCount, originalNotesCount, usersCount, ... }
+//   - server-info: server hardware metadata (= cpu / memory shape)
+//   - get-online-users-count: { count: number }
+//   - get-avatar-decorations: array (= decoration list)
+//   - pinned-users: UserLite array
+//   - retention: chart-like number array shape
+//
+// scope 外:
+//   - reset-password / fetch-rss は SMTP / mock RSS server 必要、別 PR scope
+
+import { expect, test } from '@playwright/test';
+import { callApi } from '../../fixtures/api';
+import { randomUsername, signupUser } from '../../fixtures/auth';
+import { resetRateLimit } from '../../fixtures/rate_limit';
+
+test.describe('utility root endpoints shape', () => {
+  test.beforeAll(() => {
+    resetRateLimit();
+  });
+
+  test('stats returns counter shape', async ({ request }) => {
+    const me = await signupUser(request, randomUsername('utlA'));
+    const resp = await callApi(request, 'stats', { i: me.token });
+    expect(resp.status()).toBe(200);
+    const body = (await resp.json()) as Record<string, unknown>;
+    // upstream Misskey TS / mk-go 共通の必須 field
+    for (const key of [
+      'notesCount',
+      'originalNotesCount',
+      'usersCount',
+      'originalUsersCount',
+      'instances',
+    ]) {
+      expect(typeof body[key], `stats.${key} should be number`).toBe('number');
+    }
+  });
+
+  test('server-info returns hardware metadata', async ({ request }) => {
+    const me = await signupUser(request, randomUsername('utlS'));
+    const resp = await callApi(request, 'server-info', { i: me.token });
+    expect(resp.status()).toBe(200);
+    const body = (await resp.json()) as Record<string, unknown>;
+    // 両 backend で必ず存在する hardware metadata field 群。
+    // 個別 value (= cpu cores / memory bytes) は環境依存なので type のみ。
+    expect(body.machine).toBeDefined();
+    expect(body.cpu).toBeDefined();
+    expect(body.mem).toBeDefined();
+    expect(body.fs).toBeDefined();
+  });
+
+  test('get-online-users-count returns numeric count', async ({ request }) => {
+    const me = await signupUser(request, randomUsername('utlO'));
+    const resp = await callApi(request, 'get-online-users-count', { i: me.token });
+    expect(resp.status()).toBe(200);
+    const body = (await resp.json()) as { count?: unknown };
+    expect(typeof body.count).toBe('number');
+  });
+
+  test('get-avatar-decorations returns array', async ({ request }) => {
+    // anonymous でも accept されるはず (= meta-like read endpoint)。
+    const resp = await callApi(request, 'get-avatar-decorations', {});
+    expect(resp.status()).toBe(200);
+    const body = await resp.json();
+    expect(Array.isArray(body)).toBe(true);
+    // 内容は test 環境で空のことが多いので shape のみ assert (= 配列であること)。
+  });
+
+  test('pinned-users returns UserLite array', async ({ request }) => {
+    const resp = await callApi(request, 'pinned-users', {});
+    expect(resp.status()).toBe(200);
+    const body = await resp.json();
+    expect(Array.isArray(body)).toBe(true);
+    // pinnedUsers は admin/meta で設定される、test 環境では未設定で空配列が
+    // 一般的。array であることのみ assert (= shape compat)。
+  });
+
+  test('retention returns aggregated array shape', async ({ request }) => {
+    const me = await signupUser(request, randomUsername('utlR'));
+    const resp = await callApi(request, 'retention', { i: me.token });
+    expect(resp.status()).toBe(200);
+    const body = await resp.json();
+    // retention は { date, users, data: { day_offset_X: count } }[] の
+    // 配列 (= upstream / mk-go 共通)。test 環境では空配列のことが多いので
+    // array 型のみ assert。
+    expect(Array.isArray(body)).toBe(true);
+  });
+});

--- a/tests/playwright/specs/utility/utility.spec.ts
+++ b/tests/playwright/specs/utility/utility.spec.ts
@@ -22,13 +22,20 @@ import { randomUsername, signupUser } from '../../fixtures/auth';
 import { resetRateLimit } from '../../fixtures/rate_limit';
 
 test.describe('utility root endpoints shape', () => {
-  test.beforeAll(() => {
+  // 4 auth-required endpoint で 4 回 signup すると IP rate limit (5 / 1h) を
+  // 圧迫する。1 user を beforeAll で作って共有することで signup 数を 1 に
+  // 抑える (#909 review N1)。anonymous endpoint (get-avatar-decorations /
+  // pinned-users) は token 不要なので user 不要。
+  let token: string | null = null;
+
+  test.beforeAll(async ({ request }) => {
     resetRateLimit();
+    const me = await signupUser(request, randomUsername('utl'));
+    token = me.token;
   });
 
   test('stats returns counter shape', async ({ request }) => {
-    const me = await signupUser(request, randomUsername('utlA'));
-    const resp = await callApi(request, 'stats', { i: me.token });
+    const resp = await callApi(request, 'stats', { i: token });
     expect(resp.status()).toBe(200);
     const body = (await resp.json()) as Record<string, unknown>;
     // upstream Misskey TS / mk-go 共通の必須 field
@@ -44,8 +51,7 @@ test.describe('utility root endpoints shape', () => {
   });
 
   test('server-info returns hardware metadata', async ({ request }) => {
-    const me = await signupUser(request, randomUsername('utlS'));
-    const resp = await callApi(request, 'server-info', { i: me.token });
+    const resp = await callApi(request, 'server-info', { i: token });
     expect(resp.status()).toBe(200);
     const body = (await resp.json()) as Record<string, unknown>;
     // 両 backend で必ず存在する hardware metadata field 群。
@@ -57,8 +63,7 @@ test.describe('utility root endpoints shape', () => {
   });
 
   test('get-online-users-count returns numeric count', async ({ request }) => {
-    const me = await signupUser(request, randomUsername('utlO'));
-    const resp = await callApi(request, 'get-online-users-count', { i: me.token });
+    const resp = await callApi(request, 'get-online-users-count', { i: token });
     expect(resp.status()).toBe(200);
     const body = (await resp.json()) as { count?: unknown };
     expect(typeof body.count).toBe('number');
@@ -83,8 +88,7 @@ test.describe('utility root endpoints shape', () => {
   });
 
   test('retention returns aggregated array shape', async ({ request }) => {
-    const me = await signupUser(request, randomUsername('utlR'));
-    const resp = await callApi(request, 'retention', { i: me.token });
+    const resp = await callApi(request, 'retention', { i: token });
     expect(resp.status()).toBe(200);
     const body = await resp.json();
     // retention は { date, users, data: { day_offset_X: count } }[] の


### PR DESCRIPTION
## Summary

Phase 3 の **announcements list / read flow** + **root level utility 系 endpoint** の Playwright spec を整備。

## 主な変更点

- \`tests/playwright/specs/announcements/announcements.spec.ts\`: \`admin/announcements/create\` → \`/api/announcements\` で global announcement が list に出る + 初期 unread → \`i/read-announcement\` で既読化 → list 再取得で \`isRead: true\` 反映 round-trip。admin CRUD 自体は #826 で別 cover、本 spec は public list + read 経路のみ。
- \`tests/playwright/specs/utility/utility.spec.ts\`: 6 endpoint shape verify (LCD strategy):
  - \`stats\`: \`notesCount\` / \`originalNotesCount\` / \`usersCount\` / \`originalUsersCount\` / \`instances\` 必須 counter
  - \`server-info\`: \`machine\` / \`cpu\` / \`mem\` / \`fs\` hardware metadata field
  - \`get-online-users-count\`: \`{ count: number }\` shape
  - \`get-avatar-decorations\`: array shape
  - \`pinned-users\`: UserLite array
  - \`retention\`: aggregated array shape

## scope 外

- \`reset-password\` / \`fetch-rss\` は SMTP / mock RSS server 必要、別 PR で扱う想定 (= scope 大)
- \`ping\` / \`meta\` / \`endpoints\` は globalSetup や smoke spec で間接 cover 済

## テスト

- mk-go Playwright: \`make playwright-test\` → **94 / 94 pass** (既存 87 + 新 7)
- TS Playwright: \`make playwright-ts-test\` → **93 pass + 1 skip** (既存 import-zip)

## Closes

- Closes #835

🤖 Generated with [Claude Code](https://claude.com/claude-code)