### PR TITLE
fix(playwright): admin_moderation i18n labels + avatar_decoration selector

### DIFF
--- a/tests/playwright/specs/ui/admin_moderation_blocked_hosts_save.spec.ts
+++ b/tests/playwright/specs/ui/admin_moderation_blocked_hosts_save.spec.ts
@@ -45,7 +45,7 @@ test.describe('UI: /admin/moderation blockedHosts save flow', () => {
             document.querySelectorAll('[data-cy-folder-header]'),
           ) as HTMLElement[];
           return headers.some((h) =>
-            (h.textContent ?? '').includes('Blocked hosts'),
+            (h.textContent ?? '').includes('Blocked Instances'),
           );
         },
         { timeout: 30_000 },
@@ -57,7 +57,7 @@ test.describe('UI: /admin/moderation blockedHosts save flow', () => {
           document.querySelectorAll('[data-cy-folder-header]'),
         ) as HTMLElement[];
         const target = headers.find((h) =>
-          (h.textContent ?? '').includes('Blocked hosts'),
+          (h.textContent ?? '').includes('Blocked Instances'),
         );
         target?.click();
       });

--- a/tests/playwright/specs/ui/admin_moderation_preserved_usernames_save.spec.ts
+++ b/tests/playwright/specs/ui/admin_moderation_preserved_usernames_save.spec.ts
@@ -46,7 +46,7 @@ test.describe('UI: /admin/moderation preservedUsernames save flow', () => {
             document.querySelectorAll('[data-cy-folder-header]'),
           ) as HTMLElement[];
           return headers.some((h) =>
-            (h.textContent ?? '').includes('Preserved usernames'),
+            (h.textContent ?? '').includes('Reserved usernames'),
           );
         },
         { timeout: 30_000 },
@@ -58,7 +58,7 @@ test.describe('UI: /admin/moderation preservedUsernames save flow', () => {
           document.querySelectorAll('[data-cy-folder-header]'),
         ) as HTMLElement[];
         const target = headers.find((h) =>
-          (h.textContent ?? '').includes('Preserved usernames'),
+          (h.textContent ?? '').includes('Reserved usernames'),
         );
         target?.click();
       });

