### PR TITLE
Fix #960: i/update が tokenCache を invalidate するように修正

### DIFF
--- a/internal/api/i/handler.go
+++ b/internal/api/i/handler.go
@@ -951,7 +951,9 @@ func (h *Handler) Update(c echo.Context) error {
 	// 「自分から見て」即時反映されるべきなので、現在の token entry を
 	// invalidate して次回 lookup で DB から fresh fetch させる (#960)。
 	// invalidate 対象は本 request の認証 token のみ (= 他デバイスの session
-	// は影響なし)。
+	// は影響なし)。infrastructure としては #884 で導入された
+	// TokenInvalidator interface (regenerate-token / change-password 用)
+	// を再利用しており、本 handler 専用の wiring は追加していない。
 	if h.authInvalidator != nil {
 		if tok := middleware.GetToken(c); tok != "" {
 			h.authInvalidator.InvalidateToken(tok)

--- a/internal/api/i/handler.go
+++ b/internal/api/i/handler.go
@@ -944,6 +944,20 @@ func (h *Handler) Update(c echo.Context) error {
 		h.hardMutePublisher.PublishHardMuteReload(me.ID)
 	}
 
+	// auth middleware の tokenCache (30 秒 TTL) は token → user object を
+	// キャッシュしているため、name / description などの mutable field を
+	// 更新しても、同じ token で次の request が来たとき stale な user が
+	// attach され続ける。本来 cache の効く期間 (TTL 内) は profile が
+	// 「自分から見て」即時反映されるべきなので、現在の token entry を
+	// invalidate して次回 lookup で DB から fresh fetch させる (#960)。
+	// invalidate 対象は本 request の認証 token のみ (= 他デバイスの session
+	// は影響なし)。
+	if h.authInvalidator != nil {
+		if tok := middleware.GetToken(c); tok != "" {
+			h.authInvalidator.InvalidateToken(tok)
+		}
+	}
+
 	return c.JSON(http.StatusOK, entity.PackUserDetailed(bundle.User, bundle.Profile, h.idGen))
 }
 

--- a/internal/api/i/handler_test.go
+++ b/internal/api/i/handler_test.go
@@ -653,6 +653,60 @@ func TestUpdate_FieldsEmptyClears(t *testing.T) {
 	assert.JSONEq(t, `[]`, string(repo.Profiles["user1"].Fields))
 }
 
+// #960: Update が成功した後に auth middleware の tokenCache を invalidate
+// する。同じ token の次 request で stale な user object が返るのを防ぐ。
+// invalidator が wire されており request context に token がある場合のみ
+// invalidate を呼ぶ — どちらが欠けても panic / 不正呼び出しにならない。
+func TestUpdate_InvalidatesTokenCacheOnSuccess(t *testing.T) {
+	h, repo, _, _ := newTestHandler(t)
+	user := &model.User{ID: "user1", Username: "user1", AvatarDecorations: datatypes.JSON([]byte("[]"))}
+	repo.Users["user1"] = user
+
+	inv := &stubTokenInvalidator{}
+	h.SetAuthInvalidator(inv)
+
+	// middleware が context に詰める想定の auth token を直接 set する。
+	e := echo.New()
+	req := httptest.NewRequest(http.MethodPost, "/", strings.NewReader(`{"name":"updated"}`))
+	req.Header.Set(echo.HeaderContentType, echo.MIMEApplicationJSON)
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+	c.Set(string(middleware.UserContextKey), user)
+	c.Set(string(middleware.TokenContextKey), "the-current-request-token")
+
+	require.NoError(t, h.Update(c))
+	assert.Equal(t, http.StatusOK, rec.Code)
+	require.Equal(t, []string{"the-current-request-token"}, inv.calls,
+		"成功した i/update は本 request の token を invalidate するべき")
+}
+
+func TestUpdate_NoInvalidatorIsNoop(t *testing.T) {
+	// invalidator が wire されていないとき (production では必ず wire するが
+	// 単体 test や router 配線忘れ時) は invalidate skip して 200 を返す。
+	h, repo, _, _ := newTestHandler(t)
+	user := &model.User{ID: "user1", Username: "user1", AvatarDecorations: datatypes.JSON([]byte("[]"))}
+	repo.Users["user1"] = user
+
+	rec := post(h.Update, `{"name":"updated"}`, user)
+	assert.Equal(t, http.StatusOK, rec.Code)
+}
+
+func TestUpdate_NoTokenInContextIsNoop(t *testing.T) {
+	// invalidator は wire 済みだが context に token が無いケース (= 認証
+	// pipeline が新旧混在している過渡期や unit test 直叩き)。invalidate
+	// 呼び出しは skip し、handler は 200 で完了する。
+	h, repo, _, _ := newTestHandler(t)
+	user := &model.User{ID: "user1", Username: "user1", AvatarDecorations: datatypes.JSON([]byte("[]"))}
+	repo.Users["user1"] = user
+
+	inv := &stubTokenInvalidator{}
+	h.SetAuthInvalidator(inv)
+
+	rec := post(h.Update, `{"name":"updated"}`, user)
+	assert.Equal(t, http.StatusOK, rec.Code)
+	assert.Empty(t, inv.calls, "token が context に無いとき invalidate は呼ばれない")
+}
+
 // upstream paramDef は maxItems 16。それ超えは INVALID_PARAM (400)。
 func TestUpdate_FieldsTooMany(t *testing.T) {
 	h, repo, _, _ := newTestHandler(t)

--- a/internal/server/middleware/auth.go
+++ b/internal/server/middleware/auth.go
@@ -26,7 +26,10 @@ var errOrphanedAccessToken = errors.New("auth: access_token references a deleted
 
 type contextKey string
 
-const UserContextKey contextKey = "misskeyUser"
+const (
+	UserContextKey  contextKey = "misskeyUser"
+	TokenContextKey contextKey = "misskeyToken"
+)
 
 // lastActiveUpdateInterval は同一ユーザーの lastActiveDate 書き込みを抑制
 // する間隔。本家 TS は WebSocket 接続中 5 分おきに更新する (#421)。HTTP
@@ -87,6 +90,11 @@ func (a *AuthMiddleware) Authenticate() echo.MiddlewareFunc {
 			}
 
 			c.Set(string(UserContextKey), user)
+			// handler 側でこの request の auth token を引きたいケースがある
+			// (例: i/update が成功後に tokenCache を invalidate する目的、
+			// #960)。raw token をそのまま context に積む。app/auth 経由の
+			// access_token / native login token どちらも同じキーで取得可能。
+			c.Set(string(TokenContextKey), token)
 			a.touchLastActive(user.ID)
 			return next(c)
 		}
@@ -159,6 +167,20 @@ func GetUser(c echo.Context) *model.User {
 		return nil
 	}
 	return u
+}
+
+// GetToken returns the raw auth token used for the current request, or
+// empty string if the request was not authenticated. Handlers that perform
+// self-mutation (e.g. i/update) use this to invalidate the auth middleware's
+// tokenCache entry so subsequent requests read fresh user state from DB
+// instead of returning stale cached values within the 30s TTL window
+// (#960).
+func GetToken(c echo.Context) string {
+	t, ok := c.Get(string(TokenContextKey)).(string)
+	if !ok {
+		return ""
+	}
+	return t
 }
 
 // RoleChecker abstracts role checking to avoid circular dependency with core/role.

--- a/internal/server/middleware/auth_test.go
+++ b/internal/server/middleware/auth_test.go
@@ -61,6 +61,43 @@ func TestAuthenticate_BearerToken(t *testing.T) {
 	assert.NoError(t, err)
 }
 
+// #960: handler が現在 request の auth token を取得できる必要がある
+// (i/update 成功後に tokenCache を invalidate する目的)。Authenticate
+// middleware は raw token を context に詰める。
+func TestAuthenticate_PutsTokenInContext(t *testing.T) {
+	userRepo := testutil.NewMockUserRepository()
+	tokenRepo := testutil.NewMockAccessTokenRepository()
+
+	user := &model.User{ID: "user1", Username: "testuser"}
+	nativeToken := "abcdef1234567890"
+	userRepo.Tokens[nativeToken] = user
+
+	auth := NewAuthMiddleware(userRepo, tokenRepo)
+
+	e := echo.New()
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	req.Header.Set("Authorization", "Bearer "+nativeToken)
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+
+	handler := auth.Authenticate()(func(c echo.Context) error {
+		assert.Equal(t, nativeToken, GetToken(c),
+			"middleware は raw auth token を context にそのまま積むべき")
+		return c.String(http.StatusOK, "ok")
+	})
+	require.NoError(t, handler(c))
+}
+
+func TestGetToken_NotAuthenticated(t *testing.T) {
+	// 未認証 request では GetToken は空文字を返す (panic しない)。
+	e := echo.New()
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+
+	assert.Equal(t, "", GetToken(c))
+}
+
 func TestAuthenticate_QueryParam(t *testing.T) {
 	userRepo := testutil.NewMockUserRepository()
 	tokenRepo := testutil.NewMockAccessTokenRepository()

--- a/tests/playwright/specs/ui/profile_name_save.spec.ts
+++ b/tests/playwright/specs/ui/profile_name_save.spec.ts
@@ -1,23 +1,22 @@
 // /settings/profile で name MkInput を編集 → manualSave button click →
-// /api/i/update 応答 body に新 name が反映されることを verify する
+// /api/i/update + /api/i 両方で新 name が反映されることを verify する
 // **真の write-flow** spec。
 //
 // MkInput (manualSave) は input 値変更で `<MkButton :class="$style.save">`
 // を表示する。click すると updated event → os.apiWithDialog('i/update', ...)
-// で name が persist される。本 spec は i/update の response body
-// (= updated user object) で round-trip を verify する。
+// で name が persist される。本 spec は i/update 応答 + /api/i の 2 段で
+// round-trip を verify する (= auth middleware tokenCache が i/update 後に
+// 正しく invalidate されることを backend regression test として担保、#960)。
 //
-// 注意 1: /settings/* は親 layout の MkSuperMenu に search MkInput (type=search)
+// 注意: /settings/* は親 layout の MkSuperMenu に search MkInput (type=search)
 // があり、page 全体 input[0] はこの search box。form 本体の name input を
-// 取るには type !== "search" で filter が必要 (#744 batch3)。
-//
-// 注意 2: /api/i 経由の DB round-trip 検証は意図的にしていない。auth
-// middleware の tokenCache (30s TTL, auth.go:42) は i/update で invalidate
-// されないため、更新直後の /api/i は stale な値を返す (#744 batch3 で
-// 発覚 → #960 で実装側を修正予定、修正後は /api/i round-trip に戻す)。
+// 取るには `i.type === "text"` filter が必要 (MkInput type prop default は
+// 暗黙の "text" で type 属性を render しないため input[type="text"] では
+// match しない、#744 batch3)。
 
 import { readFileSync } from 'node:fs';
 import { expect, test } from '@playwright/test';
+import { callApi } from '../../fixtures/api';
 import { type RootFixture, uiSigninAsRoot } from '../../fixtures/ui_auth';
 
 test.describe('UI: /settings/profile name save flow', () => {
@@ -29,9 +28,10 @@ test.describe('UI: /settings/profile name save flow', () => {
 
   test.setTimeout(60_000);
 
-  test('edit name MkInput → click save → i/update response reflects new name', async ({
+  test('edit name MkInput → click save → i/update + /api/i both reflect new name', async ({
     page,
     baseURL,
+    request,
   }) => {
     await uiSigninAsRoot(page, baseURL, root);
     await page.goto(`${baseURL}/settings/profile`, { waitUntil: 'domcontentloaded' });
@@ -94,11 +94,17 @@ test.describe('UI: /settings/profile name save flow', () => {
       ) as HTMLButtonElement | undefined;
       btn?.click();
     });
-    // i/update 応答 body の updated user object で name を verify する。
-    // /api/i は middleware の tokenCache (30s TTL, auth.go:42) で stale に
-    // なるため round-trip 検証には使わない (#744 batch3 で発覚)。
+    // i/update 応答 body は更新後 user object を返す (handler が fresh fetch)。
     const update = await updateResp;
     const updateBody = await update.json();
     expect(updateBody.name).toBe(newName);
+
+    // 同じ token で /api/i を読み直す。i/update は auth middleware の
+    // tokenCache を invalidate するため (#960)、cache TTL (30s) 内でも
+    // fresh user が返る。
+    const meResp = await callApi(request, 'i', { i: root.token });
+    expect(meResp.status()).toBe(200);
+    const me = await meResp.json();
+    expect(me.name).toBe(newName);
   });
 });


### PR DESCRIPTION
## Summary

\`/api/i/update\` 成功後に auth middleware の \`tokenCache\` を invalidate して、cache TTL (30s) 内でも \`/api/i\` 等が fresh user state を返すようにする。

## 背景

\`internal/server/middleware/auth.go\` の \`AuthMiddleware\` は \`token → resolved user\` を 30 秒 TTL でキャッシュする (#512 / #413 #3)。\`/api/i/update\` で name / description 等を更新しても middleware の cache は古い user object を保持し続けるため、同じ token で次の request が来たとき \`middleware.GetUser(c)\` が stale な user を attach する。

PR #959 の Playwright UI write-flow spec (profile_name_save) が round-trip 検証中にこれを発見した経緯。

## 主な変更点

### 実装
- **\`middleware/auth.go\`**: Authenticate middleware で raw auth token を context (\`TokenContextKey\`) に詰めるよう拡張。\`GetToken(c)\` helper を export
- **\`api/i/handler.go\`**: Update 成功後に \`GetToken(c)\` で request の auth token を取得し、\`authInvalidator\` 経由で \`InvalidateToken\` を呼ぶ。invalidator は #884 で既に \`TokenInvalidator\` interface として用意済みのものを再利用 (新規 wiring 不要)

### テスト
- **\`api/i/handler_test.go\`** に 3 件追加:
  - \`TestUpdate_InvalidatesTokenCacheOnSuccess\` 正常系
  - \`TestUpdate_NoInvalidatorIsNoop\` invalidator 未配線時の defensive
  - \`TestUpdate_NoTokenInContextIsNoop\` token 未配線時の defensive
- **\`middleware/auth_test.go\`** に 2 件追加:
  - \`TestAuthenticate_PutsTokenInContext\` middleware の token 配置
  - \`TestGetToken_NotAuthenticated\` 未認証時の \"\" 返却
- **\`tests/playwright/specs/ui/profile_name_save.spec.ts\`**: PR #959 で挿入した workaround (\`/api/i\` 検証 skip) を撤回し、i/update + /api/i 両方で name 反映を verify する形に戻す。本 fix の regression test を spec 側でも担保

## テスト

\`\`\`bash
go test ./internal/api/i/ ./internal/server/middleware/ ./internal/core/user/ -count=1
# all PASS

# Playwright spec 単独確認 (mk-go playwright stack rebuild 含む)
make playwright-test (profile_name_save) → PASS (2.8s)
\`\`\`

新規 5 件 (Go 単体 3 + middleware 2) + 既存 spec の re-enable 1 件、計 6 件で本 fix の挙動を pin。

## 影響範囲

- **frontend**: /settings/profile / /settings/email 等で更新後の即時反映が cache miss / hit に依存しなくなる
- **federation**: actor inbox / followers list 等は cache を使わない repo 経由なので影響なし
- **streaming**: WebSocket は subscribe 時点 1 回 user resolve なので継続的 stale にはならない (本 fix の対象外)

## 補足

\`InvalidateToken\` は token 単位削除なので、複数デバイスでログイン中の user 全部に影響しない (= 自分の他端末は次回 request で fresh fetch、stale 期間は最大 TTL で従来同等)。

## Out of scope (follow-up)

review で同種の stale cache 問題が他の self-mutation handler でも発生していることが判明。本 PR は #960 の scope に厳密に絞っており、特に **\`i/delete-account\`** の security stale window (論理削除済 user が 30s 間 API access 可能) は別途 #962 で追跡。

## 関連

- Closes #960
- Follow-up: #962 (i/delete-account / i/2fa/* の同種 stale cache 問題、及び middleware で isSuspended/isDeleted を gate する根本対策)
- 発見元: #744 (Playwright Phase 1-4) batch 3 PR #959 の profile_name_save spec
- 既存 \`InvalidateToken\` インフラ: #884 で導入 (i/regenerate-token / change-password 用)、本 PR は同 interface を i/update でも活用

🤖 Generated with [Claude Code](https://claude.com/claude-code)