### PR TITLE
feat(chat): drive/files/attached-chat-messages 実装 + 検証で判明した false stub cleanup (#1217)

### DIFF
--- a/internal/api/chat/handler.go
+++ b/internal/api/chat/handler.go
@@ -269,10 +269,14 @@ func (h *Handler) AttachedChatMessages(c echo.Context) error {
 		UntilDate *int64 `json:"untilDate"`
 	}
 	if err := c.Bind(&req); err != nil || req.FileID == "" {
-		return c.JSON(http.StatusBadRequest, apierr.Error("INVALID_PARAM", "fileId is required.", "ed1d7571-a3ac-4370-899c-0dbe5e230cc8"))
+		return c.JSON(http.StatusBadRequest, apierr.Error("INVALID_PARAM", "fileId is required.", "6b7f9d2c-1e4a-4b8c-9d3e-7a5f0c2b1e88"))
 	}
-	if req.Limit <= 0 || req.Limit > 100 {
+	// upstream paramDef は limit を minimum:1 / maximum:100 / default:10 で
+	// clamp する。> 100 は default に落とさず max へ clamp して挙動を揃える。
+	if req.Limit <= 0 {
 		req.Limit = 10
+	} else if req.Limit > 100 {
+		req.Limit = 100
 	}
 	if h.fileRepo == nil {
 		return c.JSON(http.StatusOK, []any{})

--- a/internal/api/chat/handler.go
+++ b/internal/api/chat/handler.go
@@ -25,7 +25,25 @@ type Handler struct {
 	repo  repository.ChatRepository
 	idGen id.Generator
 	svc   *corechat.Service
+	// fileRepo / moderatorChecker は drive/files/attached-chat-messages 用
+	// (#1218)。fileId の owner 検証 (moderator は任意 file 可) に使う。未配線
+	// 時は当該 endpoint が空配列を返す。
+	fileRepo         repository.DriveFileRepository
+	moderatorChecker ModeratorChecker
 }
+
+// ModeratorChecker reports whether a user has moderator privileges. Implemented
+// by core/role.Service. Used to widen attached-chat-messages from owner-only to
+// any file for moderators (upstream `userId: isModerator ? undefined : me.id`).
+type ModeratorChecker interface {
+	IsModerator(userID string) bool
+}
+
+// SetDriveFileRepo wires the drive file repository for attached-chat-messages.
+func (h *Handler) SetDriveFileRepo(r repository.DriveFileRepository) { h.fileRepo = r }
+
+// SetModeratorChecker wires a moderator checker for attached-chat-messages.
+func (h *Handler) SetModeratorChecker(m ModeratorChecker) { h.moderatorChecker = m }
 
 // NewHandler creates a new chat handler.
 func NewHandler(repo repository.ChatRepository, idGen id.Generator) *Handler {
@@ -234,6 +252,51 @@ func packUser(u *model.User) map[string]any {
 		"isBot":          u.IsBot,
 		"isCat":          u.IsCat,
 	}
+}
+
+// AttachedChatMessages handles POST /api/drive/files/attached-chat-messages.
+// 指定 drive file を添付した chat message を newest-first で返す。upstream
+// (read:drive) と同じく file は owner-scope で引く (moderator は任意 file 可)。
+// 連合互換: res は ChatMessage の配列 (packMessageDetailed)。
+func (h *Handler) AttachedChatMessages(c echo.Context) error {
+	user := middleware.GetUser(c)
+	var req struct {
+		FileID    string `json:"fileId"`
+		Limit     int    `json:"limit"`
+		SinceID   string `json:"sinceId"`
+		UntilID   string `json:"untilId"`
+		SinceDate *int64 `json:"sinceDate"`
+		UntilDate *int64 `json:"untilDate"`
+	}
+	if err := c.Bind(&req); err != nil || req.FileID == "" {
+		return c.JSON(http.StatusBadRequest, apierr.Error("INVALID_PARAM", "fileId is required.", "ed1d7571-a3ac-4370-899c-0dbe5e230cc8"))
+	}
+	if req.Limit <= 0 || req.Limit > 100 {
+		req.Limit = 10
+	}
+	if h.fileRepo == nil {
+		return c.JSON(http.StatusOK, []any{})
+	}
+	file, err := h.fileRepo.FindByID(req.FileID)
+	if err != nil || file == nil {
+		return apierr.JSONNoSuchFile(c)
+	}
+	// owner-scope: moderator 以外は自分の file のみ参照可 (他人の private chat
+	// の添付を覗けないようにする)。
+	isMod := h.moderatorChecker != nil && h.moderatorChecker.IsModerator(user.ID)
+	if !isMod && (file.UserID == nil || *file.UserID != user.ID) {
+		return apierr.JSONNoSuchFile(c)
+	}
+	sinceID, untilID := id.NormalizeCursor(req.SinceID, req.UntilID, req.SinceDate, req.UntilDate)
+	msgs, err := h.repo.ListMessagesByFileID(req.FileID, untilID, sinceID, req.Limit)
+	if err != nil {
+		return apierr.JSONInternalError(c)
+	}
+	out := make([]map[string]any, 0, len(msgs))
+	for _, m := range msgs {
+		out = append(out, h.packMessageDetailed(m, user.ID))
+	}
+	return c.JSON(http.StatusOK, out)
 }
 
 // --- Rooms ---

--- a/internal/api/chat/handler_test.go
+++ b/internal/api/chat/handler_test.go
@@ -942,3 +942,80 @@ func TestMembersUpdateMembership_Auth(t *testing.T) {
 	// not a member → 404
 	assert.Equal(t, http.StatusNotFound, post(h.MembersUpdateMembership, `{"roomId":"r1","userId":"ghost"}`, u1).Code)
 }
+
+// --- AttachedChatMessages (#1218) ---
+
+type fakeModeratorChecker struct{ mods map[string]bool }
+
+func (f fakeModeratorChecker) IsModerator(userID string) bool { return f.mods[userID] }
+
+func attachedHandler(t *testing.T) (*Handler, *testutil.MockChatRepository, *testutil.MockDriveFileRepository) {
+	t.Helper()
+	h, repo := newTestHandler()
+	fileRepo := testutil.NewMockDriveFileRepository()
+	h.SetDriveFileRepo(fileRepo)
+	h.SetModeratorChecker(fakeModeratorChecker{mods: map[string]bool{"mod1": true}})
+	return h, repo, fileRepo
+}
+
+func seedFileMsg(repo *testutil.MockChatRepository, id, fileID string) {
+	fid := fileID
+	to := "u9"
+	repo.Messages[id] = &model.ChatMessage{ID: id, FromUserID: "sender", ToUserID: &to, FileID: &fid}
+}
+
+func TestAttachedChatMessages_OwnerSeesMessages(t *testing.T) {
+	h, repo, fileRepo := attachedHandler(t)
+	owner := u1.ID
+	fileRepo.Files["f1"] = &model.DriveFile{ID: "f1", UserID: &owner}
+	seedFileMsg(repo, "m1", "f1")
+	seedFileMsg(repo, "m2", "f1")
+	seedFileMsg(repo, "m3", "other") // 別 file は除外
+
+	rec := post(h.AttachedChatMessages, `{"fileId":"f1"}`, u1)
+	assert.Equal(t, http.StatusOK, rec.Code)
+	var out []map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &out))
+	assert.Len(t, out, 2)
+}
+
+func TestAttachedChatMessages_NonOwnerRejected(t *testing.T) {
+	h, repo, fileRepo := attachedHandler(t)
+	owner := u1.ID
+	fileRepo.Files["f1"] = &model.DriveFile{ID: "f1", UserID: &owner}
+	seedFileMsg(repo, "m1", "f1")
+	// u2 は owner でも moderator でもない → NoSuchFile。
+	rec := post(h.AttachedChatMessages, `{"fileId":"f1"}`, u2)
+	assert.Equal(t, http.StatusBadRequest, rec.Code)
+}
+
+func TestAttachedChatMessages_ModeratorSeesOthersFile(t *testing.T) {
+	h, repo, fileRepo := attachedHandler(t)
+	owner := u1.ID
+	fileRepo.Files["f1"] = &model.DriveFile{ID: "f1", UserID: &owner}
+	seedFileMsg(repo, "m1", "f1")
+	rec := post(h.AttachedChatMessages, `{"fileId":"f1"}`, &model.User{ID: "mod1"})
+	assert.Equal(t, http.StatusOK, rec.Code)
+	var out []map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &out))
+	assert.Len(t, out, 1)
+}
+
+func TestAttachedChatMessages_MissingFileID(t *testing.T) {
+	h, _, _ := attachedHandler(t)
+	rec := post(h.AttachedChatMessages, `{}`, u1)
+	assert.Equal(t, http.StatusBadRequest, rec.Code)
+}
+
+func TestAttachedChatMessages_NoSuchFile(t *testing.T) {
+	h, _, _ := attachedHandler(t)
+	rec := post(h.AttachedChatMessages, `{"fileId":"ghost"}`, u1)
+	assert.Equal(t, http.StatusBadRequest, rec.Code)
+}
+
+func TestAttachedChatMessages_NoFileRepoReturnsEmpty(t *testing.T) {
+	h, _ := newTestHandler() // fileRepo 未配線
+	rec := post(h.AttachedChatMessages, `{"fileId":"f1"}`, u1)
+	assert.Equal(t, http.StatusOK, rec.Code)
+	assert.Equal(t, "[]\n", rec.Body.String())
+}

