### PR TITLE
#832 Playwright Phase 3: sw/* (push subscription) spec の整備

### DIFF
--- a/tests/playwright/specs/sw/sw.spec.ts
+++ b/tests/playwright/specs/sw/sw.spec.ts
@@ -1,0 +1,126 @@
+// Phase 3 #832: sw/* (service worker push subscription) round-trip。
+//
+// upstream Misskey TS と mk-go は両方とも:
+//   - sw/register: { endpoint, auth, publickey, sendReadMessage } で
+//     subscription を作成 → { state: 'subscribed', userId, endpoint, ... }
+//   - sw/show-registration: { endpoint } で取得 → 該当 row なしなら null
+//   - sw/update-registration: sendReadMessage を切替
+//   - sw/unregister: 削除 (auth 不要)
+//
+// 実 push 配信は browser-side / push server 必要なので scope 外。本 spec は
+// CRUD round-trip の shape 整合のみ verify する。
+
+import { expect, test } from '@playwright/test';
+import { callApi } from '../../fixtures/api';
+import { randomUsername, signupUser } from '../../fixtures/auth';
+import { resetRateLimit } from '../../fixtures/rate_limit';
+
+test.describe('sw/* push subscription round-trip', () => {
+  test.beforeAll(() => {
+    resetRateLimit();
+  });
+
+  test('register / show / update / unregister round-trip', async ({ request }) => {
+    const me = await signupUser(request, randomUsername('sw'));
+    // dummy push endpoint + key (= 実 VAPID 検証は backend で行わないので、
+    // 構造化された non-empty string を入れれば shape 互換 verify には十分)。
+    const endpoint = `https://push.example.test/${Math.random().toString(16).slice(2, 10)}`;
+    const auth = 'spec-auth-key';
+    const publickey = 'spec-publickey-base64url';
+
+    // 1. register
+    const regResp = await callApi(request, 'sw/register', {
+      i: me.token,
+      endpoint,
+      auth,
+      publickey,
+      sendReadMessage: false,
+    });
+    expect(regResp.status()).toBe(200);
+    const regBody = (await regResp.json()) as {
+      state?: string;
+      userId?: string;
+      endpoint?: string;
+      sendReadMessage?: boolean;
+    };
+    expect(regBody.state).toBe('subscribed');
+    expect(regBody.userId).toBe(me.id);
+    expect(regBody.endpoint).toBe(endpoint);
+    expect(regBody.sendReadMessage).toBe(false);
+
+    // 2. show-registration: 同 endpoint で取得
+    const showResp = await callApi(request, 'sw/show-registration', {
+      i: me.token,
+      endpoint,
+    });
+    expect(showResp.status()).toBe(200);
+    const showBody = (await showResp.json()) as {
+      userId?: string;
+      endpoint?: string;
+      sendReadMessage?: boolean;
+    };
+    expect(showBody.userId).toBe(me.id);
+    expect(showBody.endpoint).toBe(endpoint);
+    expect(showBody.sendReadMessage).toBe(false);
+
+    // 3. update-registration: sendReadMessage を true に
+    const updResp = await callApi(request, 'sw/update-registration', {
+      i: me.token,
+      endpoint,
+      sendReadMessage: true,
+    });
+    expect(updResp.status()).toBe(200);
+    const updBody = (await updResp.json()) as { sendReadMessage?: boolean };
+    expect(updBody.sendReadMessage).toBe(true);
+
+    // 4. show 再取得で update 反映確認
+    const showAfter = await callApi(request, 'sw/show-registration', {
+      i: me.token,
+      endpoint,
+    });
+    expect(showAfter.status()).toBe(200);
+    const showAfterBody = (await showAfter.json()) as { sendReadMessage?: boolean };
+    expect(showAfterBody.sendReadMessage).toBe(true);
+
+    // 5. unregister: auth 不要 (= browser 側 deactivate でも叩ける)
+    const unregResp = await callApi(request, 'sw/unregister', {
+      endpoint,
+    });
+    expect([200, 204]).toContain(unregResp.status());
+
+    // 6. unregister 後の show は「該当 row なし」を意味する empty response。
+    // upstream Misskey TS は null return を 204 No Content に変換、mk-go は
+    // 200 + JSON null を返す drift がある (#918)。両者を LCD で許容、drift
+    // 解消後に 204 strict に絞る予定。
+    const showFinal = await callApi(request, 'sw/show-registration', {
+      i: me.token,
+      endpoint,
+    });
+    expect([200, 204]).toContain(showFinal.status());
+    if (showFinal.status() === 200) {
+      expect(await showFinal.json()).toBeNull();
+    }
+  });
+
+  test('register same endpoint twice returns already-subscribed', async ({ request }) => {
+    const me = await signupUser(request, randomUsername('sw2'));
+    const endpoint = `https://push.example.test/${Math.random().toString(16).slice(2, 10)}`;
+    const params = {
+      i: me.token,
+      endpoint,
+      auth: 'spec-auth-key',
+      publickey: 'spec-publickey-base64url',
+      sendReadMessage: false,
+    };
+
+    // 初回 register
+    const first = await callApi(request, 'sw/register', params);
+    expect(first.status()).toBe(200);
+    expect(((await first.json()) as { state?: string }).state).toBe('subscribed');
+
+    // 同 endpoint で再 register → already-subscribed
+    const second = await callApi(request, 'sw/register', params);
+    expect(second.status()).toBe(200);
+    expect(((await second.json()) as { state?: string }).state).toBe('already-subscribed');
+  });
+});

