### PR TITLE
perf(bench): seed enrich (media/mute) + authed home-timeline scenario

### DIFF
--- a/tests/bench/common/compare.py
+++ b/tests/bench/common/compare.py
@@ -18,6 +18,7 @@ ENDPOINTS = [
     "users-show",
     "i",
     "notes-create",
+    "home-timeline",
 ]
 
 

--- a/tests/bench/common/profile-collector.sh
+++ b/tests/bench/common/profile-collector.sh
@@ -21,7 +21,7 @@ HOST=${HOST:-app-mkgo:3000}
 OUT=${OUT:-/output/profiles}
 SCENARIO_DURATION=${SCENARIO_DURATION:-31}
 PROFILE_SECONDS=${PROFILE_SECONDS:-25}
-SCENARIOS=${SCENARIOS:-"ping meta local-timeline users-show i notes-create"}
+SCENARIOS=${SCENARIOS:-"ping meta local-timeline users-show i notes-create home-timeline"}
 
 # シナリオ数を $SCENARIOS から動的に算出する。
 # SCENARIOS を上書きしても sleep / log のロジックがそのまま動くようにする

--- a/tests/bench/common/seed.py
+++ b/tests/bench/common/seed.py
@@ -6,6 +6,7 @@ tokens and note IDs to /seed/seed-data.json for k6 to consume.
 
 from __future__ import annotations
 
+import base64
 import json
 import os
 import random
@@ -27,6 +28,23 @@ OUTPUT_DIR = os.environ.get("OUTPUT_DIR", "/seed")
 # (100 followers/user is already a representative active-instance fan-out); an
 # explicit SEED_FOLLOWERS overrides the cap.
 FOLLOWERS_PER_USER = int(os.environ.get("SEED_FOLLOWERS", str(min(NUM_USERS - 1, 100))))
+# Number of drive files each user uploads (opt-in, default 0). When > 0, a
+# fraction of each user's notes attach 1-2 of their files so timeline packing
+# exercises the drive-file resolution path (resolveFileOwners / files batch),
+# which the text-only default seed never hits. Kept small because each file is
+# a real multipart upload.
+FILES_PER_USER = int(os.environ.get("SEED_FILES_PER_USER", "0"))
+# Number of other users each user mutes (opt-in, default 0). When > 0 the muted
+# set is non-empty so authed timelines (home-timeline scenario) exercise the
+# mute filter / loadMutedUserIDs path.
+MUTES_PER_USER = int(os.environ.get("SEED_MUTES_PER_USER", "0"))
+
+# A minimal valid 1x1 PNG, used for drive uploads when FILES_PER_USER > 0.
+# Embedding the bytes keeps the seeder self-contained (no asset file mount).
+_PNG_1X1_B64 = (
+    "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HBgTAAAAC0lEQVR42mNk+M8AAAMCAQDJ"
+    "Q2ozAAAAAElFTkSuQmCC"
+)
 
 
 def wait_for_health(url: str, timeout: int = 180) -> None:
@@ -110,6 +128,54 @@ def seed_following(http: httpx.Client, tokens: list[str], user_ids: list[str]) -
     return edges
 
 
+def upload_files(http: httpx.Client, token: str, count: int) -> list[str]:
+    """Upload `count` tiny PNGs to the target's drive via multipart, returning
+    the created file IDs. Best-effort: failures are logged and skipped so a
+    drive-disabled instance does not abort the whole seed.
+    """
+    png = base64.b64decode(_PNG_1X1_B64)
+    ids: list[str] = []
+    for k in range(count):
+        try:
+            resp = http.post(
+                "/api/drive/files/create",
+                data={"i": token},
+                files={"file": (f"bench-{k}.png", png, "image/png")},
+            )
+            if resp.status_code >= 400:
+                print(f"WARN: drive upload failed ({resp.status_code}): {resp.text[:200]}", file=sys.stderr)
+                continue
+            fid = resp.json().get("id")
+            if fid:
+                ids.append(fid)
+        except Exception as exc:
+            print(f"WARN: drive upload failed: {exc}", file=sys.stderr)
+    return ids
+
+
+def seed_mutes(http: httpx.Client, tokens: list[str], user_ids: list[str]) -> int:
+    """Each user mutes up to MUTES_PER_USER of the *other* users so authed
+    timelines exercise the mute filter. Deterministic via the shared seed.
+    Returns the number of mute edges created.
+    """
+    if MUTES_PER_USER <= 0:
+        return 0
+    random.seed(13790)
+    edges = 0
+    for i, token in enumerate(tokens):
+        if not token:
+            continue
+        candidates = [user_ids[j] for j in range(len(user_ids)) if j != i and user_ids[j]]
+        targets = random.sample(candidates, min(MUTES_PER_USER, len(candidates)))
+        for target_id in targets:
+            try:
+                api(http, "mute/create", {"userId": target_id}, token)
+                edges += 1
+            except Exception as exc:
+                print(f"WARN: mute {i}->{target_id} failed: {exc}", file=sys.stderr)
+    return edges
+
+
 def main() -> None:
     wait_for_health(TARGET_URL)
 
