### PR TITLE
fix(docker): docker-compose.yml でフロントエンドアセットを配信する

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -92,6 +92,13 @@ ENV MISSKEY_REPO_ASSETS_DIR=/app/repo-assets
 COPY --from=builder /app/third_party/misskey/packages/backend/node_modules/@misskey-dev/emoji-assets/built/twemoji /app/twemoji
 ENV MISSKEY_TWEMOJI_DIR=/app/twemoji
 
+# fluent-emoji PNG set。frontend が実績バッジ / notification icon を
+# /fluent-emoji/<hex>.png で参照する。twemoji と同じ @misskey-dev/emoji-assets
+# パッケージに含まれる (upstream 2026.5.2 #17381)。これが無いと実績バッジ等が
+# 404 になる (deploy/uds/Dockerfile.mkgo では焼き込み済みだが main は欠落していた)。
+COPY --from=builder /app/third_party/misskey/packages/backend/node_modules/@misskey-dev/emoji-assets/built/fluent-emoji /app/fluent-emoji
+ENV MISSKEY_FLUENT_EMOJI_DIR=/app/fluent-emoji
+
 # デフォルト設定ファイルをコピー (docker-compose でマウント上書き可能)。
 # `.config/docker.yml` は gitignored で operator-local なので、image に
 # 焼き込むのは `.example` 側 (placeholder 値を持つテンプレート)。

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,6 +8,9 @@ services:
         condition: service_healthy
       redis:
         condition: service_healthy
+      # 新規構築では DB が空なので、app 起動前に migration の完走を待つ。
+      migrate:
+        condition: service_completed_successfully
     environment:
       # ビルド済みフロントエンド (SPA) の配信元。下の volumes で host の
       # `third_party/misskey/built` を /frontend に bind-mount し、ここを指す。
@@ -36,6 +39,24 @@ services:
       # .config/docker.yml して編集後にコメントを外す):
       # - ./.config/docker.yml:/app/.config/default.yml:ro
     restart: unless-stopped
+
+  # DB マイグレーションを適用する one-shot サービス。新規構築では DB が空のため、
+  # これが完走しないと app は `relation "meta" does not exist` 等で機能しない。
+  # app と同じ image を使い、entrypoint だけ /app/migrate に差し替える。
+  # golang-migrate は適用済み version を schema_migrations で管理するので、TS から
+  # swap した既存 DB に対しても追加テーブルのみを冪等に適用する (data loss なし)。
+  migrate:
+    build: .
+    depends_on:
+      db:
+        condition: service_healthy
+    entrypoint: ["/app/migrate"]
+    command: ["-config", ".config/default.yml", "-direction", "up"]
+    # app 側で設定ファイルを volume mount で上書きする場合は、migrate にも同じ
+    # mount を設定して同一の DB 接続先を参照させること。
+    # volumes:
+    #   - ./.config/docker.yml:/app/.config/default.yml:ro
+    restart: "no"
 
   db:
     image: postgres:16-alpine

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,12 +9,14 @@ services:
       redis:
         condition: service_healthy
     environment:
-      # フロントエンドアセットをコンテナ外からマウントする場合に設定
-      # MISSKEY_FRONTEND_DIR: /app/frontend
-      # MISSKEY_FRONTEND_DIST_DIR: /app/frontend_dist
-      # MISSKEY_TWEMOJI_DIR: /app/twemoji
-      # MISSKEY_STATIC_DIR: /app/static
-      # MISSKEY_REPO_ASSETS_DIR: /app/repo-assets
+      # ビルド済みフロントエンド (SPA) の配信元。下の volumes で host の
+      # `third_party/misskey/built` を /frontend に bind-mount し、ここを指す。
+      # static-assets / twemoji / fluent-emoji / repo-assets は image に焼き込み
+      # 済み (Dockerfile 参照) なので mount 不要。service worker (_sw_dist_) は
+      # MISSKEY_FRONTEND_DIR の親ディレクトリから自動解決される。
+      MISSKEY_FRONTEND_DIR: /frontend/_frontend_vite_
+      MISSKEY_FRONTEND_DIST_DIR: /frontend/_frontend_dist_
+      MISSKEY_CLIENT_ASSETS_DIR: /client-assets
       TZ: Asia/Tokyo
     volumes:
       # コンテナは UID/GID 991 (Misskey TS 互換) で起動するので、
