### PR TITLE
fix(federation): group chat の leave を Remove activity で連合同期

### DIFF
--- a/internal/activitypub/renderer.go
+++ b/internal/activitypub/renderer.go
@@ -778,6 +778,27 @@ func (r *Renderer) RenderInvite(ownerID string, inner any, targetURI string) *In
 	return inv
 }
 
+// RenderChatRoomRemove builds a Remove activity announcing that the user at
+// leavingUserURI left the chat room at roomURI. Mirrors cherrypick
+// ChatService.leaveRoom's renderRemove: actor = object = the leaving user,
+// target = the room. id は addContext 互換で `{baseURL}/{UUID}` を必ず入れる
+// (id 無し activity は受信側 InboxProcessor で弾かれる)。
+func (r *Renderer) RenderChatRoomRemove(leavingUserURI, roomURI string) *Remove {
+	rm := &Remove{
+		Activity: Activity{
+			Object: Object{
+				ID:   r.urls.baseURL + "/" + uuid.NewString(),
+				Type: "Remove",
+			},
+			Actor: leavingUserURI,
+		},
+		Object: leavingUserURI,
+		Target: roomURI,
+	}
+	AddContext(rm)
+	return rm
+}
+
 // RenderChatRoomInviteRef reconstructs a room owner's original Invite as a
 // nested object, used as the `object` of an invitee's Accept / Reject when the
 // room (and its owner) are remote. All URIs are passed explicitly because they

--- a/internal/activitypub/renderer_test.go
+++ b/internal/activitypub/renderer_test.go
@@ -103,6 +103,22 @@ func TestRenderer_RenderChatRoomInviteRef(t *testing.T) {
 	assert.Equal(t, "https://remote.example/users/owner", g.AttributedTo)
 }
 
