### PR TITLE
fix(repo): username LIKE prefix で SQL wildcard escape を適用 (#1061)

### DIFF
--- a/internal/repository/user.go
+++ b/internal/repository/user.go
@@ -218,9 +218,14 @@ func (r *userRepository) IncrementNotesCount(userID string, delta int) error {
 // Phase 4でMeilisearch統合予定だが、現状は単純なLIKE検索のみ。
 //
 // origin で host filter を切り替える (#763)。
+//
+// query は escapeSQLLikePattern で SQL LIKE wildcard (`\\` / `%` / `_`) を
+// escape する (#1061)。username は仕様上 `_` を含めうるため、escape 無しだと
+// `alice_bob` を search すると `alice1bob` 等の関係ない user も hit してしまう。
+// upstream Misskey TS UserSearchService.ts:197 と同じ semantics。
 func (r *userRepository) SearchByUsername(query string, limit, offset int, origin string) ([]*model.User, error) {
 	var users []*model.User
-	q := r.db.Where("\"usernameLower\" LIKE ?", query+"%")
+	q := r.db.Where(`"usernameLower" LIKE ? ESCAPE '\'`, escapeSQLLikePattern(query)+"%")
 	switch origin {
 	case SearchOriginLocal:
 		q = q.Where("\"host\" IS NULL")
@@ -252,12 +257,11 @@ func (r *userRepository) SearchByUsername(query string, limit, offset int, origi
 // を共有して drop-in 互換を維持する。
 //
 // LIKE wildcard (`%` / `_`) の escape:
-//   - host 側: escapeSQLLikePattern で escape (#1054)。意図しない wildcard
-//     match を防ぐため。
-//   - username 側: 現状 escape していない (= 既存挙動)。username は upstream
-//     仕様で `[a-zA-Z0-9_]` だが `_` も使えるため `_` を含む username の
-//     prefix 検索は意図しない match を起こす可能性がある。本 PR scope outside
-//     なので将来別 issue で対応。
+//   - host 側: escapeSQLLikePattern で escape (#1054)。
+//   - username 側: 同じく escapeSQLLikePattern で escape (#1061)。username 仕様
+//     で `_` が許容されるため、escape 無しだと `alice_bob` を search すると
+//     `_` を 1 文字 wildcard と解釈して `alice1bob` 等の関係ない user も
+//     hit してしまう。upstream Misskey TS UserSearchService.ts:197 と一致。
 //
 // なお upstream TS は logged-in caller に対して updatedAt > / <= threshold の
 // 4-query 優先順位 (followee active/inactive + non-followee active/inactive)
@@ -268,7 +272,7 @@ func (r *userRepository) SearchByUsername(query string, limit, offset int, origi
 func (r *userRepository) SearchByUsernameAndHost(query string, host *string, limit int) ([]*model.User, error) {
 	var users []*model.User
 	q := r.db.
-		Where("\"usernameLower\" LIKE ?", query+"%").
+		Where(`"usernameLower" LIKE ? ESCAPE '\'`, escapeSQLLikePattern(query)+"%").
 		Where("\"isSuspended\" = false")
 	if host != nil {
 		q = q.Where(`lower("host") LIKE lower(?) ESCAPE '\'`, escapeSQLLikePattern(*host)+"%")

--- a/internal/repository/user.go
+++ b/internal/repository/user.go
@@ -219,7 +219,7 @@ func (r *userRepository) IncrementNotesCount(userID string, delta int) error {
 //
 // origin で host filter を切り替える (#763)。
 //
-// query は escapeSQLLikePattern で SQL LIKE wildcard (`\\` / `%` / `_`) を
+// query は escapeSQLLikePattern で SQL LIKE wildcard (`\` / `%` / `_`) を
 // escape する (#1061)。username は仕様上 `_` を含めうるため、escape 無しだと
 // `alice_bob` を search すると `alice1bob` 等の関係ない user も hit してしまう。
 // upstream Misskey TS UserSearchService.ts:197 と同じ semantics。

--- a/internal/repository/user_test.go
+++ b/internal/repository/user_test.go
@@ -551,15 +551,23 @@ func TestUserRepository_SearchByUsernameAndHost_LikeWildcardEscape(t *testing.T)
 		assert.Empty(t, out, "literal `%` should not match any actual host (= regression guard for `%` wildcard escape)")
 	})
 
-	// #1061: username 側も同じく escape されること。host="" でも username
-	// query 内の `_` が literal として扱われる。
+	// #1061: SearchByUsernameAndHost の username 側も escape されること。
+	// 上記 setup の `wildtest_u` (literal `_` を含む) に対し、`_` の位置に
+	// 別文字が入った negative candidate `wildtestX` を seed し、escape 有りなら
+	// `wildtestX` が hit しないことを直接 verify する。host filter は両 user に
+	// 共通の `with_underscore.example` を設定して、host filter で偶然絞り込まれて
+	// pass する false negative を排除する。
+	negativeCandidate := insertTestUser(t, "u_we_n", "wildtestX")
+	defer cleanupUser(t, negativeCandidate.ID)
+	require.NoError(t, repo.UpdateUser(negativeCandidate.ID, map[string]any{"host": "with_underscore.example"}))
+
 	t.Run("username underscore is escaped", func(t *testing.T) {
-		// 上記 setup の wildtest_u (host="with_underscore.example") と
-		// wildtest_a (host="witha.example") を再利用する。
-		// `wildtest_` username prefix で escape 有り → literal `_` として扱われ
-		// `wildtest_u` / `wildtest_a` 共に hit する (両者の username が
-		// `wildtest_` で始まる literal なので)。なお `wildtesta` 等は存在しない
-		// が、もし存在したら escape されないと hit してしまう。
+		// `wildtest_` username prefix を escape 有りで literal `_` として扱う:
+		//   - `wildtest_u` (literal `_` を含む) → hit
+		//   - `wildtestX` (`_` の位置に `X`) → escape 無しなら `_` wildcard 解釈で
+		//     hit してしまうが、escape 有りなら hit しない (regression guard)
+		// 両 user の host を同じく `with_underscore.example` に設定したので、
+		// 結果差は username escape 由来であることが特定できる。
 		withUnderscoreHost := "with_underscore.example"
 		out, err := repo.SearchByUsernameAndHost("wildtest_", &withUnderscoreHost, 10)
 		require.NoError(t, err)
@@ -568,6 +576,7 @@ func TestUserRepository_SearchByUsernameAndHost_LikeWildcardEscape(t *testing.T)
 			ids[u.ID] = true
 		}
 		assert.True(t, ids[withUnderscore.ID], "literal username `wildtest_` should match `wildtest_u`")
+		assert.False(t, ids[negativeCandidate.ID], "literal `_` should NOT match `wildtestX` (= regression guard for username `_` wildcard escape, #1061)")
 	})
 }
 

--- a/internal/repository/user_test.go
+++ b/internal/repository/user_test.go
@@ -339,6 +339,32 @@ func TestUserRepository_SearchByUsername(t *testing.T) {
 	assert.GreaterOrEqual(t, len(out), 2)
 }
 
+// #1061: username の SQL LIKE wildcard (`_`) が escape される。
+// upstream Misskey TS UserSearchService.ts:197 と同 semantics。
+func TestUserRepository_SearchByUsername_LikeWildcardEscape(t *testing.T) {
+	repo := NewUserRepository(testDB)
+	// `_` literal を含む username (= upstream 仕様 `[a-zA-Z0-9_]` で許容される)
+	withUnderscore := insertTestUser(t, "u_uwe_u", "wild_user")
+	defer cleanupUser(t, withUnderscore.ID)
+	// `_` の位置が任意 1 文字に置き換えられた candidate (= escape 無しだと
+	// `_` wildcard 解釈で hit してしまう)
+	withDigit := insertTestUser(t, "u_uwe_d", "wild1user")
+	defer cleanupUser(t, withDigit.ID)
+
+	t.Run("underscore in query is escaped to literal", func(t *testing.T) {
+		// `wild_` prefix で escape 有り → literal `_` として扱われ
+		// `wild_user` のみ hit、`wild1user` は hit しない
+		out, err := repo.SearchByUsername("wild_", 10, 0, "")
+		require.NoError(t, err)
+		ids := make(map[string]bool, len(out))
+		for _, u := range out {
+			ids[u.ID] = true
+		}
+		assert.True(t, ids[withUnderscore.ID], "literal `_` should match `wild_user`")
+		assert.False(t, ids[withDigit.ID], "literal `_` should NOT match `wild1user` (= regression guard for `_` wildcard escape, #1061)")
+	})
+}
+
 // origin filter (#763): "local" は host IS NULL のみ、"remote" は IS NOT NULL
 // のみ返す。"combined" / "" は両方返す。
 func TestUserRepository_SearchByUsername_OriginFilter(t *testing.T) {
@@ -523,6 +549,25 @@ func TestUserRepository_SearchByUsernameAndHost_LikeWildcardEscape(t *testing.T)
 		out, err := repo.SearchByUsernameAndHost("wildtest", &prefix, 10)
 		require.NoError(t, err)
 		assert.Empty(t, out, "literal `%` should not match any actual host (= regression guard for `%` wildcard escape)")
+	})
+
+	// #1061: username 側も同じく escape されること。host="" でも username
+	// query 内の `_` が literal として扱われる。
+	t.Run("username underscore is escaped", func(t *testing.T) {
+		// 上記 setup の wildtest_u (host="with_underscore.example") と
+		// wildtest_a (host="witha.example") を再利用する。
+		// `wildtest_` username prefix で escape 有り → literal `_` として扱われ
+		// `wildtest_u` / `wildtest_a` 共に hit する (両者の username が
+		// `wildtest_` で始まる literal なので)。なお `wildtesta` 等は存在しない
+		// が、もし存在したら escape されないと hit してしまう。
+		withUnderscoreHost := "with_underscore.example"
+		out, err := repo.SearchByUsernameAndHost("wildtest_", &withUnderscoreHost, 10)
+		require.NoError(t, err)
+		ids := make(map[string]bool, len(out))
+		for _, u := range out {
+			ids[u.ID] = true
+		}
+		assert.True(t, ids[withUnderscore.ID], "literal username `wildtest_` should match `wildtest_u`")
 	})
 }
 


### PR DESCRIPTION
## Summary

PR #1060 (#1054) で host 側の SQL LIKE wildcard escape は実装したが、**username 側 (= \`usernameLower LIKE query+%\`) は scope outside で未 escape のままだった**。本 PR で同 helper を username 側にも適用し、upstream Misskey TS \`UserSearchService.ts:197\` と完全一致させる。

## 背景

Misskey の username 規約は \`[a-zA-Z0-9_]{1,20}\` で **\`_\` (underscore) を含めうる**。SQL LIKE では \`_\` は 1 文字 wildcard なので、escape されないと:

- \`alice_bob\` を search → \`usernameLower LIKE 'alice_bob%'\` (escape 無し)
- \`_\` が 1 文字 wildcard 解釈 → \`alice1bob\`, \`alice2bob\` 等も hit
- drop-in 環境で upstream Misskey TS と挙動が異なる (upstream は escape されるので \`alice_bob\` のみ hit)

## 主な変更点

### Production

\`internal/repository/user.go\`:
- \`SearchByUsername\` (line 223): \`usernameLower LIKE\` を \`escapeSQLLikePattern(query)+"%"\` + \`ESCAPE '\\'\` に変更
- \`SearchByUsernameAndHost\` (line 271): 同様に username 側も escape
- godoc: PR #1060 で残した「username 側は scope outside」inline note を削除し、新仕様 (= 両側 escape) を記述

helper \`escapeSQLLikePattern\` は PR #1060 で導入済、本 PR では再利用するのみ。

### Tests

- \`TestUserRepository_SearchByUsername_LikeWildcardEscape\` 新規追加:
  - \`wild_\` prefix で \`wild_user\` (literal \`_\`) のみ hit
  - \`wild1user\` (= \`_\` を wildcard 解釈すると hit するはず) は hit しない (regression guard)
- \`TestUserRepository_SearchByUsernameAndHost_LikeWildcardEscape\` に \`username underscore is escaped\` サブテスト追加

## Upstream 参照

\`packages/backend/src/core/UserSearchService.ts:197\`:
\`\`\`ts
userQuery.andWhere('user.usernameLower LIKE :username', {
    username: sqlLikeEscape(params.username.toLowerCase()) + '%',
});
\`\`\`

## Coverage

- \`internal/repository\`: 90.3% (最低ライン 90% 維持)

## 実行方法

\`\`\`bash
go test ./internal/repository/... -run "TestUserRepository_SearchByUsername" -count=1 -v
make fmt && make lint && make test
\`\`\`

## Closes

Closes #1061

## 関連

- 親 PR: #1060 (#1054) — host 側修正、username 側は scope outside と宣言
- helper: \`internal/repository/sql_like_escape.go\` (PR #1060 で導入)

🤖 Generated with [Claude Code](https://claude.com/claude-code)