@@ -22,6 +24,14 @@ services:
       # 旧 root 構成から upgrade する場合は一度
       # `sudo chown -R 991:991 ./files` を実行すること。
       - ./files:/app/drive-files
+      # ビルド済みフロントエンド成果物。起動前に host で `make e2e-frontend-build`
+      # を実行して `third_party/misskey/built/{_frontend_vite_,_frontend_dist_,
+      # _sw_dist_}` を生成しておくこと。約 200MB あるため image には焼き込まず
+      # mount で渡す (UDS 版 compose と同方針)。これが無いと SPA の JS/CSS が
+      # 404 になりフロントエンドが表示されない。
+      - ./third_party/misskey/built:/frontend:ro
+      # client assets (バブルゲーム / フラッシュ等が参照)。
+      - ./third_party/misskey/packages/frontend/assets:/client-assets:ro
       # 設定ファイルを上書きする場合 (cp .config/docker.yml.example
       # .config/docker.yml して編集後にコメントを外す):
       # - ./.config/docker.yml:/app/.config/default.yml:ro

--- a/docs/migration-from-ts.md
+++ b/docs/migration-from-ts.md
@@ -128,7 +128,10 @@ make e2e-frontend-build
 docker compose up -d --build
 ```
 
-mk-goがPostgreSQLおよびRedisと共に起動する。詳細は `docker-compose.yml` を参照。
+`docker-compose.yml` には one-shot の `migrate` サービスが含まれており、app 起動前に
+DB マイグレーションが自動適用される (空 DB でも、TS から swap した既存 DB でも冪等)。
+そのため上記の 2 ステップだけで mk-go が PostgreSQL および Redis と共に起動する。
+詳細は `docker-compose.yml` を参照。
 
 `make e2e-frontend-build` で生成した `third_party/misskey/built`(SPA の vite 成果物、約200MB)は、`docker-compose.yml` が bind-mount でコンテナに渡す（`MISSKEY_FRONTEND_DIR` 等で参照）。static-assets / twemoji / fluent-emoji / repo-assets は image に焼き込まれるためマウント不要。**この frontend ビルドを忘れると SPA の JS/CSS が 404 になりフロントエンドが表示されない**ので注意。
 

--- a/docs/migration-from-ts.md
+++ b/docs/migration-from-ts.md
@@ -120,10 +120,19 @@ docker compose stop web
 新しいインスタンスをDocker Composeで立ち上げる場合は以下で起動できる:
 
 ```bash
