### PR TITLE
fix(api): shared helper method 経由の error id を per-endpoint へ整合 (part 2)

### DIFF
--- a/docs/shape-drift.md
+++ b/docs/shape-drift.md
@@ -246,6 +246,10 @@ echo wrapperはhandlerの最頻送出経路なので外すとgateが大半のrou
 
 確実に解決できたケースのみgateする方針なので、誤検出より見落としに倒している。
 
+### ep-aware helper(gate射程外だが構築により整合)
+
+同じcodeをendpointごとに別idで返す必要がある一方、複数endpointが**共有helper**を呼ぶケース(`drive`の`mapFileError`/`mapFolderError`、`users`の`listRelations`、`notes`の`serveList`、`i/2fa`の`requireWebAuthn`等)は、helperに**endpoint識別の引数**(enum/bool/id literal)を渡して各endpoint固有idを選択する。これらのidはhelper内で動的選択されるためstatic gateはdataflowを追えず**検証対象外**だが、`switch ep { ... default: panic }`等で網羅を強制し**構築により**driftを防ぐ(#977 `mapFolderError`が初出、#1336で他helperへ展開)。新規endpointを共有helperに足すときはこの分岐を必ず更新する。
+
 ### 運用
 
 ```bash

--- a/internal/api/drive/handler.go
+++ b/internal/api/drive/handler.go
@@ -502,12 +502,16 @@ const (
 func mapFileError(c echo.Context, err error, ep fileEndpoint) error {
 	switch {
 	case errors.Is(err, coredrive.ErrFileNotFound):
-		id := "067bc436-2718-4795-b0fb-ecbe43949e31" // show / find-by-hash
+		var id string
 		switch ep {
+		case fileEndpointShow, fileEndpointFindByHash:
+			id = "067bc436-2718-4795-b0fb-ecbe43949e31"
 		case fileEndpointUpdate:
 			id = "e7778c7e-3af9-49cd-9690-6dbc3e6c972d"
 		case fileEndpointDelete:
 			id = "908939ec-e52b-4458-b395-1025195cea58"
+		default:
+			panic(fmt.Sprintf("mapFileError: unknown fileEndpoint %d", ep))
 		}
 		return c.JSON(http.StatusNotFound, apierr.Error("NO_SUCH_FILE", "No such file.", id))
 	case errors.Is(err, coredrive.ErrFolderNotFound):
@@ -518,7 +522,7 @@ func mapFileError(c echo.Context, err error, ep fileEndpoint) error {
 		}
 		return c.JSON(http.StatusNotFound, apierr.Error("NO_SUCH_FOLDER", "No such folder.", id))
 	case errors.Is(err, coredrive.ErrAccessDenied):
-		id := "fe8d7103-0ea8-4ec3-814d-f8b401dc69e9"
+		var id string
 		switch ep {
 		case fileEndpointShow:
 			id = "25b73c73-68b1-41d0-bad1-381cfdf6579f"
@@ -526,6 +530,11 @@ func mapFileError(c echo.Context, err error, ep fileEndpoint) error {
 			id = "01a53b27-82fc-445b-a0c1-b558465a8ed2"
 		case fileEndpointDelete:
 			id = "5eb8d909-2540-4970-90b8-dd6f86088121"
+		case fileEndpointFindByHash:
+			// find-by-hash は ACCESS_DENIED を golden 未定義。汎用 id を使う。
+			id = "fe8d7103-0ea8-4ec3-814d-f8b401dc69e9"
+		default:
+			panic(fmt.Sprintf("mapFileError: unknown fileEndpoint %d", ep))
 		}
 		return c.JSON(http.StatusForbidden, apierr.Error("ACCESS_DENIED", "Access denied.", id))
 	case errors.Is(err, coredrive.ErrCannotUnmarkSensitive):

--- a/internal/api/drive/handler.go
+++ b/internal/api/drive/handler.go
@@ -271,7 +271,7 @@ func (h *Handler) FilesShow(c echo.Context) error {
 	}
 	f, err := h.svc.Show(user, req.FileID)
 	if err != nil {
-		return mapFileError(c, err)
+		return mapFileError(c, err, fileEndpointShow)
 	}
 	return c.JSON(http.StatusOK, h.packDriveFileFull(f))
 }
@@ -312,7 +312,7 @@ func (h *Handler) FilesUpdate(c echo.Context) error {
 
 	f, err := h.svc.Update(user, req.FileID, in)
 	if err != nil {
-		return mapFileError(c, err)
+		return mapFileError(c, err, fileEndpointUpdate)
 	}
 	// upstream は updateFile 後 `pack(file.id, { self: true })` を返す
 	// (= self single shape、DriveService.ts)。本実装も #812 の create と
@@ -328,7 +328,7 @@ func (h *Handler) FilesDelete(c echo.Context) error {
 		return apierr.JSONInvalidParam(c)
 	}
 	if err := h.svc.Delete(user, req.FileID); err != nil {
-		return mapFileError(c, err)
+		return mapFileError(c, err, fileEndpointDelete)
 	}
 	return c.NoContent(http.StatusNoContent)
 }
@@ -347,7 +347,7 @@ func (h *Handler) FilesFindByHash(c echo.Context) error {
 	}
 	f, err := h.svc.FindByHash(user, req.MD5)
 	if err != nil {
-		return mapFileError(c, err)
+		return mapFileError(c, err, fileEndpointFindByHash)
 	}
 	// upstream `packMany(files, { self: true })` 経路 (#818)。
 	return c.JSON(http.StatusOK, []entity.DriveFileEntity{h.packDriveFileSelfList(f)})
@@ -487,14 +487,47 @@ func (h *Handler) FoldersDelete(c echo.Context) error {
 
 // helpers
 
-func mapFileError(c echo.Context, err error) error {
+// fileEndpoint identifies which drive/files endpoint produced a file error, so
+// mapFileError can return the upstream-canonical per-endpoint UUID. Misskey TS
+// uses a distinct UUID per endpoint for NO_SUCH_FILE / ACCESS_DENIED (#1336)。
+type fileEndpoint int
+
+const (
+	fileEndpointShow fileEndpoint = iota
+	fileEndpointUpdate
+	fileEndpointDelete
+	fileEndpointFindByHash
+)
+
+func mapFileError(c echo.Context, err error, ep fileEndpoint) error {
 	switch {
 	case errors.Is(err, coredrive.ErrFileNotFound):
-		return c.JSON(http.StatusNotFound, apierr.Error("NO_SUCH_FILE", "No such file.", "067bc436-2718-4795-b0fb-ecbe43949e31"))
+		id := "067bc436-2718-4795-b0fb-ecbe43949e31" // show / find-by-hash
+		switch ep {
+		case fileEndpointUpdate:
+			id = "e7778c7e-3af9-49cd-9690-6dbc3e6c972d"
+		case fileEndpointDelete:
+			id = "908939ec-e52b-4458-b395-1025195cea58"
+		}
+		return c.JSON(http.StatusNotFound, apierr.Error("NO_SUCH_FILE", "No such file.", id))
 	case errors.Is(err, coredrive.ErrFolderNotFound):
-		return c.JSON(http.StatusNotFound, apierr.Error("NO_SUCH_FOLDER", "No such folder.", "1069098f-c281-440f-b085-f9932edbe091"))
+		// folder 不在は drive/files/update の parent 指定経路でのみ発生する。
+		id := "1069098f-c281-440f-b085-f9932edbe091"
+		if ep == fileEndpointUpdate {
+			id = "ea8fb7a5-af77-4a08-b608-c0218176cd73"
+		}
+		return c.JSON(http.StatusNotFound, apierr.Error("NO_SUCH_FOLDER", "No such folder.", id))
 	case errors.Is(err, coredrive.ErrAccessDenied):
-		return c.JSON(http.StatusForbidden, apierr.Error("ACCESS_DENIED", "Access denied.", "fe8d7103-0ea8-4ec3-814d-f8b401dc69e9"))
+		id := "fe8d7103-0ea8-4ec3-814d-f8b401dc69e9"
+		switch ep {
+		case fileEndpointShow:
+			id = "25b73c73-68b1-41d0-bad1-381cfdf6579f"
+		case fileEndpointUpdate:
+			id = "01a53b27-82fc-445b-a0c1-b558465a8ed2"
+		case fileEndpointDelete:
+			id = "5eb8d909-2540-4970-90b8-dd6f86088121"
+		}
+		return c.JSON(http.StatusForbidden, apierr.Error("ACCESS_DENIED", "Access denied.", id))
 	case errors.Is(err, coredrive.ErrCannotUnmarkSensitive):
 		// upstream drive/files/update の restrictedByRole は i/update と別 UUID
 		// (7f59dccb-...)。endpoint 単位で frontend が i18n 引きするので、

--- a/internal/api/i/handler_2fa.go
+++ b/internal/api/i/handler_2fa.go
@@ -179,7 +179,9 @@ func (h *Handler) TwoFAUnregister(c echo.Context) error {
 // 第 3 戻り値は「呼び出し側が処理を続行してよいか」のフラグ。false のとき
 // レスポンスは既にこの helper 内で書き込まれているので、caller はそのまま
 // nil を return する。
-func (h *Handler) requireWebAuthn(c echo.Context, password string) (*model.User, *model.UserProfile, bool) {
+// incorrectPwID は INCORRECT_PASSWORD の endpoint 固有 id。upstream は
+// register-key / key-done 等で別 id を割り当てるため、caller が渡す。
+func (h *Handler) requireWebAuthn(c echo.Context, password, incorrectPwID string) (*model.User, *model.UserProfile, bool) {
 	if h.webauthnSvc == nil || h.securityKeyRepo == nil {
 		_ = c.JSON(http.StatusServiceUnavailable, apierr.Error("UNAVAILABLE", "WebAuthn is not configured.", "5d37dbcb-891e-41ca-a3d6-e690c97775ac"))
 		return nil, nil, false
@@ -195,7 +197,7 @@ func (h *Handler) requireWebAuthn(c echo.Context, password string) (*model.User,
 		return nil, nil, false
 	}
 	if err := bcrypt.CompareHashAndPassword([]byte(*profile.Password), []byte(password)); err != nil {
-		_ = c.JSON(http.StatusForbidden, apierr.Error("INCORRECT_PASSWORD", "Incorrect password.", "932c904e-9460-45b7-9ce6-7ed33be7eb2c"))
+		_ = c.JSON(http.StatusForbidden, apierr.Error("INCORRECT_PASSWORD", "Incorrect password.", incorrectPwID))
 		return nil, nil, false
 	}
 	return user, profile, true
@@ -257,7 +259,7 @@ func (h *Handler) TwoFARegisterKey(c echo.Context) error {
 	if err := c.Bind(&req); err != nil || req.Password == "" {
 		return c.JSON(http.StatusBadRequest, apierr.Error("INVALID_PARAM", "password is required.", "ed1d7571-a3ac-4370-899c-0dbe5e230cc8"))
 	}
-	user, profile, ok := h.requireWebAuthn(c, req.Password)
+	user, profile, ok := h.requireWebAuthn(c, req.Password, "38769596-efe2-4faf-9bec-abbb3f2cd9ba")
 	if !ok {
 		return nil
 	}
@@ -305,7 +307,7 @@ func (h *Handler) TwoFAKeyDone(c echo.Context) error {
 	if len(req.Name) > twoFAKeyNameMaxLen {
 		return c.JSON(http.StatusBadRequest, apierr.Error("INVALID_PARAM", "name is too long.", "ed1d7571-a3ac-4370-899c-0dbe5e230cc8"))
 	}
-	user, profile, ok := h.requireWebAuthn(c, req.Password)
+	user, profile, ok := h.requireWebAuthn(c, req.Password, "0d7ec6d2-e652-443e-a7bf-9ee9a0cd77b0")
 	if !ok {
 		return nil
 	}
@@ -458,7 +460,7 @@ func (h *Handler) TwoFAUpdateKey(c echo.Context) error {
 	if err := c.Bind(&req); err != nil || req.Password == "" || req.CredentialID == "" || req.Name == "" {
 		return c.JSON(http.StatusBadRequest, apierr.Error("INVALID_PARAM", "password / credentialId / name are required.", "ed1d7571-a3ac-4370-899c-0dbe5e230cc8"))
 	}
-	user, _, ok := h.requireWebAuthn(c, req.Password)
+	user, _, ok := h.requireWebAuthn(c, req.Password, "932c904e-9460-45b7-9ce6-7ed33be7eb2c")
 	if !ok {
 		return nil
 	}

--- a/internal/api/notes/handler.go
+++ b/internal/api/notes/handler.go
@@ -434,26 +434,26 @@ func (r *listRequest) normalize() {
 
 // Renotes handles POST /api/notes/renotes.
 func (h *Handler) Renotes(c echo.Context) error {
-	return h.serveList(c, func(viewer *model.User, req listRequest) ([]*model.Note, error) {
+	return h.serveList(c, "12908022-2e21-46cd-ba6a-3edaf6093f46", func(viewer *model.User, req listRequest) ([]*model.Note, error) {
 		return h.queryService.ListRenotes(viewer, req.NoteID, req.UntilID, req.SinceID, req.Limit)
 	})
 }
 
 // Replies handles POST /api/notes/replies.
 func (h *Handler) Replies(c echo.Context) error {
-	return h.serveList(c, func(viewer *model.User, req listRequest) ([]*model.Note, error) {
+	return h.serveList(c, apierr.UUIDNoSuchNote, func(viewer *model.User, req listRequest) ([]*model.Note, error) {
 		return h.queryService.ListReplies(viewer, req.NoteID, req.UntilID, req.SinceID, req.Limit)
 	})
 }
 
 // Children handles POST /api/notes/children.
 func (h *Handler) Children(c echo.Context) error {
-	return h.serveList(c, func(viewer *model.User, req listRequest) ([]*model.Note, error) {
+	return h.serveList(c, apierr.UUIDNoSuchNote, func(viewer *model.User, req listRequest) ([]*model.Note, error) {
 		return h.queryService.ListChildren(viewer, req.NoteID, req.UntilID, req.SinceID, req.Limit)
 	})
 }
 
-func (h *Handler) serveList(c echo.Context, fn func(*model.User, listRequest) ([]*model.Note, error)) error {
+func (h *Handler) serveList(c echo.Context, noSuchNoteID string, fn func(*model.User, listRequest) ([]*model.Note, error)) error {
 	var req listRequest
 	if err := c.Bind(&req); err != nil || req.NoteID == "" {
 		return apierr.JSONInvalidParam(c)
@@ -464,7 +464,8 @@ func (h *Handler) serveList(c echo.Context, fn func(*model.User, listRequest) ([
 	notes, err := fn(viewer, req)
 	if err != nil {
 		if errors.Is(err, note.ErrNoteNotFound) {
-			return apierr.JSONNoSuchNote(c)
+			// upstream は notes/renotes 等で NO_SUCH_NOTE に endpoint 固有 id を割り当てる
+			return c.JSON(http.StatusNotFound, apierr.Error("NO_SUCH_NOTE", "No such note.", noSuchNoteID))
 		}
 		return apierr.JSONInternalError(c)
 	}

--- a/internal/api/users/handler.go
+++ b/internal/api/users/handler.go
@@ -624,7 +624,12 @@ func (h *Handler) listRelations(c echo.Context, followers bool) error {
 	}
 
 	if _, err := h.userService.ShowByID(req.UserID); err != nil {
-		return apierr.JSONNoSuchUser(c)
+		// upstream は users/followers と users/following で NO_SUCH_USER に別 id を割り当てる
+		nsuID := "63e4aba4-4156-4e53-be25-c9559e42d71b" // users/following
+		if followers {
+			nsuID = "27fa5435-88ab-43de-9360-387de88727cd" // users/followers
+		}
+		return c.JSON(http.StatusNotFound, apierr.Error("NO_SUCH_USER", "No such user.", nsuID))
 	}
 	// sinceDate / untilDate を aidx prefix に正規化 (#1166)。
 	req.SinceID, req.UntilID = id.NormalizeCursor(req.SinceID, req.UntilID, req.SinceDate, req.UntilDate)


### PR DESCRIPTION
## Summary

#1337 (part 1: free-function helper) の続き。残る **shared helper method 経由**の error id drift 11 件を per-endpoint id へ整合する。

複数 endpoint が共有 helper method (`mapFileError` / `requireWebAuthn` / `serveList` / `listRelations`) を呼び、1 code = 1 id を使い回していた。これらは既存の `mapFolderError` (#977) と同じ **ep-aware helper** パターンで各 endpoint 固有 id を選択する。

## 主な変更点 (11 件)

| package | helper | 整合内容 |
|---|---|---|
| drive | `mapFileError` を ep-aware 化 | files/show・update・delete の NO_SUCH_FILE / ACCESS_DENIED / NO_SUCH_FOLDER を各固有 id へ |
| i/2fa | `requireWebAuthn` に `incorrectPwID` 引数 | register-key (38769596) / key-done (0d7ec6d2) の INCORRECT_PASSWORD (update-key は drift 無しで維持) |
| notes | `serveList` に `noSuchNoteID` 引数 | notes/renotes の NO_SUCH_NOTE を 12908022 へ (replies/children は golden 未定義で維持) |
| users | `listRelations` の `followers bool` で分岐 | NO_SUCH_USER を followers (27fa5435) / following (63e4aba4) へ |

## gate との関係

これらは helper 内で id を動的選択する (ep enum / bool / id literal 引数) ため、static gate は dataflow を追えず**検証対象外**。ただし `switch ep { default: panic }` 等で網羅を強制し**構築により** drift を防ぐ (既存 `mapFolderError` と同じ verified-by-construction 方式)。`docs/shape-drift.md` に明記。

## テスト

- 厳密 call-graph での残 drift **0**
- `TestErrorIDDrift` / `TestErrorHTTPStatusDrift` green、全 api + entitycompat pass
- `make fmt` / `make lint` / `go build` 通過

## Closes

Closes #1338

🤖 Generated with [Claude Code](https://claude.com/claude-code)