### PR TITLE
fix(users): /api/users/reactions の note を完全 shape に (3rd-party reactions タブ crash #1227)

### DIFF
--- a/internal/api/users/handler_extra.go
+++ b/internal/api/users/handler_extra.go
@@ -220,6 +220,22 @@ func (h *Handler) Reactions(c echo.Context) error {
 		return c.JSON(http.StatusInternalServerError, apierr.Error("INTERNAL_ERROR", "Internal error.", "5d37dbcb-891e-41ca-a3d6-e690c97775ac"))
 	}
 
+	// note は upstream の packManyWithNote と同じく完全 shape で返す。最小 shape
+	// (id/userId/text) だと createdAt / visibility / user 等が欠落し、misskey_dart
+	// の Note.fromJson が非null フィールドの cast に失敗して落ちる (#1227)。
+	// PackNotes で batch pack して instance / emoji / buffered reaction も解決する。
+	notes := make([]*model.Note, 0, len(rows))
+	for _, r := range rows {
+		if r.Note != nil {
+			notes = append(notes, r.Note)
+		}
+	}
+	packed := entity.PackNotes(c.Request().Context(), notes, h.idGen, h.instanceLookup(), h.emojiLookup(), h.reactionReader())
+	noteByID := make(map[string]entity.NoteEntity, len(packed))
+	for _, ne := range packed {
+		noteByID[ne.ID] = ne
+	}
+
 	out := make([]map[string]any, 0, len(rows))
 	for _, r := range rows {
 		entry := map[string]any{
@@ -233,14 +249,9 @@ func (h *Handler) Reactions(c echo.Context) error {
 			entry["user"] = entity.PackUserLite(r.User)
 		}
 		if r.Note != nil {
-			noteEntry := map[string]any{
-				"id":     r.Note.ID,
-				"userId": r.Note.UserID,
+			if ne, ok := noteByID[r.Note.ID]; ok {
+				entry["note"] = ne
 			}
-			if r.Note.Text != nil {
-				noteEntry["text"] = *r.Note.Text
-			}
-			entry["note"] = noteEntry
 		}
 		out = append(out, entry)
 	}

--- a/internal/api/users/handler_extra.go
+++ b/internal/api/users/handler_extra.go
@@ -155,11 +155,12 @@ func (h *Handler) ReportAbuse(c echo.Context) error {
 //   - target user が remote なら 400 IS_REMOTE_USER (mk-go では現状 local
 //     のみ対応、upstream と同じ制限)。
 //   - それ以外 (public か self view) なら reactor の reaction list を
-//     id / createdAt / type / user / note の minimal shape で返す。
+//     id / createdAt / type / user / note shape で返す。
 //
-// note pack は upstream の packManyWithNote (= 完全 note shape) ではなく
-// 最小 shape (id / userId / text) で start。drop-in 互換性は両 backend で
-// 同 endpoint が動くことを spec で担保する (#821 PR-D)。
+// note は upstream の packManyWithNote 相当の完全 shape (PackNotes) で返す。
+// 最小 shape (id / userId / text) だと createdAt / visibility / user 等が
+// 欠落し、misskey_dart の Note.fromJson が非null cast に失敗して落ちる
+// (#1227、当初は #821 PR-D で最小 shape start としていた)。
 func (h *Handler) Reactions(c echo.Context) error {
 	viewer := middleware.GetUser(c)
 	var req struct {

--- a/internal/api/users/handler_extra_test.go
+++ b/internal/api/users/handler_extra_test.go
@@ -269,14 +269,20 @@ func TestReactions_SelfViewBypassesPublicReactions(t *testing.T) {
 	// createdAt の format check のため real aidx を使う (= ParseTime が成功)。
 	idGen, _ := id.NewGenerator("aidx")
 	rxID := idGen.Generate(time.Date(2026, 5, 7, 12, 0, 0, 0, time.UTC))
+	noteID := idGen.Generate(time.Date(2026, 5, 7, 11, 0, 0, 0, time.UTC))
 	noteText := "hi"
 	rxRepo.Reactions[rxID] = &model.NoteReaction{
 		ID:       rxID,
 		UserID:   "u_self",
-		NoteID:   "n1",
+		NoteID:   noteID,
 		Reaction: "👍",
 		User:     &model.User{ID: "u_self", Username: "self"},
-		Note:     &model.Note{ID: "n1", UserID: "u_other", Text: &noteText},
+		// Note.User を preload 済みにする (production の Preload("Note.User") 相当)。
+		Note: &model.Note{
+			ID: noteID, UserID: "u_other", Text: &noteText,
+			Visibility: "public",
+			User:       &model.User{ID: "u_other", Username: "other"},
+		},
 	}
 	rec := postExtra(h.Reactions, `{"userId":"u_self","limit":150}`, &model.User{ID: "u_self"})
 	require.Equal(t, http.StatusOK, rec.Code)
@@ -290,9 +296,18 @@ func TestReactions_SelfViewBypassesPublicReactions(t *testing.T) {
 	require.NotNil(t, entry["user"])
 	require.NotNil(t, entry["note"])
 	note, _ := entry["note"].(map[string]any)
-	assert.Equal(t, "n1", note["id"])
+	assert.Equal(t, noteID, note["id"])
 	assert.Equal(t, "u_other", note["userId"])
 	assert.Equal(t, "hi", note["text"])
+	// note は完全 shape で返ること。misskey_dart の Note.fromJson が非null必須と
+	// する createdAt / visibility / user が欠落していると落ちる (#1227 回帰防止)。
+	noteCreatedAt, ok := note["createdAt"].(string)
+	assert.True(t, ok, "note.createdAt must be a non-null string")
+	assert.NotEmpty(t, noteCreatedAt)
+	assert.Equal(t, "public", note["visibility"])
+	noteUser, ok := note["user"].(map[string]any)
+	require.True(t, ok, "note.user must be a non-null object")
+	assert.Equal(t, "u_other", noteUser["id"])
 	// createdAt は ISO8601 ms 精度で出る (= 2026-05-07T12:00:00.000Z)。
 	createdAt, ok := entry["createdAt"].(string)
 	require.True(t, ok, "createdAt should be a string")

--- a/internal/repository/note_reaction.go
+++ b/internal/repository/note_reaction.go
@@ -104,7 +104,10 @@ func (r *noteReactionRepository) ListByNoteID(noteID string, untilID, sinceID st
 // ListByNoteID と同じ keyset 方式 (paginationOrder で DESC 既定)。
 func (r *noteReactionRepository) ListByUserID(userID, untilID, sinceID string, limit int) ([]*model.NoteReaction, error) {
 	var rows []*model.NoteReaction
-	q := r.db.Preload("User").Preload("Note").Where("\"userId\" = ?", userID)
+	// Note.User も preload する。users/reactions は note を完全 shape (PackNotes)
+	// で返すため、note author が無いと misskey_dart の Note.user (UserLite) 解析が
+	// null で落ちる (#1227)。
+	q := r.db.Preload("User").Preload("Note").Preload("Note.User").Where("\"userId\" = ?", userID)
 	if untilID != "" {
 		q = q.Where("id < ?", untilID)
 	}


### PR DESCRIPTION
## Summary

3rd-party client (Miria / misskey_dart) で**他ユーザーのリアクションタブ**表示が以下でクラッシュする問題を修正する。

```
type 'Null' is not a subtype of type 'String' in type cast
#0  _$NoteFromJson (note.g.dart:12:64)
#2  _$UsersReactionsResponseFromJson (users_reactions_response.g.dart:17)
#4  MisskeyUsers.reactions (misskey_users.dart:75)
#8  NoteRepository.registerAll
#9  UserReactions.build (user_page/user_reactions.dart:24)
```

## 原因

`/api/users/reactions` が各 reaction の `note` を最小 shape (`id` / `userId` /
`text` のみ) で返しており、`createdAt` / `visibility` / `user` 等が欠落していた
(handler 内コメントでも「完全 note shape ではなく最小 shape で start」と明記)。

misskey_dart の `Note.fromJson` は `id` / `createdAt` / `userId` / `visibility`
を非null String、`user` を非null Map として cast するため、欠落フィールドで
`Null is not String` クラッシュが起きていた。

## 主な変更点

- `internal/api/users/handler_extra.go` (`Reactions`): 最小 map を
  `entity.PackNotes` での batch pack に置換。upstream の packManyWithNote 相当の
  完全 note shape (createdAt / visibility / user / instance / emoji / buffered
  reaction 解決込み) を返す。`PackNotes` を 1 回呼んで note ID → NoteEntity の
  map を作り、各 reaction entry に対応 note を詰める。
- `internal/repository/note_reaction.go` (`ListByUserID`): `Preload("Note.User")`
  を追加。note author (UserLite) が無いと misskey_dart の `note.user` 解析が
  null で落ちるため。
- `internal/api/users/handler_extra_test.go`: `TestReactions_SelfViewBypassesPublicReactions`
  を完全 shape 前提に更新し、note に `createdAt` (非null) / `visibility` /
  `user` が含まれることの回帰 assertion を追加。

## テスト

- `go build ./...` / `go vet` / `gofmt` クリーン
- `go test ./internal/api/users/...` → 92.5% (CI ゲート 90% 通過)
- `go test ./internal/repository/ -run TestNoteReaction` → pass (preload 変更の
  回帰なし)

## 関連

- 同 reporter の 3rd-party client compat 報告群: #1224 (login chain) / #1228
  (users/show relation bool)
- 診断: misskey_dart pinned ref (e9d396e) の `note.g.dart` で Note の非null
  String cast フィールドを特定。

Closes #1227

🤖 Generated with [Claude Code](https://claude.com/claude-code)