### PR TITLE
Fix /api/pages/* レスポンスに user field 注入 (MkPagePreview 描画失敗修正)

### DIFF
--- a/internal/api/pages/handler.go
+++ b/internal/api/pages/handler.go
@@ -26,13 +26,15 @@ type MainStreamPublisher interface {
 }
 
 // UserBundleSource fetches a user + profile bundle. ShowByID is used to pack
-// the caller for the `pageEvent` body emitted from /api/page-push, and
-// ShowByUsername is used to resolve the upstream-compatible
-// {username, name} shape on /api/pages/show (#955). Satisfied by
-// *core/user.Service.
+// the caller for the `pageEvent` body emitted from /api/page-push and the
+// page owner on /api/pages/show (#1134). ShowByUsername is used to resolve
+// the upstream-compatible {username, name} shape on /api/pages/show (#955).
+// FindManyByIDs is used by /api/pages/featured to batch-resolve multiple
+// owners in one round-trip (#1134). Satisfied by *core/user.Service.
 type UserBundleSource interface {
 	ShowByID(id string) (*coreuser.UserWithProfile, error)
 	ShowByUsername(username string, host *string) (*coreuser.UserWithProfile, error)
+	FindManyByIDs(ids []string) ([]*model.User, error)
 }
 
 // Handler handles page-related API endpoints.
@@ -160,7 +162,22 @@ func (h *Handler) Show(c echo.Context) error {
 		}
 		return notFound(c)
 	}
-	return c.JSON(http.StatusOK, h.pageToMap(p))
+	// owner / isLiked を attach (#1134)。owner lookup miss は frontend page.vue
+	// の `v-if="page.user"` で吸収されるため fail-soft で nil 維持。
+	// isLiked は logged-in viewer のときだけ pointer で渡し、guest 経路では
+	// upstream 同様 field を omit する。
+	var owner *model.User
+	if h.userSource != nil {
+		if bundle, oerr := h.userSource.ShowByID(p.UserID); oerr == nil && bundle != nil {
+			owner = bundle.User
+		}
+	}
+	var isLikedPtr *bool
+	if user != nil {
+		liked := h.svc.HasLiked(user.ID, p.ID)
+		isLikedPtr = &liked
+	}
+	return c.JSON(http.StatusOK, h.pageToMapWithOwner(p, owner, nil, isLikedPtr))
 }
 
 // UpdateRequest is the request body for pages/update.
@@ -262,6 +279,8 @@ type MyRequest struct {
 // My handles POST /api/i/pages.
 //
 // frontend Paginator (cursor mode) は untilId / sinceId を forward する (#493)。
+// 全 row が同一 owner なので middleware.GetUser を直接 owner として attach し、
+// 追加 round-trip 無しで `page.user` を埋める (#1134)。
 func (h *Handler) My(c echo.Context) error {
 	user := middleware.GetUser(c)
 	var req MyRequest
@@ -272,7 +291,7 @@ func (h *Handler) My(c echo.Context) error {
 	if err != nil {
 		return apierr.JSONInternalError(c)
 	}
-	return c.JSON(http.StatusOK, h.pagesToList(rows))
+	return c.JSON(http.StatusOK, h.pagesToList(rows, func(string) *model.User { return user }))
 }
 
 // FeaturedRequest is the request body for pages/featured.
@@ -284,6 +303,10 @@ type FeaturedRequest struct {
 }
 
 // Featured handles POST /api/pages/featured.
+//
+// 複数 owner なので FindManyByIDs で 1 round-trip batch 取得し、行毎の owner を
+// pagesToList に owner closure で渡す (#1134)。userSource が未配線の test 経路
+// では owner 取得不能なので空 list を返す (= silent fail-soft、501 にしない)。
 func (h *Handler) Featured(c echo.Context) error {
 	var req FeaturedRequest
 	if err := c.Bind(&req); err != nil {
@@ -293,7 +316,39 @@ func (h *Handler) Featured(c echo.Context) error {
 	if err != nil {
 		return apierr.JSONInternalError(c)
 	}
-	return c.JSON(http.StatusOK, h.pagesToList(rows))
+	ownerLookup := h.batchOwnerLookup(rows)
+	return c.JSON(http.StatusOK, h.pagesToList(rows, ownerLookup))
+}
+
+// batchOwnerLookup returns a closure that resolves page.userId → *model.User
+// in O(1) per call by pre-loading all unique owner IDs in one query. Caller
+// guarantees `rows` may contain duplicates; the lookup map dedupes via the
+// userId key. When userSource is unset or the batch fetch errors, the
+// closure returns nil for every ID and the caller (pagesToList) drops the
+// row — same fail-soft behavior as upstream PageEntityService.packMany
+// which skips unpackable rows rather than failing the whole list.
+func (h *Handler) batchOwnerLookup(rows []*model.Page) func(string) *model.User {
+	if h.userSource == nil || len(rows) == 0 {
+		return func(string) *model.User { return nil }
+	}
+	seen := make(map[string]struct{}, len(rows))
+	ids := make([]string, 0, len(rows))
+	for _, p := range rows {
+		if _, ok := seen[p.UserID]; ok {
+			continue
+		}
+		seen[p.UserID] = struct{}{}
+		ids = append(ids, p.UserID)
+	}
+	users, err := h.userSource.FindManyByIDs(ids)
+	if err != nil {
+		return func(string) *model.User { return nil }
+	}
+	byID := make(map[string]*model.User, len(users))
+	for _, u := range users {
+		byID[u.ID] = u
+	}
+	return func(uid string) *model.User { return byID[uid] }
 }
 
 // LikeRequest is the request body for pages/like and pages/unlike.
@@ -398,11 +453,18 @@ func (h *Handler) Unlike(c echo.Context) error {
 }
 
 // pagesToList packs a slice of pages using h.idGen so every element gets a
-// consistent createdAt alongside the other fields.
-func (h *Handler) pagesToList(rows []*model.Page) []map[string]any {
+// consistent createdAt alongside the other fields. ownerLookup resolves the
+// page owner per row; when it returns nil for a row the row is dropped
+// (otherwise the frontend MkPagePreview template throws on
+// `page.user.username` and the entire list disappears, #1134).
+func (h *Handler) pagesToList(rows []*model.Page, ownerLookup func(userID string) *model.User) []map[string]any {
 	out := make([]map[string]any, 0, len(rows))
 	for _, p := range rows {
-		out = append(out, h.pageToMap(p))
+		owner := ownerLookup(p.UserID)
+		if owner == nil {
+			continue
+		}
+		out = append(out, h.pageToMapWithOwner(p, owner, nil, nil))
 	}
 	return out
 }
@@ -410,8 +472,26 @@ func (h *Handler) pagesToList(rows []*model.Page) []map[string]any {
 // pageToMap delegates to entity.PackPage so the JSON shape (timestamp
 // format, field set) stays in sync between /api/pages/* and other places
 // that embed a page (e.g. pinnedPage on /api/i and /api/users/show).
+//
+// Use pageToMapWithOwner for list endpoints / detail views — they need
+// `page.user` populated or the frontend templates fail to render (#1134).
+// This bare variant remains for pinned-page embeds where the user context
+// is implicit (the embedding endpoint already returns the user separately).
 func (h *Handler) pageToMap(p *model.Page) map[string]any {
 	return entity.PackPage(p, h.idGen)
+}
+
+// pageToMapWithOwner enriches the page entity with `user` (UserLite) and
+// optional `eyeCatchingImage` / `isLiked`. Upstream PageEntityService.pack
+// always emits `user`; mk-go previously omitted it which silently broke the
+// frontend list views (#1134).
+func (h *Handler) pageToMapWithOwner(p *model.Page, owner *model.User, eyeCatchingImage map[string]any, isLiked *bool) map[string]any {
+	return entity.PackPageWithContext(p, entity.PackPageContext{
+		IDGen:            h.idGen,
+		Owner:            owner,
+		EyeCatchingImage: eyeCatchingImage,
+		IsLiked:          isLiked,
+	})
 }
 
 func notFound(c echo.Context) error {

--- a/internal/api/pages/handler_test.go
+++ b/internal/api/pages/handler_test.go
@@ -1,6 +1,7 @@
 package pages
 
 import (
+	"encoding/json"
 	"errors"
 	"net/http"
 	"net/http/httptest"
@@ -125,6 +126,29 @@ func TestShow_ByName(t *testing.T) {
 	c, rec := newReq(t, `{"userId":"alice","name":"alpha"}`)
 	require.NoError(t, h.Show(c))
 	assert.Equal(t, http.StatusOK, rec.Code)
+}
+
+// TestShow_IncludesUserAndIsLiked guards #1134 for the single-page path:
+// owner が attach され、viewer logged-in 時は isLiked field も含まれる。
+func TestShow_IncludesUserAndIsLiked(t *testing.T) {
+	h, repo, likeRepo := newHandler(t)
+	repo.Pages["p1"] = &model.Page{ID: "p1", UserID: "alice", Name: "alpha", Visibility: model.PageVisibilityPublic}
+	require.NoError(t, likeRepo.Create(&model.PageLike{ID: "l1", UserID: "bob", PageID: "p1"}))
+	h.SetUserSource(&stubUserSource{
+		bundle: &coreuser.UserWithProfile{
+			User: &model.User{ID: "alice", Username: "alice", UsernameLower: "alice"},
+		},
+	})
+	c, rec := newReq(t, `{"pageId":"p1"}`)
+	setUser(c, "bob")
+	require.NoError(t, h.Show(c))
+	require.Equal(t, http.StatusOK, rec.Code)
+	var row map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &row))
+	user, ok := row["user"].(map[string]any)
+	require.True(t, ok, "show response must include user field (#1134)")
+	assert.Equal(t, "alice", user["username"])
+	assert.Equal(t, true, row["isLiked"], "isLiked must reflect viewer's like state (#1134)")
 }
 
 func TestShow_ByUsername(t *testing.T) {
@@ -338,6 +362,25 @@ func TestMy_Success(t *testing.T) {
 	assert.Contains(t, rec.Body.String(), "alpha")
 }
 
+// TestMy_IncludesUserField guards #1134: frontend MkPagePreview の
+// `page.user.username` template が unconditional 参照なので、`user` field が
+// 必ず entity に含まれていることを検証する。
+func TestMy_IncludesUserField(t *testing.T) {
+	h, repo, _ := newHandler(t)
+	repo.Pages["p1"] = &model.Page{ID: "p1", UserID: "alice", Name: "alpha", Visibility: model.PageVisibilityPublic}
+	username := "alice"
+	c, rec := newReq(t, `{}`)
+	c.Set(string(middleware.UserContextKey), &model.User{ID: "alice", Username: username, UsernameLower: username})
+	require.NoError(t, h.My(c))
+	require.Equal(t, http.StatusOK, rec.Code)
+	var rows []map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &rows))
+	require.Len(t, rows, 1)
+	user, ok := rows[0]["user"].(map[string]any)
+	require.True(t, ok, "page entity must include user field (#1134)")
+	assert.Equal(t, "alice", user["username"])
+}
+
 func TestMy_BadJSON(t *testing.T) {
 	h, _, _ := newHandler(t)
 	c, rec := newReq(t, `{not`)
@@ -374,6 +417,46 @@ func TestFeatured_Success(t *testing.T) {
 	c, rec := newReq(t, `{}`)
 	require.NoError(t, h.Featured(c))
 	assert.Equal(t, http.StatusOK, rec.Code)
+}
+
+// TestFeatured_IncludesUserField guards #1134 for the batch-owner path:
+// userSource を wire したとき FindManyByIDs で owner が解決され、各 row に
+// `user.username` が attach されることを確認。
+func TestFeatured_IncludesUserField(t *testing.T) {
+	h, repo, _ := newHandler(t)
+	repo.Pages["p1"] = &model.Page{ID: "p1", UserID: "alice", Name: "alpha", Visibility: model.PageVisibilityPublic}
+	repo.Pages["p2"] = &model.Page{ID: "p2", UserID: "bob", Name: "beta", Visibility: model.PageVisibilityPublic}
+	h.SetUserSource(&stubUserSource{
+		manyUsers: []*model.User{
+			{ID: "alice", Username: "alice", UsernameLower: "alice"},
+			{ID: "bob", Username: "bob", UsernameLower: "bob"},
+		},
+	})
+	c, rec := newReq(t, `{}`)
+	require.NoError(t, h.Featured(c))
+	require.Equal(t, http.StatusOK, rec.Code)
+	var rows []map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &rows))
+	require.Len(t, rows, 2)
+	for _, row := range rows {
+		user, ok := row["user"].(map[string]any)
+		require.True(t, ok, "featured row must include user field (#1134)")
+		assert.NotEmpty(t, user["username"])
+	}
+}
+
+// TestFeatured_DropsRowsWithoutOwner guards the fail-soft path: when
+// userSource 未配線 (or batch fetch error) で owner が解決できない行は
+// pagesToList で drop される (= frontend が crash する代わりに silent skip)。
+func TestFeatured_DropsRowsWithoutOwner(t *testing.T) {
+	h, repo, _ := newHandler(t)
+	repo.Pages["p1"] = &model.Page{ID: "p1", UserID: "ghost", Name: "alpha", Visibility: model.PageVisibilityPublic}
+	c, rec := newReq(t, `{}`)
+	require.NoError(t, h.Featured(c))
+	require.Equal(t, http.StatusOK, rec.Code)
+	var rows []map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &rows))
+	assert.Empty(t, rows, "rows without owner must be dropped, not emitted with missing user field")
 }
 
 func TestFeatured_BadJSON(t *testing.T) {
@@ -556,6 +639,8 @@ type stubUserSource struct {
 	err              error
 	byUsernameBundle *coreuser.UserWithProfile
 	byUsernameErr    error
+	manyUsers        []*model.User
+	manyErr          error
 }
 
 func (s *stubUserSource) ShowByID(_ string) (*coreuser.UserWithProfile, error) {
@@ -570,6 +655,10 @@ func (s *stubUserSource) ShowByUsername(_ string, _ *string) (*coreuser.UserWith
 		return s.byUsernameBundle, s.byUsernameErr
 	}
 	return s.bundle, s.err
+}
+
+func (s *stubUserSource) FindManyByIDs(_ []string) ([]*model.User, error) {
+	return s.manyUsers, s.manyErr
 }
 
 func TestPagePush_PublishesPageEvent(t *testing.T) {

--- a/internal/api/users/content_lists.go
+++ b/internal/api/users/content_lists.go
@@ -182,6 +182,10 @@ func (h *Handler) GalleryPosts(c echo.Context) error {
 // Pages handles POST /api/users/pages.
 //
 // frontend Paginator (cursor mode) は untilId / sinceId を forward する (#493)。
+// upstream PageEntityService.pack 同様 `user` (UserLite) を含む full Page entity
+// shape で返す (#1134)。旧 inline map 6 field では frontend MkPagePreview の
+// `page.user.username` template が落ちて list が空になる drop-in regression
+// を起こしていた。
 func (h *Handler) Pages(c echo.Context) error {
 	var req struct {
 		UserID  string `json:"userId"`
@@ -209,16 +213,19 @@ func (h *Handler) Pages(c echo.Context) error {
 	if err != nil {
 		return apierr.JSONInternalError(c)
 	}
+	// owner は req.UserID で全 row 同一なので 1 度だけ fetch して全 row に attach。
+	// ShowByID 失敗時は empty list を返す (= upstream は user lookup 失敗時に
+	// 該当 row を skip するため、最終結果は同等)。
+	owner, oerr := h.userService.ShowByID(req.UserID)
+	if oerr != nil || owner == nil || owner.User == nil {
+		return c.JSON(http.StatusOK, []any{})
+	}
 	out := make([]map[string]any, 0, len(rows))
 	for _, p := range rows {
-		out = append(out, map[string]any{
-			"id":        p.ID,
-			"updatedAt": p.UpdatedAt,
-			"userId":    p.UserID,
-			"title":     p.Title,
-			"name":      p.Name,
-			"summary":   p.Summary,
-		})
+		out = append(out, entity.PackPageWithContext(p, entity.PackPageContext{
+			IDGen: h.idGen,
+			Owner: owner.User,
+		}))
 	}
 	return c.JSON(http.StatusOK, out)
 }

--- a/internal/api/users/content_lists_test.go
+++ b/internal/api/users/content_lists_test.go
@@ -136,14 +136,18 @@ func TestGalleryPosts_ReturnsAll(t *testing.T) {
 // --- Pages ---
 
 func TestPages(t *testing.T) {
-	h, _ := newTestHandler(t)
+	h, userRepo := newTestHandler(t)
+	// owner lookup を満たすためテストユーザーを登録 (#1134 で users/pages が
+	// owner 必須 entity shape を返すため)。
+	userRepo.Users["u1"] = &model.User{ID: "u1", Username: "u1", UsernameLower: "u1"}
 	rec := postStub(h.Pages, `{}`, nil)
 	assert.Equal(t, http.StatusBadRequest, rec.Code)
 	assert.Equal(t, http.StatusOK, postStub(h.Pages, `{"userId":"u1"}`, nil).Code)
 }
 
 func TestPages_HidesNonPublic(t *testing.T) {
-	h, _ := newTestHandler(t)
+	h, userRepo := newTestHandler(t)
+	userRepo.Users["owner"] = &model.User{ID: "owner", Username: "owner", UsernameLower: "owner"}
 	repo := testutil.NewMockPageRepository()
 	require.NoError(t, repo.Create(&model.Page{ID: "p1", UserID: "owner", Visibility: model.PageVisibilityPublic}))
 	require.NoError(t, repo.Create(&model.Page{ID: "p2", UserID: "owner", Visibility: model.PageVisibilityFollowers}))
@@ -153,4 +157,9 @@ func TestPages_HidesNonPublic(t *testing.T) {
 	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &rows))
 	require.Len(t, rows, 1)
 	assert.Equal(t, "p1", rows[0]["id"])
+	// #1134: frontend MkPagePreview が `page.user.username` を unconditional に
+	// 参照するため、user (UserLite) が必ず含まれていることを guard する。
+	user, ok := rows[0]["user"].(map[string]any)
+	require.True(t, ok, "page entity must include user field")
+	assert.Equal(t, "owner", user["username"])
 }

--- a/internal/core/page/page_service.go
+++ b/internal/core/page/page_service.go
@@ -320,3 +320,18 @@ func (s *Service) Unlike(userID, pageID string) error {
 	_ = s.repo.IncrementCount(pageID, "likedCount", -1)
 	return nil
 }
+
+// HasLiked reports whether `userID` has already liked `pageID`. Used by
+// /api/pages/show to populate the upstream-compatible `isLiked` field
+// (#1134). Returns false on lookup error so the response stays renderable
+// even when the page_like store is transiently unavailable.
+func (s *Service) HasLiked(userID, pageID string) bool {
+	if userID == "" || pageID == "" {
+		return false
+	}
+	exists, err := s.likeRepo.Exists(userID, pageID)
+	if err != nil {
+		return false
+	}
+	return exists
+}

--- a/internal/core/page/page_service_test.go
+++ b/internal/core/page/page_service_test.go
@@ -321,6 +321,18 @@ func TestFeatured(t *testing.T) {
 
 // --- Like ------------------------------------------------------------------
 
+// TestHasLiked covers the lookup helper added for /api/pages/show
+// (#1134). Empty / missing input は false で fail-soft (panic 無し)。
+func TestHasLiked(t *testing.T) {
+	svc, repo, likeRepo := newSvc(t)
+	repo.Pages["p1"] = &model.Page{ID: "p1", UserID: "u1", Visibility: model.PageVisibilityPublic}
+	assert.False(t, svc.HasLiked("u2", "p1"))
+	require.NoError(t, likeRepo.Create(&model.PageLike{ID: "l1", UserID: "u2", PageID: "p1"}))
+	assert.True(t, svc.HasLiked("u2", "p1"))
+	assert.False(t, svc.HasLiked("", "p1"))
+	assert.False(t, svc.HasLiked("u2", ""))
+}
+
 func TestLike_HappyPath(t *testing.T) {
 	svc, repo, likeRepo := newSvc(t)
 	repo.Pages["p1"] = &model.Page{ID: "p1", UserID: "u1", Visibility: model.PageVisibilityPublic}

--- a/internal/core/user/user_service.go
+++ b/internal/core/user/user_service.go
@@ -165,6 +165,17 @@ type UserWithProfile struct {
 	Profile *model.UserProfile
 }
 
+// FindManyByIDs returns the bare User rows for the given ID set in a single
+// query, without profile fetch. Intended for embed-context callers that just
+// need UserLite shape (= username / displayName / host / avatar) — currently
+// /api/pages/featured (#1134) batch-resolves owners this way.
+func (s *Service) FindManyByIDs(ids []string) ([]*model.User, error) {
+	if len(ids) == 0 {
+		return nil, nil
+	}
+	return s.userRepo.FindManyByIDs(ids)
+}
+
 // ShowByID returns the user (and profile) for the given ID.
 func (s *Service) ShowByID(id string) (*UserWithProfile, error) {
 	u, err := s.userRepo.FindByID(id)

--- a/internal/core/user/user_service_test.go
+++ b/internal/core/user/user_service_test.go
@@ -98,6 +98,26 @@ func TestService_ShowManyByIDs_AllMissing(t *testing.T) {
 	assert.Nil(t, out)
 }
 
+// TestService_FindManyByIDs covers the bare-user batch helper added for
+// /api/pages/featured owner resolution (#1134). 空入力は短絡で nil 返却、
+// 通常入力は repo に委譲して User row のみ取れる (profile fetch 無し)。
+func TestService_FindManyByIDs(t *testing.T) {
+	repo := testutil.NewMockUserRepository()
+	repo.Users["u1"] = &model.User{ID: "u1", Username: "alice"}
+	repo.Users["u2"] = &model.User{ID: "u2", Username: "bob"}
+	svc := user.NewService(repo, nil, nil, nil)
+
+	// 空入力は repo を叩かずに nil 返却。
+	out, err := svc.FindManyByIDs(nil)
+	require.NoError(t, err)
+	assert.Nil(t, out)
+
+	// 通常入力は User row 2 件取得。
+	out, err = svc.FindManyByIDs([]string{"u1", "u2"})
+	require.NoError(t, err)
+	assert.Len(t, out, 2)
+}
+
 func TestService_GetProfilesByUserIDs_BatchOK(t *testing.T) {
 	repo := testutil.NewMockUserRepository()
 	d1, d2 := "p1", "p2"

--- a/internal/entity/page.go
+++ b/internal/entity/page.go
@@ -14,6 +14,12 @@ import (
 // rendered in the same "2006-01-02T15:04:05.000Z" format used by other
 // entity packers (PackNote / PackDriveFile etc). updatedAt is rendered with
 // the same format for consistency.
+//
+// Use PackPageWithContext when the caller can supply the page owner +
+// per-viewer state — list endpoints (/api/i/pages, /api/users/pages,
+// /api/pages/featured) and the page detail (/api/pages/show) all need
+// `page.user` populated or the frontend MkPagePreview / page.vue templates
+// fail to render (`page.user.username` is unconditional).
 func PackPage(p *model.Page, idGens ...id.Generator) map[string]any {
 	if p == nil {
 		return nil
@@ -40,6 +46,54 @@ func PackPage(p *model.Page, idGens ...id.Generator) map[string]any {
 		if t, err := idGens[0].ParseTime(p.ID); err == nil {
 			out["createdAt"] = t.UTC().Format(tsFormat)
 		}
+	}
+	return out
+}
+
+// PackPageContext carries per-call enrichment data for PackPageWithContext.
+// All fields are optional; nil / zero leaves the corresponding field absent
+// (User) or null (IsLiked omitted entirely).
+type PackPageContext struct {
+	// IDGen drives the aidx → createdAt derivation just like the variadic
+	// arg on PackPage.
+	IDGen id.Generator
+	// Owner is the page.user owner. Required by frontend MkPagePreview
+	// (`page.user.username` is read unconditionally); when nil the field is
+	// emitted as null so the consumer can detect the lookup miss without
+	// throwing a TypeError in the Vue template.
+	Owner *model.User
+	// EyeCatchingImage is the pre-packed Drive file when Page.EyeCatchingImageID
+	// is set. nil means "either no image or the file lookup missed"; both
+	// render the same in MkPagePreview (the `v-if="page.eyeCatchingImage"`
+	// guard simply hides the block).
+	EyeCatchingImage map[string]any
+	// IsLiked is the viewer's like state. nil omits the field (upstream
+	// `pages/show` returns undefined when there is no logged-in viewer).
+	IsLiked *bool
+}
+
+// PackPageWithContext extends PackPage by adding `user`, `eyeCatchingImage`,
+// and `isLiked` fields when the context provides them. Upstream
+// PageEntityService.pack always populates `user`; mk-go list endpoints used
+// to omit it and the frontend MkPagePreview crashed silently (template
+// `page.user.username` reference) — see #1134.
+func PackPageWithContext(p *model.Page, ctx PackPageContext) map[string]any {
+	out := PackPage(p, ctx.IDGen)
+	if out == nil {
+		return nil
+	}
+	if ctx.Owner != nil {
+		out["user"] = PackUserLite(ctx.Owner)
+	}
+	// 注: Owner が nil の場合は user field を omit する。null 出しすると
+	// frontend MkPagePreview の page.user.username で再 throw するので、
+	// caller (list handler) は owner lookup miss の行を skip する責務がある
+	// (#1134 で対応した list endpoint 群はすべて owner 確保 → pack の順)。
+	if ctx.EyeCatchingImage != nil {
+		out["eyeCatchingImage"] = ctx.EyeCatchingImage
+	}
+	if ctx.IsLiked != nil {
+		out["isLiked"] = *ctx.IsLiked
 	}
 	return out
 }

--- a/internal/entity/page.go
+++ b/internal/entity/page.go
@@ -51,16 +51,18 @@ func PackPage(p *model.Page, idGens ...id.Generator) map[string]any {
 }
 
 // PackPageContext carries per-call enrichment data for PackPageWithContext.
-// All fields are optional; nil / zero leaves the corresponding field absent
-// (User) or null (IsLiked omitted entirely).
+// All fields are optional; nil leaves the corresponding output field
+// **omitted entirely** (never null) so the frontend cannot crash on
+// `page.user.username` etc.
 type PackPageContext struct {
 	// IDGen drives the aidx → createdAt derivation just like the variadic
 	// arg on PackPage.
 	IDGen id.Generator
 	// Owner is the page.user owner. Required by frontend MkPagePreview
-	// (`page.user.username` is read unconditionally); when nil the field is
-	// emitted as null so the consumer can detect the lookup miss without
-	// throwing a TypeError in the Vue template.
+	// (`page.user.username` is read unconditionally); when nil the `user`
+	// field is omitted entirely. List callers MUST therefore drop the row
+	// when their lookup misses (= upstream packMany semantics), otherwise
+	// MkPagePreview crashes on the next `page.user.username` access.
 	Owner *model.User
 	// EyeCatchingImage is the pre-packed Drive file when Page.EyeCatchingImageID
 	// is set. nil means "either no image or the file lookup missed"; both

--- a/internal/entity/page_test.go
+++ b/internal/entity/page_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/shiroha-a/mk/internal/model"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestPackPage_Basic(t *testing.T) {
@@ -77,4 +78,42 @@ func TestRawJSONBytes(t *testing.T) {
 	assert.Nil(t, rawJSONBytes(nil))
 	assert.Nil(t, rawJSONBytes([]byte{}))
 	assert.Equal(t, json.RawMessage(`[1]`), rawJSONBytes([]byte(`[1]`)))
+}
+
+// TestPackPageWithContext_AttachesOwnerAndOptionalFields guards #1134:
+// owner と option field が正しく entity に乗ること、optional は nil で omit
+// されることを確認する。
+func TestPackPageWithContext_AttachesOwnerAndOptionalFields(t *testing.T) {
+	idGen := newTestIDGen(t)
+	p := &model.Page{ID: idGen.Generate(time.Now()), UserID: "u1", Visibility: model.PageVisibilityPublic}
+	liked := true
+	out := PackPageWithContext(p, PackPageContext{
+		IDGen:            idGen,
+		Owner:            &model.User{ID: "u1", Username: "alice", UsernameLower: "alice"},
+		EyeCatchingImage: map[string]any{"id": "f1"},
+		IsLiked:          &liked,
+	})
+	user, ok := out["user"].(UserLite)
+	require.True(t, ok)
+	assert.Equal(t, "alice", user.Username)
+	assert.Equal(t, map[string]any{"id": "f1"}, out["eyeCatchingImage"])
+	assert.Equal(t, true, out["isLiked"])
+}
+
+func TestPackPageWithContext_OmitsAbsentOptionals(t *testing.T) {
+	idGen := newTestIDGen(t)
+	p := &model.Page{ID: idGen.Generate(time.Now()), UserID: "u1", Visibility: model.PageVisibilityPublic}
+	out := PackPageWithContext(p, PackPageContext{IDGen: idGen})
+	// Owner=nil → user field 自体を omit (null 出しすると frontend が
+	// page.user.username で再 throw するため)。
+	_, hasUser := out["user"]
+	assert.False(t, hasUser)
+	_, hasEye := out["eyeCatchingImage"]
+	assert.False(t, hasEye)
+	_, hasLiked := out["isLiked"]
+	assert.False(t, hasLiked)
+}
+
+func TestPackPageWithContext_NilPage(t *testing.T) {
+	assert.Nil(t, PackPageWithContext(nil, PackPageContext{}))
 }


### PR DESCRIPTION
## Summary

frontend Misskey TS `MkPagePreview.vue:7` は `page.user.username` を unconditional に参照しているが、mk-go の `/i/pages` / `/users/pages` / `/pages/featured` / `/pages/show` は `user` field を返していなかったため、template が silent fail し**「ページ」「My」「Featured」「他人のプロフィール pages」タブがすべて空表示**になっていた (テストユーザー報告経路)。

upstream `PageEntityService.pack` 互換に揃え、`entity.PackPageWithContext` で owner (UserLite) と optional な `eyeCatchingImage` / `isLiked` を attach できる shape を新設。

## 主な変更点

| File | 変更 |
|---|---|
| `internal/entity/page.go` | `PackPageContext` + `PackPageWithContext` 追加 (owner / eyeCatchingImage / isLiked option pattern) |
| `internal/api/pages/handler.go` | `UserBundleSource` に `FindManyByIDs` 追加 / My は viewer attach / Featured は batch lookup / Show は owner + isLiked |
| `internal/api/users/content_lists.go` | 旧 inline 6 field map → `PackPageWithContext` + owner 1-fetch attach |
| `internal/core/page/page_service.go` | `HasLiked(userID, pageID) bool` 追加 (fail-soft) |
| `internal/core/user/user_service.go` | `FindManyByIDs` 追加 (repo 委譲) |

### 経路別の owner 取得方針

- **/i/pages (My)**: viewer 自身 (= `middleware.GetUser`) を直接 attach、追加 DB round-trip 無し
- **/users/pages**: target user を 1 度だけ `ShowByID` + 全 row に attach、旧 inline 6 field map は廃止
- **/pages/featured**: 複数 owner なので `FindManyByIDs` で 1-round-trip batch fetch、owner lookup miss 行は `pagesToList` で drop (upstream の `packMany` が unpackable row を skip するのと同 fail-soft)
- **/pages/show**: `ShowByID` で owner、`HasLiked` で `isLiked` (logged-in viewer 時のみ pointer で渡し guest は field omit)

