### PR TITLE
fix(channels): 応答に createdAt / bannerUrl を追加 + pinnedNoteIds null-array を修正

### DIFF
--- a/internal/api/channels/handler.go
+++ b/internal/api/channels/handler.go
@@ -29,6 +29,24 @@ type Handler struct {
 	fieldRes      *entity.NoteFieldResolver
 	// userRepo は channels/timeline の hardMutedWords filter (#787)。
 	userRepo repository.UserRepository
+	// bannerResolver は channel の bannerId を drive file に解決して bannerUrl
+	// を埋める (#1280)。未配線なら bannerUrl は null で出す。
+	bannerResolver ChannelBannerResolver
+}
+
+// ChannelBannerResolver covers the drive-file lookups the channels handler
+// needs to resolve `bannerUrl` from a channel's bannerId (#1280). FindByID
+// drives the single-channel paths; FindByIDs batches the list endpoints to
+// avoid an N+1 banner lookup.
+type ChannelBannerResolver interface {
+	FindByID(id string) (*model.DriveFile, error)
+	FindByIDs(ids []string) ([]*model.DriveFile, error)
+}
+
+// SetDriveFileRepo wires a ChannelBannerResolver so packed channels expose
+// `bannerUrl` (#1280). nil leaves bannerUrl as null.
+func (h *Handler) SetDriveFileRepo(r ChannelBannerResolver) {
+	h.bannerResolver = r
 }
 
 // SetUserRepo wires a UserRepository so channels/timeline filters out notes
@@ -387,14 +405,25 @@ func (h *Handler) Timeline(c echo.Context) error {
 	return c.JSON(http.StatusOK, out)
 }
 
