### PR TITLE
CI: 重複 test fixture ID 検出 lint を追加 (#1094)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -170,3 +170,32 @@ jobs:
             echo "$diff"
             exit 1
           fi
+
+      # 重複 fixture ID lint (#1094 / #1089 follow-up)。
+      # internal/repository テストで insertTestUser / insertRemoteTestUser
+      # が同じ ID リテラルを 2 つ以上の caller で使うと、 cleanup 失敗時に
+      # 行残留 → 次 test の PK 衝突を起こす (#1089 で 17 箇所観測)。caller
+      # ごとに unique な ID を強制するための regression guard。
+      #
+      # 将来 caller-aware な runtime seed (insertTestUser 内部で
+      # runtime.Caller から prefix 生成) を入れれば本 lint は不要になる
+      # が、user.id が CHARACTER(16) で既存 ID 最長 12 char のため
+      # prefix 余裕が 4 char しか無く、schema 変更を伴う大改修となるため
+      # 現状は本 lint で網を張る運用とする (#1094 の中期対応として継続検討)。
+      - name: Check duplicate test fixture IDs
+        run: |
+          set -e
+          dupes=$(grep -rhn 'insertTestUser(t, "\|insertRemoteTestUser(t, "' \
+            internal/repository/*_test.go \
+            | awk -F'"' '{print $2}' | sort | uniq -c | sort -rn \
+            | awk '$1 > 1' || true)
+          if [ -n "$dupes" ]; then
+            echo "Duplicate test fixture IDs detected (#1094 / #1089):"
+            echo "$dupes"
+            echo ""
+            echo "Each insertTestUser / insertRemoteTestUser caller must use"
+            echo "a unique ID literal across the repository package. Rename"
+            echo "the duplicates to file-specific prefixes (e.g. u_<file>_*)."
+            exit 1
+          fi
+          echo "No duplicate test fixture IDs."

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -185,14 +185,22 @@ jobs:
       - name: Check duplicate test fixture IDs
         run: |
           set -e
-          dupes=$(grep -rhn 'insertTestUser(t, "\|insertRemoteTestUser(t, "' \
+          dupes=$(grep -rh 'insertTestUser(t, "\|insertRemoteTestUser(t, "' \
             internal/repository/*_test.go \
             | awk -F'"' '{print $2}' | sort | uniq -c | sort -rn \
-            | awk '$1 > 1' || true)
+            | awk '$1 > 1')
           if [ -n "$dupes" ]; then
             echo "Duplicate test fixture IDs detected (#1094 / #1089):"
-            echo "$dupes"
             echo ""
+            # 各重複 ID について file:line を併記して reviewer が CI ログだけで
+            # 犯人を特定できるようにする (= 手動 grep 不要)。
+            while IFS= read -r line; do
+              count=$(echo "$line" | awk '{print $1}')
+              id=$(echo "$line" | awk '{print $2}')
+              echo "  $id (used $count times):"
+              grep -n "\"$id\"" internal/repository/*_test.go | sed 's/^/    /'
+              echo ""
+            done <<< "$dupes"
             echo "Each insertTestUser / insertRemoteTestUser caller must use"
             echo "a unique ID literal across the repository package. Rename"
             echo "the duplicates to file-specific prefixes (e.g. u_<file>_*)."


### PR DESCRIPTION
## Summary

#1089 で 17 箇所観測した「同 fixture ID が複数 caller で再使用される」状況 (= cleanup 失敗時に PK 衝突 → CI flaky) を構造的に再発防止する **regression guard** を追加する。#1094 の短期対応 (b) CI lint を実装。

## 主な変更点

`.github/workflows/ci.yml` の `lint` job 内、 Format check step の直後に **重複 fixture ID 検出 step** を追加:

```bash
grep -rhn 'insertTestUser(t, "\|insertRemoteTestUser(t, "' \
  internal/repository/*_test.go \
  | awk -F'"' '{print $2}' | sort | uniq -c | sort -rn \
  | awk '$1 > 1'
```

重複が 1 つでも検出されたら fail メッセージ (= 重複 ID 一覧 + rename ガイダンス) と共に `exit 1`。`develop` の現状では 0 件で pass する (= #1089 で全 17 箇所を unique 化済)。

## 中期対応 (#1094 a) の保留判断

issue では **runtime caller-aware ID seed** (`insertTestUser` 内部で `runtime.Caller` から自動 prefix を生成して `user.id` に含める) も提案していたが、現状調査の結果:

- `user.id` column が **CHARACTER(16)** (固定長)
- 既存 fixture ID の最長は **12 char** (`u_orph_emoji` / `u_dab_target` / `u_admin_list`)
- prefix 余裕が **4 char** しか無く、 4-char hex hash + `_` で精一杯
- 4-char hex (16-bit) hash は 100 caller 規模で衝突確率 1/655 で deterministic に踏む可能性あり
- column 拡張は migration が必要 (= schema 変更を伴う大改修)

短期 cost / benefit 観点から、本 PR は **(b) CI lint で網を張る** 対応に絞る。 (a) caller-aware seed は中期 task として #1094 で継続検討 (= 別 PR で対応する場合は本 lint を撤去できる)。

## 検証

```
$ # 現状 develop で重複ゼロ
$ grep -rhn 'insertTestUser(t, "\|insertRemoteTestUser(t, "' internal/repository/*_test.go \
    | awk -F'"' '{print $2}' | sort | uniq -c | sort -rn | awk '$1 > 1'
(empty)

$ # 故意に重複を入れて lint が fail することも確認済
$ # → "Duplicate test fixture IDs detected" で exit 1

$ python3 -c "import yaml; yaml.safe_load(open('.github/workflows/ci.yml'))"
(no error)
```

## 関連

- 本 PR で fix (短期 b): #1094 (重複 fixture ID 構造的防止 / 短期 CI lint)
- Follow-up (中期 a): #1094 (継続) — caller-aware ID seed (schema 変更を含む大改修、別 issue 化検討)
- 前提 #1089: PR #1093 で観測された 17 箇所を unique 化済

## Closes

Closes #1094