### PR TITLE
fix(pages): Page L2 追加 + eyeCatchingImage 欠落ドリフトを修正

### DIFF
--- a/internal/entity/page.go
+++ b/internal/entity/page.go
@@ -36,7 +36,11 @@ func PackPage(p *model.Page, idGens ...id.Generator) map[string]any {
 		"font":                p.Font,
 		"userId":              p.UserID,
 		"eyeCatchingImageId":  p.EyeCatchingImageID,
-		"content":             rawJSONBytes(p.Content),
+		// golden Page は eyeCatchingImage を present 必須 (DriveFile | null) とする。
+		// 画像が無い / lookup miss でも null を出す (omit しない)。実画像は
+		// PackPageWithContext が ctx.EyeCatchingImage で上書きする。
+		"eyeCatchingImage": nil,
+		"content":          rawJSONBytes(p.Content),
 		// variables / attachedFiles は misskey_dart の Page.fromJson が非null
 		// List として cast するため、空でも null ではなく [] を返す (#1237)。
 		"variables":     jsonArrayOrEmpty(p.Variables),

--- a/internal/entity/page_test.go
+++ b/internal/entity/page_test.go
@@ -117,13 +117,17 @@ func TestPackPageWithContext_OmitsAbsentOptionals(t *testing.T) {
 	p := &model.Page{ID: idGen.Generate(time.Now()), UserID: "u1", Visibility: model.PageVisibilityPublic}
 	out := PackPageWithContext(p, PackPageContext{IDGen: idGen})
 	// Owner=nil → user field 自体を omit (null 出しすると frontend が
-	// page.user.username で再 throw するため)。
+	// page.user.username で再 throw するため)。isLiked も viewer 無し時は omit
+	// (golden isLiked? は optional)。
 	_, hasUser := out["user"]
 	assert.False(t, hasUser)
-	_, hasEye := out["eyeCatchingImage"]
-	assert.False(t, hasEye)
 	_, hasLiked := out["isLiked"]
 	assert.False(t, hasLiked)
+	// 一方 eyeCatchingImage は golden で present 必須 (DriveFile | null) なので、
+	// 画像が無くても null で present にする (omit しない) (#1264 follow-up)。
+	eye, hasEye := out["eyeCatchingImage"]
+	assert.True(t, hasEye, "eyeCatchingImage must be present (golden: DriveFile|null)")
+	assert.Nil(t, eye, "eyeCatchingImage is null when no image")
 }
 
 func TestPackPageWithContext_NilPage(t *testing.T) {

--- a/internal/entitycompat/runtime.go
+++ b/internal/entitycompat/runtime.go
@@ -25,7 +25,7 @@ func UnionSchemaNames() []string {
 // them; the generator still extracts their flat golden schema into the snapshot
 // for ValidateValue to use.
 func L2FlatSchemaNames() []string {
-	return []string{"Announcement", "Clip", "Signin"}
+	return []string{"Announcement", "Clip", "Signin", "Page"}
 }
 
 // ParseUnion parses a discriminated-union schema (variants joined by `} | {`)

--- a/internal/entitycompat/runtime_test.go
+++ b/internal/entitycompat/runtime_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/shiroha-a/mk/internal/entity"
 	"github.com/shiroha-a/mk/internal/misc/id"
 	"github.com/shiroha-a/mk/internal/model"
+	"gorm.io/datatypes"
 )
 
 // --- unit tests: union parser + runtime validator ---------------------------
@@ -255,6 +256,29 @@ func TestSigninShapeL2(t *testing.T) {
 	s := &model.Signin{ID: idGen.Generate(time.Now()), IP: "203.0.113.7", Success: true}
 	out := entity.PackSignin(s, idGen)
 	assertNoGatedDrift(t, "Signin", out, schema)
+}
+
+// TestPageShapeL2 validates PackPageWithContext's map output against golden
+// Page. Tested with the common "no eye-catching image" case: golden requires
+// `eyeCatchingImage` present (DriveFile | null), so it must be emitted as null
+// rather than omitted.
+func TestPageShapeL2(t *testing.T) {
+	schema := requireL2Schema(t, "Page")
+	idGen, _ := id.NewGenerator("aidx")
+	owner := &model.User{ID: "u_owner", Username: "owner"}
+	liked := false
+	p := &model.Page{
+		ID:        idGen.Generate(time.Now()),
+		UserID:    "u_owner",
+		UpdatedAt: time.Now(),
+		Title:     "title",
+		Name:      "name",
+		Font:      "sans-serif",
+		Content:   datatypes.JSON([]byte("[]")),
+		Variables: datatypes.JSON([]byte("[]")),
+	}
+	out := entity.PackPageWithContext(p, entity.PackPageContext{IDGen: idGen, Owner: owner, IsLiked: &liked})
+	assertNoGatedDrift(t, "Page", out, schema)
 }
 
 // TestNotificationShapeL2 validates actual PackNotification map output against

--- a/internal/entitycompat/testdata/golden_schemas.json
+++ b/internal/entitycompat/testdata/golden_schemas.json
@@ -705,6 +705,103 @@
       "type": "array"
     }
   },
