### PR TITLE
docs: shape-drift.md に L3 union dispatch (Notification) を追記

### DIFF
--- a/docs/shape-drift.md
+++ b/docs/shape-drift.md
@@ -55,7 +55,7 @@ goldenはユーザー shapeを合成可能な部品(`UserLite` / `UserDetailedNo
 
 ### 対象外
 
-- **Notification**: golden側がtype別のdiscriminated union、mk-go側も`PackNotification`が`map[string]any`を手組みするため、reflectionが届かない。map-based packerとunion型は静的検出の射程外で、差分HTTP(L2)で見る。
+- **Notification**: golden側がtype別のdiscriminated union、mk-go側も`PackNotification`が`map[string]any`を手組みするため、reflection(L0)は届かない。**L2**(fixtureでpacker出力を検証)と**L3**(`/api/i/notifications`の実HTTP応答を`ValidateResponse`のunion dispatchで検証)でカバーする。
 
 ## 運用
 
@@ -165,6 +165,12 @@ func TestCreate_Success(t *testing.T) {
 - 配列を返すendpoint(`mute/list`等)は`rows[0]`をassert。
 - ネストした子objectを検証したいとき(`/api/meta`の`counts`等)はその子だけ渡す: `shapetest.Assert(t, "QueueCount", resp["counts"].(map[string]any))`。
 - 合成型(`MetaDetailed = MetaLite & MetaDetailedOnly`)はparserがflat抽出できないので、**構成要素を個別にassert**する(同じ応答に`MetaLite`と`MetaDetailedOnly`の2回)。
+
+### discriminated union(`Notification`)
+
+`shapetest.Assert(t, "Notification", resp[0])`は**flatでもunionでも同じ呼び方**で通る。`ValidateResponse`が **flat golden → union(`golden_unions.json`)→ not-found** の順でdispatchし、unionなら値の`type` discriminatorでvariantを引いて`ValidateUnionValue`に回す(未知typeはHIGH、variant必須欄の欠落/nullもHIGH)。
+
+L2のfixtureは「packerが正しく呼ばれれば」を見るのに対し、L3は`/api/i/notifications`の**実HTTP応答**を直接unionに突合する。`type=follow`等のvariantはhandlerが`user`(reaction系は`note`も)を解決して埋める必要があるので、`SetRepos`をwireして対象userを seed したtestで配線する。
 
 ## array要素型の検出(`Elem`)
 


### PR DESCRIPTION
## Summary

#1326 で L3(`ValidateResponse`)が discriminated union 対応になったのを `docs/shape-drift.md` に反映する。docs 専用変更。

## 更新内容
- **L3「配列応答・ネスト」に discriminated union(Notification)サブセクション追加**: `ValidateResponse` の flat → union → not-found dispatch、`shapetest.Assert(t, "Notification", ...)` が flat/union 同じ呼び方で通ること、variant が `user`(reaction系は `note` も)解決を要するため `SetRepos` wire 前提であること。
- **L0「対象外: Notification」注記を更新**: 「差分HTTP(L2)で見る」→「L2(fixture)+ L3(実HTTP応答を `ValidateResponse` の union dispatch で検証)でカバー」。

## 検証
- 記載の `EmbeddedUnions` / union dispatch / `golden_unions.json` / notifications L3 配線は全て実在を確認。

## Closes
Closes #1328

🤖 Generated with [Claude Code](https://claude.com/claude-code)