### PR TITLE
fix: drift bundle 3 件 (#977 drive folders UUID + #984 users/relation + #985 MeDetailed notification fields)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ Playwright spec を両 backend で走らせる中で観測した drop-in 互換 
 - #812: drive/files/create userId / user / folder shape
 - #818: drive/files/find / find-by-hash の packMany self path
 - #845: drive/folders/show detail mode (parent / counts)
+- #977: drive/folders 系の `NO_SUCH_FOLDER` UUID を endpoint 別 (create `53326628-...` / show `d74ab9eb-...` / update `f7974dac-...` / delete `1069098f-...`) に分割。`folders/update` の parent 不在を `NO_SUCH_PARENT_FOLDER` (`ce104e3a-...`) として区別するため `ErrParentFolderNotFound` を追加
 
 #### chat
 - #851 / #855 / #860: chat packMessage / packRoom の null 省略 / field set drift
@@ -42,6 +43,7 @@ Playwright spec を両 backend で走らせる中で観測した drop-in 互換 
 - #870: blocking/create / delete return shape (UserDetailed 返却)
 - #871: users/lists/create response shape (createdAt / userIds / isPublic)
 - #872: blocked → following/create reject status (400)
+- #984: users/relation を stub から実装に切替。viewer ↔ target の follow / follow-request / block / mute / renote-mute 状態を 5 repo (`following` / `follow_request` / `blocking` / `muting` / `renote_muting`) から実 DB 状態として返す
 
 #### settings / token
 - #883: i/regenerate-token return shape (204)
@@ -49,6 +51,7 @@ Playwright spec を両 backend で走らせる中で観測した drop-in 互換 
 - #885: i/update-email error status 標準化
 - #910: app-issued access token を auth middleware で dual lookup (raw → hash)
 - #913: i/revoke-token も dual lookup + cache invalidation
+- #985: `entity.PackMeDetailed` に `emailNotificationTypes` / `mutingNotificationTypes` / `notificationRecieveConfig` を追加。i/update 経路でも 3 field が返るようになり、frontend の `updateCurrentAccountPartial` が settings/email 等の toggle 後に local state を正しく反映できる。値は `user_profile` の JSON column を unmarshal して取得し、parse 失敗時は upstream default (`["follow","receiveFollowRequest"]` / `[]` / `{}`) に倒す
 
 #### admin
 - #888: admin/show-user shape (roles / policies / signins / roleAssigns / isHibernated / lastActiveDate)

--- a/docs/api-compatibility.md
+++ b/docs/api-compatibility.md
@@ -91,6 +91,7 @@ Playwright spec を両 backend で走らせる中で観測した「TS と mk-go 
 | #812 | drive/files/create userId / user / folder shape |
 | #818 | drive/files/find / find-by-hash の packMany self path drift |
 | #845 | drive/folders/show detail mode (parent / counts) |
+| #977 | drive/folders 系の `NO_SUCH_FOLDER` UUID を endpoint 別に分割 (create `53326628-...` / show `d74ab9eb-...` / update `f7974dac-...` / delete `1069098f-...`) + `folders/update` の parent 不在を `NO_SUCH_PARENT_FOLDER` (`ce104e3a-...`) で区別 |
 
 #### chat
 | # | 内容 |
@@ -104,6 +105,7 @@ Playwright spec を両 backend で走らせる中で観測した「TS と mk-go 
 | #870 | blocking/create / delete return shape (UserDetailed を返す) |
 | #871 | users/lists/create response shape (createdAt / userIds / isPublic 含む) |
 | #872 | blocked → following/create reject status (400) |
+| #984 | users/relation を stub から実装に切替。viewer ↔ target の follow / follow-request / block / mute / renote-mute を 5 repo (`following` / `follow_request` / `blocking` / `muting` / `renote_muting`) から実 DB 状態として返す |
 
 #### settings / token
 | # | 内容 |
@@ -113,6 +115,7 @@ Playwright spec を両 backend で走らせる中で観測した「TS と mk-go 
 | #885 | i/update-email error status 標準化 |
 | #910 | app-issued access token を auth middleware で dual lookup (raw → hash) |
 | #913 | i/revoke-token も dual lookup + cache invalidation 化 |
+| #985 | `entity.PackMeDetailed` に `emailNotificationTypes` / `mutingNotificationTypes` / `notificationRecieveConfig` を追加 (i/update 経路で frontend `$i` state が settings/email 等の toggle 後に正しく反映される) |
 
 #### admin
 | # | 内容 |

--- a/internal/api/drive/handler.go
+++ b/internal/api/drive/handler.go
@@ -3,6 +3,7 @@ package drive
 
 import (
 	"errors"
+	"fmt"
 	"io"
 	"log/slog"
 	"net/http"
@@ -501,6 +502,10 @@ func mapFolderError(c echo.Context, err error, ep folderEndpoint) error {
 			id = "f7974dac-2c0d-4a27-926e-23583b28e98e"
 		case folderEndpointDelete:
 			id = "1069098f-c281-440f-b085-f9932edbe091"
+		default:
+			// 将来 endpoint を追加して switch case を漏らすと UUID drift で
+			// frontend / spec が壊れるので fail-fast する。
+			panic(fmt.Sprintf("mapFolderError: unknown folderEndpoint %d", ep))
 		}
 		return c.JSON(http.StatusNotFound, apierr.Error("NO_SUCH_FOLDER", "No such folder.", id))
 	case errors.Is(err, coredrive.ErrParentFolderNotFound):

--- a/internal/api/drive/handler.go
+++ b/internal/api/drive/handler.go
@@ -344,7 +344,7 @@ func (h *Handler) FoldersCreate(c echo.Context) error {
 	}
 	f, err := h.svc.CreateFolder(user, req.Name, req.ParentID)
 	if err != nil {
-		return mapFolderError(c, err)
+		return mapFolderError(c, err, folderEndpointCreate)
 	}
 	return c.JSON(http.StatusOK, entity.PackDriveFolder(f, h.idGen))
 }
@@ -367,7 +367,7 @@ func (h *Handler) FoldersShow(c echo.Context) error {
 	}
 	f, err := h.svc.ShowFolder(user, req.FolderID)
 	if err != nil {
-		return mapFolderError(c, err)
+		return mapFolderError(c, err, folderEndpointShow)
 	}
 	return c.JSON(http.StatusOK, h.packDriveFolderDetail(f))
 }
@@ -440,7 +440,7 @@ func (h *Handler) FoldersUpdate(c echo.Context) error {
 	}
 	f, err := h.svc.UpdateFolder(user, req.FolderID, in)
 	if err != nil {
-		return mapFolderError(c, err)
+		return mapFolderError(c, err, folderEndpointUpdate)
 	}
 	return c.JSON(http.StatusOK, entity.PackDriveFolder(f, h.idGen))
 }
