### PR TITLE
feat(api): user.tags を populate (hashtags/users Part 2)

### DIFF
--- a/internal/core/federation/resolver.go
+++ b/internal/core/federation/resolver.go
@@ -406,6 +406,9 @@ func (r *Resolver) resolveActorOnce(uri string) (*model.User, error) {
 	}
 	// AP Person Tag配列からカスタム絵文字を抽出してDBにupsert
 	user.Emojis = r.upsertEmojis(extractEmojiTags(actor.Tag), host)
+	// upstream ApPersonService と同じく person.tag の Hashtag entry を user.tags に
+	// 取り込む (hashtags/users の containment query 用)。summary text からは抽出しない。
+	user.Tags = pq.StringArray(hashtag.ExtractUserTags(extractHashtagTagNames(actor.Tag)...))
 	if err := r.userRepo.Create(user); err != nil {
 		return nil, err
 	}
@@ -576,6 +579,11 @@ func (r *Resolver) refreshActor(existing *model.User, uri string) {
 		fields["emojis"] = emojis
 		existing.Emojis = emojis
 	}
+	// person.tag の Hashtag entry を user.tags に追従させる (actor 更新時に
+	// 自己紹介の hashtag が変わったら反映する。新規取り込みと同じ正規化)。
+	tags := pq.StringArray(hashtag.ExtractUserTags(extractHashtagTagNames(actor.Tag)...))
+	fields["tags"] = tags
+	existing.Tags = tags
 	existing.LastFetchedAt = &now
 	// UpdateUserエラーはベストエフォートで無視 (次回再試行される)
 	_ = r.userRepo.UpdateUser(existing.ID, fields)

--- a/internal/core/federation/resolver_test.go
+++ b/internal/core/federation/resolver_test.go
@@ -4177,6 +4177,34 @@ func TestIngestNote_MentionLimitBoundaryAccepted(t *testing.T) {
 	assert.Len(t, note.Mentions, corenote.DefaultMentionLimit)
 }
 
+// TestResolveActor_ExistingUserRefreshesHashtags は actor 再取得 (refreshActor)
+// で person.tag の変化が user.tags に追従することを確認する (#1360, Part 2)。
+// 自己紹介の hashtag を編集した remote user が hashtags/users に反映されるための前提。
+func TestResolveActor_ExistingUserRefreshesHashtags(t *testing.T) {
+	body := `{
+		"id": "https://remote.example/users/alice",
+		"type": "Person",
+		"preferredUsername": "alice",
+		"inbox": "https://remote.example/users/alice/inbox",
+		"tag": [{"type": "Hashtag", "name": "#Refreshed"}],
+		"publicKey": {"publicKeyPem": "FAKE"}
+	}`
+	r, repo := newResolver(t, body, nil)
+	uri := "https://remote.example/users/alice"
+	host := "remote.example"
+	repo.Users["existing"] = &model.User{
+		ID:       "existing",
+		Username: "alice",
+		URI:      &uri,
+		Host:     &host,
+		Tags:     []string{"stale"},
+	}
+	_, err := r.ResolveActor(uri)
+	require.NoError(t, err)
+	// refresh で旧 tags ("stale") が person.tag 由来の正規化済み tag に置き換わる。
+	assert.Equal(t, []string{"refreshed"}, []string(repo.Users["existing"].Tags))
+}
+
 // TestResolveActor_NewUserIngestsHashtags は remote actor の person.tag の
 // Hashtag entry が正規化されて user.tags に取り込まれることを確認する
 // (#1360, Part 2)。hashtags/users が remote user を引けるための前提。

--- a/internal/core/federation/resolver_test.go
+++ b/internal/core/federation/resolver_test.go
@@ -4176,3 +4176,27 @@ func TestIngestNote_MentionLimitBoundaryAccepted(t *testing.T) {
 	require.NotNil(t, note)
 	assert.Len(t, note.Mentions, corenote.DefaultMentionLimit)
 }
+
+// TestResolveActor_NewUserIngestsHashtags は remote actor の person.tag の
+// Hashtag entry が正規化されて user.tags に取り込まれることを確認する
+// (#1360, Part 2)。hashtags/users が remote user を引けるための前提。
+func TestResolveActor_NewUserIngestsHashtags(t *testing.T) {
+	body := `{
+		"id": "https://remote.example/users/tagger",
+		"type": "Person",
+		"preferredUsername": "tagger",
+		"inbox": "https://remote.example/users/tagger/inbox",
+		"summary": "<p>bio</p>",
+		"tag": [
+			{"type": "Hashtag", "name": "#Golang", "href": "https://remote.example/tags/golang"},
+			{"type": "Hashtag", "name": "#ActivityPub"},
+			{"type": "Emoji", "name": ":party:"}
+		],
+		"publicKey": {"publicKeyPem": "FAKE"}
+	}`
+	r, _ := newResolver(t, body, nil)
+	user, err := r.ResolveActor("https://remote.example/users/tagger")
+	require.NoError(t, err)
+	// Hashtag のみ正規化して取り込む (Emoji は除外)。
+	assert.ElementsMatch(t, []string{"golang", "activitypub"}, []string(user.Tags))
+}

