### PR TITLE
fix(users): 3rd-party profile タブの shape crash 修正 (show me / clips / pages #1237)

### DIFF
--- a/internal/api/users/content_lists.go
+++ b/internal/api/users/content_lists.go
@@ -51,17 +51,16 @@ func (h *Handler) Clips(c echo.Context) error {
 	if err != nil {
 		return apierr.JSONInternalError(c)
 	}
+	// clip の owner は全行で同一 (req.UserID) なので 1 回だけ lookup して
+	// PackClip の user フィールドに使う。misskey_dart の Clip.fromJson は
+	// user を非null Map として要求するため owner なしでは落ちる (#1237)。
+	var owner *model.User
+	if h.userRepo != nil {
+		owner, _ = h.userRepo.FindByID(req.UserID)
+	}
 	out := make([]map[string]any, 0, len(rows))
 	for _, cl := range rows {
-		out = append(out, map[string]any{
-			"id":            cl.ID,
-			"userId":        cl.UserID,
-			"name":          cl.Name,
-			"description":   cl.Description,
-			"isPublic":      cl.IsPublic,
-			"notesCount":    cl.NotesCount,
-			"lastClippedAt": cl.LastClippedAt,
-		})
+		out = append(out, entity.PackClip(cl, h.idGen, owner))
 	}
 	return c.JSON(http.StatusOK, out)
 }

--- a/internal/api/users/content_lists_test.go
+++ b/internal/api/users/content_lists_test.go
@@ -4,11 +4,14 @@ import (
 	"encoding/json"
 	"net/http"
 	"testing"
+	"time"
 
+	"github.com/shiroha-a/mk/internal/misc/id"
 	"github.com/shiroha-a/mk/internal/model"
 	"github.com/shiroha-a/mk/internal/testutil"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"gorm.io/datatypes"
 )
 
 // stubGalleryRepo は users 向けに ListByUser のみ返す最小スタブ。
@@ -88,6 +91,36 @@ func TestClips_OwnerSeesPrivate(t *testing.T) {
 	var rows []map[string]any
 	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &rows))
 	assert.Len(t, rows, 2)
+}
+
+// misskey_dart の Clip.fromJson が非null必須とする createdAt / user /
+// favoritedCount が users/clips のレスポンスに含まれること (#1237)。
+func TestClips_FullShape(t *testing.T) {
+	h, userRepo := newTestHandler(t)
+	h.SetUserRepo(userRepo)
+	userRepo.Users["owner"] = &model.User{
+		ID: "owner", Username: "owner", UsernameLower: "owner",
+		AvatarDecorations: datatypes.JSON([]byte("[]")),
+	}
+	idGen, _ := id.NewGenerator("aidx")
+	clipID := idGen.Generate(time.Now())
+	repo := testutil.NewMockClipRepository()
+	require.NoError(t, repo.Create(&model.Clip{ID: clipID, UserID: "owner", Name: "favs", IsPublic: true}))
+	h.SetClipRepo(repo)
+
+	rec := postStub(h.Clips, `{"userId":"owner"}`, &model.User{ID: "owner"})
+	require.Equal(t, http.StatusOK, rec.Code)
+	var rows []map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &rows))
+	require.Len(t, rows, 1)
+	cl := rows[0]
+	createdAt, ok := cl["createdAt"].(string)
+	assert.True(t, ok, "createdAt must be a non-null string")
+	assert.NotEmpty(t, createdAt)
+	assert.Equal(t, float64(0), cl["favoritedCount"])
+	user, ok := cl["user"].(map[string]any)
+	require.True(t, ok, "user must be a non-null object")
+	assert.Equal(t, "owner", user["id"])
 }
 
 // --- Flashs ---

