### PR TITLE
test: logic層テストの盲点3件を補強 (LD-Sig round-trip / api/url / toDBFilter)

### DIFF
--- a/internal/activitypub/ld/verify_roundtrip_internal_test.go
+++ b/internal/activitypub/ld/verify_roundtrip_internal_test.go
@@ -1,0 +1,131 @@
+package ld
+
+import (
+	"crypto"
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/sha256"
+	"crypto/x509"
+	"encoding/base64"
+	"encoding/pem"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// signActivity produces a valid RsaSignature2017 signatureValue for the given
+// activity + signature options, using the exact same createVerifyData path the
+// verifier consumes. これは upstream JsonLdService.signRsaSignature2017 と等価な
+// 署名生成 (= createVerifyData → sha256 → RSA-PKCS1v15 SHA-256 sign)。
+//
+// production には sign 経路がまだ無いため、本 internal test 内で createVerifyData
+// を直接呼んで round-trip を成立させる。これにより「有効な署名が verify を通る」
+// positive case と「改竄で必ず mismatch する」case を単体で検証できる。
+func signActivity(t *testing.T, p *Processor, priv *rsa.PrivateKey, activity, sigOptions map[string]any) string {
+	t.Helper()
+	verifyData, err := p.createVerifyData(activity, sigOptions)
+	require.NoError(t, err)
+	finalHash := sha256.Sum256([]byte(verifyData))
+	sigBytes, err := rsa.SignPKCS1v15(rand.Reader, priv, crypto.SHA256, finalHash[:])
+	require.NoError(t, err)
+	return base64.StdEncoding.EncodeToString(sigBytes)
+}
+
+func rsaPubPEM(t *testing.T, priv *rsa.PrivateKey) string {
+	t.Helper()
+	pubDER, err := x509.MarshalPKIXPublicKey(&priv.PublicKey)
+	require.NoError(t, err)
+	return string(pem.EncodeToMemory(&pem.Block{Type: "PUBLIC KEY", Bytes: pubDER}))
+}
+
+// baseSignedActivity returns a minimal AS activity carrying a fully-populated
+// RsaSignature2017 signed with priv. caller は返り値を改竄して tampered case を
+// 作れる。
+func baseSignedActivity(t *testing.T, p *Processor, priv *rsa.PrivateKey) map[string]any {
+	t.Helper()
+	activity := map[string]any{
+		"@context":     "https://www.w3.org/ns/activitystreams",
+		"id":           "https://example.com/notes/n1",
+		"type":         "Note",
+		"content":      "hello world",
+		"attributedTo": "https://example.com/users/alice",
+	}
+	sigOptions := map[string]any{
+		"type":    LDSignatureType,
+		"creator": "https://example.com/users/alice#main-key",
+		"created": "2026-05-21T00:00:00Z",
+	}
+	sigValue := signActivity(t, p, priv, activity, sigOptions)
+
+	signature := make(map[string]any, len(sigOptions)+1)
+	for k, v := range sigOptions {
+		signature[k] = v
+	}
+	signature["signatureValue"] = sigValue
+	activity["signature"] = signature
+	return activity
+}
+
+// 有効な署名が verify を通って nil を返す positive round-trip。既存 verify_test.go
+// は異常系のみで、成功パスの単体検証が欠けていたギャップを埋める。
+func TestVerifyRsaSignature2017_ValidSignatureRoundTrip(t *testing.T) {
+	priv, err := rsa.GenerateKey(rand.Reader, 2048)
+	require.NoError(t, err)
+	p := NewProcessor()
+	activity := baseSignedActivity(t, p, priv)
+
+	// 検証は別 Processor instance で行う (= inbox 経路と同じく sign/verify が
+	// 独立した instance になる状況を再現)。
+	err = NewProcessor().VerifyRsaSignature2017(activity, rsaPubPEM(t, priv))
+	require.NoError(t, err, "valid RsaSignature2017 must verify successfully")
+}
+
+// 署名後に document 本体の field を改竄すると document hash が変わり、verify が
+// ErrSignatureMismatch で弾くこと。
+func TestVerifyRsaSignature2017_TamperedDocumentRejected(t *testing.T) {
+	priv, err := rsa.GenerateKey(rand.Reader, 2048)
+	require.NoError(t, err)
+	p := NewProcessor()
+	activity := baseSignedActivity(t, p, priv)
+
+	// signatureValue はそのままに content を書き換える (= MITM が本文を差し替え
+	// た状況)。
+	activity["content"] = "tampered content"
+
+	err = NewProcessor().VerifyRsaSignature2017(activity, rsaPubPEM(t, priv))
+	require.Error(t, err)
+	assert.ErrorIs(t, err, ErrSignatureMismatch)
+}
+
+// 署名後に signature options (created) を改竄すると options hash が変わり、verify
+// が ErrSignatureMismatch で弾くこと。
+func TestVerifyRsaSignature2017_TamperedOptionsRejected(t *testing.T) {
+	priv, err := rsa.GenerateKey(rand.Reader, 2048)
+	require.NoError(t, err)
+	p := NewProcessor()
+	activity := baseSignedActivity(t, p, priv)
+
+	sig := activity["signature"].(map[string]any)
+	sig["created"] = "2099-01-01T00:00:00Z"
+
+	err = NewProcessor().VerifyRsaSignature2017(activity, rsaPubPEM(t, priv))
+	require.Error(t, err)
+	assert.ErrorIs(t, err, ErrSignatureMismatch)
+}
+
+// 正しい署名でも別の鍵で verify すると弾かれること (= 鍵すり替え検知)。既存の
+// WrongKeyRejected は不正 signatureValue での縮退版だったが、本 test は「有効な
+// 署名 × 別鍵」という本来の鍵不一致シナリオを検証する。
+func TestVerifyRsaSignature2017_ValidSignatureWrongKeyRejected(t *testing.T) {
+	priv, err := rsa.GenerateKey(rand.Reader, 2048)
+	require.NoError(t, err)
+	other, err := rsa.GenerateKey(rand.Reader, 2048)
+	require.NoError(t, err)
+	p := NewProcessor()
+	activity := baseSignedActivity(t, p, priv)
+
+	err = NewProcessor().VerifyRsaSignature2017(activity, rsaPubPEM(t, other))
+	require.Error(t, err)
+	assert.ErrorIs(t, err, ErrSignatureMismatch)
+}

--- a/internal/activitypub/ld/verify_test.go
+++ b/internal/activitypub/ld/verify_test.go
@@ -194,14 +194,18 @@ func TestVerifyRsaSignature2017_BadBase64SignatureValue(t *testing.T) {
 	assert.ErrorIs(t, err, ld.ErrInvalidSignature)
 }
 
-// random RSA key で sign しても mk-go の verify が detect することを確認 (= 鍵
-// 不一致経路の sanity)。byte-for-byte TS 互換 verify は drop-in e2e で検証する。
+// signatureValue が短い不正値 (= RSA signature として復号できないサイズ) でも
+// verify が ErrSignatureMismatch で弾く negative case。
+//
+// 「有効な署名 × 別鍵 → ErrSignatureMismatch」という本来の鍵不一致シナリオは
+// verify_roundtrip_internal_test.go の ValidSignatureWrongKeyRejected で実署名を
+// 構築して検証している (内部テストから createVerifyData を呼べるため)。本 test は
+// 外部 package から到達可能な「短い signatureValue で verify が失敗する」経路を
+// 担保する。
 func TestVerifyRsaSignature2017_WrongKeyRejected(t *testing.T) {
 	p := ld.NewProcessor()
-	// 2 つの異なる鍵を生成し、片方で sign しているテスト用 fixture の verify に
-	// もう片方の公開鍵を渡すと ErrSignatureMismatch になる、という意図。
-	// ただし本 PR では mk-go 側に sign 経路がまだ無いので「empty signature
-	// payload で random pubkey に verify を回す」shape の test に縮退させる。
+	// random pubkey に対し短い不正 signatureValue ("AAAA") を verify に回すと
+	// rsa.VerifyPKCS1v15 が失敗して ErrSignatureMismatch になる。
 	otherKey, err := rsa.GenerateKey(rand.Reader, 2048)
 	require.NoError(t, err)
 	pubDER, err := x509.MarshalPKIXPublicKey(&otherKey.PublicKey)

--- a/internal/api/url/handler_test.go
+++ b/internal/api/url/handler_test.go
@@ -1,0 +1,105 @@
+package url_test
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/labstack/echo/v4"
+	"github.com/shiroha-a/mk/internal/api/apierr"
+	apiurl "github.com/shiroha-a/mk/internal/api/url"
+	"github.com/shiroha-a/mk/internal/core/urlpreview"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// doPreview builds an echo context for GET /api/url?url=<raw> and invokes the
+// handler, returning the recorder for assertions.
+func doPreview(h *apiurl.Handler, rawURL string) *httptest.ResponseRecorder {
+	e := echo.New()
+	target := "/api/url"
+	if rawURL != "" {
+		target += "?url=" + rawURL
+	}
+	req := httptest.NewRequest(http.MethodGet, target, nil)
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+	_ = h.Preview(c)
+	return rec
+}
+
+// url query param が空のとき 400 INVALID_PARAM を返す。
+func TestPreview_EmptyURL(t *testing.T) {
+	// fetcher は呼ばれない経路なので disabled で十分。
+	h := apiurl.NewHandler(urlpreview.NewFetcher(urlpreview.Config{Enabled: false}, nil, "", nil))
+	rec := doPreview(h, "")
+
+	assert.Equal(t, http.StatusBadRequest, rec.Code)
+	var body map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &body))
+	errObj := body["error"].(map[string]any)
+	assert.Equal(t, "INVALID_PARAM", errObj["code"])
+	assert.Equal(t, apierr.UUIDInvalidParam, errObj["id"])
+}
+
+// fetcher が error を返したとき、handler は HTTP 200 + 全 field null の degrade
+// body を返す (= upstream Misskey /api/url の「取得失敗でも 200 で空 card」挙動)。
+// degrade body の shape (key 一式 + null 初期化 + player object + url echo) を
+// 固定する。
+func TestPreview_FetcherError_DegradeBody(t *testing.T) {
+	// disabled fetcher は Fetch で ErrDisabled を返すので degrade 経路に入る。
+	h := apiurl.NewHandler(urlpreview.NewFetcher(urlpreview.Config{Enabled: false}, nil, "", nil))
+	rawURL := "https://example.com/article"
+	rec := doPreview(h, rawURL)
+
+	assert.Equal(t, http.StatusOK, rec.Code)
+	var body map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &body))
+
+	// メタ系は null、url は要求 URL を echo、sensitive は false。
+	for _, k := range []string{"title", "description", "thumbnail", "icon", "sitename", "activityPub"} {
+		assert.Nil(t, body[k], "degrade body の %q は null であること", k)
+	}
+	assert.Equal(t, rawURL, body["url"])
+	assert.Equal(t, false, body["sensitive"])
+
+	player, ok := body["player"].(map[string]any)
+	require.True(t, ok, "player は object であること")
+	assert.Nil(t, player["url"])
+	assert.Nil(t, player["width"])
+	assert.Nil(t, player["height"])
+	allow, ok := player["allow"].([]any)
+	require.True(t, ok, "player.allow は array であること")
+	assert.Empty(t, allow)
+}
+
+// fetcher が成功したとき、parse された Result をそのまま 200 で返す。
+func TestPreview_Success(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "text/html")
+		_, _ = w.Write([]byte(`<html><head>
+			<meta property="og:title" content="Hello">
+			<meta property="og:description" content="World">
+		</head><body></body></html>`))
+	}))
+	defer srv.Close()
+
+	f := urlpreview.NewFetcher(urlpreview.Config{
+		Enabled:          true,
+		AllowRedirect:    true,
+		TimeoutMs:        5000,
+		MaxContentLength: 1 << 20,
+	}, nil, "", nil)
+	// SetHTTPClient で SSRF-safe transport を上書きし、httptest (127.0.0.1) へ
+	// 到達できるようにする (= urlpreview/fetcher_test.go の既存パターン)。
+	f.SetHTTPClient(&http.Client{})
+	h := apiurl.NewHandler(f)
+
+	rec := doPreview(h, srv.URL)
+	assert.Equal(t, http.StatusOK, rec.Code)
+	var body map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &body))
+	assert.Equal(t, "Hello", body["title"])
+	assert.Equal(t, "World", body["description"])
+}

