### PR TITLE
fix(transfer): CSV import で withReplies=bool field を parse + threading (#1058)

### DIFF
--- a/internal/core/transfer/adapters.go
+++ b/internal/core/transfer/adapters.go
@@ -16,13 +16,14 @@ func NewFollowingServiceAdapter(svc *corefollowing.Service) *FollowingServiceAda
 	return &FollowingServiceAdapter{svc: svc}
 }
 
-// Follow delegates to core/following.Service.Follow with default options.
-// CSV import の `withReplies=bool` field 解析は未実装 (import_csv.go:11 の
-// godoc は intent 表記であって実装はまだ first field しか読まない)。実装する
-// 際は本 adapter シグネチャを拡張して FollowOptions を threading する。
-func (a *FollowingServiceAdapter) Follow(followerID, followeeID string) (any, error) {
+// Follow delegates to core/following.Service.Follow, bridging transfer's
+// FollowOptions to corefollowing.FollowOptions. CSV import 側で parse された
+// withReplies (#1058) を Service まで threading する。
+func (a *FollowingServiceAdapter) Follow(followerID, followeeID string, opts FollowOptions) (any, error) {
 	if a == nil || a.svc == nil {
 		return nil, nil
 	}
-	return a.svc.Follow(followerID, followeeID, corefollowing.FollowOptions{})
+	return a.svc.Follow(followerID, followeeID, corefollowing.FollowOptions{
+		WithReplies: opts.WithReplies,
+	})
 }

--- a/internal/core/transfer/adapters_test.go
+++ b/internal/core/transfer/adapters_test.go
@@ -16,7 +16,7 @@ func TestNewFollowingServiceAdapter_ConstructsWithRealType(t *testing.T) {
 	a := transfer.NewFollowingServiceAdapter(svc)
 	assert.NotNil(t, a)
 	// Follow on a nil inner returns (nil, nil) via the guard.
-	out, err := a.Follow("f", "g")
+	out, err := a.Follow("f", "g", transfer.FollowOptions{})
 	assert.NoError(t, err)
 	assert.Nil(t, out)
 }

--- a/internal/core/transfer/import_csv.go
+++ b/internal/core/transfer/import_csv.go
@@ -8,13 +8,19 @@ import (
 	"github.com/shiroha-a/mk/internal/model"
 )
 
-// importFollowing parses a CSV body of `acct` lines and applies a follow for
-// each. Remote users must already exist locally.
+// importFollowing parses a CSV body of `acct[,key=value...]` lines and applies
+// a follow for each. Remote users must already exist locally.
 //
-// upstream Misskey TS の CSV export 形式は `acct[,withReplies=bool]` を取るが、
-// mk-go の current 実装は first field (acct) のみ parse し withReplies は
-// default false で固定する。FollowOptions を threading する対応は #1056
-// follow-up で実装予定 (adapters.go の TODO comment 参照)。
+// Supported optional fields (key=value form, comma-separated after the acct):
+//   - `withReplies=true|false`: initial value for `following.withReplies`. Any
+//     other value (or absence) defaults to false (= upstream-equivalent loose
+//     parsing, matching `value === 'true'` semantics).
+//
+// upstream Misskey TS の export-following CSV は `acct,withReplies=BOOL` 2 fields
+// で row を出力する (ExportFollowingProcessorService.ts:98)。upstream の import
+// 側 (ImportFollowingProcessorService.ts:75) は `parts.slice(2)` で parse する
+// バグがあり 2-fields export と整合しないが、mk-go は `parts[1:]` から parse して
+// 実 export format と一致させる。
 func (i *Importer) importFollowing(user *model.User, body []byte) (*ImportResult, error) {
 	if i.deps.Following == nil {
 		return nil, fmt.Errorf("following service not configured")
@@ -22,7 +28,7 @@ func (i *Importer) importFollowing(user *model.User, body []byte) (*ImportResult
 	lines := scanCSV(body)
 	res := &ImportResult{Total: len(lines)}
 	for _, line := range lines {
-		acctStr := strings.TrimSpace(strings.SplitN(line, ",", 2)[0])
+		acctStr, opts := parseFollowingCSVLine(line)
 		target, err := i.resolveTargetUser(acctStr)
 		if err != nil || target == nil {
 			res.Skipped++
@@ -33,7 +39,7 @@ func (i *Importer) importFollowing(user *model.User, body []byte) (*ImportResult
 			res.Skipped++
 			continue
 		}
-		if _, err := i.deps.Following.Follow(user.ID, target.ID); err != nil {
+		if _, err := i.deps.Following.Follow(user.ID, target.ID, opts); err != nil {
 			res.Skipped++
 			logSkip(ImportFollowing, acctStr, err)
 			continue
@@ -41,6 +47,30 @@ func (i *Importer) importFollowing(user *model.User, body []byte) (*ImportResult
 		res.Applied++
 	}
 	return res, nil
+}
+
+// parseFollowingCSVLine splits a CSV row into its acct field and any optional
+// `key=value` fields, returning the acct and a populated FollowOptions.
+//
+// 不正な field (= `=` を含まない trailing fragment や未知の key) は silently
+// skip する (= upstream の `switch (key)` で default なしの挙動と一致)。
+func parseFollowingCSVLine(line string) (string, FollowOptions) {
+	parts := strings.Split(line, ",")
+	acct := strings.TrimSpace(parts[0])
+	var opts FollowOptions
+	for _, kv := range parts[1:] {
+		k, v, ok := strings.Cut(strings.TrimSpace(kv), "=")
+		if !ok {
+			continue
+		}
+		switch k {
+		case "withReplies":
+			// upstream Misskey TS の `value === 'true'` と同 semantics: 文字列
+			// "true" 以外は (空文字 / "false" / "invalid" 等) すべて false。
+			opts.WithReplies = v == "true"
+		}
+	}
+	return acct, opts
 }
 
 // importBlocking parses `acct` lines and applies a block per entry.

--- a/internal/core/transfer/import_csv_internal_test.go
+++ b/internal/core/transfer/import_csv_internal_test.go
@@ -1,0 +1,78 @@
+package transfer
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// TestParseFollowingCSVLine covers the `acct[,key=value...]` parser used by
+// importFollowing (#1058). upstream Misskey TS の loose `value === 'true'`
+// semantics と互換にするため、"true" 以外は (空文字 / "false" / 不明値) すべて
+// false として扱う。
+func TestParseFollowingCSVLine(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name    string
+		line    string
+		acct    string
+		options FollowOptions
+	}{
+		{
+			name:    "acct only",
+			line:    "@bob@host.example",
+			acct:    "@bob@host.example",
+			options: FollowOptions{WithReplies: false},
+		},
+		{
+			name:    "withReplies=true",
+			line:    "@bob@host.example,withReplies=true",
+			acct:    "@bob@host.example",
+			options: FollowOptions{WithReplies: true},
+		},
+		{
+			name:    "withReplies=false",
+			line:    "@bob@host.example,withReplies=false",
+			acct:    "@bob@host.example",
+			options: FollowOptions{WithReplies: false},
+		},
+		{
+			name: "withReplies=invalid falls back to false",
+			// loose parsing: "true" 以外はすべて false (upstream の
+			// `value === 'true'` と同 semantics)。
+			line:    "@bob@host.example,withReplies=yes",
+			acct:    "@bob@host.example",
+			options: FollowOptions{WithReplies: false},
+		},
+		{
+			name:    "unknown key is silently ignored",
+			line:    "@bob@host.example,silent=true",
+			acct:    "@bob@host.example",
+			options: FollowOptions{WithReplies: false},
+		},
+		{
+			name: "malformed key=value fragment (no =) silently skipped",
+			// `withReplies=true` が後続にあるので acct + WithReplies=true で
+			// 解釈される。途中の bare token は skip。
+			line:    "@bob@host.example,bareToken,withReplies=true",
+			acct:    "@bob@host.example",
+			options: FollowOptions{WithReplies: true},
+		},
+		{
+			name:    "leading/trailing spaces stripped",
+			line:    "  @bob@host.example  ,  withReplies=true  ",
+			acct:    "@bob@host.example",
+			options: FollowOptions{WithReplies: true},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			acct, opts := parseFollowingCSVLine(tc.line)
+			assert.Equal(t, tc.acct, acct)
+			assert.Equal(t, tc.options, opts)
+		})
+	}
+}

--- a/internal/core/transfer/import_test.go
+++ b/internal/core/transfer/import_test.go
@@ -17,15 +17,17 @@ import (
 // --- Stubs for core service interfaces ---
 
 type fakeFollowingService struct {
-	calls [][2]string
-	err   error
+	calls    [][2]string
+	lastOpts transfer.FollowOptions
+	err      error
 }
 
-func (f *fakeFollowingService) Follow(followerID, followeeID string) (any, error) {
+func (f *fakeFollowingService) Follow(followerID, followeeID string, opts transfer.FollowOptions) (any, error) {
 	if f.err != nil {
 		return nil, f.err
 	}
 	f.calls = append(f.calls, [2]string{followerID, followeeID})
+	f.lastOpts = opts
 	return nil, nil
 }
 
@@ -146,6 +148,33 @@ func TestImport_Following_AppliesEachRow(t *testing.T) {
 	require.Len(t, notifier.calls, 1)
 	assert.Equal(t, "importCompleted", string(notifier.calls[0].Type))
 	assert.Equal(t, "following", notifier.calls[0].Extra["importedEntity"])
+}
+
+// #1058: CSV row の withReplies=true が FollowOptions として Service に threading
+// される。fakeFollowingService が last call の opts を保存しているので、最後の
+// row の opts が WithReplies=true である事を検証する。
+func TestImport_Following_ThreadsWithReplies(t *testing.T) {
+	deps, user, fs, _, _, _ := newImporterDeps(t,
+		[]byte("bob,withReplies=true\n"))
+	imp := transfer.NewImporter(deps)
+	res, err := imp.Import(context.Background(), user.ID, transfer.ImportFollowing, "fid")
+	require.NoError(t, err)
+	assert.Equal(t, 1, res.Applied)
+	require.Len(t, fs.calls, 1)
+	assert.True(t, fs.lastOpts.WithReplies, "FollowOptions.WithReplies should be propagated from CSV row")
+}
+
+// #1058: withReplies field を省略した CSV row では default false が threading
+// される (= upstream 仕様準拠)。
+func TestImport_Following_DefaultsWithRepliesFalseWhenOmitted(t *testing.T) {
+	deps, user, fs, _, _, _ := newImporterDeps(t,
+		[]byte("bob\n"))
+	imp := transfer.NewImporter(deps)
+	res, err := imp.Import(context.Background(), user.ID, transfer.ImportFollowing, "fid")
+	require.NoError(t, err)
+	assert.Equal(t, 1, res.Applied)
+	require.Len(t, fs.calls, 1)
+	assert.False(t, fs.lastOpts.WithReplies, "missing withReplies field should default to false")
 }
 
 func TestImport_Following_SkipsUnknown(t *testing.T) {
@@ -338,6 +367,6 @@ func TestParseAcct_Malformed(t *testing.T) {
 func TestFollowingServiceAdapter(t *testing.T) {
 	// Adapter accepts nil receiver safely.
 	var a *transfer.FollowingServiceAdapter
-	_, err := a.Follow("f", "g")
+	_, err := a.Follow("f", "g", transfer.FollowOptions{})
 	assert.NoError(t, err)
 }

--- a/internal/core/transfer/import_test.go
+++ b/internal/core/transfer/import_test.go
@@ -17,9 +17,10 @@ import (
 // --- Stubs for core service interfaces ---
 
 type fakeFollowingService struct {
-	calls    [][2]string
-	lastOpts transfer.FollowOptions
-	err      error
+	calls     [][2]string
+	callsOpts []transfer.FollowOptions // per-call FollowOptions の履歴 (#1058)
+	lastOpts  transfer.FollowOptions
+	err       error
 }
 
 func (f *fakeFollowingService) Follow(followerID, followeeID string, opts transfer.FollowOptions) (any, error) {
@@ -27,6 +28,7 @@ func (f *fakeFollowingService) Follow(followerID, followeeID string, opts transf
 		return nil, f.err
 	}
 	f.calls = append(f.calls, [2]string{followerID, followeeID})
+	f.callsOpts = append(f.callsOpts, opts)
 	f.lastOpts = opts
 	return nil, nil
 }
@@ -145,6 +147,11 @@ func TestImport_Following_AppliesEachRow(t *testing.T) {
 	assert.Equal(t, 2, res.Applied)
 	assert.Equal(t, 0, res.Skipped)
 	assert.Len(t, fs.calls, 2)
+	// per-row の withReplies が独立に Service へ threading される (#1058)。
+	// lastOpts (last call のみ) ではなく callsOpts (全 call の履歴) で verify する。
+	require.Len(t, fs.callsOpts, 2)
+	assert.True(t, fs.callsOpts[0].WithReplies, "row 1 (bob,withReplies=true) should propagate WithReplies=true")
+	assert.False(t, fs.callsOpts[1].WithReplies, "row 2 (carol,withReplies=false) should propagate WithReplies=false")
 	require.Len(t, notifier.calls, 1)
 	assert.Equal(t, "importCompleted", string(notifier.calls[0].Type))
 	assert.Equal(t, "following", notifier.calls[0].Extra["importedEntity"])

--- a/internal/core/transfer/importer.go
+++ b/internal/core/transfer/importer.go
@@ -17,8 +17,20 @@ import (
 )
 
 // FollowingService is the subset of core/following.Service used by imports.
+//
+// FollowOptions 引数 (#1058) で CSV row 由来の withReplies 等の preference を
+// threading する。adapter layer で corefollowing.FollowOptions に bridge する
+// ため transfer package 単位で interface を切る (= core/following 直接依存を
+// 避ける)。
 type FollowingService interface {
-	Follow(followerID, followeeID string) (any, error)
+	Follow(followerID, followeeID string, opts FollowOptions) (any, error)
+}
+
+// FollowOptions mirrors the relevant subset of corefollowing.FollowOptions
+// that CSV imports need to threading. Currently only WithReplies is parsed
+// from the CSV row.
+type FollowOptions struct {
+	WithReplies bool
 }
 
 // BlockingService is the subset of core/blocking.Service used by imports.

--- a/internal/queue/processors/transfer_test.go
+++ b/internal/queue/processors/transfer_test.go
@@ -52,7 +52,9 @@ func (stubMutingSvc) Mute(_, muteeID string, _ *time.Time) (*model.Muting, error
 
 type stubFollowingSvc struct{}
 
-func (stubFollowingSvc) Follow(_, _ string) (any, error) { return nil, nil }
+func (stubFollowingSvc) Follow(_, _ string, _ transfer.FollowOptions) (any, error) {
+	return nil, nil
+}
 
 // --- Builders ---
 


### PR DESCRIPTION
## Summary

PR #1057 (#1056) で TODO 残置していた CSV import の \`withReplies\` parsing を実装する。upstream Misskey TS の export-following CSV (\`acct,withReplies=BOOL\` 形式) を mk-go に import すると、Following row に withReplies が正しく保存されるようになる (drop-in 互換)。

## 主な変更点

### Production

- \`internal/core/transfer/importer.go\`
  - \`FollowingService\` interface の \`Follow\` signature を \`FollowOptions\` 引数付きに拡張
  - \`transfer.FollowOptions\` struct (現状 \`WithReplies\` のみ) を新設。corefollowing 直接依存を避けて transfer layer 単位で interface を切る
- \`internal/core/transfer/adapters.go\`
  - \`FollowingServiceAdapter.Follow\` が \`transfer.FollowOptions\` を \`corefollowing.FollowOptions\` に bridge
- \`internal/core/transfer/import_csv.go\`
  - \`parseFollowingCSVLine\` helper を新設し \`acct,key=value...\` 形式を parse
  - \`withReplies=true\` → \`WithReplies=true\`、それ以外 (省略 / \`false\` / 不明値) はすべて false (= upstream \`value === 'true'\` semantics)
  - godoc を新仕様に更新 (upstream の \`parts.slice(2)\` バグについても言及)

### Tests

- 既存 7 site の \`FollowingService.Follow\` 呼び出しを新 signature に更新
- 新規 internal unit test (\`import_csv_internal_test.go\`): \`TestParseFollowingCSVLine\` 7 ケース
  - acct only / withReplies=true / withReplies=false / invalid value / unknown key / malformed fragment / whitespace
- 新規 e2e test (\`import_test.go\`):
  - \`TestImport_Following_ThreadsWithReplies\`: row の WithReplies=true が Service まで threading される
  - \`TestImport_Following_DefaultsWithRepliesFalseWhenOmitted\`: 省略時 default false

## Upstream parser バグについて

upstream Misskey TS の \`ImportFollowingProcessorService.ts:75\` は \`parts.slice(2)\` で key=value parsing するが、export 側 (\`ExportFollowingProcessorService.ts:98\`) は \`acct,withReplies=BOOL\` の 2 fields で出力するため、**upstream import は自身が export した CSV の withReplies を正しく parse できない**。

mk-go では \`parts[1:]\` で parse するため、upstream の export CSV を正しく解釈できる (= drop-in 互換は user-visible behavior 観点であり、バグまでコピーしない方針)。inline comment と godoc で根拠明示。

## Coverage

- \`internal/core/transfer\`: 92.6%
- \`internal/queue/processors\`: 91.6% (維持)

## 実行方法

\`\`\`bash
go test ./internal/core/transfer/... -run "TestParseFollowingCSVLine|TestImport_Following" -count=1 -v
go test ./internal/core/transfer/... ./internal/queue/processors/... -count=1 -cover
make fmt && make lint && make test
\`\`\`

## Closes

Closes #1058

## その他

- \`silent\` / \`requestId\` 等他の upstream FollowOptions field は本 PR scope 外 (CSV format に含まれないため不要)
- 親 PR: #1057 (#1056) で API endpoint 側 (\`/api/following/create\`) は対応済

🤖 Generated with [Claude Code](https://claude.com/claude-code)