### PR TITLE
fix(api): error id を Misskey endpoint 固有値へ整合 (drop-in 互換)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@
 	uds-init uds-frontend-build uds-build uds-up uds-down uds-down-v uds-logs uds-ps \
 	bench-up bench-run bench-down bench-logs \
 	apicompat apicompat-routes apicompat-render \
-	shapecheck shapecheck-gen shapecheck-report
+	shapecheck shapecheck-gen shapecheck-report errorid-check
 
 # Binary output
 BINARY=misskey
@@ -434,11 +434,12 @@ apicompat: apicompat-routes apicompat-render
 # サーバー / ブラウザ / Docker 不要で、CI では `go test ./...` 内の
 # TestEntityShapeDrift gate として自動実行される。詳細は docs/shape-drift.md。
 
-# golden snapshot (testdata/golden_schemas.json) を submodule の types.ts から
-# 再生成する。third_party/misskey を upstream catch-up で bump したら必ず実行し、
-# 生成された snapshot を commit すること。
+# golden snapshot (testdata/golden_schemas.json + golden_error_ids.json) を
+# submodule から再生成する。third_party/misskey を upstream catch-up で bump
+# したら必ず実行し、生成された snapshot を commit すること。
 shapecheck-gen:
 	go run ./tools/shapediff
+	go run ./tools/erroriddiff
 
 # 全 family の drift を severity 付きで一覧表示する (gate にかける前の調査用)。
 shapecheck-report:
@@ -448,3 +449,9 @@ shapecheck-report:
 # L0: TestEntityShapeDrift / L2: Test*ShapeL2 (Notification / Announcement / ...)。
 shapecheck:
 	go test ./internal/entitycompat/... -run 'TestEntityShapeDrift|ShapeL2' -count=1 -v
+
+# error-id drift gate をローカルで実行する。handler が emit する error id
+# (inline / UUID 定数 / apierr helper) を router 経由で endpoint に解決し、
+# Misskey の per-endpoint id と突合する静的 gate。詳細は docs/shape-drift.md。
+errorid-check:
+	go test ./internal/entitycompat/... -run TestErrorIDDrift -count=1 -v

