### PR TITLE
Fix #955 + #956: pages/show username + i/update fields drift bundle

### DIFF
--- a/internal/api/i/handler.go
+++ b/internal/api/i/handler.go
@@ -699,6 +699,18 @@ type UpdateRequest struct {
 	// 時に CheckWordMute で除外する。
 	MutedWords     json.RawMessage `json:"mutedWords"`
 	HardMutedWords json.RawMessage `json:"hardMutedWords"`
+	// Fields はプロフィール上の name/value ペア (#956)。upstream paramDef は
+	// `array of {name, value}` で maxItems 16。nil (= 省略) は不変、`[]` で
+	// クリア、要素ありで上書き。core/user 側で trim + 空 entry 排除を行う。
+	Fields *[]FieldInput `json:"fields"`
+}
+
+// FieldInput is the {name, value} shape accepted by i/update for profile
+// fields (#956). upstream paramDef のように name / value を string で
+// 受け取り、core/user 側で trim + 空 entry 除外を行う。
+type FieldInput struct {
+	Name  string `json:"name"`
+	Value string `json:"value"`
 }
 
 // AvatarDecorationInput is one entry of the avatarDecorations array on
@@ -891,6 +903,19 @@ func (h *Handler) Update(c echo.Context) error {
 		default:
 			return apierr.JSONInvalidParam(c)
 		}
+	}
+	if req.Fields != nil {
+		// upstream paramDef は maxItems 16。超過は INVALID_PARAM で弾く
+		// (= cherrypick / Misskey TS と同じ挙動)。各要素の trim / 空除外は
+		// core/user 側で行う。
+		if len(*req.Fields) > 16 {
+			return apierr.JSONInvalidParam(c)
+		}
+		items := make([]user.FieldItem, len(*req.Fields))
+		for i, f := range *req.Fields {
+			items[i] = user.FieldItem{Name: f.Name, Value: f.Value}
+		}
+		in.Fields = &items
 	}
 
 	bundle, err := h.userService.UpdateProfile(me.ID, in)

--- a/internal/api/i/handler_test.go
+++ b/internal/api/i/handler_test.go
@@ -637,6 +637,22 @@ func TestUpdate_FieldsPersisted(t *testing.T) {
 	)
 }
 
