### PR TITLE
Fix #913: i/revoke-token も dual lookup + cache invalidation 化

### DIFF
--- a/internal/api/i/apps.go
+++ b/internal/api/i/apps.go
@@ -145,41 +145,32 @@ func (h *Handler) RevokeToken(c echo.Context) error {
 	if req.TokenID == "" && req.Token == "" {
 		return apierr.JSONInvalidParam(c)
 	}
-	var tokenID, rawToken string
+	var tok *model.AccessToken
+	var err error
 	if req.TokenID != "" {
-		tok, err := h.accessTokenRepo.FindByID(req.TokenID)
-		if err != nil {
-			return c.NoContent(http.StatusNoContent)
-		}
-		if tok.UserID != u.ID {
-			return apierr.JSONAccessDenied(c)
-		}
-		tokenID = tok.ID
-		rawToken = tok.Token
+		tok, err = h.accessTokenRepo.FindByID(req.TokenID)
 	} else {
 		// hash 列 (miauth: sha256(token)) と token 列 (raw, app/auth) を 1 query
 		// で OR 検索する。middleware と同じ pattern (#910 / #913)。これにより
 		// app/auth flow で発行された access token も raw token 文字列で revoke
 		// できる。
 		hash := fmt.Sprintf("%x", sha256.Sum256([]byte(req.Token)))
-		tok, err := h.accessTokenRepo.FindByHashOrToken(hash, req.Token)
-		if err != nil {
-			return c.NoContent(http.StatusNoContent)
-		}
-		if tok.UserID != u.ID {
-			return apierr.JSONAccessDenied(c)
-		}
-		tokenID = tok.ID
-		rawToken = tok.Token
+		tok, err = h.accessTokenRepo.FindByHashOrToken(hash, req.Token)
 	}
-	if err := h.accessTokenRepo.DeleteByID(tokenID); err != nil {
+	if err != nil {
+		return c.NoContent(http.StatusNoContent)
+	}
+	if tok.UserID != u.ID {
+		return apierr.JSONAccessDenied(c)
+	}
+	if err := h.accessTokenRepo.DeleteByID(tok.ID); err != nil {
 		return apierr.JSONInternalError(c)
 	}
 	// auth middleware の token cache に entry が残っていると revoke の効果が
-	// 30 秒 (= cache TTL) 遅延して、上流互換ではなくなる。regenerate-token
-	// と同じく invalidator が wire されている場合は即時削除する。
-	if h.authInvalidator != nil && rawToken != "" {
-		h.authInvalidator.InvalidateToken(rawToken)
+	// cache TTL (= 30 秒) 遅延して上流互換でなくなるため、regenerate-token
+	// (#884) と同じく invalidator が wire されている場合は即時削除する。
+	if h.authInvalidator != nil && tok.Token != "" {
+		h.authInvalidator.InvalidateToken(tok.Token)
 	}
 	return c.NoContent(http.StatusNoContent)
 }

--- a/internal/api/i/apps.go
+++ b/internal/api/i/apps.go
@@ -145,7 +145,7 @@ func (h *Handler) RevokeToken(c echo.Context) error {
 	if req.TokenID == "" && req.Token == "" {
 		return apierr.JSONInvalidParam(c)
 	}
-	var tokenID string
+	var tokenID, rawToken string
 	if req.TokenID != "" {
 		tok, err := h.accessTokenRepo.FindByID(req.TokenID)
 		if err != nil {
@@ -155,10 +155,14 @@ func (h *Handler) RevokeToken(c echo.Context) error {
 			return apierr.JSONAccessDenied(c)
 		}
 		tokenID = tok.ID
+		rawToken = tok.Token
 	} else {
-		// DBはSHA-256ハッシュを格納しているため、生tokenをハッシュ化して検索
+		// hash 列 (miauth: sha256(token)) と token 列 (raw, app/auth) を 1 query
+		// で OR 検索する。middleware と同じ pattern (#910 / #913)。これにより
+		// app/auth flow で発行された access token も raw token 文字列で revoke
+		// できる。
 		hash := fmt.Sprintf("%x", sha256.Sum256([]byte(req.Token)))
-		tok, err := h.accessTokenRepo.FindByHash(hash)
+		tok, err := h.accessTokenRepo.FindByHashOrToken(hash, req.Token)
 		if err != nil {
 			return c.NoContent(http.StatusNoContent)
 		}
@@ -166,9 +170,16 @@ func (h *Handler) RevokeToken(c echo.Context) error {
 			return apierr.JSONAccessDenied(c)
 		}
 		tokenID = tok.ID
+		rawToken = tok.Token
 	}
 	if err := h.accessTokenRepo.DeleteByID(tokenID); err != nil {
 		return apierr.JSONInternalError(c)
+	}
+	// auth middleware の token cache に entry が残っていると revoke の効果が
+	// 30 秒 (= cache TTL) 遅延して、上流互換ではなくなる。regenerate-token
+	// と同じく invalidator が wire されている場合は即時削除する。
+	if h.authInvalidator != nil && rawToken != "" {
+		h.authInvalidator.InvalidateToken(rawToken)
 	}
 	return c.NoContent(http.StatusNoContent)
 }

--- a/internal/api/i/apps_test.go
+++ b/internal/api/i/apps_test.go
@@ -179,6 +179,59 @@ func TestRevokeToken_ByTokenHash(t *testing.T) {
 	assert.Equal(t, http.StatusNoContent, rec.Code)
 }
 
+// TestRevokeToken_ByRawTokenForAppIssuedToken は #913 drift fix の
+// regression guard: app/auth flow で発行された access token は
+// hash = sha256(token + app.secret) で保存されているため、middleware と
+// 同じく raw token 列の OR fallback でしか resolve できない。
+// FindByHashOrToken に切替後は raw token で revoke できる。
+func TestRevokeToken_ByRawTokenForAppIssuedToken(t *testing.T) {
+	h, _ := newExtraHandler(t)
+	repo := testutil.NewMockAccessTokenRepository()
+	rawToken := "raw_app_xyz"
+	// hash は sha256(token + secret) で raw token とは別値。SHA-256(rawToken)
+	// だけでは hit しないので、token 列 fallback でのみ resolve できる shape。
+	hashWithSecret := "hash_app_with_secret_value"
+	repo.Tokens[hashWithSecret] = &model.AccessToken{
+		ID:     "at_app_1",
+		Token:  rawToken,
+		Hash:   hashWithSecret,
+		UserID: stubUser.ID,
+	}
+	h.SetAccessTokenRepo(repo)
+	inv := &stubTokenInvalidator{}
+	h.SetAuthInvalidator(inv)
+
+	rec := postExtra(h.RevokeToken, `{"token":"`+rawToken+`"}`, stubUser)
+	assert.Equal(t, http.StatusNoContent, rec.Code)
+	_, err := repo.FindByID("at_app_1")
+	assert.Error(t, err, "token should be deleted after revoke")
+	// auth middleware の cache に残ると revoke の効果が遅延する。
+	// invalidator が raw token で呼ばれていることを確認 (= drop-in 互換)。
+	require.Equal(t, []string{rawToken}, inv.calls)
+}
+
+// TestRevokeToken_InvalidatorByTokenIDPath は tokenId 経由の revoke でも
+// cache invalidation が走ることを確認 (= miauth 経路 / app 経路の両方で
+// stale cache を残さない)。
+func TestRevokeToken_InvalidatorByTokenIDPath(t *testing.T) {
+	h, _ := newExtraHandler(t)
+	repo := testutil.NewMockAccessTokenRepository()
+	rawToken := "raw_byid_xyz"
+	repo.Tokens["h_byid"] = &model.AccessToken{
+		ID:     "at_byid_1",
+		Token:  rawToken,
+		Hash:   "h_byid",
+		UserID: stubUser.ID,
+	}
+	h.SetAccessTokenRepo(repo)
+	inv := &stubTokenInvalidator{}
+	h.SetAuthInvalidator(inv)
+
+	rec := postExtra(h.RevokeToken, `{"tokenId":"at_byid_1"}`, stubUser)
+	assert.Equal(t, http.StatusNoContent, rec.Code)
+	require.Equal(t, []string{rawToken}, inv.calls)
+}
+
 func TestRevokeToken_NoParams(t *testing.T) {
 	h, _ := newExtraHandler(t)
 	h.SetAccessTokenRepo(testutil.NewMockAccessTokenRepository())

--- a/tests/playwright/specs/i/revoke_token.spec.ts
+++ b/tests/playwright/specs/i/revoke_token.spec.ts
@@ -1,0 +1,75 @@
+// #913: i/revoke-token の round-trip。app/auth flow で発行された access token も
+// raw token 文字列で revoke できることを確認する drop-in compat regression
+// guard。
+//
+// upstream Misskey TS と mk-go は両方とも:
+//   1. app/create + auth/session/generate + accept + userkey で access token を取得
+//   2. /api/i/revoke-token { token: <raw> } で raw token 経由で失効
+//   3. revoke 後にその token で /api/i を叩くと 401
+//
+// mk-go は #913 fix 前は raw token を sha256 して hash 列だけで lookup して
+// いたため、auth/accept (= hash = sha256(token + app.secret)) で発行した
+// token は raw 経由で revoke できなかった drift がある。fix 後は middleware
+// と同じ FindByHashOrToken で hash / token 両列を OR 検索する。
+
+import { expect, test } from '@playwright/test';
+import { callApi } from '../../fixtures/api';
+import { randomUsername, signupUser } from '../../fixtures/auth';
+import { resetRateLimit } from '../../fixtures/rate_limit';
+
+test.describe('i/revoke-token raw-token round-trip', () => {
+  test.beforeAll(() => {
+    resetRateLimit();
+  });
+
+  test('revoke app-issued access token by raw token', async ({ request }) => {
+    const me = await signupUser(request, randomUsername('rvk'));
+    const appName = `spec_rvk_${Math.random().toString(16).slice(2, 8)}`;
+
+    // app + auth/session で access token を取得 (= #834 spec と同じ flow)
+    const createResp = await callApi(request, 'app/create', {
+      i: me.token,
+      name: appName,
+      description: 'spec revoke',
+      permission: ['read:account'],
+      callbackUrl: 'https://example.com/cb',
+    });
+    expect(createResp.status()).toBe(200);
+    const { secret } = (await createResp.json()) as { secret: string };
+
+    const sessionResp = await callApi(request, 'auth/session/generate', {
+      appSecret: secret,
+    });
+    expect(sessionResp.status()).toBe(200);
+    const { token: sessionToken } = (await sessionResp.json()) as { token: string };
+
+    const acceptResp = await callApi(request, 'auth/accept', {
+      i: me.token,
+      token: sessionToken,
+    });
+    expect([200, 204]).toContain(acceptResp.status());
+
+    const userkeyResp = await callApi(request, 'auth/session/userkey', {
+      appSecret: secret,
+      token: sessionToken,
+    });
+    expect(userkeyResp.status()).toBe(200);
+    const { accessToken } = (await userkeyResp.json()) as { accessToken: string };
+    expect(typeof accessToken).toBe('string');
+
+    // 取得 token で /api/i が叩ける = 認証成功
+    const beforeRevoke = await callApi(request, 'i', { i: accessToken });
+    expect(beforeRevoke.status()).toBe(200);
+
+    // raw token 文字列で revoke (= drift があった経路)
+    const revokeResp = await callApi(request, 'i/revoke-token', {
+      i: me.token,
+      token: accessToken,
+    });
+    expect([200, 204]).toContain(revokeResp.status());
+
+    // revoke 後は 401 = 失効が反映されている
+    const afterRevoke = await callApi(request, 'i', { i: accessToken });
+    expect(afterRevoke.status()).toBe(401);
+  });
+});


### PR DESCRIPTION
## Summary

#910 sibling drift。\`i/revoke-token\` は raw token を sha256 して \`hash\` 列だけで lookup していたため、\`auth/accept\` で発行された token (\`hash = sha256(token + app.secret)\`) を raw token 文字列で revoke できなかった。同時に auth middleware の token cache が残ると revoke の効果が cache TTL (= 30 秒) 遅延する drift も発見、まとめて fix。

## 主な変更点

\`internal/api/i/apps.go::RevokeToken\`:
- \`FindByHash\` → \`FindByHashOrToken\` (#912 で追加した dual lookup を re-use)。\`hash\` 列 OR \`token\` 列で resolve。
- \`DeleteByID\` 後に \`authInvalidator.InvalidateToken(rawToken)\` を呼ぶ。\`tokenId\` 経路 / raw token 経路の両方で auth middleware の cache を即時削除し、\`regenerate-token\` (#884) と同じ pattern に揃える。

## Regression guard (3-layer)

- **unit** (\`internal/api/i/apps_test.go\`):
  - \`TestRevokeToken_ByRawTokenForAppIssuedToken\` — #913 本体。app token を raw 経由で revoke + cache 削除を確認。
  - \`TestRevokeToken_InvalidatorByTokenIDPath\` — \`tokenId\` 経路でも cache invalidation が走ること。
- **e2e** (\`tests/playwright/specs/i/revoke_token.spec.ts\`):
  app/auth flow → \`/api/i\` 200 → revoke → \`/api/i\` 401 の full round-trip を両 backend で verify。

## テスト

\`\`\`
$ go test -race -count=1 -coverprofile=cov.out ./internal/api/i
ok internal/api/i  91.7%  (+0.1pp)
\`\`\`

Playwright (両 backend):

\`\`\`
mk-go: ✓ specs/i/revoke_token.spec.ts ... revoke app-issued token by raw token (282ms)
TS:    ✓ specs/i/revoke_token.spec.ts ... revoke app-issued token by raw token (215ms)
\`\`\`

## Closes

Closes #913

🤖 Generated with [Claude Code](https://claude.com/claude-code)