### PR TITLE
fix(queue): admin queue 一覧を mk-go 管理 queue のみに絞る (foreign queue 除外)

### DIFF
--- a/internal/queue/driver/mkqdriver/driver.go
+++ b/internal/queue/driver/mkqdriver/driver.go
@@ -91,6 +91,11 @@ type Driver struct {
 	client *mkq.Client
 	cfg    Config
 	queues map[string]*mkq.Queue[framedPayload]
+	// queueNames holds the Define'd queue names in configured order. Used by
+	// Inspector.Queues() so the admin dashboard lists exactly the queues
+	// mk-go manages (drop-in 時に旧 Misskey TS が共有 registry に残した foreign
+	// queue 名を含めない、#1393)。
+	queueNames []string
 
 	// rdb is a side-channel redis client used by the Inspector for
 	// ad-hoc reads that mkq's public API does not expose (currently
@@ -157,11 +162,12 @@ func New(ctx context.Context, cfg Config) (*Driver, error) {
 	}
 
 	return &Driver{
-		client:    client,
-		cfg:       cfg,
-		queues:    queues,
-		rdb:       rdb,
-		keyPrefix: keyPrefix,
+		client:     client,
+		cfg:        cfg,
+		queues:     queues,
+		queueNames: names,
+		rdb:        rdb,
+		keyPrefix:  keyPrefix,
 	}, nil
 }
 

--- a/internal/queue/driver/mkqdriver/inspector.go
+++ b/internal/queue/driver/mkqdriver/inspector.go
@@ -23,10 +23,17 @@ type Inspector struct {
 	driver *Driver
 }
 
-// Queues returns the set of queues mkq has Define'd against the
-// underlying client.
+// Queues returns the queues mk-go manages (Define'd at driver construction),
+// in configured order. We intentionally do NOT return mkq's shared Redis queue
+// registry (SMEMBERS {prefix}:queues): on a drop-in over an existing Misskey TS
+// instance that registry also carries the upstream BullMQ queue names
+// (system / endedPollNotification / postScheduledNote / db / relationship 等)
+// which mk-go never processes, so listing them would only fill the admin
+// dashboard with permanently-zero dead queues (#1393)。
 func (i *Inspector) Queues() ([]string, error) {
-	return i.driver.client.Queues(inspectorCtx())
+	out := make([]string, len(i.driver.queueNames))
+	copy(out, i.driver.queueNames)
+	return out, nil
 }
 
 // GetQueueInfo returns the wait / active / delayed / completed /

--- a/internal/queue/driver/mkqdriver/mkqdriver_test.go
+++ b/internal/queue/driver/mkqdriver/mkqdriver_test.go
@@ -3,6 +3,7 @@ package mkqdriver
 import (
 	"context"
 	"errors"
+	"reflect"
 	"runtime"
 	"testing"
 	"time"
@@ -547,5 +548,33 @@ func TestPoolSizeForWorkers(t *testing.T) {
 			t.Errorf("%s: poolSizeForWorkers(%d, %d) = %d, want %d",
 				tc.name, tc.workerSum, tc.floor, got, tc.want)
 		}
+	}
+}
+
+// Inspector.Queues は mk-go が管理する (Define 済みの) queue 名だけを順序通りに
+// 返し、mkq の共有 Redis registry (drop-in 時に旧 Misskey TS の foreign queue を
+// 含みうる) は参照しない (#1393)。driver に client/rdb を持たせず構築できることが、
+// registry を引かない (= nil client で panic しない) ことの証左でもある。
+func TestInspector_Queues_ReturnsManagedNamesOnly(t *testing.T) {
+	d := &Driver{queueNames: []string{"deliver", "inbox", "export"}}
+	ins := &Inspector{driver: d}
+
+	got, err := ins.Queues()
+	if err != nil {
+		t.Fatalf("Queues: %v", err)
+	}
+	want := []string{"deliver", "inbox", "export"}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("Queues = %v, want %v", got, want)
+	}
+
+	// 返り値は copy で、mutate しても driver の内部状態に影響しない。
+	got[0] = "mutated"
+	got2, err := ins.Queues()
+	if err != nil {
+		t.Fatalf("Queues (2): %v", err)
+	}
+	if got2[0] != "deliver" {
+		t.Fatalf("driver state mutated via returned slice: got2[0]=%q", got2[0])
 	}
 }


### PR DESCRIPTION
## Summary

admin ジョブキュー画面に、mk-go が一切処理しない upstream Misskey の queue (`system` / `endedPollNotification` / `postScheduledNote` / `db` / `relationship` 等) が「永久に 0 の死んだ queue」として並んでいた (issue #1393)。

原因: `mkqdriver.Inspector.Queues()` が **mkq の共有 Redis queue registry** (`SMEMBERS {prefix}:queues`) をそのまま返していた。drop-in で既存 Misskey TS の上に乗ると、この registry には旧 TS が登録した BullMQ queue 名が残っており、mk-go が処理しない queue まで列挙してしまう。

## 修正

`Inspector.Queues()` を、driver が起動時に Define した **mk-go 管理 queue 名** (`deliver` / `inbox` / `push` / `export` / `webhook` / `maintenance`、config 順) を返すよう変更。共有 registry は参照しない。

- これは関数の doc コメント (“queues mkq has Define'd”) 本来の意図とも一致 (実装が registry を返していたのが乖離していた)。
- 唯一の呼び出し元は `admin/queue/queues` handler。worker の処理対象決定には使われない (worker は config 由来の queue set で動く) ため、影響は admin dashboard の表示のみ。
- mkq driver 限定の変更 (asynq は対象外 / 今後サポート外)。

## テスト

- `make fmt && make lint && make test` 全 pass。
- `TestInspector_Queues_ReturnsManagedNamesOnly`: 管理 queue 名を順序通りに返し、返り値が copy (driver 内部状態を mutate しない) ことを確認。driver に client/rdb を持たせずに通ることが「registry を引かない」ことの証左。
- 既存 integration test (`ins.Queues()` が `deliver` を含む) も green 維持。

## #1393 の残件クローズ

- ✅ Memory/Clients/Uptime の実値化: #1394 (merged)
- ✅ foreign queue 列挙の除外: 本 PR
- idle queue (export/webhook/maintenance) のチャート平坦は traffic 0 の正常挙動 (ジョブが流れれば mkq の per-queue metrics で動く)。

以上で #1393 の指摘は解消するため `Closes #1393`。

Closes #1393

🤖 Generated with [Claude Code](https://claude.com/claude-code)