### PR TITLE
fix(frontend): vite manifest の import chain を recursive walk して全 CSS を <link> する

### DIFF
--- a/internal/frontendutil/frontendutil.go
+++ b/internal/frontendutil/frontendutil.go
@@ -78,32 +78,87 @@ func RepoAssetsDir() string {
 	return filepath.Join(frontendBase, "assets")
 }
 
-// ClientEntryInfo holds the Vite entry point script and its CSS dependencies.
+// ClientEntryInfo holds the Vite entry point script, CSS dependencies, and
+// module preloads collected from the manifest by walking the entry's import chain.
 type ClientEntryInfo struct {
-	Script string
-	CSS    []string
+	Script         string
+	CSS            []string
+	ModulePreloads []string
 }
 
-// DetectClientEntry reads the Vite manifest to find the entry script and CSS.
-// ビルド済みアセットが存在しない場合は空値を返す (dev mode)。
+// DetectClientEntry reads the Vite manifest to find the entry script and all
+// CSS files (= entry の直接 CSS + entry が import する全 chunk の CSS を再帰的に
+// 集めたもの)。upstream TS の HtmlTemplateService#collectViteAssetFiles と同じ動作。
+// Vite は SFC `<style scoped>` を chunk 単位の CSS file に切り出すため、entry が
+// 同期 import する chunk の CSS も最初に link しないと、それらの component (例:
+// MkCustomEmoji / MkMention) のスタイルが当たらない。ビルド済みアセットが存在し
+// ない場合は空値を返す (dev mode)。
 func DetectClientEntry() ClientEntryInfo {
 	manifestPath := filepath.Join(FrontendDir(), "manifest.json")
 	data, err := os.ReadFile(manifestPath)
 	if err != nil {
 		return ClientEntryInfo{}
 	}
-	var manifest map[string]struct {
+	type manifestChunk struct {
 		File    string   `json:"file"`
 		IsEntry bool     `json:"isEntry"`
 		CSS     []string `json:"css"`
+		Imports []string `json:"imports"`
 	}
+	var manifest map[string]manifestChunk
 	if err := json.Unmarshal(data, &manifest); err != nil {
 		return ClientEntryInfo{}
 	}
-	if entry, ok := manifest["src/_boot_.ts"]; ok {
-		return ClientEntryInfo{Script: entry.File, CSS: entry.CSS}
+	entry, ok := manifest["src/_boot_.ts"]
+	if !ok {
+		return ClientEntryInfo{}
 	}
-	return ClientEntryInfo{}
+
+	seenChunks := map[string]struct{}{}
+	seenCSS := map[string]struct{}{}
+	var cssFiles []string
+	var modulePreloads []string
+
+	addCSS := func(files []string) {
+		for _, f := range files {
+			if _, dup := seenCSS[f]; dup {
+				continue
+			}
+			seenCSS[f] = struct{}{}
+			cssFiles = append(cssFiles, f)
+		}
+	}
+	addCSS(entry.CSS)
+
+	var walk func(imports []string, recursive bool)
+	walk = func(imports []string, recursive bool) {
+		for _, id := range imports {
+			if _, dup := seenChunks[id]; dup {
+				continue
+			}
+			seenChunks[id] = struct{}{}
+			chunk, ok := manifest[id]
+			if !ok {
+				continue
+			}
+			addCSS(chunk.CSS)
+			if len(chunk.Imports) > 0 {
+				walk(chunk.Imports, true)
+			}
+			// modulePreloads は entry が同期 import する 1 hop の chunk だけ
+			// (= recursive=false の呼び出し時のみ)。upstream と同じ挙動。
+			if !recursive {
+				modulePreloads = append(modulePreloads, chunk.File)
+			}
+		}
+	}
+	walk(entry.Imports, false)
+
+	return ClientEntryInfo{
+		Script:         entry.File,
+		CSS:            cssFiles,
+		ModulePreloads: modulePreloads,
+	}
 }
 
 // AssetsHandler returns a handler that tries to serve files from primary dir

--- a/internal/frontendutil/frontendutil_test.go
+++ b/internal/frontendutil/frontendutil_test.go
@@ -103,6 +103,94 @@ func TestDetectClientEntry_ValidManifest(t *testing.T) {
 	info := DetectClientEntry()
 	assert.Equal(t, "assets/boot.abc.js", info.Script)
 	assert.Equal(t, []string{"assets/style.def.css"}, info.CSS)
+	assert.Nil(t, info.ModulePreloads)
+}
+
+// Verify that DetectClientEntry walks the entry's import chain recursively and
+// aggregates CSS from all imported chunks (upstream HtmlTemplateService#collectViteAssetFiles parity).
+// Without this, lazy-loaded SFC `<style scoped>` chunks (e.g. MkCustomEmoji /
+// MkMention) would be missing at first paint and the components fall back to
+// the browser's native <img> sizing (= 通常より明らかに大きい症状).
+func TestDetectClientEntry_WalksImports(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("MISSKEY_FRONTEND_DIR", dir)
+	manifest := `{
+		"src/_boot_.ts": {
+			"file": "scripts/boot.js",
+			"isEntry": true,
+			"css": ["assets/entry.css"],
+			"imports": ["_chunk-a.js", "_chunk-b.js"]
+		},
+		"_chunk-a.js": {
+			"file": "scripts/chunk-a.js",
+			"css": ["assets/chunk-a.css"],
+			"imports": ["_chunk-c.js"]
+		},
+		"_chunk-b.js": {
+			"file": "scripts/chunk-b.js",
+			"css": ["assets/chunk-b.css"]
+		},
+		"_chunk-c.js": {
+			"file": "scripts/chunk-c.js",
+			"css": ["assets/chunk-c.css"]
+		}
+	}`
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "manifest.json"), []byte(manifest), 0644))
+
+	info := DetectClientEntry()
+	assert.Equal(t, "scripts/boot.js", info.Script)
+	// Entry CSS + chunk-a / chunk-b (= entry の直接 import) + chunk-c (= recursive)
+	// が全て収集される。順序は entry → entry.imports[0] → entry.imports[0] の sub-import
+	// → entry.imports[1] (深さ優先)。
+	assert.Equal(t, []string{
+		"assets/entry.css",
+		"assets/chunk-a.css",
+		"assets/chunk-c.css",
+		"assets/chunk-b.css",
+	}, info.CSS)
+	// modulePreloads は entry の直接 import のみ (= 1 hop)。
+	assert.Equal(t, []string{
+		"scripts/chunk-a.js",
+		"scripts/chunk-b.js",
+	}, info.ModulePreloads)
+}
+
+// Cycles or duplicate imports must not cause infinite recursion or duplicate
+// CSS / preload entries. seenChunks は recursive walk 全体で共有されるため、
+// chunk-b は chunk-a の sub-import として先に visit され、top-level の visit
+// で skip される (= modulePreloads には入らない)。upstream の
+// collectViteAssetFiles と同じ挙動。
+func TestDetectClientEntry_DedupAndCycle(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("MISSKEY_FRONTEND_DIR", dir)
+	manifest := `{
+		"src/_boot_.ts": {
+			"file": "scripts/boot.js",
+			"isEntry": true,
+			"css": ["assets/entry.css"],
+			"imports": ["_chunk-a.js", "_chunk-b.js"]
+		},
+		"_chunk-a.js": {
+			"file": "scripts/chunk-a.js",
+			"css": ["assets/shared.css"],
+			"imports": ["_chunk-b.js"]
+		},
+		"_chunk-b.js": {
+			"file": "scripts/chunk-b.js",
+			"css": ["assets/shared.css"],
+			"imports": ["_chunk-a.js"]
+		}
+	}`
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "manifest.json"), []byte(manifest), 0644))
+
+	info := DetectClientEntry()
+	assert.Equal(t, []string{
+		"assets/entry.css",
+		"assets/shared.css",
+	}, info.CSS)
+	assert.Equal(t, []string{
+		"scripts/chunk-a.js",
+	}, info.ModulePreloads)
 }
 
 func TestDetectClientEntry_InvalidJSON(t *testing.T) {


### PR DESCRIPTION
## Summary

`internal/frontendutil/frontendutil.go::DetectClientEntry` を upstream TS の
`HtmlTemplateService#collectViteAssetFiles` と同じ動作に揃え、Vite manifest の
entry chunk が同期 import する全 chunk から CSS / module preload を再帰的に
集めるように修正する。

## 背景

submodule bump で frontend を 2026.5.1 build に更新したところ、UDS 環境で
- ノートに含まれるカスタム絵文字が通常より明らかに大きい
- メンションに挿入されるユーザーアイコンが同様に大きい

という visual regression が発生した。

調査の結果、2026.5.1 build では vite が SFC \`<style scoped>\` を chunk 単位の
CSS file に切り出しており、entry chunk の直接 CSS (24KB) には
\`MkCustomEmoji\` / \`MkMention\` 等の component scoped style が含まれず、
これらは entry が同期 import する 47 個の dependency chunk に分散していた。

\`\`\`
$ python3 -c \"import json; d=json.load(open('manifest.json'));
print('entry direct CSS:', d['src/_boot_.ts']['css']);
print('all CSS files in manifest:', len({c for v in d.values() for c in v.get('css', [])}))\"
entry direct CSS: ['assets/mcFLq06db-DPzPs2Ci.css']
all CSS files in manifest: 264
\`\`\`

mk-go の \`DetectClientEntry\` は manifest の \`src/_boot_.ts\` エントリの \`css\`
field しか読んでおらず、import chain 上の chunk CSS を全く集めていなかった
ため、これらの component が unstyled で render され、\`<img>\` が PNG native
size で表示されてサイズ崩れに繋がっていた。

2026.3.2 build では entry の direct CSS list に必要な component CSS が全て
含まれていたため bug は顕在化していなかった。2026.5.1 で chunking 戦略が
変わって露呈した形。

## 主な変更点

### \`internal/frontendutil/frontendutil.go\`

- \`ClientEntryInfo\` に \`ModulePreloads []string\` field を追加 (= 1 hop 目の
  chunk file path。将来的な \`<link rel=\"modulepreload\">\` 化に備える。今 PR
  では HTML 出力には反映しない)
- manifest entry の type を inline 定義から関数内 local \`manifestChunk\` 型に
  抽出し、\`imports\` field を読むように拡張
- entry の \`imports\` を depth-first に recursive walk し、訪問済み chunk を
  \`seenChunks\` map で dedup しながら CSS を \`seenCSS\` map dedup 付きで
  flat list に集めるように変更
- \`modulePreloads\` は upstream と同じく \"non-recursive call の chunk のみ\"
  追加 (= 直接 import の 1 hop 目)

### \`internal/frontendutil/frontendutil_test.go\`

- 既存 \`TestDetectClientEntry_ValidManifest\` に \`ModulePreloads\` の nil 検証
  を追加
- \`TestDetectClientEntry_WalksImports\` を新規追加 (= import chain の CSS
  全体集約と modulePreloads が 1 hop 限定であることを検証)
- \`TestDetectClientEntry_DedupAndCycle\` を新規追加 (= cycle / 重複 import で
  も infinite recursion や重複 entry が出ないことを検証)

\`frontend.go\` 側の HTML 生成は変更不要。既存の \`for _, css := range
clientEntry.CSS\` ループがそのまま全 CSS を \`<link rel=\"stylesheet\">\` として
emit するため、\`DetectClientEntry\` の戻り値が正しくなれば自動的に修正される。

## テスト

- \`make fmt && make lint\` 通過
- \`go test ./internal/frontendutil/... -count=1\` 全件 PASS (新規 2 件を含む)
- UDS 実機で \`docker compose -f compose.uds.yaml up --build -d\` 後、
  カスタム絵文字 / メンション icon の size 異常が解消されていることを目視
  確認

## その他

- 2026.3.2 build では起きていなかった (chunk 構成が異なる)
- 今後 upstream の chunking 戦略が変わっても、entry import chain を辿って
  CSS を集める limpid な方式で追随できる