+func TestRenderer_RenderChatRoomRemove(t *testing.T) {
+	r := newRenderer()
+	rm := r.RenderChatRoomRemove(
+		"https://example.com/users/carol",
+		"https://example.com/chat/rooms/room1",
+	)
+	assert.Equal(t, "Remove", rm.Type)
+	// actor = object = 退室者、target = room。
+	assert.Equal(t, "https://example.com/users/carol", rm.Actor)
+	assert.Equal(t, "https://example.com/users/carol", rm.Object)
+	assert.Equal(t, "https://example.com/chat/rooms/room1", rm.Target)
+	// 受信側 InboxProcessor が弾かないよう id / @context を必ず入れる。
+	assert.NotEmpty(t, rm.ID)
+	assert.NotNil(t, rm.Context)
+}
+
 func TestRenderer_RenderChatRoomMessage(t *testing.T) {
 	r := newRenderer()
 	txt := "hello room"

--- a/internal/activitypub/types.go
+++ b/internal/activitypub/types.go
@@ -413,6 +413,16 @@ type Invite struct {
 	Target string `json:"target,omitempty"`
 }
 
+// Remove represents a Remove activity. CherryPick group chat federation uses
+// it to announce a member leaving a chat room: actor and object are the
+// leaving member's actor URI, target is the room URI. Mirrors
+// ApRendererService.renderRemove.
+type Remove struct {
+	Activity
+	Object any    `json:"object"`
+	Target string `json:"target,omitempty"`
+}
+
 // Undo represents an Undo activity.
 type Undo struct {
 	Activity
@@ -560,6 +570,8 @@ func AddContext(o any) {
 	case *Reject:
 		v.Context = ctx
 	case *Invite:
+		v.Context = ctx
+	case *Remove:
 		v.Context = ctx
 	case *Undo:
 		v.Context = ctx

--- a/internal/api/chat/handler.go
+++ b/internal/api/chat/handler.go
@@ -457,7 +457,14 @@ func (h *Handler) RoomsLeave(c echo.Context) error {
 	if err := c.Bind(&req); err != nil || req.RoomID == "" {
 		return c.JSON(http.StatusBadRequest, apierr.Error("INVALID_PARAM", "roomId is required.", "ed1d7571-a3ac-4370-899c-0dbe5e230cc8"))
 	}
-	_ = h.repo.DeleteMembership(user.ID, req.RoomID)
+	// service 経由で membership 削除 + remote member/owner への Remove 連合配信
+	// (#1364)。service 未配線時 (federation disabled の旧構成) は repo 直叩きで
+	// membership 削除のみ。
+	if h.svc != nil {
+		_ = h.svc.LeaveRoom(c.Request().Context(), user.ID, req.RoomID)
+	} else {
+		_ = h.repo.DeleteMembership(user.ID, req.RoomID)
+	}
 	return c.NoContent(http.StatusNoContent)
 }
 

--- a/internal/core/chat/room_federation_test.go
+++ b/internal/core/chat/room_federation_test.go
@@ -291,6 +291,135 @@ func TestCreateRoomMessageViaAP_NonMemberForbidden(t *testing.T) {
 	assert.ErrorIs(t, err, corechat.ErrForbidden)
 }
 
+func TestLeaveRoom_DeliversRemoveToRemoteMembers(t *testing.T) {
+	svc, chatRepo, userRepo, deliverer := newInvitationService(t)
+	remoteHost := "remote.example"
+	bobURI := "https://remote.example/users/bob"
+	userRepo.Users["alice"] = &model.User{ID: "alice", Username: "alice"} // local owner
+	userRepo.Users["bob"] = &model.User{ID: "bob", Username: "bob", Host: &remoteHost, URI: &bobURI}
+	userRepo.Users["carol"] = &model.User{ID: "carol", Username: "carol"} // local, leaving
+	require.NoError(t, chatRepo.CreateRoom(&model.ChatRoom{ID: "room1", Name: "G", OwnerID: "alice"}))
+	require.NoError(t, chatRepo.CreateMembership(&model.ChatRoomMembership{ID: "m1", UserID: "bob", RoomID: "room1"}))
+	require.NoError(t, chatRepo.CreateMembership(&model.ChatRoomMembership{ID: "m2", UserID: "carol", RoomID: "room1"}))
+
+	require.NoError(t, svc.LeaveRoom(context.Background(), "carol", "room1"))
+	// membership は削除される。
+	_, err := chatRepo.FindMembership("carol", "room1")
+	assert.Error(t, err)
+	// Remove が remote member bob へ配送される。
+	assert.Equal(t, 1, deliverer.called)
+	body := string(deliverer.lastBody)
+	assert.Contains(t, body, `"type":"Remove"`)
+	assert.Contains(t, body, "https://local.example/chat/rooms/room1")
+	assert.Contains(t, body, "https://local.example/users/carol")
+}
+
+func TestLeaveRoom_LocalOnlyNoFederation(t *testing.T) {
+	svc, chatRepo, userRepo, deliverer := newInvitationService(t)
+	userRepo.Users["alice"] = &model.User{ID: "alice", Username: "alice"}
+	userRepo.Users["carol"] = &model.User{ID: "carol", Username: "carol"}
+	require.NoError(t, chatRepo.CreateRoom(&model.ChatRoom{ID: "room1", Name: "G", OwnerID: "alice"}))
+	require.NoError(t, chatRepo.CreateMembership(&model.ChatRoomMembership{ID: "m1", UserID: "carol", RoomID: "room1"}))
+
+	require.NoError(t, svc.LeaveRoom(context.Background(), "carol", "room1"))
+	_, err := chatRepo.FindMembership("carol", "room1")
+	assert.Error(t, err)
+	// remote member が居ないので配送しない。
+	assert.Equal(t, 0, deliverer.called)
+}
+
+func TestLeaveRoom_RemoteLeaverDoesNotFederate(t *testing.T) {
+	svc, chatRepo, userRepo, deliverer := newInvitationService(t)
+	remoteHost := "remote.example"
+	rmtURI := "https://remote.example/users/rmt"
+	bobURI := "https://remote.example/users/bob"
+	userRepo.Users["alice"] = &model.User{ID: "alice", Username: "alice"}
+	userRepo.Users["rmt"] = &model.User{ID: "rmt", Username: "rmt", Host: &remoteHost, URI: &rmtURI}
+	userRepo.Users["bob"] = &model.User{ID: "bob", Username: "bob", Host: &remoteHost, URI: &bobURI}
+	require.NoError(t, chatRepo.CreateRoom(&model.ChatRoom{ID: "room1", Name: "G", OwnerID: "alice"}))
+	require.NoError(t, chatRepo.CreateMembership(&model.ChatRoomMembership{ID: "m1", UserID: "rmt", RoomID: "room1"}))
+	require.NoError(t, chatRepo.CreateMembership(&model.ChatRoomMembership{ID: "m2", UserID: "bob", RoomID: "room1"}))
+
+	// remote user の leave は当人の instance が配送する (我々は受信側)。membership
+	// は削除するが本インスタンスからは Remove を送らない。
+	require.NoError(t, svc.LeaveRoom(context.Background(), "rmt", "room1"))
+	assert.Equal(t, 0, deliverer.called)
+}
+
+func TestLeaveRoom_InvalidArgs(t *testing.T) {
+	svc, _ := newRoomFedService(t)
+	assert.ErrorIs(t, svc.LeaveRoom(context.Background(), "", "room1"), corechat.ErrInvalidTarget)
+	assert.ErrorIs(t, svc.LeaveRoom(context.Background(), "u1", ""), corechat.ErrInvalidTarget)
+}
+
+func TestLeaveRoom_RoomMissingStillDeletesMembership(t *testing.T) {
+	svc, chatRepo, userRepo, deliverer := newInvitationService(t)
+	userRepo.Users["carol"] = &model.User{ID: "carol", Username: "carol"}
+	// room を作らない (FindRoomByID 失敗) → membership 削除のみ、federation skip。
+	require.NoError(t, chatRepo.CreateMembership(&model.ChatRoomMembership{ID: "m1", UserID: "carol", RoomID: "ghost"}))
+	require.NoError(t, svc.LeaveRoom(context.Background(), "carol", "ghost"))
+	_, err := chatRepo.FindMembership("carol", "ghost")
+	assert.Error(t, err)
+	assert.Equal(t, 0, deliverer.called)
+}
+
+func TestLeaveRoom_RemoteOwnerRoomURIRestored(t *testing.T) {
+	svc, chatRepo, userRepo, deliverer := newInvitationService(t)
+	remoteHost := "remote.example"
+	ownerURI := "https://remote.example/users/owner"
+	userRepo.Users["owner"] = &model.User{ID: "owner", Username: "owner", Host: &remoteHost, URI: &ownerURI}
+	userRepo.Users["carol"] = &model.User{ID: "carol", Username: "carol"} // local, leaving
+	// remote owner の room copy。carol(local) が leave → remote owner へ Remove。
+	require.NoError(t, chatRepo.CreateRoom(&model.ChatRoom{ID: "room1", Name: "G", OwnerID: "owner"}))
+	require.NoError(t, chatRepo.CreateMembership(&model.ChatRoomMembership{ID: "m1", UserID: "carol", RoomID: "room1"}))
+
+	require.NoError(t, svc.LeaveRoom(context.Background(), "carol", "room1"))
+	assert.Equal(t, 1, deliverer.called)
+	// room URI は owner host から復元した remote URI。
+	assert.Contains(t, string(deliverer.lastBody), "https://remote.example/chat/rooms/room1")
+}
+
+func TestLeaveRoom_DeliveryFailureSwallowed(t *testing.T) {
+	svc, chatRepo, userRepo, deliverer := newInvitationService(t)
+	deliverer.returnErr = assert.AnError
+	remoteHost := "remote.example"
+	bobURI := "https://remote.example/users/bob"
+	userRepo.Users["alice"] = &model.User{ID: "alice", Username: "alice"}
+	userRepo.Users["bob"] = &model.User{ID: "bob", Username: "bob", Host: &remoteHost, URI: &bobURI}
+	userRepo.Users["carol"] = &model.User{ID: "carol", Username: "carol"}
+	require.NoError(t, chatRepo.CreateRoom(&model.ChatRoom{ID: "room1", Name: "G", OwnerID: "alice"}))
+	require.NoError(t, chatRepo.CreateMembership(&model.ChatRoomMembership{ID: "m1", UserID: "bob", RoomID: "room1"}))
+	require.NoError(t, chatRepo.CreateMembership(&model.ChatRoomMembership{ID: "m2", UserID: "carol", RoomID: "room1"}))
+
+	// 配送失敗しても LeaveRoom は成功し membership は削除される。
+	require.NoError(t, svc.LeaveRoom(context.Background(), "carol", "room1"))
+	assert.Equal(t, 1, deliverer.called)
+}
+
+func TestLeaveRoom_UnwiredNoFederation(t *testing.T) {
+	svc, repo := newRoomFedService(t)
+	require.NoError(t, repo.CreateRoom(&model.ChatRoom{ID: "room1", Name: "G", OwnerID: "alice"}))
+	require.NoError(t, repo.CreateMembership(&model.ChatRoomMembership{ID: "m1", UserID: "carol", RoomID: "room1"}))
+	// AP delivery 未配線でも panic せず membership 削除のみ。
+	require.NoError(t, svc.LeaveRoom(context.Background(), "carol", "room1"))
+	_, err := repo.FindMembership("carol", "room1")
+	assert.Error(t, err)
+}
+
+func TestRemoveMemberViaAP_DeletesMembershipIdempotent(t *testing.T) {
+	svc, repo := newRoomFedService(t)
+	require.NoError(t, repo.CreateRoom(&model.ChatRoom{ID: "room1", Name: "G", OwnerID: "localOwner"}))
+	require.NoError(t, repo.CreateMembership(&model.ChatRoomMembership{ID: "m1", UserID: "rmt", RoomID: "room1"}))
+
+	require.NoError(t, svc.RemoveMemberViaAP("room1", "rmt"))
+	_, err := repo.FindMembership("rmt", "room1")
+	assert.Error(t, err)
+	// 存在しない membership の削除は no-op。
+	require.NoError(t, svc.RemoveMemberViaAP("room1", "rmt"))
+	// 引数欠落は ErrInvalidTarget。
+	assert.ErrorIs(t, svc.RemoveMemberViaAP("", "rmt"), corechat.ErrInvalidTarget)
+}
+
 func TestCreateMessageToRoom_RemoteSenderDoesNotFederate(t *testing.T) {
 	svc, chatRepo, userRepo, deliverer := newInvitationService(t)
 	remoteHost := "remote.example"

--- a/internal/core/chat/service.go
+++ b/internal/core/chat/service.go
@@ -685,6 +685,95 @@ func (s *Service) tryDeliverRoomMessage(msg *model.ChatMessage, room *model.Chat
 	}
 }
 
+// LeaveRoom removes the user's membership and, when the leaving user is local,
+// federates a Remove activity to the room's remote members (and remote owner)
+// so their membership lists stay in sync. Mirrors cherrypick
+// ChatService.leaveRoom. Membership deletion is best-effort-independent of
+// federation: the row is always removed.
+func (s *Service) LeaveRoom(_ context.Context, userID, roomID string) error {
+	if userID == "" || roomID == "" {
+		return ErrInvalidTarget
+	}
+	// room を先に引いて federation の recipient/roomURI 構築に使う。room が無くても
+	// membership 削除は冪等に試みる (drift cleanup)。
+	room, _ := s.repo.FindRoomByID(roomID)
+	if err := s.repo.DeleteMembership(userID, roomID); err != nil {
+		return err
+	}
+	if room != nil {
+		s.tryDeliverRoomLeave(room, userID)
+	}
+	return nil
+}
+
+// tryDeliverRoomLeave federates a chat room leave as a Remove activity to the
+// room's remote members and remote owner. Best-effort: no-op when AP delivery
+// is unwired, the leaving user is remote, or there are no remote recipients.
+// Per-recipient failures are logged and swallowed.
+func (s *Service) tryDeliverRoomLeave(room *model.ChatRoom, leavingUserID string) {
+	if s.deliverer == nil || s.userRepo == nil || s.renderer == nil || s.urls == nil || room == nil {
+		return
+	}
+	leaver, err := s.userRepo.FindByID(leavingUserID)
+	if err != nil || leaver == nil || !leaver.IsLocal() {
+		// remote user の leave は当人の instance から配送される (我々は受信側)。
+		return
+	}
+	// recipient = owner + 残り membership のうち remote な者 (leaving user は除外)。
+	memberIDs := map[string]struct{}{room.OwnerID: {}}
+	if members, merr := s.repo.ListMembersByRoom(room.ID); merr == nil {
+		for _, m := range members {
+			memberIDs[m.UserID] = struct{}{}
+		}
+	}
+	delete(memberIDs, leavingUserID)
+	remoteRecipients := make([]*model.User, 0)
+	var owner *model.User
+	for uid := range memberIDs {
+		u, uerr := s.userRepo.FindByID(uid)
+		if uerr != nil || u == nil {
+			continue
+		}
+		if uid == room.OwnerID {
+			owner = u
+		}
+		if !u.IsLocal() && u.URI != nil && *u.URI != "" {
+			remoteRecipients = append(remoteRecipients, u)
+		}
+	}
+	if len(remoteRecipients) == 0 {
+		return
+	}
+	// room URI: local 所有なら local 正規 URI、remote 所有 copy なら owner host から復元。
+	roomURI := s.urls.ChatRoomURI(room.ID)
+	if owner != nil && !owner.IsLocal() && owner.URI != nil {
+		if ru := remoteChatRoomURI(*owner.URI, room.ID); ru != "" {
+			roomURI = ru
+		}
+	}
+	body, err := json.Marshal(s.renderer.RenderChatRoomRemove(s.urls.UserURI(leaver.ID), roomURI))
+	if err != nil {
+		slog.Warn("chat: room leave federation: marshal failed", "roomID", room.ID, "err", err)
+		return
+	}
+	for _, recipient := range remoteRecipients {
+		if derr := s.deliverer.DeliverToUser(leaver.ID, recipient, body); derr != nil {
+			slog.Warn("chat: room leave federation: deliver failed", "roomID", room.ID, "recipient", recipient.ID, "err", derr)
+		}
+	}
+}
+
+// RemoveMemberViaAP removes a (typically remote) user's membership in response
+// to an inbound Remove activity targeting the chat room. Idempotent: a no-op
+// when the membership does not exist. Mirrors cherrypick ApInboxService.remove
+// (deletes the membership of the activity actor).
+func (s *Service) RemoveMemberViaAP(roomID, userID string) error {
+	if roomID == "" || userID == "" {
+		return ErrInvalidTarget
+	}
+	return s.repo.DeleteMembership(userID, roomID)
+}
+
 // CreateRoomMessageViaAP persists a group chat (room) message received via
 // ActivityPub and streams it to local members. The sender must be a member of
 // the room (owner or membership) — this rejects messages injected by a remote

--- a/internal/core/federation/chat_room_inbox.go
+++ b/internal/core/federation/chat_room_inbox.go
@@ -20,6 +20,7 @@ type ChatRoomReceiver interface {
 	CreateInvitationViaAP(roomID, inviteeUserID string) error
 	AddMemberViaAP(roomID, userID string) error
 	RemoveInvitationViaAP(roomID, userID string) error
+	RemoveMemberViaAP(roomID, userID string) error
 	CreateRoomMessageViaAP(uri string, sender *model.User, roomID, text string) error
 }
 

--- a/internal/core/federation/chat_room_inbox_test.go
+++ b/internal/core/federation/chat_room_inbox_test.go
@@ -23,14 +23,16 @@ func (f *fakeChatMessageReceiver) CreateMessageViaAP(_ context.Context, _ string
 
 // fakeChatRoomReceiver records inbound chat room federation calls.
 type fakeChatRoomReceiver struct {
-	ensureCalls [][4]string // roomID, name, summary, ownerUserID
-	inviteCalls [][2]string // roomID, inviteeUserID
-	memberCalls [][2]string // roomID, userID
-	removeCalls [][2]string // roomID, userID
-	msgCalls    [][3]string // roomID, senderID, text
-	ensureErr   error
-	inviteErr   error
-	msgErr      error
+	ensureCalls   [][4]string // roomID, name, summary, ownerUserID
+	inviteCalls   [][2]string // roomID, inviteeUserID
+	memberCalls   [][2]string // roomID, userID
+	removeCalls   [][2]string // roomID, userID (RemoveInvitationViaAP)
+	rmMemberCalls [][2]string // roomID, userID (RemoveMemberViaAP)
+	msgCalls      [][3]string // roomID, senderID, text
+	ensureErr     error
+	inviteErr     error
+	msgErr        error
+	rmMemberErr   error
 }
 
 func (f *fakeChatRoomReceiver) CreateRoomMessageViaAP(uri string, sender *model.User, roomID, text string) error {
@@ -60,6 +62,11 @@ func (f *fakeChatRoomReceiver) AddMemberViaAP(roomID, userID string) error {
 func (f *fakeChatRoomReceiver) RemoveInvitationViaAP(roomID, userID string) error {
 	f.removeCalls = append(f.removeCalls, [2]string{roomID, userID})
 	return nil
+}
+
+func (f *fakeChatRoomReceiver) RemoveMemberViaAP(roomID, userID string) error {
+	f.rmMemberCalls = append(f.rmMemberCalls, [2]string{roomID, userID})
+	return f.rmMemberErr
 }
 
 func TestProcess_ChatRoomInvite_CreatesRoomCopyAndInvitation(t *testing.T) {
@@ -118,6 +125,56 @@ func TestProcess_ChatRoomAccept_AddsMembership(t *testing.T) {
 	require.Len(t, recv.memberCalls, 1)
 	assert.Equal(t, "room1", recv.memberCalls[0][0])
 	assert.NotEmpty(t, recv.memberCalls[0][1])
+}
+
+// remote member の leave を伝える Remove(target=chat room) で actor の
+// membership が削除される (#1364)。
+func TestProcess_ChatRoomRemove_DeletesMembership(t *testing.T) {
+	p, _, _, _ := newProcessor(t, aliceActor)
+	recv := &fakeChatRoomReceiver{}
+	p.SetChatRoomReceiver(recv)
+	body := []byte(`{
+		"type": "Remove",
+		"actor": "https://remote.example/users/alice",
+		"target": "https://example.com/chat/rooms/room1",
+		"object": "https://remote.example/users/alice"
+	}`)
+	require.NoError(t, p.Process(body))
+	require.Len(t, recv.rmMemberCalls, 1)
+	assert.Equal(t, "room1", recv.rmMemberCalls[0][0])
+	assert.NotEmpty(t, recv.rmMemberCalls[0][1], "actor (resolved remote user) membership is removed")
+}
+
+// RemoveMemberViaAP が ErrNotFound を返す (room/membership 不在) と恒久的失敗
+// として ErrUnsupportedActivity に畳む (retry させない)。
+func TestProcess_ChatRoomRemove_NotFoundIsPermanent(t *testing.T) {
+	p, _, _, _ := newProcessor(t, aliceActor)
+	recv := &fakeChatRoomReceiver{rmMemberErr: corechat.ErrNotFound}
+	p.SetChatRoomReceiver(recv)
+	body := []byte(`{
+		"type": "Remove",
+		"actor": "https://remote.example/users/alice",
+		"target": "https://example.com/chat/rooms/room1",
+		"object": "https://remote.example/users/alice"
+	}`)
+	assert.ErrorIs(t, p.Process(body), federation.ErrUnsupportedActivity)
+}
+
+// RemoveMemberViaAP の generic error (ErrNotFound/ErrInvalidTarget 以外) は
+// retryable として propagate される (ErrUnsupportedActivity に畳まない)。
+func TestProcess_ChatRoomRemove_GenericErrorPropagates(t *testing.T) {
+	p, _, _, _ := newProcessor(t, aliceActor)
+	recv := &fakeChatRoomReceiver{rmMemberErr: errors.New("db down")}
+	p.SetChatRoomReceiver(recv)
+	body := []byte(`{
+		"type": "Remove",
+		"actor": "https://remote.example/users/alice",
+		"target": "https://example.com/chat/rooms/room1",
+		"object": "https://remote.example/users/alice"
+	}`)
+	err := p.Process(body)
+	require.Error(t, err)
+	assert.NotErrorIs(t, err, federation.ErrUnsupportedActivity)
 }
 
 func TestProcess_ChatRoomReject_RemovesInvitation(t *testing.T) {

--- a/internal/core/federation/processor.go
+++ b/internal/core/federation/processor.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/shiroha-a/mk/internal/activitypub"
 	coreblocking "github.com/shiroha-a/mk/internal/core/blocking"
+	corechat "github.com/shiroha-a/mk/internal/core/chat"
 	corefollowing "github.com/shiroha-a/mk/internal/core/following"
 	corenote "github.com/shiroha-a/mk/internal/core/note"
 	corereaction "github.com/shiroha-a/mk/internal/core/reaction"
@@ -1537,6 +1538,26 @@ func (p *Processor) handleAdd(act genericActivity) error {
 // handleRemove processes an inbound Remove activity. actorのfeaturedコレクションから
 // ノートのピン留めを解除する。
 func (p *Processor) handleRemove(act genericActivity) error {
+	var target struct {
+		Target string `json:"target"`
+	}
+	_ = json.Unmarshal(act.raw, &target)
+	// chat room target の Remove は group chat の leave (#1364)。featured pin
+	// より先に判定する (pinningRepo 未配線でも chat leave は処理する)。actor の
+	// membership を削除する (cherrypick ApInboxService.remove と同じく actor 基準)。
+	if roomID := extractChatRoomID(target.Target); roomID != "" && p.chatRoomReceiver != nil {
+		actor, err := p.resolver.ResolveActor(act.Actor)
+		if err != nil {
+			return err
+		}
+		if err := p.chatRoomReceiver.RemoveMemberViaAP(roomID, actor.ID); err != nil {
+			if errors.Is(err, corechat.ErrNotFound) || errors.Is(err, corechat.ErrInvalidTarget) {
+				return ErrUnsupportedActivity
+			}
+			return err
+		}
+		return nil
+	}
 	if p.pinningRepo == nil {
 		return ErrUnsupportedActivity
 	}
@@ -1544,10 +1565,6 @@ func (p *Processor) handleRemove(act genericActivity) error {
 	if err != nil {
 		return err
 	}
-	var target struct {
-		Target string `json:"target"`
-	}
-	_ = json.Unmarshal(act.raw, &target)
 	if actor.Featured == nil || target.Target != *actor.Featured {
 		return nil
 	}


### PR DESCRIPTION
## Summary

group chat (yojo-art/cherrypick lineage) で member の leave が remote instance に伝わらず membership 行が drift していた。yojo-art/cherrypick を verify した結果を踏まえ、**機能している Remove (leave) の送受信のみ** を faithful に実装する。

### verify による scope 確定

cherrypick の membership sync は非対称:
- **Remove (leave)**: leaving user が送信 (`ChatService.leaveRoom` の `renderRemove`) → 受信側 `ApInboxService.remove` が `/chat/rooms/{id}` target を判定して **actor の membership を削除**。→ **機能している**。
- **Add (join)**: owner が送信するが受信側 `add()` は featured pin のみ処理し chat room target を無視 (inert)。→ 実装すると投機的 no-op になるため **scope 外**。

## 主な変更点

- **activitypub**: `Remove` activity 型 + `RenderChatRoomRemove(leavingUserURI, roomURI)` (actor=object=退室者, target=room)。`AddContext` に `*Remove` case を追加 (id/@context 付与、受信側 InboxProcessor が弾かないように)。
- **send** (`core/chat.Service.LeaveRoom`): membership 削除 + leaving user が local なら remote member + remote owner へ Remove を配信 (`tryDeliverRoomMessage` と同じ recipient / roomURI 構築)。`RoomsLeave` handler を repo 直叩きから service 経由に変更。
- **receive** (`handleRemove`): featured pin の前に `extractChatRoomID(target)` をチェックし、chat room なら `ChatRoomReceiver.RemoveMemberViaAP(roomID, actor.ID)` で actor の membership を削除 (cherrypick と同じく actor 基準)。pinningRepo 未配線でも chat leave は処理する。
- **scope 外**: Add (inert)、owner による MembersBan (cherrypick の leaveRoom 対象外)。

## テスト

- activitypub: `RenderChatRoomRemove` の shape (actor=object=退室者 / target=room / id+@context)。
- core/chat: `LeaveRoom` (remote member へ Remove 配信 / local-only no-op / remote-leaver 非配信 / remote-owner roomURI 復元 / 配送失敗 swallow / 未配線 / invalid args / room 不在でも membership 削除)、`RemoveMemberViaAP` (冪等 / invalid args)。
- core/federation: chat room Remove で membership 削除 / ErrNotFound は ErrUnsupportedActivity に畳む / generic error は retryable で propagate。featured pin の Remove regression は既存テストで維持。
- `make fmt && make lint && make test` green。core/chat 91.1% / federation 90.0% / activitypub 90.3% / api/chat 91.4%。

## Closes

Closes #1364 (#1217 連合 correctness の最後の open 項目)

## その他

- 参照: yojo-art/cherrypick `ChatService.leaveRoom` / `ApInboxService.remove`。
- これで #1217 (未実装/stub audit 親トラッカー) の全 sub-task が完結。

🤖 Generated with [Claude Code](https://claude.com/claude-code)