### PR TITLE
perf(timeline): first-page timeline 応答の per-viewer JSON cache (opt-in)

### DIFF
--- a/.config/default.yml.example
+++ b/.config/default.yml.example
@@ -364,6 +364,14 @@ proxyBypassHosts:
 # profiling. **DO NOT enable in production**.
 #enablePprof: false
 
+# Cache first-page timeline responses per-viewer for a short TTL, skipping
+# DB + packing + encode on hit. Opt-in: introduces up to
+# timelineCacheTtlSeconds of staleness (a freshly posted note may not appear
+# in the REST response for a few seconds; the WebSocket stream prepends it in
+# the meantime). Most effective for frequently-polled first pages.
+#enableTimelineCache: false
+#timelineCacheTtlSeconds: 3
+
 # Expose the Prometheus /metrics endpoint with job-queue metrics.
 # Unauthenticated; restrict access via nginx / LB ACL if exposed outside
 # the cluster. See docs/design/auto-scale-job-workers.md §6.1.

--- a/internal/api/notes/handler.go
+++ b/internal/api/notes/handler.go
@@ -63,13 +63,14 @@ type Handler struct {
 	// の draft を delayed queue に enqueue するための narrow interface (#1040)。
 	// nil 時は enqueue を skip する (= test fixture / queue 未配線パス互換)。
 	scheduledNoteEnqueuer ScheduledNoteEnqueuer
-	// timelineCache は experiment (MK_TIMELINE_JSON_CACHE) 有効時のみ non-nil。
-	// first-page timeline 応答を per-viewer で短期キャッシュする。
+	// timelineCache は config flag enableTimelineCache (MK_ENABLETIMELINECACHE)
+	// 有効時のみ non-nil。first-page timeline 応答を per-viewer で短期キャッシュする。
 	timelineCache *timelineJSONCache
 }
 
 // EnableTimelineJSONCache turns on the first-page timeline response cache with
-// the given TTL. 実験フラグ MK_TIMELINE_JSON_CACHE 経由で server 配線から呼ぶ。
+// the given TTL. config flag enableTimelineCache (MK_ENABLETIMELINECACHE) 経由で
+// server 配線から呼ぶ。
 func (h *Handler) EnableTimelineJSONCache(ttl time.Duration) {
 	h.timelineCache = newTimelineJSONCache(ttl)
 }

--- a/internal/api/notes/handler.go
+++ b/internal/api/notes/handler.go
@@ -63,6 +63,15 @@ type Handler struct {
 	// の draft を delayed queue に enqueue するための narrow interface (#1040)。
 	// nil 時は enqueue を skip する (= test fixture / queue 未配線パス互換)。
 	scheduledNoteEnqueuer ScheduledNoteEnqueuer
+	// timelineCache は experiment (MK_TIMELINE_JSON_CACHE) 有効時のみ non-nil。
+	// first-page timeline 応答を per-viewer で短期キャッシュする。
+	timelineCache *timelineJSONCache
+}
+
+// EnableTimelineJSONCache turns on the first-page timeline response cache with
+// the given TTL. 実験フラグ MK_TIMELINE_JSON_CACHE 経由で server 配線から呼ぶ。
+func (h *Handler) EnableTimelineJSONCache(ttl time.Duration) {
+	h.timelineCache = newTimelineJSONCache(ttl)
 }
 
 // ScheduledNoteEnqueuer abstracts the delayed enqueue path used by

--- a/internal/api/notes/timeline_cache.go
+++ b/internal/api/notes/timeline_cache.go
@@ -8,13 +8,13 @@ import (
 )
 
 // ----------------------------------------------------------------------------
-// timeline JSON cache (experiment, flag-gated via MK_TIMELINE_JSON_CACHE).
+// timeline JSON cache (flag-gated via enableTimelineCache / MK_ENABLETIMELINECACHE).
 //
 // timeline read hot path の driver 層最適化 (Joins / raw scan / pgx native) は
-// 全滅した (memory perf-findmanybyids-gorm)。本 cache は driver ではなく上位で、
-// first-page (cursor 無し) の最終 JSON レスポンスを per-viewer + per-param で短期
-// (TTL 3s) キャッシュし、hit 時に DB hydration + entity packing + JSON encode を
-// 丸ごとスキップする。
+// 全滅した。本 cache は driver ではなく上位で、first-page (cursor 無し) の最終
+// JSON レスポンスを per-viewer + per-param で短 TTL (default 3s、config 可変)
+// キャッシュし、hit 時に DB hydration + entity packing + JSON encode を丸ごと
+// スキップする。
 //
 // 設計上の割り切り:
 //   - first-page のみ (cursor 付き無限スクロールは hit 率低く対象外、メモリ有界化)。

