### PR TITLE
fix(users): users/show self-view MeDetailed の List/policies 欠落を補完 (#1240)

### DIFF
--- a/internal/api/users/handler.go
+++ b/internal/api/users/handler.go
@@ -11,6 +11,7 @@ import (
 	"github.com/shiroha-a/mk/internal/api/apierr"
 	corefollowing "github.com/shiroha-a/mk/internal/core/following"
 	"github.com/shiroha-a/mk/internal/core/notesfilter"
+	corerole "github.com/shiroha-a/mk/internal/core/role"
 	"github.com/shiroha-a/mk/internal/core/user"
 	"github.com/shiroha-a/mk/internal/entity"
 	"github.com/shiroha-a/mk/internal/misc/id"
@@ -435,7 +436,13 @@ func (h *Handler) Show(c echo.Context) error {
 	// frontend が `/api/users/show?username=me` 経由で自分のプロフィールを
 	// 開いたとき、`/api/i` 経由の $i と field set を一致させられる。
 	if viewer != nil && viewer.ID == bundle.User.ID {
-		return c.JSON(http.StatusOK, entity.AsMeDetailed(detailed, bundle.User, bundle.Profile))
+		me := entity.AsMeDetailed(detailed, bundle.User, bundle.Profile)
+		// policies は role 依存で entity 層では計算できないため handler で埋める。
+		// users/show では権威ソースでないので default policies を best-effort で
+		// 入れる (misskey_dart の MeDetailed.fromJson は policies を非null Map と
+		// して要求する、#1240)。権威値は /api/i 経由で取得される。
+		me.Policies = corerole.DefaultPolicies()
+		return c.JSON(http.StatusOK, me)
 	}
 	return c.JSON(http.StatusOK, detailed)
 }

--- a/internal/api/users/handler_test.go
+++ b/internal/api/users/handler_test.go
@@ -437,6 +437,19 @@ func TestShow_SelfViewReturnsMeDetailed(t *testing.T) {
 		_, isBool := v.(bool)
 		assert.True(t, isBool, "%s must be a non-null bool, got %T", key, v)
 	}
+	// misskey_dart が非null List として cast する field (#1240)。null だと落ちる。
+	for _, key := range []string{"mutedWords", "mutedInstances", "achievements"} {
+		v, ok := resp[key]
+		assert.True(t, ok, "%s must be present for self-view MeDetailed", key)
+		_, isArr := v.([]any)
+		assert.True(t, isArr, "%s must be a non-null array, got %T", key, v)
+	}
+	// loggedInDays は非null num、policies は非null Map (#1240)。
+	_, isNum := resp["loggedInDays"].(float64)
+	assert.True(t, isNum, "loggedInDays must be a non-null number, got %T", resp["loggedInDays"])
+	policies, isMap := resp["policies"].(map[string]any)
+	assert.True(t, isMap, "policies must be a non-null object, got %T", resp["policies"])
+	assert.NotEmpty(t, policies, "policies must carry default role policy keys")
 }
 
 // TestShow_NonSelfViewExcludesMeDetailed: viewer != target なら MeDetailed

--- a/internal/entity/user.go
+++ b/internal/entity/user.go
@@ -147,6 +147,16 @@ type MeDetailed struct {
 	HasUnreadChannel                bool `json:"hasUnreadChannel"`
 	HasUnreadSpecifiedNotes         bool `json:"hasUnreadSpecifiedNotes"`
 	HasPendingReceivedFollowRequest bool `json:"hasPendingReceivedFollowRequest"`
+	// 以下も misskey_dart の MeDetailed.fromJson が非null List / num / Map と
+	// して cast するため self-view でも必ず値を出す (#1240)。MutedWords /
+	// MutedInstances / Achievements / LoggedInDays は profile 由来で正確に、
+	// Policies は role 依存のため handler 層で best-effort default を入れる
+	// (権威値は /api/i 経由)。
+	MutedWords     []any          `json:"mutedWords"`
+	MutedInstances []string       `json:"mutedInstances"`
+	Achievements   []any          `json:"achievements"`
+	LoggedInDays   int            `json:"loggedInDays"`
+	Policies       map[string]any `json:"policies"`
 	// EmailNotificationTypes is the list of email-notification categories the
 	// user opted in for. Defaults to ["follow", "receiveFollowRequest"] when
 	// the profile column is absent (#985).
@@ -191,6 +201,10 @@ func AsMeDetailed(d UserDetailed, u *model.User, profile *model.UserProfile) MeD
 		EmailNotificationTypes:    []string{"follow", "receiveFollowRequest"},
 		MutingNotificationTypes:   []string{},
 		NotificationRecieveConfig: map[string]any{},
+		// 非null List 必須 (#1240)。profile があれば下で jsonb から上書き。
+		MutedWords:     []any{},
+		MutedInstances: []string{},
+		Achievements:   []any{},
 	}
 	if profile != nil {
 		out.NoCrawle = profile.NoCrawle
@@ -220,8 +234,36 @@ func AsMeDetailed(d UserDetailed, u *model.User, profile *model.UserProfile) MeD
 				out.NotificationRecieveConfig = m
 			}
 		}
