### PR TITLE
fix(api): error id gate の free-helper 盲点を塞ぎ per-endpoint id へ整合 (part 1)

### DIFF
--- a/internal/api/antennas/handler.go
+++ b/internal/api/antennas/handler.go
@@ -154,7 +154,7 @@ func (h *Handler) Show(c echo.Context) error {
 			return apierr.JSONAccessDenied(c)
 		}
 		// Show は ErrAntennaNotFound 以外を返さない (未マップ含む)
-		return notFound(c)
+		return c.JSON(http.StatusNotFound, apierr.Error("NO_SUCH_ANTENNA", "No such antenna.", "c06569fb-b025-4f23-b22d-1fcd20d2816b"))
 	}
 	return c.JSON(http.StatusOK, h.antennaToMap(a))
 }
@@ -200,7 +200,7 @@ func (h *Handler) Update(c echo.Context) error {
 	if err != nil {
 		switch {
 		case errors.Is(err, coreantenna.ErrAntennaNotFound):
-			return notFound(c)
+			return c.JSON(http.StatusNotFound, apierr.Error("NO_SUCH_ANTENNA", "No such antenna.", "10c673ac-8852-48eb-aa1f-f5b67f069290"))
 		case errors.Is(err, coreantenna.ErrAccessDenied):
 			return apierr.JSONAccessDenied(c)
 		case errors.Is(err, coreantenna.ErrAntennaNameRequired),
@@ -227,7 +227,7 @@ func (h *Handler) Delete(c echo.Context) error {
 	if err := h.svc.Delete(user.ID, req.AntennaID); err != nil {
 		switch {
 		case errors.Is(err, coreantenna.ErrAntennaNotFound):
-			return notFound(c)
+			return c.JSON(http.StatusNotFound, apierr.Error("NO_SUCH_ANTENNA", "No such antenna.", "b34dcf9d-348f-44bb-99d0-6c9314cfe2df"))
 		case errors.Is(err, coreantenna.ErrAccessDenied):
 			return apierr.JSONAccessDenied(c)
 		}
@@ -277,7 +277,7 @@ func (h *Handler) Notes(c echo.Context) error {
 	if err != nil {
 		switch {
 		case errors.Is(err, coreantenna.ErrAntennaNotFound):
-			return notFound(c)
+			return c.JSON(http.StatusNotFound, apierr.Error("NO_SUCH_ANTENNA", "No such antenna.", "850926e0-fd3b-49b6-b69a-b28a5dbd82fe"))
 		case errors.Is(err, coreantenna.ErrAccessDenied):
 			return apierr.JSONAccessDenied(c)
 		}
@@ -354,8 +354,4 @@ func jsonArrayOrEmpty(b []byte) any {
 		return []any{}
 	}
 	return json.RawMessage(b)
-}
-
-func notFound(c echo.Context) error {
-	return c.JSON(http.StatusNotFound, apierr.Error("NO_SUCH_ANTENNA", "No such antenna.", "3a1fb010-b54c-4f28-9a06-a5c7c7c1c33a"))
 }

--- a/internal/api/channels/favorites.go
+++ b/internal/api/channels/favorites.go
@@ -28,7 +28,7 @@ func (h *Handler) Favorite(c echo.Context) error {
 		return c.NoContent(http.StatusNoContent)
 	}
 	if _, err := h.svc.Show(req.ChannelID); err != nil {
-		return notFound(c)
+		return c.JSON(http.StatusNotFound, apierr.Error("NO_SUCH_CHANNEL", "No such channel.", "4938f5f3-6167-4c04-9149-6607b7542861"))
 	}
 	already, _ := h.favoriteRepo.Exists(user.ID, req.ChannelID)
 	if already {

--- a/internal/api/channels/handler.go
+++ b/internal/api/channels/handler.go
@@ -185,7 +185,7 @@ func (h *Handler) Show(c echo.Context) error {
 	}
 	ch, err := h.svc.Show(req.ChannelID)
 	if err != nil {
-		return notFound(c)
+		return c.JSON(http.StatusNotFound, apierr.Error("NO_SUCH_CHANNEL", "No such channel.", "6f6c314b-7486-4897-8966-c04a66a02923"))
 	}
 	return c.JSON(http.StatusOK, h.channelToMapForViewer(ch, middleware.GetUser(c)))
 }
@@ -221,7 +221,7 @@ func (h *Handler) Update(c echo.Context) error {
 	if err != nil {
 		switch {
 		case errors.Is(err, corechannel.ErrChannelNotFound):
-			return notFound(c)
+			return c.JSON(http.StatusNotFound, apierr.Error("NO_SUCH_CHANNEL", "No such channel.", "f9c5467f-d492-4c3c-9a8d-a70dacc86512"))
 		case errors.Is(err, corechannel.ErrAccessDenied):
 			return c.JSON(http.StatusForbidden, apierr.Error("ACCESS_DENIED", "Access denied.", "1fb7cb09-d46a-4fdf-b8df-057788cce513"))
 		case errors.Is(err, corechannel.ErrChannelNameRequired):
@@ -247,7 +247,7 @@ func (h *Handler) Follow(c echo.Context) error {
 	if err := h.svc.Follow(user.ID, req.ChannelID); err != nil {
 		switch {
 		case errors.Is(err, corechannel.ErrChannelNotFound):
-			return notFound(c)
+			return c.JSON(http.StatusNotFound, apierr.Error("NO_SUCH_CHANNEL", "No such channel.", "c0031718-d573-4e85-928e-10039f1fbb68"))
 		case errors.Is(err, corechannel.ErrAlreadyFollowing):
 			return alreadyFollowing(c)
 		}
@@ -390,7 +390,7 @@ func (h *Handler) Timeline(c echo.Context) error {
 	notes, err := h.svc.Timeline(req.ChannelID, untilID, sinceID, limit)
 	if err != nil {
 		if errors.Is(err, corechannel.ErrChannelNotFound) {
-			return notFound(c)
+			return c.JSON(http.StatusNotFound, apierr.Error("NO_SUCH_CHANNEL", "No such channel.", "4d0eeeba-a02c-4c3c-9966-ef60d38d2e7f"))
 		}
 		return apierr.JSONInternalError(c)
 	}
@@ -558,10 +558,6 @@ func (h *Handler) channelsToList(rows []*model.Channel, viewer *model.User) []ma
 		out = append(out, m)
 	}
 	return out
-}
-
-func notFound(c echo.Context) error {
-	return c.JSON(http.StatusNotFound, apierr.Error("NO_SUCH_CHANNEL", "No such channel.", "8ee5d9d4-9cb0-4f40-bba4-aaa31a3b48b9"))
 }
 
 func alreadyFollowing(c echo.Context) error {

--- a/internal/api/channels/mute.go
+++ b/internal/api/channels/mute.go
@@ -28,7 +28,7 @@ func (h *Handler) MuteCreate(c echo.Context) error {
 		return c.NoContent(http.StatusNoContent)
 	}
 	if _, err := h.svc.Show(req.ChannelID); err != nil {
-		return notFound(c)
+		return c.JSON(http.StatusNotFound, apierr.Error("NO_SUCH_CHANNEL", "No such channel.", "7174361e-d58f-31d6-2e7c-6fb830786a3f"))
 	}
 	already, _ := h.mutingRepo.Exists(user.ID, req.ChannelID)
 	if already {

--- a/internal/api/clips/favorites.go
+++ b/internal/api/clips/favorites.go
@@ -37,7 +37,7 @@ func (h *Handler) Favorite(c echo.Context) error {
 	}
 	// クリップの存在確認
 	if _, err := h.svc.Show(user.ID, req.ClipID); err != nil {
-		return notFound(c)
+		return c.JSON(http.StatusNotFound, apierr.Error("NO_SUCH_CLIP", "No such clip.", "4c2aaeae-80d8-4250-9606-26cb1fdb77a5"))
 	}
 	already, _ := h.favoriteRepo.Exists(user.ID, req.ClipID)
 	if already {

--- a/internal/api/clips/handler.go
+++ b/internal/api/clips/handler.go
@@ -133,7 +133,7 @@ func (h *Handler) Show(c echo.Context) error {
 		if errors.Is(err, coreclip.ErrAccessDenied) {
 			return apierr.JSONAccessDenied(c)
 		}
-		return notFound(c)
+		return c.JSON(http.StatusNotFound, apierr.Error("NO_SUCH_CLIP", "No such clip.", "c3c5fe33-d62c-44d2-9ea5-d997703f5c20"))
 	}
 	return c.JSON(http.StatusOK, h.clipToMap(cl))
 }
@@ -165,7 +165,7 @@ func (h *Handler) Update(c echo.Context) error {
 	if err != nil {
 		switch {
 		case errors.Is(err, coreclip.ErrClipNotFound):
-			return notFound(c)
+			return c.JSON(http.StatusNotFound, apierr.Error("NO_SUCH_CLIP", "No such clip.", "b4d92d70-b216-46fa-9a3f-a8c811699257"))
 		case errors.Is(err, coreclip.ErrAccessDenied):
 			return apierr.JSONAccessDenied(c)
 		case errors.Is(err, coreclip.ErrClipNameRequired):
@@ -191,7 +191,7 @@ func (h *Handler) Delete(c echo.Context) error {
 	if err := h.svc.Delete(user.ID, req.ClipID); err != nil {
 		switch {
 		case errors.Is(err, coreclip.ErrClipNotFound):
-			return notFound(c)
+			return c.JSON(http.StatusNotFound, apierr.Error("NO_SUCH_CLIP", "No such clip.", "70ca08ba-6865-4630-b6fb-8494759aa754"))
 		case errors.Is(err, coreclip.ErrAccessDenied):
 			return apierr.JSONAccessDenied(c)
 		}
@@ -249,13 +249,13 @@ func (h *Handler) AddNote(c echo.Context) error {
 	if err := h.svc.AddNote(user.ID, req.ClipID, req.NoteID); err != nil {
 		switch {
 		case errors.Is(err, coreclip.ErrClipNotFound):
-			return notFound(c)
+			return c.JSON(http.StatusNotFound, apierr.Error("NO_SUCH_CLIP", "No such clip.", "d6e76cc0-a1b5-4c7c-a287-73fa9c716dcf"))
 		case errors.Is(err, coreclip.ErrAccessDenied):
 			return apierr.JSONAccessDenied(c)
 		case errors.Is(err, coreclip.ErrNoteNotFound):
-			return notFoundNote(c)
+			return c.JSON(http.StatusNotFound, apierr.Error("NO_SUCH_NOTE", "No such note.", "fc8c0b49-c7a3-4664-a0a6-b418d386bb8b"))
 		case errors.Is(err, coreclip.ErrAlreadyClipped):
-			return alreadyClipped(c)
+			return c.JSON(http.StatusBadRequest, apierr.Error("ALREADY_CLIPPED", "The note has already been clipped.", "734806c4-542c-463a-9311-15c512803965"))
 		case errors.Is(err, coreclip.ErrTooManyClipNotes):
 			return apierr.JSONTooManyClipNotes(c)
 		}
@@ -280,7 +280,7 @@ func (h *Handler) RemoveNote(c echo.Context) error {
 	if err := h.svc.RemoveNote(user.ID, req.ClipID, req.NoteID); err != nil {
 		switch {
 		case errors.Is(err, coreclip.ErrClipNotFound):
-			return notFound(c)
+			return c.JSON(http.StatusNotFound, apierr.Error("NO_SUCH_CLIP", "No such clip.", "b80525c6-97f7-49d7-a42d-ebccd49cfd52"))
 		case errors.Is(err, coreclip.ErrAccessDenied):
 			return apierr.JSONAccessDenied(c)
 		case errors.Is(err, coreclip.ErrNotClipped):
@@ -318,7 +318,7 @@ func (h *Handler) Notes(c echo.Context) error {
 	if err != nil {
 		switch {
 		case errors.Is(err, coreclip.ErrClipNotFound):
-			return notFound(c)
+			return c.JSON(http.StatusNotFound, apierr.Error("NO_SUCH_CLIP", "No such clip.", "1d7645e6-2b6d-4635-b0fe-fe22b0e72e00"))
 		case errors.Is(err, coreclip.ErrAccessDenied):
 			return apierr.JSONAccessDenied(c)
 		}
@@ -344,18 +344,6 @@ func (h *Handler) clipToMap(cl *model.Clip) map[string]any {
 		owner, _ = h.userRepo.FindByID(cl.UserID)
 	}
 	return entity.PackClip(cl, h.idGen, owner)
-}
-
-func notFound(c echo.Context) error {
-	return c.JSON(http.StatusNotFound, apierr.Error("NO_SUCH_CLIP", "No such clip.", "f4a9c0c6-a6c3-4a07-8e6b-0a4f2b1a27e9"))
-}
-
-func notFoundNote(c echo.Context) error {
-	return c.JSON(http.StatusNotFound, apierr.NoSuchNote())
-}
-
-func alreadyClipped(c echo.Context) error {
-	return c.JSON(http.StatusBadRequest, apierr.Error("ALREADY_CLIPPED", "The note has already been clipped.", "734806c4-542c-463a-9311-15c512803965"))
 }
 
 func notClipped(c echo.Context) error {

--- a/internal/api/flash/handler.go
+++ b/internal/api/flash/handler.go
@@ -81,7 +81,7 @@ func (h *Handler) Show(c echo.Context) error {
 	}
 	f, err := h.svc.Show(requesterID, req.FlashID)
 	if err != nil {
-		return notFound(c)
+		return c.JSON(http.StatusNotFound, apierr.Error("NO_SUCH_FLASH", "No such flash.", "f0d34a1a-d29a-401d-90ba-1982122b5630"))
 	}
 	resp := h.flashesToListWithUser([]*model.Flash{f})[0]
 	if user != nil {
@@ -120,7 +120,7 @@ func (h *Handler) Update(c echo.Context) error {
 	if err != nil {
 		switch {
 		case errors.Is(err, coreflash.ErrFlashNotFound):
-			return notFound(c)
+			return c.JSON(http.StatusNotFound, apierr.Error("NO_SUCH_FLASH", "No such flash.", "611e13d2-309e-419a-a5e4-e0422da39b02"))
 		case errors.Is(err, coreflash.ErrAccessDenied):
 			return c.JSON(http.StatusForbidden, apierr.Error("ACCESS_DENIED", "Access denied.", "08e60c88-5948-478e-a132-02ec701d67b2"))
 		case errors.Is(err, coreflash.ErrFlashTitleRequired):
@@ -146,7 +146,7 @@ func (h *Handler) Delete(c echo.Context) error {
 	if err := h.svc.Delete(user.ID, req.FlashID); err != nil {
 		switch {
 		case errors.Is(err, coreflash.ErrFlashNotFound):
-			return notFound(c)
+			return c.JSON(http.StatusNotFound, apierr.Error("NO_SUCH_FLASH", "No such flash.", "de1623ef-bbb3-4289-a71e-14cfa83d9740"))
 		case errors.Is(err, coreflash.ErrAccessDenied):
 			return c.JSON(http.StatusForbidden, apierr.Error("ACCESS_DENIED", "Access denied.", "1036ad7b-9f92-4fff-89c3-0e50dc941704"))
 		}
@@ -239,9 +239,9 @@ func (h *Handler) Like(c echo.Context) error {
 	if err := h.svc.Like(user.ID, req.FlashID); err != nil {
 		switch {
 		case errors.Is(err, coreflash.ErrFlashNotFound):
-			return notFound(c)
+			return c.JSON(http.StatusNotFound, apierr.Error("NO_SUCH_FLASH", "No such flash.", "c07c1491-9161-4c5c-9d75-01906f911f73"))
 		case errors.Is(err, coreflash.ErrAlreadyLiked):
-			return alreadyLiked(c)
+			return c.JSON(http.StatusBadRequest, apierr.Error("ALREADY_LIKED", "You already liked that flash.", "010065cf-ad43-40df-8067-abff9f4686e3"))
 		}
 		return apierr.JSONInternalError(c)
 	}
@@ -258,9 +258,9 @@ func (h *Handler) Unlike(c echo.Context) error {
 	if err := h.svc.Unlike(user.ID, req.FlashID); err != nil {
 		switch {
 		case errors.Is(err, coreflash.ErrFlashNotFound):
-			return notFound(c)
+			return c.JSON(http.StatusNotFound, apierr.Error("NO_SUCH_FLASH", "No such flash.", "afe8424a-a69e-432d-a5f2-2f0740c62410"))
 		case errors.Is(err, coreflash.ErrNotLiked):
-			return notLiked(c)
+			return c.JSON(http.StatusBadRequest, apierr.Error("NOT_LIKED", "You have not liked that flash.", "755f25a7-9871-4f65-9f34-51eaad9ae0ac"))
 		}
 		return apierr.JSONInternalError(c)
 	}
@@ -377,16 +377,4 @@ func (h *Handler) flashesToListWithUser(rows []*model.Flash) []map[string]any {
 		out = append(out, entry)
 	}
 	return out
-}
-
-func notFound(c echo.Context) error {
-	return c.JSON(http.StatusNotFound, apierr.Error("NO_SUCH_FLASH", "No such flash.", "f0d34a1a-d29a-401d-90ba-1982122b5630"))
-}
-
-func alreadyLiked(c echo.Context) error {
-	return c.JSON(http.StatusBadRequest, apierr.Error("ALREADY_LIKED", "You already liked that flash.", "33106d32-22c2-4cdb-9c2e-29ddf92fd14c"))
-}
-
-func notLiked(c echo.Context) error {
-	return c.JSON(http.StatusBadRequest, apierr.Error("NOT_LIKED", "You have not liked that flash.", "f5eb37a7-72e4-4c2a-89e1-d56fbafe8b25"))
 }

--- a/internal/api/pages/handler.go
+++ b/internal/api/pages/handler.go
@@ -103,7 +103,7 @@ func (h *Handler) Create(c echo.Context) error {
 	})
 	if err != nil {
 		if errors.Is(err, corepage.ErrPageNameConflict) {
-			return nameConflict(c)
+			return c.JSON(http.StatusBadRequest, apierr.Error("NAME_ALREADY_EXISTS", "The page name is already in use.", "4650348e-301c-499a-83c9-6aa988c66bc1"))
 		}
 		return apierr.JSONInternalError(c)
 	}
@@ -150,7 +150,7 @@ func (h *Handler) Show(c echo.Context) error {
 		}
 		bundle, ulerr := h.userSource.ShowByUsername(req.Username, nil)
 		if ulerr != nil || bundle == nil || bundle.User == nil {
-			return notFound(c)
+			return c.JSON(http.StatusNotFound, apierr.Error("NO_SUCH_PAGE", "No such page.", "222120c0-3ead-4528-811b-b96f233388d7"))
 		}
 		p, err = h.svc.ShowByName(requesterID, bundle.User.ID, req.Name)
 	default:
@@ -160,7 +160,7 @@ func (h *Handler) Show(c echo.Context) error {
 		if errors.Is(err, corepage.ErrAccessDenied) {
 			return apierr.JSONAccessDenied(c)
 		}
-		return notFound(c)
+		return c.JSON(http.StatusNotFound, apierr.Error("NO_SUCH_PAGE", "No such page.", "222120c0-3ead-4528-811b-b96f233388d7"))
 	}
 	// owner / isLiked を attach (#1134)。owner lookup miss は frontend page.vue
 	// の `v-if="page.user"` で吸収されるため fail-soft で nil 維持。
@@ -230,14 +230,14 @@ func (h *Handler) Update(c echo.Context) error {
 	if err != nil {
 		switch {
 		case errors.Is(err, corepage.ErrPageNotFound):
-			return notFound(c)
+			return c.JSON(http.StatusNotFound, apierr.Error("NO_SUCH_PAGE", "No such page.", "21149b9e-3616-4778-9592-c4ce89f5a864"))
 		case errors.Is(err, corepage.ErrAccessDenied):
 			return c.JSON(http.StatusForbidden, apierr.Error("ACCESS_DENIED", "Access denied.", "3c15cd52-3b4b-4274-967d-6456fc4f792b"))
 		case errors.Is(err, corepage.ErrPageNameRequired),
 			errors.Is(err, corepage.ErrPageTitleRequired):
 			return apierr.JSONInvalidParam(c)
 		case errors.Is(err, corepage.ErrPageNameConflict):
-			return nameConflict(c)
+			return c.JSON(http.StatusBadRequest, apierr.Error("NAME_ALREADY_EXISTS", "The page name is already in use.", "2298a392-d4a1-44c5-9ebb-ac1aeaa5a9ab"))
 		}
 		return apierr.JSONInternalError(c)
 	}
@@ -259,7 +259,7 @@ func (h *Handler) Delete(c echo.Context) error {
 	if err := h.svc.Delete(user.ID, req.PageID); err != nil {
 		switch {
 		case errors.Is(err, corepage.ErrPageNotFound):
-			return notFound(c)
+			return c.JSON(http.StatusNotFound, apierr.Error("NO_SUCH_PAGE", "No such page.", "eb0c6e1d-d519-4764-9486-52a7e1c6392a"))
 		case errors.Is(err, corepage.ErrAccessDenied):
 			return c.JSON(http.StatusForbidden, apierr.Error("ACCESS_DENIED", "Access denied.", "8b741b3e-2c22-44b3-a15f-29949aa1601e"))
 		}
@@ -374,11 +374,11 @@ func (h *Handler) Like(c echo.Context) error {
 	if err := h.svc.Like(user.ID, req.PageID); err != nil {
 		switch {
 		case errors.Is(err, corepage.ErrPageNotFound):
-			return notFound(c)
+			return c.JSON(http.StatusNotFound, apierr.Error("NO_SUCH_PAGE", "No such page.", "cc98a8a2-0dc3-4123-b198-62c71df18ed3"))
 		case errors.Is(err, corepage.ErrAccessDenied):
 			return apierr.JSONAccessDenied(c)
 		case errors.Is(err, corepage.ErrAlreadyLiked):
-			return alreadyLiked(c)
+			return c.JSON(http.StatusBadRequest, apierr.Error("ALREADY_LIKED", "You already liked that page.", "d4c1edbe-7da2-4eae-8714-1acfd2d63941"))
 		}
 		return apierr.JSONInternalError(c)
 	}
@@ -407,7 +407,7 @@ func (h *Handler) PagePush(c echo.Context) error {
 	// emitする。
 	p, err := h.svc.FindByID(req.PageID)
 	if err != nil {
-		return notFound(c)
+		return c.JSON(http.StatusNotFound, apierr.Error("NO_SUCH_PAGE", "No such page.", "4a13ad31-6729-46b4-b9af-e86b265c2e74"))
 	}
 	if h.mainStreamPublisher == nil || h.userSource == nil {
 		// 配線未完了ならemitせず204を返す(API互換のため)。
@@ -451,9 +451,9 @@ func (h *Handler) Unlike(c echo.Context) error {
 	if err := h.svc.Unlike(user.ID, req.PageID); err != nil {
 		switch {
 		case errors.Is(err, corepage.ErrPageNotFound):
-			return notFound(c)
+			return c.JSON(http.StatusNotFound, apierr.Error("NO_SUCH_PAGE", "No such page.", "a0d41e20-1993-40bd-890e-f6e560ae648e"))
 		case errors.Is(err, corepage.ErrNotLiked):
-			return notLiked(c)
+			return c.JSON(http.StatusBadRequest, apierr.Error("NOT_LIKED", "You have not liked that page.", "f5e586b0-ce93-4050-b0e3-7f31af5259ee"))
 		}
 		return apierr.JSONInternalError(c)
 	}
@@ -500,20 +500,4 @@ func (h *Handler) pageToMapWithOwner(p *model.Page, owner *model.User, eyeCatchi
 		EyeCatchingImage: eyeCatchingImage,
 		IsLiked:          isLiked,
 	})
-}
-
-func notFound(c echo.Context) error {
-	return c.JSON(http.StatusNotFound, apierr.Error("NO_SUCH_PAGE", "No such page.", "222120c0-3ead-4528-811b-b96f233388d7"))
-}
-
-func nameConflict(c echo.Context) error {
-	return c.JSON(http.StatusBadRequest, apierr.Error("NAME_ALREADY_EXISTS", "The page name is already in use.", "4650348e-301c-499a-83c9-6aa988c66bc1"))
-}
-
-func alreadyLiked(c echo.Context) error {
-	return c.JSON(http.StatusBadRequest, apierr.Error("ALREADY_LIKED", "You already liked that page.", "cc98a8a2-0dc3-4123-b198-62c71df18ed3"))
-}
-
-func notLiked(c echo.Context) error {
-	return c.JSON(http.StatusBadRequest, apierr.Error("NOT_LIKED", "You have not liked that page.", "f5e586b0-ce93-4050-b0e3-7f31af5259ee"))
 }

--- a/internal/entitycompat/error_ids_test.go
+++ b/internal/entitycompat/error_ids_test.go
@@ -139,11 +139,18 @@ type emission struct {
 }
 
 var (
-	// funcDeclRe matches a method declaration `func (recv T) Name(`.
-	funcDeclRe = regexp.MustCompile(`func \(\w+ \*?\w+\) (\w+)\(`)
-	// inlineErrRe matches apierr.Error("CODE", <msg>, <id>) where msg is a
-	// string literal or identifier and id is a literal or UUID constant.
-	inlineErrRe = regexp.MustCompile(`apierr\.Error\(\s*"([A-Z_]+)"\s*,\s*(?:"(?:[^"\\]|\\.)*"|[\w.]+)\s*,\s*("[0-9a-f-]{36}"|(?:apierr\.)?UUID\w+)\s*\)`)
+	// funcDeclRe matches a function declaration — both methods `func (recv T) Name(`
+	// and package-level free functions `func Name(`. Recognizing free functions is
+	// essential: handlers delegate error responses to package-level helpers (e.g.
+	// `func notFound(c echo.Context) error`), and without matching their boundary
+	// their emissions would be mis-attributed to the preceding method.
+	funcDeclRe = regexp.MustCompile(`func (?:\(\w+ \*?\w+\) )?(\w+)\(`)
+	// inlineErrRe matches apierr.Error("CODE", <msg>, <id>). msg may be a string
+	// literal, a parenless function call (err.Error(), fmt.Sprintf("...")), or an
+	// identifier; id may be a literal UUID or a UUID constant. A trailing comma
+	// (gofmt adds one to multi-line calls) is tolerated. `(?s)` lets the pattern
+	// span the multi-line calls gofmt produces.
+	inlineErrRe = regexp.MustCompile(`(?s)apierr\.Error\(\s*"([A-Z_]+)"\s*,\s*(?:"(?:[^"\\]|\\.)*"|[\w.]+\([^)]*\)|[\w.]+)\s*,\s*("[0-9a-f-]{36}"|(?:apierr\.)?UUID\w+)\s*,?\s*\)`)
 	// helperCallRe matches apierr.Helper( — any apierr.X( call; non-helpers
 	// (e.g. Error) are filtered against the parsed helper table.
 	helperCallRe = regexp.MustCompile(`apierr\.(\w+)\(`)


### PR DESCRIPTION
## Summary

error id drift gate の**盲点**を塞ぎ、露出した id drift を整合する (part 1: free-function helper)。

gate は handler が委譲する **package-level 自由関数** (`return notFound(c)` 等) 内の emission を、`funcDeclRe` が receiver 必須で境界認識できず直前 method に誤帰属していた。このため共有自由関数が **1 code = 1 id を複数 endpoint で使い回す** drift を素通ししていた。

## 主な変更点

### gate 精緻化

- `funcDeclRe` を method + 自由関数の両方認識に修正 → 自由関数 emission の誤帰属を防止
- `inlineErrRe` を複数行 (gofmt が付ける末尾カンマ) + 関数呼び出しメッセージ (`err.Error()`) 対応に改善 (取りこぼし 12→1、残 1 は実行時変数 id で静的解決不可)

### per-endpoint id 整合 (37 箇所)

clips / channels / antennas / flash / pages の共有自由関数 (`notFound`/`alreadyLiked` 等) 経由 emission を各 endpoint 固有 id へ inline 化。例: `NO_SUCH_CLIP` は 8 endpoint で別 id、`NO_SUCH_CHANNEL` は 9 endpoint で別 id。不要化した自由関数 **12 個を削除**。

inline により gate が emission を route-method で直接解決するため、これらは恒久的に gate 対象になる。

## テスト

- `TestErrorIDDrift` / `TestErrorHTTPStatusDrift` green
- 全 api 46 パッケージ + entitycompat pass
- `make fmt` / `make lint` / `go build` 通過

## part 2 (後続 PR)

shared helper **method** 経由のケース (drive `mapFileError` / i/2fa `requireWebAuthn` / notes `serveList` / users `listRelations`、約 12 件) は `mapFolderError` と同じ ep-param 化で整合する。

## Closes

Closes #1336

🤖 Generated with [Claude Code](https://claude.com/claude-code)