### PR TITLE
fix(i): /api/i unreadAnnouncements を upstream 互換 shape に (3rd-party login crash)

### DIFF
--- a/internal/api/i/handler.go
+++ b/internal/api/i/handler.go
@@ -1332,7 +1332,13 @@ func (h *Handler) fillUnreadFields(ctx context.Context, u *model.User, resp map[
 				// 含む upstream 互換の shape に揃える。独自 map だと createdAt が
 				// 欠落し、misskey_dart の AnnouncementsResponse.fromJson が
 				// createdAt を非null String として cast して落ちる (#1224)。
-				out = append(out, entity.PackAnnouncement(a, h.idGen, false))
+				packed := entity.PackAnnouncement(a, h.idGen, false)
+				if packed == nil {
+					// nil entry を配列に入れると [null] になり、misskey_dart が
+					// 各要素を fromJson する際 null で落ちるため除外する。
+					continue
+				}
+				out = append(out, packed)
 			}
 			resp["unreadAnnouncements"] = out
 		}

--- a/internal/api/i/handler.go
+++ b/internal/api/i/handler.go
@@ -1328,12 +1328,11 @@ func (h *Handler) fillUnreadFields(ctx context.Context, u *model.User, resp map[
 			resp["hasUnreadAnnouncement"] = len(ann) > 0
 			out := make([]map[string]any, 0, len(ann))
 			for _, a := range ann {
-				out = append(out, map[string]any{
-					"id":       a.ID,
-					"title":    a.Title,
-					"text":     a.Text,
-					"imageUrl": a.ImageURL,
-				})
+				// PackAnnouncement で createdAt / updatedAt / icon / display 等を
+				// 含む upstream 互換の shape に揃える。独自 map だと createdAt が
+				// 欠落し、misskey_dart の AnnouncementsResponse.fromJson が
+				// createdAt を非null String として cast して落ちる (#1224)。
+				out = append(out, entity.PackAnnouncement(a, h.idGen, false))
 			}
 			resp["unreadAnnouncements"] = out
 		}

--- a/internal/api/i/handler_test.go
+++ b/internal/api/i/handler_test.go
@@ -2062,8 +2062,13 @@ func TestMe_PendingFollowRequest(t *testing.T) {
 
 func TestMe_UnreadAnnouncement(t *testing.T) {
 	h, userRepo, _, _ := newTestHandler(t)
+	// 実 aidx ID を使うことで PackAnnouncement の createdAt が ParseTime で
+	// 復元され、非null の timestamp 文字列になることを保証する。
+	gen, err := id.NewGenerator("aidx")
+	require.NoError(t, err)
+	annID := gen.Generate(time.Now())
 	h.SetAnnouncementRepo(&stubAnnouncementRepo{
-		rows: []*model.Announcement{{ID: "a1", Title: "hello", Text: "world"}},
+		rows: []*model.Announcement{{ID: annID, Title: "hello", Text: "world"}},
 	})
 
 	resp := runMe(t, h, userRepo, "u1")
@@ -2071,8 +2076,14 @@ func TestMe_UnreadAnnouncement(t *testing.T) {
 	arr := resp["unreadAnnouncements"].([]any)
 	assert.Len(t, arr, 1)
 	first := arr[0].(map[string]any)
-	assert.Equal(t, "a1", first["id"])
+	assert.Equal(t, annID, first["id"])
 	assert.Equal(t, "hello", first["title"])
+	assert.Equal(t, "world", first["text"])
+	// createdAt は misskey_dart の AnnouncementsResponse が非null String として
+	// cast するため、キーが存在し空でないことを必須とする (#1224 回帰防止)。
+	createdAt, ok := first["createdAt"].(string)
+	assert.True(t, ok, "createdAt must be a non-null string")
+	assert.NotEmpty(t, createdAt)
 }
 
 func TestMe_UnreadAnnouncement_Empty(t *testing.T) {

--- a/internal/api/i/handler_test.go
+++ b/internal/api/i/handler_test.go
@@ -2086,6 +2086,24 @@ func TestMe_UnreadAnnouncement(t *testing.T) {
 	assert.NotEmpty(t, createdAt)
 }
 
+func TestMe_UnreadAnnouncement_SkipsNil(t *testing.T) {
+	h, userRepo, _, _ := newTestHandler(t)
+	gen, err := id.NewGenerator("aidx")
+	require.NoError(t, err)
+	annID := gen.Generate(time.Now())
+	// nil entry が混じっても [null] を出力せず除外されることを保証する。
+	h.SetAnnouncementRepo(&stubAnnouncementRepo{
+		rows: []*model.Announcement{nil, {ID: annID, Title: "hello", Text: "world"}},
+	})
+
+	resp := runMe(t, h, userRepo, "u1")
+	arr := resp["unreadAnnouncements"].([]any)
+	assert.Len(t, arr, 1)
+	assert.NotNil(t, arr[0])
+	first := arr[0].(map[string]any)
+	assert.Equal(t, annID, first["id"])
+}
+
 func TestMe_UnreadAnnouncement_Empty(t *testing.T) {
 	h, userRepo, _, _ := newTestHandler(t)
 	h.SetAnnouncementRepo(&stubAnnouncementRepo{rows: nil})


### PR DESCRIPTION
## Summary

3rd-party client (Miria / misskey_dart) のログインが、MiAuth token 取得 (#1225) の後段、`MisskeyI.i` (= `/api/i`) のレスポンス解析 (`MeDetailed.fromJson`) で落ちる問題を修正する。

新ログ (issue #1224) のスタックトレース:

```
type 'Null' is not a subtype of type 'String' in type cast
#0  _$AnnouncementsResponseFromJson (announcements_response.g.dart:14:64)
#2  _$MeDetailedFromJson.<anonymous closure> (user.g.dart:571)
#10 MeDetailed.fromJson
#11 MisskeyI.i
#12 AccountRepository.validateMiAuth
```

## 原因

`internal/api/i/handler.go` の `fillUnreadFields` が `unreadAnnouncements` を
`{id, title, text, imageUrl}` の独自 map で組み立てており、**`createdAt` が欠落**
していた。misskey_dart の `AnnouncementsResponse.fromJson` は以下を非null必須と
する:

- `id` → `as String`
- `createdAt` → `as String` (← line 14 col 64、今回の crash 箇所)
- `text` → `as String`
- `title` → `as String`

`createdAt` キーが JSON に存在しない → `json['createdAt']` が null → cast 失敗。

## 主な変更点

- `fillUnreadFields` の独自 map を既存の `entity.PackAnnouncement(a, h.idGen, false)`
  に置き換え。`createdAt` / `updatedAt` / `icon` / `display` /
  `needConfirmationToRead` / `silence` / `forYou` / `isRead` を含む upstream 互換
  shape に揃える (`/api/announcements` と同一 packer)。
- 回帰防止テスト: `TestMe_UnreadAnnouncement` で実 aidx ID を使い、`createdAt` が
  非null かつ非空の String として返ることを assert。

## テスト

- `go build ./... ` / `go vet` / `gofmt` クリーン
- `go test ./internal/api/i/...` → coverage 90.5% (CI ゲート 90% 通過)

## 関連

- 前段の MiAuth token 取得修正: #1225 (`/miauth/:session/check`)
- 調査メモ: misskey_dart streaming union を verify した結果、要約段階の
  「`connected` が streaming crash 原因」仮説は誤り (`connected` は upstream 互換
  かつ pong-gated、Miria は pong 非送信)。今回のログで真因が MeDetailed の
  announcement shape と判明した。

Closes #1224 

🤖 Generated with [Claude Code](https://claude.com/claude-code)