### PR TITLE
fix(frontend): fluent-emoji 参照 path を @misskey-dev/emoji-assets に追従 (#1167)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -115,6 +115,7 @@ Playwright spec を両 backend で走らせる中で観測した drop-in 互換 
 - #943: リモートユーザー counts (notesCount / followersCount / followingCount) を origin から fetch する mk-go 独自拡張
 - #945: RemoteStatsFetcher cache を `sync.Map` → LRU (size cap 10000) で memory bound 化
 - #1156: リモートユーザーのプロフィール「アクティビティ」タブが Heatmap 空 / Notes 折れ線がマイナス方面にのみ動く drop-in regression を fix。federation `handleCreate` / `handleAnnounce` で `OnNoteCreated` chart hook が発火しておらず PerUserNotesChart の +1 が記録されない一方、`handleDelete` 経路 (`NoteDeleteService.Delete`) は -1 を記録していたため日次集計が常に負方向に推移していた。`Resolver.IngestNoteWithCreated` (sibling) を追加して dedup-hit と新規 INSERT を区別し、`Processor.SetNoteChartHook` で chart hook を `safeGoFedHook` 経由で fire-and-forget 発火 (重複配送では fire しない)
+- #1167: fluent-emoji 参照 path を `@misskey-dev/emoji-assets/built/fluent-emoji` に追従 (upstream 2026.5.2 #17381 残作業、Phase 18 #1164 commit 3 の twemoji 追従と同時にやるべきだった漏れ補完)。修正前は旧 path (submodule `fluent-emojis/dist`) が残っていたため mk-go だけ achievement 1/2/3 icon が表示できていた drop-in 違反状態。修正後は upstream Misskey TS 2026.5.4 と同じ broken state (= `passedSinceAccountCreated1/2/3` の bronze/silver/gold バッジ icon が 404) に揃え、frontend `achievements.ts` 側で keycap 系を新 path 存在 emoji に rename する upstream / fork fix を待つ運用に
 
 ### Phase 15 — Federation performance (#562, #565, #569)
 

--- a/deploy/uds/Dockerfile.mkgo
+++ b/deploy/uds/Dockerfile.mkgo
@@ -40,11 +40,13 @@ RUN test -f third_party/misskey/packages/backend/node_modules/@misskey-dev/emoji
      echo "Run: make uds-frontend-build (installs third_party/misskey node_modules)" && exit 1)
 
 # fluent-emoji は実績バッジ / notification icon が /fluent-emoji/<hex>.png で
-# 参照する PNG set (1764 files)。submodule `third_party/misskey/fluent-emojis/
-# dist` に同梱されているので submodule init で取得済の前提 (#1138)。
-RUN test -f third_party/misskey/fluent-emojis/dist/1f4dd.png || \
-    (echo "ERROR: fluent-emoji assets not found (submodule fluent-emojis not initialized?)." && \
-     echo "Run: git submodule update --init --recursive" && exit 1)
+# 参照する PNG set。pnpm install 後に node_modules/@misskey-dev/emoji-assets/
+# built/fluent-emoji として hoist される (upstream 2026.5.2 #17381 で twemoji
+# と同時に fluent-emojis submodule から @misskey-dev/emoji-assets npm package
+# に移行、#1167)。make uds-frontend-build を先に走らせる運用のため存在する前提。
+RUN test -f third_party/misskey/packages/backend/node_modules/@misskey-dev/emoji-assets/built/fluent-emoji/1f4dd.png || \
+    (echo "ERROR: fluent-emoji assets not found (pnpm install not run?)." && \
+     echo "Run: make uds-frontend-build (installs third_party/misskey node_modules)" && exit 1)
 
 # Go の build cache + module cache を BuildKit cache mount として永続化 (#432)。
 RUN --mount=type=cache,target=/go/pkg/mod \
@@ -92,10 +94,11 @@ COPY --from=builder --chown=65532:65532 /app/third_party/misskey/packages/backen
 ENV MISSKEY_TWEMOJI_DIR=/app/twemoji
 
 # fluent-emoji PNG set。frontendが /fluent-emoji/<hex>.png で参照する
