### PR TITLE
feat(playwright): admin/federation + admin/job-queue + explore + lookup render spec batch 2

### DIFF
--- a/tests/playwright/specs/ui/about_page_render.spec.ts
+++ b/tests/playwright/specs/ui/about_page_render.spec.ts
@@ -1,0 +1,29 @@
+// /about page (= 公開 instance about ページ) で instance.name + i18n
+// 文字列が hydrate されることを verify する spec。
+//
+// /about は overview / emojis / federation / charts の 4 tab 構成で
+// default は overview。overview では `<b>{{ instance.name }}</b>` を render
+// するので、test 環境の instance host (= mkgo.local) が body に出るのを
+// hydration sign にする。
+
+import { expect, test } from '@playwright/test';
+
+test.describe('UI: /about renders public instance overview', () => {
+  test.setTimeout(30_000);
+
+  test('instance host appears in /about overview tab', async ({ page, baseURL }) => {
+    await page.setViewportSize({ width: 1600, height: 900 });
+    const resp = await page.goto(`${baseURL}/about`, { waitUntil: 'domcontentloaded' });
+    expect(resp!.status()).toBe(200);
+
+    // instance.name は admin/update-meta で未設定なら null になり host
+    // (= mkgo.local) で fallback される。test 環境の baseURL host を
+    // body 検索するのが最も移植性が高い hydration sign。
+    const host = new URL(baseURL!).host;
+    await page.waitForFunction(
+      (h) => document.body.textContent?.includes(h) ?? false,
+      host,
+      { timeout: 20_000 },
+    );
+  });
+});

--- a/tests/playwright/specs/ui/about_page_render.spec.ts
+++ b/tests/playwright/specs/ui/about_page_render.spec.ts
@@ -18,11 +18,13 @@ test.describe('UI: /about renders public instance overview', () => {
 
     // instance.name は admin/update-meta で未設定なら null になり host
     // (= mkgo.local) で fallback される。test 環境の baseURL host を
-    // body 検索するのが最も移植性が高い hydration sign。
-    const host = new URL(baseURL!).host;
+    // body 検索するのが最も移植性が高い hydration sign。port 付きの
+    // baseURL でも body には hostname のみが出るので hostname (port 抜き)
+    // を使う。
+    const hostname = new URL(baseURL!).hostname;
     await page.waitForFunction(
       (h) => document.body.textContent?.includes(h) ?? false,
-      host,
+      hostname,
       { timeout: 20_000 },
     );
   });

--- a/tests/playwright/specs/ui/admin_abuses_render.spec.ts
+++ b/tests/playwright/specs/ui/admin_abuses_render.spec.ts
@@ -1,0 +1,57 @@
+// /admin/abuses page で users/report-abuse 経由の abuse report が
+// MkPagination + MkAbuseReport で render されることを verify する spec。
+//
+// 通報する relation を作る: B が A (root) を report する。/admin/abuses は
+// admin/abuse-user-reports paginator で list を取得し、各 report を
+// XAbuseReport (MkAbuseReport) で render する。XAbuseReport 内の
+// reporter username が body に出るのを hydration sign にする。
+
+import { readFileSync } from 'node:fs';
+import { expect, test } from '@playwright/test';
+import { callApi } from '../../fixtures/api';
+import { DEFAULT_TEST_PASSWORD, signupUser } from '../../fixtures/auth';
+import { resetRateLimit } from '../../fixtures/rate_limit';
+import { type RootFixture, uiSigninAsRoot } from '../../fixtures/ui_auth';
+
+test.describe('UI: /admin/abuses renders abuse reports', () => {
+  let root: RootFixture;
+
+  test.beforeAll(() => {
+    resetRateLimit();
+    root = JSON.parse(readFileSync('.auth/root.json', 'utf-8'));
+  });
+
+  test.setTimeout(60_000);
+
+  test('a fresh abuse report appears in /admin/abuses', async ({ page, baseURL, request }) => {
+    // reporter user を作る (= root を report するので別 user 必要)
+    const reporterName = `rep${Date.now().toString().slice(-9)}`;
+    const reporter = await signupUser(request, reporterName, DEFAULT_TEST_PASSWORD);
+
+    // root を spam として report
+    const reportComment = `pwabuse-${Date.now().toString().slice(-9)}`;
+    const reportResp = await callApi(request, 'users/report-abuse', {
+      i: reporter.token,
+      userId: root.id,
+      comment: reportComment,
+    });
+    expect(reportResp.status()).toBe(204);
+
+    await uiSigninAsRoot(page, baseURL, root);
+    const resp = await page.goto(`${baseURL}/admin/abuses`, { waitUntil: 'domcontentloaded' });
+    expect(resp!.status()).toBe(200);
+
+    // reporter username + comment 両方を verify (= XAbuseReport が
+    // reporter info + comment を render する)
+    await page.waitForFunction(
+      (n) => document.body.textContent?.includes(n) ?? false,
+      reporterName,
+      { timeout: 20_000 },
+    );
+    await page.waitForFunction(
+      (c) => document.body.textContent?.includes(c) ?? false,
+      reportComment,
+      { timeout: 20_000 },
+    );
+  });
+});

--- a/tests/playwright/specs/ui/admin_ads_render.spec.ts
+++ b/tests/playwright/specs/ui/admin_ads_render.spec.ts
@@ -1,0 +1,58 @@
+// /admin/ads page で admin/ad/create で作成した ad が render されることを
+// verify する spec。
+//
+// /admin/ads は admin/ad/list で ad 一覧を取得し、各 ad を MkAd コンポ
+// と MkInput (URL / imageUrl 編集 form) で render する。ad の URL 文字列
+// が body に出るのを hydration sign にする。
+
+import { readFileSync } from 'node:fs';
+import { expect, test } from '@playwright/test';
+import { callApi } from '../../fixtures/api';
+import { type RootFixture, uiSigninAsRoot } from '../../fixtures/ui_auth';
+
+test.describe('UI: /admin/ads page renders created ad', () => {
+  let root: RootFixture;
+
+  test.beforeAll(() => {
+    root = JSON.parse(readFileSync('.auth/root.json', 'utf-8'));
+  });
+
+  test.setTimeout(60_000);
+
+  test('admin/ad/create + /admin/ads renders ad URL', async ({ page, baseURL, request }) => {
+    // 一意 host 名 (URL は MkInput type=url で render され、value 属性に
+    // そのまま入るので body の textContent には出ない可能性がある。代わりに
+    // memo で識別する。memo は Ad の任意メタデータ field で MkInput には
+    // bind されないが、admin/ad/list レスポンスの memo が UI 上の <input>
+    // value として render される)
+    const adUrl = `https://playwright-${Date.now().toString().slice(-9)}.invalid/`;
+    const memo = `pwad-memo-${Date.now().toString().slice(-9)}`;
+
+    const createResp = await callApi(request, 'admin/ad/create', {
+      i: root.token,
+      url: adUrl,
+      memo,
+      place: 'square',
+      priority: 'middle',
+      ratio: 1,
+      expiresAt: Date.now() + 24 * 60 * 60 * 1000,
+      startsAt: Date.now(),
+      imageUrl: 'https://example.invalid/playwright.png',
+      dayOfWeek: 0,
+    });
+    expect(createResp.status()).toBe(200);
+
+    await uiSigninAsRoot(page, baseURL, root);
+    const resp = await page.goto(`${baseURL}/admin/ads`, { waitUntil: 'domcontentloaded' });
+    expect(resp!.status()).toBe(200);
+
+    // 各 ad は <input type=url> の value に URL がセットされて render
+    // される。body.textContent に出ない (input value は textContent に
+    // 含まれない) ので、document.querySelector で <input> の value 検索。
+    await page.waitForFunction(
+      (u) => Array.from(document.querySelectorAll('input')).some((el) => el.value === u),
+      adUrl,
+      { timeout: 20_000 },
+    );
+  });
+});