-func channelToMap(ch *model.Channel) map[string]any {
-	return map[string]any{
+// channelToMap packs a channel into the misskey-compatible shape. bannerURL
+// is the caller-resolved `bannerUrl` value (nil = no banner / unresolved);
+// list callers batch-resolve it once to avoid an N+1 drive lookup (#1280).
+func (h *Handler) channelToMap(ch *model.Channel, bannerURL any) map[string]any {
+	// golden Channel の pinnedNoteIds は string[] 必須 (non-null)。pq.StringArray
+	// は nil のとき JSON null に marshal されるため、空でも [] を返すよう coalesce
+	// する (#1280。Page content #1237 と同種の null-array drift)。
+	pinnedNoteIDs := []string(ch.PinnedNoteIDs)
+	if pinnedNoteIDs == nil {
+		pinnedNoteIDs = []string{}
+	}
+	out := map[string]any{
 		"id":                    ch.ID,
 		"name":                  ch.Name,
 		"description":           ch.Description,
 		"userId":                ch.UserID,
 		"bannerId":              ch.BannerID,
-		"pinnedNoteIds":         ch.PinnedNoteIDs,
+		"bannerUrl":             bannerURL,
+		"pinnedNoteIds":         pinnedNoteIDs,
 		"color":                 ch.Color,
 		"isArchived":            ch.IsArchived,
 		"notesCount":            ch.NotesCount,
@@ -403,6 +432,71 @@ func channelToMap(ch *model.Channel) map[string]any {
 		"allowRenoteToExternal": ch.AllowRenoteToExternal,
 		"lastNotedAt":           ch.LastNotedAt,
 	}
+	// Misskey TS は createdAt を channel.id (aidx) から導出する。golden Channel
+	// でも createdAt は必須なので他 entity と同じ ISO ms 形式で埋める (#1280)。
+	if h.idGen != nil {
+		if t, err := h.idGen.ParseTime(ch.ID); err == nil {
+			out["createdAt"] = t.UTC().Format("2006-01-02T15:04:05.000Z")
+		}
+	}
+	return out
+}
+
+// channelBannerPublicURL mirrors upstream DriveFileEntityService.getPublicUrl
+// for the non-proxy path (webpublicUrl ?? url), matching how mk-go already
+// exposes DriveFile.url without pack-time media-proxy rewriting (#1280).
+func channelBannerPublicURL(f *model.DriveFile) string {
+	if f.WebpublicURL != nil && *f.WebpublicURL != "" {
+		return *f.WebpublicURL
+	}
+	return f.URL
+}
+
+// resolveBannerURL resolves a single channel's bannerId to its public URL.
+// Returns nil (= JSON null) when there is no banner or no resolver wired.
+func (h *Handler) resolveBannerURL(bannerID *string) any {
+	if bannerID == nil || *bannerID == "" || h.bannerResolver == nil {
+		return nil
+	}
+	f, err := h.bannerResolver.FindByID(*bannerID)
+	if err != nil || f == nil {
+		return nil
+	}
+	return channelBannerPublicURL(f)
+}
+
+// resolveBannerURLs batch-resolves bannerUrl for a slice of channels in a
+// single FindByIDs call, returning a channelID -> url map (#1280).
+func (h *Handler) resolveBannerURLs(rows []*model.Channel) map[string]any {
+	res := make(map[string]any, len(rows))
+	if h.bannerResolver == nil {
+		return res
+	}
+	ids := make([]string, 0, len(rows))
+	for _, ch := range rows {
+		if ch.BannerID != nil && *ch.BannerID != "" {
+			ids = append(ids, *ch.BannerID)
+		}
+	}
+	if len(ids) == 0 {
+		return res
+	}
+	files, err := h.bannerResolver.FindByIDs(ids)
+	if err != nil {
+		return res
+	}
+	byID := make(map[string]*model.DriveFile, len(files))
+	for _, f := range files {
+		byID[f.ID] = f
+	}
+	for _, ch := range rows {
+		if ch.BannerID != nil {
+			if f := byID[*ch.BannerID]; f != nil {
+				res[ch.ID] = channelBannerPublicURL(f)
+			}
+		}
+	}
+	return res
 }
 
 // channelToMapForViewer wraps channelToMap and embeds viewer-dependent
@@ -413,7 +507,7 @@ func (h *Handler) channelToMapForViewer(ch *model.Channel, viewer *model.User) m
 	// channelFavorites を join して埋めており、frontend (`channel.vue`) は
 	// このフィールドを直接参照してフォローボタン状態を切り替える。欠落
 	// すると常に未フォロー UI になる。
-	out := channelToMap(ch)
+	out := h.channelToMap(ch, h.resolveBannerURL(ch.BannerID))
 	if viewer == nil {
 		return out
 	}
@@ -435,9 +529,10 @@ func (h *Handler) channelToMapForViewer(ch *model.Channel, viewer *model.User) m
 // not N+1). viewer が nil なら viewer-dependent フィールドは省略する。
 func (h *Handler) channelsToList(rows []*model.Channel, viewer *model.User) []map[string]any {
 	out := make([]map[string]any, 0, len(rows))
+	banners := h.resolveBannerURLs(rows)
 	if viewer == nil || (h.followingRepo == nil && h.favoriteRepo == nil) {
 		for _, ch := range rows {
-			out = append(out, channelToMap(ch))
+			out = append(out, h.channelToMap(ch, banners[ch.ID]))
 		}
 		return out
 	}
@@ -453,7 +548,7 @@ func (h *Handler) channelsToList(rows []*model.Channel, viewer *model.User) []ma
 		favorited, _ = h.favoriteRepo.ExistsMany(viewer.ID, ids)
 	}
 	for _, ch := range rows {
-		m := channelToMap(ch)
+		m := h.channelToMap(ch, banners[ch.ID])
 		if followed != nil {
 			m["isFollowing"] = followed[ch.ID]
 		}

--- a/internal/api/channels/handler_test.go
+++ b/internal/api/channels/handler_test.go
@@ -1,6 +1,7 @@
 package channels
 
 import (
+	"encoding/json"
 	"errors"
 	"net/http"
 	"net/http/httptest"
@@ -10,6 +11,7 @@ import (
 
 	"github.com/labstack/echo/v4"
 	corechannel "github.com/shiroha-a/mk/internal/core/channel"
+	"github.com/shiroha-a/mk/internal/entitycompat/shapetest"
 	"github.com/shiroha-a/mk/internal/misc/id"
 	"github.com/shiroha-a/mk/internal/model"
 	"github.com/shiroha-a/mk/internal/server/middleware"
@@ -55,6 +57,10 @@ func TestCreate_Success(t *testing.T) {
 	require.NoError(t, h.Create(c))
 	assert.Equal(t, http.StatusOK, rec.Code)
 	assert.Contains(t, rec.Body.String(), "alpha")
+
+	var resp map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+	shapetest.Assert(t, "Channel", resp) // L3 (#1280)
 }
 
 func TestCreate_BadJSON(t *testing.T) {
@@ -627,4 +633,104 @@ func TestFeatured_BatchEmbedsFollowState(t *testing.T) {
 		"alice's followed channel must report isFollowing=true")
 	assert.Contains(t, body, `"isFollowing":false`,
 		"unfollowed channels must still report the field for the frontend")
+}
+
+// --- bannerUrl / createdAt resolution (#1280) -----------------------------
+
+// stubBannerResolver is a ChannelBannerResolver double for banner lookups.
+type stubBannerResolver struct {
+	files    map[string]*model.DriveFile
+	batchErr error
+}
+
+func (s *stubBannerResolver) FindByID(id string) (*model.DriveFile, error) {
+	if f, ok := s.files[id]; ok {
+		return f, nil
+	}
+	return nil, errors.New("not found")
+}
+
+func (s *stubBannerResolver) FindByIDs(ids []string) ([]*model.DriveFile, error) {
+	if s.batchErr != nil {
+		return nil, s.batchErr
+	}
+	out := make([]*model.DriveFile, 0, len(ids))
+	for _, id := range ids {
+		if f, ok := s.files[id]; ok {
+			out = append(out, f)
+		}
+	}
+	return out, nil
+}
+
+func aidxID(t *testing.T) string {
+	t.Helper()
+	gen, _ := id.NewGenerator("aidx")
+	return gen.Generate(time.Now())
+}
+
+func TestChannelToMap_BannerURL(t *testing.T) {
+	h, _, _, _ := newHandler(t)
+	web := "https://media.example/web.png"
+	h.SetDriveFileRepo(&stubBannerResolver{files: map[string]*model.DriveFile{
+		"b1": {ID: "b1", URL: "https://media.example/orig.png", WebpublicURL: &web},
+		"b2": {ID: "b2", URL: "https://media.example/orig2.png"},
+	}})
+	chID := aidxID(t)
+
+	bid := "b1"
+	out := h.channelToMapForViewer(&model.Channel{ID: chID, BannerID: &bid}, nil)
+	assert.Equal(t, web, out["bannerUrl"], "webpublicUrl is preferred over url")
+	assert.NotEmpty(t, out["createdAt"], "createdAt is derived from the aidx id")
+
+	// webpublicUrl が無ければ url にフォールバック。
+	bid2 := "b2"
+	out = h.channelToMapForViewer(&model.Channel{ID: chID, BannerID: &bid2}, nil)
+	assert.Equal(t, "https://media.example/orig2.png", out["bannerUrl"])
+}
+
+func TestChannelToMap_BannerURL_NullCases(t *testing.T) {
+	h, _, _, _ := newHandler(t)
+	chID := aidxID(t)
+
+	// resolver 未配線 -> null。
+	out := h.channelToMapForViewer(&model.Channel{ID: chID}, nil)
+	assert.Contains(t, out, "bannerUrl")
+	assert.Nil(t, out["bannerUrl"])
+
+	h.SetDriveFileRepo(&stubBannerResolver{files: map[string]*model.DriveFile{}})
+	// bannerId nil -> null。
+	out = h.channelToMapForViewer(&model.Channel{ID: chID}, nil)
+	assert.Nil(t, out["bannerUrl"])
+	// bannerId set でも lookup miss -> null。
+	bid := "missing"
+	out = h.channelToMapForViewer(&model.Channel{ID: chID, BannerID: &bid}, nil)
+	assert.Nil(t, out["bannerUrl"])
+}
+
+func TestResolveBannerURLs_Batch(t *testing.T) {
+	h, _, _, _ := newHandler(t)
+	web := "https://media.example/web.png"
+	h.SetDriveFileRepo(&stubBannerResolver{files: map[string]*model.DriveFile{
+		"b1": {ID: "b1", URL: "u1", WebpublicURL: &web},
+	}})
+	b1 := "b1"
+	rows := []*model.Channel{
+		{ID: "c1", BannerID: &b1},
+		{ID: "c2"},
+	}
+	res := h.resolveBannerURLs(rows)
+	assert.Equal(t, web, res["c1"])
+	_, ok := res["c2"]
+	assert.False(t, ok, "channel without banner has no map entry")
+
+	// FindByIDs error -> empty map (best-effort)。
+	h.SetDriveFileRepo(&stubBannerResolver{batchErr: errors.New("boom")})
+	assert.Empty(t, h.resolveBannerURLs(rows))
+
+	// resolver 未配線 -> empty map。
+	h2, _, _, _ := newHandler(t)
+	assert.Empty(t, h2.resolveBannerURLs(rows))
+	// 全 channel banner なし -> FindByIDs を呼ばず empty。
+	assert.Empty(t, h.resolveBannerURLs([]*model.Channel{{ID: "c3"}}))
 }

--- a/internal/entitycompat/runtime.go
+++ b/internal/entitycompat/runtime.go
@@ -31,7 +31,7 @@ func L2FlatSchemaNames() []string {
 	return []string{
 		"Announcement", "Clip", "Signin", "Page", "Antenna",
 		"GalleryPost", "Hashtag", "App",
-		"Flash", "InviteCode", "UserWebhook",
+		"Flash", "InviteCode", "UserWebhook", "Channel",
 	}
 }
 

--- a/internal/entitycompat/testdata/golden_schemas.json
+++ b/internal/entitycompat/testdata/golden_schemas.json
@@ -180,6 +180,103 @@
       "type": "string"
     }
   },
+  "Channel": {
+    "allowRenoteToExternal": {
+      "nullable": false,
+      "optional": false,
+      "type": "boolean"
+    },
+    "bannerId": {
+      "nullable": true,
+      "optional": false,
+      "type": "string"
+    },
+    "bannerUrl": {
+      "nullable": true,
+      "optional": false,
+      "type": "string"
+    },
+    "color": {
+      "nullable": false,
+      "optional": false,
+      "type": "string"
+    },
+    "createdAt": {
+      "nullable": false,
+      "optional": false,
+      "type": "string"
+    },
+    "description": {
+      "nullable": true,
+      "optional": false,
+      "type": "string"
+    },
+    "id": {
+      "nullable": false,
+      "optional": false,
+      "type": "string"
+    },
+    "isArchived": {
+      "nullable": false,
+      "optional": false,
+      "type": "boolean"
+    },
+    "isFavorited": {
+      "nullable": false,
+      "optional": true,
+      "type": "boolean"
+    },
+    "isFollowing": {
+      "nullable": false,
+      "optional": true,
+      "type": "boolean"
+    },
+    "isMuting": {
+      "nullable": false,
+      "optional": true,
+      "type": "boolean"
+    },
+    "isSensitive": {
+      "nullable": false,
+      "optional": false,
+      "type": "boolean"
+    },
+    "lastNotedAt": {
+      "nullable": true,
+      "optional": false,
+      "type": "string"
+    },
+    "name": {
+      "nullable": false,
+      "optional": false,
+      "type": "string"
+    },
+    "notesCount": {
+      "nullable": false,
+      "optional": false,
+      "type": "number"
+    },
+    "pinnedNoteIds": {
+      "nullable": false,
+      "optional": false,
+      "type": "array"
+    },
+    "pinnedNotes": {
+      "nullable": false,
+      "optional": true,
+      "type": "array"
+    },
+    "userId": {
+      "nullable": true,
+      "optional": false,
+      "type": "string"
+    },
+    "usersCount": {
+      "nullable": false,
+      "optional": false,
+      "type": "number"
+    }
+  },
   "Clip": {
     "createdAt": {
       "nullable": false,

--- a/internal/server/router.go
+++ b/internal/server/router.go
@@ -1618,6 +1618,7 @@ func (s *Server) setupRoutes() {
 	channelsHandler.SetFavoriteRepo(channelFavoriteRepo)
 	channelsHandler.SetMutingRepo(channelMutingRepo)
 	channelsHandler.SetFollowingRepo(channelFollowingRepo)
+	channelsHandler.SetDriveFileRepo(driveFileRepo)
 	// channels/create の canCreateChannel gate は #1020 で middleware に
 	// 昇格 (handler 内 RolePolicyChecker → middleware.RequireRolePolicy)。
 	api.POST("/channels/create", channelsHandler.Create,


### PR DESCRIPTION
## Summary

L3(実レスポンス検証, #1281 系)で検出した `channels` の golden `Channel` に対する shape drift を修正する(#1280)。golden `Channel` が必須とする `createdAt` / `bannerUrl` が欠落し、`pinnedNoteIds` が空時に `null` を返していた。

## 主な変更点
- **createdAt**: `model.Channel` に createdAt カラムは無く ID 由来。Misskey TS `ChannelEntityService` と同じく `channel.id`(aidx)から `ParseTime` で導出し ISO ms 形式で emit。`channelToMap` を package func から `*Handler` の method に変更し `idGen` へアクセスできるようにした。
- **bannerUrl**: golden は `bannerUrl: string | null` を必須とする。channel の `bannerId` を drive file に解決し `getPublicUrl` 相当(`webpublicUrl ?? url`)を埋める。`ChannelBannerResolver` injector(`SetDriveFileRepo`)を追加し、単体経路は `FindByID`、list 経路は `FindByIDs` で **batch 解決して N+1 を回避**。未配線 / banner 無し / lookup miss はすべて `null`。
- **pinnedNoteIds**: `pq.StringArray` は nil のとき JSON `null` に marshal される。golden は `string[]` 必須(non-null)なので空でも `[]` を返すよう coalesce(Page content #1237 と同種の null-array drift)。

## drift 検出の経緯
golden `Channel` 必須フィールドのうち mk-go が欠いていたもの:
- `createdAt` — 欠落 → 導出して追加
- `bannerUrl` — 欠落 → drive 解決して追加
- `pinnedNoteIds` — 空配列が `null` → `[]` に coalesce

いずれも現 misskey-ts (`ChannelEntityService` / `getPublicUrl`) の挙動を確認した上で修正。

## テスト
- `channels/create` に L3(`shapetest.Assert(t, "Channel", resp)`)を配線。
- banner 解決の webpublicUrl 優先 / url fallback / null cases(未配線・banner 無し・lookup miss)/ batch / FindByIDs error path を単体テストで網羅。
- `channels` coverage 92.6%(gate 90% 超過)、race + atomic green、`make shapecheck` green、build / vet / fmt clean。

## Closes
Closes #1280

🤖 Generated with [Claude Code](https://claude.com/claude-code)