### PR TITLE
fix: canChat 二重 drift 解消 (#988) — role policy ベース化 + Me hardcode 撤去

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,7 @@ Playwright spec を両 backend で走らせる中で観測した drop-in 互換 
 - #872: blocked → following/create reject status (400)
 - #984: users/relation を stub から実装に切替。viewer ↔ target の follow / follow-request / block / mute / renote-mute 状態を 5 repo (`following` / `follow_request` / `blocking` / `muting` / `renote_muting`) から実 DB 状態として返す
 - #970: `/api/users/show` で viewer===target のとき MeDetailed 拡張 field (isExplorable / noCrawle / emailNotificationTypes 等 14 個) を merge して返すよう拡張。upstream `pack(user, me)` semantics と一致させ、`/api/users/show?username=me` 経由でも `/api/i` と同じ shape を保つ。新規 helper `entity.AsMeDetailed` で pre-built UserDetailed を promote する design
+- #988: `canChat` 二重 drift 解消。`PackUserLite` が \`u.ChatScope != "none"\` でなく **role policy の `chatAvailability === "available"`** から derive するように変更 (upstream `UserEntityService.ts:561` 互換)。新規 `entity.CanChatLookup` interface を `internal/entity/can_chat.go` に追加し、`role.CanChatLookupAdapter` で role.Service を bridge する design (= `entity.SetAvatarDecorationLookup` と同 pattern)。`/api/i` Me handler の `resp["canChat"] = true` hardcode も撤去し、self-view でも role policy が反映される
 
 #### settings / token
 - #883: i/regenerate-token return shape (204)

--- a/docs/api-compatibility.md
+++ b/docs/api-compatibility.md
@@ -107,6 +107,7 @@ Playwright spec を両 backend で走らせる中で観測した「TS と mk-go 
 | #872 | blocked → following/create reject status (400) |
 | #984 | users/relation を stub から実装に切替。viewer ↔ target の follow / follow-request / block / mute / renote-mute を 5 repo (`following` / `follow_request` / `blocking` / `muting` / `renote_muting`) から実 DB 状態として返す |
 | #970 | `/api/users/show` で viewer===target のとき MeDetailed 拡張 field を merge (upstream `pack(user, me)` 互換)。`entity.AsMeDetailed` helper で pre-built UserDetailed を promote |
+| #988 | `canChat` 二重 drift 解消: PackUserLite が role policy `chatAvailability === "available"` 由来に切替 (旧 chatScope 比較を撤回) + Me handler の hardcode true override も撤去。新規 `entity.CanChatLookup` interface で entity ↔ role.Service を decouple |
 
 #### settings / token
 | # | 内容 |

--- a/internal/api/i/handler.go
+++ b/internal/api/i/handler.go
@@ -581,11 +581,10 @@ func (h *Handler) Me(c echo.Context) error {
 	resp["movedTo"] = u.MovedToURI
 	resp["alsoKnownAs"] = u.AlsoKnownAs
 	resp["lastFetchedAt"] = nil
-	// canChat は upstream では role policy の chatAvailability 由来だが、
-	// mk-go は PackUserLite で chatScope != "none" 由来になっており、さらに
-	// 本 handler では self-view 用に true hardcode で override している。
-	// 二重 drift は別途 #988 で tracking。本 PR では既存挙動を保つ。
-	resp["canChat"] = true
+	// canChat は PackMeDetailed → UserLite 経由で role policy
+	// chatAvailability === 'available' を見るようになった (#988)。
+	// 旧 self-view 用 hardcode `resp["canChat"] = true` を撤去し、
+	// upstream と同じ role policy ベースの判定に揃える。
 	// memo / moderationNote は UserDetailed.Memo (omitempty) / MeDetailed
 	// 構造体に無いため、JSON unmarshal 後の resp map に key が出ない。
 	// /api/i の response shape を後方互換に保つため key 自体は出す

--- a/internal/api/i/handler_test.go
+++ b/internal/api/i/handler_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/lib/pq"
 	"github.com/shiroha-a/mk/internal/core/notification"
 	coreuser "github.com/shiroha-a/mk/internal/core/user"
+	"github.com/shiroha-a/mk/internal/entity"
 	"github.com/shiroha-a/mk/internal/misc/id"
 	miscsmtp "github.com/shiroha-a/mk/internal/misc/smtp"
 	"github.com/shiroha-a/mk/internal/model"
@@ -197,6 +198,44 @@ func TestMe_Success(t *testing.T) {
 	assert.Equal(t, false, resp["securityKeys"])
 	assert.Nil(t, resp["movedTo"])
 	assert.Nil(t, resp["alsoKnownAs"])
+}
+
+// TestMe_CanChatFromRolePolicy: #988 — Me handler が canChat を role policy
+// 由来で返すこと (旧 hardcode `resp["canChat"] = true` を撤去後の regression
+// guard)。CanChatLookup を wire して false を返すと self-view でも false。
+func TestMe_CanChatFromRolePolicy(t *testing.T) {
+	h, userRepo, _, _ := newTestHandler(t)
+
+	t.Cleanup(func() { entity.SetCanChatLookup(nil) })
+	entity.SetCanChatLookup(&stubMeCanChatLookup{result: false})
+
+	user := &model.User{
+		ID:                "user-canchat",
+		Username:          "blocked",
+		ChatScope:         "all", // 旧実装ではこの値で true 固定だった
+		AvatarDecorations: datatypes.JSON([]byte("[]")),
+	}
+	userRepo.Profiles["user-canchat"] = &model.UserProfile{
+		UserID: "user-canchat",
+		Fields: datatypes.JSON([]byte("[]")),
+	}
+
+	e := echo.New()
+	req := httptest.NewRequest(http.MethodPost, "/api/i", nil)
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+	c.Set(string(middleware.UserContextKey), user)
+
+	require.NoError(t, h.Me(c))
+	var resp map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+	assert.Equal(t, false, resp["canChat"])
+}
+
+type stubMeCanChatLookup struct{ result bool }
+
+func (s *stubMeCanChatLookup) LookupCanChat(_ string) (bool, bool) {
+	return s.result, true
 }
 
 // TestMe_PreservesMeDetailedFields: #971 — Me handler を PackMeDetailed base

--- a/internal/core/role/can_chat_lookup.go
+++ b/internal/core/role/can_chat_lookup.go
@@ -1,5 +1,10 @@
 package role
 
+import (
+	"fmt"
+	"log/slog"
+)
+
 // CanChatLookupAdapter wraps a role policy provider so that entity.PackUserLite
 // can derive `canChat` from the upstream `chatAvailability === "available"`
 // semantics (#988). Implements entity.CanChatLookup without creating a
@@ -18,6 +23,10 @@ type PolicyProvider interface {
 
 // NewCanChatLookup returns an entity.CanChatLookup that resolves a user's
 // canChat status via role policies. Use entity.SetCanChatLookup(...) to wire.
+//
+// nil provider を渡された場合は nil adapter を返す代わりに usable な
+// stub adapter (= 常に ok=false を返す) を返す。これにより呼び出し側
+// (`router.go` の wire path) が nil チェック不要で済む。
 func NewCanChatLookup(provider PolicyProvider) *CanChatLookupAdapter {
 	return &CanChatLookupAdapter{provider: provider}
 }
@@ -26,18 +35,27 @@ func NewCanChatLookup(provider PolicyProvider) *CanChatLookupAdapter {
 // Returns (true, true) when chatAvailability == "available" (= default),
 // (false, true) for other values ("readonly" / "unavailable" per upstream
 // taxonomy). Returns ok=false only if the policy map is missing the key
-// (= legacy data), in which case PackUserLite falls back to default true.
+// (= legacy data) or the value has an unexpected type, in which case
+// PackUserLite falls back to default true.
 func (a *CanChatLookupAdapter) LookupCanChat(userID string) (bool, bool) {
+	if a == nil || a.provider == nil {
+		return false, false
+	}
 	policies := a.provider.GetUserPolicies(userID)
 	v, ok := policies["chatAvailability"]
 	if !ok {
+		// legacy data path: role.Service が古い persisted policy を
+		// 返したとき。silent fallback (= default true) で十分。
 		return false, false
 	}
 	s, ok := v.(string)
 	if !ok {
 		// マージ後 policies の chatAvailability は upstream の string enum
-		// ("available" / "readonly" / "unavailable") なので、別型は壊れた
-		// data。defaults へ fallback。
+		// ("available" / "readonly" / "unavailable")。別型は壊れた data
+		// なので運用 debug のため slog.Warn で残す (frontend は default
+		// で動作可能、users/relation の transient error と同 pattern)。
+		slog.Warn("canChat lookup: chatAvailability has unexpected type",
+			"userID", userID, "type", fmt.Sprintf("%T", v))
 		return false, false
 	}
 	return s == "available", true

--- a/internal/core/role/can_chat_lookup.go
+++ b/internal/core/role/can_chat_lookup.go
@@ -1,0 +1,44 @@
+package role
+
+// CanChatLookupAdapter wraps a role policy provider so that entity.PackUserLite
+// can derive `canChat` from the upstream `chatAvailability === "available"`
+// semantics (#988). Implements entity.CanChatLookup without creating a
+// dependency from entity to core/role (= keeps the layering: api → core →
+// entity, never the reverse).
+type CanChatLookupAdapter struct {
+	provider PolicyProvider
+}
+
+// PolicyProvider is the subset of role.Service used by the adapter. Defined
+// here as an interface so tests can inject a stub without depending on the
+// full Service.
+type PolicyProvider interface {
+	GetUserPolicies(userID string) map[string]any
+}
+
+// NewCanChatLookup returns an entity.CanChatLookup that resolves a user's
+// canChat status via role policies. Use entity.SetCanChatLookup(...) to wire.
+func NewCanChatLookup(provider PolicyProvider) *CanChatLookupAdapter {
+	return &CanChatLookupAdapter{provider: provider}
+}
+
+// LookupCanChat reads chatAvailability from the user's merged role policies.
+// Returns (true, true) when chatAvailability == "available" (= default),
+// (false, true) for other values ("readonly" / "unavailable" per upstream
+// taxonomy). Returns ok=false only if the policy map is missing the key
+// (= legacy data), in which case PackUserLite falls back to default true.
+func (a *CanChatLookupAdapter) LookupCanChat(userID string) (bool, bool) {
+	policies := a.provider.GetUserPolicies(userID)
+	v, ok := policies["chatAvailability"]
+	if !ok {
+		return false, false
+	}
+	s, ok := v.(string)
+	if !ok {
+		// マージ後 policies の chatAvailability は upstream の string enum
+		// ("available" / "readonly" / "unavailable") なので、別型は壊れた
+		// data。defaults へ fallback。
+		return false, false
+	}
+	return s == "available", true
+}

--- a/internal/core/role/can_chat_lookup_test.go
+++ b/internal/core/role/can_chat_lookup_test.go
@@ -1,0 +1,66 @@
+package role_test
+
+import (
+	"testing"
+
+	"github.com/shiroha-a/mk/internal/core/role"
+	"github.com/stretchr/testify/assert"
+)
+
+type stubProvider struct {
+	policies map[string]any
+}
+
+func (s *stubProvider) GetUserPolicies(_ string) map[string]any {
+	return s.policies
+}
+
+func TestCanChatLookup_Available(t *testing.T) {
+	lookup := role.NewCanChatLookup(&stubProvider{policies: map[string]any{
+		"chatAvailability": "available",
+	}})
+	val, ok := lookup.LookupCanChat("u1")
+	assert.True(t, ok)
+	assert.True(t, val)
+}
+
+// "readonly" / "unavailable" は upstream の chatAvailability 列挙の残り 2 値、
+// どちらも non-"available" なので canChat=false。
+func TestCanChatLookup_NonAvailable(t *testing.T) {
+	for _, v := range []string{"readonly", "unavailable", ""} {
+		lookup := role.NewCanChatLookup(&stubProvider{policies: map[string]any{
+			"chatAvailability": v,
+		}})
+		val, ok := lookup.LookupCanChat("u1")
+		assert.True(t, ok, "value %q should resolve ok=true", v)
+		assert.False(t, val, "value %q should resolve canChat=false", v)
+	}
+}
+
+// chatAvailability key 自体が無い (= 壊れた policy data) のときは ok=false
+// で entity 側 default に倒す。
+func TestCanChatLookup_KeyMissing(t *testing.T) {
+	lookup := role.NewCanChatLookup(&stubProvider{policies: map[string]any{
+		"someOtherKey": true,
+	}})
+	_, ok := lookup.LookupCanChat("u1")
+	assert.False(t, ok)
+}
+
+// 値が string でない場合も壊れた data として ok=false (= default).
+func TestCanChatLookup_TypeMismatch(t *testing.T) {
+	lookup := role.NewCanChatLookup(&stubProvider{policies: map[string]any{
+		"chatAvailability": true, // bool, not string
+	}})
+	_, ok := lookup.LookupCanChat("u1")
+	assert.False(t, ok)
+}
+
+// DefaultPolicies() の chatAvailability が "available" であることを検証
+// (= 既定で全 user が canChat=true で動く)。
+func TestDefaultPolicies_ChatAvailabilityAvailable(t *testing.T) {
+	policies := role.DefaultPolicies()
+	v, ok := policies["chatAvailability"]
+	assert.True(t, ok, "default policies should contain chatAvailability")
+	assert.Equal(t, "available", v)
+}

--- a/internal/core/role/can_chat_lookup_test.go
+++ b/internal/core/role/can_chat_lookup_test.go
@@ -56,6 +56,18 @@ func TestCanChatLookup_TypeMismatch(t *testing.T) {
 	assert.False(t, ok)
 }
 
+// nil provider / nil adapter で panic せず ok=false を返すこと
+// (= entity 側 default で fallback できる defensive guard)。
+func TestCanChatLookup_NilProvider(t *testing.T) {
+	lookup := role.NewCanChatLookup(nil)
+	_, ok := lookup.LookupCanChat("u1")
+	assert.False(t, ok)
+
+	var nilAdapter *role.CanChatLookupAdapter
+	_, ok = nilAdapter.LookupCanChat("u1")
+	assert.False(t, ok)
+}
+
 // DefaultPolicies() の chatAvailability が "available" であることを検証
 // (= 既定で全 user が canChat=true で動く)。
 func TestDefaultPolicies_ChatAvailabilityAvailable(t *testing.T) {

--- a/internal/entity/can_chat.go
+++ b/internal/entity/can_chat.go
@@ -1,0 +1,55 @@
+package entity
+
+import "sync"
+
+// CanChatLookup resolves a user's effective canChat status by consulting
+// role policies. Mirrors upstream Misskey TS `UserEntityService.pack`:
+//
+//	canChat: this.roleService.getUserPolicies(user.id)
+//	  .then(r => r.chatAvailability === 'available')
+//
+// Returns ok=false when the lookup isn't wired (router not configured), or
+// when policy data isn't available for this user; the caller then falls
+// back to the default true (matches DefaultPolicies' "available").
+type CanChatLookup interface {
+	LookupCanChat(userID string) (canChat bool, ok bool)
+}
+
+// canChatLookup is process-wide so PackUserLite can resolve canChat without
+// changing its signature (called from 100+ sites). Router wires this once
+// at startup via SetCanChatLookup. nil disables enrichment, which keeps
+// existing tests that don't bother wiring the lookup green (the result is
+// the upstream default `chatAvailability = "available"` → canChat=true).
+var (
+	canChatLookupMu sync.RWMutex
+	canChatLookup   CanChatLookup
+)
+
+// SetCanChatLookup wires the role-policy lookup used by PackUserLite to
+// derive canChat. Pass nil to clear (used in tests).
+func SetCanChatLookup(l CanChatLookup) {
+	canChatLookupMu.Lock()
+	canChatLookup = l
+	canChatLookupMu.Unlock()
+}
+
+// resolveCanChat returns the canChat value for userID via the registered
+// lookup, falling back to true (= upstream default `chatAvailability ===
+// "available"`) when lookup is unwired or returns ok=false.
+//
+// upstream の lookup は async だが mk-go の role.Service は in-memory
+// cache (#761) を持つ pure sync function なので、entity 層から直接
+// 呼んで OK (DB 負荷は加わらない)。
+func resolveCanChat(userID string) bool {
+	canChatLookupMu.RLock()
+	l := canChatLookup
+	canChatLookupMu.RUnlock()
+	if l == nil {
+		return true
+	}
+	val, ok := l.LookupCanChat(userID)
+	if !ok {
+		return true
+	}
+	return val
+}

--- a/internal/entity/can_chat_test.go
+++ b/internal/entity/can_chat_test.go
@@ -1,0 +1,75 @@
+package entity
+
+import (
+	"testing"
+
+	"github.com/shiroha-a/mk/internal/model"
+	"github.com/stretchr/testify/assert"
+	"gorm.io/datatypes"
+)
+
+type stubCanChatLookup struct {
+	results map[string]bool
+}
+
+func (s *stubCanChatLookup) LookupCanChat(userID string) (bool, bool) {
+	v, ok := s.results[userID]
+	return v, ok
+}
+
+// TestPackUserLite_CanChatDefault: lookup が unwired のとき canChat=true
+// (= upstream DefaultPolicies の `chatAvailability: "available"`) で fallback
+// すること。既存 unit test が SetCanChatLookup を呼ばずに通るための path。
+func TestPackUserLite_CanChatDefault(t *testing.T) {
+	t.Cleanup(func() { SetCanChatLookup(nil) })
+	SetCanChatLookup(nil)
+
+	u := &model.User{
+		ID:                "u1",
+		Username:          "default",
+		ChatScope:         "none", // 旧実装ではこの値で canChat=false だった
+		AvatarDecorations: datatypes.JSON([]byte("[]")),
+	}
+	lite := PackUserLite(u)
+	assert.True(t, lite.CanChat, "lookup unwired → default true (upstream available)")
+}
+
+// TestPackUserLite_CanChatFromLookup: lookup が wired のとき lookup の結果が
+// canChat に反映されること。role policy で chat 制限された user は false。
+func TestPackUserLite_CanChatFromLookup(t *testing.T) {
+	t.Cleanup(func() { SetCanChatLookup(nil) })
+	SetCanChatLookup(&stubCanChatLookup{results: map[string]bool{
+		"u1": true,
+		"u2": false,
+	}})
+
+	u1 := &model.User{ID: "u1", Username: "ok", AvatarDecorations: datatypes.JSON([]byte("[]"))}
+	u2 := &model.User{ID: "u2", Username: "blocked", AvatarDecorations: datatypes.JSON([]byte("[]"))}
+
+	assert.True(t, PackUserLite(u1).CanChat)
+	assert.False(t, PackUserLite(u2).CanChat)
+}
+
+// TestPackUserLite_CanChatLookupNotFound: lookup is wired but the user is not
+// in the result map (= legacy data without role assignment). Should fall back
+// to default true.
+func TestPackUserLite_CanChatLookupNotFound(t *testing.T) {
+	t.Cleanup(func() { SetCanChatLookup(nil) })
+	SetCanChatLookup(&stubCanChatLookup{results: map[string]bool{}})
+
+	u := &model.User{ID: "unknown", Username: "unknown", AvatarDecorations: datatypes.JSON([]byte("[]"))}
+	assert.True(t, PackUserLite(u).CanChat, "lookup ok=false → default true")
+}
+
+// TestPackUserLite_CanChatIgnoresChatScope: chatScope の値に関係なく lookup
+// が支配的になること (= upstream の semantics、chatScope は受信側設定で
+// canChat とは別軸)。
+func TestPackUserLite_CanChatIgnoresChatScope(t *testing.T) {
+	t.Cleanup(func() { SetCanChatLookup(nil) })
+	SetCanChatLookup(&stubCanChatLookup{results: map[string]bool{"u1": false}})
+
+	for _, scope := range []string{"all", "followers", "mutuals", "none"} {
+		u := &model.User{ID: "u1", Username: "x", ChatScope: scope, AvatarDecorations: datatypes.JSON([]byte("[]"))}
+		assert.False(t, PackUserLite(u).CanChat, "scope=%s should not affect canChat", scope)
+	}
+}

--- a/internal/entity/can_chat_test.go
+++ b/internal/entity/can_chat_test.go
@@ -73,3 +73,19 @@ func TestPackUserLite_CanChatIgnoresChatScope(t *testing.T) {
 		assert.False(t, PackUserLite(u).CanChat, "scope=%s should not affect canChat", scope)
 	}
 }
+
+// BenchmarkPackUserLite_CanChatLookup measures the per-pack overhead of the
+// canChat lookup. 100 user bulk pack (= users/show userIds path 最大値) で
+// 数 µs / pack を期待する。lookup が hot path 化したときの regression を
+// 検出する baseline (#988)。
+func BenchmarkPackUserLite_CanChatLookup(b *testing.B) {
+	b.Cleanup(func() { SetCanChatLookup(nil) })
+	SetCanChatLookup(&stubCanChatLookup{results: map[string]bool{"u1": true}})
+	u := &model.User{ID: "u1", Username: "bench", AvatarDecorations: datatypes.JSON([]byte("[]"))}
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_ = PackUserLite(u)
+	}
+}

--- a/internal/entity/user.go
+++ b/internal/entity/user.go
@@ -31,9 +31,10 @@ type UserLite struct {
 	// CanChat は upstream Misskey TS の boolean field (#692)。FE の
 	// /chat/room.vue が `!user.canChat` で「DM 受け付け不可」warning を
 	// 出すので、出さないと local user 同士で DM できないと誤表示される。
-	// mk-go では chatScope!='none' を簡易判定として使う (upstream は
-	// roleService.policy.chatAvailability を参照するが、mk-go は role
-	// policy がまだ chat に対応していないため chatScope 由来で代替)。
+	// upstream 互換で role policy の `chatAvailability === "available"`
+	// 由来で計算する (#988)。PackUserLite が resolveCanChat() 経由で
+	// CanChatLookup を呼び、router で wired される。lookup が unwired
+	// の path (= 単体テスト等) は default `true` で fallback。
 	CanChat bool `json:"canChat"`
 	// Optional TS-compat fields (Phase 7-5a)。
 	// TS側は `requireSigninToViewContents: user.x === false ? undefined : true`
@@ -247,7 +248,12 @@ func PackUserLite(u *model.User) UserLite {
 		Emojis:            make(map[string]string),
 		OnlineStatus:      "unknown",
 		BadgeRoles:        []any{},
-		CanChat:           u.ChatScope != "none",
+		// upstream `chatAvailability === 'available'` 互換 (#988)。
+		// 旧実装は `u.ChatScope != "none"` で user 自身の受信設定を返して
+		// いたが、upstream は role policy の chatAvailability を見る
+		// (admin が role に設定する権限)。lookup が wire されていない
+		// path (= 既存 unit test 等) は default true で fallback する。
+		CanChat: resolveCanChat(u.ID),
 	}
 	// requireSigninToViewContents: true のときだけ出す (TS は false→undefined)
 	if u.RequireSigninToViewContents {

--- a/internal/server/router.go
+++ b/internal/server/router.go
@@ -1231,6 +1231,10 @@ func (s *Server) setupRoutes() {
 	// 共有 catalog resolver を entity package に登録する (#521)。catalog は
 	// admin 管理で低頻度更新のため 30s TTL の in-memory cache で十分。
 	entity.SetAvatarDecorationLookup(avatardecoration.NewResolver(avatarDecorationRepo))
+	// PackUserLite の canChat を role policy 由来 (= upstream
+	// `chatAvailability === "available"`) に揃える (#988)。roleService 自体
+	// が in-memory cache を持つ (#761) ので追加 DB 負荷は実質ゼロ。
+	entity.SetCanChatLookup(corerole.NewCanChatLookup(roleService))
 	iHandler.SetNoteFieldResolver(noteFieldResolver)
 	// announcementRepoは後続で構築されるため SetupAdditional() 相当の順序依存があるが、
 	// 現状 announcementRepo := ... の行がここより後にあるため下で wire する。


### PR DESCRIPTION
## Summary

PR #987 review で発見した \`canChat\` 二重 drift を解消。upstream Misskey TS は role policy の \`chatAvailability === "available"\` で canChat を計算するが、mk-go は二重に drift していた。

### 背景

upstream \`UserEntityService.ts:561\`:

\`\`\`ts
canChat: this.roleService.getUserPolicies(user.id)
  .then(r => r.chatAvailability === 'available'),
\`\`\`

mk-go の drift:

- **Drift 1**: PackUserLite が \`u.ChatScope != \"none\"\` で計算 (= user 自身の受信設定。upstream は role 権限を見る、別軸)
- **Drift 2**: Me handler が \`resp[\"canChat\"] = true\` で hardcode override (= self-view では role policy も chatScope も無視)

## 修正内容

### Phase 1: PackUserLite を role policy ベースに切替

新規 helper:

| ファイル | 役割 |
|---------|------|
| \`internal/entity/can_chat.go\` | \`CanChatLookup\` interface + \`SetCanChatLookup\` + \`resolveCanChat()\`。\`AvatarDecorationLookup\` と同 pattern (process-wide singleton、unwired path は default true) |
| \`internal/core/role/can_chat_lookup.go\` | \`CanChatLookupAdapter\` で role.Service の \`GetUserPolicies(\"chatAvailability\")\` を読み \"available\" → true / 他 → false |

\`PackUserLite\`:

\`\`\`go
// 旧:
CanChat: u.ChatScope != \"none\",
// 新:
CanChat: resolveCanChat(u.ID),
\`\`\`

\`router.go\`:

\`\`\`go
entity.SetCanChatLookup(corerole.NewCanChatLookup(roleService))
\`\`\`

### Phase 2: Me handler hardcode 撤去

\`/api/i\` Me handler の \`resp[\"canChat\"] = true\` を撤去。PackMeDetailed → UserLite 経由で role policy 由来の canChat が乗る。

### Layering

entity ← role の依存方向を維持 (= entity package は role を import しない、role package が entity.CanChatLookup を実装する pattern)。

## Backward compat

- \`role.DefaultPolicies()\` の \`chatAvailability\` は既に \`\"available\"\`
- role assignment 無し user は全員 canChat=true (= 旧 Drift 2 と同じ挙動を維持)
- role が \`chatAvailability: \"readonly\"\` / \`\"unavailable\"\` を設定した user のみ canChat=false (= upstream と一致)
- \`chatScope\` は受信側の filter 設定として保持 (canChat とは別軸)

## 主な変更点

| ファイル | 変更 |
|---------|------|
| \`internal/entity/can_chat.go\` (新) | CanChatLookup interface + setter |
| \`internal/entity/user.go\` | PackUserLite.CanChat 計算切替 + UserLite struct コメント update |
| \`internal/core/role/can_chat_lookup.go\` (新) | adapter |
| \`internal/api/i/handler.go\` | \`resp[\"canChat\"] = true\` 削除 |
| \`internal/server/router.go\` | \`entity.SetCanChatLookup(...)\` wire |
| \`CHANGELOG.md\` / \`docs/api-compatibility.md\` | drift fix entry 追加 |

## テスト

### 新規 (9 件)

| package | test |
|---------|------|
| \`internal/entity\` | \`TestPackUserLite_CanChatDefault\` (lookup unwired → true fallback) |
| | \`TestPackUserLite_CanChatFromLookup\` (lookup wired → 値反映) |
| | \`TestPackUserLite_CanChatLookupNotFound\` (lookup ok=false → fallback) |
| | \`TestPackUserLite_CanChatIgnoresChatScope\` (chatScope 全 4 値で lookup が支配的) |
| \`internal/core/role\` | \`TestCanChatLookup_Available\` (\"available\" → true) |
| | \`TestCanChatLookup_NonAvailable\` (\"readonly\" / \"unavailable\" / \"\" → false) |
| | \`TestCanChatLookup_KeyMissing\` (壊れた data → ok=false で fallback) |
| | \`TestCanChatLookup_TypeMismatch\` (bool 値 → ok=false で fallback) |
| | \`TestDefaultPolicies_ChatAvailabilityAvailable\` (default policy 確認) |
| \`internal/api/i\` | \`TestMe_CanChatFromRolePolicy\` (hardcode 撤去後 regression guard) |

### Coverage

- \`internal/entity\`: 96.5% → **96.6%**
- \`internal/api/i\`: 91.9% (維持)
- \`internal/core/role\`: 95.3%
- \`internal/api/users\`: 92.0% (維持)

全 package 90% threshold over。\`make fmt && make lint && go test -race -count=1\` 通過。

### 実行方法

\`\`\`bash
go test -race -count=1 -coverprofile=cov.out -covermode=atomic \\
  ./internal/entity/... ./internal/api/i/... ./internal/core/role/... ./internal/api/users/...
go tool cover -func=cov.out | tail -5
\`\`\`

## Closes

- Closes #988