### PR TITLE
fix(admin): v2/admin/emoji/list の roleIds を {id,name}[] に解決

### DIFF
--- a/internal/api/admin/drive_emoji_test.go
+++ b/internal/api/admin/drive_emoji_test.go
@@ -8,8 +8,10 @@ import (
 	"testing"
 	"time"
 
+	"github.com/lib/pq"
 	apiadmin "github.com/shiroha-a/mk/internal/api/admin"
 	"github.com/shiroha-a/mk/internal/api/apierr"
+	"github.com/shiroha-a/mk/internal/entitycompat/shapetest"
 	"github.com/shiroha-a/mk/internal/model"
 	"github.com/shiroha-a/mk/internal/queue"
 	"github.com/shiroha-a/mk/internal/testutil"
@@ -664,6 +666,40 @@ func TestEmojiListV2_Basic(t *testing.T) {
 		_, hasPublicURL := em["publicUrl"]
 		assert.True(t, hasPublicURL, "v2 emoji should have publicUrl field")
 	}
+}
+
+// TestEmojiListV2_RoleObjectsAndShape は v2/admin/emoji/list の
+// roleIdsThatCanBeUsedThisEmojiAsReaction が golden EmojiDetailedAdmin と同じ
+// {id, name} object 配列で返ること、未知 role が省かれることを検証する。
+// #1300 (gate の array element shape 検出 #1298 に依存)。
+func TestEmojiListV2_RoleObjectsAndShape(t *testing.T) {
+	h, _, _, roleRepo := newTestHandler(t)
+	require.NoError(t, roleRepo.Create(&model.Role{ID: "role1", Name: "Cool"}))
+	repo := testutil.NewMockEmojiRepository()
+	require.NoError(t, repo.Create(&model.Emoji{
+		ID: "e1", Name: "smile",
+		PublicURL: "https://example.com/s.png", OriginalURL: "https://example.com/s-orig.png",
+		Aliases:                                 pq.StringArray{"happy"},
+		RoleIDsThatCanBeUsedThisEmojiAsReaction: pq.StringArray{"role1", "ghost"},
+	}))
+	h.SetEmojiRepo(repo)
+
+	rec := doPost(h.EmojiListV2, `{}`, adminUser)
+	require.Equal(t, http.StatusOK, rec.Code)
+	var resp map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+	emojis := resp["emojis"].([]any)
+	require.Len(t, emojis, 1)
+	em := emojis[0].(map[string]any)
+
+	// roleIds は {id, name} の object 配列。未知 role "ghost" は省かれる。
+	roles := em["roleIdsThatCanBeUsedThisEmojiAsReaction"].([]any)
+	require.Len(t, roles, 1)
+	r0 := roles[0].(map[string]any)
+	assert.Equal(t, "role1", r0["id"])
+	assert.Equal(t, "Cool", r0["name"])
+
+	shapetest.Assert(t, "EmojiDetailedAdmin", em) // L3 (#1300)
 }
 
 func TestEmojiListV2_NilRepo(t *testing.T) {

--- a/internal/api/admin/handler.go
+++ b/internal/api/admin/handler.go
@@ -1933,7 +1933,7 @@ func (h *Handler) EmojiListV2(c echo.Context) error {
 	}
 	if h.emojiRepo == nil {
 		return c.JSON(http.StatusOK, emojiListV2Response{
-			Emojis:   []*model.Emoji{},
+			Emojis:   []map[string]any{},
 			Count:    0,
 			AllCount: 0,
 			AllPages: 0,
@@ -1993,9 +1993,15 @@ func (h *Handler) EmojiListV2(c echo.Context) error {
 		allPages = int((allCount + int64(limit) - 1) / int64(limit))
 	}
 
+	roleNames := h.emojiRoleNameMap()
+	packed := make([]map[string]any, 0, len(emojis))
+	for _, e := range emojis {
+		packed = append(packed, packEmojiDetailedAdmin(e, roleNames))
+	}
+
 	return c.JSON(http.StatusOK, emojiListV2Response{
-		Emojis:   emojis,
-		Count:    len(emojis),
+		Emojis:   packed,
+		Count:    len(packed),
 		AllCount: allCount,
 		AllPages: allPages,
 	})
@@ -2024,10 +2030,64 @@ type emojiV2QueryReq struct {
 }
 
 type emojiListV2Response struct {
-	Emojis   []*model.Emoji `json:"emojis"`
-	Count    int            `json:"count"`
-	AllCount int64          `json:"allCount"`
-	AllPages int            `json:"allPages"`
+	Emojis   []map[string]any `json:"emojis"`
+	Count    int              `json:"count"`
+	AllCount int64            `json:"allCount"`
+	AllPages int              `json:"allPages"`
+}
+
+// emojiRoleNameMap resolves all role ids to their names once, so the v2 emoji
+// packer can embed {id, name} for roleIdsThatCanBeUsedThisEmojiAsReaction
+// without an N+1 lookup per emoji (#1300)。roleService 未配線 / 取得失敗時は
+// 空 map を返し、未知 role 同様 roleIds から省かれる。
+func (h *Handler) emojiRoleNameMap() map[string]string {
+	out := map[string]string{}
+	if h.roleService == nil {
+		return out
+	}
+	roles, err := h.roleService.List()
+	if err != nil {
+		return out
+	}
+	for _, r := range roles {
+		out[r.ID] = r.Name
+	}
+	return out
+}
+
+// packEmojiDetailedAdmin builds the golden EmojiDetailedAdmin shape for the v2
+// admin emoji list. upstream packDetailedAdmin と同じく roleIds を {id, name}
+// に解決する (golden は object array、生の string[] ではない)。未知 role は
+// 省く (#1300)。scalar field は model.Emoji の json tag と一致する。
+func packEmojiDetailedAdmin(e *model.Emoji, roleNames map[string]string) map[string]any {
+	roles := make([]map[string]any, 0, len(e.RoleIDsThatCanBeUsedThisEmojiAsReaction))
+	for _, rid := range e.RoleIDsThatCanBeUsedThisEmojiAsReaction {
+		if name, ok := roleNames[rid]; ok {
+			roles = append(roles, map[string]any{"id": rid, "name": name})
+		}
+	}
+	// golden aliases は string[] 必須 (non-null)。nil pq.StringArray は null に
+	// なるため [] へ coalesce する。
+	aliases := []string(e.Aliases)
+	if aliases == nil {
+		aliases = []string{}
+	}
+	return map[string]any{
+		"id":          e.ID,
+		"updatedAt":   e.UpdatedAt,
+		"name":        e.Name,
+		"host":        e.Host,
+		"publicUrl":   e.PublicURL,
+		"originalUrl": e.OriginalURL,
+		"uri":         e.URI,
+		"type":        e.Type,
+		"aliases":     aliases,
+		"category":    e.Category,
+		"license":     e.License,
+		"localOnly":   e.LocalOnly,
+		"isSensitive": e.IsSensitive,
+		"roleIdsThatCanBeUsedThisEmojiAsReaction": roles,
+	}
 }
 
 // --- Abuse Report endpoints ---

--- a/internal/entitycompat/runtime.go
+++ b/internal/entitycompat/runtime.go
@@ -37,6 +37,7 @@ func L2FlatSchemaNames() []string {
 		"Muting", "RenoteMuting", "Blocking", "RoleLite",
 		"EmojiSimple", "NoteFavorite", "ChatMessage", "Ad",
 		"SystemWebhook", "Achievement", "AbuseReportNotificationRecipient",
+		"EmojiDetailedAdmin",
 	}
 }
 

--- a/internal/entitycompat/testdata/golden_schemas.json
+++ b/internal/entitycompat/testdata/golden_schemas.json
@@ -761,6 +761,80 @@
       "type": "string"
     }
   },
+  "EmojiDetailedAdmin": {
+    "aliases": {
+      "nullable": false,
+      "optional": false,
+      "type": "array",
+      "elem": "string"
+    },
+    "category": {
+      "nullable": true,
+      "optional": false,
+      "type": "string"
+    },
+    "host": {
+      "nullable": true,
+      "optional": false,
+      "type": "string"
+    },
+    "id": {
+      "nullable": false,
+      "optional": false,
+      "type": "string"
+    },
+    "isSensitive": {
+      "nullable": false,
+      "optional": false,
+      "type": "boolean"
+    },
+    "license": {
+      "nullable": true,
+      "optional": false,
+      "type": "string"
+    },
+    "localOnly": {
+      "nullable": false,
+      "optional": false,
+      "type": "boolean"
+    },
+    "name": {
+      "nullable": false,
+      "optional": false,
+      "type": "string"
+    },
+    "originalUrl": {
+      "nullable": false,
+      "optional": false,
+      "type": "string"
+    },
+    "publicUrl": {
+      "nullable": false,
+      "optional": false,
+      "type": "string"
+    },
+    "roleIdsThatCanBeUsedThisEmojiAsReaction": {
+      "nullable": false,
+      "optional": false,
+      "type": "array",
+      "elem": "object"
+    },
+    "type": {
+      "nullable": true,
+      "optional": false,
+      "type": "string"
+    },
+    "updatedAt": {
+      "nullable": true,
+      "optional": false,
+      "type": "string"
+    },
+    "uri": {
+      "nullable": true,
+      "optional": false,
+      "type": "string"
+    }
+  },
   "EmojiSimple": {
     "aliases": {
       "nullable": false,


### PR DESCRIPTION
## Summary

gate の array element shape 検出(#1298)で gate-coverable になった `EmojiDetailedAdmin` の shape drift を修正する(#1300)。

## 検出 → 修正した drift
golden `EmojiDetailedAdmin`(`v2/admin/emoji/list` の item)の `roleIdsThatCanBeUsedThisEmojiAsReaction` は **`{id, name}[]`** だが、`EmojiListV2` は `[]*model.Emoji` を直接 JSON 化しており当該フィールドが role id の生 **`string[]`** になっていた。upstream の `emojiEntityService.packDetailedAdminMany` は role を解決して `{id, name}` で返す。scalar field(id/updatedAt/name/host/publicUrl/originalUrl/uri/type/aliases/category/license/localOnly/isSensitive)は完全一致。

## 主な変更点
- `EmojiListV2` の item を **`packEmojiDetailedAdmin`** で packer 化。`roleService.List()` で role id→name を**一度だけ**構築(N+1 回避)し `roleIds` を `[{id, name}]` に解決。未知 role は省く(upstream 同様)。
- `emojiListV2Response.Emojis` を `[]*model.Emoji` → `[]map[string]any` に変更。
- golden snapshot に `EmojiDetailedAdmin` を追加、非空 roleIds を持つ emoji で element shape を検証する L3 test を追加(`TestEmojiListV2_RoleObjectsAndShape`)。

## テスト
- 既存 `EmojiListV2` test 全 pass(packer 化後も publicUrl 等の field 維持)。新 test で `{id,name}` 解決 + 未知 role 除外 + L3 shape を検証。
- `admin` 86.9%(例外 gate 80% 超)、`entitycompat` 含め race + atomic green、`make shapecheck` green、build / vet / fmt clean。

## Closes
Closes #1300

🤖 Generated with [Claude Code](https://claude.com/claude-code)