### PR TITLE
fix(queue): deliver/inbox の MaxAttempts 未指定時に TS 互換 default (12/8) を当てる (#1411)

### DIFF
--- a/.config/default.yml.example
+++ b/.config/default.yml.example
@@ -238,7 +238,8 @@ id: 'aidx'
 #inboxJobPerSec: 32
 #relationshipJobPerSec: 64
 
-# Job attempts
+# Job attempts (total tries incl. the first). Defaults match Misskey:
+# deliver=12, inbox=8. Set to 1 to disable retries to a failing remote.
 #deliverJobMaxAttempts: 12
 #inboxJobMaxAttempts: 8
 

--- a/.config/docker.yml.example
+++ b/.config/docker.yml.example
@@ -146,6 +146,8 @@ id: 'aidx'
 #deliverJobPerSec: 128
 #inboxJobPerSec: 32
 
+# Job attempts (total tries incl. the first). Defaults match Misskey:
+# deliver=12, inbox=8. Set to 1 to disable retries to a failing remote.
 #deliverJobMaxAttempts: 12
 #inboxJobMaxAttempts: 8
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+- Fix: 配送先が一時的にダウンしている場合に、deliver/inbox ジョブが設定省略時にリトライされない問題を修正 (既定の試行回数を Misskey 本家と同じ deliver=12 / inbox=8 に。従来の no-retry 挙動が必要な場合は `deliverJobMaxAttempts` / `inboxJobMaxAttempts` に 1 を指定)
+
 ## 0.9.2
 
 - Feat: グループチャットの連合に対応 (招待の送受信と Accept / Reject、ルームメッセージの送受信、退出の同期)

--- a/internal/queue/policy.go
+++ b/internal/queue/policy.go
@@ -32,7 +32,12 @@ type Policy struct {
 	// MaxAttempts is the **total** number of tries (initial + retries)
 	// allowed for tasks on this queue, matching BullMQ's `attempts`
 	// option semantics — same shape as Misskey TS YAML
-	// `<queue>JobMaxAttempts`. Zero = "fall back to driver default".
+	// `<queue>JobMaxAttempts`.
+	//
+	// Zero は EnqueueDeliver / EnqueueInbox では「WithMaxRetry を付けない」
+	// = mkq の attempts=0 (= リトライ無し) を意味する。落ちた配送先への
+	// retry-backoff を発火させるため、deliver/inbox は server 側の
+	// buildPolicy が未指定時に TS 互換の default (12 / 8) を当てる (#1411)。
 	//
 	// 内部では asynq の MaxRetry (= retries on top of initial) に
 	// 変換するため EnqueueDeliver で N-1 を渡す。drop-in 互換維持の

--- a/internal/server/queue_factory.go
+++ b/internal/server/queue_factory.go
@@ -95,6 +95,21 @@ func perQueueRatesFromConfig(cfg *config.Config) map[string]int {
 	return out
 }
 
+// defaultDeliverJobMaxAttempts / defaultInboxJobMaxAttempts are the total
+// number of tries (initial + retries) applied to the deliver / inbox queues
+// when the operator hasn't set `<queue>JobMaxAttempts`. They mirror Misskey
+// TS QueueService.ts (`deliverJobMaxAttempts ?? 12` / `inboxJobMaxAttempts
+// ?? 8`) so delivery to a temporarily-down remote retries instead of failing
+// on the first attempt.
+//
+// mkq の attempts=0 は「リトライ無し」であり、ここでデフォルトを当てないと
+// 落ちた配送先への retry-backoff (#1406) がそもそも発火しない。drop-in 互換の
+// ためにも TS と同じ既定値を使う (#1411)。
+const (
+	defaultDeliverJobMaxAttempts = 12
+	defaultInboxJobMaxAttempts   = 8
+)
+
 // defaultKeepFailed bounds the failed bucket retention applied to inbox /
 // deliver enqueue when operator が config で明示しない場合の安全側 default。
 // 1000 件あれば admin UI の Errored Instances panel (host aggregation で
@@ -130,8 +145,8 @@ const (
 // 経由で mkq native の per-fire option を上流仕様で drop するため本 PR では
 // 対象外 (mkq upstream 拡張後に follow-up)。
 func applyClientPolicies(c *queue.Client, cfg *config.Config) {
-	c.SetPolicy(queue.QueueName, buildPolicy(cfg.DeliverJobMaxAttempts, cfg.DeliverJobKeepFailed, cfg.DeliverJobKeepCompleted))
-	c.SetPolicy(queue.InboxQueueName, buildPolicy(cfg.InboxJobMaxAttempts, cfg.InboxJobKeepFailed, cfg.InboxJobKeepCompleted))
+	c.SetPolicy(queue.QueueName, buildPolicy(cfg.DeliverJobMaxAttempts, defaultDeliverJobMaxAttempts, cfg.DeliverJobKeepFailed, cfg.DeliverJobKeepCompleted))
+	c.SetPolicy(queue.InboxQueueName, buildPolicy(cfg.InboxJobMaxAttempts, defaultInboxJobMaxAttempts, cfg.InboxJobKeepFailed, cfg.InboxJobKeepCompleted))
 	// export / push / webhook 用の YAML key は意図的に増やさない (TS と
 	// 同じく一律の default を踏ませれば十分)。tuning 用 hook が必要に
 	// なったら deliver/inbox と同じ pattern で *KeepCompleted / *KeepFailed
@@ -145,23 +160,35 @@ func applyClientPolicies(c *queue.Client, cfg *config.Config) {
 // override exists for the queue. すべての retention default (KeepFailed /
 // KeepCompleted / KeepCompletedAge / KeepFailedAge) を含む。tuning hook
 // が無い queue (export / push / webhook) で applyClientPolicies が一律
-// 適用するために存在する。
+// 適用するために存在する。MaxAttempts は Policy.MaxAttempts を参照しない
+// queue 群なので default 0 (= 適用しない) を渡す。
 func defaultPolicy() queue.Policy {
-	return buildPolicy(nil, nil, nil)
+	return buildPolicy(nil, 0, nil, nil)
 }
 
 // buildPolicy assembles a queue.Policy from optional config pointers,
-// applying default retention values when the operator hasn't specified
-// them. MaxAttempts は未指定なら 0 = "driver default" のまま (= 既存挙動)。
+// applying default values when the operator hasn't specified them.
+//
+// MaxAttempts は KeepFailed / KeepCompleted と同じ 3 状態設計:
+//   - nil          → defaultMaxAttempts を適用 (Misskey TS の `?? N` 相当)
+//   - 明示 0        → 0 (operator opt-out = リトライ無し)
+//   - 明示 N (>0)   → N
+//
+// defaultMaxAttempts=0 を渡せば「未指定でも適用しない」(export/push/webhook 用)。
+// mkq の attempts=0 はリトライ無しのため、deliver/inbox では必ず非ゼロの
+// default を渡して落ちた配送先への retry-backoff を発火させる (#1411)。
 //
 // KeepFailed / KeepCompleted は nil で「default 適用」、明示 0 で「retention
 // 無し (operator opt-out)」、明示 N で「N 件まで保持」の 3 状態を表す。
 // Age 値 (KeepCompletedAge / KeepFailedAge) は operator が tuning する用途が
 // 薄いため YAML key を増やさず TS と同じ 7d 固定で適用する。
-func buildPolicy(maxAttempts *int, keepFailed *int, keepCompleted *int) queue.Policy {
+func buildPolicy(maxAttempts *int, defaultMaxAttempts int, keepFailed *int, keepCompleted *int) queue.Policy {
 	p := queue.Policy{}
-	if maxAttempts != nil && *maxAttempts > 0 {
+	if maxAttempts != nil {
+		// 明示値はそのまま尊重する (0 = operator opt-out)。
 		p.MaxAttempts = *maxAttempts
+	} else {
+		p.MaxAttempts = defaultMaxAttempts
 	}
 	if keepFailed != nil {
 		p.KeepFailed = *keepFailed

--- a/internal/server/queue_factory_test.go
+++ b/internal/server/queue_factory_test.go
@@ -192,16 +192,58 @@ func TestApplyClientPolicies_OperatorOptOut(t *testing.T) {
 	assert.Equal(t, defaultKeepFailed, rec.lastOpts.KeepFailed)
 }
 
-// TestDefaultPolicy: defaultPolicy() helper が buildPolicy(nil, nil, nil)
-// と同値であることを assert (refactoring 後の equivalence pin)。
+// TestDefaultPolicy: defaultPolicy() helper が buildPolicy(nil, 0, nil, nil)
+// と同値であることを assert (refactoring 後の equivalence pin)。export/push/
+// webhook は MaxAttempts default を当てないので defaultMaxAttempts=0。
 func TestDefaultPolicy(t *testing.T) {
-	assert.Equal(t, buildPolicy(nil, nil, nil), defaultPolicy())
+	assert.Equal(t, buildPolicy(nil, 0, nil, nil), defaultPolicy())
+	// defaultPolicy は MaxAttempts を当てない (= 0)。
+	assert.Equal(t, 0, defaultPolicy().MaxAttempts)
 }
 
-// TestBuildPolicy validates the (maxAttempts, keepFailed, keepCompleted)
-// → Policy transform end-to-end: unset → defaults (= 1000 / 30 / 7d / 7d)、
-// 明示 0 → 0 (= operator opt-out, unlimited 蓄積)、明示 N → N。Age 値は
-// YAML key を持たないので常に固定 7d (#1184 / #1193)。
+// TestApplyClientPolicies_DeliverInboxDefaultAttempts: operator が
+// `<queue>JobMaxAttempts` を指定しなくても deliver=12 / inbox=8 が
+// Policy.MaxAttempts に入り、EnqueueDeliver/EnqueueInbox で WithMaxRetry
+// (N-1) が driver opts に伝搬することを pin (#1411)。MaxAttempts default が
+// 無いと mkq attempts=0 で落ちた配送先がリトライされない回帰の防止。
+func TestApplyClientPolicies_DeliverInboxDefaultAttempts(t *testing.T) {
+	rec := &recordingDriverClient{}
+	c := queue.NewClient(&stubDriver{client: rec})
+	defer func() { _ = c.Close() }()
+
+	applyClientPolicies(c, &config.Config{})
+
+	require.NoError(t, c.EnqueueDeliver(queue.DeliverPayload{Inbox: "x", Body: []byte(`{}`)}))
+	// MaxAttempts=12 → WithMaxRetry(11) = 「初回 + 11 retry」。
+	assert.True(t, rec.lastOpts.MaxRetrySet, "deliver default attempts must propagate")
+	assert.Equal(t, defaultDeliverJobMaxAttempts-1, rec.lastOpts.MaxRetry)
+
+	require.NoError(t, c.EnqueueInbox(context.Background(), queue.InboxPayload{Body: []byte(`{}`)}))
+	assert.True(t, rec.lastOpts.MaxRetrySet, "inbox default attempts must propagate")
+	assert.Equal(t, defaultInboxJobMaxAttempts-1, rec.lastOpts.MaxRetry)
+}
+
+// TestApplyClientPolicies_OperatorAttemptsOptOut: operator が
+// deliverJobMaxAttempts=0 を明示すると opt-out (リトライ無し) として尊重され、
+// WithMaxRetry が付かない (= mkq attempts=0)。KeepFailed/KeepCompleted と同じ
+// 3 状態設計を MaxAttempts でも維持する (#1411)。
+func TestApplyClientPolicies_OperatorAttemptsOptOut(t *testing.T) {
+	rec := &recordingDriverClient{}
+	c := queue.NewClient(&stubDriver{client: rec})
+	defer func() { _ = c.Close() }()
+
+	applyClientPolicies(c, &config.Config{DeliverJobMaxAttempts: intp(0)})
+
+	require.NoError(t, c.EnqueueDeliver(queue.DeliverPayload{Inbox: "x", Body: []byte(`{}`)}))
+	assert.False(t, rec.lastOpts.MaxRetrySet, "explicit 0 must opt out of retries")
+	assert.Equal(t, 0, rec.lastOpts.MaxRetry)
+}
+
+// TestBuildPolicy validates the (maxAttempts, defaultMaxAttempts, keepFailed,
+// keepCompleted) → Policy transform end-to-end. MaxAttempts は 3 状態:
+// nil → defaultMaxAttempts、明示 0 → 0 (operator opt-out)、明示 N → N (#1411)。
+// retention は unset → defaults (= 1000 / 30 / 7d / 7d)、明示 0 → 0、明示 N → N。
+// Age 値は YAML key を持たないので常に固定 7d (#1184 / #1193)。
 func TestBuildPolicy(t *testing.T) {
 	defaultAges := struct {
 		completed time.Duration
@@ -211,15 +253,16 @@ func TestBuildPolicy(t *testing.T) {
 		failed:    defaultKeepFailedAge,
 	}
 	tests := []struct {
-		name          string
-		maxAttempts   *int
-		keepFailed    *int
-		keepCompleted *int
-		want          queue.Policy
+		name            string
+		maxAttempts     *int
+		defaultAttempts int
+		keepFailed      *int
+		keepCompleted   *int
+		want            queue.Policy
 	}{
 		{
-			"all unset",
-			nil, nil, nil,
+			"all unset, no attempts default",
+			nil, 0, nil, nil,
 			queue.Policy{
 				KeepFailed:       defaultKeepFailed,
 				KeepCompleted:    defaultKeepCompleted,
@@ -228,8 +271,19 @@ func TestBuildPolicy(t *testing.T) {
 			},
 		},
 		{
-			"only maxAttempts",
-			intp(8), nil, nil,
+			"unset attempts falls back to defaultMaxAttempts",
+			nil, 12, nil, nil,
+			queue.Policy{
+				MaxAttempts:      12,
+				KeepFailed:       defaultKeepFailed,
+				KeepCompleted:    defaultKeepCompleted,
+				KeepCompletedAge: defaultAges.completed,
+				KeepFailedAge:    defaultAges.failed,
+			},
+		},
+		{
+			"explicit attempts overrides defaultMaxAttempts",
+			intp(8), 12, nil, nil,
 			queue.Policy{
 				MaxAttempts:      8,
 				KeepFailed:       defaultKeepFailed,
@@ -239,8 +293,19 @@ func TestBuildPolicy(t *testing.T) {
 			},
 		},
 		{
+			"explicit attempts 0 opts out even with defaultMaxAttempts",
+			intp(0), 12, nil, nil,
+			queue.Policy{
+				MaxAttempts:      0,
+				KeepFailed:       defaultKeepFailed,
+				KeepCompleted:    defaultKeepCompleted,
+				KeepCompletedAge: defaultAges.completed,
+				KeepFailedAge:    defaultAges.failed,
+			},
+		},
+		{
 			"only keepFailed explicit 500",
-			nil, intp(500), nil,
+			nil, 0, intp(500), nil,
 			queue.Policy{
 				KeepFailed:       500,
 				KeepCompleted:    defaultKeepCompleted,
@@ -250,7 +315,7 @@ func TestBuildPolicy(t *testing.T) {
 		},
 		{
 			"only keepFailed explicit 0 (operator opt-out)",
-			nil, intp(0), nil,
+			nil, 0, intp(0), nil,
 			queue.Policy{
 				KeepFailed:       0,
 				KeepCompleted:    defaultKeepCompleted,
@@ -260,7 +325,7 @@ func TestBuildPolicy(t *testing.T) {
 		},
 		{
 			"only keepCompleted explicit 100",
-			nil, nil, intp(100),
+			nil, 0, nil, intp(100),
 			queue.Policy{
 				KeepFailed:       defaultKeepFailed,
 				KeepCompleted:    100,
@@ -270,7 +335,7 @@ func TestBuildPolicy(t *testing.T) {
 		},
 		{
 			"only keepCompleted explicit 0 (operator opt-out)",
-			nil, nil, intp(0),
+			nil, 0, nil, intp(0),
 			queue.Policy{
 				KeepFailed:       defaultKeepFailed,
 				KeepCompleted:    0,
@@ -280,7 +345,7 @@ func TestBuildPolicy(t *testing.T) {
 		},
 		{
 			"all explicit",
-			intp(4), intp(2000), intp(50),
+			intp(4), 12, intp(2000), intp(50),
 			queue.Policy{
 				MaxAttempts:      4,
 				KeepFailed:       2000,
@@ -289,25 +354,10 @@ func TestBuildPolicy(t *testing.T) {
 				KeepFailedAge:    defaultAges.failed,
 			},
 		},
-		// maxAttempts<=0 は driver default に倒す既存挙動を維持。
-		// `MaxAttempts: 0` は「Policy で上書きしない (= driver の default
-		// retry を使う)」を意味する zero-value。明示 0 を受け取っても
-		// Policy には流さないので 0 のまま残る。
-		{
-			"maxAttempts zero leaves driver default",
-			intp(0), intp(500), intp(15),
-			queue.Policy{
-				MaxAttempts:      0,
-				KeepFailed:       500,
-				KeepCompleted:    15,
-				KeepCompletedAge: defaultAges.completed,
-				KeepFailedAge:    defaultAges.failed,
-			},
-		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := buildPolicy(tt.maxAttempts, tt.keepFailed, tt.keepCompleted)
+			got := buildPolicy(tt.maxAttempts, tt.defaultAttempts, tt.keepFailed, tt.keepCompleted)
 			assert.Equal(t, tt.want, got)
 		})
 	}


### PR DESCRIPTION
## Summary

PR #1406 で deliver/inbox の retry backoff (Misskey TS `httpRelatedBackoff` 互換) を実装したが、落ちている (offline) リモートサーバーへの配送ジョブが失敗後にリトライされない症状が残っていた。本 PR はその根本原因 (リトライがそもそも発火しない) を修正する。

## 原因

- mkq v1.0.2 の `Worker.shouldRetry` は `if o.attempts <= 0 { return false }` で、attempts 未設定 (=0) だと一切リトライしない。
- mk-go の `EnqueueDeliver`/`EnqueueInbox` は `p.MaxAttempts > 0` のときだけ `WithMaxRetry` を付ける → 0 だと mkq attempts=0。
- `buildPolicy` (`internal/server/queue_factory.go`) が MaxAttempts に default を当てていなかった (未指定 → 0)。config も `SetDefault` 無し、example yaml もコメントアウト。

→ operator が `deliverJobMaxAttempts` / `inboxJobMaxAttempts` を明示しない限り **attempts=1 (リトライ無し)**。落ちた配送先は 1 回失敗で即 failed、Delayed にも入らず #1406 の backoff も走らない。

Misskey TS `QueueService.ts` は `deliverJobMaxAttempts ?? 12` / `inboxJobMaxAttempts ?? 8` で default を当てており、mk-go の欠落は drop-in 非互換でもあった。

backoff 実装自体 (#1406) は mkq v1.0.2 上で正しく動作するため **revert 不要**。

## 主な変更点

- `internal/server/queue_factory.go`: 定数 `defaultDeliverJobMaxAttempts=12` / `defaultInboxJobMaxAttempts=8` を追加。`buildPolicy` に `defaultMaxAttempts int` 引数を足し、MaxAttempts を KeepFailed/KeepCompleted と同じ 3 状態設計に揃える:
  - `nil` → defaultMaxAttempts を適用 (TS の `?? N` 相当)
  - 明示 `0` → 0 (operator opt-out = リトライ無し)
  - 明示 `N` → N
  - export/push/webhook は `defaultMaxAttempts=0` を渡して従来挙動を維持 (これらは Policy.MaxAttempts を参照せず task-specific な retry を持つ)。
- `internal/queue/policy.go`: MaxAttempts のコメントを「0=driver default」という誤解を招く記述から実態に修正。
- `.config/default.yml.example` / `docker.yml.example`: default 値の説明コメントを追記。

## テスト

- `internal/server/queue_factory_test.go`:
  - `TestBuildPolicy` を新シグネチャに更新し、MaxAttempts の 3 状態 (nil→default / 明示0→opt-out / 明示N→N) を検証するケースを追加。
  - `TestApplyClientPolicies_DeliverInboxDefaultAttempts` (新規): 未指定でも deliver=12 / inbox=8 が `WithMaxRetry(N-1)` として driver opts に伝搬することを pin。
  - `TestApplyClientPolicies_OperatorAttemptsOptOut` (新規): 明示 0 が opt-out として尊重されることを pin。
  - `TestDefaultPolicy` を更新。
- 実行: `go test ./internal/server/... ./internal/queue/...` 全パス (mkqdriver 統合テスト含む)。`make fmt` 適用済み / `gofmt -s -l` 差分なし / `go vet` クリーン。

## Closes

Closes #1411