### PR TITLE
fix(stream): follow/unfollow 時に followee snapshot を live refresh (#1142 / #1063 follow-up)

### DIFF
--- a/internal/stream/channels/notifications.go
+++ b/internal/stream/channels/notifications.go
@@ -101,10 +101,41 @@ func (c *MainChannel) OnRedisEvent(payload []byte) {
 		Body json.RawMessage `json:"body"`
 	}
 	if err := json.Unmarshal(payload, &env); err == nil && env.Type != "" && len(env.Body) > 0 {
+		c.maybeRefreshFollowing(env.Type, env.Body)
 		_ = c.ctx.Send(env.Type, env.Body)
 		return
 	}
 	_ = c.ctx.Send("notification", json.RawMessage(payload))
+}
+
+// followingSnapshotUpdater is the optional capability a ChannelContext may
+// expose to mutate the connection's followee snapshot live. The main channel
+// uses it to keep timeline reply gating fresh after the viewer follows or
+// unfollows someone, without waiting for a reconnect (#1211).
+type followingSnapshotUpdater interface {
+	UpdateFollowingSnapshot(followeeID string, following bool)
+}
+
+// maybeRefreshFollowing updates the connection's followee snapshot when the
+// viewer's own follow list changes. The `follow` / `unfollow` events are
+// emitted to the actor's own `main` stream by the following service, so the
+// body is the followee user object; only its id is needed. `followed` (someone
+// followed me) does not change my follow list and is intentionally ignored.
+func (c *MainChannel) maybeRefreshFollowing(eventType string, body json.RawMessage) {
+	if eventType != "follow" && eventType != "unfollow" {
+		return
+	}
+	updater, ok := c.ctx.(followingSnapshotUpdater)
+	if !ok {
+		return
+	}
+	var u struct {
+		ID string `json:"id"`
+	}
+	if json.Unmarshal(body, &u) != nil || u.ID == "" {
+		return
+	}
+	updater.UpdateFollowingSnapshot(u.ID, eventType == "follow")
 }
 
 func (c *MainChannel) OnClientMessage(string, json.RawMessage) {}

--- a/internal/stream/channels/notifications_test.go
+++ b/internal/stream/channels/notifications_test.go
@@ -95,3 +95,45 @@ func TestMain_BadJSONEnvelopeFallsBack(t *testing.T) {
 	require.Len(t, ctx.sentType, 1)
 	assert.Equal(t, "notification", ctx.sentType[0])
 }
+
+func TestMain_FollowEventRefreshesSnapshot(t *testing.T) {
+	ctx := newCtx(&model.User{ID: "alice"})
+	ch := NewMain(ctx)
+	ch.Init(nil)
+	ch.OnRedisEvent([]byte(`{"type":"follow","body":{"id":"followee1"}}`))
+	// snapshot が follow で更新される (followee1 を following=true で追加)。
+	require.Len(t, ctx.followingUpd, 1)
+	assert.Equal(t, followingUpdate{"followee1", true}, ctx.followingUpd[0])
+	// client へも従来どおり転送される。
+	assert.Equal(t, []string{"follow"}, ctx.sentType)
+}
+
+func TestMain_UnfollowEventRefreshesSnapshot(t *testing.T) {
+	ctx := newCtx(&model.User{ID: "alice"})
+	ch := NewMain(ctx)
+	ch.Init(nil)
+	ch.OnRedisEvent([]byte(`{"type":"unfollow","body":{"id":"followee1"}}`))
+	require.Len(t, ctx.followingUpd, 1)
+	assert.Equal(t, followingUpdate{"followee1", false}, ctx.followingUpd[0])
+}
+
+func TestMain_FollowedEventDoesNotRefreshSnapshot(t *testing.T) {
+	ctx := newCtx(&model.User{ID: "alice"})
+	ch := NewMain(ctx)
+	ch.Init(nil)
+	// `followed` (誰かが自分を follow) は自分の follow 一覧を変えないので
+	// snapshot を触らない。client へは転送される。
+	ch.OnRedisEvent([]byte(`{"type":"followed","body":{"id":"follower1"}}`))
+	assert.Empty(t, ctx.followingUpd)
+	assert.Equal(t, []string{"followed"}, ctx.sentType)
+}
+
+func TestMain_FollowEventMissingIDIgnored(t *testing.T) {
+	ctx := newCtx(&model.User{ID: "alice"})
+	ch := NewMain(ctx)
+	ch.Init(nil)
+	// id が無い follow body は snapshot 更新できないので no-op (転送は継続)。
+	ch.OnRedisEvent([]byte(`{"type":"follow","body":{"username":"x"}}`))
+	assert.Empty(t, ctx.followingUpd)
+	assert.Equal(t, []string{"follow"}, ctx.sentType)
+}

