### PR TITLE
fix(meta): /api/meta (lite) の field partition を golden MetaLite 準拠に修正

### DIFF
--- a/internal/api/meta/handler.go
+++ b/internal/api/meta/handler.go
@@ -69,7 +69,7 @@ func (h *Handler) Meta(c echo.Context) error {
 		"shortName":              m.ShortName,
 		"uri":                    h.config.URL,
 		"description":            m.Description,
-		"langs":                  m.Langs,
+		"langs":                  strArrayOrEmpty(m.Langs),
 		"disableRegistration":    m.DisableRegistration,
 		"emailRequiredForSignup": m.EmailRequiredForSignup,
 		"enableHcaptcha":         m.EnableHcaptcha,
@@ -86,7 +86,7 @@ func (h *Handler) Meta(c echo.Context) error {
 		"cacheRemoteFiles":       m.CacheRemoteFiles,
 		"enableServiceWorker":    m.EnableServiceWorker,
 		"swPublickey":            m.SwPublicKey,
-		"serverRules":            m.ServerRules,
+		"serverRules":            strArrayOrEmpty(m.ServerRules),
 		"maxNoteTextLength":      3000,
 
 		// フロントエンド互換性フィールド (Phase 4.5c)
@@ -150,19 +150,24 @@ func (h *Handler) Meta(c echo.Context) error {
 	// NoteSearchableScope 関数の doc 参照。
 	resp["noteSearchableScope"] = NoteSearchableScope(h.config.FulltextSearch, h.config.Meilisearch)
 
-	// detail=false: TS MetaLite互換。管理者/内部向けフィールド (features, policies,
-	// clientOptions, proxyAccountName, sentryForFrontend, noteSearchableScope,
-	// providesTarball, singleUserMode) を省く。登録/captcha/ads等は含める。
+	// detail=false: TS MetaLite 互換。omit には golden MetaLite に**無い** field
+	// (= MetaDetailedOnly / mk-go 内部 field) のみを入れる。golden MetaLite は
+	// policies / clientOptions / sentryForFrontend / noteSearchableScope /
+	// providesTarball を必須とし、Misskey の MetaEntityService.pack() (lite) も
+	// 返すため、lite から落とすと client が非 null cast で落ちる (#1306 で
+	// 旧 omit がこれらを誤って除外していたのを修正)。features / cacheRemoteFiles /
+	// cacheRemoteSensitiveFiles / requireSetup / proxyAccountName は
+	// MetaDetailedOnly なので lite から除外する。
 	if !detail {
 		omit := map[string]struct{}{
-			"features":            {},
-			"policies":            {},
-			"clientOptions":       {},
-			"proxyAccountName":    {},
-			"sentryForFrontend":   {},
-			"noteSearchableScope": {},
-			"providesTarball":     {},
-			"singleUserMode":      {},
+			"features":                  {},
+			"cacheRemoteFiles":          {},
+			"cacheRemoteSensitiveFiles": {},
+			"requireSetup":              {},
+			"proxyAccountName":          {},
+			// singleUserMode は golden の MetaLite/MetaDetailedOnly どちらにも無い
+			// mk-go 内部 field。lite では従来どおり省く。
+			"singleUserMode": {},
 		}
 		lite := make(map[string]any, len(resp))
 		for k, v := range resp {
@@ -182,6 +187,17 @@ func (h *Handler) Ping(c echo.Context) error {
 	return c.JSON(http.StatusOK, map[string]any{
 		"pong": true,
 	})
+}
+
+// strArrayOrEmpty coalesces a nil string slice to a non-nil empty slice so the
+// JSON encoder emits `[]` instead of `null`. golden MetaLite の langs /
+// serverRules は string[] 必須 (non-null) で、空でも null だと client が
+// 非 null cast で落ちる (#1306。channels pinnedNoteIds #1283 と同種)。
+func strArrayOrEmpty(a []string) []string {
+	if a == nil {
+		return []string{}
+	}
+	return a
 }
 
 // mascotURL applies the legacy fallback for the mascot. Misskey フロントエンドは

--- a/internal/api/meta/handler_test.go
+++ b/internal/api/meta/handler_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/labstack/echo/v4"
 	"github.com/shiroha-a/mk/internal/config"
+	"github.com/shiroha-a/mk/internal/entitycompat/shapetest"
 	"github.com/shiroha-a/mk/internal/model"
 	"github.com/shiroha-a/mk/internal/testutil"
 	"github.com/stretchr/testify/assert"
@@ -62,6 +63,38 @@ func TestMeta(t *testing.T) {
 	features, ok := resp["features"].(map[string]any)
 	require.True(t, ok)
 	assert.Equal(t, true, features["miauth"])
+}
+
+// TestMeta_LiteShape は detail=false の応答が golden MetaLite 準拠であることを
+// 検証する。旧 omit は MetaLite 必須 field (policies/clientOptions/
+// sentryForFrontend/noteSearchableScope/providesTarball) を誤って lite から
+// 落とし、逆に MetaDetailedOnly (cacheRemoteFiles 等) を leak していた (#1306)。
+func TestMeta_LiteShape(t *testing.T) {
+	h, metaRepo := newTestHandler()
+	name := "Test Instance"
+	metaRepo.Meta = &model.Meta{ID: "x", Name: &name}
+
+	e := echo.New()
+	req := httptest.NewRequest(http.MethodPost, "/api/meta", strings.NewReader(`{"detail":false}`))
+	req.Header.Set(echo.HeaderContentType, echo.MIMEApplicationJSON)
+	rec := httptest.NewRecorder()
+	require.NoError(t, h.Meta(e.NewContext(req, rec)))
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	var resp map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+
+	// MetaLite 必須 field が lite に含まれること。
+	for _, f := range []string{"policies", "clientOptions", "sentryForFrontend", "noteSearchableScope", "providesTarball"} {
+		_, ok := resp[f]
+		assert.Truef(t, ok, "lite must include MetaLite field %q", f)
+	}
+	// MetaDetailedOnly field が lite に leak しないこと。
+	for _, f := range []string{"features", "cacheRemoteFiles", "cacheRemoteSensitiveFiles", "requireSetup", "proxyAccountName"} {
+		_, ok := resp[f]
+		assert.Falsef(t, ok, "lite must omit MetaDetailedOnly field %q", f)
+	}
+	shapetest.Assert(t, "MetaLite", resp) // L3 (#1306)
 }
 
 func TestMeta_NoMeta(t *testing.T) {
@@ -361,11 +394,15 @@ func TestMeta_DetailFalse(t *testing.T) {
 	assert.Equal(t, "Instance", resp["name"])
 	assert.Equal(t, true, resp["enableHcaptcha"])
 	assert.Equal(t, config.MisskeyVersion, resp["version"])
-	// 省かれるフィールド
+	// MetaLite に属する field は lite でも含まれる (#1306 で修正: 旧 omit は
+	// これらを誤って省いていた)。
+	assert.NotNil(t, resp["policies"])
+	assert.NotNil(t, resp["clientOptions"])
+	assert.Equal(t, "global", resp["noteSearchableScope"])
+	// MetaDetailedOnly は lite から省かれる。
 	assert.Nil(t, resp["features"])
-	assert.Nil(t, resp["policies"])
-	assert.Nil(t, resp["clientOptions"])
-	assert.Nil(t, resp["noteSearchableScope"])
+	assert.Nil(t, resp["cacheRemoteFiles"])
+	assert.Nil(t, resp["requireSetup"])
 }
 
 // TestMeta_FeaturesTimelineFlags verifies that features.localTimeline and

--- a/internal/entitycompat/runtime.go
+++ b/internal/entitycompat/runtime.go
@@ -37,7 +37,7 @@ func L2FlatSchemaNames() []string {
 		"Muting", "RenoteMuting", "Blocking", "RoleLite",
 		"EmojiSimple", "NoteFavorite", "ChatMessage", "Ad",
 		"SystemWebhook", "Achievement", "AbuseReportNotificationRecipient",
-		"EmojiDetailedAdmin", "QueueCount", "QueueJob",
+		"EmojiDetailedAdmin", "QueueCount", "QueueJob", "MetaLite",
 	}
 }
 

--- a/internal/entitycompat/testdata/golden_schemas.json
+++ b/internal/entitycompat/testdata/golden_schemas.json
@@ -1458,6 +1458,286 @@
       "type": "boolean"
     }
   },
+  "MetaLite": {
+    "ads": {
+      "nullable": false,
+      "optional": false,
+      "type": "array",
+      "elem": "object"
+    },
+    "backgroundImageUrl": {
+      "nullable": true,
+      "optional": false,
+      "type": "string"
+    },
+    "bannerUrl": {
+      "nullable": true,
+      "optional": false,
+      "type": "string"
+    },
+    "clientOptions": {
+      "nullable": false,
+      "optional": false,
+      "type": "object"
+    },
+    "defaultDarkTheme": {
+      "nullable": true,
+      "optional": false,
+      "type": "string"
+    },
+    "defaultLightTheme": {
+      "nullable": true,
+      "optional": false,
+      "type": "string"
+    },
+    "description": {
+      "nullable": true,
+      "optional": false,
+      "type": "string"
+    },
+    "disableRegistration": {
+      "nullable": false,
+      "optional": false,
+      "type": "boolean"
+    },
+    "emailRequiredForSignup": {
+      "nullable": false,
+      "optional": false,
+      "type": "boolean"
+    },
+    "enableEmail": {
+      "nullable": false,
+      "optional": false,
+      "type": "boolean"
+    },
+    "enableHcaptcha": {
+      "nullable": false,
+      "optional": false,
+      "type": "boolean"
+    },
+    "enableMcaptcha": {
+      "nullable": false,
+      "optional": false,
+      "type": "boolean"
+    },
+    "enableRecaptcha": {
+      "nullable": false,
+      "optional": false,
+      "type": "boolean"
+    },
+    "enableServiceWorker": {
+      "nullable": false,
+      "optional": false,
+      "type": "boolean"
+    },
+    "enableTestcaptcha": {
+      "nullable": false,
+      "optional": false,
+      "type": "boolean"
+    },
+    "enableTurnstile": {
+      "nullable": false,
+      "optional": false,
+      "type": "boolean"
+    },
+    "enableUrlPreview": {
+      "nullable": false,
+      "optional": false,
+      "type": "boolean"
+    },
+    "federation": {
+      "nullable": false,
+      "optional": false,
+      "type": "string"
+    },
+    "feedbackUrl": {
+      "nullable": true,
+      "optional": false,
+      "type": "string"
+    },
+    "googleAnalyticsMeasurementId": {
+      "nullable": true,
+      "optional": false,
+      "type": "string"
+    },
+    "hcaptchaSiteKey": {
+      "nullable": true,
+      "optional": false,
+      "type": "string"
+    },
+    "iconUrl": {
+      "nullable": true,
+      "optional": false,
+      "type": "string"
+    },
+    "impressumUrl": {
+      "nullable": true,
+      "optional": false,
+      "type": "string"
+    },
+    "infoImageUrl": {
+      "nullable": true,
+      "optional": false,
+      "type": "string"
+    },
+    "inquiryUrl": {
+      "nullable": true,
+      "optional": false,
+      "type": "string"
+    },
+    "langs": {
+      "nullable": false,
+      "optional": false,
+      "type": "array",
+      "elem": "string"
+    },
+    "logoImageUrl": {
+      "nullable": true,
+      "optional": false,
+      "type": "string"
+    },
+    "maintainerEmail": {
+      "nullable": true,
+      "optional": false,
+      "type": "string"
+    },
+    "maintainerName": {
+      "nullable": true,
+      "optional": false,
+      "type": "string"
+    },
+    "mascotImageUrl": {
+      "nullable": false,
+      "optional": false,
+      "type": "string"
+    },
+    "maxFileSize": {
+      "nullable": false,
+      "optional": false,
+      "type": "number"
+    },
+    "maxNoteTextLength": {
+      "nullable": false,
+      "optional": false,
+      "type": "number"
+    },
+    "mcaptchaInstanceUrl": {
+      "nullable": true,
+      "optional": false,
+      "type": "string"
+    },
+    "mcaptchaSiteKey": {
+      "nullable": true,
+      "optional": false,
+      "type": "string"
+    },
+    "mediaProxy": {
+      "nullable": false,
+      "optional": false,
+      "type": "string"
+    },
+    "name": {
+      "nullable": true,
+      "optional": false,
+      "type": "string"
+    },
+    "notFoundImageUrl": {
+      "nullable": true,
+      "optional": false,
+      "type": "string"
+    },
+    "noteSearchableScope": {
+      "nullable": false,
+      "optional": false,
+      "type": "string"
+    },
+    "notesPerOneAd": {
+      "nullable": false,
+      "optional": false,
+      "type": "number"
+    },
+    "policies": {
+      "nullable": false,
+      "optional": false,
+      "type": "object"
+    },
+    "privacyPolicyUrl": {
+      "nullable": true,
+      "optional": false,
+      "type": "string"
+    },
+    "providesTarball": {
+      "nullable": false,
+      "optional": false,
+      "type": "boolean"
+    },
+    "recaptchaSiteKey": {
+      "nullable": true,
+      "optional": false,
+      "type": "string"
+    },
+    "repositoryUrl": {
+      "nullable": true,
+      "optional": false,
+      "type": "string"
+    },
+    "sentryForFrontend": {
+      "nullable": true,
+      "optional": false,
+      "type": "object"
+    },
+    "serverErrorImageUrl": {
+      "nullable": true,
+      "optional": false,
+      "type": "string"
+    },
+    "serverRules": {
+      "nullable": false,
+      "optional": false,
+      "type": "array",
+      "elem": "string"
+    },
+    "shortName": {
+      "nullable": true,
+      "optional": false,
+      "type": "string"
+    },
+    "swPublickey": {
+      "nullable": true,
+      "optional": false,
+      "type": "string"
+    },
+    "themeColor": {
+      "nullable": true,
+      "optional": false,
+      "type": "string"
+    },
+    "tosUrl": {
+      "nullable": true,
+      "optional": false,
+      "type": "string"
+    },
+    "translatorAvailable": {
+      "nullable": false,
+      "optional": false,
+      "type": "boolean"
+    },
+    "turnstileSiteKey": {
+      "nullable": true,
+      "optional": false,
+      "type": "string"
+    },
+    "uri": {
+      "nullable": false,
+      "optional": false,
+      "type": "string"
+    },
+    "version": {
+      "nullable": false,
+      "optional": false,
+      "type": "string"
+    }
+  },
   "Muting": {
     "createdAt": {
       "nullable": false,


### PR DESCRIPTION
## Summary

`/api/meta` の lite(detail=false)応答の field partition が golden `MetaLite` と乖離していた drift を修正する(#1306)。MetaLite drift 調査の成果。

## 検出 → 修正した drift
### ① lite に欠落(MetaLite 必須なのに omit されていた)
`policies` / `clientOptions` / `sentryForFrontend` / `noteSearchableScope` / `providesTarball`
→ Misskey の `MetaEntityService.pack()`(lite)は全て返す(MetaEntityService.ts L73/112/132/135+)。client が非 null cast で参照するため drop-in クラッシュ要因。omit セットから削除して lite に含める。

### ② lite に leak(MetaDetailedOnly なのに lite に出ていた)
`cacheRemoteFiles` / `cacheRemoteSensitiveFiles` / `requireSetup`(`features`/`proxyAccountName` は既に omit 済)→ omit に追加。

### ③ null-array
`langs` / `serverRules` が nil 時に `null`(golden は string[] 必須)→ `[]` に coalesce(channels pinnedNoteIds #1283 と同種)。

## scope 外(据え置き)
どちらの golden にも無い mk-go 内部 field(`globalTimeline`/`hcaptcha`/`localTimeline`/`miauth`/`objectStorage`/`recaptcha`/`registration`/`serviceWorker`/`turnstile`)は Misskey contract 外の extension。Info 扱いで lite に残置(L3 は通る)。

## テスト
- golden snapshot に `MetaLite`(55 field)を追加、`/api/meta` lite に L3 配線(`TestMeta_LiteShape`: MetaLite 必須 present + MetaDetailedOnly 非 leak を明示 assert)。
- `TestMeta_DetailFalse` は旧(誤)挙動を guard していたため正しい partition に更新。
- `meta` 98.4% / `entitycompat` 含め race + atomic green、`make shapecheck` green、build / vet / fmt clean。

## Closes
Closes #1306

🤖 Generated with [Claude Code](https://claude.com/claude-code)