### PR TITLE
feat(admin): show-user に signins/roleAssigns を実装 + federation pie chart narrative 訂正 (#1198)

### DIFF
--- a/internal/api/admin/handler.go
+++ b/internal/api/admin/handler.go
@@ -130,6 +130,9 @@ type Handler struct {
 	// router で必ず wire する (未配線時は 30s cache TTL 待ちで stale 旧 user
 	// が auth 通過する security regression が残る)。
 	userTokenInvalidator UserTokenInvalidator
+	// signinRepo は admin/show-user の `signins` field を実データで埋める
+	// ために使う (#1198)。未配線時は `[]` fallback で shape compat を保つ。
+	signinRepo repository.SigninRepository
 }
 
 // UserTokenInvalidator drops every cached auth entry for the given userID
@@ -209,6 +212,8 @@ func (h *Handler) SetSystemAccountFetcher(f SystemAccountFetcher) {
 // SetInstanceRepo wires an InstanceRepository for admin/federation handlers
 // to use when reading/updating instance rows. Without it,
 // FederationUpdateInstance early-returns 204 (#676)。
+func (h *Handler) SetSigninRepo(r repository.SigninRepository) { h.signinRepo = r }
+
 func (h *Handler) SetInstanceRepo(r repository.InstanceRepository) {
 	h.instanceRepo = r
 }
@@ -753,12 +758,13 @@ func (h *Handler) packAdminUser(u *model.User, profile *model.UserProfile) map[s
 		// user の役割に基づいて差し替わる。
 		resp["policies"] = h.roleService.GetUserPolicies(u.ID)
 	}
-	// signins / roleAssigns / isHibernated / lastActiveDate は upstream
-	// admin/show-user shape の必須 field (#888)。mk-go では signin 履歴と
-	// role assignment 詳細を別 endpoint で取得する設計なので空配列 / null
-	// で填めて shape compat を保つ (full integration は別 issue scope)。
-	resp["signins"] = []any{}
-	resp["roleAssigns"] = []any{}
+	// signins / roleAssigns は upstream admin/show-user shape の必須 field
+	// (#888)。frontend admin moderation view が user の signin 履歴と role
+	// 割当履歴を直接参照するので実データで埋める (#1198)。repo / service
+	// 未配線や lookup 失敗時は frontend の `.map(...)` が例外を吐かないよう
+	// 空配列に fallback し slog.Warn で観測する (roles の扱いと揃え)。
+	resp["signins"] = h.packUserSignins(u.ID)
+	resp["roleAssigns"] = h.packUserRoleAssigns(u.ID)
 	resp["isHibernated"] = false
 	if u.LastActiveDate != nil {
 		resp["lastActiveDate"] = u.LastActiveDate.UTC().Format("2006-01-02T15:04:05.000Z")
@@ -766,6 +772,60 @@ func (h *Handler) packAdminUser(u *model.User, profile *model.UserProfile) map[s
 		resp["lastActiveDate"] = nil
 	}
 	return resp
+}
+
+// packUserSignins returns the user's signin history in the admin/show-user
+// `signins` shape. Upstream returns every row (signinsRepository.findBy);
+// we pass limit=-1 so GORM omits the LIMIT clause and matches that. Returns
+// an empty slice (never nil) so the JSON field is always `[]` for callers
+// without a wired signin repository or on lookup failure.
+func (h *Handler) packUserSignins(userID string) []map[string]any {
+	out := []map[string]any{}
+	if h.signinRepo == nil {
+		return out
+	}
+	signins, err := h.signinRepo.ListByUserID(userID, -1, "", "")
+	if err != nil {
+		slog.Warn("admin/show-user: failed to load signins", "userId", userID, "err", err)
+		return out
+	}
+	for _, s := range signins {
+		if packed := entity.PackSignin(s, h.idGen); packed != nil {
+			out = append(out, packed)
+		}
+	}
+	return out
+}
+
+// packUserRoleAssigns returns the user's active role assignments in the
+// admin/show-user `roleAssigns` shape ({createdAt, expiresAt, roleId}).
+// createdAt is derived from the aidx-encoded assignment ID. Mirrors upstream
+// which maps roleService.getUserAssigns (expired assignments excluded).
+func (h *Handler) packUserRoleAssigns(userID string) []map[string]any {
+	out := []map[string]any{}
+	if h.roleService == nil {
+		return out
+	}
+	assigns, err := h.roleService.GetUserAssigns(userID)
+	if err != nil {
+		slog.Warn("admin/show-user: failed to load role assignments", "userId", userID, "err", err)
+		return out
+	}
+	const tsFormat = "2006-01-02T15:04:05.000Z"
+	for _, a := range assigns {
+		entry := map[string]any{
+			"roleId":    a.RoleID,
+			"expiresAt": nil,
+		}
+		if t, perr := h.idGen.ParseTime(a.ID); perr == nil {
+			entry["createdAt"] = t.UTC().Format(tsFormat)
+		}
+		if a.ExpiresAt != nil {
+			entry["expiresAt"] = a.ExpiresAt.UTC().Format(tsFormat)
+		}
+		out = append(out, entry)
+	}
+	return out
 }
 
 // SuspendUser handles POST /api/admin/suspend-user.

--- a/internal/api/admin/handler.go
+++ b/internal/api/admin/handler.go
@@ -212,11 +212,14 @@ func (h *Handler) SetSystemAccountFetcher(f SystemAccountFetcher) {
 // SetInstanceRepo wires an InstanceRepository for admin/federation handlers
 // to use when reading/updating instance rows. Without it,
 // FederationUpdateInstance early-returns 204 (#676)。
-func (h *Handler) SetSigninRepo(r repository.SigninRepository) { h.signinRepo = r }
-
 func (h *Handler) SetInstanceRepo(r repository.InstanceRepository) {
 	h.instanceRepo = r
 }
+
+// SetSigninRepo wires a SigninRepository so admin/show-user can populate the
+// target user's signin history. Without it the `signins` field falls back to
+// an empty array (#1198).
+func (h *Handler) SetSigninRepo(r repository.SigninRepository) { h.signinRepo = r }
 
 // SetFollowingRepo attaches a FollowingRepository for admin endpoints that
 // need to enumerate Following rows by host (e.g.
@@ -776,9 +779,11 @@ func (h *Handler) packAdminUser(u *model.User, profile *model.UserProfile) map[s
 
 // packUserSignins returns the user's signin history in the admin/show-user
 // `signins` shape. Upstream returns every row (signinsRepository.findBy);
-// we pass limit=-1 so GORM omits the LIMIT clause and matches that. Returns
-// an empty slice (never nil) so the JSON field is always `[]` for callers
-// without a wired signin repository or on lookup failure.
+// we pass limit=-1 so GORM omits the LIMIT clause and matches that. Rows come
+// back newest-first (ListByUserID's default order); upstream leaves the order
+// unspecified so this is a benign deviation. Returns an empty slice (never
+// nil) so the JSON field is always `[]` for callers without a wired signin
+// repository or on lookup failure.
 func (h *Handler) packUserSignins(userID string) []map[string]any {
 	out := []map[string]any{}
 	if h.signinRepo == nil {

--- a/internal/api/admin/handler_test.go
+++ b/internal/api/admin/handler_test.go
@@ -218,6 +218,98 @@ func TestShowUser_Success(t *testing.T) {
 	assert.NotNil(t, resp["securityKeysList"])
 	assert.NotNil(t, resp["achievements"])
 	assert.Equal(t, false, resp["isAdmin"])
+	// signins / roleAssigns は repo / assignment 未配線でも nil ではなく
+	// 空配列で返る (frontend の `.map(...)` が落ちない shape compat)。
+	assert.Equal(t, []any{}, resp["signins"])
+	assert.Equal(t, []any{}, resp["roleAssigns"])
+}
+
+// failingSigninRepo は signin lookup が error を返すケースを再現する
+// repository.SigninRepository 実装。admin/show-user の fallback 経路を突く。
+type failingSigninRepo struct{}
+
+func (failingSigninRepo) Create(*model.Signin) error { return assertError{} }
+func (failingSigninRepo) ListByUserID(string, int, string, string) ([]*model.Signin, error) {
+	return nil, assertError{}
+}
+
+func TestShowUser_WithSignins(t *testing.T) {
+	h, userRepo, _, _ := newTestHandler(t)
+	idGen, _ := id.NewGenerator("aidx")
+	uid := idGen.Generate(time.Now())
+	userRepo.Users[uid] = &model.User{ID: uid, Username: "test", AvatarDecorations: []byte("[]")}
+	userRepo.Profiles[uid] = &model.UserProfile{
+		UserID: uid, MutedWords: []byte("[]"), HardMutedWords: []byte("[]"), MutedInstances: []byte("[]"),
+	}
+
+	signinRepo := testutil.NewMockSigninRepository()
+	sid := idGen.Generate(time.Now())
+	signinRepo.Signins = []*model.Signin{
+		{ID: sid, UserID: uid, IP: "203.0.113.5", Success: true},
+	}
+	h.SetSigninRepo(signinRepo)
+
+	rec := doPost(h.ShowUser, `{"userId":"`+uid+`"}`, nil)
+	assert.Equal(t, http.StatusOK, rec.Code)
+	var resp map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+	signins, ok := resp["signins"].([]any)
+	require.True(t, ok)
+	require.Len(t, signins, 1)
+	entry := signins[0].(map[string]any)
+	assert.Equal(t, sid, entry["id"])
+	assert.Equal(t, "203.0.113.5", entry["ip"])
+	assert.Equal(t, true, entry["success"])
+	assert.NotNil(t, entry["createdAt"])
+}
+
+func TestShowUser_SigninsErrorFallback(t *testing.T) {
+	h, userRepo, _, _ := newTestHandler(t)
+	idGen, _ := id.NewGenerator("aidx")
+	uid := idGen.Generate(time.Now())
+	userRepo.Users[uid] = &model.User{ID: uid, Username: "test", AvatarDecorations: []byte("[]")}
+	userRepo.Profiles[uid] = &model.UserProfile{
+		UserID: uid, MutedWords: []byte("[]"), HardMutedWords: []byte("[]"), MutedInstances: []byte("[]"),
+	}
+	h.SetSigninRepo(failingSigninRepo{})
+
+	rec := doPost(h.ShowUser, `{"userId":"`+uid+`"}`, nil)
+	assert.Equal(t, http.StatusOK, rec.Code)
+	var resp map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+	// lookup 失敗時は空配列に fallback する。
+	assert.Equal(t, []any{}, resp["signins"])
+}
+
+func TestShowUser_WithRoleAssigns(t *testing.T) {
+	h, userRepo, _, roleRepo, assignRepo := newTestHandlerWithAssign(t)
+	idGen, _ := id.NewGenerator("aidx")
+	uid := idGen.Generate(time.Now())
+	userRepo.Users[uid] = &model.User{ID: uid, Username: "test", AvatarDecorations: []byte("[]")}
+	userRepo.Profiles[uid] = &model.UserProfile{
+		UserID: uid, MutedWords: []byte("[]"), HardMutedWords: []byte("[]"), MutedInstances: []byte("[]"),
+	}
+
+	roleRepo.Roles["r1"] = &model.Role{ID: "r1", Name: "Active"}
+	roleRepo.Roles["r2"] = &model.Role{ID: "r2", Name: "Expired"}
+	future := time.Now().Add(time.Hour)
+	expired := time.Now().Add(-time.Hour)
+	aid := idGen.Generate(time.Now())
+	assignRepo.Assignments[uid+":r1"] = &model.RoleAssignment{ID: aid, UserID: uid, RoleID: "r1", ExpiresAt: &future}
+	assignRepo.Assignments[uid+":r2"] = &model.RoleAssignment{ID: "a2", UserID: uid, RoleID: "r2", ExpiresAt: &expired}
+
+	rec := doPost(h.ShowUser, `{"userId":"`+uid+`"}`, nil)
+	assert.Equal(t, http.StatusOK, rec.Code)
+	var resp map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+	assigns, ok := resp["roleAssigns"].([]any)
+	require.True(t, ok)
+	// 期限切れ (r2) は upstream getUserAssigns と同じく除外される。
+	require.Len(t, assigns, 1)
+	entry := assigns[0].(map[string]any)
+	assert.Equal(t, "r1", entry["roleId"])
+	assert.NotNil(t, entry["createdAt"])
+	assert.NotNil(t, entry["expiresAt"])
 }
 
 func TestShowUser_NotFound(t *testing.T) {

--- a/internal/core/role/role_service.go
+++ b/internal/core/role/role_service.go
@@ -273,6 +273,19 @@ func (s *Service) GetUserRoles(userID string) ([]*model.Role, error) {
 	return roles, nil
 }
 
+// GetUserAssigns returns the user's currently active role assignments.
+// Mirrors upstream RoleService.getUserAssigns: expired assignments are
+// filtered out (assignmentRepo.ListByUser already excludes rows whose
+// expiresAt has passed). Used by admin/show-user to expose assignment
+// metadata (createdAt / expiresAt / roleId) separately from the resolved
+// role list returned by GetUserRoles.
+func (s *Service) GetUserAssigns(userID string) ([]*model.RoleAssignment, error) {
+	if userID == "" {
+		return nil, nil
+	}
+	return s.assignmentRepo.ListByUser(userID)
+}
+
 // evaluateConditionalRoles returns the subset of `target=conditional`
 // roles whose `condFormula` evaluates to true for the user. Best-effort:
 // when prerequisites are missing (no userRepo wired, role list fetch

--- a/internal/core/role/role_service_test.go
+++ b/internal/core/role/role_service_test.go
@@ -58,6 +58,33 @@ func TestGetUserRoles_ExpiredRoleExcluded(t *testing.T) {
 	assert.Empty(t, roles)
 }
 
+func TestGetUserAssigns_EmptyUserID(t *testing.T) {
+	svc, _, _, _ := newTestService(t)
+	assigns, err := svc.GetUserAssigns("")
+	require.NoError(t, err)
+	assert.Empty(t, assigns)
+}
+
+func TestGetUserAssigns_ActiveOnly(t *testing.T) {
+	svc, roleRepo, assignRepo, _ := newTestService(t)
+	roleRepo.Roles["r1"] = &model.Role{ID: "r1", Name: "Active"}
+	roleRepo.Roles["r2"] = &model.Role{ID: "r2", Name: "Expired"}
+	future := time.Now().Add(1 * time.Hour)
+	expired := time.Now().Add(-1 * time.Hour)
+	assignRepo.Assignments["user1:r1"] = &model.RoleAssignment{
+		ID: "a1", UserID: "user1", RoleID: "r1", ExpiresAt: &future,
+	}
+	assignRepo.Assignments["user1:r2"] = &model.RoleAssignment{
+		ID: "a2", UserID: "user1", RoleID: "r2", ExpiresAt: &expired,
+	}
+
+	// upstream getUserAssigns と同じく期限切れ assignment は除外される。
+	assigns, err := svc.GetUserAssigns("user1")
+	require.NoError(t, err)
+	require.Len(t, assigns, 1)
+	assert.Equal(t, "r1", assigns[0].RoleID)
+}
+
 func TestIsAdministrator_RootUser(t *testing.T) {
 	svc, _, _, metaRepo := newTestService(t)
 	rootID := "root1"

--- a/internal/server/router.go
+++ b/internal/server/router.go
@@ -155,10 +155,13 @@ func (s *Server) setupRoutes() {
 	keypairRepo := repository.NewUserKeypairRepository(s.db)
 	keypairExtraRepo := repository.NewUserKeypairExtraRepository(s.db)
 	instanceRepo := repository.NewInstanceRepository(s.db)
-	// instance.{followersCount,followingCount} はリアルタイム incremental
-	// 維持の hook が未実装で常に 0 → admin/overview の federation pie chart
-	// が空になる。起動時に `following` テーブルから一回 backfill する
-	// (#421)。失敗は警告だけで起動継続。
+	// instance.{followersCount,followingCount} は following service の
+	// adjustInstanceCountsForFollowing (Follow/Unfollow/AcceptRequest) と
+	// blocking service の auto-unfollow で incremental に維持される
+	// (admin/overview の federation pie chart の data source)。起動時の
+	// backfill は、再起動時点での following テーブルとの整合性回復 +
+	// direct DB 改変や過去の counter drift への安全網として残す (#421)。
+	// 失敗は警告だけで起動継続。
 	if err := instanceRepo.RecomputeFollowCounts(); err != nil {
 		slog.Warn("instance follow-counts recompute failed", "err", err)
 	}
@@ -1913,6 +1916,9 @@ func (s *Server) setupRoutes() {
 	// 満たしている。
 	adminHandler.SetUserTokenInvalidator(s.auth)
 	adminHandler.SetInstanceRepo(instanceRepo)
+	// admin/show-user の signins field を実データで埋める (#1198)。signinRepo
+	// は signin handler 配線時に既に構築済 (line ~1030)。
+	adminHandler.SetSigninRepo(signinRepo)
 	adminHandler.SetAbuseRepo(abuseReportRepo)
 	adminHandler.SetAbuseForwarder(coreabuse.NewForwarder(abuseReportRepo, sysAcctSvc, apRenderer, deliverService))
 	adminHandler.SetDeleteAccountEnqueuer(s.queueClient)

--- a/internal/testutil/mock_repository.go
+++ b/internal/testutil/mock_repository.go
@@ -5598,7 +5598,9 @@ func (m *MockSigninRepository) ListByUserID(userID string, limit int, untilID, s
 		}
 		return rows[i].ID > rows[j].ID
 	})
-	if len(rows) > limit {
+	// limit < 0 は GORM の Limit(-1) と同じく「無制限」を意味する
+	// (admin/show-user が全 signin を取得するために -1 を渡す)。
+	if limit >= 0 && len(rows) > limit {
 		rows = rows[:limit]
 	}
 	return rows, nil


### PR DESCRIPTION
## Summary

#1142 (2026-05-20 TODO audit tracker) の残サブタスクのうち、operator-visible かつ stale narrative cleanup 系の上位 3 件をまとめて消化する。調査の結果、実コード実装が要るのは admin/show-user の 1 件のみだった。

## 主な変更点

### 1. admin/show-user の signins / roleAssigns 実装
`packAdminUser` が `signins` / `roleAssigns` を `[]` stub で返していたのを実データに置き換えた。

- **signins**: `signinRepo` を handler に注入し、upstream の全件取得 (`signinsRepository.findBy({ userId })`) に合わせて `ListByUserID(uid, -1, "", "")` で全件取得 → `entity.PackSignin`。
- **roleAssigns**: `roleService.GetUserAssigns` を新設 (= upstream `getUserAssigns` 相当)。**upstream も期限切れを除外 (active only)** なので、既存の `RoleAssignmentRepository.ListByUser` (同じ active-only filter) をそのまま使え、`ListAllByUser` の新規追加は不要だった。`{createdAt(ID 由来), expiresAt(nullable ISO), roleId}` に map する。
- repo 未配線 / lookup 失敗時は `[]` fallback + `slog.Warn` で shape compat を維持 (roles の扱いと揃え)。
- migration 不要 (signin / role_assignment table は既存)。

### 2. federation pie chart の narrative 訂正
`router.go` の起動時 backfill コメントが「instance follow counts の incremental hook が未実装で常に 0」と書いていたが、実際は #421 後に `adjustInstanceCountsForFollowing` (Follow/Unfollow/AcceptRequest) + `SetInstanceRepo` wire + `IncrementFollowersCount/FollowingCount` が実装済で、stats.go が pie chart に供給している (factually wrong)。コメントを実態に訂正した。

### 3. MockSigninRepository の panic 修正
`limit=-1` (GORM の `Limit(-1)` = 無制限) を渡すと `len(rows) > -1` が常に真になり `rows[:-1]` で panic していた。負 limit = 無制限のガードを追加し実 GORM の挙動と揃えた。

## テスト

- 追加: `TestShowUser_WithSignins` / `TestShowUser_SigninsErrorFallback` / `TestShowUser_WithRoleAssigns` (active+expired filter), `TestGetUserAssigns_EmptyUserID` / `TestGetUserAssigns_ActiveOnly`
- 既存 `TestShowUser_Success` に signins/roleAssigns の空配列 assert を追加
- カバレッジ: `internal/api/admin` **86.8%** (閾値 80%↑), `internal/core/role` **95.3%** (閾値 90%↑)

```
go test ./internal/api/admin/... ./internal/core/role/... -count=1 -cover
go build ./... && go vet ./... && gofmt -s -d .
```

## Closes

Closes #1198
Refs #1142

🤖 Generated with [Claude Code](https://claude.com/claude-code)