### PR TITLE
feat(entitycompat): L3 で array の element shape を検出する

### DIFF
--- a/internal/entitycompat/runtime.go
+++ b/internal/entitycompat/runtime.go
@@ -1,6 +1,7 @@
 package entitycompat
 
 import (
+	"encoding/json"
 	"reflect"
 	"strings"
 )
@@ -164,6 +165,11 @@ func ValidateValue(family, layer, golden string, actual map[string]any, schema S
 		if at := jsonType(v); scalarMismatch(g.Type, at) {
 			findings = append(findings, mk(name, "type", SevMed,
 				"golden type "+g.Type+" but runtime value is "+at))
+		} else if g.Type == "array" && g.Elem != "" {
+			if et, ok := arrayElemType(v); ok && elemMismatch(g.Elem, et) {
+				findings = append(findings, mk(name, "elem", SevMed,
+					"golden array element "+g.Elem+" but runtime element is "+et))
+			}
 		}
 	}
 	for name := range actual {
@@ -219,6 +225,64 @@ func jsonType(v any) string {
 	default:
 		return "other"
 	}
+}
+
+// arrayElemType returns the JSON type bucket of the first element of a slice
+// value, so the validator can compare it against the golden array element
+// type. ok is false for non-slices or empty slices (= cannot determine the
+// element type, so the caller skips the check). #1298
+func arrayElemType(v any) (string, bool) {
+	// json.RawMessage / []byte は生 JSON。byte slice として走査すると先頭の
+	// '[' (= 91) を number 要素と誤読するため、一度 decode してから要素型を
+	// 見る (L2 fixture が packer map を直接渡す経路向け。L3 は json.Unmarshal
+	// 済なので []any として届く)。#1298
+	if raw, ok := asRawJSONArray(v); ok {
+		var arr []any
+		if json.Unmarshal(raw, &arr) != nil || len(arr) == 0 {
+			return "", false
+		}
+		return jsonType(arr[0]), true
+	}
+	rv := reflect.ValueOf(v)
+	for rv.Kind() == reflect.Ptr || rv.Kind() == reflect.Interface {
+		if rv.IsNil() {
+			return "", false
+		}
+		rv = rv.Elem()
+	}
+	if rv.Kind() != reflect.Slice && rv.Kind() != reflect.Array {
+		return "", false
+	}
+	if rv.Len() == 0 {
+		return "", false
+	}
+	return jsonType(rv.Index(0).Interface()), true
+}
+
+// asRawJSONArray returns the underlying bytes when v is raw JSON (json.RawMessage
+// or []byte). The []byte case must exclude actual byte-slice payloads, but in
+// entity packers raw-JSON columns surface as json.RawMessage/datatypes.JSON
+// (both []byte) and represent serialized JSON, so treating them as raw JSON is
+// correct here.
+func asRawJSONArray(v any) ([]byte, bool) {
+	switch b := v.(type) {
+	case json.RawMessage:
+		return []byte(b), true
+	case []byte:
+		return b, true
+	}
+	return nil, false
+}
+
+// elemMismatch reports a clear array-element conflict. Only the concrete
+// buckets (string/number/boolean/object/array) are compared; "other" golden
+// elements (refs we cannot classify) are skipped to avoid false positives.
+func elemMismatch(goldenElem, actualElem string) bool {
+	switch goldenElem {
+	case "string", "number", "boolean", "object", "array":
+		return goldenElem != actualElem
+	}
+	return false
 }
 
 // scalarMismatch reports a clear scalar type conflict. Coarse buckets

--- a/internal/entitycompat/runtime_test.go
+++ b/internal/entitycompat/runtime_test.go
@@ -98,6 +98,50 @@ func TestValidateValue(t *testing.T) {
 	}
 }
 
