### PR TITLE
feat(entitycompat): API shape drift 検出ゲート (L0 静的 + L2 実行時)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,8 @@
 	e2e-submodule-init e2e-frontend-build e2e-deps e2e-run e2e-open \
 	uds-init uds-frontend-build uds-build uds-up uds-down uds-down-v uds-logs uds-ps \
 	bench-up bench-run bench-down bench-logs \
-	apicompat apicompat-routes apicompat-render
+	apicompat apicompat-routes apicompat-render \
+	shapecheck shapecheck-gen shapecheck-report
 
 # Binary output
 BINARY=misskey
@@ -426,3 +427,23 @@ apicompat-render:
 # matrix を作らないようにする (`.PHONY` 効果で常に build + dump し直す)。
 # 反復 iterate で DB 接続を毎回避けたい場合は `apicompat-render` を使う。
 apicompat: apicompat-routes apicompat-render
+
+# --- entity shape drift (Layer 0 static API compatibility) ------------------
+# mk-go の entity DTO struct を Misskey contract (misskey-js types.ts) と
+# フィールド単位で突き合わせ、shape drift (欠落 / null性 / optional性) を検出する。
+# サーバー / ブラウザ / Docker 不要で、CI では `go test ./...` 内の
+# TestEntityShapeDrift gate として自動実行される。詳細は docs/shape-drift.md。
+
+# golden snapshot (testdata/golden_schemas.json) を submodule の types.ts から
+# 再生成する。third_party/misskey を upstream catch-up で bump したら必ず実行し、
+# 生成された snapshot を commit すること。
+shapecheck-gen:
+	go run ./tools/shapediff
+
+# 全 family の drift を severity 付きで一覧表示する (gate にかける前の調査用)。
+shapecheck-report:
+	go run ./tools/shapediff -report
+
+# drift gate (L0 静的 + L2 実行時) をローカルで実行する (CI と同じ判定)。
+shapecheck:
+	go test ./internal/entitycompat/... -run 'TestEntityShapeDrift|TestNotificationShapeL2' -count=1 -v

--- a/docs/shape-drift.md
+++ b/docs/shape-drift.md
@@ -1,0 +1,113 @@
+# Entity shape drift gate (Layer 0)
+
+mk-goのentity DTO構造体を、Misskey API契約(misskey-jsの`types.ts`=OpenAPI `components.schemas`のミラー)とフィールド単位で突き合わせ、**3rd-partyクライアントのshape crashを引き起こすドリフト**を静的に検出するゲート。
+
+サーバー/ブラウザ/Docker不要で、決定的・ミリ秒で動く。CIでは`go test ./...`内の`TestEntityShapeDrift`として自動実行される。
+
+## なぜ必要か
+
+Misskey互換クライアント(Miria等)は、misskey-jsの型に従ってレスポンスをデシリアライズする。`text: string`(non-null)と宣言された欄をmk-goが`null`で返したり、必須欄を省略すると、クライアントは非nullキャストに失敗してクラッシュする。
+
+これは本質的に**スキーマ(shape)の不一致**であって、Playwrightやdrop-in E2Eのようなブラウザ越しの挙動テストで間接的に検出する問題ではない。本ゲートは契約レベルで直接diffを取るため、flakyゼロ・全フィールド網羅で検出できる。
+
+## 構成
+
+| ファイル | 役割 |
+|---|---|
+| `internal/entitycompat/shapecheck.go` | reflection / types.tsパーサ / diffロジック |
+| `internal/entitycompat/mapping.go` | entity構造体 ↔ golden schemaのマッピング表 |
+| `internal/entitycompat/gate.go` | snapshot/allowlistのロード、ゲート判定 |
+| `internal/entitycompat/testdata/golden_schemas.json` | golden契約のスナップショット(commit対象) |
+| `internal/entitycompat/testdata/allowlist.json` | 既知/意図的ドリフトのallowlist(baseline backlog) |
+| `tools/shapediff/` | snapshot再生成 + 全family drift report |
+
+golden側は**commit済みスナップショット**を読むため、テスト時にsubmoduleを必要としない(hermetic)。
+
+## 検出するドリフトの種類
+
+| Kind | Severity | 意味 |
+|---|---|---|
+| `missing` (required) | HIGH | golden必須欄をmk-goが全く出さない |
+| `missing` (optional) | LOW | golden optional欄が無い(非ブロッキング) |
+| `nullable` | HIGH | goldenがnon-nullなのにmk-goが`null`を出しうる(omitempty無しポインタ) |
+| `omit` | MED | goldenが必須なのにmk-goが`omitempty`で省略しうる |
+| `extra` | INFO | mk-go独自欄(拡張/alias候補) |
+| `layer` | INFO | 同family内の別layerに存在(配置違いだが出力上は存在) |
+
+ゲートは**HIGH/MED**のみをブロック対象とする。LOW/INFOはレポートのみ。
+
+## マッピングの考え方
+
+goldenはユーザー shapeを合成可能な部品(`UserLite` / `UserDetailedNotMeOnly` / `MeDetailedOnly`)に分解し、mk-goは構造体埋め込みでこれを写している。よって各埋め込みlayerを対応する`*Only`スキーマに突き合わせる。standaloneなentity(Note等)はfamily of one。
+
+### 対象外
+
+- **Notification**: golden側がtype別のdiscriminated union、mk-go側も`PackNotification`が`map[string]any`を手組みするため、reflectionが届かない。map-based packerとunion型は静的検出の射程外で、差分HTTP(L2)で見る。
+
+## 運用
+
+### 日常(CI)
+
+`go test ./...`で`TestEntityShapeDrift`が走る。新しいドリフトが入ったPRはここで落ちる。ローカル確認は:
+
+```bash
+make shapecheck          # gateをCIと同じ判定で実行
+make shapecheck-report   # 全familyのdrift一覧(severity付き)
+```
+
+### allowlist
+
+ゲート導入時点で存在したドリフトはbaselineとして`allowlist.json`に記録済み。各エントリは**潰すべきbacklog**であって恒久免除ではない。新規ドリフトは:
+
+1. 構造体を修正してドリフトを解消する、または
+2. 理由を添えて`allowlist.json`に追加する(意図的拡張等)
+
+allowlistに登録済みのドリフトを修正すると、そのエントリは**stale**になりゲートが落ちる(allowlistの掃除を促す)。
+
+### upstream catch-up時
+
+`third_party/misskey`を新バージョンにbumpしたら、goldenスナップショットを再生成してcommitする:
+
+```bash
+make shapecheck-gen   # testdata/golden_schemas.json を再生成
+git add internal/entitycompat/testdata/golden_schemas.json
+```
+
+これで新バージョンで追加/変更された契約欄が次回のゲートに反映される。
+
+## Layer 2: 実行時shape検証(map-based / union)
+
+L0の静的reflectionは「宣言されたshape」しか見ない。以下はその射程外:
+
+- `map[string]any`で手組みするpacker(`PackNotification`等)
+- discriminated union(通知のtype別variant)
+- 構造体は正しいが、handlerが実行時に値をpopulateし忘れるバグ
+
+L2は**packerが実際に出力したJSON値**を契約に突き合わせてこれを埋める。二backend(TS)起動は重くflakyなので避け、**fixtureでpacker出力を生成 → golden契約に検証**する軽量版を採る。
+
+| ファイル | 役割 |
+|---|---|
+| `internal/entitycompat/runtime.go` | union parser(`ParseUnion`)+ 実行時validator(`ValidateValue` / `ValidateUnionValue`) |
+| `internal/entitycompat/runtime_test.go` | `TestNotificationShapeL2`(実packer出力を検証)+ 単体テスト |
+| `testdata/golden_unions.json` | union契約のスナップショット(type literal別variant、commit対象) |
+| `testdata/allowlist_l2.json` | L2 baseline backlog |
+
+### ValidateUnionValue の判定
+
+通知mapの`type`でgolden variantを引き、そのvariantに対して検証する:
+
+- `type`に対応するvariantが無い → HIGH(strictクライアントがunion dispatchで弾く)
+- variantの必須欄が実行時に欠落 / null → HIGH
+- scalar型不一致 → MED
+- golden未知の欄 → INFO(拡張)
+
+### L2 baseline(実検出例)
+
+L2導入時点で検出された実ドリフト:
+
+- `type=pollVote` / `type=importCompleted`(HIGH): mk-goが出す通知typeがgolden union(`pollEnded` / `exportCompleted`)に無い。strictクライアントがdispatchできない。
+- `noteId`(INFO): mk-goが通知に足す独自欄(契約外、非ブロッキング)。
+
+### まだ残る射程外
+
+- `/api/i`等がhandler層で`map[string]any`にアドホック追加する欄(再利用可能なpackerを介さないため、fixtureで再現できない)。L0 baseline allowlistの`MeDetailed`系(`unreadAnnouncements`等)がこれ。最終的には二backend差分HTTP、または該当handlerの統合テストで確定する。

--- a/docs/upstream-catch-up.md
+++ b/docs/upstream-catch-up.md
@@ -150,6 +150,20 @@ git add third_party/misskey
 
 `<tag>-mk.N` の `N` は revision 番号。同 release base で追加 patch が増えたら `.1` `.2` と上げる。
 
+### submodule bump 後に必須: shape drift snapshot の再生成
+
+`third_party/misskey` を bump したら、entity shape drift gate の golden snapshot を
+再生成して commit すること。新バージョンで追加 / 変更された契約フィールドが次回の
+`TestEntityShapeDrift` に反映される。
+
+```bash
+make shapecheck-gen   # internal/entitycompat/testdata/golden_schemas.json を再生成
+make shapecheck       # gate がまだ通るか確認 (新規 drift が出たら allowlist or 修正)
+git add internal/entitycompat/testdata/golden_schemas.json
+```
+
+詳細は [shape-drift.md](./shape-drift.md)。
+
 ---
 
 ## 3. 参考リンク

--- a/internal/entitycompat/gate.go
+++ b/internal/entitycompat/gate.go
@@ -1,0 +1,86 @@
+package entitycompat
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+)
+
+// AllowEntry records a known or intentional drift the gate must not fail on.
+// The baseline allowlist captures drift that existed when the gate was
+// introduced; each entry is a backlog item to burn down, not a permanent
+// exemption. The Reason documents why (intentional extension vs. tracked gap).
+type AllowEntry struct {
+	Layer  string `json:"layer"`
+	Field  string `json:"field"`
+	Kind   string `json:"kind"`
+	Reason string `json:"reason"`
+}
+
+// LoadGoldenSnapshot reads the committed golden contract snapshot.
+func LoadGoldenSnapshot(path string) (GoldenSet, error) {
+	b, err := os.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("read golden snapshot: %w", err)
+	}
+	var g GoldenSet
+	if err := json.Unmarshal(b, &g); err != nil {
+		return nil, fmt.Errorf("decode golden snapshot: %w", err)
+	}
+	return g, nil
+}
+
+// LoadAllowlist reads the baseline/intentional drift allowlist.
+func LoadAllowlist(path string) ([]AllowEntry, error) {
+	b, err := os.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("read allowlist: %w", err)
+	}
+	var a []AllowEntry
+	if err := json.Unmarshal(b, &a); err != nil {
+		return nil, fmt.Errorf("decode allowlist: %w", err)
+	}
+	return a, nil
+}
+
+// GatedFindings returns the HIGH and MED findings across all families. LOW and
+// INFO findings are informational and not subject to the gate.
+func GatedFindings(golden GoldenSet) []Finding {
+	var out []Finding
+	for _, fam := range Families() {
+		for _, f := range DiffFamily(fam, golden) {
+			if f.Sev == SevHigh || f.Sev == SevMed {
+				out = append(out, f)
+			}
+		}
+	}
+	return out
+}
+
+type allowKey struct{ layer, field, kind string }
+
+// RunGate filters gated findings through the allowlist. It returns the
+// findings not covered by the allowlist (gate violations) and the allowlist
+// entries that matched no current finding (stale entries to remove once the
+// corresponding drift is fixed).
+func RunGate(findings []Finding, allow []AllowEntry) (violations []Finding, stale []AllowEntry) {
+	allowed := make(map[allowKey]bool, len(allow))
+	used := make(map[allowKey]bool, len(allow))
+	for _, a := range allow {
+		allowed[allowKey{a.Layer, a.Field, a.Kind}] = true
+	}
+	for _, f := range findings {
+		k := allowKey{f.Layer, f.Field, f.Kind}
+		if allowed[k] {
+			used[k] = true
+			continue
+		}
+		violations = append(violations, f)
+	}
+	for _, a := range allow {
+		if !used[allowKey{a.Layer, a.Field, a.Kind}] {
+			stale = append(stale, a)
+		}
+	}
+	return violations, stale
+}

--- a/internal/entitycompat/mapping.go
+++ b/internal/entitycompat/mapping.go
@@ -1,0 +1,53 @@
+package entitycompat
+
+import (
+	"reflect"
+
+	"github.com/shiroha-a/mk/internal/entity"
+)
+
+// Layer pairs one mk-go struct with the golden schema it must conform to.
+type Layer struct {
+	Label  string
+	Golden string
+	Type   reflect.Type
+}
+
+// Family groups related layers that share a field namespace. The User family
+// has three layers because upstream decomposes the user shape into composable
+// building blocks (UserLite / UserDetailedNotMeOnly / MeDetailedOnly) and
+// mk-go mirrors that via struct embedding. Standalone entities are a family
+// of one.
+type Family struct {
+	Name   string
+	Layers []Layer
+}
+
+// Families is the authoritative entity<->contract mapping. Each mk-go struct's
+// own (non-embedded) fields are compared against the named golden schema.
+//
+// 注: golden 側で UserDetailed / MeDetailed は intersection 型 (合成) なので
+// flat parse できない。代わりに合成元の *Only building-block schema に各
+// embedding layer を対応させる。
+func Families() []Family {
+	return []Family{
+		{
+			Name: "User",
+			Layers: []Layer{
+				{"UserLite", "UserLite", reflect.TypeOf(entity.UserLite{})},
+				{"UserDetailed", "UserDetailedNotMeOnly", reflect.TypeOf(entity.UserDetailed{})},
+				{"MeDetailed", "MeDetailedOnly", reflect.TypeOf(entity.MeDetailed{})},
+			},
+		},
+		{Name: "Note", Layers: []Layer{{"Note", "Note", reflect.TypeOf(entity.NoteEntity{})}}},
+		// 注: Notification は対象外。golden 側が type 別の discriminated union で
+		// flat 比較できず、mk-go 側も entity.NotificationItem は DTO ではなく
+		// PackNotification が map[string]any を手組みするため reflection が届かない。
+		// map ベース packer + union 型は静的検出の射程外で、差分 HTTP (L2) で見る。
+		{Name: "DriveFile", Layers: []Layer{{"DriveFile", "DriveFile", reflect.TypeOf(entity.DriveFileEntity{})}}},
+		{Name: "DriveFolder", Layers: []Layer{{"DriveFolder", "DriveFolder", reflect.TypeOf(entity.DriveFolderEntity{})}}},
+		{Name: "UserList", Layers: []Layer{{"UserList", "UserList", reflect.TypeOf(entity.UserList{})}}},
+		{Name: "Following", Layers: []Layer{{"Following", "Following", reflect.TypeOf(entity.Following{})}}},
+		{Name: "EmojiDetailed", Layers: []Layer{{"EmojiDetailed", "EmojiDetailed", reflect.TypeOf(entity.EmojiDetailed{})}}},
+	}
+}

