### PR TITLE
Fix #936 + #937 + #939: i/webhooks drop-in 互換 strict 化 + on enum

### DIFF
--- a/internal/api/webhooks/handler.go
+++ b/internal/api/webhooks/handler.go
@@ -31,6 +31,18 @@ func isValidWebhookEventType(t string) bool {
 	return ok
 }
 
+// validateOnArray は upstream Misskey TS の paramDef.on.items.enum と同等の
+// 検証を行う (#939)。各要素が webhookEventTypes に含まれていなければ false
+// を返す。空配列 / nil は valid (paramDef では required ではない)。
+func validateOnArray(on []string) bool {
+	for _, e := range on {
+		if !isValidWebhookEventType(e) {
+			return false
+		}
+	}
+	return true
+}
+
 // TestDispatcher is the minimal interface the Test endpoint uses to enqueue
 // a synthetic webhook payload. 循環依存を避けるため interface で受ける
 // (実装は core/webhook.Service 経由、dispatch through DispatchUser)。
@@ -81,6 +93,9 @@ func (h *Handler) Create(c echo.Context) error {
 	}
 	if err := c.Bind(&req); err != nil || req.Name == "" || req.URL == "" {
 		return c.JSON(http.StatusBadRequest, apierr.Error("INVALID_PARAM", "name and url are required.", "ed1d7571-a3ac-4370-899c-0dbe5e230cc8"))
+	}
+	if !validateOnArray(req.On) {
+		return c.JSON(http.StatusBadRequest, apierr.Error("INVALID_PARAM", "on must contain only webhookEventTypes values.", "ed1d7571-a3ac-4370-899c-0dbe5e230cc8"))
 	}
 
 	webhook := &model.Webhook{
@@ -144,6 +159,9 @@ func (h *Handler) Update(c echo.Context) error {
 	}
 	if err := c.Bind(&req); err != nil || req.WebhookID == "" {
 		return c.JSON(http.StatusBadRequest, apierr.Error("INVALID_PARAM", "webhookId is required.", "ed1d7571-a3ac-4370-899c-0dbe5e230cc8"))
+	}
+	if !validateOnArray(req.On) {
+		return c.JSON(http.StatusBadRequest, apierr.Error("INVALID_PARAM", "on must contain only webhookEventTypes values.", "ed1d7571-a3ac-4370-899c-0dbe5e230cc8"))
 	}
 
 	w, err := h.repo.FindByIDAndUserID(req.WebhookID, user.ID)

--- a/internal/api/webhooks/handler.go
+++ b/internal/api/webhooks/handler.go
@@ -12,6 +12,25 @@ import (
 	"github.com/shiroha-a/mk/internal/server/middleware"
 )
 
+// webhookEventTypes mirrors upstream Misskey TS の webhookEventTypes constant
+// (third_party/misskey/.../models/Webhook.ts)。i/webhooks/test の type enum
+// validation で使用 (#937)。
+var webhookEventTypes = map[string]struct{}{
+	"mention":  {},
+	"unfollow": {},
+	"follow":   {},
+	"followed": {},
+	"note":     {},
+	"reply":    {},
+	"renote":   {},
+	"reaction": {},
+}
+
+func isValidWebhookEventType(t string) bool {
+	_, ok := webhookEventTypes[t]
+	return ok
+}
+
 // TestDispatcher is the minimal interface the Test endpoint uses to enqueue
 // a synthetic webhook payload. 循環依存を避けるため interface で受ける
 // (実装は core/webhook.Service 経由、dispatch through DispatchUser)。
@@ -152,7 +171,10 @@ func (h *Handler) Update(c echo.Context) error {
 		return c.JSON(http.StatusInternalServerError, apierr.Error("INTERNAL_ERROR", "Internal error.", "5d37dbcb-891e-41ca-a3d6-e690c97775ac"))
 	}
 
-	return c.JSON(http.StatusOK, packWebhook(w))
+	// upstream Misskey TS の i/webhooks/update は handler 内で値を return しない
+	// ため Endpoint base が 204 を返す (#936)。drop-in 互換のため body 無しの
+	// 204 に揃える。caller は更新後 row が必要なら i/webhooks/show で取り直す。
+	return c.NoContent(http.StatusNoContent)
 }
 
 // Delete handles POST /api/i/webhooks/delete.
