### PR TITLE
feat(drive): /drive/files/upload-from-url を実装 (#1231)

### DIFF
--- a/internal/api/drive/handler.go
+++ b/internal/api/drive/handler.go
@@ -10,6 +10,7 @@ import (
 	"log/slog"
 	"net/http"
 	"strings"
+	"unicode/utf8"
 
 	"github.com/labstack/echo/v4"
 	"github.com/shiroha-a/mk/internal/api/apierr"
@@ -696,8 +697,10 @@ func (h *Handler) FilesUploadFromURL(c echo.Context) error {
 	if err := c.Bind(&req); err != nil || req.URL == "" {
 		return apierr.JSONInvalidParam(c)
 	}
-	// upstream paramDef は comment maxLength=512。超過は INVALID_PARAM。
-	if req.Comment != nil && len(*req.Comment) > 512 {
+	// upstream paramDef は comment maxLength=512。ajv の maxLength は文字数
+	// (code unit) 基準なので byte 長ではなく rune 数で判定する (多バイト文字を
+	// 過剰に弾かないため)。超過は INVALID_PARAM。
+	if req.Comment != nil && utf8.RuneCountInString(*req.Comment) > 512 {
 		return apierr.JSONInvalidParam(c)
 	}
 	// uploader 未配線 (= 単体テスト等) は upstream と同じ空レスポンスで返す。

--- a/internal/api/drive/handler.go
+++ b/internal/api/drive/handler.go
@@ -2,6 +2,7 @@
 package drive
 
 import (
+	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -34,6 +35,14 @@ type Handler struct {
 	emojiRepo    repository.EmojiRepository
 	bufReader    entity.BufferedReactionsReader
 	fieldRes     *entity.NoteFieldResolver
+	urlUploader  URLUploadProcessor
+}
+
+// SetURLUploader wires the processor used by /drive/files/upload-from-url to
+// download a remote file in the background and notify the user via the main
+// stream. Without it the endpoint degrades to a 204 no-op.
+func (h *Handler) SetURLUploader(p URLUploadProcessor) {
+	h.urlUploader = p
 }
 
 // SetNoteFieldResolver wires the shared resolver that fills Files /
@@ -669,8 +678,45 @@ func (h *Handler) FilesAttachedNotes(c echo.Context) error {
 }
 
 // FilesUploadFromURL handles POST /api/drive/files/upload-from-url.
+//
+// upstream Misskey TS drive/files/upload-from-url と同 semantics: URL を指定して
+// サーバーに非同期でファイルを download させる。endpoint は即 204 を返し、
+// download / 保存はバックグラウンドで実行され、完了後に user の main stream へ
+// `urlUploadFinished` ({marker, file}) を publish する (#1217)。
 func (h *Handler) FilesUploadFromURL(c echo.Context) error {
-	// URL経由のファイルアップロード（非同期処理: 204返却）
+	user := middleware.GetUser(c)
+	var req struct {
+		URL         string  `json:"url"`
+		FolderID    *string `json:"folderId"`
+		IsSensitive bool    `json:"isSensitive"`
+		Comment     *string `json:"comment"`
+		Marker      *string `json:"marker"`
+		Force       bool    `json:"force"`
+	}
+	if err := c.Bind(&req); err != nil || req.URL == "" {
+		return apierr.JSONInvalidParam(c)
+	}
+	// upstream paramDef は comment maxLength=512。超過は INVALID_PARAM。
+	if req.Comment != nil && len(*req.Comment) > 512 {
+		return apierr.JSONInvalidParam(c)
+	}
+	// uploader 未配線 (= 単体テスト等) は upstream と同じ空レスポンスで返す。
+	if h.urlUploader == nil || user == nil {
+		return c.NoContent(http.StatusNoContent)
+	}
+	// upstream は fire-and-forget。request context は応答後に cancel されるため
+	// download はバックグラウンド context で継続する。
+	in := URLUploadInput{
+		User:        user,
+		URL:         req.URL,
+		FolderID:    req.FolderID,
+		Comment:     req.Comment,
+		Marker:      req.Marker,
+		IsSensitive: req.IsSensitive,
+		Force:       req.Force,
+		RequestIP:   c.RealIP(),
+	}
+	go h.urlUploader.Process(context.Background(), in)
 	return c.NoContent(http.StatusNoContent)
 }
 

--- a/internal/api/drive/url_upload.go
+++ b/internal/api/drive/url_upload.go
@@ -1,0 +1,160 @@
+package drive
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"net/http"
+	"net/url"
+	"path"
+
+	coredrive "github.com/shiroha-a/mk/internal/core/drive"
+	"github.com/shiroha-a/mk/internal/entity"
+	"github.com/shiroha-a/mk/internal/misc/id"
+	"github.com/shiroha-a/mk/internal/model"
+	"github.com/shiroha-a/mk/internal/safehttp"
+)
+
+// defaultURLUploadMaxBytes caps a remote download when no explicit limit is
+// configured. Mirrors config.defaultMaxFileSize (250 MiB).
+const defaultURLUploadMaxBytes int64 = 262144000
+
+// driveUploader is the subset of *coredrive.Service the URL uploader needs.
+type driveUploader interface {
+	Upload(ctx context.Context, in coredrive.UploadInput) (*model.DriveFile, error)
+}
+
+// mainEventPublisher emits a `{type, body}` event to a single user's main
+// stream (satisfied by *stream.MainStreamPublisher).
+type mainEventPublisher interface {
+	PublishMainEvent(userID, eventType string, body any)
+}
+
+// URLUploadInput carries the resolved parameters of drive/files/upload-from-url.
+type URLUploadInput struct {
+	User        *model.User
+	URL         string
+	FolderID    *string
+	Comment     *string
+	Marker      *string
+	IsSensitive bool
+	Force       bool
+	RequestIP   string
+}
+
+// URLUploadProcessor downloads a remote file and stores it in the drive,
+// notifying the requesting user via the main stream when finished.
+type URLUploadProcessor interface {
+	Process(ctx context.Context, in URLUploadInput)
+}
+
+// URLUploader is the production URLUploadProcessor. httpClient must be wired
+// with safehttp.NewSSRFSafeTransport(...) so private IPs and non-http(s)
+// schemes never leak through this download path (the SSRF-safe transport also
+// blocks redirects to private IPs, so no extra redirect handling is needed).
+type URLUploader struct {
+	httpClient *http.Client
+	uploader   driveUploader
+	publisher  mainEventPublisher
+	idGen      id.Generator
+	userAgent  string
+	maxBytes   int64
+}
+
+// NewURLUploader builds a URLUploader. maxBytes <= 0 falls back to the 250 MiB
+// default; pass cfg.MaxFileSize so a download never exceeds what the drive
+// would accept anyway.
+func NewURLUploader(httpClient *http.Client, uploader driveUploader, publisher mainEventPublisher, idGen id.Generator, userAgent string, maxBytes int64) *URLUploader {
+	if maxBytes <= 0 {
+		maxBytes = defaultURLUploadMaxBytes
+	}
+	return &URLUploader{
+		httpClient: httpClient,
+		uploader:   uploader,
+		publisher:  publisher,
+		idGen:      idGen,
+		userAgent:  userAgent,
+		maxBytes:   maxBytes,
+	}
+}
+
+// Process fetches in.URL and stores it as a drive file owned by in.User, then
+// emits `urlUploadFinished` ({marker, file}) to the user's main stream.
+//
+// upstream Misskey の drive/files/upload-from-url と同じく fire-and-forget で、
+// download / 保存に失敗した場合はクライアントに urlUploadFinished を送らない
+// (= 呼び出し側 UI は timeout 表示にフォールバックする)。エラーは redacted で
+// log に残すだけにする。
+func (u *URLUploader) Process(ctx context.Context, in URLUploadInput) {
+	df, err := u.fetchAndStore(ctx, in)
+	if err != nil {
+		uid := ""
+		if in.User != nil {
+			uid = in.User.ID
+		}
+		slog.Warn("drive upload-from-url failed", "user", uid, "err", err)
+		return
+	}
+	if u.publisher == nil || in.User == nil {
+		return
+	}
+	u.publisher.PublishMainEvent(in.User.ID, "urlUploadFinished", map[string]any{
+		"marker": in.Marker,
+		"file":   entity.PackDriveFile(df, u.idGen),
+	})
+}
+
+func (u *URLUploader) fetchAndStore(ctx context.Context, in URLUploadInput) (*model.DriveFile, error) {
+	if u.httpClient == nil || u.uploader == nil {
+		return nil, fmt.Errorf("url uploader not wired")
+	}
+	parsed, err := url.Parse(in.URL)
+	if err != nil || parsed.Host == "" || (parsed.Scheme != "http" && parsed.Scheme != "https") {
+		return nil, fmt.Errorf("invalid url")
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, parsed.String(), nil)
+	if err != nil {
+		return nil, fmt.Errorf("build request: %w", err)
+	}
+	req.Header.Set("Accept", "*/*")
+	if u.userAgent != "" {
+		req.Header.Set("User-Agent", u.userAgent)
+	}
+
+	resp, err := u.httpClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("fetch: %w", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode >= 400 {
+		return nil, fmt.Errorf("upstream status %d", resp.StatusCode)
+	}
+
+	body, err := safehttp.ReadAllLimit(resp.Body, u.maxBytes)
+	if err != nil {
+		return nil, fmt.Errorf("read body: %w", err)
+	}
+
+	// Misskey TS の uploadFromUrl 相当で `name = path.basename(url)` を使う。
+	// path が無い (= ルート) URL では fallback 名を当てる。
+	name := path.Base(parsed.Path)
+	if name == "" || name == "." || name == "/" {
+		name = "unknown"
+	}
+
+	var ip *string
+	if in.RequestIP != "" {
+		ip = &in.RequestIP
+	}
+	return u.uploader.Upload(ctx, coredrive.UploadInput{
+		User:        in.User,
+		Body:        body,
+		Name:        name,
+		Comment:     in.Comment,
+		FolderID:    in.FolderID,
+		IsSensitive: in.IsSensitive,
+		Force:       in.Force,
+		RequestIP:   ip,
+	})
+}

--- a/internal/api/drive/url_upload_test.go
+++ b/internal/api/drive/url_upload_test.go
@@ -245,6 +245,28 @@ func TestFilesUploadFromURL_CommentTooLong(t *testing.T) {
 	assert.Equal(t, http.StatusBadRequest, rec.Code)
 }
 
+// 多バイト文字 512 字以内 (byte 数では 512 超) のコメントは受理されること。
+// byte 長判定だと過剰に弾いていた (rune 数判定への修正の回帰防止)。
+func TestFilesUploadFromURL_MultibyteCommentWithinLimit(t *testing.T) {
+	h, _, _ := newHandler(t)
+	rp := &recordingProcessor{calls: make(chan URLUploadInput, 1)}
+	h.SetURLUploader(rp)
+
+	comment := strings.Repeat("あ", 512) // 512 runes = 1536 bytes
+	c, rec := newJSONReq(t, `{"url":"https://example.com/x","comment":"`+comment+`"}`)
+	setUser(c, "u1")
+	require.NoError(t, h.FilesUploadFromURL(c))
+	assert.Equal(t, http.StatusNoContent, rec.Code)
+
+	select {
+	case in := <-rp.calls:
+		require.NotNil(t, in.Comment)
+		assert.Equal(t, comment, *in.Comment)
+	case <-time.After(2 * time.Second):
+		t.Fatal("Process was not invoked")
+	}
+}
+
 func TestFilesUploadFromURL_NotWired(t *testing.T) {
 	h, _, _ := newHandler(t) // urlUploader 未配線
 	c, rec := newJSONReq(t, `{"url":"https://example.com/x"}`)

--- a/internal/api/drive/url_upload_test.go
+++ b/internal/api/drive/url_upload_test.go
@@ -1,0 +1,255 @@
+package drive
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	coredrive "github.com/shiroha-a/mk/internal/core/drive"
+	"github.com/shiroha-a/mk/internal/misc/id"
+	"github.com/shiroha-a/mk/internal/model"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func ptr[T any](v T) *T { return &v }
+
+// --- mocks ---
+
+type mockDriveUploader struct {
+	gotInput *coredrive.UploadInput
+	ret      *model.DriveFile
+	err      error
+}
+
+func (m *mockDriveUploader) Upload(_ context.Context, in coredrive.UploadInput) (*model.DriveFile, error) {
+	cp := in
+	m.gotInput = &cp
+	return m.ret, m.err
+}
+
+type publishedMainEvent struct {
+	userID    string
+	eventType string
+	body      any
+}
+
+type mockMainPublisher struct {
+	mu     sync.Mutex
+	events []publishedMainEvent
+}
+
+func (m *mockMainPublisher) PublishMainEvent(userID, eventType string, body any) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.events = append(m.events, publishedMainEvent{userID, eventType, body})
+}
+
+func newTestURLUploader(uploader driveUploader, pub mainEventPublisher) *URLUploader {
+	idGen, _ := id.NewGenerator("aidx")
+	// http.DefaultClient で httptest (127.0.0.1) を叩く。production の SSRF-safe
+	// transport は private IP を弾くため unit test では使わない (SSRF 防御は
+	// safehttp package 側でテスト済み)。
+	return NewURLUploader(http.DefaultClient, uploader, pub, idGen, "mk-go-test", 0)
+}
+
+// --- URLUploader.Process ---
+
+func TestURLUploader_Process_Success(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte("file-bytes"))
+	}))
+	defer srv.Close()
+
+	idGen, _ := id.NewGenerator("aidx")
+	fileID := idGen.Generate(time.Now())
+	up := &mockDriveUploader{ret: &model.DriveFile{ID: fileID, Name: "cat.png", Type: "image/png"}}
+	pub := &mockMainPublisher{}
+	u := NewURLUploader(http.DefaultClient, up, pub, idGen, "mk-go-test", 0)
+
+	marker := "m-123"
+	u.Process(context.Background(), URLUploadInput{
+		User:        &model.User{ID: "u1"},
+		URL:         srv.URL + "/path/cat.png",
+		FolderID:    ptr("f1"),
+		Comment:     ptr("nice"),
+		Marker:      &marker,
+		IsSensitive: true,
+		Force:       true,
+		RequestIP:   "1.2.3.4",
+	})
+
+	// upload に渡った input が正しいこと。
+	require.NotNil(t, up.gotInput)
+	require.NotNil(t, up.gotInput.User)
+	assert.Equal(t, "u1", up.gotInput.User.ID)
+	assert.Equal(t, []byte("file-bytes"), up.gotInput.Body)
+	assert.Equal(t, "cat.png", up.gotInput.Name) // URL path basename
+	assert.True(t, up.gotInput.IsSensitive)
+	assert.True(t, up.gotInput.Force)
+	require.NotNil(t, up.gotInput.Comment)
+	assert.Equal(t, "nice", *up.gotInput.Comment)
+	require.NotNil(t, up.gotInput.FolderID)
+	assert.Equal(t, "f1", *up.gotInput.FolderID)
+	require.NotNil(t, up.gotInput.RequestIP)
+	assert.Equal(t, "1.2.3.4", *up.gotInput.RequestIP)
+
+	// urlUploadFinished が marker + packed file 付きで publish されること。
+	require.Len(t, pub.events, 1)
+	ev := pub.events[0]
+	assert.Equal(t, "u1", ev.userID)
+	assert.Equal(t, "urlUploadFinished", ev.eventType)
+	body, ok := ev.body.(map[string]any)
+	require.True(t, ok)
+	assert.Equal(t, &marker, body["marker"])
+	require.NotNil(t, body["file"])
+}
+
+func TestURLUploader_Process_FetchErrorNoPublish(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	defer srv.Close()
+
+	up := &mockDriveUploader{}
+	pub := &mockMainPublisher{}
+	u := newTestURLUploader(up, pub)
+
+	u.Process(context.Background(), URLUploadInput{User: &model.User{ID: "u1"}, URL: srv.URL + "/x"})
+
+	// 4xx は fetch 失敗扱い → upload も publish もしない。
+	assert.Nil(t, up.gotInput)
+	assert.Empty(t, pub.events)
+}
+
+func TestURLUploader_Process_InvalidURLNoUpload(t *testing.T) {
+	up := &mockDriveUploader{}
+	pub := &mockMainPublisher{}
+	u := newTestURLUploader(up, pub)
+
+	// http(s) 以外の scheme は弾く。
+	u.Process(context.Background(), URLUploadInput{User: &model.User{ID: "u1"}, URL: "file:///etc/passwd"})
+
+	assert.Nil(t, up.gotInput)
+	assert.Empty(t, pub.events)
+}
+
+func TestURLUploader_Process_UploadErrorNoPublish(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte("data"))
+	}))
+	defer srv.Close()
+
+	up := &mockDriveUploader{err: coredrive.ErrMaxFileSizeExceeded}
+	pub := &mockMainPublisher{}
+	u := newTestURLUploader(up, pub)
+
+	u.Process(context.Background(), URLUploadInput{User: &model.User{ID: "u1"}, URL: srv.URL + "/big.bin"})
+
+	// fetch は成功するが upload が失敗 → publish しない。
+	require.NotNil(t, up.gotInput)
+	assert.Empty(t, pub.events)
+}
+
+func TestURLUploader_Process_RootPathNameFallback(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte("data"))
+	}))
+	defer srv.Close()
+
+	idGen, _ := id.NewGenerator("aidx")
+	up := &mockDriveUploader{ret: &model.DriveFile{ID: idGen.Generate(time.Now()), Name: "unknown"}}
+	pub := &mockMainPublisher{}
+	u := NewURLUploader(http.DefaultClient, up, pub, idGen, "", 0)
+
+	// path 無し (root) の URL は name="unknown" にフォールバックする。
+	u.Process(context.Background(), URLUploadInput{User: &model.User{ID: "u1"}, URL: srv.URL})
+
+	require.NotNil(t, up.gotInput)
+	assert.Equal(t, "unknown", up.gotInput.Name)
+	assert.Nil(t, up.gotInput.RequestIP) // RequestIP 空なら nil のまま
+}
+
+func TestURLUploader_Process_NotWiredNoPanic(t *testing.T) {
+	idGen, _ := id.NewGenerator("aidx")
+	// uploader/httpClient nil でも panic せず no-op。
+	u := NewURLUploader(nil, nil, nil, idGen, "", 0)
+	u.Process(context.Background(), URLUploadInput{User: &model.User{ID: "u1"}, URL: "https://example.com/x"})
+}
+
+func TestNewURLUploader_MaxBytesDefault(t *testing.T) {
+	idGen, _ := id.NewGenerator("aidx")
+	u := NewURLUploader(http.DefaultClient, &mockDriveUploader{}, &mockMainPublisher{}, idGen, "", 0)
+	assert.Equal(t, defaultURLUploadMaxBytes, u.maxBytes)
+
+	u2 := NewURLUploader(http.DefaultClient, &mockDriveUploader{}, &mockMainPublisher{}, idGen, "", 100)
+	assert.Equal(t, int64(100), u2.maxBytes)
+}
+
+// --- FilesUploadFromURL handler ---
+
+// recordingProcessor captures Process invocations for the handler test. The
+// handler launches Process in a goroutine, so we sync via a channel.
+type recordingProcessor struct {
+	calls chan URLUploadInput
+}
+
+func (r *recordingProcessor) Process(_ context.Context, in URLUploadInput) {
+	r.calls <- in
+}
+
+func TestFilesUploadFromURL_Success(t *testing.T) {
+	h, _, _ := newHandler(t)
+	rp := &recordingProcessor{calls: make(chan URLUploadInput, 1)}
+	h.SetURLUploader(rp)
+
+	c, rec := newJSONReq(t, `{"url":"https://example.com/a/b.png","marker":"mk1","isSensitive":true}`)
+	setUser(c, "u1")
+	require.NoError(t, h.FilesUploadFromURL(c))
+	assert.Equal(t, http.StatusNoContent, rec.Code)
+
+	select {
+	case in := <-rp.calls:
+		assert.Equal(t, "https://example.com/a/b.png", in.URL)
+		assert.Equal(t, "u1", in.User.ID)
+		require.NotNil(t, in.Marker)
+		assert.Equal(t, "mk1", *in.Marker)
+		assert.True(t, in.IsSensitive)
+	case <-time.After(2 * time.Second):
+		t.Fatal("Process was not invoked")
+	}
+}
+
+func TestFilesUploadFromURL_MissingURL(t *testing.T) {
+	h, _, _ := newHandler(t)
+	h.SetURLUploader(&recordingProcessor{calls: make(chan URLUploadInput, 1)})
+
+	c, rec := newJSONReq(t, `{}`)
+	setUser(c, "u1")
+	require.NoError(t, h.FilesUploadFromURL(c))
+	assert.Equal(t, http.StatusBadRequest, rec.Code)
+}
+
+func TestFilesUploadFromURL_CommentTooLong(t *testing.T) {
+	h, _, _ := newHandler(t)
+	h.SetURLUploader(&recordingProcessor{calls: make(chan URLUploadInput, 1)})
+
+	long := strings.Repeat("a", 513)
+	c, rec := newJSONReq(t, `{"url":"https://example.com/x","comment":"`+long+`"}`)
+	setUser(c, "u1")
+	require.NoError(t, h.FilesUploadFromURL(c))
+	assert.Equal(t, http.StatusBadRequest, rec.Code)
+}
+
+func TestFilesUploadFromURL_NotWired(t *testing.T) {
+	h, _, _ := newHandler(t) // urlUploader 未配線
+	c, rec := newJSONReq(t, `{"url":"https://example.com/x"}`)
+	setUser(c, "u1")
+	require.NoError(t, h.FilesUploadFromURL(c))
+	// upstream と同じく空レスポンス (204)。
+	assert.Equal(t, http.StatusNoContent, rec.Code)
+}

