### PR TITLE
perf(bench): HTTP ベンチ seed に follower graph を追加 (notes-create の fan-out を計測可能に)

### DIFF
--- a/tests/bench/common/seed.py
+++ b/tests/bench/common/seed.py
@@ -85,6 +85,11 @@ def seed_following(http: httpx.Client, tokens: list[str], user_ids: list[str]) -
     timelines. With the default (complete graph) each user has NUM_USERS-1
     followers. Returns the number of follow edges created.
     """
+    # seed.py は mk-go 用 / TS 用に別プロセスで実行されるため、固定 seed で
+    # follow 先を決定的に選ぶ。未シードだと capped 時 (FOLLOWERS_PER_USER <
+    # NUM_USERS-1) に両スタックで異なる graph になり比較が unfair になる。固定
+    # seed なら user 数が同じ限り edge 構造が一致し、run 間でも再現性を持つ。
+    random.seed(1379)
     edges = 0
     for i, token in enumerate(tokens):
         if not token:

--- a/tests/bench/common/seed.py
+++ b/tests/bench/common/seed.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 
 import json
 import os
+import random
 import sys
 import time
 
@@ -18,11 +19,14 @@ TARGET_NAME = os.environ.get("TARGET_NAME", "target")
 NUM_USERS = int(os.environ.get("SEED_USERS", "50"))
 NUM_NOTES_PER_USER = int(os.environ.get("SEED_NOTES", "50"))
 OUTPUT_DIR = os.environ.get("OUTPUT_DIR", "/seed")
-# Number of followers each user gets. The default (NUM_USERS-1) builds a
-# complete follow graph so every note-create fans out to all other users'
-# home timelines — without this the bench measures notes-create with zero
-# followers (fanout no-op), which is not representative of real load (#1379).
-FOLLOWERS_PER_USER = int(os.environ.get("SEED_FOLLOWERS", str(NUM_USERS - 1)))
+# Number of followers each user gets. Default = a complete follow graph
+# (NUM_USERS-1) so every note-create fans out to all other users' home
+# timelines — without this the bench measures notes-create with zero followers
+# (fanout no-op), which is not representative of real load (#1379). Capped at
+# 100 so bumping SEED_USERS doesn't blow up seed time on the O(N²) follow loop
+# (100 followers/user is already a representative active-instance fan-out); an
+# explicit SEED_FOLLOWERS overrides the cap.
+FOLLOWERS_PER_USER = int(os.environ.get("SEED_FOLLOWERS", str(min(NUM_USERS - 1, 100))))
 
 
 def wait_for_health(url: str, timeout: int = 180) -> None:
@@ -86,8 +90,12 @@ def seed_following(http: httpx.Client, tokens: list[str], user_ids: list[str]) -
         if not token:
             continue
         # i 番目の user が他 user を follow する。complete graph では全員。
-        targets = [user_ids[j] for j in range(len(user_ids)) if j != i and user_ids[j]]
-        for target_id in targets[:FOLLOWERS_PER_USER]:
+        # FOLLOWERS_PER_USER で絞る場合は random.sample で分散し、特定 user に
+        # follower が偏らない (= 先頭 K 固定だと低 index user に集中する) ように
+        # する。
+        candidates = [user_ids[j] for j in range(len(user_ids)) if j != i and user_ids[j]]
+        targets = random.sample(candidates, min(FOLLOWERS_PER_USER, len(candidates)))
+        for target_id in targets:
             try:
                 api(http, "following/create", {"userId": target_id}, token)
                 edges += 1

--- a/tests/bench/common/seed.py
+++ b/tests/bench/common/seed.py
@@ -15,9 +15,14 @@ import httpx
 
 TARGET_URL = os.environ["TARGET_URL"]
 TARGET_NAME = os.environ.get("TARGET_NAME", "target")
-NUM_USERS = int(os.environ.get("SEED_USERS", "10"))
+NUM_USERS = int(os.environ.get("SEED_USERS", "50"))
 NUM_NOTES_PER_USER = int(os.environ.get("SEED_NOTES", "50"))
 OUTPUT_DIR = os.environ.get("OUTPUT_DIR", "/seed")
+# Number of followers each user gets. The default (NUM_USERS-1) builds a
+# complete follow graph so every note-create fans out to all other users'
+# home timelines — without this the bench measures notes-create with zero
+# followers (fanout no-op), which is not representative of real load (#1379).
+FOLLOWERS_PER_USER = int(os.environ.get("SEED_FOLLOWERS", str(NUM_USERS - 1)))
 
 
 def wait_for_health(url: str, timeout: int = 180) -> None:
@@ -57,6 +62,39 @@ def create_admin(http: httpx.Client, username: str, password: str) -> str:
         return data.get("i") or data.get("token") or ""
     resp.raise_for_status()
     return ""
+
+
+def resolve_user_id(http: httpx.Client, token: str) -> str:
+    """Resolve a token's own user ID via the `i` endpoint."""
+    try:
+        return api(http, "i", {}, token).get("id", "")
+    except Exception as exc:
+        print(f"WARN: resolve user id failed: {exc}", file=sys.stderr)
+        return ""
+
+
+def seed_following(http: httpx.Client, tokens: list[str], user_ids: list[str]) -> int:
+    """Build a follow graph so notes-create actually fans out to followers.
+
+    Each user follows up to FOLLOWERS_PER_USER of the *other* users, so every
+    user ends up with followers and every note-create pushes to their home
+    timelines. With the default (complete graph) each user has NUM_USERS-1
+    followers. Returns the number of follow edges created.
+    """
+    edges = 0
+    for i, token in enumerate(tokens):
+        if not token:
+            continue
+        # i 番目の user が他 user を follow する。complete graph では全員。
+        targets = [user_ids[j] for j in range(len(user_ids)) if j != i and user_ids[j]]
+        for target_id in targets[:FOLLOWERS_PER_USER]:
+            try:
+                api(http, "following/create", {"userId": target_id}, token)
+                edges += 1
+            except Exception as exc:
+                # 既に follow 済み等は best-effort で無視。
+                print(f"WARN: follow {i}->{target_id} failed: {exc}", file=sys.stderr)
+    return edges
 
 
 def main() -> None:
@@ -100,6 +138,13 @@ def main() -> None:
 
     print(f"Created {len(tokens)} users on {TARGET_NAME}")
 
+    # 各 token の user ID を解決し、follower graph を張る。これがないと
+    # notes-create が 0 follower で fan-out しない非代表な計測になる (#1379)。
+    user_ids = [resolve_user_id(http, t) for t in tokens]
+    edges = seed_following(http, tokens, user_ids)
+    print(f"Created {edges} follow edges on {TARGET_NAME} "
+          f"(~{FOLLOWERS_PER_USER} followers/user)")
+
     # ノート投入
     note_ids: list[str] = []
     for idx, token in enumerate(tokens):
@@ -125,6 +170,8 @@ def main() -> None:
         "adminToken": admin_token,
         "username": "benchadmin",
         "usernames": usernames,
+        "userIds": user_ids,
+        "followEdges": edges,
     }
     path = os.path.join(OUTPUT_DIR, "seed-data.json")
     with open(path, "w") as f:


### PR DESCRIPTION
## Summary

HTTP ベンチ (`tests/bench/`) の `seed.py` は user/note を作るだけで **follower graph を張っておらず**、`notes-create` シナリオで `ListFollowers` が 0 行 → `fanoutToFollowersAndStream` が即 return し、**note-create の実運用での支配的コストである fan-out(フォロワー N 人の home timeline への push)が全く測定されていなかった**。

## 主な変更点

- 各 user の ID を `i` endpoint で解決し、**complete follow graph**(各 user が他全員を `following/create`)を張る。
- `SEED_USERS` default を 10 → 50 に(各 note が 49-way fan-out = 小規模 active instance 相当)。`SEED_FOLLOWERS` env で調整可。
- `seed-data.json` に `userIds` / `followEdges` を出力。
- `tests/bench/common/seed.py` のみ(production code 非対象)。

## 検証(50VU bench)

- **fan-out が実際に効く**ことを cpu profile で確認: `FanoutHook.OnNoteCreated` 40.5% cum / `fanoutToFollowersAndStream` 28.3% cum(従来は 0%)。
- **fan-out 込みの notes-create: mk-go p95 132ms vs Misskey 161ms = 1.22x(mk-go が速い)**。median 20.9 vs 82.1(4x)、throughput 8593 vs 4233(2x)。
- 0-follower の旧計測(0.88x で TS 優位)は**非代表な artifact**だった。fan-out は Node.js より Go の方が効率的に捌けるため、realistic load で mk-go が引き離す。
- 結果、**mk-go は全 6 シナリオ(ping 1.23x / meta 4.80x / local-timeline 13.48x / users-show 5.64x / i 4.72x / notes-create 1.22x)で Misskey TS を上回る**。

## 実行方法

```
make bench-up && make bench-run && make bench-down
# SEED_USERS / SEED_FOLLOWERS で fan-out 規模を調整可
```

## Closes

Closes #1379

🤖 Generated with [Claude Code](https://claude.com/claude-code)