--- a/internal/core/user/user_service.go
+++ b/internal/core/user/user_service.go
@@ -8,7 +8,9 @@ import (
 	"strings"
 	"time"
 
+	"github.com/lib/pq"
 	"github.com/shiroha-a/mk/internal/entity"
+	"github.com/shiroha-a/mk/internal/misc/hashtag"
 	"github.com/shiroha-a/mk/internal/misc/id"
 	"github.com/shiroha-a/mk/internal/model"
 	"github.com/shiroha-a/mk/internal/repository"
@@ -451,6 +453,15 @@ func (s *Service) UpdateProfile(userID string, in UpdateInput) (*UserWithProfile
 	}
 	if in.Description != nil {
 		profileFields["description"] = *in.Description
+		// upstream i/update と同じく description から hashtag を抽出し、正規化して
+		// user.tags に格納する (hashtags/users の containment query 用)。description が
+		// null/空なら空配列になり tags がクリアされる (upstream の `updates.tags = tags`
+		// と同挙動)。Description は **string なので inner nil (= 明示的 null) もケアする。
+		desc := ""
+		if *in.Description != nil {
+			desc = **in.Description
+		}
+		userFields["tags"] = pq.StringArray(hashtag.ExtractUserTags(desc))
 	}
 	if in.Location != nil {
 		profileFields["location"] = *in.Location

--- a/internal/core/user/user_service_test.go
+++ b/internal/core/user/user_service_test.go
@@ -1064,3 +1064,41 @@ func TestService_SearchByUsernameAndHost(t *testing.T) {
 		assert.Len(t, out, 10)
 	})
 }
+
+// UpdateProfile で description 内の #tag が正規化 (lowercase) されて user.tags に
+// 入る。hashtags/users の containment query 用 (#1360, Part 2)。
+func TestService_UpdateProfile_PopulatesTags(t *testing.T) {
+	svc, repo, _, _ := newFullSvc(t)
+	repo.Users["u1"] = &model.User{ID: "u1", Username: "alice"}
+
+	bundle, err := svc.UpdateProfile("u1", user.UpdateInput{
+		Description: ptr(ptr("I love #Golang and #ActivityPub")),
+	})
+	require.NoError(t, err)
+	require.NotNil(t, bundle)
+	assert.ElementsMatch(t, []string{"golang", "activitypub"}, []string(repo.Users["u1"].Tags))
+}
+
+// description をクリア (空文字) すると user.tags も空になる。
+func TestService_UpdateProfile_ClearsTagsOnEmptyDescription(t *testing.T) {
+	svc, repo, _, _ := newFullSvc(t)
+	repo.Users["u1"] = &model.User{ID: "u1", Username: "alice", Tags: []string{"golang"}}
+
+	_, err := svc.UpdateProfile("u1", user.UpdateInput{
+		Description: ptr(ptr("")),
+	})
+	require.NoError(t, err)
+	assert.Empty(t, []string(repo.Users["u1"].Tags))
+}
+
+// description を更新しない場合は user.tags を触らない。
+func TestService_UpdateProfile_LeavesTagsWhenDescriptionOmitted(t *testing.T) {
+	svc, repo, _, _ := newFullSvc(t)
+	repo.Users["u1"] = &model.User{ID: "u1", Username: "alice", Tags: []string{"golang"}}
+
+	_, err := svc.UpdateProfile("u1", user.UpdateInput{
+		Name: ptr(ptr("Alice")),
+	})
+	require.NoError(t, err)
+	assert.Equal(t, []string{"golang"}, []string(repo.Users["u1"].Tags))
+}

--- a/internal/misc/hashtag/extract.go
+++ b/internal/misc/hashtag/extract.go
@@ -12,7 +12,12 @@ import (
 	"strings"
 
 	"github.com/shiroha-a/mk/internal/activitypub/mfm"
+	"github.com/shiroha-a/mk/internal/misc/searchnorm"
 )
+
+// MaxUserTags は user.tags に格納する hashtag の最大件数。upstream
+// (i/update / ApPersonService) の `.splice(0, 32)` と一致させる。
+const MaxUserTags = 32
 
 // MaxTagLength は note.tags 列の varchar(128) 制約に合わせた tag 長
 // 上限。これを超える tag は truncate される (drop ではなく trim にする
