### PR TITLE
#744 Phase 4 PR-B: hashtags + roles + notifications control spec

### DIFF
--- a/tests/playwright/specs/hashtags/hashtags.spec.ts
+++ b/tests/playwright/specs/hashtags/hashtags.spec.ts
@@ -1,0 +1,64 @@
+// Phase 4 PR-B: hashtags/* shape spec。
+//
+// 5 endpoint すべて anonymous (= requireCredential: false)、shape verify のみ:
+//   - hashtags/list / search / trend: 配列
+//   - hashtags/show: 非存在 tag → 4xx or null (LCD)
+//   - hashtags/users: 非存在 tag → 空配列
+
+import { randomUUID } from 'node:crypto';
+import { expect, test } from '@playwright/test';
+import { callApi } from '../../fixtures/api';
+import { resetRateLimit } from '../../fixtures/rate_limit';
+
+test.describe('hashtags/* shape compat', () => {
+  test.beforeAll(() => {
+    resetRateLimit();
+  });
+
+  // upstream Misskey TS の paramDef は厳格で、hashtags/list は sort 必須、
+  // hashtags/users は tag + sort 必須、hashtags/show / users の tag は
+  // alphanumeric のみ accept する。両 backend で動く params で固定する。
+  const cleanTag = `spec${randomUUID().replace(/-/g, '')}`;
+
+  test('hashtags/list returns array shape', async ({ request }) => {
+    const resp = await callApi(request, 'hashtags/list', {
+      limit: 5,
+      sort: '+mentionedUsers',
+    });
+    expect(resp.status()).toBe(200);
+    expect(Array.isArray(await resp.json())).toBe(true);
+  });
+
+  test('hashtags/search returns array shape', async ({ request }) => {
+    const resp = await callApi(request, 'hashtags/search', {
+      query: 'spec',
+      limit: 5,
+    });
+    expect(resp.status()).toBe(200);
+    expect(Array.isArray(await resp.json())).toBe(true);
+  });
+
+  test('hashtags/trend returns array shape', async ({ request }) => {
+    const resp = await callApi(request, 'hashtags/trend', {});
+    expect(resp.status()).toBe(200);
+    expect(Array.isArray(await resp.json())).toBe(true);
+  });
+
+  test('hashtags/users returns empty array for unknown tag', async ({ request }) => {
+    const resp = await callApi(request, 'hashtags/users', {
+      tag: cleanTag,
+      sort: '+follower',
+      limit: 5,
+    });
+    expect(resp.status()).toBe(200);
+    expect(await resp.json()).toEqual([]);
+  });
+
+  test('hashtags/show returns negative for unknown tag', async ({ request }) => {
+    // upstream Misskey TS は tag の長さ / 形式を厳格に validate するため、
+    // 長い random string で 400 を返すケースあり。mk-go は post-lookup で
+    // 404 / 200+empty を返す。両方を 4xx 範囲で許容する LCD。
+    const resp = await callApi(request, 'hashtags/show', { tag: cleanTag });
+    expect([200, 204, 400, 404]).toContain(resp.status());
+  });
+});

--- a/tests/playwright/specs/hashtags/hashtags.spec.ts
+++ b/tests/playwright/specs/hashtags/hashtags.spec.ts
@@ -60,9 +60,10 @@ test.describe('hashtags/* shape compat', () => {
   });
 
   test('hashtags/show returns negative for unknown tag', async ({ request }) => {
-    // upstream Misskey TS は tag の長さ / 形式を厳格に validate するため、
-    // 長い random string で 400 を返すケースあり。mk-go は post-lookup で
-    // 404 / 200+empty を返す。両方を 4xx 範囲で許容する LCD。
+    // 実観測した backend 別 status:
+    //   - upstream Misskey TS: 400 (= paramDef tag length/format validation)
+    //   - mk-go: 200 (= 空集計 result) または 404 NO_SUCH_HASHTAG
+    // どちらも frontend 側で「not found」扱い。drift 詳細は #925。
     const resp = await callApi(request, 'hashtags/show', { tag: cleanTag });
     expect([200, 204, 400, 404]).toContain(resp.status());
   });

--- a/tests/playwright/specs/hashtags/hashtags.spec.ts
+++ b/tests/playwright/specs/hashtags/hashtags.spec.ts
@@ -4,6 +4,11 @@
 //   - hashtags/list / search / trend: 配列
 //   - hashtags/show: 非存在 tag → 4xx or null (LCD)
 //   - hashtags/users: 非存在 tag → 空配列
