### PR TITLE
feat(api): hashtags/users を query 実装 (stub 解消, Part 1)

### DIFF
--- a/internal/api/hashtags/handler.go
+++ b/internal/api/hashtags/handler.go
@@ -9,7 +9,9 @@ import (
 	"github.com/lib/pq"
 	"github.com/shiroha-a/mk/internal/api/apierr"
 	"github.com/shiroha-a/mk/internal/api/pagination"
+	"github.com/shiroha-a/mk/internal/entity"
 	"github.com/shiroha-a/mk/internal/misc/id"
+	"github.com/shiroha-a/mk/internal/misc/searchnorm"
 	"github.com/shiroha-a/mk/internal/model"
 	"gorm.io/gorm"
 )
@@ -263,12 +265,28 @@ var validUsersSorts = map[string]struct{}{
 	"+updatedAt": {}, "-updatedAt": {},
 }
 
+// validUsersStates / validUsersOrigins は upstream hashtags/users paramDef の
+// state / origin enum と一致。default は upstream に合わせ state=all / origin=local。
+var validUsersStates = map[string]struct{}{"all": {}, "alive": {}}
+var validUsersOrigins = map[string]struct{}{"combined": {}, "local": {}, "remote": {}}
+
+// usersAliveWindow は state=alive の "生存" 判定窓 (upstream の now-5日)。
+const usersAliveWindow = 5 * 24 * time.Hour
+
 // Users handles POST /api/hashtags/users.
