### PR TITLE
docs(upstream): Misskey 2026.5.3 → 2026.5.4 backend diff を追加

### DIFF
--- a/docs/update/20260504diff.md
+++ b/docs/update/20260504diff.md
@@ -1,0 +1,111 @@
+# Misskey 2026.5.3 → 2026.5.4 backend diff
+
+mk-go (本リポジトリ) の upstream 追従用 diff doc。**2026.5.3 → 2026.5.4 の差分のみ** を扱う。2026.3.2 → 2026.5.0 部分は [`20260500diff.md`](./20260500diff.md)、2026.5.0 → 2026.5.1 部分は [`20260501diff.md`](./20260501diff.md)、2026.5.1 → 2026.5.2 部分は [`20260502diff.md`](./20260502diff.md) を参照。
+
+> 2026.5.2 → 2026.5.3 は backend (`packages/backend/`) に変更が無かったため diff doc を省略している (frontend のみのリリース)。
+
+- 集計範囲: `misskey-dev/misskey` の `2026.5.3..2026.5.4`
+- backend (`packages/backend/`) 計 6 files / +139 / -23
+- backend src 配下の commit は **5 commits** (内 1 件は typo fix、1 件は dep bump、3 件が実コード変更)
+- 取得方法: `git -C third_party/misskey log 2026.5.3..2026.5.4 -- packages/backend/`
+
+## 移植優先度: 高 (drop-in 互換 / privacy に直結)
+
+### Chat: `chat/rooms/show` を room メンバー / 招待済 / オーナー / moderator に限定 (`hasPermissionToViewRoomInfo`)
+
+- 該当:
+  - `packages/backend/src/core/ChatService.ts` (+21 lines, 新規 method `hasPermissionToViewRoomInfo`)
+  - `packages/backend/src/server/api/endpoints/chat/rooms/show.ts` (+4 lines, gate 追加)
+- 変更内容: room の owner / member / 招待受信者 / moderator 以外は `noSuchRoom` (404) を返す。旧来は room id を知っている誰でも room 情報を packRoom 経由で取得できていた。
+
+```ts
+// ChatService.ts:573
+@bindThis
+public async hasPermissionToViewRoomInfo(meId: MiUser['id'], room: MiChatRoom) {
+    if (room.ownerId === meId) return true;
+    if (await this.isRoomMember(room, meId)) return true;
+    if (await this.chatRoomInvitationsRepository.findOneBy({ roomId: room.id, userId: meId })) return true;
+    if (await this.roleService.isModerator({ id: meId })) return true;
+    return false;
+}
+
+// chat/rooms/show.ts:54
+if (!await this.chatService.hasPermissionToViewRoomInfo(me.id, room)) {
+    throw new ApiError(meta.errors.noSuchRoom);
+}
+```
+
+- なぜ必要: drop-in 互換 + privacy。room id を知っている任意のユーザーが room の name / description / owner / member 構成等のメタ情報を取得できる状態は、Direct Message に近い chat room の性質 (CherryPick v12 互換 chat) と齟齬がある。
+- 関連 PR: misskey-dev/misskey の merge commit (`3191f8a72d` / `04f18fe919` / `6c40c96369` のいずれか、issue/PR 番号は upstream で要追跡)
+- **mk-go 該当箇所**: `internal/api/chat/handler.go:262 RoomsShow` に **権限 check が一切ない**。`h.repo.FindRoomByID(req.RoomID)` ができればそのまま `h.packRoomDetailed(room, user.ID)` を返している。`internal/core/chat/service.go` には既に `IsRoomMember` / `isRoomMemberWith` が存在するので、upstream `hasPermissionToViewRoomInfo` 相当の helper を新設 + 同経路で呼ぶ修正が必要。`ChatRoomInvitationsRepository` 相当 (招待管理 table) が mk-go にあるか要確認 (= 無ければ owner / member / moderator の 3 条件で簡略化、招待 table 追加は別 issue)。
+
+## 移植優先度: 中 (軽微な privacy / 動作差)
+
+### Announcement: 非ログイン user が user-targeted announcement にアクセスできていた穴を塞ぐ
+
+- 該当: `packages/backend/src/core/AnnouncementService.ts` (`getAnnouncement` の 9 lines 書き換え)
+- 変更内容: `me == null && announcement.userId != null` のケースで `EntityNotFoundError` を投げる。旧来は `if (me) { if (announcement.userId && announcement.userId !== me.id) throw }` の構造で、**`me == null` (= 非ログイン) のときには userId-targeted な announcement でも閲覧できてしまっていた**。
+
+```ts
+// 旧 (2026.5.3)
+if (me) {
+    if (announcement.userId && announcement.userId !== me.id) {
+        throw new EntityNotFoundError(...);
+    }
+    // ... read state check ...
+}
+
+// 新 (2026.5.4)
+if (announcement.userId && (me == null || announcement.userId !== me.id)) {
+    throw new EntityNotFoundError(...);
+}
+if (me) {
+    // ... read state check (元のまま) ...
+}
+```
+
+- なぜ必要: user-targeted announcement (= 特定 user に対する admin 通知) は当該 user のみが見るべき内容で、非ログインユーザーに leak すべきでない。
+- 関連 PR: 同じ Merge commit 群
+- **mk-go 該当箇所**: `internal/api/announcements/handler.go` を要点検。mk-go の `/announcements/show` 系 endpoint で `userId` 列を見て me==null 経路で targeted announcement を弾いているか確認 (mk-go は `ListGlobal(userId IS NULL のみ)` 経路を別に持っているので、`Show` 経路で同種の穴があるかが要点)。
+
+## 移植優先度: 影響なし (mk-go は該当機能を実装していない / lib 別)
+
+### JsonLdService: LD-Signature verify の hardening (freeze + forbidden directive + cache cap)
+
+- 該当:
+  - `packages/backend/src/core/activitypub/JsonLdService.ts` (+86 lines)
+  - `packages/backend/src/queue/processors/InboxProcessorService.ts` (verify 順序変更 +40 lines)
+- 変更内容 (upstream side):
+  - 新規 error class `JsonLdError` / `JsonLdCacheOverflowError` / `JsonLdCacheFrozenError` / `JsonLdForbiddenDirectiveError`
+  - `JsonLd` インスタンスに per-call cache (`Map<string, RemoteDocument>` 上限 256 entry) を導入
+  - `freeze()` メソッドで signature verify 中の HTTP fetch を完全停止
+  - `checkForForbiddenDirectives` で `@included` / `@graph` / `@reverse` を含む活動を弾く (JSON-LD で signature を bypass する攻撃ベクタを塞ぐ)
+  - InboxProcessor の verify 順序を `compact → checkForForbiddenDirectives → freeze → verifyRsaSignature2017` に変更
+- なぜ必要 (upstream side): JSON-LD の `@reverse` 等のディレクティブで `signature` field を 後付け置換 する spoofing 攻撃や、verify 中の `@context` 再 fetch を悪用した SSRF / DoS の対策。
+- 関連 PR: 同じ Merge commit 群 (security-related なので非公開 disclosure 経由の可能性)
+- **mk-go 該当箇所**: **影響なし**。mk-go は LD-Signature 検証 (`verifyRsaSignature2017`) を実装していない (HTTP Signature のみ。`internal/activitypub/jsonld.go` は context 短縮の軽量正規化のみで full JSON-LD pipeline を持たない、CLAUDE.md Section 1 参照)。relay 経由配送に対する LD-Signature 検証は mk-go では未対応 (既知の制限、relay 配送は HTTP Signature ベースで処理 / `#1002` 関連)。
+
+  ただし将来 mk-go に LD-Signature 検証を入れる場合は、本 hardening を最初から組み込む方が安全 (= 「JSON-LD verify」issue を切るときに本 PR の `forbiddenDirectives` set / `freeze` semantics を参照する)。
+
+### deps: `ws` 8.20.0 → 8.20.1 (security)
+
+- 該当: `packages/backend/package.json`
+- **mk-go 該当箇所**: **影響なし**。mk-go は Go の WebSocket 実装を使用 (Echo / gorilla/websocket 系)、Node の `ws` package には依存しない。
+
+### typo fix: `cannonidedData` → `cannonizedData`
+
+- 該当: `packages/backend/src/core/activitypub/JsonLdService.ts` の local 変数 rename (1 箇所)
+- **mk-go 該当箇所**: **影響なし**。mk-go では該当変数名がそもそも存在しない (full JSON-LD pipeline 未実装のため)。
+
+## サマリ
+
+| 変更 | 優先度 | mk-go 対応 |
+|------|--------|-----------|
+| `chat/rooms/show` 権限 gate | 高 | **未対応 (要 sub-issue)** |
+| `announcements` getAnnouncement の me==null 穴 | 中 | 要点検 (mk-go 側に同種穴があるか) |
+| JsonLdService hardening | 影響なし | LD-Signature verify 未実装、将来導入時に参照 |
+| InboxProcessor verify 順序 | 影響なし | 同上 |
+| ws security bump | 影響なし | lib 別 |
+| typo fix | 影響なし | 該当変数なし |
+
+**消化見込み**: 移植が必要なのは **`chat/rooms/show` 権限 gate (高) + announcements 穴の点検 (中)** の 2 件。それぞれ S サイズ (mk-go 側の helper 追加 + 既存 endpoint で gate を呼ぶ pattern、想定 100 行未満)。


