### PR TITLE
fix(federation): instances の blocked/silenced フィルタ実装 + sort 向きを TS に合わせる

### DIFF
--- a/internal/api/federation/handler.go
+++ b/internal/api/federation/handler.go
@@ -54,6 +54,8 @@ type InstancesRequest struct {
 	Host          string `json:"host"`
 	Suspended     *bool  `json:"suspended"`
 	NotResponding *bool  `json:"notResponding"`
+	Blocked       *bool  `json:"blocked"`
+	Silenced      *bool  `json:"silenced"`
 	Federating    *bool  `json:"federating"`
 	Subscribing   *bool  `json:"subscribing"`
 	Publishing    *bool  `json:"publishing"`
@@ -76,10 +78,18 @@ func (h *Handler) Instances(c echo.Context) error {
 	}
 	// sinceDate / untilDate を aidx prefix に正規化 (#1173)。
 	sinceID, untilID := id.NormalizeCursor(req.SinceID, req.UntilID, req.SinceDate, req.UntilDate)
+	// blocked / silenced は instance 列ではなく meta.blockedHosts /
+	// silencedHosts との突合で判定する。meta は 1 回だけ取得し、フィルタ突合と
+	// レスポンスの isBlocked / isSilenced / isMediaSilenced 算出の双方で使う。
+	blockedHosts, silencedHosts, mediaSilencedHosts := h.svc.FederationHostLists()
 	filter := model.InstanceListFilter{
 		Host:          req.Host,
 		Suspended:     req.Suspended,
 		NotResponding: req.NotResponding,
+		Blocked:       req.Blocked,
+		Silenced:      req.Silenced,
+		BlockedHosts:  blockedHosts,
+		SilencedHosts: silencedHosts,
 		Federating:    req.Federating,
 		Subscribing:   req.Subscribing,
 		Publishing:    req.Publishing,
@@ -95,7 +105,7 @@ func (h *Handler) Instances(c echo.Context) error {
 	}
 	out := make([]map[string]any, 0, len(rows))
 	for _, inst := range rows {
-		out = append(out, instanceToMap(inst))
+		out = append(out, instanceToMap(inst, blockedHosts, silencedHosts, mediaSilencedHosts))
 	}
 	return c.JSON(http.StatusOK, out)
 }
@@ -123,7 +133,8 @@ func (h *Handler) ShowInstance(c echo.Context) error {
 		slog.Error("federation/show-instance: FindByHost failed", "host", req.Host, "err", err)
 		return apierr.JSONInternalError(c)
 	}
-	return c.JSON(http.StatusOK, instanceToMap(inst))
+	blockedHosts, silencedHosts, mediaSilencedHosts := h.svc.FederationHostLists()
+	return c.JSON(http.StatusOK, instanceToMap(inst, blockedHosts, silencedHosts, mediaSilencedHosts))
 }
 
 // instanceToMap shapes an Instance row into the JSON response object expected
