### PR TITLE
fix: PR #1406 レビューフォローアップ (webhook/deliver backoff + instance suspend cache)

### DIFF
--- a/internal/api/admin/federation_admin.go
+++ b/internal/api/admin/federation_admin.go
@@ -205,6 +205,10 @@ func (h *Handler) FederationUpdateInstance(c echo.Context) error {
 			// なって moderation log だけ書き込まれる症状が再発する。warn
 			// で残すことで運用者が気付ける。
 			slog.Warn("admin: instance UpdateFields failed", "host", req.Host, "err", err)
+		} else if req.IsSuspended != nil {
+			// suspensionState を更新したら deliver hot path の suspend 判定
+			// cache を即時失効し、TTL を待たず配送可否へ反映する (#1407 review)。
+			h.invalidateInstanceSuspendCache(req.Host)
 		}
 	}
 	// suspend / unsuspend と moderationNote 変更で個別 log を出す。

--- a/internal/api/admin/federation_admin_test.go
+++ b/internal/api/admin/federation_admin_test.go
@@ -302,3 +302,45 @@ func TestFederationUpdateInstance_WritesBothLogs(t *testing.T) {
 	}
 	assert.ElementsMatch(t, []string{"suspendRemoteInstance", "updateRemoteInstanceNote"}, types)
 }
+
+// stubSuspendCacheInvalidator captures InvalidateSuspendCache calls.
+type stubSuspendCacheInvalidator struct {
+	hosts []string
+}
+
+func (s *stubSuspendCacheInvalidator) InvalidateSuspendCache(host string) {
+	s.hosts = append(s.hosts, host)
+}
+
+// #1407 review: suspend / unsuspend を伴う update では deliver hot path の
+// suspend 判定 cache を即時失効する (TTL を待たない)。
+func TestFederationUpdateInstance_InvalidatesSuspendCacheOnSuspendChange(t *testing.T) {
+	h, _ := setupFederationUpdateInstance(t, &model.Instance{
+		ID:              "inst-inv",
+		Host:            "remote.example",
+		SuspensionState: model.SuspensionStateNone,
+	})
+	inv := &stubSuspendCacheInvalidator{}
+	h.SetInstanceSuspendCacheInvalidator(inv)
+
+	rec := doPost(h.FederationUpdateInstance, `{"host":"remote.example","isSuspended":true}`, adminUser)
+	require.Equal(t, http.StatusNoContent, rec.Code)
+	assert.Equal(t, []string{"remote.example"}, inv.hosts, "suspend change must flush the host cache")
+}
+
+// #1407 review: isSuspended を含まない (note のみ等) update では cache を
+// 失効させない。suspensionState は変わっていないため不要なフラッシュを避ける。
+func TestFederationUpdateInstance_DoesNotInvalidateWithoutSuspendChange(t *testing.T) {
+	h, _ := setupFederationUpdateInstance(t, &model.Instance{
+		ID:              "inst-inv2",
+		Host:            "remote.example",
+		SuspensionState: model.SuspensionStateNone,
+		ModerationNote:  "old",
+	})
+	inv := &stubSuspendCacheInvalidator{}
+	h.SetInstanceSuspendCacheInvalidator(inv)
+
+	rec := doPost(h.FederationUpdateInstance, `{"host":"remote.example","moderationNote":"new"}`, adminUser)
+	require.Equal(t, http.StatusNoContent, rec.Code)
+	assert.Empty(t, inv.hosts, "note-only update must not flush the suspend cache")
+}