+		// mutedWords / mutedInstances / achievements は jsonb 配列。空でも
+		// null ではなく [] を保つ (#1240)。parse error も default の [] のまま。
+		if arr := unmarshalJSONAnySlice(profile.MutedWords); arr != nil {
+			out.MutedWords = arr
+		}
+		if raw := []byte(profile.MutedInstances); len(raw) > 0 {
+			var arr []string
+			if err := json.Unmarshal(raw, &arr); err == nil && arr != nil {
+				out.MutedInstances = arr
+			}
+		}
+		if arr := unmarshalJSONAnySlice(profile.Achievements); arr != nil {
+			out.Achievements = arr
+		}
+		out.LoggedInDays = len(profile.LoggedInDates)
 	}
 	return out
+}
+
+// unmarshalJSONAnySlice decodes a jsonb array column into []any, returning nil
+// on empty input or parse error so the caller keeps its non-null default.
+func unmarshalJSONAnySlice(raw []byte) []any {
+	if len(raw) == 0 {
+		return nil
+	}
+	var arr []any
+	if err := json.Unmarshal(raw, &arr); err != nil {
+		return nil
+	}
+	return arr
 }
 
 // InstanceLite is the minimal instance info embedded in UserLite for remote

--- a/internal/entity/user.go
+++ b/internal/entity/user.go
@@ -152,11 +152,17 @@ type MeDetailed struct {
 	// MutedInstances / Achievements / LoggedInDays は profile 由来で正確に、
 	// Policies は role 依存のため handler 層で best-effort default を入れる
 	// (権威値は /api/i 経由)。
-	MutedWords     []any          `json:"mutedWords"`
-	MutedInstances []string       `json:"mutedInstances"`
-	Achievements   []any          `json:"achievements"`
-	LoggedInDays   int            `json:"loggedInDays"`
-	Policies       map[string]any `json:"policies"`
+	MutedWords     []any    `json:"mutedWords"`
+	MutedInstances []string `json:"mutedInstances"`
+	Achievements   []any    `json:"achievements"`
+	LoggedInDays   int      `json:"loggedInDays"`
+	// Policies は role 依存で AsMeDetailed (entity 層) では nil のまま。omitempty で
+	// 「未設定なら省略」にするのが重要 (#1240): PackMeDetailed を override 無しで
+	// 直接返す i/update / meUpdated 経路で nil を `null` として出すと frontend の
+	// updateCurrentAccountPartial が `$i.policies` を null 上書きして policy 判定が
+	// 壊れる。users/show self-view は handler が DefaultPolicies() を明示セットする
+	// ので含まれ、/api/i は handler が実 policies で override する。
+	Policies map[string]any `json:"policies,omitempty"`
 	// EmailNotificationTypes is the list of email-notification categories the
 	// user opted in for. Defaults to ["follow", "receiveFollowRequest"] when
 	// the profile column is absent (#985).

--- a/internal/entity/user_test.go
+++ b/internal/entity/user_test.go
@@ -449,6 +449,36 @@ func TestPackMeDetailed_NilProfile(t *testing.T) {
 	assert.False(t, me.ReceiveAnnouncementEmail)
 }
 
+// #1240: misskey_dart の MeDetailed.fromJson が非null List/num として cast する
+// mutedWords / mutedInstances / achievements / loggedInDays が profile から
+// 正しく埋まること。
+func TestPackMeDetailed_ListFields(t *testing.T) {
+	u := &model.User{ID: "me4", Username: "lists", AvatarDecorations: datatypes.JSON([]byte("[]"))}
+	profile := &model.UserProfile{
+		UserID:         "me4",
+		Fields:         datatypes.JSON([]byte("[]")),
+		MutedWords:     datatypes.JSON([]byte(`[["foo","bar"],"baz"]`)),
+		MutedInstances: datatypes.JSON([]byte(`["evil.example"]`)),
+		Achievements:   datatypes.JSON([]byte(`[{"name":"a","unlockedAt":1}]`)),
+		LoggedInDates:  pq.StringArray{"2026-05-01", "2026-05-02"},
+	}
+	me := PackMeDetailed(u, profile)
+	assert.Len(t, me.MutedWords, 2)
+	assert.Equal(t, []string{"evil.example"}, me.MutedInstances)
+	assert.Len(t, me.Achievements, 1)
+	assert.Equal(t, 2, me.LoggedInDays)
+}
+
+// 空 / nil profile でも非null 空配列を保つこと (#1240)。
+func TestPackMeDetailed_ListFieldsEmptyAreNonNull(t *testing.T) {
+	u := &model.User{ID: "me5", Username: "empty", AvatarDecorations: datatypes.JSON([]byte("[]"))}
+	me := PackMeDetailed(u, nil)
+	assert.Equal(t, []any{}, me.MutedWords)
+	assert.Equal(t, []string{}, me.MutedInstances)
+	assert.Equal(t, []any{}, me.Achievements)
+	assert.Equal(t, 0, me.LoggedInDays)
+}
+
 // #968: serialized JSON が drop-in 互換 key 名 (isExplorable / noCrawle 等)
 // を出すこと。フロントの updateCurrentAccountPartial が key 名で merge
 // するので、key drift があると session には反映されない。

--- a/internal/entity/user_test.go
+++ b/internal/entity/user_test.go
@@ -479,6 +479,19 @@ func TestPackMeDetailed_ListFieldsEmptyAreNonNull(t *testing.T) {
 	assert.Equal(t, 0, me.LoggedInDays)
 }
 
+// #1240: PackMeDetailed 単体 (policies override 無し) は policies を **出さない**
+// こと。i/update / meUpdated はこれを直接 frontend の updateCurrentAccountPartial
+// に流すため、`policies:null` を出すと `$i.policies` を null 上書きして policy
+// 判定が壊れる。omitempty で省略されることを保証する。
+func TestPackMeDetailed_OmitsPoliciesWhenUnset(t *testing.T) {
+	u := &model.User{ID: "me6", Username: "nopol", AvatarDecorations: datatypes.JSON([]byte("[]"))}
+	me := PackMeDetailed(u, &model.UserProfile{UserID: "me6", Fields: datatypes.JSON([]byte("[]"))})
+	assert.Nil(t, me.Policies)
+	b, err := json.Marshal(me)
+	require.NoError(t, err)
+	assert.NotContains(t, string(b), `"policies"`, "PackMeDetailed must omit policies (not emit null) so i/update merge does not null out $i.policies")
+}
+
 // #968: serialized JSON が drop-in 互換 key 名 (isExplorable / noCrawle 等)
 // を出すこと。フロントの updateCurrentAccountPartial が key 名で merge
 // するので、key drift があると session には反映されない。


### PR DESCRIPTION
## Summary

#1237 で MeDetailed の bool 群を補完した後も、Miria でプロフィール (アカウント情報) が `Null is not List<dynamic>` (user.g.dart:574 = `mutedWords`) でまだ crash していた問題を修正する (#1240)。`/api/users/show` self-view が、misskey_dart の `MeDetailed.fromJson` が非null必須とする残りのフィールドを欠いていた。

## 原因

self-view (`AsMeDetailed`) が以下を欠落:
- `mutedWords` / `mutedInstances` / `achievements`(非null List)
- `loggedInDays`(非null num)
- `policies`(非null Map)

`/api/i` は handler 層でこれらを設定済みだが、users/show self-view は `AsMeDetailed` をそのまま返すため欠落。

## 主な変更点

- `entity/user.go`:
  - `MeDetailed` struct に上記5フィールドを追加。
  - `AsMeDetailed` で `mutedWords` / `mutedInstances` / `achievements` を profile jsonb から unmarshal(空/nil でも非null `[]`)、`loggedInDays = len(LoggedInDates)`。`unmarshalJSONAnySlice` helper を追加。
  - `policies` は role 依存で entity 層では計算できないため nil のまま(handler が設定)。
- `api/users/handler.go`: self-view で `me.Policies = corerole.DefaultPolicies()` を best-effort 設定(権威値は /api/i 経由)。`isAdmin` 等と同じく users/show は非権威ソース。
- `/api/i` は `PackMeDetailed` → map 化後に mutedWords/mutedInstances/achievements/loggedInDays/policies を全て override するため **regression なし**(既存 /api/i テスト green)。

これで `MeDetailed.fromJson` の非null必須フィールドを self-view が全て満たし、#1237 (bool) → #1240 (list/num/map) と続いた shape crash の連鎖が解消する。

## テスト

- entity: `TestPackMeDetailed_ListFields`(profile jsonb から parse)、`TestPackMeDetailed_ListFieldsEmptyAreNonNull`(nil profile でも非null空配列)。
- api/users: `TestShow_SelfViewReturnsMeDetailed` に mutedWords/mutedInstances/achievements(配列)/loggedInDays(数値)/policies(非空 Map)の presence + 型 assertion を追加。
- `go build ./...` / `go vet` / `gofmt` クリーン。
- coverage: entity 95.0% / api/users 92.6% / api/i 90.6%(全ゲート通過)。

## 関連
- #1237(bool 群)、同 reporter の 3rd-party client compat 群 (#1224 / #1227 / #1228)

Closes #1241
Closes #1240

🤖 Generated with [Claude Code](https://claude.com/claude-code)