+//
+// 指定 hashtag を user.tags に持つユーザーを UserDetailed[] で返す
+// (upstream hashtags/users)。tag は searchnorm.Normalize (NFKC + lowercase) で
+// 正規化して array containment (`tags @> {normTag}`) する。user.tags 側も同じ
+// 正規化で populate される前提 (Part 2)。
 func (h *Handler) Users(c echo.Context) error {
 	var req struct {
-		Tag   string `json:"tag"`
-		Sort  string `json:"sort"`
-		Limit int    `json:"limit"`
+		Tag    string `json:"tag"`
+		Sort   string `json:"sort"`
+		State  string `json:"state"`
+		Origin string `json:"origin"`
+		Limit  int    `json:"limit"`
+		Offset int    `json:"offset"`
 	}
 	if err := c.Bind(&req); err != nil || req.Tag == "" || req.Sort == "" {
 		// upstream Misskey TS は paramDef で tag + sort を required にしている (#925)。
@@ -277,8 +295,84 @@ func (h *Handler) Users(c echo.Context) error {
 	if _, ok := validUsersSorts[req.Sort]; !ok {
 		return c.JSON(http.StatusBadRequest, apierr.Error("INVALID_PARAM", "sort must be one of upstream-defined enum.", "3d81ceae-475f-4600-b2a8-2bc116157532"))
 	}
-	// ハッシュタグを使ったユーザー一覧 (簡易版: 空配列)
-	return c.JSON(http.StatusOK, []any{})
+	if req.State == "" {
+		req.State = "all"
+	}
+	if _, ok := validUsersStates[req.State]; !ok {
+		return c.JSON(http.StatusBadRequest, apierr.Error("INVALID_PARAM", "state must be one of upstream-defined enum.", "3d81ceae-475f-4600-b2a8-2bc116157532"))
+	}
+	if req.Origin == "" {
+		req.Origin = "local"
+	}
+	if _, ok := validUsersOrigins[req.Origin]; !ok {
+		return c.JSON(http.StatusBadRequest, apierr.Error("INVALID_PARAM", "origin must be one of upstream-defined enum.", "3d81ceae-475f-4600-b2a8-2bc116157532"))
+	}
+	req.Limit = pagination.ClampLimit(req.Limit, 10, 100)
+	if req.Offset < 0 {
+		req.Offset = 0
+	}
+
+	// containment query。upstream は `:tag <@ user.tags` (= tag 配列が user.tags の
+	// 部分集合)。単一要素なので `tags @> {normTag}` と等価。
+	normTag := searchnorm.Normalize(req.Tag)
+	q := h.db.Model(&model.User{}).
+		Where("tags @> ?", pq.StringArray{normTag}).
+		Where("\"isSuspended\" = FALSE")
+	if req.State == "alive" {
+		q = q.Where("\"updatedAt\" > ?", time.Now().Add(-usersAliveWindow))
+	}
+	switch req.Origin {
+	case "local":
+		q = q.Where("host IS NULL")
+	case "remote":
+		q = q.Where("host IS NOT NULL")
+	}
+	switch req.Sort {
+	case "+follower":
+		q = q.Order("\"followersCount\" DESC")
+	case "-follower":
+		q = q.Order("\"followersCount\" ASC")
+	case "+createdAt":
+		q = q.Order("id DESC")
+	case "-createdAt":
+		q = q.Order("id ASC")
+	case "+updatedAt":
+		q = q.Order("\"updatedAt\" DESC")
+	case "-updatedAt":
+		q = q.Order("\"updatedAt\" ASC")
+	}
+
+	var users []*model.User
+	if err := q.Limit(req.Limit).Offset(req.Offset).Find(&users).Error; err != nil {
+		return apierr.JSONInternalError(c)
+	}
+
+	// UserDetailed pack 用に profile を batch fetch (per-user N+1 回避)。
+	profByID := make(map[string]*model.UserProfile, len(users))
+	if len(users) > 0 {
+		ids := make([]string, len(users))
+		for i, u := range users {
+			ids[i] = u.ID
+		}
+		var profiles []*model.UserProfile
+		if err := h.db.Where("\"userId\" IN ?", ids).Find(&profiles).Error; err != nil {
+			return apierr.JSONInternalError(c)
+		}
+		for _, p := range profiles {
+			profByID[p.UserID] = p
+		}
+	}
+
+	// createdAt 抽出用の idGen は Trend と同じく aidx を使う。
+	gen, err := id.NewGenerator("aidx")
+	if err != nil {
+		return apierr.JSONInternalError(c)
+	}
+	out := make([]entity.UserDetailed, 0, len(users))
+	for _, u := range users {
+		out = append(out, entity.PackUserDetailed(u, profByID[u.ID], gen))
+	}
+	return c.JSON(http.StatusOK, out)
 }
 
 func packTag(t *model.Hashtag) map[string]any {

--- a/internal/api/hashtags/handler_test.go
+++ b/internal/api/hashtags/handler_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/shiroha-a/mk/internal/testutil"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"gorm.io/datatypes"
 	"gorm.io/gorm"
 )
 
@@ -268,8 +269,118 @@ func TestTrend_VisibilityFilterExcludesPrivate(t *testing.T) {
 
 // --- Users ---
 
-func TestUsers_Success(t *testing.T) {
-	assert.Equal(t, http.StatusOK, doPost(newHandler().Users, `{"tag":"test","sort":"+follower"}`).Code)
+// seedTagUser inserts a local/remote user with the given normalized tags for
+// the hashtags/users query tests. user.tags は正規化済み (lowercase) で渡す
+// 前提 (= Part 2 の populate と同じ。query 側もここで正規化一致を検証する)。
+func seedTagUser(t *testing.T, id, username string, tags []string, host *string, suspended bool, followers int, updatedAt time.Time) {
+	t.Helper()
+	u := &model.User{
+		ID:                id,
+		Username:          username,
+		UsernameLower:     strings.ToLower(username),
+		Tags:              pq.StringArray(tags),
+		Host:              host,
+		IsSuspended:       suspended,
+		FollowersCount:    followers,
+		UpdatedAt:         &updatedAt,
+		AvatarDecorations: datatypes.JSON([]byte("[]")),
+	}
+	require.NoError(t, testDB.Create(u).Error)
+	t.Cleanup(func() { testDB.Exec(`DELETE FROM "user" WHERE id = ?`, id) })
+}
+
+func decodeUserIDs(t *testing.T, rec *httptest.ResponseRecorder) []string {
+	t.Helper()
+	require.Equal(t, http.StatusOK, rec.Code)
+	var list []map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &list))
+	ids := make([]string, 0, len(list))
+	for _, u := range list {
+		id, _ := u["id"].(string)
+		ids = append(ids, id)
+	}
+	return ids
+}
+
+// tag containment は正規化一致で効く: "tokyo" を持つ user は "Tokyo" query で
+// ヒットし、別タグの user はヒットしない。あわせて UserDetailed shape も確認。
+func TestUsers_ContainmentAndShape(t *testing.T) {
+	now := time.Now()
+	seedTagUser(t, "u_htu_a", "htua", []string{"tokyo"}, nil, false, 1, now)
+	seedTagUser(t, "u_htu_b", "htub", []string{"osaka"}, nil, false, 1, now)
+
+	rec := doPost(newHandler().Users, `{"tag":"Tokyo","sort":"+follower"}`)
+	require.Equal(t, http.StatusOK, rec.Code)
+	var list []map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &list))
+	require.Len(t, list, 1)
+	assert.Equal(t, "u_htu_a", list[0]["id"])
+	// UserDetailed shape (UserLite + detailed fields) で返ること。
+	assert.Equal(t, "htua", list[0]["username"])
+	assert.Contains(t, list[0], "followersCount")
+	assert.Contains(t, list[0], "notesCount")
+}
+
+// suspended user は除外される (isSuspended = FALSE)。
+func TestUsers_SuspendedExcluded(t *testing.T) {
+	now := time.Now()
+	seedTagUser(t, "u_htu_sus", "htususp", []string{"golangx"}, nil, true, 1, now)
+	ids := decodeUserIDs(t, doPost(newHandler().Users, `{"tag":"golangx","sort":"+follower"}`))
+	assert.NotContains(t, ids, "u_htu_sus")
+}
+
+// +follower DESC / -follower ASC の sort 順を確認。
+func TestUsers_SortFollower(t *testing.T) {
+	now := time.Now()
+	seedTagUser(t, "u_htu_lo", "htulo", []string{"sortt"}, nil, false, 1, now)
+	seedTagUser(t, "u_htu_hi", "htuhi", []string{"sortt"}, nil, false, 100, now)
+
+	desc := decodeUserIDs(t, doPost(newHandler().Users, `{"tag":"sortt","sort":"+follower"}`))
+	require.Equal(t, []string{"u_htu_hi", "u_htu_lo"}, desc)
+	asc := decodeUserIDs(t, doPost(newHandler().Users, `{"tag":"sortt","sort":"-follower"}`))
+	require.Equal(t, []string{"u_htu_lo", "u_htu_hi"}, asc)
+}
+
+// state=alive は updatedAt が 5日以内の user のみ返す。
+func TestUsers_StateAlive(t *testing.T) {
+	now := time.Now()
+	old := now.Add(-10 * 24 * time.Hour)
+	seedTagUser(t, "u_htu_new", "htunew", []string{"alivet"}, nil, false, 1, now)
+	seedTagUser(t, "u_htu_old", "htuold", []string{"alivet"}, nil, false, 1, old)
+
+	all := decodeUserIDs(t, doPost(newHandler().Users, `{"tag":"alivet","sort":"+follower"}`))
+	assert.ElementsMatch(t, []string{"u_htu_new", "u_htu_old"}, all)
+	alive := decodeUserIDs(t, doPost(newHandler().Users, `{"tag":"alivet","sort":"+follower","state":"alive"}`))
+	assert.Equal(t, []string{"u_htu_new"}, alive)
+}
+
+// origin=local は host IS NULL のみ、remote は host IS NOT NULL のみ、
+// combined は両方返す。
+func TestUsers_Origin(t *testing.T) {
+	now := time.Now()
+	host := "remote.example"
+	seedTagUser(t, "u_htu_loc", "htuloc", []string{"origint"}, nil, false, 1, now)
+	seedTagUser(t, "u_htu_rem", "hturem", []string{"origint"}, &host, false, 1, now)
+
+	local := decodeUserIDs(t, doPost(newHandler().Users, `{"tag":"origint","sort":"+follower","origin":"local"}`))
+	assert.Equal(t, []string{"u_htu_loc"}, local)
+	remote := decodeUserIDs(t, doPost(newHandler().Users, `{"tag":"origint","sort":"+follower","origin":"remote"}`))
+	assert.Equal(t, []string{"u_htu_rem"}, remote)
+	combined := decodeUserIDs(t, doPost(newHandler().Users, `{"tag":"origint","sort":"+follower","origin":"combined"}`))
+	assert.ElementsMatch(t, []string{"u_htu_loc", "u_htu_rem"}, combined)
+}
+
+// limit + offset が効く (offset で 2 ページ目を取得)。
+func TestUsers_LimitOffset(t *testing.T) {
+	now := time.Now()
+	seedTagUser(t, "u_htu_p1", "htup1", []string{"paget"}, nil, false, 3, now)
+	seedTagUser(t, "u_htu_p2", "htup2", []string{"paget"}, nil, false, 2, now)
+	seedTagUser(t, "u_htu_p3", "htup3", []string{"paget"}, nil, false, 1, now)
+
+	page1 := decodeUserIDs(t, doPost(newHandler().Users, `{"tag":"paget","sort":"+follower","limit":2}`))
+	require.Equal(t, []string{"u_htu_p1", "u_htu_p2"}, page1)
+	page2 := decodeUserIDs(t, doPost(newHandler().Users, `{"tag":"paget","sort":"+follower","limit":2,"offset":2}`))
+	require.Equal(t, []string{"u_htu_p3"}, page2)
 }
 
 func TestUsers_InvalidParam(t *testing.T) {
@@ -286,4 +397,15 @@ func TestUsers_SortRequired(t *testing.T) {
 // 未定義 sort で 400 を返すこと (#925 review nit)。
 func TestUsers_SortEnum(t *testing.T) {
 	assert.Equal(t, http.StatusBadRequest, doPost(newHandler().Users, `{"tag":"test","sort":"bogus"}`).Code)
+}
+
+// state / origin も upstream paramDef enum 限定。未定義値で 400。
+func TestUsers_StateEnum(t *testing.T) {
+	assert.Equal(t, http.StatusBadRequest, doPost(newHandler().Users, `{"tag":"test","sort":"+follower","state":"bogus"}`).Code)
+}
+func TestUsers_OriginEnum(t *testing.T) {
+	assert.Equal(t, http.StatusBadRequest, doPost(newHandler().Users, `{"tag":"test","sort":"+follower","origin":"bogus"}`).Code)
+}
+func TestUsers_DBError(t *testing.T) {
+	assert.Equal(t, http.StatusInternalServerError, doPost(brokenHandler().Users, `{"tag":"test","sort":"+follower"}`).Code)
 }

--- a/internal/misc/searchnorm/searchnorm.go
+++ b/internal/misc/searchnorm/searchnorm.go
@@ -1,0 +1,17 @@
+// Package searchnorm normalizes strings for case- and width-insensitive
+// search/index keys, mirroring Misskey's misc/normalize-for-search.ts
+// (`tag.normalize('NFKC').toLowerCase()`).
+package searchnorm
+
+import (
+	"strings"
+
+	"golang.org/x/text/unicode/norm"
+)
+
+// Normalize returns the NFKC-normalized, lower-cased form of s. Used to make
+// hashtag containment queries (user.tags `@>`) match regardless of case or
+// full-/half-width variants, consistently between store and query sides.
+func Normalize(s string) string {
+	return strings.ToLower(norm.NFKC.String(s))
+}

--- a/internal/misc/searchnorm/searchnorm_test.go
+++ b/internal/misc/searchnorm/searchnorm_test.go
@@ -1,0 +1,25 @@
+package searchnorm
+
+import "testing"
+
+func TestNormalize(t *testing.T) {
+	cases := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{name: "lowercases ASCII", in: "Tokyo", want: "tokyo"},
+		{name: "already normalized is unchanged", in: "golang", want: "golang"},
+		{name: "NFKC folds full-width to half-width", in: "ＡＢＣ", want: "abc"},
+		{name: "NFKC + lowercase combined", in: "Ｇｏ", want: "go"},
+		{name: "empty stays empty", in: "", want: ""},
+		{name: "non-latin is preserved", in: "東京", want: "東京"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := Normalize(tc.in); got != tc.want {
+				t.Fatalf("Normalize(%q) = %q, want %q", tc.in, got, tc.want)
+			}
+		})
+	}
+}

