### PR TITLE
feat(role): limit 系 9 policy の handler 個別 enforcement (count limit) (#1029 PR-1)

### DIFF
--- a/internal/api/antennas/handler.go
+++ b/internal/api/antennas/handler.go
@@ -123,9 +123,12 @@ func (h *Handler) Create(c echo.Context) error {
 	})
 	if err != nil {
 		// Name は事前 invalidParam で弾いているため、ここに来るのは
-		// ErrInvalidSource か repo エラーのみ。
+		// ErrInvalidSource か repo エラー、または antennaLimit 超過のみ。
 		if errors.Is(err, coreantenna.ErrInvalidSource) {
 			return apierr.JSONInvalidParam(c)
+		}
+		if errors.Is(err, coreantenna.ErrTooManyAntennas) {
+			return apierr.JSONTooManyAntennas(c)
 		}
 		return apierr.JSONInternalError(c)
 	}

--- a/internal/api/apierr/echo.go
+++ b/internal/api/apierr/echo.go
@@ -63,6 +63,54 @@ func JSONGtlDisabled(c echo.Context) error {
 	return c.JSON(http.StatusForbidden, GtlDisabled())
 }
 
+// #1029 PR-1: count limit 系 helpers。すべて 400 Bad Request (upstream
+// ApiError の default behaviour と一致)。
+
+// JSONPinLimitExceeded writes a 400 PIN_LIMIT_EXCEEDED response.
+func JSONPinLimitExceeded(c echo.Context) error {
+	return c.JSON(http.StatusBadRequest, PinLimitExceeded())
+}
+
+// JSONTooManyAntennas writes a 400 TOO_MANY_ANTENNAS response.
+func JSONTooManyAntennas(c echo.Context) error {
+	return c.JSON(http.StatusBadRequest, TooManyAntennas())
+}
+
+// JSONTooManyWebhooks writes a 400 TOO_MANY_WEBHOOKS response.
+func JSONTooManyWebhooks(c echo.Context) error {
+	return c.JSON(http.StatusBadRequest, TooManyWebhooks())
+}
+
+// JSONTooManyClips writes a 400 TOO_MANY_CLIPS response.
+func JSONTooManyClips(c echo.Context) error {
+	return c.JSON(http.StatusBadRequest, TooManyClips())
+}
+
+// JSONTooManyClipNotes writes a 400 TOO_MANY_CLIP_NOTES response.
+func JSONTooManyClipNotes(c echo.Context) error {
+	return c.JSON(http.StatusBadRequest, TooManyClipNotes())
+}
+
+// JSONTooManyUserLists writes a 400 TOO_MANY_USERLISTS response.
+func JSONTooManyUserLists(c echo.Context) error {
+	return c.JSON(http.StatusBadRequest, TooManyUserLists())
+}
+
+// JSONTooManyUsers writes a 400 TOO_MANY_USERS response.
+func JSONTooManyUsers(c echo.Context) error {
+	return c.JSON(http.StatusBadRequest, TooManyUsers())
+}
+
+// JSONTooManyNoteDrafts writes a 400 TOO_MANY_NOTE_DRAFTS response.
+func JSONTooManyNoteDrafts(c echo.Context) error {
+	return c.JSON(http.StatusBadRequest, TooManyNoteDrafts())
+}
+
+// JSONTooManyMutedWords writes a 400 TOO_MANY_MUTED_WORDS response.
+func JSONTooManyMutedWords(c echo.Context) error {
+	return c.JSON(http.StatusBadRequest, TooManyMutedWords())
+}
+
 // JSONNoSuchRenoteTarget writes a 404 NO_SUCH_RENOTE_TARGET response to the client.
 func JSONNoSuchRenoteTarget(c echo.Context) error {
 	return c.JSON(http.StatusNotFound, NoSuchRenoteTarget())

--- a/internal/api/apierr/echo_test.go
+++ b/internal/api/apierr/echo_test.go
@@ -123,6 +123,36 @@ func TestJSONGtlDisabled(t *testing.T) {
 	assert.Equal(t, UUIDGtlDisabled, errObj["id"])
 }
 
+// #1029 PR-1: JSON* helpers が 400 Bad Request + 正しい code/id を返す
+// table-driven test。
+func TestJSONCountLimitHelpers(t *testing.T) {
+	tests := []struct {
+		name string
+		fn   func(echo.Context) error
+		code string
+		uuid string
+	}{
+		{"PinLimitExceeded", JSONPinLimitExceeded, "PIN_LIMIT_EXCEEDED", UUIDPinLimitExceeded},
+		{"TooManyAntennas", JSONTooManyAntennas, "TOO_MANY_ANTENNAS", UUIDTooManyAntennas},
+		{"TooManyWebhooks", JSONTooManyWebhooks, "TOO_MANY_WEBHOOKS", UUIDTooManyWebhooks},
+		{"TooManyClips", JSONTooManyClips, "TOO_MANY_CLIPS", UUIDTooManyClips},
+		{"TooManyClipNotes", JSONTooManyClipNotes, "TOO_MANY_CLIP_NOTES", UUIDTooManyClipNotes},
+		{"TooManyUserLists", JSONTooManyUserLists, "TOO_MANY_USERLISTS", UUIDTooManyUserLists},
+		{"TooManyUsers", JSONTooManyUsers, "TOO_MANY_USERS", UUIDTooManyUsers},
+		{"TooManyNoteDrafts", JSONTooManyNoteDrafts, "TOO_MANY_NOTE_DRAFTS", UUIDTooManyNoteDrafts},
+		{"TooManyMutedWords", JSONTooManyMutedWords, "TOO_MANY_MUTED_WORDS", UUIDTooManyMutedWords},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			code, body := invoke(t, tc.fn)
+			assert.Equal(t, http.StatusBadRequest, code, "all count-limit helpers return 400")
+			errObj := body["error"].(map[string]any)
+			assert.Equal(t, tc.code, errObj["code"])
+			assert.Equal(t, tc.uuid, errObj["id"])
+		})
+	}
+}
+
 func TestJSONNoSuchRenoteTarget(t *testing.T) {
 	code, body := invoke(t, JSONNoSuchRenoteTarget)
 	assert.Equal(t, http.StatusNotFound, code)

--- a/internal/api/apierr/errors.go
+++ b/internal/api/apierr/errors.go
@@ -57,6 +57,19 @@ const (
 	// `gtlAvailable` role policy が false のときに 403 で reject する (#1026)。
 	UUIDGtlDisabled = "0332fc13-6ab2-4427-ae80-a9fadffd1a6b"
 
+	// 以下は #1029 PR-1 (count limit 系 9 endpoint) で使う policy 違反 UUID。
+	// すべて upstream Misskey TS の各 endpoint で `if (currentCount >=
+	// policies.xxxLimit)` で reject する経路と一致 (= 値の手書き整合)。
+	UUIDPinLimitExceeded  = "72dab508-c64d-498f-8740-a8eec1ba385a" // i/pin
+	UUIDTooManyAntennas   = "faf47050-e8b5-438c-913c-db2b1576fde4" // antennas/create
+	UUIDTooManyWebhooks   = "87a9bb19-111e-4e37-81d3-a3e7426453b0" // i/webhooks/create
+	UUIDTooManyClips      = "920f7c2d-6208-4b76-8082-e632020f5883" // clips/create
+	UUIDTooManyClipNotes  = "f0dba960-ff73-4615-8df4-d6ac5d9dc118" // clips/add-note
+	UUIDTooManyUserLists  = "0cf21a28-7715-4f39-a20d-777bfdb8d138" // users/lists/create
+	UUIDTooManyUsers      = "2dd9752e-a338-413d-8eec-41814430989b" // users/lists/push
+	UUIDTooManyNoteDrafts = "9ee33bbe-fde3-4c71-9b51-e50492c6b9c8" // notes/drafts/create
+	UUIDTooManyMutedWords = "010665b1-a211-42d2-bc64-8f6609d79785" // i/update mutedWords
+
 	// UUIDNoSuchEmoji は upstream `admin/emoji/update` の `noSuchEmoji` UUID
 	// (third_party/misskey/.../endpoints/admin/emoji/update.ts:24)。mk-go の
 	// 旧実装は `684b7e7e-...` という typo'd 値を返していた regression を
@@ -220,6 +233,59 @@ func LtlDisabled() map[string]any {
 // policy が false のときに返す (#1026)。
 func GtlDisabled() map[string]any {
 	return Error("GTL_DISABLED", "Global timeline has been disabled.", UUIDGtlDisabled)
+}
+
+// 以下は #1029 PR-1 count limit 系 9 endpoint で使う error helper。すべて
+// 400 Bad Request で返す upstream 互換 (= ApiCallService が ApiError 400
+// で投げる経路)。caller は role policy 値と現在 count を比較し、超過時に
+// 該当 helper を呼ぶ。
+
+// PinLimitExceeded returns the upstream `pinLimitExceeded` shape (i/pin)。
+func PinLimitExceeded() map[string]any {
+	return Error("PIN_LIMIT_EXCEEDED", "You can not pin notes any more.", UUIDPinLimitExceeded)
+}
+
+// TooManyAntennas returns the upstream `tooManyAntennas` shape (antennas/create)。
+func TooManyAntennas() map[string]any {
+	return Error("TOO_MANY_ANTENNAS", "You cannot create antenna any more.", UUIDTooManyAntennas)
+}
+
+// TooManyWebhooks returns the upstream `tooManyWebhooks` shape (i/webhooks/create)。
+func TooManyWebhooks() map[string]any {
+	return Error("TOO_MANY_WEBHOOKS", "You cannot create webhook any more.", UUIDTooManyWebhooks)
+}
+
+// TooManyClips returns the upstream `tooManyClips` shape (clips/create)。
+func TooManyClips() map[string]any {
+	return Error("TOO_MANY_CLIPS", "You cannot create clip any more.", UUIDTooManyClips)
+}
+
+// TooManyClipNotes returns the upstream `tooManyClipNotes` shape (clips/add-note)。
+func TooManyClipNotes() map[string]any {
+	return Error("TOO_MANY_CLIP_NOTES", "You cannot add notes to the clip any more.", UUIDTooManyClipNotes)
+}
+
+// TooManyUserLists returns the upstream `tooManyUserLists` shape (users/lists/create)。
+func TooManyUserLists() map[string]any {
+	return Error("TOO_MANY_USERLISTS", "You cannot create user list any more.", UUIDTooManyUserLists)
+}
+
+// TooManyUsers returns the upstream `tooManyUsers` shape (users/lists/push)。
+// upstream は code "TOO_MANY_USERS" でやや generic、context は "users on user list" に限定。
+func TooManyUsers() map[string]any {
+	return Error("TOO_MANY_USERS", "You can not push users any more.", UUIDTooManyUsers)
+}
+
+// TooManyNoteDrafts returns the upstream `NoteDraftService` の IdentifiableError
+// shape (notes/drafts/create)。upstream は code が無く message のみだが、mk-go は
+// `TOO_MANY_NOTE_DRAFTS` という code を発番して frontend が分岐できるようにする。
+func TooManyNoteDrafts() map[string]any {
+	return Error("TOO_MANY_NOTE_DRAFTS", "Too many drafts.", UUIDTooManyNoteDrafts)
+}
+
+// TooManyMutedWords returns the upstream `tooManyMutedWords` shape (i/update mutedWords)。
+func TooManyMutedWords() map[string]any {
+	return Error("TOO_MANY_MUTED_WORDS", "Too many muted words.", UUIDTooManyMutedWords)
 }
 
 // NoSuchRenoteTarget returns a 404 NO_SUCH_RENOTE_TARGET error response.

--- a/internal/api/apierr/errors_test.go
+++ b/internal/api/apierr/errors_test.go
@@ -112,6 +112,37 @@ func TestGtlDisabled(t *testing.T) {
 	assert.Equal(t, "Global timeline has been disabled.", errObj["message"])
 }
 
+// #1029 PR-1: count limit 系 9 helper の code/id/message を upstream に
+// 揃えていることを seal する table-driven test (typo / 値ずれの regression
+// guard、coverage 維持兼任)。
+func TestCountLimitHelpers(t *testing.T) {
+	tests := []struct {
+		name string
+		fn   func() map[string]any
+		code string
+		uuid string
+	}{
+		{"PinLimitExceeded", PinLimitExceeded, "PIN_LIMIT_EXCEEDED", UUIDPinLimitExceeded},
+		{"TooManyAntennas", TooManyAntennas, "TOO_MANY_ANTENNAS", UUIDTooManyAntennas},
+		{"TooManyWebhooks", TooManyWebhooks, "TOO_MANY_WEBHOOKS", UUIDTooManyWebhooks},
+		{"TooManyClips", TooManyClips, "TOO_MANY_CLIPS", UUIDTooManyClips},
+		{"TooManyClipNotes", TooManyClipNotes, "TOO_MANY_CLIP_NOTES", UUIDTooManyClipNotes},
+		{"TooManyUserLists", TooManyUserLists, "TOO_MANY_USERLISTS", UUIDTooManyUserLists},
+		{"TooManyUsers", TooManyUsers, "TOO_MANY_USERS", UUIDTooManyUsers},
+		{"TooManyNoteDrafts", TooManyNoteDrafts, "TOO_MANY_NOTE_DRAFTS", UUIDTooManyNoteDrafts},
+		{"TooManyMutedWords", TooManyMutedWords, "TOO_MANY_MUTED_WORDS", UUIDTooManyMutedWords},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			result := tc.fn()
+			errObj := result["error"].(map[string]any)
+			assert.Equal(t, tc.code, errObj["code"])
+			assert.Equal(t, tc.uuid, errObj["id"])
+			assert.NotEmpty(t, errObj["message"], "message should be non-empty")
+		})
+	}
+}
+
 func TestNoSuchRenoteTarget(t *testing.T) {
 	result := NoSuchRenoteTarget()
 	errObj := result["error"].(map[string]any)

--- a/internal/api/clips/handler.go
+++ b/internal/api/clips/handler.go
@@ -104,6 +104,9 @@ func (h *Handler) Create(c echo.Context) error {
 		IsPublic:    req.IsPublic,
 	})
 	if err != nil {
+		if errors.Is(err, coreclip.ErrTooManyClips) {
+			return apierr.JSONTooManyClips(c)
+		}
 		return apierr.JSONInternalError(c)
 	}
 	return c.JSON(http.StatusOK, clipToMap(cl))
@@ -249,6 +252,8 @@ func (h *Handler) AddNote(c echo.Context) error {
 			return notFoundNote(c)
 		case errors.Is(err, coreclip.ErrAlreadyClipped):
 			return alreadyClipped(c)
+		case errors.Is(err, coreclip.ErrTooManyClipNotes):
+			return apierr.JSONTooManyClipNotes(c)
 		}
 		return apierr.JSONInternalError(c)
 	}