@@ -158,15 +224,40 @@ def main() -> None:
     print(f"Created {edges} follow edges on {TARGET_NAME} "
           f"(~{FOLLOWERS_PER_USER} followers/user)")
 
-    # ノート投入
+    # mute graph (opt-in)。authed timeline で mute filter を踏ませる。
+    mute_edges = seed_mutes(http, tokens, user_ids)
+    if MUTES_PER_USER > 0:
+        print(f"Created {mute_edges} mute edges on {TARGET_NAME} "
+              f"(~{MUTES_PER_USER} mutes/user)")
+
+    # drive files (opt-in)。各 user 分を先にまとめて上げて token idx で引けるように。
+    user_files: list[list[str]] = [[] for _ in tokens]
+    total_files = 0
+    if FILES_PER_USER > 0:
+        for idx, token in enumerate(tokens):
+            if not token:
+                continue
+            user_files[idx] = upload_files(http, token, FILES_PER_USER)
+            total_files += len(user_files[idx])
+        print(f"Uploaded {total_files} drive files on {TARGET_NAME} "
+              f"(~{FILES_PER_USER}/user)")
+
+    # ノート投入。FILES_PER_USER > 0 のとき一部の note に自分の file を添付して
+    # timeline packing の drive-file 解決経路を踏ませる (決定的: 3 note に 1 回)。
     note_ids: list[str] = []
     for idx, token in enumerate(tokens):
+        files = user_files[idx]
         for j in range(NUM_NOTES_PER_USER):
+            body: dict = {
+                "text": f"Benchmark seed note {idx}-{j} on {TARGET_NAME}",
+                "visibility": "public",
+            }
+            if files and j % 3 == 0:
+                # 1-2 個添付 (file 数に応じて)。決定的に選ぶ。
+                pick = files[: 2] if len(files) >= 2 else files[:1]
+                body["fileIds"] = pick
             try:
-                result = api(http, "notes/create", {
-                    "text": f"Benchmark seed note {idx}-{j} on {TARGET_NAME}",
-                    "visibility": "public",
-                }, token)
+                result = api(http, "notes/create", body, token)
                 nid = result.get("createdNote", {}).get("id")
                 if nid:
                     note_ids.append(nid)
@@ -185,6 +276,8 @@ def main() -> None:
         "usernames": usernames,
         "userIds": user_ids,
         "followEdges": edges,
+        "muteEdges": mute_edges,
+        "fileCount": total_files,
     }
     path = os.path.join(OUTPUT_DIR, "seed-data.json")
     with open(path, "w") as f:

--- a/tests/bench/common/seed.py
+++ b/tests/bench/common/seed.py
@@ -229,6 +229,10 @@ def main() -> None:
     if MUTES_PER_USER > 0:
         print(f"Created {mute_edges} mute edges on {TARGET_NAME} "
               f"(~{MUTES_PER_USER} mutes/user)")
+        if mute_edges == 0:
+            print(f"WARN: SEED_MUTES_PER_USER={MUTES_PER_USER} requested but 0 mute "
+                  f"edges created on {TARGET_NAME} — mute path will not be exercised.",
+                  file=sys.stderr)
 
     # drive files (opt-in)。各 user 分を先にまとめて上げて token idx で引けるように。
     user_files: list[list[str]] = [[] for _ in tokens]