--- a/internal/api/notes/timeline_cache.go
+++ b/internal/api/notes/timeline_cache.go
@@ -1,0 +1,119 @@
+package notes
+
+import (
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+)
+
+// ----------------------------------------------------------------------------
+// timeline JSON cache (experiment, flag-gated via MK_TIMELINE_JSON_CACHE).
+//
+// timeline read hot path の driver 層最適化 (Joins / raw scan / pgx native) は
+// 全滅した (memory perf-findmanybyids-gorm)。本 cache は driver ではなく上位で、
+// first-page (cursor 無し) の最終 JSON レスポンスを per-viewer + per-param で短期
+// (TTL 3s) キャッシュし、hit 時に DB hydration + entity packing + JSON encode を
+// 丸ごとスキップする。
+//
+// 設計上の割り切り:
+//   - first-page のみ (cursor 付き無限スクロールは hit 率低く対象外、メモリ有界化)。
+//   - per-viewer key (packMany は myReaction 等 viewer 固有 field を詰めるため)。
+//   - TTL 3s の staleness は許容する。frontend は新着を WebSocket stream で前置き
+//     するので REST の数秒遅延はほぼマスクされる。
+// ----------------------------------------------------------------------------
+
+type timelineCacheEntry struct {
+	body      []byte
+	expiresAt time.Time
+}
+
+// timelineJSONCache is a bounded in-memory TTL cache of marshaled timeline
+// responses. 単一 process 内のみ (multi-process では process ごとに別 cache だが
+// 応答の正しさは保たれる)。
+type timelineJSONCache struct {
+	mu         sync.Mutex
+	m          map[string]timelineCacheEntry
+	ttl        time.Duration
+	maxEntries int
+}
+
+func newTimelineJSONCache(ttl time.Duration) *timelineJSONCache {
+	return &timelineJSONCache{
+		m:          make(map[string]timelineCacheEntry),
+		ttl:        ttl,
+		maxEntries: 50000,
+	}
+}
+
+// get returns the cached body if present and unexpired. 期限切れ entry は lazy に
+// 削除する。
+func (c *timelineJSONCache) get(key string, now time.Time) ([]byte, bool) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	e, ok := c.m[key]
+	if !ok {
+		return nil, false
+	}
+	if now.After(e.expiresAt) {
+		delete(c.m, key)
+		return nil, false
+	}
+	return e.body, true
+}
+
+// set stores body under key with the configured TTL. 上限到達時はまず期限切れを
+// 掃き、それでも上限なら今回は cache しない (= bounded、メモリ無制限増加を防ぐ)。
+func (c *timelineJSONCache) set(key string, body []byte, now time.Time) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if len(c.m) >= c.maxEntries {
+		for k, e := range c.m {
+			if now.After(e.expiresAt) {
+				delete(c.m, k)
+			}
+		}
+		if len(c.m) >= c.maxEntries {
+			return
+		}
+	}
+	c.m[key] = timelineCacheEntry{body: body, expiresAt: now.Add(c.ttl)}
+}
+
+// timelineCacheKey builds a cache key from everything that affects the output
+// for a first-page request. cursor (sinceId/untilId) は first-page では空なので
+// 含めない。出力に影響する param を取り落とすと別 viewer/別条件の応答を誤配する
+// ため、TimelineRequest の出力影響 field を全て織り込む。
+func timelineCacheKey(kind, viewerID string, req TimelineRequest) string {
+	return strings.Join([]string{
+		kind,
+		viewerID,
+		strconv.Itoa(req.Limit),
+		boolKey(req.WithFiles),
+		ptrBoolKey(req.WithRenotes),
+		ptrBoolKey(req.WithReplies),
+		ptrBoolKey(req.IncludeMyRenotes),
+		ptrBoolKey(req.IncludeRenotedMyNotes),
+		ptrBoolKey(req.IncludeLocalRenotes),
+		boolKey(req.AllowPartial),
+	}, "|")
+}
+
+func boolKey(b bool) string {
+	if b {
+		return "1"
+	}
+	return "0"
+}
+
+// ptrBoolKey distinguishes nil / true / false (nil は upstream default 解釈で
+// 出力が変わるため別 key にする)。
+func ptrBoolKey(b *bool) string {
+	if b == nil {
+		return "n"
+	}
+	if *b {
+		return "1"
+	}
+	return "0"
+}