--- a/internal/api/url/handler_test.go
+++ b/internal/api/url/handler_test.go
@@ -102,4 +102,13 @@ func TestPreview_Success(t *testing.T) {
 	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &body))
 	assert.Equal(t, "Hello", body["title"])
 	assert.Equal(t, "World", body["description"])
+
+	// success 経路でも shape を固定する: og:url 無しなので url は要求 URL を
+	// echo、sensitive は false、player は object (plain HTML なので埋め込み
+	// player URL は無し)。degrade 経路との shape 一貫性を保証する。
+	assert.Equal(t, srv.URL, body["url"])
+	assert.Equal(t, false, body["sensitive"])
+	player, ok := body["player"].(map[string]any)
+	require.True(t, ok, "player は object であること")
+	assert.Nil(t, player["url"], "plain HTML では player.url は null")
 }

--- a/internal/core/timeline/todbfilter_mapping_test.go
+++ b/internal/core/timeline/todbfilter_mapping_test.go
@@ -1,0 +1,79 @@
+package timeline
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// toDBFilter の field pass-through を網羅的に固定する regression guard。
+//
+// 既存の TestToDBFilter_UseMutingSubquery は subquery 切替 / MutedUserIDs の
+// 意図的 drop / MutedChannelIDs / WithReplies を検証しているが、残りの
+// pass-through field (WithFiles / WithRenotes / IncludeMyRenotes /
+// IncludeRenotedMyNotes / IncludeLocalRenotes) と UseRenoteMutingSubquery は
+// 未検証だった。これらは TimelineFilter から model.TimelineDBFilter へ素通しで
+// 渡って SQL 経路の WHERE 条件を決めるため、conversion で取り落とすと timeline
+// の filter が静かに無効化される。ここで全 field の伝搬を lock する。
+func TestToDBFilter_AllFieldsMapped(t *testing.T) {
+	withRenotes := false
+	withReplies := true
+	includeMyRenotes := false
+	includeRenotedMyNotes := false
+	includeLocalRenotes := false
+
+	in := TimelineFilter{
+		WithFiles:             true,
+		WithRenotes:           &withRenotes,
+		WithReplies:           &withReplies,
+		IncludeMyRenotes:      &includeMyRenotes,
+		IncludeRenotedMyNotes: &includeRenotedMyNotes,
+		IncludeLocalRenotes:   &includeLocalRenotes,
+		MutedChannelIDs:       []string{"ch1", "ch2"},
+	}
+
+	out := toDBFilter(in, "viewer1")
+
+	assert.True(t, out.WithFiles)
+	if assert.NotNil(t, out.WithRenotes) {
+		assert.False(t, *out.WithRenotes)
+	}
+	if assert.NotNil(t, out.WithReplies) {
+		assert.True(t, *out.WithReplies)
+	}
+	if assert.NotNil(t, out.IncludeMyRenotes) {
+		assert.False(t, *out.IncludeMyRenotes)
+	}
+	if assert.NotNil(t, out.IncludeRenotedMyNotes) {
+		assert.False(t, *out.IncludeRenotedMyNotes)
+	}
+	if assert.NotNil(t, out.IncludeLocalRenotes) {
+		assert.False(t, *out.IncludeLocalRenotes)
+	}
+	assert.Equal(t, []string{"ch1", "ch2"}, out.MutedChannelIDs)
+
+	// viewerID 有なら mute / renote-mute の両 subquery が有効化される。
+	assert.True(t, out.UseMutingSubquery)
+	assert.True(t, out.UseRenoteMutingSubquery)
+}
+
+// anonymous viewer (viewerID == "") では renote-mute subquery も off になる。
+// 既存テストは UseMutingSubquery のみ確認していたので renote 側を補完する。
+func TestToDBFilter_AnonymousDisablesRenoteMutingSubquery(t *testing.T) {
+	out := toDBFilter(TimelineFilter{}, "")
+	assert.False(t, out.UseMutingSubquery)
+	assert.False(t, out.UseRenoteMutingSubquery)
+}
+
+// nil pointer の field は nil のまま伝搬する (= repository 側で default 解釈に
+// 委ねる)。zero-value の TimelineFilter を渡したときの shape を固定する。
+func TestToDBFilter_NilPointersPreserved(t *testing.T) {
+	out := toDBFilter(TimelineFilter{}, "viewer1")
+	assert.False(t, out.WithFiles)
+	assert.Nil(t, out.WithRenotes)
+	assert.Nil(t, out.WithReplies)
+	assert.Nil(t, out.IncludeMyRenotes)
+	assert.Nil(t, out.IncludeRenotedMyNotes)
+	assert.Nil(t, out.IncludeLocalRenotes)
+	assert.Empty(t, out.MutedChannelIDs)
+}