+  "Page": {
+    "alignCenter": {
+      "nullable": false,
+      "optional": false,
+      "type": "boolean"
+    },
+    "attachedFiles": {
+      "nullable": false,
+      "optional": false,
+      "type": "array"
+    },
+    "content": {
+      "nullable": false,
+      "optional": false,
+      "type": "array"
+    },
+    "createdAt": {
+      "nullable": false,
+      "optional": false,
+      "type": "string"
+    },
+    "eyeCatchingImage": {
+      "nullable": true,
+      "optional": false,
+      "type": "object"
+    },
+    "eyeCatchingImageId": {
+      "nullable": true,
+      "optional": false,
+      "type": "string"
+    },
+    "font": {
+      "nullable": false,
+      "optional": false,
+      "type": "string"
+    },
+    "hideTitleWhenPinned": {
+      "nullable": false,
+      "optional": false,
+      "type": "boolean"
+    },
+    "id": {
+      "nullable": false,
+      "optional": false,
+      "type": "string"
+    },
+    "isLiked": {
+      "nullable": false,
+      "optional": true,
+      "type": "boolean"
+    },
+    "likedCount": {
+      "nullable": false,
+      "optional": false,
+      "type": "number"
+    },
+    "name": {
+      "nullable": false,
+      "optional": false,
+      "type": "string"
+    },
+    "script": {
+      "nullable": false,
+      "optional": false,
+      "type": "string"
+    },
+    "summary": {
+      "nullable": true,
+      "optional": false,
+      "type": "string"
+    },
+    "title": {
+      "nullable": false,
+      "optional": false,
+      "type": "string"
+    },
+    "updatedAt": {
+      "nullable": false,
+      "optional": false,
+      "type": "string"
+    },
+    "user": {
+      "nullable": false,
+      "optional": false,
+      "type": "object"
+    },
+    "userId": {
+      "nullable": false,
+      "optional": false,
+      "type": "string"
+    },
+    "variables": {
+      "nullable": false,
+      "optional": false,
+      "type": "array"
+    }
+  },
   "Signin": {
     "createdAt": {
       "nullable": false,


### PR DESCRIPTION
## Summary

L2 を **Page** packer へ拡張する過程で**実ドリフトを検出・修正**した。Clip/Signin/Announcement と違い、Page は L2 がクラッシュ級のドリフトを炙り出したケース。

golden `Page` は `eyeCatchingImage: DriveFile | null` を **present 必須**(null 許容)とするが、mk-go は画像ありの時だけ set し、**画像が無いページ(よくあるケース)では欄を omit** していた。これは #1224 系の必須欄欠落で、Page を返す全経路(pages/show / users/pages list / pinnedPage)に影響。

## 主な変更点
- `L2FlatSchemaNames()` に `Page` を追加。
- `TestPageShapeL2`: 画像なしページの `PackPageWithContext` 出力を golden Page に検証 → `eyeCatchingImage [missing]` を検出。
- **修正**: `PackPage` が `eyeCatchingImage: null` を常に present にする(omit しない)。実画像は `PackPageWithContext` が `ctx.EyeCatchingImage` で上書き。frontend は `v-if="page.eyeCatchingImage"` なので absent→null は無害、misskey_dart は `DriveFile?` で null OK。
- 旧挙動(eyeCatchingImage omit)を前提にしていた `TestPackPageWithContext_OmitsAbsentOptionals` を present-null assertion に更新。

## テスト
- `make shapecheck` で L0 + L2 (Notification / Announcement / Clip / Signin / Page) 全 green。
- entity 95.4% / entitycompat 96.6% (race + atomic)、`/api/i` / `pages` / `users` の既存テスト green、build / vet / fmt clean。

## Closes
Closes #1266

## その他 (follow-up)
- 簡易 `PackPage`(pinnedPage 経路: MeDetailed/UserDetailed.pinnedPage)は依然 `user` を omit する(Owner 未渡し)。golden Page は user 必須なので別途修正候補だが、handler caller (i/handler / users/handler) で owner を渡す変更が要るため別 issue とする。本 PR の eyeCatchingImage 修正は簡易 PackPage 経路にも効く(pinnedPage の eyeCatchingImage も present-null 化)。

🤖 Generated with [Claude Code](https://claude.com/claude-code)