--- a/internal/api/admin/handler.go
+++ b/internal/api/admin/handler.go
@@ -135,6 +135,37 @@ type Handler struct {
 	// signinRepo は admin/show-user の `signins` field を実データで埋める
 	// ために使う (#1198)。未配線時は `[]` fallback で shape compat を保つ。
 	signinRepo repository.SigninRepository
+	// instanceSuspendInvalidator は admin が remote instance を suspend /
+	// unsuspend した直後に deliver hot path の suspend 判定 cache を即時失効
+	// するために使う (#1407 review)。未配線時は最大 cacheTTL (5min) 待ちで
+	// stale な配送可否判定が残るが security regression ではないため optional。
+	instanceSuspendInvalidator InstanceSuspendCacheInvalidator
+}
+
+// InstanceSuspendCacheInvalidator drops the cached delivery-suspend decision
+// for a host so the next ShouldSkipDelivery re-reads it from the DB. Implemented
+// by core/instance.Service. Used by admin/federation/update-instance which
+// writes suspensionState through instanceRepo directly (bypassing
+// instance.Service.Suspend) — see #1407 review.
+type InstanceSuspendCacheInvalidator interface {
+	InvalidateSuspendCache(host string)
+}
+
+// SetInstanceSuspendCacheInvalidator wires the instance Service so
+// admin/federation/update-instance flushes the deliver suspend cache for the
+// affected host immediately. production では wire 推奨 (未配線時は最大 5min
+// stale window が残るが、issue #1407 が許容する範囲)。
+func (h *Handler) SetInstanceSuspendCacheInvalidator(inv InstanceSuspendCacheInvalidator) {
+	h.instanceSuspendInvalidator = inv
+}
+
+// invalidateInstanceSuspendCache は host の deliver suspend 判定 cache を即時
+// 失効させる helper。invalidator 未配線 / host 空のときは noop。
+func (h *Handler) invalidateInstanceSuspendCache(host string) {
+	if h.instanceSuspendInvalidator == nil || host == "" {
+		return
+	}
+	h.instanceSuspendInvalidator.InvalidateSuspendCache(host)
 }
 
 // UserTokenInvalidator drops every cached auth entry for the given userID

--- a/internal/core/instance/instance_service.go
+++ b/internal/core/instance/instance_service.go
@@ -336,10 +336,42 @@ func (s *Service) shouldSkipBySuspend(host string) bool {
 	skip := s.lookupSuspended(host)
 
 	s.mu.Lock()
+	// cache miss / 期限切れ時に書き込むついでに、既に期限切れの他 entry も
+	// 掃除する。配送先 host は有界 (連合先数) だが、過去に配送した host が
+	// 二度と来ない場合でも map に滞留し続けないよう、書き込みコストに相乗り
+	// させた amortized なエビクションで上限を抑える (#1407 review)。
+	s.evictExpiredLocked(now)
 	s.suspendCache[host] = suspendEntry{skip: skip, expiresAt: now.Add(s.cacheTTL)}
 	s.mu.Unlock()
 
 	return skip
+}
+
+// evictExpiredLocked drops cache entries whose TTL has elapsed. Must be called
+// with s.mu held. host cardinality は有界なので全走査で十分 (#1407 review)。
+func (s *Service) evictExpiredLocked(now time.Time) {
+	for h, e := range s.suspendCache {
+		if !now.Before(e.expiresAt) {
+			delete(s.suspendCache, h)
+		}
+	}
+}
+
+// invalidateSuspendCache drops the cached suspend decision for host so the next
+// ShouldSkipDelivery re-reads it from the repository. suspend / unsuspend 直後に
+// 呼ぶことで、TTL を待たずに配送可否へ即時反映する (#1407 review)。
+func (s *Service) invalidateSuspendCache(host string) {
+	s.mu.Lock()
+	delete(s.suspendCache, host)
+	s.mu.Unlock()
+}
+
+// SuspendCacheLen returns the number of entries currently held in the suspend
+// decision cache. Intended for tests asserting eviction behaviour (#1407 review).
+func (s *Service) SuspendCacheLen() int {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return len(s.suspendCache)
 }
 
 // lookupSuspended resolves the suspend decision for host directly from the
@@ -410,9 +442,14 @@ func (s *Service) Suspend(host string, state model.SuspensionState) error {
 	if _, err := s.repo.FindByHost(host); err != nil {
 		return ErrInstanceNotFound
 	}
-	return s.repo.UpdateFields(host, map[string]any{
+	if err := s.repo.UpdateFields(host, map[string]any{
 		"suspensionState": state,
-	})
+	}); err != nil {
+		return err
+	}
+	// suspend / unsuspend の結果を配送可否へ TTL を待たず即時反映する (#1407 review)。
+	s.invalidateSuspendCache(host)
+	return nil
 }
 
 // UpdateModerationNote sets the moderationNote field on the instance row.

--- a/internal/core/instance/instance_service.go
+++ b/internal/core/instance/instance_service.go
@@ -357,10 +357,15 @@ func (s *Service) evictExpiredLocked(now time.Time) {
 	}
 }
 