-# (実績バッジ / notification icon)。submodule fluent-emojis/dist は
-# 約 70MB / 1764 files、image 増になるが TS upstream image と equivalent
-# (#1138)。bind-mount 無しで serve できるよう image へ焼き込む。
-COPY --from=builder --chown=65532:65532 /app/third_party/misskey/fluent-emojis/dist /app/fluent-emoji
+# (実績バッジ / notification icon)。upstream 2026.5.2 #17381 で twemoji と
+# 同時に fluent-emojis submodule から @misskey-dev/emoji-assets npm package
+# に移行 (#1167)。約 3145 files、image 増になるが TS upstream image と
+# equivalent。bind-mount 無しで serve できるよう image へ焼き込む。
+COPY --from=builder --chown=65532:65532 /app/third_party/misskey/packages/backend/node_modules/@misskey-dev/emoji-assets/built/fluent-emoji /app/fluent-emoji
 ENV MISSKEY_FLUENT_EMOJI_DIR=/app/fluent-emoji
 
 COPY --chown=65532:65532 deploy/uds/mkgo-entrypoint.sh /entrypoint.sh

--- a/internal/frontendutil/frontendutil.go
+++ b/internal/frontendutil/frontendutil.go
@@ -63,17 +63,28 @@ func TwemojiDir() string {
 	return filepath.Join(frontendBase, "packages", "backend", "node_modules", "@misskey-dev", "emoji-assets", "built", "twemoji")
 }
 
-// FluentEmojiDir returns the path to fluent-emoji PNG files. upstream Misskey
-// TS では `node_modules/@misskey-dev/emoji-assets/built/fluent-emoji` から
-// 配信されるが、本リポジトリでは submodule `third_party/misskey/fluent-emojis/
-// dist` に同一の asset 集合が同梱されているのでこちらを参照する。frontend
+// FluentEmojiDir returns the path to fluent-emoji PNG files. frontend の
 // `ACHIEVEMENT_BADGES` (= 実績バッジ) や notification icon が `/fluent-emoji/
-// <hex>.png` の URL で参照する。環境変数 `MISSKEY_FLUENT_EMOJI_DIR` で上書き可能。
+// <hex>.png` の URL で参照する。環境変数 `MISSKEY_FLUENT_EMOJI_DIR` で上書き
+// 可能。
+//
+// upstream 2026.5.2 #17381 (twemoji と同 commit) で fluent-emoji の serve path
+// が `fluent-emojis/dist` (submodule) から
+// `node_modules/@misskey-dev/emoji-assets/built/fluent-emoji` (= 自前 npm
+// パッケージ) に移行した。drop-in 互換のため mk-go も同 path を参照する
+// (旧 submodule path は将来 upstream で削除予定)。
+//
+// 既知の broken: 新 path には keycap 系 (`0031-20e3.png` = 1️⃣ 等) が含まれない
+// ため `passedSinceAccountCreated1/2/3` achievement の bronze/silver/gold バッジ
+// icon が 404 になる。これは upstream Misskey TS 2026.5.4 でも同じ状態で、
+// upstream achievements.ts 側の bug。本家 fix を待つか、shiroha-a/misskey-ts
+// fork で代替 emoji に rename する patch を入れる follow-up (#1167) を別途
+// 計画する。
 func FluentEmojiDir() string {
 	if v := os.Getenv("MISSKEY_FLUENT_EMOJI_DIR"); v != "" {
 		return v
 	}
-	return filepath.Join(frontendBase, "fluent-emojis", "dist")
+	return filepath.Join(frontendBase, "packages", "backend", "node_modules", "@misskey-dev", "emoji-assets", "built", "fluent-emoji")
 }
 
 // StaticDir returns the path to static assets (icons, splash, favicon etc.).

