### PR TITLE
fix(api): remote user の publicReactions を false にし reactions タブ error を解消

### DIFF
--- a/internal/entity/user.go
+++ b/internal/entity/user.go
@@ -490,6 +490,14 @@ func PackUserDetailed(u *model.User, profile *model.UserProfile, idGens ...id.Ge
 		d.FollowingVisibility = string(profile.FollowingVisibility)
 	}
 
+	// upstream UserEntityService: publicReactions は
+	// `isLocalUser(user) ? profile.publicReactions : false` (issue 12964)。
+	// remote user は users/reactions が IS_REMOTE_USER を返すため、ここで false
+	// にしておかないと frontend が reactions タブを表示して error になる。
+	if u.Host != nil {
+		d.PublicReactions = false
+	}
+
 	return d
 }
 

--- a/internal/entity/user_test.go
+++ b/internal/entity/user_test.go
@@ -896,3 +896,32 @@ func TestPackMeDetailed_NotificationMalformed(t *testing.T) {
 	assert.Equal(t, []string{"follow", "receiveFollowRequest"}, me.EmailNotificationTypes)
 	assert.Equal(t, map[string]any{}, me.NotificationRecieveConfig)
 }
+
+// remote user (host != nil) は upstream UserEntityService と同じく
+// publicReactions を常に false にする (issue 12964)。これが true だと
+// frontend が reactions タブを表示し、users/reactions が IS_REMOTE_USER で
+// error になる (リモートユーザーをローカルと誤認するバグの回帰防止)。
+func TestPackUserDetailed_RemoteUserPublicReactionsFalse(t *testing.T) {
+	host := "remote.example.com"
+	u := &model.User{
+		ID:                "ruser",
+		Username:          "alice",
+		Host:              &host,
+		AvatarDecorations: datatypes.JSON([]byte("[]")),
+	}
+	// profile が publicReactions=true でも remote なら false に上書きされる。
+	profile := &model.UserProfile{UserID: "ruser", PublicReactions: true, Fields: datatypes.JSON([]byte("[]"))}
+
+	detailed := PackUserDetailed(u, profile)
+	assert.False(t, detailed.PublicReactions, "remote user must report publicReactions=false")
+}
+
+// local user は profile の publicReactions をそのまま反映する (remote 上書きが
+// local を巻き込まない回帰防止)。
+func TestPackUserDetailed_LocalUserPublicReactionsPreserved(t *testing.T) {
+	u := &model.User{ID: "luser", Username: "bob", AvatarDecorations: datatypes.JSON([]byte("[]"))}
+	profile := &model.UserProfile{UserID: "luser", PublicReactions: true, Fields: datatypes.JSON([]byte("[]"))}
+
+	detailed := PackUserDetailed(u, profile)
+	assert.True(t, detailed.PublicReactions, "local user with publicReactions=true must stay true")
+}


### PR DESCRIPTION
## 症状

リモートユーザーのプロフィール → リアクションタブが**エラーになり表示されない**。ローカルユーザーは正常。

## 根本原因

frontend はプロフィールの reactions タブを `publicReactions` (自分/admin/mod 以外) で出し分ける。`users/reactions` は remote user に IS_REMOTE_USER (400) を返す (upstream 同様、[issue 12964](https://github.com/misskey-dev/misskey/issues/12964))。

upstream の UserEntityService は `publicReactions: isLocalUser(user) ? profile.publicReactions : false` で **remote user を常に false** にし、frontend が remote のタブを出さない。

mk-go の `PackUserDetailed` は `isLocalUser` 判定が無く、remote user でも `profile.PublicReactions` (または DB default の true) を返していた → frontend が reactions タブを表示 → クリック → IS_REMOTE_USER error。

## 修正

`PackUserDetailed` で `u.Host != nil` (remote) のとき `PublicReactions=false` に上書き (upstream の isLocalUser 三項と一致)。

## 「他のタブも誤認?」調査

upstream UserEntityService で local/remote を出し分けるフィールドは **publicReactions の 1 つのみ**。`host` は正しく返るため host-gated タブ (achievements) は正常に隠れ、その他タブ (clips/pages/lists 等) は remote で空配列を返すだけで error にならない。本件が唯一の remote-as-local leak。

## テスト

- `TestPackUserDetailed_RemoteUserPublicReactionsFalse` / `_LocalUserPublicReactionsPreserved` 追加
- entity + users + entitycompat pass、`make fmt`/`lint`/`build` 通過

## Closes
Closes #1352

🤖 Generated with [Claude Code](https://claude.com/claude-code)