### PR TITLE
feat(notes): scheduled note 機能を mk-go に実装 (Phase 1: drafts/create + queue + policy) (#1040)

### DIFF
--- a/internal/api/apierr/echo.go
+++ b/internal/api/apierr/echo.go
@@ -127,6 +127,21 @@ func JSONNoFreeSpace(c echo.Context) error {
 	return c.JSON(http.StatusBadRequest, NoFreeSpace())
 }
 
+// JSONTooManyScheduledNotes writes a 400 TOO_MANY_SCHEDULED_NOTES response.
+func JSONTooManyScheduledNotes(c echo.Context) error {
+	return c.JSON(http.StatusBadRequest, TooManyScheduledNotes())
+}
+
+// JSONScheduledAtRequired writes a 400 SCHEDULED_AT_REQUIRED response.
+func JSONScheduledAtRequired(c echo.Context) error {
+	return c.JSON(http.StatusBadRequest, ScheduledAtRequired())
+}
+
+// JSONScheduledAtMustBeInFuture writes a 400 SCHEDULED_AT_MUST_BE_IN_FUTURE response.
+func JSONScheduledAtMustBeInFuture(c echo.Context) error {
+	return c.JSON(http.StatusBadRequest, ScheduledAtMustBeInFuture())
+}
+
 // JSONNoSuchRenoteTarget writes a 404 NO_SUCH_RENOTE_TARGET response to the client.
 func JSONNoSuchRenoteTarget(c echo.Context) error {
 	return c.JSON(http.StatusNotFound, NoSuchRenoteTarget())

--- a/internal/api/apierr/echo_test.go
+++ b/internal/api/apierr/echo_test.go
@@ -144,6 +144,9 @@ func TestJSONCountLimitHelpers(t *testing.T) {
 		{"ExceededLimitOfCreateInviteCode", JSONExceededLimitOfCreateInviteCode, "EXCEEDED_LIMIT_OF_CREATE_INVITE_CODE", UUIDExceededLimitOfCreateInviteCode},
 		{"MaxFileSizeExceeded", JSONMaxFileSizeExceeded, "MAX_FILE_SIZE_EXCEEDED", UUIDMaxFileSizeExceeded},
 		{"NoFreeSpace", JSONNoFreeSpace, "NO_FREE_SPACE", UUIDNoFreeSpace},
+		{"TooManyScheduledNotes", JSONTooManyScheduledNotes, "TOO_MANY_SCHEDULED_NOTES", UUIDTooManyScheduledNotes},
+		{"ScheduledAtRequired", JSONScheduledAtRequired, "SCHEDULED_AT_REQUIRED", UUIDScheduledAtRequired},
+		{"ScheduledAtMustBeInFuture", JSONScheduledAtMustBeInFuture, "SCHEDULED_AT_MUST_BE_IN_FUTURE", UUIDScheduledAtMustBeInFuture},
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {

--- a/internal/api/apierr/errors.go
+++ b/internal/api/apierr/errors.go
@@ -76,6 +76,12 @@ const (
 	UUIDMaxFileSizeExceeded             = "f9e4e5f3-4df4-40b5-b400-f236945f7073" // drive/files/create (maxFileSizeMb)
 	UUIDNoFreeSpace                     = "c6244ed2-a39a-4e1c-bf93-f0fbd7764fa6" // drive/files/create (driveCapacityMb)
 
+	// 以下は #1040 (scheduled note 機能) で使う UUID。upstream
+	// notes/drafts/create endpoint の error meta と完全一致。
+	UUIDTooManyScheduledNotes     = "c3275f19-4558-4c59-83e1-4f684b5fab66" // drafts/create scheduledNoteLimit 超過
+	UUIDScheduledAtRequired       = "94a89a43-3591-400a-9c17-dd166e71fdfa" // isActuallyScheduled=true で scheduledAt=null
+	UUIDScheduledAtMustBeInFuture = "b34d0c1b-996f-4e34-a428-c636d98df457" // scheduledAt <= now
+
 	// UUIDNoSuchEmoji は upstream `admin/emoji/update` の `noSuchEmoji` UUID
 	// (third_party/misskey/.../endpoints/admin/emoji/update.ts:24)。mk-go の
 	// 旧実装は `684b7e7e-...` という typo'd 値を返していた regression を
@@ -316,6 +322,24 @@ func MaxFileSizeExceeded() map[string]any {
 // user's drive usage plus the uploaded file size exceeds `driveCapacityMb`.
 func NoFreeSpace() map[string]any {
 	return Error("NO_FREE_SPACE", "No free space.", UUIDNoFreeSpace)
+}
+
+// TooManyScheduledNotes returns the upstream `notes/drafts/create` shape thrown
+// when the user has reached the `scheduledNoteLimit` role policy.
+func TooManyScheduledNotes() map[string]any {
+	return Error("TOO_MANY_SCHEDULED_NOTES", "You cannot create scheduled notes any more.", UUIDTooManyScheduledNotes)
+}
+
+// ScheduledAtRequired returns the upstream shape thrown when
+// `isActuallyScheduled=true` is set without a `scheduledAt` timestamp.
+func ScheduledAtRequired() map[string]any {
+	return Error("SCHEDULED_AT_REQUIRED", "scheduledAt is required when isActuallyScheduled is true.", UUIDScheduledAtRequired)
+}
+
+// ScheduledAtMustBeInFuture returns the upstream shape thrown when the
+// requested `scheduledAt` is not strictly in the future.
+func ScheduledAtMustBeInFuture() map[string]any {
+	return Error("SCHEDULED_AT_MUST_BE_IN_FUTURE", "scheduledAt must be in the future.", UUIDScheduledAtMustBeInFuture)
 }
 
 // NoSuchRenoteTarget returns a 404 NO_SUCH_RENOTE_TARGET error response.

--- a/internal/api/apierr/errors_test.go
+++ b/internal/api/apierr/errors_test.go
@@ -134,6 +134,9 @@ func TestCountLimitHelpers(t *testing.T) {
 		{"ExceededLimitOfCreateInviteCode", ExceededLimitOfCreateInviteCode, "EXCEEDED_LIMIT_OF_CREATE_INVITE_CODE", UUIDExceededLimitOfCreateInviteCode},
 		{"MaxFileSizeExceeded", MaxFileSizeExceeded, "MAX_FILE_SIZE_EXCEEDED", UUIDMaxFileSizeExceeded},
 		{"NoFreeSpace", NoFreeSpace, "NO_FREE_SPACE", UUIDNoFreeSpace},
+		{"TooManyScheduledNotes", TooManyScheduledNotes, "TOO_MANY_SCHEDULED_NOTES", UUIDTooManyScheduledNotes},
+		{"ScheduledAtRequired", ScheduledAtRequired, "SCHEDULED_AT_REQUIRED", UUIDScheduledAtRequired},
+		{"ScheduledAtMustBeInFuture", ScheduledAtMustBeInFuture, "SCHEDULED_AT_MUST_BE_IN_FUTURE", UUIDScheduledAtMustBeInFuture},
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {

--- a/internal/api/notes/handler.go
+++ b/internal/api/notes/handler.go
@@ -18,6 +18,8 @@ import (
 	"github.com/shiroha-a/mk/internal/entity"
 	"github.com/shiroha-a/mk/internal/misc/id"
 	"github.com/shiroha-a/mk/internal/model"
+	"github.com/shiroha-a/mk/internal/queue"
+	"github.com/shiroha-a/mk/internal/queue/driver"
 	"github.com/shiroha-a/mk/internal/repository"
 	"github.com/shiroha-a/mk/internal/server/middleware"
 )
@@ -56,6 +58,23 @@ type Handler struct {
 	// 匿名 viewer (userID="") に対しても base policies を返す upstream 互換
 	// semantics で、middleware ではなく handler 内で gate する。
 	policyProvider TimelinePolicyProvider
+	// scheduledNoteEnqueuer は drafts/create で `isActuallyScheduled=true`
+	// の draft を delayed queue に enqueue するための narrow interface (#1040)。
+	// nil 時は enqueue を skip する (= test fixture / queue 未配線パス互換)。
+	scheduledNoteEnqueuer ScheduledNoteEnqueuer
+}
+
+// ScheduledNoteEnqueuer abstracts the delayed enqueue path used by
+// drafts/create. Implemented by *queue.Client (= EnqueuePostScheduledNote)。
+type ScheduledNoteEnqueuer interface {
+	EnqueuePostScheduledNote(payload queue.PostScheduledNotePayload, opts ...driver.EnqueueOption) error
+}
+
+// SetScheduledNoteEnqueuer wires a delayed queue client used by drafts/create
+// when the request asks for a scheduled publish (#1040). nil disables the
+// enqueue path (= test fixture / unwired)。
+func (h *Handler) SetScheduledNoteEnqueuer(e ScheduledNoteEnqueuer) {
+	h.scheduledNoteEnqueuer = e
 }
 
 // TimelinePolicyProvider abstracts the role-policy lookup used by timeline

--- a/internal/api/notes/handler_drafts.go
+++ b/internal/api/notes/handler_drafts.go
@@ -7,6 +7,8 @@ import (
 	"github.com/labstack/echo/v4"
 	"github.com/shiroha-a/mk/internal/api/apierr"
 	"github.com/shiroha-a/mk/internal/model"
+	"github.com/shiroha-a/mk/internal/queue"
+	"github.com/shiroha-a/mk/internal/queue/driver"
 	"github.com/shiroha-a/mk/internal/repository"
 	"github.com/shiroha-a/mk/internal/server/middleware"
 )
@@ -34,16 +36,21 @@ func (h *Handler) DraftsList(c echo.Context) error {
 }
 
 // DraftsCreate handles POST /api/notes/drafts/create.
+// upstream `notes/drafts/create.ts` 互換で scheduledAt / isActuallyScheduled
+// を受け入れ、scheduledNoteLimit policy gate + 遅延 queue enqueue を行う
+// (#1040)。
 func (h *Handler) DraftsCreate(c echo.Context) error {
 	user := middleware.GetUser(c)
 	if h.draftRepo == nil {
 		return c.NoContent(http.StatusNoContent)
 	}
 	var req struct {
-		Text       *string  `json:"text"`
-		CW         *string  `json:"cw"`
-		Visibility string   `json:"visibility"`
-		FileIDs    []string `json:"fileIds"`
+		Text                *string  `json:"text"`
+		CW                  *string  `json:"cw"`
+		Visibility          string   `json:"visibility"`
+		FileIDs             []string `json:"fileIds"`
+		ScheduledAt         *int64   `json:"scheduledAt"`
+		IsActuallyScheduled bool     `json:"isActuallyScheduled"`
 	}
 	if err := c.Bind(&req); err != nil {
 		return c.JSON(http.StatusBadRequest, apierr.InvalidParam("Invalid parameters."))
@@ -51,10 +58,29 @@ func (h *Handler) DraftsCreate(c echo.Context) error {
 	if req.Visibility == "" {
 		req.Visibility = "public"
 	}
+	// scheduledAt の validation (#1040)。upstream は ms epoch (`integer`)
+	// で受け取って Date 化、time.Now() より将来であることを要求する。
+	// isActuallyScheduled=false なら scheduledAt は単なる「下書きとして保持
+	// する希望時刻」扱いで、queue enqueue / future check は行わない。
+	now := time.Now()
+	var scheduledAt *time.Time
+	if req.ScheduledAt != nil {
+		t := time.UnixMilli(*req.ScheduledAt)
+		scheduledAt = &t
+	}
+	if req.IsActuallyScheduled {
+		if scheduledAt == nil {
+			return c.JSON(http.StatusBadRequest, apierr.ScheduledAtRequired())
+		}
+		if !scheduledAt.After(now) {
+			return c.JSON(http.StatusBadRequest, apierr.ScheduledAtMustBeInFuture())
+		}
+	}
 	// noteDraftLimit role policy gate (#1029)。policyProvider は #1026 で
 	// 配線済 (timeline gate と共用)。CountByUser で current 件数を取得。
 	if h.policyProvider != nil {
-		if limit, ok := h.policyProvider.GetUserPolicies(user.ID)["noteDraftLimit"].(int); ok && limit >= 0 {
+		policies := h.policyProvider.GetUserPolicies(user.ID)
+		if limit, ok := policies["noteDraftLimit"].(int); ok && limit >= 0 {
 			count, err := h.draftRepo.CountByUser(user.ID)
 			if err != nil {
 				return apierr.JSONInternalError(c)
@@ -63,17 +89,45 @@ func (h *Handler) DraftsCreate(c echo.Context) error {
 				return apierr.JSONTooManyNoteDrafts(c)
 			}
 		}
+		// scheduledNoteLimit gate (#1040)。isActuallyScheduled draft の数を
+		// 集計して上限と比較する。upstream `NoteDraftService.create` と同 logic。
+		if req.IsActuallyScheduled {
+			if limit, ok := policies["scheduledNoteLimit"].(int); ok && limit >= 0 {
+				count, err := h.draftRepo.CountScheduledByUser(user.ID)
+				if err != nil {
+					return apierr.JSONInternalError(c)
+				}
+				if count >= int64(limit) {
+					return apierr.JSONTooManyScheduledNotes(c)
+				}
+			}
+		}
 	}
 	draft := &model.NoteDraft{
-		ID:         h.idGen.Generate(time.Now()),
-		UserID:     user.ID,
-		Text:       req.Text,
-		CW:         req.CW,
-		Visibility: req.Visibility,
-		FileIDs:    req.FileIDs,
+		ID:                  h.idGen.Generate(now),
+		UserID:              user.ID,
+		Text:                req.Text,
+		CW:                  req.CW,
+		Visibility:          req.Visibility,
+		FileIDs:             req.FileIDs,
+		ScheduledAt:         scheduledAt,
+		IsActuallyScheduled: req.IsActuallyScheduled,
 	}
 	if err := h.draftRepo.Create(draft); err != nil {
 		return c.JSON(http.StatusInternalServerError, apierr.InternalError())
+	}
+	// scheduled の場合は遅延 queue に投入 (= upstream の `schedule(draft)`
+	// と等価、delay = scheduledAt - now)。enqueue 失敗時は draft を残しつつ
+	// 500 を返し、frontend に再試行を促す (draft 残しは upstream と同じく
+	// 削除しない方が観測可能で安全)。
+	if req.IsActuallyScheduled && h.scheduledNoteEnqueuer != nil {
+		delay := scheduledAt.Sub(now)
+		if err := h.scheduledNoteEnqueuer.EnqueuePostScheduledNote(
+			queue.PostScheduledNotePayload{NoteDraftID: draft.ID},
+			driver.WithProcessIn(delay),
+		); err != nil {
+			return apierr.JSONInternalError(c)
+		}
 	}
 	return c.JSON(http.StatusOK, packDraft(draft, h.idGen))
 }

--- a/internal/api/notes/handler_drafts_test.go
+++ b/internal/api/notes/handler_drafts_test.go
@@ -2,10 +2,16 @@ package notes
 
 import (
 	"encoding/json"
+	"errors"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"strings"
 	"testing"
+	"time"
+
+	"github.com/shiroha-a/mk/internal/queue"
+	"github.com/shiroha-a/mk/internal/queue/driver"
 
 	"github.com/labstack/echo/v4"
 	"github.com/shiroha-a/mk/internal/api/apierr"
@@ -84,6 +90,23 @@ func (m *mockDraftRepo) CountByUser(userID string) (int64, error) {
 	var count int64
 	for _, d := range m.drafts {
 		if d.UserID == userID {
+			count++
+		}
+	}
+	return count, nil
+}
+
+func (m *mockDraftRepo) FindByID(id string) (*model.NoteDraft, error) {
+	if d, ok := m.drafts[id]; ok {
+		return d, nil
+	}
+	return nil, errors.New("note draft not found")
+}
+
+func (m *mockDraftRepo) CountScheduledByUser(userID string) (int64, error) {
+	var count int64
+	for _, d := range m.drafts {
+		if d.UserID == userID && d.IsActuallyScheduled {
 			count++
 		}
 	}
@@ -304,4 +327,84 @@ func TestPollsRecommendation(t *testing.T) {
 	rec := postDraft(h.PollsRecommendation, `{}`, nil)
 	assert.Equal(t, http.StatusOK, rec.Code)
 	assert.Equal(t, "[]\n", rec.Body.String())
+}
+
+// --- #1040: scheduled note (drafts/create with scheduledAt) ---
+
+// scheduledEnqueueStub captures EnqueuePostScheduledNote calls for assertion.
+type scheduledEnqueueStub struct {
+	calls []queue.PostScheduledNotePayload
+	err   error
+}
+
+func (s *scheduledEnqueueStub) EnqueuePostScheduledNote(p queue.PostScheduledNotePayload, _ ...driver.EnqueueOption) error {
+	if s.err != nil {
+		return s.err
+	}
+	s.calls = append(s.calls, p)
+	return nil
+}
+
+func futureMs(d time.Duration) int64 {
+	return time.Now().Add(d).UnixMilli()
+}
+
+func TestDraftsCreate_ScheduledHappy(t *testing.T) {
+	h, repo := newDraftHandlerWithRepo()
+	enq := &scheduledEnqueueStub{}
+	h.SetScheduledNoteEnqueuer(enq)
+	body := fmt.Sprintf(`{"text":"hi","scheduledAt":%d,"isActuallyScheduled":true}`, futureMs(time.Hour))
+	rec := postDraft(h.DraftsCreate, body, &model.User{ID: "u1"})
+	require.Equal(t, http.StatusOK, rec.Code)
+	require.Len(t, repo.drafts, 1)
+	require.Len(t, enq.calls, 1, "scheduled draft 1 件で enqueue が 1 度走る")
+	// draft.IsActuallyScheduled=true で保存される
+	for _, d := range repo.drafts {
+		assert.True(t, d.IsActuallyScheduled)
+		require.NotNil(t, d.ScheduledAt)
+	}
+}
+
+func TestDraftsCreate_ScheduledAtRequired(t *testing.T) {
+	h, _ := newDraftHandlerWithRepo()
+	rec := postDraft(h.DraftsCreate, `{"text":"hi","isActuallyScheduled":true}`, &model.User{ID: "u1"})
+	assert.Equal(t, http.StatusBadRequest, rec.Code)
+	assert.Contains(t, rec.Body.String(), "SCHEDULED_AT_REQUIRED")
+	assert.Contains(t, rec.Body.String(), "94a89a43-3591-400a-9c17-dd166e71fdfa")
+}
+
+func TestDraftsCreate_ScheduledAtMustBeInFuture(t *testing.T) {
+	h, _ := newDraftHandlerWithRepo()
+	past := time.Now().Add(-time.Hour).UnixMilli()
+	body := fmt.Sprintf(`{"text":"hi","scheduledAt":%d,"isActuallyScheduled":true}`, past)
+	rec := postDraft(h.DraftsCreate, body, &model.User{ID: "u1"})
+	assert.Equal(t, http.StatusBadRequest, rec.Code)
+	assert.Contains(t, rec.Body.String(), "SCHEDULED_AT_MUST_BE_IN_FUTURE")
+	assert.Contains(t, rec.Body.String(), "b34d0c1b-996f-4e34-a428-c636d98df457")
+}
+
+func TestDraftsCreate_ScheduledNoteLimitExceeded(t *testing.T) {
+	h, repo := newDraftHandlerWithRepo()
+	repo.drafts["d1"] = &model.NoteDraft{ID: "d1", UserID: "u1", IsActuallyScheduled: true}
+	repo.drafts["d2"] = &model.NoteDraft{ID: "d2", UserID: "u1", IsActuallyScheduled: true}
+	h.SetPolicyProvider(&draftStubPolicyProvider{policies: map[string]any{
+		"scheduledNoteLimit": 2,
+	}})
+	body := fmt.Sprintf(`{"text":"third","scheduledAt":%d,"isActuallyScheduled":true}`, futureMs(time.Hour))
+	rec := postDraft(h.DraftsCreate, body, &model.User{ID: "u1"})
+	assert.Equal(t, http.StatusBadRequest, rec.Code)
+	assert.Contains(t, rec.Body.String(), "TOO_MANY_SCHEDULED_NOTES")
+	assert.Contains(t, rec.Body.String(), "c3275f19-4558-4c59-83e1-4f684b5fab66")
+}
+
+// isActuallyScheduled=false で scheduledAt が指定されても enqueue は走らない
+// (= 単なる「下書きとしての希望時刻」)。
+func TestDraftsCreate_ScheduledAtWithoutActuallyScheduled(t *testing.T) {
+	h, _ := newDraftHandlerWithRepo()
+	enq := &scheduledEnqueueStub{}
+	h.SetScheduledNoteEnqueuer(enq)
+	body := fmt.Sprintf(`{"text":"hi","scheduledAt":%d}`, futureMs(time.Hour))
+	rec := postDraft(h.DraftsCreate, body, &model.User{ID: "u1"})
+	require.Equal(t, http.StatusOK, rec.Code)
+	assert.Empty(t, enq.calls, "isActuallyScheduled=false なら enqueue されない")
 }

--- a/internal/core/federation/deliver_service_test.go
+++ b/internal/core/federation/deliver_service_test.go
@@ -44,6 +44,9 @@ func (s *stubEnqueuer) EnqueueInbox(_ context.Context, _ queue.InboxPayload) err
 	return nil
 }
 func (s *stubEnqueuer) Close() error { return nil }
+func (s *stubEnqueuer) EnqueuePostScheduledNote(_ queue.PostScheduledNotePayload, _ ...driver.EnqueueOption) error {
+	return nil
+}
 
 func newDeliverService(t *testing.T) (*federation.DeliverService, *stubEnqueuer, *testutil.MockUserRepository, *testutil.MockFollowingRepository, *testutil.MockUserKeypairRepository) {
 	t.Helper()

--- a/internal/core/federation/poll_delivery_hook_test.go
+++ b/internal/core/federation/poll_delivery_hook_test.go
@@ -37,7 +37,10 @@ func (r *recordingEnqueuer) EnqueueSystemWebhook(context.Context, queue.WebhookP
 	return nil
 }
 func (r *recordingEnqueuer) EnqueueInbox(context.Context, queue.InboxPayload) error { return nil }
-func (r *recordingEnqueuer) Close() error                                           { return nil }
+func (r *recordingEnqueuer) EnqueuePostScheduledNote(queue.PostScheduledNotePayload, ...driver.EnqueueOption) error {
+	return nil
+}
+func (r *recordingEnqueuer) Close() error { return nil }
 
 func newHookSetup(t *testing.T) (*PollDeliveryHook, *recordingEnqueuer, *testutil.MockUserRepository, *testutil.MockUserKeypairRepository, id.Generator) {
 	t.Helper()

--- a/internal/core/webhook/service_test.go
+++ b/internal/core/webhook/service_test.go
@@ -46,7 +46,10 @@ func (f *fakeEnqueuer) EnqueueSystemWebhook(_ context.Context, p queue.WebhookPa
 	return nil
 }
 func (f *fakeEnqueuer) EnqueueInbox(_ context.Context, _ queue.InboxPayload) error { return nil }
-func (f *fakeEnqueuer) Close() error                                               { return nil }
+func (f *fakeEnqueuer) EnqueuePostScheduledNote(_ queue.PostScheduledNotePayload, _ ...driver.EnqueueOption) error {
+	return nil
+}
+func (f *fakeEnqueuer) Close() error { return nil }
 
 // --- fake webhook repos ---
 

--- a/internal/core/webpush/service_test.go
+++ b/internal/core/webpush/service_test.go
@@ -38,7 +38,10 @@ func (f *fakeEnqueuer) EnqueueSystemWebhook(_ context.Context, _ queue.WebhookPa
 	return nil
 }
 func (f *fakeEnqueuer) EnqueueInbox(_ context.Context, _ queue.InboxPayload) error { return nil }
-func (f *fakeEnqueuer) Close() error                                               { return nil }
+func (f *fakeEnqueuer) EnqueuePostScheduledNote(_ queue.PostScheduledNotePayload, _ ...driver.EnqueueOption) error {
+	return nil
+}
+func (f *fakeEnqueuer) Close() error { return nil }
 
 func TestService_PushNotification_Enqueues(t *testing.T) {
 	enq := &fakeEnqueuer{}

--- a/internal/queue/processors/post_scheduled_note.go
+++ b/internal/queue/processors/post_scheduled_note.go
@@ -1,0 +1,125 @@
+// Package processors hosts queue task handlers consumed by the asynq worker.
+//
+// This file implements the scheduled-note publish path (#1040). It is a thin
+// orchestration layer: load the draft, materialise it into a note via the
+// shared note.CreateService, then delete the draft. Notification on
+// success / failure is intentionally out of scope for the first PR and may be
+// added in a follow-up once mk-go gains the upstream `scheduledNotePosted` /
+// `scheduledNotePostFailed` notification types.
+package processors
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log/slog"
+
+	"github.com/shiroha-a/mk/internal/core/note"
+	"github.com/shiroha-a/mk/internal/model"
+	"github.com/shiroha-a/mk/internal/queue"
+	"github.com/shiroha-a/mk/internal/queue/driver"
+)
+
+// ScheduledNoteDraftRepo is the narrow subset of NoteDraftRepository required
+// by PostScheduledNoteProcessor. Defined as a separate interface so test
+// fixtures can swap a minimal stub without touching the full repository.
+type ScheduledNoteDraftRepo interface {
+	FindByID(id string) (*model.NoteDraft, error)
+	Delete(id, userID string) (int64, error)
+}
+
+// ScheduledNoteUserRepo abstracts the single user lookup needed to call
+// note.CreateService.Create with a fully-populated *model.User.
+type ScheduledNoteUserRepo interface {
+	FindByID(id string) (*model.User, error)
+}
+
+// ScheduledNotePublisher abstracts note.CreateService so callers can pass a
+// real *note.CreateService in production or a stub in tests.
+type ScheduledNotePublisher interface {
+	Create(in note.CreateInput) (*model.Note, error)
+}
+
+// PostScheduledNoteProcessor publishes a note from a previously-stored
+// `note_draft` row whose `isActuallyScheduled=true` and `scheduledAt` has
+// arrived. upstream `PostScheduledNoteProcessorService` の Go port (#1040)。
+type PostScheduledNoteProcessor struct {
+	drafts    ScheduledNoteDraftRepo
+	users     ScheduledNoteUserRepo
+	publisher ScheduledNotePublisher
+}
+
+// NewPostScheduledNoteProcessor wires the processor with its dependencies.
+func NewPostScheduledNoteProcessor(drafts ScheduledNoteDraftRepo, users ScheduledNoteUserRepo, publisher ScheduledNotePublisher) *PostScheduledNoteProcessor {
+	return &PostScheduledNoteProcessor{drafts: drafts, users: users, publisher: publisher}
+}
+
+// Handle implements the asynq task handler signature. It decodes the payload,
+// guards against drafts that no longer exist or were unscheduled before the
+// trigger fired, materialises the note via the publisher, and finally deletes
+// the draft row.
+//
+// Errors are returned to the queue so asynq retries; transient DB failures
+// will be retried automatically. A draft that vanished (= user deleted it
+// before fire time) is treated as a no-op (= return nil) — upstream behaves
+// the same way (`if (draft == null || ...) return`)。
+func (p *PostScheduledNoteProcessor) Handle(_ context.Context, task driver.Task) error {
+	payload, err := queue.DecodePostScheduledNotePayload(task.Payload())
+	if err != nil {
+		return fmt.Errorf("decode payload: %w", err)
+	}
+	draft, err := p.drafts.FindByID(payload.NoteDraftID)
+	if err != nil {
+		// Draft が消えていれば user 削除 / 手動 cancel / 既に publish 済み
+		// のどれかで、いずれも retry しても解消しない。silent success で
+		// 終わる (upstream と等価)。
+		slog.Info("scheduled note draft missing, skipping",
+			"noteDraftId", payload.NoteDraftID, "err", err)
+		return nil
+	}
+	if draft.ScheduledAt == nil || !draft.IsActuallyScheduled {
+		// Draft が unschedule された経路 (= 将来 DraftsUpdate で scheduledAt
+		// クリア相当を許容する場合)。何もせず draft を残す。
+		return nil
+	}
+	user, err := p.users.FindByID(draft.UserID)
+	if err != nil {
+		return fmt.Errorf("load draft user: %w", err)
+	}
+	if user == nil {
+		// 防御的: nil ユーザを Create に流すと panic の元なので skip。
+		return errors.New("scheduled note draft has nil user")
+	}
+	in := note.CreateInput{
+		User:           user,
+		Text:           draft.Text,
+		CW:             draft.CW,
+		Visibility:     model.NoteVisibility(draft.Visibility),
+		VisibleUserIDs: draft.VisibleUserIDs,
+		LocalOnly:      draft.LocalOnly,
+		FileIDs:        draft.FileIDs,
+		ReplyID:        draft.ReplyID,
+		RenoteID:       draft.RenoteID,
+		ChannelID:      draft.ChannelID,
+	}
+	if draft.ReactionAcceptance != nil {
+		ra := *draft.ReactionAcceptance
+		in.ReactionAcceptance = &ra
+	}
+	if _, err := p.publisher.Create(in); err != nil {
+		// publish 失敗時は asynq retry に任せ、draft 行はそのまま残す
+		// (= 次回 retry で再試行可能)。upstream は notification を発火する
+		// が mk-go はまだ scheduledNotePostFailed notification type を持た
+		// ないので log のみ。
+		slog.Warn("scheduled note publish failed",
+			"noteDraftId", payload.NoteDraftID, "userId", draft.UserID, "err", err)
+		return fmt.Errorf("publish scheduled note: %w", err)
+	}
+	if _, err := p.drafts.Delete(draft.ID, draft.UserID); err != nil {
+		// publish 成功 + draft 削除失敗時は draft が残るだけで二重 publish
+		// は起きない (asynq job 自体は 1 回しか発火しない)。log のみ。
+		slog.Warn("scheduled note draft delete failed",
+			"noteDraftId", payload.NoteDraftID, "err", err)
+	}
+	return nil
+}

--- a/internal/queue/processors/post_scheduled_note_test.go
+++ b/internal/queue/processors/post_scheduled_note_test.go
@@ -1,0 +1,163 @@
+package processors
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/shiroha-a/mk/internal/core/note"
+	"github.com/shiroha-a/mk/internal/model"
+	"github.com/shiroha-a/mk/internal/queue"
+	"github.com/shiroha-a/mk/internal/queue/driver"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// stubDraftRepo / stubUserRepo / stubPublisher are minimal in-memory doubles
+// for PostScheduledNoteProcessor tests.
+
+type stubDraftRepo struct {
+	drafts map[string]*model.NoteDraft
+	// deleted records the (id, userID) pairs that Delete saw.
+	deleted []string
+	findErr error
+	delErr  error
+}
+
+func (s *stubDraftRepo) FindByID(id string) (*model.NoteDraft, error) {
+	if s.findErr != nil {
+		return nil, s.findErr
+	}
+	d, ok := s.drafts[id]
+	if !ok {
+		return nil, errors.New("not found")
+	}
+	return d, nil
+}
+
+func (s *stubDraftRepo) Delete(id, _ string) (int64, error) {
+	if s.delErr != nil {
+		return 0, s.delErr
+	}
+	if _, ok := s.drafts[id]; ok {
+		delete(s.drafts, id)
+		s.deleted = append(s.deleted, id)
+		return 1, nil
+	}
+	return 0, nil
+}
+
+type stubUserRepo struct {
+	users map[string]*model.User
+	err   error
+}
+
+func (s *stubUserRepo) FindByID(id string) (*model.User, error) {
+	if s.err != nil {
+		return nil, s.err
+	}
+	u, ok := s.users[id]
+	if !ok {
+		return nil, errors.New("user not found")
+	}
+	return u, nil
+}
+
+type stubPublisher struct {
+	calls []note.CreateInput
+	err   error
+}
+
+func (s *stubPublisher) Create(in note.CreateInput) (*model.Note, error) {
+	if s.err != nil {
+		return nil, s.err
+	}
+	s.calls = append(s.calls, in)
+	return &model.Note{ID: "n_published", UserID: in.User.ID}, nil
+}
+
+func newProcessor(drafts map[string]*model.NoteDraft, users map[string]*model.User) (*PostScheduledNoteProcessor, *stubDraftRepo, *stubPublisher) {
+	dr := &stubDraftRepo{drafts: drafts}
+	ur := &stubUserRepo{users: users}
+	pub := &stubPublisher{}
+	return NewPostScheduledNoteProcessor(dr, ur, pub), dr, pub
+}
+
+func taskFor(draftID string) driver.Task {
+	return queue.NewPostScheduledNoteTask(queue.PostScheduledNotePayload{NoteDraftID: draftID})
+}
+
+func TestPostScheduledNote_HappyPath(t *testing.T) {
+	now := int64(1234)
+	scheduledAt := timeFromMs(now)
+	drafts := map[string]*model.NoteDraft{
+		"d1": {
+			ID:                  "d1",
+			UserID:              "u1",
+			Visibility:          "public",
+			IsActuallyScheduled: true,
+			ScheduledAt:         &scheduledAt,
+		},
+	}
+	users := map[string]*model.User{"u1": {ID: "u1", Username: "alice"}}
+	p, draftRepo, pub := newProcessor(drafts, users)
+	err := p.Handle(context.Background(), taskFor("d1"))
+	require.NoError(t, err)
+	require.Len(t, pub.calls, 1)
+	assert.Equal(t, "u1", pub.calls[0].User.ID)
+	// draft は publish 後に削除される
+	assert.NotContains(t, draftRepo.drafts, "d1")
+	assert.Contains(t, draftRepo.deleted, "d1")
+}
+
+// Draft が削除済み (= user 手動 cancel など) でも error 化せず silent success。
+func TestPostScheduledNote_DraftMissing(t *testing.T) {
+	p, _, pub := newProcessor(map[string]*model.NoteDraft{}, map[string]*model.User{})
+	err := p.Handle(context.Background(), taskFor("ghost"))
+	require.NoError(t, err)
+	assert.Empty(t, pub.calls, "draft が無いなら publish しない")
+}
+
+// isActuallyScheduled=false な draft (= 後で unschedule された) は publish せず
+// silent skip (draft も残す)。
+func TestPostScheduledNote_Unscheduled(t *testing.T) {
+	drafts := map[string]*model.NoteDraft{
+		"d1": {ID: "d1", UserID: "u1", IsActuallyScheduled: false},
+	}
+	p, draftRepo, pub := newProcessor(drafts, map[string]*model.User{"u1": {ID: "u1"}})
+	err := p.Handle(context.Background(), taskFor("d1"))
+	require.NoError(t, err)
+	assert.Empty(t, pub.calls)
+	assert.Contains(t, draftRepo.drafts, "d1", "unscheduled draft は残す")
+}
+
+// publish 失敗時は error を返して asynq retry に任せる。draft は残る。
+func TestPostScheduledNote_PublishErrorRetries(t *testing.T) {
+	scheduledAt := timeFromMs(1234)
+	drafts := map[string]*model.NoteDraft{
+		"d1": {
+			ID: "d1", UserID: "u1", Visibility: "public",
+			IsActuallyScheduled: true, ScheduledAt: &scheduledAt,
+		},
+	}
+	users := map[string]*model.User{"u1": {ID: "u1"}}
+	p, draftRepo, pub := newProcessor(drafts, users)
+	pub.err = errors.New("publish boom")
+	err := p.Handle(context.Background(), taskFor("d1"))
+	require.Error(t, err)
+	assert.Contains(t, draftRepo.drafts, "d1", "publish 失敗時は draft 残す")
+}
+
+// payload decode 失敗は error 返却 (= asynq に retry / dead letter 判断させる)。
+func TestPostScheduledNote_PayloadDecodeError(t *testing.T) {
+	p, _, _ := newProcessor(map[string]*model.NoteDraft{}, map[string]*model.User{})
+	bad := driver.RawTask{TypeName: queue.TaskTypePostScheduledNote, Body: []byte("{not json")}
+	err := p.Handle(context.Background(), bad)
+	require.Error(t, err)
+}
+
+// timeFromMs is a tiny helper to convert ms epoch to time.Time.
+func timeFromMs(ms int64) time.Time {
+	return time.UnixMilli(ms)
+}

--- a/internal/queue/queue.go
+++ b/internal/queue/queue.go
@@ -58,6 +58,7 @@ type Enqueuer interface {
 	EnqueueUserWebhook(ctx context.Context, payload WebhookPayload) error
 	EnqueueSystemWebhook(ctx context.Context, payload WebhookPayload) error
 	EnqueueInbox(ctx context.Context, payload InboxPayload) error
+	EnqueuePostScheduledNote(payload PostScheduledNotePayload, opts ...driver.EnqueueOption) error
 	Close() error
 }
 
@@ -123,6 +124,15 @@ func (c *Client) EnqueueDeliver(payload DeliverPayload, opts ...driver.EnqueueOp
 	}
 	merged := append(base, opts...)
 	return c.inner.Enqueue(context.Background(), TaskTypeDeliver, body, merged...)
+}
+
+// EnqueuePostScheduledNote enqueues a deferred publish task for a draft
+// flagged with `isActuallyScheduled=true`. caller は WithProcessIn(delay)
+// で `scheduledAt - now` を指定する想定 (#1040)。
+func (c *Client) EnqueuePostScheduledNote(payload PostScheduledNotePayload, opts ...driver.EnqueueOption) error {
+	body := mustMarshal(payload)
+	merged := append([]driver.EnqueueOption{driver.WithQueue(QueueName)}, opts...)
+	return c.inner.Enqueue(context.Background(), TaskTypePostScheduledNote, body, merged...)
 }
 
 // EnqueueExport puts an export task on the queue.

--- a/internal/queue/queue_test.go
+++ b/internal/queue/queue_test.go
@@ -397,6 +397,29 @@ func TestClient_EnqueueExport(t *testing.T) {
 	assert.Equal(t, queue.TaskTypeExport, tasks[0].Type)
 }
 
+func TestClient_EnqueuePostScheduledNote(t *testing.T) {
+	testutil.SkipIfNoDocker(t)
+	flushTestRedis(t)
+
+	c := queue.NewClient(newDriver())
+	defer func() { _ = c.Close() }()
+
+	// caller は WithProcessIn で delay を渡す想定 (= scheduledAt - now)。
+	require.NoError(t, c.EnqueuePostScheduledNote(
+		queue.PostScheduledNotePayload{NoteDraftID: "d1"},
+		driver.WithProcessIn(time.Hour),
+	))
+
+	insp := asynq.NewInspector(redisOpt())
+	defer func() { _ = insp.Close() }()
+
+	// delayed task は scheduled state で観測される
+	tasks, err := insp.ListScheduledTasks(queue.QueueName)
+	require.NoError(t, err)
+	require.Len(t, tasks, 1)
+	assert.Equal(t, queue.TaskTypePostScheduledNote, tasks[0].Type)
+}
+
 func TestClient_EnqueueImport(t *testing.T) {
 	testutil.SkipIfNoDocker(t)
 	flushTestRedis(t)
@@ -768,6 +791,20 @@ func TestNewUnfollowTask_RoundTrip(t *testing.T) {
 
 func TestDecodeUnfollowPayload_MalformedReturnsError(t *testing.T) {
 	_, err := queue.DecodeUnfollowPayload([]byte(`not-json`))
+	require.Error(t, err)
+}
+
+func TestNewPostScheduledNoteTask_RoundTrip(t *testing.T) {
+	payload := queue.PostScheduledNotePayload{NoteDraftID: "d1"}
+	task := queue.NewPostScheduledNoteTask(payload)
+	require.Equal(t, queue.TaskTypePostScheduledNote, task.Type())
+	got, err := queue.DecodePostScheduledNotePayload(task.Payload())
+	require.NoError(t, err)
+	require.Equal(t, "d1", got.NoteDraftID)
+}
+
+func TestDecodePostScheduledNotePayload_MalformedReturnsError(t *testing.T) {
+	_, err := queue.DecodePostScheduledNotePayload([]byte(`not-json`))
 	require.Error(t, err)
 }
 

--- a/internal/queue/tasks.go
+++ b/internal/queue/tasks.go
@@ -66,6 +66,13 @@ const TaskTypeInstanceRefresh = "maintenance:instanceRefresh"
 // `processors.RetentionAggregateProcessor`.
 const TaskTypeRetentionAggregate = "maintenance:retentionAggregate"
 
+// TaskTypePostScheduledNote is the task type for publishing a scheduled note
+// (= `note_draft` with `isActuallyScheduled=true`) once its `scheduledAt`
+// time has arrived. Enqueued by `notes/drafts/create` with WithProcessIn
+// (= scheduledAt - now) and consumed by
+// `processors.PostScheduledNoteProcessor` (#1040)。
+const TaskTypePostScheduledNote = "note:postScheduled"
+
 // TaskTypeInbox is the task type for inbound ActivityPub activity
 // processing (#534). Enqueued by the inbox HTTP handler after signature
 // verification, and consumed by a worker that calls
@@ -313,6 +320,29 @@ func DecodeUnfollowPayload(body []byte) (UnfollowPayload, error) {
 	var p UnfollowPayload
 	if err := json.Unmarshal(body, &p); err != nil {
 		return UnfollowPayload{}, err
+	}
+	return p, nil
+}
+
+// PostScheduledNotePayload identifies a draft scheduled for future publish.
+// upstream `PostScheduledNoteJobData { noteDraftId }` と shape 一致 (#1040)。
+type PostScheduledNotePayload struct {
+	NoteDraftID string `json:"noteDraftId"`
+}
+
+// NewPostScheduledNoteTask serializes a PostScheduledNotePayload into a
+// driver.Task.
+func NewPostScheduledNoteTask(payload PostScheduledNotePayload) driver.Task {
+	body, _ := json.Marshal(payload)
+	return driver.RawTask{TypeName: TaskTypePostScheduledNote, Body: body}
+}
+
+// DecodePostScheduledNotePayload extracts a PostScheduledNotePayload from a
+// task body.
+func DecodePostScheduledNotePayload(body []byte) (PostScheduledNotePayload, error) {
+	var p PostScheduledNotePayload
+	if err := json.Unmarshal(body, &p); err != nil {
+		return PostScheduledNotePayload{}, err
 	}
 	return p, nil
 }

--- a/internal/repository/note_draft.go
+++ b/internal/repository/note_draft.go
@@ -9,6 +9,10 @@ import (
 type NoteDraftRepository interface {
 	Create(draft *model.NoteDraft) error
 	FindByIDAndUser(id, userID string) (*model.NoteDraft, error)
+	// FindByID returns the draft by primary key without ownership check.
+	// Used by internal worker paths (= scheduled note processor) that act on
+	// behalf of the draft owner stored in the row (#1040)。
+	FindByID(id string) (*model.NoteDraft, error)
 	ListByUser(userID string, limit int) ([]*model.NoteDraft, error)
 	Update(draft *model.NoteDraft) error
 	// Delete returns the number of rows affected so callers can detect
@@ -16,6 +20,10 @@ type NoteDraftRepository interface {
 	// SQL round-trip + no TOCTOU race)。0 = 該当 draft なし、1 = 削除成功。
 	Delete(id, userID string) (int64, error)
 	CountByUser(userID string) (int64, error)
+	// CountScheduledByUser returns the number of drafts owned by userID that
+	// are flagged with isActuallyScheduled=true. Used to enforce
+	// scheduledNoteLimit role policy (#1040)。
+	CountScheduledByUser(userID string) (int64, error)
 }
 
 type noteDraftRepository struct {
@@ -62,6 +70,24 @@ func (r *noteDraftRepository) Delete(id, userID string) (int64, error) {
 func (r *noteDraftRepository) CountByUser(userID string) (int64, error) {
 	var count int64
 	if err := r.db.Model(&model.NoteDraft{}).Where(`"userId" = ?`, userID).Count(&count).Error; err != nil {
+		return 0, err
+	}
+	return count, nil
+}
+
+func (r *noteDraftRepository) FindByID(id string) (*model.NoteDraft, error) {
+	var d model.NoteDraft
+	if err := r.db.Where(`"id" = ?`, id).First(&d).Error; err != nil {
+		return nil, err
+	}
+	return &d, nil
+}
+
+func (r *noteDraftRepository) CountScheduledByUser(userID string) (int64, error) {
+	var count int64
+	if err := r.db.Model(&model.NoteDraft{}).
+		Where(`"userId" = ? AND "isActuallyScheduled" = true`, userID).
+		Count(&count).Error; err != nil {
 		return 0, err
 	}
 	return count, nil

--- a/internal/repository/note_draft_test.go
+++ b/internal/repository/note_draft_test.go
@@ -33,10 +33,22 @@ func TestNoteDraftRepository_Full(t *testing.T) {
 	_, err = repo.FindByIDAndUser("ghost", user.ID)
 	assert.Error(t, err)
 
+	// FindByID (= ownership 非考慮、worker 経路 / #1040)
+	foundByID, err := repo.FindByID("draft_1")
+	require.NoError(t, err)
+	assert.Equal(t, "draft text", *foundByID.Text)
+	_, err = repo.FindByID("ghost")
+	assert.Error(t, err)
+
 	// ListByUser
 	list, err := repo.ListByUser(user.ID, 10)
 	require.NoError(t, err)
 	assert.Len(t, list, 1)
+
+	// CountScheduledByUser (#1040): 通常 draft は isActuallyScheduled=false なので 0
+	scheduled, err := repo.CountScheduledByUser(user.ID)
+	require.NoError(t, err)
+	assert.Equal(t, int64(0), scheduled)
 
 	// ListByUser - default limit
 	list2, err := repo.ListByUser(user.ID, 0)

--- a/internal/server/router.go
+++ b/internal/server/router.go
@@ -1112,7 +1112,15 @@ func (s *Server) setupRoutes() {
 		middleware.RequireRolePolicy(roleService, corerole.PolicyCanUseTranslator))
 	api.POST("/notes/show-partial-bulk", notesHandler.ShowPartialBulk)
 	// notes/drafts + notes/thread-muting + notes/polls/recommendation (実データ)
-	notesHandler.SetDraftRepo(repository.NewNoteDraftRepository(s.db))
+	noteDraftRepo := repository.NewNoteDraftRepository(s.db)
+	notesHandler.SetDraftRepo(noteDraftRepo)
+	notesHandler.SetScheduledNoteEnqueuer(s.queueClient)
+
+	// PostScheduledNote processor (#1040): delayed queue 経由で draft を
+	// note 化する。dependencies は既存 noteCreateService + userRepo + 上記
+	// noteDraftRepo を共有する。
+	postScheduledNoteProcessor := processors.NewPostScheduledNoteProcessor(noteDraftRepo, userRepo, noteCreateService)
+	s.queueServer.Handle(queue.TaskTypePostScheduledNote, postScheduledNoteProcessor.Handle)
 	api.POST("/notes/drafts/list", notesHandler.DraftsList, middleware.RequireAuth())
 	api.POST("/notes/drafts/create", notesHandler.DraftsCreate, middleware.RequireAuth())
 	api.POST("/notes/drafts/update", notesHandler.DraftsUpdate, middleware.RequireAuth())


### PR DESCRIPTION
## Summary

upstream Misskey TS の scheduled note 機能を mk-go に Phase 1 として移植する。`note_draft` テーブルの `scheduledAt` / `isActuallyScheduled` カラムと model は migration 000025 で既に準備済みだったが、business logic (handler + queue + enforcement) が未実装で機能が動かなかった状態 → 本 PR で create→publish 経路を完結。

## 経路

```
/api/notes/drafts/create (handler) 
  → delayed queue (TaskTypePostScheduledNote + WithProcessIn)
  → PostScheduledNoteProcessor.Handle (= scheduledAt 到来時 fire)
  → note.CreateService.Create (= 既存 publish 経路)
  → NoteDraftRepository.Delete (= draft 削除)
```

## 主な変更点

### apierr (3 件追加、upstream UUID 完全一致)

- `TOO_MANY_SCHEDULED_NOTES` (`c3275f19-...`)
- `SCHEDULED_AT_REQUIRED` (`94a89a43-...`)
- `SCHEDULED_AT_MUST_BE_IN_FUTURE` (`b34d0c1b-...`)

### queue infrastructure

- `TaskTypePostScheduledNote` + `PostScheduledNotePayload {NoteDraftID}` + helpers
- `Enqueuer` に `EnqueuePostScheduledNote(payload, opts...)` 追加 (= deliver queue 共有、`WithProcessIn` で `scheduledAt - now` を渡す)
- 既存 5 stub に interface 充足 method を追加

### handler (`/api/notes/drafts/create`)

- `scheduledAt *int64` + `isActuallyScheduled bool` 受け入れ
- validation 3 種 (required / must-be-future / limit)
- policy gate: `scheduledNoteLimit` を `CountScheduledByUser` で集計
- enqueue: `WithProcessIn(scheduledAt - now)` で delayed task 投入

### processor (新規)

`internal/queue/processors/post_scheduled_note.go`:
- 3 narrow interface (`ScheduledNoteDraftRepo` / `ScheduledNoteUserRepo` / `ScheduledNotePublisher`) で test 用 stub と production 配線の両方を楽に差し替え
- draft → user → publish → delete の orchestration
- 削除済み draft / unscheduled draft は silent skip (upstream 等価)

### repository

`NoteDraftRepository` に 2 method:
- `FindByID(id)` — processor 経路の owner 未知 fetch
- `CountScheduledByUser(userID)` — scheduledNoteLimit gate 用

### router 配線

- `noteDraftRepo` を handler + processor で共有
- `s.queueServer.Handle(queue.TaskTypePostScheduledNote, ...)` で worker 配線

## テスト

| Package | 追加ケース |
|---|---|
| `api/notes` | 5 (`ScheduledHappy` / `ScheduledAtRequired` / `ScheduledAtMustBeInFuture` / `ScheduledNoteLimitExceeded` / `ScheduledAtWithoutActuallyScheduled`) |
| `queue/processors` | 5 (`HappyPath` / `DraftMissing` / `Unscheduled` / `PublishErrorRetries` / `PayloadDecodeError`) |
| `queue` | 3 (round-trip / decode error / `EnqueuePostScheduledNote` testcontainers) |
| `repository` | 既存 test に FindByID + CountScheduledByUser assert を増設 |
| `apierr` | table-driven 3 row 追加 |

実行: `go test ./... -count=1 -cover`

## カバレッジ

| Package | Coverage |
|---|---|
| `internal/api/apierr` | 97.0% |
| `internal/api/notes` | 90.5% |
| `internal/queue` | 93.5% (= 87.0% → 93.5% に復帰) |
| `internal/queue/processors` | 91.4% |
| `internal/repository` | 90.3% |

全 50+ パッケージで CI 閾値クリア。

## scope 外 (Phase 2 候補)

- **Notification 発火** (`scheduledNotePosted` / `scheduledNotePostFailed`)
- **DraftsUpdate の re-schedule / clearSchedule** (scheduledAt 変更 / delete 時の queue job 取消 + 再 enqueue)
- **Poll / VisibleUserIDs / ReactionAcceptance の完全取り込み** (現状 text / visibility / file / reply / renote / channel のみ)
- **drop-in e2e 検証** (Misskey TS frontend → mk-go の end-to-end test)

## 関連

- Refs #1040 (Phase 1 完了。Phase 2 candidates は本 PR merge 後に follow-up issue 化判断)
- upstream: `PostScheduledNoteProcessorService.ts` / `NoteDraftService.create` / `endpoints/notes/drafts/create.ts`

🤖 Generated with [Claude Code](https://claude.com/claude-code)