### PR TITLE
perf(repository): timeline note hydration を batch-IN 化 (8 preload → 4 query)

### DIFF
--- a/internal/entity/note.go
+++ b/internal/entity/note.go
@@ -284,10 +284,21 @@ func mergeBufferedReactions(ctx context.Context, notes []*model.Note, reader Buf
 		// reader 失敗時は stale な DB 値を返す (旧挙動と同等)。
 		return
 	}
+	// 同一 *Note ポインタが flat に複数回現れうる (例: 2 件の note が同じ renote
+	// 先を持つと、repository の batch hydration では両者の .Renote が同一ポインタを
+	// 指す)。mergeReactionsJSON は加算的なので、同じオブジェクトに 2 回適用すると
+	// delta が二重加算される。ポインタ単位で dedup して各オブジェクトへの適用を
+	// 1 回に限定する (id 単位ではなく: preload 経由の別オブジェクト同 id はそれぞれ
+	// base から 1 回ずつ merge されるべきで、正しい)。
+	applied := make(map[*model.Note]struct{}, len(notes))
 	for _, n := range notes {
 		if n == nil {
 			continue
 		}
+		if _, done := applied[n]; done {
+			continue
+		}
+		applied[n] = struct{}{}
 		if d, ok := deltas[n.ID]; ok && len(d) > 0 {
 			n.Reactions = mergeReactionsJSON(n.Reactions, d)
 		}

--- a/internal/entity/note_test.go
+++ b/internal/entity/note_test.go
@@ -434,6 +434,45 @@ func TestPackNotes_MergesBufferedReactions(t *testing.T) {
 	assert.Equal(t, "https://remote.example/emoji/yikes.png", out[0].ReactionEmojis["yikes@"+remoteHost])
 }
 
+// 2 件の note が同一 *Note の renote を共有する場合 (repository の batch hydration
+// で起こりうる)、buffered delta が二重加算されないこと。mergeBufferedReactions は
+// 加算的なので、flat list に同一ポインタが 2 回現れても適用は 1 回に限定する。
+func TestPackNotes_SharedRenote_NoDoubleMerge(t *testing.T) {
+	idGen := newTestIDGen(t)
+	renoteID := idGen.Generate(time.Now().Add(-time.Hour))
+	// 共有される renote 先 (base reaction 1)。
+	shared := &model.Note{
+		ID:         renoteID,
+		UserID:     "ru",
+		Visibility: model.NoteVisibilityPublic,
+		Reactions:  datatypes.JSON([]byte(`{":base@.:": 1}`)),
+		User:       &model.User{ID: "ru", Username: "renoter", AvatarDecorations: datatypes.JSON([]byte("[]"))},
+	}
+	mkRenoter := func(i int) *model.Note {
+		return &model.Note{
+			ID: idGen.Generate(time.Now().Add(time.Duration(i) * time.Second)), UserID: "u",
+			Visibility: model.NoteVisibilityPublic, RenoteID: &renoteID,
+			User:   &model.User{ID: "u", Username: "u", AvatarDecorations: datatypes.JSON([]byte("[]"))},
+			Renote: shared, // 両者が同一ポインタを共有
+		}
+	}
+	n1, n2 := mkRenoter(0), mkRenoter(1)
+	// shared renote に buffered delta +2。
+	reader := &stubBufferedReader{data: map[string]map[string]int64{
+		renoteID: {":base@.:": 2},
+	}}
+
+	out := PackNotes(context.Background(), []*model.Note{n1, n2}, idGen, nil, nil, reader)
+	require.Len(t, out, 2)
+	// 二重加算なら 1+2+2=5 になる。正しくは 1+2=3 (1 回のみ適用)。
+	for _, e := range out {
+		require.NotNil(t, e.Renote)
+		var got map[string]int
+		require.NoError(t, json.Unmarshal(e.Renote.Reactions, &got))
+		assert.Equal(t, 3, got[":base@.:"], "shared renote の buffered delta は二重加算されない")
+	}
+}
+
 // 0 以下になった merged value は出力から除外される。
 func TestPackNotes_BufferedNegativeDelta_RemovesKey(t *testing.T) {
 	idGen := newTestIDGen(t)

--- a/internal/repository/note.go
+++ b/internal/repository/note.go
@@ -429,11 +429,101 @@ func (r *noteRepository) FindManyByIDsWithUser(ids []string) ([]*model.Note, err
 	if len(ids) == 0 {
 		return nil, nil
 	}
+	// timeline read hot path。GORM の Preload は relation ごとに別クエリを発行する
+	// ため preloadNoteRelations (8 relation) は 1 ページ ~9 往復になる (#1368 計測)。
+	// ここでは relation を種類ごとに batch IN で引いて Go 側で配線し、往復を 4 query
+	// (notes / sub-notes / users / polls) に畳む。出力 shape は preload 版と同一
+	// (TestNoteRepository_FindManyByIDsWithUser_HydratesRelations が回帰を捕捉)。
+	// preload は Renote/Reply を 1 段しか展開しない (maxNoteEmbedDepth=1) ので
+	// sub-note の renote/reply は辿らない。
 	var notes []*model.Note
-	if err := preloadNoteRelations(r.db).Where("id IN ?", ids).Find(&notes).Error; err != nil {
+	if err := r.db.Where("id IN ?", ids).Find(&notes).Error; err != nil {
 		return nil, err
 	}
-	// idsの順序を保つため、idでマップ化してから並び替える
+	if len(notes) == 0 {
+		return nil, nil
+	}
+
+	// (2) renote / reply 先 (sub-note) を 1 query で取得し配線する。
+	subIDSet := make(map[string]struct{})
+	for _, n := range notes {
+		if n.RenoteID != nil && *n.RenoteID != "" {
+			subIDSet[*n.RenoteID] = struct{}{}
+		}
+		if n.ReplyID != nil && *n.ReplyID != "" {
+			subIDSet[*n.ReplyID] = struct{}{}
+		}
+	}
+	subByID := make(map[string]*model.Note, len(subIDSet))
+	if len(subIDSet) > 0 {
+		var subs []*model.Note
+		if err := r.db.Where("id IN ?", mapKeys(subIDSet)).Find(&subs).Error; err != nil {
+			return nil, err
+		}
+		for _, s := range subs {
+			subByID[s.ID] = s
+		}
+		for _, n := range notes {
+			if n.RenoteID != nil {
+				n.Renote = subByID[*n.RenoteID]
+			}
+			if n.ReplyID != nil {
+				n.Reply = subByID[*n.ReplyID]
+			}
+		}
+	}
+
+	// notes + sub-notes をまとめて user / poll の配線対象にする。
+	hydrate := make([]*model.Note, 0, len(notes)+len(subByID))
+	hydrate = append(hydrate, notes...)
+	for _, s := range subByID {
+		hydrate = append(hydrate, s)
+	}
+
+	// (3) author user を 1 query で取得し配線する。
+	userIDSet := make(map[string]struct{}, len(hydrate))
+	for _, n := range hydrate {
+		if n.UserID != "" {
+			userIDSet[n.UserID] = struct{}{}
+		}
+	}
+	if len(userIDSet) > 0 {
+		var users []*model.User
+		if err := r.db.Where("id IN ?", mapKeys(userIDSet)).Find(&users).Error; err != nil {
+			return nil, err
+		}
+		userByID := make(map[string]*model.User, len(users))
+		for _, u := range users {
+			userByID[u.ID] = u
+		}
+		for _, n := range hydrate {
+			n.User = userByID[n.UserID]
+		}
+	}
+
+	// (4) poll を 1 query で取得し配線する。preload 版と同じく全 note を対象にして
+	// HasPoll の正確性に依存しない (poll 行が在れば attach、無ければ nil)。
+	noteIDs := make([]string, 0, len(hydrate))
+	for _, n := range hydrate {
+		noteIDs = append(noteIDs, n.ID)
+	}
+	var polls []*model.Poll
+	if err := r.db.Where(`"noteId" IN ?`, noteIDs).Find(&polls).Error; err != nil {
+		return nil, err
+	}
+	if len(polls) > 0 {
+		pollByNote := make(map[string]*model.Poll, len(polls))
+		for _, p := range polls {
+			pollByNote[p.NoteID] = p
+		}
+		for _, n := range hydrate {
+			if p, ok := pollByNote[n.ID]; ok {
+				n.Poll = p
+			}
+		}
+	}
+
+	// (5) ids の順序を保って返す。
 	byID := make(map[string]*model.Note, len(notes))
 	for _, n := range notes {
 		byID[n.ID] = n
@@ -445,6 +535,15 @@ func (r *noteRepository) FindManyByIDsWithUser(ids []string) ([]*model.Note, err
 		}
 	}
 	return ordered, nil
+}
+
+// mapKeys returns the keys of a string-set as a slice (順序不定)。
+func mapKeys(m map[string]struct{}) []string {
+	out := make([]string, 0, len(m))
+	for k := range m {
+		out = append(out, k)
+	}
+	return out
 }
 
 func (r *noteRepository) ListFeatured(channelID, untilID string, limit, offset int) ([]*model.Note, error) {

--- a/internal/repository/note_bench_test.go
+++ b/internal/repository/note_bench_test.go
@@ -70,7 +70,8 @@ func BenchmarkFindManyByIDsWithUser(b *testing.B) {
 
 	page := noteIDs[:pageSize]
 
-	b.Run("WithPreloads", func(b *testing.B) {
+	// Batched: 現行 FindManyByIDsWithUser (#1368 で batch-IN 4 query 化)。
+	b.Run("Batched", func(b *testing.B) {
 		b.ReportAllocs()
 		b.ResetTimer()
 		for i := 0; i < b.N; i++ {
@@ -84,8 +85,23 @@ func BenchmarkFindManyByIDsWithUser(b *testing.B) {
 		}
 	})
 
-	// 比較用: preload 無しの素の `id IN (...)` 1 query。8 preload の round-trip
-	// コストを切り分ける (差分が preload のオーバーヘッド)。
+	// Preloads: 旧経路 (preloadNoteRelations の 8 preload = ~9 query)。batch との
+	// 比較で往復削減の効果を測る。
+	b.Run("Preloads", func(b *testing.B) {
+		b.ReportAllocs()
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			var notes []*model.Note
+			if err := preloadNoteRelations(testDB).Where("id IN ?", page).Find(&notes).Error; err != nil {
+				b.Fatalf("preload find: %v", err)
+			}
+			if len(notes) != pageSize {
+				b.Fatalf("got %d notes, want %d", len(notes), pageSize)
+			}
+		}
+	})
+
+	// NoPreload: 素の `id IN (...)` 1 query (relation 無し)。理論下限。
 	b.Run("NoPreload", func(b *testing.B) {
 		b.ReportAllocs()
 		b.ResetTimer()

--- a/internal/repository/note_test.go
+++ b/internal/repository/note_test.go
@@ -519,6 +519,76 @@ func TestNoteRepository_FindManyByIDsWithUser(t *testing.T) {
 	assert.Empty(t, out)
 }
 
+// TestNoteRepository_FindManyByIDsWithUser_HydratesRelations は hydrated shape
+// (User / Renote{.User,.Poll} / Reply{.User,.Poll} / Poll) を全て検証する強い
+// oracle。hydration の実装を入れ替える (preload → batch 等) 際の wiring 回帰を
+// 捕まえるためのもの。
+func TestNoteRepository_FindManyByIDsWithUser_HydratesRelations(t *testing.T) {
+	repo := NewNoteRepository(testDB)
+	pollRepo := NewPollRepository(testDB)
+
+	ua := insertTestUser(t, "u_hy_a", "hy_author")
+	ur := insertTestUser(t, "u_hy_r", "hy_renoter")
+	up := insertTestUser(t, "u_hy_p", "hy_replier")
+	defer cleanupUser(t, ua.ID)
+	defer cleanupUser(t, ur.ID)
+	defer cleanupUser(t, up.ID)
+
+	mkNote := func(id, uid string, hasPoll bool) *model.Note {
+		n := &model.Note{ID: id, UserID: uid, Visibility: model.NoteVisibilityPublic, HasPoll: hasPoll, Reactions: datatypes.JSON([]byte("{}"))}
+		require.NoError(t, repo.Create(n))
+		t.Cleanup(func() { cleanupNote(t, id) })
+		return n
+	}
+	mkPoll := func(noteID, uid string) {
+		require.NoError(t, pollRepo.Create(&model.Poll{
+			NoteID: noteID, Choices: pq.StringArray{"A", "B"}, Votes: pq.Int64Array{0, 0},
+			NoteVisibility: model.NoteVisibilityPublic, UserID: uid,
+		}))
+	}
+
+	// renote 先 / reply 先はそれぞれ別 user + poll を持つ。
+	nr := mkNote("n_hy_r", ur.ID, true)
+	mkPoll(nr.ID, ur.ID)
+	np := mkNote("n_hy_p", up.ID, true)
+	mkPoll(np.ID, up.ID)
+	// main note: author=ua, renote=nr, reply=np, 自身も poll を持つ。
+	main := &model.Note{
+		ID: "n_hy_m", UserID: ua.ID, Visibility: model.NoteVisibilityPublic,
+		HasPoll: true, RenoteID: &nr.ID, ReplyID: &np.ID, Reactions: datatypes.JSON([]byte("{}")),
+	}
+	require.NoError(t, repo.Create(main))
+	t.Cleanup(func() { cleanupNote(t, main.ID) })
+	mkPoll(main.ID, ua.ID)
+
+	out, err := repo.FindManyByIDsWithUser([]string{main.ID})
+	require.NoError(t, err)
+	require.Len(t, out, 1)
+	got := out[0]
+
+	// author + 自 poll
+	require.NotNil(t, got.User, "author user must be hydrated")
+	assert.Equal(t, ua.ID, got.User.ID)
+	require.NotNil(t, got.Poll, "own poll must be hydrated")
+	assert.Equal(t, main.ID, got.Poll.NoteID)
+
+	// renote + その user + poll
+	require.NotNil(t, got.Renote, "renote must be hydrated")
+	assert.Equal(t, nr.ID, got.Renote.ID)
+	require.NotNil(t, got.Renote.User, "renote.user must be hydrated")
+	assert.Equal(t, ur.ID, got.Renote.User.ID)
+	require.NotNil(t, got.Renote.Poll, "renote.poll must be hydrated")
+	assert.Equal(t, nr.ID, got.Renote.Poll.NoteID)
+
+	// reply + その user + poll
+	require.NotNil(t, got.Reply, "reply must be hydrated")
+	assert.Equal(t, np.ID, got.Reply.ID)
+	require.NotNil(t, got.Reply.User, "reply.user must be hydrated")
+	assert.Equal(t, up.ID, got.Reply.User.ID)
+	require.NotNil(t, got.Reply.Poll, "reply.poll must be hydrated")
+	assert.Equal(t, np.ID, got.Reply.Poll.NoteID)
+}
+
 func TestNoteRepository_QueryErrors(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel()


### PR DESCRIPTION
## Summary

#1368 の計測で特定した timeline read hot path のボトルネック(`FindManyByIDsWithUser` の GORM 8-preload = 1ページ ~9 往復、hydration がホットパスの ~94%)を、**種類別 batch IN + Go 側配線**(notes / sub-notes(renote+reply) / users / polls の 4 query)に置き換えて往復削減する。

memory のとおり過去 2 回(Joins / raw scan)の最適化は **50VU 並行負荷で regression** したため、機構の異なる batch-IN を採り、**50VU A/B で検証してから**採用した。

## 主な変更点

- `internal/repository/note.go`: `FindManyByIDsWithUser` を Preload から batch IN に。出力 shape は preload 版と同一(`preloadNoteRelations` は他経路用に不変、本メソッドのみ変更で blast radius 最小)。
- `note_test.go`: hydration shape(User / Renote{.User,.Poll} / Reply{.User,.Poll} / Poll)を全 assert する **強い oracle** を追加(impl 入替時の wiring 回帰を捕捉)。
- `note_bench_test.go`: Batched / Preloads / NoPreload の 3-way 比較ベンチ。

過去失敗の機構を回避: B(Joins)の N:1 行重複なし / C(raw scan)の pgx-stdlib オーバーヘッド・複数 conn 圧迫なし(GORM prepared-stmt cache 保持、クエリ数は **減**)。

## 検証

**正しさ**: oracle を preload 版で green にして期待 shape をロック → batch 版でも green。repository / notes / timeline / entity 全テスト green。

**serial micro-bench**(testcontainer, 40件): preload 3.86ms → batch 2.39ms(**-38%**, allocs 9953→7471)。

**50VU 並行負荷 A/B**(`make bench-run`, local-timeline):

| | med | p90 | p95 | reqs |
|---|---|---|---|---|
| **batch** | 14.8 | 26.8 | **30.4ms** | 54,825 |
| preload | 16.1 | 29.0 | **32.7ms** | 50,930 |

→ p95 **~7%改善** + throughput **~8%増**、**regression 無し**(過去 B=8x悪化 / C=+72% と決定的に違い、50VU gate を通過した初の hot-path 最適化)。serial の 38% に対し並行では圧縮されるが方向は改善。localhost DB(RTT ゼロ)の計測のため、本番の DB network RTT 下では 9→4 往復削減の効果はより大きくなる見込み。

## テスト

- `make fmt && make lint && make test` green。repository 90.1%。
- ベンチは `-bench` 時のみ実行(CI 不変)。

## Closes

Closes #1370

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

## 追記: code-review verify で発見した二重加算バグの修正

batch hydration はメモリ効率のため、2 件の note が同じ renote 先を持つ場合に両者の `.Renote` を**同一 `*Note` ポインタ**で共有する(preload は note ごとに別オブジェクト)。これにより `mergeBufferedReactions` の flat list に同一ポインタが 2 回現れ、`mergeReactionsJSON` が加算的(`reactions[k] += delta`)なため **buffered reaction delta が二重加算**される潜在バグがあった(共有 renote + buffered delta の同時成立時のみ顕在化、preload では起きない)。

- 修正: `mergeBufferedReactions` の merge ループを**ポインタ単位で dedup**(各 `*Note` への適用を 1 回に限定)。id 単位でなくポインタ単位なのは、preload 経由の「別オブジェクト同 id」はそれぞれ base から 1 回ずつ merge されるべきだから。
- 回帰テスト `TestPackNotes_SharedRenote_NoDoubleMerge` 追加(fix 無しで 1+2+2=5 → FAIL、fix 有りで 1+2=3 → PASS を実機確認)。
- entity coverage 95.6%。

この修正により batch hydration の pointer-sharing が pack 層で安全に扱われる。
