### PR TITLE
perf(test): timeline read ホットパスの計測ベンチを追加

### DIFF
--- a/internal/entity/note_bench_test.go
+++ b/internal/entity/note_bench_test.go
@@ -1,0 +1,49 @@
+package entity
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/lib/pq"
+	"github.com/shiroha-a/mk/internal/misc/id"
+	"github.com/shiroha-a/mk/internal/model"
+	"gorm.io/datatypes"
+)
+
+// BenchmarkPackNotes measures the pure CPU/alloc cost of packing a timeline
+// page of notes into the response shape (no DB). Lookups are nil (local notes,
+// no remote instance/emoji resolution) so this isolates the per-note struct
+// building / serialization-prep cost paid on every timeline read. Run with:
+//
+//	go test ./internal/entity -bench BenchmarkPackNotes -benchmem -run x
+func BenchmarkPackNotes(b *testing.B) {
+	idGen, _ := id.NewGenerator("aidx")
+	const pageSize = 40
+	text := "benchmark note body with some text content and a #hashtag"
+
+	base := time.Date(2026, 5, 1, 12, 0, 0, 0, time.UTC)
+	notes := make([]*model.Note, pageSize)
+	for i := 0; i < pageSize; i++ {
+		uid := fmt.Sprintf("u%d", i%10)
+		notes[i] = &model.Note{
+			ID:         idGen.Generate(base.Add(time.Duration(i) * time.Second)),
+			UserID:     uid,
+			Text:       &text,
+			Visibility: model.NoteVisibilityPublic,
+			Reactions:  datatypes.JSON([]byte(`{"👍":5,"❤":2,"🎉":1}`)),
+			FileIDs:    pq.StringArray{"f1", "f2"},
+			User:       &model.User{ID: uid, Username: uid, AvatarDecorations: datatypes.JSON([]byte("[]"))},
+		}
+	}
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		out := PackNotes(context.Background(), notes, idGen, nil, nil, nil)
+		if len(out) != pageSize {
+			b.Fatalf("packed %d, want %d", len(out), pageSize)
+		}
+	}
+}

