### PR TITLE
feat(users): UserDetailed に movedTo / alsoKnownAs / lastFetchedAt を追加

### DIFF
--- a/internal/api/i/handler.go
+++ b/internal/api/i/handler.go
@@ -51,32 +51,30 @@ type AccountMover interface {
 
 // Handler handles account-related API endpoints.
 type Handler struct {
-	userService       *user.Service
-	idGen             id.Generator
-	roleProvider      RoleProvider
-	registryRepo      repository.RegistryRepository
-	favoriteRepo      repository.NoteFavoriteRepository
-	transferEnqueuer  TransferEnqueuer
-	webauthnSvc       *twofactor.WebAuthnService
-	securityKeyRepo   repository.UserSecurityKeyRepository
-	metaRepo          repository.MetaRepository
-	emailSender       EmailSender
-	serverURL         string
-	signinRepo        repository.SigninRepository
-	accessTokenRepo   repository.AccessTokenRepository
-	galleryRepo       GalleryRepository
-	pageLikeRepo      repository.PageLikeRepository
-	mover             AccountMover
-	notificationSvc   UnreadNotificationSource
-	followRequestRepo repository.FollowRequestRepository
-	announcementRepo  AnnouncementUnreadSource
-	chatRepo          ChatUnreadSource
-	antennaUnreadRepo AntennaUnreadSource
-	channelUnreadRepo ChannelUnreadSource
-	piningRepo        repository.UserNotePiningRepository
-	noteRepo          repository.NoteRepository
-	// userRepo は movedTo / alsoKnownAs の URI→ローカルID 解決 (#1255) に使う。
-	userRepo             repository.UserRepository
+	userService          *user.Service
+	idGen                id.Generator
+	roleProvider         RoleProvider
+	registryRepo         repository.RegistryRepository
+	favoriteRepo         repository.NoteFavoriteRepository
+	transferEnqueuer     TransferEnqueuer
+	webauthnSvc          *twofactor.WebAuthnService
+	securityKeyRepo      repository.UserSecurityKeyRepository
+	metaRepo             repository.MetaRepository
+	emailSender          EmailSender
+	serverURL            string
+	signinRepo           repository.SigninRepository
+	accessTokenRepo      repository.AccessTokenRepository
+	galleryRepo          GalleryRepository
+	pageLikeRepo         repository.PageLikeRepository
+	mover                AccountMover
+	notificationSvc      UnreadNotificationSource
+	followRequestRepo    repository.FollowRequestRepository
+	announcementRepo     AnnouncementUnreadSource
+	chatRepo             ChatUnreadSource
+	antennaUnreadRepo    AntennaUnreadSource
+	channelUnreadRepo    ChannelUnreadSource
+	piningRepo           repository.UserNotePiningRepository
+	noteRepo             repository.NoteRepository
 	pageRepo             repository.PageRepository
 	instanceRepo         repository.InstanceRepository
 	emojiRepo            repository.EmojiRepository
@@ -101,6 +99,9 @@ type Handler struct {
 	// Misskey TS は持たない)。nil なら無保護 (= unit test / dev fallback)。
 	// production では必ず wire する。
 	totpReplayGuard twofactor.ReplayGuard
+	// userRepo は movedTo / alsoKnownAs の URI→ローカルID 解決 (#1255) に使う。
+	// FindByURI による local lookup のみで remote fetch しない。
+	userRepo repository.UserRepository
 }
 
 // TokenInvalidator は i/regenerate-token / i/change-password 等の sensitive
@@ -142,6 +143,10 @@ func (h *Handler) SetEmailValidationClient(c *http.Client) {
 
 // SetNoteFieldResolver wires the shared resolver that fills Files /
 // MyReaction / Channel on packed pinned notes (#426)。
+func (h *Handler) SetNoteFieldResolver(r *entity.NoteFieldResolver) {
+	h.fieldRes = r
+}
+
 // SetUserRepo wires a UserRepository used to resolve movedTo / alsoKnownAs
 // actor URIs to local user IDs (#1255). Unwired (test) leaves those null.
 func (h *Handler) SetUserRepo(r repository.UserRepository) {
@@ -160,10 +165,6 @@ func (h *Handler) resolveUserIDByURI(uri string) (string, bool) {
 		return "", false
 	}
 	return u.ID, true
-}
-
-func (h *Handler) SetNoteFieldResolver(r *entity.NoteFieldResolver) {
-	h.fieldRes = r
 }
 
 // MainStreamPublisher emits events to a single user's `main` WebSocket

--- a/internal/api/i/handler.go
+++ b/internal/api/i/handler.go
@@ -51,30 +51,32 @@ type AccountMover interface {
 
 // Handler handles account-related API endpoints.
 type Handler struct {
-	userService          *user.Service
-	idGen                id.Generator
-	roleProvider         RoleProvider
-	registryRepo         repository.RegistryRepository
-	favoriteRepo         repository.NoteFavoriteRepository
-	transferEnqueuer     TransferEnqueuer
-	webauthnSvc          *twofactor.WebAuthnService
-	securityKeyRepo      repository.UserSecurityKeyRepository
-	metaRepo             repository.MetaRepository
-	emailSender          EmailSender
-	serverURL            string
-	signinRepo           repository.SigninRepository
-	accessTokenRepo      repository.AccessTokenRepository
-	galleryRepo          GalleryRepository
-	pageLikeRepo         repository.PageLikeRepository
-	mover                AccountMover
-	notificationSvc      UnreadNotificationSource
-	followRequestRepo    repository.FollowRequestRepository
-	announcementRepo     AnnouncementUnreadSource
-	chatRepo             ChatUnreadSource
-	antennaUnreadRepo    AntennaUnreadSource
-	channelUnreadRepo    ChannelUnreadSource
-	piningRepo           repository.UserNotePiningRepository
-	noteRepo             repository.NoteRepository
+	userService       *user.Service
+	idGen             id.Generator
+	roleProvider      RoleProvider
+	registryRepo      repository.RegistryRepository
+	favoriteRepo      repository.NoteFavoriteRepository
+	transferEnqueuer  TransferEnqueuer
+	webauthnSvc       *twofactor.WebAuthnService
+	securityKeyRepo   repository.UserSecurityKeyRepository
+	metaRepo          repository.MetaRepository
+	emailSender       EmailSender
+	serverURL         string
+	signinRepo        repository.SigninRepository
+	accessTokenRepo   repository.AccessTokenRepository
+	galleryRepo       GalleryRepository
+	pageLikeRepo      repository.PageLikeRepository
+	mover             AccountMover
+	notificationSvc   UnreadNotificationSource
+	followRequestRepo repository.FollowRequestRepository
+	announcementRepo  AnnouncementUnreadSource
+	chatRepo          ChatUnreadSource
+	antennaUnreadRepo AntennaUnreadSource
+	channelUnreadRepo ChannelUnreadSource
+	piningRepo        repository.UserNotePiningRepository
+	noteRepo          repository.NoteRepository
+	// userRepo は movedTo / alsoKnownAs の URI→ローカルID 解決 (#1255) に使う。
+	userRepo             repository.UserRepository
 	pageRepo             repository.PageRepository
 	instanceRepo         repository.InstanceRepository
 	emojiRepo            repository.EmojiRepository
@@ -140,6 +142,26 @@ func (h *Handler) SetEmailValidationClient(c *http.Client) {
 
 // SetNoteFieldResolver wires the shared resolver that fills Files /
 // MyReaction / Channel on packed pinned notes (#426)。
+// SetUserRepo wires a UserRepository used to resolve movedTo / alsoKnownAs
+// actor URIs to local user IDs (#1255). Unwired (test) leaves those null.
+func (h *Handler) SetUserRepo(r repository.UserRepository) {
+	h.userRepo = r
+}
+
+// resolveUserIDByURI resolves an ActivityPub actor URI to a local user ID via
+// a local DB lookup only (no remote fetch). Returns ("", false) when unwired
+// or the URI is not known locally.
+func (h *Handler) resolveUserIDByURI(uri string) (string, bool) {
+	if h.userRepo == nil {
+		return "", false
+	}
+	u, err := h.userRepo.FindByURI(uri)
+	if err != nil || u == nil {
+		return "", false
+	}
+	return u.ID, true
+}
+
 func (h *Handler) SetNoteFieldResolver(r *entity.NoteFieldResolver) {
 	h.fieldRes = r
 }
@@ -587,6 +609,9 @@ func (h *Handler) Me(c echo.Context) error {
 	// CI の TestMe_PreservesMeDetailedFields で即検出される (= empty resp
 	// で field 不在 assertion が落ちる)。silent leak には繋がらない。
 	me := entity.PackMeDetailed(u, profile, h.idGen)
+	// movedTo / alsoKnownAs を URI→ローカルID 解決して埋める (#1255)。self
+	// view も他 path と同じ shape にするため marshal 前に enrich する。
+	me.ResolveMoveTargets(u, h.resolveUserIDByURI)
 	b, _ := json.Marshal(me)
 	resp := map[string]any{}
 	_ = json.Unmarshal(b, &resp)
@@ -594,10 +619,11 @@ func (h *Handler) Me(c echo.Context) error {
 	// MeDetailed packer に乗っていない /api/i 固有 field を上書き / 追加。
 	// avatarId / bannerId / chatScope は PackUserDetailed 経由で同 value が
 	// 既に乗っているので override 不要 (#987 review で重複削除)。
-	// movedTo / alsoKnownAs / lastFetchedAt も PackUserDetailed が golden 互換
-	// shape (movedTo: string|null / alsoKnownAs: string[]|null /
-	// lastFetchedAt: string|null) で乗せるので override しない。旧 override は
-	// alsoKnownAs を comma-joined string のまま出していて golden 非互換だった。
+	// movedTo / alsoKnownAs / lastFetchedAt は PackUserDetailed +
+	// ResolveMoveTargets (上で実施) が golden 互換 shape (movedTo: string|null /
+	// alsoKnownAs: string[]|null / lastFetchedAt: string|null) で乗せるので
+	// override しない。旧 override は alsoKnownAs を comma-joined string のまま
+	// 出していて golden 非互換だった。
 	// canChat は PackMeDetailed → UserLite 経由で role policy
 	// chatAvailability === 'available' を見るようになった (#988)。
 	// 旧 self-view 用 hardcode `resp["canChat"] = true` を撤去し、

--- a/internal/api/i/handler.go
+++ b/internal/api/i/handler.go
@@ -594,9 +594,10 @@ func (h *Handler) Me(c echo.Context) error {
 	// MeDetailed packer に乗っていない /api/i 固有 field を上書き / 追加。
 	// avatarId / bannerId / chatScope は PackUserDetailed 経由で同 value が
 	// 既に乗っているので override 不要 (#987 review で重複削除)。
-	resp["movedTo"] = u.MovedToURI
-	resp["alsoKnownAs"] = u.AlsoKnownAs
-	resp["lastFetchedAt"] = nil
+	// movedTo / alsoKnownAs / lastFetchedAt も PackUserDetailed が golden 互換
+	// shape (movedTo: string|null / alsoKnownAs: string[]|null /
+	// lastFetchedAt: string|null) で乗せるので override しない。旧 override は
+	// alsoKnownAs を comma-joined string のまま出していて golden 非互換だった。
 	// canChat は PackMeDetailed → UserLite 経由で role policy
 	// chatAvailability === 'available' を見るようになった (#988)。
 	// 旧 self-view 用 hardcode `resp["canChat"] = true` を撤去し、

--- a/internal/api/i/move_resolve_test.go
+++ b/internal/api/i/move_resolve_test.go
@@ -1,0 +1,50 @@
+package i
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/shiroha-a/mk/internal/model"
+	"github.com/shiroha-a/mk/internal/repository"
+)
+
+// stubUserRepoByURI implements only FindByURI; embedding the interface
+// satisfies repository.UserRepository without the unused methods.
+type stubUserRepoByURI struct {
+	repository.UserRepository
+	byURI map[string]*model.User
+	err   error
+}
+
+func (s stubUserRepoByURI) FindByURI(uri string) (*model.User, error) {
+	if s.err != nil {
+		return nil, s.err
+	}
+	return s.byURI[uri], nil
+}
+
+func TestResolveUserIDByURI(t *testing.T) {
+	h := &Handler{}
+
+	// unwired repo -> not resolvable.
+	if id, ok := h.resolveUserIDByURI("u://a"); ok || id != "" {
+		t.Errorf("nil userRepo: got %q %v, want \"\" false", id, ok)
+	}
+
+	h.SetUserRepo(stubUserRepoByURI{byURI: map[string]*model.User{"u://a": {ID: "id_a"}}})
+
+	// known URI -> local id.
+	if id, ok := h.resolveUserIDByURI("u://a"); !ok || id != "id_a" {
+		t.Errorf("known URI: got %q %v, want id_a true", id, ok)
+	}
+	// unknown URI (nil user, no error) -> not resolvable.
+	if _, ok := h.resolveUserIDByURI("u://missing"); ok {
+		t.Error("unknown URI must not resolve")
+	}
+
+	// repository error -> not resolvable (best-effort, like upstream catch).
+	h.SetUserRepo(stubUserRepoByURI{err: errors.New("boom")})
+	if _, ok := h.resolveUserIDByURI("u://a"); ok {
+		t.Error("repo error must not resolve")
+	}
+}

--- a/internal/api/users/handler.go
+++ b/internal/api/users/handler.go
@@ -95,6 +95,20 @@ func (h *Handler) SetUserRepo(r repository.UserRepository) {
 	h.userRepo = r
 }
 
+// resolveUserIDByURI resolves an ActivityPub actor URI to a local user ID via
+// a local DB lookup only (no remote fetch). Used by UserDetailed.ResolveMoveTargets
+// to fill movedTo / alsoKnownAs. Returns ("", false) when unwired or unknown.
+func (h *Handler) resolveUserIDByURI(uri string) (string, bool) {
+	if h.userRepo == nil {
+		return "", false
+	}
+	u, err := h.userRepo.FindByURI(uri)
+	if err != nil || u == nil {
+		return "", false
+	}
+	return u.ID, true
+}
+
 // SetNoteReactionRepo wires the NoteReactionRepository for users/reactions
 // (= reactor 視点の reaction list、#821 PR-D)。
 func (h *Handler) SetNoteReactionRepo(r repository.NoteReactionRepository) {
@@ -322,6 +336,11 @@ func (h *Handler) Show(c echo.Context) error {
 	}
 
 	detailed := entity.PackUserDetailed(bundle.User, bundle.Profile, h.idGen)
+
+	// movedTo / alsoKnownAs を URI→ローカルID 解決して埋める (#1255)。単一
+	// ユーザー path なので FindByURI は数回で済む。list path (followers 等) は
+	// N+1 を避けるため解決せず null のまま (move banner は profile でのみ表示)。
+	detailed.ResolveMoveTargets(bundle.User, h.resolveUserIDByURI)
 
 	// remote user の場合は origin instance の /api/users/show から実際の counts
 	// を取得して上書きする (#943)。Misskey TS は自インスタンス観測値のみ集計する

--- a/internal/api/users/move_resolve_test.go
+++ b/internal/api/users/move_resolve_test.go
@@ -1,0 +1,47 @@
+package users
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/shiroha-a/mk/internal/model"
+	"github.com/shiroha-a/mk/internal/repository"
+)
+
+// stubUserRepoByURI implements only FindByURI; embedding the interface
+// satisfies repository.UserRepository without the unused methods.
+type stubUserRepoByURI struct {
+	repository.UserRepository
+	byURI map[string]*model.User
+	err   error
+}
+
+func (s stubUserRepoByURI) FindByURI(uri string) (*model.User, error) {
+	if s.err != nil {
+		return nil, s.err
+	}
+	return s.byURI[uri], nil
+}
+
+func TestResolveUserIDByURI(t *testing.T) {
+	h := &Handler{}
+
+	// unwired repo -> not resolvable.
+	if id, ok := h.resolveUserIDByURI("u://a"); ok || id != "" {
+		t.Errorf("nil userRepo: got %q %v, want \"\" false", id, ok)
+	}
+
+	h.SetUserRepo(stubUserRepoByURI{byURI: map[string]*model.User{"u://a": {ID: "id_a"}}})
+
+	if id, ok := h.resolveUserIDByURI("u://a"); !ok || id != "id_a" {
+		t.Errorf("known URI: got %q %v, want id_a true", id, ok)
+	}
+	if _, ok := h.resolveUserIDByURI("u://missing"); ok {
+		t.Error("unknown URI must not resolve")
+	}
+
+	h.SetUserRepo(stubUserRepoByURI{err: errors.New("boom")})
+	if _, ok := h.resolveUserIDByURI("u://a"); ok {
+		t.Error("repo error must not resolve")
+	}
+}

--- a/internal/entity/user.go
+++ b/internal/entity/user.go
@@ -2,6 +2,7 @@ package entity
 
 import (
 	"encoding/json"
+	"strings"
 
 	"github.com/shiroha-a/mk/internal/misc/id"
 	"github.com/shiroha-a/mk/internal/model"
@@ -84,10 +85,9 @@ type UserDetailed struct {
 	// MovedTo / AlsoKnownAs はアカウント移行 (Mastodon 互換 Move) のフィールド。
 	// upstream UserEntityService は movedToUri / alsoKnownAs (URI 群) をローカル
 	// ユーザー ID に解決した上で返す (resolvePerson(...).then(u => u.id))。
-	// その URI→ID 解決は repository アクセスを要し pure packer では行えないため、
-	// ここでは解決不能時の upstream fallback と同じ null を出す。完全な解決は
-	// follow-up で handler enrich する (golden: movedTo string|null /
-	// alsoKnownAs string[]|null)。
+	// pure packer は repository アクセスを持たないので null のまま残し、repo を
+	// 持つ handler が ResolveMoveTargets で URI→ID 解決して埋める。解決不能な
+	// URI は null になる (golden: movedTo string|null / alsoKnownAs string[]|null)。
 	MovedTo       *string  `json:"movedTo"`
 	AlsoKnownAs   []string `json:"alsoKnownAs"`
 	URI           *string  `json:"uri"`
@@ -459,6 +459,46 @@ func PackUserDetailed(u *model.User, profile *model.UserProfile, idGens ...id.Ge
 	}
 
 	return d
+}
+
+// MoveTargetResolver resolves an ActivityPub actor URI to a local user ID.
+// It must perform a local lookup only (no remote fetch); an unknown URI
+// returns ("", false), mirroring upstream's resolve-or-null behavior.
+type MoveTargetResolver func(uri string) (id string, ok bool)
+
+// ResolveMoveTargets fills MovedTo / AlsoKnownAs from the account-migration
+// URIs stored on u, resolving each to a local user ID via resolve. Upstream
+// UserEntityService maps movedToUri / alsoKnownAs (URIs) to local user IDs and
+// emits null for the unresolvable ones; this mirrors that. It is a no-op when
+// u or resolve is nil, leaving the fields null.
+//
+// 注: mk-go は alsoKnownAs を comma-joined string で 1 カラムに格納している
+// (renderer.go の AP 出力と対称)。ここで split して各 URI を解決する。
+func (d *UserDetailed) ResolveMoveTargets(u *model.User, resolve MoveTargetResolver) {
+	if u == nil || resolve == nil {
+		return
+	}
+	if u.MovedToURI != nil && *u.MovedToURI != "" {
+		if id, ok := resolve(*u.MovedToURI); ok {
+			d.MovedTo = &id
+		}
+	}
+	if u.AlsoKnownAs != nil && *u.AlsoKnownAs != "" {
+		var ids []string
+		for _, uri := range strings.Split(*u.AlsoKnownAs, ",") {
+			uri = strings.TrimSpace(uri)
+			if uri == "" {
+				continue
+			}
+			if id, ok := resolve(uri); ok {
+				ids = append(ids, id)
+			}
+		}
+		// upstream は解決後 0 件なら null (空配列にしない)。
+		if len(ids) > 0 {
+			d.AlsoKnownAs = ids
+		}
+	}
 }
 
 // PackUserForFollowStreamEvent returns a UserDetailed envelope suitable for

--- a/internal/entity/user.go
+++ b/internal/entity/user.go
@@ -77,9 +77,19 @@ type UserDetailed struct {
 	// /settings/privacy が `i/update` レスポンスから直接 `$i.chatScope` に
 	// 反映するため、この field を expose しないと UI が保存後に古い値で
 	// 再描画される (DB は更新されているのに UI が "保存されない" と見える)。
-	ChatScope     string   `json:"chatScope"`
-	CreatedAt     string   `json:"createdAt"`
-	UpdatedAt     *string  `json:"updatedAt"`
+	ChatScope     string  `json:"chatScope"`
+	CreatedAt     string  `json:"createdAt"`
+	UpdatedAt     *string `json:"updatedAt"`
+	LastFetchedAt *string `json:"lastFetchedAt"`
+	// MovedTo / AlsoKnownAs はアカウント移行 (Mastodon 互換 Move) のフィールド。
+	// upstream UserEntityService は movedToUri / alsoKnownAs (URI 群) をローカル
+	// ユーザー ID に解決した上で返す (resolvePerson(...).then(u => u.id))。
+	// その URI→ID 解決は repository アクセスを要し pure packer では行えないため、
+	// ここでは解決不能時の upstream fallback と同じ null を出す。完全な解決は
+	// follow-up で handler enrich する (golden: movedTo string|null /
+	// alsoKnownAs string[]|null)。
+	MovedTo       *string  `json:"movedTo"`
+	AlsoKnownAs   []string `json:"alsoKnownAs"`
 	URI           *string  `json:"uri"`
 	URL           *string  `json:"url"`
 	PinnedNoteIDs []string `json:"pinnedNoteIds"`
@@ -424,6 +434,13 @@ func PackUserDetailed(u *model.User, profile *model.UserProfile, idGens ...id.Ge
 		if t, err := idGens[0].ParseTime(u.ID); err == nil {
 			d.CreatedAt = t.UTC().Format("2006-01-02T15:04:05.000Z")
 		}
+	}
+
+	// lastFetchedAt は upstream と同じく ISO8601 (ms) で出す。未取得 (ローカル
+	// ユーザー等) は null。
+	if u.LastFetchedAt != nil {
+		s := u.LastFetchedAt.UTC().Format("2006-01-02T15:04:05.000Z")
+		d.LastFetchedAt = &s
 	}
 
 	if profile != nil {

--- a/internal/entity/user_test.go
+++ b/internal/entity/user_test.go
@@ -175,6 +175,48 @@ func TestPackUserDetailed_LastFetchedAtNil(t *testing.T) {
 	assert.Nil(t, d.LastFetchedAt, "local user without lastFetchedAt -> null")
 }
 
+func TestResolveMoveTargets(t *testing.T) {
+	movedURI := "https://remote.example/users/dest"
+	aka := "https://a.example/users/x, https://unknown.example/users/z ,https://b.example/users/y"
+	u := &model.User{
+		ID:          "u1",
+		MovedToURI:  &movedURI,
+		AlsoKnownAs: &aka,
+	}
+	// known URIs -> local IDs; unknown -> dropped.
+	known := map[string]string{
+		movedURI:                    "dest_id",
+		"https://a.example/users/x": "x_id",
+		"https://b.example/users/y": "y_id",
+	}
+	resolve := func(uri string) (string, bool) { id, ok := known[uri]; return id, ok }
+
+	d := PackUserDetailed(u, nil)
+	d.ResolveMoveTargets(u, resolve)
+
+	require.NotNil(t, d.MovedTo)
+	assert.Equal(t, "dest_id", *d.MovedTo)
+	// unknown.example は解決できず除外され、空白も trim される。
+	assert.Equal(t, []string{"x_id", "y_id"}, d.AlsoKnownAs)
+}
+
+func TestResolveMoveTargets_NilAndUnresolvable(t *testing.T) {
+	// nil resolve / nil user は no-op。
+	d := UserDetailed{}
+	d.ResolveMoveTargets(&model.User{}, nil)
+	assert.Nil(t, d.MovedTo)
+	assert.Nil(t, d.AlsoKnownAs)
+
+	// すべて解決不能なら null のまま (空配列にしない)。
+	movedURI := "https://x/u"
+	aka := "https://y/u"
+	u := &model.User{MovedToURI: &movedURI, AlsoKnownAs: &aka}
+	d2 := UserDetailed{}
+	d2.ResolveMoveTargets(u, func(string) (string, bool) { return "", false })
+	assert.Nil(t, d2.MovedTo)
+	assert.Nil(t, d2.AlsoKnownAs, "all-unresolvable alsoKnownAs stays null, not []")
+}
+
 func TestPackUserDetailed_ProfileVisibility(t *testing.T) {
 	u := &model.User{
 		ID:                "user5",

--- a/internal/entity/user_test.go
+++ b/internal/entity/user_test.go
@@ -131,6 +131,50 @@ func TestPackUserDetailed(t *testing.T) {
 	assert.Equal(t, &lang, detailed.Lang)
 }
 
+func TestPackUserDetailed_MoveFields(t *testing.T) {
+	fetched := time.Date(2026, 5, 25, 1, 2, 3, 0, time.UTC)
+	movedURI := "https://remote.example/users/moved"
+	aka := "https://a.example/users/x,https://b.example/users/y"
+	u := &model.User{
+		ID:            "user_move",
+		Username:      "mover",
+		LastFetchedAt: &fetched,
+		MovedToURI:    &movedURI,
+		AlsoKnownAs:   &aka,
+	}
+
+	d := PackUserDetailed(u, nil)
+
+	// lastFetchedAt は ISO8601(ms) で埋まる。
+	require.NotNil(t, d.LastFetchedAt)
+	assert.Equal(t, "2026-05-25T01:02:03.000Z", *d.LastFetchedAt)
+
+	// movedTo / alsoKnownAs は URI→ID 解決を要するため pure packer では null。
+	// (upstream の解決不能時 fallback と同じ。完全解決は follow-up)
+	assert.Nil(t, d.MovedTo)
+	assert.Nil(t, d.AlsoKnownAs)
+
+	// JSON 上は 3 field とも present で、movedTo / alsoKnownAs / (未取得時の)
+	// lastFetchedAt は null になる (golden: string|null / string[]|null)。
+	b, err := json.Marshal(d)
+	require.NoError(t, err)
+	var m map[string]any
+	require.NoError(t, json.Unmarshal(b, &m))
+	for _, k := range []string{"movedTo", "alsoKnownAs", "lastFetchedAt"} {
+		_, present := m[k]
+		assert.Truef(t, present, "%q must be present in JSON", k)
+	}
+	assert.Nil(t, m["movedTo"])
+	assert.Nil(t, m["alsoKnownAs"])
+	assert.Equal(t, "2026-05-25T01:02:03.000Z", m["lastFetchedAt"])
+}
+
+func TestPackUserDetailed_LastFetchedAtNil(t *testing.T) {
+	u := &model.User{ID: "u_local", Username: "local"}
+	d := PackUserDetailed(u, nil)
+	assert.Nil(t, d.LastFetchedAt, "local user without lastFetchedAt -> null")
+}
+
 func TestPackUserDetailed_ProfileVisibility(t *testing.T) {
 	u := &model.User{
 		ID:                "user5",

--- a/internal/entitycompat/testdata/allowlist.json
+++ b/internal/entitycompat/testdata/allowlist.json
@@ -1,24 +1,6 @@
 [
   {
     "layer": "UserDetailed",
-    "field": "movedTo",
-    "kind": "missing",
-    "reason": "baseline: account-migration field absent from entity.UserDetailed struct (only model has the column). Backlog: add movedTo to the packed UserDetailed shape."
-  },
-  {
-    "layer": "UserDetailed",
-    "field": "alsoKnownAs",
-    "kind": "missing",
-    "reason": "baseline: account-migration field absent from entity.UserDetailed struct. Backlog: add alsoKnownAs to the packed shape."
-  },
-  {
-    "layer": "UserDetailed",
-    "field": "lastFetchedAt",
-    "kind": "missing",
-    "reason": "baseline: remote-fetch timestamp absent from entity.UserDetailed struct. Backlog: add lastFetchedAt to the packed shape."
-  },
-  {
-    "layer": "UserDetailed",
     "field": "memo",
     "kind": "omit",
     "reason": "baseline: golden declares memo as required (string | null); mk-go uses omitempty. Backlog: emit null instead of omitting."

--- a/internal/server/router.go
+++ b/internal/server/router.go
@@ -1240,6 +1240,7 @@ func (s *Server) setupRoutes() {
 	// Account endpoints
 	registryRepo := repository.NewRegistryRepository(s.db)
 	iHandler := i.NewHandler(userService, idGen)
+	iHandler.SetUserRepo(userRepo)
 	iHandler.SetRoleProvider(roleService)
 	iHandler.SetTOTPReplayGuard(totpReplayGuard)
 	iHandler.SetRegistryRepo(registryRepo)


### PR DESCRIPTION
## Summary

shape drift gate (#1253) の baseline allowlist にあった `UserDetailed` の HIGH ドリフト 3 件 (`movedTo` / `alsoKnownAs` / `lastFetchedAt`) を解消し、さらに `movedTo` / `alsoKnownAs` を upstream 同等に **URI→ローカルID 解決**して埋める。

ドリフト → 構造体修正 → allowlist の stale エントリ削除、という gate の burn-down サイクルの初実例。

## 主な変更点

### shape 追加
- `entity.UserDetailed` に `movedTo` (string|null) / `alsoKnownAs` (string[]|null) / `lastFetchedAt` (string|null) を追加。
- `lastFetchedAt`: `model.User.LastFetchedAt` から ISO8601(ms) で完全実装。
- `/api/i` の override 撤去 (旧実装は `alsoKnownAs` を comma-joined string で出して golden 非互換だった)。
- shape drift allowlist から 3 件削除 (gate の stale 検出で削除を強制)。

### URI→ID 解決 (#1255, レビュー指摘対応)
- `entity.MoveTargetResolver` 型 + `(*UserDetailed).ResolveMoveTargets` を追加。`PackUserDetailed` は 30 caller で signature を変えられないため、relation の `EnsureRelationFlags` と同じ **handler-enrich** パターンで pack 後に解決する。
- 解決は `repository.FindByURI` による **ローカル DB lookup のみ** (remote fetch しない)。未知 URI は null = upstream の `resolvePerson(...).catch(()=>null)` と同じ。SSRF / レイテンシ懸念なし。
- 配線: `users/show` (単一ユーザー) と `/api/i` (self) で enrich。list path (followers 等) は N+1 を避けるため null のまま (move banner は profile でのみ表示)。

## テスト
- `TestPackUserDetailed_MoveFields` / `_LastFetchedAtNil`: pure packer の shape (lastFetchedAt ISO、movedTo/alsoKnownAs null、JSON present)。
- `TestResolveMoveTargets` / `_NilAndUnresolvable`: known→ID 解決、unknown 除外、空白 trim、nil-safe、全解決不能→null。
- `make shapecheck` (L0+L2) green。entity 95.4%、race + atomic、build/vet/fmt clean。`/api/i` 既存テストも green。

## Closes

Closes #1256
Closes #1255

🤖 Generated with [Claude Code](https://claude.com/claude-code)