### PR TITLE
fix(admin): abuse-report notification-recipient の応答に updatedAt を追加 + userId/systemWebhookId を omit

### DIFF
--- a/internal/api/admin/abuse_report_notification.go
+++ b/internal/api/admin/abuse_report_notification.go
@@ -52,6 +52,7 @@ func (h *Handler) AbuseReportNotificationRecipientCreate(c echo.Context) error {
 		UserID:          req.UserID,
 		SystemWebhookID: req.SystemWebhookID,
 		IsActive:        *req.IsActive,
+		UpdatedAt:       time.Now(),
 	}
 	if err := h.recipientRepo.Create(r); err != nil {
 		return c.JSON(http.StatusInternalServerError, apierr.InternalError())
@@ -191,6 +192,8 @@ func (h *Handler) AbuseReportNotificationRecipientUpdate(c echo.Context) error {
 	if req.SystemWebhookID != nil {
 		fields["systemWebhookId"] = *req.SystemWebhookID
 	}
+	// upstream は更新のたびに updatedAt を bump する (golden は updatedAt 必須)。
+	fields["updatedAt"] = time.Now()
 	// GORM Updates(map) は対象なしでも nil を返すため、ここでのエラーは DB 障害
 	// 等の真の失敗。NotFound は続く FindByID で検出する。
 	if err := h.recipientRepo.Update(req.ID, fields); err != nil {

--- a/internal/api/admin/abuse_report_notification_test.go
+++ b/internal/api/admin/abuse_report_notification_test.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	apiadmin "github.com/shiroha-a/mk/internal/api/admin"
+	"github.com/shiroha-a/mk/internal/entitycompat/shapetest"
 	"github.com/shiroha-a/mk/internal/model"
 	"github.com/shiroha-a/mk/internal/testutil"
 	"github.com/stretchr/testify/assert"
@@ -44,6 +45,13 @@ func TestRecipientCreate_Success(t *testing.T) {
 	assert.Equal(t, "ops", got.Name)
 	assert.Equal(t, "email", got.Method)
 	assert.True(t, got.IsActive)
+
+	var raw map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &raw))
+	shapetest.Assert(t, "AbuseReportNotificationRecipient", raw) // L3 (#1294)
+	// method=email では systemWebhookId は省略される (omitempty)。
+	_, hasSysWH := raw["systemWebhookId"]
+	assert.False(t, hasSysWH, "systemWebhookId must be omitted when method=email")
 }
 
 func TestRecipientCreate_MissingRequired(t *testing.T) {

--- a/internal/entitycompat/runtime.go
+++ b/internal/entitycompat/runtime.go
@@ -35,7 +35,7 @@ func L2FlatSchemaNames() []string {
 		"FederationInstance", "NoteReaction", "ChatRoom",
 		"Muting", "RenoteMuting", "Blocking", "RoleLite",
 		"EmojiSimple", "NoteFavorite", "ChatMessage", "Ad",
-		"SystemWebhook", "Achievement",
+		"SystemWebhook", "Achievement", "AbuseReportNotificationRecipient",
 	}
 }
 

--- a/internal/entitycompat/testdata/golden_schemas.json
+++ b/internal/entitycompat/testdata/golden_schemas.json
@@ -1,4 +1,51 @@
 {
+  "AbuseReportNotificationRecipient": {
+    "id": {
+      "nullable": false,
+      "optional": false,
+      "type": "string"
+    },
+    "isActive": {
+      "nullable": false,
+      "optional": false,
+      "type": "boolean"
+    },
+    "method": {
+      "nullable": false,
+      "optional": false,
+      "type": "string"
+    },
+    "name": {
+      "nullable": false,
+      "optional": false,
+      "type": "string"
+    },
+    "systemWebhook": {
+      "nullable": false,
+      "optional": true,
+      "type": "object"
+    },
+    "systemWebhookId": {
+      "nullable": false,
+      "optional": true,
+      "type": "string"
+    },
+    "updatedAt": {
+      "nullable": false,
+      "optional": false,
+      "type": "string"
+    },
+    "user": {
+      "nullable": false,
+      "optional": true,
+      "type": "object"
+    },
+    "userId": {
+      "nullable": false,
+      "optional": true,
+      "type": "string"
+    }
+  },
   "Achievement": {
     "name": {
       "nullable": false,

--- a/internal/model/admin_models.go
+++ b/internal/model/admin_models.go
@@ -77,12 +77,17 @@ func (SystemWebhook) TableName() string { return "system_webhook" }
 
 // AbuseReportNotificationRecipient represents a notification recipient for abuse reports.
 type AbuseReportNotificationRecipient struct {
-	ID              string  `gorm:"column:id;type:varchar(32);primaryKey" json:"id"`
-	IsActive        bool    `gorm:"column:isActive;default:true" json:"isActive"`
-	Name            string  `gorm:"column:name;type:varchar(255);not null" json:"name"`
-	Method          string  `gorm:"column:method;type:varchar(64);not null;default:'email'" json:"method"`
-	UserID          *string `gorm:"column:userId;type:varchar(32)" json:"userId"`
-	SystemWebhookID *string `gorm:"column:systemWebhookId;type:varchar(32)" json:"systemWebhookId"`
+	ID        string    `gorm:"column:id;type:varchar(32);primaryKey" json:"id"`
+	IsActive  bool      `gorm:"column:isActive;default:true" json:"isActive"`
+	UpdatedAt time.Time `gorm:"column:updatedAt;type:timestamp with time zone;default:now()" json:"updatedAt"`
+	Name      string    `gorm:"column:name;type:varchar(255);not null" json:"name"`
+	Method    string    `gorm:"column:method;type:varchar(64);not null;default:'email'" json:"method"`
+	// golden の userId? / systemWebhookId? は optional (非 null)。upstream packer は
+	// method に対応しない側を omit するため、nil ポインタは null ではなく省略する
+	// (omitempty)。method=email では userId のみ、webhook では systemWebhookId のみ
+	// が出る (#1294)。
+	UserID          *string `gorm:"column:userId;type:varchar(32)" json:"userId,omitempty"`
+	SystemWebhookID *string `gorm:"column:systemWebhookId;type:varchar(32)" json:"systemWebhookId,omitempty"`
 }
 
 func (AbuseReportNotificationRecipient) TableName() string {

--- a/migration/000051_abuse_report_notification_recipient_updatedat.down.sql
+++ b/migration/000051_abuse_report_notification_recipient_updatedat.down.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "abuse_report_notification_recipient" DROP COLUMN IF EXISTS "updatedAt";

--- a/migration/000051_abuse_report_notification_recipient_updatedat.up.sql
+++ b/migration/000051_abuse_report_notification_recipient_updatedat.up.sql
@@ -1,0 +1,7 @@
+-- Misskey 本家の AbuseReportNotificationRecipient entity は updatedAt
+-- (timestamp with time zone, default CURRENT_TIMESTAMP) を持つ。mk-go の
+-- 000028 はこの列を欠いており、admin/abuse-report/notification-recipient の
+-- 応答が golden 必須の updatedAt を欠落していた (#1294 で検出)。drop-in DB
+-- 互換のため列を追加する。既存行には now() を埋める。
+ALTER TABLE "abuse_report_notification_recipient"
+    ADD COLUMN IF NOT EXISTS "updatedAt" timestamp with time zone NOT NULL DEFAULT now();


### PR DESCRIPTION
## Summary

L3(#1294 調査中)で検出した `AbuseReportNotificationRecipient` の golden に対する shape drift を修正する。

## 検出 → 修正した drift
- **`updatedAt` 欠落(required)**: Misskey 本家 entity は `updatedAt`(timestamp with time zone, default CURRENT_TIMESTAMP)を持つが、mk-go の migration 000028 はこの列を欠いていた。
  - **migration 000051** で `updatedAt timestamp with time zone NOT NULL DEFAULT now()` を追加(drop-in DB 互換、既存行は now() 埋め)。
  - `model.AbuseReportNotificationRecipient` に `UpdatedAt` 追加。Create は `now()` を set、Update は更新のたびに bump。
- **`userId`/`systemWebhookId` が null**: golden は `userId?`/`systemWebhookId?` を optional(非 null)とし、upstream packer は method に対応しない側を **omit**(email=userId のみ / webhook=systemWebhookId のみ)。model 直返し + omitempty 無しで両方 `null` を出していたため、json tag に `omitempty` を付与。

## L3
- `admin/abuse-report/notification-recipient/create` に `shapetest.Assert(t, "AbuseReportNotificationRecipient", ...)` を配線、golden snapshot に追加。
- method=email では `systemWebhookId` が省略されることも test で assert。

## テスト
- `admin`(86.8%)/ `repository`(実 DB で 000051 migration 適用)/ `entitycompat` 全 green、race + atomic、`make shapecheck` green、build / vet / fmt clean。

## Closes
Closes #1296
(drift は #1294 の調査中に検出。コミットメッセージ内の "#1294" は検出元への参照)

🤖 Generated with [Claude Code](https://claude.com/claude-code)