### PR TITLE
Fix #962: middleware で isSuspended/isDeleted gate + helper 抽出で残課題完結

### DIFF
--- a/internal/api/i/handler.go
+++ b/internal/api/i/handler.go
@@ -144,6 +144,28 @@ func (h *Handler) SetAuthInvalidator(inv TokenInvalidator) {
 	h.authInvalidator = inv
 }
 
+// invalidateRequestTokenCache removes the current request's token entry
+// from the auth middleware tokenCache so that subsequent requests with the
+// same token are forced to re-resolve user state from DB. Self-mutation
+// handlers call this after committing changes that would otherwise be
+// invisible to subsequent middleware.GetUser(c) reads within the cache
+// TTL window (#960 / #962 P0).
+//
+// noop when invalidator is not wired (= unit test or router-config drift)
+// or when no token is in the request context (= request was authenticated
+// via a non-token mechanism, or middleware wiring drift). Defensive nil-
+// guard so handler success paths do not regress on minor wiring changes.
+func (h *Handler) invalidateRequestTokenCache(c echo.Context) {
+	if h.authInvalidator == nil {
+		return
+	}
+	tok := middleware.GetToken(c)
+	if tok == "" {
+		return
+	}
+	h.authInvalidator.InvalidateToken(tok)
+}
+
 // SetMainStreamPublisher attaches a publisher used to emit events on
 // /api/i/* endpoints (currently `myTokenRegenerated`). Optional — nil
 // disables emit.
@@ -944,21 +966,11 @@ func (h *Handler) Update(c echo.Context) error {
 		h.hardMutePublisher.PublishHardMuteReload(me.ID)
 	}
 
-	// auth middleware の tokenCache (30 秒 TTL) は token → user object を
-	// キャッシュしているため、name / description などの mutable field を
-	// 更新しても、同じ token で次の request が来たとき stale な user が
-	// attach され続ける。本来 cache の効く期間 (TTL 内) は profile が
-	// 「自分から見て」即時反映されるべきなので、現在の token entry を
-	// invalidate して次回 lookup で DB から fresh fetch させる (#960)。
-	// invalidate 対象は本 request の認証 token のみ (= 他デバイスの session
-	// は影響なし)。infrastructure としては #884 で導入された
-	// TokenInvalidator interface (regenerate-token / change-password 用)
-	// を再利用しており、本 handler 専用の wiring は追加していない。
-	if h.authInvalidator != nil {
-		if tok := middleware.GetToken(c); tok != "" {
-			h.authInvalidator.InvalidateToken(tok)
-		}
-	}
+	// auth middleware の tokenCache (30 秒 TTL) は name / description などの
+	// mutable field を持つ user object を保持するため、更新後も同じ token で
+	// stale な値が返り続けてしまう。helper 経由で本 request の token を即時
+	// invalidate して、次回 lookup で DB から fresh fetch させる (#960)。
+	h.invalidateRequestTokenCache(c)
 
 	return c.JSON(http.StatusOK, entity.PackUserDetailed(bundle.User, bundle.Profile, h.idGen))
 }

--- a/internal/api/i/handler_extra.go
+++ b/internal/api/i/handler_extra.go
@@ -75,28 +75,14 @@ func (h *Handler) DeleteAccount(c echo.Context) error {
 	}); err != nil {
 		return c.JSON(http.StatusInternalServerError, apierr.Error("INTERNAL_ERROR", "Internal error.", "5d37dbcb-891e-41ca-a3d6-e690c97775ac"))
 	}
