### PR TITLE
fix(api): users/reactions で moderator が remote user の reaction を閲覧できるようにする

### DIFF
--- a/internal/api/users/handler.go
+++ b/internal/api/users/handler.go
@@ -64,6 +64,10 @@ type Handler struct {
 	// followersCount / followingCount を origin instance から取得して上書き
 	// 表示するための fetcher (#943)。nil なら local 観測値を fallback。
 	remoteStatsFetcher RemoteStatsFetcher
+	// moderatorChecker は users/reactions で viewer が moderator/admin かを
+	// 判定し、remote user / 非 public reactions の閲覧制限を bypass するため
+	// に使う (upstream の iAmModerator 経路)。
+	moderatorChecker ModeratorChecker
 }
 
 // RemoteStatsFetcher abstracts the federation.RemoteStatsFetcher so wiring is
@@ -83,6 +87,21 @@ type RemoteUserStatsView struct {
 // SetRemoteStatsFetcher wires the remote stats fetcher (#943).
 func (h *Handler) SetRemoteStatsFetcher(f RemoteStatsFetcher) {
 	h.remoteStatsFetcher = f
+}
+
+// ModeratorChecker reports whether a user holds moderator (or admin) privileges.
+// core/role.Service implements it. Narrowing to this interface avoids importing
+// core/role into the handler.
+type ModeratorChecker interface {
+	IsModerator(userID string) bool
+}
+
+// SetModeratorChecker wires the moderator check used by users/reactions so a
+// moderator/admin viewer can see any user's reactions (incl. remote), matching
+// upstream's `if (!iAmModerator) { ...isRemoteUser/publicReactions checks }`.
+// nil keeps the gate strict (= test fixture / unwired)。
+func (h *Handler) SetModeratorChecker(m ModeratorChecker) {
+	h.moderatorChecker = m
 }
 
 // SetUserRepo wires a UserRepository so users/notes filters out notes that

--- a/internal/api/users/handler_extra.go
+++ b/internal/api/users/handler_extra.go
@@ -179,11 +179,17 @@ func (h *Handler) Reactions(c echo.Context) error {
 	req.SinceID, req.UntilID = id.NormalizeCursor(req.SinceID, req.UntilID, req.SinceDate, req.UntilDate)
 	req.Limit = pagination.ClampLimit(req.Limit, 10, 100)
 
-	// target user lookup + remote / publicReactions check.
+	// upstream: moderator / admin は全ユーザー (remote / 非 public reactions
+	// 含む) の reaction を閲覧できる ("Moderators can see reactions of all
+	// users")。viewer が moderator なら remote / publicReactions check を
+	// 丸ごと bypass して reaction list を返す。
+	iAmModerator := viewer != nil && h.moderatorChecker != nil && h.moderatorChecker.IsModerator(viewer.ID)
+
+	// target user lookup + remote / publicReactions check (non-moderator のみ)。
 	// production では userRepo が必ず wire されるが、既存の handler test
 	// (TestReactions_Success 等) は userRepo を wire しないので nil guard で
 	// fall-through する (= test compat、production 影響なし)。
-	if h.userRepo != nil {
+	if !iAmModerator && h.userRepo != nil {
 		target, err := h.userRepo.FindByID(req.UserID)
 		if err != nil || target == nil {
 			return c.JSON(http.StatusNotFound, apierr.Error("NO_SUCH_USER", "No such user.", "27e494ba-2ac2-48e8-893b-10d4d8c2387b"))

--- a/internal/api/users/handler_extra_test.go
+++ b/internal/api/users/handler_extra_test.go
@@ -528,3 +528,41 @@ func TestSearchByUsernameAndHost_Error(t *testing.T) {
 	rec := postExtra(h.SearchByUsernameAndHost, `{"username":"x"}`, nil)
 	assert.Equal(t, http.StatusInternalServerError, rec.Code)
 }
+
+// stubModeratorChecker は指定 userID を moderator とみなす test stub。
+type stubModeratorChecker struct{ modID string }
+
+func (s stubModeratorChecker) IsModerator(userID string) bool { return userID == s.modID }
+
+// moderator viewer は remote user の reaction も閲覧できる (upstream:
+// "Moderators can see reactions of all users")。IS_REMOTE_USER を返さず
+// reaction list (空でも 200) を返す。リモートユーザーのリアクションが
+// moderator で見られない回帰の防止。
+func TestReactions_ModeratorSeesRemoteUser(t *testing.T) {
+	h, userRepo, _ := newReactionsHandler(t)
+	h.SetModeratorChecker(stubModeratorChecker{modID: "u_mod"})
+	host := "remote.example"
+	userRepo.Users["u_remote"] = &model.User{ID: "u_remote", Host: &host}
+	rec := postExtra(h.Reactions, `{"userId":"u_remote"}`, &model.User{ID: "u_mod"})
+	assert.Equal(t, http.StatusOK, rec.Code) // IS_REMOTE_USER ではなく list (空) を返す
+}
+
+// moderator viewer は publicReactions=false の user の reaction も閲覧できる。
+func TestReactions_ModeratorSeesNonPublic(t *testing.T) {
+	h, userRepo, _ := newReactionsHandler(t)
+	h.SetModeratorChecker(stubModeratorChecker{modID: "u_mod"})
+	userRepo.Users["u_target"] = &model.User{ID: "u_target"}
+	userRepo.Profiles["u_target"] = &model.UserProfile{UserID: "u_target", PublicReactions: false}
+	rec := postExtra(h.Reactions, `{"userId":"u_target"}`, &model.User{ID: "u_mod"})
+	assert.Equal(t, http.StatusOK, rec.Code)
+}
+
+// 非 moderator viewer では remote user は従来どおり IS_REMOTE_USER のまま。
+func TestReactions_NonModeratorRemoteStillBlocked(t *testing.T) {
+	h, userRepo, _ := newReactionsHandler(t)
+	h.SetModeratorChecker(stubModeratorChecker{modID: "u_mod"})
+	host := "remote.example"
+	userRepo.Users["u_remote"] = &model.User{ID: "u_remote", Host: &host}
+	rec := postExtra(h.Reactions, `{"userId":"u_remote"}`, &model.User{ID: "u_other"})
+	assert.Equal(t, http.StatusBadRequest, rec.Code)
+}

--- a/internal/server/router.go
+++ b/internal/server/router.go
@@ -1221,6 +1221,9 @@ func (s *Server) setupRoutes() {
 	usersHandler.SetMemoRepo(repository.NewUserMemoRepository(s.db))
 	usersHandler.SetUserListFavoriteRepo(userListFavoriteRepo)
 	usersHandler.SetUserListRepo(userListRepo)
+	// users/reactions で moderator/admin が remote / 非 public reactions を
+	// 閲覧できるようにする (upstream の iAmModerator bypass)。
+	usersHandler.SetModeratorChecker(roleService)
 	// Phase 7.3: users/* 完全化 (実データハンドラ)
 	api.POST("/users/achievements", usersHandler.Achievements)
 	api.POST("/users/clips", usersHandler.Clips)


### PR DESCRIPTION
## 症状

リモートユーザーのプロフィール → リアクションタブが (moderator/admin で見ても) エラーで表示されない。**純正 Misskey では moderator なら remote user でもリアクションした投稿が見られる**。

## 根本原因

#1353 は `publicReactions=false` (remote) で非 moderator 向けにタブを隠したが、upstream の core ロジックを見落としていた:

```js
const iAmModerator = me ? await roleService.isModerator(me) : false; // Moderators can see reactions of all users
if (!iAmModerator) {
  if (isRemoteUser(user)) throw isRemoteUser;     // ← moderator はスキップ
  if (!profile.publicReactions) throw reactionsNotPublic;
}
```

mk-go の handler は `target.Host != nil → IS_REMOTE_USER` を**無条件実行**しており、moderator でも弾いていた。frontend のタブも `(self||isAdmin||isModerator)||publicReactions` で moderator には表示されるため、タブは出るのに backend が error を返していた。

## 修正

- users handler に narrow `ModeratorChecker` (IsModerator) を配線 (roleService 実装)
- Reactions handler の remote / publicReactions check を `if !iAmModerator { ... }` で囲む (upstream 一致)
- 回帰テスト 3 件 (moderator→remote 200 / moderator→非public 200 / 非mod→remote は IS_REMOTE_USER 維持)

#1353 (remote の publicReactions=false) は非 moderator 向けに引き続き正しく、本 PR と合わせて upstream と完全一致 (moderator: タブ表示+reaction取得 / 非mod: タブ非表示)。

## テスト
- 新規 3 件 + 既存 Reactions テスト全 pass、`internal/server` pass
- `make fmt`/`lint`/`build` 通過

## Closes
Closes #1354

🤖 Generated with [Claude Code](https://claude.com/claude-code)