--- a/internal/entitycompat/runtime.go
+++ b/internal/entitycompat/runtime.go
@@ -120,33 +120,36 @@ func literalOf(rhs string) string {
 // struct round-tripped to a map) against a golden schema and returns findings.
 // Unlike the Layer 0 reflection diff this inspects concrete runtime values, so
 // it catches a required field that is present-but-null or simply not populated.
-func ValidateValue(layer, golden string, actual map[string]any, schema Schema) []Finding {
+func ValidateValue(family, layer, golden string, actual map[string]any, schema Schema) []Finding {
+	mk := func(field, kind string, sev Severity, detail string) Finding {
+		return Finding{Family: family, Layer: layer, Golden: golden, Field: field, Kind: kind, Sev: sev, Detail: detail}
+	}
 	var findings []Finding
 	for name, g := range schema {
 		v, present := actual[name]
 		if !present {
 			if !g.Optional {
-				findings = append(findings, Finding{layer, layer, golden, name, KindMissing, SevHigh,
-					"required by golden but not emitted at runtime"})
+				findings = append(findings, mk(name, KindMissing, SevHigh,
+					"required by golden but not emitted at runtime"))
 			}
 			continue
 		}
 		if v == nil {
 			if !g.Nullable {
-				findings = append(findings, Finding{layer, layer, golden, name, KindNullable, SevHigh,
-					"golden non-null but runtime value is null"})
+				findings = append(findings, mk(name, KindNullable, SevHigh,
+					"golden non-null but runtime value is null"))
 			}
 			continue
 		}
 		if at := jsonType(v); scalarMismatch(g.Type, at) {
-			findings = append(findings, Finding{layer, layer, golden, name, "type", SevMed,
-				"golden type " + g.Type + " but runtime value is " + at})
+			findings = append(findings, mk(name, "type", SevMed,
+				"golden type "+g.Type+" but runtime value is "+at))
 		}
 	}
 	for name := range actual {
 		if _, ok := schema[name]; !ok {
-			findings = append(findings, Finding{layer, layer, golden, name, KindExtra, SevInfo,
-				"emitted at runtime but not in golden"})
+			findings = append(findings, mk(name, KindExtra, SevInfo,
+				"emitted at runtime but not in golden"))
 		}
 	}
 	return findings
@@ -159,10 +162,13 @@ func ValidateUnionValue(unionName string, actual map[string]any, variants map[st
 	t, _ := actual["type"].(string)
 	schema, ok := variants[t]
 	if !ok {
-		return []Finding{{unionName, unionName, unionName, "type=" + t, KindMissing, SevHigh,
-			"runtime type literal has no matching variant in the golden union"}}
+		return []Finding{{
+			Family: unionName, Layer: unionName, Golden: unionName,
+			Field: "type=" + t, Kind: KindMissing, Sev: SevHigh,
+			Detail: "runtime type literal has no matching variant in the golden union",
+		}}
 	}
-	return ValidateValue(unionName+"["+t+"]", unionName, actual, schema)
+	return ValidateValue(unionName, unionName+"["+t+"]", unionName, actual, schema)
 }
 
 // jsonType returns the JSON type bucket of a Go value as it serializes.

--- a/internal/entitycompat/runtime.go
+++ b/internal/entitycompat/runtime.go
@@ -1,0 +1,210 @@
+package entitycompat
+
+import (
+	"reflect"
+	"strings"
+)
+
+// This file implements the "Layer 2" runtime shape check: instead of reflecting
+// over struct declarations (Layer 0), it validates the *actual JSON value* a
+// packer emits against the golden contract. That reaches what static analysis
+// cannot — map-based packers (PackNotification returns map[string]any),
+// discriminated unions, and handler populate bugs (a field declared on the
+// struct but left null/absent at runtime).
+
+// UnionSchemaNames lists the discriminated-union golden schemas the generator
+// must extract per variant. These are excluded from the Layer 0 family table
+// because a flat reflection diff is meaningless against a union.
+func UnionSchemaNames() []string {
+	return []string{"Notification"}
+}
+
+// ParseUnion parses a discriminated-union schema (variants joined by `} | {`)
+// into a map keyed by each variant's `type` string literal. Variants without a
+// `type` discriminator are skipped.
+func ParseUnion(lines []string, schemaName string) map[string]Schema {
+	open := "        " + schemaName + ": {"
+	start := -1
+	for i, ln := range lines {
+		if ln == open {
+			start = i
+			break
+		}
+	}
+	if start < 0 {
+		return nil
+	}
+
+	out := map[string]Schema{}
+	depth := 1
+	variant := Schema{}
+	variantType := ""
+
+	var curName string
+	var have, optional bool
+	var typ string
+	var buf strings.Builder
+	finalizeField := func() {
+		if !have {
+			return
+		}
+		variant[curName] = FieldShape{
+			Nullable: strings.Contains(buf.String(), "| null"),
+			Optional: optional,
+			Type:     typ,
+		}
+		have = false
+		buf.Reset()
+	}
+	finalizeVariant := func() {
+		finalizeField()
+		if variantType != "" {
+			out[variantType] = variant
+		}
+		variant = Schema{}
+		variantType = ""
+	}
+
+	for i := start + 1; i < len(lines); i++ {
+		ln := lines[i]
+		trimmed := strings.TrimSpace(ln)
+		if strings.HasPrefix(trimmed, "/*") || strings.HasPrefix(trimmed, "*") {
+			continue
+		}
+		// variant 境界: 8-space indent の `} | {` (nested の `}` は深い indent)。
+		if strings.HasPrefix(ln, "        } | {") {
+			finalizeVariant()
+			continue
+		}
+		if depth == 1 {
+			if m := propRe.FindStringSubmatch(ln); m != nil {
+				finalizeField()
+				curName = m[1]
+				optional = m[2] == "?"
+				typ = coarseTS(m[3])
+				have = true
+				if curName == "type" {
+					variantType = literalOf(m[3])
+				}
+			}
+		}
+		if have {
+			buf.WriteString(ln)
+			buf.WriteString("\n")
+		}
+		depth += strings.Count(ln, "{") - strings.Count(ln, "}")
+		if depth == 0 {
+			finalizeVariant()
+			return out
+		}
+	}
+	finalizeVariant()
+	return out
+}
+
+// literalOf extracts the single-quoted string literal from a type RHS like
+// `'follow';` -> `follow`. Returns "" when the RHS is not a bare literal.
+func literalOf(rhs string) string {
+	rhs = strings.TrimSpace(rhs)
+	if !strings.HasPrefix(rhs, "'") {
+		return ""
+	}
+	rhs = rhs[1:]
+	if i := strings.IndexByte(rhs, '\''); i >= 0 {
+		return rhs[:i]
+	}
+	return ""
+}
+
+// ValidateValue checks a decoded JSON object (a packer's map output, or a
+// struct round-tripped to a map) against a golden schema and returns findings.
+// Unlike the Layer 0 reflection diff this inspects concrete runtime values, so
+// it catches a required field that is present-but-null or simply not populated.
+func ValidateValue(layer, golden string, actual map[string]any, schema Schema) []Finding {
+	var findings []Finding
+	for name, g := range schema {
+		v, present := actual[name]
+		if !present {
+			if !g.Optional {
+				findings = append(findings, Finding{layer, layer, golden, name, KindMissing, SevHigh,
+					"required by golden but not emitted at runtime"})
+			}
+			continue
+		}
+		if v == nil {
+			if !g.Nullable {
+				findings = append(findings, Finding{layer, layer, golden, name, KindNullable, SevHigh,
+					"golden non-null but runtime value is null"})
+			}
+			continue
+		}
+		if at := jsonType(v); scalarMismatch(g.Type, at) {
+			findings = append(findings, Finding{layer, layer, golden, name, "type", SevMed,
+				"golden type " + g.Type + " but runtime value is " + at})
+		}
+	}
+	for name := range actual {
+		if _, ok := schema[name]; !ok {
+			findings = append(findings, Finding{layer, layer, golden, name, KindExtra, SevInfo,
+				"emitted at runtime but not in golden"})
+		}
+	}
+	return findings
+}
+
+// ValidateUnionValue dispatches on the value's `type` discriminator and
+// validates against the matching union variant. A `type` with no matching
+// variant is itself a HIGH finding: a strict client cannot dispatch it.
+func ValidateUnionValue(unionName string, actual map[string]any, variants map[string]Schema) []Finding {
+	t, _ := actual["type"].(string)
+	schema, ok := variants[t]
+	if !ok {
+		return []Finding{{unionName, unionName, unionName, "type=" + t, KindMissing, SevHigh,
+			"runtime type literal has no matching variant in the golden union"}}
+	}
+	return ValidateValue(unionName+"["+t+"]", unionName, actual, schema)
+}
+
+// jsonType returns the JSON type bucket of a Go value as it serializes.
+func jsonType(v any) string {
+	if v == nil {
+		return "null"
+	}
+	rv := reflect.ValueOf(v)
+	for rv.Kind() == reflect.Ptr || rv.Kind() == reflect.Interface {
+		if rv.IsNil() {
+			return "null"
+		}
+		rv = rv.Elem()
+	}
+	switch rv.Kind() {
+	case reflect.String:
+		return "string"
+	case reflect.Bool:
+		return "boolean"
+	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64,
+		reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64,
+		reflect.Float32, reflect.Float64:
+		return "number"
+	case reflect.Slice, reflect.Array:
+		return "array"
+	case reflect.Map, reflect.Struct:
+		return "object"
+	default:
+		return "other"
+	}
+}
+
+// scalarMismatch reports a clear scalar type conflict. Coarse buckets
+// (object/array/other/any) are skipped to avoid false positives on refs and
+// packed structs.
+func scalarMismatch(goldenType, actualType string) bool {
+	switch goldenType {
+	case "string", "boolean", "number":
+		switch actualType {
+		case "string", "boolean", "number":
+			return goldenType != actualType
+		}
+	}
+	return false
+}

--- a/internal/entitycompat/runtime_test.go
+++ b/internal/entitycompat/runtime_test.go
@@ -68,7 +68,7 @@ func TestValidateValue(t *testing.T) {
 		// "opt" absent -> allowed
 	}
 	got := map[string]Severity{}
-	for _, f := range ValidateValue("L", "G", actual, schema) {
+	for _, f := range ValidateValue("F", "L", "G", actual, schema) {
 		got[f.Field+"/"+f.Kind] = f.Sev
 	}
 	if got["nonnull/nullable"] != SevHigh {
@@ -89,7 +89,7 @@ func TestValidateValue(t *testing.T) {
 
 	// missing required
 	got2 := map[string]Severity{}
-	for _, f := range ValidateValue("L", "G", map[string]any{"nullable": "x", "nonnull": "x", "num": 1}, schema) {
+	for _, f := range ValidateValue("F", "L", "G", map[string]any{"nullable": "x", "nonnull": "x", "num": 1}, schema) {
 		got2[f.Field+"/"+f.Kind] = f.Sev
 	}
 	if got2["req/missing"] != SevHigh {
@@ -188,6 +188,12 @@ func TestNotificationShapeL2(t *testing.T) {
 	notif := unions["Notification"]
 	if len(notif) == 0 {
 		t.Fatal("no Notification union variants in snapshot")
+	}
+	// 各 variant が非空か (書式変更でパーサが空振りした兆候の検出)。
+	for typ, v := range notif {
+		if len(v) == 0 {
+			t.Errorf("Notification variant %q parsed to 0 fields; snapshot likely broken", typ)
+		}
 	}
 
 	cases := []struct {

--- a/internal/entitycompat/runtime_test.go
+++ b/internal/entitycompat/runtime_test.go
@@ -1,0 +1,233 @@
+package entitycompat
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/shiroha-a/mk/internal/core/notification"
+	"github.com/shiroha-a/mk/internal/entity"
+	"github.com/shiroha-a/mk/internal/misc/id"
+	"github.com/shiroha-a/mk/internal/model"
+)
+
+// --- unit tests: union parser + runtime validator ---------------------------
+
+func TestParseUnion(t *testing.T) {
+	lines := []string{
+		"        N: {",
+		"            id: string;",
+		"            type: 'a';",
+		"            onlyA: string;",
+		"        } | {",
+		"            id: string;",
+		"            type: 'b';",
+		"            onlyB: number | null;",
+		"        };",
+	}
+	got := ParseUnion(lines, "N")
+	if len(got) != 2 {
+		t.Fatalf("want 2 variants, got %d: %v", len(got), got)
+	}
+	if _, ok := got["a"]["onlyA"]; !ok {
+		t.Error("variant a missing onlyA")
+	}
+	if f, ok := got["b"]["onlyB"]; !ok || !f.Nullable {
+		t.Errorf("variant b onlyB: %+v ok=%v (want nullable)", f, ok)
+	}
+	if ParseUnion(lines, "Absent") != nil {
+		t.Error("absent union should return nil")
+	}
+}
+
+func TestLiteralOf(t *testing.T) {
+	cases := map[string]string{"'follow';": "follow", "'a' | 'b'": "a", "string;": "", "": ""}
+	for in, want := range cases {
+		if got := literalOf(in); got != want {
+			t.Errorf("literalOf(%q)=%q want %q", in, got, want)
+		}
+	}
+}
+
+func TestValidateValue(t *testing.T) {
+	schema := Schema{
+		"req":      {Type: "string"},
+		"nullable": {Type: "string", Nullable: true},
+		"nonnull":  {Type: "string"},
+		"opt":      {Type: "string", Optional: true},
+		"num":      {Type: "number"},
+	}
+	actual := map[string]any{
+		"req":      "ok",
+		"nullable": nil,   // allowed (nullable)
+		"nonnull":  nil,   // VIOLATION: null on non-null
+		"num":      "str", // VIOLATION: type mismatch
+		"extra":    1,     // INFO
+		// "opt" absent -> allowed
+	}
+	got := map[string]Severity{}
+	for _, f := range ValidateValue("L", "G", actual, schema) {
+		got[f.Field+"/"+f.Kind] = f.Sev
+	}
+	if got["nonnull/nullable"] != SevHigh {
+		t.Error("expected nonnull null violation HIGH")
+	}
+	if got["num/type"] != SevMed {
+		t.Error("expected num type mismatch MED")
+	}
+	if got["extra/extra"] != SevInfo {
+		t.Error("expected extra INFO")
+	}
+	if _, ok := got["nullable/nullable"]; ok {
+		t.Error("nullable=null must not be flagged")
+	}
+	if _, ok := got["opt/missing"]; ok {
+		t.Error("absent optional must not be flagged")
+	}
+
+	// missing required
+	got2 := map[string]Severity{}
+	for _, f := range ValidateValue("L", "G", map[string]any{"nullable": "x", "nonnull": "x", "num": 1}, schema) {
+		got2[f.Field+"/"+f.Kind] = f.Sev
+	}
+	if got2["req/missing"] != SevHigh {
+		t.Error("expected req missing HIGH")
+	}
+}
+
+func TestValidateUnionValue(t *testing.T) {
+	variants := map[string]Schema{
+		"a": {"id": {Type: "string"}, "type": {Type: "string"}},
+	}
+	// matching variant, clean
+	if f := ValidateUnionValue("N", map[string]any{"type": "a", "id": "x"}, variants); len(f) != 0 {
+		t.Errorf("clean variant should have no findings, got %v", f)
+	}
+	// unknown type literal
+	f := ValidateUnionValue("N", map[string]any{"type": "zzz"}, variants)
+	if len(f) != 1 || f[0].Sev != SevHigh {
+		t.Errorf("unknown type should be 1 HIGH finding, got %v", f)
+	}
+}
+
+func TestJSONTypeAndScalar(t *testing.T) {
+	s := "x"
+	cases := []struct {
+		v    any
+		want string
+	}{
+		{"x", "string"}, {true, "boolean"}, {1, "number"}, {1.5, "number"},
+		{[]int{1}, "array"}, {map[string]int{}, "object"}, {struct{}{}, "object"},
+		{nil, "null"}, {&s, "string"}, {(*string)(nil), "null"},
+	}
+	for _, c := range cases {
+		if got := jsonType(c.v); got != c.want {
+			t.Errorf("jsonType(%#v)=%q want %q", c.v, got, c.want)
+		}
+	}
+	if !scalarMismatch("string", "number") {
+		t.Error("string vs number should mismatch")
+	}
+	if scalarMismatch("object", "array") {
+		t.Error("object/array buckets must be skipped")
+	}
+	if scalarMismatch("string", "string") {
+		t.Error("same type must not mismatch")
+	}
+}
+
+// --- L2 integration: validate real PackNotification output ------------------
+
+func loadUnions(t *testing.T) map[string]map[string]Schema {
+	t.Helper()
+	b, err := os.ReadFile(filepath.Join("testdata", "golden_unions.json"))
+	if err != nil {
+		t.Fatalf("read golden_unions: %v", err)
+	}
+	var u map[string]map[string]Schema
+	if err := json.Unmarshal(b, &u); err != nil {
+		t.Fatalf("decode golden_unions: %v", err)
+	}
+	return u
+}
+
+// notifFixture builds a packed notification map for a given type using the
+// same construction pattern as the entity package's own packer tests.
+func notifFixture(typ notification.Type, withUser, withNote bool, extra map[string]any) map[string]any {
+	idGen, _ := id.NewGenerator("aidx")
+	n := &notification.Notification{
+		ID:         "n1",
+		CreatedAt:  time.Date(2026, 5, 25, 0, 0, 0, 0, time.UTC),
+		Type:       typ,
+		NotifierID: "u_actor",
+		Extra:      extra,
+	}
+	var user *model.User
+	var note *model.Note
+	if withUser {
+		user = &model.User{ID: "u_actor", Username: "actor", UsernameLower: "actor"}
+	}
+	if withNote {
+		s := "hi"
+		n.NoteID = "note1"
+		note = &model.Note{ID: "note1", UserID: "u_me", Text: &s}
+	}
+	if typ == notification.TypeReaction {
+		n.Reaction = ":smile:"
+	}
+	return entity.PackNotification(n, user, note, idGen, nil, nil)
+}
+
+// TestNotificationShapeL2 validates actual PackNotification map output against
+// the golden Notification union — the map-based, discriminated-union surface
+// that the Layer 0 reflection gate cannot reach.
+func TestNotificationShapeL2(t *testing.T) {
+	unions := loadUnions(t)
+	notif := unions["Notification"]
+	if len(notif) == 0 {
+		t.Fatal("no Notification union variants in snapshot")
+	}
+
+	cases := []struct {
+		typ      notification.Type
+		withUser bool
+		withNote bool
+		extra    map[string]any
+	}{
+		{notification.TypeFollow, true, false, nil},
+		{notification.TypeReaction, true, true, nil},
+		{notification.TypeMention, true, true, nil},
+		{notification.TypeReply, true, true, nil},
+		{notification.TypeRenote, true, true, nil},
+		{notification.TypeQuote, true, true, nil},
+		{notification.TypeReceiveFollowReq, true, false, nil},
+		{notification.TypePollVote, true, true, nil},
+		{notification.TypeImportCompleted, false, false, map[string]any{"fileId": "df_1"}},
+	}
+
+	allow, err := LoadAllowlist(filepath.Join("testdata", "allowlist_l2.json"))
+	if err != nil {
+		t.Fatalf("load L2 allowlist: %v", err)
+	}
+
+	var gated []Finding
+	for _, c := range cases {
+		out := notifFixture(c.typ, c.withUser, c.withNote, c.extra)
+		for _, f := range ValidateUnionValue("Notification", out, notif) {
+			if f.Sev == SevHigh || f.Sev == SevMed {
+				gated = append(gated, f)
+			}
+		}
+	}
+
+	violations, stale := RunGate(gated, allow)
+	for _, v := range violations {
+		t.Errorf("NEW notification shape drift: %s [%s]: %s\n  -> fix the packer, or add to testdata/allowlist_l2.json with a reason",
+			v.Field, v.Kind, v.Detail)
+	}
+	for _, s := range stale {
+		t.Errorf("stale L2 allowlist entry: %s [%s] no longer drifts; remove it from testdata/allowlist_l2.json", s.Field, s.Kind)
+	}
+}

--- a/internal/entitycompat/shapecheck.go
+++ b/internal/entitycompat/shapecheck.go
@@ -268,6 +268,21 @@ func coarseTS(rhs string) string {
 
 // ---- diff -------------------------------------------------------------------
 
+// newFinding builds a Finding for a family/layer diff result. Centralizing the
+// (otherwise 7-field positional) construction keeps call sites readable and
+// resilient to future field additions.
+func newFinding(fam Family, l Layer, field, kind string, sev Severity, detail string) Finding {
+	return Finding{
+		Family: fam.Name,
+		Layer:  l.Label,
+		Golden: l.Golden,
+		Field:  field,
+		Kind:   kind,
+		Sev:    sev,
+		Detail: detail,
+	}
+}
+
 // DiffFamily compares every layer of fam against the golden snapshot and
 // returns findings sorted by severity. famPresent is the union of all fields
 // emitted anywhere in the family, used to downgrade a layer-local "missing" to
@@ -293,8 +308,8 @@ func DiffFamily(fam Family, golden GoldenSet) []Finding {
 				continue
 			}
 			if famPresent[name] {
-				findings = append(findings, Finding{fam.Name, l.Label, l.Golden, name, KindLayer, SevInfo,
-					"present in another layer of the same family"})
+				findings = append(findings, newFinding(fam, l, name, KindLayer, SevInfo,
+					"present in another layer of the same family"))
 				continue
 			}
 			sev := SevHigh
@@ -303,7 +318,7 @@ func DiffFamily(fam Family, golden GoldenSet) []Finding {
 				sev = SevLow
 				detail = "declared in golden (optional), absent in mk-go"
 			}
-			findings = append(findings, Finding{fam.Name, l.Label, l.Golden, name, KindMissing, sev, detail})
+			findings = append(findings, newFinding(fam, l, name, KindMissing, sev, detail))
 		}
 
 		for name, g := range gold {
@@ -312,19 +327,19 @@ func DiffFamily(fam Family, golden GoldenSet) []Finding {
 				continue
 			}
 			if !g.Nullable && m.Nullable {
-				findings = append(findings, Finding{fam.Name, l.Label, l.Golden, name, KindNullable, SevHigh,
-					"golden=non-null, mk-go=nullable: may emit null where client casts non-null"})
+				findings = append(findings, newFinding(fam, l, name, KindNullable, SevHigh,
+					"golden=non-null, mk-go=nullable: may emit null where client casts non-null"))
 			}
 			if !g.Optional && m.Optional {
-				findings = append(findings, Finding{fam.Name, l.Label, l.Golden, name, KindOmit, SevMed,
-					"golden=required, mk-go=omitempty: may omit a field the client requires"})
+				findings = append(findings, newFinding(fam, l, name, KindOmit, SevMed,
+					"golden=required, mk-go=omitempty: may omit a field the client requires"))
 			}
 		}
 
 		for name := range mk {
 			if _, ok := gold[name]; !ok {
-				findings = append(findings, Finding{fam.Name, l.Label, l.Golden, name, KindExtra, SevInfo,
-					"in mk-go but not in golden (extension/alias?)"})
+				findings = append(findings, newFinding(fam, l, name, KindExtra, SevInfo,
+					"in mk-go but not in golden (extension/alias?)"))
 			}
 		}
 	}

--- a/internal/entitycompat/shapecheck.go
+++ b/internal/entitycompat/shapecheck.go
@@ -1,0 +1,372 @@
+// Package entitycompat provides a static "Layer 0" API shape drift detector.
+//
+// It reflects over mk-go's entity DTO structs (internal/entity) and diffs
+// their JSON shape against the Misskey API contract (the misskey-js autogen
+// `types.ts`, which mirrors the OpenAPI `components.schemas`). The class of
+// mismatch it surfaces — fields the contract declares that mk-go omits, and
+// nullability/optionality divergences — is exactly what makes Misskey-compatible
+// 3rd-party clients crash on a non-null cast.
+//
+// The detector needs no running server, no browser, and no Docker, so it runs
+// as a fast deterministic `go test` gate. The golden contract is consumed from
+// a committed snapshot (testdata/golden_schemas.json) regenerated from the
+// pinned submodule on upstream catch-up, keeping the gate hermetic.
+package entitycompat
+
+import (
+	"reflect"
+	"regexp"
+	"sort"
+	"strings"
+)
+
+// FieldShape is the normalized shape of a single JSON field: whether it may
+// serialize to null, whether it may be absent, and a coarse type bucket.
+type FieldShape struct {
+	Nullable bool   `json:"nullable"`
+	Optional bool   `json:"optional"`
+	Type     string `json:"type"`
+}
+
+// Schema maps a JSON field name to its shape.
+type Schema map[string]FieldShape
+
+// GoldenSet is the committed contract snapshot: golden schema name -> Schema.
+type GoldenSet map[string]Schema
+
+// Severity ranks a finding for gating. HIGH and MED are gated by the drift
+// test; LOW and INFO are reported but non-blocking.
+type Severity string
+
+const (
+	SevHigh Severity = "HIGH"
+	SevMed  Severity = "MED"
+	SevLow  Severity = "LOW"
+	SevInfo Severity = "INFO"
+)
+
+// Kind classifies what sort of drift a finding represents.
+const (
+	KindMissing  = "missing"  // golden has a field mk-go does not emit
+	KindNullable = "nullable" // mk-go may emit null where golden is non-null
+	KindOmit     = "omit"     // mk-go may omit a field golden requires
+	KindExtra    = "extra"    // mk-go emits a field absent from golden
+	KindLayer    = "layer"    // present in a sibling layer of the same family
+)
+
+// Finding is a single detected (or informational) shape difference.
+type Finding struct {
+	Family string
+	Layer  string
+	Golden string
+	Field  string
+	Kind   string
+	Sev    Severity
+	Detail string
+}
+
+// ---- mk-go side: reflection ------------------------------------------------
+
+// reflectOwnFields returns the shape of the non-embedded fields declared
+// directly on t. Embedded layers map to a sibling golden schema, so they are
+// excluded here and handled by their own Layer entry.
+func reflectOwnFields(t reflect.Type) Schema {
+	out := Schema{}
+	for i := 0; i < t.NumField(); i++ {
+		f := t.Field(i)
+		if f.Anonymous {
+			continue
+		}
+		name, opt, ok := jsonName(f)
+		if !ok {
+			continue
+		}
+		out[name] = FieldShape{
+			// omitempty 付きポインタは nil で「省略」= optional であり null は
+			// 出さない。omitempty 無しのポインタだけが nil 時に `null` を出す。
+			Nullable: f.Type.Kind() == reflect.Ptr && !opt,
+			Optional: opt,
+			Type:     coarseGo(f.Type),
+		}
+	}
+	return out
+}
+
+// reflectAllFields flattens every json field reachable from t, recursing into
+// embedded structs. Used to build the per-family "present somewhere" set.
+func reflectAllFields(t reflect.Type) Schema {
+	out := Schema{}
+	var walk func(reflect.Type)
+	walk = func(t reflect.Type) {
+		for i := 0; i < t.NumField(); i++ {
+			f := t.Field(i)
+			if f.Anonymous {
+				walk(f.Type)
+				continue
+			}
+			if name, opt, ok := jsonName(f); ok {
+				out[name] = FieldShape{
+					Nullable: f.Type.Kind() == reflect.Ptr && !opt,
+					Optional: opt,
+					Type:     coarseGo(f.Type),
+				}
+			}
+		}
+	}
+	walk(t)
+	return out
+}
+
+func jsonName(f reflect.StructField) (name string, omitempty, ok bool) {
+	tag := f.Tag.Get("json")
+	if tag == "" || tag == "-" {
+		return "", false, false
+	}
+	parts := strings.Split(tag, ",")
+	name = parts[0]
+	if name == "" {
+		return "", false, false
+	}
+	for _, p := range parts[1:] {
+		if p == "omitempty" {
+			omitempty = true
+		}
+	}
+	return name, omitempty, true
+}
+
+func coarseGo(t reflect.Type) string {
+	for t.Kind() == reflect.Ptr {
+		t = t.Elem()
+	}
+	switch t.Kind() {
+	case reflect.String:
+		return "string"
+	case reflect.Bool:
+		return "boolean"
+	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64,
+		reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64,
+		reflect.Float32, reflect.Float64:
+		return "number"
+	case reflect.Slice, reflect.Array:
+		return "array"
+	case reflect.Map, reflect.Struct:
+		return "object"
+	default:
+		return "any"
+	}
+}
+
+// ---- golden side: types.ts parser -----------------------------------------
+
+var propRe = regexp.MustCompile(`^            (\w+)(\??):\s*(.*)$`)
+
+// ParseTypesFile parses the openapi-typescript schema blocks named in `names`
+// out of the given types.ts content (split into lines). Missing schemas are
+// silently skipped; callers can compare the returned key set against `names`.
+func ParseTypesFile(lines []string, names []string) GoldenSet {
+	out := GoldenSet{}
+	for _, n := range names {
+		if s, ok := parseSchema(lines, n); ok {
+			out[n] = s
+		}
+	}
+	return out
+}
+
+// parseSchema extracts the top-level properties of one openapi-typescript
+// schema block. Brace depth is tracked so fields of nested inline object types
+// are not mistaken for top-level properties.
+func parseSchema(lines []string, schemaName string) (Schema, bool) {
+	open := "        " + schemaName + ": {"
+	start := -1
+	for i, ln := range lines {
+		if ln == open {
+			start = i
+			break
+		}
+	}
+	if start < 0 {
+		return nil, false
+	}
+
+	out := Schema{}
+	depth := 1
+
+	var curName string
+	var have bool
+	var optional bool
+	var typ string
+	var buf strings.Builder
+	finalize := func() {
+		if !have {
+			return
+		}
+		out[curName] = FieldShape{
+			Nullable: strings.Contains(buf.String(), "| null"),
+			Optional: optional,
+			Type:     typ,
+		}
+		have = false
+		buf.Reset()
+	}
+
+	for i := start + 1; i < len(lines); i++ {
+		ln := lines[i]
+		trimmed := strings.TrimSpace(ln)
+		if strings.HasPrefix(trimmed, "/*") || strings.HasPrefix(trimmed, "*") {
+			continue
+		}
+		if depth == 1 {
+			if m := propRe.FindStringSubmatch(ln); m != nil {
+				finalize()
+				curName = m[1]
+				optional = m[2] == "?"
+				typ = coarseTS(m[3])
+				have = true
+			}
+		}
+		if have {
+			buf.WriteString(ln)
+			buf.WriteString("\n")
+		}
+		depth += strings.Count(ln, "{") - strings.Count(ln, "}")
+		if depth == 0 {
+			finalize()
+			return out, true
+		}
+	}
+	finalize()
+	return out, true
+}
+
+func coarseTS(rhs string) string {
+	rhs = strings.TrimSuffix(strings.TrimSpace(rhs), ";")
+	rhs = strings.TrimSpace(strings.TrimSuffix(rhs, "| null"))
+	rhs = strings.TrimSpace(rhs)
+	switch {
+	case rhs == "":
+		return "object"
+	case strings.HasSuffix(rhs, "[]"):
+		return "array"
+	case strings.HasPrefix(rhs, "{"):
+		return "object"
+	case strings.HasPrefix(rhs, "'") || strings.Contains(rhs, "' | '"):
+		return "string"
+	case rhs == "string":
+		return "string"
+	case rhs == "boolean":
+		return "boolean"
+	case rhs == "number":
+		return "number"
+	case strings.Contains(rhs, "components['schemas']"):
+		return "object"
+	default:
+		return "other"
+	}
+}
+
+// ---- diff -------------------------------------------------------------------
+
+// DiffFamily compares every layer of fam against the golden snapshot and
+// returns findings sorted by severity. famPresent is the union of all fields
+// emitted anywhere in the family, used to downgrade a layer-local "missing" to
+// an informational layer-placement note when the field exists elsewhere.
+func DiffFamily(fam Family, golden GoldenSet) []Finding {
+	famPresent := map[string]bool{}
+	for _, l := range fam.Layers {
+		for name := range reflectAllFields(l.Type) {
+			famPresent[name] = true
+		}
+	}
+
+	var findings []Finding
+	for _, l := range fam.Layers {
+		gold, ok := golden[l.Golden]
+		if !ok {
+			continue
+		}
+		mk := reflectOwnFields(l.Type)
+
+		for name, g := range gold {
+			if _, ok := mk[name]; ok {
+				continue
+			}
+			if famPresent[name] {
+				findings = append(findings, Finding{fam.Name, l.Label, l.Golden, name, KindLayer, SevInfo,
+					"present in another layer of the same family"})
+				continue
+			}
+			sev := SevHigh
+			detail := "declared in golden, absent in all mk-go structs"
+			if g.Optional {
+				sev = SevLow
+				detail = "declared in golden (optional), absent in mk-go"
+			}
+			findings = append(findings, Finding{fam.Name, l.Label, l.Golden, name, KindMissing, sev, detail})
+		}
+
+		for name, g := range gold {
+			m, ok := mk[name]
+			if !ok {
+				continue
+			}
+			if !g.Nullable && m.Nullable {
+				findings = append(findings, Finding{fam.Name, l.Label, l.Golden, name, KindNullable, SevHigh,
+					"golden=non-null, mk-go=nullable: may emit null where client casts non-null"})
+			}
+			if !g.Optional && m.Optional {
+				findings = append(findings, Finding{fam.Name, l.Label, l.Golden, name, KindOmit, SevMed,
+					"golden=required, mk-go=omitempty: may omit a field the client requires"})
+			}
+		}
+
+		for name := range mk {
+			if _, ok := gold[name]; !ok {
+				findings = append(findings, Finding{fam.Name, l.Label, l.Golden, name, KindExtra, SevInfo,
+					"in mk-go but not in golden (extension/alias?)"})
+			}
+		}
+	}
+
+	sort.SliceStable(findings, func(i, j int) bool {
+		if findings[i].Layer != findings[j].Layer {
+			return findings[i].Layer < findings[j].Layer
+		}
+		if sevRank(findings[i].Sev) != sevRank(findings[j].Sev) {
+			return sevRank(findings[i].Sev) < sevRank(findings[j].Sev)
+		}
+		return findings[i].Field < findings[j].Field
+	})
+	return findings
+}
+
+func sevRank(s Severity) int {
+	switch s {
+	case SevHigh:
+		return 0
+	case SevMed:
+		return 1
+	case SevLow:
+		return 2
+	default:
+		return 3
+	}
+}
+
+// GoldenSchemaNames returns the set of golden schema names referenced by the
+// family table, so the generator knows which schemas to extract.
+func GoldenSchemaNames() []string {
+	seen := map[string]bool{}
+	var names []string
+	for _, fam := range Families() {
+		for _, l := range fam.Layers {
+			if !seen[l.Golden] {
+				seen[l.Golden] = true
+				names = append(names, l.Golden)
+			}
+		}
+	}
+	sort.Strings(names)
+	return names
+}

--- a/internal/entitycompat/shapecheck_test.go
+++ b/internal/entitycompat/shapecheck_test.go
@@ -24,10 +24,17 @@ func TestEntityShapeDrift(t *testing.T) {
 		t.Fatalf("load allowlist: %v", err)
 	}
 
-	// すべての referenced golden schema が snapshot に存在するか (regenerate 漏れ検出)。
+	// すべての referenced golden schema が snapshot に存在し、かつ非空か確認する。
+	// 0 フィールドは types.ts 書式変更でパーサが空振りした兆候で、放置すると
+	// ゲートが vacuously pass してしまう (silent failure)。
 	for _, name := range GoldenSchemaNames() {
-		if _, ok := golden[name]; !ok {
+		s, ok := golden[name]
+		if !ok {
 			t.Errorf("golden snapshot missing schema %q; run `go run ./tools/shapediff` to regenerate", name)
+			continue
+		}
+		if len(s) == 0 {
+			t.Errorf("golden schema %q has 0 fields; snapshot likely broken (types.ts format change)", name)
 		}
 	}
 

--- a/internal/entitycompat/shapecheck_test.go
+++ b/internal/entitycompat/shapecheck_test.go
@@ -1,0 +1,409 @@
+package entitycompat
+
+import (
+	"os"
+	"path/filepath"
+	"reflect"
+	"testing"
+)
+
+// --- the actual drift gate --------------------------------------------------
+
+// TestEntityShapeDrift is the CI gate. It loads the committed golden contract
+// snapshot, diffs it against the live entity structs, and fails on any HIGH/MED
+// drift not recorded in the baseline allowlist. New drift in a PR breaks here;
+// fixing a baselined drift turns its allowlist entry stale and also breaks here
+// (prompting allowlist cleanup).
+func TestEntityShapeDrift(t *testing.T) {
+	golden, err := LoadGoldenSnapshot(filepath.Join("testdata", "golden_schemas.json"))
+	if err != nil {
+		t.Fatalf("load golden: %v", err)
+	}
+	allow, err := LoadAllowlist(filepath.Join("testdata", "allowlist.json"))
+	if err != nil {
+		t.Fatalf("load allowlist: %v", err)
+	}
+
+	// すべての referenced golden schema が snapshot に存在するか (regenerate 漏れ検出)。
+	for _, name := range GoldenSchemaNames() {
+		if _, ok := golden[name]; !ok {
+			t.Errorf("golden snapshot missing schema %q; run `go run ./tools/shapediff` to regenerate", name)
+		}
+	}
+
+	violations, stale := RunGate(GatedFindings(golden), allow)
+	for _, v := range violations {
+		t.Errorf("NEW shape drift: %s.%s [%s] (golden %s): %s\n  -> fix the struct, or add to testdata/allowlist.json with a reason",
+			v.Layer, v.Field, v.Kind, v.Golden, v.Detail)
+	}
+	for _, s := range stale {
+		t.Errorf("stale allowlist entry: %s.%s [%s] no longer drifts; remove it from testdata/allowlist.json", s.Layer, s.Field, s.Kind)
+	}
+}
+
+// --- unit tests: golden parser ----------------------------------------------
+
+func TestParseSchema(t *testing.T) {
+	lines := []string{
+		"        Sample: {",
+		"            /** doc comment */",
+		"            id: string;",
+		"            name: string | null;",
+		"            count?: number;",
+		"            tags: string[];",
+		"            nested: {",
+		"                inner: string;", // must NOT be captured as top-level
+		"            };",
+		"            kind: 'a' | 'b';",
+		"        };",
+		"        Other: {",
+		"            x: number;",
+		"        };",
+	}
+	got, ok := parseSchema(lines, "Sample")
+	if !ok {
+		t.Fatal("Sample not found")
+	}
+	want := Schema{
+		"id":     {Nullable: false, Optional: false, Type: "string"},
+		"name":   {Nullable: true, Optional: false, Type: "string"},
+		"count":  {Nullable: false, Optional: true, Type: "number"},
+		"tags":   {Nullable: false, Optional: false, Type: "array"},
+		"nested": {Nullable: false, Optional: false, Type: "object"},
+		"kind":   {Nullable: false, Optional: false, Type: "string"},
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("parseSchema mismatch:\n got=%+v\nwant=%+v", got, want)
+	}
+	if _, ok := got["inner"]; ok {
+		t.Error("nested field leaked into top-level properties")
+	}
+
+	if _, ok := parseSchema(lines, "Missing"); ok {
+		t.Error("expected Missing schema to be absent")
+	}
+}
+
+func TestParseSchemaUnion(t *testing.T) {
+	// discriminated union: `} | {` keeps brace depth at 1, so all variant
+	// fields are flattened into one schema.
+	lines := []string{
+		"        U: {",
+		"            type: 'a';",
+		"            onlyA: string;",
+		"        } | {",
+		"            type: 'b';",
+		"            onlyB: number;",
+		"        };",
+	}
+	got, ok := parseSchema(lines, "U")
+	if !ok {
+		t.Fatal("U not found")
+	}
+	for _, f := range []string{"type", "onlyA", "onlyB"} {
+		if _, ok := got[f]; !ok {
+			t.Errorf("union field %q not captured", f)
+		}
+	}
+}
+
+func TestCoarseTS(t *testing.T) {
+	cases := map[string]string{
+		"string":                          "string",
+		"string | null":                   "string",
+		"boolean":                         "boolean",
+		"number":                          "number",
+		"string[]":                        "array",
+		"'x' | 'y'":                       "string",
+		"'solo'":                          "string",
+		"{":                               "object",
+		"components['schemas']['Note']":   "object",
+		"components['schemas']['Note'][]": "array",
+		"":                                "object",
+		"SomethingElse":                   "other",
+	}
+	for in, want := range cases {
+		if got := coarseTS(in); got != want {
+			t.Errorf("coarseTS(%q)=%q want %q", in, got, want)
+		}
+	}
+}
+
+// --- unit tests: reflection -------------------------------------------------
+
+type embedded struct {
+	Base string `json:"base"`
+}
+
+type reflectFixture struct {
+	embedded
+	Keep   string  `json:"keep"`
+	Null   *string `json:"nul"`
+	Opt    *bool   `json:"opt,omitempty"`
+	Num    int     `json:"num"`
+	Arr    []int   `json:"arr"`
+	M      map[string]int
+	Skip   string `json:"-"`
+	NoTag  string
+	Anon   any             `json:"anon"`
+	Nested struct{ X int } `json:"nested"`
+}
+
+func TestReflectOwnFields(t *testing.T) {
+	got := reflectOwnFields(reflect.TypeOf(reflectFixture{}))
+	if _, ok := got["base"]; ok {
+		t.Error("embedded field should be excluded from own fields")
+	}
+	if got["keep"].Nullable || got["keep"].Optional {
+		t.Error("keep should be non-null, required")
+	}
+	if !got["nul"].Nullable || got["nul"].Optional {
+		t.Error("nul: pointer w/o omitempty should be nullable, not optional")
+	}
+	if got["opt"].Nullable || !got["opt"].Optional {
+		t.Error("opt: pointer w/ omitempty should be optional, not nullable")
+	}
+	if got["num"].Type != "number" || got["arr"].Type != "array" {
+		t.Errorf("type buckets wrong: num=%s arr=%s", got["num"].Type, got["arr"].Type)
+	}
+	if _, ok := got["-"]; ok {
+		t.Error("json:\"-\" field must be skipped")
+	}
+	if _, ok := got["NoTag"]; ok {
+		t.Error("untagged field must be skipped")
+	}
+	// map with no tag is skipped (no json name); anon any -> "any"; nested struct -> object
+	if got["anon"].Type != "any" {
+		t.Errorf("anon type=%s want any", got["anon"].Type)
+	}
+	if got["nested"].Type != "object" {
+		t.Errorf("nested type=%s want object", got["nested"].Type)
+	}
+}
+
+func TestReflectAllFields(t *testing.T) {
+	got := reflectAllFields(reflect.TypeOf(reflectFixture{}))
+	if _, ok := got["base"]; !ok {
+		t.Error("reflectAllFields must include embedded fields")
+	}
+	if _, ok := got["keep"]; !ok {
+		t.Error("reflectAllFields must include own fields")
+	}
+}
+
+func TestJSONName(t *testing.T) {
+	typ := reflect.TypeOf(struct {
+		A string `json:"a"`
+		B string `json:"b,omitempty"`
+		C string `json:"-"`
+		D string `json:""`
+		E string
+	}{})
+	mustField := func(n string) reflect.StructField {
+		f, ok := typ.FieldByName(n)
+		if !ok {
+			t.Fatalf("field %s not found", n)
+		}
+		return f
+	}
+	if n, o, ok := jsonName(mustField("A")); !ok || n != "a" || o {
+		t.Errorf("A: got %q %v %v", n, o, ok)
+	}
+	if n, o, ok := jsonName(mustField("B")); !ok || n != "b" || !o {
+		t.Errorf("B: got %q %v %v", n, o, ok)
+	}
+	if _, _, ok := jsonName(mustField("C")); ok {
+		t.Error("C: json:\"-\" should be skipped")
+	}
+	if _, _, ok := jsonName(mustField("D")); ok {
+		t.Error("D: empty name should be skipped")
+	}
+	if _, _, ok := jsonName(mustField("E")); ok {
+		t.Error("E: no tag should be skipped")
+	}
+}
+
+func TestCoarseGo(t *testing.T) {
+	cases := []struct {
+		v    any
+		want string
+	}{
+		{"", "string"},
+		{true, "boolean"},
+		{int(0), "number"},
+		{uint(0), "number"},
+		{float64(0), "number"},
+		{[]int{}, "array"},
+		{map[string]int{}, "object"},
+		{struct{}{}, "object"},
+	}
+	for _, c := range cases {
+		if got := coarseGo(reflect.TypeOf(c.v)); got != c.want {
+			t.Errorf("coarseGo(%T)=%q want %q", c.v, got, c.want)
+		}
+	}
+	// pointer is unwrapped
+	s := ""
+	if got := coarseGo(reflect.TypeOf(&s)); got != "string" {
+		t.Errorf("coarseGo(*string)=%q want string", got)
+	}
+	// channel falls through to "any"
+	if got := coarseGo(reflect.TypeOf(make(chan int))); got != "any" {
+		t.Errorf("coarseGo(chan)=%q want any", got)
+	}
+}
+
+// --- unit tests: diff -------------------------------------------------------
+
+type diffLayerA struct {
+	Keep      string  `json:"keep"`
+	NullField *string `json:"nullableField"`       // nullable (no omitempty)
+	OmitField *bool   `json:"omitField,omitempty"` // optional
+	ExtraF    string  `json:"extraField"`
+}
+
+type diffLayerB struct {
+	Shared string `json:"sharedField"`
+}
+
+func TestDiffFamily(t *testing.T) {
+	golden := GoldenSet{
+		"GA": Schema{
+			"keep":          {},
+			"nullableField": {Nullable: false},                  // mk nullable -> HIGH nullable
+			"omitField":     {Optional: false},                  // mk optional -> MED omit
+			"missReq":       {Nullable: false, Optional: false}, // missing, not in family -> HIGH
+			"missOpt":       {Optional: true},                   // missing, optional -> LOW
+			"sharedField":   {},                                 // missing from A own, present in B -> INFO layer
+		},
+		"GB": Schema{"sharedField": {}},
+	}
+	fam := Family{
+		Name: "T",
+		Layers: []Layer{
+			{"A", "GA", reflect.TypeOf(diffLayerA{})},
+			{"B", "GB", reflect.TypeOf(diffLayerB{})},
+			{"Z", "ZZ-not-in-golden", reflect.TypeOf(diffLayerB{})}, // golden missing -> skipped
+		},
+	}
+
+	got := map[string]Finding{}
+	for _, f := range DiffFamily(fam, golden) {
+		got[f.Field+"/"+f.Kind] = f
+	}
+
+	check := func(key string, sev Severity, kind string) {
+		f, ok := got[key]
+		if !ok {
+			t.Errorf("expected finding %s", key)
+			return
+		}
+		if f.Sev != sev || f.Kind != kind {
+			t.Errorf("%s: sev=%s kind=%s want %s/%s", key, f.Sev, f.Kind, sev, kind)
+		}
+	}
+	check("nullableField/nullable", SevHigh, KindNullable)
+	check("omitField/omit", SevMed, KindOmit)
+	check("missReq/missing", SevHigh, KindMissing)
+	check("missOpt/missing", SevLow, KindMissing)
+	check("sharedField/layer", SevInfo, KindLayer)
+	check("extraField/extra", SevInfo, KindExtra)
+	if _, ok := got["keep/missing"]; ok {
+		t.Error("keep should match, not be reported")
+	}
+}
+
+// --- unit tests: gate + loaders ---------------------------------------------
+
+func TestRunGate(t *testing.T) {
+	findings := []Finding{
+		{Layer: "L", Field: "a", Kind: KindMissing, Sev: SevHigh},
+		{Layer: "L", Field: "b", Kind: KindOmit, Sev: SevMed},
+	}
+	allow := []AllowEntry{
+		{Layer: "L", Field: "a", Kind: KindMissing, Reason: "ok"},
+		{Layer: "L", Field: "gone", Kind: KindMissing, Reason: "stale"},
+	}
+	violations, stale := RunGate(findings, allow)
+	if len(violations) != 1 || violations[0].Field != "b" {
+		t.Errorf("violations=%+v want only b", violations)
+	}
+	if len(stale) != 1 || stale[0].Field != "gone" {
+		t.Errorf("stale=%+v want only gone", stale)
+	}
+}
+
+func TestGatedFindingsReal(t *testing.T) {
+	golden, err := LoadGoldenSnapshot(filepath.Join("testdata", "golden_schemas.json"))
+	if err != nil {
+		t.Fatalf("load golden: %v", err)
+	}
+	f := GatedFindings(golden)
+	if len(f) == 0 {
+		t.Error("expected baseline gated findings from real golden snapshot")
+	}
+	for _, x := range f {
+		if x.Sev != SevHigh && x.Sev != SevMed {
+			t.Errorf("GatedFindings returned non-gated severity %s", x.Sev)
+		}
+	}
+}
+
+func TestLoaders(t *testing.T) {
+	if _, err := LoadGoldenSnapshot("testdata/does-not-exist.json"); err == nil {
+		t.Error("expected error for missing golden file")
+	}
+	if _, err := LoadAllowlist("testdata/does-not-exist.json"); err == nil {
+		t.Error("expected error for missing allowlist file")
+	}
+	// malformed JSON exercises the decode error branch.
+	bad := filepath.Join(t.TempDir(), "bad.json")
+	if err := os.WriteFile(bad, []byte("{not json"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := LoadGoldenSnapshot(bad); err == nil {
+		t.Error("expected decode error for malformed golden JSON")
+	}
+	if _, err := LoadAllowlist(bad); err == nil {
+		t.Error("expected decode error for malformed allowlist JSON")
+	}
+}
+
+func TestParseTypesFile(t *testing.T) {
+	lines := []string{
+		"        Foo: {",
+		"            a: string;",
+		"        };",
+		"        Bar: {",
+		"            b: number;",
+		"        };",
+	}
+	got := ParseTypesFile(lines, []string{"Foo", "Bar", "Absent"})
+	if len(got) != 2 {
+		t.Fatalf("want 2 schemas, got %d (%v)", len(got), got)
+	}
+	if got["Foo"]["a"].Type != "string" || got["Bar"]["b"].Type != "number" {
+		t.Errorf("unexpected parse: %+v", got)
+	}
+	if _, ok := got["Absent"]; ok {
+		t.Error("Absent schema should be skipped, not present")
+	}
+}
+
+func TestMappingSanity(t *testing.T) {
+	names := GoldenSchemaNames()
+	if len(names) == 0 {
+		t.Fatal("no golden schema names")
+	}
+	// names must be unique
+	seen := map[string]bool{}
+	for _, n := range names {
+		if seen[n] {
+			t.Errorf("duplicate golden schema name %q", n)
+		}
+		seen[n] = true
+	}
+	if len(Families()) == 0 {
+		t.Fatal("no families defined")
+	}
+}

--- a/internal/entitycompat/testdata/allowlist.json
+++ b/internal/entitycompat/testdata/allowlist.json
@@ -1,0 +1,62 @@
+[
+  {
+    "layer": "UserDetailed",
+    "field": "movedTo",
+    "kind": "missing",
+    "reason": "baseline: account-migration field absent from entity.UserDetailed struct (only model has the column). Backlog: add movedTo to the packed UserDetailed shape."
+  },
+  {
+    "layer": "UserDetailed",
+    "field": "alsoKnownAs",
+    "kind": "missing",
+    "reason": "baseline: account-migration field absent from entity.UserDetailed struct. Backlog: add alsoKnownAs to the packed shape."
+  },
+  {
+    "layer": "UserDetailed",
+    "field": "lastFetchedAt",
+    "kind": "missing",
+    "reason": "baseline: remote-fetch timestamp absent from entity.UserDetailed struct. Backlog: add lastFetchedAt to the packed shape."
+  },
+  {
+    "layer": "UserDetailed",
+    "field": "memo",
+    "kind": "omit",
+    "reason": "baseline: golden declares memo as required (string | null); mk-go uses omitempty. Backlog: emit null instead of omitting."
+  },
+  {
+    "layer": "MeDetailed",
+    "field": "hardMutedWords",
+    "kind": "missing",
+    "reason": "baseline: populated ad-hoc in /api/i handler map but absent from entity.MeDetailed struct, so struct-based self-view paths (users/show) drift. Backlog: move into the struct."
+  },
+  {
+    "layer": "MeDetailed",
+    "field": "hasUnreadChatMessages",
+    "kind": "missing",
+    "reason": "baseline: populated ad-hoc in /api/i handler map but absent from entity.MeDetailed struct. Backlog: move into the struct."
+  },
+  {
+    "layer": "MeDetailed",
+    "field": "twoFactorBackupCodesStock",
+    "kind": "missing",
+    "reason": "baseline: populated ad-hoc in /api/i handler map but absent from entity.MeDetailed struct. Backlog: move into the struct."
+  },
+  {
+    "layer": "MeDetailed",
+    "field": "unreadAnnouncements",
+    "kind": "missing",
+    "reason": "baseline: populated ad-hoc in /api/i handler map (#1226) but absent from entity.MeDetailed struct. Backlog: move into the struct."
+  },
+  {
+    "layer": "MeDetailed",
+    "field": "unreadNotificationsCount",
+    "kind": "missing",
+    "reason": "baseline: populated ad-hoc in /api/i handler map but absent from entity.MeDetailed struct. Backlog: move into the struct."
+  },
+  {
+    "layer": "MeDetailed",
+    "field": "policies",
+    "kind": "omit",
+    "reason": "baseline: golden requires policies; mk-go emits with omitempty (#1242 fixed users/show path at handler level). Backlog: make the struct field non-omitempty."
+  }
+]

--- a/internal/entitycompat/testdata/allowlist_l2.json
+++ b/internal/entitycompat/testdata/allowlist_l2.json
@@ -1,0 +1,14 @@
+[
+  {
+    "layer": "Notification",
+    "field": "type=pollVote",
+    "kind": "missing",
+    "reason": "baseline: mk-go emits notification type 'pollVote' but the golden Notification union only has 'pollEnded'. A strict client cannot dispatch it. Backlog: rename to pollEnded, or confirm pollVote is never delivered to API clients."
+  },
+  {
+    "layer": "Notification",
+    "field": "type=importCompleted",
+    "kind": "missing",
+    "reason": "baseline: mk-go emits notification type 'importCompleted' which is absent from the golden Notification union. Backlog: confirm upstream type name / delivery path."
+  }
+]

--- a/internal/entitycompat/testdata/allowlist_l2.json
+++ b/internal/entitycompat/testdata/allowlist_l2.json
@@ -3,12 +3,12 @@
     "layer": "Notification",
     "field": "type=pollVote",
     "kind": "missing",
-    "reason": "baseline: mk-go emits notification type 'pollVote' but the golden Notification union only has 'pollEnded'. A strict client cannot dispatch it. Backlog: rename to pollEnded, or confirm pollVote is never delivered to API clients."
+    "reason": "intentional: mk-go 独自の通知 type 'pollVote' (per-vote 通知)。Misskey TS に対応 type が無く golden union にも無い (notification_service.go の TypePollVote コメント参照)。upstream の 'pollEnded' とは意味が異なる別物。strict クライアントは未知 type を無視する想定の拡張。"
   },
   {
     "layer": "Notification",
     "field": "type=importCompleted",
     "kind": "missing",
-    "reason": "baseline: mk-go emits notification type 'importCompleted' which is absent from the golden Notification union. Backlog: confirm upstream type name / delivery path."
+    "reason": "intentional: mk-go 独自の通知 type 'importCompleted' (transfer import 完了)。golden union は 'exportCompleted' のみで importCompleted は無い。upstream に対応 type が無い拡張。"
   }
 ]

--- a/internal/entitycompat/testdata/golden_schemas.json
+++ b/internal/entitycompat/testdata/golden_schemas.json
@@ -1,0 +1,935 @@
+{
+  "DriveFile": {
+    "blurhash": {
+      "nullable": true,
+      "optional": false,
+      "type": "string"
+    },
+    "comment": {
+      "nullable": true,
+      "optional": false,
+      "type": "string"
+    },
+    "createdAt": {
+      "nullable": false,
+      "optional": false,
+      "type": "string"
+    },
+    "folder": {
+      "nullable": true,
+      "optional": true,
+      "type": "object"
+    },
+    "folderId": {
+      "nullable": true,
+      "optional": false,
+      "type": "string"
+    },
+    "id": {
+      "nullable": false,
+      "optional": false,
+      "type": "string"
+    },
+    "isSensitive": {
+      "nullable": false,
+      "optional": false,
+      "type": "boolean"
+    },
+    "md5": {
+      "nullable": false,
+      "optional": false,
+      "type": "string"
+    },
+    "name": {
+      "nullable": false,
+      "optional": false,
+      "type": "string"
+    },
+    "properties": {
+      "nullable": false,
+      "optional": false,
+      "type": "object"
+    },
+    "size": {
+      "nullable": false,
+      "optional": false,
+      "type": "number"
+    },
+    "thumbnailUrl": {
+      "nullable": true,
+      "optional": false,
+      "type": "string"
+    },
+    "type": {
+      "nullable": false,
+      "optional": false,
+      "type": "string"
+    },
+    "url": {
+      "nullable": false,
+      "optional": false,
+      "type": "string"
+    },
+    "user": {
+      "nullable": true,
+      "optional": true,
+      "type": "object"
+    },
+    "userId": {
+      "nullable": true,
+      "optional": false,
+      "type": "string"
+    }
+  },
+  "DriveFolder": {
+    "createdAt": {
+      "nullable": false,
+      "optional": false,
+      "type": "string"
+    },
+    "filesCount": {
+      "nullable": false,
+      "optional": true,
+      "type": "number"
+    },
+    "foldersCount": {
+      "nullable": false,
+      "optional": true,
+      "type": "number"
+    },
+    "id": {
+      "nullable": false,
+      "optional": false,
+      "type": "string"
+    },
+    "name": {
+      "nullable": false,
+      "optional": false,
+      "type": "string"
+    },
+    "parent": {
+      "nullable": true,
+      "optional": true,
+      "type": "object"
+    },
+    "parentId": {
+      "nullable": true,
+      "optional": false,
+      "type": "string"
+    }
+  },
+  "EmojiDetailed": {
+    "aliases": {
+      "nullable": false,
+      "optional": false,
+      "type": "array"
+    },
+    "category": {
+      "nullable": true,
+      "optional": false,
+      "type": "string"
+    },
+    "host": {
+      "nullable": true,
+      "optional": false,
+      "type": "string"
+    },
+    "id": {
+      "nullable": false,
+      "optional": false,
+      "type": "string"
+    },
+    "isSensitive": {
+      "nullable": false,
+      "optional": false,
+      "type": "boolean"
+    },
+    "license": {
+      "nullable": true,
+      "optional": false,
+      "type": "string"
+    },
+    "localOnly": {
+      "nullable": false,
+      "optional": false,
+      "type": "boolean"
+    },
+    "name": {
+      "nullable": false,
+      "optional": false,
+      "type": "string"
+    },
+    "roleIdsThatCanBeUsedThisEmojiAsReaction": {
+      "nullable": false,
+      "optional": false,
+      "type": "array"
+    },
+    "url": {
+      "nullable": false,
+      "optional": false,
+      "type": "string"
+    }
+  },
+  "Following": {
+    "createdAt": {
+      "nullable": false,
+      "optional": false,
+      "type": "string"
+    },
+    "followee": {
+      "nullable": false,
+      "optional": true,
+      "type": "object"
+    },
+    "followeeId": {
+      "nullable": false,
+      "optional": false,
+      "type": "string"
+    },
+    "follower": {
+      "nullable": false,
+      "optional": true,
+      "type": "object"
+    },
+    "followerId": {
+      "nullable": false,
+      "optional": false,
+      "type": "string"
+    },
+    "id": {
+      "nullable": false,
+      "optional": false,
+      "type": "string"
+    }
+  },
+  "MeDetailedOnly": {
+    "achievements": {
+      "nullable": false,
+      "optional": false,
+      "type": "array"
+    },
+    "alwaysMarkNsfw": {
+      "nullable": false,
+      "optional": false,
+      "type": "boolean"
+    },
+    "autoAcceptFollowed": {
+      "nullable": false,
+      "optional": false,
+      "type": "boolean"
+    },
+    "autoSensitive": {
+      "nullable": false,
+      "optional": false,
+      "type": "boolean"
+    },
+    "avatarId": {
+      "nullable": true,
+      "optional": false,
+      "type": "string"
+    },
+    "bannerId": {
+      "nullable": true,
+      "optional": false,
+      "type": "string"
+    },
+    "carefulBot": {
+      "nullable": false,
+      "optional": false,
+      "type": "boolean"
+    },
+    "email": {
+      "nullable": true,
+      "optional": true,
+      "type": "string"
+    },
+    "emailNotificationTypes": {
+      "nullable": false,
+      "optional": false,
+      "type": "array"
+    },
+    "emailVerified": {
+      "nullable": true,
+      "optional": true,
+      "type": "boolean"
+    },
+    "followedMessage": {
+      "nullable": true,
+      "optional": false,
+      "type": "string"
+    },
+    "hardMutedWords": {
+      "nullable": false,
+      "optional": false,
+      "type": "array"
+    },
+    "hasPendingReceivedFollowRequest": {
+      "nullable": false,
+      "optional": false,
+      "type": "boolean"
+    },
+    "hasUnreadAnnouncement": {
+      "nullable": false,
+      "optional": false,
+      "type": "boolean"
+    },
+    "hasUnreadAntenna": {
+      "nullable": false,
+      "optional": false,
+      "type": "boolean"
+    },
+    "hasUnreadChannel": {
+      "nullable": false,
+      "optional": false,
+      "type": "boolean"
+    },
+    "hasUnreadChatMessages": {
+      "nullable": false,
+      "optional": false,
+      "type": "boolean"
+    },
+    "hasUnreadMentions": {
+      "nullable": false,
+      "optional": false,
+      "type": "boolean"
+    },
+    "hasUnreadNotification": {
+      "nullable": false,
+      "optional": false,
+      "type": "boolean"
+    },
+    "hasUnreadSpecifiedNotes": {
+      "nullable": false,
+      "optional": false,
+      "type": "boolean"
+    },
+    "hideOnlineStatus": {
+      "nullable": false,
+      "optional": false,
+      "type": "boolean"
+    },
+    "injectFeaturedNote": {
+      "nullable": false,
+      "optional": false,
+      "type": "boolean"
+    },
+    "isAdmin": {
+      "nullable": false,
+      "optional": false,
+      "type": "boolean"
+    },
+    "isDeleted": {
+      "nullable": false,
+      "optional": false,
+      "type": "boolean"
+    },
+    "isExplorable": {
+      "nullable": false,
+      "optional": false,
+      "type": "boolean"
+    },
+    "isModerator": {
+      "nullable": false,
+      "optional": false,
+      "type": "boolean"
+    },
+    "loggedInDays": {
+      "nullable": false,
+      "optional": false,
+      "type": "number"
+    },
+    "mutedInstances": {
+      "nullable": false,
+      "optional": false,
+      "type": "array"
+    },
+    "mutedWords": {
+      "nullable": false,
+      "optional": false,
+      "type": "array"
+    },
+    "noCrawle": {
+      "nullable": false,
+      "optional": false,
+      "type": "boolean"
+    },
+    "notificationRecieveConfig": {
+      "nullable": false,
+      "optional": false,
+      "type": "object"
+    },
+    "policies": {
+      "nullable": false,
+      "optional": false,
+      "type": "object"
+    },
+    "preventAiLearning": {
+      "nullable": false,
+      "optional": false,
+      "type": "boolean"
+    },
+    "receiveAnnouncementEmail": {
+      "nullable": false,
+      "optional": false,
+      "type": "boolean"
+    },
+    "securityKeys": {
+      "nullable": false,
+      "optional": false,
+      "type": "boolean"
+    },
+    "securityKeysList": {
+      "nullable": false,
+      "optional": true,
+      "type": "object"
+    },
+    "twoFactorBackupCodesStock": {
+      "nullable": false,
+      "optional": false,
+      "type": "string"
+    },
+    "twoFactorEnabled": {
+      "nullable": false,
+      "optional": false,
+      "type": "boolean"
+    },
+    "unreadAnnouncements": {
+      "nullable": false,
+      "optional": false,
+      "type": "array"
+    },
+    "unreadNotificationsCount": {
+      "nullable": false,
+      "optional": false,
+      "type": "number"
+    },
+    "usePasswordLessLogin": {
+      "nullable": false,
+      "optional": false,
+      "type": "boolean"
+    }
+  },
+  "Note": {
+    "channel": {
+      "nullable": true,
+      "optional": true,
+      "type": "object"
+    },
+    "channelId": {
+      "nullable": true,
+      "optional": true,
+      "type": "string"
+    },
+    "clippedCount": {
+      "nullable": false,
+      "optional": true,
+      "type": "number"
+    },
+    "createdAt": {
+      "nullable": false,
+      "optional": false,
+      "type": "string"
+    },
+    "cw": {
+      "nullable": true,
+      "optional": true,
+      "type": "string"
+    },
+    "deletedAt": {
+      "nullable": true,
+      "optional": true,
+      "type": "string"
+    },
+    "emojis": {
+      "nullable": false,
+      "optional": true,
+      "type": "object"
+    },
+    "fileIds": {
+      "nullable": false,
+      "optional": true,
+      "type": "array"
+    },
+    "files": {
+      "nullable": false,
+      "optional": true,
+      "type": "array"
+    },
+    "hasPoll": {
+      "nullable": false,
+      "optional": true,
+      "type": "boolean"
+    },
+    "id": {
+      "nullable": false,
+      "optional": false,
+      "type": "string"
+    },
+    "isHidden": {
+      "nullable": false,
+      "optional": true,
+      "type": "boolean"
+    },
+    "localOnly": {
+      "nullable": false,
+      "optional": true,
+      "type": "boolean"
+    },
+    "mentions": {
+      "nullable": false,
+      "optional": true,
+      "type": "array"
+    },
+    "myReaction": {
+      "nullable": true,
+      "optional": true,
+      "type": "string"
+    },
+    "poll": {
+      "nullable": true,
+      "optional": true,
+      "type": "object"
+    },
+    "reactionAcceptance": {
+      "nullable": true,
+      "optional": false,
+      "type": "string"
+    },
+    "reactionAndUserPairCache": {
+      "nullable": false,
+      "optional": true,
+      "type": "array"
+    },
+    "reactionCount": {
+      "nullable": false,
+      "optional": false,
+      "type": "number"
+    },
+    "reactionEmojis": {
+      "nullable": false,
+      "optional": false,
+      "type": "object"
+    },
+    "reactions": {
+      "nullable": false,
+      "optional": false,
+      "type": "object"
+    },
+    "renote": {
+      "nullable": true,
+      "optional": true,
+      "type": "object"
+    },
+    "renoteCount": {
+      "nullable": false,
+      "optional": false,
+      "type": "number"
+    },
+    "renoteId": {
+      "nullable": true,
+      "optional": true,
+      "type": "string"
+    },
+    "repliesCount": {
+      "nullable": false,
+      "optional": false,
+      "type": "number"
+    },
+    "reply": {
+      "nullable": true,
+      "optional": true,
+      "type": "object"
+    },
+    "replyId": {
+      "nullable": true,
+      "optional": true,
+      "type": "string"
+    },
+    "tags": {
+      "nullable": false,
+      "optional": true,
+      "type": "array"
+    },
+    "text": {
+      "nullable": true,
+      "optional": false,
+      "type": "string"
+    },
+    "uri": {
+      "nullable": false,
+      "optional": true,
+      "type": "string"
+    },
+    "url": {
+      "nullable": false,
+      "optional": true,
+      "type": "string"
+    },
+    "user": {
+      "nullable": false,
+      "optional": false,
+      "type": "object"
+    },
+    "userId": {
+      "nullable": false,
+      "optional": false,
+      "type": "string"
+    },
+    "visibility": {
+      "nullable": false,
+      "optional": false,
+      "type": "string"
+    },
+    "visibleUserIds": {
+      "nullable": false,
+      "optional": true,
+      "type": "array"
+    }
+  },
+  "UserDetailedNotMeOnly": {
+    "alsoKnownAs": {
+      "nullable": true,
+      "optional": false,
+      "type": "array"
+    },
+    "bannerBlurhash": {
+      "nullable": true,
+      "optional": false,
+      "type": "string"
+    },
+    "bannerUrl": {
+      "nullable": true,
+      "optional": false,
+      "type": "string"
+    },
+    "birthday": {
+      "nullable": true,
+      "optional": false,
+      "type": "string"
+    },
+    "canChat": {
+      "nullable": false,
+      "optional": false,
+      "type": "boolean"
+    },
+    "chatScope": {
+      "nullable": false,
+      "optional": false,
+      "type": "string"
+    },
+    "createdAt": {
+      "nullable": false,
+      "optional": false,
+      "type": "string"
+    },
+    "description": {
+      "nullable": true,
+      "optional": false,
+      "type": "string"
+    },
+    "fields": {
+      "nullable": false,
+      "optional": false,
+      "type": "object"
+    },
+    "followedMessage": {
+      "nullable": true,
+      "optional": true,
+      "type": "string"
+    },
+    "followersCount": {
+      "nullable": false,
+      "optional": false,
+      "type": "number"
+    },
+    "followersVisibility": {
+      "nullable": false,
+      "optional": false,
+      "type": "string"
+    },
+    "followingCount": {
+      "nullable": false,
+      "optional": false,
+      "type": "number"
+    },
+    "followingVisibility": {
+      "nullable": false,
+      "optional": false,
+      "type": "string"
+    },
+    "hasPendingFollowRequestFromYou": {
+      "nullable": false,
+      "optional": true,
+      "type": "boolean"
+    },
+    "hasPendingFollowRequestToYou": {
+      "nullable": false,
+      "optional": true,
+      "type": "boolean"
+    },
+    "isBlocked": {
+      "nullable": false,
+      "optional": true,
+      "type": "boolean"
+    },
+    "isBlocking": {
+      "nullable": false,
+      "optional": true,
+      "type": "boolean"
+    },
+    "isFollowed": {
+      "nullable": false,
+      "optional": true,
+      "type": "boolean"
+    },
+    "isFollowing": {
+      "nullable": false,
+      "optional": true,
+      "type": "boolean"
+    },
+    "isLocked": {
+      "nullable": false,
+      "optional": false,
+      "type": "boolean"
+    },
+    "isMuted": {
+      "nullable": false,
+      "optional": true,
+      "type": "boolean"
+    },
+    "isRenoteMuted": {
+      "nullable": false,
+      "optional": true,
+      "type": "boolean"
+    },
+    "isSilenced": {
+      "nullable": false,
+      "optional": false,
+      "type": "boolean"
+    },
+    "isSuspended": {
+      "nullable": false,
+      "optional": false,
+      "type": "boolean"
+    },
+    "lang": {
+      "nullable": true,
+      "optional": false,
+      "type": "string"
+    },
+    "lastFetchedAt": {
+      "nullable": true,
+      "optional": false,
+      "type": "string"
+    },
+    "location": {
+      "nullable": true,
+      "optional": false,
+      "type": "string"
+    },
+    "memo": {
+      "nullable": true,
+      "optional": false,
+      "type": "string"
+    },
+    "moderationNote": {
+      "nullable": false,
+      "optional": true,
+      "type": "string"
+    },
+    "movedTo": {
+      "nullable": true,
+      "optional": false,
+      "type": "string"
+    },
+    "notesCount": {
+      "nullable": false,
+      "optional": false,
+      "type": "number"
+    },
+    "notify": {
+      "nullable": false,
+      "optional": true,
+      "type": "string"
+    },
+    "pinnedNoteIds": {
+      "nullable": false,
+      "optional": false,
+      "type": "array"
+    },
+    "pinnedNotes": {
+      "nullable": false,
+      "optional": false,
+      "type": "array"
+    },
+    "pinnedPage": {
+      "nullable": true,
+      "optional": false,
+      "type": "object"
+    },
+    "pinnedPageId": {
+      "nullable": true,
+      "optional": false,
+      "type": "string"
+    },
+    "publicReactions": {
+      "nullable": false,
+      "optional": false,
+      "type": "boolean"
+    },
+    "roles": {
+      "nullable": false,
+      "optional": false,
+      "type": "array"
+    },
+    "securityKeys": {
+      "nullable": false,
+      "optional": true,
+      "type": "boolean"
+    },
+    "twoFactorEnabled": {
+      "nullable": false,
+      "optional": true,
+      "type": "boolean"
+    },
+    "updatedAt": {
+      "nullable": true,
+      "optional": false,
+      "type": "string"
+    },
+    "uri": {
+      "nullable": true,
+      "optional": false,
+      "type": "string"
+    },
+    "url": {
+      "nullable": true,
+      "optional": false,
+      "type": "string"
+    },
+    "usePasswordLessLogin": {
+      "nullable": false,
+      "optional": true,
+      "type": "boolean"
+    },
+    "verifiedLinks": {
+      "nullable": false,
+      "optional": false,
+      "type": "array"
+    },
+    "withReplies": {
+      "nullable": false,
+      "optional": true,
+      "type": "boolean"
+    }
+  },
+  "UserList": {
+    "createdAt": {
+      "nullable": false,
+      "optional": false,
+      "type": "string"
+    },
+    "id": {
+      "nullable": false,
+      "optional": false,
+      "type": "string"
+    },
+    "isPublic": {
+      "nullable": false,
+      "optional": false,
+      "type": "boolean"
+    },
+    "name": {
+      "nullable": false,
+      "optional": false,
+      "type": "string"
+    },
+    "userIds": {
+      "nullable": false,
+      "optional": true,
+      "type": "array"
+    }
+  },
+  "UserLite": {
+    "avatarBlurhash": {
+      "nullable": true,
+      "optional": false,
+      "type": "string"
+    },
+    "avatarDecorations": {
+      "nullable": false,
+      "optional": false,
+      "type": "object"
+    },
+    "avatarUrl": {
+      "nullable": false,
+      "optional": false,
+      "type": "string"
+    },
+    "badgeRoles": {
+      "nullable": true,
+      "optional": true,
+      "type": "object"
+    },
+    "emojis": {
+      "nullable": false,
+      "optional": false,
+      "type": "object"
+    },
+    "host": {
+      "nullable": true,
+      "optional": false,
+      "type": "string"
+    },
+    "id": {
+      "nullable": false,
+      "optional": false,
+      "type": "string"
+    },
+    "instance": {
+      "nullable": true,
+      "optional": true,
+      "type": "object"
+    },
+    "isBot": {
+      "nullable": false,
+      "optional": true,
+      "type": "boolean"
+    },
+    "isCat": {
+      "nullable": false,
+      "optional": true,
+      "type": "boolean"
+    },
+    "makeNotesFollowersOnlyBefore": {
+      "nullable": true,
+      "optional": true,
+      "type": "number"
+    },
+    "makeNotesHiddenBefore": {
+      "nullable": true,
+      "optional": true,
+      "type": "number"
+    },
+    "name": {
+      "nullable": true,
+      "optional": false,
+      "type": "string"
+    },
+    "onlineStatus": {
+      "nullable": false,
+      "optional": false,
+      "type": "string"
+    },
+    "requireSigninToViewContents": {
+      "nullable": false,
+      "optional": true,
+      "type": "boolean"
+    },
+    "username": {
+      "nullable": false,
+      "optional": false,
+      "type": "string"
+    }
+  }
+}

--- a/internal/entitycompat/testdata/golden_unions.json
+++ b/internal/entitycompat/testdata/golden_unions.json
@@ -1,0 +1,593 @@
+{
+  "Notification": {
+    "achievementEarned": {
+      "achievement": {
+        "nullable": false,
+        "optional": false,
+        "type": "object"
+      },
+      "createdAt": {
+        "nullable": false,
+        "optional": false,
+        "type": "string"
+      },
+      "id": {
+        "nullable": false,
+        "optional": false,
+        "type": "string"
+      },
+      "type": {
+        "nullable": false,
+        "optional": false,
+        "type": "string"
+      }
+    },
+    "app": {
+      "body": {
+        "nullable": false,
+        "optional": false,
+        "type": "string"
+      },
+      "createdAt": {
+        "nullable": false,
+        "optional": false,
+        "type": "string"
+      },
+      "header": {
+        "nullable": true,
+        "optional": false,
+        "type": "string"
+      },
+      "icon": {
+        "nullable": true,
+        "optional": false,
+        "type": "string"
+      },
+      "id": {
+        "nullable": false,
+        "optional": false,
+        "type": "string"
+      },
+      "type": {
+        "nullable": false,
+        "optional": false,
+        "type": "string"
+      }
+    },
+    "chatRoomInvitationReceived": {
+      "createdAt": {
+        "nullable": false,
+        "optional": false,
+        "type": "string"
+      },
+      "id": {
+        "nullable": false,
+        "optional": false,
+        "type": "string"
+      },
+      "invitation": {
+        "nullable": false,
+        "optional": false,
+        "type": "object"
+      },
+      "type": {
+        "nullable": false,
+        "optional": false,
+        "type": "string"
+      }
+    },
+    "createToken": {
+      "createdAt": {
+        "nullable": false,
+        "optional": false,
+        "type": "string"
+      },
+      "id": {
+        "nullable": false,
+        "optional": false,
+        "type": "string"
+      },
+      "type": {
+        "nullable": false,
+        "optional": false,
+        "type": "string"
+      }
+    },
+    "exportCompleted": {
+      "createdAt": {
+        "nullable": false,
+        "optional": false,
+        "type": "string"
+      },
+      "exportedEntity": {
+        "nullable": false,
+        "optional": false,
+        "type": "string"
+      },
+      "fileId": {
+        "nullable": false,
+        "optional": false,
+        "type": "string"
+      },
+      "id": {
+        "nullable": false,
+        "optional": false,
+        "type": "string"
+      },
+      "type": {
+        "nullable": false,
+        "optional": false,
+        "type": "string"
+      }
+    },
+    "follow": {
+      "createdAt": {
+        "nullable": false,
+        "optional": false,
+        "type": "string"
+      },
+      "id": {
+        "nullable": false,
+        "optional": false,
+        "type": "string"
+      },
+      "type": {
+        "nullable": false,
+        "optional": false,
+        "type": "string"
+      },
+      "user": {
+        "nullable": false,
+        "optional": false,
+        "type": "object"
+      },
+      "userId": {
+        "nullable": false,
+        "optional": false,
+        "type": "string"
+      }
+    },
+    "followRequestAccepted": {
+      "createdAt": {
+        "nullable": false,
+        "optional": false,
+        "type": "string"
+      },
+      "id": {
+        "nullable": false,
+        "optional": false,
+        "type": "string"
+      },
+      "message": {
+        "nullable": true,
+        "optional": false,
+        "type": "string"
+      },
+      "type": {
+        "nullable": false,
+        "optional": false,
+        "type": "string"
+      },
+      "user": {
+        "nullable": false,
+        "optional": false,
+        "type": "object"
+      },
+      "userId": {
+        "nullable": false,
+        "optional": false,
+        "type": "string"
+      }
+    },
+    "login": {
+      "createdAt": {
+        "nullable": false,
+        "optional": false,
+        "type": "string"
+      },
+      "id": {
+        "nullable": false,
+        "optional": false,
+        "type": "string"
+      },
+      "type": {
+        "nullable": false,
+        "optional": false,
+        "type": "string"
+      }
+    },
+    "mention": {
+      "createdAt": {
+        "nullable": false,
+        "optional": false,
+        "type": "string"
+      },
+      "id": {
+        "nullable": false,
+        "optional": false,
+        "type": "string"
+      },
+      "note": {
+        "nullable": false,
+        "optional": false,
+        "type": "object"
+      },
+      "type": {
+        "nullable": false,
+        "optional": false,
+        "type": "string"
+      },
+      "user": {
+        "nullable": false,
+        "optional": false,
+        "type": "object"
+      },
+      "userId": {
+        "nullable": false,
+        "optional": false,
+        "type": "string"
+      }
+    },
+    "note": {
+      "createdAt": {
+        "nullable": false,
+        "optional": false,
+        "type": "string"
+      },
+      "id": {
+        "nullable": false,
+        "optional": false,
+        "type": "string"
+      },
+      "note": {
+        "nullable": false,
+        "optional": false,
+        "type": "object"
+      },
+      "type": {
+        "nullable": false,
+        "optional": false,
+        "type": "string"
+      },
+      "user": {
+        "nullable": false,
+        "optional": false,
+        "type": "object"
+      },
+      "userId": {
+        "nullable": false,
+        "optional": false,
+        "type": "string"
+      }
+    },
+    "pollEnded": {
+      "createdAt": {
+        "nullable": false,
+        "optional": false,
+        "type": "string"
+      },
+      "id": {
+        "nullable": false,
+        "optional": false,
+        "type": "string"
+      },
+      "note": {
+        "nullable": false,
+        "optional": false,
+        "type": "object"
+      },
+      "type": {
+        "nullable": false,
+        "optional": false,
+        "type": "string"
+      },
+      "user": {
+        "nullable": false,
+        "optional": false,
+        "type": "object"
+      },
+      "userId": {
+        "nullable": false,
+        "optional": false,
+        "type": "string"
+      }
+    },
+    "quote": {
+      "createdAt": {
+        "nullable": false,
+        "optional": false,
+        "type": "string"
+      },
+      "id": {
+        "nullable": false,
+        "optional": false,
+        "type": "string"
+      },
+      "note": {
+        "nullable": false,
+        "optional": false,
+        "type": "object"
+      },
+      "type": {
+        "nullable": false,
+        "optional": false,
+        "type": "string"
+      },
+      "user": {
+        "nullable": false,
+        "optional": false,
+        "type": "object"
+      },
+      "userId": {
+        "nullable": false,
+        "optional": false,
+        "type": "string"
+      }
+    },
+    "reaction": {
+      "createdAt": {
+        "nullable": false,
+        "optional": false,
+        "type": "string"
+      },
+      "id": {
+        "nullable": false,
+        "optional": false,
+        "type": "string"
+      },
+      "note": {
+        "nullable": false,
+        "optional": false,
+        "type": "object"
+      },
+      "reaction": {
+        "nullable": false,
+        "optional": false,
+        "type": "string"
+      },
+      "type": {
+        "nullable": false,
+        "optional": false,
+        "type": "string"
+      },
+      "user": {
+        "nullable": false,
+        "optional": false,
+        "type": "object"
+      },
+      "userId": {
+        "nullable": false,
+        "optional": false,
+        "type": "string"
+      }
+    },
+    "reaction:grouped": {
+      "createdAt": {
+        "nullable": false,
+        "optional": false,
+        "type": "string"
+      },
+      "id": {
+        "nullable": false,
+        "optional": false,
+        "type": "string"
+      },
+      "note": {
+        "nullable": false,
+        "optional": false,
+        "type": "object"
+      },
+      "reactions": {
+        "nullable": false,
+        "optional": false,
+        "type": "object"
+      },
+      "type": {
+        "nullable": false,
+        "optional": false,
+        "type": "string"
+      }
+    },
+    "receiveFollowRequest": {
+      "createdAt": {
+        "nullable": false,
+        "optional": false,
+        "type": "string"
+      },
+      "id": {
+        "nullable": false,
+        "optional": false,
+        "type": "string"
+      },
+      "type": {
+        "nullable": false,
+        "optional": false,
+        "type": "string"
+      },
+      "user": {
+        "nullable": false,
+        "optional": false,
+        "type": "object"
+      },
+      "userId": {
+        "nullable": false,
+        "optional": false,
+        "type": "string"
+      }
+    },
+    "renote": {
+      "createdAt": {
+        "nullable": false,
+        "optional": false,
+        "type": "string"
+      },
+      "id": {
+        "nullable": false,
+        "optional": false,
+        "type": "string"
+      },
+      "note": {
+        "nullable": false,
+        "optional": false,
+        "type": "object"
+      },
+      "type": {
+        "nullable": false,
+        "optional": false,
+        "type": "string"
+      },
+      "user": {
+        "nullable": false,
+        "optional": false,
+        "type": "object"
+      },
+      "userId": {
+        "nullable": false,
+        "optional": false,
+        "type": "string"
+      }
+    },
+    "renote:grouped": {
+      "createdAt": {
+        "nullable": false,
+        "optional": false,
+        "type": "string"
+      },
+      "id": {
+        "nullable": false,
+        "optional": false,
+        "type": "string"
+      },
+      "note": {
+        "nullable": false,
+        "optional": false,
+        "type": "object"
+      },
+      "type": {
+        "nullable": false,
+        "optional": false,
+        "type": "string"
+      },
+      "users": {
+        "nullable": false,
+        "optional": false,
+        "type": "array"
+      }
+    },
+    "reply": {
+      "createdAt": {
+        "nullable": false,
+        "optional": false,
+        "type": "string"
+      },
+      "id": {
+        "nullable": false,
+        "optional": false,
+        "type": "string"
+      },
+      "note": {
+        "nullable": false,
+        "optional": false,
+        "type": "object"
+      },
+      "type": {
+        "nullable": false,
+        "optional": false,
+        "type": "string"
+      },
+      "user": {
+        "nullable": false,
+        "optional": false,
+        "type": "object"
+      },
+      "userId": {
+        "nullable": false,
+        "optional": false,
+        "type": "string"
+      }
+    },
+    "roleAssigned": {
+      "createdAt": {
+        "nullable": false,
+        "optional": false,
+        "type": "string"
+      },
+      "id": {
+        "nullable": false,
+        "optional": false,
+        "type": "string"
+      },
+      "role": {
+        "nullable": false,
+        "optional": false,
+        "type": "object"
+      },
+      "type": {
+        "nullable": false,
+        "optional": false,
+        "type": "string"
+      }
+    },
+    "scheduledNotePostFailed": {
+      "createdAt": {
+        "nullable": false,
+        "optional": false,
+        "type": "string"
+      },
+      "id": {
+        "nullable": false,
+        "optional": false,
+        "type": "string"
+      },
+      "noteDraft": {
+        "nullable": false,
+        "optional": false,
+        "type": "object"
+      },
+      "type": {
+        "nullable": false,
+        "optional": false,
+        "type": "string"
+      }
+    },
+    "scheduledNotePosted": {
+      "createdAt": {
+        "nullable": false,
+        "optional": false,
+        "type": "string"
+      },
+      "id": {
+        "nullable": false,
+        "optional": false,
+        "type": "string"
+      },
+      "note": {
+        "nullable": false,
+        "optional": false,
+        "type": "object"
+      },
+      "type": {
+        "nullable": false,
+        "optional": false,
+        "type": "string"
+      }
+    },
+    "test": {
+      "createdAt": {
+        "nullable": false,
+        "optional": false,
+        "type": "string"
+      },
+      "id": {
+        "nullable": false,
+        "optional": false,
+        "type": "string"
+      },
+      "type": {
+        "nullable": false,
+        "optional": false,
+        "type": "string"
+      }
+    }
+  }
+}

--- a/tools/shapediff/main.go
+++ b/tools/shapediff/main.go
@@ -41,11 +41,24 @@ func main() {
 	names := entitycompat.GoldenSchemaNames()
 	golden := entitycompat.ParseTypesFile(lines, names)
 
-	// すべての referenced schema が見つかったか確認 (typo / upstream rename の検出)。
+	// すべての referenced schema が見つかり、かつ 0 フィールドでないか確認する。
+	// 0 フィールドは types.ts の書式変更でパーサが空振りした兆候なので、壊れた
+	// snapshot を commit する前にここで落とす (silent failure 防止)。
+	bad := false
 	for _, n := range names {
-		if _, ok := golden[n]; !ok {
-			fmt.Fprintf(os.Stderr, "shapediff: WARNING golden schema %q not found in types.ts\n", n)
+		s, ok := golden[n]
+		if !ok {
+			fmt.Fprintf(os.Stderr, "shapediff: ERROR golden schema %q not found in types.ts (upstream rename?)\n", n)
+			bad = true
+			continue
 		}
+		if len(s) == 0 {
+			fmt.Fprintf(os.Stderr, "shapediff: ERROR golden schema %q parsed to 0 fields (types.ts format change?)\n", n)
+			bad = true
+		}
+	}
+	if bad {
+		os.Exit(1)
 	}
 
 	buf, err := json.MarshalIndent(golden, "", "  ")

--- a/tools/shapediff/main.go
+++ b/tools/shapediff/main.go
@@ -1,0 +1,113 @@
+// Command shapediff regenerates the golden API-contract snapshot used by the
+// entitycompat drift gate, and (with -report) prints a full drift report.
+//
+// The golden snapshot is extracted from the misskey-js autogen `types.ts`
+// (which mirrors the OpenAPI `components.schemas`) for exactly the schemas the
+// entitycompat family table references, and written to
+// internal/entitycompat/testdata/golden_schemas.json. Regenerate it whenever
+// the third_party/misskey submodule is bumped to a new upstream version.
+//
+// Usage:
+//
+//	go run ./tools/shapediff            # regenerate golden snapshot
+//	go run ./tools/shapediff -report    # also print a full drift report
+package main
+
+import (
+	"encoding/json"
+	"flag"
+	"fmt"
+	"os"
+	"sort"
+	"strings"
+
+	"github.com/shiroha-a/mk/internal/entitycompat"
+)
+
+func main() {
+	typesPath := flag.String("types", "third_party/misskey/packages/misskey-js/src/autogen/types.ts", "path to misskey-js autogen types.ts")
+	outPath := flag.String("out", "internal/entitycompat/testdata/golden_schemas.json", "golden snapshot output path")
+	unionOut := flag.String("union-out", "internal/entitycompat/testdata/golden_unions.json", "golden union snapshot output path")
+	report := flag.Bool("report", false, "print a full drift report after regenerating")
+	flag.Parse()
+
+	data, err := os.ReadFile(*typesPath)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "shapediff: read types.ts: %v\n", err)
+		os.Exit(1)
+	}
+	lines := strings.Split(string(data), "\n")
+
+	names := entitycompat.GoldenSchemaNames()
+	golden := entitycompat.ParseTypesFile(lines, names)
+
+	// すべての referenced schema が見つかったか確認 (typo / upstream rename の検出)。
+	for _, n := range names {
+		if _, ok := golden[n]; !ok {
+			fmt.Fprintf(os.Stderr, "shapediff: WARNING golden schema %q not found in types.ts\n", n)
+		}
+	}
+
+	buf, err := json.MarshalIndent(golden, "", "  ")
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "shapediff: marshal: %v\n", err)
+		os.Exit(1)
+	}
+	buf = append(buf, '\n')
+	if err := os.WriteFile(*outPath, buf, 0o644); err != nil {
+		fmt.Fprintf(os.Stderr, "shapediff: write %s: %v\n", *outPath, err)
+		os.Exit(1)
+	}
+	fmt.Printf("wrote %s (%d golden schemas)\n", *outPath, len(golden))
+
+	// L2: discriminated-union snapshots, keyed by variant `type` literal.
+	unions := map[string]map[string]entitycompat.Schema{}
+	for _, n := range entitycompat.UnionSchemaNames() {
+		if v := entitycompat.ParseUnion(lines, n); len(v) > 0 {
+			unions[n] = v
+		} else {
+			fmt.Fprintf(os.Stderr, "shapediff: WARNING union schema %q not found in types.ts\n", n)
+		}
+	}
+	ubuf, err := json.MarshalIndent(unions, "", "  ")
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "shapediff: marshal unions: %v\n", err)
+		os.Exit(1)
+	}
+	ubuf = append(ubuf, '\n')
+	if err := os.WriteFile(*unionOut, ubuf, 0o644); err != nil {
+		fmt.Fprintf(os.Stderr, "shapediff: write %s: %v\n", *unionOut, err)
+		os.Exit(1)
+	}
+	nVariants := 0
+	for _, v := range unions {
+		nVariants += len(v)
+	}
+	fmt.Printf("wrote %s (%d unions, %d variants)\n", *unionOut, len(unions), nVariants)
+
+	if *report {
+		printReport(golden)
+	}
+}
+
+func printReport(golden entitycompat.GoldenSet) {
+	total := 0
+	for _, fam := range entitycompat.Families() {
+		findings := entitycompat.DiffFamily(fam, golden)
+		fmt.Printf("\n### family %s\n", fam.Name)
+		if len(findings) == 0 {
+			fmt.Println("  (no drift)")
+			continue
+		}
+		// stable layer ordering for readability
+		sort.SliceStable(findings, func(i, j int) bool { return findings[i].Layer < findings[j].Layer })
+		for _, f := range findings {
+			if f.Sev == entitycompat.SevHigh || f.Sev == entitycompat.SevMed {
+				total++
+			}
+			fmt.Printf("  %-5s [%-8s] %-28s (%s <- %s) %s\n",
+				f.Sev, f.Kind, f.Field, f.Layer, f.Golden, f.Detail)
+		}
+	}
+	fmt.Printf("\n==> %d gated (HIGH/MED) finding(s)\n", total)
+}


### PR DESCRIPTION
## Summary

3rd-party クライアント (Miria 等) の shape crash は本質的に **API レスポンスの shape ドリフト** (フィールド欠落 / null性 / optional性の不一致) であり、直近の修正 PR の大半を占めている。これを Playwright / drop-in E2E で検出するのは重く・flaky・低カバレッジ。

本 PR は **misskey-js の機械可読な契約 (`types.ts` = OpenAPI components.schemas) と mk-go entity を直接 diff** する静的ゲートを追加する。サーバー / ブラウザ / Docker 不要・決定的・全フィールド網羅で、`go test` ゲートとして CI で自動実行される。

## 主な変更点

### L0: 静的 shape diff
- `internal/entitycompat`: entity 構造体を reflection 走査し golden 契約と field 単位 diff
- 対象 8 family (User 3層 / Note / DriveFile / DriveFolder / UserList / Following / EmojiDetailed)
- missing (HIGH/LOW) / nullable 違反 (HIGH) / omitempty 違反 (MED) / extra・layer (INFO) を検出。HIGH/MED をゲート対象
- baseline は `testdata/allowlist.json` に理由付きで記録 (= 潰すべき backlog)

### L2: 実行時 shape 検証 (map-based / union)
- L0 が届かない `map[string]any` packer・discriminated union・populate 漏れを、**packer 実出力の契約突合**でカバー (二 backend 起動なし)
- `PackNotification` 出力を golden Notification union (22 variant) に type 別検証

### 運用
- `make shapecheck` (L0+L2) / `shapecheck-gen` (golden 再生成) / `shapecheck-report`
- golden snapshot は commit 済 (hermetic)。submodule bump 時に `make shapecheck-gen` で再生成 → docs/upstream-catch-up.md に手順記載
- 仕組みの詳細は docs/shape-drift.md

### 検出した実ドリフト (baseline 記録 / 後続で潰す)
- **UserDetailed**: `movedTo` / `alsoKnownAs` / `lastFetchedAt` 欠落、`memo` omitempty
- **MeDetailed**: `unreadAnnouncements` 等 5件 (/api/i では map 補完、構造体経由経路でドリフト)、`policies` omitempty
- **Notification (L2)**: `type=pollVote` / `importCompleted` が golden union に無い (union dispatch 不可)

## テスト

- `internal/entitycompat`: 新規パッケージ。`TestEntityShapeDrift` (L0 ゲート) + `TestNotificationShapeL2` (L2 ゲート) + 各 pure logic の単体テスト
- カバレッジ **96.9%** (race + atomic、90% ゲートを例外なしクリア)
- regression 検出を確認: allowlist を空にすると baseline ドリフトでゲートが落ちる
- `make fmt` / `make lint` / `go build ./...` clean

実行方法:
\`\`\`bash
make shapecheck        # L0 + L2 ゲート
make shapecheck-report # 全 family の drift 一覧
\`\`\`

## Closes

Closes #1253

## その他

- golden の oracle 源である `packages/misskey-js` は MIT ライセンス。検証オラクルとしての利用はインターフェイス/事実の利用で、テスト時のみ・出荷物に含まれない
- 射程外 (今後): `/api/i` 等が handler 層で `map[string]any` にアドホック追加する欄。再利用可能 packer を介さないため、該当 handler の統合テストまたは二 backend 差分 HTTP で確定する

🤖 Generated with [Claude Code](https://claude.com/claude-code)