### PR TITLE
test(api): L3 実レスポンス検証を clips/flash/invite/webhooks/pages へ拡大 + Page content drift 修正

### DIFF
--- a/internal/api/clips/handler_test.go
+++ b/internal/api/clips/handler_test.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/labstack/echo/v4"
 	coreclip "github.com/shiroha-a/mk/internal/core/clip"
+	"github.com/shiroha-a/mk/internal/entitycompat/shapetest"
 	"github.com/shiroha-a/mk/internal/misc/id"
 	"github.com/shiroha-a/mk/internal/model"
 	"github.com/shiroha-a/mk/internal/server/middleware"
@@ -298,6 +299,7 @@ func TestList_FullShape(t *testing.T) {
 	user, ok := cl["user"].(map[string]any)
 	require.True(t, ok, "user must be a non-null object")
 	assert.Equal(t, "alice", user["id"])
+	shapetest.Assert(t, "Clip", cl) // L3 (#1270)
 }
 
 func TestList_BadJSON(t *testing.T) {

--- a/internal/api/flash/handler_test.go
+++ b/internal/api/flash/handler_test.go
@@ -1,6 +1,7 @@
 package flash
 
 import (
+	"encoding/json"
 	"errors"
 	"net/http"
 	"net/http/httptest"
@@ -9,6 +10,7 @@ import (
 
 	"github.com/labstack/echo/v4"
 	coreflash "github.com/shiroha-a/mk/internal/core/flash"
+	"github.com/shiroha-a/mk/internal/entitycompat/shapetest"
 	"github.com/shiroha-a/mk/internal/misc/id"
 	"github.com/shiroha-a/mk/internal/model"
 	"github.com/shiroha-a/mk/internal/server/middleware"
@@ -47,6 +49,10 @@ func TestCreate_Success(t *testing.T) {
 	setUser(c, "alice")
 	require.NoError(t, h.Create(c))
 	assert.Equal(t, http.StatusOK, rec.Code)
+
+	var resp map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+	shapetest.Assert(t, "Flash", resp) // L3 (#1270)
 }
 
 func TestCreate_BadJSON(t *testing.T) {

--- a/internal/api/invite/handler_test.go
+++ b/internal/api/invite/handler_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 
 	"github.com/labstack/echo/v4"
+	"github.com/shiroha-a/mk/internal/entitycompat/shapetest"
 	"github.com/shiroha-a/mk/internal/misc/id"
 	"github.com/shiroha-a/mk/internal/model"
 	"github.com/shiroha-a/mk/internal/server/middleware"
@@ -61,6 +62,7 @@ func TestCreate_NoPolicyProviderSucceeds(t *testing.T) {
 	assert.Nil(t, resp["expiresAt"])
 	assert.Equal(t, false, resp["used"])
 	assert.NotEmpty(t, resp["createdAt"])
+	shapetest.Assert(t, "InviteCode", resp) // L3 (#1270)
 }
 
 func TestCreate_LimitExceeded(t *testing.T) {

--- a/internal/api/pages/handler_test.go
+++ b/internal/api/pages/handler_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/labstack/echo/v4"
 	corepage "github.com/shiroha-a/mk/internal/core/page"
 	coreuser "github.com/shiroha-a/mk/internal/core/user"
+	"github.com/shiroha-a/mk/internal/entitycompat/shapetest"
 	"github.com/shiroha-a/mk/internal/misc/id"
 	"github.com/shiroha-a/mk/internal/model"
 	"github.com/shiroha-a/mk/internal/server/middleware"
@@ -132,14 +133,18 @@ func TestShow_ByName(t *testing.T) {
 // owner が attach され、viewer logged-in 時は isLiked field も含まれる。
 func TestShow_IncludesUserAndIsLiked(t *testing.T) {
 	h, repo, likeRepo := newHandler(t)
-	repo.Pages["p1"] = &model.Page{ID: "p1", UserID: "alice", Name: "alpha", Visibility: model.PageVisibilityPublic}
-	require.NoError(t, likeRepo.Create(&model.PageLike{ID: "l1", UserID: "bob", PageID: "p1"}))
+	// L3 (#1270): golden Page は createdAt を必須とするため、実ハンドラと同じく
+	// aidx 由来の ID を使って ParseTime 経由の createdAt 付与を成立させる。
+	idGen, _ := id.NewGenerator("aidx")
+	pageID := idGen.Generate(time.Now())
+	repo.Pages[pageID] = &model.Page{ID: pageID, UserID: "alice", Name: "alpha", Visibility: model.PageVisibilityPublic}
+	require.NoError(t, likeRepo.Create(&model.PageLike{ID: "l1", UserID: "bob", PageID: pageID}))
 	h.SetUserSource(&stubUserSource{
 		bundle: &coreuser.UserWithProfile{
 			User: &model.User{ID: "alice", Username: "alice", UsernameLower: "alice"},
 		},
 	})
-	c, rec := newReq(t, `{"pageId":"p1"}`)
+	c, rec := newReq(t, `{"pageId":"`+pageID+`"}`)
 	setUser(c, "bob")
 	require.NoError(t, h.Show(c))
 	require.Equal(t, http.StatusOK, rec.Code)
@@ -149,6 +154,7 @@ func TestShow_IncludesUserAndIsLiked(t *testing.T) {
 	require.True(t, ok, "show response must include user field (#1134)")
 	assert.Equal(t, "alice", user["username"])
 	assert.Equal(t, true, row["isLiked"], "isLiked must reflect viewer's like state (#1134)")
+	shapetest.Assert(t, "Page", row) // L3 (#1270)
 }
 
 func TestShow_ByUsername(t *testing.T) {

--- a/internal/api/webhooks/handler_test.go
+++ b/internal/api/webhooks/handler_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/labstack/echo/v4"
 	"github.com/lib/pq"
+	"github.com/shiroha-a/mk/internal/entitycompat/shapetest"
 	"github.com/shiroha-a/mk/internal/misc/id"
 	"github.com/shiroha-a/mk/internal/model"
 	"github.com/shiroha-a/mk/internal/server/middleware"
@@ -154,6 +155,7 @@ func TestCreate_Success(t *testing.T) {
 	var resp map[string]any
 	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
 	assert.Equal(t, "test", resp["name"])
+	shapetest.Assert(t, "UserWebhook", resp) // L3 (#1270)
 }
 
 func TestCreate_InvalidParam(t *testing.T) {

--- a/internal/entity/page.go
+++ b/internal/entity/page.go
@@ -40,9 +40,11 @@ func PackPage(p *model.Page, idGens ...id.Generator) map[string]any {
 		// 画像が無い / lookup miss でも null を出す (omit しない)。実画像は
 		// PackPageWithContext が ctx.EyeCatchingImage で上書きする。
 		"eyeCatchingImage": nil,
-		"content":          rawJSONBytes(p.Content),
-		// variables / attachedFiles は misskey_dart の Page.fromJson が非null
-		// List として cast するため、空でも null ではなく [] を返す (#1237)。
+		// content / variables / attachedFiles は misskey_dart の Page.fromJson が
+		// 非null List として cast するため、空でも null ではなく [] を返す
+		// (#1237)。content は golden Page でも PageBlock[] 必須 (non-null) だが、
+		// 当初 #1237 では content だけ rawJSONBytes のまま取りこぼしていた。
+		"content":       jsonArrayOrEmpty(p.Content),
 		"variables":     jsonArrayOrEmpty(p.Variables),
 		"attachedFiles": []any{},
 		"script":        p.Script,

--- a/internal/entitycompat/runtime.go
+++ b/internal/entitycompat/runtime.go
@@ -31,6 +31,7 @@ func L2FlatSchemaNames() []string {
 	return []string{
 		"Announcement", "Clip", "Signin", "Page", "Antenna",
 		"GalleryPost", "Hashtag", "App",
+		"Flash", "InviteCode", "UserWebhook",
 	}
 }
 

--- a/internal/entitycompat/testdata/golden_schemas.json
+++ b/internal/entitycompat/testdata/golden_schemas.json
@@ -408,6 +408,63 @@
       "type": "string"
     }
   },
+  "Flash": {
+    "createdAt": {
+      "nullable": false,
+      "optional": false,
+      "type": "string"
+    },
+    "id": {
+      "nullable": false,
+      "optional": false,
+      "type": "string"
+    },
+    "isLiked": {
+      "nullable": false,
+      "optional": true,
+      "type": "boolean"
+    },
+    "likedCount": {
+      "nullable": false,
+      "optional": false,
+      "type": "number"
+    },
+    "script": {
+      "nullable": false,
+      "optional": false,
+      "type": "string"
+    },
+    "summary": {
+      "nullable": false,
+      "optional": false,
+      "type": "string"
+    },
+    "title": {
+      "nullable": false,
+      "optional": false,
+      "type": "string"
+    },
+    "updatedAt": {
+      "nullable": false,
+      "optional": false,
+      "type": "string"
+    },
+    "user": {
+      "nullable": false,
+      "optional": false,
+      "type": "object"
+    },
+    "userId": {
+      "nullable": false,
+      "optional": false,
+      "type": "string"
+    },
+    "visibility": {
+      "nullable": false,
+      "optional": false,
+      "type": "string"
+    }
+  },
   "Following": {
     "createdAt": {
       "nullable": false,
@@ -542,6 +599,48 @@
       "nullable": false,
       "optional": false,
       "type": "string"
+    }
+  },
+  "InviteCode": {
+    "code": {
+      "nullable": false,
+      "optional": false,
+      "type": "string"
+    },
+    "createdAt": {
+      "nullable": false,
+      "optional": false,
+      "type": "string"
+    },
+    "createdBy": {
+      "nullable": true,
+      "optional": false,
+      "type": "object"
+    },
+    "expiresAt": {
+      "nullable": true,
+      "optional": false,
+      "type": "string"
+    },
+    "id": {
+      "nullable": false,
+      "optional": false,
+      "type": "string"
+    },
+    "used": {
+      "nullable": false,
+      "optional": false,
+      "type": "boolean"
+    },
+    "usedAt": {
+      "nullable": true,
+      "optional": false,
+      "type": "string"
+    },
+    "usedBy": {
+      "nullable": true,
+      "optional": false,
+      "type": "object"
     }
   },
   "MeDetailedOnly": {
@@ -1393,6 +1492,53 @@
       "type": "boolean"
     },
     "username": {
+      "nullable": false,
+      "optional": false,
+      "type": "string"
+    }
+  },
+  "UserWebhook": {
+    "active": {
+      "nullable": false,
+      "optional": false,
+      "type": "boolean"
+    },
+    "id": {
+      "nullable": false,
+      "optional": false,
+      "type": "string"
+    },
+    "latestSentAt": {
+      "nullable": true,
+      "optional": false,
+      "type": "string"
+    },
+    "latestStatus": {
+      "nullable": true,
+      "optional": false,
+      "type": "number"
+    },
+    "name": {
+      "nullable": false,
+      "optional": false,
+      "type": "string"
+    },
+    "on": {
+      "nullable": false,
+      "optional": false,
+      "type": "array"
+    },
+    "secret": {
+      "nullable": false,
+      "optional": false,
+      "type": "string"
+    },
+    "url": {
+      "nullable": false,
+      "optional": false,
+      "type": "string"
+    },
+    "userId": {
       "nullable": false,
       "optional": false,
       "type": "string"


### PR DESCRIPTION
## Summary

**L3(実レスポンス検証)を 5 handler へ一気に拡大**し、検出範囲を更に広げる。handler がアドホックに組み立てる `map[string]any` response を golden に突合する `shapetest.Assert` を各 handler test に撒く。調査中に検出した shape drift を 1 件修正した。

## 主な変更点
- golden snapshot に **Flash / InviteCode / UserWebhook** を追加(`L2FlatSchemaNames`)。Clip / Page は既存。
- `shapetest.Assert` を追加:
  - `clips`(`TestList_FullShape`)→ `Clip`
  - `flash/create` → `Flash`
  - `invite/create` → `InviteCode`
  - `webhooks/create` → `UserWebhook`
  - `pages/show` → `Page`

## 検出 → 修正した drift
- **`PackPage` の `content` が空時に `null`** を返していた。golden Page は `content: PageBlock[]` 必須(non-null)。#1237 で `variables`/`attachedFiles` は `[]` coalesce 済だったが、`content` だけ `rawJSONBytes` のまま取りこぼしていた → `jsonArrayOrEmpty` に統一(misskey_dart の `Page.fromJson` 非null List cast 互換)。
- `pages/show` の L3 test は実ハンドラ同様 aidx 由来 ID を使い、`createdAt`(ParseTime 由来)が付与される現実的な経路で検証するよう調整。

## 別 issue に切り出した drift
- **channels**: `createdAt` / `bannerUrl` 欠落を検出。`idGen`/drive 解決の配線を伴い範囲が広いため **#1280** に分離(本 PR には含めない)。

## 結果
L3 守備範囲が 5 経路増えて計 14 経路:
`/api/i` + notes/show + users/show + drive/files/create + antennas/create + userlists + gallery + app + hashtags + **clips + flash + invite + webhooks + pages**。

## テスト
- 5 package + `entity` + `entitycompat` 全 green、race + atomic、`make shapecheck`(L0 + L2)green、build / vet / fmt clean。
- カバレッジ: `entity` 95.4% / `entitycompat` 96.8%(gate 90% 超過)。

## Closes
Closes #1281

🤖 Generated with [Claude Code](https://claude.com/claude-code)