--- a/internal/api/users/handler_test.go
+++ b/internal/api/users/handler_test.go
@@ -423,6 +423,20 @@ func TestShow_SelfViewReturnsMeDetailed(t *testing.T) {
 	assert.False(t, hasIsFollowing, "isFollowing must be omitted (not null) for self-view")
 	_, hasIsFollowed := resp["isFollowed"]
 	assert.False(t, hasIsFollowed, "isFollowed must be omitted (not null) for self-view")
+	// misskey_dart の MeDetailed.fromJson が非null bool として cast する field は
+	// self-view でも必ず bool 値で出ること (#1237)。欠落 (null) だと落ちる。
+	for _, key := range []string{
+		"twoFactorEnabled", "usePasswordLessLogin", "securityKeys",
+		"isModerator", "isAdmin",
+		"hasUnreadNotification", "hasUnreadMentions", "hasUnreadAnnouncement",
+		"hasUnreadAntenna", "hasUnreadChannel", "hasUnreadSpecifiedNotes",
+		"hasPendingReceivedFollowRequest",
+	} {
+		v, ok := resp[key]
+		assert.True(t, ok, "%s must be present for self-view MeDetailed", key)
+		_, isBool := v.(bool)
+		assert.True(t, isBool, "%s must be a non-null bool, got %T", key, v)
+	}
 }
 
 // TestShow_NonSelfViewExcludesMeDetailed: viewer != target なら MeDetailed

--- a/internal/entity/clip.go
+++ b/internal/entity/clip.go
@@ -1,0 +1,42 @@
+package entity
+
+import (
+	"github.com/shiroha-a/mk/internal/misc/id"
+	"github.com/shiroha-a/mk/internal/model"
+)
+
+// PackClip converts a model.Clip into the Misskey-compatible clip shape.
+//
+// misskey_dart の Clip.fromJson は createdAt (String) / userId (String) /
+// user (UserLite) / isPublic (bool) / favoritedCount (num) を非null必須とする
+// ため、これらを必ず出す (#1237)。owner は clip の所有ユーザーで、user フィールド
+// を埋めるために caller が渡す (nil なら user は省略するが、misskey_dart 互換の
+// ため呼び出し側は必ず owner を解決して渡すこと)。createdAt は clip ID (aidx)
+// から復元する。
+//
+// favoritedCount は mk-go が clip favorite を追跡しないため 0 固定 (upstream は
+// clip_favorite の count)。
+func PackClip(cl *model.Clip, idGen id.Generator, owner *model.User) map[string]any {
+	if cl == nil {
+		return nil
+	}
+	out := map[string]any{
+		"id":             cl.ID,
+		"userId":         cl.UserID,
+		"name":           cl.Name,
+		"description":    cl.Description,
+		"isPublic":       cl.IsPublic,
+		"notesCount":     cl.NotesCount,
+		"lastClippedAt":  cl.LastClippedAt,
+		"favoritedCount": 0,
+	}
+	if idGen != nil {
+		if t, err := idGen.ParseTime(cl.ID); err == nil {
+			out["createdAt"] = t.UTC().Format("2006-01-02T15:04:05.000Z")
+		}
+	}
+	if owner != nil {
+		out["user"] = PackUserLite(owner)
+	}
+	return out
+}

--- a/internal/entity/clip.go
+++ b/internal/entity/clip.go
@@ -20,6 +20,13 @@ func PackClip(cl *model.Clip, idGen id.Generator, owner *model.User) map[string]
 	if cl == nil {
 		return nil
 	}
