### PR TITLE
feat(api): /fetch-external-resources を実装 (integrity-checked external fetch) (#1217)

### DIFF
--- a/internal/api/fetchexternal/handler.go
+++ b/internal/api/fetchexternal/handler.go
@@ -1,0 +1,103 @@
+// Package fetchexternal implements POST /api/fetch-external-resources, an
+// integrity-checked fetch of an external JSON resource ({type, data}). The
+// caller supplies the resource URL and the expected sha512 of its `data`
+// field; the server fetches the URL (via an SSRF-safe client), verifies the
+// hash, and returns the resource. Used by the frontend to load external
+// themes / plugins / assets whose content hash is already known.
+//
+// Mirrors Misskey TS endpoints/fetch-external-resources.ts.
+package fetchexternal
+
+import (
+	"context"
+	"crypto/sha512"
+	"encoding/hex"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+	"time"
+
+	"github.com/labstack/echo/v4"
+	"github.com/shiroha-a/mk/internal/api/apierr"
+)
+
+// FetchTimeout matches the upstream `timeout: 5000` ms.
+const FetchTimeout = 5 * time.Second
+
+// maxBodyBytes caps the external response size to avoid memory abuse. External
+// theme/plugin JSON is small; 5 MiB is generous.
+const maxBodyBytes = 5 << 20
+
+// Handler serves fetch-external-resources via an outbound HTTP client.
+type Handler struct {
+	httpClient *http.Client
+	userAgent  string
+}
+
+// New builds a Handler bound to the given (SSRF-safe) outbound HTTP client and
+// User-Agent.
+func New(httpClient *http.Client, userAgent string) *Handler {
+	return &Handler{httpClient: httpClient, userAgent: userAgent}
+}
+
+// Fetch handles POST /api/fetch-external-resources.
+func (h *Handler) Fetch(c echo.Context) error {
+	var req struct {
+		URL  string `json:"url"`
+		Hash string `json:"hash"`
+	}
+	if err := c.Bind(&req); err != nil || req.URL == "" || req.Hash == "" {
+		return c.JSON(http.StatusBadRequest, apierr.Error("INVALID_PARAM", "url and hash are required.", "e1c2a7b4-9f3d-4a61-8b2e-7c5d0f1a2b33"))
+	}
+	if u, err := url.Parse(req.URL); err != nil || u.Host == "" || (u.Scheme != "http" && u.Scheme != "https") {
+		return c.JSON(http.StatusBadRequest, apierr.Error("INVALID_PARAM", "url must be http(s).", "e1c2a7b4-9f3d-4a61-8b2e-7c5d0f1a2b33"))
+	}
+
+	ctx, cancel := context.WithTimeout(c.Request().Context(), FetchTimeout)
+	defer cancel()
+	httpReq, err := http.NewRequestWithContext(ctx, http.MethodGet, req.URL, nil)
+	if err != nil {
+		return h.invalidSchema(c)
+	}
+	httpReq.Header.Set("User-Agent", h.userAgent)
+	httpReq.Header.Set("Accept", "application/json")
+
+	resp, err := h.httpClient.Do(httpReq)
+	if err != nil {
+		// fetch 失敗 (DNS / SSRF block / timeout 等) も schema 取得不能として
+		// invalidSchema 扱いにする (upstream の getJson 失敗経路相当)。
+		return h.invalidSchema(c)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return h.invalidSchema(c)
+	}
+
+	body, err := io.ReadAll(io.LimitReader(resp.Body, maxBodyBytes))
+	if err != nil {
+		return h.invalidSchema(c)
+	}
+	// `data` を string として decode できなければ invalid schema。
+	var res struct {
+		Type string `json:"type"`
+		Data string `json:"data"`
+	}
+	if err := json.Unmarshal(body, &res); err != nil {
+		return h.invalidSchema(c)
+	}
+
+	// sha512(data) を CRLF 正規化してから計算する (upstream と同じ)。
+	normalized := strings.ReplaceAll(res.Data, "\r\n", "\n")
+	sum := sha512.Sum512([]byte(normalized))
+	if hex.EncodeToString(sum[:]) != req.Hash {
+		return c.JSON(http.StatusBadRequest, apierr.Error("EXT_RESOURCE_HASH_DIDNT_MATCH", "Hash did not match.", "693ba8ba-b486-40df-a174-72f8279b56a4"))
+	}
+
+	return c.JSON(http.StatusOK, map[string]any{"type": res.Type, "data": res.Data})
+}
+
+func (h *Handler) invalidSchema(c echo.Context) error {
+	return c.JSON(http.StatusBadRequest, apierr.Error("EXT_RESOURCE_RETURNED_INVALID_SCHEMA", "External resource returned invalid schema.", "bb774091-7a15-4a70-9dc5-6ac8cf125856"))
+}

--- a/internal/api/fetchexternal/handler.go
+++ b/internal/api/fetchexternal/handler.go
@@ -52,7 +52,7 @@ func (h *Handler) Fetch(c echo.Context) error {
 		return c.JSON(http.StatusBadRequest, apierr.Error("INVALID_PARAM", "url and hash are required.", "e1c2a7b4-9f3d-4a61-8b2e-7c5d0f1a2b33"))
 	}
 	if u, err := url.Parse(req.URL); err != nil || u.Host == "" || (u.Scheme != "http" && u.Scheme != "https") {
-		return c.JSON(http.StatusBadRequest, apierr.Error("INVALID_PARAM", "url must be http(s).", "e1c2a7b4-9f3d-4a61-8b2e-7c5d0f1a2b33"))
+		return c.JSON(http.StatusBadRequest, apierr.Error("INVALID_PARAM", "url must be http(s).", "f2d3b8c5-0a4e-4c72-9d1f-8b6e1a3c2d44"))
 	}
 
 	ctx, cancel := context.WithTimeout(c.Request().Context(), FetchTimeout)

--- a/internal/api/fetchexternal/handler_test.go
+++ b/internal/api/fetchexternal/handler_test.go
@@ -81,6 +81,17 @@ func TestFetch_Non2xxIsInvalidSchema(t *testing.T) {
 	assert.Contains(t, rec.Body.String(), "EXT_RESOURCE_RETURNED_INVALID_SCHEMA")
 }
 
+func TestFetch_ConnectionFailureIsInvalidSchema(t *testing.T) {
+	// 到達不能なサーバ (close 済) への fetch 失敗も invalidSchema に落ちる。
+	srv := httptest.NewServer(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {}))
+	url := srv.URL
+	srv.Close()
+	h := New(http.DefaultClient, "mk-test")
+	rec := do(t, h, `{"url":"`+url+`","hash":"x"}`)
+	assert.Equal(t, http.StatusBadRequest, rec.Code)
+	assert.Contains(t, rec.Body.String(), "EXT_RESOURCE_RETURNED_INVALID_SCHEMA")
+}
+
 func TestFetch_MissingParams(t *testing.T) {
 	h := New(http.DefaultClient, "mk-test")
 	for _, body := range []string{`{}`, `{"url":"https://e.com"}`, `{"hash":"x"}`} {

--- a/internal/api/fetchexternal/handler_test.go
+++ b/internal/api/fetchexternal/handler_test.go
@@ -1,0 +1,112 @@
+package fetchexternal
+
+import (
+	"crypto/sha512"
+	"encoding/hex"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/labstack/echo/v4"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func hashOf(data string) string {
+	sum := sha512.Sum512([]byte(strings.ReplaceAll(data, "\r\n", "\n")))
+	return hex.EncodeToString(sum[:])
+}
+
+func do(t *testing.T, h *Handler, body string) *httptest.ResponseRecorder {
+	t.Helper()
+	e := echo.New()
+	req := httptest.NewRequest(http.MethodPost, "/", strings.NewReader(body))
+	req.Header.Set(echo.HeaderContentType, echo.MIMEApplicationJSON)
+	rec := httptest.NewRecorder()
+	_ = h.Fetch(e.NewContext(req, rec))
+	return rec
+}
+
+// resourceServer serves a fixed {type, data} JSON.
+func resourceServer(t *testing.T, payload string) *httptest.Server {
+	t.Helper()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(payload))
+	}))
+	t.Cleanup(srv.Close)
+	return srv
+}
+
+func TestFetch_HashMatch(t *testing.T) {
+	data := "theme-content-string"
+	srv := resourceServer(t, `{"type":"theme","data":"`+data+`"}`)
+	h := New(srv.Client(), "mk-test")
+
+	rec := do(t, h, `{"url":"`+srv.URL+`","hash":"`+hashOf(data)+`"}`)
+	require.Equal(t, http.StatusOK, rec.Code)
+	var out map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &out))
+	assert.Equal(t, "theme", out["type"])
+	assert.Equal(t, data, out["data"])
+}
+
+func TestFetch_HashMismatch(t *testing.T) {
+	srv := resourceServer(t, `{"type":"theme","data":"actual"}`)
+	h := New(srv.Client(), "mk-test")
+	rec := do(t, h, `{"url":"`+srv.URL+`","hash":"`+hashOf("expected-different")+`"}`)
+	assert.Equal(t, http.StatusBadRequest, rec.Code)
+	assert.Contains(t, rec.Body.String(), "EXT_RESOURCE_HASH_DIDNT_MATCH")
+}
+
+func TestFetch_InvalidSchema(t *testing.T) {
+	// data が string でない → invalid schema。
+	srv := resourceServer(t, `{"type":"theme","data":{"nested":true}}`)
+	h := New(srv.Client(), "mk-test")
+	rec := do(t, h, `{"url":"`+srv.URL+`","hash":"x"}`)
+	assert.Equal(t, http.StatusBadRequest, rec.Code)
+	assert.Contains(t, rec.Body.String(), "EXT_RESOURCE_RETURNED_INVALID_SCHEMA")
+}
+
+func TestFetch_Non2xxIsInvalidSchema(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	t.Cleanup(srv.Close)
+	h := New(srv.Client(), "mk-test")
+	rec := do(t, h, `{"url":"`+srv.URL+`","hash":"x"}`)
+	assert.Equal(t, http.StatusBadRequest, rec.Code)
+	assert.Contains(t, rec.Body.String(), "EXT_RESOURCE_RETURNED_INVALID_SCHEMA")
+}
+
+func TestFetch_MissingParams(t *testing.T) {
+	h := New(http.DefaultClient, "mk-test")
+	for _, body := range []string{`{}`, `{"url":"https://e.com"}`, `{"hash":"x"}`} {
+		rec := do(t, h, body)
+		assert.Equal(t, http.StatusBadRequest, rec.Code)
+		assert.Contains(t, rec.Body.String(), "INVALID_PARAM")
+	}
+}
+
+func TestFetch_NonHTTPScheme(t *testing.T) {
+	h := New(http.DefaultClient, "mk-test")
+	rec := do(t, h, `{"url":"file:///etc/passwd","hash":"x"}`)
+	assert.Equal(t, http.StatusBadRequest, rec.Code)
+	assert.Contains(t, rec.Body.String(), "INVALID_PARAM")
+}
+
+func TestFetch_CRLFNormalizedHash(t *testing.T) {
+	// data に CRLF を含む場合、hash は LF 正規化後で計算される。
+	raw := "line1\r\nline2"
+	srv := resourceServer(t, `{"type":"t","data":`+mustJSON(raw)+`}`)
+	h := New(srv.Client(), "mk-test")
+	rec := do(t, h, `{"url":"`+srv.URL+`","hash":"`+hashOf(raw)+`"}`)
+	assert.Equal(t, http.StatusOK, rec.Code)
+}
+
+func mustJSON(s string) string {
+	b, _ := json.Marshal(s)
+	return string(b)
+}