@@ -453,7 +453,7 @@ func (h *Handler) FoldersDelete(c echo.Context) error {
 		return apierr.JSONInvalidParam(c)
 	}
 	if err := h.svc.DeleteFolder(user, req.FolderID); err != nil {
-		return mapFolderError(c, err)
+		return mapFolderError(c, err, folderEndpointDelete)
 	}
 	return c.NoContent(http.StatusNoContent)
 }
@@ -472,10 +472,42 @@ func mapFileError(c echo.Context, err error) error {
 	return apierr.JSONInternalError(c)
 }
 
-func mapFolderError(c echo.Context, err error) error {
+// folderEndpoint identifies which drive/folders endpoint produced a folder
+// error, so that mapFolderError can return the upstream-canonical UUID for
+// NO_SUCH_FOLDER. Misskey TS uses a distinct UUID per endpoint (#977):
+//   - create: 53326628-a00d-40a6-a3cd-8975105c0f95 (parent not found)
+//   - show:   d74ab9eb-bb09-4bba-bf24-fb58f761e1e9
+//   - update: f7974dac-2c0d-4a27-926e-23583b28e98e (target not found)
+//   - delete: 1069098f-c281-440f-b085-f9932edbe091
+type folderEndpoint int
+
+const (
+	folderEndpointCreate folderEndpoint = iota
+	folderEndpointShow
+	folderEndpointUpdate
+	folderEndpointDelete
+)
+
+func mapFolderError(c echo.Context, err error, ep folderEndpoint) error {
 	switch {
 	case errors.Is(err, coredrive.ErrFolderNotFound):
-		return c.JSON(http.StatusNotFound, apierr.Error("NO_SUCH_FOLDER", "No such folder.", "ea8fb7a5-af77-4a08-b608-c0218176cd73"))
+		var id string
+		switch ep {
+		case folderEndpointCreate:
+			id = "53326628-a00d-40a6-a3cd-8975105c0f95"
+		case folderEndpointShow:
+			id = "d74ab9eb-bb09-4bba-bf24-fb58f761e1e9"
+		case folderEndpointUpdate:
+			id = "f7974dac-2c0d-4a27-926e-23583b28e98e"
+		case folderEndpointDelete:
+			id = "1069098f-c281-440f-b085-f9932edbe091"
+		}
+		return c.JSON(http.StatusNotFound, apierr.Error("NO_SUCH_FOLDER", "No such folder.", id))
+	case errors.Is(err, coredrive.ErrParentFolderNotFound):
+		// folders/update のみ NO_SUCH_PARENT_FOLDER を区別する。
+		// folders/create の parent 不在は upstream も NO_SUCH_FOLDER 扱い
+		// (ErrParentFolderNotFound はそもそも CreateFolder では返らない)。
+		return c.JSON(http.StatusNotFound, apierr.Error("NO_SUCH_PARENT_FOLDER", "No such parent folder.", "ce104e3a-faaf-49d5-b459-10ff0cbbcaa1"))
 	case errors.Is(err, coredrive.ErrAccessDenied):
 		return c.JSON(http.StatusForbidden, apierr.Error("ACCESS_DENIED", "Access denied.", "fe8d7103-0ea8-4ec3-814d-f8b401dc69e9"))
 	case errors.Is(err, coredrive.ErrFolderNotEmpty):

--- a/internal/api/drive/handler_test.go
+++ b/internal/api/drive/handler_test.go
@@ -583,10 +583,10 @@ func TestFoldersUpdate_NotFound(t *testing.T) {
 	// #977: folders/update target not found UUID は f7974dac-...
 	var body map[string]any
 	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &body))
-	if errObj, ok := body["error"].(map[string]any); ok {
-		assert.Equal(t, "NO_SUCH_FOLDER", errObj["code"])
-		assert.Equal(t, "f7974dac-2c0d-4a27-926e-23583b28e98e", errObj["id"])
-	}
+	errObj, ok := body["error"].(map[string]any)
+	require.True(t, ok)
+	assert.Equal(t, "NO_SUCH_FOLDER", errObj["code"])
+	assert.Equal(t, "f7974dac-2c0d-4a27-926e-23583b28e98e", errObj["id"])
 }
 
 // #977: folders/update で parent が未存在のときに NO_SUCH_PARENT_FOLDER

--- a/internal/api/drive/handler_test.go
+++ b/internal/api/drive/handler_test.go
@@ -407,6 +407,13 @@ func TestFoldersCreate_ParentNotFound(t *testing.T) {
 	setUser(c, "u1")
 	require.NoError(t, h.FoldersCreate(c))
 	assert.Equal(t, http.StatusNotFound, rec.Code)
+	// #977: folders/create の parent 不在 UUID は 53326628-...
+	var body map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &body))
+	errObj, ok := body["error"].(map[string]any)
+	require.True(t, ok)
+	assert.Equal(t, "NO_SUCH_FOLDER", errObj["code"])
+	assert.Equal(t, "53326628-a00d-40a6-a3cd-8975105c0f95", errObj["id"])
 }
 
 func TestFoldersCreate_AccessDenied(t *testing.T) {
@@ -506,6 +513,13 @@ func TestFoldersShow_NotFound(t *testing.T) {
 	setUser(c, "u1")
 	require.NoError(t, h.FoldersShow(c))
 	assert.Equal(t, http.StatusNotFound, rec.Code)
+	// #977: folders/show の target 不在 UUID は d74ab9eb-...
+	var body map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &body))
+	errObj, ok := body["error"].(map[string]any)
+	require.True(t, ok)
+	assert.Equal(t, "NO_SUCH_FOLDER", errObj["code"])
+	assert.Equal(t, "d74ab9eb-bb09-4bba-bf24-fb58f761e1e9", errObj["id"])
 }
 
 func TestFoldersShow_AccessDenied(t *testing.T) {
@@ -566,6 +580,31 @@ func TestFoldersUpdate_NotFound(t *testing.T) {
 	setUser(c, "u1")
 	require.NoError(t, h.FoldersUpdate(c))
 	assert.Equal(t, http.StatusNotFound, rec.Code)
+	// #977: folders/update target not found UUID は f7974dac-...
+	var body map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &body))
+	if errObj, ok := body["error"].(map[string]any); ok {
+		assert.Equal(t, "NO_SUCH_FOLDER", errObj["code"])
+		assert.Equal(t, "f7974dac-2c0d-4a27-926e-23583b28e98e", errObj["id"])
+	}
+}
+
+// #977: folders/update で parent が未存在のときに NO_SUCH_PARENT_FOLDER
+// (UUID ce104e3a-...) を返すこと。ErrParentFolderNotFound branch のカバー。
+func TestFoldersUpdate_ParentNotFound(t *testing.T) {
+	h, _, folderRepo := newHandler(t)
+	uid := "u1"
+	folderRepo.Folders["c"] = &model.DriveFolder{ID: "c", UserID: &uid}
+	c, rec := newJSONReq(t, `{"folderId":"c","parentId":"ghost"}`)
+	setUser(c, "u1")
+	require.NoError(t, h.FoldersUpdate(c))
+	assert.Equal(t, http.StatusNotFound, rec.Code)
+	var body map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &body))
+	errObj, ok := body["error"].(map[string]any)
+	require.True(t, ok)
+	assert.Equal(t, "NO_SUCH_PARENT_FOLDER", errObj["code"])
+	assert.Equal(t, "ce104e3a-faaf-49d5-b459-10ff0cbbcaa1", errObj["id"])
 }
 
 // --- FoldersDelete ---
