### PR TITLE
fix(playwright): note_unrenote selector + user_unblock confirm dialog

### DIFF
--- a/tests/playwright/specs/ui/note_unrenote_via_menu.spec.ts
+++ b/tests/playwright/specs/ui/note_unrenote_via_menu.spec.ts
@@ -64,20 +64,19 @@ test.describe('UI: own note unrenote via menu flow', () => {
 
     // 4. renoteTime button (= ti-repeat icon を持つ button、renote note
     // 自体の header にある) を click → showRenoteMenu。
-    // MkNote.vue:28-30 で renote header section 内に <button ref="renoteTime">
-    // + <i class="ti ti-repeat"> + 時間表示。footer の renote button (=
-    // post composer の renote 起動) も ti-repeat だが、そちらは class が
-    // footerButton 系。本 spec は renote 詳細ページで renote header の
-    // button を取りたい。両方とも ti-fw 修飾無しなので、最初の ti-repeat
-    // button (= header) を取る (= 通常 footer より先に DOM 配置)。
+    // MkNote.vue:28 の renote header に `<button ref="renoteTime"
+    // :class="$style.renoteTime"...>` が、line 139 footer に renoteButton
+    // も ti-repeat icon を持つ。CSS module の `.renoteTime` は Vite build
+    // で hash 化されるが `[class*="renoteTime"]` でマッチできる
+    // (#974 review でも同 pattern を採用)。`ti-fw 無し ti-repeat` だけだと
+    // 元 note の footer renote button にも match して race するので、CSS
+    // module class で renoteTime header button だけを精度高く特定する。
     await page.waitForFunction(
       () => {
-        const btns = Array.from(document.querySelectorAll('button')) as HTMLButtonElement[];
-        return btns.some(
-          (b) =>
-            b.querySelector('i.ti-repeat') !== null &&
-            !b.querySelector('i.ti-fw'),
-        );
+        const btns = Array.from(
+          document.querySelectorAll('button[class*="renoteTime"]'),
+        ) as HTMLButtonElement[];
+        return btns.some((b) => b.querySelector('i.ti-repeat') !== null);
       },
       { timeout: 15_000 },
     );
@@ -85,12 +84,10 @@ test.describe('UI: own note unrenote via menu flow', () => {
     // click event では popup が開かない。mousedown を dispatch する。詳細は
     // note_delete_via_menu.spec.ts のコメント参照。
     await page.evaluate(() => {
-      const btns = Array.from(document.querySelectorAll('button')) as HTMLButtonElement[];
-      const target = btns.find(
-        (b) =>
-          b.querySelector('i.ti-repeat') !== null &&
-          !b.querySelector('i.ti-fw'),
-      );
+      const btns = Array.from(
+        document.querySelectorAll('button[class*="renoteTime"]'),
+      ) as HTMLButtonElement[];
+      const target = btns.find((b) => b.querySelector('i.ti-repeat') !== null);
       target?.dispatchEvent(new MouseEvent('mousedown', { bubbles: true, button: 0 }));
     });
 

--- a/tests/playwright/specs/ui/user_unblock_via_menu.spec.ts
+++ b/tests/playwright/specs/ui/user_unblock_via_menu.spec.ts
@@ -1,10 +1,9 @@
 // /@username の 3-dot menu → menu の "Unblock" item (ti-fw ti-ban) を
-// click → /api/blocking/delete が直接 round-trip する write-flow spec。
+// click → confirm OK → /api/blocking/delete round-trip する write-flow spec。
 //
-// get-user-menu.ts の block toggle item は user.isBlocking フラグで text
-// (block / unblock) と action が切り替わる。block create は os.confirm
-// 経由、delete (= unblock) は直接 API。本 spec は setup で root が
-// target を block しておき、unblock の最短 path を verify する。
+// get-user-menu.ts:79 で `getConfirmed(...)` を unblock 経路でも経由する
+// (`user.isBlocking ? unblockConfirm : blockConfirm` の三項のため両 case
+// で confirm)。本 spec は confirm OK click を経て unblock を完了させる。
 
 import { readFileSync } from 'node:fs';
 import { expect, test } from '@playwright/test';
@@ -70,14 +69,26 @@ test.describe('UI: user 3-dot menu unblock flow', () => {
       { timeout: 10_000 },
     );
 
+    await page.evaluate(() => {
+      const btns = Array.from(document.querySelectorAll('button')) as HTMLButtonElement[];
+      const target = btns.find((b) => b.querySelector('i.ti-fw.ti-ban') !== null);
+      target?.click();
+    });
+
+    // confirm dialog の OK click → /api/blocking/delete
+    await page.waitForFunction(
+      () => document.querySelector('[data-cy-modal-dialog-ok]') !== null,
+      { timeout: 10_000 },
+    );
     const unblockResp = page.waitForResponse(
       (r) => r.url().includes('/api/blocking/delete') && r.status() < 300,
       { timeout: 15_000 },
     );
     await page.evaluate(() => {
-      const btns = Array.from(document.querySelectorAll('button')) as HTMLButtonElement[];
-      const target = btns.find((b) => b.querySelector('i.ti-fw.ti-ban') !== null);
-      target?.click();
+      const ok = document.querySelector(
+        '[data-cy-modal-dialog-ok]',
+      ) as HTMLButtonElement | null;
+      ok?.click();
     });
     await unblockResp;
 


### PR DESCRIPTION
## Summary

PR #978 後の再 run (343 passed / 19 failed) で retries:1 でも救えなかった真の spec bug を 2 件修正。

## 主な変更点

### 1. note_unrenote_via_menu

**Root cause**: selector \`i.ti-repeat && !i.ti-fw\` が renote header の \`renoteTime\` button と元 note footer の \`renoteButton\` 両方にマッチして race。\`button[class*=\"renoteTime\"]\` で CSS module class hash 越しに renoteTime header だけを精度高く特定する。

\`renoteTime\` は \`MkNote.vue:28\` の renote header 内 button (\`@mousedown.prevent=\"showRenoteMenu()\"\`) で、CSS module の \`.renoteTime\` は Vite build で hash 化される。前 PR の \`[class*=\"...\"]\` selector pattern を踏襲。

### 2. user_unblock_via_menu

**Root cause**: \`get-user-menu.ts:79\` で \`getConfirmed(...)\` を block / unblock 両 case で経由する (\`user.isBlocking ? unblockConfirm : blockConfirm\` の三項のため)。spec が confirm dialog OK click を忘れており、\`/api/blocking/delete\` API が trigger されないまま 15s timeout していた。

修正: Delete item click → confirm dialog 出現待ち → \`[data-cy-modal-dialog-ok]\` click → API verify の順に変更。spec の冒頭コメントも 「unblock は直接 API」→「両 case で confirm 経由」に訂正。

## テスト

- 本 PR で 19 → 17 件に減少 (note_unrenote / user_unblock の 2 件解消)
- 残 17 件は #979 で個別 tracking

## Closes

- なし (= 残 17 件の親 tracker #979 でまとめて follow-up)

## その他

- 残 17 件の breakdown は #979 参照。waitForResponse / waitForFunction timeout / Test timeout が大半で、各 spec で trace.zip 解析が必要。共通 pattern (mousedown / confirm dialog / SPA mount race / selector 過広) ごとに bundle PR で出す予定。