### PR TITLE
Config templates: surface auto-scale knobs in *.yml.example

### DIFF
--- a/.config/default.yml.example
+++ b/.config/default.yml.example
@@ -249,8 +249,8 @@ id: 'aidx'
 #jobQueueAutoScale: false
 #maxWorkers: 128                # per-queue upper bound (default: runtime.NumCPU() * 16)
 #minWorkers: 4                  # per-queue lower bound (kept warm even at idle)
-#maxWorkersGlobal: 256          # optional cluster-wide cap across queues (multi-pod use)
-#autoScaleCooldownSeconds: 1    # minimum interval between scale events
+#maxWorkersGlobal: 256          # cluster-wide cap across queues for multi-pod use (default: unset = no cap)
+#autoScaleCooldownSeconds: 1    # minimum interval between scale events (5-10 recommended in production to avoid oscillation)
 
 #   ┌─────────────────────┐
 #───┘ Other configuration └─────────────────────────────────────

--- a/.config/default.yml.example
+++ b/.config/default.yml.example
@@ -242,6 +242,16 @@ id: 'aidx'
 #deliverJobMaxAttempts: 12
 #inboxJobMaxAttempts: 8
 
+# Auto-scale: when jobQueueAutoScale=true, an AIMD controller dynamically
+# resizes worker pools for queues without an explicit *JobConcurrency knob,
+# within [minWorkers, maxWorkers]. mkq driver only (asynq returns a startup
+# error). Full spec: docs/design/auto-scale-job-workers.md.
+#jobQueueAutoScale: false
+#maxWorkers: 128                # per-queue upper bound (default: runtime.NumCPU() * 16)
+#minWorkers: 4                  # per-queue lower bound (kept warm even at idle)
+#maxWorkersGlobal: 256          # optional cluster-wide cap across queues (multi-pod use)
+#autoScaleCooldownSeconds: 1    # minimum interval between scale events
+
 #   ┌─────────────────────┐
 #───┘ Other configuration └─────────────────────────────────────
 
@@ -353,3 +363,8 @@ proxyBypassHosts:
 # Mount net/http/pprof handlers at /debug/pprof/* for local
 # profiling. **DO NOT enable in production**.
 #enablePprof: false
+
+# Expose the Prometheus /metrics endpoint with job-queue metrics.
+# Unauthenticated; restrict access via nginx / LB ACL if exposed outside
+# the cluster. See docs/design/auto-scale-job-workers.md §6.1.
+#enableMetrics: false

--- a/.config/docker.yml.example
+++ b/.config/docker.yml.example
@@ -156,16 +156,11 @@ id: 'aidx'
 #jobQueueAutoScale: false
 #maxWorkers: 128                # per-queue upper bound (default: runtime.NumCPU() * 16)
 #minWorkers: 4                  # per-queue lower bound (kept warm even at idle)
-#maxWorkersGlobal: 256          # optional cluster-wide cap across queues (multi-pod use)
-#autoScaleCooldownSeconds: 1    # minimum interval between scale events
+#maxWorkersGlobal: 256          # cluster-wide cap across queues for multi-pod use (default: unset = no cap)
+#autoScaleCooldownSeconds: 1    # minimum interval between scale events (5-10 recommended in production to avoid oscillation)
 
 #   ┌─────────────────────┐
 #───┘ Other configuration └─────────────────────────────────────
-
-# Expose the Prometheus /metrics endpoint with job-queue metrics.
-# Unauthenticated; restrict access via nginx / LB ACL if exposed outside
-# the cluster. See docs/design/auto-scale-job-workers.md §6.1.
-#enableMetrics: false
 
 #disableHsts: true
 
@@ -219,3 +214,8 @@ proxyBypassHosts:
 #  sql:
 #    enableQueryParamLogging: false
 #    disableQueryTruncation: false
+
+# Expose the Prometheus /metrics endpoint with job-queue metrics.
+# Unauthenticated; restrict access via nginx / LB ACL if exposed outside
+# the cluster. See docs/design/auto-scale-job-workers.md §6.1.
+#enableMetrics: false

--- a/.config/docker.yml.example
+++ b/.config/docker.yml.example
@@ -149,8 +149,23 @@ id: 'aidx'
 #deliverJobMaxAttempts: 12
 #inboxJobMaxAttempts: 8
 
+# Auto-scale: when jobQueueAutoScale=true, an AIMD controller dynamically
+# resizes worker pools for queues without an explicit *JobConcurrency knob,
+# within [minWorkers, maxWorkers]. mkq driver only (asynq returns a startup
+# error). Full spec: docs/design/auto-scale-job-workers.md.
+#jobQueueAutoScale: false
+#maxWorkers: 128                # per-queue upper bound (default: runtime.NumCPU() * 16)
+#minWorkers: 4                  # per-queue lower bound (kept warm even at idle)
+#maxWorkersGlobal: 256          # optional cluster-wide cap across queues (multi-pod use)
+#autoScaleCooldownSeconds: 1    # minimum interval between scale events
+
 #   ┌─────────────────────┐
 #───┘ Other configuration └─────────────────────────────────────
