### PR TITLE
test(api): L3 実レスポンス検証を notes/users/drive へ拡大

### DIFF
--- a/internal/api/drive/handler_test.go
+++ b/internal/api/drive/handler_test.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/labstack/echo/v4"
 	coredrive "github.com/shiroha-a/mk/internal/core/drive"
+	"github.com/shiroha-a/mk/internal/entitycompat/shapetest"
 	"github.com/shiroha-a/mk/internal/misc/id"
 	"github.com/shiroha-a/mk/internal/model"
 	"github.com/shiroha-a/mk/internal/server/middleware"
@@ -101,6 +102,8 @@ func TestFilesCreate_AllFormFields(t *testing.T) {
 	// userId / user は null を返す (#812)。
 	assert.Nil(t, resp["userId"])
 	assert.Nil(t, resp["user"])
+	// L3 (#1270): drive/files/create の実レスポンスを golden DriveFile に突合する。
+	shapetest.Assert(t, "DriveFile", resp)
 }
 
 // TestFilesCreate_RecordsRequestIPAndHeaders guards #1148 root cause:

--- a/internal/api/notes/handler_test.go
+++ b/internal/api/notes/handler_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/labstack/echo/v4"
 	"github.com/shiroha-a/mk/internal/api/apierr"
 	corenote "github.com/shiroha-a/mk/internal/core/note"
+	"github.com/shiroha-a/mk/internal/entitycompat/shapetest"
 	"github.com/shiroha-a/mk/internal/misc/id"
 	"github.com/shiroha-a/mk/internal/model"
 	"github.com/shiroha-a/mk/internal/server/middleware"
@@ -179,6 +180,8 @@ func TestShow_Success(t *testing.T) {
 	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
 	assert.Equal(t, "note1", resp["id"])
 	assert.Equal(t, "existing note", resp["text"])
+	// L3 (#1270): notes/show の実レスポンスを golden Note に突合する。
+	shapetest.Assert(t, "Note", resp)
 }
 
 func TestShow_AttachmentEmbedsFolderAndUser(t *testing.T) {

--- a/internal/api/users/handler_test.go
+++ b/internal/api/users/handler_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/labstack/echo/v4"
 	corefollowing "github.com/shiroha-a/mk/internal/core/following"
 	coreuser "github.com/shiroha-a/mk/internal/core/user"
+	"github.com/shiroha-a/mk/internal/entitycompat/shapetest"
 	"github.com/shiroha-a/mk/internal/misc/id"
 	"github.com/shiroha-a/mk/internal/model"
 	"github.com/shiroha-a/mk/internal/server/middleware"
@@ -92,6 +93,9 @@ func TestShow_ByUserID(t *testing.T) {
 	assert.Equal(t, "user1", resp["id"])
 	assert.Equal(t, "testuser", resp["username"])
 	assert.Equal(t, "Test User", resp["name"])
+	// L3 (#1270): users/show の実レスポンスを golden User-family schema に突合する。
+	shapetest.Assert(t, "UserLite", resp)
+	shapetest.Assert(t, "UserDetailedNotMeOnly", resp)
 }
 
 // stubChartHook captures users handler chart fires.


### PR DESCRIPTION
## Summary

#1270 で導入した **L3(実レスポンス検証)** を他 handler の既存 unit test に `shapetest.Assert` で展開し、検出範囲を広げる。実サーバー不要(mock ベースの既存 handler test が capture する JSON)で、handler が実際に組み立てた map を golden に突合する。

## 主な変更点
- `notes/show` (`TestShow_Success`) → golden `Note`
- `users/show` (`TestShow_ByUserID`) → golden `UserLite` + `UserDetailedNotMeOnly`
- `drive/files/create` (`TestFilesCreate_AllFormFields`) → golden `DriveFile`

いずれも `shapetest.Assert(t, "<Schema>", resp)` を既存 test の末尾に追加するだけ。

## 結果
3 経路とも**現状 golden 準拠**(drift 無し)。これらは L0 (struct) で既に検証済の entity だが、L3 は handler が実際に組み立てた**レスポンス**を見るので、今後 handler の override / populate で壊れたら response-level で即 catch する(#1270 の /api/i mutedWords null override がまさにそのクラスだった)。

## テスト
- 3 経路の対象 test green、`notes` / `users` / `drive` package + `make shapecheck` 全 green、race + atomic、build / vet / fmt clean。

## Closes
Closes #1272

## その他
- L3 の守備範囲: /api/i (#1270) + notes/show + users/show + drive/files/create。今後も `shapetest.Assert` を各 handler test に撒くだけで拡張できる。

🤖 Generated with [Claude Code](https://claude.com/claude-code)