### PR TITLE
fix(auth): /miauth/:session/check を実装 (3rd-party client ログイン不可) (#1224)

### DIFF
--- a/internal/api/app/handler_test.go
+++ b/internal/api/app/handler_test.go
@@ -67,6 +67,22 @@ func (m *mockAuthSessionRepo) CreateAccessToken(t *model.AccessToken) error {
 	return nil
 }
 
+func (m *mockAuthSessionRepo) FindAccessTokenBySession(session string) (*model.AccessToken, error) {
+	for _, t := range m.accessTokens {
+		if t.Session != nil && *t.Session == session {
+			return t, nil
+		}
+	}
+	return nil, assert.AnError
+}
+
+func (m *mockAuthSessionRepo) MarkAccessTokenFetched(id string) error {
+	if t, ok := m.accessTokens[id]; ok {
+		t.Fetched = true
+	}
+	return nil
+}
+
 func (m *mockAuthSessionRepo) FindAppByID(id string) (*model.App, error) {
 	a, ok := m.apps[id]
 	if !ok {

--- a/internal/api/app/handler_test.go
+++ b/internal/api/app/handler_test.go
@@ -76,11 +76,12 @@ func (m *mockAuthSessionRepo) FindAccessTokenBySession(session string) (*model.A
 	return nil, assert.AnError
 }
 
-func (m *mockAuthSessionRepo) MarkAccessTokenFetched(id string) error {
-	if t, ok := m.accessTokens[id]; ok {
+func (m *mockAuthSessionRepo) MarkAccessTokenFetched(id string) (bool, error) {
+	if t, ok := m.accessTokens[id]; ok && !t.Fetched {
 		t.Fetched = true
+		return true, nil
 	}
-	return nil
+	return false, nil
 }
 
 func (m *mockAuthSessionRepo) FindAppByID(id string) (*model.App, error) {

--- a/internal/api/auth/handler.go
+++ b/internal/api/auth/handler.go
@@ -11,6 +11,7 @@ import (
 	"github.com/labstack/echo/v4"
 	"github.com/shiroha-a/mk/internal/api/apierr"
 	"github.com/shiroha-a/mk/internal/config"
+	"github.com/shiroha-a/mk/internal/entity"
 	"github.com/shiroha-a/mk/internal/misc"
 	"github.com/shiroha-a/mk/internal/misc/id"
 	"github.com/shiroha-a/mk/internal/model"
@@ -23,12 +24,19 @@ type Handler struct {
 	repo  repository.AuthSessionRepository
 	cfg   *config.Config
 	idGen id.Generator
+	// userRepo は miauth/:session/check で承認ユーザーを UserDetailedNotMe で
+	// pack するために使う (#1224)。未配線時は user フィールドを省く。
+	userRepo repository.UserRepository
 }
 
 // NewHandler creates a new auth handler.
 func NewHandler(repo repository.AuthSessionRepository, cfg *config.Config, idGen id.Generator) *Handler {
 	return &Handler{repo: repo, cfg: cfg, idGen: idGen}
 }
+
+// SetUserRepo wires the user repository used by MiAuthCheck to pack the
+// approving user.
+func (h *Handler) SetUserRepo(r repository.UserRepository) { h.userRepo = r }
 
 // SessionGenerate handles POST /api/auth/session/generate.
 func (h *Handler) SessionGenerate(c echo.Context) error {
@@ -196,6 +204,36 @@ func (h *Handler) GenToken(c echo.Context) error {
 	}
 
 	return c.JSON(http.StatusOK, map[string]any{"token": tokenStr})
+}
+
+// MiAuthCheck handles POST /api/miauth/:session/check.
+//
+// 3rd-party クライアントは MiAuth 承認 (= GenToken で session 紐付き access
+// token 作成) 後、本 endpoint を polling して token を取得する。upstream
+// ApiServerService の /miauth/:session/check 相当: session に対応する未取得の
+// token があれば fetched=true にして {ok, token, user} を返し、無ければ
+// {ok:false} を返す。認証不要 (token をまだ持たない client が叩くため)。
+func (h *Handler) MiAuthCheck(c echo.Context) error {
+	session := c.Param("session")
+	if session == "" {
+		return c.JSON(http.StatusOK, map[string]any{"ok": false})
+	}
+	tok, err := h.repo.FindAccessTokenBySession(session)
+	if err != nil || tok == nil || tok.Session == nil || tok.Fetched {
+		// session 不在 / 既に取得済 (one-time) は ok:false。
+		return c.JSON(http.StatusOK, map[string]any{"ok": false})
+	}
+	// one-time 取得: 再 polling で二重取得されないよう fetched を立てる。
+	_ = h.repo.MarkAccessTokenFetched(tok.ID)
+
+	resp := map[string]any{"ok": true, "token": tok.Token}
+	if h.userRepo != nil {
+		if u, uerr := h.userRepo.FindByID(tok.UserID); uerr == nil && u != nil {
+			profile, _ := h.userRepo.FindProfileByUserID(u.ID)
+			resp["user"] = entity.PackUserDetailed(u, profile, h.idGen)
+		}
+	}
+	return c.JSON(http.StatusOK, resp)
 }
 
 func packSession(s *model.AuthSession) map[string]any {

--- a/internal/api/auth/handler.go
+++ b/internal/api/auth/handler.go
@@ -223,8 +223,13 @@ func (h *Handler) MiAuthCheck(c echo.Context) error {
 		// session 不在 / 既に取得済 (one-time) は ok:false。
 		return c.JSON(http.StatusOK, map[string]any{"ok": false})
 	}
-	// one-time 取得: 再 polling で二重取得されないよう fetched を立てる。
-	_ = h.repo.MarkAccessTokenFetched(tok.ID)
+	// one-time 取得: fetched=false→true の遷移をアトミックに行い、勝った
+	// リクエストだけが token を払い出す。並行 polling で同じ token が二重に
+	// 渡ることを防ぐ (上の Fetched チェックは fast path で、ここが真の関門)。
+	won, err := h.repo.MarkAccessTokenFetched(tok.ID)
+	if err != nil || !won {
+		return c.JSON(http.StatusOK, map[string]any{"ok": false})
+	}
 
 	resp := map[string]any{"ok": true, "token": tok.Token}
 	if h.userRepo != nil {

--- a/internal/api/auth/handler_test.go
+++ b/internal/api/auth/handler_test.go
@@ -133,13 +133,14 @@ func (m *mockAuthSessionRepo) FindAccessTokenBySession(session string) (*model.A
 	return nil, errNotFound
 }
 
-func (m *mockAuthSessionRepo) MarkAccessTokenFetched(id string) error {
+func (m *mockAuthSessionRepo) MarkAccessTokenFetched(id string) (bool, error) {
 	for _, t := range m.accessTokens {
-		if t.ID == id {
+		if t.ID == id && !t.Fetched {
 			t.Fetched = true
+			return true, nil
 		}
 	}
-	return nil
+	return false, nil
 }
 
 func (m *mockAuthSessionRepo) FindAppByID(appID string) (*model.App, error) {
@@ -547,6 +548,31 @@ func TestMiAuthCheck_EmptySession(t *testing.T) {
 	var out map[string]any
 	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &out))
 	assert.Equal(t, false, out["ok"])
+}
+
+// failMarkRepo は MarkAccessTokenFetched が遷移に負ける (race の敗者 / DB
+// エラー) ケースを再現するためのスタブ。
+type failMarkRepo struct {
+	*mockAuthSessionRepo
+}
+
+func (f *failMarkRepo) MarkAccessTokenFetched(string) (bool, error) { return false, errNotFound }
+
+func TestMiAuthCheck_LosesFetchRace(t *testing.T) {
+	base := newMockRepo()
+	sess := "sess-race"
+	base.accessTokens["k"] = &model.AccessToken{ID: "at1", Token: "t", UserID: "u1", Session: &sess}
+	cfg := &config.Config{URL: "http://localhost:3000"}
+	idGen, _ := id.NewGenerator("aidx")
+	h := NewHandler(&failMarkRepo{base}, cfg, idGen)
+
+	rec := postMiAuthCheck(h, sess, nil)
+	var out map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &out))
+	// 遷移に負けた (または DB エラー) リクエストは token を払い出さない。
+	assert.Equal(t, false, out["ok"])
+	_, hasToken := out["token"]
+	assert.False(t, hasToken)
 }
 
 func TestMiAuthCheck_NoUserRepoOmitsUser(t *testing.T) {

--- a/internal/api/auth/handler_test.go
+++ b/internal/api/auth/handler_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/shiroha-a/mk/internal/misc/id"
 	"github.com/shiroha-a/mk/internal/model"
 	"github.com/shiroha-a/mk/internal/server/middleware"
+	"github.com/shiroha-a/mk/internal/testutil"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -120,6 +121,24 @@ func (m *mockAuthSessionRepo) CreateAccessToken(token *model.AccessToken) error 
 		key = *token.AppID + ":" + token.UserID
 	}
 	m.accessTokens[key] = token
+	return nil
+}
+
+func (m *mockAuthSessionRepo) FindAccessTokenBySession(session string) (*model.AccessToken, error) {
+	for _, t := range m.accessTokens {
+		if t.Session != nil && *t.Session == session {
+			return t, nil
+		}
+	}
+	return nil, errNotFound
+}
+
+func (m *mockAuthSessionRepo) MarkAccessTokenFetched(id string) error {
+	for _, t := range m.accessTokens {
+		if t.ID == id {
+			t.Fetched = true
+		}
+	}
 	return nil
 }
 
@@ -463,4 +482,83 @@ func TestGenToken_CreateError(t *testing.T) {
 
 	rec := post(h.GenToken, `{"permission":["read:account"]}`, user)
 	assert.Equal(t, http.StatusInternalServerError, rec.Code)
+}
+
+// --- MiAuthCheck (#1224) ---
+
+func postMiAuthCheck(h *Handler, session string, userRepo *testutil.MockUserRepository) *httptest.ResponseRecorder {
+	e := echo.New()
+	req := httptest.NewRequest(http.MethodPost, "/", nil)
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+	c.SetParamNames("session")
+	c.SetParamValues(session)
+	if userRepo != nil {
+		h.SetUserRepo(userRepo)
+	}
+	_ = h.MiAuthCheck(c)
+	return rec
+}
+
+func TestMiAuthCheck_ReturnsTokenAndUser(t *testing.T) {
+	h, repo := newTestHandler()
+	sess := "sess-abc"
+	repo.accessTokens["k"] = &model.AccessToken{ID: "at1", Token: "secret-token", UserID: "u1", Session: &sess}
+	userRepo := testutil.NewMockUserRepository()
+	userRepo.Users["u1"] = &model.User{ID: "u1", Username: "alice"}
+
+	rec := postMiAuthCheck(h, sess, userRepo)
+	require.Equal(t, http.StatusOK, rec.Code)
+	var out map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &out))
+	assert.Equal(t, true, out["ok"])
+	assert.Equal(t, "secret-token", out["token"])
+	user, ok := out["user"].(map[string]any)
+	require.True(t, ok, "user must be present and non-null")
+	assert.Equal(t, "u1", user["id"])
+	// one-time: token は fetched 済になる。
+	assert.True(t, repo.accessTokens["k"].Fetched)
+}
+
+func TestMiAuthCheck_UnknownSession(t *testing.T) {
+	h, _ := newTestHandler()
+	rec := postMiAuthCheck(h, "ghost", nil)
+	require.Equal(t, http.StatusOK, rec.Code)
+	var out map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &out))
+	assert.Equal(t, false, out["ok"])
+	_, hasToken := out["token"]
+	assert.False(t, hasToken)
+}
+
+func TestMiAuthCheck_AlreadyFetched(t *testing.T) {
+	h, repo := newTestHandler()
+	sess := "sess-used"
+	repo.accessTokens["k"] = &model.AccessToken{ID: "at1", Token: "t", UserID: "u1", Session: &sess, Fetched: true}
+	rec := postMiAuthCheck(h, sess, nil)
+	var out map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &out))
+	assert.Equal(t, false, out["ok"], "already-fetched token must not be returned again")
+}
+
+func TestMiAuthCheck_EmptySession(t *testing.T) {
+	h, _ := newTestHandler()
+	rec := postMiAuthCheck(h, "", nil)
+	var out map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &out))
+	assert.Equal(t, false, out["ok"])
+}
+
+func TestMiAuthCheck_NoUserRepoOmitsUser(t *testing.T) {
+	h, repo := newTestHandler()
+	sess := "sess-nouser"
+	repo.accessTokens["k"] = &model.AccessToken{ID: "at1", Token: "t", UserID: "u1", Session: &sess}
+	// userRepo 未配線 → token は返るが user は省略 (null ではなく欠落)。
+	rec := postMiAuthCheck(h, sess, nil)
+	var out map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &out))
+	assert.Equal(t, true, out["ok"])
+	assert.Equal(t, "t", out["token"])
+	_, hasUser := out["user"]
+	assert.False(t, hasUser)
 }

