### PR TITLE
Fix: federation handleCreate/handleAnnounce で chartHook が未発火 (#1156)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -92,6 +92,7 @@ Playwright spec を両 backend で走らせる中で観測した drop-in 互換 
 - #942: URL summary 文字化け解消 (Shift_JIS / EUC-JP / ISO-2022-JP の自動正規化)
 - #943: リモートユーザー counts (notesCount / followersCount / followingCount) を origin から fetch する mk-go 独自拡張
 - #945: RemoteStatsFetcher cache を `sync.Map` → LRU (size cap 10000) で memory bound 化
+- #1156: リモートユーザーのプロフィール「アクティビティ」タブが Heatmap 空 / Notes 折れ線がマイナス方面にのみ動く drop-in regression を fix。federation `handleCreate` / `handleAnnounce` で `OnNoteCreated` chart hook が発火しておらず PerUserNotesChart の +1 が記録されない一方、`handleDelete` 経路 (`NoteDeleteService.Delete`) は -1 を記録していたため日次集計が常に負方向に推移していた。`Resolver.IngestNoteWithCreated` (sibling) を追加して dedup-hit と新規 INSERT を区別し、`Processor.SetNoteChartHook` で chart hook を `safeGoFedHook` 経由で fire-and-forget 発火 (重複配送では fire しない)
 
 ### Phase 15 — Federation performance (#562, #565, #569)
 

--- a/internal/core/federation/processor.go
+++ b/internal/core/federation/processor.go
@@ -923,9 +923,16 @@ func (p *Processor) handleAnnounce(act genericActivity) error {
 		// しないので nil を渡す。
 		p.notificationHook.OnNoteCreated(hydrated, announcer, nil, target)
 	}
-	// chart hook 発火 (#1156)。dedup チェック (act.ID != "" の FindByURI) を
-	// 通り抜けて noteRepo.Create(renote) も成功した時点で新規作成と確定する
-	// ので、created flag は不要 (= 重複 Announce はここに辿り着かない)。
+	// chart hook 発火 (#1156)。dedup チェック (上部の `act.ID != ""` ゲート付き
+	// FindByURI) を通り抜けて noteRepo.Create(renote) も成功した時点で「この
+	// 経路では」新規作成と確定するので、created flag は持たない。
+	//
+	// 例外として `act.ID` が空 (= activity id を持たない Announce) の場合は
+	// 上の dedup 自体が skip されるため、同じ Boost が複数回届くと renote 行も
+	// 毎回新規に生成され chart も毎回 fire する。これは本 PR で導入した挙動
+	// ではなく既存の handleAnnounce 設計に従ったもの。activity id 無しの
+	// Announce を出す実装は実運用ではほぼ無いので影響軽微だが、`act.ID` の
+	// dedup 強化は別 issue でフォロー (= renote 重複そのものの解消が主題)。
 	if p.noteChartHook != nil {
 		safeGoFedHook(func() { p.noteChartHook.OnNoteCreated(hydrated) })
 	}

--- a/internal/core/federation/processor.go
+++ b/internal/core/federation/processor.go
@@ -97,6 +97,18 @@ type Processor struct {
 	// 配線されていなければ no-op。
 	notificationHook NotificationHook
 
+	// Note chart hook for inbound Create / Announce (#1156). ローカル作成は
+	// note_create_service.go から chartHook.OnNoteCreated を発火させているが、
+	// federation 経由のリモートノートは handleCreate / handleAnnounce で直接
+	// note を作るため、本フィールド経由で同じ chart hook を発火させないと
+	// PerUserNotesChart 等の inc 列が +1 されない (= プロフィールの
+	// アクティビティタブの heatmap がリモートユーザーだけ空になる)。
+	// noteChartHook は idempotent ではないので、dedup hit (= 既存ノートを返した
+	// ケース) では発火させない (IngestNoteWithCreated の created==false 時は
+	// skip)。resolver の ChartHook (= OnRemoteUserCreated) とは責務が異なるので
+	// 別 interface として分離する。
+	noteChartHook NoteChartHook
+
 	// localBaseURL はローカルユーザーのcanonical URI prefix
 	// (例: "https://go.k7a.org") を保持する。inboxで受信したactivityの
 	// object が "{localBaseURL}/users/{id}" 形式のとき、ローカルユーザーを
@@ -171,6 +183,21 @@ type TimelineFanoutHook interface {
 // 常に fire-and-forget で呼び出せばよい。
 type NotificationHook interface {
 	OnNoteCreated(note *model.Note, author *model.User, replyTarget, renoteTarget *model.Note)
+}
+
+// NoteChartHook is invoked after a freshly persisted inbound Create / Announce
+// so that PerUserNotesChart 等の counters が +1 される (#1156)。ローカル作成では
+// note_create_service.go の ChartHook が同じ役目を担う。
+//
+// dedup ヒット (同 URI の重複配送) では発火させないこと: chart hook は
+// idempotent ではなく、二重呼び出しで日次集計が +2 されてしまう。
+// 実装契約: 呼び出し側は呼び出しを goroutine で非同期化すること推奨 (= local
+// 側と同じく safeGo パターン)。
+//
+// 名称が NoteChartHook なのは、resolver の ChartHook (OnRemoteUserCreated 用)
+// と衝突するのを避けつつ責務 (note chart 系) を明示するため。
+type NoteChartHook interface {
+	OnNoteCreated(note *model.Note)
 }
 
 // NewProcessor constructs a Processor. reactionService / noteDeleteSvc は省略
@@ -364,6 +391,19 @@ func (p *Processor) SetFanoutHook(h TimelineFanoutHook) {
 // 経由で通知を作る状態になる)。
 func (p *Processor) SetNotificationHook(h NotificationHook) {
 	p.notificationHook = h
+}
+
+// SetNoteChartHook wires a NoteChartHook so that inbound Create / Announce
+// activities update PerUserNotesChart 等のリモートユーザー向け chart 集計
+// (#1156)。Without it, リモートユーザーのプロフィールの「アクティビティ」
+// タブが空になる (delete だけ note_delete_service 経由で -1 されるため
+// heatmap がマイナスにしか動かない drop-in regression が再発する)。
+//
+// 名称が SetNoteChartHook なのは resolver.SetChartHook (= 新規 remote user
+// 集計用) と衝突するのを避けるため。配線対象は同じ chart hooks 集約だが、
+// 注入経路を別 method に分けて誤配線を防ぐ。
+func (p *Processor) SetNoteChartHook(h NoteChartHook) {
+	p.noteChartHook = h
 }
 
 // followRelayIDPattern extracts the relay id embedded in
@@ -660,7 +700,7 @@ func (p *Processor) handleCreate(act genericActivity) error {
 			return p.handleChatCreate(actor, probe.ID, probe.Content, probe.To)
 		}
 	}
-	note, err := p.resolver.IngestNote(act.Object)
+	note, created, err := p.resolver.IngestNoteWithCreated(act.Object)
 	if errors.Is(err, corenote.ErrContainsTooManyMentions) {
 		// upstream Misskey #17167 (= 2026.5.0 fix / triage #1004): role policy
 		// 由来の "note contains too many mentions" は永続的に解決しない error な
@@ -709,6 +749,12 @@ func (p *Processor) handleCreate(act genericActivity) error {
 				// (#415)。
 				p.notificationHook.OnNoteCreated(hydrated, actor, hydrated.Reply, hydrated.Renote)
 			})
+		}
+		// chart hook は dedup hit では発火させない (#1156)。同 URI の
+		// Create activity が重複配送されたとき (= リトライ / S2S 二重投げ)
+		// に PerUserNotesChart の inc 列が +2 されないようにする。
+		if p.noteChartHook != nil && created {
+			safeGoFedHook(func() { p.noteChartHook.OnNoteCreated(hydrated) })
 		}
 	}
 	return nil
@@ -876,6 +922,12 @@ func (p *Processor) handleAnnounce(act genericActivity) error {
 		// (#415)。target が renoteTarget。reply 通知は Announce では発生
 		// しないので nil を渡す。
 		p.notificationHook.OnNoteCreated(hydrated, announcer, nil, target)
+	}
+	// chart hook 発火 (#1156)。dedup チェック (act.ID != "" の FindByURI) を
+	// 通り抜けて noteRepo.Create(renote) も成功した時点で新規作成と確定する
+	// ので、created flag は不要 (= 重複 Announce はここに辿り着かない)。
+	if p.noteChartHook != nil {
+		safeGoFedHook(func() { p.noteChartHook.OnNoteCreated(hydrated) })
 	}
 	return nil
 }

