### PR TITLE
test(api): L3 実レスポンス検証を userlists/gallery/app/hashtags へ拡大

### DIFF
--- a/internal/api/app/handler_test.go
+++ b/internal/api/app/handler_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/labstack/echo/v4"
 	"github.com/lib/pq"
+	"github.com/shiroha-a/mk/internal/entitycompat/shapetest"
 	"github.com/shiroha-a/mk/internal/misc"
 	"github.com/shiroha-a/mk/internal/misc/id"
 	"github.com/shiroha-a/mk/internal/model"
@@ -145,6 +146,7 @@ func TestCreate_Success(t *testing.T) {
 	assert.NotEmpty(t, resp["secret"])
 	assert.NotEmpty(t, resp["id"])
 	assert.Len(t, repo.apps, 1)
+	shapetest.Assert(t, "App", resp) // L3 (#1270)
 }
 
 func TestCreate_WithUser(t *testing.T) {

--- a/internal/api/gallery/handler_test.go
+++ b/internal/api/gallery/handler_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/labstack/echo/v4"
 	"github.com/shiroha-a/mk/internal/api/gallery"
+	"github.com/shiroha-a/mk/internal/entitycompat/shapetest"
 	"github.com/shiroha-a/mk/internal/misc/id"
 	"github.com/shiroha-a/mk/internal/model"
 	"github.com/shiroha-a/mk/internal/server/middleware"
@@ -110,6 +111,7 @@ func TestPostsCreate_Success(t *testing.T) {
 	var resp map[string]any
 	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
 	assert.Equal(t, "My Art", resp["title"])
+	shapetest.Assert(t, "GalleryPost", resp) // L3 (#1270)
 	cleanup()
 }
 

--- a/internal/api/hashtags/handler_test.go
+++ b/internal/api/hashtags/handler_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/labstack/echo/v4"
 	"github.com/lib/pq"
 	"github.com/shiroha-a/mk/internal/api/hashtags"
+	"github.com/shiroha-a/mk/internal/entitycompat/shapetest"
 	"github.com/shiroha-a/mk/internal/misc/id"
 	"github.com/shiroha-a/mk/internal/model"
 	"github.com/shiroha-a/mk/internal/testutil"
@@ -123,6 +124,10 @@ func TestShow_Found(t *testing.T) {
 	rec := doPost(newHandler().Show, `{"tag":"rustlang"}`)
 	assert.Equal(t, http.StatusOK, rec.Code)
 	assert.Contains(t, rec.Body.String(), "rustlang")
+	// L3 (#1270): hashtags/show の実レスポンスを golden Hashtag に突合する。
+	var resp map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+	shapetest.Assert(t, "Hashtag", resp)
 }
 
 // TestShow_BadRequestForUnknownTag: upstream Misskey TS は ApiError 既定動作

--- a/internal/api/userlists/handler_test.go
+++ b/internal/api/userlists/handler_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/labstack/echo/v4"
 	"github.com/shiroha-a/mk/internal/api/userlists"
+	"github.com/shiroha-a/mk/internal/entitycompat/shapetest"
 	"github.com/shiroha-a/mk/internal/misc/id"
 	"github.com/shiroha-a/mk/internal/model"
 	"github.com/shiroha-a/mk/internal/repository"
@@ -54,6 +55,7 @@ func TestCreate_Success(t *testing.T) {
 	var resp map[string]any
 	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
 	assert.Equal(t, "My List", resp["name"])
+	shapetest.Assert(t, "UserList", resp) // L3 (#1270)
 }
 
 func TestCreate_InvalidParam(t *testing.T) {

--- a/internal/entitycompat/runtime.go
+++ b/internal/entitycompat/runtime.go
@@ -25,7 +25,13 @@ func UnionSchemaNames() []string {
 // them; the generator still extracts their flat golden schema into the snapshot
 // for ValidateValue to use.
 func L2FlatSchemaNames() []string {
-	return []string{"Announcement", "Clip", "Signin", "Page", "Antenna"}
+	// L2 packer fixture / L3 handler-response 検証で実際に使う flat schema のみ
+	// 列挙する (未使用 schema を snapshot に入れない)。UserList / Following /
+	// EmojiDetailed は L0 family 側 (GoldenSchemaNames) で抽出済。
+	return []string{
+		"Announcement", "Clip", "Signin", "Page", "Antenna",
+		"GalleryPost", "Hashtag", "App",
+	}
 }
 
 // ParseUnion parses a discriminated-union schema (variants joined by `} | {`)

--- a/internal/entitycompat/testdata/golden_schemas.json
+++ b/internal/entitycompat/testdata/golden_schemas.json
@@ -148,6 +148,38 @@
       "type": "boolean"
     }
   },
+  "App": {
+    "callbackUrl": {
+      "nullable": true,
+      "optional": false,
+      "type": "string"
+    },
+    "id": {
+      "nullable": false,
+      "optional": false,
+      "type": "string"
+    },
+    "isAuthorized": {
+      "nullable": false,
+      "optional": true,
+      "type": "boolean"
+    },
+    "name": {
+      "nullable": false,
+      "optional": false,
+      "type": "string"
+    },
+    "permission": {
+      "nullable": false,
+      "optional": false,
+      "type": "array"
+    },
+    "secret": {
+      "nullable": false,
+      "optional": true,
+      "type": "string"
+    }
+  },
   "Clip": {
     "createdAt": {
       "nullable": false,
@@ -403,6 +435,110 @@
       "type": "string"
     },
     "id": {
+      "nullable": false,
+      "optional": false,
+      "type": "string"
+    }
+  },
+  "GalleryPost": {
+    "createdAt": {
+      "nullable": false,
+      "optional": false,
+      "type": "string"
+    },
+    "description": {
+      "nullable": true,
+      "optional": false,
+      "type": "string"
+    },
+    "fileIds": {
+      "nullable": false,
+      "optional": true,
+      "type": "array"
+    },
+    "files": {
+      "nullable": false,
+      "optional": true,
+      "type": "array"
+    },
+    "id": {
+      "nullable": false,
+      "optional": false,
+      "type": "string"
+    },
+    "isLiked": {
+      "nullable": false,
+      "optional": true,
+      "type": "boolean"
+    },
+    "isSensitive": {
+      "nullable": false,
+      "optional": false,
+      "type": "boolean"
+    },
+    "likedCount": {
+      "nullable": false,
+      "optional": false,
+      "type": "number"
+    },
+    "tags": {
+      "nullable": false,
+      "optional": true,
+      "type": "array"
+    },
+    "title": {
+      "nullable": false,
+      "optional": false,
+      "type": "string"
+    },
+    "updatedAt": {
+      "nullable": false,
+      "optional": false,
+      "type": "string"
+    },
+    "user": {
+      "nullable": false,
+      "optional": false,
+      "type": "object"
+    },
+    "userId": {
+      "nullable": false,
+      "optional": false,
+      "type": "string"
+    }
+  },
+  "Hashtag": {
+    "attachedLocalUsersCount": {
+      "nullable": false,
+      "optional": false,
+      "type": "number"
+    },
+    "attachedRemoteUsersCount": {
+      "nullable": false,
+      "optional": false,
+      "type": "number"
+    },
+    "attachedUsersCount": {
+      "nullable": false,
+      "optional": false,
+      "type": "number"
+    },
+    "mentionedLocalUsersCount": {
+      "nullable": false,
+      "optional": false,
+      "type": "number"
+    },
+    "mentionedRemoteUsersCount": {
+      "nullable": false,
+      "optional": false,
+      "type": "number"
+    },
+    "mentionedUsersCount": {
+      "nullable": false,
+      "optional": false,
+      "type": "number"
+    },
+    "tag": {
       "nullable": false,
       "optional": false,
       "type": "string"


### PR DESCRIPTION
## Summary

**L3(実レスポンス検証)を 4 handler へ一気に拡大**し、検出範囲を広げる。reusable packer は天井(6個)に達しているので、handler がアドホックに組み立てる `map[string]any` response を golden に突合する `shapetest.Assert` を各 handler test に撒く。

## 主な変更点
- golden snapshot に **GalleryPost / Hashtag / App** を追加(`L2FlatSchemaNames`)。一時的に batch 追加していた未使用 schema(Flash/NoteReaction/Blocking 等)は整理し、**実際に検証で使うものだけ**残した。
- `shapetest.Assert` を追加:
  - `userlists/create` → `UserList`
  - `gallery/posts/create` → `GalleryPost`
  - `app/create` → `App`
  - `hashtags/show` → `Hashtag`(`Body.String()` contains を unmarshal + assert に置換)

## 結果
**4 経路とも現状 golden 準拠**(drift 無し)。L3 の守備範囲が 4 package 増えた:
`/api/i` + notes/show + users/show + drive/files/create + antennas/create + **userlists + gallery + app + hashtags**(計 9 経路)。

## テスト
- 4 package + `entitycompat` 全 green、race + atomic、`make shapecheck`(L0 + L2×6)green、build / vet / fmt clean。

## Closes
Closes #1278

## その他
- `notify` の件(antenna)で学んだ通り、今後 drift が出たら現 misskey-ts 実装(packer 定数 / 削除済 / 実カラム)を確認してから対応する。今回の 4 経路は drift 無しなので確認不要だった。

🤖 Generated with [Claude Code](https://claude.com/claude-code)