### PR TITLE
feat(entitycompat): L2 を Clip / Signin packer へ拡張 + flat L2 test ヘルパ

### DIFF
--- a/internal/entitycompat/runtime.go
+++ b/internal/entitycompat/runtime.go
@@ -25,7 +25,7 @@ func UnionSchemaNames() []string {
 // them; the generator still extracts their flat golden schema into the snapshot
 // for ValidateValue to use.
 func L2FlatSchemaNames() []string {
-	return []string{"Announcement"}
+	return []string{"Announcement", "Clip", "Signin"}
 }
 
 // ParseUnion parses a discriminated-union schema (variants joined by `} | {`)

--- a/internal/entitycompat/runtime_test.go
+++ b/internal/entitycompat/runtime_test.go
@@ -180,20 +180,38 @@ func notifFixture(typ notification.Type, withUser, withNote bool, extra map[stri
 	return entity.PackNotification(n, user, note, idGen, nil, nil)
 }
 
+// requireL2Schema loads a flat golden schema for an L2 map-based packer test,
+// failing if the snapshot is missing/empty (regenerate-miss guard).
+func requireL2Schema(t *testing.T, name string) Schema {
+	t.Helper()
+	golden, err := LoadGoldenSnapshot(filepath.Join("testdata", "golden_schemas.json"))
+	if err != nil {
+		t.Fatalf("load golden: %v", err)
+	}
+	schema, ok := golden[name]
+	if !ok || len(schema) == 0 {
+		t.Fatalf("%s schema missing/empty in golden snapshot; run `go run ./tools/shapediff`", name)
+	}
+	return schema
+}
+
+// assertNoGatedDrift fails on any HIGH/MED finding from validating a packer's
+// runtime map output against its golden schema.
+func assertNoGatedDrift(t *testing.T, name string, actual map[string]any, schema Schema) {
+	t.Helper()
+	for _, f := range ValidateValue(name, name, name, actual, schema) {
+		if f.Sev == SevHigh || f.Sev == SevMed {
+			t.Errorf("%s shape drift: %s [%s]: %s", name, f.Field, f.Kind, f.Detail)
+		}
+	}
+}
+
 // TestAnnouncementShapeL2 validates the actual PackAnnouncement map output
 // against the golden Announcement schema. Announcement is packed as
 // map[string]any (not a reflectable struct), so this is the L2 runtime check
 // for that map-based packer (#1224 history: createdAt non-null cast crash).
 func TestAnnouncementShapeL2(t *testing.T) {
-	golden, err := LoadGoldenSnapshot(filepath.Join("testdata", "golden_schemas.json"))
-	if err != nil {
-		t.Fatalf("load golden: %v", err)
-	}
-	schema, ok := golden["Announcement"]
-	if !ok || len(schema) == 0 {
-		t.Fatal("Announcement schema missing/empty in golden snapshot; run `go run ./tools/shapediff`")
-	}
-
+	schema := requireL2Schema(t, "Announcement")
 	idGen, _ := id.NewGenerator("aidx")
 	img := "https://example.com/a.png"
 	updated := time.Date(2026, 5, 26, 1, 0, 0, 0, time.UTC)
@@ -212,15 +230,31 @@ func TestAnnouncementShapeL2(t *testing.T) {
 			NeedConfirmationToRead: true, Silence: true,
 		},
 	}
-
 	for name, a := range cases {
-		out := entity.PackAnnouncement(a, idGen, true)
-		for _, f := range ValidateValue("Announcement", "Announcement", "Announcement", out, schema) {
-			if f.Sev == SevHigh || f.Sev == SevMed {
-				t.Errorf("[%s] Announcement shape drift: %s [%s]: %s", name, f.Field, f.Kind, f.Detail)
-			}
-		}
+		assertNoGatedDrift(t, "Announcement["+name+"]", entity.PackAnnouncement(a, idGen, true), schema)
 	}
+}
+
+// TestClipShapeL2 validates PackClip's map output against golden Clip. Clip is
+// map-based; with idGen + owner it must emit all required golden fields
+// (createdAt / user 含む)。
+func TestClipShapeL2(t *testing.T) {
+	schema := requireL2Schema(t, "Clip")
+	idGen, _ := id.NewGenerator("aidx")
+	owner := &model.User{ID: "u_owner", Username: "owner"}
+	desc := "my clip"
+	cl := &model.Clip{ID: idGen.Generate(time.Now()), UserID: "u_owner", Name: "clip", Description: &desc, IsPublic: true}
+	out := entity.PackClip(cl, idGen, owner)
+	assertNoGatedDrift(t, "Clip", out, schema)
+}
+
+// TestSigninShapeL2 validates PackSignin's map output against golden Signin.
+func TestSigninShapeL2(t *testing.T) {
+	schema := requireL2Schema(t, "Signin")
+	idGen, _ := id.NewGenerator("aidx")
+	s := &model.Signin{ID: idGen.Generate(time.Now()), IP: "203.0.113.7", Success: true}
+	out := entity.PackSignin(s, idGen)
+	assertNoGatedDrift(t, "Signin", out, schema)
 }
 
 // TestNotificationShapeL2 validates actual PackNotification map output against

--- a/internal/entitycompat/testdata/golden_schemas.json
+++ b/internal/entitycompat/testdata/golden_schemas.json
@@ -61,6 +61,63 @@
       "type": "string"
     }
   },