--- a/internal/server/router.go
+++ b/internal/server/router.go
@@ -31,6 +31,7 @@ import (
 	"github.com/shiroha-a/mk/internal/api/drive"
 	apiemojis "github.com/shiroha-a/mk/internal/api/emojis"
 	apifederation "github.com/shiroha-a/mk/internal/api/federation"
+	apifetchexternal "github.com/shiroha-a/mk/internal/api/fetchexternal"
 	apifetchrss "github.com/shiroha-a/mk/internal/api/fetchrss"
 	apiflash "github.com/shiroha-a/mk/internal/api/flash"
 	"github.com/shiroha-a/mk/internal/api/following"
@@ -2388,10 +2389,11 @@ func (s *Server) setupRoutes() {
 		return c.NoContent(http.StatusNoContent)
 	}, middleware.RequireAuth())
 
-	// fetch-external-resources — URL proxy (stub)
-	api.POST("/fetch-external-resources", func(c echo.Context) error {
-		return c.JSON(http.StatusOK, map[string]any{"type": "unknown", "data": map[string]any{}})
-	})
+	// fetch-external-resources — external JSON resource を hash 検証付きで取得
+	// (#1222)。外部 theme/plugin 等を integrity-check して返す。SSRF-safe client
+	// 経由、upstream requireCredential 相当で RequireAuth を要求する。
+	fetchExternalHandler := apifetchexternal.New(s.outboundClient(apifetchexternal.FetchTimeout), s.config.UserAgent)
+	api.POST("/fetch-external-resources", fetchExternalHandler.Fetch, middleware.RequireAuth())
 
 	// fetch-rss — RSS / Atom feed プロキシ。frontend RSS / RSSTicker ウィジェット
 	// が GET で叩く実装になっているため Misskey TS と同じく allowGet 相当で


