### PR TITLE
feat(notifications): notifications/create を実装 (app 自己通知 #1233)

### DIFF
--- a/internal/api/notifications/handler.go
+++ b/internal/api/notifications/handler.go
@@ -240,18 +240,21 @@ func (h *Handler) MarkAllAsRead(c echo.Context) error {
 func (h *Handler) Create(c echo.Context) error {
 	user := middleware.GetUser(c)
 	var req struct {
-		Body   string  `json:"body"`
+		Body   *string `json:"body"`
 		Header *string `json:"header"`
 		Icon   *string `json:"icon"`
 	}
-	if err := c.Bind(&req); err != nil || req.Body == "" {
+	// upstream paramDef は body を required にするのみ (ajv の required は
+	// presence チェックなので空文字 "" も受理される)。よって不在 (nil) のみを
+	// INVALID_PARAM とし、空文字は upstream 同様に通す。
+	if err := c.Bind(&req); err != nil || req.Body == nil {
 		return apierr.JSONInvalidParam(c)
 	}
 	if h.svc == nil || user == nil {
 		return c.NoContent(http.StatusNoContent)
 	}
 
-	extra := map[string]any{"body": req.Body}
+	extra := map[string]any{"body": *req.Body}
 	if req.Header != nil {
 		extra["header"] = *req.Header
 	}

--- a/internal/api/notifications/handler.go
+++ b/internal/api/notifications/handler.go
@@ -227,9 +227,47 @@ func (h *Handler) MarkAllAsRead(c echo.Context) error {
 }
 
 // Create handles POST /api/notifications/create.
-// アプリ通知の作成 (簡易版)。
+//
+// upstream Misskey TS notifications/create と同 semantics: 認証中の app
+// (access token) が自分自身に type 'app' の任意通知を作る。body は必須、
+// header / icon は任意。body / header / icon は Extra に格納し、entity の
+// Extra spread で notification 出力に surface される (#1217)。
+//
+// 注: upstream は header/icon が無い場合 token.name / token.iconUrl に
+// フォールバックし appAccessTokenId も記録するが、mk-go の request context は
+// raw token 文字列のみで AccessToken オブジェクトを持たないため、ここでは
+// 渡された body / header / icon のみを使う (token 由来の fallback は省略)。
 func (h *Handler) Create(c echo.Context) error {
-	_ = middleware.GetUser(c)
+	user := middleware.GetUser(c)
+	var req struct {
+		Body   string  `json:"body"`
+		Header *string `json:"header"`
+		Icon   *string `json:"icon"`
+	}
+	if err := c.Bind(&req); err != nil || req.Body == "" {
+		return apierr.JSONInvalidParam(c)
+	}
+	if h.svc == nil || user == nil {
+		return c.NoContent(http.StatusNoContent)
+	}
+
+	extra := map[string]any{"body": req.Body}
+	if req.Header != nil {
+		extra["header"] = *req.Header
+	}
+	if req.Icon != nil {
+		extra["icon"] = *req.Icon
+	}
+	// app 通知は notifier を持たない。NotifierID を空にすることで
+	// service.Create の self-notification ガード (NotifierID == NotifieeID) も
+	// 回避する。upstream 同様 fire-and-forget なので結果は 204 固定。
+	if _, err := h.svc.Create(c.Request().Context(), notification.CreateInput{
+		NotifieeID: user.ID,
+		Type:       notification.TypeApp,
+		Extra:      extra,
+	}); err != nil {
+		slog.Warn("notifications/create failed", "user", user.ID, "err", err)
+	}
 	return c.NoContent(http.StatusNoContent)
 }
 

--- a/internal/api/notifications/handler_test.go
+++ b/internal/api/notifications/handler_test.go
@@ -339,6 +339,25 @@ func TestCreate_MissingBody(t *testing.T) {
 	assert.Equal(t, http.StatusBadRequest, rec.Code)
 }
 
+// upstream の ajv required は presence チェックなので body="" は受理される。
+// mk-go も不在 (nil) のみ 400 とし、空文字は通すこと (drop-in 互換)。
+func TestCreate_EmptyBodyAccepted(t *testing.T) {
+	h, _ := newTestHandler(t)
+	c, rec := newJSONRequest(t, "/api/notifications/create", `{"body":""}`)
+	setAuth(c, &model.User{ID: "alice"})
+	require.NoError(t, h.Create(c))
+	assert.Equal(t, http.StatusNoContent, rec.Code)
+
+	c2, rec2 := newJSONRequest(t, "/api/i/notifications", `{"limit":50}`)
+	setAuth(c2, &model.User{ID: "alice"})
+	require.NoError(t, h.Show(c2))
+	var resp []map[string]any
+	require.NoError(t, json.Unmarshal(rec2.Body.Bytes(), &resp))
+	require.Len(t, resp, 1)
+	assert.Equal(t, "app", resp[0]["type"])
+	assert.Equal(t, "", resp[0]["body"])
+}
+
 func TestCreate_NilService(t *testing.T) {
 	idGen, _ := id.NewGenerator("aidx")
 	h := NewHandler(nil, idGen)

--- a/internal/api/notifications/handler_test.go
+++ b/internal/api/notifications/handler_test.go
@@ -288,7 +288,61 @@ func TestMarkAllAsRead_RedisError(t *testing.T) {
 
 func TestCreate_Success(t *testing.T) {
 	h, _ := newTestHandler(t)
+	c, rec := newJSONRequest(t, "/api/notifications/create", `{"body":"hello","header":"MyApp","icon":"https://example.com/i.png"}`)
+	setAuth(c, &model.User{ID: "alice"})
+	require.NoError(t, h.Create(c))
+	assert.Equal(t, http.StatusNoContent, rec.Code)
+
+	// Show で type 'app' + body/header/icon が surface されることを検証。
+	c2, rec2 := newJSONRequest(t, "/api/i/notifications", `{"limit":50}`)
+	setAuth(c2, &model.User{ID: "alice"})
+	require.NoError(t, h.Show(c2))
+	require.Equal(t, http.StatusOK, rec2.Code)
+	var resp []map[string]any
+	require.NoError(t, json.Unmarshal(rec2.Body.Bytes(), &resp))
+	require.Len(t, resp, 1)
+	assert.Equal(t, "app", resp[0]["type"])
+	assert.Equal(t, "hello", resp[0]["body"])
+	assert.Equal(t, "MyApp", resp[0]["header"])
+	assert.Equal(t, "https://example.com/i.png", resp[0]["icon"])
+	// app 通知は notifier を持たないこと。
+	_, hasUserID := resp[0]["userId"]
+	assert.False(t, hasUserID, "app notification must not carry a notifier userId")
+}
+
+func TestCreate_BodyOnly(t *testing.T) {
+	h, _ := newTestHandler(t)
+	c, rec := newJSONRequest(t, "/api/notifications/create", `{"body":"just body"}`)
+	setAuth(c, &model.User{ID: "alice"})
+	require.NoError(t, h.Create(c))
+	assert.Equal(t, http.StatusNoContent, rec.Code)
+
+	c2, rec2 := newJSONRequest(t, "/api/i/notifications", `{"limit":50}`)
+	setAuth(c2, &model.User{ID: "alice"})
+	require.NoError(t, h.Show(c2))
+	var resp []map[string]any
+	require.NoError(t, json.Unmarshal(rec2.Body.Bytes(), &resp))
+	require.Len(t, resp, 1)
+	assert.Equal(t, "just body", resp[0]["body"])
+	// 未指定の header / icon はキーごと省略されること。
+	_, hasHeader := resp[0]["header"]
+	assert.False(t, hasHeader)
+	_, hasIcon := resp[0]["icon"]
+	assert.False(t, hasIcon)
+}
+
+func TestCreate_MissingBody(t *testing.T) {
+	h, _ := newTestHandler(t)
 	c, rec := newJSONRequest(t, "/api/notifications/create", `{}`)
+	setAuth(c, &model.User{ID: "alice"})
+	require.NoError(t, h.Create(c))
+	assert.Equal(t, http.StatusBadRequest, rec.Code)
+}
+
+func TestCreate_NilService(t *testing.T) {
+	idGen, _ := id.NewGenerator("aidx")
+	h := NewHandler(nil, idGen)
+	c, rec := newJSONRequest(t, "/api/notifications/create", `{"body":"x"}`)
 	setAuth(c, &model.User{ID: "alice"})
 	require.NoError(t, h.Create(c))
 	assert.Equal(t, http.StatusNoContent, rec.Code)

--- a/internal/core/notification/notification_service.go
+++ b/internal/core/notification/notification_service.go
@@ -26,6 +26,10 @@ const (
 	TypeRenote   Type = "renote"
 	TypeQuote    Type = "quote"
 	TypeReaction Type = "reaction"
+	// TypeApp: アプリ (access token) が notifications/create で自分自身に作る
+	// 任意通知 (#1217)。notifier を持たず、body / header / icon を Extra に
+	// 格納して entity の Extra spread で surface する。
+	TypeApp Type = "app"
 	// TypePollVote: per-vote 通知。Misskey TS には対応 type が無いため
 	// frontend が空 body で render してしまい運用上 noise だけが残る (#690)。
 	// service 側からは発火しない (poll_service が呼ばないように disable


### PR DESCRIPTION
## Summary

#1217 サブタスク A の項目。204 no-op だった `/api/notifications/create` を upstream Misskey TS と同 semantics で実装する。認証中の app (access token) が自分自身に type 'app' の任意通知を作る。

## 主な変更点

- `internal/core/notification/notification_service.go`: `TypeApp` ("app") 定数を追加。
- `internal/api/notifications/handler.go` (`Create`):
  - params `body` (必須) / `header` (任意) / `icon` (任意) を受け取り、`body` 未指定は INVALID_PARAM。
  - `body`/`header`/`icon` を `Extra` に格納し、`service.Create` で type 'app' の通知を作成。entity の Extra spread でそのまま notification 出力に surface される。
  - app 通知は notifier を持たないため `NotifierID` を空にして `service.Create` の self-notification ガード (`NotifierID == NotifieeID`) を回避。upstream 同様 fire-and-forget で結果は 204 固定 (Create エラーは log のみ)。
- rate limit (`notifications/create`: 10/1min) は既に `DefaultEndpointLimits` に定義済。

## upstream との差分

upstream は `header`/`icon` 未指定時に `token.name` / `token.iconUrl` へフォールバックし `appAccessTokenId` も記録するが、mk-go の request context は raw token 文字列のみで AccessToken オブジェクトを持たないため、渡された `body`/`header`/`icon` のみを使う (token 由来の fallback と appAccessTokenId は省略)。`body` は必須なので通知本体は常に表示される。

## テスト

- `TestCreate_Success`: body+header+icon → 204 → Show で type 'app' / body / header / icon が surface され、notifier userId を持たないことを検証。
- `TestCreate_BodyOnly`: body のみ → header/icon キーが省略されること。
- `TestCreate_MissingBody`: body 無し → 400。
- `TestCreate_NilService`: svc 未配線 → 204。
- `go build ./...` / `go vet` / `gofmt` クリーン
- `go test ./internal/api/notifications/... ./internal/core/notification/...` → 93.6% / 91.6% (ゲート通過)

## 関連
- 親 tracker: #1217

Closes #1233

🤖 Generated with [Claude Code](https://claude.com/claude-code)