--- a/internal/api/notes/timeline_cache_test.go
+++ b/internal/api/notes/timeline_cache_test.go
@@ -1,0 +1,78 @@
+package notes
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func boolPtr(b bool) *bool { return &b }
+
+func TestTimelineJSONCache_GetSetTTL(t *testing.T) {
+	c := newTimelineJSONCache(3 * time.Second)
+	base := time.Unix(1000, 0)
+
+	// miss before set
+	_, ok := c.get("k", base)
+	assert.False(t, ok)
+
+	c.set("k", []byte(`[{"id":"a"}]`), base)
+
+	// hit within TTL
+	body, ok := c.get("k", base.Add(2*time.Second))
+	assert.True(t, ok)
+	assert.Equal(t, `[{"id":"a"}]`, string(body))
+
+	// miss after TTL (期限切れは lazy 削除される)
+	_, ok = c.get("k", base.Add(4*time.Second))
+	assert.False(t, ok)
+	// 削除済みなので TTL 内 now で再 get しても miss
+	_, ok = c.get("k", base.Add(2*time.Second))
+	assert.False(t, ok)
+}
+
+// timelineCacheKey は出力に影響する全 param で別 key になること (= 別 viewer /
+// 別条件の応答を取り違えない)。同一 param なら同一 key。
+func TestTimelineCacheKey_Distinguishes(t *testing.T) {
+	baseReq := TimelineRequest{Limit: 10}
+	base := timelineCacheKey("home", "u1", baseReq)
+
+	// 同一条件 → 同一 key
+	assert.Equal(t, base, timelineCacheKey("home", "u1", TimelineRequest{Limit: 10}))
+
+	// 差分はすべて別 key
+	assert.NotEqual(t, base, timelineCacheKey("local", "u1", baseReq), "kind")
+	assert.NotEqual(t, base, timelineCacheKey("home", "u2", baseReq), "viewer")
+	assert.NotEqual(t, base, timelineCacheKey("home", "u1", TimelineRequest{Limit: 20}), "limit")
+	assert.NotEqual(t, base, timelineCacheKey("home", "u1", TimelineRequest{Limit: 10, WithFiles: true}), "withFiles")
+	assert.NotEqual(t, base, timelineCacheKey("home", "u1", TimelineRequest{Limit: 10, AllowPartial: true}), "allowPartial")
+
+	// pointer bool は nil / true / false で 3 通り別 key
+	kNil := timelineCacheKey("home", "u1", TimelineRequest{Limit: 10, WithRenotes: nil})
+	kTrue := timelineCacheKey("home", "u1", TimelineRequest{Limit: 10, WithRenotes: boolPtr(true)})
+	kFalse := timelineCacheKey("home", "u1", TimelineRequest{Limit: 10, WithRenotes: boolPtr(false)})
+	assert.NotEqual(t, kNil, kTrue)
+	assert.NotEqual(t, kNil, kFalse)
+	assert.NotEqual(t, kTrue, kFalse)
+}
+
+// 上限到達時は期限切れを掃いて bounded に保ち、それでも上限なら cache しない。
+func TestTimelineJSONCache_Bounded(t *testing.T) {
+	c := newTimelineJSONCache(3 * time.Second)
+	c.maxEntries = 2
+	base := time.Unix(1000, 0)
+
+	c.set("a", []byte("1"), base)
+	c.set("b", []byte("2"), base)
+	// 上限到達。全 entry が未期限なので "c" は cache されない。
+	c.set("c", []byte("3"), base)
+	_, okC := c.get("c", base)
+	assert.False(t, okC, "上限到達かつ全 entry 未期限なら新規は cache しない")
+
+	// a が期限切れになれば sweep されて空きができ、新規を入れられる。
+	c.set("d", []byte("4"), base.Add(4*time.Second))
+	body, okD := c.get("d", base.Add(4*time.Second))
+	assert.True(t, okD, "期限切れ sweep 後は空きに入る")
+	assert.Equal(t, "4", string(body))
+}

