### PR TITLE
test(api): L3 を admin/system-webhook + users/achievements へ拡大

### DIFF
--- a/internal/api/admin/system_webhook_test.go
+++ b/internal/api/admin/system_webhook_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/shiroha-a/mk/internal/entitycompat/shapetest"
 	"github.com/shiroha-a/mk/internal/model"
 	"github.com/shiroha-a/mk/internal/testutil"
 	"github.com/stretchr/testify/assert"
@@ -31,6 +32,10 @@ func TestSystemWebhookCreate_Success(t *testing.T) {
 	assert.Equal(t, "https://example.com/hook", got.URL)
 	assert.True(t, got.IsActive)
 	assert.Contains(t, repo.Webhooks, got.ID)
+
+	var raw map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &raw))
+	shapetest.Assert(t, "SystemWebhook", raw) // L3 (#1294)
 }
 
 func TestSystemWebhookCreate_MissingFields(t *testing.T) {

--- a/internal/api/users/achievements_test.go
+++ b/internal/api/users/achievements_test.go
@@ -1,11 +1,14 @@
 package users
 
 import (
+	"encoding/json"
 	"net/http"
 	"testing"
 
+	"github.com/shiroha-a/mk/internal/entitycompat/shapetest"
 	"github.com/shiroha-a/mk/internal/model"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"gorm.io/datatypes"
 )
 
@@ -19,6 +22,11 @@ func TestAchievements_Success(t *testing.T) {
 	rec := postStub(h.Achievements, `{"userId":"u1"}`, nil)
 	assert.Equal(t, http.StatusOK, rec.Code)
 	assert.Contains(t, rec.Body.String(), "notes1")
+
+	var resp []map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+	require.Len(t, resp, 1)
+	shapetest.Assert(t, "Achievement", resp[0]) // L3 (#1294)
 }
 
 func TestAchievements_NoProfile(t *testing.T) {

--- a/internal/entitycompat/runtime.go
+++ b/internal/entitycompat/runtime.go
@@ -35,6 +35,7 @@ func L2FlatSchemaNames() []string {
 		"FederationInstance", "NoteReaction", "ChatRoom",
 		"Muting", "RenoteMuting", "Blocking", "RoleLite",
 		"EmojiSimple", "NoteFavorite", "ChatMessage", "Ad",
+		"SystemWebhook", "Achievement",
 	}
 }
 

--- a/internal/entitycompat/testdata/golden_schemas.json
+++ b/internal/entitycompat/testdata/golden_schemas.json
@@ -1,4 +1,16 @@
 {
+  "Achievement": {
+    "name": {
+      "nullable": false,
+      "optional": false,
+      "type": "object"
+    },
+    "unlockedAt": {
+      "nullable": false,
+      "optional": false,
+      "type": "number"
+    }
+  },
   "Ad": {
     "dayOfWeek": {
       "nullable": false,
@@ -1738,6 +1750,53 @@
       "nullable": false,
       "optional": false,
       "type": "boolean"
+    }
+  },
+  "SystemWebhook": {
+    "id": {
+      "nullable": false,
+      "optional": false,
+      "type": "string"
+    },
+    "isActive": {
+      "nullable": false,
+      "optional": false,
+      "type": "boolean"
+    },
+    "latestSentAt": {
+      "nullable": true,
+      "optional": false,
+      "type": "string"
+    },
+    "latestStatus": {
+      "nullable": true,
+      "optional": false,
+      "type": "number"
+    },
+    "name": {
+      "nullable": false,
+      "optional": false,
+      "type": "string"
+    },
+    "on": {
+      "nullable": false,
+      "optional": false,
+      "type": "array"
+    },
+    "secret": {
+      "nullable": false,
+      "optional": false,
+      "type": "string"
+    },
+    "updatedAt": {
+      "nullable": false,
+      "optional": false,
+      "type": "string"
+    },
+    "url": {
+      "nullable": false,
+      "optional": false,
+      "type": "string"
     }
   },
   "UserDetailedNotMeOnly": {


### PR DESCRIPTION
## Summary

L3(実レスポンス検証)を vanilla Misskey の **SystemWebhook**(admin/system-webhook)と **Achievement**(users/achievements)へ拡大。両者とも cherrypick lineage 無し・**drift 無し・production 変更ゼロ**。

## 調査結果
- **SystemWebhook**: `model.SystemWebhook` の json tag(`id`/`isActive`/`updatedAt`/`latestSentAt`/`latestStatus`/`name`/`on`/`url`/`secret`)が golden と**完全一致**(model 直返し、Ad と同方式)。
- **Achievement**: `users/achievements` は保存済み `[{name, unlockedAt}]` を pass-through。golden Achievement(name / unlockedAt)と一致。`ClaimAchievement` の書き込み形式とも整合。

## 主な変更点
- golden snapshot に `SystemWebhook` / `Achievement` を追加。
- `shapetest.Assert` を配線: `admin/system-webhook/create` → `SystemWebhook`、`users/achievements` → `Achievement`。

## 別 issue 候補(本 PR 対象外)
- **AbuseReportNotificationRecipient**: model 直返しで golden 必須の `updatedAt` 欠落 + `userId`/`systemWebhookId` が null(golden は optional 非 null)の drift。packer + `updatedAt` 列が必要なため別途。

## テスト
- `admin`(86.8%)/ `users`(92.7%)/ `entitycompat` 全 green、race + atomic、`make shapecheck` green、build / vet / fmt clean。

## Closes
Closes #1294

🤖 Generated with [Claude Code](https://claude.com/claude-code)