### PR TITLE
feat(chat): group chat federation sub-phase 3 - room message outbound

### DIFF
--- a/internal/activitypub/renderer.go
+++ b/internal/activitypub/renderer.go
@@ -1017,6 +1017,43 @@ func (r *Renderer) RenderChatMessage(msg *model.ChatMessage, senderURI, recipien
 	return c
 }
 
+// RenderChatRoomMessage renders a group chat (room) message as a Create
+// wrapping a Note flagged with _misskey_talk, addressed to every room member.
+// The note's `@context` is set to the room URI: CherryPick receivers extract
+// the room id from it to route the message into the room. AddContext only sets
+// the top-level Create context, so the note-level room `@context` survives.
+func (r *Renderer) RenderChatRoomMessage(msg *model.ChatMessage, senderURI string, memberURIs []string, roomURI, published string) *Create {
+	noteURI := r.urls.ChatMessageURI(msg.ID)
+	note := &Note{
+		Object: Object{
+			ID:      noteURI,
+			Type:    "Note",
+			Context: roomURI,
+		},
+		AttributedTo: senderURI,
+		Published:    published,
+		To:           memberURIs,
+		MisskeyTalk:  true,
+	}
+	if msg.Text != nil {
+		note.Content = *msg.Text
+	}
+	c := &Create{
+		Activity: Activity{
+			Object: Object{
+				ID:   noteURI + "/activity",
+				Type: "Create",
+			},
+			Actor:     senderURI,
+			Published: published,
+			To:        memberURIs,
+		},
+		Object: note,
+	}
+	AddContext(c)
+	return c
+}
+
 // addressing computes to/cc lists for a note based on visibility.
 func (r *Renderer) addressing(n *model.Note) (to []string, cc []string) {
 	switch n.Visibility {

--- a/internal/activitypub/renderer_test.go
+++ b/internal/activitypub/renderer_test.go
@@ -103,6 +103,27 @@ func TestRenderer_RenderChatRoomInviteRef(t *testing.T) {
 	assert.Equal(t, "https://remote.example/users/owner", g.AttributedTo)
 }
 
+func TestRenderer_RenderChatRoomMessage(t *testing.T) {
+	r := newRenderer()
+	txt := "hello room"
+	msg := &model.ChatMessage{ID: "m1", Text: &txt}
+	members := []string{"https://example.com/users/alice", "https://remote.example/users/bob"}
+	c := r.RenderChatRoomMessage(msg, "https://example.com/users/alice", members,
+		"https://example.com/chat/rooms/room1", "2026-05-24T00:00:00Z")
+	assert.Equal(t, "Create", c.Type)
+	assert.Equal(t, members, c.To)
+	note, ok := c.Object.(*Note)
+	require.True(t, ok)
+	assert.True(t, note.MisskeyTalk)
+	assert.Equal(t, members, note.To)
+	assert.Equal(t, "hello room", note.Content)
+	// note 階層の @context が room URI (CherryPick の room 識別子)。
+	assert.Equal(t, "https://example.com/chat/rooms/room1", note.Context)
+	// top-level の @context は addContext で標準 context が入る (room URI ではない)。
+	assert.NotNil(t, c.Context)
+	assert.NotEqual(t, "https://example.com/chat/rooms/room1", c.Context)
+}
+
 func TestRenderer_RenderPerson(t *testing.T) {
 	r := newRenderer()
 	avatar := "https://example.com/avatar.png"

--- a/internal/core/chat/room_federation_test.go
+++ b/internal/core/chat/room_federation_test.go
@@ -1,6 +1,7 @@
 package chat_test
 
 import (
+	"context"
 	"testing"
 
 	corechat "github.com/shiroha-a/mk/internal/core/chat"
@@ -178,4 +179,88 @@ func TestFederateInvitationResponse_UnwiredIsNoOp(t *testing.T) {
 	svc, repo := newRoomFedService(t)
 	require.NoError(t, repo.CreateRoom(&model.ChatRoom{ID: "room1", Name: "General", OwnerID: "remoteOwner"}))
 	svc.FederateInvitationResponse("room1", "bob", true)
+}
+
+func TestCreateMessageToRoom_DeliversToRemoteMembers(t *testing.T) {
+	svc, chatRepo, userRepo, deliverer := newInvitationService(t)
+	remoteHost := "remote.example"
+	bobURI := "https://remote.example/users/bob"
+	userRepo.Users["alice"] = &model.User{ID: "alice", Username: "alice"}
+	userRepo.Users["bob"] = &model.User{ID: "bob", Username: "bob", Host: &remoteHost, URI: &bobURI}
+	// alice (local owner) の room に remote member bob。
+	require.NoError(t, chatRepo.CreateRoom(&model.ChatRoom{ID: "room1", Name: "General", OwnerID: "alice"}))
+	require.NoError(t, chatRepo.CreateMembership(&model.ChatRoomMembership{ID: "mem1", UserID: "bob", RoomID: "room1"}))
+
+	_, err := svc.CreateMessageToRoom(context.Background(), "alice", "room1", "hi room", "")
+	require.NoError(t, err)
+	assert.Equal(t, 1, deliverer.called)
+	body := string(deliverer.lastBody)
+	assert.Contains(t, body, `"_misskey_talk":true`)
+	assert.Contains(t, body, "https://local.example/chat/rooms/room1")
+	assert.Contains(t, body, "https://remote.example/users/bob")
+	assert.Contains(t, body, "hi room")
+}
+
+func TestCreateMessageToRoom_LocalOnlyRoomNoFederation(t *testing.T) {
+	svc, chatRepo, userRepo, deliverer := newInvitationService(t)
+	userRepo.Users["alice"] = &model.User{ID: "alice", Username: "alice"}
+	userRepo.Users["carol"] = &model.User{ID: "carol", Username: "carol"}
+	require.NoError(t, chatRepo.CreateRoom(&model.ChatRoom{ID: "room1", Name: "General", OwnerID: "alice"}))
+	require.NoError(t, chatRepo.CreateMembership(&model.ChatRoomMembership{ID: "mem1", UserID: "carol", RoomID: "room1"}))
+
+	_, err := svc.CreateMessageToRoom(context.Background(), "alice", "room1", "hi", "")
+	require.NoError(t, err)
+	// remote member が居ないので配送しない。
+	assert.Equal(t, 0, deliverer.called)
+}
+
+func TestCreateMessageToRoom_RemoteRoomUsesOwnerHostURI(t *testing.T) {
+	svc, chatRepo, userRepo, deliverer := newInvitationService(t)
+	remoteHost := "remote.example"
+	ownerURI := "https://remote.example/users/owner"
+	userRepo.Users["owner"] = &model.User{ID: "owner", Username: "owner", Host: &remoteHost, URI: &ownerURI}
+	userRepo.Users["alice"] = &model.User{ID: "alice", Username: "alice"}
+	// remote owner の room copy に local member alice が投稿する。
+	require.NoError(t, chatRepo.CreateRoom(&model.ChatRoom{ID: "room1", Name: "General", OwnerID: "owner"}))
+	require.NoError(t, chatRepo.CreateMembership(&model.ChatRoomMembership{ID: "mem1", UserID: "alice", RoomID: "room1"}))
+
+	_, err := svc.CreateMessageToRoom(context.Background(), "alice", "room1", "hi", "")
+	require.NoError(t, err)
+	assert.Equal(t, 1, deliverer.called)
+	// room URI は owner の host から復元した remote URI になる。
+	assert.Contains(t, string(deliverer.lastBody), "https://remote.example/chat/rooms/room1")
+}
+
+func TestCreateMessageToRoom_DeliveryFailureSwallowed(t *testing.T) {
+	svc, chatRepo, userRepo, deliverer := newInvitationService(t)
+	deliverer.returnErr = assert.AnError
+	remoteHost := "remote.example"
+	bobURI := "https://remote.example/users/bob"
+	userRepo.Users["alice"] = &model.User{ID: "alice", Username: "alice"}
+	userRepo.Users["bob"] = &model.User{ID: "bob", Username: "bob", Host: &remoteHost, URI: &bobURI}
+	require.NoError(t, chatRepo.CreateRoom(&model.ChatRoom{ID: "room1", Name: "General", OwnerID: "alice"}))
+	require.NoError(t, chatRepo.CreateMembership(&model.ChatRoomMembership{ID: "mem1", UserID: "bob", RoomID: "room1"}))
+
+	// 配送失敗してもメッセージ作成は成功する。
+	msg, err := svc.CreateMessageToRoom(context.Background(), "alice", "room1", "hi", "")
+	require.NoError(t, err)
+	require.NotNil(t, msg)
+	assert.Equal(t, 1, deliverer.called)
+}
+
+func TestCreateMessageToRoom_RemoteSenderDoesNotFederate(t *testing.T) {
+	svc, chatRepo, userRepo, deliverer := newInvitationService(t)
+	remoteHost := "remote.example"
+	senderURI := "https://remote.example/users/rmt"
+	bobURI := "https://remote.example/users/bob"
+	userRepo.Users["rmt"] = &model.User{ID: "rmt", Username: "rmt", Host: &remoteHost, URI: &senderURI}
+	userRepo.Users["bob"] = &model.User{ID: "bob", Username: "bob", Host: &remoteHost, URI: &bobURI}
+	// remote owner の room copy。sender 自身も remote member。
+	require.NoError(t, chatRepo.CreateRoom(&model.ChatRoom{ID: "room1", Name: "General", OwnerID: "rmt"}))
+	require.NoError(t, chatRepo.CreateMembership(&model.ChatRoomMembership{ID: "mem1", UserID: "bob", RoomID: "room1"}))
+
+	// remote sender が起点のメッセージは本インスタンスからは federation しない。
+	_, err := svc.CreateMessageToRoom(context.Background(), "rmt", "room1", "hi", "")
+	require.NoError(t, err)
+	assert.Equal(t, 0, deliverer.called)
 }

--- a/internal/core/chat/service.go
+++ b/internal/core/chat/service.go
@@ -638,10 +638,14 @@ func (s *Service) tryDeliverRoomMessage(msg *model.ChatMessage, room *model.Chat
 	}
 	memberURIs := make([]string, 0, len(memberIDs))
 	remoteRecipients := make([]*model.User, 0)
+	var owner *model.User
 	for uid := range memberIDs {
 		u, uerr := s.userRepo.FindByID(uid)
 		if uerr != nil || u == nil {
 			continue
+		}
+		if uid == room.OwnerID {
+			owner = u
 		}
 		if u.IsLocal() {
 			memberURIs = append(memberURIs, s.urls.UserURI(u.ID))
@@ -655,9 +659,10 @@ func (s *Service) tryDeliverRoomMessage(msg *model.ChatMessage, room *model.Chat
 	}
 
 	// room URI: local 所有なら local の正規 URI、remote 所有 copy なら owner の
-	// host から復元する (受信側は path の room id のみ抽出する)。
+	// host から復元する (受信側は path の room id のみ抽出する)。owner は member
+	// ループで既に解決済みなので使い回す。
 	roomURI := s.urls.ChatRoomURI(room.ID)
-	if owner, oerr := s.userRepo.FindByID(room.OwnerID); oerr == nil && owner != nil && !owner.IsLocal() && owner.URI != nil {
+	if owner != nil && !owner.IsLocal() && owner.URI != nil {
 		if ru := remoteChatRoomURI(*owner.URI, room.ID); ru != "" {
 			roomURI = ru
 		}

--- a/internal/core/chat/service.go
+++ b/internal/core/chat/service.go
@@ -610,7 +610,73 @@ func (s *Service) CreateMessageToRoom(ctx context.Context, fromUserID, roomID, t
 	// newChatMessage を emit する。Misskey 本家 ChatService
 	// .createMessageToRoom と同じ fan-out 方針。
 	s.emitRoomNewChatMessage(room, fromUserID, msg)
+	// remote member が居れば group Create を AP 配送する (best-effort)。
+	s.tryDeliverRoomMessage(msg, room, fromUserID)
 	return msg, nil
+}
+
+// tryDeliverRoomMessage federates a room message as a CherryPick group chat
+// Create to every remote member of the room. The note lists all members in
+// `to` and carries the room URI as its `@context`. Best-effort: no-op when AP
+// delivery is unwired, the sender is remote, or the room has no remote members.
+// Per-recipient failures are logged and swallowed.
+func (s *Service) tryDeliverRoomMessage(msg *model.ChatMessage, room *model.ChatRoom, fromUserID string) {
+	if s.deliverer == nil || s.userRepo == nil || s.renderer == nil || s.urls == nil || room == nil {
+		return
+	}
+	sender, err := s.userRepo.FindByID(fromUserID)
+	if err != nil || sender == nil || !sender.IsLocal() {
+		// remote sender が起点のメッセージは本インスタンスからは配送しない。
+		return
+	}
+	// member 集合 = owner (暗黙メンバー) + membership 行。重複は set で除外する。
+	memberIDs := map[string]struct{}{room.OwnerID: {}}
+	if members, merr := s.repo.ListMembersByRoom(room.ID); merr == nil {
+		for _, m := range members {
+			memberIDs[m.UserID] = struct{}{}
+		}
+	}
+	memberURIs := make([]string, 0, len(memberIDs))
+	remoteRecipients := make([]*model.User, 0)
+	for uid := range memberIDs {
+		u, uerr := s.userRepo.FindByID(uid)
+		if uerr != nil || u == nil {
+			continue
+		}
+		if u.IsLocal() {
+			memberURIs = append(memberURIs, s.urls.UserURI(u.ID))
+		} else if u.URI != nil && *u.URI != "" {
+			memberURIs = append(memberURIs, *u.URI)
+			remoteRecipients = append(remoteRecipients, u)
+		}
+	}
+	if len(remoteRecipients) == 0 {
+		return
+	}
+
+	// room URI: local 所有なら local の正規 URI、remote 所有 copy なら owner の
+	// host から復元する (受信側は path の room id のみ抽出する)。
+	roomURI := s.urls.ChatRoomURI(room.ID)
+	if owner, oerr := s.userRepo.FindByID(room.OwnerID); oerr == nil && owner != nil && !owner.IsLocal() && owner.URI != nil {
+		if ru := remoteChatRoomURI(*owner.URI, room.ID); ru != "" {
+			roomURI = ru
+		}
+	}
+
+	published := time.Now().UTC().Format(time.RFC3339)
+	if t, terr := s.idGen.ParseTime(msg.ID); terr == nil {
+		published = t.UTC().Format(time.RFC3339)
+	}
+	body, err := json.Marshal(s.renderer.RenderChatRoomMessage(msg, s.urls.UserURI(sender.ID), memberURIs, roomURI, published))
+	if err != nil {
+		slog.Warn("chat: room message federation: marshal failed", "msgID", msg.ID, "err", err)
+		return
+	}
+	for _, recipient := range remoteRecipients {
+		if derr := s.deliverer.DeliverToUser(sender.ID, recipient, body); derr != nil {
+			slog.Warn("chat: room message federation: deliver failed", "msgID", msg.ID, "recipient", recipient.ID, "err", derr)
+		}
+	}
 }
 
 // isRoomMemberWith reports whether userID is a member of the given room,


### PR DESCRIPTION
## Summary

#1200 (CherryPick 互換 group chat (room) federation) の **Sub-phase 3**。local user が room にメッセージを投稿したとき、group Create (Note + _misskey_talk + 多 recipient + note @context = room URI) を **remote member 全員** へ配送する。

## 主な変更点

### renderer
- `RenderChatRoomMessage(msg, senderURI, memberURIs, roomURI, published)`: `to` = 全 member URI、note 階層の `@context` = room URI、`_misskey_talk: true`。`AddContext` は top-level Create の context のみ設定するため、note 階層の room `@context` は残る (CherryPick の room 識別子)

### chat service
- `CreateMessageToRoom` に `tryDeliverRoomMessage` を追加: sender が local のとき owner (暗黙メンバー) + membership 行を集約し、**remote member の inbox へ group Create を best-effort deliver**
- room URI は **local 所有なら `ChatRoomURI`、remote 所有 copy なら owner host から復元** (`remoteChatRoomURI`、sub-phase 2.5 で導入)
- remote member 不在 / remote sender 起点 / AP 未配線は no-op、per-recipient 失敗は warn で swallow

### scope 外
- 非 owner member が remote room に投稿した場合の **owner 経由 re-fanout** は sub-phase 4 (inbound) で扱う。本 PR は「instance が知る remote member への直接配送」

## テスト
- renderer: 多 recipient + note @context = room URI + top-level は標準 context
- service: remote member へ配送 / local only room は no-op / remote 所有 room は owner host URI / 配送失敗 swallow / remote sender 起点は配送しない
- カバレッジ: activitypub 90.4% / core/chat 91.4% (閾値 90%↑)

```
go test ./internal/activitypub/ ./internal/core/chat/... -count=1 -cover
go build ./... && go vet ./... && gofmt -s -d .
```

## Closes / Refs
Closes #1207
Refs #1200, #1142

🤖 Generated with [Claude Code](https://claude.com/claude-code)