### PR TITLE
Fix CI flaky: ListSystemFiles の image filter assertion を fixture-scoped に (#1098)

### DIFF
--- a/internal/repository/drive_file_test.go
+++ b/internal/repository/drive_file_test.go
@@ -241,11 +241,19 @@ func TestDriveFileRepository_ListSystemFiles(t *testing.T) {
 	assert.False(t, ids[userFile.ID], "user-owned file must not appear")
 	assert.False(t, ids[remoteFile.ID], "remote-owned file must not appear")
 
-	// type=image/ で絞り込み: image/png のみ
+	// type=image/ で絞り込み: 本 test の fixture では sysImg のみ image/* に該当。
+	// 他 test が UserID=NULL + Type=image/* な system file 行を残しても本 test を
+	// 巻き込まないよう、 fixture ID で scoped assert する (#1098)。
 	rows, err = repo.ListSystemFiles("image/", "", "", 10)
 	require.NoError(t, err)
-	require.Len(t, rows, 1)
-	assert.Equal(t, sysImg.ID, rows[0].ID)
+	ids = make(map[string]bool, len(rows))
+	for _, r := range rows {
+		ids[r.ID] = true
+	}
+	assert.True(t, ids[sysImg.ID], "sysImg (image/png) should appear in image/ filter")
+	assert.False(t, ids[sysZip.ID], "sysZip (application/zip) must not appear")
+	assert.False(t, ids[userFile.ID], "user-owned file must not appear")
+	assert.False(t, ids[remoteFile.ID], "remote-owned file must not appear")
 
 	// limit 範囲外 (0 / 過大) でも error にならず default / clamp が効く
 	_, err = repo.ListSystemFiles("", "", "", 0)


### PR DESCRIPTION
## Summary

PR #1097 (CI YAML のみの変更) merge 後の develop 初回 CI で観測した `TestDriveFileRepository_ListSystemFiles` の偶発 fail を、 assertion を fixture ID で scoped 化して構造的に解消する。

## 観測

[run 25954809321](https://github.com/shiroha-a/mk/actions/runs/25954809321) shard 2:

```
--- FAIL: TestDriveFileRepository_ListSystemFiles (0.02s)
    drive_file_test.go:247:
      Error: "[0xc000692a20 0xc000692b40]" should have 1 item(s), but has 2
```

PR #1097 は `.github/workflows/ci.yml` のみ変更で test 影響ゼロ → 既存 flaky の偶発的表面化。

## 想定原因

- ローカル `-race -count=10` で再現しない (= package 内 serial 実行)
- CI shard で `internal/repository` と他 package が同じ PostgreSQL service container を共有しており、別 package が UserID=NULL + Type=image/* な drive_file 行を残留させると本 test が巻き込まれる

## 修正

該当行 (`require.Len(t, rows, 1)`) を **fixture ID で scoped assert** に書き換え:

```go
rows, err = repo.ListSystemFiles("image/", "", "", 10)
require.NoError(t, err)
ids = make(map[string]bool, len(rows))
for _, r := range rows {
    ids[r.ID] = true
}
assert.True(t, ids[sysImg.ID],  "sysImg should appear in image/ filter")
assert.False(t, ids[sysZip.ID], "sysZip (application/zip) must not appear")
assert.False(t, ids[userFile.ID], "user-owned file must not appear")
assert.False(t, ids[remoteFile.ID], "remote-owned file must not appear")
```

同 test 内の他 assertion (type 無指定 / pagination untilId / sinceId) は既に fixture ID 経由で scoped なので、本 PR で image filter 経路だけ揃える形。

## テスト

```
$ go test -race -count=5 -run TestDriveFileRepository_ListSystemFiles ./internal/repository/...
ok  	github.com/shiroha-a/mk/internal/repository	1.332s
```

`make fmt` / `make lint` clean。

## Closes

Closes #1098