### PR TITLE
Fix CI flaky: apierr の未cover 3 関数を埋めて 100% に押し上げる (#1090)

### DIFF
--- a/internal/api/apierr/echo_test.go
+++ b/internal/api/apierr/echo_test.go
@@ -269,3 +269,19 @@ func TestJSONFailedToResolveRemoteUser(t *testing.T) {
 	errObj := body["error"].(map[string]any)
 	assert.Equal(t, "FAILED_TO_RESOLVE_REMOTE_USER", errObj["code"])
 }
+
+func TestJSONRolePermissionDenied(t *testing.T) {
+	code, body := invoke(t, JSONRolePermissionDenied)
+	assert.Equal(t, http.StatusForbidden, code)
+	errObj := body["error"].(map[string]any)
+	assert.Equal(t, "ROLE_PERMISSION_DENIED", errObj["code"])
+	assert.Equal(t, UUIDRolePermissionDenied, errObj["id"])
+}
+
+func TestJSONRateLimitExceeded(t *testing.T) {
+	code, body := invoke(t, JSONRateLimitExceeded)
+	assert.Equal(t, http.StatusTooManyRequests, code)
+	errObj := body["error"].(map[string]any)
+	assert.Equal(t, "RATE_LIMIT_EXCEEDED", errObj["code"])
+	assert.Equal(t, UUIDRateLimitExceeded, errObj["id"])
+}

--- a/internal/api/apierr/errors_test.go
+++ b/internal/api/apierr/errors_test.go
@@ -281,6 +281,12 @@ func TestFailedToResolveRemoteUser(t *testing.T) {
 	assert.Equal(t, UUIDFailedToResolveRemoteUser, errObj["id"])
 }
 
+func TestRateLimitExceeded(t *testing.T) {
+	errObj := RateLimitExceeded()["error"].(map[string]any)
+	assert.Equal(t, "RATE_LIMIT_EXCEEDED", errObj["code"])
+	assert.Equal(t, UUIDRateLimitExceeded, errObj["id"])
+}
+
 // #698 で追加したヘルパー: 2FA フロー (register-key / key-done /
 // remove-key / update-key / password-less / done) で利用される。
 // upstream に対応 ApiError が無い code (INVALID_TOKEN /


### PR DESCRIPTION
## Summary

shard 3 でランダムに発生していた `FAIL: github.com/shiroha-a/mk/internal/api/apierr coverage 89.9% is below 90%` を解消する。`apierr` package 内に未 cover の 3 関数があり、CI 環境で揺れて閾値割れしていた。本 PR で全関数を cover し 100% に押し上げて、構造的にマージンを 10% 確保する。

## 観測

ローカル測定で 0% だった 3 関数:

| 関数 | 場所 |
|---|---|
| `JSONRolePermissionDenied` | `echo.go:46` |
| `JSONRateLimitExceeded` | `echo.go:221` |
| `RateLimitExceeded` | `errors.go:426` |

これらは Misskey 互換のため定義したが test を書き忘れていた関数群。ローカルでは package 全体 97.0% で 90% 閾値を超えていたものの、CI shard 3 で 89.9% に落ちることがあった (= 1 関数ぶんの偶発的揺れ)。

## 修正

各関数に既存 pattern (TestJSONFailedToResolveRemoteUser / TestFailedToResolveRemoteUser) を踏襲した test を追加:

- `echo_test.go`: `TestJSONRolePermissionDenied` / `TestJSONRateLimitExceeded` (status code + code + UUID を assert)
- `errors_test.go`: `TestRateLimitExceeded` (code + UUID を assert)

## カバレッジ

```
Before: 97.0% (3 関数 0%)
After:  100.0% (全関数 cover)
```

90% 閾値に対して 10% のマージンを確保し、CI 境界揺れ余地を構造的に排除。

## テスト

```
$ go test -race -count=1 -coverprofile=/tmp/apierr.out ./internal/api/apierr/...
ok  	github.com/shiroha-a/mk/internal/api/apierr	1.060s	coverage: 100.0% of statements
```

`make fmt` / `make lint` 全 clean。

## 関連 (CI flaky 全体)

本 PR で **shard 1/2/3 横断の CI flaky 4 件すべて close**:

- #1091 (mock map race / shard 2) → PR #1092 で fix 済
- #1089 (repository DB 並列衝突 / shard 1) → PR #1093 で fix 済
- #1088 (`TestDecodeImage_JP2` 3rd party lib race / shard 1) → PR #1095 で fix 済
- **#1090 (`apierr` coverage 境界 / shard 3) → 本 PR で fix**

Follow-up:
- #1094 (重複 fixture ID の構造的防止) — repository test ID 衝突の再発防止策

## Closes

Closes #1090