### PR TITLE
fix(admin): job 詳細の Created at / Processed at が 1970/1/1 になるのを修正

### DIFF
--- a/internal/api/admin/handler.go
+++ b/internal/api/admin/handler.go
@@ -384,6 +384,8 @@ type QueueTaskSummary struct {
 	LastErr       string
 	LastFailedAt  time.Time
 	NextProcessAt time.Time
+	EnqueuedAt    time.Time
+	ProcessedAt   time.Time
 	CompletedAt   time.Time
 }
 

--- a/internal/api/admin/queue.go
+++ b/internal/api/admin/queue.go
@@ -578,12 +578,10 @@ func packTaskSummary(t *QueueTaskSummary) map[string]any {
 	// frontend の MkTl / MkTime は 0 を「たった今」として扱うので害はない。
 	pack := map[string]any{
 		// Bull 互換 field (frontend 必須)
-		"id":          t.ID,
-		"name":        t.Type,
-		"timestamp":   formatUnixMillisOrZero(t.NextProcessAt),
-		"processedAt": formatUnixMillisOrZero(t.LastFailedAt),
-		"processedOn": formatUnixMillisOrZero(t.LastFailedAt),
-		"finishedOn":  formatUnixMillisOrZero(t.CompletedAt),
+		"id":   t.ID,
+		"name": t.Type,
+		// timestamp = job 作成時刻 (Bull job.timestamp)。常に present。
+		"timestamp": formatUnixMillisOrZero(t.EnqueuedAt),
 		// golden QueueJob は progress / returnValue を Record (object) 必須、
 		// failedReason を string 必須とする。Bull の job は failure 時のみ理由を
 		// 持つが、schema 上は常に present (無 failure 時は空文字) なので常に出す。
@@ -610,6 +608,20 @@ func packTaskSummary(t *QueueTaskSummary) map[string]any {
 		"payload":  string(t.Payload),
 		"retried":  t.Retried,
 		"maxRetry": t.MaxRetry,
+	}
+	// processedOn / finishedOn は golden で optional:true (number)。値があるときだけ
+	// number で出す。未処理 / 未完了は key 省略 → frontend の `job.processedOn !=
+	// null` で "Processed at"/"Finished at" 行が非表示になる (Bull 互換、#1398)。
+	if !t.ProcessedAt.IsZero() {
+		ms := t.ProcessedAt.UnixMilli()
+		pack["processedOn"] = ms
+		pack["processedAt"] = ms
+	}
+	// 完了時刻は成功 (CompletedAt) / 失敗 (LastFailedAt) いずれかの finish 時刻。
+	if finished := t.CompletedAt; !finished.IsZero() {
+		pack["finishedOn"] = finished.UnixMilli()
+	} else if !t.LastFailedAt.IsZero() {
+		pack["finishedOn"] = t.LastFailedAt.UnixMilli()
 	}
 	if t.LastErr != "" {
 		pack["lastErr"] = t.LastErr

--- a/internal/api/admin/queue.go
+++ b/internal/api/admin/queue.go
@@ -574,8 +574,6 @@ func packTaskSummary(t *QueueTaskSummary) map[string]any {
 	if data == nil {
 		data = map[string]any{}
 	}
-	// asynqはBullと違いEnqueuedAtを保持しない (TaskInfoに該当field無し)。
-	// frontend の MkTl / MkTime は 0 を「たった今」として扱うので害はない。
 	pack := map[string]any{
 		// Bull 互換 field (frontend 必須)
 		"id":   t.ID,

--- a/internal/api/admin/queue_test.go
+++ b/internal/api/admin/queue_test.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"net/http"
 	"testing"
+	"time"
 
 	apiadmin "github.com/shiroha-a/mk/internal/api/admin"
 	"github.com/shiroha-a/mk/internal/entitycompat/shapetest"
@@ -751,4 +752,48 @@ func TestQueueJobs_ListsCompletedAndFailed(t *testing.T) {
 	}
 	assert.True(t, ids["c1"], "completed job present in all-tab")
 	assert.True(t, ids["f1"], "failed job present in all-tab")
+}
+
+// ジョブ詳細の timestamp は job 作成/処理/完了の実時刻から出す (#1398)。
+// 旧実装は timestamp に NextProcessAt、processedOn に LastFailedAt を使い、
+// completed/failed ジョブで 0 (= 1970/1/1) になっていた。
+func TestQueueJobs_TimestampsFromJobState(t *testing.T) {
+	created := time.UnixMilli(1_700_000_000_000)
+	processed := time.UnixMilli(1_700_000_001_000)
+	finished := time.UnixMilli(1_700_000_002_000)
+	h, _, _, _ := newTestHandler(t)
+	insp := &stubQueueInspector{
+		completed: map[string][]*apiadmin.QueueTaskSummary{
+			"deliver": {{
+				ID: "c1", Queue: "deliver", Type: "x", State: "completed",
+				EnqueuedAt: created, ProcessedAt: processed, CompletedAt: finished,
+			}},
+		},
+		pending: map[string][]*apiadmin.QueueTaskSummary{
+			"deliver": {{ID: "p1", Queue: "deliver", Type: "x", State: "pending", EnqueuedAt: created}},
+		},
+	}
+	h.SetQueueInspector(insp)
+
+	// completed: 3 つの時刻が実 ms で出る。
+	rec := doPost(h.QueueJobs, `{"queue":"deliver","state":["completed"]}`, adminUser)
+	require.Equal(t, http.StatusOK, rec.Code)
+	var got []map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &got))
+	require.Len(t, got, 1)
+	assert.EqualValues(t, created.UnixMilli(), got[0]["timestamp"])
+	assert.EqualValues(t, processed.UnixMilli(), got[0]["processedOn"])
+	assert.EqualValues(t, finished.UnixMilli(), got[0]["finishedOn"])
+
+	// pending: processedOn / finishedOn は省略され 1970 にならない。timestamp は present。
+	rec2 := doPost(h.QueueJobs, `{"queue":"deliver","state":["wait"]}`, adminUser)
+	require.Equal(t, http.StatusOK, rec2.Code)
+	var got2 []map[string]any
+	require.NoError(t, json.Unmarshal(rec2.Body.Bytes(), &got2))
+	require.Len(t, got2, 1)
+	assert.EqualValues(t, created.UnixMilli(), got2[0]["timestamp"])
+	_, hasProcessed := got2[0]["processedOn"]
+	assert.False(t, hasProcessed, "未処理ジョブは processedOn を省略する")
+	_, hasFinished := got2[0]["finishedOn"]
+	assert.False(t, hasFinished, "未完了ジョブは finishedOn を省略する")
 }

--- a/internal/api/admin/queue_test.go
+++ b/internal/api/admin/queue_test.go
@@ -772,6 +772,13 @@ func TestQueueJobs_TimestampsFromJobState(t *testing.T) {
 		pending: map[string][]*apiadmin.QueueTaskSummary{
 			"deliver": {{ID: "p1", Queue: "deliver", Type: "x", State: "pending", EnqueuedAt: created}},
 		},
+		failed: map[string][]*apiadmin.QueueTaskSummary{
+			// 失敗ジョブは CompletedAt 無し。finishedOn は LastFailedAt から出す。
+			"deliver": {{
+				ID: "x1", Queue: "deliver", Type: "x", State: "failed",
+				EnqueuedAt: created, ProcessedAt: processed, LastFailedAt: finished, LastErr: "boom",
+			}},
+		},
 	}
 	h.SetQueueInspector(insp)
 
@@ -796,4 +803,13 @@ func TestQueueJobs_TimestampsFromJobState(t *testing.T) {
 	assert.False(t, hasProcessed, "未処理ジョブは processedOn を省略する")
 	_, hasFinished := got2[0]["finishedOn"]
 	assert.False(t, hasFinished, "未完了ジョブは finishedOn を省略する")
+
+	// failed: CompletedAt 無しでも finishedOn は LastFailedAt から出る。
+	rec3 := doPost(h.QueueJobs, `{"queue":"deliver","state":["failed"]}`, adminUser)
+	require.Equal(t, http.StatusOK, rec3.Code)
+	var got3 []map[string]any
+	require.NoError(t, json.Unmarshal(rec3.Body.Bytes(), &got3))
+	require.Len(t, got3, 1)
+	assert.EqualValues(t, processed.UnixMilli(), got3[0]["processedOn"])
+	assert.EqualValues(t, finished.UnixMilli(), got3[0]["finishedOn"])
 }

--- a/internal/queue/driver/driver.go
+++ b/internal/queue/driver/driver.go
@@ -75,7 +75,10 @@ type TaskSummary struct {
 	NextProcessAt time.Time
 	EnqueuedAt    time.Time
 	ScheduledAt   time.Time
-	CompletedAt   time.Time
+	// ProcessedAt is when the job was last dispatched to a worker (Bull
+	// job.processedOn). Populated for finished jobs; zero for never-run jobs.
+	ProcessedAt time.Time
+	CompletedAt time.Time
 }
 
 // Inspector exposes admin-level queue introspection used by the

--- a/internal/queue/driver/mkqdriver/inspector.go
+++ b/internal/queue/driver/mkqdriver/inspector.go
@@ -437,13 +437,12 @@ func jobToSummary(queue, state string, job *mkq.Job[framedPayload], st *mkq.JobS
 			s.LastErr = st.FailedReason
 			s.LastFailedAt = st.FinishedOn
 		}
-		// NextProcessAt は本来「次に処理される時刻」(将来) を意味する
-		// asynq.TaskInfo.NextProcessAt のミラー。mkq の JobState は
-		// ProcessedOn (過去: 直近のディスパッチ時刻) しか持たないため
-		// ここに ProcessedOn を入れると意味的に逆。retry までの
-		// 待ち時刻も mkq からは取得できないので zero のまま残す方が
-		// admin UI の混乱が少ない。delayed bucket の予定時刻が必要
-		// になった場合は別途 ZSET score を読みに行く実装を検討。
+		// ProcessedAt = Bull job.processedOn (過去: 直近のディスパッチ時刻)。
+		// admin job 詳細の "Processed at" 表示に使う (#1398)。
+		s.ProcessedAt = st.ProcessedOn
+		// NextProcessAt は本来「次に処理される時刻」(将来) を意味するミラー。
+		// mkq の JobState は未来の retry 予定時刻を持たないので zero のまま残す。
+		// delayed bucket の予定時刻が必要になった場合は別途 ZSET score を読む。
 	}
 	return s
 }