@@ -48,6 +53,39 @@ func Extract(parts ...string) []string {
 	}
 	if len(out) == 0 {
 		return nil
+	}
+	return out
+}
+
+// ExtractUserTags extracts hashtags from the given text fragments and returns
+// them in the form stored in user.tags: normalized via searchnorm.Normalize
+// (NFKC + lowercase), de-duplicated, and capped at MaxUserTags. This mirrors
+// Misskey's i/update / ApPersonService
+// (`extractHashtags(...).map(normalizeForSearch).splice(0, 32)`), so the stored
+// values match the normalized tag used by the hashtags/users containment query.
+//
+// local の profile description / remote の AP person.tag (Hashtag entry を
+// "#tag" 文字列化したもの) のどちらを渡しても同じ正規化結果になる。
+func ExtractUserTags(parts ...string) []string {
+	raw := Extract(parts...)
+	if len(raw) == 0 {
+		return nil
+	}
+	seen := make(map[string]struct{}, len(raw))
+	out := make([]string, 0, len(raw))
+	for _, tag := range raw {
+		n := searchnorm.Normalize(tag)
+		if n == "" {
+			continue
+		}
+		if _, ok := seen[n]; ok {
+			continue
+		}
+		seen[n] = struct{}{}
+		out = append(out, n)
+		if len(out) >= MaxUserTags {
+			break
+		}
 	}
 	return out
 }

--- a/internal/misc/hashtag/extract_test.go
+++ b/internal/misc/hashtag/extract_test.go
@@ -111,3 +111,52 @@ func TestExtract(t *testing.T) {
 		})
 	}
 }
+
+func TestExtractUserTags(t *testing.T) {
+	cases := []struct {
+		name string
+		in   []string
+		want []string
+	}{
+		{
+			name: "normalizes to lowercase",
+			in:   []string{"I love #Golang and #GoLang"},
+			want: []string{"golang"}, // case-insensitive dedup after normalize
+		},
+		{
+			name: "NFKC folds full-width",
+			in:   []string{"#Ｔｏｋｙｏ"},
+			want: []string{"tokyo"},
+		},
+		{
+			name: "AP person.tag style #-prefixed names",
+			in:   []string{"#art", "#Music"},
+			want: []string{"art", "music"},
+		},
+		{
+			name: "no hashtags returns nil",
+			in:   []string{"plain text without tags"},
+			want: nil,
+		},
+		{
+			name: "empty input returns nil",
+			in:   []string{""},
+			want: nil,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, ExtractUserTags(tc.in...))
+		})
+	}
+}
+
+// caps at MaxUserTags (32) entries.
+func TestExtractUserTags_Cap(t *testing.T) {
+	parts := make([]string, 0, 40)
+	for i := 0; i < 40; i++ {
+		parts = append(parts, "#tag"+string(rune('a'+i%26))+string(rune('0'+i/26)))
+	}
+	got := ExtractUserTags(strings.Join(parts, " "))
+	assert.Len(t, got, MaxUserTags)
+}

--- a/internal/testutil/mock_repository.go
+++ b/internal/testutil/mock_repository.go
@@ -556,6 +556,11 @@ func applyUserFields(u *model.User, fields map[string]any) {
 			case []byte:
 				u.AvatarDecorations = append([]byte(nil), s...)
 			}
+		case "tags":
+			// core/user.UpdateProfile / federation.resolver は pq.StringArray で渡す。
+			if a, ok := v.(pq.StringArray); ok {
+				u.Tags = a
+			}
 		}
 	}
 }


### PR DESCRIPTION
## Summary

Part 1 (#1358, merged) で `hashtags/users` の containment query を実装したが `user.tags` が空のままで実ユーザーには空を返していた。本 PR で local / remote 両経路の **populate** を実装し、feature を end-to-end で機能させる。

## 主な変更点

- **`misc/hashtag.ExtractUserTags(parts ...string) []string`** (新規): `Extract` (MFM hashtag 抽出) → `searchnorm.Normalize` (NFKC+lowercase) → dedup → 32 cap。local/remote で同じ正規化を保証し Part 1 の query 正規化と一致させる (upstream `extractHashtags().map(normalizeForSearch).splice(0,32)` 相当)。
- **local** (`core/user.UpdateProfile`): description 変更時に `user.tags` を更新。空 description で tags クリア (upstream i/update の `updates.tags = tags` と同挙動)。`Description` は `**string` なので inner nil (明示的 null) もケア。
- **remote** (`core/federation/resolver` person create/update): `person.tag` の Hashtag entry を `user.tags` に取り込む (upstream ApPersonService 同様、summary text からは抽出しない)。
- **testutil**: `applyUserFields` に `"tags"` case を追加 (mock が pq.StringArray を反映)。

## テスト

- `misc/hashtag`: `ExtractUserTags` の正規化 / dedup / NFKC / 32cap / 空。
- `core/user`: description→tags populate / 空 description で clear / description 省略時は tags 不変。
- `core/federation`: remote person.tag の Hashtag が正規化されて user.tags に入る (Emoji は除外)。
- `make fmt && make lint && make test` green。hashtag 90.6% / user 91.0% / federation 90.0%。

## Closes

Closes #1360

## その他

- hashtag 集計 (`updateUsertags` = `attachedUsersCount` 更新) は hashtags/list の attachedUsers sort / trend 用で `RecordDetach` 新設が要るため **Part 3 (任意) に分離**。元々未配線 (RecordAttach 未使用) なので deferring は regression ではない。
- これで Part 1 の `hashtags/users` が local (profile に #tag を書いたユーザー) / remote (person.tag を持つ actor) の双方を引けるようになる。

🤖 Generated with [Claude Code](https://claude.com/claude-code)