### PR TITLE
fix(api): 3rd-party client の follow/role/export-notification shape crash (#1249)

### DIFF
--- a/internal/api/roles/handler.go
+++ b/internal/api/roles/handler.go
@@ -100,7 +100,7 @@ func (h *Handler) List(c echo.Context) error {
 	var result []any
 	for _, r := range roles {
 		if r.IsPublic {
-			result = append(result, packRole(r))
+			result = append(result, h.packRole(r))
 		}
 	}
 	if result == nil {
@@ -121,7 +121,7 @@ func (h *Handler) Show(c echo.Context) error {
 	if err != nil || !r.IsPublic {
 		return c.JSON(http.StatusNotFound, apierr.Error("NO_SUCH_ROLE", "No such role.", "07dc7d34-c0d8-458b-9c04-4b18399b1f46"))
 	}
-	return c.JSON(http.StatusOK, packRole(r))
+	return c.JSON(http.StatusOK, h.packRole(r))
 }
 
 // Users handles POST /api/roles/users.
@@ -190,18 +190,34 @@ func (h *Handler) Notes(c echo.Context) error {
 	return c.JSON(http.StatusOK, out)
 }
 
-func packRole(r *model.Role) map[string]any {
+// packRole builds the misskey_dart RolesListResponse 互換 shape。createdAt /
+// updatedAt (非null String) / canEditMembersByModerator (非null bool) /
+// usersCount (非null num) を含めないと misskey_dart の RolesListResponse.fromJson
+// が cast で落ちる (#1249)。usersCount は mk-go が role member 数を集計していない
+// ため 0 固定 (best-effort、非crashing)。
+func (h *Handler) packRole(r *model.Role) map[string]any {
+	const tsFormat = "2006-01-02T15:04:05.000Z"
+	createdAt := ""
+	if h.idGen != nil {
+		if t, err := h.idGen.ParseTime(r.ID); err == nil {
+			createdAt = t.UTC().Format(tsFormat)
+		}
+	}
 	return map[string]any{
-		"id":              r.ID,
-		"name":            r.Name,
-		"color":           r.Color,
-		"iconUrl":         r.IconURL,
-		"description":     r.Description,
-		"isModerator":     r.IsModerator,
-		"isAdministrator": r.IsAdministrator,
-		"isPublic":        r.IsPublic,
-		"isExplorable":    r.IsExplorable,
-		"asBadge":         r.AsBadge,
-		"displayOrder":    r.DisplayOrder,
+		"id":                        r.ID,
+		"createdAt":                 createdAt,
+		"updatedAt":                 r.UpdatedAt.UTC().Format(tsFormat),
+		"name":                      r.Name,
+		"color":                     r.Color,
+		"iconUrl":                   r.IconURL,
+		"description":               r.Description,
+		"isModerator":               r.IsModerator,
+		"isAdministrator":           r.IsAdministrator,
+		"isPublic":                  r.IsPublic,
+		"isExplorable":              r.IsExplorable,
+		"asBadge":                   r.AsBadge,
+		"canEditMembersByModerator": r.CanEditMembersByModerator,
+		"displayOrder":              r.DisplayOrder,
+		"usersCount":                0,
 	}
 }

--- a/internal/api/roles/handler.go
+++ b/internal/api/roles/handler.go
@@ -197,7 +197,11 @@ func (h *Handler) Notes(c echo.Context) error {
 // ため 0 固定 (best-effort、非crashing)。
 func (h *Handler) packRole(r *model.Role) map[string]any {
 	const tsFormat = "2006-01-02T15:04:05.000Z"
-	createdAt := ""
+	// createdAt は role ID (aidx) から復元する。misskey_dart は createdAt を
+	// DateTimeConverter で parse するため、空文字だと FormatException で落ちる。
+	// ID が aidx でない等で ParseTime に失敗した場合は updatedAt (非null) へ
+	// フォールバックし、常に有効な日付文字列を返す (#1249)。
+	createdAt := r.UpdatedAt.UTC().Format(tsFormat)
 	if h.idGen != nil {
 		if t, err := h.idGen.ParseTime(r.ID); err == nil {
 			createdAt = t.UTC().Format(tsFormat)

--- a/internal/api/roles/handler_test.go
+++ b/internal/api/roles/handler_test.go
@@ -108,6 +108,23 @@ func TestShow_Success(t *testing.T) {
 	assert.Equal(t, http.StatusOK, rec.Code)
 }
 
+// #1249: role ID が aidx でなく ParseTime が失敗しても createdAt は空文字に
+// ならず updatedAt にフォールバックすること (misskey_dart の DateTimeConverter
+// は空文字を FormatException にするため)。
+func TestList_CreatedAtFallsBackToUpdatedAt(t *testing.T) {
+	h, roleRepo := newTestHandler(t)
+	roleRepo.Roles["non-aidx-id"] = &model.Role{
+		ID: "non-aidx-id", Name: "Seeded", IsPublic: true,
+		UpdatedAt: time.Date(2026, 5, 1, 0, 0, 0, 0, time.UTC),
+	}
+	rec := doPost(h.List, `{}`)
+	require.Equal(t, http.StatusOK, rec.Code)
+	var resp []map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+	require.Len(t, resp, 1)
+	assert.Equal(t, "2026-05-01T00:00:00.000Z", resp[0]["createdAt"], "non-aidx ID は updatedAt にフォールバック")
+}
+
 func TestShow_NotPublic(t *testing.T) {
 	h, roleRepo := newTestHandler(t)
 	roleRepo.Roles["r1"] = &model.Role{ID: "r1", Name: "Priv", IsPublic: false}

--- a/internal/api/roles/handler_test.go
+++ b/internal/api/roles/handler_test.go
@@ -7,6 +7,7 @@ import (
 	"net/http/httptest"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/labstack/echo/v4"
 	"github.com/shiroha-a/mk/internal/api/roles"
@@ -72,6 +73,32 @@ func TestList_Empty(t *testing.T) {
 	h, _ := newTestHandler(t)
 	rec := doPost(h.List, `{}`)
 	assert.Equal(t, http.StatusOK, rec.Code)
+}
+
+// #1249: misskey_dart の RolesListResponse.fromJson が非null必須とする
+// createdAt (String) / updatedAt (String) / canEditMembersByModerator (bool) /
+// usersCount (num) が含まれること。欠落で roles 一覧が cast crash していた。
+func TestList_FullShape(t *testing.T) {
+	h, roleRepo := newTestHandler(t)
+	idGen, _ := id.NewGenerator("aidx")
+	roleID := idGen.Generate(time.Now())
+	roleRepo.Roles[roleID] = &model.Role{
+		ID: roleID, Name: "Public", IsPublic: true,
+		UpdatedAt:                 time.Date(2026, 5, 1, 0, 0, 0, 0, time.UTC),
+		CanEditMembersByModerator: true,
+	}
+	rec := doPost(h.List, `{}`)
+	require.Equal(t, http.StatusOK, rec.Code)
+	var resp []map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+	require.Len(t, resp, 1)
+	r := resp[0]
+	createdAt, ok := r["createdAt"].(string)
+	assert.True(t, ok, "createdAt must be a non-null string")
+	assert.NotEmpty(t, createdAt)
+	assert.Equal(t, "2026-05-01T00:00:00.000Z", r["updatedAt"])
+	assert.Equal(t, true, r["canEditMembersByModerator"])
+	assert.Equal(t, float64(0), r["usersCount"])
 }
 
 func TestShow_Success(t *testing.T) {

--- a/internal/api/users/handler.go
+++ b/internal/api/users/handler.go
@@ -757,6 +757,13 @@ func (h *Handler) packRelationItems(
 				pendingTo := pendingToMap[b.User.ID]
 				d.HasPendingFollowRequestFromYou = &pendingFrom
 				d.HasPendingFollowRequestToYou = &pendingTo
+				// misskey_dart の UserDetailed union は isFollowing が present だと
+				// UserDetailedNotMeWithRelations を選び、isBlocking/isBlocked/
+				// isMuted/isRenoteMuted も非null bool として cast する (#1249)。
+				// follow/follower list は block/mute の権威ソースではない (#1144 の
+				// batch を壊さないため per-user lookup は避ける) ので best-effort
+				// false で埋める。正確な値は users/show 単体で取得される。
+				d.EnsureRelationFlags()
 			}
 			if stats := remoteStatsMap[b.User.ID]; stats != nil {
 				d.NotesCount = stats.NotesCount

--- a/internal/api/users/handler_test.go
+++ b/internal/api/users/handler_test.go
@@ -1006,6 +1006,15 @@ func TestFollowers_PopulatesIsFollowedFromViewer(t *testing.T) {
 	assert.Equal(t, true, follower["isFollowed"], "alice follows viewer(bob) → isFollowed=true")
 	// bob は alice を follow していない → isFollowing=false。
 	assert.Equal(t, false, follower["isFollowing"])
+	// #1249: isFollowing が present のため misskey_dart は WithRelations variant を
+	// 選び、isBlocking/isBlocked/isMuted/isRenoteMuted も非null bool として cast
+	// する。EnsureRelationFlags で false 埋めされ全て present であること。
+	for _, key := range []string{"isBlocking", "isBlocked", "isMuted", "isRenoteMuted", "hasPendingFollowRequestFromYou", "hasPendingFollowRequestToYou"} {
+		v, present := follower[key]
+		assert.True(t, present, "%s must be present (WithRelations variant)", key)
+		_, isBool := v.(bool)
+		assert.True(t, isBool, "%s must be a non-null bool, got %T", key, v)
+	}
 }
 
 // TestFollowers_PopulatesPendingFollowRequest guards #1144 #2: locked

--- a/internal/core/transfer/emoji_export_test.go
+++ b/internal/core/transfer/emoji_export_test.go
@@ -125,7 +125,8 @@ func TestExport_CustomEmojis(t *testing.T) {
 	// exportCompleted 通知が custom-emojis entity で発火すること。
 	require.Len(t, notifier.calls, 1)
 	assert.Equal(t, notification.TypeExportCompleted, notifier.calls[0].Type)
-	assert.Equal(t, "custom-emojis", notifier.calls[0].Extra["exportedEntity"])
+	// exportedEntity は misskey enum 値 (custom-emojis → customEmoji) に変換 (#1249)。
+	assert.Equal(t, "customEmoji", notifier.calls[0].Extra["exportedEntity"])
 	assert.Equal(t, file.ID, notifier.calls[0].Extra["fileId"])
 }
 

--- a/internal/core/transfer/export_test.go
+++ b/internal/core/transfer/export_test.go
@@ -81,6 +81,35 @@ func newExportDeps(t *testing.T) (*fakeDriveSaver, *fakeNotifier, transfer.Expor
 
 // --- Tests ---
 
+// #1249: exportCompleted 通知の exportedEntity は misskey enum 値に変換される。
+// mk-go の複数形 / kebab-case をそのまま出すと misskey_dart の enum decode で
+// 落ちるため、各 export type が正しい単数形 / camelCase になることを確認する。
+func TestExport_ExportedEntityMapsToMisskeyEnum(t *testing.T) {
+	cases := map[string]string{
+		transfer.ExportNotes:        "note",
+		transfer.ExportFavorites:    "favorite",
+		transfer.ExportUserLists:    "userList",
+		transfer.ExportAntennas:     "antenna",
+		transfer.ExportClips:        "clip",
+		transfer.ExportMuting:       "muting",
+		transfer.ExportCustomEmojis: "customEmoji",
+		transfer.ExportFollowing:    "following",
+		transfer.ExportBlocking:     "blocking",
+	}
+	for in, want := range cases {
+		t.Run(in, func(t *testing.T) {
+			saver, notifier, deps, user := newExportDeps(t)
+			deps.EmojiRepo = &fakeEmojiSource{}
+			exporter := transfer.NewExporter(deps)
+			_, err := exporter.Export(context.Background(), user.ID, in)
+			require.NoError(t, err)
+			require.NotEmpty(t, saver.uploads)
+			require.Len(t, notifier.calls, 1)
+			assert.Equal(t, want, notifier.calls[0].Extra["exportedEntity"])
+		})
+	}
+}
+
 func TestExport_UnsupportedType(t *testing.T) {
 	_, _, deps, user := newExportDeps(t)
 	exporter := transfer.NewExporter(deps)
@@ -109,7 +138,8 @@ func TestExport_Notes_EmptyReturnsJSONArray(t *testing.T) {
 	assert.Equal(t, []byte("[]"), saver.uploads[0].Body)
 	require.Len(t, notifier.calls, 1)
 	assert.Equal(t, notification.TypeExportCompleted, notifier.calls[0].Type)
-	assert.Equal(t, transfer.ExportNotes, notifier.calls[0].Extra["exportedEntity"])
+	// exportedEntity は misskey enum 値 (notes → note) に変換される (#1249)。
+	assert.Equal(t, "note", notifier.calls[0].Extra["exportedEntity"])
 }
 
 func TestExport_Notes_WithPoll(t *testing.T) {

--- a/internal/core/transfer/transfer.go
+++ b/internal/core/transfer/transfer.go
@@ -177,10 +177,40 @@ func (e *Exporter) Export(ctx context.Context, userID, exportType string) (*mode
 			NotifieeID: user.ID,
 			Type:       notification.TypeExportCompleted,
 			Extra: map[string]any{
-				"exportedEntity": exportType,
+				"exportedEntity": misskeyExportedEntity(exportType),
 				"fileId":         file.ID,
 			},
 		})
 	}
 	return file, nil
+}
+
+// misskeyExportedEntity maps mk-go's internal export type to the value the
+// exportCompleted notification's `exportedEntity` field must carry. misskey_dart
+// (および upstream Misskey TS) は enum: note / antenna / blocking / clip /
+// customEmoji / favorite / following / muting / userList で受けるため、mk-go の
+// 複数形 / kebab-case の内部値 (notes / favorites / user-lists 等) を単数形 /
+// camelCase へ変換しないと notifications 一覧が enum decode で落ちる (#1249)。
+func misskeyExportedEntity(exportType string) string {
+	switch exportType {
+	case ExportNotes:
+		return "note"
+	case ExportFavorites:
+		return "favorite"
+	case ExportUserLists:
+		return "userList"
+	case ExportAntennas:
+		return "antenna"
+	case ExportClips:
+		return "clip"
+	case ExportMuting:
+		return "muting"
+	case ExportCustomEmojis:
+		return "customEmoji"
+	case ExportFollowing, ExportBlocking:
+		// following / blocking は既に misskey enum と一致。
+		return exportType
+	default:
+		return exportType
+	}
 }

--- a/internal/entity/user.go
+++ b/internal/entity/user.go
@@ -176,6 +176,42 @@ type MeDetailed struct {
 	NotificationRecieveConfig map[string]any `json:"notificationRecieveConfig"`
 }
 
+// EnsureRelationFlags fills any nil viewer-relation bool with false **only when
+// IsFollowing is already set**. misskey_dart の UserDetailed union dispatch は
+// `isFollowing` の存在で UserDetailedNotMeWithRelations を選び、その variant は
+// isFollowed / hasPendingFollowRequestFromYou / hasPendingFollowRequestToYou /
+// isBlocking / isBlocked / isMuted / isRenoteMuted も非null bool として cast
+// するため、一部しかセットしないと `Null is not bool` で落ちる (#1249)。
+// relation を部分的にしか計算しない経路 (follow/follower list 等) で本 helper を
+// 呼び、未計算 flag を false に倒して shape を完備する。
+func (d *UserDetailed) EnsureRelationFlags() {
+	if d.IsFollowing == nil {
+		return
+	}
+	f := false
+	if d.IsFollowed == nil {
+		d.IsFollowed = &f
+	}
+	if d.HasPendingFollowRequestFromYou == nil {
+		d.HasPendingFollowRequestFromYou = &f
+	}
+	if d.HasPendingFollowRequestToYou == nil {
+		d.HasPendingFollowRequestToYou = &f
+	}
+	if d.IsBlocking == nil {
+		d.IsBlocking = &f
+	}
+	if d.IsBlocked == nil {
+		d.IsBlocked = &f
+	}
+	if d.IsMuted == nil {
+		d.IsMuted = &f
+	}
+	if d.IsRenoteMuted == nil {
+		d.IsRenoteMuted = &f
+	}
+}
+
 // PackMeDetailed packs a self-view user payload, extending PackUserDetailed
 // with MeDetailed fields. Self-mutation handlers (i/update, i/2fa/*)
 // should use this instead of PackUserDetailed so frontend's

--- a/internal/entity/user_test.go
+++ b/internal/entity/user_test.go
@@ -449,6 +449,38 @@ func TestPackMeDetailed_NilProfile(t *testing.T) {
 	assert.False(t, me.ReceiveAnnouncementEmail)
 }
 
+// #1249: EnsureRelationFlags は IsFollowing がセット済みのとき、未計算の
+// relation bool を false で埋める (misskey_dart の WithRelations variant 互換)。
+func TestEnsureRelationFlags(t *testing.T) {
+	t.Run("fills nil flags when isFollowing set", func(t *testing.T) {
+		tr := true
+		d := UserDetailed{IsFollowing: &tr}
+		d.EnsureRelationFlags()
+		for name, p := range map[string]*bool{
+			"isFollowed": d.IsFollowed, "isBlocking": d.IsBlocking,
+			"isBlocked": d.IsBlocked, "isMuted": d.IsMuted, "isRenoteMuted": d.IsRenoteMuted,
+			"hasPendingFollowRequestFromYou": d.HasPendingFollowRequestFromYou,
+			"hasPendingFollowRequestToYou":   d.HasPendingFollowRequestToYou,
+		} {
+			require.NotNil(t, p, "%s must be filled", name)
+			assert.False(t, *p)
+		}
+	})
+	t.Run("no-op when isFollowing nil", func(t *testing.T) {
+		d := UserDetailed{}
+		d.EnsureRelationFlags()
+		assert.Nil(t, d.IsBlocking)
+		assert.Nil(t, d.IsFollowed)
+	})
+	t.Run("does not overwrite already-set flags", func(t *testing.T) {
+		tr, fa := true, false
+		d := UserDetailed{IsFollowing: &tr, IsBlocking: &tr, IsMuted: &fa}
+		d.EnsureRelationFlags()
+		assert.True(t, *d.IsBlocking, "existing true must be preserved")
+		assert.False(t, *d.IsMuted)
+	})
+}
+
 // #1240: misskey_dart の MeDetailed.fromJson が非null List/num として cast する
 // mutedWords / mutedInstances / achievements / loggedInDays が profile から
 // 正しく埋まること。


### PR DESCRIPTION
## Summary

#1249(フォロー/フォロワー + 私のコメントで追記した roles / notifications)の shape crash を修正する。すべて misskey_dart の `UserDetailed` union dispatch を起点とする非null フィールド欠落。

### misskey_dart の dispatch (根本)
```dart
if (json.containsKey("isFollowing")) → UserDetailedNotMeWithRelations
else if (json.containsKey("avatarId")) → MeDetailed
else → UserDetailedNotMe
```

## 各件の原因と修正

### フォロー/フォロワー (`/api/users/following`, `/api/users/followers`)
埋め込み followee/follower に `isFollowing` をセットすると misskey_dart は `UserDetailedNotMeWithRelations` variant を選び、`isBlocking`/`isBlocked`/`isMuted`/`isRenoteMuted`/`hasPendingFollowRequest*` も**非null bool 必須**になる。`packRelationItems` は follow/pending のみセットし block/mute を omit していたため crash(user.g.dart:355)。
- `entity.UserDetailed.EnsureRelationFlags()` を新設。`isFollowing` がセット済みのとき未計算 flag を false で補完。
- list は block/mute の権威ソースではない(#1144 の batch を壊さないため per-user lookup は避ける)ので best-effort false。正確値は users/show 単体経由。

### roles (`/api/roles/list`, `/api/roles/show`) — コメント追記
`RolesListResponse.fromJson` が `createdAt`/`updatedAt`(String)/`canEditMembersByModerator`(bool)/`usersCount`(num)を非null必須とするが packRole が4つとも欠落 → `Null is not String`。
- `packRole` を method 化し createdAt(role ID 由来)/ updatedAt / canEditMembersByModerator / usersCount を追加(usersCount は role member 未集計のため 0 固定)。

### notifications (exportCompleted) — コメント追記
`exportedEntity` を mk-go 内部値(`notes`/`favorites`/`user-lists`/`custom-emojis` 等)で出していたが、misskey_dart の enum は `note`/`favorite`/`userList`/`customEmoji` 等。enum decode で落ちていた。
- `misskeyExportedEntity` で単数形 / camelCase に変換。

## テスト
- entity `TestEnsureRelationFlags`(fill / no-op / 既存値保持)+ users `TestFollowers_PopulatesIsFollowedFromViewer` に block/mute bool presence。
- roles `TestList_FullShape`(createdAt/updatedAt/canEditMembersByModerator/usersCount)。
- transfer `TestExport_ExportedEntityMapsToMisskeyEnum`(全 export type の enum 変換)+ 既存 export 通知 assertion 更新。
- `go build ./...` / `go vet` / `gofmt` クリーン。coverage: users 92.6% / entity 95.1% / roles 98.6% / transfer 92.8%(全ゲート通過)。

## 残課題(本 PR スコープ外、別 follow-up)
**explore users**(`/api/users`、みつける>ユーザー)の crash:
- `/api/users` が `PackUserDetailed` を idGen 無しで呼び createdAt="" → `FormatException`。
- かつ `isFollowing` 不在 + mk-go は `avatarId` キーを常に出すため misskey_dart が **MeDetailed と誤判定**(twoFactorEnabled 等の MeDetailed 専用 field 欠落で crash)。

これは「`avatarId` が MeDetailed 専用であるべき」という**構造的問題**で、全 UserDetailed endpoint に影響するため、慎重な別 PR で対応する(本 PR で rush すると regression リスク大)。

Refs #1249

🤖 Generated with [Claude Code](https://claude.com/claude-code)