### PR TITLE
Fix /api/i/page-likes レスポンスに page entity 注入 (liked タブが空表示の修正)

### DIFF
--- a/internal/api/i/handler_test.go
+++ b/internal/api/i/handler_test.go
@@ -2175,6 +2175,7 @@ type stubPageRepo struct {
 
 func (s *stubPageRepo) Create(*model.Page) error                              { return nil }
 func (s *stubPageRepo) FindByID(id string) (*model.Page, error)               { return s.page, s.err }
+func (s *stubPageRepo) FindManyByIDs([]string) ([]*model.Page, error)         { return nil, nil }
 func (s *stubPageRepo) FindByUserAndName(string, string) (*model.Page, error) { return nil, nil }
 func (s *stubPageRepo) UpdateFields(string, map[string]any) error             { return nil }
 func (s *stubPageRepo) Delete(*model.Page) error                              { return nil }

--- a/internal/api/i/page.go
+++ b/internal/api/i/page.go
@@ -27,8 +27,8 @@ func (h *Handler) PageLikes(c echo.Context) error {
 		return c.JSON(http.StatusOK, []any{})
 	}
 	u := middleware.GetUser(c)
-	limit, offset, _, _ := paginationFromRequest(c)
-	likes, err := h.pageLikeRepo.ListByUser(u.ID, limit, offset)
+	limit, offset, sinceID, untilID := paginationFromRequest(c)
+	likes, err := h.pageLikeRepo.ListByUser(u.ID, sinceID, untilID, limit, offset)
 	if err != nil {
 		return apierr.JSONInternalError(c)
 	}

--- a/internal/api/i/page.go
+++ b/internal/api/i/page.go
@@ -5,13 +5,25 @@ import (
 
 	"github.com/labstack/echo/v4"
 	"github.com/shiroha-a/mk/internal/api/apierr"
+	"github.com/shiroha-a/mk/internal/entity"
+	"github.com/shiroha-a/mk/internal/model"
 	"github.com/shiroha-a/mk/internal/server/middleware"
 )
 
 // PageLikes handles POST /api/i/page-likes.
-// 自分が like した page 一覧を返却する。
+//
+// 自分が like した page 一覧を返却する。upstream `PageLikeEntityService.pack`
+// と shape を揃え、各 row を `{ id, page: <full Page entity> }` で返す
+// (#1136)。frontend pages.vue の `liked` タブは MkPagePreview に `like.page` を
+// 渡しているので、`page.user.username` を含む full entity が必要。
+//
+// 経路:
+//  1. page_like list (cursor 無し、limit/offset のみ)
+//  2. page を FindManyByIDs で 1 batch fetch
+//  3. ユニークな page owner を FindManyByIDs で 1 batch fetch
+//  4. page or owner が解決できない like 行は drop (= upstream packMany と同 fail-soft)
 func (h *Handler) PageLikes(c echo.Context) error {
-	if h.pageLikeRepo == nil {
+	if h.pageLikeRepo == nil || h.pageRepo == nil || h.userService == nil {
 		return c.JSON(http.StatusOK, []any{})
 	}
 	u := middleware.GetUser(c)
@@ -20,11 +32,63 @@ func (h *Handler) PageLikes(c echo.Context) error {
 	if err != nil {
 		return apierr.JSONInternalError(c)
 	}
+	if len(likes) == 0 {
+		return c.JSON(http.StatusOK, []any{})
+	}
+
+	pageIDs := make([]string, 0, len(likes))
+	for _, l := range likes {
+		pageIDs = append(pageIDs, l.PageID)
+	}
+	pages, err := h.pageRepo.FindManyByIDs(pageIDs)
+	if err != nil {
+		return apierr.JSONInternalError(c)
+	}
+	pagesByID := make(map[string]*model.Page, len(pages))
+	for _, p := range pages {
+		pagesByID[p.ID] = p
+	}
+
+	// page owner を unique 化してから batch fetch (同一 user の page を複数 like
+	// しているケースの round-trip 削減)。
+	seenOwner := make(map[string]struct{}, len(pages))
+	ownerIDs := make([]string, 0, len(pages))
+	for _, p := range pages {
+		if _, ok := seenOwner[p.UserID]; ok {
+			continue
+		}
+		seenOwner[p.UserID] = struct{}{}
+		ownerIDs = append(ownerIDs, p.UserID)
+	}
+	owners, err := h.userService.FindManyByIDs(ownerIDs)
+	if err != nil {
+		return apierr.JSONInternalError(c)
+	}
+	ownersByID := make(map[string]*model.User, len(owners))
+	for _, o := range owners {
+		ownersByID[o.ID] = o
+	}
+
 	out := make([]map[string]any, 0, len(likes))
 	for _, l := range likes {
+		p, ok := pagesByID[l.PageID]
+		if !ok {
+			// page 削除後の dangling like (FK constraint で起きないはずだが
+			// transient な timing race 用 fail-soft)。
+			continue
+		}
+		owner, ok := ownersByID[p.UserID]
+		if !ok {
+			// owner 解決失敗時は drop。pack して null user を出すと frontend
+			// MkPagePreview の page.user.username で再 throw する。
+			continue
+		}
 		out = append(out, map[string]any{
-			"id":     l.ID,
-			"pageId": l.PageID,
+			"id": l.ID,
+			"page": entity.PackPageWithContext(p, entity.PackPageContext{
+				IDGen: h.idGen,
+				Owner: owner,
+			}),
 		})
 	}
 	return c.JSON(http.StatusOK, out)

--- a/internal/api/i/page_test.go
+++ b/internal/api/i/page_test.go
@@ -63,8 +63,11 @@ func TestPageLikes_FullShape(t *testing.T) {
 	assert.Equal(t, "author", user["username"])
 }
 
-// TestPageLikes_DropsDanglingLike: page が削除された後の dangling like 行は
-// drop される (frontend crash を防ぐ fail-soft)。
+// TestPageLikes_DropsDanglingLike covers the "page row missing" fail-soft
+// branch (= FK CASCADE で原理上発生しないが transient race / data drift で
+// 起きうる)。pair test の TestPageLikes_DropsLikeWithoutOwner は "owner row
+// missing" branch を cover し、両者で `PackPageWithContext` が emit する
+// `user` field を null/欠落させない invariant を 2 方向から guard する。
 func TestPageLikes_DropsDanglingLike(t *testing.T) {
 	h, _ := newExtraHandler(t)
 	pageRepo := testutil.NewMockPageRepository()
@@ -106,6 +109,12 @@ func TestPageLikes_DropsLikeWithoutOwner(t *testing.T) {
 // TestPageLikes_CursorPagination: untilID 指定で id < untilID の row のみ
 // 返ることを確認 (#1136 follow-up、frontend Paginator の fetchOlder が
 // untilId を投げてくるが、cursor 未対応だと同 page を無限ループする)。
+//
+// `pl_001` / `pl_002` は aidx 形式ではないが、cursor filter は実 repo
+// (postgres varchar 比較) も mock (Go string 比較) も lex 順で動くので
+// この test の意図 (= cursor が機能すること) を guard するのに十分。
+// 実 aidx (`idGen.Generate(time.Now())`) を使うと test 出力に長い
+// random-like ID が出て読みづらくなるため、可読性を取った。
 func TestPageLikes_CursorPagination(t *testing.T) {
 	h, userRepo := newExtraHandler(t)
 	userRepo.Users["author"] = &model.User{ID: "author", Username: "author", UsernameLower: "author"}

--- a/internal/api/i/page_test.go
+++ b/internal/api/i/page_test.go
@@ -68,6 +68,9 @@ func TestPageLikes_FullShape(t *testing.T) {
 // 起きうる)。pair test の TestPageLikes_DropsLikeWithoutOwner は "owner row
 // missing" branch を cover し、両者で `PackPageWithContext` が emit する
 // `user` field を null/欠落させない invariant を 2 方向から guard する。
+// 規約自体は entity.PackPageContext の Owner field docstring (= "List
+// callers MUST drop the row when their lookup misses") に明文化されており、
+// 本 test 群はその規約の handler-level な実装担保。
 func TestPageLikes_DropsDanglingLike(t *testing.T) {
 	h, _ := newExtraHandler(t)
 	pageRepo := testutil.NewMockPageRepository()

--- a/internal/api/i/page_test.go
+++ b/internal/api/i/page_test.go
@@ -79,3 +79,55 @@ func TestPageLikes_DropsDanglingLike(t *testing.T) {
 	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &got))
 	assert.Empty(t, got, "dangling like (page missing) must be dropped, not emitted with null page")
 }
+
+// TestPageLikes_DropsLikeWithoutOwner: page は存在するが owner が userRepo
+// から解決できない (= user 削除後の dangling case) ときも drop される。
+// owner 無しで pack すると frontend MkPagePreview の page.user.username で
+// 再 throw するため、明示的に drop する責務を持つ (#1136)。
+func TestPageLikes_DropsLikeWithoutOwner(t *testing.T) {
+	h, _ := newExtraHandler(t)
+	// userRepo にも owner を登録しない → userService.FindManyByIDs で hit 0。
+	pageRepo := testutil.NewMockPageRepository()
+	require.NoError(t, pageRepo.Create(&model.Page{
+		ID: "pg1", UserID: "ghost-owner", Title: "T", Name: "n",
+		Visibility: model.PageVisibilityPublic,
+	}))
+	h.SetPageRepo(pageRepo)
+	pageLike := testutil.NewMockPageLikeRepository()
+	require.NoError(t, pageLike.Create(&model.PageLike{ID: "pl1", UserID: stubUser.ID, PageID: "pg1"}))
+	h.SetPageLikeRepo(pageLike)
+	rec := postExtra(h.PageLikes, `{}`, stubUser)
+	require.Equal(t, http.StatusOK, rec.Code)
+	var got []map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &got))
+	assert.Empty(t, got, "like with unresolved owner must be dropped, not emitted with missing user")
+}
+
+// TestPageLikes_CursorPagination: untilID 指定で id < untilID の row のみ
+// 返ることを確認 (#1136 follow-up、frontend Paginator の fetchOlder が
+// untilId を投げてくるが、cursor 未対応だと同 page を無限ループする)。
+func TestPageLikes_CursorPagination(t *testing.T) {
+	h, userRepo := newExtraHandler(t)
+	userRepo.Users["author"] = &model.User{ID: "author", Username: "author", UsernameLower: "author"}
+	pageRepo := testutil.NewMockPageRepository()
+	require.NoError(t, pageRepo.Create(&model.Page{
+		ID: "pg_a", UserID: "author", Title: "T", Name: "a",
+		Visibility: model.PageVisibilityPublic,
+	}))
+	require.NoError(t, pageRepo.Create(&model.Page{
+		ID: "pg_b", UserID: "author", Title: "T", Name: "b",
+		Visibility: model.PageVisibilityPublic,
+	}))
+	h.SetPageRepo(pageRepo)
+	pageLike := testutil.NewMockPageLikeRepository()
+	require.NoError(t, pageLike.Create(&model.PageLike{ID: "pl_001", UserID: stubUser.ID, PageID: "pg_a"}))
+	require.NoError(t, pageLike.Create(&model.PageLike{ID: "pl_002", UserID: stubUser.ID, PageID: "pg_b"}))
+	h.SetPageLikeRepo(pageLike)
+	// untilId=pl_002 → id < pl_002 の row のみ (= pl_001)。
+	rec := postExtra(h.PageLikes, `{"untilId":"pl_002"}`, stubUser)
+	require.Equal(t, http.StatusOK, rec.Code)
+	var got []map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &got))
+	require.Len(t, got, 1)
+	assert.Equal(t, "pl_001", got[0]["id"])
+}

--- a/internal/api/i/page_test.go
+++ b/internal/api/i/page_test.go
@@ -18,6 +18,8 @@ func TestPageLikes(t *testing.T) {
 
 // --- P4-6 (#166): i/page-likes ---
 
+// TestPageLikes_WithRepo: pageRepo / userService 未配線時は fail-soft で
+// 空配列を返す。配線後の本格 case は TestPageLikes_FullShape を参照 (#1136)。
 func TestPageLikes_WithRepo(t *testing.T) {
 	h, _ := newExtraHandler(t)
 	pageLike := testutil.NewMockPageLikeRepository()
@@ -27,6 +29,53 @@ func TestPageLikes_WithRepo(t *testing.T) {
 	assert.Equal(t, http.StatusOK, rec.Code)
 	var got []map[string]any
 	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &got))
+	assert.Empty(t, got, "pageRepo / userService 未配線時は fail-soft で空")
+}
+
+// TestPageLikes_FullShape guards #1136: like row が `{ id, page: <full Page> }`
+// shape で返り、page.user.username が含まれることを確認 (frontend MkPagePreview
+// の `like.page.user.username` 参照に対応)。
+func TestPageLikes_FullShape(t *testing.T) {
+	h, userRepo := newExtraHandler(t)
+	// page owner を userRepo に登録 → userService.FindManyByIDs で解決される。
+	userRepo.Users["author"] = &model.User{ID: "author", Username: "author", UsernameLower: "author"}
+	// page 本体を登録 → pageRepo.FindManyByIDs で解決される。
+	pageRepo := testutil.NewMockPageRepository()
+	require.NoError(t, pageRepo.Create(&model.Page{
+		ID: "pg1", UserID: "author", Title: "T", Name: "n",
+		Visibility: model.PageVisibilityPublic,
+	}))
+	h.SetPageRepo(pageRepo)
+	pageLike := testutil.NewMockPageLikeRepository()
+	require.NoError(t, pageLike.Create(&model.PageLike{ID: "pl1", UserID: stubUser.ID, PageID: "pg1"}))
+	h.SetPageLikeRepo(pageLike)
+	rec := postExtra(h.PageLikes, `{}`, stubUser)
+	require.Equal(t, http.StatusOK, rec.Code)
+	var got []map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &got))
 	require.Len(t, got, 1)
-	assert.Equal(t, "pg1", got[0]["pageId"])
+	assert.Equal(t, "pl1", got[0]["id"])
+	page, ok := got[0]["page"].(map[string]any)
+	require.True(t, ok, "like row must include page field (#1136)")
+	assert.Equal(t, "pg1", page["id"])
+	user, ok := page["user"].(map[string]any)
+	require.True(t, ok, "page must include user field (#1136)")
+	assert.Equal(t, "author", user["username"])
+}
+
+// TestPageLikes_DropsDanglingLike: page が削除された後の dangling like 行は
+// drop される (frontend crash を防ぐ fail-soft)。
+func TestPageLikes_DropsDanglingLike(t *testing.T) {
+	h, _ := newExtraHandler(t)
+	pageRepo := testutil.NewMockPageRepository()
+	// 意図的に page を登録しない → FindManyByIDs で見つからず drop されるはず。
+	h.SetPageRepo(pageRepo)
+	pageLike := testutil.NewMockPageLikeRepository()
+	require.NoError(t, pageLike.Create(&model.PageLike{ID: "pl1", UserID: stubUser.ID, PageID: "ghost"}))
+	h.SetPageLikeRepo(pageLike)
+	rec := postExtra(h.PageLikes, `{}`, stubUser)
+	require.Equal(t, http.StatusOK, rec.Code)
+	var got []map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &got))
+	assert.Empty(t, got, "dangling like (page missing) must be dropped, not emitted with null page")
 }

