### PR TITLE
fix(i): MeDetailed の HIGH 5 field を struct へ統一 (meUpdated clobber 回避込み)

### DIFF
--- a/internal/api/i/handler.go
+++ b/internal/api/i/handler.go
@@ -645,14 +645,13 @@ func (h *Handler) Me(c echo.Context) error {
 		resp["twoFactorEnabled"] = profile.TwoFactorEnabled
 		resp["usePasswordLessLogin"] = profile.UsePasswordLessLogin
 		resp["mutedWords"] = profile.MutedWords
-		resp["hardMutedWords"] = profile.HardMutedWords
 		resp["mutedInstances"] = profile.MutedInstances
 		resp["publicReactions"] = profile.PublicReactions
 		resp["loggedInDays"] = len(profile.LoggedInDates)
 		resp["achievements"] = jsonbArray(profile.Achievements)
 		resp["securityKeys"] = profile.SecurityKeysAvailable
-		// twoFactorBackupCodesStock: full/partial/none
-		resp["twoFactorBackupCodesStock"] = backupCodesStock(profile)
+		// hardMutedWords / twoFactorBackupCodesStock は PackMeDetailed (AsMeDetailed)
+		// が profile から正しい shape で乗せるので override 不要 (#1258 follow-up)。
 		// clientData / room は jsonb を生のまま返すと frontend (本家) が
 		// オブジェクトとして parse するため、空/不正時は空オブジェクトに
 		// 正規化する。user が手動でキーを書き換えるだけなので scheme は持たない。
@@ -831,16 +830,20 @@ func jsonbArray(raw []byte) any {
 	return out
 }
 
-// backupCodesStock returns "full", "partial", or "none" based on the number of
-// remaining 2FA backup codes. Misskey uses 5 codes as the full set.
-func backupCodesStock(profile *model.UserProfile) string {
-	if !profile.TwoFactorEnabled || len(profile.TwoFactorBackupSecret) == 0 {
-		return "none"
-	}
-	if len(profile.TwoFactorBackupSecret) >= 5 {
-		return "full"
-	}
-	return "partial"
+// meDetailedWithUnread packs a MeDetailed for self-view stream/return paths
+// (i/update, meUpdated) and enriches it with authoritative unread values via
+// fillUnreadFields. Raw PackMeDetailed would emit the struct defaults
+// (unreadNotificationsCount:0 / unreadAnnouncements:[] / hasUnread*:false),
+// which the frontend's updateCurrentAccountPartial would merge into `$i`,
+// clobbering the real badge/unread state. Going through fillUnreadFields keeps
+// those fields correct on every path (the same shape /api/i returns).
+func (h *Handler) meDetailedWithUnread(ctx context.Context, u *model.User, profile *model.UserProfile) map[string]any {
+	me := entity.PackMeDetailed(u, profile, h.idGen)
+	b, _ := json.Marshal(me)
+	resp := map[string]any{}
+	_ = json.Unmarshal(b, &resp)
+	h.fillUnreadFields(ctx, u, resp)
+	return resp
 }
 
 // countMuteWords returns the total number of entries in a muted-words
@@ -1128,7 +1131,9 @@ func (h *Handler) Update(c echo.Context) error {
 	// updateCurrentAccountPartial にそのまま流し込まれるため、isExplorable /
 	// noCrawle / preventAiLearning など self-view-only field が UserDetailed
 	// 側に無いと session の `$i` が更新されず stale なまま残る (#968)。
-	return c.JSON(http.StatusOK, entity.PackMeDetailed(bundle.User, bundle.Profile, h.idGen))
+	// unread 系は meDetailedWithUnread で実値を埋める。生 PackMeDetailed だと
+	// unreadNotificationsCount:0 等の default が `$i` を clobber する (#1258 fu)。
+	return c.JSON(http.StatusOK, h.meDetailedWithUnread(c.Request().Context(), bundle.User, bundle.Profile))
 }
 
 // avatarDecorationAPIError carries a (status, body) pair from

--- a/internal/api/i/handler_2fa.go
+++ b/internal/api/i/handler_2fa.go
@@ -12,7 +12,6 @@ import (
 	"github.com/lib/pq"
 	"github.com/shiroha-a/mk/internal/api/apierr"
 	"github.com/shiroha-a/mk/internal/core/twofactor"
-	"github.com/shiroha-a/mk/internal/entity"
 	"github.com/shiroha-a/mk/internal/model"
 	"github.com/shiroha-a/mk/internal/server/middleware"
 	"golang.org/x/crypto/bcrypt"
@@ -377,7 +376,10 @@ func (h *Handler) publishMeUpdated(userID string) {
 		slog.Warn("2fa: meUpdated: load user failed", "userId", userID, "err", err)
 		return
 	}
-	packed := entity.PackMeDetailed(bundle.User, bundle.Profile, h.idGen)
+	// 生 PackMeDetailed だと unread 系が default (0/[]/false) で出て、frontend の
+	// updateCurrentAccountPartial が `$i` の実 unread 状態を clobber する。
+	// meDetailedWithUnread で fillUnreadFields を通して実値を送る (#1258 fu)。
+	packed := h.meDetailedWithUnread(context.Background(), bundle.User, bundle.Profile)
 	h.mainStreamPublisher.PublishMainEvent(userID, "meUpdated", packed)
 }
 

--- a/internal/api/i/handler_webauthn_test.go
+++ b/internal/api/i/handler_webauthn_test.go
@@ -536,6 +536,11 @@ func TestPublishMeUpdated_FullPublishWhenWired(t *testing.T) {
 	assert.Contains(t, body, "avatarId")
 	// unread enrich 経路を通っていること (clobber 回避の要)。
 	assert.Contains(t, body, "unreadNotificationsCount")
+	// #1240 不変条件: meUpdated は policies を **含めない** (含めると frontend の
+	// updateCurrentAccountPartial が $i.policies を null/空で clobber する)。
+	// meDetailedWithUnread は PackMeDetailed の omitempty を round-trip で維持する
+	// が、これは繊細なので回帰ガードとして固定する。
+	assert.NotContains(t, body, "policies", "meUpdated は policies を含めてはいけない (#1240)")
 }
 
 // publishMeUpdated: 存在しない userID は ShowByID で err → publish せず

--- a/internal/api/i/handler_webauthn_test.go
+++ b/internal/api/i/handler_webauthn_test.go
@@ -11,7 +11,6 @@ import (
 	"github.com/lib/pq"
 	"github.com/pquerna/otp/totp"
 	"github.com/shiroha-a/mk/internal/core/twofactor"
-	"github.com/shiroha-a/mk/internal/entity"
 	"github.com/shiroha-a/mk/internal/model"
 	"github.com/shiroha-a/mk/internal/repository"
 	"github.com/shiroha-a/mk/internal/testutil"
@@ -510,10 +509,10 @@ func TestPublishMeUpdatedPartial_EmptyFieldsIsNoop(t *testing.T) {
 // publishMeUpdated (full MeDetailed): publisher が wire されていれば
 // userService.ShowByID 経由で User+Profile を packed publish する。
 // payload は upstream Misskey TS と同じ MeDetailed shape (#968)。
-// UserDetailed shape に戻る regression を catch するため、body の型が
-// entity.MeDetailed であることと UserLite 由来 field が embed 経由で
-// live であることを assert する。MeDetailed 拡張 field 11 個自体の
-// transfer は entity 側の TestPackMeDetailed_* でカバー済み。
+// UserDetailed shape に戻る regression を catch するため、enriched map が
+// MeDetailed 専用 key (avatarId) と unread field を持つことを assert する。
+// MeDetailed 拡張 field 自体の transfer は entity 側の TestPackMeDetailed_*
+// でカバー済み。
 func TestPublishMeUpdated_FullPublishWhenWired(t *testing.T) {
 	h, repo, _ := newWebAuthnHandler(t)
 	setupUserWithPassword(repo, "u1", "pass")
@@ -526,10 +525,17 @@ func TestPublishMeUpdated_FullPublishWhenWired(t *testing.T) {
 	assert.Equal(t, "meUpdated", pub.calls[0].eventType)
 	require.NotNil(t, pub.calls[0].body)
 
-	me, ok := pub.calls[0].body.(entity.MeDetailed)
-	require.True(t, ok, "publishMeUpdated body は MeDetailed であるべき (UserDetailed shape に戻る regression)")
+	// #1258 fu: meUpdated は meDetailedWithUnread 経由で enrich した map を送る
+	// (raw struct だと unread が default で出て $i を clobber する)。
+	body, ok := pub.calls[0].body.(map[string]any)
+	require.True(t, ok, "publishMeUpdated body は enriched MeDetailed map であるべき")
 	// embed が壊れていないことの sanity check (UserLite 由来 field)。
-	assert.Equal(t, "u1", me.ID)
+	assert.Equal(t, "u1", body["id"])
+	// MeDetailed shape である確認 (UserDetailed shape に戻る regression catch):
+	// avatarId は MeDetailed 専用 key。
+	assert.Contains(t, body, "avatarId")
+	// unread enrich 経路を通っていること (clobber 回避の要)。
+	assert.Contains(t, body, "unreadNotificationsCount")
 }
 
 // publishMeUpdated: 存在しない userID は ShowByID で err → publish せず

--- a/internal/entity/user.go
+++ b/internal/entity/user.go
@@ -172,6 +172,14 @@ type MeDetailed struct {
 	HasUnreadChannel                bool `json:"hasUnreadChannel"`
 	HasUnreadSpecifiedNotes         bool `json:"hasUnreadSpecifiedNotes"`
 	HasPendingReceivedFollowRequest bool `json:"hasPendingReceivedFollowRequest"`
+	HasUnreadChatMessages           bool `json:"hasUnreadChatMessages"`
+	// UnreadNotificationsCount は未読通知件数。bool フラグ同様 users/show では
+	// best-effort 0 で、権威値は /api/i / i/update / meUpdated 経由 (fillUnreadFields
+	// が実値で埋める)。
+	UnreadNotificationsCount int `json:"unreadNotificationsCount"`
+	// TwoFactorBackupCodesStock は 2FA バックアップコード残量 (full/partial/none)。
+	// profile 由来なので AsMeDetailed が計算し全 view で正しい値になる (clobber 無し)。
+	TwoFactorBackupCodesStock string `json:"twoFactorBackupCodesStock"`
 	// 以下も misskey_dart の MeDetailed.fromJson が非null List / num / Map と
 	// して cast するため self-view でも必ず値を出す (#1240)。MutedWords /
 	// MutedInstances / Achievements / LoggedInDays は profile 由来で正確に、
@@ -181,6 +189,11 @@ type MeDetailed struct {
 	MutedInstances []string `json:"mutedInstances"`
 	Achievements   []any    `json:"achievements"`
 	LoggedInDays   int      `json:"loggedInDays"`
+	// HardMutedWords は profile 由来 (string[][])。MutedWords と同様 jsonb から
+	// 展開する (毎 pack 正しい値)。UnreadAnnouncements は未読アナウンス配列で、
+	// users/show では best-effort [] / 権威値は fillUnreadFields。
+	HardMutedWords      []any `json:"hardMutedWords"`
+	UnreadAnnouncements []any `json:"unreadAnnouncements"`
 	// Policies は role 依存で AsMeDetailed (entity 層) では nil のまま。omitempty で
 	// 「未設定なら省略」にするのが重要 (#1240): PackMeDetailed を override 無しで
 	// 直接返す i/update / meUpdated 経路で nil を `null` として出すと frontend の
@@ -276,6 +289,12 @@ func AsMeDetailed(d UserDetailed, u *model.User, profile *model.UserProfile) MeD
 		MutedWords:     []any{},
 		MutedInstances: []string{},
 		Achievements:   []any{},
+		// HardMutedWords / TwoFactorBackupCodesStock は profile 由来なので下で
+		// 正確に埋める。UnreadAnnouncements は runtime 値で handler が上書きする
+		// (users/show は best-effort [])。いずれも非null 必須 (#1258 follow-up)。
+		HardMutedWords:            []any{},
+		UnreadAnnouncements:       []any{},
+		TwoFactorBackupCodesStock: "none",
 	}
 	if profile != nil {
 		out.NoCrawle = profile.NoCrawle
@@ -290,6 +309,9 @@ func AsMeDetailed(d UserDetailed, u *model.User, profile *model.UserProfile) MeD
 		out.TwoFactorEnabled = profile.TwoFactorEnabled
 		out.UsePasswordLessLogin = profile.UsePasswordLessLogin
 		out.SecurityKeys = profile.SecurityKeysAvailable
+		// twoFactorBackupCodesStock は profile 由来なので全 view で正しい値にする
+		// (handler override 不要 = meUpdated / i-update でも clobber しない)。
+		out.TwoFactorBackupCodesStock = backupCodesStock(profile)
 		// EmailNotificationTypes / NotificationRecieveConfig は jsonb カラム
 		// なので JSON unmarshal してから out にコピーする。parse error は
 		// default に倒す (silent — frontend は default で動作可能)。
@@ -307,6 +329,9 @@ func AsMeDetailed(d UserDetailed, u *model.User, profile *model.UserProfile) MeD
 		}
 		// mutedWords / mutedInstances / achievements は jsonb 配列。空でも
 		// null ではなく [] を保つ (#1240)。parse error も default の [] のまま。
+		if arr := unmarshalJSONAnySlice(profile.HardMutedWords); arr != nil {
+			out.HardMutedWords = arr
+		}
 		if arr := unmarshalJSONAnySlice(profile.MutedWords); arr != nil {
 			out.MutedWords = arr
 		}
@@ -466,6 +491,20 @@ func PackUserDetailed(u *model.User, profile *model.UserProfile, idGens ...id.Ge
 	}
 
 	return d
+}
+
+// backupCodesStock returns the 2FA backup-codes stock level. Mirrors upstream
+// UserEntityService: "none" when 2FA is off or no codes remain, "full" at >=5,
+// otherwise "partial". This is the single source of truth for the
+// twoFactorBackupCodesStock field across all self-view paths.
+func backupCodesStock(profile *model.UserProfile) string {
+	if !profile.TwoFactorEnabled || len(profile.TwoFactorBackupSecret) == 0 {
+		return "none"
+	}
+	if len(profile.TwoFactorBackupSecret) >= 5 {
+		return "full"
+	}
+	return "partial"
 }
 
 // MoveTargetResolver resolves an ActivityPub actor URI to a local user ID.

--- a/internal/entity/user_test.go
+++ b/internal/entity/user_test.go
@@ -699,6 +699,48 @@ func TestPackMeDetailed_ListFieldsEmptyAreNonNull(t *testing.T) {
 	assert.Equal(t, 0, me.LoggedInDays)
 }
 
+// #1258 fu: MeDetailedOnly の HIGH 5 field が struct から非null で出ること。
+func TestPackMeDetailed_MeDetailedOnlyHighFields(t *testing.T) {
+	u := &model.User{ID: "me_high", Username: "high", AvatarDecorations: datatypes.JSON([]byte("[]"))}
+
+	// nil profile -> 非null default (users/show self の best-effort と同じ)。
+	me := PackMeDetailed(u, nil)
+	assert.Equal(t, []any{}, me.UnreadAnnouncements)
+	assert.Equal(t, []any{}, me.HardMutedWords)
+	assert.False(t, me.HasUnreadChatMessages)
+	assert.Equal(t, 0, me.UnreadNotificationsCount)
+	assert.Equal(t, "none", me.TwoFactorBackupCodesStock)
+
+	// JSON 上 5 field とも present (golden MeDetailedOnly は全て required)。
+	b, err := json.Marshal(me)
+	require.NoError(t, err)
+	for _, k := range []string{"unreadAnnouncements", "hardMutedWords", "hasUnreadChatMessages", "unreadNotificationsCount", "twoFactorBackupCodesStock"} {
+		assert.Containsf(t, string(b), `"`+k+`"`, "%s must be present", k)
+	}
+}
+
+// #1258 fu: profile 由来の hardMutedWords / twoFactorBackupCodesStock は
+// AsMeDetailed が正しく計算する (= meUpdated/i-update でも clobber しない)。
+func TestPackMeDetailed_ProfileDerivedHighFields(t *testing.T) {
+	u := &model.User{ID: "me_pd", Username: "pd", AvatarDecorations: datatypes.JSON([]byte("[]"))}
+	profile := &model.UserProfile{
+		UserID:                "me_pd",
+		Fields:                datatypes.JSON([]byte("[]")),
+		HardMutedWords:        datatypes.JSON([]byte(`[["foo","bar"],["baz"]]`)),
+		TwoFactorEnabled:      true,
+		TwoFactorBackupSecret: pq.StringArray{"a", "b"}, // 2 codes -> partial
+	}
+	me := PackMeDetailed(u, profile)
+	assert.Len(t, me.HardMutedWords, 2, "hardMutedWords は jsonb から展開")
+	assert.Equal(t, "partial", me.TwoFactorBackupCodesStock)
+
+	profile.TwoFactorBackupSecret = pq.StringArray{"a", "b", "c", "d", "e"} // >=5 -> full
+	assert.Equal(t, "full", PackMeDetailed(u, profile).TwoFactorBackupCodesStock)
+
+	profile.TwoFactorEnabled = false // 2FA off -> none
+	assert.Equal(t, "none", PackMeDetailed(u, profile).TwoFactorBackupCodesStock)
+}
+
 // #1240: PackMeDetailed 単体 (policies override 無し) は policies を **出さない**
 // こと。i/update / meUpdated はこれを直接 frontend の updateCurrentAccountPartial
 // に流すため、`policies:null` を出すと `$i.policies` を null 上書きして policy

--- a/internal/entitycompat/testdata/allowlist.json
+++ b/internal/entitycompat/testdata/allowlist.json
@@ -1,36 +1,6 @@
 [
   {
     "layer": "MeDetailed",
-    "field": "hardMutedWords",
-    "kind": "missing",
-    "reason": "baseline: populated ad-hoc in /api/i handler map but absent from entity.MeDetailed struct, so struct-based self-view paths (users/show) drift. Backlog: move into the struct."
-  },
-  {
-    "layer": "MeDetailed",
-    "field": "hasUnreadChatMessages",
-    "kind": "missing",
-    "reason": "baseline: populated ad-hoc in /api/i handler map but absent from entity.MeDetailed struct. Backlog: move into the struct."
-  },
-  {
-    "layer": "MeDetailed",
-    "field": "twoFactorBackupCodesStock",
-    "kind": "missing",
-    "reason": "baseline: populated ad-hoc in /api/i handler map but absent from entity.MeDetailed struct. Backlog: move into the struct."
-  },
-  {
-    "layer": "MeDetailed",
-    "field": "unreadAnnouncements",
-    "kind": "missing",
-    "reason": "baseline: populated ad-hoc in /api/i handler map (#1226) but absent from entity.MeDetailed struct. Backlog: move into the struct."
-  },
-  {
-    "layer": "MeDetailed",
-    "field": "unreadNotificationsCount",
-    "kind": "missing",
-    "reason": "baseline: populated ad-hoc in /api/i handler map but absent from entity.MeDetailed struct. Backlog: move into the struct."
-  },
-  {
-    "layer": "MeDetailed",
     "field": "policies",
     "kind": "omit",
     "reason": "intentional: omitempty は load-bearing。PackMeDetailed を override 無しで返す i/update / meUpdated 経路で nil を null として出すと frontend の updateCurrentAccountPartial が $i.policies を null/空で上書きして policy 判定が壊れる (#1240)。実 read path (/api/i, users/show self) は handler が DefaultPolicies() で必ず埋める。"


### PR DESCRIPTION
## Summary

shape drift gate (#1253) の baseline allowlist に残っていた **MeDetailed の HIGH(missing)5 件**を一括で解消する: `unreadAnnouncements` / `hardMutedWords` / `hasUnreadChatMessages` / `unreadNotificationsCount` / `twoFactorBackupCodesStock`。これらは `/api/i` の resp map にアドホックに足されるだけで `entity.MeDetailed` struct に無く、struct 経由の self-view (users/show self) で欠落していた (golden `MeDetailedOnly` は全て required)。

allowlist の HIGH backlog の本丸。

## 設計の肝 — meUpdated clobber の回避

`publishMeUpdated` / `i/update` は生 `PackMeDetailed` を frontend の `updateCurrentAccountPartial` に流す。runtime unread 系を struct に default 値 (0/[]/false) で足すと、これらの経路で `$i` の実 unread 状態 (通知バッジ等) を **clobber** する — `policies` が #1240 で omitempty を維持したのと同じ罠。

フィールドを 2 種に分けて対処:

| 種別 | field | 対処 |
|---|---|---|
| **profile 由来** | `hardMutedWords` / `twoFactorBackupCodesStock` | AsMeDetailed が profile から計算 → 全 view で正値 (clobber 無し) |
| **runtime 由来** | `unreadAnnouncements` / `hasUnreadChatMessages` / `unreadNotificationsCount` | struct は非null default。`/api/i` は既存 `fillUnreadFields`、`i/update` / `publishMeUpdated` も新 `meDetailedWithUnread` (fillUnreadFields 経由) で**実値**を送る |

副次効果: 既存 `HasUnread*` bool も i/update/meUpdated で default false が出ていた (latent clobber) が、これも実値化されて解消。

## 主な変更点
- `entity.MeDetailed` に 5 field 追加 + AsMeDetailed で profile 2 件計算・非null default。
- `backupCodesStock` を **entity に単一ソース化**。`/api/i` の重複 func と hardMutedWords/twoFactorBackupCodesStock の resp override を削除 (struct が唯一のソース → drift 防止)。
- `meDetailedWithUnread` ヘルパで `i/update` / `publishMeUpdated` を実値送出に。
- allowlist から 5 件削除 (gate の stale 検出が削除を強制)。

## テスト
- entity: `TestPackMeDetailed_MeDetailedOnlyHighFields` (非null default + JSON present)、`TestPackMeDetailed_ProfileDerivedHighFields` (partial/full/none, hardMutedWords 展開)。
- i: `TestPublishMeUpdated_FullPublishWhenWired` を enriched map (avatarId + unreadNotificationsCount 含む) を送る形に更新。
- `make shapecheck` (L0+L2) green。entity 95.4% / api/i 90.6%、race + atomic、`go vet ./...` / fmt clean。

## Closes
Closes #1260

## その他
- 残る allowlist は `MeDetailed.policies` (intentional / load-bearing omitempty) と Notification `pollVote`・`importCompleted` (mk-go 独自拡張) のみ。User family の HIGH/MED backlog はこれで解消。

🤖 Generated with [Claude Code](https://claude.com/claude-code)