### PR TITLE
feat(chat): group chat federation sub-phase 4 - room message inbound

### DIFF
--- a/internal/activitypub/jsonld.go
+++ b/internal/activitypub/jsonld.go
@@ -141,7 +141,17 @@ func normalizeValue(v any) any {
 				case "@type":
 					// type 配列の処理は下の flattenType に任せる。
 					canonical = "type"
-				case "@context", "@value", "@language", "@graph", "@list":
+				case "@context":
+					// 標準 JSON-LD context (array / object / AS context URL) は後段
+					// dispatcher が使わないので破棄する。ただし CherryPick group chat
+					// は note の @context に chat room URI を string で載せる規約なので、
+					// room URI の場合のみ保持して下流 (handleChatRoomMessageCreate) が
+					// room を識別できるようにする (#1209)。
+					if s, ok := child.(string); ok && strings.Contains(s, "/chat/rooms/") {
+						out["@context"] = s
+					}
+					continue
+				case "@value", "@language", "@graph", "@list":
 					// 後段 dispatcher が使わない reserved keyword は破棄する。
 					continue
 				default:

--- a/internal/activitypub/jsonld_test.go
+++ b/internal/activitypub/jsonld_test.go
@@ -205,6 +205,20 @@ func TestNormalize_DropsContext(t *testing.T) {
 	assert.Equal(t, "Note", m["type"])
 }
 
+func TestNormalize_PreservesChatRoomContext(t *testing.T) {
+	// CherryPick group chat は note の @context に room URI を string で載せる。
+	// dispatcher が room を識別できるよう、この場合のみ @context を保持する (#1209)。
+	in := []byte(`{
+		"type": "Note",
+		"_misskey_talk": true,
+		"@context": "https://remote.example/chat/rooms/room1"
+	}`)
+	out, err := Normalize(in)
+	require.NoError(t, err)
+	m := asMap(t, out)
+	assert.Equal(t, "https://remote.example/chat/rooms/room1", m["@context"])
+}
+
 func TestNormalize_UnknownKeyPassthrough(t *testing.T) {
 	in := []byte(`{
 		"_misskey_quote": "https://example.com/notes/q1"

--- a/internal/core/chat/room_federation_test.go
+++ b/internal/core/chat/room_federation_test.go
@@ -248,6 +248,49 @@ func TestCreateMessageToRoom_DeliveryFailureSwallowed(t *testing.T) {
 	assert.Equal(t, 1, deliverer.called)
 }
 
+func TestCreateRoomMessageViaAP_PersistsForMember(t *testing.T) {
+	svc, repo := newRoomFedService(t)
+	require.NoError(t, repo.CreateRoom(&model.ChatRoom{ID: "room1", Name: "General", OwnerID: "localOwner"}))
+	require.NoError(t, repo.CreateMembership(&model.ChatRoomMembership{ID: "mem1", UserID: "rmt", RoomID: "room1"}))
+	sender := &model.User{ID: "rmt", Username: "rmt"}
+
+	uri := "https://remote.example/chat/messages/m1"
+	err := svc.CreateRoomMessageViaAP(uri, sender, "room1", "hi room")
+	require.NoError(t, err)
+	stored, ferr := repo.FindMessageByURI(uri)
+	require.NoError(t, ferr)
+	assert.Equal(t, "rmt", stored.FromUserID)
+	require.NotNil(t, stored.ToRoomID)
+	assert.Equal(t, "room1", *stored.ToRoomID)
+}
+
+func TestCreateRoomMessageViaAP_DedupByURI(t *testing.T) {
+	svc, repo := newRoomFedService(t)
+	require.NoError(t, repo.CreateRoom(&model.ChatRoom{ID: "room1", Name: "General", OwnerID: "rmt"}))
+	sender := &model.User{ID: "rmt", Username: "rmt"}
+	uri := "https://remote.example/chat/messages/m1"
+	require.NoError(t, svc.CreateRoomMessageViaAP(uri, sender, "room1", "hi"))
+	// 同一 URI の再送は重複作成しない (AP retry 対策)。
+	require.NoError(t, svc.CreateRoomMessageViaAP(uri, sender, "room1", "hi"))
+	assert.Len(t, repo.Messages, 1)
+}
+
+func TestCreateRoomMessageViaAP_UnknownRoom(t *testing.T) {
+	svc, _ := newRoomFedService(t)
+	sender := &model.User{ID: "rmt", Username: "rmt"}
+	err := svc.CreateRoomMessageViaAP("https://remote.example/chat/messages/m1", sender, "ghost", "hi")
+	assert.ErrorIs(t, err, corechat.ErrNotFound)
+}
+
+func TestCreateRoomMessageViaAP_NonMemberForbidden(t *testing.T) {
+	svc, repo := newRoomFedService(t)
+	// owner = localOwner、sender rmt は member でない。
+	require.NoError(t, repo.CreateRoom(&model.ChatRoom{ID: "room1", Name: "General", OwnerID: "localOwner"}))
+	sender := &model.User{ID: "rmt", Username: "rmt"}
+	err := svc.CreateRoomMessageViaAP("https://remote.example/chat/messages/m1", sender, "room1", "hi")
+	assert.ErrorIs(t, err, corechat.ErrForbidden)
+}
+
 func TestCreateMessageToRoom_RemoteSenderDoesNotFederate(t *testing.T) {
 	svc, chatRepo, userRepo, deliverer := newInvitationService(t)
 	remoteHost := "remote.example"

--- a/internal/core/chat/service.go
+++ b/internal/core/chat/service.go
@@ -684,6 +684,55 @@ func (s *Service) tryDeliverRoomMessage(msg *model.ChatMessage, room *model.Chat
 	}
 }
 
+// CreateRoomMessageViaAP persists a group chat (room) message received via
+// ActivityPub and streams it to local members. The sender must be a member of
+// the room (owner or membership) — this rejects messages injected by a remote
+// actor that is not part of the room. URI-based dedup handles AP retries.
+// Returns ErrNotFound when the room is unknown locally and ErrForbidden when
+// the sender is not a member, both of which the caller treats as permanent.
+func (s *Service) CreateRoomMessageViaAP(uri string, sender *model.User, roomID, text string) error {
+	if sender == nil || roomID == "" {
+		return ErrInvalidTarget
+	}
+	if uri != "" {
+		if existing, err := s.repo.FindMessageByURI(uri); err == nil && existing != nil {
+			return nil
+		}
+	}
+	room, err := s.repo.FindRoomByID(roomID)
+	if err != nil || room == nil {
+		return ErrNotFound
+	}
+	isMember, err := s.isRoomMemberWith(room, sender.ID, roomID)
+	if err != nil {
+		return err
+	}
+	if !isMember {
+		return ErrForbidden
+	}
+	msg := &model.ChatMessage{
+		ID:         s.idGen.Generate(time.Now()),
+		FromUserID: sender.ID,
+		ToRoomID:   &roomID,
+	}
+	if text != "" {
+		msg.Text = &text
+	}
+	if uri != "" {
+		msg.URI = &uri
+	}
+	if err := s.repo.CreateMessage(msg); err != nil {
+		return fmt.Errorf("create AP room message: %w", err)
+	}
+	if s.publisher != nil {
+		s.publisher.PublishRoomMessage(context.Background(), roomID, EventMessage, s.packMessageStream(msg))
+	}
+	// sender は remote なので emitRoomNewChatMessage で local member の main に
+	// newChatMessage を流す (sender 自身は対象外、未読インジケータ更新)。
+	s.emitRoomNewChatMessage(room, sender.ID, msg)
+	return nil
+}
+
 // isRoomMemberWith reports whether userID is a member of the given room,
 // reusing an already-fetched room object to avoid a second FindRoomByID.
 // The owner is treated as an implicit member even without a membership row.

--- a/internal/core/federation/chat_room_inbox.go
+++ b/internal/core/federation/chat_room_inbox.go
@@ -182,11 +182,16 @@ func chatRoomIDFromContext(raw json.RawMessage) string {
 // be a member (enforced by the chat service): unknown room or non-member is a
 // permanent condition, so it is reported as ErrUnsupportedActivity (no retry).
 func (p *Processor) handleChatRoomMessageCreate(sender *model.User, noteURI, content, roomID string) error {
+	// note id 欠落 / sender が local (loopback) は retry しても解決しない恒久的
+	// 条件なので、同関数内の room 不在・非メンバーと同じく ErrUnsupportedActivity
+	// (non-retry) に揃える。
 	if noteURI == "" {
-		return fmt.Errorf("chat room message: missing note id")
+		slog.Warn("chat room message: missing note id", "sender", sender.ID)
+		return ErrUnsupportedActivity
 	}
 	if sender.IsLocal() {
-		return fmt.Errorf("chat room message: sender %s is local (loopback?)", sender.ID)
+		slog.Warn("chat room message: sender is local (loopback?)", "sender", sender.ID)
+		return ErrUnsupportedActivity
 	}
 	if p.chatRoomReceiver == nil {
 		return ErrUnsupportedActivity

--- a/internal/core/federation/chat_room_inbox.go
+++ b/internal/core/federation/chat_room_inbox.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 
 	corechat "github.com/shiroha-a/mk/internal/core/chat"
+	"github.com/shiroha-a/mk/internal/model"
 )
 
 // ChatRoomReceiver wires the chat service's room-federation operations into the
@@ -19,6 +20,7 @@ type ChatRoomReceiver interface {
 	CreateInvitationViaAP(roomID, inviteeUserID string) error
 	AddMemberViaAP(roomID, userID string) error
 	RemoveInvitationViaAP(roomID, userID string) error
+	CreateRoomMessageViaAP(uri string, sender *model.User, roomID, text string) error
 }
 
 // SetChatRoomReceiver wires the chat room federation receiver for inbound
@@ -157,4 +159,46 @@ func (p *Processor) handleChatRoomReject(act, inner genericActivity) error {
 		return err
 	}
 	return p.chatRoomReceiver.RemoveInvitationViaAP(extractChatRoomID(group.ID), rejecter.ID)
+}
+
+// chatRoomIDFromContext extracts the room id from a group chat message note's
+// `@context`. CherryPick group messages set the note-level `@context` to the
+// room URI (a JSON string); a normal note carries the standard JSON-LD context
+// (an array) which yields "". Returns "" for non-room messages.
+func chatRoomIDFromContext(raw json.RawMessage) string {
+	if len(raw) == 0 {
+		return ""
+	}
+	var ctx string
+	if json.Unmarshal(raw, &ctx) != nil {
+		// 配列形式 (標準 JSON-LD context) は room ではない。
+		return ""
+	}
+	return extractChatRoomID(ctx)
+}
+
+// handleChatRoomMessageCreate persists an inbound group chat message into a
+// locally-known room. The room must exist locally and the remote sender must
+// be a member (enforced by the chat service): unknown room or non-member is a
+// permanent condition, so it is reported as ErrUnsupportedActivity (no retry).
+func (p *Processor) handleChatRoomMessageCreate(sender *model.User, noteURI, content, roomID string) error {
+	if noteURI == "" {
+		return fmt.Errorf("chat room message: missing note id")
+	}
+	if sender.IsLocal() {
+		return fmt.Errorf("chat room message: sender %s is local (loopback?)", sender.ID)
+	}
+	if p.chatRoomReceiver == nil {
+		return ErrUnsupportedActivity
+	}
+	if err := p.chatRoomReceiver.CreateRoomMessageViaAP(noteURI, sender, roomID, content); err != nil {
+		// 未関与の room / 非メンバー送信は retry しても解決しないので drop。
+		if errors.Is(err, corechat.ErrNotFound) ||
+			errors.Is(err, corechat.ErrForbidden) ||
+			errors.Is(err, corechat.ErrInvalidTarget) {
+			return ErrUnsupportedActivity
+		}
+		return err
+	}
+	return nil
 }

--- a/internal/core/federation/chat_room_inbox_test.go
+++ b/internal/core/federation/chat_room_inbox_test.go
@@ -1,6 +1,7 @@
 package federation_test
 
 import (
+	"context"
 	"errors"
 	"testing"
 
@@ -11,14 +12,34 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+// fakeChatMessageReceiver is a stub for the 1-on-1 chat path so tests can
+// distinguish 1-on-1 routing from group (room) routing.
+type fakeChatMessageReceiver struct{ calls int }
+
+func (f *fakeChatMessageReceiver) CreateMessageViaAP(_ context.Context, _ string, _ *model.User, _, _ string) (*model.ChatMessage, error) {
+	f.calls++
+	return &model.ChatMessage{}, nil
+}
+
 // fakeChatRoomReceiver records inbound chat room federation calls.
 type fakeChatRoomReceiver struct {
 	ensureCalls [][4]string // roomID, name, summary, ownerUserID
 	inviteCalls [][2]string // roomID, inviteeUserID
 	memberCalls [][2]string // roomID, userID
 	removeCalls [][2]string // roomID, userID
+	msgCalls    [][3]string // roomID, senderID, text
 	ensureErr   error
 	inviteErr   error
+	msgErr      error
+}
+
+func (f *fakeChatRoomReceiver) CreateRoomMessageViaAP(uri string, sender *model.User, roomID, text string) error {
+	sid := ""
+	if sender != nil {
+		sid = sender.ID
+	}
+	f.msgCalls = append(f.msgCalls, [3]string{roomID, sid, text})
+	return f.msgErr
 }
 
 func (f *fakeChatRoomReceiver) EnsureRoomViaAP(roomID, name, summary, ownerUserID string) error {
@@ -289,6 +310,156 @@ func TestProcess_ChatRoomReject_NonGroupAndNoReceiver(t *testing.T) {
 	}`)
 	require.NoError(t, p2.Process(body2))
 	assert.Empty(t, recv.removeCalls)
+}
+
+func TestProcess_ChatRoomMessage_PersistedToRoom(t *testing.T) {
+	p, _, _, _ := newProcessor(t, aliceActor)
+	recv := &fakeChatRoomReceiver{}
+	p.SetChatRoomReceiver(recv)
+	// note の @context が room URI の group chat message。
+	body := []byte(`{
+		"type": "Create",
+		"actor": "https://remote.example/users/alice",
+		"object": {
+			"id": "https://remote.example/chat/messages/m1",
+			"type": "Note",
+			"attributedTo": "https://remote.example/users/alice",
+			"content": "hello room",
+			"to": ["https://example.com/users/bob", "https://remote.example/users/alice"],
+			"_misskey_talk": true,
+			"@context": "https://remote.example/chat/rooms/room1"
+		}
+	}`)
+	require.NoError(t, p.Process(body))
+	require.Len(t, recv.msgCalls, 1)
+	assert.Equal(t, "room1", recv.msgCalls[0][0])
+	assert.NotEmpty(t, recv.msgCalls[0][1], "sender (resolved remote actor) must be set")
+	assert.Equal(t, "hello room", recv.msgCalls[0][2])
+}
+
+func TestProcess_OneOnOneChat_NotRoutedToRoom(t *testing.T) {
+	p, repo, _, _ := newProcessor(t, aliceActor)
+	recv := &fakeChatRoomReceiver{}
+	p.SetChatRoomReceiver(recv)
+	chatMsg := &fakeChatMessageReceiver{}
+	p.SetChatService(chatMsg)
+	bobURI := "https://example.com/users/bob"
+	repo.Users["bob"] = &model.User{ID: "bob", Username: "bob", URI: &bobURI, ChatScope: "everyone"}
+	// @context が無い (room URI でない) ので 1-on-1 経路を通り room には行かない。
+	body := []byte(`{
+		"type": "Create",
+		"actor": "https://remote.example/users/alice",
+		"object": {
+			"id": "https://remote.example/chat/messages/m1",
+			"type": "Note",
+			"content": "hi bob",
+			"to": ["https://example.com/users/bob"],
+			"_misskey_talk": true
+		}
+	}`)
+	require.NoError(t, p.Process(body))
+	assert.Empty(t, recv.msgCalls, "1-on-1 message must not hit room federation")
+	assert.Equal(t, 1, chatMsg.calls, "1-on-1 message must route to the 1-on-1 chat receiver")
+}
+
+func TestProcess_ChatRoomMessage_UnknownRoomDropped(t *testing.T) {
+	p, _, _, _ := newProcessor(t, aliceActor)
+	recv := &fakeChatRoomReceiver{msgErr: corechat.ErrNotFound}
+	p.SetChatRoomReceiver(recv)
+	body := []byte(`{
+		"type": "Create",
+		"actor": "https://remote.example/users/alice",
+		"object": {
+			"id": "https://remote.example/chat/messages/m1",
+			"type": "Note",
+			"content": "x",
+			"to": ["https://remote.example/users/alice"],
+			"_misskey_talk": true,
+			"@context": "https://remote.example/chat/rooms/ghost"
+		}
+	}`)
+	// 未関与の room は ErrUnsupportedActivity で drop (retry させない)。
+	err := p.Process(body)
+	assert.ErrorIs(t, err, federation.ErrUnsupportedActivity)
+}
+
+func TestProcess_ChatRoomMessage_NonMemberDropped(t *testing.T) {
+	p, _, _, _ := newProcessor(t, aliceActor)
+	recv := &fakeChatRoomReceiver{msgErr: corechat.ErrForbidden}
+	p.SetChatRoomReceiver(recv)
+	body := []byte(`{
+		"type": "Create",
+		"actor": "https://remote.example/users/alice",
+		"object": {
+			"id": "https://remote.example/chat/messages/m1",
+			"type": "Note", "content": "x",
+			"to": ["https://remote.example/users/alice"],
+			"_misskey_talk": true,
+			"@context": "https://remote.example/chat/rooms/room1"
+		}
+	}`)
+	// 非メンバー送信は ErrUnsupportedActivity で drop。
+	assert.ErrorIs(t, p.Process(body), federation.ErrUnsupportedActivity)
+}
+
+func TestProcess_ChatRoomMessage_TransientErrorRetryable(t *testing.T) {
+	p, _, _, _ := newProcessor(t, aliceActor)
+	recv := &fakeChatRoomReceiver{msgErr: errors.New("db blip")}
+	p.SetChatRoomReceiver(recv)
+	body := []byte(`{
+		"type": "Create",
+		"actor": "https://remote.example/users/alice",
+		"object": {
+			"id": "https://remote.example/chat/messages/m1",
+			"type": "Note", "content": "x",
+			"to": ["https://remote.example/users/alice"],
+			"_misskey_talk": true,
+			"@context": "https://remote.example/chat/rooms/room1"
+		}
+	}`)
+	// 一過性エラー (DB 等) は retryable error のまま伝播させる。
+	err := p.Process(body)
+	require.Error(t, err)
+	assert.NotErrorIs(t, err, federation.ErrUnsupportedActivity)
+}
+
+func TestProcess_ChatRoomMessage_NoReceiverIsUnsupported(t *testing.T) {
+	p, _, _, _ := newProcessor(t, aliceActor)
+	// chatService のみ配線 (chatRoomReceiver 未配線)。group message は probe され
+	// るが room receiver が無いので未対応扱いになり、panic しない。
+	p.SetChatService(&fakeChatMessageReceiver{})
+	body := []byte(`{
+		"type": "Create",
+		"actor": "https://remote.example/users/alice",
+		"object": {
+			"id": "https://remote.example/chat/messages/m1",
+			"type": "Note", "content": "x",
+			"to": ["https://remote.example/users/alice"],
+			"_misskey_talk": true,
+			"@context": "https://remote.example/chat/rooms/room1"
+		}
+	}`)
+	assert.ErrorIs(t, p.Process(body), federation.ErrUnsupportedActivity)
+}
+
+func TestProcess_ChatRoomMessage_MissingNoteID(t *testing.T) {
+	p, _, _, _ := newProcessor(t, aliceActor)
+	recv := &fakeChatRoomReceiver{}
+	p.SetChatRoomReceiver(recv)
+	// note id が空の group message は永続化に進めない。
+	body := []byte(`{
+		"type": "Create",
+		"actor": "https://remote.example/users/alice",
+		"object": {
+			"id": "",
+			"type": "Note", "content": "x",
+			"to": ["https://remote.example/users/alice"],
+			"_misskey_talk": true,
+			"@context": "https://remote.example/chat/rooms/room1"
+		}
+	}`)
+	require.Error(t, p.Process(body))
+	assert.Empty(t, recv.msgCalls)
 }
 
 func TestProcess_NonGroupInvite_NotRoutedToChatRoom(t *testing.T) {

--- a/internal/core/federation/chat_room_inbox_test.go
+++ b/internal/core/federation/chat_room_inbox_test.go
@@ -458,7 +458,8 @@ func TestProcess_ChatRoomMessage_MissingNoteID(t *testing.T) {
 			"@context": "https://remote.example/chat/rooms/room1"
 		}
 	}`)
-	require.Error(t, p.Process(body))
+	// note id 欠落は恒久的失敗なので ErrUnsupportedActivity (retry させない)。
+	assert.ErrorIs(t, p.Process(body), federation.ErrUnsupportedActivity)
 	assert.Empty(t, recv.msgCalls)
 }
 

--- a/internal/core/federation/processor.go
+++ b/internal/core/federation/processor.go
@@ -772,16 +772,23 @@ func (p *Processor) handleCreate(act genericActivity) error {
 	}
 	// Note の `_misskey_talk` を覗き見て chat か通常 note かを分岐する。
 	// IngestNote が走る前に短絡しないと chat message が notes テーブルに
-	// 流れ込んでタイムラインを汚す。
-	if p.chatService != nil {
+	// 流れ込んでタイムラインを汚す。1-on-1 は chatService、group (room) は
+	// chatRoomReceiver が処理するのでどちらか配線済みなら probe する。
+	if p.chatService != nil || p.chatRoomReceiver != nil {
 		var probe struct {
 			Type        string          `json:"type"`
 			ID          string          `json:"id"`
 			Content     string          `json:"content"`
 			MisskeyTalk bool            `json:"_misskey_talk"`
 			To          json.RawMessage `json:"to"`
+			Context     json.RawMessage `json:"@context"`
 		}
 		if err := json.Unmarshal(act.Object, &probe); err == nil && probe.MisskeyTalk && probe.Type == "Note" {
+			// note の @context が room URI なら group chat message (#1209)。
+			// それ以外は従来の 1-on-1 DM。
+			if roomID := chatRoomIDFromContext(probe.Context); roomID != "" {
+				return p.handleChatRoomMessageCreate(actor, probe.ID, probe.Content, roomID)
+			}
 			return p.handleChatCreate(actor, probe.ID, probe.Content, probe.To)
 		}
 	}
@@ -1577,6 +1584,9 @@ func readActorString(act genericActivity) (string, error) {
 // として扱う (1-on-1 DM 前提なので残りは無視)。複数 recipient (group chat)
 // は別 issue で対応。
 func (p *Processor) handleChatCreate(sender *model.User, noteURI, content string, toRaw json.RawMessage) error {
+	if p.chatService == nil {
+		return ErrUnsupportedActivity
+	}
 	if noteURI == "" {
 		return fmt.Errorf("chat create: missing note id")
 	}


### PR DESCRIPTION
## Summary

#1200 (CherryPick 互換 group chat (room) federation) の **最終 Sub-phase 4**。inbound の group chat message を room に永続化する。これで group chat federation のコア (招待ハンドシェイク + room message in/out) が一通り完結する。

## 主な変更点

### jsonld Normalize の @context 保持 (重要)
従来 `normalizeValue` は **全ての `@context` を破棄**していたが、CherryPick group chat は note の `@context` に **chat room URI を string で載せる**規約のため、dispatch 前に room id が消えていた。`/chat/rooms/` を含む string `@context` のみ保持するよう変更 (標準 JSON-LD context = array/object/AS URL は従来どおり破棄)。これが無いと inbound group message の room を識別できない。

### processor (inbound)
- `handleCreate` の chat 分岐で note の `@context` から room id を抽出 (`chatRoomIDFromContext`)。room id が取れれば `handleChatRoomMessageCreate`、無ければ従来の 1-on-1 `handleChatCreate`
- chat probe gate を `chatService != nil || chatRoomReceiver != nil` に拡張、`handleChatCreate` に chatService nil guard 追加
- `handleChatRoomMessageCreate`: room 不在 / 非メンバー / sender local は `ErrUnsupportedActivity` (non-retry)、一過性エラーは retryable のまま伝播

### chat service
- `CreateRoomMessageViaAP`: URI dedup → room 確認 → **member 検証 (非メンバーからの注入防止)** → 永続化 + PublishRoomMessage + emitRoomNewChatMessage
- `ChatRoomReceiver` interface に `CreateRoomMessageViaAP` 追加

## セキュリティ
- 受信した room message は **送信者が room の member (owner or membership) であることを検証**してから永続化。非メンバーの remote actor が room にメッセージを注入できない

## scope 外 (follow-up)
- owner 受信時の他 remote member への **re-fanout** + member list 全同期 (Add/Remove)。owner 起点配信は完全 (sub-phase 3 で全 member へ直接配送) だが、非 owner member 間の mesh 配信は owner が知る member に限られる

## テスト
- jsonld: room URI @context 保持 / 標準 context は従来どおり破棄
- service: member への永続化 / URI dedup / 未知 room (ErrNotFound) / 非メンバー (ErrForbidden)
- processor: group message → 永続化 / 1-on-1 は 1-on-1 receiver へ / 未知 room・非メンバーは drop / 一過性エラーは retryable / receiver 未配線 / note id 欠落
- カバレッジ: activitypub 90.3% / core/federation 90.0% / core/chat 91.0% (閾値 90%↑)

```
go test ./internal/activitypub/ ./internal/core/federation/ ./internal/core/chat/... -count=1 -cover
go build ./... && go vet ./... && gofmt -s -d .
```

## Closes / Refs
Closes #1209
Refs #1200, #1142

🤖 Generated with [Claude Code](https://claude.com/claude-code)