### PR TITLE
chore: stale comment fix (chat isRead + userlists N+1 claim)

### DIFF
--- a/internal/api/chat/handler.go
+++ b/internal/api/chat/handler.go
@@ -200,9 +200,10 @@ func (h *Handler) packRoomDetailed(r *model.ChatRoom, meID string) map[string]an
 // `invitationExists` を viewer 視点で計算する (#860 PR-D)。空文字列を渡した
 // 場合は packRoomDetailed が lookup を skip して両 false 固定。
 //
-// 注: upstream の packMessageDetailed は `isRead` を返さない (json-schema
-// 上 optional)。mk-go も同様に含めない。`isRead` は packMessageLite 系で
-// 返される設計と推定されるが、追加は別 issue (#860 残 scope) で扱う。
+// 注: upstream の packMessageDetailed は `isRead` field を返さない (json-schema
+// 上 `optional: true` だが実装側で emit していない、PR #861 で再調査済)。
+// mk-go 側で先に追加すると upstream と逆方向の shape drift を生むため
+// **意図的に未対応** とする。upstream が isRead を実装した場合に追従する。
 func (h *Handler) packMessageDetailed(m *model.ChatMessage, meID string) map[string]any {
 	result := h.packMessageWithCreatedAt(m)
 	if m.ToUser != nil {

--- a/internal/api/userlists/handler.go
+++ b/internal/api/userlists/handler.go
@@ -127,9 +127,9 @@ func (h *Handler) Show(c echo.Context) error {
 // router で必ず repo wire 済)。transient error は運用で観測したいので
 // slog.Warn で記録する (= blocking handler の fetchBlockeeMap と同 pattern)。
 //
-// NOTE (#876): users/lists/list は N list 持つ user に対し本 helper を N 回
-// 呼んでおり N+1 query になる。perf 改善は ListMembersByListIDs batch fetch
-// で別 issue (#876) として追跡。
+// 本 helper は `Show` (`/api/users/lists/show`) からのみ呼ばれる単発 1 query
+// 経路。list endpoint (= `/api/users/lists/list`) は line 57 で
+// `ListMembersByListIDs` 経由の 1 batch query を使うので N+1 にならない。
 func (h *Handler) memberIDs(listID string) []string {
 	members, err := h.repo.ListMembers(listID)
 	if err != nil {


### PR DESCRIPTION
## Summary

TODO audit tracker #1142 の最初の 2 sub-task。**stale + factually wrong な narrative コメント** を実態に合わせて書き直す comment-only な PR。

実装は touched せず、CI 影響無し。

## 主な変更点

### 1. `chat/handler.go:204` — `isRead` field の状態を訂正

旧:
```go
// 注: upstream の packMessageDetailed は `isRead` を返さない ...
// 追加は別 issue (#860 残 scope) で扱う。
```

問題:
- `#860` は **CLOSED** で取り残されていた
- 再調査 (PR #861 description) の結果、**upstream 自身が `isRead` を実装上 emit していない** (json-schema 上 `optional` だが空)
- mk-go で先に追加すると **逆方向の shape drift** を起こす (= TS が返さない field を mk-go だけが返す = drop-in 互換 break)

新:
```go
// 注: upstream の packMessageDetailed は `isRead` field を返さない ...
// mk-go 側で先に追加すると upstream と逆方向の shape drift を生むため
// **意図的に未対応** とする。upstream が isRead を実装した場合に追従する。
```

### 2. `userlists/handler.go:132` — `memberIDs(listID)` の N+1 narrative 削除

旧:
```go
// NOTE (#876): users/lists/list は N list 持つ user に対し本 helper を N 回
// 呼んでおり N+1 query になる。perf 改善は ListMembersByListIDs batch fetch
// で別 issue (#876) として追跡。
```

問題:
- `#876` は **CLOSED** で `ListMembersByListIDs` 実装済 (`user_list.go:156`)
- `List` endpoint は **line 57 で既に batch 経由**
- `memberIDs(listID)` helper は `Show` 専用の **単発 1 query** で N+1 ではない
- コメント自体が factually wrong

新:
```go
// 本 helper は `Show` (`/api/users/lists/show`) からのみ呼ばれる単発 1 query
// 経路。list endpoint (= `/api/users/lists/list`) は line 57 で
// `ListMembersByListIDs` 経由の 1 batch query を使うので N+1 にならない。
```

## Drop-in 互換 / Test

- code 変更なし、comment-only
- 既存 test 影響なし (chat / userlists test 緑確認済)

## Refs

Refs #1142 (TODO audit tracker、本 PR で sub-task 2 件消化)