### PR TITLE
feat(transfer): export-custom-emojis を実装 (custom emoji zip export #1235)

### DIFF
--- a/internal/core/transfer/emoji_export.go
+++ b/internal/core/transfer/emoji_export.go
@@ -126,8 +126,10 @@ func (e *Exporter) exportCustomEmojis(ctx context.Context) ([]byte, error) {
 	meta := emojiMetaDoc{
 		MetaVersion: emojiExportMetaVersion,
 		Host:        nil,
-		ExportedAt:  time.Now().UTC().Format(time.RFC3339),
-		Emojis:      records,
+		// upstream は new Date().toISOString() (ms 付き `...000Z`) を出す。
+		// codebase 内の他 ISO timestamp とも形式を揃える。
+		ExportedAt: time.Now().UTC().Format("2006-01-02T15:04:05.000Z"),
+		Emojis:     records,
 	}
 	metaBytes, err := json.Marshal(meta)
 	if err != nil {

--- a/internal/core/transfer/emoji_export.go
+++ b/internal/core/transfer/emoji_export.go
@@ -1,0 +1,215 @@
+package transfer
+
+import (
+	"archive/zip"
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"log/slog"
+	"net/http"
+	"path"
+	"time"
+
+	"github.com/shiroha-a/mk/internal/model"
+	"github.com/shiroha-a/mk/internal/safehttp"
+)
+
+// ExportCustomEmojis is the export type for the custom-emoji ZIP archive
+// (upstream `export-custom-emojis`). Produces a ZIP of every local emoji image
+// plus a meta.json that round-trips through emojiimport's import-zip flow.
+const ExportCustomEmojis = "custom-emojis"
+
+// emojiExportMetaVersion matches the version emitted by Misskey's
+// ExportCustomEmojisProcessorService. emojiimport は値を gate しないが upstream
+// 互換のため 2 を出す。
+const emojiExportMetaVersion = 2
+
+// defaultEmojiImageMaxBytes caps a single emoji image download (8 MiB, same as
+// the admin emoji copy path).
+const defaultEmojiImageMaxBytes int64 = 8 << 20
+
+// EmojiSource lists the local custom emojis to include in an export.
+// Satisfied by repository.EmojiRepository (CachedEmojiRepository).
+type EmojiSource interface {
+	ListLocal() ([]*model.Emoji, error)
+}
+
+// EmojiImageFetcher downloads an emoji image by URL. Production wires an
+// SSRF-safe HTTP client; nil disables image embedding (meta.json only,
+// downloaded=false for every entry).
+type EmojiImageFetcher interface {
+	Fetch(ctx context.Context, url string) ([]byte, error)
+}
+
+// emojiMetaDoc / emojiMetaRecord / emojiMetaEmoji mirror the meta.json shape
+// consumed by emojiimport (and produced by upstream). Duplicated here (rather
+// than shared) so the two packages stay decoupled; the JSON contract is what
+// matters and the round-trip is covered by tests.
+type emojiMetaDoc struct {
+	MetaVersion int               `json:"metaVersion"`
+	Host        *string           `json:"host"`
+	ExportedAt  string            `json:"exportedAt"`
+	Emojis      []emojiMetaRecord `json:"emojis"`
+}
+
+type emojiMetaRecord struct {
+	FileName   string         `json:"fileName"`
+	Downloaded bool           `json:"downloaded"`
+	Emoji      emojiMetaEmoji `json:"emoji"`
+}
+
+type emojiMetaEmoji struct {
+	Name        string   `json:"name"`
+	Category    *string  `json:"category"`
+	Aliases     []string `json:"aliases"`
+	License     *string  `json:"license"`
+	IsSensitive bool     `json:"isSensitive"`
+	LocalOnly   bool     `json:"localOnly"`
+}
+
+// exportCustomEmojis builds a Misskey-compatible custom-emoji ZIP: one entry
+// per emoji image named `<emojiName>.<ext>` plus a meta.json describing every
+// emoji. Per-image download failures are tolerated (downloaded=false, no zip
+// entry) so a single unreachable image does not abort the whole export, matching
+// the import side which skips records with downloaded=false / missing entries.
+func (e *Exporter) exportCustomEmojis(ctx context.Context) ([]byte, error) {
+	if e.deps.EmojiRepo == nil {
+		return nil, fmt.Errorf("emoji source not configured")
+	}
+	emojis, err := e.deps.EmojiRepo.ListLocal()
+	if err != nil {
+		return nil, fmt.Errorf("list local emojis: %w", err)
+	}
+
+	var buf bytes.Buffer
+	zw := zip.NewWriter(&buf)
+	records := make([]emojiMetaRecord, 0, len(emojis))
+	for _, em := range emojis {
+		if err := ctx.Err(); err != nil {
+			return nil, err
+		}
+		fileName := em.Name + emojiImageExt(em)
+		downloaded := false
+		if e.deps.EmojiImageFetcher != nil {
+			url := em.PublicURL
+			if url == "" {
+				url = em.OriginalURL
+			}
+			if img, ferr := e.deps.EmojiImageFetcher.Fetch(ctx, url); ferr != nil {
+				slog.Warn("emoji export: image fetch failed", "emoji", em.Name, "err", ferr)
+			} else if len(img) > 0 {
+				w, werr := zw.Create(fileName)
+				if werr != nil {
+					return nil, fmt.Errorf("zip entry %s: %w", fileName, werr)
+				}
+				if _, werr := w.Write(img); werr != nil {
+					return nil, fmt.Errorf("write entry %s: %w", fileName, werr)
+				}
+				downloaded = true
+			}
+		}
+		records = append(records, emojiMetaRecord{
+			FileName:   fileName,
+			Downloaded: downloaded,
+			Emoji: emojiMetaEmoji{
+				Name:        em.Name,
+				Category:    em.Category,
+				Aliases:     append([]string{}, em.Aliases...),
+				License:     em.License,
+				IsSensitive: em.IsSensitive,
+				LocalOnly:   em.LocalOnly,
+			},
+		})
+	}
+
+	meta := emojiMetaDoc{
+		MetaVersion: emojiExportMetaVersion,
+		Host:        nil,
+		ExportedAt:  time.Now().UTC().Format(time.RFC3339),
+		Emojis:      records,
+	}
+	metaBytes, err := json.Marshal(meta)
+	if err != nil {
+		return nil, fmt.Errorf("marshal meta.json: %w", err)
+	}
+	mw, err := zw.Create("meta.json")
+	if err != nil {
+		return nil, fmt.Errorf("zip meta.json: %w", err)
+	}
+	if _, err := mw.Write(metaBytes); err != nil {
+		return nil, fmt.Errorf("write meta.json: %w", err)
+	}
+	if err := zw.Close(); err != nil {
+		return nil, fmt.Errorf("close zip: %w", err)
+	}
+	return buf.Bytes(), nil
+}
+
+// emojiImageExt derives the archive filename extension from the emoji's MIME
+// type, falling back to the URL path extension and finally ".png".
+func emojiImageExt(em *model.Emoji) string {
+	if em.Type != nil {
+		switch *em.Type {
+		case "image/png":
+			return ".png"
+		case "image/gif":
+			return ".gif"
+		case "image/jpeg":
+			return ".jpg"
+		case "image/webp":
+			return ".webp"
+		case "image/apng":
+			return ".apng"
+		case "image/avif":
+			return ".avif"
+		}
+	}
+	if ext := path.Ext(em.PublicURL); ext != "" {
+		return ext
+	}
+	if ext := path.Ext(em.OriginalURL); ext != "" {
+		return ext
+	}
+	return ".png"
+}
+
+// HTTPEmojiImageFetcher is the production EmojiImageFetcher. client must be an
+// SSRF-safe http.Client so emoji URLs pointing at private IPs cannot be abused.
+type HTTPEmojiImageFetcher struct {
+	client    *http.Client
+	userAgent string
+	maxBytes  int64
+}
+
+// NewHTTPEmojiImageFetcher builds a fetcher. maxBytes <= 0 falls back to 8 MiB.
+func NewHTTPEmojiImageFetcher(client *http.Client, userAgent string, maxBytes int64) *HTTPEmojiImageFetcher {
+	if maxBytes <= 0 {
+		maxBytes = defaultEmojiImageMaxBytes
+	}
+	return &HTTPEmojiImageFetcher{client: client, userAgent: userAgent, maxBytes: maxBytes}
+}
+
+// Fetch downloads the image at url, capping the body at maxBytes.
+func (f *HTTPEmojiImageFetcher) Fetch(ctx context.Context, url string) ([]byte, error) {
+	if f.client == nil || url == "" {
+		return nil, fmt.Errorf("emoji image fetcher not usable")
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return nil, fmt.Errorf("build request: %w", err)
+	}
+	req.Header.Set("Accept", "image/*, */*")
+	if f.userAgent != "" {
+		req.Header.Set("User-Agent", f.userAgent)
+	}
+	resp, err := f.client.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("fetch: %w", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode >= 400 {
+		return nil, fmt.Errorf("upstream status %d", resp.StatusCode)
+	}
+	return safehttp.ReadAllLimit(resp.Body, f.maxBytes)
+}

--- a/internal/core/transfer/emoji_export_test.go
+++ b/internal/core/transfer/emoji_export_test.go
@@ -11,6 +11,7 @@ import (
 	"net/http/httptest"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/lib/pq"
 	"github.com/shiroha-a/mk/internal/core/notification"
@@ -89,7 +90,8 @@ func TestExport_CustomEmojis(t *testing.T) {
 
 	require.Contains(t, entries, "meta.json")
 	var meta struct {
-		MetaVersion int `json:"metaVersion"`
+		MetaVersion int    `json:"metaVersion"`
+		ExportedAt  string `json:"exportedAt"`
 		Emojis      []struct {
 			FileName   string `json:"fileName"`
 			Downloaded bool   `json:"downloaded"`
@@ -104,6 +106,9 @@ func TestExport_CustomEmojis(t *testing.T) {
 	}
 	require.NoError(t, json.Unmarshal(entries["meta.json"], &meta))
 	assert.Equal(t, 2, meta.MetaVersion)
+	// exportedAt は ISO8601 ms 精度 (upstream toISOString 互換)。
+	_, perr := time.Parse("2006-01-02T15:04:05.000Z", meta.ExportedAt)
+	assert.NoError(t, perr, "exportedAt=%q should be ISO8601 ms", meta.ExportedAt)
 	require.Len(t, meta.Emojis, 2)
 
 	assert.Equal(t, "smile.png", meta.Emojis[0].FileName)

--- a/internal/core/transfer/emoji_export_test.go
+++ b/internal/core/transfer/emoji_export_test.go
@@ -1,0 +1,274 @@
+package transfer_test
+
+import (
+	"archive/zip"
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/lib/pq"
+	"github.com/shiroha-a/mk/internal/core/notification"
+	"github.com/shiroha-a/mk/internal/core/transfer"
+	"github.com/shiroha-a/mk/internal/model"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type fakeEmojiSource struct {
+	emojis []*model.Emoji
+	err    error
+}
+
+func (f *fakeEmojiSource) ListLocal() ([]*model.Emoji, error) { return f.emojis, f.err }
+
+type fakeEmojiFetcher struct {
+	byURL  map[string][]byte
+	errURL map[string]bool
+}
+
+func (f *fakeEmojiFetcher) Fetch(_ context.Context, url string) ([]byte, error) {
+	if f.errURL[url] {
+		return nil, errors.New("fetch failed")
+	}
+	if b, ok := f.byURL[url]; ok {
+		return b, nil
+	}
+	return nil, errors.New("not found")
+}
+
+func unzip(t *testing.T, body []byte) map[string][]byte {
+	t.Helper()
+	zr, err := zip.NewReader(bytes.NewReader(body), int64(len(body)))
+	require.NoError(t, err)
+	out := make(map[string][]byte, len(zr.File))
+	for _, f := range zr.File {
+		rc, err := f.Open()
+		require.NoError(t, err)
+		b, err := io.ReadAll(rc)
+		require.NoError(t, rc.Close())
+		require.NoError(t, err)
+		out[f.Name] = b
+	}
+	return out
+}
+
+func strptr(s string) *string { return &s }
+
+func TestExport_CustomEmojis(t *testing.T) {
+	saver, notifier, deps, user := newExportDeps(t)
+	deps.EmojiRepo = &fakeEmojiSource{emojis: []*model.Emoji{
+		{ID: "e1", Name: "smile", PublicURL: "https://x/e/smile.png", Type: strptr("image/png"), Category: strptr("fun"), Aliases: pq.StringArray{"happy"}, IsSensitive: true, LocalOnly: false},
+		{ID: "e2", Name: "broken", PublicURL: "https://x/e/broken.png", Type: strptr("image/png")},
+	}}
+	deps.EmojiImageFetcher = &fakeEmojiFetcher{
+		byURL:  map[string][]byte{"https://x/e/smile.png": []byte("PNGDATA")},
+		errURL: map[string]bool{"https://x/e/broken.png": true},
+	}
+	exporter := transfer.NewExporter(deps)
+
+	file, err := exporter.Export(context.Background(), user.ID, transfer.ExportCustomEmojis)
+	require.NoError(t, err)
+	require.NotNil(t, file)
+	require.Len(t, saver.uploads, 1)
+	up := saver.uploads[0]
+	assert.True(t, strings.HasSuffix(up.Name, ".zip"))
+	assert.Contains(t, up.Name, "custom-emojis")
+
+	entries := unzip(t, up.Body)
+	// 画像取得に成功した emoji だけ zip entry を持つ。
+	require.Contains(t, entries, "smile.png")
+	assert.Equal(t, []byte("PNGDATA"), entries["smile.png"])
+	_, hasBroken := entries["broken.png"]
+	assert.False(t, hasBroken, "fetch 失敗 emoji は画像 entry を持たない")
+
+	require.Contains(t, entries, "meta.json")
+	var meta struct {
+		MetaVersion int `json:"metaVersion"`
+		Emojis      []struct {
+			FileName   string `json:"fileName"`
+			Downloaded bool   `json:"downloaded"`
+			Emoji      struct {
+				Name        string   `json:"name"`
+				Category    *string  `json:"category"`
+				Aliases     []string `json:"aliases"`
+				IsSensitive bool     `json:"isSensitive"`
+				LocalOnly   bool     `json:"localOnly"`
+			} `json:"emoji"`
+		} `json:"emojis"`
+	}
+	require.NoError(t, json.Unmarshal(entries["meta.json"], &meta))
+	assert.Equal(t, 2, meta.MetaVersion)
+	require.Len(t, meta.Emojis, 2)
+
+	assert.Equal(t, "smile.png", meta.Emojis[0].FileName)
+	assert.True(t, meta.Emojis[0].Downloaded)
+	assert.Equal(t, "smile", meta.Emojis[0].Emoji.Name)
+	require.NotNil(t, meta.Emojis[0].Emoji.Category)
+	assert.Equal(t, "fun", *meta.Emojis[0].Emoji.Category)
+	assert.Equal(t, []string{"happy"}, meta.Emojis[0].Emoji.Aliases)
+	assert.True(t, meta.Emojis[0].Emoji.IsSensitive)
+
+	assert.Equal(t, "broken.png", meta.Emojis[1].FileName)
+	assert.False(t, meta.Emojis[1].Downloaded, "fetch 失敗は downloaded=false")
+
+	// exportCompleted 通知が custom-emojis entity で発火すること。
+	require.Len(t, notifier.calls, 1)
+	assert.Equal(t, notification.TypeExportCompleted, notifier.calls[0].Type)
+	assert.Equal(t, "custom-emojis", notifier.calls[0].Extra["exportedEntity"])
+	assert.Equal(t, file.ID, notifier.calls[0].Extra["fileId"])
+}
+
+func TestExport_CustomEmojis_NoFetcherProducesMetaOnly(t *testing.T) {
+	saver, _, deps, user := newExportDeps(t)
+	deps.EmojiRepo = &fakeEmojiSource{emojis: []*model.Emoji{
+		{ID: "e1", Name: "smile", PublicURL: "https://x/e/smile.png", Type: strptr("image/png")},
+	}}
+	// EmojiImageFetcher 未配線 → 画像なし meta.json のみ。
+	exporter := transfer.NewExporter(deps)
+
+	_, err := exporter.Export(context.Background(), user.ID, transfer.ExportCustomEmojis)
+	require.NoError(t, err)
+	entries := unzip(t, saver.uploads[0].Body)
+	require.Contains(t, entries, "meta.json")
+	_, hasImg := entries["smile.png"]
+	assert.False(t, hasImg)
+}
+
+func TestExport_CustomEmojis_NoRepoErrors(t *testing.T) {
+	_, _, deps, user := newExportDeps(t)
+	// EmojiRepo 未配線 → エラー。
+	exporter := transfer.NewExporter(deps)
+	_, err := exporter.Export(context.Background(), user.ID, transfer.ExportCustomEmojis)
+	require.Error(t, err)
+}
+
+func TestExport_CustomEmojis_ListError(t *testing.T) {
+	_, _, deps, user := newExportDeps(t)
+	deps.EmojiRepo = &fakeEmojiSource{err: errors.New("db down")}
+	exporter := transfer.NewExporter(deps)
+	_, err := exporter.Export(context.Background(), user.ID, transfer.ExportCustomEmojis)
+	require.Error(t, err)
+}
+
+func TestExport_CustomEmojis_ExtFallback(t *testing.T) {
+	saver, _, deps, user := newExportDeps(t)
+	// Type なし + URL の拡張子から推定 (.gif)。
+	deps.EmojiRepo = &fakeEmojiSource{emojis: []*model.Emoji{
+		{ID: "e1", Name: "dance", PublicURL: "https://x/e/dance.gif"},
+	}}
+	deps.EmojiImageFetcher = &fakeEmojiFetcher{byURL: map[string][]byte{"https://x/e/dance.gif": []byte("GIF")}}
+	exporter := transfer.NewExporter(deps)
+
+	_, err := exporter.Export(context.Background(), user.ID, transfer.ExportCustomEmojis)
+	require.NoError(t, err)
+	entries := unzip(t, saver.uploads[0].Body)
+	assert.Contains(t, entries, "dance.gif")
+}
+
+func TestExport_CustomEmojis_ExtVariants(t *testing.T) {
+	saver, _, deps, user := newExportDeps(t)
+	emojis := []*model.Emoji{
+		{ID: "1", Name: "a", PublicURL: "https://x/a", Type: strptr("image/png")},
+		{ID: "2", Name: "b", PublicURL: "https://x/b", Type: strptr("image/gif")},
+		{ID: "3", Name: "c", PublicURL: "https://x/c", Type: strptr("image/jpeg")},
+		{ID: "4", Name: "d", PublicURL: "https://x/d", Type: strptr("image/webp")},
+		{ID: "5", Name: "e", PublicURL: "https://x/e", Type: strptr("image/apng")},
+		{ID: "6", Name: "f", PublicURL: "https://x/f", Type: strptr("image/avif")},
+		// Type が未知/nil で URL にも拡張子が無い → 最終フォールバック .png。
+		{ID: "7", Name: "g", PublicURL: "https://x/g", Type: strptr("application/octet-stream")},
+	}
+	fetch := &fakeEmojiFetcher{byURL: map[string][]byte{}}
+	for _, em := range emojis {
+		fetch.byURL[em.PublicURL] = []byte("DATA")
+	}
+	deps.EmojiRepo = &fakeEmojiSource{emojis: emojis}
+	deps.EmojiImageFetcher = fetch
+	exporter := transfer.NewExporter(deps)
+
+	_, err := exporter.Export(context.Background(), user.ID, transfer.ExportCustomEmojis)
+	require.NoError(t, err)
+	entries := unzip(t, saver.uploads[0].Body)
+	for _, name := range []string{"a.png", "b.gif", "c.jpg", "d.webp", "e.apng", "f.avif", "g.png"} {
+		assert.Contains(t, entries, name)
+	}
+}
+
+func TestExport_CustomEmojis_EmptyBytesNotDownloaded(t *testing.T) {
+	saver, _, deps, user := newExportDeps(t)
+	deps.EmojiRepo = &fakeEmojiSource{emojis: []*model.Emoji{
+		{ID: "e1", Name: "empty", PublicURL: "https://x/empty.png", Type: strptr("image/png")},
+	}}
+	// fetch は成功するが 0 byte → entry を作らず downloaded=false。
+	deps.EmojiImageFetcher = &fakeEmojiFetcher{byURL: map[string][]byte{"https://x/empty.png": {}}}
+	exporter := transfer.NewExporter(deps)
+
+	_, err := exporter.Export(context.Background(), user.ID, transfer.ExportCustomEmojis)
+	require.NoError(t, err)
+	entries := unzip(t, saver.uploads[0].Body)
+	_, hasImg := entries["empty.png"]
+	assert.False(t, hasImg)
+}
+
+func TestExport_CustomEmojis_OriginalURLFallback(t *testing.T) {
+	saver, _, deps, user := newExportDeps(t)
+	// PublicURL 空 → OriginalURL から取得 + 拡張子推定。
+	deps.EmojiRepo = &fakeEmojiSource{emojis: []*model.Emoji{
+		{ID: "e1", Name: "orig", PublicURL: "", OriginalURL: "https://x/orig.webp"},
+	}}
+	deps.EmojiImageFetcher = &fakeEmojiFetcher{byURL: map[string][]byte{"https://x/orig.webp": []byte("W")}}
+	exporter := transfer.NewExporter(deps)
+
+	_, err := exporter.Export(context.Background(), user.ID, transfer.ExportCustomEmojis)
+	require.NoError(t, err)
+	entries := unzip(t, saver.uploads[0].Body)
+	assert.Contains(t, entries, "orig.webp")
+}
+
+func TestExport_CustomEmojis_ContextCancelled(t *testing.T) {
+	_, _, deps, user := newExportDeps(t)
+	deps.EmojiRepo = &fakeEmojiSource{emojis: []*model.Emoji{
+		{ID: "e1", Name: "x", PublicURL: "https://x/x.png", Type: strptr("image/png")},
+	}}
+	deps.EmojiImageFetcher = &fakeEmojiFetcher{byURL: map[string][]byte{"https://x/x.png": []byte("D")}}
+	exporter := transfer.NewExporter(deps)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	_, err := exporter.Export(ctx, user.ID, transfer.ExportCustomEmojis)
+	require.Error(t, err)
+}
+
+func TestHTTPEmojiImageFetcher(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte("IMG"))
+	}))
+	defer srv.Close()
+
+	f := transfer.NewHTTPEmojiImageFetcher(http.DefaultClient, "mk-go-test", 0)
+	b, err := f.Fetch(context.Background(), srv.URL)
+	require.NoError(t, err)
+	assert.Equal(t, []byte("IMG"), b)
+}
+
+func TestHTTPEmojiImageFetcher_StatusError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	defer srv.Close()
+
+	f := transfer.NewHTTPEmojiImageFetcher(http.DefaultClient, "", 0)
+	_, err := f.Fetch(context.Background(), srv.URL)
+	require.Error(t, err)
+}
+
+func TestHTTPEmojiImageFetcher_NilClient(t *testing.T) {
+	f := transfer.NewHTTPEmojiImageFetcher(nil, "", 0)
+	_, err := f.Fetch(context.Background(), "https://example.com/x.png")
+	require.Error(t, err)
+}

--- a/internal/core/transfer/transfer.go
+++ b/internal/core/transfer/transfer.go
@@ -97,6 +97,10 @@ type ExporterDeps struct {
 	UserListRepo     repository.UserListRepository
 	Drive            DriveSaver
 	Notifier         NotificationDispatcher
+	// EmojiRepo / EmojiImageFetcher は custom-emojis export 用 (任意)。未配線
+	// なら ExportCustomEmojis は "emoji source not configured" で失敗する。
+	EmojiRepo         EmojiSource
+	EmojiImageFetcher EmojiImageFetcher
 }
 
 // Exporter produces Misskey-compatible export files and saves them as
@@ -148,6 +152,9 @@ func (e *Exporter) Export(ctx context.Context, userID, exportType string) (*mode
 	case ExportClips:
 		body, err = e.exportClips(user.ID)
 		name = timestampedName("clips", "json")
+	case ExportCustomEmojis:
+		body, err = e.exportCustomEmojis(ctx)
+		name = timestampedName("custom-emojis", "zip")
 	default:
 		return nil, fmt.Errorf("%w: %s", ErrUnsupportedType, exportType)
 	}

--- a/internal/server/router.go
+++ b/internal/server/router.go
@@ -422,6 +422,11 @@ func (s *Server) setupRoutes() {
 		UserListRepo:     userListRepo,
 		Drive:            driveService,
 		Notifier:         notificationService,
+		// custom-emojis export: 全 local emoji を ListLocal で列挙し、各画像を
+		// SSRF-safe client で download して zip 化する (#1217)。画像取得は最大
+		// 60s/個、cap 8 MiB。
+		EmojiRepo:         emojiRepo,
+		EmojiImageFetcher: coretransfer.NewHTTPEmojiImageFetcher(s.outboundClient(60*time.Second), s.config.UserAgent, 0),
 	})
 	driveReader := coretransfer.NewRepoBackedDriveReader(driveFileRepo, driveStorage)
 	importer := coretransfer.NewImporter(coretransfer.ImporterDeps{
@@ -2395,8 +2400,20 @@ func (s *Server) setupRoutes() {
 	// notes (plain) — bulk note lookup by noteIds
 	api.POST("/notes", notesHandler.BulkShow)
 
-	// export-custom-emojis — zip export (complex, stub)
+	// export-custom-emojis — 全 local custom emoji を zip (画像 + meta.json) に
+	// export する非同期ジョブを enqueue する (#1217)。upstream 同様 endpoint は
+	// 即 204 を返し、生成完了後に exportCompleted 通知 + drive file で受け取る。
 	api.POST("/export-custom-emojis", func(c echo.Context) error {
+		user := middleware.GetUser(c)
+		if user == nil {
+			return c.NoContent(http.StatusNoContent)
+		}
+		if err := s.queueClient.EnqueueExport(queue.ExportPayload{
+			UserID: user.ID,
+			Type:   coretransfer.ExportCustomEmojis,
+		}); err != nil {
+			slog.Warn("export-custom-emojis: enqueue failed", "user", user.ID, "err", err)
+		}
 		return c.NoContent(http.StatusNoContent)
 	}, middleware.RequireAuth())
 


### PR DESCRIPTION
## Summary

#1217 サブタスク A の項目。204 no-op だった `/api/export-custom-emojis` を upstream Misskey TS と同 semantics で実装する。認証ユーザーが全 local custom emoji の zip export ジョブを enqueue し、生成完了後に `exportCompleted` 通知 + drive file で受け取る。

## 主な変更点

### `internal/core/transfer/emoji_export.go` (新規)
- `ExportCustomEmojis = "custom-emojis"` const + `exportCustomEmojis(ctx)`。
- `ListLocal()` で全 local emoji を列挙し、各画像を `EmojiImageFetcher` で URL から download → `<emojiName>.<ext>` として zip に追加 + `meta.json` を生成。
- `meta.json` は emojiimport の `metaDoc` と**同一 JSON フォーマット** (`metaVersion`/`host`/`exportedAt`/`emojis[].{fileName,downloaded,emoji{...}}`) で、**import-zip と round-trip** する。
- per-image fetch 失敗は `downloaded=false` + 画像 entry なしで許容し、job 全体を止めない (import 側が downloaded=false を skip する tolerance と対称)。
- `emojiImageExt` は MIME → 拡張子、URL path ext、最終 `.png` の順でフォールバック。
- `HTTPEmojiImageFetcher`: SSRF-safe `http.Client` + size cap (8 MiB) の画像 fetcher。
- `EmojiSource` (`ListLocal`) / `EmojiImageFetcher` interface で依存を decouple し unit test 可能に。

### `internal/core/transfer/transfer.go`
- `ExporterDeps` に `EmojiRepo` / `EmojiImageFetcher` を追加。`Export` switch に `ExportCustomEmojis` case を追加 (zip bytes + `custom-emojis-<ts>.zip`)。保存 + 通知は既存の汎用パイプラインがそのまま処理。

### `internal/server/router.go`
- endpoint stub を `queueClient.EnqueueExport(ExportPayload{Type: "custom-emojis"})` に置換 (upstream 同様 fire-and-forget で即 204)。
- `ExporterDeps` に `EmojiRepo: emojiRepo` (CachedEmojiRepository) + `EmojiImageFetcher: NewHTTPEmojiImageFetcher(outboundClient(60s), ...)` を配線。
- rate limit (1/hour) は既に `DefaultEndpointLimits` に定義済。

## テスト

- `emoji_export_test.go`: 成功 (画像 entry + meta.json contract + exportedEntity 通知) / fetcher 未配線で meta-only / EmojiRepo 未配線 error / ListLocal error / 拡張子バリアント (png/gif/jpg/webp/apng/avif + フォールバック) / 0 byte は downloaded=false / OriginalURL フォールバック / ctx cancel / HTTP fetcher (success/status error/nil client)。
- `go build ./...` / `go vet` / `gofmt` クリーン
- `go test ./internal/core/transfer/...` → 92.0% (CI ゲート 90% 通過)

## 関連
- 親 tracker: #1217

Closes #1235

🤖 Generated with [Claude Code](https://claude.com/claude-code)