### PR TITLE
test(api): L3 を admin/ad/list (Ad) へ拡大

### DIFF
--- a/internal/api/admin/ad_invite_promo_test.go
+++ b/internal/api/admin/ad_invite_promo_test.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	apiadmin "github.com/shiroha-a/mk/internal/api/admin"
+	"github.com/shiroha-a/mk/internal/entitycompat/shapetest"
 	"github.com/shiroha-a/mk/internal/model"
 	"github.com/shiroha-a/mk/internal/testutil"
 	"github.com/stretchr/testify/assert"
@@ -113,6 +114,10 @@ func TestAdList_Paginated(t *testing.T) {
 	assert.Len(t, rows, 3)
 	// id DESC
 	assert.Equal(t, "a04", rows[0].ID)
+
+	var rawRows []map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &rawRows))
+	shapetest.Assert(t, "Ad", rawRows[0]) // L3 (#1292)
 }
 
 func TestAdUpdate_PartialFields(t *testing.T) {

--- a/internal/entitycompat/runtime.go
+++ b/internal/entitycompat/runtime.go
@@ -34,7 +34,7 @@ func L2FlatSchemaNames() []string {
 		"Flash", "InviteCode", "UserWebhook", "Channel",
 		"FederationInstance", "NoteReaction", "ChatRoom",
 		"Muting", "RenoteMuting", "Blocking", "RoleLite",
-		"EmojiSimple", "NoteFavorite", "ChatMessage",
+		"EmojiSimple", "NoteFavorite", "ChatMessage", "Ad",
 	}
 }
 

--- a/internal/entitycompat/testdata/golden_schemas.json
+++ b/internal/entitycompat/testdata/golden_schemas.json
@@ -1,4 +1,61 @@
 {
+  "Ad": {
+    "dayOfWeek": {
+      "nullable": false,
+      "optional": false,
+      "type": "number"
+    },
+    "expiresAt": {
+      "nullable": false,
+      "optional": false,
+      "type": "string"
+    },
+    "id": {
+      "nullable": false,
+      "optional": false,
+      "type": "string"
+    },
+    "imageUrl": {
+      "nullable": false,
+      "optional": false,
+      "type": "string"
+    },
+    "isSensitive": {
+      "nullable": false,
+      "optional": false,
+      "type": "boolean"
+    },
+    "memo": {
+      "nullable": false,
+      "optional": false,
+      "type": "string"
+    },
+    "place": {
+      "nullable": false,
+      "optional": false,
+      "type": "string"
+    },
+    "priority": {
+      "nullable": false,
+      "optional": false,
+      "type": "string"
+    },
+    "ratio": {
+      "nullable": false,
+      "optional": false,
+      "type": "number"
+    },
+    "startsAt": {
+      "nullable": false,
+      "optional": false,
+      "type": "string"
+    },
+    "url": {
+      "nullable": false,
+      "optional": false,
+      "type": "string"
+    }
+  },
   "Announcement": {
     "createdAt": {
       "nullable": false,


### PR DESCRIPTION
## Summary

L3(実レスポンス検証)を `admin/ad/list` へ拡大。`Ad` は vanilla Misskey の広告機能(cherrypick lineage 無し)で、`model.Ad` を packer 無しで直接 JSON 化する。**drift 無し(clean)・production 変更ゼロ**。

## 調査結果
`model.Ad` の json tag(`id`/`expiresAt`/`startsAt`/`place`/`priority`/`ratio`/`url`/`imageUrl`/`memo`/`dayOfWeek`/`isSensitive`)は golden `Ad`(11 field)と**完全一致**。型も整合(`expiresAt`/`startsAt` は time.Time → RFC3339 string、`ratio`/`dayOfWeek` は number、`isSensitive` は boolean)。

## 主な変更点
- golden snapshot に `Ad` を追加(`L2FlatSchemaNames`)。
- `TestAdList_Paginated` に `shapetest.Assert(t, "Ad", rawRows[0])` を配線(`[]map[string]any` で再 decode)。

## テスト
- `admin` + `entitycompat` 全 green、race + atomic、`make shapecheck` green、build / vet / fmt clean。
- `admin` coverage 86.8%(admin 例外 gate 80% 超過)。

## Closes
Closes #1292

🤖 Generated with [Claude Code](https://claude.com/claude-code)