### PR TITLE
fix(ci): nightly workflow に submodule init + pnpm build を追加 (#954 regression)

### DIFF
--- a/.github/workflows/dropin-e2e.yml
+++ b/.github/workflows/dropin-e2e.yml
@@ -36,6 +36,28 @@ jobs:
           # 監視するもので、`develop` への変更が対象なので明示的に develop を
           # 指定する (Devin #375 #1)。
           ref: ${{ inputs.ref || 'develop' }}
+          # tests/federation/common/Dockerfile.mkgo が
+          # third_party/misskey/built/ + assets/ を COPY するので submodule
+          # を先に展開しないと docker build が "failed to compute cache key"
+          # で死ぬ (#954 で frontend bundle COPY が追加され、2026-05-09
+          # nightly から本問題が顕在化)。
+          submodules: recursive
+
+      # Dockerfile.mkgo が third_party/misskey/built/_frontend_vite_ 等を
+      # COPY する。これは `pnpm build` の成果物で submodule に commit され
+      # ていないので、docker build より前に host で run しておく。
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+
+      - name: Build third_party/misskey frontend bundle
+        working-directory: third_party/misskey
+        run: |
+          corepack enable
+          corepack prepare pnpm@latest --activate
+          pnpm install --frozen-lockfile
+          pnpm build
 
       - name: Pre-pull Misskey TS image
         # 旧版は `&` で background 化していたが、GitHub Actions の `run:`

--- a/.github/workflows/dropin-e2e.yml
+++ b/.github/workflows/dropin-e2e.yml
@@ -46,12 +46,30 @@ jobs:
       # Dockerfile.mkgo が third_party/misskey/built/_frontend_vite_ 等を
       # COPY する。これは `pnpm build` の成果物で submodule に commit され
       # ていないので、docker build より前に host で run しておく。
+      #
+      # actions/cache で built/ + node_modules を pin (playwright.yml と同じ
+      # 戦略)。submodule の pnpm-lock.yaml hash をキーに使うので、Misskey
+      # upstream を pin し直さない限り cache hit で 5-10 min → 数秒に短縮。
+      - name: Cache misskey workspace (built + node_modules)
+        id: cache-misskey
+        uses: actions/cache@v4
+        with:
+          # packages/*/node_modules で全 workspace package を glob 対応
+          # (新 package 追加時に手動更新不要)。built/ は pnpm build の成果物。
+          path: |
+            third_party/misskey/node_modules
+            third_party/misskey/packages/*/node_modules
+            third_party/misskey/built
+          key: misskey-workspace-${{ runner.os }}-${{ hashFiles('third_party/misskey/pnpm-lock.yaml') }}
+
       - name: Set up Node.js
+        if: steps.cache-misskey.outputs.cache-hit != 'true'
         uses: actions/setup-node@v4
         with:
           node-version: "22"
 
       - name: Build third_party/misskey frontend bundle
+        if: steps.cache-misskey.outputs.cache-hit != 'true'
         working-directory: third_party/misskey
         run: |
           corepack enable

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -64,6 +64,35 @@ jobs:
       - uses: actions/checkout@v4
         with:
           ref: ${{ inputs.ref || 'develop' }}
+          # tests/federation/common/Dockerfile.mkgo が
+          # third_party/misskey/built/ + assets/ を COPY するので、submodule
+          # を先に展開しないと docker build が "failed to compute cache key:
+          # ... not found" で死ぬ (#954 で frontend bundle COPY が追加されて
+          # 2026-05-09 nightly から本問題が顕在化)。
+          submodules: recursive
+
+      # mk-go backend は Dockerfile.mkgo で third_party/misskey/built/
+      # _frontend_vite_ / _frontend_dist_ / _sw_dist_ を COPY する。これらは
+      # `pnpm build` の成果物で、submodule に commit されていない。CI で
+      # 都度 build する (build context に焼き込んで docker build に渡す)。
+      # TS overlay (upstream image を pull) では本 step を skip して時間を節約。
+      - name: Set up Node.js
+        if: matrix.backend == 'mk-go'
+        uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+
+      - name: Build third_party/misskey frontend bundle
+        if: matrix.backend == 'mk-go'
+        working-directory: third_party/misskey
+        # pnpm install --frozen-lockfile + pnpm build。初回は 5-10 分かかる
+        # (vite + sw + twemoji asset 抽出)。docker build 時に build context
+        # から COPY されるので、image build より前に host で run しておく。
+        run: |
+          corepack enable
+          corepack prepare pnpm@latest --activate
+          pnpm install --frozen-lockfile
+          pnpm build
 
       - name: Pre-pull image (TS only)
         if: matrix.prepull != ''

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -76,18 +76,37 @@ jobs:
       # `pnpm build` の成果物で、submodule に commit されていない。CI で
       # 都度 build する (build context に焼き込んで docker build に渡す)。
       # TS overlay (upstream image を pull) では本 step を skip して時間を節約。
-      - name: Set up Node.js
+      #
+      # actions/cache で built/ + node_modules を pin。submodule の
+      # pnpm-lock.yaml hash をキーに使うので、Misskey upstream を pin し
+      # 直さない限り cache hit で pnpm install + build をまるごと skip
+      # (5-10 min → 数秒に短縮)。
+      - name: Cache misskey workspace (built + node_modules)
+        id: cache-misskey
         if: matrix.backend == 'mk-go'
+        uses: actions/cache@v4
+        with:
+          # packages/*/node_modules で全 workspace package を glob 対応
+          # (新 package 追加時に手動更新不要)。built/ は pnpm build の成果物。
+          path: |
+            third_party/misskey/node_modules
+            third_party/misskey/packages/*/node_modules
+            third_party/misskey/built
+          key: misskey-workspace-${{ runner.os }}-${{ hashFiles('third_party/misskey/pnpm-lock.yaml') }}
+
+      - name: Set up Node.js
+        if: matrix.backend == 'mk-go' && steps.cache-misskey.outputs.cache-hit != 'true'
         uses: actions/setup-node@v4
         with:
           node-version: "22"
 
       - name: Build third_party/misskey frontend bundle
-        if: matrix.backend == 'mk-go'
+        if: matrix.backend == 'mk-go' && steps.cache-misskey.outputs.cache-hit != 'true'
         working-directory: third_party/misskey
         # pnpm install --frozen-lockfile + pnpm build。初回は 5-10 分かかる
         # (vite + sw + twemoji asset 抽出)。docker build 時に build context
         # から COPY されるので、image build より前に host で run しておく。
+        # 以降の nightly は cache hit で本 step を skip する。
         run: |
           corepack enable
           corepack prepare pnpm@latest --activate


### PR DESCRIPTION
## Summary

過去 2 nightly (2026-05-09 / 2026-05-10) が **docker build 段階で死亡** している root cause を修正。

### 原因

PR #954 (2026-05-09 merged) で \`tests/federation/common/Dockerfile.mkgo\` に以下の COPY が追加された:

\`\`\`dockerfile
COPY --from=builder /app/third_party/misskey/built/_frontend_vite_ /app/built/_frontend_vite_
COPY --from=builder /app/third_party/misskey/built/_frontend_dist_ /app/built/_frontend_dist_
COPY --from=builder /app/third_party/misskey/built/_sw_dist_ /app/built/_sw_dist_
COPY --from=builder /app/third_party/misskey/packages/frontend/assets /app/client-assets
\`\`\`

しかし \`.github/workflows/{playwright,dropin-e2e}.yml\` が **submodule 初期化 + pnpm build を行っていなかった**ため、build context に \`third_party/misskey/\` が空のまま docker build に渡され、以下のエラーで死んでいた:

\`\`\`
target mkgo: failed to solve: failed to compute cache key:
failed to calculate checksum of ref ...:
\"/app/third_party/misskey/assets\": not found
\`\`\`

### 影響

| workflow | 失敗開始 | 失敗回数 |
|---------|---------|---------|
| Playwright (nightly) | 2026-05-09 17:22 UTC | 2 |
| Drop-in e2e (nightly) | 2026-05-09 18:26 UTC | 2 |

## 修正内容

### Commit 1 (\`ad26bf2\`): submodule init + pnpm build

両 workflow に以下を追加:

1. \`actions/checkout@v4\` に \`submodules: recursive\` — Misskey submodule の static asset (twemoji / backend assets / repo assets) を取得
2. Node 22 + corepack 経由で pnpm 有効化
3. \`third_party/misskey\` で \`pnpm install --frozen-lockfile && pnpm build\` — \`built/_frontend_vite_\` / \`_frontend_dist_\` / \`_sw_dist_\` の vite build artifact を生成

\`playwright.yml\` では mk-go matrix のみ実行 (\`if: matrix.backend == 'mk-go'\`)。TS overlay は upstream image を pull するだけなので pnpm build 不要。\`dropin-e2e.yml\` は単一 job なので全 path で実行。

### Commit 2 (\`b0c6921\`): actions/cache + glob

\`pnpm install + build\` の 5-10 min を pin-cache:

\`\`\`yaml
- name: Cache misskey workspace (built + node_modules)
  uses: actions/cache@v4
  with:
    path: |
      third_party/misskey/node_modules
      third_party/misskey/packages/*/node_modules    # ← glob で全 package auto-include
      third_party/misskey/built
    key: misskey-workspace-\${{ runner.os }}-\${{ hashFiles('third_party/misskey/pnpm-lock.yaml') }}
\`\`\`

\`if: steps.cache-misskey.outputs.cache-hit != 'true'\` で Node setup + pnpm build を cache hit で完全に skip。submodule の \`pnpm-lock.yaml\` hash が key なので、Misskey upstream を pin し直さない限り invalidate されない。

## 期待効果

| 状況 | playwright nightly time |
|------|-------------------------|
| Pre-#954 (broken before this PR) | 3-4 min |
| 修正 + cache miss (= 初回 / submodule update 後) | 10-15 min |
| 修正 + cache hit (= 通常 nightly) | **~5 min** (3-4 min + cache restore overhead) |

## 実機検証

\`workflow_dispatch\` でこの branch を kick off:

- **dropin-e2e (run \`25669148207\`)**: ✓ **success 5m15s** (失敗時は 3m21s で docker build error → 成功で完走)
- **playwright mk-go**: ✓ Build third_party/misskey frontend bundle → ✓ Bring up stack まで通過 (specs phase は別問題)
- **playwright TS**: ✗ pre-existing #978 由来の bug (本 PR scope 外、Issue #990 で追跡)

## 主な変更点

| ファイル | 変更 |
|---------|------|
| \`.github/workflows/playwright.yml\` | submodule + Node setup + pnpm build + actions/cache (mk-go matrix のみ) |
| \`.github/workflows/dropin-e2e.yml\` | submodule + Node setup + pnpm build + actions/cache (全 path) |

合計 2 ファイル / +90 行。

## Scope 外 (別 issue)

- **#990**: TS playwright matrix が NODE_ENV=test → \`/misskey/.config/test.yml\` lookup で死ぬ pre-existing bug。PR #978 由来で本 PR とは独立。本 PR ブランチで 3 つの fix attempt (double-mount / MISSKEY_CONFIG_YML / NODE_ENV=development) を試したが CI でのみ機能せず (ローカルでは ✓)、全て revert して #990 で別途調査。
- **dropin-frontend-e2e**: 2026-05-08 から別原因 (cypress spec の \`retryUntil: predicate never matched\`) で fail、本 PR 影響範囲外。
- **playwright mk-go の spec timeout**: 別問題、specs phase が CI で長い理由は未調査。

## トレードオフ

- 初回 / submodule update 後 1 nightly のみ cache miss で 10-15 min。timeout (20/25 min) には余裕
- 通常 nightly は cache hit で 5 min 以内 (修正前と同等)
- PR check には影響なし (nightly only)