### PR TITLE
fix(pages): pinnedPage に user を埋める (golden Page 必須)

### DIFF
--- a/internal/api/i/handler.go
+++ b/internal/api/i/handler.go
@@ -1439,7 +1439,9 @@ func (h *Handler) fillPinnedFields(ctx context.Context, u *model.User, profile *
 		resp["pinnedPageId"] = profile.PinnedPageID
 		if h.pageRepo != nil {
 			if p, err := h.pageRepo.FindByID(*profile.PinnedPageID); err == nil {
-				resp["pinnedPage"] = entity.PackPage(p, h.idGen)
+				// golden Page は user 必須。pinnedPage は自分の page なので
+				// owner=u を渡して user (UserLite) を埋める (#1266 follow-up)。
+				resp["pinnedPage"] = entity.PackPageWithContext(p, entity.PackPageContext{IDGen: h.idGen, Owner: u})
 			}
 		}
 	}

--- a/internal/api/i/handler_test.go
+++ b/internal/api/i/handler_test.go
@@ -2245,6 +2245,11 @@ func TestMe_PinnedPage_Populated(t *testing.T) {
 	pg, ok := resp["pinnedPage"].(map[string]any)
 	require.True(t, ok)
 	assert.Equal(t, "pinned", pg["title"])
+	// golden Page は user 必須。pinnedPage に owner=u を渡す修正 (#1266 fu) を
+	// /api/i 側でも回帰 guard する (user が present で id が self と一致)。
+	pgUser, ok := pg["user"].(map[string]any)
+	require.True(t, ok, "pinnedPage.user must be present (golden Page requires user)")
+	assert.Equal(t, "u1", pgUser["id"])
 }
 
 func TestMe_PinnedPage_NoPinnedPageID(t *testing.T) {

--- a/internal/api/users/handler.go
+++ b/internal/api/users/handler.go
@@ -967,7 +967,9 @@ func (h *Handler) fillPinned(ctx context.Context, viewer *model.User, u *model.U
 		detailed.PinnedPageID = profile.PinnedPageID
 		if h.pageRepo != nil {
 			if p, err := h.pageRepo.FindByID(*profile.PinnedPageID); err == nil {
-				detailed.PinnedPage = entity.PackPage(p, h.idGen)
+				// golden Page は user 必須。pinnedPage は profile user 自身の page
+				// なので owner=u を渡して user (UserLite) を埋める (#1266 follow-up)。
+				detailed.PinnedPage = entity.PackPageWithContext(p, entity.PackPageContext{IDGen: h.idGen, Owner: u})
 			}
 		}
 	}

--- a/internal/api/users/handler_test.go
+++ b/internal/api/users/handler_test.go
@@ -1615,6 +1615,11 @@ func TestShow_PinnedPage_Populated(t *testing.T) {
 	page, ok := resp["pinnedPage"].(map[string]any)
 	require.True(t, ok)
 	assert.Equal(t, "my page", page["title"])
+	// golden Page は user 必須。pinnedPage に owner を渡すよう修正 (#1266 fu) した
+	// ので user (UserLite) が present で、UserDetailed shape に戻る regression を防ぐ。
+	pageUser, ok := page["user"].(map[string]any)
+	require.True(t, ok, "pinnedPage.user must be present (golden Page requires user)")
+	assert.Equal(t, "user1", pageUser["id"])
 }
 
 func TestShow_PinnedFields_Defaults(t *testing.T) {


### PR DESCRIPTION
## Summary

#1266 (Page L2) の follow-up。golden `Page` は `user: UserLite` を**必須**とするが、`MeDetailed` / `UserDetailed` の `pinnedPage` は簡易 `PackPage`(owner 未渡し)で pack され `user` を omit していた。frontend MkPagePreview は `page.user.username` を unconditional に読むため、pinnedPage 描画時に crash の恐れ。

## 主な変更点
- `/api/i` (`fillPinnedFields`) と `users/show` (`fillPinned`) の pinnedPage packing を `PackPage(p, idGen)` → `PackPageWithContext(p, PackPageContext{IDGen, Owner: u})` に変更。pinnedPage は当該ユーザー自身の page なので owner=u(両関数の引数にある self / profile user)。
- `TestShow_PinnedPage_Populated` に `pinnedPage.user` present + `user.id == "user1"` の assertion を追加(caller が owner 未渡しに戻る regression を catch)。

## テスト
- `TestShow_PinnedPage_Populated` green (user present 確認)。`/api/i` / `users` package、`make shapecheck` 全 green。
- race + atomic、build / vet / fmt clean。

## Closes
Closes #1268

## その他
- `eyeCatchingImage` は #1266 の `PackPage` 修正で既に present-null 化済。本 PR で pinnedPage の Page shape が golden 準拠(user / eyeCatchingImage 含む)になる。
- これで Page を返す主要経路(pages/show / users/pages list / pinnedPage)が golden Page 準拠に揃う。

🤖 Generated with [Claude Code](https://claude.com/claude-code)