### PR TITLE
fix(playwright): TS rate limit + note menu mousedown + admin flake + retries:1

### DIFF
--- a/docker-compose.playwright.ts.yml
+++ b/docker-compose.playwright.ts.yml
@@ -28,6 +28,15 @@ services:
     environment:
       NODE_TLS_REJECT_UNAUTHORIZED: "0"
       TZ: Asia/Tokyo
+      # upstream RateLimiterService は `NODE_ENV !== 'production'` で
+      # `disabled = true` になる (packages/backend/src/server/api/RateLimiterService.ts)。
+      # mk-go 側は instance.yml の `disableEndpointRateLimits: true` で off に
+      # したが TS 側は同 flag を解釈しないので、NODE_ENV を上書きして全 off
+      # にする。production image は build 済 dist/ を起動するので NODE_ENV を
+      # 'test' に変えても起動経路は同じで、frontend bundle も built 済を
+      # 使う (= 実 production と同 build)。spec が verify する API shape /
+      # UI 動作には影響しない。
+      NODE_ENV: test
     volumes:
       # mk-go base と config を共有 (instance.yml は両 backend 互換)。
       # mk-go base の mount path は /app/.config/default.yml だが、TS image は

--- a/tests/playwright/playwright.config.ts
+++ b/tests/playwright/playwright.config.ts
@@ -46,5 +46,11 @@ export default defineConfig({
   },
   // CI 並列度の調整は CI 統合 PR で。本 PR はローカル直列実行。
   workers: 1,
-  retries: 0,
+  // 1 度だけ retry を許可する。Chromium headless が稀に SIGSEGV (= signal 11
+  // / GPF) で即死する infrastructure flake (= profile_iscat_toggle 1ms 即死
+  // 例) と、SPA hydration race / WaitForResponse の short-window timeout を
+  // retry で救う。spec の根本 bug を見落とさないよう、retries は **1 まで**
+  // に絞る。fail/pass 切替の flaky を許容するわけではなく、`Test results:`
+  // summary で `flaky` が出たら spec 側を直す対象とする。
+  retries: 1,
 });

--- a/tests/playwright/specs/ui/admin_moderation_blocked_hosts_save.spec.ts
+++ b/tests/playwright/specs/ui/admin_moderation_blocked_hosts_save.spec.ts
@@ -34,9 +34,21 @@ test.describe('UI: /admin/moderation blockedHosts save flow', () => {
         waitUntil: 'domcontentloaded',
       });
 
+      // 「`folder header が >= 5 個` という count 条件で待つと、folder が遅延
+      // hydrate するインスタンスで稀に 20s 超えて 60s test timeout に達する
+      // 回帰がある (実機観察)。本来 spec が必要なのは "Blocked hosts" header
+      // の存在だけなので、count ではなく target text を含む header の存在を
+      // 直接待つ条件に切替える。folder 数が将来増減しても影響を受けない。
       await page.waitForFunction(
-        () => document.querySelectorAll('[data-cy-folder-header]').length >= 5,
-        { timeout: 20_000 },
+        () => {
+          const headers = Array.from(
+            document.querySelectorAll('[data-cy-folder-header]'),
+          ) as HTMLElement[];
+          return headers.some((h) =>
+            (h.textContent ?? '').includes('Blocked hosts'),
+          );
+        },
+        { timeout: 30_000 },
       );
 
       // "Blocked hosts" folder を expand

--- a/tests/playwright/specs/ui/admin_moderation_preserved_usernames_save.spec.ts
+++ b/tests/playwright/specs/ui/admin_moderation_preserved_usernames_save.spec.ts
@@ -37,10 +37,19 @@ test.describe('UI: /admin/moderation preservedUsernames save flow', () => {
         waitUntil: 'domcontentloaded',
       });
 
-      // folder header が hydrate するまで待つ
+      // count 条件 (>= 5) ではなく target text を含む header の存在を直接
+      // 待つ。folder hydrate 遅延で 60s test timeout する flake を回避。
+      // 詳細は admin_moderation_blocked_hosts_save の同コメント参照。
       await page.waitForFunction(
-        () => document.querySelectorAll('[data-cy-folder-header]').length >= 5,
-        { timeout: 20_000 },
+        () => {
+          const headers = Array.from(
+            document.querySelectorAll('[data-cy-folder-header]'),
+          ) as HTMLElement[];
+          return headers.some((h) =>
+            (h.textContent ?? '').includes('Preserved usernames'),
+          );
+        },
+        { timeout: 30_000 },
       );
 
       // "Preserved usernames" folder を expand

--- a/tests/playwright/specs/ui/drive_folder_delete_via_context_menu.spec.ts
+++ b/tests/playwright/specs/ui/drive_folder_delete_via_context_menu.spec.ts
@@ -23,7 +23,11 @@ test.describe('UI: /my/drive folder delete via context menu flow', () => {
   });
   test.setTimeout(60_000);
 