--- a/internal/repository/auth_session.go
+++ b/internal/repository/auth_session.go
@@ -25,9 +25,11 @@ type AuthSessionRepository interface {
 	// session id (used by /miauth/:session/check to hand the token back to the
 	// 3rd-party client).
 	FindAccessTokenBySession(session string) (*model.AccessToken, error)
-	// MarkAccessTokenFetched flips the one-time `fetched` flag so a session
-	// token can only be retrieved once.
-	MarkAccessTokenFetched(id string) error
+	// MarkAccessTokenFetched atomically flips the one-time `fetched` flag from
+	// false to true and reports whether this call won the transition. Only the
+	// winner may hand the token to the client, so concurrent /check polls can
+	// never retrieve the same session token twice.
+	MarkAccessTokenFetched(id string) (bool, error)
 
 	// App lookup
 	FindAppByID(id string) (*model.App, error)
@@ -99,8 +101,17 @@ func (r *authSessionRepository) FindAccessTokenBySession(session string) (*model
 	return &token, nil
 }
 
-func (r *authSessionRepository) MarkAccessTokenFetched(id string) error {
-	return r.db.Model(&model.AccessToken{}).Where(`"id" = ?`, id).Update("fetched", true).Error
+func (r *authSessionRepository) MarkAccessTokenFetched(id string) (bool, error) {
+	// fetched=false の行だけを更新対象にすることで、並行する /check polling
+	// のうち false→true の遷移に勝った 1 リクエストだけが RowsAffected>0 を得る。
+	// これにより同一 session token が二重に払い出されることを防ぐ。
+	res := r.db.Model(&model.AccessToken{}).
+		Where(`"id" = ? AND "fetched" = false`, id).
+		Update("fetched", true)
+	if res.Error != nil {
+		return false, res.Error
+	}
+	return res.RowsAffected > 0, nil
 }
 
 func (r *authSessionRepository) CreateAccessToken(token *model.AccessToken) error {

--- a/internal/repository/auth_session.go
+++ b/internal/repository/auth_session.go
@@ -21,6 +21,13 @@ type AuthSessionRepository interface {
 	// AccessToken operations for MiAuth
 	FindAccessTokenByAppAndUser(appID, userID string) (*model.AccessToken, error)
 	CreateAccessToken(token *model.AccessToken) error
+	// FindAccessTokenBySession looks up the access token created for a MiAuth
+	// session id (used by /miauth/:session/check to hand the token back to the
+	// 3rd-party client).
+	FindAccessTokenBySession(session string) (*model.AccessToken, error)
+	// MarkAccessTokenFetched flips the one-time `fetched` flag so a session
+	// token can only be retrieved once.
+	MarkAccessTokenFetched(id string) error
 
 	// App lookup
 	FindAppByID(id string) (*model.App, error)
@@ -82,6 +89,18 @@ func (r *authSessionRepository) FindAccessTokenByAppAndUser(appID, userID string
 		return nil, err
 	}
 	return &token, nil
+}
+
+func (r *authSessionRepository) FindAccessTokenBySession(session string) (*model.AccessToken, error) {
+	var token model.AccessToken
+	if err := r.db.Where(`"session" = ?`, session).First(&token).Error; err != nil {
+		return nil, err
+	}
+	return &token, nil
+}
+
+func (r *authSessionRepository) MarkAccessTokenFetched(id string) error {
+	return r.db.Model(&model.AccessToken{}).Where(`"id" = ?`, id).Update("fetched", true).Error
 }
 
 func (r *authSessionRepository) CreateAccessToken(token *model.AccessToken) error {

--- a/internal/repository/auth_session_test.go
+++ b/internal/repository/auth_session_test.go
@@ -93,6 +93,30 @@ func TestAuthSessionRepository_Full(t *testing.T) {
 	_, err = repo.FindAccessTokenByAppAndUser("ghost", user.ID)
 	assert.Error(t, err)
 
+	// MiAuth session token (#1224): session 紐付き token を作成して
+	// FindAccessTokenBySession / MarkAccessTokenFetched を検証する。
+	miSession := "misess_as_1"
+	miToken := &model.AccessToken{
+		ID: "at_as_mi", Token: "mirawtoken", Hash: "mihash", UserID: user.ID,
+		Session: &miSession, Permission: pq.StringArray{"read:account"},
+	}
+	require.NoError(t, repo.CreateAccessToken(miToken))
+	defer testDB.Exec(`DELETE FROM "access_token" WHERE id = ?`, miToken.ID)
+
+	miFound, err := repo.FindAccessTokenBySession(miSession)
+	require.NoError(t, err)
+	assert.Equal(t, "mirawtoken", miFound.Token)
+	assert.False(t, miFound.Fetched)
+
+	require.NoError(t, repo.MarkAccessTokenFetched(miToken.ID))
+	refetched, err := repo.FindAccessTokenBySession(miSession)
+	require.NoError(t, err)
+	assert.True(t, refetched.Fetched, "MarkAccessTokenFetched must persist the one-time flag")
+
+	// FindAccessTokenBySession - not found
+	_, err = repo.FindAccessTokenBySession("ghost-session")
+	assert.Error(t, err)
+
 	// DeleteSession
 	require.NoError(t, repo.DeleteSession("sess_as_1"))
 	_, err = repo.FindSessionByToken("token_as_1")

--- a/internal/repository/auth_session_test.go
+++ b/internal/repository/auth_session_test.go
@@ -108,10 +108,17 @@ func TestAuthSessionRepository_Full(t *testing.T) {
 	assert.Equal(t, "mirawtoken", miFound.Token)
 	assert.False(t, miFound.Fetched)
 
-	require.NoError(t, repo.MarkAccessTokenFetched(miToken.ID))
+	won, err := repo.MarkAccessTokenFetched(miToken.ID)
+	require.NoError(t, err)
+	assert.True(t, won, "first MarkAccessTokenFetched must win the false->true transition")
 	refetched, err := repo.FindAccessTokenBySession(miSession)
 	require.NoError(t, err)
 	assert.True(t, refetched.Fetched, "MarkAccessTokenFetched must persist the one-time flag")
+
+	// 2 度目はもう fetched=true なので遷移に負ける (won=false)。
+	wonAgain, err := repo.MarkAccessTokenFetched(miToken.ID)
+	require.NoError(t, err)
+	assert.False(t, wonAgain, "second MarkAccessTokenFetched must lose: already fetched")
 
 	// FindAccessTokenBySession - not found
 	_, err = repo.FindAccessTokenBySession("ghost-session")

--- a/internal/server/router.go
+++ b/internal/server/router.go
@@ -2099,6 +2099,10 @@ func (s *Server) setupRoutes() {
 
 	// miauth/gen-token — アクセストークン直接生成
 	api.POST("/miauth/gen-token", authHandler.GenToken, middleware.RequireAuth())
+	// miauth/:session/check — 3rd-party client が session 紐付き token を取得する
+	// (#1224)。token をまだ持たない client が叩くため RequireAuth は付けない。
+	authHandler.SetUserRepo(userRepo)
+	api.POST("/miauth/:session/check", authHandler.MiAuthCheck)
 
 	// app/* — アプリ管理API
 	appHandler := apiapp.NewHandler(authSessionRepo, idGen)

--- a/internal/testutil/mock_repository.go
+++ b/internal/testutil/mock_repository.go
@@ -5703,11 +5703,12 @@ func (m *MockAuthSessionRepository) FindAccessTokenBySession(session string) (*m
 	return nil, ErrNotFound
 }
 
-func (m *MockAuthSessionRepository) MarkAccessTokenFetched(id string) error {
-	if t, ok := m.AccessTokens[id]; ok {
+func (m *MockAuthSessionRepository) MarkAccessTokenFetched(id string) (bool, error) {
+	if t, ok := m.AccessTokens[id]; ok && !t.Fetched {
 		t.Fetched = true
+		return true, nil
 	}
-	return nil
+	return false, nil
 }
 
 func (m *MockAuthSessionRepository) FindAppByID(id string) (*model.App, error) {

--- a/internal/testutil/mock_repository.go
+++ b/internal/testutil/mock_repository.go
@@ -5694,6 +5694,22 @@ func (m *MockAuthSessionRepository) CreateAccessToken(token *model.AccessToken) 
 	return nil
 }
 
+func (m *MockAuthSessionRepository) FindAccessTokenBySession(session string) (*model.AccessToken, error) {
+	for _, t := range m.AccessTokens {
+		if t.Session != nil && *t.Session == session {
+			return t, nil
+		}
+	}
+	return nil, ErrNotFound
+}
+
+func (m *MockAuthSessionRepository) MarkAccessTokenFetched(id string) error {
+	if t, ok := m.AccessTokens[id]; ok {
+		t.Fetched = true
+	}
+	return nil
+}
+
 func (m *MockAuthSessionRepository) FindAppByID(id string) (*model.App, error) {
 	a, ok := m.Apps[id]
 	if !ok {


### PR DESCRIPTION
## Summary

#1224。Miria (misskey_dart) 等の 3rd-party client で MiAuth login すると `checkMiAuthToken` が `type 'Null' is not a subtype of type 'FutureOr<String>'` でクラッシュしてログインできなかった。

**原因**: mk-go が `/api/miauth/:session/check` を**未実装**(`/miauth/gen-token` のみ)。client が check を叩くと API 404 (`{error:...}`) が返り、`token` フィールドが null → misskey_dart の String cast でクラッシュ。

承認ステップ (`GenToken` = `/miauth/gen-token` が session 紐付き access_token を作成) は実装済だったため、**取得側の check endpoint を追加**して MiAuth フローを完結させる。

## 実装
- **repo**: `FindAccessTokenBySession` / `MarkAccessTokenFetched` を追加 (+ mock)
- **auth handler**: `MiAuthCheck` を実装。session に対応する未取得 (`!fetched`) の access_token があれば `fetched=true` (one-time 化) にして `{ok:true, token, user: UserDetailedNotMe}` を返し、無ければ `{ok:false}`。token をまだ持たない client が叩くため **RequireAuth 無し** (upstream `ApiServerService` の `/miauth/:session/check` と同じ)
- **router**: `POST /api/miauth/:session/check` を登録、authHandler に userRepo を wire

## upstream 互換
upstream は session で access_token を引き、`!fetched` なら `fetched=true` + `{ok, token, user}`、無ければ `{ok:false}`。同一セマンティクス。

## scope 外 (別 PR)
同 issue の **streaming `StreamingChannelUnknownResponse` null crash** は、mk-go が channel connect で送る**非標準の `{type:"connected"}` メッセージ**が misskey_dart の未知 channel response にルートされ null cast する疑い。upstream プロトコル検証 + 公式 frontend 影響確認が必要な独立調査のため別 PR で扱う。

## テスト
- handler: token+user 返却 (one-time fetched 化) / 未知 session → ok:false / fetched 済 → ok:false / 空 session / userRepo 未配線で user 省略
- repo: FindAccessTokenBySession / MarkAccessTokenFetched (testcontainer)
- カバレッジ: api/auth 100% / api/app 100% / repository 90.0%

```
go test ./internal/api/auth/... ./internal/api/app/... ./internal/repository/ -count=1 -cover
go build ./... && go vet ./... && gofmt -s -d .
```

## Refs
Refs #1224 (streaming crash は別 PR で対応するため Closes にはしない)

🤖 Generated with [Claude Code](https://claude.com/claude-code)