### PR TITLE
fix(entity): exportCompleted 通知の exportedEntity を read 時にも正規化 (Miria crash)

### DIFF
--- a/internal/entity/notification.go
+++ b/internal/entity/notification.go
@@ -155,7 +155,42 @@ func packNotificationCore(n *notification.Notification, user *model.User, note *
 		if _, collides := out[k]; collides {
 			continue
 		}
+		// exportCompleted 通知の exportedEntity は misskey_dart / Misskey TS が
+		// singular / camelCase の enum で受ける。作成時に core/transfer 側で正規化
+		// 済み (#1249) だが、それ以前に永続化された通知は内部値 ("notes" 等) を
+		// 保持しており、misskey_dart の enum decode を全件巻き込んで落とす (#1391)。
+		// read 時にも正規化して既存データでクライアントが crash しないようにする。
+		if k == "exportedEntity" {
+			if s, ok := v.(string); ok {
+				out[k] = normalizeExportedEntity(s)
+				continue
+			}
+		}
 		out[k] = v
 	}
 	return out
+}
+
+// exportedEntityAliases maps mk-go 内部の export type 名 (plural / kebab-case) を
+// exportCompleted 通知の exportedEntity が取るべき Misskey enum 値 (singular /
+// camelCase) へ変換する。core/transfer.misskeyExportedEntity (create 時) と同じ
+// 対応で、read 時の defense-in-depth として持つ。
+var exportedEntityAliases = map[string]string{
+	"notes":         "note",
+	"favorites":     "favorite",
+	"user-lists":    "userList",
+	"antennas":      "antenna",
+	"clips":         "clip",
+	"mute":          "muting",
+	"custom-emojis": "customEmoji",
+}
+
+// normalizeExportedEntity returns the Misskey enum value for an exportedEntity,
+// translating mk-go internal aliases. Already-canonical / unknown values pass
+// through unchanged (= following / blocking は元から一致、未知値は壊さない)。
+func normalizeExportedEntity(v string) string {
+	if canon, ok := exportedEntityAliases[v]; ok {
+		return canon
+	}
+	return v
 }

--- a/internal/entity/notification_test.go
+++ b/internal/entity/notification_test.go
@@ -119,6 +119,38 @@ func TestPackNotification_ExtraFields_Merged(t *testing.T) {
 	assert.Equal(t, "df_1", out["fileId"])
 }
 
+// #1249 以前に永続化された exportCompleted 通知は exportedEntity に mk-go 内部値
+// (plural / kebab) を持つ。misskey_dart の enum decode を落とさないよう read 時に
+// singular / camelCase へ正規化する (#1391)。
+func TestPackNotification_NormalizesExportedEntity(t *testing.T) {
+	idGen, _ := id.NewGenerator("aidx")
+	cases := map[string]string{
+		"notes":         "note",
+		"favorites":     "favorite",
+		"user-lists":    "userList",
+		"antennas":      "antenna",
+		"clips":         "clip",
+		"mute":          "muting",
+		"custom-emojis": "customEmoji",
+		// already-canonical / unknown はそのまま。
+		"note":      "note",
+		"following": "following",
+		"blocking":  "blocking",
+		"weird":     "weird",
+	}
+	for stored, want := range cases {
+		n := &notification.Notification{
+			ID:        "x",
+			CreatedAt: time.Now(),
+			Type:      notification.TypeExportCompleted,
+			Extra:     map[string]any{"exportedEntity": stored, "fileId": "df_1"},
+		}
+		out := PackNotification(n, nil, nil, idGen, nil, nil)
+		assert.Equal(t, want, out["exportedEntity"], "stored=%q", stored)
+		assert.Equal(t, "df_1", out["fileId"], "stored=%q: other extra fields preserved", stored)
+	}
+}
+
 func ptrStr(s string) *string { return &s }
 
 // PackNotifications は N 件の通知を pack しても InstanceLookup を 1 回 /


### PR DESCRIPTION
## Summary

Miria (misskey_dart) の通知「みんな」タブで `/api/i/notifications` のパースが全件失敗し、タブが丸ごとエラーになる drop-in 互換バグを修正する。

エラー (issue #1391 のスクショ):
```
Invalid argument(s): 'notes' is not one of the supported values:
note, antenna, blocking, clip, customEmoji, favorite, following, muting, userList
  _$INotificationsResponseFromJson (misskey_dart/.../notifications_response.g.dart:47)
```

## 原因

- `exportCompleted` 通知の `exportedEntity` は misskey_dart / Misskey TS が singular / camelCase の enum (`note` / `favorite` / `userList` …) で受ける。
- mk-go は作成時に `core/transfer.misskeyExportedEntity` で内部値 (`notes` / `favorites` / `user-lists` / `mute` / `custom-emojis` …) を正規化済み (#1249)。**現在の作成パスは正常**。
- しかし `packNotificationCore` は `n.Extra` を**透過出力**するため、**#1249 以前に永続化された通知**が内部値 `"notes"` 等を保持しており、read 時にそのまま流出。
- misskey_dart は 1 件の enum decode 失敗で notifications リスト**全体**の parse を投げる → タブが丸ごと落ちる (「エラーが出るケースがある」と一致)。

## 修正

`packNotificationCore` の Extra merge 時に `exportedEntity` を read 側でも正規化する (defense-in-depth)。

- 作成時マップ (#1249) は維持。read 時正規化は **既存の永続化データ / 将来のマップ漏れ** でもクライアントを落とさないための保険。
- **DB migration 不要** (read 時変換)。`following` / `blocking` は元から canonical、未知値は壊さず pass-through。

## テスト

- `make fmt && make lint && make test` 全 pass。
- `TestPackNotification_NormalizesExportedEntity` を追加: 7 種の内部値 → enum 値変換 + already-canonical / unknown の pass-through + 他 Extra field (fileId) 保持を assert。

## 補足

本質的な data 修正をしたい場合は別途 migration で既存 notification の exportedEntity を書き換える選択肢もあるが、read 時正規化の方が低リスクかつ将来の create パス漏れにも効くため本 PR ではこちらを採る。

## Closes

Closes #1391

🤖 Generated with [Claude Code](https://claude.com/claude-code)