### PR TITLE
fix: MeDetailed spread bundle (#970 users/show self-view + #971 Me handler refactor)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,7 @@ Playwright spec を両 backend で走らせる中で観測した drop-in 互換 
 - #871: users/lists/create response shape (createdAt / userIds / isPublic)
 - #872: blocked → following/create reject status (400)
 - #984: users/relation を stub から実装に切替。viewer ↔ target の follow / follow-request / block / mute / renote-mute 状態を 5 repo (`following` / `follow_request` / `blocking` / `muting` / `renote_muting`) から実 DB 状態として返す
+- #970: `/api/users/show` で viewer===target のとき MeDetailed 拡張 field (isExplorable / noCrawle / emailNotificationTypes 等 14 個) を merge して返すよう拡張。upstream `pack(user, me)` semantics と一致させ、`/api/users/show?username=me` 経由でも `/api/i` と同じ shape を保つ。新規 helper `entity.AsMeDetailed` で pre-built UserDetailed を promote する design
 
 #### settings / token
 - #883: i/regenerate-token return shape (204)
@@ -52,6 +53,7 @@ Playwright spec を両 backend で走らせる中で観測した drop-in 互換 
 - #910: app-issued access token を auth middleware で dual lookup (raw → hash)
 - #913: i/revoke-token も dual lookup + cache invalidation
 - #985: `entity.PackMeDetailed` に `emailNotificationTypes` / `mutingNotificationTypes` / `notificationRecieveConfig` を追加。i/update 経路でも 3 field が返るようになり、frontend の `updateCurrentAccountPartial` が settings/email 等の toggle 後に local state を正しく反映できる。値は `user_profile` の JSON column を unmarshal して取得し、parse 失敗時は upstream default (`["follow","receiveFollowRequest"]` / `[]` / `{}`) に倒す
+- #971: `/api/i` Me handler を `PackMeDetailed` ベースに refactor。JSON round-trip で MeDetailed を resp map base に展開し、固有 field (email / mutedWords / twoFactor / clientData / role / unread 等) を merge する design。重複コード 25 行削減、MeDetailed packer 更新時に自動追従
 
 #### admin
 - #888: admin/show-user shape (roles / policies / signins / roleAssigns / isHibernated / lastActiveDate)

--- a/docs/api-compatibility.md
+++ b/docs/api-compatibility.md
@@ -106,6 +106,7 @@ Playwright spec を両 backend で走らせる中で観測した「TS と mk-go 
 | #871 | users/lists/create response shape (createdAt / userIds / isPublic 含む) |
 | #872 | blocked → following/create reject status (400) |
 | #984 | users/relation を stub から実装に切替。viewer ↔ target の follow / follow-request / block / mute / renote-mute を 5 repo (`following` / `follow_request` / `blocking` / `muting` / `renote_muting`) から実 DB 状態として返す |
+| #970 | `/api/users/show` で viewer===target のとき MeDetailed 拡張 field を merge (upstream `pack(user, me)` 互換)。`entity.AsMeDetailed` helper で pre-built UserDetailed を promote |
 
 #### settings / token
 | # | 内容 |
@@ -116,6 +117,7 @@ Playwright spec を両 backend で走らせる中で観測した「TS と mk-go 
 | #910 | app-issued access token を auth middleware で dual lookup (raw → hash) |
 | #913 | i/revoke-token も dual lookup + cache invalidation 化 |
 | #985 | `entity.PackMeDetailed` に `emailNotificationTypes` / `mutingNotificationTypes` / `notificationRecieveConfig` を追加 (i/update 経路で frontend `$i` state が settings/email 等の toggle 後に正しく反映される) |
+| #971 | `/api/i` Me handler を `PackMeDetailed` ベースに refactor。JSON round-trip で 11 self-view field + notification 3 field の重複コード 25 行を削除、MeDetailed packer 更新時に自動追従 |
 
 #### admin
 | # | 内容 |

--- a/internal/api/i/handler.go
+++ b/internal/api/i/handler.go
@@ -564,27 +564,36 @@ func (h *Handler) Me(c echo.Context) error {
 	// 1 request あたり Marshal + Unmarshal が 1 回ずつ走るが、/api/i は
 	// per-session 数回の頻度なので影響は無視できる。順序保証は不要
 	// (JSON object は順序不定)。
+	//
+	// errors are infeasible: MeDetailed struct は JSON-safe な primitive と
+	// slice / map のみで構成され、`any` 型 field を含まない。万一将来 non-
+	// marshalable な field が追加されても、(*json.UnsupportedTypeError) は
+	// CI の TestMe_PreservesMeDetailedFields で即検出される (= empty resp
+	// で field 不在 assertion が落ちる)。silent leak には繋がらない。
 	me := entity.PackMeDetailed(u, profile, h.idGen)
 	b, _ := json.Marshal(me)
 	resp := map[string]any{}
 	_ = json.Unmarshal(b, &resp)
 
 	// MeDetailed packer に乗っていない /api/i 固有 field を上書き / 追加。
+	// avatarId / bannerId / chatScope は PackUserDetailed 経由で同 value が
+	// 既に乗っているので override 不要 (#987 review で重複削除)。
 	resp["movedTo"] = u.MovedToURI
 	resp["alsoKnownAs"] = u.AlsoKnownAs
 	resp["lastFetchedAt"] = nil
-	resp["avatarId"] = u.AvatarID
-	resp["bannerId"] = u.BannerID
-	resp["chatScope"] = u.ChatScope
+	// canChat は upstream では role policy の chatAvailability 由来だが、
+	// mk-go は PackUserLite で chatScope != "none" 由来になっており、さらに
+	// 本 handler では self-view 用に true hardcode で override している。
+	// 二重 drift は別途 #988 で tracking。本 PR では既存挙動を保つ。
 	resp["canChat"] = true
+	// memo / moderationNote は UserDetailed.Memo (omitempty) / MeDetailed
+	// 構造体に無いため、JSON unmarshal 後の resp map に key が出ない。
+	// /api/i の response shape を後方互換に保つため key 自体は出す
+	// (= "memo": null)。
 	resp["memo"] = nil
 	resp["moderationNote"] = nil
 	// isSilenced は role policy 由来で /api/i 固有 (MeDetailed には無い)。
 	resp["isSilenced"] = h.isSilenced(u.ID)
-
-	// MeDetailed の followedMessage は packer 既定で profile から merge
-	// するが、profile == nil の fallback path だと nil で出る。
-	// PackUserDetailed 内で適切に処理されるので追加 override は不要。
 
 	// Private fields from profile (MeDetailed scope 外)
 	if profile != nil {

--- a/internal/api/i/handler.go
+++ b/internal/api/i/handler.go
@@ -549,81 +549,53 @@ func (h *Handler) RegistryRemove(c echo.Context) error {
 }
 
 // Me handles POST /api/i - returns the authenticated user's info.
+//
+// MeDetailed (UserLite + UserDetailed + 11 self-view + notification 3) は
+// entity.PackMeDetailed 経由で一括展開し、`/api/i` 固有の private field
+// (email / mutedWords / twoFactor* / clientData / role / unread 等) を
+// resp map に merge する design (#971)。MeDetailed packer に新 field が
+// 追加されたとき自動追従する。
 func (h *Handler) Me(c echo.Context) error {
 	u := middleware.GetUser(c)
 
 	profile := h.userService.GetProfile(u.ID)
 
-	detailed := entity.PackUserDetailed(u, profile, h.idGen)
+	// MeDetailed を JSON round-trip で map に展開して base にする。
+	// 1 request あたり Marshal + Unmarshal が 1 回ずつ走るが、/api/i は
+	// per-session 数回の頻度なので影響は無視できる。順序保証は不要
+	// (JSON object は順序不定)。
+	me := entity.PackMeDetailed(u, profile, h.idGen)
+	b, _ := json.Marshal(me)
+	resp := map[string]any{}
+	_ = json.Unmarshal(b, &resp)
 
-	// /api/i returns additional private fields
-	resp := map[string]any{
-		// UserLite fields
-		"id":                u.ID,
-		"name":              detailed.Name,
-		"username":          detailed.Username,
-		"host":              detailed.Host,
-		"avatarUrl":         detailed.AvatarURL,
-		"avatarBlurhash":    detailed.AvatarBlurhash,
-		"avatarDecorations": detailed.AvatarDecorations,
-		"isBot":             detailed.IsBot,
-		"isCat":             detailed.IsCat,
-		"emojis":            detailed.Emojis,
-		"onlineStatus":      detailed.OnlineStatus,
-		"badgeRoles":        detailed.BadgeRoles,
-		// UserDetailed fields
-		"bannerUrl":      detailed.BannerURL,
-		"bannerBlurhash": detailed.BannerBlurhash,
-		"isLocked":       detailed.IsLocked,
-		"isSilenced":     h.isSilenced(u.ID),
-		"isSuspended":    detailed.IsSuspended,
-		"description":    detailed.Description,
-		"location":       detailed.Location,
-		"birthday":       detailed.Birthday,
-		"lang":           detailed.Lang,
-		"fields":         detailed.Fields,
-		"verifiedLinks":  detailed.VerifiedLinks,
-		"followersCount": detailed.FollowersCount,
-		"followingCount": detailed.FollowingCount,
-		"notesCount":     detailed.NotesCount,
-		"uri":            detailed.URI,
-		"url":            detailed.URL,
-		"movedTo":        u.MovedToURI,
-		"alsoKnownAs":    u.AlsoKnownAs,
-		"updatedAt":      detailed.UpdatedAt,
-		"lastFetchedAt":  nil,
-		// MeDetailed fields
-		"avatarId":            u.AvatarID,
-		"bannerId":            u.BannerID,
-		"followersVisibility": detailed.FollowersVisibility,
-		"followingVisibility": detailed.FollowingVisibility,
-		"chatScope":           u.ChatScope,
-		"canChat":             true,
-		"followedMessage":     nil,
-		"memo":                nil,
-		"moderationNote":      nil,
-		"hideOnlineStatus":    u.HideOnlineStatus,
-	}
+	// MeDetailed packer に乗っていない /api/i 固有 field を上書き / 追加。
+	resp["movedTo"] = u.MovedToURI
+	resp["alsoKnownAs"] = u.AlsoKnownAs
+	resp["lastFetchedAt"] = nil
+	resp["avatarId"] = u.AvatarID
+	resp["bannerId"] = u.BannerID
+	resp["chatScope"] = u.ChatScope
+	resp["canChat"] = true
+	resp["memo"] = nil
+	resp["moderationNote"] = nil
+	// isSilenced は role policy 由来で /api/i 固有 (MeDetailed には無い)。
+	resp["isSilenced"] = h.isSilenced(u.ID)
 
-	// Private fields from profile
+	// MeDetailed の followedMessage は packer 既定で profile から merge
+	// するが、profile == nil の fallback path だと nil で出る。
+	// PackUserDetailed 内で適切に処理されるので追加 override は不要。
+
+	// Private fields from profile (MeDetailed scope 外)
 	if profile != nil {
 		resp["email"] = profile.Email
 		resp["emailVerified"] = profile.EmailVerified
-		resp["autoAcceptFollowed"] = profile.AutoAcceptFollowed
-		resp["noCrawle"] = profile.NoCrawle
-		resp["preventAiLearning"] = profile.PreventAiLearning
-		resp["alwaysMarkNsfw"] = profile.AlwaysMarkNsfw
-		resp["autoSensitive"] = profile.AutoSensitive
-		resp["carefulBot"] = profile.CarefulBot
-		resp["injectFeaturedNote"] = profile.InjectFeaturedNote
-		resp["receiveAnnouncementEmail"] = profile.ReceiveAnnouncementEmail
 		resp["twoFactorEnabled"] = profile.TwoFactorEnabled
 		resp["usePasswordLessLogin"] = profile.UsePasswordLessLogin
 		resp["mutedWords"] = profile.MutedWords
 		resp["hardMutedWords"] = profile.HardMutedWords
 		resp["mutedInstances"] = profile.MutedInstances
 		resp["publicReactions"] = profile.PublicReactions
-		resp["followedMessage"] = profile.FollowedMessage
 		resp["loggedInDays"] = len(profile.LoggedInDates)
 		resp["achievements"] = jsonbArray(profile.Achievements)
 		resp["securityKeys"] = profile.SecurityKeysAvailable
@@ -665,8 +637,7 @@ func (h *Handler) Me(c echo.Context) error {
 	}
 	resp["isAdmin"] = isAdmin
 	resp["isModerator"] = isMod
-	resp["isDeleted"] = u.IsDeleted
-	resp["isExplorable"] = u.IsExplorable
+	// isDeleted / isExplorable は PackMeDetailed 由来で base 展開済 (#971)。
 	// 未読系フィールドを依存する repo / service から実際に引く。
 	// 未wireのものは false/0/[] にフォールバックする (テスト互換)。
 	// antenna / channel / specifiedNotes は別issueで追跡中のためここでは false 固定。
@@ -692,28 +663,8 @@ func (h *Handler) Me(c echo.Context) error {
 	} else {
 		resp["securityKeysList"] = []any{}
 	}
-	// upstream `MeDetailed` の notification-related 3 field (#985)。
-	// PackMeDetailed と同じ default + profile JSON 由来の値を入れる
-	// (i/update 経路と一貫性を持たせるため)。
-	resp["mutingNotificationTypes"] = []string{}
-	notifConf := map[string]any{}
-	emailTypes := []string{"follow", "receiveFollowRequest"}
-	if profile != nil {
-		if raw := []byte(profile.EmailNotificationTypes); len(raw) > 0 {
-			var arr []string
-			if err := json.Unmarshal(raw, &arr); err == nil {
-				emailTypes = arr
-			}
-		}
-		if raw := []byte(profile.NotificationRecieveConfig); len(raw) > 0 {
-			var m map[string]any
-			if err := json.Unmarshal(raw, &m); err == nil && m != nil {
-				notifConf = m
-			}
-		}
-	}
-	resp["notificationRecieveConfig"] = notifConf
-	resp["emailNotificationTypes"] = emailTypes
+	// MeDetailed の notification-related 3 field (#985) は PackMeDetailed 経由で
+	// base 展開済 (#971 で集約)。ここで追加 override は不要。
 
 	// createdAt は ID から復元
 	if t, err := h.idGen.ParseTime(u.ID); err == nil {

--- a/internal/api/i/handler_test.go
+++ b/internal/api/i/handler_test.go
@@ -199,6 +199,72 @@ func TestMe_Success(t *testing.T) {
 	assert.Nil(t, resp["alsoKnownAs"])
 }
 
+// TestMe_PreservesMeDetailedFields: #971 — Me handler を PackMeDetailed base
+// に refactor した後も、MeDetailed の 11 self-view field + notification 3
+// field がすべて response に乗っていることを確認する regression guard。
+func TestMe_PreservesMeDetailedFields(t *testing.T) {
+	h, userRepo, _, _ := newTestHandler(t)
+
+	user := &model.User{
+		ID:                "user2",
+		Username:          "merefactor",
+		IsExplorable:      true,
+		IsDeleted:         false,
+		HideOnlineStatus:  true,
+		AvatarDecorations: datatypes.JSON([]byte("[]")),
+	}
+	userRepo.Profiles["user2"] = &model.UserProfile{
+		UserID:                    "user2",
+		NoCrawle:                  true,
+		PreventAiLearning:         false,
+		AutoSensitive:             true,
+		CarefulBot:                true,
+		AutoAcceptFollowed:        true,
+		AlwaysMarkNsfw:            true,
+		ReceiveAnnouncementEmail:  false,
+		InjectFeaturedNote:        false,
+		EmailNotificationTypes:    datatypes.JSON([]byte(`["mention","reply"]`)),
+		NotificationRecieveConfig: datatypes.JSON([]byte(`{"mention":{"type":"following"}}`)),
+		Fields:                    datatypes.JSON([]byte("[]")),
+	}
+
+	e := echo.New()
+	req := httptest.NewRequest(http.MethodPost, "/api/i", nil)
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+	c.Set(string(middleware.UserContextKey), user)
+
+	require.NoError(t, h.Me(c))
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	var resp map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+
+	// 11 MeDetailed self-view field
+	assert.Equal(t, true, resp["isExplorable"])
+	assert.Equal(t, false, resp["isDeleted"])
+	assert.Equal(t, true, resp["hideOnlineStatus"])
+	assert.Equal(t, true, resp["noCrawle"])
+	assert.Equal(t, false, resp["preventAiLearning"])
+	assert.Equal(t, true, resp["autoSensitive"])
+	assert.Equal(t, true, resp["carefulBot"])
+	assert.Equal(t, true, resp["autoAcceptFollowed"])
+	assert.Equal(t, true, resp["alwaysMarkNsfw"])
+	assert.Equal(t, false, resp["receiveAnnouncementEmail"])
+	assert.Equal(t, false, resp["injectFeaturedNote"])
+
+	// #985 notification 3 field (profile JSON column 由来)
+	emailTypes, ok := resp["emailNotificationTypes"].([]any)
+	require.True(t, ok)
+	assert.Equal(t, []any{"mention", "reply"}, emailTypes)
+	mutingTypes, ok := resp["mutingNotificationTypes"].([]any)
+	require.True(t, ok)
+	assert.Empty(t, mutingTypes)
+	notifConf, ok := resp["notificationRecieveConfig"].(map[string]any)
+	require.True(t, ok)
+	require.Contains(t, notifConf, "mention")
+}
+
 func TestMe_LoggedInDays(t *testing.T) {
 	h, userRepo, _, _ := newTestHandler(t)
 

--- a/internal/api/i/handler_test.go
+++ b/internal/api/i/handler_test.go
@@ -366,6 +366,42 @@ func TestJsonbArray(t *testing.T) {
 	}
 }
 
+// TestMe_PackUserDetailedFieldsFlowThrough: #987 review で removed
+// した explicit override (avatarId / bannerId / chatScope) が
+// PackUserDetailed → MeDetailed embed 経由でも正しく resp に乗ること。
+func TestMe_PackUserDetailedFieldsFlowThrough(t *testing.T) {
+	h, userRepo, _, _ := newTestHandler(t)
+
+	avatarID := "av-flow"
+	bannerID := "bn-flow"
+	user := &model.User{
+		ID:                "user-flow",
+		Username:          "flowthrough",
+		AvatarDecorations: datatypes.JSON([]byte("[]")),
+		ChatScope:         "followers",
+		AvatarID:          &avatarID,
+		BannerID:          &bannerID,
+	}
+	userRepo.Profiles["user-flow"] = &model.UserProfile{
+		UserID: "user-flow",
+		Fields: datatypes.JSON([]byte("[]")),
+	}
+
+	e := echo.New()
+	req := httptest.NewRequest(http.MethodPost, "/api/i", nil)
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+	c.Set(string(middleware.UserContextKey), user)
+
+	require.NoError(t, h.Me(c))
+	var resp map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+	// 3 field とも explicit override 削除後も MeDetailed embed 経由で乗る
+	assert.Equal(t, "av-flow", resp["avatarId"])
+	assert.Equal(t, "bn-flow", resp["bannerId"])
+	assert.Equal(t, "followers", resp["chatScope"])
+}
+
 func TestMe_AvatarAndBannerIDs(t *testing.T) {
 	h, userRepo, _, _ := newTestHandler(t)
 

--- a/internal/api/users/handler.go
+++ b/internal/api/users/handler.go
@@ -428,6 +428,14 @@ func (h *Handler) Show(c echo.Context) error {
 		}
 	}
 
+	// viewer===target の self-view では upstream `pack(user, me)` 互換で
+	// MeDetailed 拡張 field (isExplorable / noCrawle 等 11 個 + #985 で
+	// 追加した notification 3 field) を merge して返す (#970)。これにより
+	// frontend が `/api/users/show?username=me` 経由で自分のプロフィールを
+	// 開いたとき、`/api/i` 経由の $i と field set を一致させられる。
+	if viewer != nil && viewer.ID == bundle.User.ID {
+		return c.JSON(http.StatusOK, entity.AsMeDetailed(detailed, bundle.User, bundle.Profile))
+	}
 	return c.JSON(http.StatusOK, detailed)
 }
 

--- a/internal/api/users/handler_test.go
+++ b/internal/api/users/handler_test.go
@@ -354,6 +354,138 @@ func TestShow_UsernameNotFound(t *testing.T) {
 	assert.Equal(t, http.StatusNotFound, rec.Code)
 }
 
+// TestShow_SelfViewReturnsMeDetailed: #970 — `/api/users/show` で viewer===target
+// のとき MeDetailed 拡張 field (isExplorable / noCrawle / emailNotificationTypes
+// 等) を merge して返すこと。
+func TestShow_SelfViewReturnsMeDetailed(t *testing.T) {
+	h, userRepo := newTestHandler(t)
+
+	self := &model.User{
+		ID:                "self1",
+		Username:          "selfuser",
+		IsExplorable:      true,
+		IsDeleted:         false,
+		HideOnlineStatus:  true,
+		AvatarDecorations: datatypes.JSON([]byte("[]")),
+	}
+	userRepo.Users["self1"] = self
+	userRepo.Profiles["self1"] = &model.UserProfile{
+		UserID:                    "self1",
+		NoCrawle:                  true,
+		PreventAiLearning:         false,
+		AlwaysMarkNsfw:            true,
+		EmailNotificationTypes:    datatypes.JSON([]byte(`["mention"]`)),
+		NotificationRecieveConfig: datatypes.JSON([]byte(`{"mention":{"type":"following"}}`)),
+		Fields:                    datatypes.JSON([]byte("[]")),
+	}
+
+	body := `{"userId":"self1"}`
+	e := echo.New()
+	req := httptest.NewRequest(http.MethodPost, "/api/users/show", strings.NewReader(body))
+	req.Header.Set(echo.HeaderContentType, echo.MIMEApplicationJSON)
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+	c.Set(string(middleware.UserContextKey), self)
+
+	require.NoError(t, h.Show(c))
+	assert.Equal(t, http.StatusOK, rec.Code)
+
+	var resp map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+	// MeDetailed-only field が出ること
+	assert.Equal(t, true, resp["isExplorable"])
+	assert.Equal(t, false, resp["isDeleted"])
+	assert.Equal(t, true, resp["hideOnlineStatus"])
+	assert.Equal(t, true, resp["noCrawle"])
+	assert.Equal(t, false, resp["preventAiLearning"])
+	assert.Equal(t, true, resp["alwaysMarkNsfw"])
+	// #985 notification 3 field (profile JSON column 由来)
+	emailTypes, ok := resp["emailNotificationTypes"].([]any)
+	require.True(t, ok)
+	require.Len(t, emailTypes, 1)
+	assert.Equal(t, "mention", emailTypes[0])
+	notifConf, ok := resp["notificationRecieveConfig"].(map[string]any)
+	require.True(t, ok)
+	require.Contains(t, notifConf, "mention")
+	// 通常 UserDetailed field も残る
+	assert.Equal(t, "self1", resp["id"])
+	assert.Equal(t, "selfuser", resp["username"])
+}
+
+// TestShow_NonSelfViewExcludesMeDetailed: viewer != target なら MeDetailed
+// 拡張 field は出さない (privacy boundary)。
+func TestShow_NonSelfViewExcludesMeDetailed(t *testing.T) {
+	h, userRepo := newTestHandler(t)
+
+	target := &model.User{
+		ID:                "target1",
+		Username:          "target",
+		IsExplorable:      true,
+		AvatarDecorations: datatypes.JSON([]byte("[]")),
+	}
+	userRepo.Users["target1"] = target
+	userRepo.Profiles["target1"] = &model.UserProfile{
+		UserID:                 "target1",
+		NoCrawle:               true,
+		EmailNotificationTypes: datatypes.JSON([]byte(`["mention"]`)),
+		Fields:                 datatypes.JSON([]byte("[]")),
+	}
+	viewer := &model.User{ID: "viewer1", Username: "viewer"}
+
+	body := `{"userId":"target1"}`
+	e := echo.New()
+	req := httptest.NewRequest(http.MethodPost, "/api/users/show", strings.NewReader(body))
+	req.Header.Set(echo.HeaderContentType, echo.MIMEApplicationJSON)
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+	c.Set(string(middleware.UserContextKey), viewer)
+
+	require.NoError(t, h.Show(c))
+	assert.Equal(t, http.StatusOK, rec.Code)
+
+	var resp map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+	// MeDetailed-only field が漏れていないこと
+	_, hasIsExplorable := resp["isExplorable"]
+	assert.False(t, hasIsExplorable, "isExplorable must not leak for non-self view")
+	_, hasNoCrawle := resp["noCrawle"]
+	assert.False(t, hasNoCrawle, "noCrawle must not leak for non-self view")
+	_, hasEmailNotif := resp["emailNotificationTypes"]
+	assert.False(t, hasEmailNotif, "emailNotificationTypes must not leak for non-self view")
+}
+
+// TestShow_AnonymousViewExcludesMeDetailed: viewer == nil でも UserDetailed
+// shape (= 公開 field のみ) を返す。
+func TestShow_AnonymousViewExcludesMeDetailed(t *testing.T) {
+	h, userRepo := newTestHandler(t)
+	target := &model.User{
+		ID:                "target1",
+		Username:          "target",
+		IsExplorable:      true,
+		AvatarDecorations: datatypes.JSON([]byte("[]")),
+	}
+	userRepo.Users["target1"] = target
+	userRepo.Profiles["target1"] = &model.UserProfile{
+		UserID: "target1",
+		Fields: datatypes.JSON([]byte("[]")),
+	}
+
+	body := `{"userId":"target1"}`
+	e := echo.New()
+	req := httptest.NewRequest(http.MethodPost, "/api/users/show", strings.NewReader(body))
+	req.Header.Set(echo.HeaderContentType, echo.MIMEApplicationJSON)
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+	// viewer は context に set しない (= anonymous)
+
+	require.NoError(t, h.Show(c))
+	assert.Equal(t, http.StatusOK, rec.Code)
+	var resp map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+	_, hasIsExplorable := resp["isExplorable"]
+	assert.False(t, hasIsExplorable)
+}
+
 func TestShow_ViewerDependentFields(t *testing.T) {
 	h, userRepo := newTestHandler(t)
 

--- a/internal/entity/user.go
+++ b/internal/entity/user.go
@@ -141,8 +141,22 @@ type MeDetailed struct {
 // privacy-scoped fields like isExplorable / noCrawle stay stale in the
 // session (#968).
 func PackMeDetailed(u *model.User, profile *model.UserProfile, idGens ...id.Generator) MeDetailed {
+	return AsMeDetailed(PackUserDetailed(u, profile, idGens...), u, profile)
+}
+
+// AsMeDetailed promotes a pre-built UserDetailed payload into MeDetailed by
+// layering on the self-view-only fields sourced from User + UserProfile.
+// Used directly by users/show (#970) when viewer===target to mirror
+// upstream's `pack(user, me)` semantics, and indirectly by PackMeDetailed
+// which builds a fresh UserDetailed first.
+//
+// Why a separate helper: users/show already does additional work on the
+// pre-built UserDetailed (remote stats / instance / emojis / pinned /
+// viewer-dependent fields). Re-running PackUserDetailed would lose that
+// work, so we promote the existing UserDetailed in-place.
+func AsMeDetailed(d UserDetailed, u *model.User, profile *model.UserProfile) MeDetailed {
 	out := MeDetailed{
-		UserDetailed:     PackUserDetailed(u, profile, idGens...),
+		UserDetailed:     d,
 		IsExplorable:     u.IsExplorable,
 		IsDeleted:        u.IsDeleted,
 		HideOnlineStatus: u.HideOnlineStatus,

--- a/internal/entity/user_test.go
+++ b/internal/entity/user_test.go
@@ -538,6 +538,41 @@ func TestPackMeDetailed_NotificationNilProfile(t *testing.T) {
 	assert.Equal(t, map[string]any{}, me.NotificationRecieveConfig)
 }
 
+// #970: AsMeDetailed が pre-built UserDetailed の embed 値を保持しつつ
+// MeDetailed-only field を layering する direct entry test。users/show の
+// self-view branch が build 済の detailed (= remote stats / instance /
+// emojis / pinned / viewer-dependent fields を含む) を渡しても上書きされず、
+// 11 self-view field + notification 3 field のみが追加されること。
+func TestAsMeDetailed_PreservesEmbeddedUserDetailed(t *testing.T) {
+	u := &model.User{
+		ID:                "as1",
+		Username:          "asuser",
+		IsExplorable:      true,
+		AvatarDecorations: datatypes.JSON([]byte("[]")),
+	}
+	profile := &model.UserProfile{
+		UserID:   "as1",
+		NoCrawle: true,
+		Fields:   datatypes.JSON([]byte("[]")),
+	}
+	// pre-built UserDetailed に external な後付け修正 (= users/show が行う
+	// remote stats / pinned 反映に相当) を加えたものを base として渡す。
+	d := PackUserDetailed(u, profile)
+	d.NotesCount = 42
+	pinnedIDs := []string{"note1", "note2"}
+	d.PinnedNoteIDs = pinnedIDs
+
+	me := AsMeDetailed(d, u, profile)
+
+	// 後付け修正値は保持されている
+	assert.Equal(t, 42, me.NotesCount)
+	assert.Equal(t, pinnedIDs, me.PinnedNoteIDs)
+	// MeDetailed-only field が layering される
+	assert.True(t, me.IsExplorable)
+	assert.True(t, me.NoCrawle)
+	assert.Equal(t, []string{"follow", "receiveFollowRequest"}, me.EmailNotificationTypes)
+}
+
 // #985: profile column の JSON が壊れているときは default に倒し silent
 // fallback する (parse error は ignore)。
 func TestPackMeDetailed_NotificationMalformed(t *testing.T) {


### PR DESCRIPTION
## Summary

\`MeDetailed\` packer の用途を広げる 2 件の bundle PR。両方 #968 (PR #969) で導入した \`PackMeDetailed\` を起点に派生したスコープ。

## 修正内訳

### #970 — \`/api/users/show\` で viewer===target のとき MeDetailed shape を返す

upstream Misskey TS \`UserEntityService.pack(user, me, opts)\` の \`me?.id === user.id\` 分岐と同 semantics。新規 helper \`entity.AsMeDetailed\` を導入し、users/show が build した \`detailed UserDetailed\` (= remote stats / instance / emojis / pinned / viewer-dependent fields を含む) を **promote** する形で MeDetailed 化する。\`PackUserDetailed\` を再実行しないので、build 済の work を保持できる。

\`\`\`go
// internal/api/users/handler.go (Show 末尾)
if viewer != nil && viewer.ID == bundle.User.ID {
    return c.JSON(http.StatusOK, entity.AsMeDetailed(detailed, bundle.User, bundle.Profile))
}
return c.JSON(http.StatusOK, detailed)
\`\`\`

これで frontend が \`/api/users/show?username=me\` 経由で自分のプロフィールを開いたとき、\`/api/i\` 経由の \`\$i\` と field set を一致させられる。

### #971 — \`/api/i\` Me handler を \`PackMeDetailed\` ベースに refactor

JSON round-trip で MeDetailed を resp map base に展開し、\`/api/i\` 固有 field を merge する design に refactor。

- 11 MeDetailed self-view field (\`isExplorable\` / \`isDeleted\` / \`hideOnlineStatus\` / \`noCrawle\` / \`preventAiLearning\` / \`autoSensitive\` / \`carefulBot\` / \`autoAcceptFollowed\` / \`alwaysMarkNsfw\` / \`receiveAnnouncementEmail\` / \`injectFeaturedNote\`)
- #985 で追加した notification 3 field (\`emailNotificationTypes\` / \`mutingNotificationTypes\` / \`notificationRecieveConfig\`)

の **重複コード 25 行を削除**。MeDetailed packer 更新時は handler を触らず自動追従。

\`\`\`go
me := entity.PackMeDetailed(u, profile, h.idGen)
b, _ := json.Marshal(me)
resp := map[string]any{}
_ = json.Unmarshal(b, &resp)
// /api/i 固有 field を merge
resp["email"] = profile.Email
...
\`\`\`

### \`PackMeDetailed\` の DRY 化

\`PackMeDetailed\` を \`AsMeDetailed\` の thin wrapper に refactor。元実装と機能等価で、users/show と /api/i の両 path が同じ MeDetailed promotion logic を共有する。

\`\`\`go
func PackMeDetailed(u, profile, idGens...) MeDetailed {
    return AsMeDetailed(PackUserDetailed(u, profile, idGens...), u, profile)
}
\`\`\`

## 主な変更点

| 領域 | ファイル |
|------|---------|
| MeDetailed helper | \`internal/entity/user.go\` (AsMeDetailed 新設 / PackMeDetailed 薄く) |
| users/show | \`internal/api/users/handler.go\` (self-view branch 追加) |
| Me handler | \`internal/api/i/handler.go\` (resp map を PackMeDetailed base に refactor) |
| docs | \`CHANGELOG.md\`、\`docs/api-compatibility.md\` |

## テスト

### 新規

- \`internal/entity\`:
  - \`TestAsMeDetailed_PreservesEmbeddedUserDetailed\` — pre-built UserDetailed の値 (NotesCount / PinnedNoteIDs) が AsMeDetailed 経由で保持されることを verify
- \`internal/api/users\`:
  - \`TestShow_SelfViewReturnsMeDetailed\` — viewer===target で 11 + 3 field が出る
  - \`TestShow_NonSelfViewExcludesMeDetailed\` — viewer != target で漏れない (privacy boundary)
  - \`TestShow_AnonymousViewExcludesMeDetailed\` — viewer == nil でも漏れない
- \`internal/api/i\`:
  - \`TestMe_PreservesMeDetailedFields\` — refactor 後の Me handler が 11 + 3 field を保持することを regression guard

### Coverage

| package | before | after |
|---------|--------|-------|
| \`internal/entity\` | 96.5% | 96.5% |
| \`internal/api/i\` | 91.4% | **91.9%** |
| \`internal/api/users\` | 91.9% | **92.0%** |

全 package 90% threshold over。

### 実行方法

\`\`\`bash
go test -race -count=1 -coverprofile=cov.out -covermode=atomic \\
  ./internal/entity/... ./internal/api/i/... ./internal/api/users/...
go tool cover -func=cov.out | tail -5
\`\`\`

## Risk / 影響

- **API 互換性**: \`/api/users/show\` で self-view した際の response shape が拡張 (= additive change)。client 側 untyped JSON parse なら互換、strict typing client (= 想定なし) なら新 field を ignore するだけ
- **Performance**: \`/api/i\` で JSON Marshal + Unmarshal が 1 回ずつ追加 (per-session 数回の頻度なので無視できる)
- **Privacy**: \`users/show\` の non-self / anonymous view では MeDetailed 拡張 field は **漏れない** ことを 2 件の test で verify

## Closes

- Closes #970
- Closes #971