### PR TITLE
Fix #962 P0: i/delete-account が tokenCache を invalidate するように修正 (security)

### DIFF
--- a/internal/api/i/handler_extra.go
+++ b/internal/api/i/handler_extra.go
@@ -75,6 +75,21 @@ func (h *Handler) DeleteAccount(c echo.Context) error {
 	}); err != nil {
 		return c.JSON(http.StatusInternalServerError, apierr.Error("INTERNAL_ERROR", "Internal error.", "5d37dbcb-891e-41ca-a3d6-e690c97775ac"))
 	}
+	// auth middleware の tokenCache (30s TTL) は token → user object を保持
+	// しているため、論理削除直後でも cache 内の旧 user (isSuspended=false /
+	// isDeleted=false) で同じ token が auth を通過してしまう。middleware は
+	// 現状 isSuspended / isDeleted gate を持たない (signin handler 内のみ)
+	// ので、cache 経由の bypass を防ぐには handler 側で本 request の token
+	// entry を即時 invalidate するのが現実解 (#962 P0)。次 request は cache
+	// miss → DB から fresh fetch、middleware 通過後の handler が isDeleted な
+	// user の操作を弾く前提 (= middleware level の gate は #962 P2 で別途)。
+	// infrastructure は #884 / #960 と共通の TokenInvalidator interface を
+	// 再利用、新規 wiring は不要。
+	if h.authInvalidator != nil {
+		if tok := middleware.GetToken(c); tok != "" {
+			h.authInvalidator.InvalidateToken(tok)
+		}
+	}
 	return c.NoContent(http.StatusNoContent)
 }
 

