### PR TITLE
#837 PR-B Playwright Phase 3: reversi multiplayer spec の整備

### DIFF
--- a/tests/playwright/specs/reversi/multiplayer.spec.ts
+++ b/tests/playwright/specs/reversi/multiplayer.spec.ts
@@ -1,0 +1,82 @@
+// Phase 3 #837 PR-B: reversi multiplayer round-trip。
+//
+// upstream Misskey TS と mk-go は両方とも 2 user 間の reversi game state を
+// HTTP API で操作できる。本 spec は shape + status 互換に絞る LCD strategy:
+//
+//   - reversi/games: anonymous 可、completed game 一覧 (= 配列)
+//   - reversi/match: 招待を投函。upstream は 204 / mk-go は 200+body の
+//     drift がある (#898 wontfix、両 backend で `[200, 204]` 許容)
+//   - reversi/cancel-match: 自分の pending invitation を一括 cancel → 204
+//   - reversi/show-game: gameId 必須、unknown は 404
+//   - reversi/invitations: viewer 宛 pending 一覧 (= UserLite 配列)。
+//     cancel 後の cleanup は backend 間で挙動差あり (#899 wontfix)、本 spec
+//     では cancel 後の disappearance を strict-assert しない LCD 戦略。
+//
+// scope 外:
+//   - 実際の game state machine (= READY → playing → end)。WebSocket driven、
+//     spec scope を超える。surrender / verify も同じ理由でスキップ。
+
+import { randomUUID } from 'node:crypto';
+import { expect, test } from '@playwright/test';
+import { callApi } from '../../fixtures/api';
+import { randomUsername, signupUser } from '../../fixtures/auth';
+import { resetRateLimit } from '../../fixtures/rate_limit';
+
+test.describe('reversi/* multiplayer shape compat', () => {
+  test.beforeAll(() => {
+    resetRateLimit();
+  });
+
+  test('reversi/games returns array shape (anonymous)', async ({ request }) => {
+    const resp = await callApi(request, 'reversi/games', {});
+    expect(resp.status()).toBe(200);
+    expect(Array.isArray(await resp.json())).toBe(true);
+  });
+
+  test('reversi/show-game returns negative for unknown gameId', async ({ request }) => {
+    // 不明 gameId は negative response (= 4xx)。
+    //   - mk-go: 404 NO_SUCH_GAME
+    //   - upstream Misskey TS: paramDef で format: 'misskey:id' を要求し、
+    //     さらに Service.get 内で何らかの追加 validation があるため、
+    //     well-formed alphanumeric でも 400 を返すケースあり。
+    // どちらも frontend 側で「game not found」扱いの 4xx なので両方を許容。
+    const resp = await callApi(request, 'reversi/show-game', {
+      gameId: '9zzzzzzzzzzzzzzz',
+    });
+    expect([400, 404]).toContain(resp.status());
+  });
+
+  test('match → invitations → cancel-match round-trip', async ({ request }) => {
+    const inviter = await signupUser(request, randomUsername('rvi'));
+    const invitee = await signupUser(request, randomUsername('rvt'));
+
+    // 1. inviter が invitee を指名して match。
+    //    upstream は 204、mk-go は 200+body (#898 wontfix LCD)。
+    const matchResp = await callApi(request, 'reversi/match', {
+      i: inviter.token,
+      userId: invitee.id,
+    });
+    expect([200, 204]).toContain(matchResp.status());
+
+    // 2. invitee が invitations を引くと inviter が含まれる (= UserLite 配列)。
+    const invResp = await callApi(request, 'reversi/invitations', {
+      i: invitee.token,
+    });
+    expect(invResp.status()).toBe(200);
+    const inviters = (await invResp.json()) as { id: string; username: string }[];
+    expect(Array.isArray(inviters)).toBe(true);
+    const found = inviters.find((u) => u.id === inviter.id);
+    expect(found, 'invitee should see inviter in invitations').toBeDefined();
+    expect(found?.username).toBe(inviter.username);
+
+    // 3. inviter が cancel-match で自分の pending を取り下げ → 204。
+    const cancelResp = await callApi(request, 'reversi/cancel-match', {
+      i: inviter.token,
+    });
+    expect([200, 204]).toContain(cancelResp.status());
+    // cancel 後の invitations cleanup 挙動は backend 間で差あり (#899 wontfix):
+    //   - mk-go: row 削除 + Redis cleanup で即時消える
+    //   - TS:    Redis ZSET entry が残置されるので invitee 側からは依然として見える
+    // どちらの shape も「機能的には正しい」ので strict-assert はしない。
+  });
+});

