### PR TITLE
fix(admin): queue/show-job の応答を golden QueueJob 準拠に修正

### DIFF
--- a/internal/api/admin/queue.go
+++ b/internal/api/admin/queue.go
@@ -570,24 +570,36 @@ func packTaskSummary(t *QueueTaskSummary) map[string]any {
 		return nil
 	}
 	isFailed := t.LastErr != ""
+	// golden QueueJob.data は Record (object) 必須。空 payload を null で返すと
+	// frontend の job detail が型エラーになるため {} に coalesce する (#1304)。
+	data := rawJSONOrString(t.Payload)
+	if data == nil {
+		data = map[string]any{}
+	}
 	// asynqはBullと違いEnqueuedAtを保持しない (TaskInfoに該当field無し)。
 	// frontend の MkTl / MkTime は 0 を「たった今」として扱うので害はない。
 	pack := map[string]any{
 		// Bull 互換 field (frontend 必須)
-		"id":           t.ID,
-		"name":         t.Type,
-		"timestamp":    formatUnixMillisOrZero(t.NextProcessAt),
-		"processedAt":  formatUnixMillisOrZero(t.LastFailedAt),
-		"processedOn":  formatUnixMillisOrZero(t.LastFailedAt),
-		"finishedOn":   formatUnixMillisOrZero(t.CompletedAt),
-		"progress":     0,
+		"id":          t.ID,
+		"name":        t.Type,
+		"timestamp":   formatUnixMillisOrZero(t.NextProcessAt),
+		"processedAt": formatUnixMillisOrZero(t.LastFailedAt),
+		"processedOn": formatUnixMillisOrZero(t.LastFailedAt),
+		"finishedOn":  formatUnixMillisOrZero(t.CompletedAt),
+		// golden QueueJob は progress / returnValue を Record (object) 必須、
+		// failedReason を string 必須とする。Bull の job は failure 時のみ理由を
+		// 持つが、schema 上は常に present (無 failure 時は空文字) なので常に出す。
+		// progress / returnValue は asynq に相当概念が無いため空 object で埋める
+		// (旧実装は number 0 / null で golden と乖離していた、#1304)。
+		"progress":     map[string]any{},
 		"attempts":     t.Retried,
 		"attemptsMade": t.Retried,
 		"isFailed":     isFailed,
 		"delay":        0,
-		"returnValue":  nil,
+		"returnValue":  map[string]any{},
+		"failedReason": t.LastErr,
 		"stacktrace":   stacktraceFrom(t.LastErr),
-		"data":         rawJSONOrString(t.Payload),
+		"data":         data,
 		"opts": map[string]any{
 			"attempts": t.MaxRetry,
 			"delay":    0,
@@ -603,7 +615,6 @@ func packTaskSummary(t *QueueTaskSummary) map[string]any {
 	}
 	if t.LastErr != "" {
 		pack["lastErr"] = t.LastErr
-		pack["failedReason"] = t.LastErr
 	}
 	if !t.LastFailedAt.IsZero() {
 		pack["lastFailedAt"] = t.LastFailedAt.UTC().Format(time.RFC3339Nano)

--- a/internal/api/admin/queue_test.go
+++ b/internal/api/admin/queue_test.go
@@ -193,6 +193,13 @@ func TestQueueShowJob_Found(t *testing.T) {
 	var got map[string]any
 	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &got))
 	assert.Equal(t, "tid1", got["id"])
+	// golden QueueJob: progress/returnValue は object、failedReason は string で
+	// 常に present (#1304)。
+	shapetest.Assert(t, "QueueJob", got) // L3 (#1304)
+	assert.IsType(t, map[string]any{}, got["progress"])
+	assert.IsType(t, map[string]any{}, got["returnValue"])
+	_, hasFailedReason := got["failedReason"]
+	assert.True(t, hasFailedReason, "failedReason must always be present (golden required)")
 }
 
 func TestQueueShowJob_NotFoundWithInspector(t *testing.T) {

--- a/internal/entitycompat/runtime.go
+++ b/internal/entitycompat/runtime.go
@@ -37,7 +37,7 @@ func L2FlatSchemaNames() []string {
 		"Muting", "RenoteMuting", "Blocking", "RoleLite",
 		"EmojiSimple", "NoteFavorite", "ChatMessage", "Ad",
 		"SystemWebhook", "Achievement", "AbuseReportNotificationRecipient",
-		"EmojiDetailedAdmin", "QueueCount",
+		"EmojiDetailedAdmin", "QueueCount", "QueueJob",
 	}
 }
 

--- a/internal/entitycompat/testdata/golden_schemas.json
+++ b/internal/entitycompat/testdata/golden_schemas.json
@@ -1839,6 +1839,84 @@
       "type": "number"
     }
   },
