### PR TITLE
docs: README / architecture / federation / testing / configuration / migration を最新化

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,7 +26,7 @@ Playwright spec を両 backend で走らせる中で観測した drop-in 互換 
 - #799: notes/show で visibility 違反時の挙動 (200 で stub note)
 - #874 + perf #892 / #894: timeline endpoint で user mute filter 追加 + SQL push-down + muting subquery 化
 - #876: users/lists/list の N+1 query を batch fetch に
-- #877: notes/search の external search backend 必須 (Meilisearch 未設定で 400)
+- #877: notes/search の `fulltextSearch.provider: "none"` opt-in (= upstream TS strict-mode 互換 400 UNAVAILABLE) を追加。mk-go 既定は引き続き `sqlLike` fallback で動く
 - #878: users/search-by-username-and-host suspend filter
 
 #### drive

--- a/README.md
+++ b/README.md
@@ -2,14 +2,17 @@
 
 Misskey互換のGoバックエンド実装。TypeScript/NestJS製の[Misskey](https://github.com/misskey-dev/misskey)と同一のDB・Redis・フロントエンドを共有し、バックエンドを差し替えられる。
 
-互換バージョン: **Misskey 2026.3.2**
+互換バージョン: **Misskey 2026.3.2** (base) + drift backlog 適用済 (実質 2026.5.x 相当の挙動)
 
 ## 特徴
 
-- Go 1.26 / Echo v4 / GORM + pgx / go-redis v9 / asynq
+- Go 1.26 / Echo v4 / GORM + pgx / go-redis v9
 - Misskeyフロントエンド(SPA)をそのまま配信
 - TypeScript版と同じPostgreSQL/Redisを共有、無停止で移行可能
 - ActivityPub連合対応（HTTP Signatures、リモートオブジェクト解決、配信キュー）
+- ジョブキューは `mkq` (BullMQ wire-compat、デフォルト) または `asynq`
+- Playwright e2e で両 backend (mk-go / TS) を nightly 比較、drop-in 互換 regression を検出
+- `RemoteStatsFetcher` でリモートユーザーの notesCount / followersCount / followingCount を origin から取得 (mk-go 独自拡張)
 
 ## クイックスタート (Docker Compose)
 
@@ -78,7 +81,11 @@ go test -race -count=1 -timeout 10m \
 | [コントリビューション](docs/contributing.md) | Issue/PR運用、レビュー基準 |
 | [TS版からの移行](docs/migration-from-ts.md) | 既存Misskeyからの移行手順 |
 | [E2Eテスト](docs/e2e.md) | Cypressによるフロントエンドテスト |
+| [Drop-in e2e (pytest)](docs/dropin-e2e.md) | TS-A backend を mk-A に差し替えた state preservation 検証 |
+| [Drop-in frontend e2e (cypress)](docs/dropin-frontend-e2e.md) | 3 TS instance + cypress で frontend 視点の互換 |
 | [UDSデプロイ](docs/docker-uds.md) | UNIXドメインソケット構成 |
+| [queue-bench](docs/queue-bench.md) | BullMQ / asynq / mkq の 3-way 比較 (#563) |
+| [upstream 差分](docs/update/) | Misskey TS 2026.3.2 → 2026.5.0 → 2026.5.1 の backend 差分 (`yyyymmdd*` 命名) |
 
 ## ライセンス
 

--- a/docs/api-compatibility.md
+++ b/docs/api-compatibility.md
@@ -82,7 +82,7 @@ Playwright spec を両 backend で走らせる中で観測した「TS と mk-go 
 | #799 | notes/show で visibility 違反時の挙動 (200 で stub note を返す) |
 | #874 | timeline endpoint で user mute filter を追加 (#892 / #894 で perf 最適化) |
 | #876 | users/lists/list の N+1 query を batch fetch に最適化 |
-| #877 | notes/search の external search backend 必須要件 (Meilisearch 未設定で 400) |
+| #877 | notes/search の external search backend 互換: `fulltextSearch.provider: "none"` を opt-in で追加し upstream TS strict-mode (400 UNAVAILABLE) に揃える経路を提供 (mk-go 既定は SQL LIKE fallback で従来通り動く) |
 | #878 | users/search-by-username-and-host の suspend filter |
 
 #### drive
@@ -265,7 +265,7 @@ drop-in テスト (#367) で発見した補完カラム:
 
 - **Identicon の外見** — TS版と生成アルゴリズムが異なるため、アイコン未設定ユーザーの表示が異なる
 - **chat/* の API 設計** — TS版とパス名・パラメータが異なる (mk-go は独自設計)
-- **search backend** — Meilisearch 必須 (mk-go の DB SQL LIKE fallback は upstream に揃え無効化済、#877)
+- **search backend** — `fulltextSearch.provider` で挙動切替: 既定の `sqlLike` (= PostgreSQL `ILIKE` fallback、Meilisearch 不要、軽量 deploy 向け) / `meilisearch` (要 host 設定) / `sqlPgroonga` (要 PGroonga 拡張) / `none` (= upstream TS strict-mode 互換、400 UNAVAILABLE で reject、#877)
 - **2026.4.0 / 2026.5.0 / 2026.5.1 由来の追従未対応** — `#947` tracker 配下、`docs/update/2026050{0,1}diff.md` 参照
   - 連合互換性に直接関わるもの (alsoKnownAs / actor 正規化 / リレー Announce / etc.) は高優先 sub-task として個別 PR 化中
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -61,12 +61,15 @@
 | `following` | フォロー・アンフォロー・リクエスト承認 |
 | `reaction` | リアクション付与・削除 |
 | `timeline` | Redis fanoutによるタイムライン配信 |
-| `federation` | AP配信・受信・リモートオブジェクト解決 |
+| `federation` | AP配信・受信・リモートオブジェクト解決、`RemoteStatsFetcher` (リモート users/show counts 取得、#943) |
 | `drive` | ファイルストレージ (Local/S3)、画像変換 |
+| `mediaproxy` | リモート画像のキャッシュ proxy。GIF/APNG はアニメ pass-through (#941)、AVIF/HEIC/JXL decode 等 |
+| `urlpreview` | OG/Twitter/oEmbed プレビュー取得。`charset.NewReader` で Shift_JIS/EUC-JP 等の自動正規化 (#942) |
 | `notification` | 通知生成・配信 |
 | `chart` | 統計チャートエンジン (12エンジン) |
 | `search` | 全文検索 (Meilisearch / SQLフォールバック) |
 | `twofactor` | TOTP/WebAuthn認証 |
+| `wordmute` | 単語ミュートのパース・キャッシュ (LRU、#790) |
 
 ### `internal/repository/` (データアクセス、46ファイル)
 
@@ -106,15 +109,20 @@ Misskey-TSのテーブルと1:1対応するGORM構造体。
 
 ### `internal/queue/` (ジョブキュー)
 
-asynq (Redisベース) によるバックグラウンドジョブ。`processors/`配下にタスク実装:
+driver は `mkq` (BullMQ wire-compatible、デフォルト) または `asynq` (legacy)。設定 `jobQueueDriver` で切替 (#571 audit、#563 で 3-way bench 後 mkq を default 化)。`processors/`配下にタスク実装:
 
 - `deliver` — AP配信 (リトライ付き)
+- `inbox` — AP受信 (#565 で verify-in-worker 化、HTTP handler は 202 即返し)
 - `webhook` — Webhook送信
 - `webpush` — Web Push通知
 - `emoji_import` — カスタム絵文字インポート
 - `clean_remote_notes` — リモートノートクリーンアップ
 - `reaction_flush` — リアクションバッファのDB書き込み
 - `transfer` — アカウント移行
+
+### `internal/safehttp/`
+
+SSRF-safe HTTP transport を提供 (`NewSSRFSafeTransport`)。private IP / loopback / metadata service への接続を DNS resolve 段階で reject。`urlpreview` / `mediaproxy` / federation の `RemoteStatsFetcher` で共通利用。
 
 ### `internal/stream/` (WebSocket)
 
@@ -196,9 +204,9 @@ Misskeyは用途別に複数のRedis接続を持つ。設定で同一ホスト�
 
 ## マイグレーション
 
-`migration/`ディレクトリにgolang-migrate用のSQLファイルを配置 (000001〜000036)。
+`migration/`ディレクトリにgolang-migrate用のSQLファイルを配置 (000001 ~ 000047、2026-05-09 時点)。
 
-TS版Misskeyの既存テーブルには追加のみで破壊的変更を行わない。Go固有のテーブル追加とカラム追加はすべてIF NOT EXISTS付き。
+TS版Misskeyの既存テーブルには追加のみで破壊的変更を行わない。Go固有のテーブル追加とカラム追加はすべてIF NOT EXISTS付き。drop-in テスト (#367) で発見した補完カラム (`note.pageCount` / `note.renoteChannelId`) は `000039_dropin_compat.up.sql` で追加済。
 
 ```bash
 make migrate-up      # 最新まで適用

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -120,7 +120,7 @@ cp .config/docker.yml.example .config/docker.yml
 | `proxy` | string | - | 外向き HTTP のプロキシ URL (PR #485) |
 | `proxySmtp` | string | - | SMTP 配送のプロキシ URL。`http://host:port` (HTTP CONNECT)、`https://host:port`、`socks5://[user:pass@]host:port` (#496) |
 | `proxyBypassHosts` | []string | - | プロキシを迂回するホスト (HTTP のみ) |
-| `allowedPrivateNetworks` | []string | - | AP fetchで許可するプライベートネットワーク |
+| `allowedPrivateNetworks` | []string | - | プライベート IP / loopback / metadata service へのアウトバウンド接続を許可する CIDR allowlist。AP fetch / URL preview / mediaproxy / `RemoteStatsFetcher` (#943) で共通に効く。開発時の self-loop 用途 (`127.0.0.0/8` 等)、本番では空のまま運用する |
 | `outgoingAddress` | string | - | 外向き HTTP の送信元 IP として bind するアドレス。複数 NIC 環境で federation 配信の source IP を固定する用途 (#496)。不正値は警告のみで kernel auto-pick に fallback |
 | `outgoingAddressFamily` | string | `dual` | DNS 解決後の IP family 制限。`"ipv4"` / `"ipv6"` 指定で該当 family のみで dial、`"dual"` または空で両方 (#496) |
 

--- a/docs/federation.md
+++ b/docs/federation.md
@@ -21,6 +21,8 @@
 | `resolver.go` | リモートアクター/ノートの取得・永続化。公開鍵の2層キャッシュ (メモリ+DB, TTL 24h) |
 | `deliver_service.go` | 配信ジョブのエンキュー。フォロワーのInbox収集、ホストブロック判定 |
 | `processor.go` | 受信Activityのディスパッチ (Follow, Create, Like, Announce, Delete, Update等) |
+| `published_time.go` | AP `published` を parse + clock skew (5min) / 過去 10 年 floor で fallback (#940) |
+| `remote_stats.go` | リモート user の notesCount/followersCount/followingCount を origin の `/api/users/show` から取得 (mk-go 独自拡張、#943)。LRU cache size cap 10000 (#945)、SSRF guard 経由 |
 | `note_delivery_hook.go` | ノート公開時にCreate/Announceを配信 |
 | `following_delivery_hook.go` | フォロー/アンフォロー/承認時にFollow/Undo/Acceptを配信 |
 | `reaction_delivery_hook.go` | リアクション時にLikeを配信 |
@@ -82,20 +84,57 @@ DeliverProcessor (asynqワーカー)
 
 ## Inbox処理
 
-`internal/api/inbox/handler.go`がShared InboxとユーザーInboxの両方を処理する。
+`internal/api/inbox/handler.go`がShared InboxとユーザーInboxの両方を処理する。**verify-in-worker 化済 (#565)**: HTTP handler では body + signature header を payload として queue に詰めて 202 即返し、verify は inbox worker (asynq processor) で行う。これにより HTTP 受信スループットが TS の 2.6-2.8x。
 
-**処理フロー:**
+**HTTP handler フロー (同期、軽量):**
 1. リクエストボディ読み取り
-2. Signatureヘッダー解析
-3. `keyId`からアクター解決
-4. 公開鍵取得 (キャッシュ優先)
-5. 署名検証
-6. ホストブロックチェック
-7. インスタンスメタデータ更新
-8. チャートメトリクス記録
-9. Processorにディスパッチ
+2. queue/processors の inbox 用 payload を作成 (body + signature header)
+3. asynq enqueue
+4. 202 Accepted 即返し
+
+**inbox worker フロー (非同期、`internal/queue/processors/inbox.go`):**
+1. payload から body / Signature header を復元
+2. Signature 解析 → `keyId` からアクター解決
+3. 公開鍵取得 (キャッシュ優先) → 署名検証
+4. ホストブロックチェック
+5. インスタンスメタデータ更新 (`InstanceTouchBuffer` で per-host 1s buffer 集約、#569)
+6. チャートメトリクス記録
+7. Processor にディスパッチ
+8. fanoutHook / notificationHook を `safeGo` で async 発火 (#569)
 
 未対応のActivity種別にも202 Acceptedを返す (エラーにしない)。
+
+## 遅延配送 note の createdAt (#940)
+
+origin instance の downtime / 遅延配送等で過去の note が遅れて inbox に到着した場合、AP Object の `published` field を parse して time-based ID (aidx) に渡すことで timeline 並びを origin と揃える。
+
+- 受け入れ: RFC3339 / RFC3339Nano
+- spoof guard: 未来側 `+5min` skew tolerance を超える値は受信時刻にフォールバック
+- parse バグ guard: 過去 10 年以上前の値もフォールバック
+- 該当 helper: `internal/core/federation/published_time.go` の `parseAPPublishedTime`
+
+## AP variant handling
+
+upstream / 他実装が出してくる variant に対するロバスト性 (一部は #947 配下で対応中):
+
+| variant | 状態 |
+|---|---|
+| `published` parse + 異常値 fallback | ✅ 対応済 (#940) |
+| `attributedTo` / `actor` の string / object 双方受け入れ | 🟡 #947 配下で対応予定 (upstream #17340) |
+| `alsoKnownAs` の array / string 双方受け入れ | 🟡 #947 配下で対応予定 (upstream #17275) |
+| 存在しない Actor の Delete を ignore | 🟡 #947 配下で対応予定 (upstream #17294) |
+| リレー由来 Announce で renote を作らず元 note を直接 publish | 🟡 #947 配下で対応予定 (upstream #17308) |
+| ブロック中インスタンスの inbox job 蓄積防止 | 🟡 #947 配下で対応予定 (upstream #17336) |
+
+## RemoteStatsFetcher (mk-go 独自拡張、#943)
+
+upstream Misskey TS の `users/show` は **自インスタンスで観測した範囲** のみで notesCount / followersCount / followingCount を集計するため、リモートユーザーの数値が実体より小さく表示される。mk-go は user.Host が non-local の場合、origin instance の `/api/users/show` を https POST で叩いて公開 counts を取得し、上書き表示する。
+
+- LRU cache: size cap 10000 / positive TTL 1h / negative TTL 5min (#945)
+- SSRF guard: `safehttp.NewSSRFSafeTransport` 経由
+- host validation: URL injection (`/`, `?`, `#`, `@`, ` `) を url.Parse で reject
+- 失敗時は silent fallback で local 観測値を維持
+- フォロー一覧 / フォロワー一覧 endpoint は **自インスタンス上に存在する関係のみ** (= 数値だけ remote、一覧は local の非対称設計)
 
 ## レンダリング
 

--- a/docs/migration-from-ts.md
+++ b/docs/migration-from-ts.md
@@ -141,18 +141,36 @@ Misskey-TSに戻す場合の手順:
 
 データベースは双方向に互換性があり、mk-goが追加したテーブルはMisskey-TSからは無視される。
 
+## drop-in 互換性の現状 (2026-05-09 時点)
+
+Playwright Phase 1-4 完了 (#744) で **96 spec / 35 directory / 242 endpoint cover (54.3%)** を mk-go と Misskey TS の両 backend で nightly 検証中。発見した drop-in 互換 drift は 40+ 件すべて解消済 (詳細: [api-compatibility.md](api-compatibility.md))。
+
+- **API endpoint 互換**: 主要 endpoint (admin / notes / users / i / drive / chat / reactions / timeline / emoji / auth / federation / channels / hashtags / roles 等) は両 backend で同 status / 同 shape を返す
+- **WebSocket チャンネル**: 19/19 実装済 (#125)
+- **ActivityPub 連合**: 主要 Activity (Create / Delete / Update / Follow / Accept / Reject / Undo / Like / Announce / Block / Flag / Move / Add/Remove) は送受信対応 (詳細: [federation.md](federation.md))
+
 ## 既知の制限
 
-### 未実装の機能
+### 未実装 / 設計差異
 
 - **公開サインアップのメール認証フロー** — `emailRequiredForSignup` 有効時の pending user → メール確認フローは未実装
-- **Reversi** — ゲーム一覧は取得できるがリアルタイム対戦は未実装
+- **Reversi リアルタイム対戦** — ゲーム一覧 / WebSocket チャンネル / multiplayer は実装済 (Phase 3 spec verified)、初期実装 (#417) 由来の手動検証経路あり
 - **サーバーマシン統計** — `enableServerMachineStats` 有効時に CPU/メモリ/ディスク情報を返すが、gopsutil相当の詳細度はない
+- **chat/* の API 設計** — TS版とパス名・パラメータが異なる (mk-go 独自設計)
+- **Identicon** — 生成される自動アバターの見た目が若干異なる
+- **search backend** — `notes/search` で Meilisearch 必須化 (#877)、未設定インスタンスは 400 を返す (TS と同一挙動)
+- **2026.4.0 / 2026.5.0 / 2026.5.1 への upstream 追従** — #947 tracker 配下で sub-task 化中。詳細: [docs/update/](update/)
+
+### mk-go 独自挙動 (TS にない拡張)
+
+- **リモートユーザー counts**: `users/show` でリモートユーザーの notesCount / followersCount / followingCount を origin instance の `/api/users/show` から取得して上書き (#943)。TS は自インスタンス観測値のみ表示するため数値が小さくなる問題を解消。フォロー一覧 / フォロワー一覧は引き続き local user のみ
+- **mediaproxy アニメ pass-through**: GIF / APNG をリアクション / 絵文字ピッカー / プレビューで静止化せずに pass-through (#941)
+- **URL preview の charset 自動正規化**: Shift_JIS / EUC-JP / ISO-2022-JP 等のページで title / description が文字化けしない (#942)
+- **inbox handler の verify-in-worker 化** (#565): HTTP 受信スループットが TS の 2.6-2.8x
 
 ### Misskey-TSとの差異
 
 - **タイムライン** — Redisキャッシュが空の場合 (サーバー再起動直後等) はDBクエリにフォールバックする
-- **Identicon** — 生成される自動アバターの見た目が若干異なる
 - **通知** — WebSocketによるリアルタイム配信は対応しているが、一部のイベントタイプで差異がある可能性がある
 
 ## トラブルシューティング

--- a/docs/migration-from-ts.md
+++ b/docs/migration-from-ts.md
@@ -158,7 +158,7 @@ Playwright Phase 1-4 完了 (#744) で **96 spec / 35 directory / 242 endpoint c
 - **サーバーマシン統計** — `enableServerMachineStats` 有効時に CPU/メモリ/ディスク情報を返すが、gopsutil相当の詳細度はない
 - **chat/* の API 設計** — TS版とパス名・パラメータが異なる (mk-go 独自設計)
 - **Identicon** — 生成される自動アバターの見た目が若干異なる
-- **search backend** — `notes/search` で Meilisearch 必須化 (#877)、未設定インスタンスは 400 を返す (TS と同一挙動)
+- **search backend** — `notes/search` の provider は `fulltextSearch.provider` で切替。既定 `sqlLike` で **Meilisearch 不要のまま動く** (PostgreSQL `ILIKE` fallback)。upstream TS strict-mode (400 UNAVAILABLE) で揃えたい operator は `provider: "none"` を opt-in で選べる (#877)。Meilisearch / pgroonga は optional
 - **2026.4.0 / 2026.5.0 / 2026.5.1 への upstream 追従** — #947 tracker 配下で sub-task 化中。詳細: [docs/update/](update/)
 
 ### mk-go 独自挙動 (TS にない拡張)

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -6,8 +6,11 @@
 |---|---|---|---|
 | ユニットテスト | APIハンドラ、サービスロジック | モック | `go test ./internal/api/...` |
 | 統合テスト | リポジトリ、Redis連携 | 実DB (testcontainers) | `go test ./internal/core/...` |
-| E2Eテスト | フロントエンド操作 | 実DB + フロントエンド | `make e2e-run` (詳細は[E2Eテスト](e2e.md)) |
+| E2Eテスト (Cypress) | フロントエンド操作 | 実DB + フロントエンド | `make e2e-run` (詳細は[E2Eテスト](e2e.md)) |
 | 連合テスト | mk-go ↔ Misskey AP通信 | Docker Compose多段 | `make federation-misskey-test` |
+| Drop-in e2e (pytest) | TS-A backend を mk-A に差し替えて state preservation 検証 | TS 2 instance + mk overlay | `make dropin-swap-test` (#365 / #367 / #372 / #374、詳細は[dropin-e2e.md](dropin-e2e.md)) |
+| Drop-in frontend e2e (cypress) | 3 TS instance + mk overlay swap で frontend 視点の互換 | cypress + 3 TS + mk-A | `make dropin-frontend-swap-test` (#380 / #381 / #387 / #394、詳細は[dropin-frontend-e2e.md](dropin-frontend-e2e.md)) |
+| Playwright e2e | mk-go と Misskey TS の両 backend で API/frontend 統合互換を nightly 監視 | Docker Compose 全部 | `tests/playwright/` 配下 (#744、Phase 1-4 完了で 96 spec / 35 directory / 242 endpoint cover = 54.3%) |
 
 ## 実行方法
 
@@ -33,9 +36,12 @@ go tool cover -html=coverage.out
 | CIゲート (最低ライン) | 90% | これを下回るとCIが失敗しマージ不可 |
 | 推奨ライン | 95% | 通常のPRではここを目指す |
 | 目標ライン | 100% | 新規パッケージや小規模パッケージで積極的に狙う |
-| `internal/api/admin` | 60% | 管理APIのみCIゲートが低め (可能な限り引き上げる) |
+| `internal/api/admin` | 80% | SMTP/queue/DB集計等の外部依存で 90% 未到達のため暫定緩和 (#260 以降) |
+| `internal/testutil` | 0% | mock / test helper 専用、production code を含まないため閾値対象外 |
+| `internal/server` | 0% | router.go (~2000 行) の wire 層中心、e2e/drop-in test で実挙動検証 (#462) |
+| e2e | 0% | 統合 test 専用 |
 
-CIではパッケージごとにカバレッジを計測し、閾値未達のパッケージがあればジョブが失敗する。
+CIではパッケージごとにカバレッジを計測し、閾値未達のパッケージがあればジョブが失敗する。CI は **4-way matrix shard** で並列実行され、ImportPath 順 modulo 分配で決定的にパッケージを割り当てる (約 4.7 分 → 1.5-2 分に短縮)。
 
 ## testcontainers
 
@@ -158,3 +164,51 @@ make federation-misskey-down
 ```
 
 テストはPython (pytest)で記述され、`tests/federation/`に配置。両インスタンスに共通のAPI互換クライアント(`MisskeyLikeClient`)を使ってフォロー、ノート作成、リアクション等の連合動作を検証する。
+
+## Playwright e2e (drop-in 互換 nightly)
+
+`tests/playwright/` 配下の spec を mk-go と Misskey TS の **両 backend** で並列実行し、drop-in 互換 regression を nightly 監視する基盤。
+
+- 範囲: 96 spec / 35 directory / 242 endpoint cover (= router.go 登録 448 endpoint の 54.3%)
+- backend matrix: `mk-go` / `ts` 並列、`fail-fast: false` で片方失敗しても他方は完走
+- スケジュール: nightly 17:00 UTC (`.github/workflows/playwright.yml`)
+- spec は **backend-agnostic** (= URL 切替だけで両 backend で動く)、spec 失敗 = drop-in 互換 regression として issue 化
+
+### Drift detection workflow
+
+Playwright で発見した drift は LCD 化 → strict 化 のサイクルで消化する:
+
+1. spec を書いて両 backend で走らせる
+2. 挙動が異なる場合は `expect([200, 204]).toContain(...)` 等の **LCD (Lowest Common Denominator)** で吸収して両 backend pass させる
+3. LCD のコメントで drift 内容を記録、別 issue として起票
+4. drift fix PR で mk-go 側を strict 仕様 (= upstream Misskey TS の挙動) に揃える
+5. 同 PR で spec の LCD を strict (`expect(...).toBe(204)` 等) に格上げ
+
+**実績**: Phase 1-4 で 40+ 件の drift を fix。詳細は [api-compatibility.md](api-compatibility.md) の「対応済 drift fix」section、または #744 / #947 tracker 参照。
+
+## Drop-in テスト
+
+state preservation や frontend 視点の drop-in 互換を検証する 2 系統:
+
+### Drop-in e2e (pytest, `tests/dropin/`)
+
+Misskey TS 2 インスタンス (TS-A / TS-B) を起動して federation smoke を実行する基盤に、`docker-compose.dropin.mk.yml` overlay で TS-A の backend を mk-A に差し替えて **state 引き継ぎ** を検証する。
+
+```bash
+make dropin-up                 # TS-A / TS-B 起動 (smoke baseline)
+make dropin-mk-up              # 上から mk-A overlay (= clean DB の mk-A)
+make dropin-swap-test          # TS-then-mk 切替シナリオ (bash orchestrator)
+```
+
+nightly 18:00 UTC で `dropin-swap-test` を develop に対して実行 (`.github/workflows/dropin-e2e.yml`)。
+
+### Drop-in frontend e2e (cypress, `tests/dropin_frontend/`)
+
+3 Misskey TS インスタンス (A/B/C) + cypress runner で実ブラウザから frontend 視点の drop-in 互換を検証する。Phase 14-3 (#394) で TS-A → mk-A 切替後も spec が pass することを e2e 確認 (`CYPRESS_MODE=baseline|swap` で skip 制御)。
+
+```bash
+make dropin-frontend-baseline      # TS-A/B/C + cypress baseline spec 実行
+make dropin-frontend-swap-test     # TS-A → mk-A 切替まで含む end-to-end
+```
+
+nightly 19:00 UTC で `dropin-frontend-e2e` を実行 (`.github/workflows/dropin-frontend-e2e.yml`)。


### PR DESCRIPTION
## Summary

#949 親 tracker の高〜中優先 sub-task を Edit ベース (= 既存内容を保持しつつ追記) で一気に消化:

- ✅ #2: \`docs/architecture.md\`
- ✅ #3: \`docs/federation.md\`
- ✅ #4: \`docs/testing.md\`
- ✅ #5: \`docs/migration-from-ts.md\`
- ✅ #6: \`docs/configuration.md\`
- ✅ 横断: \`README.md\`

すべて Edit + 部分書換のみで全書換は無し (= PR #951 の事故再発防止)。

## 主な変更点

### README.md
- 互換 version 表記を \`Misskey 2026.3.2 base + drift backlog 適用済 (実質 2026.5.x 相当)\` に
- 特徴に mkq driver / Playwright nightly / RemoteStatsFetcher を追記
- doc table に dropin-e2e / dropin-frontend-e2e / queue-bench / upstream 差分 (\`docs/update/\`) を追加

### docs/architecture.md
- core packages table に \`mediaproxy\` (#941) / \`urlpreview\` (#942) / \`wordmute\` を追記、federation 内に \`RemoteStatsFetcher\` (#943) を追記
- queue processors に \`inbox\` (#565 verify-in-worker) を追加
- \`internal/safehttp\` (SSRF guard) を新 section
- migration count を 36 → 47 + drop-in compat 補完カラム言及

### docs/federation.md
- \`internal/core/federation/\` ファイル table に \`published_time.go\` (#940) / \`remote_stats.go\` (#943) を追記
- Inbox 処理を **verify-in-worker 構成** (#565) で書き直し (HTTP handler 軽量化 / inbox worker での検証 / instance touch buffer / async hook)
- 新 section:
  - **遅延配送 note の createdAt** (#940): RFC3339 parse + skew/floor guard
  - **AP variant handling**: published / actor / alsoKnownAs / Delete / リレー Announce / blocked instance の variant 状況 (#947 配下追従と合わせ)
  - **RemoteStatsFetcher** (#943, mk-go 独自拡張): cache / SSRF guard / host validation / 非対称設計

### docs/testing.md
- テスト種類 table に **Drop-in e2e (pytest)** / **Drop-in frontend e2e (cypress)** / **Playwright e2e** を追加
- カバレッジ閾値 table に admin 80% / testutil 0% / server 0% / e2e 0% の例外を追記、4-way matrix shard 化に言及
- 新 section:
  - **Playwright e2e** (drift detection workflow 含む)
  - **Drop-in テスト** (pytest 系 + cypress 系)

### docs/configuration.md
- \`allowedPrivateNetworks\` の説明を「AP fetch」のみから **「AP fetch / URL preview / mediaproxy / RemoteStatsFetcher 共通」** に拡張

### docs/migration-from-ts.md
- 新 section: **drop-in 互換性の現状 (2026-05-09 時点)** = Phase 4 完了 / 40+ drift fix 解消済
- 既知の制限を update + **mk-go 独自挙動 (TS にない拡張)** section 追加: RemoteStatsFetcher / アニメ pass-through / charset 正規化 / inbox verify-in-worker

## テスト

doc only。コード変更なし、CI 影響なし。

## Closes / 関連

- 関連: #949 (ドキュメント更新親 tracker) sub-task #2-#6 + 横断 README
- 上位 tracker: #744 (Playwright) / #947 (upstream catch-up)
- 並走 PR (merge 済): #948 (\`docs/update/\` 整理) / #950 (api-compat + CHANGELOG)

🤖 Generated with [Claude Code](https://claude.com/claude-code)