-	// auth middleware の tokenCache (30s TTL) は token → user object を保持
-	// しているため、論理削除直後でも cache 内の旧 user (isSuspended=false /
-	// isDeleted=false) で同じ token が auth を通過してしまう。middleware は
-	// 現状 isSuspended / isDeleted gate を持たない (signin handler 内のみ)
-	// ので、cache 経由の bypass を防ぐには handler 側で本 request の token
-	// entry を即時 invalidate するのが現実解 (#962 P0)。次 request は cache
-	// miss → DB から fresh fetch、middleware 通過後の handler が isDeleted な
-	// user の操作を弾く前提 (= middleware level の gate は #962 P2 で別途)。
-	// infrastructure は #884 / #960 と共通の TokenInvalidator interface を
-	// 再利用、新規 wiring は不要。
-	//
-	// なお UpdateUserFields commit と本 invalidate の間の race window
-	// (μs オーダー) は本 fix では塞げない: 並行 request が同 token で
-	// middleware cache hit (stale) → handler 実行に到達した直後に本
-	// invalidate が走るケース。完全防衛は #962 P2 (middleware が DB fetch
-	// ごとに isSuspended / isDeleted を gate する) が必要。本 fix は
-	// 30s window → μs window への defense-in-depth 第一段。
-	if h.authInvalidator != nil {
-		if tok := middleware.GetToken(c); tok != "" {
-			h.authInvalidator.InvalidateToken(tok)
-		}
-	}
+	// 論理削除直後の auth bypass を防ぐ (#962 P0)。helper の詳細は handler.go
+	// の invalidateRequestTokenCache を参照。本 endpoint 固有の motivation:
+	// isSuspended / isDeleted は cached User 上の field なので、invalidate を
+	// 呼ばないと cache TTL (30s) 内は middleware の P2 gate
+	// (auth.go #962 P2) も cache hit 経路では fire しない (cached value が
+	// stale = isSuspended:false のまま)。本 invalidate で cache 経由の最後の
+	// 抜け道を塞ぐ。
+	h.invalidateRequestTokenCache(c)
 	return c.NoContent(http.StatusNoContent)
 }
 

--- a/internal/server/middleware/auth.go
+++ b/internal/server/middleware/auth.go
@@ -89,6 +89,23 @@ func (a *AuthMiddleware) Authenticate() echo.MiddlewareFunc {
 				return next(c)
 			}
 
+			// 論理削除 / 凍結された user を anonymous request 扱いに落とす
+			// (#962 P2)。upstream Misskey は signin handler で isSuspended
+			// だけ check しているが (signin/handler.go:112)、有効 token を
+			// 既に持っている session は post-auth pipeline では gate されず、
+			// tokenCache (30s TTL) 経由でも bypass できてしまう。本 gate を
+			// 入れることで cache miss → DB fetch 経路では確実に弾ける。
+			//
+			// 限界: cache hit (= 凍結前にキャッシュされた entry) は stale
+			// な isSuspended=false を返すので gate は fire しない。
+			// self-mutation 経由 (i/delete-account #962 P0) は handler 側
+			// で InvalidateToken を呼ぶので 30s → μs window。admin 経由
+			// (admin/suspend-user 等、他 user の token を強制 invalidate
+			// する経路) は本 PR scope 外、別 issue で追跡する想定。
+			if user.IsSuspended || user.IsDeleted {
+				return next(c)
+			}
+
 			c.Set(string(UserContextKey), user)
 			// handler 側でこの request の auth token を引きたいケースがある
 			// (例: i/update が成功後に tokenCache を invalidate する目的、

--- a/internal/server/middleware/auth_test.go
+++ b/internal/server/middleware/auth_test.go
@@ -98,6 +98,86 @@ func TestGetToken_NotAuthenticated(t *testing.T) {
 	assert.Equal(t, "", GetToken(c))
 }
 
