### PR TITLE
feat(entitycompat): L3 実レスポンス検証を導入 + /api/i handler drift 3件を修正

### DIFF
--- a/internal/api/i/handler.go
+++ b/internal/api/i/handler.go
@@ -630,11 +630,11 @@ func (h *Handler) Me(c echo.Context) error {
 	// 旧 self-view 用 hardcode `resp["canChat"] = true` を撤去し、
 	// upstream と同じ role policy ベースの判定に揃える。
 	// memo / moderationNote は UserDetailed.Memo (omitempty) / MeDetailed
-	// 構造体に無いため、JSON unmarshal 後の resp map に key が出ない。
-	// /api/i の response shape を後方互換に保つため key 自体は出す
-	// (= "memo": null)。
-	resp["memo"] = nil
-	resp["moderationNote"] = nil
+	// memo は PackMeDetailed (UserDetailed.Memo, #1259) が null で乗せるので
+	// override 不要。moderationNote は golden で `moderationNote?: string`
+	// (optional・null 不可、moderator が他者を見るとき専用) なので self-view
+	// (/api/i) では出さない。旧実装は `resp["moderationNote"]=nil` で null を出し
+	// golden 非互換だった (#1270 L3 で検出)。
 	// isSilenced は role policy 由来で /api/i 固有 (MeDetailed には無い)。
 	resp["isSilenced"] = h.isSilenced(u.ID)
 
@@ -644,8 +644,9 @@ func (h *Handler) Me(c echo.Context) error {
 		resp["emailVerified"] = profile.EmailVerified
 		resp["twoFactorEnabled"] = profile.TwoFactorEnabled
 		resp["usePasswordLessLogin"] = profile.UsePasswordLessLogin
-		resp["mutedWords"] = profile.MutedWords
-		resp["mutedInstances"] = profile.MutedInstances
+		// mutedWords / mutedInstances は PackMeDetailed (AsMeDetailed) が profile
+		// から非null array で乗せる。raw profile 値で override すると空カラム時に
+		// null になり golden (string[][] / string[]、非null) 非互換 (#1270 L3 検出)。
 		resp["publicReactions"] = profile.PublicReactions
 		resp["loggedInDays"] = len(profile.LoggedInDates)
 		resp["achievements"] = jsonbArray(profile.Achievements)

--- a/internal/api/i/handler_test.go
+++ b/internal/api/i/handler_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/shiroha-a/mk/internal/core/notification"
 	coreuser "github.com/shiroha-a/mk/internal/core/user"
 	"github.com/shiroha-a/mk/internal/entity"
+	"github.com/shiroha-a/mk/internal/entitycompat/shapetest"
 	"github.com/shiroha-a/mk/internal/misc/id"
 	miscsmtp "github.com/shiroha-a/mk/internal/misc/smtp"
 	"github.com/shiroha-a/mk/internal/model"
@@ -2250,6 +2251,13 @@ func TestMe_PinnedPage_Populated(t *testing.T) {
 	pgUser, ok := pg["user"].(map[string]any)
 	require.True(t, ok, "pinnedPage.user must be present (golden Page requires user)")
 	assert.Equal(t, "u1", pgUser["id"])
+
+	// L3 (#1270): 実 /api/i レスポンス map を golden User-family schema に突合する。
+	// struct ではなく handler が PackMeDetailed + fillUnreadFields + override で
+	// 実際に組み立てた map を検証するので、populate 漏れも検出できる。
+	shapetest.Assert(t, "UserLite", resp)
+	shapetest.Assert(t, "UserDetailedNotMeOnly", resp)
+	shapetest.Assert(t, "MeDetailedOnly", resp)
 }
 
 func TestMe_PinnedPage_NoPinnedPageID(t *testing.T) {

--- a/internal/entitycompat/response.go
+++ b/internal/entitycompat/response.go
@@ -1,0 +1,46 @@
+package entitycompat
+
+import (
+	_ "embed"
+	"encoding/json"
+)
+
+// embeddedGoldenJSON is the committed golden flat-schema snapshot, embedded at
+// build time so callers in other packages (handler response-shape tests) can
+// validate without a filesystem path (their CWD differs from this package).
+//
+//go:embed testdata/golden_schemas.json
+var embeddedGoldenJSON []byte
+
+// EmbeddedGolden returns the embedded golden flat-schema snapshot.
+func EmbeddedGolden() GoldenSet {
+	var g GoldenSet
+	_ = json.Unmarshal(embeddedGoldenJSON, &g)
+	return g
+}
+
+// ValidateResponse is the "Layer 3" runtime response check: it validates an
+// actual API response map against the named golden schema and returns the
+// gated (HIGH/MED) findings. Unlike Layer 0 (struct reflection) it inspects
+// what a handler actually emits, so it catches handler populate bugs and
+// ad-hoc map[string]any responses that no reflectable struct backs.
+//
+// A non-existent schema name yields a single HIGH finding so misuse (typo /
+// not-extracted schema) is visible rather than silently passing.
+func ValidateResponse(schemaName string, actual map[string]any) []Finding {
+	schema, ok := EmbeddedGolden()[schemaName]
+	if !ok {
+		return []Finding{{
+			Family: schemaName, Layer: schemaName, Golden: schemaName,
+			Field: schemaName, Kind: KindMissing, Sev: SevHigh,
+			Detail: "golden schema not found in snapshot (typo, or add to GoldenSchemaNames/L2FlatSchemaNames)",
+		}}
+	}
+	var gated []Finding
+	for _, f := range ValidateValue(schemaName, schemaName, schemaName, actual, schema) {
+		if f.Sev == SevHigh || f.Sev == SevMed {
+			gated = append(gated, f)
+		}
+	}
+	return gated
+}

--- a/internal/entitycompat/response.go
+++ b/internal/entitycompat/response.go
@@ -3,6 +3,7 @@ package entitycompat
 import (
 	_ "embed"
 	"encoding/json"
+	"sync"
 )
 
 // embeddedGoldenJSON is the committed golden flat-schema snapshot, embedded at
@@ -12,11 +13,19 @@ import (
 //go:embed testdata/golden_schemas.json
 var embeddedGoldenJSON []byte
 
-// EmbeddedGolden returns the embedded golden flat-schema snapshot.
+var (
+	embeddedGoldenOnce sync.Once
+	embeddedGolden     GoldenSet
+)
+
+// EmbeddedGolden returns the embedded golden flat-schema snapshot. The parse is
+// memoized: L3 response checks across many handler tests call this repeatedly,
+// so the JSON is unmarshaled once. Callers must treat the result as read-only.
 func EmbeddedGolden() GoldenSet {
-	var g GoldenSet
-	_ = json.Unmarshal(embeddedGoldenJSON, &g)
-	return g
+	embeddedGoldenOnce.Do(func() {
+		_ = json.Unmarshal(embeddedGoldenJSON, &embeddedGolden)
+	})
+	return embeddedGolden
 }
 
 // ValidateResponse is the "Layer 3" runtime response check: it validates an

--- a/internal/entitycompat/runtime_test.go
+++ b/internal/entitycompat/runtime_test.go
@@ -181,6 +181,34 @@ func notifFixture(typ notification.Type, withUser, withNote bool, extra map[stri
 	return entity.PackNotification(n, user, note, idGen, nil, nil)
 }
 
+func TestEmbeddedGolden(t *testing.T) {
+	g := EmbeddedGolden()
+	if len(g) == 0 {
+		t.Fatal("embedded golden snapshot is empty")
+	}
+	if _, ok := g["UserLite"]; !ok {
+		t.Error("embedded golden missing UserLite")
+	}
+}
+
+func TestValidateResponse(t *testing.T) {
+	// 未知 schema は誤用を可視化するため単一 HIGH finding を返す。
+	f := ValidateResponse("NoSuchSchema", map[string]any{})
+	if len(f) != 1 || f[0].Sev != SevHigh {
+		t.Errorf("unknown schema: want 1 HIGH finding, got %v", f)
+	}
+	// 既知 schema (UserLite) に必須欄を欠く response -> gated drift。
+	if got := ValidateResponse("UserLite", map[string]any{"username": "x"}); len(got) == 0 {
+		t.Error("expected gated drift for incomplete UserLite response")
+	}
+	// gated は HIGH/MED のみ (INFO の extra は含まない)。
+	for _, x := range ValidateResponse("UserLite", map[string]any{"username": "x", "extraKey": 1}) {
+		if x.Sev != SevHigh && x.Sev != SevMed {
+			t.Errorf("ValidateResponse returned non-gated severity %s", x.Sev)
+		}
+	}
+}
+
 // requireL2Schema loads a flat golden schema for an L2 map-based packer test,
 // failing if the snapshot is missing/empty (regenerate-miss guard).
 func requireL2Schema(t *testing.T, name string) Schema {

--- a/internal/entitycompat/shapetest/shapetest.go
+++ b/internal/entitycompat/shapetest/shapetest.go
@@ -1,0 +1,27 @@
+// Package shapetest provides test helpers to assert that an actual API
+// response matches the golden contract (the "Layer 3" runtime response check).
+//
+// Unlike the Layer 0 struct-reflection gate, this validates what a handler
+// actually emits, so it covers ad-hoc map[string]any responses and catches
+// handler populate bugs. Intended for use from handler _test.go files:
+//
+//	shapetest.Assert(t, "MeDetailedOnly", resp)
+//
+// It deliberately lives in its own package (imports testing) so handler test
+// packages can share it without duplicating the validate-and-report loop.
+package shapetest
+
+import (
+	"testing"
+
+	"github.com/shiroha-a/mk/internal/entitycompat"
+)
+
+// Assert fails t with a clear message for each gated (HIGH/MED) shape drift
+// between the actual response map and the named golden schema.
+func Assert(t testing.TB, schemaName string, actual map[string]any) {
+	t.Helper()
+	for _, f := range entitycompat.ValidateResponse(schemaName, actual) {
+		t.Errorf("response shape drift vs golden %s: %s [%s]: %s", schemaName, f.Field, f.Kind, f.Detail)
+	}
+}


### PR DESCRIPTION
## Summary

検出範囲を「reusable packer を持つ ~12 entity」から大きく広げるため、**L3 (実レスポンス検証)** を導入する。reusable な map packer は 6 個で天井到達し、残り ~48 golden schema は handler が**アドホックに `map[string]any`** を組み立てており、L0 (struct reflection) でも L2 (packer fixture) でも届かない。L3 は**既存の handler unit test (mock ベース・実サーバー不要) が capture する JSON レスポンス**を golden に突合することで、この広い面をカバーする。

## 主な変更点

### L3 機構
- `entitycompat.EmbeddedGolden`: `go:embed` で golden snapshot を埋め込み、他 package (handler test) から filesystem path 無しで使える。
- `entitycompat.ValidateResponse(schemaName, actual)`: 実レスポンス map を golden に突合し gated (HIGH/MED) findings を返す。
- `entitycompat/shapetest` package: handler test 用の `Assert(t, schema, resp)` ヘルパ (全 handler package で再利用可能)。
- pilot: `/api/i` Me test で実レスポンスを `UserLite` / `UserDetailedNotMeOnly` / `MeDetailedOnly` に突合。

### L3 が検出した handler drift (修正)
**L0 では見えない handler 層の populate バグを 3 件検出 → 修正**(L3 の価値の実証):
- `moderationNote`: `/api/i` が `null` を出力。golden は `moderationNote?: string`(optional・null 不可、moderator が他者を見るとき専用)なので self-view では omit。
- `mutedWords` / `mutedInstances`: `/api/i` の raw profile override が空カラム時に `null` を出力(golden は非null array)。struct (AsMeDetailed) が安全な `[]` を乗せるので override を撤去。`memo` も struct (#1259) が出すので override 撤去。

## テスト
- `TestMe_PinnedPage_Populated` に L3 突合を追加 (pilot)、修正後 green。
- `TestValidateResponse` / `TestEmbeddedGolden` 追加。`make shapecheck` (L0 + L2×5) green。
- entitycompat 96.8% (race + atomic)、`/api/i` 既存テスト green、build / vet / fmt clean。

## Closes
Closes #1270

## その他
- これで gate は **L0 (struct) + L2 (map packer) + L3 (実レスポンス)** の3層。L3 は他 handler package (users / notes / drive 等) にも `shapetest.Assert` で順次広げられる。
- L3 は handler が実際に組み立てた map を見るので、struct が正しくても handler の override / populate で壊れるケースを捕捉できる(本 PR の mutedWords override null がまさにそれ)。

🤖 Generated with [Claude Code](https://claude.com/claude-code)