### PR TITLE
fix(admin): /api/admin/queue/{deliver,inbox}-delayed の応答を [host, count] tuple に揃える (#1179)

### DIFF
--- a/internal/api/admin/export_test.go
+++ b/internal/api/admin/export_test.go
@@ -1,0 +1,16 @@
+package admin
+
+// Test seams exposed to admin_test (external) package. file 名が `_test.go`
+// で終わるので production build には含まれない。
+
+// DelayedTasksFetchPageSize は fetchAllDelayedTasks の page size を test 側
+// から参照するための seam。production code から書き換えてはならない。
+const DelayedTasksFetchPageSize = delayedTasksFetchPageSize
+
+// SetDelayedTasksMaxPages は test 中だけ page 走査の上限を差し替えるための
+// seam。返り値は前の値で、t.Cleanup から呼び戻して元に戻すこと。
+func SetDelayedTasksMaxPages(n int) (prev int) {
+	prev = delayedTasksMaxPages
+	delayedTasksMaxPages = n
+	return prev
+}

--- a/internal/api/admin/export_test.go
+++ b/internal/api/admin/export_test.go
@@ -9,6 +9,10 @@ const DelayedTasksFetchPageSize = delayedTasksFetchPageSize
 
 // SetDelayedTasksMaxPages は test 中だけ page 走査の上限を差し替えるための
 // seam。返り値は前の値で、t.Cleanup から呼び戻して元に戻すこと。
+//
+// 注意: グローバル変数を書き換えるので `t.Parallel()` を使う test 内では
+// 呼ばないこと。並列 test が同じ var を書き換えると race し、cap 値が
+// 不定になる。
 func SetDelayedTasksMaxPages(n int) (prev int) {
 	prev = delayedTasksMaxPages
 	delayedTasksMaxPages = n

--- a/internal/api/admin/queue.go
+++ b/internal/api/admin/queue.go
@@ -103,6 +103,9 @@ func (h *Handler) fetchAllDelayedTasks(queueName string) []*QueueTaskSummary {
 				break
 			}
 			all = append(all, rows...)
+			// partial page を取った時点で正常にデータ尽きと判断、warn せず
+			// 抜ける。full page が続いたまま cap に到達した時だけ warn する
+			// (= データがまだ残っている可能性が高い異常状態)。
 			if len(rows) < delayedTasksFetchPageSize {
 				break
 			}

--- a/internal/api/admin/queue.go
+++ b/internal/api/admin/queue.go
@@ -3,10 +3,13 @@ package admin
 import (
 	"encoding/json"
 	"net/http"
+	"net/url"
+	"sort"
 	"strings"
 	"time"
 
 	"github.com/labstack/echo/v4"
+	"github.com/shiroha-a/mk/internal/activitypub"
 	"github.com/shiroha-a/mk/internal/api/apierr"
 	"github.com/shiroha-a/mk/internal/queue"
 )
@@ -30,61 +33,142 @@ func (h *Handler) QueueClear(c echo.Context) error {
 }
 
 // QueueDeliverDelayed handles POST /api/admin/queue/deliver-delayed.
-// Returns scheduled/retry tasks on the `deliver` queue.
+//
+// Response shape: `[[host, count], ...]` の tuple 配列 (count desc で sort)。
+// host は recipient inbox URL (`DeliverPayload.Inbox`) から抽出する。
+// upstream Misskey TS spec (`admin/queue/deliver-delayed.ts`) と互換。
+//
+// admin/control panel の "Errored Instances" panel は b[1] で count に
+// アクセスするので、object 配列 (旧 mk-go shape) では NaN 表示になる (#1179)。
 func (h *Handler) QueueDeliverDelayed(c echo.Context) error {
-	return h.listDelayedTasks(c, "deliver")
+	tasks := h.fetchAllDelayedTasks("deliver")
+	return c.JSON(http.StatusOK, aggregateByHost(tasks, deliverHostFromPayload))
 }
 
 // QueueInboxDelayed handles POST /api/admin/queue/inbox-delayed.
-// Returns scheduled/retry tasks on the `inbox` queue.
+//
+// Response shape: `[[host, count], ...]` の tuple 配列 (count desc で sort)。
+// host は HTTP Signature header の `keyId` (絶対 URL) から抽出する。
+// upstream Misskey TS は `new URL(job.data.signature.keyId).host` と
+// 同等の処理。mk-go の `InboxPayload.Host` は enqueue 時に未設定なので
+// signature header 経由でしか引けない (#1179)。
 func (h *Handler) QueueInboxDelayed(c echo.Context) error {
-	return h.listDelayedTasks(c, "inbox")
+	tasks := h.fetchAllDelayedTasks("inbox")
+	return c.JSON(http.StatusOK, aggregateByHost(tasks, inboxHostFromPayload))
 }
 
-// delayedTasksMaxFetch is the upper bound on how many of each of scheduled /
-// retry we pull from asynq to build the virtual delayed list. asynq pages
-// scheduled and retry independently so we cannot naively forward the user's
-// page number to both (retry items before the scheduled boundary would
-// disappear). We instead fetch the first asynq page (up to 100 items) of each,
-// merge scheduled-first, then slice by the user's (page, limit).
+// delayedTasksFetchPageSize は scheduled / retry を page 走査する際の 1 page
+// 当たり件数。100 は asynq inspector の page size 制限 (1〜) 内で妥当な大きさ。
+// 上限はないが、page が空になるまで繰り返すので件数に依らず正しく動く。
+const delayedTasksFetchPageSize = 100
+
+// fetchAllDelayedTasks fetches every scheduled+retry task for the queue by
+// iterating pages of size delayedTasksFetchPageSize until each list is
+// exhausted. The result is the union for downstream host aggregation.
 //
-// 想定: admin/queue/*-delayed は通常 "stuck な配送" を目視で確認する用途で、
-// 合計 200 件を超えるケースは運用上ほぼ存在しない。深いページングが必要なら
-// /admin/queue/jobs を state=scheduled / state=retry で使う。
-const delayedTasksMaxFetch = 100
-
-func (h *Handler) listDelayedTasks(c echo.Context, queueName string) error {
+// Misskey TS の BullMQ getJobs(['delayed']) は全件取得が前提なので、上限を
+// 設けずに走査する。asynq に pagination 上限は無いため、運用上の最悪値
+// (数千件) も問題にならない (= memory 一過性)。
+func (h *Handler) fetchAllDelayedTasks(queueName string) []*QueueTaskSummary {
 	if h.queueInspector == nil {
-		return c.JSON(http.StatusOK, []any{})
+		return nil
 	}
-	var req struct {
-		Limit int `json:"limit"`
-		Page  int `json:"page"`
+	var all []*QueueTaskSummary
+	for _, fetch := range []func(string, int, int) ([]*QueueTaskSummary, error){
+		h.queueInspector.ListScheduledTasks,
+		h.queueInspector.ListRetryTasks,
+	} {
+		for page := 1; ; page++ {
+			rows, err := fetch(queueName, page, delayedTasksFetchPageSize)
+			if err != nil || len(rows) == 0 {
+				break
+			}
+			all = append(all, rows...)
+			if len(rows) < delayedTasksFetchPageSize {
+				break
+			}
+		}
 	}
-	_ = c.Bind(&req)
-	if req.Limit <= 0 || req.Limit > 100 {
-		req.Limit = 30
-	}
-	if req.Page < 1 {
-		req.Page = 1
-	}
+	return all
+}
 
-	scheduled, _ := h.queueInspector.ListScheduledTasks(queueName, 1, delayedTasksMaxFetch)
-	retry, _ := h.queueInspector.ListRetryTasks(queueName, 1, delayedTasksMaxFetch)
-	combined := make([]*QueueTaskSummary, 0, len(scheduled)+len(retry))
-	combined = append(combined, scheduled...)
-	combined = append(combined, retry...)
+// aggregateByHost reduces tasks to (host, count) tuples sorted by count
+// descending, then host ascending for stable output. hostFn は task 1 件から
+// host 文字列を抽出する関数で、空文字列を返した task は skip される
+// (= 不正 payload / 集計対象外を弾く)。
+//
+// 戻り値は []any でなく [][]any なので、frontend が `b[1]` でアクセスする
+// JSON tuple 表現 (`[["a", 1], ...]`) になる。
+func aggregateByHost(tasks []*QueueTaskSummary, hostFn func(*QueueTaskSummary) string) [][]any {
+	counts := make(map[string]int)
+	for _, t := range tasks {
+		host := hostFn(t)
+		if host == "" {
+			continue
+		}
+		counts[host]++
+	}
+	hosts := make([]string, 0, len(counts))
+	for h := range counts {
+		hosts = append(hosts, h)
+	}
+	sort.Slice(hosts, func(i, j int) bool {
+		if counts[hosts[i]] != counts[hosts[j]] {
+			return counts[hosts[i]] > counts[hosts[j]]
+		}
+		return hosts[i] < hosts[j]
+	})
+	out := make([][]any, 0, len(hosts))
+	for _, h := range hosts {
+		out = append(out, []any{h, counts[h]})
+	}
+	return out
+}
 
-	offset := (req.Page - 1) * req.Limit
-	if offset >= len(combined) {
-		return c.JSON(http.StatusOK, []map[string]any{})
+// deliverHostFromPayload extracts the recipient host from a deliver queue
+// task. DeliverPayload.Inbox は recipient の AP inbox URL なので、その host
+// が即 federation 先 host になる。
+func deliverHostFromPayload(t *QueueTaskSummary) string {
+	if t == nil || len(t.Payload) == 0 {
+		return ""
 	}
-	end := min(offset+req.Limit, len(combined))
-	out := make([]map[string]any, 0, end-offset)
-	for _, t := range combined[offset:end] {
-		out = append(out, packTaskSummary(t))
+	var p queue.DeliverPayload
+	if err := json.Unmarshal(t.Payload, &p); err != nil {
+		return ""
 	}
-	return c.JSON(http.StatusOK, out)
+	u, err := url.Parse(p.Inbox)
+	if err != nil {
+		return ""
+	}
+	return u.Host
+}
+
+// inboxHostFromPayload extracts the sender host from an inbox queue task.
+// InboxPayload.Host は enqueue 時に未設定 (api/inbox/handler.go) なので、
+// `Headers["Signature"]` から HTTP Signature の keyId URL を取って host を
+// 抽出する。これは upstream Misskey TS の
+// `new URL(job.data.signature.keyId).host` と一致する。
+func inboxHostFromPayload(t *QueueTaskSummary) string {
+	if t == nil || len(t.Payload) == 0 {
+		return ""
+	}
+	var p queue.InboxPayload
+	if err := json.Unmarshal(t.Payload, &p); err != nil {
+		return ""
+	}
+	sig := p.Headers["Signature"]
+	if sig == "" {
+		return ""
+	}
+	parsed, err := activitypub.ParseSignatureHeader(sig)
+	if err != nil || parsed == nil {
+		return ""
+	}
+	u, err := url.Parse(parsed.KeyID)
+	if err != nil {
+		return ""
+	}
+	return u.Host
 }
 
 // QueueJobs handles POST /api/admin/queue/jobs.

--- a/internal/api/admin/queue.go
+++ b/internal/api/admin/queue.go
@@ -2,6 +2,7 @@ package admin
 
 import (
 	"encoding/json"
+	"log/slog"
 	"net/http"
 	"net/url"
 	"sort"
@@ -59,33 +60,58 @@ func (h *Handler) QueueInboxDelayed(c echo.Context) error {
 
 // delayedTasksFetchPageSize は scheduled / retry を page 走査する際の 1 page
 // 当たり件数。100 は asynq inspector の page size 制限 (1〜) 内で妥当な大きさ。
-// 上限はないが、page が空になるまで繰り返すので件数に依らず正しく動く。
 const delayedTasksFetchPageSize = 100
+
+// delayedTasksMaxPages は scheduled / retry それぞれの page 走査の上限。
+// = 100K tasks per state, 200K total。これは defense-in-depth の二重目的:
+//
+//   - inspector が常に full page を返すような misbehavior 時の無限ループ防御
+//   - 連合先長期 down 等の pathological case で、admin panel が backend
+//     memory を食い潰さない soft cap
+//
+// 通常の運用では数千件で頭打ちになるはずなので、この上限を踏むのは異常状態。
+// 到達時は slog.Warn で diag を残し、収集できた分だけで集計を進める
+// (= panel に top hosts は出るので、admin はその情報を元に対処できる)。
+//
+// var にしているのは test seam: cap 防御の挙動を確認する test が小さい
+// cap を一時設定するため。production code から書き換えてはならない。
+var delayedTasksMaxPages = 1000
 
 // fetchAllDelayedTasks fetches every scheduled+retry task for the queue by
 // iterating pages of size delayedTasksFetchPageSize until each list is
-// exhausted. The result is the union for downstream host aggregation.
+// exhausted or delayedTasksMaxPages の上限に達するまで。結果は downstream の
+// host aggregation の union として返す。
 //
-// Misskey TS の BullMQ getJobs(['delayed']) は全件取得が前提なので、上限を
-// 設けずに走査する。asynq に pagination 上限は無いため、運用上の最悪値
-// (数千件) も問題にならない (= memory 一過性)。
+// Misskey TS の BullMQ getJobs(['delayed']) は全件取得が前提なので、通常
+// page が空になるまで走査するが、defense-in-depth として上限を設けている
+// (`delayedTasksMaxPages` のコメント参照)。
 func (h *Handler) fetchAllDelayedTasks(queueName string) []*QueueTaskSummary {
 	if h.queueInspector == nil {
 		return nil
 	}
 	var all []*QueueTaskSummary
-	for _, fetch := range []func(string, int, int) ([]*QueueTaskSummary, error){
-		h.queueInspector.ListScheduledTasks,
-		h.queueInspector.ListRetryTasks,
+	for _, spec := range []struct {
+		state string
+		fetch func(string, int, int) ([]*QueueTaskSummary, error)
+	}{
+		{"scheduled", h.queueInspector.ListScheduledTasks},
+		{"retry", h.queueInspector.ListRetryTasks},
 	} {
-		for page := 1; ; page++ {
-			rows, err := fetch(queueName, page, delayedTasksFetchPageSize)
+		for page := 1; page <= delayedTasksMaxPages; page++ {
+			rows, err := spec.fetch(queueName, page, delayedTasksFetchPageSize)
 			if err != nil || len(rows) == 0 {
 				break
 			}
 			all = append(all, rows...)
 			if len(rows) < delayedTasksFetchPageSize {
 				break
+			}
+			if page == delayedTasksMaxPages {
+				slog.Warn("admin/queue/delayed: page cap reached, truncating aggregation",
+					"queue", queueName, "state", spec.state,
+					"maxPages", delayedTasksMaxPages,
+					"pageSize", delayedTasksFetchPageSize,
+					"collected", len(all))
 			}
 		}
 	}
@@ -128,6 +154,12 @@ func aggregateByHost(tasks []*QueueTaskSummary, hostFn func(*QueueTaskSummary) s
 // deliverHostFromPayload extracts the recipient host from a deliver queue
 // task. DeliverPayload.Inbox は recipient の AP inbox URL なので、その host
 // が即 federation 先 host になる。
+//
+// 注意: Go の `url.Parse` は JS の `new URL()` より permissive で、ほとんどの
+// malformed input に対して err=nil + Host="" の `*url.URL` を返す (err は
+// `::scheme::` 形式の壊れた scheme prefix 等、限定的な case でのみ返る)。
+// caller (`aggregateByHost`) は host == "" を skip するので、err 分岐と
+// 空 Host のどちらも同じ「集計から外す」挙動になり、両方 cover している。
 func deliverHostFromPayload(t *QueueTaskSummary) string {
 	if t == nil || len(t.Payload) == 0 {
 		return ""

--- a/internal/api/admin/queue_test.go
+++ b/internal/api/admin/queue_test.go
@@ -45,6 +45,15 @@ func inboxPayloadNoSigJSON(t *testing.T) []byte {
 	return b
 }
 
+// assertHostCount asserts that got[i] == [host, count]. JSON decode yields
+// numbers as float64, so this hides the conversion noise at call sites.
+func assertHostCount(t *testing.T, got [][]any, i int, host string, count int) {
+	t.Helper()
+	require.Greater(t, len(got), i, "got len=%d, want index %d", len(got), i)
+	assert.Equal(t, []any{host, float64(count)}, got[i],
+		"got[%d] should be [%q, %d]", i, host, count)
+}
+
 // stubQueueInspector is a test double for admin.QueueInspector that returns
 // configurable canned responses without touching Redis.
 type stubQueueInspector struct {
@@ -423,9 +432,9 @@ func TestQueueDeliverDelayed_AggregatesByHost(t *testing.T) {
 	// a.example: 3 (s1+s3+r3), b.example: 2 (s2+r1), c.example: 1 (r2)
 	// count desc, tie 無し
 	require.Len(t, got, 3)
-	assert.Equal(t, []any{"a.example", float64(3)}, got[0])
-	assert.Equal(t, []any{"b.example", float64(2)}, got[1])
-	assert.Equal(t, []any{"c.example", float64(1)}, got[2])
+	assertHostCount(t, got, 0, "a.example", 3)
+	assertHostCount(t, got, 1, "b.example", 2)
+	assertHostCount(t, got, 2, "c.example", 1)
 }
 
 // TestQueueDeliverDelayed_EmptyReturnsEmptyArray ensures the response is
@@ -478,8 +487,61 @@ func TestQueueInboxDelayed_AggregatesByHostFromSignature(t *testing.T) {
 	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &got))
 	// a.example: 2, b.example: 1
 	require.Len(t, got, 2)
-	assert.Equal(t, []any{"a.example", float64(2)}, got[0])
-	assert.Equal(t, []any{"b.example", float64(1)}, got[1])
+	assertHostCount(t, got, 0, "a.example", 2)
+	assertHostCount(t, got, 1, "b.example", 1)
+}
+
+// pagedInspector is a QueueInspector stub that always returns full pages,
+// emulating an asynq inspector that has so many tasks the cursor never
+// reaches the end (or, worse, a misbehaving inspector that ignores empty
+// state). Used to verify the page cap defense in fetchAllDelayedTasks.
+type pagedInspector struct {
+	stubQueueInspector
+	payload []byte
+	calls   int
+}
+
+func (p *pagedInspector) ListScheduledTasks(_ string, _, pageSize int) ([]*apiadmin.QueueTaskSummary, error) {
+	p.calls++
+	rows := make([]*apiadmin.QueueTaskSummary, 0, pageSize)
+	for i := 0; i < pageSize; i++ {
+		rows = append(rows, &apiadmin.QueueTaskSummary{Payload: p.payload})
+	}
+	return rows, nil
+}
+
+func (p *pagedInspector) ListRetryTasks(_ string, _, _ int) ([]*apiadmin.QueueTaskSummary, error) {
+	// retry list は常に空 = scheduled の cap だけを test 対象にする。
+	return nil, nil
+}
+
+// TestQueueDeliverDelayed_PageCapBoundsRunaway: inspector が常に full page を
+// 返してくる misbehavior / pathological case で、handler が無限ループせず
+// `delayedTasksMaxPages` で打ち切ることを担保する。defense-in-depth の
+// 動作 test (#1179 review #1 + #2)。
+func TestQueueDeliverDelayed_PageCapBoundsRunaway(t *testing.T) {
+	// 本物の cap (1000 pages) で test すると 100K item 走査で 1 unit test に
+	// しては重い。test 中だけ cap を小さくして cap の挙動だけを検証する。
+	const cap = 3
+	prev := apiadmin.SetDelayedTasksMaxPages(cap)
+	t.Cleanup(func() { apiadmin.SetDelayedTasksMaxPages(prev) })
+
+	h, _, _, _ := newTestHandler(t)
+	insp := &pagedInspector{payload: deliverPayloadJSON(t, "https://always.example/inbox")}
+	h.SetQueueInspector(insp)
+
+	rec := doPost(h.QueueDeliverDelayed, `{}`, adminUser)
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	var got [][]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &got))
+	// 1 host × cap (3) × pageSize = 3 × DelayedTasksFetchPageSize 件で
+	// 打ち切られる。
+	require.Len(t, got, 1)
+	assertHostCount(t, got, 0, "always.example", cap*apiadmin.DelayedTasksFetchPageSize)
+	// inspector への ListScheduledTasks 呼び出しは cap 回数で打ち切られる。
+	assert.Equal(t, cap, insp.calls,
+		"page iteration must stop at delayedTasksMaxPages")
 }
 
 // TestQueueDeliverDelayed_StableSortOnTie: 同 count の host は host 名 asc で

--- a/internal/api/admin/queue_test.go
+++ b/internal/api/admin/queue_test.go
@@ -495,6 +495,10 @@ func TestQueueInboxDelayed_AggregatesByHostFromSignature(t *testing.T) {
 // emulating an asynq inspector that has so many tasks the cursor never
 // reaches the end (or, worse, a misbehaving inspector that ignores empty
 // state). Used to verify the page cap defense in fetchAllDelayedTasks.
+//
+// 他の QueueInspector method は embedded stubQueueInspector の zero-value に
+// fall through する (空 map / 空 slice 返却)。cap test では fetchAllDelayedTasks
+// 経由の Scheduled/Retry list call しか走らないので問題なし。
 type pagedInspector struct {
 	stubQueueInspector
 	payload []byte
@@ -522,8 +526,9 @@ func (p *pagedInspector) ListRetryTasks(_ string, _, _ int) ([]*apiadmin.QueueTa
 func TestQueueDeliverDelayed_PageCapBoundsRunaway(t *testing.T) {
 	// 本物の cap (1000 pages) で test すると 100K item 走査で 1 unit test に
 	// しては重い。test 中だけ cap を小さくして cap の挙動だけを検証する。
-	const cap = 3
-	prev := apiadmin.SetDelayedTasksMaxPages(cap)
+	// `pageCap` という名前で builtin `cap()` の shadow を避ける。
+	const pageCap = 3
+	prev := apiadmin.SetDelayedTasksMaxPages(pageCap)
 	t.Cleanup(func() { apiadmin.SetDelayedTasksMaxPages(prev) })
 
 	h, _, _, _ := newTestHandler(t)
@@ -535,12 +540,12 @@ func TestQueueDeliverDelayed_PageCapBoundsRunaway(t *testing.T) {
 
 	var got [][]any
 	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &got))
-	// 1 host × cap (3) × pageSize = 3 × DelayedTasksFetchPageSize 件で
+	// 1 host × pageCap (3) × pageSize = 3 × DelayedTasksFetchPageSize 件で
 	// 打ち切られる。
 	require.Len(t, got, 1)
-	assertHostCount(t, got, 0, "always.example", cap*apiadmin.DelayedTasksFetchPageSize)
+	assertHostCount(t, got, 0, "always.example", pageCap*apiadmin.DelayedTasksFetchPageSize)
 	// inspector への ListScheduledTasks 呼び出しは cap 回数で打ち切られる。
-	assert.Equal(t, cap, insp.calls,
+	assert.Equal(t, pageCap, insp.calls,
 		"page iteration must stop at delayedTasksMaxPages")
 }
 

--- a/internal/api/admin/queue_test.go
+++ b/internal/api/admin/queue_test.go
@@ -7,9 +7,43 @@ import (
 	"testing"
 
 	apiadmin "github.com/shiroha-a/mk/internal/api/admin"
+	"github.com/shiroha-a/mk/internal/queue"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+// deliverPayloadJSON returns a marshaled queue.DeliverPayload with the given
+// recipient inbox URL. Helper for *-delayed aggregation tests.
+func deliverPayloadJSON(t *testing.T, inbox string) []byte {
+	t.Helper()
+	b, err := json.Marshal(queue.DeliverPayload{Inbox: inbox})
+	require.NoError(t, err)
+	return b
+}
+
+// inboxPayloadJSON returns a marshaled queue.InboxPayload whose Headers
+// contain a minimal HTTP Signature header pointing at the given keyId URL.
+// 他の field (algorithm / headers / signature) は dummy で埋める ―
+// activitypub.ParseSignatureHeader はキー順序非依存で keyId だけ拾えれば成立。
+func inboxPayloadJSON(t *testing.T, keyID string) []byte {
+	t.Helper()
+	sig := `keyId="` + keyID + `",algorithm="rsa-sha256",headers="(request-target) date host",signature="abc"`
+	b, err := json.Marshal(queue.InboxPayload{
+		Body:    []byte(`{}`),
+		Headers: map[string]string{"Signature": sig},
+	})
+	require.NoError(t, err)
+	return b
+}
+
+// inboxPayloadNoSigJSON returns a marshaled InboxPayload with no signature
+// header — used to verify the aggregator silently skips it.
+func inboxPayloadNoSigJSON(t *testing.T) []byte {
+	t.Helper()
+	b, err := json.Marshal(queue.InboxPayload{Body: []byte(`{}`)})
+	require.NoError(t, err)
+	return b
+}
 
 // stubQueueInspector is a test double for admin.QueueInspector that returns
 // configurable canned responses without touching Redis.
@@ -353,95 +387,123 @@ func TestQueueQueueStats_SingleQueueQuery(t *testing.T) {
 	assert.EqualValues(t, 1, counts["active"])
 }
 
-func TestQueueDeliverDelayed_CombinesScheduledAndRetry(t *testing.T) {
+// TestQueueDeliverDelayed_AggregatesByHost verifies the upstream Misskey TS
+// contract: [[host, count], ...] tuples sorted by count desc. Mixed
+// scheduled+retry tasks targeting the same host must be merged into one
+// bucket. Tasks whose payload cannot yield a host (invalid JSON / unparsable
+// URL / empty Inbox) must be skipped silently. (#1179)
+func TestQueueDeliverDelayed_AggregatesByHost(t *testing.T) {
 	h, _, _, _ := newTestHandler(t)
 	insp := &stubQueueInspector{
 		scheduled: map[string][]*apiadmin.QueueTaskSummary{
-			"deliver": {{ID: "s1"}},
+			"deliver": {
+				{ID: "s1", Payload: deliverPayloadJSON(t, "https://a.example/inbox")},
+				{ID: "s2", Payload: deliverPayloadJSON(t, "https://b.example/users/foo/inbox")},
+				{ID: "s3", Payload: deliverPayloadJSON(t, "https://a.example/users/x/inbox")},
+				// 不正 payload は skip
+				{ID: "bad1", Payload: []byte("not json")},
+				{ID: "bad2", Payload: deliverPayloadJSON(t, "::not a url::")},
+				{ID: "bad3", Payload: deliverPayloadJSON(t, "")},
+			},
 		},
 		retry: map[string][]*apiadmin.QueueTaskSummary{
-			"deliver": {{ID: "r1"}},
+			"deliver": {
+				{ID: "r1", Payload: deliverPayloadJSON(t, "https://b.example/inbox")},
+				{ID: "r2", Payload: deliverPayloadJSON(t, "https://c.example/inbox")},
+				{ID: "r3", Payload: deliverPayloadJSON(t, "https://a.example/u2/inbox")},
+			},
 		},
 	}
 	h.SetQueueInspector(insp)
 	rec := doPost(h.QueueDeliverDelayed, `{}`, adminUser)
 	assert.Equal(t, http.StatusOK, rec.Code)
-	var rows []map[string]any
-	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &rows))
-	assert.Len(t, rows, 2)
+
+	var got [][]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &got))
+	// a.example: 3 (s1+s3+r3), b.example: 2 (s2+r1), c.example: 1 (r2)
+	// count desc, tie 無し
+	require.Len(t, got, 3)
+	assert.Equal(t, []any{"a.example", float64(3)}, got[0])
+	assert.Equal(t, []any{"b.example", float64(2)}, got[1])
+	assert.Equal(t, []any{"c.example", float64(1)}, got[2])
 }
 
-// listDelayedTasks が scheduled と retry を結合する際に合計が limit を超え
-// ないことを確認する (regression guard)。
-func TestQueueDeliverDelayed_CappedAtLimit(t *testing.T) {
+// TestQueueDeliverDelayed_EmptyReturnsEmptyArray ensures the response is
+// `[]` (not `null`) when no tasks exist, so frontend.reduce() yields 0.
+func TestQueueDeliverDelayed_EmptyReturnsEmptyArray(t *testing.T) {
 	h, _, _, _ := newTestHandler(t)
-	scheduled := make([]*apiadmin.QueueTaskSummary, 0, 3)
-	for _, id := range []string{"s1", "s2", "s3"} {
-		scheduled = append(scheduled, &apiadmin.QueueTaskSummary{ID: id})
-	}
-	retry := make([]*apiadmin.QueueTaskSummary, 0, 3)
-	for _, id := range []string{"r1", "r2", "r3"} {
-		retry = append(retry, &apiadmin.QueueTaskSummary{ID: id})
-	}
-	insp := &stubQueueInspector{
-		scheduled: map[string][]*apiadmin.QueueTaskSummary{"deliver": scheduled},
-		retry:     map[string][]*apiadmin.QueueTaskSummary{"deliver": retry},
-	}
-	h.SetQueueInspector(insp)
-
-	rec := doPost(h.QueueDeliverDelayed, `{"limit":4}`, adminUser)
+	h.SetQueueInspector(&stubQueueInspector{})
+	rec := doPost(h.QueueDeliverDelayed, `{}`, adminUser)
 	assert.Equal(t, http.StatusOK, rec.Code)
-	var rows []map[string]any
-	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &rows))
-	assert.Len(t, rows, 4, "combined output must not exceed requested limit")
-	// scheduled を先に詰めるので s1..s3 が最初の 3 件、続いて r1 が 4 件目
-	assert.Equal(t, "s1", rows[0]["id"])
-	assert.Equal(t, "r1", rows[3]["id"])
+	assert.Equal(t, "[]\n", rec.Body.String())
 }
 
-// listDelayedTasks が scheduled/retry 境界を越えて正しくページングできること
-// を確認する。旧実装では同じ req.Page を両リストに forward していたため、
-// scheduled でページが埋まると retry 側の早い項目が永久に見えなくなる bug が
-// あった (Devin #183 review)。
-func TestQueueDeliverDelayed_PagingCrossesBoundary(t *testing.T) {
+// TestQueueDeliverDelayed_NoInspectorReturnsEmpty: queueInspector が無い
+// (queue 機能無効構成) でも 200 + `[]` を返す。frontend が render crash しない
+// よう defensive に動く。
+func TestQueueDeliverDelayed_NoInspectorReturnsEmpty(t *testing.T) {
 	h, _, _, _ := newTestHandler(t)
-	scheduled := make([]*apiadmin.QueueTaskSummary, 0, 5)
-	for _, id := range []string{"s1", "s2", "s3", "s4", "s5"} {
-		scheduled = append(scheduled, &apiadmin.QueueTaskSummary{ID: id})
-	}
-	retry := make([]*apiadmin.QueueTaskSummary, 0, 3)
-	for _, id := range []string{"r1", "r2", "r3"} {
-		retry = append(retry, &apiadmin.QueueTaskSummary{ID: id})
-	}
+	rec := doPost(h.QueueDeliverDelayed, `{}`, adminUser)
+	assert.Equal(t, http.StatusOK, rec.Code)
+	assert.Equal(t, "[]\n", rec.Body.String())
+}
+
+// TestQueueInboxDelayed_AggregatesByHostFromSignature verifies inbox tasks
+// resolve host via HTTP Signature header (keyId URL), matching upstream
+// Misskey TS の `new URL(job.data.signature.keyId).host`. (#1179)
+func TestQueueInboxDelayed_AggregatesByHostFromSignature(t *testing.T) {
+	h, _, _, _ := newTestHandler(t)
 	insp := &stubQueueInspector{
-		scheduled: map[string][]*apiadmin.QueueTaskSummary{"deliver": scheduled},
-		retry:     map[string][]*apiadmin.QueueTaskSummary{"deliver": retry},
+		scheduled: map[string][]*apiadmin.QueueTaskSummary{
+			"inbox": {
+				{ID: "s1", Payload: inboxPayloadJSON(t, "https://a.example/users/alice#main-key")},
+				{ID: "s2", Payload: inboxPayloadJSON(t, "https://a.example/users/bob#main-key")},
+				// signature 無 → skip
+				{ID: "noSig", Payload: inboxPayloadNoSigJSON(t)},
+				// 不正 JSON → skip
+				{ID: "bad", Payload: []byte("not json")},
+			},
+		},
+		retry: map[string][]*apiadmin.QueueTaskSummary{
+			"inbox": {
+				{ID: "r1", Payload: inboxPayloadJSON(t, "https://b.example/users/eve#main-key")},
+			},
+		},
 	}
 	h.SetQueueInspector(insp)
+	rec := doPost(h.QueueInboxDelayed, `{}`, adminUser)
+	assert.Equal(t, http.StatusOK, rec.Code)
 
-	// page 1 limit 3 → s1, s2, s3
-	rec := doPost(h.QueueDeliverDelayed, `{"limit":3,"page":1}`, adminUser)
-	var rows []map[string]any
-	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &rows))
-	require.Len(t, rows, 3)
-	assert.Equal(t, []any{"s1", "s2", "s3"}, []any{rows[0]["id"], rows[1]["id"], rows[2]["id"]})
+	var got [][]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &got))
+	// a.example: 2, b.example: 1
+	require.Len(t, got, 2)
+	assert.Equal(t, []any{"a.example", float64(2)}, got[0])
+	assert.Equal(t, []any{"b.example", float64(1)}, got[1])
+}
 
-	// page 2 limit 3 → s4, s5, r1 (境界をまたぐ)
-	rec = doPost(h.QueueDeliverDelayed, `{"limit":3,"page":2}`, adminUser)
-	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &rows))
-	require.Len(t, rows, 3)
-	assert.Equal(t, []any{"s4", "s5", "r1"}, []any{rows[0]["id"], rows[1]["id"], rows[2]["id"]})
-
-	// page 3 limit 3 → r2, r3
-	rec = doPost(h.QueueDeliverDelayed, `{"limit":3,"page":3}`, adminUser)
-	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &rows))
-	require.Len(t, rows, 2)
-	assert.Equal(t, []any{"r2", "r3"}, []any{rows[0]["id"], rows[1]["id"]})
-
-	// page 4 → 空
-	rec = doPost(h.QueueDeliverDelayed, `{"limit":3,"page":4}`, adminUser)
-	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &rows))
-	assert.Empty(t, rows)
+// TestQueueDeliverDelayed_StableSortOnTie: 同 count の host は host 名 asc で
+// 安定 sort される (frontend で順序が flicker しないように)。
+func TestQueueDeliverDelayed_StableSortOnTie(t *testing.T) {
+	h, _, _, _ := newTestHandler(t)
+	insp := &stubQueueInspector{
+		scheduled: map[string][]*apiadmin.QueueTaskSummary{
+			"deliver": {
+				{ID: "1", Payload: deliverPayloadJSON(t, "https://c.example/inbox")},
+				{ID: "2", Payload: deliverPayloadJSON(t, "https://a.example/inbox")},
+				{ID: "3", Payload: deliverPayloadJSON(t, "https://b.example/inbox")},
+			},
+		},
+	}
+	h.SetQueueInspector(insp)
+	rec := doPost(h.QueueDeliverDelayed, `{}`, adminUser)
+	var got [][]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &got))
+	require.Len(t, got, 3)
+	// all count = 1, host 名 asc で並ぶ
+	assert.Equal(t, "a.example", got[0][0])
+	assert.Equal(t, "b.example", got[1][0])
+	assert.Equal(t, "c.example", got[2][0])
 }
 
 // QueueJobs は単一 queue でも limit を超えない件数しか返さないことを確認する。