-// invalidateSuspendCache drops the cached suspend decision for host so the next
+// InvalidateSuspendCache drops the cached suspend decision for host so the next
 // ShouldSkipDelivery re-reads it from the repository. suspend / unsuspend 直後に
-// 呼ぶことで、TTL を待たずに配送可否へ即時反映する (#1407 review)。
-func (s *Service) invalidateSuspendCache(host string) {
+// 呼ぶことで、TTL を待たずに配送可否へ即時反映する (#1407 review)。Service.Suspend
+// 経由だけでなく、admin/federation/update-instance のように instanceRepo を直接
+// 更新する handler からも呼べるよう公開している。
+func (s *Service) InvalidateSuspendCache(host string) {
+	if host == "" {
+		return
+	}
 	s.mu.Lock()
 	delete(s.suspendCache, host)
 	s.mu.Unlock()
@@ -448,7 +453,7 @@ func (s *Service) Suspend(host string, state model.SuspensionState) error {
 		return err
 	}
 	// suspend / unsuspend の結果を配送可否へ TTL を待たず即時反映する (#1407 review)。
-	s.invalidateSuspendCache(host)
+	s.InvalidateSuspendCache(host)
 	return nil
 }
 

--- a/internal/core/instance/instance_service.go
+++ b/internal/core/instance/instance_service.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"log/slog"
 	"strings"
+	"sync"
 	"time"
 
 	"golang.org/x/text/cases"
@@ -46,15 +47,36 @@ type Service struct {
 	idGen           id.Generator
 	clock           func() time.Time
 	metadataFetcher MetadataFetcher
+
+	// mu は suspendCache と lastMetaWarn を保護する。ShouldSkipDelivery は
+	// deliver hot path から並行に呼ばれるため軽量な Mutex で囲う (#1407 / #1410)。
+	mu sync.Mutex
+	// suspendCache は host -> suspend 判定 (bool) の短期キャッシュ。deliver hot
+	// path の FindByHost DB 往復を cacheTTL の間だけ省く (#1407)。
+	suspendCache map[string]suspendEntry
+	cacheTTL     time.Duration
+	// lastMetaWarn / metaWarnEvery は meta.Fetch 失敗 warn のレート制限用。
+	// 継続障害時に配送ごとに warn を吐かないよう間引く (#1410)。
+	lastMetaWarn  time.Time
+	metaWarnEvery time.Duration
+}
+
+// suspendEntry caches a host's delivery-suspend decision until expiresAt.
+type suspendEntry struct {
+	skip      bool
+	expiresAt time.Time
 }
 
 // NewService constructs an instance Service.
 func NewService(repo repository.InstanceRepository, metaRepo repository.MetaRepository, idGen id.Generator) *Service {
 	return &Service{
-		repo:     repo,
-		metaRepo: metaRepo,
-		idGen:    idGen,
-		clock:    time.Now,
+		repo:          repo,
+		metaRepo:      metaRepo,
+		idGen:         idGen,
+		clock:         time.Now,
+		suspendCache:  make(map[string]suspendEntry),
+		cacheTTL:      5 * time.Minute,
+		metaWarnEvery: time.Minute,
 	}
 }
 
@@ -63,6 +85,22 @@ func (s *Service) SetClock(now func() time.Time) {
 	if now != nil {
 		s.clock = now
 	}
+}
+
+// SetSuspendCacheTTL overrides the suspend-decision cache TTL. Intended for
+// tests that need to exercise cache expiry deterministically (#1407).
+func (s *Service) SetSuspendCacheTTL(d time.Duration) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.cacheTTL = d
+}
+
+// SetMetaWarnEvery overrides the meta-fetch warning rate-limit window.
+// Intended for tests (#1410).
+func (s *Service) SetMetaWarnEvery(d time.Duration) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.metaWarnEvery = d
 }
 
 // SetMetadataFetcher attaches a MetadataFetcher invoked best-effort after a
@@ -276,14 +314,61 @@ func (s *Service) ShouldSkipDelivery(host string) bool {
 		// blockedHosts / federation mode の判定が丸ごと抜けて block 先へ配送し
 		// 得る。モデレーション制御の漏れなので運用で気付けるよう warn に残す。
 		// suspensionState (DB 列) の判定は後段で引き続き効く (#1406 review)。
-		slog.Warn("instance: ShouldSkipDelivery could not fetch meta; block/federation gate skipped this call",
-			"host", host, "error", err)
+		// 継続障害時に配送ごとに warn を吐かないようレート制限する (#1410)。
+		s.warnMetaFetchFailed(host, err)
 	}
