### PR TITLE
test(api): L3 を /api/meta (detail) の MetaDetailedOnly へ拡大

### DIFF
--- a/internal/api/meta/handler_test.go
+++ b/internal/api/meta/handler_test.go
@@ -63,6 +63,11 @@ func TestMeta(t *testing.T) {
 	features, ok := resp["features"].(map[string]any)
 	require.True(t, ok)
 	assert.Equal(t, true, features["miauth"])
+
+	// detail 応答は MetaLite ∪ MetaDetailedOnly (= MetaDetailed) の superset。
+	// 両 schema で検証して detail 契約全体を gate する (#1308)。
+	shapetest.Assert(t, "MetaLite", resp)         // L3 (#1306)
+	shapetest.Assert(t, "MetaDetailedOnly", resp) // L3 (#1308)
 }
 
 // TestMeta_LiteShape は detail=false の応答が golden MetaLite 準拠であることを

--- a/internal/entitycompat/runtime.go
+++ b/internal/entitycompat/runtime.go
@@ -38,6 +38,7 @@ func L2FlatSchemaNames() []string {
 		"EmojiSimple", "NoteFavorite", "ChatMessage", "Ad",
 		"SystemWebhook", "Achievement", "AbuseReportNotificationRecipient",
 		"EmojiDetailedAdmin", "QueueCount", "QueueJob", "MetaLite",
+		"MetaDetailedOnly",
 	}
 }
 

--- a/internal/entitycompat/testdata/golden_schemas.json
+++ b/internal/entitycompat/testdata/golden_schemas.json
@@ -1458,6 +1458,33 @@
       "type": "boolean"
     }
   },
+  "MetaDetailedOnly": {
+    "cacheRemoteFiles": {
+      "nullable": false,
+      "optional": false,
+      "type": "boolean"
+    },
+    "cacheRemoteSensitiveFiles": {
+      "nullable": false,
+      "optional": false,
+      "type": "boolean"
+    },
+    "features": {
+      "nullable": false,
+      "optional": true,
+      "type": "object"
+    },
+    "proxyAccountName": {
+      "nullable": true,
+      "optional": false,
+      "type": "string"
+    },
+    "requireSetup": {
+      "nullable": false,
+      "optional": false,
+      "type": "boolean"
+    }
+  },
   "MetaLite": {
     "ads": {
       "nullable": false,


### PR DESCRIPTION
## Summary

MetaLite lite 修正(#1306)の対となる **detail 応答側**を L3 で gate する(#1308)。**drift 無し・production 変更ゼロ**。

## 調査結果
golden `MetaDetailedOnly`(5 field)は mk-go の detail 応答と型一致:
- `cacheRemoteFiles`/`cacheRemoteSensitiveFiles`/`requireSetup`: boolean
- `proxyAccountName`: string|null
- `features`: object(optional)

## 主な変更点
- golden snapshot に `MetaDetailedOnly` を追加。
- `TestMeta`(detail=true default)に `shapetest.Assert` を配線。detail は `MetaLite ∪ MetaDetailedOnly`(= `MetaDetailed`)の superset なので、**MetaLite + MetaDetailedOnly の両方を assert** して `MetaDetailed` 契約全体を gate。

## テスト
- `meta` 98.4% / `entitycompat` 含め race + atomic green、`make shapecheck` green、build / vet / fmt clean。

## Closes
Closes #1308

🤖 Generated with [Claude Code](https://claude.com/claude-code)