--- a/tests/playwright/specs/reversi/multiplayer.spec.ts
+++ b/tests/playwright/specs/reversi/multiplayer.spec.ts
@@ -7,7 +7,7 @@
 //   - reversi/match: 招待を投函。upstream は 204 / mk-go は 200+body の
 //     drift がある (#898 wontfix、両 backend で `[200, 204]` 許容)
 //   - reversi/cancel-match: 自分の pending invitation を一括 cancel → 204
-//   - reversi/show-game: gameId 必須、unknown は 404
+//   - reversi/show-game: gameId 必須、unknown は 4xx (TS 400 / mk-go 404 LCD)
 //   - reversi/invitations: viewer 宛 pending 一覧 (= UserLite 配列)。
 //     cancel 後の cleanup は backend 間で挙動差あり (#899 wontfix)、本 spec
 //     では cancel 後の disappearance を strict-assert しない LCD 戦略。
@@ -16,7 +16,6 @@
 //   - 実際の game state machine (= READY → playing → end)。WebSocket driven、
 //     spec scope を超える。surrender / verify も同じ理由でスキップ。
 
-import { randomUUID } from 'node:crypto';
 import { expect, test } from '@playwright/test';
 import { callApi } from '../../fixtures/api';
 import { randomUsername, signupUser } from '../../fixtures/auth';
@@ -70,13 +69,15 @@ test.describe('reversi/* multiplayer shape compat', () => {
     expect(found?.username).toBe(inviter.username);
 
     // 3. inviter が cancel-match で自分の pending を取り下げ → 204。
+    //    両 backend ともに 204 No Content を返すので strict 化。
     const cancelResp = await callApi(request, 'reversi/cancel-match', {
       i: inviter.token,
     });
-    expect([200, 204]).toContain(cancelResp.status());
+    expect(cancelResp.status()).toBe(204);
     // cancel 後の invitations cleanup 挙動は backend 間で差あり (#899 wontfix):
     //   - mk-go: row 削除 + Redis cleanup で即時消える
     //   - TS:    Redis ZSET entry が残置されるので invitee 側からは依然として見える
-    // どちらの shape も「機能的には正しい」ので strict-assert はしない。
+    // どちらの shape も「機能的には正しい」ので strict-assert はしない (= no
+    // further assertion below)。
   });
 });


### PR DESCRIPTION
## Summary

#837 のうち PR-B (= reversi multiplayer) を整備。upstream Misskey TS と mk-go の \`reversi/*\` multiplayer endpoint の HTTP API shape 互換を Playwright で固定する。実 game state machine は WebSocket driven で spec scope を超えるため、shape + status の LCD strategy。

## 主な変更点

\`tests/playwright/specs/reversi/multiplayer.spec.ts\` (3 test):

1. **reversi/games returns array shape (anonymous)**: anonymous 可、completed game 一覧 (= 配列)
2. **reversi/show-game returns negative for unknown gameId**: 不明 gameId は両 backend ともに 4xx (= mk-go 404 NO_SUCH_GAME / TS 400 INVALID_PARAM の format 検証エラー)
3. **match → invitations → cancel-match round-trip**:
   - inviter が invitee を指名して match (= upstream 204 / mk-go 200+body の #898 wontfix 互換 LCD)
   - invitee の \`reversi/invitations\` で inviter が UserLite として見える
   - inviter が cancel-match で 204 を返す
   - cancel 後の invitations cleanup は backend 間で挙動差 (#899 wontfix) のため strict-assert なし

## scope 外

- 実 game state (start / move / end) は WebSocket 経由のため別 phase
- \`reversi/surrender\` (started game 必要) / \`reversi/verify\` (ended game 必要) は spec setup コスト過大、別 phase

## 既知 drift (LCD 許容)

- **#898**: \`reversi/match\` の return shape (TS 204 / mk-go 200+body) — wontfix 済、LCD で \`[200, 204]\`
- **#899**: \`reversi/cancel-match\` 後の invitations cleanup (mk-go 即削除 / TS 残置) — wontfix 済、cleanup を strict-assert しない

## テスト

両 backend で 3/3 spec pass:

\`\`\`
mk-go:
  ✓ reversi/games returns array shape (anonymous) (38ms)
  ✓ reversi/show-game returns negative for unknown gameId (9ms)
  ✓ match → invitations → cancel-match round-trip (199ms)
  3 passed (1.1s)

Misskey TS (2026.3.2 image):
  ✓ reversi/games returns array shape (anonymous) (40ms)
  ✓ reversi/show-game returns negative for unknown gameId (12ms)
  ✓ match → invitations → cancel-match round-trip (274ms)
  3 passed (1.1s)
\`\`\`

## Closes

Closes #837

## Related

- #744 (Phase 3 umbrella)
- #898 / #899 (本 spec で LCD 許容している既知 wontfix drift)

🤖 Generated with [Claude Code](https://claude.com/claude-code)