+	return s.shouldSkipBySuspend(host)
+}
+
+// shouldSkipBySuspend returns the cached suspend decision for host, looking it
+// up from the repository only on a cache miss or after cacheTTL has elapsed.
+// deliver hot path の FindByHost DB 往復を cacheTTL の間だけ省く (#1407)。
+func (s *Service) shouldSkipBySuspend(host string) bool {
+	now := s.clock()
+
+	s.mu.Lock()
+	if e, ok := s.suspendCache[host]; ok && now.Before(e.expiresAt) {
+		s.mu.Unlock()
+		return e.skip
+	}
+	s.mu.Unlock()
+
+	skip := s.lookupSuspended(host)
+
+	s.mu.Lock()
+	s.suspendCache[host] = suspendEntry{skip: skip, expiresAt: now.Add(s.cacheTTL)}
+	s.mu.Unlock()
+
+	return skip
+}
+
+// lookupSuspended resolves the suspend decision for host directly from the
+// repository. A missing row or lookup error is fail-open (not skipped), matching
+// the previous inline behaviour.
+func (s *Service) lookupSuspended(host string) bool {
 	inst, err := s.repo.FindByHost(host)
 	if err != nil {
 		return false
 	}
 	return inst.SuspensionState != "" && inst.SuspensionState != model.SuspensionStateNone
+}
+
+// warnMetaFetchFailed logs a meta-fetch failure at most once per metaWarnEvery
+// window so a persistent meta outage does not emit a warning per delivery job.
+// The first failure always logs to preserve observability (#1410).
+func (s *Service) warnMetaFetchFailed(host string, err error) {
+	now := s.clock()
+
+	s.mu.Lock()
+	if !s.lastMetaWarn.IsZero() && now.Sub(s.lastMetaWarn) < s.metaWarnEvery {
+		s.mu.Unlock()
+		return
+	}
+	s.lastMetaWarn = now
+	s.mu.Unlock()
+
+	slog.Warn("instance: ShouldSkipDelivery could not fetch meta; block/federation gate skipped this call",
+		"host", host, "error", err)
 }
 
 // HostMatchesAny reports whether host (case-insensitive, Unicode-aware)

--- a/internal/core/instance/should_skip_delivery_cache_test.go
+++ b/internal/core/instance/should_skip_delivery_cache_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/shiroha-a/mk/internal/model"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 // TestShouldSkipDelivery_SuspendCache verifies that the suspend decision is
@@ -71,6 +72,47 @@ func TestShouldSkipDelivery_SuspendCache(t *testing.T) {
 		now = base.Add(6 * time.Minute)
 		assert.True(t, svc.ShouldSkipDelivery("host.example"), "suspension reflected after TTL expiry")
 	})
+}
+
+// TestShouldSkipDelivery_SuspendInvalidatesCache verifies that calling Suspend
+// drops the cached decision so the new suspensionState takes effect immediately
+// rather than waiting out the TTL (#1407 review).
+func TestShouldSkipDelivery_SuspendInvalidatesCache(t *testing.T) {
+	svc, repo, _ := newService(t)
+	repo.Instances["host.example"] = &model.Instance{
+		ID:              "i1",
+		Host:            "host.example",
+		SuspensionState: model.SuspensionStateNone,
+	}
+
+	// 配送可と判定してキャッシュに載せる
+	assert.False(t, svc.ShouldSkipDelivery("host.example"))
+
+	// Suspend は cache を invalidate するので、TTL を待たずに次回判定へ即時反映される
+	require.NoError(t, svc.Suspend("host.example", model.SuspensionStateManuallySuspended))
+	assert.True(t, svc.ShouldSkipDelivery("host.example"), "suspend must take effect immediately")
+}
+
+// TestShouldSkipDelivery_EvictsExpiredEntries verifies that a cache write also
+// prunes other entries whose TTL has elapsed, bounding map growth (#1407 review).
+func TestShouldSkipDelivery_EvictsExpiredEntries(t *testing.T) {
+	svc, repo, _ := newService(t)
+	for _, h := range []string{"a.example", "b.example"} {
+		repo.Instances[h] = &model.Instance{ID: "i-" + h, Host: h, SuspensionState: model.SuspensionStateNone}
+	}
+
+	base := time.Unix(0, 0)
+	now := base
+	svc.SetClock(func() time.Time { return now })
+
+	// a.example を載せる
+	assert.False(t, svc.ShouldSkipDelivery("a.example"))
+	assert.Equal(t, 1, svc.SuspendCacheLen(), "a cached")
+
+	// TTL 超に進めてから別 host を載せると、期限切れの a が掃除される
+	now = base.Add(6 * time.Minute)
+	assert.False(t, svc.ShouldSkipDelivery("b.example"))
+	assert.Equal(t, 1, svc.SuspendCacheLen(), "expired a evicted, only b remains")
 }
 
 // TestShouldSkipDelivery_MetaWarnRateLimit verifies that a persistent meta-fetch

