### PR TITLE
fix(mkqdriver): Retry を failed bucket size に / RunTask で RetryJob fallback (#1181)

### DIFF
--- a/internal/queue/driver/mkqdriver/inspector.go
+++ b/internal/queue/driver/mkqdriver/inspector.go
@@ -42,7 +42,9 @@ func (i *Inspector) Queues() ([]string, error) {
 // 「retry-pending」と「permanent failure」を区別する bucket を持たない
 // limitation 由来。frontend (admin/job-queue.vue) は両方とも current size
 // を見れば十分なので影響は無い。BullMQ や asynq の semantic と完全一致
-// させるには mkq 自体に retry bucket を追加する別 PR が必要 (#1181)。
+// させるには mkq 自体に retry bucket を追加する必要があり、upstream に
+// 提案済 (shiroha-a/mkq#64)。それが land すれば本 driver も両 counter を
+// 区別して報告できるようになる。
 func (i *Inspector) GetQueueInfo(qname string) (*driver.InspectorInfo, error) {
 	q := i.driver.queueFor(qname)
 	if q == nil {
@@ -167,6 +169,14 @@ func (i *Inspector) DeleteAllPendingTasks(qname string) (int, error) {
 // 両 path で job が見つからなかった場合は最初の (PromoteJob の) error を
 // そのまま返す。job が wait や active など別 bucket に既に居る場合も
 // 同様に PromoteJob の error が caller に届く。
+//
+// semantic 差の注記: mkq の `RetryJob` は default で attempt 数 (`atm` /
+// `ats` BullMQ HASH counter) を 0 リセットする (`WithResetAttempts(true)`
+// 相当)。asynq の `Inspector.RunTask` は attempt 数を保持するので、
+// failed bucket path では mkq 側が「fresh start」semantic で、asynq 側が
+// 「resume with same attempts」semantic、という違いがある。admin の
+// 「Retry all queues now」の運用としては、operator が手動で promote した
+// 時点で fresh start が直感的なので、この semantic 差は意図通り。
 func (i *Inspector) RunTask(qname, taskID string) error {
 	q := i.driver.queueFor(qname)
 	if q == nil {

--- a/internal/queue/driver/mkqdriver/inspector.go
+++ b/internal/queue/driver/mkqdriver/inspector.go
@@ -30,9 +30,19 @@ func (i *Inspector) Queues() ([]string, error) {
 
 // GetQueueInfo returns the wait / active / delayed / completed /
 // failed counters for the named queue. Pending maps to mkq's wait
-// bucket (asynq's pending semantics); Retry has no direct mkq bucket
-// and stays at zero (BullMQ keeps retries inside the failed bucket
-// until the next dispatch attempt).
+// bucket (asynq's pending semantics).
+//
+// Retry semantics: mkq には asynq の Retry bucket に直接対応する独立 bucket
+// が存在せず、retry-backoff 待ちの job は failed bucket に居続け、次の
+// retry 時刻になって delayed bucket に移動する設計 (= `ListRetryTasks` も
+// failed bucket を読む)。よって driver level では Retry = failed bucket
+// size として asynq semantic に揃える。
+//
+// 副作用として Retry と Failed が同値になるが、これは mkq library が
+// 「retry-pending」と「permanent failure」を区別する bucket を持たない
+// limitation 由来。frontend (admin/job-queue.vue) は両方とも current size
+// を見れば十分なので影響は無い。BullMQ や asynq の semantic と完全一致
+// させるには mkq 自体に retry bucket を追加する別 PR が必要 (#1181)。
 func (i *Inspector) GetQueueInfo(qname string) (*driver.InspectorInfo, error) {
 	q := i.driver.queueFor(qname)
 	if q == nil {
@@ -73,10 +83,12 @@ func (i *Inspector) GetQueueInfo(qname string) (*driver.InspectorInfo, error) {
 		Completed: int(counts.Completed),
 		Failed:    int(counts.Failed),
 		Scheduled: scheduled,
-		// Retry: mkq keeps retries inside the failed bucket until they
-		// move back into delayed; surface 0 to keep the field
-		// well-defined.
-		Retry: 0,
+		// Retry = failed bucket current size。mkq では retry-backoff 待ち
+		// が failed bucket に居る ため、stream/queue_stats_publisher の
+		// `Delayed = Scheduled + Retry` 計算で正しく retry 待ち分が graph
+		// に乗るようになる。Failed と同値になる semantic limitation は
+		// 関数 doc 冒頭で説明済 (#1181)。
+		Retry: int(counts.Failed),
 	}, nil
 }
 
@@ -140,15 +152,31 @@ func (i *Inspector) DeleteAllPendingTasks(qname string) (int, error) {
 	return 0, nil
 }
 
-// RunTask promotes a delayed task to wait, equivalent to asynq's
-// "Run scheduled". For non-delayed jobs mkq.PromoteJob returns an
-// error which the caller should surface to the admin operator.
+// RunTask re-enqueues a task back into wait state, equivalent to asynq's
+// `Inspector.RunTask`. asynq の RunTask は delayed (= scheduled) と retry
+// 両方を受け入れるが、mkq では bucket 別に API が分かれている:
+//
+//   - PromoteJob: delayed → wait 専用 (失敗時 `ErrJobNotInDelayed`)
+//   - RetryJob:   failed → wait 専用 (asynq RunTask の後半相当)
+//
+// よって PromoteJob を先に試し、delayed 状態でなければ RetryJob に
+// fallback する。これで「Retry all queues now」(admin/queue/promote-jobs)
+// が failed bucket に居る retry-backoff 待ち job も含めて promote できる
+// ようになる (#1181)。
+//
+// 両 path で job が見つからなかった場合は最初の (PromoteJob の) error を
+// そのまま返す。job が wait や active など別 bucket に既に居る場合も
+// 同様に PromoteJob の error が caller に届く。
 func (i *Inspector) RunTask(qname, taskID string) error {
 	q := i.driver.queueFor(qname)
 	if q == nil {
 		return fmt.Errorf("mkqdriver: unknown queue %q", qname)
 	}
-	return q.PromoteJob(inspectorCtx(), taskID)
+	err := q.PromoteJob(inspectorCtx(), taskID)
+	if errors.Is(err, mkq.ErrJobNotInDelayed) {
+		return q.RetryJob(inspectorCtx(), taskID)
+	}
+	return err
 }
 
 // Close is a no-op — the underlying client is owned by the parent

--- a/internal/queue/driver/mkqdriver/integration_test.go
+++ b/internal/queue/driver/mkqdriver/integration_test.go
@@ -527,6 +527,110 @@ func TestInspector_RunTaskPromotesDelayed(t *testing.T) {
 	}, 3*time.Second, 50*time.Millisecond)
 }
 
+// TestInspector_GetQueueInfo_RetryReflectsFailedBucket verifies that the
+// Retry field surfaces the current failed bucket size (= retry-pending +
+// permanent failures). Without this the queueStats publisher's
+// Delayed = Scheduled + Retry calculation undercounts and admin/job-queue
+// graph stays stuck at 0 even when Errored Instances panel shows entries
+// (#1181).
+func TestInspector_GetQueueInfo_RetryReflectsFailedBucket(t *testing.T) {
+	d := newDriver(t)
+	srv := d.Server()
+	var wg sync.WaitGroup
+	wg.Add(1)
+	srv.Handle("ins:fail-then-check", func(_ context.Context, _ driver.Task) error {
+		defer wg.Done()
+		// SkipRetry sentinel = immediate failure into the failed bucket
+		// (mkq's ErrUnrecoverable). No backoff retry path involved, but
+		// the resulting bucket position is the same one retry-pending
+		// jobs occupy in mkq.
+		return fmt.Errorf("intentional fail: %w", driver.SkipRetry)
+	})
+	require.NoError(t, srv.Start())
+	t.Cleanup(srv.Shutdown)
+
+	require.NoError(t, d.Client().Enqueue(context.Background(),
+		"ins:fail-then-check", nil,
+		driver.WithQueue("deliver")))
+	if !waitGroupTimeout(&wg, 5*time.Second) {
+		t.Fatal("handler not invoked")
+	}
+
+	ins := d.Inspector()
+	require.Eventually(t, func() bool {
+		info, err := ins.GetQueueInfo("deliver")
+		return err == nil && info.Retry >= 1 && info.Failed >= 1
+	}, 5*time.Second, 50*time.Millisecond,
+		"Retry should reflect failed bucket size (was hardcoded to 0)")
+}
+
+// TestInspector_RunTask_FallsBackToRetryJobForFailedBucket verifies that
+// RunTask succeeds against a job in the failed bucket, by falling back
+// from PromoteJob (delayed-only) to RetryJob. asynq's Inspector.RunTask
+// transparently handles both buckets; this test pins the equivalent
+// behaviour for the mkq driver (#1181).
+//
+// Without this fallback the admin panel's "Retry all queues now" button
+// is a no-op on retry-pending jobs and operators cannot recover stuck
+// delivery from the UI.
+func TestInspector_RunTask_FallsBackToRetryJobForFailedBucket(t *testing.T) {
+	d := newDriver(t)
+	srv := d.Server()
+	var wg sync.WaitGroup
+	wg.Add(1)
+	srv.Handle("ins:fail-then-retry", func(_ context.Context, _ driver.Task) error {
+		defer wg.Done()
+		return fmt.Errorf("intentional fail: %w", driver.SkipRetry)
+	})
+	require.NoError(t, srv.Start())
+	t.Cleanup(srv.Shutdown)
+
+	require.NoError(t, d.Client().Enqueue(context.Background(),
+		"ins:fail-then-retry", nil,
+		driver.WithQueue("deliver")))
+	if !waitGroupTimeout(&wg, 5*time.Second) {
+		t.Fatal("handler not invoked")
+	}
+
+	ins := d.Inspector()
+	// Wait until the job has landed in the failed bucket (= ListRetryTasks
+	// sees it through mkq's failed bucket).
+	var failedTaskID string
+	require.Eventually(t, func() bool {
+		rows, err := ins.ListRetryTasks("deliver", 1, 30)
+		if err != nil || len(rows) == 0 {
+			return false
+		}
+		failedTaskID = rows[0].ID
+		return true
+	}, 5*time.Second, 50*time.Millisecond)
+
+	// RunTask must succeed via RetryJob fallback even though the job is
+	// not in mkq's delayed bucket. asynq's parity contract: callers only
+	// pass a task ID and the driver routes to the right move primitive.
+	require.NoError(t, ins.RunTask("deliver", failedTaskID),
+		"RunTask should fall back to RetryJob for failed bucket jobs")
+
+	// After the fallback the failed bucket count drops by one. We assert
+	// the count rather than chasing the job through wait→active→failed
+	// again (the handler is still registered and will refail it), since
+	// the contract under test is just "RunTask did not error and the job
+	// left the failed bucket".
+	require.Eventually(t, func() bool {
+		rows, err := ins.ListRetryTasks("deliver", 1, 30)
+		if err != nil {
+			return false
+		}
+		for _, r := range rows {
+			if r.ID == failedTaskID {
+				return false // still in failed bucket
+			}
+		}
+		return true
+	}, 5*time.Second, 50*time.Millisecond,
+		"job should have left the failed bucket after RetryJob fallback")
+}
+
 // TestScheduler_RegisterRoundtrip exercises the cron Register API and
 // the validator branches Scheduler exposes.
 func TestScheduler_RegisterRoundtrip(t *testing.T) {

--- a/internal/queue/driver/mkqdriver/integration_test.go
+++ b/internal/queue/driver/mkqdriver/integration_test.go
@@ -533,6 +533,14 @@ func TestInspector_RunTaskPromotesDelayed(t *testing.T) {
 // Delayed = Scheduled + Retry calculation undercounts and admin/job-queue
 // graph stays stuck at 0 even when Errored Instances panel shows entries
 // (#1181).
+//
+// この test は SkipRetry sentinel で permanent fail のみ trigger する。
+// retry-backoff 待ち job も mkq では同じ failed bucket に集まる設計なので、
+// この path で「failed bucket size が Retry に流れる」ことが pin できれば
+// 両ケース (permanent / backoff) を同等に cover している。retry-backoff
+// で実 cycle を回す test は wait/active 遷移込みで flaky になりやすいので
+// 採用しない (= 設計上の前提を pin することで足りる)。長期的には mkq
+// 側に proper retry bucket が入る予定 (shiroha-a/mkq#64)。
 func TestInspector_GetQueueInfo_RetryReflectsFailedBucket(t *testing.T) {
 	d := newDriver(t)
 	srv := d.Server()
@@ -541,9 +549,8 @@ func TestInspector_GetQueueInfo_RetryReflectsFailedBucket(t *testing.T) {
 	srv.Handle("ins:fail-then-check", func(_ context.Context, _ driver.Task) error {
 		defer wg.Done()
 		// SkipRetry sentinel = immediate failure into the failed bucket
-		// (mkq's ErrUnrecoverable). No backoff retry path involved, but
-		// the resulting bucket position is the same one retry-pending
-		// jobs occupy in mkq.
+		// (mkq's ErrUnrecoverable). retry-backoff 経路を回さない fast path
+		// だが、行き着く bucket は両ケース共通。
 		return fmt.Errorf("intentional fail: %w", driver.SkipRetry)
 	})
 	require.NoError(t, srv.Start())


### PR DESCRIPTION
## Summary

#1180 で /api/admin/queue/{deliver,inbox}-delayed の応答 shape を直した結果、
コントロールパネル → 連合ジョブ panel に 2 つの新しい不整合が露呈。両者
とも mkqdriver の Retry-bucket semantics が asynq driver と非対称なのが
原因の連鎖 bug。

| 症状 | 原因 |
|------|------|
| graph (Active / Delayed / Waiting) が 3 本とも 0 表示 | `GetQueueInfo.Retry = 0` hardcode で `Delayed = Scheduled + Retry` が undercount |
| 「Retry all queues now」を押しても減らない | `RunTask` が `PromoteJob` (delayed only) しか呼ばず、failed bucket は no-op |

## Fix 1: `GetQueueInfo.Retry = int(counts.Failed)`

mkq は asynq Retry bucket に直接対応する bucket を持たず、retry-backoff
待ちの job は failed bucket に居続ける設計。`ListRetryTasks` も failed
bucket を読む形だが、`GetQueueInfo.Retry` だけ 0 hardcode が残っていた。

Retry = failed bucket size として asynq semantic に揃え、`stream/queue_stats_publisher`
の `Delayed = Scheduled + Retry` が failed bucket 分も含めて graph に
表示されるようにする。

副作用: Retry と Failed が同値になるが、mkq に「retry-pending」と
「permanent failure」を区別する bucket が無い limitation 由来。
コメントで明記。

## Fix 2: `RunTask` に `RetryJob` fallback

mkq の promote API は bucket 別:

- `PromoteJob`: delayed → wait 専用 (失敗時 `ErrJobNotInDelayed`)
- `RetryJob`:   failed → wait 専用 (asynq RunTask の後半相当)

mkqdriver は前半しか実装していなかったため、failed bucket の job が
promote できなかった。`errors.Is(err, mkq.ErrJobNotInDelayed)` で
RetryJob にフォールバックし、両 bucket を透過的に扱う。

## 主な変更点

- `internal/queue/driver/mkqdriver/inspector.go`:
  - `GetQueueInfo`: `Retry: 0` → `Retry: int(counts.Failed)`、関数 doc に
    semantic limitation を明記
  - `RunTask`: PromoteJob → ErrJobNotInDelayed なら RetryJob に fallback、
    doc に asynq parity を明記

## テスト

`internal/queue/driver/mkqdriver/integration_test.go` に 2 case 追加:

- `TestInspector_GetQueueInfo_RetryReflectsFailedBucket`:
  SkipRetry で failed bucket に落とした job が `GetQueueInfo.Retry` に
  出ること
- `TestInspector_RunTask_FallsBackToRetryJobForFailedBucket`:
  failed bucket の job に対する `RunTask` が成功 (= RetryJob 経由で wait
  に戻る) こと

既存の `TestInspector_RunTaskPromotesDelayed` (delayed 経路) と合わせて
両 path を担保。

### 実行結果

```
$ go test ./internal/queue/driver/mkqdriver/...
ok  	github.com/shiroha-a/mk/internal/queue/driver/mkqdriver	27.925s
```

`make fmt` / `make lint` clean。

## 影響範囲

- mkqdriver の 2 method のみ修正
- admin handler / publisher / asynqdriver / frontend は **無改変**
- 既存 `Failed` field の意味は変更なし

## 非スコープ

- Active / Waiting graph が低トラフィック時に 0 表示になる件は publisher
  の tick 3sec interval 由来 (= 仕様)。本 PR ではフォーカスしない。
- mkq library 自体に proper retry bucket を追加する refactor は別 PR。

## Closes

#1181

## 関連

- #1180: 応答 shape fix (本 PR の前段)
- #1179: original NaN bug report