--- a/tests/playwright/specs/ui/admin_announcements_render.spec.ts
+++ b/tests/playwright/specs/ui/admin_announcements_render.spec.ts
@@ -1,0 +1,50 @@
+// /admin/announcements page で admin/announcements/create + list が動作
+// して MkFolder の label に announcement.title が出ることを verify する
+// spec。/announcements (= 公開ページ) は content_pages_extra.spec.ts で
+// 既に cover 済だが、本 spec は **admin 側の管理 page** の hydration を
+// 確認する別 layer。
+
+import { readFileSync } from 'node:fs';
+import { expect, test } from '@playwright/test';
+import { callApi } from '../../fixtures/api';
+import { type RootFixture, uiSigninAsRoot } from '../../fixtures/ui_auth';
+
+test.describe('UI: /admin/announcements renders admin-side announcement list', () => {
+  let root: RootFixture;
+
+  test.beforeAll(() => {
+    root = JSON.parse(readFileSync('.auth/root.json', 'utf-8'));
+  });
+
+  test.setTimeout(60_000);
+
+  test('admin/announcements/create + /admin/announcements renders the title', async ({
+    page,
+    baseURL,
+    request,
+  }) => {
+    const title = `pwann-${Date.now().toString().slice(-9)}`;
+    const createResp = await callApi(request, 'admin/announcements/create', {
+      i: root.token,
+      title,
+      text: 'playwright admin announcement',
+      imageUrl: null,
+    });
+    expect(createResp.status()).toBe(200);
+
+    await uiSigninAsRoot(page, baseURL, root);
+    const resp = await page.goto(`${baseURL}/admin/announcements`, {
+      waitUntil: 'domcontentloaded',
+    });
+    expect(resp!.status()).toBe(200);
+
+    // 各 announcement は MkFolder の label slot に title を入れて
+    // collapsed で render される。label の text は body.textContent に
+    // 含まれる。
+    await page.waitForFunction(
+      (t) => document.body.textContent?.includes(t) ?? false,
+      title,
+      { timeout: 20_000 },
+    );
+  });
+});

--- a/tests/playwright/specs/ui/admin_avatar_decorations_render.spec.ts
+++ b/tests/playwright/specs/ui/admin_avatar_decorations_render.spec.ts
@@ -1,0 +1,49 @@
+// /admin/avatar-decorations page で admin/avatar-decorations/create で
+// 作成した decoration の name が body に出るのを verify する spec。
+//
+// /admin/avatar-decorations は admin/avatar-decorations/list を fetch して
+// 各 decoration を MkCondensedLine + MkAvatar で render する。decoration
+// の name 文字列で hydration sign を取る。
+
+import { readFileSync } from 'node:fs';
+import { expect, test } from '@playwright/test';
+import { callApi } from '../../fixtures/api';
+import { type RootFixture, uiSigninAsRoot } from '../../fixtures/ui_auth';
+
+test.describe('UI: /admin/avatar-decorations renders configured decorations', () => {
+  let root: RootFixture;
+
+  test.beforeAll(() => {
+    root = JSON.parse(readFileSync('.auth/root.json', 'utf-8'));
+  });
+
+  test.setTimeout(60_000);
+
+  test('admin/avatar-decorations/create + page renders the name', async ({
+    page,
+    baseURL,
+    request,
+  }) => {
+    const decoName = `pwdeco-${Date.now().toString().slice(-9)}`;
+    const createResp = await callApi(request, 'admin/avatar-decorations/create', {
+      i: root.token,
+      name: decoName,
+      description: 'playwright test deco',
+      url: 'https://example.invalid/playwright-deco.png',
+      roleIdsThatCanBeUsedThisDecoration: [],
+    });
+    expect(createResp.status()).toBe(200);
+
+    await uiSigninAsRoot(page, baseURL, root);
+    const resp = await page.goto(`${baseURL}/admin/avatar-decorations`, {
+      waitUntil: 'domcontentloaded',
+    });
+    expect(resp!.status()).toBe(200);
+
+    await page.waitForFunction(
+      (n) => document.body.textContent?.includes(n) ?? false,
+      decoName,
+      { timeout: 20_000 },
+    );
+  });
+});

