### PR TITLE
Fix #925 + #926: hashtags drift 解消 + channels LCD strict 化

### DIFF
--- a/internal/api/hashtags/handler.go
+++ b/internal/api/hashtags/handler.go
@@ -23,6 +23,16 @@ func NewHandler(db *gorm.DB) *Handler {
 	return &Handler{db: db}
 }
 
+// validListSorts は upstream Misskey TS hashtags/list paramDef enum と一致 (#925)。
+var validListSorts = map[string]struct{}{
+	"+mentionedUsers": {}, "-mentionedUsers": {},
+	"+mentionedLocalUsers": {}, "-mentionedLocalUsers": {},
+	"+mentionedRemoteUsers": {}, "-mentionedRemoteUsers": {},
+	"+attachedUsers": {}, "-attachedUsers": {},
+	"+attachedLocalUsers": {}, "-attachedLocalUsers": {},
+	"+attachedRemoteUsers": {}, "-attachedRemoteUsers": {},
+}
+
 // List handles POST /api/hashtags/list.
 func (h *Handler) List(c echo.Context) error {
 	var req struct {
@@ -34,6 +44,9 @@ func (h *Handler) List(c echo.Context) error {
 		// upstream Misskey TS は paramDef で sort を required にしている (#925)。
 		// mk-go も同 shape に揃え、permissive な挙動を弾く。
 		return c.JSON(http.StatusBadRequest, apierr.Error("INVALID_PARAM", "Invalid parameters.", "3d81ceae-475f-4600-b2a8-2bc116157532"))
+	}
+	if _, ok := validListSorts[req.Sort]; !ok {
+		return c.JSON(http.StatusBadRequest, apierr.Error("INVALID_PARAM", "sort must be one of upstream-defined enum.", "3d81ceae-475f-4600-b2a8-2bc116157532"))
 	}
 	if req.Limit <= 0 {
 		req.Limit = 10
@@ -89,8 +102,10 @@ func (h *Handler) Show(c echo.Context) error {
 	}
 	var tag model.Hashtag
 	if err := h.db.Where("name = ?", req.Tag).First(&tag).Error; err != nil {
-		// upstream Misskey TS は ApiError 既定動作で 400 + NO_SUCH_HASHTAG body
-		// を返す (#925)。404 ではなく 400 + 既定 error id にも揃える。
+		// HTTP semantics 的には not-found = 404 が望ましいが、upstream
+		// Misskey TS は ApiError の既定動作で 400 を返している (#925)。
+		// drop-in 互換を優先して 400 + NO_SUCH_HASHTAG body に揃える。
+		// error id も upstream と同じ ...c167b2e6981e に統一。
 		return c.JSON(http.StatusBadRequest, apierr.Error("NO_SUCH_HASHTAG", "No such hashtag.", "110ee688-193e-4a3a-9ecf-c167b2e6981e"))
 	}
 	return c.JSON(http.StatusOK, packTag(&tag))
@@ -247,6 +262,13 @@ func (h *Handler) Trend(c echo.Context) error {
 	return c.JSON(http.StatusOK, result)
 }
 
+// validUsersSorts は upstream Misskey TS hashtags/users paramDef enum と一致 (#925)。
+var validUsersSorts = map[string]struct{}{
+	"+follower": {}, "-follower": {},
+	"+createdAt": {}, "-createdAt": {},
+	"+updatedAt": {}, "-updatedAt": {},
+}
+
 // Users handles POST /api/hashtags/users.
 func (h *Handler) Users(c echo.Context) error {
 	var req struct {
@@ -257,6 +279,9 @@ func (h *Handler) Users(c echo.Context) error {
 	if err := c.Bind(&req); err != nil || req.Tag == "" || req.Sort == "" {
 		// upstream Misskey TS は paramDef で tag + sort を required にしている (#925)。
 		return c.JSON(http.StatusBadRequest, apierr.Error("INVALID_PARAM", "tag and sort are required.", "3d81ceae-475f-4600-b2a8-2bc116157532"))
+	}
+	if _, ok := validUsersSorts[req.Sort]; !ok {
+		return c.JSON(http.StatusBadRequest, apierr.Error("INVALID_PARAM", "sort must be one of upstream-defined enum.", "3d81ceae-475f-4600-b2a8-2bc116157532"))
 	}
 	// ハッシュタグを使ったユーザー一覧 (簡易版: 空配列)
 	return c.JSON(http.StatusOK, []any{})

--- a/internal/api/hashtags/handler.go
+++ b/internal/api/hashtags/handler.go
@@ -30,7 +30,9 @@ func (h *Handler) List(c echo.Context) error {
 		Sort   string `json:"sort"`
 		Offset int    `json:"offset"`
 	}
-	if err := c.Bind(&req); err != nil {
+	if err := c.Bind(&req); err != nil || req.Sort == "" {
+		// upstream Misskey TS は paramDef で sort を required にしている (#925)。
+		// mk-go も同 shape に揃え、permissive な挙動を弾く。
 		return c.JSON(http.StatusBadRequest, apierr.Error("INVALID_PARAM", "Invalid parameters.", "3d81ceae-475f-4600-b2a8-2bc116157532"))
 	}
 	if req.Limit <= 0 {
@@ -87,7 +89,9 @@ func (h *Handler) Show(c echo.Context) error {
 	}
 	var tag model.Hashtag
 	if err := h.db.Where("name = ?", req.Tag).First(&tag).Error; err != nil {
-		return c.JSON(http.StatusNotFound, apierr.Error("NO_SUCH_HASHTAG", "No such hashtag.", "110ee688-193e-4a3a-9ecf-c167234e6f7d"))
+		// upstream Misskey TS は ApiError 既定動作で 400 + NO_SUCH_HASHTAG body
+		// を返す (#925)。404 ではなく 400 + 既定 error id にも揃える。
+		return c.JSON(http.StatusBadRequest, apierr.Error("NO_SUCH_HASHTAG", "No such hashtag.", "110ee688-193e-4a3a-9ecf-c167b2e6981e"))
 	}
 	return c.JSON(http.StatusOK, packTag(&tag))
 }
@@ -247,10 +251,12 @@ func (h *Handler) Trend(c echo.Context) error {
 func (h *Handler) Users(c echo.Context) error {
 	var req struct {
 		Tag   string `json:"tag"`
+		Sort  string `json:"sort"`
 		Limit int    `json:"limit"`
 	}
-	if err := c.Bind(&req); err != nil || req.Tag == "" {
-		return c.JSON(http.StatusBadRequest, apierr.Error("INVALID_PARAM", "tag is required.", "3d81ceae-475f-4600-b2a8-2bc116157532"))
+	if err := c.Bind(&req); err != nil || req.Tag == "" || req.Sort == "" {
+		// upstream Misskey TS は paramDef で tag + sort を required にしている (#925)。
+		return c.JSON(http.StatusBadRequest, apierr.Error("INVALID_PARAM", "tag and sort are required.", "3d81ceae-475f-4600-b2a8-2bc116157532"))
 	}
 	// ハッシュタグを使ったユーザー一覧 (簡易版: 空配列)
 	return c.JSON(http.StatusOK, []any{})

--- a/internal/api/hashtags/handler_test.go
+++ b/internal/api/hashtags/handler_test.go
@@ -85,6 +85,12 @@ func TestList_SortRequired(t *testing.T) {
 	assert.Equal(t, http.StatusBadRequest, doPost(newHandler().List, `{}`).Code)
 }
 
+// TestList_SortEnum: upstream paramDef は sort を 12 値の enum 限定にしている。
+// mk-go も同 enum に絞り、未定義 sort 値で 400 を返す (#925 review nit)。
+func TestList_SortEnum(t *testing.T) {
+	assert.Equal(t, http.StatusBadRequest, doPost(newHandler().List, `{"sort":"bogus"}`).Code)
+}
+
 func TestList_DBError(t *testing.T) {
 	assert.Equal(t, http.StatusInternalServerError, doPost(brokenHandler().List, `{"sort":"+mentionedUsers"}`).Code)
 }
@@ -119,9 +125,10 @@ func TestShow_Found(t *testing.T) {
 	assert.Contains(t, rec.Body.String(), "rustlang")
 }
 
-// TestShow_NotFound: upstream Misskey TS は ApiError 既定動作で 400 +
-// NO_SUCH_HASHTAG body を返す (#925)。404 ではなく 400 に揃える。
-func TestShow_NotFound(t *testing.T) {
+// TestShow_BadRequestForUnknownTag: upstream Misskey TS は ApiError 既定動作
+// で 400 + NO_SUCH_HASHTAG body を返す (#925)。404 ではなく 400 に揃える。
+// HTTP semantics 的には 404 が自然だが drop-in 互換を優先する。
+func TestShow_BadRequestForUnknownTag(t *testing.T) {
 	assert.Equal(t, http.StatusBadRequest, doPost(newHandler().Show, `{"tag":"ghost"}`).Code)
 }
 
@@ -268,4 +275,10 @@ func TestUsers_InvalidParam(t *testing.T) {
 // required にしている。tag だけだと 400 (#925)。
 func TestUsers_SortRequired(t *testing.T) {
 	assert.Equal(t, http.StatusBadRequest, doPost(newHandler().Users, `{"tag":"test"}`).Code)
+}
+
+// TestUsers_SortEnum: upstream paramDef は sort を 6 値の enum 限定。
+// 未定義 sort で 400 を返すこと (#925 review nit)。
+func TestUsers_SortEnum(t *testing.T) {
+	assert.Equal(t, http.StatusBadRequest, doPost(newHandler().Users, `{"tag":"test","sort":"bogus"}`).Code)
 }

--- a/internal/api/hashtags/handler_test.go
+++ b/internal/api/hashtags/handler_test.go
@@ -55,32 +55,38 @@ func cleanup() {
 
 func TestList_Success(t *testing.T) {
 	cleanup()
-	assert.Equal(t, http.StatusOK, doPost(newHandler().List, `{}`).Code)
+	assert.Equal(t, http.StatusOK, doPost(newHandler().List, `{"sort":"+mentionedUsers"}`).Code)
 }
 
 func TestList_WithData(t *testing.T) {
 	cleanup()
 	testDB.Create(&model.Hashtag{ID: "ht1", Name: "golang", MentionedUsersCount: 5})
 	defer cleanup()
-	rec := doPost(newHandler().List, `{"limit":10}`)
+	rec := doPost(newHandler().List, `{"limit":10,"sort":"+mentionedUsers"}`)
 	assert.Equal(t, http.StatusOK, rec.Code)
 	assert.Contains(t, rec.Body.String(), "golang")
 }
 
 func TestList_WithOffset(t *testing.T) {
-	assert.Equal(t, http.StatusOK, doPost(newHandler().List, `{"limit":5,"offset":1}`).Code)
+	assert.Equal(t, http.StatusOK, doPost(newHandler().List, `{"limit":5,"offset":1,"sort":"+mentionedUsers"}`).Code)
 }
 
 func TestList_LimitCap(t *testing.T) {
-	assert.Equal(t, http.StatusOK, doPost(newHandler().List, `{"limit":999}`).Code)
+	assert.Equal(t, http.StatusOK, doPost(newHandler().List, `{"limit":999,"sort":"+mentionedUsers"}`).Code)
 }
 
 func TestList_InvalidJSON(t *testing.T) {
 	assert.Equal(t, http.StatusBadRequest, doPost(newHandler().List, `invalid`).Code)
 }
 
+// TestList_SortRequired: upstream Misskey TS は paramDef で sort を required
+// にしている。mk-go も同 shape に揃え、sort 抜きは 400 で弾く (#925)。
+func TestList_SortRequired(t *testing.T) {
+	assert.Equal(t, http.StatusBadRequest, doPost(newHandler().List, `{}`).Code)
+}
+
 func TestList_DBError(t *testing.T) {
-	assert.Equal(t, http.StatusInternalServerError, doPost(brokenHandler().List, `{}`).Code)
+	assert.Equal(t, http.StatusInternalServerError, doPost(brokenHandler().List, `{"sort":"+mentionedUsers"}`).Code)
 }
 
 // --- Search ---
@@ -113,8 +119,10 @@ func TestShow_Found(t *testing.T) {
 	assert.Contains(t, rec.Body.String(), "rustlang")
 }
 
+// TestShow_NotFound: upstream Misskey TS は ApiError 既定動作で 400 +
+// NO_SUCH_HASHTAG body を返す (#925)。404 ではなく 400 に揃える。
 func TestShow_NotFound(t *testing.T) {
-	assert.Equal(t, http.StatusNotFound, doPost(newHandler().Show, `{"tag":"ghost"}`).Code)
+	assert.Equal(t, http.StatusBadRequest, doPost(newHandler().Show, `{"tag":"ghost"}`).Code)
 }
 
 func TestShow_InvalidParam(t *testing.T) {
@@ -249,9 +257,15 @@ func TestTrend_VisibilityFilterExcludesPrivate(t *testing.T) {
 // --- Users ---
 
 func TestUsers_Success(t *testing.T) {
-	assert.Equal(t, http.StatusOK, doPost(newHandler().Users, `{"tag":"test"}`).Code)
+	assert.Equal(t, http.StatusOK, doPost(newHandler().Users, `{"tag":"test","sort":"+follower"}`).Code)
 }
 
 func TestUsers_InvalidParam(t *testing.T) {
 	assert.Equal(t, http.StatusBadRequest, doPost(newHandler().Users, `{}`).Code)
+}
+
+// TestUsers_SortRequired: upstream Misskey TS は paramDef で sort も
+// required にしている。tag だけだと 400 (#925)。
+func TestUsers_SortRequired(t *testing.T) {
+	assert.Equal(t, http.StatusBadRequest, doPost(newHandler().Users, `{"tag":"test"}`).Code)
 }

--- a/tests/playwright/specs/channels/channels.spec.ts
+++ b/tests/playwright/specs/channels/channels.spec.ts
@@ -98,7 +98,7 @@ test.describe('channels/* full round-trip', () => {
       i: me.token,
       channelId,
     });
-    expect([200, 204]).toContain(followResp.status());
+    expect(followResp.status()).toBe(204);
 
     // 8. followed で含まれる
     const followedResp = await callApi(request, 'channels/followed', {
@@ -130,7 +130,7 @@ test.describe('channels/* full round-trip', () => {
       i: me.token,
       channelId,
     });
-    expect([200, 204]).toContain(favResp.status());
+    expect(favResp.status()).toBe(204);
 
     const myFavResp = await callApi(request, 'channels/my-favorites', {
       i: me.token,
@@ -151,14 +151,14 @@ test.describe('channels/* full round-trip', () => {
       i: me.token,
       channelId,
     });
-    expect([200, 204]).toContain(unfavResp.status());
+    expect(unfavResp.status()).toBe(204);
 
     // 11. mute/create → mute/list → mute/delete
     const muteCreateResp = await callApi(request, 'channels/mute/create', {
       i: me.token,
       channelId,
     });
-    expect([200, 204]).toContain(muteCreateResp.status());
+    expect(muteCreateResp.status()).toBe(204);
 
     const muteListResp = await callApi(request, 'channels/mute/list', {
       i: me.token,
@@ -171,14 +171,14 @@ test.describe('channels/* full round-trip', () => {
       i: me.token,
       channelId,
     });
-    expect([200, 204]).toContain(muteDeleteResp.status());
+    expect(muteDeleteResp.status()).toBe(204);
 
     // 12. unfollow → 204
     const unfollowResp = await callApi(request, 'channels/unfollow', {
       i: me.token,
       channelId,
     });
-    expect([200, 204]).toContain(unfollowResp.status());
+    expect(unfollowResp.status()).toBe(204);
   });
 
   test('channels/show returns negative for unknown channelId', async ({ request }) => {

--- a/tests/playwright/specs/hashtags/hashtags.spec.ts
+++ b/tests/playwright/specs/hashtags/hashtags.spec.ts
@@ -2,13 +2,13 @@
 //
 // 5 endpoint すべて anonymous (= requireCredential: false)、shape verify のみ:
 //   - hashtags/list / search / trend: 配列
-//   - hashtags/show: 非存在 tag → 4xx or null (LCD)
+//   - hashtags/show: 非存在 tag → 400 + NO_SUCH_HASHTAG (= #925 fix で揃え)
 //   - hashtags/users: 非存在 tag → 空配列
 //
-// 本 spec では papering over した drift が #925 として記録されている:
-// upstream は paramDef で sort 必須、tag 長さ validate を行うが mk-go は
-// permissive。両 backend が動く params (= sort 込み / 短い tag) を渡すこと
-// で spec 自体は両環境で pass するが、drop-in 互換性は厳密には完全ではない。
+// #925 fix で mk-go を upstream 揃えに厳格化済:
+//   - hashtags/list: sort 必須
+//   - hashtags/users: tag + sort 必須
+//   - hashtags/show: 不明 tag は 400 NO_SUCH_HASHTAG (= ApiError 既定 status)
 
 import { randomUUID } from 'node:crypto';
 import { expect, test } from '@playwright/test';
@@ -59,12 +59,12 @@ test.describe('hashtags/* shape compat', () => {
     expect(await resp.json()).toEqual([]);
   });
 
-  test('hashtags/show returns negative for unknown tag', async ({ request }) => {
-    // 実観測した backend 別 status:
-    //   - upstream Misskey TS: 400 (= paramDef tag length/format validation)
-    //   - mk-go: 200 (= 空集計 result) または 404 NO_SUCH_HASHTAG
-    // どちらも frontend 側で「not found」扱い。drift 詳細は #925。
+  test('hashtags/show returns 400 NO_SUCH_HASHTAG for unknown tag', async ({ request }) => {
+    // 両 backend ともに 400 + NO_SUCH_HASHTAG body (= ApiError 既定 status、
+    // #925 fix で mk-go 揃え済)。
     const resp = await callApi(request, 'hashtags/show', { tag: cleanTag });
-    expect([200, 204, 400, 404]).toContain(resp.status());
+    expect(resp.status()).toBe(400);
+    const body = (await resp.json()) as { error?: { code?: string } };
+    expect(body.error?.code).toBe('NO_SUCH_HASHTAG');
   });
 });


### PR DESCRIPTION
## Summary

#925 (hashtags paramDef strictness drift) と #926 (Playwright spec LCD 緩和) を 1 PR で解消。

## #925: hashtags drift 解消

upstream Misskey TS の paramDef strictness に mk-go を揃える:

| endpoint | 旧 mk-go | 新 mk-go (= upstream 揃え) |
|---|---|---|
| \`hashtags/list\` | sort optional | sort required (400 INVALID_PARAM) |
| \`hashtags/users\` | tag のみ必須 | tag + sort 必須 |
| \`hashtags/show\` | 404 NO_SUCH_HASHTAG | 400 NO_SUCH_HASHTAG (= ApiError 既定 status) |

\`hashtags/show\` の error id も upstream と同じ \`110ee688-193e-4a3a-9ecf-c167b2e6981e\` に揃え (旧 \`110ee688-193e-4a3a-9ecf-c167234e6f7d\`)。

### regression guard

- unit (\`internal/api/hashtags/handler_test.go\`):
  - \`TestList_SortRequired\` 新規 (= sort 抜きで 400)
  - \`TestUsers_SortRequired\` 新規 (= tag のみで 400)
  - \`TestShow_NotFound\` 更新 (= 404 → 400 expectation)
  - 既存 \`TestList_*\` / \`TestUsers_Success\` の payload に sort 追加
- coverage: \`internal/api/hashtags\` 93.5%
- e2e (\`tests/playwright/specs/hashtags/hashtags.spec.ts\`): LCD \`[200, 204, 400, 404]\` を \`toBe(400)\` + \`error.code === 'NO_SUCH_HASHTAG'\` strict に絞り込み

## #926: Playwright spec LCD strict 化

\`channels\` spec の 6 mutation (follow / unfollow / favorite / unfavorite / mute create / mute delete) を \`[200, 204]\` LCD から \`toBe(204)\` strict に絞り込む。両 backend ともに 204 を返すと確認済 (drift gate 強化)。

\`hashtags/show\` も #925 fix で 400 strict 化済 (上記参照)。

他 spec の \`[200, 204]\` LCD は今回 scope 外、後続 PR で順次 strict 化候補。

## テスト

両 backend で channels (2) + hashtags (5) = 7/7 pass:

\`\`\`
mk-go:    7 passed (1.2s)
TS image: 7 passed (1.3s)
\`\`\`

## Closes

Closes #925
Closes #926

🤖 Generated with [Claude Code](https://claude.com/claude-code)