### PR TITLE
docs(server): fast JSON encoder の調査結論を記録 + stale comment 修正 (#1142)

### DIFF
--- a/internal/server/json_serializer.go
+++ b/internal/server/json_serializer.go
@@ -9,11 +9,17 @@ import (
 	"github.com/labstack/echo/v4"
 )
 
-// fastJSONSerializer was previously backed by goccy/go-json (#507) but
-// goccy v0.10.6 panics with `ptrToString` nil-deref on certain hot path
-// payloads (timeline notes containing remote users). 一旦 stdlib
-// `encoding/json` に戻して安定運用、performance 改善は別 issue で
-// goccy 上げ or 別 encoder 検討。
+// fastJSONSerializer is the echo JSONSerializer used for all c.JSON / c.Bind
+// paths. It is intentionally backed by the stdlib `encoding/json`.
+//
+// 経緯 (#1142 で調査確定): #507 で goccy/go-json に差し替えたが、v0.10.6 が
+// remote Renote-with-Files を含む timeline payload で `ptrToString` nil-deref
+// panic を起こすため revert した (#542)。v0.10.6 は goccy の最新版であり
+// bump で回避する道は無い (dead end)。bytedance/sonic も評価したが、重量級の
+// JIT 依存 + arch 制約 + 独自 panic surface があり、JSON encode の限定的な
+// perf gain に対して drop-in 互換性最優先の server には blast radius が大き
+// すぎるため見送った。したがって stdlib を意図的な恒久選択とする。vetted な
+// 高速 encoder が現れたら再検討する。
 type fastJSONSerializer struct{}
 
 // Serialize writes i as JSON to the response. indent が空でなければ

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -169,8 +169,9 @@ func New(cfg *config.Config, db *gorm.DB, redis *cache.RedisClients) (*Server, e
 	e := echo.New()
 	e.HideBanner = true
 	e.HidePort = true
-	// echo の c.JSON / c.Bind 経路を goccy/go-json に差し替える (#507)。
-	// reflection cost が下がって全 endpoint が広く高速化する。
+	// 全 endpoint の c.JSON / c.Bind を共通 serializer に通す。実体は stdlib
+	// encoding/json (fastJSONSerializer の doc 参照: goccy は #542 の panic で
+	// revert、高速 encoder 化は #1142 で見送り)。
 	e.JSONSerializer = fastJSONSerializer{}
 
 	// trustProxyからIPExtractorを構成。詳細は buildIPExtractor のコメント。


### PR DESCRIPTION
## Summary

#1142 TODO audit の「fast JSON encoder 復活検討」項目の**調査結論を記録**する。挙動変更なし(comment のみ)。

## 調査結論
- goccy/go-json は #507 で導入したが v0.10.6 が remote Renote-with-Files を含む timeline payload で `ptrToString` nil-deref panic を起こし revert 済 (#542)
- **v0.10.6 が goccy の最新版**であり、bump で panic を回避する道は無い (dead end)
- bytedance/sonic も評価したが、重量級 JIT 依存 + arch 制約 + 独自 panic surface があり、JSON encode の限定的 perf gain に対し drop-in 互換性最優先の server には blast radius が大きすぎるため見送り
- stdlib `encoding/json` を**意図的な恒久選択**として明文化

## 変更点
- `json_serializer.go`: `fastJSONSerializer` の doc を調査結論に更新
- `server.go`: serializer 配線 comment が「goccy/go-json に差し替える」と **stale** だったのを stdlib 実体に合わせて修正

## テスト
- 挙動変更なし。build / vet / gofmt クリーン、既存 serializer テスト pass

## Closes / Refs
Closes #1213
Refs #1142

🤖 Generated with [Claude Code](https://claude.com/claude-code)