### PR TITLE
fix(queue): mkq の per-queue default concurrency を hot queue 優先に (inbox starve 解消)

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -101,7 +101,7 @@ cp .config/docker.yml.example .config/docker.yml
 
 > **driver 間の差分**:
 > - `asynq` driver は worker pool が共有なので `deliverJobConcurrency` は **総 concurrency** として扱われる。queue 間の priority weight は全 queue 静的 1 で固定 (deliver / inbox / push / export / webhook / maintenance すべて equal-weight)。
-> - `mkq` driver は queue ごとに worker を分けているので `deliverJobConcurrency` / `inboxJobConcurrency` はそれぞれの queue 専用 worker 数として扱われる。明示指定の無い queue は hot queue 優先の per-queue 既定値 (inbox=16 / deliver=16 / webhook=4 / push=4 / export=2 / maintenance=2) を使う。旧来の `総budget / len(queues)` 均等割りだと inbox が starve していた (#1374) ため hot-tuned default に変更。worker 数 ≒ Redis 接続数 (worker 毎に BZPopMin で接続を保持) なので、大幅に増やす場合は `redisForJobQueue.poolSize` も合わせて見直すこと。
+> - `mkq` driver は queue ごとに worker を分けているので `deliverJobConcurrency` / `inboxJobConcurrency` はそれぞれの queue 専用 worker 数として扱われる。明示指定の無い queue は hot queue 優先の per-queue 既定値 (inbox=16 / deliver=16 / webhook=4 / push=4 / export=2 / maintenance=2) を使う。旧来の `総budget / len(queues)` 均等割りだと inbox が starve していた (#1374) ため hot-tuned default に変更。worker 数 ≒ Redis 接続数 (worker 毎に BZPopMin で接続を保持) なので、`redisForJobQueue.poolSize` 未設定時は mkq driver が worker 総数 + 余裕に自動サイジングする (`<queue>JobConcurrency` を上げると pool も追従)。明示設定した場合はその値が尊重される。
 > - **per-queue concurrency tuning は `mkq` driver でしか効かない**。asynq で inbox / deliver を独立に絞りたい場合は `mkq` 推奨。
 >
 > **rate limit (`*JobPerSec`) の挙動差**:

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -86,7 +86,7 @@ cp .config/docker.yml.example .config/docker.yml
 | キー | 型 | デフォルト | 説明 |
 |---|---|---|---|
 | `deliverJobConcurrency` | int | `16` | AP配信worker数。mkq driver では deliver queue 専用、asynq driver では**総 worker pool 上限**として扱う (asynq は per-queue concurrency を持たないため、この値は queue 共通の上限) |
-| `inboxJobConcurrency` | int | - | Inbox処理 worker 数 (#534 で非同期化済)。mkq driver では inbox queue 専用 worker。asynq driver では**現状 no-op** (asynq の queue priority weight も静的 1 固定で wire していないため、共有 worker pool 内の inbox tasks は他 queue と equal-weight で競合する) |
+| `inboxJobConcurrency` | int | `16` | Inbox処理 worker 数 (#534 で非同期化済)。mkq driver では inbox queue 専用 worker (未指定時の default は 16)。asynq driver では**現状 no-op** (asynq の queue priority weight も静的 1 固定で wire していないため、共有 worker pool 内の inbox tasks は他 queue と equal-weight で競合する) |
 | `relationshipJobConcurrency` | int | - | フォロー処理 worker 数 (mk-go は relationship queue を持たないため**現状 no-op**) |
 | `deliverJobPerSec` | int | - | AP配信レート上限 (tasks/sec)。設定すると asynq middleware / mkq.WithRateLimit で worker dispatch が back-pressure される |
 | `inboxJobPerSec` | int | - | Inbox処理レート上限 (tasks/sec) (#534)。設定すると asynq middleware / mkq.WithRateLimit で worker dispatch が back-pressure される |
@@ -101,7 +101,7 @@ cp .config/docker.yml.example .config/docker.yml
 
 > **driver 間の差分**:
 > - `asynq` driver は worker pool が共有なので `deliverJobConcurrency` は **総 concurrency** として扱われる。queue 間の priority weight は全 queue 静的 1 で固定 (deliver / inbox / push / export / webhook / maintenance すべて equal-weight)。
-> - `mkq` driver は queue ごとに worker を分けているので `deliverJobConcurrency` / `inboxJobConcurrency` はそれぞれの queue 専用 worker 数として扱われる。明示指定の無い queue は `Concurrency / len(queues)` の既定値を使う。
+> - `mkq` driver は queue ごとに worker を分けているので `deliverJobConcurrency` / `inboxJobConcurrency` はそれぞれの queue 専用 worker 数として扱われる。明示指定の無い queue は hot queue 優先の per-queue 既定値 (inbox=16 / deliver=16 / webhook=4 / push=4 / export=2 / maintenance=2) を使う。旧来の `総budget / len(queues)` 均等割りだと inbox が starve していた (#1374) ため hot-tuned default に変更。worker 数 ≒ Redis 接続数 (worker 毎に BZPopMin で接続を保持) なので、大幅に増やす場合は `redisForJobQueue.poolSize` も合わせて見直すこと。
 > - **per-queue concurrency tuning は `mkq` driver でしか効かない**。asynq で inbox / deliver を独立に絞りたい場合は `mkq` 推奨。
 >
 > **rate limit (`*JobPerSec`) の挙動差**:

--- a/internal/queue/driver/mkqdriver/driver.go
+++ b/internal/queue/driver/mkqdriver/driver.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"runtime"
 	"sync"
 
 	"github.com/redis/go-redis/v9"
@@ -231,13 +232,26 @@ const poolHeadroom = 8
 // resolved per-queue concurrency plus poolHeadroom. mkq holds one blocking
 // BZPopMin connection per worker, so the pool must cover every worker
 // simultaneously or dispatch stalls on connection acquisition.
+//
+// The result is floored at go-redis' own default (10 × GOMAXPROCS) so this
+// auto-sizing never shrinks the pool below what an unset PoolSize would have
+// produced. That preserves enqueue-burst headroom on multi-core hosts and
+// leaves room for jobQueueAutoScale to grow workers past the static defaults
+// (auto-scale resizes workers but not the connection pool). Heavy auto-scale
+// deployments should still set redisForJobQueue.poolSize explicitly to cover
+// maxWorkers. Connections are created lazily (MinIdleConns=0) so a higher
+// ceiling costs nothing until load demands it.
 func workerPoolSize(queues []string, override map[string]int) int {
 	conc := resolveQueueConcurrency(queues, override)
 	sum := 0
 	for _, c := range conc {
 		sum += c
 	}
-	return sum + poolHeadroom
+	need := sum + poolHeadroom
+	if goDefault := 10 * runtime.GOMAXPROCS(0); need < goDefault {
+		need = goDefault
+	}
+	return need
 }
 
 // queueDefaultConcurrency returns the hot-tuned default pool size for a queue.

--- a/internal/queue/driver/mkqdriver/driver.go
+++ b/internal/queue/driver/mkqdriver/driver.go
@@ -37,11 +37,16 @@ type Config struct {
 	// multiple BullMQ deployments.
 	KeyPrefix string
 
-	// Concurrency is the **total** worker budget across all queues,
-	// matching asynq.Config.Concurrency semantics. Driver.Server
-	// divides this by len(QueueNames) (clamped to a minimum of 1)
-	// before passing to mkq.WithConcurrency on a per-queue basis.
-	// Zero falls back to 16, matching the historical asynq default.
+	// Concurrency is a fallback worker budget used only for queues that
+	// have neither an entry in defaultQueueConcurrency nor an explicit
+	// QueueConcurrency override (e.g. operator-defined custom queues).
+	// Known queues use the per-queue hot-tuned defaults instead (see
+	// defaultQueueConcurrency), so this rarely takes effect. Zero falls
+	// back to 16.
+	//
+	// 旧挙動: total / len(queues) の均等割りだったが、それだと federation の
+	// hot queue (inbox / deliver) が starve するため per-queue default に
+	// 置き換えた。Concurrency は未知 queue 用の保険に降格。
 	Concurrency int
 
 	// QueueNames overrides the set of queues to pre-define. Nil/empty
@@ -58,11 +63,11 @@ type Config struct {
 	// behaviour pre-v1.0.1).
 	MaxMetricsDataPoints int
 
-	// QueueConcurrency overrides the per-queue worker pool size for
-	// the named queue. Zero / missing entries fall back to the default
-	// `total / len(queues)` distribution computed from Concurrency.
-	// Used by config keys like `deliverJobConcurrency` to tune the
-	// hot deliver queue independently from the rest (#495).
+	// QueueConcurrency overrides the per-queue worker pool size for the
+	// named queue. Zero / missing entries fall back to the per-queue
+	// hot-tuned defaults (defaultQueueConcurrency). Used by config keys
+	// like `deliverJobConcurrency` / `inboxJobConcurrency` to tune the
+	// hot queues independently from the rest (#495).
 	QueueConcurrency map[string]int
 
 	// QueueRateLimits caps each named queue at N tasks/sec via
@@ -174,15 +179,66 @@ func (d *Driver) Client() driver.Client {
 	return d.dClient
 }
 
+// defaultQueueConcurrency maps each logical queue to its default worker pool
+// size when the operator hasn't set an explicit <queue>JobConcurrency.
+//
+// mkq は asynq と違い per-queue 専用 worker pool を持つ (BullMQ と同じ構造)。
+// total budget を queue 数で均等割りすると federation の hot queue (inbox /
+// deliver) が starve する (例: total 16 / 6 queue = 2 worker)。queue-bench で
+// inbox=2 は inbound drain が asynq (共有プール 16) に明確に劣ることを確認した
+// ため、Misskey TS QueueProcessorService の per-queue default を基準に hot queue
+// を厚く、低頻度 queue を薄く配分する。
+//
+// worker 数 ≒ Redis 接続数 (mkq は worker 毎に BZPopMin で blocking 接続を 1 つ
+// 保持し、worker.go が "recommended pool = concurrency + 8" を warn する) なので、
+// 接続数を抑えるため deliver は upstream の 128 ではなく 16 に留める (outbound
+// bench で 2 worker でも BullMQ の 6.6x スループットがあり Go 側は余力十分)。
+// 合計 16+16+4+4+2+2 = 44 worker (推奨 Redis pool ≈ 52)。operator は
+// <queue>JobConcurrency でいつでも上書きできる。
+var defaultQueueConcurrency = map[string]int{
+	"inbox":       16, // = Misskey inboxJobConcurrency ?? 16
+	"deliver":     16, // upstream は 128 だが Go の per-worker 効率を踏まえ抑制
+	"webhook":     4,
+	"push":        4,
+	"export":      2,
+	"maintenance": 2,
+}
+
+// unknownQueueConcurrency is applied to any queue absent from
+// defaultQueueConcurrency (e.g. operator-defined custom queues).
+const unknownQueueConcurrency = 2
+
+// queueDefaultConcurrency returns the hot-tuned default pool size for a queue.
+func queueDefaultConcurrency(name string) int {
+	if c, ok := defaultQueueConcurrency[name]; ok {
+		return c
+	}
+	return unknownQueueConcurrency
+}
+
+// resolveQueueConcurrency builds the per-queue worker pool sizes from the
+// hot-tuned defaults, overlaid with explicit <queue>JobConcurrency overrides
+// (override > 0 wins). The result covers every registered queue so the Server
+// never falls back to Concurrency for a known queue.
+func resolveQueueConcurrency(queues []string, override map[string]int) map[string]int {
+	out := make(map[string]int, len(queues))
+	for _, name := range queues {
+		out[name] = queueDefaultConcurrency(name)
+	}
+	for name, v := range override {
+		if v > 0 {
+			out[name] = v
+		}
+	}
+	return out
+}
+
 // Server returns the lazily-constructed driver.Server.
 //
-// cfg.Concurrency is interpreted as a **total** worker budget across
-// all queues (matching asynq.Config.Concurrency semantics). mkq
-// applies WithConcurrency per queue, so the per-queue value is
-// `total / len(queues)` clamped to a minimum of 1 — without this
-// scaling an operator setting `deliverJobConcurrency: 16` would get
-// 80 goroutines (5 queues × 16) on the mkq driver, vs 16 on the
-// asynq driver, surprising operators migrating between the two.
+// Per-queue worker pool sizes come from defaultQueueConcurrency (hot-tuned
+// toward inbox / deliver) overlaid with explicit <queue>JobConcurrency
+// overrides. cfg.Concurrency only seeds the fallback used for queues without
+// a per-queue value (rare; all registered queues have a default).
 func (d *Driver) Server() driver.Server {
 	d.mu.Lock()
 	defer d.mu.Unlock()
@@ -195,9 +251,14 @@ func (d *Driver) Server() driver.Server {
 		if queues < 1 {
 			queues = 1
 		}
+		// fallback (未知 queue 用): 旧来の均等割りを保険として残す。
 		perQueue := total / queues
 		if perQueue < 1 {
 			perQueue = 1
+		}
+		queueNames := make([]string, 0, len(d.queues))
+		for name := range d.queues {
+			queueNames = append(queueNames, name)
 		}
 		metricsPoints := d.cfg.MaxMetricsDataPoints
 		if metricsPoints == 0 {
@@ -207,7 +268,7 @@ func (d *Driver) Server() driver.Server {
 			driver:             d,
 			concurrency:        perQueue,
 			maxMetricsPoints:   metricsPoints,
-			perQueueConcurrent: d.cfg.QueueConcurrency,
+			perQueueConcurrent: resolveQueueConcurrency(queueNames, d.cfg.QueueConcurrency),
 			perQueueRate:       d.cfg.QueueRateLimits,
 			handlers:           make(map[string]driver.HandlerFunc),
 		}

--- a/internal/queue/driver/mkqdriver/driver.go
+++ b/internal/queue/driver/mkqdriver/driver.go
@@ -119,7 +119,23 @@ type Driver struct {
 // New returns, the connection is shared by the driver's sub-services
 // for the rest of their lifetime.
 func New(ctx context.Context, cfg Config) (*Driver, error) {
-	mkqCfg := mkq.Config{Redis: cfg.Redis, KeyPrefix: cfg.KeyPrefix}
+	names := cfg.QueueNames
+	if len(names) == 0 {
+		names = QueueNames
+	}
+
+	// worker client の Redis pool を per-queue concurrency 合計で自動サイジング
+	// する。mkq は worker 毎に BZPopMin で blocking 接続を 1 つ保持するため、
+	// operator が poolSize を明示していない (= 0) ままだと go-redis default
+	// (10×GOMAXPROCS) が小コア機で worker 総数を下回り、接続待ちで dispatch が
+	// 詰まる (worker.go が "pool < concurrency+8" を warn する)。明示設定があれば
+	// 尊重する。side-channel rdb は低頻度なので default pool のままにする。
+	workerRedis := cfg.Redis
+	if workerRedis.PoolSize == 0 {
+		workerRedis.PoolSize = workerPoolSize(names, cfg.QueueConcurrency)
+	}
+
+	mkqCfg := mkq.Config{Redis: workerRedis, KeyPrefix: cfg.KeyPrefix}
 	client, err := mkq.NewClient(ctx, mkqCfg)
 	if err != nil {
 		return nil, fmt.Errorf("mkqdriver: connect: %w", err)
@@ -133,11 +149,6 @@ func New(ctx context.Context, cfg Config) (*Driver, error) {
 	keyPrefix := cfg.KeyPrefix
 	if keyPrefix == "" {
 		keyPrefix = defaultKeyPrefix
-	}
-
-	names := cfg.QueueNames
-	if len(names) == 0 {
-		names = QueueNames
 	}
 	queues := make(map[string]*mkq.Queue[framedPayload], len(names))
 	for _, n := range names {
@@ -193,8 +204,9 @@ func (d *Driver) Client() driver.Client {
 // 保持し、worker.go が "recommended pool = concurrency + 8" を warn する) なので、
 // 接続数を抑えるため deliver は upstream の 128 ではなく 16 に留める (outbound
 // bench で 2 worker でも BullMQ の 6.6x スループットがあり Go 側は余力十分)。
-// 合計 16+16+4+4+2+2 = 44 worker (推奨 Redis pool ≈ 52)。operator は
-// <queue>JobConcurrency でいつでも上書きできる。
+// 合計 16+16+4+4+2+2 = 44 worker。worker Redis pool は New() が
+// workerPoolSize() で自動的にこの合計 + poolHeadroom に合わせる。operator は
+// <queue>JobConcurrency でいつでも上書きできる (pool も追従する)。
 var defaultQueueConcurrency = map[string]int{
 	"inbox":       16, // = Misskey inboxJobConcurrency ?? 16
 	"deliver":     16, // upstream は 128 だが Go の per-worker 効率を踏まえ抑制
@@ -207,6 +219,26 @@ var defaultQueueConcurrency = map[string]int{
 // unknownQueueConcurrency is applied to any queue absent from
 // defaultQueueConcurrency (e.g. operator-defined custom queues).
 const unknownQueueConcurrency = 2
+
+// poolHeadroom is the spare Redis connection budget added on top of the
+// per-queue worker total so enqueue / Inspector-via-Client ops are not
+// starved while every BZPopMin worker holds a connection. Matches mkq's
+// own per-worker "concurrency + 8" recommendation applied once to the
+// shared pool.
+const poolHeadroom = 8
+
+// workerPoolSize sizes the worker Redis connection pool to the sum of the
+// resolved per-queue concurrency plus poolHeadroom. mkq holds one blocking
+// BZPopMin connection per worker, so the pool must cover every worker
+// simultaneously or dispatch stalls on connection acquisition.
+func workerPoolSize(queues []string, override map[string]int) int {
+	conc := resolveQueueConcurrency(queues, override)
+	sum := 0
+	for _, c := range conc {
+		sum += c
+	}
+	return sum + poolHeadroom
+}
 
 // queueDefaultConcurrency returns the hot-tuned default pool size for a queue.
 func queueDefaultConcurrency(name string) int {

--- a/internal/queue/driver/mkqdriver/driver.go
+++ b/internal/queue/driver/mkqdriver/driver.go
@@ -228,30 +228,36 @@ const unknownQueueConcurrency = 2
 // shared pool.
 const poolHeadroom = 8
 
-// workerPoolSize sizes the worker Redis connection pool to the sum of the
-// resolved per-queue concurrency plus poolHeadroom. mkq holds one blocking
-// BZPopMin connection per worker, so the pool must cover every worker
-// simultaneously or dispatch stalls on connection acquisition.
-//
-// The result is floored at go-redis' own default (10 × GOMAXPROCS) so this
-// auto-sizing never shrinks the pool below what an unset PoolSize would have
-// produced. That preserves enqueue-burst headroom on multi-core hosts and
-// leaves room for jobQueueAutoScale to grow workers past the static defaults
-// (auto-scale resizes workers but not the connection pool). Heavy auto-scale
-// deployments should still set redisForJobQueue.poolSize explicitly to cover
-// maxWorkers. Connections are created lazily (MinIdleConns=0) so a higher
-// ceiling costs nothing until load demands it.
+// workerPoolSize sizes the worker Redis connection pool for the resolved
+// per-queue concurrency. mkq holds one blocking BZPopMin connection per
+// worker, so the pool must cover every worker simultaneously or dispatch
+// stalls on connection acquisition. The headroom / floor policy lives in
+// poolSizeForWorkers; the floor is go-redis' own default (10 × GOMAXPROCS).
 func workerPoolSize(queues []string, override map[string]int) int {
 	conc := resolveQueueConcurrency(queues, override)
 	sum := 0
 	for _, c := range conc {
 		sum += c
 	}
-	need := sum + poolHeadroom
-	if goDefault := 10 * runtime.GOMAXPROCS(0); need < goDefault {
-		need = goDefault
-	}
-	return need
+	return poolSizeForWorkers(sum, 10*runtime.GOMAXPROCS(0))
+}
+
+// poolSizeForWorkers returns the Redis pool size for workerSum BZPopMin
+// workers: workerSum + poolHeadroom, floored at floor.
+//
+// floor is go-redis' own default (10 × GOMAXPROCS) so auto-sizing never
+// shrinks the pool below what an unset PoolSize would have produced. That
+// preserves enqueue-burst headroom on multi-core hosts and leaves room for
+// jobQueueAutoScale to grow workers past the static defaults (auto-scale
+// resizes workers but not the connection pool). Heavy auto-scale deployments
+// should still set redisForJobQueue.poolSize explicitly to cover maxWorkers.
+// Connections are created lazily (MinIdleConns=0) so a higher ceiling costs
+// nothing until load demands it.
+//
+// floor is passed in (rather than read from runtime here) so the headroom +
+// floor policy is unit-testable independently of the host core count.
+func poolSizeForWorkers(workerSum, floor int) int {
+	return max(workerSum+poolHeadroom, floor)
 }
 
 // queueDefaultConcurrency returns the hot-tuned default pool size for a queue.

--- a/internal/queue/driver/mkqdriver/integration_test.go
+++ b/internal/queue/driver/mkqdriver/integration_test.go
@@ -251,6 +251,42 @@ func TestServer_PerQueueConcurrency_CapsParallelHandlers(t *testing.T) {
 	}
 }
 
+// TestServer_DefaultPerQueueConcurrency_AppliesHotTunedPools locks the
+// end-to-end wiring (New -> Server -> Start -> per-queue worker pool) for the
+// hot-tuned defaults. The pure-function unit tests cover resolveQueueConcurrency
+// in isolation, but only this asserts that a driver built with no per-queue
+// override actually spawns the hot-tuned pool sizes — catching a regression if
+// Server() ever stops feeding resolveQueueConcurrency into the pools (#1374).
+func TestServer_DefaultPerQueueConcurrency_AppliesHotTunedPools(t *testing.T) {
+	testutil.SkipIfNoDocker(t)
+	flushRedis(t)
+
+	// QueueConcurrency / Concurrency を指定しない = コード default を使う。
+	d, err := mkqdriver.New(context.Background(), mkqdriver.Config{
+		Redis: redis.UniversalOptions{Addrs: []string{testRedis.Addr}},
+	})
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = d.Close() })
+
+	srv := d.Server()
+	srv.Handle("noop", func(context.Context, driver.Task) error { return nil })
+	require.NoError(t, srv.Start())
+	t.Cleanup(srv.Shutdown)
+
+	// 旧均等割り (16/6 = 2) ではなく hot-tuned default が実 pool に反映される。
+	want := map[string]int{
+		"inbox":       16,
+		"deliver":     16,
+		"webhook":     4,
+		"push":        4,
+		"export":      2,
+		"maintenance": 2,
+	}
+	for q, n := range want {
+		assert.Equal(t, n, d.WorkerCount(q), "queue %q default pool size", q)
+	}
+}
+
 // TestEnqueue_UnknownQueueRejects ensures the driver refuses to fall
 // back to a default queue for callers that forget WithQueue.
 func TestEnqueue_UnknownQueueRejects(t *testing.T) {

--- a/internal/queue/driver/mkqdriver/mkqdriver_test.go
+++ b/internal/queue/driver/mkqdriver/mkqdriver_test.go
@@ -494,3 +494,28 @@ func TestResolveQueueConcurrency_HotQueuesNotStarved(t *testing.T) {
 		t.Errorf("deliver default concurrency = %d, want > 2 (旧均等割りの starve 回帰)", got["deliver"])
 	}
 }
+
+func TestWorkerPoolSize(t *testing.T) {
+	queues := []string{"inbox", "deliver", "push", "export", "webhook", "maintenance"}
+
+	// default: 16+16+4+4+2+2 = 44, + poolHeadroom.
+	if got, want := workerPoolSize(queues, nil), 44+poolHeadroom; got != want {
+		t.Errorf("workerPoolSize(default) = %d, want %d", got, want)
+	}
+
+	// override は合計に反映され、pool もそれに追従する。
+	override := map[string]int{"deliver": 128}
+	if got, want := workerPoolSize(queues, override), (16+128+4+4+2+2)+poolHeadroom; got != want {
+		t.Errorf("workerPoolSize(deliver=128) = %d, want %d", got, want)
+	}
+
+	// pool は全 worker を同時に賄える (= 合計 worker 数以上) ことを保証する。
+	conc := resolveQueueConcurrency(queues, nil)
+	sum := 0
+	for _, c := range conc {
+		sum += c
+	}
+	if got := workerPoolSize(queues, nil); got < sum {
+		t.Errorf("workerPoolSize = %d, must be >= total workers %d", got, sum)
+	}
+}

--- a/internal/queue/driver/mkqdriver/mkqdriver_test.go
+++ b/internal/queue/driver/mkqdriver/mkqdriver_test.go
@@ -3,6 +3,7 @@ package mkqdriver
 import (
 	"context"
 	"errors"
+	"runtime"
 	"testing"
 	"time"
 
@@ -497,15 +498,16 @@ func TestResolveQueueConcurrency_HotQueuesNotStarved(t *testing.T) {
 
 func TestWorkerPoolSize(t *testing.T) {
 	queues := []string{"inbox", "deliver", "push", "export", "webhook", "maintenance"}
+	goDefault := 10 * runtime.GOMAXPROCS(0)
 
-	// default: 16+16+4+4+2+2 = 44, + poolHeadroom.
-	if got, want := workerPoolSize(queues, nil), 44+poolHeadroom; got != want {
+	// default: 16+16+4+4+2+2 = 44, + poolHeadroom, floored at go-redis default.
+	if got, want := workerPoolSize(queues, nil), max(44+poolHeadroom, goDefault); got != want {
 		t.Errorf("workerPoolSize(default) = %d, want %d", got, want)
 	}
 
 	// override は合計に反映され、pool もそれに追従する。
 	override := map[string]int{"deliver": 128}
-	if got, want := workerPoolSize(queues, override), (16+128+4+4+2+2)+poolHeadroom; got != want {
+	if got, want := workerPoolSize(queues, override), max((16+128+4+4+2+2)+poolHeadroom, goDefault); got != want {
 		t.Errorf("workerPoolSize(deliver=128) = %d, want %d", got, want)
 	}
 
@@ -517,5 +519,10 @@ func TestWorkerPoolSize(t *testing.T) {
 	}
 	if got := workerPoolSize(queues, nil); got < sum {
 		t.Errorf("workerPoolSize = %d, must be >= total workers %d", got, sum)
+	}
+
+	// go-redis default を下回らない (multi-core での pool 縮小退行を防ぐ)。
+	if got := workerPoolSize(queues, nil); got < goDefault {
+		t.Errorf("workerPoolSize = %d, must be >= go-redis default %d", got, goDefault)
 	}
 }

--- a/internal/queue/driver/mkqdriver/mkqdriver_test.go
+++ b/internal/queue/driver/mkqdriver/mkqdriver_test.go
@@ -439,3 +439,58 @@ func TestNewDispatchHandler_NormalReturn(t *testing.T) {
 
 // errIs aliases errors.Is so the dispatch tests read consistently.
 func errIs(err, target error) bool { return errors.Is(err, target) }
+
+func TestQueueDefaultConcurrency(t *testing.T) {
+	cases := map[string]int{
+		"inbox":       16,
+		"deliver":     16,
+		"webhook":     4,
+		"push":        4,
+		"export":      2,
+		"maintenance": 2,
+		"custom":      unknownQueueConcurrency, // unknown queue falls back to the modest default
+	}
+	for name, want := range cases {
+		if got := queueDefaultConcurrency(name); got != want {
+			t.Errorf("queueDefaultConcurrency(%q) = %d, want %d", name, got, want)
+		}
+	}
+}
+
+func TestResolveQueueConcurrency_DefaultsAndOverrides(t *testing.T) {
+	queues := []string{"inbox", "deliver", "push", "export", "webhook", "maintenance"}
+	override := map[string]int{
+		"inbox":   32, // override wins over the default 16
+		"deliver": 0,  // <=0 is ignored, leaving the default 16
+	}
+	got := resolveQueueConcurrency(queues, override)
+	want := map[string]int{
+		"inbox":       32,
+		"deliver":     16,
+		"push":        4,
+		"export":      2,
+		"webhook":     4,
+		"maintenance": 2,
+	}
+	if len(got) != len(want) {
+		t.Fatalf("resolveQueueConcurrency len = %d, want %d (%v)", len(got), len(want), got)
+	}
+	for name, w := range want {
+		if got[name] != w {
+			t.Errorf("queue %q concurrency = %d, want %d", name, got[name], w)
+		}
+	}
+}
+
+// #1374: 旧均等割り (total 16 / 6 queue = 2) では inbox / deliver が starve して
+// いた。default 状態で hot queue が 2 より十分大きいことを保証する回帰テスト。
+func TestResolveQueueConcurrency_HotQueuesNotStarved(t *testing.T) {
+	queues := []string{"inbox", "deliver", "push", "export", "webhook", "maintenance"}
+	got := resolveQueueConcurrency(queues, nil)
+	if got["inbox"] <= 2 {
+		t.Errorf("inbox default concurrency = %d, want > 2 (旧均等割りの starve 回帰)", got["inbox"])
+	}
+	if got["deliver"] <= 2 {
+		t.Errorf("deliver default concurrency = %d, want > 2 (旧均等割りの starve 回帰)", got["deliver"])
+	}
+}

--- a/internal/queue/driver/mkqdriver/mkqdriver_test.go
+++ b/internal/queue/driver/mkqdriver/mkqdriver_test.go
@@ -526,3 +526,26 @@ func TestWorkerPoolSize(t *testing.T) {
 		t.Errorf("workerPoolSize = %d, must be >= go-redis default %d", got, goDefault)
 	}
 }
+
+// TestPoolSizeForWorkers は floor / headroom ロジックを GOMAXPROCS 非依存で
+// 検証する。workerPoolSize は floor に 10×GOMAXPROCS を渡すためマシンの core
+// 数で floor-taken 分岐が実行されたりされなかったりするが、floor を引数化した
+// 本ヘルパーなら両分岐を決定的に covered にできる。
+func TestPoolSizeForWorkers(t *testing.T) {
+	cases := []struct {
+		name             string
+		workerSum, floor int
+		want             int
+	}{
+		{"floor applies when workers below floor", 44, 80, 80}, // max(44+8, 80)
+		{"workers+headroom above floor", 160, 80, 168},         // max(160+8, 80)
+		{"small floor ignored", 44, 20, 52},                    // max(44+8, 20)
+		{"equal to floor", 72, 80, 80},                         // max(72+8, 80)
+	}
+	for _, tc := range cases {
+		if got := poolSizeForWorkers(tc.workerSum, tc.floor); got != tc.want {
+			t.Errorf("%s: poolSizeForWorkers(%d, %d) = %d, want %d",
+				tc.name, tc.workerSum, tc.floor, got, tc.want)
+		}
+	}
+}


### PR DESCRIPTION
## Summary

queue-bench で mkq の inbound drain が asynq より明確に遅い原因を修正する。

mkq は asynq と違い **per-queue 専用 worker pool**(BullMQ と同じ構造)を持つ。従来は総budget `Concurrency`(default 16)を `total / len(queues)` で均等割りしていたため、6 queue 構成 (deliver/inbox/push/export/webhook/maintenance) で **inbox がデフォルト 16/6 = 2 worker** に絞られていた。asynq は単一共有プール 16 なので inbox backlog 時に最大 16 worker を充てられ、これが drain 差の主因だった。

### 計測 (inboxJobConcurrency を振った A/B/C, clean DB)

| inbox workers | inbound drain (s) |
|---|---|
| 2 (旧default) | 34.67 |
| 16 | 25.66 |
| 32 | 20.73 |

inbox=16 で asynq (~24s) を上回り、worker 数律速であることを確認。

## 主な変更点

- `internal/queue/driver/mkqdriver/driver.go`: per-queue default を均等割りから hot-tuned 固定値に置換。
  - inbox=16 (= Misskey `inboxJobConcurrency ?? 16`) / deliver=16 / webhook=4 / push=4 / export=2 / maintenance=2 (計 ~44 worker)。
  - worker 数 ≒ Redis 接続数 (mkq は worker 毎に BZPopMin で blocking 接続を保持) のため、deliver は upstream の 128 ではなく 16 に抑制 (outbound bench で 2 worker でも BullMQ の 6.6x あり Go では過剰)。
  - `<queue>JobConcurrency` 設定があれば従来どおり優先 (override > 0 wins)。`Concurrency`(総budget)は未知 queue 用 fallback に降格。
  - asynq driver は共有プールで該当しないため変更なし。
- `docs/configuration.md`: inbox default を 16 に、per-queue 既定値の説明を新挙動に更新。

## テスト

- unit test 追加 (Redis 不要): `TestQueueDefaultConcurrency` / `TestResolveQueueConcurrency_DefaultsAndOverrides` / `TestResolveQueueConcurrency_HotQueuesNotStarved` (旧均等割り starve の回帰防止)。
- `go test -race ./internal/queue/driver/mkqdriver/` パス、カバレッジ 90.9% (ゲート通過)。`go test -race ./...` 全パス。
- **queue-bench 検証** (clean DB, 設定なし = コード default): mkq inbound drain **34.67s → 22.06s (-36%)**、設定無しで asynq (23.31s) を上回ることを確認。

実行方法:
```
go test ./internal/queue/driver/mkqdriver/ -run 'TestQueueDefaultConcurrency|TestResolveQueueConcurrency'
make queue-bench-down && make queue-bench-up && make queue-bench-seed && make queue-bench-inbound && make queue-bench-report
```

## Closes

Closes #1374

🤖 Generated with [Claude Code](https://claude.com/claude-code)