### PR TITLE
test(api): L3 を drive/following/notes の多経路へ拡大 + Note.reactions null-object 修正

### DIFF
--- a/internal/api/drive/handler_test.go
+++ b/internal/api/drive/handler_test.go
@@ -275,6 +275,10 @@ func TestFilesShow_Success(t *testing.T) {
 	setUser(c, "u1")
 	require.NoError(t, h.FilesShow(c))
 	assert.Equal(t, http.StatusOK, rec.Code)
+
+	var resp map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+	shapetest.Assert(t, "DriveFile", resp) // L3 (#1312)
 }
 
 func TestFilesShow_InvalidParam(t *testing.T) {
@@ -347,6 +351,7 @@ func TestFilesUpdate_Success(t *testing.T) {
 	assert.Nil(t, resp["folder"])
 	assert.Nil(t, resp["userId"])
 	assert.Nil(t, resp["user"])
+	shapetest.Assert(t, "DriveFile", resp) // L3 (#1312)
 }
 
 func TestFilesUpdate_InvalidParam(t *testing.T) {
@@ -493,6 +498,10 @@ func TestFoldersCreate_Success(t *testing.T) {
 	setUser(c, "u1")
 	require.NoError(t, h.FoldersCreate(c))
 	assert.Equal(t, http.StatusOK, rec.Code)
+
+	var resp map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+	shapetest.Assert(t, "DriveFolder", resp) // L3 (#1312)
 }
 
 func TestFoldersCreate_DefaultName(t *testing.T) {
@@ -576,6 +585,7 @@ func TestFoldersShow_Success(t *testing.T) {
 	assert.EqualValues(t, 0, resp["foldersCount"])
 	assert.EqualValues(t, 0, resp["filesCount"])
 	assert.Nil(t, resp["parent"])
+	shapetest.Assert(t, "DriveFolder", resp) // L3 (#1312)
 }
 
 // detail mode: 親 folder + 子 folder + 子内の file を持つ shape の確認 (#845)。

--- a/internal/api/following/handler_test.go
+++ b/internal/api/following/handler_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/labstack/echo/v4"
 	corefollowing "github.com/shiroha-a/mk/internal/core/following"
 	coreuser "github.com/shiroha-a/mk/internal/core/user"
+	"github.com/shiroha-a/mk/internal/entitycompat/shapetest"
 	"github.com/shiroha-a/mk/internal/misc/id"
 	"github.com/shiroha-a/mk/internal/model"
 	"github.com/shiroha-a/mk/internal/server/middleware"
@@ -138,6 +139,9 @@ func TestCreate_Success(t *testing.T) {
 	var resp map[string]any
 	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
 	assert.Equal(t, "bob", resp["id"])
+	// following/create は PackUserDetailed (UserLite & UserDetailedNotMeOnly) を返す。
+	shapetest.Assert(t, "UserLite", resp)              // L3 (#1312)
+	shapetest.Assert(t, "UserDetailedNotMeOnly", resp) // L3 (#1312)
 }
 
 func TestCreate_LockedReturnsOK(t *testing.T) {
@@ -283,6 +287,11 @@ func TestDelete_Success(t *testing.T) {
 
 	rec := postJSON(h.Delete, `{"userId": "bob"}`, alice)
 	assert.Equal(t, http.StatusOK, rec.Code)
+
+	var resp map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+	shapetest.Assert(t, "UserLite", resp)              // L3 (#1312)
+	shapetest.Assert(t, "UserDetailedNotMeOnly", resp) // L3 (#1312)
 }
 
 func TestDelete_UserNotFound(t *testing.T) {

--- a/internal/api/notes/handler_test.go
+++ b/internal/api/notes/handler_test.go
@@ -66,6 +66,7 @@ func TestCreate_Success(t *testing.T) {
 	require.True(t, ok)
 	assert.Equal(t, "Hello, world!", createdNote["text"])
 	assert.Equal(t, "public", createdNote["visibility"])
+	shapetest.Assert(t, "Note", createdNote) // L3 (#1312)
 
 	// リポジトリにノートが保存されていることを確認
 	assert.Len(t, noteRepo.Notes, 1)

--- a/internal/entity/note.go
+++ b/internal/entity/note.go
@@ -402,7 +402,11 @@ func NormalizeReactionKey(key string) string {
 // TS時代のレコードとmk時代のレコードが同一キーに集約される。
 func normalizeReactionKeys(raw datatypes.JSON) datatypes.JSON {
 	if len(raw) == 0 {
-		return raw
+		// golden Note.reactions は Record (object) 必須。reactions 未設定の note
+		// (create 直後の in-memory note 等、DB default '{}' を経ていないもの) は
+		// nil datatypes.JSON が JSON null になり drift するため {} に coalesce する
+		// (#1312。channels pinnedNoteIds #1283 と同種の null-object drift)。
+		return datatypes.JSON("{}")
 	}
 	var m map[string]float64
 	if err := json.Unmarshal(raw, &m); err != nil {


### PR DESCRIPTION
## Summary

既に golden 化済みの schema(DriveFile/DriveFolder/UserLite/UserDetailedNotMeOnly/Note)を返す**多数の handler 経路へ L3 を一気に拡大**する。調査中に検出した drift を 1 件修正。

## L3 配線(7 経路)
- `drive/files/show`, `drive/files/update` → **DriveFile**
- `drive/folders/create`, `drive/folders/show` → **DriveFolder**
- `following/create`, `following/delete`(unfollow) → **UserLite + UserDetailedNotMeOnly**(`PackUserDetailed`)
- `notes/create`(`createdNote`) → **Note**

drive/following は検証済みの再利用 packer(`PackDriveFile`/`PackDriveFolder`/`PackUserDetailed`)経由で **drift 無し**。

## 検出 → 修正した drift
- **`notes/create` の `createdNote` が `reactions: null`**(golden `Note.reactions` は Record 必須)。create 直後の in-memory note は DB default `'{}'` を経ず `Reactions` が nil で、`normalizeReactionKeys` が空時に nil を返していた → `{}` に coalesce。全 note pack に効く(null 除去方向、channels pinnedNoteIds #1283 と同種)。`notes/show`(#1275)は test が `Reactions:"{}"` を明示設定していたため顕在化していなかった。

## テスト
- `entity`(95.4%)/ `drive`(91.7%)/ `following`(94.3%)/ `notes`(90.7%)全 green、race + atomic、`make shapecheck` green、build / vet / fmt clean。

## Closes
Closes #1312

🤖 Generated with [Claude Code](https://claude.com/claude-code)