### PR TITLE
fix(federation): inbox processor を JSON array wrap activity に tolerant 化 (#1185)

### DIFF
--- a/internal/core/federation/activity_unwrap.go
+++ b/internal/core/federation/activity_unwrap.go
@@ -1,0 +1,41 @@
+package federation
+
+import (
+	"bytes"
+	"encoding/json"
+)
+
+// tryUnwrapSingletonArray inspects body and, if it is a JSON array with
+// exactly one element, returns that element's raw bytes and true.
+// All other shapes (= object, empty array, 2+ element array, null,
+// malformed JSON, empty bytes) return nil and false so the caller can
+// proceed with body unchanged.
+//
+// 背景: Foundkey 系 fork instance は valid な AS Activity を 1 要素
+// JSON array で wrap して送信してくるケースがある:
+//
+//	[{"@context":[...],"type":"Delete","actor":"...","object":{...}}]
+//
+// AS 2.0 仕様では inbox direct POST に array を送る規定は無く、上流
+// Misskey TS / mk-go ともに object 前提で decode するので、wrapper の
+// せいで「activity missing actor」相当の silent failure が起きる。
+// 本 helper で wrap を剥がして downstream に object を渡す (#1185)。
+//
+// 2+ 要素 array (= batch activity) は AS 2.0 で OrderedCollection 等
+// 別 endpoint 経由が想定されており、inbox direct POST には来ない前提。
+// 来たら conservative に no-op (= false) で素通しして既存挙動を保つ
+// (= 将来 batch 対応する余地を残す)。
+func tryUnwrapSingletonArray(body []byte) ([]byte, bool) {
+	trimmed := bytes.TrimLeft(body, " \t\n\r")
+	if len(trimmed) == 0 || trimmed[0] != '[' {
+		return nil, false
+	}
+	var arr []json.RawMessage
+	if err := json.Unmarshal(body, &arr); err != nil {
+		return nil, false
+	}
+	if len(arr) != 1 {
+		return nil, false
+	}
+	return []byte(arr[0]), true
+}

--- a/internal/core/federation/activity_unwrap.go
+++ b/internal/core/federation/activity_unwrap.go
@@ -37,5 +37,8 @@ func tryUnwrapSingletonArray(body []byte) ([]byte, bool) {
 	if len(arr) != 1 {
 		return nil, false
 	}
+	// `json.RawMessage` は `[]byte` の type alias なので、ここの型変換は
+	// no-copy。返り値 slice は元 body の sub-slice を参照する。caller
+	// (= Processor.Process) は body を以降変更しないので安全。
 	return []byte(arr[0]), true
 }

--- a/internal/core/federation/activity_unwrap_test.go
+++ b/internal/core/federation/activity_unwrap_test.go
@@ -1,0 +1,98 @@
+package federation
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+func TestTryUnwrapSingletonArray(t *testing.T) {
+	tests := []struct {
+		name   string
+		body   string
+		wantOK bool
+		wantTy string // unwrap 結果の type field (object のみ)。"" は object じゃない or unwrap 無し
+	}{
+		{
+			name:   "object (typical AP activity)",
+			body:   `{"type":"Like","actor":"a","object":"o"}`,
+			wantOK: false,
+		},
+		{
+			name:   "singleton array (Foundkey-style)",
+			body:   `[{"type":"Delete","actor":"a","object":{"id":"x"}}]`,
+			wantOK: true,
+			wantTy: "Delete",
+		},
+		{
+			name:   "singleton array with leading whitespace",
+			body:   "  \n\t[{\"type\":\"Update\",\"actor\":\"a\"}]",
+			wantOK: true,
+			wantTy: "Update",
+		},
+		{
+			name:   "empty array",
+			body:   `[]`,
+			wantOK: false,
+		},
+		{
+			name:   "two-element array (batch, unsupported)",
+			body:   `[{"type":"A"},{"type":"B"}]`,
+			wantOK: false,
+		},
+		{
+			name:   "null",
+			body:   `null`,
+			wantOK: false,
+		},
+		{
+			name:   "malformed JSON",
+			body:   `[{"type":}]`,
+			wantOK: false,
+		},
+		{
+			name:   "empty bytes",
+			body:   ``,
+			wantOK: false,
+		},
+		{
+			name:   "string (not array, not object)",
+			body:   `"hi"`,
+			wantOK: false,
+		},
+		// nested singleton array (= 入れ子) は剥がさない。inbox direct POST
+		// で来る現実的なケースは 1 段だけと割り切る。
+		{
+			name:   "nested singleton array (only one level unwrapped)",
+			body:   `[[{"type":"X"}]]`,
+			wantOK: true,
+			// unwrap 結果は `[{"type":"X"}]` (= array of 1) で、object としては parse できない。
+			wantTy: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			unwrapped, ok := tryUnwrapSingletonArray([]byte(tt.body))
+			if ok != tt.wantOK {
+				t.Fatalf("ok = %v, want %v (body=%q, unwrapped=%q)", ok, tt.wantOK, tt.body, unwrapped)
+			}
+			if !ok {
+				if unwrapped != nil {
+					t.Errorf("expected nil unwrapped on !ok, got %q", unwrapped)
+				}
+				return
+			}
+			if tt.wantTy != "" {
+				var obj struct {
+					Type string `json:"type"`
+				}
+				if err := json.Unmarshal(unwrapped, &obj); err != nil {
+					t.Fatalf("unwrapped body should be valid JSON object: %v (%q)", err, unwrapped)
+				}
+				if obj.Type != tt.wantTy {
+					t.Errorf("unwrapped type = %q, want %q", obj.Type, tt.wantTy)
+				}
+			}
+		})
+	}
+}

