### PR TITLE
feat(playwright): video recording を retain-on-failure で有効化

### DIFF
--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -75,7 +75,9 @@ jobs:
       - name: Run Playwright
         run: make ${{ matrix.test_target }}
 
-      # 失敗時のみ playwright test-results (trace / screenshot 含む) を保存。
+      # 失敗時のみ playwright test-results (trace / screenshot / video 含む)
+      # を保存。video は popup menu / contextmenu / multi-step interaction
+      # failure の debug 価値が高い。
       - name: Upload test-results on failure
         if: failure()
         uses: actions/upload-artifact@v4

--- a/tests/playwright/playwright.config.ts
+++ b/tests/playwright/playwright.config.ts
@@ -24,6 +24,13 @@ export default defineConfig({
     // API テスト中心なので screenshot / trace は失敗時のみで十分。
     screenshot: 'only-on-failure',
     trace: 'retain-on-failure',
+    // 失敗時のみ動画を保存する。batch 5 以降は popup menu / contextmenu /
+    // MkUserSelectDialog 等 multi-step interaction が増え、失敗時のスクショ
+    // 1 枚では原因特定が辛くなった。retain-on-failure は CI artifact 容量
+    // を抑えつつ、debug 価値の高い fail run のみ動画を残す。
+    // pass 時は browser context close 時に video を破棄するので、storage
+    // の累積 footprint は最小。size は 800x600 デフォルトで OK。
+    video: 'retain-on-failure',
     // nginx tls proxy が self-signed cert を提供する (#817 part2)。
     // Playwright はそれを accept できる必要がある。`request` fixture と
     // `page` fixture の両方に効く。


### PR DESCRIPTION
## Summary

Playwright spec の **動画撮影機能** を有効化。failure 時のみ動画を保存する \`retain-on-failure\` mode を採用し、batch 5 で大量に増えた popup menu / contextmenu / MkUserSelectDialog 等の multi-step interaction failure の debug を改善する。

## 主な変更点

- \`tests/playwright/playwright.config.ts\` の \`use\` block に \`video: 'retain-on-failure'\` を追加
- \`.github/workflows/playwright.yml\` の test-results upload 説明 comment に video 含まれる旨を追記

## なぜ retain-on-failure

| mode | pass run | fail run | trade-off |
|---|---|---|---|
| \`'off'\` (default) | 0 | 0 | debug できない |
| \`'on'\` | 全 spec で video 保存 | 同 | storage 浪費 |
| **\`'retain-on-failure'\`** | context close で破棄 | webm 保存 | **CI artifact ほぼ増えず、debug 価値最大** |

- pass 時 footprint ほぼゼロ
- 失敗 spec の動画は \`tests/playwright/test-results/\` に webm 出力
- 既存 nightly workflow は同ディレクトリを artifact 化済 (14 days retention) → 自動で video も含まれる

## debug 価値が高い flow 例

batch 5 で追加した spec のうち動画があると debug が捗るもの:

- popup menu 系 (note delete / pin / renote / thread-mute, user unmute / unblock / report-abuse)
- contextmenu 系 (drive folder delete / rename)
- multi-level popup (chat room create)
- MkUserSelectDialog (chat room invite)
- MkModalWindow + form (avatar decoration attach / detach)

これらは「click → menu open → click → confirm → click」の 3-5 ステップで、スクリーンショット 1 枚では中間状態が見えない。動画があれば「どの click が起きていないか」が一目で分かる。

## テスト

production code 変更なし、Go unit test 影響なし。Playwright local run で video が \`tests/playwright/test-results/\` に出力されるか確認は次 nightly run 待ち (CI で実機検証)。

🤖 Generated with [Claude Code](https://claude.com/claude-code)