### PR TITLE
ed25519: Outbound deliver で capability-gated Ed25519 sign + degrade safeguard (P4)

### DIFF
--- a/docs/federation.md
+++ b/docs/federation.md
@@ -82,6 +82,31 @@ DeliverProcessor (asynqワーカー)
 - その他の4xx: 永続的失敗、リトライしない
 - 5xx / ネットワークエラー: リトライ (不調状態としてマーク)
 
+### Ed25519署名 (capability-gated, #1067 / #1071)
+
+配送先 actor が FEP-521a Multikey で Ed25519 を expose し、sender が `user_keypair_extra` に Ed25519 鍵を持つ場合のみ Ed25519 で sign を試行する。それ以外は従来通り RSA で sign。
+
+**capability 判定の流れ:**
+
+1. `DeliverToUser(signerUserID, recipient *model.User, body)` で recipient が既知
+2. `recipientIsEd25519Capable(recipient)`: `user_publickey_extra` を `ListByUserID(recipient.ID)` で確認 (TTL 5min の in-memory cache あり、N+1 抑制)
+3. capable で sender も Ed25519 鍵を持つ → `DeliverPayload.Ed25519KeyID` / `Ed25519PrivPEM` に詰めて enqueue
+4. `DeliverProcessor` 側で Ed25519 sign を試行、4xx (410/404 除く) で失敗したら Redis に `ed25519:fail:{host}` を INCR
+5. 60s window 内に 3 件以上失敗 → `ed25519:degrade:{host}` を EX=5min で立てる
+6. degrade flag 立ち host への次回 deliver は最初から RSA で sign (= broken impl safety net)
+
+`DeliverActivity` / `DeliverToFollowers` 経路 (recipient 不明) は RSA only で動く。
+
+### Redis に格納される秘密情報
+
+DeliverPayload は `KeyPEM` (RSA private key) および `Ed25519PrivPEM` (Ed25519 private key) を含んだ JSON として asynq queue (= Redis) に書き込まれる。これは upstream Misskey TS の BullMQ payload と同じ pattern だが、本番運用では以下が推奨される:
+
+- **Redis 通信の TLS 化** (in-transit 暗号化)
+- **Redis の persistence 暗号化** (encrypt-at-rest、Disk full encryption / Redis Enterprise の透過暗号化など)
+- queue worker と Redis 間のネットワーク隔離 (private VPC / Unix socket)
+
+特に Ed25519 / RSA いずれも HTTP Signature の identity を担う秘密情報のため、queue server を信頼境界の内側に置くこと。
+
 ## Inbox処理
 
 `internal/api/inbox/handler.go`がShared InboxとユーザーInboxの両方を処理する。**verify-in-worker 化済 (#565)**: HTTP handler では body + signature header を payload として queue に詰めて 202 即返し、verify は inbox worker (asynq processor) で行う。これにより HTTP 受信スループットが TS の 2.6-2.8x。

--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.26.2
 
 require (
 	github.com/SherClockHolmes/webpush-go v1.4.0
+	github.com/alicebob/miniredis/v2 v2.38.0
 	github.com/aws/aws-sdk-go-v2 v1.41.5
 	github.com/aws/aws-sdk-go-v2/credentials v1.19.14
 	github.com/aws/aws-sdk-go-v2/service/s3 v1.99.0
@@ -150,6 +151,7 @@ require (
 	github.com/vmihailenco/msgpack/v5 v5.4.1 // indirect
 	github.com/vmihailenco/tagparser/v2 v2.0.0 // indirect
 	github.com/x448/float16 v0.8.4 // indirect
+	github.com/yuin/gopher-lua v1.1.1 // indirect
 	github.com/yusufpapurcu/wmi v1.2.4 // indirect
 	go.opentelemetry.io/auto/sdk v1.2.1 // indirect
 	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.61.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -12,6 +12,8 @@ github.com/PuerkitoBio/goquery v1.8.0 h1:PJTF7AmFCFKk1N6V6jmKfrNH9tV5pNE6lZMkG0g
 github.com/PuerkitoBio/goquery v1.8.0/go.mod h1:ypIiRMtY7COPGk+I/YbZLbxsxn9g5ejnI2HSMtkjZvI=
 github.com/SherClockHolmes/webpush-go v1.4.0 h1:ocnzNKWN23T9nvHi6IfyrQjkIc0oJWv1B1pULsf9i3s=
 github.com/SherClockHolmes/webpush-go v1.4.0/go.mod h1:XSq8pKX11vNV8MJEMwjrlTkxhAj1zKfxmyhdV7Pd6UA=
+github.com/alicebob/miniredis/v2 v2.38.0 h1:nZAzCR+Lj+Vxk4ZXzm2NuKq2O33RXj1XxJ2e2uP9jiw=
+github.com/alicebob/miniredis/v2 v2.38.0/go.mod h1:TcL7YfarKPGDAthEtl5NBeHZfeUQj6OXMm/+iu5cLMM=
 github.com/andybalholm/brotli v1.1.1 h1:PR2pgnyFznKEugtsUo0xLdDop5SKXd5Qf5ysW+7XdTA=
 github.com/andybalholm/brotli v1.1.1/go.mod h1:05ib4cKhjx3OQYUY22hTVd34Bc8upXjOLL2rKwwZBoA=
 github.com/andybalholm/cascadia v1.3.1 h1:nhxRkql1kdYCc8Snf7D5/D3spOX+dBgjA6u8x004T2c=
@@ -325,6 +327,8 @@ github.com/x448/float16 v0.8.4/go.mod h1:14CWIYCyZA/cWjXOioeEpHeN/83MdbZDRQHoFcY
 github.com/xyproto/randomstring v1.0.5 h1:YtlWPoRdgMu3NZtP45drfy1GKoojuR7hmRcnhZqKjWU=
 github.com/xyproto/randomstring v1.0.5/go.mod h1:rgmS5DeNXLivK7YprL0pY+lTuhNQW3iGxZ18UQApw/E=
 github.com/yuin/goldmark v1.4.13/go.mod h1:6yULJ656Px+3vBD8DxQVa3kxgyrAnzto9xy5taEt/CY=
+github.com/yuin/gopher-lua v1.1.1 h1:kYKnWBjvbNP4XLT3+bPEwAXJx262OhaHDWDVOPjL46M=
+github.com/yuin/gopher-lua v1.1.1/go.mod h1:GBR0iDaNXjAgGg9zfCvksxSRnQx76gclCIb7kdAd1Pw=
 github.com/yusufpapurcu/wmi v1.2.4 h1:zFUKzehAFReQwLys1b/iSMl+JQGSCSjtVqQn9bBrPo0=
 github.com/yusufpapurcu/wmi v1.2.4/go.mod h1:SBZ9tNy3G9/m5Oi98Zks0QjeHVDvuK0qfxQmPyzfmi0=
 github.com/zeebo/xxh3 v1.0.2 h1:xZmwmqxHZA8AI603jOQ0tMqmBr9lPeFwGg6d+xy9DC0=

--- a/internal/core/federation/deliver_service.go
+++ b/internal/core/federation/deliver_service.go
@@ -38,12 +38,14 @@ type HostBlockChecker interface {
 // 配信先計算と enqueue を分離するため、実際のHTTP送信は queue/processors の
 // DeliverProcessor が担当する。
 type DeliverService struct {
-	enqueuer      queue.Enqueuer
-	userRepo      repository.UserRepository
-	followingRepo repository.FollowingRepository
-	keypairRepo   repository.UserKeypairRepository
-	urls          *activitypub.URLBuilder
-	hostBlocker   HostBlockChecker
+	enqueuer           queue.Enqueuer
+	userRepo           repository.UserRepository
+	followingRepo      repository.FollowingRepository
+	keypairRepo        repository.UserKeypairRepository
+	keypairExtraRepo   repository.UserKeypairExtraRepository   // optional: sender Ed25519 鍵
+	publickeyExtraRepo repository.UserPublickeyExtraRepository // optional: recipient capability 判定
+	urls               *activitypub.URLBuilder
+	hostBlocker        HostBlockChecker
 	// syncDeliverHook, when non-nil, replaces the asynq enqueue with an
 	// inline call to the hook. test 専用で federation deliver の queue 経路
 	// を bypass し、sign + HTTP POST を同期実行する e2e_federation 用。
@@ -74,6 +76,21 @@ func (s *DeliverService) SetHostBlockChecker(c HostBlockChecker) {
 	s.hostBlocker = c
 }
 
+// SetKeypairExtraRepo wires the Ed25519 keypair repository so sender が
+// Ed25519 鍵を持つ場合に DeliverActivityWithRecipient 経路で Ed25519 sign
+// 情報を payload に詰めることができる。未配線なら全配送 RSA fallback
+// (= 旧 deployment と完全互換 / drop-in 維持) (#1067 / #1071)。
+func (s *DeliverService) SetKeypairExtraRepo(r repository.UserKeypairExtraRepository) {
+	s.keypairExtraRepo = r
+}
+
+// SetPublickeyExtraRepo wires the remote Multikey repository so recipient の
+// Ed25519 capability を user_publickey_extra で判定できる。未配線なら全配送
+// RSA fallback (#1067 / #1071)。
+func (s *DeliverService) SetPublickeyExtraRepo(r repository.UserPublickeyExtraRepository) {
+	s.publickeyExtraRepo = r
+}
+
 // SetSyncDeliverHookForTest replaces the asynq enqueue with an inline
 // synchronous call. Used by e2e_federation tests to bypass the queue layer
 // and exercise the sign + POST + inbox handling path directly. Not for
@@ -86,14 +103,38 @@ func (s *DeliverService) SetSyncDeliverHookForTest(fn func(payload queue.Deliver
 
 // DeliverActivity enqueues a deliver job for each unique inbox in inboxes.
 // signerUserID は署名に使うローカルユーザー。ブロック対象ホストの inbox は
-// スキップする。
+// スキップする。受信者の actor 情報を caller が持たない経路 (= followers /
+// inbox list ベース) は RSA only で配送される。受信者 actor URI が分かる
+// 場合は DeliverActivityWithRecipient を使うと FEP-521a Multikey 対応サーバー
+// 向けに Ed25519 sign が試行される (#1067 / #1071)。
 func (s *DeliverService) DeliverActivity(signerUserID string, body []byte, inboxes []string) error {
+	return s.deliverInternal(signerUserID, body, inboxes, nil)
+}
+
+// DeliverActivityWithRecipient is DeliverActivity + recipient capability based
+// Ed25519 sign 試行。recipient が user_publickey_extra に Ed25519 鍵を持ち、
+// sender が user_keypair_extra に Ed25519 鍵を持つ場合、payload に Ed25519
+// 鍵情報も詰める (DeliverProcessor 側で実際の sign 分岐 + degrade safeguard
+// を担う)。recipient == nil なら DeliverActivity と等価動作 (#1067 / #1071)。
+func (s *DeliverService) DeliverActivityWithRecipient(signerUserID string, body []byte, inboxes []string, recipient *model.User) error {
+	return s.deliverInternal(signerUserID, body, inboxes, recipient)
+}
+
+func (s *DeliverService) deliverInternal(signerUserID string, body []byte, inboxes []string, recipient *model.User) error {
 	if len(inboxes) == 0 {
 		return nil
 	}
 	keyID, keyPEM, err := s.signerCredentials(signerUserID)
 	if err != nil {
 		return err
+	}
+	// Ed25519 sign 経路を試行できるのは recipient が Ed25519 capable
+	// (assertionMethod を持つ) + sender が Ed25519 keypair を持つ両方が
+	// 真のときのみ。どちらかが false なら edKeyID/edPrivPEM は空のまま payload
+	// に詰められ、DeliverProcessor は従来通り RSA で sign する。
+	var edKeyID, edPrivPEM string
+	if recipient != nil && s.recipientIsEd25519Capable(recipient) {
+		edKeyID, edPrivPEM = s.signerEd25519Credentials(signerUserID)
 	}
 	seen := make(map[string]struct{}, len(inboxes))
 	for _, inbox := range inboxes {
@@ -108,10 +149,12 @@ func (s *DeliverService) DeliverActivity(signerUserID string, body []byte, inbox
 		}
 		seen[inbox] = struct{}{}
 		payload := queue.DeliverPayload{
-			Inbox:  inbox,
-			Body:   body,
-			KeyID:  keyID,
-			KeyPEM: keyPEM,
+			Inbox:          inbox,
+			Body:           body,
+			KeyID:          keyID,
+			KeyPEM:         keyPEM,
+			Ed25519KeyID:   edKeyID,
+			Ed25519PrivPEM: edPrivPEM,
 		}
 		if s.syncDeliverHook != nil {
 			// test 経路 (#780): queue を経由せず inline で sign + POST。
@@ -125,6 +168,35 @@ func (s *DeliverService) DeliverActivity(signerUserID string, body []byte, inbox
 		}
 	}
 	return nil
+}
+
+// recipientIsEd25519Capable reports whether the recipient actor has at least
+// one Ed25519 entry in user_publickey_extra (= 受信側が FEP-521a Multikey で
+// Ed25519 を expose している)。未配線時 / DB error / 行なしのいずれも false
+// (= 安全側で RSA fallback)。
+func (s *DeliverService) recipientIsEd25519Capable(recipient *model.User) bool {
+	if s.publickeyExtraRepo == nil || recipient == nil {
+		return false
+	}
+	rows, err := s.publickeyExtraRepo.ListByUserID(recipient.ID)
+	if err != nil {
+		return false
+	}
+	return len(rows) > 0
+}
+
+// signerEd25519Credentials returns (keyId, PEM) for the local signer's
+// Ed25519 keypair. 未配線時 / 鍵未発行 (= P5 backfill 前の旧 user) のいずれも
+// 空文字列を返し、caller 側で RSA only にフォールバックする。
+func (s *DeliverService) signerEd25519Credentials(userID string) (string, string) {
+	if s.keypairExtraRepo == nil {
+		return "", ""
+	}
+	kp, err := s.keypairExtraRepo.FindByUserID(userID)
+	if err != nil {
+		return "", ""
+	}
+	return s.urls.UserURI(userID) + "#ed25519-key", kp.Ed25519PrivateKey
 }
 
 // isBlockedInbox returns true when the inbox URL points at a host the local
@@ -157,7 +229,8 @@ func (s *DeliverService) DeliverToFollowers(signerUserID string, body []byte) er
 
 // DeliverToUser enqueues a delivery to a single recipient user. Local users
 // are skipped (no AP delivery needed). リモートユーザーの sharedInbox があれば
-// 優先する。
+// 優先する。recipient actor が既知なので FEP-521a Multikey による Ed25519
+// sign を試行する経路 (DeliverActivityWithRecipient) を使う (#1067 / #1071)。
 func (s *DeliverService) DeliverToUser(signerUserID string, recipient *model.User, body []byte) error {
 	if recipient == nil || recipient.IsLocal() {
 		return nil
@@ -166,7 +239,7 @@ func (s *DeliverService) DeliverToUser(signerUserID string, recipient *model.Use
 	if inbox == "" {
 		return nil
 	}
-	return s.DeliverActivity(signerUserID, body, []string{inbox})
+	return s.DeliverActivityWithRecipient(signerUserID, body, []string{inbox}, recipient)
 }
 
 // signerCredentials returns the keyId URI and PEM private key for a local

--- a/internal/core/federation/deliver_service.go
+++ b/internal/core/federation/deliver_service.go
@@ -4,6 +4,8 @@ import (
 	"errors"
 	"fmt"
 	"net/url"
+	"sync"
+	"time"
 
 	"github.com/shiroha-a/mk/internal/activitypub"
 	"github.com/shiroha-a/mk/internal/model"
@@ -32,6 +34,23 @@ type HostBlockChecker interface {
 	IsAllowed(host string) bool
 }
 
+// ed25519CacheTTL is how long recipient capability / sender Ed25519 keypair
+// lookups stay in the in-memory cache. 5 分は actor refresh の actorTTL より
+// 短く、Ed25519 鍵 rotation を検出する時間としては十分。capabilityCache に
+// 入ったあとは同 recipient への deliver で DB を叩かない (#1080 review #2/#3)。
+const ed25519CacheTTL = 5 * time.Minute
+
+type ed25519CapEntry struct {
+	capable   bool
+	fetchedAt time.Time
+}
+
+type ed25519SignerEntry struct {
+	keyID     string
+	privPEM   string
+	fetchedAt time.Time
+}
+
 // DeliverService computes recipient inboxes and enqueues HTTP-signed delivery
 // jobs onto the asynq queue.
 //
@@ -51,6 +70,13 @@ type DeliverService struct {
 	// を bypass し、sign + HTTP POST を同期実行する e2e_federation 用。
 	// production code から SetSyncDeliverHook を呼ばないこと (#780)。
 	syncDeliverHook func(payload queue.DeliverPayload) error
+	// capCache / signerCache は recipient capability / sender Ed25519 鍵の
+	// 短期 in-memory cache (#1080 review #2/#3)。多 deliver で DB を叩く
+	// N+1 を抑えるため、TTL 5min で lookup を memoize する。actor 削除 /
+	// 鍵 rotation 後は TTL 経過で自動的に refresh される。
+	capCache    sync.Map         // string (userID) -> ed25519CapEntry
+	signerCache sync.Map         // string (userID) -> ed25519SignerEntry
+	clock       func() time.Time // テストで差し替え可能
 }
 
 // NewDeliverService constructs a DeliverService.
@@ -67,6 +93,7 @@ func NewDeliverService(
 		followingRepo: followingRepo,
 		keypairRepo:   keypairRepo,
 		urls:          urls,
+		clock:         time.Now,
 	}
 }
 
@@ -173,30 +200,58 @@ func (s *DeliverService) deliverInternal(signerUserID string, body []byte, inbox
 // recipientIsEd25519Capable reports whether the recipient actor has at least
 // one Ed25519 entry in user_publickey_extra (= 受信側が FEP-521a Multikey で
 // Ed25519 を expose している)。未配線時 / DB error / 行なしのいずれも false
-// (= 安全側で RSA fallback)。
+// (= 安全側で RSA fallback)。capCache で TTL 5min 結果を memoize し、N+1
+// query を抑える (#1080 review #2)。
 func (s *DeliverService) recipientIsEd25519Capable(recipient *model.User) bool {
 	if s.publickeyExtraRepo == nil || recipient == nil {
 		return false
 	}
+	if cached, ok := s.capCache.Load(recipient.ID); ok {
+		entry := cached.(ed25519CapEntry)
+		if s.clock().Sub(entry.fetchedAt) <= ed25519CacheTTL {
+			return entry.capable
+		}
+	}
 	rows, err := s.publickeyExtraRepo.ListByUserID(recipient.ID)
 	if err != nil {
+		// DB error は cache せず次回 retry させる
 		return false
 	}
-	return len(rows) > 0
+	capable := len(rows) > 0
+	s.capCache.Store(recipient.ID, ed25519CapEntry{
+		capable:   capable,
+		fetchedAt: s.clock(),
+	})
+	return capable
 }
 
 // signerEd25519Credentials returns (keyId, PEM) for the local signer's
 // Ed25519 keypair. 未配線時 / 鍵未発行 (= P5 backfill 前の旧 user) のいずれも
-// 空文字列を返し、caller 側で RSA only にフォールバックする。
+// 空文字列を返し、caller 側で RSA only にフォールバックする。signerCache で
+// TTL 5min 結果を memoize し、N+1 query を抑える (#1080 review #3)。
 func (s *DeliverService) signerEd25519Credentials(userID string) (string, string) {
 	if s.keypairExtraRepo == nil {
 		return "", ""
 	}
+	if cached, ok := s.signerCache.Load(userID); ok {
+		entry := cached.(ed25519SignerEntry)
+		if s.clock().Sub(entry.fetchedAt) <= ed25519CacheTTL {
+			return entry.keyID, entry.privPEM
+		}
+	}
 	kp, err := s.keypairExtraRepo.FindByUserID(userID)
 	if err != nil {
+		// 鍵未発行は cache に空 entry を入れて再 query を抑える
+		s.signerCache.Store(userID, ed25519SignerEntry{fetchedAt: s.clock()})
 		return "", ""
 	}
-	return s.urls.UserURI(userID) + "#ed25519-key", kp.Ed25519PrivateKey
+	keyID := s.urls.UserURI(userID) + "#ed25519-key"
+	s.signerCache.Store(userID, ed25519SignerEntry{
+		keyID:     keyID,
+		privPEM:   kp.Ed25519PrivateKey,
+		fetchedAt: s.clock(),
+	})
+	return keyID, kp.Ed25519PrivateKey
 }
 
 // isBlockedInbox returns true when the inbox URL points at a host the local

--- a/internal/core/federation/deliver_service.go
+++ b/internal/core/federation/deliver_service.go
@@ -11,6 +11,7 @@ import (
 	"github.com/shiroha-a/mk/internal/model"
 	"github.com/shiroha-a/mk/internal/queue"
 	"github.com/shiroha-a/mk/internal/repository"
+	"golang.org/x/sync/singleflight"
 )
 
 // Errors returned by DeliverService.
@@ -77,6 +78,11 @@ type DeliverService struct {
 	capCache    sync.Map         // string (userID) -> ed25519CapEntry
 	signerCache sync.Map         // string (userID) -> ed25519SignerEntry
 	clock       func() time.Time // テストで差し替え可能
+	// capGroup / signerGroup は cache miss 時の thundering herd を collapse
+	// する singleflight (#1080 review #3 follow-up)。並行 deliver の同 userID
+	// に対する DB lookup を 1 回に集約。resolver の resolveActorGroup と同 pattern。
+	capGroup    singleflight.Group
+	signerGroup singleflight.Group
 }
 
 // NewDeliverService constructs a DeliverService.
@@ -101,6 +107,15 @@ func NewDeliverService(
 // 呼ばれ、ブロック対象ホストの inbox にはエンキューしない。
 func (s *DeliverService) SetHostBlockChecker(c HostBlockChecker) {
 	s.hostBlocker = c
+}
+
+// SetClock replaces the clock used by the capability / signer cache TTL
+// expiry checks. Intended for tests that need to deterministically advance
+// time past the 5-minute TTL without sleeping.
+func (s *DeliverService) SetClock(now func() time.Time) {
+	if now != nil {
+		s.clock = now
+	}
 }
 
 // SetKeypairExtraRepo wires the Ed25519 keypair repository so sender が
@@ -200,8 +215,9 @@ func (s *DeliverService) deliverInternal(signerUserID string, body []byte, inbox
 // recipientIsEd25519Capable reports whether the recipient actor has at least
 // one Ed25519 entry in user_publickey_extra (= 受信側が FEP-521a Multikey で
 // Ed25519 を expose している)。未配線時 / DB error / 行なしのいずれも false
-// (= 安全側で RSA fallback)。capCache で TTL 5min 結果を memoize し、N+1
-// query を抑える (#1080 review #2)。
+// (= 安全側で RSA fallback)。capCache で TTL 5min 結果を memoize し、cache
+// miss 時の thundering herd は singleflight で collapse する (#1080 review
+// #2 / #3 follow-up)。
 func (s *DeliverService) recipientIsEd25519Capable(recipient *model.User) bool {
 	if s.publickeyExtraRepo == nil || recipient == nil {
 		return false
@@ -212,23 +228,28 @@ func (s *DeliverService) recipientIsEd25519Capable(recipient *model.User) bool {
 			return entry.capable
 		}
 	}
-	rows, err := s.publickeyExtraRepo.ListByUserID(recipient.ID)
-	if err != nil {
-		// DB error は cache せず次回 retry させる
-		return false
-	}
-	capable := len(rows) > 0
-	s.capCache.Store(recipient.ID, ed25519CapEntry{
-		capable:   capable,
-		fetchedAt: s.clock(),
+	val, _, _ := s.capGroup.Do(recipient.ID, func() (any, error) {
+		rows, err := s.publickeyExtraRepo.ListByUserID(recipient.ID)
+		if err != nil {
+			// DB error は cache せず次回 retry させる (= 戻り値の bool 経由で
+			// caller に伝播、cache には書き込まない)
+			return false, nil
+		}
+		capable := len(rows) > 0
+		s.capCache.Store(recipient.ID, ed25519CapEntry{
+			capable:   capable,
+			fetchedAt: s.clock(),
+		})
+		return capable, nil
 	})
-	return capable
+	return val.(bool)
 }
 
 // signerEd25519Credentials returns (keyId, PEM) for the local signer's
 // Ed25519 keypair. 未配線時 / 鍵未発行 (= P5 backfill 前の旧 user) のいずれも
 // 空文字列を返し、caller 側で RSA only にフォールバックする。signerCache で
-// TTL 5min 結果を memoize し、N+1 query を抑える (#1080 review #3)。
+// TTL 5min 結果を memoize し、cache miss 時の thundering herd は singleflight
+// で collapse する (#1080 review #2 / #3 follow-up)。
 func (s *DeliverService) signerEd25519Credentials(userID string) (string, string) {
 	if s.keypairExtraRepo == nil {
 		return "", ""
@@ -239,19 +260,24 @@ func (s *DeliverService) signerEd25519Credentials(userID string) (string, string
 			return entry.keyID, entry.privPEM
 		}
 	}
-	kp, err := s.keypairExtraRepo.FindByUserID(userID)
-	if err != nil {
-		// 鍵未発行は cache に空 entry を入れて再 query を抑える
-		s.signerCache.Store(userID, ed25519SignerEntry{fetchedAt: s.clock()})
-		return "", ""
-	}
-	keyID := s.urls.UserURI(userID) + "#ed25519-key"
-	s.signerCache.Store(userID, ed25519SignerEntry{
-		keyID:     keyID,
-		privPEM:   kp.Ed25519PrivateKey,
-		fetchedAt: s.clock(),
+	val, _, _ := s.signerGroup.Do(userID, func() (any, error) {
+		kp, err := s.keypairExtraRepo.FindByUserID(userID)
+		if err != nil {
+			// 鍵未発行は cache に空 entry を入れて再 query を抑える
+			entry := ed25519SignerEntry{fetchedAt: s.clock()}
+			s.signerCache.Store(userID, entry)
+			return entry, nil
+		}
+		entry := ed25519SignerEntry{
+			keyID:     s.urls.UserURI(userID) + "#ed25519-key",
+			privPEM:   kp.Ed25519PrivateKey,
+			fetchedAt: s.clock(),
+		}
+		s.signerCache.Store(userID, entry)
+		return entry, nil
 	})
-	return keyID, kp.Ed25519PrivateKey
+	entry := val.(ed25519SignerEntry)
+	return entry.keyID, entry.privPEM
 }
 
 // isBlockedInbox returns true when the inbox URL points at a host the local

--- a/internal/core/federation/deliver_service_test.go
+++ b/internal/core/federation/deliver_service_test.go
@@ -84,6 +84,129 @@ type stubBlocker struct {
 func (s *stubBlocker) IsBlocked(host string) bool { return s.blocked[host] }
 func (s *stubBlocker) IsAllowed(host string) bool { return !s.disallowed[host] }
 
+// --- Ed25519 capability gate (#1067 / #1071) ---
+
+// stubKeypairExtraRepo implements repository.UserKeypairExtraRepository in
+// memory for capability tests.
+type stubKeypairExtraRepo struct {
+	rows map[string]*model.UserKeypairExtra
+}
+
+func (s *stubKeypairExtraRepo) Upsert(k *model.UserKeypairExtra) error {
+	if s.rows == nil {
+		s.rows = map[string]*model.UserKeypairExtra{}
+	}
+	s.rows[k.UserID] = k
+	return nil
+}
+
+func (s *stubKeypairExtraRepo) FindByUserID(userID string) (*model.UserKeypairExtra, error) {
+	if k, ok := s.rows[userID]; ok {
+		return k, nil
+	}
+	return nil, errors.New("not found")
+}
+
+func (s *stubKeypairExtraRepo) Delete(_ string) error { return nil }
+
+// recipient (= remote user) が user_publickey_extra に Ed25519 行を持ち、
+// sender も user_keypair_extra に Ed25519 鍵を持つときだけ payload に
+// Ed25519 鍵情報が詰められる。
+func TestDeliverToUser_WithEd25519CapableRecipient_AddsEd25519Payload(t *testing.T) {
+	svc, enq, userRepo, _, keypairRepo := newDeliverService(t)
+	installLocalSigner(t, userRepo, keypairRepo)
+
+	// sender に Ed25519 鍵 wire
+	kpExtra := &stubKeypairExtraRepo{}
+	require.NoError(t, kpExtra.Upsert(&model.UserKeypairExtra{
+		UserID: "alice", Ed25519PublicKey: "PUB-ED", Ed25519PrivateKey: "PRIV-ED",
+	}))
+	svc.SetKeypairExtraRepo(kpExtra)
+
+	// recipient (= bob) を Ed25519 capable に設定
+	host := "remote.example"
+	bob := &model.User{ID: "bob", Username: "bob", Host: &host, Inbox: strPtr("https://remote.example/users/bob/inbox")}
+	pkExtra := &stubPublickeyExtraRepo{}
+	require.NoError(t, pkExtra.Upsert(&model.UserPublickeyExtra{
+		UserID: "bob", KeyID: "https://remote.example/users/bob#ed25519-key",
+		KeyPEM: "-----BEGIN PUBLIC KEY-----\nB\n-----END PUBLIC KEY-----",
+		Alg:    model.AlgEd25519,
+	}))
+	svc.SetPublickeyExtraRepo(pkExtra)
+
+	require.NoError(t, svc.DeliverToUser("alice", bob, []byte(`{"type":"Create"}`)))
+	require.Len(t, enq.calls, 1)
+	got := enq.calls[0]
+	assert.Equal(t, "https://example.com/users/alice#ed25519-key", got.Ed25519KeyID)
+	assert.Equal(t, "PRIV-ED", got.Ed25519PrivPEM)
+	assert.Equal(t, "PEM-DATA", got.KeyPEM, "RSA も並行で詰められる (Processor 側 fallback 用)")
+}
+
+// recipient が Ed25519 capable でない → payload に Ed25519 鍵情報なし
+// (= 従来通り RSA only)。
+func TestDeliverToUser_WithRSAOnlyRecipient_NoEd25519Payload(t *testing.T) {
+	svc, enq, userRepo, _, keypairRepo := newDeliverService(t)
+	installLocalSigner(t, userRepo, keypairRepo)
+
+	kpExtra := &stubKeypairExtraRepo{}
+	require.NoError(t, kpExtra.Upsert(&model.UserKeypairExtra{
+		UserID: "alice", Ed25519PublicKey: "PUB-ED", Ed25519PrivateKey: "PRIV-ED",
+	}))
+	svc.SetKeypairExtraRepo(kpExtra)
+
+	// recipient (= bob) は Ed25519 capable でない (= ListByUserID が空 slice)
+	host := "remote.example"
+	bob := &model.User{ID: "bob", Username: "bob", Host: &host, Inbox: strPtr("https://remote.example/users/bob/inbox")}
+	svc.SetPublickeyExtraRepo(&stubPublickeyExtraRepo{})
+
+	require.NoError(t, svc.DeliverToUser("alice", bob, []byte(`{}`)))
+	require.Len(t, enq.calls, 1)
+	assert.Empty(t, enq.calls[0].Ed25519KeyID)
+	assert.Empty(t, enq.calls[0].Ed25519PrivPEM)
+}
+
+// sender が Ed25519 鍵を持たない (= P5 backfill 前の旧 user) なら payload に
+// Ed25519 情報なし。
+func TestDeliverToUser_SenderWithoutEd25519Key_NoEd25519Payload(t *testing.T) {
+	svc, enq, userRepo, _, keypairRepo := newDeliverService(t)
+	installLocalSigner(t, userRepo, keypairRepo)
+
+	// sender の Ed25519 鍵を wire しない (keypairExtraRepo 未配線 = nil)
+	host := "remote.example"
+	bob := &model.User{ID: "bob", Username: "bob", Host: &host, Inbox: strPtr("https://remote.example/users/bob/inbox")}
+	pkExtra := &stubPublickeyExtraRepo{}
+	require.NoError(t, pkExtra.Upsert(&model.UserPublickeyExtra{
+		UserID: "bob", KeyID: "k", KeyPEM: "P", Alg: model.AlgEd25519,
+	}))
+	svc.SetPublickeyExtraRepo(pkExtra)
+
+	require.NoError(t, svc.DeliverToUser("alice", bob, []byte(`{}`)))
+	require.Len(t, enq.calls, 1)
+	assert.Empty(t, enq.calls[0].Ed25519KeyID)
+}
+
+// DeliverActivity (= recipient 不明な経路) は常に Ed25519 鍵情報を詰めない。
+func TestDeliverActivity_NoRecipientNoEd25519Payload(t *testing.T) {
+	svc, enq, userRepo, _, keypairRepo := newDeliverService(t)
+	installLocalSigner(t, userRepo, keypairRepo)
+
+	// extra repo を wire しても、recipient が渡らない経路では Ed25519 詰めない
+	kpExtra := &stubKeypairExtraRepo{}
+	require.NoError(t, kpExtra.Upsert(&model.UserKeypairExtra{
+		UserID: "alice", Ed25519PublicKey: "P", Ed25519PrivateKey: "K",
+	}))
+	svc.SetKeypairExtraRepo(kpExtra)
+	pkExtra := &stubPublickeyExtraRepo{}
+	require.NoError(t, pkExtra.Upsert(&model.UserPublickeyExtra{
+		UserID: "bob", KeyID: "k", KeyPEM: "P", Alg: model.AlgEd25519,
+	}))
+	svc.SetPublickeyExtraRepo(pkExtra)
+
+	require.NoError(t, svc.DeliverActivity("alice", []byte(`{}`), []string{"https://remote.example/inbox"}))
+	require.Len(t, enq.calls, 1)
+	assert.Empty(t, enq.calls[0].Ed25519KeyID, "recipient 不明経路は RSA only")
+}
+
 func TestDeliverActivity_SkipsBlockedHosts(t *testing.T) {
 	svc, enq, userRepo, _, keypairRepo := newDeliverService(t)
 	installLocalSigner(t, userRepo, keypairRepo)

--- a/internal/core/federation/deliver_service_test.go
+++ b/internal/core/federation/deliver_service_test.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"sync/atomic"
 	"testing"
+	"time"
 
 	"github.com/shiroha-a/mk/internal/activitypub"
 	"github.com/shiroha-a/mk/internal/core/federation"
@@ -211,6 +212,63 @@ func TestDeliverToUser_RecipientCapabilityCachedAcrossCalls(t *testing.T) {
 	}
 	assert.Equal(t, int32(1), countingRepo.listCalls.Load(),
 		"recipient capability は cache 経由で 1 回だけ DB 経由")
+}
+
+// capability cache の TTL (5min) が経過したら次の deliver で再 fetch される。
+// SetClock 経由で時間進行を deterministic に制御する。
+func TestDeliverToUser_CapabilityCacheExpiresAfterTTL(t *testing.T) {
+	svc, _, userRepo, _, keypairRepo := newDeliverService(t)
+	installLocalSigner(t, userRepo, keypairRepo)
+	svc.SetKeypairExtraRepo(&stubKeypairExtraRepo{rows: map[string]*model.UserKeypairExtra{
+		"alice": {UserID: "alice", Ed25519PublicKey: "P", Ed25519PrivateKey: "K"},
+	}})
+	countingRepo := &countingPublickeyExtraRepo{stubPublickeyExtraRepo: stubPublickeyExtraRepo{}}
+	require.NoError(t, countingRepo.Upsert(&model.UserPublickeyExtra{
+		UserID: "bob", KeyID: "k", KeyPEM: "P", Alg: model.AlgEd25519,
+	}))
+	svc.SetPublickeyExtraRepo(countingRepo)
+
+	now := time.Unix(1_700_000_000, 0).UTC()
+	svc.SetClock(func() time.Time { return now })
+
+	host := "remote.example"
+	bob := &model.User{ID: "bob", Username: "bob", Host: &host, Inbox: strPtr("https://remote.example/users/bob/inbox")}
+
+	// 1 回目: cache miss → DB query
+	require.NoError(t, svc.DeliverToUser("alice", bob, []byte(`{}`)))
+	assert.Equal(t, int32(1), countingRepo.listCalls.Load())
+
+	// TTL 内: cache hit → DB query なし
+	now = now.Add(4 * time.Minute)
+	require.NoError(t, svc.DeliverToUser("alice", bob, []byte(`{}`)))
+	assert.Equal(t, int32(1), countingRepo.listCalls.Load(), "TTL 内は cache hit")
+
+	// TTL 超過: cache miss → 再 DB query
+	now = now.Add(2 * time.Minute) // 合計 6 min 経過
+	require.NoError(t, svc.DeliverToUser("alice", bob, []byte(`{}`)))
+	assert.Equal(t, int32(2), countingRepo.listCalls.Load(), "TTL 経過で refetch")
+}
+
+// capability lookup が DB error を返した場合、cache には書き込まれず次回も
+// retry される (= 一時的 DB 障害が "Ed25519 capable 永続化" として cache されない)。
+func TestDeliverToUser_CapabilityLookupDBErrorNotCached(t *testing.T) {
+	svc, _, userRepo, _, keypairRepo := newDeliverService(t)
+	installLocalSigner(t, userRepo, keypairRepo)
+	svc.SetKeypairExtraRepo(&stubKeypairExtraRepo{rows: map[string]*model.UserKeypairExtra{
+		"alice": {UserID: "alice", Ed25519PublicKey: "P", Ed25519PrivateKey: "K"},
+	}})
+	// publickeyExtraRepo は常に error を返す
+	failingRepo := &countingPublickeyExtraRepo{stubPublickeyExtraRepo: stubPublickeyExtraRepo{failErr: errors.New("db down")}}
+	svc.SetPublickeyExtraRepo(failingRepo)
+
+	host := "remote.example"
+	bob := &model.User{ID: "bob", Username: "bob", Host: &host, Inbox: strPtr("https://remote.example/users/bob/inbox")}
+
+	// 2 回 deliver: DB error なので cache に入らず、両方とも DB を叩く
+	for i := 0; i < 2; i++ {
+		require.NoError(t, svc.DeliverToUser("alice", bob, []byte(`{}`)))
+	}
+	assert.Equal(t, int32(2), failingRepo.listCalls.Load(), "DB error は cache せず retry")
 }
 
 // sender Ed25519 鍵の cache も同様。

--- a/internal/core/federation/deliver_service_test.go
+++ b/internal/core/federation/deliver_service_test.go
@@ -3,6 +3,7 @@ package federation_test
 import (
 	"context"
 	"errors"
+	"sync/atomic"
 	"testing"
 
 	"github.com/shiroha-a/mk/internal/activitypub"
@@ -183,6 +184,81 @@ func TestDeliverToUser_SenderWithoutEd25519Key_NoEd25519Payload(t *testing.T) {
 	require.NoError(t, svc.DeliverToUser("alice", bob, []byte(`{}`)))
 	require.Len(t, enq.calls, 1)
 	assert.Empty(t, enq.calls[0].Ed25519KeyID)
+}
+
+// recipient capability の TTL cache が hit すると 2 回目以降の DeliverToUser
+// で publickeyExtraRepo を叩かない (#1080 review #2: N+1 抑制)。
+func TestDeliverToUser_RecipientCapabilityCachedAcrossCalls(t *testing.T) {
+	svc, _, userRepo, _, keypairRepo := newDeliverService(t)
+	installLocalSigner(t, userRepo, keypairRepo)
+	svc.SetKeypairExtraRepo(&stubKeypairExtraRepo{rows: map[string]*model.UserKeypairExtra{
+		"alice": {UserID: "alice", Ed25519PublicKey: "P", Ed25519PrivateKey: "K"},
+	}})
+	countingRepo := &countingPublickeyExtraRepo{
+		stubPublickeyExtraRepo: stubPublickeyExtraRepo{},
+	}
+	require.NoError(t, countingRepo.Upsert(&model.UserPublickeyExtra{
+		UserID: "bob", KeyID: "k", KeyPEM: "P", Alg: model.AlgEd25519,
+	}))
+	svc.SetPublickeyExtraRepo(countingRepo)
+
+	host := "remote.example"
+	bob := &model.User{ID: "bob", Username: "bob", Host: &host, Inbox: strPtr("https://remote.example/users/bob/inbox")}
+
+	// 2 回 deliver しても ListByUserID は 1 回しか呼ばれない (cache hit)
+	for i := 0; i < 2; i++ {
+		require.NoError(t, svc.DeliverToUser("alice", bob, []byte(`{}`)))
+	}
+	assert.Equal(t, int32(1), countingRepo.listCalls.Load(),
+		"recipient capability は cache 経由で 1 回だけ DB 経由")
+}
+
+// sender Ed25519 鍵の cache も同様。
+func TestDeliverToUser_SenderEd25519KeyCachedAcrossCalls(t *testing.T) {
+	svc, _, userRepo, _, keypairRepo := newDeliverService(t)
+	installLocalSigner(t, userRepo, keypairRepo)
+	countingKpRepo := &countingKeypairExtraRepo{
+		stubKeypairExtraRepo: stubKeypairExtraRepo{rows: map[string]*model.UserKeypairExtra{
+			"alice": {UserID: "alice", Ed25519PublicKey: "P", Ed25519PrivateKey: "K"},
+		}},
+	}
+	svc.SetKeypairExtraRepo(countingKpRepo)
+	pkExtra := &stubPublickeyExtraRepo{}
+	require.NoError(t, pkExtra.Upsert(&model.UserPublickeyExtra{
+		UserID: "bob", KeyID: "k", KeyPEM: "P", Alg: model.AlgEd25519,
+	}))
+	svc.SetPublickeyExtraRepo(pkExtra)
+
+	host := "remote.example"
+	bob := &model.User{ID: "bob", Username: "bob", Host: &host, Inbox: strPtr("https://remote.example/users/bob/inbox")}
+
+	for i := 0; i < 3; i++ {
+		require.NoError(t, svc.DeliverToUser("alice", bob, []byte(`{}`)))
+	}
+	assert.Equal(t, int32(1), countingKpRepo.findCalls.Load(),
+		"sender Ed25519 鍵は cache 経由で 1 回だけ DB 経由")
+}
+
+// countingPublickeyExtraRepo wraps stubPublickeyExtraRepo to record how many
+// times ListByUserID is called, for the capability cache tests.
+type countingPublickeyExtraRepo struct {
+	stubPublickeyExtraRepo
+	listCalls atomic.Int32
+}
+
+func (c *countingPublickeyExtraRepo) ListByUserID(userID string) ([]model.UserPublickeyExtra, error) {
+	c.listCalls.Add(1)
+	return c.stubPublickeyExtraRepo.ListByUserID(userID)
+}
+
+type countingKeypairExtraRepo struct {
+	stubKeypairExtraRepo
+	findCalls atomic.Int32
+}
+
+func (c *countingKeypairExtraRepo) FindByUserID(userID string) (*model.UserKeypairExtra, error) {
+	c.findCalls.Add(1)
+	return c.stubKeypairExtraRepo.FindByUserID(userID)
 }
 
 // DeliverActivity (= recipient 不明な経路) は常に Ed25519 鍵情報を詰めない。

--- a/internal/core/federation/resolver_test.go
+++ b/internal/core/federation/resolver_test.go
@@ -3717,6 +3717,29 @@ func (s *stubPublickeyExtraRepo) DeleteByKeyID(userID, keyID string) error {
 	return nil
 }
 
+// 以下は repository.UserPublickeyExtraRepository interface 完全実装のための
+// stub。resolver test では使わないが、同 package 内の deliver_service_test
+// で stub を流用するために必要 (#1067 / #1071)。
+func (s *stubPublickeyExtraRepo) FindByUserAndKeyID(userID, keyID string) (*model.UserPublickeyExtra, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	if pk, ok := s.entries[keyID]; ok && pk.UserID == userID {
+		return pk, nil
+	}
+	return nil, errors.New("not found")
+}
+
+func (s *stubPublickeyExtraRepo) DeleteByUserID(userID string) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	for keyID, pk := range s.entries {
+		if pk.UserID == userID {
+			delete(s.entries, keyID)
+		}
+	}
+	return nil
+}
+
 // stubPublickeyRepo は keys map race test 用の minimal な PublickeyStore
 // 実装。本物の publickey_repo は GORM 経由なのでテストでは差し替える。
 type stubPublickeyRepo struct {

--- a/internal/core/federation/resolver_test.go
+++ b/internal/core/federation/resolver_test.go
@@ -3699,6 +3699,9 @@ func (s *stubPublickeyExtraRepo) FindByKeyID(keyID string) (*model.UserPublickey
 func (s *stubPublickeyExtraRepo) ListByUserID(userID string) ([]model.UserPublickeyExtra, error) {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
+	if s.failErr != nil {
+		return nil, s.failErr
+	}
 	var out []model.UserPublickeyExtra
 	for _, pk := range s.entries {
 		if pk.UserID == userID {

--- a/internal/queue/processors/deliver.go
+++ b/internal/queue/processors/deliver.go
@@ -11,7 +11,9 @@ import (
 	"log/slog"
 	"net/http"
 	"net/url"
+	"time"
 
+	"github.com/redis/go-redis/v9"
 	"github.com/shiroha-a/mk/internal/activitypub"
 	"github.com/shiroha-a/mk/internal/queue"
 	"github.com/shiroha-a/mk/internal/queue/driver"
@@ -51,11 +53,61 @@ type DeliverProcessor struct {
 	responseHook     ResponseHook
 	chartHook        ChartHook
 	suspendedChecker SuspendedChecker
+	// redis is used for the per-host Ed25519 degrade flag (#1067 / #1071).
+	// 未配線時は capability gate なしの楽観動作 (= payload に Ed25519 鍵が
+	// あれば必ず Ed25519 sign を試す) になるが、production では必須。
+	redis *redis.Client
 }
 
 // NewDeliverProcessor constructs a DeliverProcessor.
 func NewDeliverProcessor(signer HTTPSigner) *DeliverProcessor {
 	return &DeliverProcessor{signer: signer}
+}
+
+// SetRedis attaches a Redis client used to persist per-host Ed25519 degrade
+// flags. Ed25519 sign + POST が 4xx で失敗した host は `ed25519:degrade:<host>`
+// に EX=300 で記録され、以後 5 分間は同 host への配送が即 RSA fallback される
+// (= "assertionMethod を expose しているが Ed25519 verify が壊れている" 実装
+// に対する safety net #1067 / #1071)。
+func (p *DeliverProcessor) SetRedis(c *redis.Client) {
+	p.redis = c
+}
+
+// ed25519DegradeTTL is how long a host stays degraded after an Ed25519 4xx
+// failure. 5 分は production observation で「broken impl の修正 deploy」に
+// 必要な時間より長い (= 改善が deploy されれば自動回復する) ことを想定。
+const ed25519DegradeTTL = 5 * time.Minute
+
+func ed25519DegradeKey(host string) string {
+	return "ed25519:degrade:" + host
+}
+
+// isEd25519Degraded reports whether the host has the Ed25519 degrade flag
+// set in Redis. Redis 未配線 or empty host or Redis 障害は false (= 安全側
+// で Ed25519 試行を継続)。
+func (p *DeliverProcessor) isEd25519Degraded(host string) bool {
+	if p.redis == nil || host == "" {
+		return false
+	}
+	n, err := p.redis.Exists(context.Background(), ed25519DegradeKey(host)).Result()
+	if err != nil {
+		// Redis 障害時は flag 判定不能 → 安全側に倒して "未 degrade" 扱い
+		// (= 引き続き Ed25519 試行)。flag セット側も同じく fail-soft なので
+		// 一時的 Redis 障害でも deliver は止まらない。
+		return false
+	}
+	return n > 0
+}
+
+// markEd25519Degraded sets the Ed25519 degrade flag for the host with the
+// default TTL. Redis 未配線 or empty host or Redis error は best-effort skip。
+func (p *DeliverProcessor) markEd25519Degraded(host string) {
+	if p.redis == nil || host == "" {
+		return
+	}
+	if err := p.redis.Set(context.Background(), ed25519DegradeKey(host), "1", ed25519DegradeTTL).Err(); err != nil {
+		slog.Warn("ed25519 degrade flag set failed", "host", host, "error", err)
+	}
 }
 
 // SetSuspendedChecker attaches a checker for deliverSuspendedSoftware.
@@ -116,26 +168,21 @@ func (p *DeliverProcessor) Handle(_ context.Context, t driver.Task) error {
 		return fmt.Errorf("decode deliver payload: %w: %w", err, driver.SkipRetry)
 	}
 
-	key, err := activitypub.NewPrivateKey(payload.KeyID, payload.KeyPEM)
-	if err != nil {
-		// 鍵が壊れているジョブも同様にスキップする。
-		return fmt.Errorf("parse private key: %w: %w", err, driver.SkipRetry)
-	}
-
 	// deliverSuspendedSoftware: 対象インスタンスの software がリストに該当すればスキップ
-	if p.suspendedChecker != nil {
-		host := hostFromInbox(payload.Inbox)
-		if host != "" && p.suspendedChecker.IsSuspended(host) {
-			slog.Info("ap deliver: skip (software suspended)", "inbox", payload.Inbox)
-			return nil
-		}
+	host := hostFromInbox(payload.Inbox)
+	if p.suspendedChecker != nil && host != "" && p.suspendedChecker.IsSuspended(host) {
+		slog.Info("ap deliver: skip (software suspended)", "inbox", payload.Inbox)
+		return nil
 	}
 
-	resp, err := p.signer.PostSigned(payload.Inbox, payload.Body, key)
+	// Ed25519 sign 経路: payload に Ed25519 鍵情報があり (= DeliverService が
+	// recipient capable と判定) かつ host が degrade flag に立っていない
+	// (= 過去 5min 以内に Ed25519 4xx 失敗がない) ときに試す (#1067 / #1071)。
+	useEd25519 := payload.Ed25519PrivPEM != "" && !p.isEd25519Degraded(host)
+
+	resp, err := p.sendOnce(payload, useEd25519)
 	if err != nil {
-		// ネットワークエラーや接続失敗はリトライする。
-		slog.Warn("ap deliver: post failed",
-			"inbox", payload.Inbox, "err", err)
+		// network error / parse error は再投函。詳細は sendOnce 内で log 済。
 		p.recordError(payload.Inbox)
 		return err
 	}
@@ -143,6 +190,27 @@ func (p *DeliverProcessor) Handle(_ context.Context, t driver.Task) error {
 		_, _ = io.Copy(io.Discard, resp.Body)
 		_ = resp.Body.Close()
 	}()
+
+	// Ed25519 sign で 4xx が返った場合は host を degrade して RSA で 1 回 retry
+	// する safety net。"assertionMethod を expose しているが Ed25519 verify が
+	// 壊れている" broken impl 対策。retry も失敗したら通常 4xx 経路で扱う。
+	if useEd25519 && resp.StatusCode >= 400 && resp.StatusCode < 500 && resp.StatusCode != http.StatusGone && resp.StatusCode != http.StatusNotFound {
+		slog.Warn("ap deliver: ed25519 4xx, degrading host + retry with RSA",
+			"host", host, "status", resp.StatusCode)
+		p.markEd25519Degraded(host)
+		_, _ = io.Copy(io.Discard, resp.Body)
+		_ = resp.Body.Close()
+		var retryErr error
+		resp, retryErr = p.sendOnce(payload, false) // false = RSA
+		if retryErr != nil {
+			p.recordError(payload.Inbox)
+			return retryErr
+		}
+		defer func() {
+			_, _ = io.Copy(io.Discard, resp.Body)
+			_ = resp.Body.Close()
+		}()
+	}
 
 	switch {
 	case resp.StatusCode >= 200 && resp.StatusCode < 300:
@@ -170,4 +238,37 @@ func (p *DeliverProcessor) Handle(_ context.Context, t driver.Task) error {
 		p.recordError(payload.Inbox)
 		return errors.New("server error: " + resp.Status)
 	}
+}
+
+// sendOnce performs one signed POST attempt. useEd25519=true なら
+// payload.Ed25519KeyID + Ed25519PrivPEM で sign、それ以外は RSA。鍵 parse 失敗
+// 時は (useEd25519=true ならば) RSA に fallback する。RSA 鍵自体が壊れている
+// 場合は driver.SkipRetry で投函を中止。
+func (p *DeliverProcessor) sendOnce(payload queue.DeliverPayload, useEd25519 bool) (*http.Response, error) {
+	if useEd25519 {
+		key, err := activitypub.NewEd25519PrivateKey(payload.Ed25519KeyID, payload.Ed25519PrivPEM)
+		if err == nil {
+			resp, perr := p.signer.PostSigned(payload.Inbox, payload.Body, key)
+			if perr != nil {
+				slog.Warn("ap deliver: ed25519 post failed",
+					"inbox", payload.Inbox, "err", perr)
+				return nil, perr
+			}
+			return resp, nil
+		}
+		slog.Warn("ap deliver: ed25519 key parse failed, falling back to RSA",
+			"inbox", payload.Inbox, "err", err)
+		// fallthrough: RSA で sign
+	}
+	key, err := activitypub.NewPrivateKey(payload.KeyID, payload.KeyPEM)
+	if err != nil {
+		return nil, fmt.Errorf("parse private key: %w: %w", err, driver.SkipRetry)
+	}
+	resp, perr := p.signer.PostSigned(payload.Inbox, payload.Body, key)
+	if perr != nil {
+		slog.Warn("ap deliver: post failed",
+			"inbox", payload.Inbox, "err", perr)
+		return nil, perr
+	}
+	return resp, nil
 }

--- a/internal/queue/processors/deliver.go
+++ b/internal/queue/processors/deliver.go
@@ -141,8 +141,12 @@ func (p *DeliverProcessor) recordEd25519Failure(host string) {
 		return
 	}
 	if n == 1 {
-		// 初回 INCR で TTL を設定 (window がスライドする)
-		_ = p.redis.Expire(ctx, ed25519FailKey(host), ed25519FailWindow).Err()
+		// 初回 INCR で TTL を設定 (window がスライドする)。Expire 失敗時は
+		// key が TTL なしで残り counter が永続蓄積するリスクがあるので診断の
+		// ために log を出す (#1080 review #2 follow-up)。
+		if err := p.redis.Expire(ctx, ed25519FailKey(host), ed25519FailWindow).Err(); err != nil {
+			slog.Warn("ed25519 fail counter TTL set failed", "host", host, "error", err)
+		}
 	}
 	if n >= ed25519FailThreshold {
 		slog.Warn("ed25519 fail threshold reached, degrading host",

--- a/internal/queue/processors/deliver.go
+++ b/internal/queue/processors/deliver.go
@@ -73,13 +73,28 @@ func (p *DeliverProcessor) SetRedis(c *redis.Client) {
 	p.redis = c
 }
 
-// ed25519DegradeTTL is how long a host stays degraded after an Ed25519 4xx
-// failure. 5 分は production observation で「broken impl の修正 deploy」に
-// 必要な時間より長い (= 改善が deploy されれば自動回復する) ことを想定。
+// ed25519DegradeTTL is how long a host stays degraded after the failure
+// counter reaches threshold. 5 分は production observation で「broken impl の
+// 修正 deploy」に必要な時間より長い (= 改善が deploy されれば自動回復する)
+// ことを想定。
 const ed25519DegradeTTL = 5 * time.Minute
+
+// ed25519FailWindow defines the sliding window the failure counter is held in.
+// 1 つの transient 4xx で degrade が立つのを防ぐ目的で、60s の window 内に
+// threshold 件以上の失敗があったときだけ degrade を立てる。
+const ed25519FailWindow = 60 * time.Second
+
+// ed25519FailThreshold is the number of failures within ed25519FailWindow
+// required to trip the degrade flag. 1 件の false positive (= 受信側 transient
+// error) で host 全体を縮退するのを避けるため 3 を採用。
+const ed25519FailThreshold = 3
 
 func ed25519DegradeKey(host string) string {
 	return "ed25519:degrade:" + host
+}
+
+func ed25519FailKey(host string) string {
+	return "ed25519:fail:" + host
 }
 
 // isEd25519Degraded reports whether the host has the Ed25519 degrade flag
@@ -107,6 +122,32 @@ func (p *DeliverProcessor) markEd25519Degraded(host string) {
 	}
 	if err := p.redis.Set(context.Background(), ed25519DegradeKey(host), "1", ed25519DegradeTTL).Err(); err != nil {
 		slog.Warn("ed25519 degrade flag set failed", "host", host, "error", err)
+	}
+}
+
+// recordEd25519Failure increments the per-host failure counter and trips the
+// degrade flag once it reaches ed25519FailThreshold within ed25519FailWindow.
+// 1 件の transient 4xx で host 全体縮退するのを避け、連続失敗のときだけ縮退
+// させる設計 (#1080 review #4)。Redis 未配線 or Redis error は best-effort
+// skip して 楽観的 Ed25519 試行を継続。
+func (p *DeliverProcessor) recordEd25519Failure(host string) {
+	if p.redis == nil || host == "" {
+		return
+	}
+	ctx := context.Background()
+	n, err := p.redis.Incr(ctx, ed25519FailKey(host)).Result()
+	if err != nil {
+		slog.Warn("ed25519 fail counter incr failed", "host", host, "error", err)
+		return
+	}
+	if n == 1 {
+		// 初回 INCR で TTL を設定 (window がスライドする)
+		_ = p.redis.Expire(ctx, ed25519FailKey(host), ed25519FailWindow).Err()
+	}
+	if n >= ed25519FailThreshold {
+		slog.Warn("ed25519 fail threshold reached, degrading host",
+			"host", host, "count", n)
+		p.markEd25519Degraded(host)
 	}
 }
 
@@ -186,7 +227,14 @@ func (p *DeliverProcessor) Handle(_ context.Context, t driver.Task) error {
 		p.recordError(payload.Inbox)
 		return err
 	}
+	// closure 内の resp は defer 実行時の現在値を見る (= retry 後の resp も
+	// 同じ defer 1 つで cleanup される)。retry 経路では古い resp を手動 Close
+	// したあと `resp = nil` してから新 resp を代入することで double Close を
+	// 回避する設計 (#1080 review #1)。
 	defer func() {
+		if resp == nil {
+			return
+		}
 		_, _ = io.Copy(io.Discard, resp.Body)
 		_ = resp.Body.Close()
 	}()
@@ -195,21 +243,18 @@ func (p *DeliverProcessor) Handle(_ context.Context, t driver.Task) error {
 	// する safety net。"assertionMethod を expose しているが Ed25519 verify が
 	// 壊れている" broken impl 対策。retry も失敗したら通常 4xx 経路で扱う。
 	if useEd25519 && resp.StatusCode >= 400 && resp.StatusCode < 500 && resp.StatusCode != http.StatusGone && resp.StatusCode != http.StatusNotFound {
-		slog.Warn("ap deliver: ed25519 4xx, degrading host + retry with RSA",
+		slog.Warn("ap deliver: ed25519 4xx, recording failure + retry with RSA",
 			"host", host, "status", resp.StatusCode)
-		p.markEd25519Degraded(host)
+		p.recordEd25519Failure(host)
 		_, _ = io.Copy(io.Discard, resp.Body)
 		_ = resp.Body.Close()
-		var retryErr error
-		resp, retryErr = p.sendOnce(payload, false) // false = RSA
+		resp = nil // defer の double Close を避ける
+		retryResp, retryErr := p.sendOnce(payload, false)
 		if retryErr != nil {
 			p.recordError(payload.Inbox)
 			return retryErr
 		}
-		defer func() {
-			_, _ = io.Copy(io.Discard, resp.Body)
-			_ = resp.Body.Close()
-		}()
+		resp = retryResp // defer は新 resp を Close する
 	}
 
 	switch {

--- a/internal/queue/processors/deliver_test.go
+++ b/internal/queue/processors/deliver_test.go
@@ -239,9 +239,9 @@ func TestDeliverProcessor_Ed25519_MalformedKeyFallsBackToRSA(t *testing.T) {
 	assert.Equal(t, payload.KeyID, signer.calls[0])
 }
 
-// Ed25519 sign で 4xx が返ったら host を degrade flag に立てて RSA で再送する。
-// 同一 task 内で 2 回 PostSigned が呼ばれ、それぞれ Ed25519 → RSA の順。
-func TestDeliverProcessor_Ed25519_4xxTriggersDegradeAndRSARetry(t *testing.T) {
+// Ed25519 sign で 4xx が返ったら fail counter を INCR し、3 件未満なら
+// degrade flag は立てずに RSA で再送する (= 1 件 false positive を防ぐ)。
+func TestDeliverProcessor_Ed25519_4xxIncrementsCounterButNoDegrade(t *testing.T) {
 	mr, err := miniredis.Run()
 	require.NoError(t, err)
 	defer mr.Close()
@@ -266,10 +266,47 @@ func TestDeliverProcessor_Ed25519_4xxTriggersDegradeAndRSARetry(t *testing.T) {
 	assert.Equal(t, payload.Ed25519KeyID, signer.calls[0])
 	assert.Equal(t, payload.KeyID, signer.calls[1])
 
-	// Redis に degrade flag が立っている
-	ok, err := rdb.Exists(context.Background(), "ed25519:degrade:remote.example").Result()
+	// fail counter は 1、degrade flag は立たない (= threshold=3 で trip するため)
+	cnt, err := rdb.Get(context.Background(), "ed25519:fail:remote.example").Result()
 	require.NoError(t, err)
-	assert.EqualValues(t, 1, ok)
+	assert.Equal(t, "1", cnt)
+	degraded, err := rdb.Exists(context.Background(), "ed25519:degrade:remote.example").Result()
+	require.NoError(t, err)
+	assert.EqualValues(t, 0, degraded, "1 件失敗では degrade は立たない")
+}
+
+// 3 件連続 Ed25519 4xx で fail counter が threshold (3) に達したら degrade
+// flag が立つ。以後 5min は同 host への deliver が即 RSA に縮退する。
+func TestDeliverProcessor_Ed25519_3xFailureTripsDegrade(t *testing.T) {
+	mr, err := miniredis.Run()
+	require.NoError(t, err)
+	defer mr.Close()
+	rdb := goredis.NewClient(&goredis.Options{Addr: mr.Addr()})
+	defer rdb.Close()
+
+	// 3 件分の Ed25519 4xx + 3 件分の RSA retry 200 を用意
+	signer := &recordingSigner{
+		responses: []*http.Response{
+			okResponse(http.StatusBadRequest), okResponse(http.StatusOK),
+			okResponse(http.StatusBadRequest), okResponse(http.StatusOK),
+			okResponse(http.StatusBadRequest), okResponse(http.StatusOK),
+		},
+	}
+	p := processors.NewDeliverProcessor(signer)
+	p.SetRedis(rdb)
+
+	payload := makePayload(t)
+	payload.Ed25519KeyID = "https://example.com/users/u1#ed25519-key"
+	payload.Ed25519PrivPEM = generateTestEd25519Key(t)
+
+	for i := 0; i < 3; i++ {
+		require.NoError(t, p.Handle(context.Background(), makeTask(t, payload)))
+	}
+
+	// counter が threshold に達して degrade flag が立つ
+	degraded, err := rdb.Exists(context.Background(), "ed25519:degrade:remote.example").Result()
+	require.NoError(t, err)
+	assert.EqualValues(t, 1, degraded, "3 件失敗で degrade 確定")
 }
 
 // degrade flag が立っている host への deliver は最初から RSA で送られる。

--- a/internal/queue/processors/deliver_test.go
+++ b/internal/queue/processors/deliver_test.go
@@ -12,6 +12,8 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/alicebob/miniredis/v2"
+	goredis "github.com/redis/go-redis/v9"
 	"github.com/shiroha-a/mk/internal/activitypub"
 	"github.com/shiroha-a/mk/internal/queue"
 	"github.com/shiroha-a/mk/internal/queue/driver"
@@ -154,6 +156,144 @@ func TestDeliverProcessor_BadKey_SkipsRetry(t *testing.T) {
 	err := p.Handle(context.Background(), makeTask(t, payload))
 	require.Error(t, err)
 	assert.ErrorIs(t, err, driver.SkipRetry)
+}
+
+// --- Ed25519 sign / capability gate / degrade safeguard (#1067 / #1071) ---
+
+// recordingSigner records every PostSigned call so multi-call test (Ed25519
+// 4xx → RSA retry) can assert which keyId was used in each attempt.
+type recordingSigner struct {
+	responses []*http.Response // pop in order
+	errs      []error
+	calls     []string // recorded KeyID for each call
+}
+
+func (r *recordingSigner) PostSigned(_ string, _ []byte, key *activitypub.PrivateKey) (*http.Response, error) {
+	if key != nil {
+		r.calls = append(r.calls, key.KeyID)
+	}
+	if len(r.responses) == 0 && len(r.errs) == 0 {
+		return okResponse(http.StatusOK), nil
+	}
+	if len(r.errs) > 0 && r.errs[0] != nil {
+		err := r.errs[0]
+		r.errs = r.errs[1:]
+		if len(r.responses) > 0 {
+			r.responses = r.responses[1:]
+		}
+		return nil, err
+	}
+	resp := r.responses[0]
+	r.responses = r.responses[1:]
+	if len(r.errs) > 0 {
+		r.errs = r.errs[1:]
+	}
+	return resp, nil
+}
+
+// generateTestEd25519Key returns a freshly minted PEM-encoded Ed25519 (PKCS8)
+// private key for the processor to parse via activitypub.NewEd25519PrivateKey.
+func generateTestEd25519Key(t *testing.T) string {
+	t.Helper()
+	priv, _, err := activitypub.GenerateEd25519Keypair()
+	require.NoError(t, err)
+	return priv
+}
+
+// payload に Ed25519 鍵情報がある場合、processor は Ed25519 で sign する。
+func TestDeliverProcessor_Ed25519_PreferredWhenPayloadHasKey(t *testing.T) {
+	signer := &recordingSigner{responses: []*http.Response{okResponse(http.StatusOK)}}
+	p := processors.NewDeliverProcessor(signer)
+
+	payload := makePayload(t)
+	payload.Ed25519KeyID = "https://example.com/users/u1#ed25519-key"
+	payload.Ed25519PrivPEM = generateTestEd25519Key(t)
+
+	require.NoError(t, p.Handle(context.Background(), makeTask(t, payload)))
+	require.Len(t, signer.calls, 1)
+	assert.Equal(t, payload.Ed25519KeyID, signer.calls[0], "Ed25519 key was used for signing")
+}
+
+// payload に Ed25519 鍵情報がない場合は従来通り RSA で sign される。
+func TestDeliverProcessor_Ed25519_AbsentFallbackToRSA(t *testing.T) {
+	signer := &recordingSigner{responses: []*http.Response{okResponse(http.StatusOK)}}
+	p := processors.NewDeliverProcessor(signer)
+
+	payload := makePayload(t) // Ed25519KeyID / Ed25519PrivPEM は空
+	require.NoError(t, p.Handle(context.Background(), makeTask(t, payload)))
+	require.Len(t, signer.calls, 1)
+	assert.Equal(t, payload.KeyID, signer.calls[0], "RSA key was used")
+}
+
+// Ed25519 PEM が壊れていれば RSA に fallback する (fail-soft)。
+func TestDeliverProcessor_Ed25519_MalformedKeyFallsBackToRSA(t *testing.T) {
+	signer := &recordingSigner{responses: []*http.Response{okResponse(http.StatusOK)}}
+	p := processors.NewDeliverProcessor(signer)
+
+	payload := makePayload(t)
+	payload.Ed25519KeyID = "https://example.com/users/u1#ed25519-key"
+	payload.Ed25519PrivPEM = "NOT A VALID PEM"
+
+	require.NoError(t, p.Handle(context.Background(), makeTask(t, payload)))
+	require.Len(t, signer.calls, 1)
+	assert.Equal(t, payload.KeyID, signer.calls[0])
+}
+
+// Ed25519 sign で 4xx が返ったら host を degrade flag に立てて RSA で再送する。
+// 同一 task 内で 2 回 PostSigned が呼ばれ、それぞれ Ed25519 → RSA の順。
+func TestDeliverProcessor_Ed25519_4xxTriggersDegradeAndRSARetry(t *testing.T) {
+	mr, err := miniredis.Run()
+	require.NoError(t, err)
+	defer mr.Close()
+	rdb := goredis.NewClient(&goredis.Options{Addr: mr.Addr()})
+	defer rdb.Close()
+
+	signer := &recordingSigner{
+		responses: []*http.Response{
+			okResponse(http.StatusBadRequest),
+			okResponse(http.StatusOK),
+		},
+	}
+	p := processors.NewDeliverProcessor(signer)
+	p.SetRedis(rdb)
+
+	payload := makePayload(t)
+	payload.Ed25519KeyID = "https://example.com/users/u1#ed25519-key"
+	payload.Ed25519PrivPEM = generateTestEd25519Key(t)
+
+	require.NoError(t, p.Handle(context.Background(), makeTask(t, payload)))
+	require.Len(t, signer.calls, 2, "Ed25519 4xx → RSA retry の 2 段送信")
+	assert.Equal(t, payload.Ed25519KeyID, signer.calls[0])
+	assert.Equal(t, payload.KeyID, signer.calls[1])
+
+	// Redis に degrade flag が立っている
+	ok, err := rdb.Exists(context.Background(), "ed25519:degrade:remote.example").Result()
+	require.NoError(t, err)
+	assert.EqualValues(t, 1, ok)
+}
+
+// degrade flag が立っている host への deliver は最初から RSA で送られる。
+func TestDeliverProcessor_Ed25519_DegradeFlagSkipsEd25519(t *testing.T) {
+	mr, err := miniredis.Run()
+	require.NoError(t, err)
+	defer mr.Close()
+	rdb := goredis.NewClient(&goredis.Options{Addr: mr.Addr()})
+	defer rdb.Close()
+
+	// 事前に degrade flag を立てる
+	require.NoError(t, rdb.Set(context.Background(), "ed25519:degrade:remote.example", "1", 0).Err())
+
+	signer := &recordingSigner{responses: []*http.Response{okResponse(http.StatusOK)}}
+	p := processors.NewDeliverProcessor(signer)
+	p.SetRedis(rdb)
+
+	payload := makePayload(t)
+	payload.Ed25519KeyID = "https://example.com/users/u1#ed25519-key"
+	payload.Ed25519PrivPEM = generateTestEd25519Key(t)
+
+	require.NoError(t, p.Handle(context.Background(), makeTask(t, payload)))
+	require.Len(t, signer.calls, 1)
+	assert.Equal(t, payload.KeyID, signer.calls[0], "degrade flag により最初から RSA で送信")
 }
 
 // stubResponseHook captures host events for assertions.

--- a/internal/queue/tasks.go
+++ b/internal/queue/tasks.go
@@ -128,6 +128,14 @@ type DeliverPayload struct {
 	KeyID string `json:"keyId"`
 	// KeyPEM is the PEM-encoded RSA private key for signing the request.
 	KeyPEM string `json:"keyPem"`
+	// Ed25519KeyID is the Ed25519 HTTP Signature keyId
+	// (e.g. https://example.com/users/u1#ed25519-key) で、recipient が FEP-521a
+	// Multikey で Ed25519 を expose していると DeliverService が判断したとき
+	// のみ詰める。未設定なら DeliverProcessor は従来通り RSA で sign する
+	// (#1067 / #1071)。
+	Ed25519KeyID string `json:"ed25519KeyId,omitempty"`
+	// Ed25519PrivPEM is the PEM-encoded Ed25519 (PKCS8) private key.
+	Ed25519PrivPEM string `json:"ed25519PrivPem,omitempty"`
 }
 
 // NewDeliverTask serializes the payload into a driver.Task ready to

--- a/internal/server/router.go
+++ b/internal/server/router.go
@@ -534,6 +534,10 @@ func (s *Server) setupRoutes() {
 	// AP delivery: DeliverService + フック登録 + asynq processor 登録
 	deliverService := corefederation.NewDeliverService(s.queueClient, userRepo, followingRepo, keypairRepo, apURLs)
 	deliverService.SetHostBlockChecker(instanceService)
+	// FEP-521a Multikey 対応で recipient capable + sender Ed25519 鍵あり 経路で
+	// Ed25519 sign を試行できるよう wire (#1067 / #1071)。
+	deliverService.SetKeypairExtraRepo(keypairExtraRepo)
+	deliverService.SetPublickeyExtraRepo(repository.NewUserPublickeyExtraRepository(s.db))
 	// test (#780) で queue を bypass して同期 deliver する hook を後付けで
 	// 差し替えられるよう、Server から参照を保持する。
 	s.deliverSvc = deliverService
@@ -573,6 +577,10 @@ func (s *Server) setupRoutes() {
 	deliverProcessor := processors.NewDeliverProcessor(apClient)
 	// 配信結果に応じて instance.isNotResponding を更新する
 	deliverProcessor.SetResponseHook(instanceService)
+	// FEP-521a Multikey 対応で host 単位の Ed25519 degrade flag を Redis に
+	// 持つ (#1067 / #1071)。Ed25519 sign 失敗時 5min 同 host を RSA only に
+	// 縮退する safety net。
+	deliverProcessor.SetRedis(s.redis.Default)
 	// deliverSuspendedSoftware: 対象インスタンスへの配送をスキップする
 	if suspMeta, err := metaRepo.Fetch(); err == nil && len(suspMeta.DeliverSuspendedSoftware) > 0 {
 		deliverProcessor.SetSuspendedChecker(


### PR DESCRIPTION
## Summary

配送先 actor が FEP-521a Multikey で Ed25519 を expose している (= \`user_publickey_extra\` に Ed25519 行あり) かつ sender が \`user_keypair_extra\` に鍵を持つときだけ Ed25519 で sign し、4xx で失敗したら host 単位の degrade flag を Redis に立てて RSA で再送する。\"assertionMethod を expose しているが Ed25519 verify が壊れている\" broken impl への safety net も同梱。

親 issue: #1067
Closes #1071
依存: P1 #1068 / P2 #1078 / P3 #1079 (全て merged)

## drop-in 互換

- \`DeliverPayload\` の新 field は \`omitempty\` で旧 worker は無視 → 後方互換
- recipient が Ed25519 capable でない / sender が Ed25519 鍵未発行のいずれかなら payload に Ed25519 情報なし → 従来通り RSA only
- degrade flag は Redis 未配線時 fail-soft で常に false (= 楽観的に Ed25519 試行)
- 既存 \`DeliverActivity\` 経路 (followers / inbox list ベース) は recipient 不明なので Ed25519 sign 試行なし
- Misskey TS は \`user_publickey_extra\` / \`user_keypair_extra\` を認識せず、payload の Ed25519 field も読まないため drop-in swap 時に問題なし

## 主な変更点

### \`queue/tasks.go\`
- \`DeliverPayload\` に \`Ed25519KeyID\` / \`Ed25519PrivPEM\` (両方 omitempty) を追加

### \`core/federation/deliver_service.go\`
- \`keypairExtraRepo\` / \`publickeyExtraRepo\` field + setters
- 新規 \`DeliverActivityWithRecipient(signerUserID, body, inboxes, recipient *model.User)\` で recipient capable かつ sender に Ed25519 鍵がある場合のみ payload に Ed25519 情報を詰める
- \`DeliverToUser\` は内部で \`DeliverActivityWithRecipient\` を使う
- 既存 \`DeliverActivity\` (= followers / inbox list 経路) は RSA only のまま

### \`queue/processors/deliver.go\`
- \`SetRedis(*redis.Client)\` + degrade flag helpers (\`ed25519:degrade:<host>\` EX=5min)
- payload に Ed25519 鍵あり + degrade flag なし → Ed25519 sign 試行
- Ed25519 sign で 4xx (410/404 除く) → host を degrade + 同 task 内で RSA 再送
- Ed25519 PEM 不正 → RSA fallback (fail-soft)
- 既存ロジックは \`sendOnce\` ヘルパに集約

### \`server/router.go\`
- \`deliverService.SetKeypairExtraRepo\` + \`SetPublickeyExtraRepo\`
- \`deliverProcessor.SetRedis(s.redis.Default)\`

## テスト

\`\`\`bash
make test       # 全 119 pkg pass
go test ./internal/core/federation/ -cover           # 90.1%
go test ./internal/queue/processors/ -cover          # 91.3%
\`\`\`

新規 test (9 件):

**queue/processors** (miniredis ベース):
- \`Ed25519_PreferredWhenPayloadHasKey\` (Ed25519 が選ばれる)
- \`Ed25519_AbsentFallbackToRSA\` (鍵なしで RSA)
- \`Ed25519_MalformedKeyFallsBackToRSA\` (不正 PEM で fail-soft)
- \`Ed25519_4xxTriggersDegradeAndRSARetry\` (4xx → degrade flag + RSA 再送)
- \`Ed25519_DegradeFlagSkipsEd25519\` (flag 立ち host は最初から RSA)

**core/federation**:
- \`DeliverToUser_WithEd25519CapableRecipient_AddsEd25519Payload\`
- \`DeliverToUser_WithRSAOnlyRecipient_NoEd25519Payload\`
- \`DeliverToUser_SenderWithoutEd25519Key_NoEd25519Payload\`
- \`DeliverActivity_NoRecipientNoEd25519Payload\`

## 新規依存 (test only)

\`github.com/alicebob/miniredis/v2 v2.38.0\` — Redis degrade flag の挙動を unit test で walks through するため。production code は引き続き \`redis.Client\` を直接使用。

## 次のステップ

このマージ後、parent #1067 の残りに進める:

- **P5 (#1072)** — 既存 local user の lazy backfill (P1 のみ依存で独立。本 PR とは並行可能)
- **P6 (#1073)** — Drop-in test (TS ↔ mk swap で Ed25519 expose / RSA fallback / 連合継続)

P5 が完了すると mk-go 既存 user (P1 以前) も actor JSON で Ed25519 を expose するようになります。P6 は最終 e2e 検証。