+  "Clip": {
+    "createdAt": {
+      "nullable": false,
+      "optional": false,
+      "type": "string"
+    },
+    "description": {
+      "nullable": true,
+      "optional": false,
+      "type": "string"
+    },
+    "favoritedCount": {
+      "nullable": false,
+      "optional": false,
+      "type": "number"
+    },
+    "id": {
+      "nullable": false,
+      "optional": false,
+      "type": "string"
+    },
+    "isFavorited": {
+      "nullable": false,
+      "optional": true,
+      "type": "boolean"
+    },
+    "isPublic": {
+      "nullable": false,
+      "optional": false,
+      "type": "boolean"
+    },
+    "lastClippedAt": {
+      "nullable": true,
+      "optional": false,
+      "type": "string"
+    },
+    "name": {
+      "nullable": false,
+      "optional": false,
+      "type": "string"
+    },
+    "notesCount": {
+      "nullable": false,
+      "optional": true,
+      "type": "number"
+    },
+    "user": {
+      "nullable": false,
+      "optional": false,
+      "type": "object"
+    },
+    "userId": {
+      "nullable": false,
+      "optional": false,
+      "type": "string"
+    }
+  },
   "DriveFile": {
     "blurhash": {
       "nullable": true,
@@ -646,6 +703,33 @@
       "nullable": false,
       "optional": true,
       "type": "array"
+    }
+  },
+  "Signin": {
+    "createdAt": {
+      "nullable": false,
+      "optional": false,
+      "type": "string"
+    },
+    "headers": {
+      "nullable": false,
+      "optional": false,
+      "type": "other"
+    },
+    "id": {
+      "nullable": false,
+      "optional": false,
+      "type": "string"
+    },
+    "ip": {
+      "nullable": false,
+      "optional": false,
+      "type": "string"
+    },
+    "success": {
+      "nullable": false,
+      "optional": false,
+      "type": "boolean"
     }
   },
   "UserDetailedNotMeOnly": {


### PR DESCRIPTION
## Summary

#1262 で確立した L2 flat (map-based packer) 検証パターンを **Clip / Signin** へ広げる。`PackClip` / `PackSignin` は条件付き set (`out["createdAt"]=...` / `out["user"]=...` / `out["headers"]=...`) で golden 必須欄を全て満たしており、idGen (+ owner) を渡せば**現状ドリフト無し** = 純粋なカバレッジ拡張。

## 主な変更点
- `L2FlatSchemaNames()` に `Clip` / `Signin` を追加 (generator が golden snapshot に抽出)。
- `TestClipShapeL2` / `TestSigninShapeL2` を追加 (fixture で packer の実 map 出力を golden に検証)。
- flat L2 test の共通ヘルパ `requireL2Schema` / `assertNoGatedDrift` を導入し、Announcement も含め 3 entity で統一 (重複削減)。

## テスト
- `make shapecheck` で L0 + L2 (Notification / Announcement / Clip / Signin) を一括実行、全 green。
- entitycompat coverage 96.6% (race + atomic)、build / vet / fmt clean。

## Closes
Closes #1264

## その他
- **Page は対象外**: `PackPageWithContext` (full: user/eyeCatchingImage/isLiked 込み) と 簡易 `PackPage` (それらを欠く) の二段構成で、どの endpoint がどちらを返すかの調査が要るため別 issue とする。
- gate が守る範囲: struct DTO (L0) + Notification union + Announcement / Clip / Signin (L2 flat)。今後の map-based packer も `L2FlatSchemaNames()` + fixture で同様に追加可能。

🤖 Generated with [Claude Code](https://claude.com/claude-code)