### PR TITLE
Fix: e2e-frontend-build を pnpm 11 の TTY 不在環境で動作させる

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -192,9 +192,14 @@ e2e-submodule-init:
 
 # 本家フロントエンドを Docker 内でビルドする。数分〜10 分程度かかる。
 # 成果物は third_party/misskey/packages/frontend/... 配下に出力される。
-# パッチは submodule (shiroha-a/misskey-ts、tag 2026.5.1-mk.0) に直接コミット済み。
+# パッチは submodule (shiroha-a/misskey-ts、tag 2026.5.4-mk.0) に直接コミット済み。
+#
+# CI=true を渡す理由: upstream 2026.5.2 で pnpm 10 → 11 に移行 (#17400 dep bump
+# 系)、pnpm 11 は previous install (node_modules) を消す前に prompt を出す挙動が
+# default。docker run は TTY 無し起動なので prompt が出せず ERR_PNPM_ABORTED_
+# REMOVE_MODULES_DIR_NO_TTY で abort する。CI=true で skip させる。
 e2e-frontend-build:
-	docker run --rm -v $(PWD):$(E2E_WORKDIR) -w $(E2E_WORKDIR)/third_party/misskey \
+	docker run --rm -e CI=true -v $(PWD):$(E2E_WORKDIR) -w $(E2E_WORKDIR)/third_party/misskey \
 		$(E2E_NODE_IMAGE) \
 		bash -lc "corepack enable && corepack prepare pnpm@latest --activate && pnpm install --frozen-lockfile && pnpm build"
 


### PR DESCRIPTION
## Summary

upstream 2026.5.2 で pnpm 10 → 11 に移行 (`#17400` dep bump 系) した影響で、\`make e2e-frontend-build\` / \`make uds-frontend-build\` が docker run の TTY 無し環境で以下のエラーで abort するようになっていた:

\`\`\`
[ERR_PNPM_ABORTED_REMOVE_MODULES_DIR_NO_TTY] Aborted removal of modules directory due to no TTY
\`\`\`

pnpm 11 は previous install の \`node_modules\` を消す前に prompt を出すのが default。\`docker run --rm\` は TTY 無しで起動するため prompt が出せず reject → abort。**\`CI=true\` env を渡すと pnpm が CI 環境と判定して prompt を skip する**。

#1164 (2026.5.4 追従) で submodule を bump した直後の UDS 環境再構築で発覚 (= ローカル frontend build が落ちた)。

## 主な変更点

| File | 変更 |
|------|------|
| \`Makefile\` | \`e2e-frontend-build\` の \`docker run\` に \`-e CI=true\` を追加。同コメントで \`CI=true\` を渡す理由を docs 化。tag 参照を \`2026.5.4-mk.0\` に update (= submodule の現在 pin と一致) |

## drop-in 互換 / 動作影響

- build 経路のみ、production code / runtime behavior 変更なし
- \`uds-frontend-build\` は \`e2e-frontend-build\` のエイリアスなので両方で fix が effective
- \`e2e-deps\` 等の他 docker run target は同 issue を踏む可能性があるが、本 PR は frontend build 1 件に scope を絞る (他 target で同 error が発生したら別 follow-up)

## Test plan

- [x] 修正後の \`make uds-frontend-build\` で全 13 workspace package が Done で完走
- [x] 続けて \`make uds-up\` で 4 container (mkgo / nginx / postgres / valkey) が healthy に起動
- [x] mkgo 起動 log で \`starting Misskey server socket=/run/mkgo/mkgo.sock url=https://go.k7a.org\` を確認
- [ ] CI (= 既存 e2e workflow が同 path で動いていれば green) を通す

## Related

- #1164 (2026.5.4 追従、submodule bump で pnpm 11 が顕在化)
- upstream `#17400` (deps: update dependencies、pnpm 11 移行を含む)