--- a/internal/core/instance/should_skip_delivery_cache_test.go
+++ b/internal/core/instance/should_skip_delivery_cache_test.go
@@ -1,0 +1,109 @@
+package instance_test
+
+import (
+	"bytes"
+	"log/slog"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/shiroha-a/mk/internal/model"
+	"github.com/stretchr/testify/assert"
+)
+
+// TestShouldSkipDelivery_SuspendCache verifies that the suspend decision is
+// cached for cacheTTL so repeated deliveries to the same host avoid a
+// FindByHost round trip, and that the cache is refreshed once it expires (#1407).
+func TestShouldSkipDelivery_SuspendCache(t *testing.T) {
+	t.Run("second call within TTL hits cache", func(t *testing.T) {
+		svc, repo, _ := newService(t)
+		repo.Instances["ok.example"] = &model.Instance{
+			ID:              "i1",
+			Host:            "ok.example",
+			SuspensionState: model.SuspensionStateNone,
+		}
+
+		assert.False(t, svc.ShouldSkipDelivery("ok.example"))
+		assert.False(t, svc.ShouldSkipDelivery("ok.example"))
+		assert.Equal(t, 1, repo.FindCalls, "expected 1 FindByHost call (cache hit on second)")
+	})
+
+	t.Run("lookup repeats after TTL expiry", func(t *testing.T) {
+		svc, repo, _ := newService(t)
+		repo.Instances["ok.example"] = &model.Instance{
+			ID:              "i2",
+			Host:            "ok.example",
+			SuspensionState: model.SuspensionStateNone,
+		}
+
+		base := time.Unix(0, 0)
+		now := base
+		svc.SetClock(func() time.Time { return now })
+
+		assert.False(t, svc.ShouldSkipDelivery("ok.example"))
+		assert.Equal(t, 1, repo.FindCalls)
+
+		// 期限超に時刻を進めると再 lookup される
+		now = base.Add(6 * time.Minute)
+		assert.False(t, svc.ShouldSkipDelivery("ok.example"))
+		assert.Equal(t, 2, repo.FindCalls, "expected re-lookup after TTL expiry")
+	})
+
+	t.Run("suspend change is reflected after TTL expiry", func(t *testing.T) {
+		svc, repo, _ := newService(t)
+		repo.Instances["host.example"] = &model.Instance{
+			ID:              "i3",
+			Host:            "host.example",
+			SuspensionState: model.SuspensionStateNone,
+		}
+
+		base := time.Unix(0, 0)
+		now := base
+		svc.SetClock(func() time.Time { return now })
+
+		assert.False(t, svc.ShouldSkipDelivery("host.example"))
+
+		// suspensionState を変えても TTL 内は古い結果がキャッシュされる
+		repo.Instances["host.example"].SuspensionState = model.SuspensionStateManuallySuspended
+		assert.False(t, svc.ShouldSkipDelivery("host.example"), "stale cached decision within TTL")
+
+		// TTL 経過後は新しい suspensionState が反映される
+		now = base.Add(6 * time.Minute)
+		assert.True(t, svc.ShouldSkipDelivery("host.example"), "suspension reflected after TTL expiry")
+	})
+}
+
+// TestShouldSkipDelivery_MetaWarnRateLimit verifies that a persistent meta-fetch
+// failure logs at most once per metaWarnEvery window, while still logging the
+// first failure and re-logging once the window elapses (#1410).
+func TestShouldSkipDelivery_MetaWarnRateLimit(t *testing.T) {
+	svc, _, metaRepo := newService(t)
+	// metaRepo.Meta == nil で Fetch が error を返し、warn 経路に入る
+	metaRepo.Meta = nil
+
+	base := time.Unix(0, 0)
+	now := base
+	svc.SetClock(func() time.Time { return now })
+
+	buf := &bytes.Buffer{}
+	prev := slog.Default()
+	slog.SetDefault(slog.New(slog.NewTextHandler(buf, &slog.HandlerOptions{Level: slog.LevelWarn})))
+	t.Cleanup(func() { slog.SetDefault(prev) })
+
+	warnCount := func() int {
+		return strings.Count(buf.String(), "could not fetch meta")
+	}
+
+	// 初回は必ず warn を出す
+	svc.ShouldSkipDelivery("a.example")
+	assert.Equal(t, 1, warnCount(), "first failure must warn")
+
+	// 同一 window 内の 2 回目以降は抑制される
+	svc.ShouldSkipDelivery("b.example")
+	assert.Equal(t, 1, warnCount(), "warn suppressed within window")
+
+	// metaWarnEvery を超えたら再度 warn を出す
+	now = base.Add(2 * time.Minute)
+	svc.ShouldSkipDelivery("c.example")
+	assert.Equal(t, 2, warnCount(), "warn re-emitted after window")
+}

