### PR TITLE
ed25519: schema migration + 鍵生成 配線 (P1)

### DIFF
--- a/internal/core/signup/signup_service.go
+++ b/internal/core/signup/signup_service.go
@@ -89,11 +89,12 @@ type WebhookHook interface {
 
 // Service handles user registration.
 type Service struct {
-	userRepo    repository.UserRepository
-	metaRepo    repository.MetaRepository
-	keypairRepo repository.UserKeypairRepository
-	pendingRepo repository.UserPendingRepository
-	ticketRepo  repository.RegistrationTicketRepository
+	userRepo         repository.UserRepository
+	metaRepo         repository.MetaRepository
+	keypairRepo      repository.UserKeypairRepository
+	keypairExtraRepo repository.UserKeypairExtraRepository
+	pendingRepo      repository.UserPendingRepository
+	ticketRepo       repository.RegistrationTicketRepository
 	// db は PromotePending を transaction 化して partial failure rollback と
 	// invitation ticket の SELECT FOR UPDATE ロックを実現する用途。未設定 (nil)
 	// なら従来の repo-based 非 tx パスにフォールバックする (mock テスト用)。
@@ -136,10 +137,42 @@ func (s *Service) SetKeypairRepo(r repository.UserKeypairRepository) {
 	s.keypairRepo = r
 }
 
+// SetKeypairExtraRepo wires the user keypair extra repository. When set,
+// Signup will also generate an Ed25519 keypair alongside the RSA one and
+// store it in user_keypair_extra so the actor JSON can publish it via
+// assertionMethod[] (FEP-521a Multikey). Optional: 未配線でも RSA only で動く
+// (= upstream Misskey TS と完全に同じ挙動)。
+func (s *Service) SetKeypairExtraRepo(r repository.UserKeypairExtraRepository) {
+	s.keypairExtraRepo = r
+}
+
 // SetWebhookHook attaches a WebhookHook invoked after user creation so that
 // system webhooks subscribed to `userCreated` can fire.
 func (s *Service) SetWebhookHook(h WebhookHook) {
 	s.webhookHook = h
+}
+
+// maybeCreateEd25519Keypair generates and stores an Ed25519 keypair for the
+// given user when keypairExtraRepo is wired. tx が non-nil なら同 tx 内で
+// INSERT し、nil なら repository の Upsert を使う。keypairExtraRepo 未配線
+// (= mock テスト or 未対応 deployment) の場合は何もせず nil を返す。
+func (s *Service) maybeCreateEd25519Keypair(tx *gorm.DB, userID string) error {
+	if s.keypairExtraRepo == nil {
+		return nil
+	}
+	privPEM, pubPEM, err := activitypub.GenerateEd25519Keypair()
+	if err != nil {
+		return err
+	}
+	row := &model.UserKeypairExtra{
+		UserID:            userID,
+		Ed25519PublicKey:  pubPEM,
+		Ed25519PrivateKey: privPEM,
+	}
+	if tx != nil {
+		return tx.Create(row).Error
+	}
+	return s.keypairExtraRepo.Upsert(row)
 }
 
 // SignupResult holds the created user and their native token.
@@ -238,6 +271,10 @@ func (s *Service) Signup(username, password string, isInitialSetup bool) (*Signu
 		}); err != nil {
 			return nil, err
 		}
+	}
+	// Ed25519 keypair (FEP-521a Multikey 用)。keypairExtraRepo wire 時のみ。
+	if err := s.maybeCreateEd25519Keypair(nil, userID); err != nil {
+		return nil, err
 	}
 
 	// 初回セットアップの場合は rootUserId を設定
@@ -444,6 +481,10 @@ func (s *Service) promotePendingTx(pending *model.UserPending) (*SignupResult, e
 				return err
 			}
 		}
+		// Ed25519 keypair も同 tx 内で発行 (#1067 / #1068)
+		if err := s.maybeCreateEd25519Keypair(tx, userID); err != nil {
+			return err
+		}
 
 		// pending row 削除
 		if err := tx.Where("id = ?", pending.ID).Delete(&model.UserPending{}).Error; err != nil {
@@ -532,6 +573,9 @@ func (s *Service) promotePendingNoTx(pending *model.UserPending) (*SignupResult,
 		}); err != nil {
 			return nil, err
 		}
+	}
+	if err := s.maybeCreateEd25519Keypair(nil, userID); err != nil {
+		return nil, err
 	}
 	_ = s.pendingRepo.Delete(pending.ID)
 

--- a/internal/core/signup/signup_service.go
+++ b/internal/core/signup/signup_service.go
@@ -152,6 +152,17 @@ func (s *Service) SetWebhookHook(h WebhookHook) {
 	s.webhookHook = h
 }
 
+// txInserter abstracts `tx.Create(value).Error` so the tx-create error wrap
+// path of maybeCreateEd25519Keypair can be unit-tested without spinning up a
+// real PostgreSQL transaction. `*gorm.DB` satisfies this interface natively.
+//
+// PromotePending tx 経路の tx error path は idGen が毎回新規 ULID を返す関係で
+// integration test での FK / PK violation 再現が困難なため、最小の interface
+// 抽出だけで unit test 可能な形に切り出している (#1075 follow-up)。
+type txInserter interface {
+	Create(value any) *gorm.DB
+}
+
 // maybeCreateEd25519Keypair generates and stores an Ed25519 keypair for the
 // given user when keypairExtraRepo is wired. tx が non-nil なら同 tx 内で
 // INSERT し、nil なら repository の Upsert を使う。keypairExtraRepo 未配線
