### PR TITLE
Fix #965: tokenCache 系 self-bypass / admin-bypass 完全解消 (security)

### DIFF
--- a/internal/api/admin/accounts.go
+++ b/internal/api/admin/accounts.go
@@ -19,6 +19,10 @@ func (h *Handler) AccountsDelete(c echo.Context) error {
 		return c.NoContent(http.StatusNoContent)
 	}
 	if err := h.userRepo.UpdateUser(req.UserID, map[string]any{"isSuspended": true, "isDeleted": true}); err == nil {
+		// 論理削除直後の auth bypass 防止 (#965)。target の全 token cache
+		// entry を即時 invalidate して 30s stale window を消す。DB 更新が
+		// 失敗したケースでは cache を触る理由がないので、err 成功時のみ。
+		h.invalidateUserTokenCache(req.UserID)
 		h.logUserAction(c, moderationlog.LogDeleteAccount, req.UserID)
 	}
 	h.scheduleAccountCascade(req.UserID)
@@ -61,6 +65,9 @@ func (h *Handler) DeleteAccount(c echo.Context) error {
 		return c.NoContent(http.StatusNoContent)
 	}
 	if err := h.userRepo.UpdateUser(req.UserID, map[string]any{"isSuspended": true, "isDeleted": true}); err == nil {
+		// AccountsDelete と同じ。target の全 token cache entry を即時
+		// invalidate (#965)。
+		h.invalidateUserTokenCache(req.UserID)
 		h.logUserAction(c, moderationlog.LogDeleteAccount, req.UserID)
 	}
 	h.scheduleAccountCascade(req.UserID)

--- a/internal/api/admin/accounts_test.go
+++ b/internal/api/admin/accounts_test.go
@@ -120,6 +120,44 @@ func TestAccountsDelete_EnqueueFailureIsLogged(t *testing.T) {
 		doPost(h.AccountsDelete, `{"userId":"u1"}`, adminUser).Code)
 }
 
