### PR TITLE
Fix: fanout に replyToMe escape hatch を追加 (他人→自分 reply が home TL に出ない)

### DIFF
--- a/internal/core/timeline/fanout_hook.go
+++ b/internal/core/timeline/fanout_hook.go
@@ -235,13 +235,20 @@ func (h *FanoutHook) fanoutToFollowersAndStream(ctx context.Context, authorID st
 		//   - self-thread (= replyUserId = userId) → 全 follower に push (= TL
 		//     filter で `replyUserId = note.userId` 経路で残るので fanout でも
 		//     全 push する semantics)
+		//   - reply-to-follower (= replyUserId = follower.id、自分への reply) →
+		//     全 push (upstream `replyToMe` escape hatch、#1150)。stream filter
+		//     `replyShouldEmit` も同 escape hatch を持つので fanout / stream の
+		//     挙動を symmetric に保つ。
 		//   - その他 reply (= 他人宛 reply) → withReplies=true の follower のみ push
 		// これにより「他人 A → 他人 B reply」が default で他 follower の TL に
-		// 流れず、Misskey TS の `following.withReplies` setting と完全互換に。
+		// 流れず、かつ「他人 A → follower 本人」reply は default で push される
+		// (= Misskey TS の `following.withReplies` setting + replyToMe 仕様と
+		// 完全互換)。
 		isReply := n.ReplyID != nil
 		isSelfThread := isReply && n.ReplyUserID != nil && *n.ReplyUserID == n.UserID
 		for _, f := range rows {
-			if isReply && !isSelfThread && !f.WithReplies {
+			isReplyToFollower := isReply && n.ReplyUserID != nil && *n.ReplyUserID == f.FollowerID
+			if isReply && !isSelfThread && !isReplyToFollower && !f.WithReplies {
 				continue
 			}
 			h.pushWithLimit(ctx, HomeTimelineName(f.FollowerID), n.ID, homeCap)

--- a/internal/core/timeline/fanout_hook_test.go
+++ b/internal/core/timeline/fanout_hook_test.go
@@ -188,6 +188,45 @@ func TestFanoutHook_SelfThreadReplyFanoutsToAllFollowers(t *testing.T) {
 	}
 }
 
+// TestFanoutHook_ReplyToFollowerIsPushedRegardlessOfWithReplies guards
+// #1150: 「他人が follower 本人宛にした reply」は WithReplies 設定に関わら
+// ず follower 本人の home TL に push される。stream filter `replyShouldEmit`
+// が `replyToMe` escape hatch を持つので fanout 側も symmetric に揃える
+// (= reload で消える非対称挙動を解消)。
+//
+// scenario: author が follower1 / follower2 を持ち、follower1 が
+// withReplies=false。author が follower1 宛 reply を作ると、follower1 の
+// home TL に push される (= self への reply は default で受け取りたい)。
+// follower2 (= 無関係) も withReplies=true なので受け取る。
+func TestFanoutHook_ReplyToFollowerIsPushedRegardlessOfWithReplies(t *testing.T) {
+	h, fanout, following := newTestHook(t)
+	ctx := context.Background()
+	following.Followings["f1"] = &model.Following{ID: "f1", FollowerID: "follower1", FolloweeID: "author", WithReplies: false}
+	following.Followings["f2"] = &model.Following{ID: "f2", FollowerID: "follower2", FolloweeID: "author", WithReplies: false}
+
+	noteID := idGen.Generate(time.Now())
+	replyID := "reply-target"
+	follower1ID := "follower1"
+	n := &model.Note{
+		ID:          noteID,
+		UserID:      "author",
+		Visibility:  model.NoteVisibilityPublic,
+		ReplyID:     &replyID,
+		ReplyUserID: &follower1ID, // follower1 宛 reply
+	}
+	h.OnNoteCreated(n, &model.User{ID: "author"})
+
+	// follower1 は自分宛 reply なので受け取る (replyToMe escape hatch)
+	out, err := fanout.Get(ctx, HomeTimelineName("follower1"), "", "", 10)
+	require.NoError(t, err)
+	assert.Equal(t, []string{noteID}, out, "follower1 (= reply target) should receive reply regardless of WithReplies")
+
+	// follower2 は無関係な reply なので withReplies=false の通常 gate で skip
+	out, err = fanout.Get(ctx, HomeTimelineName("follower2"), "", "", 10)
+	require.NoError(t, err)
+	assert.Empty(t, out, "follower2 (= unrelated) should not receive reply when WithReplies=false")
+}
+
 // 通常 note (reply 無し) は WithReplies 設定に関わらず全 follower に push される。
 func TestFanoutHook_NonReplyFanoutsToAllFollowers(t *testing.T) {
 	h, fanout, following := newTestHook(t)


### PR DESCRIPTION
## Summary

「**自分への リプライ**」(= 他人が自分の note に返信) が home timeline に表示されない drop-in regression を fix (テストユーザー報告経路 + UDS 実機検証)。

UDS 検証:
- shiroha が aoikagase を follow、`withReplies=false` (default)
- shiroha note → aoikagase reply
- shiroha の `/api/notes/timeline` → aoikagase reply が **出ない**

## 原因

`internal/core/timeline/fanout_hook.go:241-246` の per-follower reply gate が `isSelfThread` のみ escape hatch を持ち、**`isReplyToFollower` (= reply.userId == follower 本人)** を見ていなかった。

`withReplies=false` の follower 宛 reply が default で fanout skip され、Redis home TL cache に乗らない。一方 stream filter `replyShouldEmit` (note_filter.go:209) は `replyToMe` escape hatch を持つので realtime WS では emit され、**reload で消える非対称な挙動**になっていた。

upstream Misskey TS の `FanoutTimelineService` は `reply.userId === followerId` で同 escape hatch を持つ。本実装は config miss。

## 主な変更点

| File | 変更 |
|---|---|
| `internal/core/timeline/fanout_hook.go` | per-follower loop に `isReplyToFollower` 判定 + gate 除外条件追加 |
| `internal/core/timeline/fanout_hook_test.go` | regression guard 1 件追加 (`TestFanoutHook_ReplyToFollowerIsPushedRegardlessOfWithReplies`) |

### 設計

reply gate の優先順位 (= push 判定):

| condition | push? |
|---|---|
| 通常 note (reply 無し) | ✓ |
| self-thread (`replyUserId == userId`) | ✓ |
| **reply-to-follower (`replyUserId == follower.id`)** ← **新規** | ✓ |
| その他 reply (= 他人宛) | follower の `withReplies=true` のみ |

これで fanout と stream filter の escape hatch が完全 symmetric。

## Drop-in 互換

- fanout cache push が **増える方向のみ** (削減なし)、既存挙動は壊れない
- 他人宛 reply の gate (= withReplies=true でのみ push) はそのまま
- self-thread の全 follower push もそのまま
- upstream Misskey TS の挙動に**より近づく方向**の差分

## テスト

### 追加 regression guard

`TestFanoutHook_ReplyToFollowerIsPushedRegardlessOfWithReplies`:
- author → follower1 宛 reply (follower1 / follower2 共に withReplies=false)
- follower1 (= reply target): push される (replyToMe escape)
- follower2 (= unrelated): push されない (= withReplies=false 通常 gate)

両方向の挙動を symmetric な setup で 1 test 内に guard。

### 実行

```bash
go test ./internal/core/timeline/ -run "TestFanoutHook_Reply"
make fmt && make lint && make test
```

## Closes

Closes #1150