### PR TITLE
fix(federation): tags 更新の nil→SQL NULL を防ぎプロフィール更新の全失敗を解消

### DIFF
--- a/internal/core/federation/resolver.go
+++ b/internal/core/federation/resolver.go
@@ -591,7 +591,14 @@ func (r *Resolver) refreshActor(existing *model.User, uri string) {
 	// person.tag の Hashtag entry を user.tags に追従させる (actor 更新時に
 	// 自己紹介の hashtag が変わったら反映する。新規取り込みと同じ正規化)。
 	oldTags := []string(existing.Tags)
+	// ExtractUserTags は hashtag が無いと nil を返すが、nil の pq.StringArray は
+	// Updates() map 経由で SQL NULL になり user.tags (NOT NULL) 制約に違反する。
+	// その場合 actor 更新 (emojis / name / lastFetchedAt 等を含む atomic UPDATE)
+	// 全体が失敗するため空配列に倒して '{}' を書く。
 	tags := pq.StringArray(hashtag.ExtractUserTags(extractHashtagTagNames(actor.Tag)...))
+	if tags == nil {
+		tags = pq.StringArray{}
+	}
 	fields["tags"] = tags
 	existing.Tags = tags
 	existing.LastFetchedAt = &now
@@ -1157,8 +1164,15 @@ func (r *Resolver) UpdateRemoteNote(body []byte) (*model.Note, error) {
 	newTags := hashtag.Extract(hashtagSources...)
 	tagsChanged := !slices.Equal([]string(existing.Tags), newTags)
 	if tagsChanged {
-		fields["tags"] = pq.StringArray(newTags)
-		existing.Tags = pq.StringArray(newTags)
+		// Extract は hashtag が無いと nil を返すが、nil の pq.StringArray は
+		// Updates() map 経由で SQL NULL になり note.tags (NOT NULL) 制約に違反する。
+		// tags が非空→空に変わるケースで踏むため空配列に倒して '{}' を書く。
+		noteTags := pq.StringArray(newTags)
+		if noteTags == nil {
+			noteTags = pq.StringArray{}
+		}
+		fields["tags"] = noteTags
+		existing.Tags = noteTags
 	}
 	// AP `attachment` 配列の差分を反映する (#378)。driveFileRepo 未設定時は
 	// upsertAttachments が空 slice を返すので何もしない (= 既存 fileIDs を

--- a/internal/core/federation/resolver_test.go
+++ b/internal/core/federation/resolver_test.go
@@ -1164,6 +1164,35 @@ func TestUpdateRemoteNote_RecalculatesHashtags(t *testing.T) {
 	assert.ElementsMatch(t, []string{"federation", "news"}, []string(got.Tags), "古い tags は捨て、tag 配列 + 本文 fallback で再構築")
 }
 
+// #1372: hashtag が消えて tags が非空→空に変わる場合、note.tags は非nilの空配列
+// ('{}') でなければならない。nil の pq.StringArray は Updates() 経由で SQL NULL に
+// なり note.tags (NOT NULL) 制約に違反する。
+func TestUpdateRemoteNote_ClearsTagsToEmptyNotNull(t *testing.T) {
+	repo := testutil.NewMockUserRepository()
+	noteRepo := testutil.NewMockNoteRepository()
+	uri := "https://remote.example/notes/n1"
+	host := "remote.example"
+	noteRepo.Notes["n1"] = &model.Note{
+		ID: "n1", URI: &uri, UserID: "alice-id", UserHost: &host,
+		Tags: []string{"old"},
+	}
+	urls := activitypub.NewURLBuilder("https://example.com")
+	idGen, _ := id.NewGenerator("aidx")
+	r := federation.NewResolver(repo, noteRepo, urls, &stubFetcher{}, idGen)
+
+	body := `{
+		"id": "https://remote.example/notes/n1",
+		"type": "Note",
+		"attributedTo": "https://remote.example/users/alice",
+		"content": "edited, no more hashtags"
+	}`
+	got, err := r.UpdateRemoteNote([]byte(body))
+	require.NoError(t, err)
+	require.NotNil(t, got)
+	require.NotNil(t, got.Tags, "tags は非nilの空配列でなければ SQL NULL で NOT NULL 違反 (#1372)")
+	assert.Empty(t, []string(got.Tags))
+}
+
 func TestUpdateRemoteNote_NoNoteRepo(t *testing.T) {
 	repo := testutil.NewMockUserRepository()
 	urls := activitypub.NewURLBuilder("https://example.com")
@@ -1861,6 +1890,34 @@ func TestResolveActor_UsertagHookFiresOnRefresh(t *testing.T) {
 	assert.False(t, hook.usertagCalls[0].isLocal)
 	assert.Equal(t, []string{"old"}, hook.usertagCalls[0].oldTags)
 	assert.Equal(t, []string{"new"}, hook.usertagCalls[0].newTags)
+}
+
+// #1372: refreshActor で remote actor が hashtag を持たない場合、user.tags は
+// 非nilの空配列 ('{}') に更新されなければならない。nil の pq.StringArray は
+// Updates() 経由で SQL NULL になり user.tags (NOT NULL) 制約に違反し、actor 更新
+// (emojis / name / lastFetchedAt 等を含む atomic UPDATE) 全体が失敗する。
+func TestResolveActor_RefreshClearsTagsToEmptyNotNull(t *testing.T) {
+	body := `{
+		"id": "https://remote.example/users/alice",
+		"type": "Person",
+		"preferredUsername": "alice",
+		"inbox": "https://remote.example/users/alice/inbox",
+		"publicKey": {"publicKeyPem": "FAKE"}
+	}`
+	r, repo := newResolver(t, body, nil)
+	uri := "https://remote.example/users/alice"
+	host := "remote.example"
+	repo.Users["existing"] = &model.User{
+		ID:       "existing",
+		Username: "alice",
+		URI:      &uri,
+		Host:     &host,
+		Tags:     []string{"old"},
+	}
+	_, err := r.ResolveActor(uri)
+	require.NoError(t, err)
+	require.NotNil(t, repo.Users["existing"].Tags, "tags は非nilの空配列でなければ SQL NULL で NOT NULL 違反 (#1372)")
+	assert.Empty(t, []string(repo.Users["existing"].Tags))
 }
 
 func TestIngestNote_HashtagHookFiresOnRemoteIngest(t *testing.T) {

--- a/internal/core/user/user_service.go
+++ b/internal/core/user/user_service.go
@@ -483,6 +483,12 @@ func (s *Service) UpdateProfile(userID string, in UpdateInput) (*UserWithProfile
 			desc = **in.Description
 		}
 		newTags = hashtag.ExtractUserTags(desc)
+		// ExtractUserTags は hashtag が無いと nil を返すが、nil の pq.StringArray は
+		// Updates() map 経由で SQL NULL になり user.tags (NOT NULL) 制約に違反する。
+		// その場合 profile 更新全体が atomic に失敗するため空配列に倒して '{}' を書く。
+		if newTags == nil {
+			newTags = []string{}
+		}
 		userFields["tags"] = pq.StringArray(newTags)
 		oldTags = []string(existing.Tags)
 		tagsChanged = true

--- a/internal/core/user/user_service_test.go
+++ b/internal/core/user/user_service_test.go
@@ -1088,6 +1088,10 @@ func TestService_UpdateProfile_ClearsTagsOnEmptyDescription(t *testing.T) {
 		Description: ptr(ptr("")),
 	})
 	require.NoError(t, err)
+	// tags は非nilの空配列 ('{}') でなければならない。nil の pq.StringArray を
+	// Updates() に渡すと SQL NULL になり user.tags (NOT NULL) 制約に違反して
+	// profile 更新全体が atomic に失敗する (#1372)。
+	require.NotNil(t, repo.Users["u1"].Tags)
 	assert.Empty(t, []string(repo.Users["u1"].Tags))
 }
 


### PR DESCRIPTION
## Summary

queue-bench (inbound) 実行中に develop で発見した federation regression を修正する。

`hashtag.ExtractUserTags` / `hashtag.Extract` は対象 hashtag が無い場合に **nil** を返す(意図的・テスト済の契約)。これを `pq.StringArray(nil)` として `Updates()` の fields map に入れると **SQL NULL** にシリアライズされ、`user.tags` / `note.tags`(いずれも `NOT NULL DEFAULT '{}'`)制約に違反する。

UPDATE は atomic なので tags=NULL で弾かれると**同じ map 内の emojis / name / inbox / lastFetchedAt 等もろとも更新が全失敗**し、さらに呼び出し側が `_ = UpdateUser(...)` で best-effort 無視するため**サイレント**に進行していた。hashtags/users Part 2 (#1360, user.tags populate) で UPDATE 経路に tags 書き込みが入って顕在化した。hashtag を持たない actor / プロフィール(=大多数)が影響を受ける。

```
ERROR: null value in column "tags" of relation "user" violates not-null constraint (SQLSTATE 23502)
UPDATE "user" SET "emojis"='{}',...,"tags"=NULL,...,"lastFetchedAt"=...
```

## 主な変更点

- DB write site 3 箇所で nil の tags を非nil空配列(`pq.StringArray{}` → `'{}'`)に coerce:
  - `internal/core/federation/resolver.go` `refreshActor` (remote actor 更新)
  - `internal/core/federation/resolver.go` `UpdateRemoteNote` (note tags が非空→空)
  - `internal/core/user/user_service.go` `UpdateProfile` (local profile、bio の hashtag 全消し)
- `hashtag.Extract` / `ExtractUserTags` の nil 戻り契約はテスト済のため変更しない。
- CREATE 経路(resolver.go の新規 actor / note_create_service.go)は GORM が `default:'{}'` 付き zero-value 列を INSERT から省くため安全であり、変更しない。

## テスト

- 回帰テスト 3 件を追加。fix を一時退避して全件 FAIL → fix ありで PASS を確認済:
  - `TestResolveActor_RefreshClearsTagsToEmptyNotNull`
  - `TestUpdateRemoteNote_ClearsTagsToEmptyNotNull`
  - 強化: `TestService_UpdateProfile_ClearsTagsOnEmptyDescription`(従来 `assert.Empty` は nil/空配列を区別せず見逃していたため `require.NotNil` を追加)
- `make fmt` / `make lint` clean、`go test -race ./...` 全パス。
- カバレッジ: `internal/core/federation` 90.0% / `internal/core/user` 91.4%(≥90% ゲート通過)。

実行方法:
```
go test -race -count=1 ./internal/core/federation/ ./internal/core/user/
```

## Closes

Closes #1372

🤖 Generated with [Claude Code](https://claude.com/claude-code)