--- a/internal/api/i/handler_extra.go
+++ b/internal/api/i/handler_extra.go
@@ -85,6 +85,13 @@ func (h *Handler) DeleteAccount(c echo.Context) error {
 	// user の操作を弾く前提 (= middleware level の gate は #962 P2 で別途)。
 	// infrastructure は #884 / #960 と共通の TokenInvalidator interface を
 	// 再利用、新規 wiring は不要。
+	//
+	// なお UpdateUserFields commit と本 invalidate の間の race window
+	// (μs オーダー) は本 fix では塞げない: 並行 request が同 token で
+	// middleware cache hit (stale) → handler 実行に到達した直後に本
+	// invalidate が走るケース。完全防衛は #962 P2 (middleware が DB fetch
+	// ごとに isSuspended / isDeleted を gate する) が必要。本 fix は
+	// 30s window → μs window への defense-in-depth 第一段。
 	if h.authInvalidator != nil {
 		if tok := middleware.GetToken(c); tok != "" {
 			h.authInvalidator.InvalidateToken(tok)

--- a/internal/api/i/handler_extra_test.go
+++ b/internal/api/i/handler_extra_test.go
@@ -170,7 +170,8 @@ func TestDeleteAccount_NoInvalidatorIsNoop(t *testing.T) {
 }
 
 // invalidator は wire 済みだが context に token が無いケースは invalidate
-// を skip し handler は 204 で完了する (#960 と同等の defensive)。
+// を skip し handler は 204 で完了する (#960 と同等の defensive)。core 削除
+// 挙動は token 有無に依存しないので IsDeleted は確実に立つ。
 func TestDeleteAccount_NoTokenInContextIsNoop(t *testing.T) {
 	h, repo := newExtraHandler(t)
 	user := setupUserWithPassword(repo, "u1", "pass")
@@ -180,6 +181,7 @@ func TestDeleteAccount_NoTokenInContextIsNoop(t *testing.T) {
 
 	rec := postExtra(h.DeleteAccount, `{"password":"pass"}`, user)
 	assert.Equal(t, http.StatusNoContent, rec.Code)
+	assert.True(t, repo.Users["u1"].IsDeleted, "token 不在でも core 削除挙動は実行される")
 	assert.Empty(t, inv.calls, "token が context に無いとき invalidate は呼ばれない")
 }
 

--- a/internal/api/i/handler_extra_test.go
+++ b/internal/api/i/handler_extra_test.go
@@ -132,6 +132,57 @@ func TestDeleteAccount_InvalidParam(t *testing.T) {
 	assert.Equal(t, http.StatusBadRequest, rec.Code)
 }
 
+// #962 P0: 論理削除完了後に auth middleware の tokenCache を invalidate
+// する。同じ token の次 request で stale な user (isSuspended=false) で
+// API 通過する security regression を防ぐ。
+func TestDeleteAccount_InvalidatesTokenCacheOnSuccess(t *testing.T) {
+	h, repo := newExtraHandler(t)
+	user := setupUserWithPassword(repo, "u1", "pass")
+
+	inv := &stubTokenInvalidator{}
+	h.SetAuthInvalidator(inv)
+
+	// middleware が context に詰める想定の auth token を直接 set する。
+	e := echo.New()
+	req := httptest.NewRequest(http.MethodPost, "/", strings.NewReader(`{"password":"pass"}`))
+	req.Header.Set(echo.HeaderContentType, echo.MIMEApplicationJSON)
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+	c.Set(string(middleware.UserContextKey), user)
+	c.Set(string(middleware.TokenContextKey), "victim-session-token")
+
+	require.NoError(t, h.DeleteAccount(c))
+	assert.Equal(t, http.StatusNoContent, rec.Code)
+	require.Equal(t, []string{"victim-session-token"}, inv.calls,
+		"DeleteAccount 成功時は本 request の token を即時 invalidate するべき")
+}
+
+// invalidator が wire されていないとき (test 直叩き / router 配線忘れ) は
+// 削除自体は成功して 204 を返す。core 削除挙動が invalidator dependency に
+// 引きずられない defensive。
+func TestDeleteAccount_NoInvalidatorIsNoop(t *testing.T) {
+	h, repo := newExtraHandler(t)
+	user := setupUserWithPassword(repo, "u1", "pass")
+
+	rec := postExtra(h.DeleteAccount, `{"password":"pass"}`, user)
+	assert.Equal(t, http.StatusNoContent, rec.Code)
+	assert.True(t, repo.Users["u1"].IsDeleted)
+}
+
+// invalidator は wire 済みだが context に token が無いケースは invalidate
+// を skip し handler は 204 で完了する (#960 と同等の defensive)。
+func TestDeleteAccount_NoTokenInContextIsNoop(t *testing.T) {
+	h, repo := newExtraHandler(t)
+	user := setupUserWithPassword(repo, "u1", "pass")
+
+	inv := &stubTokenInvalidator{}
+	h.SetAuthInvalidator(inv)
+
+	rec := postExtra(h.DeleteAccount, `{"password":"pass"}`, user)
+	assert.Equal(t, http.StatusNoContent, rec.Code)
+	assert.Empty(t, inv.calls, "token が context に無いとき invalidate は呼ばれない")
+}
+
 // --- Favorites ---
 
 func TestFavorites_Success(t *testing.T) {


### PR DESCRIPTION
## Summary

\`/api/i/delete-account\` 成功後に auth middleware の \`tokenCache\` を invalidate して、論理削除直後の attack window (30s) を即時閉じる。**security 系 fix**。

## 背景

\`i/delete-account\` は user の \`isSuspended\` / \`isDeleted\` を true に設定する論理削除を行うが、auth middleware の \`tokenCache\` (30s TTL) は古い user object (\`isSuspended=false\` / \`isDeleted=false\`) を保持し続ける。

middleware は \`isSuspended\` / \`isDeleted\` を gate していない (\`signin/handler.go:112\` の signin handler 内のみ。post-auth pipeline ではされない) ため、論理削除直後でも cache 経由で同じ token が auth を通過し、最大 30 秒間 \`notes/create\` / \`users/follow\` / \`drive/files/upload\` 等を実行できる attack window が生まれていた。

## 主な変更点

### 実装
- **\`api/i/handler_extra.go\`**: \`DeleteAccount\` handler の \`UpdateUserFields\` 成功後に \`GetToken(c)\` で本 request の auth token を取得し、\`authInvalidator.InvalidateToken\` を呼ぶ。infrastructure は #884 / #960 と共通の \`TokenInvalidator\` interface を再利用、新規 wiring 不要 (\`router.go:1172\` の \`SetAuthInvalidator\` 配線が自動的に効く)

### テスト
- **\`api/i/handler_extra_test.go\`** に 3 件追加:
  - \`TestDeleteAccount_InvalidatesTokenCacheOnSuccess\` 正常系
  - \`TestDeleteAccount_NoInvalidatorIsNoop\` invalidator 未配線時の defensive
  - \`TestDeleteAccount_NoTokenInContextIsNoop\` token 未配線時の defensive

## Limitation (P2 への bridge)

middleware 自体に \`isSuspended\` / \`isDeleted\` gate を入れる根本対策は本 PR の scope 外 (#962 P2)。本 fix は \`tokenCache\` stale 経由の bypass を塞ぐが、\`TokenInvalidator\` の本質は **ASAP best-effort** であって network race / multi-node 環境では遅延し得る。完全な防衛のためには post-auth handler 側に \`isSuspended\` / \`isDeleted\` 拒否 gate も別途必要。

## テスト

\`\`\`bash
go test ./internal/api/i/ ./internal/server/middleware/ -count=1
# ok internal/api/i
# ok internal/server/middleware

make fmt && make lint
# clean
\`\`\`

DeleteAccount 関連 test 計 8 件 (既存 4 + 新規 3 + 既存 UpdateError 1) 全て pass、新規 3 件で本 fix の挙動を pin。

## 影響範囲

- 削除完了とほぼ同時に token cache から旧 user が削除される
- multi-device session: 本 request の token のみ削除なので他端末は最大 TTL (30s) で従来同等
- federation / streaming: 直接の subscribe 経路は使わないため影響なし

## 関連

- Refs #962 (本 PR は P0 のみ対応、P1 = i/2fa/* / P2 = middleware level gate は別途)
- 同 pattern の前例:
  - #960 (i/update の tokenCache invalidate)
  - #884 (regenerate-token / change-password 用 \`TokenInvalidator\` interface 導入)

🤖 Generated with [Claude Code](https://claude.com/claude-code)