### PR TITLE
test(api): L3 を users/search/users-bulk/search-by-username へ拡大

### DIFF
--- a/internal/api/users/handler_extra_test.go
+++ b/internal/api/users/handler_extra_test.go
@@ -14,6 +14,7 @@ import (
 	corefollowing "github.com/shiroha-a/mk/internal/core/following"
 	coreuser "github.com/shiroha-a/mk/internal/core/user"
 	"github.com/shiroha-a/mk/internal/entity"
+	"github.com/shiroha-a/mk/internal/entitycompat/shapetest"
 	"github.com/shiroha-a/mk/internal/misc/id"
 	"github.com/shiroha-a/mk/internal/model"
 	"github.com/shiroha-a/mk/internal/server/middleware"
@@ -394,6 +395,11 @@ func TestSearchByUsernameAndHost_Success(t *testing.T) {
 	userRepo.Users["u1"] = &model.User{ID: "u1", Username: "alice", UsernameLower: "alice"}
 	rec := postExtra(h.SearchByUsernameAndHost, `{"username":"alice"}`, nil)
 	assert.Equal(t, http.StatusOK, rec.Code)
+
+	var out []map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &out))
+	require.Len(t, out, 1)
+	shapetest.Assert(t, "UserLite", out[0]) // L3 (#1314)
 }
 
 func TestSearchByUsernameAndHost_InvalidParam(t *testing.T) {

--- a/internal/api/users/handler_test.go
+++ b/internal/api/users/handler_test.go
@@ -700,6 +700,9 @@ func TestSearch_Success(t *testing.T) {
 	var out []map[string]any
 	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &out))
 	assert.Len(t, out, 1)
+	// users/search は PackUserDetailed (UserLite & UserDetailedNotMeOnly) の配列。
+	shapetest.Assert(t, "UserLite", out[0])              // L3 (#1314)
+	shapetest.Assert(t, "UserDetailedNotMeOnly", out[0]) // L3 (#1314)
 }
 
 // users/search bulk path is now batch (#517). Per-row FindProfileByUserID

--- a/internal/api/users/recommendation_test.go
+++ b/internal/api/users/recommendation_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/shiroha-a/mk/internal/entitycompat/shapetest"
 	"github.com/shiroha-a/mk/internal/model"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -45,6 +46,11 @@ func TestUsersBulk_Success(t *testing.T) {
 	rec := postStub(h.UsersBulk, `{"userIds":["u1"]}`, nil)
 	assert.Equal(t, http.StatusOK, rec.Code)
 	assert.Contains(t, rec.Body.String(), "alice")
+
+	var out []map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &out))
+	require.Len(t, out, 1)
+	shapetest.Assert(t, "UserLite", out[0]) // L3 (#1314)
 }
 
 func TestUsersBulk_Empty(t *testing.T) {


### PR DESCRIPTION
## Summary

既に golden 化済みの `UserLite` / `UserDetailedNotMeOnly` を返す users の多経路へ L3 を拡大する。**drift 無し・production 変更ゼロ**。

## L3 配線(3 経路)
- `users/search`(PackUserDetailed 配列)→ **UserLite + UserDetailedNotMeOnly**(`out[0]`)
- `users/users`(UsersBulk, PackUserLite 配列)→ **UserLite**
- `users/search-by-username-and-host`(PackUserLite 配列)→ **UserLite**

いずれも検証済みの再利用 packer(`PackUserDetailed` / `PackUserLite`)経由で drift 無し。`users/show`(既配線)と合わせ users の主要 user-returning 経路が L3 下に。

## テスト
- `users` 92.7% 全 green、race + atomic、`make shapecheck` green、build / vet / fmt clean。

## Closes
Closes #1314

🤖 Generated with [Claude Code](https://claude.com/claude-code)