### PR TITLE
fix(mkqdriver): Retry / Scheduled を delayed bucket の atm filter で正しく分離 (#1187)

### DIFF
--- a/internal/queue/driver/mkqdriver/inspector.go
+++ b/internal/queue/driver/mkqdriver/inspector.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"log/slog"
 
 	"github.com/shiroha-a/mkq"
 
@@ -32,19 +33,27 @@ func (i *Inspector) Queues() ([]string, error) {
 // failed counters for the named queue. Pending maps to mkq's wait
 // bucket (asynq's pending semantics).
 //
-// Retry semantics: mkq には asynq の Retry bucket に直接対応する独立 bucket
-// が存在せず、retry-backoff 待ちの job は failed bucket に居続け、次の
-// retry 時刻になって delayed bucket に移動する設計 (= `ListRetryTasks` も
-// failed bucket を読む)。よって driver level では Retry = failed bucket
-// size として asynq semantic に揃える。
+// Retry / Scheduled semantics: mkq の delayed bucket は scheduled
+// (cron / 初回 delayed enqueue) と retry-backoff 待ち (= 失敗して次の
+// 試行待ち) が **混在** している (BullMQ 同等。mkq#64 close 時の
+// upstream comment で確認)。両者を区別するため driver 側で delayed
+// bucket を `atm` (= attemptsMade、BullMQ HASH field) で filter し、
+// `atm == 0` を Scheduled / `atm > 0` を Retry にマッピングする。
+// `failed` bucket は permanent failure (= dead letter) のみで Retry には
+// 含めない。これにより asynq semantic と完全一致する (#1187):
 //
-// 副作用として Retry と Failed が同値になるが、これは mkq library が
-// 「retry-pending」と「permanent failure」を区別する bucket を持たない
-// limitation 由来。frontend (admin/job-queue.vue) は両方とも current size
-// を見れば十分なので影響は無い。BullMQ や asynq の semantic と完全一致
-// させるには mkq 自体に retry bucket を追加する必要があり、upstream に
-// 提案済 (shiroha-a/mkq#64)。それが land すれば本 driver も両 counter を
-// 区別して報告できるようになる。
+//	asynq.Scheduled = delayed[atm==0] + repeat ZSET
+//	asynq.Retry     = delayed[atm>0]
+//	asynq.Failed    = failed bucket size
+//
+// cost: delayed bucket 全件 ListJobs (ZRANGE + N×HGETALL pipeline) が
+// publisher の 3 秒間隔で走る。通常 < 100 件で問題なし、federation 障害
+// 時の数千件でも admin polling として許容。将来必要なら Lua count-only
+// API を mkq に proposal する余地あり。
+//
+// fallback: delayed split が失敗したら保守的に旧挙動 (delayed 全体を
+// Scheduled、Retry=0) に倒す。panel 表示は救う方が優先 (= 全部 error 返し
+// にすると graph が真っ白になる)。
 func (i *Inspector) GetQueueInfo(qname string) (*driver.InspectorInfo, error) {
 	q := i.driver.queueFor(qname)
 	if q == nil {
@@ -62,21 +71,22 @@ func (i *Inspector) GetQueueInfo(qname string) (*driver.InspectorInfo, error) {
 	// ZCARD 失敗は致命ではないので 0 として扱い、queue 全体を error
 	// 返却にしない (Counts が成功した時点で UI 表示は救う方を優先)。
 	repeatCount, _ := i.driver.rdb.ZCard(inspectorCtx(), i.driver.repeatKey(qname)).Result()
+
+	// delayed bucket を atm で split (#1187、mkq#64 close 時の手法)。
+	scheduledCount, retryCount, err := i.countDelayedByAttempts(q)
+	if err != nil {
+		slog.Warn("mkqdriver: failed to split delayed bucket by atm, falling back",
+			"queue", qname, "err", err)
+		scheduledCount = int(counts.Delayed)
+		retryCount = 0
+	}
+
 	// Size mirrors asynq.QueueInfo.Size:
 	//   "sum of Pending, Active, Scheduled, Retry, Aggregating and Archived"
 	// — explicitly excluding Completed (asynq treats stored completed
-	// tasks as retention storage, not queue residents).
-	//
-	// mkq → asynq bucket map:
-	//   wait        ↔ pending
-	//   active      ↔ active
-	//   delayed     ↔ scheduled (+ repeat ZSET, mk-go addition)
-	//   prioritized ↔ pending (asynq has no prioritized bucket)
-	//   failed      ↔ archived (stored failed jobs)
-	//
-	// completed / paused は asynq Size に含まれないので除外する。
-	// 含めると admin UI の queue size が driver 切替で大きく変動する。
-	scheduled := int(counts.Delayed) + int(repeatCount)
+	// tasks as retention storage, not queue residents). 旧実装と同様、
+	// delayed 全体 + failed bucket + repeat を入れる (= 内訳が変わっても
+	// 合計値は不変)。
 	return &driver.InspectorInfo{
 		Queue:     qname,
 		Size:      int(counts.Wait+counts.Active+counts.Delayed+counts.Prioritized+counts.Failed) + int(repeatCount),
@@ -84,14 +94,31 @@ func (i *Inspector) GetQueueInfo(qname string) (*driver.InspectorInfo, error) {
 		Pending:   int(counts.Wait),
 		Completed: int(counts.Completed),
 		Failed:    int(counts.Failed),
-		Scheduled: scheduled,
-		// Retry = failed bucket current size。mkq では retry-backoff 待ち
-		// が failed bucket に居る ため、stream/queue_stats_publisher の
-		// `Delayed = Scheduled + Retry` 計算で正しく retry 待ち分が graph
-		// に乗るようになる。Failed と同値になる semantic limitation は
-		// 関数 doc 冒頭で説明済 (#1181)。
-		Retry: int(counts.Failed),
+		Scheduled: scheduledCount + int(repeatCount),
+		Retry:     retryCount,
 	}, nil
+}
+
+// countDelayedByAttempts inspects mkq's delayed bucket and partitions
+// entries by `atm` (= attemptsMade): atm == 0 → scheduled, atm > 0 →
+// retry-backoff. 戻り値は (scheduled, retry, err) のカウント (#1187)。
+//
+// delayed bucket は ZSET-backed なので 全件取り直しでも score 順に並ぶ。
+// fetch cost は ZRANGE 1 + HGETALL N pipeline で、publisher 3 秒間隔の
+// admin polling として許容範囲。
+func (i *Inspector) countDelayedByAttempts(q *mkq.Queue[framedPayload]) (scheduled int, retry int, err error) {
+	listed, err := q.ListJobs(inspectorCtx(), mkq.JobBucketDelayed, 0, -1, true)
+	if err != nil {
+		return 0, 0, err
+	}
+	for _, lj := range listed {
+		if lj.Job != nil && lj.Job.AttemptsMade > 0 {
+			retry++
+		} else {
+			scheduled++
+		}
+	}
+	return scheduled, retry, nil
 }
 
 // QueueMetrics returns BullMQ-compatible per-minute completed /
@@ -163,8 +190,13 @@ func (i *Inspector) DeleteAllPendingTasks(qname string) (int, error) {
 //
 // よって PromoteJob を先に試し、delayed 状態でなければ RetryJob に
 // fallback する。これで「Retry all queues now」(admin/queue/promote-jobs)
-// が failed bucket に居る retry-backoff 待ち job も含めて promote できる
-// ようになる (#1181)。
+// が **delayed bucket (= scheduled + retry-backoff 待ち) と failed bucket
+// (= permanent failure)** どちらの job も含めて promote できる (#1181)。
+//
+// 注意: #1187 以前は「retry-backoff は failed bucket に居る」と説明して
+// いたが事実誤認。mkq の delayed bucket が両者を混在させている (#1187 で
+// 訂正)。fallback ロジック自体は不変で、両 API を試すので両 bucket を
+// 覆える。
 //
 // 両 path で job が見つからなかった場合は最初の (PromoteJob の) error を
 // そのまま返す。job が wait や active など別 bucket に既に居る場合も
@@ -204,16 +236,66 @@ func (i *Inspector) ListActiveTasks(qname string, page, pageSize int) ([]*driver
 	return i.list(qname, mkq.JobBucketActive, page, pageSize)
 }
 
-// ListScheduledTasks returns up to pageSize delayed (scheduled) tasks.
+// ListScheduledTasks returns up to pageSize tasks scheduled for first-time
+// processing (= delayed bucket entries with `atm == 0`). cron / 初回
+// delayed enqueue 等が含まれる。retry-backoff 待ち (= `atm > 0`) は
+// `ListRetryTasks` 側に出る (#1187)。
 func (i *Inspector) ListScheduledTasks(qname string, page, pageSize int) ([]*driver.TaskSummary, error) {
-	return i.list(qname, mkq.JobBucketDelayed, page, pageSize)
+	return i.listDelayedFiltered(qname, false /* want atm == 0 */, page, pageSize)
 }
 
-// ListRetryTasks returns up to pageSize tasks waiting to be retried.
-// mkq keeps retries inside the failed bucket; expose those here so
-// admin UIs can show "retry" as a separate tab rather than empty.
+// ListRetryTasks returns up to pageSize tasks waiting for a retry attempt
+// (= delayed bucket entries with `atm > 0`). mkq の delayed bucket は
+// scheduled (cron 等) と retry-backoff 待ちが混在しており、後者だけを
+// 抽出して admin UI の Retry tab に出す (#1187、mkq#64 close 時の手法)。
+// permanent failure (= dead letter) は failed bucket に居て本 list には
+// 含まれない。
 func (i *Inspector) ListRetryTasks(qname string, page, pageSize int) ([]*driver.TaskSummary, error) {
-	return i.list(qname, mkq.JobBucketFailed, page, pageSize)
+	return i.listDelayedFiltered(qname, true /* want atm > 0 */, page, pageSize)
+}
+
+// listDelayedFiltered fetches the delayed bucket in full, filters by
+// `atm` (= attemptsMade) according to retry, and applies page/pageSize
+// in Go. Pagination is post-filter so callers see consistent counts.
+func (i *Inspector) listDelayedFiltered(qname string, retry bool, page, pageSize int) ([]*driver.TaskSummary, error) {
+	q := i.driver.queueFor(qname)
+	if q == nil {
+		return nil, fmt.Errorf("mkqdriver: unknown queue %q", qname)
+	}
+	if page < 1 {
+		page = 1
+	}
+	if pageSize <= 0 || pageSize > 100 {
+		pageSize = 30
+	}
+	listed, err := q.ListJobs(inspectorCtx(), mkq.JobBucketDelayed, 0, -1, true)
+	if err != nil {
+		return nil, fmt.Errorf("mkqdriver: list delayed %s: %w", qname, err)
+	}
+	// filter で集めた後 page/pageSize で slice する。post-filter pagination
+	// なので「Retry に 5 件出ているはずだが page 1 が空」のような不整合が
+	// 起きない。
+	filtered := make([]*driver.TaskSummary, 0, len(listed))
+	for _, lj := range listed {
+		hasAttempts := lj.Job != nil && lj.Job.AttemptsMade > 0
+		if hasAttempts != retry {
+			continue
+		}
+		summary := jobToSummary(qname, string(mkq.JobBucketDelayed), lj.Job, lj.State)
+		if summary == nil {
+			continue
+		}
+		filtered = append(filtered, summary)
+	}
+	start := (page - 1) * pageSize
+	if start >= len(filtered) {
+		return []*driver.TaskSummary{}, nil
+	}
+	end := start + pageSize
+	if end > len(filtered) {
+		end = len(filtered)
+	}
+	return filtered[start:end], nil
 }
 
 // GetTaskInfo returns the full snapshot for a single task. The

--- a/internal/queue/driver/mkqdriver/inspector.go
+++ b/internal/queue/driver/mkqdriver/inspector.go
@@ -73,7 +73,7 @@ func (i *Inspector) GetQueueInfo(qname string) (*driver.InspectorInfo, error) {
 	repeatCount, _ := i.driver.rdb.ZCard(inspectorCtx(), i.driver.repeatKey(qname)).Result()
 
 	// delayed bucket を atm で split (#1187、mkq#64 close 時の手法)。
-	scheduledCount, retryCount, err := i.countDelayedByAttempts(q)
+	scheduledCount, retryCount, err := i.partitionDelayedByAttempts(q)
 	if err != nil {
 		slog.Warn("mkqdriver: failed to split delayed bucket by atm, falling back",
 			"queue", qname, "err", err)
@@ -85,8 +85,11 @@ func (i *Inspector) GetQueueInfo(qname string) (*driver.InspectorInfo, error) {
 	//   "sum of Pending, Active, Scheduled, Retry, Aggregating and Archived"
 	// — explicitly excluding Completed (asynq treats stored completed
 	// tasks as retention storage, not queue residents). 旧実装と同様、
-	// delayed 全体 + failed bucket + repeat を入れる (= 内訳が変わっても
-	// 合計値は不変)。
+	// delayed 全体 + failed bucket + repeat を入れる。
+	//
+	// #1187 で内訳が変わったが合計値は不変: scheduledCount + retryCount ==
+	// counts.Delayed (= 同じ delayed bucket を partition しただけ) なので、
+	// Size 計算では partition 前の counts.Delayed をそのまま使える。
 	return &driver.InspectorInfo{
 		Queue:     qname,
 		Size:      int(counts.Wait+counts.Active+counts.Delayed+counts.Prioritized+counts.Failed) + int(repeatCount),
@@ -99,14 +102,18 @@ func (i *Inspector) GetQueueInfo(qname string) (*driver.InspectorInfo, error) {
 	}, nil
 }
 
-// countDelayedByAttempts inspects mkq's delayed bucket and partitions
-// entries by `atm` (= attemptsMade): atm == 0 → scheduled, atm > 0 →
-// retry-backoff. 戻り値は (scheduled, retry, err) のカウント (#1187)。
+// partitionDelayedByAttempts inspects mkq's delayed bucket and partitions
+// entries into two counts by `atm` (= attemptsMade):
+//
+//   - atm == 0 → scheduled (cron / 初回 delayed enqueue)
+//   - atm > 0  → retry-backoff (= 失敗して次の試行待ち)
+//
+// 戻り値は (scheduled, retry, err) (#1187)。
 //
 // delayed bucket は ZSET-backed なので 全件取り直しでも score 順に並ぶ。
 // fetch cost は ZRANGE 1 + HGETALL N pipeline で、publisher 3 秒間隔の
 // admin polling として許容範囲。
-func (i *Inspector) countDelayedByAttempts(q *mkq.Queue[framedPayload]) (scheduled int, retry int, err error) {
+func (i *Inspector) partitionDelayedByAttempts(q *mkq.Queue[framedPayload]) (scheduled int, retry int, err error) {
 	listed, err := q.ListJobs(inspectorCtx(), mkq.JobBucketDelayed, 0, -1, true)
 	if err != nil {
 		return 0, 0, err

--- a/internal/queue/driver/mkqdriver/integration_test.go
+++ b/internal/queue/driver/mkqdriver/integration_test.go
@@ -566,6 +566,57 @@ func TestInspector_GetQueueInfo_FailedReportedAsFailedNotRetry(t *testing.T) {
 		"permanent failure should land in Failed, not Retry (#1187)")
 }
 
+// TestInspector_GetQueueInfo_UnknownQueue: queueFor が nil を返す未知 queue
+// で `mkqdriver: unknown queue` error を返す (= error path / fallback の
+// 入口を pin)。
+func TestInspector_GetQueueInfo_UnknownQueue(t *testing.T) {
+	d := newDriver(t)
+	_, err := d.Inspector().GetQueueInfo("does-not-exist")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "unknown queue")
+}
+
+// TestInspector_ListRetryTasks_UnknownQueue: listDelayedFiltered 経路の
+// queueFor==nil error path を pin (= ListScheduledTasks も同 helper を
+// 通るので 1 test で両方 cover)。
+func TestInspector_ListRetryTasks_UnknownQueue(t *testing.T) {
+	d := newDriver(t)
+	_, err := d.Inspector().ListRetryTasks("does-not-exist", 1, 30)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "unknown queue")
+}
+
+// TestInspector_ListScheduledTasks_BoundaryPaging verifies the
+// listDelayedFiltered pagination guards: page < 1 / pageSize <= 0 /
+// pageSize > 100 はすべて default に倒れる、start >= len(filtered) は
+// 空 slice を返す (= ある page 番号より先には何も無い)。
+func TestInspector_ListScheduledTasks_BoundaryPaging(t *testing.T) {
+	d := newDriver(t)
+	ctx := context.Background()
+
+	require.NoError(t, d.Client().Enqueue(ctx,
+		"ins:paging", nil,
+		driver.WithQueue("deliver"),
+		driver.WithProcessIn(time.Hour),
+	))
+
+	ins := d.Inspector()
+	// page=0 / pageSize=0 → default (page=1, pageSize=30) で 1 件返る。
+	rows, err := ins.ListScheduledTasks("deliver", 0, 0)
+	require.NoError(t, err)
+	require.Len(t, rows, 1)
+
+	// pageSize > 100 → default pageSize 30 に倒れる。同 fixture で 1 件。
+	rows, err = ins.ListScheduledTasks("deliver", 1, 200)
+	require.NoError(t, err)
+	require.Len(t, rows, 1)
+
+	// page=2 (= start=30) は 1 件しかない fixture で空 slice。
+	rows, err = ins.ListScheduledTasks("deliver", 2, 30)
+	require.NoError(t, err)
+	assert.Empty(t, rows)
+}
+
 // TestInspector_GetQueueInfo_RetryReflectsDelayedAtmPositive verifies the
 // new semantic for the retry-backoff path: a delayed bucket entry with
 // `atm > 0` (= 過去に attempt 失敗して backoff 待ち) is surfaced as

--- a/internal/queue/driver/mkqdriver/integration_test.go
+++ b/internal/queue/driver/mkqdriver/integration_test.go
@@ -527,37 +527,32 @@ func TestInspector_RunTaskPromotesDelayed(t *testing.T) {
 	}, 3*time.Second, 50*time.Millisecond)
 }
 
-// TestInspector_GetQueueInfo_RetryReflectsFailedBucket verifies that the
-// Retry field surfaces the current failed bucket size (= retry-pending +
-// permanent failures). Without this the queueStats publisher's
-// Delayed = Scheduled + Retry calculation undercounts and admin/job-queue
-// graph stays stuck at 0 even when Errored Instances panel shows entries
-// (#1181).
+// TestInspector_GetQueueInfo_FailedReportedAsFailedNotRetry verifies the
+// post-#1187 semantic: SkipRetry / permanent failures land in the failed
+// bucket and are reported via `Failed`. They no longer leak into `Retry`
+// — Retry is reserved for delayed bucket entries with `atm > 0`.
 //
-// この test は SkipRetry sentinel で permanent fail のみ trigger する。
-// retry-backoff 待ち job も mkq では同じ failed bucket に集まる設計なので、
-// この path で「failed bucket size が Retry に流れる」ことが pin できれば
-// 両ケース (permanent / backoff) を同等に cover している。retry-backoff
-// で実 cycle を回す test は wait/active 遷移込みで flaky になりやすいので
-// 採用しない (= 設計上の前提を pin することで足りる)。長期的には mkq
-// 側に proper retry bucket が入る予定 (shiroha-a/mkq#64)。
-func TestInspector_GetQueueInfo_RetryReflectsFailedBucket(t *testing.T) {
+// 旧 #1181 fix では mkq の bucket 構造を「retry-backoff も failed bucket
+// に居る」と誤解して `Retry = counts.Failed` にしていたが、mkq#64 close
+// 時の upstream comment で訂正された (delayed bucket が両者を混在させて
+// いるのが正しい)。本 test は新 semantic を pin する (#1187)。
+func TestInspector_GetQueueInfo_FailedReportedAsFailedNotRetry(t *testing.T) {
 	d := newDriver(t)
 	srv := d.Server()
 	var wg sync.WaitGroup
 	wg.Add(1)
-	srv.Handle("ins:fail-then-check", func(_ context.Context, _ driver.Task) error {
+	srv.Handle("ins:permanent-fail", func(_ context.Context, _ driver.Task) error {
 		defer wg.Done()
 		// SkipRetry sentinel = immediate failure into the failed bucket
-		// (mkq's ErrUnrecoverable). retry-backoff 経路を回さない fast path
-		// だが、行き着く bucket は両ケース共通。
+		// (mkq's ErrUnrecoverable). retry-backoff 経路を回さない fast
+		// path だが、行き着くのは failed bucket (= permanent failure)。
 		return fmt.Errorf("intentional fail: %w", driver.SkipRetry)
 	})
 	require.NoError(t, srv.Start())
 	t.Cleanup(srv.Shutdown)
 
 	require.NoError(t, d.Client().Enqueue(context.Background(),
-		"ins:fail-then-check", nil,
+		"ins:permanent-fail", nil,
 		driver.WithQueue("deliver")))
 	if !waitGroupTimeout(&wg, 5*time.Second) {
 		t.Fatal("handler not invoked")
@@ -566,9 +561,104 @@ func TestInspector_GetQueueInfo_RetryReflectsFailedBucket(t *testing.T) {
 	ins := d.Inspector()
 	require.Eventually(t, func() bool {
 		info, err := ins.GetQueueInfo("deliver")
-		return err == nil && info.Retry >= 1 && info.Failed >= 1
+		return err == nil && info.Failed >= 1 && info.Retry == 0
 	}, 5*time.Second, 50*time.Millisecond,
-		"Retry should reflect failed bucket size (was hardcoded to 0)")
+		"permanent failure should land in Failed, not Retry (#1187)")
+}
+
+// TestInspector_GetQueueInfo_RetryReflectsDelayedAtmPositive verifies the
+// new semantic for the retry-backoff path: a delayed bucket entry with
+// `atm > 0` (= 過去に attempt 失敗して backoff 待ち) is surfaced as
+// `Retry` (= NOT `Scheduled`, NOT `Failed`) (#1187, mkq#64 close).
+//
+// driver level に backoff option が無いので、natural な retry cycle を
+// 回す代わりに WithProcessIn で初回 delayed に積んだ後 HSET で `atm` を
+// 直接 1 に書き換えて simulate する (white-box; mkq の HASH key 構造を
+// 既存 `TestEnqueue_MaxRetryAppliedToBullMQHash` と同じ手法で利用)。
+func TestInspector_GetQueueInfo_RetryReflectsDelayedAtmPositive(t *testing.T) {
+	d := newDriver(t)
+	ctx := context.Background()
+
+	require.NoError(t, d.Client().Enqueue(ctx,
+		"ins:retry-pending", nil,
+		driver.WithQueue("deliver"),
+		driver.WithProcessIn(time.Hour),
+	))
+
+	// 最新 job ID を `bull:<queue>:id` カウンタから取り、HASH の atm を
+	// 1 に上書きする (= mkq が retry-backoff で 1 度 attempt 済の状態を
+	// simulate)。
+	idStr, err := testRedis.Client.Get(ctx, "bull:deliver:id").Result()
+	require.NoError(t, err)
+	require.NoError(t, testRedis.Client.HSet(ctx, "bull:deliver:"+idStr, "atm", 1).Err())
+
+	ins := d.Inspector()
+	info, err := ins.GetQueueInfo("deliver")
+	require.NoError(t, err)
+	assert.Equal(t, 1, info.Retry, "atm>0 delayed entry should be classified as Retry (#1187)")
+	assert.Equal(t, 0, info.Scheduled, "scheduled should not include atm>0 entries")
+	assert.Equal(t, 0, info.Failed, "failed bucket must remain untouched by retry-backoff entries")
+}
+
+// TestInspector_ListRetryTasks_FiltersDelayedAtmPositive verifies that
+// ListRetryTasks returns only delayed bucket entries with `atm > 0`
+// (= retry-backoff waiters), not the entire failed bucket. (#1187)
+func TestInspector_ListRetryTasks_FiltersDelayedAtmPositive(t *testing.T) {
+	d := newDriver(t)
+	ctx := context.Background()
+
+	// 2 件 enqueue (= 同じ atm=0 delayed)、片方だけ atm=1 に書き換え。
+	require.NoError(t, d.Client().Enqueue(ctx,
+		"ins:retry-A", nil,
+		driver.WithQueue("deliver"),
+		driver.WithProcessIn(time.Hour),
+	))
+	require.NoError(t, d.Client().Enqueue(ctx,
+		"ins:retry-B", nil,
+		driver.WithQueue("deliver"),
+		driver.WithProcessIn(time.Hour),
+	))
+
+	// `bull:deliver:id` は最新 ID を返すので、これが atm>0 にする方
+	// (= retry-B 想定)、もう片方 (= retry-A) は atm=0 のままで scheduled
+	// 扱い。
+	idB, err := testRedis.Client.Get(ctx, "bull:deliver:id").Result()
+	require.NoError(t, err)
+	require.NoError(t, testRedis.Client.HSet(ctx, "bull:deliver:"+idB, "atm", 1).Err())
+
+	ins := d.Inspector()
+	retry, err := ins.ListRetryTasks("deliver", 1, 30)
+	require.NoError(t, err)
+	require.Len(t, retry, 1, "only atm>0 entries should appear in ListRetryTasks")
+
+	scheduled, err := ins.ListScheduledTasks("deliver", 1, 30)
+	require.NoError(t, err)
+	require.Len(t, scheduled, 1, "atm=0 entry should be in ListScheduledTasks")
+}
+
+// TestInspector_ListScheduledTasks_FiltersDelayedAtmZero verifies that
+// ListScheduledTasks returns only delayed bucket entries with `atm == 0`
+// (= first-time scheduled, cron / WithProcessIn 等)、retry-backoff
+// (atm > 0) は ListRetryTasks 側に出る (#1187)。
+func TestInspector_ListScheduledTasks_FiltersDelayedAtmZero(t *testing.T) {
+	d := newDriver(t)
+
+	// WithProcessIn で delayed bucket に直接 enqueue (= 初回処理待ち、atm=0)。
+	require.NoError(t, d.Client().Enqueue(context.Background(),
+		"ins:list-scheduled", nil,
+		driver.WithQueue("deliver"),
+		driver.WithProcessIn(time.Hour),
+	))
+
+	ins := d.Inspector()
+	scheduled, err := ins.ListScheduledTasks("deliver", 1, 30)
+	require.NoError(t, err)
+	require.Len(t, scheduled, 1, "first-time scheduled (atm=0) entry should appear")
+
+	// 同時に retry path には居ないこと。
+	retry, err := ins.ListRetryTasks("deliver", 1, 30)
+	require.NoError(t, err)
+	assert.Empty(t, retry, "retry list must not contain atm=0 entries")
 }
 
 // TestClient_Enqueue_WithKeepFailed_BoundsFailedBucket verifies the
@@ -642,17 +732,20 @@ func TestInspector_RunTask_FallsBackToRetryJobForFailedBucket(t *testing.T) {
 	}
 
 	ins := d.Inspector()
-	// Wait until the job has landed in the failed bucket (= ListRetryTasks
-	// sees it through mkq's failed bucket).
+	ctx := context.Background()
+	// Wait until the job has landed in the failed bucket. failed bucket は
+	// 公開 list API には出ないので (#1187 で ListRetryTasks が delayed 専用
+	// に変わった)、raw Redis ZRANGE で task ID を取り出す。
 	var failedTaskID string
 	require.Eventually(t, func() bool {
-		rows, err := ins.ListRetryTasks("deliver", 1, 30)
-		if err != nil || len(rows) == 0 {
+		ids, err := testRedis.Client.ZRange(ctx, "bull:deliver:failed", 0, -1).Result()
+		if err != nil || len(ids) == 0 {
 			return false
 		}
-		failedTaskID = rows[0].ID
+		failedTaskID = ids[0]
 		return true
-	}, 5*time.Second, 50*time.Millisecond)
+	}, 5*time.Second, 50*time.Millisecond,
+		"job should have landed in the failed bucket")
 
 	// RunTask must succeed via RetryJob fallback even though the job is
 	// not in mkq's delayed bucket. asynq's parity contract: callers only
@@ -660,18 +753,17 @@ func TestInspector_RunTask_FallsBackToRetryJobForFailedBucket(t *testing.T) {
 	require.NoError(t, ins.RunTask("deliver", failedTaskID),
 		"RunTask should fall back to RetryJob for failed bucket jobs")
 
-	// After the fallback the failed bucket count drops by one. We assert
-	// the count rather than chasing the job through wait→active→failed
-	// again (the handler is still registered and will refail it), since
-	// the contract under test is just "RunTask did not error and the job
-	// left the failed bucket".
+	// After the fallback the failed bucket loses this job (= ZRANGE no
+	// longer contains it). We assert at the bucket level rather than
+	// chasing the job through wait→active→failed again (the handler is
+	// still registered and will refail it).
 	require.Eventually(t, func() bool {
-		rows, err := ins.ListRetryTasks("deliver", 1, 30)
+		ids, err := testRedis.Client.ZRange(ctx, "bull:deliver:failed", 0, -1).Result()
 		if err != nil {
 			return false
 		}
-		for _, r := range rows {
-			if r.ID == failedTaskID {
+		for _, id := range ids {
+			if id == failedTaskID {
 				return false // still in failed bucket
 			}
 		}


### PR DESCRIPTION
## Summary

#1182 で採用した \`Retry = counts.Failed\` (= failed bucket size) は mkq
の bucket 構造への事実誤認に基づくものだった。shiroha-a/mkq#64 close
時の upstream comment で訂正されたとおり、retry-backoff 待ちは
**delayed bucket** に居る (= BullMQ 同等)。本 PR は upstream が示唆した
手法 (delayed bucket を \`atm\` HASH field で filter) を driver level に
実装する。

\`\`\`
旧:  failed bucket = retry-pending + permanent failure  (誤)
新:  failed bucket = permanent failure のみ
     delayed bucket = scheduled (cron/初回) + retry-backoff 待ち  ← 混在
\`\`\`

## Approach

### \`countDelayedByAttempts(q)\` helper

delayed bucket 全件 \`ListJobs\` して \`AttemptsMade > 0\` (= retry-pending)
と \`== 0\` (= scheduled) に partition。

### \`GetQueueInfo\` 3 way split

| asynq field | mkq 由来 |
|---|---|
| Scheduled | delayed[atm==0] + repeat ZSET |
| Retry     | delayed[atm>0] |
| Failed    | failed bucket size (permanent failure) |
| その他    | 不変 |

scan 失敗時は保守的に旧挙動 (delayed 全体を Scheduled、Retry=0) に
fallback (= 全体 error にすると admin graph が真っ白になる、表示を救う
方優先)。

### \`ListRetryTasks\` / \`ListScheduledTasks\`

\`listDelayedFiltered\` helper で delayed 全件 fetch → atm で filter →
page/pageSize で slice (= post-filter pagination で counts と一致)。

### \`RunTask\` の PromoteJob → RetryJob fallback

**維持**。両 bucket (delayed / failed) の手動 retry を覆える設計は不変、
doc コメントだけ「retry-backoff は failed bucket」の誤記を訂正。

## テスト

### 既存

- \`TestInspector_GetQueueInfo_RetryReflectsFailedBucket\` (旧 #1181 fix で追加) → \`_FailedReportedAsFailedNotRetry\` に書き直し
- \`TestInspector_RunTask_FallsBackToRetryJobForFailedBucket\`: ListRetryTasks 経由で failed bucket task ID 取得 → raw Redis ZRANGE に置換 (= 新 semantic で ListRetryTasks が failed bucket を出さないため)

### 新規

- \`TestInspector_GetQueueInfo_RetryReflectsDelayedAtmPositive\`: HSET atm=1 で retry-backoff simulate、GetQueueInfo.Retry=1 を確認
- \`TestInspector_ListRetryTasks_FiltersDelayedAtmPositive\`: 2 件 delayed で片方だけ atm=1、ListRetryTasks=1件 / ListScheduledTasks=1件 で split 確認
- \`TestInspector_ListScheduledTasks_FiltersDelayedAtmZero\`: 初回 WithProcessIn (atm=0) が Scheduled に出て Retry に出ない確認

### 実行結果

\`\`\`
$ go test ./internal/queue/driver/mkqdriver/...
ok  internal/queue/driver/mkqdriver    28.243s
\`\`\`

\`make fmt\` / \`make lint\` clean。

## 影響範囲 (operator visible)

- **Errored Instances panel**: 旧 = permanent dead host / 新 = retry-backoff 待ち host
- **Retry column 意味**: dead letter → backoff 中 (正規化)
- **Failed column / Size**: 不変
- **frontend**: 無改変 (= 表示位置同じ、意味だけ semantic に揃う)

## cost / performance

delayed bucket 全件 ListJobs (ZRANGE + N×HGETALL pipeline) が publisher
3 秒間隔 + admin polling で走る。通常 < 100 件で問題なし、federation
障害時数千件でも許容範囲。将来必要なら count-only Lua API の追加余地
あり (= 別 issue)。

## Closes

#1187 (UDS の inbox failure 連続 fix の最終分)

## 関連 (この issue series の総括)

- #1183: 発生源 (Like の remote resolve permanent error を best-effort ack)
- #1184: 蓄積防止 (removeOnFail / KeepFailed)
- #1185: Foundkey 互換 (JSON array wrap activity tolerance)
- #1186: 重複 reaction の idempotent
- **#1187 (本 PR)**: mkqdriver semantic correction (mkq#64 close 受けた真 fix)