### PR TITLE
feat(notes): scheduled note Phase 2-B (publish 結果 notification 発火) (#1045)

### DIFF
--- a/internal/core/notification/notification_service.go
+++ b/internal/core/notification/notification_service.go
@@ -39,6 +39,12 @@ const (
 	TypeFollowRequestAccept Type = "followRequestAccepted"
 	TypeExportCompleted     Type = "exportCompleted"
 	TypeImportCompleted     Type = "importCompleted"
+	// TypeScheduledNotePosted / TypeScheduledNotePostFailed は upstream
+	// Misskey TS の \`PostScheduledNoteProcessorService\` が発火する 2 種類
+	// の通知 (#1045 Phase 2-B)。posted は \`noteId\` を Extra (or NoteID) に
+	// 持ち、postFailed は \`noteDraftId\` を Extra に持つ。
+	TypeScheduledNotePosted     Type = "scheduledNotePosted"
+	TypeScheduledNotePostFailed Type = "scheduledNotePostFailed"
 )
 
 // MaxPerUser caps how many notifications are kept per user in the Redis stream.

--- a/internal/queue/processors/post_scheduled_note.go
+++ b/internal/queue/processors/post_scheduled_note.go
@@ -16,6 +16,7 @@ import (
 	"time"
 
 	"github.com/shiroha-a/mk/internal/core/note"
+	"github.com/shiroha-a/mk/internal/core/notification"
 	"github.com/shiroha-a/mk/internal/model"
 	"github.com/shiroha-a/mk/internal/queue"
 	"github.com/shiroha-a/mk/internal/queue/driver"
@@ -59,6 +60,15 @@ type ScheduledNotePublisher interface {
 	Create(in note.CreateInput) (*model.Note, error)
 }
 
+// ScheduledNoteNotifier dispatches the scheduled note publish result to the
+// notification system. upstream Misskey TS の \`NotificationService.create\`
+// と同 contract で、posted (= 成功時 noteId) / postFailed (= 失敗時
+// noteDraftId) の 2 種を発火する (#1045 Phase 2-B)。nil の場合は notification
+// skip (= Phase 2-A 時点の slog のみ挙動と互換)。
+type ScheduledNoteNotifier interface {
+	Create(ctx context.Context, in notification.CreateInput) (*notification.Notification, error)
+}
+
 // PostScheduledNoteProcessor publishes a note from a previously-stored
 // `note_draft` row whose `isActuallyScheduled=true` and `scheduledAt` has
 // arrived. upstream `PostScheduledNoteProcessorService` の Go port (#1040)。
@@ -69,6 +79,8 @@ type PostScheduledNoteProcessor struct {
 	// lock は idempotency 用 (#1045 Phase 2-A)。nil の場合は lock skip = Phase 1
 	// と同等の at-least-once 挙動 (= test fixture / 未配線 path)。
 	lock ScheduledNoteLock
+	// notifier は publish 結果通知用 (#1045 Phase 2-B)。nil で発火 skip。
+	notifier ScheduledNoteNotifier
 }
 
 // NewPostScheduledNoteProcessor wires the processor with its dependencies.
@@ -81,6 +93,14 @@ func NewPostScheduledNoteProcessor(drafts ScheduledNoteDraftRepo, users Schedule
 // (#1045 Phase 2-A)。
 func (p *PostScheduledNoteProcessor) SetLock(l ScheduledNoteLock) {
 	p.lock = l
+}
+
+// SetNotifier wires the notification dispatcher used to fire
+// \`scheduledNotePosted\` / \`scheduledNotePostFailed\` on publish completion
+// (#1045 Phase 2-B)。nil disables (= notification skip)、production では
+// core/notification.Service を配線する。
+func (p *PostScheduledNoteProcessor) SetNotifier(n ScheduledNoteNotifier) {
+	p.notifier = n
 }
 
 // Handle implements the asynq task handler signature. It decodes the payload,
@@ -173,14 +193,39 @@ func (p *PostScheduledNoteProcessor) Handle(ctx context.Context, task driver.Tas
 		}
 		in.Poll = pollInput
 	}
-	if _, err := p.publisher.Create(in); err != nil {
+	publishedNote, err := p.publisher.Create(in)
+	if err != nil {
 		// publish 失敗時は asynq retry に任せ、draft 行はそのまま残す
-		// (= 次回 retry で再試行可能)。upstream は notification を発火する
-		// が mk-go はまだ scheduledNotePostFailed notification type を持た
-		// ないので log のみ。
+		// (= 次回 retry で再試行可能)。同時に user に postFailed 通知を
+		// 1 度だけ発火する (= upstream \`scheduledNotePostFailed\` と同 shape、
+		// extra に noteDraftId)。
 		slog.Warn("scheduled note publish failed",
 			"noteDraftId", payload.NoteDraftID, "userId", draft.UserID, "err", err)
+		if p.notifier != nil {
+			if _, nerr := p.notifier.Create(ctx, notification.CreateInput{
+				NotifieeID: draft.UserID,
+				Type:       notification.TypeScheduledNotePostFailed,
+				Extra:      map[string]any{"noteDraftId": draft.ID},
+			}); nerr != nil {
+				// notification 失敗は publish error 経路に影響させない (= retry
+				// 中に多重通知を避ける best-effort)。
+				slog.Warn("scheduled note postFailed notification failed",
+					"noteDraftId", payload.NoteDraftID, "err", nerr)
+			}
+		}
 		return fmt.Errorf("publish scheduled note: %w", err)
+	}
+	// publish 成功通知 (#1045 Phase 2-B)。upstream は \`noteId\` を引数で渡し、
+	// frontend が note を embed して表示する。
+	if p.notifier != nil {
+		if _, nerr := p.notifier.Create(ctx, notification.CreateInput{
+			NotifieeID: draft.UserID,
+			Type:       notification.TypeScheduledNotePosted,
+			NoteID:     publishedNote.ID,
+		}); nerr != nil {
+			slog.Warn("scheduled note posted notification failed",
+				"noteDraftId", payload.NoteDraftID, "err", nerr)
+		}
 	}
 	if _, err := p.drafts.Delete(draft.ID, draft.UserID); err != nil {
 		// publish 成功 + draft 削除失敗時は draft が残るだけで二重 publish

--- a/internal/queue/processors/post_scheduled_note.go
+++ b/internal/queue/processors/post_scheduled_note.go
@@ -96,11 +96,26 @@ func (p *PostScheduledNoteProcessor) SetLock(l ScheduledNoteLock) {
 }
 
 // SetNotifier wires the notification dispatcher used to fire
-// \`scheduledNotePosted\` / \`scheduledNotePostFailed\` on publish completion
+// `scheduledNotePosted` / `scheduledNotePostFailed` on publish completion
 // (#1045 Phase 2-B)。nil disables (= notification skip)、production では
 // core/notification.Service を配線する。
 func (p *PostScheduledNoteProcessor) SetNotifier(n ScheduledNoteNotifier) {
 	p.notifier = n
+}
+
+// logNotificationErr classifies a notification dispatch error and emits the
+// appropriate log level. graceful shutdown / deadline cancel は normal な
+// 運用シナリオなので Warn に出さず Debug に格下げする (= log noise を抑え、
+// 真の notification backend 障害だけ Warn で観測する、#1045 Phase 2-B
+// follow-up)。
+func logNotificationErr(action string, draftID string, err error) {
+	if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+		slog.Debug("scheduled note notification skipped during shutdown",
+			"action", action, "noteDraftId", draftID, "err", err)
+		return
+	}
+	slog.Warn("scheduled note notification failed",
+		"action", action, "noteDraftId", draftID, "err", err)
 }
 
 // Handle implements the asynq task handler signature. It decodes the payload,
@@ -209,13 +224,12 @@ func (p *PostScheduledNoteProcessor) Handle(ctx context.Context, task driver.Tas
 			}); nerr != nil {
 				// notification 失敗は publish error 経路に影響させない (= retry
 				// 中に多重通知を避ける best-effort)。
-				slog.Warn("scheduled note postFailed notification failed",
-					"noteDraftId", payload.NoteDraftID, "err", nerr)
+				logNotificationErr("postFailed", payload.NoteDraftID, nerr)
 			}
 		}
 		return fmt.Errorf("publish scheduled note: %w", err)
 	}
