### PR TITLE
Fix: RemoteStatsFetcher に Mastodon API fallback を追加 (Mastodon系の counts が 0 表示)

### DIFF
--- a/internal/core/federation/remote_stats.go
+++ b/internal/core/federation/remote_stats.go
@@ -64,9 +64,10 @@ const remoteStatsCacheSize = 10000
 // TTL は per-entry で持ち、read 時に判定する (LRU library 自体は size
 // eviction のみで TTL を扱わない)。
 type RemoteStatsFetcher struct {
-	client *http.Client
-	cache  *lru.Cache[string, cachedRemoteStats]
-	group  singleflight.Group
+	client    *http.Client
+	cache     *lru.Cache[string, cachedRemoteStats]
+	group     singleflight.Group
+	userAgent string
 }
 
 type cachedRemoteStats struct {
@@ -79,14 +80,20 @@ type cachedRemoteStats struct {
 // built from allowedPrivateNetworks (= config.AllowedPrivateNetworks 互換) と
 // optional safehttp.Option (e.g. WithProxy)。
 //
+// userAgent は outbound request に set する User-Agent header 値で、通常は
+// `cfg.UserAgent` (= `mk-go/<ver> (<url>)` 形式) を渡す。空欄なら header は
+// 設定しない (= Go default の `Go-http-client/1.1` が送られる、test path)。
+//
 // urlpreview / mediaproxy と同じく safehttp 経由で組み立てる pattern (#943
 // review SSRF guard)。
-func NewRemoteStatsFetcher(allowedPrivateNetworks []string, opts ...safehttp.Option) *RemoteStatsFetcher {
+func NewRemoteStatsFetcher(allowedPrivateNetworks []string, userAgent string, opts ...safehttp.Option) *RemoteStatsFetcher {
 	transport := safehttp.NewSSRFSafeTransport(allowedPrivateNetworks, opts...)
-	return newFetcherWithClient(&http.Client{
+	f := newFetcherWithClient(&http.Client{
 		Transport: transport,
 		Timeout:   remoteStatsTimeout,
 	}, remoteStatsCacheSize)
+	f.userAgent = userAgent
+	return f
 }
 
 // newRemoteStatsFetcherWithTransport はテスト専用 constructor。redirectTransport
@@ -211,6 +218,9 @@ func (f *RemoteStatsFetcher) fetchMisskey(ctx context.Context, host, username st
 	}
 	req.Header.Set("Content-Type", "application/json")
 	req.Header.Set("Accept", "application/json")
+	if f.userAgent != "" {
+		req.Header.Set("User-Agent", f.userAgent)
+	}
 	resp, err := f.client.Do(req)
 	if err != nil {
 		slog.Debug("remoteStats: misskey fetch failed", "host", host, "username", username, "err", err)
@@ -261,6 +271,9 @@ func (f *RemoteStatsFetcher) fetchMastodon(ctx context.Context, host, username s
 		return nil
 	}
 	req.Header.Set("Accept", "application/json")
+	if f.userAgent != "" {
+		req.Header.Set("User-Agent", f.userAgent)
+	}
 	resp, err := f.client.Do(req)
 	if err != nil {
 		slog.Debug("remoteStats: mastodon fetch failed", "host", host, "username", username, "err", err)

--- a/internal/core/federation/remote_stats.go
+++ b/internal/core/federation/remote_stats.go
@@ -172,10 +172,34 @@ func isValidHost(host string) bool {
 	return parsed.Host == host && parsed.Path == "/"
 }
 
-// fetchRemote performs the actual HTTP POST to https://<host>/api/users/show.
-// Misskey 系 instance は username + host=null で local user lookup できる。
-// Mastodon 等 Misskey 互換でない instance は 4xx/404 を返すので nil を出す。
+// fetchRemote retrieves public stats for a remote user via a fallback chain:
+//  1. Misskey-compat: POST `/api/users/show` with `{username, host:null}`
+//  2. Mastodon-compat: GET `/api/v1/accounts/lookup?acct=<username>`
+//
+// 各経路は 4xx/404/parse-fail で nil を返し、次の fallback に進む。全経路
+// 失敗時は nil で local 観測値 fallback (#1154)。本 fetcher は mk-go 独自
+// 拡張 (#943) なので upstream Misskey TS に対応 endpoint なく、
+// Mastodon 系 instance (= Mastodon / Pleroma / Akkoma / Iceshrimp 等)
+// との相互運用は本 chain で確保する。
+//
+// 将来拡張: 3rd fallback として ActivityPub actor の `outbox.totalItems` /
+// `followers.totalItems` / `following.totalItems` を採用すれば、本 chain で
+// 拾えない fediverse 実装も覆える (= universal だが追加 3 round-trip 必要)。
+// 本 PR scope 外、需要が出たら別 issue で扱う。
 func (f *RemoteStatsFetcher) fetchRemote(ctx context.Context, host, username string) *RemoteUserStats {
+	if stats := f.fetchMisskey(ctx, host, username); stats != nil {
+		return stats
+	}
+	if stats := f.fetchMastodon(ctx, host, username); stats != nil {
+		return stats
+	}
+	return nil
+}
+
+// fetchMisskey calls the Misskey-compat `/api/users/show` endpoint.
+// `{username, host:null}` で origin instance のローカル user lookup を要求する
+// shape は upstream Misskey TS の paramDef と一致。
+func (f *RemoteStatsFetcher) fetchMisskey(ctx context.Context, host, username string) *RemoteUserStats {
 	endpoint := fmt.Sprintf("https://%s/api/users/show", host)
 	body, _ := json.Marshal(map[string]any{
 		"username": username,
@@ -189,15 +213,13 @@ func (f *RemoteStatsFetcher) fetchRemote(ctx context.Context, host, username str
 	req.Header.Set("Accept", "application/json")
 	resp, err := f.client.Do(req)
 	if err != nil {
-		slog.Debug("remoteStats: fetch failed", "host", host, "username", username, "err", err)
+		slog.Debug("remoteStats: misskey fetch failed", "host", host, "username", username, "err", err)
 		return nil
 	}
 	defer resp.Body.Close()
 	if resp.StatusCode != http.StatusOK {
 		return nil
 	}
-	// 過大 response は driver / reverse proxy 側で 4xx を返す前提なので、ここは
-	// 念のため 1MB 程度で切る。Misskey UserDetailed の JSON は通常 5KB 未満。
 	limited := io.LimitReader(resp.Body, 1<<20)
 	var payload struct {
 		NotesCount     *int `json:"notesCount"`
@@ -213,6 +235,56 @@ func (f *RemoteStatsFetcher) fetchRemote(ctx context.Context, host, username str
 	stats := &RemoteUserStats{}
 	if payload.NotesCount != nil {
 		stats.NotesCount = *payload.NotesCount
+	}
+	if payload.FollowersCount != nil {
+		stats.FollowersCount = *payload.FollowersCount
+	}
+	if payload.FollowingCount != nil {
+		stats.FollowingCount = *payload.FollowingCount
+	}
+	return stats
+}
+
+// fetchMastodon calls the Mastodon-compat `/api/v1/accounts/lookup` endpoint.
+// `?acct=<username>` で local account の数値統計を取得する (= 同一 host の
+// local user lookup なので host suffix 不要)。Pleroma / Akkoma / Iceshrimp
+// 等の Mastodon API 互換実装でも動作する (#1154)。
+//
+// response field mapping (Mastodon → mk-go):
+//   - statuses_count   → NotesCount
+//   - followers_count  → FollowersCount
+//   - following_count  → FollowingCount
+func (f *RemoteStatsFetcher) fetchMastodon(ctx context.Context, host, username string) *RemoteUserStats {
+	endpoint := fmt.Sprintf("https://%s/api/v1/accounts/lookup?acct=%s", host, url.QueryEscape(username))
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, endpoint, nil)
+	if err != nil {
+		return nil
+	}
+	req.Header.Set("Accept", "application/json")
+	resp, err := f.client.Do(req)
+	if err != nil {
+		slog.Debug("remoteStats: mastodon fetch failed", "host", host, "username", username, "err", err)
+		return nil
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return nil
+	}
+	limited := io.LimitReader(resp.Body, 1<<20)
+	var payload struct {
+		StatusesCount  *int `json:"statuses_count"`
+		FollowersCount *int `json:"followers_count"`
+		FollowingCount *int `json:"following_count"`
+	}
+	if err := json.NewDecoder(limited).Decode(&payload); err != nil {
+		return nil
+	}
+	if payload.StatusesCount == nil && payload.FollowersCount == nil && payload.FollowingCount == nil {
+		return nil
+	}
+	stats := &RemoteUserStats{}
+	if payload.StatusesCount != nil {
+		stats.NotesCount = *payload.StatusesCount
 	}
 	if payload.FollowersCount != nil {
 		stats.FollowersCount = *payload.FollowersCount

--- a/internal/core/federation/remote_stats_test.go
+++ b/internal/core/federation/remote_stats_test.go
@@ -105,11 +105,43 @@ func TestRemoteStatsFetcher_Fetch_MisskeyPathSkipsMastodon(t *testing.T) {
 	assert.Equal(t, int32(0), atomic.LoadInt32(&mastodonHits), "Misskey success の場合 Mastodon fallback は呼ばない")
 }
 
+// TestRemoteStatsFetcher_Fetch_UserAgentSent guards #1154 review follow-up:
+// 設定された User-Agent が Misskey path / Mastodon path 両方の outbound
+// request に乗ること (= remote operator から fetch 元を識別できる礼儀 +
+// rate-limit policy の判断材料を提供)。
+func TestRemoteStatsFetcher_Fetch_UserAgentSent(t *testing.T) {
+	const expectedUA = "mk-go/test (https://example.com)"
+	var misskeyUA, mastodonUA string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/api/users/show":
+			misskeyUA = r.Header.Get("User-Agent")
+			http.Error(w, "not found", http.StatusNotFound)
+		case "/api/v1/accounts/lookup":
+			mastodonUA = r.Header.Get("User-Agent")
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"id":"1","username":"alice","statuses_count":1}`))
+		}
+	}))
+	defer srv.Close()
+
+	f := newRemoteStatsFetcherWithTransport(redirectTransport{target: srv.URL})
+	// userAgent は constructor で渡す pattern (production) と test helper の
+	// 両立のため、test では直接 field に代入する。NewRemoteStatsFetcher 経由
+	// だと httptest server に向け直すための custom transport が使えない。
+	f.userAgent = expectedUA
+
+	stats := f.Fetch(context.Background(), "fediverse.example", "alice")
+	require.NotNil(t, stats)
+	assert.Equal(t, expectedUA, misskeyUA, "Misskey path に UA が乗る")
+	assert.Equal(t, expectedUA, mastodonUA, "Mastodon path に UA が乗る")
+}
+
 func TestRemoteStatsFetcher_Fetch_NilOrEmpty(t *testing.T) {
 	var f *RemoteStatsFetcher
 	assert.Nil(t, f.Fetch(context.Background(), "h", "u"))
 
-	f = NewRemoteStatsFetcher(nil)
+	f = NewRemoteStatsFetcher(nil, "")
 	assert.Nil(t, f.Fetch(context.Background(), "", "u"))
 	assert.Nil(t, f.Fetch(context.Background(), "h", ""))
 }

--- a/internal/core/federation/remote_stats_test.go
+++ b/internal/core/federation/remote_stats_test.go
@@ -39,6 +39,72 @@ func TestRemoteStatsFetcher_Fetch_Success(t *testing.T) {
 	assert.Equal(t, int32(1), atomic.LoadInt32(&hits))
 }
 
+// TestRemoteStatsFetcher_Fetch_MastodonFallback guards #1154: Mastodon 系
+// instance (= Misskey 互換 endpoint を持たない) でも Mastodon API
+// (`/api/v1/accounts/lookup`) 経由で stats を取得できる fallback chain。
+// /api/users/show は 404 を返し、/api/v1/accounts/lookup が成功する
+// scenario をシミュレートする。
+func TestRemoteStatsFetcher_Fetch_MastodonFallback(t *testing.T) {
+	var misskeyHits, mastodonHits int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/api/users/show":
+			atomic.AddInt32(&misskeyHits, 1)
+			http.Error(w, "not found", http.StatusNotFound)
+		case "/api/v1/accounts/lookup":
+			atomic.AddInt32(&mastodonHits, 1)
+			// query string で username が来ているはず。
+			if r.URL.Query().Get("acct") != "alice" {
+				http.Error(w, "missing acct", http.StatusBadRequest)
+				return
+			}
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"id":"1","username":"alice","statuses_count":123,"followers_count":45,"following_count":6}`))
+		default:
+			http.Error(w, "unexpected", http.StatusNotFound)
+		}
+	}))
+	defer srv.Close()
+
+	f := newRemoteStatsFetcherWithTransport(redirectTransport{target: srv.URL})
+
+	stats := f.Fetch(context.Background(), "mastodon.example", "alice")
+	require.NotNil(t, stats, "Mastodon fallback で stats が取得できる")
+	assert.Equal(t, 123, stats.NotesCount, "statuses_count → NotesCount")
+	assert.Equal(t, 45, stats.FollowersCount, "followers_count → FollowersCount")
+	assert.Equal(t, 6, stats.FollowingCount, "following_count → FollowingCount")
+
+	// fallback chain が両 endpoint を順に叩いていることを確認。
+	assert.Equal(t, int32(1), atomic.LoadInt32(&misskeyHits), "Misskey endpoint を先に試した")
+	assert.Equal(t, int32(1), atomic.LoadInt32(&mastodonHits), "Misskey 404 → Mastodon fallback 実行")
+}
+
+// TestRemoteStatsFetcher_Fetch_MisskeyPathSkipsMastodon: Misskey endpoint
+// が success を返したら Mastodon fallback は呼ばれない (= 余分な HTTP
+// request を出さない)。
+func TestRemoteStatsFetcher_Fetch_MisskeyPathSkipsMastodon(t *testing.T) {
+	var misskeyHits, mastodonHits int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/api/users/show":
+			atomic.AddInt32(&misskeyHits, 1)
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"notesCount":10,"followersCount":20,"followingCount":30}`))
+		case "/api/v1/accounts/lookup":
+			atomic.AddInt32(&mastodonHits, 1)
+			http.Error(w, "should not be called", http.StatusInternalServerError)
+		}
+	}))
+	defer srv.Close()
+
+	f := newRemoteStatsFetcherWithTransport(redirectTransport{target: srv.URL})
+	stats := f.Fetch(context.Background(), "misskey.example", "bob")
+	require.NotNil(t, stats)
+	assert.Equal(t, 10, stats.NotesCount)
+	assert.Equal(t, int32(1), atomic.LoadInt32(&misskeyHits))
+	assert.Equal(t, int32(0), atomic.LoadInt32(&mastodonHits), "Misskey success の場合 Mastodon fallback は呼ばない")
+}
+
 func TestRemoteStatsFetcher_Fetch_NilOrEmpty(t *testing.T) {
 	var f *RemoteStatsFetcher
 	assert.Nil(t, f.Fetch(context.Background(), "h", "u"))
@@ -203,7 +269,13 @@ type redirectTransport struct {
 
 func (rt redirectTransport) RoundTrip(req *http.Request) (*http.Response, error) {
 	rewritten := req.Clone(req.Context())
-	parsed, err := http.NewRequest(req.Method, rt.target+req.URL.Path, rewritten.Body)
+	// RawQuery も保持して rewrite する (= Mastodon API の ?acct= 等の
+	// query string を維持、#1154 で発覚)。
+	target := rt.target + req.URL.Path
+	if req.URL.RawQuery != "" {
+		target += "?" + req.URL.RawQuery
+	}
+	parsed, err := http.NewRequest(req.Method, target, rewritten.Body)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/server/router.go
+++ b/internal/server/router.go
@@ -1179,7 +1179,7 @@ func (s *Server) setupRoutes() {
 	usersHandler.SetUserRepo(userRepo)
 	usersHandler.SetNoteReactionRepo(reactionRepo)
 	usersHandler.SetRemoteStatsFetcher(&remoteStatsFetcherAdapter{
-		fetcher: corefederation.NewRemoteStatsFetcher(s.config.AllowedPrivateNetworks, s.outboundOpts()...),
+		fetcher: corefederation.NewRemoteStatsFetcher(s.config.AllowedPrivateNetworks, s.config.UserAgent, s.outboundOpts()...),
 	})
 	api.POST("/users/show", usersHandler.Show)
 	api.POST("/users/search", usersHandler.Search,


### PR DESCRIPTION
## Summary

PR #1147 で `/api/users/{followers,following}` の embed user に `RemoteStatsFetcher` を適用したが、**Mastodon 系サーバーのユーザー (= Mastodon / Pleroma / Akkoma / Iceshrimp 等) の counts が全て 0 で表示される** (テストユーザー報告経路、UDS 実機確認済)。

原因: `fetchRemote` が Misskey 専用 `/api/users/show` (JSON POST) しか叩いておらず、Mastodon 系は同 URL を持たないので 404 → nil fallback → local 観測値 (= 連合経由で見えた部分集合のみ、典型 0) のまま表示される。

## 主な変更点

| File | 変更 |
|---|---|
| `internal/core/federation/remote_stats.go` | `fetchRemote` を fallback chain に refactor、`fetchMisskey` / `fetchMastodon` 分離 |
| `internal/core/federation/remote_stats_test.go` | regression guard 2 件 + redirectTransport の RawQuery 維持 fix |

### Fallback chain

| order | endpoint | shape |
|---|---|---|
| 1 | `POST /api/users/show` (Misskey) | `{notesCount, followersCount, followingCount}` |
| 2 | `GET /api/v1/accounts/lookup?acct=<username>` (Mastodon) | `{statuses_count, followers_count, following_count}` |
| - | (全部失敗) | nil → caller が local 観測値 fallback |

### Field mapping (Mastodon → mk-go)
- `statuses_count` → `NotesCount`
- `followers_count` → `FollowersCount`
- `following_count` → `FollowingCount`

### 既存 + 追加の利点

- **既存 Misskey 経路は untouched** — success 時は Mastodon fallback を呼ばない (= 余分な HTTP request 無し)
- **caching は変更なし** — Misskey 成功 / Mastodon 成功 / 全失敗 のいずれも 1h positive / 5min negative cache
- **upstream Misskey TS 非対応** — 本 fetcher 自体が mk-go 独自拡張 (PR #943)、drop-in 互換制約から自由

## Drop-in 互換

- API response shape 変更なし
- Mastodon 系 user の counts が **0 → 実値** で表示される方向のみ
- Misskey 系 user は影響なし (= 同じ Misskey endpoint 経路で成功)

## テスト

### 追加 regression guard (2 件)

- `TestRemoteStatsFetcher_Fetch_MastodonFallback`: Misskey endpoint が 404 → Mastodon fallback で取得成功 + field mapping を assert
- `TestRemoteStatsFetcher_Fetch_MisskeyPathSkipsMastodon`: Misskey success の場合 Mastodon fallback は呼ばない (= 余分 request 無し) を assert

### redirectTransport の bug fix (副産物)

test 用 transport が `req.URL.RawQuery` を落とすbug があり、Mastodon の `?acct=` query string が server に届かなかった。RawQuery を保持するよう修正、既存 path-only test は影響なし。

### 将来拡張案 (本 PR scope 外)

- 3rd fallback: ActivityPub actor の `outbox.totalItems` / `followers.totalItems` / `following.totalItems` 採用で universal fediverse 対応
- 3 round-trip 追加コストあり、需要が出たら別 issue で扱う

## Closes

Closes #1154