### PR TITLE
fix(admin): job queue 画面の per-queue db (memory/clients/uptime) を Redis INFO から埋める

### DIFF
--- a/internal/api/admin/handler.go
+++ b/internal/api/admin/handler.go
@@ -91,6 +91,7 @@ type Handler struct {
 	adminDB                 *gorm.DB
 	userIPRepo              repository.UserIPRepository
 	queueInspector          QueueInspector
+	queueRedis              QueueRedisInfoProvider
 	emojiEnqueuer           EmojiImportEnqueuer
 	emojiImageFetcher       EmojiImageFetcher
 	relayService            RelayService

--- a/internal/api/admin/queue.go
+++ b/internal/api/admin/queue.go
@@ -343,19 +343,14 @@ func (h *Handler) QueuePromoteJobs(c echo.Context) error {
 // shapeQueueForFrontend adapts a QueueInfoResult to the Misskey Bull-shaped
 // JSON expected by the admin/job-queue.vue page.
 //
-// BullMQ (Misskey本家のjob queue) と asynq は設計思想が根本的に異なり、
-// 完全互換は不可能：
-//   - asynq に存在しない queue 名 (inbox / db / relationship / system 等):
-//     frontend は Misskey.queueTypes で hardcode しており mk-go の queue 名
-//     (deliver / push / webhook / export / maintenance) と一致しない。
-//   - db.{memory,uptime,clients} は BullMQ が per-queue で持つ Redis 統計。
-//     asynq には相当機能が無い。
-//   - metrics.{completed,failed}.data は BullMQ の per-queue time-series。
-//     asynq は retention 設定なしでは履歴を持たない。
+// counts / db は mkq driver から取得した実値で埋まる (db は job-queue Redis の
+// INFO 由来。queueDBStats 参照)。metrics.{completed,failed}.data は mkq の
+// per-queue time-series で、job-metrics retention が有効な queue でのみ履歴を
+// 持つ (無効なら data 空 + cumulative count にフォールバック)。
 //
-// BullMQ と完全互換のまま Go ネイティブ性能を活かすのは別レイヤ (独立
-// OSS ライブラリ化) で取り組む方針 (#377 参照)。それまでの中継措置として
-// 見た目が壊れないよう未対応 field を 0 固定で stub する。
+// 残る非互換: frontend は Misskey の queue 名 (system / endedPollNotification /
+// postScheduledNote 等) を列挙しうるが、mk-go が実行しない queue は GetQueueInfo
+// が空を返すため 0 表示になる (#1393 で別途整理予定)。
 func shapeQueueForFrontend(info *QueueInfoResult, completed, failed *QueueMetricsResult, db map[string]any) map[string]any {
 	// delayed は Misskey 用語で scheduled + retry の合計に相当する
 	// (どちらも「すぐには実行されない」状態)。

--- a/internal/api/admin/queue.go
+++ b/internal/api/admin/queue.go
@@ -356,7 +356,7 @@ func (h *Handler) QueuePromoteJobs(c echo.Context) error {
 // BullMQ と完全互換のまま Go ネイティブ性能を活かすのは別レイヤ (独立
 // OSS ライブラリ化) で取り組む方針 (#377 参照)。それまでの中継措置として
 // 見た目が壊れないよう未対応 field を 0 固定で stub する。
-func shapeQueueForFrontend(info *QueueInfoResult, completed, failed *QueueMetricsResult) map[string]any {
+func shapeQueueForFrontend(info *QueueInfoResult, completed, failed *QueueMetricsResult, db map[string]any) map[string]any {
 	// delayed は Misskey 用語で scheduled + retry の合計に相当する
 	// (どちらも「すぐには実行されない」状態)。
 	delayed := info.Scheduled + info.Retry
@@ -384,16 +384,10 @@ func shapeQueueForFrontend(info *QueueInfoResult, completed, failed *QueueMetric
 			"completed": map[string]any{"data": completedData, "count": completedCount},
 			"failed":    map[string]any{"data": failedData, "count": failedCount},
 		},
-		// asynq にはBull相当のper-queue redis DB statsがないため、frontend
-		// が参照するフィールドを0固定でstubする。
-		"db": map[string]any{
-			"processId": 0,
-			"port":      0,
-			"runId":     "",
-			"clients":   map[string]any{"connected": 0, "blocked": 0},
-			"memory":    map[string]any{"peak": 0, "total": 0, "used": 0},
-			"uptime":    0,
-		},
+		// db は job-queue Redis の INFO 由来 (memory / clients / uptime 等)。
+		// caller が queueDBStats() で一度引いて全 queue に渡す (INFO は接続単位
+		// で全 queue 同値)。provider 未配線時は defaultQueueDB() の 0 埋め。
+		"db": db,
 	}
 }
 
@@ -442,13 +436,14 @@ func (h *Handler) QueueQueueStats(c echo.Context) error {
 	if h.queueInspector == nil {
 		return c.JSON(http.StatusOK, map[string]any{})
 	}
+	db := h.queueDBStats(c.Request().Context())
 	info, err := h.queueInspector.GetQueueInfo(req.Queue)
 	if err != nil || info == nil {
 		completed, failed := h.fetchQueueMetrics(req.Queue)
-		return c.JSON(http.StatusOK, shapeQueueForFrontend(&QueueInfoResult{Queue: req.Queue}, completed, failed))
+		return c.JSON(http.StatusOK, shapeQueueForFrontend(&QueueInfoResult{Queue: req.Queue}, completed, failed, db))
 	}
 	completed, failed := h.fetchQueueMetrics(req.Queue)
-	return c.JSON(http.StatusOK, shapeQueueForFrontend(info, completed, failed))
+	return c.JSON(http.StatusOK, shapeQueueForFrontend(info, completed, failed, db))
 }
 
 // fetchQueueMetrics queries the inspector for completed / failed
@@ -474,6 +469,8 @@ func (h *Handler) QueueQueues(c echo.Context) error {
 	if err != nil {
 		return c.JSON(http.StatusInternalServerError, apierr.InternalError())
 	}
+	// db (Redis INFO) は全 queue で同値なので一度だけ引いて使い回す。
+	db := h.queueDBStats(c.Request().Context())
 	result := make([]map[string]any, 0, len(queues))
 	for _, q := range queues {
 		info, err := h.queueInspector.GetQueueInfo(q)
@@ -481,7 +478,7 @@ func (h *Handler) QueueQueues(c echo.Context) error {
 			continue
 		}
 		completed, failed := h.fetchQueueMetrics(q)
-		result = append(result, shapeQueueForFrontend(info, completed, failed))
+		result = append(result, shapeQueueForFrontend(info, completed, failed, db))
 	}
 	return c.JSON(http.StatusOK, result)
 }

--- a/internal/api/admin/queue_dbstats.go
+++ b/internal/api/admin/queue_dbstats.go
@@ -1,0 +1,112 @@
+package admin
+
+import (
+	"context"
+	"strconv"
+	"strings"
+)
+
+// QueueRedisInfoProvider exposes the job-queue Redis `INFO` output. Implemented
+// by a thin adapter over the go-redis client in server wiring so that this
+// package stays free of a go-redis import. Mirrors upstream Misskey TS
+// `QueueService.queueGetQueue`, which builds the `db` block from
+// `parseRedisInfo(await queue.client.info())`.
+type QueueRedisInfoProvider interface {
+	QueueRedisInfo(ctx context.Context) (string, error)
+}
+
+// SetQueueRedis wires the job-queue Redis INFO provider used to populate the
+// per-queue `db` (memory / clients / uptime) block returned by queue-stats /
+// queues. nil leaves the zero-stub behaviour intact.
+func (h *Handler) SetQueueRedis(p QueueRedisInfoProvider) {
+	h.queueRedis = p
+}
+
+// defaultQueueDB returns the zero-valued `db` block used when no Redis INFO is
+// available (provider unwired / INFO error). frontend (admin/job-queue.vue) が
+// 参照する shape を満たす。
+func defaultQueueDB() map[string]any {
+	return map[string]any{
+		"version":   "",
+		"mode":      "",
+		"runId":     "",
+		"processId": "",
+		"port":      0,
+		"os":        "",
+		"uptime":    0,
+		"memory":    map[string]any{"total": 0, "used": 0, "peak": 0, "fragmentationRatio": 0},
+		"clients":   map[string]any{"connected": 0, "blocked": 0},
+	}
+}
+
+// queueDBStats fetches the job-queue Redis INFO and maps it into the `db` block.
+// Redis INFO は per-queue でなく接続単位 (= job-queue Redis 全体) なので全 queue
+// で同値になる (upstream も各 queue が同じ Redis を見るため同じ)。provider 未配線
+// / INFO 失敗時は defaultQueueDB() を返して 200 を維持する。
+func (h *Handler) queueDBStats(ctx context.Context) map[string]any {
+	if h.queueRedis == nil {
+		return defaultQueueDB()
+	}
+	raw, err := h.queueRedis.QueueRedisInfo(ctx)
+	if err != nil {
+		return defaultQueueDB()
+	}
+	info := parseRedisInfo(raw)
+
+	atoi := func(k string) int {
+		n, _ := strconv.Atoi(strings.TrimSpace(info[k]))
+		return n
+	}
+	// total_system_memory が無い (maxmemory 運用) ときは maxmemory に fallback。
+	// upstream: parseInt(total_system_memory) || parseInt(maxmemory)。
+	total := atoi("total_system_memory")
+	if total == 0 {
+		total = atoi("maxmemory")
+	}
+	// mem_fragmentation_ratio は float ("1.52")。upstream は parseInt 相当で
+	// 整数部のみ採る。
+	fragRatio := 0
+	if f, ferr := strconv.ParseFloat(strings.TrimSpace(info["mem_fragmentation_ratio"]), 64); ferr == nil {
+		fragRatio = int(f)
+	}
+
+	return map[string]any{
+		"version":   info["redis_version"],
+		"mode":      info["redis_mode"],
+		"runId":     info["run_id"],
+		"processId": info["process_id"],
+		"port":      atoi("tcp_port"),
+		"os":        info["os"],
+		"uptime":    atoi("uptime_in_seconds"),
+		"memory": map[string]any{
+			"total":              total,
+			"used":               atoi("used_memory"),
+			"peak":               atoi("used_memory_peak"),
+			"fragmentationRatio": fragRatio,
+		},
+		"clients": map[string]any{
+			"connected": atoi("connected_clients"),
+			"blocked":   atoi("blocked_clients"),
+		},
+	}
+}
+
+// parseRedisInfo parses the line-oriented Redis `INFO` payload into a flat
+// key→value map. Section headers ("# Server") and blank lines are skipped;
+// only the first ':' on each line splits key from value (values never contain
+// a leading key, and CRLF is trimmed).
+func parseRedisInfo(raw string) map[string]string {
+	out := make(map[string]string, 128)
+	for _, line := range strings.Split(raw, "\n") {
+		line = strings.TrimRight(line, "\r")
+		if line == "" || strings.HasPrefix(line, "#") {
+			continue
+		}
+		idx := strings.IndexByte(line, ':')
+		if idx <= 0 {
+			continue
+		}
+		out[line[:idx]] = line[idx+1:]
+	}
+	return out
+}

--- a/internal/api/admin/queue_dbstats_internal_test.go
+++ b/internal/api/admin/queue_dbstats_internal_test.go
@@ -1,0 +1,98 @@
+package admin
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestParseRedisInfo(t *testing.T) {
+	raw := "# Server\r\nredis_version:7.2.4\r\nrun_id:abc\r\n\r\n# Memory\r\nused_memory:123\r\nmem_fragmentation_ratio:1.52\r\n"
+	info := parseRedisInfo(raw)
+	assert.Equal(t, "7.2.4", info["redis_version"])
+	assert.Equal(t, "abc", info["run_id"])
+	assert.Equal(t, "123", info["used_memory"])
+	assert.Equal(t, "1.52", info["mem_fragmentation_ratio"])
+	// section header / blank line は無視。
+	_, hasHeader := info["# Server"]
+	assert.False(t, hasHeader)
+}
+
+type stubRedisInfo struct {
+	raw string
+	err error
+}
+
+func (s stubRedisInfo) QueueRedisInfo(_ context.Context) (string, error) {
+	return s.raw, s.err
+}
+
+func TestQueueDBStats_FromProvider(t *testing.T) {
+	raw := "# Server\n" +
+		"redis_version:7.2.4\n" +
+		"redis_mode:standalone\n" +
+		"run_id:abc123\n" +
+		"process_id:42\n" +
+		"tcp_port:6379\n" +
+		"os:Linux\n" +
+		"uptime_in_seconds:12345\n" +
+		"# Clients\n" +
+		"connected_clients:7\n" +
+		"blocked_clients:1\n" +
+		"# Memory\n" +
+		"used_memory:1048576\n" +
+		"used_memory_peak:2097152\n" +
+		"total_system_memory:8589934592\n" +
+		"mem_fragmentation_ratio:1.52\n" +
+		"maxmemory:0\n"
+
+	h := &Handler{}
+	h.SetQueueRedis(stubRedisInfo{raw: raw})
+	db := h.queueDBStats(context.Background())
+
+	assert.Equal(t, "7.2.4", db["version"])
+	assert.Equal(t, "standalone", db["mode"])
+	assert.Equal(t, "abc123", db["runId"])
+	assert.Equal(t, "42", db["processId"])
+	assert.Equal(t, 6379, db["port"])
+	assert.Equal(t, "Linux", db["os"])
+	assert.Equal(t, 12345, db["uptime"])
+
+	mem := db["memory"].(map[string]any)
+	assert.Equal(t, 1048576, mem["used"])
+	assert.Equal(t, 2097152, mem["peak"])
+	assert.Equal(t, 8589934592, mem["total"])
+	assert.Equal(t, 1, mem["fragmentationRatio"]) // parseInt 相当 (1.52 → 1)
+
+	cl := db["clients"].(map[string]any)
+	assert.Equal(t, 7, cl["connected"])
+	assert.Equal(t, 1, cl["blocked"])
+}
+
+// total_system_memory が無いときは maxmemory に fallback する。
+func TestQueueDBStats_MaxmemoryFallback(t *testing.T) {
+	raw := "# Memory\nused_memory:10\nmaxmemory:5000\n"
+	h := &Handler{}
+	h.SetQueueRedis(stubRedisInfo{raw: raw})
+	db := h.queueDBStats(context.Background())
+	mem := db["memory"].(map[string]any)
+	assert.Equal(t, 5000, mem["total"])
+}
+
+// provider 未配線 / INFO エラー時は zero-stub を返す (200 維持)。
+func TestQueueDBStats_DefaultWhenUnavailable(t *testing.T) {
+	// 未配線。
+	h := &Handler{}
+	db := h.queueDBStats(context.Background())
+	assert.Equal(t, "", db["version"])
+	assert.Equal(t, 0, db["port"])
+	mem := db["memory"].(map[string]any)
+	assert.Equal(t, 0, mem["used"])
+
+	// INFO エラー。
+	h.SetQueueRedis(stubRedisInfo{err: assert.AnError})
+	db2 := h.queueDBStats(context.Background())
+	require.Equal(t, defaultQueueDB(), db2)
+}

--- a/internal/api/admin/queue_dbstats_test.go
+++ b/internal/api/admin/queue_dbstats_test.go
@@ -1,0 +1,73 @@
+package admin_test
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"testing"
+
+	apiadmin "github.com/shiroha-a/mk/internal/api/admin"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type stubQueueRedisInfo struct{ raw string }
+
+func (s stubQueueRedisInfo) QueueRedisInfo(_ context.Context) (string, error) {
+	return s.raw, nil
+}
+
+// QueueQueueStats が job-queue Redis INFO 由来の db (memory / clients / uptime)
+// を埋めることを handler 経由で確認する (#1393)。従来は 0 固定 stub だった。
+func TestQueueQueueStats_PopulatesDBFromRedisInfo(t *testing.T) {
+	h, _, _, _ := newTestHandler(t)
+	insp := &stubQueueInspector{
+		info: map[string]*apiadmin.QueueInfoResult{
+			"deliver": {Queue: "deliver", Active: 1},
+		},
+	}
+	h.SetQueueInspector(insp)
+	h.SetQueueRedis(stubQueueRedisInfo{raw: "# Memory\n" +
+		"used_memory:2048\n" +
+		"used_memory_peak:4096\n" +
+		"# Clients\n" +
+		"connected_clients:3\n" +
+		"blocked_clients:0\n" +
+		"# Server\n" +
+		"uptime_in_seconds:99\n" +
+		"tcp_port:6379\n"})
+
+	rec := doPost(h.QueueQueueStats, `{"queue":"deliver"}`, adminUser)
+	require.Equal(t, http.StatusOK, rec.Code)
+	var got map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &got))
+
+	db, ok := got["db"].(map[string]any)
+	require.True(t, ok)
+	assert.EqualValues(t, 99, db["uptime"])
+	assert.EqualValues(t, 6379, db["port"])
+	mem := db["memory"].(map[string]any)
+	assert.EqualValues(t, 2048, mem["used"])
+	assert.EqualValues(t, 4096, mem["peak"])
+	clients := db["clients"].(map[string]any)
+	assert.EqualValues(t, 3, clients["connected"])
+}
+
+// provider 未配線時は db が 0-stub のまま (= 従来挙動、200 維持)。
+func TestQueueQueueStats_DBStubWhenNoRedis(t *testing.T) {
+	h, _, _, _ := newTestHandler(t)
+	insp := &stubQueueInspector{
+		info: map[string]*apiadmin.QueueInfoResult{"deliver": {Queue: "deliver"}},
+	}
+	h.SetQueueInspector(insp)
+	// SetQueueRedis を呼ばない。
+
+	rec := doPost(h.QueueQueueStats, `{"queue":"deliver"}`, adminUser)
+	require.Equal(t, http.StatusOK, rec.Code)
+	var got map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &got))
+	db := got["db"].(map[string]any)
+	assert.EqualValues(t, 0, db["uptime"])
+	mem := db["memory"].(map[string]any)
+	assert.EqualValues(t, 0, mem["used"])
+}