--- a/docs/shape-drift.md
+++ b/docs/shape-drift.md
@@ -214,3 +214,40 @@ L3拡大の過程で検出・修正した実ドリフトの代表例(いずれ�
 | `v2/admin/emoji/list` | `roleIds`が`string[]`(golden `{id,name}[]`) | array要素型 |
 | `admin/queue/show-job` | `progress`/`returnValue`/`failedReason`/`data` | 型 + null + 欠落 |
 | `/api/meta` (lite) | MetaLite必須5欄をomit、MetaDetailedOnly 3欄をleak | partition |
+
+## Error-id drift gate（error.id の per-endpoint 整合）
+
+shape gateがレスポンス**ボディ**の契約を守るのに対し、これは**エラーレスポンスのid**を守る別ゲート(`TestErrorIDDrift`)。
+
+Misskeyのエラーは`{code, message, id}`形式で、クライアントは`code`だけでなく**endpoint固有のUUID `id`**でエラーを識別する。mk-goは「1 code = 1 UUID使い回し」になりがちだが、Misskeyは**endpointごとに別id**を割り当てる(例: `NO_SUCH_WEBHOOK`はshow/update/delete/testで4つ別id)。idがズレると`code`が正しくてもdrop-inクライアントがエラーを誤分類する。
+
+### 仕組み
+
+完全に静的(サーバ起動不要)。`internal/api/**/*.go`を走査し、各handler **method**が返すエラーの`(code, id)`を3経路で抽出する:
+
+- **inline literal**: `apierr.Error("CODE", msg, "uuid")`
+- **UUID定数参照**: `apierr.Error("CODE", msg, apierr.UUIDxxx)`(`errors.go`の定数表で解決)
+- **helper呼び出し**: `apierr.NoSuchUser()`等(`errors.go`のhelper表で`(code, uuid)`に解決)
+
+`router.go`の`path→handler`登録(import alias→pkg、`xxx := pkg.NewHandler()`のvar→pkg、ルート登録)を解決して各methodをendpointへ対応づけ、`(endpoint, code)`をgoldenの値と突合する。
+
+### golden
+
+`tools/erroriddiff`がMisskeyの`endpoints/*.ts`の`meta.errors`から`endpoint → {code: id}`を抽出し、`internal/entitycompat/testdata/golden_error_ids.json`へ生成・embedする(third_party非依存でCI実行可)。
+
+### 除外（lineage / upstream typo）
+
+- **reversi/* ・ chat/***: cherrypick派生。idもvanillaへ寄せない(`errorIDExcludedPrefixes`)。
+- **不正UUIDのgolden値はskip**: upstreamのtypoでidが壊れている箇所(`sw/update-registration`は先頭スペース、`i/2fa/update-key`等は非hex文字を含む)は揃える対象が無いため、`validUUID`で弾く(自己文書化された除外)。
+- **mk-go独自code・route未解決**: 対応するMisskey契約が無いので対象外(driftではない)。
+
+確実に解決できたケースのみgateする方針なので、誤検出より見落としに倒している。
+
+### 運用
+
+```bash
+make errorid-check    # gate をローカル実行 (TestErrorIDDrift)
+make shapecheck-gen   # shape golden と合わせて golden_error_ids.json も再生成
+```
+
+upstream bump時は`make shapecheck-gen`で両goldenを再生成してcommit。新しいerror idを返すendpointを足すときは、verify-before-fixに従い対応するMisskey endpointの`meta.errors`のidを確認してから実装する。

--- a/docs/shape-drift.md
+++ b/docs/shape-drift.md
@@ -223,13 +223,16 @@ Misskeyのエラーは`{code, message, id}`形式で、クライアントは`cod
 
 ### 仕組み
 
-完全に静的(サーバ起動不要)。`internal/api/**/*.go`を走査し、各handler **method**が返すエラーの`(code, id)`を3経路で抽出する:
+完全に静的(サーバ起動不要)。`internal/api/**/*.go`を走査し、各handler **method**が返すエラーの`(code, id)`を4経路で抽出する:
 
 - **inline literal**: `apierr.Error("CODE", msg, "uuid")`
 - **UUID定数参照**: `apierr.Error("CODE", msg, apierr.UUIDxxx)`(`errors.go`の定数表で解決)
 - **helper呼び出し**: `apierr.NoSuchUser()`等(`errors.go`のhelper表で`(code, uuid)`に解決)
+- **echo wrapper**: `apierr.JSONNoSuchNote(c)`等(`echo.go`の`JSONXxx`→内部helper→`(code, uuid)`に解決)
 
-`router.go`の`path→handler`登録(import alias→pkg、`xxx := pkg.NewHandler()`のvar→pkg、ルート登録)を解決して各methodをendpointへ対応づけ、`(endpoint, code)`をgoldenの値と突合する。
+echo wrapperはhandlerの最頻送出経路なので外すとgateが大半のrouteを素通しする(実例: これを足すと解決数が577→652に増え、未検出だったdrift 25件が露出した)。
+
+`router.go`の`path→handler`登録(import alias→pkg、`xxx := pkg.NewHandler()`のvar→pkg、ルート登録)を解決して各methodをendpointへ対応づけ、`(endpoint, code)`をgoldenの値と突合する。regexベースの抽出が空振りした場合の **silent-zero** を防ぐため、解決できたemissionが下限(400)を下回ったらgateを失敗させる。
 
 ### golden
 

--- a/internal/api/admin/drive.go
+++ b/internal/api/admin/drive.go
@@ -126,27 +126,27 @@ func (h *Handler) DriveShowFile(c echo.Context) error {
 		return c.JSON(http.StatusBadRequest, apierr.Error("INVALID_PARAM", "fileId or url is required.", "3d81ceae-475f-4600-b2a8-2bc116157532"))
 	}
 	if h.driveFileRepo == nil {
-		return c.JSON(http.StatusNotFound, apierr.Error("NO_SUCH_FILE", "No such file.", "ac4f7b11-1a6e-47e3-bf3d-3dce9a0e07ab"))
+		return c.JSON(http.StatusNotFound, apierr.Error("NO_SUCH_FILE", "No such file.", "caf3ca38-c6e5-472e-a30c-b05377dcc240"))
 	}
 	viewer := middleware.GetUser(c)
 	if req.FileID != "" {
 		file, err := h.driveFileRepo.FindByID(req.FileID)
 		if err != nil {
-			return c.JSON(http.StatusNotFound, apierr.Error("NO_SUCH_FILE", "No such file.", "ac4f7b11-1a6e-47e3-bf3d-3dce9a0e07ab"))
+			return c.JSON(http.StatusNotFound, apierr.Error("NO_SUCH_FILE", "No such file.", "caf3ca38-c6e5-472e-a30c-b05377dcc240"))
 		}
 		return c.JSON(http.StatusOK, h.packAdminDriveShowFile(file, viewer))
 	}
 	// url 指定時は adminDB を使って url / thumbnailUrl / webpublicUrl いずれか
 	// に一致する 1 件を引く。 driveFileRepo には該当 API が無いため raw query で。
 	if h.adminDB == nil {
-		return c.JSON(http.StatusNotFound, apierr.Error("NO_SUCH_FILE", "No such file.", "ac4f7b11-1a6e-47e3-bf3d-3dce9a0e07ab"))
+		return c.JSON(http.StatusNotFound, apierr.Error("NO_SUCH_FILE", "No such file.", "caf3ca38-c6e5-472e-a30c-b05377dcc240"))
 	}
 	var file model.DriveFile
 	if err := h.adminDB.Where(
 		`"url" = ? OR "thumbnailUrl" = ? OR "webpublicUrl" = ?`,
 		req.URL, req.URL, req.URL,
 	).First(&file).Error; err != nil {
-		return c.JSON(http.StatusNotFound, apierr.Error("NO_SUCH_FILE", "No such file.", "ac4f7b11-1a6e-47e3-bf3d-3dce9a0e07ab"))
+		return c.JSON(http.StatusNotFound, apierr.Error("NO_SUCH_FILE", "No such file.", "caf3ca38-c6e5-472e-a30c-b05377dcc240"))
 	}
 	return c.JSON(http.StatusOK, h.packAdminDriveShowFile(&file, viewer))
 }

--- a/internal/api/admin/handler.go
+++ b/internal/api/admin/handler.go
@@ -1402,7 +1402,7 @@ func (h *Handler) RolesShow(c echo.Context) error {
 	}
 	r, err := h.roleService.Show(req.RoleID)
 	if err != nil {
-		return c.JSON(http.StatusNotFound, apierr.Error("NO_SUCH_ROLE", "No such role.", "07dc7d34-c0d8-458b-9c04-4b18399b1f46"))
+		return c.JSON(http.StatusNotFound, apierr.Error("NO_SUCH_ROLE", "No such role.", "07dc7d34-c0d8-49b7-96c6-db3ce64ee0b3"))
 	}
 	return c.JSON(http.StatusOK, r)
 }
@@ -1450,7 +1450,7 @@ func (h *Handler) RolesUpdate(c echo.Context) error {
 	}
 	before, err := h.roleService.Show(req.RoleID)
 	if err != nil {
-		return c.JSON(http.StatusNotFound, apierr.Error("NO_SUCH_ROLE", "No such role.", "07dc7d34-c0d8-458b-9c04-4b18399b1f46"))
+		return c.JSON(http.StatusNotFound, apierr.Error("NO_SUCH_ROLE", "No such role.", "cd23ef55-09ad-428a-ac61-95a45e124b32"))
 	}
 	fields := map[string]any{}
 	if req.Name != nil {
@@ -1542,7 +1542,7 @@ func (h *Handler) RolesUpdate(c echo.Context) error {
 	after, err := h.roleService.UpdateFields(req.RoleID, fields)
 	if err != nil {
 		if err == role.ErrRoleNotFound {
-			return c.JSON(http.StatusNotFound, apierr.Error("NO_SUCH_ROLE", "No such role.", "07dc7d34-c0d8-458b-9c04-4b18399b1f46"))
+			return c.JSON(http.StatusNotFound, apierr.Error("NO_SUCH_ROLE", "No such role.", "cd23ef55-09ad-428a-ac61-95a45e124b32"))
 		}
 		return c.JSON(http.StatusInternalServerError, apierr.Error("INTERNAL_ERROR", "Internal error.", "5d37dbcb-891e-41ca-a3d6-e690c97775ac"))
 	}
@@ -1565,7 +1565,7 @@ func (h *Handler) RolesDelete(c echo.Context) error {
 	// 削除直後だと role 情報を取れないので事前に snapshot を取って log info に含める
 	snapshot, _ := h.roleService.Show(req.RoleID)
 	if err := h.roleService.Delete(req.RoleID); err != nil {
-		return c.JSON(http.StatusNotFound, apierr.Error("NO_SUCH_ROLE", "No such role.", "07dc7d34-c0d8-458b-9c04-4b18399b1f46"))
+		return c.JSON(http.StatusNotFound, apierr.Error("NO_SUCH_ROLE", "No such role.", "de0d6ecd-8e0a-4253-88ff-74bc89ae3d45"))
 	}
 	h.logModeration(c, moderationlog.LogDeleteRole, map[string]any{
 		"roleId": req.RoleID,
@@ -1592,7 +1592,7 @@ func (h *Handler) RolesAssign(c echo.Context) error {
 	}
 	if err := h.roleService.Assign(req.UserID, req.RoleID, expiresAt); err != nil {
 		if err == role.ErrRoleNotFound {
-			return c.JSON(http.StatusNotFound, apierr.Error("NO_SUCH_ROLE", "No such role.", "07dc7d34-c0d8-458b-9c04-4b18399b1f46"))
+			return c.JSON(http.StatusNotFound, apierr.Error("NO_SUCH_ROLE", "No such role.", "6503c040-6af4-4ed9-bf07-f2dd16678eab"))
 		}
 		if err == role.ErrAlreadyAssigned {
 			return c.JSON(http.StatusConflict, apierr.Error("ALREADY_ASSIGNED", "Role already assigned.", "67d8689c-25c6-435f-8eed-6ea68e5e53e9"))
@@ -1614,7 +1614,7 @@ func (h *Handler) RolesUnassign(c echo.Context) error {
 	}
 	if err := h.roleService.Unassign(req.UserID, req.RoleID); err != nil {
 		if err == role.ErrNotAssigned {
-			return c.JSON(http.StatusNotFound, apierr.Error("NOT_ASSIGNED", "Role not assigned.", "b9060ac7-5c94-4da4-9f55-2047140f5a68"))
+			return c.JSON(http.StatusNotFound, apierr.Error("NOT_ASSIGNED", "Role not assigned.", "b9060ac7-5c94-4da4-9f55-2047c953df44"))
 		}
 		return c.JSON(http.StatusInternalServerError, apierr.Error("INTERNAL_ERROR", "Internal error.", "5d37dbcb-891e-41ca-a3d6-e690c97775ac"))
 	}
@@ -1648,7 +1648,7 @@ func (h *Handler) RolesUsers(c echo.Context) error {
 	assignments, err := h.roleService.ListByRole(req.RoleID, untilID, sinceID, limit)
 	if err != nil {
 		if err == role.ErrRoleNotFound {
-			return c.JSON(http.StatusNotFound, apierr.Error("NO_SUCH_ROLE", "No such role.", "07dc7d34-c0d8-458b-9c04-4b18399b1f46"))
+			return c.JSON(http.StatusNotFound, apierr.Error("NO_SUCH_ROLE", "No such role.", "224eff5e-2488-4b18-b3e7-f50d94421648"))
 		}
 		return c.JSON(http.StatusInternalServerError, apierr.Error("INTERNAL_ERROR", "Internal error.", "5d37dbcb-891e-41ca-a3d6-e690c97775ac"))
 	}
@@ -1876,10 +1876,10 @@ func (h *Handler) EmojiDelete(c echo.Context) error {
 	// log info に snapshot を含めるため削除前に取得。取得失敗は NO_SUCH_EMOJI。
 	snapshot, err := h.emojiRepo.FindByID(req.ID)
 	if err != nil {
-		return c.JSON(http.StatusNotFound, apierr.Error("NO_SUCH_EMOJI", "No such emoji.", "684b7e7e-7e91-4e4c-a5cc-8050e4b8e0d8"))
+		return c.JSON(http.StatusNotFound, apierr.Error("NO_SUCH_EMOJI", "No such emoji.", "be83669b-773a-44b7-b1f8-e5e5170ac3c2"))
 	}
 	if err := h.emojiRepo.Delete(req.ID); err != nil {
-		return c.JSON(http.StatusNotFound, apierr.Error("NO_SUCH_EMOJI", "No such emoji.", "684b7e7e-7e91-4e4c-a5cc-8050e4b8e0d8"))
+		return c.JSON(http.StatusNotFound, apierr.Error("NO_SUCH_EMOJI", "No such emoji.", "be83669b-773a-44b7-b1f8-e5e5170ac3c2"))
 	}
 	h.logModeration(c, moderationlog.LogDeleteCustomEmoji, map[string]any{
 		"emojiId": req.ID,

--- a/internal/api/announcements/handler.go
+++ b/internal/api/announcements/handler.go
@@ -304,7 +304,7 @@ func (h *Handler) AdminUpdate(c echo.Context) error {
 	// before snapshot for moderation log + global/user 分岐判定
 	before, err := h.repo.FindByID(req.ID)
 	if err != nil {
-		return c.JSON(http.StatusNotFound, apierr.Error("NO_SUCH_ANNOUNCEMENT", "No such announcement.", "b57b5e1d-0158-4f8d-bd54-1ab374089a15"))
+		return c.JSON(http.StatusNotFound, apierr.Error("NO_SUCH_ANNOUNCEMENT", "No such announcement.", "d3aae5a7-6372-4cb4-b61c-f511ffc2d7cc"))
 	}
 	fields := map[string]any{}
 	if req.Title != nil {
@@ -350,7 +350,7 @@ func (h *Handler) AdminUpdate(c echo.Context) error {
 		return c.NoContent(http.StatusNoContent)
 	}
 	if err := h.repo.UpdateFields(req.ID, fields); err != nil {
-		return c.JSON(http.StatusNotFound, apierr.Error("NO_SUCH_ANNOUNCEMENT", "No such announcement.", "b57b5e1d-0158-4f8d-bd54-1ab374089a15"))
+		return c.JSON(http.StatusNotFound, apierr.Error("NO_SUCH_ANNOUNCEMENT", "No such announcement.", "d3aae5a7-6372-4cb4-b61c-f511ffc2d7cc"))
 	}
 	after, err := h.repo.FindByID(req.ID)
 	if err != nil {
@@ -375,7 +375,7 @@ func (h *Handler) AdminDelete(c echo.Context) error {
 	// snapshot before delete (log info に含める + global/user 分岐判定)
 	snapshot, _ := h.repo.FindByID(req.ID)
 	if err := h.repo.Delete(req.ID); err != nil {
-		return c.JSON(http.StatusNotFound, apierr.Error("NO_SUCH_ANNOUNCEMENT", "No such announcement.", "b57b5e1d-0158-4f8d-bd54-1ab374089a15"))
+		return c.JSON(http.StatusNotFound, apierr.Error("NO_SUCH_ANNOUNCEMENT", "No such announcement.", "ecad8040-a276-4e85-bda9-015a708d291e"))
 	}
 	if snapshot != nil {
 		h.logAnnouncementAction(c, moderationlog.LogDeleteGlobalAnnouncement, moderationlog.LogDeleteUserAnnouncement, snapshot, map[string]any{

--- a/internal/api/announcements/handler_show.go
+++ b/internal/api/announcements/handler_show.go
@@ -32,12 +32,12 @@ func (h *Handler) Show(c echo.Context) error {
 	}
 	a, err := h.repo.FindByID(req.AnnouncementID)
 	if err != nil {
-		return c.JSON(http.StatusNotFound, apierr.Error("NO_SUCH_ANNOUNCEMENT", "No such announcement.", "e0ef2076-ee94-4ebc-a2c8-63bec9e7ab72"))
+		return c.JSON(http.StatusNotFound, apierr.Error("NO_SUCH_ANNOUNCEMENT", "No such announcement.", "b57b5e1d-4f49-404a-9edb-46b00268f121"))
 	}
 	if a.UserID != nil {
 		me := middleware.GetUser(c)
 		if me == nil || *a.UserID != me.ID {
-			return c.JSON(http.StatusNotFound, apierr.Error("NO_SUCH_ANNOUNCEMENT", "No such announcement.", "e0ef2076-ee94-4ebc-a2c8-63bec9e7ab72"))
+			return c.JSON(http.StatusNotFound, apierr.Error("NO_SUCH_ANNOUNCEMENT", "No such announcement.", "b57b5e1d-4f49-404a-9edb-46b00268f121"))
 		}
 	}
 	return c.JSON(http.StatusOK, packAnnouncement(a, h.idGen))

--- a/internal/api/auth/handler.go
+++ b/internal/api/auth/handler.go
@@ -49,7 +49,7 @@ func (h *Handler) SessionGenerate(c echo.Context) error {
 
 	app, err := h.repo.FindAppBySecret(req.AppSecret)
 	if err != nil {
-		return c.JSON(http.StatusNotFound, apierr.Error("NO_SUCH_APP", "No such app.", "c5628b5a-3c9e-4e3f-b765-44952b2bfb0e"))
+		return c.JSON(http.StatusNotFound, apierr.Error("NO_SUCH_APP", "No such app.", "92f93e63-428e-4f2f-a5a4-39e1407fe998"))
 	}
 
 	token := uuid.New().String()
@@ -81,7 +81,7 @@ func (h *Handler) SessionShow(c echo.Context) error {
 
 	session, err := h.repo.FindSessionByToken(req.Token)
 	if err != nil {
-		return c.JSON(http.StatusNotFound, apierr.Error("NO_SUCH_SESSION", "No such session.", "bd72c97d-eca4-4403-8269-7b9cc0b9a2c0"))
+		return c.JSON(http.StatusNotFound, apierr.Error("NO_SUCH_SESSION", "No such session.", "bd72c97d-eba7-4adb-a467-f171b8847250"))
 	}
 
 	return c.JSON(http.StatusOK, packSession(session))
@@ -99,7 +99,7 @@ func (h *Handler) Accept(c echo.Context) error {
 
 	session, err := h.repo.FindSessionByToken(req.Token)
 	if err != nil {
-		return c.JSON(http.StatusNotFound, apierr.Error("NO_SUCH_SESSION", "No such session.", "bd72c97d-eca4-4403-8269-7b9cc0b9a2c0"))
+		return c.JSON(http.StatusNotFound, apierr.Error("NO_SUCH_SESSION", "No such session.", "9c72d8de-391a-43c1-9d06-08d29efde8df"))
 	}
 
 	// アクセストークンが既に存在するか確認
@@ -143,12 +143,12 @@ func (h *Handler) SessionUserkey(c echo.Context) error {
 
 	app, err := h.repo.FindAppBySecret(req.AppSecret)
 	if err != nil {
-		return c.JSON(http.StatusNotFound, apierr.Error("NO_SUCH_APP", "No such app.", "c5628b5a-3c9e-4e3f-b765-44952b2bfb0e"))
+		return c.JSON(http.StatusNotFound, apierr.Error("NO_SUCH_APP", "No such app.", "fcab192a-2c5a-43b7-8ad8-9b7054d8d40d"))
 	}
 
 	session, err := h.repo.FindSessionByTokenAndAppID(req.Token, app.ID)
 	if err != nil {
-		return c.JSON(http.StatusNotFound, apierr.Error("NO_SUCH_SESSION", "No such session.", "bd72c97d-eca4-4403-8269-7b9cc0b9a2c0"))
+		return c.JSON(http.StatusNotFound, apierr.Error("NO_SUCH_SESSION", "No such session.", "5b5a1503-8bc8-4bd0-8054-dc189e8cdcb3"))
 	}
 
 	if session.UserID == nil {

--- a/internal/api/blocking/handler.go
+++ b/internal/api/blocking/handler.go
@@ -53,7 +53,7 @@ func (h *Handler) Create(c echo.Context) error {
 		case errors.Is(err, coreblocking.ErrSelfBlock):
 			return c.JSON(http.StatusBadRequest, apierr.Error("BLOCKEE_IS_YOURSELF", "You cannot block yourself.", "88b19138-f28d-42c0-8499-6a31bbd0fdc6"))
 		case errors.Is(err, coreblocking.ErrBlockeeNotFound):
-			return apierr.JSONNoSuchUser(c)
+			return c.JSON(http.StatusNotFound, apierr.Error("NO_SUCH_USER", "No such user.", "7cc4f851-e2f1-4621-9633-ec9e1d00c01e"))
 		case errors.Is(err, coreblocking.ErrAlreadyBlocking):
 			return c.JSON(http.StatusBadRequest, apierr.Error("ALREADY_BLOCKING", "You are already blocking that user.", "787fed64-acb9-464a-82eb-afbd745b9614"))
 		}

--- a/internal/api/channels/handler.go
+++ b/internal/api/channels/handler.go
@@ -223,7 +223,7 @@ func (h *Handler) Update(c echo.Context) error {
 		case errors.Is(err, corechannel.ErrChannelNotFound):
 			return notFound(c)
 		case errors.Is(err, corechannel.ErrAccessDenied):
-			return apierr.JSONAccessDenied(c)
+			return c.JSON(http.StatusForbidden, apierr.Error("ACCESS_DENIED", "Access denied.", "1fb7cb09-d46a-4fdf-b8df-057788cce513"))
 		case errors.Is(err, corechannel.ErrChannelNameRequired):
 			return apierr.JSONInvalidParam(c)
 		}

--- a/internal/api/chat/handler.go
+++ b/internal/api/chat/handler.go
@@ -302,13 +302,13 @@ func (h *Handler) AttachedChatMessages(c echo.Context) error {
 	}
 	file, err := h.fileRepo.FindByID(req.FileID)
 	if err != nil || file == nil {
-		return apierr.JSONNoSuchFile(c)
+		return c.JSON(http.StatusBadRequest, apierr.Error("NO_SUCH_FILE", "Some files are not found.", "485ce26d-f5d2-4313-9783-e689d131eafb"))
 	}
 	// owner-scope: moderator 以外は自分の file のみ参照可 (他人の private chat
 	// の添付を覗けないようにする)。
 	isMod := h.moderatorChecker != nil && h.moderatorChecker.IsModerator(user.ID)
 	if !isMod && (file.UserID == nil || *file.UserID != user.ID) {
-		return apierr.JSONNoSuchFile(c)
+		return c.JSON(http.StatusBadRequest, apierr.Error("NO_SUCH_FILE", "Some files are not found.", "485ce26d-f5d2-4313-9783-e689d131eafb"))
 	}
 	sinceID, untilID := id.NormalizeCursor(req.SinceID, req.UntilID, req.SinceDate, req.UntilDate)
 	msgs, err := h.repo.ListMessagesByFileID(req.FileID, untilID, sinceID, req.Limit)

--- a/internal/api/drive/handler.go
+++ b/internal/api/drive/handler.go
@@ -243,9 +243,9 @@ func (h *Handler) FilesCreate(c echo.Context) error {
 				"Cannot upload the file because it is an unallowed file type.",
 				"4becd248-7f2c-48c4-a9f0-75edc4f9a1ea"))
 		case errors.Is(err, coredrive.ErrMaxFileSizeExceeded):
-			return apierr.JSONMaxFileSizeExceeded(c)
+			return c.JSON(http.StatusBadRequest, apierr.Error("MAX_FILE_SIZE_EXCEEDED", "Max file size exceeded.", "b9d8c348-33f0-4673-b9a9-5d4da058977a"))
 		case errors.Is(err, coredrive.ErrNoFreeSpace):
-			return apierr.JSONNoFreeSpace(c)
+			return c.JSON(http.StatusBadRequest, apierr.Error("NO_FREE_SPACE", "No free space.", "d08dbc37-a6a9-463a-8c47-96c32ab5f064"))
 		}
 		return apierr.JSONInternalError(c)
 	}

--- a/internal/api/drive/handler.go
+++ b/internal/api/drive/handler.go
@@ -491,7 +491,7 @@ func mapFileError(c echo.Context, err error) error {
 	case errors.Is(err, coredrive.ErrFileNotFound):
 		return c.JSON(http.StatusNotFound, apierr.Error("NO_SUCH_FILE", "No such file.", "067bc436-2718-4795-b0fb-ecbe43949e31"))
 	case errors.Is(err, coredrive.ErrFolderNotFound):
-		return c.JSON(http.StatusNotFound, apierr.Error("NO_SUCH_FOLDER", "No such folder.", "ea8fb7a5-af77-4a08-b608-c0218176cd73"))
+		return c.JSON(http.StatusNotFound, apierr.Error("NO_SUCH_FOLDER", "No such folder.", "1069098f-c281-440f-b085-f9932edbe091"))
 	case errors.Is(err, coredrive.ErrAccessDenied):
 		return c.JSON(http.StatusForbidden, apierr.Error("ACCESS_DENIED", "Access denied.", "fe8d7103-0ea8-4ec3-814d-f8b401dc69e9"))
 	case errors.Is(err, coredrive.ErrCannotUnmarkSensitive):

--- a/internal/api/drive/handler_test.go
+++ b/internal/api/drive/handler_test.go
@@ -244,7 +244,7 @@ func TestFilesCreate_MaxFileSizeExceeded(t *testing.T) {
 	require.NoError(t, h.FilesCreate(c))
 	assert.Equal(t, http.StatusBadRequest, rec.Code)
 	assert.Contains(t, rec.Body.String(), "MAX_FILE_SIZE_EXCEEDED")
-	assert.Contains(t, rec.Body.String(), "f9e4e5f3-4df4-40b5-b400-f236945f7073")
+	assert.Contains(t, rec.Body.String(), "b9d8c348-33f0-4673-b9a9-5d4da058977a")
 }
 
 // driveCapacityMb 超過 (= 既存 usage + 新 file > capacity) は 400 NO_FREE_SPACE。
@@ -262,7 +262,7 @@ func TestFilesCreate_NoFreeSpace(t *testing.T) {
 	require.NoError(t, h.FilesCreate(c))
 	assert.Equal(t, http.StatusBadRequest, rec.Code)
 	assert.Contains(t, rec.Body.String(), "NO_FREE_SPACE")
-	assert.Contains(t, rec.Body.String(), "c6244ed2-a39a-4e1c-bf93-f0fbd7764fa6")
+	assert.Contains(t, rec.Body.String(), "d08dbc37-a6a9-463a-8c47-96c32ab5f064")
 }
 
 // --- FilesShow ---

--- a/internal/api/flash/handler.go
+++ b/internal/api/flash/handler.go
@@ -122,7 +122,7 @@ func (h *Handler) Update(c echo.Context) error {
 		case errors.Is(err, coreflash.ErrFlashNotFound):
 			return notFound(c)
 		case errors.Is(err, coreflash.ErrAccessDenied):
-			return apierr.JSONAccessDenied(c)
+			return c.JSON(http.StatusForbidden, apierr.Error("ACCESS_DENIED", "Access denied.", "08e60c88-5948-478e-a132-02ec701d67b2"))
 		case errors.Is(err, coreflash.ErrFlashTitleRequired):
 			return apierr.JSONInvalidParam(c)
 		}
@@ -148,7 +148,7 @@ func (h *Handler) Delete(c echo.Context) error {
 		case errors.Is(err, coreflash.ErrFlashNotFound):
 			return notFound(c)
 		case errors.Is(err, coreflash.ErrAccessDenied):
-			return apierr.JSONAccessDenied(c)
+			return c.JSON(http.StatusForbidden, apierr.Error("ACCESS_DENIED", "Access denied.", "1036ad7b-9f92-4fff-89c3-0e50dc941704"))
 		}
 		return apierr.JSONInternalError(c)
 	}

--- a/internal/api/following/relation.go
+++ b/internal/api/following/relation.go
@@ -25,7 +25,7 @@ func (h *Handler) Invalidate(c echo.Context) error {
 	}
 	if err := h.followingService.Unfollow(req.UserID, me.ID); err != nil {
 		if errors.Is(err, corefollowing.ErrNotFollowing) {
-			return c.JSON(http.StatusBadRequest, apierr.Error("NOT_FOLLOWING", "You are not followed by that user.", "5dbf82f5-c92b-40b1-87d1-6c8c0741fd09"))
+			return c.JSON(http.StatusBadRequest, apierr.Error("NOT_FOLLOWING", "You are not followed by that user.", "918faac3-074f-41ae-9c43-ed5d2946770d"))
 		}
 		return apierr.JSONInternalError(c)
 	}

--- a/internal/api/gallery/handler.go
+++ b/internal/api/gallery/handler.go
@@ -128,7 +128,7 @@ func (h *Handler) PostsShow(c echo.Context) error {
 	}
 	var post model.GalleryPost
 	if err := h.db.Preload("User").Where("id = ?", req.PostID).First(&post).Error; err != nil {
-		return c.JSON(http.StatusNotFound, apierr.Error("NO_SUCH_POST", "No such post.", "1137bf14-c27b-46e0-86d3-0cbbf8b0aca5"))
+		return c.JSON(http.StatusNotFound, apierr.Error("NO_SUCH_POST", "No such post.", "1137bf14-c5b0-4604-85bb-5b5371b1cd45"))
 	}
 	return c.JSON(http.StatusOK, h.packOne(&post))
 }
@@ -144,7 +144,7 @@ func (h *Handler) PostsDelete(c echo.Context) error {
 	}
 	result := h.db.Where("id = ? AND \"userId\" = ?", req.PostID, user.ID).Delete(&model.GalleryPost{})
 	if result.RowsAffected == 0 {
-		return c.JSON(http.StatusNotFound, apierr.Error("NO_SUCH_POST", "No such post.", "1137bf14-c27b-46e0-86d3-0cbbf8b0aca5"))
+		return c.JSON(http.StatusNotFound, apierr.Error("NO_SUCH_POST", "No such post.", "ae52f367-4bd7-4ecd-afc6-5672fff427f5"))
 	}
 	return c.NoContent(http.StatusNoContent)
 }
@@ -189,7 +189,7 @@ func (h *Handler) PostsLike(c echo.Context) error {
 		PostID: req.PostID,
 	}
 	if err := h.db.Create(like).Error; err != nil {
-		return c.JSON(http.StatusConflict, apierr.Error("ALREADY_LIKED", "Already liked.", "40e8fb37-7a93-4e2c-87fc-c1c25e4a68a1"))
+		return c.JSON(http.StatusConflict, apierr.Error("ALREADY_LIKED", "Already liked.", "40e9ed56-a59c-473a-bf3f-f289c54fb5a7"))
 	}
 	h.db.Model(&model.GalleryPost{}).Where("id = ?", req.PostID).UpdateColumn("\"likedCount\"", gorm.Expr("\"likedCount\" + 1"))
 	return c.NoContent(http.StatusNoContent)

--- a/internal/api/i/email_update.go
+++ b/internal/api/i/email_update.go
@@ -66,7 +66,7 @@ func (h *Handler) UpdateEmail(c echo.Context) error {
 	// を framework が 400 (= client error) に変換する (#885)。mk-go も
 	// drop-in 互換のため 400 に揃える (旧 mk-go は 403)。
 	if err := bcrypt.CompareHashAndPassword([]byte(*profile.Password), []byte(req.Password)); err != nil {
-		return c.JSON(http.StatusBadRequest, apierr.Error("INCORRECT_PASSWORD", "Incorrect password.", "e86c14a4-0da8-4571-8f36-8a2e9f9b3a00"))
+		return c.JSON(http.StatusBadRequest, apierr.Error("INCORRECT_PASSWORD", "Incorrect password.", "e54c1d7e-e7d6-4103-86b6-0a95069b4ad3"))
 	}
 
 	fields := map[string]any{
@@ -136,7 +136,7 @@ func (h *Handler) VerifyEmail(c echo.Context) error {
 
 	profile, err := h.userService.FindProfileByVerifyCode(req.Code)
 	if err != nil {
-		return c.JSON(http.StatusNotFound, apierr.Error("NO_SUCH_CODE", "No such code.", "1e53842e-b7f4-4e1c-8f1e-8d0a2d9b0c7e"))
+		return c.JSON(http.StatusNotFound, apierr.Error("NO_SUCH_CODE", "No such code.", "97c1f576-e4b8-4b8a-a6dc-9cb65e7f6f85"))
 	}
 
 	if verr := h.userService.UpdateProfileFields(profile.UserID, map[string]any{

--- a/internal/api/i/handler.go
+++ b/internal/api/i/handler.go
@@ -1284,7 +1284,7 @@ func (h *Handler) Pin(c echo.Context) error {
 	if err := h.userService.PinNote(me.ID, req.NoteID); err != nil {
 		switch {
 		case errors.Is(err, user.ErrNoteNotFound):
-			return apierr.JSONNoSuchNote(c)
+			return c.JSON(http.StatusNotFound, apierr.Error("NO_SUCH_NOTE", "No such note.", "56734f8b-3928-431e-bf80-6ff87df40cb3"))
 		case errors.Is(err, user.ErrAlreadyPinned):
 			return c.JSON(http.StatusBadRequest, apierr.Error("ALREADY_PINNED", "That note has already been pinned.", "8b18c2b7-68fe-4edb-9892-c0cbaeb6c913"))
 		case errors.Is(err, user.ErrPinLimitExceeded):
@@ -1308,7 +1308,7 @@ func (h *Handler) Unpin(c echo.Context) error {
 
 	if err := h.userService.UnpinNote(me.ID, req.NoteID); err != nil {
 		if errors.Is(err, user.ErrPinNotFound) {
-			return apierr.JSONNoSuchNote(c)
+			return c.JSON(http.StatusNotFound, apierr.Error("NO_SUCH_NOTE", "No such note.", "454170ce-9d63-4a43-9da1-ea10afe81e21"))
 		}
 		return apierr.JSONInternalError(c)
 	}

--- a/internal/api/i/handler.go
+++ b/internal/api/i/handler.go
@@ -1099,7 +1099,7 @@ func (h *Handler) Update(c echo.Context) error {
 	if err != nil {
 		switch {
 		case errors.Is(err, user.ErrUserNotFound):
-			return c.JSON(http.StatusNotFound, apierr.Error("NO_SUCH_USER", "No such user.", "4362f8dc-731f-4ad8-a694-be5a88922a24"))
+			return c.JSON(http.StatusNotFound, apierr.Error("NO_SUCH_USER", "No such user.", "fcd2eef9-a9b2-4c4f-8624-038099e90aa5"))
 		case errors.Is(err, user.ErrAvatarNotFound):
 			// upstream Misskey の NO_SUCH_AVATAR error UUID を流用 (frontend
 			// がコード固有の locale 表示をしているため一致が望ましい)。

--- a/internal/api/i/handler_2fa.go
+++ b/internal/api/i/handler_2fa.go
@@ -58,7 +58,7 @@ func (h *Handler) TwoFARegister(c echo.Context) error {
 		return c.JSON(http.StatusForbidden, apierr.InvalidToken())
 	}
 	if err := bcrypt.CompareHashAndPassword([]byte(*profile.Password), []byte(req.Password)); err != nil {
-		return c.JSON(http.StatusForbidden, apierr.Error("INCORRECT_PASSWORD", "Incorrect password.", "932c904e-9460-45b7-9ce6-7ed33be7eb2c"))
+		return c.JSON(http.StatusForbidden, apierr.Error("INCORRECT_PASSWORD", "Incorrect password.", "78d6c839-20c9-4c66-b90a-fc0542168b48"))
 	}
 
 	secret, uri, err := twofactor.GenerateSecret("Misskey", user.Username)
@@ -158,7 +158,7 @@ func (h *Handler) TwoFAUnregister(c echo.Context) error {
 		return c.JSON(http.StatusForbidden, apierr.InvalidToken())
 	}
 	if err := bcrypt.CompareHashAndPassword([]byte(*profile.Password), []byte(req.Password)); err != nil {
-		return c.JSON(http.StatusForbidden, apierr.Error("INCORRECT_PASSWORD", "Incorrect password.", "932c904e-9460-45b7-9ce6-7ed33be7eb2c"))
+		return c.JSON(http.StatusForbidden, apierr.Error("INCORRECT_PASSWORD", "Incorrect password.", "7add0395-9901-4098-82f9-4f67af65f775"))
 	}
 
 	_ = h.userService.UpdateProfileFields(user.ID, map[string]any{
@@ -429,7 +429,7 @@ func (h *Handler) TwoFARemoveKey(c echo.Context) error {
 		return c.JSON(http.StatusForbidden, apierr.InvalidToken())
 	}
 	if err := bcrypt.CompareHashAndPassword([]byte(*profile.Password), []byte(req.Password)); err != nil {
-		return c.JSON(http.StatusForbidden, apierr.Error("INCORRECT_PASSWORD", "Incorrect password.", "932c904e-9460-45b7-9ce6-7ed33be7eb2c"))
+		return c.JSON(http.StatusForbidden, apierr.Error("INCORRECT_PASSWORD", "Incorrect password.", "141c598d-a825-44c8-9173-cfb9d92be493"))
 	}
 
 	if err := h.securityKeyRepo.Delete(req.CredentialID, user.ID); err != nil {

--- a/internal/api/i/registry.go
+++ b/internal/api/i/registry.go
@@ -45,7 +45,7 @@ func (h *Handler) RegistryGetDetail(c echo.Context) error {
 	req.Scope = normalizeRegistryScope(req.Scope)
 	item, err := h.registryRepo.Get(u.ID, req.Key, req.Scope, req.Domain)
 	if err != nil {
-		return c.JSON(http.StatusNotFound, apierr.Error("NO_SUCH_KEY", "No such key.", "7f5e1e4a-1e2a-41b9-80e3-8a0d6e8aa8b1"))
+		return c.JSON(http.StatusNotFound, apierr.Error("NO_SUCH_KEY", "No such key.", "97a1e8e7-c0f7-47d2-957a-92e61256e01a"))
 	}
 	return c.JSON(http.StatusOK, map[string]any{
 		"updatedAt": item.UpdatedAt,

--- a/internal/api/invite/handler.go
+++ b/internal/api/invite/handler.go
@@ -160,7 +160,8 @@ func (h *Handler) Delete(c echo.Context) error {
 		return c.NoContent(http.StatusNoContent)
 	}
 	if ticket.CreatedByID == nil || *ticket.CreatedByID != user.ID {
-		return c.JSON(http.StatusForbidden, apierr.Error("ACCESS_DENIED", "Access denied.", apierr.UUIDAccessDenied))
+		// invite/delete は汎用 ACCESS_DENIED ではなく endpoint 固有 id を使う
+		return c.JSON(http.StatusForbidden, apierr.Error("ACCESS_DENIED", "Access denied.", "5eb8d909-2540-4970-90b8-dd6f86088121"))
 	}
 	if err := h.repo.Delete(req.InviteID); err != nil {
 		return apierr.JSONInternalError(c)

--- a/internal/api/mute/handler.go
+++ b/internal/api/mute/handler.go
@@ -58,7 +58,7 @@ func (h *Handler) Create(c echo.Context) error {
 		case errors.Is(err, coremuting.ErrSelfMute):
 			return c.JSON(http.StatusBadRequest, apierr.Error("MUTEE_IS_YOURSELF", "You cannot mute yourself.", "a4619cb2-5f23-484b-9301-94c903074e10"))
 		case errors.Is(err, coremuting.ErrMuteeNotFound):
-			return apierr.JSONNoSuchUser(c)
+			return c.JSON(http.StatusNotFound, apierr.Error("NO_SUCH_USER", "No such user.", "6fef56f3-e765-4957-88e5-c6f65329b8a5"))
 		case errors.Is(err, coremuting.ErrAlreadyMuting):
 			return c.JSON(http.StatusBadRequest, apierr.Error("ALREADY_MUTING", "You are already muting that user.", "7e7359cb-160c-4956-b08f-4d1c653cd007"))
 		}

--- a/internal/api/notes/handler.go
+++ b/internal/api/notes/handler.go
@@ -398,7 +398,8 @@ func (h *Handler) Delete(c echo.Context) error {
 	if err := h.deleteService.Delete(user, req.NoteID); err != nil {
 		switch {
 		case errors.Is(err, note.ErrNoteNotFound):
-			return c.JSON(http.StatusNotFound, apierr.NoSuchNote())
+			// notes/delete は汎用 UUIDNoSuchNote ではなく endpoint 固有 id を使う
+			return c.JSON(http.StatusNotFound, apierr.Error("NO_SUCH_NOTE", "No such note.", "490be23f-8c1f-4796-819f-94cb4f9d1630"))
 		case errors.Is(err, note.ErrNoteAccessDenied):
 			return c.JSON(http.StatusForbidden, apierr.Error("ACCESS_DENIED", "You are not the author of this note.", "fe8d7103-0ea8-4ec3-814d-f8b401dc69e9"))
 		default:

--- a/internal/api/notes/handler.go
+++ b/internal/api/notes/handler.go
@@ -576,7 +576,7 @@ func (h *Handler) Conversation(c echo.Context) error {
 	notes, err := h.queryService.Conversation(viewer, req.NoteID, req.Limit)
 	if err != nil {
 		// 現状QueryService.ConversationはErrNoteNotFound以外を返さない
-		return apierr.JSONNoSuchNote(c)
+		return c.JSON(http.StatusNotFound, apierr.Error("NO_SUCH_NOTE", "No such note.", "e1035875-9551-45ec-afa8-1ded1fcb53c8"))
 	}
 	return c.JSON(http.StatusOK, h.packMany(c.Request().Context(), notes, viewer))
 }

--- a/internal/api/notes/handler_drafts.go
+++ b/internal/api/notes/handler_drafts.go
@@ -74,7 +74,7 @@ func (h *Handler) DraftsCreate(c echo.Context) error {
 		// 互換の \`TOO_MANY_SCHEDULED_NOTES\` で reject し、frontend には
 		// 上限到達と同じ UX を返す (#1045 Phase 2-C)。
 		if h.scheduledNoteEnqueuer != nil && !h.scheduledNoteEnqueuer.SupportsScheduledNote() {
-			return apierr.JSONTooManyScheduledNotes(c)
+			return c.JSON(http.StatusBadRequest, apierr.Error("TOO_MANY_SCHEDULED_NOTES", "You cannot create scheduled notes any more.", "22ae69eb-09e3-4541-a850-773cfa45e693"))
 		}
 		if scheduledAt == nil {
 			// Misskey は SCHEDULED_AT_* に create / update で別 id を割り当てるため endpoint 固有 id を inline で返す
@@ -106,7 +106,7 @@ func (h *Handler) DraftsCreate(c echo.Context) error {
 					return apierr.JSONInternalError(c)
 				}
 				if count >= int64(limit) {
-					return apierr.JSONTooManyScheduledNotes(c)
+					return c.JSON(http.StatusBadRequest, apierr.Error("TOO_MANY_SCHEDULED_NOTES", "You cannot create scheduled notes any more.", "22ae69eb-09e3-4541-a850-773cfa45e693"))
 				}
 			}
 		}
@@ -195,7 +195,7 @@ func (h *Handler) DraftsUpdate(c echo.Context) error {
 		// 新しく schedule する / 既に scheduled だった draft の scheduledAt が
 		// 変わった場合は validation + capability check が必要。
 		if h.scheduledNoteEnqueuer != nil && !h.scheduledNoteEnqueuer.SupportsScheduledNote() {
-			return apierr.JSONTooManyScheduledNotes(c)
+			return c.JSON(http.StatusBadRequest, apierr.Error("TOO_MANY_SCHEDULED_NOTES", "You cannot create scheduled notes any more.", "02f5df79-08ae-4a33-8524-f1503c8f6212"))
 		}
 		if draft.ScheduledAt == nil {
 			// notes/drafts/update は create とは別の SCHEDULED_AT_* id を持つ

--- a/internal/api/notes/handler_drafts.go
+++ b/internal/api/notes/handler_drafts.go
@@ -77,10 +77,11 @@ func (h *Handler) DraftsCreate(c echo.Context) error {
 			return apierr.JSONTooManyScheduledNotes(c)
 		}
 		if scheduledAt == nil {
-			return c.JSON(http.StatusBadRequest, apierr.ScheduledAtRequired())
+			// Misskey は SCHEDULED_AT_* に create / update で別 id を割り当てるため endpoint 固有 id を inline で返す
+			return c.JSON(http.StatusBadRequest, apierr.Error("SCHEDULED_AT_REQUIRED", "scheduledAt is required when isActuallyScheduled is true.", "15e28a55-e74c-4d65-89b7-8880cdaaa87d"))
 		}
 		if !scheduledAt.After(now) {
-			return c.JSON(http.StatusBadRequest, apierr.ScheduledAtMustBeInFuture())
+			return c.JSON(http.StatusBadRequest, apierr.Error("SCHEDULED_AT_MUST_BE_IN_FUTURE", "scheduledAt must be in the future.", "e4bed6c9-017e-4934-aed0-01c22cc60ec1"))
 		}
 	}
 	// noteDraftLimit role policy gate (#1029)。policyProvider は #1026 で
@@ -197,10 +198,11 @@ func (h *Handler) DraftsUpdate(c echo.Context) error {
 			return apierr.JSONTooManyScheduledNotes(c)
 		}
 		if draft.ScheduledAt == nil {
-			return c.JSON(http.StatusBadRequest, apierr.ScheduledAtRequired())
+			// notes/drafts/update は create とは別の SCHEDULED_AT_* id を持つ
+			return c.JSON(http.StatusBadRequest, apierr.Error("SCHEDULED_AT_REQUIRED", "scheduledAt is required when isActuallyScheduled is true.", "fe9737d5-cc41-498c-af9d-149207307530"))
 		}
 		if !draft.ScheduledAt.After(now) {
-			return c.JSON(http.StatusBadRequest, apierr.ScheduledAtMustBeInFuture())
+			return c.JSON(http.StatusBadRequest, apierr.Error("SCHEDULED_AT_MUST_BE_IN_FUTURE", "scheduledAt must be in the future.", "ed1a6673-d0d1-4364-aaae-9bf3f139cbc5"))
 		}
 	}
 	_ = h.draftRepo.Update(draft)

--- a/internal/api/notes/handler_drafts_test.go
+++ b/internal/api/notes/handler_drafts_test.go
@@ -408,7 +408,7 @@ func TestDraftsCreate_ScheduledNoteLimitExceeded(t *testing.T) {
 	rec := postDraft(h.DraftsCreate, body, &model.User{ID: "u1"})
 	assert.Equal(t, http.StatusBadRequest, rec.Code)
 	assert.Contains(t, rec.Body.String(), "TOO_MANY_SCHEDULED_NOTES")
-	assert.Contains(t, rec.Body.String(), "c3275f19-4558-4c59-83e1-4f684b5fab66")
+	assert.Contains(t, rec.Body.String(), "22ae69eb-09e3-4541-a850-773cfa45e693")
 }
 
 // isActuallyScheduled=false で scheduledAt が指定されても enqueue は走らない

--- a/internal/api/notes/handler_drafts_test.go
+++ b/internal/api/notes/handler_drafts_test.go
@@ -384,7 +384,7 @@ func TestDraftsCreate_ScheduledAtRequired(t *testing.T) {
 	rec := postDraft(h.DraftsCreate, `{"text":"hi","isActuallyScheduled":true}`, &model.User{ID: "u1"})
 	assert.Equal(t, http.StatusBadRequest, rec.Code)
 	assert.Contains(t, rec.Body.String(), "SCHEDULED_AT_REQUIRED")
-	assert.Contains(t, rec.Body.String(), "94a89a43-3591-400a-9c17-dd166e71fdfa")
+	assert.Contains(t, rec.Body.String(), "15e28a55-e74c-4d65-89b7-8880cdaaa87d")
 }
 
 func TestDraftsCreate_ScheduledAtMustBeInFuture(t *testing.T) {
@@ -394,7 +394,7 @@ func TestDraftsCreate_ScheduledAtMustBeInFuture(t *testing.T) {
 	rec := postDraft(h.DraftsCreate, body, &model.User{ID: "u1"})
 	assert.Equal(t, http.StatusBadRequest, rec.Code)
 	assert.Contains(t, rec.Body.String(), "SCHEDULED_AT_MUST_BE_IN_FUTURE")
-	assert.Contains(t, rec.Body.String(), "b34d0c1b-996f-4e34-a428-c636d98df457")
+	assert.Contains(t, rec.Body.String(), "e4bed6c9-017e-4934-aed0-01c22cc60ec1")
 }
 
 func TestDraftsCreate_ScheduledNoteLimitExceeded(t *testing.T) {

--- a/internal/api/notes/handler_extra.go
+++ b/internal/api/notes/handler_extra.go
@@ -28,7 +28,7 @@ func (h *Handler) FavoritesCreate(c echo.Context) error {
 		return c.JSON(http.StatusBadRequest, apierr.Error("INVALID_PARAM", "noteId is required.", "3d81ceae-475f-4600-b2a8-2bc116157532"))
 	}
 	if _, err := h.noteRepo.FindByID(req.NoteID); err != nil {
-		return apierr.JSONNoSuchNote(c)
+		return c.JSON(http.StatusNotFound, apierr.Error("NO_SUCH_NOTE", "No such note.", "6dd26674-e060-4816-909a-45ba3f4da458"))
 	}
 	if h.favoriteRepo == nil {
 		return c.JSON(http.StatusInternalServerError, apierr.Error("INTERNAL_ERROR", "Internal error.", "5d37dbcb-891e-41ca-a3d6-e690c97775ac"))
@@ -109,7 +109,7 @@ func (h *Handler) Unrenote(c echo.Context) error {
 	// renoteId が指定ノートの自分のノートを探して削除
 	renote, err := h.noteRepo.FindRenoteByUser(user.ID, req.NoteID)
 	if err != nil {
-		return apierr.JSONNoSuchNote(c)
+		return c.JSON(http.StatusNotFound, apierr.Error("NO_SUCH_NOTE", "No such note.", "efd4a259-2442-496b-8dd7-b255aa1a160f"))
 	}
 	if err := h.deleteService.Delete(user, renote.ID); err != nil {
 		return c.JSON(http.StatusInternalServerError, apierr.Error("INTERNAL_ERROR", "Internal error.", "5d37dbcb-891e-41ca-a3d6-e690c97775ac"))
@@ -258,7 +258,7 @@ func (h *Handler) Translate(c echo.Context) error {
 
 	n, err := h.noteRepo.FindByID(req.NoteID)
 	if err != nil {
-		return apierr.JSONNoSuchNote(c)
+		return c.JSON(http.StatusNotFound, apierr.Error("NO_SUCH_NOTE", "No such note.", "bea9b03f-36e0-49c5-a4db-627a029f8971"))
 	}
 
 	if n.Text == nil || *n.Text == "" {

--- a/internal/api/notes/handler_extra.go
+++ b/internal/api/notes/handler_extra.go
@@ -35,7 +35,7 @@ func (h *Handler) FavoritesCreate(c echo.Context) error {
 	}
 	exists, _ := h.favoriteRepo.Exists(user.ID, req.NoteID)
 	if exists {
-		return c.JSON(http.StatusConflict, apierr.Error("ALREADY_FAVORITED", "Already favorited.", "a402c12b-34dd-41d2-97d8-4d2c5b7e4645"))
+		return c.JSON(http.StatusConflict, apierr.Error("ALREADY_FAVORITED", "Already favorited.", "a402c12b-34dd-41d2-97d8-4d2ffd96a1a6"))
 	}
 	now := time.Now()
 	fav := &model.NoteFavorite{
@@ -181,10 +181,10 @@ func (h *Handler) UserListTimeline(c echo.Context) error {
 	if h.userListRepo != nil {
 		list, err := h.userListRepo.FindByID(req.ListID)
 		if err != nil {
-			return c.JSON(http.StatusNotFound, apierr.Error("NO_SUCH_LIST", "No such list.", "7bc05c21-1d7a-41ae-88f1-d8571571e198"))
+			return c.JSON(http.StatusNotFound, apierr.Error("NO_SUCH_LIST", "No such list.", "8fb1fbd5-e476-4c37-9fb0-43d55b63a2ff"))
 		}
 		if list.UserID != me.ID {
-			return c.JSON(http.StatusNotFound, apierr.Error("NO_SUCH_LIST", "No such list.", "7bc05c21-1d7a-41ae-88f1-d8571571e198"))
+			return c.JSON(http.StatusNotFound, apierr.Error("NO_SUCH_LIST", "No such list.", "8fb1fbd5-e476-4c37-9fb0-43d55b63a2ff"))
 		}
 	}
 	// sinceDate / untilDate を aidx prefix に正規化 (#1166)。
@@ -253,7 +253,7 @@ func (h *Handler) Translate(c echo.Context) error {
 	}
 
 	if h.translator == nil {
-		return c.JSON(http.StatusServiceUnavailable, apierr.Error("UNAVAILABLE", "Translator is not configured.", "bef6e895-c05f-4572-96ab-58f5ae1e2e28"))
+		return c.JSON(http.StatusServiceUnavailable, apierr.Error("UNAVAILABLE", "Translator is not configured.", "50a70314-2d8a-431b-b433-efa5cc56444c"))
 	}
 
 	n, err := h.noteRepo.FindByID(req.NoteID)

--- a/internal/api/notes/polls_handler.go
+++ b/internal/api/notes/polls_handler.go
@@ -27,7 +27,7 @@ func (h *Handler) PollsVote(c echo.Context) error {
 	if err := h.pollService.Vote(user, req.NoteID, *req.Choice); err != nil {
 		switch {
 		case errors.Is(err, poll.ErrNoteNotFound), errors.Is(err, poll.ErrNoPoll):
-			return apierr.JSONNoSuchNote(c)
+			return c.JSON(http.StatusNotFound, apierr.Error("NO_SUCH_NOTE", "No such note.", "ecafbd2e-c283-4d6d-aecb-1a0a33b75396"))
 		case errors.Is(err, poll.ErrNoteNotVisible):
 			return c.JSON(http.StatusForbidden, apierr.Error("ACCESS_DENIED", "You can not see this note.", "fe8d7103-0ea8-4ec3-814d-f8b401dc69e9"))
 		case errors.Is(err, poll.ErrInvalidChoice):

--- a/internal/api/notes/reactions_handler.go
+++ b/internal/api/notes/reactions_handler.go
@@ -32,7 +32,7 @@ func (h *Handler) ReactionsCreate(c echo.Context) error {
 	if err != nil {
 		switch {
 		case errors.Is(err, reaction.ErrNoteNotFound):
-			return apierr.JSONNoSuchNote(c)
+			return c.JSON(http.StatusNotFound, apierr.Error("NO_SUCH_NOTE", "No such note.", "033d0620-5bfe-4027-965d-980b0c85a3ea"))
 		case errors.Is(err, reaction.ErrNoteNotVisible):
 			return c.JSON(http.StatusForbidden, apierr.Error("ACCESS_DENIED", "You can not see this note.", "fe8d7103-0ea8-4ec3-814d-f8b401dc69e9"))
 		case errors.Is(err, reaction.ErrAlreadyReacted):
@@ -64,7 +64,7 @@ func (h *Handler) ReactionsDelete(c echo.Context) error {
 	if err := h.reactionService.Delete(user, req.NoteID); err != nil {
 		switch {
 		case errors.Is(err, reaction.ErrNoteNotFound):
-			return apierr.JSONNoSuchNote(c)
+			return c.JSON(http.StatusNotFound, apierr.Error("NO_SUCH_NOTE", "No such note.", "764d9fce-f9f2-4a0e-92b1-6ceac9a7ad37"))
 		case errors.Is(err, reaction.ErrReactionNotFound):
 			return c.JSON(http.StatusNotFound, apierr.Error("NOT_REACTED", "You are not reacting to that note.", "92f4426d-4196-4125-aa5b-02943e2ec8fc"))
 		}
@@ -104,7 +104,7 @@ func (h *Handler) Reactions(c echo.Context) error {
 	if err != nil {
 		switch {
 		case errors.Is(err, reaction.ErrNoteNotFound), errors.Is(err, reaction.ErrNoteNotVisible):
-			return apierr.JSONNoSuchNote(c)
+			return c.JSON(http.StatusNotFound, apierr.Error("NO_SUCH_NOTE", "No such note.", "263fff3d-d0e1-4af4-bea7-8408059b451a"))
 		}
 		return apierr.JSONInternalError(c)
 	}

--- a/internal/api/pages/handler.go
+++ b/internal/api/pages/handler.go
@@ -232,7 +232,7 @@ func (h *Handler) Update(c echo.Context) error {
 		case errors.Is(err, corepage.ErrPageNotFound):
 			return notFound(c)
 		case errors.Is(err, corepage.ErrAccessDenied):
-			return apierr.JSONAccessDenied(c)
+			return c.JSON(http.StatusForbidden, apierr.Error("ACCESS_DENIED", "Access denied.", "3c15cd52-3b4b-4274-967d-6456fc4f792b"))
 		case errors.Is(err, corepage.ErrPageNameRequired),
 			errors.Is(err, corepage.ErrPageTitleRequired):
 			return apierr.JSONInvalidParam(c)
@@ -261,7 +261,7 @@ func (h *Handler) Delete(c echo.Context) error {
 		case errors.Is(err, corepage.ErrPageNotFound):
 			return notFound(c)
 		case errors.Is(err, corepage.ErrAccessDenied):
-			return apierr.JSONAccessDenied(c)
+			return c.JSON(http.StatusForbidden, apierr.Error("ACCESS_DENIED", "Access denied.", "8b741b3e-2c22-44b3-a15f-29949aa1601e"))
 		}
 		return apierr.JSONInternalError(c)
 	}

--- a/internal/api/renotemute/handler.go
+++ b/internal/api/renotemute/handler.go
@@ -49,7 +49,7 @@ func (h *Handler) Create(c echo.Context) error {
 		case errors.Is(err, coremuting.ErrMuteeNotFound):
 			return apierr.JSONNoSuchUser(c)
 		case errors.Is(err, coremuting.ErrAlreadyMuting):
-			return c.JSON(http.StatusBadRequest, apierr.Error("ALREADY_MUTING", "You are already muting that user.", "ccfecbe4-1f1c-4fc2-8bdb-9f3672ab7191"))
+			return c.JSON(http.StatusBadRequest, apierr.Error("ALREADY_MUTING", "You are already muting that user.", "ccfecbe4-1f1c-4fc2-8a3d-c3ffee61cb7b"))
 		}
 		return apierr.JSONInternalError(c)
 	}
@@ -66,9 +66,9 @@ func (h *Handler) Delete(c echo.Context) error {
 	if err := h.svc.Unmute(user.ID, req.UserID); err != nil {
 		switch {
 		case errors.Is(err, coremuting.ErrSelfMute):
-			return c.JSON(http.StatusBadRequest, apierr.Error("MUTEE_IS_YOURSELF", "You cannot unmute yourself.", "afa929cc-95f0-4e30-92c1-b4b5e5e0f38e"))
+			return c.JSON(http.StatusBadRequest, apierr.Error("MUTEE_IS_YOURSELF", "You cannot unmute yourself.", "619b1314-0850-4597-a242-e245f3da42af"))
 		case errors.Is(err, coremuting.ErrNotMuting):
-			return c.JSON(http.StatusBadRequest, apierr.Error("NOT_MUTING", "You are not muting that user.", "5467d020-daa9-4553-81e1-135c0c35a96d"))
+			return c.JSON(http.StatusBadRequest, apierr.Error("NOT_MUTING", "You are not muting that user.", "2e4ef874-8bf0-4b4b-b069-4598f6d05817"))
 		}
 		return apierr.JSONInternalError(c)
 	}

--- a/internal/api/renotemute/handler.go
+++ b/internal/api/renotemute/handler.go
@@ -47,7 +47,7 @@ func (h *Handler) Create(c echo.Context) error {
 		case errors.Is(err, coremuting.ErrSelfMute):
 			return c.JSON(http.StatusBadRequest, apierr.Error("MUTEE_IS_YOURSELF", "You cannot mute yourself.", "37285718-52f7-4aef-b7de-c38b8e8a8420"))
 		case errors.Is(err, coremuting.ErrMuteeNotFound):
-			return apierr.JSONNoSuchUser(c)
+			return c.JSON(http.StatusNotFound, apierr.Error("NO_SUCH_USER", "No such user.", "5e0a5dff-1e94-4202-87ae-4d9c89eb2271"))
 		case errors.Is(err, coremuting.ErrAlreadyMuting):
 			return c.JSON(http.StatusBadRequest, apierr.Error("ALREADY_MUTING", "You are already muting that user.", "ccfecbe4-1f1c-4fc2-8a3d-c3ffee61cb7b"))
 		}

--- a/internal/api/roles/handler.go
+++ b/internal/api/roles/handler.go
@@ -119,7 +119,7 @@ func (h *Handler) Show(c echo.Context) error {
 	}
 	r, err := h.roleService.Show(req.RoleID)
 	if err != nil || !r.IsPublic {
-		return c.JSON(http.StatusNotFound, apierr.Error("NO_SUCH_ROLE", "No such role.", "07dc7d34-c0d8-458b-9c04-4b18399b1f46"))
+		return c.JSON(http.StatusNotFound, apierr.Error("NO_SUCH_ROLE", "No such role.", "de5502bf-009a-4639-86c1-fec349e46dcb"))
 	}
 	return c.JSON(http.StatusOK, h.packRole(r))
 }
@@ -133,7 +133,7 @@ func (h *Handler) Users(c echo.Context) error {
 		return c.JSON(http.StatusBadRequest, apierr.Error("INVALID_PARAM", "roleId is required.", "3d81ceae-475f-4600-b2a8-2bc116157532"))
 	}
 	if _, err := h.roleService.Show(req.RoleID); err != nil {
-		return c.JSON(http.StatusNotFound, apierr.Error("NO_SUCH_ROLE", "No such role.", "07dc7d34-c0d8-458b-9c04-4b18399b1f46"))
+		return c.JSON(http.StatusNotFound, apierr.Error("NO_SUCH_ROLE", "No such role.", "30aaaee3-4792-48dc-ab0d-cf501a575ac5"))
 	}
 	return c.JSON(http.StatusOK, []any{})
 }
@@ -154,10 +154,10 @@ func (h *Handler) Notes(c echo.Context) error {
 
 	r, err := h.roleService.Show(req.RoleID)
 	if err != nil {
-		return c.JSON(http.StatusNotFound, apierr.Error("NO_SUCH_ROLE", "No such role.", "07dc7d34-c0d8-458b-9c04-4b18399b1f46"))
+		return c.JSON(http.StatusNotFound, apierr.Error("NO_SUCH_ROLE", "No such role.", "eb70323a-df61-4dd4-ad90-89c83c7cf26e"))
 	}
 	if !r.IsPublic {
-		return c.JSON(http.StatusNotFound, apierr.Error("NO_SUCH_ROLE", "No such role.", "07dc7d34-c0d8-458b-9c04-4b18399b1f46"))
+		return c.JSON(http.StatusNotFound, apierr.Error("NO_SUCH_ROLE", "No such role.", "eb70323a-df61-4dd4-ad90-89c83c7cf26e"))
 	}
 
 	if h.notesQuery == nil {

--- a/internal/api/userlists/handler.go
+++ b/internal/api/userlists/handler.go
@@ -157,7 +157,7 @@ func (h *Handler) Push(c echo.Context) error {
 	}
 	list, err := h.repo.FindByID(req.ListID)
 	if err != nil {
-		return c.JSON(http.StatusNotFound, apierr.Error("NO_SUCH_LIST", "No such list.", "7bc05c21-1d7a-41ae-88f1-66820f4dc686"))
+		return c.JSON(http.StatusNotFound, apierr.Error("NO_SUCH_LIST", "No such list.", "2214501d-ac96-4049-b717-91e42272a711"))
 	}
 	// userEachUserListsLimit role policy gate (#1029)。list owner の policy
 	// で評価する (upstream は owner = me 経路、mk-go も owner.UserID と me 一致

--- a/internal/api/users/handler.go
+++ b/internal/api/users/handler.go
@@ -554,7 +554,7 @@ func (h *Handler) Notes(c echo.Context) error {
 	}
 
 	if _, err := h.userService.ShowByID(req.UserID); err != nil {
-		return apierr.JSONNoSuchUser(c)
+		return c.JSON(http.StatusNotFound, apierr.Error("NO_SUCH_USER", "No such user.", "27e494ba-2ac2-48e8-893b-10d4d8c2387b"))
 	}
 
 	// upstream paramDef のデフォルトに合わせる (= withFiles=false /

--- a/internal/api/users/recommendation.go
+++ b/internal/api/users/recommendation.go
@@ -24,7 +24,7 @@ func (h *Handler) GetFrequentlyRepliedUsers(c echo.Context) error {
 	}
 	clampListLimit(&req.Limit)
 	if _, err := h.userService.ShowByID(req.UserID); err != nil {
-		return apierr.JSONNoSuchUser(c)
+		return c.JSON(http.StatusNotFound, apierr.Error("NO_SUCH_USER", "No such user.", "e6965129-7b2a-40a4-bae2-cd84cd434822"))
 	}
 	rows, err := h.noteRepo.CountReplyTargets(req.UserID, req.Limit)
 	if err != nil {

--- a/internal/api/webhooks/handler.go
+++ b/internal/api/webhooks/handler.go
@@ -167,7 +167,7 @@ func (h *Handler) Show(c echo.Context) error {
 
 	w, err := h.repo.FindByIDAndUserID(req.WebhookID, user.ID)
 	if err != nil {
-		return c.JSON(http.StatusNotFound, apierr.Error("NO_SUCH_WEBHOOK", "No such webhook.", "50f614d9-3e73-4e43-8345-2e1e25012b7a"))
+		return c.JSON(http.StatusNotFound, apierr.Error("NO_SUCH_WEBHOOK", "No such webhook.", "50f614d9-3047-4f7e-90d8-ad6b2d5fb098"))
 	}
 
 	return c.JSON(http.StatusOK, packWebhook(w))
@@ -193,7 +193,7 @@ func (h *Handler) Update(c echo.Context) error {
 
 	w, err := h.repo.FindByIDAndUserID(req.WebhookID, user.ID)
 	if err != nil {
-		return c.JSON(http.StatusNotFound, apierr.Error("NO_SUCH_WEBHOOK", "No such webhook.", "50f614d9-3e73-4e43-8345-2e1e25012b7a"))
+		return c.JSON(http.StatusNotFound, apierr.Error("NO_SUCH_WEBHOOK", "No such webhook.", "fb0fea69-da18-45b1-828d-bd4fd1612518"))
 	}
 
 	if req.Name != "" {
@@ -233,7 +233,7 @@ func (h *Handler) Delete(c echo.Context) error {
 	}
 
 	if _, err := h.repo.FindByIDAndUserID(req.WebhookID, user.ID); err != nil {
-		return c.JSON(http.StatusNotFound, apierr.Error("NO_SUCH_WEBHOOK", "No such webhook.", "50f614d9-3e73-4e43-8345-2e1e25012b7a"))
+		return c.JSON(http.StatusNotFound, apierr.Error("NO_SUCH_WEBHOOK", "No such webhook.", "bae73e5a-5522-4965-ae19-3a8688e71d82"))
 	}
 
 	if err := h.repo.Delete(req.WebhookID, user.ID); err != nil {
@@ -265,7 +265,7 @@ func (h *Handler) Test(c echo.Context) error {
 
 	webhook, err := h.repo.FindByIDAndUserID(req.WebhookID, user.ID)
 	if err != nil {
-		return c.JSON(http.StatusNotFound, apierr.Error("NO_SUCH_WEBHOOK", "No such webhook.", "50f614d9-3e73-4e43-8345-2e1e25012b7a"))
+		return c.JSON(http.StatusNotFound, apierr.Error("NO_SUCH_WEBHOOK", "No such webhook.", "0c52149c-e913-18f8-5dc7-74870bfe0cf9"))
 	}
 
 	if h.dispatcher != nil {

--- a/internal/entitycompat/error_ids_test.go
+++ b/internal/entitycompat/error_ids_test.go
@@ -1,0 +1,276 @@
+package entitycompat
+
+import (
+	_ "embed"
+	"encoding/json"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"regexp"
+	"sort"
+	"strings"
+	"testing"
+)
+
+// embeddedErrorIDsJSON is the committed golden per-endpoint error-id snapshot
+// (endpoint path -> code -> UUID), extracted from Misskey's meta.errors by
+// `go run ./tools/erroriddiff`. It is embedded so the gate runs without the
+// third_party submodule present (CI does not check it out).
+//
+//go:embed testdata/golden_error_ids.json
+var embeddedErrorIDsJSON []byte
+
+// errorIDExcludedPrefixes are endpoint families whose error ids are NOT gated
+// against vanilla Misskey: mk-go's reversi/* and chat/* are derived from
+// yojo-art/cherrypick (federated reversi / chat extensions) and legitimately
+// carry cherrypick error ids rather than vanilla ones.
+var errorIDExcludedPrefixes = []string{"reversi/", "chat/"}
+
+// validUUID matches a well-formed lowercase UUID. Golden ids that fail this are
+// skipped: a few upstream meta.errors entries carry malformed ids (e.g. a
+// leading space in sw/update-registration, or a non-hex character in
+// i/2fa/update-key). Those are upstream typos with no faithful target, so the
+// gate cannot meaningfully align to them.
+var validUUID = regexp.MustCompile(`^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$`)
+
+// TestErrorIDDrift is the static "error-id gate". It scans every mk-go API
+// handler's emitted error (code, id) — inline literals, UUID-constant
+// references, and apierr helper calls — resolves each handler method to its
+// route via router.go, and checks the emitted id against the per-endpoint
+// golden extracted from Misskey. A handler that emits a code Misskey also
+// defines for that endpoint must use Misskey's exact id, otherwise drop-in
+// clients that branch on error.id misclassify the error.
+//
+// Only confidently-resolved cases are gated: an emission is checked when its
+// route resolves to an endpoint, the golden defines that code for the endpoint,
+// and the golden id is a well-formed UUID. mk-go-only codes and unresolved
+// routes are not flagged (they are not drift against the upstream contract).
+func TestErrorIDDrift(t *testing.T) {
+	root := repoRoot(t)
+
+	var golden map[string]map[string]string
+	if err := json.Unmarshal(embeddedErrorIDsJSON, &golden); err != nil {
+		t.Fatalf("parse golden_error_ids.json: %v", err)
+	}
+
+	routes := parseRoutes(t, filepath.Join(root, "internal/server/router.go"))
+	helpers, consts := parseApierr(t, filepath.Join(root, "internal/api/apierr/errors.go"))
+
+	type drift struct{ endpoint, code, got, want string }
+	var drifts []drift
+
+	apiDir := filepath.Join(root, "internal/api")
+	err := filepath.WalkDir(apiDir, func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if d.IsDir() || !strings.HasSuffix(path, ".go") || strings.HasSuffix(path, "_test.go") {
+			return nil
+		}
+		pkg := filepath.Base(filepath.Dir(path))
+		src, err := os.ReadFile(path)
+		if err != nil {
+			return err
+		}
+		for _, em := range scanEmissions(string(src), helpers, consts) {
+			for _, route := range routes[pkg+"\x00"+em.fn] {
+				ep := strings.TrimPrefix(route, "/")
+				if excludedEndpoint(ep) {
+					continue
+				}
+				want, ok := golden[ep][em.code]
+				if !ok || !validUUID.MatchString(want) {
+					continue
+				}
+				if em.uuid != want {
+					drifts = append(drifts, drift{ep, em.code, em.uuid, want})
+				}
+			}
+		}
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("walk api dir: %v", err)
+	}
+
+	if len(drifts) > 0 {
+		sort.Slice(drifts, func(i, j int) bool {
+			if drifts[i].endpoint != drifts[j].endpoint {
+				return drifts[i].endpoint < drifts[j].endpoint
+			}
+			return drifts[i].code < drifts[j].code
+		})
+		var b strings.Builder
+		b.WriteString("error-id drift: handler emits an id that differs from Misskey's per-endpoint id.\n")
+		b.WriteString("Align the handler to the upstream id (or exclude the endpoint if it is cherrypick-derived).\n")
+		for _, d := range drifts {
+			b.WriteString("  " + d.endpoint + " " + d.code + ": got " + d.got + " want " + d.want + "\n")
+		}
+		t.Fatal(b.String())
+	}
+}
+
+// emission is one error response a handler emits: the enclosing method name,
+// the error code, and the resolved UUID.
+type emission struct {
+	fn   string
+	code string
+	uuid string
+}
+
+var (
+	// funcDeclRe matches a method declaration `func (recv T) Name(`.
+	funcDeclRe = regexp.MustCompile(`func \(\w+ \*?\w+\) (\w+)\(`)
+	// inlineErrRe matches apierr.Error("CODE", <msg>, <id>) where msg is a
+	// string literal or identifier and id is a literal or UUID constant.
+	inlineErrRe = regexp.MustCompile(`apierr\.Error\(\s*"([A-Z_]+)"\s*,\s*(?:"(?:[^"\\]|\\.)*"|[\w.]+)\s*,\s*("[0-9a-f-]{36}"|(?:apierr\.)?UUID\w+)\s*\)`)
+	// helperCallRe matches apierr.Helper( — any apierr.X( call; non-helpers
+	// (e.g. Error) are filtered against the parsed helper table.
+	helperCallRe = regexp.MustCompile(`apierr\.(\w+)\(`)
+)
+
+// scanEmissions extracts every error emission from one Go source file, keyed by
+// the enclosing method. Splitting on method boundaries keeps multi-line
+// apierr.Error(...) calls attached to the right route.
+func scanEmissions(src string, helpers map[string]emission, consts map[string]string) []emission {
+	locs := funcDeclRe.FindAllStringSubmatchIndex(src, -1)
+	var out []emission
+	for i, loc := range locs {
+		fn := src[loc[2]:loc[3]]
+		end := len(src)
+		if i+1 < len(locs) {
+			end = locs[i+1][0]
+		}
+		body := src[loc[0]:end]
+
+		for _, m := range inlineErrRe.FindAllStringSubmatch(body, -1) {
+			out = append(out, emission{fn: fn, code: m[1], uuid: resolveUUID(m[2], consts)})
+		}
+		for _, m := range helperCallRe.FindAllStringSubmatch(body, -1) {
+			if h, ok := helpers[m[1]]; ok {
+				out = append(out, emission{fn: fn, code: h.code, uuid: h.uuid})
+			}
+		}
+	}
+	return out
+}
+
+// resolveUUID turns the 3rd Error() argument into a concrete UUID: a quoted
+// literal is unquoted, a (possibly apierr-qualified) UUID constant is looked up.
+func resolveUUID(expr string, consts map[string]string) string {
+	if strings.HasPrefix(expr, `"`) {
+		return strings.Trim(expr, `"`)
+	}
+	return consts[strings.TrimPrefix(expr, "apierr.")]
+}
+
+var (
+	constRe        = regexp.MustCompile(`\b(UUID\w+)\s*=\s*"([0-9a-f-]{36})"`)
+	funcDeclBareRe = regexp.MustCompile(`func (\w+)\(`)
+	helperBodyRe   = regexp.MustCompile(`Error\(\s*"([A-Z_]+)"\s*,\s*(?:"(?:[^"\\]|\\.)*"|[\w.]+)\s*,\s*("[0-9a-f-]{36}"|UUID\w+)`)
+)
+
+// parseApierr reads internal/api/apierr/errors.go and returns the UUID-constant
+// table and the helper table (helper func name -> {code, uuid}). Helpers are
+// the zero/var-arg wrappers such as NoSuchUser() that return Error(code, _, id).
+func parseApierr(t *testing.T, path string) (helpers map[string]emission, consts map[string]string) {
+	src, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read apierr: %v", err)
+	}
+	consts = map[string]string{}
+	for _, m := range constRe.FindAllStringSubmatch(string(src), -1) {
+		consts[m[1]] = m[2]
+	}
+	helpers = map[string]emission{}
+	locs := funcDeclBareRe.FindAllStringSubmatchIndex(string(src), -1)
+	for i, loc := range locs {
+		name := string(src[loc[2]:loc[3]])
+		if name == "Error" {
+			continue
+		}
+		end := len(src)
+		if i+1 < len(locs) {
+			end = locs[i+1][0]
+		}
+		if m := helperBodyRe.FindStringSubmatch(string(src[loc[0]:end])); m != nil {
+			helpers[name] = emission{code: m[1], uuid: resolveUUID(m[2], consts)}
+		}
+	}
+	return helpers, consts
+}
+
+var routeRe = regexp.MustCompile(`\.(?:GET|POST|PUT|DELETE)\("(/[^"]*)",\s*(\w+)\.(\w+)`)
+
+// parseRoutes reads router.go and returns a map keyed by "pkg\x00method" to the
+// route paths registered to that handler method. Handler variables are resolved
+// to their package directory via the import-alias and constructor tables, so a
+// method like notes.FavoritesCreate maps to /notes/favorites/create.
+func parseRoutes(t *testing.T, path string) map[string][]string {
+	src, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read router: %v", err)
+	}
+	s := string(src)
+
+	// import alias -> package dir basename (aliased and bare forms).
+	alias2dir := map[string]string{}
+	for _, m := range regexp.MustCompile(`(\w+)\s+"github\.com/shiroha-a/mk/(internal/api/[\w/]+)"`).FindAllStringSubmatch(s, -1) {
+		alias2dir[m[1]] = filepath.Base(m[2])
+	}
+	for _, m := range regexp.MustCompile(`\n\s+"github\.com/shiroha-a/mk/(internal/api/[\w/]+)"`).FindAllStringSubmatch(s, -1) {
+		b := filepath.Base(m[1])
+		if _, ok := alias2dir[b]; !ok {
+			alias2dir[b] = b
+		}
+	}
+	// handler var -> package dir (via `h := alias.NewHandler(...)`).
+	var2dir := map[string]string{}
+	for _, m := range regexp.MustCompile(`(\w+)\s*:?=\s*(\w+)\.New\w*\(`).FindAllStringSubmatch(s, -1) {
+		if d, ok := alias2dir[m[2]]; ok {
+			var2dir[m[1]] = d
+		} else {
+			var2dir[m[1]] = m[2]
+		}
+	}
+
+	routes := map[string][]string{}
+	for _, m := range routeRe.FindAllStringSubmatch(s, -1) {
+		dir, ok := var2dir[m[2]]
+		if !ok {
+			continue
+		}
+		key := dir + "\x00" + m[3]
+		routes[key] = append(routes[key], m[1])
+	}
+	return routes
+}
+
+func excludedEndpoint(ep string) bool {
+	for _, p := range errorIDExcludedPrefixes {
+		if strings.HasPrefix(ep, p) {
+			return true
+		}
+	}
+	return false
+}
+
+// repoRoot finds the module root by walking up from the test's working
+// directory (which `go test` sets to the package dir) until it finds go.mod.
+// This is robust under -trimpath, where runtime.Caller paths are unusable.
+func repoRoot(t *testing.T) string {
+	wd, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("getwd: %v", err)
+	}
+	for d := wd; ; {
+		if _, err := os.Stat(filepath.Join(d, "go.mod")); err == nil {
+			return d
+		}
+		parent := filepath.Dir(d)
+		if parent == d {
+			t.Fatalf("go.mod not found from %s", wd)
+		}
+		d = parent
+	}
+}

