### PR TITLE
test(api): L3 を i/gallery/likes + i/page-likes の embed entity へ拡大

### DIFF
--- a/internal/api/i/gallery_test.go
+++ b/internal/api/i/gallery_test.go
@@ -67,8 +67,10 @@ func TestGalleryLikes_WithRepo(t *testing.T) {
 		likes: []*model.GalleryLike{
 			{ID: "l1", PostID: "p1", UserID: stubUser.ID},
 		},
+		// 実 repo の FindPostsByIDs は Preload("User") するため、stub でも post に
+		// User を持たせて golden GalleryPost の user 必須を満たす。
 		posts: []*model.GalleryPost{
-			{ID: "p1", Title: "t", UserID: stubUser.ID},
+			{ID: "p1", Title: "t", UserID: stubUser.ID, User: stubUser},
 		},
 	})
 	rec := postExtra(h.GalleryLikes, `{}`, stubUser)
@@ -79,4 +81,5 @@ func TestGalleryLikes_WithRepo(t *testing.T) {
 	post, ok := got[0]["post"].(map[string]any)
 	require.True(t, ok, "expected post object embedded")
 	assert.Equal(t, "p1", post["id"])
+	shapetest.Assert(t, "GalleryPost", post) // L3 (#1324)
 }

--- a/internal/api/i/page_test.go
+++ b/internal/api/i/page_test.go
@@ -4,7 +4,10 @@ import (
 	"encoding/json"
 	"net/http"
 	"testing"
+	"time"
 
+	"github.com/shiroha-a/mk/internal/entitycompat/shapetest"
+	"github.com/shiroha-a/mk/internal/misc/id"
 	"github.com/shiroha-a/mk/internal/model"
 	"github.com/shiroha-a/mk/internal/testutil"
 	"github.com/stretchr/testify/assert"
@@ -39,15 +42,18 @@ func TestPageLikes_FullShape(t *testing.T) {
 	h, userRepo := newExtraHandler(t)
 	// page owner を userRepo に登録 → userService.FindManyByIDs で解決される。
 	userRepo.Users["author"] = &model.User{ID: "author", Username: "author", UsernameLower: "author"}
-	// page 本体を登録 → pageRepo.FindManyByIDs で解決される。
+	// page 本体を登録 → pageRepo.FindManyByIDs で解決される。golden Page は
+	// createdAt 必須 (PackPage が ID 由来で導出) なので aidx ID を使う。
+	idGen, _ := id.NewGenerator("aidx")
+	pageID := idGen.Generate(time.Now())
 	pageRepo := testutil.NewMockPageRepository()
 	require.NoError(t, pageRepo.Create(&model.Page{
-		ID: "pg1", UserID: "author", Title: "T", Name: "n",
+		ID: pageID, UserID: "author", Title: "T", Name: "n",
 		Visibility: model.PageVisibilityPublic,
 	}))
 	h.SetPageRepo(pageRepo)
 	pageLike := testutil.NewMockPageLikeRepository()
-	require.NoError(t, pageLike.Create(&model.PageLike{ID: "pl1", UserID: stubUser.ID, PageID: "pg1"}))
+	require.NoError(t, pageLike.Create(&model.PageLike{ID: "pl1", UserID: stubUser.ID, PageID: pageID}))
 	h.SetPageLikeRepo(pageLike)
 	rec := postExtra(h.PageLikes, `{}`, stubUser)
 	require.Equal(t, http.StatusOK, rec.Code)
@@ -57,10 +63,11 @@ func TestPageLikes_FullShape(t *testing.T) {
 	assert.Equal(t, "pl1", got[0]["id"])
 	page, ok := got[0]["page"].(map[string]any)
 	require.True(t, ok, "like row must include page field (#1136)")
-	assert.Equal(t, "pg1", page["id"])
+	assert.Equal(t, pageID, page["id"])
 	user, ok := page["user"].(map[string]any)
 	require.True(t, ok, "page must include user field (#1136)")
 	assert.Equal(t, "author", user["username"])
+	shapetest.Assert(t, "Page", page) // L3 (#1324)
 }
 
 // TestPageLikes_DropsDanglingLike covers the "page row missing" fail-soft


### PR DESCRIPTION
## Summary

i package の like list endpoint が embed する entity(GalleryPost / Page)へ L3 を拡大。**drift 無し・production 変更ゼロ**(test 調整のみ)。

## L3 配線(embed object)
- `i/gallery/likes` → `resp[0].post` を **GalleryPost** で検証
- `i/page-likes` → `resp[0].page` を **Page** で検証

いずれも検証済み packer(`packGalleryPost` #1322 / `PackPageWithContext` #1282)+ handler 側の author/owner 解決(GalleryLikes は `FindPostsByIDs` の `Preload("User")`、PageLikes は owner batch lookup)経由で clean。

## test 調整(production 無変更)
- **GalleryLikes**: 実 repo の `FindPostsByIDs` は `Preload("User")` するため、stub post にも `User` を持たせて golden `GalleryPost` の user 必須を満たす。
- **PageLikes**: page ID を aidx 生成に変更(`PackPage` の `createdAt` は ID 由来。`"pg1"` 非 aidx だと createdAt 欠落、pages/show #1282 と同パターン)。

## テスト
- `i` 90.7% 全 green、race + atomic、`make shapecheck` green、build / vet / fmt clean。

## Closes
Closes #1324

🤖 Generated with [Claude Code](https://claude.com/claude-code)