### PR TITLE
feat(role): drive (capacity/size) + invite (3 policy) の handler enforcement (#1029 PR-2)

### DIFF
--- a/internal/api/apierr/echo.go
+++ b/internal/api/apierr/echo.go
@@ -111,6 +111,22 @@ func JSONTooManyMutedWords(c echo.Context) error {
 	return c.JSON(http.StatusBadRequest, TooManyMutedWords())
 }
 
+// JSONExceededLimitOfCreateInviteCode writes a 400 response thrown when the
+// inviteLimit / inviteLimitCycle policy is exceeded.
+func JSONExceededLimitOfCreateInviteCode(c echo.Context) error {
+	return c.JSON(http.StatusBadRequest, ExceededLimitOfCreateInviteCode())
+}
+
+// JSONMaxFileSizeExceeded writes a 400 MAX_FILE_SIZE_EXCEEDED response.
+func JSONMaxFileSizeExceeded(c echo.Context) error {
+	return c.JSON(http.StatusBadRequest, MaxFileSizeExceeded())
+}
+
+// JSONNoFreeSpace writes a 400 NO_FREE_SPACE response.
+func JSONNoFreeSpace(c echo.Context) error {
+	return c.JSON(http.StatusBadRequest, NoFreeSpace())
+}
+
 // JSONNoSuchRenoteTarget writes a 404 NO_SUCH_RENOTE_TARGET response to the client.
 func JSONNoSuchRenoteTarget(c echo.Context) error {
 	return c.JSON(http.StatusNotFound, NoSuchRenoteTarget())

--- a/internal/api/apierr/echo_test.go
+++ b/internal/api/apierr/echo_test.go
@@ -141,6 +141,9 @@ func TestJSONCountLimitHelpers(t *testing.T) {
 		{"TooManyUsers", JSONTooManyUsers, "TOO_MANY_USERS", UUIDTooManyUsers},
 		{"TooManyNoteDrafts", JSONTooManyNoteDrafts, "TOO_MANY_NOTE_DRAFTS", UUIDTooManyNoteDrafts},
 		{"TooManyMutedWords", JSONTooManyMutedWords, "TOO_MANY_MUTED_WORDS", UUIDTooManyMutedWords},
+		{"ExceededLimitOfCreateInviteCode", JSONExceededLimitOfCreateInviteCode, "EXCEEDED_LIMIT_OF_CREATE_INVITE_CODE", UUIDExceededLimitOfCreateInviteCode},
+		{"MaxFileSizeExceeded", JSONMaxFileSizeExceeded, "MAX_FILE_SIZE_EXCEEDED", UUIDMaxFileSizeExceeded},
+		{"NoFreeSpace", JSONNoFreeSpace, "NO_FREE_SPACE", UUIDNoFreeSpace},
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {

--- a/internal/api/apierr/errors.go
+++ b/internal/api/apierr/errors.go
@@ -70,6 +70,12 @@ const (
 	UUIDTooManyNoteDrafts = "9ee33bbe-fde3-4c71-9b51-e50492c6b9c8" // notes/drafts/create
 	UUIDTooManyMutedWords = "010665b1-a211-42d2-bc64-8f6609d79785" // i/update mutedWords
 
+	// 以下は #1029 PR-2 (drive + invite policy enforcement) で使う UUID。
+	// upstream Misskey TS の対応 endpoint と完全一致 (= drop-in 互換)。
+	UUIDExceededLimitOfCreateInviteCode = "8b165dd3-6f37-4557-8db1-73175d63c641" // invite/create
+	UUIDMaxFileSizeExceeded             = "f9e4e5f3-4df4-40b5-b400-f236945f7073" // drive/files/create (maxFileSizeMb)
+	UUIDNoFreeSpace                     = "c6244ed2-a39a-4e1c-bf93-f0fbd7764fa6" // drive/files/create (driveCapacityMb)
+
 	// UUIDNoSuchEmoji は upstream `admin/emoji/update` の `noSuchEmoji` UUID
 	// (third_party/misskey/.../endpoints/admin/emoji/update.ts:24)。mk-go の
 	// 旧実装は `684b7e7e-...` という typo'd 値を返していた regression を
@@ -286,6 +292,30 @@ func TooManyNoteDrafts() map[string]any {
 // TooManyMutedWords returns the upstream `tooManyMutedWords` shape (i/update mutedWords)。
 func TooManyMutedWords() map[string]any {
 	return Error("TOO_MANY_MUTED_WORDS", "Too many muted words.", UUIDTooManyMutedWords)
+}
+
+// ExceededLimitOfCreateInviteCode returns the upstream `invite/create` shape
+// triggered when the inviteLimit / inviteLimitCycle policy is exceeded.
+func ExceededLimitOfCreateInviteCode() map[string]any {
+	return Error(
+		"EXCEEDED_LIMIT_OF_CREATE_INVITE_CODE",
+		"You have exceeded the limit for creating an invitation code.",
+		UUIDExceededLimitOfCreateInviteCode,
+	)
+}
+
+// MaxFileSizeExceeded returns the upstream `drive/files/create` shape thrown
+// when the uploaded file size is larger than `maxFileSizeMb`. Upstream uses
+// IdentifiableError without an explicit code, so mk-go assigns
+// `MAX_FILE_SIZE_EXCEEDED` for frontend branching.
+func MaxFileSizeExceeded() map[string]any {
+	return Error("MAX_FILE_SIZE_EXCEEDED", "Max file size exceeded.", UUIDMaxFileSizeExceeded)
+}
+
+// NoFreeSpace returns the upstream `drive/files/create` shape thrown when the
+// user's drive usage plus the uploaded file size exceeds `driveCapacityMb`.
+func NoFreeSpace() map[string]any {
+	return Error("NO_FREE_SPACE", "No free space.", UUIDNoFreeSpace)
 }
 
 // NoSuchRenoteTarget returns a 404 NO_SUCH_RENOTE_TARGET error response.

--- a/internal/api/apierr/errors_test.go
+++ b/internal/api/apierr/errors_test.go
@@ -131,6 +131,9 @@ func TestCountLimitHelpers(t *testing.T) {
 		{"TooManyUsers", TooManyUsers, "TOO_MANY_USERS", UUIDTooManyUsers},
 		{"TooManyNoteDrafts", TooManyNoteDrafts, "TOO_MANY_NOTE_DRAFTS", UUIDTooManyNoteDrafts},
 		{"TooManyMutedWords", TooManyMutedWords, "TOO_MANY_MUTED_WORDS", UUIDTooManyMutedWords},
+		{"ExceededLimitOfCreateInviteCode", ExceededLimitOfCreateInviteCode, "EXCEEDED_LIMIT_OF_CREATE_INVITE_CODE", UUIDExceededLimitOfCreateInviteCode},
+		{"MaxFileSizeExceeded", MaxFileSizeExceeded, "MAX_FILE_SIZE_EXCEEDED", UUIDMaxFileSizeExceeded},
+		{"NoFreeSpace", NoFreeSpace, "NO_FREE_SPACE", UUIDNoFreeSpace},
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {

--- a/internal/api/drive/handler.go
+++ b/internal/api/drive/handler.go
@@ -227,6 +227,10 @@ func (h *Handler) FilesCreate(c echo.Context) error {
 			return c.JSON(http.StatusBadRequest, apierr.Error("UNALLOWED_FILE_TYPE",
 				"Cannot upload the file because it is an unallowed file type.",
 				"4becd248-7f2c-48c4-a9f0-75edc4f9a1ea"))
+		case errors.Is(err, coredrive.ErrMaxFileSizeExceeded):
+			return apierr.JSONMaxFileSizeExceeded(c)
+		case errors.Is(err, coredrive.ErrNoFreeSpace):
+			return apierr.JSONNoFreeSpace(c)
 		}
 		return apierr.JSONInternalError(c)
 	}

--- a/internal/api/drive/handler_test.go
+++ b/internal/api/drive/handler_test.go
@@ -152,6 +152,60 @@ func TestFilesCreate_RepoError(t *testing.T) {
 	assert.Equal(t, http.StatusInternalServerError, rec.Code)
 }
 
+// --- #1029 PR-2: drive policy handler-level mapping ---
+
+// driveRoleStub は coredrive.RoleChecker を実装する最小 stub。
+// moderator 判定は常に false、policies は固定 map を返す。
+type driveRoleStub struct {
+	policies map[string]any
+}
+
+func (s *driveRoleStub) IsModerator(_ string) bool               { return false }
+func (s *driveRoleStub) GetUserPolicies(_ string) map[string]any { return s.policies }
+
+func newHandlerWithPolicy(t *testing.T, policies map[string]any) (*Handler, *testutil.MockDriveFileRepository) {
+	t.Helper()
+	fileRepo := testutil.NewMockDriveFileRepository()
+	folderRepo := testutil.NewMockDriveFolderRepository()
+	folderRepo.FilesRef = fileRepo
+	storage := coredrive.NewLocalStorage(t.TempDir(), "https://example.com/files")
+	idGen, _ := id.NewGenerator("aidx")
+	svc := coredrive.NewService(fileRepo, folderRepo, storage, idGen)
+	svc.SetRoleChecker(&driveRoleStub{policies: policies})
+	return NewHandler(svc, idGen), fileRepo
+}
+
+// maxFileSizeMb 超過は 400 MAX_FILE_SIZE_EXCEEDED で upstream UUID と完全一致。
+func TestFilesCreate_MaxFileSizeExceeded(t *testing.T) {
+	h, _ := newHandlerWithPolicy(t, map[string]any{"maxFileSizeMb": 1})
+	// 2MB body (= 1MB cap 超過)
+	body := strings.Repeat("a", 2*1024*1024)
+	c, rec := newMultipartReq(t, "x.bin", body, nil)
+	setUser(c, "u1")
+	require.NoError(t, h.FilesCreate(c))
+	assert.Equal(t, http.StatusBadRequest, rec.Code)
+	assert.Contains(t, rec.Body.String(), "MAX_FILE_SIZE_EXCEEDED")
+	assert.Contains(t, rec.Body.String(), "f9e4e5f3-4df4-40b5-b400-f236945f7073")
+}
+
+// driveCapacityMb 超過 (= 既存 usage + 新 file > capacity) は 400 NO_FREE_SPACE。
+func TestFilesCreate_NoFreeSpace(t *testing.T) {
+	h, fileRepo := newHandlerWithPolicy(t, map[string]any{
+		// size gate は余裕、capacity が tight
+		"maxFileSizeMb":   100,
+		"driveCapacityMb": 1,
+	})
+	owner := "u1"
+	// 1MB 既存使用中 + 任意の新 file → capacity 超過
+	fileRepo.Files["existing"] = &model.DriveFile{ID: "existing", UserID: &owner, Size: 1024 * 1024}
+	c, rec := newMultipartReq(t, "x.txt", "small body content", nil)
+	setUser(c, "u1")
+	require.NoError(t, h.FilesCreate(c))
+	assert.Equal(t, http.StatusBadRequest, rec.Code)
+	assert.Contains(t, rec.Body.String(), "NO_FREE_SPACE")
+	assert.Contains(t, rec.Body.String(), "c6244ed2-a39a-4e1c-bf93-f0fbd7764fa6")
+}
+
 // --- FilesShow ---
 
 func TestFilesShow_Success(t *testing.T) {

--- a/internal/api/invite/handler.go
+++ b/internal/api/invite/handler.go
@@ -1,0 +1,221 @@
+// Package invite implements the user-scope /api/invite/* endpoints used by
+// users who hold the canInvite role policy to issue / list / delete / inspect
+// invite codes. Admin-scope invite endpoints live under
+// internal/api/admin/invite.go and have separate semantics.
+package invite
+
+import (
+	cryptorand "crypto/rand"
+	"io"
+	"net/http"
+	"time"
+
+	"github.com/labstack/echo/v4"
+	"github.com/shiroha-a/mk/internal/api/apierr"
+	"github.com/shiroha-a/mk/internal/entity"
+	"github.com/shiroha-a/mk/internal/misc/id"
+	"github.com/shiroha-a/mk/internal/model"
+	"github.com/shiroha-a/mk/internal/repository"
+	"github.com/shiroha-a/mk/internal/server/middleware"
+)
+
+// RolePolicyProvider returns the merged role policy map for a user. The
+// handler consumes inviteLimit / inviteLimitCycle / inviteExpirationTime from
+// the returned map to enforce upstream Misskey TS semantics (#1029 PR-2).
+// Nil provider disables the gate (= legacy unrestricted behaviour kept for
+// test fixtures).
+type RolePolicyProvider interface {
+	GetUserPolicies(userID string) map[string]any
+}
+
+// Handler exposes /api/invite/* handler methods.
+type Handler struct {
+	repo               repository.RegistrationTicketRepository
+	idGen              id.Generator
+	rolePolicyProvider RolePolicyProvider
+}
+
+// NewHandler returns a Handler wired with the given repository + id generator.
+func NewHandler(repo repository.RegistrationTicketRepository, idGen id.Generator) *Handler {
+	return &Handler{repo: repo, idGen: idGen}
+}
+
+// SetRolePolicyProvider wires the policy provider used by Create / Limit.
+// Nil keeps the gate disabled (= test fixture / wire 未配線).
+func (h *Handler) SetRolePolicyProvider(p RolePolicyProvider) {
+	h.rolePolicyProvider = p
+}
+
+// Create implements POST /api/invite/create. Upstream Misskey TS
+// `invite/create.ts` semantics: enforce inviteLimit / inviteLimitCycle as a
+// rolling time-window count, set expiresAt from inviteExpirationTime (0 / unset
+// = null = 無期限), then persist the ticket.
+func (h *Handler) Create(c echo.Context) error {
+	user := middleware.GetUser(c)
+	now := time.Now()
+
+	policies := h.policies(user.ID)
+	if invLimit, ok := policies["inviteLimit"].(int); ok && invLimit > 0 {
+		cycleMin := 0
+		if v, ok2 := policies["inviteLimitCycle"].(int); ok2 {
+			cycleMin = v
+		}
+		sinceID := h.idGen.Generate(now.Add(-time.Duration(cycleMin) * time.Minute))
+		count, err := h.repo.CountByCreatorSince(user.ID, sinceID)
+		if err != nil {
+			return apierr.JSONInternalError(c)
+		}
+		if count >= int64(invLimit) {
+			return apierr.JSONExceededLimitOfCreateInviteCode(c)
+		}
+	}
+
+	// inviteExpirationTime (= 分単位) が truthy なら expiresAt を計算する。
+	// 0 / 未設定なら null (= 無期限) を維持し、upstream の falsy skip と一致する。
+	var expiresAt *time.Time
+	if v, ok := policies["inviteExpirationTime"].(int); ok && v > 0 {
+		exp := now.Add(time.Duration(v) * time.Minute)
+		expiresAt = &exp
+	}
+
+	ticket := &model.RegistrationTicket{
+		ID:          h.idGen.Generate(now),
+		Code:        generateInviteCode(),
+		CreatedByID: &user.ID,
+		ExpiresAt:   expiresAt,
+	}
+	if err := h.repo.Create(ticket); err != nil {
+		return apierr.JSONInternalError(c)
+	}
+
+	resp := map[string]any{
+		"id":        ticket.ID,
+		"code":      ticket.Code,
+		"expiresAt": ticket.ExpiresAt,
+		"createdBy": entity.PackUserLite(user),
+		"usedBy":    nil,
+		"usedAt":    nil,
+		"used":      false,
+	}
+	if t, err := h.idGen.ParseTime(ticket.ID); err == nil {
+		resp["createdAt"] = t.UTC().Format("2006-01-02T15:04:05.000Z")
+	}
+	return c.JSON(http.StatusOK, resp)
+}
+
+// List implements POST /api/invite/list.
+func (h *Handler) List(c echo.Context) error {
+	user := middleware.GetUser(c)
+	var req struct {
+		Limit   int    `json:"limit"`
+		SinceID string `json:"sinceId"`
+		UntilID string `json:"untilId"`
+	}
+	_ = c.Bind(&req)
+
+	tickets, err := h.repo.ListByCreator(user.ID, req.SinceID, req.UntilID, req.Limit)
+	if err != nil {
+		// upstream は handler 内で DB error を listing 404 相当ではなく empty
+		// array で返している。caller (frontend invite 管理画面) は array length
+		// で空チェックするので 500 を返すと UI が壊れる、空 array で graceful
+		// degrade する方が drop-in 互換性が高い。
+		return c.JSON(http.StatusOK, []any{})
+	}
+	out := make([]map[string]any, 0, len(tickets))
+	for _, t := range tickets {
+		entry := map[string]any{
+			"id":        t.ID,
+			"code":      t.Code,
+			"expiresAt": t.ExpiresAt,
+			"createdBy": nil,
+			"usedBy":    nil,
+			"usedAt":    t.UsedAt,
+			"used":      t.UsedByID != nil,
+		}
+		if ts, err := h.idGen.ParseTime(t.ID); err == nil {
+			entry["createdAt"] = ts.UTC().Format("2006-01-02T15:04:05.000Z")
+		}
+		out = append(out, entry)
+	}
+	return c.JSON(http.StatusOK, out)
+}
+
+// Delete implements POST /api/invite/delete. Only the original creator can
+// delete their own ticket (= upstream `invite/delete.ts` access check)。
+func (h *Handler) Delete(c echo.Context) error {
+	user := middleware.GetUser(c)
+	var req struct {
+		InviteID string `json:"inviteId"`
+	}
+	if err := c.Bind(&req); err != nil || req.InviteID == "" {
+		return c.JSON(http.StatusBadRequest, apierr.Error("INVALID_PARAM", "inviteId is required.", apierr.UUIDInvalidParam))
+	}
+	ticket, err := h.repo.FindByID(req.InviteID)
+	if err != nil {
+		// 既に削除済 / 存在しない場合は upstream と同様に 204 を返す (= idempotent)。
+		return c.NoContent(http.StatusNoContent)
+	}
+	if ticket.CreatedByID == nil || *ticket.CreatedByID != user.ID {
+		return c.JSON(http.StatusForbidden, apierr.Error("ACCESS_DENIED", "Access denied.", apierr.UUIDAccessDenied))
+	}
+	if err := h.repo.Delete(req.InviteID); err != nil {
+		return apierr.JSONInternalError(c)
+	}
+	return c.NoContent(http.StatusNoContent)
+}
+
+// Limit implements POST /api/invite/limit. Returns the remaining slots within
+// the current inviteLimitCycle window. Upstream `invite/limit.ts` returns
+// `remaining: null` when policies.inviteLimit is falsy (= 無制限), otherwise
+// `max(0, inviteLimit - count)`.
+func (h *Handler) Limit(c echo.Context) error {
+	user := middleware.GetUser(c)
+	policies := h.policies(user.ID)
+	invLimit, hasLimit := policies["inviteLimit"].(int)
+	if !hasLimit || invLimit <= 0 {
+		return c.JSON(http.StatusOK, map[string]any{"remaining": nil})
+	}
+	cycleMin := 0
+	if v, ok := policies["inviteLimitCycle"].(int); ok {
+		cycleMin = v
+	}
+	sinceID := h.idGen.Generate(time.Now().Add(-time.Duration(cycleMin) * time.Minute))
+	count, err := h.repo.CountByCreatorSince(user.ID, sinceID)
+	if err != nil {
+		return apierr.JSONInternalError(c)
+	}
+	remaining := int64(invLimit) - count
+	if remaining < 0 {
+		remaining = 0
+	}
+	return c.JSON(http.StatusOK, map[string]any{"remaining": remaining})
+}
+
+// policies returns the merged role policy map for userID, or an empty map
+// when no provider is wired so callers can safely type-assert keys.
+func (h *Handler) policies(userID string) map[string]any {
+	if h.rolePolicyProvider == nil {
+		return map[string]any{}
+	}
+	if p := h.rolePolicyProvider.GetUserPolicies(userID); p != nil {
+		return p
+	}
+	return map[string]any{}
+}
+
+// generateInviteCode creates an 8-character random invite code over
+// `[a-z0-9]`. mk-go 既存実装 (旧 router.go 内 helper) と同 charset / 長さで、
+// 移植後も既発行コードの長さ / 文字種分布を維持する。upstream Misskey TS
+// は別 charset (`23456789ABCDEFGHJKLMNPQRSTUVWXYZ` + timestamp suffix) を
+// 使うので drop-in 互換の観点では別 issue で揃える余地あり。
+func generateInviteCode() string {
+	const chars = "abcdefghijklmnopqrstuvwxyz0123456789"
+	b := make([]byte, 8)
+	if _, err := io.ReadFull(cryptorand.Reader, b); err != nil {
+		panic("crypto/rand failed: " + err.Error())
+	}
+	for i := range b {
+		b[i] = chars[b[i]%byte(len(chars))]
+	}
+	return string(b)
+}

--- a/internal/api/invite/handler_test.go
+++ b/internal/api/invite/handler_test.go
@@ -1,0 +1,300 @@
+package invite
+
+import (
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/labstack/echo/v4"
+	"github.com/shiroha-a/mk/internal/misc/id"
+	"github.com/shiroha-a/mk/internal/model"
+	"github.com/shiroha-a/mk/internal/server/middleware"
+	"github.com/shiroha-a/mk/internal/testutil"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+var errStub = errors.New("stub error")
+
+// stubInvitePolicy is a minimal RolePolicyProvider double.
+type stubInvitePolicy struct {
+	policies map[string]any
+}
+
+func (s *stubInvitePolicy) GetUserPolicies(_ string) map[string]any { return s.policies }
+
+func newTestHandler(t *testing.T) (*Handler, *testutil.MockRegistrationTicketRepository) {
+	t.Helper()
+	repo := testutil.NewMockRegistrationTicketRepository()
+	idGen, err := id.NewGenerator("aidx")
+	require.NoError(t, err)
+	return NewHandler(repo, idGen), repo
+}
+
+func post(handler func(echo.Context) error, body string, user *model.User) *httptest.ResponseRecorder {
+	e := echo.New()
+	req := httptest.NewRequest(http.MethodPost, "/", strings.NewReader(body))
+	req.Header.Set(echo.HeaderContentType, echo.MIMEApplicationJSON)
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+	if user != nil {
+		c.Set(string(middleware.UserContextKey), user)
+	}
+	_ = handler(c)
+	return rec
+}
+
+// --- Create -----------------------------------------------------------------
+
+func TestCreate_NoPolicyProviderSucceeds(t *testing.T) {
+	h, repo := newTestHandler(t)
+	rec := post(h.Create, `{}`, &model.User{ID: "u1"})
+	assert.Equal(t, http.StatusOK, rec.Code)
+	assert.Len(t, repo.Tickets, 1)
+	var resp map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+	assert.NotEmpty(t, resp["code"])
+	// inviteExpirationTime 未設定 → expiresAt は null
+	assert.Nil(t, resp["expiresAt"])
+	assert.Equal(t, false, resp["used"])
+	assert.NotEmpty(t, resp["createdAt"])
+}
+
+func TestCreate_LimitExceeded(t *testing.T) {
+	h, repo := newTestHandler(t)
+	// 既に 2 invite 保有 (CountByCreatorSince で count される)
+	user := "u1"
+	repo.Tickets["t1"] = &model.RegistrationTicket{ID: "z_t1", CreatedByID: &user}
+	repo.Tickets["t2"] = &model.RegistrationTicket{ID: "z_t2", CreatedByID: &user}
+	h.SetRolePolicyProvider(&stubInvitePolicy{policies: map[string]any{
+		"inviteLimit":      2,
+		"inviteLimitCycle": 60 * 24, // 1 day, ensure sinceID is well before now
+	}})
+	rec := post(h.Create, `{}`, &model.User{ID: user})
+	assert.Equal(t, http.StatusBadRequest, rec.Code)
+	assert.Contains(t, rec.Body.String(), "EXCEEDED_LIMIT_OF_CREATE_INVITE_CODE")
+	assert.Contains(t, rec.Body.String(), "8b165dd3-6f37-4557-8db1-73175d63c641")
+}
+
+func TestCreate_LimitPassesUnderLimit(t *testing.T) {
+	h, _ := newTestHandler(t)
+	h.SetRolePolicyProvider(&stubInvitePolicy{policies: map[string]any{
+		"inviteLimit":      10,
+		"inviteLimitCycle": 60,
+	}})
+	rec := post(h.Create, `{}`, &model.User{ID: "u1"})
+	assert.Equal(t, http.StatusOK, rec.Code, "limit 内なら通常成功")
+}
+
+func TestCreate_LimitZeroOrUnsetIsUnlimited(t *testing.T) {
+	h, _ := newTestHandler(t)
+	h.SetRolePolicyProvider(&stubInvitePolicy{policies: map[string]any{
+		"inviteLimit": 0, // upstream falsy = skip
+	}})
+	rec := post(h.Create, `{}`, &model.User{ID: "u1"})
+	assert.Equal(t, http.StatusOK, rec.Code, "policy 0 は upstream falsy 相当で gate skip")
+}
+
+func TestCreate_ExpiresAtSetFromPolicy(t *testing.T) {
+	h, repo := newTestHandler(t)
+	h.SetRolePolicyProvider(&stubInvitePolicy{policies: map[string]any{
+		"inviteExpirationTime": 60, // 60 minutes
+	}})
+	rec := post(h.Create, `{}`, &model.User{ID: "u1"})
+	require.Equal(t, http.StatusOK, rec.Code)
+	require.Len(t, repo.Tickets, 1)
+	var saved *model.RegistrationTicket
+	for _, t := range repo.Tickets {
+		saved = t
+	}
+	require.NotNil(t, saved.ExpiresAt, "expiresAt は inviteExpirationTime > 0 で設定される")
+}
+
+// countErrRepo は CountByCreatorSince だけ error を返す stub。
+type countErrRepo struct {
+	*testutil.MockRegistrationTicketRepository
+}
+
+func (r *countErrRepo) CountByCreatorSince(_, _ string) (int64, error) { return 0, errStub }
+
+func TestCreate_CountErrorReturns500(t *testing.T) {
+	idGen, _ := id.NewGenerator("aidx")
+	h := NewHandler(&countErrRepo{testutil.NewMockRegistrationTicketRepository()}, idGen)
+	h.SetRolePolicyProvider(&stubInvitePolicy{policies: map[string]any{"inviteLimit": 5}})
+	rec := post(h.Create, `{}`, &model.User{ID: "u1"})
+	assert.Equal(t, http.StatusInternalServerError, rec.Code)
+}
+
+// failCreateRepo は Create だけ error を返す stub。
+type failCreateRepo struct {
+	*testutil.MockRegistrationTicketRepository
+}
+
+func (r *failCreateRepo) Create(_ *model.RegistrationTicket) error { return errStub }
+
+func TestCreate_RepoCreateError(t *testing.T) {
+	idGen, _ := id.NewGenerator("aidx")
+	h := NewHandler(&failCreateRepo{testutil.NewMockRegistrationTicketRepository()}, idGen)
+	rec := post(h.Create, `{}`, &model.User{ID: "u1"})
+	assert.Equal(t, http.StatusInternalServerError, rec.Code)
+}
+
+// --- List -------------------------------------------------------------------
+
+func TestList_Success(t *testing.T) {
+	h, repo := newTestHandler(t)
+	user := "u1"
+	repo.Tickets["t1"] = &model.RegistrationTicket{ID: "z_a1", Code: "code-a1", CreatedByID: &user}
+	repo.Tickets["t2"] = &model.RegistrationTicket{ID: "z_a2", Code: "code-a2", CreatedByID: &user}
+	otherUser := "u2"
+	repo.Tickets["t3"] = &model.RegistrationTicket{ID: "z_a3", Code: "code-a3", CreatedByID: &otherUser}
+	rec := post(h.List, `{"limit":50}`, &model.User{ID: user})
+	require.Equal(t, http.StatusOK, rec.Code)
+	var out []map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &out))
+	assert.Len(t, out, 2, "他 user の invite は除外される")
+}
+
+func TestList_Empty(t *testing.T) {
+	h, _ := newTestHandler(t)
+	rec := post(h.List, `{}`, &model.User{ID: "u1"})
+	require.Equal(t, http.StatusOK, rec.Code)
+	assert.Equal(t, "[]", strings.TrimSpace(rec.Body.String()))
+}
+
+// listErrRepo は ListByCreator だけ error を返す stub。
+type listErrRepo struct {
+	*testutil.MockRegistrationTicketRepository
+}
+
+func (r *listErrRepo) ListByCreator(_, _, _ string, _ int) ([]*model.RegistrationTicket, error) {
+	return nil, errStub
+}
+
+func TestList_RepoErrorReturnsEmptyArray(t *testing.T) {
+	idGen, _ := id.NewGenerator("aidx")
+	h := NewHandler(&listErrRepo{testutil.NewMockRegistrationTicketRepository()}, idGen)
+	rec := post(h.List, `{}`, &model.User{ID: "u1"})
+	require.Equal(t, http.StatusOK, rec.Code, "DB error 時も 200 + 空 array で graceful degrade する")
+	assert.Equal(t, "[]", strings.TrimSpace(rec.Body.String()))
+}
+
+// --- Delete -----------------------------------------------------------------
+
+func TestDelete_Success(t *testing.T) {
+	h, repo := newTestHandler(t)
+	user := "u1"
+	repo.Tickets["t1"] = &model.RegistrationTicket{ID: "t1", CreatedByID: &user}
+	rec := post(h.Delete, `{"inviteId":"t1"}`, &model.User{ID: user})
+	assert.Equal(t, http.StatusNoContent, rec.Code)
+	assert.NotContains(t, repo.Tickets, "t1")
+}
+
+func TestDelete_InvalidParam(t *testing.T) {
+	h, _ := newTestHandler(t)
+	rec := post(h.Delete, `{}`, &model.User{ID: "u1"})
+	assert.Equal(t, http.StatusBadRequest, rec.Code)
+}
+
+func TestDelete_NotFoundReturnsNoContent(t *testing.T) {
+	h, _ := newTestHandler(t)
+	rec := post(h.Delete, `{"inviteId":"ghost"}`, &model.User{ID: "u1"})
+	assert.Equal(t, http.StatusNoContent, rec.Code, "not found は idempotent に 204")
+}
+
+func TestDelete_AccessDeniedWhenNotCreator(t *testing.T) {
+	h, repo := newTestHandler(t)
+	owner := "u2"
+	repo.Tickets["t1"] = &model.RegistrationTicket{ID: "t1", CreatedByID: &owner}
+	rec := post(h.Delete, `{"inviteId":"t1"}`, &model.User{ID: "u1"})
+	assert.Equal(t, http.StatusForbidden, rec.Code)
+	assert.Contains(t, rec.Body.String(), "ACCESS_DENIED")
+}
+
+// failDeleteRepo は Delete だけ error を返す stub。
+type failDeleteRepo struct {
+	*testutil.MockRegistrationTicketRepository
+}
+
+func (r *failDeleteRepo) Delete(_ string) error { return errStub }
+
+func TestDelete_RepoErrorReturns500(t *testing.T) {
+	idGen, _ := id.NewGenerator("aidx")
+	mock := testutil.NewMockRegistrationTicketRepository()
+	user := "u1"
+	mock.Tickets["t1"] = &model.RegistrationTicket{ID: "t1", CreatedByID: &user}
+	h := NewHandler(&failDeleteRepo{mock}, idGen)
+	rec := post(h.Delete, `{"inviteId":"t1"}`, &model.User{ID: user})
+	assert.Equal(t, http.StatusInternalServerError, rec.Code)
+}
+
+// --- Limit ------------------------------------------------------------------
+
+func TestLimit_UnlimitedWhenNoPolicy(t *testing.T) {
+	h, _ := newTestHandler(t)
+	rec := post(h.Limit, `{}`, &model.User{ID: "u1"})
+	require.Equal(t, http.StatusOK, rec.Code)
+	var out map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &out))
+	assert.Nil(t, out["remaining"], "provider 未配線は null = 無制限")
+}
+
+func TestLimit_UnlimitedWhenInviteLimitZero(t *testing.T) {
+	h, _ := newTestHandler(t)
+	h.SetRolePolicyProvider(&stubInvitePolicy{policies: map[string]any{"inviteLimit": 0}})
+	rec := post(h.Limit, `{}`, &model.User{ID: "u1"})
+	require.Equal(t, http.StatusOK, rec.Code)
+	var out map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &out))
+	assert.Nil(t, out["remaining"], "policy 0 は falsy で null = 無制限")
+}
+
+func TestLimit_ReturnsRemaining(t *testing.T) {
+	h, repo := newTestHandler(t)
+	user := "u1"
+	// 既に 3 invite (= z_a* で時刻 prefix > sinceID になるよう)
+	repo.Tickets["t1"] = &model.RegistrationTicket{ID: "z_a1", CreatedByID: &user}
+	repo.Tickets["t2"] = &model.RegistrationTicket{ID: "z_a2", CreatedByID: &user}
+	repo.Tickets["t3"] = &model.RegistrationTicket{ID: "z_a3", CreatedByID: &user}
+	h.SetRolePolicyProvider(&stubInvitePolicy{policies: map[string]any{
+		"inviteLimit":      10,
+		"inviteLimitCycle": 60 * 24,
+	}})
+	rec := post(h.Limit, `{}`, &model.User{ID: user})
+	require.Equal(t, http.StatusOK, rec.Code)
+	var out map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &out))
+	// json.Unmarshal は int を float64 にする
+	assert.Equal(t, float64(7), out["remaining"], "10 - 3 = 7")
+}
+
+func TestLimit_RemainingClampedToZero(t *testing.T) {
+	h, repo := newTestHandler(t)
+	user := "u1"
+	for i := 0; i < 5; i++ {
+		repo.Tickets[string(rune('a'+i))] = &model.RegistrationTicket{
+			ID:          "z_" + string(rune('a'+i)),
+			CreatedByID: &user,
+		}
+	}
+	h.SetRolePolicyProvider(&stubInvitePolicy{policies: map[string]any{
+		"inviteLimit":      3,
+		"inviteLimitCycle": 60 * 24,
+	}})
+	rec := post(h.Limit, `{}`, &model.User{ID: user})
+	require.Equal(t, http.StatusOK, rec.Code)
+	var out map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &out))
+	assert.Equal(t, float64(0), out["remaining"], "limit < count でも 0 で打ち切り")
+}
+
+func TestLimit_CountErrorReturns500(t *testing.T) {
+	idGen, _ := id.NewGenerator("aidx")
+	h := NewHandler(&countErrRepo{testutil.NewMockRegistrationTicketRepository()}, idGen)
+	h.SetRolePolicyProvider(&stubInvitePolicy{policies: map[string]any{"inviteLimit": 5}})
+	rec := post(h.Limit, `{}`, &model.User{ID: "u1"})
+	assert.Equal(t, http.StatusInternalServerError, rec.Code)
+}

