### PR TITLE
fix(repo): SearchByUsernameAndHost で host=nil 時に local 強制を撤廃 (#1064)

### DIFF
--- a/internal/api/resetpassword/handler_test.go
+++ b/internal/api/resetpassword/handler_test.go
@@ -42,7 +42,7 @@ func (m *mockUserRepo) IncrementFollowersCount(string, int) error { return nil }
 func (m *mockUserRepo) SearchByUsername(string, int, int, string) ([]*model.User, error) {
 	return nil, nil
 }
-func (m *mockUserRepo) SearchByUsernameAndHost(string, *string, int) ([]*model.User, error) {
+func (m *mockUserRepo) SearchByUsernameAndHost(string, *string, bool, int) ([]*model.User, error) {
 	return nil, nil
 }
 func (m *mockUserRepo) UpdateUser(string, map[string]any) error               { return nil }

--- a/internal/api/users/handler_extra_test.go
+++ b/internal/api/users/handler_extra_test.go
@@ -387,9 +387,9 @@ func TestSearchByUsernameAndHost_InvalidParam(t *testing.T) {
 	assert.Equal(t, http.StatusBadRequest, rec.Code)
 }
 
-// #766: host が指定されたら当該 host の user のみ返す。host=nil なら local
-// user (host IS NULL) のみ。"全 host のマッチを返す" 旧挙動の regression
-// guard。
+// #766 / #1064: host filter の 3-state semantics を handler 経由で覆う。
+//   - host 未指定 / 空文字 → host filter なし (= local + remote)
+//   - host 指定 → 当該 host の prefix match (case-insensitive)
 func TestSearchByUsernameAndHost_FiltersByHost(t *testing.T) {
 	h, userRepo, _ := newExtraHandler(t)
 	remote := "remote.example"
@@ -398,17 +398,25 @@ func TestSearchByUsernameAndHost_FiltersByHost(t *testing.T) {
 	userRepo.Users["u_remote"] = &model.User{ID: "u_remote", Username: "alice", UsernameLower: "alice", Host: &remote}
 	userRepo.Users["u_other"] = &model.User{ID: "u_other", Username: "alice", UsernameLower: "alice", Host: &other}
 
-	// host 未指定 / 空文字 → local user のみ
+	// #1064: host 未指定 / 空文字 → local + remote 両方返す。
+	// 旧来は local 限定だったが、frontend MkAutocomplete が `@alice` だけ
+	// 入力した状態で host=undefined を送るので、それでは remote candidate
+	// が一切出ない drop-in 互換性違反だった。
 	for _, body := range []string{`{"username":"alice"}`, `{"username":"alice","host":""}`} {
 		rec := postExtra(h.SearchByUsernameAndHost, body, nil)
 		require.Equal(t, http.StatusOK, rec.Code)
 		var got []entity.UserLite
 		require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &got))
-		require.Len(t, got, 1, "body=%s should return only local user", body)
-		assert.Equal(t, "u_local", got[0].ID)
+		ids := make(map[string]bool, len(got))
+		for _, u := range got {
+			ids[u.ID] = true
+		}
+		assert.True(t, ids["u_local"], "body=%s should include local user", body)
+		assert.True(t, ids["u_remote"], "body=%s should include remote user", body)
+		assert.True(t, ids["u_other"], "body=%s should include other-host user", body)
 	}
 
-	// host 指定 → 当該 host の user のみ (local や別 host の user は除外)
+	// host 指定 → 当該 host の prefix match user のみ (local や別 host の user は除外)
 	rec := postExtra(h.SearchByUsernameAndHost, `{"username":"alice","host":"remote.example"}`, nil)
 	require.Equal(t, http.StatusOK, rec.Code)
 	var got []entity.UserLite
@@ -422,6 +430,13 @@ func TestSearchByUsernameAndHost_FiltersByHost(t *testing.T) {
 	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &got))
 	require.Len(t, got, 1)
 	assert.Equal(t, "u_remote", got[0].ID)
+
+	// #1064: host="." は local 限定 (upstream の shortcut)。
+	rec = postExtra(h.SearchByUsernameAndHost, `{"username":"alice","host":"."}`, nil)
+	require.Equal(t, http.StatusOK, rec.Code)
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &got))
+	require.Len(t, got, 1)
+	assert.Equal(t, "u_local", got[0].ID)
 }
 
 // --- UpdateMemo ---
@@ -478,7 +493,7 @@ type failingSearchRepo struct {
 	*testutil.MockUserRepository
 }
 
