### PR TITLE
fix(antennas): L3 で検出した Antenna shape drift 3件を修正

### DIFF
--- a/internal/api/antennas/handler.go
+++ b/internal/api/antennas/handler.go
@@ -312,13 +312,19 @@ func (h *Handler) antennaToMap(a *model.Antenna) map[string]any {
 			createdAt = t.UTC().Format("2006-01-02T15:04:05.000Z")
 		}
 	}
+	// users は pq.StringArray (nil なら null になる) を golden の非null array に
+	// 合わせて [] へ coalesce する (#1270 L3 検出)。
+	users := []string(a.Users)
+	if users == nil {
+		users = []string{}
+	}
 	return map[string]any{
 		"id":              a.ID,
 		"createdAt":       createdAt,
 		"name":            a.Name,
 		"src":             a.Src,
 		"userListId":      a.UserListID,
-		"users":           a.Users,
+		"users":           users,
 		"keywords":        a.Keywords,
 		"excludeKeywords": a.ExcludeKeywords,
 		"caseSensitive":   a.CaseSensitive,
@@ -328,6 +334,11 @@ func (h *Handler) antennaToMap(a *model.Antenna) map[string]any {
 		"localOnly":       a.LocalOnly,
 		"isActive":        a.IsActive,
 		"hasUnreadNote":   false,
+		// excludeNotesInSensitiveChannel は model にあるので反映。notify は
+		// golden で必須 (boolean) だが mk-go は antenna notify を未実装なので
+		// false 固定で shape だけ満たす (#1270 L3 検出)。
+		"excludeNotesInSensitiveChannel": a.ExcludeNotesInSensitiveChannel,
+		"notify":                         false,
 	}
 }
 

--- a/internal/api/antennas/handler_test.go
+++ b/internal/api/antennas/handler_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/labstack/echo/v4"
 	"github.com/redis/go-redis/v9"
 	coreantenna "github.com/shiroha-a/mk/internal/core/antenna"
+	"github.com/shiroha-a/mk/internal/entitycompat/shapetest"
 	"github.com/shiroha-a/mk/internal/misc/id"
 	"github.com/shiroha-a/mk/internal/model"
 	"github.com/shiroha-a/mk/internal/server/middleware"
@@ -98,6 +99,9 @@ func TestCreate_NoUserIdInResponse(t *testing.T) {
 	hasUnread, ok := body["hasUnreadNote"].(bool)
 	assert.True(t, ok, "hasUnreadNote must be a non-null bool")
 	assert.False(t, hasUnread)
+	// L3 (#1270): antennas/create の実レスポンスを golden Antenna に突合する
+	// (上の #1244 手動チェックを gate 化して全 field をカバー)。
+	shapetest.Assert(t, "Antenna", body)
 }
 
 func TestCreate_BadJSON(t *testing.T) {

--- a/internal/entitycompat/runtime.go
+++ b/internal/entitycompat/runtime.go
@@ -25,7 +25,7 @@ func UnionSchemaNames() []string {
 // them; the generator still extracts their flat golden schema into the snapshot
 // for ValidateValue to use.
 func L2FlatSchemaNames() []string {
-	return []string{"Announcement", "Clip", "Signin", "Page"}
+	return []string{"Announcement", "Clip", "Signin", "Page", "Antenna"}
 }
 
 // ParseUnion parses a discriminated-union schema (variants joined by `} | {`)

--- a/internal/entitycompat/testdata/golden_schemas.json
+++ b/internal/entitycompat/testdata/golden_schemas.json
@@ -61,6 +61,93 @@
       "type": "string"
     }
   },
+  "Antenna": {
+    "caseSensitive": {
+      "nullable": false,
+      "optional": false,
+      "type": "boolean"
+    },
+    "createdAt": {
+      "nullable": false,
+      "optional": false,
+      "type": "string"
+    },
+    "excludeBots": {
+      "nullable": false,
+      "optional": false,
+      "type": "boolean"
+    },
+    "excludeKeywords": {
+      "nullable": false,
+      "optional": false,
+      "type": "array"
+    },
+    "excludeNotesInSensitiveChannel": {
+      "nullable": false,
+      "optional": false,
+      "type": "boolean"
+    },
+    "hasUnreadNote": {
+      "nullable": false,
+      "optional": false,
+      "type": "boolean"
+    },
+    "id": {
+      "nullable": false,
+      "optional": false,
+      "type": "string"
+    },
+    "isActive": {
+      "nullable": false,
+      "optional": false,
+      "type": "boolean"
+    },
+    "keywords": {
+      "nullable": false,
+      "optional": false,
+      "type": "array"
+    },
+    "localOnly": {
+      "nullable": false,
+      "optional": false,
+      "type": "boolean"
+    },
+    "name": {
+      "nullable": false,
+      "optional": false,
+      "type": "string"
+    },
+    "notify": {
+      "nullable": false,
+      "optional": false,
+      "type": "boolean"
+    },
+    "src": {
+      "nullable": false,
+      "optional": false,
+      "type": "string"
+    },
+    "userListId": {
+      "nullable": true,
+      "optional": false,
+      "type": "string"
+    },
+    "users": {
+      "nullable": false,
+      "optional": false,
+      "type": "array"
+    },
+    "withFile": {
+      "nullable": false,
+      "optional": false,
+      "type": "boolean"
+    },
+    "withReplies": {
+      "nullable": false,
+      "optional": false,
+      "type": "boolean"
+    }
+  },
   "Clip": {
     "createdAt": {
       "nullable": false,


### PR DESCRIPTION
## Summary

L3(実レスポンス検証)を `antennas/create` へ広げたところ、`antennaToMap` の **shape drift を 3 件検出 → 修正**した。Note/User/Drive 系(L3 クリーン)と違い、Antenna は L3 が実バグを炙り出したケース。

`TestCreate_NoUserIdInResponse` は #1244 で `createdAt` / `hasUnreadNote` のみ手動 check していたが、L3 で全 field をカバーすると以下が露見:
- `notify`(必須 boolean)欠落
- `excludeNotesInSensitiveChannel`(必須 boolean)欠落
- `users` が nil 時に `null`(golden は非null array)

## 主な変更点
- `Antenna` を `L2FlatSchemaNames` に追加(golden snapshot へ抽出)。
- `antennaToMap` 修正:
  - `excludeNotesInSensitiveChannel` を model から反映。
  - `users` を `[]` へ coalesce(pq.StringArray nil → null 回避)。
  - `notify` は mk-go が antenna notify を**未実装**のため `false` 固定で shape のみ満たす。
- `antennas/create` test に `shapetest.Assert(t, "Antenna", body)` を追加(#1244 手動 check を gate 化、以後 全 field を response-level で guard)。

## テスト
- `antennas` package + `make shapecheck`(L0 + L2×6)全 green、race + atomic、build / vet / fmt clean。

## Closes
Closes #1276

## その他
- L3 の守備範囲: /api/i + notes/show + users/show + drive/files/create + **antennas/create**。
- `notify` は shape 準拠の degraded 値(常に false)。antenna notify 機能自体の実装は別 issue。

🤖 Generated with [Claude Code](https://claude.com/claude-code)