### PR DESCRIPTION
## Summary

upstream Misskey の 2026.5.4 リリースに対する追従用 diff doc を追加 (`docs/update/20260504diff.md`)。**2026.5.2 → 2026.5.3 は backend に変更が無かったため省略** (frontend のみのリリース)。

過去 doc (\`20260500diff.md\` / \`20260501diff.md\` / \`20260502diff.md\`) と同じフォーマットで「集計範囲 / 取得方法 / 移植優先度別 entry / mk-go 該当箇所」を整理。

並行で fork (\`shiroha-a/misskey-ts\`) に \`2026.5.4-mk.0\` タグを push 済 (upstream \`Release: 2026.5.4\` 直上に MkModal null guard cherry-pick の 1 commit、過去の \`mk.0\` パターンを踏襲)。submodule bump はこの PR には含めず、本 diff doc を起点に sub-issue で移植 → 別 PR で bump する想定。

## 主な変更点

| 優先度 | 変更 | mk-go 影響 |
|--------|------|-----------|
| 高 | \`chat/rooms/show\` 権限 gate (\`hasPermissionToViewRoomInfo\`) | **mk-go は権限 check 完全欠如** (\`internal/api/chat/handler.go:262\`)、要 sub-issue で fix |
| 中 | \`AnnouncementService.getAnnouncement\` の me==null + user-targeted 穴 | mk-go \`internal/api/announcements/handler.go\` を要点検 |
| 影響なし | JsonLdService hardening (freeze / forbiddenDirective / cache cap) | mk-go は LD-Signature 検証を未実装 |
| 影響なし | InboxProcessor verify 順序変更 | 同上 |
| 影響なし | \`ws\` security bump (8.20.0 → 8.20.1) | Node 専用 lib、Go は別実装 |
| 影響なし | typo fix (\`cannonidedData\` → \`cannonizedData\`) | mk-go では該当変数なし |

消化見込み: 移植が必要なのは **高 + 中の 2 件** (それぞれ S サイズ、想定 100 行未満)。

## drop-in 互換 / 動作影響

- doc only 追加、コード変更なし
- 既存 docs / Makefile / CI に影響なし

## Test plan

- [x] \`20260502diff.md\` のフォーマットを踏襲して構造を揃え
- [x] mk-go 側の該当ファイル位置 (handler.go:262 等) を grep で確認済
- [x] fork (\`shiroha-a/misskey-ts\`) に \`2026.5.4-mk.0\` タグ push 済 (sha 265a4b160a)

issue なしの単独 docs PR (small self-contained docs cleanup pattern)。