-	// publish 成功通知 (#1045 Phase 2-B)。upstream は \`noteId\` を引数で渡し、
+	// publish 成功通知 (#1045 Phase 2-B)。upstream は `noteId` を引数で渡し、
 	// frontend が note を embed して表示する。
 	if p.notifier != nil {
 		if _, nerr := p.notifier.Create(ctx, notification.CreateInput{
@@ -223,8 +237,7 @@ func (p *PostScheduledNoteProcessor) Handle(ctx context.Context, task driver.Tas
 			Type:       notification.TypeScheduledNotePosted,
 			NoteID:     publishedNote.ID,
 		}); nerr != nil {
-			slog.Warn("scheduled note posted notification failed",
-				"noteDraftId", payload.NoteDraftID, "err", nerr)
+			logNotificationErr("posted", payload.NoteDraftID, nerr)
 		}
 	}
 	if _, err := p.drafts.Delete(draft.ID, draft.UserID); err != nil {

--- a/internal/queue/processors/post_scheduled_note_test.go
+++ b/internal/queue/processors/post_scheduled_note_test.go
@@ -374,6 +374,18 @@ func TestPostScheduledNote_NotifierErrorDoesNotBreakPublish(t *testing.T) {
 	assert.Len(t, pub.calls, 1, "publish 自体は走る")
 }
 
+// logNotificationErr は graceful shutdown / deadline 系 error を Debug に
+// 格下げし、通常 error は Warn のまま残す。panic しないことを smoke 確認
+// (= slog の出力先は別管理なので、ここでは分岐のカバレッジ確保が目的)。
+func TestLogNotificationErr_ShutdownErrorsAreDebug(t *testing.T) {
+	logNotificationErr("posted", "d1", context.Canceled)
+	logNotificationErr("postFailed", "d1", context.DeadlineExceeded)
+}
+
+func TestLogNotificationErr_GenericErrorsAreWarn(t *testing.T) {
+	logNotificationErr("posted", "d1", errors.New("boom"))
+}
+
 // notifier 未配線 (= Phase 2-A 互換挙動) でも publish 経路は通常動作する。
 func TestPostScheduledNote_NoNotifierConfigured(t *testing.T) {
 	scheduledAt := timeFromMs(1234)

--- a/internal/queue/processors/post_scheduled_note_test.go
+++ b/internal/queue/processors/post_scheduled_note_test.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/shiroha-a/mk/internal/core/note"
+	"github.com/shiroha-a/mk/internal/core/notification"
 	"github.com/shiroha-a/mk/internal/model"
 	"github.com/shiroha-a/mk/internal/queue"
 	"github.com/shiroha-a/mk/internal/queue/driver"
@@ -286,4 +287,105 @@ func TestPostScheduledNote_NoPoll(t *testing.T) {
 	require.NoError(t, p.Handle(context.Background(), taskFor("d1")))
 	require.Len(t, pub.calls, 1)
 	assert.Nil(t, pub.calls[0].Poll, "hasPoll=false の draft は Poll 設定なし")
+}
+
+// --- #1045 Phase 2-B: notification ---
+
+// stubNotifier captures Create calls for assertion. err != nil で
+// notification 発火経路が publish 結果を損なわないことを確認する。
+type stubNotifier struct {
+	calls []notification.CreateInput
+	err   error
+}
+
+func (s *stubNotifier) Create(_ context.Context, in notification.CreateInput) (*notification.Notification, error) {
+	if s.err != nil {
+		return nil, s.err
+	}
+	s.calls = append(s.calls, in)
+	return &notification.Notification{ID: "stub-notif", Type: in.Type}, nil
+}
+
+// publish 成功時は scheduledNotePosted 通知が 1 度発火し、payload に
+// publish した note.ID が乗る。
+func TestPostScheduledNote_NotifiesOnPosted(t *testing.T) {
+	scheduledAt := timeFromMs(1234)
+	drafts := map[string]*model.NoteDraft{
+		"d1": {
+			ID: "d1", UserID: "u1", Visibility: "public",
+			IsActuallyScheduled: true, ScheduledAt: &scheduledAt,
+		},
+	}
+	users := map[string]*model.User{"u1": {ID: "u1"}}
+	p, _, pub := newProcessor(drafts, users)
+	notif := &stubNotifier{}
+	p.SetNotifier(notif)
+
+	require.NoError(t, p.Handle(context.Background(), taskFor("d1")))
+	require.Len(t, pub.calls, 1, "publish は 1 度")
+	require.Len(t, notif.calls, 1, "posted 通知が 1 度発火")
+	assert.Equal(t, "u1", notif.calls[0].NotifieeID)
+	assert.Equal(t, notification.TypeScheduledNotePosted, notif.calls[0].Type)
+	assert.Equal(t, "n_published", notif.calls[0].NoteID,
+		"publish した note の ID が通知に乗る")
+}
+
+// publish 失敗時は scheduledNotePostFailed 通知が発火し、payload の Extra
+// に noteDraftId が乗る。publish error 自体は handler 戻り値で伝播する。
+func TestPostScheduledNote_NotifiesOnFailed(t *testing.T) {
+	scheduledAt := timeFromMs(1234)
+	drafts := map[string]*model.NoteDraft{
+		"d1": {
+			ID: "d1", UserID: "u1", Visibility: "public",
+			IsActuallyScheduled: true, ScheduledAt: &scheduledAt,
+		},
+	}
+	users := map[string]*model.User{"u1": {ID: "u1"}}
+	p, _, pub := newProcessor(drafts, users)
+	pub.err = errors.New("publish boom")
+	notif := &stubNotifier{}
+	p.SetNotifier(notif)
+
+	err := p.Handle(context.Background(), taskFor("d1"))
+	require.Error(t, err, "publish 失敗は handler error で伝播")
+	require.Len(t, notif.calls, 1, "postFailed 通知が 1 度発火")
+	assert.Equal(t, "u1", notif.calls[0].NotifieeID)
+	assert.Equal(t, notification.TypeScheduledNotePostFailed, notif.calls[0].Type)
+	require.NotNil(t, notif.calls[0].Extra)
+	assert.Equal(t, "d1", notif.calls[0].Extra["noteDraftId"])
+}
+
+// notifier 自体が error を返しても publish 経路 (= handler 戻り値) には
+// 影響しない (= best-effort)。
+func TestPostScheduledNote_NotifierErrorDoesNotBreakPublish(t *testing.T) {
+	scheduledAt := timeFromMs(1234)
+	drafts := map[string]*model.NoteDraft{
+		"d1": {
+			ID: "d1", UserID: "u1", Visibility: "public",
+			IsActuallyScheduled: true, ScheduledAt: &scheduledAt,
+		},
+	}
+	users := map[string]*model.User{"u1": {ID: "u1"}}
+	p, _, pub := newProcessor(drafts, users)
+	p.SetNotifier(&stubNotifier{err: errors.New("notif boom")})
+
+	require.NoError(t, p.Handle(context.Background(), taskFor("d1")),
+		"notification 失敗は handler error にしない")
+	assert.Len(t, pub.calls, 1, "publish 自体は走る")
+}
+
+// notifier 未配線 (= Phase 2-A 互換挙動) でも publish 経路は通常動作する。
+func TestPostScheduledNote_NoNotifierConfigured(t *testing.T) {
+	scheduledAt := timeFromMs(1234)
+	drafts := map[string]*model.NoteDraft{
+		"d1": {
+			ID: "d1", UserID: "u1", Visibility: "public",
+			IsActuallyScheduled: true, ScheduledAt: &scheduledAt,
+		},
+	}
+	users := map[string]*model.User{"u1": {ID: "u1"}}
+	p, _, pub := newProcessor(drafts, users)
+	// SetNotifier 呼ばない → nil
+	require.NoError(t, p.Handle(context.Background(), taskFor("d1")))
+	assert.Len(t, pub.calls, 1)
 }

--- a/internal/server/router.go
+++ b/internal/server/router.go
@@ -1124,6 +1124,9 @@ func (s *Server) setupRoutes() {
 	// at-least-once delivery で job が二重 fire しても重複 publish を防ぐ。
 	postScheduledNoteProcessor.SetLock(processors.NewRedisScheduledNoteLock(
 		s.redis.Default, s.config.Redis.KeyPrefix(), 0))
+	// publish 結果通知 (#1045 Phase 2-B): scheduledNotePosted (= 成功) /
+	// scheduledNotePostFailed (= 失敗) を user の通知 stream に発火する。
+	postScheduledNoteProcessor.SetNotifier(notificationService)
 	s.queueServer.Handle(queue.TaskTypePostScheduledNote, postScheduledNoteProcessor.Handle)
 	api.POST("/notes/drafts/list", notesHandler.DraftsList, middleware.RequireAuth())
 	api.POST("/notes/drafts/create", notesHandler.DraftsCreate, middleware.RequireAuth())


### PR DESCRIPTION
## Summary

#1045 Phase 2 の **2-B** を消化。scheduled note の publish 結果を upstream Misskey TS と同 shape で user の通知 stream に発火する。

## 実装

### notification type 2 件追加
- `TypeScheduledNotePosted` = `"scheduledNotePosted"`
- `TypeScheduledNotePostFailed` = `"scheduledNotePostFailed"`

upstream の `PostScheduledNoteProcessorService.process` が発火する key と完全一致。

### narrow interface `ScheduledNoteNotifier`
1 method only (`Create(ctx, CreateInput) (*Notification, error)`)、`*core/notification.Service` がそのまま満たす。`PostScheduledNoteProcessor.SetNotifier(...)` で後付け配線。

### Handle に発火 logic
- **publish 成功**: `Type=ScheduledNotePosted` + `NoteID=publishedNote.ID`
- **publish 失敗**: `Type=ScheduledNotePostFailed` + `Extra={"noteDraftId": draft.ID}`
- notifier error は **best-effort** で publish 結果に影響しない (= log のみ)

## テスト

processor に 4 ケース追加:
- `NotifiesOnPosted` / `NotifiesOnFailed` / `NotifierErrorDoesNotBreakPublish` / `NoNotifierConfigured`

実行: `go test ./internal/queue/processors/... -count=1 -cover`

## カバレッジ

| Package | Coverage |
|---|---|
| `internal/queue/processors` | 91.5% (clear) |
| `internal/core/notification` | 91.6% (新 const 追加、既存 test 影響なし) |

## 後方互換

- notifier 未配線 (test fixture) では publish は変わらず動作 = Phase 2-A 互換
- 新 type は upstream key と完全一致 → drop-in 互換維持
- notification 失敗は publish 経路に影響しない best-effort

## 引き続き Phase 2 残

- **2-C**: DraftsUpdate での re-schedule / clearSchedule (asynq cancel API 調査)
- **2-E**: drop-in e2e 検証

## 関連

- Refs #1045 (Phase 2 tracker)
- 前提: #1046 (Phase 2-A + 2-D merged)
- upstream: `PostScheduledNoteProcessorService.process`

🤖 Generated with [Claude Code](https://claude.com/claude-code)