--- a/internal/stream/channels/timeline_test.go
+++ b/internal/stream/channels/timeline_test.go
@@ -23,6 +23,13 @@ type stubContext struct {
 	sendError     error
 	hardMuteRules []byte
 	followingSnap map[string]bool
+	followingUpd  []followingUpdate
+}
+
+// followingUpdate records a call to UpdateFollowingSnapshot for assertions.
+type followingUpdate struct {
+	id        string
+	following bool
 }
 
 func (s *stubContext) ID() string { return s.id }
@@ -46,6 +53,11 @@ func (s *stubContext) Unsubscribe(topic string) {
 }
 func (s *stubContext) HardMuteRules() []byte              { return s.hardMuteRules }
 func (s *stubContext) FollowingSnapshot() map[string]bool { return s.followingSnap }
+func (s *stubContext) UpdateFollowingSnapshot(followeeID string, following bool) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.followingUpd = append(s.followingUpd, followingUpdate{followeeID, following})
+}
 
 func newCtx(user any) *stubContext {
 	return &stubContext{id: "ch1", user: user}

--- a/internal/stream/connection.go
+++ b/internal/stream/connection.go
@@ -171,6 +171,38 @@ func (c *Connection) FollowingSnapshot() map[string]bool {
 	return c.followingSnapshot
 }
 
+// UpdateFollowingSnapshot mutates the live followee snapshot after a
+// follow/unfollow so reply gating stays fresh without a reconnect (#1211).
+// It is copy-on-write: a new map is built and swapped under the lock, leaving
+// any map already handed out via FollowingSnapshot() immutable for concurrent
+// readers (timeline channels iterate it outside the lock). A nil snapshot
+// (anonymous / lookup unwired) is left untouched — those connections gate on
+// the escape hatches only and never consult the snapshot.
+func (c *Connection) UpdateFollowingSnapshot(followeeID string, following bool) {
+	if followeeID == "" {
+		return
+	}
+	c.followingMu.Lock()
+	defer c.followingMu.Unlock()
+	if c.followingSnapshot == nil {
+		return
+	}
+	next := make(map[string]bool, len(c.followingSnapshot)+1)
+	for k, v := range c.followingSnapshot {
+		next[k] = v
+	}
+	if following {
+		// 新規 follow は withReplies=false (reply 表示は後から opt-in)。再 follow で
+		// 既存エントリがある場合は withReplies 設定を維持する。
+		if _, exists := next[followeeID]; !exists {
+			next[followeeID] = false
+		}
+	} else {
+		delete(next, followeeID)
+	}
+	c.followingSnapshot = next
+}
+
 // SetPermissions attaches OAuth2 permission scopes for this connection.
 // トークン経由で接続された場合に、AccessToken の permission 配列を渡す想定。
 // cookie/session 認証の場合は呼び出さない（空の permissions は権限ありとも無しとも区別できないため、

--- a/internal/stream/connection_test.go
+++ b/internal/stream/connection_test.go
@@ -317,3 +317,50 @@ func TestConnection_FollowingSnapshot(t *testing.T) {
 		t.Fatalf("FollowingSnapshot = %v, want %v", got, snap)
 	}
 }