@@ -594,6 +633,13 @@ func TestFoldersDelete_NotFound(t *testing.T) {
 	setUser(c, "u1")
 	require.NoError(t, h.FoldersDelete(c))
 	assert.Equal(t, http.StatusNotFound, rec.Code)
+	// #977: folders/delete の UUID は 1069098f-...
+	var body map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &body))
+	errObj, ok := body["error"].(map[string]any)
+	require.True(t, ok)
+	assert.Equal(t, "NO_SUCH_FOLDER", errObj["code"])
+	assert.Equal(t, "1069098f-c281-440f-b085-f9932edbe091", errObj["id"])
 }
 
 func TestFoldersDelete_NotEmpty(t *testing.T) {

--- a/internal/api/i/handler.go
+++ b/internal/api/i/handler.go
@@ -692,9 +692,28 @@ func (h *Handler) Me(c echo.Context) error {
 	} else {
 		resp["securityKeysList"] = []any{}
 	}
-	resp["mutingNotificationTypes"] = []any{}
-	resp["notificationRecieveConfig"] = map[string]any{}
-	resp["emailNotificationTypes"] = []string{"follow", "receiveFollowRequest"}
+	// upstream `MeDetailed` の notification-related 3 field (#985)。
+	// PackMeDetailed と同じ default + profile JSON 由来の値を入れる
+	// (i/update 経路と一貫性を持たせるため)。
+	resp["mutingNotificationTypes"] = []string{}
+	notifConf := map[string]any{}
+	emailTypes := []string{"follow", "receiveFollowRequest"}
+	if profile != nil {
+		if raw := []byte(profile.EmailNotificationTypes); len(raw) > 0 {
+			var arr []string
+			if err := json.Unmarshal(raw, &arr); err == nil {
+				emailTypes = arr
+			}
+		}
+		if raw := []byte(profile.NotificationRecieveConfig); len(raw) > 0 {
+			var m map[string]any
+			if err := json.Unmarshal(raw, &m); err == nil && m != nil {
+				notifConf = m
+			}
+		}
+	}
+	resp["notificationRecieveConfig"] = notifConf
+	resp["emailNotificationTypes"] = emailTypes
 
 	// createdAt は ID から復元
 	if t, err := h.idGen.ParseTime(u.ID); err == nil {

--- a/internal/api/users/handler_extra.go
+++ b/internal/api/users/handler_extra.go
@@ -19,9 +19,16 @@ func (h *Handler) SetAbuseRepo(r repository.AbuseReportRepository) {
 }
 
 // Relation handles POST /api/users/relation.
-// ユーザー間の関係 (フォロー/ブロック/ミュート等) を返す。
+// upstream Misskey TS `users/relation.ts` (= getRelation in
+// server/api/common/getRelation.ts) と同 semantics で viewer と target の
+// follow / follow-request / block / mute / renote-mute の関係性を返す。
+//
+// repo が wired されていない (= legacy handler test) では該当 field を false
+// に保つので production runtime には影響しない (router で必ず wired される)。
+// viewer が unauthenticated でも middleware.GetUser が non-nil を返さないだけ
+// で 401 にはならない (= 関係性は全 false で返る、upstream も viewer 必須)。
 func (h *Handler) Relation(c echo.Context) error {
-	_ = middleware.GetUser(c) // 認証チェック
+	viewer := middleware.GetUser(c)
 	var req struct {
 		UserID string `json:"userId"`
 	}
@@ -29,7 +36,7 @@ func (h *Handler) Relation(c echo.Context) error {
 		return c.JSON(http.StatusBadRequest, apierr.Error("INVALID_PARAM", "userId is required.", "3d81ceae-475f-4600-b2a8-2bc116157532"))
 	}
 
-	return c.JSON(http.StatusOK, map[string]any{
+	out := map[string]any{
 		"id":                             req.UserID,
 		"isFollowing":                    false,
 		"isFollowed":                     false,
@@ -39,7 +46,51 @@ func (h *Handler) Relation(c echo.Context) error {
 		"isBlocked":                      false,
 		"isMuted":                        false,
 		"isRenoteMuted":                  false,
-	})
+	}
+
+	if viewer == nil {
+		return c.JSON(http.StatusOK, out)
+	}
+
+	// FindByPair は対 row が無いとき (rec, err) = (nil, err) で返るため、
+	// 存在判定は rec != nil で行う。DB error は default の false に倒すので
+	// silent (frontend は falsy display で fallback)。
+	if h.followingRepo != nil {
+		if rec, _ := h.followingRepo.FindByPair(viewer.ID, req.UserID); rec != nil {
+			out["isFollowing"] = true
+		}
+		if rec, _ := h.followingRepo.FindByPair(req.UserID, viewer.ID); rec != nil {
+			out["isFollowed"] = true
+		}
+	}
+	if h.followRequestRepo != nil {
+		if rec, _ := h.followRequestRepo.FindByPair(viewer.ID, req.UserID); rec != nil {
+			out["hasPendingFollowRequestFromYou"] = true
+		}
+		if rec, _ := h.followRequestRepo.FindByPair(req.UserID, viewer.ID); rec != nil {
+			out["hasPendingFollowRequestToYou"] = true
+		}
+	}
+	if h.blockingRepo != nil {
+		if rec, _ := h.blockingRepo.FindByPair(viewer.ID, req.UserID); rec != nil {
+			out["isBlocking"] = true
+		}
+		if rec, _ := h.blockingRepo.FindByPair(req.UserID, viewer.ID); rec != nil {
+			out["isBlocked"] = true
+		}
+	}
+	if h.mutingRepo != nil {
+		if rec, _ := h.mutingRepo.FindByPair(viewer.ID, req.UserID); rec != nil {
+			out["isMuted"] = true
+		}
+	}
+	if h.renoteMutingRepo != nil {
+		if rec, _ := h.renoteMutingRepo.FindByPair(viewer.ID, req.UserID); rec != nil {
+			out["isRenoteMuted"] = true
+		}
+	}
+
+	return c.JSON(http.StatusOK, out)
 }
 
 // ReportAbuse handles POST /api/users/report-abuse.

--- a/internal/api/users/handler_extra.go
+++ b/internal/api/users/handler_extra.go
@@ -1,6 +1,8 @@
 package users
 
 import (
+	"errors"
+	"log/slog"
 	"net/http"
 	"time"
 
@@ -11,6 +13,7 @@ import (
 	"github.com/shiroha-a/mk/internal/model"
 	"github.com/shiroha-a/mk/internal/repository"
 	"github.com/shiroha-a/mk/internal/server/middleware"
+	"gorm.io/gorm"
 )
 
 // SetAbuseRepo attaches the abuse report repository.
@@ -23,10 +26,12 @@ func (h *Handler) SetAbuseRepo(r repository.AbuseReportRepository) {
 // server/api/common/getRelation.ts) と同 semantics で viewer と target の
 // follow / follow-request / block / mute / renote-mute の関係性を返す。
 //
+// 認証は router.go の `middleware.RequireAuth()` で前段強制されているため
+// production では viewer == nil は到達不可。下の `viewer == nil` branch は
+// defensive guard + 単体テスト用 (= handler を直接叩く test path)。
+//
 // repo が wired されていない (= legacy handler test) では該当 field を false
 // に保つので production runtime には影響しない (router で必ず wired される)。
-// viewer が unauthenticated でも middleware.GetUser が non-nil を返さないだけ
-// で 401 にはならない (= 関係性は全 false で返る、upstream も viewer 必須)。
 func (h *Handler) Relation(c echo.Context) error {
 	viewer := middleware.GetUser(c)
 	var req struct {
@@ -52,41 +57,64 @@ func (h *Handler) Relation(c echo.Context) error {
 		return c.JSON(http.StatusOK, out)
 	}
 
-	// FindByPair は対 row が無いとき (rec, err) = (nil, err) で返るため、
-	// 存在判定は rec != nil で行う。DB error は default の false に倒すので
-	// silent (frontend は falsy display で fallback)。
-	if h.followingRepo != nil {
-		if rec, _ := h.followingRepo.FindByPair(viewer.ID, req.UserID); rec != nil {
-			out["isFollowing"] = true
+	// FindByPair は (rec, err) で返す契約 (gorm.ErrRecordNotFound は relation
+	// 無し)。row 不在は default の false に倒すが、transient な DB error
+	// (timeout / connection 切断等) は運用 debug のため slog.Warn で残す
+	// (frontend には false で fallback、次の API call で正される程度の影響)。
+	warnRelErr := func(label string, err error) {
+		if err != nil && !errors.Is(err, gorm.ErrRecordNotFound) {
+			slog.Warn("users/relation lookup failed", "rel", label, "viewer", viewer.ID, "target", req.UserID, "err", err)
 		}
-		if rec, _ := h.followingRepo.FindByPair(req.UserID, viewer.ID); rec != nil {
+	}
+
+	if h.followingRepo != nil {
+		if rec, err := h.followingRepo.FindByPair(viewer.ID, req.UserID); rec != nil {
+			out["isFollowing"] = true
+		} else {
+			warnRelErr("isFollowing", err)
+		}
+		if rec, err := h.followingRepo.FindByPair(req.UserID, viewer.ID); rec != nil {
 			out["isFollowed"] = true
+		} else {
+			warnRelErr("isFollowed", err)
 		}
 	}
 	if h.followRequestRepo != nil {
-		if rec, _ := h.followRequestRepo.FindByPair(viewer.ID, req.UserID); rec != nil {
+		if rec, err := h.followRequestRepo.FindByPair(viewer.ID, req.UserID); rec != nil {
 			out["hasPendingFollowRequestFromYou"] = true
+		} else {
+			warnRelErr("hasPendingFollowRequestFromYou", err)
 		}
-		if rec, _ := h.followRequestRepo.FindByPair(req.UserID, viewer.ID); rec != nil {
+		if rec, err := h.followRequestRepo.FindByPair(req.UserID, viewer.ID); rec != nil {
 			out["hasPendingFollowRequestToYou"] = true
+		} else {
+			warnRelErr("hasPendingFollowRequestToYou", err)
 		}
 	}
 	if h.blockingRepo != nil {
-		if rec, _ := h.blockingRepo.FindByPair(viewer.ID, req.UserID); rec != nil {
+		if rec, err := h.blockingRepo.FindByPair(viewer.ID, req.UserID); rec != nil {
 			out["isBlocking"] = true
+		} else {
+			warnRelErr("isBlocking", err)
 		}
-		if rec, _ := h.blockingRepo.FindByPair(req.UserID, viewer.ID); rec != nil {
+		if rec, err := h.blockingRepo.FindByPair(req.UserID, viewer.ID); rec != nil {
 			out["isBlocked"] = true
+		} else {
+			warnRelErr("isBlocked", err)
 		}
 	}
 	if h.mutingRepo != nil {
-		if rec, _ := h.mutingRepo.FindByPair(viewer.ID, req.UserID); rec != nil {
+		if rec, err := h.mutingRepo.FindByPair(viewer.ID, req.UserID); rec != nil {
 			out["isMuted"] = true
+		} else {
+			warnRelErr("isMuted", err)
 		}
 	}
 	if h.renoteMutingRepo != nil {
-		if rec, _ := h.renoteMutingRepo.FindByPair(viewer.ID, req.UserID); rec != nil {
+		if rec, err := h.renoteMutingRepo.FindByPair(viewer.ID, req.UserID); rec != nil {
 			out["isRenoteMuted"] = true
+		} else {
+			warnRelErr("isRenoteMuted", err)
 		}
 	}
 

--- a/internal/api/users/handler_extra_test.go
+++ b/internal/api/users/handler_extra_test.go
@@ -68,6 +68,59 @@ func TestRelation_InvalidParam(t *testing.T) {
 	assert.Equal(t, http.StatusBadRequest, rec.Code)
 }
 
+// TestRelation_NilViewer covers the unauthenticated branch — Relation returns
+// 200 with all relation flags false (matches upstream behavior).
+func TestRelation_NilViewer(t *testing.T) {
+	h, _, _ := newExtraHandler(t)
+	rec := postExtra(h.Relation, `{"userId":"u2"}`, nil)
+	assert.Equal(t, http.StatusOK, rec.Code)
+	var resp map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+	assert.Equal(t, false, resp["isFollowing"])
+	assert.Equal(t, false, resp["isBlocking"])
+}
+
+// TestRelation_PopulatedRelations wires the 5 repos and seeds rows so every
+// bool field flips to true. Validates #984 drift fix: handler returns real
+// DB-backed state instead of hardcoded false.
+func TestRelation_PopulatedRelations(t *testing.T) {
+	h, _, _ := newExtraHandler(t)
+	followingRepo := testutil.NewMockFollowingRepository()
+	followRequestRepo := testutil.NewMockFollowRequestRepository()
+	blockingRepo := testutil.NewMockBlockingRepository()
+	mutingRepo := testutil.NewMockMutingRepository()
+	renoteMutingRepo := testutil.NewMockRenoteMutingRepository()
+	h.SetFollowingRepo(followingRepo)
+	h.SetFollowRequestRepo(followRequestRepo)
+	h.SetBlockingRepo(blockingRepo)
+	h.SetMutingRepo(mutingRepo)
+	h.SetRenoteMutingRepo(renoteMutingRepo)
+
+	// 双方向の follow / request / block + viewer→target の mute / renote-mute
+	require.NoError(t, followingRepo.Create(&model.Following{ID: "f1", FollowerID: "u1", FolloweeID: "u2"}))
+	require.NoError(t, followingRepo.Create(&model.Following{ID: "f2", FollowerID: "u2", FolloweeID: "u1"}))
+	require.NoError(t, followRequestRepo.Create(&model.FollowRequest{ID: "fr1", FollowerID: "u1", FolloweeID: "u2"}))
+	require.NoError(t, followRequestRepo.Create(&model.FollowRequest{ID: "fr2", FollowerID: "u2", FolloweeID: "u1"}))
+	require.NoError(t, blockingRepo.Create(&model.Blocking{ID: "b1", BlockerID: "u1", BlockeeID: "u2"}))
+	require.NoError(t, blockingRepo.Create(&model.Blocking{ID: "b2", BlockerID: "u2", BlockeeID: "u1"}))
+	require.NoError(t, mutingRepo.Create(&model.Muting{ID: "m1", MuterID: "u1", MuteeID: "u2"}))
+	require.NoError(t, renoteMutingRepo.Create(&model.RenoteMuting{ID: "rm1", MuterID: "u1", MuteeID: "u2"}))
+
+	rec := postExtra(h.Relation, `{"userId":"u2"}`, &model.User{ID: "u1"})
+	assert.Equal(t, http.StatusOK, rec.Code)
+	var resp map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+	assert.Equal(t, "u2", resp["id"])
+	assert.Equal(t, true, resp["isFollowing"])
+	assert.Equal(t, true, resp["isFollowed"])
+	assert.Equal(t, true, resp["hasPendingFollowRequestFromYou"])
+	assert.Equal(t, true, resp["hasPendingFollowRequestToYou"])
+	assert.Equal(t, true, resp["isBlocking"])
+	assert.Equal(t, true, resp["isBlocked"])
+	assert.Equal(t, true, resp["isMuted"])
+	assert.Equal(t, true, resp["isRenoteMuted"])
+}
+
 // --- ReportAbuse ---
 
 func TestReportAbuse_Success(t *testing.T) {

--- a/internal/api/users/handler_extra_test.go
+++ b/internal/api/users/handler_extra_test.go
@@ -2,6 +2,7 @@ package users_test
 
 import (
 	"encoding/json"
+	"errors"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -78,6 +79,58 @@ func TestRelation_NilViewer(t *testing.T) {
 	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
 	assert.Equal(t, false, resp["isFollowing"])
 	assert.Equal(t, false, resp["isBlocking"])
+}
+
+// failingFollowingRepo always returns a non-NotFound error so the warn path
+// (#984) can be exercised — `users/relation` should silently fall back to
+// false and emit slog.Warn instead of leaking the error to the response.
+type failingFollowingRepo struct {
+	*testutil.MockFollowingRepository
+}
+
+func (f *failingFollowingRepo) FindByPair(_, _ string) (*model.Following, error) {
+	return nil, errors.New("simulated transient DB error")
+}
+
+// TestRelation_TransientDBErrorFallsBackToFalse: non-NotFound error from
+// repo should not propagate; relation field stays false. Smoke test the
+// warnRelErr path.
+func TestRelation_TransientDBErrorFallsBackToFalse(t *testing.T) {
+	h, _, _ := newExtraHandler(t)
+	repo := &failingFollowingRepo{MockFollowingRepository: testutil.NewMockFollowingRepository()}
+	h.SetFollowingRepo(repo)
+
+	rec := postExtra(h.Relation, `{"userId":"u2"}`, &model.User{ID: "u1"})
+	assert.Equal(t, http.StatusOK, rec.Code)
+	var resp map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+	assert.Equal(t, false, resp["isFollowing"])
+	assert.Equal(t, false, resp["isFollowed"])
+}
+
+// TestRelation_PartialDirection covers the case where only one direction of
+// a follow exists (u1 → u2 follow, no reverse). Guards against cross-talk
+// regressions where bidirectional fields are mistakenly tied together.
+func TestRelation_PartialDirection(t *testing.T) {
+	h, _, _ := newExtraHandler(t)
+	followingRepo := testutil.NewMockFollowingRepository()
+	h.SetFollowingRepo(followingRepo)
+	require.NoError(t, followingRepo.Create(&model.Following{ID: "f1", FollowerID: "u1", FolloweeID: "u2"}))
+
+	rec := postExtra(h.Relation, `{"userId":"u2"}`, &model.User{ID: "u1"})
+	assert.Equal(t, http.StatusOK, rec.Code)
+	var resp map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+	// u1 → u2 follow のみ。逆方向 (= u2 → u1) は存在しない。
+	assert.Equal(t, true, resp["isFollowing"])
+	assert.Equal(t, false, resp["isFollowed"])
+	// 他 relation も全 false に保たれること (cross-talk regression guard)。
+	assert.Equal(t, false, resp["hasPendingFollowRequestFromYou"])
+	assert.Equal(t, false, resp["hasPendingFollowRequestToYou"])
+	assert.Equal(t, false, resp["isBlocking"])
+	assert.Equal(t, false, resp["isBlocked"])
+	assert.Equal(t, false, resp["isMuted"])
+	assert.Equal(t, false, resp["isRenoteMuted"])
 }
 
 // TestRelation_PopulatedRelations wires the 5 repos and seeds rows so every

--- a/internal/core/drive/drive_service.go
+++ b/internal/core/drive/drive_service.go
@@ -24,6 +24,11 @@ var (
 	ErrFileNotFound = errors.New("drive file not found")
 	// ErrFolderNotFound is returned when the target folder does not exist.
 	ErrFolderNotFound = errors.New("drive folder not found")
+	// ErrParentFolderNotFound is returned when the parent folder referenced
+	// by a create/update operation does not exist. Distinct from
+	// ErrFolderNotFound so that drive/folders/update can map this to the
+	// upstream NO_SUCH_PARENT_FOLDER code (#977).
+	ErrParentFolderNotFound = errors.New("drive parent folder not found")
 	// ErrAccessDenied is returned when a file/folder is owned by another user.
 	ErrAccessDenied = errors.New("access denied")
 	// ErrFolderNotEmpty is returned when attempting to delete a folder that
@@ -599,7 +604,10 @@ func (s *Service) UpdateFolder(user *model.User, id string, in UpdateFolderInput
 		if *in.ParentID != nil {
 			parent, err := s.folderRepo.FindByID(**in.ParentID)
 			if err != nil {
-				return nil, ErrFolderNotFound
+				// folders/update では parent が未存在のときに upstream は
+				// NO_SUCH_PARENT_FOLDER (#977) を返すので、target 不在の
+				// ErrFolderNotFound と区別する。
+				return nil, ErrParentFolderNotFound
 			}
 			if parent.UserID == nil || *parent.UserID != user.ID {
 				return nil, ErrAccessDenied

--- a/internal/core/drive/drive_service_test.go
+++ b/internal/core/drive/drive_service_test.go
@@ -485,7 +485,8 @@ func TestUpdateFolder_ParentNotFound(t *testing.T) {
 	pid := "ghost"
 	pidPtr := &pid
 	_, err := svc.UpdateFolder(&model.User{ID: "u1"}, "c", drive.UpdateFolderInput{ParentID: &pidPtr})
-	require.ErrorIs(t, err, drive.ErrFolderNotFound)
+	// #977: target 不在の ErrFolderNotFound と区別する distinct error。
+	require.ErrorIs(t, err, drive.ErrParentFolderNotFound)
 }
 
 func TestUpdateFolder_ParentAccessDenied(t *testing.T) {

--- a/internal/entity/user.go
+++ b/internal/entity/user.go
@@ -1,6 +1,8 @@
 package entity
 
 import (
+	"encoding/json"
+
 	"github.com/shiroha-a/mk/internal/misc/id"
 	"github.com/shiroha-a/mk/internal/model"
 	"gorm.io/datatypes"
@@ -119,6 +121,17 @@ type MeDetailed struct {
 	AlwaysMarkNsfw           bool `json:"alwaysMarkNsfw"`
 	ReceiveAnnouncementEmail bool `json:"receiveAnnouncementEmail"`
 	InjectFeaturedNote       bool `json:"injectFeaturedNote"`
+	// EmailNotificationTypes is the list of email-notification categories the
+	// user opted in for. Defaults to ["follow", "receiveFollowRequest"] when
+	// the profile column is absent (#985).
+	EmailNotificationTypes []string `json:"emailNotificationTypes"`
+	// MutingNotificationTypes is kept as an empty slice for backward
+	// compatibility — upstream UserEntityService.ts:615 returns `[]` with
+	// a "後方互換性のため" comment (#985).
+	MutingNotificationTypes []string `json:"mutingNotificationTypes"`
+	// NotificationRecieveConfig retains the (sic) upstream typo so frontends
+	// can read state without renaming. Empty map when unset (#985).
+	NotificationRecieveConfig map[string]any `json:"notificationRecieveConfig"`
 }
 
 // PackMeDetailed packs a self-view user payload, extending PackUserDetailed
@@ -133,6 +146,11 @@ func PackMeDetailed(u *model.User, profile *model.UserProfile, idGens ...id.Gene
 		IsExplorable:     u.IsExplorable,
 		IsDeleted:        u.IsDeleted,
 		HideOnlineStatus: u.HideOnlineStatus,
+		// default は upstream UserEntityService と同じ値。profile が
+		// non-nil なら下で JSON column から上書きする。
+		EmailNotificationTypes:    []string{"follow", "receiveFollowRequest"},
+		MutingNotificationTypes:   []string{},
+		NotificationRecieveConfig: map[string]any{},
 	}
 	if profile != nil {
 		out.NoCrawle = profile.NoCrawle
@@ -143,6 +161,21 @@ func PackMeDetailed(u *model.User, profile *model.UserProfile, idGens ...id.Gene
 		out.AlwaysMarkNsfw = profile.AlwaysMarkNsfw
 		out.ReceiveAnnouncementEmail = profile.ReceiveAnnouncementEmail
 		out.InjectFeaturedNote = profile.InjectFeaturedNote
+		// EmailNotificationTypes / NotificationRecieveConfig は jsonb カラム
+		// なので JSON unmarshal してから out にコピーする。parse error は
+		// default に倒す (silent — frontend は default で動作可能)。
+		if raw := []byte(profile.EmailNotificationTypes); len(raw) > 0 {
+			var arr []string
+			if err := json.Unmarshal(raw, &arr); err == nil {
+				out.EmailNotificationTypes = arr
+			}
+		}
+		if raw := []byte(profile.NotificationRecieveConfig); len(raw) > 0 {
+			var m map[string]any
+			if err := json.Unmarshal(raw, &m); err == nil && m != nil {
+				out.NotificationRecieveConfig = m
+			}
+		}
 	}
 	return out
 }

--- a/internal/entity/user_test.go
+++ b/internal/entity/user_test.go
@@ -476,3 +476,83 @@ func TestPackMeDetailed_SerializedJSON(t *testing.T) {
 	assert.Contains(t, s, `"hideOnlineStatus":false`)
 	assert.Contains(t, s, `"isDeleted":false`)
 }
+
+// #985: notification 3 field (emailNotificationTypes /
+// mutingNotificationTypes / notificationRecieveConfig) のデフォルト値が
+// JSON に乗ること + emailNotificationTypes の default が upstream と一致。
+func TestPackMeDetailed_NotificationDefaults(t *testing.T) {
+	u := &model.User{
+		ID:                "me4",
+		Username:          "default-notif",
+		AvatarDecorations: datatypes.JSON([]byte("[]")),
+	}
+	profile := &model.UserProfile{
+		UserID: "me4",
+		Fields: datatypes.JSON([]byte("[]")),
+	}
+
+	me := PackMeDetailed(u, profile)
+
+	assert.Equal(t, []string{"follow", "receiveFollowRequest"}, me.EmailNotificationTypes)
+	assert.Equal(t, []string{}, me.MutingNotificationTypes)
+	assert.Equal(t, map[string]any{}, me.NotificationRecieveConfig)
+
+	b, err := json.Marshal(me)
+	require.NoError(t, err)
+	s := string(b)
+	assert.Contains(t, s, `"emailNotificationTypes":["follow","receiveFollowRequest"]`)
+	assert.Contains(t, s, `"mutingNotificationTypes":[]`)
+	assert.Contains(t, s, `"notificationRecieveConfig":{}`)
+}
+
+// #985: profile JSON column に値が入っているときに override されることを
+// 確認 (emailNotificationTypes / notificationRecieveConfig の path をカバー)。
+func TestPackMeDetailed_NotificationOverride(t *testing.T) {
+	u := &model.User{
+		ID:                "me5",
+		Username:          "override-notif",
+		AvatarDecorations: datatypes.JSON([]byte("[]")),
+	}
+	profile := &model.UserProfile{
+		UserID:                    "me5",
+		EmailNotificationTypes:    datatypes.JSON([]byte(`["mention"]`)),
+		NotificationRecieveConfig: datatypes.JSON([]byte(`{"mention":{"type":"following"}}`)),
+		Fields:                    datatypes.JSON([]byte("[]")),
+	}
+
+	me := PackMeDetailed(u, profile)
+	assert.Equal(t, []string{"mention"}, me.EmailNotificationTypes)
+	require.Contains(t, me.NotificationRecieveConfig, "mention")
+}
+
+// #985: profile が nil の fallback path でも 3 field は default で埋まる。
+func TestPackMeDetailed_NotificationNilProfile(t *testing.T) {
+	u := &model.User{
+		ID:                "me6",
+		Username:          "nilprof-notif",
+		AvatarDecorations: datatypes.JSON([]byte("[]")),
+	}
+	me := PackMeDetailed(u, nil)
+	assert.Equal(t, []string{"follow", "receiveFollowRequest"}, me.EmailNotificationTypes)
+	assert.Equal(t, []string{}, me.MutingNotificationTypes)
+	assert.Equal(t, map[string]any{}, me.NotificationRecieveConfig)
+}
+
+// #985: profile column の JSON が壊れているときは default に倒し silent
+// fallback する (parse error は ignore)。
+func TestPackMeDetailed_NotificationMalformed(t *testing.T) {
+	u := &model.User{
+		ID:                "me7",
+		Username:          "malformed-notif",
+		AvatarDecorations: datatypes.JSON([]byte("[]")),
+	}
+	profile := &model.UserProfile{
+		UserID:                    "me7",
+		EmailNotificationTypes:    datatypes.JSON([]byte(`not-json`)),
+		NotificationRecieveConfig: datatypes.JSON([]byte(`not-json`)),
+		Fields:                    datatypes.JSON([]byte("[]")),
+	}
+	me := PackMeDetailed(u, profile)
+	assert.Equal(t, []string{"follow", "receiveFollowRequest"}, me.EmailNotificationTypes)
+	assert.Equal(t, map[string]any{}, me.NotificationRecieveConfig)
+}

--- a/tests/playwright/specs/ui/drive_folder_delete_via_context_menu.spec.ts
+++ b/tests/playwright/specs/ui/drive_folder_delete_via_context_menu.spec.ts
@@ -23,11 +23,9 @@ test.describe('UI: /my/drive folder delete via context menu flow', () => {
   });
   test.setTimeout(60_000);
 
-  // mk-go の `mapFolderError` (internal/api/drive/handler.go:478) が
-  // drive/folders/show / drive/folders/delete に対して `ea8fb7a5-...` を
-  // 返しており upstream (`d74ab9eb-...` / `1069098f-...`) と drift。
-  // 詳細は #977。drift fix がマージされたら本 skip を解除する。
-  test.skip('contextmenu folder → Delete → /api/drive/folders/delete', async ({
+  // #977 drift fix で endpoint 別の upstream-canonical UUID を返すように
+  // 修正済み (drive/folders/show: `d74ab9eb-...`)。
+  test('contextmenu folder → Delete → /api/drive/folders/delete', async ({
     page,
     baseURL,
     request,
@@ -98,7 +96,7 @@ test.describe('UI: /my/drive folder delete via context menu flow', () => {
     await deleteResp;
 
     // 5. API 経由で削除確認 — drive/folders/show は 404 + NO_SUCH_FOLDER を返す
-    // (drive/handler.go:220、UUID d77545ec-1283-4b73-bbe1-e90e1da6a4e7)。
+    // (#977 drift fix 後の UUID `d74ab9eb-bb09-4bba-bf24-fb58f761e1e9`)。
     const showResp = await callApi(request, 'drive/folders/show', {
       i: root.token,
       folderId,
@@ -106,6 +104,6 @@ test.describe('UI: /my/drive folder delete via context menu flow', () => {
     expect(showResp.status()).toBe(404);
     const showBody = await showResp.json();
     expect(showBody.error?.code).toBe('NO_SUCH_FOLDER');
-    expect(showBody.error?.id).toBe('d77545ec-1283-4b73-bbe1-e90e1da6a4e7');
+    expect(showBody.error?.id).toBe('d74ab9eb-bb09-4bba-bf24-fb58f761e1e9');
   });
 });

--- a/tests/playwright/specs/ui/follow_request_accept_button.spec.ts
+++ b/tests/playwright/specs/ui/follow_request_accept_button.spec.ts
@@ -86,30 +86,15 @@ test.describe('UI: /my/follow-requests accept button flow', () => {
     await acceptResp;
 
     // 7. API 経由で関係性 verify: requester is now following root.
-    // 注: mk-go の users/relation (handler_extra.go:34) は現状 stub で
-    // `isFollowing: false` を hardcoded で返す drift があるため、
-    // users/followers list で実 follow 関係を確認する path に変更。
-    // `relationItem.followerId` で row を identify (handler.go:579-584)。
-    // 別 PR で users/relation の実装を fix する予定 (drift tracking)。
-    //
-    // limit=100 は test isolation 前提 (= root の follower は本 spec 内で
-    // signup する 1 user だけ)。他 spec が global state を残して root の
-    // follower が 100 件を超えると flake する余地があるが、現状の test
-    // 構成 (= signup 系 spec は self-create user で root を follow しない)
-    // では問題ない。
-    const followersResp = await callApi(request, 'users/followers', {
-      i: root.token,
+    // #984 drift fix で users/relation が実 DB 状態を返すようになったので、
+    // requester 視点で isFollowing=true を確認する strict path に戻す。
+    const relResp = await callApi(request, 'users/relation', {
+      i: requester.token,
       userId: root.id,
-      limit: 100,
     });
-    expect(followersResp.status()).toBe(200);
-    const followers = await followersResp.json();
-    expect(Array.isArray(followers)).toBe(true);
-    expect(
-      followers.some(
-        (f: { followerId?: string }) => f.followerId === requester.id,
-      ),
-    ).toBe(true);
+    expect(relResp.status()).toBe(200);
+    const rel = await relResp.json();
+    expect(rel.isFollowing).toBe(true);
 
     // 8. cleanup: root の isLocked を false に戻す (他 spec への副作用回避)
     await callApi(request, 'i/update', { i: root.token, isLocked: false });

--- a/tests/playwright/specs/ui/settings_email_notification_mention_toggle.spec.ts
+++ b/tests/playwright/specs/ui/settings_email_notification_mention_toggle.spec.ts
@@ -47,14 +47,10 @@ test.describe('UI: /settings/email emailNotification_mention toggle flow', () =>
     });
     const update = await updateResp;
     const body = await update.json();
-    // spec の主目的は「switch toggle → /api/i/update round-trip」の verify。
-    // i/update response が 200 + body.id truthy なら toggle 動作は確認済。
-    // 旧 assertion `expect(Array.isArray(body.emailNotificationTypes)).toBe(true)`
-    // は mk-go の `entity.PackMeDetailed` が emailNotificationTypes field を
-    // 含まない drift で false。drift fix は別 PR、本 spec は round-trip 自体
-    // の verify に絞る。
-    // TODO: MeDetailed packer に emailNotificationTypes が追加されたら
-    // `expect(Array.isArray(body.emailNotificationTypes)).toBe(true)` を復活する。
+    // #985 drift fix で PackMeDetailed に emailNotificationTypes が追加され、
+    // i/update response にも乗るようになった (default ["follow",
+    // "receiveFollowRequest"] または profile JSON column の値)。
     expect(body.id).toBeTruthy();
+    expect(Array.isArray(body.emailNotificationTypes)).toBe(true);
   });
 });


### PR DESCRIPTION
## Summary

PR #983 review で発見した 3 件の backend drift を 1 bundle で消化。spec の workaround / TODO marker も同時に解消する。

## 修正内訳

### #977 drive/folders `NO_SUCH_FOLDER` UUID drift

- `mapFolderError` に `folderEndpoint` context を追加し、4 endpoint で **upstream-canonical な UUID** を返す
  | endpoint | UUID |
  |----------|------|
  | create (parent 不在) | `53326628-a00d-40a6-a3cd-8975105c0f95` |
  | show | `d74ab9eb-bb09-4bba-bf24-fb58f761e1e9` |
  | update (target 不在) | `f7974dac-2c0d-4a27-926e-23583b28e98e` |
  | delete | `1069098f-c281-440f-b085-f9932edbe091` |
- `ErrParentFolderNotFound` を新設し、`folders/update` の **parent 不在**を `NO_SUCH_PARENT_FOLDER` (`ce104e3a-...`) として target 不在と区別する
- Playwright `drive_folder_delete_via_context_menu` の skip を解除、assertion を upstream UUID に更新

### #984 `users/relation` full implementation

- 全 8 bool field (`isFollowing` / `isFollowed` / `hasPendingFollowRequestFromYou` / `hasPendingFollowRequestToYou` / `isBlocking` / `isBlocked` / `isMuted` / `isRenoteMuted`) を **実 DB 状態**から計算する
- 既存 5 repo (`following` / `follow_request` / `blocking` / `muting` / `renote_muting`) の `FindByPair` を順に叩くシンプルな実装。repo nil guard / DB error は silent false に倒す
- viewer == nil は 200 + 全 false (= upstream 互換)
- Playwright `follow_request_accept_button` の verify path を `users/followers` → `users/relation` に戻す (#983 で workaround 化した drift 回避を撤回)

### #985 `MeDetailed` packer に notification 3 field 追加

- `MeDetailed` struct に
  - `EmailNotificationTypes []string`
  - `MutingNotificationTypes []string`
  - `NotificationRecieveConfig map[string]any` (sic — upstream の typo を継承)
  を追加
- `PackMeDetailed` で `UserProfile` の jsonb column (`emailNotificationTypes` / `notificationRecieveConfig`) を unmarshal して値を埋める。parse 失敗時は upstream default に倒す
  - default: `["follow", "receiveFollowRequest"]` / `[]` / `{}`
- `i/handler.go` の GetMe も同じ logic で 3 field を出すように更新 (i と i/update の response を一貫させる)
- Playwright `settings_email_notification_mention_toggle` の `expect(Array.isArray(body.emailNotificationTypes))` strict assertion を re-enable

## 主な変更点

| 領域 | ファイル |
|------|---------|
| drive UUID | `internal/api/drive/handler.go`、`internal/core/drive/drive_service.go` |
| users/relation | `internal/api/users/handler_extra.go` |
| MeDetailed | `internal/entity/user.go`、`internal/api/i/handler.go` |
| spec re-enable | `tests/playwright/specs/ui/{drive_folder_delete_via_context_menu,follow_request_accept_button,settings_email_notification_mention_toggle}.spec.ts` |
| docs | `CHANGELOG.md`、`docs/api-compatibility.md` |

## テスト

- 新規 unit test
  - `internal/entity`: `TestPackMeDetailed_Notification{Defaults,Override,NilProfile,Malformed}` の 4 件
  - `internal/api/users`: `TestRelation_NilViewer` / `TestRelation_PopulatedRelations`
  - `internal/api/drive`: `TestFoldersCreate_ParentNotFound` / `TestFoldersShow_NotFound` / `TestFoldersUpdate_NotFound` / `TestFoldersUpdate_ParentNotFound` (新規) / `TestFoldersDelete_NotFound` に endpoint 別 UUID assertion を追加
- 既存 test 更新
  - `internal/core/drive`: `TestUpdateFolder_ParentNotFound` の expected error を `ErrParentFolderNotFound` に
- Coverage (race + atomic, 単独 PR scope)
  - `internal/entity`: **96.5%**
  - `internal/api/i`: **91.4%**
  - `internal/api/users`: **92.7%**
  - `internal/core/drive`: **99.2%**
  - `internal/api/drive`: **93.3%**
- `make fmt` / `make lint` / `go test -race -count=1 ./...` 通過 (e2e_federation は initial run で 1 件 flaky だが再 run で green)

### 実行方法

\`\`\`bash
# unit test (race + coverage)
go test -race -count=1 -coverprofile=cov.out -covermode=atomic \\
  ./internal/entity/... ./internal/api/i/... ./internal/api/users/... \\
  ./internal/core/drive/... ./internal/api/drive/...
go tool cover -func=cov.out | tail -5
\`\`\`

Playwright re-enable 3 spec の動作確認は次回 nightly run で確認する。

## Closes

- Closes #977
- Closes #984
- Closes #985

## その他

- session 累積で完了した backend drift bundle (= UI/spec 由来でない、本物の backend 実装 drift)
- spec 側の workaround / TODO marker をすべて strict path に戻したので、playwright 全 spec が drift fix 込みの strict mode で走る