### PR TITLE
Fix: fanout に followers-visibility reply の follow gate 追加

### DIFF
--- a/internal/core/timeline/fanout_hook.go
+++ b/internal/core/timeline/fanout_hook.go
@@ -219,6 +219,32 @@ func shouldFanoutToFollowers(n *model.Note) bool {
 // homeCap は OnNoteCreated 側で meta から取得済みのものを再利用する。
 func (h *FanoutHook) fanoutToFollowersAndStream(ctx context.Context, authorID string, n *model.Note, author *model.User, homeCap int) {
 	const pageSize = 200
+	// reply note は follower の `following.withReplies` 設定で push 制御
+	// する (#1047 / upstream 互換)。
+	//   - 通常 note (= replyId nil) → 全 follower に push
+	//   - self-thread (= replyUserId = userId) → 全 follower に push (= TL
+	//     filter で `replyUserId = note.userId` 経路で残るので fanout でも
+	//     全 push する semantics)
+	//   - reply-to-follower (= replyUserId = follower.id、自分への reply) →
+	//     全 push (upstream `replyToMe` escape hatch、#1150)。stream filter
+	//     `replyShouldEmit` も同 escape hatch を持つので fanout / stream の
+	//     挙動を symmetric に保つ。
+	//   - その他 reply (= 他人宛 reply) → withReplies=true の follower のみ push
+	// これにより「他人 A → 他人 B reply」が default で他 follower の TL に
+	// 流れず、かつ「他人 A → follower 本人」reply は default で push される
+	// (= Misskey TS の `following.withReplies` setting + replyToMe 仕様と
+	// 完全互換)。
+	//
+	// 加えて #1152: reply 対象 note の `visibility=followers` の場合、reply
+	// target を follow していない follower は drop する (= stream filter
+	// `replyShouldEmit` の followers-visibility gate と symmetric)。「context
+	// が見えない reply 本文だけが流れる」privacy 漏洩を防ぐ。`n.Reply` が
+	// nil (= FindByIDWithRelations の preload 失敗) の case は visibility 不明
+	// なので保守的に gate を skip (= 既存挙動 = push)。stream filter は drop
+	// に倒すが fanout は全 follower への影響が大きいので over-restrict を避ける。
+	isReply := n.ReplyID != nil
+	isSelfThread := isReply && n.ReplyUserID != nil && *n.ReplyUserID == n.UserID
+	isFollowersOnlyReply := isReply && n.Reply != nil && n.Reply.Visibility == model.NoteVisibilityFollowers
 	offset := 0
 	for {
 		rows, err := h.followingRepo.ListFollowers(authorID, pageSize, offset)
@@ -229,27 +255,36 @@ func (h *FanoutHook) fanoutToFollowersAndStream(ctx context.Context, authorID st
 		if len(rows) == 0 {
 			return
 		}
-		// reply note は follower の `following.withReplies` 設定で push 制御
-		// する (#1047 / upstream 互換)。
-		//   - 通常 note (= replyId nil) → 全 follower に push
-		//   - self-thread (= replyUserId = userId) → 全 follower に push (= TL
-		//     filter で `replyUserId = note.userId` 経路で残るので fanout でも
-		//     全 push する semantics)
-		//   - reply-to-follower (= replyUserId = follower.id、自分への reply) →
-		//     全 push (upstream `replyToMe` escape hatch、#1150)。stream filter
-		//     `replyShouldEmit` も同 escape hatch を持つので fanout / stream の
-		//     挙動を symmetric に保つ。
-		//   - その他 reply (= 他人宛 reply) → withReplies=true の follower のみ push
-		// これにより「他人 A → 他人 B reply」が default で他 follower の TL に
-		// 流れず、かつ「他人 A → follower 本人」reply は default で push される
-		// (= Misskey TS の `following.withReplies` setting + replyToMe 仕様と
-		// 完全互換)。
-		isReply := n.ReplyID != nil
-		isSelfThread := isReply && n.ReplyUserID != nil && *n.ReplyUserID == n.UserID
+		// followers-only reply の per-page follow check (batch lookup)。
+		// `FilterFollowingsToAnchor(replyUserID, followerIDs)` で「reply target
+		// を follow している follower の subset」を 1 query で取得する。
+		// query 失敗時は保守的に gate を skip (= 既存挙動 = push)。
+		var followsReplyTarget map[string]bool
+		if isFollowersOnlyReply && n.ReplyUserID != nil {
+			followerIDs := make([]string, 0, len(rows))
+			for _, f := range rows {
+				followerIDs = append(followerIDs, f.FollowerID)
+			}
+			if ids, err := h.followingRepo.FilterFollowingsToAnchor(*n.ReplyUserID, followerIDs); err == nil {
+				followsReplyTarget = make(map[string]bool, len(ids))
+				for _, id := range ids {
+					followsReplyTarget[id] = true
+				}
+			}
+		}
 		for _, f := range rows {
 			isReplyToFollower := isReply && n.ReplyUserID != nil && *n.ReplyUserID == f.FollowerID
 			if isReply && !isSelfThread && !isReplyToFollower && !f.WithReplies {
 				continue
+			}
+			// followers-only reply: reply target を follow していない follower
+			// は drop (isReplyToFollower の場合は follower 自身が target なので
+			// escape)。followsReplyTarget が nil (= query 失敗 / 該当無し) の
+			// 場合は保守的に skip gate せず push 継続。
+			if isFollowersOnlyReply && !isReplyToFollower && followsReplyTarget != nil {
+				if !followsReplyTarget[f.FollowerID] {
+					continue
+				}
 			}
 			h.pushWithLimit(ctx, HomeTimelineName(f.FollowerID), n.ID, homeCap)
 			if h.publisher != nil {

--- a/internal/core/timeline/fanout_hook_test.go
+++ b/internal/core/timeline/fanout_hook_test.go
@@ -227,6 +227,89 @@ func TestFanoutHook_ReplyToFollowerIsPushedRegardlessOfWithReplies(t *testing.T)
 	assert.Empty(t, out, "follower2 (= unrelated) should not receive reply when WithReplies=false")
 }
 
+// TestFanoutHook_FollowersOnlyReply_DropsFollowersNotFollowingReplyTarget
+// guards #1152: reply 対象 note の `visibility=followers` の場合、reply
+// target を follow していない follower は drop される (= stream filter
+// `replyShouldEmit` と symmetric)。「context が見えない reply 本文だけが
+// 流れる」 privacy 漏洩を防ぐ。
+//
+// scenario: author が follower1 / follower2 を持ち、author が `replyTarget`
+// (visibility=followers) に reply を作る。
+//   - follower1 は replyTarget の author (= reply.userId) を follow → push
+//   - follower2 は replyTarget の author を follow していない → drop
+//
+// 両 follower 共に withReplies=true なので #1150 経路は skip されない。
+func TestFanoutHook_FollowersOnlyReply_DropsFollowersNotFollowingReplyTarget(t *testing.T) {
+	h, fanout, following := newTestHook(t)
+	ctx := context.Background()
+	// follower1 / follower2 共に author を withReplies=true で follow。
+	following.Followings["f1"] = &model.Following{ID: "f1", FollowerID: "follower1", FolloweeID: "author", WithReplies: true}
+	following.Followings["f2"] = &model.Following{ID: "f2", FollowerID: "follower2", FolloweeID: "author", WithReplies: true}
+	// follower1 → replyTargetUser (= 自分が reply 先を follow している)
+	following.Followings["f3"] = &model.Following{ID: "f3", FollowerID: "follower1", FolloweeID: "replyTargetUser"}
+
+	noteID := idGen.Generate(time.Now())
+	replyTargetID := "reply-target-note"
+	replyTargetUser := "replyTargetUser"
+	n := &model.Note{
+		ID:          noteID,
+		UserID:      "author",
+		Visibility:  model.NoteVisibilityPublic, // 本 note 自体の visibility は public
+		ReplyID:     &replyTargetID,
+		ReplyUserID: &replyTargetUser,
+		// preload された reply 対象 note (= 自分は followers-only)
+		Reply: &model.Note{
+			ID:         replyTargetID,
+			UserID:     replyTargetUser,
+			Visibility: model.NoteVisibilityFollowers,
+		},
+	}
+	h.OnNoteCreated(n, &model.User{ID: "author"})
+
+	// follower1: replyTargetUser を follow しているので reply を受け取る
+	out, err := fanout.Get(ctx, HomeTimelineName("follower1"), "", "", 10)
+	require.NoError(t, err)
+	assert.Equal(t, []string{noteID}, out, "follower1 (= replyTargetUser を follow 中) は reply 受け取る")
+
+	// follower2: replyTargetUser を follow していないので drop
+	out, err = fanout.Get(ctx, HomeTimelineName("follower2"), "", "", 10)
+	require.NoError(t, err)
+	assert.Empty(t, out, "follower2 (= replyTargetUser 非 follow) は followers-only reply を受け取らない")
+}
+
+// TestFanoutHook_FollowersOnlyReply_ReplyToFollowerEscapeHatch covers #1152
+// + #1150 の組み合わせ: follower が reply target 本人なら、follow 関係
+// (= 自己 follow は不要) をチェックせず push する。`isReplyToFollower`
+// escape hatch が followers-only gate より優先される。
+func TestFanoutHook_FollowersOnlyReply_ReplyToFollowerEscapeHatch(t *testing.T) {
+	h, fanout, following := newTestHook(t)
+	ctx := context.Background()
+	following.Followings["f1"] = &model.Following{ID: "f1", FollowerID: "follower1", FolloweeID: "author", WithReplies: true}
+	// follower1 自身を replyTargetUser に設定 (= 自分宛 reply)
+	follower1 := "follower1"
+
+	noteID := idGen.Generate(time.Now())
+	replyTargetID := "reply-target-note"
+	n := &model.Note{
+		ID:          noteID,
+		UserID:      "author",
+		Visibility:  model.NoteVisibilityPublic,
+		ReplyID:     &replyTargetID,
+		ReplyUserID: &follower1, // follower1 宛 reply
+		Reply: &model.Note{
+			ID:         replyTargetID,
+			UserID:     follower1,
+			Visibility: model.NoteVisibilityFollowers,
+		},
+	}
+	h.OnNoteCreated(n, &model.User{ID: "author"})
+
+	// follower1 は reply target 本人なので followers-only gate を escape して受け取る
+	out, err := fanout.Get(ctx, HomeTimelineName("follower1"), "", "", 10)
+	require.NoError(t, err)
+	assert.Equal(t, []string{noteID}, out, "follower1 (= reply target 本人) は followers-only gate を escape")
+}
+
 // 通常 note (reply 無し) は WithReplies 設定に関わらず全 follower に push される。
 func TestFanoutHook_NonReplyFanoutsToAllFollowers(t *testing.T) {
 	h, fanout, following := newTestHook(t)


### PR DESCRIPTION
## Summary

PR #1151 の sibling fix。fanout / stream の非対称が `replyToMe` 以外にもう 1 件残っていた:

「reply 対象 note の `visibility=followers` のとき、reply target を follow していない follower は drop」という gate を stream filter (`replyShouldEmit:228`) は持つが、fanout は持っていなかった。

**結果 (旧挙動)**: stream 経由では drop されるが Redis cache (= reload 経路) には push されて残るので、followers-only な context が見えない reply 本文だけが他人の TL に流れる **privacy 漏洩**が起きていた。

## 主な変更点

| File | 変更 |
|---|---|
| `internal/core/timeline/fanout_hook.go` | `isFollowersOnlyReply` 判定 + per-page `FilterFollowingsToAnchor` batch query + per-follower follow gate |
| `internal/core/timeline/fanout_hook_test.go` | regression guard 2 件 |

### 設計

per-page で `FilterFollowingsToAnchor(reply.userId, followerIDs)` を 1 batch query 発行し、reply target を follow している follower の subset を事前計算。loop 内で follow していない follower は drop。

#### Escape hatch (= gate を skip して push する条件)

| condition | rationale |
|---|---|
| `isReplyToFollower` (follower 本人が reply target) | #1150 経路、自分宛 reply は常に push |
| `n.Reply == nil` (preload 失敗) | 保守的に gate skip、既存挙動 (= push) 維持。stream は drop に倒すが fanout は全 follower への影響が大きいので over-restrict を避ける |

#### Stream filter との対比 (symmetric)

| condition | stream `replyShouldEmit` | fanout (本 PR 後) |
|---|---|---|
| visibility=followers, replyToMe | pass | pass (`isReplyToFollower` 経路) |
| visibility=followers, follows reply target | pass | pass (`followsReplyTarget[f.FollowerID]`) |
| visibility=followers, !follows reply target | drop | drop (本 PR で追加) |

## Drop-in 互換

- cache push が **減る方向** (= 旧来 push されていた privacy 漏洩 case を新規 drop)
- stream filter で既に drop されていた case を fanout にも揃えるだけ、frontend 表示挙動は変わらず
- upstream Misskey TS `FanoutTimelineService` と完全互換

## テスト

### 追加 regression guard (2 件)

- `TestFanoutHook_FollowersOnlyReply_DropsFollowersNotFollowingReplyTarget`: follower1 (reply target を follow) は受け取る / follower2 (非 follow) は drop
- `TestFanoutHook_FollowersOnlyReply_ReplyToFollowerEscapeHatch`: follower1 = reply target 本人なら followers-only gate escape (`isReplyToFollower` 優先)

### 実行

```bash
go test ./internal/core/timeline/ -run TestFanoutHook
make fmt && make lint && make test
```

## Closes

Closes #1152