### PR TITLE
Perf: handleAnnounce の fanoutHook / notificationHook を safeGoFedHook で非同期化 (#1158)

### DIFF
--- a/internal/core/federation/processor.go
+++ b/internal/core/federation/processor.go
@@ -169,9 +169,29 @@ type ChatMessageReceiver interface {
 	CreateMessageViaAP(ctx context.Context, uri string, fromUser *model.User, toUserID, text string) (*model.ChatMessage, error)
 }
 
+// Hook mutation contract (TimelineFanoutHook / NotificationHook / NoteChartHook):
+//
+// 以下 3 interface の OnNoteCreated は handleCreate / handleAnnounce 経路で
+// safeGoFedHook 経由の **並行 goroutine** から発火される (#569 / #1156 / #1158)。
+// 3 hook は同じ `*model.Note` ポインタを共有して並行実行されるため、
+// 実装側は渡された note (および各種 relation: Reply / Renote / User 等) を
+// **read-only として扱うこと**。
+//
+//   - 渡された note や relation を mutate しない (例: `note.User = ...` 禁止)
+//   - field 値の保持が必要なら呼び出し側でコピーを作る (`localUser := *note.User`
+//     等)
+//   - 集計値の Inc など hook 内 DB 書き込みは note 自体の値変更を伴わない限り OK
+//
+// 同期発火だった頃 (#569 / #1158 以前) は read-only 契約が暗黙だったが、
+// 並行発火後は契約違反が data race として顕在化するため明示する。違反疑いがある
+// ときは `-race` test で検出可能 (= queue-bench / processor_test のいずれかが
+// CONCURRENT MAP READ AND WRITE 等で落ちる)。
+
 // TimelineFanoutHook is invoked after a remote note has been persisted so
 // that timeline/streaming subscribers receive the note. パッケージ間の循環
 // 依存を避けるためinterfaceで受け取る (実装は core/timeline.FanoutHook)。
+//
+// note / author は read-only。詳細は本ファイル上部の "Hook mutation contract"。
 type TimelineFanoutHook interface {
 	OnNoteCreated(note *model.Note, author *model.User)
 }
@@ -181,6 +201,9 @@ type TimelineFanoutHook interface {
 // ローカル作成と同じ interface を使う (実装は core/notification.Hook)。
 // notifyLocalUser 側で notifiee が local かどうかを判定するため、ここでは
 // 常に fire-and-forget で呼び出せばよい。
+//
+// note / author / replyTarget / renoteTarget は read-only。詳細は本ファイル
+// 上部の "Hook mutation contract"。
 type NotificationHook interface {
 	OnNoteCreated(note *model.Note, author *model.User, replyTarget, renoteTarget *model.Note)
 }
@@ -196,6 +219,8 @@ type NotificationHook interface {
 //
 // 名称が NoteChartHook なのは、resolver の ChartHook (OnRemoteUserCreated 用)
 // と衝突するのを避けつつ責務 (note chart 系) を明示するため。
+//
+// note は read-only。詳細は本ファイル上部の "Hook mutation contract"。
 type NoteChartHook interface {
 	OnNoteCreated(note *model.Note)
 }

--- a/internal/core/federation/processor.go
+++ b/internal/core/federation/processor.go
@@ -914,14 +914,22 @@ func (p *Processor) handleAnnounce(act genericActivity) error {
 	}
 	_ = p.noteRepo.IncrementCount(target.ID, "renoteCount", 1)
 	hydrated := hydrateNoteForFanout(p.noteRepo, renote)
+	// hook はベストエフォートで safeGoFedHook 経由で非同期発火する (#1158)。
+	// handleCreate (#569) と同じく Redis LPUSH / publish 待ちで inbox worker
+	// drain を block しないことが目的。順序保証は handleCreate と同様に各 hook
+	// 側の冪等性で吸収する。closure capture する `hydrated` / `announcer` /
+	// `target` は handleAnnounce 内 local 変数で関数 return 後も生存するため
+	// goroutine 上の参照は安全 (race なし)。
 	if p.fanoutHook != nil {
-		p.fanoutHook.OnNoteCreated(hydrated, announcer)
+		safeGoFedHook(func() { p.fanoutHook.OnNoteCreated(hydrated, announcer) })
 	}
 	if p.notificationHook != nil {
 		// remote user が local note を renote した時に元投稿者へ通知を出す
 		// (#415)。target が renoteTarget。reply 通知は Announce では発生
 		// しないので nil を渡す。
-		p.notificationHook.OnNoteCreated(hydrated, announcer, nil, target)
+		safeGoFedHook(func() {
+			p.notificationHook.OnNoteCreated(hydrated, announcer, nil, target)
+		})
 	}
 	// chart hook 発火 (#1156)。dedup チェック (上部の `act.ID != ""` ゲート付き
 	// FindByURI) を通り抜けて noteRepo.Create(renote) も成功した時点で「この

--- a/internal/core/federation/processor_test.go
+++ b/internal/core/federation/processor_test.go
@@ -1506,15 +1506,18 @@ func TestProcess_AnnounceCallsFanoutHook(t *testing.T) {
 		"object": "https://example.com/notes/local1"
 	}`)
 	require.NoError(t, p.Process(body))
-	// fanoutHookが呼ばれたこと
-	require.Len(t, hook.calls, 1)
+	// fanoutHookが呼ばれたこと (#1158 で async になったので Eventually で待つ)
+	require.Eventually(t, func() bool {
+		return len(hook.snapshot()) == 1
+	}, time.Second, 10*time.Millisecond)
+	calls := hook.snapshot()
 	// Announce で作成された renote の ID が渡される
-	assert.NotEqual(t, "local1", hook.calls[0].noteID)
+	assert.NotEqual(t, "local1", calls[0].noteID)
 	// hydrateNoteForFanout により Renote relation が preload された状態で
 	// 渡される (#416: streaming payload で renote が null にならない保証)。
-	require.NotNil(t, hook.calls[0].note)
-	require.NotNil(t, hook.calls[0].note.Renote, "Renote relation must be hydrated before fanout")
-	assert.Equal(t, "local1", hook.calls[0].note.Renote.ID)
+	require.NotNil(t, calls[0].note)
+	require.NotNil(t, calls[0].note.Renote, "Renote relation must be hydrated before fanout")
+	assert.Equal(t, "local1", calls[0].note.Renote.ID)
 }
 
 func TestProcess_CreateWithoutFanoutHook(t *testing.T) {
@@ -1618,13 +1621,17 @@ func TestProcess_AnnounceCallsNotificationHook(t *testing.T) {
 	}`)
 	require.NoError(t, p.Process(body))
 
-	require.Len(t, hook.calls, 1)
+	// notificationHook が呼ばれたこと (#1158 で async になったので Eventually で待つ)
+	require.Eventually(t, func() bool {
+		return len(hook.snapshot()) == 1
+	}, time.Second, 10*time.Millisecond)
+	calls := hook.snapshot()
 	// renoteTarget に local note が渡る。hook 内部の notifyLocalUser が
 	// renoteTarget.UserID == "bob" を見て bob へ通知を送る。
-	require.NotNil(t, hook.calls[0].renoteTarget)
-	assert.Equal(t, "local1", hook.calls[0].renoteTarget.ID)
-	assert.Equal(t, "bob", hook.calls[0].renoteTarget.UserID)
-	assert.Nil(t, hook.calls[0].replyTarget, "Announce は reply ではない")
+	require.NotNil(t, calls[0].renoteTarget)
+	assert.Equal(t, "local1", calls[0].renoteTarget.ID)
+	assert.Equal(t, "bob", calls[0].renoteTarget.UserID)
+	assert.Nil(t, calls[0].replyTarget, "Announce は reply ではない")
 }
 
 func TestProcess_CreateCallsNotificationHook(t *testing.T) {


### PR DESCRIPTION
## Summary

\`handleCreate\` (#569 で対応済) と同じプロファイルに揃え、Announce (Boost) burst 時の inbox worker drain time を短縮する。chart hook は PR #1157 で既に非同期化されており、本 PR で残る 2 hook も async に揃えることで「chart hook だけ async」という非対称を解消する。

## 主な変更点

| File | 変更 |
|------|------|
| \`internal/core/federation/processor.go\` | \`handleAnnounce\` の \`fanoutHook.OnNoteCreated\` / \`notificationHook.OnNoteCreated\` を \`safeGoFedHook\` 経由で非同期発火 |
| \`internal/core/federation/processor_test.go\` | \`TestProcess_AnnounceCallsFanoutHook\` / \`TestProcess_AnnounceCallsNotificationHook\` を \`require.Eventually + snapshot()\` パターンに切り替え (handleCreate 側 \`TestProcess_CreateCallsFanoutHook\` と同じ) |

closure capture する \`hydrated\` / \`announcer\` / \`target\` は \`handleAnnounce\` 内 local 変数で関数 return 後も生存するため goroutine 上の参照は安全 (race なし)。

## drop-in 互換 / 動作影響

- schema 変更なし
- API shape 変更なし
- 外部から観測可能な挙動は同じ (hook の発火タイミングのみ非同期に変わる)
- 既存 \`TestProcess_AnnounceFromRelay_PublishesTargetWithoutRenote\` / \`TestProcess_AnnounceHappyPath\` / \`TestProcess_Announce_FiresChartHook\` 等の挙動 test も pass を維持

## Test plan

- [x] \`go test ./internal/core/federation/... -run "TestProcess_Announce"\` で 13 件全 pass
- [x] handleCreate / Announce の fanout / notification hook test 計 4 件が async 化後も pass
- [x] \`make fmt && make lint && make test\` 全 pass
- [x] federation パッケージのカバレッジ 90.1% (CI 閾値 90% を維持)
- [ ] queue-bench で Announce 受信 throughput 改善の確認 (任意、follow-up)

## 完了条件 (#1158 から転記)

- [x] \`handleAnnounce\` の \`fanoutHook.OnNoteCreated\` を \`safeGoFedHook\` でラップ
- [x] \`handleAnnounce\` の \`notificationHook.OnNoteCreated\` を \`safeGoFedHook\` でラップ
- [x] \`hydrated\` capture の race 安全性確認 (local 変数 closure capture、関数 return 後も goroutine 内で生存)
- [x] 既存 \`TestProcess_AnnounceFromRelay_PublishesTargetWithoutRenote\` 等が async 化後も pass

## Closes

Closes #1158