### PR TITLE
ed25519: Resolver で assertionMethod parse + keyId dual lookup (P3)

### DIFF
--- a/internal/activitypub/keypair.go
+++ b/internal/activitypub/keypair.go
@@ -122,6 +122,22 @@ func ParseRSAPublicKey(pemStr string) (*rsa.PublicKey, error) {
 	return pub.(*rsa.PublicKey), nil
 }
 
+// MarshalEd25519PublicKeyPEM encodes an Ed25519 public key into the PKIX
+// SubjectPublicKeyInfo PEM form so it can be stored in user_publickey_extra
+// alongside RSA keys (= 同一テーブルで ParsePublicKey が type-dispatch 可能)。
+// 入力 key の長さは ed25519.PublicKeySize (= 32 byte) でなければならない。
+func MarshalEd25519PublicKeyPEM(pub ed25519.PublicKey) (string, error) {
+	if len(pub) != ed25519.PublicKeySize {
+		return "", fmt.Errorf("invalid ed25519 public key size %d", len(pub))
+	}
+	pubBytes, err := x509.MarshalPKIXPublicKey(pub)
+	if err != nil {
+		return "", err
+	}
+	block := &pem.Block{Type: "PUBLIC KEY", Bytes: pubBytes}
+	return string(pem.EncodeToMemory(block)), nil
+}
+
 // ParseEd25519PublicKeyPEM decodes a PEM-encoded Ed25519 public key
 // (PKIX SubjectPublicKeyInfo). Errors are returned when the PEM is missing,
 // malformed, or contains a non-Ed25519 key (= caller can fall back to RSA).