@@ -241,6 +245,20 @@ def main() -> None:
             total_files += len(user_files[idx])
         print(f"Uploaded {total_files} drive files on {TARGET_NAME} "
               f"(~{FILES_PER_USER}/user)")
+        # silent failure を検知可能にする: drive 未設定等で 0 件だと、片 backend
+        # だけ file 無しになり cross-backend 比較が非対称になる。要求したのに 0 /
+        # 期待数未満なら loud に警告して operator が両 stack の fileCount を突き合
+        # わせられるようにする (= 黙って skew した比較を出さない)。
+        expected = FILES_PER_USER * sum(1 for t in tokens if t)
+        if total_files == 0:
+            print(f"WARN: SEED_FILES_PER_USER={FILES_PER_USER} requested but 0 files "
+                  f"uploaded on {TARGET_NAME} (drive disabled?). Cross-backend "
+                  f"comparison will be ASYMMETRIC — compare both stacks' fileCount.",
+                  file=sys.stderr)
+        elif total_files < expected:
+            print(f"WARN: only {total_files}/{expected} files uploaded on "
+                  f"{TARGET_NAME} (some uploads failed) — verify both stacks match.",
+                  file=sys.stderr)
 
     # ノート投入。FILES_PER_USER > 0 のとき一部の note に自分の file を添付して
     # timeline packing の drive-file 解決経路を踏ませる (決定的: 3 note に 1 回)。

--- a/tests/bench/docker-compose.bench.yml
+++ b/tests/bench/docker-compose.bench.yml
@@ -168,6 +168,10 @@ services:
       TARGET_NAME: mkgo
       SEED_USERS: "10"
       SEED_NOTES: "50"
+      # enrich (opt-in, host env で両 stack 同値): media/mute を入れて packing /
+      # file / mute 経路を計測可能にする。default 0 = 従来の text-only seed。
+      SEED_FILES_PER_USER: "${SEED_FILES_PER_USER:-0}"
+      SEED_MUTES_PER_USER: "${SEED_MUTES_PER_USER:-0}"
       OUTPUT_DIR: /seed
     volumes:
       - seed-mkgo:/seed
@@ -187,6 +191,8 @@ services:
       TARGET_NAME: misskey
       SEED_USERS: "10"
       SEED_NOTES: "50"
+      SEED_FILES_PER_USER: "${SEED_FILES_PER_USER:-0}"
+      SEED_MUTES_PER_USER: "${SEED_MUTES_PER_USER:-0}"
       OUTPUT_DIR: /seed
     volumes:
       - seed-misskey:/seed
@@ -249,7 +255,7 @@ services:
       # k6/all-scenarios.js のシナリオ列と一致させる。
       # script 側で SCENARIO_COUNT は dynamic に算出するので、ここを変えれば
       # 何個でも対応できる (Devin #501 INFO-3)。
-      SCENARIOS: "ping meta local-timeline users-show i notes-create"
+      SCENARIOS: "ping meta local-timeline users-show i notes-create home-timeline"
     volumes:
       - ./common/profile-collector.sh:/profile-collector.sh:ro
       - ./results:/output

--- a/tests/bench/k6/all-scenarios.js
+++ b/tests/bench/k6/all-scenarios.js
@@ -77,6 +77,14 @@ export const options = {
       tags: { endpoint: "notes-create" },
       startTime: `${SCENARIO_DURATION * 5}s`,
     },
+    homeTimeline: {
+      executor: "ramping-vus",
+      startVUs: 0,
+      stages: readStages,
+      exec: "homeTimelineScenario",
+      tags: { endpoint: "home-timeline" },
+      startTime: `${SCENARIO_DURATION * 6}s`,
+    },
   },
   thresholds: {
     "http_req_duration{endpoint:ping}": ["p(95)<200"],
@@ -85,6 +93,11 @@ export const options = {
     "http_req_duration{endpoint:users-show}": ["p(95)<500"],
     "http_req_duration{endpoint:i}": ["p(95)<500"],
     "http_req_duration{endpoint:notes-create}": ["p(95)<2000"],
+    // home-timeline は計測専用 (gate しない)。ただし k6 は threshold を持つ tagged
+    // sub-metric のみ summary-export に出すため、percentile を report に残すには
+    // threshold 定義が必須。authed home timeline は TS 側で 1s を超えうるので、
+    // 常に pass する tautology (p95>=0) を置いて「abort せず計測だけする」。
+    "http_req_duration{endpoint:home-timeline}": ["p(95)>=0"],
   },
 };
 