### PR DESCRIPTION
## Summary

プロジェクト評価で特定した logic 層テストの盲点 3 件を補強する。いずれも **production code 変更なし、テスト追加のみ**。3 issue を 1 PR に集約し、各 issue を 1 コミットに分割した。

## 主な変更点

### #1381 LD-Signature positive/tampered round-trip (`internal/activitypub/ld/`)
- 既存 `verify_test.go` は異常系のみで、**有効な署名が verify を通る positive case の単体テストが欠けていた** (コメント自体が縮退を認めていた)。
- 非公開 `createVerifyData` を内部テストから使い、正しい `RsaSignature2017` 署名を構築する round-trip を追加: valid → nil / tampered document / tampered options(created) / 別鍵 → `ErrSignatureMismatch`。
- これにより「verify が常に false / true を返すよう壊れても検出できない」状態を解消。coverage 91.1%。

### #1382 /api/url Preview handler (`internal/api/url/`)
- 唯一テストファイルが存在しなかったパッケージに `handler_test.go` を新設。
- empty url → 400 `INVALID_PARAM` / fetcher error → 200 + degrade body の shape (全 null + `player` object + `sensitive`=false + `url` echo) / success → 200 + Result を検証。
- fetcher は `urlpreview.NewFetcher` + `SetHTTPClient(httptest)` で注入 (既存 fetcher_test.go パターン踏襲)。coverage 100%。

### #1383 toDBFilter field mapping regression guard (`internal/core/timeline/`)
- 当初の「mock↔実SQL parity」前提は**無効と判明** (mock の timeline 系は `TimelineDBFilter` を `_` で無視する documented な no-op で、比較対象が存在しない。実 SQL の mute 意味論は repository testcontainer テストで既にカバー済み)。
- 真の残存リスクである filter 構築 `toDBFilter` の**未検証 field** (`WithFiles` / `WithRenotes` / `Include*` 系 / `UseRenoteMutingSubquery`) を網羅する regression guard へ pivot。issue 本文も更新済み。coverage 96.9%。

## テスト

- `make fmt && make lint && make test` 全 pass。
- 追加した 3 パッケージは `-race -count=1` でも pass、`go build ./...` OK、`gofmt -s` / `go vet` clean。
- 実行方法: `go test -race ./internal/activitypub/ld/... ./internal/api/url/... ./internal/core/timeline/...`

## Closes

Closes #1381
Closes #1382
Closes #1383

🤖 Generated with [Claude Code](https://claude.com/claude-code)