--- a/internal/frontendutil/frontendutil_test.go
+++ b/internal/frontendutil/frontendutil_test.go
@@ -70,7 +70,10 @@ func TestTwemojiDir_EnvOverride(t *testing.T) {
 
 func TestFluentEmojiDir_Default(t *testing.T) {
 	t.Setenv("MISSKEY_FLUENT_EMOJI_DIR", "")
-	assert.Equal(t, filepath.Join("third_party/misskey", "fluent-emojis", "dist"), FluentEmojiDir())
+	// upstream 2026.5.2 #17381 で fluent-emoji の serve path が
+	// fluent-emojis/dist (submodule) → @misskey-dev/emoji-assets/built/fluent-emoji
+	// に移行した (twemoji と同 commit、#1167)。
+	assert.Equal(t, filepath.Join("third_party/misskey", "packages", "backend", "node_modules", "@misskey-dev", "emoji-assets", "built", "fluent-emoji"), FluentEmojiDir())
 }
 
 func TestFluentEmojiDir_EnvOverride(t *testing.T) {


### PR DESCRIPTION
## Summary

upstream Misskey TS 2026.5.2 で twemoji と同時に fluent-emoji も serve path が \`fluent-emojis/dist\` (submodule) → \`node_modules/@misskey-dev/emoji-assets/built/fluent-emoji\` (= 自前 npm パッケージ) に移行された (#17381)。

[PR #1164](../pull/1165) の commit 3 (\`4c9c32b\` twemoji path) で **twemoji 側だけ追従し、fluent-emoji は保留** していたが、upstream は両方を同 commit で移行しているため mk-go も同タイミングで切り替えるべきだった (= 作業漏れ補完)。

## 観察された状況

| Layer | upstream (2026.5.4) | mk-go (修正前) | mk-go (本 PR 後) |
|-------|---------------------|----------------|------------------|
| frontend (`achievements.ts`) | `/fluent-emoji/0031-20e3.png` (= 1️⃣) を request | 同じ | 同じ |
| backend serve path | 新 path (= \`node_modules/.../fluent-emoji\`) | 旧 path (= submodule \`fluent-emojis/dist\`) | 新 path に追従 |
| 結果 (= achievement 1/2/3 の icon) | **404** (新 path に keycap なし) | **200** (旧 submodule path に keycap が残っているため意図せず動いている) | **404** (= upstream と同じ broken state) |

つまり mk-go の現状 (= 修正前) は「意図せず upstream より動いている」奇妙な状態で、drop-in 互換性が崩れていた。

## 影響範囲 (= achievement 3 件のみ)

| Achievement | 表示 |
|-------------|------|
| \`passedSinceAccountCreated1\` (アカウント 1 年経過、bronze) | 1️⃣ keycap |
| \`passedSinceAccountCreated2\` (2 年経過、silver) | 2️⃣ keycap |
| \`passedSinceAccountCreated3\` (3 年経過、gold) | 3️⃣ keycap |

それ以外の 55+ achievement / about-misskey の treasure button は新 path に存在 = 影響なし。

これは **本家 Misskey TS 2026.5.4 でも同じ broken state** (本家ユーザーで再現確認済)。upstream achievements.ts 側の bug で、fix されたら mk-go も自動追従する形。

## 主な変更点

| File | 変更 |
|------|------|
| \`internal/frontendutil/frontendutil.go\` | \`FluentEmojiDir()\` の return path を \`node_modules/@misskey-dev/emoji-assets/built/fluent-emoji\` に変更。コメントに upstream PR 番号 + 既知 broken (keycap 1/2/3) を docs 化 |
| \`internal/frontendutil/frontendutil_test.go\` | expected path 追従 |
| \`deploy/uds/Dockerfile.mkgo\` | sanity check + COPY ステージを新 path に変更 |

main \`Dockerfile\` (= e2e 経路) は fluent-emoji を参照しないため変更不要。

## drop-in 互換 / 動作影響

- operator が \`MISSKEY_FLUENT_EMOJI_DIR\` env で override している場合は影響なし
- default で \`make uds-frontend-build\` 後の image を使う運用では pnpm install で \`@misskey-dev/emoji-assets\` package が hoist されるので新 path で resolve される
- achievement 1/2/3 の icon が 404 になる (= upstream と同じ broken state、drop-in 互換的には正しい挙動)
- 上記 broken は upstream 側で fix されたら mk-go も自動追従、もしくは \`shiroha-a/misskey-ts\` fork の achievements.ts で代替 emoji に rename する patch を follow-up で入れる選択肢もあり

## Test plan

- [x] \`make fmt && make lint\` 全 pass
- [x] \`go test ./internal/frontendutil/... -run TestFluentEmojiDir\` 2 件 pass (default / env override)
- [x] CI green を待つ
- [ ] merge 後の UDS / nightly drop-in test で動作確認 (achievement 1/2/3 が 404 になることを目視確認)

## Closes

Closes #1167