--- a/internal/api/drive/handler.go
+++ b/internal/api/drive/handler.go
@@ -668,12 +668,6 @@ func (h *Handler) FilesAttachedNotes(c echo.Context) error {
 	return c.JSON(http.StatusOK, out)
 }
 
-// FilesAttachedChatMessages handles POST /api/drive/files/attached-chat-messages.
-func (h *Handler) FilesAttachedChatMessages(c echo.Context) error {
-	// チャットメッセージの添付ファイル検索（簡易版: 空配列）
-	return c.JSON(http.StatusOK, []any{})
-}
-
 // FilesUploadFromURL handles POST /api/drive/files/upload-from-url.
 func (h *Handler) FilesUploadFromURL(c echo.Context) error {
 	// URL経由のファイルアップロード（非同期処理: 204返却）

--- a/internal/api/drive/handler_test.go
+++ b/internal/api/drive/handler_test.go
@@ -937,13 +937,6 @@ func TestFilesAttachedNotes_ForwardsCursorParams(t *testing.T) {
 	assert.Equal(t, 7, spy.gotLimit)
 }
 
-func TestFilesAttachedChatMessages(t *testing.T) {
-	h, _, _ := newHandler(t)
-	c, rec := newJSONReq(t, `{"fileId":"f1"}`)
-	require.NoError(t, h.FilesAttachedChatMessages(c))
-	assert.Equal(t, http.StatusOK, rec.Code)
-}
-
 func TestFilesUploadFromURL(t *testing.T) {
 	h, _, _ := newHandler(t)
 	c, rec := newJSONReq(t, `{"url":"https://example.com/img.png"}`)

--- a/internal/api/i/handler.go
+++ b/internal/api/i/handler.go
@@ -662,9 +662,11 @@ func (h *Handler) Me(c echo.Context) error {
 	resp["isAdmin"] = isAdmin
 	resp["isModerator"] = isMod
 	// isDeleted / isExplorable は PackMeDetailed 由来で base 展開済 (#971)。
-	// 未読系フィールドを依存する repo / service から実際に引く。
-	// 未wireのものは false/0/[] にフォールバックする (テスト互換)。
-	// antenna / channel / specifiedNotes は別issueで追跡中のためここでは false 固定。
+	// 未読系フィールドを依存する repo / service から実際に引く
+	// (hasUnreadAntenna / hasUnreadChannel は antennaUnreadRepo /
+	// channelUnreadRepo、hasUnreadSpecifiedNotes は notificationSvc.UnreadSummary
+	// 経由で fillUnreadFields が populate する)。未wireのものは false/0/[] に
+	// フォールバックする (テスト互換)。
 	h.fillUnreadFields(c.Request().Context(), u, resp)
 	h.fillPinnedFields(c.Request().Context(), u, profile, resp)
 	resp["policies"] = userPolicies

--- a/internal/api/i/handler_extra.go
+++ b/internal/api/i/handler_extra.go
@@ -180,12 +180,6 @@ func (h *Handler) Favorites(c echo.Context) error {
 	return c.JSON(http.StatusOK, result)
 }
 
-// NotificationsGrouped handles POST /api/i/notifications-grouped.
-// フロントエンドがブート直後に呼ぶ。簡易版として空配列を返す。
-func (h *Handler) NotificationsGrouped(c echo.Context) error {
-	return c.JSON(http.StatusOK, []any{})
-}
-
 // RegenerateToken handles POST /api/i/regenerate-token.
 func (h *Handler) RegenerateToken(c echo.Context) error {
 	u := middleware.GetUser(c)

--- a/internal/api/i/handler_extra_test.go
+++ b/internal/api/i/handler_extra_test.go
@@ -284,14 +284,6 @@ func TestFavorites_UntilIDPaginates(t *testing.T) {
 	}
 }
 
-// --- NotificationsGrouped ---
-
-func TestNotificationsGrouped(t *testing.T) {
-	h, _ := newExtraHandler(t)
-	rec := postExtra(h.NotificationsGrouped, `{}`, &model.User{ID: "u1"})
-	assert.Equal(t, http.StatusOK, rec.Code)
-}
-
 // --- RegenerateToken ---
 
 func TestRegenerateToken_Success(t *testing.T) {

--- a/internal/repository/chat.go
+++ b/internal/repository/chat.go
@@ -23,6 +23,10 @@ type ChatRepository interface {
 	DeleteMessage(id string) error
 	ListMessagesByRoom(roomID string, limit int) ([]*model.ChatMessage, error)
 	ListMessagesByUser(userID, otherUserID string, limit int) ([]*model.ChatMessage, error)
+	// ListMessagesByFileID returns chat messages that attached the given drive
+	// file, newest-first, with id-cursor pagination. Used by
+	// drive/files/attached-chat-messages.
+	ListMessagesByFileID(fileID, untilID, sinceID string, limit int) ([]*model.ChatMessage, error)
 	SearchMessages(userID, query string, limit int) ([]*model.ChatMessage, error)
 
 	// Membership operations
@@ -165,6 +169,25 @@ func (r *chatRepository) ListMessagesByRoom(roomID string, limit int) ([]*model.
 	var msgs []*model.ChatMessage
 	if err := r.db.Preload("FromUser").Preload("File").Where(`"toRoomId" = ?`, roomID).
 		Order(`"id" DESC`).Limit(limit).Find(&msgs).Error; err != nil {
+		return nil, err
+	}
+	return msgs, nil
+}
+
+func (r *chatRepository) ListMessagesByFileID(fileID, untilID, sinceID string, limit int) ([]*model.ChatMessage, error) {
+	if limit <= 0 {
+		limit = 10
+	}
+	q := r.db.Preload("FromUser").Preload("ToUser").Preload("ToRoom").Preload("File").
+		Where(`"fileId" = ?`, fileID)
+	if untilID != "" {
+		q = q.Where(`"id" < ?`, untilID)
+	}
+	if sinceID != "" {
+		q = q.Where(`"id" > ?`, sinceID)
+	}
+	var msgs []*model.ChatMessage
+	if err := q.Order(`"id" DESC`).Limit(limit).Find(&msgs).Error; err != nil {
 		return nil, err
 	}
 	return msgs, nil

--- a/internal/repository/chat_test.go
+++ b/internal/repository/chat_test.go
@@ -567,3 +567,48 @@ func TestChatRepository_Invitation(t *testing.T) {
 	// DeleteInvitation
 	require.NoError(t, repo.DeleteInvitation("inv_1"))
 }
+
+func TestChatRepository_ListMessagesByFileID(t *testing.T) {
+	repo := NewChatRepository(testDB)
+	user := insertTestUser(t, "u_chat_file", "chatfileuser")
+	defer cleanupUser(t, user.ID)
+
+	fileX := "file_x"
+	other := "file_y"
+	mk := func(id, fileID string) *model.ChatMessage {
+		f := fileID
+		to := user.ID
+		return &model.ChatMessage{
+			ID: id, FromUserID: user.ID, ToUserID: &to, FileID: &f,
+			Reads: pq.StringArray{}, Reactions: pq.StringArray{},
+		}
+	}
+	for _, m := range []*model.ChatMessage{mk("cmf_1", fileX), mk("cmf_2", fileX), mk("cmf_3", other)} {
+		require.NoError(t, repo.CreateMessage(m))
+		defer testDB.Exec(`DELETE FROM "chat_message" WHERE id = ?`, m.ID)
+	}
+
+	// fileX の message だけが newest-first で返る。
+	msgs, err := repo.ListMessagesByFileID(fileX, "", "", 10)
+	require.NoError(t, err)
+	require.Len(t, msgs, 2)
+	assert.Equal(t, "cmf_2", msgs[0].ID)
+	assert.Equal(t, "cmf_1", msgs[1].ID)
+
+	// untilID cursor: cmf_2 より前 (= cmf_1) のみ。
+	older, err := repo.ListMessagesByFileID(fileX, "cmf_2", "", 10)
+	require.NoError(t, err)
+	require.Len(t, older, 1)
+	assert.Equal(t, "cmf_1", older[0].ID)
+
+	// sinceID cursor: cmf_1 より後 (= cmf_2) のみ。
+	newer, err := repo.ListMessagesByFileID(fileX, "", "cmf_1", 10)
+	require.NoError(t, err)
+	require.Len(t, newer, 1)
+	assert.Equal(t, "cmf_2", newer[0].ID)
+
+	// default limit (0 → 10)。
+	def, err := repo.ListMessagesByFileID(fileX, "", "", 0)
+	require.NoError(t, err)
+	assert.Len(t, def, 2)
+}

--- a/internal/server/router.go
+++ b/internal/server/router.go
@@ -1457,7 +1457,8 @@ func (s *Server) setupRoutes() {
 	api.POST("/drive/files/find", driveHandler.FilesFind, middleware.RequireAuth())
 	api.POST("/drive/files/check-existence", driveHandler.FilesCheckExistence, middleware.RequireAuth())
 	api.POST("/drive/files/attached-notes", driveHandler.FilesAttachedNotes, middleware.RequireAuth())
-	api.POST("/drive/files/attached-chat-messages", driveHandler.FilesAttachedChatMessages, middleware.RequireAuth())
+	// drive/files/attached-chat-messages は chat message を pack するため chat
+	// handler 側で処理する (route 登録は chatHandler 構築後、#1218)。
 	api.POST("/drive/files/upload-from-url", driveHandler.FilesUploadFromURL, middleware.RequireAuth())
 	api.POST("/drive/files/move-bulk", driveHandler.FilesMoveBulk, middleware.RequireAuth())
 	api.POST("/drive/stream", driveHandler.Stream, middleware.RequireAuth())
@@ -2159,6 +2160,11 @@ func (s *Server) setupRoutes() {
 	// chat/* — Misskey v2026 チャット機能 (実データ)
 	chatHandler := apichat.NewHandler(chatRepo, idGen)
 	chatHandler.SetService(chatService)
+	// drive/files/attached-chat-messages: chat message を pack するため chat
+	// handler が処理する。file の owner-scope (moderator は任意 file 可) (#1218)。
+	chatHandler.SetDriveFileRepo(driveFileRepo)
+	chatHandler.SetModeratorChecker(roleService)
+	api.POST("/drive/files/attached-chat-messages", chatHandler.AttachedChatMessages, middleware.RequireAuth())
 	api.POST("/chat/rooms/create", chatHandler.RoomsCreate, middleware.RequireAuth())
 	api.POST("/chat/rooms/show", chatHandler.RoomsShow, middleware.RequireAuth())
 	api.POST("/chat/rooms/update", chatHandler.RoomsUpdate, middleware.RequireAuth())

--- a/internal/testutil/mock_chat.go
+++ b/internal/testutil/mock_chat.go
@@ -1,6 +1,7 @@
 package testutil
 
 import (
+	"sort"
 	"sync"
 
 	"github.com/shiroha-a/mk/internal/model"
@@ -177,6 +178,32 @@ func (m *MockChatRepository) ListMessagesByRoom(_ string, _ int) ([]*model.ChatM
 
 func (m *MockChatRepository) ListMessagesByUser(_, _ string, _ int) ([]*model.ChatMessage, error) {
 	return nil, nil
+}
+
+func (m *MockChatRepository) ListMessagesByFileID(fileID, untilID, sinceID string, limit int) ([]*model.ChatMessage, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if limit <= 0 {
+		limit = 10
+	}
+	var out []*model.ChatMessage
+	for _, msg := range m.Messages {
+		if msg.FileID == nil || *msg.FileID != fileID {
+			continue
+		}
+		if untilID != "" && msg.ID >= untilID {
+			continue
+		}
+		if sinceID != "" && msg.ID <= sinceID {
+			continue
+		}
+		out = append(out, msg)
+	}
+	sort.Slice(out, func(i, j int) bool { return out[i].ID > out[j].ID })
+	if len(out) > limit {
+		out = out[:limit]
+	}
+	return out, nil
 }
 
 func (m *MockChatRepository) SearchMessages(_, _ string, _ int) ([]*model.ChatMessage, error) {


### PR DESCRIPTION
## Summary

#1217 audit の section A 消化。実コード検証の結果、approved だった「safe cluster」の大半が **既に実装済 / dead code** と判明したため、実体のある1件 (attached-chat-messages) を実装し、残りを cleanup する。

## attached-chat-messages 実装 (real feature)
misskey本体に実在する endpoint で frontend (admin-file.chat.vue) が使用。mk-go では `[]` stub だった。

- chat repo に `ListMessagesByFileID(fileID, untilID, sinceID, limit)` 追加 (+ mock)
- chat handler に `AttachedChatMessages` を実装。file を **owner-scope** で取得 (moderator は任意 file 可、upstream `userId: isModerator ? undefined : me.id` 相当 → 他人の private chat の添付を覗けない)、fileId に添付された chat message を id-cursor pagination で newest-first に返す。pack は既存 `packMessageDetailed`
- router: route を drive handler stub から **chat handler に付け替え** (chat message を pack するため)、`SetDriveFileRepo` / `SetModeratorChecker(roleService)` を wire

## 検証で判明した false stub cleanup
`/review` 同様の verify-before-implement で、approved cluster の2/3が誤検出と判明:
- **notifications-grouped**: route は既に `notificationsHandler.Show` を指しており**動作中**。i handler の `NotificationsGrouped` (`[]` 返し) は **dead code (未 route)** → test ごと削除
- **i/me antenna/channel/specifiedNotes unread**: `fillUnreadFields` で**既に実装・配線済** (antennaUnreadRepo / channelUnreadRepo / UnreadSummary)。「false 固定」コメントが stale だったので実態に修正
- drive handler の `FilesAttachedChatMessages` stub → 削除 (chat handler に移管)

## テスト
- repo: `ListMessagesByFileID` (fileId filter / untilID・sinceID cursor / default limit、testcontainer)
- handler: owner 閲覧 / 非 owner 拒否 / moderator は他人 file 可 / fileId 欠落 / NoSuchFile / fileRepo 未配線で空配列
- カバレッジ: repository 90.0% / api/chat 91.8% / api/drive 91.7% / api/i 90.5% (閾値クリア)

```
go test ./internal/repository/ ./internal/api/chat/... ./internal/api/drive/... ./internal/api/i/... -count=1 -cover
go build ./... && go vet ./... && gofmt -s -d .
```

## Closes / Refs
Closes #1218
Refs #1217

🤖 Generated with [Claude Code](https://claude.com/claude-code)