@@ -121,4 +134,11 @@ export function notesCreateScenario() {
   const text = `bench ${Date.now()}-${__VU}-${__ITER}`;
   const res = client.createNote(text, token);
   check(res, { "notes-create 200": (r) => r.status === 200 });
+}
+
+export function homeTimelineScenario() {
+  const token = getToken();
+  if (!token) return;
+  const res = client.homeTimeline(token, 20);
+  check(res, { "home-timeline 200": (r) => r.status === 200 });
 }

--- a/tests/bench/k6/lib/client.js
+++ b/tests/bench/k6/lib/client.js
@@ -34,6 +34,12 @@ export class MisskeyClient {
     return this.api("notes/local-timeline", { limit: limit || 20 });
   }
 
+  // homeTimeline is authenticated (token required) so it exercises the
+  // viewer-dependent path: mute filter / myReaction / poll-vote resolution.
+  homeTimeline(token, limit) {
+    return this.api("notes/timeline", { limit: limit || 20 }, token);
+  }
+
   createNote(text, token) {
     return this.api(
       "notes/create",


### PR DESCRIPTION
## Summary

entity packing の最適化候補 (drive-file owner 解決の batch 化 / mute filter / viewer 依存 field) を bench で計測しようとしたところ、現 bench は **計測不能** だった:
- seed が **text note のみ・mute 無し・media 無し** (`seed.py`)
- k6 `local-timeline` が **匿名** (token 無し) で mute / myReaction を踏まない (`client.js`)

このままでは packing/file/mute 系の改善が「測れない」ため、bench を enrich して計測可能にする (= 今後の perf 改善の前提基盤)。production code 変更なし、bench infra のみ。

## 主な変更点

### seed enrichment (`tests/bench/common/seed.py`)
- **media**: `SEED_FILES_PER_USER` (opt-in, default 0) 個の小 PNG を `drive/files/create` で upload し、各 user の note の 1/3 に `fileIds` で添付。匿名 local-timeline でも packing で `resolveFileOwners` / files batch を踏む。
- **mute**: `SEED_MUTES_PER_USER` (opt-in, default 0) 人を `mute/create`。authed home-timeline で mute filter / loadMutedUserIDs を踏む。
- follow graph と同じ固定 random seed で両 backend 決定的。PNG bytes は埋め込み (asset mount 不要)。

### authed home-timeline scenario (k6)
- `client.homeTimeline(token)` + `home-timeline` scenario (authed) を追加。mute / myReaction / poll-vote 等 viewer 依存経路を計測可能に。
- `home-timeline` の threshold は tautology `p(95)>=0`: k6 は threshold を持つ tagged sub-metric のみ summary-export に出すため percentile を report に残すには threshold が必須。一方 authed home は TS 側で 1s 超えうるので gate はしない (breach → k6 exit 99 → abort-on-container-exit で全体停止を避ける)。
- `compose` / `profile-collector.sh` / `compare.py` の SCENARIOS にも `home-timeline` を追加。

## 検証 (`SEED_FILES_PER_USER=3 SEED_MUTES_PER_USER=3`)

- seed 出力: **fileCount=30 / muteEdges=30** (3/user × 10 users)。
- local-timeline: 31ms → **37ms p95** (file 解決経路が計測に反映)。
- home-timeline: **p95 142.7ms** が新規に計測可能 (authed = mute/myReaction を踏む)。
- enrich 無効 (env 未指定) では従来の text-only seed と同等。

## 影響範囲 / 注意

- bench infra のみ。Go 変更なし (`go build ./...` OK)。
- enrich 有効時は baseline 数値が変わる (より代表的な seed)。default は不変。

## Closes

Closes #1387

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
**運用注記 (レビュー反映)**: cross-backend (mk-go vs TS) で enrich 比較する際は、両 seed ログの `Uploaded N drive files` が一致することを確認すること。TS 側 drive 未設定等で片方が 0 件だと比較が非対称になる。seed は要求に対し 0 件 / 期待未満のとき stderr に loud 警告を出すので検知可能。mk-go 同士の A/B では無関係。