### PR TITLE
fix(frontend): SPA splash 画面を upstream _splash.tsx 互換 markup に揃える

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,7 @@ Playwright spec を両 backend で走らせる中で観測した drop-in 互換 
 - #984: users/relation を stub から実装に切替。viewer ↔ target の follow / follow-request / block / mute / renote-mute 状態を 5 repo (`following` / `follow_request` / `blocking` / `muting` / `renote_muting`) から実 DB 状態として返す
 - #970: `/api/users/show` で viewer===target のとき MeDetailed 拡張 field (isExplorable / noCrawle / emailNotificationTypes 等 14 個) を merge して返すよう拡張。upstream `pack(user, me)` semantics と一致させ、`/api/users/show?username=me` 経由でも `/api/i` と同じ shape を保つ。新規 helper `entity.AsMeDetailed` で pre-built UserDetailed を promote する design
 - #988: `canChat` 二重 drift 解消。`PackUserLite` が \`u.ChatScope != "none"\` でなく **role policy の `chatAvailability === "available"`** から derive するように変更 (upstream `UserEntityService.ts:561` 互換)。新規 `entity.CanChatLookup` interface を `internal/entity/can_chat.go` に追加し、`role.CanChatLookupAdapter` で role.Service を bridge する design (= `entity.SetAvatarDecorationLookup` と同 pattern)。`/api/i` Me handler の `resp["canChat"] = true` hardcode も撤去し、self-view でも role policy が反映される
