### PR TITLE
fix(admin): job queue 画面で completed/failed ジョブを一覧表示する

### DIFF
--- a/internal/api/admin/handler.go
+++ b/internal/api/admin/handler.go
@@ -344,6 +344,8 @@ type QueueInspector interface {
 	ListActiveTasks(qname string, page, pageSize int) ([]*QueueTaskSummary, error)
 	ListScheduledTasks(qname string, page, pageSize int) ([]*QueueTaskSummary, error)
 	ListRetryTasks(qname string, page, pageSize int) ([]*QueueTaskSummary, error)
+	ListCompletedTasks(qname string, page, pageSize int) ([]*QueueTaskSummary, error)
+	ListFailedTasks(qname string, page, pageSize int) ([]*QueueTaskSummary, error)
 	GetTaskInfo(qname, taskID string) (*QueueTaskSummary, error)
 	QueueMetrics(qname, kind string) (*QueueMetricsResult, error)
 }

--- a/internal/api/admin/queue.go
+++ b/internal/api/admin/queue.go
@@ -280,9 +280,9 @@ func parseStateField(raw json.RawMessage) []string {
 	return []string{"wait"}
 }
 
-// listTasksForState maps a Bull/asynq state name to the matching asynq list
-// call. Returns an empty slice for states asynq does not support (completed /
-// failed / paused) so the admin tab renders an empty list instead of 500.
+// listTasksForState maps a Bull state name to the matching inspector list call.
+// completed / failed は mkq の finished-job 保持から引く。"paused" は queue 状態
+// であってジョブ一覧ではないため空で返す (admin tab は空表示)。
 func (h *Handler) listTasksForState(queue, state string, page, limit int) ([]*QueueTaskSummary, error) {
 	switch state {
 	case "active":
@@ -299,9 +299,15 @@ func (h *Handler) listTasksForState(queue, state string, page, limit int) ([]*Qu
 		sched, _ := h.queueInspector.ListScheduledTasks(queue, page, limit)
 		retry, _ := h.queueInspector.ListRetryTasks(queue, page, limit)
 		return append(sched, retry...), nil
-	case "completed", "failed", "paused":
-		// asynq は retention 未設定だと completed/failed 履歴を保持しない。
-		// 履歴APIが無いので空配列でフロントを通す (tab 表示自体は出す)。
+	case "completed":
+		// mkq は WithKeepCompleted retention で完了ジョブを保持する。frontend
+		// の All / Latest / Completed タブはこれを引く (#1396)。
+		return h.queueInspector.ListCompletedTasks(queue, page, limit)
+	case "failed":
+		return h.queueInspector.ListFailedTasks(queue, page, limit)
+	case "paused":
+		// "paused" は queue 状態であってジョブ一覧ではない。mk-go は queue を
+		// pause しないため空で返す。
 		return nil, nil
 	default:
 		return h.queueInspector.ListPendingTasks(queue, page, limit)

--- a/internal/api/admin/queue_test.go
+++ b/internal/api/admin/queue_test.go
@@ -64,6 +64,8 @@ type stubQueueInspector struct {
 	active        map[string][]*apiadmin.QueueTaskSummary
 	scheduled     map[string][]*apiadmin.QueueTaskSummary
 	retry         map[string][]*apiadmin.QueueTaskSummary
+	completed     map[string][]*apiadmin.QueueTaskSummary
+	failed        map[string][]*apiadmin.QueueTaskSummary
 	task          map[string]*apiadmin.QueueTaskSummary
 	metrics       map[string]map[string]*apiadmin.QueueMetricsResult // [queue][kind]
 	deleted       []string
@@ -110,6 +112,12 @@ func (s *stubQueueInspector) ListScheduledTasks(q string, _, _ int) ([]*apiadmin
 }
 func (s *stubQueueInspector) ListRetryTasks(q string, _, _ int) ([]*apiadmin.QueueTaskSummary, error) {
 	return s.retry[q], nil
+}
+func (s *stubQueueInspector) ListCompletedTasks(q string, _, _ int) ([]*apiadmin.QueueTaskSummary, error) {
+	return s.completed[q], nil
+}
+func (s *stubQueueInspector) ListFailedTasks(q string, _, _ int) ([]*apiadmin.QueueTaskSummary, error) {
+	return s.failed[q], nil
 }
 func (s *stubQueueInspector) GetTaskInfo(_, id string) (*apiadmin.QueueTaskSummary, error) {
 	if t, ok := s.task[id]; ok {
@@ -707,4 +715,40 @@ func TestQueueStats_DelayedIncludesScheduledAndRetry(t *testing.T) {
 
 	// inbox: Scheduled 5 + Retry 6 = 11
 	assert.EqualValues(t, 11, resp["inbox"]["delayed"], "delayed must be Scheduled+Retry")
+}
+
+// QueueJobs は mkq の finished-job 保持から completed / failed を一覧する (#1396)。
+// 旧実装は asynq 前提で completed/failed を nil 固定にしており、busy queue でも
+// All / Completed タブが空になっていた。
+func TestQueueJobs_ListsCompletedAndFailed(t *testing.T) {
+	h, _, _, _ := newTestHandler(t)
+	insp := &stubQueueInspector{
+		completed: map[string][]*apiadmin.QueueTaskSummary{
+			"inbox": {{ID: "c1", Queue: "inbox", Type: "inbox:process", State: "completed"}},
+		},
+		failed: map[string][]*apiadmin.QueueTaskSummary{
+			"inbox": {{ID: "f1", Queue: "inbox", Type: "inbox:process", State: "failed"}},
+		},
+	}
+	h.SetQueueInspector(insp)
+
+	// state=completed → 完了ジョブが返る。
+	rec := doPost(h.QueueJobs, `{"queue":"inbox","state":["completed"]}`, adminUser)
+	require.Equal(t, http.StatusOK, rec.Code)
+	var got []map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &got))
+	require.Len(t, got, 1)
+	assert.Equal(t, "c1", got[0]["id"])
+
+	// state=all (frontend の All タブ) → completed + failed が両方含まれる。
+	rec2 := doPost(h.QueueJobs, `{"queue":"inbox","state":["completed","failed","active","delayed","wait"]}`, adminUser)
+	require.Equal(t, http.StatusOK, rec2.Code)
+	var got2 []map[string]any
+	require.NoError(t, json.Unmarshal(rec2.Body.Bytes(), &got2))
+	ids := map[string]bool{}
+	for _, j := range got2 {
+		ids[j["id"].(string)] = true
+	}
+	assert.True(t, ids["c1"], "completed job present in all-tab")
+	assert.True(t, ids["f1"], "failed job present in all-tab")
 }

--- a/internal/queue/driver/asynqdriver/inspector.go
+++ b/internal/queue/driver/asynqdriver/inspector.go
@@ -89,6 +89,17 @@ func (i *Inspector) ListActiveTasks(qname string, page, pageSize int) ([]*driver
 	return i.listTasks(qname, "active", page, pageSize)
 }
 
+// ListCompletedTasks / ListFailedTasks return nil: asynq does not retain
+// finished-job history without per-task retention, and asynq support is being
+// dropped in favour of mkq. Provided to satisfy driver.Inspector.
+func (i *Inspector) ListCompletedTasks(_ string, _, _ int) ([]*driver.TaskSummary, error) {
+	return nil, nil
+}
+
+func (i *Inspector) ListFailedTasks(_ string, _, _ int) ([]*driver.TaskSummary, error) {
+	return nil, nil
+}
+
 // ListScheduledTasks returns up to pageSize scheduled tasks.
 func (i *Inspector) ListScheduledTasks(qname string, page, pageSize int) ([]*driver.TaskSummary, error) {
 	return i.listTasks(qname, "scheduled", page, pageSize)

--- a/internal/queue/driver/driver.go
+++ b/internal/queue/driver/driver.go
@@ -92,6 +92,11 @@ type Inspector interface {
 	ListActiveTasks(qname string, page, pageSize int) ([]*TaskSummary, error)
 	ListScheduledTasks(qname string, page, pageSize int) ([]*TaskSummary, error)
 	ListRetryTasks(qname string, page, pageSize int) ([]*TaskSummary, error)
+	// ListCompletedTasks / ListFailedTasks return finished jobs retained in
+	// the completed / failed buckets. Drivers without finished-job retention
+	// return an empty slice.
+	ListCompletedTasks(qname string, page, pageSize int) ([]*TaskSummary, error)
+	ListFailedTasks(qname string, page, pageSize int) ([]*TaskSummary, error)
 
 	GetTaskInfo(qname, taskID string) (*TaskSummary, error)
 

--- a/internal/queue/driver/mkqdriver/inspector.go
+++ b/internal/queue/driver/mkqdriver/inspector.go
@@ -250,6 +250,17 @@ func (i *Inspector) ListActiveTasks(qname string, page, pageSize int) ([]*driver
 	return i.list(qname, mkq.JobBucketActive, page, pageSize)
 }
 
+// ListCompletedTasks returns up to pageSize jobs retained in the completed
+// bucket (mkq keeps finished jobs per WithKeepCompleted retention).
+func (i *Inspector) ListCompletedTasks(qname string, page, pageSize int) ([]*driver.TaskSummary, error) {
+	return i.list(qname, mkq.JobBucketCompleted, page, pageSize)
+}
+
+// ListFailedTasks returns up to pageSize jobs retained in the failed bucket.
+func (i *Inspector) ListFailedTasks(qname string, page, pageSize int) ([]*driver.TaskSummary, error) {
+	return i.list(qname, mkq.JobBucketFailed, page, pageSize)
+}
+
 // ListScheduledTasks returns up to pageSize tasks scheduled for first-time
 // processing (= delayed bucket entries with `atm == 0`). cron / 初回
 // delayed enqueue 等が含まれる。retry-backoff 待ち (= `atm > 0`) は

--- a/internal/queue/inspector.go
+++ b/internal/queue/inspector.go
@@ -68,6 +68,16 @@ func (i *Inspector) ListActiveTasks(qname string, page, pageSize int) ([]*TaskSu
 	return i.inner.ListActiveTasks(qname, page, pageSize)
 }
 
+// ListCompletedTasks returns up to pageSize completed (finished) tasks.
+func (i *Inspector) ListCompletedTasks(qname string, page, pageSize int) ([]*TaskSummary, error) {
+	return i.inner.ListCompletedTasks(qname, page, pageSize)
+}
+
+// ListFailedTasks returns up to pageSize failed (finished) tasks.
+func (i *Inspector) ListFailedTasks(qname string, page, pageSize int) ([]*TaskSummary, error) {
+	return i.inner.ListFailedTasks(qname, page, pageSize)
+}
+
 // ListScheduledTasks returns up to pageSize scheduled tasks.
 func (i *Inspector) ListScheduledTasks(qname string, page, pageSize int) ([]*TaskSummary, error) {
 	return i.inner.ListScheduledTasks(qname, page, pageSize)

--- a/internal/queue/metrics/metrics_test.go
+++ b/internal/queue/metrics/metrics_test.go
@@ -70,6 +70,12 @@ func (i *fakeInspector) ListPendingTasks(qname string, page, pageSize int) ([]*d
 func (i *fakeInspector) ListActiveTasks(qname string, page, pageSize int) ([]*driver.TaskSummary, error) {
 	return nil, nil
 }
+func (i *fakeInspector) ListCompletedTasks(qname string, page, pageSize int) ([]*driver.TaskSummary, error) {
+	return nil, nil
+}
+func (i *fakeInspector) ListFailedTasks(qname string, page, pageSize int) ([]*driver.TaskSummary, error) {
+	return nil, nil
+}
 func (i *fakeInspector) ListScheduledTasks(qname string, page, pageSize int) ([]*driver.TaskSummary, error) {
 	return nil, nil
 }

--- a/internal/server/autoscale_wiring_test.go
+++ b/internal/server/autoscale_wiring_test.go
@@ -98,6 +98,12 @@ func (i *scriptableInspector) ListPendingTasks(qname string, page, pageSize int)
 func (i *scriptableInspector) ListActiveTasks(qname string, page, pageSize int) ([]*driver.TaskSummary, error) {
 	return nil, nil
 }
+func (i *scriptableInspector) ListCompletedTasks(qname string, page, pageSize int) ([]*driver.TaskSummary, error) {
+	return nil, nil
+}
+func (i *scriptableInspector) ListFailedTasks(qname string, page, pageSize int) ([]*driver.TaskSummary, error) {
+	return nil, nil
+}
 func (i *scriptableInspector) ListScheduledTasks(qname string, page, pageSize int) ([]*driver.TaskSummary, error) {
 	return nil, nil
 }

--- a/internal/server/metrics_route_test.go
+++ b/internal/server/metrics_route_test.go
@@ -79,6 +79,12 @@ func (i *fakeMetricsInspector) ListPendingTasks(qname string, page, pageSize int
 func (i *fakeMetricsInspector) ListActiveTasks(qname string, page, pageSize int) ([]*driver.TaskSummary, error) {
 	return nil, nil
 }
+func (i *fakeMetricsInspector) ListCompletedTasks(qname string, page, pageSize int) ([]*driver.TaskSummary, error) {
+	return nil, nil
+}
+func (i *fakeMetricsInspector) ListFailedTasks(qname string, page, pageSize int) ([]*driver.TaskSummary, error) {
+	return nil, nil
+}
 func (i *fakeMetricsInspector) ListScheduledTasks(qname string, page, pageSize int) ([]*driver.TaskSummary, error) {
 	return nil, nil
 }

--- a/internal/server/queue_adapter.go
+++ b/internal/server/queue_adapter.go
@@ -95,6 +95,16 @@ func (a *queueInspectorAdapter) ListScheduledTasks(qname string, page, pageSize 
 	return taskSummariesToAdmin(rows), err
 }
 
+func (a *queueInspectorAdapter) ListCompletedTasks(qname string, page, pageSize int) ([]*apiadmin.QueueTaskSummary, error) {
+	rows, err := a.inner.ListCompletedTasks(qname, page, pageSize)
+	return taskSummariesToAdmin(rows), err
+}
+
+func (a *queueInspectorAdapter) ListFailedTasks(qname string, page, pageSize int) ([]*apiadmin.QueueTaskSummary, error) {
+	rows, err := a.inner.ListFailedTasks(qname, page, pageSize)
+	return taskSummariesToAdmin(rows), err
+}
+
 func (a *queueInspectorAdapter) ListRetryTasks(qname string, page, pageSize int) ([]*apiadmin.QueueTaskSummary, error) {
 	rows, err := a.inner.ListRetryTasks(qname, page, pageSize)
 	return taskSummariesToAdmin(rows), err


### PR DESCRIPTION
## Summary

admin ジョブキュー画面の下部「ジョブ一覧」(All / Latest / Completed / Failed タブ) が**常に空**だった (issue #1396)。

原因: `listTasksForState` が `completed` / `failed` / `paused` を **asynq 前提で nil 固定**にしていた (「asynq は finished-job 履歴を保持しない」)。frontend の All タブは `[completed, failed, active, delayed, wait]` を要求するが、busy queue (inbox / deliver) はジョブの大半が `completed` 済みのため、active/delayed/wait が一瞬 0 だと一覧が丸ごと空に見えていた。

mk-go の現行ドライバ **mkq は finished-job (completed/failed bucket) を retention 付きで保持する**ので、それを一覧する経路を通す。

## 主な変更点

- `driver.Inspector` に `ListCompletedTasks` / `ListFailedTasks` を追加。
  - mkqdriver: `i.list(qname, mkq.JobBucketCompleted/Failed, ...)` で finished-job を引く。
  - asynqdriver: nil stub (finished-job 保持なし / 今後サポート外)。
- `queue.Inspector` → `admin.QueueInspector` → `queueInspectorAdapter` に伝播。
- `listTasksForState`: `completed`→`ListCompletedTasks`、`failed`→`ListFailedTasks`。`paused` は queue 状態であってジョブ一覧ではないため空のまま。doc コメントも asynq 前提を除去。

## テスト

- `make fmt && make lint && make test` 全 pass。
- `TestQueueJobs_ListsCompletedAndFailed`: `state=["completed"]` で完了ジョブ、`state=[all...]` で completed + failed が両方含まれることを handler 経由で確認。
- driver.Inspector 拡張に伴う test stub (mkqdriver / asynqdriver / metrics / autoscale / metrics_route / admin) を更新。

## #1393 / #1394 / #1395 の系譜

ジョブキュー管理画面は「ウィジェット (deliver/inbox streaming) しか考慮されていなかった」ため、admin ページの各部 (per-queue db, queue 一覧, ジョブ一覧) が順次 asynq 前提のまま放置されていた。本 PR でジョブ一覧 (下部) を埋めて一通り解消。

Closes #1396

🤖 Generated with [Claude Code](https://claude.com/claude-code)