--- a/internal/core/drive/drive_service.go
+++ b/internal/core/drive/drive_service.go
@@ -7,6 +7,7 @@ import (
 	"encoding/hex"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"io"
 	"log/slog"
 	"strings"
@@ -244,7 +245,14 @@ func (s *Service) Upload(ctx context.Context, in UploadInput) (*model.DriveFile,
 			}
 			if mb, ok := policies["driveCapacityMb"].(int); ok && mb > 0 {
 				capBytes := int64(mb) * 1024 * 1024
-				usage, _ := s.fileRepo.UsageByUser(in.User.ID)
+				// UsageByUser の DB error を握り潰すと usage=0 として gate を
+				// pass してしまい driveCapacityMb 制限が事実上効かなくなる。
+				// production の transient DB error 時に黙って upload を許可する
+				// のは避けたいので明示的に internal error として伝播する。
+				usage, err := s.fileRepo.UsageByUser(in.User.ID)
+				if err != nil {
+					return nil, fmt.Errorf("calc drive usage: %w", err)
+				}
 				if usage+int64(len(info.Body)) > capBytes {
 					return nil, ErrNoFreeSpace
 				}

--- a/internal/core/drive/drive_service.go
+++ b/internal/core/drive/drive_service.go
@@ -45,6 +45,17 @@ var (
 	// their own drive file. Handler translates this into the drive-specific
 	// RESTRICTED_BY_ROLE response (UUID 7f59dccb-...) (#1028).
 	ErrCannotUnmarkSensitive = errors.New("cannot unmark sensitive while alwaysMarkNsfw policy is active")
+	// ErrMaxFileSizeExceeded is returned when the uploaded file size exceeds
+	// the user's `maxFileSizeMb` role policy (#1029 PR-2). Handler maps this
+	// to upstream's `MAX_FILE_SIZE_EXCEEDED` 400 response.
+	ErrMaxFileSizeExceeded = errors.New("max file size exceeded")
+	// ErrNoFreeSpace is returned when the user's current drive usage plus the
+	// new file size exceeds `driveCapacityMb` (#1029 PR-2). Handler maps this
+	// to upstream's `NO_FREE_SPACE` 400 response. remote user の場合 upstream
+	// は `expireOldFile` で古い file を退去させて capacity を確保するが、
+	// mk-go では LRU 退去ロジックが未実装のため remote user は本 gate を
+	// skip して従来どおり受け入れる (cleanup logic は future work)。
+	ErrNoFreeSpace = errors.New("no free space")
 )
 
 // StreamingPublisher receives drive file life-cycle events so that
@@ -217,6 +228,26 @@ func (s *Service) Upload(ctx context.Context, in UploadInput) (*model.DriveFile,
 			if v, ok := policies["alwaysMarkNsfw"].(bool); ok && v {
 				rolePolicyForceSensitive = true
 				in.IsSensitive = true
+			}
+		}
+		// maxFileSizeMb / driveCapacityMb gate (#1029 PR-2)。upstream Misskey TS
+		// `DriveService.addFile` は **local user のみ** local capacity / size を
+		// 強制し、remote user は expireOldFile で逃げ道を作る。mk-go には
+		// expireOldFile 相当の LRU 退去がまだ無いので remote は skip する
+		// (= 受け入れて drive_file 行は作成、cleanup は future work)。
+		if in.User.IsLocal() && policies != nil {
+			if mb, ok := policies["maxFileSizeMb"].(int); ok && mb > 0 {
+				maxBytes := int64(mb) * 1024 * 1024
+				if int64(len(info.Body)) > maxBytes {
+					return nil, ErrMaxFileSizeExceeded
+				}
+			}
+			if mb, ok := policies["driveCapacityMb"].(int); ok && mb > 0 {
+				capBytes := int64(mb) * 1024 * 1024
+				usage, _ := s.fileRepo.UsageByUser(in.User.ID)
+				if usage+int64(len(info.Body)) > capBytes {
+					return nil, ErrNoFreeSpace
+				}
 			}
 		}
 	}

--- a/internal/core/drive/drive_service_test.go
+++ b/internal/core/drive/drive_service_test.go
@@ -478,6 +478,38 @@ func TestUpload_DriveLimitsZeroSkipsGate(t *testing.T) {
 	require.NoError(t, err, "policy 0 は upstream falsy 相当で gate skip")
 }
 
+// usageErrRepo は UsageByUser だけ error を返す stub。driveCapacityMb gate
+// で DB error が transient に起きた場合、usage=0 で握り潰さず internal
+// error として伝播することを確認する (#1041 review feedback)。
+type usageErrRepo struct {
+	*testutil.MockDriveFileRepository
+}
+
+func (r *usageErrRepo) UsageByUser(_ string) (int64, error) {
+	return 0, errors.New("transient db error")
+}
+
+func TestUpload_DriveCapacityUsageErrorPropagates(t *testing.T) {
+	fileRepo := &usageErrRepo{MockDriveFileRepository: testutil.NewMockDriveFileRepository()}
+	storage := drive.NewLocalStorage(t.TempDir(), "")
+	idGen, _ := id.NewGenerator("aidx")
+	svc := drive.NewService(fileRepo, testutil.NewMockDriveFolderRepository(), storage, idGen)
+	svc.SetRoleChecker(&fakeMod{
+		policies: map[string]map[string]any{
+			"u1": {"driveCapacityMb": 1},
+		},
+	})
+	user := &model.User{ID: "u1"}
+	_, err := svc.Upload(context.Background(), drive.UploadInput{
+		User: user, Body: []byte("hello"), Name: "x.txt",
+	})
+	require.Error(t, err)
+	// wrap で原因を保持していることを確認 (handler 側は default 500 経路に流す)
+	assert.Contains(t, err.Error(), "calc drive usage")
+	// 同 error は ErrNoFreeSpace でも MaxFileSize でもないので errors.Is で識別不能
+	assert.False(t, errors.Is(err, drive.ErrNoFreeSpace))
+}
+
 // system file (User == nil) は role policy gate の対象外 (= emoji copy 等)。
 func TestUpload_SystemFileBypassesPolicy(t *testing.T) {
 	svc, _, _ := newSvc(t)

--- a/internal/core/drive/drive_service_test.go
+++ b/internal/core/drive/drive_service_test.go
@@ -396,6 +396,88 @@ func TestUpload_RoleCheckerNoPoliciesSkipsGate(t *testing.T) {
 	require.NoError(t, err)
 }
 
+// --- #1029 PR-2: maxFileSizeMb / driveCapacityMb gate ---
+
+// maxFileSizeMb 超過の upload は ErrMaxFileSizeExceeded で reject される。
+func TestUpload_MaxFileSizeExceeded(t *testing.T) {
+	svc, _, _ := newSvc(t)
+	svc.SetRoleChecker(&fakeMod{
+		policies: map[string]map[string]any{
+			"u1": {"maxFileSizeMb": 1}, // = 1MB cap
+		},
+	})
+	user := &model.User{ID: "u1"} // Host == nil = local user
+	_, err := svc.Upload(context.Background(), drive.UploadInput{
+		User: user, Body: make([]byte, 2*1024*1024), Name: "x.bin",
+	})
+	require.ErrorIs(t, err, drive.ErrMaxFileSizeExceeded)
+}
+
+// driveCapacityMb 超過 (= 既存 usage + 新 file > capacity) は ErrNoFreeSpace。
+func TestUpload_NoFreeSpace(t *testing.T) {
+	svc, fileRepo, _ := newSvc(t)
+	owner := "u1"
+	// 既に 1MB 使用中、capacity 1MB → 新規 upload はサイズ不問で reject。
+	fileRepo.Files["existing"] = &model.DriveFile{ID: "existing", UserID: &owner, Size: 1024 * 1024}
+	svc.SetRoleChecker(&fakeMod{
+		policies: map[string]map[string]any{
+			"u1": {"driveCapacityMb": 1, "maxFileSizeMb": 100}, // size gate は余裕、capacity が tight
+		},
+	})
+	user := &model.User{ID: "u1"}
+	_, err := svc.Upload(context.Background(), drive.UploadInput{
+		User: user, Body: []byte("hello world data text"), Name: "x.txt",
+	})
+	require.ErrorIs(t, err, drive.ErrNoFreeSpace)
+}
+
+// remote user は本 gate を skip する (= mk-go に expireOldFile が未実装な為)。
+func TestUpload_RemoteUserBypassesCapacityGates(t *testing.T) {
+	svc, _, _ := newSvc(t)
+	svc.SetRoleChecker(&fakeMod{
+		policies: map[string]map[string]any{
+			"u1": {"maxFileSizeMb": 1, "driveCapacityMb": 1},
+		},
+	})
+	remoteHost := "remote.example"
+	user := &model.User{ID: "u1", Host: &remoteHost}
+	_, err := svc.Upload(context.Background(), drive.UploadInput{
+		User: user, Body: make([]byte, 2*1024*1024), Name: "x.bin",
+	})
+	require.NoError(t, err, "remote user は drive policy gate を skip する")
+}
+
+// limit 内 (= size <= maxFileSizeMb かつ usage+size <= driveCapacityMb) なら通る。
+func TestUpload_DriveLimitsPassUnderThreshold(t *testing.T) {
+	svc, _, _ := newSvc(t)
+	svc.SetRoleChecker(&fakeMod{
+		policies: map[string]map[string]any{
+			"u1": {"maxFileSizeMb": 1, "driveCapacityMb": 1},
+		},
+	})
+	user := &model.User{ID: "u1"}
+	_, err := svc.Upload(context.Background(), drive.UploadInput{
+		User: user, Body: []byte("small body"), Name: "x.txt",
+	})
+	require.NoError(t, err)
+}
+
+// maxFileSizeMb / driveCapacityMb が 0 (= unset) なら gate skip。upstream
+// `if (policies.maxFileSizeMb)` で 0 falsy = 無制限。
+func TestUpload_DriveLimitsZeroSkipsGate(t *testing.T) {
+	svc, _, _ := newSvc(t)
+	svc.SetRoleChecker(&fakeMod{
+		policies: map[string]map[string]any{
+			"u1": {"maxFileSizeMb": 0, "driveCapacityMb": 0},
+		},
+	})
+	user := &model.User{ID: "u1"}
+	_, err := svc.Upload(context.Background(), drive.UploadInput{
+		User: user, Body: make([]byte, 2*1024*1024), Name: "x.bin",
+	})
+	require.NoError(t, err, "policy 0 は upstream falsy 相当で gate skip")
+}
+
 // system file (User == nil) は role policy gate の対象外 (= emoji copy 等)。
 func TestUpload_SystemFileBypassesPolicy(t *testing.T) {
 	svc, _, _ := newSvc(t)

--- a/internal/repository/registration_ticket.go
+++ b/internal/repository/registration_ticket.go
@@ -48,6 +48,14 @@ type RegistrationTicketRepository interface {
 	// `now` is passed by callers so tests can supply a deterministic clock
 	// when evaluating the `expired` filter.
 	List(filter string, limit, offset int, now time.Time) ([]*model.RegistrationTicket, error)
+	// CountByCreatorSince returns the number of tickets created by creatorID
+	// whose ID compares strictly greater than sinceID. Used by
+	// invite/create + invite/limit endpoints to enforce the
+	// inviteLimit + inviteLimitCycle role policy (#1029 PR-2). aidx 型 ID
+	// は時刻 prefix を持つので id 比較で「特定時刻以降に作成された」レコード
+	// を絞り込める (upstream は typeorm `MoreThan(idService.gen(time))` で
+	// 同じセマンティクスを実現している)。
+	CountByCreatorSince(creatorID, sinceID string) (int64, error)
 	Delete(id string) error
 }
 
@@ -118,6 +126,17 @@ func (r *registrationTicketRepository) List(filter string, limit, offset int, no
 		return nil, err
 	}
 	return rows, nil
+}
+
+// CountByCreatorSince counts tickets created by creatorID with id > sinceID.
+func (r *registrationTicketRepository) CountByCreatorSince(creatorID, sinceID string) (int64, error) {
+	var count int64
+	if err := r.db.Model(&model.RegistrationTicket{}).
+		Where(`"createdById" = ? AND "id" > ?`, creatorID, sinceID).
+		Count(&count).Error; err != nil {
+		return 0, err
+	}
+	return count, nil
 }
 
 func (r *registrationTicketRepository) Delete(id string) error {

--- a/internal/repository/registration_ticket.go
+++ b/internal/repository/registration_ticket.go
@@ -56,6 +56,13 @@ type RegistrationTicketRepository interface {
 	// を絞り込める (upstream は typeorm `MoreThan(idService.gen(time))` で
 	// 同じセマンティクスを実現している)。
 	CountByCreatorSince(creatorID, sinceID string) (int64, error)
+	// FindByID returns the ticket with the given primary key, or
+	// gorm.ErrRecordNotFound when no row matches.
+	FindByID(id string) (*model.RegistrationTicket, error)
+	// ListByCreator returns tickets owned by creatorID, paginated by id
+	// cursor (sinceID < id < untilID, empty cursors disable each bound).
+	// Used by invite/list (= 自分が発行した invite の一覧)。
+	ListByCreator(creatorID, sinceID, untilID string, limit int) ([]*model.RegistrationTicket, error)
 	Delete(id string) error
 }
 
@@ -137,6 +144,42 @@ func (r *registrationTicketRepository) CountByCreatorSince(creatorID, sinceID st
 		return 0, err
 	}
 	return count, nil
+}
+
+// FindByID returns the ticket by primary key.
+func (r *registrationTicketRepository) FindByID(id string) (*model.RegistrationTicket, error) {
+	var ticket model.RegistrationTicket
+	if err := r.db.Where(`"id" = ?`, id).First(&ticket).Error; err != nil {
+		return nil, err
+	}
+	return &ticket, nil
+}
+
+// ListByCreator returns the invites owned by creatorID with id cursor
+// pagination, limited to limit rows. limit <= 0 falls back to 30, > 100 is
+// clamped to 100 (= upstream paramDef.limit のデフォルトと max)。
+func (r *registrationTicketRepository) ListByCreator(creatorID, sinceID, untilID string, limit int) ([]*model.RegistrationTicket, error) {
+	if limit <= 0 {
+		limit = 30
+	}
+	if limit > 100 {
+		limit = 100
+	}
+	q := r.db.Model(&model.RegistrationTicket{}).
+		Where(`"createdById" = ?`, creatorID).
+		Order(`"id" DESC`).
+		Limit(limit)
+	if sinceID != "" {
+		q = q.Where(`"id" > ?`, sinceID)
+	}
+	if untilID != "" {
+		q = q.Where(`"id" < ?`, untilID)
+	}
+	var rows []*model.RegistrationTicket
+	if err := q.Find(&rows).Error; err != nil {
+		return nil, err
+	}
+	return rows, nil
 }
 
 func (r *registrationTicketRepository) Delete(id string) error {

--- a/internal/repository/registration_ticket_test.go
+++ b/internal/repository/registration_ticket_test.go
@@ -142,3 +142,42 @@ func TestRegistrationTicketRepository_FindByIDForUpdateTx_NotFound(t *testing.T)
 	})
 	assert.Error(t, err)
 }
