### PR TITLE
perf+refactor(role,server): rolesCache TTL layer + /api/i/import-* / export-* 二重 route 解消

### DIFF
--- a/internal/core/role/role_service.go
+++ b/internal/core/role/role_service.go
@@ -97,7 +97,11 @@ type Service struct {
 	// userRoleCache (per-user) は同じ TTL 内で先に hit するので、本 cache が
 	// fire するのは cache miss / TTL 失効 / conditional role 評価が要る user
 	// に限られる。Create / UpdateFields / Delete で flush する。
-	rolesListMu        sync.Mutex
+	//
+	// sync.RWMutex で hot path (cache hit) を RLock に倒し、cache miss /
+	// invalidate の writer のみ Lock を取る。複数 goroutine が同時に cache
+	// hit する場合のロック競合を排除する (#1035 review)。
+	rolesListMu        sync.RWMutex
 	rolesListCache     []*model.Role
 	rolesListExpiresAt time.Time
 }
@@ -157,7 +161,26 @@ func (s *Service) InvalidateAllRoleCaches() {
 // Create / UpdateFields / Delete で cache invalidate する設計だが、外部経路
 // (admin/roles の直接 repo 更新等) は TTL でしか cover できない。
 // roleCacheTTL = 5 min で staleness は bounded (= userRoleCache と同 trade-off)。
+//
+// 返却される slice は **shared snapshot** で、caller は read-only に扱う
+// (mutate 不可、append / sort 等で書き換えない)。複数 goroutine が同 cache
+// snapshot を同時に iterate するので、要素 (*model.Role) の field mutate
+// もしない。mutation が要るなら slices.Clone(...) で copy を取ってから操作する。
 func (s *Service) listRolesCached() ([]*model.Role, error) {
+	// Fast path: RLock で cache hit を確認、cache hit なら lock を即座に
+	// 解放して return。複数 goroutine の hot path 並列実行を許す。
+	s.rolesListMu.RLock()
+	if s.rolesListCache != nil && time.Now().Before(s.rolesListExpiresAt) {
+		roles := s.rolesListCache
+		s.rolesListMu.RUnlock()
+		return roles, nil
+	}
+	s.rolesListMu.RUnlock()
+
+	// Slow path: write lock で cache を更新。再 check で double-check pattern
+	// (= 他 goroutine が RUnlock 〜 Lock 間に cache を埋めた場合、重複 fetch
+	// を避ける)。これにより同時 cache miss する N goroutine でも roleRepo.List()
+	// は通常 1 回しか発火しない (single-flight 相当)。
 	s.rolesListMu.Lock()
 	defer s.rolesListMu.Unlock()
 	if s.rolesListCache != nil && time.Now().Before(s.rolesListExpiresAt) {

--- a/internal/core/role/role_service.go
+++ b/internal/core/role/role_service.go
@@ -89,6 +89,17 @@ type Service struct {
 	// admin/roles/update が roleRepo を直接叩く経路は TTL でしかカバー
 	// できないが、roleCacheTTL = 5 min で staleness は bounded (#300 3-5)。
 	userRoleCache sync.Map // userID -> *roleCacheEntry
+
+	// rolesListCache は roleRepo.List() 結果の TTL キャッシュ (#1030)。
+	// evaluateConditionalRoles から呼ばれて全 role を fetch する経路で、cache
+	// miss 時に毎リクエスト全 role を DB から取ってしまう問題への対策。
+	// 上流 Misskey TS の rolesCache (= RoleService の global) と等価。
+	// userRoleCache (per-user) は同じ TTL 内で先に hit するので、本 cache が
+	// fire するのは cache miss / TTL 失効 / conditional role 評価が要る user
+	// に限られる。Create / UpdateFields / Delete で flush する。
+	rolesListMu        sync.Mutex
+	rolesListCache     []*model.Role
+	rolesListExpiresAt time.Time
 }
 
 // NewService constructs a RoleService.
@@ -128,12 +139,47 @@ func (s *Service) InvalidateUserRoleCache(userID string) {
 
 // InvalidateAllRoleCaches drops every cached entry. Used when a role is
 // deleted (we don't know which users were assigned without an extra DB hit,
-// so the simplest safe action is to flush the whole cache).
+// so the simplest safe action is to flush the whole cache). 全 user role
+// cache に加え roleRepo.List() cache (#1030) も flush する。
 func (s *Service) InvalidateAllRoleCaches() {
 	s.userRoleCache.Range(func(k, _ any) bool {
 		s.userRoleCache.Delete(k)
 		return true
 	})
+	s.invalidateRolesListCache()
+}
+
+// listRolesCached returns the role list backed by a single-slot TTL cache
+// (#1030). roleRepo.List() 直接 access の代替で、evaluateConditionalRoles の
+// hot path で全 role fetch を amortize する。TTL 失効 / cache miss 時のみ
+// roleRepo.List() を叩く。
+//
+// Create / UpdateFields / Delete で cache invalidate する設計だが、外部経路
+// (admin/roles の直接 repo 更新等) は TTL でしか cover できない。
+// roleCacheTTL = 5 min で staleness は bounded (= userRoleCache と同 trade-off)。
+func (s *Service) listRolesCached() ([]*model.Role, error) {
+	s.rolesListMu.Lock()
+	defer s.rolesListMu.Unlock()
+	if s.rolesListCache != nil && time.Now().Before(s.rolesListExpiresAt) {
+		return s.rolesListCache, nil
+	}
+	roles, err := s.roleRepo.List()
+	if err != nil {
+		return nil, err
+	}
+	s.rolesListCache = roles
+	s.rolesListExpiresAt = time.Now().Add(roleCacheTTL)
+	return roles, nil
+}
+
+// invalidateRolesListCache clears the rolesListCache so the next call hits
+// roleRepo.List() again. Called from Create / UpdateFields / Delete and
+// from InvalidateAllRoleCaches.
+func (s *Service) invalidateRolesListCache() {
+	s.rolesListMu.Lock()
+	defer s.rolesListMu.Unlock()
+	s.rolesListCache = nil
+	s.rolesListExpiresAt = time.Time{}
 }
 
 // GetUserRoles returns all active roles applied to the user. The returned
@@ -195,7 +241,7 @@ func (s *Service) evaluateConditionalRoles(userID string, assigned []*model.Role
 	if s.userRepo == nil {
 		return nil
 	}
-	allRoles, err := s.roleRepo.List()
+	allRoles, err := s.listRolesCached()
 	if err != nil {
 		return nil
 	}
@@ -705,6 +751,10 @@ func (s *Service) Create(name, description string, opts CreateOptions) (*model.R
 	if err := s.roleRepo.Create(role); err != nil {
 		return nil, err
 	}
+	// 新規 role を追加したので role list cache を invalidate (#1030)。
+	// conditional role が増える可能性があり、stale cache だと evaluation で
+	// 見逃すため。
+	s.invalidateRolesListCache()
 	return role, nil
 }
 
@@ -760,6 +810,11 @@ func (s *Service) UpdateFields(id string, fields map[string]any) (*model.Role, e
 	if err := s.roleRepo.UpdateFields(id, fields); err != nil {
 		return nil, err
 	}
+	// CondFormula / Target / Policies が変わると evaluateConditionalRoles の
+	// 結果が変わるので role list cache を invalidate (#1030)。具体的な field
+	// を区別せず一律 flush するのは admin 経路で頻度が低いから (= 5min stale
+	// な userRoleCache と同 trade-off)。
+	s.invalidateRolesListCache()
 	return s.roleRepo.FindByID(id)
 }
 

--- a/internal/core/role/role_service_test.go
+++ b/internal/core/role/role_service_test.go
@@ -1,6 +1,7 @@
 package role_test
 
 import (
+	"sync"
 	"testing"
 	"time"
 
@@ -1010,6 +1011,40 @@ func TestUpdateFields_InvalidatesRoleListCache(t *testing.T) {
 
 	_, _ = svc.GetUserRoles("u2") // 別 user で確認
 	assert.Equal(t, 2, roleRepo.listCalls)
+}
+
+// 並行 cache miss でも roleRepo.List() は single-flight 相当で 1 回しか
+// 発火しないことを担保する (#1035 review: RWMutex 化に伴う double-check
+// pattern の regression guard、-race で並行性も検証する)。
+func TestListRolesCached_ConcurrentMissSingleFlight(t *testing.T) {
+	svc, roleRepo, _ := newServiceWithCountingRoleRepo(t)
+	roleRepo.Roles["r-bot"] = &model.Role{
+		ID:          "r-bot",
+		Target:      model.RoleTargetConditional,
+		CondFormula: datatypes.JSON([]byte(`{"type":"isBot"}`)),
+	}
+	userRepo := testutil.NewMockUserRepository()
+	// 複数 user を作って evaluateConditionalRoles を並行に起動できるようにする
+	for i := 0; i < 20; i++ {
+		uid := "u" + string(rune('a'+i))
+		require.NoError(t, userRepo.Create(&model.User{ID: uid, Username: uid, IsBot: true}))
+	}
+	svc.SetUserRepo(userRepo)
+
+	var wg sync.WaitGroup
+	for i := 0; i < 20; i++ {
+		uid := "u" + string(rune('a'+i))
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			_, _ = svc.GetUserRoles(uid)
+		}()
+	}
+	wg.Wait()
+	// 全 20 goroutine が cache miss から開始しても、double-check pattern で
+	// roleRepo.List() は 1 回しか呼ばれない (= single-flight 相当)。
+	assert.Equal(t, 1, roleRepo.listCalls,
+		"concurrent cache miss should de-dup to single roleRepo.List() call")
 }
 
 // Delete (= InvalidateAllRoleCaches 経由) で role list cache も flush される。

--- a/internal/core/role/role_service_test.go
+++ b/internal/core/role/role_service_test.go
@@ -910,6 +910,131 @@ func TestGetUserRoles_EmptyUserIDDoesNotCache(t *testing.T) {
 		"empty userID must not hit the repo at all")
 }
 
+// --- #1030: roleRepo.List() の TTL cache ---
+
+type countingRoleRepo struct {
+	*testutil.MockRoleRepository
+	listCalls int
+}
+
+func (c *countingRoleRepo) List() ([]*model.Role, error) {
+	c.listCalls++
+	return c.MockRoleRepository.List()
+}
+
+func newServiceWithCountingRoleRepo(t *testing.T) (*role.Service, *countingRoleRepo, *testutil.MockRoleAssignmentRepository) {
+	t.Helper()
+	mockRoleRepo := testutil.NewMockRoleRepository()
+	roleRepo := &countingRoleRepo{MockRoleRepository: mockRoleRepo}
+	assignRepo := testutil.NewMockRoleAssignmentRepository(mockRoleRepo)
+	metaRepo := testutil.NewMockMetaRepository()
+	idGen, _ := id.NewGenerator("aidx")
+	svc := role.NewService(roleRepo, assignRepo, metaRepo, idGen)
+	return svc, roleRepo, assignRepo
+}
+
+// evaluateConditionalRoles 経由で複数 user が連続して GetUserRoles を呼んでも、
+// roleRepo.List() は cache hit で 1 回しか発火しないことを保証する (#1030)。
+// userRoleCache は user 単位なので別 user の cache miss でも fire するが、
+// rolesListCache は global なので「1 回呼んだら 5 min 共有」になる。
+func TestListRolesCached_HitsRepoOnceAcrossUsers(t *testing.T) {
+	svc, roleRepo, _ := newServiceWithCountingRoleRepo(t)
+	// conditional role を 1 件用意して evaluateConditionalRoles 経路を起動
+	roleRepo.Roles["r-bot"] = &model.Role{
+		ID:          "r-bot",
+		Target:      model.RoleTargetConditional,
+		CondFormula: datatypes.JSON([]byte(`{"type":"isBot"}`)),
+	}
+	userRepo := testutil.NewMockUserRepository()
+	require.NoError(t, userRepo.Create(&model.User{ID: "u1", Username: "u1", IsBot: true}))
+	require.NoError(t, userRepo.Create(&model.User{ID: "u2", Username: "u2", IsBot: false}))
+	svc.SetUserRepo(userRepo)
+
+	// 別 user の連続呼び出しで user-level cache は別 entry を持つが、roleRepo
+	// 側は global TTL cache に乗るので呼び出し回数は 1 回のままになる。
+	_, _ = svc.GetUserRoles("u1")
+	_, _ = svc.GetUserRoles("u2")
+	_, _ = svc.GetUserRoles("u1")
+	assert.Equal(t, 1, roleRepo.listCalls,
+		"rolesListCache は global なので user 跨ぎでも 1 回しか repo を叩かない")
+}
+
+// Create で role list cache が invalidate されることを担保。
+func TestCreate_InvalidatesRoleListCache(t *testing.T) {
+	svc, roleRepo, _ := newServiceWithCountingRoleRepo(t)
+	roleRepo.Roles["r-bot"] = &model.Role{
+		ID:          "r-bot",
+		Target:      model.RoleTargetConditional,
+		CondFormula: datatypes.JSON([]byte(`{"type":"isBot"}`)),
+	}
+	userRepo := testutil.NewMockUserRepository()
+	require.NoError(t, userRepo.Create(&model.User{ID: "u1", Username: "u1", IsBot: true}))
+	svc.SetUserRepo(userRepo)
+
+	// warm cache
+	_, _ = svc.GetUserRoles("u1")
+	assert.Equal(t, 1, roleRepo.listCalls)
+
+	// 新規 role を作ると role list cache が flush される
+	_, err := svc.Create("NewRole", "desc", role.CreateOptions{})
+	require.NoError(t, err)
+
+	// 同 user の userRoleCache はまだ live なので GetUserRoles 自体は repo を
+	// 叩かないが、cache を bust するため別 user で確認する。
+	require.NoError(t, userRepo.Create(&model.User{ID: "u2", Username: "u2", IsBot: true}))
+	_, _ = svc.GetUserRoles("u2")
+	assert.Equal(t, 2, roleRepo.listCalls,
+		"Create で role list cache が invalidate されて、次回 evaluation で repo を再 fetch")
+}
+
+// UpdateFields で role list cache が invalidate されることを担保。
+func TestUpdateFields_InvalidatesRoleListCache(t *testing.T) {
+	svc, roleRepo, _ := newServiceWithCountingRoleRepo(t)
+	roleRepo.Roles["r-bot"] = &model.Role{
+		ID:          "r-bot",
+		Target:      model.RoleTargetConditional,
+		CondFormula: datatypes.JSON([]byte(`{"type":"isBot"}`)),
+	}
+	roleRepo.Roles["r2"] = &model.Role{ID: "r2", Name: "Other"}
+	userRepo := testutil.NewMockUserRepository()
+	require.NoError(t, userRepo.Create(&model.User{ID: "u1", Username: "u1", IsBot: true}))
+	require.NoError(t, userRepo.Create(&model.User{ID: "u2", Username: "u2", IsBot: true}))
+	svc.SetUserRepo(userRepo)
+
+	_, _ = svc.GetUserRoles("u1")
+	assert.Equal(t, 1, roleRepo.listCalls)
+
+	// 別 role の condFormula を変更しても全 role list cache は flush される
+	_, err := svc.UpdateFields("r2", map[string]any{"name": "Updated"})
+	require.NoError(t, err)
+
+	_, _ = svc.GetUserRoles("u2") // 別 user で確認
+	assert.Equal(t, 2, roleRepo.listCalls)
+}
+
+// Delete (= InvalidateAllRoleCaches 経由) で role list cache も flush される。
+func TestDelete_InvalidatesRoleListCache(t *testing.T) {
+	svc, roleRepo, _ := newServiceWithCountingRoleRepo(t)
+	roleRepo.Roles["r-bot"] = &model.Role{
+		ID:          "r-bot",
+		Target:      model.RoleTargetConditional,
+		CondFormula: datatypes.JSON([]byte(`{"type":"isBot"}`)),
+	}
+	roleRepo.Roles["r2"] = &model.Role{ID: "r2", Name: "Trial"}
+	userRepo := testutil.NewMockUserRepository()
+	require.NoError(t, userRepo.Create(&model.User{ID: "u1", Username: "u1", IsBot: true}))
+	require.NoError(t, userRepo.Create(&model.User{ID: "u2", Username: "u2", IsBot: true}))
+	svc.SetUserRepo(userRepo)
+
+	_, _ = svc.GetUserRoles("u1")
+	assert.Equal(t, 1, roleRepo.listCalls)
+
+	require.NoError(t, svc.Delete("r2"))
+
+	_, _ = svc.GetUserRoles("u2")
+	assert.Equal(t, 2, roleRepo.listCalls)
+}
+
 // 失敗した Assign / Unassign は invalidate しない (DB 状態が変わらないため)。
 func TestAssign_FailedDoesNotInvalidate(t *testing.T) {
 	svc, roleRepo, assignRepo := newServiceWithCountingAssign(t)

--- a/internal/server/router.go
+++ b/internal/server/router.go
@@ -1325,44 +1325,13 @@ func (s *Server) setupRoutes() {
 	api.POST("/i/registry/keys", iHandler.RegistryKeys, middleware.RequireAuth())
 	api.POST("/i/registry/scopes-with-domain", iHandler.RegistryScopesWithDomain, middleware.RequireAuth())
 
-	// i/export-* — データエクスポート (asynqキューにエンキュー)
-	for _, exportType := range []string{
-		"notes", "following", "blocking", "mute", "favorites", "user-lists", "antennas", "clips",
-	} {
-		et := exportType
-		api.POST("/i/export-"+et, func(c echo.Context) error {
-			user := middleware.GetUser(c)
-			if s.queueClient != nil {
-				_ = s.queueClient.EnqueueExport(queue.ExportPayload{UserID: user.ID, Type: et})
-			}
-			return c.NoContent(http.StatusNoContent)
-		}, middleware.RequireAuth())
-	}
-	// i/import-* — データインポート (asynqキューにエンキュー)。本 for-loop は
-	// 上方の explicit api.POST("/i/import-*", iHandler.Import*) と同じ path を
-	// 後勝ちで上書きするため、policy gate もここに必要 (#1020)。
-	// importType (kebab-case path 断片) と PolicyKey の対応は手書きで持つ。
-	importPolicyByType := map[string]string{
-		"following":  corerole.PolicyCanImportFollowing,
-		"blocking":   corerole.PolicyCanImportBlocking,
-		"muting":     corerole.PolicyCanImportMuting,
-		"user-lists": corerole.PolicyCanImportUserLists,
-		"antennas":   corerole.PolicyCanImportAntennas,
-	}
-	for _, importType := range []string{
-		"following", "blocking", "muting", "user-lists", "antennas",
-	} {
-		it := importType
-		api.POST("/i/import-"+it, func(c echo.Context) error {
-			user := middleware.GetUser(c)
-			if s.queueClient != nil {
-				_ = s.queueClient.EnqueueImport(queue.ImportPayload{UserID: user.ID, Type: it})
-			}
-			return c.NoContent(http.StatusNoContent)
-		},
-			middleware.RequireAuth(),
-			middleware.RequireRolePolicy(roleService, importPolicyByType[it]))
-	}
+	// i/export-* / i/import-* は上方 (line ~1245-1265) の explicit registration
+	// が active (iHandler.Export* / Import* via transfer_handler.go) で、proper
+	// な typed transfer.ExportXxx 定数と fileId 受け取りロジックを持つ。
+	// かつて本箇所に generic for-loop による登録が同 path で重複していたが
+	// (#1020 で気づいた pre-existing pattern)、それは fileId を受けず string
+	// literal "following" 等を直接 type に渡す壊れた version で、Echo の
+	// route override 経由で active 実装を蹴る悪影響があった。#1031 で削除済。
 
 	// Hashtags endpoints (Phase 6)
 	hashtagsHandler := apihashtags.NewHandler(s.db)


### PR DESCRIPTION
## Summary

#1020 audit の sub-issue **#1030 + #1031** を Group C (インフラ改善) として 1 PR にまとめて消化する。機能追加なし、純パフォーマンス改善 + リファクタ。

## Commit 1: #1030 \`roleRepo.List()\` cache layer

PR #1023 で conditional role 評価を統合した際、\`evaluateConditionalRoles\` は cache miss 時に毎回 \`roleRepo.List()\` を叩いていた。upstream Misskey TS の \`RoleService.rolesCache\` 相当の global TTL cache を mk-go にも追加。

- \`Service\` に \`rolesListMu / rolesListCache / rolesListExpiresAt\` を追加 (sync.Mutex で保護した single-slot TTL cache)
- \`listRolesCached()\` で TTL 内なら snapshot を返す、それ以外は \`roleRepo.List()\` を 1 度だけ呼んで cache 更新
- Mutation 経路 (\`Create\` / \`UpdateFields\` / \`Delete\` 経由の \`InvalidateAllRoleCaches\`) で cache flush
- TTL = 既存 \`roleCacheTTL = 5 min\` (\`userRoleCache\` と同 trade-off)
- 新規 test 4 件: \`countingRoleRepo\` で \`List()\` 呼び出し回数を seal

## Commit 2: #1031 二重 route 登録解消

router.go の \`/api/i/import-*\` / \`/api/i/export-*\` は 2 箇所で登録されていた:

1. **explicit registration** (line ~1245-1265): \`iHandler.Import*\` / \`Export*\` (\`transfer_handler.go\` の proper 実装、typed \`transfer.Import*\` 定数 + fileId 受け取り)
2. **for-loop registration** (line ~1325-1365): string literal を直接 \`queue.Payload.Type\` に渡す壊れた version、**fileId を受け取らない** ので import job が機能しない

Echo v4 の \`Router.Add\` は同 path/method の重複登録を後勝ちで override する仕様 = for-loop が proper 実装を shadow していた (PR #1023 のときは "loop が active" と誤判断)。

→ for-loop (export-* 8 件 + import-* 5 件) を削除して explicit のみ残す。policy gate (#1023) は explicit 側に既に貼られているので gate の effect は変わらない。

## 挙動変更

- **\`/api/i/import-{following,blocking,muting,user-lists,antennas}\`**: 壊れた挙動 (fileId 無視) から **proper な fileId 必須** に。upstream Misskey TS 互換の正しい挙動 (frontend は元から fileId を送る前提)。
- **\`/api/i/export-{notes,following,blocking,mute,favorites,user-lists,antennas,clips}\`**: \`transfer.Export*\` typed 定数を使う proper 版に揃う (worker 側の type 分岐が正しく機能)。

## 主な変更点

- \`internal/core/role/role_service.go\` — \`Service\` 構造体拡張、\`listRolesCached\` / \`invalidateRolesListCache\` 追加、mutation 経路で flush
- \`internal/core/role/role_service_test.go\` — \`countingRoleRepo\` + cache test 4 件
- \`internal/server/router.go\` — for-loop 削除 (export-* + import-*) + placeholder コメントで経緯記録

## テスト

カバレッジ:
- \`internal/core/role\`: 95.8% → **96.0%**
- \`internal/server\`: 11.0% (例外パッケージ、CI 閾値 0%)
- \`internal/api/i\`: 92.1% (\`transfer_handler.go\` の既存 test が active 経路を cover)
- 全 50+ パッケージで CI 閾値クリア

実行方法:

\`\`\`bash
make fmt && make lint && make test
\`\`\`

## Closes

Closes #1030
Closes #1031

🤖 Generated with [Claude Code](https://claude.com/claude-code)