### PR TITLE
Docs: 2026.5.1 → 2026.5.2 upstream backend diff doc

### DIFF
--- a/docs/update/20260502diff.md
+++ b/docs/update/20260502diff.md
@@ -1,0 +1,170 @@
+# Misskey 2026.5.1 → 2026.5.2 backend diff
+
+mk-go (本リポジトリ) の upstream 追従用 diff doc。**2026.5.1 → 2026.5.2 の差分のみ** を扱う。2026.3.2 → 2026.5.0 部分は [`20260500diff.md`](./20260500diff.md)、2026.5.0 → 2026.5.1 部分は [`20260501diff.md`](./20260501diff.md) を参照。
+
+- 集計範囲: `misskey-dev/misskey` の `2026.5.1..2026.5.2`
+- backend (`packages/backend/`) 計 15 files / +313 / -62
+- backend src 配下の commit は **7 commits** (内 4 件は package.json の dep bump、3 件が実コード変更)
+- 取得方法: `git -C third_party/misskey log 2026.5.1..2026.5.2 -- packages/backend/`
+
+## 移植優先度: 高 (API 互換 / アセット参照に影響)
+
+### API: `users/notify/list` → `following/list` に rename + 拡張 (#17385 → #17416)
+
+`feat: 投稿通知設定したユーザーをリストで見ることができるように (#17385)` で `users/notify/list` を新設したが、**直後の `fix: move users/notify/list to following/list (#17416)` で API パスと shape の両方が変更された**。2026.5.2 時点での最終形は `following/list` のみで、`users/notify/list` は endpoint-list から削除されている。
+
+- 該当: 
+  - 追加 `server/api/endpoints/following/list.ts` (69 lines)
+  - 削除 `server/api/endpoints/users/notify/list.ts` (途中で作られた直後に消えた)
+  - `server/api/endpoint-list.ts` (rename)
+- 変更内容:
+  - **URL**: `users/notify/list` → `following/list`
+  - **paramDef**: 新たに `notification: boolean (default false)` を追加。`true` のときだけ `following.notify IS NOT NULL` で絞る。default では single user の `following` 一覧をそのまま返す (= 「自分が follow している人の一覧」)。
+  - **response shape**: `UserDetailed[]` → `Following[]` (= `populateFollowee: true` の `FollowingEntityService.packMany`)
+  - kind は `read:following` のまま据え置き。
+- なぜ必要: #17385 のレビューで「`users/notify/*` だけで notify 設定済 follower の一覧 endpoint を新設するのは命名が混乱する。`following/list` に `notification` query を足すのが自然」となり後追い fix。
+- 関連 PR: misskey-dev/misskey#17385 / misskey-dev/misskey#17416
+- mk-go 該当箇所: 
+  - `internal/api/following/handler.go` に `List` handler を新設 (`internal/server/router.go:1822` 付近で `api.POST("/following/list", followingHandler.List, middleware.RequireAuth())` を wire)
+  - `notification=true` で `following.notify IS NOT NULL` filter、default で全件
+  - response は `entity.PackFollowing` を `populateFollowee: true` 相当で返す (= 既存 `FollowingEntityService` 同等の field を埋める)
+  - `users/notify/list` は **mk-go では実装しない** (= 中間 commit のみで release には乗っていないため drop-in 対象外)
+
+```ts
+// following/list.ts (2026.5.2 最終形)
+export const paramDef = {
+    type: 'object',
+    properties: {
+        notification: { type: 'boolean', default: false },
+        sinceId: { type: 'string', format: 'misskey:id' },
+        untilId: { type: 'string', format: 'misskey:id' },
+        sinceDate: { type: 'integer' },
+        untilDate: { type: 'integer' },
+        limit: { type: 'integer', minimum: 1, maximum: 100, default: 10 },
+    },
+} as const;
+
+// handler 本体
+const query = this.queryService.makePaginationQuery(...)
+    .andWhere('following.followerId = :userId', { userId: me.id });
+
+if (ps.notification) {
+    query.andWhere('following.notify IS NOT NULL');
+}
+
+query.innerJoinAndSelect('following.followee', 'followee');
+
+const followings = await query.limit(ps.limit).getMany();
+return await this.followingEntityService.packMany(followings, me, { populateFollowee: true });
+```
+
+### Frontend assets: twemoji / fluent-emoji の参照先 path 変更 (#17381)
+
+`enhance: 絵文字データの参照を自前ライブラリに変更 (#17381)` で `@discordapp/twemoji` (16.0.1) + `@twemoji/parser` (16.0.0) を撤去し、`@misskey-dev/emoji-assets` (17.0.3) + `@misskey-dev/emoji-data` (17.0.3) に差し替え。**emoji-regex の生成元と SVG ファイルの配置 path が両方変わる** ので mk-go の frontendutil も追従が必要。
+
+- 該当: 
+  - `package.json` (dep 入れ替え)
+  - `src/misc/emoji-regex.ts` (上流 import に切替)
+  - `src/server/web/ClientServerService.ts` (二箇所 path 変更 + private field rename)
+- 変更内容:
+  - `fluentEmojisDir` → `fluentEmojiDir` (private field rename、複数形 typo 修正)
+  - `node_modules/@discordapp/twemoji/dist/svg` → `node_modules/@misskey-dev/emoji-assets/built/twemoji`
+  - `<rootDir>/fluent-emojis/dist` → `node_modules/@misskey-dev/emoji-assets/built/fluent-emoji` (= 別 git submodule の `fluent-emojis` 提出を npm 依存に統合)
+  - `emoji-regex.ts` は **regex 文字列そのものを inline していた** のを `@misskey-dev/emoji-data/regex` import に切替。regex 自体は Twemoji v17 相当に bump (Unicode 17 / emoji 17.0 対応)。
+- なぜ必要: Twemoji が公式 deprecation。Misskey 側で v17 対応 fork (`@misskey-dev/emoji-assets`) と regex データ (`@misskey-dev/emoji-data`) を内製化し、external dep への依存度を下げる。
+- 関連 PR: misskey-dev/misskey#17381
+- mk-go 該当箇所:
+  - `internal/frontendutil/frontendutil.go:54-59` `TwemojiDir()` の return path を `@discordapp/twemoji/dist/svg` → `@misskey-dev/emoji-assets/built/twemoji` に変更
+  - `internal/frontendutil/frontendutil_test.go:60,64-65` の expected path を同じく書き換え
+  - 旧 `fluent-emojis/dist` を別 path で serve していなければ追加実装不要。serve していた場合は `@misskey-dev/emoji-assets/built/fluent-emoji` を新 path として配信
+  - mk-go で MFM や note text 解析で emoji regex を持っている経路があれば、Unicode 17 / emoji 17.0 対応の最新 regex に追従 (mk-go は server-side では emoji を全角文字としてしか扱わないため影響は限定的)
+
+```ts
+// ClientServerService.ts (before → after)
+this.fluentEmojisDir = resolve(this.config.rootDir, 'fluent-emojis/dist');
+this.twemojiDir = resolve(backendRootdir, 'node_modules/@discordapp/twemoji/dist/svg');
+// ↓
+this.fluentEmojiDir = resolve(backendRootdir, 'node_modules/@misskey-dev/emoji-assets/built/fluent-emoji');
+this.twemojiDir = resolve(backendRootdir, 'node_modules/@misskey-dev/emoji-assets/built/twemoji');
+```
+
+## 移植優先度: 中 (TS 内部 perf 改善 / mk-go では別実装)
+
+### Perf: RSA 署名を slacc (Rust napi) スレッドプール化 (#17322)
+
+- 該当: 
+  - `boot/common.ts` (新 `initExtraThreadPool(config)` ヘルパ)
+  - `boot/master.ts` / `boot/worker.ts` (master / worker 両プロセスで init)
+  - `config.ts` (新 `threadPoolSize: number` config、default 1)
+  - `core/activitypub/ApRequestService.ts` (`createSignedPost` / `createSignedGet` を async 化、`#signToRequest` 内で `RsaKeyPair.fromPem().sign` を `promisify` 呼び出し)
+  - `core/activitypub/JsonLdService.ts` (LD signing も `RsaKeyPair.sign` で async)
+  - `package.json` (`slacc` 0.0.10 → 0.1.5 に bump、`slacc-<platform>-*` の native binary 13 種類が全部追従)
+- 変更内容: HTTP Signature / LD Signature の RSA 署名を **Node の crypto.sign (= main thread block)** から **slacc (Rust napi crate) の専用スレッドプール** に逃す。`config.threadPoolSize` で並列度を制御 (= libuv の `UV_THREADPOOL_SIZE` と分離した独立プール)。
+- 影響: 大規模 instance で deliver job の RSA sign が main thread の event loop を詰まらせない。queue-bench (#563) 系のベンチで TS 側の outbound throughput が改善する見込み。
+- 関連 PR: misskey-dev/misskey#17322
+- mk-go 該当箇所: **mk-go は Go 標準の `crypto/rsa` を goroutine で呼ぶため、本質的に既に thread-off-loaded されており追加対応不要**。`config.threadPoolSize` 相当の YAML key も mk-go では不要 (= GOMAXPROCS で代用)。
+  - drop-in 互換: mk-go が `.config/default.yml` で `threadPoolSize:` を **未知 key として読み捨て** ているか確認。Viper は未知 key で error にならないので問題なし。
+
+### CI / unit test 環境: vitest setup で slacc init を強制 (#17322 副作用)
+
+- 該当: `test/environment.unit.ts` (新規、+10) / `test/unit/ap-request.ts` (await 追加、4 lines) / `vitest.config.unit.ts` (1 line)
+- 変更内容: TS 側 unit test で `slacc.init()` を testEnvironment で先に呼ばないと RSA sign が undefined になる対策。mk-go では無関係。
+
+## 移植不要 (TS-internal dep bump のみ)
+
+### `sanitize-html` 2.17.3 → 2.17.4 [security] (#17402)
+- TS-internal な HTML sanitize ライブラリの security patch。mk-go は HTML sanitize に [microcosm-cc/bluemonday](https://github.com/microcosm-cc/bluemonday) を使っており別 library。security advisory が bluemonday に影響しないか別途確認は必要だが、本 diff 起因の作業は無し。
+
+### `re2` 1.24.0 → 1.24.1 (commit `62b323b58b`)
+- TS の Node binding for Google re2。mk-go は Go 標準 regexp + re2 互換 syntax で済んでいるので無関係。
+
+### `deps: update dependencies (#17400)` の bulk bump
+- AWS SDK / nest / sentry / bullmq / got / nanoid / nodemailer 等の minor bump。`@napi-rs/canvas` 0.1.100 → 1.0.0 が唯一の major bump だが、これは TS 側の画像処理 (チャート PNG / OG 画像生成) で使われているもので mk-go は別系統 (Go 標準 image + freetype / `disintegration/imaging`) のため影響なし。
+- pnpm 10 → pnpm 11 への移行も含む。mk-go の `make uds-frontend-build` 等で frontend をビルドする経路があれば、pnpm 11 への切替確認が必要。
+
+## 変更されたファイル (backend src + test のみ)
+
+```
+boot/
+  common.ts                                    ← #17322 slacc init helper
+  master.ts                                    ← #17322 master で init
+  worker.ts                                    ← #17322 worker で init
+config.ts                                      ← #17322 threadPoolSize config
+core/
+  activitypub/ApRequestService.ts              ← #17322 RSA sign async 化
+  activitypub/JsonLdService.ts                 ← #17322 LD sign async 化
+misc/emoji-regex.ts                            ← #17381 @misskey-dev/emoji-data 経由に
+server/
+  api/endpoint-list.ts                         ← #17385 + #17416 add/rename
+  api/endpoints/following/list.ts (新規)        ← #17416 final endpoint
+  api/endpoints/users/notify/list.ts (削除)     ← #17385 で追加 → #17416 で削除
+  web/ClientServerService.ts                   ← #17381 emoji asset path 変更
+test/
+  e2e/note-notify.ts (新規)                    ← #17385 e2e
+  environment.unit.ts (新規)                   ← #17322 vitest unit setup
+  unit/ap-request.ts                           ← #17322 await 追加
+vitest.config.unit.ts                          ← #17322 testEnvironment 指定
+package.json                                   ← dep bump 4 commits 合算
+```
+
+## backend 関連 commits (sha → 概要)
+
+```
+9410bc5194  fix: move users/notify/list to following/list (#17416)        ← 要対応 (API rename)
+08c6efb044  fix(deps): sanitize-html v2.17.4 [security] (#17402)          ← 移植不要 (mk-go は bluemonday)
+62b323b58b  update re2                                                     ← 移植不要 (Go 標準 regexp)
+a3227c99ed  deps: update dependencies (#17400)                            ← 移植不要 (TS-internal bulk bump)
+6665c398d6  feat: 投稿通知設定したユーザーをリストで見れるように (#17385)   ← 要対応だが #17416 後の final shape のみ追従
+b950f905e5  perf: rsa sign on slacc (#17322)                              ← 移植不要 (mk-go は Go crypto/rsa + goroutine)
+a09a2c2eee  enhance: 絵文字データの参照を自前ライブラリに変更 (#17381)      ← 要対応 (twemoji path 変更)
+```
+
+## 推奨対応プラン
+
+mk-go 既存の sub-issue 切り出しパターン (#947 系) と同じく、本 diff から個別 issue を切る。優先順位:
+
+1. **API drop-in 互換: `following/list` 新設 + `notification` param 対応** (#17385 + #17416 を 1 PR で消化、`users/notify/list` は実装しない)
+2. **frontend assets: `TwemojiDir()` を `@misskey-dev/emoji-assets/built/twemoji` 参照に変更** (#17381) — `uds-frontend-build` や drop-in frontend e2e でビルド済 image が `@discordapp/twemoji` を含まないと SVG 404 になるため、`make uds-frontend-build` 後の動作確認が必須
+3. **`fluent-emojis/dist` の serve があれば `@misskey-dev/emoji-assets/built/fluent-emoji` に切替** (#17381 副作用) — 現状 mk-go で fluent-emoji を serve していなければスキップ可
+
+upstream submodule (`third_party/misskey/`) は既に 2026.5.2-mk.0 に bump 済 (`git submodule status` で確認)。本 doc は upstream 取り込み後の追従作業 triage 用。


### PR DESCRIPTION
## Summary

- upstream Misskey TS `2026.5.2` release への追従 triage 用 diff doc を `docs/update/20260502diff.md` に追加
- backend (`packages/backend/`) **15 files / +313 / -62、7 commits** (うち 4 件は dep bump、3 件が実コード変更)
- 既存 `20260500diff.md` / `20260501diff.md` と揃えたフォーマット (背景 / 集計範囲 / 優先度別 sub-task / 移植不要 / 変更ファイル一覧 / 推奨対応プラン)

## 主な変更点

`docs/update/20260502diff.md` を新規追加するのみ。コード変更なし。

### 高優先 (drop-in 互換に影響、追従必要)

- `following/list` 新設 + `notification: boolean` param 対応
  - mk-go では `internal/api/following/handler.go` に `List` handler を新設、`internal/server/router.go` で wire
  - 中間 commit で追加された `users/notify/list` は 2026.5.2 release では既に削除されているため、mk-go では **実装しない** (`following/list` のみ追従)
- `internal/frontendutil/frontendutil.go` `TwemojiDir()` の参照 path 変更
  - `node_modules/@discordapp/twemoji/dist/svg` → `node_modules/@misskey-dev/emoji-assets/built/twemoji`
  - 対応する `frontendutil_test.go:60,64-65` も追従
- fluent-emoji の serve があれば同じく `@misskey-dev/emoji-assets/built/fluent-emoji` に追従

### 中優先 (mk-go では別実装、確認のみ)

- slacc thread pool RSA sign — mk-go は Go `crypto/rsa` + goroutine で本質的に thread-off-loaded 済、`config.threadPoolSize` を Viper が silent に読み捨てる確認のみ

### 移植不要 (TS-internal dep bump)

- `sanitize-html` 2.17.3 → 2.17.4 [security] — mk-go は bluemonday
- `re2` 1.24.0 → 1.24.1 — mk-go は Go 標準 regexp
- bulk dep bump (AWS SDK / nest / sentry / bullmq / `@napi-rs/canvas` 1.0 major bump 等) — mk-go は別系統
- pnpm 10 → pnpm 11 — `make uds-frontend-build` で frontend ビルドする経路の sanity check のみ

## テスト

doc のみのため自動テスト追加なし。`make fmt && make lint && make test` 未実行 (Go コード変更なしのため影響なし)。

## 関連

- Refs #1118 (Tracker: Misskey TS 2026.5.1 → 2026.5.2 への upstream 追従)
- 過去の同種 doc: `docs/update/20260500diff.md` / `docs/update/20260501diff.md`
- 旧 tracker: #947 (closed)

## その他

submodule `third_party/misskey/` の 2026.5.2-mk.0 への bump は本 PR では扱わず、追従作業完了後に別 PR で実施する想定 (旧 tracker #947 の運用と同様)。