--- a/internal/core/federation/activity_unwrap_test.go
+++ b/internal/core/federation/activity_unwrap_test.go
@@ -59,14 +59,16 @@ func TestTryUnwrapSingletonArray(t *testing.T) {
 			body:   `"hi"`,
 			wantOK: false,
 		},
-		// nested singleton array (= 入れ子) は剥がさない。inbox direct POST
-		// で来る現実的なケースは 1 段だけと割り切る。
+		// 入れ子 `[[...]]` は 1 段だけ unwrap して `[...]` (= array of 1)
+		// を返す。downstream は array を object として parse できず
+		// missing-actor で fail するので、入れ子は abnormal payload として
+		// 素通しされる挙動になる。helper は単純に 1 段 unwrap、判定は
+		// downstream に任せる。
 		{
 			name:   "nested singleton array (only one level unwrapped)",
 			body:   `[[{"type":"X"}]]`,
 			wantOK: true,
-			// unwrap 結果は `[{"type":"X"}]` (= array of 1) で、object としては parse できない。
-			wantTy: "",
+			wantTy: "", // unwrap 結果は array なので object として parse 不可
 		},
 	}
 

--- a/internal/core/federation/processor.go
+++ b/internal/core/federation/processor.go
@@ -298,8 +298,14 @@ func (p *Processor) Process(body []byte) error {
 	// array で wrap して送信してくるケースがある (#1185)。AS 仕様上
 	// inbox direct POST は object 前提なので、array が来た時は剥がして
 	// 中身を処理する。2+ 要素は AS spec 外として no-op で素通し。
+	//
+	// Normalize の前で剥がす: Normalize は内部で json.Unmarshal → 再
+	// encode するが top-level の array → object 変換はしないので、
+	// object 化はここで済ませる必要がある。
 	if unwrapped, ok := tryUnwrapSingletonArray(body); ok {
-		slog.Info("federation: unwrapping singleton JSON array activity (Foundkey-style)",
+		// 観測性のため発火を記録 (log message は中立的に表現、Foundkey 由来は
+		// helper / 本コメント側の doc に残す)。
+		slog.Info("federation: unwrapping singleton JSON array activity",
 			"originalSize", len(body), "unwrappedSize", len(unwrapped))
 		body = unwrapped
 	}

--- a/internal/core/federation/processor.go
+++ b/internal/core/federation/processor.go
@@ -294,6 +294,16 @@ type genericActivity struct {
 // retried inbox jobs will produce duplicate side effects (notifications
 // fired twice, counters double-incremented, etc).
 func (p *Processor) Process(body []byte) error {
+	// Foundkey 系 fork instance は valid な AS Activity を 1 要素 JSON
+	// array で wrap して送信してくるケースがある (#1185)。AS 仕様上
+	// inbox direct POST は object 前提なので、array が来た時は剥がして
+	// 中身を処理する。2+ 要素は AS spec 外として no-op で素通し。
+	if unwrapped, ok := tryUnwrapSingletonArray(body); ok {
+		slog.Info("federation: unwrapping singleton JSON array activity (Foundkey-style)",
+			"originalSize", len(body), "unwrappedSize", len(unwrapped))
+		body = unwrapped
+	}
+
 	normalized, err := activitypub.Normalize(body)
 	if err != nil {
 		return fmt.Errorf("invalid activity json: %w", err)

--- a/internal/core/federation/processor_step_f_test.go
+++ b/internal/core/federation/processor_step_f_test.go
@@ -458,6 +458,49 @@ func TestProcess_AnnounceIncrementsRenoteCount(t *testing.T) {
 
 // --- Delete ------------------------------------------------------------------
 
+// TestProcess_SingletonArrayActivity_Foundkey verifies that a valid AP
+// Delete activity wrapped in a single-element JSON array (= Foundkey-style
+// send format) is unwrapped and processed normally instead of failing
+// with "activity missing actor" (#1185).
+//
+// 実機データ (UDS 本番) で 26 件の missing-actor failure がすべて 1 つの
+// Foundkey instance 由来だったケースの regression guard。
+func TestProcess_SingletonArrayActivity_Foundkey(t *testing.T) {
+	env := newFullProcessor(t, aliceActor)
+	uri := "https://remote.example/notes/n1"
+	env.noteRepo.Notes["n1"] = &model.Note{ID: "n1", UserID: "alice-id", URI: &uri}
+	aliceURI := "https://remote.example/users/alice"
+	env.userRepo.Users["alice-id"] = &model.User{ID: "alice-id", Username: "alice", URI: &aliceURI}
+
+	// 1 要素 JSON array で wrap した payload (Foundkey-style)。
+	body := []byte(`[
+		{
+			"type": "Delete",
+			"actor": "https://remote.example/users/alice",
+			"object": {"id": "https://remote.example/notes/n1", "type": "Tombstone"}
+		}
+	]`)
+	require.NoError(t, env.processor.Process(body))
+
+	// 中身が unwrap されて handleDelete が走った結果、n1 が削除される。
+	_, err := env.noteRepo.FindByID("n1")
+	assert.Error(t, err, "wrapped Delete activity should still remove the target note")
+}
+
+// TestProcess_MultiElementArray_NotUnwrapped: 2 要素 array は AS spec 外
+// として現状は no-op で素通し → 既存挙動の missing-actor で fail する。
+// 将来 batch 対応する余地を残すための保守的な挙動を pin する (#1185)。
+func TestProcess_MultiElementArray_NotUnwrapped(t *testing.T) {
+	env := newFullProcessor(t, aliceActor)
+	body := []byte(`[
+		{"type":"Delete","actor":"https://remote.example/users/alice","object":{"id":"x"}},
+		{"type":"Delete","actor":"https://remote.example/users/alice","object":{"id":"y"}}
+	]`)
+	err := env.processor.Process(body)
+	assert.ErrorContains(t, err, "missing actor",
+		"multi-element array should not be unwrapped; downstream still fails with missing actor")
+}
+
 func TestProcess_DeleteRemoteNote(t *testing.T) {
 	env := newFullProcessor(t, aliceActor)
 	// alice 自身が著者であるリモートnoteを事前に登録


### PR DESCRIPTION
## Summary

UDS 本番 inbox failed bucket の 26 件「activity missing actor」failure
が、すべて 1 つの Foundkey 系 fork instance からの送信で、valid な AP
activity を 1 要素 JSON array で wrap していたことが原因の bug fix。

\`\`\`json
[
  {"@context":[...],"type":"Delete","actor":"...","object":{...}}
]
\`\`\`

mk-go の \`Processor.Process\` が object 前提で json.Unmarshal してたため
silent fail → missing-actor error → failed bucket。

## Approach

\`Processor.Process()\` の Normalize 前で 1 要素 JSON array を unwrap する
helper \`tryUnwrapSingletonArray\` を呼ぶ。

仕様:

| 入力 | 戻り値 |
|---|---|
| object (通常 AP) | 素通し |
| 1 要素 array (Foundkey-style) | 中身を unwrap |
| 0 要素 / 2+ 要素 / null / malformed / 空 | no-op |

2+ 要素 (= AS OrderedCollection batch) は inbox direct POST に来ない
前提で、来ても保守的に no-op で素通し (= 既存 missing-actor fail を
維持、将来 batch 対応の余地を残す)。

unwrap 発火時 \`slog.Info\` で originalSize / unwrappedSize を残して
観測性を確保。

## Misskey TS の挙動

upstream Misskey TS は \`request.body as IActivity\` で cast のみで array
tolerance 無し。mk-go 単独で先行修正する形 (= drop-in 互換 + Foundkey
互換を mk-go 側で両立)。

## 主な変更点

- \`internal/core/federation/activity_unwrap.go\`: helper 新設
- \`internal/core/federation/processor.go\`: Process 入口で unwrap 呼び
  出し + slog.Info で発火記録

## テスト

### 新規

- \`activity_unwrap_test.go\`: 10 case (object / 1-array / whitespace
  前置 / 0-array / 2-array / null / malformed / empty bytes / string /
  nested array)
- \`processor_step_f_test.go\`:
  - \`TestProcess_SingletonArrayActivity_Foundkey\`: Foundkey-style
    Delete activity が unwrap され、handleDelete 経由で対象 note が
    削除されることを e2e で確認
  - \`TestProcess_MultiElementArray_NotUnwrapped\`: 2 要素 array は
    素通しで missing-actor fail に倒れる保守的挙動を pin

### 実行結果

\`\`\`
$ go test ./internal/core/federation/...
ok  github.com/shiroha-a/mk/internal/core/federation    1.693s
\`\`\`

\`make fmt\` / \`make lint\` clean。

## 影響範囲

- Processor.Process 入口 1 箇所
- 既存 single-object payload は完全に regress なし

## Closes

#1185

## 関連

- #1181 / #1182 / #1183 / #1184: inbox failed bucket 周辺の連続 fix
- 残 open follow-up: #1186 (重複 reaction idempotent) / #1187 (mkqdriver
  semantic correction)