### PR TITLE
perf(entity): resolveFileOwners の folder/owner 解決を batch 化 (timeline packing N+1)

### DIFF
--- a/internal/entity/note_field_resolver.go
+++ b/internal/entity/note_field_resolver.go
@@ -213,9 +213,6 @@ func (r *NoteFieldResolver) packNoteFiles(fileIDs []string, fileMap map[string]*
 	return packed
 }
 
-// resolveFileOwners は folder / owner を best-effort で 1 件ずつ引く。
-// attachment 数は実用上少ないため batch クエリは省略 (folder/owner の
-// 専用 batch インターフェースを増やさない trade-off)。
 // batchDriveFolderLookup / batchFileOwnerLookup are optional capabilities. When
 // the wired lookup implements them, resolveFileOwners fetches all distinct
 // folder / owner IDs in a single query each instead of one FindByID per distinct

--- a/internal/entity/note_field_resolver.go
+++ b/internal/entity/note_field_resolver.go
@@ -216,30 +216,87 @@ func (r *NoteFieldResolver) packNoteFiles(fileIDs []string, fileMap map[string]*
 // resolveFileOwners は folder / owner を best-effort で 1 件ずつ引く。
 // attachment 数は実用上少ないため batch クエリは省略 (folder/owner の
 // 専用 batch インターフェースを増やさない trade-off)。
+// batchDriveFolderLookup / batchFileOwnerLookup are optional capabilities. When
+// the wired lookup implements them, resolveFileOwners fetches all distinct
+// folder / owner IDs in a single query each instead of one FindByID per distinct
+// ID. これは media が多い timeline での distinct(folder)+distinct(owner) 個別
+// round-trip を畳む (#1389)。未実装なら従来の per-ID fetch に fall back する。
+type batchDriveFolderLookup interface {
+	FindByIDs(ids []string) ([]*model.DriveFolder, error)
+}
+
+type batchFileOwnerLookup interface {
+	FindManyByIDs(ids []string) ([]*model.User, error)
+}
+
 func (r *NoteFieldResolver) resolveFileOwners(files []*model.DriveFile) (map[string]*model.DriveFolder, map[string]*model.User) {
 	folderCache := map[string]*model.DriveFolder{}
 	userCache := map[string]*model.User{}
+
+	// distinct な folderID / userID を収集する。cache に nil を seed して「収集
+	// 済み」を兼ねる (fill 側で実体に上書き、見つからなければ nil のまま = 従来の
+	// 「FindByID 失敗時 nil」と同じ挙動)。
+	var folderIDs, userIDs []string
 	for _, f := range files {
 		if r.driveFolder != nil && f.FolderID != nil {
 			if _, seen := folderCache[*f.FolderID]; !seen {
-				if folder, err := r.driveFolder.FindByID(*f.FolderID); err == nil {
-					folderCache[*f.FolderID] = folder
-				} else {
-					folderCache[*f.FolderID] = nil
-				}
+				folderCache[*f.FolderID] = nil
+				folderIDs = append(folderIDs, *f.FolderID)
 			}
 		}
 		if r.fileOwner != nil && f.UserID != nil {
 			if _, seen := userCache[*f.UserID]; !seen {
-				if u, err := r.fileOwner.FindByID(*f.UserID); err == nil {
-					userCache[*f.UserID] = u
-				} else {
-					userCache[*f.UserID] = nil
-				}
+				userCache[*f.UserID] = nil
+				userIDs = append(userIDs, *f.UserID)
 			}
 		}
 	}
+
+	r.fillFolderCache(folderIDs, folderCache)
+	r.fillUserCache(userIDs, userCache)
 	return folderCache, userCache
+}
+
+// fillFolderCache populates cache for the given distinct folder IDs, batching
+// via FindByIDs when the lookup supports it, else per-ID FindByID.
+func (r *NoteFieldResolver) fillFolderCache(ids []string, cache map[string]*model.DriveFolder) {
+	if r.driveFolder == nil || len(ids) == 0 {
+		return
+	}
+	if b, ok := r.driveFolder.(batchDriveFolderLookup); ok {
+		if rows, err := b.FindByIDs(ids); err == nil {
+			for _, f := range rows {
+				cache[f.ID] = f
+			}
+		}
+		return
+	}
+	for _, id := range ids {
+		if f, err := r.driveFolder.FindByID(id); err == nil {
+			cache[id] = f
+		}
+	}
+}
+
+// fillUserCache populates cache for the given distinct owner IDs, batching via
+// FindManyByIDs when the lookup supports it, else per-ID FindByID.
+func (r *NoteFieldResolver) fillUserCache(ids []string, cache map[string]*model.User) {
+	if r.fileOwner == nil || len(ids) == 0 {
+		return
+	}
+	if b, ok := r.fileOwner.(batchFileOwnerLookup); ok {
+		if rows, err := b.FindManyByIDs(ids); err == nil {
+			for _, u := range rows {
+				cache[u.ID] = u
+			}
+		}
+		return
+	}
+	for _, id := range ids {
+		if u, err := r.fileOwner.FindByID(id); err == nil {
+			cache[id] = u
+		}
+	}
 }
 
 // appendNoteFileIDs / appendNoteIDs / appendNoteChannelIDs / applyMyReaction /

--- a/internal/entity/note_field_resolver_test.go
+++ b/internal/entity/note_field_resolver_test.go
@@ -192,6 +192,86 @@ func TestNoteFieldResolver_ResolveFiles_EmbedsFolderAndOwner(t *testing.T) {
 	require.Len(t, notes[0].Files, 2)
 }
 
+// batchFolderStub / batchOwnerStub は optional batch interface
+// (FindByIDs / FindManyByIDs) を実装し、呼び出し回数と渡された ID を記録する。
+type batchFolderStub struct {
+	folders map[string]*model.DriveFolder
+	calls   int
+	lastIDs []string
+}
+
+func (s *batchFolderStub) FindByID(id string) (*model.DriveFolder, error) {
+	if f, ok := s.folders[id]; ok {
+		return f, nil
+	}
+	return nil, assertError("not found")
+}
+
+func (s *batchFolderStub) FindByIDs(ids []string) ([]*model.DriveFolder, error) {
+	s.calls++
+	s.lastIDs = ids
+	out := make([]*model.DriveFolder, 0, len(ids))
+	for _, id := range ids {
+		if f, ok := s.folders[id]; ok {
+			out = append(out, f)
+		}
+	}
+	return out, nil
+}
+
+type batchOwnerStub struct {
+	users map[string]*model.User
+	calls int
+}
+
+func (s *batchOwnerStub) FindByID(id string) (*model.User, error) {
+	if u, ok := s.users[id]; ok {
+		return u, nil
+	}
+	return nil, assertError("not found")
+}
+
+func (s *batchOwnerStub) FindManyByIDs(ids []string) ([]*model.User, error) {
+	s.calls++
+	out := make([]*model.User, 0, len(ids))
+	for _, id := range ids {
+		if u, ok := s.users[id]; ok {
+			out = append(out, u)
+		}
+	}
+	return out, nil
+}
+
+// lookup が batch interface を実装する場合、distinct folder / owner を 1 query
+// ずつで引く (= per-distinct-ID の FindByID を畳む N+1 解消、#1389)。
+func TestNoteFieldResolver_ResolveFiles_BatchesFolderAndOwner(t *testing.T) {
+	fA, fB := "folder-a", "folder-b"
+	uA, uB := "user-a", "user-b"
+	files := &stubDriveFileLookup{files: map[string]*model.DriveFile{
+		"f1": {ID: "f1", FolderID: &fA, UserID: &uA, Name: "1.png", Type: "image/png", URL: "https://e/1"},
+		"f2": {ID: "f2", FolderID: &fB, UserID: &uB, Name: "2.png", Type: "image/png", URL: "https://e/2"},
+		// f3 は f1 と同じ folder / owner → dedup されて batch ID には重複しない。
+		"f3": {ID: "f3", FolderID: &fA, UserID: &uA, Name: "3.png", Type: "image/png", URL: "https://e/3"},
+	}}
+	folders := &batchFolderStub{folders: map[string]*model.DriveFolder{
+		fA: {ID: fA, Name: "A"}, fB: {ID: fB, Name: "B"},
+	}}
+	owners := &batchOwnerStub{users: map[string]*model.User{
+		uA: {ID: uA, Username: "a"}, uB: {ID: uB, Username: "b"},
+	}}
+	r := NewNoteFieldResolver(files, folders, owners, nil, nil, makeIDGen(t))
+
+	notes := []NoteEntity{{ID: "n1", FileIDs: pq.StringArray{"f1", "f2", "f3"}}}
+	r.ResolveFiles(notes)
+
+	require.Len(t, notes[0].Files, 3)
+	// distinct folder / owner が 2 件あっても batch なら 1 query ずつ。
+	assert.Equal(t, 1, folders.calls, "FindByIDs は 1 回 (per-distinct-ID でない)")
+	assert.Equal(t, 1, owners.calls, "FindManyByIDs は 1 回")
+	// dedup 済み distinct ID が渡る (f1/f3 が共有する fA は 1 度だけ)。
+	assert.ElementsMatch(t, []string{fA, fB}, folders.lastIDs)
+}
+
 // folder / owner lookup が err を返してもパニックせず folder/user nil で
 // pack される。
 func TestNoteFieldResolver_ResolveFiles_LookupErrorsTolerated(t *testing.T) {

--- a/internal/repository/drive_folder.go
+++ b/internal/repository/drive_folder.go
@@ -9,6 +9,9 @@ import (
 type DriveFolderRepository interface {
 	Create(f *model.DriveFolder) error
 	FindByID(id string) (*model.DriveFolder, error)
+	// FindByIDs returns folders for the given ID set in a single query.
+	// entity packing が folder embed を batch するために使う (timeline N+1 解消)。
+	FindByIDs(ids []string) ([]*model.DriveFolder, error)
 	Update(id string, fields map[string]any) error
 	Delete(f *model.DriveFolder) error
 	ListByUser(userID string, parentID *string, untilID, sinceID string, limit int) ([]*model.DriveFolder, error)
@@ -39,6 +42,17 @@ func (r *driveFolderRepository) FindByID(id string) (*model.DriveFolder, error) 
 		return nil, err
 	}
 	return &f, nil
+}
+
+func (r *driveFolderRepository) FindByIDs(ids []string) ([]*model.DriveFolder, error) {
+	if len(ids) == 0 {
+		return nil, nil
+	}
+	var folders []*model.DriveFolder
+	if err := r.db.Where("id IN ?", ids).Find(&folders).Error; err != nil {
+		return nil, err
+	}
+	return folders, nil
 }
 
 func (r *driveFolderRepository) Update(id string, fields map[string]any) error {

--- a/internal/testutil/mock_drive.go
+++ b/internal/testutil/mock_drive.go
@@ -233,6 +233,18 @@ func (m *MockDriveFolderRepository) FindByID(id string) (*model.DriveFolder, err
 	return f, nil
 }
 
+// FindByIDs returns the folders present in the mock for the given ID set
+// (missing IDs are skipped, mirroring an IN query).
+func (m *MockDriveFolderRepository) FindByIDs(ids []string) ([]*model.DriveFolder, error) {
+	out := make([]*model.DriveFolder, 0, len(ids))
+	for _, id := range ids {
+		if f, ok := m.Folders[id]; ok {
+			out = append(out, f)
+		}
+	}
+	return out, nil
+}
+
 func (m *MockDriveFolderRepository) Update(id string, fields map[string]any) error {
 	f, ok := m.Folders[id]
 	if !ok {


### PR DESCRIPTION
## Summary

timeline packing で唯一残っていた N+1 を解消する。`entity.NoteFieldResolver.resolveFileOwners` は添付 drive file の folder / owner を解決する際、distinct な folderID / userID **ごとに個別 `FindByID`** を発行していた (dedupe 済みなので per-file ではないが `distinct(folders) + distinct(owners)` 回の round trip)。他の packing 経路 (instance / emoji / reaction / myReaction / poll / channel / files 本体) は既に batch 済み。

## 主な変更点

- `DriveFolderRepository.FindByIDs` を追加 (concrete + interface + mock)。`UserRepository.FindManyByIDs` は既存。
- entity に optional batch interface (`batchDriveFolderLookup` / `batchFileOwnerLookup`) を定義し、`resolveFileOwners` で type assertion。lookup が実装していれば distinct ID を **1 query ずつ**、していなければ従来の per-ID dedup に **fall back**。
- `DriveFolderLookup` / `FileOwnerLookup` interface は**不変** → 既存 test stub / 他 caller に影響なし。出力 shape / nil 挙動 (folder/owner 不在は nil) は従来と完全一致。

## テスト

- `make fmt && make lint && make test` 全 pass。
- `TestNoteFieldResolver_ResolveFiles_BatchesFolderAndOwner` を追加: distinct folder/owner が 2 件あっても `FindByIDs` / `FindManyByIDs` が **各 1 回** + dedup された ID が渡ることを assert (= N+1 解消の実証)。
- 既存の fallback 経路 (per-ID stub) / error tolerance test も green 維持。

## 影響評価 (正直版)

- dedupe 済みのため元から catastrophic な N+1 ではない。効くのは **media 多数 + author/folder 多様な timeline** + remote DB RTT。
- 現 bench seed (#1388) は file に folderId を付けないため **folder-batch 経路は bench で踏まれず** (owner half のみ)、localhost 低 RTT では within-noise 見込み。よって controlled bench A/B は実施していない (二重 build コスト vs 予見される within-noise)。N+1 解消自体は unit test で確証。
- 本番効果を bench で測りたい場合は seed が folder 配下に file を作る拡張が別途必要 (follow-up)。

## Closes

Closes #1389

🤖 Generated with [Claude Code](https://claude.com/claude-code)