### PR DESCRIPTION
## Summary

#1217 audit。`/fetch-external-resources` は `{type:"unknown", data:{}}` 固定 stub かつ **RequireAuth 無し**だった。upstream fetch-external-resources 相当を実装する。

外部 theme / plugin / asset を **integrity-check して取得**する endpoint。caller が url と期待 sha512(`hash`) を渡し、server が url を fetch して hash 検証後に返す。

## 実装
- `internal/api/fetchexternal` handler を新設 (`fetchrss` を mirror)
- url を JSON `{type, data}` として **SSRF-safe outbound client** で fetch → `sha512(data, CRLF→LF 正規化)` が `hash` と一致すれば `{type, data}` を返す
- errors (upstream code/id 準拠):
  - JSON decode 失敗 / 非2xx / fetch 失敗 → `EXT_RESOURCE_RETURNED_INVALID_SCHEMA` (bb774091-...)
  - hash 不一致 → `EXT_RESOURCE_HASH_DIDNT_MATCH` (693ba8ba-...)
- **abuse 抑制**: timeout 5s / body cap 5MiB / http(s) scheme 制限 / SSRF-safe transport (private IP block)
- router: stub を置換し **RequireAuth を追加** (upstream requireCredential 相当)

## scope 外
- upstream の `secure: true` (OAuth app token 拒否) は mk-go に該当機構が無いため見送り。RequireAuth で credential は要求する
- rate limit (upstream 50/hour) は mk-go の rate limit 層で別途

## テスト
- hash 一致で返す / hash 不一致 → hashUnmached / data 非string → invalidSchema / 非2xx → invalidSchema / params 欠落 → INVALID_PARAM / 非http scheme 拒否 / CRLF 正規化 hash
- カバレッジ: fetchexternal 90.3% (閾値クリア、未カバーは request 構築/ReadAll エラー等の防御分岐)

```
go test ./internal/api/fetchexternal/ -count=1 -cover
go build ./... && go vet ./... && gofmt -s -d .
```

## Closes / Refs
Closes #1222
Refs #1217

🤖 Generated with [Claude Code](https://claude.com/claude-code)