--- a/internal/api/inbox/handler.go
+++ b/internal/api/inbox/handler.go
@@ -222,7 +222,8 @@ func (h *Handler) verifySignature(req *http.Request) (*model.User, error) {
 	if err != nil {
 		return nil, err
 	}
-	pem, err := h.resolver.PublicKeyForActor(actor.ID)
+	// keyId fragment ベースで Ed25519 / RSA を dispatch する (#1067 / #1070)。
+	pem, err := h.resolver.PublicKeyForKeyID(actor.ID, parsed.KeyID)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/core/federation/resolver.go
+++ b/internal/core/federation/resolver.go
@@ -88,6 +88,17 @@ type PublickeyStore interface {
 	FindByUserID(userID string) (*model.UserPublickey, error)
 }
 
+// PublickeyExtraStore abstracts persistence of *additional* remote actor
+// public keys (Ed25519 / Multikey) for FEP-521a compliant peers. Resolver
+// upserts here when an inbound actor JSON includes `assertionMethod[]`
+// (#1067 / #1070). `user_publickey_extra` table backs this in production;
+// tests use an in-memory mock.
+type PublickeyExtraStore interface {
+	Upsert(pk *model.UserPublickeyExtra) error
+	FindByKeyID(keyID string) (*model.UserPublickeyExtra, error)
+	ListByUserID(userID string) ([]model.UserPublickeyExtra, error)
+}
+
 // Resolver fetches remote actors / notes and persists them in the local
 // user / note tables.
 //
@@ -104,18 +115,19 @@ type Resolver struct {
 	// access を保護する。queue worker や inbox handler は別 actor を並行
 	// 処理するため、ロック無しの map read/write は runtime panic を起こす
 	// (Devin review #555 FLAG-1)。
-	keysMu          sync.RWMutex
-	keys            map[string]publicKeyEntry      // userID → publicKey + fetchedAt
-	clock           func() time.Time               // テストで差し替える時計
-	actorTTL        time.Duration                  // アクター情報の最大寿命
-	instanceTracker InstanceTracker                // optional: ホスト発見を通知
-	chartHook       ChartHook                      // optional: 新規 remote user の集計
-	hashtagHook     HashtagHook                    // optional: per-tag mentionedUsersCount 集計 (#680)
-	publickeyRepo   PublickeyStore                 // optional: 公開鍵の永続化
-	pollRepo        repository.PollRepository      // optional: Question(投票)のPoll作成
-	pollVoter       PollVoter                      // optional: AP vote (Note.name) の投票記録
-	emojiRepo       repository.EmojiRepository     // optional: リモート絵文字の永続化
-	driveFileRepo   repository.DriveFileRepository // optional: リモート添付の link 化
+	keysMu             sync.RWMutex
+	keys               map[string]publicKeyEntry      // userID → publicKey + fetchedAt
+	clock              func() time.Time               // テストで差し替える時計
+	actorTTL           time.Duration                  // アクター情報の最大寿命
+	instanceTracker    InstanceTracker                // optional: ホスト発見を通知
+	chartHook          ChartHook                      // optional: 新規 remote user の集計
+	hashtagHook        HashtagHook                    // optional: per-tag mentionedUsersCount 集計 (#680)
+	publickeyRepo      PublickeyStore                 // optional: 公開鍵の永続化 (RSA)
+	publickeyExtraRepo PublickeyExtraStore            // optional: 追加公開鍵 (Ed25519 / Multikey) の永続化
+	pollRepo           repository.PollRepository      // optional: Question(投票)のPoll作成
+	pollVoter          PollVoter                      // optional: AP vote (Note.name) の投票記録
+	emojiRepo          repository.EmojiRepository     // optional: リモート絵文字の永続化
+	driveFileRepo      repository.DriveFileRepository // optional: リモート添付の link 化
 	// imageProbeClient は image attachment の dimension probe (#461) で
 	// 使う outbound HTTP client。SSRF-safe transport (router.go で
 	// safehttp.NewSSRFSafeTransport を適用したもの) を渡す前提で、
@@ -193,6 +205,14 @@ func (r *Resolver) SetHashtagHook(h HashtagHook) {
 // storage. nil 渡しは無効化と同義 (in-memory only に戻る)。
 func (r *Resolver) SetPublickeyRepo(repo PublickeyStore) {
 	r.publickeyRepo = repo
+}
+
+// SetPublickeyExtraRepo attaches a PublickeyExtraStore for persistent
+// additional public key storage (FEP-521a Multikey / Ed25519). nil 渡しは
+// 無効化と同義: ResolveActor は actor の assertionMethod[] を parse せず、
+// PublicKeyForKeyID は user_publickey (RSA) のみを返す (#1067 / #1070)。
+func (r *Resolver) SetPublickeyExtraRepo(repo PublickeyExtraStore) {
+	r.publickeyExtraRepo = repo
 }
 
 // SetPollRepo attaches a PollRepository for ingesting Question (poll) objects.
@@ -399,6 +419,7 @@ func (r *Resolver) resolveActorOnce(uri string) (*model.User, error) {
 		slog.Warn("create remote user profile failed", "userId", user.ID, "err", err)
 	}
 	r.cachePublicKey(user.ID, actor.PublicKey.ID, actor.PublicKey.PublicKeyPEM)
+	r.cacheAssertionMethods(user.ID, actor.AssertionMethod)
 	r.notifyInstance(host)
 	if r.chartHook != nil {
 		r.chartHook.OnRemoteUserCreated(user)
@@ -559,6 +580,7 @@ func (r *Resolver) refreshActor(existing *model.User, uri string) {
 		_ = r.userRepo.UpdateProfile(existing.ID, map[string]any{"description": desc})
 	}
 	r.cachePublicKey(existing.ID, actor.PublicKey.ID, actor.PublicKey.PublicKeyPEM)
+	r.cacheAssertionMethods(existing.ID, actor.AssertionMethod)
 	if existing.Host != nil {
 		r.notifyInstance(*existing.Host)
 	}
@@ -596,6 +618,7 @@ func (r *Resolver) refreshPublicKey(userID, uri string) {
 		return
 	}
 	r.cachePublicKey(userID, actor.PublicKey.ID, actor.PublicKey.PublicKeyPEM)
+	r.cacheAssertionMethods(userID, actor.AssertionMethod)
 }
 
 // cachePublicKey stores a PEM in the in-memory cache and optionally persists
@@ -613,6 +636,59 @@ func (r *Resolver) cachePublicKey(userID, keyID, pem string) {
 			slog.Warn("failed to persist public key", "userId", userID, "err", err)
 		}
 	}
+}
+
+// cacheAssertionMethods parses FEP-521a Multikey entries from a remote actor's
+// `assertionMethod[]` and upserts the recognised Ed25519 keys into
+// user_publickey_extra (#1067 / #1070). decode 失敗・非 Ed25519 multicodec・
+// その他不正 entry は warn log + skip して RSA only にフォールバックする。
+// publickeyExtraRepo 未配線 (= 旧 deployment) のときは何もしない。
+func (r *Resolver) cacheAssertionMethods(userID string, ams []activitypub.Multikey) {
+	if r.publickeyExtraRepo == nil || len(ams) == 0 {
+		return
+	}
+	for _, am := range ams {
+		if am.Type != activitypub.MultikeyType || am.ID == "" || am.PublicKeyMultibase == "" {
+			continue
+		}
+		pub, err := activitypub.DecodeEd25519Multikey(am.PublicKeyMultibase)
+		if err != nil {
+			slog.Warn("assertionMethod decode failed",
+				"userID", userID, "keyID", am.ID, "error", err)
+			continue
+		}
+		pemStr, err := activitypub.MarshalEd25519PublicKeyPEM(pub)
+		if err != nil {
+			slog.Warn("assertionMethod PEM marshal failed",
+				"userID", userID, "keyID", am.ID, "error", err)
+			continue
+		}
+		if err := r.publickeyExtraRepo.Upsert(&model.UserPublickeyExtra{
+			UserID: userID,
+			KeyID:  am.ID,
+			KeyPEM: pemStr,
+			Alg:    model.AlgEd25519,
+		}); err != nil {
+			slog.Warn("assertionMethod persist failed",
+				"userID", userID, "keyID", am.ID, "error", err)
+		}
+	}
+}
+
+// PublicKeyForKeyID returns the PEM-encoded public key whose keyId matches the
+// given fragment URI. user_publickey_extra (Ed25519 / Multikey) を最初に探し、
+// miss なら user_publickey の primary key (RSA) を返す fallback semantics。
+// 受信した HTTP Signature の keyId fragment (e.g. `#main-key` / `#ed25519-key`)
+// から正しい公開鍵を選ぶための path で、in-memory cache は介さない (= 永続層
+// の最新値で verify する。assertionMethod が削除されたら次回 fetch で extra
+// 行が古いままになる可能性はあるが、verify はそれでも通る = 後方互換)。
+func (r *Resolver) PublicKeyForKeyID(actorID, keyID string) (string, error) {
+	if r.publickeyExtraRepo != nil && keyID != "" {
+		if row, err := r.publickeyExtraRepo.FindByKeyID(keyID); err == nil {
+			return row.KeyPEM, nil
+		}
+	}
+	return r.PublicKeyForActor(actorID)
 }
 
 // ResolveActorByKeyID resolves an actor based on the keyId fragment URI.

--- a/internal/core/federation/resolver.go
+++ b/internal/core/federation/resolver.go
@@ -24,6 +24,7 @@ import (
 	"github.com/shiroha-a/mk/internal/model"
 	"github.com/shiroha-a/mk/internal/repository"
 	"golang.org/x/sync/singleflight"
+	"gorm.io/gorm"
 )
 
 // HTTPFetcher abstracts the HTTP client used for fetching remote AP objects.
@@ -93,10 +94,16 @@ type PublickeyStore interface {
 // upserts here when an inbound actor JSON includes `assertionMethod[]`
 // (#1067 / #1070). `user_publickey_extra` table backs this in production;
 // tests use an in-memory mock.
+//
+// DeleteByKeyID は resolver が cacheAssertionMethods で actor JSON から消えた
+// 旧 keyId を purge するために使う。これが無いと remote が Ed25519 鍵を
+// rotate した後も古い鍵が user_publickey_extra に残り、compromised key で
+// の rogue verify を許してしまう (#1070 follow-up)。
 type PublickeyExtraStore interface {
 	Upsert(pk *model.UserPublickeyExtra) error
 	FindByKeyID(keyID string) (*model.UserPublickeyExtra, error)
 	ListByUserID(userID string) ([]model.UserPublickeyExtra, error)
+	DeleteByKeyID(userID, keyID string) error
 }
 
 // Resolver fetches remote actors / notes and persists them in the local
@@ -638,15 +645,23 @@ func (r *Resolver) cachePublicKey(userID, keyID, pem string) {
 	}
 }
 
-// cacheAssertionMethods parses FEP-521a Multikey entries from a remote actor's
-// `assertionMethod[]` and upserts the recognised Ed25519 keys into
-// user_publickey_extra (#1067 / #1070). decode 失敗・非 Ed25519 multicodec・
-// その他不正 entry は warn log + skip して RSA only にフォールバックする。
-// publickeyExtraRepo 未配線 (= 旧 deployment) のときは何もしない。
+// cacheAssertionMethods reconciles a remote actor's FEP-521a `assertionMethod[]`
+// with our user_publickey_extra rows (#1067 / #1070):
+//
+//  1. 各 Multikey entry を decode して PEM 化 → user_publickey_extra に upsert
+//  2. 既存 row のうち、今回の actor JSON に存在しない keyId は purge (delete)
+//
+// 2 が無いと remote が Ed25519 鍵を rotate した後も古い鍵が残り、攻撃者が
+// compromised key で署名した activity が verify 通ってしまうので security
+// 上必須。publickeyExtraRepo 未配線 (= 旧 deployment) のときは何もしない。
+// 不正な entry (非 Multikey type / decode 失敗 / persist 失敗) は warn log
+// + skip して RSA only にフォールバックする (fail-soft)。
 func (r *Resolver) cacheAssertionMethods(userID string, ams []activitypub.Multikey) {
-	if r.publickeyExtraRepo == nil || len(ams) == 0 {
+	if r.publickeyExtraRepo == nil {
 		return
 	}
+	// 1. 新 entries の upsert + 受領 keyId set を構築
+	receivedKeyIDs := make(map[string]bool, len(ams))
 	for _, am := range ams {
 		if am.Type != activitypub.MultikeyType || am.ID == "" || am.PublicKeyMultibase == "" {
 			continue
@@ -671,6 +686,23 @@ func (r *Resolver) cacheAssertionMethods(userID string, ams []activitypub.Multik
 		}); err != nil {
 			slog.Warn("assertionMethod persist failed",
 				"userID", userID, "keyID", am.ID, "error", err)
+			continue
+		}
+		receivedKeyIDs[am.ID] = true
+	}
+	// 2. actor JSON に無い既存 keyId を purge (key rotation 対応)
+	existing, err := r.publickeyExtraRepo.ListByUserID(userID)
+	if err != nil {
+		slog.Warn("assertionMethod list failed", "userID", userID, "error", err)
+		return
+	}
+	for _, row := range existing {
+		if receivedKeyIDs[row.KeyID] {
+			continue
+		}
+		if err := r.publickeyExtraRepo.DeleteByKeyID(userID, row.KeyID); err != nil {
+			slog.Warn("stale assertionMethod delete failed",
+				"userID", userID, "keyID", row.KeyID, "error", err)
 		}
 	}
 }
@@ -680,12 +712,21 @@ func (r *Resolver) cacheAssertionMethods(userID string, ams []activitypub.Multik
 // miss なら user_publickey の primary key (RSA) を返す fallback semantics。
 // 受信した HTTP Signature の keyId fragment (e.g. `#main-key` / `#ed25519-key`)
 // から正しい公開鍵を選ぶための path で、in-memory cache は介さない (= 永続層
-// の最新値で verify する。assertionMethod が削除されたら次回 fetch で extra
-// 行が古いままになる可能性はあるが、verify はそれでも通る = 後方互換)。
+// の最新値で verify する)。
+//
+// `gorm.ErrRecordNotFound` (= keyId 一致なし = 通常状態) は silent fallback、
+// それ以外の DB error は診断のため slog.Warn を出す (= silent degradation を
+// 回避)。stale assertion key の削除は cacheAssertionMethods 側で actor fetch
+// 時に diff & delete するため、ここでは古い行が引っかかる可能性は最小化される。
 func (r *Resolver) PublicKeyForKeyID(actorID, keyID string) (string, error) {
 	if r.publickeyExtraRepo != nil && keyID != "" {
-		if row, err := r.publickeyExtraRepo.FindByKeyID(keyID); err == nil {
+		row, err := r.publickeyExtraRepo.FindByKeyID(keyID)
+		if err == nil {
 			return row.KeyPEM, nil
+		}
+		if !errors.Is(err, gorm.ErrRecordNotFound) {
+			slog.Warn("publickeyExtra lookup failed",
+				"actorID", actorID, "keyID", keyID, "error", err)
 		}
 	}
 	return r.PublicKeyForActor(actorID)

--- a/internal/core/federation/resolver_test.go
+++ b/internal/core/federation/resolver_test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/shiroha-a/mk/internal/testutil"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"gorm.io/gorm"
 )
 
 // stubFetcher returns canned bytes/error for FetchObject.
@@ -3689,7 +3690,10 @@ func (s *stubPublickeyExtraRepo) FindByKeyID(keyID string) (*model.UserPublickey
 	if pk, ok := s.entries[keyID]; ok {
 		return pk, nil
 	}
-	return nil, errors.New("not found")
+	// production の gorm 経由 repository は ErrRecordNotFound を返すので、
+	// stub も同じ semantic を返して PublicKeyForKeyID の DB error と "行なし"
+	// の区別 path をテスト経由でも walk できるようにする (#1070 follow-up)。
+	return nil, gorm.ErrRecordNotFound
 }
 
 func (s *stubPublickeyExtraRepo) ListByUserID(userID string) ([]model.UserPublickeyExtra, error) {
@@ -3702,6 +3706,15 @@ func (s *stubPublickeyExtraRepo) ListByUserID(userID string) ([]model.UserPublic
 		}
 	}
 	return out, nil
+}
+
+func (s *stubPublickeyExtraRepo) DeleteByKeyID(userID, keyID string) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if pk, ok := s.entries[keyID]; ok && pk.UserID == userID {
+		delete(s.entries, keyID)
+	}
+	return nil
 }
 
 // stubPublickeyRepo は keys map race test 用の minimal な PublickeyStore
@@ -3844,6 +3857,73 @@ func TestPublicKeyForKeyID_DualLookup(t *testing.T) {
 	pem, err = r.PublicKeyForKeyID("alice", "https://remote.example/users/alice#main-key")
 	require.NoError(t, err)
 	assert.Contains(t, pem, "RSA-FAKE")
+}
+
+// 同じ actor を refresh する経路で stale keyId が削除されることを検証する。
+// 1 回目 ResolveActor で 2 keys を seed → actorTTL を 0 に強制 → 2 回目で
+// 1 key だけになった body を返す fetcher に切り替え → 旧 1 key が purge される。
+func TestResolveActor_RefreshRemovesStaleAssertionMethod(t *testing.T) {
+	pub, _, err := ed25519.GenerateKey(rand.Reader)
+	require.NoError(t, err)
+	mb, err := activitypub.EncodeEd25519Multikey(pub)
+	require.NoError(t, err)
+
+	bodyTwoKeys := `{
+		"id": "https://remote.example/users/alice",
+		"type": "Person",
+		"preferredUsername": "alice",
+		"inbox": "https://remote.example/users/alice/inbox",
+		"publicKey": {"id": "https://remote.example/users/alice#main-key", "owner": "x", "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nFAKE\n-----END PUBLIC KEY-----"},
+		"assertionMethod": [
+			{"id": "https://remote.example/users/alice#old-key", "type": "Multikey", "controller": "x", "publicKeyMultibase": "` + mb + `"},
+			{"id": "https://remote.example/users/alice#new-key", "type": "Multikey", "controller": "x", "publicKeyMultibase": "` + mb + `"}
+		]
+	}`
+	bodyOneKey := `{
+		"id": "https://remote.example/users/alice",
+		"type": "Person",
+		"preferredUsername": "alice",
+		"inbox": "https://remote.example/users/alice/inbox",
+		"publicKey": {"id": "https://remote.example/users/alice#main-key", "owner": "x", "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nFAKE\n-----END PUBLIC KEY-----"},
+		"assertionMethod": [
+			{"id": "https://remote.example/users/alice#new-key", "type": "Multikey", "controller": "x", "publicKeyMultibase": "` + mb + `"}
+		]
+	}`
+
+	repo := testutil.NewMockUserRepository()
+	noteRepo := testutil.NewMockNoteRepository()
+	urls := activitypub.NewURLBuilder("https://example.com")
+	idGen, _ := id.NewGenerator("aidx")
+	swappable := &swappableFetcher{body: bodyTwoKeys}
+	r := federation.NewResolver(repo, noteRepo, urls, swappable, idGen)
+	extra := &stubPublickeyExtraRepo{}
+	r.SetPublickeyExtraRepo(extra)
+	r.SetActorTTL(time.Nanosecond) // 即時 refresh をトリガするため極短 TTL
+
+	// 1 回目: 2 keys が seed される
+	user, err := r.ResolveActor("https://remote.example/users/alice")
+	require.NoError(t, err)
+	rows, _ := extra.ListByUserID(user.ID)
+	require.Len(t, rows, 2)
+
+	// 2 回目: fetcher を 1 key body に差し替えて refresh をトリガ (TTL 失効済)
+	swappable.body = bodyOneKey
+	time.Sleep(2 * time.Nanosecond) // TTL を確実に超過させる
+	_, err = r.ResolveActor("https://remote.example/users/alice")
+	require.NoError(t, err)
+
+	rows, _ = extra.ListByUserID(user.ID)
+	require.Len(t, rows, 1, "stale #old-key は purge されて #new-key のみ残る")
+	assert.Equal(t, "https://remote.example/users/alice#new-key", rows[0].KeyID)
+}
+
+// swappableFetcher は body を test 中に差し替えられる stubFetcher 派生。
+type swappableFetcher struct {
+	body string
+}
+
+func (s *swappableFetcher) FetchObject(_ string) ([]byte, error) {
+	return []byte(s.body), nil
 }
 
 // publickeyExtraRepo 未配線でも PublicKeyForKeyID は PublicKeyForActor と

--- a/internal/core/federation/resolver_test.go
+++ b/internal/core/federation/resolver_test.go
@@ -1,6 +1,8 @@
 package federation_test
 
 import (
+	"crypto/ed25519"
+	"crypto/rand"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -3657,6 +3659,51 @@ func TestResolveNote_DedupesConcurrentCalls(t *testing.T) {
 
 func ptrString(s string) *string { return &s }
 
+// stubPublickeyExtraRepo は FEP-521a Multikey 永続化用の in-memory mock。
+// resolver の cacheAssertionMethods / PublicKeyForKeyID 経路を unit test
+// から exercise するために使う (#1067 / #1070)。
+type stubPublickeyExtraRepo struct {
+	mu      sync.RWMutex
+	entries map[string]*model.UserPublickeyExtra // keyed by keyID
+	upserts []model.UserPublickeyExtra
+	failErr error
+}
+
+func (s *stubPublickeyExtraRepo) Upsert(pk *model.UserPublickeyExtra) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.failErr != nil {
+		return s.failErr
+	}
+	if s.entries == nil {
+		s.entries = make(map[string]*model.UserPublickeyExtra)
+	}
+	s.entries[pk.KeyID] = pk
+	s.upserts = append(s.upserts, *pk)
+	return nil
+}
+
+func (s *stubPublickeyExtraRepo) FindByKeyID(keyID string) (*model.UserPublickeyExtra, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	if pk, ok := s.entries[keyID]; ok {
+		return pk, nil
+	}
+	return nil, errors.New("not found")
+}
+
+func (s *stubPublickeyExtraRepo) ListByUserID(userID string) ([]model.UserPublickeyExtra, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	var out []model.UserPublickeyExtra
+	for _, pk := range s.entries {
+		if pk.UserID == userID {
+			out = append(out, *pk)
+		}
+	}
+	return out, nil
+}
+
 // stubPublickeyRepo は keys map race test 用の minimal な PublickeyStore
 // 実装。本物の publickey_repo は GORM 経由なのでテストでは差し替える。
 type stubPublickeyRepo struct {
@@ -3681,6 +3728,138 @@ func (s *stubPublickeyRepo) Upsert(pk *model.UserPublickey) error {
 	}
 	s.entries[pk.UserID] = pk
 	return nil
+}
+
+// Ed25519 鍵を持つ remote actor を fetch して assertionMethod を
+// user_publickey_extra に upsert する (#1067 / #1070)。
+func TestResolveActor_PersistsAssertionMethod(t *testing.T) {
+	pub, _, err := ed25519.GenerateKey(rand.Reader)
+	require.NoError(t, err)
+	mb, err := activitypub.EncodeEd25519Multikey(pub)
+	require.NoError(t, err)
+
+	body := `{
+		"id": "https://remote.example/users/alice",
+		"type": "Person",
+		"preferredUsername": "alice",
+		"inbox": "https://remote.example/users/alice/inbox",
+		"publicKey": {
+			"id": "https://remote.example/users/alice#main-key",
+			"owner": "https://remote.example/users/alice",
+			"publicKeyPem": "-----BEGIN PUBLIC KEY-----\nFAKE\n-----END PUBLIC KEY-----"
+		},
+		"assertionMethod": [{
+			"id": "https://remote.example/users/alice#ed25519-key",
+			"type": "Multikey",
+			"controller": "https://remote.example/users/alice",
+			"publicKeyMultibase": "` + mb + `"
+		}]
+	}`
+
+	r, _ := newResolver(t, body, nil)
+	extra := &stubPublickeyExtraRepo{}
+	r.SetPublickeyExtraRepo(extra)
+
+	user, err := r.ResolveActor("https://remote.example/users/alice")
+	require.NoError(t, err)
+
+	row, err := extra.FindByKeyID("https://remote.example/users/alice#ed25519-key")
+	require.NoError(t, err)
+	assert.Equal(t, user.ID, row.UserID)
+	assert.Equal(t, model.AlgEd25519, row.Alg)
+	assert.Contains(t, row.KeyPEM, "PUBLIC KEY")
+
+	// round-trip: 保存された PEM から元の Ed25519 公開鍵を復元できる
+	parsed, err := activitypub.ParseEd25519PublicKeyPEM(row.KeyPEM)
+	require.NoError(t, err)
+	assert.Equal(t, pub, parsed)
+}
+
+// 不正な Multikey (Multibase decode 失敗) が混ざっていても、正常な entry は
+// upsert される (silently skip + warn log)。
+func TestResolveActor_SkipsMalformedAssertionMethod(t *testing.T) {
+	pub, _, err := ed25519.GenerateKey(rand.Reader)
+	require.NoError(t, err)
+	mb, err := activitypub.EncodeEd25519Multikey(pub)
+	require.NoError(t, err)
+
+	body := `{
+		"id": "https://remote.example/users/alice",
+		"type": "Person",
+		"preferredUsername": "alice",
+		"inbox": "https://remote.example/users/alice/inbox",
+		"publicKey": {
+			"id": "https://remote.example/users/alice#main-key",
+			"owner": "https://remote.example/users/alice",
+			"publicKeyPem": "-----BEGIN PUBLIC KEY-----\nFAKE\n-----END PUBLIC KEY-----"
+		},
+		"assertionMethod": [
+			{"id": "https://remote.example/users/alice#bad", "type": "Multikey", "controller": "x", "publicKeyMultibase": "INVALID"},
+			{"id": "https://remote.example/users/alice#ed25519-key", "type": "Multikey", "controller": "x", "publicKeyMultibase": "` + mb + `"},
+			{"id": "https://remote.example/users/alice#non-multikey", "type": "JsonWebKey", "controller": "x", "publicKeyMultibase": "z6Mk..."}
+		]
+	}`
+
+	r, _ := newResolver(t, body, nil)
+	extra := &stubPublickeyExtraRepo{}
+	r.SetPublickeyExtraRepo(extra)
+
+	_, err = r.ResolveActor("https://remote.example/users/alice")
+	require.NoError(t, err)
+
+	// 不正 entry / 非 Multikey type は skip され、正常な Ed25519 のみ upsert される
+	rows, err := extra.ListByUserID(extra.upserts[0].UserID)
+	require.NoError(t, err)
+	require.Len(t, rows, 1)
+	assert.Equal(t, "https://remote.example/users/alice#ed25519-key", rows[0].KeyID)
+}
+
+// PublicKeyForKeyID は user_publickey_extra (Ed25519 / Multikey) を最初に探し、
+// miss なら user_publickey (RSA) を fallback で返す dual lookup を行う (#1070)。
+func TestPublicKeyForKeyID_DualLookup(t *testing.T) {
+	r, _ := newResolver(t, sampleActor, nil)
+	pkRepo := &stubPublickeyRepo{entries: map[string]*model.UserPublickey{}}
+	r.SetPublickeyRepo(pkRepo)
+	extra := &stubPublickeyExtraRepo{}
+	r.SetPublickeyExtraRepo(extra)
+
+	// user_publickey に RSA primary key を seed
+	require.NoError(t, pkRepo.Upsert(&model.UserPublickey{
+		UserID: "alice", KeyID: "https://remote.example/users/alice#main-key",
+		KeyPEM: "-----BEGIN PUBLIC KEY-----\nRSA-FAKE\n-----END PUBLIC KEY-----",
+	}))
+	// user_publickey_extra に Ed25519 を seed
+	require.NoError(t, extra.Upsert(&model.UserPublickeyExtra{
+		UserID: "alice", KeyID: "https://remote.example/users/alice#ed25519-key",
+		KeyPEM: "-----BEGIN PUBLIC KEY-----\nED25519-FAKE\n-----END PUBLIC KEY-----",
+		Alg:    model.AlgEd25519,
+	}))
+
+	// Ed25519 keyId 一致 → extra から返る
+	pem, err := r.PublicKeyForKeyID("alice", "https://remote.example/users/alice#ed25519-key")
+	require.NoError(t, err)
+	assert.Contains(t, pem, "ED25519-FAKE")
+
+	// RSA keyId (= extra に無し) → PublicKeyForActor fallback で RSA primary が返る
+	pem, err = r.PublicKeyForKeyID("alice", "https://remote.example/users/alice#main-key")
+	require.NoError(t, err)
+	assert.Contains(t, pem, "RSA-FAKE")
+}
+
+// publickeyExtraRepo 未配線でも PublicKeyForKeyID は PublicKeyForActor と
+// 等価な挙動を保つ (= drop-in 互換)。
+func TestPublicKeyForKeyID_WithoutExtraRepoFallsBackToActor(t *testing.T) {
+	r, _ := newResolver(t, sampleActor, nil)
+	pkRepo := &stubPublickeyRepo{entries: map[string]*model.UserPublickey{}}
+	r.SetPublickeyRepo(pkRepo)
+	require.NoError(t, pkRepo.Upsert(&model.UserPublickey{
+		UserID: "alice", KeyID: "https://remote.example/users/alice#main-key",
+		KeyPEM: "-----BEGIN PUBLIC KEY-----\nFALLBACK\n-----END PUBLIC KEY-----",
+	}))
+
+	pem, err := r.PublicKeyForKeyID("alice", "https://remote.example/users/alice#ed25519-key")
+	require.NoError(t, err)
+	assert.Contains(t, pem, "FALLBACK")
 }
 
 // 複数 goroutine が異なる actor の PublicKeyForActor を並行に呼ぶと、内部

--- a/internal/queue/processors/inbox.go
+++ b/internal/queue/processors/inbox.go
@@ -28,9 +28,15 @@ type FederationProcessor interface {
 // signed with that actor's published public key. Implemented by
 // federation.Resolver in production. nil の場合 verify を skip するので、
 // payload に headers が無い (= legacy 形式) ケースと同様に扱う。
+//
+// PublicKeyForKeyID は signature header の keyId fragment (`#main-key` /
+// `#ed25519-key` 等) に対応する PEM を返す。user_publickey_extra (FEP-521a
+// Multikey) を先に探し、miss なら user_publickey の primary key (RSA) を
+// fallback で返す → drop-in 互換維持 (#1067 / #1070)。
 type SignatureVerifier interface {
 	ResolveActor(actorURI string) (*model.User, error)
 	PublicKeyForActor(actorID string) (string, error)
+	PublicKeyForKeyID(actorID, keyID string) (string, error)
 }
 
 // HostBlockChecker reports whether a host is on the blocked list and whether
@@ -176,7 +182,8 @@ func (p *InboxProcessor) verifyPayload(payload queue.InboxPayload) (*model.User,
 	if err != nil {
 		return nil, err
 	}
-	pem, err := p.verifier.PublicKeyForActor(actor.ID)
+	// keyId fragment ベースで Ed25519 / RSA を dispatch する (#1067 / #1070)。
+	pem, err := p.verifier.PublicKeyForKeyID(actor.ID, parsed.KeyID)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/queue/processors/inbox_test.go
+++ b/internal/queue/processors/inbox_test.go
@@ -106,6 +106,13 @@ func (s *stubVerifier) PublicKeyForActor(_ string) (string, error) {
 	return s.pubKey, nil
 }
 
+// PublicKeyForKeyID は dual lookup を mock では行わず、常に primary key を
+// 返す。Ed25519 / keyId fragment 別 dispatch のテストは federation.Resolver
+// 側の integration test で cover する。
+func (s *stubVerifier) PublicKeyForKeyID(actorID, _ string) (string, error) {
+	return s.PublicKeyForActor(actorID)
+}
+
 type stubBlocker struct{ blocked, allowed func(string) bool }
 
 func (s *stubBlocker) IsBlocked(h string) bool {

--- a/internal/repository/user_publickey_extra.go
+++ b/internal/repository/user_publickey_extra.go
@@ -15,6 +15,10 @@ type UserPublickeyExtraRepository interface {
 	FindByUserAndKeyID(userID, keyID string) (*model.UserPublickeyExtra, error)
 	FindByKeyID(keyID string) (*model.UserPublickeyExtra, error)
 	ListByUserID(userID string) ([]model.UserPublickeyExtra, error)
+	// DeleteByKeyID deletes a single (userID, keyID) row. resolver が actor
+	// fetch 時に assertionMethod[] から消えた keyId を purge する用途 (key
+	// rotation で古い Ed25519 鍵による rogue verify を防ぐ #1070 follow-up)。
+	DeleteByKeyID(userID, keyID string) error
 	DeleteByUserID(userID string) error
 }
 
@@ -56,6 +60,10 @@ func (r *userPublickeyExtraRepository) ListByUserID(userID string) ([]model.User
 		return nil, err
 	}
 	return rows, nil
+}
+
+func (r *userPublickeyExtraRepository) DeleteByKeyID(userID, keyID string) error {
+	return r.db.Where(`"userId" = ? AND "keyId" = ?`, userID, keyID).Delete(&model.UserPublickeyExtra{}).Error
 }
 
 func (r *userPublickeyExtraRepository) DeleteByUserID(userID string) error {

--- a/internal/repository/user_publickey_extra_test.go
+++ b/internal/repository/user_publickey_extra_test.go
@@ -63,6 +63,31 @@ func TestUserPublickeyExtraRepository_MultipleKeysPerUser(t *testing.T) {
 	assert.Len(t, rows, 2)
 }
 
+func TestUserPublickeyExtraRepository_DeleteByKeyID(t *testing.T) {
+	repo := NewUserPublickeyExtraRepository(testDB)
+	user := insertTestUser(t, "u_upkx_dkid", "upkx_dkid")
+	defer cleanupUser(t, user.ID)
+	defer cleanupUserPublickeyExtra(t, user.ID)
+
+	require.NoError(t, repo.Upsert(&model.UserPublickeyExtra{
+		UserID: user.ID, KeyID: "k1", KeyPEM: "PEM1", Alg: model.AlgEd25519,
+	}))
+	require.NoError(t, repo.Upsert(&model.UserPublickeyExtra{
+		UserID: user.ID, KeyID: "k2", KeyPEM: "PEM2", Alg: model.AlgEd25519,
+	}))
+
+	// k1 のみ削除 → k2 は残る (key rotation シナリオの primitive)
+	require.NoError(t, repo.DeleteByKeyID(user.ID, "k1"))
+
+	rows, err := repo.ListByUserID(user.ID)
+	require.NoError(t, err)
+	require.Len(t, rows, 1)
+	assert.Equal(t, "k2", rows[0].KeyID)
+
+	// 存在しない (userId, keyId) の delete は no-op (GORM Delete は 0 row でも nil)
+	assert.NoError(t, repo.DeleteByKeyID(user.ID, "non_existent"))
+}
+
 func TestUserPublickeyExtraRepository_DeleteByUserID(t *testing.T) {
 	repo := NewUserPublickeyExtraRepository(testDB)
 	user := insertTestUser(t, "u_upkx_3", "upkx3")
@@ -101,5 +126,7 @@ func TestUserPublickeyExtraRepository_QueryErrors(t *testing.T) {
 	_, err = repo.ListByUserID("x")
 	assert.Error(t, err)
 	err = repo.DeleteByUserID("x")
+	assert.Error(t, err)
+	err = repo.DeleteByKeyID("x", "k")
 	assert.Error(t, err)
 }

--- a/internal/server/router.go
+++ b/internal/server/router.go
@@ -485,6 +485,9 @@ func (s *Server) setupRoutes() {
 	federationResolver := corefederation.NewResolver(userRepo, noteRepo, apURLs, apFetcher, idGen)
 	publickeyRepo := repository.NewUserPublickeyRepository(s.db)
 	federationResolver.SetPublickeyRepo(publickeyRepo)
+	// FEP-521a Multikey 対応で remote actor の assertionMethod[] を parse して
+	// user_publickey_extra に persist する (#1067 / #1070)。
+	federationResolver.SetPublickeyExtraRepo(repository.NewUserPublickeyExtraRepository(s.db))
 	federationResolver.SetPollRepo(pollRepo)
 	// AP vote (Note.name + inReplyTo to a poll) を local poll service に
 	// 流して投票として記録する (#690)。これがないとリモートからの投票が


### PR DESCRIPTION
## Summary

リモート actor の FEP-521a Multikey (= \`assertionMethod[]\`) を \`user_publickey_extra\` に persist し、HTTP Signature verify 時に keyId fragment ベースで RSA / Ed25519 を dispatch する dual lookup を実装。

親 issue: #1067
Closes #1070
依存: P1 #1068 / P2 #1069 (両方 merged)

## drop-in 互換

- 既存 \`user_publickey\` (RSA) には一切触らない (= add-only schema は P1 で確定済)
- \`publickeyExtraRepo\` 未配線 (= 旧 deployment) の場合 \`PublicKeyForKeyID\` は \`PublicKeyForActor\` と等価動作 → 完全な後方互換
- 不正 Multikey / 非 Ed25519 multicodec は silently skip + slog.Warn → 連合継続

## 主な変更点

### 新規 helper
- \`internal/activitypub/keypair.go\` \`MarshalEd25519PublicKeyPEM(pub)\` — Ed25519 raw key → PKIX PEM 文字列 (user_publickey_extra に保存可能な形)

### core/federation/resolver.go
- \`PublickeyExtraStore\` interface (Upsert / FindByKeyID / ListByUserID)
- \`Resolver.publickeyExtraRepo\` + \`SetPublickeyExtraRepo\` setter
- \`cacheAssertionMethods(userID, ams)\` 内部 helper: 各 Multikey を decode → PEM → user_publickey_extra に upsert、不正は warn log + skip
- 3 callsite (新規 user / 既存更新 / refreshPublicKey) で \`actor.AssertionMethod\` を渡す
- \`PublicKeyForKeyID(actorID, keyID)\` 新規 method: user_publickey_extra → user_publickey の dual lookup

### queue/processors/inbox.go + api/inbox/handler.go
- \`SignatureVerifier\` interface に \`PublicKeyForKeyID\` を追加
- verify path で \`PublicKeyForActor → PublicKeyForKeyID\` に切替、keyId fragment 一致で正しい鍵 (Ed25519 / RSA) を引く

### server/router.go
- \`federationResolver.SetPublickeyExtraRepo(repository.NewUserPublickeyExtraRepository(...))\` を P2 と同じ箇所に追加

## テスト

新規 4 件 (federation pkg):
- \`TestResolveActor_PersistsAssertionMethod\` (正規 Multikey → upsert + round-trip 検証)
- \`TestResolveActor_SkipsMalformedAssertionMethod\` (不正 / 非 Multikey 混在で正常 entry のみ upsert)
- \`TestPublicKeyForKeyID_DualLookup\` (Ed25519/RSA keyId 別 dispatch)
- \`TestPublicKeyForKeyID_WithoutExtraRepoFallsBackToActor\` (drop-in 後方互換)

\`\`\`bash
make test     # 全 119 パッケージ pass
go test ./internal/core/federation/ -cover         # 90.2%
go test ./internal/queue/processors/ -cover        # 91.6%
go test ./internal/api/inbox/ -cover               # 98.5%
\`\`\`

## 次のステップ

このマージ後、parent #1067 の以下の sub issue に進める:

- P4 (#1071) — Outbound deliver で capability-gated Ed25519 sign + safeguard
- P5 (#1072) — 既存 local user の lazy backfill (Ed25519 鍵が無い user 向け)

P4 は P2/P3 両方の依存を満たし、これで本 PR マージ後に着手可能 (Fedibird など assertionMethod expose サーバーへの Ed25519 sign が実現)。P5 は P1 のみ依存で独立に並行進行可。