@@ -179,14 +201,21 @@ func (h *Handler) Delete(c echo.Context) error {
 // Test handles POST /api/i/webhooks/test.
 // 本家互換: req.type で指定されたイベント種別のテストペイロードを dispatcher
 // に渡し、通常の配信パイプラインを通して登録済み webhook に送信する。
+//
+// upstream Misskey TS の paramDef は webhookId + type を required + type に
+// webhookEventTypes enum check を強制している (third_party/misskey/.../i/
+// webhooks/test.ts、#937)。
 func (h *Handler) Test(c echo.Context) error {
 	user := middleware.GetUser(c)
 	var req struct {
 		WebhookID string `json:"webhookId"`
 		Type      string `json:"type"`
 	}
-	if err := c.Bind(&req); err != nil || req.WebhookID == "" {
-		return c.JSON(http.StatusBadRequest, apierr.Error("INVALID_PARAM", "webhookId is required.", "ed1d7571-a3ac-4370-899c-0dbe5e230cc8"))
+	if err := c.Bind(&req); err != nil || req.WebhookID == "" || req.Type == "" {
+		return c.JSON(http.StatusBadRequest, apierr.Error("INVALID_PARAM", "webhookId and type are required.", "ed1d7571-a3ac-4370-899c-0dbe5e230cc8"))
+	}
+	if !isValidWebhookEventType(req.Type) {
+		return c.JSON(http.StatusBadRequest, apierr.Error("INVALID_PARAM", "type must be one of: mention, unfollow, follow, followed, note, reply, renote, reaction.", "ed1d7571-a3ac-4370-899c-0dbe5e230cc8"))
 	}
 
 	webhook, err := h.repo.FindByIDAndUserID(req.WebhookID, user.ID)
@@ -195,12 +224,8 @@ func (h *Handler) Test(c echo.Context) error {
 	}
 
 	if h.dispatcher != nil {
-		eventType := req.Type
-		if eventType == "" {
-			eventType = "note"
-		}
 		// ダミー body。クライアント側で判定するための最低限のフィールドを入れる。
-		h.dispatcher.DispatchUser(user.ID, eventType, map[string]any{
+		h.dispatcher.DispatchUser(user.ID, req.Type, map[string]any{
 			"test":      true,
 			"webhookId": webhook.ID,
 		})

--- a/internal/api/webhooks/handler_test.go
+++ b/internal/api/webhooks/handler_test.go
@@ -134,6 +134,13 @@ func TestCreate_InvalidParam(t *testing.T) {
 	assert.Equal(t, http.StatusBadRequest, rec.Code)
 }
 
+func TestCreate_InvalidOnEnum(t *testing.T) {
+	// upstream paramDef.on.items.enum: webhookEventTypes (#939)。
+	h, _ := newTestHandler()
+	rec := post(h.Create, `{"name":"test","url":"https://example.com","on":["note","unknownEvent"]}`, &model.User{ID: "u1"})
+	assert.Equal(t, http.StatusBadRequest, rec.Code)
+}
+
 func TestCreate_Error(t *testing.T) {
 	h, repo := newTestHandler()
 	repo.createErr = errMock
@@ -226,6 +233,14 @@ func TestUpdate_NotFound(t *testing.T) {
 func TestUpdate_InvalidParam(t *testing.T) {
 	h, _ := newTestHandler()
 	rec := post(h.Update, `{}`, &model.User{ID: "u1"})
+	assert.Equal(t, http.StatusBadRequest, rec.Code)
+}
+
+func TestUpdate_InvalidOnEnum(t *testing.T) {
+	// upstream paramDef.on.items.enum: webhookEventTypes (#939)。
+	h, repo := newTestHandler()
+	repo.webhooks["w1"] = &model.Webhook{ID: "w1", UserID: "u1", On: pq.StringArray{}}
+	rec := post(h.Update, `{"webhookId":"w1","on":["note","unknownEvent"]}`, &model.User{ID: "u1"})
 	assert.Equal(t, http.StatusBadRequest, rec.Code)
 }
 

--- a/internal/api/webhooks/handler_test.go
+++ b/internal/api/webhooks/handler_test.go
@@ -195,15 +195,16 @@ func TestShow_InvalidParam(t *testing.T) {
 // --- Update ---
 
 func TestUpdate_Success(t *testing.T) {
+	// upstream Misskey TS の i/webhooks/update は body 無しの 204 を返すので
+	// drop-in 互換のため mk-go 側も 204 + body 無しに揃える (#936)。
 	h, repo := newTestHandler()
 	repo.webhooks["w1"] = &model.Webhook{ID: "w1", UserID: "u1", Name: "old", URL: "https://old.example", On: pq.StringArray{}}
 	rec := post(h.Update, `{"webhookId":"w1","name":"new","url":"https://new.example","on":["follow"],"active":false}`, &model.User{ID: "u1"})
-	assert.Equal(t, http.StatusOK, rec.Code)
-
-	var resp map[string]any
-	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
-	assert.Equal(t, "new", resp["name"])
-	assert.Equal(t, false, resp["active"])
+	assert.Equal(t, http.StatusNoContent, rec.Code)
+	assert.Empty(t, rec.Body.String())
+	// repo に反映されていることを確認 (caller は別途 i/webhooks/show で取り直す前提)
+	assert.Equal(t, "new", repo.webhooks["w1"].Name)
+	assert.False(t, repo.webhooks["w1"].Active)
 }
 
 func TestUpdate_Partial(t *testing.T) {
@@ -212,7 +213,7 @@ func TestUpdate_Partial(t *testing.T) {
 	repo.webhooks["w1"] = &model.Webhook{ID: "w1", UserID: "u1", Name: "name", URL: "https://example.com", Secret: secret, On: pq.StringArray{}}
 	newSecret := "newsecret"
 	rec := post(h.Update, `{"webhookId":"w1","secret":"`+newSecret+`"}`, &model.User{ID: "u1"})
-	assert.Equal(t, http.StatusOK, rec.Code)
+	assert.Equal(t, http.StatusNoContent, rec.Code)
 	assert.Equal(t, newSecret, repo.webhooks["w1"].Secret)
 }
 
@@ -296,16 +297,20 @@ func TestTest_Success(t *testing.T) {
 	assert.Equal(t, "note", disp.calls[0].eventType)
 }
 
-func TestTest_DefaultTypeIsNote(t *testing.T) {
+func TestTest_TypeRequired(t *testing.T) {
+	// upstream paramDef は webhookId + type 両方を required にしている (#937)。
 	h, repo := newTestHandler()
 	repo.webhooks["w1"] = &model.Webhook{ID: "w1", UserID: "u1"}
-	disp := &stubDispatcher{}
-	h.SetDispatcher(disp)
-
 	rec := post(h.Test, `{"webhookId":"w1"}`, &model.User{ID: "u1"})
-	assert.Equal(t, http.StatusNoContent, rec.Code)
-	require.Len(t, disp.calls, 1)
-	assert.Equal(t, "note", disp.calls[0].eventType)
+	assert.Equal(t, http.StatusBadRequest, rec.Code)
+}
+
+func TestTest_InvalidType(t *testing.T) {
+	// upstream paramDef は type に webhookEventTypes enum を強制 (#937)。
+	h, repo := newTestHandler()
+	repo.webhooks["w1"] = &model.Webhook{ID: "w1", UserID: "u1"}
+	rec := post(h.Test, `{"webhookId":"w1","type":"unknownEvent"}`, &model.User{ID: "u1"})
+	assert.Equal(t, http.StatusBadRequest, rec.Code)
 }
 
 func TestTest_NoDispatcherStillReturns204(t *testing.T) {
@@ -317,7 +322,7 @@ func TestTest_NoDispatcherStillReturns204(t *testing.T) {
 
 func TestTest_NotFound(t *testing.T) {
 	h, _ := newTestHandler()
-	rec := post(h.Test, `{"webhookId":"ghost"}`, &model.User{ID: "u1"})
+	rec := post(h.Test, `{"webhookId":"ghost","type":"note"}`, &model.User{ID: "u1"})
 	assert.Equal(t, http.StatusNotFound, rec.Code)
 }
 

--- a/internal/api/webhooks/handler_test.go
+++ b/internal/api/webhooks/handler_test.go
@@ -115,6 +115,24 @@ func post(handler func(echo.Context) error, body string, user *model.User) *http
 	return rec
 }
 
+// --- validateOnArray helper (#939) ---
+
+func TestValidateOnArray(t *testing.T) {
+	// nil / 空配列は valid (paramDef では required ではないため許容)。
+	assert.True(t, validateOnArray(nil))
+	assert.True(t, validateOnArray([]string{}))
+	// upstream webhookEventTypes に含まれる値は全て valid。
+	assert.True(t, validateOnArray([]string{"note", "follow", "reaction"}))
+	assert.True(t, validateOnArray([]string{
+		"mention", "unfollow", "follow", "followed",
+		"note", "reply", "renote", "reaction",
+	}))
+	// 1 つでも enum 違反があれば invalid (途中までが valid でも全体を reject)。
+	assert.False(t, validateOnArray([]string{"foo"}))
+	assert.False(t, validateOnArray([]string{"note", "foo"}))
+	assert.False(t, validateOnArray([]string{"note", "Note"})) // case-sensitive
+}
+
 // --- Create ---
 
 func TestCreate_Success(t *testing.T) {

--- a/tests/playwright/specs/i/webhooks.spec.ts
+++ b/tests/playwright/specs/i/webhooks.spec.ts
@@ -58,11 +58,8 @@ test.describe('i/webhooks/* CRUD', () => {
     const shown = (await showResp.json()) as UserWebhook;
     expect(shown.id).toBe(webhookId);
 
-    // 4. update
-    // upstream TS は paramDef で `on` 必須、mk-go は GORM Updates(map) で
-    // pq.StringArray ラップ無しの []string が NULL 化して 500 になる drift
-    // (#932 admin/system-webhook と同 class)。両 backend pass する payload
-    // が存在しないため [200, 204, 500] LCD で吸収する。
+    // 4. update。upstream TS は body 無しの 204 を返す (#936 fix 後は mk-go も
+    //    204 統一)。caller が更新後 row を必要なら i/webhooks/show で取り直す。
     const updResp = await callApi(request, 'i/webhooks/update', {
       i: userToken,
       webhookId,
@@ -72,15 +69,16 @@ test.describe('i/webhooks/* CRUD', () => {
       on: ['mention'],
       isActive: false,
     });
-    expect([200, 204, 500]).toContain(updResp.status());
+    expect(updResp.status()).toBe(204);
 
-    // 5. test (= 仮想 webhook を発火)
+    // 5. test (= 仮想 webhook を発火)。upstream paramDef は webhookId + type 必須 +
+    //    type に webhookEventTypes enum 制約 (#937 fix 後は mk-go も同 strictness)。
     const testResp = await callApi(request, 'i/webhooks/test', {
       i: userToken,
       webhookId,
       type: 'mention',
     });
-    expect([200, 204, 500]).toContain(testResp.status());
+    expect(testResp.status()).toBe(204);
 
     // 6. delete
     const delResp = await callApi(request, 'i/webhooks/delete', {


### PR DESCRIPTION
## Summary

Playwright spec の \`[200, 204, 500]\` LCD 強化中に発見した i/webhooks 系 drift を 3 件 fix (review で #939 を発見、同 PR にバンドル)。

### #936 i/webhooks/update status code drift

| | mk-go (旧) | TS upstream | mk-go (新) |
|---|---|---|---|
| status | 200 + packWebhook(w) | 204 No Content | **204 No Content** |

upstream の Endpoint base は handler 戻り値が無いと 204 を返すため、mk-go も同 shape に揃えた。caller は更新後 row が必要なら \`i/webhooks/show\` で取り直す (upstream と同 flow)。

### #937 i/webhooks/test paramDef drift

| | mk-go (旧) | TS upstream | mk-go (新) |
|---|---|---|---|
| required | \`webhookId\` のみ | \`webhookId\` + \`type\` | \`webhookId\` + \`type\` |
| type enum | (チェック無し) | \`webhookEventTypes\` 8 値 | 同 8 値 enum check |
| 旧 fallback | \`type=""\` で \`"note"\` 補完 | (無し) | 削除 |

\`webhookEventTypes\` (\`mention\`, \`unfollow\`, \`follow\`, \`followed\`, \`note\`, \`reply\`, \`renote\`, \`reaction\`) は \`third_party/misskey/.../models/Webhook.ts\` と一致。

### #939 i/webhooks/{create,update} on array enum drift

PR review で発見した同 class drift。upstream paramDef は \`on.items.enum: webhookEventTypes\` で配列要素まで enum 強制している。mk-go は未検証だったため、不正 event type が DB に投入される可能性があった。\`validateOnArray\` helper で \`isValidWebhookEventType\` を再利用して fix。

### Playwright spec

- \`tests/playwright/specs/i/webhooks.spec.ts\`:
  - update の \`[200, 204, 500]\` LCD → \`204\` strict
  - test の \`[200, 204, 500]\` LCD → \`204\` strict
- 旧コメントの「#932 と同 class で 500」は誤検知。\`i/webhooks\` repo は \`db.Save(model)\` 経由 (\`Updates(map)\` ではない) ため #932 の drift class に該当しないと検証済み。

## 主な変更点

**Production:**
- \`internal/api/webhooks/handler.go\`:
  - \`webhookEventTypes\` 定数 + \`isValidWebhookEventType\` / \`validateOnArray\` helper を追加
  - \`Create\` / \`Update\` で \`on\` array 要素の enum check を追加 (#939)
  - \`Update\` の戻り値を 204 に変更 (#936)
  - \`Test\` の paramDef strict 化 (\`type\` required + enum check)、fallback 削除 (#937)

**Test:**
- \`internal/api/webhooks/handler_test.go\`:
  - \`TestUpdate_Success\` / \`TestUpdate_Partial\` を 204 + body 無し検証に修正
  - \`TestTest_DefaultTypeIsNote\` を削除 (fallback 無くなったため)
  - \`TestTest_TypeRequired\` / \`TestTest_InvalidType\` を新規追加 (#937)
  - \`TestCreate_InvalidOnEnum\` / \`TestUpdate_InvalidOnEnum\` を新規追加 (#939)
  - \`TestTest_NotFound\` を type 込み payload に修正

**Spec:**
- \`tests/playwright/specs/i/webhooks.spec.ts\` の LCD 2 箇所を strict 化

## テスト

- \`make fmt\` / \`make lint\`: 通過
- \`go test -race ./internal/api/webhooks/...\`: pass、coverage **100.0%**

## Closes

Closes #936
Closes #937
Closes #939

🤖 Generated with [Claude Code](https://claude.com/claude-code)