--- a/internal/repository/note_bench_test.go
+++ b/internal/repository/note_bench_test.go
@@ -23,6 +23,15 @@ func BenchmarkFindManyByIDsWithUser(b *testing.B) {
 	const notes = 200
 	const pageSize = 40
 
+	// 前回 run が seed 途中で中断して b.Cleanup を逃した場合の残骸を消してから
+	// seed する (= bu_%/bn_% の PK 衝突で再実行不能になるのを防ぐ、idempotent start)。
+	cleanup := func() {
+		testDB.Exec(`DELETE FROM "note" WHERE id LIKE 'bn_%'`)
+		testDB.Exec(`DELETE FROM "user" WHERE id LIKE 'bu_%'`)
+	}
+	cleanup()
+	b.Cleanup(cleanup)
+
 	userIDs := make([]string, users)
 	for i := 0; i < users; i++ {
 		uid := fmt.Sprintf("bu_%d", i)
@@ -32,10 +41,6 @@ func BenchmarkFindManyByIDsWithUser(b *testing.B) {
 			b.Fatalf("seed user: %v", err)
 		}
 	}
-	b.Cleanup(func() {
-		testDB.Exec(`DELETE FROM "note" WHERE id LIKE 'bn_%'`)
-		testDB.Exec(`DELETE FROM "user" WHERE id LIKE 'bu_%'`)
-	})
 
 	noteIDs := make([]string, notes)
 	text := "benchmark note body with some text content"

--- a/internal/repository/note_bench_test.go
+++ b/internal/repository/note_bench_test.go
@@ -1,0 +1,97 @@
+package repository
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/lib/pq"
+	"github.com/shiroha-a/mk/internal/model"
+	"gorm.io/datatypes"
+)
+
+// BenchmarkFindManyByIDsWithUser measures the timeline note-hydration hot path:
+// fetching a page of note IDs with all preloaded relations (User / Renote /
+// Renote.User / Renote.Poll / Reply / Reply.User / Reply.Poll / Poll). GORM
+// issues a separate query per preload, so this benchmark surfaces the
+// round-trip cost that the timeline read path pays for every page. Run with:
+//
+//	go test ./internal/repository -bench BenchmarkFindManyByIDsWithUser -benchmem -run x
+func BenchmarkFindManyByIDsWithUser(b *testing.B) {
+	repo := NewNoteRepository(testDB)
+
+	const users = 50
+	const notes = 200
+	const pageSize = 40
+
+	userIDs := make([]string, users)
+	for i := 0; i < users; i++ {
+		uid := fmt.Sprintf("bu_%d", i)
+		userIDs[i] = uid
+		u := &model.User{ID: uid, Username: uid, UsernameLower: uid, AvatarDecorations: datatypes.JSON([]byte("[]"))}
+		if err := testDB.Create(u).Error; err != nil {
+			b.Fatalf("seed user: %v", err)
+		}
+	}
+	b.Cleanup(func() {
+		testDB.Exec(`DELETE FROM "note" WHERE id LIKE 'bn_%'`)
+		testDB.Exec(`DELETE FROM "user" WHERE id LIKE 'bu_%'`)
+	})
+
+	noteIDs := make([]string, notes)
+	text := "benchmark note body with some text content"
+	for i := 0; i < notes; i++ {
+		nid := fmt.Sprintf("bn_%d", i)
+		noteIDs[i] = nid
+		n := &model.Note{
+			ID:         nid,
+			UserID:     userIDs[i%users],
+			Text:       &text,
+			Visibility: model.NoteVisibilityPublic,
+			Reactions:  datatypes.JSON([]byte(`{"👍":3,"❤":1}`)),
+			FileIDs:    pq.StringArray{},
+		}
+		// 約 1/4 を renote / reply にして preload (Renote / Reply 系) を踏ませる。
+		if i >= 8 && i%4 == 0 {
+			target := noteIDs[i-8]
+			n.RenoteID = &target
+		} else if i >= 8 && i%4 == 1 {
+			target := noteIDs[i-8]
+			n.ReplyID = &target
+		}
+		if err := testDB.Create(n).Error; err != nil {
+			b.Fatalf("seed note: %v", err)
+		}
+	}
+
+	page := noteIDs[:pageSize]
+
+	b.Run("WithPreloads", func(b *testing.B) {
+		b.ReportAllocs()
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			got, err := repo.FindManyByIDsWithUser(page)
+			if err != nil {
+				b.Fatalf("FindManyByIDsWithUser: %v", err)
+			}
+			if len(got) != pageSize {
+				b.Fatalf("got %d notes, want %d", len(got), pageSize)
+			}
+		}
+	})
+
+	// 比較用: preload 無しの素の `id IN (...)` 1 query。8 preload の round-trip
+	// コストを切り分ける (差分が preload のオーバーヘッド)。
+	b.Run("NoPreload", func(b *testing.B) {
+		b.ReportAllocs()
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			var notes []*model.Note
+			if err := testDB.Where("id IN ?", page).Find(&notes).Error; err != nil {
+				b.Fatalf("bare find: %v", err)
+			}
+			if len(notes) != pageSize {
+				b.Fatalf("got %d notes, want %d", len(notes), pageSize)
+			}
+		}
+	})
+}


### PR DESCRIPTION
## Summary

性能改善(評価で最大の未証明領域だった timeline read)の前段として、hot path を**実測**する Go ベンチを追加。「計測してからボトルネックを叩く」(過去2回の最適化失敗の反省)の第一歩。`-bench` 指定時のみ実行されるため通常 `go test` / CI は不変。

## 計測結果 (testcontainer Postgres, 40件/ページ)

| 段階 | ns/op | allocs/op |
|---|---|---|
| hydration `WithPreloads` (本番経路 = 8 preload) | 3,939,698 | 9,957 |
| hydration `NoPreload` (素の `id IN`) | 811,875 | 3,052 |
| `PackNotes` (純 CPU/alloc) | 254,109 | 2,247 |

- **hydration がホットパスの ~94%、pack は ~6%**。
- hydration のうち **8 preload (Renote/Reply/Poll 系) が +3.13ms ≒ 78%**。GORM は preload ごとに別クエリを発行 → 1 ページ ~9 往復。
- 本番は DB への network RTT が往復ごとに乗るため、往復削減の価値は計測値より更に大きい。

## 主な変更点

- `internal/repository/note_bench_test.go` `BenchmarkFindManyByIDsWithUser`(`WithPreloads` / `NoPreload` サブベンチ)。
- `internal/entity/note_bench_test.go` `BenchmarkPackNotes`(DB 無し、nil lookup で pack の純コストを isolate)。

## 結論 / 次の一手

最大 ROI は **8 preload を少数クエリに畳む note hydration の最適化**(pgx-native pool + prepared statement 路線)。これは別 issue/PR で実装。PackNotes (alloc 56/note) は二次的 follow-up。

## テスト

- `go test`(`-bench` なし)では benchmark は実行されない(`[no tests to run]` 確認済 = CI 不変)。
- `go test ./internal/{repository,entity} -bench . -benchmem -run x` で再現可能。

## Closes

Closes #1368

🤖 Generated with [Claude Code](https://claude.com/claude-code)