### PR TITLE
test(api): L3 を webhooks/userlists/gallery/clips の show 経路へ拡大

### DIFF
--- a/internal/api/clips/handler_test.go
+++ b/internal/api/clips/handler_test.go
@@ -97,11 +97,20 @@ func TestCreate_RepoError(t *testing.T) {
 
 func TestShow_Success(t *testing.T) {
 	h, repo, _, _ := newHandler(t)
-	repo.Clips["c1"] = &model.Clip{ID: "c1", UserID: "alice", Name: "alpha"}
-	c, rec := newReq(t, `{"clipId":"c1"}`)
+	userRepo := testutil.NewMockUserRepository()
+	userRepo.Users["alice"] = &model.User{ID: "alice", Username: "alice"}
+	h.SetUserRepo(userRepo)
+	idGen, _ := id.NewGenerator("aidx")
+	clipID := idGen.Generate(time.Now())
+	repo.Clips[clipID] = &model.Clip{ID: clipID, UserID: "alice", Name: "alpha"}
+	c, rec := newReq(t, `{"clipId":"`+clipID+`"}`)
 	setUser(c, "alice")
 	require.NoError(t, h.Show(c))
 	assert.Equal(t, http.StatusOK, rec.Code)
+
+	var resp map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+	shapetest.Assert(t, "Clip", resp) // L3 (#1320)
 }
 
 func TestShow_BadJSON(t *testing.T) {

--- a/internal/api/gallery/handler_test.go
+++ b/internal/api/gallery/handler_test.go
@@ -129,7 +129,11 @@ func TestPostsShow_Found(t *testing.T) {
 	cleanup()
 	testDB.Create(&model.GalleryPost{ID: "gp_s1", UpdatedAt: time.Now(), Title: "Show", UserID: "gal_u1", FileIDs: []string{}, Tags: []string{}})
 	defer cleanup()
-	assert.Equal(t, http.StatusOK, doPost(newHandler().PostsShow, `{"postId":"gp_s1"}`, nil).Code)
+	rec := doPost(newHandler().PostsShow, `{"postId":"gp_s1"}`, nil)
+	assert.Equal(t, http.StatusOK, rec.Code)
+	var resp map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+	shapetest.Assert(t, "GalleryPost", resp) // L3 (#1320)
 }
 
 func TestPostsShow_NotFound(t *testing.T) {

--- a/internal/api/userlists/handler_test.go
+++ b/internal/api/userlists/handler_test.go
@@ -69,6 +69,10 @@ func TestShow_Success(t *testing.T) {
 	repo.Lists["l1"] = &model.UserList{ID: "l1", UserID: "u1", Name: "Test"}
 	rec := doPost(h.Show, `{"listId":"l1"}`, &model.User{ID: "u1"})
 	assert.Equal(t, http.StatusOK, rec.Code)
+
+	var resp map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+	shapetest.Assert(t, "UserList", resp) // L3 (#1320)
 }
 
 func TestShow_NotFound(t *testing.T) {

--- a/internal/api/webhooks/handler_test.go
+++ b/internal/api/webhooks/handler_test.go
@@ -263,6 +263,10 @@ func TestShow_Success(t *testing.T) {
 	repo.webhooks["w1"] = &model.Webhook{ID: "w1", UserID: "u1", Name: "hook1", On: pq.StringArray{}}
 	rec := post(h.Show, `{"webhookId":"w1"}`, &model.User{ID: "u1"})
 	assert.Equal(t, http.StatusOK, rec.Code)
+
+	var resp map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+	shapetest.Assert(t, "UserWebhook", resp) // L3 (#1320)
 }
 
 func TestShow_NotFound(t *testing.T) {


### PR DESCRIPTION
## Summary

既に golden 化済みの schema を返す **show 経路へ L3 を拡大**する。**drift 無し・production 変更ゼロ**。

## L3 配線(4 経路)
- `webhooks/show` → **UserWebhook**(`packWebhook`)
- `userlists/show` → **UserList**(`PackUserList`)
- `gallery/posts/show` → **GalleryPost**(`packOne`)
- `clips/show` → **Clip**(`clipToMap`; owner 解決のため `userRepo` を wire + aidx ID 使用)

いずれも create で検証済みの packer と同一経路のため drift 無し。

## 見送り
- `flash/show`: `newHandler` が `userRepo=nil` 構築で `flashesToListWithUser` が `user` を埋められない(handler 再構築が必要)。`Flash` shape は `flash/create`(#1282)で既に gate 済みのため見送り。

## テスト
- `webhooks` / `userlists` / `gallery` / `clips` 全 green、race + atomic、`make shapecheck` green、build / vet / fmt clean。

## Closes
Closes #1320

🤖 Generated with [Claude Code](https://claude.com/claude-code)