### PR TITLE
docs(update): #947 tracker の triage doc 追加 (2026.3.2 -> 2026.5.1)

### DIFF
--- a/docs/update/20260512-947-triage.md
+++ b/docs/update/20260512-947-triage.md
@@ -1,0 +1,463 @@
+# #947 (2026.3.2 → 2026.5.1) upstream 追従 triage
+
+upstream 高優先度 15 件について、`git show <sha>` で patch を精読し、mk-go 側の該当箇所を grep + read で特定した結果。各 item に Gap 判定 + 推定難易度を付与し、sub-issue 化の前段とする。
+
+注: 本 doc 作成時点で `third_party/misskey` submodule は 2026.3.2 + 1 frontend nit (`79ccc36ec0`) で固定。upstream master からは 120 commits behind。各 sha は `git fetch upstream master` 経由で local の `.git` には存在するため diff 自体は読める。
+
+## サマリ
+
+| # | upstream PR | 領域 | Gap 判定 | 難易度 |
+|---|---|---|---|---|
+| 1 | #17340 | AP actor 正規化 | 部分対応 | S |
+| 2 | #17275 | AP alsoKnownAs 配列/文字列両対応 | 未対応 | S |
+| 3 | #17294 | AP 存在しない Actor の Delete 無視 | 未対応 | S |
+| 4 | #17308 | AP relay 由来 Announce で renote 作らず | 未対応 | M |
+| 5 | #17336 | AP blocked instance inbox job 蓄積防止 | アーキ差で実質対応済 | S |
+| 6 | #17167 | role 由来 validation error の retry 防止 | 未対応 | S |
+| 7 | #17310 | ULID Crockford W/X/Y/Z parse | 影響なし (oklog/ulid 使用) | N/A |
+| 8 | #17335 | Note 通知に visibility filter 適用 | 未対応 | M |
+| 9 | #17334 | RoleService.getAdministratorIds 重複排除 | 該当 method 未実装 | S (調査込み) |
+| 10 | #17341 | meilisearch 未設定時の noteSearchableScope | 部分対応 | S |
+| 11 | #17356 | relay Announce の lock 取得 | 既対応 (DB-level dedup) | N/A |
+| 12 | #17363 | followers-only note の follower 通知 | 未対応 (#8 と同 scope) | S |
+| 13 | #17358 | ULID notificationTimeline XADD overflow | 影響なし (mk-go は時刻 base) | N/A |
+| 14 | #17121 | canCreateChannel role policy | 未対応 | M |
+| 15 | #17354 | /i/2fa/register-key 削除 | 存在するが drop-in 互換で保留 | L (時期待ち) |
+
+**消化見込み**: 影響なし 3 件 (7, 11, 13) + 既対応扱い 1 件 (5) = **4 件は close 候補**、新規実装が必要なのは **11 件**。難易度 S が多く、ほとんどは 1 PR / 100 行未満で消化可。中規模 (M) が 3 件 (4, 8, 14)、保留扱い (L) が 1 件 (15)。
+
+---
+
+## 1. #17340 ActivityPub: activity.actor を string / 埋め込み object 双方で受ける
+
+**sha**: `23715c64` (2026.3.2 → 2026.5.0)
+
+### Upstream 変更
+
+`ApInboxService.ts` の `add` / `delete` / `remove` / `undo` / `update` handler と `InboxProcessorService.ts` の 1 箇所で、`activity.actor` を `getApId(activity.actor)` でラップして「actor が string ID か embedded object か」の差を吸収する。
+
+### mk-go 該当箇所
+
+- `internal/core/federation/processor.go:185` `genericActivity` struct: `Actor string` で string 限定
+- `internal/core/federation/processor.go:779` `readObjectString()` という同種の helper が object → ID 抽出用に既にある (Object field 向けに使われている)
+- Actor field には `readObjectString` が適用されていない
+
+### Gap
+
+**部分対応**。Object field には正規化 helper があるが Actor field には未適用。embedded actor object を含む activity を受けると JSON parse は通るが、`Actor` が空文字列になって以降の resolver が失敗する経路がある。
+
+### 推定実装
+
+`internal/core/federation/processor.go` で:
+
+1. `genericActivity.Actor` を `json.RawMessage` に変更
+2. `Actor` を読むタイミングで `readObjectString` を流用して string ID を抽出する `extractActorID(raw)` helper を追加
+3. caller (`handleCreate`, `handleAnnounce`, `handleDelete`, `handleUndo`, `handleUpdate`, `handleFollow`, `handleAccept`, `handleReject`) をリファクタ
+
+**難易度**: **S** (helper 1 個 + caller の参照書き換え)
+
+---
+
+## 2. #17275 ActivityPub: alsoKnownAs を array / string 双方で受ける
+
+**sha**: `8169c57b` (2026.3.2 → 2026.5.0)
+
+### Upstream 変更
+
+`ApPersonService.ts` の `createPerson` / `updatePerson` で `alsoKnownAs` が array でも単一 string でも受け入れるよう `toArray()` helper でラップ。`UserEntityService.ts` も同様に DB 読み出し側で正規化。
+
+### mk-go 該当箇所
+
+- `internal/activitypub/types.go:99` `Person` struct: `AlsoKnownAs []string` で array 限定
+- `internal/core/federation/processor.go:1109` 周辺で movedTo / alsoKnownAs 更新コメントあり
+
+### Gap
+
+**未対応**。string 単独で送られてきた alsoKnownAs を受け取ると JSON unmarshal が失敗する (`[]string` への直接バインドは object/string 失敗)。
+
+### 推定実装
+
+1. `Person.AlsoKnownAs` を `json.RawMessage` に変更
+2. `func (p *Person) UnmarshalAlsoKnownAs() []string` を追加して array / single string 両対応
+3. movedTo 更新側で同 helper を呼ぶ
+
+**難易度**: **S**
+
+---
+
+## 3. #17294 ActivityPub: 存在しない Actor の Delete を ignore
+
+**sha**: `29cecd75` (2026.3.2 → 2026.5.0)
+
+### Upstream 変更
+
+`InboxProcessorService.ts` の handler 入口に `isActor(activity.object) && isDelete(activity)` の条件で「**Delete 対象 actor がローカル DB に存在しない場合、その先の処理に進まず早期 return**」する block を追加。新規 user record の作成を防ぐ。
+
+### mk-go 該当箇所
+
+- `internal/core/federation/processor.go:826-852` `handleDelete`
+  - 現状 actor URI を resolver で解決し、失敗時 error を返してから retry に乗る経路。
+  - line 837 で `author.URI == targetURI` 判定があるが、これは「actor 自身の delete」検出後の no-op であり、**未知 actor の delete を捨てる**処理ではない
+
+### Gap
+
+**未対応**。upstream は handler 入り口で先制チェック、mk-go は resolver 失敗時の error path 任せ。retry に乗る経路があるため、定期的に「delete された remote user の delete activity が retry で繰り返し試行される」現象が起きうる。
+
+### 推定実装
+
+`handleDelete` の冒頭に:
+
+```go
+if isDeleteOfActor(act) {
+    if _, err := p.userRepo.FindByURI(ctx, targetURI); errors.Is(err, repository.ErrNotFound) {
+        return nil // 存在しない actor の delete は ignore
+    }
+}
+```
+
+**難易度**: **S**
+
+---
+
+## 4. #17308 ActivityPub: リレー由来 Announce で renote を作らず元 note を直接 publish
+
+**sha**: `277a1ef3` (2026.3.2 → 2026.5.0)
+
+### Upstream 変更
+
+- `RelayService.ts` に `isRelayActor(actor)` メソッド追加 (= AP actor URI が登録済み relay の inbox host と一致するか判定)
+- `ApInboxService.ts::announceNote` で `if (isRelayActor(actor))` 分岐:
+  - renote create を **bypass**
+  - 元 note (= announce 対象) を取得して `publishNotesStream(noteId, 'noteUpdated')` を直接呼ぶ
+  - federation allowlist チェックは target note URI で実施
+
+### mk-go 該当箇所
+
+- `internal/core/relay/relay.go` 存在するが `IsRelayActor()` 相当の method なし
+- `internal/core/federation/processor.go:774-824` `handleAnnounce`: 常に renote を create + `notificationHook.OnNoteCreated(..., target)` を呼ぶ
+
+### Gap
+
+**未対応**。relay 由来でも renote が作成され、TL に「relay actor が renote した」表示が出る (本家挙動と乖離)。
+
+### 推定実装
+
+1. `internal/core/relay/relay.go` に `IsRelayActor(uri string) bool` 追加 (登録済み relay 一覧から host 比較、cache 推奨)
+2. `processor.go::handleAnnounce` で relay 判定し、renote 作成 path をスキップ → 元 note の stream publish のみ
+3. allowlist check 順序の調整 (target note URI ベース)
+
+**難易度**: **M** (relay 検出 + 配信経路 2 分岐 + 既存 spec 影響確認)
+
+---
+
+## 5. #17336 ActivityPub: ブロック中インスタンスの inbox job 蓄積防止
+
+**sha**: `0f5da633` (2026.3.2 → 2026.5.0)
+
+### Upstream 変更
+
+`InboxProcessorService.ts` の error handler を `switch (e.id)` に整理し、`'09d79f9e-64f1-4316-9cfa-e75c4d091574'` (Instance is blocked) ケースを追加。`return 'skip: blocked instance'` で **non-retry 終了**。
+
+### mk-go 該当箇所
+
+- `internal/queue/processors/inbox.go:135` `isBlocked(actor)` で block 検出時 nil return (= 既に non-retry skip)
+- ただし mk-go は host block check を **signature verify 直後** で行う (`#565` で worker 側に移動済み)。upstream のように「note create の途中で blocked-instance error を捕まえる」経路ではない
+
+### Gap
+
+**アーキ差で実質対応済**。mk-go では blocked host は note 処理の最深部まで届かず、上流で弾かれて queue に乗らない。upstream の修正は `NoteCreateService` 経由で初めて block 判定する場合の救済策で、mk-go の verify-in-worker 設計だと不要。
+
+ただし保険として `internal/queue/processors/inbox.go` の error path で `ErrInstanceBlocked` のような sentinel を非 retry 化する対応はあっても良い (#7344 同様 case)。
+
+### 推定実装
+
+- (任意) processor error path で具体的な instance-block error を retry 対象から除外する case 追加
+
+**難易度**: **S** (任意対応)。**close 候補**として処理して良い。
+
+---
+
+## 6. #17167 role validation error の retry 防止
+
+**sha**: `12e590a6` (2026.3.2 → 2026.5.0)
+
+### Upstream 変更
+
+`InboxProcessorService.ts` の error handler に `'9f466dab-c856-48cd-9e65-ff90ff750580'` (note contains too many mentions) ケース追加 → non-retry。Role policy の `mentionLimit` 超過は永続的に解決しない error なので retry させない。
+
+### mk-go 該当箇所
+
+- mk-go の `NoteCreateService` で role policy の `mentionLimit` チェックがあるか要確認 (`grep mentionLimit internal/core/note/`)
+- 該当 error を processor が捕まえて retry 対象から除外する分岐がない
+
+### Gap
+
+**未対応**。mention limit check 自体が mk-go にあるか不明 (調査要)。あれば processor で skip 化、なければ policy check の追加とセット。
+
+### 推定実装
+
+1. NoteCreateService に `MaxMentions` policy check を入れる (なければ)
+2. `internal/queue/processors/inbox.go` の error path に sentinel error を加えて non-retry 化
+
+**難易度**: **S** (mentionLimit 実装の有無次第)
+
+---
+
+## 7. #17310 ID 生成: ULID Crockford Base32 パース修正
+
+**sha**: `5dc50834` (2026.3.2 → 2026.5.0)
+
+### Upstream 変更
+
+`packages/backend/src/misc/id/ulid.ts::parseUlidFull` が `parseBigInt32` (= 一般 base32) を使っていたため、ULID で W/X/Y/Z (value 24-31) を含む ID で誤って parse する bug。Crockford 専用 `parseBigIntCrockford` に置換。
+
+### mk-go 該当箇所
+
+- `internal/misc/id/id.go:205` `ulidGen` は `oklog/ulid/v2` を使用 (標準ライブラリ実装に委譲)
+- `oklog/ulid/v2` は仕様準拠の Crockford parser を持つので W/X/Y/Z も正しく扱う
+
+### Gap
+
+**影響なし**。**close 候補**。
+
+---
+
+## 8. #17335 Note 通知: 公開範囲 (visibility) を考慮
+
+**sha**: `b45f18cd` (2026.3.2 → 2026.5.0)
+
+### Upstream 変更
+
+`NoteCreateService.ts::NotificationManager.notify` を書き換え、`note.visibility` でフィルタ後に通知を実際送る:
+
+- `public` / `home`: 全 target に通知
+- `specified`: `visibleUserIds` に含まれる target だけ
+- `followers`: フィルタなし (但しコメントアウト、`#17363` で復活)
+- `default`: 空 (= 誰にも通知しない)
+
+### mk-go 該当箇所
+
+- `internal/core/note/note_create_service.go` で visibility は保持されるが、mention/reply notification fan-out の filter が見当たらない
+- 通知発火は `internal/core/notification/notification_service.go` 経由だがフィルタ層がない可能性
+
+### Gap
+
+**未対応**。`specified` 可視性 note で `visibleUserIds` 外の user に mention があった場合、現状は通知が飛ぶ可能性 (= 情報漏洩リスク)。
+
+### 推定実装
+
+mk-go 側に NotificationManager 相当を作るか、`OnNoteCreated` hook 内で visibility filter を追加:
+
+```go
+filtered := filterMentionsByVisibility(note, mentionTargets)
+```
+
+**難易度**: **M** (notification fan-out path の reshape)
+
+---
+
+## 9. #17334 Role: getAdministratorIds の重複排除
+
+**sha**: `3a3057a1` (2026.3.2 → 2026.5.0)
+
+### Upstream 変更
+
+`RoleService.ts::getAdministratorIds` の return を `assigns.map(a => a.userId)` から `[...new Set(...)].sort(...)` に変更。admin role を複数持つ user が複数 ID で返る bug を修正。
+
+### mk-go 該当箇所
+
+- `internal/core/role/role_service.go` に `getAdministratorIds` 相当の method は **見つからなかった** (grep 結果)
+- 通知系で admin に notify する経路があるか要確認
+
+### Gap
+
+**該当 method が未実装かどうかの調査が要**。実装があれば dedup 追加 (S)、未実装なら abuse-report 等の通知経路でいまどう admin を特定しているかを確認。
+
+### 推定実装
+
+- 既存 method があれば `unique + sort` 化
+- なければ実装が必要な箇所を特定 (例: abuse-report、role 通知、admin chart)
+
+**難易度**: **S** (実装後)
+
+---
+
+## 10. #17341 Search: Meilisearch 未使用時の noteSearchableScope 修正
+
+**sha**: `1dc5c60b` (2026.3.2 → 2026.5.0)
+
+### Upstream 変更
+
+`MetaEntityService.ts` で `noteSearchableScope` 計算式の bug 修正。`meilisearch` config block があるが `provider !== 'meilisearch'` のケースで、誤って `local` を返していた。正しくは `global`。
+
+### mk-go 該当箇所
+
+- `internal/api/meta/handler.go:255` `NoteSearchableScope` helper
+- 現状: `m == nil || m.Scope == "" || m.Scope == "local"` で local、他は global
+- `fulltextSearch.provider` を見ていない可能性
+
+### Gap
+
+**部分対応**。`fulltextSearch.provider` setting (= `sqlLike` / `meilisearch` / `none` のいずれか) を見て、`meilisearch` 以外なら scope に関わらず local を返すべきか、upstream に倣うか要再確認。
+
+### 推定実装
+
+`NoteSearchableScope` 関数を provider-aware に改修。`sqlLike` の場合は default local が妥当。
+
+**難易度**: **S** (1 関数の条件式調整)
+
+---
+
+## 11. #17356 ActivityPub: relay actor からの Announce でも lock を取って race を防ぐ
+
+**sha**: `35711fc8` (2026.5.0 → 2026.5.1)
+
+### Upstream 変更
+
+`ApInboxService.ts::announceNote` の lock 取得 key を `getApId(fromRelay ? target : activity)` で統一。これにより relay 由来でも `activity.id` で lock 取得 → 同 activity の重複処理 race を防ぐ。
+
+### mk-go 該当箇所
+
+- `internal/core/federation/processor.go:789` `noteRepo.FindByURI(act.ID)` で **DB-level dedup** が既に動いている
+- mk-go には Redis-level distributed lock 機構がないが、single-instance では DB transaction 境界で race を防げる
+
+### Gap
+
+**既対応 (アーキ差)**。upstream は multi-instance 前提で Redis lock、mk-go は single-instance で DB unique 制約に依存。**close 候補**。
+
+multi-instance 構成 (= mk-go 複数 pod の load balance) を視野に入れるなら Redis lock が必要だが、現状の運用前提なら不要。
+
+---
+
+## 12. #17363 Notification: followers-only note が follower に通知されない bug
+
+**sha**: `f5a3d899` (2026.5.0 → 2026.5.1)
+
+### Upstream 変更
+
+`NoteCreateService.ts` の `case 'followers'` のコメントアウトを外して `visibleUserIds = null;` を設定。`visibleUserIds = null` は `for (const x of this.queue) { if (!visibleUserIds.has(x.target)) continue; ... }` の filter check で **null を「フィルタなし」として扱う**ことが前提。
+
+### mk-go 該当箇所
+
+`#8` (visibility filter) と同 scope。mk-go ではそもそも filter 自体が無いので、`#8` 実装時に followers ケースも忘れず含める。
+
+### Gap
+
+**未対応** (`#8` 実装の一部として吸収)。
+
+**難易度**: **S** (`#8` の一部)
+
+---
+
+## 13. #17358 Notification: ULID 環境で notificationTimeline XADD が overflow
+
+**sha**: `6229ac36` (2026.5.0 → 2026.5.1)
+
+### Upstream 変更
+
+`NotificationService.ts::toXListId` で `additional.toString()` をそのまま使っていたが、ULID の additional は 80-bit のため Redis Stream の sequence (uint64) を overflow → XADD 失敗 → 通知 ~10s 遅延。修正は `BigInt.asUintN(64, additional)` で下位 64bit truncate。
+
+### mk-go 該当箇所
+
+- `internal/core/notification/notification_service.go:626-630` `toXAddID(_ string, t time.Time) string` は **ID parse を経由せず、引数 `time.Time` から sequence を生成**
+
+### Gap
+
+**影響なし**。mk-go は最初から時刻ベースで sequence を作っているので overflow しない。**close 候補**。
+
+---
+
+## 14. #17121 API: canCreateChannel role policy 追加
+
+**sha**: `37412f0e` (2026.5.0 → 2026.5.1)
+
+### Upstream 変更
+
+- `RoleService.ts` の `RolePolicies` type に `canCreateChannel: boolean` 追加、`DEFAULT_POLICIES.canCreateChannel = true`
+- aggregate (`calc`) で `vs.some(v => v === true)` 集約
+- `/channels/create` endpoint に `requiredRolePolicy: 'canCreateChannel'` 追加
+- json-schema / misskey-js / locale autogen 同期
+
+### mk-go 該当箇所
+
+- `internal/core/role/role_service.go:401-403` policy map: `canSearchUsers`, `canUseTranslator`, `canHideAds` まで揃っているが **`canCreateChannel` 不在**
+- `internal/api/channels/handler.go` の create endpoint で role policy gate なし
+
+### Gap
+
+**未対応**。drop-in 互換のために本家 frontend が canCreateChannel を期待する → 値が欠けると frontend 側で false 扱いされ「チャンネル作成不可」状態になる可能性。
+
+### 推定実装
+
+1. `internal/core/role/role_service.go` の policy map に `canCreateChannel: true` 追加 (default)
+2. 集約ロジック (`canHideAds` と同じ pattern) を適用
+3. `/channels/create` で `requireRolePolicy("canCreateChannel")` check (mk-go の middleware pattern を踏襲)
+4. `/api/meta` で `policies` を返す経路を通って frontend に届くこと確認
+
+**難易度**: **M** (policy 追加 + endpoint gate + meta 連携)
+
+---
+
+## 15. #17354 API 削除: /api/i/2fa/register-key
+
+**sha**: `723d8add` (2026.5.0 → 2026.5.1)
+
+### Upstream 変更
+
+passkey library refresh (`@simplewebauthn/types` → `@simplewebauthn/server`) に伴い、旧 attestation flow endpoint `register-key.ts` (131 lines) を削除。新 flow は `i/2fa/register` + `i/2fa/key-done` で完結。
+
+### mk-go 該当箇所
+
+- `internal/server/router.go:1290` `/i/2fa/register` ◯ (新 flow)
+- `internal/server/router.go:1293` `/i/2fa/register-key` ◯ (旧 endpoint、存在する)
+
+両方とも実装済み。
+
+### Gap
+
+**drop-in 互換で保留**。`third_party/misskey` submodule が 2026.3.2 (= 旧 frontend) で固定されている間は frontend が `register-key` を呼ぶので削除不可。
+
+### 推定実装
+
+submodule を 2026.5.1 に bump するタイミングで:
+
+1. `register-key` endpoint を `410 Gone` 返却に変更
+2. router から行を削除
+3. 関連 test (`handler_webauthn_test.go:162-187`) を撤去
+
+**難易度**: **L** (submodule bump とセット、時期依存)
+
+---
+
+## 推奨次ステップ
+
+### Wave 1 (close 候補 4 件、まとめて確認 PR 1 本)
+
+- #7 (ULID parse — 影響なし)
+- #11 (relay lock — DB dedup で対応済)
+- #13 (XADD overflow — 時刻 base で影響なし)
+- #5 (blocked inbox — アーキ差で実質対応済)
+
+これらは「mk-go では既に対応 / 影響なし」を *コメント追加 + test で明示*するだけの軽い PR、または 4 件分まとめて #947 にコメントで報告して check 入れて close。
+
+### Wave 2 (S 難易度 5 件、1 PR / 1-2 PR で bundle)
+
+- #1 (AP actor 正規化)
+- #2 (alsoKnownAs 配列/文字列)
+- #3 (Delete actor 不在 ignore)
+- #6 (role validation retry)
+- #10 (noteSearchableScope)
+
+いずれも 30-100 行の修正 + test 数本。AP 系 (#1-#3) は 1 PR、残り 2 件は別 PR にするのが review 効率的。
+
+### Wave 3 (M 難易度 3 件、PR 1 本ずつ)
+
+- #4 (relay Announce 由来 publish 分岐)
+- #8 + #12 (visibility filter + followers-only)
+- #14 (canCreateChannel policy)
+
+設計確認 + 既存 spec 影響範囲込み。各 PR 200-500 行規模。
+
+### Wave 4 (submodule bump 込み 1 件)
+
+- #15 (register-key 削除) — 別途 submodule bump PR とセット


### PR DESCRIPTION
## Summary

#947 upstream 追従 tracker の下準備として、高優先度 15 件の triage doc を `docs/update/20260512-947-triage.md` に追加する。各 item について:

- upstream の sha / PR 番号 / 1 行概要
- `git show <sha>` で読んだ patch 本体の核 (変更関数 / ロジック)
- mk-go 側の該当箇所 (`file_path:line_number` 形式)
- Gap 判定 (既対応 / 部分対応 / 未対応 / 影響なし)
- 推定難易度 (S / M / L)
- 推定実装方針 (1-2 段落)

を 1 件ずつ整理。

注: `third_party/misskey` submodule は 2026.3.2 + 1 frontend nit (`79ccc36ec0`) のまま据え置きで作業。upstream の各 sha は `git fetch upstream master` で local の `.git` に存在しているため diff 自体は読めるが、working tree は 2026.3.2 ベース。submodule bump は #15 (register-key 削除) を含む別 PR にする想定。

## 結論サマリ

- **close 候補 4 件**: アーキ差や標準ライブラリ依存で「mk-go では既に対応 / 影響なし」
  - #5 (blocked inbox, verify-in-worker で深部到達しない)
  - #7 (ULID parse, oklog/ulid 使用)
  - #11 (relay lock, DB-level dedup で代替)
  - #13 (XADD overflow, mk-go は時刻 base で sequence 生成)

- **S 難易度 5 件**: #1 #2 #3 #6 #10
- **M 難易度 3 件**: #4 #8+#12 #14
- **L 難易度 1 件** (submodule bump とセット): #15

doc 末尾に Wave 1-4 の推奨実行順を記載。

## 主な変更点

- `docs/update/20260512-947-triage.md` 新規追加 (463 行)

## テスト

- 該当なし (docs のみ)
- `docs/update/yyyymmdd*` 命名規則 (#947 / #948 / #949 経由で定着) に従い `20260512-947-triage.md` を採用

## Refs

Refs #947 (tracker は close せず、本 doc を基に sub-issue 化 / wave PR を順次回す)

🤖 Generated with [Claude Code](https://claude.com/claude-code)