--- a/migration/000052_user_tags_gin_index.down.sql
+++ b/migration/000052_user_tags_gin_index.down.sql
@@ -1,0 +1,1 @@
+DROP INDEX IF EXISTS "IDX_user_tags";

--- a/migration/000052_user_tags_gin_index.up.sql
+++ b/migration/000052_user_tags_gin_index.up.sql
@@ -1,0 +1,6 @@
+-- hashtags/users は user.tags 配列の containment (tags @> ARRAY[...]) で
+-- 指定 hashtag を持つユーザーを引く。GIN インデックスで containment を
+-- 高速化する (note.tags の IDX_note_tags と同方針, #655)。
+-- upstream User entity の user.tags index は btree (配列 containment には
+-- 効かない) なので、mk-go は GIN を採用して query を実効化する。
+CREATE INDEX IF NOT EXISTS "IDX_user_tags" ON "user" USING gin ("tags");


### PR DESCRIPTION
## Summary

`POST /api/hashtags/users` は param 検証のみで `[]any{}` 固定の stub だった (親トラッカー #1217)。upstream `hashtags/users` 互換で `user.tags` の array containment query を実装する。

これは 2-part の **Part 1 (query)**。`user.tags` を持つ user に対しては正しく動作する。populate 配線 (local i/update + remote AP person) は Part 2 (別 issue) で対応。

## 主な変更点

- **`internal/misc/searchnorm`** (新規): `normalizeForSearch` 相当 (`NFKC + lowercase`)。`@>`/`<@` containment は store/query 双方の正規化一致が前提なので共有 util 化。
- **`hashtags/users` `Users()`**:
  - `tag` を `searchnorm.Normalize` して `tags @> {normTag}` containment + `isSuspended = FALSE`
  - `state=alive` → `updatedAt > now-5日`、`origin` = `local`(host IS NULL) / `remote`(host IS NOT NULL) / `combined` (default `local`)
  - `sort` 6 種、`limit` (1-100, default 10) + `offset`
  - 結果 user の profile を batch fetch (N+1 回避) して `UserDetailed[]` で packMany
  - `state` / `origin` も upstream paramDef enum 限定で未定義値は 400
  - handler は既存同様 `h.db` 直叩き + idGen ローカル生成 (router 配線変更なし)
- **migration 000052**: `user.tags` に GIN インデックス (`IDX_user_tags`) を追加。containment query が seq scan に落ちないようにする (`note.tags` の `IDX_note_tags` と同方針)。upstream の user.tags index は btree で配列 containment に効かないため GIN を採用 (drop-in DB には追加のみで無害)。EXPLAIN で `Bitmap Index Scan on IDX_user_tags` を確認済み。

## テスト

- `internal/misc/searchnorm`: NFKC/lowercase 単体 (100%)。
- `hashtags/users` (実 DB): containment+正規化一致 / UserDetailed shape / suspended 除外 / sort (DESC/ASC) / state=alive / origin (local/remote/combined) / limit+offset / state・origin enum 400 / DBError 500。
- migration 000052: up/down + EXPLAIN を実 DB で検証。
- `make fmt && make lint && make test` green。hashtags 90.1% / searchnorm 100%、drift gate green。

## Closes

Closes #1358

## その他

- mk-go の note.tags / hashtag.name は元の大小文字で格納 (upstream の lowercase とは既存 divergence) だが、本 PR の user.tags は upstream 同様 normalize する (case/全角半角非依存検索が機能)。
- Part 2 (user.tags populate) マージまで、本 endpoint は tag 未 populate のため実ユーザーには空を返す (query 自体は正しく動作)。

🤖 Generated with [Claude Code](https://claude.com/claude-code)