### PR TITLE
Fix CI flaky: TestDecodeImage_JP2 を -race build から除外 (#1088)

### DIFF
--- a/internal/core/mediaproxy/service_jp2_test.go
+++ b/internal/core/mediaproxy/service_jp2_test.go
@@ -1,0 +1,44 @@
+//go:build !race
+
+// JPEG 2000 input 経路の round-trip test を `-race` build から除外する。
+// `mrjoshuak/go-jpeg2000` v1.2.1 の `(*encoder).encodeTile` が起動する
+// 子 goroutine が同 `*T1` の field を mutex 無しで read/write しており、
+// Go race detector に検出される (#1088 / lib 内部 bug)。mk-go 側で
+// 修正できないため、`-race` build (= CI shard 1) ではこの test を
+// compile から外し、通常 build では引き続き走らせて回帰検出する。
+//
+// 上流 library が race fix を出したら本 build tag を撤去できる。
+
+package mediaproxy
+
+import (
+	"bytes"
+	"image"
+	"image/color"
+	"testing"
+
+	jpeg2000 "github.com/mrjoshuak/go-jpeg2000"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestDecodeImage_JP2 は #734 で追加した JPEG 2000 pure Go decoder
+// (mrjoshuak/go-jpeg2000) の input 経路を確認する。Encode → Decode の
+// round-trip で bounds が保たれれば OK。標準 image.Decode 経由で動作する。
+func TestDecodeImage_JP2(t *testing.T) {
+	// 2x2 RGB image を JP2 で encode してから decode で読み直す
+	src := image.NewRGBA(image.Rect(0, 0, 2, 2))
+	src.Set(0, 0, color.RGBA{R: 255, A: 255})
+	src.Set(1, 0, color.RGBA{G: 255, A: 255})
+	src.Set(0, 1, color.RGBA{B: 255, A: 255})
+	src.Set(1, 1, color.RGBA{R: 255, G: 255, A: 255})
+
+	var buf bytes.Buffer
+	require.NoError(t, jpeg2000.Encode(&buf, src, nil), "encode JP2")
+	require.NotEmpty(t, buf.Bytes())
+
+	img, err := decodeImage(buf.Bytes(), "image/jp2")
+	require.NoError(t, err)
+	assert.Equal(t, 2, img.Bounds().Dx())
+	assert.Equal(t, 2, img.Bounds().Dy())
+}

--- a/internal/core/mediaproxy/service_test.go
+++ b/internal/core/mediaproxy/service_test.go
@@ -1,7 +1,6 @@
 package mediaproxy
 
 import (
-	"bytes"
 	"context"
 	"fmt"
 	"image"
@@ -12,7 +11,6 @@ import (
 	"net/http/httptest"
 	"testing"
 
-	jpeg2000 "github.com/mrjoshuak/go-jpeg2000"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -675,26 +673,10 @@ func TestFetch_PassThrough_MNG(t *testing.T) {
 	assert.Equal(t, mngBytes, body)
 }
 
-// TestDecodeImage_JP2 は #734 で追加した JPEG 2000 pure Go decoder
-// (mrjoshuak/go-jpeg2000) の input 経路を確認する。Encode → Decode の
-// round-trip で bounds が保たれれば OK。標準 image.Decode 経由で動作する。
-func TestDecodeImage_JP2(t *testing.T) {
-	// 2x2 RGB image を JP2 で encode してから decode で読み直す
-	src := image.NewRGBA(image.Rect(0, 0, 2, 2))
-	src.Set(0, 0, color.RGBA{R: 255, A: 255})
-	src.Set(1, 0, color.RGBA{G: 255, A: 255})
-	src.Set(0, 1, color.RGBA{B: 255, A: 255})
-	src.Set(1, 1, color.RGBA{R: 255, G: 255, A: 255})
-
-	var buf bytes.Buffer
-	require.NoError(t, jpeg2000.Encode(&buf, src, nil), "encode JP2")
-	require.NotEmpty(t, buf.Bytes())
-
-	img, err := decodeImage(buf.Bytes(), "image/jp2")
-	require.NoError(t, err)
-	assert.Equal(t, 2, img.Bounds().Dx())
-	assert.Equal(t, 2, img.Bounds().Dy())
-}
+// TestDecodeImage_JP2 は service_jp2_test.go に移動した (#1088)。
+// 3rd party lib `mrjoshuak/go-jpeg2000` 内部の data race を踏むため
+// `-race` build から除外する必要があり、build tag (`//go:build !race`)
+// で separate file 化している。
 
 // TestDecodeImage_TGA は #672 Phase 1 で追加した TGA decoder (blezek/tga)
 // が contentType 経由で manual dispatch されることを確認する。


### PR DESCRIPTION
## Summary

shard 1 でランダムに fail していた `TestDecodeImage_JP2` を build tag で `-race` build から除外して flaky を解消する。

本 test は `jpeg2000.Encode` 経由で 3rd party lib `mrjoshuak/go-jpeg2000` v1.2.1 の内部 race を踏むため、Go race detector に検出されていた。**mk-go 側で fix できない** ため、`-race` build からは compile を外し、通常 build では引き続き走らせて回帰検出する design に倒す。

## 観測した race

```
WARNING: DATA RACE
Write at 0x... by goroutine 277:
  go-jpeg2000/internal/entropy.(*T1).EncodeFast5()
      .../mrjoshuak/go-jpeg2000@v1.2.1/internal/entropy/t1_fast5.go:30
Previous read at 0x... by goroutine 278:
  go-jpeg2000/internal/entropy.(*T1).TruncationPoints()
      .../mrjoshuak/go-jpeg2000@v1.2.1/internal/entropy/t1.go:156

Goroutine 277 / 278 created at:
  go-jpeg2000.(*encoder).encodeTile.func1()
      .../mrjoshuak/go-jpeg2000@v1.2.1/encoder.go:1027
```

`(*encoder).encodeTile.func1` が起動する子 goroutine が同 `*T1` の field を mutex 無しで read/write している lib 内部 bug。

## 修正方針

build tag `//go:build !race` を持つ別 file `service_jp2_test.go` に `TestDecodeImage_JP2` を切り出す:

- **通常 build (= 開発時 `go test ./...`)**: JP2 round-trip test 実行
- **`-race` build (= CI test-shards)**: test を compile から除外

上流 library が race fix を release したら本 build tag を撤去できる (元 file に戻すだけ)。

## カバレッジ影響

mediaproxy package coverage:
- 通常 build: 90.9%
- `-race` build (CI): 90.5%

どちらも 90% 閾値クリア。`decodeImage` 関数のカバレッジは 88.9% (JP2 dispatch path 含む) で、JP2 path の細部 cover は通常 build (= 開発者ローカル / 上流 library 修正後の CI) で担保される。

`-race` 環境のマージン 0.5% は薄いが、本 PR はそもそも shard 1 flaky 解消が目的で、coverage 薄化は trade-off として許容範囲。将来 mediaproxy 内に新 code を入れて 90% 割れた場合は別 PR で fixture-based JP2 test (Encode 回避) を追加する余地あり。

## テスト

```
$ go test -count=1 ./internal/core/mediaproxy/...
ok  	github.com/shiroha-a/mk/internal/core/mediaproxy	3.621s

$ go test -race -count=3 ./internal/core/mediaproxy/...
ok  	github.com/shiroha-a/mk/internal/core/mediaproxy	39.009s

$ go test -race -coverprofile=... ./internal/core/mediaproxy/...
ok  	github.com/shiroha-a/mk/internal/core/mediaproxy	28.983s	coverage: 90.5% of statements
```

`make fmt` / `make lint` 全 clean。

## 関連 (残 CI flaky)

- 本 PR で fix: #1088 (`TestDecodeImage_JP2` 3rd party lib race / shard 1)
- 残り: #1090 (`internal/api/apierr` coverage 境界 flaky / shard 3)
- Follow-up: 上流 `mrjoshuak/go-jpeg2000` への race fix PR は中長期検討 (= mk-go 内では追わない)

## Closes

Closes #1088