### Drop-in 互換

- 既存 API URL / param shape は変更なし
- error code 追加なし
- レスポンスに **field が追加される方向のみ** の差分 (削除なし)
- 旧来 frontend は `user` field 不在で silent fail していたので、本 fix で「設定したのに見えない」期待挙動が復元される方向

## テスト

CI で全 package green (90% 閾値含む)。

### 追加 regression guard (5 件)

- `TestMy_IncludesUserField` — `/i/pages` row に `user.username` が含まれる
- `TestFeatured_IncludesUserField` — `/pages/featured` で batch lookup 経由でも `user.username` が含まれる
- `TestFeatured_DropsRowsWithoutOwner` — owner lookup miss 行は drop される (frontend crash 防止)
- `TestShow_IncludesUserAndIsLiked` — `/pages/show` に owner + isLiked が含まれる
- `TestPages_HidesNonPublic` (users) — non-self viewer の users/pages にも `user.username` 含まれる
- `TestPackPageWithContext_*` (entity 3 件) — option pattern の attach / omit / nil-safe 挙動
- `TestHasLiked` — service helper の fail-soft 挙動

### 実行

```bash
go test ./internal/api/pages/ ./internal/api/users/ ./internal/entity/ ./internal/core/page/ ./internal/core/user/
make fmt && make lint
```

## Closes

Closes #1134