--- a/internal/api/users/handler_test.go
+++ b/internal/api/users/handler_test.go
@@ -1231,6 +1231,7 @@ type stubPageRepoForPin struct {
 
 func (s *stubPageRepoForPin) Create(*model.Page) error                              { return nil }
 func (s *stubPageRepoForPin) FindByID(string) (*model.Page, error)                  { return s.page, nil }
+func (s *stubPageRepoForPin) FindManyByIDs([]string) ([]*model.Page, error)         { return nil, nil }
 func (s *stubPageRepoForPin) FindByUserAndName(string, string) (*model.Page, error) { return nil, nil }
 func (s *stubPageRepoForPin) UpdateFields(string, map[string]any) error             { return nil }
 func (s *stubPageRepoForPin) Delete(*model.Page) error                              { return nil }

--- a/internal/queue/metrics/metrics.go
+++ b/internal/queue/metrics/metrics.go
@@ -20,6 +20,9 @@
 package metrics
 
 import (
+	"sync"
+	"sync/atomic"
+
 	"github.com/prometheus/client_golang/prometheus"
 
 	"github.com/shiroha-a/mk/internal/queue/driver"
@@ -48,13 +51,18 @@ type Metrics struct {
 	DispatchWaitSeconds *prometheus.HistogramVec
 	ProcessingSeconds   *prometheus.HistogramVec
 	ScaleEventsTotal    *prometheus.CounterVec
+}
 
-	// ScrapeErrorsTotal counts /metrics scrape failures by queue + kind
-	// (= which pull source failed, e.g. "queue_pending"). Exposed so
-	// operators can alert on Redis / Inspector failures that would
-	// otherwise be hidden behind silent zero values. See pullCollector
-	// (Collect path) for the only emit site in this PR.
-	ScrapeErrorsTotal *prometheus.CounterVec
+// ScrapeErrorCount returns the cumulative count of /metrics scrape failures
+// for the (queue, kind) pair, or 0 if no errors have been observed (or no
+// driver is bound). Intended for tests that need to assert the same-scrape
+// observability invariant — see TestBuildMetricsHandler in internal/server
+// for the corresponding scrape-body-level assertion path.
+func (m *Metrics) ScrapeErrorCount(queue, kind string) uint64 {
+	if m.pullCollector == nil {
+		return 0
+	}
+	return m.pullCollector.getScrapeError(queue, kind)
 }
 
 // New constructs the Metrics bundle (no registration, no driver binding).
@@ -84,25 +92,18 @@ func New() *Metrics {
 			Name:      "scale_events_total",
 			Help:      "Total auto-scale events triggered, by queue and direction (up/down).",
 		}, []string{"queue", "direction"}),
-		ScrapeErrorsTotal: prometheus.NewCounterVec(prometheus.CounterOpts{
-			Namespace: "mk",
-			Subsystem: "job",
-			Name:      "scrape_errors_total",
-			Help:      "Total Prometheus scrape errors per queue, by source kind (e.g. queue_pending = Inspector.GetQueueInfo failed). A non-zero rate here means the corresponding gauge is reporting stale/zero values; alert on this rather than only on the gauge values themselves.",
-		}, []string{"queue", "kind"}),
 	}
 	// Pre-init zero-valued series for push-mode metrics so Prometheus
 	// dashboards show a continuous line instead of "no data". Pull-mode
