### PR TITLE
fix(api): 3rd-party client の list view shape crash を4件修正 (following/antenna/clip/chat)

### DIFF
--- a/internal/api/antennas/handler.go
+++ b/internal/api/antennas/handler.go
@@ -132,7 +132,7 @@ func (h *Handler) Create(c echo.Context) error {
 		}
 		return apierr.JSONInternalError(c)
 	}
-	return c.JSON(http.StatusOK, antennaToMap(a))
+	return c.JSON(http.StatusOK, h.antennaToMap(a))
 }
 
 // ShowRequest is the request body for antennas/show.
@@ -155,7 +155,7 @@ func (h *Handler) Show(c echo.Context) error {
 		// Show は ErrAntennaNotFound 以外を返さない (未マップ含む)
 		return notFound(c)
 	}
-	return c.JSON(http.StatusOK, antennaToMap(a))
+	return c.JSON(http.StatusOK, h.antennaToMap(a))
 }
 
 // UpdateRequest is the request body for antennas/update.
@@ -208,7 +208,7 @@ func (h *Handler) Update(c echo.Context) error {
 		}
 		return apierr.JSONInternalError(c)
 	}
-	return c.JSON(http.StatusOK, antennaToMap(a))
+	return c.JSON(http.StatusOK, h.antennaToMap(a))
 }
 
 // DeleteRequest is the request body for antennas/delete.
@@ -244,7 +244,7 @@ func (h *Handler) List(c echo.Context) error {
 	}
 	out := make([]map[string]any, 0, len(rows))
 	for _, a := range rows {
-		out = append(out, antennaToMap(a))
+		out = append(out, h.antennaToMap(a))
 	}
 	return c.JSON(http.StatusOK, out)
 }
@@ -296,13 +296,25 @@ func (h *Handler) Notes(c echo.Context) error {
 	return c.JSON(http.StatusOK, out)
 }
 
