### PR TITLE
fix(api): pagination limit の max 欠落 (unbounded) 10 endpoint を修正 + gate 拡大 (phase 2)

### DIFF
--- a/internal/api/drive/handler.go
+++ b/internal/api/drive/handler.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/labstack/echo/v4"
 	"github.com/shiroha-a/mk/internal/api/apierr"
+	"github.com/shiroha-a/mk/internal/api/pagination"
 	coredrive "github.com/shiroha-a/mk/internal/core/drive"
 	"github.com/shiroha-a/mk/internal/core/notesfilter"
 	"github.com/shiroha-a/mk/internal/entity"
@@ -626,9 +627,7 @@ func (h *Handler) FilesList(c echo.Context) error {
 	if err := c.Bind(&req); err != nil {
 		return apierr.JSONInvalidParam(c)
 	}
-	if req.Limit <= 0 {
-		req.Limit = 10
-	}
+	req.Limit = pagination.ClampLimit(req.Limit, 10, 100)
 	if h.fileRepo == nil {
 		return c.JSON(http.StatusOK, []any{})
 	}
@@ -795,9 +794,7 @@ func (h *Handler) Stream(c echo.Context) error {
 	if err := c.Bind(&req); err != nil {
 		return apierr.JSONInvalidParam(c)
 	}
-	if req.Limit <= 0 {
-		req.Limit = 10
-	}
+	req.Limit = pagination.ClampLimit(req.Limit, 10, 100)
 	if h.fileRepo == nil {
 		return c.JSON(http.StatusOK, []any{})
 	}
@@ -828,9 +825,7 @@ func (h *Handler) FoldersList(c echo.Context) error {
 	if err := c.Bind(&req); err != nil {
 		return apierr.JSONInvalidParam(c)
 	}
-	if req.Limit <= 0 {
-		req.Limit = 10
-	}
+	req.Limit = pagination.ClampLimit(req.Limit, 10, 100)
 	if h.folderRepo == nil {
 		return c.JSON(http.StatusOK, []any{})
 	}

--- a/internal/api/hashtags/handler.go
+++ b/internal/api/hashtags/handler.go
@@ -74,9 +74,7 @@ func (h *Handler) Search(c echo.Context) error {
 	if err := c.Bind(&req); err != nil || req.Query == "" {
 		return c.JSON(http.StatusBadRequest, apierr.Error("INVALID_PARAM", "query is required.", "3d81ceae-475f-4600-b2a8-2bc116157532"))
 	}
-	if req.Limit <= 0 {
-		req.Limit = 10
-	}
+	req.Limit = pagination.ClampLimit(req.Limit, 10, 100)
 	var tags []*model.Hashtag
 	if err := h.db.Where("name ILIKE ?", "%"+req.Query+"%").Limit(req.Limit).Find(&tags).Error; err != nil {
 		return c.JSON(http.StatusInternalServerError, apierr.Error("INTERNAL_ERROR", "Internal error.", "5d37dbcb-891e-41ca-a3d6-e690c97775ac"))

--- a/internal/api/notes/handler_extra.go
+++ b/internal/api/notes/handler_extra.go
@@ -86,9 +86,7 @@ func (h *Handler) Featured(c echo.Context) error {
 	if err := c.Bind(&req); err != nil {
 		return c.JSON(http.StatusBadRequest, apierr.Error("INVALID_PARAM", "Invalid parameters.", "3d81ceae-475f-4600-b2a8-2bc116157532"))
 	}
-	if req.Limit <= 0 {
-		req.Limit = 10
-	}
+	req.Limit = pagination.ClampLimit(req.Limit, 10, 100)
 	// untilDate を aidx prefix に正規化 (#1166)。
 	_, untilID := id.NormalizeCursor("", req.UntilID, nil, req.UntilDate)
 	notes, err := h.noteRepo.ListFeatured(req.ChannelID, untilID, req.Limit, req.Offset)
@@ -132,9 +130,7 @@ func (h *Handler) Mentions(c echo.Context) error {
 	if err := c.Bind(&req); err != nil {
 		return c.JSON(http.StatusBadRequest, apierr.Error("INVALID_PARAM", "Invalid parameters.", "3d81ceae-475f-4600-b2a8-2bc116157532"))
 	}
-	if req.Limit <= 0 {
-		req.Limit = 10
-	}
+	req.Limit = pagination.ClampLimit(req.Limit, 10, 100)
 	// sinceDate / untilDate を aidx prefix に正規化 (#1166)。
 	sinceID, untilID := id.NormalizeCursor(req.SinceID, req.UntilID, req.SinceDate, req.UntilDate)
 	notes, err := h.noteRepo.ListMentions(user.ID, req.Limit, sinceID, untilID)
@@ -220,9 +216,7 @@ func (h *Handler) SearchByTag(c echo.Context) error {
 	if req.Tag == "" {
 		return c.JSON(http.StatusBadRequest, apierr.Error("INVALID_PARAM", "tag is required.", "3d81ceae-475f-4600-b2a8-2bc116157532"))
 	}
-	if req.Limit <= 0 {
-		req.Limit = 10
-	}
+	req.Limit = pagination.ClampLimit(req.Limit, 10, 100)
 	// sinceDate / untilDate を aidx prefix に正規化 (#1166)。
 	sinceID, untilID := id.NormalizeCursor(req.SinceID, req.UntilID, req.SinceDate, req.UntilDate)
 	// tagsカラムにtagを含むノートを検索

--- a/internal/api/users/handler.go
+++ b/internal/api/users/handler.go
@@ -483,9 +483,7 @@ func (h *Handler) Search(c echo.Context) error {
 	if err := c.Bind(&req); err != nil {
 		return apierr.JSONInvalidParam(c)
 	}
-	if req.Limit <= 0 {
-		req.Limit = 10
-	}
+	req.Limit = pagination.ClampLimit(req.Limit, 10, 100)
 	// origin の enum 検証 (#763)。upstream Misskey TS は paramDef の
 	// JSON schema で 不正値を 400 reject する。mk-go も同等にする。
 	// 空文字列は default (combined) として許容。

--- a/internal/api/users/handler_extra.go
+++ b/internal/api/users/handler_extra.go
@@ -264,9 +264,7 @@ func (h *Handler) FeaturedNotes(c echo.Context) error {
 	if err := c.Bind(&req); err != nil || req.UserID == "" {
 		return c.JSON(http.StatusBadRequest, apierr.Error("INVALID_PARAM", "userId is required.", "3d81ceae-475f-4600-b2a8-2bc116157532"))
 	}
-	if req.Limit <= 0 {
-		req.Limit = 10
-	}
+	req.Limit = pagination.ClampLimit(req.Limit, 10, 100)
 	notes, err := h.noteRepo.ListByUserID(req.UserID, "", "", req.Limit)
 	if err != nil {
 		return c.JSON(http.StatusInternalServerError, apierr.Error("INTERNAL_ERROR", "Internal error.", "5d37dbcb-891e-41ca-a3d6-e690c97775ac"))
@@ -288,9 +286,7 @@ func (h *Handler) SearchByUsernameAndHost(c echo.Context) error {
 	if err := c.Bind(&req); err != nil || req.Username == "" {
 		return c.JSON(http.StatusBadRequest, apierr.Error("INVALID_PARAM", "username is required.", "3d81ceae-475f-4600-b2a8-2bc116157532"))
 	}
-	if req.Limit <= 0 {
-		req.Limit = 10
-	}
+	req.Limit = pagination.ClampLimit(req.Limit, 10, 100)
 	// host=nil → local user、host=*string → 当該 host のみで絞り込む
 	// (#766 fix、upstream Misskey TS の同 endpoint と同じ semantics)。
 	users, err := h.userService.SearchByUsernameAndHost(req.Username, req.Host, req.Limit)


### PR DESCRIPTION
## Summary

#1341 (phase 1) の続き。limit gate の coverage 拡大中に、**max clamp 欠落で limit が unbounded** な endpoint を 10 件発見・修正。

これらは `if req.Limit <= 0 { req.Limit = 10 }` で default のみ clamp し**上限なし**のため、`limit=100000` 等が query に渡る (性能/DoS 懸念)。Misskey は `maximum: 100` を宣言し ajv が reject するため実 drift。

## 主な変更点

`pagination.ClampLimit(req.Limit, 10, 100)` へ移行し max=100 を補完 (Misskey paramDef 一致):

- `drive/files`, `drive/folders`, `drive/stream`
- `hashtags/search`
- `notes/featured`, `notes/mentions`, `notes/search-by-tag`
- `users/search`, `users/featured-notes`, `users/search-by-username-and-host`

gate checked: **20→31** (恒久的に regression gate 対象に)。

## テスト

- `TestLimitSpecDrift` green (checked=31)
- 全 api 46 パッケージ pass (max 追加で limit>100 の挙動が unbounded→100 に変わるが既存 test 無影響)
- `make fmt` / `lint` / `build` 通過

## 後続

helper 経由 (`clampListLimit` / `parseHostPage` / `paginationFromRequest`)、`*int` idiom (`my/apps` 等)、offset-pagination 系を段階移行。

## Closes
Closes #1342

🤖 Generated with [Claude Code](https://claude.com/claude-code)