+// TestValidateValue_ArrayElem covers the Layer 2 array element-type check
+// (#1298): string[] vs object[] etc. that the coarse "array" Type alone cannot
+// distinguish.
+func TestValidateValue_ArrayElem(t *testing.T) {
+	schema := Schema{
+		"roles":   {Type: "array", Elem: "object"}, // golden {id,name}[]
+		"tags":    {Type: "array", Elem: "string"}, // golden string[]
+		"raw":     {Type: "array", Elem: "object"}, // raw JSON column (json.RawMessage)
+		"refs":    {Type: "array", Elem: "other"},  // unclassifiable element -> skipped
+		"emptied": {Type: "array", Elem: "object"}, // empty -> cannot determine -> skipped
+	}
+	actual := map[string]any{
+		// VIOLATION: golden wants object elements but runtime is string[].
+		"roles": []any{"role1", "role2"},
+		// OK: string elements match.
+		"tags": []any{"a", "b"},
+		// OK: raw JSON decoded to object elements.
+		"raw": json.RawMessage(`[{"id":"r1","name":"n1"}]`),
+		// skipped: golden elem "other".
+		"refs": []any{"whatever"},
+		// skipped: empty array.
+		"emptied": []any{},
+	}
+	got := map[string]Severity{}
+	for _, f := range ValidateValue("F", "L", "G", actual, schema) {
+		got[f.Field+"/"+f.Kind] = f.Sev
+	}
+	if got["roles/elem"] != SevMed {
+		t.Error("expected roles element mismatch (string vs object) MED")
+	}
+	if _, ok := got["tags/elem"]; ok {
+		t.Error("matching string[] must not be flagged")
+	}
+	if _, ok := got["raw/elem"]; ok {
+		t.Error("raw JSON object[] must decode and match (no finding)")
+	}
+	if _, ok := got["refs/elem"]; ok {
+		t.Error("golden elem 'other' must be skipped")
+	}
+	if _, ok := got["emptied/elem"]; ok {
+		t.Error("empty array must be skipped (element type undeterminable)")
+	}
+}
+
 func TestValidateUnionValue(t *testing.T) {
 	variants := map[string]Schema{
 		"a": {"id": {Type: "string"}, "type": {Type: "string"}},

--- a/internal/entitycompat/shapecheck.go
+++ b/internal/entitycompat/shapecheck.go
@@ -26,6 +26,11 @@ type FieldShape struct {
 	Nullable bool   `json:"nullable"`
 	Optional bool   `json:"optional"`
 	Type     string `json:"type"`
+	// Elem is the element type of an array field ("string"/"number"/"boolean"/
+	// "object"/"array"/"other"). Empty for non-array fields. Lets the Layer 2
+	// validator distinguish e.g. string[] from {id,name}[] which the coarse
+	// "array" Type alone cannot (#1298)。
+	Elem string `json:"elem,omitempty"`
 }
 
 // Schema maps a JSON field name to its shape.
@@ -202,10 +207,18 @@ func parseSchema(lines []string, schemaName string) (Schema, bool) {
 		if !have {
 			return
 		}
+		// prop 行の coarseTS では多行 `{...}[]` を取りこぼす (m[3] が `{` で
+		// "object" 判定) ため、蓄積した field 全文 (buf) から array 判定と
+		// 要素型を再計算する。array でなければ既存の typ を維持する (#1298)。
+		fieldType, elem := typ, ""
+		if at, ae, ok := classifyArray(curName, buf.String()); ok {
+			fieldType, elem = at, ae
+		}
 		out[curName] = FieldShape{
 			Nullable: strings.Contains(buf.String(), "| null"),
 			Optional: optional,
-			Type:     typ,
+			Type:     fieldType,
+			Elem:     elem,
 		}
 		have = false
 		buf.Reset()
@@ -226,11 +239,15 @@ func parseSchema(lines []string, schemaName string) (Schema, bool) {
 				have = true
 			}
 		}
-		if have {
+		delta := strings.Count(ln, "{") - strings.Count(ln, "}")
+		// schema を閉じる行 (depth が 0 に戻る `};`) は最後の field の buf に
+		// 混入させない。混入すると多行 array の末尾 `[]` 判定が後続の `}` で
+		// 崩れて object と誤型付けされる (#1298)。
+		if have && depth+delta > 0 {
 			buf.WriteString(ln)
 			buf.WriteString("\n")
 		}
-		depth += strings.Count(ln, "{") - strings.Count(ln, "}")
+		depth += delta
 		if depth == 0 {
 			finalize()
 			return out, true
@@ -260,6 +277,52 @@ func coarseTS(rhs string) string {
 	case rhs == "number":
 		return "number"
 	case strings.Contains(rhs, "components['schemas']"):
+		return "object"
+	default:
+		return "other"
+	}
+}
+
+// classifyArray inspects a field's full (possibly multi-line) text and, when
+// the type is an array, returns ("array", <element type>, true). For non-array
+// fields it returns ("", "", false) so the caller keeps the prop-line coarseTS
+// result. Handles single-line `T[]` and multi-line `{ ... }[]` alike (#1298)。
+func classifyArray(name, raw string) (typ, elem string, ok bool) {
+	s := raw
+	// strip the leading `<name>?:` prefix.
+	if i := strings.Index(s, ":"); i >= 0 {
+		s = s[i+1:]
+	}
+	// 多行を 1 行に潰して末尾判定を安定させる。
+	s = strings.Join(strings.Fields(s), " ")
+	s = strings.TrimSpace(strings.TrimSuffix(strings.TrimSpace(s), ";"))
+	// 末尾の `| null` を剥がす (nullable は別途 buf で判定済)。
+	if strings.HasSuffix(s, "| null") {
+		s = strings.TrimSpace(strings.TrimSuffix(s, "| null"))
+	}
+	if !strings.HasSuffix(s, "[]") {
+		return "", "", false
+	}
+	inner := strings.TrimSpace(strings.TrimSuffix(s, "[]"))
+	return "array", elemKind(inner), true
+}
+
+// elemKind maps an array element type expression to a coarse element kind.
+func elemKind(inner string) string {
+	switch {
+	case inner == "string":
+		return "string"
+	case inner == "number":
+		return "number"
+	case inner == "boolean":
+		return "boolean"
+	case strings.HasSuffix(inner, "[]"):
+		return "array"
+	case strings.HasPrefix(inner, "{"):
+		return "object"
+	case strings.HasPrefix(inner, "'") || strings.Contains(inner, "' | '"):
+		return "string"
+	case strings.Contains(inner, "components['schemas']"):
 		return "object"
 	default:
 		return "other"

--- a/internal/entitycompat/shapecheck_test.go
+++ b/internal/entitycompat/shapecheck_test.go
@@ -62,6 +62,10 @@ func TestParseSchema(t *testing.T) {
 		"                inner: string;", // must NOT be captured as top-level
 		"            };",
 		"            kind: 'a' | 'b';",
+		"            roles: {", // multi-line object array -> Type=array, Elem=object
+		"                id: string;",
+		"                name: string;",
+		"            }[];",
 		"        };",
 		"        Other: {",
 		"            x: number;",
@@ -75,9 +79,10 @@ func TestParseSchema(t *testing.T) {
 		"id":     {Nullable: false, Optional: false, Type: "string"},
 		"name":   {Nullable: true, Optional: false, Type: "string"},
 		"count":  {Nullable: false, Optional: true, Type: "number"},
-		"tags":   {Nullable: false, Optional: false, Type: "array"},
+		"tags":   {Nullable: false, Optional: false, Type: "array", Elem: "string"},
 		"nested": {Nullable: false, Optional: false, Type: "object"},
 		"kind":   {Nullable: false, Optional: false, Type: "string"},
+		"roles":  {Nullable: false, Optional: false, Type: "array", Elem: "object"},
 	}
 	if !reflect.DeepEqual(got, want) {
 		t.Errorf("parseSchema mismatch:\n got=%+v\nwant=%+v", got, want)

--- a/internal/entitycompat/testdata/golden_schemas.json
+++ b/internal/entitycompat/testdata/golden_schemas.json
@@ -196,7 +196,8 @@
     "excludeKeywords": {
       "nullable": false,
       "optional": false,
-      "type": "array"
+      "type": "array",
+      "elem": "array"
     },
     "excludeNotesInSensitiveChannel": {
       "nullable": false,
@@ -221,7 +222,8 @@
     "keywords": {
       "nullable": false,
       "optional": false,
-      "type": "array"
+      "type": "array",
+      "elem": "array"
     },
     "localOnly": {
       "nullable": false,
@@ -251,7 +253,8 @@
     "users": {
       "nullable": false,
       "optional": false,
-      "type": "array"
+      "type": "array",
+      "elem": "string"
     },
     "withFile": {
       "nullable": false,
@@ -288,7 +291,8 @@
     "permission": {
       "nullable": false,
       "optional": false,
-      "type": "array"
+      "type": "array",
+      "elem": "string"
     },
     "secret": {
       "nullable": false,
@@ -397,12 +401,14 @@
     "pinnedNoteIds": {
       "nullable": false,
       "optional": false,
-      "type": "array"
+      "type": "array",
+      "elem": "string"
     },
     "pinnedNotes": {
       "nullable": false,
       "optional": true,
-      "type": "array"
+      "type": "array",
+      "elem": "object"
     },
     "userId": {
       "nullable": true,
@@ -454,7 +460,8 @@
     "reactions": {
       "nullable": false,
       "optional": false,
-      "type": "object"
+      "type": "array",
+      "elem": "object"
     },
     "text": {
       "nullable": true,
@@ -704,7 +711,8 @@
     "aliases": {
       "nullable": false,
       "optional": false,
-      "type": "array"
+      "type": "array",
+      "elem": "string"
     },
     "category": {
       "nullable": true,
@@ -744,7 +752,8 @@
     "roleIdsThatCanBeUsedThisEmojiAsReaction": {
       "nullable": false,
       "optional": false,
-      "type": "array"
+      "type": "array",
+      "elem": "string"
     },
     "url": {
       "nullable": false,
@@ -756,7 +765,8 @@
     "aliases": {
       "nullable": false,
       "optional": false,
-      "type": "array"
+      "type": "array",
+      "elem": "string"
     },
     "category": {
       "nullable": true,
@@ -781,7 +791,8 @@
     "roleIdsThatCanBeUsedThisEmojiAsReaction": {
       "nullable": false,
       "optional": true,
-      "type": "array"
+      "type": "array",
+      "elem": "string"
     },
     "url": {
       "nullable": false,
@@ -1024,12 +1035,14 @@
     "fileIds": {
       "nullable": false,
       "optional": true,
-      "type": "array"
+      "type": "array",
+      "elem": "string"
     },
     "files": {
       "nullable": false,
       "optional": true,
-      "type": "array"
+      "type": "array",
+      "elem": "object"
     },
     "id": {
       "nullable": false,
@@ -1054,7 +1067,8 @@
     "tags": {
       "nullable": false,
       "optional": true,
-      "type": "array"
+      "type": "array",
+      "elem": "string"
     },
     "title": {
       "nullable": false,
@@ -1160,7 +1174,8 @@
     "achievements": {
       "nullable": false,
       "optional": false,
-      "type": "array"
+      "type": "array",
+      "elem": "object"
     },
     "alwaysMarkNsfw": {
       "nullable": false,
@@ -1200,7 +1215,8 @@
     "emailNotificationTypes": {
       "nullable": false,
       "optional": false,
-      "type": "array"
+      "type": "array",
+      "elem": "string"
     },
     "emailVerified": {
       "nullable": true,
@@ -1215,7 +1231,8 @@
     "hardMutedWords": {
       "nullable": false,
       "optional": false,
-      "type": "array"
+      "type": "array",
+      "elem": "array"
     },
     "hasPendingReceivedFollowRequest": {
       "nullable": false,
@@ -1295,12 +1312,14 @@
     "mutedInstances": {
       "nullable": false,
       "optional": false,
-      "type": "array"
+      "type": "array",
+      "elem": "string"
     },
     "mutedWords": {
       "nullable": false,
       "optional": false,
-      "type": "array"
+      "type": "array",
+      "elem": "array"
     },
     "noCrawle": {
       "nullable": false,
@@ -1335,7 +1354,8 @@
     "securityKeysList": {
       "nullable": false,
       "optional": true,
-      "type": "object"
+      "type": "array",
+      "elem": "object"
     },
     "twoFactorBackupCodesStock": {
       "nullable": false,
@@ -1350,7 +1370,8 @@
     "unreadAnnouncements": {
       "nullable": false,
       "optional": false,
-      "type": "array"
+      "type": "array",
+      "elem": "object"
     },
     "unreadNotificationsCount": {
       "nullable": false,
@@ -1429,12 +1450,14 @@
     "fileIds": {
       "nullable": false,
       "optional": true,
-      "type": "array"
+      "type": "array",
+      "elem": "string"
     },
     "files": {
       "nullable": false,
       "optional": true,
-      "type": "array"
+      "type": "array",
+      "elem": "object"
     },
     "hasPoll": {
       "nullable": false,
@@ -1459,7 +1482,8 @@
     "mentions": {
       "nullable": false,
       "optional": true,
-      "type": "array"
+      "type": "array",
+      "elem": "string"
     },
     "myReaction": {
       "nullable": true,
@@ -1479,7 +1503,8 @@
     "reactionAndUserPairCache": {
       "nullable": false,
       "optional": true,
-      "type": "array"
+      "type": "array",
+      "elem": "string"
     },
     "reactionCount": {
       "nullable": false,
@@ -1529,7 +1554,8 @@
     "tags": {
       "nullable": false,
       "optional": true,
-      "type": "array"
+      "type": "array",
+      "elem": "string"
     },
     "text": {
       "nullable": true,
@@ -1564,7 +1590,8 @@
     "visibleUserIds": {
       "nullable": false,
       "optional": true,
-      "type": "array"
+      "type": "array",
+      "elem": "string"
     }
   },
   "NoteFavorite": {
@@ -1620,12 +1647,14 @@
     "attachedFiles": {
       "nullable": false,
       "optional": false,
-      "type": "array"
+      "type": "array",
+      "elem": "object"
     },
     "content": {
       "nullable": false,
       "optional": false,
-      "type": "array"
+      "type": "array",
+      "elem": "object"
     },
     "createdAt": {
       "nullable": false,
@@ -1705,7 +1734,8 @@
     "variables": {
       "nullable": false,
       "optional": false,
-      "type": "array"
+      "type": "array",
+      "elem": "other"
     }
   },
   "RenoteMuting": {
@@ -1828,7 +1858,8 @@
     "on": {
       "nullable": false,
       "optional": false,
-      "type": "array"
+      "type": "array",
+      "elem": "string"
     },
     "secret": {
       "nullable": false,
@@ -1850,7 +1881,8 @@
     "alsoKnownAs": {
       "nullable": true,
       "optional": false,
-      "type": "array"
+      "type": "array",
+      "elem": "string"
     },
     "bannerBlurhash": {
       "nullable": true,
@@ -1890,7 +1922,8 @@
     "fields": {
       "nullable": false,
       "optional": false,
-      "type": "object"
+      "type": "array",
+      "elem": "object"
     },
     "followedMessage": {
       "nullable": true,
@@ -2015,12 +2048,14 @@
     "pinnedNoteIds": {
       "nullable": false,
       "optional": false,
-      "type": "array"
+      "type": "array",
+      "elem": "string"
     },
     "pinnedNotes": {
       "nullable": false,
       "optional": false,
-      "type": "array"
+      "type": "array",
+      "elem": "object"
     },
     "pinnedPage": {
       "nullable": true,
@@ -2040,7 +2075,8 @@
     "roles": {
       "nullable": false,
       "optional": false,
-      "type": "array"
+      "type": "array",
+      "elem": "object"
     },
     "securityKeys": {
       "nullable": false,
@@ -2075,7 +2111,8 @@
     "verifiedLinks": {
       "nullable": false,
       "optional": false,
-      "type": "array"
+      "type": "array",
+      "elem": "string"
     },
     "withReplies": {
       "nullable": false,
@@ -2107,7 +2144,8 @@
     "userIds": {
       "nullable": false,
       "optional": true,
-      "type": "array"
+      "type": "array",
+      "elem": "string"
     }
   },
   "UserLite": {
@@ -2119,7 +2157,8 @@
     "avatarDecorations": {
       "nullable": false,
       "optional": false,
-      "type": "object"
+      "type": "array",
+      "elem": "object"
     },
     "avatarUrl": {
       "nullable": false,
@@ -2129,7 +2168,8 @@
     "badgeRoles": {
       "nullable": true,
       "optional": true,
-      "type": "object"
+      "type": "array",
+      "elem": "object"
     },
     "emojis": {
       "nullable": false,
@@ -2221,7 +2261,8 @@
     "on": {
       "nullable": false,
       "optional": false,
-      "type": "array"
+      "type": "array",
+      "elem": "string"
     },
     "secret": {
       "nullable": false,


### PR DESCRIPTION
## Summary

shape drift gate が **array の要素型を区別**できるようにする(#1298)。従来は coarse な `type:"array"` のみで、`string[]` と `{id,name}[]` の取り違え(例: `EmojiDetailedAdmin.roleIdsThatCanBeUsedThisEmojiAsReaction`、#1296 調査で発覚)を検出できなかった。production code 変更なし(gate 基盤の強化)。

## 主な変更点
- **`FieldShape.Elem`**(array 要素型)を追加。golden parser を多行 array 対応に修正し、array は要素型を `Elem` に記録。
- **parser bug fix**: 最後の field の buf に schema 閉じ行 `};` が混入し、多行 `{...}[]` の末尾 `[]` 判定が後続 `}` で崩れて **object と誤型付け**されていた(`ChatMessage.reactions` が該当)。schema 閉じ行を buf に入れないよう修正 → `array` + `elem:object` に矯正。
- **`ValidateValue`**: golden が array かつ `Elem` ありなら、runtime の非空 array の要素型を `Elem` と突合(空 array は判定不能で skip)。`json.RawMessage`/`[]byte` の生 JSON 列は byte 走査で先頭 `'['` を number と誤読するため、一度 decode してから要素型を見る。
- golden snapshot 再生成(array field に `elem` 付与)。**L0(DiffFamily)は Nullable/Optional のみ比較するため影響なし**。

## 効果
`EmojiDetailedAdmin.roleIds` 等の `string[]` vs `object[]` drift(#1296)が L3 で検出可能になる(test データが非空 array を持つ場合)。

## テスト
- `TestValidateValue_ArrayElem` で element-mismatch / 一致 / raw JSON decode / 空 array skip / `other` skip を網羅。`TestParseSchema` に多行 object-array ケース追加。
- `entitycompat` 94.1%(gate 90% 超)、全 L3 配線 package(chat/notes/pages/admin 他)で element check の regression 無し、race + atomic、`make shapecheck` green、build / vet / fmt clean。

## Closes
Closes #1298

🤖 Generated with [Claude Code](https://claude.com/claude-code)