+
+func TestConnection_UpdateFollowingSnapshot_AddRemove(t *testing.T) {
+	c := NewConnection("c1", &model.User{ID: "alice"}, newFakeConn())
+	c.SetFollowingSnapshot(map[string]bool{"u1": true})
+
+	// 新規 follow は withReplies=false で追加される。
+	c.UpdateFollowingSnapshot("u2", true)
+	got := c.FollowingSnapshot()
+	require.Len(t, got, 2)
+	assert.True(t, got["u1"], "既存エントリの withReplies は維持される")
+	assert.False(t, got["u2"], "新規 follow は withReplies=false")
+
+	// 再 follow は既存 withReplies を保持する (上書きしない)。
+	c.UpdateFollowingSnapshot("u1", true)
+	assert.True(t, c.FollowingSnapshot()["u1"])
+
+	// unfollow は削除する。
+	c.UpdateFollowingSnapshot("u1", false)
+	got = c.FollowingSnapshot()
+	require.Len(t, got, 1)
+	_, ok := got["u1"]
+	assert.False(t, ok)
+}
+
+func TestConnection_UpdateFollowingSnapshot_NilSnapshotNoOp(t *testing.T) {
+	c := NewConnection("c1", &model.User{ID: "alice"}, newFakeConn())
+	// snapshot 未設定 (anonymous/未配線) では map を作らず no-op。
+	c.UpdateFollowingSnapshot("u1", true)
+	assert.Nil(t, c.FollowingSnapshot())
+}
+
+func TestConnection_UpdateFollowingSnapshot_CopyOnWrite(t *testing.T) {
+	c := NewConnection("c1", &model.User{ID: "alice"}, newFakeConn())
+	c.SetFollowingSnapshot(map[string]bool{"u1": true})
+	// FollowingSnapshot() で得た map は更新後も不変 (copy-on-write)。
+	before := c.FollowingSnapshot()
+	c.UpdateFollowingSnapshot("u2", true)
+	_, leaked := before["u2"]
+	assert.False(t, leaked, "既に handed out した map は mutate されない")
+}
+
+func TestConnection_UpdateFollowingSnapshot_EmptyIDNoOp(t *testing.T) {
+	c := NewConnection("c1", &model.User{ID: "alice"}, newFakeConn())
+	c.SetFollowingSnapshot(map[string]bool{"u1": true})
+	c.UpdateFollowingSnapshot("", true)
+	assert.Len(t, c.FollowingSnapshot(), 1)
+}

--- a/internal/stream/dispatcher.go
+++ b/internal/stream/dispatcher.go
@@ -413,6 +413,15 @@ func (c *channelContext) FollowingSnapshot() map[string]bool {
 	return c.dispatcher.conn.FollowingSnapshot()
 }
 
+// UpdateFollowingSnapshot forwards a live follow/unfollow snapshot update to the
+// connection so reply gating stays fresh without a reconnect (#1211).
+func (c *channelContext) UpdateFollowingSnapshot(followeeID string, following bool) {
+	if c.dispatcher.conn == nil {
+		return
+	}
+	c.dispatcher.conn.UpdateFollowingSnapshot(followeeID, following)
+}
+
 // --- readNotification / subNote / unsubNote ---
 
 // handleReadNotification marks all notifications as read for the connected user.


### PR DESCRIPTION
## Summary

#1142 TODO audit 項目。streaming connection の `followingSnapshot` (followeeID → withReplies) は #1063 で**接続確立時に1回だけ** fetch され、timeline channel の reply gating に使われる。follow/unfollow しても再接続するまで stale で、**follow 直後に相手の reply が live HTL に出ない** degrade があった。これを解消する。

## 主な変更点

### Connection.UpdateFollowingSnapshot (copy-on-write)
- 新規 follow → `withReplies=false` で追加 (reply 表示は後から opt-in)
- 再 follow → 既存 `withReplies` を維持
- unfollow → 削除
- **copy-on-write**: 新 map を作って lock 下で差し替え。`FollowingSnapshot()` で既に handed out された map は不変なので、timeline channel の per-publish read (lock 外で iterate) と **data race しない**
- snapshot nil (anonymous / lookup 未配線) は no-op (escape hatch のみで gate する設計を維持)

### MainChannel での hook
- `main:{userID}` の `follow`/`unfollow` envelope (following service が follower 自身へ publish 済) から followee id を抽出し snapshot を更新
- `followed` (誰かが自分を follow) は自分の follow 一覧を変えないので**無視**
- client への転送は従来どおり継続
- `ChannelContext` interface は広げず **optional interface (type assertion)** で実装 → mock への影響を最小化

## scope 外
- `withReplies` の途中変更 (i/following/update 相当) の refresh。本 PR は follow/unfollow の membership 変化に限定

## テスト
- Connection: add/remove / 再 follow で withReplies 維持 / nil snapshot no-op / **copy-on-write** (handed out map 不変) / 空 id no-op
- MainChannel: follow/unfollow で snapshot 更新 + client 転送 / followed は更新しない / id 欠落は no-op
- `-race` 付きで pass。カバレッジ stream 91.2% / channels 94.2% (閾値 90%↑)

```
go test ./internal/stream/... -race -count=1 -cover
go build ./... && go vet ./... && gofmt -s -d .
```

## Closes / Refs
Closes #1211
Refs #1142, #1063

🤖 Generated with [Claude Code](https://claude.com/claude-code)