### PR TITLE
fix(reaction): 重複 Like を idempotent に no-op 化 (#1186)

### DIFF
--- a/internal/core/federation/processor_step_f_test.go
+++ b/internal/core/federation/processor_step_f_test.go
@@ -13,6 +13,7 @@ import (
 	corereaction "github.com/shiroha-a/mk/internal/core/reaction"
 	"github.com/shiroha-a/mk/internal/misc/id"
 	"github.com/shiroha-a/mk/internal/model"
+	"github.com/shiroha-a/mk/internal/repository"
 	"github.com/shiroha-a/mk/internal/testutil"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -125,6 +126,26 @@ func TestProcess_LikeAlreadyReacted(t *testing.T) {
 	}`)
 	require.NoError(t, env.processor.Process(body))
 	// 2 回目: ErrAlreadyReacted は飲み込まれる
+	require.NoError(t, env.processor.Process(body))
+}
+
+// TestProcess_LikeDuplicateRaceSwallowed: reaction_service の Create が
+// repository.ErrDuplicateReaction (= DB unique violation by race) を
+// 受けても、service が ErrAlreadyReacted に変換し handleLike が swallow
+// するので activity が ack される。AP idempotent semantic を保つ (#1186)。
+func TestProcess_LikeDuplicateRaceSwallowed(t *testing.T) {
+	env := newFullProcessor(t, aliceActor)
+	env.noteRepo.Notes["n1"] = &model.Note{ID: "n1", UserID: "bob", Visibility: model.NoteVisibilityPublic}
+	// reactionRepo.Create を強制的に ErrDuplicateReaction で失敗させる
+	// (= FindByPair 後に並行 process が同 user×note に Create を入れた
+	//   race を simulate)。
+	env.reactionRepo.CreateErr = repository.ErrDuplicateReaction
+	body := []byte(`{
+		"type": "Like",
+		"actor": "https://remote.example/users/alice",
+		"object": "https://example.com/notes/n1",
+		"content": "👍"
+	}`)
 	require.NoError(t, env.processor.Process(body))
 }
 

--- a/internal/core/reaction/reaction_service.go
+++ b/internal/core/reaction/reaction_service.go
@@ -250,6 +250,11 @@ func (s *Service) Create(user *model.User, noteID, rawReaction string) (string, 
 		// なので、repository level の sentinel を service level の
 		// `ErrAlreadyReacted` に変換して caller (= handleLike / API
 		// handler) の既存 swallow path を使わせる (#1186)。
+		//
+		// 注意: mk-go 内で `reactionRepo.Create` を直接呼ぶ caller は
+		// 本 service.Create のみ (= 単一 chokepoint)。将来 service 経由
+		// しない直接 caller を増やす場合、その経路でも同等の sentinel
+		// 変換が必要 (= 直接呼ぶより service 経由に揃えるのが望ましい)。
 		if errors.Is(err, repository.ErrDuplicateReaction) {
 			return "", ErrAlreadyReacted
 		}

--- a/internal/core/reaction/reaction_service.go
+++ b/internal/core/reaction/reaction_service.go
@@ -243,6 +243,16 @@ func (s *Service) Create(user *model.User, noteID, rawReaction string) (string, 
 		Reaction: reaction,
 	}
 	if err := s.reactionRepo.Create(rec); err != nil {
+		// `FindByPair` 実行後の窓で並行 Create (= 別 inbox process / 別
+		// reaction 経路) が同 user×note を入れたとき、PG unique constraint
+		// で `ErrDuplicateReaction` を取る。AP の Like activity は
+		// idempotent に処理する (= 重複は silent ignore する) のが仕様
+		// なので、repository level の sentinel を service level の
+		// `ErrAlreadyReacted` に変換して caller (= handleLike / API
+		// handler) の既存 swallow path を使わせる (#1186)。
+		if errors.Is(err, repository.ErrDuplicateReaction) {
+			return "", ErrAlreadyReacted
+		}
 		return "", err
 	}
 	_ = s.countWriter.Increment(target.ID, reaction, 1)

--- a/internal/core/reaction/reaction_service_test.go
+++ b/internal/core/reaction/reaction_service_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/shiroha-a/mk/internal/core/reaction"
 	"github.com/shiroha-a/mk/internal/misc/id"
 	"github.com/shiroha-a/mk/internal/model"
+	"github.com/shiroha-a/mk/internal/repository"
 	"github.com/shiroha-a/mk/internal/testutil"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -108,6 +109,23 @@ func TestService_Create_AlreadyReactedSame(t *testing.T) {
 	require.NoError(t, err)
 	_, err = svc.Create(&model.User{ID: "viewer"}, "n1", "👍")
 	require.ErrorIs(t, err, reaction.ErrAlreadyReacted)
+}
+
+// TestService_Create_DuplicateConvertedToAlreadyReacted: race condition で
+// reactionRepo.Create が `repository.ErrDuplicateReaction` を返したとき、
+// service は `ErrAlreadyReacted` に変換して caller に返す。`FindByPair`
+// 後の窓で並行 Create が入った AP idempotent semantic を保つため (#1186)。
+func TestService_Create_DuplicateConvertedToAlreadyReacted(t *testing.T) {
+	svc, repo, reactRepo, _, _ := newService(t)
+	seedNote(repo, "n1", "author", model.NoteVisibilityPublic)
+	// FindByPair は何も返さず (= 既存 reaction 無いように見える) →
+	// service は新規 Create に進む → ここで race 想定の
+	// ErrDuplicateReaction を返す。
+	reactRepo.CreateErr = repository.ErrDuplicateReaction
+
+	_, err := svc.Create(&model.User{ID: "viewer"}, "n1", "👍")
+	require.ErrorIs(t, err, reaction.ErrAlreadyReacted,
+		"repository ErrDuplicateReaction must be converted to service ErrAlreadyReacted")
 }
 
 func TestService_Create_ReplaceExisting(t *testing.T) {


### PR DESCRIPTION
## Summary

UDS 本番 inbox failed bucket で観測された
\`process inbox activity: user has already reacted to this note\` 1 件
を idempotent semantic で吸収する fix。

## 真因

mk-go の reaction service 内に **2 種類の重複 sentinel** が分離して存在:

| Layer | Sentinel | 発生 |
|---|---|---|
| service (\`core/reaction\`) | \`ErrAlreadyReacted\` | \`FindByPair\` で既存 reaction 発見 |
| repository (\`repository\`) | \`ErrDuplicateReaction\` | PG unique 制約 (23505) を \`Create\` で取った |

\`handleLike\` は前者だけ swallow。FindByPair 後の race で並行 process
が同 user×note の Create を入れたとき、後者を受けて未 handle → failed
bucket 行きしていた。

## Approach

\`reaction_service.go:Create\` で \`reactionRepo.Create(rec)\` の error を
classify:

\`\`\`go
if err := s.reactionRepo.Create(rec); err != nil {
    if errors.Is(err, repository.ErrDuplicateReaction) {
        return "", ErrAlreadyReacted
    }
    return "", err
}
\`\`\`

これで:
- service caller (handleLike / API handler) は \`ErrAlreadyReacted\` 1 つ
  だけ気にすれば良い (= repository level error が leak しない設計に揃う)
- 既存の swallow path が race condition も idempotent に吸収
- AP 仕様の Like idempotent semantic を満たす

## tests

### 新規

- \`reaction_service_test.go\`:
  \`TestService_Create_DuplicateConvertedToAlreadyReacted\` で mock
  reactionRepo.CreateErr に \`repository.ErrDuplicateReaction\` を仕込み、
  service.Create が \`ErrAlreadyReacted\` を返すことを確認。
- \`processor_step_f_test.go\`:
  \`TestProcess_LikeDuplicateRaceSwallowed\` で federation 経路 e2e で
  race を simulate し、activity が ack される (= failed bucket 行きしない)
  ことを担保。

### 実行結果

\`\`\`
$ go test ./internal/core/reaction/... ./internal/core/federation/...
ok  internal/core/reaction       3.134s
ok  internal/core/federation     1.261s
\`\`\`

\`make fmt\` / \`make lint\` clean。

## 影響範囲

- \`reaction_service.go:Create\` の error path に 1 分岐追加のみ
- 既存挙動 regress なし (= 正常 Create / FindByPair-detected 重複 path
  は完全に不変)

## Closes

#1186

## 関連

- #1183 / #1184 / #1185 (merged): 連合 failure の発生源 / 蓄積 / Foundkey
  互換の対策
- 残 open: #1187 (mkqdriver semantic correction、mkq#64 close 受けて)