+- splash 画面 drift 解消: SPA ロード中の `<div id="splash">` markup を upstream `_splash.tsx` 互換に揃える (#993)。旧実装は mascotImageUrl (= ai.png) を中央に表示し "Loading..." text だけ出していたが、upstream は server iconUrl + 回転 spinner SVG (bg/fg 2 枚) を表示する。修正後: `<img id="splashIcon" src="...">` + `<div id="splashSpinner">` (2 SVG)。default icon は `/static-assets/splash.png` (Misskey ロゴ)、admin が meta.iconUrl を設定していればそれを使う
 
 #### settings / token
 - #883: i/regenerate-token return shape (204)

--- a/internal/server/frontend.go
+++ b/internal/server/frontend.go
@@ -36,7 +36,7 @@ func frontendHTML(cfg *config.Config, metaRepo repository.MetaRepository, proxyA
 		// splash 中央のアイコンは upstream `_splash.tsx` 互換で server
 		// iconUrl を使う (= 管理者が設定したインスタンス画像)。未設定なら
 		// `/static-assets/splash.png` (Misskey ロゴ) にフォールバック。
-		// mascotImageUrl (Ai キャラ) は別 field で splash には使わない (#)
+		// mascotImageUrl (Ai キャラ) は別 field で splash には使わない (#993)。
 		splashIconURL := "/static-assets/splash.png"
 		metaJSON := "{}"
 		if m, err := metaRepo.Fetch(); err == nil {

--- a/internal/server/frontend.go
+++ b/internal/server/frontend.go
@@ -33,9 +33,11 @@ func frontendHTML(cfg *config.Config, metaRepo repository.MetaRepository, proxyA
 		instanceDesc := ""
 		iconURL := "/static-assets/icons/192.png"
 		themeColor := "#86b300"
-		// mascotImageUrl は splash 中央のローディング画像に使う。meta 値が
-		// あれば優先、なければ /assets/ai.png にフォールバック (本家挙動)。
-		mascotURL := "/assets/ai.png"
+		// splash 中央のアイコンは upstream `_splash.tsx` 互換で server
+		// iconUrl を使う (= 管理者が設定したインスタンス画像)。未設定なら
+		// `/static-assets/splash.png` (Misskey ロゴ) にフォールバック。
+		// mascotImageUrl (Ai キャラ) は別 field で splash には使わない (#)
+		splashIconURL := "/static-assets/splash.png"
 		metaJSON := "{}"
 		if m, err := metaRepo.Fetch(); err == nil {
 			if m.Name != nil && *m.Name != "" {
@@ -46,12 +48,10 @@ func frontendHTML(cfg *config.Config, metaRepo repository.MetaRepository, proxyA
 			}
 			if m.IconURL != nil && *m.IconURL != "" {
 				iconURL = *m.IconURL
+				splashIconURL = *m.IconURL
 			}
 			if m.ThemeColor != nil && *m.ThemeColor != "" {
 				themeColor = *m.ThemeColor
-			}
-			if m.MascotImageURL != nil && *m.MascotImageURL != "" {
-				mascotURL = *m.MascotImageURL
 			}
 			metaJSON = buildMetaJSON(cfg, m, proxyAccountResolver)
 		}
@@ -97,15 +97,16 @@ func frontendHTML(cfg *config.Config, metaRepo repository.MetaRepository, proxyA
 </head><body>
 <noscript><p>Please turn on your JavaScript</p></noscript>
 <div id="splash">
-<div style="padding:64px;text-align:center">
-<img src="%s" alt="" style="max-width:160px;height:auto;display:block;margin:0 auto 16px"/>
-<p>Loading...</p>
+<img id="splashIcon" src="%s" />
+<div id="splashSpinner">
+<svg class="spinner bg" viewBox="0 0 152 152" xmlns="http://www.w3.org/2000/svg"><g transform="matrix(1,0,0,1,12,12)"><circle cx="64" cy="64" r="64" style="fill:none;stroke:currentColor;stroke-width:24px;"/></g></svg>
+<svg class="spinner fg" viewBox="0 0 152 152" xmlns="http://www.w3.org/2000/svg"><g transform="matrix(1,0,0,1,12,12)"><path d="M128,64C128,28.654 99.346,0 64,0C99.346,0 128,28.654 128,64Z" style="fill:none;stroke:currentColor;stroke-width:24px;"/></g></svg>
 </div>
 </div>
 </body></html>`, instanceName, instanceName, instanceDesc, iconURL, cfg.URL,
 			themeColor, cfg.URL, instanceName, iconURL, viteClientTag, cssLinkTags,
 			cfg.Version, clientEntryJS,
-			time.Now().UnixMilli(), metaJSON, mascotURL)
+			time.Now().UnixMilli(), metaJSON, splashIconURL)
 
 		return c.HTML(http.StatusOK, html)
 	}

--- a/internal/server/frontend_test.go
+++ b/internal/server/frontend_test.go
@@ -1,0 +1,94 @@
+package server
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/labstack/echo/v4"
+	"github.com/shiroha-a/mk/internal/config"
+	"github.com/shiroha-a/mk/internal/model"
+	"github.com/shiroha-a/mk/internal/testutil"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// frontendHTML が upstream `_splash.tsx` 互換の splash markup を返すこと。
+// upstream 互換要素 (#xxx):
+//   - id="splash" wrapper
+//   - id="splashIcon" な img 要素
+//   - id="splashSpinner" + 2 spinner SVG (bg / fg)
+//   - default img src は /static-assets/splash.png (meta.iconUrl 未設定時)
+//   - meta.iconUrl が設定されていればそちらを使う
+//   - ai.png mascot は splash には使わない
+func TestFrontendHTML_SplashStructure(t *testing.T) {
+	cfg := &config.Config{URL: "https://example.test", Version: "0.0.1-test"}
+
+	t.Run("default fallback to /static-assets/splash.png", func(t *testing.T) {
+		repo := testutil.NewMockMetaRepository()
+		handler := frontendHTML(cfg, repo, nil)
+
+		e := echo.New()
+		rec := httptest.NewRecorder()
+		c := e.NewContext(httptest.NewRequest(http.MethodGet, "/", nil), rec)
+		require.NoError(t, handler(c))
+
+		body := rec.Body.String()
+		assert.Contains(t, body, `<div id="splash">`)
+		assert.Contains(t, body, `<img id="splashIcon"`)
+		assert.Contains(t, body, `src="/static-assets/splash.png"`,
+			"default splash icon should be /static-assets/splash.png (Misskey logo)")
+		assert.Contains(t, body, `<div id="splashSpinner">`)
+		assert.Contains(t, body, `class="spinner bg"`)
+		assert.Contains(t, body, `class="spinner fg"`)
+		// ai.png は mascot 用、splash には出ない
+		assert.NotContains(t, body, `src="/assets/ai.png"`,
+			"splash should not use ai.png (mascot)")
+		// 旧 placeholder の "Loading..." text も無いこと
+		assert.NotContains(t, body, "<p>Loading...</p>")
+	})
+
+	t.Run("uses configured meta.iconUrl when set", func(t *testing.T) {
+		repo := testutil.NewMockMetaRepository()
+		customIcon := "https://example.test/files/server-icon.png"
+		repo.Meta = &model.Meta{ID: "x", IconURL: &customIcon}
+
+		handler := frontendHTML(cfg, repo, nil)
+		e := echo.New()
+		rec := httptest.NewRecorder()
+		c := e.NewContext(httptest.NewRequest(http.MethodGet, "/", nil), rec)
+		require.NoError(t, handler(c))
+
+		body := rec.Body.String()
+		// splash img src には server icon が反映される
+		assert.True(t, strings.Contains(body, `<img id="splashIcon" src="`+customIcon+`"`),
+			"splash icon should use configured meta.iconUrl")
+	})
+
+	t.Run("mascot field is not used for splash", func(t *testing.T) {
+		// 旧実装は mascotImageUrl を splash に使っていたので regression guard。
+		repo := testutil.NewMockMetaRepository()
+		mascot := "https://example.test/custom-mascot.png"
+		repo.Meta = &model.Meta{ID: "x", MascotImageURL: &mascot}
+
+		handler := frontendHTML(cfg, repo, nil)
+		e := echo.New()
+		rec := httptest.NewRecorder()
+		c := e.NewContext(httptest.NewRequest(http.MethodGet, "/", nil), rec)
+		require.NoError(t, handler(c))
+
+		body := rec.Body.String()
+		// splash img には反映されないこと (mascotImageUrl は /api/meta で
+		// frontend が別用途で使う field、splash のアイコンではない)
+		splashStart := strings.Index(body, `<img id="splashIcon"`)
+		splashEnd := strings.Index(body[splashStart:], `</div>`)
+		require.Greater(t, splashStart, 0)
+		require.Greater(t, splashEnd, 0)
+		splashSection := body[splashStart : splashStart+splashEnd]
+		assert.NotContains(t, splashSection, mascot,
+			"mascot URL should not appear in splash img")
+		// default splash.png が使われる
+		assert.Contains(t, splashSection, `src="/static-assets/splash.png"`)
+	})
+}

--- a/internal/server/frontend_test.go
+++ b/internal/server/frontend_test.go
@@ -80,11 +80,13 @@ func TestFrontendHTML_SplashStructure(t *testing.T) {
 
 		body := rec.Body.String()
 		// splash img には反映されないこと (mascotImageUrl は /api/meta で
-		// frontend が別用途で使う field、splash のアイコンではない)
+		// frontend が別用途で使う field、splash のアイコンではない)。
+		// strings.Index は見つからない場合 -1 を返すので、有効な offset は
+		// >= 0 で check する (relative offset なので 0 もあり得る)。
 		splashStart := strings.Index(body, `<img id="splashIcon"`)
+		require.GreaterOrEqual(t, splashStart, 0, "splashIcon img not found in body")
 		splashEnd := strings.Index(body[splashStart:], `</div>`)
-		require.Greater(t, splashStart, 0)
-		require.Greater(t, splashEnd, 0)
+		require.GreaterOrEqual(t, splashEnd, 0, "closing </div> not found after splashIcon")
 		splashSection := body[splashStart : splashStart+splashEnd]
 		assert.NotContains(t, splashSection, mascot,
 			"mascot URL should not appear in splash img")

--- a/tests/playwright/specs/smoke/frontend_load.spec.ts
+++ b/tests/playwright/specs/smoke/frontend_load.spec.ts
@@ -46,6 +46,25 @@ test.describe('smoke: frontend SPA loads', () => {
     expect(bodyHTML.length).toBeGreaterThan(50);
   });
 
+  // splash 画面の DOM 構造が upstream `_splash.tsx` 互換であること (#993)。
+  // page.goto だと Vue mount で splash が消えるので、raw HTML を fetch して
+  // initial response の markup を verify する。
+  test('initial HTML contains upstream-compatible splash markup', async ({ request, baseURL }) => {
+    const resp = await request.get(`${baseURL}/`);
+    expect(resp.status()).toBe(200);
+    const html = await resp.text();
+    // splash 構造の必須要素
+    expect(html).toContain('<div id="splash">');
+    expect(html).toContain('<img id="splashIcon"');
+    expect(html).toContain('<div id="splashSpinner">');
+    // spinner 2 SVG (bg = static circle, fg = rotating arc)
+    expect(html).toContain('class="spinner bg"');
+    expect(html).toContain('class="spinner fg"');
+    // 旧 mascot (ai.png) や placeholder text は出ないこと
+    expect(html).not.toContain('src="/assets/ai.png"');
+    expect(html).not.toContain('<p>Loading...</p>');
+  });
+
   test('frontend asset (manifest.json) is served', async ({ request, baseURL }) => {
     // Vite manifest が frontend ビルドから配信されているかを確認。manifest
     // が無いと SPA は起動できない。注: `/_frontend_vite_/manifest.json` は


### PR DESCRIPTION
## Summary

mk-go の SPA ロード画面が upstream Misskey TS と乖離していた drift を解消。実機で観測:
- ❌ mk-go: \`ai.png\` (Ai キャラ) + \"Loading...\" text
- ✅ upstream: サーバーアイコン (未設定なら Misskey ロゴ) + 回転 spinner

## 原因

\`internal/server/frontend.go\` の splash markup が upstream \`_splash.tsx\` から 2 点 drift:

| 項目 | mk-go (旧) | upstream / mk-go (新) |
|------|-----------|-----------------------|
| 中央画像 source | \`mascotImageUrl\` (default \`/assets/ai.png\`) | \`meta.iconUrl\` (default \`/static-assets/splash.png\`) |
| ロード表現 | \`<p>Loading...</p>\` plain text | \`<div id=\"splashSpinner\">\` + 2 SVG (bg/fg) で回転 |

CSS (\`/vite/loader/style.css\`) は upstream 由来で \`#splashIcon\` / \`#splashSpinner\` / \`.spinner.bg\` / \`.spinner.fg\` のスタイルが定義済みだったが、HTML 側に対応する id / class 要素が無かったため style が一切当たらず、custom inline style の plain markup が露呈していた。

## 修正

\`internal/server/frontend.go\` の splash HTML を upstream \`_splash.tsx\` の 1:1 mirror に変更:

\`\`\`html
<div id=\"splash\">
  <img id=\"splashIcon\" src=\"...\"/>
  <div id=\"splashSpinner\">
    <svg class=\"spinner bg\" ...>...</svg>
    <svg class=\"spinner fg\" ...>...</svg>
  </div>
</div>
\`\`\`

icon source も \`mascotURL\` → \`splashIconURL\` に rename + default を \`/assets/ai.png\` → \`/static-assets/splash.png\` (Misskey ロゴ) に変更。upstream の \`HtmlTemplateService.ts:174\` (\`icon: this.meta.iconUrl\`) と同 semantics。

mascotImageUrl は元々 splash には使わない field (= /api/meta で frontend が別用途で使う)。

## 主な変更点

| ファイル | 変更 |
|---------|------|
| \`internal/server/frontend.go\` | splash markup + icon source 変更 |
| \`internal/server/frontend_test.go\` (新) | splash 構造の regression guard 3 sub-test |
| \`CHANGELOG.md\` | drift fix entry 追加 |

## テスト

新規 \`TestFrontendHTML_SplashStructure\` (3 sub-test):

1. **default fallback to /static-assets/splash.png**: meta 未設定で splash.png + spinner SVG が出る
2. **uses configured meta.iconUrl when set**: 管理者設定の iconUrl が反映される
3. **mascot field is not used for splash**: 旧実装 regression を guard (mascotImageUrl が splash に漏れない)

\`make fmt && make lint && go test -race ./internal/server/...\` 全 pass。

## ローカル検証手順

\`\`\`bash
make playwright-up      # mk-go 起動
curl -s http://localhost:3000/ | grep -A5 '<div id=\"splash\">'
# → <img id=\"splashIcon\" ... + <div id=\"splashSpinner\"> が出る
\`\`\`

ブラウザで \`http://localhost:3000\` を開くと:
- 旧: ai.png + \"Loading...\" text
- 新: splash.png (or 管理者設定の server icon) + 回転する loading リング

## Risk / 影響

- Backward compat: API 影響なし、HTML response shape のみ
- mascotImageUrl は \`/api/meta\` で別途返却されるので frontend の別用途には影響なし
- 既存 spec で splash の DOM structure を assert しているものは無い (search 確認済み)