--- a/tests/playwright/specs/sw/sw.spec.ts
+++ b/tests/playwright/specs/sw/sw.spec.ts
@@ -10,6 +10,7 @@
 // 実 push 配信は browser-side / push server 必要なので scope 外。本 spec は
 // CRUD round-trip の shape 整合のみ verify する。
 
+import { randomUUID } from 'node:crypto';
 import { expect, test } from '@playwright/test';
 import { callApi } from '../../fixtures/api';
 import { randomUsername, signupUser } from '../../fixtures/auth';
@@ -24,7 +25,8 @@ test.describe('sw/* push subscription round-trip', () => {
     const me = await signupUser(request, randomUsername('sw'));
     // dummy push endpoint + key (= 実 VAPID 検証は backend で行わないので、
     // 構造化された non-empty string を入れれば shape 互換 verify には十分)。
-    const endpoint = `https://push.example.test/${Math.random().toString(16).slice(2, 10)}`;
+    // worker 並列化時の endpoint 衝突を避けるため UUID v4 で path を組む。
+    const endpoint = `https://push.example.test/${randomUUID()}`;
     const auth = 'spec-auth-key';
     const publickey = 'spec-publickey-base64url';
 
@@ -70,7 +72,15 @@ test.describe('sw/* push subscription round-trip', () => {
       sendReadMessage: true,
     });
     expect(updResp.status()).toBe(200);
-    const updBody = (await updResp.json()) as { sendReadMessage?: boolean };
+    const updBody = (await updResp.json()) as {
+      userId?: string;
+      endpoint?: string;
+      sendReadMessage?: boolean;
+    };
+    // upstream / mk-go 共通で全 3 field 返るので shape 互換を register / show と
+    // 同じ強度で verify する。
+    expect(updBody.userId).toBe(me.id);
+    expect(updBody.endpoint).toBe(endpoint);
     expect(updBody.sendReadMessage).toBe(true);
 
     // 4. show 再取得で update 反映確認
@@ -104,7 +114,7 @@ test.describe('sw/* push subscription round-trip', () => {
 
   test('register same endpoint twice returns already-subscribed', async ({ request }) => {
     const me = await signupUser(request, randomUsername('sw2'));
-    const endpoint = `https://push.example.test/${Math.random().toString(16).slice(2, 10)}`;
+    const endpoint = `https://push.example.test/${randomUUID()}`;
     const params = {
       i: me.token,
       endpoint,


### PR DESCRIPTION
## Summary

#744 Phase 3 として、\`sw/*\` (4 endpoint) の Playwright spec を整備し、両 backend (TS / mk-go) で push subscription 登録の drop-in 互換を担保する。実 push 配信 / browser-side service worker は scope 外、本 spec は CRUD round-trip の shape 整合のみ verify。

## 主な変更点

### 新規 spec ファイル

\`tests/playwright/specs/sw/sw.spec.ts\` (2 test):

1. **register / show / update / unregister round-trip** (= 主シナリオ):
   - 仮想の endpoint + auth + publickey で register → \`{ state: 'subscribed', userId, endpoint, sendReadMessage }\`
   - show-registration で取得整合性
   - update-registration で sendReadMessage 切替 → show 再取得で反映確認
   - unregister (auth 不要)
   - unregister 後の show が empty (= 該当行なし)
2. **register same endpoint twice returns already-subscribed**:
   同一 endpoint で再 register → \`state: 'already-subscribed'\`

### 検出した drift

- **#918**: \`sw/show-registration\` の null path で TS は **204 No Content**、mk-go は **200 + JSON null** を返す drift。upstream Endpoint base が null return → 204 に auto-convert する設計の差。本 spec では LCD 許容、別 PR で fix 予定。

### scope 外

- 実 push 配信 (= push server / VAPID 鍵対応の真の subscription、Phase 4 候補)
- service worker の install / activate (= browser-side、API spec とは別)

## テスト

両 backend で 2/2 spec pass:

\`\`\`
mk-go:
  ✓ register / show / update / unregister round-trip (237ms)
  ✓ register same endpoint twice returns already-subscribed (175ms)
  2 passed (1.3s)

Misskey TS (2026.3.2 image):
  ✓ register / show / update / unregister round-trip (198ms)
  ✓ register same endpoint twice returns already-subscribed (95ms)
  2 passed (1.1s)
\`\`\`

## Closes

Closes #832

## Related

- #744 (umbrella)
- #918 (本 spec で発見した sw/show-registration null path drift)

🤖 Generated with [Claude Code](https://claude.com/claude-code)