### PR TITLE
feat(entitycompat): L2 を flat map-based packer (Announcement) へ拡張

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -445,5 +445,6 @@ shapecheck-report:
 	go run ./tools/shapediff -report
 
 # drift gate (L0 静的 + L2 実行時) をローカルで実行する (CI と同じ判定)。
+# L0: TestEntityShapeDrift / L2: Test*ShapeL2 (Notification / Announcement / ...)。
 shapecheck:
-	go test ./internal/entitycompat/... -run 'TestEntityShapeDrift|TestNotificationShapeL2' -count=1 -v
+	go test ./internal/entitycompat/... -run 'TestEntityShapeDrift|ShapeL2' -count=1 -v

--- a/docs/shape-drift.md
+++ b/docs/shape-drift.md
@@ -88,9 +88,18 @@ L2は**packerが実際に出力したJSON値**を契約に突き合わせてこ�
 | ファイル | 役割 |
 |---|---|
 | `internal/entitycompat/runtime.go` | union parser(`ParseUnion`)+ 実行時validator(`ValidateValue` / `ValidateUnionValue`) |
-| `internal/entitycompat/runtime_test.go` | `TestNotificationShapeL2`(実packer出力を検証)+ 単体テスト |
+| `internal/entitycompat/runtime_test.go` | `Test*ShapeL2`(実packer出力を検証)+ 単体テスト |
 | `testdata/golden_unions.json` | union契約のスナップショット(type literal別variant、commit対象) |
 | `testdata/allowlist_l2.json` | L2 baseline backlog |
+
+### 対象packer
+
+L2は2種の検証関数を持つ:
+
+- **`ValidateUnionValue`**: discriminated union(`Notification`)を`type`でvariant dispatchして検証。`UnionSchemaNames()`が対象。
+- **`ValidateValue`**: flatなmap-based packer(`Announcement`等)を golden flat schema に対して検証。`L2FlatSchemaNames()`が対象。golden schemaは`golden_schemas.json`に同居(L0と同じflat形式)。
+
+map-based packer(`map[string]any`を手組みするもの)はL0のreflectionが届かないため、L2で実出力を検証する。新しいmap-based packerを守りたいときは`L2FlatSchemaNames()`にgolden schema名を足し、fixtureで`Test*ShapeL2`を書く。
 
 ### ValidateUnionValue の判定
 

--- a/internal/entitycompat/runtime.go
+++ b/internal/entitycompat/runtime.go
@@ -19,6 +19,15 @@ func UnionSchemaNames() []string {
 	return []string{"Notification"}
 }
 
+// L2FlatSchemaNames lists flat (non-union) golden schemas that are validated at
+// Layer 2 against a map-based packer's runtime output. These entities are
+// packed as map[string]any (not reflectable structs), so Layer 0 cannot reach
+// them; the generator still extracts their flat golden schema into the snapshot
+// for ValidateValue to use.
+func L2FlatSchemaNames() []string {
+	return []string{"Announcement"}
+}
+
 // ParseUnion parses a discriminated-union schema (variants joined by `} | {`)
 // into a map keyed by each variant's `type` string literal. Variants without a
 // `type` discriminator are skipped.