+  "QueueJob": {
+    "attempts": {
+      "nullable": false,
+      "optional": false,
+      "type": "number"
+    },
+    "data": {
+      "nullable": false,
+      "optional": false,
+      "type": "other"
+    },
+    "delay": {
+      "nullable": false,
+      "optional": false,
+      "type": "number"
+    },
+    "failedReason": {
+      "nullable": false,
+      "optional": false,
+      "type": "string"
+    },
+    "finishedOn": {
+      "nullable": false,
+      "optional": true,
+      "type": "number"
+    },
+    "id": {
+      "nullable": false,
+      "optional": false,
+      "type": "string"
+    },
+    "isFailed": {
+      "nullable": false,
+      "optional": false,
+      "type": "boolean"
+    },
+    "name": {
+      "nullable": false,
+      "optional": false,
+      "type": "string"
+    },
+    "opts": {
+      "nullable": false,
+      "optional": false,
+      "type": "other"
+    },
+    "processedBy": {
+      "nullable": false,
+      "optional": true,
+      "type": "string"
+    },
+    "processedOn": {
+      "nullable": false,
+      "optional": true,
+      "type": "number"
+    },
+    "progress": {
+      "nullable": false,
+      "optional": false,
+      "type": "other"
+    },
+    "returnValue": {
+      "nullable": false,
+      "optional": false,
+      "type": "other"
+    },
+    "stacktrace": {
+      "nullable": false,
+      "optional": false,
+      "type": "array",
+      "elem": "string"
+    },
+    "timestamp": {
+      "nullable": false,
+      "optional": false,
+      "type": "number"
+    }
+  },
   "RenoteMuting": {
     "createdAt": {
       "nullable": false,


### PR DESCRIPTION
## Summary

`admin/queue/show-job` 等の `packTaskSummary` が golden `QueueJob` の必須 field を満たしていなかった shape drift を修正する(#1304)。

## 検出 → 修正した drift
golden `QueueJob` に対し:
- **`progress`**: number `0` → Record(object)。空 object `{}` に。
- **`returnValue`**: `null` → Record(object, non-null)。空 object `{}` に。
- **`failedReason`**: failure 時のみ present → golden は string 必須。常に present(無 failure 時は `""`)に。
- **`data`**: 空 payload で `null` → Record(object, non-null)。`{}` に coalesce。

`timestamp`/`processedOn`/`finishedOn`(number)/`stacktrace`(string[])/`attempts`/`delay`/`opts`/`isFailed` は既に golden 準拠。asynq-native の extra field(`queue`/`state`/`payload`/`retried` 等)は admin tool 互換のため据え置き(Info 扱い)。

## gate との関係
golden `QueueJob` の `data`/`opts`/`progress`/`returnValue` は `Record<string, never>` で coarseTS は "other" 型 → L3 の型検査はされないが、**`returnValue` null / `data` null は nullable 検査で、`failedReason` 欠落は required 検査で gate が検出**する。`progress`=number は "other" で gate 盲点のため test で明示 assert して補完。

## テスト
- `admin` 86.9%(例外 gate 80% 超)、`entitycompat` 含め race + atomic green、`make shapecheck` green、build / vet / fmt clean。既存 queue test 全 pass(progress/returnValue/failedReason への依存なし)。

## Closes
Closes #1304

🤖 Generated with [Claude Code](https://claude.com/claude-code)