-func (f *failingSearchRepo) SearchByUsernameAndHost(_ string, _ *string, _ int) ([]*model.User, error) {
+func (f *failingSearchRepo) SearchByUsernameAndHost(_ string, _ *string, _ bool, _ int) ([]*model.User, error) {
 	return nil, assert.AnError
 }
 

--- a/internal/core/retention/service_test.go
+++ b/internal/core/retention/service_test.go
@@ -55,7 +55,7 @@ func (s *stubUserRepo) IncrementFollowersCount(string, int) error               
 func (s *stubUserRepo) SearchByUsername(string, int, int, string) ([]*model.User, error) {
 	return nil, nil
 }
-func (s *stubUserRepo) SearchByUsernameAndHost(string, *string, int) ([]*model.User, error) {
+func (s *stubUserRepo) SearchByUsernameAndHost(string, *string, bool, int) ([]*model.User, error) {
 	return nil, nil
 }
 func (s *stubUserRepo) UpdateUser(string, map[string]any) error               { return nil }

--- a/internal/core/user/user_service.go
+++ b/internal/core/user/user_service.go
@@ -83,8 +83,9 @@ type Service struct {
 	// selfHostname は SearchByUsernameAndHost で「host==self-hostname → local
 	// 限定」を判定するために保持する (upstream UserSearchService と互換、
 	// #1064)。空文字なら remap を skip して "." 一致のみ local 限定にする。
-	// SetSelfHostname 内で lowercase 正規化して格納する (search 側 per-call
-	// の ToLower を省くため)。
+	// SetSelfHostname 内で TrimSpace + lowercase に正規化して格納する
+	// (search 側 per-call の ToLower を省くためと、whitespace のみ入力で
+	// remap が無意味に有効化される edge case の防御)。
 	selfHostname string
 }
 

--- a/internal/core/user/user_service.go
+++ b/internal/core/user/user_service.go
@@ -80,6 +80,10 @@ type Service struct {
 	// override するのに使う (#1029)。nil 時は MaxPinnedNotes 定数 fallback
 	// (= 旧挙動互換)。実装は core/role.Service。
 	rolePolicyProvider RolePolicyProvider
+	// selfHostname は SearchByUsernameAndHost で「host==self-hostname → local
+	// 限定」を判定するために保持する (upstream UserSearchService と互換、
+	// #1064)。空文字なら remap を skip して "." 一致のみ local 限定にする。
+	selfHostname string
 }
 
 // RolePolicyProvider abstracts role-policy lookup used to override default
@@ -135,6 +139,14 @@ func (s *Service) SetDriveFileRepository(repo repository.DriveFileRepository) {
 // leaves ShowByUsername DB-only.
 func (s *Service) SetRemoteUserResolver(r RemoteUserResolver) {
 	s.remoteResolver = r
+}
+
+// SetSelfHostname records the running instance's canonical hostname so that
+// SearchByUsernameAndHost can map `host==self-hostname` to "local only" the
+// same way upstream UserSearchService does (#1064). Empty string disables the
+// remap (only the literal `"."` keeps the local-only shortcut).
+func (s *Service) SetSelfHostname(hostname string) {
+	s.selfHostname = hostname
 }
 
 // UserWithProfile bundles a user and its profile for handlers.
@@ -276,11 +288,19 @@ func (s *Service) Search(query string, limit, offset int, origin string) ([]*mod
 	return s.userRepo.SearchByUsername(strings.ToLower(q), limit, offset, origin)
 }
 
-// SearchByUsernameAndHost narrows username prefix matches to a specific host
-// (or local users when host is nil/empty). upstream Misskey TS の
-// users/search-by-username-and-host endpoint と同じ semantics (#766)。
-//   - host=nil or empty → host IS NULL (local users)
-//   - host=*string      → 当該 host のみ (case-insensitive)
+// SearchByUsernameAndHost narrows username prefix matches with a host filter.
+// upstream Misskey TS の users/search-by-username-and-host endpoint と同じ
+// semantics (#766 / #1064):
+//   - host=nil or empty  → host filter なし (= local + remote 両方)
+//   - host="." or self-hostname → local 限定 (host IS NULL)
+//   - host=その他       → 当該 host の prefix match (case-insensitive)
+//
+// #1064 fix: 旧来は host=nil で local 強制していたが、frontend MkAutocomplete
+// は `@alice` だけ入力したとき host=undefined を送るため、これだと remote user
+// 候補が一切出ない。upstream `generateUserQueryBuilder` も `params.host`
+// falsy で host filter を skip するので合わせる。"." と self-hostname だけ
+// local 限定への remap を Service 側で行う (= self-hostname は Service 設定
+// から引く)。
 func (s *Service) SearchByUsernameAndHost(username string, host *string, limit int) ([]*model.User, error) {
 	q := strings.TrimSpace(strings.TrimPrefix(username, "@"))
 	if q == "" {
@@ -289,15 +309,20 @@ func (s *Service) SearchByUsernameAndHost(username string, host *string, limit i
 	if limit <= 0 {
 		limit = 10
 	}
-	// upstream は host="" / null を local 扱いにするので合わせる。
 	var hostNorm *string
+	localOnly := false
 	if host != nil {
 		h := strings.ToLower(strings.TrimSpace(*host))
-		if h != "" {
+		switch {
+		case h == "":
+			// falsy → host filter なし。hostNorm は nil のままにする。
+		case h == "." || (s.selfHostname != "" && h == strings.ToLower(s.selfHostname)):
+			localOnly = true
+		default:
 			hostNorm = &h
 		}
 	}
-	return s.userRepo.SearchByUsernameAndHost(strings.ToLower(q), hostNorm, limit)
+	return s.userRepo.SearchByUsernameAndHost(strings.ToLower(q), hostNorm, localOnly, limit)
 }
 
 // UpdateInput represents the editable fields of a user profile.

--- a/internal/core/user/user_service.go
+++ b/internal/core/user/user_service.go
@@ -148,11 +148,14 @@ func (s *Service) SetRemoteUserResolver(r RemoteUserResolver) {
 // same way upstream UserSearchService does (#1064). Empty string disables the
 // remap (only the literal `"."` keeps the local-only shortcut).
 //
-// 入力は setter 内で lowercase 正規化して保持する。search の per-call ホット
-// パスで毎回 strings.ToLower するのを避けるため (autocomplete は per-keystroke
-// で呼ばれる)。
+// 入力は setter 内で TrimSpace + lowercase に正規化して保持する。search の
+// per-call ホットパスで毎回 strings.ToLower するのを避けるためと、
+// whitespace のみ入力 (= "  ") で remap が無意味に有効化される edge case を
+// 防ぐ防御。実 caller は `s.config.Hostname` (= `url.Hostname()` 由来) で
+// whitespace が入る経路は通常 無いが、Setter contract として境界条件を
+// 確実にする。
 func (s *Service) SetSelfHostname(hostname string) {
-	s.selfHostname = strings.ToLower(hostname)
+	s.selfHostname = strings.ToLower(strings.TrimSpace(hostname))
 }
 
 // UserWithProfile bundles a user and its profile for handlers.

--- a/internal/core/user/user_service.go
+++ b/internal/core/user/user_service.go
@@ -83,6 +83,8 @@ type Service struct {
 	// selfHostname は SearchByUsernameAndHost で「host==self-hostname → local
 	// 限定」を判定するために保持する (upstream UserSearchService と互換、
 	// #1064)。空文字なら remap を skip して "." 一致のみ local 限定にする。
+	// SetSelfHostname 内で lowercase 正規化して格納する (search 側 per-call
+	// の ToLower を省くため)。
 	selfHostname string
 }
 
@@ -145,8 +147,12 @@ func (s *Service) SetRemoteUserResolver(r RemoteUserResolver) {
 // SearchByUsernameAndHost can map `host==self-hostname` to "local only" the
 // same way upstream UserSearchService does (#1064). Empty string disables the
 // remap (only the literal `"."` keeps the local-only shortcut).
+//
+// 入力は setter 内で lowercase 正規化して保持する。search の per-call ホット
+// パスで毎回 strings.ToLower するのを避けるため (autocomplete は per-keystroke
+// で呼ばれる)。
 func (s *Service) SetSelfHostname(hostname string) {
-	s.selfHostname = hostname
+	s.selfHostname = strings.ToLower(hostname)
 }
 
 // UserWithProfile bundles a user and its profile for handlers.
@@ -316,7 +322,9 @@ func (s *Service) SearchByUsernameAndHost(username string, host *string, limit i
 		switch {
 		case h == "":
 			// falsy → host filter なし。hostNorm は nil のままにする。
-		case h == "." || (s.selfHostname != "" && h == strings.ToLower(s.selfHostname)):
+		case h == "." || (s.selfHostname != "" && h == s.selfHostname):
+			// selfHostname は SetSelfHostname で lowercase 済みなので
+			// 直接比較できる (#1064)。
 			localOnly = true
 		default:
 			hostNorm = &h

--- a/internal/core/user/user_service_test.go
+++ b/internal/core/user/user_service_test.go
@@ -875,7 +875,10 @@ func TestUpdateProfileFields(t *testing.T) {
 	require.NoError(t, err)
 }
 
-// #766: SearchByUsernameAndHost の各分岐を service レイヤーで覆う。
+// #766 / #1064: SearchByUsernameAndHost の各分岐を service レイヤーで覆う。
+// upstream UserSearchService.generateUserQueryBuilder と同じく、host=falsy は
+// filter 無し (local + remote)、host="." or self-hostname は local 限定、
+// それ以外は host prefix match。
 func TestService_SearchByUsernameAndHost(t *testing.T) {
 	svc, userRepo, _, _ := newFullSvc(t)
 	remoteHost := "remote.example"
@@ -890,26 +893,84 @@ func TestService_SearchByUsernameAndHost(t *testing.T) {
 		assert.Nil(t, out)
 	})
 
-	t.Run("@ prefix is stripped", func(t *testing.T) {
+	t.Run("@ prefix is stripped and host=nil returns local+remote", func(t *testing.T) {
 		out, err := svc.SearchByUsernameAndHost("@alice", nil, 10)
 		require.NoError(t, err)
-		require.Len(t, out, 1)
-		assert.Equal(t, "u_local", out[0].ID)
+		ids := make(map[string]bool, len(out))
+		for _, u := range out {
+			ids[u.ID] = true
+		}
+		assert.True(t, ids["u_local"], "@ prefix should strip and host=nil returns local")
+		assert.True(t, ids["u_remote"], "host=nil should include remote")
+		assert.True(t, ids["u_other"], "host=nil should include other host too")
 	})
 
-	t.Run("host=nil filters to local", func(t *testing.T) {
+	// #1064: host=nil は upstream `params.host` falsy 経路で host filter なし
+	// = local + remote 両方返す。旧来は local 限定だったが drift だった。
+	t.Run("host=nil returns local and remote", func(t *testing.T) {
 		out, err := svc.SearchByUsernameAndHost("alice", nil, 10)
 		require.NoError(t, err)
-		require.Len(t, out, 1)
-		assert.Equal(t, "u_local", out[0].ID)
+		ids := make(map[string]bool, len(out))
+		for _, u := range out {
+			ids[u.ID] = true
+		}
+		assert.True(t, ids["u_local"])
+		assert.True(t, ids["u_remote"])
+		assert.True(t, ids["u_other"])
 	})
 
-	t.Run("host=empty string treated as local", func(t *testing.T) {
+	t.Run("host=empty string is treated as nil (no filter)", func(t *testing.T) {
 		empty := ""
 		out, err := svc.SearchByUsernameAndHost("alice", &empty, 10)
 		require.NoError(t, err)
+		ids := make(map[string]bool, len(out))
+		for _, u := range out {
+			ids[u.ID] = true
+		}
+		assert.True(t, ids["u_local"])
+		assert.True(t, ids["u_remote"])
+		assert.True(t, ids["u_other"])
+	})
+
+	// #1064: "." は upstream で local 限定への shortcut。
+	t.Run("host=. returns only local", func(t *testing.T) {
+		dot := "."
+		out, err := svc.SearchByUsernameAndHost("alice", &dot, 10)
+		require.NoError(t, err)
 		require.Len(t, out, 1)
 		assert.Equal(t, "u_local", out[0].ID)
+	})
+
+	// #1064: host が自 hostname と一致したら local 限定に remap される。
+	t.Run("host=self-hostname returns only local", func(t *testing.T) {
+		svc.SetSelfHostname("my.example")
+		t.Cleanup(func() { svc.SetSelfHostname("") })
+		self := "my.example"
+		out, err := svc.SearchByUsernameAndHost("alice", &self, 10)
+		require.NoError(t, err)
+		require.Len(t, out, 1)
+		assert.Equal(t, "u_local", out[0].ID)
+	})
+
+	// 自 hostname 比較は case-insensitive。
+	t.Run("self-hostname remap is case-insensitive", func(t *testing.T) {
+		svc.SetSelfHostname("My.Example")
+		t.Cleanup(func() { svc.SetSelfHostname("") })
+		upper := "MY.EXAMPLE"
+		out, err := svc.SearchByUsernameAndHost("alice", &upper, 10)
+		require.NoError(t, err)
+		require.Len(t, out, 1)
+		assert.Equal(t, "u_local", out[0].ID)
+	})
+
+	// selfHostname 未設定なら "." 以外の input は host filter として扱われる。
+	t.Run("self-hostname unset leaves other inputs as host filter", func(t *testing.T) {
+		other := "my.example"
+		out, err := svc.SearchByUsernameAndHost("alice", &other, 10)
+		require.NoError(t, err)
+		// selfHostname 未設定なので "my.example" prefix match。仕込み user に
+		// `my.example` host を持つものは無いので 0 件。
+		assert.Empty(t, out)
 	})
 
 	t.Run("host=specific narrows to that host", func(t *testing.T) {
@@ -922,6 +983,15 @@ func TestService_SearchByUsernameAndHost(t *testing.T) {
 	t.Run("host comparison is case-insensitive", func(t *testing.T) {
 		upper := "REMOTE.EXAMPLE"
 		out, err := svc.SearchByUsernameAndHost("alice", &upper, 10)
+		require.NoError(t, err)
+		require.Len(t, out, 1)
+		assert.Equal(t, "u_remote", out[0].ID)
+	})
+
+	// #1054 / #1060: host prefix match は維持される。`rem` で remote.example が hit。
+	t.Run("host prefix matches remote host", func(t *testing.T) {
+		prefix := "rem"
+		out, err := svc.SearchByUsernameAndHost("alice", &prefix, 10)
 		require.NoError(t, err)
 		require.Len(t, out, 1)
 		assert.Equal(t, "u_remote", out[0].ID)

--- a/internal/core/user/user_service_test.go
+++ b/internal/core/user/user_service_test.go
@@ -942,6 +942,9 @@ func TestService_SearchByUsernameAndHost(t *testing.T) {
 	})
 
 	// #1064: host が自 hostname と一致したら local 限定に remap される。
+	// 各 selfHostname 関連 subtest は冒頭で明示的に初期状態を Set し、
+	// `t.Cleanup` の実行順序に依存しない (= 個別 `-run` 実行や test reorder
+	// 耐性のため)。
 	t.Run("host=self-hostname returns only local", func(t *testing.T) {
 		svc.SetSelfHostname("my.example")
 		t.Cleanup(func() { svc.SetSelfHostname("") })
@@ -964,7 +967,9 @@ func TestService_SearchByUsernameAndHost(t *testing.T) {
 	})
 
 	// selfHostname 未設定なら "." 以外の input は host filter として扱われる。
+	// 前の subtest の cleanup に依存せず冒頭で明示的に "" を Set する。
 	t.Run("self-hostname unset leaves other inputs as host filter", func(t *testing.T) {
+		svc.SetSelfHostname("")
 		other := "my.example"
 		out, err := svc.SearchByUsernameAndHost("alice", &other, 10)
 		require.NoError(t, err)
@@ -973,7 +978,7 @@ func TestService_SearchByUsernameAndHost(t *testing.T) {
 		assert.Empty(t, out)
 	})
 
-	t.Run("host=specific narrows to that host", func(t *testing.T) {
+	t.Run("host=remoteHost narrows to host prefix match", func(t *testing.T) {
 		out, err := svc.SearchByUsernameAndHost("alice", &remoteHost, 10)
 		require.NoError(t, err)
 		require.Len(t, out, 1)

--- a/internal/core/user/user_service_test.go
+++ b/internal/core/user/user_service_test.go
@@ -966,6 +966,34 @@ func TestService_SearchByUsernameAndHost(t *testing.T) {
 		assert.Equal(t, "u_local", out[0].ID)
 	})
 
+	// SetSelfHostname は input を TrimSpace してから保存するので、whitespace
+	// 込みで設定しても "." 一致のみ local 限定に degrade することは無く、
+	// hostname だけ抽出されて正しく remap が機能する。
+	t.Run("self-hostname is trimmed on set", func(t *testing.T) {
+		svc.SetSelfHostname("  my.example  ")
+		t.Cleanup(func() { svc.SetSelfHostname("") })
+		self := "my.example"
+		out, err := svc.SearchByUsernameAndHost("alice", &self, 10)
+		require.NoError(t, err)
+		require.Len(t, out, 1)
+		assert.Equal(t, "u_local", out[0].ID)
+	})
+
+	// whitespace のみの input は空文字と同じ扱い (= remap disabled、"." 一致のみ
+	// local 限定)。SetSelfHostname の TrimSpace が空にしたケースで remap が
+	// 誤って効かないことを regression guard。
+	t.Run("self-hostname whitespace-only is treated as unset", func(t *testing.T) {
+		svc.SetSelfHostname("   ")
+		t.Cleanup(func() { svc.SetSelfHostname("") })
+		// 任意の host 文字列を与えても local 限定にならない (= host filter として動く)。
+		other := "my.example"
+		out, err := svc.SearchByUsernameAndHost("alice", &other, 10)
+		require.NoError(t, err)
+		// 仕込み user に `my.example` host を持つものは無いので 0 件。
+		// remap が誤って効いて local 1 件返ったらこの assertion が落ちる。
+		assert.Empty(t, out)
+	})
+
 	// selfHostname 未設定なら "." 以外の input は host filter として扱われる。
 	// 前の subtest の cleanup に依存せず冒頭で明示的に "" を Set する。
 	t.Run("self-hostname unset leaves other inputs as host filter", func(t *testing.T) {

--- a/internal/repository/user.go
+++ b/internal/repository/user.go
@@ -50,10 +50,15 @@ type UserRepository interface {
 	// 空文字列 / 未知値は SearchOriginCombined と同等扱い。
 	SearchByUsername(query string, limit, offset int, origin string) ([]*model.User, error)
 	// SearchByUsernameAndHost は username prefix と host を SQL で絞り込む
-	// (#766)。host=nil は local (host IS NULL)、host=*string は当該 host
-	// (case-insensitive) のみ。upstream Misskey TS の同名 endpoint と同じ
-	// semantics。caller は username / host を pre-lowercase して渡すこと。
-	SearchByUsernameAndHost(query string, host *string, limit int) ([]*model.User, error)
+	// (#766 / #1054 / #1064)。upstream Misskey TS の同名 endpoint と同じ
+	// semantics:
+	//   - localOnly=true       → host IS NULL (= local 限定)
+	//   - localOnly=false / host=nil → host filter なし (= local + remote 両方返す)
+	//   - localOnly=false / host=*string → lower("host") LIKE lower(?) ESCAPE '\'
+	//     (prefix match)
+	// caller は username / host を pre-lowercase して渡すこと。self-hostname
+	// や "." の取り扱い (= local 限定への remap) は Service レイヤで行う。
+	SearchByUsernameAndHost(query string, host *string, localOnly bool, limit int) ([]*model.User, error)
 	UpdateUser(userID string, fields map[string]any) error
 	UpdateProfile(userID string, fields map[string]any) error
 	CreateProfile(profile *model.UserProfile) error
@@ -242,9 +247,24 @@ func (r *userRepository) SearchByUsername(query string, limit, offset int, origi
 	return users, nil
 }
 
-// SearchByUsernameAndHost narrows username prefix matches to a specific host
-// (or local users when host is nil). #766 fix: SearchByUsername の origin
-// 軸では「特定 host への絞り込み」ができないので分離した sibling method。
+// SearchByUsernameAndHost narrows username prefix matches with a host filter.
+// #766 fix: SearchByUsername の origin 軸では「特定 host への絞り込み」が
+// できないので分離した sibling method。
+//
+// 3-state semantics (upstream Misskey TS の UserSearchService と一致):
+//   - localOnly=true            → "host" IS NULL (= local 限定)
+//   - localOnly=false, host=nil → host filter なし (= local + remote 両方)
+//   - localOnly=false, host=ptr → lower("host") LIKE lower(?) ESCAPE '\'
+//     (prefix match)
+//
+// #1064 fix: 旧来 host=nil で local 強制していたが、upstream
+// `generateUserQueryBuilder` は `params.host` falsy 時に host filter を一切
+// 付けない (= local + remote 両方返す) ため drop-in 互換性違反だった。
+// frontend MkAutocomplete は `@alice` だけ入力したとき host=undefined を送る
+// ので、host=nil でも remote user を候補に含める必要がある。upstream で
+// local 限定にしたい場合は `host === config.hostname` か `host === '.'` で
+// gate する設計なので、その判定は Service 側 (= self-hostname を知っている
+// 層) で行い、ここには `localOnly` フラグで降ろす。
 //
 // host comparison は upstream Misskey TS の UserSearchService と一致させて
 // `lower(host) LIKE lower(?) || '%'` の prefix match (#1054)。frontend の
@@ -269,15 +289,16 @@ func (r *userRepository) SearchByUsername(query string, limit, offset int, origi
 // 除外する quirk があり、brand-new user の discoverability を悪化させる。
 // mk-go では本 quirk を意図的に採用せず、followersCount DESC + id ASC の
 // 単純な sort を維持する (= 新規 user も即 search hit する)。詳細は #878。
-func (r *userRepository) SearchByUsernameAndHost(query string, host *string, limit int) ([]*model.User, error) {
+func (r *userRepository) SearchByUsernameAndHost(query string, host *string, localOnly bool, limit int) ([]*model.User, error) {
 	var users []*model.User
 	q := r.db.
 		Where(`"usernameLower" LIKE ? ESCAPE '\'`, escapeSQLLikePattern(query)+"%").
 		Where("\"isSuspended\" = false")
-	if host != nil {
-		q = q.Where(`lower("host") LIKE lower(?) ESCAPE '\'`, escapeSQLLikePattern(*host)+"%")
-	} else {
+	switch {
+	case localOnly:
 		q = q.Where("\"host\" IS NULL")
+	case host != nil:
+		q = q.Where(`lower("host") LIKE lower(?) ESCAPE '\'`, escapeSQLLikePattern(*host)+"%")
 	}
 	if err := q.
 		Order("\"followersCount\" DESC, id ASC").

--- a/internal/repository/user_test.go
+++ b/internal/repository/user_test.go
@@ -422,8 +422,11 @@ func TestUserRepository_SearchByUsername_OriginFilter(t *testing.T) {
 	})
 }
 
-// host filter (#766): host=nil は local (host IS NULL) のみ、host=*string
-// は当該 host のみ返す。host comparison は case-insensitive。
+// host filter 3-state semantics (#766 / #1054 / #1064):
+//   - localOnly=true        → host IS NULL のみ
+//   - localOnly=false, host=nil → host filter なし (= local + remote 両方)
+//   - localOnly=false, host=ptr → 当該 host の prefix match (case-insensitive)
+//
 // IDX_user_usernameLower_local_unique 制約があるので local user は 1 つに
 // 留め、remote 同士は host が違えば同 username でも OK な前提で組む。
 func TestUserRepository_SearchByUsernameAndHost(t *testing.T) {
@@ -439,8 +442,28 @@ func TestUserRepository_SearchByUsernameAndHost(t *testing.T) {
 	require.NoError(t, repo.UpdateUser(other.ID, map[string]any{"host": otherHost}))
 	defer cleanupUser(t, other.ID)
 
-	t.Run("host=nil returns only local", func(t *testing.T) {
-		out, err := repo.SearchByUsernameAndHost("hosttest", nil, 10)
+	// #1064: host=nil + localOnly=false は upstream の `params.host` falsy 経路
+	// と同じ semantics で、host filter を一切付けずに local + remote 両方返す。
+	// 旧来 (#766) は local 強制だったが、frontend MkAutocomplete が `@alice`
+	// だけ入力した状態で host=undefined を送るため、それでは remote user 候補
+	// が一切出なくなる drop-in 互換性違反だった。
+	t.Run("host=nil returns local and remote", func(t *testing.T) {
+		out, err := repo.SearchByUsernameAndHost("hosttest", nil, false, 10)
+		require.NoError(t, err)
+		ids := make(map[string]bool, len(out))
+		for _, u := range out {
+			ids[u.ID] = true
+		}
+		assert.True(t, ids[local.ID], "host=nil should include local user")
+		assert.True(t, ids[remote.ID], "host=nil should include remote.example user")
+		assert.True(t, ids[other.ID], "host=nil should include other.example user")
+	})
+
+	// #1064: localOnly=true は upstream で host==config.hostname / "." 一致を
+	// Service レイヤで判定した結果、repo に降りてくるフラグ。host IS NULL の
+	// user のみ返る。host pointer は無視される。
+	t.Run("localOnly=true returns only local", func(t *testing.T) {
+		out, err := repo.SearchByUsernameAndHost("hosttest", nil, true, 10)
 		require.NoError(t, err)
 		ids := make(map[string]bool, len(out))
 		for _, u := range out {
@@ -452,7 +475,7 @@ func TestUserRepository_SearchByUsernameAndHost(t *testing.T) {
 	})
 
 	t.Run("host=remote returns only that host", func(t *testing.T) {
-		out, err := repo.SearchByUsernameAndHost("hosttest", &remoteHost, 10)
+		out, err := repo.SearchByUsernameAndHost("hosttest", &remoteHost, false, 10)
 		require.NoError(t, err)
 		ids := make(map[string]bool, len(out))
 		for _, u := range out {
@@ -465,7 +488,7 @@ func TestUserRepository_SearchByUsernameAndHost(t *testing.T) {
 
 	t.Run("host comparison is case-insensitive", func(t *testing.T) {
 		upper := "REMOTE.EXAMPLE"
-		out, err := repo.SearchByUsernameAndHost("hosttest", &upper, 10)
+		out, err := repo.SearchByUsernameAndHost("hosttest", &upper, false, 10)
 		require.NoError(t, err)
 		ids := make(map[string]bool, len(out))
 		for _, u := range out {
@@ -482,7 +505,7 @@ func TestUserRepository_SearchByUsernameAndHost(t *testing.T) {
 		t.Cleanup(func() {
 			_ = repo.UpdateUser(local.ID, map[string]any{"isSuspended": false})
 		})
-		out, err := repo.SearchByUsernameAndHost("hosttest", nil, 10)
+		out, err := repo.SearchByUsernameAndHost("hosttest", nil, true, 10)
 		require.NoError(t, err)
 		ids := make(map[string]bool, len(out))
 		for _, u := range out {
@@ -497,7 +520,7 @@ func TestUserRepository_SearchByUsernameAndHost(t *testing.T) {
 	// で remote user 候補が一切出ない。
 	t.Run("host prefix match hits remote users", func(t *testing.T) {
 		prefix := "rem"
-		out, err := repo.SearchByUsernameAndHost("hosttest", &prefix, 10)
+		out, err := repo.SearchByUsernameAndHost("hosttest", &prefix, false, 10)
 		require.NoError(t, err)
 		ids := make(map[string]bool, len(out))
 		for _, u := range out {
@@ -531,7 +554,7 @@ func TestUserRepository_SearchByUsernameAndHost_LikeWildcardEscape(t *testing.T)
 		// escape 有りなら literal `_` として扱われ、`with_underscore.example`
 		// のみ hit する。
 		prefix := "with_"
-		out, err := repo.SearchByUsernameAndHost("wildtest", &prefix, 10)
+		out, err := repo.SearchByUsernameAndHost("wildtest", &prefix, false, 10)
 		require.NoError(t, err)
 		ids := make(map[string]bool, len(out))
 		for _, u := range out {
@@ -546,7 +569,7 @@ func TestUserRepository_SearchByUsernameAndHost_LikeWildcardEscape(t *testing.T)
 		// confirm するため: `%` を渡しても全 host にマッチする wildcard と
 		// しては解釈されず、literal `%` を含む host のみ hit する (= 0 件)。
 		prefix := "%"
-		out, err := repo.SearchByUsernameAndHost("wildtest", &prefix, 10)
+		out, err := repo.SearchByUsernameAndHost("wildtest", &prefix, false, 10)
 		require.NoError(t, err)
 		assert.Empty(t, out, "literal `%` should not match any actual host (= regression guard for `%` wildcard escape)")
 	})
@@ -569,7 +592,7 @@ func TestUserRepository_SearchByUsernameAndHost_LikeWildcardEscape(t *testing.T)
 		// 両 user の host を同じく `with_underscore.example` に設定したので、
 		// 結果差は username escape 由来であることが特定できる。
 		withUnderscoreHost := "with_underscore.example"
-		out, err := repo.SearchByUsernameAndHost("wildtest_", &withUnderscoreHost, 10)
+		out, err := repo.SearchByUsernameAndHost("wildtest_", &withUnderscoreHost, false, 10)
 		require.NoError(t, err)
 		ids := make(map[string]bool, len(out))
 		for _, u := range out {

--- a/internal/repository/user_test.go
+++ b/internal/repository/user_test.go
@@ -474,7 +474,9 @@ func TestUserRepository_SearchByUsernameAndHost(t *testing.T) {
 		assert.False(t, ids[other.ID])
 	})
 
-	t.Run("host=remote returns only that host", func(t *testing.T) {
+	t.Run("host=remote narrows to host prefix match", func(t *testing.T) {
+		// `remote.example` (exact) を渡すと same-host の user のみ hit。
+		// `other.example` は prefix が異なるので除外。
 		out, err := repo.SearchByUsernameAndHost("hosttest", &remoteHost, false, 10)
 		require.NoError(t, err)
 		ids := make(map[string]bool, len(out))
@@ -483,6 +485,22 @@ func TestUserRepository_SearchByUsernameAndHost(t *testing.T) {
 		}
 		assert.False(t, ids[local.ID])
 		assert.True(t, ids[remote.ID])
+		assert.False(t, ids[other.ID])
+	})
+
+	// #1064 contract: localOnly=true は host pointer を無視して host IS NULL の
+	// user のみを返す。Service レイヤは self-hostname / "." remap 時に
+	// hostNorm=nil を渡すので production 経路では併存しないが、interface
+	// contract として明示する regression guard。
+	t.Run("localOnly=true ignores host pointer", func(t *testing.T) {
+		out, err := repo.SearchByUsernameAndHost("hosttest", &remoteHost, true, 10)
+		require.NoError(t, err)
+		ids := make(map[string]bool, len(out))
+		for _, u := range out {
+			ids[u.ID] = true
+		}
+		assert.True(t, ids[local.ID], "localOnly=true should include local user even with host=remoteHost")
+		assert.False(t, ids[remote.ID], "localOnly=true should exclude remote even with matching host pointer")
 		assert.False(t, ids[other.ID])
 	})
 

--- a/internal/repository/user_test.go
+++ b/internal/repository/user_test.go
@@ -474,9 +474,10 @@ func TestUserRepository_SearchByUsernameAndHost(t *testing.T) {
 		assert.False(t, ids[other.ID])
 	})
 
-	t.Run("host=remote narrows to host prefix match", func(t *testing.T) {
+	t.Run("host=remoteHost narrows to host prefix match", func(t *testing.T) {
 		// `remote.example` (exact) を渡すと same-host の user のみ hit。
-		// `other.example` は prefix が異なるので除外。
+		// `other.example` は prefix が異なるので除外。test 名は service test の
+		// 同等 case (`host=remoteHost narrows to host prefix match`) と命名統一。
 		out, err := repo.SearchByUsernameAndHost("hosttest", &remoteHost, false, 10)
 		require.NoError(t, err)
 		ids := make(map[string]bool, len(out))

--- a/internal/server/router.go
+++ b/internal/server/router.go
@@ -218,6 +218,10 @@ func (s *Server) setupRoutes() {
 	// /api/i/update の avatarId / bannerId 経路 (#467) で drive_file の
 	// 所有権検証 + URL コピーが必要なため、driveFileRepo を配線する。
 	userService.SetDriveFileRepository(driveFileRepo)
+	// users/search-by-username-and-host で host=<self-hostname> 入力時に
+	// local 限定にする upstream 互換 remap (#1064) のため、自 hostname を
+	// Service に渡す。空文字なら remap は "." 一致のみになる。
+	userService.SetSelfHostname(s.config.Hostname)
 	followingService := corefollowing.NewService(userRepo, followingRepo, followRequestRepo, idGen)
 	// remote instance の followersCount / followingCount を Follow/Unfollow 時に
 	// incremental 更新する (#596)。未配線でも本機能には影響しないが、admin

--- a/internal/testutil/mock_repository.go
+++ b/internal/testutil/mock_repository.go
@@ -195,26 +195,38 @@ func (m *MockUserRepository) SearchByUsername(query string, limit, offset int, o
 	return matches[offset:end], nil
 }
 
-// SearchByUsernameAndHost narrows the prefix match to a specific host (or
-// local users when host is nil). #766 fix と同じ contract で、host
-// comparison は case-insensitive。
-func (m *MockUserRepository) SearchByUsernameAndHost(query string, host *string, limit int) ([]*model.User, error) {
+// SearchByUsernameAndHost narrows the prefix match with a 3-state host filter
+// (#766 / #1054 / #1064 contract):
+//   - localOnly=true       → u.Host == nil のみ
+//   - localOnly=false, host=nil → host filter なし (= local + remote 両方)
+//   - localOnly=false, host=ptr → u.Host が *host の prefix match (case-insensitive)
+//
+// upstream `lower("host") LIKE lower(?) || '%'` を string prefix で
+// 模倣する。
+func (m *MockUserRepository) SearchByUsernameAndHost(query string, host *string, localOnly bool, limit int) ([]*model.User, error) {
 	var matches []*model.User
+	hostPrefix := ""
+	if host != nil {
+		hostPrefix = strings.ToLower(*host)
+	}
 	for _, u := range m.Users {
 		if !(len(u.UsernameLower) >= len(query) && u.UsernameLower[:len(query)] == query) {
 			continue
 		}
-		if host == nil {
+		switch {
+		case localOnly:
 			if u.Host == nil {
 				matches = append(matches, u)
 			}
-			continue
-		}
-		if u.Host == nil {
-			continue
-		}
-		if strings.EqualFold(*u.Host, *host) {
+		case host == nil:
 			matches = append(matches, u)
+		default:
+			if u.Host == nil {
+				continue
+			}
+			if strings.HasPrefix(strings.ToLower(*u.Host), hostPrefix) {
+				matches = append(matches, u)
+			}
 		}
 	}
 	if limit > 0 && len(matches) > limit {

--- a/internal/testutil/mock_repository.go
+++ b/internal/testutil/mock_repository.go
@@ -201,8 +201,14 @@ func (m *MockUserRepository) SearchByUsername(query string, limit, offset int, o
 //   - localOnly=false, host=nil → host filter なし (= local + remote 両方)
 //   - localOnly=false, host=ptr → u.Host が *host の prefix match (case-insensitive)
 //
-// upstream `lower("host") LIKE lower(?) || '%'` を string prefix で
-// 模倣する。
+// upstream `lower("host") LIKE lower(?) || '%'` を string prefix で模倣する。
+//
+// なお mock は production 側の SQL LIKE wildcard escape (#1054 / #1061 で
+// `%` / `_` / `\` を literal 化する `escapeSQLLikePattern`) を**実装しない**。
+// wildcard escape semantics は repository 側 testcontainer test
+// (`TestUserRepository_SearchByUsernameAndHost_LikeWildcardEscape`) で
+// 検証する分担にしている。mock を使う上位 (service / handler) test では
+// wildcard を含む host を渡さないこと。
 func (m *MockUserRepository) SearchByUsernameAndHost(query string, host *string, localOnly bool, limit int) ([]*model.User, error) {
 	var matches []*model.User
 	hostPrefix := ""


### PR DESCRIPTION
## Summary

UDS 本番で観測した「ノート投稿フォームの mention autocomplete で \`@alice\` (username のみ) 入力時にリモートユーザー候補が出ない」バグの修正。#1054 (PR #1060) で host prefix match は upstream Misskey TS 互換に直したが、host が undefined/null/空文字で送られたケース (= frontend MkAutocomplete が host suffix 無しで API を叩く経路) では旧来通り \`"host" IS NULL\` を強制して local user 限定に絞っており、upstream \`generateUserQueryBuilder\` の falsy host = filter 無し semantics と drift していた。

## 主な変更点

### Repository (`internal/repository/user.go`)
- \`SearchByUsernameAndHost\` 第 3 引数に \`localOnly bool\` を追加
- 3-state semantics に書き直し:
  - \`localOnly=true\`            → \`"host" IS NULL\` (local 限定)
  - \`localOnly=false, host=nil\` → host filter 無し (local + remote 両方)
  - \`localOnly=false, host=ptr\` → \`lower("host") LIKE lower(?) ESCAPE '\\'\`
- 旧来 (#766) host=nil で local 強制していた branch は撤廃。upstream \`UserSearchService.generateUserQueryBuilder\` と完全一致

### Service (`internal/core/user/user_service.go`)
- \`Service.SetSelfHostname(string)\` setter を追加し、router で \`s.config.Hostname\` を配線
- \`SearchByUsernameAndHost\` で host の正規化を 3-state に拡張:
  - falsy (nil / 空 / 空白) → host filter 無し (local + remote)
  - \`"."\` or self-hostname → \`localOnly=true\` (upstream shortcut)
  - その他                  → host prefix match
- self-hostname 比較は case-insensitive

### Testutil (`internal/testutil/mock_repository.go`)
- \`MockUserRepository.SearchByUsernameAndHost\` も 3-state semantics に揃え、host は exact match から prefix match (case-insensitive) に変更

### Router (`internal/server/router.go`)
- \`userService.SetSelfHostname(s.config.Hostname)\` を配線

### Mock callers
- \`mockUserRepo\` / \`stubUserRepo\` / \`failingSearchRepo\` の signature を新 contract に合わせて更新

## テスト

### `internal/repository/user_test.go`
- \`host=nil returns local and remote\` (新挙動、#1064 core regression guard)
- \`localOnly=true returns only local\` (3-state の localOnly 経路)
- 既存の host=remote returns only that host / case-insensitive / suspended user filter / host prefix match は維持

### `internal/core/user/user_service_test.go`
- \`host=nil returns local and remote\`
- \`host=empty string is treated as nil (no filter)\`
- \`host=. returns only local\`
- \`host=self-hostname returns only local\` (+ case-insensitive サブテスト)
- \`self-hostname unset leaves other inputs as host filter\`
- \`host prefix matches remote host\`

### `internal/api/users/handler_extra_test.go`
- handler 経由で host 未指定 / "" 時に local + remote 両方返ることを覆う
- \`host="."\` で local 限定の shortcut

### Coverage
- \`internal/repository\`: 90.3%
- \`internal/core/user\`: 90.8%
- \`internal/api/users\`: 92.1%

### 実行方法
\`\`\`bash
go test ./internal/repository/... ./internal/core/user/... ./internal/api/users/... -count=1 -cover
make fmt && make lint && make test
\`\`\`

## Closes

Closes #1064

## その他

- localOnly フラグは Service レイヤで self-hostname / \`"."\` を判定して repo に伝える設計。repo は config を知らない (= 単純なフィルタ層に留める) ため
- \`host=undefined\` を送る frontend MkAutocomplete のコードパスは upstream TS と同一なので別途修正は不要

🤖 Generated with [Claude Code](https://claude.com/claude-code)