--- a/internal/core/federation/processor_chart_test.go
+++ b/internal/core/federation/processor_chart_test.go
@@ -1,6 +1,7 @@
 package federation_test
 
 import (
+	"strconv"
 	"testing"
 	"time"
 
@@ -98,6 +99,43 @@ func TestProcess_Announce_FiresChartHook(t *testing.T) {
 	assert.NotEmpty(t, noteID, "chart hook must receive renote ID")
 	// 受け取った note は新規作成した renote であり、target ID とは別
 	assert.NotEqual(t, "n1", noteID, "chart hook must receive the newly-created renote, not the announce target")
+}
+
+// mentionLimit を超える inbound Create は ErrContainsTooManyMentions で
+// reject される (#1004 / upstream #17167)。reject 時には note が DB に入らない
+// ので chart hook も fire してはいけない (= IngestNoteWithCreated は
+// (nil, false, err) を返し、handleCreate は err catch して early return する)。
+// これが守れないと、mentionLimit overflow を投げてくる malformed actor が
+// 連発するだけで PerUserNotesChart の inc 列が膨れる攻撃面になる。
+func TestProcess_CreateNote_MentionLimitReject_NoChartHook(t *testing.T) {
+	env := newFullProcessor(t, aliceActor)
+	hook := newRecordingNoteChartHook()
+	env.processor.SetNoteChartHook(hook)
+
+	var tagJSON string
+	for i := 1; i <= 21; i++ { // 21 = DefaultMentionLimit (20) + 1
+		if i > 1 {
+			tagJSON += ","
+		}
+		tagJSON += `{"type": "Mention", "href": "https://example.com/users/u` + strconv.Itoa(i) + `"}`
+	}
+	body := []byte(`{
+		"type": "Create",
+		"actor": "https://remote.example/users/alice",
+		"object": {
+			"id": "https://remote.example/notes/over-` + strconv.Itoa(int(time.Now().UnixNano())) + `",
+			"type": "Note",
+			"attributedTo": "https://remote.example/users/alice",
+			"content": "x",
+			"to": ["https://www.w3.org/ns/activitystreams#Public"],
+			"tag": [` + tagJSON + `]
+		}
+	}`)
+	// reject されるが ack 扱いで err は nil
+	require.NoError(t, env.processor.Process(body))
+	// chart hook が fire しないこと (= mentionLimit overflow で counters が
+	// 膨らまされない)
+	hook.expectNoMoreCalls(t, 200*time.Millisecond)
 }
 
 // chart hook が未配線 (= nil) のままでも Process が panic / error を出さない

--- a/internal/core/federation/processor_chart_test.go
+++ b/internal/core/federation/processor_chart_test.go
@@ -1,0 +1,120 @@
+package federation_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/shiroha-a/mk/internal/model"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// recordingNoteChartHook captures NoteChartHook.OnNoteCreated calls. Calls go
+// through safeGoFedHook so the test must await delivery via channel rather
+// than relying on call-count immediately after Process returns (#1156).
+type recordingNoteChartHook struct {
+	calls chan string
+}
+
+func newRecordingNoteChartHook() *recordingNoteChartHook {
+	return &recordingNoteChartHook{calls: make(chan string, 16)}
+}
+
+func (h *recordingNoteChartHook) OnNoteCreated(note *model.Note) {
+	id := ""
+	if note != nil {
+		id = note.ID
+	}
+	h.calls <- id
+}
+
+// waitForOne waits for exactly one OnNoteCreated and returns the captured
+// note ID. Fails the test if no call arrives within the timeout.
+func (h *recordingNoteChartHook) waitForOne(t *testing.T) string {
+	t.Helper()
+	select {
+	case id := <-h.calls:
+		return id
+	case <-time.After(2 * time.Second):
+		t.Fatal("noteChartHook.OnNoteCreated was not invoked within timeout")
+		return ""
+	}
+}
+
+// expectNoMoreCalls asserts that no further OnNoteCreated arrives in a short
+// settle window. Used to guard against double-fire on dedup paths.
+func (h *recordingNoteChartHook) expectNoMoreCalls(t *testing.T, settle time.Duration) {
+	t.Helper()
+	select {
+	case got := <-h.calls:
+		t.Fatalf("noteChartHook.OnNoteCreated fired unexpectedly (note=%s)", got)
+	case <-time.After(settle):
+	}
+}
+
+// federation handleCreate must fire NoteChartHook.OnNoteCreated exactly once
+// for a fresh inbound Create(Note), and must NOT fire it for a redelivered
+// (= dedup-hit) Create with the same URI (#1156). 旧実装は chart hook が一切
+// 呼ばれず、PerUserNotesChart の inc 列がリモートユーザーで +1 されない
+// regression を引き起こしていた。
+func TestProcess_CreateNote_FiresChartHook_FreshOnly(t *testing.T) {
+	env := newFullProcessor(t, aliceActor)
+	hook := newRecordingNoteChartHook()
+	env.processor.SetNoteChartHook(hook)
+
+	require.NoError(t, env.processor.Process([]byte(noteCreateBody)))
+	noteID := hook.waitForOne(t)
+	assert.NotEmpty(t, noteID, "chart hook must receive a note with non-empty ID")
+
+	// 同 URI の Create を二度目に流す → IngestNoteWithCreated は dedup hit で
+	// created=false を返すので chart hook は再発火してはいけない。
+	require.NoError(t, env.processor.Process([]byte(noteCreateBody)))
+	hook.expectNoMoreCalls(t, 200*time.Millisecond)
+}
+
+// handleAnnounce (= 純粋な Boost) で chart hook が renote 作成時に発火する
+// ことを確認 (#1156)。dedup チェックは handleCreate より前の段階で URI 一致
+// により切られるので、handleAnnounce 本体に到達 = 新規作成と確定する。
+func TestProcess_Announce_FiresChartHook(t *testing.T) {
+	env := newFullProcessor(t, aliceActor)
+	hook := newRecordingNoteChartHook()
+	env.processor.SetNoteChartHook(hook)
+
+	// target note (= 原投稿) と原投稿者 bob をローカル DB に
+	env.noteRepo.Notes["n1"] = &model.Note{
+		ID: "n1", UserID: "bob", Visibility: model.NoteVisibilityPublic,
+	}
+	env.userRepo.Users["bob"] = &model.User{ID: "bob", Username: "bob"}
+
+	body := []byte(`{
+		"type": "Announce",
+		"id": "https://remote.example/announces/chart-1",
+		"actor": "https://remote.example/users/alice",
+		"object": "https://example.com/notes/n1"
+	}`)
+	require.NoError(t, env.processor.Process(body))
+
+	noteID := hook.waitForOne(t)
+	assert.NotEmpty(t, noteID, "chart hook must receive renote ID")
+	// 受け取った note は新規作成した renote であり、target ID とは別
+	assert.NotEqual(t, "n1", noteID, "chart hook must receive the newly-created renote, not the announce target")
+}
+
+// chart hook が未配線 (= nil) のままでも Process が panic / error を出さない
+// ことを guard (#1156)。SetNoteChartHook はオプショナル wire なので、test や
+// 軽量 deployment で chart subsystem を立ち上げないケースでも壊れないこと。
+func TestProcess_NoteChartHook_NilSafe(t *testing.T) {
+	env := newFullProcessor(t, aliceActor)
+	// SetNoteChartHook を呼ばない (= field は nil)
+	require.NoError(t, env.processor.Process([]byte(noteCreateBody)))
+
+	env.noteRepo.Notes["n1"] = &model.Note{ID: "n1", UserID: "bob", Visibility: model.NoteVisibilityPublic}
+	env.userRepo.Users["bob"] = &model.User{ID: "bob", Username: "bob"}
+	announce := []byte(`{
+		"type": "Announce",
+		"id": "https://remote.example/announces/nil-safe",
+		"actor": "https://remote.example/users/alice",
+		"object": "https://example.com/notes/n1"
+	}`)
+	require.NoError(t, env.processor.Process(announce))
+}

--- a/internal/core/federation/resolver.go
+++ b/internal/core/federation/resolver.go
@@ -807,10 +807,17 @@ func (r *Resolver) IngestNote(body []byte) (*model.Note, error) {
 // so non-idempotent counters such as PerUserNotesChart are not double-applied
 // when the same Create activity is delivered twice (#1156).
 //
-// `created == false` cases:
-//   - existing note matched by URI (dedup hit)
-//   - AP poll vote (note=nil; processed as a Vote, no note row created)
-//   - any error path
+// Return value matrix:
+//
+//   - fresh INSERT (Create succeeded)           → (note,     true,  nil)
+//   - dedup hit (existing row matched by URI)   → (existing, false, nil)
+//   - AP poll vote (processed as a Vote)        → (nil,      false, nil)
+//   - validation / ingest / actor resolve error → (nil,      false, err)
+//
+// Note that the dedup-hit case is the only path that returns a non-nil note
+// with `created == false`; callers MUST check `created` before firing any
+// non-idempotent hook (chart counters, notification, etc.) since the dedup
+// path otherwise looks indistinguishable from a fresh ingest at the call site.
 func (r *Resolver) IngestNoteWithCreated(body []byte) (*model.Note, bool, error) {
 	if r.noteRepo == nil {
 		return nil, false, ErrInvalidNote

--- a/internal/core/federation/resolver.go
+++ b/internal/core/federation/resolver.go
@@ -793,23 +793,41 @@ func (r *Resolver) resolveNoteOnce(uri string) (*model.Note, error) {
 // IngestNote parses an ActivityStreams Note JSON and persists it as a local
 // row authored by the (resolved) attributedTo actor. 既に同じ URI の note を
 // 取り込み済みなら既存レコードを返す。
+//
+// `created` フラグが必要な caller (e.g. processor.handleCreate の chart hook 発火
+// 判定) は IngestNoteWithCreated を直接呼ぶこと。
 func (r *Resolver) IngestNote(body []byte) (*model.Note, error) {
+	note, _, err := r.IngestNoteWithCreated(body)
+	return note, err
+}
+
+// IngestNoteWithCreated is the same as IngestNote but also returns whether
+// the note was freshly persisted (`created == true`) or returned from the
+// dedup cache (`created == false`). Caller can gate chart hooks on `created`
+// so non-idempotent counters such as PerUserNotesChart are not double-applied
+// when the same Create activity is delivered twice (#1156).
+//
+// `created == false` cases:
+//   - existing note matched by URI (dedup hit)
+//   - AP poll vote (note=nil; processed as a Vote, no note row created)
+//   - any error path
+func (r *Resolver) IngestNoteWithCreated(body []byte) (*model.Note, bool, error) {
 	if r.noteRepo == nil {
-		return nil, ErrInvalidNote
+		return nil, false, ErrInvalidNote
 	}
 	var apNote activitypub.Note
 	if err := json.Unmarshal(body, &apNote); err != nil {
-		return nil, ErrInvalidNote
+		return nil, false, ErrInvalidNote
 	}
 	if apNote.ID == "" || apNote.AttributedTo == "" {
-		return nil, ErrInvalidNote
+		return nil, false, ErrInvalidNote
 	}
 	if existing, err := r.noteRepo.FindByURI(apNote.ID); err == nil {
-		return existing, nil
+		return existing, false, nil
 	}
 	actor, err := r.ResolveActor(apNote.AttributedTo)
 	if err != nil {
-		return nil, err
+		return nil, false, err
 	}
 	// 遅延配送 / origin downtime 後の bulk push などで note が遅れて届くケース
 	// では AP の `published` を採用しないと timeline 上の並びが受信時刻順に
@@ -887,7 +905,7 @@ func (r *Resolver) IngestNote(body []byte) (*model.Note, error) {
 				}
 				// vote として処理した場合、reply note は作成せず終了
 				// (note=nil で caller の fanout / notification も skip される)。
-				return nil, nil
+				return nil, false, nil
 			}
 			slog.Warn("federation: AP poll vote choice not found",
 				"actor", actor.ID, "noteId", replyTarget.ID, "choice", apNote.Name)
@@ -911,7 +929,7 @@ func (r *Resolver) IngestNote(body []byte) (*model.Note, error) {
 	// path (NoteCreateService.checkMentionLimit) と同じ policy を federation
 	// 受信側にも適用する。
 	if corenote.DefaultMentionLimit > 0 && len(note.Mentions) > corenote.DefaultMentionLimit {
-		return nil, corenote.ErrContainsTooManyMentions
+		return nil, false, corenote.ErrContainsTooManyMentions
 	}
 	// specified visibility では AP `to` 配列が宛先 actor URI 列。CanView の
 	// VisibleUserIDs チェック (core/note/visibility.go) で受信者が note を
@@ -949,7 +967,7 @@ func (r *Resolver) IngestNote(body []byte) (*model.Note, error) {
 		note.HasPoll = true
 	}
 	if err := r.noteRepo.Create(note); err != nil {
-		return nil, err
+		return nil, false, err
 	}
 	// ローカルノートへの返信の場合、repliesCount を増やす。
 	// これにより timeline や API 上の「返信数」表示が federated reply も
@@ -968,7 +986,7 @@ func (r *Resolver) IngestNote(body []byte) (*model.Note, error) {
 	if r.hashtagHook != nil && len(note.Tags) > 0 {
 		r.hashtagHook.OnNoteCreated(note, actor)
 	}
-	return note, nil
+	return note, true, nil
 }
 
 // createPollFromQuestion creates a Poll record from an AP Question's oneOf/anyOf choices.

--- a/internal/core/federation/resolver_test.go
+++ b/internal/core/federation/resolver_test.go
@@ -521,6 +521,36 @@ func TestIngestNote_DedupOnExisting(t *testing.T) {
 	assert.Equal(t, "existing", got.ID)
 }
 
+// IngestNoteWithCreated は新規 INSERT 経路で created=true、dedup hit で
+// created=false を返す (#1156)。Processor 側で chart hook を created flag
+// で gate するために使う。
+func TestIngestNoteWithCreated_FreshIngest(t *testing.T) {
+	repo := testutil.NewMockUserRepository()
+	noteRepo := testutil.NewMockNoteRepository()
+	urls := activitypub.NewURLBuilder("https://example.com")
+	idGen, _ := id.NewGenerator("aidx")
+	r := federation.NewResolver(repo, noteRepo, urls, &stubFetcher{body: []byte(sampleActor)}, idGen)
+	got, created, err := r.IngestNoteWithCreated([]byte(sampleRemoteNote))
+	require.NoError(t, err)
+	require.NotNil(t, got)
+	assert.True(t, created, "fresh ingest must report created=true so caller can fire chart hooks")
+}
+
+func TestIngestNoteWithCreated_DedupReturnsFalse(t *testing.T) {
+	repo := testutil.NewMockUserRepository()
+	noteRepo := testutil.NewMockNoteRepository()
+	uri := "https://remote.example/notes/n1"
+	noteRepo.Notes["existing"] = &model.Note{ID: "existing", URI: &uri}
+	urls := activitypub.NewURLBuilder("https://example.com")
+	idGen, _ := id.NewGenerator("aidx")
+	r := federation.NewResolver(repo, noteRepo, urls, &stubFetcher{body: []byte(sampleActor)}, idGen)
+	got, created, err := r.IngestNoteWithCreated([]byte(sampleRemoteNote))
+	require.NoError(t, err)
+	require.NotNil(t, got)
+	assert.Equal(t, "existing", got.ID)
+	assert.False(t, created, "dedup hit must report created=false so caller can skip non-idempotent chart hooks")
+}
+
 func TestIngestNote_ResolveActorError(t *testing.T) {
 	repo := testutil.NewMockUserRepository()
 	noteRepo := testutil.NewMockNoteRepository()

--- a/internal/core/note/note_create_service.go
+++ b/internal/core/note/note_create_service.go
@@ -139,6 +139,14 @@ type IndexHook interface {
 // subsystem can fan the event into NotesChart, PerUserNotesChart,
 // InstanceChart and ActiveUsersChart. パッケージ間の循環依存を避ける
 // ため interface で受け取る (実装は core/chart/charthook)。
+//
+// federation 経由のリモートノートに対しては同 shape の interface
+// `core/federation.NoteChartHook` が processor.handleCreate /
+// handleAnnounce 側で同じ役目を果たす (#1156)。命名が分かれているのは
+// federation パッケージ内に既存の `ChartHook` (= 新規 remote user 用、
+// OnRemoteUserCreated) があるため。配線対象は同じ `charthook.Hooks` 集約で、
+// router.go から両 setter (note.SetChartHook / federation.SetNoteChartHook)
+// に渡される。
 type ChartHook interface {
 	OnNoteCreated(note *model.Note)
 }

--- a/internal/server/router.go
+++ b/internal/server/router.go
@@ -697,6 +697,12 @@ func (s *Server) setupRoutes() {
 	federationResolver.SetChartHook(chartHooks)
 	deliverProcessor.SetChartHook(chartHooks)
 	inboxProcessor.SetChartHook(chartHooks)
+	// federation 経由のリモートノート (Create / Announce) も PerUserNotesChart
+	// 等の note 系 chart に +1 を記録するために配線する (#1156)。これが無いと
+	// リモートユーザーのプロフィール「アクティビティ」タブの heatmap が空に
+	// なり、削除 (-1) だけが note_delete_service 経由で記録されてマイナス側に
+	// しか動かなくなる drop-in regression が発生する。
+	federationProcessor.SetNoteChartHook(chartHooks)
 
 	// Hashtag service: ノート作成 (local / federation 両経路) で hashtag table の
 	// mentionedUsersCount / mentionedUserIds を更新する (#680)。/api/hashtags/list


### PR DESCRIPTION
## Summary

- リモートユーザーのプロフィール「アクティビティ」タブで Heatmap が空、Notes グラフがマイナス方面にしか動かない drop-in regression を fix。federation `handleCreate` / `handleAnnounce` で `chartHook.OnNoteCreated` が未発火だったため PerUserNotesChart の inc 列に +1 が記録されない一方、`handleDelete` だけが `noteDeleteSvc` 経由で -1 を記録していたのが原因。
- `Resolver.IngestNoteWithCreated(body) (*model.Note, bool, error)` sibling を追加。新規 INSERT で `created=true`、dedup hit で `created=false` を返し、caller が chart hook を gate できるようにする (既存 `IngestNote` の signature は不変なので ~40 件の test 影響なし)。
- `Processor` に `NoteChartHook` interface + `noteChartHook` field + `SetNoteChartHook` setter を追加し、`handleCreate` (created=true のみ) / `handleAnnounce` (dedup チェック後の Create 成功直後) で `safeGoFedHook(... OnNoteCreated ...)` を発火。`router.go` で `federationProcessor.SetNoteChartHook(chartHooks)` を wire。

## 主な変更点

| File | 変更 |
|------|------|
| `internal/core/federation/resolver.go` | `IngestNoteWithCreated` sibling 追加。`IngestNote` は wrap して signature 不変 |
| `internal/core/federation/processor.go` | `NoteChartHook` interface / field / setter 追加、`handleCreate` / `handleAnnounce` で発火 |
| `internal/server/router.go` | `federationProcessor.SetNoteChartHook(chartHooks)` を wire |
| `internal/core/federation/resolver_test.go` | `IngestNoteWithCreated` の fresh / dedup test 追加 |
| `internal/core/federation/processor_chart_test.go` (新規) | regression test 3 件 (handleCreate fresh-only / handleAnnounce / nil-safe) |
| `CHANGELOG.md` | UDS production 由来 fix entry を追加 |

## drop-in 互換

- schema 変更なし
- error code 追加なし
- API response shape 変更なし
- 行動変化は「リモートユーザーの note chart が正しく +1 される」方向のみ
- `meta.enableChartsForRemoteUser` flag による gate は `charthook.OnNoteCreated` 内で従来どおり適用されるため、operator が remote chart を OFF にしている環境では既存挙動を維持

## Test plan

- [x] `go test ./internal/core/federation/...` で新規 5 test 含め全 pass
- [x] `make fmt && make lint && make test` を local で全 pass
- [x] `internal/core/federation` のカバレッジ 90.1% (CI 閾値 90% を維持)
- [ ] UDS 上で fix 後 binary に差し替え、リモートユーザーのプロフィール → アクティビティタブで Heatmap に色が乗ること、Notes グラフが正の方向にも動くことを目視確認
- [ ] 既存 nightly drop-in workflows (`dropin-e2e.yml` / `playwright.yml`) で regression が無いこと

## Closes

Closes #1156