### PR TITLE
test(api): L3 を antennas/show·list + announcements/show へ拡大 + Antenna keywords null-array 修正

### DIFF
--- a/internal/api/announcements/handler_show_test.go
+++ b/internal/api/announcements/handler_show_test.go
@@ -1,11 +1,14 @@
 package announcements_test
 
 import (
+	"encoding/json"
 	"net/http"
 	"testing"
 
+	"github.com/shiroha-a/mk/internal/entitycompat/shapetest"
 	"github.com/shiroha-a/mk/internal/model"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 // Show エンドポイントの 3 経路 (bad param / not found / ok) をカバーする。
@@ -27,6 +30,10 @@ func TestShow_Success(t *testing.T) {
 	repo.Items["a1"] = &model.Announcement{ID: "a1", Title: "hi", Text: "hello", IsActive: true}
 	rec := doPost(h.Show, `{"announcementId":"a1"}`, nil)
 	assert.Equal(t, http.StatusOK, rec.Code)
+
+	var resp map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+	shapetest.Assert(t, "Announcement", resp) // L3 (#1318)
 }
 
 // upstream Misskey TS 2026.5.4 fix: userId-targeted announcement に対して

--- a/internal/api/antennas/handler.go
+++ b/internal/api/antennas/handler.go
@@ -2,6 +2,7 @@
 package antennas
 
 import (
+	"encoding/json"
 	"errors"
 	"net/http"
 
@@ -319,14 +320,17 @@ func (h *Handler) antennaToMap(a *model.Antenna) map[string]any {
 		users = []string{}
 	}
 	return map[string]any{
-		"id":              a.ID,
-		"createdAt":       createdAt,
-		"name":            a.Name,
-		"src":             a.Src,
-		"userListId":      a.UserListID,
-		"users":           users,
-		"keywords":        a.Keywords,
-		"excludeKeywords": a.ExcludeKeywords,
+		"id":         a.ID,
+		"createdAt":  createdAt,
+		"name":       a.Name,
+		"src":        a.Src,
+		"userListId": a.UserListID,
+		"users":      users,
+		// keywords / excludeKeywords は jsonb (datatypes.JSON)。未設定 antenna は
+		// nil で JSON null になるが golden Antenna は string[][] 必須なので [] へ
+		// coalesce する (#1318。users #1270 と同種の null-array drift)。
+		"keywords":        jsonArrayOrEmpty(a.Keywords),
+		"excludeKeywords": jsonArrayOrEmpty(a.ExcludeKeywords),
 		"caseSensitive":   a.CaseSensitive,
 		"excludeBots":     a.ExcludeBots,
 		"withReplies":     a.WithReplies,
@@ -340,6 +344,16 @@ func (h *Handler) antennaToMap(a *model.Antenna) map[string]any {
 		"excludeNotesInSensitiveChannel": a.ExcludeNotesInSensitiveChannel,
 		"notify":                         false,
 	}
+}
+
+// jsonArrayOrEmpty coalesces a nil/empty jsonb column to a non-null empty
+// array so the JSON encoder emits `[]` instead of `null`。非空なら格納済みの
+// 生 JSON をそのまま返す (#1318)。
+func jsonArrayOrEmpty(b []byte) any {
+	if len(b) == 0 {
+		return []any{}
+	}
+	return json.RawMessage(b)
 }
 
 func notFound(c echo.Context) error {

--- a/internal/api/antennas/handler_test.go
+++ b/internal/api/antennas/handler_test.go
@@ -155,6 +155,10 @@ func TestShow_Success(t *testing.T) {
 	setUser(c, "alice")
 	require.NoError(t, h.Show(c))
 	assert.Equal(t, http.StatusOK, rec.Code)
+
+	var resp map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+	shapetest.Assert(t, "Antenna", resp) // L3 (#1318)
 }
 
 func TestShow_BadJSON(t *testing.T) {
@@ -322,6 +326,11 @@ func TestList_Success(t *testing.T) {
 	require.NoError(t, h.List(c))
 	assert.Equal(t, http.StatusOK, rec.Code)
 	assert.Contains(t, rec.Body.String(), "alpha")
+
+	var resp []map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+	require.Len(t, resp, 1)
+	shapetest.Assert(t, "Antenna", resp[0]) // L3 (#1318)
 }
 
 // listFailRepo causes ListByUser to fail.


### PR DESCRIPTION
## Summary

既に golden 化済みの `Antenna` / `Announcement` を返す show/list 経路へ L3 を拡大する。調査中に検出した null-array drift を 1 件修正。

## L3 配線
- `antennas/show`, `antennas/list` → **Antenna**
- `announcements/show` → **Announcement**(`packAnnouncement` 経由で drift 無し)

## 検出 → 修正した drift
- **`antennas/show`·`list` の `keywords` / `excludeKeywords` が `null`**(golden `Antenna` は `string[][]` 必須)。未設定 antenna は jsonb(`datatypes.JSON`)が nil で JSON `null` になる → `antennaToMap` で `[]` へ coalesce(`users` #1270 と同種)。`antennas/create`(#1277)は request 由来で keywords 設定済だったため顕在化していなかった。

## テスト
- `antennas` 91.8% / `announcements` 96.0% 全 green、race + atomic、`make shapecheck` green、build / vet / fmt clean。

## Closes
Closes #1318

🤖 Generated with [Claude Code](https://claude.com/claude-code)