### PR TITLE
chore: bump MkGoVersion 0.0.1-experimental -> 0.9.0

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,7 @@ GOFLAGS=-trimpath
 
 # バージョン情報。MisskeyVersion は /api/meta の version フィールド
 # (Misskey TS 互換クライアント向け) で使われる。drop-in 互換のため固定値。
-MKGO_VERSION ?= 0.0.1-experimental
+MKGO_VERSION ?= 0.9.0
 MISSKEY_VERSION ?= 2026.3.2
 LDFLAGS=-s -w \
 	-X github.com/shiroha-a/mk/internal/config.MkGoVersion=$(MKGO_VERSION) \

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -15,7 +15,7 @@ import (
 // MkGoVersion is the mk-go version. Override at build time via:
 //
 //	go build -ldflags "-X github.com/shiroha-a/mk/internal/config.MkGoVersion=1.0.0"
-var MkGoVersion = "0.0.1-experimental"
+var MkGoVersion = "0.9.0"
 
 // MisskeyVersion is the compatible Misskey version. Override at build time via:
 //


### PR DESCRIPTION
## Summary

mk-go の自前 version 文字列 `MkGoVersion` を pre-1.0 milestone として `0.9.0` に bump する。

drop-in 互換のため `/api/meta` の `version` field は引き続き `MisskeyVersion` (= 2026.3.2) を返す。今回変わるのは:

- `/nodeinfo/2.1` の `software.version` (連合先 / federation 集計サイトから mk-go と認識される版数)
- mk-go bin の起動ログ
- HTTP `User-Agent`: `mk-go/0.9.0 (...)`

## なぜ 0.9.0 か

`0.0.1-experimental` は project 立ち上げ時の暫定値で、現状の完成度 (Phase 1-16 完了 / Playwright 242 endpoint cover / federation perf TS の 2.6-2.8x / drop-in e2e nightly green / UDS production 実運用中) を反映していない。

正式リリース予定はまだないため `1.0.0` は時期尚早。`1.0.0-rc.x` だと breaking change を入れにくくなるため、pre-1.0 milestone として「実質完成、API shape は drift fix で動く余地を残す」を意図する `0.9.0` を選択。

## 主な変更点

- `Makefile:21` `MKGO_VERSION ?= 0.0.1-experimental` → `0.9.0`
- `internal/config/config.go:18` `var MkGoVersion = "0.0.1-experimental"` → `"0.9.0"`

## テスト

- `make fmt` / `make lint` green
- `go test ./internal/config/... ./internal/api/nodeinfo/...` green (version 文字列を assert している test がないため touch なし、既存 test 全 pass で確認)

## Closes

Closes #994

🤖 Generated with [Claude Code](https://claude.com/claude-code)