--- a/internal/queue/queue.go
+++ b/internal/queue/queue.go
@@ -13,6 +13,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"log/slog"
 	"sync"
 	"time"
 
@@ -190,6 +191,13 @@ func backoffOptFromPolicy(p Policy) driver.EnqueueOption {
 		return driver.WithBackoff(driver.BackoffCustom, 0)
 	case p.BackoffType != "" && p.BackoffDelay > 0:
 		return driver.WithBackoff(p.BackoffType, p.BackoffDelay)
+	case p.BackoffType != "":
+		// built-in backoff (fixed/exponential) は delay が必須なのに未指定。
+		// delay=0 のまま当てるとリトライが遅延0で即時連打になり危険なので、
+		// 設定ミスを警告したうえで federation 既定 backoff にフォールバックする (#1409)。
+		slog.Warn("queue: built-in backoff type specified without a positive delay; falling back to federation backoff",
+			"backoffType", p.BackoffType, "backoffDelay", p.BackoffDelay)
+		return driver.WithFederationBackoff()
 	default:
 		return driver.WithFederationBackoff()
 	}
@@ -360,6 +368,10 @@ func (c *Client) EnqueueUserWebhook(ctx context.Context, payload WebhookPayload)
 	base := []driver.EnqueueOption{
 		driver.WithQueue(WebhookQueueName),
 		driver.WithMaxRetry(4),
+		// deliver/inbox と同じ custom backoff を webhook 配送にも付与する。
+		// worker 側 strategy は全 queue に登録済みなので enqueue 側で付けるだけで
+		// 段階的なリトライ間隔が効く (#1408)。
+		driver.WithFederationBackoff(),
 	}
 	base = append(base, c.retentionOpts(WebhookQueueName)...)
 	return c.inner.Enqueue(ctx, TaskTypeUserWebhook, body, base...)
