### PR TITLE
Fix CI flaky: repository test の ID 衝突 + pgx prepared plan invalidation (#1089)

### DIFF
--- a/internal/repository/flash_test.go
+++ b/internal/repository/flash_test.go
@@ -32,7 +32,7 @@ func newTestFlash(id, ownerID, title string) *model.Flash {
 
 func TestFlashRepository_CreateAndFindByID(t *testing.T) {
 	repo := NewFlashRepository(testDB)
-	user := insertTestUser(t, "u_fr_1", "flashuser1")
+	user := insertTestUser(t, "u_fla_1", "flashuser1")
 	defer cleanupUser(t, user.ID)
 
 	f := newTestFlash("fl_cr_1", user.ID, "alpha")
@@ -52,7 +52,7 @@ func TestFlashRepository_FindByID_NotFound(t *testing.T) {
 
 func TestFlashRepository_UpdateFields(t *testing.T) {
 	repo := NewFlashRepository(testDB)
-	user := insertTestUser(t, "u_fr_2", "flashuser2")
+	user := insertTestUser(t, "u_fla_2", "flashuser2")
 	defer cleanupUser(t, user.ID)
 
 	f := newTestFlash("fl_cr_2", user.ID, "beta")
@@ -106,7 +106,7 @@ func TestFlashRepository_UpdateFields_EmptyPermissions(t *testing.T) {
 
 func TestFlashRepository_Delete(t *testing.T) {
 	repo := NewFlashRepository(testDB)
-	user := insertTestUser(t, "u_fr_3", "flashuser3")
+	user := insertTestUser(t, "u_fla_3", "flashuser3")
 	defer cleanupUser(t, user.ID)
 
 	f := newTestFlash("fl_cr_3", user.ID, "gamma")
@@ -118,7 +118,7 @@ func TestFlashRepository_Delete(t *testing.T) {
 
 func TestFlashRepository_IncrementCount(t *testing.T) {
 	repo := NewFlashRepository(testDB)
-	user := insertTestUser(t, "u_fr_4", "flashuser4")
+	user := insertTestUser(t, "u_fla_4", "flashuser4")
 	defer cleanupUser(t, user.ID)
 
 	f := newTestFlash("fl_cr_4", user.ID, "delta")
@@ -133,7 +133,7 @@ func TestFlashRepository_IncrementCount(t *testing.T) {
 
 func TestFlashRepository_ListByUser(t *testing.T) {
 	repo := NewFlashRepository(testDB)
-	user := insertTestUser(t, "u_fr_5", "flashuser5")
+	user := insertTestUser(t, "u_fla_5", "flashuser5")
 	defer cleanupUser(t, user.ID)
 
 	for _, id := range []string{"fl_lst_1", "fl_lst_2", "fl_lst_3"} {
@@ -168,7 +168,7 @@ func TestFlashRepository_ListByUser_QueryError(t *testing.T) {
 
 func TestFlashRepository_ListFeatured(t *testing.T) {
 	repo := NewFlashRepository(testDB)
-	user := insertTestUser(t, "u_fr_6", "flashuser6")
+	user := insertTestUser(t, "u_fla_6", "flashuser6")
 	defer cleanupUser(t, user.ID)
 
 	flashes := []*model.Flash{
@@ -213,7 +213,7 @@ func TestFlashRepository_ListFeatured_QueryError(t *testing.T) {
 
 func TestFlashRepository_Search(t *testing.T) {
 	repo := NewFlashRepository(testDB)
-	user := insertTestUser(t, "u_fr_7", "flashuser7")
+	user := insertTestUser(t, "u_fla_7", "flashuser7")
 	defer cleanupUser(t, user.ID)
 
 	titles := map[string]string{

--- a/internal/repository/following_test.go
+++ b/internal/repository/following_test.go
@@ -177,7 +177,7 @@ func TestFollowingRepository_ListRemoteFollowerInboxes(t *testing.T) {
 
 func TestUserRepository_IncrementFollowingCount(t *testing.T) {
 	repo := NewUserRepository(testDB)
-	user := insertTestUser(t, "u_inc_1", "incuser")
+	user := insertTestUser(t, "u_f_inc_1", "fincuser1")
 	defer cleanupUser(t, user.ID)
 
 	require.NoError(t, repo.IncrementFollowingCount(user.ID, 1))

--- a/internal/repository/note_test.go
+++ b/internal/repository/note_test.go
@@ -584,7 +584,7 @@ func TestNoteRepository_IncrementReaction(t *testing.T) {
 
 func TestNoteRepository_IncrementCount(t *testing.T) {
 	repo := NewNoteRepository(testDB)
-	user := insertTestUser(t, "u_inc_1", "incuser")
+	user := insertTestUser(t, "u_n_inc_1", "incuser1")
 	defer cleanupUser(t, user.ID)
 
 	note := &model.Note{
@@ -1473,7 +1473,7 @@ func TestNoteRepository_ListByFileID_Cursor(t *testing.T) {
 
 func TestNoteRepository_IncrementUserNotesCount(t *testing.T) {
 	repo := NewNoteRepository(testDB)
-	user := insertTestUser(t, "u_inc_1", "incuser")
+	user := insertTestUser(t, "u_n_inc_2", "incuser2")
 	defer cleanupUser(t, user.ID)
 
 	require.NoError(t, repo.IncrementUserNotesCount(user.ID, 3))

--- a/internal/testutil/testdb.go
+++ b/internal/testutil/testdb.go
@@ -29,7 +29,16 @@ func OpenTestDB() (*gorm.DB, error) {
 	dsn := fmt.Sprintf("host=%s port=%s user=%s password=%s dbname=%s sslmode=%s",
 		host, port, user, pass, name, sslmode)
 
-	return gorm.Open(postgres.Open(dsn), &gorm.Config{
+	// PreferSimpleProtocol: pgx の auto-prepared statement cache を無効化する。
+	// 共有 testDB を多 test で再利用する CI 環境で、軽微な schema 差分 (= AutoMigrate
+	// による additive 変更や test 経路で DDL 相当が走るケース) のあと再 query すると
+	// `ERROR: cached plan must not change result type` が偶発的に出る (#1089)。
+	// simple protocol に倒すと server 側 prepared statement を作らないため本問題が
+	// 構造的に消える。性能は落ちるが test では問題ない。
+	return gorm.Open(postgres.New(postgres.Config{
+		DSN:                  dsn,
+		PreferSimpleProtocol: true,
+	}), &gorm.Config{
 		Logger: logger.Default.LogMode(logger.Silent),
 	})
 }


### PR DESCRIPTION
## Summary

shard 1 でランダムに fail していた 3 種類の `internal/repository` test flaky を 1 PR で解消する。並列実行ではなく `t.Parallel()` 無しの serial 実行でも、 fixture ID の test 関数間重複 / 共有 testDB の prepared plan invalidation で偶発 fail していた。

## 主な変更点

### (A)(C) ID 衝突修正

複数の test 関数で重複していた fixture ID を unique 化:

- `flash_test.go` の `u_fr_1..7` → `u_fla_1..7` (= follow_request_test.go と分離、 flash 専用 prefix)
- `note_test.go` 内 2 箇所の `u_inc_1` → `u_n_inc_1` / `u_n_inc_2` (note increment 系)
- `following_test.go:180` の `u_inc_1` → `u_f_inc_1` (following increment 系)

命名規則は **`u_<file 文脈の abbreviation>_<連番>`** で統一 (= note: `u_n_inc_*` / following: `u_f_inc_*` / flash: `u_fla_*`)。 prefix から元 test の文脈が読める。

serial 実行でも `cleanupUser` の DELETE が FK 等で失敗して行が残留すると次 test の `testDB.Create(user)` が PK 衝突を起こすケースを構造的に回避。

### (B) pgx prepared plan invalidation 修正

`testutil.OpenTestDB` に `PreferSimpleProtocol: true` を追加し、pgx の auto-prepared statement cache を無効化。test 経路で schema 周辺の微差 (AutoMigrate / DDL 相当) が走った後に再 query すると偶発的に `cached plan must not change result type` (SQLSTATE 0A000) が出ていたが、simple protocol に倒すと server 側 prepared statement を作らないため本問題が構造的に消える。性能低下は test 環境では許容範囲。

## テスト

ローカル PostgreSQL 実 DB で:

```
$ go test -race -count=5 ./internal/repository/...
ok  	github.com/shiroha-a/mk/internal/repository	33.391s

$ go test -race -count=10 -run "TestFollowRequestRepository_Delete|TestNoteRepository_SearchByFilter|TestRegistrationTicketRepository_CountByCreatorSince" ./internal/repository/...
ok  	github.com/shiroha-a/mk/internal/repository	2.437s
```

`make fmt` / `make lint` / `go build ./...` 全 clean。

## 設計判断

- **`cleanupUser` を `t.Cleanup()` 化は scope 外**: defer は `require.NoError` (= `t.FailNow`) でも実行される (Go の deferred call は `runtime.Goexit` でも動く)。 cleanup 関数自体の DELETE failure は ID unique 化で根本回避済み。
- **重複 ID の構造的防止策は別 PR**: 本 PR は具体的に観測された 10 箇所の重複を手動 rename で fix する症状直接解消アプローチ。runtime caller-aware ID seed / CI 重複検出 lint といった構造的防止策は #1094 で記録し、follow-up で対応。

## 関連 (残 CI flaky)

- 本 PR で fix: #1089 (repository tests DB 並列衝突 / shard 1)
- Follow-up: #1094 (重複 fixture ID の構造的防止)
- 残り: #1088 (`TestDecodeImage_JP2` 3rd party lib race / shard 1)
- 残り: #1090 (`internal/api/apierr` coverage 境界 flaky / shard 3)

## Closes

Closes #1089