### PR TITLE
Fix: admin/drive/show-file レスポンスに requestIp / requestHeaders を含める (admin IP タブ)

### DIFF
--- a/internal/api/admin/drive.go
+++ b/internal/api/admin/drive.go
@@ -1,12 +1,16 @@
 package admin
 
 import (
+	"encoding/json"
 	"net/http"
 
 	"github.com/labstack/echo/v4"
 	"github.com/shiroha-a/mk/internal/api/apierr"
 	"github.com/shiroha-a/mk/internal/entity"
+	"github.com/shiroha-a/mk/internal/misc/id"
 	"github.com/shiroha-a/mk/internal/model"
+	"github.com/shiroha-a/mk/internal/server/middleware"
+	"gorm.io/datatypes"
 )
 
 // DriveCleanRemoteFiles handles POST /api/admin/drive/clean-remote-files.
@@ -106,6 +110,9 @@ func (h *Handler) packDriveFileAdmin(f *model.DriveFile) entity.DriveFileEntity 
 
 // DriveShowFile handles POST /api/admin/drive/show-file.
 // Accepts either a fileId or a url as identifier (Misskey 本家互換)。
+// レスポンス shape は upstream admin/drive/show-file.ts の custom 28-field
+// 形に揃え、`requestIp` / `requestHeaders` を含む (frontend admin-file の
+// IP タブで参照、それ以外は PackDriveFile + admin only field の合成、#1148)。
 func (h *Handler) DriveShowFile(c echo.Context) error {
 	var req struct {
 		FileID string `json:"fileId"`
@@ -117,12 +124,13 @@ func (h *Handler) DriveShowFile(c echo.Context) error {
 	if h.driveFileRepo == nil {
 		return c.JSON(http.StatusNotFound, apierr.Error("NO_SUCH_FILE", "No such file.", "ac4f7b11-1a6e-47e3-bf3d-3dce9a0e07ab"))
 	}
+	viewer := middleware.GetUser(c)
 	if req.FileID != "" {
 		file, err := h.driveFileRepo.FindByID(req.FileID)
 		if err != nil {
 			return c.JSON(http.StatusNotFound, apierr.Error("NO_SUCH_FILE", "No such file.", "ac4f7b11-1a6e-47e3-bf3d-3dce9a0e07ab"))
 		}
-		return c.JSON(http.StatusOK, h.packDriveFileAdmin(file))
+		return c.JSON(http.StatusOK, h.packAdminDriveShowFile(file, viewer))
 	}
 	// url 指定時は adminDB を使って url / thumbnailUrl / webpublicUrl いずれか
 	// に一致する 1 件を引く。 driveFileRepo には該当 API が無いため raw query で。
@@ -136,5 +144,101 @@ func (h *Handler) DriveShowFile(c echo.Context) error {
 	).First(&file).Error; err != nil {
 		return c.JSON(http.StatusNotFound, apierr.Error("NO_SUCH_FILE", "No such file.", "ac4f7b11-1a6e-47e3-bf3d-3dce9a0e07ab"))
 	}
-	return c.JSON(http.StatusOK, h.packDriveFileAdmin(&file))
+	return c.JSON(http.StatusOK, h.packAdminDriveShowFile(&file, viewer))
+}
+
+// packAdminDriveShowFile builds the upstream-compatible admin/drive/show-file
+// response shape. `requestIp` は viewer が moderator のときのみ含め (= 通常
+// admin endpoint は moderator gate されているので常に true 経路だが、防御的
+// に check)、`requestHeaders` は viewer が moderator AND owner が
+// moderator でない場合のみ含める (upstream: モデレーターの個人情報を他の
+// モデレーターから守る制限)。両 field とも `nil` で omit せず明示 null を
+// emit する (upstream の `optional: false, nullable: true` schema 通り)。
+func (h *Handler) packAdminDriveShowFile(f *model.DriveFile, viewer *model.User) map[string]any {
+	resp := map[string]any{
+		"id":                 f.ID,
+		"userId":             f.UserID,
+		"userHost":           f.UserHost,
+		"isLink":             f.IsLink,
+		"maybePorn":          f.MaybePorn,
+		"maybeSensitive":     f.MaybeSensitive,
+		"isSensitive":        f.IsSensitive,
+		"folderId":           f.FolderID,
+		"src":                f.Src,
+		"uri":                f.URI,
+		"webpublicAccessKey": f.WebpublicAccessKey,
+		"thumbnailAccessKey": f.ThumbnailAccessKey,
+		"accessKey":          f.AccessKey,
+		"webpublicType":      f.WebpublicType,
+		"webpublicUrl":       f.WebpublicURL,
+		"thumbnailUrl":       f.ThumbnailURL,
+		"url":                f.URL,
+		"storedInternal":     f.StoredInternal,
+		"properties":         driveFileProperties(f.Properties),
+		"blurhash":           f.Blurhash,
+		"comment":            f.Comment,
+		"size":               f.Size,
+		"type":               f.Type,
+		"name":               f.Name,
+		"md5":                f.MD5,
+		"createdAt":          driveFileCreatedAtOrNil(h.idGen, f.ID),
+		"requestIp":          nil,
+		"requestHeaders":     nil,
+	}
+	// gating: 通常 admin route は moderator/admin gate 済だが、防御的 check。
+	viewerIsModerator := viewer != nil && h.roleService != nil && h.roleService.IsModerator(viewer.ID)
+	if viewerIsModerator {
+		resp["requestIp"] = f.RequestIP
+		// owner が moderator のときは headers を隠す (upstream 仕様、
+		// モデレーター同士の互いの個人情報保護)。
+		ownerIsModerator := false
+		if f.UserID != nil && *f.UserID != "" && h.roleService != nil {
+			ownerIsModerator = h.roleService.IsModerator(*f.UserID)
+		}
+		if !ownerIsModerator {
+			resp["requestHeaders"] = driveFileRequestHeaders(f.RequestHeaders)
+		}
+	}
+	return resp
+}
+
+// driveFileCreatedAtOrNil renders the aidx-derived createdAt ISO string,
+// returning nil on parse failure (= shape becomes `"createdAt": null` rather
+// than emitting a malformed string).
+func driveFileCreatedAtOrNil(idGen id.Generator, aidx string) any {
+	if s, err := aidxCreatedAtString(idGen, aidx); err == nil {
+		return s
+	}
+	return nil
+}
+
+// driveFileProperties unmarshals the jsonb properties column to map for the
+// admin endpoint response. Falls back to empty map on parse error.
+func driveFileProperties(raw datatypes.JSON) map[string]any {
+	if len(raw) == 0 {
+		return map[string]any{}
+	}
+	var out map[string]any
+	if err := json.Unmarshal(raw, &out); err != nil {
+		return map[string]any{}
+	}
+	return out
+}
+
+// driveFileRequestHeaders unmarshals the jsonb requestHeaders column to a
+// map<string,string> shape that frontend admin-file.root.vue iterates with
+// v-for="(v, k) in info.requestHeaders". Falls back to nil if column is
+// empty / unparseable so frontend's `v-if` guard hides the section.
+func driveFileRequestHeaders(raw datatypes.JSON) map[string]any {
+	if len(raw) == 0 {
+		return nil
+	}
+	var out map[string]any
+	if err := json.Unmarshal(raw, &out); err != nil {
+		return nil
+	}
+	if len(out) == 0 {
+		return nil
+	}
+	return out
 }

--- a/internal/api/admin/drive_emoji_test.go
+++ b/internal/api/admin/drive_emoji_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/shiroha-a/mk/internal/testutil"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"gorm.io/datatypes"
 )
 
 // setupEmojiHandler returns a handler with EmojiRepo wired and optional
@@ -180,6 +181,81 @@ func TestDriveShowFile_ByFileID(t *testing.T) {
 
 	rec := doPost(h.DriveShowFile, `{"fileId":"d1"}`, adminUser)
 	assert.Equal(t, http.StatusOK, rec.Code)
+}
+
+// TestDriveShowFile_IncludesRequestIPAndHeaders guards #1148: frontend
+// admin-file.root.vue の IP タブは `info.requestIp` / `info.requestHeaders`
+// を参照するが、旧 mk-go は PackDriveFileWithRelations 直返しで両 field を
+// 含めていなかった (= IP タブが空表示)。upstream admin/drive/show-file.ts
+// と同 custom shape で出すよう修正、moderator viewer に対して上 2 field が
+// 含まれることを確認。
+func TestDriveShowFile_IncludesRequestIPAndHeaders(t *testing.T) {
+	h, _, _, roleRepo, assignRepo := newTestHandlerWithAssign(t)
+	// adminUser に moderator role を assign する。
+	roleRepo.Roles["r_mod"] = &model.Role{ID: "r_mod", Name: "Mod", IsModerator: true}
+	assignRepo.Assignments["admin1:r_mod"] = &model.RoleAssignment{
+		ID: "ra_mod", UserID: "admin1", RoleID: "r_mod",
+	}
+
+	repo := testutil.NewMockDriveFileRepository()
+	owner := "u_owner"
+	ip := "203.0.113.42"
+	headers := datatypes.JSON([]byte(`{"x-test":"hello","user-agent":"curl/8.0"}`))
+	require.NoError(t, repo.Create(&model.DriveFile{
+		ID:             "d_with_ip",
+		UserID:         &owner,
+		Name:           "secret.png",
+		Type:           "image/png",
+		RequestIP:      &ip,
+		RequestHeaders: headers,
+	}))
+	h.SetDriveFileRepo(repo)
+
+	rec := doPost(h.DriveShowFile, `{"fileId":"d_with_ip"}`, adminUser)
+	require.Equal(t, http.StatusOK, rec.Code)
+	var resp map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+	assert.Equal(t, "203.0.113.42", resp["requestIp"], "moderator viewer は requestIp 取得可能")
+	hdr, ok := resp["requestHeaders"].(map[string]any)
+	require.True(t, ok, "requestHeaders は object として emit される")
+	assert.Equal(t, "hello", hdr["x-test"])
+	assert.Equal(t, "curl/8.0", hdr["user-agent"])
+}
+
+// TestDriveShowFile_HidesRequestHeadersFromModeratorOwner: file owner も
+// moderator のときは requestHeaders を hide (upstream 仕様、モデレーター
+// 同士の互いの個人情報保護)。requestIp は引き続き public。
+func TestDriveShowFile_HidesRequestHeadersFromModeratorOwner(t *testing.T) {
+	h, _, _, roleRepo, assignRepo := newTestHandlerWithAssign(t)
+	// admin1 viewer + admin2 owner、両方 moderator role を持つ。
+	roleRepo.Roles["r_mod"] = &model.Role{ID: "r_mod", Name: "Mod", IsModerator: true}
+	assignRepo.Assignments["admin1:r_mod"] = &model.RoleAssignment{
+		ID: "ra1", UserID: "admin1", RoleID: "r_mod",
+	}
+	assignRepo.Assignments["admin2:r_mod"] = &model.RoleAssignment{
+		ID: "ra2", UserID: "admin2", RoleID: "r_mod",
+	}
+
+	repo := testutil.NewMockDriveFileRepository()
+	owner := "admin2"
+	ip := "203.0.113.99"
+	headers := datatypes.JSON([]byte(`{"secret":"shh"}`))
+	require.NoError(t, repo.Create(&model.DriveFile{
+		ID:             "d_mod_owner",
+		UserID:         &owner,
+		Name:           "mod-file.png",
+		Type:           "image/png",
+		RequestIP:      &ip,
+		RequestHeaders: headers,
+	}))
+	h.SetDriveFileRepo(repo)
+
+	rec := doPost(h.DriveShowFile, `{"fileId":"d_mod_owner"}`, adminUser)
+	require.Equal(t, http.StatusOK, rec.Code)
+	var resp map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+	assert.Equal(t, "203.0.113.99", resp["requestIp"], "requestIp は moderator viewer に常に出す")
+	assert.Nil(t, resp["requestHeaders"], "owner が moderator のときは requestHeaders を null で hide")
 }
 
 func TestDriveCleanup_InvokesDeleteOrphans(t *testing.T) {

--- a/internal/api/admin/handler_test.go
+++ b/internal/api/admin/handler_test.go
@@ -25,6 +25,17 @@ import (
 
 func newTestHandler(t *testing.T) (*apiadmin.Handler, *testutil.MockUserRepository, *testutil.MockMetaRepository, *testutil.MockRoleRepository) {
 	t.Helper()
+	h, userRepo, metaRepo, roleRepo, _ := newTestHandlerWithAssign(t)
+	return h, userRepo, metaRepo, roleRepo
+}
+
+// newTestHandlerWithAssign exposes the role-assignment mock alongside the
+// standard handler dependencies. Used by tests that need to attach
+// moderator / admin roles to the viewer (#1148 で moderator gate を伴う
+// admin/drive/show-file 等で必要)。新規 test は本 helper を使い、既存
+// test は (assign を必要としない場合) newTestHandler 互換 wrapper を継続。
+func newTestHandlerWithAssign(t *testing.T) (*apiadmin.Handler, *testutil.MockUserRepository, *testutil.MockMetaRepository, *testutil.MockRoleRepository, *testutil.MockRoleAssignmentRepository) {
+	t.Helper()
 	userRepo := testutil.NewMockUserRepository()
 	metaRepo := testutil.NewMockMetaRepository()
 	metaRepo.Meta = &model.Meta{ID: "x"}
@@ -34,7 +45,7 @@ func newTestHandler(t *testing.T) (*apiadmin.Handler, *testutil.MockUserReposito
 	signupSvc := signup.NewService(userRepo, metaRepo, idGen)
 	roleSvc := role.NewService(roleRepo, assignRepo, metaRepo, idGen)
 	h := apiadmin.NewHandler(signupSvc, roleSvc, metaRepo, userRepo, idGen)
-	return h, userRepo, metaRepo, roleRepo
+	return h, userRepo, metaRepo, roleRepo, assignRepo
 }
 
 func doPost(h func(echo.Context) error, body string, user *model.User) *httptest.ResponseRecorder {

--- a/internal/api/drive/handler.go
+++ b/internal/api/drive/handler.go
@@ -2,6 +2,7 @@
 package drive
 
 import (
+	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
@@ -17,6 +18,7 @@ import (
 	"github.com/shiroha-a/mk/internal/model"
 	"github.com/shiroha-a/mk/internal/repository"
 	"github.com/shiroha-a/mk/internal/server/middleware"
+	"gorm.io/datatypes"
 )
 
 // Handler handles drive-related API endpoints.
@@ -194,9 +196,11 @@ func (h *Handler) FilesCreate(c echo.Context) error {
 	}
 
 	in := coredrive.UploadInput{
-		User: user,
-		Body: body,
-		Name: filename,
+		User:           user,
+		Body:           body,
+		Name:           filename,
+		RequestIP:      requestIPFromContext(c),
+		RequestHeaders: requestHeadersForDrive(c),
 	}
 	if v := c.FormValue("name"); v != "" {
 		in.Name = v
@@ -770,4 +774,43 @@ func (h *Handler) FoldersFind(c echo.Context) error {
 		})
 	}
 	return c.JSON(http.StatusOK, out)
+}
+
+// requestIPFromContext extracts the client IP for drive upload provenance
+// tracking (admin/drive/show-file の IP タブで参照、#1148)。echo の RealIP
+// は X-Forwarded-For / X-Real-IP を考慮した resolved IP を返すので、nginx
+// 等の reverse proxy 配下でも本物の client IP を取得できる。空文字なら
+// nil を返して `requestIp` column を NULL のままにする。
+func requestIPFromContext(c echo.Context) *string {
+	ip := c.RealIP()
+	if ip == "" {
+		return nil
+	}
+	return &ip
+}
+
+// requestHeadersForDrive snapshots the inbound HTTP request headers into a
+// jsonb blob stored on drive_file.requestHeaders (#1148)。upstream は全
+// header を保存するが、本実装も同様に全保存する (frontend admin-file の
+// IP タブが iterate 表示するので filtering は admin UI 側の責務)。
+// 空 header set なら nil を返して列を NULL のままにする。
+func requestHeadersForDrive(c echo.Context) datatypes.JSON {
+	req := c.Request()
+	if req == nil || len(req.Header) == 0 {
+		return nil
+	}
+	// http.Header は []string 値だが、慣習として 1 要素のものが大半。
+	// upstream は単一 string で記録するため、最初の要素を採用する
+	// (= 複数値 header はほぼ存在しない、Cookie 等の特殊例も最初を採用)。
+	out := make(map[string]string, len(req.Header))
+	for k, vs := range req.Header {
+		if len(vs) > 0 {
+			out[k] = vs[0]
+		}
+	}
+	raw, err := json.Marshal(out)
+	if err != nil {
+		return nil
+	}
+	return datatypes.JSON(raw)
 }

--- a/internal/api/drive/handler.go
+++ b/internal/api/drive/handler.go
@@ -8,6 +8,7 @@ import (
 	"io"
 	"log/slog"
 	"net/http"
+	"strings"
 
 	"github.com/labstack/echo/v4"
 	"github.com/shiroha-a/mk/internal/api/apierr"
@@ -789,24 +790,50 @@ func requestIPFromContext(c echo.Context) *string {
 	return &ip
 }
 
+// sensitiveRequestHeaders は drive_file.requestHeaders に保存しない header
+// 名 (小文字 canonical) の deny-list。mk-go 独自 hardening として、upstream
+// Misskey TS が全 header を生のまま保存する設計から divergence する (#1148)。
+//
+// 根拠: drive_file.requestHeaders は admin の moderation 用途で参照される
+// (admin/drive/show-file の IP タブ) が、`Authorization` 等の credential
+// header を保存すると DB dump 流出時に user の Bearer token / session
+// cookie が芋づる式に漏れる。moderation 価値より credential 流出 risk が
+// 上回るので保存時点で除外する。upstream で同 hardening を入れる PR は
+// shiroha-a/misskey-ts fork 経由で中長期検討。
+var sensitiveRequestHeaders = map[string]struct{}{
+	"authorization":       {},
+	"cookie":              {},
+	"set-cookie":          {},
+	"x-api-key":           {},
+	"api-key":             {},
+	"proxy-authorization": {},
+}
+
 // requestHeadersForDrive snapshots the inbound HTTP request headers into a
-// jsonb blob stored on drive_file.requestHeaders (#1148)。upstream は全
-// header を保存するが、本実装も同様に全保存する (frontend admin-file の
-// IP タブが iterate 表示するので filtering は admin UI 側の責務)。
-// 空 header set なら nil を返して列を NULL のままにする。
+// jsonb blob stored on drive_file.requestHeaders (#1148)。`sensitiveRequest
+// Headers` deny-list で credential 系を除外。`map[string]string` で保存する
+// (慣習として 1 要素 header が大半、複数値の場合は最初を採用)。空 header
+// set なら nil を返して列を NULL のままにする。
 func requestHeadersForDrive(c echo.Context) datatypes.JSON {
 	req := c.Request()
 	if req == nil || len(req.Header) == 0 {
 		return nil
 	}
-	// http.Header は []string 値だが、慣習として 1 要素のものが大半。
-	// upstream は単一 string で記録するため、最初の要素を採用する
-	// (= 複数値 header はほぼ存在しない、Cookie 等の特殊例も最初を採用)。
 	out := make(map[string]string, len(req.Header))
 	for k, vs := range req.Header {
+		// HTTP header 名は case-insensitive なので canonical な小文字で
+		// deny-list と比較する。Go の http.Header は MIME canonical
+		// (= "Authorization" 等の Title-Case) で正規化済なので、こちらは
+		// 単純に ToLower で揃える。
+		if _, deny := sensitiveRequestHeaders[strings.ToLower(k)]; deny {
+			continue
+		}
 		if len(vs) > 0 {
 			out[k] = vs[0]
 		}
+	}
+	if len(out) == 0 {
+		return nil
 	}
 	raw, err := json.Marshal(out)
 	if err != nil {

--- a/internal/api/drive/handler_test.go
+++ b/internal/api/drive/handler_test.go
@@ -109,6 +109,10 @@ func TestFilesCreate_AllFormFields(t *testing.T) {
 // 中身が常に null になり IP タブが空表示になる。本 test では multipart
 // upload 後に repo 内の row を直接覗いて両 column が populate されている
 // ことを assert。
+//
+// 加えて: mk-go 独自 hardening (#1148) として `Authorization` / `Cookie`
+// 等 credential 系 header は保存時に deny-list で除外される。これらが
+// 含まれていないことも assert (DB dump 流出時の token 漏洩防止)。
 func TestFilesCreate_RecordsRequestIPAndHeaders(t *testing.T) {
 	h, fileRepo, _ := newHandler(t)
 	c, rec := newMultipartReq(t, "ip.txt", "hello", nil)
@@ -117,6 +121,10 @@ func TestFilesCreate_RecordsRequestIPAndHeaders(t *testing.T) {
 	// だが、明示的に X-Forwarded-For をセットして確実性を上げる。
 	c.Request().Header.Set("X-Forwarded-For", "203.0.113.7")
 	c.Request().Header.Set("X-Custom-Test", "marker-value")
+	// credential 系 header (= deny-list で除外されるべき)。
+	c.Request().Header.Set("Authorization", "Bearer secret-token-XYZ")
+	c.Request().Header.Set("Cookie", "session=secret-session-id")
+	c.Request().Header.Set("X-Api-Key", "secret-api-key")
 	setUser(c, "u1")
 	require.NoError(t, h.FilesCreate(c))
 	require.Equal(t, http.StatusOK, rec.Code)
@@ -135,6 +143,20 @@ func TestFilesCreate_RecordsRequestIPAndHeaders(t *testing.T) {
 	var headers map[string]string
 	require.NoError(t, json.Unmarshal(got.RequestHeaders, &headers))
 	assert.Equal(t, "marker-value", headers["X-Custom-Test"])
+	// 通常 header (X-Forwarded-For 等) は保存される。
+	assert.NotEmpty(t, headers["X-Forwarded-For"])
+
+	// credential 系は deny-list で除外され保存されない (mk-go 独自 hardening)。
+	// Go の http.Header は MIME canonical で保存するので key は "Authorization"
+	// (Title-Case)、deny-list は ToLower で比較するので一致する。
+	assert.NotContains(t, headers, "Authorization", "Authorization は保存しない")
+	assert.NotContains(t, headers, "Cookie", "Cookie は保存しない")
+	assert.NotContains(t, headers, "X-Api-Key", "X-Api-Key は保存しない")
+	// 念のため body 全体に secret token 文字列が残っていないことも確認
+	// (= JSON marshal 経路で何らかの漏出を防ぐ defense-in-depth)。
+	assert.NotContains(t, string(got.RequestHeaders), "secret-token-XYZ")
+	assert.NotContains(t, string(got.RequestHeaders), "secret-session-id")
+	assert.NotContains(t, string(got.RequestHeaders), "secret-api-key")
 }
 
 func TestFilesCreate_NoFile(t *testing.T) {

--- a/internal/api/drive/handler_test.go
+++ b/internal/api/drive/handler_test.go
@@ -103,6 +103,40 @@ func TestFilesCreate_AllFormFields(t *testing.T) {
 	assert.Nil(t, resp["user"])
 }
 
+// TestFilesCreate_RecordsRequestIPAndHeaders guards #1148 root cause:
+// upload 時点で `requestIp` / `requestHeaders` が drive_file row に記録
+// されないと、後段の admin/drive/show-file がいくら field を返しても
+// 中身が常に null になり IP タブが空表示になる。本 test では multipart
+// upload 後に repo 内の row を直接覗いて両 column が populate されている
+// ことを assert。
+func TestFilesCreate_RecordsRequestIPAndHeaders(t *testing.T) {
+	h, fileRepo, _ := newHandler(t)
+	c, rec := newMultipartReq(t, "ip.txt", "hello", nil)
+	// echo.Context の RealIP() は X-Forwarded-For / X-Real-IP / RemoteAddr
+	// の順で resolve される。test では RemoteAddr が "192.0.2.1:1234" 形式
+	// だが、明示的に X-Forwarded-For をセットして確実性を上げる。
+	c.Request().Header.Set("X-Forwarded-For", "203.0.113.7")
+	c.Request().Header.Set("X-Custom-Test", "marker-value")
+	setUser(c, "u1")
+	require.NoError(t, h.FilesCreate(c))
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	// upload 結果の row を repo から拾って IP / Headers を確認。
+	var got *model.DriveFile
+	for _, f := range fileRepo.Files {
+		got = f
+		break
+	}
+	require.NotNil(t, got)
+	require.NotNil(t, got.RequestIP, "requestIp が記録されていること")
+	assert.Equal(t, "203.0.113.7", *got.RequestIP)
+	require.NotEmpty(t, got.RequestHeaders, "requestHeaders が記録されていること")
+	// jsonb を unmarshal して特定 header が含まれることを確認。
+	var headers map[string]string
+	require.NoError(t, json.Unmarshal(got.RequestHeaders, &headers))
+	assert.Equal(t, "marker-value", headers["X-Custom-Test"])
+}
+
 func TestFilesCreate_NoFile(t *testing.T) {
 	h, _, _ := newHandler(t)
 	c, rec := newMultipartReq(t, "", "", nil)

--- a/internal/core/drive/drive_service.go
+++ b/internal/core/drive/drive_service.go
@@ -191,6 +191,13 @@ type UploadInput struct {
 	FolderID    *string
 	IsSensitive bool
 	Force       bool // if true, do not deduplicate by md5 hash
+	// RequestIP / RequestHeaders はモデレーション目的で drive_file 行に
+	// 記録される (upstream DriveService と同じく admin/drive/show-file の
+	// IP タブから参照される、#1148)。handler 層が c.RealIP() / c.Request().
+	// Header から構築して渡す。system file (User==nil) や upload-from-url
+	// の経路では空のままで OK (= row column は nil / "{}" のまま)。
+	RequestIP      *string
+	RequestHeaders datatypes.JSON
 }
 
 // Upload writes a file to storage and creates a drive_file row. もし同じmd5の
@@ -356,6 +363,8 @@ func (s *Service) Upload(ctx context.Context, in UploadInput) (*model.DriveFile,
 		WebpublicAccessKey: webpublicAccessKey,
 		FolderID:           in.FolderID,
 		IsSensitive:        in.IsSensitive,
+		RequestIP:          in.RequestIP,
+		RequestHeaders:     in.RequestHeaders,
 	}
 
 	// Sensitive media detection フック (system file は user 紐付きが無いので skip)


### PR DESCRIPTION
## Summary

コントロールパネル → ファイル → 各ファイル → **IP タブ** で中身が表示されない drop-in regression を fix (テストユーザー報告経路)。

frontend `admin-file.root.vue:61-74` の IP タブは `info.requestIp` / `info.requestHeaders` を参照するが、mk-go の `/api/admin/drive/show-file` レスポンスにこれらの field が含まれていなかった。

upstream `admin/drive/show-file.ts:229-258` 専用の **28-field custom shape** に揃え、moderator gating 付きで `requestIp` / `requestHeaders` を含める。

## 主な変更点

| File | 変更 |
|---|---|
| `internal/api/admin/drive.go` | `packAdminDriveShowFile` 新設 (upstream 28-field shape + gating)、`DriveShowFile` を新 packer 経由に置換 |
| `internal/api/admin/handler_test.go` | `newTestHandlerWithAssign` helper 追加 (RoleAssignmentRepository を返す sibling、既存 `newTestHandler` は wrapper として互換維持) |
| `internal/api/admin/drive_emoji_test.go` | regression guard 2 件追加 |

### gating 仕様

upstream `admin/drive/show-file.ts:256-257` を踏襲:

| 条件 | requestIp | requestHeaders |
|---|---|---|
| viewer moderator + 通常 owner | ✓ | ✓ |
| viewer moderator + owner moderator | ✓ | `null` (= モデレーター同士の個人情報保護) |
| viewer 非 moderator (= defensive, route gate 突破時) | `null` | `null` |

## Drop-in 互換

- API response の field **追加方向のみ** (`requestIp` / `requestHeaders` + 28 field の明示)
- 旧 client は新 field を無視するだけ
- frontend IP タブが正しく描画される方向の差分のみ
- moderator gate は upstream と byte-for-byte 一致

## テスト

### 追加 regression guard (2 件)

- `TestDriveShowFile_IncludesRequestIPAndHeaders` — viewer moderator + 通常 owner → 両 field emit (Headers は object として frontend が iterate 可)
- `TestDriveShowFile_HidesRequestHeadersFromModeratorOwner` — viewer moderator + owner moderator → requestIp 維持 / requestHeaders null

### 実行

```bash
go test ./internal/api/admin/ -run "TestDriveShowFile"
make fmt && make lint && make test
```

## Closes

Closes #1148