### PR DESCRIPTION
## Summary

コントロールパネル → 連合ジョブ → Errored Instances panel が壊れていて、
ヘッダーに `(NaN jobs)`、その下に `(NaN jobs)` の行が複数並ぶ状態の bug fix。

## Root cause

`/api/admin/queue/deliver-delayed` と `/api/admin/queue/inbox-delayed` の
**response shape が Misskey TS spec と乖離**していた。

- TS spec (`packages/backend/src/server/api/endpoints/admin/queue/deliver-delayed.ts`):
  `[[host, count], ...]` の tuple 配列 (host 別集計)
- mk-go 現状: 個別 task summary object 配列 (`/api/admin/queue/jobs` と同 shape)

frontend (`pages/admin/federation-job-queue.chart.vue`) は
`jobs.reduce((a, b) => a + b[1], 0)` で `b[1]` (count) を見るので、
mk-go object 配列だと undefined → NaN になっていた。

## 主な変更点

`internal/api/admin/queue.go`:

- `QueueDeliverDelayed` / `QueueInboxDelayed` を host aggregation 方式に
  書き換え。
- `fetchAllDelayedTasks(queue)`: scheduled+retry を page 100 件で走査し
  全件取得する helper。
- `aggregateByHost(tasks, hostFn)`: host extractor を受け取って
  `[[host, count], ...]` tuple を count desc → host asc で sort して返す。
