### PR TITLE
test(api): L3 を users/followers·following (Following) へ拡大

### DIFF
--- a/internal/api/users/handler_test.go
+++ b/internal/api/users/handler_test.go
@@ -980,6 +980,7 @@ func TestFollowers_Success(t *testing.T) {
 	assert.NotEmpty(t, createdAt)
 	assert.Equal(t, "follower1", out[0]["followerId"])
 	assert.Equal(t, "user1", out[0]["followeeId"])
+	shapetest.Assert(t, "Following", out[0]) // L3 (#1330)
 }
 
 // TestFollowers_PopulatesIsFollowedFromViewer guards #1144: when a viewer
@@ -1372,6 +1373,7 @@ func TestFollowing_Success(t *testing.T) {
 	var out []map[string]any
 	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &out))
 	assert.Len(t, out, 1)
+	shapetest.Assert(t, "Following", out[0]) // L3 (#1330)
 }
 
 func TestFollowing_InvalidParam(t *testing.T) {


### PR DESCRIPTION
## Summary

未配線だった golden `Following` を `users/followers`·`following` で gate する。これで**公開 endpoint を持つ golden schema は全て L3 配線済み**になる(`EmojiDetailed` は公開 endpoint 無しで L0 のみ)。**drift 無し・production 変更ゼロ**。

## L3 配線
- `users/followers` → **Following**(`out[0]`、follower populate)
- `users/following` → **Following**(`out[0]`、followee populate)

`relationItem` の json tag(`id`/`createdAt`/`followerId`/`followeeId` 必須 + `follower`/`followee` omitempty)は golden `Following` と一致。

## テスト
- `users` 92.7% 全 green、race + atomic、`make shapecheck` green、build / vet / fmt clean。

## Closes
Closes #1330

🤖 Generated with [Claude Code](https://claude.com/claude-code)