@@ -132,7 +143,12 @@ func (h *Handler) ShowInstance(c echo.Context) error {
 //
 // federating / subscribing / publishingは本家Misskeyと同様に
 // followingCount / followersCountから動的に計算する (DBには列を持たない)。
-func instanceToMap(inst *model.Instance) map[string]any {
+//
+// isBlocked / isSilenced / isMediaSilenced は instance 列ではなく
+// meta.blockedHosts / silencedHosts / mediaSilencedHosts との suffix-match で
+// 判定する (本家 InstanceEntityService と同じ)。突合対象の host 一覧は呼び出し
+// 元が meta から 1 度だけ取得して渡す。
+func instanceToMap(inst *model.Instance, blockedHosts, silencedHosts, mediaSilencedHosts []string) map[string]any {
 	return map[string]any{
 		"id":                      inst.ID,
 		"firstRetrievedAt":        inst.FirstRetrievedAt,
@@ -149,6 +165,9 @@ func instanceToMap(inst *model.Instance) map[string]any {
 		"notRespondingSince":      inst.NotRespondingSince,
 		"isSuspended":             inst.SuspensionState != model.SuspensionStateNone,
 		"suspensionState":         inst.SuspensionState,
+		"isBlocked":               coreinstance.HostMatchesAny(blockedHosts, inst.Host),
+		"isSilenced":              coreinstance.HostMatchesAny(silencedHosts, inst.Host),
+		"isMediaSilenced":         coreinstance.HostMatchesAny(mediaSilencedHosts, inst.Host),
 		"softwareName":            inst.SoftwareName,
 		"softwareVersion":         inst.SoftwareVersion,
 		"openRegistrations":       inst.OpenRegistrations,

--- a/internal/api/federation/handler.go
+++ b/internal/api/federation/handler.go
@@ -81,15 +81,18 @@ func (h *Handler) Instances(c echo.Context) error {
 	// blocked / silenced は instance 列ではなく meta.blockedHosts /
 	// silencedHosts との突合で判定する。meta は 1 回だけ取得し、フィルタ突合と
 	// レスポンスの isBlocked / isSilenced / isMediaSilenced 算出の双方で使う。
-	blockedHosts, silencedHosts, mediaSilencedHosts := h.svc.FederationHostLists()
+	hosts, err := h.svc.FederationHostLists()
+	if err != nil {
+		return apierr.JSONInternalError(c)
+	}
 	filter := model.InstanceListFilter{
 		Host:          req.Host,
 		Suspended:     req.Suspended,
 		NotResponding: req.NotResponding,
 		Blocked:       req.Blocked,
 		Silenced:      req.Silenced,
-		BlockedHosts:  blockedHosts,
-		SilencedHosts: silencedHosts,
+		BlockedHosts:  hosts.Blocked,
+		SilencedHosts: hosts.Silenced,
 		Federating:    req.Federating,
 		Subscribing:   req.Subscribing,
 		Publishing:    req.Publishing,
@@ -105,7 +108,7 @@ func (h *Handler) Instances(c echo.Context) error {
 	}
 	out := make([]map[string]any, 0, len(rows))
 	for _, inst := range rows {
-		out = append(out, instanceToMap(inst, blockedHosts, silencedHosts, mediaSilencedHosts))
+		out = append(out, instanceToMap(inst, hosts))
 	}
 	return c.JSON(http.StatusOK, out)
 }
@@ -133,8 +136,12 @@ func (h *Handler) ShowInstance(c echo.Context) error {
 		slog.Error("federation/show-instance: FindByHost failed", "host", req.Host, "err", err)
 		return apierr.JSONInternalError(c)
 	}
-	blockedHosts, silencedHosts, mediaSilencedHosts := h.svc.FederationHostLists()
-	return c.JSON(http.StatusOK, instanceToMap(inst, blockedHosts, silencedHosts, mediaSilencedHosts))
+	hosts, err := h.svc.FederationHostLists()
+	if err != nil {
+		slog.Error("federation/show-instance: FederationHostLists failed", "host", req.Host, "err", err)
+		return apierr.JSONInternalError(c)
+	}
+	return c.JSON(http.StatusOK, instanceToMap(inst, hosts))
 }
 
 // instanceToMap shapes an Instance row into the JSON response object expected
@@ -148,7 +155,7 @@ func (h *Handler) ShowInstance(c echo.Context) error {
 // meta.blockedHosts / silencedHosts / mediaSilencedHosts との suffix-match で
 // 判定する (本家 InstanceEntityService と同じ)。突合対象の host 一覧は呼び出し
 // 元が meta から 1 度だけ取得して渡す。
-func instanceToMap(inst *model.Instance, blockedHosts, silencedHosts, mediaSilencedHosts []string) map[string]any {
+func instanceToMap(inst *model.Instance, hosts coreinstance.FederationHostSets) map[string]any {
 	return map[string]any{
 		"id":                      inst.ID,
 		"firstRetrievedAt":        inst.FirstRetrievedAt,
@@ -165,9 +172,9 @@ func instanceToMap(inst *model.Instance, blockedHosts, silencedHosts, mediaSilen
 		"notRespondingSince":      inst.NotRespondingSince,
 		"isSuspended":             inst.SuspensionState != model.SuspensionStateNone,
 		"suspensionState":         inst.SuspensionState,
-		"isBlocked":               coreinstance.HostMatchesAny(blockedHosts, inst.Host),
-		"isSilenced":              coreinstance.HostMatchesAny(silencedHosts, inst.Host),
-		"isMediaSilenced":         coreinstance.HostMatchesAny(mediaSilencedHosts, inst.Host),
+		"isBlocked":               coreinstance.HostMatchesAny(hosts.Blocked, inst.Host),
+		"isSilenced":              coreinstance.HostMatchesAny(hosts.Silenced, inst.Host),
+		"isMediaSilenced":         coreinstance.HostMatchesAny(hosts.MediaSilenced, inst.Host),
 		"softwareName":            inst.SoftwareName,
 		"softwareVersion":         inst.SoftwareVersion,
 		"openRegistrations":       inst.OpenRegistrations,

--- a/internal/api/federation/handler_test.go
+++ b/internal/api/federation/handler_test.go
@@ -172,6 +172,17 @@ func TestInstances_StatusFields(t *testing.T) {
 	assert.Equal(t, false, got[0]["isMediaSilenced"])
 }
 
+// TestInstances_MetaError: meta が読めないとき blocked/silenced 判定が
+// できないので 500 を返す (本家 TS も metaService.fetch throw で 500)。
+func TestInstances_MetaError(t *testing.T) {
+	h, repo, metaRepo := newHandlerWithMeta(t)
+	seedInstance(t, repo, "normal.example")
+	metaRepo.Meta = nil
+	c, rec := newReq(t, `{}`)
+	require.NoError(t, h.Instances(c))
+	assert.Equal(t, http.StatusInternalServerError, rec.Code)
+}
+
 func TestInstances_BadJSON(t *testing.T) {
 	h, _ := newHandler(t)
 	c, rec := newReq(t, `{not json`)
@@ -241,6 +252,17 @@ func TestShowInstance_NotFound(t *testing.T) {
 func TestShowInstance_DBError(t *testing.T) {
 	h, repo := newHandler(t)
 	repo.FindByHostErr = errors.New("connection reset by peer")
+	c, rec := newReq(t, `{"host":"alpha.example"}`)
+	require.NoError(t, h.ShowInstance(c))
+	assert.Equal(t, http.StatusInternalServerError, rec.Code)
+}
+
+// TestShowInstance_MetaError: instance 行は見つかっても meta が読めなければ
+// isBlocked 等を埋められないので 500。
+func TestShowInstance_MetaError(t *testing.T) {
+	h, repo, metaRepo := newHandlerWithMeta(t)
+	seedInstance(t, repo, "alpha.example")
+	metaRepo.Meta = nil
 	c, rec := newReq(t, `{"host":"alpha.example"}`)
 	require.NoError(t, h.ShowInstance(c))
 	assert.Equal(t, http.StatusInternalServerError, rec.Code)

--- a/internal/api/federation/handler_test.go
+++ b/internal/api/federation/handler_test.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/labstack/echo/v4"
+	"github.com/lib/pq"
 	coreinstance "github.com/shiroha-a/mk/internal/core/instance"
 	"github.com/shiroha-a/mk/internal/misc/id"
 	"github.com/shiroha-a/mk/internal/model"
@@ -19,13 +20,20 @@ import (
 )
 
 func newHandler(t *testing.T) (*Handler, *testutil.MockInstanceRepository) {
+	h, repo, _ := newHandlerWithMeta(t)
+	return h, repo
+}
+
+// newHandlerWithMeta is like newHandler but also exposes the MockMetaRepository
+// so tests can configure blockedHosts / silencedHosts / mediaSilencedHosts.
+func newHandlerWithMeta(t *testing.T) (*Handler, *testutil.MockInstanceRepository, *testutil.MockMetaRepository) {
 	t.Helper()
 	repo := testutil.NewMockInstanceRepository()
 	metaRepo := testutil.NewMockMetaRepository()
 	metaRepo.Meta = &model.Meta{}
 	idGen, _ := id.NewGenerator("aidx")
 	svc := coreinstance.NewService(repo, metaRepo, idGen)
-	return NewHandler(svc), repo
+	return NewHandler(svc), repo, metaRepo
 }
 
 func newReq(t *testing.T, body string) (echo.Context, *httptest.ResponseRecorder) {
@@ -83,6 +91,85 @@ func TestInstances_Filtered(t *testing.T) {
 	assert.Equal(t, http.StatusOK, rec.Code)
 	assert.Contains(t, rec.Body.String(), "alpha.example")
 	assert.NotContains(t, rec.Body.String(), "beta.example")
+}
+
+// TestInstances_BlockedFilter は federation 画面の「ブロック」タブのバグ
+// (blocked/silenced フィルタが無視され全件返っていた) の regression guard。
+// blocked:true は meta.blockedHosts に exact 一致する host だけ、blocked:false
+// はそれ以外を返すこと。
+func TestInstances_BlockedFilter(t *testing.T) {
+	h, repo, metaRepo := newHandlerWithMeta(t)
+	seedInstance(t, repo, "blocked.example")
+	seedInstance(t, repo, "normal.example")
+	metaRepo.Meta = &model.Meta{BlockedHosts: pq.StringArray{"blocked.example"}}
+
+	c, rec := newReq(t, `{"blocked":true}`)
+	require.NoError(t, h.Instances(c))
+	assert.Equal(t, http.StatusOK, rec.Code)
+	assert.Contains(t, rec.Body.String(), "blocked.example")
+	assert.NotContains(t, rec.Body.String(), "normal.example")
+
+	c, rec = newReq(t, `{"blocked":false}`)
+	require.NoError(t, h.Instances(c))
+	assert.NotContains(t, rec.Body.String(), "blocked.example")
+	assert.Contains(t, rec.Body.String(), "normal.example")
+}
+
+// TestInstances_BlockedEmptyList: blockedHosts が空のとき blocked:true は 0 件
+// (本家の 1=0 相当)、blocked:false は全件返ること。
+func TestInstances_BlockedEmptyList(t *testing.T) {
+	h, repo, _ := newHandlerWithMeta(t)
+	seedInstance(t, repo, "normal.example")
+
+	c, rec := newReq(t, `{"blocked":true}`)
+	require.NoError(t, h.Instances(c))
+	assert.NotContains(t, rec.Body.String(), "normal.example")
+
+	c, rec = newReq(t, `{"blocked":false}`)
+	require.NoError(t, h.Instances(c))
+	assert.Contains(t, rec.Body.String(), "normal.example")
+}
+
+// TestInstances_SilencedFilter は silenced タブの同等 regression guard。
+func TestInstances_SilencedFilter(t *testing.T) {
+	h, repo, metaRepo := newHandlerWithMeta(t)
+	seedInstance(t, repo, "silenced.example")
+	seedInstance(t, repo, "normal.example")
+	metaRepo.Meta = &model.Meta{SilencedHosts: pq.StringArray{"silenced.example"}}
+
+	c, rec := newReq(t, `{"silenced":true}`)
+	require.NoError(t, h.Instances(c))
+	assert.Contains(t, rec.Body.String(), "silenced.example")
+	assert.NotContains(t, rec.Body.String(), "normal.example")
+
+	c, rec = newReq(t, `{"silenced":false}`)
+	require.NoError(t, h.Instances(c))
+	assert.NotContains(t, rec.Body.String(), "silenced.example")
+	assert.Contains(t, rec.Body.String(), "normal.example")
+}
+
+// TestInstances_StatusFields verifies isBlocked / isSilenced / isMediaSilenced
+// が meta との suffix-match で算出されレスポンスに載ること。サブドメインも
+// suffix-match で拾う (本家 InstanceEntityService と同じ)。
+func TestInstances_StatusFields(t *testing.T) {
+	h, repo, metaRepo := newHandlerWithMeta(t)
+	seedInstance(t, repo, "sub.blocked.example")
+	metaRepo.Meta = &model.Meta{
+		BlockedHosts:       pq.StringArray{"blocked.example"},
+		SilencedHosts:      pq.StringArray{"sub.blocked.example"},
+		MediaSilencedHosts: pq.StringArray{"other.example"},
+	}
+
+	c, rec := newReq(t, `{"host":"sub.blocked.example"}`)
+	require.NoError(t, h.Instances(c))
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	var got []map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &got))
+	require.Len(t, got, 1)
+	assert.Equal(t, true, got[0]["isBlocked"], "subdomain of blockedHosts entry is blocked")
+	assert.Equal(t, true, got[0]["isSilenced"])
+	assert.Equal(t, false, got[0]["isMediaSilenced"])
 }
 
 func TestInstances_BadJSON(t *testing.T) {

--- a/internal/api/federation/stats.go
+++ b/internal/api/federation/stats.go
@@ -33,11 +33,14 @@ func (h *Handler) Stats(c echo.Context) error {
 		return c.JSON(http.StatusOK, empty)
 	}
 
-	subs, err := h.svc.List(model.InstanceListFilter{SortBy: "-followers", Limit: req.Limit})
+	// "+" 接頭辞が DESC (= 上位順) なので、followers / following の多い順を
+	// 取るには +followers / +following を渡す (repository の sort の向きを本家
+	// TS の federation/instances に合わせたため)。
+	subs, err := h.svc.List(model.InstanceListFilter{SortBy: "+followers", Limit: req.Limit})
 	if err != nil {
 		return apierr.JSONInternalError(c)
 	}
-	pubs, err := h.svc.List(model.InstanceListFilter{SortBy: "-following", Limit: req.Limit})
+	pubs, err := h.svc.List(model.InstanceListFilter{SortBy: "+following", Limit: req.Limit})
 	if err != nil {
 		return apierr.JSONInternalError(c)
 	}
@@ -46,17 +49,21 @@ func (h *Handler) Stats(c echo.Context) error {
 		return apierr.JSONInternalError(c)
 	}
 
+	// isBlocked / isSilenced / isMediaSilenced 用に meta の host 一覧を 1 度
+	// だけ取得し、両リストの pack で使い回す。
+	blockedHosts, silencedHosts, mediaSilencedHosts := h.svc.FederationHostLists()
+
 	topSubFollowers := 0
 	topSub := make([]map[string]any, 0, len(subs))
 	for _, inst := range subs {
 		topSubFollowers += inst.FollowersCount
-		topSub = append(topSub, instanceToMap(inst))
+		topSub = append(topSub, instanceToMap(inst, blockedHosts, silencedHosts, mediaSilencedHosts))
 	}
 	topPubFollowing := 0
 	topPub := make([]map[string]any, 0, len(pubs))
 	for _, inst := range pubs {
 		topPubFollowing += inst.FollowingCount
-		topPub = append(topPub, instanceToMap(inst))
+		topPub = append(topPub, instanceToMap(inst, blockedHosts, silencedHosts, mediaSilencedHosts))
 	}
 
 	return c.JSON(http.StatusOK, map[string]any{

--- a/internal/api/federation/stats.go
+++ b/internal/api/federation/stats.go
@@ -51,19 +51,22 @@ func (h *Handler) Stats(c echo.Context) error {
 
 	// isBlocked / isSilenced / isMediaSilenced 用に meta の host 一覧を 1 度
 	// だけ取得し、両リストの pack で使い回す。
-	blockedHosts, silencedHosts, mediaSilencedHosts := h.svc.FederationHostLists()
+	hosts, err := h.svc.FederationHostLists()
+	if err != nil {
+		return apierr.JSONInternalError(c)
+	}
 
 	topSubFollowers := 0
 	topSub := make([]map[string]any, 0, len(subs))
 	for _, inst := range subs {
 		topSubFollowers += inst.FollowersCount
-		topSub = append(topSub, instanceToMap(inst, blockedHosts, silencedHosts, mediaSilencedHosts))
+		topSub = append(topSub, instanceToMap(inst, hosts))
 	}
 	topPubFollowing := 0
 	topPub := make([]map[string]any, 0, len(pubs))
 	for _, inst := range pubs {
 		topPubFollowing += inst.FollowingCount
-		topPub = append(topPub, instanceToMap(inst, blockedHosts, silencedHosts, mediaSilencedHosts))
+		topPub = append(topPub, instanceToMap(inst, hosts))
 	}
 
 	return c.JSON(http.StatusOK, map[string]any{

--- a/internal/api/federation/stats_test.go
+++ b/internal/api/federation/stats_test.go
@@ -15,6 +15,15 @@ func TestStats_EmptyService(t *testing.T) {
 	assert.Equal(t, http.StatusOK, postStub(h.Stats).Code)
 }
 
+// TestStats_MetaError: instance List は成功しても meta が読めなければ
+// isBlocked 等を埋められないので 500。
+func TestStats_MetaError(t *testing.T) {
+	h, instRepo, metaRepo := newHandlerWithMeta(t)
+	_ = instRepo.Create(&model.Instance{ID: "inst-1", Host: "alpha.example", FollowersCount: 1})
+	metaRepo.Meta = nil
+	assert.Equal(t, http.StatusInternalServerError, postBody(h.Stats, `{"limit":2}`).Code)
+}
+
 func TestStats_WithTopInstances(t *testing.T) {
 	h, instRepo := newHandler(t)
 	// 3 instance を登録。2 は top に入り、1 は "other" に流れる想定で
@@ -39,4 +48,8 @@ func TestStats_WithTopInstances(t *testing.T) {
 	// topPubInstances は following 上位 2 件 = 20 + 5 = 25
 	// 合計 following = 28、other = 3
 	assert.EqualValues(t, 3, body["otherFollowingCount"])
+	// host 順 (alpha/beta/gamma) と following 順 (beta/alpha/gamma) は食い違う。
+	// topPub 先頭が beta であることで +following DESC の sort が実際に効いて
+	// いる (= host 順に素通りしていない) ことを担保する。
+	assert.Equal(t, "beta.example", topPub[0].(map[string]any)["host"])
 }

--- a/internal/core/instance/instance_service.go
+++ b/internal/core/instance/instance_service.go
@@ -176,17 +176,34 @@ func (s *Service) IsSilenced(host string) bool {
 	return HostMatchesAny(meta.SilencedHosts, host)
 }
 
+// FederationHostSets bundles the host lists that drive the federation panel's
+// blocked / silenced / media-silenced state. 3 つとも同じ []string なので、
+// 位置引数で取り違えないよう named field の struct にまとめる。
+type FederationHostSets struct {
+	Blocked       []string
+	Silenced      []string
+	MediaSilenced []string
+}
+
 // FederationHostLists returns the blocked / silenced / media-silenced host
 // lists from meta. federation/instances ハンドラがフィルタ突合と、レスポンスの
 // isBlocked / isSilenced / isMediaSilenced 算出の双方で使うため、meta を 1 回
-// だけ読んで使い回す入口。meta が読めない場合は nil を返す (ベストエフォート;
-// admin federation 一覧が transient error で完全に落ちるのを避ける)。
-func (s *Service) FederationHostLists() (blocked, silenced, mediaSilenced []string) {
+// だけ読んで使い回す入口。
+//
+// IsBlocked / IsSilenced (inbox hot path) はベストエフォートで meta error を
+// 握り潰すが、こちらは admin endpoint 専用なので error をそのまま返す: meta が
+// 読めない状況は本家 TS でも 500 になり (metaService.fetch が throw)、空一覧を
+// 200 で返して「ブロックなし」と誤表示するより安全。
+func (s *Service) FederationHostLists() (FederationHostSets, error) {
 	meta, err := s.metaRepo.Fetch()
 	if err != nil {
-		return nil, nil, nil
+		return FederationHostSets{}, err
 	}
-	return meta.BlockedHosts, meta.SilencedHosts, meta.MediaSilencedHosts
+	return FederationHostSets{
+		Blocked:       meta.BlockedHosts,
+		Silenced:      meta.SilencedHosts,
+		MediaSilenced: meta.MediaSilencedHosts,
+	}, nil
 }
 
 // IsAllowed reports whether the local instance is willing to federate with

--- a/internal/core/instance/instance_service.go
+++ b/internal/core/instance/instance_service.go
@@ -161,7 +161,7 @@ func (s *Service) IsBlocked(host string) bool {
 	if err != nil {
 		return false
 	}
-	return hostMatchesAny(meta.BlockedHosts, host)
+	return HostMatchesAny(meta.BlockedHosts, host)
 }
 
 // IsSilenced reports whether the host matches an entry in meta.silencedHosts.
@@ -173,7 +173,20 @@ func (s *Service) IsSilenced(host string) bool {
 	if err != nil {
 		return false
 	}
-	return hostMatchesAny(meta.SilencedHosts, host)
+	return HostMatchesAny(meta.SilencedHosts, host)
+}
+
+// FederationHostLists returns the blocked / silenced / media-silenced host
+// lists from meta. federation/instances ハンドラがフィルタ突合と、レスポンスの
+// isBlocked / isSilenced / isMediaSilenced 算出の双方で使うため、meta を 1 回
+// だけ読んで使い回す入口。meta が読めない場合は nil を返す (ベストエフォート;
+// admin federation 一覧が transient error で完全に落ちるのを避ける)。
+func (s *Service) FederationHostLists() (blocked, silenced, mediaSilenced []string) {
+	meta, err := s.metaRepo.Fetch()
+	if err != nil {
+		return nil, nil, nil
+	}
+	return meta.BlockedHosts, meta.SilencedHosts, meta.MediaSilencedHosts
 }
 
 // IsAllowed reports whether the local instance is willing to federate with
@@ -207,14 +220,14 @@ func (s *Service) IsAllowed(host string) bool {
 	case "none":
 		return false
 	case "specified":
-		if !hostMatchesAny(meta.FederationHosts, host) {
+		if !HostMatchesAny(meta.FederationHosts, host) {
 			return false
 		}
 	}
-	return !hostMatchesAny(meta.BlockedHosts, host)
+	return !HostMatchesAny(meta.BlockedHosts, host)
 }
 
-// hostMatchesAny reports whether host (case-insensitive, Unicode-aware)
+// HostMatchesAny reports whether host (case-insensitive, Unicode-aware)
 // matches any of the given patterns under Misskey TS's suffix-match rule.
 // A pattern matches if host equals it, or host ends with `.<pattern>`
 // (i.e. host is a subdomain).
@@ -228,7 +241,7 @@ func (s *Service) IsAllowed(host string) bool {
 // ガードが既に効くので "." 単独が任意 host に誤マッチすることは無いが、
 // admin が誤って空エントリを混入させた場合に "全 host を allow / block" に
 // 化けない defensive guard を残す)。
-func hostMatchesAny(patterns []string, host string) bool {
+func HostMatchesAny(patterns []string, host string) bool {
 	if host == "" {
 		return false
 	}

--- a/internal/core/instance/instance_service_test.go
+++ b/internal/core/instance/instance_service_test.go
@@ -155,20 +155,19 @@ func TestService_FederationHostLists(t *testing.T) {
 	metaRepo.Meta.BlockedHosts = pq.StringArray{"bad.example"}
 	metaRepo.Meta.SilencedHosts = pq.StringArray{"quiet.example"}
 	metaRepo.Meta.MediaSilencedHosts = pq.StringArray{"media.example"}
-	blocked, silenced, mediaSilenced := svc.FederationHostLists()
-	assert.Equal(t, []string{"bad.example"}, []string(blocked))
-	assert.Equal(t, []string{"quiet.example"}, []string(silenced))
-	assert.Equal(t, []string{"media.example"}, []string(mediaSilenced))
+	hosts, err := svc.FederationHostLists()
+	require.NoError(t, err)
+	assert.Equal(t, []string{"bad.example"}, []string(hosts.Blocked))
+	assert.Equal(t, []string{"quiet.example"}, []string(hosts.Silenced))
+	assert.Equal(t, []string{"media.example"}, []string(hosts.MediaSilenced))
 }
 
-// meta が読めない場合は 3 つとも nil を返す (ベストエフォート)。
+// meta が読めない場合は error を返す (admin endpoint なので握り潰さない)。
 func TestService_FederationHostLists_MetaError(t *testing.T) {
 	svc, _, metaRepo := newService(t)
 	metaRepo.Meta = nil
-	blocked, silenced, mediaSilenced := svc.FederationHostLists()
-	assert.Nil(t, blocked)
-	assert.Nil(t, silenced)
-	assert.Nil(t, mediaSilenced)
+	_, err := svc.FederationHostLists()
+	assert.Error(t, err)
 }
 
 // federation == "all" (default) は blockedHosts 以外の全 host を allow する。

--- a/internal/core/instance/instance_service_test.go
+++ b/internal/core/instance/instance_service_test.go
@@ -150,6 +150,27 @@ func TestService_IsSilenced_MetaError(t *testing.T) {
 	assert.False(t, svc.IsSilenced("any.example"))
 }
 
+func TestService_FederationHostLists(t *testing.T) {
+	svc, _, metaRepo := newService(t)
+	metaRepo.Meta.BlockedHosts = pq.StringArray{"bad.example"}
+	metaRepo.Meta.SilencedHosts = pq.StringArray{"quiet.example"}
+	metaRepo.Meta.MediaSilencedHosts = pq.StringArray{"media.example"}
+	blocked, silenced, mediaSilenced := svc.FederationHostLists()
+	assert.Equal(t, []string{"bad.example"}, []string(blocked))
+	assert.Equal(t, []string{"quiet.example"}, []string(silenced))
+	assert.Equal(t, []string{"media.example"}, []string(mediaSilenced))
+}
+
+// meta が読めない場合は 3 つとも nil を返す (ベストエフォート)。
+func TestService_FederationHostLists_MetaError(t *testing.T) {
+	svc, _, metaRepo := newService(t)
+	metaRepo.Meta = nil
+	blocked, silenced, mediaSilenced := svc.FederationHostLists()
+	assert.Nil(t, blocked)
+	assert.Nil(t, silenced)
+	assert.Nil(t, mediaSilenced)
+}
+
 // federation == "all" (default) は blockedHosts 以外の全 host を allow する。
 func TestService_IsAllowed_AllMode(t *testing.T) {
 	svc, _, metaRepo := newService(t)
@@ -228,7 +249,7 @@ func TestService_HostMatching(t *testing.T) {
 		// defensive guard)。
 		{name: "empty pattern never matches", pattern: "", host: "example.com", want: false},
 		// IDN raw 表記 (Punycode 化前) でも case-insensitive で一致すること。
-		// strings.ToLower は ASCII 専用だが hostMatchesAny は Unicode-aware
+		// strings.ToLower は ASCII 専用だが HostMatchesAny は Unicode-aware
 		// な x/text/cases.Caser を通しているので、TS の String.toLowerCase()
 		// と同じ挙動を保てる (#590 review #5)。
 		{name: "unicode case-insensitive (German)", pattern: "müNSTer.example", host: "MÜNSTER.example", want: true},

--- a/internal/model/instance.go
+++ b/internal/model/instance.go
@@ -51,6 +51,16 @@ type InstanceListFilter struct {
 	Federating    *bool // followingCount > 0 OR followersCount > 0
 	Subscribing   *bool // followersCount > 0 (向こうがフォローしてくる)
 	Publishing    *bool // followingCount > 0 (こちらからフォローしている)
+	// Blocked / Silenced は instance 列ではなく meta.blockedHosts /
+	// silencedHosts との突合で判定する。突合対象の host 一覧は service 層が
+	// meta から解決して BlockedHosts / SilencedHosts に詰める。本家 TS の
+	// federation/instances と同じく exact host IN/NOT IN matching を使う
+	// (suffix match の IsBlocked / IsSilenced とは別物)。BlockedHosts /
+	// SilencedHosts は対応する *bool が non-nil のときだけ参照される。
+	Blocked       *bool
+	Silenced      *bool
+	BlockedHosts  []string
+	SilencedHosts []string
 	SortBy        string
 	Limit         int
 	Offset        int

--- a/internal/repository/instance.go
+++ b/internal/repository/instance.go
@@ -154,6 +154,34 @@ func (r *instanceRepository) List(filter model.InstanceListFilter) ([]*model.Ins
 			q = q.Where("\"followingCount\" = 0")
 		}
 	}
+	// blocked / silenced は service が meta から解決した host 一覧との exact
+	// IN / NOT IN で突合する (本家 federation/instances と同じ semantics):
+	//   - X == true  かつ list 空 → 0 件 (1 = 0)
+	//   - X == true  かつ list あり → host IN (list)
+	//   - X == false かつ list 空 → 全件 (条件なし)
+	//   - X == false かつ list あり → host NOT IN (list)
+	if filter.Blocked != nil {
+		if *filter.Blocked {
+			if len(filter.BlockedHosts) == 0 {
+				q = q.Where("1 = 0")
+			} else {
+				q = q.Where("host IN ?", filter.BlockedHosts)
+			}
+		} else if len(filter.BlockedHosts) > 0 {
+			q = q.Where("host NOT IN ?", filter.BlockedHosts)
+		}
+	}
+	if filter.Silenced != nil {
+		if *filter.Silenced {
+			if len(filter.SilencedHosts) == 0 {
+				q = q.Where("1 = 0")
+			} else {
+				q = q.Where("host IN ?", filter.SilencedHosts)
+			}
+		} else if len(filter.SilencedHosts) > 0 {
+			q = q.Where("host NOT IN ?", filter.SilencedHosts)
+		}
+	}
 	cursor := filter.SinceID != "" || filter.UntilID != ""
 	if filter.SinceID != "" {
 		q = q.Where("id > ?", filter.SinceID)
@@ -164,32 +192,46 @@ func (r *instanceRepository) List(filter model.InstanceListFilter) ([]*model.Ins
 	if cursor {
 		q = q.Order(paginationOrder(filter.SinceID, filter.UntilID, "id"))
 	} else {
+		// sort key の向きは本家 federation/instances に合わせる: 接頭辞 "+" が
+		// DESC、"-" が ASC (frontend のラベルも "+notes" = 降順)。pubSub は
+		// followingCount → followersCount の複合ソート。+host / -host は本家に
+		// 無い mk-go 拡張なので従来どおり host の昇順 / 降順を維持する。
 		switch filter.SortBy {
+		case "+pubSub":
+			q = q.Order("\"followingCount\" DESC").Order("\"followersCount\" DESC")
+		case "-pubSub":
+			q = q.Order("\"followingCount\" ASC").Order("\"followersCount\" ASC")
+		case "+notes":
+			q = q.Order("\"notesCount\" DESC")
+		case "-notes":
+			q = q.Order("\"notesCount\" ASC")
+		case "+users":
+			q = q.Order("\"usersCount\" DESC")
+		case "-users":
+			q = q.Order("\"usersCount\" ASC")
+		case "+following":
+			q = q.Order("\"followingCount\" DESC")
+		case "-following":
+			q = q.Order("\"followingCount\" ASC")
+		case "+followers":
+			q = q.Order("\"followersCount\" DESC")
+		case "-followers":
+			q = q.Order("\"followersCount\" ASC")
+		case "+firstRetrievedAt":
+			q = q.Order("\"firstRetrievedAt\" DESC")
+		case "-firstRetrievedAt":
+			q = q.Order("\"firstRetrievedAt\" ASC")
+		case "+latestRequestReceivedAt":
+			q = q.Order("\"latestRequestReceivedAt\" DESC NULLS LAST")
+		case "-latestRequestReceivedAt":
+			q = q.Order("\"latestRequestReceivedAt\" ASC NULLS FIRST")
 		case "+host":
 			q = q.Order("host ASC")
 		case "-host":
 			q = q.Order("host DESC")
-		case "+notes":
-			q = q.Order("\"notesCount\" ASC")
-		case "-notes":
-			q = q.Order("\"notesCount\" DESC")
-		case "+users":
-			q = q.Order("\"usersCount\" ASC")
-		case "-users":
-			q = q.Order("\"usersCount\" DESC")
-		case "+following":
-			q = q.Order("\"followingCount\" ASC")
-		case "-following":
-			q = q.Order("\"followingCount\" DESC")
-		case "+followers":
-			q = q.Order("\"followersCount\" ASC")
-		case "-followers":
-			q = q.Order("\"followersCount\" DESC")
-		case "+firstRetrievedAt":
-			q = q.Order("\"firstRetrievedAt\" ASC")
 		default:
-			// デフォルトは新しい順
-			q = q.Order("\"firstRetrievedAt\" DESC")
+			// 本家 TS は sort 未指定時 instance.id DESC (= aidx なので新しい順)。
+			q = q.Order("id DESC")
 		}
 	}
 	limit := filter.Limit

--- a/internal/repository/instance_test.go
+++ b/internal/repository/instance_test.go
@@ -193,6 +193,57 @@ func TestInstanceRepository_List_Filters(t *testing.T) {
 	assert.Len(t, rows, 2) // b と c
 }
 
+// TestInstanceRepository_List_BlockedSilenced exercises the exact host
+// IN/NOT IN matching used by the blocked / silenced filters, including the
+// empty-list edge cases (true+empty -> 0 rows, false+empty -> all rows).
+func TestInstanceRepository_List_BlockedSilenced(t *testing.T) {
+	repo := NewInstanceRepository(testDB)
+	blocked := newTestInstance("i_ir_bs_a", "bs-blocked.example")
+	silenced := newTestInstance("i_ir_bs_b", "bs-silenced.example")
+	normal := newTestInstance("i_ir_bs_c", "bs-normal.example")
+	for _, inst := range []*model.Instance{blocked, silenced, normal} {
+		require.NoError(t, repo.Create(inst))
+		defer cleanupInstance(t, inst.ID)
+	}
+
+	blockedHosts := []string{"bs-blocked.example"}
+	silencedHosts := []string{"bs-silenced.example"}
+	tt := true
+	ff := false
+
+	rows, err := repo.List(model.InstanceListFilter{Host: "bs-", Blocked: &tt, BlockedHosts: blockedHosts})
+	require.NoError(t, err)
+	require.Len(t, rows, 1)
+	assert.Equal(t, "bs-blocked.example", rows[0].Host)
+
+	rows, err = repo.List(model.InstanceListFilter{Host: "bs-", Blocked: &ff, BlockedHosts: blockedHosts})
+	require.NoError(t, err)
+	assert.Len(t, rows, 2) // silenced と normal
+
+	// blocked:true かつ blockedHosts が空 -> 0 件 (本家 1=0 相当)。
+	rows, err = repo.List(model.InstanceListFilter{Host: "bs-", Blocked: &tt})
+	require.NoError(t, err)
+	assert.Empty(t, rows)
+
+	// blocked:false かつ blockedHosts が空 -> 条件なしで全件。
+	rows, err = repo.List(model.InstanceListFilter{Host: "bs-", Blocked: &ff})
+	require.NoError(t, err)
+	assert.Len(t, rows, 3)
+
+	rows, err = repo.List(model.InstanceListFilter{Host: "bs-", Silenced: &tt, SilencedHosts: silencedHosts})
+	require.NoError(t, err)
+	require.Len(t, rows, 1)
+	assert.Equal(t, "bs-silenced.example", rows[0].Host)
+
+	rows, err = repo.List(model.InstanceListFilter{Host: "bs-", Silenced: &ff, SilencedHosts: silencedHosts})
+	require.NoError(t, err)
+	assert.Len(t, rows, 2) // blocked と normal
+
+	rows, err = repo.List(model.InstanceListFilter{Host: "bs-", Silenced: &tt})
+	require.NoError(t, err)
+	assert.Empty(t, rows)
+}
+
 func TestInstanceRepository_List_Sort(t *testing.T) {
 	repo := NewInstanceRepository(testDB)
 	a := newTestInstance("i_ir_5a", "sort-a.example")
@@ -208,12 +259,78 @@ func TestInstanceRepository_List_Sort(t *testing.T) {
 
 	for _, sortBy := range []string{
 		"+host", "-host", "+notes", "-notes", "+users", "-users",
-		"+firstRetrievedAt", "",
+		"+following", "-following", "+followers", "-followers",
+		"+pubSub", "-pubSub", "+firstRetrievedAt", "-firstRetrievedAt",
+		"+latestRequestReceivedAt", "-latestRequestReceivedAt", "",
 	} {
 		rows, err := repo.List(model.InstanceListFilter{Host: "sort-", SortBy: sortBy, Limit: 10})
 		require.NoError(t, err)
-		assert.Len(t, rows, 2)
+		assert.Len(t, rows, 2, "sort=%s", sortBy)
 	}
+}
+
+// TestInstanceRepository_List_SortDirection は sort key の向きが本家 TS と
+// 一致すること (= "+" が DESC、"-" が ASC) を実順序で検証する regression
+// guard。以前は向きが逆 (frontend の "降順" ラベルと食い違い) だった。
+func TestInstanceRepository_List_SortDirection(t *testing.T) {
+	repo := NewInstanceRepository(testDB)
+	now := time.Now()
+	low := newTestInstance("i_ir_6a", "sortdir-low.example")
+	low.NotesCount = 1
+	low.FollowersCount = 1
+	low.FollowingCount = 1
+	lowReq := now.Add(-2 * time.Hour)
+	low.LatestRequestReceivedAt = &lowReq
+	high := newTestInstance("i_ir_6b", "sortdir-high.example")
+	high.NotesCount = 100
+	high.FollowersCount = 50
+	high.FollowingCount = 80
+	highReq := now.Add(-1 * time.Hour)
+	high.LatestRequestReceivedAt = &highReq
+	for _, inst := range []*model.Instance{low, high} {
+		require.NoError(t, repo.Create(inst))
+		defer cleanupInstance(t, inst.ID)
+	}
+
+	// "+" は DESC: 値の大きい high が先頭。
+	for _, sortBy := range []string{"+notes", "+followers", "+following", "+pubSub", "+latestRequestReceivedAt"} {
+		rows, err := repo.List(model.InstanceListFilter{Host: "sortdir-", SortBy: sortBy, Limit: 10})
+		require.NoError(t, err)
+		require.Len(t, rows, 2, "sort=%s", sortBy)
+		assert.Equal(t, "sortdir-high.example", rows[0].Host, "sort=%s should put larger value first", sortBy)
+	}
+	// "-" は ASC: 値の小さい low が先頭。
+	for _, sortBy := range []string{"-notes", "-followers", "-following", "-pubSub", "-latestRequestReceivedAt"} {
+		rows, err := repo.List(model.InstanceListFilter{Host: "sortdir-", SortBy: sortBy, Limit: 10})
+		require.NoError(t, err)
+		require.Len(t, rows, 2, "sort=%s", sortBy)
+		assert.Equal(t, "sortdir-low.example", rows[0].Host, "sort=%s should put smaller value first", sortBy)
+	}
+}
+
+// TestInstanceRepository_List_LatestRequestNullsOrder verifies the NULLS LAST /
+// NULLS FIRST handling for latestRequestReceivedAt: +(DESC) keeps NULLs last,
+// -(ASC) puts NULLs first.
+func TestInstanceRepository_List_LatestRequestNullsOrder(t *testing.T) {
+	repo := NewInstanceRepository(testDB)
+	withTime := newTestInstance("i_ir_7a", "nulls-has.example")
+	ts := time.Now().Add(-1 * time.Hour)
+	withTime.LatestRequestReceivedAt = &ts
+	noTime := newTestInstance("i_ir_7b", "nulls-none.example") // latestRequestReceivedAt = NULL
+	for _, inst := range []*model.Instance{withTime, noTime} {
+		require.NoError(t, repo.Create(inst))
+		defer cleanupInstance(t, inst.ID)
+	}
+
+	rows, err := repo.List(model.InstanceListFilter{Host: "nulls-", SortBy: "+latestRequestReceivedAt", Limit: 10})
+	require.NoError(t, err)
+	require.Len(t, rows, 2)
+	assert.Equal(t, "nulls-none.example", rows[1].Host, "NULL sorts last on +(DESC)")
+
+	rows, err = repo.List(model.InstanceListFilter{Host: "nulls-", SortBy: "-latestRequestReceivedAt", Limit: 10})
+	require.NoError(t, err)
+	require.Len(t, rows, 2)
+	assert.Equal(t, "nulls-none.example", rows[0].Host, "NULL sorts first on -(ASC)")
 }
 
 func TestInstanceRepository_List_LimitClamp(t *testing.T) {

--- a/internal/testutil/mock_repository.go
+++ b/internal/testutil/mock_repository.go
@@ -2566,6 +2566,20 @@ func (m *MockInstanceRepository) List(filter model.InstanceListFilter) ([]*model
 				continue
 			}
 		}
+		// blocked / silenced は real repository と同じ exact host IN/NOT IN
+		// semantics を再現する。membership と *bool が食い違う行を除外すると、
+		// 空リスト + true → 全除外、空リスト + false → 全件、という TS 互換の
+		// 挙動になる。
+		if filter.Blocked != nil {
+			if hostInList(inst.Host, filter.BlockedHosts) != *filter.Blocked {
+				continue
+			}
+		}
+		if filter.Silenced != nil {
+			if hostInList(inst.Host, filter.SilencedHosts) != *filter.Silenced {
+				continue
+			}
+		}
 		rows = append(rows, inst)
 	}
 	for i := 0; i < len(rows); i++ {
@@ -2587,6 +2601,18 @@ func (m *MockInstanceRepository) List(filter model.InstanceListFilter) ([]*model
 		end = len(rows)
 	}
 	return rows[filter.Offset:end], nil
+}
+
+// hostInList reports exact (case-sensitive) membership of host in list.
+// Mirrors the repository's `host IN (...)` matching used for the blocked /
+// silenced filters.
+func hostInList(host string, list []string) bool {
+	for _, h := range list {
+		if h == host {
+			return true
+		}
+	}
+	return false
 }
 
 func applyInstanceFields(i *model.Instance, fields map[string]any) {

--- a/internal/testutil/mock_repository.go
+++ b/internal/testutil/mock_repository.go
@@ -2582,13 +2582,7 @@ func (m *MockInstanceRepository) List(filter model.InstanceListFilter) ([]*model
 		}
 		rows = append(rows, inst)
 	}
-	for i := 0; i < len(rows); i++ {
-		for j := i + 1; j < len(rows); j++ {
-			if rows[i].Host > rows[j].Host {
-				rows[i], rows[j] = rows[j], rows[i]
-			}
-		}
-	}
+	sortMockInstances(rows, filter.SortBy)
 	limit := filter.Limit
 	if limit <= 0 || limit > 100 {
 		limit = 30
@@ -2601,6 +2595,83 @@ func (m *MockInstanceRepository) List(filter model.InstanceListFilter) ([]*model
 		end = len(rows)
 	}
 	return rows[filter.Offset:end], nil
+}
+
+// sortMockInstances orders rows in place to mirror the real
+// instanceRepository.List sort semantics: "+" prefix is DESC, "-" is ASC,
+// +pubSub is a (followingCount, followersCount) composite, latestRequestReceivedAt
+// honours NULLS LAST/FIRST, and the empty/default key falls back to id DESC.
+// Keeping this faithful lets handler-level tests (e.g. federation/stats top-N
+// selection) actually exercise the chosen sort key.
+func sortMockInstances(rows []*model.Instance, sortBy string) {
+	reqTime := func(t *time.Time) (int64, bool) {
+		if t == nil {
+			return 0, false
+		}
+		return t.UnixNano(), true
+	}
+	var less func(a, b *model.Instance) bool
+	switch sortBy {
+	case "+pubSub":
+		less = func(a, b *model.Instance) bool {
+			if a.FollowingCount != b.FollowingCount {
+				return a.FollowingCount > b.FollowingCount
+			}
+			return a.FollowersCount > b.FollowersCount
+		}
+	case "-pubSub":
+		less = func(a, b *model.Instance) bool {
+			if a.FollowingCount != b.FollowingCount {
+				return a.FollowingCount < b.FollowingCount
+			}
+			return a.FollowersCount < b.FollowersCount
+		}
+	case "+notes":
+		less = func(a, b *model.Instance) bool { return a.NotesCount > b.NotesCount }
+	case "-notes":
+		less = func(a, b *model.Instance) bool { return a.NotesCount < b.NotesCount }
+	case "+users":
+		less = func(a, b *model.Instance) bool { return a.UsersCount > b.UsersCount }
+	case "-users":
+		less = func(a, b *model.Instance) bool { return a.UsersCount < b.UsersCount }
+	case "+following":
+		less = func(a, b *model.Instance) bool { return a.FollowingCount > b.FollowingCount }
+	case "-following":
+		less = func(a, b *model.Instance) bool { return a.FollowingCount < b.FollowingCount }
+	case "+followers":
+		less = func(a, b *model.Instance) bool { return a.FollowersCount > b.FollowersCount }
+	case "-followers":
+		less = func(a, b *model.Instance) bool { return a.FollowersCount < b.FollowersCount }
+	case "+firstRetrievedAt":
+		less = func(a, b *model.Instance) bool { return a.FirstRetrievedAt.After(b.FirstRetrievedAt) }
+	case "-firstRetrievedAt":
+		less = func(a, b *model.Instance) bool { return a.FirstRetrievedAt.Before(b.FirstRetrievedAt) }
+	case "+latestRequestReceivedAt": // DESC NULLS LAST
+		less = func(a, b *model.Instance) bool {
+			av, aok := reqTime(a.LatestRequestReceivedAt)
+			bv, bok := reqTime(b.LatestRequestReceivedAt)
+			if aok != bok {
+				return aok // non-NULL sorts before NULL
+			}
+			return av > bv
+		}
+	case "-latestRequestReceivedAt": // ASC NULLS FIRST
+		less = func(a, b *model.Instance) bool {
+			av, aok := reqTime(a.LatestRequestReceivedAt)
+			bv, bok := reqTime(b.LatestRequestReceivedAt)
+			if aok != bok {
+				return !aok // NULL sorts before non-NULL
+			}
+			return av < bv
+		}
+	case "+host":
+		less = func(a, b *model.Instance) bool { return a.Host < b.Host }
+	case "-host":
+		less = func(a, b *model.Instance) bool { return a.Host > b.Host }
+	default:
+		less = func(a, b *model.Instance) bool { return a.ID > b.ID }
+	}
+	sort.SliceStable(rows, func(i, j int) bool { return less(rows[i], rows[j]) })
 }
 
 // hostInList reports exact (case-sensitive) membership of host in list.


### PR DESCRIPTION
## Summary

コントロールパネル→連合 で、ブロックも配送停止(サイレンス)もしていない購読/配信中のサーバーが、すべて「ブロック一覧」「サイレンス一覧」タブに表示されるバグを修正する。

原因は `/api/federation/instances` が `blocked` / `silenced` フィルタを実装しておらず、frontend が送る `{ blocked: true }` / `{ silenced: true }` を `c.Bind` で読み捨て、フィルタが効かず全インスタンスを返していたこと。本家ではこの 2 つは `instance` 列ではなく `meta.blockedHosts` / `silencedHosts` との `host IN/NOT IN` 突合で判定する。

調査中に判明した同エンドポイントの drift も併せて修正する (#1272 でスコープ合意済み)。

## 主な変更点

### blocked / silenced フィルタ (本バグ)
- `InstancesRequest` / `InstanceListFilter` に `Blocked` / `Silenced` を追加。
- service が `meta` から解決した host 一覧を filter に詰め、`repository.List` が exact `host IN/NOT IN` で突合 (空リスト時: true→0件 / false→全件 と本家準拠)。

### エンティティ shape
- レスポンスに `isBlocked` / `isSilenced` / `isMediaSilenced` を追加 (本家 `InstanceEntityService` と同じく meta との suffix-match)。これが無いと連合パネルのステータスバッジ(`getStatus`)が Blocked/Silenced を表示できなかった。
- `federation/stats` の top instances も同じ shape に揃える。
- `hostMatchesAny` を `HostMatchesAny` に export し packer から再利用。

### sort の向き (同一エンドポイントの drift)
- `repository.List` の sort が全フィールドで本家 TS と逆だった (`+notes` が TS=DESC に対し mk-go=ASC、frontend ラベル「ノート(降順)=+notes」とも食い違い)。`+`=DESC / `-`=ASC に統一。
- 未対応だった `+pubSub`/`-pubSub` (followingCount→followersCount 複合)・`+/-latestRequestReceivedAt` (NULLS LAST/FIRST)・`-firstRetrievedAt` を追加。default を `id DESC` に変更。
- 向きの修正に伴い `stats.go` の top instances 取得を `-followers`/`-following` → `+followers`/`+following` に変更 (=DESC=上位順を維持)。

## テスト

追加:
- handler: blocked/silenced 各フィルタ、空リストのエッジケース、サブドメインの suffix-match 表示 (`TestInstances_BlockedFilter` / `BlockedEmptyList` / `SilencedFilter` / `StatusFields`)
- repository: 実DBで blocked/silenced の IN/NOT IN + 空リスト (`TestInstanceRepository_List_BlockedSilenced`)、sort の実順序 (`...SortDirection`)、NULLS 順序 (`...LatestRequestNullsOrder`)
- service: `FederationHostLists` 正常系/meta読込失敗系
- testutil mock の `List` にも blocked/silenced 突合を再現

実行:
```bash
go test ./internal/api/federation/... ./internal/core/instance/... ./internal/repository/...
make fmt && make lint
```

- カバレッジ: federation 92.6% / core/instance 96.6% / repository 90.1% (いずれも 90% ゲート超)
- `go test ./...` は無関係な flaky e2e (`TestReversi_ReadyPropagatesAndStarts`、WebSocket タイミング依存) を除き green。単独再実行で pass を確認済み。

## Closes

Closes #1272