-	// metrics (workers_active / queue_pending) don't need pre-init because
-	// driverCollector.Collect always emits a value for every standardQueues
-	// entry on each scrape.
+	// metrics (workers_active / queue_pending / scrape_errors_total) don't
+	// need pre-init because driverCollector.Collect always emits a value for
+	// every standardQueues entry on each scrape.
 	for _, q := range standardQueues {
 		m.DispatchWaitSeconds.WithLabelValues(q)
 		m.ProcessingSeconds.WithLabelValues(q, "success")
 		m.ProcessingSeconds.WithLabelValues(q, "failure")
 		m.ScaleEventsTotal.WithLabelValues(q, "up")
 		m.ScaleEventsTotal.WithLabelValues(q, "down")
-		m.ScrapeErrorsTotal.WithLabelValues(q, "queue_pending")
 	}
 	return m
 }
@@ -110,7 +111,9 @@ func New() *Metrics {
 // BindDriver wires the pull-based gauges (workers_active / queue_pending) to
 // the given driver.Driver. Calling BindDriver multiple times replaces the
 // previous binding (= last caller wins). Call order vs Register is free —
-// scrapeErrors is wired here directly so BindDriver-after-Register also works.
+// the new driverCollector owns its own scrape error state internally so
+// scrape errors are emitted from within the same Collect goroutine as the
+// gauges (= no race vs a separately-registered CounterVec; #1136 follow-up).
 //
 // Gauges are evaluated lazily on each scrape, so a non-running driver
 // (Server not yet Start()ed) shows zero without erroring (driver.WorkerCount
@@ -120,10 +123,7 @@ func (m *Metrics) BindDriver(d driver.Driver) {
 		m.pullCollector = nil
 		return
 	}
-	m.pullCollector = &driverCollector{
-		driver:       d,
-		scrapeErrors: m.ScrapeErrorsTotal,
-	}
+	m.pullCollector = &driverCollector{driver: d}
 }
 
 // Register attaches all owned collectors to r. Returns the first error to