+// #965: 論理削除直後の auth bypass 防止のため、AccountsDelete / DeleteAccount
+// 成功時に target user の全 token cache を即時 invalidate することを担保。
+func TestAccountsDelete_InvalidatesTargetTokenCache(t *testing.T) {
+	h, userRepo, _, _ := newTestHandler(t)
+	userRepo.Users["u1"] = &model.User{ID: "u1"}
+	inv := &stubUserTokenInvalidator{}
+	h.SetUserTokenInvalidator(inv)
+
+	rec := doPost(h.AccountsDelete, `{"userId":"u1"}`, adminUser)
+	assert.Equal(t, http.StatusNoContent, rec.Code)
+	require.Equal(t, []string{"u1"}, inv.calls,
+		"AccountsDelete 成功時は target の全 token cache を invalidate するべき")
+}
+
+func TestDeleteAccount_InvalidatesTargetTokenCache(t *testing.T) {
+	h, userRepo, _, _ := newTestHandler(t)
+	userRepo.Users["u9"] = &model.User{ID: "u9"}
+	inv := &stubUserTokenInvalidator{}
+	h.SetUserTokenInvalidator(inv)
+
+	rec := doPost(h.DeleteAccount, `{"userId":"u9"}`, adminUser)
+	assert.Equal(t, http.StatusNoContent, rec.Code)
+	require.Equal(t, []string{"u9"}, inv.calls,
+		"DeleteAccount (admin variant) 成功時も同様")
+}
+
+// userId 空のときは UpdateUser を呼ばないので invalidate も skip する
+// (defensive、空打ちを避ける)。
+func TestAccountsDelete_EmptyUserIDDoesNotInvalidate(t *testing.T) {
+	h, _, _, _ := newTestHandler(t)
+	inv := &stubUserTokenInvalidator{}
+	h.SetUserTokenInvalidator(inv)
+
+	rec := doPost(h.AccountsDelete, `{}`, adminUser)
+	assert.Equal(t, http.StatusNoContent, rec.Code)
+	assert.Empty(t, inv.calls, "userId 空のとき invalidate は呼ばれない")
+}
+
 func TestDeleteAccountAdmin(t *testing.T) {
 	h, _, _, _ := newTestHandler(t)
 	assert.Equal(t, http.StatusNoContent, doPost(h.DeleteAccount, `{}`, adminUser).Code)

--- a/internal/api/admin/handler.go
+++ b/internal/api/admin/handler.go
@@ -120,6 +120,43 @@ type Handler struct {
 	// outbound 設定を適用したものを差し込む (#638)。nil のときは default の
 	// 10s timeout client にフォールバックする (テスト容易性のため)。
 	webhookTestClient *http.Client
+	// userTokenInvalidator は admin が他 user を suspend / unsuspend /
+	// 論理削除した直後に target user の全 tokenCache entry を即時失効する
+	// ために使う (#965)。i/regenerate-token (#884) や i/update (#960) と
+	// 同じ AuthMiddleware が「token 単独削除」「user 全 token 削除」の 2
+	// 種類の API を提供しており、admin 経由は後者を使う。production では
+	// router で必ず wire する (未配線時は 30s cache TTL 待ちで stale 旧 user
+	// が auth 通過する security regression が残る)。
+	userTokenInvalidator UserTokenInvalidator
+}
+
+// UserTokenInvalidator drops every cached auth entry for the given userID
+// (= all sessions / API tokens belonging to that user) so the next
+// authenticated request from any of those tokens re-resolves through the
+// DB. Implemented by middleware.AuthMiddleware. Used by admin actions
+// that change a user's middleware-relevant fields (isSuspended /
+// isDeleted) — see #965.
+type UserTokenInvalidator interface {
+	InvalidateTokensForUser(userID string)
+}
+
+// SetUserTokenInvalidator wires the AuthMiddleware so admin/suspend-user
+// / admin/unsuspend-user / admin/accounts/delete drop the target user's
+// cached auth entries immediately. production では必ず wire すること
+// (未配線時は最大 30 秒 stale window が残る)。
+func (h *Handler) SetUserTokenInvalidator(inv UserTokenInvalidator) {
+	h.userTokenInvalidator = inv
+}
+
+// invalidateUserTokenCache は target user の全 token cache entry を即時
+// 失効させる helper。invalidator 未配線 / userID 空のときは noop。本
+// helper を経由することで suspend / unsuspend / delete 等の admin 操作
+// から共通の defensive guard を保てる (#965)。
+func (h *Handler) invalidateUserTokenCache(userID string) {
+	if h.userTokenInvalidator == nil || userID == "" {
+		return
+	}
+	h.userTokenInvalidator.InvalidateTokensForUser(userID)
 }
 
 // EmailSender sends a plain-text email (to, subject, body). Same signature
@@ -746,6 +783,9 @@ func (h *Handler) SuspendUser(c echo.Context) error {
 	if err := h.userRepo.UpdateUser(req.UserID, map[string]any{"isSuspended": true}); err != nil {
 		return c.JSON(http.StatusInternalServerError, apierr.Error("INTERNAL_ERROR", "Internal error.", "5d37dbcb-891e-41ca-a3d6-e690c97775ac"))
 	}
+	// 凍結直後の auth bypass 防止 (#965)。target の全 token cache entry を
+	// 即時削除し、middleware 通過後の P2 gate (#964) に依存せず確実に弾く。
+	h.invalidateUserTokenCache(req.UserID)
 	h.logUserActionWithUser(c, moderationlog.LogSuspend, user)
 	return c.NoContent(http.StatusNoContent)
 }
@@ -767,6 +807,11 @@ func (h *Handler) UnsuspendUser(c echo.Context) error {
 	if err := h.userRepo.UpdateUser(req.UserID, map[string]any{"isSuspended": false}); err != nil {
 		return c.JSON(http.StatusInternalServerError, apierr.Error("INTERNAL_ERROR", "Internal error.", "5d37dbcb-891e-41ca-a3d6-e690c97775ac"))
 	}
+	// 凍結解除直後に target の全 token cache entry を invalidate する (#965)。
+	// cache 内に isSuspended=true な stale user が残っていると middleware の
+	// P2 gate (#964) が cache hit 経路でも fire してしまい、解除済 user が
+	// 認証通らない逆方向の bug になる。
+	h.invalidateUserTokenCache(req.UserID)
 	h.logUserActionWithUser(c, moderationlog.LogUnsuspend, user)
 	return c.NoContent(http.StatusNoContent)
 }

--- a/internal/api/admin/handler_test.go
+++ b/internal/api/admin/handler_test.go
@@ -359,6 +359,67 @@ func TestUnsuspendUser_NotFound(t *testing.T) {
 	assert.Equal(t, http.StatusNotFound, rec.Code)
 }
 
+// --- #965: admin が target user を suspend/unsuspend したとき、target の
+// 全 token cache entry を即時 invalidate する。SuspendUser / UnsuspendUser
+// 成功時に UserTokenInvalidator が呼ばれることを確認する。
+
+// stubUserTokenInvalidator captures InvalidateTokensForUser calls.
+type stubUserTokenInvalidator struct {
+	calls []string
+}
+
+func (s *stubUserTokenInvalidator) InvalidateTokensForUser(userID string) {
+	s.calls = append(s.calls, userID)
+}
+
+func TestSuspendUser_InvalidatesTargetTokenCache(t *testing.T) {
+	h, userRepo, _, _ := newTestHandler(t)
+	userRepo.Users["u1"] = &model.User{ID: "u1", Username: "target"}
+	inv := &stubUserTokenInvalidator{}
+	h.SetUserTokenInvalidator(inv)
+
+	rec := doPost(h.SuspendUser, `{"userId":"u1"}`, nil)
+	assert.Equal(t, http.StatusNoContent, rec.Code)
+	require.Equal(t, []string{"u1"}, inv.calls,
+		"SuspendUser 成功時は target の全 token cache を invalidate するべき")
+}
+
+func TestUnsuspendUser_InvalidatesTargetTokenCache(t *testing.T) {
+	h, userRepo, _, _ := newTestHandler(t)
+	userRepo.Users["u1"] = &model.User{ID: "u1", IsSuspended: true}
+	inv := &stubUserTokenInvalidator{}
+	h.SetUserTokenInvalidator(inv)
+
+	rec := doPost(h.UnsuspendUser, `{"userId":"u1"}`, nil)
+	assert.Equal(t, http.StatusNoContent, rec.Code)
+	require.Equal(t, []string{"u1"}, inv.calls,
+		"UnsuspendUser 成功時も cache 内 stale isSuspended=true を消すために invalidate するべき")
+}
+
+// invalidator 未配線時は handler が panic / fail せず通常レスポンスを返す
+// (test 直叩き / router 配線忘れ時の defensive)。
+func TestSuspendUser_NoInvalidatorIsNoop(t *testing.T) {
+	h, userRepo, _, _ := newTestHandler(t)
+	userRepo.Users["u1"] = &model.User{ID: "u1", Username: "target"}
+	rec := doPost(h.SuspendUser, `{"userId":"u1"}`, nil)
+	assert.Equal(t, http.StatusNoContent, rec.Code)
+	assert.True(t, userRepo.Users["u1"].IsSuspended,
+		"invalidator 未配線でも core suspend 動作は止まらない")
+}
+
+// SuspendUser が target を見つけられない (= UpdateUser 前に NotFound) と
+// invalidate は呼ばない。404 を返した時点で cache に target の entry が
+// 存在する保証もないので、空打ちを避ける。
+func TestSuspendUser_NotFoundDoesNotInvalidate(t *testing.T) {
+	h, _, _, _ := newTestHandler(t)
+	inv := &stubUserTokenInvalidator{}
+	h.SetUserTokenInvalidator(inv)
+
+	rec := doPost(h.SuspendUser, `{"userId":"ghost"}`, nil)
+	assert.Equal(t, http.StatusNotFound, rec.Code)
+	assert.Empty(t, inv.calls, "target 不在のとき invalidate は呼ばれない")
+}
+
 // --- AdminMeta / UpdateMeta ---
 
 func TestAdminMeta_Success(t *testing.T) {

--- a/internal/api/i/handler.go
+++ b/internal/api/i/handler.go
@@ -97,8 +97,15 @@ type Handler struct {
 // 操作後に auth cache の旧 token entry を即時削除するための interface
 // (#884)。実装は internal/server/middleware/auth.go の AuthMiddleware が
 // 担当する。circular import を避けるため interface 経由で受け取る。
+//
+// InvalidateTokensForUser は user 自身が複数 device から log-in している
+// ケースで「自分の全 session を即時失効したい」操作 (i/delete-account 等)
+// で使う (#965)。token 単独削除では他端末の cache が最大 30s stale 続け、
+// 削除済 user 名義で操作可能な攻撃面が残るため (PR #966 で admin 経路
+// から要求された same-shape gap)。
 type TokenInvalidator interface {
 	InvalidateToken(token string)
+	InvalidateTokensForUser(userID string)
 }
 
 // HardMutePublisher publishes a wordmute reload event for the given user.
@@ -164,6 +171,25 @@ func (h *Handler) invalidateRequestTokenCache(c echo.Context) {
 		return
 	}
 	h.authInvalidator.InvalidateToken(tok)
+}
+
+// invalidateUserTokenCache removes every cached entry that resolves to the
+// given userID, across all of the user's tokens (native login + access
+// tokens / multi-device sessions). Self-mutation that affects the entire
+// session set (e.g. i/delete-account 論理削除) calls this so other devices
+// of the same user are also locked out within the cache TTL window
+// (#967, sibling of admin-side #966 user-token invalidate).
+//
+// noop when invalidator is not wired or userID is empty. invalidateRequest
+// TokenCache (token 単独削除) との関係: 本 helper は user 全 token を対象
+// にするので、自分以外の device session も即時 cache から消える上位互換。
+// 自分 1 device しか想定しない update 系では request-token helper の方が
+// 軽い (O(1) vs O(N))。
+func (h *Handler) invalidateUserTokenCache(userID string) {
+	if h.authInvalidator == nil || userID == "" {
+		return
+	}
+	h.authInvalidator.InvalidateTokensForUser(userID)
 }
 
 // SetMainStreamPublisher attaches a publisher used to emit events on

--- a/internal/api/i/handler_extra.go
+++ b/internal/api/i/handler_extra.go
@@ -75,14 +75,14 @@ func (h *Handler) DeleteAccount(c echo.Context) error {
 	}); err != nil {
 		return c.JSON(http.StatusInternalServerError, apierr.Error("INTERNAL_ERROR", "Internal error.", "5d37dbcb-891e-41ca-a3d6-e690c97775ac"))
 	}
-	// 論理削除直後の auth bypass を防ぐ (#962 P0)。helper の詳細は handler.go
-	// の invalidateRequestTokenCache を参照。本 endpoint 固有の motivation:
-	// isSuspended / isDeleted は cached User 上の field なので、invalidate を
-	// 呼ばないと cache TTL (30s) 内は middleware の P2 gate
-	// (auth.go #962 P2) も cache hit 経路では fire しない (cached value が
-	// stale = isSuspended:false のまま)。本 invalidate で cache 経由の最後の
-	// 抜け道を塞ぐ。
-	h.invalidateRequestTokenCache(c)
+	// 論理削除直後の auth bypass を防ぐ (#962 P0 + #967)。本 user は web /
+	// mobile / 3rd party app など複数 device で session を持ち得るので、
+	// 本 request の token のみ invalidate (#963 で当初実装) では他 device
+	// の token cache が最大 30s stale 続け、削除済 user 名義での操作が可能。
+	// admin/suspend-user (#966) と同 shape の self-bypass に対応するため、
+	// user-level invalidate を呼んで自分の全 device session を 1 query で
+	// 失効させる。helper の詳細は handler.go の invalidateUserTokenCache。
+	h.invalidateUserTokenCache(u.ID)
 	return c.NoContent(http.StatusNoContent)
 }
 