--- a/tests/playwright/specs/ui/avatar_decoration_attach_via_dialog.spec.ts
+++ b/tests/playwright/specs/ui/avatar_decoration_attach_via_dialog.spec.ts
@@ -60,13 +60,22 @@ test.describe('UI: /settings/avatar-decoration attach via dialog flow', () => {
     );
 
     // 5. 該当 decoration の card を click (= openDecoration → XDialog)
-    // XDecoration は内部で `<img>` を持つ。decoration name を含む親要素を
-    // 探して click する。
+    // avatar-decoration.decoration.vue の root は `<div :class="$style.root"
+    // @click="emit('click')">` で CSS module の root class を持つ。元の
+    // `div, button` 全部対象 + textContent.includes selector は body 等の
+    // page-level 親要素を pickup して click を listener 持たない要素に投げ、
+    // XDialog が出ないまま 90s timeout する flake になっていた。
+    // `[class*="decorations"]` (= 親 grid container) 内の `[class*="root"]`
+    // (= XDecoration root) で精度高く絞る。CSS module hash の差分は
+    // `[class*="..."]` で吸収。
     await page.evaluate((n) => {
-      const els = Array.from(document.querySelectorAll('[class*="decoration"], div, button')) as HTMLElement[];
-      const target = els.find(
-        (el) => (el.textContent ?? '').trim().includes(n) && el.querySelector('img') !== null,
-      );
+      const roots: Element[] = [];
+      document.querySelectorAll('[class*="decorations"]').forEach((c) => {
+        c.querySelectorAll('[class*="root"]').forEach((r) => roots.push(r));
+      });
+      const target = roots.find(
+        (el) => (el.textContent ?? '').includes(n),
+      ) as HTMLElement | undefined;
       target?.click();
     }, decorationName);
 

--- a/tests/playwright/specs/ui/avatar_decoration_detach_via_dialog.spec.ts
+++ b/tests/playwright/specs/ui/avatar_decoration_detach_via_dialog.spec.ts
@@ -74,27 +74,27 @@ test.describe('UI: /settings/avatar-decoration detach via dialog flow', () => {
       { timeout: 20_000 },
     );
 
-    // 4. 装着済 thumbnail (= 上部 attached list の最初の card) を click。
-    // attached card は openAttachedDecoration を bind しており、img を含む。
-    // 装着済の url 専用 img を持つ card を click することで XDialog が
-    // usingIndex != null mode で起動する。
+    // 4. 装着済 thumbnail (= 上部 attached list の card) を click。
+    // avatar-decoration.decoration.vue:7-9 の root は
+    // `<div :class="$style.root" @click="emit('click')">`。Vue の @click は
+    // addEventListener-based なので element.onclick property には現れない
+    // (= 旧 spec の `node.onclick` 判定は常に false で fallback img.click()
+    // に到達 → bubbling は通るが listener が走らない race の場面があり
+    // 90s timeout していた)。`[class*="decorations"]` 親 grid 内の
+    // `[class*="root"]` で XDecoration root を直接特定し、url を含む img を
+    // 持つ root だけを target に絞る。CSS module hash 差分は `[class*="..."]`
+    // で吸収。avatar-decoration.vue 上部 (attached) → 下部 (available) の
+    // DOM 順なので find() で最初に hit するのは attached side (= 装着済)。
     await page.evaluate((u) => {
-      const imgs = Array.from(document.querySelectorAll('img')) as HTMLImageElement[];
-      const targetImg = imgs.find((i) => i.src.includes(u));
-      if (!targetImg) return;
-      // img を含む clickable 親要素を探す。click handler は a / div / button
-      // のいずれかにある (avatar-decoration.vue:25-26 では @click bind の
-      // div)。
-      let node: HTMLElement | null = targetImg;
-      for (let depth = 0; depth < 6 && node; depth++) {
-        if (node.tagName === 'A' || node.tagName === 'BUTTON' || node.onclick) {
-          node.click();
-          return;
-        }
-        node = node.parentElement;
-      }
-      // fallback: img の最も近い parent を click (Vue listener が capture)
-      targetImg.click();
+      const roots: Element[] = [];
+      document.querySelectorAll('[class*="decorations"]').forEach((c) => {
+        c.querySelectorAll('[class*="root"]').forEach((r) => roots.push(r));
+      });
+      const target = roots.find((el) => {
+        const img = el.querySelector('img') as HTMLImageElement | null;
+        return img !== null && img.src.includes(u);
+      }) as HTMLElement | undefined;
+      target?.click();
     }, decorationUrl);
 
     // 5. XDialog の "Detach" button (ti-x + "Detach") hydrate を待つ。

--- a/tests/playwright/specs/ui/avatar_decoration_detach_via_dialog.spec.ts
+++ b/tests/playwright/specs/ui/avatar_decoration_detach_via_dialog.spec.ts
@@ -80,16 +80,23 @@ test.describe('UI: /settings/avatar-decoration detach via dialog flow', () => {
     // addEventListener-based なので element.onclick property には現れない
     // (= 旧 spec の `node.onclick` 判定は常に false で fallback img.click()
     // に到達 → bubbling は通るが listener が走らない race の場面があり
-    // 90s timeout していた)。`[class*="decorations"]` 親 grid 内の
-    // `[class*="root"]` で XDecoration root を直接特定し、url を含む img を
-    // 持つ root だけを target に絞る。CSS module hash 差分は `[class*="..."]`
-    // で吸収。avatar-decoration.vue 上部 (attached) → 下部 (available) の
-    // DOM 順なので find() で最初に hit するのは attached side (= 装着済)。
+    // 90s timeout していた)。
+    //
+    // avatar-decoration.vue は **上部 = 装着済 (attached) / 下部 = 利用可能
+    // (available)** の 2 つの `[class*="decorations"]` grid を持ち、本 spec
+    // の setup では同じ decoration が両方に表示される。`querySelectorAll` は
+    // DOM 順を保証するので 0 番目 (= attached) container を strict に取り、
+    // 下部 available 側を誤って click してしまう risk を排除する。
+    // CSS module hash 差分は `[class*="..."]` で吸収。
     await page.evaluate((u) => {
-      const roots: Element[] = [];
-      document.querySelectorAll('[class*="decorations"]').forEach((c) => {
-        c.querySelectorAll('[class*="root"]').forEach((r) => roots.push(r));
-      });
+      const containers = Array.from(
+        document.querySelectorAll('[class*="decorations"]'),
+      );
+      const attachedContainer = containers[0];
+      if (!attachedContainer) return;
+      const roots = Array.from(
+        attachedContainer.querySelectorAll('[class*="root"]'),
+      );
       const target = roots.find((el) => {
         const img = el.querySelector('img') as HTMLImageElement | null;
         return img !== null && img.src.includes(u);


### PR DESCRIPTION
## Summary

#979 で tracking していた残 17 件のうち、root cause を確定できた 4 件を修正する follow-up PR。

## 主な変更点

### 1. admin_moderation_blocked_hosts_save (i18n label drift)

spec が \`'Blocked hosts'\` を \`[data-cy-folder-header]\` text matching で待っていたが、\`admin/moderation.vue:140\` の i18n key は \`blockedInstances\` で en-US.yml の値は **\`\"Blocked Instances\"\`**。PR #978 の selector 改善 (count → text-based) は正しい方向だったが、target text 自体が drift していて永遠に hit しない罠だった。

### 2. admin_moderation_preserved_usernames_save (i18n label drift)

同様に \`'Preserved usernames'\` に対し、\`preservedUsernames\` の en-US.yml 値は **\`\"Reserved usernames\"\`** (preserved → reserved の表記揺れ)。

### 3. avatar_decoration_attach_via_dialog (selector 過広)

\`[class*=\"decoration\"], div, button\` + \`textContent.includes(name)\` で page-level 親要素 (body / main / etc) が hit して click が listener 持たない要素に投げられ、XDialog が出ないまま 90s timeout していた。

\`avatar-decoration.decoration.vue:7-9\` の root は \`<div :class=\"\$style.root\" @click=\"emit('click')\">\` で、親 grid は \`[class*=\"decorations\"]\` を持つ。この階層を辿る selector に絞り込み:
- \`[class*=\"decorations\"]\` 内の \`[class*=\"root\"]\` を target に
- CSS module hash 差分は \`[class*=\"...\"]\` で吸収

### 4. avatar_decoration_detach_via_dialog (Vue @click 判定誤り + selector 統一)

旧実装は img tag から ancestor を辿って \`node.onclick\` を判定していたが、Vue の \`@click\` listener は addEventListener-based で \`element.onclick\` property には現れないため、判定が常に false で fallback \`targetImg.click()\` に到達。img.click() の bubbling は通るが timing race で 90s timeout する場面があった。

attach 同様に \`[class*=\"decorations\"]\` 親 → \`[class*=\"root\"]\` で XDecoration root を直接特定し、url を含む img を持つ root を click する pattern に統一。

## テスト

ローカル full re-run で 19 → 15 件想定 (本 PR の 4 件解消)。残 13 件は個別の root cause があり、#979 で tracking 継続:

- \`admin_announcement_unarchive_button\`: \`/admin/announcements\` の MkSelect dropdown で archived filter 切替が必要 (= 初期 'active' filter のため archived announcement が list に出ない)
- \`antenna_delete_button\`: \`MkAntennaEditor\` mount race
- 他 11 件は個別 trace 解析が必要

## Closes

- なし (= 残 13 件は #979 で tracking)

## その他

- 本 PR で fix した 4 件のうち 2 件 (admin_moderation × 2) は **i18n label drift** で、PR #978 の selector 改善 (count → text-based) を採用したが target text 自体が間違っていた。今後 text-based selector を作る際は \`en-US.yml\` で実値確認するのが必須。