### PR TITLE
Fix #929 + #931 + #932: admin paramDef strict + pq.StringArray drift bundle

### DIFF
--- a/internal/api/admin/abuse_report_notification.go
+++ b/internal/api/admin/abuse_report_notification.go
@@ -12,9 +12,6 @@ import (
 
 // AbuseReportNotificationRecipientCreate handles POST /api/admin/abuse-report/notification-recipient/create.
 func (h *Handler) AbuseReportNotificationRecipientCreate(c echo.Context) error {
-	if h.recipientRepo == nil {
-		return c.NoContent(http.StatusNoContent)
-	}
 	var req struct {
 		Name            string  `json:"name"`
 		Method          string  `json:"method"`
@@ -25,17 +22,28 @@ func (h *Handler) AbuseReportNotificationRecipientCreate(c echo.Context) error {
 	if err := c.Bind(&req); err != nil {
 		return c.JSON(http.StatusBadRequest, apierr.InvalidParam("Invalid parameters."))
 	}
-	// upstream Misskey TS は paramDef で isActive / name / method を required
-	// にしている。さらに method='email' のとき userId 必須、method='webhook'
-	// のとき systemWebhookId 必須の相関 check を行う (#929)。
+	// upstream Misskey TS の paramDef:
+	//   required: ['isActive', 'name', 'method']
+	//   method.enum: ['email', 'webhook']
+	// + method='email' で userId 必須、method='webhook' で systemWebhookId 必須
+	// の相関 check (third_party/misskey/.../notification-recipient/create.ts、#929)。
+	// nil-repo branch より先に validate して、不正リクエストを早期 reject する。
 	if req.Name == "" || req.Method == "" || req.IsActive == nil {
 		return c.JSON(http.StatusBadRequest, apierr.InvalidParam("name / method / isActive are required."))
 	}
+	if req.Method != "email" && req.Method != "webhook" {
+		return c.JSON(http.StatusBadRequest, apierr.InvalidParam("method must be 'email' or 'webhook'."))
+	}
+	// 相関 check の error code / id は upstream create.ts の meta.errors 定義と
+	// 一致 (CORRELATION_CHECK_EMAIL=348bb8ae-..., CORRELATION_CHECK_WEBHOOK=b0c15051-...)。
 	if req.Method == "email" && (req.UserID == nil || *req.UserID == "") {
 		return c.JSON(http.StatusBadRequest, apierr.Error("CORRELATION_CHECK_EMAIL", "If \"method\" is email, \"userId\" must be set.", "348bb8ae-575a-6fe9-4327-5811999def8f"))
 	}
 	if req.Method == "webhook" && (req.SystemWebhookID == nil || *req.SystemWebhookID == "") {
 		return c.JSON(http.StatusBadRequest, apierr.Error("CORRELATION_CHECK_WEBHOOK", "If \"method\" is webhook, \"systemWebhookId\" must be set.", "b0c15051-de2d-29ef-260c-9585cddd701a"))
+	}
+	if h.recipientRepo == nil {
+		return c.NoContent(http.StatusNoContent)
 	}
 	r := &model.AbuseReportNotificationRecipient{
 		ID:              h.idGen.Generate(time.Now()),

--- a/internal/api/admin/abuse_report_notification.go
+++ b/internal/api/admin/abuse_report_notification.go
@@ -18,14 +18,24 @@ func (h *Handler) AbuseReportNotificationRecipientCreate(c echo.Context) error {
 	var req struct {
 		Name            string  `json:"name"`
 		Method          string  `json:"method"`
+		IsActive        *bool   `json:"isActive"`
 		UserID          *string `json:"userId"`
 		SystemWebhookID *string `json:"systemWebhookId"`
 	}
 	if err := c.Bind(&req); err != nil {
 		return c.JSON(http.StatusBadRequest, apierr.InvalidParam("Invalid parameters."))
 	}
-	if req.Method == "" {
-		req.Method = "email"
+	// upstream Misskey TS は paramDef で isActive / name / method を required
+	// にしている。さらに method='email' のとき userId 必須、method='webhook'
+	// のとき systemWebhookId 必須の相関 check を行う (#929)。
+	if req.Name == "" || req.Method == "" || req.IsActive == nil {
+		return c.JSON(http.StatusBadRequest, apierr.InvalidParam("name / method / isActive are required."))
+	}
+	if req.Method == "email" && (req.UserID == nil || *req.UserID == "") {
+		return c.JSON(http.StatusBadRequest, apierr.Error("CORRELATION_CHECK_EMAIL", "If \"method\" is email, \"userId\" must be set.", "348bb8ae-575a-6fe9-4327-5811999def8f"))
+	}
+	if req.Method == "webhook" && (req.SystemWebhookID == nil || *req.SystemWebhookID == "") {
+		return c.JSON(http.StatusBadRequest, apierr.Error("CORRELATION_CHECK_WEBHOOK", "If \"method\" is webhook, \"systemWebhookId\" must be set.", "b0c15051-de2d-29ef-260c-9585cddd701a"))
 	}
 	r := &model.AbuseReportNotificationRecipient{
 		ID:              h.idGen.Generate(time.Now()),
@@ -33,7 +43,7 @@ func (h *Handler) AbuseReportNotificationRecipientCreate(c echo.Context) error {
 		Method:          req.Method,
 		UserID:          req.UserID,
 		SystemWebhookID: req.SystemWebhookID,
-		IsActive:        true,
+		IsActive:        *req.IsActive,
 	}
 	if err := h.recipientRepo.Create(r); err != nil {
 		return c.JSON(http.StatusInternalServerError, apierr.InternalError())

--- a/internal/api/admin/abuse_report_notification_test.go
+++ b/internal/api/admin/abuse_report_notification_test.go
@@ -68,6 +68,14 @@ func TestRecipientCreate_CorrelationCheck(t *testing.T) {
 	assert.Equal(t, http.StatusBadRequest, rec.Code)
 }
 
+func TestRecipientCreate_InvalidMethod(t *testing.T) {
+	// upstream paramDef は method.enum: ['email', 'webhook'] を強制 (#929 C)。
+	h, _ := setupAbuseRecipientHandler(t)
+	rec := doPost(h.AbuseReportNotificationRecipientCreate,
+		`{"name":"ops","method":"slack","isActive":true,"userId":"u1"}`, adminUser)
+	assert.Equal(t, http.StatusBadRequest, rec.Code)
+}
+
 func TestRecipientCreate_RepoError(t *testing.T) {
 	h, repo := setupAbuseRecipientHandler(t)
 	repo.CreateErr = assertError{}
@@ -146,7 +154,11 @@ func TestRecipientUpdate_MissingID(t *testing.T) {
 
 func TestAbuseReportNotificationRecipientCreate(t *testing.T) {
 	h, _, _, _ := newTestHandler(t)
-	assert.Equal(t, http.StatusNoContent, doPost(h.AbuseReportNotificationRecipientCreate, `{}`, adminUser).Code)
+	// required 欠落は 400 (validate-first ordering、#929 C)。
+	assert.Equal(t, http.StatusBadRequest, doPost(h.AbuseReportNotificationRecipientCreate, `{}`, adminUser).Code)
+	// required 揃いの正規 bind は nil recipientRepo で 204
+	assert.Equal(t, http.StatusNoContent, doPost(h.AbuseReportNotificationRecipientCreate,
+		`{"name":"ops","method":"email","isActive":true,"userId":"u1"}`, adminUser).Code)
 }
 
 func TestAbuseReportNotificationRecipientDelete(t *testing.T) {

--- a/internal/api/admin/abuse_report_notification_test.go
+++ b/internal/api/admin/abuse_report_notification_test.go
@@ -33,8 +33,10 @@ func setupAbuseRecipientHandler(t *testing.T, seed ...*model.AbuseReportNotifica
 func TestRecipientCreate_Success(t *testing.T) {
 	h, _ := setupAbuseRecipientHandler(t)
 
+	// upstream Misskey TS paramDef: name + method + isActive required、
+	// method=email では userId 必須 (#929 C)。
 	rec := doPost(h.AbuseReportNotificationRecipientCreate,
-		`{"name":"ops","method":"email"}`, adminUser)
+		`{"name":"ops","method":"email","isActive":true,"userId":"u1"}`, adminUser)
 	assert.Equal(t, http.StatusOK, rec.Code)
 
 	var got model.AbuseReportNotificationRecipient
@@ -44,19 +46,33 @@ func TestRecipientCreate_Success(t *testing.T) {
 	assert.True(t, got.IsActive)
 }
 
-func TestRecipientCreate_DefaultMethod(t *testing.T) {
+func TestRecipientCreate_MissingRequired(t *testing.T) {
+	// upstream paramDef で name + method + isActive は required (#929 C)。
 	h, _ := setupAbuseRecipientHandler(t)
-	rec := doPost(h.AbuseReportNotificationRecipientCreate, `{"name":"ops"}`, adminUser)
-	assert.Equal(t, http.StatusOK, rec.Code)
-	var got model.AbuseReportNotificationRecipient
-	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &got))
-	assert.Equal(t, "email", got.Method)
+	assert.Equal(t, http.StatusBadRequest, doPost(h.AbuseReportNotificationRecipientCreate, `{}`, adminUser).Code)
+	// method 欠落
+	assert.Equal(t, http.StatusBadRequest, doPost(h.AbuseReportNotificationRecipientCreate, `{"name":"ops","isActive":true}`, adminUser).Code)
+	// isActive 欠落
+	assert.Equal(t, http.StatusBadRequest, doPost(h.AbuseReportNotificationRecipientCreate, `{"name":"ops","method":"email"}`, adminUser).Code)
+}
+
+func TestRecipientCreate_CorrelationCheck(t *testing.T) {
+	// method=email なら userId 必須、method=webhook なら systemWebhookId 必須 (#929 C)。
+	h, _ := setupAbuseRecipientHandler(t)
+	rec := doPost(h.AbuseReportNotificationRecipientCreate,
+		`{"name":"ops","method":"email","isActive":true}`, adminUser)
+	assert.Equal(t, http.StatusBadRequest, rec.Code)
+
+	rec = doPost(h.AbuseReportNotificationRecipientCreate,
+		`{"name":"ops","method":"webhook","isActive":true}`, adminUser)
+	assert.Equal(t, http.StatusBadRequest, rec.Code)
 }
 
 func TestRecipientCreate_RepoError(t *testing.T) {
 	h, repo := setupAbuseRecipientHandler(t)
 	repo.CreateErr = assertError{}
-	rec := doPost(h.AbuseReportNotificationRecipientCreate, `{"name":"x"}`, adminUser)
+	rec := doPost(h.AbuseReportNotificationRecipientCreate,
+		`{"name":"x","method":"email","isActive":true,"userId":"u1"}`, adminUser)
 	assert.Equal(t, http.StatusInternalServerError, rec.Code)
 }
 
@@ -159,7 +175,8 @@ func TestRecipientCreate_WritesModerationLog(t *testing.T) {
 	h, _ := setupAbuseRecipientHandler(t)
 	repo := attachModLog(t, h)
 
-	rec := doPost(h.AbuseReportNotificationRecipientCreate, `{"name":"r","method":"email"}`, adminUser)
+	rec := doPost(h.AbuseReportNotificationRecipientCreate,
+		`{"name":"r","method":"email","isActive":true,"userId":"u1"}`, adminUser)
 	require.Equal(t, http.StatusOK, rec.Code)
 	require.Eventually(t, func() bool { return len(repo.Snapshot()) == 1 }, 500*time.Millisecond, 5*time.Millisecond)
 	assert.Equal(t, "createAbuseReportNotificationRecipient", repo.Snapshot()[0].Type)

--- a/internal/api/admin/avatar_decorations.go
+++ b/internal/api/admin/avatar_decorations.go
@@ -5,6 +5,8 @@ import (
 	"time"
 
 	"github.com/labstack/echo/v4"
+	"github.com/lib/pq"
+
 	"github.com/shiroha-a/mk/internal/api/apierr"
 	"github.com/shiroha-a/mk/internal/core/moderationlog"
 	"github.com/shiroha-a/mk/internal/model"
@@ -108,7 +110,9 @@ func (h *Handler) AvatarDecorationsUpdate(c echo.Context) error {
 		fields["url"] = *req.URL
 	}
 	if req.RoleIDs != nil {
-		fields["roleIdsThatCanBeUsedThisDecoration"] = *req.RoleIDs
+		// pq.StringArray でラップしないと GORM Updates(map) が空 string[] を
+		// NULL 化して NOT NULL 制約違反になる (#931、#896 / #900 / #901 と同 class)。
+		fields["roleIdsThatCanBeUsedThisDecoration"] = pq.StringArray(*req.RoleIDs)
 	}
 	if err := h.avatarDecoRepo.UpdateFields(req.ID, fields); err != nil {
 		return c.JSON(http.StatusInternalServerError, apierr.InternalError())

--- a/internal/api/admin/queue.go
+++ b/internal/api/admin/queue.go
@@ -13,16 +13,19 @@ import (
 
 // QueueClear handles POST /api/admin/queue/clear.
 func (h *Handler) QueueClear(c echo.Context) error {
+	// upstream Misskey TS は paramDef で queue + state を required にしている (#929)。
+	// mk-go も同 shape に揃え、permissive な「全 queue 一括 clear」を弾く。
+	var req struct {
+		Queue string `json:"queue"`
+		State string `json:"state"`
+	}
+	if err := c.Bind(&req); err != nil || req.Queue == "" || req.State == "" {
+		return c.JSON(http.StatusBadRequest, apierr.InvalidParam("queue and state are required."))
+	}
 	if h.queueInspector == nil {
 		return c.NoContent(http.StatusNoContent)
 	}
-	queues, err := h.queueInspector.Queues()
-	if err != nil {
-		return c.JSON(http.StatusInternalServerError, apierr.InternalError())
-	}
-	for _, q := range queues {
-		_, _ = h.queueInspector.DeleteAllPendingTasks(q)
-	}
+	_, _ = h.queueInspector.DeleteAllPendingTasks(req.Queue)
 	return c.NoContent(http.StatusNoContent)
 }
 
@@ -91,9 +94,6 @@ func (h *Handler) listDelayedTasks(c echo.Context, queueName string) error {
 // mk-go は asynq バックなので Bull state 名を asynq の list 呼び出しに
 // マッピングする。合計 limit を超えないよう走査中に切り詰める。
 func (h *Handler) QueueJobs(c echo.Context) error {
-	if h.queueInspector == nil {
-		return c.JSON(http.StatusOK, []any{})
-	}
 	// state は string でも string[] でも受け取れるようにする (frontend は
 	// 配列、既存テストや admin CLI からは単一文字列でくる可能性がある)。
 	var req struct {
@@ -103,7 +103,13 @@ func (h *Handler) QueueJobs(c echo.Context) error {
 		Page   int             `json:"page"`
 		Search string          `json:"search"`
 	}
-	_ = c.Bind(&req)
+	if err := c.Bind(&req); err != nil || req.Queue == "" || len(req.State) == 0 {
+		// upstream Misskey TS は paramDef で queue + state を required にしている (#929)。
+		return c.JSON(http.StatusBadRequest, apierr.InvalidParam("queue and state are required."))
+	}
+	if h.queueInspector == nil {
+		return c.JSON(http.StatusOK, []any{})
+	}
 	if req.Limit <= 0 || req.Limit > 100 {
 		req.Limit = 30
 	}
@@ -111,14 +117,9 @@ func (h *Handler) QueueJobs(c echo.Context) error {
 		req.Page = 1
 	}
 	states := parseStateField(req.State)
+	// queue は paramDef で required 化済 (上の req.Queue == "" で 400 を返す)
+	// ので必ず非空。ここは単一 queue のみを対象にする。
 	queues := []string{req.Queue}
-	if req.Queue == "" {
-		qs, err := h.queueInspector.Queues()
-		if err != nil {
-			return c.JSON(http.StatusInternalServerError, apierr.InternalError())
-		}
-		queues = qs
-	}
 	seen := make(map[string]struct{}, req.Limit)
 	out := make([]map[string]any, 0, req.Limit)
 outer:
@@ -195,29 +196,30 @@ func (h *Handler) listTasksForState(queue, state string, page, limit int) ([]*Qu
 
 // QueuePromoteJobs handles POST /api/admin/queue/promote-jobs.
 func (h *Handler) QueuePromoteJobs(c echo.Context) error {
-	// asynq に bulk promote API が無いため、全キューの scheduled/retry を 1 ページ
-	// 分ずつ拾って RunTask で逐次 promote する。大量投入時は後続のページを
-	// クライアント側で再呼び出しする運用。
+	// asynq に bulk promote API が無いため、対象 queue の scheduled/retry を
+	// 1 ページずつ拾って RunTask で逐次 promote する。大量投入時は後続の
+	// ページを クライアント側で再呼び出しする運用。
+	// upstream Misskey TS は paramDef で queue を required にしている (#929)。
+	var req struct {
+		Queue string `json:"queue"`
+	}
+	if err := c.Bind(&req); err != nil || req.Queue == "" {
+		return c.JSON(http.StatusBadRequest, apierr.InvalidParam("queue is required."))
+	}
 	if h.queueInspector == nil {
 		return c.NoContent(http.StatusNoContent)
 	}
-	queues, err := h.queueInspector.Queues()
-	if err != nil {
-		return c.JSON(http.StatusInternalServerError, apierr.InternalError())
-	}
 	promoted := 0
-	for _, q := range queues {
-		for _, state := range []string{"scheduled", "retry"} {
-			var rows []*QueueTaskSummary
-			if state == "scheduled" {
-				rows, _ = h.queueInspector.ListScheduledTasks(q, 1, 100)
-			} else {
-				rows, _ = h.queueInspector.ListRetryTasks(q, 1, 100)
-			}
-			for _, t := range rows {
-				if err := h.queueInspector.RunTask(q, t.ID); err == nil {
-					promoted++
-				}
+	for _, state := range []string{"scheduled", "retry"} {
+		var rows []*QueueTaskSummary
+		if state == "scheduled" {
+			rows, _ = h.queueInspector.ListScheduledTasks(req.Queue, 1, 100)
+		} else {
+			rows, _ = h.queueInspector.ListRetryTasks(req.Queue, 1, 100)
+		}
+		for _, t := range rows {
+			if err := h.queueInspector.RunTask(req.Queue, t.ID); err == nil {
+				promoted++
 			}
 		}
 	}
@@ -316,36 +318,23 @@ func metricsToFrontend(m *QueueMetricsResult, fallbackCount int64) ([]int64, int
 // はなくゼロ埋めの shape を返して、フロント側の queueInfo が stale に
 // ならないようにする。
 func (h *Handler) QueueQueueStats(c echo.Context) error {
-	if h.queueInspector == nil {
-		return c.JSON(http.StatusOK, map[string]any{})
-	}
+	// upstream Misskey TS は paramDef で queue を required にしている (#929)。
 	var req struct {
 		Queue string `json:"queue"`
 	}
-	_ = c.Bind(&req)
-	if req.Queue != "" {
-		info, err := h.queueInspector.GetQueueInfo(req.Queue)
-		if err != nil || info == nil {
-			completed, failed := h.fetchQueueMetrics(req.Queue)
-			return c.JSON(http.StatusOK, shapeQueueForFrontend(&QueueInfoResult{Queue: req.Queue}, completed, failed))
-		}
+	if err := c.Bind(&req); err != nil || req.Queue == "" {
+		return c.JSON(http.StatusBadRequest, apierr.InvalidParam("queue is required."))
+	}
+	if h.queueInspector == nil {
+		return c.JSON(http.StatusOK, map[string]any{})
+	}
+	info, err := h.queueInspector.GetQueueInfo(req.Queue)
+	if err != nil || info == nil {
 		completed, failed := h.fetchQueueMetrics(req.Queue)
-		return c.JSON(http.StatusOK, shapeQueueForFrontend(info, completed, failed))
+		return c.JSON(http.StatusOK, shapeQueueForFrontend(&QueueInfoResult{Queue: req.Queue}, completed, failed))
 	}
-	queues, err := h.queueInspector.Queues()
-	if err != nil {
-		return c.JSON(http.StatusInternalServerError, apierr.InternalError())
-	}
-	out := map[string]any{}
-	for _, q := range queues {
-		info, err := h.queueInspector.GetQueueInfo(q)
-		if err != nil {
-			continue
-		}
-		completed, failed := h.fetchQueueMetrics(q)
-		out[q] = shapeQueueForFrontend(info, completed, failed)
-	}
-	return c.JSON(http.StatusOK, out)
+	completed, failed := h.fetchQueueMetrics(req.Queue)
+	return c.JSON(http.StatusOK, shapeQueueForFrontend(info, completed, failed))
 }
 
 // fetchQueueMetrics queries the inspector for completed / failed
@@ -395,6 +384,12 @@ func (h *Handler) QueueRemoveJob(c echo.Context) error {
 	if h.queueInspector == nil {
 		return c.NoContent(http.StatusNoContent)
 	}
+	// asynq DeleteTask は不明 task id でも nil error を返す (= idempotent)
+	// が、upstream Misskey TS は 4xx を返す。drop-in 互換のため事前に
+	// GetTaskInfo で存在確認して、無ければ 404 を返す (#929)。
+	if _, err := h.queueInspector.GetTaskInfo(req.Queue, req.ID); err != nil {
+		return c.JSON(http.StatusNotFound, apierr.NotFound())
+	}
 	if err := h.queueInspector.DeleteTask(req.Queue, req.ID); err != nil {
 		return c.JSON(http.StatusNotFound, apierr.NotFound())
 	}
@@ -412,6 +407,11 @@ func (h *Handler) QueueRetryJob(c echo.Context) error {
 	}
 	if h.queueInspector == nil {
 		return c.NoContent(http.StatusNoContent)
+	}
+	// asynq RunTask も不明 id で nil を返す idempotent 挙動。drop-in 互換の
+	// ため事前に GetTaskInfo で存在確認 (#929)。
+	if _, err := h.queueInspector.GetTaskInfo(req.Queue, req.ID); err != nil {
+		return c.JSON(http.StatusNotFound, apierr.NotFound())
 	}
 	if err := h.queueInspector.RunTask(req.Queue, req.ID); err != nil {
 		return c.JSON(http.StatusNotFound, apierr.NotFound())

--- a/internal/api/admin/queue.go
+++ b/internal/api/admin/queue.go
@@ -117,30 +117,25 @@ func (h *Handler) QueueJobs(c echo.Context) error {
 		req.Page = 1
 	}
 	states := parseStateField(req.State)
-	// queue は paramDef で required 化済 (上の req.Queue == "" で 400 を返す)
-	// ので必ず非空。ここは単一 queue のみを対象にする。
-	queues := []string{req.Queue}
 	seen := make(map[string]struct{}, req.Limit)
 	out := make([]map[string]any, 0, req.Limit)
 outer:
-	for _, q := range queues {
-		for _, state := range states {
-			rows, err := h.listTasksForState(q, state, req.Page, req.Limit)
-			if err != nil {
+	for _, state := range states {
+		rows, err := h.listTasksForState(req.Queue, state, req.Page, req.Limit)
+		if err != nil {
+			continue
+		}
+		for _, t := range rows {
+			if len(out) >= req.Limit {
+				break outer
+			}
+			// state指定が複数重なる (例: all タブ) とき同じ task が
+			// 重複しないよう ID で de-dup する。
+			if _, dup := seen[t.ID]; dup {
 				continue
 			}
-			for _, t := range rows {
-				if len(out) >= req.Limit {
-					break outer
-				}
-				// state指定が複数重なる (例: all タブ) とき同じ task が
-				// 重複しないよう ID で de-dup する。
-				if _, dup := seen[t.ID]; dup {
-					continue
-				}
-				seen[t.ID] = struct{}{}
-				out = append(out, packTaskSummary(t))
-			}
+			seen[t.ID] = struct{}{}
+			out = append(out, packTaskSummary(t))
 		}
 	}
 	return c.JSON(http.StatusOK, out)

--- a/internal/api/admin/queue_test.go
+++ b/internal/api/admin/queue_test.go
@@ -85,19 +85,23 @@ func (s *stubQueueInspector) QueueMetrics(q, kind string) (*apiadmin.QueueMetric
 // --- Queue --------------------------------------------------------------------
 
 func TestQueueClear_WithInspector(t *testing.T) {
+	// queue + state 指定で対象 queue 1 つだけが clear される (#929 A の strict 化後)。
 	h, _, _, _ := newTestHandler(t)
-	insp := &stubQueueInspector{queues: []string{"deliver", "inbox"}}
+	insp := &stubQueueInspector{}
 	h.SetQueueInspector(insp)
-	rec := doPost(h.QueueClear, `{}`, adminUser)
+	rec := doPost(h.QueueClear, `{"queue":"deliver","state":"wait"}`, adminUser)
 	assert.Equal(t, http.StatusNoContent, rec.Code)
-	assert.ElementsMatch(t, []string{"deliver", "inbox"}, insp.deleteAllHits)
+	assert.Equal(t, []string{"deliver"}, insp.deleteAllHits)
 }
 
-func TestQueueClear_QueuesError(t *testing.T) {
+func TestQueueClear_MissingParams(t *testing.T) {
+	// upstream Misskey TS paramDef で queue + state は required (#929 A)。
 	h, _, _, _ := newTestHandler(t)
-	insp := &stubQueueInspector{queuesErr: errors.New("redis down")}
+	insp := &stubQueueInspector{}
 	h.SetQueueInspector(insp)
-	assert.Equal(t, http.StatusInternalServerError, doPost(h.QueueClear, `{}`, adminUser).Code)
+	assert.Equal(t, http.StatusBadRequest, doPost(h.QueueClear, `{}`, adminUser).Code)
+	assert.Equal(t, http.StatusBadRequest, doPost(h.QueueClear, `{"queue":"deliver"}`, adminUser).Code)
+	assert.Equal(t, http.StatusBadRequest, doPost(h.QueueClear, `{"state":"wait"}`, adminUser).Code)
 }
 
 func TestQueueJobs_FilterByQueueAndState(t *testing.T) {
@@ -121,21 +125,14 @@ func TestQueueJobs_FilterByQueueAndState(t *testing.T) {
 	assert.Equal(t, "a1", rows[0]["id"])
 }
 
-func TestQueueJobs_AllQueuesPendingDefault(t *testing.T) {
+func TestQueueJobs_MissingParams(t *testing.T) {
+	// upstream Misskey TS paramDef で queue + state は required (#929 A)。
 	h, _, _, _ := newTestHandler(t)
-	insp := &stubQueueInspector{
-		queues: []string{"deliver", "inbox"},
-		pending: map[string][]*apiadmin.QueueTaskSummary{
-			"deliver": {{ID: "d1", Queue: "deliver"}},
-			"inbox":   {{ID: "i1", Queue: "inbox"}},
-		},
-	}
+	insp := &stubQueueInspector{}
 	h.SetQueueInspector(insp)
-	rec := doPost(h.QueueJobs, `{}`, adminUser)
-	assert.Equal(t, http.StatusOK, rec.Code)
-	var rows []map[string]any
-	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &rows))
-	assert.Len(t, rows, 2)
+	assert.Equal(t, http.StatusBadRequest, doPost(h.QueueJobs, `{}`, adminUser).Code)
+	assert.Equal(t, http.StatusBadRequest, doPost(h.QueueJobs, `{"queue":"deliver"}`, adminUser).Code)
+	assert.Equal(t, http.StatusBadRequest, doPost(h.QueueJobs, `{"state":"wait"}`, adminUser).Code)
 }
 
 func TestQueueShowJob_Found(t *testing.T) {
@@ -164,7 +161,14 @@ func TestQueueShowJob_NotFoundWithInspector(t *testing.T) {
 
 func TestQueueRemoveJob_Success(t *testing.T) {
 	h, _, _, _ := newTestHandler(t)
-	insp := &stubQueueInspector{}
+	// asynq DeleteTask は不明 id で nil を返す (idempotent) ため、existence
+	// 確認用に GetTaskInfo を事前 hit する (#929 B)。stub の task map に
+	// 入れて GetTaskInfo を pass させる。
+	insp := &stubQueueInspector{
+		task: map[string]*apiadmin.QueueTaskSummary{
+			"tid1": {ID: "tid1", Queue: "deliver"},
+		},
+	}
 	h.SetQueueInspector(insp)
 	rec := doPost(h.QueueRemoveJob, `{"queue":"deliver","id":"tid1"}`, adminUser)
 	assert.Equal(t, http.StatusNoContent, rec.Code)
@@ -172,8 +176,10 @@ func TestQueueRemoveJob_Success(t *testing.T) {
 }
 
 func TestQueueRemoveJob_NotFound(t *testing.T) {
+	// task map が空 = GetTaskInfo が "not found" を返すケース。idempotent な
+	// asynq DeleteTask に到達せず precheck で 404 (#929 B)。
 	h, _, _, _ := newTestHandler(t)
-	insp := &stubQueueInspector{deleteErr: errors.New("not found")}
+	insp := &stubQueueInspector{}
 	h.SetQueueInspector(insp)
 	rec := doPost(h.QueueRemoveJob, `{"queue":"deliver","id":"x"}`, adminUser)
 	assert.Equal(t, http.StatusNotFound, rec.Code)
@@ -181,17 +187,29 @@ func TestQueueRemoveJob_NotFound(t *testing.T) {
 
 func TestQueueRetryJob_Success(t *testing.T) {
 	h, _, _, _ := newTestHandler(t)
-	insp := &stubQueueInspector{}
+	insp := &stubQueueInspector{
+		task: map[string]*apiadmin.QueueTaskSummary{
+			"tid1": {ID: "tid1", Queue: "deliver"},
+		},
+	}
 	h.SetQueueInspector(insp)
 	rec := doPost(h.QueueRetryJob, `{"queue":"deliver","id":"tid1"}`, adminUser)
 	assert.Equal(t, http.StatusNoContent, rec.Code)
 	assert.Equal(t, []string{"tid1"}, insp.runCalls)
 }
 
+func TestQueueRetryJob_NotFound(t *testing.T) {
+	// 不明 id は GetTaskInfo precheck で 404。RunTask は idempotent (#929 B)。
+	h, _, _, _ := newTestHandler(t)
+	insp := &stubQueueInspector{}
+	h.SetQueueInspector(insp)
+	rec := doPost(h.QueueRetryJob, `{"queue":"deliver","id":"x"}`, adminUser)
+	assert.Equal(t, http.StatusNotFound, rec.Code)
+}
+
 func TestQueuePromoteJobs_RunsScheduledAndRetry(t *testing.T) {
 	h, _, _, _ := newTestHandler(t)
 	insp := &stubQueueInspector{
-		queues: []string{"deliver"},
 		scheduled: map[string][]*apiadmin.QueueTaskSummary{
 			"deliver": {{ID: "s1"}, {ID: "s2"}},
 		},
@@ -201,7 +219,8 @@ func TestQueuePromoteJobs_RunsScheduledAndRetry(t *testing.T) {
 	}
 	h.SetQueueInspector(insp)
 
-	rec := doPost(h.QueuePromoteJobs, `{}`, adminUser)
+	// queue は paramDef required (#929 A)。
+	rec := doPost(h.QueuePromoteJobs, `{"queue":"deliver"}`, adminUser)
 	assert.Equal(t, http.StatusOK, rec.Code)
 	var got map[string]any
 	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &got))
@@ -212,10 +231,9 @@ func TestQueuePromoteJobs_RunsScheduledAndRetry(t *testing.T) {
 func TestQueueQueueStats_WithInspector(t *testing.T) {
 	// frontend admin/job-queue.vue が期待する Misskey Bull shape
 	// ({name, counts:{active,delayed,waiting,...}, metrics:..., db:...})
-	// を返すことを検証する。
+	// を返すことを検証する (#929 A の strict 化後は単一 queue のみ)。
 	h, _, _, _ := newTestHandler(t)
 	insp := &stubQueueInspector{
-		queues: []string{"deliver"},
 		info: map[string]*apiadmin.QueueInfoResult{
 			"deliver": {Queue: "deliver", Size: 5, Pending: 3, Active: 1, Completed: 10, Failed: 2, Scheduled: 0, Retry: 1},
 		},
@@ -227,14 +245,12 @@ func TestQueueQueueStats_WithInspector(t *testing.T) {
 		},
 	}
 	h.SetQueueInspector(insp)
-	rec := doPost(h.QueueQueueStats, `{}`, adminUser)
+	rec := doPost(h.QueueQueueStats, `{"queue":"deliver"}`, adminUser)
 	assert.Equal(t, http.StatusOK, rec.Code)
 	var got map[string]any
 	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &got))
-	deliver, ok := got["deliver"].(map[string]any)
-	require.True(t, ok)
-	assert.Equal(t, "deliver", deliver["name"])
-	counts, ok := deliver["counts"].(map[string]any)
+	assert.Equal(t, "deliver", got["name"])
+	counts, ok := got["counts"].(map[string]any)
 	require.True(t, ok)
 	assert.EqualValues(t, 1, counts["active"])
 	assert.EqualValues(t, 3, counts["waiting"])
@@ -242,7 +258,7 @@ func TestQueueQueueStats_WithInspector(t *testing.T) {
 	assert.EqualValues(t, 1, counts["delayed"])
 
 	// metrics shape: data 配列と count が driver から伝播。
-	metrics, ok := deliver["metrics"].(map[string]any)
+	metrics, ok := got["metrics"].(map[string]any)
 	require.True(t, ok)
 	completed, ok := metrics["completed"].(map[string]any)
 	require.True(t, ok)
@@ -398,24 +414,21 @@ func TestQueueDeliverDelayed_PagingCrossesBoundary(t *testing.T) {
 	assert.Empty(t, rows)
 }
 
-// QueueJobs で queue 未指定時、複数キューを走査しても合計 limit を超えない
-// ことを確認する。
-func TestQueueJobs_MultiQueueCappedAtLimit(t *testing.T) {
+// QueueJobs は単一 queue でも limit を超えない件数しか返さないことを確認する。
+func TestQueueJobs_SingleQueueCappedAtLimit(t *testing.T) {
 	h, _, _, _ := newTestHandler(t)
 	insp := &stubQueueInspector{
-		queues: []string{"deliver", "inbox"},
 		pending: map[string][]*apiadmin.QueueTaskSummary{
 			"deliver": {{ID: "d1"}, {ID: "d2"}, {ID: "d3"}},
-			"inbox":   {{ID: "i1"}, {ID: "i2"}},
 		},
 	}
 	h.SetQueueInspector(insp)
 
-	rec := doPost(h.QueueJobs, `{"limit":2}`, adminUser)
+	rec := doPost(h.QueueJobs, `{"queue":"deliver","state":"wait","limit":2}`, adminUser)
 	assert.Equal(t, http.StatusOK, rec.Code)
 	var rows []map[string]any
 	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &rows))
-	assert.Len(t, rows, 2, "multi-queue fan-out must still respect limit")
+	assert.Len(t, rows, 2, "single-queue output must respect limit")
 }
 
 // --- thin nil-inspector smoke tests ---
@@ -426,7 +439,9 @@ func TestQueueJobs_MultiQueueCappedAtLimit(t *testing.T) {
 
 func TestQueueClear(t *testing.T) {
 	h, _, _, _ := newTestHandler(t)
-	assert.Equal(t, http.StatusNoContent, doPost(h.QueueClear, `{}`, adminUser).Code)
+	// queue/state 欠落は 400、required 揃いの正規 bind は nil inspector で 204
+	assert.Equal(t, http.StatusBadRequest, doPost(h.QueueClear, `{}`, adminUser).Code)
+	assert.Equal(t, http.StatusNoContent, doPost(h.QueueClear, `{"queue":"deliver","state":"wait"}`, adminUser).Code)
 }
 
 func TestQueueDeliverDelayed(t *testing.T) {
@@ -441,17 +456,21 @@ func TestQueueInboxDelayed(t *testing.T) {
 
 func TestQueueJobs(t *testing.T) {
 	h, _, _, _ := newTestHandler(t)
-	assert.Equal(t, http.StatusOK, doPost(h.QueueJobs, `{}`, adminUser).Code)
+	// queue/state 欠落は 400、required 揃いの正規 bind は nil inspector で 200 (空配列)
+	assert.Equal(t, http.StatusBadRequest, doPost(h.QueueJobs, `{}`, adminUser).Code)
+	assert.Equal(t, http.StatusOK, doPost(h.QueueJobs, `{"queue":"deliver","state":"wait"}`, adminUser).Code)
 }
 
 func TestQueuePromoteJobs(t *testing.T) {
 	h, _, _, _ := newTestHandler(t)
-	assert.Equal(t, http.StatusNoContent, doPost(h.QueuePromoteJobs, `{}`, adminUser).Code)
+	assert.Equal(t, http.StatusBadRequest, doPost(h.QueuePromoteJobs, `{}`, adminUser).Code)
+	assert.Equal(t, http.StatusNoContent, doPost(h.QueuePromoteJobs, `{"queue":"deliver"}`, adminUser).Code)
 }
 
 func TestQueueQueueStats(t *testing.T) {
 	h, _, _, _ := newTestHandler(t)
-	assert.Equal(t, http.StatusOK, doPost(h.QueueQueueStats, `{}`, adminUser).Code)
+	assert.Equal(t, http.StatusBadRequest, doPost(h.QueueQueueStats, `{}`, adminUser).Code)
+	assert.Equal(t, http.StatusOK, doPost(h.QueueQueueStats, `{"queue":"deliver"}`, adminUser).Code)
 }
 
 func TestQueueQueues(t *testing.T) {

--- a/internal/api/admin/queue_test.go
+++ b/internal/api/admin/queue_test.go
@@ -222,6 +222,21 @@ func TestQueueRetryJob_NotFound(t *testing.T) {
 	assert.Equal(t, http.StatusNotFound, rec.Code)
 }
 
+func TestQueueRetryJob_RunTaskError(t *testing.T) {
+	// precheck pass 後に RunTask 自体が失敗する race condition (precheck と
+	// RunTask の間に別 admin が削除した等)。RemoveJob と symmetric。
+	h, _, _, _ := newTestHandler(t)
+	insp := &stubQueueInspector{
+		task: map[string]*apiadmin.QueueTaskSummary{
+			"tid1": {ID: "tid1", Queue: "deliver"},
+		},
+		runErr: errors.New("not found"),
+	}
+	h.SetQueueInspector(insp)
+	rec := doPost(h.QueueRetryJob, `{"queue":"deliver","id":"tid1"}`, adminUser)
+	assert.Equal(t, http.StatusNotFound, rec.Code)
+}
+
 func TestQueuePromoteJobs_RunsScheduledAndRetry(t *testing.T) {
 	h, _, _, _ := newTestHandler(t)
 	insp := &stubQueueInspector{

--- a/internal/api/admin/queue_test.go
+++ b/internal/api/admin/queue_test.go
@@ -185,6 +185,21 @@ func TestQueueRemoveJob_NotFound(t *testing.T) {
 	assert.Equal(t, http.StatusNotFound, rec.Code)
 }
 
+func TestQueueRemoveJob_DeleteTaskError(t *testing.T) {
+	// precheck は pass するが DeleteTask 自体が失敗する race condition を guard。
+	// (例: precheck と DeleteTask の間に他 admin が削除済) 引き続き 404 を返す。
+	h, _, _, _ := newTestHandler(t)
+	insp := &stubQueueInspector{
+		task: map[string]*apiadmin.QueueTaskSummary{
+			"tid1": {ID: "tid1", Queue: "deliver"},
+		},
+		deleteErr: errors.New("not found"),
+	}
+	h.SetQueueInspector(insp)
+	rec := doPost(h.QueueRemoveJob, `{"queue":"deliver","id":"tid1"}`, adminUser)
+	assert.Equal(t, http.StatusNotFound, rec.Code)
+}
+
 func TestQueueRetryJob_Success(t *testing.T) {
 	h, _, _, _ := newTestHandler(t)
 	insp := &stubQueueInspector{

--- a/internal/api/admin/system_webhook.go
+++ b/internal/api/admin/system_webhook.go
@@ -8,6 +8,8 @@ import (
 	"time"
 
 	"github.com/labstack/echo/v4"
+	"github.com/lib/pq"
+
 	"github.com/shiroha-a/mk/internal/api/apierr"
 	"github.com/shiroha-a/mk/internal/core/moderationlog"
 	"github.com/shiroha-a/mk/internal/model"
@@ -193,7 +195,9 @@ func (h *Handler) SystemWebhookUpdate(c echo.Context) error {
 		fields["secret"] = *req.Secret
 	}
 	if req.On != nil {
-		fields["on"] = *req.On
+		// pq.StringArray でラップしないと GORM Updates(map) が空 string[] を
+		// NULL 化して NOT NULL 制約違反になる (#932、#931 / #896 と同 class)。
+		fields["on"] = pq.StringArray(*req.On)
 	}
 	if req.IsActive != nil {
 		fields["isActive"] = *req.IsActive

--- a/internal/testutil/mock_repository.go
+++ b/internal/testutil/mock_repository.go
@@ -5641,7 +5641,12 @@ func (m *MockSystemWebhookRepository) UpdateAdminFields(id string, fields map[st
 				w.Secret = s
 			}
 		case "on":
-			if arr, ok := v.([]string); ok {
+			// production code は pq.StringArray でラップして送る (#932)。
+			// 旧 path との互換のため []string も受ける。
+			switch arr := v.(type) {
+			case pq.StringArray:
+				w.On = []string(arr)
+			case []string:
 				w.On = arr
 			}
 		case "isActive":
@@ -5970,7 +5975,12 @@ func (m *MockAvatarDecorationRepository) UpdateFields(id string, fields map[stri
 				d.URL = s
 			}
 		case "roleIdsThatCanBeUsedThisDecoration":
-			if arr, ok := v.([]string); ok {
+			// production code は pq.StringArray でラップして送る (#931)。
+			// 旧 path との互換のため []string も受ける。
+			switch arr := v.(type) {
+			case pq.StringArray:
+				d.RoleIDs = []string(arr)
+			case []string:
 				d.RoleIDs = arr
 			}
 		case "updatedAt":

--- a/tests/playwright/instance.yml
+++ b/tests/playwright/instance.yml
@@ -31,6 +31,11 @@ redisForTimelines:
 
 id: aidx
 
+# mk-go binary 用の job queue driver。default は mkq だが、Playwright env では
+# 明示して default 変更時の意図せぬ切替を防ぐ。TS image (docker-compose.playwright.ts.yml
+# overlay) では BullMQ 固定で、本キーは TS 側に渡されても無視されるので副作用なし。
+jobQueueDriver: mkq
+
 # 注: 本 config は mk-go binary (docker-compose.playwright.yml) と TS image
 # (docker-compose.playwright.ts.yml overlay) の **両方で共有** する。差分が
 # 発生したら別 file に分けるが、現状 db/redis hostname も同じなので 1 file

--- a/tests/playwright/specs/admin/avatar_decorations.spec.ts
+++ b/tests/playwright/specs/admin/avatar_decorations.spec.ts
@@ -33,9 +33,7 @@ test.describe('admin/avatar-decorations/* CRUD round-trip', () => {
   test('create → list で含まれる → update → delete round-trip', async ({ request }) => {
     const name = `spec_deco_${randomUUID()}`;
 
-    // 1. create (両 backend ともに 200 + decoration object を返す。
-    //  create は INSERT で空 string[] が '{}' リテラルとして通るので
-    //  update と異なり drift にならない、#931 参照)
+    // 1. create (両 backend ともに 200 + decoration object を返す)
     const createResp = await callApi(request, 'admin/avatar-decorations/create', {
       i: root.token,
       name,
@@ -56,18 +54,15 @@ test.describe('admin/avatar-decorations/* CRUD round-trip', () => {
     expect(found, 'created decoration should appear in list').toBeDefined();
     const decoId = found!.id;
 
-    // 3. update で description 変更
-    // roleIdsThatCanBeUsedThisDecoration: [] を送ると mk-go の GORM
-    // Updates(map) が空 string[] を NULL 化して制約違反になる drift
-    // (#896 / #900 と同 class、本 spec で発覚 → #931 として起票済)。
-    // spec scope では update に role 配列を含めない (= 既存値維持) ことで
-    // 両 backend で動かす。#931 fix 後に role 配列付きの strict 化を予定。
+    // 3. update で description + 空 roleIds 配列。#931 fix 後は空配列でも
+    // 両 backend で 204 (mk-go は pq.StringArray でラップして '{}' を保存)。
     const updResp = await callApi(request, 'admin/avatar-decorations/update', {
       i: root.token,
       id: decoId,
       name,
       description: 'updated by spec',
       url: 'https://example.invalid/deco.png',
+      roleIdsThatCanBeUsedThisDecoration: [],
     });
     expect(updResp.status()).toBe(204);
 

--- a/tests/playwright/specs/admin/queue.spec.ts
+++ b/tests/playwright/specs/admin/queue.spec.ts
@@ -32,9 +32,7 @@ test.describe('admin/queue/* shape compat', () => {
     root = JSON.parse(readFileSync('.auth/root.json', 'utf-8'));
   });
 
-  // upstream Misskey TS は paramDef で queue + state 必須、mk-go は permissive。
-  // 両 backend で動く params (= queue: 'deliver', state: ['active'] 等) を
-  // 渡して shape compat を verify する LCD strategy。
+  // upstream Misskey TS の paramDef に合わせて queue + state を必須化済 (#929 A)。
   test('admin/queue/jobs returns array shape', async ({ request }) => {
     const resp = await callApi(request, 'admin/queue/jobs', {
       i: root.token,
@@ -127,26 +125,23 @@ test.describe('admin/queue/* shape compat', () => {
     expect([400, 404]).toContain(resp.status());
   });
 
-  // retry-job / remove-job: 不明 id の挙動は backend 間で差あり。
-  //   - mk-go: asynq DeleteTask / RunTask が idempotent な場合 204 を返すこと
-  //     がある (= 内部 task store が「該当 id 無し」を success 扱い)
-  //   - TS (BullMQ): 通常 4xx
-  // どちらも frontend 側は「削除済」扱いするため LCD で吸収。
-  test('admin/queue/retry-job returns 2xx/4xx for unknown id', async ({ request }) => {
+  // mk-go は asynq DeleteTask / RunTask の idempotent 挙動を GetTaskInfo
+  // precheck で TS と同じ 4xx に揃えた (#929 B)。
+  test('admin/queue/retry-job returns 4xx for unknown id', async ({ request }) => {
     const resp = await callApi(request, 'admin/queue/retry-job', {
       i: root.token,
       queue: 'deliver',
       id: 'nonexistent-job-id',
     });
-    expect([200, 204, 400, 404]).toContain(resp.status());
+    expect([400, 404]).toContain(resp.status());
   });
 
-  test('admin/queue/remove-job returns 2xx/4xx for unknown id', async ({ request }) => {
+  test('admin/queue/remove-job returns 4xx for unknown id', async ({ request }) => {
     const resp = await callApi(request, 'admin/queue/remove-job', {
       i: root.token,
       queue: 'deliver',
       id: 'nonexistent-job-id',
     });
-    expect([200, 204, 400, 404]).toContain(resp.status());
+    expect([400, 404]).toContain(resp.status());
   });
 });

--- a/tests/playwright/specs/admin/system_webhook.spec.ts
+++ b/tests/playwright/specs/admin/system_webhook.spec.ts
@@ -68,14 +68,10 @@ test.describe('admin/system-webhook/* CRUD', () => {
     expect(shown.id).toBe(webhookId);
     expect(shown.name).toBe(name);
 
-    // 4. update で isActive を切替
-    // 両 backend を満たす update payload が存在しない drift (#932):
-    //   - upstream TS: paramDef `required: ['id', 'isActive', 'name', 'on', 'url']`
-    //     のため `on` を送らないと 400
-    //   - mk-go: GORM Updates(map) で `on: [...]` が pq.StringArray なしで
-    //     NULL 化して 500 (#931 avatar-decorations と同 class、#932 として起票)
-    // → on を送ると mk-go 500 / 送らないと TS 400。本 spec では on 込みで送り、
-    //   両 backend を [200, 204, 500] LCD で吸収する。#932 fix 後に strict 化予定。
+    // 4. update で isActive を切替。upstream TS paramDef は
+    //    required: ['id','isActive','name','on','url'] なので全 field 必須。
+    //    mk-go 側は #932 で pq.StringArray ラップ済 (空 string[] が NULL 化
+    //    して NOT NULL 違反になる drift を解消)。
     const updResp = await callApi(request, 'admin/system-webhook/update', {
       i: root.token,
       id: webhookId,
@@ -85,16 +81,16 @@ test.describe('admin/system-webhook/* CRUD', () => {
       url: 'https://example.invalid/webhook-updated',
       secret: 'spec-secret-updated',
     });
-    expect([200, 204, 500]).toContain(updResp.status());
+    expect(updResp.status()).toBe(200);
 
     // 5. test (= 仮想 webhook を発火)。実 HTTP 配信は test 環境で fail
-    //    するが、handler 側は dispatch を試みて 204 を返すはず。
+    //    するが、handler 側は dispatch を試みて 204 を返す (両 backend)。
     const testResp = await callApi(request, 'admin/system-webhook/test', {
       i: root.token,
       webhookId,
       type: 'abuseReport',
     });
-    expect([200, 204, 500]).toContain(testResp.status());
+    expect([200, 204]).toContain(testResp.status());
 
     // 6. delete
     const delResp = await callApi(request, 'admin/system-webhook/delete', {


### PR DESCRIPTION
## Summary

Phase 4 PR-C/D/E spec で発見された 3 件の admin drift を 1 PR でまとめて fix。

### #929 admin/queue + admin/abuse-report

- **A: paramDef strict 化** — admin/queue/{clear,jobs,promote-jobs,queue-stats} は upstream Misskey TS で queue/state を required にしているが、mk-go は permissive で全 queue 一括 操作に fallback していた。required にして upstream に合わせる。
- **B: idempotency 解消** — admin/queue/{remove-job,retry-job} は asynq DeleteTask/RunTask が不明 id でも nil を返す idempotent 挙動で、TS の 4xx と drift。GetTaskInfo precheck を入れて 404 に統一。
- **C: 相関 check** — admin/abuse-report/notification-recipient/create に paramDef strict (name/method/isActive required) + method=email→userId 必須、method=webhook→systemWebhookId 必須の相関 check を実装。

### #931 admin/avatar-decorations/update

`roleIdsThatCanBeUsedThisDecoration` を `pq.StringArray` でラップ。GORM Updates(map) は plain []string を NULL 化して NOT NULL 違反になる既知 drift class (#896 / #900 / #901 と同パターン)。

### #932 admin/system-webhook/update

`on` フィールドも同様に `pq.StringArray` でラップ。i/webhooks/update は `db.Save(model)` 経由なので影響なし (model 上の type 宣言が pq.StringArray なので GORM が正しくシリアライズする)。

## 主な変更点

**Production:**
- \`internal/api/admin/queue.go\`: paramDef strict + GetTaskInfo precheck
- \`internal/api/admin/abuse_report_notification.go\`: paramDef strict + 相関 check
- \`internal/api/admin/avatar_decorations.go\`: pq.StringArray ラップ
- \`internal/api/admin/system_webhook.go\`: pq.StringArray ラップ

**Test:**
- \`internal/testutil/mock_repository.go\`: mock UpdateFields に \`pq.StringArray\` 用の type switch 追加 (production が pq.StringArray を渡しても assertion が通るよう)
- \`internal/api/admin/queue_test.go\`: required param 化に追従、missing-param 専用テスト + #929 B precheck テスト追加
- \`internal/api/admin/abuse_report_notification_test.go\`: required param + 相関 check 専用テスト追加

**Spec tightening (Playwright):**
- \`tests/playwright/specs/admin/avatar_decorations.spec.ts\`: update に \`roleIds: []\` を restore + drift 注釈削除
- \`tests/playwright/specs/admin/system_webhook.spec.ts\`: update の \`[200, 204, 500]\` LCD を \`200\` strict 化
- \`tests/playwright/specs/admin/queue.spec.ts\`: retry-job/remove-job の \`[200, 204, 400, 404]\` LCD を \`[400, 404]\` strict 化

## テスト

- \`make fmt\` / \`make lint\`: 通過
- \`go test -race -count=1 ./internal/api/admin/...\`: pass、coverage 85.9% (CI threshold 80%)
- \`go test -race -count=1 ./internal/api/...\`: 全 api パッケージ pass
- Playwright spec の strict 化は両 backend で nightly が回るため次回 nightly で confirm

## Closes

Closes #929
Closes #931
Closes #932

🤖 Generated with [Claude Code](https://claude.com/claude-code)