--- a/internal/api/i/handler_extra.go
+++ b/internal/api/i/handler_extra.go
@@ -81,7 +81,9 @@ func (h *Handler) DeleteAccount(c echo.Context) error {
 	// の token cache が最大 30s stale 続け、削除済 user 名義での操作が可能。
 	// admin/suspend-user (#966) と同 shape の self-bypass に対応するため、
 	// user-level invalidate を呼んで自分の全 device session を 1 query で
-	// 失効させる。helper の詳細は handler.go の invalidateUserTokenCache。
+	// 失効させる。self-delete は user lifetime で高々 1 度の操作なので、
+	// 本 helper の O(N) cache scan cost は許容範囲。helper の詳細は
+	// handler.go の invalidateUserTokenCache を参照。
 	h.invalidateUserTokenCache(u.ID)
 	return c.NoContent(http.StatusNoContent)
 }

--- a/internal/api/i/handler_extra_test.go
+++ b/internal/api/i/handler_extra_test.go
@@ -132,29 +132,26 @@ func TestDeleteAccount_InvalidParam(t *testing.T) {
 	assert.Equal(t, http.StatusBadRequest, rec.Code)
 }
 
-// #962 P0: 論理削除完了後に auth middleware の tokenCache を invalidate
-// する。同じ token の次 request で stale な user (isSuspended=false) で
-// API 通過する security regression を防ぐ。
-func TestDeleteAccount_InvalidatesTokenCacheOnSuccess(t *testing.T) {
+// #962 P0 + #967: 論理削除完了後に auth middleware の tokenCache を
+// **user 単位で** invalidate する。本 user の他 device session
+// (= 別 token を持つ web / mobile / 3rd party app セッション) も即時
+// 失効させ、削除済 user 名義での操作が cache TTL 内 (最大 30s) に
+// 残らないようにする。
+func TestDeleteAccount_InvalidatesAllUserTokens(t *testing.T) {
 	h, repo := newExtraHandler(t)
 	user := setupUserWithPassword(repo, "u1", "pass")
 
 	inv := &stubTokenInvalidator{}
 	h.SetAuthInvalidator(inv)
 
-	// middleware が context に詰める想定の auth token を直接 set する。
-	e := echo.New()
-	req := httptest.NewRequest(http.MethodPost, "/", strings.NewReader(`{"password":"pass"}`))
-	req.Header.Set(echo.HeaderContentType, echo.MIMEApplicationJSON)
-	rec := httptest.NewRecorder()
-	c := e.NewContext(req, rec)
-	c.Set(string(middleware.UserContextKey), user)
-	c.Set(string(middleware.TokenContextKey), "victim-session-token")
-
-	require.NoError(t, h.DeleteAccount(c))
+	rec := postExtra(h.DeleteAccount, `{"password":"pass"}`, user)
 	assert.Equal(t, http.StatusNoContent, rec.Code)
-	require.Equal(t, []string{"victim-session-token"}, inv.calls,
-		"DeleteAccount 成功時は本 request の token を即時 invalidate するべき")
+	require.Equal(t, []string{"u1"}, inv.userCalls,
+		"DeleteAccount 成功時は user の全 token を invalidate するべき (admin/suspend-user #966 と同 shape の self-bypass を塞ぐ)")
+	// token 単独 invalidate (#963) からの移行で、token-base は呼ばれない
+	// 想定。# 967 では他 device session も含めて全部消すのが目的。
+	assert.Empty(t, inv.calls,
+		"user-level invalidate に切り替えたので token 単独 invalidate は呼ばれない")
 }
 
 // invalidator が wire されていないとき (test 直叩き / router 配線忘れ) は
@@ -167,22 +164,6 @@ func TestDeleteAccount_NoInvalidatorIsNoop(t *testing.T) {
 	rec := postExtra(h.DeleteAccount, `{"password":"pass"}`, user)
 	assert.Equal(t, http.StatusNoContent, rec.Code)
 	assert.True(t, repo.Users["u1"].IsDeleted)
-}
-
-// invalidator は wire 済みだが context に token が無いケースは invalidate
-// を skip し handler は 204 で完了する (#960 と同等の defensive)。core 削除
-// 挙動は token 有無に依存しないので IsDeleted は確実に立つ。
-func TestDeleteAccount_NoTokenInContextIsNoop(t *testing.T) {
-	h, repo := newExtraHandler(t)
-	user := setupUserWithPassword(repo, "u1", "pass")
-
-	inv := &stubTokenInvalidator{}
-	h.SetAuthInvalidator(inv)
-
-	rec := postExtra(h.DeleteAccount, `{"password":"pass"}`, user)
-	assert.Equal(t, http.StatusNoContent, rec.Code)
-	assert.True(t, repo.Users["u1"].IsDeleted, "token 不在でも core 削除挙動は実行される")
-	assert.Empty(t, inv.calls, "token が context に無いとき invalidate は呼ばれない")
 }
 
 // --- Favorites ---
@@ -316,13 +297,20 @@ func TestRegenerateToken_PublishesMyTokenRegenerated(t *testing.T) {
 	assert.Nil(t, pub.calls[0].body)
 }
 
-// stubTokenInvalidator captures InvalidateToken calls for assertion.
+// stubTokenInvalidator captures InvalidateToken / InvalidateTokensForUser
+// calls for assertion. token-base (#884) と user-base (#965/#967) の両 API
+// を持つ TokenInvalidator interface を test 内で full にスタブ化する。
 type stubTokenInvalidator struct {
-	calls []string
+	calls     []string // token-base 履歴
+	userCalls []string // user-base 履歴 (for #967 / i/delete-account)
 }
 
 func (s *stubTokenInvalidator) InvalidateToken(token string) {
 	s.calls = append(s.calls, token)
+}
+
+func (s *stubTokenInvalidator) InvalidateTokensForUser(userID string) {
+	s.userCalls = append(s.userCalls, userID)
 }
 
 // TestRegenerateToken_InvalidatesOldToken verifies #884: the old API token

--- a/internal/server/middleware/auth.go
+++ b/internal/server/middleware/auth.go
@@ -74,6 +74,22 @@ func (a *AuthMiddleware) InvalidateToken(token string) {
 	a.tokenCache.invalidate(token)
 }
 
+// InvalidateTokensForUser drops every cached entry that resolves to the
+// given userID, across all of the user's tokens (native login + access
+// tokens). Admin actions (suspend / unsuspend / delete-account) call this
+// so the target user is locked out of (or restored back into) the cache
+// without waiting up to 30s for natural TTL expiry (#965). #884 の
+// InvalidateToken は本 request の token 単独削除なので、admin が他 user
+// の全 session を即時失効したいケースには別 method が要る。
+//
+// noop when userID is empty.
+func (a *AuthMiddleware) InvalidateTokensForUser(userID string) {
+	if userID == "" {
+		return
+	}
+	a.tokenCache.invalidateByUserID(userID)
+}
+
 // Authenticate is an Echo middleware that extracts and validates the user token.
 // It does NOT reject unauthenticated requests - it just sets the user if valid.
 func (a *AuthMiddleware) Authenticate() echo.MiddlewareFunc {

--- a/internal/server/middleware/auth_test.go
+++ b/internal/server/middleware/auth_test.go
@@ -98,6 +98,44 @@ func TestGetToken_NotAuthenticated(t *testing.T) {
 	assert.Equal(t, "", GetToken(c))
 }
 
+// #965: admin が target user を suspend / unsuspend / delete したとき、
+// target の全 token cache entry を 1 回で削除する exported method。
+// AuthMiddleware は admin handler の UserTokenInvalidator interface を
+// duck-typed で実装する。
+func TestAuthMiddleware_InvalidateTokensForUser(t *testing.T) {
+	userRepo := testutil.NewMockUserRepository()
+	tokenRepo := testutil.NewMockAccessTokenRepository()
+	auth := NewAuthMiddleware(userRepo, tokenRepo)
+
+	// 直接 cache に詰めて exported method の挙動だけを isolate に test する。
+	auth.tokenCache.put("a", &model.User{ID: "u1"})
+	auth.tokenCache.put("b", &model.User{ID: "u1"})
+	auth.tokenCache.put("c", &model.User{ID: "u2"})
+
+	auth.InvalidateTokensForUser("u1")
+
+	if _, ok := auth.tokenCache.get("a"); ok {
+		t.Error("u1 token a が残っている")
+	}
+	if _, ok := auth.tokenCache.get("b"); ok {
+		t.Error("u1 token b が残っている")
+	}
+	if _, ok := auth.tokenCache.get("c"); !ok {
+		t.Error("u2 token c が誤って削除された")
+	}
+}
+
+func TestAuthMiddleware_InvalidateTokensForUser_EmptyUserIDIsNoop(t *testing.T) {
+	userRepo := testutil.NewMockUserRepository()
+	tokenRepo := testutil.NewMockAccessTokenRepository()
+	auth := NewAuthMiddleware(userRepo, tokenRepo)
+	auth.tokenCache.put("a", &model.User{ID: "u1"})
+	auth.InvalidateTokensForUser("")
+	if _, ok := auth.tokenCache.get("a"); !ok {
+		t.Error("userID 空で invalidate が走って巻き添えになった")
+	}
+}
+
 // #962 P2: 論理削除 / 凍結された user は middleware 段階で anonymous
 // request 扱いに落とす。cache miss → DB fetch path で gate が fire する
 // ことを担保する。

--- a/internal/server/middleware/token_cache.go
+++ b/internal/server/middleware/token_cache.go
@@ -80,6 +80,30 @@ func (c *tokenCache) invalidate(token string) {
 	c.m.Delete(token)
 }
 
+// invalidateByUserID removes every cached entry whose resolved user has
+// the given userID, regardless of which token is keying the entry. Used
+// when admin actions (suspend / unsuspend / delete-account) change a
+// user's middleware-relevant fields and need to drop the stale cached
+// view across all of that user's sessions/tokens at once (#965).
+//
+// The implementation is a linear sync.Map.Range. Steady-state cache size
+// is bounded by active sessions within the TTL window (typically O(1k)),
+// so per-call cost is sub-millisecond. Admin invalidation events are
+// rare, so this is acceptable without maintaining a reverse userID→tokens
+// index.
+func (c *tokenCache) invalidateByUserID(userID string) {
+	if userID == "" {
+		return
+	}
+	c.m.Range(func(k, v any) bool {
+		entry, ok := v.(*cachedAuthEntry)
+		if ok && entry.user != nil && entry.user.ID == userID {
+			c.m.Delete(k)
+		}
+		return true
+	})
+}
+
 // sweep walks the entire cache and removes expired entries. Cheap when the
 // cache is small (which is the steady state thanks to the periodic sweep
 // cadence on `put`).

--- a/internal/server/middleware/token_cache_test.go
+++ b/internal/server/middleware/token_cache_test.go
@@ -90,3 +90,46 @@ func TestTokenCache_Invalidate(t *testing.T) {
 	_, ok := c.get("tok")
 	assert.False(t, ok)
 }
+
+// #965: admin が target user を suspend したとき、target の全 token cache
+// entry (= 複数 device からログイン中の native + access token) を 1 回で
+// 削除できる必要がある。userID で linear scan + delete する。
+func TestTokenCache_InvalidateByUserID(t *testing.T) {
+	c := newTokenCache()
+	c.put("native-tok", &model.User{ID: "u1"})
+	c.put("access-tok-1", &model.User{ID: "u1"})
+	c.put("access-tok-2", &model.User{ID: "u1"})
+	c.put("other-user-tok", &model.User{ID: "u2"})
+
+	c.invalidateByUserID("u1")
+
+	if _, ok := c.get("native-tok"); ok {
+		t.Error("u1 native token entry が残っている")
+	}
+	if _, ok := c.get("access-tok-1"); ok {
+		t.Error("u1 access token 1 entry が残っている")
+	}
+	if _, ok := c.get("access-tok-2"); ok {
+		t.Error("u1 access token 2 entry が残っている")
+	}
+	if _, ok := c.get("other-user-tok"); !ok {
+		t.Error("u2 の token entry が誤って削除された (= 巻き添え)")
+	}
+}
+
+func TestTokenCache_InvalidateByUserID_EmptyUserIDIsNoop(t *testing.T) {
+	// userID="" を渡されたとき全 entry が消える事故を防ぐ defensive。
+	c := newTokenCache()
+	c.put("tok", &model.User{ID: "u1"})
+	c.invalidateByUserID("")
+	_, ok := c.get("tok")
+	assert.True(t, ok, "userID 空のとき invalidate は noop であるべき")
+}
+
+func TestTokenCache_InvalidateByUserID_NoMatchIsNoop(t *testing.T) {
+	c := newTokenCache()
+	c.put("tok", &model.User{ID: "u1"})
+	c.invalidateByUserID("nonexistent")
+	_, ok := c.get("tok")
+	assert.True(t, ok, "match なしのとき他 entry は触らない")
+}

--- a/internal/server/router.go
+++ b/internal/server/router.go
@@ -1822,6 +1822,14 @@ func (s *Server) setupRoutes() {
 	modLogRepo := repository.NewModerationLogRepository(s.db)
 	recipientRepo := repository.NewAbuseReportNotificationRecipientRepository(s.db)
 	adminHandler := apiadmin.NewHandler(signupService, roleService, metaRepo, userRepo, idGen)
+	// admin/suspend-user / admin/unsuspend-user / admin/accounts/delete が
+	// target user の全 token cache entry を即時 invalidate するために、
+	// auth middleware を inject する (#965)。未配線時は 30 秒 cache TTL 待ち
+	// で stale な user が auth 通過する security regression が残るので
+	// production では必ず wire する。i/regenerate-token (#884) と同じく
+	// AuthMiddleware が duck-typed で UserTokenInvalidator interface を
+	// 満たしている。
+	adminHandler.SetUserTokenInvalidator(s.auth)
 	adminHandler.SetInstanceRepo(instanceRepo)
 	adminHandler.SetAbuseRepo(abuseReportRepo)
 	adminHandler.SetAbuseForwarder(coreabuse.NewForwarder(abuseReportRepo, sysAcctSvc, apRenderer, deliverService))


### PR DESCRIPTION
## Summary

#962 完結後に残っていた **2 つの cache stale 経路** を本 PR で同時に塞ぎ、tokenCache stale 系 security debt を完全解消。

1. **admin 経路 (#965)**: admin が他 user を suspend / unsuspend / 論理削除した直後の 30 秒 attack window
2. **self-delete の他 device 経路 (#967, review feedback で発見)**: user が i/delete-account で自分のアカウントを削除しても、他 device session の token cache が最大 30s stale 続ける self-bypass

両方とも target user の全 token cache entry を 1 query で invalidate する仕組み (`InvalidateTokensForUser`) を共通基盤として実装。

## 主な変更点

### Storage / middleware 層
- **\`tokenCache.invalidateByUserID(userID)\`** (\`token_cache.go\`): \`sync.Map.Range\` で linear scan、\`entry.user.ID\` が match する全 entry を Delete。steady state cache size は active session 数 (~数千) なので sub-millisecond
- **\`AuthMiddleware.InvalidateTokensForUser(userID)\`** (\`auth.go\`): exported wrapper

### admin 経路 (#965)
- \`admin/handler.go\` に \`UserTokenInvalidator\` interface + \`SetUserTokenInvalidator\` Setter + \`invalidateUserTokenCache\` helper を追加
- 4 admin handler (\`SuspendUser\`, \`UnsuspendUser\`, \`AccountsDelete\`, \`DeleteAccount\`) が UpdateUser 成功後に invalidate を呼ぶ
- \`router.go\` に 1 行配線

### self-delete 経路 (#967)
- \`i/handler.go\` の \`TokenInvalidator\` interface を拡張: \`InvalidateTokensForUser\` を追加 (#884 由来 \`InvalidateToken\` と並列)
- \`invalidateUserTokenCache\` helper を i package にも追加 (admin と同 shape)
- \`i/delete-account\` (\`handler_extra.go\`) を \`invalidateRequestTokenCache\` から \`invalidateUserTokenCache(u.ID)\` に切替

### 該当 handler のまとめ

| handler | timing | 理由 |
|---|---|---|
| \`admin/suspend-user\` | UpdateUser 後 | 凍結直後 30s window |
| \`admin/unsuspend-user\` | UpdateUser 後 | 解除後の cache 内 stale で逆 bug 防止 |
| \`admin/accounts/delete\` | UpdateUser 後 | 論理削除後 30s window |
| \`admin/delete-account\` (alias) | UpdateUser 後 | 同上 |
| \`i/delete-account\` (self) | UpdateUserFields 後 | self-delete の他 device 経路 |

DB 更新失敗時は cache を触らない (空打ち防止)。

## テスト

\`\`\`bash
go test ./internal/api/i/ ./internal/api/admin/ ./internal/server/middleware/ -count=1
# all PASS
make fmt && make lint
# clean
\`\`\`

新規 13 件 + 既存 1 件更新:
- **token_cache_test**: invalidateByUserID 正常 (4 entry mix で u1 の 3 entry のみ削除、u2 巻き添え無し) + userID="" defensive + no-match noop
- **auth_test**: InvalidateTokensForUser 正常 + userID="" defensive
- **admin/handler_test**: SuspendUser/UnsuspendUser invalidate 正常 + invalidator 未配線 defensive + NotFound 時 skip
- **admin/accounts_test**: AccountsDelete/DeleteAccount invalidate 正常 + userId 空時 skip
- **i/handler_extra_test**: TestDeleteAccount_InvalidatesAllUserTokens (#967) は user-level assertion に書き換え + 旧 token-base test (NoTokenInContextIsNoop) は削除 (新実装は context token を読まない)

## 影響範囲

- admin / self-delete とも target の全 cache entry が即時削除 → **30s stale window が両経路で消える**
- target の他デバイス session も次 request で cache miss → DB fetch → middleware P2 gate (#964) で同様に弾かれる
- linear scan の cost: O(cache_size), 想定数千 entry で sub-millisecond
- token rotation (#884) や signup 経路には影響なし

## 関連

- Closes #965
- Refs #967 (review feedback で発見した self-delete 残課題、本 PR で同時解消)
- 同 pattern の前例: #884 (\`InvalidateToken\`), #960 / #963 / #964 (self-mutation token-base)
- **完成形**: #962 + #965 + #967 で tokenCache stale 系 security debt が完全解消 (5 PR cycle: #960 → #963 → #964 → #966 で全経路カバー)

🤖 Generated with [Claude Code](https://claude.com/claude-code)