### PR TITLE
Fix: Mastodon系 actor.summary を MFM 変換せず profile に保存していた regression

### DIFF
--- a/internal/core/federation/resolver.go
+++ b/internal/core/federation/resolver.go
@@ -436,18 +436,20 @@ func (r *Resolver) resolveActorOnce(uri string) (*model.User, error) {
 
 // extractRemoteDescription returns the actor's bio mapped to
 // UserProfile.Description. upstream `ApPersonService` の logic と同じく
-// `_misskey_summary` (MFM そのまま) を優先し、なければ AP `summary` (HTML
-// or plain text) を採用する。upstream は htmlToMfm で MFM 変換してから保存
-// するが、mk-go には未実装なので生 HTML をそのまま保存する (= frontend
-// 側で render される、見た目は upstream と完全互換ではないが Empty 化は
-// 回避される。HTML→MFM 変換は将来の別 issue で扱う)。
-// varchar(2048) 制約を rune 単位で respect し、空は nil で表す。
+// `_misskey_summary` (MFM そのまま) を優先し、なければ AP `summary`
+// (HTML、Mastodon 系は `<p>...</p>` で wrap して送ってくる) を `mfm.FromHTML`
+// で MFM 変換してから保存する。生 HTML を保存すると frontend MFM render が
+// `<p>` を escape してリテラル表示する drop-in regression を起こすため
+// (#1140 で発覚)。varchar(2048) 制約を rune 単位で respect し、空は nil で表す。
 func extractRemoteDescription(actor *activitypub.Person) *string {
 	var raw string
 	if actor.MisskeySummary != "" {
 		raw = actor.MisskeySummary
 	} else if actor.Summary != "" {
-		raw = actor.Summary
+		// AP summary は Mastodon / Pleroma 等が HTML で送ってくる仕様
+		// (`<p>...</p>` ラップが典型)。MFM render を期待する frontend に
+		// そのまま渡すと escape されてタグがリテラル表示される。
+		raw = mfm.FromHTML(actor.Summary)
 	}
 	if raw == "" {
 		return nil

--- a/internal/core/federation/resolver.go
+++ b/internal/core/federation/resolver.go
@@ -441,6 +441,11 @@ func (r *Resolver) resolveActorOnce(uri string) (*model.User, error) {
 // で MFM 変換してから保存する。生 HTML を保存すると frontend MFM render が
 // `<p>` を escape してリテラル表示する drop-in regression を起こすため
 // (#1140 で発覚)。varchar(2048) 制約を rune 単位で respect し、空は nil で表す。
+//
+// 注: truncation 順序は upstream と意図的に差をつけている。upstream は
+// HTML 段階で truncate (mid-tag 切断の risk) してから htmlToMfm、本実装は
+// FromHTML で MFM に縮約してから truncate する。後者の方が content 効率
+// が良く、mid-tag 切断による壊れ HTML を parser に渡す経路が無い。
 func extractRemoteDescription(actor *activitypub.Person) *string {
 	var raw string
 	if actor.MisskeySummary != "" {

--- a/internal/core/federation/resolver_test.go
+++ b/internal/core/federation/resolver_test.go
@@ -174,6 +174,9 @@ func TestResolveActor_NewUserWithoutIconBanner(t *testing.T) {
 
 // AP `summary` (= リモートユーザの bio) を UserProfile.description に取り込む。
 // profile 行も同時に作成される (= 旧実装は user 行のみ作成していた regression)。
+// Mastodon 系の `<p>...</p>` ラップは mfm.FromHTML で MFM に変換される
+// (生 HTML を保存すると frontend MFM render が escape してリテラル表示する
+// drop-in regression を起こす、#1140)。
 func TestResolveActor_NewUserIngestsDescription(t *testing.T) {
 	body := `{
 		"id": "https://remote.example/users/alice",
@@ -189,7 +192,39 @@ func TestResolveActor_NewUserIngestsDescription(t *testing.T) {
 	profile, err := repo.FindProfileByUserID(user.ID)
 	require.NoError(t, err, "profile 行が作成される (back-fill 経路の前提)")
 	require.NotNil(t, profile.Description)
-	assert.Equal(t, "<p>Hello from remote!</p>", *profile.Description)
+	assert.Equal(t, "Hello from remote!", *profile.Description,
+		"<p> wrap は mfm.FromHTML で MFM 段落区切りに変換され TrimSpace で消える")
+}
+
+// TestResolveActor_MastodonStyleSummaryConvertedToMFM guards #1140:
+// Mastodon / Pleroma 系の actor.summary は典型的に `<p>...</p>` で wrap
+// され、`<a href>` mention や `<br>` を含む。これらが mfm.FromHTML 経由で
+// MFM に変換され、profile.description に純 MFM として保存されることを
+// 確認 (生 HTML が残ると frontend MFM render が escape して `<p>` 等が
+// リテラル表示される drop-in regression)。
+func TestResolveActor_MastodonStyleSummaryConvertedToMFM(t *testing.T) {
+	body := `{
+		"id": "https://mstdn.example/users/bob",
+		"type": "Person",
+		"preferredUsername": "bob",
+		"inbox": "https://mstdn.example/users/bob/inbox",
+		"summary": "<p>Hello!<br/>I&#39;m bob.</p><p>Follow me at <a href=\"https://example.com\">my site</a></p>",
+		"publicKey": {"publicKeyPem": "FAKE"}
+	}`
+	r, repo := newResolver(t, body, nil)
+	user, err := r.ResolveActor("https://mstdn.example/users/bob")
+	require.NoError(t, err)
+	profile, err := repo.FindProfileByUserID(user.ID)
+	require.NoError(t, err)
+	require.NotNil(t, profile.Description)
+	// `<p>` → 段落区切り (\n\n) / `<br>` → \n / `<a>` → [text](url) MFM。
+	desc := *profile.Description
+	assert.NotContains(t, desc, "<p>", "<p> tag must be converted out, not stored raw")
+	assert.NotContains(t, desc, "</p>", "</p> tag must be converted out")
+	assert.NotContains(t, desc, "<a ", "<a> tag must be converted to MFM link syntax")
+	assert.Contains(t, desc, "Hello!")
+	assert.Contains(t, desc, "I'm bob.")
+	assert.Contains(t, desc, "[my site](https://example.com)")
 }
 
 // `_misskey_summary` がある場合は AP `summary` より優先される (upstream

--- a/internal/core/federation/resolver_test.go
+++ b/internal/core/federation/resolver_test.go
@@ -1347,6 +1347,49 @@ func TestResolveActor_TTLRefreshUpdatesDescription(t *testing.T) {
 	assert.Equal(t, "new bio", *repo.Profiles["existing"].Description)
 }
 
+// TestResolveActor_TTLRefreshConvertsHTMLDescription guards #1140 on the
+// refresh path: 既存 remote actor が 旧 mk-go (生 HTML 保存) で取り込まれて
+// いた場合、次の TTL refresh で MFM 化されて natural healing する。本 PR で
+// fix した extractRemoteDescription は initial insert + refresh 両方から
+// 呼ばれるので、symmetry で動作するが、明示的な regression guard としても
+// refresh path を直接 cover する。
+func TestResolveActor_TTLRefreshConvertsHTMLDescription(t *testing.T) {
+	repo := testutil.NewMockUserRepository()
+	noteRepo := testutil.NewMockNoteRepository()
+	urls := activitypub.NewURLBuilder("https://example.com")
+	idGen, _ := id.NewGenerator("aidx")
+	uri := "https://mstdn.example/users/bob"
+	old := time.Now().Add(-48 * time.Hour)
+	repo.Users["existing-bob"] = &model.User{
+		ID:            "existing-bob",
+		Username:      "bob",
+		URI:           &uri,
+		LastFetchedAt: &old,
+	}
+	// 既存 row には旧 mk-go 由来の生 HTML が入っている state を再現。
+	staleDesc := "<p>old html bio</p>"
+	repo.Profiles["existing-bob"] = &model.UserProfile{
+		UserID:      "existing-bob",
+		Description: &staleDesc,
+	}
+	updated := `{
+		"id": "https://mstdn.example/users/bob",
+		"type": "Person",
+		"preferredUsername": "bob",
+		"inbox": "https://mstdn.example/users/bob/inbox",
+		"summary": "<p>fresh html bio from Mastodon</p>",
+		"publicKey": {"publicKeyPem": "REFRESHED"}
+	}`
+	r := federation.NewResolver(repo, noteRepo, urls, &stubFetcher{body: []byte(updated)}, idGen)
+	_, err := r.ResolveActor(uri)
+	require.NoError(t, err)
+	got := repo.Profiles["existing-bob"].Description
+	require.NotNil(t, got)
+	assert.Equal(t, "fresh html bio from Mastodon", *got,
+		"refresh path は extractRemoteDescription 経由なので MFM 変換が効く")
+	assert.NotContains(t, *got, "<p>", "natural healing で生 HTML が残らない")
+}
+
 // 既存 user で profile 行が無い (= 本 fix 以前に取り込まれた remote user) は
 // refresh 経路で back-fill される (#1022)。production の漸進的な救済経路。
 func TestResolveActor_TTLRefreshBackfillsProfile(t *testing.T) {


### PR DESCRIPTION
## Summary

Mastodon / Pleroma 等の AP 系インスタンスの remote user のプロフィール画面で、自己紹介欄に **`<p></p>` 等の HTML タグがリテラル表示** されていた drop-in regression を fix (テストユーザー報告経路)。

`extractRemoteDescription` (= AP actor.summary → UserProfile.Description) が生 HTML をそのまま保存していたが、frontend は description を MFM として render するので tag が escape されてリテラル表示されていた。`mfm.FromHTML` を通すよう配線。

## 主な変更点

| File | 変更 |
|---|---|
| `internal/core/federation/resolver.go` | `extractRemoteDescription` で AP summary 採用時に `mfm.FromHTML()` 適用、旧 TODO コメント (= 実態と食い違い) を実装済の note に書き換え |
| `internal/core/federation/resolver_test.go` | `TestResolveActor_NewUserIngestsDescription` を新挙動に更新、`TestResolveActor_MastodonStyleSummaryConvertedToMFM` を regression guard として新規追加 |

### 設計

- AP `summary` (HTML) は `mfm.FromHTML()` を通す (`internal/activitypub/mfm/from_html.go` で既存 — note.content 経路では使われていたが description 経路だけが配線漏れだった)
- `_misskey_summary` (= `actor.MisskeySummary`) は元から MFM なので touched しない (upstream `ApPersonService` と同 priority)
- truncation (2048 rune) は MFM 変換後の文字列に適用 (旧設計と同じ位置)

### Drop-in 互換

- API URL / response shape 変更なし
- `_misskey_summary` 経路は影響なし (= Misskey 同士の federation には影響無し)
- 既存 DB 行は **次の actor TTL refresh で自動的に MFM 化** される (refresh path も同 helper 経由、natural healing、migration 不要)

## 影響範囲

- **影響**: AP `summary` で HTML を送ってくる全 instance (Mastodon / Pleroma / Akkoma / MissTwins / Friendica / iceshrimp 等)
- **影響なし**: Misskey 系 (`_misskey_summary` 経由 + 元から HTML を送らない)

## テスト

```bash
go test ./internal/core/federation/ -run TestResolveActor
make fmt && make lint && make test
```

### 追加 regression guard

- `TestResolveActor_MastodonStyleSummaryConvertedToMFM` — `<p>` + `<br>` + `<a href>` を含む典型的な Mastodon summary が `<p>` / `<a>` を含まない MFM 出力に変換される
- 既存 `TestResolveActor_NewUserIngestsDescription` の expected を更新 (旧: 生 HTML → 新: MFM)
- 既存 `TestResolveActor_NewUserPrefersMisskeySummary` で `_misskey_summary` 経路が touched されないことも確認済

## Closes

Closes #1140