### PR TITLE
Fix: users/{followers,following} に viewer 視点 relation flag を埋める (followsYou label)

### DIFF
--- a/internal/api/users/handler.go
+++ b/internal/api/users/handler.go
@@ -700,6 +700,11 @@ func (h *Handler) packRelationItems(
 	// 全 user の flag を nil 維持 (upstream も me が nil の経路では
 	// UserDetailedNotMe の relation field を omit する)。
 	followingMap, followedMap := h.batchFollowRelations(viewer, bundleByID)
+	// pending follow request も同じく 2 batch query で解決 (#1144 #2)。
+	// MkFollowButton が `hasPendingFollowRequestFromYou` で表示分岐するため
+	// `isFollowing` だけだと「pending 中なのに Follow ボタン」が出る regression
+	// になる。upstream UserDetailedNotMe schema と整合させる。
+	pendingFromMap, pendingToMap := h.batchPendingRequestRelations(viewer, bundleByID)
 
 	out := make([]relationItem, 0, len(filtered))
 	for _, f := range filtered {
@@ -719,6 +724,10 @@ func (h *Handler) packRelationItems(
 				isFollowed := followedMap[b.User.ID]
 				d.IsFollowing = &isFollowing
 				d.IsFollowed = &isFollowed
+				pendingFrom := pendingFromMap[b.User.ID]
+				pendingTo := pendingToMap[b.User.ID]
+				d.HasPendingFollowRequestFromYou = &pendingFrom
+				d.HasPendingFollowRequestToYou = &pendingTo
 			}
 			if followers {
 				item.Follower = &d
@@ -732,13 +741,67 @@ func (h *Handler) packRelationItems(
 }
 
 // batchFollowRelations resolves viewer's follow relations against the
-// candidate user set in 2 batch queries (followingRepo.FilterFollowing /
-// FilterFollowedBy). Returns nil maps if viewer or repo is nil so callers
-// can skip safely.
+// candidate user set in 2 batch queries (followingRepo.FilterFollowings
+// FromAnchor / ToAnchor). Returns nil maps if viewer or repo is nil so
+// callers can skip safely.
 func (h *Handler) batchFollowRelations(viewer *model.User, bundleByID map[string]*user.UserWithProfile) (map[string]bool, map[string]bool) {
 	if viewer == nil || h.followingRepo == nil || len(bundleByID) == 0 {
 		return nil, nil
 	}
+	candidates := buildRelationCandidates(viewer, bundleByID)
+	if len(candidates) == 0 {
+		return nil, nil
+	}
+	followingMap := make(map[string]bool, len(candidates))
+	followedMap := make(map[string]bool, len(candidates))
+	if ids, err := h.followingRepo.FilterFollowingsFromAnchor(viewer.ID, candidates); err == nil {
+		for _, id := range ids {
+			followingMap[id] = true
+		}
+	}
+	if ids, err := h.followingRepo.FilterFollowingsToAnchor(viewer.ID, candidates); err == nil {
+		for _, id := range ids {
+			followedMap[id] = true
+		}
+	}
+	return followingMap, followedMap
+}
+
+// batchPendingRequestRelations resolves viewer's pending follow_request
+// relations across the candidate user set in 2 batch queries
+// (followRequestRepo.FilterPendingFromAnchor / ToAnchor). Returns nil maps
+// if viewer or repo is nil so callers can skip safely.
+//
+// `hasPendingFollowRequestFromYou` / `hasPendingFollowRequestToYou` を
+// list 経路で埋めないと frontend MkFollowButton が「pending 中なのに
+// `Follow` ボタン」を表示する drift になる (#1144 #2)。
+func (h *Handler) batchPendingRequestRelations(viewer *model.User, bundleByID map[string]*user.UserWithProfile) (map[string]bool, map[string]bool) {
+	if viewer == nil || h.followRequestRepo == nil || len(bundleByID) == 0 {
+		return nil, nil
+	}
+	candidates := buildRelationCandidates(viewer, bundleByID)
+	if len(candidates) == 0 {
+		return nil, nil
+	}
+	fromMap := make(map[string]bool, len(candidates))
+	toMap := make(map[string]bool, len(candidates))
+	if ids, err := h.followRequestRepo.FilterPendingFromAnchor(viewer.ID, candidates); err == nil {
+		for _, id := range ids {
+			fromMap[id] = true
+		}
+	}
+	if ids, err := h.followRequestRepo.FilterPendingToAnchor(viewer.ID, candidates); err == nil {
+		for _, id := range ids {
+			toMap[id] = true
+		}
+	}
+	return fromMap, toMap
+}
+
+// buildRelationCandidates returns the candidate user IDs for viewer-relative
+// batch relation lookups, excluding viewer's own id (= self-flag has no
+// meaning, matches upstream `UserDetailedNotMe` semantics).
+func buildRelationCandidates(viewer *model.User, bundleByID map[string]*user.UserWithProfile) []string {
 	candidates := make([]string, 0, len(bundleByID))
 	for id := range bundleByID {
 		if id == viewer.ID {
@@ -746,22 +809,7 @@ func (h *Handler) batchFollowRelations(viewer *model.User, bundleByID map[string
 		}
 		candidates = append(candidates, id)
 	}
-	if len(candidates) == 0 {
-		return nil, nil
-	}
-	followingMap := make(map[string]bool, len(candidates))
-	followedMap := make(map[string]bool, len(candidates))
-	if ids, err := h.followingRepo.FilterFollowing(viewer.ID, candidates); err == nil {
-		for _, id := range ids {
-			followingMap[id] = true
-		}
-	}
-	if ids, err := h.followingRepo.FilterFollowedBy(viewer.ID, candidates); err == nil {
-		for _, id := range ids {
-			followedMap[id] = true
-		}
-	}
-	return followingMap, followedMap
+	return candidates
 }
 
 // fillPinned populates PinnedNoteIDs / PinnedNotes / PinnedPageID / PinnedPage

--- a/internal/api/users/handler.go
+++ b/internal/api/users/handler.go
@@ -594,14 +594,15 @@ func (h *Handler) listRelations(c echo.Context, followers bool) error {
 		return apierr.JSONNoSuchUser(c)
 	}
 
+	viewer := middleware.GetUser(c)
 	var (
 		rows []relationItem
 		err  error
 	)
 	if followers {
-		rows, err = h.collectFollowers(req)
+		rows, err = h.collectFollowers(req, viewer)
 	} else {
-		rows, err = h.collectFollowing(req)
+		rows, err = h.collectFollowing(req, viewer)
 	}
 	if err != nil {
 		return apierr.JSONInternalError(c)
@@ -619,20 +620,20 @@ type relationItem struct {
 	Followee   *entity.UserDetailed `json:"followee,omitempty"`
 }
 
-func (h *Handler) collectFollowers(req FollowersRequest) ([]relationItem, error) {
+func (h *Handler) collectFollowers(req FollowersRequest, viewer *model.User) ([]relationItem, error) {
 	rows, err := h.followingService.ListReceivedFollowing(req.UserID, req.Limit, req.Offset)
 	if err != nil {
 		return nil, err
 	}
-	return h.packRelationItems(rows, req, true), nil
+	return h.packRelationItems(rows, req, true, viewer), nil
 }
 
-func (h *Handler) collectFollowing(req FollowersRequest) ([]relationItem, error) {
+func (h *Handler) collectFollowing(req FollowersRequest, viewer *model.User) ([]relationItem, error) {
 	rows, err := h.followingService.ListSentFollowing(req.UserID, req.Limit, req.Offset)
 	if err != nil {
 		return nil, err
 	}
-	return h.packRelationItems(rows, req, false), nil
+	return h.packRelationItems(rows, req, false, viewer), nil
 }
 
 // packRelationItems builds the response slice for users/followers and
@@ -641,10 +642,18 @@ func (h *Handler) collectFollowing(req FollowersRequest) ([]relationItem, error)
 // ShowManyByIDs (#503) で 1 batch query にまとめ、map で O(1) 解決して
 // 旧 ShowByID per-row N+1 を解消する (#300 2-3)。instance は引き続き
 // batch 1 回で resolve する (#277)。
+//
+// viewer が non-nil なら follow relation flag (isFollowing / isFollowed) を
+// `FilterFollowing` / `FilterFollowedBy` の 2 batch query で埋める (#1144、
+// frontend MkUserInfo の `followsYou` ラベル + MkFollowButton の初期 state
+// が正しく描画されるのに必要)。viewer が自分自身を含む list 経路でも viewer
+// と list 内 user の id 一致時は relation lookup を skip する (= self-flag
+// は意味なし)。
 func (h *Handler) packRelationItems(
 	rows []*model.Following,
 	req FollowersRequest,
 	followers bool,
+	viewer *model.User,
 ) []relationItem {
 	filtered := make([]*model.Following, 0, len(rows))
 	idSet := make(map[string]struct{}, len(rows))
@@ -686,6 +695,12 @@ func (h *Handler) packRelationItems(
 	}
 	resolver := entity.NewInstanceResolver(h.instanceLookup(), remoteUsers...)
 
+	// viewer 視点の follow relation を 2 batch query で先に解決しておく
+	// (#1144)。viewer が nil (= unauthenticated) なら lookup skip して
+	// 全 user の flag を nil 維持 (upstream も me が nil の経路では
+	// UserDetailedNotMe の relation field を omit する)。
+	followingMap, followedMap := h.batchFollowRelations(viewer, bundleByID)
+
 	out := make([]relationItem, 0, len(filtered))
 	for _, f := range filtered {
 		item := relationItem{ID: f.ID, FollowerID: f.FollowerID, FolloweeID: f.FolloweeID}
@@ -699,6 +714,12 @@ func (h *Handler) packRelationItems(
 			d := entity.PackUserDetailed(b.User, b.Profile, h.idGen)
 			resolver.FillUserLite(&d.UserLite)
 			h.populateUserEmojis(b.User, &d.UserLite)
+			if viewer != nil && viewer.ID != b.User.ID {
+				isFollowing := followingMap[b.User.ID]
+				isFollowed := followedMap[b.User.ID]
+				d.IsFollowing = &isFollowing
+				d.IsFollowed = &isFollowed
+			}
 			if followers {
 				item.Follower = &d
 			} else {
@@ -708,6 +729,39 @@ func (h *Handler) packRelationItems(
 		out = append(out, item)
 	}
 	return out
+}
+
+// batchFollowRelations resolves viewer's follow relations against the
+// candidate user set in 2 batch queries (followingRepo.FilterFollowing /
+// FilterFollowedBy). Returns nil maps if viewer or repo is nil so callers
+// can skip safely.
+func (h *Handler) batchFollowRelations(viewer *model.User, bundleByID map[string]*user.UserWithProfile) (map[string]bool, map[string]bool) {
+	if viewer == nil || h.followingRepo == nil || len(bundleByID) == 0 {
+		return nil, nil
+	}
+	candidates := make([]string, 0, len(bundleByID))
+	for id := range bundleByID {
+		if id == viewer.ID {
+			continue
+		}
+		candidates = append(candidates, id)
+	}
+	if len(candidates) == 0 {
+		return nil, nil
+	}
+	followingMap := make(map[string]bool, len(candidates))
+	followedMap := make(map[string]bool, len(candidates))
+	if ids, err := h.followingRepo.FilterFollowing(viewer.ID, candidates); err == nil {
+		for _, id := range ids {
+			followingMap[id] = true
+		}
+	}
+	if ids, err := h.followingRepo.FilterFollowedBy(viewer.ID, candidates); err == nil {
+		for _, id := range ids {
+			followedMap[id] = true
+		}
+	}
+	return followingMap, followedMap
 }
 
 // fillPinned populates PinnedNoteIDs / PinnedNotes / PinnedPageID / PinnedPage

--- a/internal/api/users/handler_test.go
+++ b/internal/api/users/handler_test.go
@@ -33,6 +33,11 @@ func newTestHandler(t *testing.T) (*Handler, *testutil.MockUserRepository) {
 	svc := coreuser.NewService(userRepo, noteRepo, piningRepo, idGen)
 	fSvc := corefollowing.NewService(userRepo, fRepo, frRepo, idGen)
 	h := NewHandler(svc, fSvc, noteRepo, idGen)
+	// followingRepo を service と共有する形で wire しておく (#1144 で
+	// users/{followers,following} の relation flag batch lookup が
+	// h.followingRepo 経由になったため)。explicit setup が要る test では
+	// SetFollowingRepo で上書きする。
+	h.SetFollowingRepo(fRepo)
 	return h, userRepo
 }
 
@@ -926,6 +931,69 @@ func TestFollowers_Success(t *testing.T) {
 	var out []map[string]any
 	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &out))
 	assert.Len(t, out, 1)
+}
+
+// TestFollowers_PopulatesIsFollowedFromViewer guards #1144: when a viewer
+// (auth user) requests users/followers of a profile, each follower row's
+// embedded `follower` UserDetailed must carry `isFollowed` from the
+// viewer's perspective (= "does this follower follow me?"). frontend
+// MkUserInfo renders the "follows you" label based on this flag.
+func TestFollowers_PopulatesIsFollowedFromViewer(t *testing.T) {
+	h, repo := newTestHandler(t)
+	addTestUser(repo) // user1 = target profile
+	// viewer = bob, follower = alice
+	repo.Users["bob"] = &model.User{ID: "bob", Username: "bob", UsernameLower: "bob",
+		AvatarDecorations: datatypes.JSON([]byte("[]"))}
+	repo.Users["alice"] = &model.User{ID: "alice", Username: "alice", UsernameLower: "alice",
+		AvatarDecorations: datatypes.JSON([]byte("[]"))}
+	// alice follows user1 (= alice 表示される follower)、
+	// 加えて alice follows bob (viewer) → isFollowed = true 期待。
+	fSvc := h.followingService
+	_, err := fSvc.Follow("alice", "user1", corefollowing.FollowOptions{})
+	require.NoError(t, err)
+	_, err = fSvc.Follow("alice", "bob", corefollowing.FollowOptions{})
+	require.NoError(t, err)
+
+	rec := postStub(h.Followers, `{"userId":"user1"}`, repo.Users["bob"])
+	require.Equal(t, http.StatusOK, rec.Code)
+	var out []map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &out))
+	require.Len(t, out, 1)
+	follower, ok := out[0]["follower"].(map[string]any)
+	require.True(t, ok)
+	assert.Equal(t, true, follower["isFollowed"], "alice follows viewer(bob) → isFollowed=true")
+	// bob は alice を follow していない → isFollowing=false。
+	assert.Equal(t, false, follower["isFollowing"])
+}
+
+// TestFollowing_PopulatesIsFollowedFromViewer covers the symmetric case
+// for /api/users/following — each `followee` UserDetailed gets viewer's
+// relation flags.
+func TestFollowing_PopulatesIsFollowedFromViewer(t *testing.T) {
+	h, repo := newTestHandler(t)
+	addTestUser(repo) // user1 = target profile
+	repo.Users["bob"] = &model.User{ID: "bob", Username: "bob", UsernameLower: "bob",
+		AvatarDecorations: datatypes.JSON([]byte("[]"))}
+	repo.Users["charlie"] = &model.User{ID: "charlie", Username: "charlie", UsernameLower: "charlie",
+		AvatarDecorations: datatypes.JSON([]byte("[]"))}
+	fSvc := h.followingService
+	// user1 follows charlie → charlie が followee として list される。
+	_, err := fSvc.Follow("user1", "charlie", corefollowing.FollowOptions{})
+	require.NoError(t, err)
+	// viewer(bob) follows charlie → isFollowing=true、charlie は bob を
+	// follow していない → isFollowed=false。
+	_, err = fSvc.Follow("bob", "charlie", corefollowing.FollowOptions{})
+	require.NoError(t, err)
+
+	rec := postStub(h.Following, `{"userId":"user1"}`, repo.Users["bob"])
+	require.Equal(t, http.StatusOK, rec.Code)
+	var out []map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &out))
+	require.Len(t, out, 1)
+	followee, ok := out[0]["followee"].(map[string]any)
+	require.True(t, ok)
+	assert.Equal(t, true, followee["isFollowing"], "viewer(bob) follows charlie → isFollowing=true")
+	assert.Equal(t, false, followee["isFollowed"])
 }
 
 // users/followers が follower user の取得を per-row ShowByID で叩いて

--- a/internal/api/users/handler_test.go
+++ b/internal/api/users/handler_test.go
@@ -33,11 +33,12 @@ func newTestHandler(t *testing.T) (*Handler, *testutil.MockUserRepository) {
 	svc := coreuser.NewService(userRepo, noteRepo, piningRepo, idGen)
 	fSvc := corefollowing.NewService(userRepo, fRepo, frRepo, idGen)
 	h := NewHandler(svc, fSvc, noteRepo, idGen)
-	// followingRepo を service と共有する形で wire しておく (#1144 で
-	// users/{followers,following} の relation flag batch lookup が
-	// h.followingRepo 経由になったため)。explicit setup が要る test では
-	// SetFollowingRepo で上書きする。
+	// followingRepo + followRequestRepo を service と共有する形で wire
+	// しておく (#1144 で users/{followers,following} の relation flag +
+	// pending request flag の batch lookup が handler 直配線の repo 経由に
+	// なったため)。explicit setup が要る test では Set*Repo で上書きする。
 	h.SetFollowingRepo(fRepo)
+	h.SetFollowRequestRepo(frRepo)
 	return h, userRepo
 }
 
@@ -964,6 +965,40 @@ func TestFollowers_PopulatesIsFollowedFromViewer(t *testing.T) {
 	assert.Equal(t, true, follower["isFollowed"], "alice follows viewer(bob) → isFollowed=true")
 	// bob は alice を follow していない → isFollowing=false。
 	assert.Equal(t, false, follower["isFollowing"])
+}
+
+// TestFollowers_PopulatesPendingFollowRequest guards #1144 #2: locked
+// account からの pending follow request 状態でも MkFollowButton が正しく
+// "follow request pending" 表示にできるよう、
+// `hasPendingFollowRequestFromYou` / `hasPendingFollowRequestToYou` を
+// embed UserDetailed に埋める。
+func TestFollowers_PopulatesPendingFollowRequest(t *testing.T) {
+	h, repo := newTestHandler(t)
+	addTestUser(repo) // user1 = target profile
+	locked := true
+	repo.Users["bob"] = &model.User{ID: "bob", Username: "bob", UsernameLower: "bob",
+		IsLocked: locked, AvatarDecorations: datatypes.JSON([]byte("[]"))}
+	repo.Users["alice"] = &model.User{ID: "alice", Username: "alice", UsernameLower: "alice",
+		IsLocked: locked, AvatarDecorations: datatypes.JSON([]byte("[]"))}
+	fSvc := h.followingService
+	// alice follows user1 → alice が表示される follower。
+	_, err := fSvc.Follow("alice", "user1", corefollowing.FollowOptions{})
+	require.NoError(t, err)
+	// viewer(bob) が alice (locked) に follow request 送信中 →
+	// alice.hasPendingFollowRequestFromYou=true 期待。
+	_, err = fSvc.Follow("bob", "alice", corefollowing.FollowOptions{})
+	require.NoError(t, err) // locked なので pending request になる
+
+	rec := postStub(h.Followers, `{"userId":"user1"}`, repo.Users["bob"])
+	require.Equal(t, http.StatusOK, rec.Code)
+	var out []map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &out))
+	require.Len(t, out, 1)
+	follower, ok := out[0]["follower"].(map[string]any)
+	require.True(t, ok)
+	assert.Equal(t, true, follower["hasPendingFollowRequestFromYou"],
+		"viewer(bob) → alice (locked) に pending request → fromYou=true")
+	assert.Equal(t, false, follower["hasPendingFollowRequestToYou"])
 }
 
 // TestFollowing_PopulatesIsFollowedFromViewer covers the symmetric case

--- a/internal/repository/follow_request.go
+++ b/internal/repository/follow_request.go
@@ -11,6 +11,16 @@ type FollowRequestRepository interface {
 	Delete(r *model.FollowRequest) error
 	FindByPair(followerID, followeeID string) (*model.FollowRequest, error)
 	Exists(followerID, followeeID string) (bool, error)
+	// FilterPendingFromAnchor returns the subset of candidateIDs that have
+	// a pending follow request initiated by anchorID (anchor → candidate
+	// direction). Used to batch-compute `hasPendingFollowRequestFromYou`
+	// across a user list (#1144).
+	FilterPendingFromAnchor(anchorID string, candidateIDs []string) ([]string, error)
+	// FilterPendingToAnchor returns the subset of candidateIDs that have
+	// a pending follow request targeting anchorID (candidate → anchor
+	// direction). Used to batch-compute `hasPendingFollowRequestToYou`
+	// across a user list (#1144).
+	FilterPendingToAnchor(anchorID string, candidateIDs []string) ([]string, error)
 	// ListReceived returns follow requests where userID is the followee.
 	// sinceID / untilID はMisskey本家の pagination cursor。空文字で無指定扱い。
 	ListReceived(userID string, limit int, sinceID, untilID string) ([]*model.FollowRequest, error)
@@ -54,6 +64,32 @@ func (r *followRequestRepository) Exists(followerID, followeeID string) (bool, e
 		return false, err
 	}
 	return count > 0, nil
+}
+
+func (r *followRequestRepository) FilterPendingFromAnchor(anchorID string, candidateIDs []string) ([]string, error) {
+	if anchorID == "" || len(candidateIDs) == 0 {
+		return nil, nil
+	}
+	var ids []string
+	if err := r.db.Model(&model.FollowRequest{}).
+		Where(`"followerId" = ? AND "followeeId" IN ?`, anchorID, candidateIDs).
+		Pluck(`"followeeId"`, &ids).Error; err != nil {
+		return nil, err
+	}
+	return ids, nil
+}
+
+func (r *followRequestRepository) FilterPendingToAnchor(anchorID string, candidateIDs []string) ([]string, error) {
+	if anchorID == "" || len(candidateIDs) == 0 {
+		return nil, nil
+	}
+	var ids []string
+	if err := r.db.Model(&model.FollowRequest{}).
+		Where(`"followerId" IN ? AND "followeeId" = ?`, candidateIDs, anchorID).
+		Pluck(`"followerId"`, &ids).Error; err != nil {
+		return nil, err
+	}
+	return ids, nil
 }
 
 func (r *followRequestRepository) ListReceived(userID string, limit int, sinceID, untilID string) ([]*model.FollowRequest, error) {

--- a/internal/repository/follow_request_test.go
+++ b/internal/repository/follow_request_test.go
@@ -65,6 +65,71 @@ func TestFollowRequestRepository_Exists(t *testing.T) {
 	assert.True(t, exists)
 }
 
+// TestFollowRequestRepository_FilterPendingFromAnchor + ToAnchor cover the
+// batch lookup added for users/{followers,following} pending request flag
+// population (#1144 #2、MkFollowButton の `hasPendingFollowRequestFromYou`
+// 表示分岐に必要)。
+func TestFollowRequestRepository_FilterPendingFromAnchor(t *testing.T) {
+	repo := NewFollowRequestRepository(testDB)
+	anchor := insertTestUser(t, "u_pf_a", "anchorpf")
+	defer cleanupUser(t, anchor.ID)
+	t1 := insertTestUser(t, "u_pf_t1", "targetpf1")
+	defer cleanupUser(t, t1.ID)
+	t2 := insertTestUser(t, "u_pf_t2", "targetpf2")
+	defer cleanupUser(t, t2.ID)
+
+	insertFollowRequest(t, "pf_1", anchor.ID, t1.ID)
+	defer testDB.Exec(`DELETE FROM "follow_request" WHERE id = ?`, "pf_1")
+
+	out, err := repo.FilterPendingFromAnchor("", []string{t1.ID})
+	require.NoError(t, err)
+	assert.Nil(t, out)
+	out, err = repo.FilterPendingFromAnchor(anchor.ID, nil)
+	require.NoError(t, err)
+	assert.Nil(t, out)
+
+	out, err = repo.FilterPendingFromAnchor(anchor.ID, []string{t1.ID, t2.ID, "ghost"})
+	require.NoError(t, err)
+	assert.ElementsMatch(t, []string{t1.ID}, out)
+}
+
+func TestFollowRequestRepository_FilterPendingToAnchor(t *testing.T) {
+	repo := NewFollowRequestRepository(testDB)
+	anchor := insertTestUser(t, "u_pt_a", "anchorpt")
+	defer cleanupUser(t, anchor.ID)
+	c1 := insertTestUser(t, "u_pt_c1", "candpt1")
+	defer cleanupUser(t, c1.ID)
+	c2 := insertTestUser(t, "u_pt_c2", "candpt2")
+	defer cleanupUser(t, c2.ID)
+
+	insertFollowRequest(t, "pt_1", c1.ID, anchor.ID)
+	defer testDB.Exec(`DELETE FROM "follow_request" WHERE id = ?`, "pt_1")
+
+	out, err := repo.FilterPendingToAnchor("", []string{c1.ID})
+	require.NoError(t, err)
+	assert.Nil(t, out)
+	out, err = repo.FilterPendingToAnchor(anchor.ID, nil)
+	require.NoError(t, err)
+	assert.Nil(t, out)
+
+	out, err = repo.FilterPendingToAnchor(anchor.ID, []string{c1.ID, c2.ID, "ghost"})
+	require.NoError(t, err)
+	assert.ElementsMatch(t, []string{c1.ID}, out)
+}
+
+// TestFollowRequestRepository_FilterPending_QueryError covers the DB error
+// branch of both Filter helpers (cancelled ctx).
+func TestFollowRequestRepository_FilterPending_QueryError(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	db := testDB.WithContext(ctx)
+	repo := NewFollowRequestRepository(db)
+	_, err := repo.FilterPendingFromAnchor("u", []string{"v"})
+	assert.Error(t, err)
+	_, err = repo.FilterPendingToAnchor("u", []string{"v"})
+	assert.Error(t, err)
+}
+
 func TestFollowRequestRepository_Delete(t *testing.T) {
 	repo := NewFollowRequestRepository(testDB)
 	follower := insertTestUser(t, "u_fr_5", "frfollower5")

--- a/internal/repository/following.go
+++ b/internal/repository/following.go
@@ -11,6 +11,15 @@ type FollowingRepository interface {
 	Delete(f *model.Following) error
 	FindByPair(followerID, followeeID string) (*model.Following, error)
 	Exists(followerID, followeeID string) (bool, error)
+	// FilterFollowing returns the subset of candidateIDs that anchorID
+	// follows (= rows where followerId=anchorID AND followeeId IN candidates).
+	// Used to batch-compute `isFollowing` across a user list (e.g.
+	// users/following / users/followers) without N+1 Exists round-trips (#1144).
+	FilterFollowing(anchorID string, candidateIDs []string) ([]string, error)
+	// FilterFollowedBy returns the subset of candidateIDs that follow
+	// anchorID (= rows where followerId IN candidates AND followeeId=anchorID).
+	// Used to batch-compute `isFollowed` across a user list (#1144).
+	FilterFollowedBy(anchorID string, candidateIDs []string) ([]string, error)
 	ListFollowers(userID string, limit, offset int) ([]*model.Following, error)
 	ListFollowing(userID string, limit, offset int) ([]*model.Following, error)
 	// ListFollowersByHost returns Following rows whose followerHost matches
@@ -75,6 +84,32 @@ func (r *followingRepository) Exists(followerID, followeeID string) (bool, error
 		return false, err
 	}
 	return count > 0, nil
+}
+
+func (r *followingRepository) FilterFollowing(anchorID string, candidateIDs []string) ([]string, error) {
+	if anchorID == "" || len(candidateIDs) == 0 {
+		return nil, nil
+	}
+	var ids []string
+	if err := r.db.Model(&model.Following{}).
+		Where(`"followerId" = ? AND "followeeId" IN ?`, anchorID, candidateIDs).
+		Pluck(`"followeeId"`, &ids).Error; err != nil {
+		return nil, err
+	}
+	return ids, nil
+}
+
+func (r *followingRepository) FilterFollowedBy(anchorID string, candidateIDs []string) ([]string, error) {
+	if anchorID == "" || len(candidateIDs) == 0 {
+		return nil, nil
+	}
+	var ids []string
+	if err := r.db.Model(&model.Following{}).
+		Where(`"followerId" IN ? AND "followeeId" = ?`, candidateIDs, anchorID).
+		Pluck(`"followerId"`, &ids).Error; err != nil {
+		return nil, err
+	}
+	return ids, nil
 }
 
 func (r *followingRepository) ListFollowers(userID string, limit, offset int) ([]*model.Following, error) {

--- a/internal/repository/following.go
+++ b/internal/repository/following.go
@@ -11,15 +11,17 @@ type FollowingRepository interface {
 	Delete(f *model.Following) error
 	FindByPair(followerID, followeeID string) (*model.Following, error)
 	Exists(followerID, followeeID string) (bool, error)
-	// FilterFollowing returns the subset of candidateIDs that anchorID
-	// follows (= rows where followerId=anchorID AND followeeId IN candidates).
-	// Used to batch-compute `isFollowing` across a user list (e.g.
-	// users/following / users/followers) without N+1 Exists round-trips (#1144).
-	FilterFollowing(anchorID string, candidateIDs []string) ([]string, error)
-	// FilterFollowedBy returns the subset of candidateIDs that follow
-	// anchorID (= rows where followerId IN candidates AND followeeId=anchorID).
-	// Used to batch-compute `isFollowed` across a user list (#1144).
-	FilterFollowedBy(anchorID string, candidateIDs []string) ([]string, error)
+	// FilterFollowingsFromAnchor returns the subset of candidateIDs that
+	// anchorID follows (anchor → candidate direction, = rows where
+	// followerId=anchorID AND followeeId IN candidates). Used to batch-
+	// compute `isFollowing` across a user list (e.g. users/following /
+	// users/followers) without N+1 Exists round-trips (#1144).
+	FilterFollowingsFromAnchor(anchorID string, candidateIDs []string) ([]string, error)
+	// FilterFollowingsToAnchor returns the subset of candidateIDs that
+	// follow anchorID (candidate → anchor direction, = rows where
+	// followerId IN candidates AND followeeId=anchorID). Used to batch-
+	// compute `isFollowed` across a user list (#1144).
+	FilterFollowingsToAnchor(anchorID string, candidateIDs []string) ([]string, error)
 	ListFollowers(userID string, limit, offset int) ([]*model.Following, error)
 	ListFollowing(userID string, limit, offset int) ([]*model.Following, error)
 	// ListFollowersByHost returns Following rows whose followerHost matches
@@ -86,7 +88,7 @@ func (r *followingRepository) Exists(followerID, followeeID string) (bool, error
 	return count > 0, nil
 }
 
-func (r *followingRepository) FilterFollowing(anchorID string, candidateIDs []string) ([]string, error) {
+func (r *followingRepository) FilterFollowingsFromAnchor(anchorID string, candidateIDs []string) ([]string, error) {
 	if anchorID == "" || len(candidateIDs) == 0 {
 		return nil, nil
 	}
@@ -99,7 +101,7 @@ func (r *followingRepository) FilterFollowing(anchorID string, candidateIDs []st
 	return ids, nil
 }
 
-func (r *followingRepository) FilterFollowedBy(anchorID string, candidateIDs []string) ([]string, error) {
+func (r *followingRepository) FilterFollowingsToAnchor(anchorID string, candidateIDs []string) ([]string, error) {
 	if anchorID == "" || len(candidateIDs) == 0 {
 		return nil, nil
 	}

--- a/internal/repository/following_test.go
+++ b/internal/repository/following_test.go
@@ -66,6 +66,74 @@ func TestFollowingRepository_Exists(t *testing.T) {
 	assert.True(t, exists)
 }
 
+// TestFollowingRepository_FilterFollowingsFromAnchor + ToAnchor cover the
+// batch lookup added for users/{followers,following} relation flag
+// population (#1144). 空 input は短絡で nil 返却、通常 input は anchor が
+// follow している (or anchor を follow している) candidate のみ返る。
+// cancelled ctx の error path も別 test で cover。
+func TestFollowingRepository_FilterFollowingsFromAnchor(t *testing.T) {
+	repo := NewFollowingRepository(testDB)
+	anchor := insertTestUser(t, "u_ff_a", "anchorff")
+	defer cleanupUser(t, anchor.ID)
+	t1 := insertTestUser(t, "u_ff_t1", "targetff1")
+	defer cleanupUser(t, t1.ID)
+	t2 := insertTestUser(t, "u_ff_t2", "targetff2")
+	defer cleanupUser(t, t2.ID)
+
+	insertFollowing(t, "ff_1", anchor.ID, t1.ID)
+	defer testDB.Exec(`DELETE FROM "following" WHERE id = ?`, "ff_1")
+
+	// 空入力は repo を叩かずに nil 返却。
+	out, err := repo.FilterFollowingsFromAnchor("", []string{t1.ID})
+	require.NoError(t, err)
+	assert.Nil(t, out)
+	out, err = repo.FilterFollowingsFromAnchor(anchor.ID, nil)
+	require.NoError(t, err)
+	assert.Nil(t, out)
+
+	// 通常入力: anchor は t1 のみ follow → t1 だけ返る (t2 は除外、ghost も miss)。
+	out, err = repo.FilterFollowingsFromAnchor(anchor.ID, []string{t1.ID, t2.ID, "ghost"})
+	require.NoError(t, err)
+	assert.ElementsMatch(t, []string{t1.ID}, out)
+}
+
+func TestFollowingRepository_FilterFollowingsToAnchor(t *testing.T) {
+	repo := NewFollowingRepository(testDB)
+	anchor := insertTestUser(t, "u_ft_a", "anchorft")
+	defer cleanupUser(t, anchor.ID)
+	c1 := insertTestUser(t, "u_ft_c1", "candft1")
+	defer cleanupUser(t, c1.ID)
+	c2 := insertTestUser(t, "u_ft_c2", "candft2")
+	defer cleanupUser(t, c2.ID)
+
+	insertFollowing(t, "ft_1", c1.ID, anchor.ID)
+	defer testDB.Exec(`DELETE FROM "following" WHERE id = ?`, "ft_1")
+
+	out, err := repo.FilterFollowingsToAnchor("", []string{c1.ID})
+	require.NoError(t, err)
+	assert.Nil(t, out)
+	out, err = repo.FilterFollowingsToAnchor(anchor.ID, nil)
+	require.NoError(t, err)
+	assert.Nil(t, out)
+
+	out, err = repo.FilterFollowingsToAnchor(anchor.ID, []string{c1.ID, c2.ID, "ghost"})
+	require.NoError(t, err)
+	assert.ElementsMatch(t, []string{c1.ID}, out)
+}
+
+// TestFollowingRepository_FilterFollowings_QueryError covers the DB error
+// branch of both Filter helpers (cancelled ctx → driver error → bubble up).
+func TestFollowingRepository_FilterFollowings_QueryError(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	db := testDB.WithContext(ctx)
+	repo := NewFollowingRepository(db)
+	_, err := repo.FilterFollowingsFromAnchor("u", []string{"v"})
+	assert.Error(t, err)
+	_, err = repo.FilterFollowingsToAnchor("u", []string{"v"})
+	assert.Error(t, err)
+}
+
 func TestFollowingRepository_Delete(t *testing.T) {
 	repo := NewFollowingRepository(testDB)
 	follower := insertTestUser(t, "u_fl_5", "follower5")

--- a/internal/testutil/mock_repository.go
+++ b/internal/testutil/mock_repository.go
@@ -4212,6 +4212,46 @@ func (m *MockFollowingRepository) Exists(followerID, followeeID string) (bool, e
 	return true, nil
 }
 
+func (m *MockFollowingRepository) FilterFollowing(anchorID string, candidateIDs []string) ([]string, error) {
+	if anchorID == "" || len(candidateIDs) == 0 {
+		return nil, nil
+	}
+	candidates := make(map[string]struct{}, len(candidateIDs))
+	for _, id := range candidateIDs {
+		candidates[id] = struct{}{}
+	}
+	var ids []string
+	for _, f := range m.Followings {
+		if f.FollowerID != anchorID {
+			continue
+		}
+		if _, ok := candidates[f.FolloweeID]; ok {
+			ids = append(ids, f.FolloweeID)
+		}
+	}
+	return ids, nil
+}
+
+func (m *MockFollowingRepository) FilterFollowedBy(anchorID string, candidateIDs []string) ([]string, error) {
+	if anchorID == "" || len(candidateIDs) == 0 {
+		return nil, nil
+	}
+	candidates := make(map[string]struct{}, len(candidateIDs))
+	for _, id := range candidateIDs {
+		candidates[id] = struct{}{}
+	}
+	var ids []string
+	for _, f := range m.Followings {
+		if f.FolloweeID != anchorID {
+			continue
+		}
+		if _, ok := candidates[f.FollowerID]; ok {
+			ids = append(ids, f.FollowerID)
+		}
+	}
+	return ids, nil
+}
+
 func (m *MockFollowingRepository) ListFollowers(userID string, limit, offset int) ([]*model.Following, error) {
 	var rows []*model.Following
 	for _, f := range m.Followings {

--- a/internal/testutil/mock_repository.go
+++ b/internal/testutil/mock_repository.go
@@ -4212,7 +4212,7 @@ func (m *MockFollowingRepository) Exists(followerID, followeeID string) (bool, e
 	return true, nil
 }
 
-func (m *MockFollowingRepository) FilterFollowing(anchorID string, candidateIDs []string) ([]string, error) {
+func (m *MockFollowingRepository) FilterFollowingsFromAnchor(anchorID string, candidateIDs []string) ([]string, error) {
 	if anchorID == "" || len(candidateIDs) == 0 {
 		return nil, nil
 	}
@@ -4232,7 +4232,7 @@ func (m *MockFollowingRepository) FilterFollowing(anchorID string, candidateIDs 
 	return ids, nil
 }
 
-func (m *MockFollowingRepository) FilterFollowedBy(anchorID string, candidateIDs []string) ([]string, error) {
+func (m *MockFollowingRepository) FilterFollowingsToAnchor(anchorID string, candidateIDs []string) ([]string, error) {
 	if anchorID == "" || len(candidateIDs) == 0 {
 		return nil, nil
 	}
@@ -4404,6 +4404,46 @@ func (m *MockFollowRequestRepository) Exists(followerID, followeeID string) (boo
 		return false, nil
 	}
 	return true, nil
+}
+
+func (m *MockFollowRequestRepository) FilterPendingFromAnchor(anchorID string, candidateIDs []string) ([]string, error) {
+	if anchorID == "" || len(candidateIDs) == 0 {
+		return nil, nil
+	}
+	candidates := make(map[string]struct{}, len(candidateIDs))
+	for _, id := range candidateIDs {
+		candidates[id] = struct{}{}
+	}
+	var ids []string
+	for _, r := range m.Requests {
+		if r.FollowerID != anchorID {
+			continue
+		}
+		if _, ok := candidates[r.FolloweeID]; ok {
+			ids = append(ids, r.FolloweeID)
+		}
+	}
+	return ids, nil
+}
+
+func (m *MockFollowRequestRepository) FilterPendingToAnchor(anchorID string, candidateIDs []string) ([]string, error) {
+	if anchorID == "" || len(candidateIDs) == 0 {
+		return nil, nil
+	}
+	candidates := make(map[string]struct{}, len(candidateIDs))
+	for _, id := range candidateIDs {
+		candidates[id] = struct{}{}
+	}
+	var ids []string
+	for _, r := range m.Requests {
+		if r.FolloweeID != anchorID {
+			continue
+		}
+		if _, ok := candidates[r.FollowerID]; ok {
+			ids = append(ids, r.FollowerID)
+		}
+	}
+	return ids, nil
 }
 
 func (m *MockFollowRequestRepository) ListReceived(userID string, limit int, sinceID, untilID string) ([]*model.FollowRequest, error) {


### PR DESCRIPTION
## Summary

プロフィールのフォロー/フォロワー一覧で「**フォローされています**」(`followsYou`) ラベルが表示されない drop-in regression を fix (テストユーザー報告経路)。

`packRelationItems` (= `/api/users/followers` + `/api/users/following` の response builder) が embed する `follower` / `followee` UserDetailed に **viewer 視点の relation flag (`isFollowing` / `isFollowed`) を一切埋めていなかった**。frontend `MkUserInfo.vue:16` は `user.isFollowed` を見て label を出すので、常に undefined では label 出ず。

upstream `FollowingEntityService.pack` は `userEntityService.pack(..., me, { schema: 'UserDetailedNotMe' })` で viewer 視点の relation flag を含む UserDetailed を返している。mk-go を同等にする。

## 主な変更点

| File | 変更 |
|---|---|
| `internal/repository/following.go` | `FilterFollowing(anchorID, candidateIDs)` / `FilterFollowedBy(anchorID, candidateIDs)` batch lookup 追加 (`IN`-query 1 round-trip) |
| `internal/testutil/mock_repository.go` | mock も同 method 追加 (interface 同期) |
| `internal/api/users/handler.go` | `listRelations` → `collectFollowers/Following` → `packRelationItems` の signature に viewer を通す。`batchFollowRelations` helper を新設し、viewer 非 nil 時に 2 batch query で relation map 構築、user 毎の embed で `IsFollowing` / `IsFollowed` 設定 |
| `internal/api/users/handler_test.go` | `newTestHandler` で `h.SetFollowingRepo(fRepo)` 配線 + regression guard 2 件追加 |

### 設計

- **batch lookup 戦略**: per-row `Exists()` を呼ぶと N+1 になるため、ユニーク target id set を取得後 2 batch query (= 1 query for isFollowing + 1 query for isFollowed) で解決。20 user list なら 2 query 固定
- **viewer 自身の row は skip**: `viewer.ID == target.ID` の場合 relation flag は意味無いので埋めない (= upstream の `UserDetailedNotMe` schema が viewer 自身を含まない semantics と整合)
- **fail-soft**: `FilterFollowing/FilterFollowedBy` の error は silent (= 部分結果でも shape を保つ)、production では router で必ず repo wire 済

## Drop-in 互換

- API URL / response shape 完全保持、relation flag が **追加される方向のみ**
- 旧来 undefined だった `isFollowing` / `isFollowed` が viewer 認証時に正しい値で埋まる
- 他 endpoint (`/api/users/show`) と同等の relation flag が list 経路でも使える → frontend で N+1 self-fetch (`MkFollowButton` initial state) も解消

## テスト

### 追加 regression guard (2 件)

- `TestFollowers_PopulatesIsFollowedFromViewer` — alice が viewer(bob) を follow → `follower.isFollowed=true`、bob は alice 未 follow → `isFollowing=false`
- `TestFollowing_PopulatesIsFollowedFromViewer` — viewer(bob) が charlie を follow → `followee.isFollowing=true`、charlie は bob 未 follow → `isFollowed=false`

### 実行

```bash
go test ./internal/api/users/ -run "TestFollowers|TestFollowing"
make fmt && make lint && make test
```

## Closes

Closes #1144