### PR TITLE
fix(users): UserDetailed.memo の omitempty を解消 (policies は intentional 再分類)

### DIFF
--- a/internal/entity/user.go
+++ b/internal/entity/user.go
@@ -118,11 +118,12 @@ type UserDetailed struct {
 	Notify                         *string `json:"notify,omitempty"`
 	WithReplies                    *bool   `json:"withReplies,omitempty"`
 	// Memo は viewer 自身が target に付けたメモ。golden UserDetailedNotMeOnly は
-	// `memo: string | null` (必須・null 許容) なので、上の relation bool 群と違い
-	// omitempty を付けず未設定時は null を出す。#1228 の null-cast crash は非 null
-	// bool (`isFollowing as bool`) の話で、nullable string の memo には当てはまらない。
-	// self-view (MeDetailed) では golden に memo が無いが、extra な memo:null は
-	// クライアントが無視するので無害。
+	// `memo: string | null` (必須・null 許容)。MeDetailed も合成型
+	// `UserLite & UserDetailedNotMeOnly & MeDetailedOnly` で memo を含むため、
+	// not-me / self どちらの view でも memo は present 必須。よって上の relation
+	// bool 群 (golden optional) と違い omitempty を付けず、未設定時は null を出す。
+	// #1228 の null-cast crash は非 null bool (`isFollowing as bool`) の話で、
+	// nullable string の memo には当てはまらない。
 	Memo *string `json:"memo"`
 }
 

--- a/internal/entity/user.go
+++ b/internal/entity/user.go
@@ -117,7 +117,13 @@ type UserDetailed struct {
 	HasPendingFollowRequestToYou   *bool   `json:"hasPendingFollowRequestToYou,omitempty"`
 	Notify                         *string `json:"notify,omitempty"`
 	WithReplies                    *bool   `json:"withReplies,omitempty"`
-	Memo                           *string `json:"memo,omitempty"`
+	// Memo は viewer 自身が target に付けたメモ。golden UserDetailedNotMeOnly は
+	// `memo: string | null` (必須・null 許容) なので、上の relation bool 群と違い
+	// omitempty を付けず未設定時は null を出す。#1228 の null-cast crash は非 null
+	// bool (`isFollowing as bool`) の話で、nullable string の memo には当てはまらない。
+	// self-view (MeDetailed) では golden に memo が無いが、extra な memo:null は
+	// クライアントが無視するので無害。
+	Memo *string `json:"memo"`
 }
 
 // MeDetailed extends UserDetailed with fields that upstream Misskey TS

--- a/internal/entity/user_test.go
+++ b/internal/entity/user_test.go
@@ -217,6 +217,27 @@ func TestResolveMoveTargets_NilAndUnresolvable(t *testing.T) {
 	assert.Nil(t, d2.AlsoKnownAs, "all-unresolvable alsoKnownAs stays null, not []")
 }
 
+func TestPackUserDetailed_MemoNullNotOmitted(t *testing.T) {
+	u := &model.User{ID: "u_memo", Username: "memo"}
+	d := PackUserDetailed(u, nil)
+	b, err := json.Marshal(d)
+	require.NoError(t, err)
+	var m map[string]any
+	require.NoError(t, json.Unmarshal(b, &m))
+
+	// memo は golden で required(string|null)なので、未設定でも present かつ null。
+	v, present := m["memo"]
+	assert.True(t, present, "memo must be present (golden: string|null required)")
+	assert.Nil(t, v, "memo is null when the viewer has no memo")
+
+	// 一方 relation bool 群は golden optional なので未設定なら omit のまま
+	// (null を出すと misskey_dart が `as bool` で crash する #1228)。
+	for _, k := range []string{"isFollowing", "isFollowed", "isMuted", "withReplies"} {
+		_, p := m[k]
+		assert.Falsef(t, p, "%q must stay omitempty (golden optional)", k)
+	}
+}
+
 func TestPackUserDetailed_ProfileVisibility(t *testing.T) {
 	u := &model.User{
 		ID:                "user5",

--- a/internal/entitycompat/testdata/allowlist.json
+++ b/internal/entitycompat/testdata/allowlist.json
@@ -1,11 +1,5 @@
 [
   {
-    "layer": "UserDetailed",
-    "field": "memo",
-    "kind": "omit",
-    "reason": "baseline: golden declares memo as required (string | null); mk-go uses omitempty. Backlog: emit null instead of omitting."
-  },
-  {
     "layer": "MeDetailed",
     "field": "hardMutedWords",
     "kind": "missing",
@@ -39,6 +33,6 @@
     "layer": "MeDetailed",
     "field": "policies",
     "kind": "omit",
-    "reason": "baseline: golden requires policies; mk-go emits with omitempty (#1242 fixed users/show path at handler level). Backlog: make the struct field non-omitempty."
+    "reason": "intentional: omitempty は load-bearing。PackMeDetailed を override 無しで返す i/update / meUpdated 経路で nil を null として出すと frontend の updateCurrentAccountPartial が $i.policies を null/空で上書きして policy 判定が壊れる (#1240)。実 read path (/api/i, users/show self) は handler が DefaultPolicies() で必ず埋める。"
   }
 ]


### PR DESCRIPTION
## Summary

shape drift gate (#1253) の baseline allowlist にあった MED(omit)2 件を精査し、`memo` を burn down、load-bearing な `policies` は intentional として整理する。

## 主な変更点

### `UserDetailed.memo` — omitempty 解消 (burn down)
- golden `UserDetailedNotMeOnly` は `memo: string | null` (**必須・null 許容**)。mk-go は relation bool 群と同じ omitempty block に置いて未設定時に**省略**していた → golden 非互換。
- `MeDetailed` も合成型 `UserLite & UserDetailedNotMeOnly & MeDetailedOnly` で memo を含むため、**not-me / self どちらの view でも memo は present 必須**。よって omitempty を外し未設定時は `null` を出す (self-view の memo:null も golden 準拠で正しい)。
- relation bool の omitempty は #1228 の `isFollowing as bool` (非 null bool cast) crash 回避が理由で、**nullable string の memo には該当しない**。

### `MeDetailed.policies` — intentional に再分類 (据え置き)
- policies の omitempty は **load-bearing**: PackMeDetailed を override 無しで返す `i/update` / `meUpdated` 経路で nil を `null` で出すと frontend の `updateCurrentAccountPartial` が `$i.policies` を壊す (#1240)。よって burn down せず allowlist 理由を「intentional」に訂正。実 read path は handler が `DefaultPolicies()` で必ず埋める。

### allowlist
- `memo` を削除 (gate の stale 検出が削除を強制)、`policies` の理由を intentional に更新。

## テスト
- `TestPackUserDetailed_MemoNullNotOmitted`: memo は present かつ null、relation bool は omit 維持 (両者の差を regression guard で固定)。
- `make shapecheck` (L0+L2) green。entity 95.4%、`/api/i` / `users` 既存テストも green。

## Closes
Closes #1258

🤖 Generated with [Claude Code](https://claude.com/claude-code)