--- a/internal/entitycompat/error_ids_test.go
+++ b/internal/entitycompat/error_ids_test.go
@@ -55,9 +55,17 @@ func TestErrorIDDrift(t *testing.T) {
 
 	routes := parseRoutes(t, filepath.Join(root, "internal/server/router.go"))
 	helpers, consts := parseApierr(t, filepath.Join(root, "internal/api/apierr/errors.go"))
+	// echo.go の JSONXxx(c) ラッパーも emission として解決する。これらは
+	// handler の最頻送出経路 (例: apierr.JSONNoSuchNote(c)) なので、外すと
+	// gate が大半の error を素通しする。helperCallRe は apierr.JSONXxx( にも
+	// マッチするため、helper 表に併合すれば scanEmissions がそのまま解決する。
+	for name, em := range parseJSONWrappers(t, filepath.Join(root, "internal/api/apierr/echo.go"), helpers) {
+		helpers[name] = em
+	}
 
 	type drift struct{ endpoint, code, got, want string }
 	var drifts []drift
+	resolved := 0
 
 	apiDir := filepath.Join(root, "internal/api")
 	err := filepath.WalkDir(apiDir, func(path string, d fs.DirEntry, err error) error {
@@ -74,6 +82,7 @@ func TestErrorIDDrift(t *testing.T) {
 		}
 		for _, em := range scanEmissions(string(src), helpers, consts) {
 			for _, route := range routes[pkg+"\x00"+em.fn] {
+				resolved++
 				ep := strings.TrimPrefix(route, "/")
 				if excludedEndpoint(ep) {
 					continue
@@ -91,6 +100,16 @@ func TestErrorIDDrift(t *testing.T) {
 	})
 	if err != nil {
 		t.Fatalf("walk api dir: %v", err)
+	}
+
+	// silent-zero guard: regex ベースの抽出/解決が upstream フォーマット変更や
+	// リファクタで空振りすると、emission が 0 件になり gate が無意味に PASS して
+	// しまう。実際の解決数は数百件あるので、大きく下回ったら parser 破損とみなす。
+	if resolved < 400 {
+		t.Fatalf("error-id gate resolved only %d emissions (expected >=400); the source/router parser likely broke", resolved)
+	}
+	if len(golden) < 100 {
+		t.Fatalf("golden has only %d endpoints (expected >=100); regenerate with `make shapecheck-gen`", len(golden))
 	}
 
 	if len(drifts) > 0 {
@@ -198,6 +217,38 @@ func parseApierr(t *testing.T, path string) (helpers map[string]emission, consts
 		}
 	}
 	return helpers, consts
+}
+
+var jsonWrapperRe = regexp.MustCompile(`func (JSON\w+)\(c echo\.Context\) error \{`)
+
+// jsonWrapperBodyRe matches the inner helper call of a JSON wrapper, e.g.
+// `c.JSON(http.StatusNotFound, NoSuchNote())` -> inner helper "NoSuchNote".
+var jsonWrapperBodyRe = regexp.MustCompile(`c\.JSON\([^,]+,\s*(\w+)\(`)
+
+// parseJSONWrappers reads internal/api/apierr/echo.go and returns the echo
+// wrapper table (JSONXxx -> {code, uuid}) by resolving each wrapper's inner
+// helper call against the helper table. Handlers most often emit errors via
+// these wrappers, so without this the gate would miss the majority of routes.
+func parseJSONWrappers(t *testing.T, path string, helpers map[string]emission) map[string]emission {
+	src, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read echo wrappers: %v", err)
+	}
+	out := map[string]emission{}
+	locs := jsonWrapperRe.FindAllStringSubmatchIndex(string(src), -1)
+	for i, loc := range locs {
+		name := string(src[loc[2]:loc[3]])
+		end := len(src)
+		if i+1 < len(locs) {
+			end = locs[i+1][0]
+		}
+		if m := jsonWrapperBodyRe.FindStringSubmatch(string(src[loc[0]:end])); m != nil {
+			if h, ok := helpers[m[1]]; ok {
+				out[name] = h
+			}
+		}
+	}
+	return out
 }
 
 var routeRe = regexp.MustCompile(`\.(?:GET|POST|PUT|DELETE)\("(/[^"]*)",\s*(\w+)\.(\w+)`)

--- a/internal/entitycompat/testdata/golden_error_ids.json
+++ b/internal/entitycompat/testdata/golden_error_ids.json
@@ -1,0 +1,855 @@
+{
+  "admin/abuse-report/notification-recipient/create": {
+    "CORRELATION_CHECK_EMAIL": "348bb8ae-575a-6fe9-4327-5811999def8f",
+    "CORRELATION_CHECK_WEBHOOK": "b0c15051-de2d-29ef-260c-9585cddd701a",
+    "EMAIL_ADDRESS_NOT_SET": "7cc1d85e-2f58-fc31-b644-3de8d0d3421f"
+  },
+  "admin/abuse-report/notification-recipient/show": {
+    "NO_SUCH_RECIPIENT": "013de6a8-f757-04cb-4d73-cc2a7e3368e4"
+  },
+  "admin/abuse-report/notification-recipient/update": {
+    "CORRELATION_CHECK_EMAIL": "348bb8ae-575a-6fe9-4327-5811999def8f",
+    "CORRELATION_CHECK_WEBHOOK": "b0c15051-de2d-29ef-260c-9585cddd701a",
+    "EMAIL_ADDRESS_NOT_SET": "7cc1d85e-2f58-fc31-b644-3de8d0d3421f"
+  },
+  "admin/accounts/create": {
+    "ACCESS_DENIED": "1fb7cb09-d46a-4fff-b8df-057708cce513",
+    "INCORRECT_INITIAL_PASSWORD": "97147c55-1ae1-4f6f-91d6-e1c3e0e76d62"
+  },
+  "admin/accounts/find-by-email": {
+    "USER_NOT_FOUND": "cb865949-8af5-4062-a88c-ef55e8786d1d"
+  },
+  "admin/ad/delete": {
+    "NO_SUCH_AD": "ccac9863-3a03-416e-b899-8a64041118b1"
+  },
+  "admin/ad/update": {
+    "NO_SUCH_AD": "b7aa1727-1354-47bc-a182-3a9c3973d300"
+  },
+  "admin/announcements/delete": {
+    "NO_SUCH_ANNOUNCEMENT": "ecad8040-a276-4e85-bda9-015a708d291e"
+  },
+  "admin/announcements/update": {
+    "NO_SUCH_ANNOUNCEMENT": "d3aae5a7-6372-4cb4-b61c-f511ffc2d7cc"
+  },
+  "admin/captcha/save": {
+    "INVALID_PARAMETERS": "26654194-410e-44e2-b42e-460ff6f92476",
+    "INVALID_PROVIDER": "14bf7ae1-80cc-4363-acb2-4fd61d086af0",
+    "NO_RESPONSE_PROVIDED": "40acbba8-0937-41fb-bb3f-474514d40afe",
+    "REQUEST_FAILED": "0f4fe2f1-2c15-4d6e-b714-efbfcde231cd",
+    "UNKNOWN": "f868d509-e257-42a9-99c1-42614b031a97",
+    "VERIFICATION_FAILED": "c41c067f-24f3-4150-84b2-b5a3ae8c2214"
+  },
+  "admin/drive/show-file": {
+    "NO_SUCH_FILE": "caf3ca38-c6e5-472e-a30c-b05377dcc240"
+  },
+  "admin/emoji/add": {
+    "DUPLICATE_NAME": "f7a3462c-4e6e-4069-8421-b9bd4f4c3975",
+    "NO_SUCH_FILE": "fc46b5a4-6b92-4c33-ac66-b806659bb5cf",
+    "UNSUPPORTED_FILE_TYPE": "f7599d96-8750-af68-1633-9575d625c1a7"
+  },
+  "admin/emoji/copy": {
+    "DUPLICATE_NAME": "f7a3462c-4e6e-4069-8421-b9bd4f4c3975",
+    "NO_SUCH_EMOJI": "e2785b66-dca3-4087-9cac-b93c541cc425"
+  },
+  "admin/emoji/delete": {
+    "NO_SUCH_EMOJI": "be83669b-773a-44b7-b1f8-e5e5170ac3c2"
+  },
+  "admin/emoji/update": {
+    "NO_SUCH_EMOJI": "684dec9d-a8c2-4364-9aa8-456c49cb1dc8",
+    "NO_SUCH_FILE": "14fb9fd9-0731-4e2f-aeb9-f09e4740333d",
+    "SAME_NAME_EMOJI_EXISTS": "7180fe9d-1ee3-bff9-647d-fe9896d2ffb8"
+  },
+  "admin/forward-abuse-user-report": {
+    "NO_SUCH_ABUSE_REPORT": "8763e21b-d9bc-40be-acf6-54c1a6986493"
+  },
+  "admin/invite/create": {
+    "INVALID_DATE_TIME": "f1380b15-3760-4c6c-a1db-5c3aaf1cbd49"
+  },
+  "admin/promo/create": {
+    "ALREADY_PROMOTED": "ae427aa2-7a41-484f-a18c-2c1104051604",
+    "NO_SUCH_NOTE": "ee449fbe-af2a-453b-9cae-cf2fe7c895fc"
+  },
+  "admin/relays/add": {
+    "INVALID_URL": "fb8c92d3-d4e5-44e7-b3d4-800d5cef8b2c"
+  },
+  "admin/resolve-abuse-user-report": {
+    "NO_SUCH_ABUSE_REPORT": "ac3794dd-2ce4-d878-e546-73c60c06b398"
+  },
+  "admin/roles/assign": {
+    "ACCESS_DENIED": "25b5bc31-dc79-4ebd-9bd2-c84978fd052c",
+    "NO_SUCH_ROLE": "6503c040-6af4-4ed9-bf07-f2dd16678eab",
+    "NO_SUCH_USER": "558ea170-f653-4700-94d0-5a818371d0df"
+  },
+  "admin/roles/delete": {
+    "NO_SUCH_ROLE": "de0d6ecd-8e0a-4253-88ff-74bc89ae3d45"
+  },
+  "admin/roles/show": {
+    "NO_SUCH_ROLE": "07dc7d34-c0d8-49b7-96c6-db3ce64ee0b3"
+  },
+  "admin/roles/unassign": {
+    "ACCESS_DENIED": "24636eee-e8c1-493e-94b2-e16ad401e262",
+    "NOT_ASSIGNED": "b9060ac7-5c94-4da4-9f55-2047c953df44",
+    "NO_SUCH_ROLE": "6e519036-a70d-4c76-b679-bc8fb18194e2",
+    "NO_SUCH_USER": "2b730f78-1179-461b-88ad-d24c9af1a5ce"
+  },
+  "admin/roles/update": {
+    "NO_SUCH_ROLE": "cd23ef55-09ad-428a-ac61-95a45e124b32"
+  },
+  "admin/roles/users": {
+    "NO_SUCH_ROLE": "224eff5e-2488-4b18-b3e7-f50d94421648"
+  },
+  "admin/system-webhook/show": {
+    "NO_SUCH_SYSTEM_WEBHOOK": "38dd1ffe-04b4-6ff5-d8ba-4e6a6ae22c9d"
+  },
+  "admin/system-webhook/test": {
+    "NO_SUCH_WEBHOOK": "0c52149c-e913-18f8-5dc7-74870bfe0cf9"
+  },
+  "admin/update-abuse-user-report": {
+    "NO_SUCH_ABUSE_REPORT": "15f51cf5-46d1-4b1d-a618-b35bcbed0662"
+  },
+  "announcements/show": {
+    "NO_SUCH_ANNOUNCEMENT": "b57b5e1d-4f49-404a-9edb-46b00268f121"
+  },
+  "antennas/create": {
+    "EMPTY_KEYWORD": "53ee222e-1ddd-4f9a-92e5-9fb82ddb463a",
+    "NO_SUCH_USER_LIST": "95063e93-a283-4b8b-9aa5-bcdb8df69a7f",
+    "TOO_MANY_ANTENNAS": "faf47050-e8b5-438c-913c-db2b1576fde4"
+  },
+  "antennas/delete": {
+    "NO_SUCH_ANTENNA": "b34dcf9d-348f-44bb-99d0-6c9314cfe2df"
+  },
+  "antennas/notes": {
+    "NO_SUCH_ANTENNA": "850926e0-fd3b-49b6-b69a-b28a5dbd82fe"
+  },
+  "antennas/show": {
+    "NO_SUCH_ANTENNA": "c06569fb-b025-4f23-b22d-1fcd20d2816b"
+  },
+  "antennas/update": {
+    "EMPTY_KEYWORD": "721aaff6-4e1b-4d88-8de6-877fae9f68c4",
+    "NO_SUCH_ANTENNA": "10c673ac-8852-48eb-aa1f-f5b67f069290",
+    "NO_SUCH_USER_LIST": "1c6b35c9-943e-48c2-81e4-2844989407f7"
+  },
+  "ap/show": {
+    "FEDERATION_NOT_ALLOWED": "974b799e-1a29-4889-b706-18d4dd93e266",
+    "NO_SUCH_OBJECT": "dc94d745-1262-4e63-a17d-fecaa57efc82",
+    "REQUEST_FAILED": "81b539cf-4f57-4b29-bc98-032c33c0792e",
+    "RESPONSE_INVALID": "70193c39-54f3-4813-82f0-70a680f7495b",
+    "URI_INVALID": "1a5eab56-e47b-48c2-8d5e-217b897d70db"
+  },
+  "app/show": {
+    "NO_SUCH_APP": "dce83913-2dc6-4093-8a7b-71dbb11718a3"
+  },
+  "auth/accept": {
+    "NO_SUCH_SESSION": "9c72d8de-391a-43c1-9d06-08d29efde8df"
+  },
+  "auth/session/generate": {
+    "NO_SUCH_APP": "92f93e63-428e-4f2f-a5a4-39e1407fe998"
+  },
+  "auth/session/show": {
+    "NO_SUCH_SESSION": "bd72c97d-eba7-4adb-a467-f171b8847250"
+  },
+  "auth/session/userkey": {
+    "NO_SUCH_APP": "fcab192a-2c5a-43b7-8ad8-9b7054d8d40d",
+    "NO_SUCH_SESSION": "5b5a1503-8bc8-4bd0-8054-dc189e8cdcb3",
+    "PENDING_SESSION": "8c8a4145-02cc-4cca-8e66-29ba60445a8e"
+  },
+  "blocking/create": {
+    "ALREADY_BLOCKING": "787fed64-acb9-464a-82eb-afbd745b9614",
+    "BLOCKEE_IS_YOURSELF": "88b19138-f28d-42c0-8499-6a31bbd0fdc6",
+    "NO_SUCH_USER": "7cc4f851-e2f1-4621-9633-ec9e1d00c01e"
+  },
+  "blocking/delete": {
+    "BLOCKEE_IS_YOURSELF": "06f6fac6-524b-473c-a354-e97a40ae6eac",
+    "NOT_BLOCKING": "291b2efa-60c6-45c0-9f6a-045c8f9b02cd",
+    "NO_SUCH_USER": "8621d8bf-c358-4303-a066-5ea78610eb3f"
+  },
+  "bubble-game/register": {
+    "INVALID_SEED": "eb627bc7-574b-4a52-a860-3c3eae772b88"
+  },
+  "channels/create": {
+    "NO_SUCH_FILE": "cd1e9f3e-5a12-4ab4-96f6-5d0a2cc32050"
+  },
+  "channels/favorite": {
+    "NO_SUCH_CHANNEL": "4938f5f3-6167-4c04-9149-6607b7542861"
+  },
+  "channels/follow": {
+    "NO_SUCH_CHANNEL": "c0031718-d573-4e85-928e-10039f1fbb68"
+  },
+  "channels/mute/create": {
+    "ALREADY_MUTING_CHANNEL": "5a251978-769a-da44-3e89-3931e43bb592",
+    "EXPIRES_AT_IS_PAST": "42b32236-df2c-a45f-fdbf-def67268f749",
+    "NO_SUCH_CHANNEL": "7174361e-d58f-31d6-2e7c-6fb830786a3f"
+  },
+  "channels/mute/delete": {
+    "NOT_MUTING_CHANNEL": "14d55962-6ea8-d990-1333-d6bef78dc2ab",
+    "NO_SUCH_CHANNEL": "e7998769-6e94-d9c2-6b8f-94a527314aba"
+  },
+  "channels/show": {
+    "NO_SUCH_CHANNEL": "6f6c314b-7486-4897-8966-c04a66a02923"
+  },
+  "channels/timeline": {
+    "NO_SUCH_CHANNEL": "4d0eeeba-a02c-4c3c-9966-ef60d38d2e7f"
+  },
+  "channels/unfavorite": {
+    "NO_SUCH_CHANNEL": "353c68dd-131a-476c-aa99-88a345e83668"
+  },
+  "channels/unfollow": {
+    "NO_SUCH_CHANNEL": "19959ee9-0153-4c51-bbd9-a98c49dc59d6"
+  },
+  "channels/update": {
+    "ACCESS_DENIED": "1fb7cb09-d46a-4fdf-b8df-057788cce513",
+    "NO_SUCH_CHANNEL": "f9c5467f-d492-4c3c-9a8d-a70dacc86512",
+    "NO_SUCH_FILE": "e86c14a4-0da2-4032-8df3-e737a04c7f3b"
+  },
+  "chat/messages/create-to-room": {
+    "CONTENT_REQUIRED": "340517b7-6d04-42c0-bac1-37ee804e3594",
+    "NO_SUCH_FILE": "b6accbd3-1d7b-4d9f-bdb7-eb185bac06db",
+    "NO_SUCH_ROOM": "8098520d-2da5-4e8f-8ee1-df78b55a4ec6"
+  },
+  "chat/messages/create-to-user": {
+    "CONTENT_REQUIRED": "25587321-b0e6-449c-9239-f8925092942c",
+    "NO_SUCH_FILE": "4372b8e2-185d-4146-8749-2f68864a3e5f",
+    "NO_SUCH_USER": "11795c64-40ea-4198-b06e-3c873ed9039d",
+    "RECIPIENT_IS_YOURSELF": "17e2ba79-e22a-4cbc-bf91-d327643f4a7e",
+    "YOU_HAVE_BEEN_BLOCKED": "c15a5199-7422-4968-941a-2a462c478f7d"
+  },
+  "chat/messages/delete": {
+    "NO_SUCH_MESSAGE": "36b67f0e-66a6-414b-83df-992a55294f17"
+  },
+  "chat/messages/react": {
+    "NO_SUCH_MESSAGE": "9b5839b9-0ba0-4351-8c35-37082093d200"
+  },
+  "chat/messages/room-timeline": {
+    "NO_SUCH_ROOM": "c4d9f88c-9270-4632-b032-6ed8cee36f7f"
+  },
+  "chat/messages/search": {
+    "NO_SUCH_ROOM": "460b3669-81b0-4dc9-a997-44442141bf83"
+  },
+  "chat/messages/show": {
+    "NO_SUCH_MESSAGE": "3710865b-1848-4da9-8d61-cfed15510b93"
+  },
+  "chat/messages/unreact": {
+    "NO_SUCH_MESSAGE": "c39ea42f-e3ca-428a-ad57-390e0a711595"
+  },
+  "chat/messages/user-timeline": {
+    "NO_SUCH_USER": "11795c64-40ea-4198-b06e-3c873ed9039d"
+  },
+  "chat/rooms/delete": {
+    "NO_SUCH_ROOM": "d4e3753d-97bf-4a19-ab8e-21080fbc0f4b"
+  },
+  "chat/rooms/invitations/create": {
+    "NO_SUCH_ROOM": "916f9507-49ba-4e90-b57f-1fd4deaa47a5"
+  },
+  "chat/rooms/invitations/ignore": {
+    "NO_SUCH_ROOM": "5130557e-5a11-4cfb-9cc5-fe60cda5de0d"
+  },
+  "chat/rooms/invitations/outbox": {
+    "NO_SUCH_ROOM": "a3c6b309-9717-4316-ae94-a69b53437237"
+  },
+  "chat/rooms/join": {
+    "NO_SUCH_ROOM": "84416476-5ce8-4a2c-b568-9569f1b10733"
+  },
+  "chat/rooms/leave": {
+    "NO_SUCH_ROOM": "cb7f3179-50e8-4389-8c30-dbe2650a67c9"
+  },
+  "chat/rooms/members": {
+    "NO_SUCH_ROOM": "7b9fe84c-eafc-4d21-bf89-485458ed2c18"
+  },
+  "chat/rooms/mute": {
+    "NO_SUCH_ROOM": "c2cde4eb-8d0f-42f1-8f2f-c4d6bfc8e5df"
+  },
+  "chat/rooms/show": {
+    "NO_SUCH_ROOM": "857ae02f-8759-4d20-9adb-6e95fffe4fd7"
+  },
+  "chat/rooms/update": {
+    "NO_SUCH_ROOM": "fcdb0f92-bda6-47f9-bd05-343e0e020932"
+  },
+  "clips/add-note": {
+    "ALREADY_CLIPPED": "734806c4-542c-463a-9311-15c512803965",
+    "NO_SUCH_CLIP": "d6e76cc0-a1b5-4c7c-a287-73fa9c716dcf",
+    "NO_SUCH_NOTE": "fc8c0b49-c7a3-4664-a0a6-b418d386bb8b",
+    "TOO_MANY_CLIP_NOTES": "f0dba960-ff73-4615-8df4-d6ac5d9dc118"
+  },
+  "clips/create": {
+    "TOO_MANY_CLIPS": "920f7c2d-6208-4b76-8082-e632020f5883"
+  },
+  "clips/delete": {
+    "NO_SUCH_CLIP": "70ca08ba-6865-4630-b6fb-8494759aa754"
+  },
+  "clips/favorite": {
+    "ALREADY_FAVORITED": "92658936-c625-4273-8326-2d790129256e",
+    "NO_SUCH_CLIP": "4c2aaeae-80d8-4250-9606-26cb1fdb77a5"
+  },
+  "clips/notes": {
+    "NO_SUCH_CLIP": "1d7645e6-2b6d-4635-b0fe-fe22b0e72e00"
+  },
+  "clips/remove-note": {
+    "NO_SUCH_CLIP": "b80525c6-97f7-49d7-a42d-ebccd49cfd52",
+    "NO_SUCH_NOTE": "aff017de-190e-434b-893e-33a9ff5049d8"
+  },
+  "clips/show": {
+    "NO_SUCH_CLIP": "c3c5fe33-d62c-44d2-9ea5-d997703f5c20"
+  },
+  "clips/unfavorite": {
+    "NOT_FAVORITED": "90c3a9e8-b321-4dae-bf57-2bf79bbcc187",
+    "NO_SUCH_CLIP": "2603966e-b865-426c-94a7-af4a01241dc1"
+  },
+  "clips/update": {
+    "NO_SUCH_CLIP": "b4d92d70-b216-46fa-9a3f-a8c811699257"
+  },
+  "drive/files/attached-chat-messages": {
+    "NO_SUCH_FILE": "485ce26d-f5d2-4313-9783-e689d131eafb"
+  },
+  "drive/files/attached-notes": {
+    "NO_SUCH_FILE": "c118ece3-2e4b-4296-99d1-51756e32d232"
+  },
+  "drive/files/create": {
+    "INAPPROPRIATE": "bec5bd69-fba3-43c9-b4fb-2894b66ad5d2",
+    "INVALID_FILE_NAME": "f449b209-0c60-4e51-84d5-29486263bfd4",
+    "MAX_FILE_SIZE_EXCEEDED": "b9d8c348-33f0-4673-b9a9-5d4da058977a",
+    "NO_FREE_SPACE": "d08dbc37-a6a9-463a-8c47-96c32ab5f064",
+    "UNALLOWED_FILE_TYPE": "4becd248-7f2c-48c4-a9f0-75edc4f9a1ea"
+  },
+  "drive/files/delete": {
+    "ACCESS_DENIED": "5eb8d909-2540-4970-90b8-dd6f86088121",
+    "NO_SUCH_FILE": "908939ec-e52b-4458-b395-1025195cea58"
+  },
+  "drive/files/show": {
+    "ACCESS_DENIED": "25b73c73-68b1-41d0-bad1-381cfdf6579f",
+    "NO_SUCH_FILE": "067bc436-2718-4795-b0fb-ecbe43949e31"
+  },
+  "drive/files/update": {
+    "ACCESS_DENIED": "01a53b27-82fc-445b-a0c1-b558465a8ed2",
+    "INVALID_FILE_NAME": "395e7156-f9f0-475e-af89-53c3c23080c2",
+    "NO_SUCH_FILE": "e7778c7e-3af9-49cd-9690-6dbc3e6c972d",
+    "NO_SUCH_FOLDER": "ea8fb7a5-af77-4a08-b608-c0218176cd73",
+    "RESTRICTED_BY_ROLE": "7f59dccb-f465-75ab-5cf4-3ce44e3282f7"
+  },
+  "drive/folders/create": {
+    "NO_SUCH_FOLDER": "53326628-a00d-40a6-a3cd-8975105c0f95"
+  },
+  "drive/folders/delete": {
+    "HAS_CHILD_FILES_OR_FOLDERS": "b0fc8a17-963c-405d-bfbc-859a487295e1",
+    "NO_SUCH_FOLDER": "1069098f-c281-440f-b085-f9932edbe091"
+  },
+  "drive/folders/show": {
+    "NO_SUCH_FOLDER": "d74ab9eb-bb09-4bba-bf24-fb58f761e1e9"
+  },
+  "drive/folders/update": {
+    "NO_SUCH_FOLDER": "f7974dac-2c0d-4a27-926e-23583b28e98e",
+    "NO_SUCH_PARENT_FOLDER": "ce104e3a-faaf-49d5-b459-10ff0cbbcaa1",
+    "RECURSIVE_NESTING": "dbeb024837894013aed44279f9199740"
+  },
+  "fetch-external-resources": {
+    "EXT_RESOURCE_HASH_DIDNT_MATCH": "693ba8ba-b486-40df-a174-72f8279b56a4",
+    "EXT_RESOURCE_RETURNED_INVALID_SCHEMA": "bb774091-7a15-4a70-9dc5-6ac8cf125856"
+  },
+  "flash/delete": {
+    "ACCESS_DENIED": "1036ad7b-9f92-4fff-89c3-0e50dc941704",
+    "NO_SUCH_FLASH": "de1623ef-bbb3-4289-a71e-14cfa83d9740"
+  },
+  "flash/like": {
+    "ALREADY_LIKED": "010065cf-ad43-40df-8067-abff9f4686e3",
+    "NO_SUCH_FLASH": "c07c1491-9161-4c5c-9d75-01906f911f73",
+    "YOUR_FLASH": "3fd8a0e7-5955-4ba9-85bb-bf3e0c30e13b"
+  },
+  "flash/show": {
+    "NO_SUCH_FLASH": "f0d34a1a-d29a-401d-90ba-1982122b5630"
+  },
+  "flash/unlike": {
+    "NOT_LIKED": "755f25a7-9871-4f65-9f34-51eaad9ae0ac",
+    "NO_SUCH_FLASH": "afe8424a-a69e-432d-a5f2-2f0740c62410"
+  },
+  "flash/update": {
+    "ACCESS_DENIED": "08e60c88-5948-478e-a132-02ec701d67b2",
+    "NO_SUCH_FLASH": "611e13d2-309e-419a-a5e4-e0422da39b02"
+  },
+  "following/create": {
+    "ALREADY_FOLLOWING": "35387507-38c7-4cb9-9197-300b93783fa0",
+    "BLOCKED": "c4ab57cc-4e41-45e9-bfd9-584f61e35ce0",
+    "BLOCKING": "4e2206ec-aa4f-4960-b865-6c23ac38e2d9",
+    "FOLLOWEE_IS_YOURSELF": "26fbe7bb-a331-4857-af17-205b426669a9",
+    "NO_SUCH_USER": "fcd2eef9-a9b2-4c4f-8624-038099e90aa5"
+  },
+  "following/delete": {
+    "FOLLOWEE_IS_YOURSELF": "d9e400b9-36b0-4808-b1d8-79e707f1296c",
+    "NOT_FOLLOWING": "5dbf82f5-c92b-40b1-87d1-6c8c0741fd09",
+    "NO_SUCH_USER": "5b12c78d-2b28-4dca-99d2-f56139b42ff8"
+  },
+  "following/invalidate": {
+    "FOLLOWER_IS_YOURSELF": "07dc03b9-03da-422d-885b-438313707662",
+    "NOT_FOLLOWING": "918faac3-074f-41ae-9c43-ed5d2946770d",
+    "NO_SUCH_USER": "b77e6ae6-a3e5-40da-9cc8-c240115479cc"
+  },
+  "following/requests/accept": {
+    "NO_FOLLOW_REQUEST": "bcde4f8b-0913-4614-8881-614e522fb041",
+    "NO_SUCH_USER": "66ce1645-d66c-46bb-8b79-96739af885bd"
+  },
+  "following/requests/cancel": {
+    "FOLLOW_REQUEST_NOT_FOUND": "089b125b-d338-482a-9a09-e2622ac9f8d4",
+    "NO_SUCH_USER": "4e68c551-fc4c-4e46-bb41-7d4a37bf9dab"
+  },
+  "following/requests/reject": {
+    "NO_SUCH_USER": "abc2ffa6-25b2-4380-ba99-321ff3a94555"
+  },
+  "following/update": {
+    "FOLLOWEE_IS_YOURSELF": "4c4cbaf9-962a-463b-8418-a5e365dbf2eb",
+    "NOT_FOLLOWING": "b8dc75cf-1cb5-46c9-b14b-5f1ffbd782c9",
+    "NO_SUCH_USER": "14318698-f67e-492a-99da-5353a5ac52be"
+  },
+  "gallery/posts/delete": {
+    "ACCESS_DENIED": "c86e09de-1c48-43ac-a435-1c7e42ed4496",
+    "NO_SUCH_POST": "ae52f367-4bd7-4ecd-afc6-5672fff427f5"
+  },
+  "gallery/posts/like": {
+    "ALREADY_LIKED": "40e9ed56-a59c-473a-bf3f-f289c54fb5a7",
+    "NO_SUCH_POST": "56c06af3-1287-442f-9701-c93f7c4a62ff",
+    "YOUR_POST": "f78f1511-5ebc-4478-a888-1198d752da68"
+  },
+  "gallery/posts/show": {
+    "NO_SUCH_POST": "1137bf14-c5b0-4604-85bb-5b5371b1cd45"
+  },
+  "gallery/posts/unlike": {
+    "NOT_LIKED": "e3e8e06e-be37-41f7-a5b4-87a8250288f0",
+    "NO_SUCH_POST": "c32e6dd0-b555-4413-925e-b3757d19ed84"
+  },
+  "hashtags/show": {
+    "NO_SUCH_HASHTAG": "110ee688-193e-4a3a-9ecf-c167b2e6981e"
+  },
+  "i": {
+    "USER_IS_DELETED": "e5b3b9f0-2b8f-4b9f-9c1f-8c5c1b2e1b1a"
+  },
+  "i/2fa/key-done": {
+    "INCORRECT_PASSWORD": "0d7ec6d2-e652-443e-a7bf-9ee9a0cd77b0",
+    "TWO_FACTOR_NOT_ENABLED": "798d6847-b1ed-4f9c-b1f9-163c42655995"
+  },
+  "i/2fa/password-less": {
+    "NO_SECURITY_KEY": "f9c54d7f-d4c2-4d3c-9a8g-a70daac86512"
+  },
+  "i/2fa/register": {
+    "INCORRECT_PASSWORD": "78d6c839-20c9-4c66-b90a-fc0542168b48"
+  },
+  "i/2fa/register-key": {
+    "INCORRECT_PASSWORD": "38769596-efe2-4faf-9bec-abbb3f2cd9ba",
+    "TWO_FACTOR_NOT_ENABLED": "bf32b864-449b-47b8-974e-f9a5468546f1",
+    "USER_NOT_FOUND": "652f899f-66d4-490e-993e-6606c8ec04c3"
+  },
+  "i/2fa/remove-key": {
+    "INCORRECT_PASSWORD": "141c598d-a825-44c8-9173-cfb9d92be493"
+  },
+  "i/2fa/unregister": {
+    "INCORRECT_PASSWORD": "7add0395-9901-4098-82f9-4f67af65f775"
+  },
+  "i/2fa/update-key": {
+    "ACCESS_DENIED": "1fb7cb09-d46a-4fff-b8df-057708cce513",
+    "NO_SUCH_KEY": "f9c5467f-d492-4d3c-9a8g-a70dacc86512"
+  },
+  "i/import-antennas": {
+    "EMPTY_FILE": "7f60115d-8d93-4b0f-bd0e-3815dcbb389f",
+    "NO_SUCH_FILE": "3b71d086-c3fa-431c-b01d-ded65a777172",
+    "NO_SUCH_USER": "e842c379-8ac7-4cf7-b07a-4d4de7e4671c",
+    "TOO_MANY_ANTENNAS": "600917d4-a4cb-4cc5-8ba8-7ac8ea3c7779"
+  },
+  "i/import-blocking": {
+    "EMPTY_FILE": "6f3a4dcc-f060-a707-4950-806fbdbe60d6",
+    "NO_SUCH_FILE": "ebb53e5f-6574-9c0c-0b92-7ca6def56d7e",
+    "TOO_BIG_FILE": "b7fbf0b1-aeef-3b21-29ef-fadd4cb72ccf",
+    "UNEXPECTED_FILE_TYPE": "b6fab7d6-d945-d67c-dfdb-32da1cd12cfe"
+  },
+  "i/import-following": {
+    "EMPTY_FILE": "31a1b42c-06f7-42ae-8a38-a661c5c9f691",
+    "NO_SUCH_FILE": "b98644cf-a5ac-4277-a502-0b8054a709a3",
+    "TOO_BIG_FILE": "dee9d4ed-ad07-43ed-8b34-b2856398bc60",
+    "UNEXPECTED_FILE_TYPE": "660f3599-bce0-4f95-9dde-311fd841c183"
+  },
+  "i/import-muting": {
+    "EMPTY_FILE": "d2f12af1-e7b4-feac-86a3-519548f2728e",
+    "NO_SUCH_FILE": "e674141e-bd2a-ba85-e616-aefb187c9c2a",
+    "TOO_BIG_FILE": "9b4ada6d-d7f7-0472-0713-4f558bd1ec9c",
+    "UNEXPECTED_FILE_TYPE": "568c6e42-c86c-ba09-c004-517f83f9f1a8"
+  },
+  "i/import-user-lists": {
+    "EMPTY_FILE": "99efe367-ce6e-4d44-93f8-5fae7b040356",
+    "NO_SUCH_FILE": "ea9cc34f-c415-4bc6-a6fe-28ac40357049",
+    "TOO_BIG_FILE": "ae6e7a22-971b-4b52-b2be-fc0b9b121fe9",
+    "UNEXPECTED_FILE_TYPE": "a3c9edda-dd9b-4596-be6a-150ef813745c"
+  },
+  "i/move": {
+    "ALREADY_MOVED": "b234a14e-9ebe-4581-8000-074b3c215962",
+    "DESTINATION_ACCOUNT_FORBIDS": "b5c90186-4ab0-49c8-9bba-a1f766282ba4",
+    "NOT_ROOT_FORBIDDEN": "4362e8dc-731f-4ad8-a694-be2a88922a24",
+    "NO_SUCH_USER": "fcd2eef9-a9b2-4c4f-8624-038099e90aa5",
+    "URI_NULL": "95ba11b9-90e8-43a5-ba16-7acc1ab32e71"
+  },
+  "i/pin": {
+    "ALREADY_PINNED": "8b18c2b7-68fe-4edb-9892-c0cbaeb6c913",
+    "NO_SUCH_NOTE": "56734f8b-3928-431e-bf80-6ff87df40cb3",
+    "PIN_LIMIT_EXCEEDED": "72dab508-c64d-498f-8740-a8eec1ba385a"
+  },
+  "i/registry/get": {
+    "NO_SUCH_KEY": "ac3ed68a-62f0-422b-a7bc-d5e09e8f6a6a"
+  },
+  "i/registry/get-detail": {
+    "NO_SUCH_KEY": "97a1e8e7-c0f7-47d2-957a-92e61256e01a"
+  },
+  "i/registry/remove": {
+    "NO_SUCH_KEY": "1fac4e8a-a6cd-4e39-a4a5-3a7e11f1b019"
+  },
+  "i/unpin": {
+    "NO_SUCH_NOTE": "454170ce-9d63-4a43-9da1-ea10afe81e21"
+  },
+  "i/update": {
+    "AVATAR_NOT_AN_IMAGE": "f419f9f8-2f4d-46b1-9fb4-49d3a2fd7191",
+    "BANNER_NOT_AN_IMAGE": "75aedb19-2afd-4e6d-87fc-67941256fa60",
+    "FORBIDDEN_TO_SET_YOURSELF": "25c90186-4ab0-49c8-9bba-a1fa6c202ba4",
+    "INVALID_REGEXP": "0d786918-10df-41cd-8f33-8dec7d9a89a5",
+    "NO_SUCH_AVATAR": "539f3a45-f215-4f81-a9a8-31293640207f",
+    "NO_SUCH_BANNER": "0d8f5629-f210-41c2-9433-735831a58595",
+    "NO_SUCH_PAGE": "8e01b590-7eb9-431b-a239-860e086c408e",
+    "NO_SUCH_USER": "fcd2eef9-a9b2-4c4f-8624-038099e90aa5",
+    "RESTRICTED_BY_ROLE": "8feff0ba-5ab5-585b-31f4-4df816663fad",
+    "TOO_MANY_MUTED_WORDS": "010665b1-a211-42d2-bc64-8f6609d79785",
+    "URI_NULL": "bf326f31-d430-4f97-9933-5d61e4d48a23",
+    "YOUR_ACCOUNT_MOVED": "56f20ec9-fd06-4fa5-841b-edd6d7d4fa31",
+    "YOUR_NAME_CONTAINS_PROHIBITED_WORDS": "0b3f9f6a-2f4d-4b1f-9fb4-49d3a2fd7191"
+  },
+  "i/update-email": {
+    "EMAIL_REQUIRED": "324c7a88-59f2-492f-903f-89134f93e47e",
+    "INCORRECT_PASSWORD": "e54c1d7e-e7d6-4103-86b6-0a95069b4ad3",
+    "UNAVAILABLE": "a2defefb-f220-8849-0af6-17f816099323"
+  },
+  "i/webhooks/create": {
+    "TOO_MANY_WEBHOOKS": "87a9bb19-111e-4e37-81d3-a3e7426453b0"
+  },
+  "i/webhooks/delete": {
+    "NO_SUCH_WEBHOOK": "bae73e5a-5522-4965-ae19-3a8688e71d82"
+  },
+  "i/webhooks/show": {
+    "NO_SUCH_WEBHOOK": "50f614d9-3047-4f7e-90d8-ad6b2d5fb098"
+  },
+  "i/webhooks/test": {
+    "NO_SUCH_WEBHOOK": "0c52149c-e913-18f8-5dc7-74870bfe0cf9"
+  },
+  "i/webhooks/update": {
+    "NO_SUCH_WEBHOOK": "fb0fea69-da18-45b1-828d-bd4fd1612518"
+  },
+  "invite/create": {
+    "EXCEEDED_LIMIT_OF_CREATE_INVITE_CODE": "8b165dd3-6f37-4557-8db1-73175d63c641"
+  },
+  "invite/delete": {
+    "ACCESS_DENIED": "5eb8d909-2540-4970-90b8-dd6f86088121",
+    "CAN_NOT_DELETE_INVITE_CODE": "ff17af39-000c-4d4e-abdf-848fa30fc1ce",
+    "NO_SUCH_INVITE_CODE": "cd4f9ae4-7854-4e3e-8df9-c296f051e634"
+  },
+  "mute/create": {
+    "ALREADY_MUTING": "7e7359cb-160c-4956-b08f-4d1c653cd007",
+    "MUTEE_IS_YOURSELF": "a4619cb2-5f23-484b-9301-94c903074e10",
+    "NO_SUCH_USER": "6fef56f3-e765-4957-88e5-c6f65329b8a5"
+  },
+  "mute/delete": {
+    "MUTEE_IS_YOURSELF": "f428b029-6b39-4d48-a1d2-cc1ae6dd5cf9",
+    "NOT_MUTING": "5467d020-daa9-4553-81e1-135c0c35a96d",
+    "NO_SUCH_USER": "b851d00b-8ab1-4a56-8b1b-e24187cb48ef"
+  },
+  "notes/clips": {
+    "NO_SUCH_NOTE": "47db1a1c-b0af-458d-8fb4-986e4efafe1e"
+  },
+  "notes/conversation": {
+    "NO_SUCH_NOTE": "e1035875-9551-45ec-afa8-1ded1fcb53c8"
+  },
+  "notes/create": {
+    "CANNOT_CREATE_ALREADY_EXPIRED_POLL": "04da457d-b083-4055-9082-955525eda5a5",
+    "CANNOT_RENOTE_DUE_TO_VISIBILITY": "be9529e9-fe72-4de0-ae43-0b363c4938af",
+    "CANNOT_RENOTE_OUTSIDE_OF_CHANNEL": "33510210-8452-094c-6227-4a6c05d99f00",
+    "CANNOT_RENOTE_TO_A_PURE_RENOTE": "fd4cc33e-2a37-48dd-99cc-9b806eb2031a",
+    "CANNOT_REPLY_TO_AN_INVISIBLE_NOTE": "b98980fa-3780-406c-a935-b6d0eeee10d1",
+    "CANNOT_REPLY_TO_A_PURE_RENOTE": "3ac74a84-8fd5-4bb0-870f-01804f82ce15",
+    "CANNOT_REPLY_TO_SPECIFIED_VISIBILITY_NOTE_WITH_EXTENDED_VISIBILITY": "ed940410-535c-4d5e-bfa3-af798671e93c",
+    "CONTAINS_PROHIBITED_WORDS": "aa6e01d3-a85c-669d-758a-76aab43af334",
+    "CONTAINS_TOO_MANY_MENTIONS": "4de0363a-3046-481b-9b0f-feff3e211025",
+    "NO_SUCH_CHANNEL": "b1653923-5453-4edc-b786-7c4f39bb0bbb",
+    "NO_SUCH_FILE": "b6992544-63e7-67f0-fa7f-32444b1b5306",
+    "NO_SUCH_RENOTE_TARGET": "b5c90186-4ab0-49c8-9bba-a1f76c282ba4",
+    "NO_SUCH_REPLY_TARGET": "749ee0f6-d3da-459a-bf02-282e2da4292c",
+    "YOU_HAVE_BEEN_BLOCKED": "b390d7e1-8a5e-46ed-b625-06271cafd3d3"
+  },
+  "notes/delete": {
+    "ACCESS_DENIED": "fe8d7103-0ea8-4ec3-814d-f8b401dc69e9",
+    "NO_SUCH_NOTE": "490be23f-8c1f-4796-819f-94cb4f9d1630"
+  },
+  "notes/drafts/create": {
+    "CANNOT_CREATE_ALREADY_EXPIRED_POLL": "04da457d-b083-4055-9082-955525eda5a5",
+    "CANNOT_RENOTE_DUE_TO_VISIBILITY": "be9529e9-fe72-4de0-ae43-0b363c4938af",
+    "CANNOT_RENOTE_OUTSIDE_OF_CHANNEL": "33510210-8452-094c-6227-4a6c05d99f00",
+    "CANNOT_RENOTE_TO_A_PURE_RENOTE": "fd4cc33e-2a37-48dd-99cc-9b806eb2031a",
+    "CANNOT_RENOTE_TO_EXTERNAL": "ed1952ac-2d26-4957-8b30-2deda76bedf7",
+    "CANNOT_REPLY_TO_AN_INVISIBLE_NOTE": "b98980fa-3780-406c-a935-b6d0eeee10d1",
+    "CANNOT_REPLY_TO_A_PURE_RENOTE": "3ac74a84-8fd5-4bb0-870f-01804f82ce15",
+    "CANNOT_REPLY_TO_SPECIFIED_VISIBILITY_NOTE_WITH_EXTENDED_VISIBILITY": "ed940410-535c-4d5e-bfa3-af798671e93c",
+    "CONTAINS_PROHIBITED_WORDS": "aa6e01d3-a85c-669d-758a-76aab43af334",
+    "CONTAINS_TOO_MANY_MENTIONS": "4de0363a-3046-481b-9b0f-feff3e211025",
+    "NO_SUCH_CHANNEL": "b1653923-5453-4edc-b786-7c4f39bb0bbb",
+    "NO_SUCH_FILE": "b6992544-63e7-67f0-fa7f-32444b1b5306",
+    "NO_SUCH_RENOTE_TARGET": "b5c90186-4ab0-49c8-9bba-a1f76c282ba4",
+    "NO_SUCH_REPLY_TARGET": "749ee0f6-d3da-459a-bf02-282e2da4292c",
+    "SCHEDULED_AT_MUST_BE_IN_FUTURE": "e4bed6c9-017e-4934-aed0-01c22cc60ec1",
+    "SCHEDULED_AT_REQUIRED": "15e28a55-e74c-4d65-89b7-8880cdaaa87d",
+    "TOO_MANY_DRAFTS": "9ee33bbe-fde3-4c71-9b51-e50492c6b9c8",
+    "TOO_MANY_SCHEDULED_NOTES": "22ae69eb-09e3-4541-a850-773cfa45e693",
+    "YOU_HAVE_BEEN_BLOCKED": "b390d7e1-8a5e-46ed-b625-06271cafd3d3"
+  },
+  "notes/drafts/delete": {
+    "ACCESS_DENIED": "56f35758-7dd5-468b-8439-5d6fb8ec9b8e",
+    "NO_SUCH_NOTE_DRAFT": "49cd6b9d-848e-41ee-b0b9-adaca711a6b1"
+  },
+  "notes/drafts/update": {
+    "ACCESS_DENIED": "56f35758-7dd5-468b-8439-5d6fb8ec9b8e",
+    "CANNOT_CREATE_ALREADY_EXPIRED_POLL": "04da457d-b083-4055-9082-955525eda5a5",
+    "CANNOT_RENOTE": "76cc5583-5a14-4ad3-8717-0298507e32db",
+    "CANNOT_RENOTE_DUE_TO_VISIBILITY": "be9529e9-fe72-4de0-ae43-0b363c4938af",
+    "CANNOT_RENOTE_OUTSIDE_OF_CHANNEL": "33510210-8452-094c-6227-4a6c05d99f00",
+    "CANNOT_RENOTE_TO_A_PURE_RENOTE": "fd4cc33e-2a37-48dd-99cc-9b806eb2031a",
+    "CANNOT_RENOTE_TO_EXTERNAL": "ed1952ac-2d26-4957-8b30-2deda76bedf7",
+    "CANNOT_REPLY_TO_AN_INVISIBLE_NOTE": "b98980fa-3780-406c-a935-b6d0eeee10d1",
+    "CANNOT_REPLY_TO_A_PURE_RENOTE": "3ac74a84-8fd5-4bb0-870f-01804f82ce15",
+    "CANNOT_REPLY_TO_SPECIFIED_NOTE_WITH_EXTENDED_VISIBILITY": "ed940410-535c-4d5e-bfa3-af798671e93c",
+    "CANNOT_REPLY_TO_SPECIFIED_VISIBILITY_NOTE_WITH_EXTENDED_VISIBILITY": "215dbc76-336c-4d2a-9605-95766ba7dab0",
+    "CONTAINS_PROHIBITED_WORDS": "aa6e01d3-a85c-669d-758a-76aab43af334",
+    "CONTAINS_TOO_MANY_MENTIONS": "4de0363a-3046-481b-9b0f-feff3e211025",
+    "NO_SUCH_CHANNEL": "b1653923-5453-4edc-b786-7c4f39bb0bbb",
+    "NO_SUCH_FILE": "b6992544-63e7-67f0-fa7f-32444b1b5306",
+    "NO_SUCH_NOTE_DRAFT": "49cd6b9d-848e-41ee-b0b9-adaca711a6b1",
+    "NO_SUCH_RENOTE": "64929870-2540-4d11-af41-3b484d78c956",
+    "NO_SUCH_RENOTE_TARGET": "b5c90186-4ab0-49c8-9bba-a1f76c282ba4",
+    "NO_SUCH_REPLY": "c4721841-22fc-4bb7-ad3d-897ef1d375b5",
+    "NO_SUCH_REPLY_TARGET": "749ee0f6-d3da-459a-bf02-282e2da4292c",
+    "SCHEDULED_AT_MUST_BE_IN_FUTURE": "ed1a6673-d0d1-4364-aaae-9bf3f139cbc5",
+    "SCHEDULED_AT_REQUIRED": "fe9737d5-cc41-498c-af9d-149207307530",
+    "TOO_MANY_SCHEDULED_NOTES": "02f5df79-08ae-4a33-8524-f1503c8f6212",
+    "YOU_HAVE_BEEN_BLOCKED": "b390d7e1-8a5e-46ed-b625-06271cafd3d3"
+  },
+  "notes/favorites/create": {
+    "ALREADY_FAVORITED": "a402c12b-34dd-41d2-97d8-4d2ffd96a1a6",
+    "NO_SUCH_NOTE": "6dd26674-e060-4816-909a-45ba3f4da458"
+  },
+  "notes/favorites/delete": {
+    "NOT_FAVORITED": "b625fc69-635e-45e9-86f4-dbefbef35af5",
+    "NO_SUCH_NOTE": "80848a2c-398f-4343-baa9-df1d57696c56"
+  },
+  "notes/global-timeline": {
+    "GTL_DISABLED": "0332fc13-6ab2-4427-ae80-a9fadffd1a6b"
+  },
+  "notes/hybrid-timeline": {
+    "BOTH_WITH_REPLIES_AND_WITH_FILES": "dfaa3eb7-8002-4cb7-bcc4-1095df46656f",
+    "STL_DISABLED": "620763f4-f621-4533-ab33-0577a1a3c342"
+  },
+  "notes/local-timeline": {
+    "BOTH_WITH_REPLIES_AND_WITH_FILES": "dd9c8400-1cb5-4eef-8a31-200c5f933793",
+    "LTL_DISABLED": "45a6eb02-7695-4393-b023-dd3be9aaaefd"
+  },
+  "notes/polls/vote": {
+    "ALREADY_EXPIRED": "1022a357-b085-4054-9083-8f8de358337e",
+    "ALREADY_VOTED": "0963fc77-efac-419b-9424-b391608dc6d8",
+    "INVALID_CHOICE": "e0cc9a04-f2e8-41e4-a5f1-4127293260cc",
+    "NO_POLL": "5f979967-52d9-4314-a911-1c673727f92f",
+    "NO_SUCH_NOTE": "ecafbd2e-c283-4d6d-aecb-1a0a33b75396",
+    "YOU_HAVE_BEEN_BLOCKED": "85a5377e-b1e9-4617-b0b9-5bea73331e49"
+  },
+  "notes/reactions": {
+    "NO_SUCH_NOTE": "263fff3d-d0e1-4af4-bea7-8408059b451a"
+  },
+  "notes/reactions/create": {
+    "ALREADY_REACTED": "71efcf98-86d6-4e2b-b2ad-9d032369366b",
+    "CANNOT_REACT_TO_RENOTE": "eaccdc08-ddef-43fe-908f-d108faad57f5",
+    "NO_SUCH_NOTE": "033d0620-5bfe-4027-965d-980b0c85a3ea",
+    "YOU_HAVE_BEEN_BLOCKED": "20ef5475-9f38-4e4c-bd33-de6d979498ec"
+  },
+  "notes/reactions/delete": {
+    "NOT_REACTED": "92f4426d-4196-4125-aa5b-02943e2ec8fc",
+    "NO_SUCH_NOTE": "764d9fce-f9f2-4a0e-92b1-6ceac9a7ad37"
+  },
+  "notes/renotes": {
+    "NO_SUCH_NOTE": "12908022-2e21-46cd-ba6a-3edaf6093f46"
+  },
+  "notes/search": {
+    "UNAVAILABLE": "0b44998d-77aa-4427-80d0-d2c9b8523011"
+  },
+  "notes/show": {
+    "CONTENT_RESTRICTED_BY_SERVER": "145f88d2-b03d-4087-8143-a78928883c4b",
+    "CONTENT_RESTRICTED_BY_USER": "fbcc002d-37d9-4944-a6b0-d9e29f2d33ab",
+    "NO_SUCH_NOTE": "24fcbfc6-2e37-42b6-8388-c29b3861a08d"
+  },
+  "notes/thread-muting/create": {
+    "NO_SUCH_NOTE": "5ff67ada-ed3b-2e71-8e87-a1a421e177d2"
+  },
+  "notes/thread-muting/delete": {
+    "NO_SUCH_NOTE": "bddd57ac-ceb3-b29d-4334-86ea5fae481a"
+  },
+  "notes/translate": {
+    "CANNOT_TRANSLATE_INVISIBLE_NOTE": "ea29f2ca-c368-43b3-aaf1-5ac3e74bbe5d",
+    "NO_SUCH_NOTE": "bea9b03f-36e0-49c5-a4db-627a029f8971",
+    "UNAVAILABLE": "50a70314-2d8a-431b-b433-efa5cc56444c"
+  },
+  "notes/unrenote": {
+    "NO_SUCH_NOTE": "efd4a259-2442-496b-8dd7-b255aa1a160f"
+  },
+  "notes/user-list-timeline": {
+    "NO_SUCH_LIST": "8fb1fbd5-e476-4c37-9fb0-43d55b63a2ff"
+  },
+  "page-push": {
+    "NO_SUCH_PAGE": "4a13ad31-6729-46b4-b9af-e86b265c2e74"
+  },
+  "pages/create": {
+    "NAME_ALREADY_EXISTS": "4650348e-301c-499a-83c9-6aa988c66bc1",
+    "NO_SUCH_FILE": "b7b97489-0f66-4b12-a5ff-b21bd63f6e1c"
+  },
+  "pages/delete": {
+    "ACCESS_DENIED": "8b741b3e-2c22-44b3-a15f-29949aa1601e",
+    "NO_SUCH_PAGE": "eb0c6e1d-d519-4764-9486-52a7e1c6392a"
+  },
+  "pages/like": {
+    "ALREADY_LIKED": "d4c1edbe-7da2-4eae-8714-1acfd2d63941",
+    "NO_SUCH_PAGE": "cc98a8a2-0dc3-4123-b198-62c71df18ed3",
+    "YOUR_PAGE": "28800466-e6db-40f2-8fae-bf9e82aa92b8"
+  },
+  "pages/show": {
+    "NO_SUCH_PAGE": "222120c0-3ead-4528-811b-b96f233388d7"
+  },
+  "pages/unlike": {
+    "NOT_LIKED": "f5e586b0-ce93-4050-b0e3-7f31af5259ee",
+    "NO_SUCH_PAGE": "a0d41e20-1993-40bd-890e-f6e560ae648e"
+  },
+  "pages/update": {
+    "ACCESS_DENIED": "3c15cd52-3b4b-4274-967d-6456fc4f792b",
+    "NAME_ALREADY_EXISTS": "2298a392-d4a1-44c5-9ebb-ac1aeaa5a9ab",
+    "NO_SUCH_FILE": "cfc23c7c-3887-490e-af30-0ed576703c82",
+    "NO_SUCH_PAGE": "21149b9e-3616-4778-9592-c4ce89f5a864"
+  },
+  "promo/read": {
+    "NO_SUCH_NOTE": "d785b897-fcd3-4fe9-8fc3-b85c26e6c932"
+  },
+  "renote-mute/create": {
+    "ALREADY_MUTING": "ccfecbe4-1f1c-4fc2-8a3d-c3ffee61cb7b",
+    "MUTEE_IS_YOURSELF": "37285718-52f7-4aef-b7de-c38b8e8a8420",
+    "NO_SUCH_USER": "5e0a5dff-1e94-4202-87ae-4d9c89eb2271"
+  },
+  "renote-mute/delete": {
+    "MUTEE_IS_YOURSELF": "619b1314-0850-4597-a242-e245f3da42af",
+    "NOT_MUTING": "2e4ef874-8bf0-4b4b-b069-4598f6d05817",
+    "NO_SUCH_USER": "9b6728cf-638c-4aa1-bedb-e07d8101474d"
+  },
+  "reversi/match": {
+    "NO_SUCH_USER": "0b4f0559-b484-4e31-9581-3f73cee89b28",
+    "TARGET_IS_YOURSELF": "96fd7bd6-d2bc-426c-a865-d055dcd2828e"
+  },
+  "reversi/show-game": {
+    "NO_SUCH_GAME": "f13a03db-fae1-46c9-87f3-43c8165419e1"
+  },
+  "reversi/surrender": {
+    "ACCESS_DENIED": "6e04164b-a992-4c93-8489-2123069973e1",
+    "ALREADY_ENDED": "6c2ad4a6-cbf1-4a5b-b187-b772826cfc6d",
+    "NO_SUCH_GAME": "ace0b11f-e0a6-4076-a30d-e8284c81b2df"
+  },
+  "reversi/verify": {
+    "NO_SUCH_GAME": "8fb05624-b525-43dd-90f7-511852bdfeee"
+  },
+  "roles/notes": {
+    "NO_SUCH_ROLE": "eb70323a-df61-4dd4-ad90-89c83c7cf26e"
+  },
+  "roles/show": {
+    "NO_SUCH_ROLE": "de5502bf-009a-4639-86c1-fec349e46dcb"
+  },
+  "roles/users": {
+    "NO_SUCH_ROLE": "30aaaee3-4792-48dc-ab0d-cf501a575ac5"
+  },
+  "sw/update-registration": {
+    "NO_SUCH_REGISTRATION": " b09d8066-8064-5613-efb6-0e963b21d012"
+  },
+  "users/followers": {
+    "FORBIDDEN": "3c6a84db-d619-26af-ca14-06232a21df8a",
+    "NO_SUCH_USER": "27fa5435-88ab-43de-9360-387de88727cd"
+  },
+  "users/following": {
+    "BIRTHDAY_DATE_FORMAT_INVALID": "a2b007b9-4782-4eba-abd3-93b05ed4130d",
+    "FORBIDDEN": "f6cdb0df-c19f-ec5c-7dbb-0ba84a1f92ba",
+    "NO_SUCH_USER": "63e4aba4-4156-4e53-be25-c9559e42d71b"
+  },
+  "users/get-frequently-replied-users": {
+    "NO_SUCH_USER": "e6965129-7b2a-40a4-bae2-cd84cd434822"
+  },
+  "users/lists/create": {
+    "TOO_MANY_USERLISTS": "0cf21a28-7715-4f39-a20d-777bfdb8d138"
+  },
+  "users/lists/create-from-public": {
+    "ALREADY_ADDED": "c3ad6fdb-692b-47ee-a455-7bd12c7af615",
+    "NO_SUCH_LIST": "9292f798-6175-4f7d-93f4-b6742279667d",
+    "NO_SUCH_USER": "13c457db-a8cb-4d88-b70a-211ceeeabb5f",
+    "TOO_MANY_USERLISTS": "e9c105b2-c595-47de-97fb-7f7c2c33e92f",
+    "TOO_MANY_USERS": "1845ea77-38d1-426e-8e4e-8b83b24f5bd7",
+    "YOU_HAVE_BEEN_BLOCKED": "a2497f2a-2389-439c-8626-5298540530f4"
+  },
+  "users/lists/delete": {
+    "NO_SUCH_LIST": "78436795-db79-42f5-b1e2-55ea2cf19166"
+  },
+  "users/lists/favorite": {
+    "ALREADY_FAVORITED": "6425bba0-985b-461e-af1b-518070e72081",
+    "NO_SUCH_USER_LIST": "7dbaf3cf-7b42-4b8f-b431-b3919e580dbe"
+  },
+  "users/lists/get-memberships": {
+    "NO_SUCH_LIST": "7bc05c21-1d7a-41ae-88f1-66820f4dc686"
+  },
+  "users/lists/list": {
+    "INVALID_PARAM": "ab36de0e-29e9-48cb-9732-d82f1281620d",
+    "NO_SUCH_USER": "a8af4a82-0980-4cc4-a6af-8b0ffd54465e",
+    "REMOTE_USER_NOT_ALLOWED": "53858f1b-3315-4a01-81b7-db9b48d4b79a"
+  },
+  "users/lists/pull": {
+    "NO_SUCH_LIST": "7f44670e-ab16-43b8-b4c1-ccd2ee89cc02",
+    "NO_SUCH_USER": "588e7f72-c744-4a61-b180-d354e912bda2"
+  },
+  "users/lists/push": {
+    "ALREADY_ADDED": "1de7c884-1595-49e9-857e-61f12f4d4fc5",
+    "NO_SUCH_LIST": "2214501d-ac96-4049-b717-91e42272a711",
+    "NO_SUCH_USER": "a89abd3d-f0bc-4cce-beb1-2f446f4f1e6a",
+    "TOO_MANY_USERS": "2dd9752e-a338-413d-8eec-41814430989b",
+    "YOU_HAVE_BEEN_BLOCKED": "990232c5-3f9d-4d83-9f3f-ef27b6332a4b"
+  },
+  "users/lists/show": {
+    "NO_SUCH_LIST": "7bc05c21-1d7a-41ae-88f1-66820f4dc686"
+  },
+  "users/lists/unfavorite": {
+    "ALREADY_FAVORITED": "835c4b27-463d-4cfa-969b-a9058678d465",
+    "NO_SUCH_USER_LIST": "baedb33e-76b8-4b0c-86a8-9375c0a7b94b"
+  },
+  "users/lists/update": {
+    "NO_SUCH_LIST": "796666fe-3dff-4d39-becb-8a5932c1d5b7"
+  },
+  "users/lists/update-membership": {
+    "NO_SUCH_LIST": "7f44670e-ab16-43b8-b4c1-ccd2ee89cc02",
+    "NO_SUCH_USER": "588e7f72-c744-4a61-b180-d354e912bda2"
+  },
+  "users/notes": {
+    "BOTH_WITH_REPLIES_AND_WITH_FILES": "91c8cb9f-36ed-46e7-9ca2-7df96ed6e222",
+    "NO_SUCH_USER": "27e494ba-2ac2-48e8-893b-10d4d8c2387b",
+    "SIGNIN_REQUIRED": "d1588a9e-4b4d-4c07-807f-16f1486577a2"
+  },
+  "users/reactions": {
+    "IS_REMOTE_USER": "6b95fa98-8cf9-2350-e284-f0ffdb54a805",
+    "REACTIONS_NOT_PUBLIC": "673a7dd2-6924-1093-e0c0-e68456ceae5c"
+  },
+  "users/report-abuse": {
+    "CANNOT_REPORT_THE_ADMIN": "35e166f5-05fb-4f87-a2d5-adb42676d48f",
+    "CANNOT_REPORT_YOURSELF": "1e13149e-b1e8-43cf-902e-c01dbfcb202f",
+    "NO_SUCH_USER": "1acefcb5-0959-43fd-9685-b48305736cb5"
+  },
+  "users/show": {
+    "FAILED_TO_RESOLVE_REMOTE_USER": "ef7b9be4-9cba-4e6f-ab41-90ed171c7d3c",
+    "NO_SUCH_USER": "4362f8dc-731f-4ad8-a694-be5a88922a24"
+  },
+  "users/update-memo": {
+    "NO_SUCH_USER": "6fef56f3-e765-4957-88e5-c6f65329b8a5"
+  },
+  "verify-email": {
+    "NO_SUCH_CODE": "97c1f576-e4b8-4b8a-a6dc-9cb65e7f6f85"
+  }
+}

--- a/tools/erroriddiff/main.go
+++ b/tools/erroriddiff/main.go
@@ -1,0 +1,86 @@
+// Command erroriddiff regenerates the golden per-endpoint error-id snapshot
+// used by the entitycompat error-id drift gate (TestErrorIDDrift).
+//
+// Misskey identifies API errors not only by their `code` but by a per-endpoint
+// UUID `id` (meta.errors[*].id). Clients branch on that id, so an id that does
+// not match the upstream endpoint breaks drop-in compatibility even when the
+// code is right. This tool extracts every endpoint's (code -> id) map from the
+// backend endpoint definitions and writes it to
+// internal/entitycompat/testdata/golden_error_ids.json. Regenerate it whenever
+// the third_party/misskey submodule is bumped to a new upstream version.
+//
+// Usage:
+//
+//	go run ./tools/erroriddiff
+package main
+
+import (
+	"encoding/json"
+	"flag"
+	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+)
+
+// codeIDRe matches a Misskey meta.errors entry. All 448 upstream entries place
+// `id` directly after `code`, so the adjacent pattern captures every pair.
+var codeIDRe = regexp.MustCompile(`code:\s*'([^']+)'\s*,\s*id:\s*'([^']+)'`)
+
+func main() {
+	epDir := flag.String("endpoints", "third_party/misskey/packages/backend/src/server/api/endpoints", "path to Misskey backend endpoints dir")
+	out := flag.String("out", "internal/entitycompat/testdata/golden_error_ids.json", "golden snapshot output path")
+	flag.Parse()
+
+	golden := map[string]map[string]string{}
+	err := filepath.WalkDir(*epDir, func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if d.IsDir() || !strings.HasSuffix(path, ".ts") {
+			return nil
+		}
+		rel, err := filepath.Rel(*epDir, path)
+		if err != nil {
+			return err
+		}
+		ep := strings.TrimSuffix(filepath.ToSlash(rel), ".ts")
+		data, err := os.ReadFile(path)
+		if err != nil {
+			return err
+		}
+		for _, m := range codeIDRe.FindAllStringSubmatch(string(data), -1) {
+			if golden[ep] == nil {
+				golden[ep] = map[string]string{}
+			}
+			golden[ep][m[1]] = m[2]
+		}
+		return nil
+	})
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "erroriddiff: walk: %v\n", err)
+		os.Exit(1)
+	}
+	if len(golden) == 0 {
+		fmt.Fprintln(os.Stderr, "erroriddiff: ERROR no endpoints parsed (wrong path or upstream format change?)")
+		os.Exit(1)
+	}
+
+	buf, err := json.MarshalIndent(golden, "", "  ")
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "erroriddiff: marshal: %v\n", err)
+		os.Exit(1)
+	}
+	if err := os.WriteFile(*out, append(buf, '\n'), 0o644); err != nil {
+		fmt.Fprintf(os.Stderr, "erroriddiff: write: %v\n", err)
+		os.Exit(1)
+	}
+
+	ids := 0
+	for _, m := range golden {
+		ids += len(m)
+	}
+	fmt.Printf("erroriddiff: wrote %d endpoints / %d error ids -> %s\n", len(golden), ids, *out)
+}


