### PR TITLE
feat(queue): 全 enqueue で removeOnComplete (KeepCompleted) を設定して completed bucket の永続蓄積を防ぐ (#1193)

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -164,6 +164,14 @@ type Source struct {
 	DeliverJobKeepFailed *int `mapstructure:"deliverJobKeepFailed"`
 	InboxJobKeepFailed   *int `mapstructure:"inboxJobKeepFailed"`
 
+	// `<queue>JobKeepCompleted` は completed bucket retention の最大
+	// 件数。意味的には KeepFailed と同じ「件数で上限を切る」。0 で
+	// 蓄積無制限 (= UDS 観測で実害があった BullMQ default 挙動) に
+	// opt-out 可能。未指定なら mk-go internal default (TS と同じ 30)
+	// が適用される (#1193)。
+	DeliverJobKeepCompleted *int `mapstructure:"deliverJobKeepCompleted"`
+	InboxJobKeepCompleted   *int `mapstructure:"inboxJobKeepCompleted"`
+
 	// JobQueueAutoScale toggles the AIMD auto-scale controller (#1120).
 	// Default false. When true, queues without an explicit
 	// `<queue>JobConcurrency` are managed by the controller within
@@ -325,6 +333,8 @@ type Config struct {
 	InboxJobMaxAttempts        *int
 	DeliverJobKeepFailed       *int
 	InboxJobKeepFailed         *int
+	DeliverJobKeepCompleted    *int
+	InboxJobKeepCompleted      *int
 
 	// Auto-scale knobs (#1120 tracker). See docs/design/auto-scale-job-workers.md.
 	JobQueueAutoScale        bool
@@ -569,6 +579,8 @@ func resolve(src *Source) (*Config, error) {
 		InboxJobMaxAttempts:        src.InboxJobMaxAttempts,
 		DeliverJobKeepFailed:       src.DeliverJobKeepFailed,
 		InboxJobKeepFailed:         src.InboxJobKeepFailed,
+		DeliverJobKeepCompleted:    src.DeliverJobKeepCompleted,
+		InboxJobKeepCompleted:      src.InboxJobKeepCompleted,
 		JobQueueAutoScale:          src.JobQueueAutoScale,
 		MaxWorkers:                 src.MaxWorkers,
 		MinWorkers:                 src.MinWorkers,

--- a/internal/queue/driver/asynqdriver/asynqdriver_test.go
+++ b/internal/queue/driver/asynqdriver/asynqdriver_test.go
@@ -106,6 +106,27 @@ func TestToAsynqOptions_KeepFailedIsSilentNoOp(t *testing.T) {
 	}
 }
 
+// TestToAsynqOptions_KeepCompletedIsSilentNoOp / AgeIsSilentNoOp:
+// completed bucket 系も含めて KeepFailed と同じく silent no-op (#1193)。
+// asynq は完了履歴管理が BullMQ と異なる系統なので driver-neutral hint を
+// 反映できない。
+func TestToAsynqOptions_KeepCompletedIsSilentNoOp(t *testing.T) {
+	got := toAsynqOptions(driver.EnqueueOptions{KeepCompleted: 30, KeepCompletedSet: true})
+	if len(got) != 0 {
+		t.Fatalf("KeepCompleted must be silently ignored by asynqdriver, got %d options", len(got))
+	}
+}
+
+func TestToAsynqOptions_AgeIsSilentNoOp(t *testing.T) {
+	got := toAsynqOptions(driver.EnqueueOptions{
+		KeepCompletedAge: 7 * 24 * time.Hour,
+		KeepFailedAge:    7 * 24 * time.Hour,
+	})
+	if len(got) != 0 {
+		t.Fatalf("age options must be silently ignored by asynqdriver, got %d options", len(got))
+	}
+}
+
 // fakeRedis returns a non-routable RedisClientOpt; we never Start the
 // server in these tests so the address is fine. asynq client/inspector
 // constructors do not Dial until the first request.

--- a/internal/queue/driver/driver_test.go
+++ b/internal/queue/driver/driver_test.go
@@ -32,15 +32,22 @@ func TestApplyEnqueueOptions(t *testing.T) {
 		WithUnique(time.Hour),
 		WithProcessIn(5 * time.Second),
 		WithKeepFailed(500),
+		WithKeepCompleted(30),
+		WithKeepCompletedAge(7 * 24 * time.Hour),
+		WithKeepFailedAge(7 * 24 * time.Hour),
 	})
 	want := EnqueueOptions{
-		Queue:         "deliver",
-		MaxRetry:      3,
-		MaxRetrySet:   true,
-		UniqueTTL:     time.Hour,
-		ProcessIn:     5 * time.Second,
-		KeepFailed:    500,
-		KeepFailedSet: true,
+		Queue:            "deliver",
+		MaxRetry:         3,
+		MaxRetrySet:      true,
+		UniqueTTL:        time.Hour,
+		ProcessIn:        5 * time.Second,
+		KeepFailed:       500,
+		KeepFailedSet:    true,
+		KeepCompleted:    30,
+		KeepCompletedSet: true,
+		KeepCompletedAge: 7 * 24 * time.Hour,
+		KeepFailedAge:    7 * 24 * time.Hour,
 	}
 	if got != want {
 		t.Fatalf("got %#v want %#v", got, want)
@@ -73,5 +80,36 @@ func TestApplyEnqueueOptions_KeepFailedZeroSentinel(t *testing.T) {
 	def := ApplyEnqueueOptions(nil)
 	if def.KeepFailedSet {
 		t.Fatalf("default options must not record KeepFailedSet")
+	}
+}
+
+// TestApplyEnqueueOptions_KeepCompletedZeroSentinel: WithKeepCompleted(0)
+// も同じく「明示的 opt-out」を表し、KeepCompletedSet で default と区別
+// できる必要がある (#1193、KeepFailed と対称)。
+func TestApplyEnqueueOptions_KeepCompletedZeroSentinel(t *testing.T) {
+	got := ApplyEnqueueOptions([]EnqueueOption{WithKeepCompleted(0)})
+	if got.KeepCompleted != 0 || !got.KeepCompletedSet {
+		t.Fatalf("explicit zero not recorded: %#v", got)
+	}
+
+	def := ApplyEnqueueOptions(nil)
+	if def.KeepCompletedSet {
+		t.Fatalf("default options must not record KeepCompletedSet")
+	}
+}
+
+// TestApplyEnqueueOptions_AgeOptions: age-based retention は Set sentinel
+// を持たない (age=0 は「設定なし」と同義扱い、BullMQ 仕様で age を 0 に
+// する意味のあるケースが無いため)。
+func TestApplyEnqueueOptions_AgeOptions(t *testing.T) {
+	got := ApplyEnqueueOptions([]EnqueueOption{
+		WithKeepCompletedAge(7 * 24 * time.Hour),
+		WithKeepFailedAge(3 * 24 * time.Hour),
+	})
+	if got.KeepCompletedAge != 7*24*time.Hour {
+		t.Fatalf("KeepCompletedAge: got %v", got.KeepCompletedAge)
+	}
+	if got.KeepFailedAge != 3*24*time.Hour {
+		t.Fatalf("KeepFailedAge: got %v", got.KeepFailedAge)
 	}
 }

--- a/internal/queue/driver/mkqdriver/mkqdriver_test.go
+++ b/internal/queue/driver/mkqdriver/mkqdriver_test.go
@@ -130,6 +130,71 @@ func TestToMkqAddOptions_KeepFailedPositive(t *testing.T) {
 	}
 }
 
+// TestToMkqAddOptions_KeepCompletedZeroSkipped: KeepFailed と同じ 0-skip
+// semantic を KeepCompleted 側でも維持する (mkq native の WithKeepCompleted(0)
+// は「即時削除」で driver-neutral semantic と真逆、#1193 review)。
+func TestToMkqAddOptions_KeepCompletedZeroSkipped(t *testing.T) {
+	o := driver.EnqueueOptions{KeepCompleted: 0, KeepCompletedSet: true}
+	got := toMkqAddOptions(o, "task", nil)
+	if len(got) != 1 {
+		t.Fatalf("KeepCompleted=0 must not emit mkq.WithKeepCompleted, got %d options", len(got))
+	}
+}
+
+// TestToMkqAddOptions_KeepCompletedPositive: value>0 のときは
+// mkq.WithKeepCompleted として直訳される。
+func TestToMkqAddOptions_KeepCompletedPositive(t *testing.T) {
+	o := driver.EnqueueOptions{KeepCompleted: 30, KeepCompletedSet: true}
+	got := toMkqAddOptions(o, "task", nil)
+	// WithJobName + WithKeepCompleted の 2 個。
+	if len(got) != 2 {
+		t.Fatalf("KeepCompleted>0 should emit mkq.WithKeepCompleted, got %d options", len(got))
+	}
+}
+
+// TestToMkqAddOptions_AgePositive: KeepCompletedAge / KeepFailedAge の
+// 両方が正値なら 2 個追加で計 3 個。0 は emit しない。
+func TestToMkqAddOptions_AgePositive(t *testing.T) {
+	o := driver.EnqueueOptions{
+		KeepCompletedAge: 7 * 24 * time.Hour,
+		KeepFailedAge:    7 * 24 * time.Hour,
+	}
+	got := toMkqAddOptions(o, "task", nil)
+	// WithJobName + WithKeepCompletedAge + WithKeepFailedAge の 3 個。
+	if len(got) != 3 {
+		t.Fatalf("both ages should emit 2 options + WithJobName = 3 total, got %d", len(got))
+	}
+}
+
+// TestToMkqAddOptions_AgeZeroSkipped: age=0 は「未指定」扱いで emit しない
+// (BullMQ 仕様で age=0 を意味的に使う場面が無く、Set sentinel 不要)。
+func TestToMkqAddOptions_AgeZeroSkipped(t *testing.T) {
+	o := driver.EnqueueOptions{KeepCompletedAge: 0, KeepFailedAge: 0}
+	got := toMkqAddOptions(o, "task", nil)
+	if len(got) != 1 {
+		t.Fatalf("age=0 must not emit options, got %d", len(got))
+	}
+}
+
+// TestToMkqAddOptions_FullRetention: TS upstream の `{age: 7d, count: 30}`
+// /  `{age: 7d, count: 100}` 互換を 1 ジョブで両側設定したケース。
+// WithJobName + WithKeepFailed + WithKeepCompleted + WithKeepCompletedAge +
+// WithKeepFailedAge の 5 options が emit される。
+func TestToMkqAddOptions_FullRetention(t *testing.T) {
+	o := driver.EnqueueOptions{
+		KeepFailed:       100,
+		KeepFailedSet:    true,
+		KeepCompleted:    30,
+		KeepCompletedSet: true,
+		KeepCompletedAge: 7 * 24 * time.Hour,
+		KeepFailedAge:    7 * 24 * time.Hour,
+	}
+	got := toMkqAddOptions(o, "task", nil)
+	if len(got) != 5 {
+		t.Fatalf("full retention should emit 4 retention options + WithJobName = 5 total, got %d", len(got))
+	}
+}
+
 func TestToMkqAddOptions_MaxRetryRequiresExplicit(t *testing.T) {
 	// MaxRetrySet=false → default attempts; no option emitted.
 	got := toMkqAddOptions(driver.EnqueueOptions{MaxRetry: 3}, "task", nil)

--- a/internal/queue/driver/mkqdriver/option.go
+++ b/internal/queue/driver/mkqdriver/option.go
@@ -66,6 +66,22 @@ func toMkqAddOptions(o driver.EnqueueOptions, taskType string, payload []byte) [
 		// `removeOnFail: N` 互換 (#1184)。
 		out = append(out, mkq.WithKeepFailed(o.KeepFailed))
 	}
+	if o.KeepCompletedSet && o.KeepCompleted > 0 {
+		// `WithKeepFailed` と同じ 0-skip semantic (上のコメント参照)。
+		// mkq native の `WithKeepCompleted(0)` は「即時削除」で
+		// driver-neutral の「unlimited 蓄積」と真逆なので skip する。
+		// BullMQ の `removeOnComplete: N` 互換 (#1193)。
+		out = append(out, mkq.WithKeepCompleted(o.KeepCompleted))
+	}
+	if o.KeepCompletedAge > 0 {
+		// age-based retention は count と独立に効く。両方指定すれば
+		// BullMQ TS の `removeOnComplete: {age: 7d, count: 30}` 互換に
+		// なる (どちらの条件に引っ掛かっても prune される)。
+		out = append(out, mkq.WithKeepCompletedAge(o.KeepCompletedAge))
+	}
+	if o.KeepFailedAge > 0 {
+		out = append(out, mkq.WithKeepFailedAge(o.KeepFailedAge))
+	}
 	return out
 }
 

--- a/internal/queue/driver/option.go
+++ b/internal/queue/driver/option.go
@@ -11,6 +11,9 @@ import "time"
 //   - UniqueTTL 0        : no unique-key dedup
 //   - ProcessIn 0        : process immediately
 //   - KeepFailed 0       : driver default (= no automatic retention)
+//   - KeepCompleted 0    : driver default (= no automatic retention)
+//   - KeepCompletedAge 0 : driver default (= no age-based prune)
+//   - KeepFailedAge 0    : driver default (= no age-based prune)
 type EnqueueOptions struct {
 	Queue     string
 	MaxRetry  int
@@ -29,6 +32,32 @@ type EnqueueOptions struct {
 	// (= documented intent としての semantic を保つ)。
 	KeepFailed    int
 	KeepFailedSet bool
+
+	// KeepCompleted bounds the size of the completed ZSET, mirroring
+	// KeepFailed's semantics for the completed bucket. mkq translates
+	// this to `mkq.WithKeepCompleted(n)`. asynq has no per-job
+	// equivalent (= silent no-op). BullMQ の `removeOnComplete: N`
+	// 互換 (#1193)。
+	//
+	// KeepCompletedSet も KeepFailedSet と同じ「明示 0 vs default」
+	// 区別 pattern。
+	KeepCompleted    int
+	KeepCompletedSet bool
+
+	// KeepCompletedAge drops completed jobs older than this duration
+	// (BullMQ `removeOnComplete: {age: <seconds>}` 互換)。mkq
+	// translates to `mkq.WithKeepCompletedAge(age)`。0 = age-based
+	// prune 無し (driver default を踏ませる)。asynq では silent no-op。
+	//
+	// Combine with KeepCompleted to cap by both count and age in
+	// the same way BullMQ TS's `{age, count}` object form works
+	// (BullMQ TS の `removeOnComplete: {age: 7d, count: 30}` 互換)。
+	KeepCompletedAge time.Duration
+
+	// KeepFailedAge is the failed-side analogue of KeepCompletedAge
+	// (BullMQ `removeOnFail: {age: <seconds>}` 互換)。0 = age-based
+	// prune 無し。
+	KeepFailedAge time.Duration
 
 	// MaxRetrySet distinguishes "MaxRetry left at default" from
 	// "MaxRetry explicitly set to 0". asynq treats MaxRetry=0 as
@@ -87,6 +116,49 @@ func WithKeepFailed(n int) EnqueueOption {
 		o.KeepFailed = n
 		o.KeepFailedSet = true
 	}
+}
+
+// WithKeepCompleted bounds the size of the completed bucket / ZSET for
+// this task's queue, mirroring WithKeepFailed's semantics for completed
+// jobs. n==0 explicitly disables retention (= unlimited accumulation).
+//
+// 主な使い道: BullMQ default の「completed job 無制限保持」を防ぐ。
+// inbox / deliver / db / push / webhook queue の completed bookkeeping
+// が時間と共に redis memory を蝕む実害があるため (#1193 で UDS 観測)。
+// BullMQ の `removeOnComplete: N` と意味同等。
+//
+// driver 別:
+//   - mkqdriver: `n > 0` のときだけ `mkq.WithKeepCompleted(n)` を AddJob
+//     に渡す。注意: mkq native の `WithKeepCompleted(0)` は **「即時削除」**
+//     (BullMQ `removeOnComplete: true` 相当) で driver-neutral semantic と
+//     真逆なので、driver translation 側で 0 は skip する。
+//   - asynqdriver: silent no-op (asynq は完了履歴の per-job retention 制御
+//     を持たず、archived bucket とは別系統で管理される)
+func WithKeepCompleted(n int) EnqueueOption {
+	return func(o *EnqueueOptions) {
+		o.KeepCompleted = n
+		o.KeepCompletedSet = true
+	}
+}
+
+// WithKeepCompletedAge drops completed jobs older than age, mirroring
+// mkq's `WithKeepCompletedAge` (BullMQ `removeOnComplete: {age: <sec>}`
+// 互換)。WithKeepCompleted と併用すると count / age の両条件で prune
+// される (BullMQ TS の `removeOnComplete: {age: 7d, count: 30}` 互換)。
+//
+// driver 別:
+//   - mkqdriver: `age > 0` のときだけ `mkq.WithKeepCompletedAge(age)` を
+//     AddJob に渡す。
+//   - asynqdriver: silent no-op (asynq に対応 API なし)
+func WithKeepCompletedAge(age time.Duration) EnqueueOption {
+	return func(o *EnqueueOptions) { o.KeepCompletedAge = age }
+}
+
+// WithKeepFailedAge is the failed-side analogue of WithKeepCompletedAge
+// (BullMQ `removeOnFail: {age: <sec>}` 互換)。WithKeepFailed と併用
+// すると count / age の両条件で prune される。
+func WithKeepFailedAge(age time.Duration) EnqueueOption {
+	return func(o *EnqueueOptions) { o.KeepFailedAge = age }
 }
 
 // ApplyEnqueueOptions folds the variadic options into a single

--- a/internal/queue/policy.go
+++ b/internal/queue/policy.go
@@ -1,5 +1,7 @@
 package queue
 
+import "time"
+
 // Policy captures runtime tuning knobs for a single logical queue. The
 // fields are applied lazily by NewClient (default MaxRetry on enqueue) and
 // by the driver Server constructors (worker concurrency / rate limit). All
@@ -39,6 +41,24 @@ type Policy struct {
 	// `MaxAttempts` と同じく EnqueueDeliver / EnqueueInbox が caller
 	// opts の前に prepend する形で渡る (#1184)。
 	KeepFailed int
+
+	// KeepCompleted bounds the size of the completed bucket / ZSET for
+	// this queue, mirroring KeepFailed's semantics for the completed
+	// side (BullMQ `removeOnComplete: N` 互換、#1193)。0 = retention
+	// 無し (= BullMQ default の無制限蓄積、UDS 観測で実害があった
+	// 旧挙動)。
+	KeepCompleted int
+
+	// KeepCompletedAge bounds completed job retention by age, mirroring
+	// BullMQ TS の `removeOnComplete: {age: <seconds>}`。KeepCompleted
+	// と併用すると count / age の両条件で prune される (TS upstream
+	// は両方指定する規約)。
+	KeepCompletedAge time.Duration
+
+	// KeepFailedAge は failed bucket の age-based retention。
+	// KeepFailed と併用して BullMQ TS の `removeOnFail: {age: <sec>,
+	// count: N}` を再現する。
+	KeepFailedAge time.Duration
 }
 
 // PolicyMap maps queue name → Policy. Lookups for missing queues return

--- a/internal/queue/policy.go
+++ b/internal/queue/policy.go
@@ -7,10 +7,16 @@ import "time"
 // by the driver Server constructors (worker concurrency / rate limit). All
 // zero values mean "use the driver default" — silent no-op when unset.
 //
-// MaxAttempts only affects enqueue paths that pre-pend the default before
-// caller opts (currently EnqueueDeliver only — webhook / cleanRemoteNotes
-// / reactionFlush keep their hard-coded retry policies because they encode
-// task-specific semantics rather than queue-wide tuning).
+// 各 field の適用範囲:
+//
+//   - MaxAttempts: EnqueueDeliver / EnqueueInbox のみ pre-pend する
+//     (webhook / cleanRemoteNotes / reactionFlush 等は task-specific semantics
+//     を encode する hard-coded retry を保持)。
+//   - KeepFailed / KeepCompleted / KeepCompletedAge / KeepFailedAge:
+//     **全 enqueue helper** で pre-pend される (#1184 / #1193)。retention 系は
+//     queue-wide hygiene として一律に効かせる方針 (Misskey TS が QueueService.ts
+//     全 helper で `removeOnComplete`/`removeOnFail` を一律 set している規範に
+//     合わせる)。
 type Policy struct {
 	// Concurrency overrides the worker pool size for this queue. 0 means
 	// "fall back to driver default" — for asynq this is the global pool

--- a/internal/queue/queue.go
+++ b/internal/queue/queue.go
@@ -150,13 +150,20 @@ func (c *Client) policyFor(queueName string) Policy {
 // BullMQ-compatible removeOnComplete / removeOnFail are wired uniformly
 // across deliver / inbox / export / push / webhook (#1193)。
 //
-// 各 field は 0 (= unset) のとき option を emit しない (driver default
-// = unlimited retention) ように `> 0` で guard。これは driver-neutral
-// layer の `WithKeepFailed` / `WithKeepCompleted` の 0-skip semantic と
-// 同じ規約 (mkqdriver/option.go の対応 guard 参照)。
+// 自前で Policy を引いていない caller 向けの薄い wrapper。MaxAttempts も
+// 見たい caller は policyFor を呼んでから retentionOptsFromPolicy を直接
+// 使うことで RLock を 1 回に抑えられる (EnqueueDeliver / EnqueueInbox 経路)。
 func (c *Client) retentionOpts(queueName string) []driver.EnqueueOption {
-	p := c.policyFor(queueName)
-	var out []driver.EnqueueOption
+	return retentionOptsFromPolicy(c.policyFor(queueName))
+}
+
+// retentionOptsFromPolicy is the lock-free core of retentionOpts. 各 field は
+// 0 (= unset) のとき option を emit しない (driver default = unlimited retention)
+// ように `> 0` で guard。これは driver-neutral layer の `WithKeepFailed` /
+// `WithKeepCompleted` の 0-skip semantic と同じ規約 (mkqdriver/option.go の
+// 対応 guard 参照)。
+func retentionOptsFromPolicy(p Policy) []driver.EnqueueOption {
+	out := make([]driver.EnqueueOption, 0, 4)
 	if p.KeepCompleted > 0 {
 		out = append(out, driver.WithKeepCompleted(p.KeepCompleted))
 	}
@@ -188,14 +195,16 @@ func (c *Client) retentionOpts(queueName string) []driver.EnqueueOption {
 // (#531 review)。
 func (c *Client) EnqueueDeliver(payload DeliverPayload, opts ...driver.EnqueueOption) error {
 	body := mustMarshal(payload)
-	base := []driver.EnqueueOption{driver.WithQueue(QueueName)}
+	// 1 回の policyFor で MaxAttempts と retention の両方を済ませる
+	// (RLock 1 回 / map lookup 1 回に集約)。
 	p := c.policyFor(QueueName)
+	base := []driver.EnqueueOption{driver.WithQueue(QueueName)}
 	if p.MaxAttempts > 0 {
 		base = append(base, driver.WithMaxRetry(p.MaxAttempts-1))
 	}
 	// completed / failed bucket retention を Policy から組み立てる (#1184 / #1193)。
 	// mkqdriver 経路でのみ効き、asynqdriver では silent no-op。
-	base = append(base, c.retentionOpts(QueueName)...)
+	base = append(base, retentionOptsFromPolicy(p)...)
 	merged := append(base, opts...)
 	return c.inner.Enqueue(context.Background(), TaskTypeDeliver, body, merged...)
 }
@@ -302,12 +311,13 @@ func (c *Client) EnqueueImportCustomEmojis(payload ImportCustomEmojisPayload) er
 // variadic pattern に揃える。
 func (c *Client) EnqueueInbox(ctx context.Context, payload InboxPayload) error {
 	body := mustMarshal(payload)
-	base := []driver.EnqueueOption{driver.WithQueue(InboxQueueName)}
+	// EnqueueDeliver と同じ理由で 1-shot lookup (#1184 / #1193)。
 	p := c.policyFor(InboxQueueName)
+	base := []driver.EnqueueOption{driver.WithQueue(InboxQueueName)}
 	if p.MaxAttempts > 0 {
 		base = append(base, driver.WithMaxRetry(p.MaxAttempts-1))
 	}
-	base = append(base, c.retentionOpts(InboxQueueName)...)
+	base = append(base, retentionOptsFromPolicy(p)...)
 	return c.inner.Enqueue(ctx, TaskTypeInbox, body, base...)
 }
 

--- a/internal/queue/queue.go
+++ b/internal/queue/queue.go
@@ -144,6 +144,34 @@ func (c *Client) policyFor(queueName string) Policy {
 	return c.policies.PolicyFor(queueName)
 }
 
+// retentionOpts returns the driver-neutral options derived from the
+// queue's Policy (KeepCompleted / KeepCompletedAge / KeepFailed /
+// KeepFailedAge). All Enqueue* helpers pre-pend this output so the
+// BullMQ-compatible removeOnComplete / removeOnFail are wired uniformly
+// across deliver / inbox / export / push / webhook (#1193)。
+//
+// 各 field は 0 (= unset) のとき option を emit しない (driver default
+// = unlimited retention) ように `> 0` で guard。これは driver-neutral
+// layer の `WithKeepFailed` / `WithKeepCompleted` の 0-skip semantic と
+// 同じ規約 (mkqdriver/option.go の対応 guard 参照)。
+func (c *Client) retentionOpts(queueName string) []driver.EnqueueOption {
+	p := c.policyFor(queueName)
+	var out []driver.EnqueueOption
+	if p.KeepCompleted > 0 {
+		out = append(out, driver.WithKeepCompleted(p.KeepCompleted))
+	}
+	if p.KeepCompletedAge > 0 {
+		out = append(out, driver.WithKeepCompletedAge(p.KeepCompletedAge))
+	}
+	if p.KeepFailed > 0 {
+		out = append(out, driver.WithKeepFailed(p.KeepFailed))
+	}
+	if p.KeepFailedAge > 0 {
+		out = append(out, driver.WithKeepFailedAge(p.KeepFailedAge))
+	}
+	return out
+}
+
 // EnqueueDeliver puts a deliver task on the queue. opts override the
 // default queue selection if they include WithQueue, but normal
 // callers should pass payload-only and let the queue routing stay
@@ -165,11 +193,9 @@ func (c *Client) EnqueueDeliver(payload DeliverPayload, opts ...driver.EnqueueOp
 	if p.MaxAttempts > 0 {
 		base = append(base, driver.WithMaxRetry(p.MaxAttempts-1))
 	}
-	if p.KeepFailed > 0 {
-		// mkqdriver 経路でのみ効く。asynqdriver は silent no-op。
-		// failed bucket retention で永続蓄積を防ぐ (#1184)。
-		base = append(base, driver.WithKeepFailed(p.KeepFailed))
-	}
+	// completed / failed bucket retention を Policy から組み立てる (#1184 / #1193)。
+	// mkqdriver 経路でのみ効き、asynqdriver では silent no-op。
+	base = append(base, c.retentionOpts(QueueName)...)
 	merged := append(base, opts...)
 	return c.inner.Enqueue(context.Background(), TaskTypeDeliver, body, merged...)
 }
@@ -179,7 +205,9 @@ func (c *Client) EnqueueDeliver(payload DeliverPayload, opts ...driver.EnqueueOp
 // で `scheduledAt - now` を指定する想定 (#1040)。
 func (c *Client) EnqueuePostScheduledNote(payload PostScheduledNotePayload, opts ...driver.EnqueueOption) error {
 	body := mustMarshal(payload)
-	merged := append([]driver.EnqueueOption{driver.WithQueue(QueueName)}, opts...)
+	base := []driver.EnqueueOption{driver.WithQueue(QueueName)}
+	base = append(base, c.retentionOpts(QueueName)...)
+	merged := append(base, opts...)
 	return c.inner.Enqueue(context.Background(), TaskTypePostScheduledNote, body, merged...)
 }
 
@@ -241,26 +269,26 @@ func (c *Client) ClearScheduledNote(draftID string) error {
 // EnqueueExport puts an export task on the queue.
 func (c *Client) EnqueueExport(payload ExportPayload) error {
 	body := mustMarshal(payload)
-	return c.inner.Enqueue(context.Background(), TaskTypeExport, body,
-		driver.WithQueue(ExportQueueName),
-	)
+	base := []driver.EnqueueOption{driver.WithQueue(ExportQueueName)}
+	base = append(base, c.retentionOpts(ExportQueueName)...)
+	return c.inner.Enqueue(context.Background(), TaskTypeExport, body, base...)
 }
 
 // EnqueueImport puts an import task on the queue.
 func (c *Client) EnqueueImport(payload ImportPayload) error {
 	body := mustMarshal(payload)
-	return c.inner.Enqueue(context.Background(), TaskTypeImport, body,
-		driver.WithQueue(ExportQueueName),
-	)
+	base := []driver.EnqueueOption{driver.WithQueue(ExportQueueName)}
+	base = append(base, c.retentionOpts(ExportQueueName)...)
+	return c.inner.Enqueue(context.Background(), TaskTypeImport, body, base...)
 }
 
 // EnqueueImportCustomEmojis puts an admin emoji-zip import task on the
 // export queue. Misskey 本家も同じ "dbQueue" (低優先) に積んでいる。
 func (c *Client) EnqueueImportCustomEmojis(payload ImportCustomEmojisPayload) error {
 	body := mustMarshal(payload)
-	return c.inner.Enqueue(context.Background(), TaskTypeImportCustomEmojis, body,
-		driver.WithQueue(ExportQueueName),
-	)
+	base := []driver.EnqueueOption{driver.WithQueue(ExportQueueName)}
+	base = append(base, c.retentionOpts(ExportQueueName)...)
+	return c.inner.Enqueue(context.Background(), TaskTypeImportCustomEmojis, body, base...)
 }
 
 // EnqueueInbox puts an inbound ActivityPub activity onto the inbox queue
@@ -279,18 +307,16 @@ func (c *Client) EnqueueInbox(ctx context.Context, payload InboxPayload) error {
 	if p.MaxAttempts > 0 {
 		base = append(base, driver.WithMaxRetry(p.MaxAttempts-1))
 	}
-	if p.KeepFailed > 0 {
-		base = append(base, driver.WithKeepFailed(p.KeepFailed))
-	}
+	base = append(base, c.retentionOpts(InboxQueueName)...)
 	return c.inner.Enqueue(ctx, TaskTypeInbox, body, base...)
 }
 
 // EnqueueWebPush puts a Web Push delivery task on the push queue.
 func (c *Client) EnqueueWebPush(ctx context.Context, payload WebPushPayload) error {
 	body := mustMarshal(payload)
-	return c.inner.Enqueue(ctx, TaskTypeWebPush, body,
-		driver.WithQueue(PushQueueName),
-	)
+	base := []driver.EnqueueOption{driver.WithQueue(PushQueueName)}
+	base = append(base, c.retentionOpts(PushQueueName)...)
+	return c.inner.Enqueue(ctx, TaskTypeWebPush, body, base...)
 }
 
 // EnqueueUserWebhook puts a user webhook delivery task on the webhook
@@ -298,38 +324,46 @@ func (c *Client) EnqueueWebPush(ctx context.Context, payload WebPushPayload) err
 // して扱うため実際のリトライ対象は 5xx とネットワークエラーに限られる)。
 func (c *Client) EnqueueUserWebhook(ctx context.Context, payload WebhookPayload) error {
 	body := mustMarshal(payload)
-	return c.inner.Enqueue(ctx, TaskTypeUserWebhook, body,
+	base := []driver.EnqueueOption{
 		driver.WithQueue(WebhookQueueName),
 		driver.WithMaxRetry(4),
-	)
+	}
+	base = append(base, c.retentionOpts(WebhookQueueName)...)
+	return c.inner.Enqueue(ctx, TaskTypeUserWebhook, body, base...)
 }
 
 // EnqueueSystemWebhook puts a system webhook delivery task on the webhook queue.
 func (c *Client) EnqueueSystemWebhook(ctx context.Context, payload WebhookPayload) error {
 	body := mustMarshal(payload)
-	return c.inner.Enqueue(ctx, TaskTypeSystemWebhook, body,
+	base := []driver.EnqueueOption{
 		driver.WithQueue(WebhookQueueName),
 		driver.WithMaxRetry(4),
-	)
+	}
+	base = append(base, c.retentionOpts(WebhookQueueName)...)
+	return c.inner.Enqueue(ctx, TaskTypeSystemWebhook, body, base...)
 }
 
 // EnqueueCleanRemoteNotes puts a remote notes cleaning task on the queue.
 // 重複排除のため UniqueFor を設定。
 func (c *Client) EnqueueCleanRemoteNotes() error {
-	return c.inner.Enqueue(context.Background(), TaskTypeCleanRemoteNotes, nil,
+	base := []driver.EnqueueOption{
 		driver.WithQueue(QueueName),
 		driver.WithMaxRetry(0),
-		driver.WithUnique(6*time.Hour),
-	)
+		driver.WithUnique(6 * time.Hour),
+	}
+	base = append(base, c.retentionOpts(QueueName)...)
+	return c.inner.Enqueue(context.Background(), TaskTypeCleanRemoteNotes, nil, base...)
 }
 
 // EnqueueReactionFlush puts a reaction flush task on the queue.
 func (c *Client) EnqueueReactionFlush() error {
-	return c.inner.Enqueue(context.Background(), TaskTypeReactionFlush, nil,
+	base := []driver.EnqueueOption{
 		driver.WithQueue(QueueName),
 		driver.WithMaxRetry(0),
-		driver.WithUnique(25*time.Second),
-	)
+		driver.WithUnique(25 * time.Second),
+	}
+	base = append(base, c.retentionOpts(QueueName)...)
+	return c.inner.Enqueue(context.Background(), TaskTypeReactionFlush, nil, base...)
 }
 
 // EnqueueDeleteAccount schedules a cascade deletion of the user's
@@ -338,11 +372,13 @@ func (c *Client) EnqueueReactionFlush() error {
 // still processing.
 func (c *Client) EnqueueDeleteAccount(payload DeleteAccountPayload) error {
 	body := mustMarshal(payload)
-	return c.inner.Enqueue(context.Background(), TaskTypeDeleteAccount, body,
+	base := []driver.EnqueueOption{
 		driver.WithQueue(QueueName),
 		driver.WithMaxRetry(2),
-		driver.WithUnique(24*time.Hour),
-	)
+		driver.WithUnique(24 * time.Hour),
+	}
+	base = append(base, c.retentionOpts(QueueName)...)
+	return c.inner.Enqueue(context.Background(), TaskTypeDeleteAccount, body, base...)
 }
 
 // EnqueueUnfollow schedules a single Unfollow job for the given pair.
@@ -352,10 +388,12 @@ func (c *Client) EnqueueDeleteAccount(payload DeleteAccountPayload) error {
 // AP delivery 失敗を吸収できる程度に設定。
 func (c *Client) EnqueueUnfollow(payload UnfollowPayload) error {
 	body := mustMarshal(payload)
-	return c.inner.Enqueue(context.Background(), TaskTypeUnfollow, body,
+	base := []driver.EnqueueOption{
 		driver.WithQueue(QueueName),
 		driver.WithMaxRetry(3),
-	)
+	}
+	base = append(base, c.retentionOpts(QueueName)...)
+	return c.inner.Enqueue(context.Background(), TaskTypeUnfollow, body, base...)
 }
 
 // Close releases the underlying client connection.

--- a/internal/queue/queue_keepfailed_test.go
+++ b/internal/queue/queue_keepfailed_test.go
@@ -3,6 +3,7 @@ package queue_test
 import (
 	"context"
 	"testing"
+	"time"
 
 	"github.com/shiroha-a/mk/internal/queue"
 	"github.com/shiroha-a/mk/internal/queue/driver"
@@ -86,4 +87,97 @@ func TestClient_EnqueueDeliver_PolicyZeroKeepFailedSkipped(t *testing.T) {
 
 	assert.False(t, rec.lastOpts.KeepFailedSet, "KeepFailedSet must NOT be set when policy KeepFailed=0")
 	assert.Equal(t, 0, rec.lastOpts.KeepFailed)
+}
+
+// TestClient_EnqueueDeliver_PolicyKeepCompletedApplied verifies that
+// Policy.KeepCompleted reaches the driver as driver.WithKeepCompleted(n)
+// (#1193, KeepFailed と対称)。
+func TestClient_EnqueueDeliver_PolicyKeepCompletedApplied(t *testing.T) {
+	rec := &recordingDriverClient{}
+	c := queue.NewClient(&stubDriver{client: rec})
+	defer func() { _ = c.Close() }()
+
+	c.SetPolicy(queue.QueueName, queue.Policy{
+		KeepCompleted:    30,
+		KeepCompletedAge: 7 * 24 * time.Hour,
+		KeepFailedAge:    7 * 24 * time.Hour,
+	})
+
+	require.NoError(t, c.EnqueueDeliver(queue.DeliverPayload{Inbox: "x", Body: []byte(`{}`)}))
+
+	assert.True(t, rec.lastOpts.KeepCompletedSet, "KeepCompletedSet must be propagated")
+	assert.Equal(t, 30, rec.lastOpts.KeepCompleted)
+	assert.Equal(t, 7*24*time.Hour, rec.lastOpts.KeepCompletedAge)
+	assert.Equal(t, 7*24*time.Hour, rec.lastOpts.KeepFailedAge)
+}
+
+// TestClient_EnqueueInbox_PolicyKeepCompletedApplied: 同様 inbox 経路。
+func TestClient_EnqueueInbox_PolicyKeepCompletedApplied(t *testing.T) {
+	rec := &recordingDriverClient{}
+	c := queue.NewClient(&stubDriver{client: rec})
+	defer func() { _ = c.Close() }()
+
+	c.SetPolicy(queue.InboxQueueName, queue.Policy{KeepCompleted: 30})
+
+	require.NoError(t, c.EnqueueInbox(context.Background(), queue.InboxPayload{Body: []byte(`{}`)}))
+
+	assert.True(t, rec.lastOpts.KeepCompletedSet)
+	assert.Equal(t, 30, rec.lastOpts.KeepCompleted)
+}
+
+// TestClient_EnqueueDeliver_PolicyZeroKeepCompletedSkipped: KeepCompleted=0
+// は emit しない (KeepFailed と同じ semantic、driver 側で unlimited 蓄積)。
+func TestClient_EnqueueDeliver_PolicyZeroKeepCompletedSkipped(t *testing.T) {
+	rec := &recordingDriverClient{}
+	c := queue.NewClient(&stubDriver{client: rec})
+	defer func() { _ = c.Close() }()
+
+	c.SetPolicy(queue.QueueName, queue.Policy{KeepCompleted: 0})
+
+	require.NoError(t, c.EnqueueDeliver(queue.DeliverPayload{Inbox: "x", Body: []byte(`{}`)}))
+
+	assert.False(t, rec.lastOpts.KeepCompletedSet, "KeepCompletedSet must NOT be set when policy KeepCompleted=0")
+}
+
+// TestClient_EnqueueExport_PolicyApplied: export queue (= TS の dbQueue
+// 相当) でも Policy が適用される (#1193 で applyClientPolicies が 5 queue
+// 全てに広がった)。
+func TestClient_EnqueueExport_PolicyApplied(t *testing.T) {
+	rec := &recordingDriverClient{}
+	c := queue.NewClient(&stubDriver{client: rec})
+	defer func() { _ = c.Close() }()
+
+	c.SetPolicy(queue.ExportQueueName, queue.Policy{
+		KeepCompleted:    30,
+		KeepCompletedAge: 7 * 24 * time.Hour,
+	})
+
+	require.NoError(t, c.EnqueueExport(queue.ExportPayload{UserID: "u", Type: "notes"}))
+
+	assert.Equal(t, 30, rec.lastOpts.KeepCompleted)
+	assert.Equal(t, 7*24*time.Hour, rec.lastOpts.KeepCompletedAge)
+}
+
+// TestClient_EnqueueWebPush_PolicyApplied: push queue でも適用される。
+func TestClient_EnqueueWebPush_PolicyApplied(t *testing.T) {
+	rec := &recordingDriverClient{}
+	c := queue.NewClient(&stubDriver{client: rec})
+	defer func() { _ = c.Close() }()
+
+	c.SetPolicy(queue.PushQueueName, queue.Policy{KeepCompleted: 30})
+
+	require.NoError(t, c.EnqueueWebPush(context.Background(), queue.WebPushPayload{}))
+	assert.Equal(t, 30, rec.lastOpts.KeepCompleted)
+}
+
+// TestClient_EnqueueUserWebhook_PolicyApplied: webhook queue でも適用。
+func TestClient_EnqueueUserWebhook_PolicyApplied(t *testing.T) {
+	rec := &recordingDriverClient{}
+	c := queue.NewClient(&stubDriver{client: rec})
+	defer func() { _ = c.Close() }()
+
+	c.SetPolicy(queue.WebhookQueueName, queue.Policy{KeepCompleted: 30})
+
+	require.NoError(t, c.EnqueueUserWebhook(context.Background(), queue.WebhookPayload{}))
+	assert.Equal(t, 30, rec.lastOpts.KeepCompleted)
 }

--- a/internal/server/queue_factory.go
+++ b/internal/server/queue_factory.go
@@ -103,19 +103,55 @@ func perQueueRatesFromConfig(cfg *config.Config) map[string]int {
 // 解除可能 (= 蓄積無制限の従来挙動)。
 const defaultKeepFailed = 1000
 
-// applyClientPolicies copies enqueue-side defaults (deliverJobMaxAttempts /
-// inboxJobMaxAttempts / deliverJobKeepFailed / inboxJobKeepFailed) onto the
-// queue.Client. Called once at server construction so EnqueueDeliver /
-// EnqueueInbox can pre-pend driver options when callers don't override.
+// defaultKeepCompleted は completed bucket retention の最大件数 default。
+// Misskey TS upstream の QueueService.ts が全 enqueue で `removeOnComplete:
+// {age: 7d, count: 30}` を指定しているのに合わせて 30 件に揃える。BullMQ
+// default の「無制限保持」が UDS 観測で実害 (inbox completed 15K+ 蓄積) を
+// 出していたためここで切る (#1193)。`<queue>JobKeepCompleted: 0` で
+// operator が明示解除可能 (= TS と挙動を意図的にずらしたい場合)。
+const defaultKeepCompleted = 30
+
+// defaultKeepCompletedAge / defaultKeepFailedAge は age-based retention の
+// default。BullMQ TS upstream と同じ 7 日。count 上限と組み合わせて
+// 「7 日 以内 かつ 最新 N 件」を保持する (BullMQ TS の object form 互換)。
+const (
+	defaultKeepCompletedAge = 7 * 24 * time.Hour
+	defaultKeepFailedAge    = 7 * 24 * time.Hour
+)
+
+// applyClientPolicies copies enqueue-side defaults onto the queue.Client.
+// Called once at server construction so EnqueueDeliver / EnqueueInbox can
+// pre-pend driver options when callers don't override.
+//
+// Policy 設定は deliver / inbox / export / push / webhook の application
+// queue 全てに対して適用する。Misskey TS upstream の QueueService.ts が
+// 全 enqueue helper で `removeOnComplete: {age: 7d, count: 30}` を指定して
+// いる規約に合わせるため (#1193)。maintenance queue は Scheduler.Register
+// 経由で mkq native の per-fire option を上流仕様で drop するため本 PR では
+// 対象外 (mkq upstream 拡張後に follow-up)。
 func applyClientPolicies(c *queue.Client, cfg *config.Config) {
-	c.SetPolicy(queue.QueueName, buildPolicy(cfg.DeliverJobMaxAttempts, cfg.DeliverJobKeepFailed))
-	c.SetPolicy(queue.InboxQueueName, buildPolicy(cfg.InboxJobMaxAttempts, cfg.InboxJobKeepFailed))
+	deliverPolicy := buildPolicy(cfg.DeliverJobMaxAttempts, cfg.DeliverJobKeepFailed, cfg.DeliverJobKeepCompleted)
+	inboxPolicy := buildPolicy(cfg.InboxJobMaxAttempts, cfg.InboxJobKeepFailed, cfg.InboxJobKeepCompleted)
+	c.SetPolicy(queue.QueueName, deliverPolicy)
+	c.SetPolicy(queue.InboxQueueName, inboxPolicy)
+	// export / push / webhook 用の YAML key は意図的に増やさない (TS と
+	// 同じく一律の default を踏ませれば十分)。tuning 用 hook が必要に
+	// なったら deliver/inbox と同じ pattern で *KeepCompleted / *KeepFailed
+	// を追加すれば対応可能。
+	c.SetPolicy(queue.ExportQueueName, buildPolicy(nil, nil, nil))
+	c.SetPolicy(queue.PushQueueName, buildPolicy(nil, nil, nil))
+	c.SetPolicy(queue.WebhookQueueName, buildPolicy(nil, nil, nil))
 }
 
 // buildPolicy assembles a queue.Policy from optional config pointers,
-// applying defaultKeepFailed when the operator hasn't specified a value.
-// MaxAttempts は未指定なら 0 = "driver default" のまま (= 既存挙動)。
-func buildPolicy(maxAttempts *int, keepFailed *int) queue.Policy {
+// applying default retention values when the operator hasn't specified
+// them. MaxAttempts は未指定なら 0 = "driver default" のまま (= 既存挙動)。
+//
+// KeepFailed / KeepCompleted は nil で「default 適用」、明示 0 で「retention
+// 無し (operator opt-out)」、明示 N で「N 件まで保持」の 3 状態を表す。
+// Age 値 (KeepCompletedAge / KeepFailedAge) は operator が tuning する用途が
+// 薄いため YAML key を増やさず TS と同じ 7d 固定で適用する。
+func buildPolicy(maxAttempts *int, keepFailed *int, keepCompleted *int) queue.Policy {
 	p := queue.Policy{}
 	if maxAttempts != nil && *maxAttempts > 0 {
 		p.MaxAttempts = *maxAttempts
@@ -125,5 +161,12 @@ func buildPolicy(maxAttempts *int, keepFailed *int) queue.Policy {
 	} else {
 		p.KeepFailed = defaultKeepFailed
 	}
+	if keepCompleted != nil {
+		p.KeepCompleted = *keepCompleted
+	} else {
+		p.KeepCompleted = defaultKeepCompleted
+	}
+	p.KeepCompletedAge = defaultKeepCompletedAge
+	p.KeepFailedAge = defaultKeepFailedAge
 	return p
 }

--- a/internal/server/queue_factory.go
+++ b/internal/server/queue_factory.go
@@ -130,17 +130,24 @@ const (
 // 経由で mkq native の per-fire option を上流仕様で drop するため本 PR では
 // 対象外 (mkq upstream 拡張後に follow-up)。
 func applyClientPolicies(c *queue.Client, cfg *config.Config) {
-	deliverPolicy := buildPolicy(cfg.DeliverJobMaxAttempts, cfg.DeliverJobKeepFailed, cfg.DeliverJobKeepCompleted)
-	inboxPolicy := buildPolicy(cfg.InboxJobMaxAttempts, cfg.InboxJobKeepFailed, cfg.InboxJobKeepCompleted)
-	c.SetPolicy(queue.QueueName, deliverPolicy)
-	c.SetPolicy(queue.InboxQueueName, inboxPolicy)
+	c.SetPolicy(queue.QueueName, buildPolicy(cfg.DeliverJobMaxAttempts, cfg.DeliverJobKeepFailed, cfg.DeliverJobKeepCompleted))
+	c.SetPolicy(queue.InboxQueueName, buildPolicy(cfg.InboxJobMaxAttempts, cfg.InboxJobKeepFailed, cfg.InboxJobKeepCompleted))
 	// export / push / webhook 用の YAML key は意図的に増やさない (TS と
 	// 同じく一律の default を踏ませれば十分)。tuning 用 hook が必要に
 	// なったら deliver/inbox と同じ pattern で *KeepCompleted / *KeepFailed
 	// を追加すれば対応可能。
-	c.SetPolicy(queue.ExportQueueName, buildPolicy(nil, nil, nil))
-	c.SetPolicy(queue.PushQueueName, buildPolicy(nil, nil, nil))
-	c.SetPolicy(queue.WebhookQueueName, buildPolicy(nil, nil, nil))
+	c.SetPolicy(queue.ExportQueueName, defaultPolicy())
+	c.SetPolicy(queue.PushQueueName, defaultPolicy())
+	c.SetPolicy(queue.WebhookQueueName, defaultPolicy())
+}
+
+// defaultPolicy returns the queue.Policy applied when no operator config
+// override exists for the queue. すべての retention default (KeepFailed /
+// KeepCompleted / KeepCompletedAge / KeepFailedAge) を含む。tuning hook
+// が無い queue (export / push / webhook) で applyClientPolicies が一律
+// 適用するために存在する。
+func defaultPolicy() queue.Policy {
+	return buildPolicy(nil, nil, nil)
 }
 
 // buildPolicy assembles a queue.Policy from optional config pointers,

--- a/internal/server/queue_factory_test.go
+++ b/internal/server/queue_factory_test.go
@@ -2,6 +2,7 @@ package server
 
 import (
 	"testing"
+	"time"
 
 	"github.com/shiroha-a/mk/internal/config"
 	"github.com/shiroha-a/mk/internal/queue"
@@ -79,30 +80,116 @@ func TestApplyClientPolicies_NoOpForZero(t *testing.T) {
 	})
 }
 
-// TestBuildPolicy validates the (maxAttempts, keepFailed) → Policy
-// transform end-to-end: unset → defaultKeepFailed (= 1000)、明示 0 →
-// 0 (= operator opt-out, unlimited 蓄積)、明示 N → N (#1184)。
+// TestBuildPolicy validates the (maxAttempts, keepFailed, keepCompleted)
+// → Policy transform end-to-end: unset → defaults (= 1000 / 30 / 7d / 7d)、
+// 明示 0 → 0 (= operator opt-out, unlimited 蓄積)、明示 N → N。Age 値は
+// YAML key を持たないので常に固定 7d (#1184 / #1193)。
 func TestBuildPolicy(t *testing.T) {
-	tests := []struct {
-		name        string
-		maxAttempts *int
-		keepFailed  *int
-		want        queue.Policy
+	defaultAges := struct {
+		completed time.Duration
+		failed    time.Duration
 	}{
-		{"both unset", nil, nil, queue.Policy{KeepFailed: defaultKeepFailed}},
-		{"only maxAttempts", intp(8), nil, queue.Policy{MaxAttempts: 8, KeepFailed: defaultKeepFailed}},
-		{"only keepFailed explicit 500", nil, intp(500), queue.Policy{KeepFailed: 500}},
-		{"only keepFailed explicit 0 (operator opt-out)", nil, intp(0), queue.Policy{KeepFailed: 0}},
-		{"both explicit", intp(4), intp(2000), queue.Policy{MaxAttempts: 4, KeepFailed: 2000}},
+		completed: defaultKeepCompletedAge,
+		failed:    defaultKeepFailedAge,
+	}
+	tests := []struct {
+		name          string
+		maxAttempts   *int
+		keepFailed    *int
+		keepCompleted *int
+		want          queue.Policy
+	}{
+		{
+			"all unset",
+			nil, nil, nil,
+			queue.Policy{
+				KeepFailed:       defaultKeepFailed,
+				KeepCompleted:    defaultKeepCompleted,
+				KeepCompletedAge: defaultAges.completed,
+				KeepFailedAge:    defaultAges.failed,
+			},
+		},
+		{
+			"only maxAttempts",
+			intp(8), nil, nil,
+			queue.Policy{
+				MaxAttempts:      8,
+				KeepFailed:       defaultKeepFailed,
+				KeepCompleted:    defaultKeepCompleted,
+				KeepCompletedAge: defaultAges.completed,
+				KeepFailedAge:    defaultAges.failed,
+			},
+		},
+		{
+			"only keepFailed explicit 500",
+			nil, intp(500), nil,
+			queue.Policy{
+				KeepFailed:       500,
+				KeepCompleted:    defaultKeepCompleted,
+				KeepCompletedAge: defaultAges.completed,
+				KeepFailedAge:    defaultAges.failed,
+			},
+		},
+		{
+			"only keepFailed explicit 0 (operator opt-out)",
+			nil, intp(0), nil,
+			queue.Policy{
+				KeepFailed:       0,
+				KeepCompleted:    defaultKeepCompleted,
+				KeepCompletedAge: defaultAges.completed,
+				KeepFailedAge:    defaultAges.failed,
+			},
+		},
+		{
+			"only keepCompleted explicit 100",
+			nil, nil, intp(100),
+			queue.Policy{
+				KeepFailed:       defaultKeepFailed,
+				KeepCompleted:    100,
+				KeepCompletedAge: defaultAges.completed,
+				KeepFailedAge:    defaultAges.failed,
+			},
+		},
+		{
+			"only keepCompleted explicit 0 (operator opt-out)",
+			nil, nil, intp(0),
+			queue.Policy{
+				KeepFailed:       defaultKeepFailed,
+				KeepCompleted:    0,
+				KeepCompletedAge: defaultAges.completed,
+				KeepFailedAge:    defaultAges.failed,
+			},
+		},
+		{
+			"all explicit",
+			intp(4), intp(2000), intp(50),
+			queue.Policy{
+				MaxAttempts:      4,
+				KeepFailed:       2000,
+				KeepCompleted:    50,
+				KeepCompletedAge: defaultAges.completed,
+				KeepFailedAge:    defaultAges.failed,
+			},
+		},
 		// maxAttempts<=0 は driver default に倒す既存挙動を維持。
 		// `MaxAttempts: 0` は「Policy で上書きしない (= driver の default
 		// retry を使う)」を意味する zero-value。明示 0 を受け取っても
 		// Policy には流さないので 0 のまま残る。
-		{"maxAttempts zero leaves driver default", intp(0), intp(500), queue.Policy{MaxAttempts: 0, KeepFailed: 500}},
+		{
+			"maxAttempts zero leaves driver default",
+			intp(0), intp(500), intp(15),
+			queue.Policy{
+				MaxAttempts:      0,
+				KeepFailed:       500,
+				KeepCompleted:    15,
+				KeepCompletedAge: defaultAges.completed,
+				KeepFailedAge:    defaultAges.failed,
+			},
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := buildPolicy(tt.maxAttempts, tt.keepFailed)
+			got := buildPolicy(tt.maxAttempts, tt.keepFailed, tt.keepCompleted)
 			assert.Equal(t, tt.want, got)
 		})
 	}

--- a/internal/server/queue_factory_test.go
+++ b/internal/server/queue_factory_test.go
@@ -126,10 +126,8 @@ func TestApplyClientPolicies_AllFiveQueues(t *testing.T) {
 	applyClientPolicies(c, &config.Config{})
 
 	cases := []struct {
-		name   string
-		enq    func() error
-		queue  string
-		fields string
+		name string
+		enq  func() error
 	}{
 		{
 			name: "deliver",

--- a/internal/server/queue_factory_test.go
+++ b/internal/server/queue_factory_test.go
@@ -1,11 +1,13 @@
 package server
 
 import (
+	"context"
 	"testing"
 	"time"
 
 	"github.com/shiroha-a/mk/internal/config"
 	"github.com/shiroha-a/mk/internal/queue"
+	"github.com/shiroha-a/mk/internal/queue/driver"
 	"github.com/shiroha-a/mk/internal/queue/driver/asynqdriver"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -78,6 +80,124 @@ func TestApplyClientPolicies_NoOpForZero(t *testing.T) {
 		applyClientPolicies(c, &config.Config{})
 		applyClientPolicies(c, &config.Config{DeliverJobMaxAttempts: intp(0)})
 	})
+}
+
+// recordingDriverClient is a minimal driver.Client implementation that
+// captures the last Enqueue call's options. server _test 内に持つ用途は
+// applyClientPolicies が 5 queue 全てに Policy を伝搬するのを enqueue
+// 経由で観測すること (queue.Client.policyFor が unexported のため)。
+type recordingDriverClient struct {
+	lastTaskType string
+	lastOpts     driver.EnqueueOptions
+}
+
+func (r *recordingDriverClient) Enqueue(_ context.Context, taskType string, _ []byte, opts ...driver.EnqueueOption) error {
+	r.lastTaskType = taskType
+	r.lastOpts = driver.ApplyEnqueueOptions(opts)
+	return nil
+}
+
+func (r *recordingDriverClient) Close() error { return nil }
+
+// stubDriver wraps just enough of driver.Driver to satisfy queue.NewClient.
+type stubDriver struct {
+	client driver.Client
+}
+
+func (s *stubDriver) Client() driver.Client        { return s.client }
+func (s *stubDriver) Inspector() driver.Inspector  { return nil }
+func (s *stubDriver) Server() driver.Server        { return nil }
+func (s *stubDriver) Scheduler() driver.Scheduler  { return nil }
+func (s *stubDriver) Close() error                 { return nil }
+func (s *stubDriver) WorkerCount(_ string) int     { return 0 }
+func (s *stubDriver) Resize(_ string, _ int) error { return driver.ErrResizeNotSupported }
+
+// TestApplyClientPolicies_AllFiveQueues verifies that applyClientPolicies
+// propagates retention defaults onto all five application queues (deliver /
+// inbox / export / push / webhook) — not just deliver / inbox like before
+// #1193。各 queue で enqueue 後に recordingDriverClient が見る driver
+// options が default の `{age: 7d, count: 30}` / `{age: 7d, count: 1000}`
+// を含むことを assert する。
+func TestApplyClientPolicies_AllFiveQueues(t *testing.T) {
+	rec := &recordingDriverClient{}
+	c := queue.NewClient(&stubDriver{client: rec})
+	defer func() { _ = c.Close() }()
+
+	applyClientPolicies(c, &config.Config{})
+
+	cases := []struct {
+		name   string
+		enq    func() error
+		queue  string
+		fields string
+	}{
+		{
+			name: "deliver",
+			enq: func() error {
+				return c.EnqueueDeliver(queue.DeliverPayload{Inbox: "x", Body: []byte(`{}`)})
+			},
+		},
+		{
+			name: "inbox",
+			enq: func() error {
+				return c.EnqueueInbox(context.Background(), queue.InboxPayload{Body: []byte(`{}`)})
+			},
+		},
+		{
+			name: "export",
+			enq: func() error {
+				return c.EnqueueExport(queue.ExportPayload{UserID: "u", Type: "notes"})
+			},
+		},
+		{
+			name: "push",
+			enq: func() error {
+				return c.EnqueueWebPush(context.Background(), queue.WebPushPayload{})
+			},
+		},
+		{
+			name: "webhook",
+			enq: func() error {
+				return c.EnqueueUserWebhook(context.Background(), queue.WebhookPayload{})
+			},
+		},
+	}
+	for _, tt := range cases {
+		t.Run(tt.name, func(t *testing.T) {
+			require.NoError(t, tt.enq())
+			assert.Equal(t, defaultKeepCompleted, rec.lastOpts.KeepCompleted, "KeepCompleted default propagated")
+			assert.True(t, rec.lastOpts.KeepCompletedSet, "KeepCompletedSet must be propagated")
+			assert.Equal(t, defaultKeepFailed, rec.lastOpts.KeepFailed)
+			assert.True(t, rec.lastOpts.KeepFailedSet)
+			assert.Equal(t, defaultKeepCompletedAge, rec.lastOpts.KeepCompletedAge)
+			assert.Equal(t, defaultKeepFailedAge, rec.lastOpts.KeepFailedAge)
+		})
+	}
+}
+
+// TestApplyClientPolicies_OperatorOptOut: deliverJobKeepCompleted=0 を
+// operator が明示すると completed retention が 0 (= unlimited 蓄積に
+// opt-out) として伝わり、driver opt 側で WithKeepCompleted が emit
+// されなくなることを pin (#1193 review feedback)。
+func TestApplyClientPolicies_OperatorOptOut(t *testing.T) {
+	rec := &recordingDriverClient{}
+	c := queue.NewClient(&stubDriver{client: rec})
+	defer func() { _ = c.Close() }()
+
+	applyClientPolicies(c, &config.Config{DeliverJobKeepCompleted: intp(0)})
+
+	require.NoError(t, c.EnqueueDeliver(queue.DeliverPayload{Inbox: "x", Body: []byte(`{}`)}))
+
+	assert.False(t, rec.lastOpts.KeepCompletedSet, "operator opt-out must NOT set KeepCompletedSet")
+	assert.Equal(t, 0, rec.lastOpts.KeepCompleted)
+	// failed 側は default が残るはず。
+	assert.Equal(t, defaultKeepFailed, rec.lastOpts.KeepFailed)
+}
+
+// TestDefaultPolicy: defaultPolicy() helper が buildPolicy(nil, nil, nil)
+// と同値であることを assert (refactoring 後の equivalence pin)。
+func TestDefaultPolicy(t *testing.T) {
+	assert.Equal(t, buildPolicy(nil, nil, nil), defaultPolicy())
 }
 
 // TestBuildPolicy validates the (maxAttempts, keepFailed, keepCompleted)


### PR DESCRIPTION
## Summary

- #1184 で配線した `removeOnFail` (KeepFailed) と対称な `removeOnComplete` (KeepCompleted) を BullMQ 仕様 (`{age, count}`) で全 enqueue 経路に配線
- driver-neutral / mkqdriver / asynqdriver / Policy / queue.Client / queue_factory / config の 7 layer を通して TS upstream `QueueService.ts` の規範 (`{age: 7d, count: 30}` for completed / `{age: 7d, count: 100}` for failed) に揃える
- 対象: deliver / inbox / export / push / webhook の 5 queue。Maintenance queue (cron 起動の chart tick 等) は mkq Scheduler の上流仕様で per-fire option drop のため未対応 (follow-up issue で扱う)

## 背景

UDS 本番で observe したところ valkey が `bull:inbox:completed` zset に 15,247 members、`bull:deliver:completed` に 2,154 members を蓄積していた。mkq driver は BullMQ 互換の `bull:` prefix を default で使うため、BullMQ default 動作 (完了履歴の無制限保持) の影響をそのまま受けて永続的に redis memory を蝕んでいた。

Misskey TS upstream は `packages/backend/src/core/QueueService.ts` の全 enqueue helper で `removeOnComplete: {age: 3600*24*7, count: 30}` を指定して防いでいる。mk-go も同じ規範に揃える。

## 主な変更点

### driver-neutral 層 (`internal/queue/driver/option.go`)

- `WithKeepCompleted(n int)` — count-based completed retention
- `WithKeepCompletedAge(age time.Duration)` — age-based completed retention
- `WithKeepFailedAge(age time.Duration)` — age-based failed retention (#1184 で count のみ配線、age を補完)
- `EnqueueOptions` 構造体に `KeepCompleted` / `KeepCompletedSet` / `KeepCompletedAge` / `KeepFailedAge` を追加 (`KeepFailed` と同じ Set sentinel pattern)

### mkqdriver 翻訳 (`internal/queue/driver/mkqdriver/option.go`)

- `WithKeepCompleted` → `mkq.WithKeepCompleted(n)` (n>0 のみ emit)
- `WithKeepCompletedAge` → `mkq.WithKeepCompletedAge(age)` (age>0 のみ)
- `WithKeepFailedAge` → `mkq.WithKeepFailedAge(age)` (age>0 のみ)
- 0-skip semantic は `WithKeepFailed` と同じ (mkq native `WithKeepCompleted(0)` は「即時削除」で driver-neutral 意味と真逆のため translation 層で 0 を skip)

### asynqdriver

asynq は per-job 相当 API を持たないので silent no-op。テストで「count + age 4 種すべて silent」を pin。

### Policy / queue.Client (`internal/queue/policy.go`, `queue.go`)

- `Policy` に `KeepCompleted` / `KeepCompletedAge` / `KeepFailedAge` を追加
- `Client.retentionOpts(queueName)` helper を新設し、全 13 enqueue helper (`EnqueueDeliver` / `EnqueuePostScheduledNote` / `EnqueueExport` / `EnqueueImport` / `EnqueueImportCustomEmojis` / `EnqueueInbox` / `EnqueueWebPush` / `EnqueueUserWebhook` / `EnqueueSystemWebhook` / `EnqueueCleanRemoteNotes` / `EnqueueReactionFlush` / `EnqueueDeleteAccount` / `EnqueueUnfollow`) に統一的に prepend

### config (`internal/config/config.go`)

- `deliverJobKeepCompleted` / `inboxJobKeepCompleted` YAML key を追加 (count 上限を operator が tuning できるように)
- age 値は TS と同じく 7d 固定 (operator が tuning する用途が薄いため YAML key 不要)

### queue_factory (`internal/server/queue_factory.go`)

- `defaultKeepCompleted = 30` (TS と同値)
- `defaultKeepCompletedAge = 7 * 24 * time.Hour`
- `defaultKeepFailedAge = 7 * 24 * time.Hour` (#1184 で age 側が未配線だった分)
- `applyClientPolicies` を `deliver` / `inbox` 2 queue から `deliver` / `inbox` / `export` / `push` / `webhook` の 5 queue に拡大
- 既存 `defaultKeepFailed = 1000` は据え置き (#1184 で TS の 100 から意図的にずらしている)

### scope 外 (follow-up)

Maintenance queue (`chart:tick` / `chart:resync` / `chart:clean` / `instanceRefresh` / `retentionAggregate`) は `Scheduler.Register` 経由で mkq native の per-fire option を上流仕様で drop するため、本 PR では retention 配線していない。mkq upstream 拡張 (queue-level retention default の API 化) 後の follow-up issue で扱う。

## テスト

新規 + 既存テスト 124 packages all green:

```
make fmt && make lint && make test
```

per-package coverage (CI threshold 90% で gated):

```
internal/queue/driver           100.0%
internal/queue/driver/mkqdriver  90.6%
internal/queue/driver/asynqdriver 92.0%
internal/queue                   92.2%
internal/config                  96.0%
internal/server (queue_factory.go の buildPolicy / applyClientPolicies は個別 100%)
```

追加テスト:
- `driver/driver_test.go`: `WithKeepCompleted` / `WithKeepCompletedAge` / `WithKeepFailedAge` の解析 + 0 sentinel の Set 検出
- `driver/mkqdriver/mkqdriver_test.go`: 0-skip / 正値 emit / age / 4 retention 全部設定時の option 数 pin
- `driver/asynqdriver/asynqdriver_test.go`: silent no-op (count + age)
- `queue/queue_keepfailed_test.go`: 全 5 application queue (deliver / inbox / export / push / webhook) で Policy → driver options propagation
- `server/queue_factory_test.go`: `buildPolicy` を 8 ケース (defaults / 明示 0 / N 件 / 組合せ) に拡張

## Ops note (PR 外作業)

既存 valkey 上の `bull:{inbox,deliver,export,push,webhook}:completed` zset を 1 度だけ手動 trim 推奨:

```
redis-cli ZREMRANGEBYRANK bull:inbox:completed   0 -31
redis-cli ZREMRANGEBYRANK bull:deliver:completed 0 -31
```

配線後の enqueue から自動 prune が効くので恒久対応は本 PR で完結。

## Closes

Closes #1193