### PR TITLE
docs: CHANGELOG.md Phase 1-8 で消えていた 2 bullets を復元

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -154,3 +154,5 @@ Misskey TS 2 インスタンス + pytest で federation smoke + 状態継承を�
 - フォロー、リアクション、通知
 - WebSocketストリーミング
 - ActivityPub送信/受信
+- ジョブキュー (asynq)
+- 検索 (Meilisearch/SQLフォールバック)


### PR DESCRIPTION
## Summary

PR #950 で CHANGELOG.md を全書き換えした際に、Phase 1-8 セクション末尾の 2 bullets を copy 漏れで落としていた。指摘を受けて復元する 2 行追加 PR。

## 復元する内容

\`\`\`diff
### Phase 1-8 — 基盤構築

  - HTTPサーバー、DB/Redis接続、設定ローダー
  - ユーザー、ノート、タイムライン、ドライブ
  - フォロー、リアクション、通知
  - WebSocketストリーミング
  - ActivityPub送信/受信
+ - ジョブキュー (asynq)
+ - 検索 (Meilisearch/SQLフォールバック)
\`\`\`

## 検証

\`git show 2344adb:CHANGELOG.md\` (= PR #950 の前の最新 CHANGELOG) と diff:

\`\`\`
$ diff <(git show 2344adb:CHANGELOG.md | sed -n '/^### Phase P3/,$p') \\
       <(sed -n '/^### Phase P3/,$p' CHANGELOG.md)
47,48d46
< - ジョブキュー (asynq)
< - 検索 (Meilisearch/SQLフォールバック)
\`\`\`

→ Phase P3 以降は他 byte-for-byte 一致、本 2 bullets だけ欠損していたので追加で完全復元。

🤖 Generated with [Claude Code](https://claude.com/claude-code)