### PR TITLE
feat(entitycompat): L3 ValidateResponse を union 対応にし notifications を gate

### DIFF
--- a/internal/api/notifications/handler_test.go
+++ b/internal/api/notifications/handler_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/labstack/echo/v4"
 	"github.com/redis/go-redis/v9"
 	"github.com/shiroha-a/mk/internal/core/notification"
+	"github.com/shiroha-a/mk/internal/entitycompat/shapetest"
 	"github.com/shiroha-a/mk/internal/misc/id"
 	"github.com/shiroha-a/mk/internal/model"
 	"github.com/shiroha-a/mk/internal/server/middleware"
@@ -481,6 +482,9 @@ func TestShow_WithInstanceAndEmojiResolution(t *testing.T) {
 	inst, ok := user["instance"].(map[string]any)
 	require.True(t, ok, "user.instance must be set on remote notifier")
 	assert.Equal(t, themeColor, inst["themeColor"])
+	// L3 (#1326): 実 HTTP 応答を golden Notification union に突合 (type=follow で
+	// variant dispatch)。gate の union 対応 (ValidateResponse) を実経路で検証。
+	shapetest.Assert(t, "Notification", resp[0])
 }
 
 func TestShow_IncludeTypesFilter(t *testing.T) {

--- a/internal/entitycompat/response.go
+++ b/internal/entitycompat/response.go
@@ -13,9 +13,19 @@ import (
 //go:embed testdata/golden_schemas.json
 var embeddedGoldenJSON []byte
 
+// embeddedUnionsJSON is the committed golden discriminated-union snapshot
+// (union name -> type literal -> variant schema), embedded so L3 response
+// checks can validate union-shaped responses (e.g. Notification) without a
+// filesystem path (#1326)。
+//
+//go:embed testdata/golden_unions.json
+var embeddedUnionsJSON []byte
+
 var (
 	embeddedGoldenOnce sync.Once
 	embeddedGolden     GoldenSet
+	embeddedUnionsOnce sync.Once
+	embeddedUnions     map[string]map[string]Schema
 )
 
 // EmbeddedGolden returns the embedded golden flat-schema snapshot. The parse is
@@ -28,6 +38,15 @@ func EmbeddedGolden() GoldenSet {
 	return embeddedGolden
 }
 
+// EmbeddedUnions returns the embedded golden discriminated-union snapshot
+// (union name -> type literal -> variant schema), memoized like EmbeddedGolden.
+func EmbeddedUnions() map[string]map[string]Schema {
+	embeddedUnionsOnce.Do(func() {
+		_ = json.Unmarshal(embeddedUnionsJSON, &embeddedUnions)
+	})
+	return embeddedUnions
+}
+
 // ValidateResponse is the "Layer 3" runtime response check: it validates an
 // actual API response map against the named golden schema and returns the
 // gated (HIGH/MED) findings. Unlike Layer 0 (struct reflection) it inspects
@@ -36,17 +55,29 @@ func EmbeddedGolden() GoldenSet {
 //
 // A non-existent schema name yields a single HIGH finding so misuse (typo /
 // not-extracted schema) is visible rather than silently passing.
+//
+// schemaName may name either a flat golden schema or a discriminated union
+// (e.g. Notification); the union variants are dispatched on the value's `type`
+// discriminator (#1326)。
 func ValidateResponse(schemaName string, actual map[string]any) []Finding {
-	schema, ok := EmbeddedGolden()[schemaName]
-	if !ok {
-		return []Finding{{
-			Family: schemaName, Layer: schemaName, Golden: schemaName,
-			Field: schemaName, Kind: KindMissing, Sev: SevHigh,
-			Detail: "golden schema not found in snapshot (typo, or add to GoldenSchemaNames/L2FlatSchemaNames)",
-		}}
+	if schema, ok := EmbeddedGolden()[schemaName]; ok {
+		return gateHighMed(ValidateValue(schemaName, schemaName, schemaName, actual, schema))
 	}
+	if variants, ok := EmbeddedUnions()[schemaName]; ok {
+		return gateHighMed(ValidateUnionValue(schemaName, actual, variants))
+	}
+	return []Finding{{
+		Family: schemaName, Layer: schemaName, Golden: schemaName,
+		Field: schemaName, Kind: KindMissing, Sev: SevHigh,
+		Detail: "golden schema not found in snapshot (typo, or add to GoldenSchemaNames/L2FlatSchemaNames/UnionSchemaNames)",
+	}}
+}
+
+// gateHighMed keeps only the gating (HIGH/MED) findings; LOW/INFO are reported
+// elsewhere but never fail an L3 assertion.
+func gateHighMed(findings []Finding) []Finding {
 	var gated []Finding
-	for _, f := range ValidateValue(schemaName, schemaName, schemaName, actual, schema) {
+	for _, f := range findings {
 		if f.Sev == SevHigh || f.Sev == SevMed {
 			gated = append(gated, f)
 		}

--- a/internal/entitycompat/runtime_test.go
+++ b/internal/entitycompat/runtime_test.go
@@ -253,6 +253,33 @@ func TestValidateResponse(t *testing.T) {
 	}
 }
 
+// TestValidateResponse_Union covers the discriminated-union dispatch path
+// (#1326): a union schema name (Notification) routes to ValidateUnionValue via
+// the value's `type` discriminator.
+func TestValidateResponse_Union(t *testing.T) {
+	if _, ok := EmbeddedUnions()["Notification"]; !ok {
+		t.Fatal("embedded unions missing Notification")
+	}
+	// follow variant の必須欄 (createdAt/id/type/user/userId) を満たす -> clean。
+	ok := map[string]any{
+		"id": "n1", "createdAt": "2026-05-27T00:00:00.000Z", "type": "follow",
+		"userId": "u1", "user": map[string]any{"id": "u1"},
+	}
+	if f := ValidateResponse("Notification", ok); len(f) != 0 {
+		t.Errorf("complete follow notification should pass, got %v", f)
+	}
+	// 未知 type literal -> union dispatch 不能で HIGH。
+	if f := ValidateResponse("Notification", map[string]any{"type": "zzz"}); len(f) != 1 || f[0].Sev != SevHigh {
+		t.Errorf("unknown notification type: want 1 HIGH, got %v", f)
+	}
+	// 必須 user 欠落 -> gated drift。
+	if f := ValidateResponse("Notification", map[string]any{
+		"id": "n1", "createdAt": "x", "type": "follow", "userId": "u1",
+	}); len(f) == 0 {
+		t.Error("expected gated drift for follow notification missing user")
+	}
+}
+
 // requireL2Schema loads a flat golden schema for an L2 map-based packer test,
 // failing if the snapshot is missing/empty (regenerate-miss guard).
 func requireL2Schema(t *testing.T, name string) Schema {


### PR DESCRIPTION
## Summary

L3 の `ValidateResponse` は flat golden schema のみ対応で、`Notification` のような **discriminated union を実 HTTP 応答で検証できなかった**(L2 fixture のみ)。core endpoint の `/api/i/notifications` を L3 でも gate できるよう拡張する(#1326)。

## 主な変更点
- **`response.go`**: `golden_unions.json` を `//go:embed` し `EmbeddedUnions()` を追加。`ValidateResponse` を **「flat → union → not-found」** の順で dispatch(union は value の `type` discriminator で variant を引いて `ValidateUnionValue`)。`shapetest.Assert(t, "Notification", ...)` がそのまま union 経路を通る。`gateHighMed` helper を抽出。
- **L3 配線**: `/api/i/notifications`(`TestShow_WithInstanceAndEmojiResolution`: `SetRepos` wire 済 + remote follow notification)に `shapetest.Assert(t, "Notification", resp[0])`。follow variant の `createdAt`/`id`/`type`/`user`/`userId` を実応答で検証。
- **unit test**: `ValidateResponse` の union dispatch を entitycompat package で網羅(clean follow / 未知 type literal → HIGH / 必須 user 欠落 → gated)。

## 効果
これまで L2 fixture でしか検証できなかった Notification union が、実際の `/api/i/notifications` HTTP 応答に対して L3 で gate されるようになった。

## テスト
- `entitycompat` 94.2% / `notifications` 93.6% 全 green、race + atomic、`make shapecheck` green、build / vet / fmt clean。

## Closes
Closes #1326

🤖 Generated with [Claude Code](https://claude.com/claude-code)