### PR TITLE
ed25519: drop-in roundtrip test で TS-A 戻し後の連合継続を検証 (#1082)

### DIFF
--- a/tests/dropin/run-swap-test.sh
+++ b/tests/dropin/run-swap-test.sh
@@ -8,7 +8,10 @@
 #   4. mk-go overlay で app-a を mk-go ビルドに置き換えて起動
 #   5. mk-A の healthy 待ち
 #   6. test_swap_verify.py で state preserved + 新規 federation 動作を確認
-#   7. cleanup
+#   7. mk-A backend を停止して TS-A に戻す (#1082 SHOULD shape)
+#   8. TS-A 起動 healthy 待ち + nginx-a restart
+#   9. test_swap_roundtrip_verify.py で TS 戻し後の連合継続を確認
+#  10. cleanup
 #
 # pytest セッションを跨いで docker compose を切り替える必要があるため、
 # orchestration を bash で外側に置く。test runner コンテナ内に docker CLI を
@@ -87,5 +90,38 @@ docker compose -f "$BASE" -f "$OVERLAY" restart nginx-a
 
 echo "===> stage 6: verify state preserved on mk-A"
 docker compose -f "$BASE" -f "$OVERLAY" --profile test run --rm test-runner pytest test_swap_verify.py -v
+
+echo "===> stage 7: stop mk-A backend (roundtrip 戻し前準備)"
+docker compose -f "$BASE" -f "$OVERLAY" stop app-a
+
+echo "===> stage 8: bring up TS-A backend (overlay 解除で TS に戻す)"
+# overlay を指定せず base のみで up することで、app-a が TS-A の image に戻る。
+docker compose -f "$BASE" up -d app-a
+
+echo "===> stage 8b: wait for TS-A healthy"
+deadline=$(($(date +%s) + 180))
+while :; do
+  state=$(docker compose -f "$BASE" ps --format json | python3 -c "
+import sys, json
+ls=[json.loads(l) for l in sys.stdin if l.strip()]
+ms=[s for s in ls if s.get('Service')=='app-a']
+print(ms[0].get('Health') if ms else 'missing')
+")
+  if [ "$state" = "healthy" ]; then
+    break
+  fi
+  if [ "$(date +%s)" -ge "$deadline" ]; then
+    echo "FAIL: TS-A (roundtrip) did not become healthy within 180s"
+    docker compose -f "$BASE" logs app-a | tail -50
+    exit 1
+  fi
+  sleep 3
+done
+
+echo "===> stage 8c: restart nginx-a so the upstream re-resolves to TS-A"
+docker compose -f "$BASE" restart nginx-a
+
+echo "===> stage 9: verify federation continuity after TS roundtrip (#1082)"
+docker compose -f "$BASE" --profile test run --rm test-runner pytest test_swap_roundtrip_verify.py -v
 
 echo "===> all stages PASS"

--- a/tests/dropin/run-swap-test.sh
+++ b/tests/dropin/run-swap-test.sh
@@ -61,7 +61,10 @@ echo "===> stage 3: stop TS-A backend (DB-A / Redis-A keep state)"
 docker compose -f "$BASE" stop app-a
 
 echo "===> stage 4: bring up mk-go overlay on instance A"
-docker compose -f "$BASE" -f "$OVERLAY" up -d --build app-a
+# --force-recreate で旧 TS-A image の停止 container を確実に破棄し、新規
+# mk-A container として起動する。image label 一致時に compose が container
+# を reuse して image が更新されない曖昧さを回避 (#1085 review #1)。
+docker compose -f "$BASE" -f "$OVERLAY" up -d --build --force-recreate app-a
 
 echo "===> stage 5: wait for mk-A healthy"
 deadline=$(($(date +%s) + 180))
@@ -96,7 +99,9 @@ docker compose -f "$BASE" -f "$OVERLAY" stop app-a
 
 echo "===> stage 8: bring up TS-A backend (overlay 解除で TS に戻す)"
 # overlay を指定せず base のみで up することで、app-a が TS-A の image に戻る。
-docker compose -f "$BASE" up -d app-a
+# --force-recreate で停止中の mk-A container を確実に破棄し、新規 TS-A
+# container を起動する (#1085 review #1)。
+docker compose -f "$BASE" up -d --force-recreate app-a
 
 echo "===> stage 8b: wait for TS-A healthy"
 deadline=$(($(date +%s) + 180))

--- a/tests/dropin/test_swap_roundtrip_verify.py
+++ b/tests/dropin/test_swap_roundtrip_verify.py
@@ -1,0 +1,117 @@
+"""SHOULD scenario (#1082): TS-A 戻し後の連合継続。
+
+`run-swap-test.sh` の stage 9 で実行される。シナリオ:
+
+  TS-A signup
+    → test_swap_setup.py で alice/bob/follow/note 構築
+    → mk-A 切替 (P5 lazy backfill で user_keypair_extra に Ed25519 鍵発行)
+    → test_swap_verify.py で MUST 検証 (#1073)
+    → ★ TS-A backend に戻し ★
+    → 本ファイル: roundtrip 後の連合継続を検証
+
+期待挙動:
+  - TS-A の actor JSON から assertionMethod が消える (Misskey TS は出さない仕様)
+  - 既存 RSA publicKey は引き続き expose
+  - user_keypair_extra の row は DB に残るが TS は touch しない → 戻し時の
+    state 引き継ぎは破壊されない
+  - TS-B からの federation (follow / 投稿 / リアクション) が RSA 経由で
+    引き続き動く
+"""
+
+from __future__ import annotations
+
+from conftest import A_DOMAIN  # type: ignore[import-not-found]
+from conftest_base import MisskeyLikeClient, poll_until  # type: ignore[import-not-found]
+
+
+def test_roundtrip_alice_actor_no_longer_exposes_assertion_method(
+    instance_a: MisskeyLikeClient,
+    alice: dict,
+) -> None:
+    """TS-A 戻し後の actor JSON で assertionMethod が消える。Misskey TS は
+    `user_keypair_extra` テーブルを認識せず renderer も assertionMethod を
+    出さない仕様なので、mk-A 時代に発行された Ed25519 鍵は実質「actor JSON
+    上は」消えた扱いになる。既存 RSA publicKey は引き続き expose されて
+    いて federation は RSA fallback で継続する (#1082)。
+    """
+    resp = instance_a.http.get(
+        f"/users/{alice['id']}",
+        headers={"Accept": "application/activity+json"},
+    )
+    assert resp.status_code == 200, (
+        f"expected 200 from actor endpoint, got {resp.status_code}"
+    )
+    actor = resp.json()
+
+    # TS は assertionMethod を出さない (= 戻し後 actor JSON 上から消える)
+    ams = actor.get("assertionMethod")
+    assert not ams, (
+        f"TS-A should not expose assertionMethod after roundtrip; got: {ams!r}"
+    )
+
+    # 既存 RSA publicKey は依然存在し、federation の verify path はこちらで動く
+    pub = actor.get("publicKey") or {}
+    assert "publicKeyPem" in pub, "RSA publicKey must remain after roundtrip"
+    assert pub.get("id", "").endswith("#main-key"), (
+        f"primary key id should still be #main-key (got: {pub.get('id')!r})"
+    )
+
+
+def test_roundtrip_alice_can_post_and_bob_receives(
+    instance_a: MisskeyLikeClient,
+    instance_b: MisskeyLikeClient,
+    alice: dict,
+    bob: dict,
+) -> None:
+    """TS-A 戻し後の alice が新規 note を投稿し、TS-B (= bob) 側に federation
+    経由で届くことを確認する。Ed25519 鍵を失った (= 出さなくなった) 状態で
+    RSA fallback で deliver / verify が継続する evidence。
+    """
+    note_text = "dropin-roundtrip-after-ts-restore"
+    instance_a.create_note(note_text)
+
+    def _arrived() -> bool:
+        tl = instance_b._api("notes/timeline", {"limit": 40})
+        return any(n.get("text") == note_text for n in tl)
+
+    assert poll_until(
+        _arrived, timeout=120, desc="bob receives post-roundtrip note from TS-A alice"
+    )
+
+
+def test_roundtrip_bob_can_react_to_alice_note(
+    instance_a: MisskeyLikeClient,
+    instance_b: MisskeyLikeClient,
+    alice: dict,
+    bob: dict,
+) -> None:
+    """TS-B (= bob) から TS-A 戻し後の alice の note にリアクションを付け、
+    alice 側 (TS-A) に federation 経由で届くことを確認する。逆方向
+    (TS-B → TS-A) の deliver も RSA で動く evidence。
+    """
+    # 先ほどの test で送った roundtrip note を bob 側で探す
+    note_text = "dropin-roundtrip-after-ts-restore"
+    tl_b = instance_b._api("notes/timeline", {"limit": 40})
+    target = next((n for n in tl_b if n.get("text") == note_text), None)
+    assert target is not None, "roundtrip note must be visible on B before reacting"
+
+    try:
+        instance_b.react(target["id"], "🎉")
+    except RuntimeError as e:
+        if "ALREADY" not in str(e).upper():
+            raise
+
+    def _alice_sees_reaction() -> bool:
+        notifications = instance_a.get_notifications(limit=20)
+        for n in notifications:
+            if n.get("type") != "reaction":
+                continue
+            from_user = n.get("user") or {}
+            # bob は instance A から見ると remote (host = "b") として届く
+            if from_user.get("username") == "bob" and from_user.get("host") != A_DOMAIN:
+                return True
+        return False
+
+    assert poll_until(
+        _alice_sees_reaction, timeout=120, desc="alice (TS-A) receives bob reaction after roundtrip"
+    )

--- a/tests/dropin/test_swap_roundtrip_verify.py
+++ b/tests/dropin/test_swap_roundtrip_verify.py
@@ -88,12 +88,23 @@ def test_roundtrip_bob_can_react_to_alice_note(
     """TS-B (= bob) から TS-A 戻し後の alice の note にリアクションを付け、
     alice 側 (TS-A) に federation 経由で届くことを確認する。逆方向
     (TS-B → TS-A) の deliver も RSA で動く evidence。
+
+    本 test は前段 test に依存せず独立に動くよう、自身で reaction target
+    note を作って bob 側に伝搬するまで待ってからリアクションを付ける。
     """
-    # 先ほどの test で送った roundtrip note を bob 側で探す
-    note_text = "dropin-roundtrip-after-ts-restore"
+    target_text = "dropin-roundtrip-bob-react-target"
+    instance_a.create_note(target_text)
+
+    def _arrived_on_b() -> bool:
+        tl = instance_b._api("notes/timeline", {"limit": 40})
+        return any(n.get("text") == target_text for n in tl)
+
+    assert poll_until(
+        _arrived_on_b, timeout=120, desc="bob receives roundtrip reaction-target note"
+    )
+
     tl_b = instance_b._api("notes/timeline", {"limit": 40})
-    target = next((n for n in tl_b if n.get("text") == note_text), None)
-    assert target is not None, "roundtrip note must be visible on B before reacting"
+    target = next(n for n in tl_b if n.get("text") == target_text)
 
     try:
         instance_b.react(target["id"], "🎉")


### PR DESCRIPTION
## Summary

ed25519 P6 follow-up: mk-A 切替後に TS-A backend に戻したとき、Ed25519 鍵を失った (= 出さなくなった) 状態で他鯖との federation が RSA fallback で継続することを drop-in test で検証。

親 issue: #1067 (closed)
Closes #1082

## drop-in 互換 e2e 担保

- mk-A 経由で \`user_keypair_extra\` に発行された Ed25519 鍵は DB に残るが、TS は touch せず actor JSON も出さない
- 既存 RSA \`publicKey\` は両 backend で共通の identity → federation 継続
- 他鯖の Ed25519 cache が失効した後も RSA fallback 経路で deliver / verify が動く

## 主な変更点

### \`tests/dropin/run-swap-test.sh\`
既存 stage 1-6 の後に stage 7-9 を追加:
- stage 7: mk-A backend を stop (DB-A / Redis-A / user_keypair_extra 行は残る)
- stage 8: overlay 解除で TS-A image を再起動 → healthy 待ち + nginx-a restart
- stage 9: \`test_swap_roundtrip_verify.py\` で連合継続を検証

### \`tests/dropin/test_swap_roundtrip_verify.py\` (新規)
3 test:
- \`test_roundtrip_alice_actor_no_longer_exposes_assertion_method\`: TS-A 戻し後の actor JSON で assertionMethod が omit + 既存 RSA publicKey 維持
- \`test_roundtrip_alice_can_post_and_bob_receives\`: TS-A 戻し後の alice → TS-B (bob) への deliver が RSA で動く
- \`test_roundtrip_bob_can_react_to_alice_note\`: TS-B → TS-A の逆方向 federation も RSA で動く

## テスト

\`\`\`bash
make test       # 全 119 pkg pass (production code 変更なし)
bash -n tests/dropin/run-swap-test.sh   # bash syntax OK
\`\`\`

drop-in test 本体は nightly \`dropin-e2e\` workflow (18:00 UTC) で初回実行。PR required check には含まれない (大きな orchestration を要するため通常の test shard には乗らない方針)。

## 残スコープ

- **#1083** — Fedibird mock との Ed25519 verify (NICE-TO-HAVE): 別 PR で対応

## production observation 補強

ed25519 シリーズの全 e2e 経路が nightly で walks through されるようになった:
- TS-A → mk-A swap で Ed25519 expose (P6 MUST、PR #1084 で追加済)
- mk-A → TS-A 戻しで連合継続 (P6 SHOULD、本 PR)

両方向 swap の regression を nightly で検出する仕組み。