+
+# Expose the Prometheus /metrics endpoint with job-queue metrics.
+# Unauthenticated; restrict access via nginx / LB ACL if exposed outside
+# the cluster. See docs/design/auto-scale-job-workers.md §6.1.
+#enableMetrics: false
 
 #disableHsts: true
 

--- a/deploy/uds/config/default.yml.example
+++ b/deploy/uds/config/default.yml.example
@@ -209,6 +209,16 @@ id: 'aidx'
 #deliverJobMaxAttempts: 12
 #inboxJobMaxAttempts: 8
 
+# Auto-scale: when jobQueueAutoScale=true, an AIMD controller dynamically
+# resizes worker pools for queues without an explicit *JobConcurrency knob,
+# within [minWorkers, maxWorkers]. mkq driver only (asynq returns a startup
+# error). Full spec: docs/design/auto-scale-job-workers.md.
+#jobQueueAutoScale: false
+#maxWorkers: 128                # per-queue upper bound (default: runtime.NumCPU() * 16)
+#minWorkers: 4                  # per-queue lower bound (kept warm even at idle)
+#maxWorkersGlobal: 256          # optional cluster-wide cap across queues (multi-pod use)
+#autoScaleCooldownSeconds: 1    # minimum interval between scale events
+
 #   ┌─────────────────────┐
 #───┘ Other configuration └─────────────────────────────────────
 
@@ -282,3 +292,8 @@ proxyBypassHosts:
 # Mount net/http/pprof handlers at /debug/pprof/* for local
 # profiling. **DO NOT enable in production**.
 #enablePprof: false
+
+# Expose the Prometheus /metrics endpoint with job-queue metrics.
+# Unauthenticated; restrict access via nginx / LB ACL if exposed outside
+# the cluster. See docs/design/auto-scale-job-workers.md §6.1.
+#enableMetrics: false

--- a/deploy/uds/config/default.yml.example
+++ b/deploy/uds/config/default.yml.example
@@ -216,8 +216,8 @@ id: 'aidx'
 #jobQueueAutoScale: false
 #maxWorkers: 128                # per-queue upper bound (default: runtime.NumCPU() * 16)
 #minWorkers: 4                  # per-queue lower bound (kept warm even at idle)
-#maxWorkersGlobal: 256          # optional cluster-wide cap across queues (multi-pod use)
-#autoScaleCooldownSeconds: 1    # minimum interval between scale events
+#maxWorkersGlobal: 256          # cluster-wide cap across queues for multi-pod use (default: unset = no cap)
+#autoScaleCooldownSeconds: 1    # minimum interval between scale events (5-10 recommended in production to avoid oscillation)
 
 #   ┌─────────────────────┐
 #───┘ Other configuration └─────────────────────────────────────


### PR DESCRIPTION
## Summary

auto-scale 機能 (PR #1127 〜 #1132) で導入した新 knob を **3 つの config 例ファイル**に追記して discoverability を確保する。default 挙動は不変 (全 entry コメントアウト)。

## Background

過去の auto-scale PR では `docs/configuration.md` に説明を追加したが、`*.yml.example` への追記が漏れていた。operator が example を元に自分の deployment 用 yml を作るときに、auto-scale knob の存在に気付けない状態だった。本 PR で 3 example を揃え、`deliverJobConcurrency` / `enablePprof` 等の既存パターンに合わせる。

## 主な変更点

3 file ともに同 5 + 1 = 6 entry を追加 (全コメントアウト):

\`\`\`yaml
# Job queue settings セクション
#jobQueueAutoScale: false
#maxWorkers: 128
#minWorkers: 4
#maxWorkersGlobal: 256
#autoScaleCooldownSeconds: 1

# Other configuration セクション (enablePprof 近く)
#enableMetrics: false
\`\`\`

| File | 用途 |
|---|---|
| \`.config/default.yml.example\` | local dev template |
| \`.config/docker.yml.example\` | docker-compose template |
| \`deploy/uds/config/default.yml.example\` | UDS production template |

## Operator-local config (gitignored)

\`deploy/uds/config/default.yml\` / \`.config/default.yml\` は operator-local
として gitignore 済 (CLAUDE.md §Project Structure 参照)。本 PR では template
の整備のみで、operator-local copy には影響しない (各 operator が必要なら手で
merge する想定)。

## テスト

config schema 変更なし (既存 mapstructure binding が parse する knob のみ追記)。\`make test\` 影響なし。

🤖 Generated with [Claude Code](https://claude.com/claude-code)