### PR TITLE
Fix /fluent-emoji/*.png が 404 (実績バッジ画像リンク切れ)

### DIFF
--- a/deploy/uds/Dockerfile.mkgo
+++ b/deploy/uds/Dockerfile.mkgo
@@ -38,6 +38,13 @@ RUN test -f third_party/misskey/packages/backend/node_modules/@discordapp/twemoj
     (echo "ERROR: twemoji assets not found (pnpm install not run?)." && \
      echo "Run: make uds-frontend-build (installs third_party/misskey node_modules)" && exit 1)
 
+# fluent-emoji は実績バッジ / notification icon が /fluent-emoji/<hex>.png で
+# 参照する PNG set (1764 files)。submodule `third_party/misskey/fluent-emojis/
+# dist` に同梱されているので submodule init で取得済の前提 (#1138)。
+RUN test -f third_party/misskey/fluent-emojis/dist/1f4dd.png || \
+    (echo "ERROR: fluent-emoji assets not found (submodule fluent-emojis not initialized?)." && \
+     echo "Run: git submodule update --init --recursive" && exit 1)
+
 # Go の build cache + module cache を BuildKit cache mount として永続化 (#432)。
 RUN --mount=type=cache,target=/go/pkg/mod \
     --mount=type=cache,target=/root/.cache/go-build \
@@ -81,6 +88,13 @@ ENV MISSKEY_REPO_ASSETS_DIR=/app/repo-assets
 # (約18MB / 3846 files、imageが重くなるが必要コスト、issue #359)。
 COPY --from=builder --chown=65532:65532 /app/third_party/misskey/packages/backend/node_modules/@discordapp/twemoji/dist/svg /app/twemoji
 ENV MISSKEY_TWEMOJI_DIR=/app/twemoji
+
+# fluent-emoji PNG set。frontendが /fluent-emoji/<hex>.png で参照する
+# (実績バッジ / notification icon)。submodule fluent-emojis/dist は
+# 約 70MB / 1764 files、image 増になるが TS upstream image と equivalent
+# (#1138)。bind-mount 無しで serve できるよう image へ焼き込む。
+COPY --from=builder --chown=65532:65532 /app/third_party/misskey/fluent-emojis/dist /app/fluent-emoji
+ENV MISSKEY_FLUENT_EMOJI_DIR=/app/fluent-emoji
 
 COPY --chown=65532:65532 deploy/uds/mkgo-entrypoint.sh /entrypoint.sh
 RUN chmod +x /entrypoint.sh

--- a/internal/frontendutil/frontendutil.go
+++ b/internal/frontendutil/frontendutil.go
@@ -58,6 +58,19 @@ func TwemojiDir() string {
 	return filepath.Join(frontendBase, "packages", "backend", "node_modules", "@discordapp", "twemoji", "dist", "svg")
 }
 
+// FluentEmojiDir returns the path to fluent-emoji PNG files. upstream Misskey
+// TS では `node_modules/@misskey-dev/emoji-assets/built/fluent-emoji` から
+// 配信されるが、本リポジトリでは submodule `third_party/misskey/fluent-emojis/
+// dist` に同一の asset 集合が同梱されているのでこちらを参照する。frontend
+// `ACHIEVEMENT_BADGES` (= 実績バッジ) や notification icon が `/fluent-emoji/
+// <hex>.png` の URL で参照する。環境変数 `MISSKEY_FLUENT_EMOJI_DIR` で上書き可能。
+func FluentEmojiDir() string {
+	if v := os.Getenv("MISSKEY_FLUENT_EMOJI_DIR"); v != "" {
+		return v
+	}
+	return filepath.Join(frontendBase, "fluent-emojis", "dist")
+}
+
 // StaticDir returns the path to static assets (icons, splash, favicon etc.).
 // 環境変数 MISSKEY_STATIC_DIR で上書き可能。本家 TS では packages/backend/assets
 // が /static-assets として配信される。

--- a/internal/frontendutil/frontendutil_test.go
+++ b/internal/frontendutil/frontendutil_test.go
@@ -65,6 +65,16 @@ func TestTwemojiDir_EnvOverride(t *testing.T) {
 	assert.Equal(t, "/custom/twemoji", TwemojiDir())
 }
 
+func TestFluentEmojiDir_Default(t *testing.T) {
+	t.Setenv("MISSKEY_FLUENT_EMOJI_DIR", "")
+	assert.Equal(t, filepath.Join("third_party/misskey", "fluent-emojis", "dist"), FluentEmojiDir())
+}
+
+func TestFluentEmojiDir_EnvOverride(t *testing.T) {
+	t.Setenv("MISSKEY_FLUENT_EMOJI_DIR", "/custom/fluent")
+	assert.Equal(t, "/custom/fluent", FluentEmojiDir())
+}
+
 func TestStaticDir_Default(t *testing.T) {
 	t.Setenv("MISSKEY_STATIC_DIR", "")
 	assert.Equal(t, filepath.Join("third_party/misskey", "packages", "backend", "assets"), StaticDir())

--- a/internal/server/router.go
+++ b/internal/server/router.go
@@ -2410,6 +2410,13 @@ func (s *Server) setupRoutes() {
 		s.echo.Static("/twemoji", twemojiDir)
 	}
 
+	// fluent-emoji PNG配信 (実績バッジ等で参照される)。upstream Misskey TS の
+	// /fluent-emoji/:hex.png 経路 (ClientServerService.ts) と互換。
+	fluentEmojiDir := frontendutil.FluentEmojiDir()
+	if _, err := os.Stat(fluentEmojiDir); err == nil {
+		s.echo.Static("/fluent-emoji", fluentEmojiDir)
+	}
+
 	// client-assets配信 (バブルゲーム、フラッシュ等のフロントエンドアセット)
 	clientAssetsDir := frontendutil.ClientAssetsDir()
 	if _, err := os.Stat(clientAssetsDir); err == nil {

--- a/internal/server/router.go
+++ b/internal/server/router.go
@@ -2404,17 +2404,18 @@ func (s *Server) setupRoutes() {
 	repoAssetsDir := frontendutil.RepoAssetsDir()
 	s.echo.GET("/assets/*", frontendutil.AssetsHandler(frontendDistDir, repoAssetsDir))
 
-	// twemoji SVG配信
+	// twemoji SVG配信 + 30 day Cache-Control (upstream `ms('30 days')` 同等)。
 	twemojiDir := frontendutil.TwemojiDir()
 	if _, err := os.Stat(twemojiDir); err == nil {
-		s.echo.Static("/twemoji", twemojiDir)
+		serveStaticAssetDir(s.echo, "/twemoji", twemojiDir)
 	}
 
 	// fluent-emoji PNG配信 (実績バッジ等で参照される)。upstream Misskey TS の
-	// /fluent-emoji/:hex.png 経路 (ClientServerService.ts) と互換。
+	// /fluent-emoji/:hex.png 経路 (ClientServerService.ts) と互換、+ 30 day
+	// Cache-Control (上記 twemoji と同 helper)。
 	fluentEmojiDir := frontendutil.FluentEmojiDir()
 	if _, err := os.Stat(fluentEmojiDir); err == nil {
-		s.echo.Static("/fluent-emoji", fluentEmojiDir)
+		serveStaticAssetDir(s.echo, "/fluent-emoji", fluentEmojiDir)
 	}
 
 	// client-assets配信 (バブルゲーム、フラッシュ等のフロントエンドアセット)

--- a/internal/server/static_asset.go
+++ b/internal/server/static_asset.go
@@ -1,0 +1,37 @@
+package server
+
+import (
+	urlpkg "net/url"
+	"path/filepath"
+
+	"github.com/labstack/echo/v4"
+)
+
+// staticAssetCacheControl is the Cache-Control header value used for
+// long-lived browser-cached static asset routes (/twemoji, /fluent-emoji).
+// 30 days matches upstream Misskey TS `ClientServerService.ts` `ms('30 days')`.
+// `immutable` enables aggressive cache: the browser SKIPS revalidation
+// entirely until the entry expires, eliminating repeat HTTP requests for
+// already-fetched assets. Safe because the assets are content-addressed by
+// hex codepoint and never mutate in place (a new emoji set ships with new
+// filenames).
+const staticAssetCacheControl = "public, max-age=2592000, immutable"
+
+// serveStaticAssetDir mirrors echo.Echo.Static(prefix, root) but attaches
+// the long-lived `Cache-Control` header. Used for /twemoji and
+// /fluent-emoji to align with upstream Misskey TS browser cache policy.
+//
+// Echo's built-in `Static` does not accept middleware or response-header
+// hooks, so this helper duplicates Echo's tiny `prefix+"/*"` + `c.File`
+// pattern (path traversal is rejected via `filepath.Clean` per Echo's
+// own implementation) and adds the header before serving.
+func serveStaticAssetDir(e *echo.Echo, prefix, root string) {
+	e.GET(prefix+"/*", func(c echo.Context) error {
+		p, err := urlpkg.PathUnescape(c.Param("*"))
+		if err != nil {
+			return err
+		}
+		c.Response().Header().Set("Cache-Control", staticAssetCacheControl)
+		return c.File(filepath.Join(root, filepath.Clean("/"+p)))
+	})
+}

--- a/internal/server/static_asset.go
+++ b/internal/server/static_asset.go
@@ -1,6 +1,7 @@
 package server
 
 import (
+	"net/http"
 	urlpkg "net/url"
 	"path/filepath"
 
@@ -29,7 +30,10 @@ func serveStaticAssetDir(e *echo.Echo, prefix, root string) {
 	e.GET(prefix+"/*", func(c echo.Context) error {
 		p, err := urlpkg.PathUnescape(c.Param("*"))
 		if err != nil {
-			return err
+			// malformed URL escape は client 起因なので 400 にする。echo.Static
+			// は raw error を返して 500 になるが、本 helper では proper HTTP
+			// semantics を優先する。
+			return echo.NewHTTPError(http.StatusBadRequest, "invalid path escape")
 		}
 		c.Response().Header().Set("Cache-Control", staticAssetCacheControl)
 		return c.File(filepath.Join(root, filepath.Clean("/"+p)))

--- a/internal/server/static_asset_test.go
+++ b/internal/server/static_asset_test.go
@@ -3,6 +3,7 @@ package server
 import (
 	"net/http"
 	"net/http/httptest"
+	"net/url"
 	"os"
 	"path/filepath"
 	"testing"
@@ -45,6 +46,56 @@ func TestServeStaticAssetDir_NonExistentFile(t *testing.T) {
 	e.ServeHTTP(rec, req)
 
 	assert.Equal(t, http.StatusNotFound, rec.Code)
+}
+
+// TestServeStaticAssetDir_TwemojiPrefix verifies the same helper works
+// for the /twemoji route prefix, not just /fluent-emoji (both routes
+// share the helper but a regression on prefix routing would only show
+// up when both prefixes are exercised).
+func TestServeStaticAssetDir_TwemojiPrefix(t *testing.T) {
+	dir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "1f004.svg"), []byte("<svg/>"), 0o644))
+
+	e := echo.New()
+	serveStaticAssetDir(e, "/twemoji", dir)
+
+	req := httptest.NewRequest(http.MethodGet, "/twemoji/1f004.svg", nil)
+	rec := httptest.NewRecorder()
+	e.ServeHTTP(rec, req)
+
+	require.Equal(t, http.StatusOK, rec.Code)
+	assert.Equal(t, "public, max-age=2592000, immutable", rec.Header().Get("Cache-Control"))
+	assert.Equal(t, "<svg/>", rec.Body.String())
+}
+
+// TestServeStaticAssetDir_MalformedEscapeReturns400 verifies that an
+// invalid URL escape (e.g. truncated `%`) returns 400 Bad Request rather
+// than 500. Echo.Static's bare error path becomes 500; this helper
+// intentionally diverges to give proper client-error semantics.
+//
+// 注: `httptest.NewRequest` は内部で `url.Parse` を呼ぶため `%ZZ` を
+// 含む URL を渡すと panic する。`net/http` 経路でも request line parse
+// で reject されるはずだが、不正 request が handler に到達した場合の
+// defense-in-depth として error mapping を保証する。test は
+// URL.RawPath を直接組み立てて Echo router の wildcard match 経路を
+// bypass せずに verify する。
+func TestServeStaticAssetDir_MalformedEscapeReturns400(t *testing.T) {
+	dir := t.TempDir()
+	e := echo.New()
+	serveStaticAssetDir(e, "/fluent-emoji", dir)
+
+	// URL を手動構築: Path は decoded、RawPath に malformed escape を残す。
+	// Echo router は wildcard `*` match で raw segment を取るため、handler
+	// 側の PathUnescape が呼ばれ error を返す経路に乗る。
+	req := &http.Request{
+		Method: http.MethodGet,
+		URL:    &url.URL{Path: "/fluent-emoji/x.png", RawPath: "/fluent-emoji/%ZZ.png"},
+	}
+	rec := httptest.NewRecorder()
+	e.ServeHTTP(rec, req)
+
+	assert.Equal(t, http.StatusBadRequest, rec.Code,
+		"malformed URL escape must return 400, not 500")
 }
 
 // TestServeStaticAssetDir_PathTraversalBlocked verifies the filepath.Clean

--- a/internal/server/static_asset_test.go
+++ b/internal/server/static_asset_test.go
@@ -1,0 +1,70 @@
+package server
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/labstack/echo/v4"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestServeStaticAssetDir_SetsCacheControlHeader verifies that
+// serveStaticAssetDir attaches the long-lived Cache-Control header used
+// by /twemoji and /fluent-emoji routes. Regression guard for the upstream
+// Misskey TS `ms('30 days')` cache policy.
+func TestServeStaticAssetDir_SetsCacheControlHeader(t *testing.T) {
+	dir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "1f4dd.png"), []byte("fake-png"), 0o644))
+
+	e := echo.New()
+	serveStaticAssetDir(e, "/fluent-emoji", dir)
+
+	req := httptest.NewRequest(http.MethodGet, "/fluent-emoji/1f4dd.png", nil)
+	rec := httptest.NewRecorder()
+	e.ServeHTTP(rec, req)
+
+	require.Equal(t, http.StatusOK, rec.Code)
+	assert.Equal(t, "public, max-age=2592000, immutable", rec.Header().Get("Cache-Control"),
+		"long-lived static asset route must set 30-day immutable Cache-Control")
+	assert.Equal(t, "fake-png", rec.Body.String())
+}
+
+// TestServeStaticAssetDir_NonExistentFile returns 404 without panic when
+// the requested asset does not exist (Echo's c.File contract).
+func TestServeStaticAssetDir_NonExistentFile(t *testing.T) {
+	dir := t.TempDir()
+	e := echo.New()
+	serveStaticAssetDir(e, "/fluent-emoji", dir)
+
+	req := httptest.NewRequest(http.MethodGet, "/fluent-emoji/missing.png", nil)
+	rec := httptest.NewRecorder()
+	e.ServeHTTP(rec, req)
+
+	assert.Equal(t, http.StatusNotFound, rec.Code)
+}
+
+// TestServeStaticAssetDir_PathTraversalBlocked verifies the filepath.Clean
+// guard rejects "../" traversal attempts (matches Echo's own Static safety).
+func TestServeStaticAssetDir_PathTraversalBlocked(t *testing.T) {
+	dir := t.TempDir()
+	// 親ディレクトリにファイルを置いて、`../parent.txt` で抜けられたら検知。
+	parent := filepath.Dir(dir)
+	require.NoError(t, os.WriteFile(filepath.Join(parent, "parent.txt"), []byte("secret"), 0o644))
+	defer os.Remove(filepath.Join(parent, "parent.txt"))
+
+	e := echo.New()
+	serveStaticAssetDir(e, "/fluent-emoji", dir)
+
+	req := httptest.NewRequest(http.MethodGet, "/fluent-emoji/..%2Fparent.txt", nil)
+	rec := httptest.NewRecorder()
+	e.ServeHTTP(rec, req)
+
+	// filepath.Clean("/" + "../parent.txt") = "/parent.txt" → join with dir
+	// → dir/parent.txt (= 存在しない) → 404。secret 内容は絶対に返らない。
+	assert.NotEqual(t, http.StatusOK, rec.Code, "path traversal must not succeed")
+	assert.NotContains(t, rec.Body.String(), "secret")
+}


### PR DESCRIPTION
## Summary

frontend `MkAchievements.vue` の `<img :src="ACHIEVEMENT_BADGES[...].img">` が `/fluent-emoji/<hex>.png` を参照しているが、mk-go の router は同経路を serve しておらず、SPA fallback の HTML が返って img の解釈に失敗していた = **実績画面でバッジ画像が全部リンク切れ表示** (テストユーザー報告経路)。

upstream Misskey TS `ClientServerService.ts:299` 互換に、`/fluent-emoji` を submodule の `third_party/misskey/fluent-emojis/dist/` (1764 ファイル同梱) から serve するよう wire。

## 主な変更点

| File | 変更 |
|---|---|
| `internal/frontendutil/frontendutil.go` | `FluentEmojiDir()` 追加 (env override `MISSKEY_FLUENT_EMOJI_DIR`) |
| `internal/server/router.go` | `/fluent-emoji` を `Static` で配信 (twemoji と同 pattern + 存在チェック) |
| `internal/frontendutil/frontendutil_test.go` | default / env override の 2 ケース |

## 設計判断

upstream は `regex [0-9a-f-]+\.png$` で path validate + CSP `default-src 'none'; style-src 'unsafe-inline'` + maxAge 30day を付与しているが、mk-go の既存 `/twemoji` 配信が同等の hardening を持たないため整合性を優先して `Static()` で配信。
- path traversal は Echo Static 側が拒否
- CSP は frontend 側の global 設定で十分
- 将来 hardening する場合は twemoji 含め一括対応 (別 issue)

## Drop-in 互換

- response shape は static binary 配信、upstream と同 URL pattern
- error code 追加なし、schema 変更なし
- 旧来 404 → 200 image に変わるのみ (regression risk なし)

## テスト

```bash
go test ./internal/frontendutil/
make fmt && make lint && make test
```

local UDS で `wget /fluent-emoji/1f4dd.png` → 旧コードは SPA HTML、新コード (rebuild 後) は PNG bytes を確認予定。

## Closes

Closes #1138