-docker compose up -d
+# 1. 起動前に必ずフロントエンドをビルドする (submodule + node_modules を取得し、
+#    third_party/misskey/built/ に SPA 成果物を生成する)。
+make e2e-frontend-build
+
+# 2. 起動 (初回は image build も走る)
+docker compose up -d --build
 ```
 
 mk-goがPostgreSQLおよびRedisと共に起動する。詳細は `docker-compose.yml` を参照。
+
+`make e2e-frontend-build` で生成した `third_party/misskey/built`(SPA の vite 成果物、約200MB)は、`docker-compose.yml` が bind-mount でコンテナに渡す（`MISSKEY_FRONTEND_DIR` 等で参照）。static-assets / twemoji / fluent-emoji / repo-assets は image に焼き込まれるためマウント不要。**この frontend ビルドを忘れると SPA の JS/CSS が 404 になりフロントエンドが表示されない**ので注意。
+
+> bare-metal 起動(バイナリを repo root から実行)の場合は、mk-go がデフォルトで `third_party/misskey/built/` 等の相対パスを参照するため環境変数の設定は不要。docker では WORKDIR が `/app` で相対パスが効かないため、上記の bind-mount + 環境変数で渡す。
 
 ### Docker container の UID
 


### PR DESCRIPTION
## Summary

ルートの `docker-compose.yml` で起動すると、フロントエンド SPA のアセット (vite ビルド成果物) が配信されずフロントが正常表示されない問題を修正する (issue #1402)。UDS 版 (`compose.uds.yaml`) は bind-mount で渡しており正常動作していた。

## 原因

- フロント配信に必要な `MISSKEY_FRONTEND_DIR` (= `built/_frontend_vite_`、SPA の JS/CSS + manifest.json)・`_frontend_dist_`・client assets が、main `docker-compose.yml` では未設定 (env がコメントアウト) かつ bind-mount もされていなかった。
- main `Dockerfile` は static-assets / repo-assets / twemoji は焼き込むが、ビルド済みフロント (約 200MB) は焼き込まない設計 (UDS と同じく mount 前提)。
- 加えて main `Dockerfile` は **fluent-emoji の焼き込みが欠落** (UDS には有り) しており、実績バッジ等の `/fluent-emoji/*.png` が 404 だった。

## 修正 (UDS の動作構成に揃える)

- **docker-compose.yml**: `third_party/misskey/built` と `packages/frontend/assets` を bind-mount し、`MISSKEY_FRONTEND_DIR` / `MISSKEY_FRONTEND_DIST_DIR` / `MISSKEY_CLIENT_ASSETS_DIR` を設定 (SW は FRONTEND_DIR の親から自動解決)。200MB あるため image には焼かず mount で渡す。
- **Dockerfile**: fluent-emoji を焼き込む (UDS と parity)。
- **docs/migration-from-ts.md**: docker 起動前に `make e2e-frontend-build` が必須な点と、bare-metal (相対パス参照で env 不要) との差を明記。

## 検証 (実機)

`make e2e-frontend-build` 済みで `docker compose up --build`:

| path | status |
|---|---|
| `/vite/manifest.json` | 200 (フロント mount が効いている) |
| `/fluent-emoji/1f4dd.png` | 200 (焼き込み修正) |
| `/twemoji/1f004.svg` | 200 |
| `/assets/ai.png` | 200 |
| `/` (SPA HTML) | `/vite/assets/*.css` 等が注入される |

`docker compose build` 成功・`docker compose config` 検証済み。

## 補足

- DB マイグレーションは main compose では別手順 (`docker compose exec app /app/migrate ... -direction up`) で適用する既存設計で、本 PR の対象外。
- main の `docker-compose.yml` は committed の動作する設定そのものなので、UDS のような別途 `.example` は設けていない (config (`.config/docker.yml`) 側のみ `.example` を持つ既存方針を踏襲)。

## Closes

Closes #1402

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

## 追加修正 (migration 自動適用)

レビュー指摘を受け、新規構築 (空 DB) で `docker compose up -d --build` が一発で完走するよう、one-shot `migrate` サービスを追加した。これまでは app 起動後に手動で `docker compose exec app /app/migrate ...` を叩かないと `relation "meta" does not exist` で機能しなかった。

- **docker-compose.yml**: app と同 image で entrypoint を `/app/migrate` に差し替えた `migrate` サービスを追加。app は `depends_on: migrate: condition: service_completed_successfully` で完了を待つ。golang-migrate は `schema_migrations` で適用済み version を管理するため、TS から swap した既存 DB に対しても追加テーブルのみ冪等適用 (data loss なし)。
- **docs/migration-from-ts.md**: 新規構築セクションを「2 ステップで完走」に更新。

### 実機検証 (空 DB クリーン構築)

`docker compose down -v` 後に `up -d --build`:

| 項目 | 結果 |
|---|---|
| migrate サービス | exit=0 (`migration completed direction=up`) |
| app の relation エラー | なし |
| `/api/meta` (POST) | 200 (DB 機能) |
| `/vite/manifest.json` | 200 |
| `/fluent-emoji/1f4dd.png` | 200 |