### PR TITLE
Fix #910: app-issued access token を auth middleware で resolve できるよう dual lookup 化

### DIFF
--- a/internal/repository/access_token.go
+++ b/internal/repository/access_token.go
@@ -8,6 +8,17 @@ import (
 // AccessTokenRepository provides data access for access tokens.
 type AccessTokenRepository interface {
 	FindByHash(hash string) (*model.AccessToken, error)
+	// FindByHashOrToken は middleware 用の dual lookup。
+	// upstream Misskey TS の AuthenticateService が
+	//   WHERE hash = ? OR token = ?
+	// で参照している pattern を 1 query に集約する。
+	//
+	//  - miauth/gen-token は hash = sha256(token) で保存 → hash 列で hit
+	//  - auth/accept は hash = sha256(token + app.secret) で保存 → token 列で hit
+	//
+	// 2 経路を 1 query にすることで middleware ホットパスでの追加 round trip を
+	// 避けつつ、app-issued token も miauth token も一律で resolve できる (#910)。
+	FindByHashOrToken(hash, rawToken string) (*model.AccessToken, error)
 	FindByID(id string) (*model.AccessToken, error)
 	ListByUserID(userID string) ([]*model.AccessToken, error)
 	// ListByUserIDPreloadApp は /i/apps 用に App を JOIN し、sort で
@@ -33,6 +44,17 @@ func NewAccessTokenRepository(db *gorm.DB) AccessTokenRepository {
 func (r *accessTokenRepository) FindByHash(hash string) (*model.AccessToken, error) {
 	var token model.AccessToken
 	if err := r.db.Where("hash = ?", hash).Preload("User").First(&token).Error; err != nil {
+		return nil, err
+	}
+	return &token, nil
+}
+
+func (r *accessTokenRepository) FindByHashOrToken(hash, rawToken string) (*model.AccessToken, error) {
+	var token model.AccessToken
+	if err := r.db.
+		Where(`"hash" = ? OR "token" = ?`, hash, rawToken).
+		Preload("User").
+		First(&token).Error; err != nil {
 		return nil, err
 	}
 	return &token, nil

--- a/internal/repository/access_token_test.go
+++ b/internal/repository/access_token_test.go
@@ -41,8 +41,10 @@ func TestAccessTokenRepository_FindByHashOrToken(t *testing.T) {
 	user := insertTestUser(t, "u_atfh_1", "tokenuser_or")
 	defer cleanupUser(t, user.ID)
 
-	// app/auth flow を再現: hash = sha256(token + secret) で保存され、
-	// raw token 列で middleware が hit することを確認する。
+	// 2 種類の token を作って両 path を verify する:
+	//   miauthToken = miauth/gen-token と同じ shape (hash 列で hit する)
+	//   appToken    = auth/accept と同じ shape (hash = sha256(token+secret) なので
+	//                 hash 列では miss、raw token 列で hit する)
 	miauthToken := &model.AccessToken{
 		ID:     "at_atfh_miauth",
 		Token:  "raw_miauth_xyz",

--- a/internal/repository/access_token_test.go
+++ b/internal/repository/access_token_test.go
@@ -35,3 +35,50 @@ func TestAccessTokenRepository_FindByHash_NotFound(t *testing.T) {
 	_, err := repo.FindByHash("nonexistent_hash")
 	assert.Error(t, err)
 }
+
+func TestAccessTokenRepository_FindByHashOrToken(t *testing.T) {
+	repo := NewAccessTokenRepository(testDB)
+	user := insertTestUser(t, "u_atfh_1", "tokenuser_or")
+	defer cleanupUser(t, user.ID)
+
+	// app/auth flow を再現: hash = sha256(token + secret) で保存され、
+	// raw token 列で middleware が hit することを確認する。
+	miauthToken := &model.AccessToken{
+		ID:     "at_atfh_miauth",
+		Token:  "raw_miauth_xyz",
+		Hash:   "hash_miauth_xyz",
+		UserID: user.ID,
+	}
+	require.NoError(t, testDB.Create(miauthToken).Error)
+	defer testDB.Exec(`DELETE FROM "access_token" WHERE id = ?`, miauthToken.ID)
+
+	appToken := &model.AccessToken{
+		ID:     "at_atfh_app",
+		Token:  "raw_app_xyz",
+		Hash:   "hash_app_with_secret",
+		UserID: user.ID,
+	}
+	require.NoError(t, testDB.Create(appToken).Error)
+	defer testDB.Exec(`DELETE FROM "access_token" WHERE id = ?`, appToken.ID)
+
+	t.Run("hits via hash column (miauth path)", func(t *testing.T) {
+		found, err := repo.FindByHashOrToken("hash_miauth_xyz", "raw_miauth_xyz")
+		require.NoError(t, err)
+		assert.Equal(t, miauthToken.ID, found.ID)
+		assert.NotNil(t, found.User)
+	})
+
+	t.Run("hits via token column (app/auth path)", func(t *testing.T) {
+		// hash 値は middleware が知らない (= sha256(token+secret))。
+		// raw token 列で OR 検索が hit するはず。
+		found, err := repo.FindByHashOrToken("sha256_of_raw_app_xyz_alone", "raw_app_xyz")
+		require.NoError(t, err)
+		assert.Equal(t, appToken.ID, found.ID)
+		assert.NotNil(t, found.User)
+	})
+
+	t.Run("not found when neither matches", func(t *testing.T) {
+		_, err := repo.FindByHashOrToken("nonexistent_hash", "nonexistent_token")
+		assert.Error(t, err)
+	})
+}

--- a/internal/server/middleware/auth.go
+++ b/internal/server/middleware/auth.go
@@ -278,13 +278,9 @@ func (a *AuthMiddleware) resolveUser(token string) (*model.User, error) {
 		return user, nil
 	}
 
-	// access tokenのhashで検索。
-	// upstream Misskey TS の AuthenticateService が hash 列 OR token 列の
-	// dual lookup を 1 query で行う pattern (#910) を再現する:
-	//   - miauth/gen-token は hash = sha256(token) → hash 列で hit
-	//   - auth/accept は hash = sha256(token + app.secret) → hash 列で miss、
-	//     token (raw) 列で hit する経路で resolve される
-	// これにより app-issued token も middleware で正しく認証できる。
+	// hash 列 (miauth: sha256(token)) と token 列 (raw, app/auth) を 1 query
+	// で OR 検索する。upstream Misskey TS の AuthenticateService と同 pattern
+	// (#910)。両 index がある前提で BitmapOr scan に乗る。
 	hash := sha256Hash(token)
 	accessToken, err := a.accessTokenRepo.FindByHashOrToken(hash, token)
 	if err != nil {

--- a/internal/server/middleware/auth.go
+++ b/internal/server/middleware/auth.go
@@ -278,9 +278,15 @@ func (a *AuthMiddleware) resolveUser(token string) (*model.User, error) {
 		return user, nil
 	}
 
-	// access tokenのhashで検索
+	// access tokenのhashで検索。
+	// upstream Misskey TS の AuthenticateService が hash 列 OR token 列の
+	// dual lookup を 1 query で行う pattern (#910) を再現する:
+	//   - miauth/gen-token は hash = sha256(token) → hash 列で hit
+	//   - auth/accept は hash = sha256(token + app.secret) → hash 列で miss、
+	//     token (raw) 列で hit する経路で resolve される
+	// これにより app-issued token も middleware で正しく認証できる。
 	hash := sha256Hash(token)
-	accessToken, err := a.accessTokenRepo.FindByHash(hash)
+	accessToken, err := a.accessTokenRepo.FindByHashOrToken(hash, token)
 	if err != nil {
 		// not-found 系は cache に積まない: 失効後 30 秒間 stale を返さない
 		// ようにするのと、未知 token 連打への DDoS を rate limiter 側に任せる

--- a/internal/server/middleware/auth_test.go
+++ b/internal/server/middleware/auth_test.go
@@ -275,6 +275,47 @@ func TestAuthenticate_AccessToken(t *testing.T) {
 	assert.NoError(t, err)
 }
 
+// TestAuthenticate_AppIssuedAccessToken は #910 drift fix の regression guard:
+// auth/accept は hash = sha256(token + app.secret) で保存するため、
+// middleware が hash 列だけで lookup すると 401 になる。token (raw) 列での
+// fallback (FindByHashOrToken) で resolve されることを確認する。
+func TestAuthenticate_AppIssuedAccessToken(t *testing.T) {
+	userRepo := testutil.NewMockUserRepository()
+	tokenRepo := testutil.NewMockAccessTokenRepository()
+
+	user := &model.User{ID: "user_app_1", Username: "appuser"}
+	rawToken := "raw_app_token_xyz"
+	// app/auth flow と同じく hash は raw token そのものではなく
+	// raw + secret の sha256 で別値。middleware の sha256(rawToken) は
+	// 一致しないので、token 列 fallback でしか resolve できない。
+	hashWithSecret := sha256Hash(rawToken + "app_secret_value")
+	tokenRepo.Tokens[hashWithSecret] = &model.AccessToken{
+		ID:     "at_app_1",
+		Token:  rawToken,
+		Hash:   hashWithSecret,
+		UserID: user.ID,
+		User:   user,
+	}
+
+	auth := NewAuthMiddleware(userRepo, tokenRepo)
+
+	e := echo.New()
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	req.Header.Set("Authorization", "Bearer "+rawToken)
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+
+	handler := auth.Authenticate()(func(c echo.Context) error {
+		u := GetUser(c)
+		assert.NotNil(t, u)
+		assert.Equal(t, "user_app_1", u.ID)
+		return c.String(http.StatusOK, "ok")
+	})
+
+	require.NoError(t, handler(c))
+	assert.Equal(t, http.StatusOK, rec.Code)
+}
+
 func TestAuthenticate_JSONBodyToken(t *testing.T) {
 	userRepo := testutil.NewMockUserRepository()
 	tokenRepo := testutil.NewMockAccessTokenRepository()

--- a/internal/testutil/mock_repository.go
+++ b/internal/testutil/mock_repository.go
@@ -2007,6 +2007,22 @@ func (m *MockAccessTokenRepository) FindByHash(hash string) (*model.AccessToken,
 	return t, nil
 }
 
+// FindByHashOrToken は実 repo の WHERE hash = ? OR token = ? を再現する。
+// 実 repo は hash 列と token 列の OR 検索を 1 query で行うため、mock も
+// 両条件を順に評価する。Tokens map は hash key で持っているので、token 列
+// 検索は線形探索になるが test scope では問題ない。
+func (m *MockAccessTokenRepository) FindByHashOrToken(hash, rawToken string) (*model.AccessToken, error) {
+	if t, ok := m.Tokens[hash]; ok {
+		return t, nil
+	}
+	for _, t := range m.Tokens {
+		if t.Token == rawToken {
+			return t, nil
+		}
+	}
+	return nil, ErrNotFound
+}
+
 func (m *MockAccessTokenRepository) FindByID(id string) (*model.AccessToken, error) {
 	for _, t := range m.Tokens {
 		if t.ID == id {

--- a/migration/000047_access_token_token_index.down.sql
+++ b/migration/000047_access_token_token_index.down.sql
@@ -1,0 +1,1 @@
+DROP INDEX IF EXISTS "IDX_access_token_token";

--- a/migration/000047_access_token_token_index.up.sql
+++ b/migration/000047_access_token_token_index.up.sql
@@ -1,0 +1,9 @@
+-- access_token.token に index を追加 (#910 review nit)。
+--
+-- middleware は hash 列 OR token 列の dual lookup で resolve する
+-- (FindByHashOrToken)。hash 列には初版から index があったが、token 列
+-- (= raw token, app/auth flow で middleware hit する経路) は未 indexed
+-- だったため、PostgreSQL は OR query で seq scan に fallback していた。
+-- upstream Misskey TS の Init migration には token / hash 両方の index が
+-- あるので、drop-in compat として揃える。
+CREATE INDEX IF NOT EXISTS "IDX_access_token_token" ON "access_token" ("token");

--- a/tests/playwright/specs/app/auth_flow.spec.ts
+++ b/tests/playwright/specs/app/auth_flow.spec.ts
@@ -7,12 +7,10 @@
 //   4. auth/session/show { token } で session 情報を確認 (pending state)
 //   5. user が auth/accept { token } で承認 (要 user token)
 //   6. auth/session/userkey { appSecret, token } で access token を取得
+//   7. その access token で /api/i が叩ける = 認証完成
 //
-// mk-go の auth middleware には hash 不整合 drift (#910) があり、userkey で
-// 受け取った access token を middleware 経由 (例: /api/i) で叩くと 401 に
-// なる。本 spec では shape 互換 (= userkey が accessToken + user.id を返す)
-// までを drop-in compat の境界として固定し、token を実際に middleware に
-// 通す経路は drift 解消 (#910) 後に別 spec で再 enable する。
+// upstream Misskey の app token (= 3rd party 用) と /signin-flow の i-token
+// (= ユーザー直接 login) を区別する設計の round-trip 全体を 1 spec で検証。
 
 import { expect, test } from '@playwright/test';
 import { callApi } from '../../fixtures/api';
@@ -30,9 +28,7 @@ test.describe('app + auth/session 3rd party flow', () => {
     resetRateLimit();
   });
 
-  // テスト名は userkey の shape 互換確認まで。最終的な /api/i 検証は #910
-  // drift 解消後に enable する。
-  test('app/create → auth/session/generate → accept → userkey shape compat', async ({
+  test('app/create → auth/session/generate → accept → userkey → /api/i works', async ({
     request,
   }) => {
     const me = await signupUser(request, randomUsername('app'));
@@ -109,13 +105,13 @@ test.describe('app + auth/session 3rd party flow', () => {
     // を防ぐ。
     expect(userkey.accessToken).not.toBe(me.token);
 
-    // 7. 取得 token で /api/i が叩ける = 認証完了
-    //
-    // mk-go では auth/accept で access_token を sha256(token + app.Secret) で
-    // store する一方、middleware は sha256(token) で lookup するため hash
-    // 不整合で 401 になる drift がある (#910)。upstream Misskey TS と shape は
-    // 一致するが行為レベルで token が使えないため、drop-in 互換 verify は
-    // userkey の shape (= accessToken + user.id) までで打ち切り、token を
-    // middleware 経由で叩くアサーションは drift 解消 (#910) 後に再 enable する。
+    // 7. 取得 token で /api/i が叩ける = 認証完了。
+    // mk-go では auth/accept で access_token を sha256(token + app.secret) で
+    // store するため、middleware は hash 列 OR token (raw) 列の dual lookup
+    // で resolve する (#910)。upstream Misskey TS と同じ pattern。
+    const iResp = await callApi(request, 'i', { i: userkey.accessToken });
+    expect(iResp.status()).toBe(200);
+    const iBody = (await iResp.json()) as { id: string };
+    expect(iBody.id).toBe(me.id);
   });
 });


### PR DESCRIPTION
## Summary

mk-go の auth middleware は \`sha256(rawToken)\` で \`hash\` 列だけを lookup していたが、\`auth/accept\` は upstream Misskey TS と同じく \`hash = sha256(token + app.secret)\` で保存するため、app/auth flow で発行した access token を middleware 経由で叩くと **401** になる drift があった (#910)。#834 の Playwright spec (PR #911) で発覚。

upstream Misskey TS (\`AuthenticateService.authenticate\`) は

\`\`\`
WHERE hash = ? OR token = ?
\`\`\`

の dual condition lookup で miauth (\`hash=sha256(token)\`) と app/auth (\`hash=sha256(token+secret)\`) 両方を 1 query で resolve している。これに揃える。

## 主な変更点

- \`AccessTokenRepository.FindByHashOrToken(hash, rawToken)\` を追加。\`hash\` 列 OR \`token\` 列の OR 検索を 1 query (\`Preload("User")\` 維持)。
- \`middleware/auth.resolveUser\` を \`FindByHash\` → \`FindByHashOrToken\` に切替。hot path の round trip を増やさず両 token 経路を resolve。
- \`testutil.MockAccessTokenRepository.FindByHashOrToken\` も同 semantics で再現。
- \`tests/playwright/specs/app/auth_flow.spec.ts\` の step 7 (\`/api/i\` 検証) を re-enable。

## Regression guard (3-layer)

- **integration** (\`internal/repository/access_token_test.go\`):
  \`FindByHashOrToken\` を hash 経路 / token 経路 / not-found の 3 case で確認
- **unit** (\`internal/server/middleware/auth_test.go\`):
  \`TestAuthenticate_AppIssuedAccessToken\` — hash mismatch (= sha256(token+secret)) の access_token に対して raw token を Bearer で送ると middleware が user を resolve すること
- **e2e** (\`tests/playwright/specs/app/auth_flow.spec.ts\`):
  step 7 (取得 token で \`/api/i\`) を再 enable し、両 backend で 7 step round-trip pass を確認

## テスト

\`\`\`
$ go test -race -count=1 -coverprofile=cov.out \\
    ./internal/repository ./internal/server/middleware ./internal/api/auth
ok internal/repository                90.3%
ok internal/server/middleware         94.7%
ok internal/api/auth                  100.0%
\`\`\`

Playwright (両 backend):

\`\`\`
mk-go: ✓ specs/app/auth_flow.spec.ts ... → /api/i works (219ms)
TS:    ✓ specs/app/auth_flow.spec.ts ... → /api/i works (186ms)
\`\`\`

## Closes

Closes #910

🤖 Generated with [Claude Code](https://claude.com/claude-code)