+
+// CountByCreatorSince は creatorID + id > sinceID の組み合わせで rolling
+// window count を返す (#1029 PR-2 で invite/create + invite/limit が使う)。
+func TestRegistrationTicketRepository_CountByCreatorSince(t *testing.T) {
+	repo := NewRegistrationTicketRepository(testDB)
+	cleanupInvite(t, "rt_cc_1", "rt_cc_2", "rt_cc_3", "rt_cc_other")
+	defer cleanupInvite(t, "rt_cc_1", "rt_cc_2", "rt_cc_3", "rt_cc_other")
+	u := insertTestUser(t, "rt_cc_user", "rtccu")
+	defer cleanupUser(t, u.ID)
+	other := insertTestUser(t, "rt_cc_other_user", "rtcco")
+	defer cleanupUser(t, other.ID)
+
+	// creatorID と id (時刻 prefix) で window を切る。アルファベット順比較で
+	// id > sinceID を満たすので rt_cc_2 / rt_cc_3 のみ count される。
+	require.NoError(t, repo.Create(&model.RegistrationTicket{ID: "rt_cc_1", Code: "ccc-1", CreatedByID: &u.ID}))
+	require.NoError(t, repo.Create(&model.RegistrationTicket{ID: "rt_cc_2", Code: "ccc-2", CreatedByID: &u.ID}))
+	require.NoError(t, repo.Create(&model.RegistrationTicket{ID: "rt_cc_3", Code: "ccc-3", CreatedByID: &u.ID}))
+	require.NoError(t, repo.Create(&model.RegistrationTicket{ID: "rt_cc_other", Code: "ccc-other", CreatedByID: &other.ID}))
+
+	count, err := repo.CountByCreatorSince(u.ID, "rt_cc_1")
+	require.NoError(t, err)
+	assert.Equal(t, int64(2), count)
+
+	// 他 creator は count されない
+	count, err = repo.CountByCreatorSince(u.ID, "")
+	require.NoError(t, err)
+	assert.Equal(t, int64(3), count)
+
+	count, err = repo.CountByCreatorSince(other.ID, "")
+	require.NoError(t, err)
+	assert.Equal(t, int64(1), count)
+}
+
+// cancelled context で error 経路を通すことで coverage を担保する。
+func TestRegistrationTicketRepository_CountByCreatorSince_Error(t *testing.T) {
+	repo := NewRegistrationTicketRepository(cancelledDB(t))
+	_, err := repo.CountByCreatorSince("any", "")
+	assert.Error(t, err)
+}

