### PR TITLE
Fix UserDetailed: avatarId を MeDetailed 専用に移動して非self の MeDetailed 誤判定を解消 (#1249 explore)

### DIFF
--- a/internal/api/following/handler.go
+++ b/internal/api/following/handler.go
@@ -79,7 +79,7 @@ func (h *Handler) Create(c echo.Context) error {
 		}
 	}
 
-	return c.JSON(http.StatusOK, entity.PackUserDetailed(bundle.User, bundle.Profile))
+	return c.JSON(http.StatusOK, entity.PackUserDetailed(bundle.User, bundle.Profile, h.idGen))
 }
 
 // DeleteRequest is the request body for following/delete.
@@ -112,7 +112,7 @@ func (h *Handler) Delete(c echo.Context) error {
 		}
 	}
 
-	return c.JSON(http.StatusOK, entity.PackUserDetailed(bundle.User, bundle.Profile))
+	return c.JSON(http.StatusOK, entity.PackUserDetailed(bundle.User, bundle.Profile, h.idGen))
 }
 
 // RequestActionRequest is the shared request body for following/requests/{accept,reject,cancel}.
@@ -268,10 +268,10 @@ func (h *Handler) ListRequests(c echo.Context) error {
 	for _, r := range requests {
 		item := ListRequestsResponseItem{ID: r.ID}
 		if b, err := h.userService.ShowByID(r.FollowerID); err == nil {
-			item.Follower = entity.PackUserDetailed(b.User, b.Profile)
+			item.Follower = entity.PackUserDetailed(b.User, b.Profile, h.idGen)
 		}
 		if b, err := h.userService.ShowByID(r.FolloweeID); err == nil {
-			item.Followee = entity.PackUserDetailed(b.User, b.Profile)
+			item.Followee = entity.PackUserDetailed(b.User, b.Profile, h.idGen)
 		}
 		out = append(out, item)
 	}

--- a/internal/api/following/requests_sent.go
+++ b/internal/api/following/requests_sent.go
@@ -34,10 +34,10 @@ func (h *Handler) RequestsSent(c echo.Context) error {
 	for _, r := range rows {
 		item := ListRequestsResponseItem{ID: r.ID}
 		if b, err := h.userService.ShowByID(r.FollowerID); err == nil {
-			item.Follower = entity.PackUserDetailed(b.User, b.Profile)
+			item.Follower = entity.PackUserDetailed(b.User, b.Profile, h.idGen)
 		}
 		if b, err := h.userService.ShowByID(r.FolloweeID); err == nil {
-			item.Followee = entity.PackUserDetailed(b.User, b.Profile)
+			item.Followee = entity.PackUserDetailed(b.User, b.Profile, h.idGen)
 		}
 		out = append(out, item)
 	}

--- a/internal/core/following/following_service.go
+++ b/internal/core/following/following_service.go
@@ -336,7 +336,7 @@ func (s *Service) Follow(followerID, followeeID string, opts FollowOptions) (*Fo
 	// body.isFollowing / body.hasPendingFollowRequestFromYouを読むため、
 	// UserDetailed shapeでpackしてviewer依存フィールドも埋めておく。
 	if s.mainStreamPublisher != nil {
-		s.mainStreamPublisher.PublishMainEvent(followerID, "follow", entity.PackUserForFollowStreamEvent(followee, true, false))
+		s.mainStreamPublisher.PublishMainEvent(followerID, "follow", entity.PackUserForFollowStreamEvent(followee, true, false, s.idGen))
 		s.mainStreamPublisher.PublishMainEvent(followeeID, "followed", entity.PackUserLite(follower))
 	}
 
@@ -384,7 +384,7 @@ func (s *Service) Unfollow(followerID, followeeID string) error {
 			// shapeでisFollowing=false / hasPendingFollowRequestFromYou=falseを
 			// 明示的に埋める (frontendはこれらを直接代入するのでundefined不可)。
 			if s.mainStreamPublisher != nil {
-				s.mainStreamPublisher.PublishMainEvent(followerID, "unfollow", entity.PackUserForFollowStreamEvent(followee, false, false))
+				s.mainStreamPublisher.PublishMainEvent(followerID, "unfollow", entity.PackUserForFollowStreamEvent(followee, false, false, s.idGen))
 			}
 		}
 	}
@@ -448,7 +448,7 @@ func (s *Service) AcceptRequest(followeeID, followerID string) error {
 			// を publish する (TS本家 UserFollowingService.acceptFollow
 			// と同等)。follow event body は UserDetailed + isFollowing=true。
 			if s.mainStreamPublisher != nil {
-				s.mainStreamPublisher.PublishMainEvent(req.FollowerID, "follow", entity.PackUserForFollowStreamEvent(followee, true, false))
+				s.mainStreamPublisher.PublishMainEvent(req.FollowerID, "follow", entity.PackUserForFollowStreamEvent(followee, true, false, s.idGen))
 				s.mainStreamPublisher.PublishMainEvent(req.FolloweeID, "followed", entity.PackUserLite(follower))
 			}
 		}
@@ -545,7 +545,7 @@ func (s *Service) publishFollowRequestResolved(followerID string, followee *mode
 	if err != nil || !follower.IsLocal() {
 		return
 	}
-	s.mainStreamPublisher.PublishMainEvent(followerID, "unfollow", entity.PackUserForFollowStreamEvent(followee, false, false))
+	s.mainStreamPublisher.PublishMainEvent(followerID, "unfollow", entity.PackUserForFollowStreamEvent(followee, false, false, s.idGen))
 }
 
 // ListReceivedRequests returns follow requests received by userID. sinceID /

--- a/internal/entity/user.go
+++ b/internal/entity/user.go
@@ -47,10 +47,14 @@ type UserLite struct {
 }
 
 // UserDetailed includes additional fields for detailed user views.
+//
+// 注: avatarId / bannerId は **MeDetailed 専用** (self view のみ) で、MeDetailed
+// struct 側に持つ。misskey_dart の UserDetailed union dispatch は `avatarId` key
+// の存在で MeDetailed を判別する (`containsKey("avatarId") → MeDetailed`) ため、
+// 非self の UserDetailed に avatarId を出すと MeDetailed と誤判定されて crash する
+// (#1251)。よって base UserDetailed には含めない。
 type UserDetailed struct {
 	UserLite
-	AvatarID            *string        `json:"avatarId"`
-	BannerID            *string        `json:"bannerId"`
 	BannerURL           *string        `json:"bannerUrl"`
 	BannerBlurhash      *string        `json:"bannerBlurhash"`
 	IsLocked            bool           `json:"isLocked"`
@@ -116,17 +120,21 @@ type UserDetailed struct {
 // scoped to self-view (#968 / sibling of #693 ChatScope drift).
 type MeDetailed struct {
 	UserDetailed
-	IsExplorable             bool `json:"isExplorable"`
-	IsDeleted                bool `json:"isDeleted"`
-	HideOnlineStatus         bool `json:"hideOnlineStatus"`
-	NoCrawle                 bool `json:"noCrawle"`
-	PreventAiLearning        bool `json:"preventAiLearning"`
-	AutoSensitive            bool `json:"autoSensitive"`
-	CarefulBot               bool `json:"carefulBot"`
-	AutoAcceptFollowed       bool `json:"autoAcceptFollowed"`
-	AlwaysMarkNsfw           bool `json:"alwaysMarkNsfw"`
-	ReceiveAnnouncementEmail bool `json:"receiveAnnouncementEmail"`
-	InjectFeaturedNote       bool `json:"injectFeaturedNote"`
+	// avatarId / bannerId は self view 専用 (#1251)。misskey_dart の dispatch が
+	// `avatarId` key の存在で MeDetailed を判別するため、MeDetailed のみが出す。
+	AvatarID                 *string `json:"avatarId"`
+	BannerID                 *string `json:"bannerId"`
+	IsExplorable             bool    `json:"isExplorable"`
+	IsDeleted                bool    `json:"isDeleted"`
+	HideOnlineStatus         bool    `json:"hideOnlineStatus"`
+	NoCrawle                 bool    `json:"noCrawle"`
+	PreventAiLearning        bool    `json:"preventAiLearning"`
+	AutoSensitive            bool    `json:"autoSensitive"`
+	CarefulBot               bool    `json:"carefulBot"`
+	AutoAcceptFollowed       bool    `json:"autoAcceptFollowed"`
+	AlwaysMarkNsfw           bool    `json:"alwaysMarkNsfw"`
+	ReceiveAnnouncementEmail bool    `json:"receiveAnnouncementEmail"`
+	InjectFeaturedNote       bool    `json:"injectFeaturedNote"`
 	// 以下は misskey_dart の MeDetailed.fromJson が非null bool として cast する
 	// ため、self-view (users/show me) でも必ず値を出す必要がある (#1237)。
 	// /api/i は handler 層でこれらを正確な値に上書きするが、users/show の
@@ -234,7 +242,11 @@ func PackMeDetailed(u *model.User, profile *model.UserProfile, idGens ...id.Gene
 // work, so we promote the existing UserDetailed in-place.
 func AsMeDetailed(d UserDetailed, u *model.User, profile *model.UserProfile) MeDetailed {
 	out := MeDetailed{
-		UserDetailed:     d,
+		UserDetailed: d,
+		// avatarId / bannerId は self view 専用 (#1251)。base UserDetailed には
+		// 出さず MeDetailed (= /api/i / users/show self) でのみ u から set する。
+		AvatarID:         u.AvatarID,
+		BannerID:         u.BannerID,
 		IsExplorable:     u.IsExplorable,
 		IsDeleted:        u.IsDeleted,
 		HideOnlineStatus: u.HideOnlineStatus,
@@ -387,8 +399,6 @@ func PackUserLite(u *model.User) UserLite {
 func PackUserDetailed(u *model.User, profile *model.UserProfile, idGens ...id.Generator) UserDetailed {
 	d := UserDetailed{
 		UserLite:            PackUserLite(u),
-		AvatarID:            u.AvatarID,
-		BannerID:            u.BannerID,
 		BannerURL:           u.BannerURL,
 		BannerBlurhash:      u.BannerBlurhash,
 		IsLocked:            u.IsLocked,
@@ -438,13 +448,17 @@ func PackUserDetailed(u *model.User, profile *model.UserProfile, idGens ...id.Ge
 // the main channel's "follow" and "unfollow" stream events. Upstream Misskey
 // packs these events with the UserDetailedNotMe schema, and
 // MkFollowButton.onFollowChange reads isFollowing and
-// hasPendingFollowRequestFromYou directly to toggle the button — so both
-// fields must be populated from the viewer's perspective. Other viewer-
-// dependent fields (isBlocking, isMuted, etc.) are left at their zero values
-// because the follow button does not consume them.
-func PackUserForFollowStreamEvent(u *model.User, isFollowing, hasPendingFollowRequestFromYou bool) UserDetailed {
-	d := PackUserDetailed(u, nil)
+// hasPendingFollowRequestFromYou directly to toggle the button.
+//
+// isFollowing をセットするため misskey_dart は UserDetailedNotMeWithRelations
+// variant を選び、残りの relation bool + createdAt も非null必須になる (#1251)。
+// idGen で createdAt を有効にし、EnsureRelationFlags で未設定 relation bool を
+// false 補完して shape を完備する。idGen が nil の場合 createdAt は空になるため
+// caller は必ず idGen を渡すこと。
+func PackUserForFollowStreamEvent(u *model.User, isFollowing, hasPendingFollowRequestFromYou bool, idGen id.Generator) UserDetailed {
+	d := PackUserDetailed(u, nil, idGen)
 	d.IsFollowing = &isFollowing
 	d.HasPendingFollowRequestFromYou = &hasPendingFollowRequestFromYou
+	d.EnsureRelationFlags()
 	return d
 }

--- a/internal/entity/user_test.go
+++ b/internal/entity/user_test.go
@@ -3,6 +3,7 @@ package entity
 import (
 	"encoding/json"
 	"testing"
+	"time"
 
 	"github.com/lib/pq"
 	"github.com/shiroha-a/mk/internal/model"
@@ -341,20 +342,32 @@ func TestPackUserDetailed_FieldsDefaultWhenProfileNil(t *testing.T) {
 }
 
 func TestPackUserForFollowStreamEvent(t *testing.T) {
-	u := &model.User{ID: "u1", Username: "alice", AvatarDecorations: datatypes.JSON([]byte("[]"))}
+	idGen := newTestIDGen(t)
+	uid := idGen.Generate(time.Now())
+	u := &model.User{ID: uid, Username: "alice", AvatarDecorations: datatypes.JSON([]byte("[]"))}
 
 	t.Run("follow event sets isFollowing=true and hasPending=false", func(t *testing.T) {
-		out := PackUserForFollowStreamEvent(u, true, false)
+		out := PackUserForFollowStreamEvent(u, true, false, idGen)
 		require.NotNil(t, out.IsFollowing)
 		assert.True(t, *out.IsFollowing)
 		require.NotNil(t, out.HasPendingFollowRequestFromYou)
 		assert.False(t, *out.HasPendingFollowRequestFromYou)
-		assert.Equal(t, "u1", out.ID)
+		assert.Equal(t, uid, out.ID)
 		assert.Equal(t, "alice", out.Username)
+		// idGen から復元した createdAt が空でないこと (misskey_dart の
+		// DateTimeConverter が FormatException で落ちないため)。
+		assert.NotEmpty(t, out.CreatedAt)
+		// EnsureRelationFlags が WithRelations parse 用の関係 bool を埋めること。
+		require.NotNil(t, out.IsFollowed)
+		assert.False(t, *out.IsFollowed)
+		require.NotNil(t, out.IsBlocking)
+		assert.False(t, *out.IsBlocking)
+		require.NotNil(t, out.IsMuted)
+		assert.False(t, *out.IsMuted)
 	})
 
 	t.Run("unfollow event sets isFollowing=false and hasPending=false", func(t *testing.T) {
-		out := PackUserForFollowStreamEvent(u, false, false)
+		out := PackUserForFollowStreamEvent(u, false, false, idGen)
 		require.NotNil(t, out.IsFollowing)
 		assert.False(t, *out.IsFollowing)
 		require.NotNil(t, out.HasPendingFollowRequestFromYou)
@@ -362,7 +375,7 @@ func TestPackUserForFollowStreamEvent(t *testing.T) {
 	})
 
 	t.Run("pending request sets isFollowing=false and hasPending=true", func(t *testing.T) {
-		out := PackUserForFollowStreamEvent(u, false, true)
+		out := PackUserForFollowStreamEvent(u, false, true, idGen)
 		require.NotNil(t, out.IsFollowing)
 		assert.False(t, *out.IsFollowing)
 		require.NotNil(t, out.HasPendingFollowRequestFromYou)
@@ -370,11 +383,79 @@ func TestPackUserForFollowStreamEvent(t *testing.T) {
 	})
 
 	t.Run("serialized JSON exposes the viewer fields", func(t *testing.T) {
-		out := PackUserForFollowStreamEvent(u, true, false)
+		out := PackUserForFollowStreamEvent(u, true, false, idGen)
 		b, err := json.Marshal(out)
 		require.NoError(t, err)
 		assert.Contains(t, string(b), `"isFollowing":true`)
 		assert.Contains(t, string(b), `"hasPendingFollowRequestFromYou":false`)
+	})
+}
+
+// TestUserDetailed_OmitsAvatarIDKey は #1251 の core 修正を検証する。misskey_dart の
+// UserDetailed union dispatch は `avatarId` key の存在で MeDetailed を選ぶため、
+// 他人ビュー (UserDetailed / users explore) では avatarId / bannerId key を一切
+// 出してはならない。出すと NotMe ユーザーが MeDetailed として誤 parse され、
+// createdAt="" 等で fromJson が落ちる。
+func TestUserDetailed_OmitsAvatarIDKey(t *testing.T) {
+	idGen := newTestIDGen(t)
+	uid := idGen.Generate(time.Now())
+	avatarID := "avatar-id-1"
+	bannerID := "banner-id-1"
+	u := &model.User{
+		ID:                uid,
+		Username:          "other",
+		AvatarID:          &avatarID,
+		BannerID:          &bannerID,
+		AvatarDecorations: datatypes.JSON([]byte("[]")),
+	}
+
+	detailed := PackUserDetailed(u, nil, idGen)
+	b, err := json.Marshal(detailed)
+	require.NoError(t, err)
+
+	// avatarId / bannerId key 自体が出てはいけない (MeDetailed discriminator のため)。
+	assert.NotContains(t, string(b), `"avatarId"`)
+	assert.NotContains(t, string(b), `"bannerId"`)
+	// idGen から復元した createdAt が非空であること (NotMe parse が落ちない)。
+	assert.NotEmpty(t, detailed.CreatedAt)
+}
+
+// TestMeDetailed_EmitsAvatarIDKey は self-view では avatarId / bannerId key が
+// 出ることを検証する。これが MeDetailed dispatch の discriminator であり、
+// avatar 未設定でも `"avatarId":null` の key が存在する必要がある (#1251)。
+func TestMeDetailed_EmitsAvatarIDKey(t *testing.T) {
+	idGen := newTestIDGen(t)
+	uid := idGen.Generate(time.Now())
+
+	t.Run("with avatar set", func(t *testing.T) {
+		avatarID := "avatar-id-1"
+		u := &model.User{
+			ID:                uid,
+			Username:          "me",
+			AvatarID:          &avatarID,
+			AvatarDecorations: datatypes.JSON([]byte("[]")),
+		}
+		me := PackMeDetailed(u, nil, idGen)
+		b, err := json.Marshal(me)
+		require.NoError(t, err)
+		assert.Contains(t, string(b), `"avatarId":"avatar-id-1"`)
+		assert.Contains(t, string(b), `"bannerId"`)
+		require.NotNil(t, me.AvatarID)
+		assert.Equal(t, "avatar-id-1", *me.AvatarID)
+	})
+
+	t.Run("without avatar still emits null key for dispatch", func(t *testing.T) {
+		u := &model.User{
+			ID:                uid,
+			Username:          "me",
+			AvatarDecorations: datatypes.JSON([]byte("[]")),
+		}
+		me := PackMeDetailed(u, nil, idGen)
+		b, err := json.Marshal(me)
+		require.NoError(t, err)
+		// avatar 未設定でも key 自体は出ること (dispatch discriminator)。
+		assert.Contains(t, string(b), `"avatarId":null`)
+		assert.Contains(t, string(b), `"bannerId":null`)
 	})
 }
 

--- a/internal/server/router.go
+++ b/internal/server/router.go
@@ -954,7 +954,9 @@ func (s *Server) setupRoutes() {
 		result := make([]entity.UserDetailed, 0, len(users))
 		for _, u := range users {
 			profile, _ := userRepo.FindProfileByUserID(u.ID)
-			result = append(result, entity.PackUserDetailed(u, profile))
+			// idGen を渡して createdAt を有効にする。未配線だと createdAt="" で
+			// misskey_dart の DateTimeConverter が FormatException で落ちる (#1251)。
+			result = append(result, entity.PackUserDetailed(u, profile, idGen))
 		}
 		return c.JSON(http.StatusOK, result)
 	})


### PR DESCRIPTION
## Summary

3rd-party client (misskey_dart / Miria) で explore (みつける>ユーザー) / follow・follower リストが crash する構造的問題を修正する (#1249 で報告、#1251 で切り出し)。

misskey_dart の `UserDetailed` union dispatch は次の順で variant を選ぶ:

```dart
if (containsKey("isFollowing"))      → UserDetailedNotMeWithRelations
else if (containsKey("avatarId"))    → MeDetailed
else                                 → UserDetailedNotMe
```

`avatarId` / `bannerId` は **どの variant の fromJson でも読まれず、MeDetailed (self 応答) を判別するためだけの discriminator key**。ところが mk-go は `PackUserDetailed` が全 UserDetailed に `avatarId` / `bannerId` を出していたため、`isFollowing` を持たない非self user (explore / 未認証 viewer / follow リストの self-row) が **MeDetailed と誤判定** され、`twoFactorEnabled` 等の欠落や `createdAt=""` で `FormatException` を起こして crash していた。

加えて explore `/api/users` は `PackUserDetailed` を **idGen 無し**で呼んでおり、`createdAt=""` が NotMe parse でも落ちる要因になっていた。

## 主な変更点

- **entity (`internal/entity/user.go`)**: `AvatarID` / `BannerID` を `UserDetailed` struct から `MeDetailed` struct へ移動。`AsMeDetailed` が `User` から set するため `/api/i` / `users/show` self では引き続き出る。非self の `UserDetailed` は `avatarId` key を一切出さず NotMe / WithRelations へ正しく分岐する。
- **explore (`internal/server/router.go`)**: `/api/users` の `PackUserDetailed` 呼び出しに `idGen` を配線し `createdAt` を有効化。
- **following (`internal/api/following/`)**: `PackUserDetailed` 呼び出し 6 箇所に `h.idGen` を配線。
- **stream event (`PackUserForFollowStreamEvent`)**: `idGen` 引数を追加し `EnsureRelationFlags` を呼ぶ。`isFollowing` を set するため WithRelations variant になり、relation bool + `createdAt` が非null必須になる。production caller 4 箇所 (`following_service.go`) を更新。

## テスト

- `TestUserDetailed_OmitsAvatarIDKey`: 非self `UserDetailed` の JSON に `avatarId` / `bannerId` key が出ず、idGen 指定時に `createdAt` が非空であることを検証。
- `TestMeDetailed_EmitsAvatarIDKey`: self-view では avatar 未設定でも `avatarId":null` key が出ること (dispatch discriminator) を検証。
- `TestPackUserForFollowStreamEvent`: 新 signature + `createdAt` 非空 + `EnsureRelationFlags` による relation bool 補完を検証。

```bash
go test ./internal/entity/... ./internal/api/following/... ./internal/api/users/... ./internal/core/following/... -count=1 -cover
# entity 95.4% / following 94.3% / users 92.6% / core-following 94.3% — 全て 90% gate 超え
```

`make fmt && go vet ./...` clean、`go build ./...` 通過。

## Closes

Closes #1251
Closes #1249

## その他

admin / proxy 系の no-idGen `PackUserDetailed` (`internal/api/admin/`) は admin 専用で Miria 非到達のため本 PR の scope 外 (#1251 備考)。

🤖 Generated with [Claude Code](https://claude.com/claude-code)