### PR TITLE
fix(files): storedInternal=true な行は useObjectStorage=true でもローカル提供 (#1414)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Fix: `useObjectStorage = true` のインスタンスで、`storedInternal = true` なドライブファイルへの `/files/:accessKey` アクセスが常に 404 になる問題を修正 (Misskey TS からの S3 移行前に保存されたローカルファイルが、移行後もアクセス可能に)
 - Fix: 配送先が一時的にダウンしている場合に、deliver/inbox ジョブが設定省略時にリトライされない問題を修正 (既定の試行回数を Misskey 本家と同じ deliver=12 / inbox=8 に。従来の no-retry 挙動が必要な場合は `deliverJobMaxAttempts` / `inboxJobMaxAttempts` に 1 を指定)
 
 ## 0.9.2

--- a/internal/core/transfer/drive_reader_test.go
+++ b/internal/core/transfer/drive_reader_test.go
@@ -98,6 +98,9 @@ func (f *fakeDriveFileRepo) DeleteByHost(_ string) (int64, error) {
 func (f *fakeDriveFileRepo) FindByAccessKey(_ string) (*model.DriveFile, error) {
 	return nil, errors.New("not implemented")
 }
+func (f *fakeDriveFileRepo) FindByAnyAccessKey(_ string) (*model.DriveFile, error) {
+	return nil, errors.New("not implemented")
+}
 
 // Ensure fakeDriveFileRepo implements the real repository interface so the
 // reader accepts it.

--- a/internal/repository/drive_file.go
+++ b/internal/repository/drive_file.go
@@ -12,6 +12,11 @@ type DriveFileRepository interface {
 	FindByIDs(ids []string) ([]*model.DriveFile, error)
 	FindByMD5(userID, md5 string) (*model.DriveFile, error)
 	FindByAccessKey(accessKey string) (*model.DriveFile, error)
+	// FindByAnyAccessKey looks up a DriveFile whose primary / thumbnail /
+	// webpublic access key matches. Used by `/files/:accessKey` to resolve
+	// storedInternal=true rows that the configured storage backend (S3)
+	// does not hold (#1414).
+	FindByAnyAccessKey(accessKey string) (*model.DriveFile, error)
 	// FindByURI looks up a drive_file by its AP `uri` field. Used for
 	// deduping remote attachments on inbound Note ingest (#378).
 	FindByURI(uri string) (*model.DriveFile, error)
@@ -122,6 +127,25 @@ func (r *driveFileRepository) FindByAccessKey(accessKey string) (*model.DriveFil
 	}
 	var f model.DriveFile
 	if err := r.db.Where("\"accessKey\" = ?", accessKey).First(&f).Error; err != nil {
+		return nil, err
+	}
+	return &f, nil
+}
+
+// FindByAnyAccessKey resolves an access key by matching the primary,
+// thumbnail, or webpublic column. `/files/:accessKey` 経由でアクセスされる
+// access key は元データ・thumbnail・webpublic のいずれかなので、3 列を OR で
+// 引く必要がある (#1414)。3 列とも unique index 付きで planner は bitmap-or
+// に落とせる。primary のみで充足する mediaproxy.swapToVariant とは別経路。
+func (r *driveFileRepository) FindByAnyAccessKey(accessKey string) (*model.DriveFile, error) {
+	if accessKey == "" {
+		return nil, gorm.ErrRecordNotFound
+	}
+	var f model.DriveFile
+	if err := r.db.Where(
+		`"accessKey" = ? OR "thumbnailAccessKey" = ? OR "webpublicAccessKey" = ?`,
+		accessKey, accessKey, accessKey,
+	).First(&f).Error; err != nil {
 		return nil, err
 	}
 	return &f, nil

--- a/internal/repository/drive_file_test.go
+++ b/internal/repository/drive_file_test.go
@@ -112,6 +112,35 @@ func TestDriveFileRepository_ListByUser(t *testing.T) {
 	assert.Len(t, rows, 1)
 }
 
+func TestDriveFileRepository_FindByAnyAccessKey(t *testing.T) {
+	repo := NewDriveFileRepository(testDB)
+	user := insertTestUser(t, "u_df_ak", "dfak")
+	defer cleanupUser(t, user.ID)
+
+	primary := "pk-" + user.ID
+	thumb := "tk-" + user.ID
+	web := "wk-" + user.ID
+	f := newTestDriveFile("f_ak", user.ID, "akmd5", nil)
+	f.AccessKey = &primary
+	f.ThumbnailAccessKey = &thumb
+	f.WebpublicAccessKey = &web
+	require.NoError(t, repo.Create(f))
+	defer cleanupDriveFile(t, f.ID)
+
+	// primary / thumbnail / webpublic いずれの key でも同じ行に解決する
+	for _, k := range []string{primary, thumb, web} {
+		got, err := repo.FindByAnyAccessKey(k)
+		require.NoError(t, err, "lookup %s", k)
+		assert.Equal(t, f.ID, got.ID)
+	}
+
+	// 空文字 / 未マッチは ErrRecordNotFound
+	_, err := repo.FindByAnyAccessKey("")
+	assert.Error(t, err)
+	_, err = repo.FindByAnyAccessKey("does-not-exist")
+	assert.Error(t, err)
+}
+
 func TestDriveFileRepository_QueryErrors(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel()

--- a/internal/server/files.go
+++ b/internal/server/files.go
@@ -1,0 +1,99 @@
+package server
+
+import (
+	"bytes"
+	"io"
+	"net/http"
+	"os"
+	"time"
+
+	"github.com/labstack/echo/v4"
+
+	coredrive "github.com/shiroha-a/mk/internal/core/drive"
+	"github.com/shiroha-a/mk/internal/model"
+)
+
+// filesDriveLookup is the minimal interface filesHandler needs to decide
+// whether a request maps to a locally-stored drive_file row. Implemented
+// by repository.DriveFileRepository; abstracted here so handler tests can
+// stub without standing up a real DB.
+type filesDriveLookup interface {
+	FindByAnyAccessKey(accessKey string) (*model.DriveFile, error)
+}
+
+// filesHandler serves `GET /files/:accessKey`.
+//
+// `useObjectStorage=true` な instance では primary が S3Storage に切り替わるが、
+// Misskey TS から S3 移行する前にアップロードされた drive_file 行は
+// `storedInternal=true` のままローカル FS に残っており、TS upstream の
+// FileServerService も storedInternal を見て storage を切り替える。同じ挙動に
+// 合わせるため、DB を引いて storedInternal=true なら local を、それ以外
+// (= 行が無い・ false / lookup 自体が unwired) は primary を使う (#1414)。
+//
+// lookup == nil もしくは DB error 時は primary に倒す。これは
+// useObjectStorage=false で local が primary を兼ねている wiring を壊さない
+// ためで、その経路では DB lookup を省ける。
+//
+// MIME type はファイル内容の先頭から自動判定し、`http.ServeContent` で
+// Range / If-Modified-Since / Content-Length 対応の正しい応答を返す。
+//
+// 旧実装は echo の `c.Stream` + `io.MultiReader` で chunked transfer に
+// 倒していたが、Cloudflare Tunnel 経由のデプロイで bigger-than-buffer
+// (33KB 程度) なファイルが truncate される問題があった (#730)。明示
+// Content-Length + Cache-Control: no-transform でこれを回避する。
+func filesHandler(lookup filesDriveLookup, primary, local coredrive.Storage) echo.HandlerFunc {
+	return func(c echo.Context) error {
+		key := c.Param("accessKey")
+		storage := primary
+		if lookup != nil && local != nil {
+			if f, err := lookup.FindByAnyAccessKey(key); err == nil && f.StoredInternal {
+				storage = local
+			}
+		}
+		body, err := storage.Get(key)
+		if err != nil {
+			return c.NoContent(http.StatusNotFound)
+		}
+		defer body.Close()
+
+		// LocalStorage は *os.File を返すので io.ReadSeeker として扱える。
+		// 互換性のため type assertion で seekable かを確認し、非対応 (将来
+		// S3 等の non-seekable storage を増やした場合) なら全 body を memory
+		// に読み込む fallback にフォールバックする。
+		// modtime も *os.File なら Stat() から取得して If-Modified-Since の
+		// 304 経路を有効にする。それ以外は零値で http.ServeContent が
+		// Last-Modified を出さない (Cache-Control: immutable で代替)。
+		var modtime time.Time
+		seeker, ok := body.(io.ReadSeeker)
+		if ok {
+			if f, isFile := body.(*os.File); isFile {
+				if st, err := f.Stat(); err == nil {
+					modtime = st.ModTime()
+				}
+			}
+		} else {
+			data, rerr := io.ReadAll(body)
+			if rerr != nil {
+				return c.NoContent(http.StatusInternalServerError)
+			}
+			seeker = bytes.NewReader(data)
+		}
+
+		buf := make([]byte, 512)
+		n, _ := seeker.Read(buf)
+		contentType := http.DetectContentType(buf[:n])
+		if _, err := seeker.Seek(0, io.SeekStart); err != nil {
+			return c.NoContent(http.StatusInternalServerError)
+		}
+
+		// `Cache-Control: no-transform` で Cloudflare Polish 等 CDN 中間層
+		// による画像再エンコードを抑止する (#730)。Polish は animated WebP
+		// を別 size で出力するため UDS デプロイ環境で「絵文字がチカチカ
+		// する + サイズが切れる」現象を起こす。`immutable` で長期 cache 化、
+		// `no-transform` で binary 1:1 配信を契約する。
+		c.Response().Header().Set("Cache-Control", "max-age=31536000, immutable, no-transform")
+		c.Response().Header().Set(echo.HeaderContentType, contentType)
+		http.ServeContent(c.Response(), c.Request(), key, modtime, seeker)
+		return nil
+	}
+}

--- a/internal/server/files_test.go
+++ b/internal/server/files_test.go
@@ -1,0 +1,210 @@
+package server
+
+import (
+	"errors"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/labstack/echo/v4"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	coredrive "github.com/shiroha-a/mk/internal/core/drive"
+	"github.com/shiroha-a/mk/internal/model"
+)
+
+// stubFilesLookup is a minimal stand-in for filesDriveLookup. We hand-roll
+// the stub rather than reuse testutil.MockDriveFileRepository so the test
+// stays focused on the handler's storage-switching contract.
+type stubFilesLookup struct {
+	byKey map[string]*model.DriveFile
+	err   error
+}
+
+func (s *stubFilesLookup) FindByAnyAccessKey(key string) (*model.DriveFile, error) {
+	if s.err != nil {
+		return nil, s.err
+	}
+	f, ok := s.byKey[key]
+	if !ok {
+		return nil, errors.New("not found")
+	}
+	return f, nil
+}
+
+// memStorage is an in-memory coredrive.Storage so handler tests do not
+// touch the filesystem. byKey は accessKey → body の map で、Get で
+// io.NopCloser に包んで返す (non-seekable 経路を試すため敢えて *os.File
+// を使わない)。
+type memStorage struct {
+	byKey   map[string]string
+	getFail map[string]error
+}
+
+func (m *memStorage) Put(string, io.Reader) (string, error) { return "", nil }
+func (m *memStorage) Get(key string) (io.ReadCloser, error) {
+	if err, ok := m.getFail[key]; ok {
+		return nil, err
+	}
+	body, ok := m.byKey[key]
+	if !ok {
+		return nil, coredrive.ErrObjectNotFound
+	}
+	return io.NopCloser(strings.NewReader(body)), nil
+}
+func (m *memStorage) Delete(string) error { return nil }
+
+func newFilesTestContext(t *testing.T, key string) (echo.Context, *httptest.ResponseRecorder) {
+	t.Helper()
+	e := echo.New()
+	req := httptest.NewRequest(http.MethodGet, "/files/"+key, nil)
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+	c.SetPath("/files/:accessKey")
+	c.SetParamNames("accessKey")
+	c.SetParamValues(key)
+	return c, rec
+}
+
+// useObjectStorage 相当 wiring: primary が S3 (storedInternal=false 行のみ
+// 持つ) で local が在来の LocalStorage (storedInternal=true 行を持つ)。
+// storedInternal=true の row は local から、それ以外は primary から提供
+// されることを契約する (#1414)。
+func TestFilesHandler_StoredInternalServesFromLocal(t *testing.T) {
+	key := "internal-key"
+	lookup := &stubFilesLookup{
+		byKey: map[string]*model.DriveFile{
+			key: {ID: "f1", StoredInternal: true},
+		},
+	}
+	primary := &memStorage{byKey: map[string]string{}}
+	local := &memStorage{byKey: map[string]string{key: "local-body"}}
+
+	c, rec := newFilesTestContext(t, key)
+	h := filesHandler(lookup, primary, local)
+	require.NoError(t, h(c))
+
+	assert.Equal(t, http.StatusOK, rec.Code)
+	assert.Equal(t, "local-body", rec.Body.String())
+	assert.Equal(t, "max-age=31536000, immutable, no-transform", rec.Header().Get("Cache-Control"))
+}
+
+func TestFilesHandler_NonInternalServesFromPrimary(t *testing.T) {
+	key := "s3-key"
+	lookup := &stubFilesLookup{
+		byKey: map[string]*model.DriveFile{
+			key: {ID: "f2", StoredInternal: false},
+		},
+	}
+	primary := &memStorage{byKey: map[string]string{key: "s3-body"}}
+	local := &memStorage{byKey: map[string]string{}}
+
+	c, rec := newFilesTestContext(t, key)
+	h := filesHandler(lookup, primary, local)
+	require.NoError(t, h(c))
+
+	assert.Equal(t, http.StatusOK, rec.Code)
+	assert.Equal(t, "s3-body", rec.Body.String())
+}
+
+// DB に行がなければ primary に倒す (旧挙動互換)。
+func TestFilesHandler_LookupMissFallsBackToPrimary(t *testing.T) {
+	key := "orphan-key"
+	lookup := &stubFilesLookup{byKey: map[string]*model.DriveFile{}}
+	primary := &memStorage{byKey: map[string]string{key: "primary-body"}}
+	local := &memStorage{byKey: map[string]string{key: "should-not-be-used"}}
+
+	c, rec := newFilesTestContext(t, key)
+	h := filesHandler(lookup, primary, local)
+	require.NoError(t, h(c))
+
+	assert.Equal(t, http.StatusOK, rec.Code)
+	assert.Equal(t, "primary-body", rec.Body.String())
+}
+
+// lookup を未配線にしても primary 経路で素通る (useObjectStorage=false な
+// 旧 wiring の最低保証)。
+func TestFilesHandler_NilLookupUsesPrimary(t *testing.T) {
+	key := "k"
+	primary := &memStorage{byKey: map[string]string{key: "p"}}
+	local := &memStorage{byKey: map[string]string{key: "l"}}
+
+	c, rec := newFilesTestContext(t, key)
+	h := filesHandler(nil, primary, local)
+	require.NoError(t, h(c))
+
+	assert.Equal(t, "p", rec.Body.String())
+}
+
+// primary が ErrObjectNotFound を返すと 404 を返す。
+func TestFilesHandler_PrimaryMissReturns404(t *testing.T) {
+	key := "missing"
+	lookup := &stubFilesLookup{byKey: map[string]*model.DriveFile{}}
+	primary := &memStorage{byKey: map[string]string{}}
+	local := &memStorage{byKey: map[string]string{}}
+
+	c, rec := newFilesTestContext(t, key)
+	h := filesHandler(lookup, primary, local)
+	require.NoError(t, h(c))
+
+	assert.Equal(t, http.StatusNotFound, rec.Code)
+}
+
+// fileStorage は Get で実 *os.File を返す storage 実装。filesHandler の
+// `body.(*os.File)` で modtime を引く branch を踏むために用意する。
+type fileStorage struct {
+	root string
+}
+
+func (s *fileStorage) Put(string, io.Reader) (string, error) { return "", nil }
+func (s *fileStorage) Get(key string) (io.ReadCloser, error) {
+	f, err := os.Open(filepath.Join(s.root, key))
+	if err != nil {
+		return nil, coredrive.ErrObjectNotFound
+	}
+	return f, nil
+}
+func (s *fileStorage) Delete(string) error { return nil }
+
+// LocalStorage 互換経路 (*os.File を返す storage) で Stat() からの
+// modtime 取得と Last-Modified 出力経路まで踏む。
+func TestFilesHandler_OsFileSeekablePath(t *testing.T) {
+	dir := t.TempDir()
+	key := "local-os-key"
+	require.NoError(t, os.WriteFile(filepath.Join(dir, key), []byte("local-bytes"), 0o644))
+
+	lookup := &stubFilesLookup{byKey: map[string]*model.DriveFile{
+		key: {ID: "f3", StoredInternal: true},
+	}}
+	primary := &memStorage{byKey: map[string]string{}}
+	local := &fileStorage{root: dir}
+
+	c, rec := newFilesTestContext(t, key)
+	h := filesHandler(lookup, primary, local)
+	require.NoError(t, h(c))
+
+	assert.Equal(t, http.StatusOK, rec.Code)
+	assert.Equal(t, "local-bytes", rec.Body.String())
+	assert.NotEmpty(t, rec.Header().Get(echo.HeaderLastModified))
+}
+
+// MIME 判定: PNG signature を返した場合は image/png を Content-Type に
+// 出すこと (DetectContentType の経路を通すための smoke test)。
+func TestFilesHandler_SetsDetectedContentType(t *testing.T) {
+	key := "png-key"
+	// PNG signature header (8 bytes) で http.DetectContentType が image/png
+	// を返す経路を踏む。
+	pngHeader := "\x89PNG\r\n\x1a\n"
+	primary := &memStorage{byKey: map[string]string{key: pngHeader + "..."}}
+	c, rec := newFilesTestContext(t, key)
+	h := filesHandler(nil, primary, nil)
+	require.NoError(t, h(c))
+
+	assert.Equal(t, http.StatusOK, rec.Code)
+	assert.Equal(t, "image/png", rec.Header().Get(echo.HeaderContentType))
+}

--- a/internal/server/files_test.go
+++ b/internal/server/files_test.go
@@ -42,15 +42,11 @@ func (s *stubFilesLookup) FindByAnyAccessKey(key string) (*model.DriveFile, erro
 // io.NopCloser に包んで返す (non-seekable 経路を試すため敢えて *os.File
 // を使わない)。
 type memStorage struct {
-	byKey   map[string]string
-	getFail map[string]error
+	byKey map[string]string
 }
 
 func (m *memStorage) Put(string, io.Reader) (string, error) { return "", nil }
 func (m *memStorage) Get(key string) (io.ReadCloser, error) {
-	if err, ok := m.getFail[key]; ok {
-		return nil, err
-	}
 	body, ok := m.byKey[key]
 	if !ok {
 		return nil, coredrive.ErrObjectNotFound

--- a/internal/server/router.go
+++ b/internal/server/router.go
@@ -1,9 +1,7 @@
 package server
 
 import (
-	"bytes"
 	"context"
-	"io"
 	"net/http"
 	"net/http/pprof"
 	urlpkg "net/url"
@@ -361,11 +359,15 @@ func (s *Server) setupRoutes() {
 	// ようにする (#690)。streamPubSub は下方で生成されるため遅延配線。
 
 	// Drive storage (Phase 4.9: Meta に基づいて Local / S3 を切り替え)
+	// localDriveStorage は driveStorage が S3 に切り替わっても、
+	// storedInternal=true な drive_file を `/files/:accessKey` で提供する
+	// fallback として常に保持する (#1414)。
+	localDriveStorage := coredrive.NewLocalStorage("./drive-files", s.config.DriveURL)
 	var driveStorage coredrive.Storage
 	if serverMeta, err := metaRepo.Fetch(); err == nil {
 		driveStorage = coredrive.NewStorageFromMeta(serverMeta, "./drive-files", s.config.DriveURL)
 	} else {
-		driveStorage = coredrive.NewLocalStorage("./drive-files", s.config.DriveURL)
+		driveStorage = localDriveStorage
 	}
 	driveService := coredrive.NewService(driveFileRepo, driveFolderRepo, driveStorage, idGen)
 	// drive/files/show は moderator なら他人 / リモートユーザー所有の file
@@ -1494,66 +1496,9 @@ func (s *Server) setupRoutes() {
 	api.POST("/drive/stream", driveHandler.Stream, middleware.RequireAuth())
 	// Phase 7.4: drive/* — 全て実データハンドラに移行済み
 
-	// Static file serving for LocalStorage
-	// MIME type はファイル内容の先頭から自動判定し、`http.ServeContent` で
-	// Range / If-Modified-Since / Content-Length 対応の正しい応答を返す。
-	//
-	// 旧実装は echo の `c.Stream` + `io.MultiReader` で chunked transfer に
-	// 倒していたが、Cloudflare Tunnel 経由のデプロイで bigger-than-buffer
-	// (33KB 程度) なファイルが truncate される問題があった (#730)。明示
-	// Content-Length + Cache-Control: no-transform でこれを回避する。
-	s.echo.GET("/files/:accessKey", func(c echo.Context) error {
-		key := c.Param("accessKey")
-		body, err := driveStorage.Get(key)
-		if err != nil {
-			return c.NoContent(http.StatusNotFound)
-		}
-		defer body.Close()
-
-		// LocalStorage は *os.File を返すので io.ReadSeeker として扱える。
-		// 互換性のため type assertion で seekable かを確認し、非対応 (将来
-		// S3 等の non-seekable storage を増やした場合) なら全 body を memory
-		// に読み込む fallback にフォールバックする。
-		// modtime も *os.File なら Stat() から取得して If-Modified-Since の
-		// 304 経路を有効にする。それ以外は零値で http.ServeContent が
-		// Last-Modified を出さない (Cache-Control: immutable で代替)。
-		var modtime time.Time
-		seeker, ok := body.(io.ReadSeeker)
-		if ok {
-			if f, isFile := body.(*os.File); isFile {
-				if st, err := f.Stat(); err == nil {
-					modtime = st.ModTime()
-				}
-			}
-		} else {
-			data, rerr := io.ReadAll(body)
-			if rerr != nil {
-				return c.NoContent(http.StatusInternalServerError)
-			}
-			seeker = bytes.NewReader(data)
-		}
-
-		// 先頭 512 バイト読んで MIME type を判定 → 元位置に戻す
-		buf := make([]byte, 512)
-		n, _ := seeker.Read(buf)
-		contentType := http.DetectContentType(buf[:n])
-		if _, err := seeker.Seek(0, io.SeekStart); err != nil {
-			return c.NoContent(http.StatusInternalServerError)
-		}
-
-		// `Cache-Control: no-transform` で Cloudflare Polish 等 CDN 中間層
-		// による画像再エンコードを抑止する (#730)。Polish は animated WebP
-		// を別 size で出力するため UDS デプロイ環境で「絵文字がチカチカ
-		// する + サイズが切れる」現象を起こす。`immutable` で長期 cache 化、
-		// `no-transform` で binary 1:1 配信を契約する。
-		c.Response().Header().Set("Cache-Control", "max-age=31536000, immutable, no-transform")
-		c.Response().Header().Set(echo.HeaderContentType, contentType)
-		// http.ServeContent が Content-Length / Range / If-Modified-Since を
-		// 適切に処理する。modtime 取得できれば Last-Modified を発行して
-		// 304 経路も活きる。
-		http.ServeContent(c.Response(), c.Request(), key, modtime, seeker)
-		return nil
-	})
+	// Static file serving for LocalStorage / S3 backend. `storedInternal=true`
+	// な行は driveStorage が S3 でも localDriveStorage に倒して提供する (#1414)。
+	s.echo.GET("/files/:accessKey", filesHandler(driveFileRepo, driveStorage, localDriveStorage))
 
 	// Media proxy endpoint
 	proxyAllowlist := coremediaproxy.NewDBAllowlistChecker(s.db)

--- a/internal/server/router.go
+++ b/internal/server/router.go
@@ -1498,7 +1498,16 @@ func (s *Server) setupRoutes() {
 
 	// Static file serving for LocalStorage / S3 backend. `storedInternal=true`
 	// な行は driveStorage が S3 でも localDriveStorage に倒して提供する (#1414)。
-	s.echo.GET("/files/:accessKey", filesHandler(driveFileRepo, driveStorage, localDriveStorage))
+	//
+	// driveStorage がローカル (= object storage 非活性) の場合は primary と
+	// local が同じローカル FS を指すため storedInternal 判定が無意味。この
+	// 経路では lookup を nil 配線し、ホットパスである `/files/:accessKey` の
+	// 毎リクエスト DB クエリを省く (filesHandler の nil-lookup 分岐に倒す)。
+	var filesLookup filesDriveLookup
+	if _, isLocal := driveStorage.(*coredrive.LocalStorage); !isLocal {
+		filesLookup = driveFileRepo
+	}
+	s.echo.GET("/files/:accessKey", filesHandler(filesLookup, driveStorage, localDriveStorage))
 
 	// Media proxy endpoint
 	proxyAllowlist := coremediaproxy.NewDBAllowlistChecker(s.db)

--- a/internal/testutil/mock_drive.go
+++ b/internal/testutil/mock_drive.go
@@ -89,6 +89,10 @@ func (m *MockDriveFileRepository) FindByAccessKey(accessKey string) (*model.Driv
 	return nil, ErrNotFound
 }
 
+func (m *MockDriveFileRepository) FindByAnyAccessKey(accessKey string) (*model.DriveFile, error) {
+	return m.FindByAccessKey(accessKey)
+}
+
 func (m *MockDriveFileRepository) Update(id string, fields map[string]any) error {
 	f, ok := m.Files[id]
 	if !ok {


### PR DESCRIPTION
## Summary

`useObjectStorage = true` のインスタンスで、`storedInternal = true` なドライブファイルへの `/files/:accessKey` アクセスが常に 404 になる問題を修正します (#1414)。

Misskey TS からローカルストレージ → S3 に移行したインスタンスでは、移行前に保存されたファイルが `drive_file.storedInternal = true` のまま残ります。upstream Misskey TS の FileServerService は行ごとの `storedInternal` を見てローカル / S3 を切り替えており、mk-go も同じ挙動に揃えます。

## 主な変更点

- `internal/repository/drive_file.go`
  - `FindByAnyAccessKey(accessKey)` を新設。primary / thumbnail / webpublic の 3 列を OR で引いて行を返します (3 列とも unique index 付き、planner は bitmap-or に落とせる想定)。
  - 既存 `FindByAccessKey` は mediaproxy.swapToVariant の経路で primary 単独確認に使われるため触りません。
- `internal/server/files.go` (新規)
  - `/files/:accessKey` のハンドラを `router.go` の inline closure から切り出し、`filesHandler(lookup, primary, local)` として extract。
  - DB lookup の結果 `storedInternal=true` なら local を、それ以外 (false / 行なし / lookup 未配線) は primary (= driveStorage) を使う分岐を追加。
  - lookup が DB error や行なしを返した場合は既存挙動 (driveStorage で 404) を維持します。
- `internal/server/router.go`
  - `LocalStorage` を `useObjectStorage` の値に関わらず常に生成し、wire 層から fallback として渡すように変更。S3 経路時の fallback ストレージとして保持。
- `internal/testutil/mock_drive.go`
  - `FindByAnyAccessKey` を mock に追加 (既存 `FindByAccessKey` の OR ロジックを再利用)。
- `internal/core/transfer/drive_reader_test.go`
  - `fakeDriveFileRepo` に `FindByAnyAccessKey` の stub を追加 (interface 充足のため)。
- `CHANGELOG.md` Unreleased に追記。

## テスト

- `internal/repository/drive_file_test.go`: `TestDriveFileRepository_FindByAnyAccessKey` を追加。primary / thumbnail / webpublic いずれの key でも同じ行に解決すること、空文字 / 未マッチで `ErrRecordNotFound` を返すことを検証。
- `internal/server/files_test.go` (新規): handler に 7 ケース追加。
  - `StoredInternalServesFromLocal` — S3 primary + local の wiring で `storedInternal=true` 行が local 経由で提供される
  - `NonInternalServesFromPrimary` — `storedInternal=false` 行は primary 経路
  - `LookupMissFallsBackToPrimary` — DB に行がない key は primary に倒す (既存挙動)
  - `NilLookupUsesPrimary` — lookup 未配線でも primary 経路で素通る
  - `PrimaryMissReturns404` — primary も lookup も miss なら 404
  - `OsFileSeekablePath` — `*os.File` を返す storage で `Stat()` modtime → `Last-Modified` まで踏む
  - `SetsDetectedContentType` — PNG signature で `Content-Type: image/png` を出す
- `files.go` のファイル単位カバレッジ 93.1%。
- 既存 affected packages (`internal/server` / `internal/repository` / `internal/core/transfer` / `internal/testutil` / `internal/api/notes`) すべて green。

```
go test ./internal/server/ ./internal/repository/ ./internal/core/transfer/ ./internal/testutil/ ./internal/api/notes/
ok  	github.com/shiroha-a/mk/internal/server
ok  	github.com/shiroha-a/mk/internal/repository
ok  	github.com/shiroha-a/mk/internal/core/transfer
ok  	github.com/shiroha-a/mk/internal/testutil
ok  	github.com/shiroha-a/mk/internal/api/notes
```

`make fmt && make lint` も clean です。

## Closes

Closes #1414