### PR TITLE
feat(chat): group chat federation sub-phase 1 - 招待 outbound (Invite deliver)

### DIFF
--- a/internal/activitypub/renderer.go
+++ b/internal/activitypub/renderer.go
@@ -115,6 +115,15 @@ func (b *URLBuilder) ChatMessageURI(messageID string) string {
 	return b.baseURL + "/chat-messages/" + messageID
 }
 
+// ChatRoomURI returns the canonical AP URI for a chat room. CherryPick group
+// chat federation embeds this in the Group object id, in Add/Remove targets,
+// and in the group chat message note's `@context`. The path shape
+// (`/chat/rooms/{id}`) is load-bearing: receivers extract the room id with
+// `/\/chat\/rooms\/([a-zA-Z0-9]+)$/`.
+func (b *URLBuilder) ChatRoomURI(roomID string) string {
+	return b.baseURL + "/chat/rooms/" + roomID
+}
+
 // ErrMentionUserNotFound is returned by MentionResolver implementations
 // when the user does not exist (typically deleted or the ID is stale).
 // Caller (renderer) は本 sentinel を skip 扱いにし、その他 error は DB
@@ -728,6 +737,45 @@ func (r *Renderer) RenderReject(actorID string, inner any) *Reject {
 	}
 	AddContext(a)
 	return a
+}
+
+// RenderChatRoom returns the ActivityStreams `Group` object representing a
+// chat room, used as the object of Invite / Accept / Reject activities in
+// CherryPick group chat federation. Mirrors ApRendererService.renderChatRoom.
+func (r *Renderer) RenderChatRoom(room *model.ChatRoom) *ChatRoomGroup {
+	g := &ChatRoomGroup{
+		Object: Object{
+			ID:   r.urls.ChatRoomURI(room.ID),
+			Type: "Group",
+			Name: room.Name,
+		},
+		AttributedTo: r.urls.UserURI(room.OwnerID),
+	}
+	if room.Description != "" {
+		g.Summary = room.Description
+	}
+	return g
+}
+
+// RenderInvite wraps a chat room Group object in an Invite activity targeted
+// at the invitee's actor URI. Mirrors ApRendererService.renderInvite.
+//
+// id は RenderAccept と同じく addContext 互換で `{baseURL}/{UUID}` を必ず入れる
+// (id 無し activity は受信側 InboxProcessor で弾かれる)。actor は room owner。
+func (r *Renderer) RenderInvite(ownerID string, inner any, targetURI string) *Invite {
+	inv := &Invite{
+		Activity: Activity{
+			Object: Object{
+				ID:   r.urls.baseURL + "/" + uuid.NewString(),
+				Type: "Invite",
+			},
+			Actor: r.urls.UserURI(ownerID),
+		},
+		Object: inner,
+		Target: targetURI,
+	}
+	AddContext(inv)
+	return inv
 }
 
 // RenderLike returns a Like activity for the given reaction.

--- a/internal/activitypub/renderer_test.go
+++ b/internal/activitypub/renderer_test.go
@@ -45,6 +45,44 @@ func TestURLBuilder_FollowURI_FullURI(t *testing.T) {
 	assert.Equal(t, uri, b.FollowURI("alice", "https://remote.example/users/bob"))
 }
 