- `deliverHostFromPayload`: `DeliverPayload.Inbox` URL → `URL.Host`
- `inboxHostFromPayload`: `payload.Headers["Signature"]` を
  `activitypub.ParseSignatureHeader` で parse → `KeyID` URL → `URL.Host`
  (`InboxPayload.Host` は enqueue 時に未設定で使えないため signature 経由)
- 旧 `listDelayedTasks` / `delayedTasksMaxFetch` を削除 (他に呼び出しなし)

`internal/api/admin/queue_test.go`:

- 旧 paging-based test (`*_CombinesScheduledAndRetry` / `*_CappedAtLimit` /
  `*_PagingCrossesBoundary`) を撤去
- 新 aggregation test を 5 case 追加:
  - `_AggregatesByHost`: scheduled+retry の merge / 不正 payload skip
  - `_EmptyReturnsEmptyArray`: 空 task で `[]` (`null` ではない)
  - `_NoInspectorReturnsEmpty`: queueInspector nil でも 200 + `[]`
  - `_StableSortOnTie`: 同 count は host 名 asc で stable
  - `TestQueueInboxDelayed_AggregatesByHostFromSignature`: signature header 経由

## テスト

- `make fmt` / `make lint` clean
- `go test ./internal/api/admin/...` 全 pass
- UDS 本番 (mk-mkgo-1) で再現確認済 → 修正版を deploy 後に panel が正しく
  host 名と job 数を表示することを目視で確認予定

## Closes

#1179