### PR TITLE
chore(playwright): TS baseline image を 2026.3.2 → 2026.5.1 に bump

### DIFF
--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -58,7 +58,7 @@ jobs:
             # 不確実)。foreground で完了を待ち、続く compose up 内の同
             # image pull は docker daemon の cache hit で 0s で済む方が
             # 確実。version は docker-compose.playwright.ts.yml と sync。
-            prepull: docker pull misskey/misskey:2026.3.2
+            prepull: docker pull misskey/misskey:2026.5.1
             # #978 で NODE_ENV=test を入れた副作用で compile-config が
             # /misskey/.config/test.yml を look up し、production image の
             # .config dir が空のため migrate 失敗で container 起動できない

--- a/docker-compose.playwright.ts.yml
+++ b/docker-compose.playwright.ts.yml
@@ -4,7 +4,7 @@
 # を引き継ぐ。overlay 単独で起動することはないので明示は不要。
 #
 # spec は upstream Misskey TS の API 互換挙動を期待値として書いている。
-# 本 overlay は backend を `misskey/misskey:2026.3.2` に置き換えて、上流の
+# 本 overlay は backend を `misskey/misskey:2026.5.1` に置き換えて、上流の
 # 真の挙動で spec が pass することを baseline として確認する。
 # (mk-go 単体 stack は docker-compose.playwright.yml、両者で同 spec が
 # pass = drop-in 互換が保証される、という設計。)
@@ -23,7 +23,7 @@
 
 services:
   mkgo:
-    image: misskey/misskey:2026.3.2
+    image: misskey/misskey:2026.5.1
     build: !reset null
     environment:
       NODE_TLS_REJECT_UNAUTHORIZED: "0"


### PR DESCRIPTION
## Summary

Playwright nightly の TS baseline matrix が使う Misskey TS image を
\`2026.3.2\` → \`2026.5.1\` に bump し、mk-go matrix と version を一致させる。

## 背景

- PR #998 で mk-go 側の \`MisskeyVersion\` 定数を 2026.5.1 に揃え、frontend
  submodule も \`2026.5.1-mk.0\` に bump 済
- Playwright nightly は \`backend = [mk-go, ts]\` の matrix で両 backend の
  drop-in 互換を nightly 検証する設計だが、TS 側だけ \`2026.3.2\` image に
  取り残されていた
- 同 version で比較しないと \"drift fix が必要なのか upstream の version 差
  なのか\" 判別がつかなくなるため、合わせて bump

## 主な変更点

- \`docker-compose.playwright.ts.yml\`
  - L7 のコメント内 image tag を \`2026.5.1\` に更新
  - L26 の \`image: misskey/misskey:2026.3.2\` を \`2026.5.1\` に変更
- \`.github/workflows/playwright.yml\`
  - L61 の \`prepull: docker pull misskey/misskey:2026.3.2\` を \`2026.5.1\` に変更

dropin / federation 系の \`misskey/misskey:2025.2.1\` pin は意図的な過去 release
固定 (= 古い snapshot との互換性 baseline) のため対象外。

## テスト

- ローカル build / lint なし (= compose / workflow YAML のみ。
  \`docker-compose config\` で構文チェックは GitHub Actions 上で自動的に走る)
- nightly playwright workflow (17:00 UTC) で実際の green 確認は次回 cron で

## その他

- mk-go matrix には影響なし (= base \`docker-compose.playwright.yml\` のみ参照)
- TS matrix は #990 issue により \`continue-on-error: true\` の non-blocking
  扱いのまま (= image bump は前提条件の整備)