### PR TITLE
fix(migration): TS→mk-go 移行で expired poll が一斉に pollEnded 通知発火する問題を修正 (#1415)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Fix: Misskey TS から mk-go に移行した直後、既に期限切れだったアンケートに対してアンケート終了 (pollEnded) 通知が一斉発火する問題を修正 (移行時 backfill migration を追加)
 - Fix: 配送先が一時的にダウンしている場合に、deliver/inbox ジョブが設定省略時にリトライされない問題を修正 (既定の試行回数を Misskey 本家と同じ deliver=12 / inbox=8 に。従来の no-retry 挙動が必要な場合は `deliverJobMaxAttempts` / `inboxJobMaxAttempts` に 1 を指定)
 
 ## 0.9.2

--- a/internal/repository/poll_test.go
+++ b/internal/repository/poll_test.go
@@ -115,6 +115,69 @@ func TestPollRepository_ListExpiredUnnotified_LimitCap(t *testing.T) {
 	assert.GreaterOrEqual(t, len(rows), 3)
 }
 
+// TestPollRepository_BackfillNotifiedAt は migration 053 が含む backfill SQL
+// (#1415) の挙動を guard する。Misskey TS から mk-go へ移行した際、000044 が
+// notifiedAt = NULL でカラムを追加するため、既に expiresAt 経過後の poll は
+// 軒並み「未通知」となり ExpiryWorker 初回 tick で一斉発火する不具合の修正。
+//
+// 053 は startup 時点で既に testDB に適用済みなので、ここでは SQL 自体を
+// 再実行する形で「期限切れ未通知 → 通知済みに backfill される / 未満了は
+// 触らない / 既に通知済みは触らない」契約を確認する。
+func TestPollRepository_BackfillNotifiedAt(t *testing.T) {
+	repo := NewPollRepository(testDB)
+	user := insertTestUser(t, "u_bf_1", "bfuser")
+	defer cleanupUser(t, user.ID)
+
+	now := time.Now()
+	past := now.Add(-2 * time.Hour)
+	future := now.Add(time.Hour)
+	already := past.Add(time.Minute)
+
+	mk := func(id string, expires *time.Time, notified *time.Time) {
+		note := &model.Note{ID: id, UserID: user.ID, Visibility: model.NoteVisibilityPublic, HasPoll: true, Reactions: datatypes.JSON([]byte("{}"))}
+		require.NoError(t, testDB.Create(note).Error)
+		t.Cleanup(func() { cleanupNote(t, note.ID) })
+		require.NoError(t, repo.Create(&model.Poll{
+			NoteID: id, Choices: pq.StringArray{"a"}, Votes: pq.Int64Array{0},
+			NoteVisibility: model.NoteVisibilityPublic, UserID: user.ID,
+			ExpiresAt:  expires,
+			NotifiedAt: notified,
+		}))
+	}
+	// 1) 期限切れ未通知 → backfill 対象
+	mk("p_bf_target", &past, nil)
+	// 2) 未満了 → 触らない
+	mk("p_bf_future", &future, nil)
+	// 3) 既に通知済み → 触らない
+	mk("p_bf_already", &past, &already)
+	// 4) expiresAt なし → 触らない
+	mk("p_bf_noexpire", nil, nil)
+
+	// 053 と同じ SQL を再実行する。冪等なので既に適用済みの DB でも結果は変わらない。
+	require.NoError(t, testDB.Exec(
+		`UPDATE "poll" SET "notifiedAt" = "expiresAt"
+		  WHERE "expiresAt" IS NOT NULL AND "expiresAt" < NOW() AND "notifiedAt" IS NULL`,
+	).Error)
+
+	target, err := repo.FindByNoteID("p_bf_target")
+	require.NoError(t, err)
+	require.NotNil(t, target.NotifiedAt, "backfill 対象は notifiedAt が埋まる")
+	assert.WithinDuration(t, past, *target.NotifiedAt, time.Second, "notifiedAt = expiresAt にコピーされる")
+
+	future2, err := repo.FindByNoteID("p_bf_future")
+	require.NoError(t, err)
+	assert.Nil(t, future2.NotifiedAt, "未満了は触らない")
+
+	already2, err := repo.FindByNoteID("p_bf_already")
+	require.NoError(t, err)
+	require.NotNil(t, already2.NotifiedAt)
+	assert.WithinDuration(t, already, *already2.NotifiedAt, time.Second, "既に通知済みの timestamp は維持される")
+
+	noexp, err := repo.FindByNoteID("p_bf_noexpire")
+	require.NoError(t, err)
+	assert.Nil(t, noexp.NotifiedAt, "expiresAt=NULL は触らない")
+}
+
 func TestPollRepository_MarkNotified(t *testing.T) {
 	repo := NewPollRepository(testDB)
 	user := insertTestUser(t, "u_mn_1", "mnuser")

--- a/migration/000053_poll_notified_at_backfill.down.sql
+++ b/migration/000053_poll_notified_at_backfill.down.sql
@@ -1,0 +1,4 @@
+-- 000053 は backfill のみで schema 変更を伴わないため、down では復元せず
+-- no-op で済ます。元の NULL に戻すと #1415 の mass notification を再度誘発
+-- してしまうため、意図的に巻き戻さない。
+SELECT 1;

--- a/migration/000053_poll_notified_at_backfill.up.sql
+++ b/migration/000053_poll_notified_at_backfill.up.sql
@@ -1,0 +1,18 @@
+-- #1415: Misskey TS から mk-go へ移行した instance で、000044 が `poll.notifiedAt`
+-- を NULL で追加した結果、既に expiresAt 経過後のアンケートが軒並み「未通知」
+-- 状態として残り、ExpiryWorker の初回 tick で全 author + 投票者へ pollEnded
+-- 通知が一斉発火する問題を、過去分を一括して通知済みにすることで止める。
+--
+-- 既に 000044 を適用済みかつ過去分の発火を既に踏んだ instance に対しては
+-- no-op (notifiedAt が埋まっているため `notifiedAt IS NULL` で素通り)。
+-- 000044 を含めて新規インストールする instance では (古い expired poll が
+-- 存在しないため) UPDATE は 0 行で no-op。
+--
+-- expiresAt 値を notifiedAt にコピーするのは upstream Misskey TS が
+-- 「通知時刻 = 期限到達時刻」として扱う semantics に合わせる意図 (= 後から
+-- backfill された行も新規 expire と timestamp 上は区別がつかない)。
+UPDATE "poll"
+   SET "notifiedAt" = "expiresAt"
+ WHERE "expiresAt" IS NOT NULL
+   AND "expiresAt" < NOW()
+   AND "notifiedAt" IS NULL;


### PR DESCRIPTION
## Summary

Misskey TS から mk-go に移行した直後、既に期限切れだったアンケートに対して `pollEnded` 通知が author + 投票者の全員に対して一斉発火する問題を修正します (#1415)。

## 原因

`000044_poll_notified_at.up.sql` が `poll.notifiedAt` を NULL で追加するため、移行前から `expiresAt` 経過後となっていた全アンケートが「未通知」と判定され、`core/poll/ExpiryWorker` の初回 tick (60s 間隔) で `expiresAt < NOW() AND notifiedAt IS NULL` を満たす全行を拾って通知が飛ぶ。

## 修正

新規 migration `000053_poll_notified_at_backfill.up.sql` で、`expiresAt < NOW() AND notifiedAt IS NULL` な行に対し `notifiedAt = expiresAt` を埋める backfill UPDATE を追加。

```sql
UPDATE "poll"
   SET "notifiedAt" = "expiresAt"
 WHERE "expiresAt" IS NOT NULL
   AND "expiresAt" < NOW()
   AND "notifiedAt" IS NULL;
```

挙動:

| 状態 | 影響 |
| --- | --- |
| 0.9.2 (= 044 適用済み) + worker tick 前 | backfill で通知済み化、mass notification 回避 |
| 0.9.2 + 既に worker tick 済み (notifiedAt 埋まり) | WHERE で素通り、no-op |
| 新規インストール (expired poll 不在) | UPDATE 0 行、no-op |
| 今後 TS→mk-go 移行 (053 まで含めて 1 トランザクション内で適用) | 044 直後に backfill が走り、worker tick 前に通知済み化 |

`expiresAt` を `notifiedAt` にコピーするのは upstream Misskey TS が「通知時刻 = 期限到達時刻」として扱う意図に合わせる目的。

down は no-op (SELECT 1) としています。NULL に戻すと #1415 を再度誘発するため意図的に巻き戻しません。

## なぜ 044 を直接修正しないか

044 は 0.9.1 / 0.9.2 で既にリリース済みで、適用済みインスタンスは再 run しません。修正版 044 を作っても適用済み環境には届かないため、新規 migration として 053 を追加する形にしました。

## テスト

`internal/repository/poll_test.go` に `TestPollRepository_BackfillNotifiedAt` を追加。同等 SQL を再実行して下記契約を guard:

- 期限切れ未通知 → `notifiedAt = expiresAt` で backfill
- 未満了 → 触らない
- 既に通知済み → 既存 timestamp を維持
- `expiresAt = NULL` → 触らない

```
TEST_DB_PORT=5433 go test ./internal/repository/ -run TestPollRepository -v
=== RUN   TestPollRepository_BackfillNotifiedAt
--- PASS: TestPollRepository_BackfillNotifiedAt (0.03s)
...
PASS
```

`make fmt && make lint` clean。

## Closes

Closes #1415