### PR TITLE
fix(users): isFollowing/isFollowed に omitempty (3rd-party 自身プロフィール crash #1228)

### DIFF
--- a/internal/api/users/handler_test.go
+++ b/internal/api/users/handler_test.go
@@ -416,6 +416,13 @@ func TestShow_SelfViewReturnsMeDetailed(t *testing.T) {
 	// 通常 UserDetailed field も残る
 	assert.Equal(t, "self1", resp["id"])
 	assert.Equal(t, "selfuser", resp["username"])
+	// self-view では relation を計算しないため isFollowing / isFollowed は
+	// null ではなく省略されること。null だと misskey_dart の
+	// UserDetailedNotMeWithRelations が bool cast で落ちる (#1228)。
+	_, hasIsFollowing := resp["isFollowing"]
+	assert.False(t, hasIsFollowing, "isFollowing must be omitted (not null) for self-view")
+	_, hasIsFollowed := resp["isFollowed"]
+	assert.False(t, hasIsFollowed, "isFollowed must be omitted (not null) for self-view")
 }
 
 // TestShow_NonSelfViewExcludesMeDetailed: viewer != target なら MeDetailed

--- a/internal/entity/user.go
+++ b/internal/entity/user.go
@@ -87,9 +87,14 @@ type UserDetailed struct {
 	PinnedPageID *string `json:"pinnedPageId"`
 	PinnedPage   any     `json:"pinnedPage"`
 	Roles        []any   `json:"roles"`
-	// viewer依存フィールド (ハンドラ側でセット)
-	IsFollowing                    *bool   `json:"isFollowing"`
-	IsFollowed                     *bool   `json:"isFollowed"`
+	// viewer依存フィールド (ハンドラ側でセット)。viewer===target の self-view や
+	// 未認証では relation を計算せず nil のままになる。upstream Misskey は self/
+	// no-me のとき relation フィールド一式を省略する (`detail && meId !== userId`)
+	// ため、ここも omitempty で揃える。omitempty が無いと nil が `null` として
+	// 出力され、misskey_dart の UserDetailedNotMeWithRelations が
+	// `isFollowing as bool` で null cast に失敗する (#1228)。
+	IsFollowing                    *bool   `json:"isFollowing,omitempty"`
+	IsFollowed                     *bool   `json:"isFollowed,omitempty"`
 	IsBlocking                     *bool   `json:"isBlocking,omitempty"`
 	IsBlocked                      *bool   `json:"isBlocked,omitempty"`
 	IsMuted                        *bool   `json:"isMuted,omitempty"`


### PR DESCRIPTION
## Summary

3rd-party client (Miria / misskey_dart) で**自身のプロフィール表示**が以下でクラッシュする問題を修正する。

```
type 'Null' is not a subtype of type 'bool' in type cast
#0  _$UserDetailedNotMeWithRelationsFromJson (user.g.dart:349:40)  ← isFollowing
#2  new UserDetailed.fromJson (user.dart:84)
#3  MisskeyUsers.show (misskey_users.dart:18)
```

## 原因

`UserDetailed` の `IsFollowing` / `IsFollowed` だけ JSON タグに `omitempty` が
無く、他の relation フラグ (`isBlocking` / `isMuted` / `hasPendingFollowRequest*`
等) は付いていた。`/api/users/show` は viewer===target の self-view や未認証時
には relation を計算せず `*bool` を nil のままにするが、omitempty が無いと nil
pointer が `"isFollowing": null` として出力される。

misskey_dart の `UserDetailed.fromJson` は relation key の有無で variant を判定し、
key が present だと `UserDetailedNotMeWithRelations` を選んで `json['isFollowing']
as bool` を実行する。null だと `Null is not bool` で落ちる。

upstream Misskey は `detail && meId !== userId` の時のみ relation 一式を含める
(self/no-me では全て省略) ので、mk-go も両 field に omitempty を付けて揃える。

## 主な変更点

- `internal/entity/user.go`: `IsFollowing` / `IsFollowed` の json タグに
  `,omitempty` を追加。これで self/no-me では省略され (misskey_dart は
  relation 無しの `UserDetailedNotMe` variant を選ぶ)、other-user view では
  非nil pointer なので従来通り true/false が出力される。
- `internal/api/users/handler_test.go`: `TestShow_SelfViewReturnsMeDetailed` に
  self-view で `isFollowing` / `isFollowed` が **null ではなく省略**される
  ことの回帰 assertion を追加。

## テスト

- `go build ./...` / `go vet` / `gofmt` クリーン
- `go test ./internal/api/users/... ./internal/entity/...` → users 92.5% /
  entity 94.9% (CI ゲート 90% 通過)

## 関連

- 同 reporter の 3rd-party client compat 報告群: #1224 (login chain) / #1227
  (users/reactions note shape)
- 診断: misskey_dart pinned ref (e9d396e) の `user.g.dart` で
  `UserDetailedNotMeWithRelations` の非null bool cast フィールドを特定。

Closes #1228

🤖 Generated with [Claude Code](https://claude.com/claude-code)