--- a/internal/server/queue_adapter.go
+++ b/internal/server/queue_adapter.go
@@ -152,6 +152,8 @@ func taskSummaryToAdmin(t *queue.TaskSummary) *apiadmin.QueueTaskSummary {
 		LastErr:       t.LastErr,
 		LastFailedAt:  t.LastFailedAt,
 		NextProcessAt: t.NextProcessAt,
+		EnqueuedAt:    t.EnqueuedAt,
+		ProcessedAt:   t.ProcessedAt,
 		CompletedAt:   t.CompletedAt,
 	}
 }


### PR DESCRIPTION
## Summary

#1397 で job queue 画面下部のジョブ一覧が表示されるようになったが、各ジョブの **Created at / Processed at が 1970/1/1 (epoch 0)** になっていた (issue #1398)。

## 原因

`packTaskSummary` の timestamp マッピングが誤っていた:
- frontend `job-queue.job.vue` は **Created at ← `job.timestamp`** / **Processed at ← `job.processedOn`** / **Finished at ← `job.finishedOn`** を表示する。
- mk-go は `timestamp` に `NextProcessAt`、`processedOn` に `LastFailedAt` を入れていた。completed/failed ジョブではこれらが zero → `formatUnixMillisOrZero` が 0 を返し 1970 表示。
- 実際の作成時刻 (`EnqueuedAt` = mkq `job.Timestamp`) は adapter が drop し、処理時刻 (`st.ProcessedOn`) は TaskSummary に取り込まれていなかった。

## 修正

- `driver.TaskSummary` / `admin.QueueTaskSummary` に `ProcessedAt` を追加 (EnqueuedAt も adapter で伝播)。mkqdriver `jobToSummary` で `st.ProcessedOn` を取り込む。
- `packTaskSummary`:
  - `timestamp` ← `EnqueuedAt` (作成時刻、常に present)。
  - `processedOn` / `finishedOn` は golden で **optional:true (number)**。値があるときだけ number で出し、zero のとき **key を省略** → frontend の `job.processedOn != null` で「Processed at / Finished at」行が非表示 (Bull 互換、1970 を出さない)。
  - `finishedOn` は成功 (`CompletedAt`) / 失敗 (`LastFailedAt`) いずれかの finish 時刻。

## テスト

- `make fmt && make lint && make test` 全 pass (QueueJob L3 shapetest も optional 省略で golden 準拠を維持)。
- `TestQueueJobs_TimestampsFromJobState`: completed ジョブで timestamp/processedOn/finishedOn が実 ms、pending ジョブで processedOn/finishedOn が省略される (1970 を出さない) ことを確認。

Closes #1398

🤖 Generated with [Claude Code](https://claude.com/claude-code)