### PR TITLE
fix(api): users/reactions に note visibility filter を追加

### DIFF
--- a/internal/api/users/handler_extra.go
+++ b/internal/api/users/handler_extra.go
@@ -9,7 +9,6 @@ import (
 	"github.com/labstack/echo/v4"
 	"github.com/shiroha-a/mk/internal/api/apierr"
 	"github.com/shiroha-a/mk/internal/api/pagination"
-	"github.com/shiroha-a/mk/internal/core/note"
 	"github.com/shiroha-a/mk/internal/core/notesfilter"
 	"github.com/shiroha-a/mk/internal/entity"
 	"github.com/shiroha-a/mk/internal/misc/id"
@@ -219,23 +218,19 @@ func (h *Handler) Reactions(c echo.Context) error {
 	if h.noteReactionRepo == nil {
 		return c.JSON(http.StatusOK, []any{})
 	}
-	rows, err := h.noteReactionRepo.ListByUserID(req.UserID, req.UntilID, req.SinceID, req.Limit)
+	// upstream の generateVisibilityQuery(query, me) 相当を repo の SQL に push
+	// down する (moderator も含む全 viewer に適用)。viewer が閲覧できない note
+	// (followers/specified) の reaction を LIMIT 前に除外することで、post-filter
+	// 時に起きる「ページが limit 未満になりページネーションが途切れる」問題を
+	// 避ける。
+	viewerID := ""
+	if viewer != nil {
+		viewerID = viewer.ID
+	}
+	rows, err := h.noteReactionRepo.ListByUserID(req.UserID, viewerID, req.UntilID, req.SinceID, req.Limit)
 	if err != nil {
 		return c.JSON(http.StatusInternalServerError, apierr.Error("INTERNAL_ERROR", "Internal error.", "5d37dbcb-891e-41ca-a3d6-e690c97775ac"))
 	}
-
-	// upstream は generateVisibilityQuery(query, me) で viewer が閲覧できない
-	// note (followers/specified) の reaction を moderator も含む全 viewer から
-	// 除外する。mk-go は post-fetch で CanSeeNote で filter する (timeline の
-	// FilterVisible と同 pattern)。これが無いと reaction 経由で非公開 note が
-	// 露出する。
-	visible := rows[:0]
-	for _, r := range rows {
-		if r.Note == nil || note.CanSeeNote(viewer, r.Note, h.followingRepo) {
-			visible = append(visible, r)
-		}
-	}
-	rows = visible
 
 	// note は upstream の packManyWithNote と同じく完全 shape で返す。最小 shape
 	// (id/userId/text) だと createdAt / visibility / user 等が欠落し、misskey_dart

--- a/internal/api/users/handler_extra.go
+++ b/internal/api/users/handler_extra.go
@@ -9,6 +9,7 @@ import (
 	"github.com/labstack/echo/v4"
 	"github.com/shiroha-a/mk/internal/api/apierr"
 	"github.com/shiroha-a/mk/internal/api/pagination"
+	"github.com/shiroha-a/mk/internal/core/note"
 	"github.com/shiroha-a/mk/internal/core/notesfilter"
 	"github.com/shiroha-a/mk/internal/entity"
 	"github.com/shiroha-a/mk/internal/misc/id"
@@ -222,6 +223,19 @@ func (h *Handler) Reactions(c echo.Context) error {
 	if err != nil {
 		return c.JSON(http.StatusInternalServerError, apierr.Error("INTERNAL_ERROR", "Internal error.", "5d37dbcb-891e-41ca-a3d6-e690c97775ac"))
 	}
+
+	// upstream は generateVisibilityQuery(query, me) で viewer が閲覧できない
+	// note (followers/specified) の reaction を moderator も含む全 viewer から
+	// 除外する。mk-go は post-fetch で CanSeeNote で filter する (timeline の
+	// FilterVisible と同 pattern)。これが無いと reaction 経由で非公開 note が
+	// 露出する。
+	visible := rows[:0]
+	for _, r := range rows {
+		if r.Note == nil || note.CanSeeNote(viewer, r.Note, h.followingRepo) {
+			visible = append(visible, r)
+		}
+	}
+	rows = visible
 
 	// note は upstream の packManyWithNote と同じく完全 shape で返す。最小 shape
 	// (id/userId/text) だと createdAt / visibility / user 等が欠落し、misskey_dart

--- a/internal/api/users/handler_extra_test.go
+++ b/internal/api/users/handler_extra_test.go
@@ -327,6 +327,9 @@ func TestReactions_PublicReactions(t *testing.T) {
 		UserID:   "u_pub",
 		NoteID:   "n2",
 		Reaction: "❤",
+		// real repo は FK + Preload で note が必ず存在するので public note を seed
+		// する (visibility filter で除外されないことの確認も兼ねる)。
+		Note: &model.Note{ID: "n2", UserID: "u_author", Visibility: "public"},
 	}
 	rec := postExtra(h.Reactions, `{"userId":"u_pub"}`, &model.User{ID: "u_viewer"})
 	require.Equal(t, http.StatusOK, rec.Code)

--- a/internal/api/users/handler_extra_test.go
+++ b/internal/api/users/handler_extra_test.go
@@ -566,3 +566,72 @@ func TestReactions_NonModeratorRemoteStillBlocked(t *testing.T) {
 	rec := postExtra(h.Reactions, `{"userId":"u_remote"}`, &model.User{ID: "u_other"})
 	assert.Equal(t, http.StatusBadRequest, rec.Code)
 }
+
+// seedVisibilityReactions は public note と followers-only note それぞれへの
+// reaction を target に seed する。visibility filter の検証用 helper。
+func seedVisibilityReactions(t *testing.T, rxRepo *testutil.MockNoteReactionRepository, targetID string) (publicRxID, followersRxID string) {
+	t.Helper()
+	idGen, _ := id.NewGenerator("aidx")
+	publicRxID = idGen.Generate(time.Date(2026, 5, 10, 12, 0, 0, 0, time.UTC))
+	followersRxID = idGen.Generate(time.Date(2026, 5, 10, 13, 0, 0, 0, time.UTC))
+	pubNoteID := idGen.Generate(time.Date(2026, 5, 10, 11, 0, 0, 0, time.UTC))
+	folNoteID := idGen.Generate(time.Date(2026, 5, 10, 11, 30, 0, 0, time.UTC))
+	pubText, folText := "public note", "followers only note"
+	rxRepo.Reactions[publicRxID] = &model.NoteReaction{
+		ID: publicRxID, UserID: targetID, NoteID: pubNoteID, Reaction: "👍",
+		User: &model.User{ID: targetID, Username: "target"},
+		Note: &model.Note{
+			ID: pubNoteID, UserID: "u_author", Text: &pubText,
+			Visibility: "public", User: &model.User{ID: "u_author", Username: "author"},
+		},
+	}
+	rxRepo.Reactions[followersRxID] = &model.NoteReaction{
+		ID: followersRxID, UserID: targetID, NoteID: folNoteID, Reaction: "❤",
+		User: &model.User{ID: targetID, Username: "target"},
+		Note: &model.Note{
+			ID: folNoteID, UserID: "u_author", Text: &folText,
+			Visibility: "followers", User: &model.User{ID: "u_author", Username: "author"},
+		},
+	}
+	return publicRxID, followersRxID
+}
+
+// upstream の generateVisibilityQuery(query, me) 相当: viewer が閲覧できない
+// note (followers-only で follower でない) の reaction は除外され、public note
+// の reaction のみ返る。followingRepo を wire しないので CanSeeNote は
+// followers note を false と判定する (= 非 follower viewer 相当)。
+func TestReactions_FiltersInvisibleNotes(t *testing.T) {
+	h, userRepo, rxRepo := newReactionsHandler(t)
+	userRepo.Users["u_target"] = &model.User{ID: "u_target"}
+	userRepo.Profiles["u_target"] = &model.UserProfile{UserID: "u_target", PublicReactions: true}
+	publicRxID, followersRxID := seedVisibilityReactions(t, rxRepo, "u_target")
+
+	rec := postExtra(h.Reactions, `{"userId":"u_target","limit":150}`, &model.User{ID: "u_viewer"})
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	var list []map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &list))
+	require.Len(t, list, 1, "followers-only note reaction must be filtered out")
+	assert.Equal(t, publicRxID, list[0]["id"])
+	assert.NotEqual(t, followersRxID, list[0]["id"])
+}
+
+// moderator viewer でも visibility filter は適用される (upstream は
+// generateVisibilityQuery を moderator 含む全 viewer に無条件適用)。
+// moderator は remote / publicReactions gate を bypass するが、follower で
+// ない followers-only note の reaction は除外される。
+func TestReactions_ModeratorStillFiltersInvisibleNotes(t *testing.T) {
+	h, userRepo, rxRepo := newReactionsHandler(t)
+	h.SetModeratorChecker(stubModeratorChecker{modID: "u_mod"})
+	userRepo.Users["u_target"] = &model.User{ID: "u_target"}
+	userRepo.Profiles["u_target"] = &model.UserProfile{UserID: "u_target", PublicReactions: false}
+	publicRxID, _ := seedVisibilityReactions(t, rxRepo, "u_target")
+
+	rec := postExtra(h.Reactions, `{"userId":"u_target","limit":150}`, &model.User{ID: "u_mod"})
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	var list []map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &list))
+	require.Len(t, list, 1, "moderator must not see followers-only note reaction")
+	assert.Equal(t, publicRxID, list[0]["id"])
+}