-func antennaToMap(a *model.Antenna) map[string]any {
+func (h *Handler) antennaToMap(a *model.Antenna) map[string]any {
 	// upstream Misskey TS の packAntenna は userId field を embed しない
 	// (= antenna は user-scoped で frontend が呼出 user の id を別経路で持つ
 	// 設計、#904)。drop-in 互換維持のため mk-go も同 shape に揃える。
+	//
+	// createdAt は antenna ID (aidx) から復元する。以前は lastUsedAt を流用して
+	// いたが createdAt は作成時刻であるべき + misskey_dart の Antenna.fromJson が
+	// 非null String として cast するため ISO ms 形式で出す (#1244)。
+	// hasUnreadNote は misskey_dart が非null bool として cast する (#1244)。
+	// mk-go は antenna 未読 note を追跡しないため false 固定。
+	createdAt := ""
+	if h.idGen != nil {
+		if t, err := h.idGen.ParseTime(a.ID); err == nil {
+			createdAt = t.UTC().Format("2006-01-02T15:04:05.000Z")
+		}
+	}
 	return map[string]any{
 		"id":              a.ID,
-		"createdAt":       a.LastUsedAt,
+		"createdAt":       createdAt,
 		"name":            a.Name,
 		"src":             a.Src,
 		"userListId":      a.UserListID,
@@ -315,6 +327,7 @@ func antennaToMap(a *model.Antenna) map[string]any {
 		"withFile":        a.WithFile,
 		"localOnly":       a.LocalOnly,
 		"isActive":        a.IsActive,
+		"hasUnreadNote":   false,
 	}
 }
 

--- a/internal/api/antennas/handler_test.go
+++ b/internal/api/antennas/handler_test.go
@@ -90,6 +90,14 @@ func TestCreate_NoUserIdInResponse(t *testing.T) {
 	// 必須 field の existence は念のため touch しておく (drift で吸い込ま
 	// れないように reverse の guard)。
 	assert.Equal(t, "alpha", body["name"])
+	// misskey_dart の Antenna.fromJson は createdAt (非null String) /
+	// hasUnreadNote (非null bool) を要求する (#1244)。
+	createdAt, ok := body["createdAt"].(string)
+	assert.True(t, ok, "createdAt must be a non-null string")
+	assert.NotEmpty(t, createdAt)
+	hasUnread, ok := body["hasUnreadNote"].(bool)
+	assert.True(t, ok, "hasUnreadNote must be a non-null bool")
+	assert.False(t, hasUnread)
 }
 
 func TestCreate_BadJSON(t *testing.T) {

--- a/internal/api/chat/handler.go
+++ b/internal/api/chat/handler.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"log/slog"
 	"net/http"
+	"strings"
 	"time"
 
 	"github.com/labstack/echo/v4"
@@ -117,7 +118,7 @@ func packMessage(m *model.ChatMessage) map[string]any {
 	result := map[string]any{
 		"id":         m.ID,
 		"fromUserId": m.FromUserID,
-		"reactions":  m.Reactions,
+		"reactions":  packChatReactions(m.Reactions),
 	}
 	if m.ToUserID != nil {
 		result["toUserId"] = *m.ToUserID
@@ -135,6 +136,24 @@ func packMessage(m *model.ChatMessage) map[string]any {
 		result["fromUser"] = packUser(m.FromUser)
 	}
 	return result
+}
+
+// packChatReactions converts the stored `"<userId>/<reaction>"` reaction
+// strings (CherryPick chat reaction 形式) into the object array shape that
+// misskey_dart の ChatMessage.fromJson expects (`reactions: [{reaction}]`)。
+// raw 文字列配列のまま返すと `String is not Map<String, dynamic>` で落ちる
+// (#1246)。user は upstream の packMessageLite と同じく省略 (schema 上 nullable)。
+func packChatReactions(reactions []string) []map[string]any {
+	out := make([]map[string]any, 0, len(reactions))
+	for _, r := range reactions {
+		reaction := r
+		// 保存形式は "<userId>/<reaction>"。最初の "/" 以降を reaction とする。
+		if i := strings.Index(r, "/"); i >= 0 {
+			reaction = r[i+1:]
+		}
+		out = append(out, map[string]any{"reaction": reaction})
+	}
+	return out
 }
 
 // packMessageWithCreatedAt augments packMessage with createdAt parsed from the

--- a/internal/api/chat/handler_test.go
+++ b/internal/api/chat/handler_test.go
@@ -307,11 +307,21 @@ func TestMessagesShow_WithFromUser(t *testing.T) {
 	h, repo := newTestHandler()
 	repo.Messages["m1"] = &model.ChatMessage{
 		ID: "m1", FromUserID: "u1", FromUser: u1,
-		Reads: pq.StringArray{}, Reactions: pq.StringArray{},
+		Reads: pq.StringArray{}, Reactions: pq.StringArray{"u2/👍"},
 	}
 	rec := post(h.MessagesShow, `{"messageId":"m1"}`, u1)
 	assert.Equal(t, http.StatusOK, rec.Code)
 	assert.Contains(t, rec.Body.String(), "alice")
+	// misskey_dart の ChatMessage.fromJson は reactions を {reaction} object の
+	// 配列として cast する。"<userId>/<reaction>" 文字列のまま返すと落ちる (#1246)。
+	var body map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &body))
+	reactions, ok := body["reactions"].([]any)
+	require.True(t, ok, "reactions must be an array")
+	require.Len(t, reactions, 1)
+	r0, ok := reactions[0].(map[string]any)
+	require.True(t, ok, "each reaction must be an object")
+	assert.Equal(t, "👍", r0["reaction"], "userId prefix must be stripped")
 }
 
 func TestRoomsUpdate_WithDescription(t *testing.T) {

--- a/internal/api/clips/favorites.go
+++ b/internal/api/clips/favorites.go
@@ -88,7 +88,7 @@ func (h *Handler) MyFavorites(c echo.Context) error {
 		if err != nil {
 			continue
 		}
-		out = append(out, clipToMap(cl))
+		out = append(out, h.clipToMap(cl))
 	}
 	return c.JSON(http.StatusOK, out)
 }

--- a/internal/api/clips/handler.go
+++ b/internal/api/clips/handler.go
@@ -109,7 +109,7 @@ func (h *Handler) Create(c echo.Context) error {
 		}
 		return apierr.JSONInternalError(c)
 	}
-	return c.JSON(http.StatusOK, clipToMap(cl))
+	return c.JSON(http.StatusOK, h.clipToMap(cl))
 }
 
 // ShowRequest is the request body for clips/show.
