### PR TITLE
test(api): L3 を admin/queue/queue-stats (QueueCount) へ拡大

### DIFF
--- a/internal/api/admin/queue_test.go
+++ b/internal/api/admin/queue_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	apiadmin "github.com/shiroha-a/mk/internal/api/admin"
+	"github.com/shiroha-a/mk/internal/entitycompat/shapetest"
 	"github.com/shiroha-a/mk/internal/queue"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -329,6 +330,7 @@ func TestQueueQueueStats_WithInspector(t *testing.T) {
 	assert.EqualValues(t, 3, counts["waiting"])
 	// scheduled(0) + retry(1) がdelayedに集約される。
 	assert.EqualValues(t, 1, counts["delayed"])
+	shapetest.Assert(t, "QueueCount", counts) // L3 (#1302)
 
 	// metrics shape: data 配列と count が driver から伝播。
 	metrics, ok := got["metrics"].(map[string]any)

--- a/internal/entitycompat/runtime.go
+++ b/internal/entitycompat/runtime.go
@@ -37,7 +37,7 @@ func L2FlatSchemaNames() []string {
 		"Muting", "RenoteMuting", "Blocking", "RoleLite",
 		"EmojiSimple", "NoteFavorite", "ChatMessage", "Ad",
 		"SystemWebhook", "Achievement", "AbuseReportNotificationRecipient",
-		"EmojiDetailedAdmin",
+		"EmojiDetailedAdmin", "QueueCount",
 	}
 }
 

--- a/internal/entitycompat/testdata/golden_schemas.json
+++ b/internal/entitycompat/testdata/golden_schemas.json
@@ -1812,6 +1812,33 @@
       "elem": "other"
     }
   },
+  "QueueCount": {
+    "active": {
+      "nullable": false,
+      "optional": false,
+      "type": "number"
+    },
+    "completed": {
+      "nullable": false,
+      "optional": false,
+      "type": "number"
+    },
+    "delayed": {
+      "nullable": false,
+      "optional": false,
+      "type": "number"
+    },
+    "failed": {
+      "nullable": false,
+      "optional": false,
+      "type": "number"
+    },
+    "waiting": {
+      "nullable": false,
+      "optional": false,
+      "type": "number"
+    }
+  },
   "RenoteMuting": {
     "createdAt": {
       "nullable": false,


### PR DESCRIPTION
## Summary

L3 を vanilla Misskey の **QueueCount**(admin/queue の per-queue counts)へ拡大。**drift 無し・production 変更ゼロ**。

## 調査結果
- `admin/queue/queue-stats` の応答内 `counts`(`{active, delayed, waiting, completed, failed}` 全 number)が golden `QueueCount`(`{waiting, active, completed, failed, delayed}`)と一致。
- `counts` サブオブジェクトに `shapetest.Assert(t, "QueueCount", counts)` を配線。

## 別 issue 候補(本 PR 対象外)
- **QueueJob**(`admin/queue/show-job` の `packTaskSummary`)は golden に対し drift 多数: `progress`=number(golden object)、`returnValue`=null(golden object)、`failedReason` 条件付き欠落(golden required)、`timestamp` 等の型。Bull 互換 shim と golden の乖離が大きく別途要調査。

## テスト
- `admin` 86.9%(例外 gate 80% 超)、`entitycompat` 含め race + atomic green、`make shapecheck` green、build / vet / fmt clean。

## Closes
Closes #1302

🤖 Generated with [Claude Code](https://claude.com/claude-code)