### PR TITLE
Fix #972: i/update が profile 4 bool field を受け付けるよう drift 解消

### DIFF
--- a/internal/api/i/handler.go
+++ b/internal/api/i/handler.go
@@ -876,6 +876,9 @@ func (h *Handler) Update(c echo.Context) error {
 		return apierr.JSONInvalidParam(c)
 	}
 
+	// 全 *bool field は req と in の field type が一致するので struct literal
+	// で直接代入する。req.X が nil なら in.X も nil (= service 側で no-op
+	// 扱い) になり、`if != nil` block 経由と意味的に等価。
 	in := user.UpdateInput{
 		IsLocked:                 req.IsLocked,
 		IsBot:                    req.IsBot,
@@ -886,6 +889,7 @@ func (h *Handler) Update(c echo.Context) error {
 		AutoSensitive:            req.AutoSensitive,
 		NoCrawle:                 req.NoCrawle,
 		PreventAiLearning:        req.PreventAiLearning,
+		PublicReactions:          req.PublicReactions,
 		AutoAcceptFollowed:       req.AutoAcceptFollowed,
 		CarefulBot:               req.CarefulBot,
 		InjectFeaturedNote:       req.InjectFeaturedNote,
@@ -916,9 +920,6 @@ func (h *Handler) Update(c echo.Context) error {
 	}
 	if req.FollowedMessage != nil {
 		in.FollowedMessage = &req.FollowedMessage
-	}
-	if req.PublicReactions != nil {
-		in.PublicReactions = req.PublicReactions
 	}
 	if len(req.Room) > 0 {
 		// json.RawMessage は親の Unmarshal が構文チェック済みの

--- a/internal/api/i/handler.go
+++ b/internal/api/i/handler.go
@@ -724,6 +724,14 @@ type UpdateRequest struct {
 	AutoSensitive     *bool   `json:"autoSensitive"`
 	NoCrawle          *bool   `json:"noCrawle"`
 	PreventAiLearning *bool   `json:"preventAiLearning"`
+	// 以下 4 field は upstream Misskey TS i/update.ts:178-188 の paramDef に
+	// あり、profile の bool 設定として persist される。response 側は
+	// MeDetailed packer (#969) 経由で含まれていたが、UpdateRequest struct
+	// から抜けていて silent drop される asymmetric drift があった (#972)。
+	AutoAcceptFollowed       *bool `json:"autoAcceptFollowed"`
+	CarefulBot               *bool `json:"carefulBot"`
+	InjectFeaturedNote       *bool `json:"injectFeaturedNote"`
+	ReceiveAnnouncementEmail *bool `json:"receiveAnnouncementEmail"`
 	// ChatScope は 1-on-1 DM の受信許可レベル (#692)。
 	// upstream paramDef enum: everyone / followers / following / mutual / none
 	ChatScope *string `json:"chatScope"`
@@ -869,15 +877,19 @@ func (h *Handler) Update(c echo.Context) error {
 	}
 
 	in := user.UpdateInput{
-		IsLocked:          req.IsLocked,
-		IsBot:             req.IsBot,
-		IsCat:             req.IsCat,
-		IsExplorable:      req.IsExplorable,
-		HideOnlineStatus:  req.HideOnlineStatus,
-		AlwaysMarkNsfw:    req.AlwaysMarkNsfw,
-		AutoSensitive:     req.AutoSensitive,
-		NoCrawle:          req.NoCrawle,
-		PreventAiLearning: req.PreventAiLearning,
+		IsLocked:                 req.IsLocked,
+		IsBot:                    req.IsBot,
+		IsCat:                    req.IsCat,
+		IsExplorable:             req.IsExplorable,
+		HideOnlineStatus:         req.HideOnlineStatus,
+		AlwaysMarkNsfw:           req.AlwaysMarkNsfw,
+		AutoSensitive:            req.AutoSensitive,
+		NoCrawle:                 req.NoCrawle,
+		PreventAiLearning:        req.PreventAiLearning,
+		AutoAcceptFollowed:       req.AutoAcceptFollowed,
+		CarefulBot:               req.CarefulBot,
+		InjectFeaturedNote:       req.InjectFeaturedNote,
+		ReceiveAnnouncementEmail: req.ReceiveAnnouncementEmail,
 	}
 	if req.Name != nil {
 		// 表示名の禁止ワードチェック。meta 未注入 / 未設定時は素通りする。

--- a/internal/api/i/handler_test.go
+++ b/internal/api/i/handler_test.go
@@ -623,6 +623,79 @@ func TestUpdate_FollowedMessageAndPublicReactions(t *testing.T) {
 	assert.False(t, p.PublicReactions)
 }
 
+// #972: i/update が autoAcceptFollowed / carefulBot / injectFeaturedNote /
+// receiveAnnouncementEmail を受け付けて profile に persist することを確認
+// する。これらは upstream Misskey TS i/update.ts:178-188 paramDef に存在
+// するが、mk-go では UpdateRequest struct から抜けていて silent drop される
+// drift があった。response 側 (PackMeDetailed #969) には含まれていたので
+// 「読めるが書けない」asymmetric drift を 4 field 同時に解消する。
+func TestUpdate_ProfileBoolFields_972(t *testing.T) {
+	h, repo, _, _ := newTestHandler(t)
+	user := &model.User{
+		ID:                "user1",
+		Username:          "user1",
+		AvatarDecorations: datatypes.JSON([]byte("[]")),
+	}
+	repo.Users["user1"] = user
+	// 既定値とは逆向きに設定して、reset 期待値が「未設定の Go zero」と
+	// 区別できる初期 state を作る。
+	repo.Profiles["user1"] = &model.UserProfile{
+		UserID:                   "user1",
+		Fields:                   datatypes.JSON([]byte("[]")),
+		AutoAcceptFollowed:       false,
+		CarefulBot:               false,
+		InjectFeaturedNote:       true,
+		ReceiveAnnouncementEmail: true,
+	}
+
+	rec := post(h.Update, `{"autoAcceptFollowed":true,"carefulBot":true,"injectFeaturedNote":false,"receiveAnnouncementEmail":false}`, user)
+	assert.Equal(t, http.StatusOK, rec.Code)
+
+	p := repo.Profiles["user1"]
+	assert.True(t, p.AutoAcceptFollowed, "autoAcceptFollowed が persist される")
+	assert.True(t, p.CarefulBot, "carefulBot が persist される")
+	assert.False(t, p.InjectFeaturedNote, "injectFeaturedNote が persist される")
+	assert.False(t, p.ReceiveAnnouncementEmail, "receiveAnnouncementEmail が persist される")
+
+	// response body も MeDetailed shape (#969) で 4 field を新値で返す。
+	var body map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &body))
+	assert.Equal(t, true, body["autoAcceptFollowed"])
+	assert.Equal(t, true, body["carefulBot"])
+	assert.Equal(t, false, body["injectFeaturedNote"])
+	assert.Equal(t, false, body["receiveAnnouncementEmail"])
+}
+
+// #972: 4 field を omit した update は対応 profile field を変えない (= nil
+// pointer は no-op) ことを確認する。partial-update セマンティクスの担保。
+func TestUpdate_ProfileBoolFields_OmittedIsNoop(t *testing.T) {
+	h, repo, _, _ := newTestHandler(t)
+	user := &model.User{
+		ID:                "user1",
+		Username:          "user1",
+		AvatarDecorations: datatypes.JSON([]byte("[]")),
+	}
+	repo.Users["user1"] = user
+	repo.Profiles["user1"] = &model.UserProfile{
+		UserID:                   "user1",
+		Fields:                   datatypes.JSON([]byte("[]")),
+		AutoAcceptFollowed:       true,
+		CarefulBot:               true,
+		InjectFeaturedNote:       false,
+		ReceiveAnnouncementEmail: false,
+	}
+
+	// 別 field のみ更新する request — 4 field は不変であるべき。
+	rec := post(h.Update, `{"isLocked":true}`, user)
+	assert.Equal(t, http.StatusOK, rec.Code)
+
+	p := repo.Profiles["user1"]
+	assert.True(t, p.AutoAcceptFollowed, "omit した autoAcceptFollowed は不変")
+	assert.True(t, p.CarefulBot, "omit した carefulBot は不変")
+	assert.False(t, p.InjectFeaturedNote, "omit した injectFeaturedNote は不変")
+	assert.False(t, p.ReceiveAnnouncementEmail, "omit した receiveAnnouncementEmail は不変")
+}
+
 func TestUpdate_InvalidJSON(t *testing.T) {
 	h, _, _, _ := newTestHandler(t)
 	user := &model.User{ID: "user1"}

--- a/internal/core/user/user_service.go
+++ b/internal/core/user/user_service.go
@@ -301,6 +301,14 @@ type UpdateInput struct {
 	AutoSensitive     *bool
 	NoCrawle          *bool
 	PreventAiLearning *bool
+	// 以下 4 field は upstream Misskey TS i/update.ts:178-188 の paramDef に
+	// あり profile 側に persist される bool 設定。response 側 MeDetailed
+	// packer (#969) には含まれていたが、UpdateInput / UpdateRequest 側で
+	// 抜けていて silent drop される drift があった (#972)。
+	AutoAcceptFollowed       *bool
+	CarefulBot               *bool
+	InjectFeaturedNote       *bool
+	ReceiveAnnouncementEmail *bool
 	// ChatScope は誰からのチャットを許可するか (1-on-1 DM 用)。
 	// 受け付けるのは "everyone" / "followers" / "following" / "mutual" / "none"
 	// (CherryPick / Misskey TS と同じ enum)。検証は呼び出し側 (#692)。
@@ -404,6 +412,20 @@ func (s *Service) UpdateProfile(userID string, in UpdateInput) (*UserWithProfile
 	}
 	if in.PreventAiLearning != nil {
 		profileFields["preventAiLearning"] = *in.PreventAiLearning
+	}
+	// #972: upstream paramDef にあるが mk-go で抜けていた 4 field を
+	// profile に persist する。
+	if in.AutoAcceptFollowed != nil {
+		profileFields["autoAcceptFollowed"] = *in.AutoAcceptFollowed
+	}
+	if in.CarefulBot != nil {
+		profileFields["carefulBot"] = *in.CarefulBot
+	}
+	if in.InjectFeaturedNote != nil {
+		profileFields["injectFeaturedNote"] = *in.InjectFeaturedNote
+	}
+	if in.ReceiveAnnouncementEmail != nil {
+		profileFields["receiveAnnouncementEmail"] = *in.ReceiveAnnouncementEmail
 	}
 	if in.ChatScope != nil {
 		userFields["chatScope"] = *in.ChatScope

--- a/internal/testutil/mock_repository.go
+++ b/internal/testutil/mock_repository.go
@@ -589,6 +589,22 @@ func applyProfileFields(p *model.UserProfile, fields map[string]any) {
 			if b, ok := v.(bool); ok {
 				p.PreventAiLearning = b
 			}
+		case "autoAcceptFollowed":
+			if b, ok := v.(bool); ok {
+				p.AutoAcceptFollowed = b
+			}
+		case "carefulBot":
+			if b, ok := v.(bool); ok {
+				p.CarefulBot = b
+			}
+		case "injectFeaturedNote":
+			if b, ok := v.(bool); ok {
+				p.InjectFeaturedNote = b
+			}
+		case "receiveAnnouncementEmail":
+			if b, ok := v.(bool); ok {
+				p.ReceiveAnnouncementEmail = b
+			}
 		case "password":
 			if s, ok := v.(string); ok {
 				p.Password = &s


### PR DESCRIPTION
## Summary

upstream Misskey TS \`i/update.ts:178-188\` の paramDef にあるが、mk-go の \`UpdateRequest\` struct から抜けていて silent drop される 4 field を バンドル修正:

- \`autoAcceptFollowed\` — 鍵アカウントの自動承認設定
- \`carefulBot\` — bot からの follow / reaction の慎重モード
- \`injectFeaturedNote\` — おすすめ note を TL に混ぜる設定
- \`receiveAnnouncementEmail\` — 運営からのお知らせメール受信設定

response 側は #969 (\`PackMeDetailed\` packer) で含まれていたので、本 PR で input 側を対称化することで「読めるが書けない」asymmetric drift を解消する。fix の shape は同一 (struct + persist 3 か所) なので 1 PR でバンドル。

Closes #972

## 主な変更点

- \`internal/api/i/handler.go\`: \`UpdateRequest\` struct に 4 field 追加 + \`UpdateInput\` への copy 追加。
- \`internal/core/user/user_service.go\`: \`UpdateInput\` struct に 4 field 追加 + \`profileFields\` map への persist 処理追加。
- \`internal/testutil/mock_repository.go\`: \`MockUserRepository.UpdateProfile\` の switch case に 4 field を追加 (上記 service 経由の persist が mock 側でも反映されるように)。
- \`internal/api/i/handler_test.go\`: 2 test 追加。
  - \`TestUpdate_ProfileBoolFields_972\`: 4 field を request で送ると profile に persist + response body に新値が返ることを strict 検証。
  - \`TestUpdate_ProfileBoolFields_OmittedIsNoop\`: 4 field を omit した update で対応 profile field が不変 (= partial-update セマンティクス担保)。

## follow-up

- PR #967 の \`settings_privacy_auto_accept_followed_toggle.spec.ts\` を本 PR merge 後に strict assertion (\`expect(body.autoAcceptFollowed).toBe(true)\`) に戻す予定。
- 残 3 field (carefulBot / injectFeaturedNote / receiveAnnouncementEmail) は spec 化されていないので Playwright 側追加対応は不要。

## テスト

\`\`\`bash
go test ./internal/api/i/... -run \"TestUpdate_ProfileBoolFields\" -v   # 2 ケース pass
go test ./internal/api/i/... ./internal/core/user/... ./internal/testutil/...  # 全 pass
make fmt && make lint  # clean
\`\`\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)