### PR DESCRIPTION
## Summary

API エラーレスポンスの `id` (UUID) drift を per-endpoint で修正し、再発防止の **error-id drift gate** を新設する。shape-drift gate (#1 完了) に続く #2「behavior 互換」の第一弾。

Misskey クライアントはエラーを `code` だけでなく `id` (endpoint 固有 UUID) で識別する。mk-go は **1 code = 1 UUID を複数 endpoint で使い回す**箇所が多く、Misskey の **endpoint ごとに別 UUID** という契約とずれていた。

## 主な変更点

### 1. error id の per-endpoint 整合 (計 78 箇所)

- inline literal 51 箇所 + helper/定数経由 6 箇所 + echo wrapper 経由 25 箇所 (call site 27) を、各 endpoint 固有 id へ整合
- 変更は id 文字列のみ、ロジック不変。すべて Misskey `endpoints/*.ts` の `meta.errors` と照合
  - 例: `NO_SUCH_WEBHOOK` を show/update/delete/test の 4 固有 id へ; `NO_SUCH_NOTE`/`NO_SUCH_USER`/`ACCESS_DENIED` の canonical helper 使い回しを各 endpoint 固有 id へ

### 2. error-id drift gate 新設 (再発防止)

- `internal/entitycompat/error_ids_test.go` の `TestErrorIDDrift`: handler が emit する `(code, id)` を **4 経路** (inline / UUID 定数 / apierr helper / echo `JSONXxx` wrapper) で静的抽出し、`router.go` 解決で endpoint に対応づけ golden と突合
- echo wrapper 経路は handler の最頻送出経路。当初これを解決しておらず gate が 25 drift を素通ししていた (セルフレビューで検出) → wrapper 解決を追加し解決 emission 数 577→652
- **silent-zero guard**: regex 抽出が空振りして解決数が下限 (400) を下回ったら gate を失敗させ、vacuous PASS を防ぐ
- golden は `tools/erroriddiff` が `endpoints/*.ts` から生成し `testdata/golden_error_ids.json` に embed (third_party 非依存で CI 実行可)
- `make errorid-check` で単体実行、`make shapecheck-gen` で shape golden と一括再生成。`docs/shape-drift.md` に運用追記

### 除外 (意図的)

- **reversi/* ・ chat/***: cherrypick 派生。id も vanilla へ寄せない (`errorIDExcludedPrefixes`)
- **upstream typo で id が壊れた箇所**: `sw/update-registration` (先頭スペース)、`i/2fa/update-key` 等 (非 hex 文字)。`validUUID` で自動 skip

## テスト

- `TestErrorIDDrift` green (vanilla mismatch 0、解決 emission 652 件)
- 変更パッケージ + `apierr` / `signin` / `entitycompat` の `go test` 全 pass (id assert テスト 5 件を新値へ更新)
- `make fmt` / `make lint` / `go build ./...` 通過、golden 再生成は決定的

```
make errorid-check
```

## Closes

Closes #1332

🤖 Generated with [Claude Code](https://claude.com/claude-code)