+// #962 P2: 論理削除 / 凍結された user は middleware 段階で anonymous
+// request 扱いに落とす。cache miss → DB fetch path で gate が fire する
+// ことを担保する。
+func TestAuthenticate_SuspendedUserTreatedAsAnonymous(t *testing.T) {
+	userRepo := testutil.NewMockUserRepository()
+	tokenRepo := testutil.NewMockAccessTokenRepository()
+
+	suspended := &model.User{ID: "u1", Username: "suspended", IsSuspended: true}
+	token := "suspended-user-token"
+	userRepo.Tokens[token] = suspended
+
+	auth := NewAuthMiddleware(userRepo, tokenRepo)
+
+	e := echo.New()
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	req.Header.Set("Authorization", "Bearer "+token)
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+
+	handler := auth.Authenticate()(func(c echo.Context) error {
+		assert.Nil(t, GetUser(c), "凍結 user は context に attach されない")
+		assert.Equal(t, "", GetToken(c), "凍結 user は token も context に attach されない")
+		return c.String(http.StatusOK, "ok")
+	})
+	require.NoError(t, handler(c))
+}
+
+func TestAuthenticate_DeletedUserTreatedAsAnonymous(t *testing.T) {
+	userRepo := testutil.NewMockUserRepository()
+	tokenRepo := testutil.NewMockAccessTokenRepository()
+
+	deleted := &model.User{ID: "u2", Username: "deleted", IsDeleted: true}
+	token := "deleted-user-token"
+	userRepo.Tokens[token] = deleted
+
+	auth := NewAuthMiddleware(userRepo, tokenRepo)
+
+	e := echo.New()
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	req.Header.Set("Authorization", "Bearer "+token)
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+
+	handler := auth.Authenticate()(func(c echo.Context) error {
+		assert.Nil(t, GetUser(c), "削除済 user は context に attach されない")
+		return c.String(http.StatusOK, "ok")
+	})
+	require.NoError(t, handler(c))
+}
+
+// 凍結 → RequireAuth gate と組み合わせると 401 になることを担保。
+// signin handler 以外の認証要 endpoint は middleware 通過時点で
+// CREDENTIAL_REQUIRED で弾かれる (= 30s attack window が closed)。
+func TestRequireAuth_SuspendedRejected(t *testing.T) {
+	userRepo := testutil.NewMockUserRepository()
+	tokenRepo := testutil.NewMockAccessTokenRepository()
+
+	suspended := &model.User{ID: "u3", Username: "frozen", IsSuspended: true}
+	token := "another-suspended-token"
+	userRepo.Tokens[token] = suspended
+
+	auth := NewAuthMiddleware(userRepo, tokenRepo)
+
+	e := echo.New()
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	req.Header.Set("Authorization", "Bearer "+token)
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+
+	// Authenticate → RequireAuth の chain は production の認証要 endpoint
+	// と同じ pipeline。
+	chained := auth.Authenticate()(RequireAuth()(func(c echo.Context) error {
+		t.Fatal("RequireAuth は通過するべきでない")
+		return nil
+	}))
+	require.NoError(t, chained(c))
+	assert.Equal(t, http.StatusUnauthorized, rec.Code,
+		"凍結 user は RequireAuth で 401 が返る")
+}
+
 func TestAuthenticate_QueryParam(t *testing.T) {
 	userRepo := testutil.NewMockUserRepository()
 	tokenRepo := testutil.NewMockAccessTokenRepository()


### PR DESCRIPTION
## Summary

#962 を完結させる。

- **P2 (本 PR の主目的)**: middleware Authenticate 後段で \`isSuspended\` / \`isDeleted\` を gate。論理削除 / 凍結された user は anonymous request 扱いに落とし、同じ token での post-auth pipeline 通過を遮断
- **P0 (#963 で完了済)**: i/delete-account の tokenCache invalidate
- **P1 (i/2fa/\*)**: 実装側分析の結果 **不要** と判明。2FA fields は \`UserProfile\` 上で middleware tokenCache 対象外
- **追加: helper 抽出**: i/update + i/delete-account の invalidate boilerplate を \`invalidateRequestTokenCache\` に集約 (PR #963 review nit)

## 主な変更点

### \`internal/server/middleware/auth.go\` — P2 gate

Authenticate middleware で \`resolveUser\` 後に \`user.IsSuspended || user.IsDeleted\` チェックを追加。true なら \`UserContextKey\` を context に詰めず anonymous 扱いに落とす。

\`\`\`go
if user.IsSuspended || user.IsDeleted {
    return next(c)
}
\`\`\`

#### 限界 (comment にも明記)

- **cache hit 経路では fire しない**: 凍結前にキャッシュされた entry は stale な \`isSuspended=false\` を保持。cache hit は cached value を返すため gate 不発
- **self-mutation 経由は P0/#963 で 30s → μs window**: handler 側で InvalidateToken を呼ぶことで cache から削除 → 次 request は cache miss → DB fetch で gate fire
- **admin/suspend-user 経由は別 issue**: 他 user の token を強制 invalidate する経路 (= 凍結対象 user の全 token を 1 query で invalidate) は本 PR scope 外

### \`internal/api/i/handler.go\` — helper 抽出

\`\`\`go
func (h *Handler) invalidateRequestTokenCache(c echo.Context) {
    if h.authInvalidator == nil {
        return
    }
    tok := middleware.GetToken(c)
    if tok == "" {
        return
    }
    h.authInvalidator.InvalidateToken(tok)
}
\`\`\`

\`Update\` (#960) と \`DeleteAccount\` (#963) の重複 boilerplate を集約。今後同 pattern を他 self-mutation handler に展開するとき 1 行で済むように整備。

### P1 (i/2fa/\*) は invalidate 不要 — 実装で確認済

\`handler_2fa.go\` の 8 箇所の update 呼び出しは全て \`UpdateProfileFields\` (= \`model.UserProfile\` 側更新)。auth middleware の \`tokenCache\` は \`*model.User\` のみキャッシュし、\`*model.UserProfile\` は handler 内で別 fetch する設計のため、2FA 系 update は cache stale を引き起こさない。

| handler | 更新対象 | cache stale? | 対応 |
|---|---|---|---|
| i/update | User (name, isBot, ...) | yes | invalidate (#960) |
| i/delete-account | User (isSuspended, isDeleted) | yes | invalidate (#963) |
| i/2fa/* | UserProfile | **no** | 不要 |
| i/regenerate-token | User (rotate される旧 token) | yes | rotate 完了時に旧 token を invalidate (#884 既存、本 PR の `現在 request の token を invalidate` とは別経路) |
| i/change-password | UserProfile | no | 不要 |

## テスト

\`\`\`bash
go test ./internal/api/i/ ./internal/server/middleware/ -count=1
# all PASS
make fmt && make lint
# clean
\`\`\`

### 新規追加 (3 件 / middleware)
- \`TestAuthenticate_SuspendedUserTreatedAsAnonymous\`: 凍結 user の anonymous 落とし
- \`TestAuthenticate_DeletedUserTreatedAsAnonymous\`: 削除 user の同上
- \`TestRequireAuth_SuspendedRejected\`: Authenticate + RequireAuth chain で 401

### Helper の branch coverage

既存 6 件 (Update + DeleteAccount × 3 シナリオ) で全 branch (invalidator nil / token "" / 正常) を exercise 済 → 重複 helper test なし。

## 影響範囲

- **凍結 / 削除済 user**: middleware level で anonymous 扱い → 認証要 endpoint は \`CREDENTIAL_REQUIRED\` (401) で即時拒否
- **self-mutation 系**: cache invalidate で TTL 内 stale 完全回避 (30s → μs window)
- **admin 経由の他 user 凍結**: cache TTL (最大 30s) 後に DB fetch で gate fire → 即時無効化は別 issue
- **federation / streaming / 既存 admin endpoint**: 変更なし

## 関連

- Closes #962
- 派生 PR: #960, #963 (本 PR と合わせて #962 全体カバー)
- 既存インフラ: #884 (\`TokenInvalidator\` interface)、#512 (\`tokenCache\` TTL)
- フォローアップ候補: admin 経由 (admin/suspend-user) の即時無効化 = 対象 user の全 token を 1 query で invalidate する仕組み (別 issue で追跡可)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
