### PR TITLE
feat(queue): inbox / deliver enqueue で removeOnFail (KeepFailed) を設定 (#1184)

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -157,6 +157,12 @@ type Source struct {
 	RelationshipJobPerSec      *int `mapstructure:"relationshipJobPerSec"`
 	DeliverJobMaxAttempts      *int `mapstructure:"deliverJobMaxAttempts"`
 	InboxJobMaxAttempts        *int `mapstructure:"inboxJobMaxAttempts"`
+	// `<queue>JobKeepFailed` は failed bucket retention の最大件数。
+	// 0 = retention 無し (= 蓄積し続ける) なので、operator が明示的に
+	// 「全部残す」運用にしたい場合のみ 0 を設定する。未指定なら mk-go
+	// の internal default (defaultKeepFailed) が適用される。
+	DeliverJobKeepFailed *int `mapstructure:"deliverJobKeepFailed"`
+	InboxJobKeepFailed   *int `mapstructure:"inboxJobKeepFailed"`
 
 	// JobQueueAutoScale toggles the AIMD auto-scale controller (#1120).
 	// Default false. When true, queues without an explicit
@@ -317,6 +323,8 @@ type Config struct {
 	RelationshipJobPerSec      *int
 	DeliverJobMaxAttempts      *int
 	InboxJobMaxAttempts        *int
+	DeliverJobKeepFailed       *int
+	InboxJobKeepFailed         *int
 
 	// Auto-scale knobs (#1120 tracker). See docs/design/auto-scale-job-workers.md.
 	JobQueueAutoScale        bool
@@ -559,6 +567,8 @@ func resolve(src *Source) (*Config, error) {
 		RelationshipJobPerSec:      src.RelationshipJobPerSec,
 		DeliverJobMaxAttempts:      src.DeliverJobMaxAttempts,
 		InboxJobMaxAttempts:        src.InboxJobMaxAttempts,
+		DeliverJobKeepFailed:       src.DeliverJobKeepFailed,
+		InboxJobKeepFailed:         src.InboxJobKeepFailed,
 		JobQueueAutoScale:          src.JobQueueAutoScale,
 		MaxWorkers:                 src.MaxWorkers,
 		MinWorkers:                 src.MinWorkers,

--- a/internal/queue/driver/asynqdriver/asynqdriver_test.go
+++ b/internal/queue/driver/asynqdriver/asynqdriver_test.go
@@ -96,6 +96,16 @@ func TestToAsynqOptions_MaxRetryRequiresExplicit(t *testing.T) {
 	}
 }
 
+// TestToAsynqOptions_KeepFailedIsSilentNoOp: asynq には per-job 相当
+// API が無いので driver-neutral `WithKeepFailed` は silent no-op で
+// なければならない (#1184 の driver semantics)。
+func TestToAsynqOptions_KeepFailedIsSilentNoOp(t *testing.T) {
+	got := toAsynqOptions(driver.EnqueueOptions{KeepFailed: 100, KeepFailedSet: true})
+	if len(got) != 0 {
+		t.Fatalf("KeepFailed must be silently ignored by asynqdriver, got %d options", len(got))
+	}
+}
+
 // fakeRedis returns a non-routable RedisClientOpt; we never Start the
 // server in these tests so the address is fine. asynq client/inspector
 // constructors do not Dial until the first request.

--- a/internal/queue/driver/asynqdriver/option.go
+++ b/internal/queue/driver/asynqdriver/option.go
@@ -9,6 +9,12 @@ import (
 // toAsynqOptions translates a driver.EnqueueOptions into the
 // equivalent []asynq.Option list. Empty / zero fields are skipped so
 // the asynq library applies its own defaults (e.g. MaxRetry=25).
+//
+// 注意: `KeepFailed` は asynq に per-job 相当 API が無いので silent
+// no-op (= mkq 専用 retention)。driver-neutral API として上位が
+// `WithKeepFailed` を渡しても asynq では効果を持たない設計 (#1184)。
+// 必要なら asynq archived bucket の age-based retention を別途設定
+// する経路で対応する。
 func toAsynqOptions(o driver.EnqueueOptions) []asynq.Option {
 	out := make([]asynq.Option, 0, 4)
 	if o.Queue != "" {

--- a/internal/queue/driver/driver_test.go
+++ b/internal/queue/driver/driver_test.go
@@ -31,13 +31,16 @@ func TestApplyEnqueueOptions(t *testing.T) {
 		WithMaxRetry(3),
 		WithUnique(time.Hour),
 		WithProcessIn(5 * time.Second),
+		WithKeepFailed(500),
 	})
 	want := EnqueueOptions{
-		Queue:       "deliver",
-		MaxRetry:    3,
-		MaxRetrySet: true,
-		UniqueTTL:   time.Hour,
-		ProcessIn:   5 * time.Second,
+		Queue:         "deliver",
+		MaxRetry:      3,
+		MaxRetrySet:   true,
+		UniqueTTL:     time.Hour,
+		ProcessIn:     5 * time.Second,
+		KeepFailed:    500,
+		KeepFailedSet: true,
 	}
 	if got != want {
 		t.Fatalf("got %#v want %#v", got, want)
@@ -55,5 +58,20 @@ func TestApplyEnqueueOptionsZeroSentinel(t *testing.T) {
 	def := ApplyEnqueueOptions(nil)
 	if def.MaxRetrySet {
 		t.Fatalf("default options must not record MaxRetrySet")
+	}
+}
+
+// TestApplyEnqueueOptions_KeepFailedZeroSentinel: WithKeepFailed(0) は
+// 「operator が明示的に retention 解除 (= unlimited 蓄積)」を表す。
+// 未指定 (= default) と区別するため KeepFailedSet を使う (#1184)。
+func TestApplyEnqueueOptions_KeepFailedZeroSentinel(t *testing.T) {
+	got := ApplyEnqueueOptions([]EnqueueOption{WithKeepFailed(0)})
+	if got.KeepFailed != 0 || !got.KeepFailedSet {
+		t.Fatalf("explicit zero not recorded: %#v", got)
+	}
+
+	def := ApplyEnqueueOptions(nil)
+	if def.KeepFailedSet {
+		t.Fatalf("default options must not record KeepFailedSet")
 	}
 }

--- a/internal/queue/driver/mkqdriver/integration_test.go
+++ b/internal/queue/driver/mkqdriver/integration_test.go
@@ -571,6 +571,48 @@ func TestInspector_GetQueueInfo_RetryReflectsFailedBucket(t *testing.T) {
 		"Retry should reflect failed bucket size (was hardcoded to 0)")
 }
 
+// TestClient_Enqueue_WithKeepFailed_BoundsFailedBucket verifies the
+// `driver.WithKeepFailed(n)` option translates to `mkq.WithKeepFailed(n)`
+// so the failed bucket size is bounded at n entries even when N+M
+// permanent-fail jobs are enqueued. Without this the bucket would grow
+// unbounded and admin observability degrades (#1184).
+func TestClient_Enqueue_WithKeepFailed_BoundsFailedBucket(t *testing.T) {
+	d := newDriver(t)
+	srv := d.Server()
+	var wg sync.WaitGroup
+	const cap = 3
+	const total = 7 // cap=3, つまり最後 3 件だけ残るはず
+	wg.Add(total)
+	srv.Handle("keepfailed:burst", func(_ context.Context, _ driver.Task) error {
+		defer wg.Done()
+		return fmt.Errorf("intentional fail: %w", driver.SkipRetry)
+	})
+	require.NoError(t, srv.Start())
+	t.Cleanup(srv.Shutdown)
+
+	for i := 0; i < total; i++ {
+		require.NoError(t, d.Client().Enqueue(context.Background(),
+			"keepfailed:burst", []byte(fmt.Sprintf(`{"i":%d}`, i)),
+			driver.WithQueue("deliver"),
+			driver.WithKeepFailed(cap),
+		))
+	}
+	if !waitGroupTimeout(&wg, 10*time.Second) {
+		t.Fatal("not all handlers invoked")
+	}
+
+	ins := d.Inspector()
+	// mkq の retention 削除は finalise の同期 path で動く (= worker が
+	// 失敗 ack を返した瞬間に古い entry を ZREMRANGEBYRANK で prune)。
+	// 全 7 件 handle 完了後、ある程度待って failed bucket が cap 件以下
+	// に絞られていることを確認する (= 上限 retention 動作)。
+	require.Eventually(t, func() bool {
+		info, err := ins.GetQueueInfo("deliver")
+		return err == nil && info.Failed <= cap && info.Failed >= 1
+	}, 5*time.Second, 50*time.Millisecond,
+		"failed bucket should be bounded at WithKeepFailed(%d) (=%d max)", cap, cap)
+}
+
 // TestInspector_RunTask_FallsBackToRetryJobForFailedBucket verifies that
 // RunTask succeeds against a job in the failed bucket, by falling back
 // from PromoteJob (delayed-only) to RetryJob. asynq's Inspector.RunTask

--- a/internal/queue/driver/mkqdriver/mkqdriver_test.go
+++ b/internal/queue/driver/mkqdriver/mkqdriver_test.go
@@ -106,6 +106,30 @@ func TestUniqueKey_NilPayload(t *testing.T) {
 	}
 }
 
+// TestToMkqAddOptions_KeepFailedZeroSkipped: driver-neutral semantic で
+// `WithKeepFailed(0)` は「retention 無し = unlimited 蓄積」だが、mkq
+// native の `WithKeepFailed(0)` は「即時削除」で意味が真逆。translation
+// 層で 0 を skip して semantic を揃えていることを pin する (#1184 review)。
+func TestToMkqAddOptions_KeepFailedZeroSkipped(t *testing.T) {
+	o := driver.EnqueueOptions{KeepFailed: 0, KeepFailedSet: true}
+	got := toMkqAddOptions(o, "task", nil)
+	// WithJobName 1 個のみ (= KeepFailed=0 は mkq に渡されない)。
+	if len(got) != 1 {
+		t.Fatalf("KeepFailed=0 must not emit mkq.WithKeepFailed, got %d options", len(got))
+	}
+}
+
+// TestToMkqAddOptions_KeepFailedPositive: value>0 のときは
+// mkq.WithKeepFailed として直訳される。
+func TestToMkqAddOptions_KeepFailedPositive(t *testing.T) {
+	o := driver.EnqueueOptions{KeepFailed: 500, KeepFailedSet: true}
+	got := toMkqAddOptions(o, "task", nil)
+	// WithJobName + WithKeepFailed の 2 個。
+	if len(got) != 2 {
+		t.Fatalf("KeepFailed>0 should emit mkq.WithKeepFailed, got %d options", len(got))
+	}
+}
+
 func TestToMkqAddOptions_MaxRetryRequiresExplicit(t *testing.T) {
 	// MaxRetrySet=false → default attempts; no option emitted.
 	got := toMkqAddOptions(driver.EnqueueOptions{MaxRetry: 3}, "task", nil)

--- a/internal/queue/driver/mkqdriver/option.go
+++ b/internal/queue/driver/mkqdriver/option.go
@@ -55,11 +55,15 @@ func toMkqAddOptions(o driver.EnqueueOptions, taskType string, payload []byte) [
 	if o.ProcessIn > 0 {
 		out = append(out, mkq.WithDelay(o.ProcessIn))
 	}
-	if o.KeepFailedSet {
-		// asynq には per-job 相当が無いので driver-neutral name は
-		// KeepFailed としているが、mkq library 側 API も同名
-		// (`mkq.WithKeepFailed`) で一対一に対応する。BullMQ の
-		// `removeOnFail: N` 互換。
+	if o.KeepFailedSet && o.KeepFailed > 0 {
+		// driver-neutral semantic では `WithKeepFailed(0)` = 「retention
+		// 無し (= unlimited 蓄積、従来挙動)」だが、mkq native の
+		// `WithKeepFailed(0)` は **逆に「failed bucket 即時削除」**
+		// (`removeOnFail: true` 相当) で意味が真逆。両 semantic を揃える
+		// ため、value=0 のときは mkq に渡さない (= mkq が WithKeepFailed
+		// 未呼び出し時の default = unlimited を踏ませる)。
+		// value>0 のときだけ N 件 retention として直訳する。BullMQ の
+		// `removeOnFail: N` 互換 (#1184)。
 		out = append(out, mkq.WithKeepFailed(o.KeepFailed))
 	}
 	return out

--- a/internal/queue/driver/mkqdriver/option.go
+++ b/internal/queue/driver/mkqdriver/option.go
@@ -55,6 +55,13 @@ func toMkqAddOptions(o driver.EnqueueOptions, taskType string, payload []byte) [
 	if o.ProcessIn > 0 {
 		out = append(out, mkq.WithDelay(o.ProcessIn))
 	}
+	if o.KeepFailedSet {
+		// asynq には per-job 相当が無いので driver-neutral name は
+		// KeepFailed としているが、mkq library 側 API も同名
+		// (`mkq.WithKeepFailed`) で一対一に対応する。BullMQ の
+		// `removeOnFail: N` 互換。
+		out = append(out, mkq.WithKeepFailed(o.KeepFailed))
+	}
 	return out
 }
 

--- a/internal/queue/driver/option.go
+++ b/internal/queue/driver/option.go
@@ -19,8 +19,14 @@ type EnqueueOptions struct {
 
 	// KeepFailed bounds the size of the failed ZSET for this task's
 	// queue. mkq translates this to `mkq.WithKeepFailed(n)`. asynq has
-	// no per-job equivalent (= silent no-op). 0 と "default" の区別は
-	// KeepFailedSet で表現する (= MaxRetry / MaxRetrySet と同じ pattern)。
+	// no per-job equivalent (= silent no-op).
+	//
+	// KeepFailedSet は MaxRetry / MaxRetrySet と同じ「明示 0 vs default」
+	// 区別 pattern を踏襲して提供するが、driver translation 上は両者とも
+	// 「unlimited 蓄積 (= driver default)」になり挙動は同じ
+	// (mkqdriver/option.go の `> 0` guard 参照)。operator が `<queue>JobKeepFailed:
+	// 0` と明示的に opt-out したこと自体は Set=true として記録される
+	// (= documented intent としての semantic を保つ)。
 	KeepFailed    int
 	KeepFailedSet bool
 

--- a/internal/queue/driver/option.go
+++ b/internal/queue/driver/option.go
@@ -10,11 +10,19 @@ import "time"
 //   - MaxRetry 0         : driver default retry count
 //   - UniqueTTL 0        : no unique-key dedup
 //   - ProcessIn 0        : process immediately
+//   - KeepFailed 0       : driver default (= no automatic retention)
 type EnqueueOptions struct {
 	Queue     string
 	MaxRetry  int
 	UniqueTTL time.Duration
 	ProcessIn time.Duration
+
+	// KeepFailed bounds the size of the failed ZSET for this task's
+	// queue. mkq translates this to `mkq.WithKeepFailed(n)`. asynq has
+	// no per-job equivalent (= silent no-op). 0 と "default" の区別は
+	// KeepFailedSet で表現する (= MaxRetry / MaxRetrySet と同じ pattern)。
+	KeepFailed    int
+	KeepFailedSet bool
 
 	// MaxRetrySet distinguishes "MaxRetry left at default" from
 	// "MaxRetry explicitly set to 0". asynq treats MaxRetry=0 as
@@ -51,6 +59,25 @@ func WithUnique(ttl time.Duration) EnqueueOption {
 // WithProcessIn delays processing of the task by the given duration.
 func WithProcessIn(d time.Duration) EnqueueOption {
 	return func(o *EnqueueOptions) { o.ProcessIn = d }
+}
+
+// WithKeepFailed bounds the size of the failed bucket / ZSET for this
+// task's queue: when the failed bucket exceeds n entries, the oldest
+// ones are pruned automatically. n==0 explicitly disables retention
+// (= unlimited accumulation, matches the historical behaviour).
+//
+// 主な使い道: inbox / deliver 等の連合 queue で transient failure が
+// 永続蓄積するのを防ぐ。BullMQ の `removeOnFail: N` と意味同等。
+//
+// driver 別:
+//   - mkqdriver: `mkq.WithKeepFailed(n)` を AddJob に渡す
+//   - asynqdriver: silent no-op (asynq は per-job 相当 API を持たない、
+//     archived bucket の age-based prune に依拠)
+func WithKeepFailed(n int) EnqueueOption {
+	return func(o *EnqueueOptions) {
+		o.KeepFailed = n
+		o.KeepFailedSet = true
+	}
 }
 
 // ApplyEnqueueOptions folds the variadic options into a single

--- a/internal/queue/driver/option.go
+++ b/internal/queue/driver/option.go
@@ -70,7 +70,10 @@ func WithProcessIn(d time.Duration) EnqueueOption {
 // 永続蓄積するのを防ぐ。BullMQ の `removeOnFail: N` と意味同等。
 //
 // driver 別:
-//   - mkqdriver: `mkq.WithKeepFailed(n)` を AddJob に渡す
+//   - mkqdriver: `n > 0` のときだけ `mkq.WithKeepFailed(n)` を AddJob に
+//     渡す。注意: mkq native の `WithKeepFailed(0)` は **「即時削除」**
+//     (BullMQ `removeOnFail: true` 相当) で driver-neutral semantic と
+//     真逆なので、driver translation 側で 0 は skip する。
 //   - asynqdriver: silent no-op (asynq は per-job 相当 API を持たない、
 //     archived bucket の age-based prune に依拠)
 func WithKeepFailed(n int) EnqueueOption {

--- a/internal/queue/policy.go
+++ b/internal/queue/policy.go
@@ -30,6 +30,15 @@ type Policy struct {
 	// 変換するため EnqueueDeliver で N-1 を渡す。drop-in 互換維持の
 	// ために TS の YAML 値そのままで一致させる必要がある (#531 review)。
 	MaxAttempts int
+
+	// KeepFailed bounds the size of the failed bucket / ZSET for this
+	// queue. mkq では per-job `WithKeepFailed(n)` に翻訳されて failed
+	// ZSET の超過分が古い順に prune される (BullMQ `removeOnFail: N`
+	// 互換)。0 = retention 無し (= 蓄積し続ける、従来挙動)。
+	//
+	// `MaxAttempts` と同じく EnqueueDeliver / EnqueueInbox が caller
+	// opts の前に prepend する形で渡る (#1184)。
+	KeepFailed int
 }
 
 // PolicyMap maps queue name → Policy. Lookups for missing queues return

--- a/internal/queue/queue.go
+++ b/internal/queue/queue.go
@@ -161,8 +161,14 @@ func (c *Client) policyFor(queueName string) Policy {
 func (c *Client) EnqueueDeliver(payload DeliverPayload, opts ...driver.EnqueueOption) error {
 	body := mustMarshal(payload)
 	base := []driver.EnqueueOption{driver.WithQueue(QueueName)}
-	if attempts := c.policyFor(QueueName).MaxAttempts; attempts > 0 {
-		base = append(base, driver.WithMaxRetry(attempts-1))
+	p := c.policyFor(QueueName)
+	if p.MaxAttempts > 0 {
+		base = append(base, driver.WithMaxRetry(p.MaxAttempts-1))
+	}
+	if p.KeepFailed > 0 {
+		// mkqdriver 経路でのみ効く。asynqdriver は silent no-op。
+		// failed bucket retention で永続蓄積を防ぐ (#1184)。
+		base = append(base, driver.WithKeepFailed(p.KeepFailed))
 	}
 	merged := append(base, opts...)
 	return c.inner.Enqueue(context.Background(), TaskTypeDeliver, body, merged...)
@@ -269,8 +275,12 @@ func (c *Client) EnqueueImportCustomEmojis(payload ImportCustomEmojisPayload) er
 func (c *Client) EnqueueInbox(ctx context.Context, payload InboxPayload) error {
 	body := mustMarshal(payload)
 	base := []driver.EnqueueOption{driver.WithQueue(InboxQueueName)}
-	if attempts := c.policyFor(InboxQueueName).MaxAttempts; attempts > 0 {
-		base = append(base, driver.WithMaxRetry(attempts-1))
+	p := c.policyFor(InboxQueueName)
+	if p.MaxAttempts > 0 {
+		base = append(base, driver.WithMaxRetry(p.MaxAttempts-1))
+	}
+	if p.KeepFailed > 0 {
+		base = append(base, driver.WithKeepFailed(p.KeepFailed))
 	}
 	return c.inner.Enqueue(ctx, TaskTypeInbox, body, base...)
 }

--- a/internal/queue/queue_keepfailed_test.go
+++ b/internal/queue/queue_keepfailed_test.go
@@ -1,0 +1,89 @@
+package queue_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/shiroha-a/mk/internal/queue"
+	"github.com/shiroha-a/mk/internal/queue/driver"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// recordingDriverClient is a minimal driver.Client implementation that
+// captures the last Enqueue call's options. Used to verify wire-through
+// of queue.Policy.KeepFailed into driver opts (#1184).
+type recordingDriverClient struct {
+	lastTaskType string
+	lastOpts     driver.EnqueueOptions
+}
+
+func (r *recordingDriverClient) Enqueue(_ context.Context, taskType string, _ []byte, opts ...driver.EnqueueOption) error {
+	r.lastTaskType = taskType
+	r.lastOpts = driver.ApplyEnqueueOptions(opts)
+	return nil
+}
+
+func (r *recordingDriverClient) Close() error { return nil }
+
+// stubDriver wraps a Client + a nil Inspector so queue.NewClient can
+// construct a queue.Client without spinning up an actual driver.
+type stubDriver struct {
+	client driver.Client
+}
+
+func (s *stubDriver) Client() driver.Client        { return s.client }
+func (s *stubDriver) Inspector() driver.Inspector  { return nil }
+func (s *stubDriver) Server() driver.Server        { return nil }
+func (s *stubDriver) Scheduler() driver.Scheduler  { return nil }
+func (s *stubDriver) Close() error                 { return nil }
+func (s *stubDriver) WorkerCount(_ string) int     { return 0 }
+func (s *stubDriver) Resize(_ string, _ int) error { return driver.ErrResizeNotSupported }
+
+// TestClient_EnqueueDeliver_PolicyKeepFailedApplied verifies that
+// Policy.KeepFailed reaches the driver Enqueue call as
+// driver.WithKeepFailed(n) (#1184).
+func TestClient_EnqueueDeliver_PolicyKeepFailedApplied(t *testing.T) {
+	rec := &recordingDriverClient{}
+	c := queue.NewClient(&stubDriver{client: rec})
+	defer func() { _ = c.Close() }()
+
+	c.SetPolicy(queue.QueueName, queue.Policy{KeepFailed: 250})
+
+	require.NoError(t, c.EnqueueDeliver(queue.DeliverPayload{Inbox: "x", Body: []byte(`{}`)}))
+
+	assert.Equal(t, queue.TaskTypeDeliver, rec.lastTaskType)
+	assert.True(t, rec.lastOpts.KeepFailedSet, "KeepFailedSet must be propagated")
+	assert.Equal(t, 250, rec.lastOpts.KeepFailed)
+}
+
+// TestClient_EnqueueInbox_PolicyKeepFailedApplied: 同様 inbox 経路。
+func TestClient_EnqueueInbox_PolicyKeepFailedApplied(t *testing.T) {
+	rec := &recordingDriverClient{}
+	c := queue.NewClient(&stubDriver{client: rec})
+	defer func() { _ = c.Close() }()
+
+	c.SetPolicy(queue.InboxQueueName, queue.Policy{KeepFailed: 500})
+
+	require.NoError(t, c.EnqueueInbox(context.Background(), queue.InboxPayload{Body: []byte(`{}`)}))
+
+	assert.Equal(t, queue.TaskTypeInbox, rec.lastTaskType)
+	assert.True(t, rec.lastOpts.KeepFailedSet)
+	assert.Equal(t, 500, rec.lastOpts.KeepFailed)
+}
+
+// TestClient_EnqueueDeliver_PolicyZeroKeepFailedSkipped: KeepFailed=0
+// (= 未指定 or 明示的 unlimited) は driver opts に WithKeepFailed を
+// 渡さない (= driver default = retention 無し)。
+func TestClient_EnqueueDeliver_PolicyZeroKeepFailedSkipped(t *testing.T) {
+	rec := &recordingDriverClient{}
+	c := queue.NewClient(&stubDriver{client: rec})
+	defer func() { _ = c.Close() }()
+
+	c.SetPolicy(queue.QueueName, queue.Policy{KeepFailed: 0})
+
+	require.NoError(t, c.EnqueueDeliver(queue.DeliverPayload{Inbox: "x", Body: []byte(`{}`)}))
+
+	assert.False(t, rec.lastOpts.KeepFailedSet, "KeepFailedSet must NOT be set when policy KeepFailed=0")
+	assert.Equal(t, 0, rec.lastOpts.KeepFailed)
+}

--- a/internal/server/queue_factory.go
+++ b/internal/server/queue_factory.go
@@ -95,15 +95,35 @@ func perQueueRatesFromConfig(cfg *config.Config) map[string]int {
 	return out
 }
 
+// defaultKeepFailed bounds the failed bucket retention applied to inbox /
+// deliver enqueue when operator が config で明示しない場合の安全側 default。
+// 1000 件あれば admin UI の Errored Instances panel (host aggregation で
+// top-N 表示) は確実に賄え、redis memory pressure (1 job ≈ 1KB × 2 queue
+// = 2MB) も問題にならない。`<queue>JobKeepFailed: 0` で operator が明示
+// 解除可能 (= 蓄積無制限の従来挙動)。
+const defaultKeepFailed = 1000
+
 // applyClientPolicies copies enqueue-side defaults (deliverJobMaxAttempts /
-// inboxJobMaxAttempts) onto the queue.Client. Called once at server
-// construction so EnqueueDeliver / EnqueueInbox can pre-pend WithMaxRetry
-// when callers don't override.
+// inboxJobMaxAttempts / deliverJobKeepFailed / inboxJobKeepFailed) onto the
+// queue.Client. Called once at server construction so EnqueueDeliver /
+// EnqueueInbox can pre-pend driver options when callers don't override.
 func applyClientPolicies(c *queue.Client, cfg *config.Config) {
-	if cfg.DeliverJobMaxAttempts != nil && *cfg.DeliverJobMaxAttempts > 0 {
-		c.SetPolicy(queue.QueueName, queue.Policy{MaxAttempts: *cfg.DeliverJobMaxAttempts})
+	c.SetPolicy(queue.QueueName, buildPolicy(cfg.DeliverJobMaxAttempts, cfg.DeliverJobKeepFailed))
+	c.SetPolicy(queue.InboxQueueName, buildPolicy(cfg.InboxJobMaxAttempts, cfg.InboxJobKeepFailed))
+}
+
+// buildPolicy assembles a queue.Policy from optional config pointers,
+// applying defaultKeepFailed when the operator hasn't specified a value.
+// MaxAttempts は未指定なら 0 = "driver default" のまま (= 既存挙動)。
+func buildPolicy(maxAttempts *int, keepFailed *int) queue.Policy {
+	p := queue.Policy{}
+	if maxAttempts != nil && *maxAttempts > 0 {
+		p.MaxAttempts = *maxAttempts
 	}
-	if cfg.InboxJobMaxAttempts != nil && *cfg.InboxJobMaxAttempts > 0 {
-		c.SetPolicy(queue.InboxQueueName, queue.Policy{MaxAttempts: *cfg.InboxJobMaxAttempts})
+	if keepFailed != nil {
+		p.KeepFailed = *keepFailed
+	} else {
+		p.KeepFailed = defaultKeepFailed
 	}
+	return p
 }

--- a/internal/server/queue_factory_test.go
+++ b/internal/server/queue_factory_test.go
@@ -78,3 +78,29 @@ func TestApplyClientPolicies_NoOpForZero(t *testing.T) {
 		applyClientPolicies(c, &config.Config{DeliverJobMaxAttempts: intp(0)})
 	})
 }
+
+// TestBuildPolicy validates the (maxAttempts, keepFailed) → Policy
+// transform end-to-end: unset → defaultKeepFailed (= 1000)、明示 0 →
+// 0 (= operator opt-out, unlimited 蓄積)、明示 N → N (#1184)。
+func TestBuildPolicy(t *testing.T) {
+	tests := []struct {
+		name        string
+		maxAttempts *int
+		keepFailed  *int
+		want        queue.Policy
+	}{
+		{"both unset", nil, nil, queue.Policy{KeepFailed: defaultKeepFailed}},
+		{"only maxAttempts", intp(8), nil, queue.Policy{MaxAttempts: 8, KeepFailed: defaultKeepFailed}},
+		{"only keepFailed explicit 500", nil, intp(500), queue.Policy{KeepFailed: 500}},
+		{"only keepFailed explicit 0 (operator opt-out)", nil, intp(0), queue.Policy{KeepFailed: 0}},
+		{"both explicit", intp(4), intp(2000), queue.Policy{MaxAttempts: 4, KeepFailed: 2000}},
+		// maxAttempts<=0 は driver default に倒す既存挙動を維持。
+		{"maxAttempts zero ignored", intp(0), intp(500), queue.Policy{MaxAttempts: 0, KeepFailed: 500}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := buildPolicy(tt.maxAttempts, tt.keepFailed)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}

--- a/internal/server/queue_factory_test.go
+++ b/internal/server/queue_factory_test.go
@@ -95,7 +95,10 @@ func TestBuildPolicy(t *testing.T) {
 		{"only keepFailed explicit 0 (operator opt-out)", nil, intp(0), queue.Policy{KeepFailed: 0}},
 		{"both explicit", intp(4), intp(2000), queue.Policy{MaxAttempts: 4, KeepFailed: 2000}},
 		// maxAttempts<=0 は driver default に倒す既存挙動を維持。
-		{"maxAttempts zero ignored", intp(0), intp(500), queue.Policy{MaxAttempts: 0, KeepFailed: 500}},
+		// `MaxAttempts: 0` は「Policy で上書きしない (= driver の default
+		// retry を使う)」を意味する zero-value。明示 0 を受け取っても
+		// Policy には流さないので 0 のまま残る。
+		{"maxAttempts zero leaves driver default", intp(0), intp(500), queue.Policy{MaxAttempts: 0, KeepFailed: 500}},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
## Summary

#1180 / #1182 / #1183 の延長で UDS 本番の inbox failed bucket が
**487 件** まで膨らんでいた事案の retention 対策。BullMQ `removeOnFail:
N` 相当を driver-neutral API として追加し、mkqdriver で
\`mkq.WithKeepFailed(n)\` に翻訳して failed bucket の自動 prune を有効化
する。

## Approach

### driver layer (driver-neutral)

\`driver.EnqueueOptions\` に \`KeepFailed int\` + \`KeepFailedSet bool\`
追加 (= MaxRetry / MaxRetrySet と同じ「default vs explicit 0」区別
pattern)。\`WithKeepFailed(n int)\` helper も新設。

- **mkqdriver**: \`KeepFailedSet\` → \`mkq.WithKeepFailed(n)\` 翻訳
- **asynqdriver**: per-job 相当 API なしのため silent no-op (doc で
  明示、test で pin)

### queue.Client / config 経路

\`Policy.KeepFailed\` 追加 → \`EnqueueDeliver\` / \`EnqueueInbox\` で
policy から引いて driver opts に prepend (caller opts より前 = caller
override 維持)。

config に \`DeliverJobKeepFailed\` / \`InboxJobKeepFailed\` (\`*int\`)、
\`queue_factory.go\` で operator 未指定なら \`defaultKeepFailed = 1000\` を
適用。

## 設計判断

- **default 1000**: admin UI の Errored Instances panel (host aggregation
  で top-N 表示) を確実に賄え、redis memory pressure (1 job ≈ 1KB × 2
  queue ≈ 2MB) も問題にならない範囲。operator は \`<queue>JobKeepFailed:
  0\` で明示的に「無制限蓄積」を選べる契約。
- **inbox / deliver のみ対象**: webhook / export / push / maintenance は
  retention 必要性低い (MaxRetry=4 限定 / 単発 / 短命 / cron driven)。
- **asynqdriver silent no-op**: driver-neutral API の対称性を保ちつつ
  asynq では効果なし。asynq archived bucket は age-based で別経路。

## テスト

### Unit
- \`driver/driver_test.go\`: WithKeepFailed roundtrip + zero sentinel
- \`asynqdriver/asynqdriver_test.go\`: silent no-op pin
- \`queue/queue_keepfailed_test.go\`: policy → driver opts wire-through
  (recording stub、3 case: deliver / inbox / KeepFailed=0 skip)

### Integration (testcontainers + 実 Redis)
- \`mkqdriver/integration_test.go\`:
  \`TestClient_Enqueue_WithKeepFailed_BoundsFailedBucket\` で cap=3、7 件
  permanent fail を流して failed bucket が ≤ 3 に絞られることを確認

### 実行結果

\`\`\`
$ go test -count=1 -short ./internal/queue/... ./internal/config/... ./internal/server/...
ok  internal/queue                              2.541s
ok  internal/queue/driver                       0.008s
ok  internal/queue/driver/asynqdriver           3.926s
ok  internal/queue/driver/mkqdriver            28.027s
ok  internal/config                             0.119s
ok  internal/server                             6.080s
\`\`\`

\`make fmt\` / \`make lint\` clean。

## 期待効果

- UDS deploy 後、inbox / deliver の failed bucket が 1000 件 (operator
  設定可) で頭打ち
- redis memory 圧迫防止
- admin UI Errored Instances panel が古い stale entry で埋もれない

## 関連

- #1183 (発生源対策、merged): Like / Undo / Announce で remote fetch を
  best-effort 化、新規 failure 発生を絞る
- 本 PR (蓄積対策): 残り transient な failure も含めて永続蓄積を防ぐ
- #1185 / #1186 / #1187: 別経路 (Foundkey 互換 / 重複 reaction / mkq
  semantic) の独立 follow-up

両者で連合 failure の永続蓄積問題が両面で塞がる。

## Closes

#1184