### PR TITLE
feat(api): list handler を handler-level ClampLimit へ統一し pagination gate を 64 endpoint へ (phase 3)

### DIFF
--- a/internal/api/admin/handler.go
+++ b/internal/api/admin/handler.go
@@ -13,6 +13,7 @@ import (
 	"github.com/labstack/echo/v4"
 	"github.com/lib/pq"
 	"github.com/shiroha-a/mk/internal/api/apierr"
+	"github.com/shiroha-a/mk/internal/api/pagination"
 	"github.com/shiroha-a/mk/internal/config"
 	"github.com/shiroha-a/mk/internal/core/moderationlog"
 	"github.com/shiroha-a/mk/internal/core/role"
@@ -633,6 +634,7 @@ func (h *Handler) ShowUsers(c echo.Context) error {
 		return c.JSON(http.StatusBadRequest, apierr.Error("INVALID_PARAM", "Invalid parameters.", "3d81ceae-475f-4600-b2a8-2bc116157532"))
 	}
 
+	req.Limit = pagination.ClampLimit(req.Limit, 10, 100)
 	users, err := h.userRepo.ListUsers(model.UserListFilter{
 		State:    req.State,
 		Origin:   req.Origin,
@@ -1908,6 +1910,7 @@ func (h *Handler) EmojiList(c echo.Context) error {
 	}
 	// sinceDate / untilDate を aidx prefix に正規化 (#1173)。
 	sinceID, untilID := id.NormalizeCursor(req.SinceID, req.UntilID, req.SinceDate, req.UntilDate)
+	req.Limit = pagination.ClampLimit(req.Limit, 10, 100)
 	emojis, err := h.emojiRepo.ListWithFilter(req.Query, req.Category, true, sinceID, untilID, req.Limit, req.Offset)
 	if err != nil {
 		return c.JSON(http.StatusInternalServerError, apierr.Error("INTERNAL_ERROR", "Internal error.", "5d37dbcb-891e-41ca-a3d6-e690c97775ac"))
@@ -2156,6 +2159,7 @@ func (h *Handler) AbuseReports(c echo.Context) error {
 	}
 	// sinceDate / untilDate を aidx prefix に正規化 (#1173)。
 	sinceID, untilID := id.NormalizeCursor(req.SinceID, req.UntilID, req.SinceDate, req.UntilDate)
+	req.Limit = pagination.ClampLimit(req.Limit, 10, 100)
 	reports, err := h.abuseRepo.List(resolved, req.ReporterOrigin, req.TargetUserOrigin, sinceID, untilID, req.Limit)
 	if err != nil {
 		return c.JSON(http.StatusInternalServerError, apierr.Error("INTERNAL_ERROR", "Internal error.", "5d37dbcb-891e-41ca-a3d6-e690c97775ac"))
@@ -2269,6 +2273,7 @@ func (h *Handler) ShowModerationLogs(c echo.Context) error {
 	if err := c.Bind(&req); err != nil {
 		return c.JSON(http.StatusBadRequest, apierr.Error("INVALID_PARAM", "Invalid parameters.", "3d81ceae-475f-4600-b2a8-2bc116157532"))
 	}
+	req.Limit = pagination.ClampLimit(req.Limit, 10, 100)
 	logs, err := h.modLogService.List(req.Limit, req.Offset)
 	if err != nil {
 		return c.JSON(http.StatusInternalServerError, apierr.Error("INTERNAL_ERROR", "Internal error.", "5d37dbcb-891e-41ca-a3d6-e690c97775ac"))

--- a/internal/api/announcements/handler.go
+++ b/internal/api/announcements/handler.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/labstack/echo/v4"
 	"github.com/shiroha-a/mk/internal/api/apierr"
+	"github.com/shiroha-a/mk/internal/api/pagination"
 	"github.com/shiroha-a/mk/internal/core/moderationlog"
 	"github.com/shiroha-a/mk/internal/entity"
 	"github.com/shiroha-a/mk/internal/misc/id"
@@ -123,6 +124,7 @@ func (h *Handler) List(c echo.Context) error {
 	var items []*model.Announcement
 	var err error
 	if user != nil {
+		req.Limit = pagination.ClampLimit(req.Limit, 10, 100)
 		items, err = h.repo.ListForUser(user.ID, activeOnly, req.Limit, req.Offset, sinceID, untilID)
 	} else {
 		items, err = h.repo.ListGlobal(activeOnly, req.Limit, req.Offset, sinceID, untilID)
@@ -411,6 +413,7 @@ func (h *Handler) AdminList(c echo.Context) error {
 	}
 	// sinceDate / untilDate を aidx prefix に正規化 (#1173)。
 	sinceID, untilID := id.NormalizeCursor(req.SinceID, req.UntilID, req.SinceDate, req.UntilDate)
+	req.Limit = pagination.ClampLimit(req.Limit, 10, 100)
 	items, err := h.repo.ListForAdmin(req.UserID, req.Status, req.Limit, req.Offset, sinceID, untilID)
 	if err != nil {
 		return c.JSON(http.StatusInternalServerError, apierr.Error("INTERNAL_ERROR", "Internal error.", "5d37dbcb-891e-41ca-a3d6-e690c97775ac"))

--- a/internal/api/antennas/handler.go
+++ b/internal/api/antennas/handler.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/labstack/echo/v4"
 	"github.com/shiroha-a/mk/internal/api/apierr"
+	"github.com/shiroha-a/mk/internal/api/pagination"
 	coreantenna "github.com/shiroha-a/mk/internal/core/antenna"
 	"github.com/shiroha-a/mk/internal/core/notesfilter"
 	"github.com/shiroha-a/mk/internal/entity"
@@ -273,6 +274,7 @@ func (h *Handler) Notes(c echo.Context) error {
 	}
 	// sinceDate / untilDate を aidx prefix に正規化 (#1166)。
 	sinceID, untilID := id.NormalizeCursor(req.SinceID, req.UntilID, req.SinceDate, req.UntilDate)
+	req.Limit = pagination.ClampLimit(req.Limit, 10, 100)
 	ids, err := h.svc.Notes(c.Request().Context(), user.ID, req.AntennaID, req.Limit, sinceID, untilID)
 	if err != nil {
 		switch {

--- a/internal/api/channels/handler.go
+++ b/internal/api/channels/handler.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/labstack/echo/v4"
 	"github.com/shiroha-a/mk/internal/api/apierr"
+	"github.com/shiroha-a/mk/internal/api/pagination"
 	corechannel "github.com/shiroha-a/mk/internal/core/channel"
 	"github.com/shiroha-a/mk/internal/core/notesfilter"
 	"github.com/shiroha-a/mk/internal/entity"
@@ -298,6 +299,7 @@ func (h *Handler) Followed(c echo.Context) error {
 	}
 	// sinceDate / untilDate を aidx prefix に正規化 (#1166)。
 	sinceID, untilID := id.NormalizeCursor(req.SinceID, req.UntilID, req.SinceDate, req.UntilDate)
+	req.Limit = pagination.ClampLimit(req.Limit, 5, 100)
 	rows, err := h.svc.ListFollowed(user.ID, sinceID, untilID, req.Limit, req.Offset)
 	if err != nil {
 		return apierr.JSONInternalError(c)
@@ -314,6 +316,7 @@ func (h *Handler) Owned(c echo.Context) error {
 	}
 	// sinceDate / untilDate を aidx prefix に正規化 (#1166)。
 	sinceID, untilID := id.NormalizeCursor(req.SinceID, req.UntilID, req.SinceDate, req.UntilDate)
+	req.Limit = pagination.ClampLimit(req.Limit, 5, 100)
 	rows, err := h.svc.ListOwned(user.ID, sinceID, untilID, req.Limit, req.Offset)
 	if err != nil {
 		return apierr.JSONInternalError(c)
@@ -355,6 +358,7 @@ func (h *Handler) Search(c echo.Context) error {
 	}
 	// sinceDate / untilDate を aidx prefix に正規化 (#1166)。
 	sinceID, untilID := id.NormalizeCursor(req.SinceID, req.UntilID, req.SinceDate, req.UntilDate)
+	req.Limit = pagination.ClampLimit(req.Limit, 5, 100)
 	rows, err := h.svc.Search(req.Query, sinceID, untilID, req.Limit, req.Offset)
 	if err != nil {
 		return apierr.JSONInternalError(c)

--- a/internal/api/clips/handler.go
+++ b/internal/api/clips/handler.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/labstack/echo/v4"
 	"github.com/shiroha-a/mk/internal/api/apierr"
+	"github.com/shiroha-a/mk/internal/api/pagination"
 	coreclip "github.com/shiroha-a/mk/internal/core/clip"
 	"github.com/shiroha-a/mk/internal/core/notesfilter"
 	"github.com/shiroha-a/mk/internal/entity"
@@ -222,6 +223,7 @@ func (h *Handler) List(c echo.Context) error {
 	}
 	// sinceDate / untilDate を aidx prefix に正規化 (#1166)。
 	sinceID, untilID := id.NormalizeCursor(req.SinceID, req.UntilID, req.SinceDate, req.UntilDate)
+	req.Limit = pagination.ClampLimit(req.Limit, 10, 100)
 	rows, err := h.svc.ListByUser(user.ID, sinceID, untilID, req.Limit, req.Offset)
 	if err != nil {
 		return apierr.JSONInternalError(c)
@@ -314,6 +316,7 @@ func (h *Handler) Notes(c echo.Context) error {
 	}
 	// sinceDate / untilDate を aidx prefix に正規化 (#1166)。
 	sinceID, untilID := id.NormalizeCursor(req.SinceID, req.UntilID, req.SinceDate, req.UntilDate)
+	req.Limit = pagination.ClampLimit(req.Limit, 10, 100)
 	notes, err := h.svc.Notes(requesterID, req.ClipID, untilID, sinceID, req.Limit)
 	if err != nil {
 		switch {

--- a/internal/api/drive/handler.go
+++ b/internal/api/drive/handler.go
@@ -709,6 +709,7 @@ func (h *Handler) FilesAttachedNotes(c echo.Context) error {
 	}
 	// sinceDate / untilDate を aidx prefix に正規化 (#1173)。
 	sinceID, untilID := id.NormalizeCursor(req.SinceID, req.UntilID, req.SinceDate, req.UntilDate)
+	req.Limit = pagination.ClampLimit(req.Limit, 10, 100)
 	notes, err := h.noteRepo.ListByFileID(req.FileID, sinceID, untilID, req.Limit)
 	if err != nil {
 		return c.JSON(http.StatusOK, []any{})

--- a/internal/api/federation/handler.go
+++ b/internal/api/federation/handler.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/labstack/echo/v4"
 	"github.com/shiroha-a/mk/internal/api/apierr"
+	"github.com/shiroha-a/mk/internal/api/pagination"
 	coreinstance "github.com/shiroha-a/mk/internal/core/instance"
 	"github.com/shiroha-a/mk/internal/misc/id"
 	"github.com/shiroha-a/mk/internal/model"
@@ -85,6 +86,7 @@ func (h *Handler) Instances(c echo.Context) error {
 	if err != nil {
 		return apierr.JSONInternalError(c)
 	}
+	req.Limit = pagination.ClampLimit(req.Limit, 30, 100)
 	filter := model.InstanceListFilter{
 		Host:          req.Host,
 		Suspended:     req.Suspended,

--- a/internal/api/flash/handler.go
+++ b/internal/api/flash/handler.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/labstack/echo/v4"
 	"github.com/shiroha-a/mk/internal/api/apierr"
+	"github.com/shiroha-a/mk/internal/api/pagination"
 	coreflash "github.com/shiroha-a/mk/internal/core/flash"
 	"github.com/shiroha-a/mk/internal/entity"
 	"github.com/shiroha-a/mk/internal/misc/id"
@@ -187,6 +188,7 @@ func (h *Handler) My(c echo.Context) error {
 	}
 	// sinceDate / untilDate を aidx prefix に正規化 (#1166)。
 	sinceID, untilID := id.NormalizeCursor(req.SinceID, req.UntilID, req.SinceDate, req.UntilDate)
+	req.Limit = pagination.ClampLimit(req.Limit, 10, 100)
 	rows, err := h.svc.My(user.ID, sinceID, untilID, req.Limit, req.Offset)
 	if err != nil {
 		return apierr.JSONInternalError(c)
@@ -202,6 +204,7 @@ func (h *Handler) Featured(c echo.Context) error {
 	}
 	// sinceDate / untilDate を aidx prefix に正規化 (#1166)。
 	sinceID, untilID := id.NormalizeCursor(req.SinceID, req.UntilID, req.SinceDate, req.UntilDate)
+	req.Limit = pagination.ClampLimit(req.Limit, 10, 100)
 	rows, err := h.svc.Featured(sinceID, untilID, req.Limit, req.Offset)
 	if err != nil {
 		return apierr.JSONInternalError(c)
@@ -217,6 +220,7 @@ func (h *Handler) Search(c echo.Context) error {
 	}
 	// sinceDate / untilDate を aidx prefix に正規化 (#1166)。
 	sinceID, untilID := id.NormalizeCursor(req.SinceID, req.UntilID, req.SinceDate, req.UntilDate)
+	req.Limit = pagination.ClampLimit(req.Limit, 5, 100)
 	rows, err := h.svc.Search(req.Query, sinceID, untilID, req.Limit, req.Offset)
 	if err != nil {
 		return apierr.JSONInternalError(c)
@@ -280,6 +284,7 @@ func (h *Handler) MyLikes(c echo.Context) error {
 	}
 	// sinceDate / untilDate を aidx prefix に正規化 (#1166)。
 	sinceID, untilID := id.NormalizeCursor(req.SinceID, req.UntilID, req.SinceDate, req.UntilDate)
+	req.Limit = pagination.ClampLimit(req.Limit, 10, 100)
 	pairs, err := h.svc.MyLikes(user.ID, sinceID, untilID, req.Limit, req.Offset)
 	if err != nil {
 		return apierr.JSONInternalError(c)

--- a/internal/api/following/handler.go
+++ b/internal/api/following/handler.go
@@ -255,6 +255,7 @@ func (h *Handler) ListRequests(c echo.Context) error {
 	// sinceDate / untilDate を aidx prefix に正規化 (#1166)。
 	sinceID, untilID := id.NormalizeCursor(req.SinceID, req.UntilID, req.SinceDate, req.UntilDate)
 
+	req.Limit = pagination.ClampLimit(req.Limit, 10, 100)
 	requests, err := h.followingService.ListReceivedRequests(me.ID, req.Limit, sinceID, untilID)
 	if err != nil {
 		return apierr.JSONInternalError(c)

--- a/internal/api/following/requests_sent.go
+++ b/internal/api/following/requests_sent.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/labstack/echo/v4"
 	"github.com/shiroha-a/mk/internal/api/apierr"
+	"github.com/shiroha-a/mk/internal/api/pagination"
 	"github.com/shiroha-a/mk/internal/entity"
 	"github.com/shiroha-a/mk/internal/misc/id"
 	"github.com/shiroha-a/mk/internal/server/middleware"
@@ -26,6 +27,7 @@ func (h *Handler) RequestsSent(c echo.Context) error {
 	_ = c.Bind(&req)
 	// sinceDate / untilDate を aidx prefix に正規化 (#1166)。
 	sinceID, untilID := id.NormalizeCursor(req.SinceID, req.UntilID, req.SinceDate, req.UntilDate)
+	req.Limit = pagination.ClampLimit(req.Limit, 10, 100)
 	rows, err := h.followingService.ListSentRequests(me.ID, req.Limit, sinceID, untilID)
 	if err != nil {
 		return apierr.JSONInternalError(c)

--- a/internal/api/i/handler_extra.go
+++ b/internal/api/i/handler_extra.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/labstack/echo/v4"
 	"github.com/shiroha-a/mk/internal/api/apierr"
+	"github.com/shiroha-a/mk/internal/api/pagination"
 	"github.com/shiroha-a/mk/internal/entity"
 	"github.com/shiroha-a/mk/internal/misc/id"
 	"github.com/shiroha-a/mk/internal/model"
@@ -140,6 +141,7 @@ func (h *Handler) Favorites(c echo.Context) error {
 	}
 	// sinceDate / untilDate を aidx prefix に正規化 (#1166)。
 	sinceID, untilID := id.NormalizeCursor(req.SinceID, req.UntilID, req.SinceDate, req.UntilDate)
+	req.Limit = pagination.ClampLimit(req.Limit, 10, 100)
 	favs, err := h.favoriteRepo.ListByUser(u.ID, untilID, sinceID, req.Limit)
 	if err != nil {
 		return c.JSON(http.StatusInternalServerError, apierr.Error("INTERNAL_ERROR", "Internal error.", "5d37dbcb-891e-41ca-a3d6-e690c97775ac"))

--- a/internal/api/invite/handler.go
+++ b/internal/api/invite/handler.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/labstack/echo/v4"
 	"github.com/shiroha-a/mk/internal/api/apierr"
+	"github.com/shiroha-a/mk/internal/api/pagination"
 	"github.com/shiroha-a/mk/internal/entity"
 	"github.com/shiroha-a/mk/internal/misc/id"
 	"github.com/shiroha-a/mk/internal/model"
@@ -117,6 +118,7 @@ func (h *Handler) List(c echo.Context) error {
 	// sinceDate / untilDate を aidx prefix に正規化 (#1173)。
 	sinceID, untilID := id.NormalizeCursor(req.SinceID, req.UntilID, req.SinceDate, req.UntilDate)
 
+	req.Limit = pagination.ClampLimit(req.Limit, 30, 100)
 	tickets, err := h.repo.ListByCreator(user.ID, sinceID, untilID, req.Limit)
 	if err != nil {
 		// upstream は handler 内で DB error を listing 404 相当ではなく empty

--- a/internal/api/notes/handler.go
+++ b/internal/api/notes/handler.go
@@ -436,6 +436,7 @@ func (r *listRequest) normalize() {
 // Renotes handles POST /api/notes/renotes.
 func (h *Handler) Renotes(c echo.Context) error {
 	return h.serveList(c, "12908022-2e21-46cd-ba6a-3edaf6093f46", func(viewer *model.User, req listRequest) ([]*model.Note, error) {
+		req.Limit = pagination.ClampLimit(req.Limit, 10, 100)
 		return h.queryService.ListRenotes(viewer, req.NoteID, req.UntilID, req.SinceID, req.Limit)
 	})
 }
@@ -443,6 +444,7 @@ func (h *Handler) Renotes(c echo.Context) error {
 // Replies handles POST /api/notes/replies.
 func (h *Handler) Replies(c echo.Context) error {
 	return h.serveList(c, apierr.UUIDNoSuchNote, func(viewer *model.User, req listRequest) ([]*model.Note, error) {
+		req.Limit = pagination.ClampLimit(req.Limit, 10, 100)
 		return h.queryService.ListReplies(viewer, req.NoteID, req.UntilID, req.SinceID, req.Limit)
 	})
 }
@@ -450,6 +452,7 @@ func (h *Handler) Replies(c echo.Context) error {
 // Children handles POST /api/notes/children.
 func (h *Handler) Children(c echo.Context) error {
 	return h.serveList(c, apierr.UUIDNoSuchNote, func(viewer *model.User, req listRequest) ([]*model.Note, error) {
+		req.Limit = pagination.ClampLimit(req.Limit, 10, 100)
 		return h.queryService.ListChildren(viewer, req.NoteID, req.UntilID, req.SinceID, req.Limit)
 	})
 }

--- a/internal/api/notes/timeline_handler.go
+++ b/internal/api/notes/timeline_handler.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/labstack/echo/v4"
 	"github.com/shiroha-a/mk/internal/api/apierr"
+	"github.com/shiroha-a/mk/internal/api/pagination"
 	"github.com/shiroha-a/mk/internal/core/timeline"
 	"github.com/shiroha-a/mk/internal/misc/id"
 	"github.com/shiroha-a/mk/internal/model"
@@ -89,6 +90,7 @@ func (h *Handler) Timeline(c echo.Context) error {
 			MutedUserIDs:          h.loadMutedUserIDs(viewer),
 			RenoteMutedUserIDs:    h.loadRenoteMutedUserIDs(viewer),
 		}
+		req.Limit = pagination.ClampLimit(req.Limit, 10, 100)
 		return h.timelineService.HomeTimeline(c.Request().Context(), viewer, req.UntilID, req.SinceID, req.Limit, f)
 	}, true)
 }
@@ -108,6 +110,7 @@ func (h *Handler) LocalTimeline(c echo.Context) error {
 			MutedUserIDs:       h.loadMutedUserIDs(viewer),
 			RenoteMutedUserIDs: h.loadRenoteMutedUserIDs(viewer),
 		}
+		req.Limit = pagination.ClampLimit(req.Limit, 10, 100)
 		return h.timelineService.LocalTimeline(c.Request().Context(), viewer, req.UntilID, req.SinceID, req.Limit, f)
 	}, false)
 }
@@ -126,6 +129,7 @@ func (h *Handler) GlobalTimeline(c echo.Context) error {
 			MutedUserIDs:       h.loadMutedUserIDs(viewer),
 			RenoteMutedUserIDs: h.loadRenoteMutedUserIDs(viewer),
 		}
+		req.Limit = pagination.ClampLimit(req.Limit, 10, 100)
 		return h.timelineService.GlobalTimeline(c.Request().Context(), viewer, req.UntilID, req.SinceID, req.Limit, f)
 	}, false)
 }
@@ -150,6 +154,7 @@ func (h *Handler) HybridTimeline(c echo.Context) error {
 			MutedUserIDs:          h.loadMutedUserIDs(viewer),
 			RenoteMutedUserIDs:    h.loadRenoteMutedUserIDs(viewer),
 		}
+		req.Limit = pagination.ClampLimit(req.Limit, 10, 100)
 		return h.timelineService.HybridTimeline(c.Request().Context(), viewer, req.UntilID, req.SinceID, req.Limit, f)
 	}, true)
 }

--- a/internal/api/notifications/handler.go
+++ b/internal/api/notifications/handler.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/labstack/echo/v4"
 	"github.com/shiroha-a/mk/internal/api/apierr"
+	"github.com/shiroha-a/mk/internal/api/pagination"
 	"github.com/shiroha-a/mk/internal/core/notification"
 	"github.com/shiroha-a/mk/internal/entity"
 	"github.com/shiroha-a/mk/internal/misc/id"
@@ -111,6 +112,7 @@ func (h *Handler) Show(c echo.Context) error {
 	// (= aidx) で判定する設計なので adapter pattern で完結する。
 	req.SinceID, req.UntilID = id.NormalizeCursor(req.SinceID, req.UntilID, req.SinceDate, req.UntilDate)
 
+	req.Limit = pagination.ClampLimit(req.Limit, 10, 100)
 	rows, err := h.svc.List(c.Request().Context(), user.ID, req.Limit)
 	if err != nil {
 		return apierr.JSONInternalError(c)

--- a/internal/api/pages/handler.go
+++ b/internal/api/pages/handler.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/labstack/echo/v4"
 	"github.com/shiroha-a/mk/internal/api/apierr"
+	"github.com/shiroha-a/mk/internal/api/pagination"
 	corepage "github.com/shiroha-a/mk/internal/core/page"
 	coreuser "github.com/shiroha-a/mk/internal/core/user"
 	"github.com/shiroha-a/mk/internal/entity"
@@ -291,6 +292,7 @@ func (h *Handler) My(c echo.Context) error {
 	}
 	// sinceDate / untilDate を aidx prefix に正規化 (#1166)。
 	sinceID, untilID := id.NormalizeCursor(req.SinceID, req.UntilID, req.SinceDate, req.UntilDate)
+	req.Limit = pagination.ClampLimit(req.Limit, 10, 100)
 	rows, err := h.svc.ListByUser(user.ID, sinceID, untilID, req.Limit, req.Offset)
 	if err != nil {
 		return apierr.JSONInternalError(c)


### PR DESCRIPTION
## Summary

#1343 (phase 2) の続き。limit clamp が handler / 共有 helper / service の各層に散在し、一部 endpoint は max clamp が無く **unbounded** だった (clips/list は svc→repo が raw を SQL LIMIT に渡す)。真の unbounded を静的特定するのは多層トレースが必要で困難なため、**svc 層の clamp に依存せず全 list handler で handler-level `pagination.ClampLimit` を適用**する方針に統一する。

## 主な変更点

- 残り **31 list handler** に handler-level `ClampLimit(req.Limit, golden_default, golden_max)` を golden 値で挿入
- gate checked: **31→64 endpoint** (golden 113 中)
- **真の unbounded を修正**: `clips/{list,notes}`, `drive/files/attached-notes`, `flash/{my,my-likes,featured}`, `antennas/notes`, `announcements`, `following/requests/{list,sent}` 等
- svc が既に clamp する箇所 (`i/notifications` 等) は handler 側 golden 値が手前で適用される **redundant-but-harmless な defense-in-depth**

## 方針

- clamp 挙動自体 (mk=clamp / Misskey=reject) は不変。**default/max 値のみ** gate
- svc 層の重複 clamp は無害なので残置 (dead clamp 整理は別途)
- `gallery/featured` は `.Limit(10)` ハードコードで limit param 非対応のため対象外 (別件)

## テスト

- `TestLimitSpecDrift` green (checked=64)
- 全 api 46 パッケージ + entitycompat pass (FAIL=0)
- `make fmt` / `lint` / `build` 通過

## Closes
Closes #1344

🤖 Generated with [Claude Code](https://claude.com/claude-code)