+// 空配列 fields=[] を投げると現状を `[]` で上書き (= clear)。nil との挙動
+// 差別化を handler 経路で確認する。
+func TestUpdate_FieldsEmptyClears(t *testing.T) {
+	h, repo, _, _ := newTestHandler(t)
+	user := &model.User{ID: "user1", Username: "user1", AvatarDecorations: datatypes.JSON([]byte("[]"))}
+	repo.Users["user1"] = user
+	repo.Profiles["user1"] = &model.UserProfile{
+		UserID: "user1",
+		Fields: datatypes.JSON([]byte(`[{"name":"x","value":"y"}]`)),
+	}
+
+	rec := post(h.Update, `{"fields":[]}`, user)
+	assert.Equal(t, http.StatusOK, rec.Code)
+	assert.JSONEq(t, `[]`, string(repo.Profiles["user1"].Fields))
+}
+
 // upstream paramDef は maxItems 16。それ超えは INVALID_PARAM (400)。
 func TestUpdate_FieldsTooMany(t *testing.T) {
 	h, repo, _, _ := newTestHandler(t)

--- a/internal/api/i/handler_test.go
+++ b/internal/api/i/handler_test.go
@@ -618,6 +618,46 @@ func TestUpdate_ChatScope_OmittedIsNoop(t *testing.T) {
 	assert.Equal(t, "followers", repo.Users["user1"].ChatScope)
 }
 
+// #956: i/update で fields を accept して user_profile.fields に persist する。
+// trim と空 entry 排除は core/user 側で行う。本 test は handler 経由で
+// fields が core まで届くことを確認する。
+func TestUpdate_FieldsPersisted(t *testing.T) {
+	h, repo, _, _ := newTestHandler(t)
+	user := &model.User{ID: "user1", Username: "user1", AvatarDecorations: datatypes.JSON([]byte("[]"))}
+	repo.Users["user1"] = user
+	repo.Profiles["user1"] = &model.UserProfile{UserID: "user1", Fields: datatypes.JSON([]byte("[]"))}
+
+	rec := post(h.Update, `{"fields":[{"name":"  blog ","value":" https://example.com "},{"name":"","value":"empty"},{"name":"x","value":"y"}]}`, user)
+	assert.Equal(t, http.StatusOK, rec.Code)
+	p := repo.Profiles["user1"]
+	require.NotNil(t, p)
+	assert.JSONEq(t,
+		`[{"name":"blog","value":"https://example.com"},{"name":"x","value":"y"}]`,
+		string(p.Fields),
+	)
+}
+
+// upstream paramDef は maxItems 16。それ超えは INVALID_PARAM (400)。
+func TestUpdate_FieldsTooMany(t *testing.T) {
+	h, repo, _, _ := newTestHandler(t)
+	user := &model.User{ID: "user1", Username: "user1", AvatarDecorations: datatypes.JSON([]byte("[]"))}
+	repo.Users["user1"] = user
+	repo.Profiles["user1"] = &model.UserProfile{UserID: "user1", Fields: datatypes.JSON([]byte("[]"))}
+
+	// 17 entries
+	items := ""
+	for i := 0; i < 17; i++ {
+		if i > 0 {
+			items += ","
+		}
+		items += `{"name":"a","value":"b"}`
+	}
+	rec := post(h.Update, `{"fields":[`+items+`]}`, user)
+	assert.Equal(t, http.StatusBadRequest, rec.Code)
+	// 失敗したので fields は不変 ([] のまま)
+	assert.JSONEq(t, `[]`, string(repo.Profiles["user1"].Fields))
+}
+
 func TestUpdate_UserNotFound(t *testing.T) {
 	h, _, _, _ := newTestHandler(t)
 	user := &model.User{ID: "ghost"}

--- a/internal/api/pages/handler.go
+++ b/internal/api/pages/handler.go
@@ -25,11 +25,14 @@ type MainStreamPublisher interface {
 	PublishMainEvent(userID, eventType string, body any)
 }
 
-// UserBundleSource fetches a user + profile bundle used to pack the caller
-// for the `pageEvent` body. Narrow interface — satisfied by
+// UserBundleSource fetches a user + profile bundle. ShowByID is used to pack
+// the caller for the `pageEvent` body emitted from /api/page-push, and
+// ShowByUsername is used to resolve the upstream-compatible
+// {username, name} shape on /api/pages/show (#955). Satisfied by
 // *core/user.Service.
 type UserBundleSource interface {
 	ShowByID(id string) (*coreuser.UserWithProfile, error)
+	ShowByUsername(username string, host *string) (*coreuser.UserWithProfile, error)
 }
 
 // Handler handles page-related API endpoints.
@@ -105,12 +108,15 @@ func (h *Handler) Create(c echo.Context) error {
 	return c.JSON(http.StatusOK, h.pageToMap(p))
 }
 
-// ShowRequest is the request body for pages/show. pageId か (userId, name) の
-// どちらかを指定する。
+// ShowRequest is the request body for pages/show. upstream Misskey TS の
+// paramDef は anyOf で 3 形を accept する: {pageId} / {userId, name} /
+// {username, name} (#955)。frontend (page.vue) は 3 つ目の {username, name}
+// を投げてくるので、本 struct も同 shape を受ける。
 type ShowRequest struct {
-	PageID string `json:"pageId"`
-	UserID string `json:"userId"`
-	Name   string `json:"name"`
+	PageID   string `json:"pageId"`
+	UserID   string `json:"userId"`
+	Username string `json:"username"`
+	Name     string `json:"name"`
 }
 
 // Show handles POST /api/pages/show.
@@ -133,6 +139,18 @@ func (h *Handler) Show(c echo.Context) error {
 		p, err = h.svc.Show(requesterID, req.PageID)
 	case req.UserID != "" && req.Name != "":
 		p, err = h.svc.ShowByName(requesterID, req.UserID, req.Name)
+	case req.Username != "" && req.Name != "":
+		// {username, name} 経路 (#955): username で local user を引いて
+		// その user.id + name で page を引く。upstream は host=NULL の
+		// local user 縛り (= remote の page は連合経路で配信されない)。
+		if h.userSource == nil {
+			return apierr.JSONInternalError(c)
+		}
+		bundle, ulerr := h.userSource.ShowByUsername(req.Username, nil)
+		if ulerr != nil || bundle == nil || bundle.User == nil {
+			return notFound(c)
+		}
+		p, err = h.svc.ShowByName(requesterID, bundle.User.ID, req.Name)
 	default:
 		return apierr.JSONInvalidParam(c)
 	}

--- a/internal/api/pages/handler_test.go
+++ b/internal/api/pages/handler_test.go
@@ -127,6 +127,41 @@ func TestShow_ByName(t *testing.T) {
 	assert.Equal(t, http.StatusOK, rec.Code)
 }
 
+func TestShow_ByUsername(t *testing.T) {
+	// #955: pages/show が {username, name} 経路も accept する。upstream
+	// frontend (page.vue) はこの shape を投げるので drop-in 互換に必須。
+	h, repo, _ := newHandler(t)
+	repo.Pages["p1"] = &model.Page{ID: "p1", UserID: "alice", Name: "alpha", Visibility: model.PageVisibilityPublic}
+	h.SetUserSource(&stubUserSource{
+		byUsernameBundle: &coreuser.UserWithProfile{User: &model.User{ID: "alice", Username: "alice"}},
+	})
+	c, rec := newReq(t, `{"username":"alice","name":"alpha"}`)
+	require.NoError(t, h.Show(c))
+	assert.Equal(t, http.StatusOK, rec.Code)
+}
+
+func TestShow_ByUsername_UserNotFound(t *testing.T) {
+	// username が存在しない場合は 404 (= NO_SUCH_PAGE と同じ shape) を
+	// 返す。upstream は user 不在も page 不在もまとめて noSuchPage に
+	// 集約する設計。
+	h, _, _ := newHandler(t)
+	h.SetUserSource(&stubUserSource{
+		byUsernameErr: errors.New("user not found"),
+	})
+	c, rec := newReq(t, `{"username":"ghost","name":"alpha"}`)
+	require.NoError(t, h.Show(c))
+	assert.Equal(t, http.StatusNotFound, rec.Code)
+}
+
+func TestShow_ByUsername_NoLookupConfigured(t *testing.T) {
+	// userSource 未注入の場合、{username, name} 経路は internal error
+	// (= 通常配線では起こらないが defense-in-depth)。
+	h, _, _ := newHandler(t)
+	c, rec := newReq(t, `{"username":"alice","name":"alpha"}`)
+	require.NoError(t, h.Show(c))
+	assert.Equal(t, http.StatusInternalServerError, rec.Code)
+}
+
 func TestShow_BadJSON(t *testing.T) {
 	h, _, _ := newHandler(t)
 	c, rec := newReq(t, `{not`)
@@ -517,11 +552,23 @@ func (s *stubMainStreamPublisher) PublishMainEvent(userID, eventType string, bod
 }
 
 type stubUserSource struct {
-	bundle *coreuser.UserWithProfile
-	err    error
+	bundle           *coreuser.UserWithProfile
+	err              error
+	byUsernameBundle *coreuser.UserWithProfile
+	byUsernameErr    error
 }
 
 func (s *stubUserSource) ShowByID(_ string) (*coreuser.UserWithProfile, error) {
+	return s.bundle, s.err
+}
+
+func (s *stubUserSource) ShowByUsername(_ string, _ *string) (*coreuser.UserWithProfile, error) {
+	// byUsernameBundle / byUsernameErr が個別にセットされていれば優先、
+	// 無ければ ShowByID と同じ bundle を返す (= 既存の page-push test での
+	// stub 動作を維持)。
+	if s.byUsernameBundle != nil || s.byUsernameErr != nil {
+		return s.byUsernameBundle, s.byUsernameErr
+	}
 	return s.bundle, s.err
 }
 

--- a/internal/core/user/user_service.go
+++ b/internal/core/user/user_service.go
@@ -333,6 +333,19 @@ type UpdateInput struct {
 	// CheckWordMute helper が note を除外する (#787)。
 	MutedWords     *json.RawMessage
 	HardMutedWords *json.RawMessage
+	// Fields は user_profile.fields の上書き値 (#956)。nil なら不変、
+	// 空 slice なら全消去、要素ありなら正規化後 (= 名前 / 値 ともに trim
+	// した上で空 entry を除外) を jsonb に書き込む。upstream paramDef は
+	// maxItems 16 で、本 service は呼び出し側が cap 済の slice を渡す
+	// 前提 (api/i ハンドラ側で長さ検証する)。
+	Fields *[]FieldItem
+}
+
+// FieldItem represents one row of user_profile.fields. upstream Misskey の
+// PropertyValue 連合経路にも乗る shape (= name / value ペア)。
+type FieldItem struct {
+	Name  string `json:"name"`
+	Value string `json:"value"`
 }
 
 // UpdateProfile applies the non-nil fields to the user and user_profile rows.
@@ -410,6 +423,26 @@ func (s *Service) UpdateProfile(userID string, in UpdateInput) (*UserWithProfile
 		// avatarDecorations は user (not user_profile) 側の jsonb 列。
 		// Room と同じく []byte ではなく string で渡して bytea 化を防ぐ。
 		userFields["avatarDecorations"] = string(*in.AvatarDecorations)
+	}
+	if in.Fields != nil {
+		// upstream Misskey TS 互換 (#956): name / value をそれぞれ trim して
+		// 両方非空の entry のみ残す。空 slice 渡しはクリア (= []) として
+		// 書き込む。jsonb 列なので []byte でなく string キャストで bytea
+		// 化を防ぐ。
+		normalized := make([]FieldItem, 0, len(*in.Fields))
+		for _, f := range *in.Fields {
+			n := strings.TrimSpace(f.Name)
+			v := strings.TrimSpace(f.Value)
+			if n == "" || v == "" {
+				continue
+			}
+			normalized = append(normalized, FieldItem{Name: n, Value: v})
+		}
+		raw, err := json.Marshal(normalized)
+		if err != nil {
+			return nil, err
+		}
+		profileFields["fields"] = string(raw)
 	}
 
 	// avatarId / bannerId 更新 (#467)。driveFileRepo 未配線時は media

--- a/internal/core/user/user_service_test.go
+++ b/internal/core/user/user_service_test.go
@@ -409,15 +409,24 @@ func TestService_UpdateProfile_Fields(t *testing.T) {
 		string(got.Fields),
 	)
 
+	// nil (= 省略) は不変。Fields=[{x,y}, ...] 状態で他 field のみ更新
+	// しても Fields が消えないことを pinpoint で verify する (= "Fields が
+	// nil なら touch しない" 性質)。Description ptr-to-ptr で更新する。
+	desc := "new description"
+	descPtr := &desc
+	_, err = svc.UpdateProfile("u1", user.UpdateInput{Description: &descPtr})
+	require.NoError(t, err)
+	got = repo.Profiles["u1"]
+	assert.JSONEq(t,
+		`[{"name":"blog","value":"https://example.com"},{"name":"whitespace-name","value":"v"},{"name":"x","value":"y"}]`,
+		string(got.Fields),
+	)
+	require.NotNil(t, got.Description)
+	assert.Equal(t, desc, *got.Description)
+
 	// 後続更新で空 slice を渡すと clear (= [] 書き込み)。
 	empty := []user.FieldItem{}
 	_, err = svc.UpdateProfile("u1", user.UpdateInput{Fields: &empty})
-	require.NoError(t, err)
-	got = repo.Profiles["u1"]
-	assert.JSONEq(t, `[]`, string(got.Fields))
-
-	// nil (= 省略) は不変。一度 [] に clear した後で nil 渡しても [] のまま。
-	_, err = svc.UpdateProfile("u1", user.UpdateInput{})
 	require.NoError(t, err)
 	got = repo.Profiles["u1"]
 	assert.JSONEq(t, `[]`, string(got.Fields))

--- a/internal/core/user/user_service_test.go
+++ b/internal/core/user/user_service_test.go
@@ -384,6 +384,45 @@ func TestService_UpdateProfile_MutedWords(t *testing.T) {
 	assert.JSONEq(t, `["spoiler"]`, string(got.HardMutedWords))
 }
 
+// #956: profile fields (name/value 配列) の persist + 正規化。
+// upstream Misskey TS は trim + 空 entry 排除を行うので、mk-go も同挙動に
+// 揃える (= name または value どちらかが trim 後に空なら drop)。
+func TestService_UpdateProfile_Fields(t *testing.T) {
+	svc, repo, _, _ := newFullSvc(t)
+	repo.Users["u1"] = &model.User{ID: "u1", Username: "alice"}
+
+	in := []user.FieldItem{
+		{Name: "  blog  ", Value: " https://example.com  "},
+		{Name: "empty-value", Value: ""},
+		{Name: "", Value: "empty-name-only"},
+		{Name: "  whitespace-name  ", Value: "  v  "},
+		{Name: "x", Value: "y"},
+	}
+	_, err := svc.UpdateProfile("u1", user.UpdateInput{Fields: &in})
+	require.NoError(t, err)
+
+	got := repo.Profiles["u1"]
+	require.NotNil(t, got)
+	// 空 entry が drop され、name/value とも trim される。順序は維持。
+	assert.JSONEq(t,
+		`[{"name":"blog","value":"https://example.com"},{"name":"whitespace-name","value":"v"},{"name":"x","value":"y"}]`,
+		string(got.Fields),
+	)
+
+	// 後続更新で空 slice を渡すと clear (= [] 書き込み)。
+	empty := []user.FieldItem{}
+	_, err = svc.UpdateProfile("u1", user.UpdateInput{Fields: &empty})
+	require.NoError(t, err)
+	got = repo.Profiles["u1"]
+	assert.JSONEq(t, `[]`, string(got.Fields))
+
+	// nil (= 省略) は不変。一度 [] に clear した後で nil 渡しても [] のまま。
+	_, err = svc.UpdateProfile("u1", user.UpdateInput{})
+	require.NoError(t, err)
+	got = repo.Profiles["u1"]
+	assert.JSONEq(t, `[]`, string(got.Fields))
+}
+
 // #467: avatarId に SET / CLEAR / 不明 ID / 他人ファイル / 非画像 MIME を
 // 与えたときの挙動を確認する。banner も同経路 (applyMediaUpdate を共有)
 // なので avatar 側で代表させる。

--- a/internal/testutil/mock_repository.go
+++ b/internal/testutil/mock_repository.go
@@ -653,6 +653,16 @@ func applyProfileFields(p *model.UserProfile, fields map[string]any) {
 			case []byte:
 				p.HardMutedWords = val
 			}
+		case "fields":
+			// production の core/user.UpdateProfile は trim + 空 entry 排除
+			// 後の JSON を `string(json.Marshal(...))` で渡す。テストでは
+			// []byte / string どちらでも受け取れるようにしておく (#956)。
+			switch val := v.(type) {
+			case string:
+				p.Fields = []byte(val)
+			case []byte:
+				p.Fields = append([]byte(nil), val...)
+			}
 		case "clientData":
 			switch val := v.(type) {
 			case string:

--- a/tests/playwright/specs/ui/content_pages_extra.spec.ts
+++ b/tests/playwright/specs/ui/content_pages_extra.spec.ts
@@ -41,16 +41,13 @@ test.describe('UI: extra content pages render after API-side create', () => {
   });
 
   // /@:username/pages/:pageName route は frontend (page.vue) が
-  // pages/show に { username, name } を投げるが、mk-go の ShowRequest は
-  // { pageId } か { userId, name } のみ accept する (#955 drift)。
-  //
-  // test.fail で XFAIL マーク。#955 fix 後は test 実体が pass するように
-  // なるが、fail マークが付いている限り CI が "expected to fail but passed"
-  // で落ちる → 修正側が本マーカーを外す圧力になる (= skip と違って自動検出)。
-  test.fail('navigate to /@alice/pages/:slug after creating a user page via API (#955 drift)', async ({ page, baseURL, request }) => {
+  // pages/show に { username, name } を投げる。mk-go の ShowRequest は #955
+  // で username パラメータも accept するよう拡張済 (= ShowByUsername で
+  // host=NULL の local user を引いて user.id + name で page lookup)。
+  test('navigate to /@alice/pages/:slug after creating a user page via API', async ({ page, baseURL, request }) => {
     const title = `playwright-page ${Date.now()}`;
     const slug = `pw${Date.now()}`;
-    const create = await callApi(request, 'i/pages/create', {
+    const create = await callApi(request, 'pages/create', {
       i: root.token,
       title,
       name: slug,
@@ -64,6 +61,8 @@ test.describe('UI: extra content pages render after API-side create', () => {
       hideTitleWhenPinned: false,
     });
     expect(create.status()).toBe(200);
+    const createdPage = await create.json();
+    expect(createdPage.id, 'pages/create should return id').toBeTruthy();
 
     await uiSigninAsRoot(page, baseURL, root);
     const resp = await page.goto(`${baseURL}/@${root.username}/pages/${slug}`, { waitUntil: 'domcontentloaded' });

--- a/tests/playwright/specs/ui/profile_fields_render.spec.ts
+++ b/tests/playwright/specs/ui/profile_fields_render.spec.ts
@@ -5,10 +5,9 @@
 // を verify する API-only。本 spec は MkUserHome + MkMfm chain で
 // description が body に出ることまで covers する。
 //
-// 注: profile fields は mk-go の i/update が fields パラメータを drop して
-// いる drift がある (#956)。fields 検証は別 test に切り出して test.fail で
-// XFAIL マーク化、fix された瞬間に CI が "expected to fail but passed" で
-// 落ちて修正側が本マーカーを外す圧力になる。
+// fields の round-trip も #956 で i/update に Fields を accept するよう
+// 拡張済 (trim + 空 entry 排除 + maxItems 16 cap)。本 spec では /api/i 上で
+// fields が trim 済の name/value で round-trip されることを verify する。
 
 import { expect, test } from '@playwright/test';
 import { callApi } from '../../fixtures/api';
@@ -47,10 +46,9 @@ test.describe('UI: /@:user renders profile description / fields', () => {
     );
   });
 
-  // #956: i/update が fields を drop しているため /api/i のレスポンス上
-  // fields=[] になる。fix 後は本 test が pass するため XFAIL マーカーを
-  // 外す圧力になる。
-  test.fail('/api/i round-trips fields after i/update (#956 drift)', async ({ request }) => {
+  // #956 fix 後: i/update に fields を投げると user_profile.fields に persist
+  // されて /api/i が round-trip 値を返す。
+  test('/api/i round-trips fields after i/update', async ({ request }) => {
     const userName = `proffld${Date.now().toString().slice(-9)}`;
     const user = await signupUser(request, userName, DEFAULT_TEST_PASSWORD);
 


### PR DESCRIPTION
## Summary

UDS / drop-in 互換のため、frontend が投げる upstream Misskey TS 互換 shape を mk-go の API が accept していない drift 2 件を bundle で fix。

- **#955**: \`pages/show\` が \`{username, name}\` を accept しない (frontend page.vue がこの shape を投げる) → ShowRequest に Username を追加 + ShowByUsername 経路を実装
- **#956**: \`i/update\` が \`fields\` パラメータを silent drop → UpdateInput / UpdateRequest に Fields を追加 + trim + 空 entry 排除 + maxItems 16 cap + user_profile.fields jsonb に persist

副次的に、Playwright \`content_pages_extra.spec.ts\` で \`i/pages/create\` (= mk-go catchall で 200 + {} 化される存在しない endpoint) を \`pages/create\` に修正。silent fail していた構造的問題を解消。

## 主な変更点

### #955: pages/show username 受付

- \`internal/api/pages/handler.go\`:
  - \`ShowRequest\` に \`Username string \\\`json:\"username\"\\\`\` を追加
  - \`Show()\` の switch に \`case req.Username != \"\" && req.Name != \"\":\` を追加し、\`UserBundleSource.ShowByUsername(username, nil)\` で local user (host=NULL) を引いて user.id + name で page lookup
  - \`UserBundleSource\` interface を \`ShowByUsername\` 込みに拡張 (router で注入済の \`*core/user.Service\` が満たす)
- test stub \`stubUserSource\` に \`ShowByUsername\` 実装 (\`byUsernameBundle\` / \`byUsernameErr\` フィールドで個別制御)
- \`TestShow_ByUsername\` / \`_UserNotFound\` / \`_NoLookupConfigured\` を追加

### #956: i/update fields persist

- \`internal/core/user/user_service.go\`:
  - \`UpdateInput\` に \`Fields *[]FieldItem\` を追加 (\`FieldItem{Name, Value}\`)
  - \`UpdateProfile\` で name/value ともに \`strings.TrimSpace\` + 空除外、結果を \`json.Marshal\` してから \`profileFields[\"fields\"]\` に書き込む (= upstream Misskey TS の filter+map と同等の正規化)
- \`internal/api/i/handler.go\`:
  - \`UpdateRequest\` に \`Fields *[]FieldInput \\\`json:\"fields\"\\\`\`
  - \`Update()\` で \`len(*req.Fields) > 16\` を INVALID_PARAM、要素を \`user.FieldItem\` に変換して伝搬
- \`internal/testutil/mock_repository.go\` の \`applyProfileFields\` に \`fields\` case を追加 (string / []byte 両対応)
- \`TestService_UpdateProfile_Fields\` (trim / 空除外 / clear / nil 不変) と \`TestUpdate_FieldsPersisted\` / \`_FieldsTooMany\` を追加

### Playwright XFAIL 解除

- \`content_pages_extra.spec.ts\`: \`test.fail('#955 drift')\` を通常 test に戻す + endpoint 名 \`i/pages/create\` → \`pages/create\` 修正
- \`profile_fields_render.spec.ts\`: \`test.fail('#956 drift')\` を通常 test に戻す

## テスト

- ローカル: \`make test\` (Go 全パッケージ green)
- ローカル: Playwright suite 211 全 pass (XFAIL 2 件が通常 pass に転換)
- 追加した unit test:
  - pages/show: 3 件 (\`TestShow_ByUsername\` / \`_UserNotFound\` / \`_NoLookupConfigured\`)
  - i/update: 2 件 (\`TestUpdate_FieldsPersisted\` / \`_FieldsTooMany\`)
  - core/user: 1 件 (\`TestService_UpdateProfile_Fields\`)

## Closes

Closes #955
Closes #956

🤖 Generated with [Claude Code](https://claude.com/claude-code)