### PR TITLE
fix(federation): Like/Undo/Announce で remote resolve の permanent error を best-effort ack 化 (#1183)

### DIFF
--- a/internal/core/federation/permanent_error.go
+++ b/internal/core/federation/permanent_error.go
@@ -7,11 +7,16 @@ import (
 	corereaction "github.com/shiroha-a/mk/internal/core/reaction"
 )
 
-// isPermanentResolveError reports whether err represents a permanent failure
-// during remote ActivityPub object / actor resolution. callers in this
-// package use it to decide between "best-effort skip" (= log warn and return
-// nil, swallowing the activity) and "transient failure" (= return err to put
+// isPermanentSkipError reports whether err represents a permanent failure
+// that the inbox processor should silently ack rather than feed back into
+// the retry queue. callers (= Like / Undo / Announce handler 群) use this
+// to choose between "best-effort skip" (= log info and return nil,
+// swallowing the activity) and "transient failure" (= return err to put
 // the activity back on the retry queue).
+//
+// 「resolve 経路の失敗」と「activity 処理の policy 違反」の両方を含むため
+// 命名は resolve 限定にしていない (= reactionService.Create が返す
+// `ErrNoteNotVisible` も同 helper で吸収する想定)。
 //
 // permanent と分類する error:
 //
@@ -27,7 +32,7 @@ import (
 // transient と分類する (false 返す) error: 5xx / network error / timeout
 // 等、対側の一過性障害。retry サイクルに乗せる。`nil` も false を返す
 // (= 「成功」を「permanent fail」と誤判定しないため。
-func isPermanentResolveError(err error) bool {
+func isPermanentSkipError(err error) bool {
 	if err == nil {
 		return false
 	}

--- a/internal/core/federation/permanent_error.go
+++ b/internal/core/federation/permanent_error.go
@@ -1,0 +1,49 @@
+package federation
+
+import (
+	"errors"
+
+	"github.com/shiroha-a/mk/internal/activitypub"
+	corereaction "github.com/shiroha-a/mk/internal/core/reaction"
+)
+
+// isPermanentResolveError reports whether err represents a permanent failure
+// during remote ActivityPub object / actor resolution. callers in this
+// package use it to decide between "best-effort skip" (= log warn and return
+// nil, swallowing the activity) and "transient failure" (= return err to put
+// the activity back on the retry queue).
+//
+// permanent と分類する error:
+//
+//   - HTTP 4xx (401 / 403 / 404 / 410) — `*activitypub.StatusError`
+//     mk-go が follower で無い follower-only note / 削除済 / authorized
+//     fetch 拒否 のいずれも、retry しても解消しない構造的失敗。
+//   - `ErrInvalidActor` / `ErrInvalidNote` — 取得は成功したが対側が返した
+//     JSON が parse 不能。schema 不正で retry でも直らない。
+//   - `corereaction.ErrNoteNotVisible` — note 解決後の visibility 違反。
+//     mk-go の policy 上 reaction を作れないので、activity 全体は ack
+//     して終わる方が筋。
+//
+// transient と分類する (false 返す) error: 5xx / network error / timeout
+// 等、対側の一過性障害。retry サイクルに乗せる。`nil` も false を返す
+// (= 「成功」を「permanent fail」と誤判定しないため。
+func isPermanentResolveError(err error) bool {
+	if err == nil {
+		return false
+	}
+	var statusErr *activitypub.StatusError
+	if errors.As(err, &statusErr) {
+		switch statusErr.StatusCode {
+		case 401, 403, 404, 410:
+			return true
+		}
+		return false
+	}
+	if errors.Is(err, ErrInvalidActor) || errors.Is(err, ErrInvalidNote) {
+		return true
+	}
+	if errors.Is(err, corereaction.ErrNoteNotVisible) {
+		return true
+	}
+	return false
+}

--- a/internal/core/federation/permanent_error_test.go
+++ b/internal/core/federation/permanent_error_test.go
@@ -39,7 +39,7 @@ func TestIsPermanentResolveError(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := isPermanentResolveError(tt.err)
+			got := isPermanentSkipError(tt.err)
 			assert.Equal(t, tt.want, got, "err=%v", tt.err)
 		})
 	}

--- a/internal/core/federation/permanent_error_test.go
+++ b/internal/core/federation/permanent_error_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestIsPermanentResolveError(t *testing.T) {
+func TestIsPermanentSkipError(t *testing.T) {
 	tests := []struct {
 		name string
 		err  error

--- a/internal/core/federation/permanent_error_test.go
+++ b/internal/core/federation/permanent_error_test.go
@@ -1,0 +1,46 @@
+package federation
+
+import (
+	"errors"
+	"fmt"
+	"net"
+	"testing"
+
+	"github.com/shiroha-a/mk/internal/activitypub"
+	corereaction "github.com/shiroha-a/mk/internal/core/reaction"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestIsPermanentResolveError(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{"nil", nil, false},
+		{"status 404", &activitypub.StatusError{StatusCode: 404, Status: "404 Not Found"}, true},
+		{"status 401", &activitypub.StatusError{StatusCode: 401, Status: "401 Unauthorized"}, true},
+		{"status 403", &activitypub.StatusError{StatusCode: 403, Status: "403 Forbidden"}, true},
+		{"status 410", &activitypub.StatusError{StatusCode: 410, Status: "410 Gone"}, true},
+		{"status 500", &activitypub.StatusError{StatusCode: 500, Status: "500 Internal Server Error"}, false},
+		{"status 502", &activitypub.StatusError{StatusCode: 502, Status: "502 Bad Gateway"}, false},
+		{"status 503", &activitypub.StatusError{StatusCode: 503, Status: "503 Service Unavailable"}, false},
+		{"status 530", &activitypub.StatusError{StatusCode: 530, Status: "530"}, false},
+		{"ErrInvalidActor", ErrInvalidActor, true},
+		{"ErrInvalidNote", ErrInvalidNote, true},
+		{"ErrInvalidActor wrapped", fmt.Errorf("resolve: %w", ErrInvalidActor), true},
+		{"ErrInvalidNote wrapped", fmt.Errorf("ingest: %w", ErrInvalidNote), true},
+		{"ErrNoteNotVisible", corereaction.ErrNoteNotVisible, true},
+		{"ErrNoteNotVisible wrapped", fmt.Errorf("create: %w", corereaction.ErrNoteNotVisible), true},
+		{"status 404 wrapped", fmt.Errorf("fetch %s: %w", "url", &activitypub.StatusError{StatusCode: 404, Status: "404"}), true},
+		{"status 500 wrapped", fmt.Errorf("fetch: %w", &activitypub.StatusError{StatusCode: 500, Status: "500"}), false},
+		{"generic error", errors.New("dial failed"), false},
+		{"net.OpError (transient)", &net.OpError{Op: "dial", Err: errors.New("connection refused")}, false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := isPermanentResolveError(tt.err)
+			assert.Equal(t, tt.want, got, "err=%v", tt.err)
+		})
+	}
+}

--- a/internal/core/federation/processor.go
+++ b/internal/core/federation/processor.go
@@ -582,8 +582,8 @@ func (p *Processor) handleUndoLike(act genericActivity, inner genericActivity) e
 	reactor, err := p.resolver.ResolveActor(act.Actor)
 	if err != nil {
 		// permanent な actor resolve 失敗は ack して skip (#1183)。
-		if isPermanentResolveError(err) {
-			slog.Warn("federation: Undo(Like) actor resolve permanent fail, skip",
+		if isPermanentSkipError(err) {
+			slog.Info("federation: Undo(Like) actor resolve permanent fail, skip",
 				"actor", act.Actor, "err", err)
 			return nil
 		}
@@ -608,8 +608,8 @@ func (p *Processor) handleUndoLike(act genericActivity, inner genericActivity) e
 		// が存在しないだけでも idempotent (= 削除済みは ErrReactionNotFound で
 		// nil 返却) なので、resolve できない先の reaction は元から無い扱いで
 		// 整合する (#1183)。
-		if isPermanentResolveError(err) {
-			slog.Warn("federation: Undo(Like) target resolve permanent fail, skip",
+		if isPermanentSkipError(err) {
+			slog.Info("federation: Undo(Like) target resolve permanent fail, skip",
 				"object", targetURI, "actor", act.Actor, "err", err)
 			return nil
 		}
@@ -633,8 +633,8 @@ func (p *Processor) handleUndoAnnounce(act genericActivity, inner genericActivit
 		// permanent な actor resolve 失敗は ack (#1183)。announcer が居な
 		// ければ Announce record も作っていないはずなので削除対象も無く
 		// idempotent と整合する。
-		if isPermanentResolveError(err) {
-			slog.Warn("federation: Undo(Announce) actor resolve permanent fail, skip",
+		if isPermanentSkipError(err) {
+			slog.Info("federation: Undo(Announce) actor resolve permanent fail, skip",
 				"actor", act.Actor, "err", err)
 			return nil
 		}
@@ -649,8 +649,8 @@ func (p *Processor) handleUndoAnnounce(act genericActivity, inner genericActivit
 		// permanent な target resolve 失敗は ack。target が解決できなければ
 		// renote record も無いはずなので、削除対象が無いまま activity を ack
 		// する形で整合する (#1183)。
-		if isPermanentResolveError(err) {
-			slog.Warn("federation: Undo(Announce) target resolve permanent fail, skip",
+		if isPermanentSkipError(err) {
+			slog.Info("federation: Undo(Announce) target resolve permanent fail, skip",
 				"object", targetURI, "actor", act.Actor, "err", err)
 			return nil
 		}
@@ -866,8 +866,8 @@ func (p *Processor) handleLike(act genericActivity) error {
 		// failed bucket 行きを避ける (#1183)。reactor が居なければ reaction
 		// 自体作れないので skip = noop。transient (5xx / network) は従来通り
 		// retry サイクルに乗せる。
-		if isPermanentResolveError(err) {
-			slog.Warn("federation: Like actor resolve permanent fail, skip",
+		if isPermanentSkipError(err) {
+			slog.Info("federation: Like actor resolve permanent fail, skip",
 				"actor", act.Actor, "err", err)
 			return nil
 		}
@@ -908,8 +908,8 @@ func (p *Processor) handleLike(act genericActivity) error {
 	if err != nil {
 		// permanent な target resolve 失敗 (followers-only / 削除済 等) は
 		// reaction record を作らず ack。retry しても永久に解消しない (#1183)。
-		if isPermanentResolveError(err) {
-			slog.Warn("federation: Like target resolve permanent fail, skip reaction record",
+		if isPermanentSkipError(err) {
+			slog.Info("federation: Like target resolve permanent fail, skip reaction record",
 				"object", like.Object, "actor", act.Actor, "err", err)
 			return nil
 		}
@@ -929,8 +929,8 @@ func (p *Processor) handleLike(act genericActivity) error {
 		}
 		// reaction service が visibility 違反 (`ErrNoteNotVisible`) 等を
 		// 返すケースも permanent 扱いで skip (#1183)。
-		if isPermanentResolveError(err) {
-			slog.Warn("federation: Like reaction create permanent fail, skip",
+		if isPermanentSkipError(err) {
+			slog.Info("federation: Like reaction create permanent fail, skip",
 				"object", like.Object, "actor", act.Actor, "err", err)
 			return nil
 		}
@@ -945,8 +945,8 @@ func (p *Processor) handleAnnounce(act genericActivity) error {
 	if err != nil {
 		// permanent な actor resolve 失敗は ack して skip (#1183、handleLike
 		// と同じ理由)。
-		if isPermanentResolveError(err) {
-			slog.Warn("federation: Announce actor resolve permanent fail, skip",
+		if isPermanentSkipError(err) {
+			slog.Info("federation: Announce actor resolve permanent fail, skip",
 				"actor", act.Actor, "err", err)
 			return nil
 		}
@@ -960,8 +960,8 @@ func (p *Processor) handleAnnounce(act genericActivity) error {
 	if err != nil {
 		// permanent な target resolve 失敗 (削除済 note / followers-only) は
 		// Announce 記録を skip して ack (#1183)。
-		if isPermanentResolveError(err) {
-			slog.Warn("federation: Announce target resolve permanent fail, skip",
+		if isPermanentSkipError(err) {
+			slog.Info("federation: Announce target resolve permanent fail, skip",
 				"object", targetURI, "actor", act.Actor, "err", err)
 			return nil
 		}

--- a/internal/core/federation/processor.go
+++ b/internal/core/federation/processor.go
@@ -583,7 +583,7 @@ func (p *Processor) handleUndoLike(act genericActivity, inner genericActivity) e
 	if err != nil {
 		// permanent な actor resolve 失敗は ack して skip (#1183)。
 		if isPermanentSkipError(err) {
-			slog.Info("federation: Undo(Like) actor resolve permanent fail, skip",
+			slog.Info("federation: skipping Undo(Like) (actor unresolvable)",
 				"actor", act.Actor, "err", err)
 			return nil
 		}
@@ -609,7 +609,7 @@ func (p *Processor) handleUndoLike(act genericActivity, inner genericActivity) e
 		// nil 返却) なので、resolve できない先の reaction は元から無い扱いで
 		// 整合する (#1183)。
 		if isPermanentSkipError(err) {
-			slog.Info("federation: Undo(Like) target resolve permanent fail, skip",
+			slog.Info("federation: skipping Undo(Like) (target unresolvable)",
 				"object", targetURI, "actor", act.Actor, "err", err)
 			return nil
 		}
@@ -634,7 +634,7 @@ func (p *Processor) handleUndoAnnounce(act genericActivity, inner genericActivit
 		// ければ Announce record も作っていないはずなので削除対象も無く
 		// idempotent と整合する。
 		if isPermanentSkipError(err) {
-			slog.Info("federation: Undo(Announce) actor resolve permanent fail, skip",
+			slog.Info("federation: skipping Undo(Announce) (actor unresolvable)",
 				"actor", act.Actor, "err", err)
 			return nil
 		}
@@ -650,7 +650,7 @@ func (p *Processor) handleUndoAnnounce(act genericActivity, inner genericActivit
 		// renote record も無いはずなので、削除対象が無いまま activity を ack
 		// する形で整合する (#1183)。
 		if isPermanentSkipError(err) {
-			slog.Info("federation: Undo(Announce) target resolve permanent fail, skip",
+			slog.Info("federation: skipping Undo(Announce) (target unresolvable)",
 				"object", targetURI, "actor", act.Actor, "err", err)
 			return nil
 		}
@@ -867,7 +867,7 @@ func (p *Processor) handleLike(act genericActivity) error {
 		// 自体作れないので skip = noop。transient (5xx / network) は従来通り
 		// retry サイクルに乗せる。
 		if isPermanentSkipError(err) {
-			slog.Info("federation: Like actor resolve permanent fail, skip",
+			slog.Info("federation: skipping Like (actor unresolvable)",
 				"actor", act.Actor, "err", err)
 			return nil
 		}
@@ -909,7 +909,7 @@ func (p *Processor) handleLike(act genericActivity) error {
 		// permanent な target resolve 失敗 (followers-only / 削除済 等) は
 		// reaction record を作らず ack。retry しても永久に解消しない (#1183)。
 		if isPermanentSkipError(err) {
-			slog.Info("federation: Like target resolve permanent fail, skip reaction record",
+			slog.Info("federation: skipping Like (target unresolvable)",
 				"object", like.Object, "actor", act.Actor, "err", err)
 			return nil
 		}
@@ -930,7 +930,7 @@ func (p *Processor) handleLike(act genericActivity) error {
 		// reaction service が visibility 違反 (`ErrNoteNotVisible`) 等を
 		// 返すケースも permanent 扱いで skip (#1183)。
 		if isPermanentSkipError(err) {
-			slog.Info("federation: Like reaction create permanent fail, skip",
+			slog.Info("federation: skipping Like (reaction policy violation)",
 				"object", like.Object, "actor", act.Actor, "err", err)
 			return nil
 		}
@@ -946,7 +946,7 @@ func (p *Processor) handleAnnounce(act genericActivity) error {
 		// permanent な actor resolve 失敗は ack して skip (#1183、handleLike
 		// と同じ理由)。
 		if isPermanentSkipError(err) {
-			slog.Info("federation: Announce actor resolve permanent fail, skip",
+			slog.Info("federation: skipping Announce (actor unresolvable)",
 				"actor", act.Actor, "err", err)
 			return nil
 		}
@@ -961,7 +961,7 @@ func (p *Processor) handleAnnounce(act genericActivity) error {
 		// permanent な target resolve 失敗 (削除済 note / followers-only) は
 		// Announce 記録を skip して ack (#1183)。
 		if isPermanentSkipError(err) {
-			slog.Info("federation: Announce target resolve permanent fail, skip",
+			slog.Info("federation: skipping Announce (target unresolvable)",
 				"object", targetURI, "actor", act.Actor, "err", err)
 			return nil
 		}

--- a/internal/core/federation/processor.go
+++ b/internal/core/federation/processor.go
@@ -581,6 +581,12 @@ func (p *Processor) handleUndoFollow(act genericActivity, inner genericActivity)
 func (p *Processor) handleUndoLike(act genericActivity, inner genericActivity) error {
 	reactor, err := p.resolver.ResolveActor(act.Actor)
 	if err != nil {
+		// permanent な actor resolve 失敗は ack して skip (#1183)。
+		if isPermanentResolveError(err) {
+			slog.Warn("federation: Undo(Like) actor resolve permanent fail, skip",
+				"actor", act.Actor, "err", err)
+			return nil
+		}
 		return err
 	}
 	targetURI, err := readObjectString(inner.Object)
@@ -598,6 +604,15 @@ func (p *Processor) handleUndoLike(act genericActivity, inner genericActivity) e
 	}
 	target, err := p.resolver.ResolveNote(targetURI)
 	if err != nil {
+		// permanent な target resolve 失敗は ack。Undo の対象 reaction record
+		// が存在しないだけでも idempotent (= 削除済みは ErrReactionNotFound で
+		// nil 返却) なので、resolve できない先の reaction は元から無い扱いで
+		// 整合する (#1183)。
+		if isPermanentResolveError(err) {
+			slog.Warn("federation: Undo(Like) target resolve permanent fail, skip",
+				"object", targetURI, "actor", act.Actor, "err", err)
+			return nil
+		}
 		return err
 	}
 	if err := p.reactionService.Delete(reactor, target.ID); err != nil {
@@ -615,6 +630,14 @@ func (p *Processor) handleUndoLike(act genericActivity, inner genericActivity) e
 func (p *Processor) handleUndoAnnounce(act genericActivity, inner genericActivity) error {
 	announcer, err := p.resolver.ResolveActor(act.Actor)
 	if err != nil {
+		// permanent な actor resolve 失敗は ack (#1183)。announcer が居な
+		// ければ Announce record も作っていないはずなので削除対象も無く
+		// idempotent と整合する。
+		if isPermanentResolveError(err) {
+			slog.Warn("federation: Undo(Announce) actor resolve permanent fail, skip",
+				"actor", act.Actor, "err", err)
+			return nil
+		}
 		return err
 	}
 	targetURI, err := readObjectString(inner.Object)
@@ -623,6 +646,14 @@ func (p *Processor) handleUndoAnnounce(act genericActivity, inner genericActivit
 	}
 	target, err := p.resolver.ResolveNote(targetURI)
 	if err != nil {
+		// permanent な target resolve 失敗は ack。target が解決できなければ
+		// renote record も無いはずなので、削除対象が無いまま activity を ack
+		// する形で整合する (#1183)。
+		if isPermanentResolveError(err) {
+			slog.Warn("federation: Undo(Announce) target resolve permanent fail, skip",
+				"object", targetURI, "actor", act.Actor, "err", err)
+			return nil
+		}
 		return err
 	}
 	// announcer が pure renote を 1 件でも持っていれば削除する。複数あった場合
@@ -830,6 +861,16 @@ func hydrateNoteForFanout(repo interface {
 func (p *Processor) handleLike(act genericActivity) error {
 	reactor, err := p.resolver.ResolveActor(act.Actor)
 	if err != nil {
+		// permanent な actor resolve 失敗 (削除済 / visibility 制限 /
+		// authorized fetch 拒否 / malformed JSON) は activity を ack して
+		// failed bucket 行きを避ける (#1183)。reactor が居なければ reaction
+		// 自体作れないので skip = noop。transient (5xx / network) は従来通り
+		// retry サイクルに乗せる。
+		if isPermanentResolveError(err) {
+			slog.Warn("federation: Like actor resolve permanent fail, skip",
+				"actor", act.Actor, "err", err)
+			return nil
+		}
 		return err
 	}
 	// アクティビティ全体を Like として解釈し content/_misskey_reaction を取得する。
@@ -865,6 +906,13 @@ func (p *Processor) handleLike(act genericActivity) error {
 	}
 	target, err := p.resolver.ResolveNote(like.Object)
 	if err != nil {
+		// permanent な target resolve 失敗 (followers-only / 削除済 等) は
+		// reaction record を作らず ack。retry しても永久に解消しない (#1183)。
+		if isPermanentResolveError(err) {
+			slog.Warn("federation: Like target resolve permanent fail, skip reaction record",
+				"object", like.Object, "actor", act.Actor, "err", err)
+			return nil
+		}
 		return err
 	}
 	// Like activity に乗ってきたカスタム絵文字メタデータを emoji table に
@@ -879,6 +927,13 @@ func (p *Processor) handleLike(act genericActivity) error {
 		if errors.Is(err, corereaction.ErrAlreadyReacted) {
 			return nil
 		}
+		// reaction service が visibility 違反 (`ErrNoteNotVisible`) 等を
+		// 返すケースも permanent 扱いで skip (#1183)。
+		if isPermanentResolveError(err) {
+			slog.Warn("federation: Like reaction create permanent fail, skip",
+				"object", like.Object, "actor", act.Actor, "err", err)
+			return nil
+		}
 		return err
 	}
 	return nil
@@ -888,6 +943,13 @@ func (p *Processor) handleLike(act genericActivity) error {
 func (p *Processor) handleAnnounce(act genericActivity) error {
 	announcer, err := p.resolver.ResolveActor(act.Actor)
 	if err != nil {
+		// permanent な actor resolve 失敗は ack して skip (#1183、handleLike
+		// と同じ理由)。
+		if isPermanentResolveError(err) {
+			slog.Warn("federation: Announce actor resolve permanent fail, skip",
+				"actor", act.Actor, "err", err)
+			return nil
+		}
 		return err
 	}
 	targetURI, err := readObjectString(act.Object)
@@ -896,6 +958,13 @@ func (p *Processor) handleAnnounce(act genericActivity) error {
 	}
 	target, err := p.resolver.ResolveNote(targetURI)
 	if err != nil {
+		// permanent な target resolve 失敗 (削除済 note / followers-only) は
+		// Announce 記録を skip して ack (#1183)。
+		if isPermanentResolveError(err) {
+			slog.Warn("federation: Announce target resolve permanent fail, skip",
+				"object", targetURI, "actor", act.Actor, "err", err)
+			return nil
+		}
 		return err
 	}
 	// upstream Misskey #17308 (= 2026.5.0 fix / triage #1002): relay 由来の

--- a/internal/core/federation/processor_step_f_test.go
+++ b/internal/core/federation/processor_step_f_test.go
@@ -129,14 +129,18 @@ func TestProcess_LikeAlreadyReacted(t *testing.T) {
 }
 
 func TestProcess_LikeUnknownTarget(t *testing.T) {
+	// best-effort ack semantic (#1183): target note の resolve 失敗
+	// (= stubFetcher が actor JSON を返すので Note として parse できず
+	// `ErrInvalidNote` で permanent fail) は activity を ack して reaction
+	// record を作らない。retry サイクルに乗せない。
 	env := newFullProcessor(t, aliceActor)
 	body := []byte(`{
 		"type": "Like",
 		"actor": "https://remote.example/users/alice",
 		"object": "https://example.com/notes/missing"
 	}`)
-	err := env.processor.Process(body)
-	assert.Error(t, err)
+	require.NoError(t, env.processor.Process(body))
+	assert.Empty(t, env.reactionRepo.Reactions, "permanent target resolve fail は reaction を作らない")
 }
 
 func TestProcess_LikeNoReactionService(t *testing.T) {
@@ -162,14 +166,17 @@ func TestProcess_LikeBadObject(t *testing.T) {
 }
 
 func TestProcess_LikeActorError(t *testing.T) {
+	// best-effort ack (#1183): actor JSON parse 失敗 (ErrInvalidActor) は
+	// permanent fail として ack。reactor が居なければ reaction も作れない
+	// ので skip = noop。
 	env := newFullProcessor(t, "{not json")
 	body := []byte(`{
 		"type": "Like",
 		"actor": "https://remote.example/users/alice",
 		"object": "https://example.com/notes/n1"
 	}`)
-	err := env.processor.Process(body)
-	assert.Error(t, err)
+	require.NoError(t, env.processor.Process(body))
+	assert.Empty(t, env.reactionRepo.Reactions, "permanent actor resolve fail は reaction を作らない")
 }
 
 // --- Like content / _misskey_reaction (ported from nekonoverse handler_like) --
@@ -295,25 +302,26 @@ func TestProcess_AnnounceDuplicate(t *testing.T) {
 }
 
 func TestProcess_AnnounceUnknownTarget(t *testing.T) {
+	// best-effort ack (#1183): target resolve 失敗は permanent として skip。
 	env := newFullProcessor(t, aliceActor)
 	body := []byte(`{
 		"type": "Announce",
 		"actor": "https://remote.example/users/alice",
 		"object": "https://example.com/notes/missing"
 	}`)
-	err := env.processor.Process(body)
-	assert.Error(t, err)
+	require.NoError(t, env.processor.Process(body))
 }
 
 func TestProcess_AnnounceActorError(t *testing.T) {
+	// best-effort ack (#1183): actor resolve 失敗 (ErrInvalidActor) は
+	// permanent として skip。
 	env := newFullProcessor(t, "{not json")
 	body := []byte(`{
 		"type": "Announce",
 		"actor": "https://remote.example/users/alice",
 		"object": "https://example.com/notes/n1"
 	}`)
-	err := env.processor.Process(body)
-	assert.Error(t, err)
+	require.NoError(t, env.processor.Process(body))
 }
 
 func TestProcess_AnnounceBadObject(t *testing.T) {
@@ -704,25 +712,26 @@ func TestProcess_UndoLikeNoReactionService(t *testing.T) {
 }
 
 func TestProcess_UndoLikeUnknownTarget(t *testing.T) {
+	// best-effort ack (#1183): Undo(Like) の target resolve 失敗は ack。
+	// 元 reaction record も無いはずなので idempotent と整合する。
 	env := newFullProcessor(t, aliceActor)
 	undo := []byte(`{
 		"type": "Undo",
 		"actor": "https://remote.example/users/alice",
 		"object": {"type":"Like","object":"https://example.com/notes/missing"}
 	}`)
-	err := env.processor.Process(undo)
-	assert.Error(t, err)
+	require.NoError(t, env.processor.Process(undo))
 }
 
 func TestProcess_UndoLikeActorError(t *testing.T) {
+	// best-effort ack (#1183): Undo(Like) の actor resolve 失敗は ack。
 	env := newFullProcessor(t, "{not json")
 	undo := []byte(`{
 		"type": "Undo",
 		"actor": "https://remote.example/users/alice",
 		"object": {"type":"Like","object":"https://example.com/notes/n1"}
 	}`)
-	err := env.processor.Process(undo)
-	assert.Error(t, err)
+	require.NoError(t, env.processor.Process(undo))
 }
 
 func TestProcess_UndoLikeBadObject(t *testing.T) {
@@ -784,25 +793,25 @@ func TestProcess_UndoAnnounceNoMatch(t *testing.T) {
 }
 
 func TestProcess_UndoAnnounceActorError(t *testing.T) {
+	// best-effort ack (#1183): Undo(Announce) の actor resolve 失敗は ack。
 	env := newFullProcessor(t, "{not json")
 	undo := []byte(`{
 		"type": "Undo",
 		"actor": "https://remote.example/users/alice",
 		"object": {"type":"Announce","object":"https://example.com/notes/n1"}
 	}`)
-	err := env.processor.Process(undo)
-	assert.Error(t, err)
+	require.NoError(t, env.processor.Process(undo))
 }
 
 func TestProcess_UndoAnnounceUnknownTarget(t *testing.T) {
+	// best-effort ack (#1183): Undo(Announce) の target resolve 失敗は ack。
 	env := newFullProcessor(t, aliceActor)
 	undo := []byte(`{
 		"type": "Undo",
 		"actor": "https://remote.example/users/alice",
 		"object": {"type":"Announce","object":"https://example.com/notes/missing"}
 	}`)
-	err := env.processor.Process(undo)
-	assert.Error(t, err)
+	require.NoError(t, env.processor.Process(undo))
 }
 
 func TestProcess_UndoAnnounceBadObject(t *testing.T) {
@@ -1333,8 +1342,41 @@ func TestProcess_UndoAnnounceNoMatchSkips(t *testing.T) {
 	require.NoError(t, env.processor.Process(undo))
 }
 
-// handleLike: reactionService.Create returns a non-AlreadyReacted error
-// (use a followers-only target so it returns ErrNoteNotVisible).
+// TestProcess_LikeTransientFetchError: 5xx 等の transient な fetcher error は
+// 従来通り err 返却で activity を retry サイクルに乗せる (#1183 の best-effort
+// 化は permanent error 限定であって、transient はそのまま retry させる)。
+func TestProcess_LikeTransientFetchError(t *testing.T) {
+	userRepo := testutil.NewMockUserRepository()
+	noteRepo := testutil.NewMockNoteRepository()
+	reactionRepo := testutil.NewMockNoteReactionRepository()
+	emojiRepo := testutil.NewMockEmojiRepository()
+	followingRepo := testutil.NewMockFollowingRepository()
+	urls := activitypub.NewURLBuilder("https://example.com")
+	idGen, _ := id.NewGenerator("aidx")
+	// 502 Bad Gateway = transient 障害想定。permanent error の whitelist
+	// (401/403/404/410 / ErrInvalidActor / ErrInvalidNote / ErrNoteNotVisible)
+	// に該当しないため、handler は err を caller に伝搬 = failed bucket → retry。
+	fetcher := &stubFetcher{err: &activitypub.StatusError{StatusCode: 502, Status: "502 Bad Gateway"}}
+	resolver := federation.NewResolver(userRepo, noteRepo, urls, fetcher, idGen)
+	resolver.SetEmojiRepo(emojiRepo)
+	followingSvc := corefollowing.NewService(userRepo, followingRepo, testutil.NewMockFollowRequestRepository(), idGen)
+	reactionSvc := corereaction.NewService(noteRepo, reactionRepo, emojiRepo, followingRepo, idGen)
+	deleteSvc := corenote.NewDeleteService(noteRepo)
+	p := federation.NewProcessor(resolver, followingSvc, reactionSvc, deleteSvc, userRepo, noteRepo)
+
+	body := []byte(`{
+		"type": "Like",
+		"actor": "https://remote.example/users/alice",
+		"object": "https://example.com/notes/n1"
+	}`)
+	err := p.Process(body)
+	require.Error(t, err, "transient (5xx) は retry されるべき")
+	assert.Empty(t, reactionRepo.Reactions)
+}
+
+// handleLike: reactionService.Create returns ErrNoteNotVisible (followers-only
+// target).best-effort ack (#1183): visibility 違反は permanent fail として
+// ack し、reaction record を作らない。
 func TestProcess_LikeNotVisible(t *testing.T) {
 	env := newFullProcessor(t, aliceActor)
 	env.noteRepo.Notes["n1"] = &model.Note{
@@ -1348,8 +1390,8 @@ func TestProcess_LikeNotVisible(t *testing.T) {
 		"object": "https://example.com/notes/n1",
 		"content": "👍"
 	}`)
-	err := env.processor.Process(body)
-	assert.Error(t, err)
+	require.NoError(t, env.processor.Process(body))
+	assert.Empty(t, env.reactionRepo.Reactions, "visibility 違反は reaction を作らない")
 }
 
 // handleReject: Unfollow returns a non-NotFollowing error.


### PR DESCRIPTION
## Summary

UDS 本番 inbox failed bucket の 87% (376/440) が「Like の target note を
remote fetch して 404 / 401 / invalid JSON 等の permanent error」由来で
永続蓄積していた問題の根本対策。permanent な resolve 失敗を ack 扱いに
して failed bucket への積上げを止める。

## Approach

\`isPermanentResolveError(err) bool\` helper で error 分類 policy を 1
箇所に集約 (\`internal/core/federation/permanent_error.go\`):

| 分類 | 対象 | 挙動 |
|---|---|---|
| **permanent** | StatusError 401/403/404/410, ErrInvalidActor, ErrInvalidNote, ErrNoteNotVisible | \`return nil\` で activity を ack、副作用無し |
| **transient** | StatusError 5xx, network / timeout, その他 | 従来通り \`return err\` で retry サイクル維持 |

\`errors.As\` / \`errors.Is\` で wrap も認識。

## 適用 handler (4 件)

- \`handleLike\` (ResolveActor / ResolveNote / reactionService.Create の
  visibility 違反)
- \`handleAnnounce\` (ResolveActor / ResolveNote)
- \`handleUndoLike\` (ResolveActor / ResolveNote)
- \`handleUndoAnnounce\` (ResolveActor / ResolveNote)

それぞれ permanent → \`slog.Warn\` で diag を残しつつ \`return nil\` で
202 ack 相当。

## 影響範囲外 (= 触らない)

- Create / Update / Delete / Follow / Accept 他 handler の resolve 失敗
  挙動は **本 PR では変更しない** (= note 作成等は resolve 必須なので
  permanent でも error 伝搬が正しい semantic)
- on-demand resolve (UI 側で初回表示時に解決) は別 PR
- \`removeOnFail\` 設定は #1184 で扱う (補完関係)

## テスト

### 新規

- \`permanent_error_test.go\`: helper を 17 case で網羅 (4xx / 5xx /
  wrap / nil / sentinel error 各種)
- \`TestProcess_LikeTransientFetchError\`: 502 transient で従来通り err
  返却される regression guard

### 更新 (9 件)

旧 semantic 期待 (\`assert.Error\`) を新 semantic 期待 (\`require.NoError\` +
副作用無し検証) に書き換え:

- \`TestProcess_LikeUnknownTarget\` / \`TestProcess_LikeActorError\` / \`TestProcess_LikeNotVisible\`
- \`TestProcess_AnnounceUnknownTarget\` / \`TestProcess_AnnounceActorError\`
- \`TestProcess_UndoLikeUnknownTarget\` / \`TestProcess_UndoLikeActorError\`
- \`TestProcess_UndoAnnounceUnknownTarget\` / \`TestProcess_UndoAnnounceActorError\`

### 実行結果

\`\`\`
$ go test ./internal/core/federation/... ./internal/queue/processors/...
ok  github.com/shiroha-a/mk/internal/core/federation       1.797s
ok  github.com/shiroha-a/mk/internal/queue/processors      2.751s
\`\`\`

\`make fmt\` / \`make lint\` clean。

## Closes

#1183

## 関連

- #1180 / #1181 / #1182: 本問題の発見過程
- #1184: inbox / deliver で \`removeOnFail\` 設定 (発生を止めても止まり
  きらない transient 失敗の retention 上限、補完)
- #1185: JSON array wrap activity tolerance (Foundkey 互換)
- #1186: 重複 reaction の idempotent 化
- #1187: mkqdriver semantic correction (mkq#64 close 後の真 fix)