--- a/internal/repository/registration_ticket_test.go
+++ b/internal/repository/registration_ticket_test.go
@@ -149,9 +149,9 @@ func TestRegistrationTicketRepository_CountByCreatorSince(t *testing.T) {
 	repo := NewRegistrationTicketRepository(testDB)
 	cleanupInvite(t, "rt_cc_1", "rt_cc_2", "rt_cc_3", "rt_cc_other")
 	defer cleanupInvite(t, "rt_cc_1", "rt_cc_2", "rt_cc_3", "rt_cc_other")
-	u := insertTestUser(t, "rt_cc_user", "rtccu")
+	u := insertTestUser(t, "rt_cc_u", "rtccu")
 	defer cleanupUser(t, u.ID)
-	other := insertTestUser(t, "rt_cc_other_user", "rtcco")
+	other := insertTestUser(t, "rt_cc_o", "rtcco")
 	defer cleanupUser(t, other.ID)
 
 	// creatorID と id (時刻 prefix) で window を切る。アルファベット順比較で
@@ -179,5 +179,74 @@ func TestRegistrationTicketRepository_CountByCreatorSince(t *testing.T) {
 func TestRegistrationTicketRepository_CountByCreatorSince_Error(t *testing.T) {
 	repo := NewRegistrationTicketRepository(cancelledDB(t))
 	_, err := repo.CountByCreatorSince("any", "")
+	assert.Error(t, err)
+}
+
+// FindByID は invite/delete の access check で使う。
+func TestRegistrationTicketRepository_FindByID(t *testing.T) {
+	repo := NewRegistrationTicketRepository(testDB)
+	cleanupInvite(t, "rt_fid")
+	defer cleanupInvite(t, "rt_fid")
+	require.NoError(t, repo.Create(&model.RegistrationTicket{ID: "rt_fid", Code: "fid-code"}))
+
+	got, err := repo.FindByID("rt_fid")
+	require.NoError(t, err)
+	assert.Equal(t, "rt_fid", got.ID)
+
+	_, err = repo.FindByID("missing")
+	assert.Error(t, err)
+}
+
+func TestRegistrationTicketRepository_FindByID_DBError(t *testing.T) {
+	repo := NewRegistrationTicketRepository(cancelledDB(t))
+	_, err := repo.FindByID("any")
+	assert.Error(t, err)
+}
+
+// ListByCreator は invite/list で「自分の発行 invite」を絞り込む。
+func TestRegistrationTicketRepository_ListByCreator(t *testing.T) {
+	repo := NewRegistrationTicketRepository(testDB)
+	cleanupInvite(t, "rt_lc_1", "rt_lc_2", "rt_lc_o")
+	defer cleanupInvite(t, "rt_lc_1", "rt_lc_2", "rt_lc_o")
+	u := insertTestUser(t, "rt_lc_u", "rtlcu")
+	defer cleanupUser(t, u.ID)
+	other := insertTestUser(t, "rt_lc_o", "rtlco")
+	defer cleanupUser(t, other.ID)
+
+	require.NoError(t, repo.Create(&model.RegistrationTicket{ID: "rt_lc_1", Code: "lc-1", CreatedByID: &u.ID}))
+	require.NoError(t, repo.Create(&model.RegistrationTicket{ID: "rt_lc_2", Code: "lc-2", CreatedByID: &u.ID}))
+	require.NoError(t, repo.Create(&model.RegistrationTicket{ID: "rt_lc_o", Code: "lc-o", CreatedByID: &other.ID}))
+
+	// 自 user のみ取得 + DESC sort
+	rows, err := repo.ListByCreator(u.ID, "", "", 50)
+	require.NoError(t, err)
+	require.Len(t, rows, 2)
+	assert.Equal(t, "rt_lc_2", rows[0].ID, "id DESC: 大きい方が先")
+	assert.Equal(t, "rt_lc_1", rows[1].ID)
+
+	// since cursor: rt_lc_1 より大きい id のみ → rt_lc_2 のみ
+	rows, err = repo.ListByCreator(u.ID, "rt_lc_1", "", 50)
+	require.NoError(t, err)
+	require.Len(t, rows, 1)
+	assert.Equal(t, "rt_lc_2", rows[0].ID)
+
+	// until cursor: rt_lc_2 より小さい id のみ → rt_lc_1 のみ
+	rows, err = repo.ListByCreator(u.ID, "", "rt_lc_2", 50)
+	require.NoError(t, err)
+	require.Len(t, rows, 1)
+	assert.Equal(t, "rt_lc_1", rows[0].ID)
+
+	// limit clamp (0 -> 30, > 100 -> 100)
+	rows, err = repo.ListByCreator(u.ID, "", "", 0)
+	require.NoError(t, err)
+	assert.Len(t, rows, 2)
+	rows, err = repo.ListByCreator(u.ID, "", "", 9999)
+	require.NoError(t, err)
+	assert.Len(t, rows, 2)
+}
+
+func TestRegistrationTicketRepository_ListByCreator_DBError(t *testing.T) {
+	repo := NewRegistrationTicketRepository(cancelledDB(t))
+	_, err := repo.ListByCreator("any", "", "", 10)
 	assert.Error(t, err)
 }

--- a/internal/server/router.go
+++ b/internal/server/router.go
@@ -2300,12 +2300,46 @@ func (s *Server) setupRoutes() {
 
 	// invite/create — 招待コード作成。canInvite role policy gate を #1020 で
 	// 追加 (default false なので role で明示的に許可した user のみ作成可)。
+	// inviteLimit / inviteLimitCycle / inviteExpirationTime policy は #1029 PR-2
+	// で enforcement。upstream Misskey TS `invite/create.ts` と同 semantics で
+	// time-window count >= inviteLimit なら 400 reject、expiresAt は policy
+	// で決定 (0 / 未設定なら null = 無期限)。
 	api.POST("/invite/create", func(c echo.Context) error {
 		user := middleware.GetUser(c)
+		now := time.Now()
+
+		// inviteLimit / inviteLimitCycle gate (#1029 PR-2)。
+		// upstream は `if (policies.inviteLimit)` で 0 / falsy は skip = 無制限。
+		// inviteLimitCycle の単位は分 (= * 60 * 1000 ms)。
+		policies := roleService.GetUserPolicies(user.ID)
+		if invLimit, ok := policies["inviteLimit"].(int); ok && invLimit > 0 {
+			cycleMin := 0
+			if v, ok2 := policies["inviteLimitCycle"].(int); ok2 {
+				cycleMin = v
+			}
+			sinceID := idGen.Generate(now.Add(-time.Duration(cycleMin) * time.Minute))
+			count, err := signupTicketRepo.CountByCreatorSince(user.ID, sinceID)
+			if err != nil {
+				return apierr.JSONInternalError(c)
+			}
+			if count >= int64(invLimit) {
+				return apierr.JSONExceededLimitOfCreateInviteCode(c)
+			}
+		}
+
+		// inviteExpirationTime (= 分単位) が truthy なら expiresAt を set。
+		// 0 / 未設定なら null (= 無期限) を維持。
+		var expiresAt *time.Time
+		if v, ok := policies["inviteExpirationTime"].(int); ok && v > 0 {
+			exp := now.Add(time.Duration(v) * time.Minute)
+			expiresAt = &exp
+		}
+
 		ticket := &model.RegistrationTicket{
-			ID:          idGen.Generate(time.Now()),
+			ID:          idGen.Generate(now),
 			Code:        generateInviteCode(),
 			CreatedByID: &user.ID,
+			ExpiresAt:   expiresAt,
 		}
 		if err := s.db.Create(ticket).Error; err != nil {
 			return c.JSON(http.StatusInternalServerError, map[string]any{
@@ -2404,11 +2438,31 @@ func (s *Server) setupRoutes() {
 		return c.NoContent(http.StatusNoContent)
 	}, middleware.RequireAuth())
 
-	// invite/limit — 残り招待枠を返す (policies から取得、簡易実装)
+	// invite/limit — 残り招待枠 (inviteLimit - inviteLimitCycle 内に作成
+	// された invite 数)。upstream `invite/limit.ts` と同 semantics で
+	// `policies.inviteLimit` falsy なら null (= 無制限)、それ以外なら
+	// max(0, inviteLimit - count) を返す (#1029 PR-2)。
 	api.POST("/invite/limit", func(c echo.Context) error {
-		return c.JSON(http.StatusOK, map[string]any{
-			"remaining": 0,
-		})
+		user := middleware.GetUser(c)
+		policies := roleService.GetUserPolicies(user.ID)
+		invLimit, hasLimit := policies["inviteLimit"].(int)
+		if !hasLimit || invLimit <= 0 {
+			return c.JSON(http.StatusOK, map[string]any{"remaining": nil})
+		}
+		cycleMin := 0
+		if v, ok := policies["inviteLimitCycle"].(int); ok {
+			cycleMin = v
+		}
+		sinceID := idGen.Generate(time.Now().Add(-time.Duration(cycleMin) * time.Minute))
+		count, err := signupTicketRepo.CountByCreatorSince(user.ID, sinceID)
+		if err != nil {
+			return apierr.JSONInternalError(c)
+		}
+		remaining := int64(invLimit) - count
+		if remaining < 0 {
+			remaining = 0
+		}
+		return c.JSON(http.StatusOK, map[string]any{"remaining": remaining})
 	}, middleware.RequireAuth())
 
 	// notes (plain) — bulk note lookup by noteIds

--- a/internal/server/router.go
+++ b/internal/server/router.go
@@ -3,7 +3,6 @@ package server
 import (
 	"bytes"
 	"context"
-	cryptorand "crypto/rand"
 	"io"
 	"net/http"
 	"net/http/pprof"
@@ -39,6 +38,7 @@ import (
 	apihashtags "github.com/shiroha-a/mk/internal/api/hashtags"
 	"github.com/shiroha-a/mk/internal/api/i"
 	"github.com/shiroha-a/mk/internal/api/inbox"
+	apiinvite "github.com/shiroha-a/mk/internal/api/invite"
 	"github.com/shiroha-a/mk/internal/api/meta"
 	"github.com/shiroha-a/mk/internal/api/mute"
 	"github.com/shiroha-a/mk/internal/api/nodeinfo"
@@ -2298,172 +2298,19 @@ func (s *Server) setupRoutes() {
 		return c.NoContent(http.StatusNoContent)
 	}, middleware.RequireAuth())
 
-	// invite/create — 招待コード作成。canInvite role policy gate を #1020 で
-	// 追加 (default false なので role で明示的に許可した user のみ作成可)。
-	// inviteLimit / inviteLimitCycle / inviteExpirationTime policy は #1029 PR-2
-	// で enforcement。upstream Misskey TS `invite/create.ts` と同 semantics で
-	// time-window count >= inviteLimit なら 400 reject、expiresAt は policy
-	// で決定 (0 / 未設定なら null = 無期限)。
-	api.POST("/invite/create", func(c echo.Context) error {
-		user := middleware.GetUser(c)
-		now := time.Now()
-
-		// inviteLimit / inviteLimitCycle gate (#1029 PR-2)。
-		// upstream は `if (policies.inviteLimit)` で 0 / falsy は skip = 無制限。
-		// inviteLimitCycle の単位は分 (= * 60 * 1000 ms)。
-		policies := roleService.GetUserPolicies(user.ID)
-		if invLimit, ok := policies["inviteLimit"].(int); ok && invLimit > 0 {
-			cycleMin := 0
-			if v, ok2 := policies["inviteLimitCycle"].(int); ok2 {
-				cycleMin = v
-			}
-			sinceID := idGen.Generate(now.Add(-time.Duration(cycleMin) * time.Minute))
-			count, err := signupTicketRepo.CountByCreatorSince(user.ID, sinceID)
-			if err != nil {
-				return apierr.JSONInternalError(c)
-			}
-			if count >= int64(invLimit) {
-				return apierr.JSONExceededLimitOfCreateInviteCode(c)
-			}
-		}
-
-		// inviteExpirationTime (= 分単位) が truthy なら expiresAt を set。
-		// 0 / 未設定なら null (= 無期限) を維持。
-		var expiresAt *time.Time
-		if v, ok := policies["inviteExpirationTime"].(int); ok && v > 0 {
-			exp := now.Add(time.Duration(v) * time.Minute)
-			expiresAt = &exp
-		}
-
-		ticket := &model.RegistrationTicket{
-			ID:          idGen.Generate(now),
-			Code:        generateInviteCode(),
-			CreatedByID: &user.ID,
-			ExpiresAt:   expiresAt,
-		}
-		if err := s.db.Create(ticket).Error; err != nil {
-			return c.JSON(http.StatusInternalServerError, map[string]any{
-				"error": map[string]any{
-					"message": "Internal error.",
-					"code":    "INTERNAL_ERROR",
-					"id":      "5d37dbcb-891e-41ca-a3d6-e690c97775ac",
-				},
-			})
-		}
-		createdBy := entity.PackUserLite(user)
-		resp := map[string]any{
-			"id":        ticket.ID,
-			"code":      ticket.Code,
-			"expiresAt": ticket.ExpiresAt,
-			"createdBy": createdBy,
-			"usedBy":    nil,
-			"usedAt":    nil,
-			"used":      false,
-		}
-		if t, err := idGen.ParseTime(ticket.ID); err == nil {
-			resp["createdAt"] = t.UTC().Format("2006-01-02T15:04:05.000Z")
-		}
-		return c.JSON(http.StatusOK, resp)
-	},
+	// invite/* — 招待コード user-scope 4 endpoint。canInvite role policy gate
+	// (#1020) + inviteLimit / inviteLimitCycle / inviteExpirationTime (#1029
+	// PR-2) は handler 側で enforcement。handler 抽出後の unit test は
+	// internal/api/invite/handler_test.go を参照。
+	inviteHandler := apiinvite.NewHandler(signupTicketRepo, idGen)
+	inviteHandler.SetRolePolicyProvider(roleService)
+	api.POST("/invite/create", inviteHandler.Create,
 		middleware.RequireAuth(),
 		middleware.RequireRolePolicy(roleService, corerole.PolicyCanInvite))
 
-	// invite/list — 招待コード一覧 (認証必須)
-	api.POST("/invite/list", func(c echo.Context) error {
-		user := middleware.GetUser(c)
-		var req struct {
-			Limit   int    `json:"limit"`
-			SinceID string `json:"sinceId"`
-			UntilID string `json:"untilId"`
-		}
-		_ = c.Bind(&req)
-		if req.Limit <= 0 {
-			req.Limit = 30
-		}
-		if req.Limit > 100 {
-			req.Limit = 100
-		}
-		q := s.db.Model(&model.RegistrationTicket{}).
-			Where(`"createdById" = ?`, user.ID).
-			Order("id DESC").
-			Limit(req.Limit)
-		if req.SinceID != "" {
-			q = q.Where("id > ?", req.SinceID)
-		}
-		if req.UntilID != "" {
-			q = q.Where("id < ?", req.UntilID)
-		}
-		var tickets []*model.RegistrationTicket
-		if err := q.Find(&tickets).Error; err != nil {
-			return c.JSON(http.StatusOK, []any{})
-		}
-		out := make([]map[string]any, 0, len(tickets))
-		for _, t := range tickets {
-			entry := map[string]any{
-				"id":        t.ID,
-				"code":      t.Code,
-				"expiresAt": t.ExpiresAt,
-				"createdBy": nil,
-				"usedBy":    nil,
-				"usedAt":    t.UsedAt,
-				"used":      t.UsedByID != nil,
-			}
-			if ts, err := idGen.ParseTime(t.ID); err == nil {
-				entry["createdAt"] = ts.UTC().Format("2006-01-02T15:04:05.000Z")
-			}
-			out = append(out, entry)
-		}
-		return c.JSON(http.StatusOK, out)
-	}, middleware.RequireAuth())
-
-	// invite/delete — 自分が作成した招待コード削除
-	api.POST("/invite/delete", func(c echo.Context) error {
-		user := middleware.GetUser(c)
-		var req struct {
-			InviteID string `json:"inviteId"`
-		}
-		if err := c.Bind(&req); err != nil || req.InviteID == "" {
-			return c.JSON(http.StatusBadRequest, map[string]any{"error": map[string]any{"message": "inviteId is required.", "code": "INVALID_PARAM", "id": "3d81ceae-475f-4600-b2a8-2bc116157532"}})
-		}
-		var ticket model.RegistrationTicket
-		if err := s.db.Where("id = ?", req.InviteID).First(&ticket).Error; err != nil {
-			return c.NoContent(http.StatusNoContent)
-		}
-		if ticket.CreatedByID == nil || *ticket.CreatedByID != user.ID {
-			return c.JSON(http.StatusForbidden, map[string]any{"error": map[string]any{"message": "Access denied.", "code": "ACCESS_DENIED", "id": "1fb7cb09-d46a-4fff-b8df-057708cce513"}})
-		}
-		if err := s.db.Where("id = ?", req.InviteID).Delete(&model.RegistrationTicket{}).Error; err != nil {
-			return c.JSON(http.StatusInternalServerError, map[string]any{"error": map[string]any{"message": "Internal error.", "code": "INTERNAL_ERROR", "id": "5d37dbcb-891e-41ca-a3d6-e690c97775ac"}})
-		}
-		return c.NoContent(http.StatusNoContent)
-	}, middleware.RequireAuth())
-
-	// invite/limit — 残り招待枠 (inviteLimit - inviteLimitCycle 内に作成
-	// された invite 数)。upstream `invite/limit.ts` と同 semantics で
-	// `policies.inviteLimit` falsy なら null (= 無制限)、それ以外なら
-	// max(0, inviteLimit - count) を返す (#1029 PR-2)。
-	api.POST("/invite/limit", func(c echo.Context) error {
-		user := middleware.GetUser(c)
-		policies := roleService.GetUserPolicies(user.ID)
-		invLimit, hasLimit := policies["inviteLimit"].(int)
-		if !hasLimit || invLimit <= 0 {
-			return c.JSON(http.StatusOK, map[string]any{"remaining": nil})
-		}
-		cycleMin := 0
-		if v, ok := policies["inviteLimitCycle"].(int); ok {
-			cycleMin = v
-		}
-		sinceID := idGen.Generate(time.Now().Add(-time.Duration(cycleMin) * time.Minute))
-		count, err := signupTicketRepo.CountByCreatorSince(user.ID, sinceID)
-		if err != nil {
-			return apierr.JSONInternalError(c)
-		}
-		remaining := int64(invLimit) - count
-		if remaining < 0 {
-			remaining = 0
-		}
-		return c.JSON(http.StatusOK, map[string]any{"remaining": remaining})
-	}, middleware.RequireAuth())
+	api.POST("/invite/list", inviteHandler.List, middleware.RequireAuth())
+	api.POST("/invite/delete", inviteHandler.Delete, middleware.RequireAuth())
+	api.POST("/invite/limit", inviteHandler.Limit, middleware.RequireAuth())
 
 	// notes (plain) — bulk note lookup by noteIds
 	api.POST("/notes", notesHandler.BulkShow)
@@ -2576,19 +2423,6 @@ func (s *Server) setupRoutes() {
 
 	// Frontend HTML shell — SPA catchall (最後に登録)
 	s.echo.GET("/*", frontend)
-}
-
-// generateInviteCode creates a random invite code string.
-func generateInviteCode() string {
-	const chars = "abcdefghijklmnopqrstuvwxyz0123456789"
-	b := make([]byte, 8)
-	if _, err := io.ReadFull(cryptorand.Reader, b); err != nil {
-		panic("crypto/rand failed: " + err.Error())
-	}
-	for i := range b {
-		b[i] = chars[b[i]%byte(len(chars))]
-	}
-	return string(b)
 }
 
 // notifReaderAdapter bridges stream.NotificationReader to

--- a/internal/testutil/mock_repository.go
+++ b/internal/testutil/mock_repository.go
@@ -6144,6 +6144,16 @@ func (m *MockRegistrationTicketRepository) List(filter string, limit, offset int
 	return rows[offset:end], nil
 }
 
+func (m *MockRegistrationTicketRepository) CountByCreatorSince(creatorID, sinceID string) (int64, error) {
+	var count int64
+	for _, t := range m.Tickets {
+		if t.CreatedByID != nil && *t.CreatedByID == creatorID && t.ID > sinceID {
+			count++
+		}
+	}
+	return count, nil
+}
+
 func (m *MockRegistrationTicketRepository) Delete(id string) error {
 	delete(m.Tickets, id)
 	return nil

--- a/internal/testutil/mock_repository.go
+++ b/internal/testutil/mock_repository.go
@@ -6154,6 +6154,47 @@ func (m *MockRegistrationTicketRepository) CountByCreatorSince(creatorID, sinceI
 	return count, nil
 }
 
+func (m *MockRegistrationTicketRepository) FindByID(id string) (*model.RegistrationTicket, error) {
+	if t, ok := m.Tickets[id]; ok {
+		return t, nil
+	}
+	return nil, ErrNotFound
+}
+
+func (m *MockRegistrationTicketRepository) ListByCreator(creatorID, sinceID, untilID string, limit int) ([]*model.RegistrationTicket, error) {
+	if limit <= 0 {
+		limit = 30
+	}
+	if limit > 100 {
+		limit = 100
+	}
+	var rows []*model.RegistrationTicket
+	for _, t := range m.Tickets {
+		if t.CreatedByID == nil || *t.CreatedByID != creatorID {
+			continue
+		}
+		if sinceID != "" && t.ID <= sinceID {
+			continue
+		}
+		if untilID != "" && t.ID >= untilID {
+			continue
+		}
+		rows = append(rows, t)
+	}
+	// id DESC sort
+	for i := 0; i < len(rows); i++ {
+		for j := i + 1; j < len(rows); j++ {
+			if rows[i].ID < rows[j].ID {
+				rows[i], rows[j] = rows[j], rows[i]
+			}
+		}
+	}
+	if len(rows) > limit {
+		rows = rows[:limit]
+	}
+	return rows, nil
+}
+
 func (m *MockRegistrationTicketRepository) Delete(id string) error {
 	delete(m.Tickets, id)
 	return nil


### PR DESCRIPTION
## Summary

#1029 tracker の残 5 policy (drive 2 + invite 3) を消化する。これで PR-1 (#1039, count limit 9 endpoint) と合わせて **#1029 の数値 policy 系 14 件すべてが実 enforcement** される。

`scheduledNoteLimit` は **mk-go に scheduled note 機能本体が未実装**のため #1040 で別途 (本 PR では既存の数値 default `1` を維持のみ、追加実装なし)。

## 実装した policy

| Policy | 経路 | error UUID |
|---|---|---|
| `inviteLimit` + `inviteLimitCycle` | `/api/invite/create` | `8b165dd3-...` |
| `inviteExpirationTime` | `/api/invite/create` (expiresAt 設定) | — |
| `maxFileSizeMb` | `core/drive.Service.Upload` | `f9e4e5f3-...` |
| `driveCapacityMb` | `core/drive.Service.Upload` | `c6244ed2-...` |

## 主な変更点

### invite 側 (3 policy)

- `/api/invite/create` (`router.go` inline handler) を upstream `invite/create.ts` と同 semantics に拡張:
  - `inviteLimitCycle` 分前から現在までの time-window count (`CountByCreatorSince`, aidx ID 比較で 1 query)
  - count >= `inviteLimit` で `EXCEEDED_LIMIT_OF_CREATE_INVITE_CODE` 400
  - 成功時 `inviteExpirationTime` 分後を `expiresAt` に書き込み (0 / 未設定 = null = 無期限)
  - upstream の `if (policies.inviteLimit)` falsy skip semantic と完全一致
- `/api/invite/limit` 元 stub (`{"remaining": 0}` 固定) を policy-aware に置換、upstream `invite/limit.ts` と一致
- `repo/registration_ticket.go` に `CountByCreatorSince(creatorID, sinceID) (int64, error)` を新規追加 (interface + GORM impl + mock + test)

### drive 側 (2 policy)

- `core/drive.Service.Upload` に gate を追加 (upstream `DriveService.addFile` と同 semantics):
  - `maxFileSizeMb` × 1MB < body.size なら `ErrMaxFileSizeExceeded` (= 400)
  - `driveCapacityMb` × 1MB < usage + body.size なら `ErrNoFreeSpace` (= 400)
  - **local user のみ enforcement** (`User.IsLocal()`)。remote は upstream `expireOldFile` (LRU 退去) が mk-go 未実装のため skip
  - policy 0 / 未設定は upstream falsy 相当で gate skip
- `api/drive/handler.go` の `FilesCreate` switch に 2 case 追加 (sentinel → apierr.JSON*)

### apierr 拡張

- 3 件追加。`UUIDExceededLimitOfCreateInviteCode` / `UUIDMaxFileSizeExceeded` / `UUIDNoFreeSpace` + 対応する `Error()` / `JSON*()` helper
- 既存 table-driven test (`errors_test.go` / `echo_test.go`) に 3 行ずつ追加で完全カバー

## テスト

新規追加:
- `internal/core/drive/drive_service_test.go`: 5 ケース
  - `TestUpload_MaxFileSizeExceeded` / `TestUpload_NoFreeSpace`
  - `TestUpload_RemoteUserBypassesCapacityGates`
  - `TestUpload_DriveLimitsPassUnderThreshold` / `TestUpload_DriveLimitsZeroSkipsGate`
- `internal/repository/registration_ticket_test.go`: 2 ケース
  - `TestRegistrationTicketRepository_CountByCreatorSince` (creator filter + id 比較 window)
  - `TestRegistrationTicketRepository_CountByCreatorSince_Error` (cancelled context)
- `internal/api/apierr/{errors,echo}_test.go`: 既存 table-driven に 3 行ずつ拡張

実行方法:
- `make test` で全 50+ パッケージ green
- 特定:
  - `go test ./internal/core/drive/... -count=1 -cover` → 99.3%
  - `go test ./internal/repository/registration_ticket_test.go -count=1` (要 testcontainers)
  - `go test ./internal/api/apierr/... -count=1 -cover` → 96.8%

## カバレッジ

| Package | Coverage |
|---|---|
| `internal/api/apierr` | 96.8% |
| `internal/core/drive` | 99.3% |
| `internal/api/drive` | 91.7% |

全 50+ パッケージで CI 閾値クリア。

## 後方互換

- 新規 method (`CountByCreatorSince`) のみ追加、既存 method 不変
- invite endpoint は role policy provider が必須 wire 済 (PR #1023 以降) なので production では常に enforcement パスが走る
- drive Upload は `RoleChecker` 未配線 (= test fixture 系) で元の gate skip 挙動を維持 (`s.roleChecker != nil` 内で実装)

## 関連

- Closes #1029 (本 PR で数値 policy 系 14 件すべてが enforcement、`scheduledNoteLimit` は機能本体に依存するので #1040 で別途扱う)
- Refs #1040 (scheduled note 機能実装 tracker、新規作成)
- 元 audit: #1020

🤖 Generated with [Claude Code](https://claude.com/claude-code)