+//
+// 本 spec では papering over した drift が #925 として記録されている:
+// upstream は paramDef で sort 必須、tag 長さ validate を行うが mk-go は
+// permissive。両 backend が動く params (= sort 込み / 短い tag) を渡すこと
+// で spec 自体は両環境で pass するが、drop-in 互換性は厳密には完全ではない。
 
 import { randomUUID } from 'node:crypto';
 import { expect, test } from '@playwright/test';

--- a/tests/playwright/specs/notifications/control.spec.ts
+++ b/tests/playwright/specs/notifications/control.spec.ts
@@ -1,0 +1,49 @@
+// Phase 4 PR-B: notifications/* control endpoints (auth required)。
+// 既存 notifications/*.spec.ts が event 系 (= reaction / mention / follow 等の
+// 通知発生 path) を cover、本 spec は self-issued control endpoint を埋める:
+//
+//   - notifications/create: { body, header?, icon? } で自分宛 通知作成 → 204
+//   - notifications/flush: 全削除 → 204
+//   - notifications/test-notification: 連動 test 通知発火 → 204
+//   - notifications/mark-all-as-read: 既存 spec で 1 度 cover 済だが、ここでも
+//     state-less に再 hit (= idempotent)
+
+import { expect, test } from '@playwright/test';
+import { callApi } from '../../fixtures/api';
+import { randomUsername, signupUser } from '../../fixtures/auth';
+import { resetRateLimit } from '../../fixtures/rate_limit';
+
+test.describe('notifications/* control', () => {
+  test.beforeAll(() => {
+    resetRateLimit();
+  });
+
+  test('create / mark-all-as-read / test-notification / flush', async ({ request }) => {
+    const me = await signupUser(request, randomUsername('nc'));
+
+    // create で自分宛 notification を 1 件発生させる
+    const createResp = await callApi(request, 'notifications/create', {
+      i: me.token,
+      body: 'spec self-notification',
+    });
+    expect([200, 204]).toContain(createResp.status());
+
+    // mark-all-as-read → 204 (= 既存 spec と同 shape、idempotent)
+    const markResp = await callApi(request, 'notifications/mark-all-as-read', {
+      i: me.token,
+    });
+    expect([200, 204]).toContain(markResp.status());
+
+    // test-notification: server が test 通知を発火 → 204
+    const testResp = await callApi(request, 'notifications/test-notification', {
+      i: me.token,
+    });
+    expect([200, 204]).toContain(testResp.status());
+
+    // flush: 自分宛 notification を全削除 → 204
+    const flushResp = await callApi(request, 'notifications/flush', {
+      i: me.token,
+    });
+    expect([200, 204]).toContain(flushResp.status());
+  });
+});

--- a/tests/playwright/specs/roles/roles.spec.ts
+++ b/tests/playwright/specs/roles/roles.spec.ts
@@ -1,0 +1,43 @@
+// Phase 4 PR-B: roles/* (public 側) shape spec。admin/roles/* は別 (#826 で
+// cover 済)。本 spec は frontend が roles list / show / users / notes を
+// 叩く経路を verify する。
+//
+//   - roles/list (auth required): 配列
+//   - roles/show / users / notes: roleId 不明で 4xx (= reversi/show-game pattern)
+
+import { expect, test } from '@playwright/test';
+import { callApi } from '../../fixtures/api';
+import { randomUsername, signupUser } from '../../fixtures/auth';
+import { resetRateLimit } from '../../fixtures/rate_limit';
+
+test.describe('roles/* public shape compat', () => {
+  test.beforeAll(() => {
+    resetRateLimit();
+  });
+
+  test('roles/list returns array shape (auth required)', async ({ request }) => {
+    const me = await signupUser(request, randomUsername('rl'));
+    const resp = await callApi(request, 'roles/list', { i: me.token });
+    expect(resp.status()).toBe(200);
+    expect(Array.isArray(await resp.json())).toBe(true);
+  });
+
+  for (const endpoint of ['roles/show', 'roles/users']) {
+    test(`${endpoint} returns negative for unknown roleId`, async ({ request }) => {
+      // upstream paramDef format: 'misskey:id' で TS は 400、mk-go は post-lookup で 404。LCD。
+      const resp = await callApi(request, endpoint, {
+        roleId: '9zzzzzzzzzzzzzzz',
+      });
+      expect([400, 404]).toContain(resp.status());
+    });
+  }
+
+  test('roles/notes returns negative for unknown roleId (auth required)', async ({ request }) => {
+    const me = await signupUser(request, randomUsername('rln'));
+    const resp = await callApi(request, 'roles/notes', {
+      i: me.token,
+      roleId: '9zzzzzzzzzzzzzzz',
+    });
+    expect([400, 404]).toContain(resp.status());
+  });
+});

