### PR TITLE
ed25519: Renderer で assertionMethod expose + Multikey encode helper (P2)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -28,6 +28,7 @@ require (
 	github.com/meilisearch/meilisearch-go v0.36.1
 	github.com/mmcdole/gofeed v1.3.0
 	github.com/mrjoshuak/go-jpeg2000 v1.2.1
+	github.com/multiformats/go-multibase v0.3.0
 	github.com/oklog/ulid/v2 v2.1.1
 	github.com/pquerna/otp v1.5.0
 	github.com/redis/go-redis/v9 v9.18.0
@@ -122,6 +123,9 @@ require (
 	github.com/moby/term v0.5.2 // indirect
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
 	github.com/modern-go/reflect2 v1.0.2 // indirect
+	github.com/mr-tron/base58 v1.3.0 // indirect
+	github.com/multiformats/go-base32 v0.1.0 // indirect
+	github.com/multiformats/go-base36 v0.2.0 // indirect
 	github.com/opencontainers/go-digest v1.0.0 // indirect
 	github.com/opencontainers/image-spec v1.1.1 // indirect
 	github.com/pelletier/go-toml/v2 v2.2.4 // indirect

--- a/go.sum
+++ b/go.sum
@@ -229,8 +229,16 @@ github.com/modern-go/reflect2 v1.0.2 h1:xBagoLtFs94CBntxluKeaWgTMpvLxC4ur3nMaC9G
 github.com/modern-go/reflect2 v1.0.2/go.mod h1:yWuevngMOJpCy52FWWMvUC8ws7m/LJsjYzDa0/r8luk=
 github.com/morikuni/aec v1.0.0 h1:nP9CBfwrvYnBRgY6qfDQkygYDmYwOilePFkwzv4dU8A=
 github.com/morikuni/aec v1.0.0/go.mod h1:BbKIizmSmc5MMPqRYbxO4ZU0S0+P200+tUnFx7PXmsc=
+github.com/mr-tron/base58 v1.3.0 h1:K6Y13R2h+dku0wOqKtecgRnBUBPrZzLZy5aIj8lCcJI=
+github.com/mr-tron/base58 v1.3.0/go.mod h1:2BuubE67DCSWwVfx37JWNG8emOC0sHEU4/HpcYgCLX8=
 github.com/mrjoshuak/go-jpeg2000 v1.2.1 h1:6k+J+YkJx676Pofom8rCx35J69Hc3PvzUZ3cytkIfzo=
 github.com/mrjoshuak/go-jpeg2000 v1.2.1/go.mod h1:Zvb2bdmP52/rpmJOuzMo1HQR75zex//CvqEvopdTweo=
+github.com/multiformats/go-base32 v0.1.0 h1:pVx9xoSPqEIQG8o+UbAe7DNi51oej1NtK+aGkbLYxPE=
+github.com/multiformats/go-base32 v0.1.0/go.mod h1:Kj3tFY6zNr+ABYMqeUNeGvkIC/UYgtWibDcT0rExnbI=
+github.com/multiformats/go-base36 v0.2.0 h1:lFsAbNOGeKtuKozrtBsAkSVhv1p9D0/qedU9rQyccr0=
+github.com/multiformats/go-base36 v0.2.0/go.mod h1:qvnKE++v+2MWCfePClUEjE78Z7P2a1UV0xHgWc0hkp4=
+github.com/multiformats/go-multibase v0.3.0 h1:8helZD2+4Db7NNWFiktk2NePbF0boolBe6bDQvM4r68=
+github.com/multiformats/go-multibase v0.3.0/go.mod h1:MoBLQPCkRTOL3eveIPO81860j2AQY8JwcnNlRkGRUfI=
 github.com/oklog/ulid/v2 v2.1.1 h1:suPZ4ARWLOJLegGFiZZ1dFAkqzhMjL3J1TzI+5wHz8s=
 github.com/oklog/ulid/v2 v2.1.1/go.mod h1:rcEKHmBBKfef9DhnvX7y1HZBYxjXb0cP5ExxNsTT1QQ=
 github.com/opencontainers/go-digest v1.0.0 h1:apOUWs51W5PlhuyGyz9FCeeBIOUDA/6nW8Oi/yOhh5U=

--- a/internal/activitypub/keypair.go
+++ b/internal/activitypub/keypair.go
@@ -122,6 +122,20 @@ func ParseRSAPublicKey(pemStr string) (*rsa.PublicKey, error) {
 	return pub.(*rsa.PublicKey), nil
 }
 
+// ParseEd25519PublicKeyPEM decodes a PEM-encoded Ed25519 public key
+// (PKIX SubjectPublicKeyInfo). Errors are returned when the PEM is missing,
+// malformed, or contains a non-Ed25519 key (= caller can fall back to RSA).
+func ParseEd25519PublicKeyPEM(pemStr string) (ed25519.PublicKey, error) {
+	pub, kt, err := ParsePublicKey(pemStr)
+	if err != nil {
+		return nil, err
+	}
+	if kt != KeyTypeEd25519 {
+		return nil, errors.New("not an Ed25519 public key")
+	}
+	return pub.(ed25519.PublicKey), nil
+}
+
 // ParsePublicKey decodes a PEM-encoded public key and reports its type.
 // RSA / Ed25519を識別できる。それ以外は "unsupported public key type" で
 // 拒否する (Misskeyフェデレーションでは ECDSA等は事実上使われていない)。

--- a/internal/activitypub/multikey.go
+++ b/internal/activitypub/multikey.go
@@ -1,0 +1,83 @@
+package activitypub
+
+import (
+	"crypto/ed25519"
+	"errors"
+	"fmt"
+
+	"github.com/multiformats/go-multibase"
+)
+
+// FEP-521a / W3C VC Data Integrity (Multikey) で Ed25519 public key を
+// publicKeyMultibase 値として表現するための encode/decode ヘルパ。
+//
+// publicKeyMultibase の形式:
+//
+//	"z" + base58btc(multicodec_varint_prefix || raw_ed25519_public_key)
+//
+// - multibase prefix `z` = base58btc
+// - multicodec varint prefix for Ed25519 public key = 0xed 0x01 (2 bytes)
+// - raw Ed25519 public key = 32 bytes
+// → 結果は必ず `z6Mk...` 形式の 48 文字程度の文字列になる。
+//
+// 参考: https://w3c-ccg.github.io/security-vocab/#Multikey
+//
+// Fedibird / Mastodon glitch-soc など FEP-521a 対応サーバーが actor JSON の
+// `assertionMethod[]` で Ed25519 公開鍵を expose する際に使う標準形式。
+// mk-go は同形式で expose し、リモートから受信したものを parse する。
+
+// ed25519MulticodecPrefix is the varint-encoded multicodec for an Ed25519
+// public key (table value 0xed). Multibase / Multikey 仕様に基づく 2 byte の
+// 固定プレフィックスで、varint encode 結果は `0xed 0x01` になる。
+var ed25519MulticodecPrefix = []byte{0xed, 0x01}
+
+// ed25519PublicKeySize is the canonical size of an Ed25519 public key in bytes.
+const ed25519PublicKeySize = 32
+
+// ErrInvalidMultikey is returned when a publicKeyMultibase string is malformed
+// or does not represent an Ed25519 public key (wrong multibase, wrong
+// multicodec, wrong key length, etc).
+var ErrInvalidMultikey = errors.New("invalid Ed25519 multikey")
+
+// EncodeEd25519Multikey returns the publicKeyMultibase representation of pub
+// (e.g. "z6Mk..."). pub の長さが 32 bytes でない場合 error を返す。
+func EncodeEd25519Multikey(pub ed25519.PublicKey) (string, error) {
+	if len(pub) != ed25519PublicKeySize {
+		return "", fmt.Errorf("%w: public key size %d != %d", ErrInvalidMultikey, len(pub), ed25519PublicKeySize)
+	}
+	payload := make([]byte, 0, len(ed25519MulticodecPrefix)+ed25519PublicKeySize)
+	payload = append(payload, ed25519MulticodecPrefix...)
+	payload = append(payload, pub...)
+	return multibase.Encode(multibase.Base58BTC, payload)
+}
+
+// DecodeEd25519Multikey parses a publicKeyMultibase string and returns the
+// embedded Ed25519 public key. multibase prefix が `z` (base58btc) でない、
+// multicodec prefix が Ed25519 ではない、key 長が 32 byte でない、いずれの
+// 場合も ErrInvalidMultikey をラップした error を返す。
+func DecodeEd25519Multikey(s string) (ed25519.PublicKey, error) {
+	enc, raw, err := multibase.Decode(s)
+	if err != nil {
+		return nil, fmt.Errorf("%w: multibase decode: %v", ErrInvalidMultikey, err)
+	}
+	if enc != multibase.Base58BTC {
+		return nil, fmt.Errorf("%w: unexpected multibase encoding %v (want base58btc)", ErrInvalidMultikey, enc)
+	}
+	if len(raw) < len(ed25519MulticodecPrefix) {
+		return nil, fmt.Errorf("%w: payload too short", ErrInvalidMultikey)
+	}
+	for i, b := range ed25519MulticodecPrefix {
+		if raw[i] != b {
+			return nil, fmt.Errorf("%w: not an Ed25519 multicodec prefix", ErrInvalidMultikey)
+		}
+	}
+	body := raw[len(ed25519MulticodecPrefix):]
+	if len(body) != ed25519PublicKeySize {
+		return nil, fmt.Errorf("%w: key size %d != %d", ErrInvalidMultikey, len(body), ed25519PublicKeySize)
+	}
+	// ed25519.PublicKey は []byte の type alias なので copy で隔離する
+	// (multibase.Decode の返す raw slice は内部 buffer の view の可能性)。
+	pub := make(ed25519.PublicKey, ed25519PublicKeySize)
+	copy(pub, body)
+	return pub, nil
+}

--- a/internal/activitypub/multikey_test.go
+++ b/internal/activitypub/multikey_test.go
@@ -1,0 +1,101 @@
+package activitypub
+
+import (
+	"crypto/ed25519"
+	"crypto/rand"
+	"strings"
+	"testing"
+
+	"github.com/multiformats/go-multibase"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestEncodeEd25519Multikey_RoundTrip(t *testing.T) {
+	pub, _, err := ed25519.GenerateKey(rand.Reader)
+	require.NoError(t, err)
+
+	mb, err := EncodeEd25519Multikey(pub)
+	require.NoError(t, err)
+	// FEP-521a / W3C VC Data Integrity の Ed25519 Multikey は必ず `z6Mk` で始まる
+	// (`z` = base58btc, `6Mk` = `0xed01` multicodec prefix を 32 byte zero key と
+	// concat した結果の prefix)。具体的な byte 列によらず prefix は同じ。
+	assert.True(t, strings.HasPrefix(mb, "z6Mk"), "want z6Mk... prefix, got %s", mb)
+
+	got, err := DecodeEd25519Multikey(mb)
+	require.NoError(t, err)
+	assert.Equal(t, pub, got)
+}
+
+// 既知のオールゼロ Ed25519 公開鍵 (32 byte の 0) の Multikey 表現を hardcode で
+// 検証する。multicodec 0xed01 + 32 zero-byte で base58btc encode した結果は
+// 下記の固定文字列になり、go-multibase / multicodec ライブラリの encode 出力が
+// 変化したことを CI で早期検出するための regression guard。
+func TestEncodeEd25519Multikey_KnownVector_ZeroKey(t *testing.T) {
+	zero := make(ed25519.PublicKey, ed25519PublicKeySize) // all zero
+	mb, err := EncodeEd25519Multikey(zero)
+	require.NoError(t, err)
+	assert.Equal(t, "z6MkeTG3bFFSLYVU7VqhgZxqr6YzpaGrQtFMh1uvqGy1vDnP", mb)
+
+	// round-trip でも zero key が復元される
+	back, err := DecodeEd25519Multikey(mb)
+	require.NoError(t, err)
+	assert.Equal(t, zero, back)
+}
+
+func TestEncodeEd25519Multikey_WrongSize(t *testing.T) {
+	short := ed25519.PublicKey(make([]byte, 16))
+	_, err := EncodeEd25519Multikey(short)
+	require.Error(t, err)
+	assert.ErrorIs(t, err, ErrInvalidMultikey)
+}
+
+func TestDecodeEd25519Multikey_InvalidPrefix(t *testing.T) {
+	// 全く異なる multibase prefix を使う (例: base16 prefix `f`)
+	_, err := DecodeEd25519Multikey("fdeadbeef")
+	require.Error(t, err)
+	assert.ErrorIs(t, err, ErrInvalidMultikey)
+}
+
+func TestDecodeEd25519Multikey_NonEd25519Multicodec(t *testing.T) {
+	// secp256k1 public key multicodec prefix (0xe7 0x01) + 33 dummy bytes を
+	// base58btc encode した正しい multibase 文字列を作成 → Ed25519 decoder で
+	// "not an Ed25519 multicodec prefix" 経路で reject されることを確認。
+	payload := append([]byte{0xe7, 0x01}, make([]byte, 33)...)
+	mb, err := multibase.Encode(multibase.Base58BTC, payload)
+	require.NoError(t, err)
+
+	_, err = DecodeEd25519Multikey(mb)
+	require.Error(t, err)
+	assert.ErrorIs(t, err, ErrInvalidMultikey)
+}
+
+func TestDecodeEd25519Multikey_WrongKeyLength(t *testing.T) {
+	// Ed25519 multicodec prefix + 16 byte body (短すぎる) を base58btc encode し
+	// → "key size 16 != 32" 経路で reject されることを確認。
+	payload := append([]byte{0xed, 0x01}, make([]byte, 16)...)
+	mb, err := multibase.Encode(multibase.Base58BTC, payload)
+	require.NoError(t, err)
+
+	_, err = DecodeEd25519Multikey(mb)
+	require.Error(t, err)
+	assert.ErrorIs(t, err, ErrInvalidMultikey)
+}
+
+func TestDecodeEd25519Multikey_PayloadTooShort(t *testing.T) {
+	// multicodec prefix の途中で切れた payload (1 byte のみ) → "payload too short"
+	// 経路で reject されることを確認。
+	payload := []byte{0xed}
+	mb, err := multibase.Encode(multibase.Base58BTC, payload)
+	require.NoError(t, err)
+
+	_, err = DecodeEd25519Multikey(mb)
+	require.Error(t, err)
+	assert.ErrorIs(t, err, ErrInvalidMultikey)
+}
+
+func TestDecodeEd25519Multikey_EmptyString(t *testing.T) {
+	_, err := DecodeEd25519Multikey("")
+	require.Error(t, err)
+	assert.ErrorIs(t, err, ErrInvalidMultikey)
+}

--- a/internal/activitypub/renderer.go
+++ b/internal/activitypub/renderer.go
@@ -251,7 +251,9 @@ func (r *Renderer) RenderPerson(u *model.User, profile *model.UserProfile, publi
 	// 追加 expose する。Fedibird など FEP-521a 対応サーバーが Ed25519 鍵で
 	// HTTP Signature を verify できるようにするための拡張 (#1067 / #1069)。
 	// keyId fragment は `#ed25519-key` を採用 (Fedibird / Mastodon glitch-soc
-	// と同じ慣習)。
+	// と同じ慣習)。encode error (= key size != 32 byte) は production では
+	// 発火しない理論上の defensive path だが、診断のため warn log を出して
+	// silent omission を回避する。
 	if ed25519PublicKey != nil {
 		if mb, err := EncodeEd25519Multikey(ed25519PublicKey); err == nil {
 			p.AssertionMethod = []Multikey{{
@@ -260,6 +262,9 @@ func (r *Renderer) RenderPerson(u *model.User, profile *model.UserProfile, publi
 				Controller:         uri,
 				PublicKeyMultibase: mb,
 			}}
+		} else {
+			slog.Warn("ed25519 multikey encode failed",
+				"userID", u.ID, "error", err)
 		}
 	}
 	if u.AvatarURL != nil {

--- a/internal/activitypub/renderer.go
+++ b/internal/activitypub/renderer.go
@@ -1,6 +1,7 @@
 package activitypub
 
 import (
+	"crypto/ed25519"
 	"crypto/sha256"
 	"encoding/hex"
 	"encoding/json"
@@ -215,8 +216,11 @@ func (r *Renderer) SetHost(host string) {
 
 // RenderPerson packs a local user into a Person actor object.
 // profile は nil でもよい (その場合 summary 等のフィールドは省略される)。
-// publicKeyPEM はリポジトリから取得した公開鍵PEM文字列。
-func (r *Renderer) RenderPerson(u *model.User, profile *model.UserProfile, publicKeyPEM string) *Person {
+// publicKeyPEM はリポジトリから取得した RSA 公開鍵 PEM 文字列。
+// ed25519PublicKey が non-nil の場合は FEP-521a Multikey 形式で
+// `assertionMethod[]` に追加 expose する (#1067 / #1069)。Encode 失敗時は
+// silently skip して RSA のみ出力する fail-soft 動作。
+func (r *Renderer) RenderPerson(u *model.User, profile *model.UserProfile, publicKeyPEM string, ed25519PublicKey ed25519.PublicKey) *Person {
 	uri := r.urls.UserURI(u.ID)
 
 	actorType := actorTypeForUser(u)
@@ -242,6 +246,21 @@ func (r *Renderer) RenderPerson(u *model.User, profile *model.UserProfile, publi
 		ManuallyApproves: u.IsLocked,
 		Discoverable:     u.IsExplorable,
 		IsCat:            u.IsCat,
+	}
+	// Ed25519 鍵を持つ user に対しては assertionMethod に Multikey として
+	// 追加 expose する。Fedibird など FEP-521a 対応サーバーが Ed25519 鍵で
+	// HTTP Signature を verify できるようにするための拡張 (#1067 / #1069)。
+	// keyId fragment は `#ed25519-key` を採用 (Fedibird / Mastodon glitch-soc
+	// と同じ慣習)。
+	if ed25519PublicKey != nil {
+		if mb, err := EncodeEd25519Multikey(ed25519PublicKey); err == nil {
+			p.AssertionMethod = []Multikey{{
+				ID:                 uri + "#ed25519-key",
+				Type:               MultikeyType,
+				Controller:         uri,
+				PublicKeyMultibase: mb,
+			}}
+		}
 	}
 	if u.AvatarURL != nil {
 		p.Icon = &Image{Type: "Image", URL: *u.AvatarURL}

--- a/internal/activitypub/renderer_test.go
+++ b/internal/activitypub/renderer_test.go
@@ -1,6 +1,8 @@
 package activitypub
 
 import (
+	"crypto/ed25519"
+	"crypto/rand"
 	"errors"
 	"strings"
 	"testing"
@@ -55,7 +57,7 @@ func TestRenderer_RenderPerson(t *testing.T) {
 		IsLocked:     true,
 		IsExplorable: true,
 	}
-	p := r.RenderPerson(u, nil, "PUBKEY")
+	p := r.RenderPerson(u, nil, "PUBKEY", nil)
 	assert.Equal(t, "https://example.com/users/u1", p.ID)
 	assert.Equal(t, "Person", p.Type)
 	assert.Equal(t, "alice", p.PreferredUsername)
@@ -70,10 +72,47 @@ func TestRenderer_RenderPerson(t *testing.T) {
 func TestRenderer_RenderPerson_NoOptionalFields(t *testing.T) {
 	r := newRenderer()
 	u := &model.User{ID: "u1", Username: "alice"}
-	p := r.RenderPerson(u, nil, "PUBKEY")
+	p := r.RenderPerson(u, nil, "PUBKEY", nil)
 	assert.Empty(t, p.Name)
 	assert.Nil(t, p.Icon)
 	assert.False(t, p.ManuallyApproves)
+}
+
+func TestRenderer_RenderPerson_AssertionMethodOmittedWhenNoEd25519(t *testing.T) {
+	r := newRenderer()
+	u := &model.User{ID: "u1", Username: "alice"}
+	p := r.RenderPerson(u, nil, "PUBKEY", nil)
+	// Ed25519 鍵を持たない user (= TS で signup された / backfill 未済) は
+	// AssertionMethod を出さず upstream actor JSON と shape を揃える。
+	assert.Empty(t, p.AssertionMethod)
+}
+
+func TestRenderer_RenderPerson_AssertionMethodWithEd25519(t *testing.T) {
+	r := newRenderer()
+	u := &model.User{ID: "u1", Username: "alice"}
+
+	pub, _, err := ed25519.GenerateKey(rand.Reader)
+	require.NoError(t, err)
+	p := r.RenderPerson(u, nil, "PUBKEY", pub)
+
+	require.Len(t, p.AssertionMethod, 1)
+	am := p.AssertionMethod[0]
+	assert.Equal(t, "https://example.com/users/u1#ed25519-key", am.ID)
+	assert.Equal(t, MultikeyType, am.Type)
+	assert.Equal(t, "https://example.com/users/u1", am.Controller)
+	// publicKeyMultibase は z6Mk... prefix (Ed25519 Multikey 仕様)
+	assert.True(t, strings.HasPrefix(am.PublicKeyMultibase, "z6Mk"))
+
+	// round-trip で正しく decode できることを確認
+	decoded, err := DecodeEd25519Multikey(am.PublicKeyMultibase)
+	require.NoError(t, err)
+	assert.Equal(t, pub, decoded)
+
+	// @context に Multikey vocabulary が含まれている
+	ctx, ok := p.Context.([]any)
+	require.True(t, ok, "person context should be a slice")
+	assert.Contains(t, ctx, MultikeyContextURL)
+	assert.Contains(t, ctx, DataIntegrityContextURL)
 }
 
 func TestRenderer_RenderPerson_MisskeyCanChat(t *testing.T) {
@@ -94,7 +133,7 @@ func TestRenderer_RenderPerson_MisskeyCanChat(t *testing.T) {
 	for _, tc := range cases {
 		t.Run(tc.scope, func(t *testing.T) {
 			u := &model.User{ID: "u1", Username: "alice", ChatScope: tc.scope}
-			p := r.RenderPerson(u, nil, "PUBKEY")
+			p := r.RenderPerson(u, nil, "PUBKEY", nil)
 			require.NotNil(t, p.MisskeyCanChat)
 			assert.Equal(t, tc.want, *p.MisskeyCanChat)
 		})
@@ -499,7 +538,7 @@ func TestRenderer_RenderDelete(t *testing.T) {
 func TestRenderer_RenderPerson_Bot(t *testing.T) {
 	r := newRenderer()
 	u := &model.User{ID: "u1", Username: "bot", IsBot: true}
-	p := r.RenderPerson(u, nil, "PUBKEY")
+	p := r.RenderPerson(u, nil, "PUBKEY", nil)
 	assert.Equal(t, "Service", p.Type)
 }
 
@@ -519,7 +558,7 @@ func TestRenderer_RenderPerson_WithProfile(t *testing.T) {
 		FollowedMessage: &followedMsg,
 		Fields:          fields,
 	}
-	p := r.RenderPerson(u, profile, "PUBKEY")
+	p := r.RenderPerson(u, profile, "PUBKEY", nil)
 	assert.Contains(t, p.Summary, "<b>hello</b>")
 	assert.Equal(t, desc, p.MisskeySummary)
 	assert.Equal(t, "2000-01-01", p.VcardBday)
@@ -548,7 +587,7 @@ func TestRenderer_RenderPerson_BannerAndMovedTo(t *testing.T) {
 		AlsoKnownAs: &alsoKnownAs,
 		Featured:    &featured,
 	}
-	p := r.RenderPerson(u, nil, "PUBKEY")
+	p := r.RenderPerson(u, nil, "PUBKEY", nil)
 	require.NotNil(t, p.Image)
 	assert.Equal(t, banner, p.Image.URL)
 	assert.Equal(t, movedTo, p.MovedTo)
@@ -566,7 +605,7 @@ func TestRenderer_RenderPerson_MisskeyExtensionFields(t *testing.T) {
 		MakeNotesFollowersOnlyBefore: &before,
 		MakeNotesHiddenBefore:        nil,
 	}
-	p := r.RenderPerson(u, nil, "PUBKEY")
+	p := r.RenderPerson(u, nil, "PUBKEY", nil)
 	assert.True(t, p.MisskeyRequireSigninToViewContents)
 	require.NotNil(t, p.MisskeyMakeNotesFollowersOnlyBefore)
 	assert.Equal(t, 30, *p.MisskeyMakeNotesFollowersOnlyBefore)
@@ -576,7 +615,7 @@ func TestRenderer_RenderPerson_MisskeyExtensionFields(t *testing.T) {
 func TestRenderer_RenderPerson_MisskeyExtensionFields_Defaults(t *testing.T) {
 	r := newRenderer()
 	u := &model.User{ID: "u1", Username: "alice"}
-	p := r.RenderPerson(u, nil, "PUBKEY")
+	p := r.RenderPerson(u, nil, "PUBKEY", nil)
 	// デフォルト (false / nil) は omitempty で出力されない
 	assert.False(t, p.MisskeyRequireSigninToViewContents)
 	assert.Nil(t, p.MisskeyMakeNotesFollowersOnlyBefore)
@@ -803,7 +842,7 @@ func TestRenderer_RenderPerson_EmojiTag(t *testing.T) {
 		Username: "alice",
 		Emojis:   pq.StringArray{"verified"},
 	}
-	p := r.RenderPerson(u, nil, "PUBKEY")
+	p := r.RenderPerson(u, nil, "PUBKEY", nil)
 	require.Len(t, p.Tag, 1)
 	et, ok := p.Tag[0].(EmojiTag)
 	require.True(t, ok)

--- a/internal/activitypub/renderer_test.go
+++ b/internal/activitypub/renderer_test.go
@@ -87,6 +87,17 @@ func TestRenderer_RenderPerson_AssertionMethodOmittedWhenNoEd25519(t *testing.T)
 	assert.Empty(t, p.AssertionMethod)
 }
 
+// 32 byte 以外の "Ed25519" 鍵 (= 仕様違反) を渡した場合は EncodeEd25519Multikey
+// が error を返し、Renderer は assertionMethod を omit して fail-soft で
+// 動作する (#1067 / #1069)。
+func TestRenderer_RenderPerson_InvalidEd25519KeySize_FailsSoft(t *testing.T) {
+	r := newRenderer()
+	u := &model.User{ID: "u1", Username: "alice"}
+	short := ed25519.PublicKey(make([]byte, 16)) // 仕様違反
+	p := r.RenderPerson(u, nil, "PUBKEY", short)
+	assert.Empty(t, p.AssertionMethod)
+}
+
 func TestRenderer_RenderPerson_AssertionMethodWithEd25519(t *testing.T) {
 	r := newRenderer()
 	u := &model.User{ID: "u1", Username: "alice"}

--- a/internal/activitypub/types.go
+++ b/internal/activitypub/types.go
@@ -51,6 +51,15 @@ const ContextURL = "https://www.w3.org/ns/activitystreams"
 // SecurityContextURL is the W3C security vocabulary used for HTTP Signatures.
 const SecurityContextURL = "https://w3id.org/security/v1"
 
+// MultikeyContextURL is the W3C Multikey vocabulary (FEP-521a) used to expose
+// Ed25519 public keys via Person.assertionMethod[]. Fedibird / Mastodon
+// glitch-soc などが解釈可能。
+const MultikeyContextURL = "https://w3id.org/security/multikey/v1"
+
+// DataIntegrityContextURL is the W3C VC Data Integrity vocabulary that defines
+// the `assertionMethod` term used to attach Multikey entries to actors.
+const DataIntegrityContextURL = "https://w3id.org/security/data-integrity/v1"
+
 // Public is the magic IRI used to denote a publicly addressable activity.
 const Public = "https://www.w3.org/ns/activitystreams#Public"
 
@@ -93,6 +102,24 @@ type PublicKey struct {
 	Owner        string `json:"owner"`
 	PublicKeyPEM string `json:"publicKeyPem"`
 }
+
+// Multikey represents a single FEP-521a Multikey entry expose-d via
+// Person.assertionMethod[]. Used by mk-go to publish Ed25519 public keys
+// alongside the legacy RSA-only `publicKey` field, so capability-aware
+// receivers can verify HTTP Signatures with Ed25519 if the local user owns
+// an Ed25519 keypair.
+//
+// PublicKeyMultibase encodes the raw key with the standard "z" + base58btc +
+// multicodec prefix format (see internal/activitypub/multikey.go).
+type Multikey struct {
+	ID                 string `json:"id"`
+	Type               string `json:"type"`
+	Controller         string `json:"controller"`
+	PublicKeyMultibase string `json:"publicKeyMultibase"`
+}
+
+// MultikeyType is the canonical `type` value for a Multikey entry.
+const MultikeyType = "Multikey"
 
 // Endpoints holds the endpoints sub-object for an Actor.
 type Endpoints struct {
@@ -138,6 +165,11 @@ type Person struct {
 	MisskeyCanChat *bool        `json:"_misskey_canChat,omitempty"`
 	MovedTo        string       `json:"movedTo,omitempty"`
 	AlsoKnownAs    APStringList `json:"alsoKnownAs,omitempty"`
+	// AssertionMethod は FEP-521a Multikey 形式で expose する追加公開鍵リスト
+	// (mk-go では現状 Ed25519 のみ)。omitempty なので Ed25519 鍵を持たない
+	// user / TS で signup した user では出力されず、drop-in 互換を維持する
+	// (#1067 / #1069)。
+	AssertionMethod []Multikey `json:"assertionMethod,omitempty"`
 }
 
 // Note represents a note object (microblog post).
@@ -394,6 +426,19 @@ var MisskeyContext = map[string]any{
 // 不変として扱うこと。各オブジェクトには newContext() で新しいコピーを渡す。
 var fullContext = []any{ContextURL, SecurityContextURL, MisskeyContext}
 
+// personContext は Person actor 専用の拡張コンテキスト。FEP-521a の
+// `assertionMethod` (Multikey) を JSON-LD term として認識させるため、
+// fullContext に Multikey / Data-Integrity vocabulary を append している。
+// Note / Activity 等の他オブジェクトは Multikey を含まないので fullContext
+// 側は変更せず、Person 出力のみ context を拡張する設計 (#1067 / #1069)。
+var personContext = []any{
+	ContextURL,
+	SecurityContextURL,
+	MultikeyContextURL,
+	DataIntegrityContextURL,
+	MisskeyContext,
+}
+
 // newContext returns a fresh copy of fullContext so callers cannot
 // accidentally mutate the shared template via append.
 func newContext() []any {
@@ -402,13 +447,24 @@ func newContext() []any {
 	return c
 }
 
+// newPersonContext returns a fresh copy of personContext (= fullContext +
+// Multikey / Data-Integrity vocab) for Person actor output.
+func newPersonContext() []any {
+	c := make([]any, len(personContext))
+	copy(c, personContext)
+	return c
+}
+
 // AddContext attaches the standard AS+security+Misskey context to any object
 // that embeds Object. 配列で持つことで複数 vocabulary を表現する。
+// Person 専用には Multikey / Data-Integrity vocabulary を追加で含めて、
+// `assertionMethod` term を JSON-LD として正しく解釈可能にする。
 func AddContext(o any) {
 	ctx := newContext()
 	switch v := o.(type) {
 	case *Person:
-		v.Context = ctx
+		v.Context = newPersonContext()
+		return
 	case *Note:
 		v.Context = ctx
 	case *Create:

--- a/internal/api/ap/handler.go
+++ b/internal/api/ap/handler.go
@@ -2,6 +2,7 @@
 package ap
 
 import (
+	"crypto/ed25519"
 	"encoding/json"
 	"net/http"
 	"strings"
@@ -29,14 +30,15 @@ type RemoteResolver interface {
 
 // Handler handles ActivityPub resource endpoints.
 type Handler struct {
-	renderer       *activitypub.Renderer
-	userService    *coreuser.Service
-	queryService   *corenote.QueryService
-	keypairRepo    repository.UserKeypairRepository
-	idGen          id.Generator
-	remoteFetcher  RemoteFetcher
-	remoteResolver RemoteResolver
-	nonAPFallback  echo.HandlerFunc
+	renderer         *activitypub.Renderer
+	userService      *coreuser.Service
+	queryService     *corenote.QueryService
+	keypairRepo      repository.UserKeypairRepository
+	keypairExtraRepo repository.UserKeypairExtraRepository
+	idGen            id.Generator
+	remoteFetcher    RemoteFetcher
+	remoteResolver   RemoteResolver
+	nonAPFallback    echo.HandlerFunc
 }
 
 // SetRemote attaches remote AP fetcher and resolver.
@@ -82,6 +84,33 @@ func NewHandler(
 		keypairRepo:  keypairRepo,
 		idGen:        idGen,
 	}
+}
+
+// SetKeypairExtraRepo wires the Ed25519 keypair repository so that actor JSON
+// responses can include `assertionMethod[]` Multikey entries for users that
+// own an Ed25519 keypair (#1067 / #1069). Optional: 未配線でも RSA only で
+// 動き、upstream Misskey TS と同一の actor JSON shape を維持する。
+func (h *Handler) SetKeypairExtraRepo(r repository.UserKeypairExtraRepository) {
+	h.keypairExtraRepo = r
+}
+
+// lookupEd25519PublicKey returns the Ed25519 public key for the local user
+// when keypairExtraRepo is wired AND an Ed25519 row exists. It returns nil on
+// any of: repo unwired / row missing / PEM parse failure (fail-soft to RSA
+// only — drop-in 互換維持)。
+func (h *Handler) lookupEd25519PublicKey(userID string) ed25519.PublicKey {
+	if h.keypairExtraRepo == nil {
+		return nil
+	}
+	row, err := h.keypairExtraRepo.FindByUserID(userID)
+	if err != nil {
+		return nil
+	}
+	pub, err := activitypub.ParseEd25519PublicKeyPEM(row.Ed25519PublicKey)
+	if err != nil {
+		return nil
+	}
+	return pub
 }
 
 // User handles GET /users/:id with ActivityPub content negotiation.
@@ -132,7 +161,7 @@ func (h *Handler) User(c echo.Context) error {
 	if err != nil {
 		return c.NoContent(http.StatusInternalServerError)
 	}
-	person := h.renderer.RenderPerson(bundle.User, bundle.Profile, keypair.PublicKey)
+	person := h.renderer.RenderPerson(bundle.User, bundle.Profile, keypair.PublicKey, h.lookupEd25519PublicKey(bundle.User.ID))
 	return writeActivityJSON(c, person)
 }
 
@@ -163,7 +192,7 @@ func (h *Handler) UserByAcct(c echo.Context) error {
 	if err != nil {
 		return c.NoContent(http.StatusInternalServerError)
 	}
-	person := h.renderer.RenderPerson(bundle.User, bundle.Profile, keypair.PublicKey)
+	person := h.renderer.RenderPerson(bundle.User, bundle.Profile, keypair.PublicKey, h.lookupEd25519PublicKey(bundle.User.ID))
 	return writeActivityJSON(c, person)
 }
 
@@ -312,7 +341,7 @@ func (h *Handler) resolveLocal(uri string) (any, error) {
 		if err != nil {
 			return nil, err
 		}
-		return h.renderer.RenderPerson(bundle.User, bundle.Profile, keypair.PublicKey), nil
+		return h.renderer.RenderPerson(bundle.User, bundle.Profile, keypair.PublicKey, h.lookupEd25519PublicKey(bundle.User.ID)), nil
 	}
 	return nil, http.ErrNotSupported
 }

--- a/internal/api/ap/handler.go
+++ b/internal/api/ap/handler.go
@@ -4,6 +4,8 @@ package ap
 import (
 	"crypto/ed25519"
 	"encoding/json"
+	"errors"
+	"log/slog"
 	"net/http"
 	"strings"
 
@@ -15,6 +17,7 @@ import (
 	"github.com/shiroha-a/mk/internal/misc/id"
 	"github.com/shiroha-a/mk/internal/model"
 	"github.com/shiroha-a/mk/internal/repository"
+	"gorm.io/gorm"
 )
 
 // RemoteFetcher fetches remote ActivityPub objects.
@@ -98,16 +101,27 @@ func (h *Handler) SetKeypairExtraRepo(r repository.UserKeypairExtraRepository) {
 // when keypairExtraRepo is wired AND an Ed25519 row exists. It returns nil on
 // any of: repo unwired / row missing / PEM parse failure (fail-soft to RSA
 // only — drop-in 互換維持)。
+//
+// "row missing" は P5 backfill 前の通常状態なので silently skip するが、
+// それ以外の DB error / PEM parse error は診断のため warn log を出す。これが
+// 無いと一時的 PostgreSQL 障害で全 user の actor JSON から Ed25519 が消える
+// silent degradation が発生したとき気付けない。
 func (h *Handler) lookupEd25519PublicKey(userID string) ed25519.PublicKey {
 	if h.keypairExtraRepo == nil {
 		return nil
 	}
 	row, err := h.keypairExtraRepo.FindByUserID(userID)
 	if err != nil {
+		if !errors.Is(err, gorm.ErrRecordNotFound) {
+			slog.Warn("ed25519 keypair lookup failed",
+				"userID", userID, "error", err)
+		}
 		return nil
 	}
 	pub, err := activitypub.ParseEd25519PublicKeyPEM(row.Ed25519PublicKey)
 	if err != nil {
+		slog.Warn("ed25519 PEM parse failed",
+			"userID", userID, "error", err)
 		return nil
 	}
 	return pub

--- a/internal/api/ap/handler_test.go
+++ b/internal/api/ap/handler_test.go
@@ -153,6 +153,31 @@ func TestUser_WithEd25519Repo_NoRowForUser(t *testing.T) {
 	assert.NotContains(t, rec.Body.String(), `"assertionMethod"`)
 }
 
+// keypairExtraRepo の FindByUserID が gorm.ErrRecordNotFound 以外の DB error
+// を返した場合も AssertionMethod を omit して RSA only で 200 を返す
+// (fail-soft)。silent degradation の診断は slog.Warn 経由で記録される。
+type failingKeypairExtraRepo struct {
+	err error
+}
+
+func (f *failingKeypairExtraRepo) Upsert(_ *model.UserKeypairExtra) error { return f.err }
+func (f *failingKeypairExtraRepo) FindByUserID(_ string) (*model.UserKeypairExtra, error) {
+	return nil, f.err
+}
+func (f *failingKeypairExtraRepo) Delete(_ string) error { return f.err }
+
+func TestUser_WithEd25519Repo_DBError_FailsSoft(t *testing.T) {
+	h, userRepo, _, keypairRepo := newHandler(t)
+	userRepo.Users["u1"] = &model.User{ID: "u1", Username: "alice"}
+	keypairRepo.items["u1"] = &model.UserKeypair{UserID: "u1", PublicKey: "PUBKEY"}
+	h.SetKeypairExtraRepo(&failingKeypairExtraRepo{err: errors.New("connection refused")})
+
+	c, rec := newReq(t, "id", "u1")
+	require.NoError(t, h.User(c))
+	assert.Equal(t, http.StatusOK, rec.Code)
+	assert.NotContains(t, rec.Body.String(), `"assertionMethod"`)
+}
+
 // keypairExtraRepo が wire 済 + Ed25519 row はあるが PEM が壊れている場合 →
 // silently skip して AssertionMethod を omit する (= RSA only に fail-soft)。
 func TestUser_WithEd25519Repo_MalformedPEM_FailsSoft(t *testing.T) {

--- a/internal/api/ap/handler_test.go
+++ b/internal/api/ap/handler_test.go
@@ -111,6 +111,68 @@ func TestUser_KeypairFetchError(t *testing.T) {
 	assert.Equal(t, http.StatusInternalServerError, rec.Code)
 }
 
+// FEP-521a Multikey expose 経路 (#1067 / #1069):
+// keypairExtraRepo を wire し、Ed25519 鍵を持つ user の actor JSON に
+// assertionMethod[] が出力されることを確認する。
+func TestUser_WithEd25519Keypair_ExposesAssertionMethod(t *testing.T) {
+	h, userRepo, _, keypairRepo := newHandler(t)
+	userRepo.Users["u1"] = &model.User{ID: "u1", Username: "alice"}
+	keypairRepo.items["u1"] = &model.UserKeypair{UserID: "u1", PublicKey: "PUBKEY"}
+
+	// Ed25519 鍵対を生成して PEM で extra repo に格納
+	_, edPubPEM, err := activitypub.GenerateEd25519Keypair()
+	require.NoError(t, err)
+	extra := testutil.NewMockUserKeypairExtraRepository()
+	require.NoError(t, extra.Upsert(&model.UserKeypairExtra{
+		UserID:            "u1",
+		Ed25519PublicKey:  edPubPEM,
+		Ed25519PrivateKey: "STUB",
+	}))
+	h.SetKeypairExtraRepo(extra)
+
+	c, rec := newReq(t, "id", "u1")
+	require.NoError(t, h.User(c))
+	assert.Equal(t, http.StatusOK, rec.Code)
+	body := rec.Body.String()
+	assert.Contains(t, body, `"assertionMethod"`)
+	assert.Contains(t, body, `"Multikey"`)
+	assert.Contains(t, body, `#ed25519-key`)
+}
+
+// keypairExtraRepo は wire 済だが該当 user に Ed25519 行がない場合 →
+// AssertionMethod は出力されない (fail-soft fallback)。
+func TestUser_WithEd25519Repo_NoRowForUser(t *testing.T) {
+	h, userRepo, _, keypairRepo := newHandler(t)
+	userRepo.Users["u1"] = &model.User{ID: "u1", Username: "alice"}
+	keypairRepo.items["u1"] = &model.UserKeypair{UserID: "u1", PublicKey: "PUBKEY"}
+	h.SetKeypairExtraRepo(testutil.NewMockUserKeypairExtraRepository())
+
+	c, rec := newReq(t, "id", "u1")
+	require.NoError(t, h.User(c))
+	assert.Equal(t, http.StatusOK, rec.Code)
+	assert.NotContains(t, rec.Body.String(), `"assertionMethod"`)
+}
+
+// keypairExtraRepo が wire 済 + Ed25519 row はあるが PEM が壊れている場合 →
+// silently skip して AssertionMethod を omit する (= RSA only に fail-soft)。
+func TestUser_WithEd25519Repo_MalformedPEM_FailsSoft(t *testing.T) {
+	h, userRepo, _, keypairRepo := newHandler(t)
+	userRepo.Users["u1"] = &model.User{ID: "u1", Username: "alice"}
+	keypairRepo.items["u1"] = &model.UserKeypair{UserID: "u1", PublicKey: "PUBKEY"}
+	extra := testutil.NewMockUserKeypairExtraRepository()
+	require.NoError(t, extra.Upsert(&model.UserKeypairExtra{
+		UserID:            "u1",
+		Ed25519PublicKey:  "NOT-A-VALID-PEM",
+		Ed25519PrivateKey: "STUB",
+	}))
+	h.SetKeypairExtraRepo(extra)
+
+	c, rec := newReq(t, "id", "u1")
+	require.NoError(t, h.User(c))
+	assert.Equal(t, http.StatusOK, rec.Code)
+	assert.NotContains(t, rec.Body.String(), `"assertionMethod"`)
+}
+
 // newBrowserReq builds a non-AP request (no application/activity+json in
 // Accept). Used to exercise the SPA / redirect fallback branch.
 func newBrowserReq(t *testing.T, paramName, paramValue string) (echo.Context, *httptest.ResponseRecorder) {

--- a/internal/server/router.go
+++ b/internal/server/router.go
@@ -1528,6 +1528,9 @@ func (s *Server) setupRoutes() {
 	// ActivityPub resource endpoints
 	apHandler := ap.NewHandler(apRenderer, userService, noteQueryService, keypairRepo, idGen)
 	apHandler.SetRemote(apFetcher, federationResolver)
+	// FEP-521a Multikey 対応で actor JSON に assertionMethod[] を expose する
+	// ため Ed25519 keypair repo を wire (#1067 / #1069)。
+	apHandler.SetKeypairExtraRepo(keypairExtraRepo)
 	// AP リソース系エンドポイントは Accept ヘッダで content negotiation する。
 	// ブラウザからのリロード (Accept: text/html など) では SPA 用の HTML を
 	// 返したいので、フォールバックとして frontendHTML を注入しておく。


### PR DESCRIPTION
## Summary

FEP-521a Multikey 仕様で Ed25519 公開鍵を actor JSON の \`assertionMethod[]\` として expose する。Fedibird など FEP-521a 対応サーバーが mk-go の actor fetch 時に Ed25519 鍵を取得して HTTP Signature を verify できるようにするための拡張。

親 issue: #1067
Closes #1069
依存: P1 #1068 (= PR #1074, merged)

## actor JSON 出力例 (Ed25519 鍵を持つ user)

\`\`\`json
{
  \"@context\": [
    \"https://www.w3.org/ns/activitystreams\",
    \"https://w3id.org/security/v1\",
    \"https://w3id.org/security/multikey/v1\",
    \"https://w3id.org/security/data-integrity/v1\",
    { /* misskey 拡張 */ }
  ],
  \"id\": \"https://example.com/users/abc\",
  \"type\": \"Person\",
  \"publicKey\": {
    \"id\": \"https://example.com/users/abc#main-key\",
    \"publicKeyPem\": \"-----BEGIN PUBLIC KEY-----\\n...RSA...\\n-----END PUBLIC KEY-----\"
  },
  \"assertionMethod\": [
    {
      \"id\": \"https://example.com/users/abc#ed25519-key\",
      \"type\": \"Multikey\",
      \"controller\": \"https://example.com/users/abc\",
      \"publicKeyMultibase\": \"z6Mk...\"
    }
  ]
}
\`\`\`

## drop-in 互換

- Misskey TS の JSON-LD parser は未知 \`assertionMethod\` term を drop。\`publicKey\` (RSA) のみ読む → 連合継続
- mk-go 内部で Ed25519 鍵を持たない user は \`assertionMethod\` を omit する (\`omitempty\` + nil 引数) ため TS 戻し直後の shape と完全一致
- 既存 Note / Activity の context は変更なし (Person 専用に拡張)
- 新規依存 \`github.com/multiformats/go-multibase v0.3.0\` は枯れた FEP-521a 標準ライブラリ

## 主な変更点

### 新規ファイル
- \`internal/activitypub/multikey.go\` — EncodeEd25519Multikey / DecodeEd25519Multikey + ErrInvalidMultikey sentinel
- \`internal/activitypub/multikey_test.go\` — 6 test (round-trip / 既知 zero-key vector / size check / 非 Ed25519 multicodec reject / wrong key length / payload too short / empty)

### 改修
- \`internal/activitypub/keypair.go\` — \`ParseEd25519PublicKeyPEM\` helper 追加 (非 Ed25519 / 不正 PEM は error)
- \`internal/activitypub/types.go\` — \`MultikeyContextURL\` / \`DataIntegrityContextURL\` 定数、\`Multikey\` struct + \`MultikeyType\` 定数、\`Person.AssertionMethod\` field、Person 専用 \`personContext\` 配列
- \`internal/activitypub/renderer.go\` — \`RenderPerson\` の signature を 第 4 引数 \`ed25519PublicKey ed25519.PublicKey\` で拡張、nil なら assertionMethod 省略 / non-nil なら Multikey encode 失敗を fail-soft skip
- \`internal/api/ap/handler.go\` — \`Handler.keypairExtraRepo\` field + \`SetKeypairExtraRepo\` setter + \`lookupEd25519PublicKey\` private helper、3 callsite (User / UserByAcct / ResolveLocalObject) で Ed25519 鍵を引いて渡す
- \`internal/server/router.go\` — \`apHandler.SetKeypairExtraRepo(keypairExtraRepo)\` を P1 と同じ箇所に追加

## テスト

\`\`\`bash
make test          # 全 119 パッケージ pass (e2e_federation 1 件 flaky → 再実行で pass)
go test ./internal/activitypub/ -cover         # 91.1%
go test ./internal/api/ap/ -cover              # 100.0%
\`\`\`

新規 / 拡張 test:
- multikey_test.go: 6 件 (encode/decode / 既知 vector / 全 error path)
- renderer_test.go: AssertionMethodOmittedWhenNoEd25519 / AssertionMethodWithEd25519 (snapshot + round-trip + @context Multikey URL 検証)
- handler_test.go (api/ap): WithEd25519Keypair_ExposesAssertionMethod / NoRowForUser / MalformedPEM_FailsSoft (fail-soft 3 経路)

## 次のステップ

このマージ後、parent #1067 の以下の sub issue に進める:

- P3 (#1070) — Resolver で \`assertionMethod[]\` parse + \`user_publickey_extra\` upsert + keyId dual lookup
- P5 (#1072) — 既存 local user の lazy backfill (Ed25519 鍵が無い user 向け)

P2 がマージされても、現状 Ed25519 鍵を持つ user は **P1 マージ後に新規 signup された user のみ** (= 既存 user の lazy backfill は P5 で対応) なので、本番 actor JSON への影響は限定的。