--- a/internal/entitycompat/runtime_test.go
+++ b/internal/entitycompat/runtime_test.go
@@ -180,6 +180,37 @@ func notifFixture(typ notification.Type, withUser, withNote bool, extra map[stri
 	return entity.PackNotification(n, user, note, idGen, nil, nil)
 }
 
+// TestAnnouncementShapeL2 validates the actual PackAnnouncement map output
+// against the golden Announcement schema. Announcement is packed as
+// map[string]any (not a reflectable struct), so this is the L2 runtime check
+// for that map-based packer (#1224 history: createdAt non-null cast crash).
+func TestAnnouncementShapeL2(t *testing.T) {
+	golden, err := LoadGoldenSnapshot(filepath.Join("testdata", "golden_schemas.json"))
+	if err != nil {
+		t.Fatalf("load golden: %v", err)
+	}
+	schema, ok := golden["Announcement"]
+	if !ok || len(schema) == 0 {
+		t.Fatal("Announcement schema missing/empty in golden snapshot; run `go run ./tools/shapediff`")
+	}
+
+	idGen, _ := id.NewGenerator("aidx")
+	a := &model.Announcement{
+		ID:      idGen.Generate(time.Now()),
+		Title:   "maintenance",
+		Text:    "we will be down",
+		Icon:    "info",
+		Display: "normal",
+	}
+	out := entity.PackAnnouncement(a, idGen, false)
+
+	for _, f := range ValidateValue("Announcement", "Announcement", "Announcement", out, schema) {
+		if f.Sev == SevHigh || f.Sev == SevMed {
+			t.Errorf("Announcement shape drift: %s [%s]: %s", f.Field, f.Kind, f.Detail)
+		}
+	}
+}
+
 // TestNotificationShapeL2 validates actual PackNotification map output against
 // the golden Notification union — the map-based, discriminated-union surface
 // that the Layer 0 reflection gate cannot reach.

--- a/internal/entitycompat/runtime_test.go
+++ b/internal/entitycompat/runtime_test.go
@@ -195,18 +195,30 @@ func TestAnnouncementShapeL2(t *testing.T) {
 	}
 
 	idGen, _ := id.NewGenerator("aidx")
-	a := &model.Announcement{
-		ID:      idGen.Generate(time.Now()),
-		Title:   "maintenance",
-		Text:    "we will be down",
-		Icon:    "info",
-		Display: "normal",
+	img := "https://example.com/a.png"
+	updated := time.Date(2026, 5, 26, 1, 0, 0, 0, time.UTC)
+	uid := "u_author"
+	cases := map[string]*model.Announcement{
+		// nullable 欄 (imageUrl/updatedAt) 未設定 -> null path。
+		"minimal": {
+			ID: idGen.Generate(time.Now()), Title: "maintenance", Text: "down",
+			Icon: "info", Display: "normal",
+		},
+		// nullable 欄に値あり -> 非null string pass-through path (scalarMismatch を
+		// 実際に効かせる) + forYou=true (UserID 設定)。
+		"populated": {
+			ID: idGen.Generate(time.Now()), Title: "t", Text: "x", Icon: "info",
+			Display: "banner", ImageURL: &img, UpdatedAt: &updated, UserID: &uid,
+			NeedConfirmationToRead: true, Silence: true,
+		},
 	}
-	out := entity.PackAnnouncement(a, idGen, false)
 
-	for _, f := range ValidateValue("Announcement", "Announcement", "Announcement", out, schema) {
-		if f.Sev == SevHigh || f.Sev == SevMed {
-			t.Errorf("Announcement shape drift: %s [%s]: %s", f.Field, f.Kind, f.Detail)
+	for name, a := range cases {
+		out := entity.PackAnnouncement(a, idGen, true)
+		for _, f := range ValidateValue("Announcement", "Announcement", "Announcement", out, schema) {
+			if f.Sev == SevHigh || f.Sev == SevMed {
+				t.Errorf("[%s] Announcement shape drift: %s [%s]: %s", name, f.Field, f.Kind, f.Detail)
+			}
 		}
 	}
 }

--- a/internal/entitycompat/testdata/golden_schemas.json
+++ b/internal/entitycompat/testdata/golden_schemas.json
@@ -1,4 +1,66 @@
 {
+  "Announcement": {
+    "createdAt": {
+      "nullable": false,
+      "optional": false,
+      "type": "string"
+    },
+    "display": {
+      "nullable": false,
+      "optional": false,
+      "type": "string"
+    },
+    "forYou": {
+      "nullable": false,
+      "optional": false,
+      "type": "boolean"
+    },
+    "icon": {
+      "nullable": false,
+      "optional": false,
+      "type": "string"
+    },
+    "id": {
+      "nullable": false,
+      "optional": false,
+      "type": "string"
+    },
+    "imageUrl": {
+      "nullable": true,
+      "optional": false,
+      "type": "string"
+    },
+    "isRead": {
+      "nullable": false,
+      "optional": true,
+      "type": "boolean"
+    },
+    "needConfirmationToRead": {
+      "nullable": false,
+      "optional": false,
+      "type": "boolean"
+    },
+    "silence": {
+      "nullable": false,
+      "optional": false,
+      "type": "boolean"
+    },
+    "text": {
+      "nullable": false,
+      "optional": false,
+      "type": "string"
+    },
+    "title": {
+      "nullable": false,
+      "optional": false,
+      "type": "string"
+    },
+    "updatedAt": {
+      "nullable": true,
+      "optional": false,
+      "type": "string"
+    }
+  },
   "DriveFile": {
     "blurhash": {
       "nullable": true,

--- a/tools/shapediff/main.go
+++ b/tools/shapediff/main.go
@@ -38,7 +38,9 @@ func main() {
 	}
 	lines := strings.Split(string(data), "\n")
 
-	names := entitycompat.GoldenSchemaNames()
+	// L0 family の golden schema に加え、L2 で map-based packer の出力検証に使う
+	// flat schema (Announcement 等) も同じ snapshot に抽出する。
+	names := append(entitycompat.GoldenSchemaNames(), entitycompat.L2FlatSchemaNames()...)
 	golden := entitycompat.ParseTypesFile(lines, names)
 
 	// すべての referenced schema が見つかり、かつ 0 フィールドでないか確認する。


### PR DESCRIPTION
## Summary

shape drift gate の **L2 (実行時 map 検証) を map-based packer へ拡張**する最初の実例。L0 (reflection) の family 拡張は上限に到達した — entity の struct DTO は全てマッピング済 / inline sub-object (ChannelLite 等) / helper のいずれかで、残りの実体 (Clip / Page / Gallery / Announcement …) は全て `map[string]any` packer で reflection が届かない。

最初の L2 flat 対象に **Announcement** を選定:
- `PackAnnouncement` は `map[string]any` を返す代表的な map-based packer
- #1224 で createdAt 非null cast crash の歴史があり、先の MeDetailed PR で触れた `unreadAnnouncements` 経路の実体
- golden `Announcement` は flat schema で、PackAnnouncement の 12 key と**完全一致** → 現状ドリフト無し (純粋なカバレッジ拡張)

## 主な変更点
- `L2FlatSchemaNames()` を追加。generator が L0 family golden に加え flat L2 schema (Announcement) も `golden_schemas.json` に抽出。
- 既存 `ValidateValue` で `PackAnnouncement` の実出力を golden `Announcement` に検証する `TestAnnouncementShapeL2`。
- `make shapecheck` の filter を `'TestEntityShapeDrift|ShapeL2'` に (将来の `*ShapeL2` も自動で拾う)。
- `docs/shape-drift.md` に `ValidateUnionValue` (union) と `ValidateValue` (flat map-based) の使い分け + 新規 packer を L2 に足す手順を追記。

## テスト
- `TestAnnouncementShapeL2` green (drift 無し)。`make shapecheck` で L0 + L2 (Notification / Announcement) を一括実行。
- entitycompat coverage 96.6% (race + atomic)、build / vet / fmt clean。

## Closes
Closes #1262

## その他
- これで gate は struct DTO (L0) + Notification union + Announcement (L2) を守る。今後 Clip / Page / Gallery 等を同じ `L2FlatSchemaNames()` + fixture パターンで追加していける。
- L0 family は実質完済 (User/Note/Drive/Following/UserList/Emoji)。allowlist の残りは intentional のみ (policies / pollVote / importCompleted)。

🤖 Generated with [Claude Code](https://claude.com/claude-code)