--- a/tests/playwright/specs/roles/roles.spec.ts
+++ b/tests/playwright/specs/roles/roles.spec.ts
@@ -1,6 +1,6 @@
-// Phase 4 PR-B: roles/* (public 側) shape spec。admin/roles/* は別 (#826 で
-// cover 済)。本 spec は frontend が roles list / show / users / notes を
-// 叩く経路を verify する。
+// Phase 4 PR-B: roles/* (public 側) shape spec。admin/roles/* は別 (PR #890
+// で cover 済 / #826 issue close)。本 spec は frontend が roles list / show
+// / users / notes を叩く経路を verify する。
 //
 //   - roles/list (auth required): 配列
 //   - roles/show / users / notes: roleId 不明で 4xx (= reversi/show-game pattern)


### PR DESCRIPTION
## Summary

Phase 4 の 2 本目。13 endpoint を 3 spec ファイルに分割して shape + status 互換 cover。

## 主な変更点

| spec | endpoint | test 数 |
|------|----------|---------|
| \`specs/hashtags/hashtags.spec.ts\` | list / search / trend / users / show | 5 |
| \`specs/roles/roles.spec.ts\` | list / show / users / notes (public 側、admin/roles は別) | 4 |
| \`specs/notifications/control.spec.ts\` | create / mark-all-as-read / test-notification / flush (1 round-trip) | 1 |

## 検出した drift

### #925 (新規起票): hashtags/* paramDef strictness drift

実は **drift あり**。本 spec では papering over しているが drop-in 互換性は完全ではない:

- **hashtags/list**: TS \`required: ['sort']\` / mk-go optional
- **hashtags/users**: TS \`required: ['tag', 'sort']\` / mk-go は \`tag\` のみ必須
- **hashtags/show**: TS は tag 長さ / 形式 validate (= 400) / mk-go は post-lookup (= 404 / empty)

frontend は upstream paramDef を満たすため実害は薄いが、mk-go の permissive 動作は drop-in 切替時に「TS で動かない自前 client」を生む可能性。本 PR は LCD で spec を pass させる対応、本格 fix は #925 で別途検討。

### negative test の LCD pattern

\`reversi/show-game\` (#922) / \`channels/show\` (#923) と同 pattern:
- TS: paramDef format pre-validation で 400
- mk-go: post-lookup で 404
- frontend は両方を「not found」扱いするため LCD 許容

## テスト

両 backend で 10/10 spec pass:

\`\`\`
mk-go:
  ✓ hashtags/* (5 tests)
  ✓ roles/* (4 tests)
  ✓ notifications/* control (1 round-trip)
  10 passed (1.6s)

Misskey TS (2026.3.2 image):
  10 passed (1.4s)
\`\`\`

## Coverage

endpoint coverage **39.5% → 42.5%** (+13 endpoint、累計 +29 endpoint from Phase 4 開始時)。

## Phase 4 全体計画

| PR | 領域 | 想定数 | status |
|---|---|---|---|
| PR-A | channels | 16 | ✅ #923 merged |
| **PR-B** | **hashtags + roles + notifications** (本 PR) | **13** | 🟢 review |
| PR-C | admin/queue + admin/abuse-report read | ~16 | 🟢 計画 |
| PR-D | admin/show + get-stats + ad / avatar / drive read | ~20 | 🟢 計画 |
| PR-E | admin/federation + captcha + announcements list 等 | ~15 | 🟢 計画 |
| PR-F | i/* 残 + chat 残 + 雑多 | ~25 | 🟢 計画 |

## Related

- #744 Phase 4 (umbrella)
- **#925** (本 spec で papering over した hashtags paramDef drift)

🤖 Generated with [Claude Code](https://claude.com/claude-code)