@@ -135,7 +135,7 @@ func (h *Handler) Show(c echo.Context) error {
 		}
 		return notFound(c)
 	}
-	return c.JSON(http.StatusOK, clipToMap(cl))
+	return c.JSON(http.StatusOK, h.clipToMap(cl))
 }
 
 // UpdateRequest is the request body for clips/update.
@@ -173,7 +173,7 @@ func (h *Handler) Update(c echo.Context) error {
 		}
 		return apierr.JSONInternalError(c)
 	}
-	return c.JSON(http.StatusOK, clipToMap(cl))
+	return c.JSON(http.StatusOK, h.clipToMap(cl))
 }
 
 // DeleteRequest is the request body for clips/delete.
@@ -228,7 +228,7 @@ func (h *Handler) List(c echo.Context) error {
 	}
 	out := make([]map[string]any, 0, len(rows))
 	for _, cl := range rows {
-		out = append(out, clipToMap(cl))
+		out = append(out, h.clipToMap(cl))
 	}
 	return c.JSON(http.StatusOK, out)
 }
@@ -334,16 +334,16 @@ func (h *Handler) Notes(c echo.Context) error {
 	return c.JSON(http.StatusOK, out)
 }
 
-func clipToMap(cl *model.Clip) map[string]any {
-	return map[string]any{
-		"id":            cl.ID,
-		"userId":        cl.UserID,
-		"name":          cl.Name,
-		"description":   cl.Description,
-		"isPublic":      cl.IsPublic,
-		"notesCount":    cl.NotesCount,
-		"lastClippedAt": cl.LastClippedAt,
+// clipToMap packs a clip into the misskey_dart-compatible shape via
+// entity.PackClip. owner (clip の所有ユーザー) を userRepo から解決して user
+// field を埋める。misskey_dart の Clip.fromJson は createdAt / user /
+// favoritedCount を非null必須とするため、旧 ad-hoc map では落ちていた (#1245)。
+func (h *Handler) clipToMap(cl *model.Clip) map[string]any {
+	var owner *model.User
+	if h.userRepo != nil {
+		owner, _ = h.userRepo.FindByID(cl.UserID)
 	}
+	return entity.PackClip(cl, h.idGen, owner)
 }
 
 func notFound(c echo.Context) error {

--- a/internal/api/clips/handler_test.go
+++ b/internal/api/clips/handler_test.go
@@ -1,11 +1,13 @@
 package clips
 
 import (
+	"encoding/json"
 	"errors"
 	"net/http"
 	"net/http/httptest"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/labstack/echo/v4"
 	coreclip "github.com/shiroha-a/mk/internal/core/clip"
@@ -267,6 +269,35 @@ func TestList_Success(t *testing.T) {
 	require.NoError(t, h.List(c))
 	assert.Equal(t, http.StatusOK, rec.Code)
 	assert.Contains(t, rec.Body.String(), "alpha")
+}
+
+// #1245: clips/list が misskey_dart の Clip.fromJson 互換 shape を返すこと。
+// createdAt / user / favoritedCount が非null で含まれること (旧 clipToMap は
+// これらを欠いて `Null is not String` で落ちていた)。
+func TestList_FullShape(t *testing.T) {
+	h, repo, _, _ := newHandler(t)
+	userRepo := testutil.NewMockUserRepository()
+	userRepo.Users["alice"] = &model.User{ID: "alice", Username: "alice"}
+	h.SetUserRepo(userRepo)
+	idGen, _ := id.NewGenerator("aidx")
+	clipID := idGen.Generate(time.Now())
+	repo.Clips[clipID] = &model.Clip{ID: clipID, UserID: "alice", Name: "alpha", IsPublic: true}
+
+	c, rec := newReq(t, `{}`)
+	setUser(c, "alice")
+	require.NoError(t, h.List(c))
+	require.Equal(t, http.StatusOK, rec.Code)
+	var rows []map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &rows))
+	require.Len(t, rows, 1)
+	cl := rows[0]
+	createdAt, ok := cl["createdAt"].(string)
+	assert.True(t, ok, "createdAt must be a non-null string")
+	assert.NotEmpty(t, createdAt)
+	assert.Equal(t, float64(0), cl["favoritedCount"])
+	user, ok := cl["user"].(map[string]any)
+	require.True(t, ok, "user must be a non-null object")
+	assert.Equal(t, "alice", user["id"])
 }
 
 func TestList_BadJSON(t *testing.T) {

--- a/internal/api/users/handler.go
+++ b/internal/api/users/handler.go
@@ -629,7 +629,10 @@ func (h *Handler) listRelations(c echo.Context, followers bool) error {
 
 // relationItem represents a single entry in followers/following lists.
 type relationItem struct {
-	ID         string               `json:"id"`
+	ID string `json:"id"`
+	// CreatedAt は misskey_dart の Following.fromJson が非null String として
+	// cast するため必須 (#1243)。following row の ID (aidx) から復元する。
+	CreatedAt  string               `json:"createdAt"`
 	FollowerID string               `json:"followerId"`
 	FolloweeID string               `json:"followeeId"`
 	Follower   *entity.UserDetailed `json:"follower,omitempty"`
@@ -732,6 +735,9 @@ func (h *Handler) packRelationItems(
 	out := make([]relationItem, 0, len(filtered))
 	for _, f := range filtered {
 		item := relationItem{ID: f.ID, FollowerID: f.FollowerID, FolloweeID: f.FolloweeID}
+		if t, err := h.idGen.ParseTime(f.ID); err == nil {
+			item.CreatedAt = t.UTC().Format("2006-01-02T15:04:05.000Z")
+		}
 		var target string
 		if followers {
 			target = f.FollowerID

--- a/internal/api/users/handler_test.go
+++ b/internal/api/users/handler_test.go
@@ -966,6 +966,13 @@ func TestFollowers_Success(t *testing.T) {
 	var out []map[string]any
 	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &out))
 	assert.Len(t, out, 1)
+	// misskey_dart の Following.fromJson は createdAt / followerId / followeeId を
+	// 非null必須とする (#1243)。
+	createdAt, ok := out[0]["createdAt"].(string)
+	assert.True(t, ok, "createdAt must be a non-null string")
+	assert.NotEmpty(t, createdAt)
+	assert.Equal(t, "follower1", out[0]["followerId"])
+	assert.Equal(t, "user1", out[0]["followeeId"])
 }
 
 // TestFollowers_PopulatesIsFollowedFromViewer guards #1144: when a viewer

--- a/internal/core/chat/pack_message_test.go
+++ b/internal/core/chat/pack_message_test.go
@@ -26,7 +26,8 @@ func TestPackMessage_AllFieldsFilled(t *testing.T) {
 		FileID:     &fileID,
 		URI:        &uri,
 		Reads:      pq.StringArray{"bob"},
-		Reactions:  pq.StringArray{"bob:+1"},
+		// 保存形式は "<userId>/<reaction>" (handler.go の ReactionsCreate)。
+		Reactions: pq.StringArray{"bob/👍"},
 	}
 	out := packMessage(msg)
 
@@ -38,5 +39,6 @@ func TestPackMessage_AllFieldsFilled(t *testing.T) {
 	assert.Equal(t, "file1", out["fileId"])
 	assert.Equal(t, "https://example.com/messages/m1", out["uri"])
 	assert.Equal(t, []string{"bob"}, out["reads"])
-	assert.Equal(t, []string{"bob:+1"}, out["reactions"])
+	// reactions は misskey_dart 互換の {reaction} object 配列 + userId prefix 除去 (#1246)。
+	assert.Equal(t, []map[string]any{{"reaction": "👍"}}, out["reactions"])
 }

--- a/internal/core/chat/service.go
+++ b/internal/core/chat/service.go
@@ -14,6 +14,7 @@ import (
 	"fmt"
 	"log/slog"
 	"net/url"
+	"strings"
 	"time"
 
 	"github.com/shiroha-a/mk/internal/activitypub"
@@ -888,8 +889,25 @@ func packMessage(msg *model.ChatMessage) map[string]any {
 	if msg.Reads != nil {
 		out["reads"] = []string(msg.Reads)
 	}
-	if msg.Reactions != nil {
-		out["reactions"] = []string(msg.Reactions)
+	// misskey_dart の ChatMessage.fromJson は reactions を ChatMessageReaction
+	// (Map) の非null配列として cast するため、"<userId>/<reaction>" 文字列配列を
+	// {reaction} object 配列に変換し、空でも [] を出す (#1246 streaming 版)。
+	out["reactions"] = packStreamReactions(msg.Reactions)
+	return out
+}
+
+// packStreamReactions converts stored "<userId>/<reaction>" reaction strings
+// into the misskey_dart ChatMessageReaction object shape (`[{reaction}]`).
+// api/chat.packChatReactions の streaming 版 (layering 上 api を import できない
+// ため重複)。
+func packStreamReactions(reactions []string) []map[string]any {
+	out := make([]map[string]any, 0, len(reactions))
+	for _, r := range reactions {
+		reaction := r
+		if i := strings.Index(r, "/"); i >= 0 {
+			reaction = r[i+1:]
+		}
+		out = append(out, map[string]any{"reaction": reaction})
 	}
 	return out
 }


### PR DESCRIPTION
## Summary

Miria (misskey_dart) の各一覧画面が shape 不整合で crash する4件 (#1243 / #1244 / #1245 / #1246) をまとめて修正する。いずれも「mk-go が misskey_dart の非null フィールドを欠落/誤型で返す」同根の問題。

## 各件の原因と修正

### #1243 フォロー/フォロワー一覧 (`/api/users/following`, `/api/users/followers`)
`Following.fromJson` は `createdAt` / `followerId` / `followeeId` を非null必須とするが、`relationItem` が `createdAt` を欠いていた。
- `relationItem` に `CreatedAt`(following row の ID=aidx 由来)を追加。

### #1244 アンテナ一覧 (`/api/antennas/list` 他)
`Antenna.fromJson` が `hasUnreadNote`(非null bool)を要求するが mk-go は欠落。また `createdAt` に `lastUsedAt` を流用していた。
- `antennaToMap` を method 化し `hasUnreadNote: false`(mk-go は antenna 未読を追跡しない)を追加、`createdAt` を antenna ID(aidx)由来の ISO ms に修正。

### #1245 クリップ一覧 (`/api/clips/list`, `show`, `create`, `update`, favorites)
`Clip.fromJson` が `createdAt` / `user` / `favoritedCount` を非null必須とするが `clipToMap` が欠落(#1227/#1237 と同根の api/clips 版、follow-up として記録していたもの)。
- `clipToMap` を `entity.PackClip` ベースの method に統一(owner を userRepo から解決)。全 clips endpoint を一括修正。

### #1246 チャットのホーム (`/api/chat/history` 他)
`ChatMessage.fromJson` が `reactions` を `ChatMessageReaction`(Map)の配列として cast するが、mk-go は `"<userId>/<reaction>"` の文字列配列を返していた(`String is not Map`)。
- `packMessage` の reactions を `{reaction}` object 配列に変換する `packChatReactions` を追加(userId prefix を除去、user は upstream の lite pack 同様省略=schema 上 nullable)。

## テスト

各 endpoint に回帰テストを追加:
- clips: `TestList_FullShape`(createdAt/user/favoritedCount)
- users: `TestFollowers_Success` に createdAt/followerId/followeeId assertion
- antennas: `TestCreate_NoUserIdInResponse` に createdAt/hasUnreadNote assertion
- chat: `TestMessagesShow_WithFromUser` に reactions object 配列 assertion

`go build ./...` / `go vet` / `gofmt` クリーン。coverage: clips 90.9% / users 92.6% / antennas 91.3% / chat 91.5%(全ゲート通過)。

## 関連
- 同 reporter の 3rd-party client compat 群 (#1224 / #1227 / #1228 / #1237 / #1240)

Closes #1243
Closes #1244
Closes #1245
Closes #1246

🤖 Generated with [Claude Code](https://claude.com/claude-code)