--- a/internal/api/i/handler.go
+++ b/internal/api/i/handler.go
@@ -951,30 +951,41 @@ func (h *Handler) Update(c echo.Context) error {
 	// `[]` (= 2 byte の空配列) はクリア要求として通す。validation は配列形式
 	// であることだけ。upstream paramDef も内側構造は `array of (string |
 	// string[])` で、要素 0 個も許容する。
+	// wordMuteLimit role policy gate (#1029)。upstream
+	// `checkMuteWordCount(mutedWords, policies.wordMuteLimit)` と同 logic。
+	// mutedWords / hardMutedWords 両方が指定された request で同 policy を 2 度
+	// lookup しないよう、helper closure で memoize する (canUpdateBioMedia と
+	// 同 pattern, upstream の `policies ??= await ...` と等価)。
+	var (
+		wordMuteLimitChecked bool
+		wordMuteLimitValue   int
+		wordMuteLimitOk      bool
+	)
+	wordMuteLimit := func() (int, bool) {
+		if !wordMuteLimitChecked {
+			wordMuteLimitChecked = true
+			if h.roleProvider != nil {
+				if v, ok := h.roleProvider.GetUserPolicies(me.ID)["wordMuteLimit"].(int); ok && v >= 0 {
+					wordMuteLimitValue = v
+					wordMuteLimitOk = true
+				}
+			}
+		}
+		return wordMuteLimitValue, wordMuteLimitOk
+	}
 	if mw, ok, err := normalizeMutedWords(req.MutedWords); err != nil {
 		return apierr.JSONInvalidParam(c)
 	} else if ok {
-		// wordMuteLimit role policy gate (#1029)。upstream
-		// `checkMuteWordCount(mutedWords, policies.wordMuteLimit)` と同 logic。
-		if h.roleProvider != nil {
-			if limit, lok := h.roleProvider.GetUserPolicies(me.ID)["wordMuteLimit"].(int); lok && limit >= 0 {
-				if countMuteWords(mw) > limit {
-					return apierr.JSONTooManyMutedWords(c)
-				}
-			}
+		if limit, lok := wordMuteLimit(); lok && countMuteWords(mw) > limit {
+			return apierr.JSONTooManyMutedWords(c)
 		}
 		in.MutedWords = &mw
 	}
 	if mw, ok, err := normalizeMutedWords(req.HardMutedWords); err != nil {
 		return apierr.JSONInvalidParam(c)
 	} else if ok {
-		// hardMutedWords も同 policy で gate (#1029)。
-		if h.roleProvider != nil {
-			if limit, lok := h.roleProvider.GetUserPolicies(me.ID)["wordMuteLimit"].(int); lok && limit >= 0 {
-				if countMuteWords(mw) > limit {
-					return apierr.JSONTooManyMutedWords(c)
-				}
-			}
+		if limit, lok := wordMuteLimit(); lok && countMuteWords(mw) > limit {
+			return apierr.JSONTooManyMutedWords(c)
 		}
 		in.HardMutedWords = &mw
 	}

--- a/internal/api/i/handler.go
+++ b/internal/api/i/handler.go
@@ -800,6 +800,30 @@ func backupCodesStock(profile *model.UserProfile) string {
 	return "partial"
 }
 
+// countMuteWords returns the total number of entries in a muted-words
+// payload, flattening AND-groups. mirrors upstream Misskey TS i/update.ts
+// `checkMuteWordCount`: 各 entry が string なら 1、array なら array.length
+// を加算する (#1029)。raw が nil / 空なら 0。
+func countMuteWords(raw json.RawMessage) int {
+	if len(raw) == 0 {
+		return 0
+	}
+	var arr []any
+	if err := json.Unmarshal(raw, &arr); err != nil {
+		return 0
+	}
+	length := 0
+	for _, item := range arr {
+		switch v := item.(type) {
+		case string:
+			length++
+		case []any:
+			length += len(v)
+		}
+	}
+	return length
+}
+
 // normalizeMutedWords validates and normalizes the mutedWords / hardMutedWords
 // payload from i/update. Returns (raw, ok, err): ok=false means "field not
 // present in request" (caller should leave the column unchanged); err != nil
@@ -930,11 +954,28 @@ func (h *Handler) Update(c echo.Context) error {
 	if mw, ok, err := normalizeMutedWords(req.MutedWords); err != nil {
 		return apierr.JSONInvalidParam(c)
 	} else if ok {
+		// wordMuteLimit role policy gate (#1029)。upstream
+		// `checkMuteWordCount(mutedWords, policies.wordMuteLimit)` と同 logic。
+		if h.roleProvider != nil {
+			if limit, lok := h.roleProvider.GetUserPolicies(me.ID)["wordMuteLimit"].(int); lok && limit >= 0 {
+				if countMuteWords(mw) > limit {
+					return apierr.JSONTooManyMutedWords(c)
+				}
+			}
+		}
 		in.MutedWords = &mw
 	}
 	if mw, ok, err := normalizeMutedWords(req.HardMutedWords); err != nil {
 		return apierr.JSONInvalidParam(c)
 	} else if ok {
+		// hardMutedWords も同 policy で gate (#1029)。
+		if h.roleProvider != nil {
+			if limit, lok := h.roleProvider.GetUserPolicies(me.ID)["wordMuteLimit"].(int); lok && limit >= 0 {
+				if countMuteWords(mw) > limit {
+					return apierr.JSONTooManyMutedWords(c)
+				}
+			}
+		}
 		in.HardMutedWords = &mw
 	}
 	// upstream Misskey TS i/update.ts: avatarId / bannerId が non-null 文字列で

--- a/internal/api/notes/handler_drafts.go
+++ b/internal/api/notes/handler_drafts.go
@@ -51,6 +51,19 @@ func (h *Handler) DraftsCreate(c echo.Context) error {
 	if req.Visibility == "" {
 		req.Visibility = "public"
 	}
+	// noteDraftLimit role policy gate (#1029)。policyProvider は #1026 で
+	// 配線済 (timeline gate と共用)。CountByUser で current 件数を取得。
+	if h.policyProvider != nil {
+		if limit, ok := h.policyProvider.GetUserPolicies(user.ID)["noteDraftLimit"].(int); ok && limit >= 0 {
+			count, err := h.draftRepo.CountByUser(user.ID)
+			if err != nil {
+				return apierr.JSONInternalError(c)
+			}
+			if int(count) >= limit {
+				return apierr.JSONTooManyNoteDrafts(c)
+			}
+		}
+	}
 	draft := &model.NoteDraft{
 		ID:         h.idGen.Generate(time.Now()),
 		UserID:     user.ID,

--- a/internal/api/notes/handler_drafts.go
+++ b/internal/api/notes/handler_drafts.go
@@ -59,7 +59,7 @@ func (h *Handler) DraftsCreate(c echo.Context) error {
 			if err != nil {
 				return apierr.JSONInternalError(c)
 			}
-			if int(count) >= limit {
+			if count >= int64(limit) {
 				return apierr.JSONTooManyNoteDrafts(c)
 			}
 		}

--- a/internal/api/notes/handler_drafts_test.go
+++ b/internal/api/notes/handler_drafts_test.go
@@ -151,6 +151,36 @@ func TestDraftsCreate_Error(t *testing.T) {
 	assert.Equal(t, http.StatusInternalServerError, rec.Code)
 }
 
+// #1029: noteDraftLimit role policy gate test。
+type draftStubPolicyProvider struct {
+	policies map[string]any
+}
+
+func (s *draftStubPolicyProvider) GetUserPolicies(_ string) map[string]any {
+	return s.policies
+}
+
+func TestDraftsCreate_NoteDraftLimitExceeded(t *testing.T) {
+	h, repo := newDraftHandlerWithRepo()
+	repo.drafts["d1"] = &model.NoteDraft{ID: "d1", UserID: "u1"}
+	repo.drafts["d2"] = &model.NoteDraft{ID: "d2", UserID: "u1"}
+	h.SetPolicyProvider(&draftStubPolicyProvider{policies: map[string]any{
+		"noteDraftLimit": 2,
+	}})
+	rec := postDraft(h.DraftsCreate, `{"text":"third"}`, &model.User{ID: "u1"})
+	assert.Equal(t, http.StatusBadRequest, rec.Code)
+	assert.Contains(t, rec.Body.String(), "TOO_MANY_NOTE_DRAFTS")
+}
+
+func TestDraftsCreate_NoteDraftLimit_PassesUnderLimit(t *testing.T) {
+	h, _ := newDraftHandlerWithRepo()
+	h.SetPolicyProvider(&draftStubPolicyProvider{policies: map[string]any{
+		"noteDraftLimit": 10,
+	}})
+	rec := postDraft(h.DraftsCreate, `{"text":"draft"}`, &model.User{ID: "u1"})
+	assert.Equal(t, http.StatusOK, rec.Code)
+}
+
 // --- DraftsUpdate ---
 
 func TestDraftsUpdate_NilRepo(t *testing.T) {

--- a/internal/api/userlists/handler.go
+++ b/internal/api/userlists/handler.go
@@ -84,11 +84,11 @@ func (h *Handler) Create(c echo.Context) error {
 	// userListLimit role policy gate (#1029)。
 	if h.rolePolicyProvider != nil {
 		if limit, ok := h.rolePolicyProvider.GetUserPolicies(user.ID)["userListLimit"].(int); ok && limit >= 0 {
-			existing, err := h.repo.ListByUser(user.ID)
+			count, err := h.repo.CountByUser(user.ID)
 			if err != nil {
 				return apierr.JSONInternalError(c)
 			}
-			if len(existing) >= limit {
+			if count >= int64(limit) {
 				return apierr.JSONTooManyUserLists(c)
 			}
 		}
@@ -164,11 +164,11 @@ func (h *Handler) Push(c echo.Context) error {
 	// を確認する access gate は別途必要だが本 PR scope 外、limit 単独で gate)。
 	if h.rolePolicyProvider != nil {
 		if limit, ok := h.rolePolicyProvider.GetUserPolicies(list.UserID)["userEachUserListsLimit"].(int); ok && limit >= 0 {
-			members, err := h.repo.ListMembers(list.ID)
+			count, err := h.repo.CountMembers(list.ID)
 			if err != nil {
 				return apierr.JSONInternalError(c)
 			}
-			if len(members) >= limit {
+			if count >= int64(limit) {
 				return apierr.JSONTooManyUsers(c)
 			}
 		}

--- a/internal/api/userlists/handler.go
+++ b/internal/api/userlists/handler.go
@@ -17,13 +17,26 @@ import (
 
 // Handler handles users/lists API endpoints.
 type Handler struct {
-	repo  repository.UserListRepository
-	idGen id.Generator
+	repo               repository.UserListRepository
+	idGen              id.Generator
+	rolePolicyProvider RolePolicyProvider
+}
+
+// RolePolicyProvider abstracts role-policy lookup for `userListLimit` /
+// `userEachUserListsLimit` enforcement (#1029)。実装は core/role.Service。
+type RolePolicyProvider interface {
+	GetUserPolicies(userID string) map[string]any
 }
 
 // NewHandler creates a new userlists Handler.
 func NewHandler(repo repository.UserListRepository, idGen id.Generator) *Handler {
 	return &Handler{repo: repo, idGen: idGen}
+}
+
+// SetRolePolicyProvider wires a RolePolicyProvider so Create / Push enforce
+// the userListLimit / userEachUserListsLimit role policies (#1029).
+func (h *Handler) SetRolePolicyProvider(p RolePolicyProvider) {
+	h.rolePolicyProvider = p
 }
 
 // List handles POST /api/users/lists/list.
@@ -67,6 +80,18 @@ func (h *Handler) Create(c echo.Context) error {
 	}
 	if err := c.Bind(&req); err != nil || req.Name == "" {
 		return c.JSON(http.StatusBadRequest, apierr.Error("INVALID_PARAM", "name is required.", "3d81ceae-475f-4600-b2a8-2bc116157532"))
+	}
+	// userListLimit role policy gate (#1029)。
+	if h.rolePolicyProvider != nil {
+		if limit, ok := h.rolePolicyProvider.GetUserPolicies(user.ID)["userListLimit"].(int); ok && limit >= 0 {
+			existing, err := h.repo.ListByUser(user.ID)
+			if err != nil {
+				return apierr.JSONInternalError(c)
+			}
+			if len(existing) >= limit {
+				return apierr.JSONTooManyUserLists(c)
+			}
+		}
 	}
 	list := &model.UserList{
 		ID:     h.idGen.Generate(time.Now()),
@@ -130,8 +155,23 @@ func (h *Handler) Push(c echo.Context) error {
 	if err := c.Bind(&req); err != nil || req.ListID == "" || req.UserID == "" {
 		return c.JSON(http.StatusBadRequest, apierr.Error("INVALID_PARAM", "listId and userId are required.", "3d81ceae-475f-4600-b2a8-2bc116157532"))
 	}
-	if _, err := h.repo.FindByID(req.ListID); err != nil {
+	list, err := h.repo.FindByID(req.ListID)
+	if err != nil {
 		return c.JSON(http.StatusNotFound, apierr.Error("NO_SUCH_LIST", "No such list.", "7bc05c21-1d7a-41ae-88f1-66820f4dc686"))
+	}
+	// userEachUserListsLimit role policy gate (#1029)。list owner の policy
+	// で評価する (upstream は owner = me 経路、mk-go も owner.UserID と me 一致
+	// を確認する access gate は別途必要だが本 PR scope 外、limit 単独で gate)。
+	if h.rolePolicyProvider != nil {
+		if limit, ok := h.rolePolicyProvider.GetUserPolicies(list.UserID)["userEachUserListsLimit"].(int); ok && limit >= 0 {
+			members, err := h.repo.ListMembers(list.ID)
+			if err != nil {
+				return apierr.JSONInternalError(c)
+			}
+			if len(members) >= limit {
+				return apierr.JSONTooManyUsers(c)
+			}
+		}
 	}
 	m := &model.UserListMembership{
 		ID:         h.idGen.Generate(time.Now()),

--- a/internal/api/userlists/handler_test.go
+++ b/internal/api/userlists/handler_test.go
@@ -246,6 +246,54 @@ func (d *duplicateAddMemberRepo) AddMember(_ *model.UserListMembership) error {
 	return repository.ErrUserListDuplicateMember
 }
 
+// #1029: userListLimit / userEachUserListsLimit role policy gate test。
+type stubRolePolicyProvider struct {
+	policies map[string]any
+}
+
+func (s *stubRolePolicyProvider) GetUserPolicies(_ string) map[string]any {
+	return s.policies
+}
+
+func TestCreate_UserListLimitExceeded(t *testing.T) {
+	h, repo := newTestHandler(t)
+	// 既に 2 list 保有
+	repo.Lists["l1"] = &model.UserList{ID: "l1", UserID: "u1"}
+	repo.Lists["l2"] = &model.UserList{ID: "l2", UserID: "u1"}
+	h.SetRolePolicyProvider(&stubRolePolicyProvider{policies: map[string]any{
+		"userListLimit": 2,
+	}})
+	rec := doPost(h.Create, `{"name":"third"}`, &model.User{ID: "u1"})
+	assert.Equal(t, http.StatusBadRequest, rec.Code)
+	assert.Contains(t, rec.Body.String(), "TOO_MANY_USERLISTS")
+	assert.Contains(t, rec.Body.String(), "0cf21a28-7715-4f39-a20d-777bfdb8d138")
+}
+
+func TestCreate_UserListLimit_PassesUnderLimit(t *testing.T) {
+	h, _ := newTestHandler(t)
+	h.SetRolePolicyProvider(&stubRolePolicyProvider{policies: map[string]any{
+		"userListLimit": 10,
+	}})
+	rec := doPost(h.Create, `{"name":"My List"}`, &model.User{ID: "u1"})
+	assert.Equal(t, http.StatusOK, rec.Code, "limit 内なら通常成功")
+}
+
+func TestPush_UserEachUserListsLimitExceeded(t *testing.T) {
+	h, repo := newTestHandler(t)
+	repo.Lists["l1"] = &model.UserList{ID: "l1", UserID: "u1"}
+	repo.Members = []*model.UserListMembership{
+		{ID: "m1", UserListID: "l1", UserID: "u_a"},
+		{ID: "m2", UserListID: "l1", UserID: "u_b"},
+	}
+	h.SetRolePolicyProvider(&stubRolePolicyProvider{policies: map[string]any{
+		"userEachUserListsLimit": 2,
+	}})
+	rec := doPost(h.Push, `{"listId":"l1","userId":"u_c"}`, &model.User{ID: "u1"})
+	assert.Equal(t, http.StatusBadRequest, rec.Code)
+	assert.Contains(t, rec.Body.String(), "TOO_MANY_USERS")
+	assert.Contains(t, rec.Body.String(), "2dd9752e-a338-413d-8eec-41814430989b")
+}
+
 func TestPush_AlreadyAdded(t *testing.T) {
 	repo := &duplicateAddMemberRepo{testutil.NewMockUserListRepository()}
 	repo.Lists["l1"] = &model.UserList{ID: "l1"}

--- a/internal/api/webhooks/handler.go
+++ b/internal/api/webhooks/handler.go
@@ -115,11 +115,11 @@ func (h *Handler) Create(c echo.Context) error {
 	// 現在保有数を比較。provider 未配線 / policy 不在は gate skip。
 	if h.rolePolicyProvider != nil {
 		if limit, ok := h.rolePolicyProvider.GetUserPolicies(user.ID)["webhookLimit"].(int); ok && limit >= 0 {
-			existing, err := h.repo.ListByUserID(user.ID)
+			count, err := h.repo.CountByUserID(user.ID)
 			if err != nil {
 				return apierr.JSONInternalError(c)
 			}
-			if len(existing) >= limit {
+			if count >= int64(limit) {
 				return apierr.JSONTooManyWebhooks(c)
 			}
 		}

--- a/internal/api/webhooks/handler.go
+++ b/internal/api/webhooks/handler.go
@@ -52,9 +52,16 @@ type TestDispatcher interface {
 
 // Handler handles i/webhooks/* endpoints.
 type Handler struct {
-	repo       repository.WebhookRepository
-	idGen      id.Generator
-	dispatcher TestDispatcher
+	repo               repository.WebhookRepository
+	idGen              id.Generator
+	dispatcher         TestDispatcher
+	rolePolicyProvider RolePolicyProvider
+}
+
+// RolePolicyProvider abstracts role-policy lookup for `webhookLimit`
+// enforcement (#1029)。実装は core/role.Service。
+type RolePolicyProvider interface {
+	GetUserPolicies(userID string) map[string]any
 }
 
 // NewHandler creates a new webhooks handler.
@@ -66,6 +73,12 @@ func NewHandler(repo repository.WebhookRepository, idGen id.Generator) *Handler 
 // a synthetic test payload through the production pipeline.
 func (h *Handler) SetDispatcher(d TestDispatcher) {
 	h.dispatcher = d
+}
+
+// SetRolePolicyProvider wires a RolePolicyProvider so Create enforces the
+// `webhookLimit` role policy (#1029).
+func (h *Handler) SetRolePolicyProvider(p RolePolicyProvider) {
+	h.rolePolicyProvider = p
 }
 
 func packWebhook(w *model.Webhook) map[string]any {
@@ -96,6 +109,20 @@ func (h *Handler) Create(c echo.Context) error {
 	}
 	if !validateOnArray(req.On) {
 		return c.JSON(http.StatusBadRequest, apierr.Error("INVALID_PARAM", "on must contain only webhookEventTypes values.", "ed1d7571-a3ac-4370-899c-0dbe5e230cc8"))
+	}
+
+	// webhookLimit role policy gate (#1029)。policy 経由で取得した上限と
+	// 現在保有数を比較。provider 未配線 / policy 不在は gate skip。
+	if h.rolePolicyProvider != nil {
+		if limit, ok := h.rolePolicyProvider.GetUserPolicies(user.ID)["webhookLimit"].(int); ok && limit >= 0 {
+			existing, err := h.repo.ListByUserID(user.ID)
+			if err != nil {
+				return apierr.JSONInternalError(c)
+			}
+			if len(existing) >= limit {
+				return apierr.JSONTooManyWebhooks(c)
+			}
+		}
 	}
 
 	webhook := &model.Webhook{

--- a/internal/api/webhooks/handler_test.go
+++ b/internal/api/webhooks/handler_test.go
@@ -72,6 +72,16 @@ func (m *mockWebhookRepo) ListActiveByUserID(userID string) ([]*model.Webhook, e
 	return result, nil
 }
 
+func (m *mockWebhookRepo) CountByUserID(userID string) (int64, error) {
+	var count int64
+	for _, w := range m.webhooks {
+		if w.UserID == userID {
+			count++
+		}
+	}
+	return count, nil
+}
+
 func (m *mockWebhookRepo) Update(w *model.Webhook) error {
 	if m.updateErr != nil {
 		return m.updateErr

--- a/internal/api/webhooks/handler_test.go
+++ b/internal/api/webhooks/handler_test.go
@@ -176,6 +176,54 @@ func TestCreate_Error(t *testing.T) {
 	assert.Equal(t, http.StatusInternalServerError, rec.Code)
 }
 
+// --- webhookLimit role policy gate (#1029) ---
+
+type stubRolePolicyProvider struct {
+	policies map[string]any
+}
+
+func (s *stubRolePolicyProvider) GetUserPolicies(_ string) map[string]any { return s.policies }
+
+func TestCreate_WebhookLimitExceeded(t *testing.T) {
+	h, repo := newTestHandler()
+	// 既に 2 webhook 保有
+	repo.webhooks["w1"] = &model.Webhook{ID: "w1", UserID: "u1", On: pq.StringArray{}}
+	repo.webhooks["w2"] = &model.Webhook{ID: "w2", UserID: "u1", On: pq.StringArray{}}
+	h.SetRolePolicyProvider(&stubRolePolicyProvider{policies: map[string]any{
+		"webhookLimit": 2,
+	}})
+	rec := post(h.Create, `{"name":"test","url":"https://example.com"}`, &model.User{ID: "u1"})
+	assert.Equal(t, http.StatusBadRequest, rec.Code)
+	assert.Contains(t, rec.Body.String(), "TOO_MANY_WEBHOOKS")
+	assert.Contains(t, rec.Body.String(), "87a9bb19-111e-4e37-81d3-a3e7426453b0")
+}
+
+func TestCreate_WebhookLimit_PassesUnderLimit(t *testing.T) {
+	h, _ := newTestHandler()
+	h.SetRolePolicyProvider(&stubRolePolicyProvider{policies: map[string]any{
+		"webhookLimit": 10,
+	}})
+	rec := post(h.Create, `{"name":"test","url":"https://example.com"}`, &model.User{ID: "u1"})
+	assert.Equal(t, http.StatusOK, rec.Code, "limit 内なら通常成功")
+}
+
+// failCountRepo は CountByUserID だけ error を返す stub。webhookLimit gate
+// で count 取得が失敗した場合に 500 を返すパスを検証する。
+type failCountRepo struct{ *mockWebhookRepo }
+
+func (f *failCountRepo) CountByUserID(_ string) (int64, error) { return 0, errMock }
+
+func TestCreate_WebhookLimit_CountError(t *testing.T) {
+	repo := newMockRepo()
+	idGen, _ := id.NewGenerator("aidx")
+	h := NewHandler(&failCountRepo{repo}, idGen)
+	h.SetRolePolicyProvider(&stubRolePolicyProvider{policies: map[string]any{
+		"webhookLimit": 5,
+	}})
+	rec := post(h.Create, `{"name":"test","url":"https://example.com"}`, &model.User{ID: "u1"})
+	assert.Equal(t, http.StatusInternalServerError, rec.Code)
+}
+
 // --- List ---
 
 func TestList_Success(t *testing.T) {

--- a/internal/core/antenna/antenna_service.go
+++ b/internal/core/antenna/antenna_service.go
@@ -148,11 +148,11 @@ func (s *Service) Create(in CreateInput) (*model.Antenna, error) {
 	// 現在保有数を比較。provider 未配線 / policy 不在は gate skip (旧挙動)。
 	if s.rolePolicyProvider != nil {
 		if limit, ok := s.rolePolicyProvider.GetUserPolicies(in.OwnerID)["antennaLimit"].(int); ok && limit >= 0 {
-			existing, err := s.repo.ListByUser(in.OwnerID)
+			count, err := s.repo.CountByUser(in.OwnerID)
 			if err != nil {
 				return nil, err
 			}
-			if len(existing) >= limit {
+			if count >= int64(limit) {
 				return nil, ErrTooManyAntennas
 			}
 		}

--- a/internal/core/antenna/antenna_service.go
+++ b/internal/core/antenna/antenna_service.go
@@ -25,6 +25,9 @@ var (
 	ErrAntennaNotFound = errors.New("antenna not found")
 	// ErrAntennaNameRequired is returned when name is empty on Create / Update.
 	ErrAntennaNameRequired = errors.New("antenna name is required")
+	// ErrTooManyAntennas is returned by Create when the user already owns
+	// `antennaLimit` antennas (#1029, upstream tooManyAntennas)。
+	ErrTooManyAntennas = errors.New("antenna limit exceeded")
 	// ErrAccessDenied is returned when a user attempts to update / delete an
 	// antenna they do not own.
 	ErrAccessDenied = errors.New("not the owner of this antenna")
@@ -51,6 +54,20 @@ type Service struct {
 	client        *redis.Client
 	idGen         id.Generator
 	clock         func() time.Time
+	// rolePolicyProvider は Create で antennaLimit gate に使う (#1029)。
+	// nil 時は gate skip (旧挙動互換)。
+	rolePolicyProvider RolePolicyProvider
+}
+
+// RolePolicyProvider abstracts role-policy lookup for antenna count limits (#1029).
+type RolePolicyProvider interface {
+	GetUserPolicies(userID string) map[string]any
+}
+
+// SetRolePolicyProvider wires a RolePolicyProvider so Create enforces the
+// `antennaLimit` role policy (#1029).
+func (s *Service) SetRolePolicyProvider(p RolePolicyProvider) {
+	s.rolePolicyProvider = p
 }
 
 // NewService constructs an antenna Service. userRepo は現状未使用だが、将来
@@ -126,6 +143,19 @@ func (s *Service) Create(in CreateInput) (*model.Antenna, error) {
 	}
 	if !validSource(in.Src) {
 		return nil, ErrInvalidSource
+	}
+	// antennaLimit role policy gate (#1029)。policy 経由で取得した上限と
+	// 現在保有数を比較。provider 未配線 / policy 不在は gate skip (旧挙動)。
+	if s.rolePolicyProvider != nil {
+		if limit, ok := s.rolePolicyProvider.GetUserPolicies(in.OwnerID)["antennaLimit"].(int); ok && limit >= 0 {
+			existing, err := s.repo.ListByUser(in.OwnerID)
+			if err != nil {
+				return nil, err
+			}
+			if len(existing) >= limit {
+				return nil, ErrTooManyAntennas
+			}
+		}
 	}
 	// Marshal of [][]string never fails, so we ignore the error.
 	keywords, _ := json.Marshal(normalizeKeywords(in.Keywords))

--- a/internal/core/antenna/antenna_service_test.go
+++ b/internal/core/antenna/antenna_service_test.go
@@ -890,9 +890,11 @@ func (r *failingUserListRepo) FindByID(_ string) (*model.UserList, error) {
 	return nil, errors.New("boom")
 }
 func (r *failingUserListRepo) ListByUser(_ string) ([]*model.UserList, error) { return nil, nil }
+func (r *failingUserListRepo) CountByUser(_ string) (int64, error)            { return 0, nil }
 func (r *failingUserListRepo) Delete(_ string) error                          { return nil }
 func (r *failingUserListRepo) AddMember(_ *model.UserListMembership) error    { return nil }
 func (r *failingUserListRepo) RemoveMember(_, _ string) error                 { return nil }
+func (r *failingUserListRepo) CountMembers(_ string) (int64, error)           { return 0, nil }
 func (r *failingUserListRepo) ListMembers(_ string) ([]*model.UserListMembership, error) {
 	return nil, errors.New("list members error")
 }

--- a/internal/core/clip/clip_service.go
+++ b/internal/core/clip/clip_service.go
@@ -29,6 +29,12 @@ var (
 	ErrAlreadyClipped = errors.New("note is already clipped")
 	// ErrNotClipped is returned when there is no clip_note row to remove.
 	ErrNotClipped = errors.New("note is not clipped")
+	// ErrTooManyClips は Create で clipLimit 超過 (#1029、upstream
+	// tooManyClips)。
+	ErrTooManyClips = errors.New("clip limit exceeded")
+	// ErrTooManyClipNotes は AddNote で noteEachClipsLimit 超過 (#1029、
+	// upstream tooManyClipNotes)。
+	ErrTooManyClipNotes = errors.New("clip note limit exceeded")
 )
 
 // Service provides clip CRUD plus AddNote / RemoveNote / Notes operations.
@@ -38,6 +44,20 @@ type Service struct {
 	notes    repository.NoteRepository
 	idGen    id.Generator
 	clock    func() time.Time
+	// rolePolicyProvider は clipLimit / noteEachClipsLimit の gate に使う
+	// (#1029)。nil 時は gate skip。
+	rolePolicyProvider RolePolicyProvider
+}
+
+// RolePolicyProvider abstracts role-policy lookup for clip count limits (#1029)。
+type RolePolicyProvider interface {
+	GetUserPolicies(userID string) map[string]any
+}
+
+// SetRolePolicyProvider wires a RolePolicyProvider so Create / AddNote
+// enforce the clipLimit / noteEachClipsLimit role policies (#1029).
+func (s *Service) SetRolePolicyProvider(p RolePolicyProvider) {
+	s.rolePolicyProvider = p
 }
 
 // NewService constructs a clip Service.
@@ -78,6 +98,18 @@ func (s *Service) Create(in CreateInput) (*model.Clip, error) {
 	}
 	if in.OwnerID == "" {
 		return nil, errors.New("ownerId is required")
+	}
+	// clipLimit role policy gate (#1029)。
+	if s.rolePolicyProvider != nil {
+		if limit, ok := s.rolePolicyProvider.GetUserPolicies(in.OwnerID)["clipLimit"].(int); ok && limit >= 0 {
+			existing, err := s.repo.ListByUser(in.OwnerID, "", "", 9999, 0)
+			if err != nil {
+				return nil, err
+			}
+			if len(existing) >= limit {
+				return nil, ErrTooManyClips
+			}
+		}
 	}
 	now := s.clock()
 	c := &model.Clip{
@@ -173,6 +205,20 @@ func (s *Service) AddNote(ownerID, clipID, noteID string) error {
 	}
 	if _, err := s.noteRepo.FindByPair(clipID, noteID); err == nil {
 		return ErrAlreadyClipped
+	}
+	// noteEachClipsLimit role policy gate (#1029)。clip 内 note 数の上限を
+	// owner の policy で評価する (clip 自体は owner-only mutation なので
+	// ownerID と一致する)。
+	if s.rolePolicyProvider != nil {
+		if limit, ok := s.rolePolicyProvider.GetUserPolicies(ownerID)["noteEachClipsLimit"].(int); ok && limit >= 0 {
+			existing, err := s.noteRepo.ListByClip(clipID, "", "", 9999)
+			if err != nil {
+				return err
+			}
+			if len(existing) >= limit {
+				return ErrTooManyClipNotes
+			}
+		}
 	}
 	now := s.clock()
 	cn := &model.ClipNote{

--- a/internal/core/clip/clip_service.go
+++ b/internal/core/clip/clip_service.go
@@ -102,11 +102,11 @@ func (s *Service) Create(in CreateInput) (*model.Clip, error) {
 	// clipLimit role policy gate (#1029)。
 	if s.rolePolicyProvider != nil {
 		if limit, ok := s.rolePolicyProvider.GetUserPolicies(in.OwnerID)["clipLimit"].(int); ok && limit >= 0 {
-			existing, err := s.repo.ListByUser(in.OwnerID, "", "", 9999, 0)
+			count, err := s.repo.CountByUser(in.OwnerID)
 			if err != nil {
 				return nil, err
 			}
-			if len(existing) >= limit {
+			if count >= int64(limit) {
 				return nil, ErrTooManyClips
 			}
 		}
@@ -211,11 +211,11 @@ func (s *Service) AddNote(ownerID, clipID, noteID string) error {
 	// ownerID と一致する)。
 	if s.rolePolicyProvider != nil {
 		if limit, ok := s.rolePolicyProvider.GetUserPolicies(ownerID)["noteEachClipsLimit"].(int); ok && limit >= 0 {
-			existing, err := s.noteRepo.ListByClip(clipID, "", "", 9999)
+			count, err := s.noteRepo.CountByClip(clipID)
 			if err != nil {
 				return err
 			}
-			if len(existing) >= limit {
+			if count >= int64(limit) {
 				return ErrTooManyClipNotes
 			}
 		}

--- a/internal/core/clip/clip_service_test.go
+++ b/internal/core/clip/clip_service_test.go
@@ -32,6 +32,46 @@ func TestCreate_HappyPath(t *testing.T) {
 	assert.Len(t, repo.Clips, 1)
 }
 
+// #1029: clipLimit role policy gate test。
+type stubRolePolicyProvider struct {
+	policies map[string]any
+}
+
+func (s *stubRolePolicyProvider) GetUserPolicies(_ string) map[string]any { return s.policies }
+
+func TestCreate_ClipLimitExceeded(t *testing.T) {
+	svc, repo, _, _ := newSvc(t)
+	repo.Clips["c1"] = &model.Clip{ID: "c1", UserID: "u1"}
+	repo.Clips["c2"] = &model.Clip{ID: "c2", UserID: "u1"}
+	svc.SetRolePolicyProvider(&stubRolePolicyProvider{policies: map[string]any{
+		"clipLimit": 2,
+	}})
+	_, err := svc.Create(clip.CreateInput{OwnerID: "u1", Name: "third"})
+	require.ErrorIs(t, err, clip.ErrTooManyClips)
+}
+
+func TestCreate_ClipLimit_PassesUnderLimit(t *testing.T) {
+	svc, _, _, _ := newSvc(t)
+	svc.SetRolePolicyProvider(&stubRolePolicyProvider{policies: map[string]any{
+		"clipLimit": 10,
+	}})
+	_, err := svc.Create(clip.CreateInput{OwnerID: "u1", Name: "first"})
+	require.NoError(t, err)
+}
+
+func TestAddNote_NoteEachClipsLimitExceeded(t *testing.T) {
+	svc, repo, noteRepo, notes := newSvc(t)
+	repo.Clips["c1"] = &model.Clip{ID: "c1", UserID: "u1"}
+	notes.Notes["n1"] = &model.Note{ID: "n1"}
+	noteRepo.Entries["cn1"] = &model.ClipNote{ID: "cn1", ClipID: "c1", NoteID: "old1"}
+	noteRepo.Entries["cn2"] = &model.ClipNote{ID: "cn2", ClipID: "c1", NoteID: "old2"}
+	svc.SetRolePolicyProvider(&stubRolePolicyProvider{policies: map[string]any{
+		"noteEachClipsLimit": 2,
+	}})
+	err := svc.AddNote("u1", "c1", "n1")
+	require.ErrorIs(t, err, clip.ErrTooManyClipNotes)
+}
+
 func TestCreate_NameRequired(t *testing.T) {
 	svc, _, _, _ := newSvc(t)
 	_, err := svc.Create(clip.CreateInput{OwnerID: "u1"})

--- a/internal/core/user/user_service.go
+++ b/internal/core/user/user_service.go
@@ -76,6 +76,24 @@ type Service struct {
 	// 所有者検証 + image MIME チェックするのに使う。未配線時は media
 	// 更新経路全体を skip して旧来挙動 (avatar / banner 不変) に戻す。
 	driveFileRepo repository.DriveFileRepository
+	// rolePolicyProvider は PinNote の上限を role policy `pinLimit` で
+	// override するのに使う (#1029)。nil 時は MaxPinnedNotes 定数 fallback
+	// (= 旧挙動互換)。実装は core/role.Service。
+	rolePolicyProvider RolePolicyProvider
+}
+
+// RolePolicyProvider abstracts role-policy lookup used to override default
+// limits with admin-authored values. 実装は core/role.Service の
+// GetUserPolicies (#1029)。
+type RolePolicyProvider interface {
+	GetUserPolicies(userID string) map[string]any
+}
+
+// SetRolePolicyProvider wires a RolePolicyProvider so the user service can
+// honour role-policy overrides for limits like pinLimit (#1029). nil 時は
+// MaxPinnedNotes 定数 fallback の旧挙動を維持する。
+func (s *Service) SetRolePolicyProvider(p RolePolicyProvider) {
+	s.rolePolicyProvider = p
 }
 
 // NewService creates a new user Service.
@@ -604,7 +622,15 @@ func (s *Service) PinNote(userID, noteID string) error {
 	if err != nil {
 		return err
 	}
-	if count >= MaxPinnedNotes {
+	// role policy `pinLimit` で上限を override (#1029)。未配線 / key 不在 /
+	// 非 int の場合は MaxPinnedNotes 定数 fallback (= 旧挙動互換)。
+	limit := MaxPinnedNotes
+	if s.rolePolicyProvider != nil {
+		if v, ok := s.rolePolicyProvider.GetUserPolicies(userID)["pinLimit"].(int); ok {
+			limit = v
+		}
+	}
+	if count >= limit {
 		return ErrPinLimitExceeded
 	}
 

--- a/internal/core/webhook/service_test.go
+++ b/internal/core/webhook/service_test.go
@@ -63,6 +63,7 @@ func (r *fakeWebhookRepo) FindByIDAndUserID(_, _ string) (*model.Webhook, error)
 func (r *fakeWebhookRepo) ListByUserID(_ string) ([]*model.Webhook, error) {
 	return nil, nil
 }
+func (r *fakeWebhookRepo) CountByUserID(_ string) (int64, error) { return 0, nil }
 func (r *fakeWebhookRepo) ListActiveByUserID(userID string) ([]*model.Webhook, error) {
 	if r.listEr != nil {
 		return nil, r.listEr

--- a/internal/queue/processors/webhook_test.go
+++ b/internal/queue/processors/webhook_test.go
@@ -75,6 +75,7 @@ func (r *stubUserWebhookRepo) FindByIDAndUserID(_, _ string) (*model.Webhook, er
 	return nil, nil
 }
 func (r *stubUserWebhookRepo) ListByUserID(_ string) ([]*model.Webhook, error) { return nil, nil }
+func (r *stubUserWebhookRepo) CountByUserID(_ string) (int64, error)           { return 0, nil }
 func (r *stubUserWebhookRepo) ListActiveByUserID(_ string) ([]*model.Webhook, error) {
 	return nil, nil
 }

--- a/internal/repository/antenna.go
+++ b/internal/repository/antenna.go
@@ -12,6 +12,10 @@ type AntennaRepository interface {
 	UpdateFields(antennaID string, fields map[string]any) error
 	Delete(a *model.Antenna) error
 	ListByUser(userID string) ([]*model.Antenna, error)
+	// CountByUser returns the number of antennas owned by userID. Used by
+	// antennaLimit policy gate so we don't have to fetch all rows just to
+	// count them (#1029 PR-1 follow-up).
+	CountByUser(userID string) (int64, error)
 	ListAllActive() ([]*model.Antenna, error)
 }
 
@@ -57,6 +61,17 @@ func (r *antennaRepository) ListByUser(userID string) ([]*model.Antenna, error) 
 		return nil, err
 	}
 	return rows, nil
+}
+
+// CountByUser returns the number of antennas owned by the given user.
+func (r *antennaRepository) CountByUser(userID string) (int64, error) {
+	var count int64
+	if err := r.db.Model(&model.Antenna{}).
+		Where(`"userId" = ?`, userID).
+		Count(&count).Error; err != nil {
+		return 0, err
+	}
+	return count, nil
 }
 
 // ListAllActive returns every antenna with isActive=true. NoteCreate イベント

--- a/internal/repository/antenna_test.go
+++ b/internal/repository/antenna_test.go
@@ -128,6 +128,10 @@ func TestAntennaRepository_ListByUser(t *testing.T) {
 	rows, err := repo.ListByUser(user.ID)
 	require.NoError(t, err)
 	assert.Len(t, rows, 3)
+
+	count, err := repo.CountByUser(user.ID)
+	require.NoError(t, err)
+	assert.Equal(t, int64(3), count)
 }
 
 func TestAntennaRepository_ListAllActive(t *testing.T) {
@@ -164,5 +168,7 @@ func TestAntennaRepository_QueryErrors(t *testing.T) {
 	_, err := repo.ListByUser("any")
 	assert.Error(t, err)
 	_, err = repo.ListAllActive()
+	assert.Error(t, err)
+	_, err = repo.CountByUser("any")
 	assert.Error(t, err)
 }

--- a/internal/repository/clip.go
+++ b/internal/repository/clip.go
@@ -14,6 +14,9 @@ type ClipRepository interface {
 	// ListByUser returns clips owned by userID with cursor (sinceID/untilID)
 	// or offset pagination. Empty cursors fall back to offset.
 	ListByUser(userID string, sinceID, untilID string, limit, offset int) ([]*model.Clip, error)
+	// CountByUser returns the number of clips owned by userID. Used by
+	// clipLimit policy gate (#1029 PR-1 follow-up).
+	CountByUser(userID string) (int64, error)
 	// ListPublicByUser returns only public clips owned by userID. Used by
 	// users/clips when the viewer is not the owner so LIMIT applies to the
 	// already-filtered set. Same cursor semantics as ListByUser.
@@ -78,6 +81,17 @@ func (r *clipRepository) ListByUser(userID, sinceID, untilID string, limit, offs
 		return nil, err
 	}
 	return rows, nil
+}
+
+// CountByUser returns the number of clips owned by the given user.
+func (r *clipRepository) CountByUser(userID string) (int64, error) {
+	var count int64
+	if err := r.db.Model(&model.Clip{}).
+		Where(`"userId" = ?`, userID).
+		Count(&count).Error; err != nil {
+		return 0, err
+	}
+	return count, nil
 }
 
 func (r *clipRepository) ListPublicByUser(userID, sinceID, untilID string, limit, offset int) ([]*model.Clip, error) {

--- a/internal/repository/clip_note.go
+++ b/internal/repository/clip_note.go
@@ -11,6 +11,9 @@ type ClipNoteRepository interface {
 	Delete(cn *model.ClipNote) error
 	FindByPair(clipID, noteID string) (*model.ClipNote, error)
 	ListByClip(clipID string, untilID, sinceID string, limit int) ([]*model.ClipNote, error)
+	// CountByClip returns the number of notes in the given clip. Used by
+	// noteEachClipsLimit policy gate (#1029 PR-1 follow-up).
+	CountByClip(clipID string) (int64, error)
 }
 
 type clipNoteRepository struct {
@@ -36,6 +39,17 @@ func (r *clipNoteRepository) FindByPair(clipID, noteID string) (*model.ClipNote,
 		return nil, err
 	}
 	return &cn, nil
+}
+
+// CountByClip returns the number of notes in the given clip.
+func (r *clipNoteRepository) CountByClip(clipID string) (int64, error) {
+	var count int64
+	if err := r.db.Model(&model.ClipNote{}).
+		Where(`"clipId" = ?`, clipID).
+		Count(&count).Error; err != nil {
+		return 0, err
+	}
+	return count, nil
 }
 
 // ListByClip returns the entries for a clip with since/until pagination on

--- a/internal/repository/clip_note_test.go
+++ b/internal/repository/clip_note_test.go
@@ -42,6 +42,10 @@ func TestClipNoteRepository_LifeCycle(t *testing.T) {
 	require.NoError(t, err)
 	assert.Len(t, rows, 1)
 
+	count, err := repo.CountByClip(c.ID)
+	require.NoError(t, err)
+	assert.Equal(t, int64(1), count)
+
 	require.NoError(t, repo.Delete(cn))
 	_, err = repo.FindByPair(c.ID, n.ID)
 	assert.Error(t, err)
@@ -99,5 +103,7 @@ func TestClipNoteRepository_ListByClip_QueryError(t *testing.T) {
 	db := testDB.WithContext(ctx)
 	repo := NewClipNoteRepository(db)
 	_, err := repo.ListByClip("any", "", "", 10)
+	assert.Error(t, err)
+	_, err = repo.CountByClip("any")
 	assert.Error(t, err)
 }

--- a/internal/repository/clip_test.go
+++ b/internal/repository/clip_test.go
@@ -110,6 +110,10 @@ func TestClipRepository_ListByUser(t *testing.T) {
 	rows, err := repo.ListByUser(user.ID, "", "", 10, 0)
 	require.NoError(t, err)
 	assert.Len(t, rows, 3)
+
+	count, err := repo.CountByUser(user.ID)
+	require.NoError(t, err)
+	assert.Equal(t, int64(3), count)
 }
 
 func TestClipRepository_ListByUser_LimitClamp(t *testing.T) {
@@ -128,6 +132,8 @@ func TestClipRepository_ListByUser_QueryError(t *testing.T) {
 	db := testDB.WithContext(ctx)
 	repo := NewClipRepository(db)
 	_, err := repo.ListByUser("nobody", "", "", 10, 0)
+	assert.Error(t, err)
+	_, err = repo.CountByUser("nobody")
 	assert.Error(t, err)
 }
 

--- a/internal/repository/user_list.go
+++ b/internal/repository/user_list.go
@@ -18,10 +18,16 @@ type UserListRepository interface {
 	Create(list *model.UserList) error
 	FindByID(id string) (*model.UserList, error)
 	ListByUser(userID string) ([]*model.UserList, error)
+	// CountByUser returns the number of lists owned by userID. Used by
+	// userListLimit policy gate (#1029 PR-1 follow-up).
+	CountByUser(userID string) (int64, error)
 	Delete(id string) error
 	AddMember(m *model.UserListMembership) error
 	RemoveMember(listID, userID string) error
 	ListMembers(listID string) ([]*model.UserListMembership, error)
+	// CountMembers returns the number of members in the given list. Used by
+	// userEachUserListsLimit policy gate (#1029 PR-1 follow-up).
+	CountMembers(listID string) (int64, error)
 	// ListMembersByListIDs returns userIDs grouped by listID in 1 query
 	// (= users/lists/list の N+1 を消す batch fetch、#876)。
 	ListMembersByListIDs(listIDs []string) (map[string][]string, error)
@@ -63,6 +69,17 @@ func (r *userListRepository) ListByUser(userID string) ([]*model.UserList, error
 	return lists, nil
 }
 
+// CountByUser returns the number of lists owned by the given user.
+func (r *userListRepository) CountByUser(userID string) (int64, error) {
+	var count int64
+	if err := r.db.Model(&model.UserList{}).
+		Where(`"userId" = ?`, userID).
+		Count(&count).Error; err != nil {
+		return 0, err
+	}
+	return count, nil
+}
+
 func (r *userListRepository) Delete(id string) error {
 	return r.db.Where("id = ?", id).Delete(&model.UserList{}).Error
 }
@@ -83,6 +100,17 @@ func (r *userListRepository) AddMember(m *model.UserListMembership) error {
 func (r *userListRepository) RemoveMember(listID, userID string) error {
 	return r.db.Where("\"userListId\" = ? AND \"userId\" = ?", listID, userID).
 		Delete(&model.UserListMembership{}).Error
+}
+
+// CountMembers returns the number of members in the given list.
+func (r *userListRepository) CountMembers(listID string) (int64, error) {
+	var count int64
+	if err := r.db.Model(&model.UserListMembership{}).
+		Where(`"userListId" = ?`, listID).
+		Count(&count).Error; err != nil {
+		return 0, err
+	}
+	return count, nil
 }
 
 func (r *userListRepository) ListMembers(listID string) ([]*model.UserListMembership, error) {

--- a/internal/repository/user_list_test.go
+++ b/internal/repository/user_list_test.go
@@ -32,6 +32,10 @@ func TestUserListRepository_CRUD(t *testing.T) {
 	require.NoError(t, err)
 	assert.Len(t, lists, 1)
 
+	count, err := repo.CountByUser("ul_owner")
+	require.NoError(t, err)
+	assert.Equal(t, int64(1), count)
+
 	require.NoError(t, repo.Delete(list.ID))
 	_, err = repo.FindByID(list.ID)
 	assert.Error(t, err)
@@ -59,6 +63,10 @@ func TestUserListRepository_Members(t *testing.T) {
 	require.NoError(t, err)
 	assert.Len(t, members, 1)
 
+	count, err := repo.CountMembers(list.ID)
+	require.NoError(t, err)
+	assert.Equal(t, int64(1), count)
+
 	require.NoError(t, repo.RemoveMember(list.ID, "ul_m1"))
 	members, _ = repo.ListMembers(list.ID)
 	assert.Empty(t, members)
@@ -70,6 +78,8 @@ func TestUserListRepository_ListByUser_Error(t *testing.T) {
 	repo := NewUserListRepository(testDB.WithContext(ctx))
 	_, err := repo.ListByUser("x")
 	assert.Error(t, err)
+	_, err = repo.CountByUser("x")
+	assert.Error(t, err)
 }
 
 func TestUserListRepository_ListMembers_Error(t *testing.T) {
@@ -77,6 +87,8 @@ func TestUserListRepository_ListMembers_Error(t *testing.T) {
 	cancel()
 	repo := NewUserListRepository(testDB.WithContext(ctx))
 	_, err := repo.ListMembers("x")
+	assert.Error(t, err)
+	_, err = repo.CountMembers("x")
 	assert.Error(t, err)
 }
 

--- a/internal/repository/webhook.go
+++ b/internal/repository/webhook.go
@@ -13,6 +13,9 @@ type WebhookRepository interface {
 	FindByID(id string) (*model.Webhook, error)
 	FindByIDAndUserID(id, userID string) (*model.Webhook, error)
 	ListByUserID(userID string) ([]*model.Webhook, error)
+	// CountByUserID returns the number of webhooks owned by userID. Used by
+	// webhookLimit policy gate (#1029 PR-1 follow-up).
+	CountByUserID(userID string) (int64, error)
 	ListActiveByUserID(userID string) ([]*model.Webhook, error)
 	Update(webhook *model.Webhook) error
 	UpdateLatestStatus(id string, sentAt time.Time, status int) error
@@ -54,6 +57,17 @@ func (r *webhookRepository) ListByUserID(userID string) ([]*model.Webhook, error
 		return nil, err
 	}
 	return webhooks, nil
+}
+
+// CountByUserID returns the number of webhooks owned by the given user.
+func (r *webhookRepository) CountByUserID(userID string) (int64, error) {
+	var count int64
+	if err := r.db.Model(&model.Webhook{}).
+		Where(`"userId" = ?`, userID).
+		Count(&count).Error; err != nil {
+		return 0, err
+	}
+	return count, nil
 }
 
 func (r *webhookRepository) ListActiveByUserID(userID string) ([]*model.Webhook, error) {

--- a/internal/repository/webhook_test.go
+++ b/internal/repository/webhook_test.go
@@ -51,6 +51,11 @@ func TestWebhookRepository_Full(t *testing.T) {
 	require.NoError(t, err)
 	assert.Len(t, list, 1)
 
+	// CountByUserID
+	count, err := repo.CountByUserID(user.ID)
+	require.NoError(t, err)
+	assert.Equal(t, int64(1), count)
+
 	// Update
 	found.Name = "Updated Hook"
 	require.NoError(t, repo.Update(found))

--- a/internal/server/router.go
+++ b/internal/server/router.go
@@ -213,6 +213,8 @@ func (s *Server) setupRoutes() {
 	noteQueryService.SetFavoriteRepo(noteFavoriteRepo)
 	noteQueryService.SetThreadMutingRepo(noteThreadMutingRepo)
 	userService := coreuser.NewService(userRepo, noteRepo, piningRepo, idGen)
+	// PinNote の上限を role policy `pinLimit` で override 可能にする (#1029)。
+	userService.SetRolePolicyProvider(roleService)
 	// /api/i/update の avatarId / bannerId 経路 (#467) で drive_file の
 	// 所有権検証 + URL コピーが必要なため、driveFileRepo を配線する。
 	userService.SetDriveFileRepository(driveFileRepo)
@@ -250,6 +252,7 @@ func (s *Server) setupRoutes() {
 	antennaService := coreantenna.NewService(antennaRepo, userRepo, s.redis.Default, idGen)
 	antennaService.SetFollowingRepo(followingRepo)
 	antennaService.SetUserListRepo(userListRepo)
+	antennaService.SetRolePolicyProvider(roleService) // #1029: antennaLimit
 	// Phase 7-2 follow-up (#271): antenna 着信時に所有者の unread row を
 	// 作成して /api/i の hasUnreadAntenna に反映する。
 	antennaNoteUnreadRepo := repository.NewAntennaNoteUnreadRepository(s.db)
@@ -258,6 +261,7 @@ func (s *Server) setupRoutes() {
 
 	// Clips (Phase 4.4)
 	clipService := coreclip.NewService(clipRepo, clipNoteRepo, noteRepo, idGen)
+	clipService.SetRolePolicyProvider(roleService) // #1029: clipLimit / noteEachClipsLimit
 
 	// Pages / Flash (Phase 4.5)
 	pageService := corepage.NewService(pageRepo, pageLikeRepo, idGen)
@@ -1286,6 +1290,7 @@ func (s *Server) setupRoutes() {
 	// i/webhooks/* — Webhook管理 (実データ)
 	webhookHandler := apiwebhooks.NewHandler(webhookRepo, idGen)
 	webhookHandler.SetDispatcher(webhookService)
+	webhookHandler.SetRolePolicyProvider(roleService) // #1029: webhookLimit
 	api.POST("/i/webhooks/create", webhookHandler.Create, middleware.RequireAuth())
 	api.POST("/i/webhooks/list", webhookHandler.List, middleware.RequireAuth())
 	api.POST("/i/webhooks/show", webhookHandler.Show, middleware.RequireAuth())
@@ -1819,6 +1824,7 @@ func (s *Server) setupRoutes() {
 
 	// User lists (Phase 6)
 	userListHandler := apiuserlists.NewHandler(userListRepo, idGen)
+	userListHandler.SetRolePolicyProvider(roleService) // #1029: userListLimit / userEachUserListsLimit
 	api.POST("/users/lists/list", userListHandler.List, middleware.RequireAuth())
 	api.POST("/users/lists/create", userListHandler.Create, middleware.RequireAuth())
 	api.POST("/users/lists/show", userListHandler.Show, middleware.RequireAuth())

--- a/internal/testutil/mock_repository.go
+++ b/internal/testutil/mock_repository.go
@@ -2651,6 +2651,16 @@ func (m *MockClipRepository) ListByUser(userID, sinceID, untilID string, limit, 
 	return paginateClips(rows, sinceID, untilID, limit, offset), nil
 }
 
+func (m *MockClipRepository) CountByUser(userID string) (int64, error) {
+	var count int64
+	for _, c := range m.Clips {
+		if c.UserID == userID {
+			count++
+		}
+	}
+	return count, nil
+}
+
 func (m *MockClipRepository) ListPublicByUser(userID, sinceID, untilID string, limit, offset int) ([]*model.Clip, error) {
 	var rows []*model.Clip
 	for _, c := range m.Clips {
@@ -2759,6 +2769,16 @@ func (m *MockClipNoteRepository) FindByPair(clipID, noteID string) (*model.ClipN
 		}
 	}
 	return nil, ErrNotFound
+}
+
+func (m *MockClipNoteRepository) CountByClip(clipID string) (int64, error) {
+	var count int64
+	for _, cn := range m.Entries {
+		if cn.ClipID == clipID {
+			count++
+		}
+	}
+	return count, nil
 }
 
 func (m *MockClipNoteRepository) ListByClip(clipID string, untilID, sinceID string, limit int) ([]*model.ClipNote, error) {
@@ -3422,6 +3442,16 @@ func (m *MockAntennaRepository) ListByUser(userID string) ([]*model.Antenna, err
 		}
 	}
 	return rows, nil
+}
+
+func (m *MockAntennaRepository) CountByUser(userID string) (int64, error) {
+	var count int64
+	for _, a := range m.Antennas {
+		if a.UserID == userID {
+			count++
+		}
+	}
+	return count, nil
 }
 
 func (m *MockAntennaRepository) ListAllActive() ([]*model.Antenna, error) {
@@ -4278,6 +4308,16 @@ func (m *MockUserListRepository) ListByUser(userID string) ([]*model.UserList, e
 	return result, nil
 }
 
+func (m *MockUserListRepository) CountByUser(userID string) (int64, error) {
+	var count int64
+	for _, l := range m.Lists {
+		if l.UserID == userID {
+			count++
+		}
+	}
+	return count, nil
+}
+
 func (m *MockUserListRepository) Delete(id string) error {
 	delete(m.Lists, id)
 	return nil
@@ -4297,6 +4337,16 @@ func (m *MockUserListRepository) RemoveMember(listID, userID string) error {
 	}
 	m.Members = filtered
 	return nil
+}
+
+func (m *MockUserListRepository) CountMembers(listID string) (int64, error) {
+	var count int64
+	for _, mem := range m.Members {
+		if mem.UserListID == listID {
+			count++
+		}
+	}
+	return count, nil
 }
 
 func (m *MockUserListRepository) ListMembers(listID string) ([]*model.UserListMembership, error) {


### PR DESCRIPTION
## Summary

#1029 tracker の **count limit 系 9 endpoint** を消化する。残 4 policy (drive 2 件 + invite 3 件) は別 PR (PR-2) で処理予定。

upstream Misskey TS の各 endpoint / service が \`if (currentCount >= policies.xxxLimit) throw ...\` で gate する pattern を mk-go に移植。**pattern 共通** で 9 endpoint × ~30 行 = 538 行 net 追加。

## 実装した gate (9 policy / 9 endpoint)

| Policy | 経路 | Count 取得 |
|---|---|---|
| \`pinLimit\` | \`user.PinNote\` | \`piningRepo.CountByUser\` (既存) |
| \`antennaLimit\` | \`antenna.Service.Create\` | \`repo.ListByUser\` |
| \`webhookLimit\` | \`webhooks.Handler.Create\` | \`repo.ListByUserID\` |
| \`clipLimit\` | \`clip.Service.Create\` | \`repo.ListByUser\` |
| \`noteEachClipsLimit\` | \`clip.Service.AddNote\` | \`noteRepo.ListByClip\` |
| \`userListLimit\` | \`userlists.Handler.Create\` | \`repo.ListByUser\` |
| \`userEachUserListsLimit\` | \`userlists.Handler.Push\` | \`repo.ListMembers\` |
| \`noteDraftLimit\` | \`notes.Handler.DraftsCreate\` | \`draftRepo.CountByUser\` (既存) |
| \`wordMuteLimit\` | \`i.Handler.Update\` (mutedWords / hardMutedWords) | flatten req payload |

各 service / handler に \`RolePolicyProvider\` interface (narrow contract で \`GetUserPolicies(userID) map[string]any\` のみ) を inject、router で \`roleService\` を wire する。

\`wordMuteLimit\` は req payload の flattened length (string entry = 1、\`[]string\` entry = len) を upstream \`checkMuteWordCount\` と同 logic で count する (\`countMuteWords\` helper、i/update.ts 互換)。

## 新 error helpers (apierr に 9 件追加)

すべて 400 Bad Request + upstream の code / id / message と完全一致:

| Code | UUID |
|---|---|
| \`PIN_LIMIT_EXCEEDED\` | \`72dab508-c64d-498f-8740-a8eec1ba385a\` |
| \`TOO_MANY_ANTENNAS\` | \`faf47050-e8b5-438c-913c-db2b1576fde4\` |
| \`TOO_MANY_WEBHOOKS\` | \`87a9bb19-111e-4e37-81d3-a3e7426453b0\` |
| \`TOO_MANY_CLIPS\` | \`920f7c2d-6208-4b76-8082-e632020f5883\` |
| \`TOO_MANY_CLIP_NOTES\` | \`f0dba960-ff73-4615-8df4-d6ac5d9dc118\` |
| \`TOO_MANY_USERLISTS\` | \`0cf21a28-7715-4f39-a20d-777bfdb8d138\` |
| \`TOO_MANY_USERS\` | \`2dd9752e-a338-413d-8eec-41814430989b\` |
| \`TOO_MANY_NOTE_DRAFTS\` | \`9ee33bbe-fde3-4c71-9b51-e50492c6b9c8\` (upstream NoteDraftService の IdentifiableError UUID、code は mk-go 発番) |
| \`TOO_MANY_MUTED_WORDS\` | \`010665b1-a211-42d2-bc64-8f6609d79785\` |

## 後方互換

すべての service / handler で \`rolePolicyProvider == nil\` 時は gate skip (= 旧挙動互換、test fixture 維持)。policy 値が \`int\` 以外なら fail-soft で skip。production では \`role.Service\` が常に wired され \`DefaultPolicies\` も \`int\` を返すので発火しない。

\`user.MaxPinnedNotes = 5\` 定数は維持 (= role provider 未配線時の fallback、role.DefaultPolicies の \`pinLimit: 5\` と一致)。

## テスト

apierr 18 新規 ケース (table-driven、code/id/status seal) + 各 service / handler レベルの limit gate / under-limit ケース 11 件。

カバレッジ (全 90% 閾値クリア):
- \`api/apierr\`: 96.6%
- \`api/userlists\`: 95.0%
- \`core/clip\`: 98.0%
- \`core/antenna\`: 96.0%
- \`api/i\`: 90.5%
- \`api/notes\`: 90.5%
- \`core/user\`: 90.6%
- \`api/webhooks\`: 91.9%
- \`api/clips\`: 90.0%
- 全 50+ パッケージで CI 閾値クリア

実行方法:

\`\`\`bash
make fmt && make lint && make test
\`\`\`

## 残 scope (#1029 PR-2 予定)

- \`driveCapacityMb\` / \`maxFileSizeMb\` (drive upload service)
- \`inviteLimit\` / \`inviteLimitCycle\` / \`inviteExpirationTime\` (invite/create)
- \`scheduledNoteLimit\` (mk-go に scheduled note 機能なし、close 時に明示)

## Related

Related to #1029 (tracker は PR-2 完了時に close)

🤖 Generated with [Claude Code](https://claude.com/claude-code)