### PR TITLE
Fix: users/{followers,following} の embed user に RemoteStatsFetcher 適用

### DIFF
--- a/internal/api/users/handler.go
+++ b/internal/api/users/handler.go
@@ -600,9 +600,9 @@ func (h *Handler) listRelations(c echo.Context, followers bool) error {
 		err  error
 	)
 	if followers {
-		rows, err = h.collectFollowers(req, viewer)
+		rows, err = h.collectFollowers(c.Request().Context(), req, viewer)
 	} else {
-		rows, err = h.collectFollowing(req, viewer)
+		rows, err = h.collectFollowing(c.Request().Context(), req, viewer)
 	}
 	if err != nil {
 		return apierr.JSONInternalError(c)
@@ -620,20 +620,20 @@ type relationItem struct {
 	Followee   *entity.UserDetailed `json:"followee,omitempty"`
 }
 
-func (h *Handler) collectFollowers(req FollowersRequest, viewer *model.User) ([]relationItem, error) {
+func (h *Handler) collectFollowers(ctx context.Context, req FollowersRequest, viewer *model.User) ([]relationItem, error) {
 	rows, err := h.followingService.ListReceivedFollowing(req.UserID, req.Limit, req.Offset)
 	if err != nil {
 		return nil, err
 	}
-	return h.packRelationItems(rows, req, true, viewer), nil
+	return h.packRelationItems(ctx, rows, req, true, viewer), nil
 }
 
-func (h *Handler) collectFollowing(req FollowersRequest, viewer *model.User) ([]relationItem, error) {
+func (h *Handler) collectFollowing(ctx context.Context, req FollowersRequest, viewer *model.User) ([]relationItem, error) {
 	rows, err := h.followingService.ListSentFollowing(req.UserID, req.Limit, req.Offset)
 	if err != nil {
 		return nil, err
 	}
-	return h.packRelationItems(rows, req, false, viewer), nil
+	return h.packRelationItems(ctx, rows, req, false, viewer), nil
 }
 
 // packRelationItems builds the response slice for users/followers and
@@ -650,6 +650,7 @@ func (h *Handler) collectFollowing(req FollowersRequest, viewer *model.User) ([]
 // と list 内 user の id 一致時は relation lookup を skip する (= self-flag
 // は意味なし)。
 func (h *Handler) packRelationItems(
+	ctx context.Context,
 	rows []*model.Following,
 	req FollowersRequest,
 	followers bool,
@@ -706,6 +707,12 @@ func (h *Handler) packRelationItems(
 	// になる。upstream UserDetailedNotMe schema と整合させる。
 	pendingFromMap, pendingToMap := h.batchPendingRequestRelations(viewer, bundleByID)
 
+	// remote user の notes/followers/following count を origin instance の
+	// /api/users/show から fetch して上書き (#1146)。Show 経路 (handler.go:329)
+	// と同 logic だが、本 list 経路では N 件並列 fetch で N round-trip を回避
+	// する (singleflight が同 key dedup、cache 1h で次 scroll は HTTP 0)。
+	remoteStatsMap := h.batchRemoteStatsOverride(ctx, bundleByID)
+
 	out := make([]relationItem, 0, len(filtered))
 	for _, f := range filtered {
 		item := relationItem{ID: f.ID, FollowerID: f.FollowerID, FolloweeID: f.FolloweeID}
@@ -728,6 +735,11 @@ func (h *Handler) packRelationItems(
 				pendingTo := pendingToMap[b.User.ID]
 				d.HasPendingFollowRequestFromYou = &pendingFrom
 				d.HasPendingFollowRequestToYou = &pendingTo
+			}
+			if stats := remoteStatsMap[b.User.ID]; stats != nil {
+				d.NotesCount = stats.NotesCount
+				d.FollowersCount = stats.FollowersCount
+				d.FollowingCount = stats.FollowingCount
 			}
 			if followers {
 				item.Follower = &d
@@ -796,6 +808,54 @@ func (h *Handler) batchPendingRequestRelations(viewer *model.User, bundleByID ma
 		}
 	}
 	return fromMap, toMap
+}
+
+// batchRemoteStatsOverride fans out RemoteStatsFetcher.Fetch goroutines for
+// every remote user in bundleByID and returns the resulting stats keyed by
+// user ID. Local users (host == nil) are skipped. fetcher が未配線 / list
+// に remote user 0 件なら nil を返して caller が override loop を skip できる
+// (#1146)。
+//
+// 並列化の妥当性: 各 Fetch は HTTP I/O bound (~500ms RTT) で CPU は遊んで
+// いるので、20-100 件並列でも runtime コストは無視可能。同じ (host, username)
+// に対する concurrent call は fetcher 内部の singleflight.Group で 1 HTTP に
+// dedup される。ctx は request context を伝播するので client abort で全
+// goroutine が cancel される。
+func (h *Handler) batchRemoteStatsOverride(ctx context.Context, bundleByID map[string]*user.UserWithProfile) map[string]*RemoteUserStatsView {
+	if h.remoteStatsFetcher == nil || len(bundleByID) == 0 {
+		return nil
+	}
+	type job struct {
+		userID, host, username string
+	}
+	jobs := make([]job, 0, len(bundleByID))
+	for id, b := range bundleByID {
+		if b.User.Host == nil || *b.User.Host == "" {
+			continue
+		}
+		jobs = append(jobs, job{userID: id, host: *b.User.Host, username: b.User.Username})
+	}
+	if len(jobs) == 0 {
+		return nil
+	}
+	out := make(map[string]*RemoteUserStatsView, len(jobs))
+	var mu sync.Mutex
+	var wg sync.WaitGroup
+	wg.Add(len(jobs))
+	for _, j := range jobs {
+		go func(j job) {
+			defer wg.Done()
+			stats := h.remoteStatsFetcher.Fetch(ctx, j.host, j.username)
+			if stats == nil {
+				return
+			}
+			mu.Lock()
+			out[j.userID] = stats
+			mu.Unlock()
+		}(j)
+	}
+	wg.Wait()
+	return out
 }
 
 // buildRelationCandidates returns the candidate user IDs for viewer-relative

--- a/internal/api/users/handler.go
+++ b/internal/api/users/handler.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"net/http"
 	"sync"
+	"time"
 
 	"github.com/labstack/echo/v4"
 	"github.com/shiroha-a/mk/internal/api/apierr"
@@ -810,6 +811,15 @@ func (h *Handler) batchPendingRequestRelations(viewer *model.User, bundleByID ma
 	return fromMap, toMap
 }
 
+// remoteStatsBatchTimeout caps the wall-clock time the list response will
+// wait for remote `/api/users/show` Fetches. fetcher が独自の HTTP timeout
+// (= safehttp 経由で 10-30s) を持つが、複数 remote host のうち 1 host が
+// 遅い場合に list 全体の tail latency が悪化する。本 timeout でその上限を
+// 5s に縮め、slow host があれば silent fallback (local count) を維持する
+// (#1146 #1)。値は典型 list (limit=20) の cold cache 想定で「20 host の
+// HTTPS RTT が並列で 5s 以内に揃う」前提。
+const remoteStatsBatchTimeout = 5 * time.Second
+
 // batchRemoteStatsOverride fans out RemoteStatsFetcher.Fetch goroutines for
 // every remote user in bundleByID and returns the resulting stats keyed by
 // user ID. Local users (host == nil) are skipped. fetcher が未配線 / list
@@ -819,8 +829,12 @@ func (h *Handler) batchPendingRequestRelations(viewer *model.User, bundleByID ma
 // 並列化の妥当性: 各 Fetch は HTTP I/O bound (~500ms RTT) で CPU は遊んで
 // いるので、20-100 件並列でも runtime コストは無視可能。同じ (host, username)
 // に対する concurrent call は fetcher 内部の singleflight.Group で 1 HTTP に
-// dedup される。ctx は request context を伝播するので client abort で全
-// goroutine が cancel される。
+// dedup される。
+//
+// ctx propagation: 上位 request ctx に `remoteStatsBatchTimeout` の deadline
+// を被せた派生 ctx を全 goroutine に渡し、deadline 超過 / client abort
+// どちらでも fetcher 内部の HTTP client が ctx cancel を受けて即時 return
+// する (= 取りこぼした user は silent fallback で local count 維持)。
 func (h *Handler) batchRemoteStatsOverride(ctx context.Context, bundleByID map[string]*user.UserWithProfile) map[string]*RemoteUserStatsView {
 	if h.remoteStatsFetcher == nil || len(bundleByID) == 0 {
 		return nil
@@ -838,6 +852,8 @@ func (h *Handler) batchRemoteStatsOverride(ctx context.Context, bundleByID map[s
 	if len(jobs) == 0 {
 		return nil
 	}
+	fetchCtx, cancel := context.WithTimeout(ctx, remoteStatsBatchTimeout)
+	defer cancel()
 	out := make(map[string]*RemoteUserStatsView, len(jobs))
 	var mu sync.Mutex
 	var wg sync.WaitGroup
@@ -845,7 +861,7 @@ func (h *Handler) batchRemoteStatsOverride(ctx context.Context, bundleByID map[s
 	for _, j := range jobs {
 		go func(j job) {
 			defer wg.Done()
-			stats := h.remoteStatsFetcher.Fetch(ctx, j.host, j.username)
+			stats := h.remoteStatsFetcher.Fetch(fetchCtx, j.host, j.username)
 			if stats == nil {
 				return
 			}

--- a/internal/api/users/handler_test.go
+++ b/internal/api/users/handler_test.go
@@ -1001,6 +1001,86 @@ func TestFollowers_PopulatesPendingFollowRequest(t *testing.T) {
 	assert.Equal(t, false, follower["hasPendingFollowRequestToYou"])
 }
 
+// fakeRemoteStatsFetcher is a stub for users.RemoteStatsFetcher returning
+// canned stats per (host, username) pair. Used by remote stats override
+// regression tests (#1146).
+type fakeRemoteStatsFetcher struct {
+	stats map[string]*RemoteUserStatsView // key = host + "|" + username
+	calls int
+}
+
+func (f *fakeRemoteStatsFetcher) Fetch(_ context.Context, host, username string) *RemoteUserStatsView {
+	f.calls++
+	return f.stats[host+"|"+username]
+}
+
+// TestFollowers_AppliesRemoteStatsOverride guards #1146: remote user の
+// notesCount / followersCount / followingCount は origin instance の
+// /api/users/show から取得した値で上書きされる (RemoteStatsFetcher 経由)。
+// 旧来は Show 経路だけで適用されていて、list 経路 (followers/following) では
+// ローカル観測値のままだった。
+func TestFollowers_AppliesRemoteStatsOverride(t *testing.T) {
+	h, repo := newTestHandler(t)
+	addTestUser(repo) // user1 = local target profile
+	remoteHost := "remote.example"
+	repo.Users["remote-alice"] = &model.User{
+		ID:                "remote-alice",
+		Username:          "alice",
+		UsernameLower:     "alice",
+		Host:              &remoteHost,
+		NotesCount:        5,  // ローカル観測値 (= 古い)
+		FollowersCount:    10, // ローカル観測値
+		FollowingCount:    3,  // ローカル観測値
+		AvatarDecorations: datatypes.JSON([]byte("[]")),
+	}
+	// remote-alice が user1 を follow → list に出る。
+	fSvc := h.followingService
+	_, err := fSvc.Follow("remote-alice", "user1", corefollowing.FollowOptions{})
+	require.NoError(t, err)
+	// fetcher は remote-alice に対して大きい本物の値を返す。
+	h.SetRemoteStatsFetcher(&fakeRemoteStatsFetcher{
+		stats: map[string]*RemoteUserStatsView{
+			"remote.example|alice": {NotesCount: 500, FollowersCount: 1000, FollowingCount: 250},
+		},
+	})
+
+	rec := post(h.Followers, `{"userId":"user1"}`)
+	require.Equal(t, http.StatusOK, rec.Code)
+	var out []map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &out))
+	require.Len(t, out, 1)
+	follower, ok := out[0]["follower"].(map[string]any)
+	require.True(t, ok)
+	// 上書き後の remote 実値が反映されていることを assert (= 旧 5/10/3 では
+	// なく 500/1000/250)。
+	assert.Equal(t, float64(500), follower["notesCount"])
+	assert.Equal(t, float64(1000), follower["followersCount"])
+	assert.Equal(t, float64(250), follower["followingCount"])
+}
+
+// TestFollowers_RemoteStatsOverride_SkipsLocalUser: local user (Host==nil) は
+// fetcher 経路を skip し、ローカル観測値をそのまま使う。HTTP request 削減。
+func TestFollowers_RemoteStatsOverride_SkipsLocalUser(t *testing.T) {
+	h, repo := newTestHandler(t)
+	addTestUser(repo) // user1 = local target
+	repo.Users["local-bob"] = &model.User{
+		ID:                "local-bob",
+		Username:          "bob",
+		UsernameLower:     "bob",
+		NotesCount:        42,
+		AvatarDecorations: datatypes.JSON([]byte("[]")),
+	}
+	fSvc := h.followingService
+	_, err := fSvc.Follow("local-bob", "user1", corefollowing.FollowOptions{})
+	require.NoError(t, err)
+	fetcher := &fakeRemoteStatsFetcher{stats: map[string]*RemoteUserStatsView{}}
+	h.SetRemoteStatsFetcher(fetcher)
+
+	rec := post(h.Followers, `{"userId":"user1"}`)
+	require.Equal(t, http.StatusOK, rec.Code)
+	assert.Equal(t, 0, fetcher.calls, "local user (Host==nil) は fetcher を呼ばない")
+}
+
 // TestFollowing_PopulatesIsFollowedFromViewer covers the symmetric case
 // for /api/users/following — each `followee` UserDetailed gets viewer's
 // relation flags.

--- a/internal/api/users/handler_test.go
+++ b/internal/api/users/handler_test.go
@@ -1058,6 +1058,83 @@ func TestFollowers_AppliesRemoteStatsOverride(t *testing.T) {
 	assert.Equal(t, float64(250), follower["followingCount"])
 }
 
+// TestFollowing_AppliesRemoteStatsOverride covers the symmetric path for
+// /api/users/following — same helper is used so symmetry is expected, but
+// explicit regression guard against prefix routing or pack-side regressions.
+func TestFollowing_AppliesRemoteStatsOverride(t *testing.T) {
+	h, repo := newTestHandler(t)
+	addTestUser(repo) // user1 = local target profile
+	remoteHost := "remote.example"
+	repo.Users["remote-charlie"] = &model.User{
+		ID:                "remote-charlie",
+		Username:          "charlie",
+		UsernameLower:     "charlie",
+		Host:              &remoteHost,
+		NotesCount:        1,
+		FollowersCount:    2,
+		FollowingCount:    3,
+		AvatarDecorations: datatypes.JSON([]byte("[]")),
+	}
+	fSvc := h.followingService
+	// user1 follows charlie → charlie が followee として list される。
+	_, err := fSvc.Follow("user1", "remote-charlie", corefollowing.FollowOptions{})
+	require.NoError(t, err)
+	h.SetRemoteStatsFetcher(&fakeRemoteStatsFetcher{
+		stats: map[string]*RemoteUserStatsView{
+			"remote.example|charlie": {NotesCount: 9000, FollowersCount: 8000, FollowingCount: 7000},
+		},
+	})
+
+	rec := post(h.Following, `{"userId":"user1"}`)
+	require.Equal(t, http.StatusOK, rec.Code)
+	var out []map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &out))
+	require.Len(t, out, 1)
+	followee, ok := out[0]["followee"].(map[string]any)
+	require.True(t, ok)
+	assert.Equal(t, float64(9000), followee["notesCount"])
+	assert.Equal(t, float64(8000), followee["followersCount"])
+	assert.Equal(t, float64(7000), followee["followingCount"])
+}
+
+// TestFollowers_RemoteStatsOverride_FallsBackOnFetchError: fetcher が nil
+// (= 取得失敗 / 未登録) を返した remote user は local 観測値を維持して
+// silent fallback する (= upstream Show 経路と同 pattern)。
+func TestFollowers_RemoteStatsOverride_FallsBackOnFetchError(t *testing.T) {
+	h, repo := newTestHandler(t)
+	addTestUser(repo)
+	remoteHost := "remote.example"
+	repo.Users["remote-dora"] = &model.User{
+		ID:                "remote-dora",
+		Username:          "dora",
+		UsernameLower:     "dora",
+		Host:              &remoteHost,
+		AvatarDecorations: datatypes.JSON([]byte("[]")),
+	}
+	fSvc := h.followingService
+	_, err := fSvc.Follow("remote-dora", "user1", corefollowing.FollowOptions{})
+	require.NoError(t, err)
+	// fSvc.Follow が user.FollowingCount を auto-increment するので、
+	// test の baseline は Follow 後に固定 (= override しない事実だけ確認)。
+	repo.Users["remote-dora"].NotesCount = 77
+	repo.Users["remote-dora"].FollowersCount = 99
+	repo.Users["remote-dora"].FollowingCount = 11
+	// fetcher は dora 用の stats を登録しない → Fetch が nil 返却 → fallback。
+	h.SetRemoteStatsFetcher(&fakeRemoteStatsFetcher{stats: map[string]*RemoteUserStatsView{}})
+
+	rec := post(h.Followers, `{"userId":"user1"}`)
+	require.Equal(t, http.StatusOK, rec.Code)
+	var out []map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &out))
+	require.Len(t, out, 1)
+	follower, ok := out[0]["follower"].(map[string]any)
+	require.True(t, ok)
+	// fetch 失敗時は local 観測値そのまま (override しない)。
+	assert.Equal(t, float64(77), follower["notesCount"], "fetcher nil → local count fallback")
+	assert.Equal(t, float64(99), follower["followersCount"])
+	assert.Equal(t, float64(11), follower["followingCount"])
+}
+
 // TestFollowers_RemoteStatsOverride_SkipsLocalUser: local user (Host==nil) は
 // fetcher 経路を skip し、ローカル観測値をそのまま使う。HTTP request 削減。
 func TestFollowers_RemoteStatsOverride_SkipsLocalUser(t *testing.T) {


### PR DESCRIPTION
## Summary

過去 PR #943 で導入した `RemoteStatsFetcher` (= リモートユーザーの notesCount / followersCount / followingCount を origin instance の `/api/users/show` から取得して上書きする drop-in 拡張) が、**`/api/users/show` 経路だけに配線されていた**。フォロー/フォロワー一覧ページ (`/api/users/followers` + `/api/users/following`) の embed user では適用されず、ローカル観測値のままだった (テストユーザー報告経路)。

#1144 で同経路に viewer 視点の relation flag wiring を入れた sibling 配線として、remote stats override も追加。

## 主な変更点

| File | 変更 |
|---|---|
| `internal/api/users/handler.go` | `listRelations` / `collectFollowers/Following` / `packRelationItems` に `ctx` を threading + `batchRemoteStatsOverride` helper 追加 |
| `internal/api/users/handler_test.go` | fake fetcher stub + regression guard 2 件 |

### 設計

- **goroutine fan-out** で N 件の remote user を並列 Fetch (= 各 user は HTTP I/O bound、CPU は遊んでいるので 20-100 件並列でも runtime コストは無視可能)
- **singleflight.Group** が同 (host, username) key の concurrent call を内部で dedup (= fetcher が cold cache でも thundering herd 防止)
- **ctx 伝播** で client abort 時に全 goroutine が cancel される
- **local user (Host==nil) は skip** で HTTP request 削減
- **silent fallback**: fetcher 未配線 / fetch 失敗時は local 観測値を維持 (Show 経路と同 pattern)

## Drop-in 互換

- API shape 変更なし、`notesCount` 等の値が「ローカル小さい値」→「remote 実値」に変わる方向のみ
- 旧来 Show 経路で見られた remote 実値が list 経路でも見られるようになる (= 表示の一貫性が回復する方向の差分)

## テスト

### 追加 regression guard (2 件)

- `TestFollowers_AppliesRemoteStatsOverride` — remote 実値 (500/1000/250) でローカル観測値 (5/10/3) が上書きされる
- `TestFollowers_RemoteStatsOverride_SkipsLocalUser` — local user (Host==nil) では fetcher が呼ばれない (HTTP 削減)

### 実行

```bash
go test ./internal/api/users/ -run "TestFollowers"
make fmt && make lint && make test
```

## Closes

Closes #1146