--- a/internal/server/router.go
+++ b/internal/server/router.go
@@ -1778,6 +1778,13 @@ func (s *Server) setupRoutes() {
 	notificationService.SetPacker(notificationPublisher)
 	driveService.SetStreamingPublisher(drivePublisher)
 	driveService.SetMainStreamPublisher(mainStreamPublisher)
+	// /drive/files/upload-from-url: SSRF-safe client で URL を download し、
+	// drive へ保存後 urlUploadFinished を main stream に流す (#1217)。download は
+	// 大きめになりうるので 60s timeout、cap は cfg.MaxFileSize に揃える。
+	driveHandler.SetURLUploader(drive.NewURLUploader(
+		s.outboundClient(60*time.Second), driveService, mainStreamPublisher,
+		idGen, s.config.UserAgent, s.config.MaxFileSize,
+	))
 	followingService.SetMainStreamPublisher(mainStreamPublisher)
 	userService.SetMainStreamPublisher(mainStreamPublisher)
 	noteCreateService.SetMainStreamPublisher(mainStreamPublisher)


### PR DESCRIPTION
## Summary

#1217 サブタスク A の最上位項目。204 no-op だった `/api/drive/files/upload-from-url` を upstream Misskey TS と同 semantics で実装する。URL を指定するとサーバーが非同期で download し drive に保存、完了後に user の main stream へ `urlUploadFinished` を流す。

## 主な変更点

### 新規 `internal/api/drive/url_upload.go`
- `URLUploadProcessor` interface + `URLUploader` 実装。`Process` が SSRF-safe fetch → `drive.Service.Upload` → `urlUploadFinished` ({marker, file}) publish を行う。
- `driveUploader` / `mainEventPublisher` interface で依存を decouple し、httptest + mock で unit test 可能にした。
- download cap は `cfg.MaxFileSize` (default 250 MiB)。`path.Base(url)` を file 名に、root path は `unknown` fallback。
- fetch / upload 失敗時は redacted log のみ残して publish しない (upstream 同様 fire-and-forget、UI は timeout 表示にフォールバック)。

### `internal/api/drive/handler.go`
- `FilesUploadFromURL`: param 検証 (`url` 必須 / `comment` maxLength 512)、`user` + uploader 配線時のみ `go Process(context.Background(), ...)` を起動し即 204。request context は応答後 cancel されるため background context を使う。
- 未配線 (単体テスト) は upstream 同様 204 no-op。

### `internal/server/router.go`
- `driveHandler.SetURLUploader(...)` を配線 (SSRF-safe client 60s + driveService + mainStreamPublisher + cfg.MaxFileSize)。
- rate limit (60/1hour) は既に `DefaultEndpointLimits` に定義済。

## upstream との対応

upstream は `uploadFromUrl(...).then(pack(file,{self:true})).then(publishMainStream('urlUploadFinished', {marker, file}))`。mk-go では `driveFileCreated` は `svc.Upload` 内で既に emit 済みのため、本実装は `urlUploadFinished` (marker 付き) を追加する。packer は `driveFileCreated` と同じ `entity.PackDriveFile`。

## テスト

- `url_upload_test.go`: Process の success / fetch error / invalid url / upload error / root-path name fallback / not-wired no-op / maxBytes default、handler の success (goroutine 起動を channel で同期) / missing url / comment too long / not-wired。
- `go build ./...` / `go vet` / `gofmt` クリーン
- `go test ./internal/api/drive/...` → 91.7% (CI ゲート 90% 通過)

## 関連
- 親 tracker: #1217

Closes #1231

🤖 Generated with [Claude Code](https://claude.com/claude-code)