+func TestURLBuilder_ChatRoomURI(t *testing.T) {
+	b := NewURLBuilder("https://example.com")
+	// path shape は CherryPick の room id 抽出正規表現 (/chat/rooms/{id}) に揃える。
+	assert.Equal(t, "https://example.com/chat/rooms/room1", b.ChatRoomURI("room1"))
+}
+
+func TestRenderer_RenderChatRoom(t *testing.T) {
+	r := newRenderer()
+	g := r.RenderChatRoom(&model.ChatRoom{ID: "room1", Name: "General", OwnerID: "owner1", Description: "hello"})
+	assert.Equal(t, "Group", g.Type)
+	assert.Equal(t, "https://example.com/chat/rooms/room1", g.ID)
+	assert.Equal(t, "General", g.Name)
+	assert.Equal(t, "hello", g.Summary)
+	assert.Equal(t, "https://example.com/users/owner1", g.AttributedTo)
+}
+
+func TestRenderer_RenderChatRoom_NoDescription(t *testing.T) {
+	r := newRenderer()
+	g := r.RenderChatRoom(&model.ChatRoom{ID: "room1", Name: "General", OwnerID: "owner1"})
+	// description 空のときは summary を省略する (omitempty)。
+	assert.Empty(t, g.Summary)
+}
+
+func TestRenderer_RenderInvite(t *testing.T) {
+	r := newRenderer()
+	group := r.RenderChatRoom(&model.ChatRoom{ID: "room1", Name: "General", OwnerID: "owner1"})
+	inv := r.RenderInvite("owner1", group, "https://remote.example/users/bob")
+	assert.Equal(t, "Invite", inv.Type)
+	assert.Equal(t, "https://example.com/users/owner1", inv.Actor)
+	assert.Equal(t, "https://remote.example/users/bob", inv.Target)
+	// id は addContext 互換で必ず入る (id 無し activity は受信側で弾かれる)。
+	assert.True(t, strings.HasPrefix(inv.ID, "https://example.com/"))
+	assert.NotEmpty(t, inv.Context, "@context が addContext で入ること")
+	g, ok := inv.Object.(*ChatRoomGroup)
+	require.True(t, ok)
+	assert.Equal(t, "https://example.com/chat/rooms/room1", g.ID)
+}
+
 func TestRenderer_RenderPerson(t *testing.T) {
 	r := newRenderer()
 	avatar := "https://example.com/avatar.png"

--- a/internal/activitypub/types.go
+++ b/internal/activitypub/types.go
@@ -394,6 +394,25 @@ type Reject struct {
 	Object any `json:"object"`
 }
 
+// ChatRoomGroup is the ActivityStreams `Group` object representing a chat
+// room in CherryPick group chat federation. It is used as the object of
+// Invite / Accept / Reject activities and mirrors CherryPick
+// ApRendererService.renderChatRoom (type=Group, id=room URI, attributedTo=owner).
+type ChatRoomGroup struct {
+	Object
+	Summary      string `json:"summary,omitempty"`
+	AttributedTo string `json:"attributedTo,omitempty"`
+}
+
+// Invite represents an Invite activity used to invite a (typically remote)
+// user into a chat room (CherryPick group chat federation). object is the
+// ChatRoomGroup, target is the invitee's actor URI.
+type Invite struct {
+	Activity
+	Object any    `json:"object"`
+	Target string `json:"target,omitempty"`
+}
+
 // Undo represents an Undo activity.
 type Undo struct {
 	Activity
@@ -539,6 +558,8 @@ func AddContext(o any) {
 	case *Accept:
 		v.Context = ctx
 	case *Reject:
+		v.Context = ctx
+	case *Invite:
 		v.Context = ctx
 	case *Undo:
 		v.Context = ctx

--- a/internal/api/chat/handler.go
+++ b/internal/api/chat/handler.go
@@ -687,6 +687,11 @@ func (h *Handler) InvitationsCreate(c echo.Context) error {
 	if err := h.repo.CreateInvitation(inv); err != nil {
 		return c.JSON(http.StatusInternalServerError, apierr.Error("INTERNAL_ERROR", "Internal error.", "5d37dbcb-891e-41ca-a3d6-e690c97775ac"))
 	}
+	// invitee が remote user なら Invite activity を配送する (CherryPick group
+	// chat federation, #1201)。local invitee なら service 側で no-op。
+	if h.svc != nil {
+		h.svc.FederateInvitation(req.RoomID, req.UserID)
+	}
 	return c.NoContent(http.StatusNoContent)
 }
 

--- a/internal/api/chat/handler.go
+++ b/internal/api/chat/handler.go
@@ -674,12 +674,20 @@ func (h *Handler) ReactionsDelete(c echo.Context) error {
 
 // InvitationsCreate handles POST /api/chat/rooms/invitations/create.
 func (h *Handler) InvitationsCreate(c echo.Context) error {
+	user := middleware.GetUser(c)
 	var req struct {
 		RoomID string `json:"roomId"`
 		UserID string `json:"userId"`
 	}
 	if err := c.Bind(&req); err != nil || req.RoomID == "" || req.UserID == "" {
 		return c.JSON(http.StatusBadRequest, apierr.Error("INVALID_PARAM", "roomId and userId are required.", "ed1d7571-a3ac-4370-899c-0dbe5e230cc8"))
+	}
+	// owner だけが招待を作成・連合できる。これが無いと任意の認証ユーザーが
+	// owner の鍵で署名された Invite を remote へなりすまし送信できてしまう
+	// (#1201 review)。room owner 以外は NO_SUCH_ROOM で弾く (RoomsUpdate と同方針)。
+	room, err := h.repo.FindRoomByID(req.RoomID)
+	if err != nil || room.OwnerID != user.ID {
+		return c.JSON(http.StatusNotFound, apierr.Error("NO_SUCH_ROOM", "No such room.", "6ab4d7df-5043-57b9-bd5d-ff9908288473"))
 	}
 	inv := &model.ChatRoomInvitation{
 		ID: h.idGen.Generate(time.Now()), UserID: req.UserID, RoomID: req.RoomID,

--- a/internal/api/chat/handler_test.go
+++ b/internal/api/chat/handler_test.go
@@ -603,7 +603,8 @@ func TestReactionsDelete(t *testing.T) {
 // --- Invitations ---
 
 func TestInvitationsCreate_Success(t *testing.T) {
-	h, _ := newTestHandler()
+	h, repo := newTestHandler()
+	require.NoError(t, repo.CreateRoom(&model.ChatRoom{ID: "r1", Name: "General", OwnerID: u1.ID}))
 	rec := post(h.InvitationsCreate, `{"roomId":"r1","userId":"u2"}`, u1)
 	assert.Equal(t, http.StatusNoContent, rec.Code)
 }
@@ -614,8 +615,17 @@ func TestInvitationsCreate_InvalidParam(t *testing.T) {
 	assert.Equal(t, http.StatusBadRequest, rec.Code)
 }
 
+func TestInvitationsCreate_NotOwnerRejected(t *testing.T) {
+	h, repo := newTestHandler()
+	// room owner は u2。u1 は owner でないので招待を作成・連合できない。
+	require.NoError(t, repo.CreateRoom(&model.ChatRoom{ID: "r1", Name: "General", OwnerID: "u2"}))
+	rec := post(h.InvitationsCreate, `{"roomId":"r1","userId":"u3"}`, u1)
+	assert.Equal(t, http.StatusNotFound, rec.Code)
+}
+
 func TestInvitationsCreate_Error(t *testing.T) {
 	h, repo := newTestHandler()
+	require.NoError(t, repo.CreateRoom(&model.ChatRoom{ID: "r1", Name: "General", OwnerID: u1.ID}))
 	repo.CreateErr = errMock
 	rec := post(h.InvitationsCreate, `{"roomId":"r1","userId":"u2"}`, u1)
 	assert.Equal(t, http.StatusInternalServerError, rec.Code)

--- a/internal/core/chat/ap_delivery_test.go
+++ b/internal/core/chat/ap_delivery_test.go
@@ -323,6 +323,20 @@ func TestFederateInvitation_SkipsLocalInvitee(t *testing.T) {
 	assert.Equal(t, 0, deliverer.called)
 }
 
+func TestFederateInvitation_SkipsRemoteOwnedRoom(t *testing.T) {
+	svc, chatRepo, userRepo, deliverer := newInvitationService(t)
+	remoteHost := "remote.example"
+	ownerURI := "https://remote.example/users/owner"
+	inviteeURI := "https://remote.example/users/bob"
+	// owner が remote の room は本インスタンスから署名配送できないため no-op。
+	userRepo.Users["remoteOwner"] = &model.User{ID: "remoteOwner", Username: "owner", Host: &remoteHost, URI: &ownerURI}
+	userRepo.Users["bob"] = &model.User{ID: "bob", Username: "bob", Host: &remoteHost, URI: &inviteeURI}
+	require.NoError(t, chatRepo.CreateRoom(&model.ChatRoom{ID: "room1", Name: "General", OwnerID: "remoteOwner"}))
+
+	svc.FederateInvitation("room1", "bob")
+	assert.Equal(t, 0, deliverer.called)
+}
+
 func TestFederateInvitation_NoOpWhenRoomMissing(t *testing.T) {
 	svc, _, userRepo, deliverer := newInvitationService(t)
 	remoteHost := "remote.example"

--- a/internal/core/chat/ap_delivery_test.go
+++ b/internal/core/chat/ap_delivery_test.go
@@ -280,3 +280,70 @@ func TestCreateMessageToUser_NonGranularScope_NoFollowingRepoOK(t *testing.T) {
 	_, err := svc.CreateMessageToUser(context.Background(), "alice", "bob", "ok", "")
 	require.NoError(t, err)
 }
+
+// newInvitationService builds a chat service with AP delivery wired and keeps
+// the chat repo reference so room rows can be seeded for invitation tests.
+func newInvitationService(t *testing.T) (*corechat.Service, *testutil.MockChatRepository, *testutil.MockUserRepository, *fakeAPDeliverer) {
+	t.Helper()
+	chatRepo := newFakeRepo()
+	idGen, _ := id.NewGenerator("aidx")
+	svc := corechat.NewService(chatRepo, idGen)
+	userRepo := testutil.NewMockUserRepository()
+	urls := activitypub.NewURLBuilder("https://local.example")
+	renderer := activitypub.NewRenderer(urls)
+	deliverer := &fakeAPDeliverer{}
+	svc.SetAPDelivery(userRepo, renderer, urls, deliverer)
+	return svc, chatRepo, userRepo, deliverer
+}
+
+func TestFederateInvitation_DeliversInviteToRemoteInvitee(t *testing.T) {
+	svc, chatRepo, userRepo, deliverer := newInvitationService(t)
+	remoteHost := "remote.example"
+	remoteURI := "https://remote.example/users/bob"
+	userRepo.Users["owner1"] = &model.User{ID: "owner1", Username: "owner1"}
+	userRepo.Users["bob"] = &model.User{ID: "bob", Username: "bob", Host: &remoteHost, URI: &remoteURI}
+	require.NoError(t, chatRepo.CreateRoom(&model.ChatRoom{ID: "room1", Name: "General", OwnerID: "owner1"}))
+
+	svc.FederateInvitation("room1", "bob")
+	assert.Equal(t, 1, deliverer.called)
+	body := string(deliverer.lastBody)
+	assert.Contains(t, body, `"type":"Invite"`)
+	assert.Contains(t, body, `"type":"Group"`)
+	assert.Contains(t, body, "https://local.example/chat/rooms/room1")
+	assert.Contains(t, body, `"target":"https://remote.example/users/bob"`)
+}
+
+func TestFederateInvitation_SkipsLocalInvitee(t *testing.T) {
+	svc, chatRepo, userRepo, deliverer := newInvitationService(t)
+	userRepo.Users["owner1"] = &model.User{ID: "owner1", Username: "owner1"}
+	userRepo.Users["carol"] = &model.User{ID: "carol", Username: "carol"}
+	require.NoError(t, chatRepo.CreateRoom(&model.ChatRoom{ID: "room1", Name: "General", OwnerID: "owner1"}))
+
+	svc.FederateInvitation("room1", "carol")
+	assert.Equal(t, 0, deliverer.called)
+}
+
+func TestFederateInvitation_NoOpWhenRoomMissing(t *testing.T) {
+	svc, _, userRepo, deliverer := newInvitationService(t)
+	remoteHost := "remote.example"
+	remoteURI := "https://remote.example/users/bob"
+	userRepo.Users["bob"] = &model.User{ID: "bob", Username: "bob", Host: &remoteHost, URI: &remoteURI}
+
+	// room が存在しなければ deliver しない (warn log のみ)。
+	svc.FederateInvitation("ghost", "bob")
+	assert.Equal(t, 0, deliverer.called)
+}
+
+func TestFederateInvitation_DeliveryFailureIsSwallowed(t *testing.T) {
+	svc, chatRepo, userRepo, deliverer := newInvitationService(t)
+	deliverer.returnErr = assert.AnError
+	remoteHost := "remote.example"
+	remoteURI := "https://remote.example/users/bob"
+	userRepo.Users["owner1"] = &model.User{ID: "owner1", Username: "owner1"}
+	userRepo.Users["bob"] = &model.User{ID: "bob", Username: "bob", Host: &remoteHost, URI: &remoteURI}
+	require.NoError(t, chatRepo.CreateRoom(&model.ChatRoom{ID: "room1", Name: "General", OwnerID: "owner1"}))
+
+	// 配送失敗は panic/propagate せず swallow される。
+	svc.FederateInvitation("room1", "bob")
+	assert.Equal(t, 1, deliverer.called)
+}

--- a/internal/core/chat/service.go
+++ b/internal/core/chat/service.go
@@ -337,6 +337,44 @@ func (s *Service) tryDeliverToRemoteUser(msg *model.ChatMessage, fromUserID, toU
 	_ = s.repo.UpdateDeliveryStatus(msg.ID, false, false)
 }
 
+// FederateInvitation delivers an Invite activity to a remote invitee so the
+// remote instance can surface the chat room invitation (CherryPick group chat
+// federation). Best-effort: no-op when AP delivery is unwired or the invitee
+// is local; delivery failures are logged and swallowed (the local invitation
+// row has already been committed, matching the 1-on-1 delivery policy). The
+// activity is signed by the room owner (the inviter).
+func (s *Service) FederateInvitation(roomID, inviteeID string) {
+	if s.deliverer == nil || s.userRepo == nil || s.renderer == nil || s.urls == nil {
+		return
+	}
+	invitee, err := s.userRepo.FindByID(inviteeID)
+	if err != nil || invitee == nil || invitee.IsLocal() {
+		return
+	}
+	inviteeURI := ""
+	if invitee.URI != nil {
+		inviteeURI = *invitee.URI
+	}
+	if inviteeURI == "" {
+		return
+	}
+	room, err := s.repo.FindRoomByID(roomID)
+	if err != nil || room == nil {
+		slog.Warn("chat: invitation federation: room not found", "roomID", roomID, "err", err)
+		return
+	}
+	group := s.renderer.RenderChatRoom(room)
+	invite := s.renderer.RenderInvite(room.OwnerID, group, inviteeURI)
+	body, err := json.Marshal(invite)
+	if err != nil {
+		slog.Warn("chat: invitation federation: marshal failed", "roomID", roomID, "err", err)
+		return
+	}
+	if err := s.deliverer.DeliverToUser(room.OwnerID, invitee, body); err != nil {
+		slog.Warn("chat: invitation federation: deliver failed", "roomID", roomID, "inviteeID", inviteeID, "err", err)
+	}
+}
+
 // CreateMessageViaAP persists a chat message received via ActivityPub from a
 // remote user. The uri parameter is the activity's canonical ID. AP retries
 // are common so URI-based dedup is performed (IngestNote と同じパターン).

--- a/internal/core/chat/service.go
+++ b/internal/core/chat/service.go
@@ -363,6 +363,12 @@ func (s *Service) FederateInvitation(roomID, inviteeID string) {
 		slog.Warn("chat: invitation federation: room not found", "roomID", roomID, "err", err)
 		return
 	}
+	// owner が remote の room は本インスタンスから Invite を署名配送できない
+	// (秘密鍵が無い)。federation するのは local owner の room のみ。
+	owner, err := s.userRepo.FindByID(room.OwnerID)
+	if err != nil || owner == nil || !owner.IsLocal() {
+		return
+	}
 	group := s.renderer.RenderChatRoom(room)
 	invite := s.renderer.RenderInvite(room.OwnerID, group, inviteeURI)
 	body, err := json.Marshal(invite)


### PR DESCRIPTION
## Summary

#1200 (CherryPick 互換 group chat (room) federation) の **Sub-phase 1**。AP rendering の基盤と、room owner が **remote user を招待** したときの Invite activity 配送を実装する。

これは #1142 の「group chat (multi-recipient DM) 対応」サブタスクを Phase 化したものの最初の一歩。調査で、当該サブタスクは小修正ではなく CherryPick 互換の room federation 全体 (invitation / membership / room message in-out) が必要な Phase 級機能と判明したため、#1200 で 4 sub-phase に分割している。

## 主な変更点

### AP rendering 基盤 (`internal/activitypub/`)
- `URLBuilder.ChatRoomURI(roomID)` → `/chat/rooms/{id}`。CherryPick 受信側の roomId 抽出正規表現 `/\/chat\/rooms\/([a-zA-Z0-9]+)$/` に揃えた path shape
- `ChatRoomGroup` (AS `Group` object: type/id/name/summary/attributedTo) と `Invite` activity 型を追加
- `AddContext` の type switch に `*Invite` を追加 (id/@context 無し activity は受信側 InboxProcessor で弾かれるため)
- `Renderer.RenderChatRoom` (Group object) / `RenderInvite` を追加。`RenderAccept`/`RenderReject` は既存を再利用予定

### chat service / handler
- `Service.FederateInvitation(roomID, inviteeID)`: invitee が remote user のとき Invite を invitee inbox へ deliver (signer = room owner)。local invitee / AP 未配線 / room 不在は no-op、配送失敗は warn log で swallow (1-on-1 delivery と同方針)
- handler `InvitationsCreate` を service 経由で federation 配線

### scope 外 (後続 sub-phase)
- Accept/Reject deliver は inbound invite (room copy 作成) と対になるため **Sub-phase 2**
- room message in/out は **Sub-phase 3/4**

## テスト
- renderer 単体: `ChatRoomURI` / `RenderChatRoom` (description 有無) / `RenderInvite` (Group object 入れ子・target・@context)
- service: remote invitee へ Invite deliver / local invitee は no-op / room 不在 no-op / 配送失敗 swallow
- カバレッジ: activitypub 90.1% / core/chat 92.1% / api/chat 91.5% (いずれも閾値 90%↑)

```
go test ./internal/activitypub/ ./internal/core/chat/... ./internal/api/chat/... -count=1 -cover
go build ./... && go vet ./... && gofmt -s -d .
```

## Closes / Refs
Closes #1201
Refs #1200, #1142

🤖 Generated with [Claude Code](https://claude.com/claude-code)