### PR TITLE
fix(chat): messages/create の応答に fromUser を追加

### DIFF
--- a/internal/api/chat/handler.go
+++ b/internal/api/chat/handler.go
@@ -558,7 +558,7 @@ func (h *Handler) MessagesCreate(c echo.Context) error {
 	if err != nil {
 		return h.mapChatErr(c, err)
 	}
-	return c.JSON(http.StatusOK, h.packMessageDetailed(h.reloadIfFilePending(msg), user.ID))
+	return c.JSON(http.StatusOK, h.packMessageDetailed(withSender(h.reloadIfFilePending(msg), user), user.ID))
 }
 
 // messagesCreateLegacy preserves pre-Phase-9.8 behaviour for callers that
@@ -573,7 +573,19 @@ func (h *Handler) messagesCreateLegacy(c echo.Context, user *model.User, text, t
 	if err := h.repo.CreateMessage(msg); err != nil {
 		return c.JSON(http.StatusInternalServerError, apierr.Error("INTERNAL_ERROR", "Internal error.", "5d37dbcb-891e-41ca-a3d6-e690c97775ac"))
 	}
-	return c.JSON(http.StatusOK, h.packMessageDetailed(h.reloadIfFilePending(msg), user.ID))
+	return c.JSON(http.StatusOK, h.packMessageDetailed(withSender(h.reloadIfFilePending(msg), user), user.ID))
+}
+
+// withSender attaches the authenticated sender as FromUser when the row has
+// no eager-loaded relation, so create responses include the golden-required
+// `fromUser` (UserLite). 作成直後の message は CreateMessage が FromUser を
+// Preload しないため fromUser が欠落していた (#1288。ChatRoom owner #1285 と
+// 同種の embed 漏れ)。reload で DB から FromUser が載った場合は上書きしない。
+func withSender(m *model.ChatMessage, sender *model.User) *model.ChatMessage {
+	if m != nil && m.FromUser == nil {
+		m.FromUser = sender
+	}
+	return m
 }
 
 // reloadIfFilePending re-fetches the message via FindMessageByID (which

--- a/internal/api/chat/handler_test.go
+++ b/internal/api/chat/handler_test.go
@@ -281,6 +281,10 @@ func TestMessagesCreate_Success(t *testing.T) {
 	assert.Equal(t, http.StatusOK, rec.Code)
 	assert.Len(t, repo.Messages, 1)
 	_ = text
+
+	var resp map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+	shapetest.Assert(t, "ChatMessage", resp) // L3 (#1288)
 }
 
 func TestMessagesCreate_Error(t *testing.T) {

--- a/internal/entitycompat/runtime.go
+++ b/internal/entitycompat/runtime.go
@@ -34,7 +34,7 @@ func L2FlatSchemaNames() []string {
 		"Flash", "InviteCode", "UserWebhook", "Channel",
 		"FederationInstance", "NoteReaction", "ChatRoom",
 		"Muting", "RenoteMuting", "Blocking", "RoleLite",
-		"EmojiSimple", "NoteFavorite",
+		"EmojiSimple", "NoteFavorite", "ChatMessage",
 	}
 }
 

--- a/internal/entitycompat/testdata/golden_schemas.json
+++ b/internal/entitycompat/testdata/golden_schemas.json
@@ -299,6 +299,73 @@
       "type": "number"
     }
   },
+  "ChatMessage": {
+    "createdAt": {
+      "nullable": false,
+      "optional": false,
+      "type": "string"
+    },
+    "file": {
+      "nullable": true,
+      "optional": true,
+      "type": "object"
+    },
+    "fileId": {
+      "nullable": true,
+      "optional": true,
+      "type": "string"
+    },
+    "fromUser": {
+      "nullable": false,
+      "optional": false,
+      "type": "object"
+    },
+    "fromUserId": {
+      "nullable": false,
+      "optional": false,
+      "type": "string"
+    },
+    "id": {
+      "nullable": false,
+      "optional": false,
+      "type": "string"
+    },
+    "isRead": {
+      "nullable": false,
+      "optional": true,
+      "type": "boolean"
+    },
+    "reactions": {
+      "nullable": false,
+      "optional": false,
+      "type": "object"
+    },
+    "text": {
+      "nullable": true,
+      "optional": true,
+      "type": "string"
+    },
+    "toRoom": {
+      "nullable": true,
+      "optional": true,
+      "type": "object"
+    },
+    "toRoomId": {
+      "nullable": true,
+      "optional": true,
+      "type": "string"
+    },
+    "toUser": {
+      "nullable": true,
+      "optional": true,
+      "type": "object"
+    },
+    "toUserId": {
+      "nullable": true,
+      "optional": true,
+      "type": "string"
+    }
+  },
   "ChatRoom": {
     "createdAt": {
       "nullable": false,


### PR DESCRIPTION
## Summary

L3(#1286 系)で検出した `chat/messages/create` の golden `ChatMessage` に対する shape drift を修正する(#1288)。golden が必須とする `fromUser`(UserLite)が応答から欠落していた。

## 主な変更点
- **fromUser 欠落の修正**: `packMessage` は `m.FromUser != nil` のときだけ `fromUser` を emit するが、`MessagesCreate` / `messagesCreateLegacy` は作成した message に `FromUser` relation を attach しないため欠落していた(ChatRoom owner #1285 と同種の embed 漏れ)。upstream(CherryPick federated chat)`ChatEntityService` は `fromUserId` から fromUser を解決して必ず含めるため、create 経路では作成者(= 認証 user)を attach。
- **`withSender` helper** を追加し svc / legacy 両経路をカバー。reload で DB から `FromUser` が載った場合は上書きしない(`if m.FromUser == nil` ガード)。
- `chat/messages/create` に L3(`shapetest.Assert(t, "ChatMessage", resp)`)を配線、golden snapshot に `ChatMessage` を追加。

## drift 詳細
golden `ChatMessage` 必須: id / createdAt / fromUserId / **fromUser** / reactions。修正後すべて供給(createdAt は aidx ID 由来、reactions は常に非 null 配列)。

## テスト
- `chat` + `entitycompat` 全 green、race + atomic、`make shapecheck` green、build / vet / fmt clean。
- `chat` coverage 91.6%(gate 90% 超過)。

## Closes
Closes #1288

🤖 Generated with [Claude Code](https://claude.com/claude-code)