### PR TITLE
fix(federation): remote actor の summary を UserProfile.description に取り込む (#1022)

### DIFF
--- a/internal/core/federation/resolver.go
+++ b/internal/core/federation/resolver.go
@@ -382,12 +382,53 @@ func (r *Resolver) resolveActorOnce(uri string) (*model.User, error) {
 	if err := r.userRepo.Create(user); err != nil {
 		return nil, err
 	}
+	// remote actor の bio (= AP `summary` または `_misskey_summary`) を
+	// `user_profile.description` に取り込む (#1022)。profile 行を作成しないと
+	// 既存の Description 取得経路が常に NULL を返してしまい、frontend で
+	// 自己紹介欄が空のまま表示される regression につながる。
+	hostCopy := host
+	profile := &model.UserProfile{
+		UserID:      user.ID,
+		Description: extractRemoteDescription(actor),
+		UserHost:    &hostCopy,
+	}
+	if err := r.userRepo.CreateProfile(profile); err != nil {
+		// profile 作成失敗時は user 取り込みは成立させる (= 次回 refreshActor
+		// で back-fill する経路を維持)。production race / fixture 衝突など
+		// transient な失敗時に actor resolve 自体まで道連れにしない。
+		slog.Warn("create remote user profile failed", "userId", user.ID, "err", err)
+	}
 	r.cachePublicKey(user.ID, actor.PublicKey.ID, actor.PublicKey.PublicKeyPEM)
 	r.notifyInstance(host)
 	if r.chartHook != nil {
 		r.chartHook.OnRemoteUserCreated(user)
 	}
 	return user, nil
+}
+
+// extractRemoteDescription returns the actor's bio mapped to
+// UserProfile.Description. upstream `ApPersonService` の logic と同じく
+// `_misskey_summary` (MFM そのまま) を優先し、なければ AP `summary` (HTML
+// or plain text) を採用する。upstream は htmlToMfm で MFM 変換してから保存
+// するが、mk-go には未実装なので生 HTML をそのまま保存する (= frontend
+// 側で render される、見た目は upstream と完全互換ではないが Empty 化は
+// 回避される。HTML→MFM 変換は将来の別 issue で扱う)。
+// varchar(2048) 制約を rune 単位で respect し、空は nil で表す。
+func extractRemoteDescription(actor *activitypub.Person) *string {
+	var raw string
+	if actor.MisskeySummary != "" {
+		raw = actor.MisskeySummary
+	} else if actor.Summary != "" {
+		raw = actor.Summary
+	}
+	if raw == "" {
+		return nil
+	}
+	const maxLen = 2048
+	if runes := []rune(raw); len(runes) > maxLen {
+		raw = string(runes[:maxLen])
+	}
+	return &raw
 }
 
 // ForceResolveActor resolves an actor and always re-fetches the profile,
@@ -503,6 +544,20 @@ func (r *Resolver) refreshActor(existing *model.User, uri string) {
 	existing.LastFetchedAt = &now
 	// UpdateUserエラーはベストエフォートで無視 (次回再試行される)
 	_ = r.userRepo.UpdateUser(existing.ID, fields)
+	// UserProfile.Description (#1022)。actor.Summary が変わった場合に追従する。
+	// profile 行が無いケース (= 本 fix 以前に取り込まれた remote user) は
+	// back-fill する。Update / Create のいずれも best-effort で fail しても
+	// user 更新は維持する。
+	desc := extractRemoteDescription(actor)
+	if _, err := r.userRepo.FindProfileByUserID(existing.ID); err != nil {
+		_ = r.userRepo.CreateProfile(&model.UserProfile{
+			UserID:      existing.ID,
+			Description: desc,
+			UserHost:    existing.Host,
+		})
+	} else {
+		_ = r.userRepo.UpdateProfile(existing.ID, map[string]any{"description": desc})
+	}
 	r.cachePublicKey(existing.ID, actor.PublicKey.ID, actor.PublicKey.PublicKeyPEM)
 	if existing.Host != nil {
 		r.notifyInstance(*existing.Host)

--- a/internal/core/federation/resolver_test.go
+++ b/internal/core/federation/resolver_test.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"net/http"
 	"strconv"
+	"strings"
 	"sync"
 	"sync/atomic"
 	"testing"
@@ -164,6 +165,81 @@ func TestResolveActor_NewUserWithoutIconBanner(t *testing.T) {
 	require.NoError(t, err)
 	assert.Nil(t, user.AvatarURL)
 	assert.Nil(t, user.BannerURL)
+}
+
+// --- #1022: remote actor summary → UserProfile.description ---
+
+// AP `summary` (= リモートユーザの bio) を UserProfile.description に取り込む。
+// profile 行も同時に作成される (= 旧実装は user 行のみ作成していた regression)。
+func TestResolveActor_NewUserIngestsDescription(t *testing.T) {
+	body := `{
+		"id": "https://remote.example/users/alice",
+		"type": "Person",
+		"preferredUsername": "alice",
+		"inbox": "https://remote.example/users/alice/inbox",
+		"summary": "<p>Hello from remote!</p>",
+		"publicKey": {"publicKeyPem": "FAKE"}
+	}`
+	r, repo := newResolver(t, body, nil)
+	user, err := r.ResolveActor("https://remote.example/users/alice")
+	require.NoError(t, err)
+	profile, err := repo.FindProfileByUserID(user.ID)
+	require.NoError(t, err, "profile 行が作成される (back-fill 経路の前提)")
+	require.NotNil(t, profile.Description)
+	assert.Equal(t, "<p>Hello from remote!</p>", *profile.Description)
+}
+
+// `_misskey_summary` がある場合は AP `summary` より優先される (upstream
+// ApPersonService と同じ logic、MFM が壊れずに保存される)。
+func TestResolveActor_NewUserPrefersMisskeySummary(t *testing.T) {
+	body := `{
+		"id": "https://remote.example/users/alice",
+		"type": "Person",
+		"preferredUsername": "alice",
+		"inbox": "https://remote.example/users/alice/inbox",
+		"summary": "<p>HTML summary</p>",
+		"_misskey_summary": "**MFM summary**",
+		"publicKey": {"publicKeyPem": "FAKE"}
+	}`
+	r, repo := newResolver(t, body, nil)
+	user, err := r.ResolveActor("https://remote.example/users/alice")
+	require.NoError(t, err)
+	profile, err := repo.FindProfileByUserID(user.ID)
+	require.NoError(t, err)
+	require.NotNil(t, profile.Description)
+	assert.Equal(t, "**MFM summary**", *profile.Description)
+}
+
+// summary 無し actor も profile 行は作成され、Description は nil。
+// 既存 production DB の back-fill 経路 (next refresh で追記) が成立する前提。
+func TestResolveActor_NewUserNoSummary(t *testing.T) {
+	r, repo := newResolver(t, sampleActor, nil)
+	user, err := r.ResolveActor("https://remote.example/users/alice")
+	require.NoError(t, err)
+	profile, err := repo.FindProfileByUserID(user.ID)
+	require.NoError(t, err)
+	assert.Nil(t, profile.Description, "summary 無しは Description nil")
+}
+
+// 2048 rune を超える summary は varchar(2048) 制約に合わせて truncate。
+// rune 単位で切ることで UTF-8 multibyte 文字境界が壊れない。
+func TestResolveActor_NewUserDescriptionTruncated(t *testing.T) {
+	long := strings.Repeat("あ", 2100) // 2100 rune
+	body := `{
+		"id": "https://remote.example/users/alice",
+		"type": "Person",
+		"preferredUsername": "alice",
+		"inbox": "https://remote.example/users/alice/inbox",
+		"summary": "` + long + `",
+		"publicKey": {"publicKeyPem": "FAKE"}
+	}`
+	r, repo := newResolver(t, body, nil)
+	user, err := r.ResolveActor("https://remote.example/users/alice")
+	require.NoError(t, err)
+	profile, err := repo.FindProfileByUserID(user.ID)
+	require.NoError(t, err)
+	require.NotNil(t, profile.Description)
+	assert.Equal(t, 2048, len([]rune(*profile.Description)))
 }
 
 func TestResolveActor_ExistingUser(t *testing.T) {
@@ -1195,6 +1271,77 @@ func TestResolveActor_TTLRefresh(t *testing.T) {
 	pem, err := r.PublicKeyForActor("existing")
 	require.NoError(t, err)
 	assert.Contains(t, pem, "REFRESHED")
+}
+
+// refresh 時に actor.summary を UserProfile.description に同期する (#1022)。
+// profile 行が既に存在するケース (= post-fix で新規取り込まれた user) は
+// UpdateProfile 経由で description を上書きする。
+func TestResolveActor_TTLRefreshUpdatesDescription(t *testing.T) {
+	repo := testutil.NewMockUserRepository()
+	noteRepo := testutil.NewMockNoteRepository()
+	urls := activitypub.NewURLBuilder("https://example.com")
+	idGen, _ := id.NewGenerator("aidx")
+	uri := "https://remote.example/users/alice"
+	old := time.Now().Add(-48 * time.Hour)
+	repo.Users["existing"] = &model.User{
+		ID:            "existing",
+		Username:      "alice",
+		URI:           &uri,
+		LastFetchedAt: &old,
+	}
+	oldDesc := "old bio"
+	repo.Profiles["existing"] = &model.UserProfile{
+		UserID:      "existing",
+		Description: &oldDesc,
+	}
+	updated := `{
+		"id": "https://remote.example/users/alice",
+		"type": "Person",
+		"preferredUsername": "alice",
+		"inbox": "https://remote.example/users/alice/inbox",
+		"summary": "new bio",
+		"publicKey": {"publicKeyPem": "REFRESHED"}
+	}`
+	r := federation.NewResolver(repo, noteRepo, urls, &stubFetcher{body: []byte(updated)}, idGen)
+	_, err := r.ResolveActor(uri)
+	require.NoError(t, err)
+	require.NotNil(t, repo.Profiles["existing"].Description)
+	assert.Equal(t, "new bio", *repo.Profiles["existing"].Description)
+}
+
+// 既存 user で profile 行が無い (= 本 fix 以前に取り込まれた remote user) は
+// refresh 経路で back-fill される (#1022)。production の漸進的な救済経路。
+func TestResolveActor_TTLRefreshBackfillsProfile(t *testing.T) {
+	repo := testutil.NewMockUserRepository()
+	noteRepo := testutil.NewMockNoteRepository()
+	urls := activitypub.NewURLBuilder("https://example.com")
+	idGen, _ := id.NewGenerator("aidx")
+	uri := "https://remote.example/users/alice"
+	old := time.Now().Add(-48 * time.Hour)
+	host := "remote.example"
+	repo.Users["existing"] = &model.User{
+		ID:            "existing",
+		Username:      "alice",
+		Host:          &host,
+		URI:           &uri,
+		LastFetchedAt: &old,
+	}
+	// profile 行は意図的に未作成
+	updated := `{
+		"id": "https://remote.example/users/alice",
+		"type": "Person",
+		"preferredUsername": "alice",
+		"inbox": "https://remote.example/users/alice/inbox",
+		"summary": "back-filled bio",
+		"publicKey": {"publicKeyPem": "REFRESHED"}
+	}`
+	r := federation.NewResolver(repo, noteRepo, urls, &stubFetcher{body: []byte(updated)}, idGen)
+	_, err := r.ResolveActor(uri)
+	require.NoError(t, err)
+	profile, err := repo.FindProfileByUserID("existing")
+	require.NoError(t, err, "back-fill で profile 行が作成される")
+	require.NotNil(t, profile.Description)
+	assert.Equal(t, "back-filled bio", *profile.Description)
 }
 
 func TestResolveActor_TTLRefreshUpdatesIconBanner(t *testing.T) {


### PR DESCRIPTION
## Summary

UDS 本番で発見されたリモートユーザ description (自己紹介) 表示バグの修正。

## 原因

`resolveActorOnce` は new remote actor 取り込み時に `model.User` 行のみ作成し、`model.UserProfile` 行を作成していなかった。さらに `actor.Summary` (AP の `summary` フィールド) を読む処理も無いため、Description 以外にも profile-side フィールド一式が常に空のままだった。`refreshActor` も同様 profile 不触で、profile 更新時の同期も発生しない。

## 主な変更点

- `resolveActorOnce`: user 作成成功後に `userRepo.CreateProfile` で profile 行を明示的に作成。`extractRemoteDescription` helper で upstream `ApPersonService` と同 logic (= `_misskey_summary` 優先、なければ AP `summary`、空は nil、varchar(2048) は rune 単位 truncate) で Description を導出。
- `refreshActor`: `actor.Summary` の変更を `UserProfile.Description` に同期。profile 行が無いケース (本 fix 以前に取り込まれた既存 user) は back-fill 経路で補完。
- HTML → MFM 変換 (htmlToMfm 相当) は mk-go 未実装のため本 PR では生 HTML 保存。完全互換は別 issue。

## テスト

resolver_test.go に 6 ケース追加:
- `TestResolveActor_NewUserIngestsDescription`
- `TestResolveActor_NewUserPrefersMisskeySummary`
- `TestResolveActor_NewUserNoSummary`
- `TestResolveActor_NewUserDescriptionTruncated`
- `TestResolveActor_TTLRefreshUpdatesDescription`
- `TestResolveActor_TTLRefreshBackfillsProfile`

実行: `go test ./internal/core/federation/... -count=1 -cover` → coverage 90.3%。

## カバレッジ

| Package | Coverage |
|---|---|
| `internal/core/federation` | 90.3% (閾値クリア) |

## scope 外 (別 issue 候補)

- HTML → MFM 変換 (htmlToMfm 相当)
- 他 profile field の取り込み (fields / birthday / location 等)

## 関連

- Closes #1022 (元 UDS bug)
- Refs upstream `ApPersonService.ts:398` / `:608` (= 移植元 logic)

🤖 Generated with [Claude Code](https://claude.com/claude-code)