--- a/internal/server/queue_adapter.go
+++ b/internal/server/queue_adapter.go
@@ -1,10 +1,24 @@
 package server
 
 import (
+	"context"
+
+	"github.com/redis/go-redis/v9"
 	apiadmin "github.com/shiroha-a/mk/internal/api/admin"
 	"github.com/shiroha-a/mk/internal/queue"
 	"github.com/shiroha-a/mk/internal/stream"
 )
+
+// jobQueueRedisInfo adapts the job-queue go-redis client to the admin handler's
+// QueueRedisInfoProvider, exposing the raw `INFO` payload for the per-queue db
+// block (memory / clients / uptime)。go-redis 依存を admin package から隔離する。
+type jobQueueRedisInfo struct {
+	rdb *redis.Client
+}
+
+func (j jobQueueRedisInfo) QueueRedisInfo(ctx context.Context) (string, error) {
+	return j.rdb.Info(ctx).Result()
+}
 
 // queueStatsInspectorAdapter adapts queue.Inspector to the minimal
 // stream.QueueInspector interface needed by QueueStatsPublisher. Keeping this

--- a/internal/server/router.go
+++ b/internal/server/router.go
@@ -2001,6 +2001,11 @@ func (s *Server) setupRoutes() {
 	if s.queueInspector != nil {
 		adminHandler.SetQueueInspector(&queueInspectorAdapter{inner: s.queueInspector})
 	}
+	// per-queue db (Redis INFO: memory / clients / uptime) を admin queue 画面に
+	// 出すため job-queue Redis を配線 (#1393)。
+	if s.redis != nil && s.redis.JobQueue != nil {
+		adminHandler.SetQueueRedis(jobQueueRedisInfo{rdb: s.redis.JobQueue})
+	}
 	adminHandler.SetInstanceMetadataFetcher(metadataFetcher)
 	adminHandler.SetSystemAccountFetcher(sysAcctSvc)
 	// admin/federation/remove-all-following が host 単位で全 follower を


### PR DESCRIPTION
## Summary

admin ジョブキュー画面 (`/admin/queue`) の各 queue overview で **Memory / Clients / Uptime / processId / port / runId が常に 0/空** だった (issue #1393 のスクショ)。

`shapeQueueForFrontend` の `db` block が「asynq に per-queue redis stats が無い」という前提で **0 固定 stub** のまま放置されていたのが原因。実際には upstream Misskey TS と同様、これらは **job-queue Redis の `INFO`** から取れる (per-queue でなく接続単位の値で、全 queue 同値)。

## 主な変更点

- admin handler に job-queue Redis の `INFO` を返す narrow provider `QueueRedisInfoProvider` を追加 + `SetQueueRedis` で配線。
- `parseRedisInfo` で INFO を parse し、`db` block を実値で構築:
  `version / mode / os / runId / processId / port / uptime / memory{total,used,peak,fragmentationRatio} / clients{connected,blocked}`。
  upstream `QueueService.queueGetQueue` の `parseRedisInfo(await queue.client.info())` と同じ field 対応 (`total_system_memory || maxmemory` fallback 含む)。
- go-redis 依存は server 側 adapter (`jobQueueRedisInfo`) に隔離。admin package は string INFO を受ける interface のみ (go-redis 非依存)。
- `db` は全 queue で同値なので `queues` 一覧では INFO を 1 回だけ引いて使い回す。
- provider 未配線 / INFO エラー時は従来の 0-stub を返して 200 維持 (drop-in 安全)。

## テスト

- `make fmt && make lint && make test` 全 pass。
- internal: `parseRedisInfo` (CRLF/コメント/section)、`queueDBStats` (provider 由来 / maxmemory fallback / 未配線・エラー時 default)。
- 外部 (handler 経由): `QueueQueueStats` が db を実値で埋める / provider 未配線時は 0-stub。

## スコープ (issue #1393 のうち本 PR が直す範囲)

- ✅ Memory / Clients / Uptime 等 overview の 0 固定 → 実値。
- ⬜ idle queue (export/webhook/maintenance 等) のチャートが平坦なのは **traffic 0 の正常挙動** (export 等を流せば動く)。
- ⬜ `system` / `endedPollNotification` / `postScheduledNote` 等 mk-go が実行しない foreign queue が一覧に出る件は別途検討。

よって `Closes` ではなく **Refs #1393** とし、残りは issue に残す。

Refs #1393

🤖 Generated with [Claude Code](https://claude.com/claude-code)