### PR TITLE
ed25519: 既存 local user の lazy backfill (P5)

### DIFF
--- a/internal/api/ap/handler.go
+++ b/internal/api/ap/handler.go
@@ -98,27 +98,70 @@ func (h *Handler) SetKeypairExtraRepo(r repository.UserKeypairExtraRepository) {
 }
 
 // lookupEd25519PublicKey returns the Ed25519 public key for the local user
-// when keypairExtraRepo is wired AND an Ed25519 row exists. It returns nil on
-// any of: repo unwired / row missing / PEM parse failure (fail-soft to RSA
-// only — drop-in 互換維持)。
+// when keypairExtraRepo is wired. P1 マイグレーション前から存在する旧 user
+// には user_keypair_extra に行が無いため、ErrRecordNotFound のときに lazy
+// backfill (鍵生成 + InsertIfAbsent + 再 lookup) を行って actor JSON に
+// assertionMethod を expose する (#1072)。生成失敗 / PEM parse 失敗のいずれも
+// nil を返して RSA only にフォールバックする。
 //
-// "row missing" は P5 backfill 前の通常状態なので silently skip するが、
-// それ以外の DB error / PEM parse error は診断のため warn log を出す。これが
-// 無いと一時的 PostgreSQL 障害で全 user の actor JSON から Ed25519 が消える
-// silent degradation が発生したとき気付けない。
+// 並列 actor JSON 生成で同 user に対して複数 goroutine が backfill を
+// 開始しても、InsertIfAbsent (ON CONFLICT DO NOTHING) で 最初に書かれた
+// 行が残り、後続は再 lookup で既存行を取得する → race-safe。
+//
+// DB error (= ErrRecordNotFound 以外) と PEM parse error は診断のため
+// slog.Warn を出す。
 func (h *Handler) lookupEd25519PublicKey(userID string) ed25519.PublicKey {
 	if h.keypairExtraRepo == nil {
 		return nil
 	}
 	row, err := h.keypairExtraRepo.FindByUserID(userID)
-	if err != nil {
-		if !errors.Is(err, gorm.ErrRecordNotFound) {
-			slog.Warn("ed25519 keypair lookup failed",
-				"userID", userID, "error", err)
-		}
+	if err == nil {
+		return h.parseEd25519PublicKeyOrLog(userID, row.Ed25519PublicKey)
+	}
+	if !errors.Is(err, gorm.ErrRecordNotFound) {
+		slog.Warn("ed25519 keypair lookup failed",
+			"userID", userID, "error", err)
 		return nil
 	}
-	pub, err := activitypub.ParseEd25519PublicKeyPEM(row.Ed25519PublicKey)
+	// 行なし → P5 lazy backfill 経路
+	return h.backfillEd25519PublicKey(userID)
+}
+
+// backfillEd25519PublicKey generates a fresh Ed25519 keypair for a local user
+// that pre-dates the P1 migration, persists it via InsertIfAbsent (race-safe),
+// and returns the public key for the renderer. Any failure path returns nil
+// → RSA only fallback。
+func (h *Handler) backfillEd25519PublicKey(userID string) ed25519.PublicKey {
+	privPEM, pubPEM, err := activitypub.GenerateEd25519Keypair()
+	if err != nil {
+		slog.Warn("ed25519 backfill keypair generate failed",
+			"userID", userID, "error", err)
+		return nil
+	}
+	if err := h.keypairExtraRepo.InsertIfAbsent(&model.UserKeypairExtra{
+		UserID:            userID,
+		Ed25519PublicKey:  pubPEM,
+		Ed25519PrivateKey: privPEM,
+	}); err != nil {
+		slog.Warn("ed25519 backfill insert failed",
+			"userID", userID, "error", err)
+		return nil
+	}
+	// 並列 backfill で別 goroutine が先に書いた可能性があるので、再 lookup
+	// で確実に永続化された行の公開鍵を返す。
+	row, err := h.keypairExtraRepo.FindByUserID(userID)
+	if err != nil {
+		slog.Warn("ed25519 backfill re-lookup failed",
+			"userID", userID, "error", err)
+		return nil
+	}
+	return h.parseEd25519PublicKeyOrLog(userID, row.Ed25519PublicKey)
+}
+
+// parseEd25519PublicKeyOrLog parses an Ed25519 PEM and logs on failure.
+// Shared by lookup / backfill paths.
+func (h *Handler) parseEd25519PublicKeyOrLog(userID, pemStr string) ed25519.PublicKey {
+	pub, err := activitypub.ParseEd25519PublicKeyPEM(pemStr)
 	if err != nil {
 		slog.Warn("ed25519 PEM parse failed",
 			"userID", userID, "error", err)

--- a/internal/api/ap/handler.go
+++ b/internal/api/ap/handler.go
@@ -17,6 +17,7 @@ import (
 	"github.com/shiroha-a/mk/internal/misc/id"
 	"github.com/shiroha-a/mk/internal/model"
 	"github.com/shiroha-a/mk/internal/repository"
+	"golang.org/x/sync/singleflight"
 	"gorm.io/gorm"
 )
 
@@ -42,6 +43,10 @@ type Handler struct {
 	remoteFetcher    RemoteFetcher
 	remoteResolver   RemoteResolver
 	nonAPFallback    echo.HandlerFunc
+	// backfillGroup collapses parallel lazy-backfill 経路の Generate +
+	// InsertIfAbsent を同 user ID で 1 回に集約する。多 goroutine が
+	// 同時に backfill しても entropy / CPU を浪費しない (#1081 review #1)。
+	backfillGroup singleflight.Group
 }
 
 // SetRemote attaches remote AP fetcher and resolver.
@@ -131,24 +136,52 @@ func (h *Handler) lookupEd25519PublicKey(userID string) ed25519.PublicKey {
 // that pre-dates the P1 migration, persists it via InsertIfAbsent (race-safe),
 // and returns the public key for the renderer. Any failure path returns nil
 // → RSA only fallback。
+//
+// 同 userID への並行 backfill は singleflight で 1 回に集約され、Generate +
+// InsertIfAbsent + 再 lookup を多 goroutine が個別に走らせる無駄を抑える
+// (#1081 review #1)。InsertIfAbsent の戻り値 inserted で「自分が書いた」
+// 「他が先に書いた」を区別し、inserted=true なら自身が生成した PEM を
+// そのまま返して再 FindByUserID を skip (= 1 query 削減 #1081 review #2)。
 func (h *Handler) backfillEd25519PublicKey(userID string) ed25519.PublicKey {
+	val, _, _ := h.backfillGroup.Do(userID, func() (any, error) {
+		// 失敗時に typed-nil の ed25519.PublicKey を返すと caller 側で
+		// `val == nil` が false になる (interface comparison の罠)。明示的に
+		// untyped nil を return して check が正しく short-circuit するように
+		// する。
+		if pub := h.runEd25519Backfill(userID); pub != nil {
+			return pub, nil
+		}
+		return nil, nil
+	})
+	if val == nil {
+		return nil
+	}
+	return val.(ed25519.PublicKey)
+}
+
+func (h *Handler) runEd25519Backfill(userID string) ed25519.PublicKey {
 	privPEM, pubPEM, err := activitypub.GenerateEd25519Keypair()
 	if err != nil {
 		slog.Warn("ed25519 backfill keypair generate failed",
 			"userID", userID, "error", err)
 		return nil
 	}
-	if err := h.keypairExtraRepo.InsertIfAbsent(&model.UserKeypairExtra{
+	inserted, err := h.keypairExtraRepo.InsertIfAbsent(&model.UserKeypairExtra{
 		UserID:            userID,
 		Ed25519PublicKey:  pubPEM,
 		Ed25519PrivateKey: privPEM,
-	}); err != nil {
+	})
+	if err != nil {
 		slog.Warn("ed25519 backfill insert failed",
 			"userID", userID, "error", err)
 		return nil
 	}
-	// 並列 backfill で別 goroutine が先に書いた可能性があるので、再 lookup
-	// で確実に永続化された行の公開鍵を返す。
+	if inserted {
+		// 自身が書いた行 → 生成済 PEM をそのまま返す (1 query 削減)
+		return h.parseEd25519PublicKeyOrLog(userID, pubPEM)
+	}
+	// 並列 race (= singleflight 期間外の重複 backfill) で別 goroutine が
+	// 先に書いた → 再 lookup で永続化された別公開鍵を取得
 	row, err := h.keypairExtraRepo.FindByUserID(userID)
 	if err != nil {
 		slog.Warn("ed25519 backfill re-lookup failed",

--- a/internal/api/ap/handler_test.go
+++ b/internal/api/ap/handler_test.go
@@ -166,7 +166,10 @@ func TestUser_WithEd25519Repo_NoRowForUser_TriggersLazyBackfill(t *testing.T) {
 
 // 並列 actor JSON 生成で同 user に対する複数 lookup が同時に走っても、
 // InsertIfAbsent (ON CONFLICT DO NOTHING) で最初に書かれた行が残り、後続は
-// 再 lookup で既存行を取得する race-safe 性質を確認する (#1072)。
+// 再 lookup で既存行を取得する race-safe 性質を確認する (#1072)。さらに
+// singleflight (#1081 follow-up) によって 8 並列でも 1 つの publicKey
+// Multibase string が全 goroutine で観測されることを assert する (#1081
+// review #4)。
 func TestUser_LazyBackfill_RaceSafe(t *testing.T) {
 	h, userRepo, _, keypairRepo := newHandler(t)
 	userRepo.Users["u1"] = &model.User{ID: "u1", Username: "alice"}
@@ -174,6 +177,11 @@ func TestUser_LazyBackfill_RaceSafe(t *testing.T) {
 	extra := testutil.NewMockUserKeypairExtraRepository()
 	h.SetKeypairExtraRepo(extra)
 
+	// 全 goroutine が actor JSON 内で見た公開鍵を集約して同一であることを assert
+	var (
+		mu        sync.Mutex
+		seenMKeys []string
+	)
 	var wg sync.WaitGroup
 	for i := 0; i < 8; i++ {
 		wg.Add(1)
@@ -182,6 +190,17 @@ func TestUser_LazyBackfill_RaceSafe(t *testing.T) {
 			c, rec := newReq(t, "id", "u1")
 			require.NoError(t, h.User(c))
 			assert.Equal(t, http.StatusOK, rec.Code)
+			// レスポンス JSON の publicKeyMultibase を抽出
+			body := rec.Body.String()
+			if idx := strings.Index(body, `"publicKeyMultibase":"`); idx >= 0 {
+				start := idx + len(`"publicKeyMultibase":"`)
+				end := strings.Index(body[start:], `"`)
+				if end > 0 {
+					mu.Lock()
+					seenMKeys = append(seenMKeys, body[start:start+end])
+					mu.Unlock()
+				}
+			}
 		}()
 	}
 	wg.Wait()
@@ -190,6 +209,14 @@ func TestUser_LazyBackfill_RaceSafe(t *testing.T) {
 	row, ok := extra.Keypairs["u1"]
 	require.True(t, ok)
 	assert.NotEmpty(t, row.Ed25519PublicKey)
+
+	// 全 goroutine で観測した publicKeyMultibase は完全に同一 (= race で
+	// 鍵分裂しない)。長さ 8 + 全要素同値で sanity check。
+	require.Len(t, seenMKeys, 8, "全 goroutine が publicKeyMultibase を観測")
+	for i := 1; i < len(seenMKeys); i++ {
+		assert.Equal(t, seenMKeys[0], seenMKeys[i],
+			"全 goroutine で同一 Multikey が見える (= 鍵分裂なし)")
+	}
 }
 
 // keypairExtraRepo の FindByUserID が gorm.ErrRecordNotFound 以外の DB error
@@ -199,8 +226,10 @@ type failingKeypairExtraRepo struct {
 	err error
 }
 
-func (f *failingKeypairExtraRepo) Upsert(_ *model.UserKeypairExtra) error         { return f.err }
-func (f *failingKeypairExtraRepo) InsertIfAbsent(_ *model.UserKeypairExtra) error { return f.err }
+func (f *failingKeypairExtraRepo) Upsert(_ *model.UserKeypairExtra) error { return f.err }
+func (f *failingKeypairExtraRepo) InsertIfAbsent(_ *model.UserKeypairExtra) (bool, error) {
+	return false, f.err
+}
 func (f *failingKeypairExtraRepo) FindByUserID(_ string) (*model.UserKeypairExtra, error) {
 	return nil, f.err
 }
@@ -225,8 +254,8 @@ type insertFailingExtraRepo struct {
 	insertErr error
 }
 
-func (i *insertFailingExtraRepo) InsertIfAbsent(_ *model.UserKeypairExtra) error {
-	return i.insertErr
+func (i *insertFailingExtraRepo) InsertIfAbsent(_ *model.UserKeypairExtra) (bool, error) {
+	return false, i.insertErr
 }
 
 func TestUser_LazyBackfill_InsertFailureFallsBackToRSAOnly(t *testing.T) {

--- a/internal/api/ap/handler_test.go
+++ b/internal/api/ap/handler_test.go
@@ -5,6 +5,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"strings"
+	"sync"
 	"testing"
 
 	"github.com/labstack/echo/v4"
@@ -139,18 +140,56 @@ func TestUser_WithEd25519Keypair_ExposesAssertionMethod(t *testing.T) {
 	assert.Contains(t, body, `#ed25519-key`)
 }
 
-// keypairExtraRepo は wire 済だが該当 user に Ed25519 行がない場合 →
-// AssertionMethod は出力されない (fail-soft fallback)。
-func TestUser_WithEd25519Repo_NoRowForUser(t *testing.T) {
+// keypairExtraRepo が wire 済 + 該当 user に Ed25519 行が無い場合は P5 lazy
+// backfill が走り、新規鍵が生成・保存されて actor JSON に assertionMethod
+// が expose される (#1072)。
+func TestUser_WithEd25519Repo_NoRowForUser_TriggersLazyBackfill(t *testing.T) {
 	h, userRepo, _, keypairRepo := newHandler(t)
 	userRepo.Users["u1"] = &model.User{ID: "u1", Username: "alice"}
 	keypairRepo.items["u1"] = &model.UserKeypair{UserID: "u1", PublicKey: "PUBKEY"}
-	h.SetKeypairExtraRepo(testutil.NewMockUserKeypairExtraRepository())
+	extra := testutil.NewMockUserKeypairExtraRepository()
+	h.SetKeypairExtraRepo(extra)
 
 	c, rec := newReq(t, "id", "u1")
 	require.NoError(t, h.User(c))
 	assert.Equal(t, http.StatusOK, rec.Code)
-	assert.NotContains(t, rec.Body.String(), `"assertionMethod"`)
+	// backfill 後は assertionMethod が出力される
+	assert.Contains(t, rec.Body.String(), `"assertionMethod"`)
+	assert.Contains(t, rec.Body.String(), `"Multikey"`)
+	assert.Contains(t, rec.Body.String(), `#ed25519-key`)
+	// mock 上に新規 row が保存されている
+	row, ok := extra.Keypairs["u1"]
+	require.True(t, ok)
+	assert.Contains(t, row.Ed25519PublicKey, "PUBLIC KEY")
+	assert.Contains(t, row.Ed25519PrivateKey, "PRIVATE KEY")
+}
+
+// 並列 actor JSON 生成で同 user に対する複数 lookup が同時に走っても、
+// InsertIfAbsent (ON CONFLICT DO NOTHING) で最初に書かれた行が残り、後続は
+// 再 lookup で既存行を取得する race-safe 性質を確認する (#1072)。
+func TestUser_LazyBackfill_RaceSafe(t *testing.T) {
+	h, userRepo, _, keypairRepo := newHandler(t)
+	userRepo.Users["u1"] = &model.User{ID: "u1", Username: "alice"}
+	keypairRepo.items["u1"] = &model.UserKeypair{UserID: "u1", PublicKey: "PUBKEY"}
+	extra := testutil.NewMockUserKeypairExtraRepository()
+	h.SetKeypairExtraRepo(extra)
+
+	var wg sync.WaitGroup
+	for i := 0; i < 8; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			c, rec := newReq(t, "id", "u1")
+			require.NoError(t, h.User(c))
+			assert.Equal(t, http.StatusOK, rec.Code)
+		}()
+	}
+	wg.Wait()
+
+	// 8 並列で backfill しても DB 上は 1 行だけ
+	row, ok := extra.Keypairs["u1"]
+	require.True(t, ok)
+	assert.NotEmpty(t, row.Ed25519PublicKey)
 }
 
 // keypairExtraRepo の FindByUserID が gorm.ErrRecordNotFound 以外の DB error
@@ -160,7 +199,8 @@ type failingKeypairExtraRepo struct {
 	err error
 }
 
-func (f *failingKeypairExtraRepo) Upsert(_ *model.UserKeypairExtra) error { return f.err }
+func (f *failingKeypairExtraRepo) Upsert(_ *model.UserKeypairExtra) error         { return f.err }
+func (f *failingKeypairExtraRepo) InsertIfAbsent(_ *model.UserKeypairExtra) error { return f.err }
 func (f *failingKeypairExtraRepo) FindByUserID(_ string) (*model.UserKeypairExtra, error) {
 	return nil, f.err
 }
@@ -171,6 +211,32 @@ func TestUser_WithEd25519Repo_DBError_FailsSoft(t *testing.T) {
 	userRepo.Users["u1"] = &model.User{ID: "u1", Username: "alice"}
 	keypairRepo.items["u1"] = &model.UserKeypair{UserID: "u1", PublicKey: "PUBKEY"}
 	h.SetKeypairExtraRepo(&failingKeypairExtraRepo{err: errors.New("connection refused")})
+
+	c, rec := newReq(t, "id", "u1")
+	require.NoError(t, h.User(c))
+	assert.Equal(t, http.StatusOK, rec.Code)
+	assert.NotContains(t, rec.Body.String(), `"assertionMethod"`)
+}
+
+// backfill 経路で InsertIfAbsent が DB error を返した場合 → assertionMethod
+// は出ず RSA only に fail-soft。
+type insertFailingExtraRepo struct {
+	*testutil.MockUserKeypairExtraRepository
+	insertErr error
+}
+
+func (i *insertFailingExtraRepo) InsertIfAbsent(_ *model.UserKeypairExtra) error {
+	return i.insertErr
+}
+
+func TestUser_LazyBackfill_InsertFailureFallsBackToRSAOnly(t *testing.T) {
+	h, userRepo, _, keypairRepo := newHandler(t)
+	userRepo.Users["u1"] = &model.User{ID: "u1", Username: "alice"}
+	keypairRepo.items["u1"] = &model.UserKeypair{UserID: "u1", PublicKey: "PUBKEY"}
+	h.SetKeypairExtraRepo(&insertFailingExtraRepo{
+		MockUserKeypairExtraRepository: testutil.NewMockUserKeypairExtraRepository(),
+		insertErr:                      errors.New("constraint violation"),
+	})
 
 	c, rec := newReq(t, "id", "u1")
 	require.NoError(t, h.User(c))

--- a/internal/core/federation/deliver_service_test.go
+++ b/internal/core/federation/deliver_service_test.go
@@ -102,6 +102,17 @@ func (s *stubKeypairExtraRepo) Upsert(k *model.UserKeypairExtra) error {
 	return nil
 }
 
+func (s *stubKeypairExtraRepo) InsertIfAbsent(k *model.UserKeypairExtra) error {
+	if s.rows == nil {
+		s.rows = map[string]*model.UserKeypairExtra{}
+	}
+	if _, exists := s.rows[k.UserID]; exists {
+		return nil
+	}
+	s.rows[k.UserID] = k
+	return nil
+}
+
 func (s *stubKeypairExtraRepo) FindByUserID(userID string) (*model.UserKeypairExtra, error) {
 	if k, ok := s.rows[userID]; ok {
 		return k, nil

--- a/internal/core/federation/deliver_service_test.go
+++ b/internal/core/federation/deliver_service_test.go
@@ -102,15 +102,15 @@ func (s *stubKeypairExtraRepo) Upsert(k *model.UserKeypairExtra) error {
 	return nil
 }
 
-func (s *stubKeypairExtraRepo) InsertIfAbsent(k *model.UserKeypairExtra) error {
+func (s *stubKeypairExtraRepo) InsertIfAbsent(k *model.UserKeypairExtra) (bool, error) {
 	if s.rows == nil {
 		s.rows = map[string]*model.UserKeypairExtra{}
 	}
 	if _, exists := s.rows[k.UserID]; exists {
-		return nil
+		return false, nil
 	}
 	s.rows[k.UserID] = k
-	return nil
+	return true, nil
 }
 
 func (s *stubKeypairExtraRepo) FindByUserID(userID string) (*model.UserKeypairExtra, error) {

--- a/internal/core/signup/signup_service_test.go
+++ b/internal/core/signup/signup_service_test.go
@@ -285,6 +285,9 @@ type failingUpsertKeypairExtraRepo struct{}
 func (f *failingUpsertKeypairExtraRepo) Upsert(_ *model.UserKeypairExtra) error {
 	return assert.AnError
 }
+func (f *failingUpsertKeypairExtraRepo) InsertIfAbsent(_ *model.UserKeypairExtra) error {
+	return assert.AnError
+}
 func (f *failingUpsertKeypairExtraRepo) FindByUserID(_ string) (*model.UserKeypairExtra, error) {
 	return nil, testutil.ErrNotFound
 }

--- a/internal/core/signup/signup_service_test.go
+++ b/internal/core/signup/signup_service_test.go
@@ -285,8 +285,8 @@ type failingUpsertKeypairExtraRepo struct{}
 func (f *failingUpsertKeypairExtraRepo) Upsert(_ *model.UserKeypairExtra) error {
 	return assert.AnError
 }
-func (f *failingUpsertKeypairExtraRepo) InsertIfAbsent(_ *model.UserKeypairExtra) error {
-	return assert.AnError
+func (f *failingUpsertKeypairExtraRepo) InsertIfAbsent(_ *model.UserKeypairExtra) (bool, error) {
+	return false, assert.AnError
 }
 func (f *failingUpsertKeypairExtraRepo) FindByUserID(_ string) (*model.UserKeypairExtra, error) {
 	return nil, testutil.ErrNotFound

--- a/internal/repository/user_keypair_extra.go
+++ b/internal/repository/user_keypair_extra.go
@@ -13,7 +13,12 @@ type UserKeypairExtraRepository interface {
 	// Race-safe primitive for P5 lazy backfill: 並列 actor JSON 生成で複数
 	// goroutine が同 user の鍵を同時に生成しても DB 上は最初に書かれた行が
 	// 残り、Upsert (UPDATE) のように後勝ちで鍵が置換されない (#1072)。
-	InsertIfAbsent(k *model.UserKeypairExtra) error
+	//
+	// Returns (inserted, err): inserted=true なら自 row が DB に書かれた、
+	// false なら別 goroutine が先に書いた既存行が残った (= 自分の k は捨てる)。
+	// caller は inserted=true のとき re-lookup を skip して自身の生成鍵を
+	// そのまま使える (= 1 query 削減 #1081 review #2)。
+	InsertIfAbsent(k *model.UserKeypairExtra) (bool, error)
 	FindByUserID(userID string) (*model.UserKeypairExtra, error)
 	Delete(userID string) error
 }
@@ -34,11 +39,15 @@ func (r *userKeypairExtraRepository) Upsert(k *model.UserKeypairExtra) error {
 	}).Create(k).Error
 }
 
-func (r *userKeypairExtraRepository) InsertIfAbsent(k *model.UserKeypairExtra) error {
-	return r.db.Clauses(clause.OnConflict{
+func (r *userKeypairExtraRepository) InsertIfAbsent(k *model.UserKeypairExtra) (bool, error) {
+	tx := r.db.Clauses(clause.OnConflict{
 		Columns:   []clause.Column{{Name: "userId"}},
 		DoNothing: true,
-	}).Create(k).Error
+	}).Create(k)
+	if tx.Error != nil {
+		return false, tx.Error
+	}
+	return tx.RowsAffected == 1, nil
 }
 
 func (r *userKeypairExtraRepository) FindByUserID(userID string) (*model.UserKeypairExtra, error) {

--- a/internal/repository/user_keypair_extra.go
+++ b/internal/repository/user_keypair_extra.go
@@ -9,6 +9,11 @@ import (
 // UserKeypairExtraRepository provides data access for the `user_keypair_extra` table.
 type UserKeypairExtraRepository interface {
 	Upsert(k *model.UserKeypairExtra) error
+	// InsertIfAbsent inserts the row only when no entry exists for the userId.
+	// Race-safe primitive for P5 lazy backfill: 並列 actor JSON 生成で複数
+	// goroutine が同 user の鍵を同時に生成しても DB 上は最初に書かれた行が
+	// 残り、Upsert (UPDATE) のように後勝ちで鍵が置換されない (#1072)。
+	InsertIfAbsent(k *model.UserKeypairExtra) error
 	FindByUserID(userID string) (*model.UserKeypairExtra, error)
 	Delete(userID string) error
 }
@@ -26,6 +31,13 @@ func (r *userKeypairExtraRepository) Upsert(k *model.UserKeypairExtra) error {
 	return r.db.Clauses(clause.OnConflict{
 		Columns:   []clause.Column{{Name: "userId"}},
 		DoUpdates: clause.AssignmentColumns([]string{"ed25519PublicKey", "ed25519PrivateKey"}),
+	}).Create(k).Error
+}
+
+func (r *userKeypairExtraRepository) InsertIfAbsent(k *model.UserKeypairExtra) error {
+	return r.db.Clauses(clause.OnConflict{
+		Columns:   []clause.Column{{Name: "userId"}},
+		DoNothing: true,
 	}).Create(k).Error
 }
 

--- a/internal/repository/user_keypair_extra_test.go
+++ b/internal/repository/user_keypair_extra_test.go
@@ -43,6 +43,34 @@ func TestUserKeypairExtraRepository_UpsertAndFind(t *testing.T) {
 	assert.Equal(t, "PRIVKEY_v2", got.Ed25519PrivateKey)
 }
 
+// InsertIfAbsent は ON CONFLICT DO NOTHING 動作:
+//   - 既存行が無いとき → 新規挿入
+//   - 既存行があるとき → no-op (= 旧 row 保持、新 row 廃棄) → race-safe な
+//     lazy backfill primitive (#1072)。
+func TestUserKeypairExtraRepository_InsertIfAbsent(t *testing.T) {
+	repo := NewUserKeypairExtraRepository(testDB)
+	user := insertTestUser(t, "u_kpx_iia", "kpx_iia")
+	defer cleanupUser(t, user.ID)
+	defer cleanupUserKeypairExtra(t, user.ID)
+
+	// 1 回目: 新規挿入
+	require.NoError(t, repo.InsertIfAbsent(&model.UserKeypairExtra{
+		UserID: user.ID, Ed25519PublicKey: "PUB1", Ed25519PrivateKey: "PRIV1",
+	}))
+	got, err := repo.FindByUserID(user.ID)
+	require.NoError(t, err)
+	assert.Equal(t, "PUB1", got.Ed25519PublicKey)
+
+	// 2 回目: 既存行があるので no-op (旧 row が保持される)
+	require.NoError(t, repo.InsertIfAbsent(&model.UserKeypairExtra{
+		UserID: user.ID, Ed25519PublicKey: "PUB2", Ed25519PrivateKey: "PRIV2",
+	}))
+	got, err = repo.FindByUserID(user.ID)
+	require.NoError(t, err)
+	assert.Equal(t, "PUB1", got.Ed25519PublicKey, "既存行は保持される (race-safe)")
+	assert.Equal(t, "PRIV1", got.Ed25519PrivateKey)
+}
+
 func TestUserKeypairExtraRepository_Delete(t *testing.T) {
 	repo := NewUserKeypairExtraRepository(testDB)
 	user := insertTestUser(t, "u_kpx_2", "kpx2")

--- a/internal/repository/user_keypair_extra_test.go
+++ b/internal/repository/user_keypair_extra_test.go
@@ -53,18 +53,22 @@ func TestUserKeypairExtraRepository_InsertIfAbsent(t *testing.T) {
 	defer cleanupUser(t, user.ID)
 	defer cleanupUserKeypairExtra(t, user.ID)
 
-	// 1 回目: 新規挿入
-	require.NoError(t, repo.InsertIfAbsent(&model.UserKeypairExtra{
+	// 1 回目: 新規挿入 → inserted=true
+	inserted, err := repo.InsertIfAbsent(&model.UserKeypairExtra{
 		UserID: user.ID, Ed25519PublicKey: "PUB1", Ed25519PrivateKey: "PRIV1",
-	}))
+	})
+	require.NoError(t, err)
+	assert.True(t, inserted, "初回 insert は inserted=true")
 	got, err := repo.FindByUserID(user.ID)
 	require.NoError(t, err)
 	assert.Equal(t, "PUB1", got.Ed25519PublicKey)
 
-	// 2 回目: 既存行があるので no-op (旧 row が保持される)
-	require.NoError(t, repo.InsertIfAbsent(&model.UserKeypairExtra{
+	// 2 回目: 既存行があるので no-op (旧 row が保持される) → inserted=false
+	inserted, err = repo.InsertIfAbsent(&model.UserKeypairExtra{
 		UserID: user.ID, Ed25519PublicKey: "PUB2", Ed25519PrivateKey: "PRIV2",
-	}))
+	})
+	require.NoError(t, err)
+	assert.False(t, inserted, "既存行ありの場合 inserted=false")
 	got, err = repo.FindByUserID(user.ID)
 	require.NoError(t, err)
 	assert.Equal(t, "PUB1", got.Ed25519PublicKey, "既存行は保持される (race-safe)")

--- a/internal/testutil/mock_repository.go
+++ b/internal/testutil/mock_repository.go
@@ -4053,6 +4053,17 @@ func (m *MockUserKeypairExtraRepository) Upsert(k *model.UserKeypairExtra) error
 	return nil
 }
 
+// InsertIfAbsent inserts only when no entry exists for the userId. Returns nil
+// in both insert-success and "row already exists" cases (= ON CONFLICT DO
+// NOTHING semantic of the production repository).
+func (m *MockUserKeypairExtraRepository) InsertIfAbsent(k *model.UserKeypairExtra) error {
+	if _, exists := m.Keypairs[k.UserID]; exists {
+		return nil
+	}
+	m.Keypairs[k.UserID] = k
+	return nil
+}
+
 func (m *MockUserKeypairExtraRepository) FindByUserID(userID string) (*model.UserKeypairExtra, error) {
 	k, ok := m.Keypairs[userID]
 	if !ok {

--- a/internal/testutil/mock_repository.go
+++ b/internal/testutil/mock_repository.go
@@ -4053,15 +4053,16 @@ func (m *MockUserKeypairExtraRepository) Upsert(k *model.UserKeypairExtra) error
 	return nil
 }
 
-// InsertIfAbsent inserts only when no entry exists for the userId. Returns nil
-// in both insert-success and "row already exists" cases (= ON CONFLICT DO
-// NOTHING semantic of the production repository).
-func (m *MockUserKeypairExtraRepository) InsertIfAbsent(k *model.UserKeypairExtra) error {
+// InsertIfAbsent inserts only when no entry exists for the userId. Returns
+// (inserted, nil) where inserted=true if a new row was inserted, false if a
+// row already existed (= ON CONFLICT DO NOTHING semantic of the production
+// repository).
+func (m *MockUserKeypairExtraRepository) InsertIfAbsent(k *model.UserKeypairExtra) (bool, error) {
 	if _, exists := m.Keypairs[k.UserID]; exists {
-		return nil
+		return false, nil
 	}
 	m.Keypairs[k.UserID] = k
-	return nil
+	return true, nil
 }
 
 func (m *MockUserKeypairExtraRepository) FindByUserID(userID string) (*model.UserKeypairExtra, error) {


### PR DESCRIPTION
## Summary

P1 マイグレーション前から存在する local user (= \`user_keypair_extra\` に行が無い) の actor JSON 生成時に、Ed25519 鍵を on-demand で発行・永続化して \`assertionMethod\` に expose する **lazy backfill** を実装。

親 issue: #1067
Closes #1072
依存: P1 #1068 のみ (P2/P3/P4 も依存できるが、P5 単独で機能)

## drop-in 互換

- 新規 user は P1 経路で signup 時に既に Ed25519 鍵を持つため backfill 不要
- 旧 user (= P1 以前の signup) は最初の actor JSON fetch で lazy backfill → 以後 \`assertionMethod\` を expose
- backfill 失敗 (鍵生成 / DB Insert / PEM parse のいずれか) → RSA only にフォールバック (連合継続)
- TS swap 時は TS が \`user_keypair_extra\` を読まないため、backfill された鍵は table に残るが TS は無視 (= 影響なし)。mk-go に戻したときに再利用される

## 主な変更点

### \`internal/repository/user_keypair_extra.go\`
- 新規 method \`InsertIfAbsent(*UserKeypairExtra) error\`: ON CONFLICT DO NOTHING で race-safe な lazy backfill primitive
- 並列で同 user の鍵を生成しても DB 上は最初に書かれた行が残る (= Upsert のように後勝ちで鍵が置換されない)

### \`internal/api/ap/handler.go\`
- \`lookupEd25519PublicKey\` の \`ErrRecordNotFound\` 分岐で \`backfillEd25519PublicKey\` を呼ぶよう拡張
- \`backfillEd25519PublicKey\`: GenerateEd25519Keypair → InsertIfAbsent → 再 FindByUserID で永続化された行を取得して公開鍵を返す
- 並列 backfill で別 goroutine が先に書いた場合も、再 lookup で確実に正しい鍵を返す race-safe pattern
- 失敗時は nil 返却で RSA only fallback

### mock / stub
- \`testutil.MockUserKeypairExtraRepository\` に \`InsertIfAbsent\` 実装
- 既存 stub 4 種 (failingUpsertKeypairExtraRepo / failingKeypairExtraRepo / stubKeypairExtraRepo / failingExtraUpsert) に method 追加で interface 充足

## テスト

新規 4 件:

\`internal/repository\`:
- \`TestUserKeypairExtraRepository_InsertIfAbsent\`: ON CONFLICT DO NOTHING の挙動 (既存行が保持される) を repository 層で検証

\`internal/api/ap\`:
- \`TestUser_WithEd25519Repo_NoRowForUser_TriggersLazyBackfill\` (旧 test 改名): 旧 user に対して actor JSON 生成時に backfill が走り、\`assertionMethod\` が expose される + mock 上に新規 row が保存される
- \`TestUser_LazyBackfill_RaceSafe\`: 8 並列 actor JSON 生成で DB 上 1 行に集約される race-safe 性を検証
- \`TestUser_LazyBackfill_InsertFailureFallsBackToRSAOnly\`: \`InsertIfAbsent\` が DB error を返した場合に RSA only に fail-soft

\`\`\`bash
make test       # 全 119 pkg pass
go test ./internal/api/ap/ -cover         # 97.5%
go test ./internal/repository/ -cover     # 90.4%
\`\`\`

## Admin CLI 一括 backfill (任意、本 PR スコープ外)

issue #1072 では \`admin CLI による一括 backfill\` も任意項目として挙げていたが、本 PR では lazy backfill のみ実装。理由:

- 全 user の最初の actor JSON fetch (= 他鯖からの follow / search 等) で自然に backfill が走る
- 一括 backfill が必要な状況は限定的 (= initial migration timing で全 user の Ed25519 鍵を即時用意したい場合のみ)
- 必要に応じて後続 PR で \`cmd/migrate\` に \`backfill-ed25519\` サブコマンドを追加

## ed25519 全体進捗

| Phase | Issue | PR | Status |
|-------|-------|-----|--------|
| P1 | #1068 | #1074 | merged |
| P2 | #1069 | #1078 | merged |
| P3 | #1070 | #1079 | merged |
| P4 | #1071 | #1080 | merged |
| **P5** | **#1072** | **#1081** | **PR open** |
| P6 | #1073 | - | 着手可 (Drop-in test) |

## 次のステップ

このマージ後、parent #1067 の最終 sub issue:

- **P6 (#1073)** — Drop-in test (TS ↔ mk swap で Ed25519 expose / RSA fallback / 連合継続)