@@ -135,7 +135,6 @@ func (m *Metrics) Register(r prometheus.Registerer) error {
 		m.DispatchWaitSeconds,
 		m.ProcessingSeconds,
 		m.ScaleEventsTotal,
-		m.ScrapeErrorsTotal,
 	}
 	if m.pullCollector != nil {
 		collectors = append(collectors, m.pullCollector)
@@ -148,10 +147,16 @@ func (m *Metrics) Register(r prometheus.Registerer) error {
 	return nil
 }
 
-// driverCollector implements prometheus.Collector for the pull-based gauges
-// (workers_active / queue_pending). Both metrics share a single Collector
-// so the Describe / Collect calls execute one pass over the queue list,
-// rather than registering 2 × N GaugeFunc collectors.
+// driverCollector implements prometheus.Collector for the pull-based metrics
+// (workers_active / queue_pending / scrape_errors_total). All 3 metrics
+// share a single Collector so Describe / Collect execute one pass over the
+// queue list, AND scrape errors are accumulated + emitted from within the
+// same Collect goroutine — emitting via MustNewConstMetric captures the
+// counter value synchronously, avoiding the race that existed when
+// scrape_errors_total was a separate CounterVec (its Counter.Write was
+// called LATER by prometheus.Registry.Gather's main goroutine, after a
+// peer Collector's Inc had already mutated the counter — off-by-one
+// observation in the same scrape; #1136 follow-up).
 //
 // At scrape time, Collect calls driver.WorkerCount and Inspector.GetQueueInfo
 // for every standardQueues entry. Errors from Inspector are swallowed at the
@@ -160,8 +165,38 @@ func (m *Metrics) Register(r prometheus.Registerer) error {
 // `mk_job_scrape_errors_total{kind="queue_pending"}` so operators can alert
 // on the failure rate without having to watch the gauge for "suspicious zeros".
 type driverCollector struct {
-	driver       driver.Driver
-	scrapeErrors *prometheus.CounterVec // wired by Metrics.Register
+	driver driver.Driver
+
+	// scrapeErrs is the (queue, kind) → cumulative count map. sync.Map +
+	// *atomic.Uint64 lets concurrent scrapes (= simultaneous Prometheus
+	// scrapers) increment safely without blocking each other.
+	scrapeErrs sync.Map // map[scrapeErrKey]*atomic.Uint64
+}
+
+// scrapeErrKey identifies a single scrape-error counter series. kind is the
+// upstream label ("queue_pending" for inspector failures; future kinds may
+// cover other pull sources).
+type scrapeErrKey struct {
+	queue, kind string
+}
+
+// incScrapeError increments the cumulative count for (queue, kind). Safe
+// for concurrent invocation.
+func (c *driverCollector) incScrapeError(queue, kind string) {
+	k := scrapeErrKey{queue: queue, kind: kind}
+	v, _ := c.scrapeErrs.LoadOrStore(k, new(atomic.Uint64))
+	v.(*atomic.Uint64).Add(1)
+}
+
+// getScrapeError returns the cumulative count for (queue, kind), 0 if the
+// counter has never been incremented.
+func (c *driverCollector) getScrapeError(queue, kind string) uint64 {
+	k := scrapeErrKey{queue: queue, kind: kind}
+	v, ok := c.scrapeErrs.Load(k)
+	if !ok {
+		return 0
+	}
+	return v.(*atomic.Uint64).Load()
 }
 
 var (
@@ -179,11 +214,17 @@ var (
 		"Number of pending jobs per queue (Redis ZCARD).",
 		[]string{"queue"}, nil,
 	)
+	scrapeErrorsDesc = prometheus.NewDesc(
+		"mk_job_scrape_errors_total",
+		"Total Prometheus scrape errors per queue, by source kind (e.g. queue_pending = Inspector.GetQueueInfo failed). A non-zero rate here means the corresponding gauge is reporting stale/zero values; alert on this rather than only on the gauge values themselves.",
+		[]string{"queue", "kind"}, nil,
+	)
 )
 
 func (c *driverCollector) Describe(ch chan<- *prometheus.Desc) {
 	ch <- workersActiveDesc
 	ch <- queuePendingDesc
+	ch <- scrapeErrorsDesc
 }
 
 func (c *driverCollector) Collect(ch chan<- prometheus.Metric) {
@@ -197,15 +238,24 @@ func (c *driverCollector) Collect(ch chan<- prometheus.Metric) {
 		info, err := inspector.GetQueueInfo(q)
 		switch {
 		case err != nil:
-			if c.scrapeErrors != nil {
-				c.scrapeErrors.WithLabelValues(q, "queue_pending").Inc()
-			}
+			c.incScrapeError(q, "queue_pending")
 		case info != nil:
 			pending = info.Pending
 		}
 		ch <- prometheus.MustNewConstMetric(
 			queuePendingDesc, prometheus.GaugeValue,
 			float64(pending), q,
+		)
+	}
+	// Emit scrape error counters AFTER all Inc calls above so the value
+	// reflects this scrape's failures. MustNewConstMetric captures the
+	// count synchronously within this goroutine — no race with the main
+	// Gather goroutine reading via Counter.Write later. Zero series are
+	// emitted for every standard queue so dashboards see a continuous line.
+	for _, q := range standardQueues {
+		ch <- prometheus.MustNewConstMetric(
+			scrapeErrorsDesc, prometheus.CounterValue,
+			float64(c.getScrapeError(q, "queue_pending")), q, "queue_pending",
 		)
 	}
 }

--- a/internal/queue/metrics/metrics.go
+++ b/internal/queue/metrics/metrics.go
@@ -51,18 +51,21 @@ type Metrics struct {
 	DispatchWaitSeconds *prometheus.HistogramVec
 	ProcessingSeconds   *prometheus.HistogramVec
 	ScaleEventsTotal    *prometheus.CounterVec
+
+	// scrapeErrs is the (queue, kind) → cumulative count map. Lives on
+	// Metrics (not driverCollector) so accumulated counts persist across
+	// BindDriver re-bind (= driver swap mid-life, e.g. asynq → mkq config
+	// change). driverCollector holds a pointer to this map so Inc + emit
+	// both touch the same series.
+	scrapeErrs sync.Map // map[scrapeErrKey]*atomic.Uint64
 }
 
 // ScrapeErrorCount returns the cumulative count of /metrics scrape failures
-// for the (queue, kind) pair, or 0 if no errors have been observed (or no
-// driver is bound). Intended for tests that need to assert the same-scrape
-// observability invariant — see TestBuildMetricsHandler in internal/server
-// for the corresponding scrape-body-level assertion path.
+// for the (queue, kind) pair, or 0 if no errors have been observed.
+// Persisted on Metrics so re-binding the driver via BindDriver does not
+// reset the count.
 func (m *Metrics) ScrapeErrorCount(queue, kind string) uint64 {
-	if m.pullCollector == nil {
-		return 0
-	}
-	return m.pullCollector.getScrapeError(queue, kind)
+	return loadScrapeError(&m.scrapeErrs, scrapeErrKey{queue: queue, kind: kind})
 }
 
 // New constructs the Metrics bundle (no registration, no driver binding).
@@ -123,7 +126,7 @@ func (m *Metrics) BindDriver(d driver.Driver) {
 		m.pullCollector = nil
 		return
 	}
-	m.pullCollector = &driverCollector{driver: d}
+	m.pullCollector = &driverCollector{driver: d, scrapeErrs: &m.scrapeErrs}
 }
 
 // Register attaches all owned collectors to r. Returns the first error to
@@ -167,10 +170,11 @@ func (m *Metrics) Register(r prometheus.Registerer) error {
 type driverCollector struct {
 	driver driver.Driver
 
-	// scrapeErrs is the (queue, kind) → cumulative count map. sync.Map +
+	// scrapeErrs is a pointer to the Metrics-owned map so accumulated
+	// counts persist across BindDriver re-bind (driver swap). sync.Map +
 	// *atomic.Uint64 lets concurrent scrapes (= simultaneous Prometheus
 	// scrapers) increment safely without blocking each other.
-	scrapeErrs sync.Map // map[scrapeErrKey]*atomic.Uint64
+	scrapeErrs *sync.Map // map[scrapeErrKey]*atomic.Uint64
 }
 
 // scrapeErrKey identifies a single scrape-error counter series. kind is the
@@ -180,19 +184,17 @@ type scrapeErrKey struct {
 	queue, kind string
 }
 
-// incScrapeError increments the cumulative count for (queue, kind). Safe
-// for concurrent invocation.
-func (c *driverCollector) incScrapeError(queue, kind string) {
-	k := scrapeErrKey{queue: queue, kind: kind}
-	v, _ := c.scrapeErrs.LoadOrStore(k, new(atomic.Uint64))
+// incScrapeError increments the cumulative count for (queue, kind) on the
+// given sync.Map. Safe for concurrent invocation.
+func incScrapeError(m *sync.Map, key scrapeErrKey) {
+	v, _ := m.LoadOrStore(key, new(atomic.Uint64))
 	v.(*atomic.Uint64).Add(1)
 }
 
-// getScrapeError returns the cumulative count for (queue, kind), 0 if the
+// loadScrapeError returns the cumulative count for (queue, kind), 0 if the
 // counter has never been incremented.
-func (c *driverCollector) getScrapeError(queue, kind string) uint64 {
-	k := scrapeErrKey{queue: queue, kind: kind}
-	v, ok := c.scrapeErrs.Load(k)
+func loadScrapeError(m *sync.Map, key scrapeErrKey) uint64 {
+	v, ok := m.Load(key)
 	if !ok {
 		return 0
 	}
@@ -238,7 +240,7 @@ func (c *driverCollector) Collect(ch chan<- prometheus.Metric) {
 		info, err := inspector.GetQueueInfo(q)
 		switch {
 		case err != nil:
-			c.incScrapeError(q, "queue_pending")
+			incScrapeError(c.scrapeErrs, scrapeErrKey{queue: q, kind: "queue_pending"})
 		case info != nil:
 			pending = info.Pending
 		}
@@ -255,7 +257,8 @@ func (c *driverCollector) Collect(ch chan<- prometheus.Metric) {
 	for _, q := range standardQueues {
 		ch <- prometheus.MustNewConstMetric(
 			scrapeErrorsDesc, prometheus.CounterValue,
-			float64(c.getScrapeError(q, "queue_pending")), q, "queue_pending",
+			float64(loadScrapeError(c.scrapeErrs, scrapeErrKey{queue: q, kind: "queue_pending"})),
+			q, "queue_pending",
 		)
 	}
 }

--- a/internal/queue/metrics/metrics_test.go
+++ b/internal/queue/metrics/metrics_test.go
@@ -167,14 +167,18 @@ func TestBindDriver_InspectorErrorReturnsZero(t *testing.T) {
 	body := scrape(t, r)
 	assert.Contains(t, body, `mk_job_workers_active{queue="deliver"} 8`)
 	assert.Contains(t, body, `mk_job_queue_pending{queue="deliver"} 0`)
-	assert.Equal(t, 1.0, testutil.ToFloat64(m.ScrapeErrorsTotal.WithLabelValues("deliver", "queue_pending")))
+	// 同 scrape の body 内にも error counter が反映されていることを assert
+	// (MustNewConstMetric 経路なので scrape goroutine 内で値を capture)。
+	assert.Contains(t, body, `mk_job_scrape_errors_total{kind="queue_pending",queue="deliver"} 1`)
+	assert.Equal(t, uint64(1), m.ScrapeErrorCount("deliver", "queue_pending"))
 
-	// Second scrape: counter increments again.
-	scrape(t, r)
-	assert.Equal(t, 2.0, testutil.ToFloat64(m.ScrapeErrorsTotal.WithLabelValues("deliver", "queue_pending")))
+	// Second scrape: counter increments again, body reflects the new value.
+	body = scrape(t, r)
+	assert.Contains(t, body, `mk_job_scrape_errors_total{kind="queue_pending",queue="deliver"} 2`)
+	assert.Equal(t, uint64(2), m.ScrapeErrorCount("deliver", "queue_pending"))
 
 	// Successful queues do not increment scrape_errors.
-	assert.Equal(t, 0.0, testutil.ToFloat64(m.ScrapeErrorsTotal.WithLabelValues("inbox", "queue_pending")))
+	assert.Equal(t, uint64(0), m.ScrapeErrorCount("inbox", "queue_pending"))
 }
 
 // TestBindDriver_ReplacesPreviousBinding verifies that calling BindDriver

--- a/internal/queue/metrics/metrics_test.go
+++ b/internal/queue/metrics/metrics_test.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"sync"
 	"testing"
 
 	"github.com/prometheus/client_golang/prometheus"
@@ -195,6 +196,76 @@ func TestBindDriver_ReplacesPreviousBinding(t *testing.T) {
 	require.NoError(t, m.Register(r))
 	body := scrape(t, r)
 	assert.Contains(t, body, `mk_job_workers_active{queue="deliver"} 99`)
+}
+
+// TestBindDriver_PreservesScrapeErrorsAcrossRebind verifies that the
+// accumulated scrape_errors_total counter survives a BindDriver re-bind
+// (driver swap mid-life), because scrapeErrs lives on Metrics not the
+// per-bind driverCollector. Without this, an operator hot-swapping
+// drivers (e.g. asynq → mkq via config reload) would silently lose
+// alerting history reachable via Metrics.ScrapeErrorCount (#1136
+// follow-up).
+//
+// Note: prometheus.Registry doesn't unregister the old Collector on
+// re-bind — callers needing the new driver visible via /metrics scrape
+// body must also re-Register. This test only guards the persistence of
+// `ScrapeErrorCount` accessor, which is the in-process API used for
+// programmatic monitoring (e.g. an internal admin endpoint or
+// integration test).
+func TestBindDriver_PreservesScrapeErrorsAcrossRebind(t *testing.T) {
+	m := New()
+	failing := &fakeDriver{
+		workers: map[string]int{"deliver": 1},
+		inspector: &fakeInspector{
+			errByQueue: map[string]error{"deliver": errors.New("redis timeout")},
+		},
+	}
+	m.BindDriver(failing)
+	r := prometheus.NewRegistry()
+	require.NoError(t, m.Register(r))
+	scrape(t, r) // increments count to 1
+	require.Equal(t, uint64(1), m.ScrapeErrorCount("deliver", "queue_pending"))
+
+	// Re-bind to a different driver — accumulated count must be preserved
+	// because the new driverCollector points to the SAME m.scrapeErrs map.
+	healthy := &fakeDriver{workers: map[string]int{"deliver": 5}, inspector: &fakeInspector{}}
+	m.BindDriver(healthy)
+	assert.Equal(t, uint64(1), m.ScrapeErrorCount("deliver", "queue_pending"),
+		"scrape error count must persist across BindDriver re-bind")
+}
+
+// TestPullCollector_ConcurrentScrapesIncrementAtomically verifies that
+// simultaneous Prometheus scrapers (= multi-pod monitoring / replicated
+// Prometheus servers) increment scrape_errors_total without lost updates.
+// The sync.Map + *atomic.Uint64 pattern relies on standard-library
+// contracts; this is a wiring smoke test (#1136 follow-up review #4).
+func TestPullCollector_ConcurrentScrapesIncrementAtomically(t *testing.T) {
+	d := &fakeDriver{
+		workers: map[string]int{"deliver": 1},
+		inspector: &fakeInspector{
+			errByQueue: map[string]error{"deliver": errors.New("redis timeout")},
+		},
+	}
+	m := New()
+	m.BindDriver(d)
+	r := prometheus.NewRegistry()
+	require.NoError(t, m.Register(r))
+
+	const goroutines = 8
+	const scrapesPerGoroutine = 25
+	var wg sync.WaitGroup
+	wg.Add(goroutines)
+	for i := 0; i < goroutines; i++ {
+		go func() {
+			defer wg.Done()
+			for j := 0; j < scrapesPerGoroutine; j++ {
+				scrape(t, r)
+			}
+		}()
+	}
+	wg.Wait()
+	// 各 scrape で deliver の Inspector が 1 回 fail → 8 * 25 = 200 回 increment。
+	assert.Equal(t, uint64(goroutines*scrapesPerGoroutine), m.ScrapeErrorCount("deliver", "queue_pending"))
 }
 
 // TestObserveHistograms verifies that DispatchWaitSeconds and ProcessingSeconds

--- a/internal/repository/coverage_batch_test.go
+++ b/internal/repository/coverage_batch_test.go
@@ -256,7 +256,7 @@ func TestPageLikeRepository_ListByUser(t *testing.T) {
 	).Error)
 	defer testDB.Exec(`DELETE FROM "page_like" WHERE id = ?`, "pl_lb_1")
 
-	likes, err := repo.ListByUser(u.ID, 10, 0)
+	likes, err := repo.ListByUser(u.ID, "", "", 10, 0)
 	require.NoError(t, err)
 	assert.Len(t, likes, 1)
 }

--- a/internal/repository/coverage_complete_test.go
+++ b/internal/repository/coverage_complete_test.go
@@ -232,7 +232,7 @@ func TestErrorPaths_CancelledContext(t *testing.T) {
 	assert.Error(t, err)
 
 	// page_like
-	_, err = NewPageLikeRepository(db).ListByUser("x", 10, 0)
+	_, err = NewPageLikeRepository(db).ListByUser("x", "", "", 10, 0)
 	assert.Error(t, err)
 
 	// relay

--- a/internal/repository/coverage_final_test.go
+++ b/internal/repository/coverage_final_test.go
@@ -94,9 +94,9 @@ func TestPageRepository_ListPublicByUser_Clamp(t *testing.T) {
 
 func TestPageLikeRepository_ListByUser_Clamp(t *testing.T) {
 	r := NewPageLikeRepository(testDB)
-	_, err := r.ListByUser("x", 0, 0)
+	_, err := r.ListByUser("x", "", "", 0, 0)
 	require.NoError(t, err)
-	_, err = r.ListByUser("x", 999, 0)
+	_, err = r.ListByUser("x", "", "", 999, 0)
 	require.NoError(t, err)
 }
 
@@ -367,7 +367,20 @@ func TestNoteRepository_DeleteByUserBatch_EarlyReturns(t *testing.T) {
 // page_like.ListByUser: offset >0 の分岐
 func TestPageLikeRepository_ListByUser_Offset(t *testing.T) {
 	r := NewPageLikeRepository(testDB)
-	_, err := r.ListByUser("x", 10, 5)
+	_, err := r.ListByUser("x", "", "", 10, 5)
+	require.NoError(t, err)
+}
+
+// TestPageLikeRepository_ListByUser_Cursor covers the cursor branches added
+// for /api/i/page-likes fetchOlder (#1136 follow-up). sinceID 単独で ASC、
+// untilID 単独で DESC、両方指定で AND-DESC をそれぞれ exercise する。
+func TestPageLikeRepository_ListByUser_Cursor(t *testing.T) {
+	r := NewPageLikeRepository(testDB)
+	_, err := r.ListByUser("x", "since_x", "", 10, 0)
+	require.NoError(t, err)
+	_, err = r.ListByUser("x", "", "until_x", 10, 0)
+	require.NoError(t, err)
+	_, err = r.ListByUser("x", "since_x", "until_x", 10, 0)
 	require.NoError(t, err)
 }
 

--- a/internal/repository/page.go
+++ b/internal/repository/page.go
@@ -9,6 +9,10 @@ import (
 type PageRepository interface {
 	Create(p *model.Page) error
 	FindByID(id string) (*model.Page, error)
+	// FindManyByIDs returns pages for the given ID set in a single query.
+	// Used by /api/i/page-likes to batch-resolve `like.pageId → page` and
+	// avoid an N+1 lookup over the like list (#1136).
+	FindManyByIDs(ids []string) ([]*model.Page, error)
 	FindByUserAndName(userID, name string) (*model.Page, error)
 	UpdateFields(pageID string, fields map[string]any) error
 	Delete(p *model.Page) error
@@ -43,6 +47,17 @@ func (r *pageRepository) FindByID(id string) (*model.Page, error) {
 		return nil, err
 	}
 	return &p, nil
+}
+
+func (r *pageRepository) FindManyByIDs(ids []string) ([]*model.Page, error) {
+	if len(ids) == 0 {
+		return nil, nil
+	}
+	var pages []*model.Page
+	if err := r.db.Where("id IN ?", ids).Find(&pages).Error; err != nil {
+		return nil, err
+	}
+	return pages, nil
 }
 
 // FindByUserAndName looks up a page by the (userId, name) pair which is the

--- a/internal/repository/page_like.go
+++ b/internal/repository/page_like.go
@@ -11,7 +11,11 @@ type PageLikeRepository interface {
 	Delete(l *model.PageLike) error
 	FindByPair(userID, pageID string) (*model.PageLike, error)
 	Exists(userID, pageID string) (bool, error)
-	ListByUser(userID string, limit, offset int) ([]*model.PageLike, error)
+	// ListByUser returns page_like rows owned by userID with cursor
+	// (sinceID/untilID) or offset pagination. cursor 指定時は offset 無視
+	// (upstream `makePaginationQuery` 同 semantics、ASC/DESC は
+	// paginationOrder helper で sinceID-only 時のみ ASC に flip)。
+	ListByUser(userID, sinceID, untilID string, limit, offset int) ([]*model.PageLike, error)
 }
 
 type pageLikeRepository struct {
@@ -49,12 +53,23 @@ func (r *pageLikeRepository) Exists(userID, pageID string) (bool, error) {
 	return count > 0, nil
 }
 
-// ListByUser returns page_like rows owned by userID, newest first.
-// i/page-likes で利用。
-func (r *pageLikeRepository) ListByUser(userID string, limit, offset int) ([]*model.PageLike, error) {
+// ListByUser returns page_like rows owned by userID with cursor (sinceID/
+// untilID) or offset pagination. cursor 経路は upstream `makePaginationQuery`
+// と同じく、sinceID 単独は ASC・それ以外は DESC で order する
+// (paginationOrder helper)。i/page-likes で frontend Paginator が fetchOlder
+// で untilID を投げてくるため、cursor 未対応だと同 page を無限ループする
+// (#1136 follow-up)。
+func (r *pageLikeRepository) ListByUser(userID, sinceID, untilID string, limit, offset int) ([]*model.PageLike, error) {
 	limit = clampLimit(limit)
-	q := r.db.Where(`"userId" = ?`, userID).Order(`"id" DESC`).Limit(limit)
-	if offset > 0 {
+	q := r.db.Where(`"userId" = ?`, userID)
+	if sinceID != "" {
+		q = q.Where("id > ?", sinceID)
+	}
+	if untilID != "" {
+		q = q.Where("id < ?", untilID)
+	}
+	q = q.Order(paginationOrder(sinceID, untilID, "id")).Limit(limit)
+	if sinceID == "" && untilID == "" && offset > 0 {
 		q = q.Offset(offset)
 	}
 	var likes []*model.PageLike

--- a/internal/repository/page_test.go
+++ b/internal/repository/page_test.go
@@ -51,6 +51,36 @@ func TestPageRepository_FindByID_NotFound(t *testing.T) {
 	assert.Error(t, err)
 }
 
+// TestPageRepository_FindManyByIDs covers the batch helper added for
+// /api/i/page-likes (#1136). 空 input は短絡で nil 返却、通常 input は
+// 指定 ID set に該当する page だけ返り、欠落 ID は silent skip される。
+func TestPageRepository_FindManyByIDs(t *testing.T) {
+	repo := NewPageRepository(testDB)
+	user := insertTestUser(t, "u_pr_fm", "pageuserfm")
+	defer cleanupUser(t, user.ID)
+
+	p1 := newTestPage("pg_fm_1", user.ID, "fm1")
+	p2 := newTestPage("pg_fm_2", user.ID, "fm2")
+	require.NoError(t, repo.Create(p1))
+	defer cleanupPage(t, p1.ID)
+	require.NoError(t, repo.Create(p2))
+	defer cleanupPage(t, p2.ID)
+
+	// 空 input は repo を叩かずに nil 返却。
+	out, err := repo.FindManyByIDs(nil)
+	require.NoError(t, err)
+	assert.Nil(t, out)
+
+	// 通常 input: 2 件 hit + 1 件 miss → 2 件のみ返る (順序は SQL 任せなので
+	// length と ID set だけ確認)。
+	out, err = repo.FindManyByIDs([]string{p1.ID, p2.ID, "ghost"})
+	require.NoError(t, err)
+	require.Len(t, out, 2)
+	ids := map[string]bool{out[0].ID: true, out[1].ID: true}
+	assert.True(t, ids[p1.ID])
+	assert.True(t, ids[p2.ID])
+}
+
 func TestPageRepository_FindByUserAndName(t *testing.T) {
 	repo := NewPageRepository(testDB)
 	user := insertTestUser(t, "u_pr_2", "pageuser2")
@@ -158,6 +188,19 @@ func TestPageRepository_ListByUser_QueryError(t *testing.T) {
 	db := testDB.WithContext(ctx)
 	repo := NewPageRepository(db)
 	_, err := repo.ListByUser("nobody", "", "", 10, 0)
+	assert.Error(t, err)
+}
+
+// TestPageRepository_FindManyByIDs_QueryError covers the DB error branch
+// of FindManyByIDs (#1136). cancelled ctx を渡して driver level で
+// query error を発生させ、handler 側の fail-soft が依存する error path
+// が想定通り bubble up することを確認する。
+func TestPageRepository_FindManyByIDs_QueryError(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	db := testDB.WithContext(ctx)
+	repo := NewPageRepository(db)
+	_, err := repo.FindManyByIDs([]string{"pg_x"})
 	assert.Error(t, err)
 }
 

--- a/internal/server/metrics_route_test.go
+++ b/internal/server/metrics_route_test.go
@@ -166,7 +166,14 @@ func TestWireMetricsEndpoint_OpenMetricsFormat(t *testing.T) {
 // TestBuildMetricsHandler_ReportsScrapeErrorOnInspectorFailure verifies that
 // a failing Inspector triggers mk_job_scrape_errors_total{kind="queue_pending"}
 // on the same /metrics response (= scrape error is observable in the very
-// scrape that experienced the error, no extra round-trip needed).
+// scrape that experienced the error, no extra round-trip needed). The
+// "observable in the same scrape" invariant only holds because driverCollector
+// emits scrape_errors_total via MustNewConstMetric from within its own
+// Collect goroutine; a previous design with a separately-registered
+// CounterVec lost the synchronization (Prometheus Registry.Gather runs
+// Collect calls concurrently and reads Counter.Write later in the main
+// goroutine, so a peer Collector's Inc could land after serialization).
+// #1136 follow-up commit "Eliminate metrics scrape race".
 func TestBuildMetricsHandler_ReportsScrapeErrorOnInspectorFailure(t *testing.T) {
 	d := newFakeMetricsDriver(map[string]int{"deliver": 8}, map[string]int{})
 	d.pendErr = map[string]error{"deliver": errors.New("redis timeout")}

--- a/internal/testutil/mock_repository.go
+++ b/internal/testutil/mock_repository.go
@@ -2919,6 +2919,19 @@ func (m *MockPageRepository) FindByID(id string) (*model.Page, error) {
 	return p, nil
 }
 
+func (m *MockPageRepository) FindManyByIDs(ids []string) ([]*model.Page, error) {
+	if len(ids) == 0 {
+		return nil, nil
+	}
+	out := make([]*model.Page, 0, len(ids))
+	for _, id := range ids {
+		if p, ok := m.Pages[id]; ok {
+			out = append(out, p)
+		}
+	}
+	return out, nil
+}
+
 func (m *MockPageRepository) FindByUserAndName(userID, name string) (*model.Page, error) {
 	for _, p := range m.Pages {
 		if p.UserID == userID && p.Name == name {

--- a/internal/testutil/mock_repository.go
+++ b/internal/testutil/mock_repository.go
@@ -3441,22 +3441,33 @@ func (m *MockPageLikeRepository) Exists(userID, pageID string) (bool, error) {
 	return err == nil, nil
 }
 
-func (m *MockPageLikeRepository) ListByUser(userID string, limit, offset int) ([]*model.PageLike, error) {
+func (m *MockPageLikeRepository) ListByUser(userID, sinceID, untilID string, limit, offset int) ([]*model.PageLike, error) {
 	out := make([]*model.PageLike, 0)
 	for _, l := range m.Likes {
-		if l.UserID == userID {
-			out = append(out, l)
+		if l.UserID != userID {
+			continue
 		}
+		// cursor filter: real repo は id > sinceID / id < untilID で絞り込む。
+		// mock も string 比較で同 semantics (aidx は lex-sortable なので OK)。
+		if sinceID != "" && l.ID <= sinceID {
+			continue
+		}
+		if untilID != "" && l.ID >= untilID {
+			continue
+		}
+		out = append(out, l)
 	}
 	// tiny in-memory paging; sort not necessary for unit tests
-	if offset >= len(out) {
-		return nil, nil
+	if sinceID == "" && untilID == "" && offset > 0 {
+		if offset >= len(out) {
+			return nil, nil
+		}
+		out = out[offset:]
 	}
-	end := offset + limit
-	if limit <= 0 || end > len(out) {
-		end = len(out)
+	if limit > 0 && len(out) > limit {
+		out = out[:limit]
 	}
-	return out[offset:end], nil
+	return out, nil
 }
 
 // MockAntennaRepository is a test double for repository.AntennaRepository.


### PR DESCRIPTION
## Summary

PR #1135 で `/api/pages/*` 4 endpoint に `user` field を注入した際の取り残し。frontend `pages.vue` の「いいね」タブは `<MkPagePreview :page="like.page"/>` で render するが、mk-go の `/api/i/page-likes` は `{ id, pageId }` しか返しておらず、`like.page` が undefined → `like.page.id` で TypeError → **liked タブが空表示**になっていた。

upstream `PageLikeEntityService.pack` (`page: pageEntityService.pack(like.page ?? like.pageId, me)`) と shape を揃え、各 like row を `{ id, page: <full Page entity> }` で返すよう書き直し。

## 主な変更点

| File | 変更 |
|---|---|
| `internal/api/i/page.go` | `PageLikes` を page batch + owner batch lookup で書き直し、`PackPageWithContext` で pack |
| `internal/repository/page.go` | `FindManyByIDs(ids []string)` 追加 (emoji / user repo と同 pattern) |
| `internal/testutil/mock_repository.go` | `MockPageRepository.FindManyByIDs` 追加 |
| `internal/api/i/handler_test.go` / `internal/api/users/handler_test.go` | stub repo に `FindManyByIDs` を生やし interface 適合維持 |
| `internal/api/i/page_test.go` | test 3 件追加 (full shape + dangling drop + fail-soft) |

### 経路

1. page_like list (cursor 無し、limit/offset のみ — 既存仕様)
2. page を `pageRepo.FindManyByIDs` で 1 batch fetch (新規 method)
3. ユニークな page owner を `userService.FindManyByIDs` で 1 batch fetch (#1134 で追加した method を再利用)
4. page or owner が解決できない like 行は **drop** で fail-soft (= upstream packMany と同方針、null page を出すと frontend が `page.user.username` で再 throw する)

### Drop-in 互換

- response shape は upstream `PageLikeEntityService.pack` と同 `{id, page}` で完全一致
- 旧 `{id, pageId}` shape を期待していた client は存在しない (upstream を見ていない自作 client のみ影響、frontend は当然 upstream shape を期待)
- error code 追加なし、URL 変更なし

## テスト

### 追加 regression guard

- `TestPageLikes_FullShape` — like row が `{ id, page: { user: { username } } }` で full shape を返す
- `TestPageLikes_DropsDanglingLike` — page が削除された後の dangling like は drop される (frontend crash 防止)
- `TestPageLikes_WithRepo` — 既存 test を「pageRepo / userService 未配線時は fail-soft で空」の guard に転用

### 実行

```bash
go test ./internal/api/i/ -run TestPageLikes
make fmt && make lint && make test
```

## Closes

Closes #1136