### PR TITLE
perf(role): DefaultPolicies を共有 cache 化 (read-only caller の per-req alloc 解消)

### DIFF
--- a/internal/core/role/role_service.go
+++ b/internal/core/role/role_service.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"errors"
 	"log/slog"
+	"maps"
 	"math"
 	"sort"
 	"strings"
@@ -463,7 +464,9 @@ type rolePolicyOverride struct {
 // userID が "" の場合は base policies のみを返す (= upstream の userId==null
 // と同等)。
 func (s *Service) GetUserPolicies(userID string) map[string]any {
-	basePolicies := DefaultPolicies()
+	// applyMetaBasePolicies が basePolicies を mutate するため、共有 cache では
+	// なく clone を使う (DefaultPolicies の共有 map を壊さない、#1377)。
+	basePolicies := DefaultPoliciesClone()
 	s.applyMetaBasePolicies(basePolicies)
 
 	if userID == "" {
@@ -1009,8 +1012,34 @@ func (s *Service) Delete(id string) error {
 	return nil
 }
 
-// DefaultPolicies returns the Misskey default policies.
+// defaultPoliciesCache holds the immutable default policy map, built once at
+// package init. DefaultPolicies hands this shared instance to read-only
+// callers so high-traffic endpoints (meta calls it 3x/req, users/show, i)
+// avoid a per-request 39-entry map allocation — previously the single largest
+// allocation source (#1377, ~19% of all allocs in the HTTP bench), driving GC
+// pressure / tail latency.
+var defaultPoliciesCache = buildDefaultPolicies()
+
+// DefaultPolicies returns the shared, immutable Misskey default policies map.
+//
+// The returned map is shared across all callers and MUST NOT be mutated. Use
+// DefaultPoliciesClone when you need to overlay meta / role overrides.
 func DefaultPolicies() map[string]any {
+	return defaultPoliciesCache
+}
+
+// DefaultPoliciesClone returns a fresh mutable copy of the default policies for
+// callers that overlay values (e.g. GetUserPolicies merging meta / role
+// overrides). The clone is shallow, which is safe because all overlay paths
+// replace map entries by key rather than mutating the contained slice in place.
+func DefaultPoliciesClone() map[string]any {
+	return maps.Clone(defaultPoliciesCache)
+}
+
+// buildDefaultPolicies constructs the default policy map. Called once to seed
+// defaultPoliciesCache; do not call per-request (use DefaultPolicies /
+// DefaultPoliciesClone).
+func buildDefaultPolicies() map[string]any {
 	return map[string]any{
 		"gtlAvailable":               true,
 		"ltlAvailable":               true,

--- a/internal/core/role/role_service_test.go
+++ b/internal/core/role/role_service_test.go
@@ -866,6 +866,42 @@ func TestDefaultPolicies(t *testing.T) {
 	assert.Equal(t, 5, p["pinLimit"])
 }
 
+// #1377: DefaultPolicies は共有 cache を返すため、DefaultPoliciesClone は
+// 独立した copy でなければならない。clone を mutate しても共有 default が
+// 壊れないことを保証する (壊れると全リクエストの policy が汚染される)。
+func TestDefaultPoliciesClone_Isolation(t *testing.T) {
+	origDrive := role.DefaultPolicies()["driveCapacityMb"]
+
+	clone := role.DefaultPoliciesClone()
+	assert.Equal(t, origDrive, clone["driveCapacityMb"], "clone は同値で始まる")
+
+	clone["driveCapacityMb"] = 999999
+	clone["injected"] = true
+
+	assert.Equal(t, origDrive, role.DefaultPolicies()["driveCapacityMb"],
+		"clone の mutation が共有 default を破壊している")
+	_, leaked := role.DefaultPolicies()["injected"]
+	assert.False(t, leaked, "clone への key 追加が共有 default に漏れている")
+}
+
+// #1377: GetUserPolicies は applyMetaBasePolicies で base を mutate するため
+// clone を使う。meta override が共有 DefaultPolicies cache を汚染しないことを
+// 保証する (= 本最適化の安全性の要)。clone を使わないと本テストは fail する。
+func TestGetUserPolicies_MetaOverrideDoesNotCorruptSharedDefault(t *testing.T) {
+	svc, _, _, metaRepo := newTestService(t)
+	metaRepo.Meta = &model.Meta{
+		ID:       "x",
+		Policies: datatypes.JSON([]byte(`{"driveCapacityMb": 5000}`)),
+	}
+	origDrive := role.DefaultPolicies()["driveCapacityMb"] // = 100
+
+	got := svc.GetUserPolicies("") // userID="" → base + meta override のみ
+	assert.Equal(t, 5000, got["driveCapacityMb"], "meta override が反映される")
+
+	assert.Equal(t, origDrive, role.DefaultPolicies()["driveCapacityMb"],
+		"GetUserPolicies の meta override が共有 default を破壊している (#1377)")
+}
+
 func TestIsSilenced_DefaultIsFalse(t *testing.T) {
 	svc, _, _, _ := newTestService(t)
 	// 誰もロールを持っていない → DefaultPolicies は canPublicNote=true


### PR DESCRIPTION
## Summary

mk-go vs Misskey TS の HTTP ベンチ + pprof で `role.DefaultPolicies` が **alloc 首位(全 alloc の 19% / 4.8GB cumulative)** だったため、共有 cache 化する。

39 エントリの `map[string]any` を呼び出しごとに新規 alloc しており、特に `meta` handler は **1 req で 3 回**(うち 2 回は `PolicyBool(DefaultPolicies(), "...")` で **map 全体を alloc して bool を 1 個読むだけ**)呼んでいた。

## 主な変更点

- `DefaultPolicies()` を package init で 1 回構築した**共有不変 map** を返すよう変更。read-only caller(meta / frontend / signup / admin / users-show / i fallback)は alloc ゼロ化。
- 唯一 base を mutate する `GetUserPolicies`(`applyMetaBasePolicies` の meta overlay)のみ `DefaultPoliciesClone()` に切替。精査の結果 mutator はこの 1 経路のみで、role override merge は新 map を構築するため shallow clone で安全。
- `internal/core/role/role_service.go` のみ(他 caller は無変更で恩恵を受ける)。

## 計測結果(正直な記載)

50VU HTTP bench (`make bench-run`):

- **総 alloc: 24.82GB → 22.78GB(−8.2%)**。`DefaultPolicies` は alloc profile から消失。
- **p95 latency は誤差範囲で不変**(meta 10.0→10.3ms / notes-create 175.5→172.1ms / users-show 16.0→15.2ms)。

GC 圧の ~8% 減では 50VU の p95 tail は動かなかった。tail は別要因(背景 hook の DB 競合 / gorm-json alloc)が支配的。**本 PR は alloc 削減 + API 明確化の小幅な改善で、latency 改善は伴わない**(誇張しない)。

## テスト

- 回帰テスト追加: `TestDefaultPoliciesClone_Isolation`(clone の mutation 隔離)、`TestGetUserPolicies_MetaOverrideDoesNotCorruptSharedDefault`(meta override が共有 cache を汚染しないこと、clone を使わないと FAIL することを確認済み)。
- `go test -race ./internal/core/role/` カバレッジ 95.3%、`go test -race ./...` 全 pass。

## Closes

Closes #1377

🤖 Generated with [Claude Code](https://claude.com/claude-code)