+	const tsFormat = "2006-01-02T15:04:05.000Z"
+	// lastClippedAt は createdAt や codebase 内の他 timestamp と同じ ISO ms
+	// 形式に揃える (nil なら null)。misskey_dart は nullable で受けるが形式は統一。
+	var lastClippedAt any
+	if cl.LastClippedAt != nil {
+		lastClippedAt = cl.LastClippedAt.UTC().Format(tsFormat)
+	}
 	out := map[string]any{
 		"id":             cl.ID,
 		"userId":         cl.UserID,
@@ -27,12 +34,12 @@ func PackClip(cl *model.Clip, idGen id.Generator, owner *model.User) map[string]
 		"description":    cl.Description,
 		"isPublic":       cl.IsPublic,
 		"notesCount":     cl.NotesCount,
-		"lastClippedAt":  cl.LastClippedAt,
+		"lastClippedAt":  lastClippedAt,
 		"favoritedCount": 0,
 	}
 	if idGen != nil {
 		if t, err := idGen.ParseTime(cl.ID); err == nil {
-			out["createdAt"] = t.UTC().Format("2006-01-02T15:04:05.000Z")
+			out["createdAt"] = t.UTC().Format(tsFormat)
 		}
 	}
 	if owner != nil {

--- a/internal/entity/clip_test.go
+++ b/internal/entity/clip_test.go
@@ -13,7 +13,8 @@ func TestPackClip_Basic(t *testing.T) {
 	clipID := idGen.Generate(time.Now())
 	desc := "my clip"
 	owner := &model.User{ID: "u1", Username: "alice"}
-	cl := &model.Clip{ID: clipID, UserID: "u1", Name: "favs", Description: &desc, IsPublic: true, NotesCount: 5}
+	lastClipped := time.Date(2026, 4, 10, 1, 2, 3, 0, time.UTC)
+	cl := &model.Clip{ID: clipID, UserID: "u1", Name: "favs", Description: &desc, IsPublic: true, NotesCount: 5, LastClippedAt: &lastClipped}
 
 	out := PackClip(cl, idGen, owner)
 	assert.Equal(t, clipID, out["id"])
@@ -22,6 +23,8 @@ func TestPackClip_Basic(t *testing.T) {
 	assert.Equal(t, &desc, out["description"])
 	assert.Equal(t, true, out["isPublic"])
 	assert.Equal(t, 5, out["notesCount"])
+	// lastClippedAt は ISO ms 形式 (createdAt と統一)。
+	assert.Equal(t, "2026-04-10T01:02:03.000Z", out["lastClippedAt"])
 	// misskey_dart の Clip.fromJson が非null必須とする field (#1237)。
 	createdAt, ok := out["createdAt"].(string)
 	assert.True(t, ok, "createdAt must be a non-null string")

--- a/internal/entity/clip_test.go
+++ b/internal/entity/clip_test.go
@@ -1,0 +1,45 @@
+package entity
+
+import (
+	"testing"
+	"time"
+
+	"github.com/shiroha-a/mk/internal/model"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestPackClip_Basic(t *testing.T) {
+	idGen := newTestIDGen(t)
+	clipID := idGen.Generate(time.Now())
+	desc := "my clip"
+	owner := &model.User{ID: "u1", Username: "alice"}
+	cl := &model.Clip{ID: clipID, UserID: "u1", Name: "favs", Description: &desc, IsPublic: true, NotesCount: 5}
+
+	out := PackClip(cl, idGen, owner)
+	assert.Equal(t, clipID, out["id"])
+	assert.Equal(t, "u1", out["userId"])
+	assert.Equal(t, "favs", out["name"])
+	assert.Equal(t, &desc, out["description"])
+	assert.Equal(t, true, out["isPublic"])
+	assert.Equal(t, 5, out["notesCount"])
+	// misskey_dart の Clip.fromJson が非null必須とする field (#1237)。
+	createdAt, ok := out["createdAt"].(string)
+	assert.True(t, ok, "createdAt must be a non-null string")
+	assert.NotEmpty(t, createdAt)
+	assert.Equal(t, 0, out["favoritedCount"])
+	user, ok := out["user"].(UserLite)
+	assert.True(t, ok, "user must be present")
+	assert.Equal(t, "u1", user.ID)
+}
+
+func TestPackClip_NilOwnerOmitsUser(t *testing.T) {
+	idGen := newTestIDGen(t)
+	cl := &model.Clip{ID: idGen.Generate(time.Now()), UserID: "u1", Name: "x"}
+	out := PackClip(cl, idGen, nil)
+	_, hasUser := out["user"]
+	assert.False(t, hasUser)
+}
+
+func TestPackClip_NilInput(t *testing.T) {
+	assert.Nil(t, PackClip(nil, nil, nil))
+}

--- a/internal/entity/page.go
+++ b/internal/entity/page.go
@@ -37,10 +37,13 @@ func PackPage(p *model.Page, idGens ...id.Generator) map[string]any {
 		"userId":              p.UserID,
 		"eyeCatchingImageId":  p.EyeCatchingImageID,
 		"content":             rawJSONBytes(p.Content),
-		"variables":           rawJSONBytes(p.Variables),
-		"script":              p.Script,
-		"visibility":          string(p.Visibility),
-		"likedCount":          p.LikedCount,
+		// variables / attachedFiles は misskey_dart の Page.fromJson が非null
+		// List として cast するため、空でも null ではなく [] を返す (#1237)。
+		"variables":     jsonArrayOrEmpty(p.Variables),
+		"attachedFiles": []any{},
+		"script":        p.Script,
+		"visibility":    string(p.Visibility),
+		"likedCount":    p.LikedCount,
 	}
 	if len(idGens) > 0 && idGens[0] != nil {
 		if t, err := idGens[0].ParseTime(p.ID); err == nil {
@@ -105,6 +108,16 @@ func PackPageWithContext(p *model.Page, ctx PackPageContext) map[string]any {
 func rawJSONBytes(b []byte) any {
 	if len(b) == 0 {
 		return nil
+	}
+	return json.RawMessage(b)
+}
+
+// jsonArrayOrEmpty returns the raw jsonb array bytes verbatim, or an empty
+// array `[]` when the column is empty/null. Used for fields the client casts
+// to a non-nullable List (e.g. page.variables) so they never serialize to null.
+func jsonArrayOrEmpty(b []byte) any {
+	if len(b) == 0 {
+		return []any{}
 	}
 	return json.RawMessage(b)
 }

--- a/internal/entity/page_test.go
+++ b/internal/entity/page_test.go
@@ -50,9 +50,21 @@ func TestPackPage_Basic(t *testing.T) {
 	assert.Equal(t, "public", out["visibility"])
 	assert.Equal(t, 3, out["likedCount"])
 	assert.Equal(t, "2026-04-10T01:02:03.000Z", out["updatedAt"])
+	// attachedFiles は misskey_dart の Page.fromJson が非null List 必須なので
+	// 常に出ること (#1237)。
+	assert.Equal(t, []any{}, out["attachedFiles"])
 	// createdAtはaidx-IDから復元されるためkey自体が存在することだけ確認。
 	_, ok := out["createdAt"]
 	assert.True(t, ok)
+}
+
+// 空 / nil の variables カラムでも null ではなく [] を返すこと (#1237)。
+// misskey_dart の Page.fromJson は variables を非null List として cast する。
+func TestPackPage_EmptyVariablesIsArray(t *testing.T) {
+	p := &model.Page{ID: "bogus", Visibility: model.PageVisibilityPublic, Variables: nil}
+	out := PackPage(p)
+	assert.Equal(t, []any{}, out["variables"])
+	assert.Equal(t, []any{}, out["attachedFiles"])
 }
 
 func TestPackPage_NilInput(t *testing.T) {

--- a/internal/entity/user.go
+++ b/internal/entity/user.go
@@ -127,6 +127,26 @@ type MeDetailed struct {
 	AlwaysMarkNsfw           bool `json:"alwaysMarkNsfw"`
 	ReceiveAnnouncementEmail bool `json:"receiveAnnouncementEmail"`
 	InjectFeaturedNote       bool `json:"injectFeaturedNote"`
+	// 以下は misskey_dart の MeDetailed.fromJson が非null bool として cast する
+	// ため、self-view (users/show me) でも必ず値を出す必要がある (#1237)。
+	// /api/i は handler 層でこれらを正確な値に上書きするが、users/show の
+	// self-view は AsMeDetailed をそのまま返すので struct 側で埋める。
+	// TwoFactorEnabled / UsePasswordLessLogin / SecurityKeys は profile 由来で
+	// 正確に埋まる。IsModerator / IsAdmin / HasUnread* /
+	// HasPendingReceivedFollowRequest は users/show では権威ソースでないため
+	// best-effort で zero (false) に倒す (権威値は /api/i 経由)。
+	TwoFactorEnabled                bool `json:"twoFactorEnabled"`
+	UsePasswordLessLogin            bool `json:"usePasswordLessLogin"`
+	SecurityKeys                    bool `json:"securityKeys"`
+	IsModerator                     bool `json:"isModerator"`
+	IsAdmin                         bool `json:"isAdmin"`
+	HasUnreadNotification           bool `json:"hasUnreadNotification"`
+	HasUnreadMentions               bool `json:"hasUnreadMentions"`
+	HasUnreadAnnouncement           bool `json:"hasUnreadAnnouncement"`
+	HasUnreadAntenna                bool `json:"hasUnreadAntenna"`
+	HasUnreadChannel                bool `json:"hasUnreadChannel"`
+	HasUnreadSpecifiedNotes         bool `json:"hasUnreadSpecifiedNotes"`
+	HasPendingReceivedFollowRequest bool `json:"hasPendingReceivedFollowRequest"`
 	// EmailNotificationTypes is the list of email-notification categories the
 	// user opted in for. Defaults to ["follow", "receiveFollowRequest"] when
 	// the profile column is absent (#985).
@@ -181,6 +201,10 @@ func AsMeDetailed(d UserDetailed, u *model.User, profile *model.UserProfile) MeD
 		out.AlwaysMarkNsfw = profile.AlwaysMarkNsfw
 		out.ReceiveAnnouncementEmail = profile.ReceiveAnnouncementEmail
 		out.InjectFeaturedNote = profile.InjectFeaturedNote
+		// security 系は profile から正確に埋める (#1237)。
+		out.TwoFactorEnabled = profile.TwoFactorEnabled
+		out.UsePasswordLessLogin = profile.UsePasswordLessLogin
+		out.SecurityKeys = profile.SecurityKeysAvailable
 		// EmailNotificationTypes / NotificationRecieveConfig は jsonb カラム
 		// なので JSON unmarshal してから out にコピーする。parse error は
 		// default に倒す (silent — frontend は default で動作可能)。


### PR DESCRIPTION
## Summary

Miria (misskey_dart) でプロフィールの **アカウント情報 / クリップ / ページ** タブが shape 不整合で crash する問題を修正する (#1237、ノートタブは OK)。いずれも「mk-go が misskey_dart の非null フィールドを null/欠落で返す」同根の問題。

## 各タブの原因と修正

### アカウント情報 — `/api/users/show` (self)
`MeDetailed.fromJson` は `twoFactorEnabled` / `usePasswordLessLogin` / `securityKeys` / `isModerator` / `isAdmin` / `hasUnread*` / `hasPendingReceivedFollowRequest` を**非null bool 必須**とするが、self-view は `AsMeDetailed`(部分 MeDetailed struct)を返すため欠落 → 最初の欠落 bool (`twoFactorEnabled`) で `Null is not bool`。
- `MeDetailed` struct にこれら bool を追加。`AsMeDetailed` で security 系を `profile` から正確に埋める。
- role / unread は users/show では**権威ソースでない**ため best-effort で `false`(権威値は `/api/i` 経由で取得される)。
- `/api/i` は handler 層でこれらを正確値に override するため **regression なし**(既存テスト green)。

### クリップ — `/api/users/clips`
`Clip.fromJson` は `createdAt` (String) / `user` (UserLite Map) / `favoritedCount` (num) を**非null必須**とするが mk-go は3つとも欠落。
- 新設 `entity.PackClip(cl, idGen, owner)` で完全 shape に。`createdAt` は clip ID (aidx) 由来、`user` は owner の UserLite、`favoritedCount` は mk-go 未追跡のため `0`。
- handler は owner (`req.UserID`) を1回 lookup して全行に使う。

### ページ — `/api/users/pages`
`Page.fromJson` は `variables` / `attachedFiles` を**非null List** として cast するが、`PackPage` は variables を空時 null / attachedFiles を欠落。
- `PackPage` の variables を空時も `[]`(非null)に、`attachedFiles` を `[]` として追加(base packer なので /api/pages/* 等の全 page 経路も同時に修正)。

## テスト

- entity: `TestPackClip_*`、`TestPackPage_EmptyVariablesIsArray` + attachedFiles assertion。
- api/users: `TestClips_FullShape`(createdAt/user/favoritedCount)、`TestShow_SelfViewReturnsMeDetailed` に MeDetailed bool 群の presence + 型 assertion を追加。
- `go build ./...` / `go vet` / `gofmt` クリーン。
- coverage: entity 95.0% / api/users 92.5% / api/i 90.6% / api/clips 90.1%(全てゲート通過)。

## 既知の follow-up (本 PR スコープ外)

`internal/api/clips/handler.go` の `clipToMap` も同一の不完全 shape(createdAt/user/favoritedCount 欠落)で、`/api/clips/*` 経由でも同じ crash が起きうる。#1237 はプロフィールタブ (users/clips) のスコープなので本 PR では触れず、別 follow-up とする(同根)。

Closes #1237
Closes #1238

🤖 Generated with [Claude Code](https://claude.com/claude-code)