--- a/internal/api/notes/timeline_handler.go
+++ b/internal/api/notes/timeline_handler.go
@@ -1,8 +1,10 @@
 package notes
 
 import (
+	"encoding/json"
 	"log/slog"
 	"net/http"
+	"time"
 
 	"github.com/labstack/echo/v4"
 	"github.com/shiroha-a/mk/internal/api/apierr"
@@ -78,7 +80,7 @@ func (h *Handler) timelineAvailable(c echo.Context, policyKey string) bool {
 
 // Timeline handles POST /api/notes/timeline (home timeline).
 func (h *Handler) Timeline(c echo.Context) error {
-	return h.serveTimeline(c, func(viewer *model.User, req TimelineRequest) ([]*model.Note, error) {
+	return h.serveTimeline(c, "home", func(viewer *model.User, req TimelineRequest) ([]*model.Note, error) {
 		f := timeline.TimelineFilter{
 			WithFiles:             req.WithFiles,
 			WithRenotes:           req.WithRenotes,
@@ -100,7 +102,7 @@ func (h *Handler) LocalTimeline(c echo.Context) error {
 	if !h.timelineAvailable(c, policyKeyLtlAvailable) {
 		return apierr.JSONLtlDisabled(c)
 	}
-	return h.serveTimeline(c, func(viewer *model.User, req TimelineRequest) ([]*model.Note, error) {
+	return h.serveTimeline(c, "local", func(viewer *model.User, req TimelineRequest) ([]*model.Note, error) {
 		f := timeline.TimelineFilter{
 			WithFiles:          req.WithFiles,
 			WithRenotes:        req.WithRenotes,
@@ -120,7 +122,7 @@ func (h *Handler) GlobalTimeline(c echo.Context) error {
 	if !h.timelineAvailable(c, policyKeyGtlAvailable) {
 		return apierr.JSONGtlDisabled(c)
 	}
-	return h.serveTimeline(c, func(viewer *model.User, req TimelineRequest) ([]*model.Note, error) {
+	return h.serveTimeline(c, "global", func(viewer *model.User, req TimelineRequest) ([]*model.Note, error) {
 		f := timeline.TimelineFilter{
 			WithFiles:          req.WithFiles,
 			WithRenotes:        req.WithRenotes,
@@ -141,7 +143,7 @@ func (h *Handler) HybridTimeline(c echo.Context) error {
 	if !h.timelineAvailable(c, policyKeyLtlAvailable) {
 		return apierr.JSONLtlDisabled(c)
 	}
-	return h.serveTimeline(c, func(viewer *model.User, req TimelineRequest) ([]*model.Note, error) {
+	return h.serveTimeline(c, "hybrid", func(viewer *model.User, req TimelineRequest) ([]*model.Note, error) {
 		f := timeline.TimelineFilter{
 			WithFiles:             req.WithFiles,
 			WithRenotes:           req.WithRenotes,
@@ -218,6 +220,7 @@ func (h *Handler) loadRenoteMutedUserIDs(viewer *model.User) []string {
 // timeline endpoints. requireAuthがtrueのときviewer==nilで401相当を返す。
 func (h *Handler) serveTimeline(
 	c echo.Context,
+	kind string,
 	fn func(*model.User, TimelineRequest) ([]*model.Note, error),
 	requireAuth bool,
 ) error {
@@ -245,11 +248,37 @@ func (h *Handler) serveTimeline(
 		return c.JSON(http.StatusOK, []any{})
 	}
 
+	// experiment: first-page (cursor 無し) のみ JSON cache を引く。hit 時は DB +
+	// pack + encode を丸ごとスキップ。cache 無効時 / cursor 付きは cacheKey="" で
+	// 従来通り c.JSON 経路を通る (= default 挙動は byte 一致のまま)。
+	var cacheKey string
+	if h.timelineCache != nil && req.SinceID == "" && req.UntilID == "" {
+		vid := "anon"
+		if viewer != nil {
+			vid = viewer.ID
+		}
+		cacheKey = timelineCacheKey(kind, vid, req)
+		if body, ok := h.timelineCache.get(cacheKey, time.Now()); ok {
+			return c.JSONBlob(http.StatusOK, body)
+		}
+	}
+
 	notes, err := fn(viewer, req)
 	if err != nil {
 		// requireAuthでviewer nilチェックは事前に行っているので、Service層からの
 		// ErrUnauthenticatedはここには到達しない。残りはRedis等の障害のみ。
 		return apierr.JSONInternalError(c)
 	}
-	return c.JSON(http.StatusOK, h.packMany(c.Request().Context(), notes, viewer))
+	packed := h.packMany(c.Request().Context(), notes, viewer)
+	if cacheKey != "" {
+		if body, mErr := json.Marshal(packed); mErr == nil {
+			// echo の c.JSON は json.Encoder 経由で末尾に改行を付ける。cache 経路も
+			// 同じ byte 列にして default (c.JSON) 経路と応答を一致させる。
+			body = append(body, '\n')
+			h.timelineCache.set(cacheKey, body, time.Now())
+			return c.JSONBlob(http.StatusOK, body)
+		}
+		// marshal 失敗時は通常の c.JSON 経路へ fallthrough。
+	}
+	return c.JSON(http.StatusOK, packed)
 }

--- a/internal/api/notes/timeline_handler_test.go
+++ b/internal/api/notes/timeline_handler_test.go
@@ -369,3 +369,135 @@ func TestTimeline_HappyPathHybrid(t *testing.T) {
 	require.NoError(t, h.HybridTimeline(c))
 	require.Equal(t, http.StatusOK, rec.Code)
 }
+
+// timeline JSON cache (enableTimelineCache) の handler-level 統合テスト。
+// cache primitive の unit test (timeline_cache_test.go) とは別に、serveTimeline
+// への組み込み (first-page gate / key 構築 / cursor bypass / per-viewer 分離 /
+// c.JSON との byte 一致) を検証する。
+
+// first-page は cache され、TTL 内の 2nd request は 1st と byte 一致で stale を
+// 返す (= cache hit が効いている証拠)。
+func TestTimeline_Cache_ServesStaleWithinTTL(t *testing.T) {
+	noteRepo := testutil.NewMockNoteRepository()
+	note1 := seedTimelineNote(noteRepo)
+	tl, fanout := newRealTimelineService(t, noteRepo)
+	ctx := context.Background()
+	require.NoError(t, fanout.Push(ctx, coretimeline.LocalTimeline, note1, 100))
+
+	h := newTimelineHandler(t, noteRepo, tl)
+	h.EnableTimelineJSONCache(3 * time.Second)
+
+	c1, rec1 := newJSONRequest(t, "/api/notes/local-timeline", `{}`)
+	require.NoError(t, h.LocalTimeline(c1))
+	require.Equal(t, http.StatusOK, rec1.Code)
+	body1 := rec1.Body.String()
+	var resp1 []map[string]any
+	require.NoError(t, json.Unmarshal([]byte(body1), &resp1))
+	require.Len(t, resp1, 1)
+
+	// データを変える。cache が効いていれば 2nd には反映されない。
+	note2 := seedTimelineNote(noteRepo)
+	require.NoError(t, fanout.Push(ctx, coretimeline.LocalTimeline, note2, 100))
+
+	c2, rec2 := newJSONRequest(t, "/api/notes/local-timeline", `{}`)
+	require.NoError(t, h.LocalTimeline(c2))
+	require.Equal(t, http.StatusOK, rec2.Code)
+	assert.Equal(t, body1, rec2.Body.String(), "cache hit は 1st と byte 一致 (stale)")
+	var resp2 []map[string]any
+	require.NoError(t, json.Unmarshal(rec2.Body.Bytes(), &resp2))
+	assert.Len(t, resp2, 1, "cache hit なので note2 は反映されない")
+}
+
+// cursor (untilId) 付き request は cache を bypass し fresh データを返す。
+func TestTimeline_Cache_CursorBypasses(t *testing.T) {
+	noteRepo := testutil.NewMockNoteRepository()
+	note1 := seedTimelineNote(noteRepo)
+	tl, fanout := newRealTimelineService(t, noteRepo)
+	ctx := context.Background()
+	require.NoError(t, fanout.Push(ctx, coretimeline.LocalTimeline, note1, 100))
+
+	h := newTimelineHandler(t, noteRepo, tl)
+	h.EnableTimelineJSONCache(3 * time.Second)
+
+	// first-page を 1 回引いて cache を温める。
+	c0, rec0 := newJSONRequest(t, "/api/notes/local-timeline", `{}`)
+	require.NoError(t, h.LocalTimeline(c0))
+	require.Equal(t, http.StatusOK, rec0.Code)
+
+	note2 := seedTimelineNote(noteRepo)
+	require.NoError(t, fanout.Push(ctx, coretimeline.LocalTimeline, note2, 100))
+
+	// untilId 付き → cache を bypass して fresh (note1 + note2)。
+	c1, rec1 := newJSONRequest(t, "/api/notes/local-timeline", `{"untilId":"zzzzzzzzzzzzzzzz"}`)
+	require.NoError(t, h.LocalTimeline(c1))
+	require.Equal(t, http.StatusOK, rec1.Code)
+	var resp []map[string]any
+	require.NoError(t, json.Unmarshal(rec1.Body.Bytes(), &resp))
+	assert.Len(t, resp, 2, "cursor 付きは cache を bypass し fresh データ (2 件) を返す")
+}
+
+// per-viewer key: viewer A の cache が viewer B へ漏れない。local-timeline は
+// fanout list を共有するが cache key は viewerID で分かれる。A が cache を温めた
+// 後にデータを増やすと、別 viewer B は fresh (= A の stale cache を受けない)、
+// 一方 A 自身は stale cache を引く、という非対称で isolation を示す。
+func TestTimeline_Cache_PerViewerIsolation(t *testing.T) {
+	noteRepo := testutil.NewMockNoteRepository()
+	note1 := seedTimelineNote(noteRepo)
+	tl, fanout := newRealTimelineService(t, noteRepo)
+	ctx := context.Background()
+	require.NoError(t, fanout.Push(ctx, coretimeline.LocalTimeline, note1, 100))
+
+	h := newTimelineHandler(t, noteRepo, tl)
+	h.EnableTimelineJSONCache(3 * time.Second)
+
+	// viewer A が cache を温める (note1 のみ)。
+	cA, recA := newJSONRequest(t, "/api/notes/local-timeline", `{}`)
+	setAuthUser(cA, &model.User{ID: "A"})
+	require.NoError(t, h.LocalTimeline(cA))
+	require.Equal(t, http.StatusOK, recA.Code)
+	var rA []map[string]any
+	require.NoError(t, json.Unmarshal(recA.Body.Bytes(), &rA))
+	require.Len(t, rA, 1)
+
+	// データを増やす。
+	note2 := seedTimelineNote(noteRepo)
+	require.NoError(t, fanout.Push(ctx, coretimeline.LocalTimeline, note2, 100))
+
+	// viewer B は別 key なので miss → fresh (2 件)。A の 1 件 cache を受けない。
+	cB, recB := newJSONRequest(t, "/api/notes/local-timeline", `{}`)
+	setAuthUser(cB, &model.User{ID: "B"})
+	require.NoError(t, h.LocalTimeline(cB))
+	require.Equal(t, http.StatusOK, recB.Code)
+	var rB []map[string]any
+	require.NoError(t, json.Unmarshal(recB.Body.Bytes(), &rB))
+	assert.Len(t, rB, 2, "別 viewer B は fresh (2 件) を受け取る (A の stale cache を受けない)")
+
+	// viewer A は自分の key で hit → stale (1 件) のまま。
+	cA2, recA2 := newJSONRequest(t, "/api/notes/local-timeline", `{}`)
+	setAuthUser(cA2, &model.User{ID: "A"})
+	require.NoError(t, h.LocalTimeline(cA2))
+	var rA2 []map[string]any
+	require.NoError(t, json.Unmarshal(recA2.Body.Bytes(), &rA2))
+	assert.Len(t, rA2, 1, "viewer A は自分の cache で stale (1 件)")
+}
+
+// cache miss 経路 (marshal + 改行) の応答が cache 無効時の c.JSON 経路と byte 一致
+// すること (= 改行整合の回帰 guard)。
+func TestTimeline_Cache_ByteIdenticalToNonCached(t *testing.T) {
+	noteRepo := testutil.NewMockNoteRepository()
+	note1 := seedTimelineNote(noteRepo)
+	tl, fanout := newRealTimelineService(t, noteRepo)
+	require.NoError(t, fanout.Push(context.Background(), coretimeline.LocalTimeline, note1, 100))
+
+	hNo := newTimelineHandler(t, noteRepo, tl)
+	cNo, recNo := newJSONRequest(t, "/api/notes/local-timeline", `{}`)
+	require.NoError(t, hNo.LocalTimeline(cNo))
+
+	hYes := newTimelineHandler(t, noteRepo, tl)
+	hYes.EnableTimelineJSONCache(3 * time.Second)
+	cYes, recYes := newJSONRequest(t, "/api/notes/local-timeline", `{}`)
+	require.NoError(t, hYes.LocalTimeline(cYes))
+
+	assert.Equal(t, recNo.Body.String(), recYes.Body.String(),
+		"cache miss 経路 (marshal+改行) は c.JSON 経路と byte 一致")
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -247,6 +247,16 @@ type Source struct {
 	// For local profiling only; must not be enabled in production.
 	EnablePprof bool `mapstructure:"enablePprof"`
 
+	// EnableTimelineCache caches first-page timeline responses per-viewer for
+	// a short TTL, skipping DB hydration + packing + encode on hit. Opt-in
+	// (default false) because it introduces up to TimelineCacheTTLSeconds of
+	// staleness (a freshly posted note may not appear in the REST response
+	// for a few seconds; the WebSocket stream prepends it in the meantime).
+	EnableTimelineCache bool `mapstructure:"enableTimelineCache"`
+	// TimelineCacheTTLSeconds is the TTL for EnableTimelineCache. Defaults to
+	// 3 when unset (<= 0).
+	TimelineCacheTTLSeconds int `mapstructure:"timelineCacheTtlSeconds"`
+
 	// EnableMetrics registers a Prometheus /metrics endpoint exposing the
 	// job-queue metrics defined in internal/queue/metrics (worker count /
 	// queue depth / scale events). Defaults to false. Operators that
@@ -371,6 +381,13 @@ type Config struct {
 	// EnablePprof registers net/http/pprof handlers at /debug/pprof/*.
 	EnablePprof bool
 
+	// EnableTimelineCache caches first-page timeline responses per-viewer for
+	// TimelineCacheTTLSeconds. Opt-in; see the source struct doc for the
+	// staleness trade-off.
+	EnableTimelineCache bool
+	// TimelineCacheTTLSeconds is the TTL for EnableTimelineCache (default 3).
+	TimelineCacheTTLSeconds int
+
 	// EnableMetrics registers the Prometheus /metrics endpoint. See
 	// internal/queue/metrics for the exposed metric catalog.
 	EnableMetrics bool
@@ -451,6 +468,8 @@ func bindEnvKeys(v *viper.Viper) {
 		"logging.sql.disableQueryTruncation",
 		"logging.sql.enableQueryParamLogging",
 		"enablePprof",
+		"enableTimelineCache",
+		"timelineCacheTtlSeconds",
 		"enableMetrics",
 		"sentryForBackend.options.dsn",
 		"sentryForBackend.options.environment",
@@ -605,9 +624,11 @@ func resolve(src *Source) (*Config, error) {
 
 		TrustProxy: resolveTrustProxy(src.TrustProxy),
 
-		TestMode:      src.TestMode,
-		EnablePprof:   src.EnablePprof,
-		EnableMetrics: src.EnableMetrics,
+		TestMode:                src.TestMode,
+		EnablePprof:             src.EnablePprof,
+		EnableTimelineCache:     src.EnableTimelineCache,
+		TimelineCacheTTLSeconds: src.TimelineCacheTTLSeconds,
+		EnableMetrics:           src.EnableMetrics,
 
 		SentryForBackend:  src.SentryForBackend,
 		SentryForFrontend: src.SentryForFrontend,

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -826,6 +826,26 @@ func TestLoad_EnablePprof_DefaultFalse(t *testing.T) {
 	assert.False(t, cfg.EnablePprof)
 }
 
+func TestLoad_EnableTimelineCache(t *testing.T) {
+	yaml := testYAML + `
+enableTimelineCache: true
+timelineCacheTtlSeconds: 5
+`
+	path := writeTestConfig(t, yaml)
+	cfg, err := Load(path)
+	require.NoError(t, err)
+	assert.True(t, cfg.EnableTimelineCache)
+	assert.Equal(t, 5, cfg.TimelineCacheTTLSeconds)
+}
+
+func TestLoad_EnableTimelineCache_DefaultFalse(t *testing.T) {
+	path := writeTestConfig(t, testYAML)
+	cfg, err := Load(path)
+	require.NoError(t, err)
+	assert.False(t, cfg.EnableTimelineCache)
+	assert.Equal(t, 0, cfg.TimelineCacheTTLSeconds)
+}
+
 func TestLoad_EnableMetrics(t *testing.T) {
 	yaml := testYAML + `
 enableMetrics: true

--- a/internal/server/router.go
+++ b/internal/server/router.go
@@ -1093,6 +1093,17 @@ func (s *Server) setupRoutes() {
 
 	// Notes endpoints
 	notesHandler := notes.NewHandler(noteRepo, noteCreateService, noteDeleteService, noteQueryService, timelineService, reactionService, pollService, searchService, idGen)
+	// first-page timeline 応答を per-viewer 短期キャッシュ (hit 時に DB + pack +
+	// encode を skip)。opt-in (enableTimelineCache / MK_ENABLETIMELINECACHE)。
+	// staleness trade-off があるため default off。
+	if s.config.EnableTimelineCache {
+		ttl := time.Duration(s.config.TimelineCacheTTLSeconds) * time.Second
+		if ttl <= 0 {
+			ttl = 3 * time.Second
+		}
+		notesHandler.EnableTimelineJSONCache(ttl)
+		slog.Info("timeline JSON cache enabled", "ttlSeconds", int(ttl.Seconds()))
+	}
 	notesHandler.SetDriveFileRepo(driveFileRepo)
 	notesHandler.SetNoteReactionRepo(reactionRepo)
 	notesHandler.SetChannelRepo(channelRepo)

--- a/tests/bench/docker-compose.bench.yml
+++ b/tests/bench/docker-compose.bench.yml
@@ -60,6 +60,8 @@ services:
       MK_DISABLEENDPOINTRATELIMITS: "true"
       # bench で profile-collector が /debug/pprof/* に到達できるようにする (#500 / #413 #7)
       MK_ENABLEPPROF: "true"
+      # first-page timeline 応答の per-viewer JSON cache (host env で A/B トグル)。
+      MK_ENABLETIMELINECACHE: "${MK_ENABLETIMELINECACHE:-false}"
     depends_on:
       postgres-mkgo: { condition: service_healthy }
       redis-mkgo: { condition: service_healthy }


### PR DESCRIPTION
## Summary

timeline read hot path の高速化。driver 層最適化 (GORM Joins / raw scan / pgx native pool) は別途 3 アプローチとも 50VU bench で regression し dead と判明したため、**上位層**で first-page (cursor 無し) timeline 応答の最終 JSON を per-viewer + per-param で短期キャッシュする。hit 時に DB hydration (`FindManyByIDsWithUser`) + entity packing (`packMany`) + JSON encode を丸ごとスキップする。**default off の opt-in**。

## ベンチ結果 (dockerized bench-pprof, 50VU)

| local-timeline | p95 | throughput |
|---|---|---|
| cache OFF | 31.6ms | 53,909 reqs |
| cache ON | **4.6ms (-85%)** | **308,579 reqs (+472%)** |

Err 0%、他シナリオ (ping/meta/users-show/i/notes-create) 不変。

> **注意 (重要)**: この 6.9x は bench の**楽観上限**。k6 local-timeline は同一 first-page を TTL (3s) 内に反復するため near-100% hit になる。本番は viewer 多様 + 無限スクロール (cursor は cache 対象外) で hit 率が下がるため、実 p95 改善はより小さい。first-page open は最頻 single request なので実利はあるが、この数値を本番値として扱わないこと。

## 主な変更点

- `internal/api/notes/timeline_cache.go` (新規): bounded in-memory TTL cache + key builder。
- `serveTimeline`: first-page のみ cache を引く。hit→`c.JSONBlob`、miss→pack→`json.Marshal`(+末尾改行で `c.JSON` と byte 一致)→store→返す。cache 無効 / cursor 付きは従来の `c.JSON` 経路 (default byte 一致)。
- key: kind(home/local/global/hybrid) + viewerID(anon可) + 出力影響 param 全部 (limit / withFiles / *bool 群 / allowPartial)。packMany は myReaction 等 viewer 固有 field を詰めるため per-viewer key 必須。
- config: `enableTimelineCache` (env `MK_ENABLETIMELINECACHE`) + `timelineCacheTtlSeconds` (default 3)。`.config/default.yml.example` に doc 追記。
- `tests/bench/docker-compose.bench.yml`: A/B トグル用 env (`MK_ENABLETIMELINECACHE`)。

## staleness trade-off

TTL 中は新規投稿 / mute 変更 / 削除が反映されない。frontend の WebSocket stream が新着を前置きするので REST の数秒遅延はほぼマスクされるが、home timeline の「自分の投稿が数秒見えない」が最も目立つ。よって **default off** とし運用者が判断する。drop-in: 応答 shape 同一、観測差は staleness のみ。

## テスト

- `make fmt && make lint && make test` 全 pass。
- cache unit test (TTL / key 識別 / bounded): `internal/api/notes/timeline_cache_test.go`。
- config test (env override / default): `internal/config/config_test.go`。
- default off で既存 timeline 挙動は byte 一致 (cache 経路を通らない)。

## Closes

Closes #1385

🤖 Generated with [Claude Code](https://claude.com/claude-code)