### PR TITLE
feat(timeline): mention escape hatch を home/hybrid/local TL reply gate に追加 (#1195)

### DIFF
--- a/internal/core/timeline/fanout_hook.go
+++ b/internal/core/timeline/fanout_hook.go
@@ -274,7 +274,14 @@ func (h *FanoutHook) fanoutToFollowersAndStream(ctx context.Context, authorID st
 		}
 		for _, f := range rows {
 			isReplyToFollower := isReply && n.ReplyUserID != nil && *n.ReplyUserID == f.FollowerID
-			if isReply && !isSelfThread && !isReplyToFollower && !f.WithReplies {
+			// follower が note.mentions に含まれているなら withReplies=false の
+			// reply filter を escape する (mk-go 独自仕様 / 上流 TS は持たない
+			// escape hatch、#1195)。「他人 A → 他人 B reply」で本文に viewer
+			// (= follower) への mention が含まれているとき、author の意図とし
+			// て viewer に届けたいはずなので follower の withReplies 設定で隠
+			// さない。
+			isMentioned := isReply && containsMention(n.Mentions, f.FollowerID)
+			if isReply && !isSelfThread && !isReplyToFollower && !isMentioned && !f.WithReplies {
 				continue
 			}
 			// followers-only reply: reply target を follow していない follower
@@ -396,4 +403,19 @@ func (h *FanoutHook) removeFromUserLists(ctx context.Context, authorID, noteID s
 	for _, listID := range listIDs {
 		h.removeBestEffort(ctx, UserListTimelineName(listID), noteID)
 	}
+}
+
+// containsMention reports whether `mentions` (= model.Note.Mentions, a list of
+// user IDs) includes `userID`. typical mention 数は < 10 なので map 化せず
+// 線形探索で十分。fanout reply gate の mention escape hatch (#1195) で使う。
+func containsMention(mentions []string, userID string) bool {
+	if userID == "" {
+		return false
+	}
+	for _, m := range mentions {
+		if m == userID {
+			return true
+		}
+	}
+	return false
 }

--- a/internal/core/timeline/fanout_hook.go
+++ b/internal/core/timeline/fanout_hook.go
@@ -3,6 +3,7 @@ package timeline
 import (
 	"context"
 	"log/slog"
+	"slices"
 
 	"github.com/shiroha-a/mk/internal/model"
 	"github.com/shiroha-a/mk/internal/repository"
@@ -280,7 +281,7 @@ func (h *FanoutHook) fanoutToFollowersAndStream(ctx context.Context, authorID st
 			// (= follower) への mention が含まれているとき、author の意図とし
 			// て viewer に届けたいはずなので follower の withReplies 設定で隠
 			// さない。
-			isMentioned := isReply && containsMention(n.Mentions, f.FollowerID)
+			isMentioned := isReply && slices.Contains(n.Mentions, f.FollowerID)
 			if isReply && !isSelfThread && !isReplyToFollower && !isMentioned && !f.WithReplies {
 				continue
 			}
@@ -403,19 +404,4 @@ func (h *FanoutHook) removeFromUserLists(ctx context.Context, authorID, noteID s
 	for _, listID := range listIDs {
 		h.removeBestEffort(ctx, UserListTimelineName(listID), noteID)
 	}
-}
-
-// containsMention reports whether `mentions` (= model.Note.Mentions, a list of
-// user IDs) includes `userID`. typical mention 数は < 10 なので map 化せず
-// 線形探索で十分。fanout reply gate の mention escape hatch (#1195) で使う。
-func containsMention(mentions []string, userID string) bool {
-	if userID == "" {
-		return false
-	}
-	for _, m := range mentions {
-		if m == userID {
-			return true
-		}
-	}
-	return false
 }

--- a/internal/core/timeline/fanout_hook_test.go
+++ b/internal/core/timeline/fanout_hook_test.go
@@ -227,6 +227,47 @@ func TestFanoutHook_ReplyToFollowerIsPushedRegardlessOfWithReplies(t *testing.T)
 	assert.Empty(t, out, "follower2 (= unrelated) should not receive reply when WithReplies=false")
 }
 
+// TestFanoutHook_MentionedFollowerEscapesReplyFilter guards #1195: 他人 A
+// → 他人 B reply で本文に follower C への mention が含まれているとき、
+// C は withReplies=false でも home TL に push される (= mk-go 独自 escape
+// hatch、upstream Misskey TS は持たない意図的 deviation)。
+//
+// scenario: author が follower1 / follower2 を持ち、follower1 / follower2
+// 共に withReplies=false。author が `replyTargetUser` 宛 reply を作り、
+// note.Mentions に follower1 を含める。
+//   - follower1 は mentioned → push (mention escape hatch)
+//   - follower2 は mentioned でも replyToMe でも selfThread でもない →
+//     既存 reply gate で drop
+func TestFanoutHook_MentionedFollowerEscapesReplyFilter(t *testing.T) {
+	h, fanout, following := newTestHook(t)
+	ctx := context.Background()
+	following.Followings["f1"] = &model.Following{ID: "f1", FollowerID: "follower1", FolloweeID: "author", WithReplies: false}
+	following.Followings["f2"] = &model.Following{ID: "f2", FollowerID: "follower2", FolloweeID: "author", WithReplies: false}
+
+	noteID := idGen.Generate(time.Now())
+	replyID := "reply-target"
+	otherUser := "other-user"
+	n := &model.Note{
+		ID:          noteID,
+		UserID:      "author",
+		Visibility:  model.NoteVisibilityPublic,
+		ReplyID:     &replyID,
+		ReplyUserID: &otherUser, // 他人宛 reply
+		Mentions:    []string{"follower1"},
+	}
+	h.OnNoteCreated(n, &model.User{ID: "author"})
+
+	// follower1 は mention されているので withReplies=false でも push される
+	out, err := fanout.Get(ctx, HomeTimelineName("follower1"), "", "", 10)
+	require.NoError(t, err)
+	assert.Equal(t, []string{noteID}, out, "mentioned follower1 should receive reply regardless of WithReplies")
+
+	// follower2 は mention されていないので default reply gate で drop
+	out, err = fanout.Get(ctx, HomeTimelineName("follower2"), "", "", 10)
+	require.NoError(t, err)
+	assert.Empty(t, out, "non-mentioned follower2 should NOT receive reply when WithReplies=false")
+}
+
 // TestFanoutHook_FollowersOnlyReply_DropsFollowersNotFollowingReplyTarget
 // guards #1152: reply 対象 note の `visibility=followers` の場合、reply
 // target を follow していない follower は drop される (= stream filter

--- a/internal/core/timeline/fanout_hook_test.go
+++ b/internal/core/timeline/fanout_hook_test.go
@@ -351,6 +351,50 @@ func TestFanoutHook_FollowersOnlyReply_ReplyToFollowerEscapeHatch(t *testing.T) 
 	assert.Equal(t, []string{noteID}, out, "follower1 (= reply target 本人) は followers-only gate を escape")
 }
 
+// TestFanoutHook_MentionEscapeDoesNotBypassFollowersVisibilityGate guards
+// #1195 の scope boundary: mention escape hatch は basic withReplies gate のみ
+// を pass させ、followers-visibility privacy gate (= reply target を follow
+// していない follower への reply 本文露出防止) は引き続き drop する。stream
+// 側で同 scenario を `TestReplyShouldEmit_MentionEscapeDoesNotOverrideFollowersVisibility`
+// で pin 済み、fanout 側もここで同 symmetry を pin して privacy boundary が
+// 将来 escape に飲み込まれないようにする。
+//
+// scenario: A が `replyTargetUser` (visibility=followers) に reply、本文に
+// follower1 を mention。follower1 は author を withReplies=true で follow し
+// ているが replyTargetUser は follow していない。
+//   - mention されていても followers-visibility gate は通らないので drop。
+func TestFanoutHook_MentionEscapeDoesNotBypassFollowersVisibilityGate(t *testing.T) {
+	h, fanout, following := newTestHook(t)
+	ctx := context.Background()
+	following.Followings["f1"] = &model.Following{ID: "f1", FollowerID: "follower1", FolloweeID: "author", WithReplies: true}
+	// follower1 は replyTargetUser を follow していない (= followers-only gate
+	// が effective)。
+
+	noteID := idGen.Generate(time.Now())
+	replyTargetID := "reply-target-note"
+	replyTargetUser := "replyTargetUser"
+	n := &model.Note{
+		ID:          noteID,
+		UserID:      "author",
+		Visibility:  model.NoteVisibilityPublic,
+		ReplyID:     &replyTargetID,
+		ReplyUserID: &replyTargetUser,
+		Mentions:    []string{"follower1"}, // mention されていても escape は basic gate のみ
+		Reply: &model.Note{
+			ID:         replyTargetID,
+			UserID:     replyTargetUser,
+			Visibility: model.NoteVisibilityFollowers,
+		},
+	}
+	h.OnNoteCreated(n, &model.User{ID: "author"})
+
+	// follower1 は mention されているが replyTargetUser を follow していない
+	// ので followers-visibility gate で drop される (privacy boundary 維持)。
+	out, err := fanout.Get(ctx, HomeTimelineName("follower1"), "", "", 10)
+	require.NoError(t, err)
+	assert.Empty(t, out, "mentioned follower should still be dropped by followers-visibility gate (#1195 scope boundary)")
+}
+
 // 通常 note (reply 無し) は WithReplies 設定に関わらず全 follower に push される。
 func TestFanoutHook_NonReplyFanoutsToAllFollowers(t *testing.T) {
 	h, fanout, following := newTestHook(t)

--- a/internal/stream/channels/note_filter.go
+++ b/internal/stream/channels/note_filter.go
@@ -2,6 +2,7 @@ package channels
 
 import (
 	"encoding/json"
+	"slices"
 
 	"github.com/shiroha-a/mk/internal/core/wordmute"
 	"github.com/shiroha-a/mk/internal/model"
@@ -64,6 +65,10 @@ type replyMeta struct {
 // notePayload is the minimal structure needed for filtering decisions.
 // hardMutedWords (#787) も同 struct で見るので user / cw を含める。
 // #1063 で reply 関連を replyMeta 経由で取り込み、reply gate で参照する。
+// Mentions は #1195 で追加。reply gate の mention escape hatch で「viewer
+// が note.mentions に含まれていれば withReplies 設定に関係なく pass」を
+// 判定するのに使う。NoteEntityService.pack は packed note に `mentions:
+// string[]` を出力するので JSON tag で拾える。
 type notePayload struct {
 	UserID   string     `json:"userId"`
 	Text     *string    `json:"text"`
@@ -71,6 +76,7 @@ type notePayload struct {
 	RenoteID *string    `json:"renoteId"`
 	ReplyID  *string    `json:"replyId"`
 	FileIDs  []string   `json:"fileIds"`
+	Mentions []string   `json:"mentions"`
 	Reply    *replyMeta `json:"reply,omitempty"`
 }
 
@@ -208,6 +214,11 @@ func replyShouldEmit(payload []byte, viewerID string, snap map[string]bool, para
 
 	replyToMe := viewerID != "" && note.Reply.UserID == viewerID
 	selfThread := note.Reply.UserID == note.UserID
+	// mk-go 独自 escape hatch (#1195): viewer が note.mentions に含まれて
+	// いれば、withReplies / followee.withReplies の設定に関係なく reply gate を
+	// pass する。upstream Misskey TS は home/hybrid/local channel いずれもこの
+	// escape を持たないので意図的 deviation。
+	isMentioned := viewerID != "" && slices.Contains(note.Mentions, viewerID)
 
 	var followeeWithReplies bool
 	if snap != nil {
@@ -232,15 +243,16 @@ func replyShouldEmit(payload []byte, viewerID string, snap map[string]bool, para
 			}
 			return true
 		}
-		// 残り 2 escape hatch (replyToMe / selfThread)。isMe は上で抜けている。
-		return replyToMe || selfThread
+		// 残り 3 escape hatch (replyToMe / selfThread / isMentioned)。
+		// isMe は上で抜けている。isMentioned は mk-go 独自 (#1195)。
+		return replyToMe || selfThread || isMentioned
 
 	case replyGateLocal:
 		// local-timeline は anonymous で reply gate 不要、authenticated 時のみ
 		// `!this.withReplies && !following[note.userId].withReplies` → 3 escape
-		// hatch のみで pass。
+		// hatch + isMentioned で pass。isMentioned は mk-go 独自 (#1195)。
 		if !followeeWithReplies && !paramWithReplies {
-			return replyToMe || selfThread
+			return replyToMe || selfThread || isMentioned
 		}
 		return true
 	}

--- a/internal/stream/channels/note_filter_test.go
+++ b/internal/stream/channels/note_filter_test.go
@@ -195,19 +195,27 @@ func TestReplyShouldEmit_MentionedViewerEscapesReplyFilter(t *testing.T) {
 
 // TestReplyShouldEmit_MentionEscapeRequiresAuthenticatedViewer: anonymous
 // viewer (= viewerID="") は note.mentions に空文字 ID が混入しても escape
-// しない (空文字 viewer に対する誤誘発防止)。
+// しない (空文字 viewer に対する誤誘発防止)。全 reply gate mode で対称に
+// pin する: home は snapshot 経由の default drop、local/hybrid は anonymous
+// 早期 return での pass-through、いずれも mention escape が誤発火しないこと
+// を確認する。
 func TestReplyShouldEmit_MentionEscapeRequiresAuthenticatedViewer(t *testing.T) {
 	// mentions に "" が含まれる悪意ある / 破損 payload。
 	payload := []byte(`{"userId":"author","replyId":"p1","mentions":[""],"reply":{"userId":"target","visibility":"public"}}`)
-	// home / hybrid は anonymous で snap=nil なので default path、snap が
-	// あっても anonymous viewer は mention escape を発火させない。
-	// local / hybrid は anonymous で別 early-return path に乗るので mention
-	// escape の影響を受けない (TestReplyShouldEmit_LocalAnonymousPassesAllReplies
-	// 等で別途 pin)。ここでは home の anonymous (= snapshot 経由でも drop)
-	// path で escape が発火しないことを確認。
 	snap := map[string]bool{"author": false}
+
+	// home: anonymous + snapshot 有りでも default drop path に乗る。mention
+	// escape は viewerID 空で発火しないので drop が維持される。
 	assert.False(t, replyShouldEmit(payload, "", snap, false, replyGateHome),
 		"home: anonymous viewer must not be escaped by empty-string mention")
+
+	// local / hybrid: anonymous は anyway pass-through (`viewerID == ""` の
+	// 早期 return)。mention escape の有無に関係なく true を返す挙動が、
+	// 空文字 mention の混入で乱れないことを pin。
+	assert.True(t, replyShouldEmit(payload, "", nil, false, replyGateLocal),
+		"local: anonymous viewer pass-through must not depend on mention escape")
+	assert.True(t, replyShouldEmit(payload, "", nil, false, replyGateHybrid),
+		"hybrid: anonymous viewer pass-through must not depend on mention escape")
 }
 
 // TestReplyShouldEmit_MentionEscapeRespectsFollowersVisibility: mention

--- a/internal/stream/channels/note_filter_test.go
+++ b/internal/stream/channels/note_filter_test.go
@@ -172,6 +172,59 @@ func TestReplyShouldEmit_HybridConnectParamWithRepliesPasses(t *testing.T) {
 	assert.True(t, replyShouldEmit(payload, "viewer", nil, true, replyGateHybrid))
 }
 
+// TestReplyShouldEmit_MentionedViewerEscapesReplyFilter guards #1195:
+// viewer が note.mentions に含まれている場合、3 default escape hatch に
+// 該当しなくても reply gate を pass する (mk-go 独自 escape、上流 TS は
+// この escape を意図的に持たない)。
+func TestReplyShouldEmit_MentionedViewerEscapesReplyFilter(t *testing.T) {
+	// 他人 → 他人 reply (isMe / replyToMe / selfThread どれも false) で、
+	// viewer が note.mentions に含まれる payload。
+	payload := []byte(`{"userId":"author","replyId":"p1","mentions":["viewer"],"reply":{"userId":"target","visibility":"public"}}`)
+
+	// snapshot 空 (= author を follow していても withReplies=false)。upstream TS
+	// 互換 path なら drop されるが、mention escape で home / hybrid / local
+	// すべての mode で pass する。
+	snap := map[string]bool{"author": false}
+	assert.True(t, replyShouldEmit(payload, "viewer", snap, false, replyGateHome),
+		"home: mentioned viewer should bypass reply gate")
+	assert.True(t, replyShouldEmit(payload, "viewer", snap, false, replyGateHybrid),
+		"hybrid: mentioned viewer should bypass reply gate")
+	assert.True(t, replyShouldEmit(payload, "viewer", snap, false, replyGateLocal),
+		"local: mentioned viewer should bypass reply gate")
+}
+
+// TestReplyShouldEmit_MentionEscapeRequiresAuthenticatedViewer: anonymous
+// viewer (= viewerID="") は note.mentions に空文字 ID が混入しても escape
+// しない (空文字 viewer に対する誤誘発防止)。
+func TestReplyShouldEmit_MentionEscapeRequiresAuthenticatedViewer(t *testing.T) {
+	// mentions に "" が含まれる悪意ある / 破損 payload。
+	payload := []byte(`{"userId":"author","replyId":"p1","mentions":[""],"reply":{"userId":"target","visibility":"public"}}`)
+	// home / hybrid は anonymous で snap=nil なので default path、snap が
+	// あっても anonymous viewer は mention escape を発火させない。
+	// local / hybrid は anonymous で別 early-return path に乗るので mention
+	// escape の影響を受けない (TestReplyShouldEmit_LocalAnonymousPassesAllReplies
+	// 等で別途 pin)。ここでは home の anonymous (= snapshot 経由でも drop)
+	// path で escape が発火しないことを確認。
+	snap := map[string]bool{"author": false}
+	assert.False(t, replyShouldEmit(payload, "", snap, false, replyGateHome),
+		"home: anonymous viewer must not be escaped by empty-string mention")
+}
+
+// TestReplyShouldEmit_MentionEscapeRespectsFollowersVisibility: mention
+// escape は basic reply gate を pass させるが、followers-visibility 経路
+// 自体は別 gate なのでそちらの judgment は upstream 互換のまま (= mention
+// escape は basic gate 専用)。今後 followers-visibility にも mention
+// escape を広げるなら別 issue で扱う。
+func TestReplyShouldEmit_MentionEscapeDoesNotOverrideFollowersVisibility(t *testing.T) {
+	// followee.withReplies=true、reply.visibility=followers、viewer は
+	// target を follow していない & 自分宛でもない & mentions に含まれる。
+	// followers-visibility branch は mention を見ないので drop が保持される。
+	payload := []byte(`{"userId":"author","replyId":"p1","mentions":["viewer"],"reply":{"userId":"target","visibility":"followers"}}`)
+	snap := map[string]bool{"author": true} // followee.withReplies=true
+	assert.False(t, replyShouldEmit(payload, "viewer", snap, false, replyGateHome),
+		"followers-visibility branch should not be bypassed by mention escape (mk-go #1195 scope)")
+}
+
 func TestReplyShouldEmit_MissingReplyEmbedIsConservative(t *testing.T) {
 	// reply embed が無い場合 (= reply.userId 参照できない) は 3 escape hatch の
 	// うち isMe しか判定できない。conservative に drop して fanout / DB の


### PR DESCRIPTION
## Summary

- 「フォロイー A → 他人 B reply に viewer (自分) が mention されている場合、`following.withReplies=false` でも home / hybrid / local TL に表示する」mk-go 独自 escape hatch を追加
- fanout (push) layer / stream filter (live) layer の両方に同じ semantics で配線
- **upstream Misskey TS は同 escape hatch を持たないため意図的 drop-in deviation**

## 背景

operator 観測: フォロイー A → 他人 B reply の本文に viewer (自分) への mention が含まれている場合、現状の mk-go では home / hybrid / local TL に表示されない (= live update / refresh いずれの経路でも drop)。

Misskey TS upstream の同等挙動を確認:

- `home-timeline.ts` / `hybrid-timeline.ts` / `local-timeline.ts` の reply gate
- `NoteCreateService.ts` fanout の `isReply()` helper (`packages/backend/src/misc/is-reply.ts`)

いずれも escape hatch は次の 3 種のみで、**`note.mentions?.includes(viewerId)` は意図的に escape hatch から外れている**:

- `reply.userId === me.id` (replyToMe)
- `note.userId === me.id` (isMe / author = viewer)
- `reply.userId === note.userId` (selfThread)

つまり mk-go 現状の挙動は TS-compat。本 PR は operator 直接要望に基づき「mention が本文に明示されている = author が viewer に届けたい意図」を escape hatch として追加する mk-go 独自仕様。CLAUDE.md Section 6 の drop-in 互換最優先方針からは僅かに踏み出すが、UX 期待値に合わせるための judgment call。

## 主な変更点

### fanout layer (`internal/core/timeline/fanout_hook.go`)

`fanoutToFollowersAndStream` の per-follower skip 条件に \`isMentioned\` 追加:

\`\`\`go
isReplyToFollower := isReply && n.ReplyUserID != nil && *n.ReplyUserID == f.FollowerID
isMentioned := isReply && containsMention(n.Mentions, f.FollowerID)
if isReply && !isSelfThread && !isReplyToFollower && !isMentioned && !f.WithReplies {
    continue
}
\`\`\`

\`containsMention(mentions []string, userID string) bool\` helper を新設 (line 411-)。typical mention 数 < 10 なので線形探索で十分。

### stream layer (`internal/stream/channels/note_filter.go`)

- \`notePayload\` 構造体に \`Mentions []string\` を追加 (\`json:\"mentions\"\`、NoteEntityService.pack の出力を pick up)
- \`replyShouldEmit\` の \`replyGateHome\` / \`replyGateHybrid\` / \`replyGateLocal\` の最終 return 行を \`replyToMe || selfThread || isMentioned\` に拡張
- 標準ライブラリ \`slices.Contains\` で mention 判定 (Go 1.21+、既存 \`stream/connection.go\` も同 pattern)

### followers-visibility 経路は scope 外

\`reply.visibility=followers\` への reply の follow 関係 check 自体は別 gate (privacy boundary) で、mention escape を広げると「viewer は B の followers-only post を follow せずに A の reply を見られる」privacy implication が出るため、本 PR では escape を basic \`withReplies\` gate に限定。テストで「followers-visibility branch は mention で bypass されない」ことを pin (\`TestReplyShouldEmit_MentionEscapeDoesNotOverrideFollowersVisibility\`)。

## テスト

- \`fanout_hook_test.go\`: \`TestFanoutHook_MentionedFollowerEscapesReplyFilter\` — 「他人 A → 他人 B reply に follower C を mention」で C のみ push、他 follower は default reply gate で drop
- \`note_filter_test.go\`: home / hybrid / local 3 mode で mention escape が共通に効くこと、anonymous viewer は誤発火しないこと、followers-visibility 経路は escape 対象外であること (3 test)

\`\`\`
make fmt && make lint && make test  # 全 124 packages all green
\`\`\`

per-package coverage (CI threshold 90% で gated):

| package | coverage |
|---|---|
| internal/core/timeline | 96.7% |
| internal/stream/channels | 94.3% |
| fanoutToFollowersAndStream (func) | 100.0% |
| replyShouldEmit (func) | 93.8% |

## scope 外 (follow-up 候補)

- notification 側 (\`internal/core/notification/hooks.go\`) — 既に \`n.Mentions\` 経由で mention notification を正しく生成しており変更不要
- \`/api/notes/mentions\` — \`mentions @> ARRAY[?]::varchar[]\` の pure query で影響なし
- DB-side timeline filter (\`internal/repository/note.go:574\` の \`applyTimelineFilter\`) — Redis cache pass-through が default、DB fallback の reply filter 改修は別 issue で扱う
- channel timeline / antenna / user list — 本 PR では home / hybrid / local の 3 main TL 限定
- maintenance / followers-visibility 経路の mention escape 拡張

## Closes

Closes #1195