--- a/tests/playwright/specs/ui/admin_branding_render.spec.ts
+++ b/tests/playwright/specs/ui/admin_branding_render.spec.ts
@@ -24,15 +24,16 @@ test.describe('UI: /admin/branding page hydrates form controls', () => {
     const resp = await page.goto(`${baseURL}/admin/branding`, { waitUntil: 'domcontentloaded' });
     expect(resp!.status()).toBe(200);
 
-    // entrancePageStyle (radios) + iconUrl / bannerUrl 等 (input type=url)
-    // + visitor switches など、複数の form 要素が必ず render される。
-    // 5+ input/radio/switch が visible になれば form 全体が hydrate された
-    // と判定 (= admin/meta が前段で fetch されてから初めて MkRadios が
-    // 値を bind する pipeline)。
+    // /admin/branding 固有 sign: definePage の title が i18n.ts.branding
+    // (= "Branding") + iconUrl の MkInput type=url が必ず存在する。
+    // 単に input 数だけだと home dashboard の widgets でも通るので、
+    // 「Branding」文字列 + url input >=1 + 全 input >=5 の AND で固有性確保。
     await page.waitForFunction(
       () => {
-        const inputs = document.querySelectorAll('input').length;
-        return inputs >= 5;
+        const text = document.body.textContent ?? '';
+        const allInputs = document.querySelectorAll('input').length;
+        const urlInputs = document.querySelectorAll('input[type="url"]').length;
+        return text.includes('Branding') && allInputs >= 5 && urlInputs >= 1;
       },
       { timeout: 20_000 },
     );

--- a/tests/playwright/specs/ui/admin_branding_render.spec.ts
+++ b/tests/playwright/specs/ui/admin_branding_render.spec.ts
@@ -1,0 +1,40 @@
+// /admin/branding page で MkRadios + MkSwitch + MkInput が hydrate される
+// ことを verify する spec。
+//
+// /admin/branding は server settings (entrancePageStyle / iconUrl 等) を
+// admin/meta + admin/update-meta 経由で読み書きする。本 spec は controls
+// が mount されることだけを smoke する (= hidden form なら必ず複数 input
+// が render される)。
+
+import { readFileSync } from 'node:fs';
+import { expect, test } from '@playwright/test';
+import { type RootFixture, uiSigninAsRoot } from '../../fixtures/ui_auth';
+
+test.describe('UI: /admin/branding page hydrates form controls', () => {
+  let root: RootFixture;
+
+  test.beforeAll(() => {
+    root = JSON.parse(readFileSync('.auth/root.json', 'utf-8'));
+  });
+
+  test.setTimeout(60_000);
+
+  test('branding form controls (radios / switches / inputs) appear', async ({ page, baseURL }) => {
+    await uiSigninAsRoot(page, baseURL, root);
+    const resp = await page.goto(`${baseURL}/admin/branding`, { waitUntil: 'domcontentloaded' });
+    expect(resp!.status()).toBe(200);
+
+    // entrancePageStyle (radios) + iconUrl / bannerUrl 等 (input type=url)
+    // + visitor switches など、複数の form 要素が必ず render される。
+    // 5+ input/radio/switch が visible になれば form 全体が hydrate された
+    // と判定 (= admin/meta が前段で fetch されてから初めて MkRadios が
+    // 値を bind する pipeline)。
+    await page.waitForFunction(
+      () => {
+        const inputs = document.querySelectorAll('input').length;
+        return inputs >= 5;
+      },
+      { timeout: 20_000 },
+    );
+  });
+});

--- a/tests/playwright/specs/ui/admin_database_render.spec.ts
+++ b/tests/playwright/specs/ui/admin_database_render.spec.ts
@@ -1,8 +1,9 @@
 // /admin/database page で admin/get-table-stats 経由 DB table 一覧が
 // MkKeyValue として render されることを verify する spec。
 //
-// 全 backend で table "user" は必ず存在するので、"user" + "(" + "recs)"
-// の組合せが body に出るのを hydration sign にする。
+// 全 backend で table "drive_file" は必ず存在するので、"drive_file" key
+// + value 末尾の "recs)" 文字列の組合せで hydration sign を取る ("user"
+// だと "users" 等他箇所にも match して偽陽性になりうる)。
 
 import { readFileSync } from 'node:fs';
 import { expect, test } from '@playwright/test';
@@ -26,12 +27,14 @@ test.describe('UI: /admin/database page renders table stats', () => {
     expect(resp!.status()).toBe(200);
 
     // 各 table は MkKeyValue で `{name}` key + `{size} ({count} recs)`
-    // value として render される。"user" は必ず存在 + value 末尾が "recs)"
-    // で hardcode されているので両方を verify。
+    // value として render される。"recs)" は MkKeyValue value 末尾の
+    // hardcode で他 page では使われない。加えて mk-go / Misskey TS 両方で
+    // 必ず存在する table 名 "drive_file" を組み合わせて固有性を確保
+    // ("user" だと "users" 等他箇所にも match)。
     await page.waitForFunction(
       () => {
         const text = document.body.textContent ?? '';
-        return text.includes('user') && text.includes('recs)');
+        return text.includes('drive_file') && text.includes('recs)');
       },
       { timeout: 20_000 },
     );

--- a/tests/playwright/specs/ui/admin_database_render.spec.ts
+++ b/tests/playwright/specs/ui/admin_database_render.spec.ts
@@ -1,0 +1,39 @@
+// /admin/database page で admin/get-table-stats 経由 DB table 一覧が
+// MkKeyValue として render されることを verify する spec。
+//
+// 全 backend で table "user" は必ず存在するので、"user" + "(" + "recs)"
+// の組合せが body に出るのを hydration sign にする。
+
+import { readFileSync } from 'node:fs';
+import { expect, test } from '@playwright/test';
+import { type RootFixture, uiSigninAsRoot } from '../../fixtures/ui_auth';
+
+test.describe('UI: /admin/database page renders table stats', () => {
+  let root: RootFixture;
+
+  test.beforeAll(() => {
+    root = JSON.parse(readFileSync('.auth/root.json', 'utf-8'));
+  });
+
+  test.setTimeout(60_000);
+
+  test('admin/get-table-stats hydrates table list on /admin/database', async ({
+    page,
+    baseURL,
+  }) => {
+    await uiSigninAsRoot(page, baseURL, root);
+    const resp = await page.goto(`${baseURL}/admin/database`, { waitUntil: 'domcontentloaded' });
+    expect(resp!.status()).toBe(200);
+
+    // 各 table は MkKeyValue で `{name}` key + `{size} ({count} recs)`
+    // value として render される。"user" は必ず存在 + value 末尾が "recs)"
+    // で hardcode されているので両方を verify。
+    await page.waitForFunction(
+      () => {
+        const text = document.body.textContent ?? '';
+        return text.includes('user') && text.includes('recs)');
+      },
+      { timeout: 20_000 },
+    );
+  });
+});

--- a/tests/playwright/specs/ui/admin_federation_render.spec.ts
+++ b/tests/playwright/specs/ui/admin_federation_render.spec.ts
@@ -1,0 +1,42 @@
+// /admin/federation page の hydration smoke。
+//
+// federation page は MkInput (host filter) + MkSelect (state / sort) +
+// MkPagination (instance list) で構成される。test 環境は remote instance を
+// 持たないので list は空でも、上記の controls は必ず render される。
+// PageWithHeader + MkInput + MkSelect の chain が壊れていないことを smoke
+// level で verify する。
+
+import { readFileSync } from 'node:fs';
+import { expect, test } from '@playwright/test';
+import { type RootFixture, uiSigninAsRoot } from '../../fixtures/ui_auth';
+
+test.describe('UI: /admin/federation page hydrates', () => {
+  let root: RootFixture;
+
+  test.beforeAll(() => {
+    root = JSON.parse(readFileSync('.auth/root.json', 'utf-8'));
+  });
+
+  test.setTimeout(60_000);
+
+  test('controls (host input + state/sort selects) mount on /admin/federation', async ({ page, baseURL }) => {
+    await uiSigninAsRoot(page, baseURL, root);
+    const resp = await page.goto(`${baseURL}/admin/federation`, { waitUntil: 'domcontentloaded' });
+    expect(resp!.status()).toBe(200);
+
+    // host filter は <input> として render される。state / sort は MkSelect
+    // で内部的に <select> または combobox 相当の要素を持つ。最低限 input 1 つ
+    // (host filter) が visible になれば federation page の controls が
+    // hydrate された証拠。
+    await page.waitForFunction(
+      () => document.querySelectorAll('input').length > 0,
+      { timeout: 20_000 },
+    );
+
+    // navbar (= 認証済 home の data-cy) が維持されているか確認。これで
+    // /admin route guard も成立している。
+    await expect(page.locator('[data-cy-open-post-form]').first()).toBeVisible({
+      timeout: 15_000,
+    });
+  });
+});

--- a/tests/playwright/specs/ui/admin_files_render.spec.ts
+++ b/tests/playwright/specs/ui/admin_files_render.spec.ts
@@ -1,0 +1,33 @@
+// /admin/files page で host filter / user ID / MIME type input + 行政
+// 用 file list paginator が hydrate されることを smoke する spec。
+//
+// /admin/files は admin/drive/files paginator + MkSelect (origin) +
+// MkInput x3 (host / userId / type) を mount する。filter UI が必ず存在する
+// ので、input が 3 つ以上 visible になることを hydration sign にする。
+
+import { readFileSync } from 'node:fs';
+import { expect, test } from '@playwright/test';
+import { type RootFixture, uiSigninAsRoot } from '../../fixtures/ui_auth';
+
+test.describe('UI: /admin/files page hydrates filter inputs', () => {
+  let root: RootFixture;
+
+  test.beforeAll(() => {
+    root = JSON.parse(readFileSync('.auth/root.json', 'utf-8'));
+  });
+
+  test.setTimeout(60_000);
+
+  test('host / userId / MIME type inputs appear on /admin/files', async ({ page, baseURL }) => {
+    await uiSigninAsRoot(page, baseURL, root);
+    const resp = await page.goto(`${baseURL}/admin/files`, { waitUntil: 'domcontentloaded' });
+    expect(resp!.status()).toBe(200);
+
+    // host / userId / type filter は MkInput (= <input>) なので、
+    // input 数 >= 3 で「filter UI が hydrate された」と判定。
+    await page.waitForFunction(
+      () => document.querySelectorAll('input').length >= 3,
+      { timeout: 20_000 },
+    );
+  });
+});

--- a/tests/playwright/specs/ui/admin_invites_render.spec.ts
+++ b/tests/playwright/specs/ui/admin_invites_render.spec.ts
@@ -1,0 +1,50 @@
+// /admin/invites page で admin/invite/create で発行した invite code が
+// MkInviteCode コンポ経由で render されることを verify する spec。
+//
+// /admin/invites は admin/invite/list を Paginator で叩いて invite を
+// 一覧 render する。MkInviteCode は invite.code を <div :class="_selectableAtomic">
+// として render するので body 検索可。
+
+import { readFileSync } from 'node:fs';
+import { expect, test } from '@playwright/test';
+import { callApi } from '../../fixtures/api';
+import { type RootFixture, uiSigninAsRoot } from '../../fixtures/ui_auth';
+
+test.describe('UI: /admin/invites renders newly issued invite codes', () => {
+  let root: RootFixture;
+
+  test.beforeAll(() => {
+    root = JSON.parse(readFileSync('.auth/root.json', 'utf-8'));
+  });
+
+  test.setTimeout(60_000);
+
+  test('admin/invite/create + /admin/invites renders the new code', async ({
+    page,
+    baseURL,
+    request,
+  }) => {
+    // 1 件発行する (= count default 1)
+    const createResp = await callApi(request, 'admin/invite/create', {
+      i: root.token,
+      count: 1,
+    });
+    expect(createResp.status()).toBe(200);
+    const tickets = await createResp.json();
+    expect(Array.isArray(tickets), 'admin/invite/create returns array').toBe(true);
+    expect(tickets.length).toBeGreaterThanOrEqual(1);
+    const code: string = tickets[0].code;
+    expect(typeof code).toBe('string');
+    expect(code.length).toBeGreaterThan(0);
+
+    await uiSigninAsRoot(page, baseURL, root);
+    const resp = await page.goto(`${baseURL}/admin/invites`, { waitUntil: 'domcontentloaded' });
+    expect(resp!.status()).toBe(200);
+
+    await page.waitForFunction(
+      (c) => document.body.textContent?.includes(c) ?? false,
+      code,
+      { timeout: 20_000 },
+    );
+  });
+});

--- a/tests/playwright/specs/ui/admin_moderation_render.spec.ts
+++ b/tests/playwright/specs/ui/admin_moderation_render.spec.ts
@@ -1,0 +1,39 @@
+// /admin/moderation page で MkSwitch + MkSelect + textarea 等の form
+// controls が hydrate されることを smoke する spec。
+//
+// /admin/moderation は registration / email-required / serverRules /
+// ugcVisibility 等を admin/meta 経由で read/write する form の集合。本
+// spec は controls が必要数 mount されるかだけを smoke する。
+
+import { readFileSync } from 'node:fs';
+import { expect, test } from '@playwright/test';
+import { type RootFixture, uiSigninAsRoot } from '../../fixtures/ui_auth';
+
+test.describe('UI: /admin/moderation page hydrates form controls', () => {
+  let root: RootFixture;
+
+  test.beforeAll(() => {
+    root = JSON.parse(readFileSync('.auth/root.json', 'utf-8'));
+  });
+
+  test.setTimeout(60_000);
+
+  test('moderation form (switches / selects) hydrates', async ({ page, baseURL }) => {
+    await uiSigninAsRoot(page, baseURL, root);
+    const resp = await page.goto(`${baseURL}/admin/moderation`, { waitUntil: 'domcontentloaded' });
+    expect(resp!.status()).toBe(200);
+
+    // openRegistration / emailRequiredForSignup の MkSwitch + ugcVisibility
+    // / sensitiveWords 等の MkSelect/MkTextarea があり、admin/meta が
+    // hydrate されないと bind されないので、checkbox/input が複数 mount
+    // される=hydrate 完了の sign。
+    await page.waitForFunction(
+      () => {
+        const checkboxes = document.querySelectorAll('input[type="checkbox"]').length;
+        const inputs = document.querySelectorAll('input').length;
+        return checkboxes >= 2 || inputs >= 3;
+      },
+      { timeout: 20_000 },
+    );
+  });
+});

--- a/tests/playwright/specs/ui/admin_modlog_render.spec.ts
+++ b/tests/playwright/specs/ui/admin_modlog_render.spec.ts
@@ -23,9 +23,17 @@ test.describe('UI: /admin/modlog page hydrates filter controls', () => {
     const resp = await page.goto(`${baseURL}/admin/modlog`, { waitUntil: 'domcontentloaded' });
     expect(resp!.status()).toBe(200);
 
-    // type select + moderator input + paginator control = input >= 1
+    // /admin/modlog 固有 sign: definePage の title が
+    // i18n.ts.moderationLogs (= "Moderation logs") なので、
+    // 同文字列 + filter input が両方揃うことを verify する。
+    // home dashboard に streaming される input でも 1 件だけは満たすが、
+    // "Moderation logs" は modlog page 以外では出ない。
     await page.waitForFunction(
-      () => document.querySelectorAll('input').length >= 1,
+      () => {
+        const text = document.body.textContent ?? '';
+        const inputs = document.querySelectorAll('input').length;
+        return text.includes('Moderation logs') && inputs >= 1;
+      },
       { timeout: 20_000 },
     );
   });

--- a/tests/playwright/specs/ui/admin_modlog_render.spec.ts
+++ b/tests/playwright/specs/ui/admin_modlog_render.spec.ts
@@ -1,0 +1,32 @@
+// /admin/modlog page で type filter (MkSelect) + moderator ID input が
+// hydrate されることを smoke する spec。
+//
+// /admin/modlog は admin/show-moderation-logs paginator + filter form を
+// mount する。実 log は moderation 操作後にしか発生しないので、本 spec は
+// filter UI の有無だけを sign にする (= log entry 表示 verify は別 spec)。
+
+import { readFileSync } from 'node:fs';
+import { expect, test } from '@playwright/test';
+import { type RootFixture, uiSigninAsRoot } from '../../fixtures/ui_auth';
+
+test.describe('UI: /admin/modlog page hydrates filter controls', () => {
+  let root: RootFixture;
+
+  test.beforeAll(() => {
+    root = JSON.parse(readFileSync('.auth/root.json', 'utf-8'));
+  });
+
+  test.setTimeout(60_000);
+
+  test('modlog page renders type filter + moderator ID input', async ({ page, baseURL }) => {
+    await uiSigninAsRoot(page, baseURL, root);
+    const resp = await page.goto(`${baseURL}/admin/modlog`, { waitUntil: 'domcontentloaded' });
+    expect(resp!.status()).toBe(200);
+
+    // type select + moderator input + paginator control = input >= 1
+    await page.waitForFunction(
+      () => document.querySelectorAll('input').length >= 1,
+      { timeout: 20_000 },
+    );
+  });
+});

--- a/tests/playwright/specs/ui/admin_queue_render.spec.ts
+++ b/tests/playwright/specs/ui/admin_queue_render.spec.ts
@@ -1,0 +1,42 @@
+// /admin/job-queue page の hydration smoke。
+//
+// PageWithHeader の tabs は misskey-js の `queueTypes` 定数 (= deliver /
+// inbox / db / system / objectStorage / ...) を hardcode で展開するので、
+// queue inspector が wire されていない test 環境でも tab 名は必ず render
+// される。"deliver" + "inbox" の両 tab 名が body に出るのを hydration sign
+// にする (= MkPaginatedHeader が tabs prop を mount できた証拠)。
+//
+// 注: queue overview の Active/Delayed/Waiting 数値は admin/queue/queues の
+// API から populate されるが、Playwright stack では queueInspector が
+// 未配線で空配列を返すため body には現れない。本 smoke は frontend chain
+// だけを cover し、API 値 verify は別 spec (specs/admin/queue.spec.ts)。
+
+import { readFileSync } from 'node:fs';
+import { expect, test } from '@playwright/test';
+import { type RootFixture, uiSigninAsRoot } from '../../fixtures/ui_auth';
+
+test.describe('UI: /admin/job-queue page hydrates queue tab list', () => {
+  let root: RootFixture;
+
+  test.beforeAll(() => {
+    root = JSON.parse(readFileSync('.auth/root.json', 'utf-8'));
+  });
+
+  test.setTimeout(60_000);
+
+  test('queue type tabs (deliver / inbox) appear on /admin/job-queue', async ({ page, baseURL }) => {
+    await uiSigninAsRoot(page, baseURL, root);
+    const resp = await page.goto(`${baseURL}/admin/job-queue`, { waitUntil: 'domcontentloaded' });
+    expect(resp!.status()).toBe(200);
+
+    // header tabs は misskey-js queueTypes から生成され、deliver / inbox
+    // は mk-go / Misskey TS の両 backend で必ず存在する標準 queue。
+    await page.waitForFunction(
+      () => {
+        const text = document.body.textContent ?? '';
+        return text.includes('deliver') && text.includes('inbox');
+      },
+      { timeout: 20_000 },
+    );
+  });
+});

--- a/tests/playwright/specs/ui/admin_relays_render.spec.ts
+++ b/tests/playwright/specs/ui/admin_relays_render.spec.ts
@@ -1,0 +1,45 @@
+// /admin/relays page で admin/relays/add で登録した relay inbox URL が
+// MkButton 行の text として render されることを verify する spec。
+//
+// /admin/relays は admin/relays/list で relay 一覧を取得し、各 relay の
+// inbox URL + status を panel として render する。本 spec は inbox URL
+// が body に出るのを hydration sign にする。
+
+import { readFileSync } from 'node:fs';
+import { expect, test } from '@playwright/test';
+import { callApi } from '../../fixtures/api';
+import { type RootFixture, uiSigninAsRoot } from '../../fixtures/ui_auth';
+
+test.describe('UI: /admin/relays page renders configured relays', () => {
+  let root: RootFixture;
+
+  test.beforeAll(() => {
+    root = JSON.parse(readFileSync('.auth/root.json', 'utf-8'));
+  });
+
+  test.setTimeout(60_000);
+
+  test('admin/relays/add + /admin/relays renders relay inbox URL', async ({
+    page,
+    baseURL,
+    request,
+  }) => {
+    // テスト用 relay inbox URL (= 実 federation はしないので適当な host で OK)
+    const inboxUrl = `https://pwrelay-${Date.now().toString().slice(-9)}.invalid/inbox`;
+    const addResp = await callApi(request, 'admin/relays/add', {
+      i: root.token,
+      inbox: inboxUrl,
+    });
+    expect(addResp.status()).toBe(200);
+
+    await uiSigninAsRoot(page, baseURL, root);
+    const resp = await page.goto(`${baseURL}/admin/relays`, { waitUntil: 'domcontentloaded' });
+    expect(resp!.status()).toBe(200);
+
+    await page.waitForFunction(
+      (u) => document.body.textContent?.includes(u) ?? false,
+      inboxUrl,
+      { timeout: 20_000 },
+    );
+  });
+});

--- a/tests/playwright/specs/ui/admin_roles_render.spec.ts
+++ b/tests/playwright/specs/ui/admin_roles_render.spec.ts
@@ -1,0 +1,58 @@
+// /admin/roles page で admin/roles/create で作成した role の name が
+// MkRolePreview 経由で render されることを verify する spec。
+//
+// admin/roles ページは admin/roles/list で role 一覧を取得し、target 別
+// (manual / conditional) に MkFoldableSection で render する。本 spec は
+// manual role を 1 件作成 → /admin/roles を navigate → role.name が body
+// に出るのを hydration sign にする。
+
+import { readFileSync } from 'node:fs';
+import { expect, test } from '@playwright/test';
+import { callApi } from '../../fixtures/api';
+import { type RootFixture, uiSigninAsRoot } from '../../fixtures/ui_auth';
+
+test.describe('UI: /admin/roles page renders created role', () => {
+  let root: RootFixture;
+
+  test.beforeAll(() => {
+    root = JSON.parse(readFileSync('.auth/root.json', 'utf-8'));
+  });
+
+  test.setTimeout(60_000);
+
+  test('admin/roles/create + /admin/roles renders role name', async ({ page, baseURL, request }) => {
+    const roleName = `pwrole-${Date.now().toString().slice(-9)}`;
+    const createResp = await callApi(request, 'admin/roles/create', {
+      i: root.token,
+      name: roleName,
+      description: 'playwright test role',
+      color: null,
+      iconUrl: null,
+      target: 'manual',
+      condFormula: {},
+      isPublic: false,
+      isAdministrator: false,
+      isModerator: false,
+      asBadge: false,
+      canEditMembersByModerator: false,
+      displayOrder: 0,
+      policies: {},
+    });
+    expect(createResp.status()).toBe(200);
+    const created = await createResp.json();
+    expect(created.id).toBeTruthy();
+
+    await uiSigninAsRoot(page, baseURL, root);
+    const resp = await page.goto(`${baseURL}/admin/roles`, { waitUntil: 'domcontentloaded' });
+    expect(resp!.status()).toBe(200);
+
+    // /admin/roles は MkRolePreview で role.name を MkSpacer 内 text として
+    // mount する。manual role の section は default で expanded されるが、
+    // MkFoldableSection の 内部レンダ完了まで待ってから body 検索する。
+    await page.waitForFunction(
+      (n) => document.body.textContent?.includes(n) ?? false,
+      roleName,
+      { timeout: 20_000 },
+    );
+  });
+});

--- a/tests/playwright/specs/ui/admin_security_render.spec.ts
+++ b/tests/playwright/specs/ui/admin_security_render.spec.ts
@@ -1,0 +1,34 @@
+// /admin/security page で MkRadios + MkRange + MkSwitch 等の form
+// controls が hydrate されることを smoke する spec。
+//
+// /admin/security は sensitive media detection / bot protection 等の
+// admin/meta 値を read/write する form の集合。本 spec は controls が
+// 必要数 mount されることだけを sign にする。
+
+import { readFileSync } from 'node:fs';
+import { expect, test } from '@playwright/test';
+import { type RootFixture, uiSigninAsRoot } from '../../fixtures/ui_auth';
+
+test.describe('UI: /admin/security page hydrates form controls', () => {
+  let root: RootFixture;
+
+  test.beforeAll(() => {
+    root = JSON.parse(readFileSync('.auth/root.json', 'utf-8'));
+  });
+
+  test.setTimeout(60_000);
+
+  test('security form (radios / switches / inputs) hydrates', async ({ page, baseURL }) => {
+    await uiSigninAsRoot(page, baseURL, root);
+    const resp = await page.goto(`${baseURL}/admin/security`, { waitUntil: 'domcontentloaded' });
+    expect(resp!.status()).toBe(200);
+
+    // sensitiveMediaDetection radios + sensitivity range + bot protection
+    // 等で input/checkbox が複数 mount される。最低 3 個でほぼ全 backend で
+    // mount される。
+    await page.waitForFunction(
+      () => document.querySelectorAll('input').length >= 3,
+      { timeout: 20_000 },
+    );
+  });
+});

--- a/tests/playwright/specs/ui/admin_system_webhook_render.spec.ts
+++ b/tests/playwright/specs/ui/admin_system_webhook_render.spec.ts
@@ -1,0 +1,50 @@
+// /admin/system-webhook page で admin/system-webhook/create で登録した
+// webhook の name が render されることを verify する spec。
+//
+// /admin/system-webhook は admin/system-webhook/list を fetch して各
+// webhook を XItem (system-webhook.item.vue) で render する。XItem は
+// webhook.name を text として表示するので body 検索可。
+
+import { readFileSync } from 'node:fs';
+import { expect, test } from '@playwright/test';
+import { callApi } from '../../fixtures/api';
+import { type RootFixture, uiSigninAsRoot } from '../../fixtures/ui_auth';
+
+test.describe('UI: /admin/system-webhook renders configured webhooks', () => {
+  let root: RootFixture;
+
+  test.beforeAll(() => {
+    root = JSON.parse(readFileSync('.auth/root.json', 'utf-8'));
+  });
+
+  test.setTimeout(60_000);
+
+  test('admin/system-webhook/create + /admin/system-webhook renders webhook name', async ({
+    page,
+    baseURL,
+    request,
+  }) => {
+    const webhookName = `pwwh-${Date.now().toString().slice(-9)}`;
+    const createResp = await callApi(request, 'admin/system-webhook/create', {
+      i: root.token,
+      isActive: true,
+      name: webhookName,
+      on: ['abuseReport'],
+      url: 'https://playwright-webhook.invalid/hook',
+      secret: '',
+    });
+    expect(createResp.status()).toBe(200);
+
+    await uiSigninAsRoot(page, baseURL, root);
+    const resp = await page.goto(`${baseURL}/admin/system-webhook`, {
+      waitUntil: 'domcontentloaded',
+    });
+    expect(resp!.status()).toBe(200);
+
+    await page.waitForFunction(
+      (n) => document.body.textContent?.includes(n) ?? false,
+      webhookName,
+      { timeout: 20_000 },
+    );
+  });
+});

--- a/tests/playwright/specs/ui/admin_users_render.spec.ts
+++ b/tests/playwright/specs/ui/admin_users_render.spec.ts
@@ -1,0 +1,36 @@
+// /admin/users page で MkPagination が admin/show-users 経由で user 一覧を
+// hydrate して、各 user の username が MkUserCardMini で render される
+// ことを verify する spec。
+//
+// admin/users は host filter / status filter 等の MkInput / MkSelect を
+// 持つが、本 spec は最低限の hydration smoke として root.username が body
+// に出ることだけを確認する。
+
+import { readFileSync } from 'node:fs';
+import { expect, test } from '@playwright/test';
+import { type RootFixture, uiSigninAsRoot } from '../../fixtures/ui_auth';
+
+test.describe('UI: /admin/users page renders user list', () => {
+  let root: RootFixture;
+
+  test.beforeAll(() => {
+    root = JSON.parse(readFileSync('.auth/root.json', 'utf-8'));
+  });
+
+  test.setTimeout(60_000);
+
+  test('root username appears in /admin/users user list', async ({ page, baseURL }) => {
+    await uiSigninAsRoot(page, baseURL, root);
+    const resp = await page.goto(`${baseURL}/admin/users`, { waitUntil: 'domcontentloaded' });
+    expect(resp!.status()).toBe(200);
+
+    // admin/show-users 経由で root を含む全 user が render される。
+    // MkUserCardMini は username を <span> として render するので
+    // body.textContent で照合できる。
+    await page.waitForFunction(
+      (n) => document.body.textContent?.includes(n) ?? false,
+      root.username,
+      { timeout: 20_000 },
+    );
+  });
+});

--- a/tests/playwright/specs/ui/drive_file_detail_render.spec.ts
+++ b/tests/playwright/specs/ui/drive_file_detail_render.spec.ts
@@ -1,0 +1,69 @@
+// /my/drive/file/:fileId page で drive file の info tab が hydrate されて
+// file 名 / type / size 等が render されることを verify する spec。
+//
+// upload は API (drive/files/create multipart) で行い、UI 側は drive file
+// 詳細 page の hydration (drive/files/show 経由) を smoke する。drive file
+// 編集 / 削除の UI 操作は data-cy が無く fragility が高いため scope 外。
+
+import { readFileSync } from 'node:fs';
+import { expect, test } from '@playwright/test';
+import { type RootFixture, uiSigninAsRoot } from '../../fixtures/ui_auth';
+
+test.describe('UI: /my/drive/file/:fileId hydrates file metadata', () => {
+  let root: RootFixture;
+
+  test.beforeAll(() => {
+    root = JSON.parse(readFileSync('.auth/root.json', 'utf-8'));
+  });
+
+  test.setTimeout(60_000);
+
+  test('drive file detail page renders the file name', async ({ page, baseURL, request }) => {
+    // 同 SHA256 の buffer を upload しても mk-go drive/files/create は
+    // dedupe で既存 entry を返してくることがある (= test 累積で 1x1 PNG が
+    // 既に登録済 + 同 hash で hit)。そのため API が返した file の name で
+    // 検証する (= 自分が指定した name と一致するとは限らない)。本 spec の
+    // scope は drive file detail page hydration の smoke なので、ID で
+    // 引いた file の name が body に出れば十分。
+    const fileName = `pw-drive-detail-${Date.now()}.png`;
+    const driveResp = await request.post(`${baseURL}/api/drive/files/create`, {
+      ignoreHTTPSErrors: true,
+      multipart: {
+        i: root.token,
+        file: {
+          name: fileName,
+          mimeType: 'image/png',
+          buffer: Buffer.from(
+            'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNkYAAAAAYAAjCB0C8AAAAASUVORK5CYII=',
+            'base64',
+          ),
+        },
+      },
+    });
+    expect(driveResp.status()).toBe(200);
+    const file = await driveResp.json();
+    expect(file.id, 'drive/files/create should return file id').toBeTruthy();
+    const actualName: string = file.name;
+    expect(typeof actualName).toBe('string');
+
+    await uiSigninAsRoot(page, baseURL, root);
+    const resp = await page.goto(`${baseURL}/my/drive/file/${file.id}`, {
+      waitUntil: 'domcontentloaded',
+    });
+    expect(resp!.status()).toBe(200);
+
+    // info tab の <h2 :class="$style.fileName">{{ file.name }}</h2> が
+    // hydrate して filename 文字列が body に出る。
+    await page.waitForFunction(
+      (n) => document.body.textContent?.includes(n) ?? false,
+      actualName,
+      { timeout: 20_000 },
+    );
+
+    // MIME type "image/png" も file info の MkKeyValue で render される。
+    await page.waitForFunction(
+      () => document.body.textContent?.includes('image/png') ?? false,
+      { timeout: 20_000 },
+    );
+  });
+});

--- a/tests/playwright/specs/ui/explore_users_render.spec.ts
+++ b/tests/playwright/specs/ui/explore_users_render.spec.ts
@@ -1,0 +1,47 @@
+// /explore#users page で recently-registered な user が render されることを
+// verify する spec。
+//
+// upstream Misskey の router 定義では `/explore` 単体に `hash: 'initialTab'`
+// が紐づいており、URL hash (= `#users`) が initialTab prop に渡って users
+// tab で初期化される。`/explore/users` は SPA route として存在せず not-found
+// に流れるので、本 spec は `/explore#users` を使う。
+//
+// signupUser でフレッシュ user を作成した直後に navigate すると、
+// "Recently registered users" セクションに新 user の username が含まれる
+// (= users/get-recently-registered endpoint からの hydration)。MkUserList
+// + MkPagination の chain が壊れていないことの smoke。
+
+import { readFileSync } from 'node:fs';
+import { expect, test } from '@playwright/test';
+import { DEFAULT_TEST_PASSWORD, signupUser } from '../../fixtures/auth';
+import { resetRateLimit } from '../../fixtures/rate_limit';
+import { type RootFixture, uiSigninAsRoot } from '../../fixtures/ui_auth';
+
+test.describe('UI: /explore/users renders recently-registered users', () => {
+  let root: RootFixture;
+
+  test.beforeAll(() => {
+    resetRateLimit();
+    root = JSON.parse(readFileSync('.auth/root.json', 'utf-8'));
+  });
+
+  test.setTimeout(60_000);
+
+  test('newly signed-up user appears in /explore#users', async ({ page, baseURL, request }) => {
+    const newUserName = `expnew${Date.now().toString().slice(-9)}`;
+    await signupUser(request, newUserName, DEFAULT_TEST_PASSWORD);
+
+    await uiSigninAsRoot(page, baseURL, root);
+    const resp = await page.goto(`${baseURL}/explore#users`, { waitUntil: 'domcontentloaded' });
+    expect(resp!.status()).toBe(200);
+
+    // /explore/users は recently-registered user を含む複数 section を
+    // hydrate するので、新規 user の username が body に出るのを sign に
+    // する (MkUserList の MkUserName 経由)。
+    await page.waitForFunction(
+      (n) => document.body.textContent?.includes(n) ?? false,
+      newUserName,
+      { timeout: 20_000 },
+    );
+  });
+});

--- a/tests/playwright/specs/ui/flash_detail_render.spec.ts
+++ b/tests/playwright/specs/ui/flash_detail_render.spec.ts
@@ -1,0 +1,54 @@
+// /play/:id (flash 詳細 page) で flash/create で作成した flash の title /
+// summary が hydrate されることを verify する spec。
+//
+// upstream Misskey の flash route は `/play/:id` (= AiScript playground)。
+// flash/show 経由で title / summary / script を取得して MkFlashPage の中
+// で render する。本 spec は title / summary を body match で smoke する。
+
+import { readFileSync } from 'node:fs';
+import { expect, test } from '@playwright/test';
+import { callApi } from '../../fixtures/api';
+import type { RootFixture } from '../../fixtures/ui_auth';
+
+test.describe('UI: /play/:id flash detail page hydrates', () => {
+  let root: RootFixture;
+
+  test.beforeAll(() => {
+    root = JSON.parse(readFileSync('.auth/root.json', 'utf-8'));
+  });
+
+  test.setTimeout(60_000);
+
+  test('flash/create + /play/:id renders title and summary', async ({ page, baseURL, request }) => {
+    const title = `pwflash-${Date.now().toString().slice(-9)}`;
+    const summary = `pwflash-summary-${Date.now().toString().slice(-9)}`;
+
+    const createResp = await callApi(request, 'flash/create', {
+      i: root.token,
+      title,
+      summary,
+      script: '<:: "hello world"',
+      permissions: [],
+      visibility: 'public',
+    });
+    expect(createResp.status()).toBe(200);
+    const flash = await createResp.json();
+    expect(flash.id, 'flash/create should return id').toBeTruthy();
+
+    await page.setViewportSize({ width: 1600, height: 900 });
+    const resp = await page.goto(`${baseURL}/play/${flash.id}`, { waitUntil: 'domcontentloaded' });
+    expect(resp!.status()).toBe(200);
+
+    // title + summary が body に出る (= MkFlashPage の hydration 完了)
+    await page.waitForFunction(
+      (t) => document.body.textContent?.includes(t) ?? false,
+      title,
+      { timeout: 20_000 },
+    );
+    await page.waitForFunction(
+      (s) => document.body.textContent?.includes(s) ?? false,
+      summary,
+      { timeout: 20_000 },
+    );
+  });
+});

--- a/tests/playwright/specs/ui/games_index_render.spec.ts
+++ b/tests/playwright/specs/ui/games_index_render.spec.ts
@@ -1,0 +1,37 @@
+// /games page で bubble-game / reversi の link panel が hydrate される
+// ことを smoke する spec。
+//
+// /games は MkA (link) を 2 つ render する単純な page。logo image の
+// /url 属性で hydration sign を取る。
+
+import { readFileSync } from 'node:fs';
+import { expect, test } from '@playwright/test';
+import { type RootFixture, uiSigninAsRoot } from '../../fixtures/ui_auth';
+
+test.describe('UI: /games page renders game links', () => {
+  let root: RootFixture;
+
+  test.beforeAll(() => {
+    root = JSON.parse(readFileSync('.auth/root.json', 'utf-8'));
+  });
+
+  test.setTimeout(60_000);
+
+  test('games index renders both bubble-game and reversi links', async ({ page, baseURL }) => {
+    await uiSigninAsRoot(page, baseURL, root);
+    const resp = await page.goto(`${baseURL}/games`, { waitUntil: 'domcontentloaded' });
+    expect(resp!.status()).toBe(200);
+
+    // bubble-game / reversi の <a href> が render される
+    await page.waitForFunction(
+      () => {
+        const links = Array.from(document.querySelectorAll('a')).map((a) => a.href);
+        return (
+          links.some((h) => h.endsWith('/bubble-game') || h.includes('/bubble-game')) &&
+          links.some((h) => h.endsWith('/reversi') || h.includes('/reversi'))
+        );
+      },
+      { timeout: 20_000 },
+    );
+  });
+});

--- a/tests/playwright/specs/ui/local_timeline_render.spec.ts
+++ b/tests/playwright/specs/ui/local_timeline_render.spec.ts
@@ -1,0 +1,52 @@
+// /timeline default tab の初期 hydration smoke。upstream Misskey の /timeline
+// route は store.r.tl.value.src で home / local / global / hybrid の最後に
+// 選択した tab を render する。新規 root 認証直後は home tab がデフォルト
+// で、root 自身の note は home timeline に乗る。本 spec は root が public
+// note を post → /timeline navigate → note text が body に出るのを smoke。
+//
+// /timeline/local や /timeline/global は SPA route として独立しておらず、
+// /timeline の中の tab 切替で表示される (= URL は変わらない)。よって本
+// spec は default tab で見える note のみを verify する。
+
+import { readFileSync } from 'node:fs';
+import { expect, test } from '@playwright/test';
+import { callApi } from '../../fixtures/api';
+import { type RootFixture, uiSigninAsRoot } from '../../fixtures/ui_auth';
+
+test.describe('UI: /timeline renders a recent note from the viewer', () => {
+  let root: RootFixture;
+
+  test.beforeAll(() => {
+    root = JSON.parse(readFileSync('.auth/root.json', 'utf-8'));
+  });
+
+  test.setTimeout(60_000);
+
+  test('a fresh public note from root appears in /timeline default tab', async ({
+    page,
+    baseURL,
+    request,
+  }) => {
+    const noteText = `pwtl-${Date.now().toString().slice(-9)}`;
+    const noteResp = await callApi(request, 'notes/create', {
+      i: root.token,
+      text: noteText,
+      visibility: 'public',
+    });
+    expect(noteResp.status()).toBe(200);
+
+    await uiSigninAsRoot(page, baseURL, root);
+    const resp = await page.goto(`${baseURL}/timeline`, {
+      waitUntil: 'domcontentloaded',
+    });
+    expect(resp!.status()).toBe(200);
+
+    // note text が body に出る = MkStreamingNotesTimeline の hydration
+    // (初期 fetch + MkNote render) が完了
+    await page.waitForFunction(
+      (t) => document.body.textContent?.includes(t) ?? false,
+      noteText,
+      { timeout: 20_000 },
+    );
+  });
+});

--- a/tests/playwright/specs/ui/lookup_render.spec.ts
+++ b/tests/playwright/specs/ui/lookup_render.spec.ts
@@ -1,0 +1,47 @@
+// /lookup?uri=<acct> を navigate して、acct を解決した user の profile page
+// に redirect されることを verify する spec。
+//
+// /lookup は misskey-hub からの share / drop-in URL 経由 lookup の入口で、
+// query param uri を `users/show` または `ap/show` で解決し SPA router 内で
+// /@:acct に replace 遷移する。本 spec は acct 経路 (= local user の username
+// だけで lookup) を smoke する。
+
+import { readFileSync } from 'node:fs';
+import { expect, test } from '@playwright/test';
+import { type RootFixture, uiSigninAsRoot } from '../../fixtures/ui_auth';
+
+test.describe('UI: /lookup resolves local acct and redirects to profile', () => {
+  let root: RootFixture;
+
+  test.beforeAll(() => {
+    root = JSON.parse(readFileSync('.auth/root.json', 'utf-8'));
+  });
+
+  test.setTimeout(60_000);
+
+  test('/lookup?uri=<root.username> redirects to /@<root.username>', async ({ page, baseURL }) => {
+    await uiSigninAsRoot(page, baseURL, root);
+
+    // /lookup?uri=<acct> を navigate。/lookup は initial load 時 fetching
+    // → users/show 解決後に SPA replace で /@:acct に飛ぶ (waitUntil:
+    // 'domcontentloaded' では replace 前で response.status を捕捉する)。
+    const resp = await page.goto(`${baseURL}/lookup?uri=${root.username}`, {
+      waitUntil: 'domcontentloaded',
+    });
+    expect(resp!.status()).toBe(200);
+
+    // SPA router の replace は client-side で行われるので URL が
+    // /@<username> に変わるまで待つ。
+    await page.waitForURL((u) => u.pathname.startsWith(`/@${root.username}`), {
+      timeout: 20_000,
+    });
+
+    // profile page には username が body に出る (= MkUserPage の hydration
+    // 完了)。
+    await page.waitForFunction(
+      (n) => document.body.textContent?.includes(n) ?? false,
+      root.username,
+      { timeout: 20_000 },
+    );
+  });
+});

--- a/tests/playwright/specs/ui/my_clips_render.spec.ts
+++ b/tests/playwright/specs/ui/my_clips_render.spec.ts
@@ -1,0 +1,45 @@
+// /my/clips page で clips/create で作成した clip の name が MkClipPreview
+// で render されることを verify する spec。
+//
+// /my/clips は clips/list (= 自分の clip) と clips/my-favorites の 2 tab
+// 構成。default tab は 'my' で、MkPagination + MkClipPreview の chain で
+// render する。content_pages.spec.ts で /clips/:id 詳細 page は cover 済
+// だが、本 spec は **list page** の hydration を verify する別 layer。
+
+import { readFileSync } from 'node:fs';
+import { expect, test } from '@playwright/test';
+import { callApi } from '../../fixtures/api';
+import { type RootFixture, uiSigninAsRoot } from '../../fixtures/ui_auth';
+
+test.describe('UI: /my/clips renders the user clip list', () => {
+  let root: RootFixture;
+
+  test.beforeAll(() => {
+    root = JSON.parse(readFileSync('.auth/root.json', 'utf-8'));
+  });
+
+  test.setTimeout(60_000);
+
+  test('clips/create + /my/clips renders clip name', async ({ page, baseURL, request }) => {
+    const clipName = `pwclip-${Date.now().toString().slice(-9)}`;
+    const createResp = await callApi(request, 'clips/create', {
+      i: root.token,
+      name: clipName,
+      isPublic: true,
+    });
+    expect(createResp.status()).toBe(200);
+    const clip = await createResp.json();
+    expect(clip.id, 'clips/create should return id').toBeTruthy();
+
+    await uiSigninAsRoot(page, baseURL, root);
+    const resp = await page.goto(`${baseURL}/my/clips`, { waitUntil: 'domcontentloaded' });
+    expect(resp!.status()).toBe(200);
+
+    // MkClipPreview は clip.name を text として render するので body 検索可
+    await page.waitForFunction(
+      (n) => document.body.textContent?.includes(n) ?? false,
+      clipName,
+      { timeout: 20_000 },
+    );
+  });
+});

--- a/tests/playwright/specs/ui/my_favorites_render.spec.ts
+++ b/tests/playwright/specs/ui/my_favorites_render.spec.ts
@@ -1,0 +1,49 @@
+// /my/favorites page で notes/favorites/create 後の note text が
+// MkPagination + MkNote 経由で render されることを verify する spec。
+//
+// upstream Misskey の /my/favorites は i/favorites endpoint を Paginator
+// で叩いて (favorite, note) を取得し、各 note を MkNote で render する。
+// 本 spec は note text を hydration sign にする。
+
+import { readFileSync } from 'node:fs';
+import { expect, test } from '@playwright/test';
+import { callApi } from '../../fixtures/api';
+import { type RootFixture, uiSigninAsRoot } from '../../fixtures/ui_auth';
+
+test.describe('UI: /my/favorites renders favorited notes', () => {
+  let root: RootFixture;
+
+  test.beforeAll(() => {
+    root = JSON.parse(readFileSync('.auth/root.json', 'utf-8'));
+  });
+
+  test.setTimeout(60_000);
+
+  test('a favorited note appears in /my/favorites', async ({ page, baseURL, request }) => {
+    // 自分の note を favorite する (= 一番シンプルに /my/favorites に乗る)
+    const noteText = `pwfav-${Date.now().toString().slice(-9)}`;
+    const noteResp = await callApi(request, 'notes/create', {
+      i: root.token,
+      text: noteText,
+      visibility: 'public',
+    });
+    expect(noteResp.status()).toBe(200);
+    const noteId = (await noteResp.json()).createdNote.id;
+
+    const favResp = await callApi(request, 'notes/favorites/create', {
+      i: root.token,
+      noteId,
+    });
+    expect(favResp.status()).toBe(204);
+
+    await uiSigninAsRoot(page, baseURL, root);
+    const resp = await page.goto(`${baseURL}/my/favorites`, { waitUntil: 'domcontentloaded' });
+    expect(resp!.status()).toBe(200);
+
+    await page.waitForFunction(
+      (t) => document.body.textContent?.includes(t) ?? false,
+      noteText,
+      { timeout: 20_000 },
+    );
+  });
+});

--- a/tests/playwright/specs/ui/my_lists_render.spec.ts
+++ b/tests/playwright/specs/ui/my_lists_render.spec.ts
@@ -1,0 +1,42 @@
+// /my/lists page で users/lists/create で作成した list の name が
+// MkA の link text として render されることを verify する spec。
+//
+// /my/lists は users/lists/list 経由で list 一覧を取得し、各 list を
+// MkA + MkAvatars で render する。list.name + nUsers の i18n string が
+// body に出るのを smoke する。
+
+import { readFileSync } from 'node:fs';
+import { expect, test } from '@playwright/test';
+import { callApi } from '../../fixtures/api';
+import { type RootFixture, uiSigninAsRoot } from '../../fixtures/ui_auth';
+
+test.describe('UI: /my/lists renders user-list names', () => {
+  let root: RootFixture;
+
+  test.beforeAll(() => {
+    root = JSON.parse(readFileSync('.auth/root.json', 'utf-8'));
+  });
+
+  test.setTimeout(60_000);
+
+  test('users/lists/create + /my/lists renders list name', async ({ page, baseURL, request }) => {
+    const listName = `pwlist-${Date.now().toString().slice(-9)}`;
+    const createResp = await callApi(request, 'users/lists/create', {
+      i: root.token,
+      name: listName,
+    });
+    expect(createResp.status()).toBe(200);
+    const list = await createResp.json();
+    expect(list.id, 'users/lists/create should return id').toBeTruthy();
+
+    await uiSigninAsRoot(page, baseURL, root);
+    const resp = await page.goto(`${baseURL}/my/lists`, { waitUntil: 'domcontentloaded' });
+    expect(resp!.status()).toBe(200);
+
+    await page.waitForFunction(
+      (n) => document.body.textContent?.includes(n) ?? false,
+      listName,
+      { timeout: 20_000 },
+    );
+  });
+});

--- a/tests/playwright/specs/ui/route_matrix.spec.ts
+++ b/tests/playwright/specs/ui/route_matrix.spec.ts
@@ -24,8 +24,12 @@ const AUTH_ROUTES: RouteCase[] = [
   { path: '/timeline/global', label: 'timeline/global' },
   { path: '/timeline/hybrid', label: 'timeline/hybrid' },
   // discovery / explore
-  { path: '/explore/users', label: 'explore/users' },
-  { path: '/explore/tags', label: 'explore/tags' },
+  // /explore は単体 route。tab は initialTab prop に hash 経由で渡されるが、
+  // 連続 page.goto で hash だけ変えると Playwright は null response を返す
+  // (= same-document navigation 扱い) ので、route_matrix では default tab
+  // 経路だけを cover する。tab 別 hydration verify は専用 spec
+  // (specs/ui/explore_users_render.spec.ts) で行う。
+  { path: '/explore', label: 'explore (default = featured)' },
   // i / 自アカウント系
   { path: '/my/favorites', label: 'my/favorites' },
   { path: '/my/clips', label: 'my/clips' },
@@ -55,7 +59,7 @@ const AUTH_ROUTES: RouteCase[] = [
   { path: '/admin/overview', label: 'admin/overview' },
   { path: '/admin/users', label: 'admin/users' },
   { path: '/admin/emojis', label: 'admin/emojis' },
-  { path: '/admin/queue', label: 'admin/queue' },
+  { path: '/admin/job-queue', label: 'admin/job-queue' },
   { path: '/admin/federation', label: 'admin/federation' },
   { path: '/admin/abuses', label: 'admin/abuses' },
   { path: '/admin/announcements', label: 'admin/announcements' },

--- a/tests/playwright/specs/ui/scratchpad_render.spec.ts
+++ b/tests/playwright/specs/ui/scratchpad_render.spec.ts
@@ -1,0 +1,42 @@
+// /scratchpad page で MkCodeEditor + Run button + Output container が
+// hydrate されることを smoke する spec。
+//
+// scratchpad は AiScript playground (= /play/:id とは別の sandbox)。
+// MkCodeEditor は CodeMirror で AiScript モードを mount するので、
+// hydration sign は code editor の textarea / "Output" container labels
+// で十分。
+
+import { readFileSync } from 'node:fs';
+import { expect, test } from '@playwright/test';
+import { type RootFixture, uiSigninAsRoot } from '../../fixtures/ui_auth';
+
+test.describe('UI: /scratchpad page hydrates AiScript playground', () => {
+  let root: RootFixture;
+
+  test.beforeAll(() => {
+    root = JSON.parse(readFileSync('.auth/root.json', 'utf-8'));
+  });
+
+  test.setTimeout(60_000);
+
+  test('scratchpad editor + output container appear on /scratchpad', async ({
+    page,
+    baseURL,
+  }) => {
+    await uiSigninAsRoot(page, baseURL, root);
+    const resp = await page.goto(`${baseURL}/scratchpad`, { waitUntil: 'domcontentloaded' });
+    expect(resp!.status()).toBe(200);
+
+    // hydration 完了 = MkCodeEditor (CodeMirror) の textarea / output
+    // container header が render される。MkContainer の "UI inspector" /
+    // "Output" のような label が body に出るのを sign にする。
+    await page.waitForFunction(
+      () => {
+        const text = document.body.textContent ?? '';
+        // i18n の Output / UI inspector 文字列。test 環境は 英語 default。
+        return text.includes('Output') && text.includes('UI inspector');
+      },
+      { timeout: 20_000 },
+    );
+  });
+});


### PR DESCRIPTION
## Summary

PR #954 で固めた UI spec 基盤の上に、未カバーの authenticated route を hydrate verify する spec を 4 本追加。検証中に upstream Misskey の SPA route 定義と route_matrix で参照していた path の乖離を 2 件 (= \`/admin/queue\` → \`/admin/job-queue\` / \`/explore/users\` → \`/explore#users\`) 発見し、route_matrix も修正。

## 主な変更点

### 新規 spec (4 本)

- **admin_federation_render.spec.ts**: \`/admin/federation\` で MkInput (host filter) + MkSelect (state/sort) + 認証済 navbar の hydration を smoke
- **admin_queue_render.spec.ts**: \`/admin/job-queue\` で header tabs (deliver / inbox 等の queue type 名) が render されることを smoke。Active/Delayed/Waiting 数値は admin/queue/queues の値で populate されるが Playwright stack の queueInspector が未配線で空配列を返すため、tab 名 (= misskey-js queueTypes 定数 hardcode) で hydration sign を取る
- **explore_users_render.spec.ts**: \`/explore#users\` (hash で initialTab=users を受け取る) で recently-registered な fresh user が body に出ることを verify
- **lookup_render.spec.ts**: \`/lookup?uri=<acct>\` が users/show 解決後に \`/@<acct>\` へ SPA replace 遷移し、profile page が hydrate されることを verify

### route_matrix の修正

- \`/admin/queue\` → \`/admin/job-queue\` (実 SPA route 名は job-queue)
- \`/explore/users\` / \`/explore/tags\` の存在しない route を \`/explore\` default tab だけに置き換え (hash variant は連続 goto で null response を返す Playwright 制約があるので専用 spec の scope に分離)

## 設計判断

- /explore は \`hash: 'initialTab'\` で tab を URL hash から populate する upstream の挙動に合わせて、専用 spec で hash 経由 navigate を試す
- /admin/job-queue の queue inspector 未配線時の挙動は test-only の問題で production 影響なし。tab 名で hydration を見れば smoke として十分
- /lookup の SPA replace 遷移は \`page.waitForURL\` で URL pathname の変化を捕捉する pattern を確立 (= 後続の同様 route で再利用可)

## テスト

- ローカル: \`make playwright-test\` で 215 全 pass (本 PR で +4 spec)

## 関連

- 関連 tracker: #744 (Playwright Phase 1-4)
- 前 PR: #954 (UI 操作 + frontend hydration spec batch 1, 18 本)

🤖 Generated with [Claude Code](https://claude.com/claude-code)