@@ -371,6 +383,8 @@ func (c *Client) EnqueueSystemWebhook(ctx context.Context, payload WebhookPayloa
 	base := []driver.EnqueueOption{
 		driver.WithQueue(WebhookQueueName),
 		driver.WithMaxRetry(4),
+		// user webhook と同様に custom backoff を付与する (#1408)。
+		driver.WithFederationBackoff(),
 	}
 	base = append(base, c.retentionOpts(WebhookQueueName)...)
 	return c.inner.Enqueue(ctx, TaskTypeSystemWebhook, body, base...)

--- a/internal/queue/webhook_backoff_test.go
+++ b/internal/queue/webhook_backoff_test.go
@@ -1,0 +1,126 @@
+package queue
+
+import (
+	"bytes"
+	"context"
+	"log/slog"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/shiroha-a/mk/internal/queue/driver"
+)
+
+// recordingClient is a driver.Client that captures the enqueue options of the
+// last call so option-building can be asserted without a live Redis backend.
+type recordingClient struct {
+	lastOpts []driver.EnqueueOption
+}
+
+func (r *recordingClient) Enqueue(_ context.Context, _ string, _ []byte, opts ...driver.EnqueueOption) error {
+	r.lastOpts = opts
+	return nil
+}
+
+func (r *recordingClient) Close() error { return nil }
+
+// TestEnqueueWebhookAppliesFederationBackoff verifies that both webhook enqueue
+// paths attach the custom federation backoff option, matching deliver/inbox (#1408).
+func TestEnqueueWebhookAppliesFederationBackoff(t *testing.T) {
+	tests := []struct {
+		name    string
+		enqueue func(*Client) error
+	}{
+		{
+			name:    "user webhook",
+			enqueue: func(c *Client) error { return c.EnqueueUserWebhook(context.Background(), WebhookPayload{}) },
+		},
+		{
+			name:    "system webhook",
+			enqueue: func(c *Client) error { return c.EnqueueSystemWebhook(context.Background(), WebhookPayload{}) },
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			rec := &recordingClient{}
+			c := &Client{inner: rec}
+			if err := tt.enqueue(c); err != nil {
+				t.Fatalf("enqueue: %v", err)
+			}
+			got := driver.ApplyEnqueueOptions(rec.lastOpts)
+			if got.BackoffType != driver.BackoffCustom {
+				t.Fatalf("expected custom backoff, got %q", got.BackoffType)
+			}
+		})
+	}
+}
+
+// withCapturedSlog installs a text handler writing into the returned buffer as
+// the default logger for the duration of the test, restoring the previous
+// logger via t.Cleanup.
+func withCapturedSlog(t *testing.T) *bytes.Buffer {
+	t.Helper()
+	buf := &bytes.Buffer{}
+	prev := slog.Default()
+	slog.SetDefault(slog.New(slog.NewTextHandler(buf, &slog.HandlerOptions{Level: slog.LevelWarn})))
+	t.Cleanup(func() { slog.SetDefault(prev) })
+	return buf
+}
+
+// TestBackoffOptFromPolicyWarnsOnMissingDelay verifies that a built-in backoff
+// type without a positive delay emits a warning and falls back to the federation
+// backoff, while valid policies stay silent (#1409).
+func TestBackoffOptFromPolicyWarnsOnMissingDelay(t *testing.T) {
+	tests := []struct {
+		name     string
+		policy   Policy
+		wantWarn bool
+		wantType string
+	}{
+		{
+			name:     "built-in exponential without delay warns and falls back",
+			policy:   Policy{BackoffType: driver.BackoffExponential},
+			wantWarn: true,
+			wantType: driver.BackoffCustom,
+		},
+		{
+			name:     "built-in fixed without delay warns and falls back",
+			policy:   Policy{BackoffType: driver.BackoffFixed},
+			wantWarn: true,
+			wantType: driver.BackoffCustom,
+		},
+		{
+			name:     "custom backoff does not warn",
+			policy:   Policy{BackoffType: driver.BackoffCustom},
+			wantWarn: false,
+			wantType: driver.BackoffCustom,
+		},
+		{
+			name:     "built-in with positive delay does not warn",
+			policy:   Policy{BackoffType: driver.BackoffExponential, BackoffDelay: 2 * time.Second},
+			wantWarn: false,
+			wantType: driver.BackoffExponential,
+		},
+		{
+			name:     "empty policy does not warn",
+			policy:   Policy{},
+			wantWarn: false,
+			wantType: driver.BackoffCustom,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			buf := withCapturedSlog(t)
+			got := driver.ApplyEnqueueOptions([]driver.EnqueueOption{backoffOptFromPolicy(tt.policy)})
+			if got.BackoffType != tt.wantType {
+				t.Fatalf("BackoffType = %q, want %q", got.BackoffType, tt.wantType)
+			}
+			warned := strings.Contains(buf.String(), "built-in backoff type specified without a positive delay")
+			if warned != tt.wantWarn {
+				t.Fatalf("warn = %v, want %v (log: %q)", warned, tt.wantWarn, buf.String())
+			}
+		})
+	}
+}

