### PR TITLE
test(api): L3 を i/signin-history + i/gallery/posts へ拡大 + GalleryPost user/fileIds/tags 修正

### DIFF
--- a/internal/api/i/gallery.go
+++ b/internal/api/i/gallery.go
@@ -105,6 +105,16 @@ func packGalleryPost(p *model.GalleryPost, idGen id.Generator) map[string]any {
 			createdAt = t.UTC().Format(tsFormat)
 		}
 	}
+	// fileIds / tags は golden GalleryPost で string[] (non-null)。nil の
+	// pq.StringArray は JSON null になるため [] へ coalesce する (#1322)。
+	fileIDs := []string(p.FileIDs)
+	if fileIDs == nil {
+		fileIDs = []string{}
+	}
+	tags := []string(p.Tags)
+	if tags == nil {
+		tags = []string{}
+	}
 	resp := map[string]any{
 		"id":          p.ID,
 		"createdAt":   createdAt,
@@ -112,11 +122,11 @@ func packGalleryPost(p *model.GalleryPost, idGen id.Generator) map[string]any {
 		"title":       p.Title,
 		"description": p.Description,
 		"userId":      p.UserID,
-		"fileIds":     []string(p.FileIDs),
+		"fileIds":     fileIDs,
 		"files":       []any{},
 		"isSensitive": p.IsSensitive,
 		"likedCount":  p.LikedCount,
-		"tags":        []string(p.Tags),
+		"tags":        tags,
 	}
 	if p.User != nil {
 		resp["user"] = entity.PackUserLite(p.User)
@@ -138,6 +148,12 @@ func (h *Handler) GalleryPosts(c echo.Context) error {
 	}
 	out := make([]map[string]any, 0, len(posts))
 	for _, p := range posts {
+		// golden GalleryPost は user (UserLite) を必須とする。i/gallery/posts は
+		// 認証 user 自身の投稿一覧なので、relation 未 preload の場合は作成者
+		// (= 認証 user) を attach してから pack する (#1322)。
+		if p.User == nil {
+			p.User = u
+		}
 		out = append(out, packGalleryPost(p, h.idGen))
 	}
 	return c.JSON(http.StatusOK, out)

--- a/internal/api/i/gallery_test.go
+++ b/internal/api/i/gallery_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/shiroha-a/mk/internal/entitycompat/shapetest"
 	"github.com/shiroha-a/mk/internal/misc/id"
 	"github.com/shiroha-a/mk/internal/model"
 	"github.com/stretchr/testify/assert"
@@ -54,6 +55,7 @@ func TestGalleryPosts_WithRepo(t *testing.T) {
 	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &got))
 	require.Len(t, got, 1)
 	assert.Equal(t, postID, got[0]["id"])
+	shapetest.Assert(t, "GalleryPost", got[0]) // L3 (#1322)
 }
 
 func TestGalleryLikes_WithRepo(t *testing.T) {

--- a/internal/api/i/signin_history_test.go
+++ b/internal/api/i/signin_history_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/shiroha-a/mk/internal/entitycompat/shapetest"
 	"github.com/shiroha-a/mk/internal/misc/id"
 	"github.com/shiroha-a/mk/internal/model"
 	"github.com/shiroha-a/mk/internal/testutil"
@@ -43,6 +44,7 @@ func TestSigninHistory_WithData(t *testing.T) {
 	assert.Equal(t, "192.168.1.1", resp[0]["ip"])
 	assert.Equal(t, true, resp[0]["success"])
 	assert.NotEmpty(t, resp[0]["createdAt"])
+	shapetest.Assert(t, "Signin", resp[0]) // L3 (#1322)
 }
 
 func TestSigninHistory_Empty(t *testing.T) {


### PR DESCRIPTION
## Summary

i package の entity 返却 endpoint へ L3 を拡大。調査中に i/gallery/posts の drift を検出・修正。

## L3 配線
- `i/signin-history` → **Signin**(drift 無し: id/ip/headers/success/createdAt 充足)
- `i/gallery/posts` → **GalleryPost**

## 検出 → 修正した drift(i/gallery の `packGalleryPost`、gallery package とは別実装)
- **user 欠落**: `i/gallery/posts` は認証 user 自身の投稿一覧(`ListByUser(u.ID)`)。relation 未 preload 時は作成者(= 認証 user)を attach(ChatRoom owner #1285 と同種)。
- **fileIds / tags が nil 時 null**: golden `GalleryPost` は `string[]`(non-null)。`[]` へ coalesce(channels pinnedNoteIds #1283 と同種)。

`i/Apps` は token shape(`lastUsedAt`/`iconUrl`/`description` 等)で golden `App` とは別物のため対象外。

## テスト
- `i` 90.7% 全 green、race + atomic、`make shapecheck` green、build / vet / fmt clean。

## Closes
Closes #1322

🤖 Generated with [Claude Code](https://claude.com/claude-code)