### PR TITLE
test(api): L3 を mute/blocking/renote-mute/roles/emojis/i-favorites へ拡大

### DIFF
--- a/internal/api/blocking/handler_test.go
+++ b/internal/api/blocking/handler_test.go
@@ -1,6 +1,7 @@
 package blocking
 
 import (
+	"encoding/json"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -8,6 +9,7 @@ import (
 
 	"github.com/labstack/echo/v4"
 	coreblocking "github.com/shiroha-a/mk/internal/core/blocking"
+	"github.com/shiroha-a/mk/internal/entitycompat/shapetest"
 	"github.com/shiroha-a/mk/internal/misc/id"
 	"github.com/shiroha-a/mk/internal/model"
 	"github.com/shiroha-a/mk/internal/server/middleware"
@@ -203,6 +205,11 @@ func TestList_OK(t *testing.T) {
 	setUser(c, "alice")
 	require.NoError(t, h.List(c))
 	assert.Equal(t, http.StatusOK, rec.Code)
+
+	var resp []map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+	require.Len(t, resp, 1)
+	shapetest.Assert(t, "Blocking", resp[0]) // L3 (#1286)
 }
 
 func TestList_LimitClamping(t *testing.T) {

--- a/internal/api/emojis/handler_test.go
+++ b/internal/api/emojis/handler_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/labstack/echo/v4"
 	"github.com/shiroha-a/mk/internal/api/emojis"
+	"github.com/shiroha-a/mk/internal/entitycompat/shapetest"
 	"github.com/shiroha-a/mk/internal/model"
 	"github.com/shiroha-a/mk/internal/testutil"
 	"github.com/stretchr/testify/assert"
@@ -66,6 +67,7 @@ func TestEmojis_WithLocalEmojis(t *testing.T) {
 	assert.Equal(t, "smile", emoji["name"])
 	assert.Equal(t, "faces", emoji["category"])
 	assert.Equal(t, "https://example.com/emoji/smile.png", emoji["url"])
+	shapetest.Assert(t, "EmojiSimple", emoji) // L3 (#1286)
 }
 
 // failingEmojiRepo always fails on ListLocal.

--- a/internal/api/i/handler_extra_test.go
+++ b/internal/api/i/handler_extra_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/labstack/echo/v4"
 	coreuser "github.com/shiroha-a/mk/internal/core/user"
+	"github.com/shiroha-a/mk/internal/entitycompat/shapetest"
 	"github.com/shiroha-a/mk/internal/misc/id"
 	"github.com/shiroha-a/mk/internal/model"
 	"github.com/shiroha-a/mk/internal/server/middleware"
@@ -256,6 +257,11 @@ func TestFavorites_WithNote(t *testing.T) {
 	h.SetFavoriteRepo(favRepo)
 	rec := postExtra(h.Favorites, `{}`, &model.User{ID: "u1"})
 	assert.Equal(t, http.StatusOK, rec.Code)
+
+	var resp []map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+	require.Len(t, resp, 1)
+	shapetest.Assert(t, "NoteFavorite", resp[0]) // L3 (#1286)
 }
 
 // untilId 経由の cursor pagination が repo に正しく伝わり、cursor 以下の

--- a/internal/api/mute/handler_test.go
+++ b/internal/api/mute/handler_test.go
@@ -1,6 +1,7 @@
 package mute
 
 import (
+	"encoding/json"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -8,6 +9,7 @@ import (
 
 	"github.com/labstack/echo/v4"
 	coremuting "github.com/shiroha-a/mk/internal/core/muting"
+	"github.com/shiroha-a/mk/internal/entitycompat/shapetest"
 	"github.com/shiroha-a/mk/internal/misc/id"
 	"github.com/shiroha-a/mk/internal/model"
 	"github.com/shiroha-a/mk/internal/server/middleware"
@@ -208,6 +210,11 @@ func TestList_OK(t *testing.T) {
 	setUser(c, "alice")
 	require.NoError(t, h.List(c))
 	assert.Equal(t, http.StatusOK, rec.Code)
+
+	var resp []map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+	require.Len(t, resp, 1)
+	shapetest.Assert(t, "Muting", resp[0]) // L3 (#1286)
 }
 
 func TestList_LimitClamping(t *testing.T) {

--- a/internal/api/renotemute/handler_test.go
+++ b/internal/api/renotemute/handler_test.go
@@ -1,6 +1,7 @@
 package renotemute
 
 import (
+	"encoding/json"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -8,6 +9,7 @@ import (
 
 	"github.com/labstack/echo/v4"
 	coremuting "github.com/shiroha-a/mk/internal/core/muting"
+	"github.com/shiroha-a/mk/internal/entitycompat/shapetest"
 	"github.com/shiroha-a/mk/internal/misc/id"
 	"github.com/shiroha-a/mk/internal/model"
 	"github.com/shiroha-a/mk/internal/server/middleware"
@@ -197,6 +199,11 @@ func TestList_OK(t *testing.T) {
 	setUser(c, "alice")
 	require.NoError(t, h.List(c))
 	assert.Equal(t, http.StatusOK, rec.Code)
+
+	var resp []map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+	require.Len(t, resp, 1)
+	shapetest.Assert(t, "RenoteMuting", resp[0]) // L3 (#1286)
 }
 
 func TestList_LimitClamping(t *testing.T) {

--- a/internal/api/roles/handler_test.go
+++ b/internal/api/roles/handler_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/labstack/echo/v4"
 	"github.com/shiroha-a/mk/internal/api/roles"
 	corerole "github.com/shiroha-a/mk/internal/core/role"
+	"github.com/shiroha-a/mk/internal/entitycompat/shapetest"
 	"github.com/shiroha-a/mk/internal/misc/id"
 	"github.com/shiroha-a/mk/internal/model"
 	"github.com/shiroha-a/mk/internal/testutil"
@@ -99,6 +100,7 @@ func TestList_FullShape(t *testing.T) {
 	assert.Equal(t, "2026-05-01T00:00:00.000Z", r["updatedAt"])
 	assert.Equal(t, true, r["canEditMembersByModerator"])
 	assert.Equal(t, float64(0), r["usersCount"])
+	shapetest.Assert(t, "RoleLite", r) // L3 (#1286)
 }
 
 func TestShow_Success(t *testing.T) {

--- a/internal/entitycompat/runtime.go
+++ b/internal/entitycompat/runtime.go
@@ -33,6 +33,8 @@ func L2FlatSchemaNames() []string {
 		"GalleryPost", "Hashtag", "App",
 		"Flash", "InviteCode", "UserWebhook", "Channel",
 		"FederationInstance", "NoteReaction", "ChatRoom",
+		"Muting", "RenoteMuting", "Blocking", "RoleLite",
+		"EmojiSimple", "NoteFavorite",
 	}
 }
 

--- a/internal/entitycompat/testdata/golden_schemas.json
+++ b/internal/entitycompat/testdata/golden_schemas.json
@@ -180,6 +180,28 @@
       "type": "string"
     }
   },
+  "Blocking": {
+    "blockee": {
+      "nullable": false,
+      "optional": false,
+      "type": "object"
+    },
+    "blockeeId": {
+      "nullable": false,
+      "optional": false,
+      "type": "string"
+    },
+    "createdAt": {
+      "nullable": false,
+      "optional": false,
+      "type": "string"
+    },
+    "id": {
+      "nullable": false,
+      "optional": false,
+      "type": "string"
+    }
+  },
   "Channel": {
     "allowRenoteToExternal": {
       "nullable": false,
@@ -539,6 +561,43 @@
     "roleIdsThatCanBeUsedThisEmojiAsReaction": {
       "nullable": false,
       "optional": false,
+      "type": "array"
+    },
+    "url": {
+      "nullable": false,
+      "optional": false,
+      "type": "string"
+    }
+  },
+  "EmojiSimple": {
+    "aliases": {
+      "nullable": false,
+      "optional": false,
+      "type": "array"
+    },
+    "category": {
+      "nullable": true,
+      "optional": false,
+      "type": "string"
+    },
+    "isSensitive": {
+      "nullable": false,
+      "optional": true,
+      "type": "boolean"
+    },
+    "localOnly": {
+      "nullable": false,
+      "optional": true,
+      "type": "boolean"
+    },
+    "name": {
+      "nullable": false,
+      "optional": false,
+      "type": "string"
+    },
+    "roleIdsThatCanBeUsedThisEmojiAsReaction": {
+      "nullable": false,
+      "optional": true,
       "type": "array"
     },
     "url": {
@@ -1121,6 +1180,33 @@
       "type": "boolean"
     }
   },
+  "Muting": {
+    "createdAt": {
+      "nullable": false,
+      "optional": false,
+      "type": "string"
+    },
+    "expiresAt": {
+      "nullable": true,
+      "optional": false,
+      "type": "string"
+    },
+    "id": {
+      "nullable": false,
+      "optional": false,
+      "type": "string"
+    },
+    "mutee": {
+      "nullable": false,
+      "optional": false,
+      "type": "object"
+    },
+    "muteeId": {
+      "nullable": false,
+      "optional": false,
+      "type": "string"
+    }
+  },
   "Note": {
     "channel": {
       "nullable": true,
@@ -1298,6 +1384,28 @@
       "type": "array"
     }
   },
+  "NoteFavorite": {
+    "createdAt": {
+      "nullable": false,
+      "optional": false,
+      "type": "string"
+    },
+    "id": {
+      "nullable": false,
+      "optional": false,
+      "type": "string"
+    },
+    "note": {
+      "nullable": false,
+      "optional": false,
+      "type": "object"
+    },
+    "noteId": {
+      "nullable": false,
+      "optional": false,
+      "type": "string"
+    }
+  },
   "NoteReaction": {
     "createdAt": {
       "nullable": false,
@@ -1415,6 +1523,70 @@
       "nullable": false,
       "optional": false,
       "type": "array"
+    }
+  },
+  "RenoteMuting": {
+    "createdAt": {
+      "nullable": false,
+      "optional": false,
+      "type": "string"
+    },
+    "id": {
+      "nullable": false,
+      "optional": false,
+      "type": "string"
+    },
+    "mutee": {
+      "nullable": false,
+      "optional": false,
+      "type": "object"
+    },
+    "muteeId": {
+      "nullable": false,
+      "optional": false,
+      "type": "string"
+    }
+  },
+  "RoleLite": {
+    "color": {
+      "nullable": true,
+      "optional": false,
+      "type": "string"
+    },
+    "description": {
+      "nullable": false,
+      "optional": false,
+      "type": "string"
+    },
+    "displayOrder": {
+      "nullable": false,
+      "optional": false,
+      "type": "number"
+    },
+    "iconUrl": {
+      "nullable": true,
+      "optional": false,
+      "type": "string"
+    },
+    "id": {
+      "nullable": false,
+      "optional": false,
+      "type": "string"
+    },
+    "isAdministrator": {
+      "nullable": false,
+      "optional": false,
+      "type": "boolean"
+    },
+    "isModerator": {
+      "nullable": false,
+      "optional": false,
+      "type": "boolean"
+    },
+    "name": {
+      "nullable": false,
+      "optional": false,
+      "type": "string"
     }
   },
   "Signin": {


### PR DESCRIPTION
## Summary

**L3(実レスポンス検証)を 6 handler へ一気に拡大**し、検出範囲を大きく広げる。relation list 系 + roles/emojis/favorites を golden に突合する `shapetest.Assert` を各 handler test に撒く。**6 経路とも drift 無し**(現 golden 準拠)、production code 変更なし。

## 主な変更点
- golden snapshot に **Muting / RenoteMuting / Blocking / RoleLite / EmojiSimple / NoteFavorite** を追加(`L2FlatSchemaNames`)。
- `shapetest.Assert` を追加:
  - `mute/list` → `Muting`(`mutee` = UserDetailedNotMe を embed)
  - `blocking/list` → `Blocking`(`blockee` を embed)
  - `renote-mute/list` → `RenoteMuting`
  - `roles/list` → `RoleLite`
  - `emojis` → `EmojiSimple`(`{emojis:[...]}` の要素)
  - `i/favorites` → `NoteFavorite`(`note` = Note を embed)

## 結果
L3 守備範囲が 6 経路増えて計 24 経路。

## 別 issue 送り(packer 側に embed 漏れ → 要修正)
調査の結果、以下は packer に欠落フィールドがあり修正を伴うため本 PR に含めない:
- **ChatMessage**(chat/messages/create): `fromUser` が未 attach の可能性 + svc/legacy 2 経路
- **ReversiGameLite**(reversi): `user1`/`user2`/`createdAt` 等の embed 漏れ
- **Ad**(admin/ad/list): admin パッケージのカバレッジ制約 + packer 要確認

## テスト
- 6 package + `entitycompat` 全 green、race + atomic、`make shapecheck` green、build / vet / fmt clean。
- production code 変更ゼロのためカバレッジは増加方向のみ。

## Closes
Closes #1286

🤖 Generated with [Claude Code](https://claude.com/claude-code)