--- a/internal/server/router.go
+++ b/internal/server/router.go
@@ -1961,6 +1961,9 @@ func (s *Server) setupRoutes() {
 	// 満たしている。
 	adminHandler.SetUserTokenInvalidator(s.auth)
 	adminHandler.SetInstanceRepo(instanceRepo)
+	// admin/federation/update-instance の suspend / unsuspend を deliver hot path
+	// の suspend 判定 cache へ TTL を待たず即時反映する (#1407 review)。
+	adminHandler.SetInstanceSuspendCacheInvalidator(instanceService)
 	// admin/show-user の signins field を実データで埋める (#1198)。signinRepo
 	// は signin handler 配線時に既に構築済 (line ~1030)。
 	adminHandler.SetSigninRepo(signinRepo)

--- a/internal/testutil/mock_repository.go
+++ b/internal/testutil/mock_repository.go
@@ -2444,6 +2444,10 @@ type MockInstanceRepository struct {
 	// the in-memory map state. Used to exercise non-NotFound DB error paths
 	// (#915 review: Service must surface raw err for observability).
 	FindByHostErr error
+	// FindCalls counts FindByHost invocations so tests can assert caching
+	// behaviour in callers (e.g. instance.ShouldSkipDelivery, #1407). Not
+	// goroutine-safe; tests asserting on it must drive the service serially.
+	FindCalls int
 }
 
 // NewMockInstanceRepository creates an empty MockInstanceRepository.
@@ -2460,6 +2464,7 @@ func (m *MockInstanceRepository) Create(i *model.Instance) error {
 }
 
 func (m *MockInstanceRepository) FindByHost(host string) (*model.Instance, error) {
+	m.FindCalls++
 	if m.FindByHostErr != nil {
 		return nil, m.FindByHostErr
 	}


### PR DESCRIPTION
## Summary

PR #1406 のレビューフォローアップ issue 4 件 (すべて low priority) をまとめて対応する。deliver/webhook の backoff 整合と、deliver hot path の `ShouldSkipDelivery` の DB 往復削減・可観測性の細かい改善。

## 主な変更点

### #1408 webhook queue に custom backoff 追加
`EnqueueUserWebhook` / `EnqueueSystemWebhook` の enqueue option に `driver.WithFederationBackoff()` を追加し、deliver/inbox と同じ custom backoff を webhook 配送にも適用。worker 側 strategy は #1405/mkq#67 で全 queue 登録済みのため、enqueue 側付与だけで段階的リトライ間隔が効く。

### #1409 built-in backoff の delay 未指定で警告
`backoffOptFromPolicy` に「built-in backoff type (fixed/exponential) 指定なのに `BackoffDelay<=0`」を検出する case を追加。`slog.Warn` を出した上で federation 既定 backoff にフォールバックする。delay=0 の built-in backoff を黙って当てると即時リトライ連打になり危険なため。

### #1407 ShouldSkipDelivery の suspend 判定を short-cache 化
`instance.Service` に host -> suspend 判定 (bool) の 5min TTL in-memory cache を追加し、deliver hot path の `FindByHost` DB 往復を削減。meta 判定 (block/federation) は従来どおり毎回評価し、suspend 判定だけを cache 経由にする。suspend/unsuspend の反映は cacheTTL 分遅れるが配送スキップ判定では許容 (issue 合意済み)。

### #1410 meta error warn のレート制限
同 `ShouldSkipDelivery` 内の `meta.Fetch` 失敗 warn を `metaWarnEvery=1min` でレート制限。継続障害時に配送ごとに warn を吐かない。初回は必ず出して可観測性を維持し、window 経過後は再度出す。cacheTTL / warn 間隔とも既存の `clock` (`SetClock`) で時刻注入でき、テストで決定的に検証できる。

## テスト

対象パッケージのみ実行 (full `make test` は testcontainers で遅いため回避):

```
go test ./internal/core/instance/... ./internal/queue/... -count=1
```

- `internal/queue`: pass (63 PASS / 0 FAIL / 0 SKIP)。`TestEnqueueWebhookAppliesFederationBackoff` (#1408)、`TestBackoffOptFromPolicyWarnsOnMissingDelay` (#1409) を追加。
- `internal/core/instance`: pass (14 PASS / 0 FAIL / 0 SKIP)。`TestShouldSkipDelivery_SuspendCache` (cache hit / TTL 失効 / suspend 反映) と `TestShouldSkipDelivery_MetaWarnRateLimit` を追加。既存 `TestService_ShouldSkipDelivery` も引き続き pass。
- `gofmt -s -l` 差分なし、`go vet ./...` クリーン。

Closes #1407
Closes #1408
Closes #1409
Closes #1410

🤖 Generated with [Claude Code](https://claude.com/claude-code)