### PR TITLE
feat(playwright): write-flow batch 4 - 24 spec 追加 (admin / settings / 既存 entity edit / chat)

### DIFF
--- a/tests/playwright/fixtures/files.ts
+++ b/tests/playwright/fixtures/files.ts
@@ -24,6 +24,44 @@ export interface DriveFile {
   size: number;
 }
 
+// uploadTinyPNG は test 用の 1x1 透過 PNG を /api/drive/files/create に
+// multipart で upload する helper。drive 系 spec が複数で同 pattern を
+// 抱えていたので集約 (#967 batch4 review)。call sites:
+//   - drive_file_rename / drive_file_toggle_sensitive / drive_file_delete
+//   - drive_file_describe_save / drive_file_detail_render
+// 失敗時はキャッチ側で test を fail させたいので、status と body を
+// そのまま返さず正常系で DriveFile を返し、異常系は throw する。
+import type { APIRequestContext } from '@playwright/test';
+
+export async function uploadTinyPNG(
+  request: APIRequestContext,
+  baseURL: string,
+  token: string,
+  name: string,
+): Promise<DriveFile> {
+  const resp = await request.post(`${baseURL}/api/drive/files/create`, {
+    ignoreHTTPSErrors: true,
+    multipart: {
+      i: token,
+      file: {
+        name,
+        mimeType: 'image/png',
+        buffer: tinyPNG,
+      },
+    },
+  });
+  if (resp.status() !== 200) {
+    throw new Error(
+      `drive/files/create failed: ${resp.status()} ${await resp.text()}`,
+    );
+  }
+  const body = (await resp.json()) as DriveFile;
+  if (!body.id) {
+    throw new Error(`drive/files/create returned no id: ${JSON.stringify(body)}`);
+  }
+  return body;
+}
+
 // CRC32 lookup table for ZIP fixture builder (#882). standard polynomial
 // 0xEDB88320 (= reflected 0x04C11DB7)。一度だけ計算して以降は table 参照。
 const CRC32_TABLE = (() => {

--- a/tests/playwright/fixtures/files.ts
+++ b/tests/playwright/fixtures/files.ts
@@ -5,6 +5,8 @@
 // node の Sharp/Canvas 依存が増えるので、固定の minimal PNG を base64 で
 // 持つ方が deterministic + 軽量。
 
+import type { APIRequestContext } from '@playwright/test';
+
 // 1x1 transparent PNG, 67 bytes。base64 decode 結果も deterministic で
 // md5 (= file content hash) も常に同じになる = find-by-hash spec で
 // 検証 anchor として使える。
@@ -26,13 +28,9 @@ export interface DriveFile {
 
 // uploadTinyPNG は test 用の 1x1 透過 PNG を /api/drive/files/create に
 // multipart で upload する helper。drive 系 spec が複数で同 pattern を
-// 抱えていたので集約 (#967 batch4 review)。call sites:
-//   - drive_file_rename / drive_file_toggle_sensitive / drive_file_delete
-//   - drive_file_describe_save / drive_file_detail_render
+// 抱えていたので集約 (#967 batch4 review)。
 // 失敗時はキャッチ側で test を fail させたいので、status と body を
 // そのまま返さず正常系で DriveFile を返し、異常系は throw する。
-import type { APIRequestContext } from '@playwright/test';
-
 export async function uploadTinyPNG(
   request: APIRequestContext,
   baseURL: string,

--- a/tests/playwright/specs/ui/admin_announcement_archive_button.spec.ts
+++ b/tests/playwright/specs/ui/admin_announcement_archive_button.spec.ts
@@ -1,0 +1,81 @@
+// /admin/announcements で 既存 announcement folder を expand →
+// "End (Archive)" button click → /api/admin/announcements/update
+// (isActive=false) round-trip する **真の write-flow** spec。
+//
+// admin/announcements.vue line 32: archive button text は
+// `{{ end }} ({{ archive }})` (i18n.ts._announcement.end + i18n.ts.archive)。
+// 該当 announcement folder を default open で render するために、API で
+// 新規 (id 付き) announcement を作成 → /admin/announcements に navigate。
+// 新作 announcement folder は MkFolder の defaultOpen logic で auto open
+// しないので、folder header click が必要。
+
+import { readFileSync } from 'node:fs';
+import { expect, test } from '@playwright/test';
+import { callApi } from '../../fixtures/api';
+import { type RootFixture, uiSigninAsRoot } from '../../fixtures/ui_auth';
+
+test.describe('UI: /admin/announcements archive button flow', () => {
+  let root: RootFixture;
+  test.beforeAll(() => {
+    root = JSON.parse(readFileSync('.auth/root.json', 'utf-8'));
+  });
+  test.setTimeout(60_000);
+
+  test('create via API → expand folder → click Archive → admin/announcements/update', async ({
+    page,
+    baseURL,
+    request,
+  }) => {
+    const title = `pwann-arch-${Date.now().toString().slice(-9)}`;
+    const text = `pwann-arch-body-${Date.now().toString().slice(-9)}`;
+    const createResp = await callApi(request, 'admin/announcements/create', {
+      i: root.token,
+      title,
+      text,
+    });
+    expect(createResp.status()).toBe(200);
+
+    await uiSigninAsRoot(page, baseURL, root);
+    await page.goto(`${baseURL}/admin/announcements`, { waitUntil: 'domcontentloaded' });
+
+    // 新作 announcement の title が body に出るまで待つ (= list 反映)
+    await page.waitForFunction(
+      (t) => document.body.textContent?.includes(t) ?? false,
+      title,
+      { timeout: 20_000 },
+    );
+
+    // 該当 folder の header をすべて click すると expand する。
+    // textContent に title を含む button (= folder header) を click。
+    await page.evaluate((t) => {
+      const headers = Array.from(
+        document.querySelectorAll('[data-cy-folder-header]'),
+      ) as HTMLButtonElement[];
+      const target = headers.find((h) => (h.textContent ?? '').includes(t));
+      target?.click();
+    }, title);
+
+    // Archive button が visible になるまで待つ。textContent は
+    // 'End (Archive)' を含む。
+    await page.waitForFunction(
+      () => {
+        const btns = Array.from(document.querySelectorAll('button'));
+        return btns.some((b) => (b.textContent ?? '').includes('Archive'));
+      },
+      { timeout: 10_000 },
+    );
+
+    const updateResp = page.waitForResponse(
+      (r) => r.url().includes('/api/admin/announcements/update') && r.status() < 400,
+      { timeout: 15_000 },
+    );
+    await page.evaluate(() => {
+      const btn = Array.from(document.querySelectorAll('button')).find((b) =>
+        (b.textContent ?? '').includes('Archive'),
+      ) as HTMLButtonElement | undefined;
+      btn?.click();
+    });
+    const resp = await updateResp;
+    expect(resp.status()).toBeLessThan(400);
+  });
+});

--- a/tests/playwright/specs/ui/admin_avatar_decoration_create_form.spec.ts
+++ b/tests/playwright/specs/ui/admin_avatar_decoration_create_form.spec.ts
@@ -1,0 +1,98 @@
+// /admin/avatar-decorations で header "+ Add" → MkWindow popup → name +
+// imageUrl 入力 → "Create" button click → /api/admin/avatar-decorations/create
+// round-trip する **真の write-flow** spec。
+//
+// avatar-decorations.vue の add() は popupAsyncWithDialog で
+// avatar-decoration-edit-dialog.vue を開く (MkWindow ベース)。dialog 内に
+// name MkInput + imageUrl MkInput + description MkTextarea が並ぶ。Create
+// click は MkButton primary で "Create" textContent (= avatarDecoration が
+// null のとき)。
+
+import { readFileSync } from 'node:fs';
+import { expect, test } from '@playwright/test';
+import { type RootFixture, uiSigninAsRoot } from '../../fixtures/ui_auth';
+
+test.describe('UI: /admin/avatar-decorations create form flow', () => {
+  let root: RootFixture;
+  test.beforeAll(() => {
+    root = JSON.parse(readFileSync('.auth/root.json', 'utf-8'));
+  });
+  test.setTimeout(60_000);
+
+  test('click + → fill name+imageUrl → Create → admin/avatar-decorations/create round-trips', async ({
+    page,
+    baseURL,
+  }) => {
+    await uiSigninAsRoot(page, baseURL, root);
+    await page.goto(`${baseURL}/admin/avatar-decorations`, {
+      waitUntil: 'domcontentloaded',
+    });
+
+    // header の "+" button (ti-plus) を待つ
+    await page.waitForFunction(
+      () => document.querySelector('button i.ti-plus') !== null,
+      { timeout: 20_000 },
+    );
+
+    const baselineInputs = await page.evaluate(
+      () => document.querySelectorAll('input').length,
+    );
+
+    // "+" header click → edit dialog popup
+    await page.evaluate(() => {
+      const btn = (document.querySelector('button i.ti-plus')?.closest('button')) as
+        | HTMLButtonElement
+        | null;
+      btn?.click();
+    });
+
+    // dialog 内 input が +2 (name / imageUrl) されたら expand 完了
+    await page.waitForFunction(
+      (n) => document.querySelectorAll('input').length >= n + 2,
+      baselineInputs,
+      { timeout: 10_000 },
+    );
+
+    const decoName = `pwdecoui-${Date.now().toString().slice(-9)}`;
+    const decoUrl = 'https://example.test/decoration.png';
+
+    // dialog 内 input 2 個 (name = 1 つ目、imageUrl = 2 つ目) を埋める。
+    // page baseline 以降の input が dialog のもの。
+    await page.evaluate(
+      ({ n, u, base }) => {
+        const inputs = Array.from(document.querySelectorAll('input')) as HTMLInputElement[];
+        const dialogInputs = inputs.slice(base);
+        const setter = Object.getOwnPropertyDescriptor(
+          window.HTMLInputElement.prototype,
+          'value',
+        )?.set;
+        const setValue = (el: HTMLInputElement | undefined, v: string) => {
+          if (!el) return;
+          el.focus();
+          setter?.call(el, v);
+          el.dispatchEvent(new Event('input', { bubbles: true }));
+        };
+        setValue(dialogInputs[0], n);
+        setValue(dialogInputs[1], u);
+      },
+      { n: decoName, u: decoUrl, base: baselineInputs },
+    );
+
+    // admin/avatar-decorations/create response 捕捉して "Create" click
+    const createResp = page.waitForResponse(
+      (r) =>
+        r.url().includes('/api/admin/avatar-decorations/create') && r.status() < 400,
+      { timeout: 15_000 },
+    );
+    await page.evaluate(() => {
+      // dialog 内の "Create" button (= MkButton primary、textContent に
+      // "Create" を含む)
+      const btn = Array.from(document.querySelectorAll('button')).find((b) =>
+        (b.textContent ?? '').trim() === 'Create',
+      ) as HTMLButtonElement | undefined;
+      btn?.click();
+    });
+    const resp = await createResp;
+    expect(resp.status()).toBeLessThan(400);
+  });
+});

--- a/tests/playwright/specs/ui/admin_branding_save.spec.ts
+++ b/tests/playwright/specs/ui/admin_branding_save.spec.ts
@@ -1,0 +1,43 @@
+// /admin/branding で "Save" button click → /api/admin/update-meta
+// round-trip する **真の write-flow** spec。
+//
+// admin/branding.vue はインスタンスのアイコン / 名前 / 説明等の form。
+// Save click で現在値を commit (branding.vue:148 / 197)。
+
+import { readFileSync } from 'node:fs';
+import { expect, test } from '@playwright/test';
+import { type RootFixture, uiSigninAsRoot } from '../../fixtures/ui_auth';
+
+test.describe('UI: /admin/branding save flow', () => {
+  let root: RootFixture;
+  test.beforeAll(() => {
+    root = JSON.parse(readFileSync('.auth/root.json', 'utf-8'));
+  });
+  test.setTimeout(60_000);
+
+  test('click Save → /api/admin/update-meta round-trips', async ({ page, baseURL }) => {
+    await uiSigninAsRoot(page, baseURL, root);
+    await page.goto(`${baseURL}/admin/branding`, { waitUntil: 'domcontentloaded' });
+
+    await page.waitForFunction(
+      () => {
+        const btns = Array.from(document.querySelectorAll('button'));
+        return btns.some((b) => (b.textContent ?? '').includes('Save'));
+      },
+      { timeout: 20_000 },
+    );
+
+    const updateResp = page.waitForResponse(
+      (r) => r.url().includes('/api/admin/update-meta') && r.status() < 400,
+      { timeout: 15_000 },
+    );
+    await page.evaluate(() => {
+      const btn = Array.from(document.querySelectorAll('button')).find((b) =>
+        (b.textContent ?? '').includes('Save'),
+      ) as HTMLButtonElement | undefined;
+      btn?.click();
+    });
+    const resp = await updateResp;
+    expect(resp.status()).toBeLessThan(400);
+  });
+});

--- a/tests/playwright/specs/ui/admin_email_settings_save.spec.ts
+++ b/tests/playwright/specs/ui/admin_email_settings_save.spec.ts
@@ -1,0 +1,46 @@
+// /admin/email-settings で "Save" button click → /api/admin/update-meta
+// round-trip する **真の write-flow** spec。
+//
+// admin/email-settings.vue は SMTP / email 設定 form。toggle / input は
+// 何も変更せずに Save するだけで update-meta が走る (= 現在値を再 commit)。
+// frontend は disableEmail / SMTP host 等の既存値を re-send するので
+// regression は起きない。
+
+import { readFileSync } from 'node:fs';
+import { expect, test } from '@playwright/test';
+import { type RootFixture, uiSigninAsRoot } from '../../fixtures/ui_auth';
+
+test.describe('UI: /admin/email-settings save flow', () => {
+  let root: RootFixture;
+  test.beforeAll(() => {
+    root = JSON.parse(readFileSync('.auth/root.json', 'utf-8'));
+  });
+  test.setTimeout(60_000);
+
+  test('click Save → /api/admin/update-meta round-trips', async ({ page, baseURL }) => {
+    await uiSigninAsRoot(page, baseURL, root);
+    await page.goto(`${baseURL}/admin/email-settings`, { waitUntil: 'domcontentloaded' });
+
+    // Save button が hydrate するまで待つ (textContent "Save")
+    await page.waitForFunction(
+      () => {
+        const btns = Array.from(document.querySelectorAll('button'));
+        return btns.some((b) => (b.textContent ?? '').includes('Save'));
+      },
+      { timeout: 20_000 },
+    );
+
+    const updateResp = page.waitForResponse(
+      (r) => r.url().includes('/api/admin/update-meta') && r.status() < 400,
+      { timeout: 15_000 },
+    );
+    await page.evaluate(() => {
+      const btn = Array.from(document.querySelectorAll('button')).find((b) =>
+        (b.textContent ?? '').includes('Save'),
+      ) as HTMLButtonElement | undefined;
+      btn?.click();
+    });
+    const resp = await updateResp;
+    expect(resp.status()).toBeLessThan(400);
+  });
+});

--- a/tests/playwright/specs/ui/admin_external_services_google_save.spec.ts
+++ b/tests/playwright/specs/ui/admin_external_services_google_save.spec.ts
@@ -1,0 +1,63 @@
+// /admin/external-services で 1 番目の MkFolder (Google Analytics) を
+// expand → Save click → /api/admin/update-meta round-trip する
+// **真の write-flow** spec。
+//
+// external-services.vue では各サービス別に MkFolder + Save button を
+// 持つ。folder は SearchMarker 経由で defaultOpen でないので、folder
+// header を expand する必要あり。1 番目 = Google Analytics。
+
+import { readFileSync } from 'node:fs';
+import { expect, test } from '@playwright/test';
+import { type RootFixture, uiSigninAsRoot } from '../../fixtures/ui_auth';
+
+test.describe('UI: /admin/external-services Google Analytics save flow', () => {
+  let root: RootFixture;
+  test.beforeAll(() => {
+    root = JSON.parse(readFileSync('.auth/root.json', 'utf-8'));
+  });
+  test.setTimeout(60_000);
+
+  test('expand folder → Save → /api/admin/update-meta round-trips', async ({
+    page,
+    baseURL,
+  }) => {
+    await uiSigninAsRoot(page, baseURL, root);
+    await page.goto(`${baseURL}/admin/external-services`, {
+      waitUntil: 'domcontentloaded',
+    });
+
+    // 1 つ目の folder header (Google Analytics) を click して expand
+    await page.waitForFunction(
+      () => document.querySelector('[data-cy-folder-header]') !== null,
+      { timeout: 20_000 },
+    );
+    await page.evaluate(() => {
+      const header = document.querySelector('[data-cy-folder-header]') as
+        | HTMLButtonElement
+        | null;
+      header?.click();
+    });
+
+    // Save button が visible になるまで待つ
+    await page.waitForFunction(
+      () => {
+        const btns = Array.from(document.querySelectorAll('button'));
+        return btns.some((b) => (b.textContent ?? '').trim() === 'Save');
+      },
+      { timeout: 10_000 },
+    );
+
+    const updateResp = page.waitForResponse(
+      (r) => r.url().includes('/api/admin/update-meta') && r.status() < 400,
+      { timeout: 15_000 },
+    );
+    await page.evaluate(() => {
+      const btn = Array.from(document.querySelectorAll('button')).find(
+        (b) => (b.textContent ?? '').trim() === 'Save',
+      ) as HTMLButtonElement | undefined;
+      btn?.click();
+    });
+    const resp = await updateResp;
+    expect(resp.status()).toBeLessThan(400);
+  });
+});

--- a/tests/playwright/specs/ui/admin_invite_create_form.spec.ts
+++ b/tests/playwright/specs/ui/admin_invite_create_form.spec.ts
@@ -1,0 +1,67 @@
+// /admin/invites で MkFolder "Create invite code" を expand → "Create"
+// button click → /api/admin/invite/create round-trip → 一覧に新コード
+// が prepend される **真の write-flow** spec。
+//
+// invites.vue では create form は MkFolder で `:expanded="false"` 起点。
+// header click で expand する必要がある。MkFolder header は
+// `data-cy-folder-header` 属性 (#744 batch3 で globalSetup から判明) で
+// 取得可能。expand 後に "Create" button (i18n.ts.create = "Create") を click。
+
+import { readFileSync } from 'node:fs';
+import { expect, test } from '@playwright/test';
+import { type RootFixture, uiSigninAsRoot } from '../../fixtures/ui_auth';
+
+test.describe('UI: /admin/invites create form flow', () => {
+  let root: RootFixture;
+  test.beforeAll(() => {
+    root = JSON.parse(readFileSync('.auth/root.json', 'utf-8'));
+  });
+  test.setTimeout(60_000);
+
+  test('expand folder → click Create → /api/admin/invite/create round-trips', async ({
+    page,
+    baseURL,
+  }) => {
+    await uiSigninAsRoot(page, baseURL, root);
+    await page.goto(`${baseURL}/admin/invites`, { waitUntil: 'domcontentloaded' });
+
+    // MkFolder header が hydrate するまで待つ
+    await page.waitForFunction(
+      () => document.querySelector('[data-cy-folder-header]') !== null,
+      { timeout: 20_000 },
+    );
+
+    // 1 つ目の MkFolder を expand (= "Create invite code" form を開く)
+    await page.evaluate(() => {
+      const header = document.querySelector('[data-cy-folder-header]') as HTMLButtonElement | null;
+      header?.click();
+    });
+
+    // Create button が visible になるまで待つ (= folder content が expand 完了)
+    await page.waitForFunction(
+      () => {
+        const btns = Array.from(document.querySelectorAll('button'));
+        return btns.some((b) => (b.textContent ?? '').trim() === 'Create');
+      },
+      { timeout: 10_000 },
+    );
+
+    // admin/invite/create response 捕捉して Create click
+    const createResp = page.waitForResponse(
+      (r) => r.url().includes('/api/admin/invite/create') && r.status() === 200,
+      { timeout: 15_000 },
+    );
+    await page.evaluate(() => {
+      const btn = Array.from(document.querySelectorAll('button')).find(
+        (b) => (b.textContent ?? '').trim() === 'Create',
+      ) as HTMLButtonElement | undefined;
+      btn?.click();
+    });
+    const created = await createResp;
+    const body = await created.json();
+    // admin/invite/create returns array of {code, ...}
+    expect(Array.isArray(body)).toBe(true);
+    expect(body.length).toBeGreaterThan(0);
+    expect(body[0]).toHaveProperty('code');
+  });
+});

--- a/tests/playwright/specs/ui/admin_object_storage_save.spec.ts
+++ b/tests/playwright/specs/ui/admin_object_storage_save.spec.ts
@@ -1,0 +1,43 @@
+// /admin/object-storage で "Save" button click → /api/admin/update-meta
+// round-trip する **真の write-flow** spec。
+//
+// admin/object-storage.vue は S3-compat 設定 form。Save click で現在値を
+// commit する (object-storage.vue:101 / line 137 で apiWithDialog)。
+
+import { readFileSync } from 'node:fs';
+import { expect, test } from '@playwright/test';
+import { type RootFixture, uiSigninAsRoot } from '../../fixtures/ui_auth';
+
+test.describe('UI: /admin/object-storage save flow', () => {
+  let root: RootFixture;
+  test.beforeAll(() => {
+    root = JSON.parse(readFileSync('.auth/root.json', 'utf-8'));
+  });
+  test.setTimeout(60_000);
+
+  test('click Save → /api/admin/update-meta round-trips', async ({ page, baseURL }) => {
+    await uiSigninAsRoot(page, baseURL, root);
+    await page.goto(`${baseURL}/admin/object-storage`, { waitUntil: 'domcontentloaded' });
+
+    await page.waitForFunction(
+      () => {
+        const btns = Array.from(document.querySelectorAll('button'));
+        return btns.some((b) => (b.textContent ?? '').includes('Save'));
+      },
+      { timeout: 20_000 },
+    );
+
+    const updateResp = page.waitForResponse(
+      (r) => r.url().includes('/api/admin/update-meta') && r.status() < 400,
+      { timeout: 15_000 },
+    );
+    await page.evaluate(() => {
+      const btn = Array.from(document.querySelectorAll('button')).find((b) =>
+        (b.textContent ?? '').includes('Save'),
+      ) as HTMLButtonElement | undefined;
+      btn?.click();
+    });
+    const resp = await updateResp;
+    expect(resp.status()).toBeLessThan(400);
+  });
+});

--- a/tests/playwright/specs/ui/admin_relay_add_form.spec.ts
+++ b/tests/playwright/specs/ui/admin_relay_add_form.spec.ts
@@ -1,0 +1,77 @@
+// /admin/relays で header の "+ Add relay" button click → MkDialog
+// (input dialog) → inbox URL 入力 → OK → /api/admin/relays/add round-trip
+// する **真の write-flow** spec。
+//
+// admin/relays.vue の addRelay() は os.inputText() を使う。MkDialog の
+// 構造は list_create_form.spec.ts と同じ (data-cy-modal-dialog-ok 経由
+// の OK button + modal 内 input)。
+
+import { readFileSync } from 'node:fs';
+import { expect, test } from '@playwright/test';
+import { type RootFixture, uiSigninAsRoot } from '../../fixtures/ui_auth';
+
+test.describe('UI: /admin/relays add form flow', () => {
+  let root: RootFixture;
+  test.beforeAll(() => {
+    root = JSON.parse(readFileSync('.auth/root.json', 'utf-8'));
+  });
+  test.setTimeout(60_000);
+
+  test('click "+ Add relay" → fill inbox URL → OK → /api/admin/relays/add', async ({
+    page,
+    baseURL,
+  }) => {
+    await uiSigninAsRoot(page, baseURL, root);
+    await page.goto(`${baseURL}/admin/relays`, { waitUntil: 'domcontentloaded' });
+
+    // header の "+" button (ti-plus) が hydrate するまで待つ
+    await page.waitForFunction(
+      () => document.querySelector('button i.ti-plus') !== null,
+      { timeout: 20_000 },
+    );
+
+    // "+" header action click → os.inputText popup (= MkDialog)
+    await page.evaluate(() => {
+      const btn = (document.querySelector('button i.ti-plus')?.closest('button')) as
+        | HTMLButtonElement
+        | null;
+      btn?.click();
+    });
+
+    // MkDialog が open するまで待つ
+    await page.waitForFunction(
+      () => document.querySelector('[data-cy-modal-dialog-ok]') !== null,
+      { timeout: 10_000 },
+    );
+
+    const inboxURL = `https://relay-${Date.now().toString().slice(-9)}.example.test/inbox`;
+
+    // dialog 内 last input (= MkDialog の MkInput) に書き込み
+    await page.evaluate((u) => {
+      const inputs = Array.from(document.querySelectorAll('input')) as HTMLInputElement[];
+      const target = inputs[inputs.length - 1];
+      if (!target) return;
+      target.focus();
+      const setter = Object.getOwnPropertyDescriptor(
+        window.HTMLInputElement.prototype,
+        'value',
+      )?.set;
+      setter?.call(target, u);
+      target.dispatchEvent(new Event('input', { bubbles: true }));
+    }, inboxURL);
+
+    // admin/relays/add response 捕捉して OK click
+    const addResp = page.waitForResponse(
+      (r) => r.url().includes('/api/admin/relays/add') && r.status() < 400,
+      { timeout: 15_000 },
+    );
+    await page.evaluate(() => {
+      const ok = document.querySelector(
+        '[data-cy-modal-dialog-ok]',
+      ) as HTMLButtonElement | null;
+      ok?.click();
+    });
+    const resp = await addResp;
+    expect(resp.status()).toBeLessThan(400);
+  });
+});

--- a/tests/playwright/specs/ui/admin_role_edit_save.spec.ts
+++ b/tests/playwright/specs/ui/admin_role_edit_save.spec.ts
@@ -1,0 +1,92 @@
+// /admin/roles/:id/edit で 既存 role の name を変更 → Save click →
+// /api/admin/roles/update round-trip する **真の write-flow** spec。
+
+import { readFileSync } from 'node:fs';
+import { expect, test } from '@playwright/test';
+import { callApi } from '../../fixtures/api';
+import { type RootFixture, uiSigninAsRoot } from '../../fixtures/ui_auth';
+
+test.describe('UI: /admin/roles/:id/edit update flow', () => {
+  let root: RootFixture;
+  test.beforeAll(() => {
+    root = JSON.parse(readFileSync('.auth/root.json', 'utf-8'));
+  });
+  test.setTimeout(60_000);
+
+  test('create role via API → edit name → Save → /api/admin/roles/update', async ({
+    page,
+    baseURL,
+    request,
+  }) => {
+    const initialName = `pwrole-init-${Date.now().toString().slice(-9)}`;
+    // mk-go admin/roles/create paramDef は 13 field 必須 (#889): name /
+    // description / target / condFormula / isPublic / isModerator /
+    // isAdministrator / asBadge / canEditMembersByModerator /
+    // displayOrder / policies。color / iconUrl は nullable optional。
+    const createResp = await callApi(request, 'admin/roles/create', {
+      i: root.token,
+      name: initialName,
+      description: '',
+      color: null,
+      iconUrl: null,
+      target: 'manual',
+      condFormula: { id: '00000000-0000-0000-0000-000000000000', type: 'isLocal' },
+      isPublic: false,
+      isModerator: false,
+      isAdministrator: false,
+      isExplorable: false,
+      asBadge: false,
+      canEditMembersByModerator: false,
+      displayOrder: 0,
+      policies: {},
+    });
+    expect(createResp.status()).toBe(200);
+    const roleId = (await createResp.json()).id;
+    expect(roleId).toBeTruthy();
+
+    await uiSigninAsRoot(page, baseURL, root);
+    await page.goto(`${baseURL}/admin/roles/${roleId}/edit`, {
+      waitUntil: 'domcontentloaded',
+    });
+
+    await page.waitForFunction(
+      (n) => {
+        const inputs = Array.from(document.querySelectorAll('input')) as HTMLInputElement[];
+        return inputs.some((i) => i.value === n);
+      },
+      initialName,
+      { timeout: 20_000 },
+    );
+
+    const newName = `pwrole-updated-${Date.now().toString().slice(-9)}`;
+    await page.evaluate(
+      ({ from, to }) => {
+        const target = (
+          Array.from(document.querySelectorAll('input')) as HTMLInputElement[]
+        ).find((i) => i.value === from);
+        if (!target) return;
+        target.focus();
+        const setter = Object.getOwnPropertyDescriptor(
+          window.HTMLInputElement.prototype,
+          'value',
+        )?.set;
+        setter?.call(target, to);
+        target.dispatchEvent(new Event('input', { bubbles: true }));
+      },
+      { from: initialName, to: newName },
+    );
+
+    const updateResp = page.waitForResponse(
+      (r) => r.url().includes('/api/admin/roles/update') && r.status() < 400,
+      { timeout: 15_000 },
+    );
+    await page.evaluate(() => {
+      const btn = Array.from(document.querySelectorAll('button')).find((b) =>
+        (b.textContent ?? '').includes('Save'),
+      ) as HTMLButtonElement | undefined;
+      btn?.click();
+    });
+    const resp = await updateResp;
+    expect(resp.status()).toBeLessThan(400);
+  });
+});

--- a/tests/playwright/specs/ui/admin_system_webhook_create_form.spec.ts
+++ b/tests/playwright/specs/ui/admin_system_webhook_create_form.spec.ts
@@ -1,0 +1,97 @@
+// /admin/system-webhook で "Create" button → MkSystemWebhookEditor dialog →
+// title / url を埋めて Save → /api/admin/system-webhook/create が round-trip
+// する write-flow spec。
+//
+// system-webhook.vue の onCreateWebhookClicked は
+// showSystemWebhookEditorDialog({mode: 'create'}) を popup する (line 45-48)。
+// dialog の中に MkInput が 3 個 (title / url / secret) と 5 個程度の switch
+// (events.* trigger) が並び、最後に primary "Save" button (= onSubmitClicked)
+// がある。本 spec は title + url 必須を埋めて Save を click する。
+
+import { readFileSync } from 'node:fs';
+import { expect, test } from '@playwright/test';
+import { type RootFixture, uiSigninAsRoot } from '../../fixtures/ui_auth';
+
+test.describe('UI: /admin/system-webhook create flow', () => {
+  let root: RootFixture;
+  test.beforeAll(() => {
+    root = JSON.parse(readFileSync('.auth/root.json', 'utf-8'));
+  });
+  test.setTimeout(60_000);
+
+  test('Create button → editor dialog → admin/system-webhook/create', async ({
+    page,
+    baseURL,
+  }) => {
+    await uiSigninAsRoot(page, baseURL, root);
+    await page.goto(`${baseURL}/admin/system-webhook`, {
+      waitUntil: 'domcontentloaded',
+    });
+
+    // "Create webhook" primary button (= ti-plus icon を持つ button) hydrate
+    await page.waitForFunction(
+      () => {
+        const btns = Array.from(document.querySelectorAll('button')) as HTMLButtonElement[];
+        return btns.some((b) => b.querySelector('i.ti-plus') !== null);
+      },
+      { timeout: 20_000 },
+    );
+
+    await page.evaluate(() => {
+      const btns = Array.from(document.querySelectorAll('button')) as HTMLButtonElement[];
+      const create = btns.find((b) => b.querySelector('i.ti-plus') !== null);
+      create?.click();
+    });
+
+    // dialog 内 text input が 3 個 (title / url / secret) hydrate するまで待つ
+    await page.waitForFunction(
+      () => {
+        const inputs = Array.from(document.querySelectorAll('input')) as HTMLInputElement[];
+        return inputs.filter((i) => i.type === 'text').length >= 3;
+      },
+      { timeout: 10_000 },
+    );
+
+    // title / url を投入。3rd (secret) は optional なので空のまま。
+    const title = `pw-webhook-${Date.now()}`;
+    const url = `https://example.invalid/pw/${Date.now()}`;
+    await page.evaluate(
+      ({ t, u }) => {
+        const inputs = (Array.from(document.querySelectorAll('input')) as HTMLInputElement[]).filter(
+          (i) => i.type === 'text',
+        );
+        const setter = Object.getOwnPropertyDescriptor(
+          window.HTMLInputElement.prototype,
+          'value',
+        )?.set;
+        if (inputs[0]) {
+          inputs[0].focus();
+          setter?.call(inputs[0], t);
+          inputs[0].dispatchEvent(new Event('input', { bubbles: true }));
+        }
+        if (inputs[1]) {
+          inputs[1].focus();
+          setter?.call(inputs[1], u);
+          inputs[1].dispatchEvent(new Event('input', { bubbles: true }));
+        }
+      },
+      { t: title, u: url },
+    );
+
+    // Save button (= primary, "Save" text を持つ button)
+    const createResp = page.waitForResponse(
+      (r) =>
+        r.url().includes('/api/admin/system-webhook/create') && r.status() < 300,
+      { timeout: 15_000 },
+    );
+    await page.evaluate(() => {
+      const btns = Array.from(document.querySelectorAll('button')) as HTMLButtonElement[];
+      const save = btns.find(
+        (b) => !b.disabled && (b.textContent ?? '').trim().match(/Save/i),
+      );
+      save?.click();
+    });
+    const create = await createResp;
+    expect(create.status()).toBeLessThan(300);
+  });
+});

--- a/tests/playwright/specs/ui/admin_user_suspend_toggle.spec.ts
+++ b/tests/playwright/specs/ui/admin_user_suspend_toggle.spec.ts
@@ -1,0 +1,118 @@
+// /admin/user?userId=:id で suspend MkSwitch を click → confirm dialog の
+// OK → /api/admin/suspend-user が走る write-flow spec。
+//
+// admin-user.vue の toggleSuspend は MkSwitch v-model 変化で起動する
+// (line 97 + 347-358)。click → os.confirm() で warning dialog → 承諾後に
+// admin/suspend-user 叩いて refresh。本 spec は新規 user を signup して
+// 即 suspend を toggle、API 経由で isSuspended が true になっていることを
+// 確認する。root を巻き添え suspend しないよう必ず別 user を target にする。
+
+import { readFileSync } from 'node:fs';
+import { expect, test } from '@playwright/test';
+import { callApi } from '../../fixtures/api';
+import { signupUser } from '../../fixtures/auth';
+import { type RootFixture, uiSigninAsRoot } from '../../fixtures/ui_auth';
+
+test.describe('UI: /admin/user suspend toggle flow', () => {
+  let root: RootFixture;
+  test.beforeAll(() => {
+    root = JSON.parse(readFileSync('.auth/root.json', 'utf-8'));
+  });
+  test.setTimeout(90_000);
+
+  test('toggle suspend switch + confirm OK → /api/admin/suspend-user', async ({
+    page,
+    baseURL,
+    request,
+  }) => {
+    // 1. target user を signup (root を suspend しないように必ず別 user)
+    const username = `pwsus${Date.now().toString().slice(-9)}`;
+    const target = await signupUser(request, username);
+    expect(target.id).toBeTruthy();
+
+    // 2. /admin/user?userId=:id を root として開く
+    await uiSigninAsRoot(page, baseURL, root);
+    const resp = await page.goto(
+      `${baseURL}/admin/user?userId=${target.id}`,
+      { waitUntil: 'domcontentloaded' },
+    );
+    expect(resp!.status()).toBe(200);
+
+    // user info hydrate を待つ (username が body に出る)
+    await page.waitForFunction(
+      (u) => document.body.textContent?.includes(u) ?? false,
+      target.username,
+      { timeout: 20_000 },
+    );
+
+    // 3. suspend switch (= "Suspend" label を含む checkbox) を click
+    // /admin/user は admin moderation switches が複数並ぶ。"Suspend" は
+    // MkSwitch label に i18n.ts.suspend (= "Suspend") を表示するため、
+    // text 周辺の checkbox を取る。簡易には全 checkbox を取って index で
+    // 当てる: admin-user.vue 順は moderator / silence / suspend / 他なので
+    // 4 つ目以降。signup 直後 user では事前 toggle 無しで suspend は
+    // false → 押すと true になる。
+    //
+    // 確実性のため、label 文字列で switch を識別する: "Suspend" を含む
+    // 親要素を探し、その配下の checkbox を click する。
+    await page.waitForFunction(
+      () => {
+        const labels = Array.from(document.querySelectorAll('label, span'));
+        return labels.some((l) =>
+          (l.textContent ?? '').trim().match(/^Suspend$/i),
+        );
+      },
+      { timeout: 15_000 },
+    );
+
+    // confirm dialog の OK button (data-cy-modal-dialog-ok) が後で出てくる。
+    // suspend click → dialog open → OK click → API call。response 待ちは
+    // OK click 後に始める。
+    await page.evaluate(() => {
+      // Suspend label を持つ要素から最も近い checkbox を探す
+      const labels = Array.from(document.querySelectorAll('label, span, div'));
+      const suspendLabel = labels.find(
+        (l) => (l.textContent ?? '').trim().match(/^Suspend$/i),
+      );
+      if (!suspendLabel) return;
+      // 親方向に MkSwitch の root を辿って配下の checkbox を取る
+      let node: HTMLElement | null = suspendLabel as HTMLElement;
+      for (let depth = 0; depth < 6 && node; depth++) {
+        const cb = node.querySelector('input[type="checkbox"]') as HTMLInputElement | null;
+        if (cb) {
+          cb.click();
+          return;
+        }
+        node = node.parentElement;
+      }
+    });
+
+    // 4. confirm dialog OK click → admin/suspend-user 走る
+    await page.waitForFunction(
+      () => document.querySelector('[data-cy-modal-dialog-ok]') !== null,
+      { timeout: 10_000 },
+    );
+    const suspendResp = page.waitForResponse(
+      (r) =>
+        r.url().includes('/api/admin/suspend-user') && r.status() < 300,
+      { timeout: 15_000 },
+    );
+    await page.evaluate(() => {
+      const ok = document.querySelector(
+        '[data-cy-modal-dialog-ok]',
+      ) as HTMLButtonElement | null;
+      ok?.click();
+    });
+    await suspendResp;
+
+    // 5. API 経由で target.isSuspended=true を verify
+    const showResp = await callApi(request, 'admin/show-user', {
+      i: root.token,
+      userId: target.id,
+    });
+    expect(showResp.status()).toBe(200);
+    const shown = await showResp.json();
+    expect(shown.id).toBe(target.id);
+    expect(shown.isSuspended).toBe(true);
+  });
+});

--- a/tests/playwright/specs/ui/announcement_read_button.spec.ts
+++ b/tests/playwright/specs/ui/announcement_read_button.spec.ts
@@ -1,0 +1,68 @@
+// /announcements で未読 announcement の "Got it!" button click →
+// /api/i/read-announcement round-trip する **真の write-flow** spec。
+//
+// announcements.vue は tab !== 'past' && !announcement.isRead && !silence
+// な announcement に "Got it!" button を出す (line 36-37)。click すると
+// read() が i/read-announcement を呼ぶ (line 85)。
+//
+// 本 spec は admin/announcements/create で uniq title の unread
+// announcement を作成 → /announcements に navigate → 該当 entry の Got
+// it! button を click → API round-trip を verify する。
+
+import { readFileSync } from 'node:fs';
+import { expect, test } from '@playwright/test';
+import { callApi } from '../../fixtures/api';
+import { type RootFixture, uiSigninAsRoot } from '../../fixtures/ui_auth';
+
+test.describe('UI: /announcements read button flow', () => {
+  let root: RootFixture;
+  test.beforeAll(() => {
+    root = JSON.parse(readFileSync('.auth/root.json', 'utf-8'));
+  });
+  test.setTimeout(60_000);
+
+  test('admin creates → user reads via "Got it!" → /api/i/read-announcement', async ({
+    page,
+    baseURL,
+    request,
+  }) => {
+    // admin として announcement を作成 (root は admin 権限)。
+    const title = `pwann-${Date.now().toString().slice(-9)}`;
+    const text = `pwann-body-${Date.now().toString().slice(-9)}`;
+    const createResp = await callApi(request, 'admin/announcements/create', {
+      i: root.token,
+      title,
+      text,
+    });
+    expect(createResp.status()).toBe(200);
+
+    await uiSigninAsRoot(page, baseURL, root);
+    await page.goto(`${baseURL}/announcements`, { waitUntil: 'domcontentloaded' });
+
+    // 新 announcement の title が body に出るまで待つ。
+    await page.waitForFunction(
+      (t) => document.body.textContent?.includes(t) ?? false,
+      title,
+      { timeout: 20_000 },
+    );
+
+    // i/read-announcement response 捕捉 → "Got it!" click。
+    // /announcements の Got it! は MkButton primary で textContent に
+    // "Got it!" を含む。同 page には別 popup (MkSourceCodeAvailablePopup)
+    // も "Got it!" を持ちうるが、popup より先 (= 上) にある announcement
+    // 内 button が DOM 順で先頭。
+    const readResp = page.waitForResponse(
+      (r) => r.url().includes('/api/i/read-announcement') && r.status() < 400,
+      { timeout: 15_000 },
+    );
+    await page.evaluate(() => {
+      const btns = Array.from(document.querySelectorAll('button'));
+      const btn = btns.find((b) => (b.textContent ?? '').includes('Got it!')) as
+        | HTMLButtonElement
+        | undefined;
+      btn?.click();
+    });
+    const resp = await readResp;
+    expect(resp.status()).toBeLessThan(400);
+  });
+});

--- a/tests/playwright/specs/ui/antenna_edit_save.spec.ts
+++ b/tests/playwright/specs/ui/antenna_edit_save.spec.ts
@@ -1,0 +1,83 @@
+// /my/antennas/:id で 既存 antenna の name を変更 → Save click →
+// /api/antennas/update round-trip する **真の write-flow** spec。
+
+import { readFileSync } from 'node:fs';
+import { expect, test } from '@playwright/test';
+import { callApi } from '../../fixtures/api';
+import { type RootFixture, uiSigninAsRoot } from '../../fixtures/ui_auth';
+
+test.describe('UI: /my/antennas/:id update flow', () => {
+  let root: RootFixture;
+  test.beforeAll(() => {
+    root = JSON.parse(readFileSync('.auth/root.json', 'utf-8'));
+  });
+  test.setTimeout(60_000);
+
+  test('create antenna via API → edit name → Save → /api/antennas/update', async ({
+    page,
+    baseURL,
+    request,
+  }) => {
+    const initialName = `pwant-init-${Date.now().toString().slice(-9)}`;
+    const createResp = await callApi(request, 'antennas/create', {
+      i: root.token,
+      name: initialName,
+      src: 'all',
+      keywords: [['*']],
+      excludeKeywords: [],
+      caseSensitive: false,
+      withReplies: false,
+      withFile: false,
+      localOnly: false,
+    });
+    expect(createResp.status()).toBe(200);
+    const antennaId = (await createResp.json()).id;
+    expect(antennaId).toBeTruthy();
+
+    await uiSigninAsRoot(page, baseURL, root);
+    await page.goto(`${baseURL}/my/antennas/${antennaId}`, {
+      waitUntil: 'domcontentloaded',
+    });
+
+    // antenna name MkInput が initialName で hydrate
+    await page.waitForFunction(
+      (n) => {
+        const inputs = Array.from(document.querySelectorAll('input')) as HTMLInputElement[];
+        return inputs.some((i) => i.value === n);
+      },
+      initialName,
+      { timeout: 20_000 },
+    );
+
+    const newName = `pwant-updated-${Date.now().toString().slice(-9)}`;
+    await page.evaluate(
+      ({ from, to }) => {
+        const target = (
+          Array.from(document.querySelectorAll('input')) as HTMLInputElement[]
+        ).find((i) => i.value === from);
+        if (!target) return;
+        target.focus();
+        const setter = Object.getOwnPropertyDescriptor(
+          window.HTMLInputElement.prototype,
+          'value',
+        )?.set;
+        setter?.call(target, to);
+        target.dispatchEvent(new Event('input', { bubbles: true }));
+      },
+      { from: initialName, to: newName },
+    );
+
+    const updateResp = page.waitForResponse(
+      (r) => r.url().includes('/api/antennas/update') && r.status() < 400,
+      { timeout: 15_000 },
+    );
+    await page.evaluate(() => {
+      const btn = Array.from(document.querySelectorAll('button')).find((b) =>
+        (b.textContent ?? '').includes('Save'),
+      ) as HTMLButtonElement | undefined;
+      btn?.click();
+    });
+    const resp = await updateResp;
+    expect(resp.status()).toBeLessThan(400);
+  });
+});

--- a/tests/playwright/specs/ui/channel_edit_save.spec.ts
+++ b/tests/playwright/specs/ui/channel_edit_save.spec.ts
@@ -1,0 +1,78 @@
+// /channels/:id/edit で 既存 channel の name を変更 → Save click →
+// /api/channels/update round-trip する **真の write-flow** spec。
+
+import { readFileSync } from 'node:fs';
+import { expect, test } from '@playwright/test';
+import { callApi } from '../../fixtures/api';
+import { type RootFixture, uiSigninAsRoot } from '../../fixtures/ui_auth';
+
+test.describe('UI: /channels/:id/edit update flow', () => {
+  let root: RootFixture;
+  test.beforeAll(() => {
+    root = JSON.parse(readFileSync('.auth/root.json', 'utf-8'));
+  });
+  test.setTimeout(60_000);
+
+  test('create channel via API → edit name → Save → /api/channels/update', async ({
+    page,
+    baseURL,
+    request,
+  }) => {
+    const initialName = `pwchan-init-${Date.now().toString().slice(-9)}`;
+    const createResp = await callApi(request, 'channels/create', {
+      i: root.token,
+      name: initialName,
+    });
+    expect(createResp.status()).toBe(200);
+    const channelId = (await createResp.json()).id;
+    expect(channelId).toBeTruthy();
+
+    await uiSigninAsRoot(page, baseURL, root);
+    await page.goto(`${baseURL}/channels/${channelId}/edit`, {
+      waitUntil: 'domcontentloaded',
+    });
+
+    // name MkInput が initialName で hydrate
+    await page.waitForFunction(
+      (n) => {
+        const inputs = Array.from(document.querySelectorAll('input')) as HTMLInputElement[];
+        return inputs.some((i) => i.value === n);
+      },
+      initialName,
+      { timeout: 20_000 },
+    );
+
+    const newName = `pwchan-updated-${Date.now().toString().slice(-9)}`;
+    await page.evaluate(
+      ({ from, to }) => {
+        const target = (
+          Array.from(document.querySelectorAll('input')) as HTMLInputElement[]
+        ).find((i) => i.value === from);
+        if (!target) return;
+        target.focus();
+        const setter = Object.getOwnPropertyDescriptor(
+          window.HTMLInputElement.prototype,
+          'value',
+        )?.set;
+        setter?.call(target, to);
+        target.dispatchEvent(new Event('input', { bubbles: true }));
+      },
+      { from: initialName, to: newName },
+    );
+
+    // channel-editor.vue line 61: existing channel の button text は
+    // i18n.ts.save = "Save" (channelId が truthy のとき)
+    const updateResp = page.waitForResponse(
+      (r) => r.url().includes('/api/channels/update') && r.status() < 400,
+      { timeout: 15_000 },
+    );
+    await page.evaluate(() => {
+      const btn = Array.from(document.querySelectorAll('button')).find((b) =>
+        (b.textContent ?? '').includes('Save'),
+      ) as HTMLButtonElement | undefined;
+      btn?.click();
+    });
+    const resp = await updateResp;
+    expect(resp.status()).toBeLessThan(400);
+  });
+});

--- a/tests/playwright/specs/ui/chat_send_to_room.spec.ts
+++ b/tests/playwright/specs/ui/chat_send_to_room.spec.ts
@@ -1,0 +1,80 @@
+// /chat/room/:id で textarea に message 入力 → send button (ti-send icon) →
+// /api/chat/messages/create-to-room round-trip する **真の write-flow** spec。
+//
+// API setup: chat/rooms/create で room を作る (alice owned)。chat/room.vue
+// は room.form.vue を inner で持ち、textarea + ti-send button を提供する。
+
+import { readFileSync } from 'node:fs';
+import { expect, test } from '@playwright/test';
+import { callApi } from '../../fixtures/api';
+import { type RootFixture, uiSigninAsRoot } from '../../fixtures/ui_auth';
+
+test.describe('UI: /chat/room/:id send message flow', () => {
+  let root: RootFixture;
+  test.beforeAll(() => {
+    root = JSON.parse(readFileSync('.auth/root.json', 'utf-8'));
+  });
+  test.setTimeout(60_000);
+
+  test('create room via API → type → send → /api/chat/messages/create-to-room', async ({
+    page,
+    baseURL,
+    request,
+  }) => {
+    const roomName = `pwroom-${Date.now().toString().slice(-9)}`;
+    const createResp = await callApi(request, 'chat/rooms/create', {
+      i: root.token,
+      name: roomName,
+    });
+    expect(createResp.status()).toBe(200);
+    const roomId = (await createResp.json()).id;
+    expect(roomId).toBeTruthy();
+
+    await uiSigninAsRoot(page, baseURL, root);
+    await page.goto(`${baseURL}/chat/room/${roomId}`, { waitUntil: 'domcontentloaded' });
+
+    // room form の textarea が hydrate
+    await page.waitForFunction(
+      () => document.querySelectorAll('textarea').length >= 1,
+      { timeout: 20_000 },
+    );
+
+    const messageText = `pwmsg-${Date.now().toString().slice(-9)}`;
+    await page.evaluate((m) => {
+      const ta = document.querySelector('textarea') as HTMLTextAreaElement | null;
+      if (!ta) return;
+      ta.focus();
+      const setter = Object.getOwnPropertyDescriptor(
+        window.HTMLTextAreaElement.prototype,
+        'value',
+      )?.set;
+      setter?.call(ta, m);
+      ta.dispatchEvent(new Event('input', { bubbles: true }));
+    }, messageText);
+
+    // send button (ti-send icon) が enabled になるまで待つ
+    await page.waitForFunction(
+      () => {
+        const btn = (document.querySelector('button i.ti-send')?.closest('button')) as
+          | HTMLButtonElement
+          | null;
+        return btn != null && !btn.disabled;
+      },
+      { timeout: 5_000 },
+    );
+
+    const sendResp = page.waitForResponse(
+      (r) =>
+        r.url().includes('/api/chat/messages/create-to-room') && r.status() < 400,
+      { timeout: 15_000 },
+    );
+    await page.evaluate(() => {
+      const btn = (document.querySelector('button i.ti-send')?.closest('button')) as
+        | HTMLButtonElement
+        | null;
+      btn?.click();
+    });
+    const resp = await sendResp;
+    expect(resp.status()).toBeLessThan(400);
+  });
+});

--- a/tests/playwright/specs/ui/clip_create_form.spec.ts
+++ b/tests/playwright/specs/ui/clip_create_form.spec.ts
@@ -1,0 +1,96 @@
+// /my/clips で "+ Add" button click → MkFormDialog (name + description +
+// isPublic の 3 field form) → name 入力 → "Done" click → /api/clips/create
+// round-trip → 一覧に新 clip が並ぶ **真の write-flow** spec。
+//
+// my-clips/index.vue の create() は os.form() を使い MkFormDialog を popup
+// する。MkFormDialog は MkModalWindow の `:withOkButton="true"` で本体下に
+// "Done" button を載せる。fields は MkForm.vue で type='string' (=
+// MkInput type=text) と type='boolean' (= MkSwitch) を render する。
+
+import { readFileSync } from 'node:fs';
+import { expect, test } from '@playwright/test';
+import { type RootFixture, uiSigninAsRoot } from '../../fixtures/ui_auth';
+
+test.describe('UI: /my/clips create form flow', () => {
+  let root: RootFixture;
+  test.beforeAll(() => {
+    root = JSON.parse(readFileSync('.auth/root.json', 'utf-8'));
+  });
+  test.setTimeout(60_000);
+
+  test('click + Add → fill name → Done → /api/clips/create round-trips', async ({
+    page,
+    baseURL,
+  }) => {
+    await uiSigninAsRoot(page, baseURL, root);
+    await page.goto(`${baseURL}/my/clips`, { waitUntil: 'domcontentloaded' });
+
+    // header "+ Add" button が hydrate するまで待つ (i18n.ts.add → "Add")
+    await page.waitForFunction(
+      () => {
+        const btns = Array.from(document.querySelectorAll('button'));
+        return btns.some((b) => (b.textContent ?? '').includes('Add'));
+      },
+      { timeout: 20_000 },
+    );
+
+    // dialog popup 前の input 数を baseline として記録 → click → dialog 内
+    // input が +1 (名前 field) されたことで判定する。
+    const baselineInputs = await page.evaluate(
+      () => document.querySelectorAll('input').length,
+    );
+
+    // "+ Add" click → MkFormDialog popup
+    await page.evaluate(() => {
+      const btn = Array.from(document.querySelectorAll('button')).find((b) =>
+        (b.textContent ?? '').includes('Add'),
+      ) as HTMLButtonElement | undefined;
+      btn?.click();
+    });
+
+    // MkFormDialog の name MkInput (= form の text 入力 1 個) が出るまで待つ。
+    await page.waitForFunction(
+      (n) => document.querySelectorAll('input').length > n,
+      baselineInputs,
+      { timeout: 10_000 },
+    );
+
+    const clipName = `pwclipui-${Date.now().toString().slice(-9)}`;
+
+    // form 内の name MkInput を取る。MkForm の field は MkInput (text) /
+    // MkTextarea / MkSwitch (checkbox) で、name = type='text' の input。
+    // 複数 text input がある場合 dialog 内が最後 (= unshift order) なので
+    // type === 'text' で filter して最後を選ぶ。
+    await page.evaluate((n) => {
+      const inputs = (
+        Array.from(document.querySelectorAll('input')) as HTMLInputElement[]
+      ).filter((i) => i.type === 'text');
+      const target = inputs[inputs.length - 1];
+      if (!target) return;
+      target.focus();
+      const setter = Object.getOwnPropertyDescriptor(
+        window.HTMLInputElement.prototype,
+        'value',
+      )?.set;
+      setter?.call(target, n);
+      target.dispatchEvent(new Event('input', { bubbles: true }));
+    }, clipName);
+
+    // clips/create response を捕捉して "Done" click
+    const createResp = page.waitForResponse(
+      (r) => r.url().includes('/api/clips/create') && r.status() === 200,
+      { timeout: 15_000 },
+    );
+    await page.evaluate(() => {
+      // MkModalWindow の ok button (i18n.ts.done = "Done")
+      const btn = Array.from(document.querySelectorAll('button')).find((b) =>
+        (b.textContent ?? '').includes('Done'),
+      ) as HTMLButtonElement | undefined;
+      btn?.click();
+    });
+    const created = await createResp;
+    const body = await created.json();
+    expect(body.id).toBeTruthy();
+    expect(body.name).toBe(clipName);
+  });
+});

--- a/tests/playwright/specs/ui/clip_edit_save.spec.ts
+++ b/tests/playwright/specs/ui/clip_edit_save.spec.ts
@@ -1,0 +1,120 @@
+// /clips/:id ページの header pencil button → MkFormDialog で name 編集 →
+// OK で /api/clips/update が走ることを verify する write-flow spec。
+//
+// clip.vue の headerActions は MkPageHeader headerActions = `ti-pencil`
+// アイコンの button のみ (own clip + signed in 時)。click すると
+// os.form() で MkFormDialog が popup し、name / description / isPublic
+// の 3 fields が並ぶ。最初の text input が name なのでそこを書き換えて
+// MkFormDialog の OK button を click すれば update round-trip が走る。
+
+import { readFileSync } from 'node:fs';
+import { expect, test } from '@playwright/test';
+import { type RootFixture, uiSigninAsRoot } from '../../fixtures/ui_auth';
+
+test.describe('UI: /clips/:id edit name round-trip', () => {
+  let root: RootFixture;
+
+  test.beforeAll(() => {
+    root = JSON.parse(readFileSync('.auth/root.json', 'utf-8'));
+  });
+
+  test.setTimeout(60_000);
+
+  test('header pencil → MkFormDialog rename → /api/clips/update', async ({
+    page,
+    baseURL,
+    request,
+  }) => {
+    // 1. test 用 clip を API で create
+    const initialName = `pw-clip-${Date.now()}`;
+    const createResp = await request.post(`${baseURL}/api/clips/create`, {
+      ignoreHTTPSErrors: true,
+      data: { i: root.token, name: initialName, isPublic: false },
+    });
+    expect(createResp.status()).toBe(200);
+    const clip = await createResp.json();
+    const clipId: string = clip.id;
+    expect(clipId).toBeTruthy();
+
+    // 2. clip 詳細ページを開いて hydrate を待つ
+    await uiSigninAsRoot(page, baseURL, root);
+    const resp = await page.goto(`${baseURL}/clips/${clipId}`, {
+      waitUntil: 'domcontentloaded',
+    });
+    expect(resp!.status()).toBe(200);
+    await page.waitForFunction(
+      (n) => document.body.textContent?.includes(n) ?? false,
+      initialName,
+      { timeout: 20_000 },
+    );
+
+    // 3. header の pencil アイコン button (= edit handler) が hydrate
+    // するまで待ってから click。複数 ti-pencil が居るとき (= ページ内
+    // 別 button) と区別するため、MkPageHeader の headerActions に属する
+    // button (`<button><i class="ti ti-pencil">`) のうち最初の 1 個を
+    // 取る。clip own user の clip detail で edit は他に置き換えが無い。
+    await page.waitForFunction(
+      () => {
+        const btns = Array.from(document.querySelectorAll('button')) as HTMLButtonElement[];
+        return btns.some((b) => b.querySelector('i.ti-pencil') !== null);
+      },
+      { timeout: 15_000 },
+    );
+    await page.evaluate(() => {
+      const btns = Array.from(document.querySelectorAll('button')) as HTMLButtonElement[];
+      const editBtn = btns.find((b) => b.querySelector('i.ti-pencil') !== null);
+      editBtn?.click();
+    });
+
+    // 4. MkFormDialog が popup → 最初の text input (= name) が見える
+    await page.waitForFunction(
+      () => {
+        const inputs = Array.from(document.querySelectorAll('input')) as HTMLInputElement[];
+        return inputs.filter((i) => i.type === 'text').length >= 1;
+      },
+      { timeout: 10_000 },
+    );
+
+    // 5. 新しい name を投入。MkFormDialog 内の text input は name で、
+    // settings layout の MkSuperMenu search 入力 (type=search) と被らない
+    // よう type=text のみ抽出。dialog mount 直後の最初 type=text が name。
+    const newName = `pw-clip-renamed-${Date.now()}`;
+    await page.evaluate((name) => {
+      const inputs = Array.from(document.querySelectorAll('input')) as HTMLInputElement[];
+      const textInputs = inputs.filter((i) => i.type === 'text');
+      const target = textInputs[textInputs.length - 1];
+      if (!target) return;
+      target.focus();
+      const setter = Object.getOwnPropertyDescriptor(
+        window.HTMLInputElement.prototype,
+        'value',
+      )?.set;
+      setter?.call(target, name);
+      target.dispatchEvent(new Event('input', { bubbles: true }));
+    }, newName);
+
+    // 6. MkFormDialog OK → clips/update round-trip
+    const updateResp = page.waitForResponse(
+      (r) => r.url().includes('/api/clips/update') && r.status() < 300,
+      { timeout: 15_000 },
+    );
+    await page.evaluate(() => {
+      const ok = document.querySelector(
+        '[data-cy-modal-dialog-ok]',
+      ) as HTMLButtonElement | null;
+      ok?.click();
+    });
+    const update = await updateResp;
+    expect(update.status()).toBeLessThan(300);
+
+    // 7. API GET で round-trip verify
+    const showResp = await request.post(`${baseURL}/api/clips/show`, {
+      ignoreHTTPSErrors: true,
+      data: { i: root.token, clipId },
+    });
+    expect(showResp.status()).toBe(200);
+    const shown = await showResp.json();
+    expect(shown.id).toBe(clipId);
+    expect(shown.name).toBe(newName);
+  });
+});

--- a/tests/playwright/specs/ui/drive_file_delete.spec.ts
+++ b/tests/playwright/specs/ui/drive_file_delete.spec.ts
@@ -8,6 +8,7 @@
 
 import { readFileSync } from 'node:fs';
 import { expect, test } from '@playwright/test';
+import { uploadTinyPNG } from '../../fixtures/files';
 import { type RootFixture, uiSigninAsRoot } from '../../fixtures/ui_auth';
 
 test.describe('UI: /my/drive/file/:fileId delete flow', () => {
@@ -23,25 +24,8 @@ test.describe('UI: /my/drive/file/:fileId delete flow', () => {
     request,
   }) => {
     // 1. test 用 file を upload
-    const fileName = `pw-del-${Date.now()}.png`;
-    const uploadResp = await request.post(`${baseURL}/api/drive/files/create`, {
-      ignoreHTTPSErrors: true,
-      multipart: {
-        i: root.token,
-        file: {
-          name: fileName,
-          mimeType: 'image/png',
-          buffer: Buffer.from(
-            'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNkYAAAAAYAAjCB0C8AAAAASUVORK5CYII=',
-            'base64',
-          ),
-        },
-      },
-    });
-    expect(uploadResp.status()).toBe(200);
-    const file = await uploadResp.json();
-    const fileId: string = file.id;
-    expect(fileId).toBeTruthy();
+    const file = await uploadTinyPNG(request, baseURL!, root.token, `pw-del-${Date.now()}.png`);
+    const fileId = file.id;
 
     // 2. detail page を開いて hydrate を待つ
     await uiSigninAsRoot(page, baseURL, root);

--- a/tests/playwright/specs/ui/drive_file_delete.spec.ts
+++ b/tests/playwright/specs/ui/drive_file_delete.spec.ts
@@ -1,0 +1,94 @@
+// /my/drive/file/:fileId で trash button を click → confirm dialog OK →
+// /api/drive/files/delete が round-trip する write-flow spec。
+//
+// drive.file.info.vue の deleteFile() は os.confirm warning → 承諾後に
+// drive/files/delete を叩く。ボタンは fileQuickActionsOthers 内、ti-trash
+// アイコン + danger style。post / sensitive ボタンと違い trash は唯一の
+// danger color。
+
+import { readFileSync } from 'node:fs';
+import { expect, test } from '@playwright/test';
+import { type RootFixture, uiSigninAsRoot } from '../../fixtures/ui_auth';
+
+test.describe('UI: /my/drive/file/:fileId delete flow', () => {
+  let root: RootFixture;
+  test.beforeAll(() => {
+    root = JSON.parse(readFileSync('.auth/root.json', 'utf-8'));
+  });
+  test.setTimeout(60_000);
+
+  test('trash button → confirm OK → /api/drive/files/delete', async ({
+    page,
+    baseURL,
+    request,
+  }) => {
+    // 1. test 用 file を upload
+    const fileName = `pw-del-${Date.now()}.png`;
+    const uploadResp = await request.post(`${baseURL}/api/drive/files/create`, {
+      ignoreHTTPSErrors: true,
+      multipart: {
+        i: root.token,
+        file: {
+          name: fileName,
+          mimeType: 'image/png',
+          buffer: Buffer.from(
+            'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNkYAAAAAYAAjCB0C8AAAAASUVORK5CYII=',
+            'base64',
+          ),
+        },
+      },
+    });
+    expect(uploadResp.status()).toBe(200);
+    const file = await uploadResp.json();
+    const fileId: string = file.id;
+    expect(fileId).toBeTruthy();
+
+    // 2. detail page を開いて hydrate を待つ
+    await uiSigninAsRoot(page, baseURL, root);
+    const resp = await page.goto(`${baseURL}/my/drive/file/${fileId}`, {
+      waitUntil: 'domcontentloaded',
+    });
+    expect(resp!.status()).toBe(200);
+
+    // trash button (= ti-trash icon を持つ button) hydrate を待つ
+    await page.waitForFunction(
+      () => {
+        const btns = Array.from(document.querySelectorAll('button')) as HTMLButtonElement[];
+        return btns.some((b) => b.querySelector('i.ti-trash') !== null);
+      },
+      { timeout: 20_000 },
+    );
+
+    // 3. trash click → confirm dialog 出現
+    await page.evaluate(() => {
+      const btns = Array.from(document.querySelectorAll('button')) as HTMLButtonElement[];
+      const trash = btns.find((b) => b.querySelector('i.ti-trash') !== null);
+      trash?.click();
+    });
+
+    await page.waitForFunction(
+      () => document.querySelector('[data-cy-modal-dialog-ok]') !== null,
+      { timeout: 10_000 },
+    );
+
+    // 4. OK → drive/files/delete round-trip
+    const deleteResp = page.waitForResponse(
+      (r) => r.url().includes('/api/drive/files/delete') && r.status() < 300,
+      { timeout: 15_000 },
+    );
+    await page.evaluate(() => {
+      const ok = document.querySelector(
+        '[data-cy-modal-dialog-ok]',
+      ) as HTMLButtonElement | null;
+      ok?.click();
+    });
+    await deleteResp;
+
+    // 5. API 経由で 削除確認 — show は 404 を返す
+    const showResp = await request.post(`${baseURL}/api/drive/files/show`, {
+      ignoreHTTPSErrors: true,
+      data: { i: root.token, fileId },
+    });
+    expect(showResp.status()).toBeGreaterThanOrEqual(400);
+  });
+});

--- a/tests/playwright/specs/ui/drive_file_delete.spec.ts
+++ b/tests/playwright/specs/ui/drive_file_delete.spec.ts
@@ -84,11 +84,14 @@ test.describe('UI: /my/drive/file/:fileId delete flow', () => {
     });
     await deleteResp;
 
-    // 5. API 経由で 削除確認 — show は 404 を返す
+    // 5. API 経由で 削除確認 — drive/files/show は削除済 file に対して
+    // 404 + NO_SUCH_FILE error code を返す (handler.go:466 確認)。
     const showResp = await request.post(`${baseURL}/api/drive/files/show`, {
       ignoreHTTPSErrors: true,
       data: { i: root.token, fileId },
     });
-    expect(showResp.status()).toBeGreaterThanOrEqual(400);
+    expect(showResp.status()).toBe(404);
+    const showBody = await showResp.json();
+    expect(showBody.error?.code).toBe('NO_SUCH_FILE');
   });
 });

--- a/tests/playwright/specs/ui/drive_file_delete.spec.ts
+++ b/tests/playwright/specs/ui/drive_file_delete.spec.ts
@@ -85,7 +85,10 @@ test.describe('UI: /my/drive/file/:fileId delete flow', () => {
     await deleteResp;
 
     // 5. API 経由で 削除確認 — drive/files/show は削除済 file に対して
-    // 404 + NO_SUCH_FILE error code を返す (handler.go:466 確認)。
+    // 404 + NO_SUCH_FILE error code + 固定 UUID を返す (handler.go:466
+    // 確認)。code に加えて UUID も verify することで code rename 系の
+    // refactor regression も catch する。UUID は upstream Misskey TS と
+    // 一致する Misskey-compat ID なので drift 検出にも有効。
     const showResp = await request.post(`${baseURL}/api/drive/files/show`, {
       ignoreHTTPSErrors: true,
       data: { i: root.token, fileId },
@@ -93,5 +96,6 @@ test.describe('UI: /my/drive/file/:fileId delete flow', () => {
     expect(showResp.status()).toBe(404);
     const showBody = await showResp.json();
     expect(showBody.error?.code).toBe('NO_SUCH_FILE');
+    expect(showBody.error?.id).toBe('067bc436-2718-4795-b0fb-ecbe43949e31');
   });
 });

--- a/tests/playwright/specs/ui/drive_file_describe_save.spec.ts
+++ b/tests/playwright/specs/ui/drive_file_describe_save.spec.ts
@@ -105,19 +105,18 @@ test.describe('UI: /my/drive/file/:fileId describe save flow', () => {
       target.dispatchEvent(new Event('input', { bubbles: true }));
     }, caption);
 
-    // 5. OK button (MkModalWindow `:withOkButton` で footer に primary OK)
-    // → drive/files/update が走る
+    // 5. OK button → drive/files/update が走る。MkModalWindow.vue:15 の OK
+    // button は `{{ i18n.ts.done }} <i class="ti ti-check">` で text は
+    // i18n 依存 ("Done" / "完了" 等) だが ti-check icon は固定。/my/drive/file
+    // 詳細 page には他の ti-check icon button が無いので構造ベースで安定。
     const updateResp = page.waitForResponse(
       (r) => r.url().includes('/api/drive/files/update') && r.status() < 300,
       { timeout: 15_000 },
     );
-    // MkModalWindow の OK は data-cy- ではなく primary text "Ok" / "OK"。
-    // 念のため textContent で当てる。
     await page.evaluate(() => {
       const btns = Array.from(document.querySelectorAll('button')) as HTMLButtonElement[];
       const ok = btns.find(
-        (b) =>
-          !b.disabled && /^(Ok|OK|オーケー)$/i.test((b.textContent ?? '').trim()),
+        (b) => !b.disabled && b.querySelector('i.ti-check') !== null,
       );
       ok?.click();
     });

--- a/tests/playwright/specs/ui/drive_file_describe_save.spec.ts
+++ b/tests/playwright/specs/ui/drive_file_describe_save.spec.ts
@@ -9,6 +9,7 @@
 
 import { readFileSync } from 'node:fs';
 import { expect, test } from '@playwright/test';
+import { uploadTinyPNG } from '../../fixtures/files';
 import { type RootFixture, uiSigninAsRoot } from '../../fixtures/ui_auth';
 
 test.describe('UI: /my/drive/file/:fileId describe save flow', () => {
@@ -24,25 +25,8 @@ test.describe('UI: /my/drive/file/:fileId describe save flow', () => {
     request,
   }) => {
     // 1. test 用 file を upload
-    const fileName = `pw-cap-${Date.now()}.png`;
-    const uploadResp = await request.post(`${baseURL}/api/drive/files/create`, {
-      ignoreHTTPSErrors: true,
-      multipart: {
-        i: root.token,
-        file: {
-          name: fileName,
-          mimeType: 'image/png',
-          buffer: Buffer.from(
-            'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNkYAAAAAYAAjCB0C8AAAAASUVORK5CYII=',
-            'base64',
-          ),
-        },
-      },
-    });
-    expect(uploadResp.status()).toBe(200);
-    const file = await uploadResp.json();
-    const fileId: string = file.id;
-    expect(fileId).toBeTruthy();
+    const file = await uploadTinyPNG(request, baseURL!, root.token, `pw-cap-${Date.now()}.png`);
+    const fileId = file.id;
 
     // 2. detail page open
     await uiSigninAsRoot(page, baseURL, root);

--- a/tests/playwright/specs/ui/drive_file_describe_save.spec.ts
+++ b/tests/playwright/specs/ui/drive_file_describe_save.spec.ts
@@ -1,0 +1,135 @@
+// /my/drive/file/:fileId で description button (kvEditBtn) → MkModalWindow
+// (MkFileCaptionEditWindow) → caption textarea 編集 → OK → /api/drive/files/update
+// で comment 更新が round-trip する write-flow spec。
+//
+// drive.file.info.vue:182 の describe() は os.popupAsyncWithDialog で
+// MkFileCaptionEditWindow を popup する。dialog 内には MkTextarea (autofocus)
+// が 1 つあり、OK click で `done(caption)` callback → comment field を
+// drive/files/update に流す (空文字なら null clear)。
+
+import { readFileSync } from 'node:fs';
+import { expect, test } from '@playwright/test';
+import { type RootFixture, uiSigninAsRoot } from '../../fixtures/ui_auth';
+
+test.describe('UI: /my/drive/file/:fileId describe save flow', () => {
+  let root: RootFixture;
+  test.beforeAll(() => {
+    root = JSON.parse(readFileSync('.auth/root.json', 'utf-8'));
+  });
+  test.setTimeout(60_000);
+
+  test('describe button → caption textarea → OK → /api/drive/files/update', async ({
+    page,
+    baseURL,
+    request,
+  }) => {
+    // 1. test 用 file を upload
+    const fileName = `pw-cap-${Date.now()}.png`;
+    const uploadResp = await request.post(`${baseURL}/api/drive/files/create`, {
+      ignoreHTTPSErrors: true,
+      multipart: {
+        i: root.token,
+        file: {
+          name: fileName,
+          mimeType: 'image/png',
+          buffer: Buffer.from(
+            'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNkYAAAAAYAAjCB0C8AAAAASUVORK5CYII=',
+            'base64',
+          ),
+        },
+      },
+    });
+    expect(uploadResp.status()).toBe(200);
+    const file = await uploadResp.json();
+    const fileId: string = file.id;
+    expect(fileId).toBeTruthy();
+
+    // 2. detail page open
+    await uiSigninAsRoot(page, baseURL, root);
+    const resp = await page.goto(`${baseURL}/my/drive/file/${fileId}`, {
+      waitUntil: 'domcontentloaded',
+    });
+    expect(resp!.status()).toBe(200);
+
+    // hydrate を file 名で確認
+    await page.waitForFunction(
+      (n) => document.body.textContent?.includes(n) ?? false,
+      file.name,
+      { timeout: 20_000 },
+    );
+
+    // 3. describe button (= kvEditBtn 系のうち、内部に "Description" 文字列を
+    // 含む button) を click。drive.file.info.vue にはレイアウト上 2 つの
+    // kvEditBtn (move folder / describe) があり、describe は MkKeyValue
+    // の key text が "Description"。最初の hit で当てる。
+    await page.waitForFunction(
+      () => {
+        const btns = Array.from(document.querySelectorAll('button')) as HTMLButtonElement[];
+        return btns.some(
+          (b) =>
+            (b.textContent ?? '').includes('Description') &&
+            b.querySelector('i.ti-pencil') !== null,
+        );
+      },
+      { timeout: 15_000 },
+    );
+    await page.evaluate(() => {
+      const btns = Array.from(document.querySelectorAll('button')) as HTMLButtonElement[];
+      const target = btns.find(
+        (b) =>
+          (b.textContent ?? '').includes('Description') &&
+          b.querySelector('i.ti-pencil') !== null,
+      );
+      target?.click();
+    });
+
+    // 4. MkModalWindow + MkTextarea が出現するまで待つ。caption textarea は
+    // autofocus 属性付き。テキスト入力は post_note.spec.ts と同じ native
+    // value setter pattern。
+    await page.waitForFunction(
+      () => document.querySelectorAll('textarea').length >= 1,
+      { timeout: 10_000 },
+    );
+
+    const caption = `pw-caption-${Date.now()}`;
+    await page.evaluate((c) => {
+      const tas = Array.from(document.querySelectorAll('textarea')) as HTMLTextAreaElement[];
+      const target = tas[tas.length - 1];
+      if (!target) return;
+      target.focus();
+      const setter = Object.getOwnPropertyDescriptor(
+        window.HTMLTextAreaElement.prototype,
+        'value',
+      )?.set;
+      setter?.call(target, c);
+      target.dispatchEvent(new Event('input', { bubbles: true }));
+    }, caption);
+
+    // 5. OK button (MkModalWindow `:withOkButton` で footer に primary OK)
+    // → drive/files/update が走る
+    const updateResp = page.waitForResponse(
+      (r) => r.url().includes('/api/drive/files/update') && r.status() < 300,
+      { timeout: 15_000 },
+    );
+    // MkModalWindow の OK は data-cy- ではなく primary text "Ok" / "OK"。
+    // 念のため textContent で当てる。
+    await page.evaluate(() => {
+      const btns = Array.from(document.querySelectorAll('button')) as HTMLButtonElement[];
+      const ok = btns.find(
+        (b) =>
+          !b.disabled && /^(Ok|OK|オーケー)$/i.test((b.textContent ?? '').trim()),
+      );
+      ok?.click();
+    });
+    await updateResp;
+
+    // 6. API 経由で comment 反映 verify
+    const showResp = await request.post(`${baseURL}/api/drive/files/show`, {
+      ignoreHTTPSErrors: true,
+      data: { i: root.token, fileId },
+    });
+    expect(showResp.status()).toBe(200);
+    const shown = await showResp.json();
+    expect(shown.comment).toBe(caption);
+  });
+});

--- a/tests/playwright/specs/ui/drive_file_detail_render.spec.ts
+++ b/tests/playwright/specs/ui/drive_file_detail_render.spec.ts
@@ -7,6 +7,7 @@
 
 import { readFileSync } from 'node:fs';
 import { expect, test } from '@playwright/test';
+import { uploadTinyPNG } from '../../fixtures/files';
 import { type RootFixture, uiSigninAsRoot } from '../../fixtures/ui_auth';
 
 test.describe('UI: /my/drive/file/:fileId hydrates file metadata', () => {
@@ -25,25 +26,8 @@ test.describe('UI: /my/drive/file/:fileId hydrates file metadata', () => {
     // 検証する (= 自分が指定した name と一致するとは限らない)。本 spec の
     // scope は drive file detail page hydration の smoke なので、ID で
     // 引いた file の name が body に出れば十分。
-    const fileName = `pw-drive-detail-${Date.now()}.png`;
-    const driveResp = await request.post(`${baseURL}/api/drive/files/create`, {
-      ignoreHTTPSErrors: true,
-      multipart: {
-        i: root.token,
-        file: {
-          name: fileName,
-          mimeType: 'image/png',
-          buffer: Buffer.from(
-            'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNkYAAAAAYAAjCB0C8AAAAASUVORK5CYII=',
-            'base64',
-          ),
-        },
-      },
-    });
-    expect(driveResp.status()).toBe(200);
-    const file = await driveResp.json();
-    expect(file.id, 'drive/files/create should return file id').toBeTruthy();
-    const actualName: string = file.name;
+    const file = await uploadTinyPNG(request, baseURL!, root.token, `pw-drive-detail-${Date.now()}.png`);
+    const actualName = file.name;
     expect(typeof actualName).toBe('string');
 
     await uiSigninAsRoot(page, baseURL, root);

--- a/tests/playwright/specs/ui/drive_file_rename.spec.ts
+++ b/tests/playwright/specs/ui/drive_file_rename.spec.ts
@@ -1,0 +1,128 @@
+// /my/drive/file/:fileId で rename ボタンを click → MkDialog の
+// inputText で新しい file 名を入れて OK → /api/drive/files/update が
+// 走り、API GET で名前が更新されていることを verify する write-flow spec。
+//
+// drive.file.info.vue の rename() は os.inputText の resolve 後に
+// os.apiWithDialog('drive/files/update', { fileId, name }) を呼ぶ。
+// dialog は単一の MkInput type='text' 1 個だけなので、現れた input に
+// 値を投入して MkDialog の OK を click すれば round-trip が走る。
+
+import { readFileSync } from 'node:fs';
+import { expect, test } from '@playwright/test';
+import { type RootFixture, uiSigninAsRoot } from '../../fixtures/ui_auth';
+
+test.describe('UI: /my/drive/file/:fileId rename round-trip', () => {
+  let root: RootFixture;
+
+  test.beforeAll(() => {
+    root = JSON.parse(readFileSync('.auth/root.json', 'utf-8'));
+  });
+
+  test.setTimeout(60_000);
+
+  test('rename button → inputText dialog → drive/files/update', async ({
+    page,
+    baseURL,
+    request,
+  }) => {
+    // 1. test 用 drive file を upload
+    const initialName = `pw-rename-${Date.now()}.png`;
+    const driveResp = await request.post(`${baseURL}/api/drive/files/create`, {
+      ignoreHTTPSErrors: true,
+      multipart: {
+        i: root.token,
+        file: {
+          name: initialName,
+          mimeType: 'image/png',
+          buffer: Buffer.from(
+            'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNkYAAAAAYAAjCB0C8AAAAASUVORK5CYII=',
+            'base64',
+          ),
+        },
+      },
+    });
+    expect(driveResp.status()).toBe(200);
+    const file = await driveResp.json();
+    const fileId: string = file.id;
+    const oldName: string = file.name;
+    expect(fileId).toBeTruthy();
+
+    // 2. detail page を開いて hydrate を待つ
+    await uiSigninAsRoot(page, baseURL, root);
+    const resp = await page.goto(`${baseURL}/my/drive/file/${fileId}`, {
+      waitUntil: 'domcontentloaded',
+    });
+    expect(resp!.status()).toBe(200);
+    await page.waitForFunction(
+      (n) => document.body.textContent?.includes(n) ?? false,
+      oldName,
+      { timeout: 20_000 },
+    );
+
+    // 3. rename ボタンを click。drive.file.info.vue の rename() ボタンは
+    // 「<h2> file name + <i.ti-pencil>」を子に持つ唯一の <button>。
+    // vite hash で class セレクタは production で死ぬので、構造で当てる。
+    await page.evaluate(() => {
+      const btns = Array.from(document.querySelectorAll('button')) as HTMLButtonElement[];
+      const renameBtn = btns.find(
+        (b) => b.querySelector('h2') !== null && b.querySelector('i.ti-pencil') !== null,
+      );
+      renameBtn?.click();
+    });
+
+    // 4. inputText dialog (= MkDialog with single MkInput type='text') を待つ
+    await page.waitForFunction(
+      () => {
+        const inputs = Array.from(
+          document.querySelectorAll('input'),
+        ) as HTMLInputElement[];
+        return inputs.some((i) => i.type === 'text');
+      },
+      { timeout: 10_000 },
+    );
+
+    // 5. 新しい file 名を input に投入
+    const newName = `pw-renamed-${Date.now()}.png`;
+    await page.evaluate((name) => {
+      const inputs = Array.from(
+        document.querySelectorAll('input'),
+      ) as HTMLInputElement[];
+      // dialog 内 input は最後に mount された text input。MkSuperMenu の
+      // search input (= settings layout) と被らないよう type=text のみ抽出。
+      const target = inputs.filter((i) => i.type === 'text').pop();
+      if (!target) return;
+      target.focus();
+      const setter = Object.getOwnPropertyDescriptor(
+        window.HTMLInputElement.prototype,
+        'value',
+      )?.set;
+      setter?.call(target, name);
+      target.dispatchEvent(new Event('input', { bubbles: true }));
+    }, newName);
+
+    // 6. MkDialog の OK button (data-cy-modal-dialog-ok) を click → update 呼出
+    const updateResp = page.waitForResponse(
+      (r) =>
+        r.url().includes('/api/drive/files/update') && r.status() < 300,
+      { timeout: 15_000 },
+    );
+    await page.evaluate(() => {
+      const ok = document.querySelector(
+        '[data-cy-modal-dialog-ok]',
+      ) as HTMLButtonElement | null;
+      ok?.click();
+    });
+    const update = await updateResp;
+    expect(update.status()).toBeLessThan(300);
+
+    // 7. API 経由で round-trip を verify
+    const showResp = await request.post(`${baseURL}/api/drive/files/show`, {
+      ignoreHTTPSErrors: true,
+      data: { i: root.token, fileId },
+    });
+    expect(showResp.status()).toBe(200);
+    const shown = await showResp.json();
+    expect(shown.id).toBe(fileId);
+    expect(shown.name).toBe(newName);
+  });
+});

--- a/tests/playwright/specs/ui/drive_file_rename.spec.ts
+++ b/tests/playwright/specs/ui/drive_file_rename.spec.ts
@@ -9,6 +9,7 @@
 
 import { readFileSync } from 'node:fs';
 import { expect, test } from '@playwright/test';
+import { uploadTinyPNG } from '../../fixtures/files';
 import { type RootFixture, uiSigninAsRoot } from '../../fixtures/ui_auth';
 
 test.describe('UI: /my/drive/file/:fileId rename round-trip', () => {
@@ -26,26 +27,9 @@ test.describe('UI: /my/drive/file/:fileId rename round-trip', () => {
     request,
   }) => {
     // 1. test 用 drive file を upload
-    const initialName = `pw-rename-${Date.now()}.png`;
-    const driveResp = await request.post(`${baseURL}/api/drive/files/create`, {
-      ignoreHTTPSErrors: true,
-      multipart: {
-        i: root.token,
-        file: {
-          name: initialName,
-          mimeType: 'image/png',
-          buffer: Buffer.from(
-            'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNkYAAAAAYAAjCB0C8AAAAASUVORK5CYII=',
-            'base64',
-          ),
-        },
-      },
-    });
-    expect(driveResp.status()).toBe(200);
-    const file = await driveResp.json();
-    const fileId: string = file.id;
-    const oldName: string = file.name;
-    expect(fileId).toBeTruthy();
+    const file = await uploadTinyPNG(request, baseURL!, root.token, `pw-rename-${Date.now()}.png`);
+    const fileId = file.id;
+    const oldName = file.name;
 
     // 2. detail page を開いて hydrate を待つ
     await uiSigninAsRoot(page, baseURL, root);

--- a/tests/playwright/specs/ui/drive_file_toggle_sensitive.spec.ts
+++ b/tests/playwright/specs/ui/drive_file_toggle_sensitive.spec.ts
@@ -1,0 +1,93 @@
+// /my/drive/file/:fileId で markAsSensitive ボタンを click → /api/drive/files/update
+// が走り isSensitive が反転することを verify する write-flow spec。
+//
+// drive.file.info.vue の toggleSensitive() は misskeyApi('drive/files/update',
+// { fileId, isSensitive: !file.isSensitive }) を直接呼ぶ (line 136)。dialog
+// は出ないので、button click → response 待ちで完結する。
+// button は v-if/v-else で 2 つ用意されており、現在 isSensitive=false のとき
+// `<i class="ti ti-eye-exclamation">` を持つ button (markAsSensitive) を
+// click する。
+
+import { readFileSync } from 'node:fs';
+import { expect, test } from '@playwright/test';
+import { type RootFixture, uiSigninAsRoot } from '../../fixtures/ui_auth';
+
+test.describe('UI: /my/drive/file/:fileId toggle sensitive flow', () => {
+  let root: RootFixture;
+  test.beforeAll(() => {
+    root = JSON.parse(readFileSync('.auth/root.json', 'utf-8'));
+  });
+  test.setTimeout(60_000);
+
+  test('click eye-exclamation button → /api/drive/files/update isSensitive=true', async ({
+    page,
+    baseURL,
+    request,
+  }) => {
+    // 1. test 用 file を upload (default で isSensitive=false)
+    const fileName = `pw-sens-${Date.now()}.png`;
+    const uploadResp = await request.post(`${baseURL}/api/drive/files/create`, {
+      ignoreHTTPSErrors: true,
+      multipart: {
+        i: root.token,
+        file: {
+          name: fileName,
+          mimeType: 'image/png',
+          buffer: Buffer.from(
+            'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNkYAAAAAYAAjCB0C8AAAAASUVORK5CYII=',
+            'base64',
+          ),
+        },
+      },
+    });
+    expect(uploadResp.status()).toBe(200);
+    const file = await uploadResp.json();
+    const fileId: string = file.id;
+    expect(fileId).toBeTruthy();
+
+    // dedupe で既存 file が isSensitive=true で返ってくる可能性があるため、
+    // まず API で false にリセットして spec 状態を deterministic にする。
+    await request.post(`${baseURL}/api/drive/files/update`, {
+      ignoreHTTPSErrors: true,
+      data: { i: root.token, fileId, isSensitive: false },
+    });
+
+    // 2. detail page を開いて hydrate を待つ
+    await uiSigninAsRoot(page, baseURL, root);
+    const resp = await page.goto(`${baseURL}/my/drive/file/${fileId}`, {
+      waitUntil: 'domcontentloaded',
+    });
+    expect(resp!.status()).toBe(200);
+
+    // markAsSensitive button (= ti-eye-exclamation icon、isSensitive=false の v-else 分岐)
+    await page.waitForFunction(
+      () => {
+        const btns = Array.from(document.querySelectorAll('button')) as HTMLButtonElement[];
+        return btns.some((b) => b.querySelector('i.ti-eye-exclamation') !== null);
+      },
+      { timeout: 20_000 },
+    );
+
+    // 3. button click → /api/drive/files/update 走る
+    const updateResp = page.waitForResponse(
+      (r) => r.url().includes('/api/drive/files/update') && r.status() < 300,
+      { timeout: 15_000 },
+    );
+    await page.evaluate(() => {
+      const btns = Array.from(document.querySelectorAll('button')) as HTMLButtonElement[];
+      const target = btns.find((b) => b.querySelector('i.ti-eye-exclamation') !== null);
+      target?.click();
+    });
+    await updateResp;
+
+    // 4. API 経由で isSensitive=true を verify
+    const showResp = await request.post(`${baseURL}/api/drive/files/show`, {
+      ignoreHTTPSErrors: true,
+      data: { i: root.token, fileId },
+    });
+    expect(showResp.status()).toBe(200);
+    const shown = await showResp.json();
+    expect(shown.id).toBe(fileId);
+    expect(shown.isSensitive).toBe(true);
+  });
+});

--- a/tests/playwright/specs/ui/drive_file_toggle_sensitive.spec.ts
+++ b/tests/playwright/specs/ui/drive_file_toggle_sensitive.spec.ts
@@ -10,6 +10,7 @@
 
 import { readFileSync } from 'node:fs';
 import { expect, test } from '@playwright/test';
+import { uploadTinyPNG } from '../../fixtures/files';
 import { type RootFixture, uiSigninAsRoot } from '../../fixtures/ui_auth';
 
 test.describe('UI: /my/drive/file/:fileId toggle sensitive flow', () => {
@@ -25,25 +26,8 @@ test.describe('UI: /my/drive/file/:fileId toggle sensitive flow', () => {
     request,
   }) => {
     // 1. test 用 file を upload (default で isSensitive=false)
-    const fileName = `pw-sens-${Date.now()}.png`;
-    const uploadResp = await request.post(`${baseURL}/api/drive/files/create`, {
-      ignoreHTTPSErrors: true,
-      multipart: {
-        i: root.token,
-        file: {
-          name: fileName,
-          mimeType: 'image/png',
-          buffer: Buffer.from(
-            'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNkYAAAAAYAAjCB0C8AAAAASUVORK5CYII=',
-            'base64',
-          ),
-        },
-      },
-    });
-    expect(uploadResp.status()).toBe(200);
-    const file = await uploadResp.json();
-    const fileId: string = file.id;
-    expect(fileId).toBeTruthy();
+    const file = await uploadTinyPNG(request, baseURL!, root.token, `pw-sens-${Date.now()}.png`);
+    const fileId = file.id;
 
     // dedupe で既存 file が isSensitive=true で返ってくる可能性があるため、
     // まず API で false にリセットして spec 状態を deterministic にする。

--- a/tests/playwright/specs/ui/flash_edit_save.spec.ts
+++ b/tests/playwright/specs/ui/flash_edit_save.spec.ts
@@ -1,0 +1,77 @@
+// /play/:id/edit で 既存 flash の title を変更 → Save click →
+// /api/flash/update round-trip する **真の write-flow** spec。
+
+import { readFileSync } from 'node:fs';
+import { expect, test } from '@playwright/test';
+import { callApi } from '../../fixtures/api';
+import { type RootFixture, uiSigninAsRoot } from '../../fixtures/ui_auth';
+
+test.describe('UI: /play/:id/edit update flow', () => {
+  let root: RootFixture;
+  test.beforeAll(() => {
+    root = JSON.parse(readFileSync('.auth/root.json', 'utf-8'));
+  });
+  test.setTimeout(60_000);
+
+  test('create flash via API → edit title → Save → /api/flash/update', async ({
+    page,
+    baseURL,
+    request,
+  }) => {
+    const initialTitle = `pwflash-init-${Date.now().toString().slice(-9)}`;
+    const createResp = await callApi(request, 'flash/create', {
+      i: root.token,
+      title: initialTitle,
+      summary: '',
+      script: '/// @ 1.0.0',
+      permissions: [],
+      visibility: 'public',
+    });
+    expect(createResp.status()).toBe(200);
+    const flashId = (await createResp.json()).id;
+    expect(flashId).toBeTruthy();
+
+    await uiSigninAsRoot(page, baseURL, root);
+    await page.goto(`${baseURL}/play/${flashId}/edit`, { waitUntil: 'domcontentloaded' });
+
+    await page.waitForFunction(
+      (t) => {
+        const inputs = Array.from(document.querySelectorAll('input')) as HTMLInputElement[];
+        return inputs.some((i) => i.value === t);
+      },
+      initialTitle,
+      { timeout: 20_000 },
+    );
+
+    const newTitle = `pwflash-updated-${Date.now().toString().slice(-9)}`;
+    await page.evaluate(
+      ({ from, to }) => {
+        const target = (
+          Array.from(document.querySelectorAll('input')) as HTMLInputElement[]
+        ).find((i) => i.value === from);
+        if (!target) return;
+        target.focus();
+        const setter = Object.getOwnPropertyDescriptor(
+          window.HTMLInputElement.prototype,
+          'value',
+        )?.set;
+        setter?.call(target, to);
+        target.dispatchEvent(new Event('input', { bubbles: true }));
+      },
+      { from: initialTitle, to: newTitle },
+    );
+
+    const updateResp = page.waitForResponse(
+      (r) => r.url().includes('/api/flash/update') && r.status() < 400,
+      { timeout: 15_000 },
+    );
+    await page.evaluate(() => {
+      const btn = Array.from(document.querySelectorAll('button')).find((b) =>
+        (b.textContent ?? '').includes('Save'),
+      ) as HTMLButtonElement | undefined;
+      btn?.click();
+    });
+    const resp = await updateResp;
+    expect(resp.status()).toBeLessThan(400);
+  });
+});

--- a/tests/playwright/specs/ui/list_edit_save.spec.ts
+++ b/tests/playwright/specs/ui/list_edit_save.spec.ts
@@ -1,0 +1,86 @@
+// /my/lists/:listId で 既存 list の name を変更 → Save click →
+// /api/users/lists/update round-trip する **真の write-flow** spec。
+
+import { readFileSync } from 'node:fs';
+import { expect, test } from '@playwright/test';
+import { callApi } from '../../fixtures/api';
+import { type RootFixture, uiSigninAsRoot } from '../../fixtures/ui_auth';
+
+test.describe('UI: /my/lists/:listId update flow', () => {
+  let root: RootFixture;
+  test.beforeAll(() => {
+    root = JSON.parse(readFileSync('.auth/root.json', 'utf-8'));
+  });
+  test.setTimeout(60_000);
+
+  test('create list via API → edit name → Save → /api/users/lists/update', async ({
+    page,
+    baseURL,
+    request,
+  }) => {
+    const initialName = `pwlist-init-${Date.now().toString().slice(-9)}`;
+    const createResp = await callApi(request, 'users/lists/create', {
+      i: root.token,
+      name: initialName,
+    });
+    expect(createResp.status()).toBe(200);
+    const listId = (await createResp.json()).id;
+    expect(listId).toBeTruthy();
+
+    await uiSigninAsRoot(page, baseURL, root);
+    await page.goto(`${baseURL}/my/lists/${listId}`, { waitUntil: 'domcontentloaded' });
+
+    // /my/lists/:id の "Settings" MkFolder は defaultOpen ではないので
+    // まず folder header を click して expand する。
+    await page.waitForFunction(
+      () => document.querySelector('[data-cy-folder-header]') !== null,
+      { timeout: 20_000 },
+    );
+    await page.evaluate(() => {
+      const header = document.querySelector('[data-cy-folder-header]') as
+        | HTMLButtonElement
+        | null;
+      header?.click();
+    });
+
+    await page.waitForFunction(
+      (n) => {
+        const inputs = Array.from(document.querySelectorAll('input')) as HTMLInputElement[];
+        return inputs.some((i) => i.value === n);
+      },
+      initialName,
+      { timeout: 10_000 },
+    );
+
+    const newName = `pwlist-updated-${Date.now().toString().slice(-9)}`;
+    await page.evaluate(
+      ({ from, to }) => {
+        const target = (
+          Array.from(document.querySelectorAll('input')) as HTMLInputElement[]
+        ).find((i) => i.value === from);
+        if (!target) return;
+        target.focus();
+        const setter = Object.getOwnPropertyDescriptor(
+          window.HTMLInputElement.prototype,
+          'value',
+        )?.set;
+        setter?.call(target, to);
+        target.dispatchEvent(new Event('input', { bubbles: true }));
+      },
+      { from: initialName, to: newName },
+    );
+
+    const updateResp = page.waitForResponse(
+      (r) => r.url().includes('/api/users/lists/update') && r.status() < 400,
+      { timeout: 15_000 },
+    );
+    await page.evaluate(() => {
+      const btn = Array.from(document.querySelectorAll('button')).find((b) =>
+        (b.textContent ?? '').includes('Save'),
+      ) as HTMLButtonElement | undefined;
+      btn?.click();
+    });
+    const resp = await updateResp;
+    expect(resp.status()).toBeLessThan(400);
+  });
+});

--- a/tests/playwright/specs/ui/notifications_mark_all_read.spec.ts
+++ b/tests/playwright/specs/ui/notifications_mark_all_read.spec.ts
@@ -1,0 +1,53 @@
+// /my/notifications で header の "Mark all as read" button click →
+// /api/notifications/mark-all-as-read round-trip する **真の write-flow** spec。
+//
+// notifications.vue の headerActions に "Mark all as read" (icon ti-check)
+// が定義されていて (line 71-77)、tab='all' のときだけ visible。本 spec は
+// 通知 0 件でも button click で API は走ること (= empty state でも UI が
+// stale で hang しない) を verify する。
+
+import { readFileSync } from 'node:fs';
+import { expect, test } from '@playwright/test';
+import { type RootFixture, uiSigninAsRoot } from '../../fixtures/ui_auth';
+
+test.describe('UI: /my/notifications mark-all-as-read flow', () => {
+  let root: RootFixture;
+  test.beforeAll(() => {
+    root = JSON.parse(readFileSync('.auth/root.json', 'utf-8'));
+  });
+  test.setTimeout(60_000);
+
+  test('click mark-all-as-read header → /api/notifications/mark-all-as-read', async ({
+    page,
+    baseURL,
+  }) => {
+    await uiSigninAsRoot(page, baseURL, root);
+    await page.goto(`${baseURL}/my/notifications`, { waitUntil: 'domcontentloaded' });
+
+    // header action "Mark all as read" は icon ti-check の icon-only button
+    // (tooltip text のみ、textContent は空)。ti-check icon を持つ button を
+    // header から取る。
+    await page.waitForFunction(
+      () => document.querySelector('button i.ti-check') !== null,
+      { timeout: 20_000 },
+    );
+
+    // mk-go (notifications/handler.go) は成功時 204 を返す。upstream Misskey
+    // TS は 200 で response body 無し。drop-in 互換で 200/204 両方を accept。
+    const markResp = page.waitForResponse(
+      (r) =>
+        r.url().includes('/api/notifications/mark-all-as-read') && r.status() < 300,
+      { timeout: 15_000 },
+    );
+    await page.evaluate(() => {
+      // header の filter / mark-all-as-read 2 button が並ぶ。filter は
+      // ti-filter icon、mark-all-as-read は ti-check icon。
+      const btn = (document.querySelector('button i.ti-check')?.closest('button')) as
+        | HTMLButtonElement
+        | null;
+      btn?.click();
+    });
+    const resp = await markResp;
+    expect(resp.status()).toBeLessThan(300);
+  });
+});

--- a/tests/playwright/specs/ui/page_edit_save.spec.ts
+++ b/tests/playwright/specs/ui/page_edit_save.spec.ts
@@ -1,0 +1,87 @@
+// /pages/edit/:id で 既存 page の title を変更 → Save click →
+// /api/pages/update round-trip する **真の write-flow** spec。
+//
+// API setup: pages/create で新 page を 1 つ作る (= alice の page)。次に
+// /pages/edit/:id に navigate して page-editor.vue が hydrate されたら
+// title input を書き換え、Save click。
+
+import { readFileSync } from 'node:fs';
+import { expect, test } from '@playwright/test';
+import { callApi } from '../../fixtures/api';
+import { type RootFixture, uiSigninAsRoot } from '../../fixtures/ui_auth';
+
+test.describe('UI: /pages/edit/:id update form flow', () => {
+  let root: RootFixture;
+  test.beforeAll(() => {
+    root = JSON.parse(readFileSync('.auth/root.json', 'utf-8'));
+  });
+  test.setTimeout(60_000);
+
+  test('create via API → edit page title → Save → /api/pages/update', async ({
+    page,
+    baseURL,
+    request,
+  }) => {
+    // setup: 編集対象の page を 1 つ作成
+    const initialTitle = `pwpage-init-${Date.now().toString().slice(-9)}`;
+    const slug = `pwpageed${Date.now().toString().slice(-9)}`;
+    const createResp = await callApi(request, 'pages/create', {
+      i: root.token,
+      title: initialTitle,
+      name: slug,
+      content: [],
+      variables: [],
+      script: '',
+    });
+    expect(createResp.status()).toBe(200);
+    const created = await createResp.json();
+    const pageId = created.id;
+    expect(pageId).toBeTruthy();
+
+    await uiSigninAsRoot(page, baseURL, root);
+    await page.goto(`${baseURL}/pages/edit/${pageId}`, { waitUntil: 'domcontentloaded' });
+
+    // page editor の title MkInput が initialTitle で hydrate
+    await page.waitForFunction(
+      (t) => {
+        const inputs = Array.from(document.querySelectorAll('input')) as HTMLInputElement[];
+        return inputs.some((i) => i.value === t);
+      },
+      initialTitle,
+      { timeout: 20_000 },
+    );
+
+    // title を書き換え
+    const newTitle = `pwpage-updated-${Date.now().toString().slice(-9)}`;
+    await page.evaluate(
+      ({ from, to }) => {
+        const target = (
+          Array.from(document.querySelectorAll('input')) as HTMLInputElement[]
+        ).find((i) => i.value === from);
+        if (!target) return;
+        target.focus();
+        const setter = Object.getOwnPropertyDescriptor(
+          window.HTMLInputElement.prototype,
+          'value',
+        )?.set;
+        setter?.call(target, to);
+        target.dispatchEvent(new Event('input', { bubbles: true }));
+      },
+      { from: initialTitle, to: newTitle },
+    );
+
+    // pages/update response 捕捉して Save click
+    const updateResp = page.waitForResponse(
+      (r) => r.url().includes('/api/pages/update') && r.status() < 400,
+      { timeout: 15_000 },
+    );
+    await page.evaluate(() => {
+      const btn = Array.from(document.querySelectorAll('button')).find((b) =>
+        (b.textContent ?? '').includes('Save'),
+      ) as HTMLButtonElement | undefined;
+      btn?.click();
+    });
+    const resp = await updateResp;
+    expect(resp.status()).toBeLessThan(400);
+  });
+});

--- a/tests/playwright/specs/ui/profile_birthday_save.spec.ts
+++ b/tests/playwright/specs/ui/profile_birthday_save.spec.ts
@@ -36,11 +36,12 @@ test.describe('UI: /settings/profile birthday save flow', () => {
     );
 
     // YYYY-MM-DD format。run ごとに変わる値で実機 round-trip を担保する
-    // (累積実行で同 値が連続すると "保存しない" 判定で hit する可能性を
-    // 回避するため、1990 〜 2010 の range で deterministic にズラす)。
-    const epochDay = Math.floor(Date.now() / (1000 * 60 * 60 * 24));
-    const dayInRange = epochDay % 365;
-    const year = 1990 + (epochDay % 21);
+    // (連続 run で同値だと "未変更" 判定で MkInput の Save button が出ず
+    // timeout する)。秒単位の resolution で 1990 〜 2010 範囲をズラすので、
+    // 同秒内連続 run でない限り値が衝突しない。
+    const seconds = Math.floor(Date.now() / 1000);
+    const dayInRange = seconds % 365;
+    const year = 1990 + (seconds % 21);
     const baseDate = new Date(year, 0, 1);
     baseDate.setDate(baseDate.getDate() + dayInRange);
     const newBirthday = `${baseDate.getFullYear()}-${String(baseDate.getMonth() + 1).padStart(2, '0')}-${String(baseDate.getDate()).padStart(2, '0')}`;

--- a/tests/playwright/specs/ui/profile_birthday_save.spec.ts
+++ b/tests/playwright/specs/ui/profile_birthday_save.spec.ts
@@ -1,0 +1,93 @@
+// /settings/profile で birthday MkInput (type="date", manualSave) を編集
+// → save click → /api/i/update + /api/i 両方で新 birthday が反映されることを
+// verify する write-flow spec。
+//
+// /settings/profile 内の type="date" input は唯一 profile.birthday なので
+// `i.type === 'date'` filter で曖昧性なく当てられる。manualSave なので
+// 値変更後に "Save" button が出現する流れは profile_name_save と同 pattern。
+
+import { readFileSync } from 'node:fs';
+import { expect, test } from '@playwright/test';
+import { callApi } from '../../fixtures/api';
+import { type RootFixture, uiSigninAsRoot } from '../../fixtures/ui_auth';
+
+test.describe('UI: /settings/profile birthday save flow', () => {
+  let root: RootFixture;
+  test.beforeAll(() => {
+    root = JSON.parse(readFileSync('.auth/root.json', 'utf-8'));
+  });
+  test.setTimeout(60_000);
+
+  test('edit birthday → save → i/update + /api/i both reflect', async ({
+    page,
+    baseURL,
+    request,
+  }) => {
+    await uiSigninAsRoot(page, baseURL, root);
+    await page.goto(`${baseURL}/settings/profile`, { waitUntil: 'domcontentloaded' });
+
+    // birthday input (type="date") が hydrate するまで待つ
+    await page.waitForFunction(
+      () => {
+        const inputs = Array.from(document.querySelectorAll('input')) as HTMLInputElement[];
+        return inputs.some((i) => i.type === 'date');
+      },
+      { timeout: 20_000 },
+    );
+
+    // YYYY-MM-DD format。run ごとに変わる値で実機 round-trip を担保する
+    // (累積実行で同 値が連続すると "保存しない" 判定で hit する可能性を
+    // 回避するため、1990 〜 2010 の range で deterministic にズラす)。
+    const epochDay = Math.floor(Date.now() / (1000 * 60 * 60 * 24));
+    const dayInRange = epochDay % 365;
+    const year = 1990 + (epochDay % 21);
+    const baseDate = new Date(year, 0, 1);
+    baseDate.setDate(baseDate.getDate() + dayInRange);
+    const newBirthday = `${baseDate.getFullYear()}-${String(baseDate.getMonth() + 1).padStart(2, '0')}-${String(baseDate.getDate()).padStart(2, '0')}`;
+
+    await page.evaluate((b) => {
+      const inputs = (Array.from(document.querySelectorAll('input')) as HTMLInputElement[]).filter(
+        (i) => i.type === 'date',
+      );
+      const target = inputs[0];
+      if (!target) return;
+      target.focus();
+      const setter = Object.getOwnPropertyDescriptor(
+        window.HTMLInputElement.prototype,
+        'value',
+      )?.set;
+      setter?.call(target, b);
+      target.dispatchEvent(new Event('input', { bubbles: true }));
+      target.dispatchEvent(new Event('change', { bubbles: true }));
+    }, newBirthday);
+
+    // manualSave button の出現を待つ
+    await page.waitForFunction(
+      () => {
+        const btns = Array.from(document.querySelectorAll('button'));
+        return btns.some((b) => (b.textContent ?? '').includes('Save'));
+      },
+      { timeout: 10_000 },
+    );
+
+    const updateResp = page.waitForResponse(
+      (r) => r.url().includes('/api/i/update') && r.status() === 200,
+      { timeout: 15_000 },
+    );
+    await page.evaluate(() => {
+      const btn = Array.from(document.querySelectorAll('button')).find((b) =>
+        (b.textContent ?? '').includes('Save'),
+      ) as HTMLButtonElement | undefined;
+      btn?.click();
+    });
+    const update = await updateResp;
+    const updateBody = await update.json();
+    expect(updateBody.birthday).toBe(newBirthday);
+
+    // /api/i でも反映されること (= tokenCache invalidation, #960)
+    const meResp = await callApi(request, 'i', { i: root.token });
+    expect(meResp.status()).toBe(200);
+    const me = await meResp.json();
+    expect(me.birthday).toBe(newBirthday);
+  });
+});

--- a/tests/playwright/specs/ui/profile_followed_message_save.spec.ts
+++ b/tests/playwright/specs/ui/profile_followed_message_save.spec.ts
@@ -1,0 +1,83 @@
+// /settings/profile で followedMessage MkInput (manualSave 3rd text input) を
+// 編集 → save click → /api/i/update + /api/i 両方で新 followedMessage が反映
+// されることを verify する write-flow spec。
+//
+// /settings/profile の type=text 入力順 (collapsed folder 前提):
+//   inputs[0] = profile.name
+//   inputs[1] = profile.location
+//   inputs[2] = profile.followedMessage  ← 本 spec の対象
+// fields metadata は MkFolder 内 (デフォルト folded) なので index は安定。
+
+import { readFileSync } from 'node:fs';
+import { expect, test } from '@playwright/test';
+import { callApi } from '../../fixtures/api';
+import { type RootFixture, uiSigninAsRoot } from '../../fixtures/ui_auth';
+
+test.describe('UI: /settings/profile followedMessage save flow', () => {
+  let root: RootFixture;
+  test.beforeAll(() => {
+    root = JSON.parse(readFileSync('.auth/root.json', 'utf-8'));
+  });
+  test.setTimeout(60_000);
+
+  test('edit followedMessage → save → i/update + /api/i both reflect', async ({
+    page,
+    baseURL,
+    request,
+  }) => {
+    await uiSigninAsRoot(page, baseURL, root);
+    await page.goto(`${baseURL}/settings/profile`, { waitUntil: 'domcontentloaded' });
+
+    await page.waitForFunction(
+      () => {
+        const inputs = Array.from(document.querySelectorAll('input')) as HTMLInputElement[];
+        return inputs.filter((i) => i.type === 'text').length >= 3;
+      },
+      { timeout: 20_000 },
+    );
+
+    const newMsg = `pwfm-${Date.now().toString().slice(-9)}`;
+    await page.evaluate((msg) => {
+      const inputs = (Array.from(document.querySelectorAll('input')) as HTMLInputElement[]).filter(
+        (i) => i.type === 'text',
+      );
+      const target = inputs[2];
+      if (!target) return;
+      target.focus();
+      const setter = Object.getOwnPropertyDescriptor(
+        window.HTMLInputElement.prototype,
+        'value',
+      )?.set;
+      setter?.call(target, msg);
+      target.dispatchEvent(new Event('input', { bubbles: true }));
+      target.dispatchEvent(new Event('change', { bubbles: true }));
+    }, newMsg);
+
+    await page.waitForFunction(
+      () => {
+        const btns = Array.from(document.querySelectorAll('button'));
+        return btns.some((b) => (b.textContent ?? '').includes('Save'));
+      },
+      { timeout: 10_000 },
+    );
+
+    const updateResp = page.waitForResponse(
+      (r) => r.url().includes('/api/i/update') && r.status() === 200,
+      { timeout: 15_000 },
+    );
+    await page.evaluate(() => {
+      const btn = Array.from(document.querySelectorAll('button')).find((b) =>
+        (b.textContent ?? '').includes('Save'),
+      ) as HTMLButtonElement | undefined;
+      btn?.click();
+    });
+    const update = await updateResp;
+    const updateBody = await update.json();
+    expect(updateBody.followedMessage).toBe(newMsg);
+
+    const meResp = await callApi(request, 'i', { i: root.token });
+    expect(meResp.status()).toBe(200);
+    const me = await meResp.json();
+    expect(me.followedMessage).toBe(newMsg);
+  });
+});

--- a/tests/playwright/specs/ui/profile_isbot_toggle.spec.ts
+++ b/tests/playwright/specs/ui/profile_isbot_toggle.spec.ts
@@ -9,6 +9,7 @@
 
 import { readFileSync } from 'node:fs';
 import { expect, test } from '@playwright/test';
+import { callApi } from '../../fixtures/api';
 import { type RootFixture, uiSigninAsRoot } from '../../fixtures/ui_auth';
 
 test.describe('UI: /settings/profile isBot toggle flow', () => {
@@ -21,7 +22,11 @@ test.describe('UI: /settings/profile isBot toggle flow', () => {
   test('expand advancedSettings folder → toggle isBot → /api/i/update', async ({
     page,
     baseURL,
+    request,
   }) => {
+    // 値 strict assertion のため初期 state を false (= DB default) に reset。
+    await callApi(request, 'i/update', { i: root.token, isBot: false });
+
     await uiSigninAsRoot(page, baseURL, root);
     await page.goto(`${baseURL}/settings/profile`, {
       waitUntil: 'domcontentloaded',
@@ -64,9 +69,10 @@ test.describe('UI: /settings/profile isBot toggle flow', () => {
     }, beforeCheckboxes);
     const update = await updateResp;
     const body = await update.json();
-    // isBot は UserDetailed (= UserLite 由来 since IsBot is in MiUser) で
-    // /api/i/update 応答にも含まれる。値そのものは boolean を strict 確認。
+    // beforeAll の API reset で false から始まるので、click 後は必ず true
+    // (isBot は UserDetailed = UserLite 由来 field なので i/update body に
+    // 元から含まれる)。
     expect(body.id).toBeTruthy();
-    expect(typeof body.isBot).toBe('boolean');
+    expect(body.isBot).toBe(true);
   });
 });

--- a/tests/playwright/specs/ui/profile_isbot_toggle.spec.ts
+++ b/tests/playwright/specs/ui/profile_isbot_toggle.spec.ts
@@ -1,0 +1,72 @@
+// /settings/profile の "advancedSettings" MkFolder を expand → isBot
+// switch (folder 内 2 番目の checkbox) を toggle → /api/i/update が走る
+// write-flow spec。
+//
+// profile.vue の advancedSettings 折り畳み内には isCat / isBot 2 個の
+// MkSwitch があり、expand 後の checkbox 列の (folder 前 N 個) + 2 番目が
+// isBot。サインアップ直後は folder 前は 0 個なので isBot = index 1。
+// (profile.vue:142-147)
+
+import { readFileSync } from 'node:fs';
+import { expect, test } from '@playwright/test';
+import { type RootFixture, uiSigninAsRoot } from '../../fixtures/ui_auth';
+
+test.describe('UI: /settings/profile isBot toggle flow', () => {
+  let root: RootFixture;
+  test.beforeAll(() => {
+    root = JSON.parse(readFileSync('.auth/root.json', 'utf-8'));
+  });
+  test.setTimeout(60_000);
+
+  test('expand advancedSettings folder → toggle isBot → /api/i/update', async ({
+    page,
+    baseURL,
+  }) => {
+    await uiSigninAsRoot(page, baseURL, root);
+    await page.goto(`${baseURL}/settings/profile`, {
+      waitUntil: 'domcontentloaded',
+    });
+
+    await page.waitForFunction(
+      () => document.querySelectorAll('input').length >= 2,
+      { timeout: 20_000 },
+    );
+
+    const beforeCheckboxes = await page.evaluate(
+      () => document.querySelectorAll('input[type="checkbox"]').length,
+    );
+
+    // settings/profile の MkFolder は metadataEdit と advancedSettings の 2 つ。
+    // advancedSettings を expand したいので headers[1] を click (= 2 個目の
+    // folder)。 metadataEdit は 1 個目。
+    await page.evaluate(() => {
+      const headers = Array.from(
+        document.querySelectorAll('[data-cy-folder-header]'),
+      ) as HTMLElement[];
+      headers[1]?.click();
+    });
+    await page.waitForFunction(
+      (n) => document.querySelectorAll('input[type="checkbox"]').length >= n + 2,
+      beforeCheckboxes,
+      { timeout: 10_000 },
+    );
+
+    // isCat (index = beforeCheckboxes) の次 = isBot (index + 1)
+    const updateResp = page.waitForResponse(
+      (r) => r.url().includes('/api/i/update') && r.status() < 300,
+      { timeout: 15_000 },
+    );
+    await page.evaluate((before) => {
+      const cbs = Array.from(
+        document.querySelectorAll('input[type="checkbox"]'),
+      ) as HTMLInputElement[];
+      cbs[before + 1]?.click();
+    }, beforeCheckboxes);
+    const update = await updateResp;
+    const body = await update.json();
+    // isBot は UserDetailed (= UserLite 由来 since IsBot is in MiUser) で
+    // /api/i/update 応答にも含まれる。値そのものは boolean を strict 確認。
+    expect(body.id).toBeTruthy();
+    expect(typeof body.isBot).toBe('boolean');
+  });
+});

--- a/tests/playwright/specs/ui/profile_iscat_toggle.spec.ts
+++ b/tests/playwright/specs/ui/profile_iscat_toggle.spec.ts
@@ -11,6 +11,7 @@
 
 import { readFileSync } from 'node:fs';
 import { expect, test } from '@playwright/test';
+import { callApi } from '../../fixtures/api';
 import { type RootFixture, uiSigninAsRoot } from '../../fixtures/ui_auth';
 
 test.describe('UI: /settings/profile isCat toggle flow', () => {
@@ -23,7 +24,13 @@ test.describe('UI: /settings/profile isCat toggle flow', () => {
   test('expand advancedSettings folder → toggle isCat → /api/i/update', async ({
     page,
     baseURL,
+    request,
   }) => {
+    // 値 strict assertion を効かせるため、初期 state を false に reset。
+    // prior run の累積で isCat=true のまま残っていると click で false に
+    // 反転して期待と逆になるので、明示的に既知 state から始める。
+    await callApi(request, 'i/update', { i: root.token, isCat: false });
+
     await uiSigninAsRoot(page, baseURL, root);
     await page.goto(`${baseURL}/settings/profile`, {
       waitUntil: 'domcontentloaded',
@@ -35,25 +42,26 @@ test.describe('UI: /settings/profile isCat toggle flow', () => {
       { timeout: 20_000 },
     );
 
-    // 折りたたみ folder ("advancedSettings") を expand。folder 内には
-    // isCat / isBot の 2 個の MkSwitch (= input[type=checkbox]) があり、
-    // 折りたたみ状態では DOM に出ない (Vue の v-if 相当)。
-    // 「click 前 checkbox 数」を測ってから folder を click し、checkbox
-    // 数が 2 増えたことで expand 成功を verify する。
+    // settings/profile の MkFolder は metadataEdit (1 つ目) と
+    // advancedSettings (2 つ目) の 2 つ。advancedSettings の折りたたみ
+    // 内には isCat / isBot の 2 個の MkSwitch (= input[type=checkbox])
+    // があり、折りたたみ状態では DOM に出ない (Vue の v-if 相当)。
+    // 「click 前 checkbox 数」を測ってから headers[1] (= advancedSettings)
+    // を click し、checkbox 数が 2 増えたことで expand 成功を verify する。
+    // metadataEdit (headers[0]) を expand しても checkbox は増えないので
+    // 必ず headers[1] を選ぶこと (#969 review round の bug fix)。
     const beforeCheckboxes = await page.evaluate(
       () => document.querySelectorAll('input[type="checkbox"]').length,
     );
 
-    // settings/profile の MkFolder header は唯一: advancedSettings。
-    // [data-cy-folder-header] で取れる (MkFolder の標準 attribute)。
     await page.evaluate(() => {
       const headers = Array.from(
         document.querySelectorAll('[data-cy-folder-header]'),
       ) as HTMLElement[];
-      headers[0]?.click();
+      headers[1]?.click();
     });
     await page.waitForFunction(
-      (n) => document.querySelectorAll('input[type="checkbox"]').length > n,
+      (n) => document.querySelectorAll('input[type="checkbox"]').length >= n + 2,
       beforeCheckboxes,
       { timeout: 10_000 },
     );
@@ -72,10 +80,10 @@ test.describe('UI: /settings/profile isCat toggle flow', () => {
     }, beforeCheckboxes);
     const update = await updateResp;
     const body = await update.json();
-    // i/update は MeDetailed shape を返す (#969 で fix 済) 前提の strict
-    // assert: isCat field が boolean で含まれる。クリック前 false 期待
-    // だが prior run 累積で逆向きにもなり得るので boolean 型のみ確認。
+    // beforeAll の API reset で isCat=false から始まるので、click 後は
+    // 必ず true が返る strict assertion。i/update が MeDetailed shape を
+    // 返すことも併せて verify (#969)。
     expect(body.id).toBeTruthy();
-    expect(typeof body.isCat).toBe('boolean');
+    expect(body.isCat).toBe(true);
   });
 });

--- a/tests/playwright/specs/ui/profile_iscat_toggle.spec.ts
+++ b/tests/playwright/specs/ui/profile_iscat_toggle.spec.ts
@@ -1,0 +1,81 @@
+// /settings/profile の "advancedSettings" MkFolder を expand → isCat
+// switch を toggle → /api/i/update が走る write-flow spec。
+//
+// profile.vue の isCat / isBot は collapsed な MkFolder の中にいるため、
+// folder header を click して expand しないと switch が DOM に出ない。
+// expand 後の最初の checkbox が isCat、その次が isBot。
+//
+// page には deep watcher (= profile object 全体) が居り、isCat の v-model
+// 変化で `save()` が呼ばれて os.apiWithDialog('i/update', { isCat,... })
+// が走る (profile.vue:207-211)。
+
+import { readFileSync } from 'node:fs';
+import { expect, test } from '@playwright/test';
+import { type RootFixture, uiSigninAsRoot } from '../../fixtures/ui_auth';
+
+test.describe('UI: /settings/profile isCat toggle flow', () => {
+  let root: RootFixture;
+  test.beforeAll(() => {
+    root = JSON.parse(readFileSync('.auth/root.json', 'utf-8'));
+  });
+  test.setTimeout(60_000);
+
+  test('expand advancedSettings folder → toggle isCat → /api/i/update', async ({
+    page,
+    baseURL,
+  }) => {
+    await uiSigninAsRoot(page, baseURL, root);
+    await page.goto(`${baseURL}/settings/profile`, {
+      waitUntil: 'domcontentloaded',
+    });
+
+    // 最初の MkInput (= name) が hydrate するまで待つ
+    await page.waitForFunction(
+      () => document.querySelectorAll('input').length >= 2,
+      { timeout: 20_000 },
+    );
+
+    // 折りたたみ folder ("advancedSettings") を expand。folder 内には
+    // isCat / isBot の 2 個の MkSwitch (= input[type=checkbox]) があり、
+    // 折りたたみ状態では DOM に出ない (Vue の v-if 相当)。
+    // 「click 前 checkbox 数」を測ってから folder を click し、checkbox
+    // 数が 2 増えたことで expand 成功を verify する。
+    const beforeCheckboxes = await page.evaluate(
+      () => document.querySelectorAll('input[type="checkbox"]').length,
+    );
+
+    // settings/profile の MkFolder header は唯一: advancedSettings。
+    // [data-cy-folder-header] で取れる (MkFolder の標準 attribute)。
+    await page.evaluate(() => {
+      const headers = Array.from(
+        document.querySelectorAll('[data-cy-folder-header]'),
+      ) as HTMLElement[];
+      headers[0]?.click();
+    });
+    await page.waitForFunction(
+      (n) => document.querySelectorAll('input[type="checkbox"]').length > n,
+      beforeCheckboxes,
+      { timeout: 10_000 },
+    );
+
+    // folder 内最初の switch (= isCat) を click → i/update 走る
+    const updateResp = page.waitForResponse(
+      (r) => r.url().includes('/api/i/update') && r.status() < 300,
+      { timeout: 15_000 },
+    );
+    await page.evaluate((before) => {
+      const cbs = Array.from(
+        document.querySelectorAll('input[type="checkbox"]'),
+      ) as HTMLInputElement[];
+      // expand 前に居なかった checkbox 群の先頭が isCat
+      cbs[before]?.click();
+    }, beforeCheckboxes);
+    const update = await updateResp;
+    const body = await update.json();
+    // i/update は MeDetailed shape を返す (#969 で fix 済) 前提の strict
+    // assert: isCat field が boolean で含まれる。クリック前 false 期待
+    // だが prior run 累積で逆向きにもなり得るので boolean 型のみ確認。
+    expect(body.id).toBeTruthy();
+    expect(typeof body.isCat).toBe('boolean');
+  });
+});

--- a/tests/playwright/specs/ui/profile_location_save.spec.ts
+++ b/tests/playwright/specs/ui/profile_location_save.spec.ts
@@ -1,0 +1,84 @@
+// /settings/profile で location MkInput (manualSave 2nd text input) を編集
+// → save click → /api/i/update + /api/i 両方で新 location が反映されることを
+// verify する write-flow spec。
+//
+// /settings/profile の type=text 入力順 (collapsed folder 前提):
+//   inputs[0] = profile.name
+//   inputs[1] = profile.location  ← 本 spec の対象
+//   inputs[2] = profile.followedMessage
+// fields metadata は MkFolder 内 (デフォルト folded) なので index は安定。
+
+import { readFileSync } from 'node:fs';
+import { expect, test } from '@playwright/test';
+import { callApi } from '../../fixtures/api';
+import { type RootFixture, uiSigninAsRoot } from '../../fixtures/ui_auth';
+
+test.describe('UI: /settings/profile location save flow', () => {
+  let root: RootFixture;
+  test.beforeAll(() => {
+    root = JSON.parse(readFileSync('.auth/root.json', 'utf-8'));
+  });
+  test.setTimeout(60_000);
+
+  test('edit location → save → i/update + /api/i both reflect', async ({
+    page,
+    baseURL,
+    request,
+  }) => {
+    await uiSigninAsRoot(page, baseURL, root);
+    await page.goto(`${baseURL}/settings/profile`, { waitUntil: 'domcontentloaded' });
+
+    await page.waitForFunction(
+      () => {
+        const inputs = Array.from(document.querySelectorAll('input')) as HTMLInputElement[];
+        return inputs.filter((i) => i.type === 'text').length >= 2;
+      },
+      { timeout: 20_000 },
+    );
+
+    const newLocation = `pwloc-${Date.now().toString().slice(-9)}`;
+    await page.evaluate((loc) => {
+      const inputs = (Array.from(document.querySelectorAll('input')) as HTMLInputElement[]).filter(
+        (i) => i.type === 'text',
+      );
+      const target = inputs[1];
+      if (!target) return;
+      target.focus();
+      const setter = Object.getOwnPropertyDescriptor(
+        window.HTMLInputElement.prototype,
+        'value',
+      )?.set;
+      setter?.call(target, loc);
+      target.dispatchEvent(new Event('input', { bubbles: true }));
+      target.dispatchEvent(new Event('change', { bubbles: true }));
+    }, newLocation);
+
+    await page.waitForFunction(
+      () => {
+        const btns = Array.from(document.querySelectorAll('button'));
+        return btns.some((b) => (b.textContent ?? '').includes('Save'));
+      },
+      { timeout: 10_000 },
+    );
+
+    const updateResp = page.waitForResponse(
+      (r) => r.url().includes('/api/i/update') && r.status() === 200,
+      { timeout: 15_000 },
+    );
+    await page.evaluate(() => {
+      const btn = Array.from(document.querySelectorAll('button')).find((b) =>
+        (b.textContent ?? '').includes('Save'),
+      ) as HTMLButtonElement | undefined;
+      btn?.click();
+    });
+    const update = await updateResp;
+    const updateBody = await update.json();
+    expect(updateBody.location).toBe(newLocation);
+
+    // /api/i でも反映されること (= tokenCache invalidation, #960)
+    const meResp = await callApi(request, 'i', { i: root.token });
+    expect(meResp.status()).toBe(200);
+    const me = await meResp.json();
+    expect(me.location).toBe(newLocation);
+  });
+});

--- a/tests/playwright/specs/ui/settings_email_receive_announcement_toggle.spec.ts
+++ b/tests/playwright/specs/ui/settings_email_receive_announcement_toggle.spec.ts
@@ -1,0 +1,59 @@
+// /settings/email で receiveAnnouncementEmail switch (1st) を click →
+// /api/i/update が round-trip する write-flow spec。
+//
+// email.vue:26 の MkSwitch :modelValue="$i.receiveAnnouncementEmail" は
+// 直接 i/update を叩く onChangeReceiveAnnouncementEmail を呼ぶ
+// (manualSave じゃない、即時保存)。switch 順は receiveAnnouncementEmail /
+// emailNotification_* (5個) の計 6 で、本 spec は 1 番目を toggle する。
+//
+// #973 (PR fix #972) で i/update が receiveAnnouncementEmail を accept する
+// ように修正されたので、value 反映を strict assertion で verify できる。
+
+import { readFileSync } from 'node:fs';
+import { expect, test } from '@playwright/test';
+import { callApi } from '../../fixtures/api';
+import { type RootFixture, uiSigninAsRoot } from '../../fixtures/ui_auth';
+
+test.describe('UI: /settings/email receiveAnnouncementEmail toggle flow', () => {
+  let root: RootFixture;
+  test.beforeAll(() => {
+    root = JSON.parse(readFileSync('.auth/root.json', 'utf-8'));
+  });
+  test.setTimeout(60_000);
+
+  test('toggle receiveAnnouncementEmail switch (1st) → /api/i/update round-trips', async ({
+    page,
+    baseURL,
+    request,
+  }) => {
+    // 値 strict assertion のため初期 state を true (= DB default) に reset。
+    await callApi(request, 'i/update', { i: root.token, receiveAnnouncementEmail: true });
+
+    await uiSigninAsRoot(page, baseURL, root);
+    await page.goto(`${baseURL}/settings/email`, { waitUntil: 'domcontentloaded' });
+
+    // 6 個以上の checkbox が hydrate するまで待つ
+    await page.waitForFunction(
+      () => document.querySelectorAll('input[type="checkbox"]').length >= 6,
+      { timeout: 20_000 },
+    );
+
+    const updateResp = page.waitForResponse(
+      (r) => r.url().includes('/api/i/update') && r.status() === 200,
+      { timeout: 15_000 },
+    );
+    await page.evaluate(() => {
+      const cbs = Array.from(
+        document.querySelectorAll('input[type="checkbox"]'),
+      ) as HTMLInputElement[];
+      // index 0 = 1 番目 = receiveAnnouncementEmail
+      cbs[0]?.click();
+    });
+    const update = await updateResp;
+    const body = await update.json();
+    expect(body.id).toBeTruthy();
+    // beforeAll で true → click 後は必ず false (#973 で i/update accept、
+    // #969 PackMeDetailed で response 含む)。
+    expect(body.receiveAnnouncementEmail).toBe(false);
+  });
+});

--- a/tests/playwright/specs/ui/settings_notifications_mark_all_read_button.spec.ts
+++ b/tests/playwright/specs/ui/settings_notifications_mark_all_read_button.spec.ts
@@ -1,0 +1,54 @@
+// /settings/notifications で "Mark all notifications as read" button click
+// → /api/notifications/mark-all-as-read round-trip する **真の write-flow**
+// spec。
+//
+// /my/notifications header の同名 action とは別経路 (settings 内 button)
+// で、source は notifications.vue (settings) line 46 の MkButton。
+
+import { readFileSync } from 'node:fs';
+import { expect, test } from '@playwright/test';
+import { type RootFixture, uiSigninAsRoot } from '../../fixtures/ui_auth';
+
+test.describe('UI: /settings/notifications mark all read button flow', () => {
+  let root: RootFixture;
+  test.beforeAll(() => {
+    root = JSON.parse(readFileSync('.auth/root.json', 'utf-8'));
+  });
+  test.setTimeout(60_000);
+
+  test('click "Mark as read" button → /api/notifications/mark-all-as-read', async ({
+    page,
+    baseURL,
+  }) => {
+    await uiSigninAsRoot(page, baseURL, root);
+    await page.goto(`${baseURL}/settings/notifications`, {
+      waitUntil: 'domcontentloaded',
+    });
+
+    // "Mark all notifications as read" button が hydrate するまで待つ。
+    // i18n.ts.markAsReadAllNotifications。
+    await page.waitForFunction(
+      () => {
+        const btns = Array.from(document.querySelectorAll('button'));
+        return btns.some((b) =>
+          (b.textContent ?? '').includes('Mark all notifications as read'),
+        );
+      },
+      { timeout: 20_000 },
+    );
+
+    const markResp = page.waitForResponse(
+      (r) =>
+        r.url().includes('/api/notifications/mark-all-as-read') && r.status() < 300,
+      { timeout: 15_000 },
+    );
+    await page.evaluate(() => {
+      const btn = Array.from(document.querySelectorAll('button')).find((b) =>
+        (b.textContent ?? '').includes('Mark all notifications as read'),
+      ) as HTMLButtonElement | undefined;
+      btn?.click();
+    });
+    const resp = await markResp;
+    expect(resp.status()).toBeLessThan(300);
+  });
+});

--- a/tests/playwright/specs/ui/settings_privacy_auto_accept_followed_toggle.spec.ts
+++ b/tests/playwright/specs/ui/settings_privacy_auto_accept_followed_toggle.spec.ts
@@ -7,7 +7,6 @@
 
 import { readFileSync } from 'node:fs';
 import { expect, test } from '@playwright/test';
-import { callApi } from '../../fixtures/api';
 import { type RootFixture, uiSigninAsRoot } from '../../fixtures/ui_auth';
 
 test.describe('UI: /settings/privacy autoAcceptFollowed toggle flow', () => {
@@ -20,10 +19,13 @@ test.describe('UI: /settings/privacy autoAcceptFollowed toggle flow', () => {
   test('toggle autoAcceptFollowed switch (2nd) → /api/i/update round-trips', async ({
     page,
     baseURL,
-    request,
   }) => {
-    // 値 strict assertion のため初期 state を false (= DB default) に reset。
-    await callApi(request, 'i/update', { i: root.token, autoAcceptFollowed: false });
+    // mk-go の i/update は autoAcceptFollowed を受け取らない drift がある
+    // (#972)。本 spec で strict 値検証を効かせるには backend fix が必要なので、
+    // 一旦 loose 検証 (boolean 型のみ) に留め、#972 fix 後に strict 化する。
+    // API reset も silent drop されるので呼ばない (= 累積実行で値の向きが
+    // 不定になるが、本 spec の主旨は「2 番目 switch を click すると
+    // i/update が走る」UI flow 検証なので shape のみ verify)。
 
     await uiSigninAsRoot(page, baseURL, root);
     await page.goto(`${baseURL}/settings/privacy`, { waitUntil: 'domcontentloaded' });
@@ -46,9 +48,10 @@ test.describe('UI: /settings/privacy autoAcceptFollowed toggle flow', () => {
     });
     const update = await updateResp;
     const body = await update.json();
-    // beforeAll の API reset で false から始まるので、click 後は必ず true
-    // (#969 の MeDetailed packer 経由で autoAcceptFollowed が body に含まれる)。
     expect(body.id).toBeTruthy();
-    expect(body.autoAcceptFollowed).toBe(true);
+    // #972 (i/update が autoAcceptFollowed を受け取らない drift) 修正後に
+    // 値 strict assert に戻す。現状は MeDetailed shape (#969) に含まれる
+    // ことだけ verify。
+    expect(typeof body.autoAcceptFollowed).toBe('boolean');
   });
 });

--- a/tests/playwright/specs/ui/settings_privacy_auto_accept_followed_toggle.spec.ts
+++ b/tests/playwright/specs/ui/settings_privacy_auto_accept_followed_toggle.spec.ts
@@ -7,6 +7,7 @@
 
 import { readFileSync } from 'node:fs';
 import { expect, test } from '@playwright/test';
+import { callApi } from '../../fixtures/api';
 import { type RootFixture, uiSigninAsRoot } from '../../fixtures/ui_auth';
 
 test.describe('UI: /settings/privacy autoAcceptFollowed toggle flow', () => {
@@ -19,13 +20,12 @@ test.describe('UI: /settings/privacy autoAcceptFollowed toggle flow', () => {
   test('toggle autoAcceptFollowed switch (2nd) → /api/i/update round-trips', async ({
     page,
     baseURL,
+    request,
   }) => {
-    // mk-go の i/update は autoAcceptFollowed を受け取らない drift がある
-    // (#972)。本 spec で strict 値検証を効かせるには backend fix が必要なので、
-    // 一旦 loose 検証 (boolean 型のみ) に留め、#972 fix 後に strict 化する。
-    // API reset も silent drop されるので呼ばない (= 累積実行で値の向きが
-    // 不定になるが、本 spec の主旨は「2 番目 switch を click すると
-    // i/update が走る」UI flow 検証なので shape のみ verify)。
+    // 値 strict assertion のため初期 state を false (= DB default) に reset。
+    // #972 (PR #973) で i/update が autoAcceptFollowed を accept するように
+    // 修正されたので strict 化が機能する。
+    await callApi(request, 'i/update', { i: root.token, autoAcceptFollowed: false });
 
     await uiSigninAsRoot(page, baseURL, root);
     await page.goto(`${baseURL}/settings/privacy`, { waitUntil: 'domcontentloaded' });
@@ -49,9 +49,9 @@ test.describe('UI: /settings/privacy autoAcceptFollowed toggle flow', () => {
     const update = await updateResp;
     const body = await update.json();
     expect(body.id).toBeTruthy();
-    // #972 (i/update が autoAcceptFollowed を受け取らない drift) 修正後に
-    // 値 strict assert に戻す。現状は MeDetailed shape (#969) に含まれる
-    // ことだけ verify。
-    expect(typeof body.autoAcceptFollowed).toBe('boolean');
+    // beforeAll の API reset で false から始まるので、click 後は必ず true
+    // (#972 / PR #973 で i/update accept + #969 PackMeDetailed で response
+    // 含む、両 layer 揃って strict round-trip が機能)。
+    expect(body.autoAcceptFollowed).toBe(true);
   });
 });

--- a/tests/playwright/specs/ui/settings_privacy_auto_accept_followed_toggle.spec.ts
+++ b/tests/playwright/specs/ui/settings_privacy_auto_accept_followed_toggle.spec.ts
@@ -1,0 +1,50 @@
+// /settings/privacy で autoAcceptFollowed switch (2nd) を click → /api/i/update
+// が round-trip する write-flow spec。
+//
+// privacy.vue の MkSwitch 順は isLocked / autoAcceptFollowed / publicReactions
+// / hideOnlineStatus / noCrawle / preventAiLearning / isExplorable。本 spec は
+// 2 番目の switch を click することで、最初の switch だけ動作する偽陽性を排除。
+
+import { readFileSync } from 'node:fs';
+import { expect, test } from '@playwright/test';
+import { type RootFixture, uiSigninAsRoot } from '../../fixtures/ui_auth';
+
+test.describe('UI: /settings/privacy autoAcceptFollowed toggle flow', () => {
+  let root: RootFixture;
+  test.beforeAll(() => {
+    root = JSON.parse(readFileSync('.auth/root.json', 'utf-8'));
+  });
+  test.setTimeout(60_000);
+
+  test('toggle autoAcceptFollowed switch (2nd) → /api/i/update round-trips', async ({
+    page,
+    baseURL,
+  }) => {
+    await uiSigninAsRoot(page, baseURL, root);
+    await page.goto(`${baseURL}/settings/privacy`, { waitUntil: 'domcontentloaded' });
+
+    await page.waitForFunction(
+      () => document.querySelectorAll('input[type="checkbox"]').length >= 7,
+      { timeout: 20_000 },
+    );
+
+    const updateResp = page.waitForResponse(
+      (r) => r.url().includes('/api/i/update') && r.status() === 200,
+      { timeout: 15_000 },
+    );
+    await page.evaluate(() => {
+      const cbs = Array.from(
+        document.querySelectorAll('input[type="checkbox"]'),
+      ) as HTMLInputElement[];
+      // index 1 = 2 番目 = autoAcceptFollowed
+      cbs[1]?.click();
+    });
+    const update = await updateResp;
+    const body = await update.json();
+    // #969 で MeDetailed packer 経由になり autoAcceptFollowed が body に
+    // 含まれる前提の strict assert (boolean 型のみ確認、prior run 累積で
+    // 値の向きは予測できないため)。
+    expect(body.id).toBeTruthy();
+    expect(typeof body.autoAcceptFollowed).toBe('boolean');
+  });
+});

--- a/tests/playwright/specs/ui/settings_privacy_auto_accept_followed_toggle.spec.ts
+++ b/tests/playwright/specs/ui/settings_privacy_auto_accept_followed_toggle.spec.ts
@@ -7,6 +7,7 @@
 
 import { readFileSync } from 'node:fs';
 import { expect, test } from '@playwright/test';
+import { callApi } from '../../fixtures/api';
 import { type RootFixture, uiSigninAsRoot } from '../../fixtures/ui_auth';
 
 test.describe('UI: /settings/privacy autoAcceptFollowed toggle flow', () => {
@@ -19,7 +20,11 @@ test.describe('UI: /settings/privacy autoAcceptFollowed toggle flow', () => {
   test('toggle autoAcceptFollowed switch (2nd) → /api/i/update round-trips', async ({
     page,
     baseURL,
+    request,
   }) => {
+    // 値 strict assertion のため初期 state を false (= DB default) に reset。
+    await callApi(request, 'i/update', { i: root.token, autoAcceptFollowed: false });
+
     await uiSigninAsRoot(page, baseURL, root);
     await page.goto(`${baseURL}/settings/privacy`, { waitUntil: 'domcontentloaded' });
 
@@ -41,10 +46,9 @@ test.describe('UI: /settings/privacy autoAcceptFollowed toggle flow', () => {
     });
     const update = await updateResp;
     const body = await update.json();
-    // #969 で MeDetailed packer 経由になり autoAcceptFollowed が body に
-    // 含まれる前提の strict assert (boolean 型のみ確認、prior run 累積で
-    // 値の向きは予測できないため)。
+    // beforeAll の API reset で false から始まるので、click 後は必ず true
+    // (#969 の MeDetailed packer 経由で autoAcceptFollowed が body に含まれる)。
     expect(body.id).toBeTruthy();
-    expect(typeof body.autoAcceptFollowed).toBe('boolean');
+    expect(body.autoAcceptFollowed).toBe(true);
   });
 });

--- a/tests/playwright/specs/ui/settings_privacy_explorable_toggle.spec.ts
+++ b/tests/playwright/specs/ui/settings_privacy_explorable_toggle.spec.ts
@@ -1,0 +1,55 @@
+// /settings/privacy で isExplorable switch を click → /api/i/update が
+// {isExplorable: ...} で round-trip する **真の write-flow** spec。
+//
+// privacy.vue では isLocked / autoAcceptFollowed / publicReactions /
+// hideOnlineStatus / noCrawle / preventAiLearning / isExplorable の順で
+// MkSwitch が並んでいる (line 14, 22, 29, 48, 55, 62, 69)。本 spec は
+// 7 番目の switch (isExplorable) を click することで、最初の switch だけ
+// が動作する偽陽性を排除する。
+
+import { readFileSync } from 'node:fs';
+import { expect, test } from '@playwright/test';
+import { type RootFixture, uiSigninAsRoot } from '../../fixtures/ui_auth';
+
+test.describe('UI: /settings/privacy isExplorable toggle flow', () => {
+  let root: RootFixture;
+  test.beforeAll(() => {
+    root = JSON.parse(readFileSync('.auth/root.json', 'utf-8'));
+  });
+  test.setTimeout(60_000);
+
+  test('toggle isExplorable switch (7th) → /api/i/update round-trips', async ({
+    page,
+    baseURL,
+  }) => {
+    await uiSigninAsRoot(page, baseURL, root);
+    await page.goto(`${baseURL}/settings/privacy`, { waitUntil: 'domcontentloaded' });
+
+    // 7 個以上の checkbox が hydrate するまで待つ
+    await page.waitForFunction(
+      () => document.querySelectorAll('input[type="checkbox"]').length >= 7,
+      { timeout: 20_000 },
+    );
+
+    const updateResp = page.waitForResponse(
+      (r) => r.url().includes('/api/i/update') && r.status() === 200,
+      { timeout: 15_000 },
+    );
+    await page.evaluate(() => {
+      // 7 番目 (index 6) = isExplorable switch (privacy.vue:69)
+      const cbs = Array.from(
+        document.querySelectorAll('input[type="checkbox"]'),
+      ) as HTMLInputElement[];
+      cbs[6]?.click();
+    });
+    // mk-go の i/update 応答は entity.PackUserDetailed 経由で、現状
+    // isExplorable field を含まない drift がある (upstream UserDetailed には
+    // 含まれる)。本 spec では status 200 + user object 形だけ verify する
+    // (= 7 番目の switch click で /api/i/update が走ったことを担保、本 PR
+    // の scope は UI 操作 → API round-trip までなので drift は別 issue)。
+    const update = await updateResp;
+    const body = await update.json();
+    expect(body.id).toBeTruthy();
+    expect(body.username).toBe(root.username);
+  });
+});

--- a/tests/playwright/specs/ui/settings_privacy_explorable_toggle.spec.ts
+++ b/tests/playwright/specs/ui/settings_privacy_explorable_toggle.spec.ts
@@ -9,6 +9,7 @@
 
 import { readFileSync } from 'node:fs';
 import { expect, test } from '@playwright/test';
+import { callApi } from '../../fixtures/api';
 import { type RootFixture, uiSigninAsRoot } from '../../fixtures/ui_auth';
 
 test.describe('UI: /settings/privacy isExplorable toggle flow', () => {
@@ -21,7 +22,13 @@ test.describe('UI: /settings/privacy isExplorable toggle flow', () => {
   test('toggle isExplorable switch (7th) → /api/i/update round-trips', async ({
     page,
     baseURL,
+    request,
   }) => {
+    // 値 strict assertion を効かせるため、初期 state を true (= DB default)
+    // に reset。prior run 累積で false のまま残っていると click で true に
+    // 反転して期待と逆になるので、明示的に既知 state から始める。
+    await callApi(request, 'i/update', { i: root.token, isExplorable: true });
+
     await uiSigninAsRoot(page, baseURL, root);
     await page.goto(`${baseURL}/settings/privacy`, { waitUntil: 'domcontentloaded' });
 
@@ -42,18 +49,13 @@ test.describe('UI: /settings/privacy isExplorable toggle flow', () => {
       ) as HTMLInputElement[];
       cbs[6]?.click();
     });
-    // #968 (PR #969) で MeDetailed packer が導入され、i/update 応答に
-    // isExplorable / noCrawle / preventAiLearning など self-view-only field
-    // が含まれるようになった。本 spec では「7 番目の switch を click した
-    // 後、応答 body の isExplorable が toggle 後の値 (= boolean) を返す」
-    // ことを strict assert する。click 前の値が観測しにくいので、boolean
-    // 型であることを担保するに留める (true/false どちらでも通すため
-    // toggle 方向に依存しない、初期 DB 状態 default:true の前提で false
-    // 期待だが、prior run の影響で逆向きにもなり得るため)。
+    // beforeAll の API reset で isExplorable=true から始まるので、click
+    // 後は必ず false が返る strict assertion。i/update が MeDetailed
+    // shape (#968 / PR #969) を返すことも併せて verify。
     const update = await updateResp;
     const body = await update.json();
     expect(body.id).toBeTruthy();
     expect(body.username).toBe(root.username);
-    expect(typeof body.isExplorable).toBe('boolean');
+    expect(body.isExplorable).toBe(false);
   });
 });

--- a/tests/playwright/specs/ui/settings_privacy_explorable_toggle.spec.ts
+++ b/tests/playwright/specs/ui/settings_privacy_explorable_toggle.spec.ts
@@ -42,14 +42,18 @@ test.describe('UI: /settings/privacy isExplorable toggle flow', () => {
       ) as HTMLInputElement[];
       cbs[6]?.click();
     });
-    // mk-go の i/update 応答は entity.PackUserDetailed 経由で、現状
-    // isExplorable field を含まない drift がある (upstream UserDetailed には
-    // 含まれる)。本 spec では status 200 + user object 形だけ verify する
-    // (= 7 番目の switch click で /api/i/update が走ったことを担保、本 PR
-    // の scope は UI 操作 → API round-trip までなので drift は別 issue)。
+    // #968 (PR #969) で MeDetailed packer が導入され、i/update 応答に
+    // isExplorable / noCrawle / preventAiLearning など self-view-only field
+    // が含まれるようになった。本 spec では「7 番目の switch を click した
+    // 後、応答 body の isExplorable が toggle 後の値 (= boolean) を返す」
+    // ことを strict assert する。click 前の値が観測しにくいので、boolean
+    // 型であることを担保するに留める (true/false どちらでも通すため
+    // toggle 方向に依存しない、初期 DB 状態 default:true の前提で false
+    // 期待だが、prior run の影響で逆向きにもなり得るため)。
     const update = await updateResp;
     const body = await update.json();
     expect(body.id).toBeTruthy();
     expect(body.username).toBe(root.username);
+    expect(typeof body.isExplorable).toBe('boolean');
   });
 });

--- a/tests/playwright/specs/ui/settings_privacy_hide_online_status_toggle.spec.ts
+++ b/tests/playwright/specs/ui/settings_privacy_hide_online_status_toggle.spec.ts
@@ -7,6 +7,7 @@
 
 import { readFileSync } from 'node:fs';
 import { expect, test } from '@playwright/test';
+import { callApi } from '../../fixtures/api';
 import { type RootFixture, uiSigninAsRoot } from '../../fixtures/ui_auth';
 
 test.describe('UI: /settings/privacy hideOnlineStatus toggle flow', () => {
@@ -19,7 +20,11 @@ test.describe('UI: /settings/privacy hideOnlineStatus toggle flow', () => {
   test('toggle hideOnlineStatus switch (4th) → /api/i/update round-trips', async ({
     page,
     baseURL,
+    request,
   }) => {
+    // 値 strict assertion のため初期 state を false (= DB default) に reset。
+    await callApi(request, 'i/update', { i: root.token, hideOnlineStatus: false });
+
     await uiSigninAsRoot(page, baseURL, root);
     await page.goto(`${baseURL}/settings/privacy`, { waitUntil: 'domcontentloaded' });
 
@@ -42,7 +47,8 @@ test.describe('UI: /settings/privacy hideOnlineStatus toggle flow', () => {
     const update = await updateResp;
     const body = await update.json();
     expect(body.id).toBeTruthy();
-    // #969 で MeDetailed shape に含まれる self-view-only field。
-    expect(typeof body.hideOnlineStatus).toBe('boolean');
+    // beforeAll の API reset で false から始まるので、click 後は必ず true
+    // (#969 で MeDetailed shape に hideOnlineStatus が含まれる)。
+    expect(body.hideOnlineStatus).toBe(true);
   });
 });

--- a/tests/playwright/specs/ui/settings_privacy_hide_online_status_toggle.spec.ts
+++ b/tests/playwright/specs/ui/settings_privacy_hide_online_status_toggle.spec.ts
@@ -1,0 +1,48 @@
+// /settings/privacy で hideOnlineStatus switch (4th) を click → /api/i/update
+// が round-trip する write-flow spec。
+//
+// privacy.vue の MkSwitch 順は isLocked / autoAcceptFollowed / publicReactions
+// / hideOnlineStatus / noCrawle / preventAiLearning / isExplorable。本 spec は
+// 4 番目の switch を click。
+
+import { readFileSync } from 'node:fs';
+import { expect, test } from '@playwright/test';
+import { type RootFixture, uiSigninAsRoot } from '../../fixtures/ui_auth';
+
+test.describe('UI: /settings/privacy hideOnlineStatus toggle flow', () => {
+  let root: RootFixture;
+  test.beforeAll(() => {
+    root = JSON.parse(readFileSync('.auth/root.json', 'utf-8'));
+  });
+  test.setTimeout(60_000);
+
+  test('toggle hideOnlineStatus switch (4th) → /api/i/update round-trips', async ({
+    page,
+    baseURL,
+  }) => {
+    await uiSigninAsRoot(page, baseURL, root);
+    await page.goto(`${baseURL}/settings/privacy`, { waitUntil: 'domcontentloaded' });
+
+    await page.waitForFunction(
+      () => document.querySelectorAll('input[type="checkbox"]').length >= 7,
+      { timeout: 20_000 },
+    );
+
+    const updateResp = page.waitForResponse(
+      (r) => r.url().includes('/api/i/update') && r.status() === 200,
+      { timeout: 15_000 },
+    );
+    await page.evaluate(() => {
+      const cbs = Array.from(
+        document.querySelectorAll('input[type="checkbox"]'),
+      ) as HTMLInputElement[];
+      // index 3 = 4 番目 = hideOnlineStatus
+      cbs[3]?.click();
+    });
+    const update = await updateResp;
+    const body = await update.json();
+    expect(body.id).toBeTruthy();
+    // #969 で MeDetailed shape に含まれる self-view-only field。
+    expect(typeof body.hideOnlineStatus).toBe('boolean');
+  });
+});

--- a/tests/playwright/specs/ui/settings_privacy_locked_toggle.spec.ts
+++ b/tests/playwright/specs/ui/settings_privacy_locked_toggle.spec.ts
@@ -12,6 +12,7 @@
 
 import { readFileSync } from 'node:fs';
 import { expect, test } from '@playwright/test';
+import { callApi } from '../../fixtures/api';
 import { type RootFixture, uiSigninAsRoot } from '../../fixtures/ui_auth';
 
 test.describe('UI: /settings/privacy isLocked toggle flow', () => {
@@ -24,7 +25,13 @@ test.describe('UI: /settings/privacy isLocked toggle flow', () => {
   test('toggle isLocked switch → /api/i/update round-trips', async ({
     page,
     baseURL,
+    request,
   }) => {
+    // 値 strict assertion を効かせるため、初期 state を false (= DB default)
+    // に reset。prior run 累積で true のまま残っていると click で false に
+    // 反転して期待と逆になるので、明示的に既知 state から始める。
+    await callApi(request, 'i/update', { i: root.token, isLocked: false });
+
     await uiSigninAsRoot(page, baseURL, root);
     await page.goto(`${baseURL}/settings/privacy`, { waitUntil: 'domcontentloaded' });
 
@@ -46,9 +53,7 @@ test.describe('UI: /settings/privacy isLocked toggle flow', () => {
     });
     const update = await updateResp;
     const body = await update.json();
-    // updated user object には isLocked が含まれる (true / false どちらでも、
-    // 状態が toggle されたこと自体を verify する)。
-    expect(body).toHaveProperty('isLocked');
-    expect(typeof body.isLocked).toBe('boolean');
+    // beforeAll の API reset で false から始まるので、click 後は必ず true。
+    expect(body.isLocked).toBe(true);
   });
 });

--- a/tests/playwright/specs/ui/settings_privacy_locked_toggle.spec.ts
+++ b/tests/playwright/specs/ui/settings_privacy_locked_toggle.spec.ts
@@ -1,0 +1,54 @@
+// /settings/privacy で isLocked switch を click → /api/i/update が
+// {isLocked: true} で round-trip する **真の write-flow** spec。
+//
+// MkSwitch は <input type="checkbox" @click="toggle"> として render され、
+// `@update:modelValue="save()"` で /api/i/update を即時呼ぶ。本 spec は
+// 1 つ目の MkSwitch (isLocked) を click して API 起動を verify する。
+//
+// 注意: /settings/* は親 layout の MkSuperMenu に search MkInput
+// (type=search) があり、page 全体 input[0] はそれ。form 本体の switch を
+// 取るには `i.type === 'checkbox'` filter が必要 (#744 batch3 で発覚した
+// MkInput type 暗黙 text と同 origin)。
+
+import { readFileSync } from 'node:fs';
+import { expect, test } from '@playwright/test';
+import { type RootFixture, uiSigninAsRoot } from '../../fixtures/ui_auth';
+
+test.describe('UI: /settings/privacy isLocked toggle flow', () => {
+  let root: RootFixture;
+  test.beforeAll(() => {
+    root = JSON.parse(readFileSync('.auth/root.json', 'utf-8'));
+  });
+  test.setTimeout(60_000);
+
+  test('toggle isLocked switch → /api/i/update round-trips', async ({
+    page,
+    baseURL,
+  }) => {
+    await uiSigninAsRoot(page, baseURL, root);
+    await page.goto(`${baseURL}/settings/privacy`, { waitUntil: 'domcontentloaded' });
+
+    // checkbox が hydrate するまで待つ
+    await page.waitForFunction(
+      () => document.querySelectorAll('input[type="checkbox"]').length >= 1,
+      { timeout: 20_000 },
+    );
+
+    // i/update response を捕捉して isLocked switch を click
+    const updateResp = page.waitForResponse(
+      (r) => r.url().includes('/api/i/update') && r.status() === 200,
+      { timeout: 15_000 },
+    );
+    await page.evaluate(() => {
+      // 最初の checkbox = isLocked switch (privacy.vue:14)
+      const cb = document.querySelector('input[type="checkbox"]') as HTMLInputElement | null;
+      cb?.click();
+    });
+    const update = await updateResp;
+    const body = await update.json();
+    // updated user object には isLocked が含まれる (true / false どちらでも、
+    // 状態が toggle されたこと自体を verify する)。
+    expect(body).toHaveProperty('isLocked');
+    expect(typeof body.isLocked).toBe('boolean');
+  });
+});

--- a/tests/playwright/specs/ui/settings_privacy_no_crawle_toggle.spec.ts
+++ b/tests/playwright/specs/ui/settings_privacy_no_crawle_toggle.spec.ts
@@ -6,6 +6,7 @@
 
 import { readFileSync } from 'node:fs';
 import { expect, test } from '@playwright/test';
+import { callApi } from '../../fixtures/api';
 import { type RootFixture, uiSigninAsRoot } from '../../fixtures/ui_auth';
 
 test.describe('UI: /settings/privacy noCrawle toggle flow', () => {
@@ -18,7 +19,12 @@ test.describe('UI: /settings/privacy noCrawle toggle flow', () => {
   test('toggle noCrawle switch (5th) → /api/i/update round-trips', async ({
     page,
     baseURL,
+    request,
   }) => {
+    // 値 strict assertion を効かせるため初期 state を false (= DB default)
+    // に reset。
+    await callApi(request, 'i/update', { i: root.token, noCrawle: false });
+
     await uiSigninAsRoot(page, baseURL, root);
     await page.goto(`${baseURL}/settings/privacy`, { waitUntil: 'domcontentloaded' });
 
@@ -43,5 +49,8 @@ test.describe('UI: /settings/privacy noCrawle toggle flow', () => {
     const update = await updateResp;
     const body = await update.json();
     expect(body.id).toBeTruthy();
+    // beforeAll の API reset で false から始まるので、click 後は必ず true
+    // (#969 の MeDetailed packer 経由で noCrawle が body に含まれる)。
+    expect(body.noCrawle).toBe(true);
   });
 });

--- a/tests/playwright/specs/ui/settings_privacy_no_crawle_toggle.spec.ts
+++ b/tests/playwright/specs/ui/settings_privacy_no_crawle_toggle.spec.ts
@@ -1,0 +1,47 @@
+// /settings/privacy で 5 番目 switch (noCrawle) を click → /api/i/update
+// が走ることを verify する **真の write-flow** spec。
+//
+// 異なる index の switch を toggle することで「最初の switch だけ動く偽
+// 陽性」regression を排除する補助 spec (#744 batch4)。
+
+import { readFileSync } from 'node:fs';
+import { expect, test } from '@playwright/test';
+import { type RootFixture, uiSigninAsRoot } from '../../fixtures/ui_auth';
+
+test.describe('UI: /settings/privacy noCrawle toggle flow', () => {
+  let root: RootFixture;
+  test.beforeAll(() => {
+    root = JSON.parse(readFileSync('.auth/root.json', 'utf-8'));
+  });
+  test.setTimeout(60_000);
+
+  test('toggle noCrawle switch (5th) → /api/i/update round-trips', async ({
+    page,
+    baseURL,
+  }) => {
+    await uiSigninAsRoot(page, baseURL, root);
+    await page.goto(`${baseURL}/settings/privacy`, { waitUntil: 'domcontentloaded' });
+
+    await page.waitForFunction(
+      () => document.querySelectorAll('input[type="checkbox"]').length >= 5,
+      { timeout: 20_000 },
+    );
+
+    const updateResp = page.waitForResponse(
+      (r) => r.url().includes('/api/i/update') && r.status() === 200,
+      { timeout: 15_000 },
+    );
+    await page.evaluate(() => {
+      // privacy.vue の switch 順: isLocked / autoAcceptFollowed /
+      // publicReactions / hideOnlineStatus / noCrawle (= index 4) /
+      // preventAiLearning / isExplorable
+      const cbs = Array.from(
+        document.querySelectorAll('input[type="checkbox"]'),
+      ) as HTMLInputElement[];
+      cbs[4]?.click();
+    });
+    const update = await updateResp;
+    const body = await update.json();
+    expect(body.id).toBeTruthy();
+  });
+});

--- a/tests/playwright/specs/ui/settings_privacy_prevent_ai_learning_toggle.spec.ts
+++ b/tests/playwright/specs/ui/settings_privacy_prevent_ai_learning_toggle.spec.ts
@@ -7,6 +7,7 @@
 
 import { readFileSync } from 'node:fs';
 import { expect, test } from '@playwright/test';
+import { callApi } from '../../fixtures/api';
 import { type RootFixture, uiSigninAsRoot } from '../../fixtures/ui_auth';
 
 test.describe('UI: /settings/privacy preventAiLearning toggle flow', () => {
@@ -19,7 +20,11 @@ test.describe('UI: /settings/privacy preventAiLearning toggle flow', () => {
   test('toggle preventAiLearning switch (6th) → /api/i/update round-trips', async ({
     page,
     baseURL,
+    request,
   }) => {
+    // 値 strict assertion のため初期 state を true (= DB default) に reset。
+    await callApi(request, 'i/update', { i: root.token, preventAiLearning: true });
+
     await uiSigninAsRoot(page, baseURL, root);
     await page.goto(`${baseURL}/settings/privacy`, { waitUntil: 'domcontentloaded' });
 
@@ -42,6 +47,8 @@ test.describe('UI: /settings/privacy preventAiLearning toggle flow', () => {
     const update = await updateResp;
     const body = await update.json();
     expect(body.id).toBeTruthy();
-    expect(typeof body.preventAiLearning).toBe('boolean');
+    // beforeAll の API reset で true から始まるので、click 後は必ず false
+    // (#969 で MeDetailed shape に preventAiLearning が含まれる)。
+    expect(body.preventAiLearning).toBe(false);
   });
 });

--- a/tests/playwright/specs/ui/settings_privacy_prevent_ai_learning_toggle.spec.ts
+++ b/tests/playwright/specs/ui/settings_privacy_prevent_ai_learning_toggle.spec.ts
@@ -1,0 +1,47 @@
+// /settings/privacy で preventAiLearning switch (6th) を click → /api/i/update
+// が round-trip する write-flow spec。
+//
+// privacy.vue の MkSwitch 順は isLocked / autoAcceptFollowed / publicReactions
+// / hideOnlineStatus / noCrawle / preventAiLearning / isExplorable。本 spec は
+// 6 番目の switch を click。
+
+import { readFileSync } from 'node:fs';
+import { expect, test } from '@playwright/test';
+import { type RootFixture, uiSigninAsRoot } from '../../fixtures/ui_auth';
+
+test.describe('UI: /settings/privacy preventAiLearning toggle flow', () => {
+  let root: RootFixture;
+  test.beforeAll(() => {
+    root = JSON.parse(readFileSync('.auth/root.json', 'utf-8'));
+  });
+  test.setTimeout(60_000);
+
+  test('toggle preventAiLearning switch (6th) → /api/i/update round-trips', async ({
+    page,
+    baseURL,
+  }) => {
+    await uiSigninAsRoot(page, baseURL, root);
+    await page.goto(`${baseURL}/settings/privacy`, { waitUntil: 'domcontentloaded' });
+
+    await page.waitForFunction(
+      () => document.querySelectorAll('input[type="checkbox"]').length >= 7,
+      { timeout: 20_000 },
+    );
+
+    const updateResp = page.waitForResponse(
+      (r) => r.url().includes('/api/i/update') && r.status() === 200,
+      { timeout: 15_000 },
+    );
+    await page.evaluate(() => {
+      const cbs = Array.from(
+        document.querySelectorAll('input[type="checkbox"]'),
+      ) as HTMLInputElement[];
+      // index 5 = 6 番目 = preventAiLearning
+      cbs[5]?.click();
+    });
+    const update = await updateResp;
+    const body = await update.json();
+    expect(body.id).toBeTruthy();
+    expect(typeof body.preventAiLearning).toBe('boolean');
+  });
+});

--- a/tests/playwright/specs/ui/settings_privacy_public_reactions_toggle.spec.ts
+++ b/tests/playwright/specs/ui/settings_privacy_public_reactions_toggle.spec.ts
@@ -1,0 +1,43 @@
+// /settings/privacy で 3 番目 switch (publicReactions) を click →
+// /api/i/update が走ることを verify する **真の write-flow** spec。
+
+import { readFileSync } from 'node:fs';
+import { expect, test } from '@playwright/test';
+import { type RootFixture, uiSigninAsRoot } from '../../fixtures/ui_auth';
+
+test.describe('UI: /settings/privacy publicReactions toggle flow', () => {
+  let root: RootFixture;
+  test.beforeAll(() => {
+    root = JSON.parse(readFileSync('.auth/root.json', 'utf-8'));
+  });
+  test.setTimeout(60_000);
+
+  test('toggle publicReactions switch (3rd) → /api/i/update round-trips', async ({
+    page,
+    baseURL,
+  }) => {
+    await uiSigninAsRoot(page, baseURL, root);
+    await page.goto(`${baseURL}/settings/privacy`, { waitUntil: 'domcontentloaded' });
+
+    await page.waitForFunction(
+      () => document.querySelectorAll('input[type="checkbox"]').length >= 3,
+      { timeout: 20_000 },
+    );
+
+    const updateResp = page.waitForResponse(
+      (r) => r.url().includes('/api/i/update') && r.status() === 200,
+      { timeout: 15_000 },
+    );
+    await page.evaluate(() => {
+      // privacy.vue: index 2 = publicReactions
+      const cbs = Array.from(
+        document.querySelectorAll('input[type="checkbox"]'),
+      ) as HTMLInputElement[];
+      cbs[2]?.click();
+    });
+    const update = await updateResp;
+    const body = await update.json();
+    expect(body).toHaveProperty('publicReactions');
+    expect(typeof body.publicReactions).toBe('boolean');
+  });
+});

--- a/tests/playwright/specs/ui/settings_privacy_public_reactions_toggle.spec.ts
+++ b/tests/playwright/specs/ui/settings_privacy_public_reactions_toggle.spec.ts
@@ -3,6 +3,7 @@
 
 import { readFileSync } from 'node:fs';
 import { expect, test } from '@playwright/test';
+import { callApi } from '../../fixtures/api';
 import { type RootFixture, uiSigninAsRoot } from '../../fixtures/ui_auth';
 
 test.describe('UI: /settings/privacy publicReactions toggle flow', () => {
@@ -15,7 +16,11 @@ test.describe('UI: /settings/privacy publicReactions toggle flow', () => {
   test('toggle publicReactions switch (3rd) → /api/i/update round-trips', async ({
     page,
     baseURL,
+    request,
   }) => {
+    // 値 strict assertion のため初期 state を true (= DB default) に reset。
+    await callApi(request, 'i/update', { i: root.token, publicReactions: true });
+
     await uiSigninAsRoot(page, baseURL, root);
     await page.goto(`${baseURL}/settings/privacy`, { waitUntil: 'domcontentloaded' });
 
@@ -37,7 +42,7 @@ test.describe('UI: /settings/privacy publicReactions toggle flow', () => {
     });
     const update = await updateResp;
     const body = await update.json();
-    expect(body).toHaveProperty('publicReactions');
-    expect(typeof body.publicReactions).toBe('boolean');
+    // beforeAll の API reset で true から始まるので、click 後は必ず false。
+    expect(body.publicReactions).toBe(false);
   });
 });

--- a/tests/playwright/specs/ui/webhook_edit_save.spec.ts
+++ b/tests/playwright/specs/ui/webhook_edit_save.spec.ts
@@ -1,0 +1,78 @@
+// /settings/webhook/edit/:id で 既存 webhook の name を変更 → Save click →
+// /api/i/webhooks/update round-trip する **真の write-flow** spec。
+
+import { readFileSync } from 'node:fs';
+import { expect, test } from '@playwright/test';
+import { callApi } from '../../fixtures/api';
+import { type RootFixture, uiSigninAsRoot } from '../../fixtures/ui_auth';
+
+test.describe('UI: /settings/webhook/edit/:id update flow', () => {
+  let root: RootFixture;
+  test.beforeAll(() => {
+    root = JSON.parse(readFileSync('.auth/root.json', 'utf-8'));
+  });
+  test.setTimeout(60_000);
+
+  test('create webhook via API → edit name → Save → /api/i/webhooks/update', async ({
+    page,
+    baseURL,
+    request,
+  }) => {
+    const initialName = `pwwh-init-${Date.now().toString().slice(-9)}`;
+    const createResp = await callApi(request, 'i/webhooks/create', {
+      i: root.token,
+      name: initialName,
+      url: 'https://example.test/webhook',
+      secret: 'pwwh-secret',
+      on: ['follow'],
+    });
+    expect(createResp.status()).toBe(200);
+    const webhookId = (await createResp.json()).id;
+    expect(webhookId).toBeTruthy();
+
+    await uiSigninAsRoot(page, baseURL, root);
+    await page.goto(`${baseURL}/settings/webhook/edit/${webhookId}`, {
+      waitUntil: 'domcontentloaded',
+    });
+
+    await page.waitForFunction(
+      (n) => {
+        const inputs = Array.from(document.querySelectorAll('input')) as HTMLInputElement[];
+        return inputs.some((i) => i.value === n);
+      },
+      initialName,
+      { timeout: 20_000 },
+    );
+
+    const newName = `pwwh-updated-${Date.now().toString().slice(-9)}`;
+    await page.evaluate(
+      ({ from, to }) => {
+        const target = (
+          Array.from(document.querySelectorAll('input')) as HTMLInputElement[]
+        ).find((i) => i.value === from);
+        if (!target) return;
+        target.focus();
+        const setter = Object.getOwnPropertyDescriptor(
+          window.HTMLInputElement.prototype,
+          'value',
+        )?.set;
+        setter?.call(target, to);
+        target.dispatchEvent(new Event('input', { bubbles: true }));
+      },
+      { from: initialName, to: newName },
+    );
+
+    const updateResp = page.waitForResponse(
+      (r) => r.url().includes('/api/i/webhooks/update') && r.status() < 400,
+      { timeout: 15_000 },
+    );
+    await page.evaluate(() => {
+      const btn = Array.from(document.querySelectorAll('button')).find((b) =>
+        (b.textContent ?? '').includes('Save'),
+      ) as HTMLButtonElement | undefined;
+      btn?.click();
+    });
+    const resp = await updateResp;
+    expect(resp.status()).toBeLessThan(400);
+  });
+});


### PR DESCRIPTION
## Summary

PR #959 batch 3 (write-flow 17 本) に続く batch 4。**UI 操作で API round-trip まで通す spec を 24 本追加**して累計 41 本に。

#962 / #965 / #966 の security fix 完結後で middleware が安定したのを機に、create / edit / save / button の 4 系統で write-flow を一気に拡充。

## カバレッジ追加分

### Settings switches (4 spec)
\`settings_privacy_locked_toggle\` / \`_explorable\` / \`_no_crawle\` / \`_public_reactions\`

privacy.vue の MkSwitch を index 違いで toggle → /api/i/update。**異なる位置の switch** で「最初の switch だけ動く」regression を排除。

### Admin save buttons (4 spec) — /api/admin/update-meta
\`admin_email_settings_save\` / \`_object_storage_save\` / \`_branding_save\` / \`_external_services_google_save\` (folder expand 必要な variant)

### Admin form / dialog (4 spec)
- \`admin_invite_create_form\`: MkFolder expand → "Create" → \`/api/admin/invite/create\`
- \`admin_relay_add_form\`: header "+" → MkDialog → OK → \`/api/admin/relays/add\`
- \`admin_avatar_decoration_create_form\`: header "+" → MkWindow popup → name+url → \`/api/admin/avatar-decorations/create\`
- \`admin_announcement_archive_button\`: API setup → folder expand → "Archive" → \`/api/admin/announcements/update\`

### Existing entity edit save (7 spec)
API setup (\`XX/create\`) → SPA edit page navigate → field 書き換え → Save click → \`XX/update\` のパターン:

- \`page_edit_save\`: \`/pages/edit/:id\` → \`/api/pages/update\`
- \`channel_edit_save\`: \`/channels/:id/edit\` → \`/api/channels/update\`
- \`antenna_edit_save\`: \`/my/antennas/:id\` → \`/api/antennas/update\`
- \`flash_edit_save\`: \`/play/:id/edit\` → \`/api/flash/update\`
- \`admin_role_edit_save\`: \`/admin/roles/:id/edit\` → \`/api/admin/roles/update\` (admin/roles/create は 13 field 必須)
- \`webhook_edit_save\`: \`/settings/webhook/edit/:id\` → \`/api/i/webhooks/update\`
- \`list_edit_save\`: \`/my/lists/:id\` → \`/api/users/lists/update\` (Settings folder expand 必要)

### User-side / 各種 (5 spec)
- \`clip_create_form\`: "+ Add" → MkFormDialog (os.form, multi-field) → "Done" → \`/api/clips/create\`
- \`notifications_mark_all_read\`: header の ti-check icon → \`/api/notifications/mark-all-as-read\`
- \`announcement_read_button\`: API setup → \`/announcements\` → "Got it!" → \`/api/i/read-announcement\`
- \`chat_send_to_room\`: API setup → \`/chat/room/:id\` → textarea + ti-send → \`/api/chat/messages/create-to-room\`
- \`settings_notifications_mark_all_read_button\`: \`/settings/notifications\` → button → \`/api/notifications/mark-all-as-read\`

## 検証中の発見

- **mk-go の i/update 応答に \`isExplorable\` field 欠落**: drift。spec は status 200 + user object 形のみ verify (別 issue 候補)
- **mk-go の notifications/mark-all-as-read は 204 を返す** (upstream は 200) → spec で < 300 で accept
- **MkFormDialog (os.form 経由) の input は MkInput + MkSwitch 混在** → \`type === 'text'\` で filter 必須
- **mk-go admin/roles/create は 13 field 必須** (#889) → spec で全 field を渡す
- **/my/lists/:id の "Settings" MkFolder は defaultOpen ではない** → folder header click で expand してから input access

## テスト

\`\`\`bash
make playwright-test (batch 4 24 spec)
# 24 passed (1m)
\`\`\`

各 spec は accountSetupWizard=-1 で MkUserSetupDialog を抑止 (#744 batch3 fix を継承) し、TLS / signin / API call → DOM verify の完全 path を回す。

## 残課題 (Phase 5 候補)

- **note 操作系** (react / clip add / pin): popup menu / reaction picker 必須で複雑
- **drive folder rename / file rename**: context menu + dialog
- **admin user suspend in admin/users**: list + detail page navigation
- **/admin/security 詳細 (BotProtection 等)**: nested folder + dynamic field

## 関連

- 関連 tracker: #744 (Playwright Phase 1-4)
- 前 PR: #959 batch 3 (15 spec で write-flow 17 累計)
- **本 PR**: write-flow 24 spec 追加 → 累計 **41 spec**
- UI suite 全体: ~125 spec

🤖 Generated with [Claude Code](https://claude.com/claude-code)