--- a/internal/api/users/handler_extra_test.go
+++ b/internal/api/users/handler_extra_test.go
@@ -360,7 +360,7 @@ type failingListByUserIDRepo struct {
 	*testutil.MockNoteReactionRepository
 }
 
-func (f *failingListByUserIDRepo) ListByUserID(_ string, _, _ string, _ int) ([]*model.NoteReaction, error) {
+func (f *failingListByUserIDRepo) ListByUserID(_, _, _, _ string, _ int) ([]*model.NoteReaction, error) {
 	return nil, assert.AnError
 }
 
@@ -598,8 +598,8 @@ func seedVisibilityReactions(t *testing.T, rxRepo *testutil.MockNoteReactionRepo
 
 // upstream の generateVisibilityQuery(query, me) 相当: viewer が閲覧できない
 // note (followers-only で follower でない) の reaction は除外され、public note
-// の reaction のみ返る。followingRepo を wire しないので CanSeeNote は
-// followers note を false と判定する (= 非 follower viewer 相当)。
+// の reaction のみ返る。mock の Following を設定しないので followers note は
+// 非 follower viewer 扱いで除外される。
 func TestReactions_FiltersInvisibleNotes(t *testing.T) {
 	h, userRepo, rxRepo := newReactionsHandler(t)
 	userRepo.Users["u_target"] = &model.User{ID: "u_target"}
@@ -614,6 +614,66 @@ func TestReactions_FiltersInvisibleNotes(t *testing.T) {
 	require.Len(t, list, 1, "followers-only note reaction must be filtered out")
 	assert.Equal(t, publicRxID, list[0]["id"])
 	assert.NotEqual(t, followersRxID, list[0]["id"])
+}
+
+// follower viewer は followers-only note の reaction も閲覧できる
+// (mock の Following に viewer -> author を登録)。public とあわせ 2 件返る。
+func TestReactions_FollowerSeesFollowersOnlyNote(t *testing.T) {
+	h, userRepo, rxRepo := newReactionsHandler(t)
+	userRepo.Users["u_target"] = &model.User{ID: "u_target"}
+	userRepo.Profiles["u_target"] = &model.UserProfile{UserID: "u_target", PublicReactions: true}
+	seedVisibilityReactions(t, rxRepo, "u_target")
+	// u_follower が note author (u_author) を follow している。
+	rxRepo.Following = map[string][]string{"u_follower": {"u_author"}}
+
+	rec := postExtra(h.Reactions, `{"userId":"u_target","limit":150}`, &model.User{ID: "u_follower"})
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	var list []map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &list))
+	require.Len(t, list, 2, "follower must see both public and followers-only note reactions")
+}
+
+// specified note は visibleUserIds に含まれる viewer のみ閲覧でき、含まれない
+// viewer からは除外される (CanSeeNote の specified 分岐相当)。
+func TestReactions_SpecifiedNoteVisibility(t *testing.T) {
+	idGen, _ := id.NewGenerator("aidx")
+	rxID := idGen.Generate(time.Date(2026, 5, 11, 12, 0, 0, 0, time.UTC))
+	noteID := idGen.Generate(time.Date(2026, 5, 11, 11, 0, 0, 0, time.UTC))
+	text := "specified note"
+	seed := func(rxRepo *testutil.MockNoteReactionRepository) {
+		rxRepo.Reactions[rxID] = &model.NoteReaction{
+			ID: rxID, UserID: "u_target", NoteID: noteID, Reaction: "👀",
+			User: &model.User{ID: "u_target", Username: "target"},
+			Note: &model.Note{
+				ID: noteID, UserID: "u_author", Text: &text,
+				Visibility: "specified", VisibleUserIDs: []string{"u_allowed"},
+				User: &model.User{ID: "u_author", Username: "author"},
+			},
+		}
+	}
+
+	// visibleUserIds に含まれる viewer は閲覧可。
+	h, userRepo, rxRepo := newReactionsHandler(t)
+	userRepo.Users["u_target"] = &model.User{ID: "u_target"}
+	userRepo.Profiles["u_target"] = &model.UserProfile{UserID: "u_target", PublicReactions: true}
+	seed(rxRepo)
+	rec := postExtra(h.Reactions, `{"userId":"u_target","limit":150}`, &model.User{ID: "u_allowed"})
+	require.Equal(t, http.StatusOK, rec.Code)
+	var allowed []map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &allowed))
+	require.Len(t, allowed, 1, "viewer in visibleUserIds must see the specified note reaction")
+
+	// 含まれない viewer からは除外。
+	h2, userRepo2, rxRepo2 := newReactionsHandler(t)
+	userRepo2.Users["u_target"] = &model.User{ID: "u_target"}
+	userRepo2.Profiles["u_target"] = &model.UserProfile{UserID: "u_target", PublicReactions: true}
+	seed(rxRepo2)
+	rec2 := postExtra(h2.Reactions, `{"userId":"u_target","limit":150}`, &model.User{ID: "u_other"})
+	require.Equal(t, http.StatusOK, rec2.Code)
+	var other []map[string]any
+	require.NoError(t, json.Unmarshal(rec2.Body.Bytes(), &other))
+	assert.Len(t, other, 0, "viewer not in visibleUserIds must not see the specified note reaction")
 }
 
 // moderator viewer でも visibility filter は適用される (upstream は

