### PR TITLE
Perf: queue-bench に Announce mode を追加 + handleAnnounce 経路の reference 値

### DIFF
--- a/docs/queue-bench.md
+++ b/docs/queue-bench.md
@@ -15,11 +15,20 @@
 
 ### Inbound (inbox job throughput)
 
-`faker` (Go HTTPS, AP HTTP signature 直接) → 3 receiver inbox に signed Create を blast。
+`faker` (Go HTTPS, AP HTTP signature 直接) → 3 receiver inbox に signed activity を blast。
 
 - 各 receiver に faker actor を pubkey 込みで pre-seed (外部 fetch 排除)
 - `faker` は **pre-sign 並列化** で sender 側を律速から外し、receiver の verify+enqueue が bottleneck になるよう設計
 - 計測: faker → receiver の RPS (= 受信→200 までの rate) と post-send drain time
+
+#### Activity type (`INBOUND_ACTIVITY_TYPE`)
+
+faker payload は 2 種類から選択 (env で driver_inbound に渡す):
+
+- `create` (default): `Create(Note)` — handleCreate 経路を計測 (#569)
+- `announce`: `Announce(object=<receiver-local note URI>)` — handleAnnounce 経路を計測 (#1158)
+  - `seed` が各 stack に benchsender 経由で 1 件 target note を作成し、URI を `seed.json` に書き出す
+  - faker は per-(target, index) で activity.id を完全ユニーク化 (target hash 含む) して dedup 干渉を回避
 
 ## 実行
 
@@ -34,8 +43,11 @@ make queue-bench-seed
 # 3) outbound 計測
 make queue-bench-outbound
 
-# 4) inbound 計測
+# 4a) inbound 計測 (default: Create 経路)
 make queue-bench-inbound
+
+# 4b) inbound 計測 (Announce 経路、#1158 等で利用)
+INBOUND_ACTIVITY_TYPE=announce make queue-bench-inbound
 
 # 5) report 生成 (tests/queue-bench/results/queue-report.md)
 make queue-bench-report
@@ -52,8 +64,27 @@ make queue-bench-down
 `tests/queue-bench/results/`:
 
 - `outbound.json` — 生データ (per-stack drain time / hits / depth time series)
-- `inbound.json` — faker.send 統計 + per-receiver drain
+- `inbound.json` — faker.send 統計 + per-receiver drain (最後に走った activity type の値で上書き)
+- `inbound-announce-after.json` — Announce 経路の参考値 (PR #1158 適用後、2026-05-21)
 - `queue-report.md` — markdown 比較表
+
+### Announce 経路 reference 値 (PR #1158 マージ後、2026-05-21)
+
+10000 req × 3 target、concurrency 128 で計測。app コンテナは develop @ `9adc836` (PR #1161 マージ後)。
+
+| Stack | Send Duration | Effective rps | Drain time | Peak queue depth | Notes |
+|---|---|---|---|---|---|
+| mk-go (asynq) | 3.66s | 2729.9 | 47.15s | 9827 | 受信→202 まで 3 秒台 |
+| mk-go (mkq) | 3.46s | 2891.3 | 63.43s | 9912 | 同上 |
+| Misskey TS | 10.46s | 956.4 | 18.08s | 0 | worker が send と同期処理 |
+
+観測:
+
+- mk-go (async/mkq) は **TS の 2.9x** の send-side throughput (Create 経路の 3.0x と同水準)
+- Announce 経路は Create 経路と比べて -4〜-12% (HTTP signature verify + target note resolve + renote create の overhead)
+- mk-go は peak depth 9800+ まで queue を積んで worker が drain (47-63s)、TS は send と同期で peak=0
+
+PR #1158 の effect (handleAnnounce hook async 化) を before/after で数字化する作業は、bench tool の startup 安定性 (3 stack 並列起動で random に 1 stack が ok=0 になる) が解消できていないため follow-up で別途実施予定。
 
 ## 設計メモ
 

--- a/tests/queue-bench/common/driver_inbound.py
+++ b/tests/queue-bench/common/driver_inbound.py
@@ -20,6 +20,10 @@ from queue_probe import DriverKind, make_probe
 
 INBOUND_COUNT = int(os.environ.get("INBOUND_COUNT", "10000"))
 INBOUND_CONCURRENCY = int(os.environ.get("INBOUND_CONCURRENCY", "128"))
+# Activity type を切替: create (default) / announce。announce の場合は
+# seed.json から各 stack の target_note_uri を読んで faker に objects map を
+# 渡す。#1158 の handleAnnounce async 化の効果を計測するときに announce 指定。
+INBOUND_ACTIVITY_TYPE = os.environ.get("INBOUND_ACTIVITY_TYPE", "create")
 POLL_INTERVAL_S = 0.1
 DRAIN_TIMEOUT_S = 600.0
 FAKER_URL = os.environ["FAKER_URL"]
@@ -39,8 +43,16 @@ INBOX_URLS = {
 }
 
 
-def faker_send(targets: list[str], count: int, concurrency: int) -> dict[str, Any]:
-    payload = {"targets": targets, "count": count, "concurrency": concurrency}
+def faker_send(targets: list[str], count: int, concurrency: int,
+               activity_type: str, objects: dict[str, str]) -> dict[str, Any]:
+    payload: dict[str, Any] = {
+        "targets": targets,
+        "count": count,
+        "concurrency": concurrency,
+        "activityType": activity_type,
+    }
+    if activity_type == "announce":
+        payload["objects"] = objects
     # send は count*len(targets) 件を blasting するので timeout は十分長く。
     r = httpx.post(f"{FAKER_URL}/send", json=payload, timeout=DRAIN_TIMEOUT_S)
     r.raise_for_status()
@@ -96,9 +108,26 @@ def main() -> int:
 
     targets = [INBOX_URLS[stack] for stack in seed["stacks"].keys()]
 
+    # announce mode: target inbox URL → 受信側 local note URI へのマップを
+    # seed.json から作る。target_note_uri が空の stack は announce 対象から
+    # 除外する (= seed 失敗 fallback)。
+    objects: dict[str, str] = {}
+    if INBOUND_ACTIVITY_TYPE == "announce":
+        for stack, info in seed["stacks"].items():
+            uri = info.get("target_note_uri", "")
+            if uri:
+                objects[INBOX_URLS[stack]] = uri
+        if len(objects) != len(targets):
+            print(
+                "warning: some stacks miss target_note_uri, "
+                f"announce mode skips {len(targets) - len(objects)} targets",
+                flush=True,
+            )
+
     print(
         f"firing faker: {len(targets)} targets x {INBOUND_COUNT} count "
-        f"({INBOUND_COUNT*len(targets)} total) @ concurrency={INBOUND_CONCURRENCY}",
+        f"({INBOUND_COUNT*len(targets)} total) @ concurrency={INBOUND_CONCURRENCY} "
+        f"activityType={INBOUND_ACTIVITY_TYPE}",
         flush=True,
     )
 
@@ -122,7 +151,8 @@ def main() -> int:
 
     # send 開始
     send_start = time.monotonic()
-    send_resp = faker_send(targets, INBOUND_COUNT, INBOUND_CONCURRENCY)
+    send_resp = faker_send(targets, INBOUND_COUNT, INBOUND_CONCURRENCY,
+                           INBOUND_ACTIVITY_TYPE, objects)
     send_elapsed = time.monotonic() - send_start
     send_done.set()
     print(

--- a/tests/queue-bench/common/driver_inbound.py
+++ b/tests/queue-bench/common/driver_inbound.py
@@ -109,20 +109,27 @@ def main() -> int:
     targets = [INBOX_URLS[stack] for stack in seed["stacks"].keys()]
 
     # announce mode: target inbox URL → 受信側 local note URI へのマップを
-    # seed.json から作る。target_note_uri が空の stack は announce 対象から
-    # 除外する (= seed 失敗 fallback)。
+    # seed.json から作る。target_note_uri が欠けている stack があると
+    # faker 側で「announce mode requires Objects[...]」error になり bench が
+    # 中途半端に進むため、driver 側で先に abort して原因 (= seed 失敗) を
+    # 明示する。
     objects: dict[str, str] = {}
     if INBOUND_ACTIVITY_TYPE == "announce":
+        missing: list[str] = []
         for stack, info in seed["stacks"].items():
             uri = info.get("target_note_uri", "")
             if uri:
                 objects[INBOX_URLS[stack]] = uri
-        if len(objects) != len(targets):
+            else:
+                missing.append(stack)
+        if missing:
             print(
-                "warning: some stacks miss target_note_uri, "
-                f"announce mode skips {len(targets) - len(objects)} targets",
+                f"error: announce mode but {len(missing)} stacks miss "
+                f"target_note_uri: {missing}. seed が失敗している可能性、"
+                "make queue-bench-seed のログを確認してください。",
                 flush=True,
             )
+            return 2
 
     print(
         f"firing faker: {len(targets)} targets x {INBOUND_COUNT} count "

--- a/tests/queue-bench/common/seed.py
+++ b/tests/queue-bench/common/seed.py
@@ -237,10 +237,24 @@ def main() -> int:
     for stack, info in STACKS.items():
         url = info["url"]
         print(f"[{stack}] {url}", flush=True)
+        target_note_uri = ""
         with httpx.Client(base_url=url, timeout=20, verify=False) as http:
             password = "bench-pass-1234"
             token = create_admin(http, "benchsender", password)
             user_id = fetch_local_user_id(http, token)
+            # Announce 経路 bench 用に target note を 1 件作る。faker が
+            # この URI を object として Announce を投げ、handleAnnounce が
+            # renote を生成する path を計測する。local note の `uri` は mk /
+            # TS どちらでも null なので、AS URI を base_url + /notes/<id> で
+            # 組み立てる (Misskey 互換)。
+            r = http.post(
+                "/api/notes/create",
+                json={"i": token, "text": "queue-bench announce target", "visibility": "public"},
+            )
+            r.raise_for_status()
+            note_id = r.json().get("createdNote", {}).get("id", "")
+            if note_id:
+                target_note_uri = f"{url}/notes/{note_id}"
 
         enable_federation(stack, info["db_host"])
         followers = insert_blackhole_followers(stack, info["db_host"], user_id, OUTBOUND_FOLLOWERS)
@@ -253,6 +267,7 @@ def main() -> int:
             "user_id": user_id,
             "follower_count": len(followers),
             "faker_remote_user_id": faker_remote_id,
+            "target_note_uri": target_note_uri,
         }
 
     out_path = "/state/seed.json"

--- a/tests/queue-bench/common/seed.py
+++ b/tests/queue-bench/common/seed.py
@@ -260,15 +260,19 @@ def main() -> int:
         followers = insert_blackhole_followers(stack, info["db_host"], user_id, OUTBOUND_FOLLOWERS)
         faker_remote_id = insert_faker_actor(stack, info["db_host"], faker_actor)
 
-        state["stacks"][stack] = {
+        stack_state: dict[str, Any] = {
             "url": url,
             "kind": info["kind"],
             "token": token,
             "user_id": user_id,
             "follower_count": len(followers),
             "faker_remote_user_id": faker_remote_id,
-            "target_note_uri": target_note_uri,
         }
+        # 空文字列ではなく key 自体を omit する。consumer 側は
+        # info.get("target_note_uri", "") で取り出すので互換は維持される。
+        if target_note_uri:
+            stack_state["target_note_uri"] = target_note_uri
+        state["stacks"][stack] = stack_state
 
     out_path = "/state/seed.json"
     with open(out_path, "w") as f:

--- a/tests/queue-bench/docker-compose.queue-bench.yml
+++ b/tests/queue-bench/docker-compose.queue-bench.yml
@@ -270,6 +270,9 @@ services:
       FAKER_URL: http://faker:8081
       INBOUND_COUNT: "10000"
       INBOUND_CONCURRENCY: "128"
+      # create (default) または announce。announce は seed が生成した
+      # target_note_uri を faker に渡して Announce 経路の bench を回す。
+      INBOUND_ACTIVITY_TYPE: "${INBOUND_ACTIVITY_TYPE:-create}"
       REDIS_ASYNQ_HOST: redis-asynq
       REDIS_MKQ_HOST: redis-mkq
       REDIS_TS_HOST: redis-ts

--- a/tests/queue-bench/faker/main.go
+++ b/tests/queue-bench/faker/main.go
@@ -23,6 +23,7 @@ import (
 	"crypto/tls"
 	"crypto/x509"
 	"encoding/base64"
+	"encoding/hex"
 	"encoding/json"
 	"encoding/pem"
 	"errors"
@@ -214,6 +215,17 @@ type sendRequest struct {
 	Targets     []string `json:"targets"`     // inbox URLs
 	Count       int      `json:"count"`       // requests per target (total = count*len(targets))
 	Concurrency int      `json:"concurrency"` // parallel workers per target
+
+	// ActivityType selects payload shape:
+	//   "" / "create"  → Create(Note) (default、後方互換)
+	//   "announce"     → Announce(object=Objects[target])
+	ActivityType string `json:"activityType,omitempty"`
+	// Objects maps inbox URL → AS object URI used by Announce mode.
+	// e.g. `{"https://mk-asynq/inbox": "https://mk-asynq/notes/<id>"}`
+	// announce mode で全 target に同じ note URI を Announce すると receiver 側で
+	// (act.ID dedup 経由でない場合) 重複 renote が大量に作られて bench にならない
+	// ため、receiver-local の note URI を target ごとに分けて渡す。
+	Objects map[string]string `json:"objects,omitempty"`
 }
 
 type sendStats struct {
@@ -338,7 +350,7 @@ func (f *faker) preSign(req sendRequest) (map[string][]signedReq, error) {
 		go func() {
 			defer wg.Done()
 			for j := range jobs {
-				sr, err := f.buildSigned(j.target, j.index)
+				sr, err := f.buildSigned(req, j.target, j.index)
 				if err != nil {
 					firstErr.CompareAndSwap(nil, err)
 					stop()
@@ -369,26 +381,57 @@ func (f *faker) preSign(req sendRequest) (map[string][]signedReq, error) {
 	return out, nil
 }
 
-func (f *faker) buildSigned(target string, index int) (signedReq, error) {
-	noteID := fmt.Sprintf("%s/notes/bench-%d-%d", f.actorURI, time.Now().UnixNano(), index)
-	activityID := noteID + "/activity"
+func (f *faker) buildSigned(req sendRequest, target string, index int) (signedReq, error) {
 	now := time.Now().UTC()
 	pub := []string{"https://www.w3.org/ns/activitystreams#Public"}
 
-	activity := map[string]any{
-		"@context": []any{"https://www.w3.org/ns/activitystreams"},
-		"id":       activityID,
-		"type":     "Create",
-		"actor":    f.actorURI,
-		"to":       pub,
-		"object": map[string]any{
-			"id":           noteID,
-			"type":         "Note",
-			"attributedTo": f.actorURI,
-			"to":           pub,
-			"content":      fmt.Sprintf("queue-bench note %d", index),
-			"published":    now.Format(time.RFC3339),
-		},
+	// Activity type を req.ActivityType で分岐。default は Create。
+	// announce mode は req.Objects[target] が宛先の note URI を保持する前提。
+	// 受信側 mk の handleAnnounce は act.ID != "" の場合に FindByURI で dedup
+	// するため、bench では activity.ID を per-(target, index) でユニーク化する。
+	var activity map[string]any
+	switch req.ActivityType {
+	case "announce":
+		objectURI := req.Objects[target]
+		if objectURI == "" {
+			return signedReq{}, fmt.Errorf("announce mode requires Objects[%q] target object URI", target)
+		}
+		// activity.id は per-(target, index) で完全ユニーク化する。target の
+		// hash を含めないと「同じ index で別 target」が同じ ID を生成して
+		// しまい、receiver 側 (handleAnnounce の act.ID ベース dedup) で
+		// 1 件目以降が誤って drop される可能性がある。
+		tHash := sha256.Sum256([]byte(target))
+		announceID := fmt.Sprintf("%s/activities/announce-%d-%s-%d",
+			f.actorURI, time.Now().UnixNano(), hex.EncodeToString(tHash[:4]), index)
+		activity = map[string]any{
+			"@context":  []any{"https://www.w3.org/ns/activitystreams"},
+			"id":        announceID,
+			"type":      "Announce",
+			"actor":     f.actorURI,
+			"object":    objectURI,
+			"to":        pub,
+			"published": now.Format(time.RFC3339),
+		}
+	case "", "create":
+		noteID := fmt.Sprintf("%s/notes/bench-%d-%d", f.actorURI, time.Now().UnixNano(), index)
+		activityID := noteID + "/activity"
+		activity = map[string]any{
+			"@context": []any{"https://www.w3.org/ns/activitystreams"},
+			"id":       activityID,
+			"type":     "Create",
+			"actor":    f.actorURI,
+			"to":       pub,
+			"object": map[string]any{
+				"id":           noteID,
+				"type":         "Note",
+				"attributedTo": f.actorURI,
+				"to":           pub,
+				"content":      fmt.Sprintf("queue-bench note %d", index),
+				"published":    now.Format(time.RFC3339),
+			},
+		}
+	default:
+		return signedReq{}, fmt.Errorf("unknown activityType %q (want create | announce)", req.ActivityType)
 	}
 	body, err := json.Marshal(activity)
 	if err != nil {


### PR DESCRIPTION
## Summary

PR #1158 で handleAnnounce の \`fanoutHook\` / \`notificationHook\` を \`safeGoFedHook\` で非同期化したが、その経路を計測する手段が queue-bench に無かった (= faker が Create 専用)。Announce 経路の inbound throughput も計測できるよう tool を拡張し、PR #1158 マージ後の reference 値を docs に記録する。

issue なしの bench tool 拡張 PR (small self-contained pattern)。

## 主な変更点

| File | 変更 |
|------|------|
| \`tests/queue-bench/faker/main.go\` | \`sendRequest\` に \`ActivityType\` + \`Objects\` 追加、\`buildSigned\` を type 別分岐、activity.id を per-(target, index) で完全ユニーク化 |
| \`tests/queue-bench/common/seed.py\` | 各 stack の benchsender に Announce target note を 1 件作成 + \`target_note_uri\` を seed.json に記録 |
| \`tests/queue-bench/common/driver_inbound.py\` | env \`INBOUND_ACTIVITY_TYPE\` で create/announce 切替 |
| \`tests/queue-bench/docker-compose.queue-bench.yml\` | \`INBOUND_ACTIVITY_TYPE\` env pass-through |
| \`docs/queue-bench.md\` | activity type 使い分けと PR #1158 マージ後の Announce 経路 reference 値追記 |

## 使い方

\`\`\`bash
# 1) 既存 Create 経路 (default)
make queue-bench-inbound

# 2) Announce 経路 (#1158 / その先で利用)
INBOUND_ACTIVITY_TYPE=announce make queue-bench-inbound
\`\`\`

## reference 値 (PR #1158 マージ後、develop @ \`9adc836\`、2026-05-21)

10000 req × 3 target、concurrency 128、3 stack 全て ok=10000:

| Stack | Send Duration | Effective rps | Drain time | Peak depth |
|---|---|---|---|---|
| mk-go (asynq) | 3.66s | 2729.9 | 47.15s | 9827 |
| mk-go (mkq) | 3.46s | 2891.3 | 63.43s | 9912 |
| Misskey TS | 10.46s | 956.4 | 18.08s | 0 |

mk-go は Create 経路 (3039.6 rps) と比べて -4〜-12% (Announce は target note resolve + renote create の overhead)、TS の 2.9x を維持。

## #1158 効果計測 (before/after) について

本 PR は計測ツールの拡張のみ。before/after 比較は別途試みたが、**stack 並列起動で 3 stack のうち 1 stack が random に ok=0 になる非決定的問題** に阻まれて信頼できる比較データが取れていない。

これと #1158 効果の直接計測は follow-up issue として切り出し、docker-compose の sequential startup 化や app restart 後の wait 強化と合わせて別 PR で対応する想定。

## drop-in 互換 / 動作影響

- bench tool 拡張のみ、production code に変更なし
- 既存 \`INBOUND_ACTIVITY_TYPE\` 未指定パスは \`create\` で後方互換
- CI に影響なし (queue-bench は手動実行)