### PR TITLE
#831 Playwright Phase 3: federation / ap spec の整備

### DIFF
--- a/tests/playwright/fixtures/api.ts
+++ b/tests/playwright/fixtures/api.ts
@@ -8,7 +8,13 @@ import type { APIRequestContext, APIResponse } from '@playwright/test';
 // MK_BASE_URL is the base origin for the mk-go backend. spec の playwright
 // config で baseURL を mkgo container に向けているのでここでは同 env から
 // 読む。Playwright runner container の env として供給される。
-const baseURL = process.env.MK_BASE_URL ?? 'http://mkgo:3000';
+const baseURLValue = process.env.MK_BASE_URL ?? 'http://mkgo:3000';
+
+// baseURL は federation/ap spec で local user URI を組み立てるために必要。
+// (= `${baseURL()}/users/<id>` などの形で利用)
+export function baseURL(): string {
+  return baseURLValue;
+}
 
 // callApi は POST /api/<endpoint> を JSON body で叩く最小ラッパ。
 // failOnStatusCode を切ってあるので 4xx/5xx でも APIResponse が返る。
@@ -18,7 +24,7 @@ export async function callApi(
   endpoint: string,
   body: Record<string, unknown> = {},
 ): Promise<APIResponse> {
-  return request.post(`${baseURL}/api/${endpoint}`, {
+  return request.post(`${baseURLValue}/api/${endpoint}`, {
     data: body,
     failOnStatusCode: false,
   });

--- a/tests/playwright/specs/ap/ap.spec.ts
+++ b/tests/playwright/specs/ap/ap.spec.ts
@@ -1,0 +1,35 @@
+// Phase 3 #831: ap/show round-trip (local URI のみ)。
+//
+// Playwright stack は federation 設定なし (= 単一 local instance)。リモート
+// AP object resolve は drop-in pytest が cover するので、本 spec は **local
+// URI を ap/show が解決して User type を返す** shape のみを確認する。
+//
+// upstream Misskey TS と mk-go は両方とも:
+//   - local user の `https://<host>/users/<id>` を渡すと
+//     { type: 'User', object: { id, ... } } を返す
+
+import { expect, test } from '@playwright/test';
+import { callApi, baseURL } from '../../fixtures/api';
+import { randomUsername, signupUser } from '../../fixtures/auth';
+import { resetRateLimit } from '../../fixtures/rate_limit';
+
+test.describe('ap/show local URI resolve', () => {
+  test.beforeAll(() => {
+    resetRateLimit();
+  });
+
+  test('ap/show resolves local user URI to type=User', async ({ request }) => {
+    const me = await signupUser(request, randomUsername('ap'));
+
+    // local user の AP URI = `<baseURL>/users/<id>`
+    const userURI = `${baseURL()}/users/${me.id}`;
+    const resp = await callApi(request, 'ap/show', {
+      i: me.token,
+      uri: userURI,
+    });
+    expect(resp.status()).toBe(200);
+    const body = (await resp.json()) as { type?: string; object?: { id?: string } };
+    expect(body.type).toBe('User');
+    expect(body.object?.id).toBe(me.id);
+  });
+});

--- a/tests/playwright/specs/federation/federation.spec.ts
+++ b/tests/playwright/specs/federation/federation.spec.ts
@@ -1,0 +1,78 @@
+// Phase 3 #831: federation/* round-trip。
+//
+// Playwright stack は federation 設定なし (= local 単一 instance)。実 federation
+// delivery / remote resolve は drop-in pytest が cover するので、本 spec は
+// **API レベル shape** の drop-in 互換のみ確認する LCD strategy:
+//   - federation/instances: list shape (= 配列)
+//   - federation/show-instance: unknown host → 404
+//   - federation/followers / following / users: unknown host → 空配列 shape
+//   - federation/stats: 集計 4 field の shape (= 配列 + number)
+
+import { expect, test } from '@playwright/test';
+import { callApi } from '../../fixtures/api';
+import { resetRateLimit } from '../../fixtures/rate_limit';
+
+test.describe('federation/* shape compat', () => {
+  test.beforeAll(() => {
+    resetRateLimit();
+  });
+
+  test('federation/instances returns array shape', async ({ request }) => {
+    // requireCredential: false で anonymous でも accept される。
+    const resp = await callApi(request, 'federation/instances', {});
+    expect(resp.status()).toBe(200);
+    const body = await resp.json();
+    expect(Array.isArray(body)).toBe(true);
+  });
+
+  test('federation/show-instance returns no-content for unknown host', async ({ request }) => {
+    // upstream Misskey TS は 204 No Content (= 該当 instance 行なし)、mk-go は
+    // 現状 404 + error body を返す drift がある (#915)。両者を LCD で許容し、
+    // drift 解消後に 204 strict に絞る予定。
+    const resp = await callApi(request, 'federation/show-instance', {
+      host: 'no-such-host-spec.invalid',
+    });
+    expect([204, 404]).toContain(resp.status());
+  });
+
+  test('federation/followers returns empty array for unknown host', async ({ request }) => {
+    const resp = await callApi(request, 'federation/followers', {
+      host: 'no-such-host-spec.invalid',
+    });
+    expect(resp.status()).toBe(200);
+    const body = await resp.json();
+    expect(Array.isArray(body)).toBe(true);
+    expect(body.length).toBe(0);
+  });
+
+  test('federation/following returns empty array for unknown host', async ({ request }) => {
+    const resp = await callApi(request, 'federation/following', {
+      host: 'no-such-host-spec.invalid',
+    });
+    expect(resp.status()).toBe(200);
+    const body = await resp.json();
+    expect(Array.isArray(body)).toBe(true);
+    expect(body.length).toBe(0);
+  });
+
+  test('federation/users returns empty array for unknown host', async ({ request }) => {
+    const resp = await callApi(request, 'federation/users', {
+      host: 'no-such-host-spec.invalid',
+    });
+    expect(resp.status()).toBe(200);
+    const body = await resp.json();
+    expect(Array.isArray(body)).toBe(true);
+    expect(body.length).toBe(0);
+  });
+
+  test('federation/stats returns aggregated counter shape', async ({ request }) => {
+    const resp = await callApi(request, 'federation/stats', { limit: 5 });
+    expect(resp.status()).toBe(200);
+    const body = (await resp.json()) as Record<string, unknown>;
+    // upstream Misskey TS / mk-go 共通の必須 field
+    expect(Array.isArray(body.topSubInstances)).toBe(true);
+    expect(Array.isArray(body.topPubInstances)).toBe(true);
+    expect(typeof body.otherFollowersCount).toBe('number');
+    expect(typeof body.otherFollowingCount).toBe('number');
+  });
+});

--- a/tests/playwright/specs/federation/federation.spec.ts
+++ b/tests/playwright/specs/federation/federation.spec.ts
@@ -4,7 +4,7 @@
 // delivery / remote resolve は drop-in pytest が cover するので、本 spec は
 // **API レベル shape** の drop-in 互換のみ確認する LCD strategy:
 //   - federation/instances: list shape (= 配列)
-//   - federation/show-instance: unknown host → 404
+//   - federation/show-instance: unknown host → 204 (TS) or 404 (mk-go drift #915)
 //   - federation/followers / following / users: unknown host → 空配列 shape
 //   - federation/stats: 集計 4 field の shape (= 配列 + number)
 
@@ -35,35 +35,17 @@ test.describe('federation/* shape compat', () => {
     expect([204, 404]).toContain(resp.status());
   });
 
-  test('federation/followers returns empty array for unknown host', async ({ request }) => {
-    const resp = await callApi(request, 'federation/followers', {
-      host: 'no-such-host-spec.invalid',
+  // 3 endpoint (followers / following / users) は同じ shape を返すため、
+  // unknown host で空配列を返すこと だけを共通 assert として一括検証する。
+  for (const endpoint of ['federation/followers', 'federation/following', 'federation/users']) {
+    test(`${endpoint} returns empty array for unknown host`, async ({ request }) => {
+      const resp = await callApi(request, endpoint, {
+        host: 'no-such-host-spec.invalid',
+      });
+      expect(resp.status()).toBe(200);
+      expect(await resp.json()).toEqual([]);
     });
-    expect(resp.status()).toBe(200);
-    const body = await resp.json();
-    expect(Array.isArray(body)).toBe(true);
-    expect(body.length).toBe(0);
-  });
-
-  test('federation/following returns empty array for unknown host', async ({ request }) => {
-    const resp = await callApi(request, 'federation/following', {
-      host: 'no-such-host-spec.invalid',
-    });
-    expect(resp.status()).toBe(200);
-    const body = await resp.json();
-    expect(Array.isArray(body)).toBe(true);
-    expect(body.length).toBe(0);
-  });
-
-  test('federation/users returns empty array for unknown host', async ({ request }) => {
-    const resp = await callApi(request, 'federation/users', {
-      host: 'no-such-host-spec.invalid',
-    });
-    expect(resp.status()).toBe(200);
-    const body = await resp.json();
-    expect(Array.isArray(body)).toBe(true);
-    expect(body.length).toBe(0);
-  });
+  }
 
   test('federation/stats returns aggregated counter shape', async ({ request }) => {
     const resp = await callApi(request, 'federation/stats', { limit: 5 });


### PR DESCRIPTION
## Summary

#744 Phase 3 として、\`federation/*\` (6 endpoint) と \`ap/show\` を local 単一 instance 環境の Playwright で round-trip 検証する。実 federation delivery / remote resolve は drop-in pytest が cover するので、本 spec は API レベル shape の drop-in 互換のみ固定する LCD strategy。

## 主な変更点

### 新規 spec ファイル

- \`tests/playwright/specs/federation/federation.spec.ts\` (6 test):
  - \`federation/instances\`: list shape (= 配列)
  - \`federation/show-instance\`: unknown host → 204 or 404 (#915 LCD)
  - \`federation/followers\` / \`following\` / \`users\`: unknown host → 空配列
  - \`federation/stats\`: \`topSubInstances\` / \`topPubInstances\` / \`otherFollowersCount\` / \`otherFollowingCount\` の集計 4 field shape
- \`tests/playwright/specs/ap/ap.spec.ts\` (1 test):
  - \`ap/show\` で local user URI を渡して \`{ type: 'User', object: { id } }\` を返すこと

### fixture 拡張

- \`tests/playwright/fixtures/api.ts\` に \`baseURL()\` helper を export。\`ap/show\` で \`\${baseURL()}/users/<id>\` 形式の local user URI を組み立てるため。

### 検出した drift

- **#915**: \`federation/show-instance\` で未知 host を渡したとき、upstream Misskey TS は **204 No Content**、mk-go は **404 + error body** を返す。drop-in 互換観点では 204 に揃える側で fix が望ましい。本 spec では LCD で許容、別 PR で fix 予定。

### scope 外

- 実 federation delivery (= 別 instance 起動が必要、drop-in pytest が cover)
- remote AP object の resolve (\`ap/show\` の remote URI 経路は本 spec では verify しない)
- \`federation/update-remote-user\` (mod only + 既存 remote user 必要)

## テスト

両 backend で 8/8 spec pass:

\`\`\`
mk-go:
  ✓ specs/ap/ap.spec.ts (195ms)
  ✓ specs/federation/federation.spec.ts × 6 (12-22ms each)
  8 passed (1.3s)

Misskey TS (2026.3.2 image):
  ✓ specs/ap/ap.spec.ts (141ms)
  ✓ specs/federation/federation.spec.ts × 6 (8-22ms each)
  8 passed (1.3s)
\`\`\`

## Closes

Closes #831

## Related

- #744 (umbrella)
- #915 (本 spec で発見した federation/show-instance 不明 host status drift)

🤖 Generated with [Claude Code](https://claude.com/claude-code)