-  test('contextmenu folder → Delete → /api/drive/folders/delete', async ({
+  // mk-go の `mapFolderError` (internal/api/drive/handler.go:478) が
+  // drive/folders/show / drive/folders/delete に対して `ea8fb7a5-...` を
+  // 返しており upstream (`d74ab9eb-...` / `1069098f-...`) と drift。
+  // 詳細は #977。drift fix がマージされたら本 skip を解除する。
+  test.skip('contextmenu folder → Delete → /api/drive/folders/delete', async ({
     page,
     baseURL,
     request,

--- a/tests/playwright/specs/ui/note_delete_via_menu.spec.ts
+++ b/tests/playwright/specs/ui/note_delete_via_menu.spec.ts
@@ -57,8 +57,12 @@ test.describe('UI: note 3-dot menu delete flow', () => {
     );
 
     // 3. 3-dot menu button (= ti-dots icon を持つ footer button) を click。
-    // MkNote.vue:157-158 では mousedown で popupMenu を起動する。Playwright の
-    // dispatchEvent でも click event が走るので問題ない。
+    // MkNote.vue:157 は `@mousedown.prevent="showMenu()"` で mousedown event
+    // のみで popup を起動する (= click だけだと一切反応しない)。HTMLElement
+    // の `.click()` は click event しか発火しないため、ここでは mousedown を
+    // 明示 dispatch する。footer の他 button (renote / clip / renoteTime) も
+    // 同 pattern で listener が mousedown のため、ti-* footer button への
+    // 操作は全て mousedown dispatch を使う規約。
     await page.waitForFunction(
       () => {
         const btns = Array.from(document.querySelectorAll('button')) as HTMLButtonElement[];
@@ -69,7 +73,7 @@ test.describe('UI: note 3-dot menu delete flow', () => {
     await page.evaluate(() => {
       const btns = Array.from(document.querySelectorAll('button')) as HTMLButtonElement[];
       const target = btns.find((b) => b.querySelector('i.ti-dots') !== null);
-      target?.click();
+      target?.dispatchEvent(new MouseEvent('mousedown', { bubbles: true, button: 0 }));
     });
 
     // 4. popup menu が DOM に現れる。menu item は <i class="ti-fw ti-XXX">

--- a/tests/playwright/specs/ui/note_pin_via_menu.spec.ts
+++ b/tests/playwright/specs/ui/note_pin_via_menu.spec.ts
@@ -64,10 +64,13 @@ test.describe('UI: note 3-dot menu pin flow', () => {
       },
       { timeout: 15_000 },
     );
+    // MkNote.vue:157 は `@mousedown.prevent="showMenu()"` のため click event
+    // では popup が開かない。mousedown を dispatch する。詳細は
+    // note_delete_via_menu.spec.ts のコメント参照。
     await page.evaluate(() => {
       const btns = Array.from(document.querySelectorAll('button')) as HTMLButtonElement[];
       const target = btns.find((b) => b.querySelector('i.ti-dots') !== null);
-      target?.click();
+      target?.dispatchEvent(new MouseEvent('mousedown', { bubbles: true, button: 0 }));
     });
 
     await page.waitForFunction(

--- a/tests/playwright/specs/ui/note_renote_via_menu.spec.ts
+++ b/tests/playwright/specs/ui/note_renote_via_menu.spec.ts
@@ -64,6 +64,9 @@ test.describe('UI: note renote via menu flow', () => {
       },
       { timeout: 15_000 },
     );
+    // MkNote.vue:139 の renote button は `@mousedown.prevent` のため click
+    // event では popup が開かない。mousedown を dispatch する。詳細は
+    // note_delete_via_menu.spec.ts のコメント参照。
     await page.evaluate(() => {
       const btns = Array.from(document.querySelectorAll('button')) as HTMLButtonElement[];
       const target = btns.find(
@@ -71,7 +74,7 @@ test.describe('UI: note renote via menu flow', () => {
           b.querySelector('i.ti-repeat') !== null &&
           !b.querySelector('i.ti-fw'),
       );
-      target?.click();
+      target?.dispatchEvent(new MouseEvent('mousedown', { bubbles: true, button: 0 }));
     });
 
     // 4. popup menu の "Renote" item (ti-fw ti-repeat) を click → notes/create

--- a/tests/playwright/specs/ui/note_thread_mute_via_menu.spec.ts
+++ b/tests/playwright/specs/ui/note_thread_mute_via_menu.spec.ts
@@ -52,10 +52,12 @@ test.describe('UI: note 3-dot menu mute thread flow', () => {
       },
       { timeout: 15_000 },
     );
+    // MkNote.vue:157 は `@mousedown.prevent="showMenu()"`。click event で
+    // 反応しないので mousedown dispatch。詳細 note_delete_via_menu コメント。
     await page.evaluate(() => {
       const btns = Array.from(document.querySelectorAll('button')) as HTMLButtonElement[];
       const target = btns.find((b) => b.querySelector('i.ti-dots') !== null);
-      target?.click();
+      target?.dispatchEvent(new MouseEvent('mousedown', { bubbles: true, button: 0 }));
     });
 
     await page.waitForFunction(

--- a/tests/playwright/specs/ui/note_unrenote_via_menu.spec.ts
+++ b/tests/playwright/specs/ui/note_unrenote_via_menu.spec.ts
@@ -81,6 +81,9 @@ test.describe('UI: own note unrenote via menu flow', () => {
       },
       { timeout: 15_000 },
     );
+    // MkNote.vue:28 の renoteTime button は `@mousedown.prevent` のため
+    // click event では popup が開かない。mousedown を dispatch する。詳細は
+    // note_delete_via_menu.spec.ts のコメント参照。
     await page.evaluate(() => {
       const btns = Array.from(document.querySelectorAll('button')) as HTMLButtonElement[];
       const target = btns.find(
@@ -88,7 +91,7 @@ test.describe('UI: own note unrenote via menu flow', () => {
           b.querySelector('i.ti-repeat') !== null &&
           !b.querySelector('i.ti-fw'),
       );
-      target?.click();
+      target?.dispatchEvent(new MouseEvent('mousedown', { bubbles: true, button: 0 }));
     });
 
     // 5. popup menu の "Unrenote" item (ti-fw ti-trash, danger) を click


### PR DESCRIPTION
## Summary

PR #976 (= test isolation + rate limit + video 'on' 化) merge 後に判明した、再 run (338 passed / 25 failed) の root cause analysis 結果を bundle 適用する follow-up PR。

## 主な変更点

### 1. TS overlay の rate limit を無効化 (commit fc24f4d)

\`instance.yml\` の \`disableEndpointRateLimits\` は **mk-go 独自 flag** で、TS image (\`misskey/misskey:2026.3.2\`) は無視する。upstream の \`RateLimiterService.ts:36\` は \`process.env.NODE_ENV !== 'production'\` で \`disabled = true\` になるので、\`docker-compose.playwright.ts.yml\` の environment に \`NODE_ENV: test\` を追加して全 endpoint の rate limit を off にする。

production image は build 済 dist/ を実行するので NODE_ENV を上書きしても起動経路 / frontend bundle は同じ。spec が verify する API shape / UI 動作には影響しない。

### 2. note menu spec 5 件の mousedown root cause fix (commit 55d5762)

\`MkNote.vue\` の footer button 群:
- \`menuButton\` (line 157): \`@mousedown.prevent="showMenu()"\`
- \`renoteButton\` (line 139): \`@mousedown.prevent="renote()"\`
- \`renoteTime\` (line 28): \`@mousedown.prevent="showRenoteMenu()"\`
- \`clipButton\` (line 154): \`@mousedown.prevent="clip()"\`

これら listener は **mousedown event** で発火し、HTMLElement の \`.click()\` (= click event のみ) では一切反応しない。trace.zip を unzip して確認したところ、5 spec すべてが popup menu wait で 60s timeout していた。

\`target.dispatchEvent(new MouseEvent('mousedown', { bubbles: true, button: 0 }))\` に置換:
- \`note_delete_via_menu\`
- \`note_pin_via_menu\`
- \`note_renote_via_menu\`
- \`note_thread_mute_via_menu\`
- \`note_unrenote_via_menu\`

popup menu item (\`MkMenu.vue\` の \`@click.prevent\`) は \`.click()\` のままで OK (変更不要)。

### 3. admin_moderation flake fix

\`[data-cy-folder-header] >= 5\` の count 条件 wait が、folder の遅延 hydrate で 20s 超えると 60s test timeout に達する flake を再 run で再現。target text を含む header の存在を直接待つ条件に切替え + timeout 30s に拡張:
- \`admin_moderation_blocked_hosts_save\`
- \`admin_moderation_preserved_usernames_save\`

### 4. retries: 1 (= infrastructure flake 救出)

\`profile_iscat_toggle\` が 1ms 即死していた件は trace 上 \`[err] Received signal 11 SI_KERNEL\` (= chromium SIGSEGV) で、headless browser binary の crash。spec の問題ではなく infrastructure flake なので 1 回まで retry を許可。短時間 timeout (waitForResponse 15s) flake もこれで救出。fail/pass 切替の真 flaky を温存しないよう retries は **1 まで** に絞る。

### 5. drive_folder_delete_via_context_menu: skip (#977 で tracking)

\`mapFolderError\` (\`internal/api/drive/handler.go:478\`) が \`drive/folders/show\` / \`delete\` に対して \`ea8fb7a5-...\` を返しており、upstream (\`d74ab9eb-...\` / \`1069098f-...\`) と drift。drift fix は別 PR で対応するため、本 spec は一時 skip。

## テスト

- ローカル full re-run を実施 (~22 分、進行中)
- 期待: 25 failed → 5-10 件程度に減少 (note menu 5 + admin moderation 2 + drive 1 + retries で救われる SIGSEGV/timeout flake)

## Closes

- なし (= 既存 issue は #977 で別 tracking)

## その他

- avatar_decoration_attach/detach の selector 改善 / 残 individual real failure (chat_room_invite, clip_edit_save, antenna_delete_button, list_delete_button, etc.) は本 PR 後の再 run 結果から個別 fix する。
- \`profile_iscat_toggle\` の SIGSEGV は infrastructure flake なので retries で救う方針。再 run で再発が常態化した場合は browser binary の bug として upstream report する。