--- a/internal/repository/note_reaction.go
+++ b/internal/repository/note_reaction.go
@@ -23,8 +23,10 @@ type NoteReactionRepository interface {
 	ListByNoteID(noteID string, untilID, sinceID string, limit int, reactions []string) ([]*model.NoteReaction, error)
 	// ListByUserID returns reactions made by the given user, with User and Note
 	// preloaded for packing. upstream Misskey TS の users/reactions endpoint
-	// 用 (reactor 視点の reaction list)。
-	ListByUserID(userID, untilID, sinceID string, limit int) ([]*model.NoteReaction, error)
+	// 用 (reactor 視点の reaction list)。viewerID は閲覧者 (空文字列で匿名) で、
+	// upstream の generateVisibilityQuery と同じく viewer が見られない note
+	// (followers/specified) の reaction を SQL 段階で除外する。
+	ListByUserID(userID, viewerID, untilID, sinceID string, limit int) ([]*model.NoteReaction, error)
 }
 
 type noteReactionRepository struct {
@@ -102,12 +104,29 @@ func (r *noteReactionRepository) ListByNoteID(noteID string, untilID, sinceID st
 // の users/reactions endpoint で使う reactor 視点の list。User / Note を
 // preload して pack 時に追加 query が走らないようにする。pagination は
 // ListByNoteID と同じ keyset 方式 (paginationOrder で DESC 既定)。
-func (r *noteReactionRepository) ListByUserID(userID, untilID, sinceID string, limit int) ([]*model.NoteReaction, error) {
+func (r *noteReactionRepository) ListByUserID(userID, viewerID, untilID, sinceID string, limit int) ([]*model.NoteReaction, error) {
 	var rows []*model.NoteReaction
 	// Note.User も preload する。users/reactions は note を完全 shape (PackNotes)
 	// で返すため、note author が無いと misskey_dart の Note.user (UserLite) 解析が
 	// null で落ちる (#1227)。
 	q := r.db.Preload("User").Preload("Note").Preload("Note.User").Where("\"userId\" = ?", userID)
+	// upstream の generateVisibilityQuery 相当を相関 EXISTS で SQL に push down
+	// する。post-fetch filter だと viewer が見られない note が除外された分
+	// 1 ページが limit 未満になりページネーションが途切れるため、LIMIT 前に
+	// 絞る。条件は core/note.CanSeeNote と一致させる (= timeline の FilterVisible
+	// と同じ可視性定義。upstream の mentions / replyUserId は CanSeeNote 側に
+	// 無いので合わせて含めない)。
+	if viewerID == "" {
+		// 匿名は public / home のみ。
+		q = q.Where(`EXISTS (SELECT 1 FROM "note" v WHERE v."id" = "note_reaction"."noteId" AND v."visibility" IN ('public','home'))`)
+	} else {
+		q = q.Where(`EXISTS (SELECT 1 FROM "note" v WHERE v."id" = "note_reaction"."noteId" AND (`+
+			`v."visibility" IN ('public','home') `+
+			`OR v."userId" = ? `+
+			`OR (v."visibility" = 'followers' AND v."userId" IN (SELECT f."followeeId" FROM "following" f WHERE f."followerId" = ?)) `+
+			`OR (v."visibility" = 'specified' AND ? = ANY(v."visibleUserIds"))))`,
+			viewerID, viewerID, viewerID)
+	}
 	if untilID != "" {
 		q = q.Where("id < ?", untilID)
 	}

--- a/internal/repository/note_reaction_test.go
+++ b/internal/repository/note_reaction_test.go
@@ -223,14 +223,19 @@ func TestNoteReactionRepository_ListByUserID_VisibilityPushDown(t *testing.T) {
 	followingRepo := NewFollowingRepository(testDB)
 	noteRepo := NewNoteRepository(testDB)
 
-	reactor := insertTestUser(t, "u_nrv_r", "nrvreact")
-	author := insertTestUser(t, "u_nrv_a", "nrvauthor")
-	follower := insertTestUser(t, "u_nrv_f", "nrvfollower")
-	allowed := insertTestUser(t, "u_nrv_al", "nrvallowed")
-	stranger := insertTestUser(t, "u_nrv_s", "nrvstranger")
-	for _, id := range []string{reactor.ID, author.ID, follower.ID, allowed.ID, stranger.ID} {
-		defer cleanupUser(t, id)
+	// 各 insert 直後に cleanup を登録する。途中の insert が失敗しても先行分が
+	// leak しないようにする (defer をまとめて後段で登録すると、途中失敗時に
+	// 先行ユーザーが共有 testDB に残る)。
+	mkUser := func(id, username string) *model.User {
+		u := insertTestUser(t, id, username)
+		t.Cleanup(func() { cleanupUser(t, u.ID) })
+		return u
 	}
+	reactor := mkUser("u_nrv_r", "nrvreact")
+	author := mkUser("u_nrv_a", "nrvauthor")
+	follower := mkUser("u_nrv_f", "nrvfollower")
+	allowed := mkUser("u_nrv_al", "nrvallowed")
+	stranger := mkUser("u_nrv_s", "nrvstranger")
 
 	notes := []*model.Note{
 		{ID: "n_nrv_pub", UserID: author.ID, Visibility: model.NoteVisibilityPublic, Reactions: datatypes.JSON([]byte("{}"))},

--- a/internal/repository/note_reaction_test.go
+++ b/internal/repository/note_reaction_test.go
@@ -3,8 +3,10 @@ package repository
 import (
 	"context"
 	"errors"
+	"sort"
 	"testing"
 
+	"github.com/lib/pq"
 	"github.com/shiroha-a/mk/internal/model"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -181,7 +183,8 @@ func TestNoteReactionRepository_ListByUserID(t *testing.T) {
 
 	// user2 視点で 2 件、Preload("User") / Preload("Note") が効いていることも
 	// 確認する。
-	out, err := repo.ListByUserID(user2.ID, "", "", 10)
+	// note は全て public なので匿名 viewer (viewerID="") でも全件見える。
+	out, err := repo.ListByUserID(user2.ID, "", "", "", 10)
 	require.NoError(t, err)
 	require.Len(t, out, 2)
 	for _, rec := range out {
@@ -192,22 +195,101 @@ func TestNoteReactionRepository_ListByUserID(t *testing.T) {
 	}
 
 	// user1 視点で 1 件 (= note2 のみ)。
-	out, err = repo.ListByUserID(user1.ID, "", "", 10)
+	out, err = repo.ListByUserID(user1.ID, "", "", "", 10)
 	require.NoError(t, err)
 	require.Len(t, out, 1)
 	assert.Equal(t, "rx_u3", out[0].ID)
 
 	// untilID で絞り込み (rx_u2 より前 → rx_u1 の 1 件)。
-	out, err = repo.ListByUserID(user2.ID, "rx_u2", "", 10)
+	out, err = repo.ListByUserID(user2.ID, "", "rx_u2", "", 10)
 	require.NoError(t, err)
 	require.Len(t, out, 1)
 	assert.Equal(t, "rx_u1", out[0].ID)
 
 	// sinceID で絞り込み (rx_u1 より後 → rx_u2 の 1 件)。
-	out, err = repo.ListByUserID(user2.ID, "", "rx_u1", 10)
+	out, err = repo.ListByUserID(user2.ID, "", "", "rx_u1", 10)
 	require.NoError(t, err)
 	require.Len(t, out, 1)
 	assert.Equal(t, "rx_u2", out[0].ID)
+}
+
+// TestNoteReactionRepository_ListByUserID_VisibilityPushDown は
+// generateVisibilityQuery 相当の SQL push down を検証する。reactor が
+// public / followers-only / specified の 3 note に reaction し、viewer ごとに
+// 見える reaction が変わることを確認する (LIMIT 前に SQL で絞られるため
+// ページネーションが途切れない)。
+func TestNoteReactionRepository_ListByUserID_VisibilityPushDown(t *testing.T) {
+	repo := NewNoteReactionRepository(testDB)
+	followingRepo := NewFollowingRepository(testDB)
+	noteRepo := NewNoteRepository(testDB)
+
+	reactor := insertTestUser(t, "u_nrv_r", "nrvreact")
+	author := insertTestUser(t, "u_nrv_a", "nrvauthor")
+	follower := insertTestUser(t, "u_nrv_f", "nrvfollower")
+	allowed := insertTestUser(t, "u_nrv_al", "nrvallowed")
+	stranger := insertTestUser(t, "u_nrv_s", "nrvstranger")
+	for _, id := range []string{reactor.ID, author.ID, follower.ID, allowed.ID, stranger.ID} {
+		defer cleanupUser(t, id)
+	}
+
+	notes := []*model.Note{
+		{ID: "n_nrv_pub", UserID: author.ID, Visibility: model.NoteVisibilityPublic, Reactions: datatypes.JSON([]byte("{}"))},
+		{ID: "n_nrv_fol", UserID: author.ID, Visibility: model.NoteVisibilityFollowers, Reactions: datatypes.JSON([]byte("{}"))},
+		{ID: "n_nrv_spec", UserID: author.ID, Visibility: model.NoteVisibilitySpecified, VisibleUserIDs: pq.StringArray{allowed.ID}, Reactions: datatypes.JSON([]byte("{}"))},
+	}
+	for _, n := range notes {
+		require.NoError(t, noteRepo.Create(n))
+		defer cleanupNote(t, n.ID)
+	}
+
+	for _, r := range []struct{ id, nid, rx string }{
+		{"rxv_pub", "n_nrv_pub", "👍"},
+		{"rxv_fol", "n_nrv_fol", "❤"},
+		{"rxv_spec", "n_nrv_spec", "👀"},
+	} {
+		rec := &model.NoteReaction{ID: r.id, UserID: reactor.ID, NoteID: r.nid, Reaction: r.rx}
+		require.NoError(t, repo.Create(rec))
+		defer cleanupReaction(t, rec.ID)
+	}
+
+	// follower が author を follow している。
+	f := &model.Following{ID: "fl_nrv_1", FollowerID: follower.ID, FolloweeID: author.ID}
+	require.NoError(t, followingRepo.Create(f))
+	defer testDB.Exec(`DELETE FROM "following" WHERE id = ?`, f.ID)
+
+	idsOf := func(rows []*model.NoteReaction) []string {
+		out := make([]string, 0, len(rows))
+		for _, r := range rows {
+			out = append(out, r.ID)
+		}
+		sort.Strings(out)
+		return out
+	}
+
+	// 匿名 viewer は public のみ。
+	out, err := repo.ListByUserID(reactor.ID, "", "", "", 50)
+	require.NoError(t, err)
+	assert.Equal(t, []string{"rxv_pub"}, idsOf(out))
+
+	// stranger (follow なし / specified 対象外) も public のみ。
+	out, err = repo.ListByUserID(reactor.ID, stranger.ID, "", "", 50)
+	require.NoError(t, err)
+	assert.Equal(t, []string{"rxv_pub"}, idsOf(out))
+
+	// follower は public + followers。
+	out, err = repo.ListByUserID(reactor.ID, follower.ID, "", "", 50)
+	require.NoError(t, err)
+	assert.Equal(t, []string{"rxv_fol", "rxv_pub"}, idsOf(out))
+
+	// specified の visibleUserIds に含まれる viewer は public + specified。
+	out, err = repo.ListByUserID(reactor.ID, allowed.ID, "", "", 50)
+	require.NoError(t, err)
+	assert.Equal(t, []string{"rxv_pub", "rxv_spec"}, idsOf(out))
+
+	// author 本人は自分の followers / specified note を全て見られる。
+	out, err = repo.ListByUserID(reactor.ID, author.ID, "", "", 50)
+	require.NoError(t, err)
+	assert.Equal(t, []string{"rxv_fol", "rxv_pub", "rxv_spec"}, idsOf(out))
 }
 
 func TestNoteReactionRepository_QueryErrors(t *testing.T) {

--- a/internal/testutil/mock_repository.go
+++ b/internal/testutil/mock_repository.go
@@ -1406,14 +1406,14 @@ func (m *MockNoteReactionRepository) ListByUserID(userID, viewerID, untilID, sin
 }
 
 // canViewerSeeNote replicates the real repo's visibility EXISTS subquery
-// inline. 条件は core/note.CanSeeNote と一致させる (public/home は全員、followers
-// は author 本人または follow 済み、specified は author 本人または visibleUserIds
-// に含まれる)。n == nil は mock が visibility を評価できないため visible 扱いに
-// する (= 最小構成の reaction を使う既存 handler test 互換。実 repo は FK +
-// Preload で note が必ず存在するためこの分岐は production では起きない)。
+// inline. 条件は core/note.CanSeeNote / real repo の SQL と一致させる
+// (public/home は全員、followers は author 本人または follow 済み、specified は
+// author 本人または visibleUserIds に含まれる)。n == nil は real repo の EXISTS
+// が note 行を要求して false になるのと揃えて除外する (production は FK + Preload
+// で note が必ず存在するためこの分岐は起きない。test は note を必ず seed する)。
 func (m *MockNoteReactionRepository) canViewerSeeNote(viewerID string, n *model.Note) bool {
 	if n == nil {
-		return true
+		return false
 	}
 	switch n.Visibility {
 	case model.NoteVisibilityPublic, model.NoteVisibilityHome:

--- a/internal/testutil/mock_repository.go
+++ b/internal/testutil/mock_repository.go
@@ -1268,6 +1268,12 @@ func (m *MockNoteFavoriteRepository) ListByUser(userID, untilID, sinceID string,
 type MockNoteReactionRepository struct {
 	Reactions map[string]*model.NoteReaction // keyed by id
 	CreateErr error                          // optional error to return on Create
+	// Following は ListByUserID の visibility filter (followers note の follow
+	// 判定) に使う followerID -> followeeIDs map。未設定なら follow なし扱い
+	// (= 非 follower viewer)。testutil は repository を import すると repository
+	// 内部テストとの循環になるため、core/note.CanSeeNote は使わず inline で
+	// 可視性を再現する (条件は CanSeeNote と一致させる)。
+	Following map[string][]string
 }
 
 func NewMockNoteReactionRepository() *MockNoteReactionRepository {
@@ -1360,10 +1366,15 @@ func (m *MockNoteReactionRepository) ListByNoteID(noteID, untilID, sinceID strin
 
 // ListByUserID returns reactions made by a user. paginationOrder と同じく
 // sinceID 単独指定時のみ ASC、それ以外 DESC (ListByNoteID と同 logic)。
-func (m *MockNoteReactionRepository) ListByUserID(userID, untilID, sinceID string, limit int) ([]*model.NoteReaction, error) {
+func (m *MockNoteReactionRepository) ListByUserID(userID, viewerID, untilID, sinceID string, limit int) ([]*model.NoteReaction, error) {
 	var rows []*model.NoteReaction
 	for _, r := range m.Reactions {
 		if r.UserID != userID {
+			continue
+		}
+		// real repo の EXISTS visibility subquery を inline 再現する (LIMIT 前に
+		// 絞ることで viewer が見られない note の reaction を除外)。
+		if !m.canViewerSeeNote(viewerID, r.Note) {
 			continue
 		}
 		if untilID != "" && r.ID >= untilID {
@@ -1392,6 +1403,46 @@ func (m *MockNoteReactionRepository) ListByUserID(userID, untilID, sinceID strin
 		rows = rows[:limit]
 	}
 	return rows, nil
+}
+
+// canViewerSeeNote replicates the real repo's visibility EXISTS subquery
+// inline. 条件は core/note.CanSeeNote と一致させる (public/home は全員、followers
+// は author 本人または follow 済み、specified は author 本人または visibleUserIds
+// に含まれる)。n == nil は mock が visibility を評価できないため visible 扱いに
+// する (= 最小構成の reaction を使う既存 handler test 互換。実 repo は FK +
+// Preload で note が必ず存在するためこの分岐は production では起きない)。
+func (m *MockNoteReactionRepository) canViewerSeeNote(viewerID string, n *model.Note) bool {
+	if n == nil {
+		return true
+	}
+	switch n.Visibility {
+	case model.NoteVisibilityPublic, model.NoteVisibilityHome:
+		return true
+	}
+	if viewerID == "" {
+		return false
+	}
+	// author 本人は followers/specified を問わず閲覧可。
+	if viewerID == n.UserID {
+		return true
+	}
+	switch n.Visibility {
+	case model.NoteVisibilityFollowers:
+		for _, followee := range m.Following[viewerID] {
+			if followee == n.UserID {
+				return true
+			}
+		}
+		return false
+	case model.NoteVisibilitySpecified:
+		for _, id := range n.VisibleUserIDs {
+			if id == viewerID {
+				return true
+			}
+		}
+		return false
+	}
+	return false
 }
 
 // MockEmojiRepository is a test double for repository.EmojiRepository.


### PR DESCRIPTION
## Summary

`users/reactions` で reactor が付けた reaction を返す際、viewer が閲覧できない note (followers-only / specified) の reaction が完全 shape で露出していた gap を、upstream の `generateVisibilityQuery(query, me)` 相当を **repo の SQL に push down** して塞ぐ。

既存 gap だが #1355 (moderator が任意ユーザーの reactions を閲覧可) で moderator 経由の露出が拡大していた。

## アプローチ: post-fetch ではなく SQL push down

当初 handler 側の post-fetch `CanSeeNote` filter で実装したが、fetch した `limit` 件から不可視分を除外するとページが `limit` 未満になり、最悪その `limit` 件が全て不可視だと空配列を返してページネーションが途切れる問題があった。upstream は `generateVisibilityQuery` を WHERE に入れて LIMIT 前に絞るため、mk-go も合わせて SQL に push down した。

## 主な変更点

- `internal/repository/note_reaction.go`: `ListByUserID` に `viewerID` を追加し、相関 EXISTS subquery で visibility を SQL 段階で絞る。条件は `core/note.CanSeeNote` と一致 (public/home は全員、followers は author 本人/follow 済み、specified は author 本人/visibleUserIds 含む)。匿名 (`viewerID=""`) は public/home のみ。moderator 含む全 viewer に適用。
- `internal/api/users/handler_extra.go`: handler の post-fetch filter を撤去し `viewerID` を渡すだけにする。
- `internal/testutil/mock_repository.go`: `MockNoteReactionRepository` に `Following` map と `canViewerSeeNote` を追加し同じ可視性を inline 再現 (testutil は repository を import すると repository 内部テストと循環するため `core/note` は使わず inline)。
- テスト:
  - repository 統合テスト `TestNoteReactionRepository_ListByUserID_VisibilityPushDown`: 匿名 / stranger / follower / specified allowed / author の各 viewer で見える reaction が変わることを実 DB で検証。
  - handler test: follower が followers-only を見られるケース、specified の可視/不可視ケース、moderator でも不可視 note は除外されるケースを追加。

## テスト

- `make fmt && make lint && make test` green。
- `go test ./internal/api/users/... -cover` → 92.6%、`./internal/repository/... -cover` → 90.1% (いずれも閾値90%超)。
- entitycompat drift gate green (endpoint shape / permission 変更なし)。

## Closes

Closes #1356

## その他

- upstream `generateVisibilityQuery` は `note.mentions` / followers の `replyUserId = me` も見るが、mk-go の `CanSeeNote` (timeline 共通の可視性定義) に無いため本 PR でも含めない (含めるなら CanSeeNote 側で project-wide に対応すべき別件)。
- block/mute/suspended-user filter (upstream の `generateBlockedHostQueryForNote` 等) は既存 handler でも未対応の別 gap で本 PR の scope 外。

🤖 Generated with [Claude Code](https://claude.com/claude-code)