@@ -159,7 +170,7 @@ func (s *Service) SetWebhookHook(h WebhookHook) {
 //
 // systemaccount.completeFromOrphan と error wrap 形式を揃え、log で発生個所が
 // 追えるようにする。
-func (s *Service) maybeCreateEd25519Keypair(tx *gorm.DB, userID string) error {
+func (s *Service) maybeCreateEd25519Keypair(tx txInserter, userID string) error {
 	if s.keypairExtraRepo == nil {
 		return nil
 	}

--- a/internal/core/signup/signup_service.go
+++ b/internal/core/signup/signup_service.go
@@ -170,6 +170,13 @@ type txInserter interface {
 //
 // systemaccount.completeFromOrphan と error wrap 形式を揃え、log で発生個所が
 // 追えるようにする。
+//
+// IMPORTANT: tx には untyped nil (= `nil` literal) または有効な `*gorm.DB` を
+// 渡すこと。typed nil の `*gorm.DB` を渡すと interface comparison で not-nil
+// 扱いになり (`var tx *gorm.DB = nil; var i txInserter = tx; i != nil` が true)、
+// `tx.Create(...)` で nil deref panic になる。現 callsite (Signup /
+// promotePendingNoTx は literal nil、promotePendingTx は Begin 直後の valid tx)
+// はこれを満たすので問題ないが、新規 callsite を追加する際の罠。
 func (s *Service) maybeCreateEd25519Keypair(tx txInserter, userID string) error {
 	if s.keypairExtraRepo == nil {
 		return nil

--- a/internal/core/signup/signup_service.go
+++ b/internal/core/signup/signup_service.go
@@ -156,13 +156,16 @@ func (s *Service) SetWebhookHook(h WebhookHook) {
 // given user when keypairExtraRepo is wired. tx が non-nil なら同 tx 内で
 // INSERT し、nil なら repository の Upsert を使う。keypairExtraRepo 未配線
 // (= mock テスト or 未対応 deployment) の場合は何もせず nil を返す。
+//
+// systemaccount.completeFromOrphan と error wrap 形式を揃え、log で発生個所が
+// 追えるようにする。
 func (s *Service) maybeCreateEd25519Keypair(tx *gorm.DB, userID string) error {
 	if s.keypairExtraRepo == nil {
 		return nil
 	}
 	privPEM, pubPEM, err := activitypub.GenerateEd25519Keypair()
 	if err != nil {
-		return err
+		return fmt.Errorf("signup: generate ed25519 keypair: %w", err)
 	}
 	row := &model.UserKeypairExtra{
 		UserID:            userID,
@@ -170,9 +173,15 @@ func (s *Service) maybeCreateEd25519Keypair(tx *gorm.DB, userID string) error {
 		Ed25519PrivateKey: privPEM,
 	}
 	if tx != nil {
-		return tx.Create(row).Error
+		if err := tx.Create(row).Error; err != nil {
+			return fmt.Errorf("signup: create ed25519 keypair (tx): %w", err)
+		}
+		return nil
 	}
-	return s.keypairExtraRepo.Upsert(row)
+	if err := s.keypairExtraRepo.Upsert(row); err != nil {
+		return fmt.Errorf("signup: create ed25519 keypair: %w", err)
+	}
+	return nil
 }
 
 // SignupResult holds the created user and their native token.

--- a/internal/core/signup/signup_service_integration_test.go
+++ b/internal/core/signup/signup_service_integration_test.go
@@ -37,6 +37,7 @@ func cleanupSignupRows(t *testing.T, db *gorm.DB, prefix string) {
 	db.Exec(`DELETE FROM "user_pending" WHERE id LIKE ? OR username LIKE ?`, prefix+"%", prefix+"%")
 	db.Exec(`DELETE FROM "user_profile" WHERE "userId" IN (SELECT id FROM "user" WHERE id LIKE ? OR "usernameLower" LIKE ?)`, prefix+"%", prefix+"%")
 	db.Exec(`DELETE FROM "user_keypair" WHERE "userId" LIKE ?`, prefix+"%")
+	db.Exec(`DELETE FROM "user_keypair_extra" WHERE "userId" LIKE ?`, prefix+"%")
 	db.Exec(`DELETE FROM "user" WHERE id LIKE ? OR "usernameLower" LIKE ?`, prefix+"%", prefix+"%")
 	db.Exec(`DELETE FROM "registration_ticket" WHERE id LIKE ? OR code LIKE ?`, prefix+"%", prefix+"%")
 }
@@ -238,6 +239,30 @@ func TestPromotePending_TxCreatesKeypair(t *testing.T) {
 	require.NoError(t, err)
 	assert.NotEmpty(t, kp.PublicKey)
 	assert.NotEmpty(t, kp.PrivateKey)
+}
+
+// tx 経路で keypairExtraRepo が wire されていれば Ed25519 鍵対も同 tx で作成される。
+// FEP-521a Multikey 対応 (#1067 / #1068)。
+func TestPromotePending_TxCreatesKeypairExtra(t *testing.T) {
+	db := integrationDB(t)
+	const prefix = "itkpx_"
+	defer cleanupSignupRows(t, db, prefix)
+
+	svc := newTxService(t, db)
+	keypairRepo := repository.NewUserKeypairRepository(db)
+	keypairExtraRepo := repository.NewUserKeypairExtraRepository(db)
+	svc.SetKeypairRepo(keypairRepo)
+	svc.SetKeypairExtraRepo(keypairExtraRepo)
+
+	row, err := svc.CreatePending(prefix+"kpx", "kpx@it.example", "pw", nil)
+	require.NoError(t, err)
+	result, err := svc.PromotePending(row.Code)
+	require.NoError(t, err)
+
+	kx, err := keypairExtraRepo.FindByUserID(result.User.ID)
+	require.NoError(t, err)
+	assert.Contains(t, kx.Ed25519PublicKey, "PUBLIC KEY")
+	assert.Contains(t, kx.Ed25519PrivateKey, "PRIVATE KEY")
 }
 
 // tx 経路で webhook hook が wire されていれば commit 後に発火する。

--- a/internal/core/signup/signup_service_internal_test.go
+++ b/internal/core/signup/signup_service_internal_test.go
@@ -1,0 +1,47 @@
+package signup
+
+// Internal (white-box) tests that need access to the unexported
+// maybeCreateEd25519Keypair / txInserter for error-path coverage that is not
+// reachable via the public Service API.
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/shiroha-a/mk/internal/testutil"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gorm.io/gorm"
+)
+
+// failingTxInserter satisfies txInserter and always returns a *gorm.DB with
+// the supplied error. Used to exercise the tx-create error wrap path of
+// maybeCreateEd25519Keypair (#1075 follow-up). PromotePending tx 経路の error
+// path は idGen が毎回新規 ULID を生成する関係で integration test での再現
+// (FK/PK violation seed 等) が困難なので unit test 側で cover する。
+type failingTxInserter struct {
+	err error
+}
+
+func (f *failingTxInserter) Create(_ any) *gorm.DB {
+	return &gorm.DB{Error: f.err}
+}
+
+func TestMaybeCreateEd25519Keypair_TxCreateError(t *testing.T) {
+	svc := &Service{
+		keypairExtraRepo: testutil.NewMockUserKeypairExtraRepository(),
+	}
+	tx := &failingTxInserter{err: errors.New("tx create failed")}
+	err := svc.maybeCreateEd25519Keypair(tx, "u1")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "signup: create ed25519 keypair (tx)")
+}
+
+// keypairExtraRepo 未配線 (nil) なら tx エラーは発生しないで早期 return nil する
+// guard も明示的に cover する (= "extra repo nil なら何もしない" semantics)。
+func TestMaybeCreateEd25519Keypair_NilRepoIsNoOp(t *testing.T) {
+	svc := &Service{} // keypairExtraRepo == nil
+	tx := &failingTxInserter{err: errors.New("must not be called")}
+	err := svc.maybeCreateEd25519Keypair(tx, "u1")
+	assert.NoError(t, err)
+}

--- a/internal/core/signup/signup_service_test.go
+++ b/internal/core/signup/signup_service_test.go
@@ -277,15 +277,18 @@ func TestSignup_WithKeypairExtraRepo(t *testing.T) {
 	assert.NotEmpty(t, kx.Ed25519PrivateKey)
 }
 
+// failingUpsertKeypairExtraRepo は Upsert だけ意図的に失敗させる test double。
+// FindByUserID / Delete は呼ばれない想定だが、将来 helper が existence check で
+// 呼んでも誤動作しないよう ErrNotFound / 成功を返す defense-in-depth な挙動にする。
 type failingUpsertKeypairExtraRepo struct{}
 
 func (f *failingUpsertKeypairExtraRepo) Upsert(_ *model.UserKeypairExtra) error {
 	return assert.AnError
 }
 func (f *failingUpsertKeypairExtraRepo) FindByUserID(_ string) (*model.UserKeypairExtra, error) {
-	return nil, assert.AnError
+	return nil, testutil.ErrNotFound
 }
-func (f *failingUpsertKeypairExtraRepo) Delete(_ string) error { return assert.AnError }
+func (f *failingUpsertKeypairExtraRepo) Delete(_ string) error { return nil }
 
 func TestSignup_KeypairExtraUpsertError(t *testing.T) {
 	svc, _, _ := newTestService(t)

--- a/internal/core/signup/signup_service_test.go
+++ b/internal/core/signup/signup_service_test.go
@@ -260,6 +260,42 @@ func TestSignup_KeypairCreateError(t *testing.T) {
 	assert.Error(t, err)
 }
 
+func TestSignup_WithKeypairExtraRepo(t *testing.T) {
+	svc, _, _ := newTestService(t)
+	keypairRepo := testutil.NewMockUserKeypairRepository()
+	keypairExtraRepo := testutil.NewMockUserKeypairExtraRepository()
+	svc.SetKeypairRepo(keypairRepo)
+	svc.SetKeypairExtraRepo(keypairExtraRepo)
+
+	result, err := svc.Signup("alice", "pass", false)
+	require.NoError(t, err)
+
+	// Ed25519 鍵が併発行されている
+	kx, ok := keypairExtraRepo.Keypairs[result.User.ID]
+	require.True(t, ok)
+	assert.NotEmpty(t, kx.Ed25519PublicKey)
+	assert.NotEmpty(t, kx.Ed25519PrivateKey)
+}
+
+type failingUpsertKeypairExtraRepo struct{}
+
+func (f *failingUpsertKeypairExtraRepo) Upsert(_ *model.UserKeypairExtra) error {
+	return assert.AnError
+}
+func (f *failingUpsertKeypairExtraRepo) FindByUserID(_ string) (*model.UserKeypairExtra, error) {
+	return nil, assert.AnError
+}
+func (f *failingUpsertKeypairExtraRepo) Delete(_ string) error { return assert.AnError }
+
+func TestSignup_KeypairExtraUpsertError(t *testing.T) {
+	svc, _, _ := newTestService(t)
+	svc.SetKeypairRepo(testutil.NewMockUserKeypairRepository())
+	svc.SetKeypairExtraRepo(&failingUpsertKeypairExtraRepo{})
+
+	_, err := svc.Signup("alice", "pass", false)
+	assert.Error(t, err)
+}
+
 // --- Pending signup (#595) ---
 
 // CreatePending 経路でも 73 byte 以上 password は ErrPasswordTooLong (#1075)。
@@ -404,6 +440,38 @@ func TestPromotePending_WithKeypair(t *testing.T) {
 	require.NoError(t, err)
 	_, ok := keypairRepo.Keypairs[result.User.ID]
 	assert.True(t, ok, "keypair must be created during PromotePending")
+}
+
+func TestPromotePending_WithKeypairExtra(t *testing.T) {
+	svc, _, _ := newTestService(t)
+	pendingRepo := testutil.NewMockUserPendingRepository()
+	svc.SetUserPendingRepo(pendingRepo)
+	svc.SetKeypairRepo(testutil.NewMockUserKeypairRepository())
+	keypairExtraRepo := testutil.NewMockUserKeypairExtraRepository()
+	svc.SetKeypairExtraRepo(keypairExtraRepo)
+
+	row, err := svc.CreatePending("kpxuser", "kpx@example.com", "pw", nil)
+	require.NoError(t, err)
+
+	result, err := svc.PromotePending(row.Code)
+	require.NoError(t, err)
+	kx, ok := keypairExtraRepo.Keypairs[result.User.ID]
+	require.True(t, ok, "ed25519 keypair must be created during PromotePending")
+	assert.Contains(t, kx.Ed25519PublicKey, "PUBLIC KEY")
+}
+
+func TestPromotePending_KeypairExtraUpsertError(t *testing.T) {
+	svc, _, _ := newTestService(t)
+	pendingRepo := testutil.NewMockUserPendingRepository()
+	svc.SetUserPendingRepo(pendingRepo)
+	svc.SetKeypairRepo(testutil.NewMockUserKeypairRepository())
+	svc.SetKeypairExtraRepo(&failingUpsertKeypairExtraRepo{})
+
+	row, err := svc.CreatePending("kpxerr", "kpxerr@example.com", "pw", nil)
+	require.NoError(t, err)
+
+	_, err = svc.PromotePending(row.Code)
+	assert.Error(t, err)
 }
 
 func TestPromotePending_WebhookHookFires(t *testing.T) {

--- a/internal/core/systemaccount/systemaccount.go
+++ b/internal/core/systemaccount/systemaccount.go
@@ -21,11 +21,12 @@ import (
 // Service fetches (or lazily creates) the built-in system users used
 // for subsystem-to-AP interactions. 各 kind は一意なので 1 行のみ。
 type Service struct {
-	userRepo    repository.UserRepository
-	keypairRepo repository.UserKeypairRepository
-	saRepo      repository.SystemAccountRepository
-	idGen       id.Generator
-	clock       func() time.Time
+	userRepo         repository.UserRepository
+	keypairRepo      repository.UserKeypairRepository
+	keypairExtraRepo repository.UserKeypairExtraRepository
+	saRepo           repository.SystemAccountRepository
+	idGen            id.Generator
+	clock            func() time.Time
 }
 
 // NewService constructs a Service.
@@ -49,6 +50,14 @@ func (s *Service) SetClock(now func() time.Time) {
 	if now != nil {
 		s.clock = now
 	}
+}
+
+// SetKeypairExtraRepo wires the Ed25519 keypair repository. When set, system
+// account creation also generates an Ed25519 keypair so the actor JSON can
+// publish it via assertionMethod[] (FEP-521a Multikey). Optional: 未配線でも
+// RSA only で動く。
+func (s *Service) SetKeypairExtraRepo(r repository.UserKeypairExtraRepository) {
+	s.keypairExtraRepo = r
 }
 
 // Fetch returns the system user for the given kind, creating it if
@@ -121,6 +130,23 @@ func (s *Service) completeFromOrphan(kind string, user *model.User) (*model.User
 			PrivateKey: privPEM,
 		}); kerr != nil {
 			return nil, fmt.Errorf("systemaccount: create keypair: %w", kerr)
+		}
+	}
+	// Ed25519 keypair も idempotent に発行・保存 (#1067 / #1068)。
+	// keypairExtraRepo 未配線時は何もしない (= RSA only fallback)。
+	if s.keypairExtraRepo != nil {
+		if _, err := s.keypairExtraRepo.FindByUserID(user.ID); err != nil {
+			privPEM, pubPEM, kerr := activitypub.GenerateEd25519Keypair()
+			if kerr != nil {
+				return nil, fmt.Errorf("systemaccount: generate ed25519 keypair: %w", kerr)
+			}
+			if kerr := s.keypairExtraRepo.Upsert(&model.UserKeypairExtra{
+				UserID:            user.ID,
+				Ed25519PublicKey:  pubPEM,
+				Ed25519PrivateKey: privPEM,
+			}); kerr != nil {
+				return nil, fmt.Errorf("systemaccount: create ed25519 keypair: %w", kerr)
+			}
 		}
 	}
 	if err := s.saRepo.Create(&model.SystemAccount{

--- a/internal/core/systemaccount/systemaccount_test.go
+++ b/internal/core/systemaccount/systemaccount_test.go
@@ -218,3 +218,61 @@ func idGenFor(t *testing.T) id.Generator {
 	require.NoError(t, err)
 	return g
 }
+
+func TestFetch_GeneratesEd25519KeypairWhenWired(t *testing.T) {
+	svc, _, _, _ := newService(t)
+	extra := testutil.NewMockUserKeypairExtraRepository()
+	svc.SetKeypairExtraRepo(extra)
+
+	user, err := svc.Fetch("relay")
+	require.NoError(t, err)
+	kx, ok := extra.Keypairs[user.ID]
+	require.True(t, ok)
+	assert.Contains(t, kx.Ed25519PublicKey, "PUBLIC KEY")
+	assert.Contains(t, kx.Ed25519PrivateKey, "PRIVATE KEY")
+}
+
+func TestFetch_SkipsEd25519WhenExtraRepoNotWired(t *testing.T) {
+	svc, _, keypairRepo, _ := newService(t)
+
+	user, err := svc.Fetch("relay")
+	require.NoError(t, err)
+	// RSA 鍵だけ作られる (extra repo 未配線で skip される)
+	_, ok := keypairRepo.Keypairs[user.ID]
+	assert.True(t, ok)
+}
+
+func TestFetch_Ed25519IdempotentAcrossSecondCall(t *testing.T) {
+	svc, _, _, _ := newService(t)
+	extra := testutil.NewMockUserKeypairExtraRepository()
+	svc.SetKeypairExtraRepo(extra)
+
+	user, err := svc.Fetch("relay")
+	require.NoError(t, err)
+	firstPub := extra.Keypairs[user.ID].Ed25519PublicKey
+
+	// 2 回目 Fetch しても鍵は変わらない (idempotent)
+	_, err = svc.Fetch("relay")
+	require.NoError(t, err)
+	assert.Equal(t, firstPub, extra.Keypairs[user.ID].Ed25519PublicKey)
+}
+
+type failingExtraUpsert struct {
+	*testutil.MockUserKeypairExtraRepository
+	err error
+}
+
+func (f *failingExtraUpsert) Upsert(_ *model.UserKeypairExtra) error { return f.err }
+
+func TestFetch_ErrorBubblesFromEd25519KeypairCreate(t *testing.T) {
+	svc, _, _, _ := newService(t)
+	extra := &failingExtraUpsert{
+		MockUserKeypairExtraRepository: testutil.NewMockUserKeypairExtraRepository(),
+		err:                            errors.New("ed25519 db down"),
+	}
+	svc.SetKeypairExtraRepo(extra)
+
+	_, err := svc.Fetch("relay")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "ed25519")
+}

--- a/internal/model/user_keypair_extra.go
+++ b/internal/model/user_keypair_extra.go
@@ -1,0 +1,17 @@
+package model
+
+// UserKeypairExtra represents the `user_keypair_extra` table.
+//
+// mk-go 独自の add-only テーブルで、local user の Ed25519 鍵ペアを保存する。
+// 既存 user_keypair (RSA) は upstream Misskey TS との drop-in 互換のため untouched
+// とし、Ed25519 用は本テーブルに分離して持つ (#1067 / #1068)。
+type UserKeypairExtra struct {
+	UserID            string `gorm:"column:userId;type:varchar(32);primaryKey" json:"userId"`
+	Ed25519PublicKey  string `gorm:"column:ed25519PublicKey;type:varchar(256);not null" json:"ed25519PublicKey"`
+	Ed25519PrivateKey string `gorm:"column:ed25519PrivateKey;type:varchar(256);not null" json:"-"`
+
+	// Relations
+	User *User `gorm:"foreignKey:UserID" json:"user,omitempty"`
+}
+
+func (UserKeypairExtra) TableName() string { return "user_keypair_extra" }

--- a/internal/model/user_publickey_extra.go
+++ b/internal/model/user_publickey_extra.go
@@ -1,0 +1,25 @@
+package model
+
+// UserPublickeyExtra represents the `user_publickey_extra` table.
+//
+// mk-go 独自の add-only テーブルで、リモート user の追加公開鍵 (Ed25519 等) を
+// keyId 単位で保存する。actor JSON の assertionMethod[] (FEP-521a Multikey) から
+// parse した鍵を格納し、HTTP Signature verify と outbound deliver 時の capability
+// 判定に使う (#1067 / #1068)。
+//
+// 既存 user_publickey (RSA, userId が PK で 1 行のみ) と異なり、本テーブルは
+// (userId, keyId) 複合 PK で 1 actor が複数鍵を持つことを許容する。
+type UserPublickeyExtra struct {
+	UserID string `gorm:"column:userId;type:varchar(32);primaryKey" json:"userId"`
+	KeyID  string `gorm:"column:keyId;type:varchar(256);primaryKey" json:"keyId"`
+	KeyPEM string `gorm:"column:keyPem;type:varchar(4096);not null" json:"keyPem"`
+	Alg    string `gorm:"column:alg;type:varchar(32);not null" json:"alg"`
+
+	// Relations
+	User *User `gorm:"foreignKey:UserID" json:"user,omitempty"`
+}
+
+func (UserPublickeyExtra) TableName() string { return "user_publickey_extra" }
+
+// AlgEd25519 is the canonical "alg" column value for Ed25519 entries.
+const AlgEd25519 = "ed25519"

--- a/internal/repository/user_keypair_extra.go
+++ b/internal/repository/user_keypair_extra.go
@@ -1,0 +1,42 @@
+package repository
+
+import (
+	"github.com/shiroha-a/mk/internal/model"
+	"gorm.io/gorm"
+	"gorm.io/gorm/clause"
+)
+
+// UserKeypairExtraRepository provides data access for the `user_keypair_extra` table.
+type UserKeypairExtraRepository interface {
+	Upsert(k *model.UserKeypairExtra) error
+	FindByUserID(userID string) (*model.UserKeypairExtra, error)
+	Delete(userID string) error
+}
+
+type userKeypairExtraRepository struct {
+	db *gorm.DB
+}
+
+// NewUserKeypairExtraRepository creates a new UserKeypairExtraRepository.
+func NewUserKeypairExtraRepository(db *gorm.DB) UserKeypairExtraRepository {
+	return &userKeypairExtraRepository{db: db}
+}
+
+func (r *userKeypairExtraRepository) Upsert(k *model.UserKeypairExtra) error {
+	return r.db.Clauses(clause.OnConflict{
+		Columns:   []clause.Column{{Name: "userId"}},
+		DoUpdates: clause.AssignmentColumns([]string{"ed25519PublicKey", "ed25519PrivateKey"}),
+	}).Create(k).Error
+}
+
+func (r *userKeypairExtraRepository) FindByUserID(userID string) (*model.UserKeypairExtra, error) {
+	var k model.UserKeypairExtra
+	if err := r.db.Where(`"userId" = ?`, userID).First(&k).Error; err != nil {
+		return nil, err
+	}
+	return &k, nil
+}
+
+func (r *userKeypairExtraRepository) Delete(userID string) error {
+	return r.db.Where(`"userId" = ?`, userID).Delete(&model.UserKeypairExtra{}).Error
+}

--- a/internal/repository/user_keypair_extra_test.go
+++ b/internal/repository/user_keypair_extra_test.go
@@ -1,0 +1,80 @@
+package repository
+
+import (
+	"context"
+	"testing"
+
+	"github.com/shiroha-a/mk/internal/model"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func cleanupUserKeypairExtra(t *testing.T, userID string) {
+	t.Helper()
+	testDB.Exec(`DELETE FROM "user_keypair_extra" WHERE "userId" = ?`, userID)
+}
+
+func TestUserKeypairExtraRepository_UpsertAndFind(t *testing.T) {
+	repo := NewUserKeypairExtraRepository(testDB)
+	user := insertTestUser(t, "u_kpx_1", "kpx1")
+	defer cleanupUser(t, user.ID)
+	defer cleanupUserKeypairExtra(t, user.ID)
+
+	k := &model.UserKeypairExtra{
+		UserID:            user.ID,
+		Ed25519PublicKey:  "PUBKEY_v1",
+		Ed25519PrivateKey: "PRIVKEY_v1",
+	}
+	require.NoError(t, repo.Upsert(k))
+
+	got, err := repo.FindByUserID(user.ID)
+	require.NoError(t, err)
+	assert.Equal(t, "PUBKEY_v1", got.Ed25519PublicKey)
+	assert.Equal(t, "PRIVKEY_v1", got.Ed25519PrivateKey)
+
+	// Upsert は同一 userId で更新できる
+	k.Ed25519PublicKey = "PUBKEY_v2"
+	k.Ed25519PrivateKey = "PRIVKEY_v2"
+	require.NoError(t, repo.Upsert(k))
+
+	got, err = repo.FindByUserID(user.ID)
+	require.NoError(t, err)
+	assert.Equal(t, "PUBKEY_v2", got.Ed25519PublicKey)
+	assert.Equal(t, "PRIVKEY_v2", got.Ed25519PrivateKey)
+}
+
+func TestUserKeypairExtraRepository_Delete(t *testing.T) {
+	repo := NewUserKeypairExtraRepository(testDB)
+	user := insertTestUser(t, "u_kpx_2", "kpx2")
+	defer cleanupUser(t, user.ID)
+	defer cleanupUserKeypairExtra(t, user.ID)
+
+	require.NoError(t, repo.Upsert(&model.UserKeypairExtra{
+		UserID:            user.ID,
+		Ed25519PublicKey:  "PUB",
+		Ed25519PrivateKey: "PRIV",
+	}))
+	require.NoError(t, repo.Delete(user.ID))
+
+	_, err := repo.FindByUserID(user.ID)
+	assert.Error(t, err)
+}
+
+func TestUserKeypairExtraRepository_FindByUserID_NotFound(t *testing.T) {
+	repo := NewUserKeypairExtraRepository(testDB)
+	_, err := repo.FindByUserID("u_kpx_nonexistent")
+	assert.Error(t, err)
+}
+
+func TestUserKeypairExtraRepository_QueryErrors(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	repo := NewUserKeypairExtraRepository(testDB.WithContext(ctx))
+
+	err := repo.Upsert(&model.UserKeypairExtra{UserID: "x", Ed25519PublicKey: "p", Ed25519PrivateKey: "k"})
+	assert.Error(t, err)
+	_, err = repo.FindByUserID("x")
+	assert.Error(t, err)
+	err = repo.Delete("x")
+	assert.Error(t, err)
+}

--- a/internal/repository/user_publickey_extra.go
+++ b/internal/repository/user_publickey_extra.go
@@ -1,0 +1,63 @@
+package repository
+
+import (
+	"github.com/shiroha-a/mk/internal/model"
+	"gorm.io/gorm"
+	"gorm.io/gorm/clause"
+)
+
+// UserPublickeyExtraRepository provides data access for the `user_publickey_extra`
+// table. Unlike UserPublickeyRepository (which keyes by userId only), this
+// repository keyes by (userId, keyId) composite PK so that a single actor can
+// publish multiple keys (e.g. RSA + Ed25519).
+type UserPublickeyExtraRepository interface {
+	Upsert(pk *model.UserPublickeyExtra) error
+	FindByUserAndKeyID(userID, keyID string) (*model.UserPublickeyExtra, error)
+	FindByKeyID(keyID string) (*model.UserPublickeyExtra, error)
+	ListByUserID(userID string) ([]model.UserPublickeyExtra, error)
+	DeleteByUserID(userID string) error
+}
+
+type userPublickeyExtraRepository struct {
+	db *gorm.DB
+}
+
+// NewUserPublickeyExtraRepository creates a new UserPublickeyExtraRepository.
+func NewUserPublickeyExtraRepository(db *gorm.DB) UserPublickeyExtraRepository {
+	return &userPublickeyExtraRepository{db: db}
+}
+
+func (r *userPublickeyExtraRepository) Upsert(pk *model.UserPublickeyExtra) error {
+	return r.db.Clauses(clause.OnConflict{
+		Columns:   []clause.Column{{Name: "userId"}, {Name: "keyId"}},
+		DoUpdates: clause.AssignmentColumns([]string{"keyPem", "alg"}),
+	}).Create(pk).Error
+}
+
+func (r *userPublickeyExtraRepository) FindByUserAndKeyID(userID, keyID string) (*model.UserPublickeyExtra, error) {
+	var pk model.UserPublickeyExtra
+	if err := r.db.Where(`"userId" = ? AND "keyId" = ?`, userID, keyID).First(&pk).Error; err != nil {
+		return nil, err
+	}
+	return &pk, nil
+}
+
+func (r *userPublickeyExtraRepository) FindByKeyID(keyID string) (*model.UserPublickeyExtra, error) {
+	var pk model.UserPublickeyExtra
+	if err := r.db.Where(`"keyId" = ?`, keyID).First(&pk).Error; err != nil {
+		return nil, err
+	}
+	return &pk, nil
+}
+
+func (r *userPublickeyExtraRepository) ListByUserID(userID string) ([]model.UserPublickeyExtra, error) {
+	var rows []model.UserPublickeyExtra
+	if err := r.db.Where(`"userId" = ?`, userID).Find(&rows).Error; err != nil {
+		return nil, err
+	}
+	return rows, nil
+}
+
+func (r *userPublickeyExtraRepository) DeleteByUserID(userID string) error {
+	return r.db.Where(`"userId" = ?`, userID).Delete(&model.UserPublickeyExtra{}).Error
+}

--- a/internal/repository/user_publickey_extra_test.go
+++ b/internal/repository/user_publickey_extra_test.go
@@ -1,0 +1,105 @@
+package repository
+
+import (
+	"context"
+	"testing"
+
+	"github.com/shiroha-a/mk/internal/model"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func cleanupUserPublickeyExtra(t *testing.T, userID string) {
+	t.Helper()
+	testDB.Exec(`DELETE FROM "user_publickey_extra" WHERE "userId" = ?`, userID)
+}
+
+func TestUserPublickeyExtraRepository_UpsertAndFind(t *testing.T) {
+	repo := NewUserPublickeyExtraRepository(testDB)
+	user := insertTestUser(t, "u_upkx_1", "upkx1")
+	defer cleanupUser(t, user.ID)
+	defer cleanupUserPublickeyExtra(t, user.ID)
+
+	pk1 := &model.UserPublickeyExtra{
+		UserID: user.ID,
+		KeyID:  "https://example.com/users/x#ed25519-key",
+		KeyPEM: "-----BEGIN PUBLIC KEY-----\nAAA\n-----END PUBLIC KEY-----",
+		Alg:    model.AlgEd25519,
+	}
+	require.NoError(t, repo.Upsert(pk1))
+
+	got, err := repo.FindByUserAndKeyID(user.ID, pk1.KeyID)
+	require.NoError(t, err)
+	assert.Equal(t, pk1.KeyPEM, got.KeyPEM)
+	assert.Equal(t, model.AlgEd25519, got.Alg)
+
+	got, err = repo.FindByKeyID(pk1.KeyID)
+	require.NoError(t, err)
+	assert.Equal(t, user.ID, got.UserID)
+
+	// 同一 (userId, keyId) で再 Upsert すると更新される
+	pk1.KeyPEM = "-----BEGIN PUBLIC KEY-----\nBBB\n-----END PUBLIC KEY-----"
+	require.NoError(t, repo.Upsert(pk1))
+	got, err = repo.FindByUserAndKeyID(user.ID, pk1.KeyID)
+	require.NoError(t, err)
+	assert.Contains(t, got.KeyPEM, "BBB")
+}
+
+func TestUserPublickeyExtraRepository_MultipleKeysPerUser(t *testing.T) {
+	repo := NewUserPublickeyExtraRepository(testDB)
+	user := insertTestUser(t, "u_upkx_2", "upkx2")
+	defer cleanupUser(t, user.ID)
+	defer cleanupUserPublickeyExtra(t, user.ID)
+
+	require.NoError(t, repo.Upsert(&model.UserPublickeyExtra{
+		UserID: user.ID, KeyID: "k1", KeyPEM: "PEM1", Alg: model.AlgEd25519,
+	}))
+	require.NoError(t, repo.Upsert(&model.UserPublickeyExtra{
+		UserID: user.ID, KeyID: "k2", KeyPEM: "PEM2", Alg: model.AlgEd25519,
+	}))
+
+	rows, err := repo.ListByUserID(user.ID)
+	require.NoError(t, err)
+	assert.Len(t, rows, 2)
+}
+
+func TestUserPublickeyExtraRepository_DeleteByUserID(t *testing.T) {
+	repo := NewUserPublickeyExtraRepository(testDB)
+	user := insertTestUser(t, "u_upkx_3", "upkx3")
+	defer cleanupUser(t, user.ID)
+	defer cleanupUserPublickeyExtra(t, user.ID)
+
+	require.NoError(t, repo.Upsert(&model.UserPublickeyExtra{
+		UserID: user.ID, KeyID: "k1", KeyPEM: "PEM1", Alg: model.AlgEd25519,
+	}))
+	require.NoError(t, repo.DeleteByUserID(user.ID))
+
+	rows, err := repo.ListByUserID(user.ID)
+	require.NoError(t, err)
+	assert.Empty(t, rows)
+}
+
+func TestUserPublickeyExtraRepository_NotFound(t *testing.T) {
+	repo := NewUserPublickeyExtraRepository(testDB)
+	_, err := repo.FindByUserAndKeyID("nope_user", "nope_key")
+	assert.Error(t, err)
+	_, err = repo.FindByKeyID("nope_key")
+	assert.Error(t, err)
+}
+
+func TestUserPublickeyExtraRepository_QueryErrors(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	repo := NewUserPublickeyExtraRepository(testDB.WithContext(ctx))
+
+	err := repo.Upsert(&model.UserPublickeyExtra{UserID: "x", KeyID: "k", KeyPEM: "p", Alg: model.AlgEd25519})
+	assert.Error(t, err)
+	_, err = repo.FindByUserAndKeyID("x", "k")
+	assert.Error(t, err)
+	_, err = repo.FindByKeyID("k")
+	assert.Error(t, err)
+	_, err = repo.ListByUserID("x")
+	assert.Error(t, err)
+	err = repo.DeleteByUserID("x")
+	assert.Error(t, err)
+}

--- a/internal/server/router.go
+++ b/internal/server/router.go
@@ -153,6 +153,7 @@ func (s *Server) setupRoutes() {
 	driveFileRepo := repository.NewDriveFileRepository(s.db)
 	driveFolderRepo := repository.NewDriveFolderRepository(s.db)
 	keypairRepo := repository.NewUserKeypairRepository(s.db)
+	keypairExtraRepo := repository.NewUserKeypairExtraRepository(s.db)
 	instanceRepo := repository.NewInstanceRepository(s.db)
 	// instance.{followersCount,followingCount} はリアルタイム incremental
 	// 維持の hook が未実装で常に 0 → admin/overview の federation pie chart
@@ -198,6 +199,8 @@ func (s *Server) setupRoutes() {
 	signupService := coresignup.NewService(userRepo, metaRepo, idGen)
 	// ActivityPub 配信のためにローカルユーザーは RSA 鍵対を必要とする。
 	signupService.SetKeypairRepo(keypairRepo)
+	// FEP-521a Multikey 対応で Ed25519 鍵対も併発行 (#1067 / #1068)。
+	signupService.SetKeypairExtraRepo(keypairExtraRepo)
 	noteCreateService := corenote.NewCreateService(noteRepo, pollRepo, idGen, followingRepo)
 	// Phase 7-1 follow-up (#254): 本家互換の残存 error 検出ロジック用依存を注入。
 	// Setter経由なのでテストでは任意に省略可能。既存の同repository変数を再利用。
@@ -541,6 +544,8 @@ func (s *Server) setupRoutes() {
 	// 直後でセットアップする。admin/relays ハンドラへ注入し、Accept/Reject
 	// inbox 処理で status を更新できるように processor にも渡す。
 	sysAcctSvc := coresystemaccount.NewService(userRepo, keypairRepo, repository.NewSystemAccountRepository(s.db), idGen)
+	// FEP-521a Multikey 対応で system account も Ed25519 鍵対を併発行 (#1067 / #1068)。
+	sysAcctSvc.SetKeypairExtraRepo(keypairExtraRepo)
 	relaySvc := corerelay.NewService(repository.NewRelayRepository(s.db), sysAcctSvc, apRenderer, deliverService, idGen)
 
 	// AP fetch のデフォルト signer に instance.actor を配線する (#419)。

--- a/internal/testutil/mock_repository.go
+++ b/internal/testutil/mock_repository.go
@@ -4038,6 +4038,34 @@ func (m *MockUserKeypairRepository) FindByUserID(userID string) (*model.UserKeyp
 	return k, nil
 }
 
+// MockUserKeypairExtraRepository is a test double for
+// repository.UserKeypairExtraRepository.
+type MockUserKeypairExtraRepository struct {
+	Keypairs map[string]*model.UserKeypairExtra // keyed by userID
+}
+
+func NewMockUserKeypairExtraRepository() *MockUserKeypairExtraRepository {
+	return &MockUserKeypairExtraRepository{Keypairs: make(map[string]*model.UserKeypairExtra)}
+}
+
+func (m *MockUserKeypairExtraRepository) Upsert(k *model.UserKeypairExtra) error {
+	m.Keypairs[k.UserID] = k
+	return nil
+}
+
+func (m *MockUserKeypairExtraRepository) FindByUserID(userID string) (*model.UserKeypairExtra, error) {
+	k, ok := m.Keypairs[userID]
+	if !ok {
+		return nil, ErrNotFound
+	}
+	return k, nil
+}
+
+func (m *MockUserKeypairExtraRepository) Delete(userID string) error {
+	delete(m.Keypairs, userID)
+	return nil
+}
+
 // MockFollowingRepository is a test double for repository.FollowingRepository.
 type MockFollowingRepository struct {
 	Followings map[string]*model.Following // keyed by ID

--- a/migration/000049_user_keypair_extra.down.sql
+++ b/migration/000049_user_keypair_extra.down.sql
@@ -1,0 +1,1 @@
+DROP TABLE IF EXISTS "user_keypair_extra";

--- a/migration/000049_user_keypair_extra.up.sql
+++ b/migration/000049_user_keypair_extra.up.sql
@@ -1,0 +1,9 @@
+-- user_keypair_extra: local user の Ed25519 鍵ペアを保存する mk-go 独自テーブル。
+-- 既存 user_keypair (RSA) は upstream Misskey TS との drop-in 互換のため untouched
+-- とし、Ed25519 用は別テーブルに分離する。TS は本テーブルを認識せず SELECT/INSERT
+-- 共に行わないので、TS swap 時にも壊れない (#1067 / #1068)。
+CREATE TABLE IF NOT EXISTS "user_keypair_extra" (
+    "userId"            varchar(32) PRIMARY KEY REFERENCES "user"("id") ON DELETE CASCADE,
+    "ed25519PublicKey"  varchar(256) NOT NULL,
+    "ed25519PrivateKey" varchar(256) NOT NULL
+);

--- a/migration/000050_user_publickey_extra.down.sql
+++ b/migration/000050_user_publickey_extra.down.sql
@@ -1,0 +1,2 @@
+DROP INDEX IF EXISTS "IDX_user_publickey_extra_keyId";
+DROP TABLE IF EXISTS "user_publickey_extra";

--- a/migration/000050_user_publickey_extra.up.sql
+++ b/migration/000050_user_publickey_extra.up.sql
@@ -1,0 +1,14 @@
+-- user_publickey_extra: リモート user の追加公開鍵 (Ed25519 等) を保存する mk-go
+-- 独自テーブル。actor JSON の assertionMethod[] (FEP-521a Multikey) から parse した
+-- 鍵を keyId 単位で保持し、HTTP Signature の verify と outbound deliver 時の
+-- capability 判定に使う。既存 user_publickey (RSA, single row per userId) は untouched
+-- とし、TS drop-in 互換を保つ (#1067 / #1068)。
+CREATE TABLE IF NOT EXISTS "user_publickey_extra" (
+    "userId" varchar(32)   NOT NULL REFERENCES "user"("id") ON DELETE CASCADE,
+    "keyId"  varchar(256)  NOT NULL,
+    "keyPem" varchar(4096) NOT NULL,
+    "alg"    varchar(32)   NOT NULL,
+    PRIMARY KEY ("userId", "keyId")
+);
+CREATE INDEX IF NOT EXISTS "IDX_user_publickey_extra_keyId"
+    ON "user_publickey_extra" ("keyId");


### PR DESCRIPTION
## Summary

- local user の Ed25519 鍵対を `user_keypair_extra` に併発行する add-only schema を追加 (migration 000049)
- リモート user の追加公開鍵 (assertionMethod 由来) を `user_publickey_extra` に `(userId, keyId)` 複合 PK で保持する schema を追加 (migration 000050)
- `signup.Service` / `systemaccount.Service` に `SetKeypairExtraRepo` setter を追加し、wire 時に RSA 鍵対と並行で Ed25519 鍵対も発行
- `router.go` で `keypairExtraRepo` を生成して両 service に wire

親 issue: #1067
Closes #1068

## drop-in 互換

既存 `user_keypair` / `user_publickey` テーブルは untouched。Misskey TS は新規 2 テーブルを認識せず SELECT/INSERT どちらも行わないため、TS 戻し時の連合は壊れない。`SetKeypairExtraRepo` 未配線時は RSA only で動き、upstream Misskey TS と完全に同じ挙動になる。

## 主な変更点

### 新規ファイル
- `migration/000049_user_keypair_extra.{up,down}.sql`
- `migration/000050_user_publickey_extra.{up,down}.sql`
- `internal/model/user_keypair_extra.go` / `user_publickey_extra.go`
- `internal/repository/user_keypair_extra.go` + `_test.go`
- `internal/repository/user_publickey_extra.go` + `_test.go`

### 改修
- `internal/core/signup/signup_service.go` — `SetKeypairExtraRepo` + `maybeCreateEd25519Keypair` helper + 3 callsite (Signup / promotePendingTx / promotePendingNoTx) で Ed25519 鍵併発行
- `internal/core/signup/signup_service_test.go` — Ed25519 配線時の挙動 / Upsert error path test 追加
- `internal/core/signup/signup_service_integration_test.go` — tx 経路 (`promotePendingTx`) の Ed25519 keypair 作成を testcontainers 経由で検証
- `internal/core/systemaccount/systemaccount.go` — `SetKeypairExtraRepo` + `completeFromOrphan` で Ed25519 鍵 idempotent 発行
- `internal/core/systemaccount/systemaccount_test.go` — Ed25519 wire 時 / 未配線時 / idempotency / error bubble の 4 test 追加
- `internal/server/router.go` — `keypairExtraRepo` を生成して signup / systemaccount に wire
- `internal/testutil/mock_repository.go` — `MockUserKeypairExtraRepository` を追加

## テスト

ローカル実行 (testcontainers の PostgreSQL を使用):

```bash
make fmt && make lint
make test     # 全パッケージ pass
go test ./internal/core/signup/ -cover           # 90.6%
go test ./internal/core/systemaccount/ -cover    # 92.7%
go test ./internal/repository/ -cover            # 90.4%
```

新規 test:
- `internal/repository/user_keypair_extra_test.go` 4 件
- `internal/repository/user_publickey_extra_test.go` 5 件
- `internal/core/signup/signup_service_test.go` 3 件 (`TestSignup_WithKeypairExtraRepo` / `TestSignup_KeypairExtraUpsertError` / `TestPromotePending_WithKeypairExtra` / `TestPromotePending_KeypairExtraUpsertError`)
- `internal/core/signup/signup_service_integration_test.go` 1 件 (`TestPromotePending_TxCreatesKeypairExtra`)
- `internal/core/systemaccount/systemaccount_test.go` 4 件

## 次のステップ

このマージ後、parent #1067 の以下の sub issue に進む:

- P2 #1069 — Renderer で `assertionMethod[]` expose + Multikey encode helper (`go-multibase` 新規依存)
- P3 #1070 — Resolver で `assertionMethod[]` parse + `user_publickey_extra` upsert + keyId dual lookup
- P5 #1072 — 既存 local user の lazy backfill (Ed25519 鍵が無い user 向け)

P2/P3 がそろうと P4 (#1071) で outbound deliver の capability-gated Ed25519 sign に進める。