### PR TITLE
fix(api): users / clips の note 列挙系で visibility filter を補強

### DIFF
--- a/internal/api/clips/handler.go
+++ b/internal/api/clips/handler.go
@@ -29,21 +29,12 @@ type Handler struct {
 	// userRepo は clips/notes 経由で他人の clip を閲覧する際の hardMutedWords
 	// filter (#787) のために viewer profile を引く。未配線時は filter skip。
 	userRepo repository.UserRepository
-	// followingRepo は clips/notes で clip 内の各 note の visibility 判定
-	// (= core/note.CanSeeNote) で follower 関係を引くために使う。
-	followingRepo repository.FollowingRepository
 }
 
 // SetUserRepo wires a UserRepository so clips/notes filters out notes that
 // match the viewer's hardMutedWords (#787).
 func (h *Handler) SetUserRepo(r repository.UserRepository) {
 	h.userRepo = r
-}
-
-// SetFollowingRepo wires a FollowingRepository used by clips/notes for the
-// per-note visibility check. 未配線時は CanSeeNote が fail-closed に倒れる。
-func (h *Handler) SetFollowingRepo(r repository.FollowingRepository) {
-	h.followingRepo = r
 }
 
 // SetNoteFieldResolver wires the shared resolver that fills Files /
@@ -336,7 +327,8 @@ func (h *Handler) Notes(c echo.Context) error {
 		}
 		return apierr.JSONInternalError(c)
 	}
-	notes = notesfilter.FilterVisible(user, notes, h.followingRepo)
+	// visibility は clip service の ListByClipVisible で push down 済み (#1418
+	// review)。ここでは hardMutedWords filter のみ適用する。
 	notes = notesfilter.ApplyHardMute(h.userRepo, user, notes)
 	entities := entity.PackNotes(c.Request().Context(), notes, h.idGen, h.instanceLookup(), h.emojiLookup(), h.reactionReader())
 	h.fieldRes.Apply(entities, user)

--- a/internal/api/clips/handler.go
+++ b/internal/api/clips/handler.go
@@ -9,6 +9,7 @@ import (
 	"github.com/shiroha-a/mk/internal/api/apierr"
 	"github.com/shiroha-a/mk/internal/api/pagination"
 	coreclip "github.com/shiroha-a/mk/internal/core/clip"
+	corenote "github.com/shiroha-a/mk/internal/core/note"
 	"github.com/shiroha-a/mk/internal/core/notesfilter"
 	"github.com/shiroha-a/mk/internal/entity"
 	"github.com/shiroha-a/mk/internal/misc/id"
@@ -29,12 +30,21 @@ type Handler struct {
 	// userRepo は clips/notes 経由で他人の clip を閲覧する際の hardMutedWords
 	// filter (#787) のために viewer profile を引く。未配線時は filter skip。
 	userRepo repository.UserRepository
+	// followingRepo は clips/notes で clip 内の各 note の visibility 判定
+	// (= core/note.CanSeeNote) で follower 関係を引くために使う。
+	followingRepo repository.FollowingRepository
 }
 
 // SetUserRepo wires a UserRepository so clips/notes filters out notes that
 // match the viewer's hardMutedWords (#787).
 func (h *Handler) SetUserRepo(r repository.UserRepository) {
 	h.userRepo = r
+}
+
+// SetFollowingRepo wires a FollowingRepository used by clips/notes for the
+// per-note visibility check. 未配線時は CanSeeNote が fail-closed に倒れる。
+func (h *Handler) SetFollowingRepo(r repository.FollowingRepository) {
+	h.followingRepo = r
 }
 
 // SetNoteFieldResolver wires the shared resolver that fills Files /
@@ -77,6 +87,22 @@ func (h *Handler) emojiLookup() entity.EmojiLookup {
 		return nil
 	}
 	return h.emojiRepo
+}
+
+// filterVisible drops notes the viewer is not allowed to see. followingRepo
+// が未配線の場合 CanSeeNote は followers visibility を投稿者本人以外に
+// 見せない (fail-closed)。
+func (h *Handler) filterVisible(viewer *model.User, notes []*model.Note) []*model.Note {
+	if len(notes) == 0 {
+		return notes
+	}
+	out := make([]*model.Note, 0, len(notes))
+	for _, n := range notes {
+		if corenote.CanSeeNote(viewer, n, h.followingRepo) {
+			out = append(out, n)
+		}
+	}
+	return out
 }
 
 // NewHandler creates a new clips Handler.
@@ -327,6 +353,7 @@ func (h *Handler) Notes(c echo.Context) error {
 		}
 		return apierr.JSONInternalError(c)
 	}
+	notes = h.filterVisible(user, notes)
 	notes = notesfilter.ApplyHardMute(h.userRepo, user, notes)
 	entities := entity.PackNotes(c.Request().Context(), notes, h.idGen, h.instanceLookup(), h.emojiLookup(), h.reactionReader())
 	h.fieldRes.Apply(entities, user)

--- a/internal/api/clips/handler.go
+++ b/internal/api/clips/handler.go
@@ -9,7 +9,6 @@ import (
 	"github.com/shiroha-a/mk/internal/api/apierr"
 	"github.com/shiroha-a/mk/internal/api/pagination"
 	coreclip "github.com/shiroha-a/mk/internal/core/clip"
-	corenote "github.com/shiroha-a/mk/internal/core/note"
 	"github.com/shiroha-a/mk/internal/core/notesfilter"
 	"github.com/shiroha-a/mk/internal/entity"
 	"github.com/shiroha-a/mk/internal/misc/id"
@@ -87,22 +86,6 @@ func (h *Handler) emojiLookup() entity.EmojiLookup {
 		return nil
 	}
 	return h.emojiRepo
-}
-
-// filterVisible drops notes the viewer is not allowed to see. followingRepo
-// が未配線の場合 CanSeeNote は followers visibility を投稿者本人以外に
-// 見せない (fail-closed)。
-func (h *Handler) filterVisible(viewer *model.User, notes []*model.Note) []*model.Note {
-	if len(notes) == 0 {
-		return notes
-	}
-	out := make([]*model.Note, 0, len(notes))
-	for _, n := range notes {
-		if corenote.CanSeeNote(viewer, n, h.followingRepo) {
-			out = append(out, n)
-		}
-	}
-	return out
 }
 
 // NewHandler creates a new clips Handler.
@@ -353,7 +336,7 @@ func (h *Handler) Notes(c echo.Context) error {
 		}
 		return apierr.JSONInternalError(c)
 	}
-	notes = h.filterVisible(user, notes)
+	notes = notesfilter.FilterVisible(user, notes, h.followingRepo)
 	notes = notesfilter.ApplyHardMute(h.userRepo, user, notes)
 	entities := entity.PackNotes(c.Request().Context(), notes, h.idGen, h.instanceLookup(), h.emojiLookup(), h.reactionReader())
 	h.fieldRes.Apply(entities, user)

--- a/internal/api/clips/handler_test.go
+++ b/internal/api/clips/handler_test.go
@@ -30,6 +30,9 @@ func newHandler(t *testing.T) (
 	repo := testutil.NewMockClipRepository()
 	noteRepo := testutil.NewMockClipNoteRepository()
 	notes := testutil.NewMockNoteRepository()
+	// ListByClipVisible の visibility push-down 再現のため、clip mock に note の
+	// visibility lookup 用 map を共有させる (#1418 review)。
+	noteRepo.Notes = notes.Notes
 	idGen, _ := id.NewGenerator("aidx")
 	svc := coreclip.NewService(repo, noteRepo, notes, idGen)
 	return NewHandler(svc, idGen), repo, noteRepo, notes
@@ -580,7 +583,6 @@ func TestNotes_AnonymousOnPublic(t *testing.T) {
 // 閲覧権限のない viewer に対して除外されることを guard する。
 func TestNotes_AnonymousExcludesNonPublicVisibilityInPublicClip(t *testing.T) {
 	h, repo, clipNoteRepo, notes := newHandler(t)
-	h.SetFollowingRepo(testutil.NewMockFollowingRepository())
 	repo.Clips["c1"] = &model.Clip{ID: "c1", UserID: "alice", IsPublic: true}
 	// clip に紐づく ClipNote を直接 seed (AddNote を経由しない = visibility に
 	// 関係なく clip に存在する状態を再現する)。
@@ -605,12 +607,13 @@ func TestNotes_AnonymousExcludesNonPublicVisibilityInPublicClip(t *testing.T) {
 	assert.False(t, ids["n_spec"], "specified は対象外 viewer に漏らさない")
 }
 
-// listFailNoteRepo causes ListByClip to fail.
+// listFailNoteRepo causes the clip note listing to fail. clip service Notes は
+// ListByClipVisible を呼ぶためそちらを override する。
 type listFailNoteRepo struct {
 	*testutil.MockClipNoteRepository
 }
 
-func (r *listFailNoteRepo) ListByClip(_ string, _, _ string, _ int) ([]*model.ClipNote, error) {
+func (r *listFailNoteRepo) ListByClipVisible(_, _, _, _ string, _ int) ([]*model.ClipNote, error) {
 	return nil, errors.New("boom")
 }
 

--- a/internal/api/clips/handler_test.go
+++ b/internal/api/clips/handler_test.go
@@ -576,6 +576,35 @@ func TestNotes_AnonymousOnPublic(t *testing.T) {
 	assert.Equal(t, http.StatusOK, rec.Code)
 }
 
+// public clip に含まれる followers / specified visibility のノートは、
+// 閲覧権限のない viewer に対して除外されることを guard する。
+func TestNotes_AnonymousExcludesNonPublicVisibilityInPublicClip(t *testing.T) {
+	h, repo, clipNoteRepo, notes := newHandler(t)
+	h.SetFollowingRepo(testutil.NewMockFollowingRepository())
+	repo.Clips["c1"] = &model.Clip{ID: "c1", UserID: "alice", IsPublic: true}
+	// clip に紐づく ClipNote を直接 seed (AddNote を経由しない = visibility に
+	// 関係なく clip に存在する状態を再現する)。
+	clipNoteRepo.Entries["cn_pub"] = &model.ClipNote{ID: "cn_pub", ClipID: "c1", NoteID: "n_pub"}
+	clipNoteRepo.Entries["cn_fol"] = &model.ClipNote{ID: "cn_fol", ClipID: "c1", NoteID: "n_fol"}
+	clipNoteRepo.Entries["cn_spec"] = &model.ClipNote{ID: "cn_spec", ClipID: "c1", NoteID: "n_spec"}
+	notes.Notes["n_pub"] = &model.Note{ID: "n_pub", UserID: "alice", Visibility: "public", User: &model.User{ID: "alice"}}
+	notes.Notes["n_fol"] = &model.Note{ID: "n_fol", UserID: "alice", Visibility: "followers", User: &model.User{ID: "alice"}}
+	notes.Notes["n_spec"] = &model.Note{ID: "n_spec", UserID: "alice", Visibility: "specified", VisibleUserIDs: []string{"other"}, User: &model.User{ID: "alice"}}
+
+	c, rec := newReq(t, `{"clipId":"c1"}`)
+	require.NoError(t, h.Notes(c))
+	require.Equal(t, http.StatusOK, rec.Code)
+	var out []map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &out))
+	ids := map[string]bool{}
+	for _, n := range out {
+		ids[n["id"].(string)] = true
+	}
+	assert.True(t, ids["n_pub"])
+	assert.False(t, ids["n_fol"], "followers は anonymous に漏らさない")
+	assert.False(t, ids["n_spec"], "specified は対象外 viewer に漏らさない")
+}
+
 // listFailNoteRepo causes ListByClip to fail.
 type listFailNoteRepo struct {
 	*testutil.MockClipNoteRepository

--- a/internal/api/notes/handler_test.go
+++ b/internal/api/notes/handler_test.go
@@ -836,7 +836,7 @@ func (f *failingNoteRepo) IncrementReaction(_ string, _ string, _ int) error { r
 func (f *failingNoteRepo) ListByUserID(_ string, _, _ string, _ int) ([]*model.Note, error) {
 	return nil, nil
 }
-func (f *failingNoteRepo) ListByUserIDFiltered(_, _, _ string, _ int, _, _, _, _ bool) ([]*model.Note, error) {
+func (f *failingNoteRepo) ListByUserIDFiltered(_, _, _, _ string, _ int, _, _, _, _ bool) ([]*model.Note, error) {
 	return nil, nil
 }
 func (f *failingNoteRepo) ListByChannelID(_ string, _, _ string, _ int) ([]*model.Note, error) {

--- a/internal/api/users/handler.go
+++ b/internal/api/users/handler.go
@@ -11,7 +11,6 @@ import (
 	"github.com/shiroha-a/mk/internal/api/apierr"
 	"github.com/shiroha-a/mk/internal/api/pagination"
 	corefollowing "github.com/shiroha-a/mk/internal/core/following"
-	corenote "github.com/shiroha-a/mk/internal/core/note"
 	"github.com/shiroha-a/mk/internal/core/notesfilter"
 	corerole "github.com/shiroha-a/mk/internal/core/role"
 	"github.com/shiroha-a/mk/internal/core/user"
@@ -227,22 +226,6 @@ func (h *Handler) emojiLookup() entity.EmojiLookup {
 		return nil
 	}
 	return h.emojiRepo
-}
-
-// filterVisible drops notes the viewer is not allowed to see. followingRepo
-// が未配線の場合 CanSeeNote は followers visibility を投稿者本人以外に
-// 見せない (fail-closed)。
-func (h *Handler) filterVisible(viewer *model.User, notes []*model.Note) []*model.Note {
-	if len(notes) == 0 {
-		return notes
-	}
-	out := make([]*model.Note, 0, len(notes))
-	for _, n := range notes {
-		if corenote.CanSeeNote(viewer, n, h.followingRepo) {
-			out = append(out, n)
-		}
-	}
-	return out
 }
 
 // populateUserEmojis resolves custom emoji names in user.Emojis to URLs and
@@ -608,13 +591,18 @@ func (h *Handler) Notes(c echo.Context) error {
 
 	// sinceDate / untilDate を aidx prefix に正規化 (#1166)。
 	sinceID, untilID := id.NormalizeCursor(req.SinceID, req.UntilID, req.SinceDate, req.UntilDate)
-	notes, err := h.noteRepo.ListByUserIDFiltered(req.UserID, untilID, sinceID, req.Limit, withFiles, withReplies, withRenotes, withChannelNotes)
+	viewer := middleware.GetUser(c)
+	viewerID := ""
+	if viewer != nil {
+		viewerID = viewer.ID
+	}
+	// visibility は repository 側で LIMIT 前に push down する (#1418 review)。
+	// post-fetch filter だとページ過少充填 + followers 判定の N+1 になるため。
+	notes, err := h.noteRepo.ListByUserIDFiltered(req.UserID, viewerID, untilID, sinceID, req.Limit, withFiles, withReplies, withRenotes, withChannelNotes)
 	if err != nil {
 		return apierr.JSONInternalError(c)
 	}
 
-	viewer := middleware.GetUser(c)
-	notes = h.filterVisible(viewer, notes)
 	notes = notesfilter.ApplyHardMute(h.userRepo, viewer, notes)
 	out := entity.PackNotes(c.Request().Context(), notes, h.idGen, h.instanceLookup(), h.emojiLookup(), h.reactionReader())
 	h.fieldRes.Apply(out, viewer)
@@ -987,7 +975,7 @@ func (h *Handler) fillPinned(ctx context.Context, viewer *model.User, u *model.U
 			detailed.PinnedNoteIDs = ids
 			if h.noteRepo != nil {
 				if notes, err := h.noteRepo.FindManyByIDsWithUser(ids); err == nil {
-					notes = h.filterVisible(viewer, notes)
+					notes = notesfilter.FilterVisible(viewer, notes, h.followingRepo)
 					entities := entity.PackNotes(ctx, notes, h.idGen, h.instanceLookup(), h.emojiLookup(), h.reactionReader())
 					h.fieldRes.Apply(entities, viewer)
 					packed := make([]any, 0, len(entities))

--- a/internal/api/users/handler.go
+++ b/internal/api/users/handler.go
@@ -11,6 +11,7 @@ import (
 	"github.com/shiroha-a/mk/internal/api/apierr"
 	"github.com/shiroha-a/mk/internal/api/pagination"
 	corefollowing "github.com/shiroha-a/mk/internal/core/following"
+	corenote "github.com/shiroha-a/mk/internal/core/note"
 	"github.com/shiroha-a/mk/internal/core/notesfilter"
 	corerole "github.com/shiroha-a/mk/internal/core/role"
 	"github.com/shiroha-a/mk/internal/core/user"
@@ -226,6 +227,22 @@ func (h *Handler) emojiLookup() entity.EmojiLookup {
 		return nil
 	}
 	return h.emojiRepo
+}
+
+// filterVisible drops notes the viewer is not allowed to see. followingRepo
+// が未配線の場合 CanSeeNote は followers visibility を投稿者本人以外に
+// 見せない (fail-closed)。
+func (h *Handler) filterVisible(viewer *model.User, notes []*model.Note) []*model.Note {
+	if len(notes) == 0 {
+		return notes
+	}
+	out := make([]*model.Note, 0, len(notes))
+	for _, n := range notes {
+		if corenote.CanSeeNote(viewer, n, h.followingRepo) {
+			out = append(out, n)
+		}
+	}
+	return out
 }
 
 // populateUserEmojis resolves custom emoji names in user.Emojis to URLs and
@@ -597,6 +614,7 @@ func (h *Handler) Notes(c echo.Context) error {
 	}
 
 	viewer := middleware.GetUser(c)
+	notes = h.filterVisible(viewer, notes)
 	notes = notesfilter.ApplyHardMute(h.userRepo, viewer, notes)
 	out := entity.PackNotes(c.Request().Context(), notes, h.idGen, h.instanceLookup(), h.emojiLookup(), h.reactionReader())
 	h.fieldRes.Apply(out, viewer)
@@ -969,6 +987,7 @@ func (h *Handler) fillPinned(ctx context.Context, viewer *model.User, u *model.U
 			detailed.PinnedNoteIDs = ids
 			if h.noteRepo != nil {
 				if notes, err := h.noteRepo.FindManyByIDsWithUser(ids); err == nil {
+					notes = h.filterVisible(viewer, notes)
 					entities := entity.PackNotes(ctx, notes, h.idGen, h.instanceLookup(), h.emojiLookup(), h.reactionReader())
 					h.fieldRes.Apply(entities, viewer)
 					packed := make([]any, 0, len(entities))

--- a/internal/api/users/handler_extra.go
+++ b/internal/api/users/handler_extra.go
@@ -285,7 +285,7 @@ func (h *Handler) FeaturedNotes(c echo.Context) error {
 		return c.JSON(http.StatusInternalServerError, apierr.Error("INTERNAL_ERROR", "Internal error.", "5d37dbcb-891e-41ca-a3d6-e690c97775ac"))
 	}
 	viewer := middleware.GetUser(c)
-	notes = h.filterVisible(viewer, notes)
+	notes = notesfilter.FilterVisible(viewer, notes, h.followingRepo)
 	notes = notesfilter.ApplyHardMute(h.userRepo, viewer, notes)
 	result := entity.PackNotes(c.Request().Context(), notes, h.idGen, h.instanceLookup(), h.emojiLookup(), h.reactionReader())
 	h.fieldRes.Apply(result, viewer)

--- a/internal/api/users/handler_extra.go
+++ b/internal/api/users/handler_extra.go
@@ -285,6 +285,7 @@ func (h *Handler) FeaturedNotes(c echo.Context) error {
 		return c.JSON(http.StatusInternalServerError, apierr.Error("INTERNAL_ERROR", "Internal error.", "5d37dbcb-891e-41ca-a3d6-e690c97775ac"))
 	}
 	viewer := middleware.GetUser(c)
+	notes = h.filterVisible(viewer, notes)
 	notes = notesfilter.ApplyHardMute(h.userRepo, viewer, notes)
 	result := entity.PackNotes(c.Request().Context(), notes, h.idGen, h.instanceLookup(), h.emojiLookup(), h.reactionReader())
 	h.fieldRes.Apply(result, viewer)

--- a/internal/api/users/handler_extra_test.go
+++ b/internal/api/users/handler_extra_test.go
@@ -391,6 +391,28 @@ func TestFeaturedNotes_InvalidParam(t *testing.T) {
 	assert.Equal(t, http.StatusBadRequest, rec.Code)
 }
 
+// anonymous viewer に対して followers / specified visibility の
+// ノートが除外されることを guard する。
+func TestFeaturedNotes_AnonymousExcludesNonPublicVisibility(t *testing.T) {
+	h, _, noteRepo := newExtraHandler(t)
+	h.SetFollowingRepo(testutil.NewMockFollowingRepository())
+	noteRepo.Notes["fn_pub"] = &model.Note{ID: "fn_pub", UserID: "u1", Visibility: "public", User: &model.User{ID: "u1"}}
+	noteRepo.Notes["fn_fol"] = &model.Note{ID: "fn_fol", UserID: "u1", Visibility: "followers", User: &model.User{ID: "u1"}}
+	noteRepo.Notes["fn_spec"] = &model.Note{ID: "fn_spec", UserID: "u1", Visibility: "specified", VisibleUserIDs: []string{"other"}, User: &model.User{ID: "u1"}}
+
+	rec := postExtra(h.FeaturedNotes, `{"userId":"u1"}`, nil)
+	require.Equal(t, http.StatusOK, rec.Code)
+	var out []map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &out))
+	ids := map[string]bool{}
+	for _, n := range out {
+		ids[n["id"].(string)] = true
+	}
+	assert.True(t, ids["fn_pub"])
+	assert.False(t, ids["fn_fol"], "followers は anonymous に漏らさない")
+	assert.False(t, ids["fn_spec"], "specified は対象外 viewer に漏らさない")
+}
+
 // --- SearchByUsernameAndHost ---
 
 func TestSearchByUsernameAndHost_Success(t *testing.T) {

--- a/internal/api/users/handler_test.go
+++ b/internal/api/users/handler_test.go
@@ -935,6 +935,62 @@ func TestNotes_WithChannelNotes(t *testing.T) {
 	assert.True(t, hasChannel, "withChannelNotes=true で channel 投稿が含まれる")
 }
 
+// followers / specified visibility のノートは閲覧権限のない viewer に対して
+// 除外されることを guard する。
+func TestNotes_AnonymousExcludesNonPublicVisibility(t *testing.T) {
+	h, repo := newTestHandler(t)
+	addTestUser(repo)
+	noteRepo := h.noteRepo.(*testutil.MockNoteRepository)
+	text := "secret"
+	noteRepo.Notes["nv_pub"] = &model.Note{
+		ID: "nv_pub", UserID: "user1", Text: &text,
+		Visibility: model.NoteVisibilityPublic, Reactions: datatypes.JSON([]byte("{}")),
+	}
+	noteRepo.Notes["nv_fol"] = &model.Note{
+		ID: "nv_fol", UserID: "user1", Text: &text,
+		Visibility: model.NoteVisibilityFollowers, Reactions: datatypes.JSON([]byte("{}")),
+	}
+	noteRepo.Notes["nv_spec"] = &model.Note{
+		ID: "nv_spec", UserID: "user1", Text: &text,
+		Visibility:     model.NoteVisibilitySpecified,
+		VisibleUserIDs: []string{"other"},
+		Reactions:      datatypes.JSON([]byte("{}")),
+	}
+
+	rec := post(h.Notes, `{"userId":"user1"}`)
+	require.Equal(t, http.StatusOK, rec.Code)
+	var out []map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &out))
+	ids := map[string]bool{}
+	for _, n := range out {
+		ids[n["id"].(string)] = true
+	}
+	assert.True(t, ids["nv_pub"], "public は anonymous で見える")
+	assert.False(t, ids["nv_fol"], "followers は anonymous に漏らさない")
+	assert.False(t, ids["nv_spec"], "specified は対象外 viewer に漏らさない")
+}
+
+// follower 関係にある viewer は followers visibility のノートを閲覧可能。
+func TestNotes_FollowerSeesFollowersVisibility(t *testing.T) {
+	h, repo := newTestHandler(t)
+	addTestUser(repo)
+	noteRepo := h.noteRepo.(*testutil.MockNoteRepository)
+	text := "for-followers"
+	noteRepo.Notes["nv_fol2"] = &model.Note{
+		ID: "nv_fol2", UserID: "user1", Text: &text,
+		Visibility: model.NoteVisibilityFollowers, Reactions: datatypes.JSON([]byte("{}")),
+	}
+	fRepo := h.followingRepo.(*testutil.MockFollowingRepository)
+	fRepo.Followings["f1"] = &model.Following{ID: "f1", FollowerID: "viewer", FolloweeID: "user1"}
+
+	rec := postStub(h.Notes, `{"userId":"user1"}`, &model.User{ID: "viewer"})
+	require.Equal(t, http.StatusOK, rec.Code)
+	var out []map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &out))
+	require.Len(t, out, 1)
+	assert.Equal(t, "nv_fol2", out[0]["id"])
+}
+
 func TestNotes_LimitClamp(t *testing.T) {
 	h, repo := newTestHandler(t)
 	addTestUser(repo)

--- a/internal/api/users/handler_test.go
+++ b/internal/api/users/handler_test.go
@@ -980,8 +980,9 @@ func TestNotes_FollowerSeesFollowersVisibility(t *testing.T) {
 		ID: "nv_fol2", UserID: "user1", Text: &text,
 		Visibility: model.NoteVisibilityFollowers, Reactions: datatypes.JSON([]byte("{}")),
 	}
-	fRepo := h.followingRepo.(*testutil.MockFollowingRepository)
-	fRepo.Followings["f1"] = &model.Following{ID: "f1", FollowerID: "viewer", FolloweeID: "user1"}
+	// visibility は repository 側で push down されるため、mock note repo の
+	// Following map に follow 関係を持たせる (handler は viewerID を渡すだけ)。
+	noteRepo.Following = map[string][]string{"viewer": {"user1"}}
 
 	rec := postStub(h.Notes, `{"userId":"user1"}`, &model.User{ID: "viewer"})
 	require.Equal(t, http.StatusOK, rec.Code)
@@ -1503,7 +1504,7 @@ func (f *failingNoteRepo) ListByUserID(_ string, _, _ string, _ int) ([]*model.N
 	return nil, assertErr
 }
 
-func (f *failingNoteRepo) ListByUserIDFiltered(_, _, _ string, _ int, _, _, _, _ bool) ([]*model.Note, error) {
+func (f *failingNoteRepo) ListByUserIDFiltered(_, _, _, _ string, _ int, _, _, _, _ bool) ([]*model.Note, error) {
 	return nil, assertErr
 }
 
@@ -1654,6 +1655,42 @@ func TestShow_PinnedNotes_Populated(t *testing.T) {
 	notes, ok := resp["pinnedNotes"].([]any)
 	require.True(t, ok)
 	assert.Len(t, notes, 1)
+}
+
+// pinnedNotes に followers / specified visibility の note が含まれる場合、
+// 閲覧権限のない viewer (anonymous) には pinnedNotes 本体から除外されること
+// を guard する。pinnedNoteIds は visibility に関係なく出る upstream 挙動を
+// 維持しつつ、pack 済み note 本体だけ落とす (#1418 review)。
+func TestShow_PinnedNotes_ExcludesNonVisibleFromBody(t *testing.T) {
+	h, userRepo := newTestHandler(t)
+	addTestUser(userRepo)
+
+	piningRepo := testutil.NewMockUserNotePiningRepository()
+	require.NoError(t, piningRepo.Create(&model.UserNotePining{ID: "pp_pub", UserID: "user1", NoteID: "pn_pub"}))
+	require.NoError(t, piningRepo.Create(&model.UserNotePining{ID: "pp_fol", UserID: "user1", NoteID: "pn_fol"}))
+	h.SetPiningRepo(piningRepo)
+
+	nr, _ := h.noteRepo.(*testutil.MockNoteRepository)
+	require.NotNil(t, nr)
+	txt := "pinned"
+	nr.Notes["pn_pub"] = &model.Note{ID: "pn_pub", UserID: "user1", Text: &txt, Visibility: model.NoteVisibilityPublic, Reactions: datatypes.JSON([]byte("{}"))}
+	nr.Notes["pn_fol"] = &model.Note{ID: "pn_fol", UserID: "user1", Text: &txt, Visibility: model.NoteVisibilityFollowers, Reactions: datatypes.JSON([]byte("{}"))}
+
+	body := `{"userId": "user1"}`
+	e := echo.New()
+	req := httptest.NewRequest(http.MethodPost, "/api/users/show", strings.NewReader(body))
+	req.Header.Set(echo.HeaderContentType, echo.MIMEApplicationJSON)
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+	require.NoError(t, h.Show(c))
+
+	var resp map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+	notes, ok := resp["pinnedNotes"].([]any)
+	require.True(t, ok)
+	require.Len(t, notes, 1, "followers の pinned note は anonymous の pinnedNotes から除外される")
+	first := notes[0].(map[string]any)
+	assert.Equal(t, "pn_pub", first["id"])
 }
 
 func TestShow_PinnedPage_Populated(t *testing.T) {

--- a/internal/core/clip/clip_service.go
+++ b/internal/core/clip/clip_service.go
@@ -264,7 +264,10 @@ func (s *Service) Notes(requesterID, clipID, untilID, sinceID string, limit int)
 	if !c.IsPublic && c.UserID != requesterID {
 		return nil, ErrAccessDenied
 	}
-	rows, err := s.noteRepo.ListByClip(clipID, untilID, sinceID, limit)
+	// visibility は repository 側で LIMIT 前に push down する (#1418 review)。
+	// clip は author 混在のため post-fetch filter だと per-note の follow 判定
+	// N+1 + ページ過少充填になる。
+	rows, err := s.noteRepo.ListByClipVisible(clipID, requesterID, untilID, sinceID, limit)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/core/clip/clip_service_test.go
+++ b/internal/core/clip/clip_service_test.go
@@ -18,6 +18,9 @@ func newSvc(t *testing.T) (*clip.Service, *testutil.MockClipRepository, *testuti
 	repo := testutil.NewMockClipRepository()
 	noteRepo := testutil.NewMockClipNoteRepository()
 	notes := testutil.NewMockNoteRepository()
+	// ListByClipVisible の visibility push-down 再現のため、clip mock に note の
+	// visibility lookup 用 map を共有させる (#1418 review)。
+	noteRepo.Notes = notes.Notes
 	idGen, _ := id.NewGenerator("aidx")
 	return clip.NewService(repo, noteRepo, notes, idGen), repo, noteRepo, notes
 }
@@ -318,8 +321,8 @@ func TestRemoveNote_RepoError(t *testing.T) {
 func TestNotes_HappyPath(t *testing.T) {
 	svc, repo, _, notes := newSvc(t)
 	repo.Clips["c1"] = &model.Clip{ID: "c1", UserID: "u1"}
-	notes.Notes["n1"] = &model.Note{ID: "n1"}
-	notes.Notes["n2"] = &model.Note{ID: "n2"}
+	notes.Notes["n1"] = &model.Note{ID: "n1", Visibility: model.NoteVisibilityPublic}
+	notes.Notes["n2"] = &model.Note{ID: "n2", Visibility: model.NoteVisibilityPublic}
 	require.NoError(t, svc.AddNote("u1", "c1", "n1"))
 	require.NoError(t, svc.AddNote("u1", "c1", "n2"))
 
@@ -344,7 +347,7 @@ func TestNotes_PrivateAccessDenied(t *testing.T) {
 func TestNotes_PublicReadableByAnyone(t *testing.T) {
 	svc, repo, _, notes := newSvc(t)
 	repo.Clips["c1"] = &model.Clip{ID: "c1", UserID: "u1", IsPublic: true}
-	notes.Notes["n1"] = &model.Note{ID: "n1"}
+	notes.Notes["n1"] = &model.Note{ID: "n1", Visibility: model.NoteVisibilityPublic}
 	require.NoError(t, svc.AddNote("u1", "c1", "n1"))
 	rows, err := svc.Notes("u2", "c1", "", "", 10)
 	require.NoError(t, err)
@@ -359,12 +362,13 @@ func TestNotes_EmptyClipReturnsNil(t *testing.T) {
 	assert.Empty(t, rows)
 }
 
-// listFailRepo causes ListByClip to fail.
+// listFailRepo causes the clip note listing to fail. Service.Notes は
+// ListByClipVisible を呼ぶためそちらを override する。
 type listFailRepo struct {
 	*testutil.MockClipNoteRepository
 }
 
-func (r *listFailRepo) ListByClip(_ string, _, _ string, _ int) ([]*model.ClipNote, error) {
+func (r *listFailRepo) ListByClipVisible(_, _, _, _ string, _ int) ([]*model.ClipNote, error) {
 	return nil, errors.New("boom")
 }
 

--- a/internal/core/notesfilter/visibility.go
+++ b/internal/core/notesfilter/visibility.go
@@ -1,0 +1,27 @@
+package notesfilter
+
+import (
+	corenote "github.com/shiroha-a/mk/internal/core/note"
+	"github.com/shiroha-a/mk/internal/model"
+	"github.com/shiroha-a/mk/internal/repository"
+)
+
+// FilterVisible drops notes the viewer is not allowed to see, per
+// core/note.CanSeeNote. Used for bounded note sets (featured / pinned / clip)
+// where post-fetch filtering is acceptable; deeply paginated endpoints should
+// push visibility into SQL instead to avoid under-filled pages.
+//
+// followingRepo == nil の場合、followers visibility は投稿者本人以外には
+// 見せない (fail-closed)。
+func FilterVisible(viewer *model.User, notes []*model.Note, followingRepo repository.FollowingRepository) []*model.Note {
+	if len(notes) == 0 {
+		return notes
+	}
+	out := make([]*model.Note, 0, len(notes))
+	for _, n := range notes {
+		if corenote.CanSeeNote(viewer, n, followingRepo) {
+			out = append(out, n)
+		}
+	}
+	return out
+}

--- a/internal/core/notesfilter/visibility_test.go
+++ b/internal/core/notesfilter/visibility_test.go
@@ -1,0 +1,42 @@
+package notesfilter_test
+
+import (
+	"testing"
+
+	"github.com/shiroha-a/mk/internal/core/notesfilter"
+	"github.com/shiroha-a/mk/internal/model"
+	"github.com/shiroha-a/mk/internal/testutil"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestFilterVisible(t *testing.T) {
+	pub := &model.Note{ID: "pub", UserID: "author", Visibility: model.NoteVisibilityPublic}
+	fol := &model.Note{ID: "fol", UserID: "author", Visibility: model.NoteVisibilityFollowers}
+	spec := &model.Note{ID: "spec", UserID: "author", Visibility: model.NoteVisibilitySpecified, VisibleUserIDs: []string{"allowed"}}
+	notes := []*model.Note{pub, fol, spec}
+
+	idsOf := func(rows []*model.Note) []string {
+		out := make([]string, 0, len(rows))
+		for _, n := range rows {
+			out = append(out, n.ID)
+		}
+		return out
+	}
+
+	// 空入力はそのまま返す。
+	assert.Empty(t, notesfilter.FilterVisible(nil, nil, nil))
+
+	// anonymous viewer は public のみ。followingRepo nil でも fail-closed。
+	assert.Equal(t, []string{"pub"}, idsOf(notesfilter.FilterVisible(nil, notes, nil)))
+
+	// follower は public + followers。
+	fRepo := testutil.NewMockFollowingRepository()
+	fRepo.Followings["f1"] = &model.Following{ID: "f1", FollowerID: "follower", FolloweeID: "author"}
+	assert.Equal(t, []string{"pub", "fol"}, idsOf(notesfilter.FilterVisible(&model.User{ID: "follower"}, notes, fRepo)))
+
+	// specified の対象 viewer は public + specified。
+	assert.Equal(t, []string{"pub", "spec"}, idsOf(notesfilter.FilterVisible(&model.User{ID: "allowed"}, notes, fRepo)))
+
+	// author 本人は全 visibility を閲覧可。
+	assert.Equal(t, []string{"pub", "fol", "spec"}, idsOf(notesfilter.FilterVisible(&model.User{ID: "author"}, notes, fRepo)))
+}

--- a/internal/repository/clip_note.go
+++ b/internal/repository/clip_note.go
@@ -11,6 +11,12 @@ type ClipNoteRepository interface {
 	Delete(cn *model.ClipNote) error
 	FindByPair(clipID, noteID string) (*model.ClipNote, error)
 	ListByClip(clipID string, untilID, sinceID string, limit int) ([]*model.ClipNote, error)
+	// ListByClipVisible is ListByClip with a visibility push-down: clip entries
+	// whose referenced note the viewer cannot see (per core/note.CanSeeNote) are
+	// excluded before LIMIT. viewerID 空文字は匿名 (public/home のみ)。clips/notes
+	// で post-fetch filter によるページ過少充填と per-note の follow 判定 N+1 を
+	// 避けるため (#1418 review)。export 経路は全件必要なので ListByClip を使う。
+	ListByClipVisible(clipID, viewerID, untilID, sinceID string, limit int) ([]*model.ClipNote, error)
 	// CountByClip returns the number of notes in the given clip. Used by
 	// noteEachClipsLimit policy gate (#1029 PR-1 follow-up).
 	CountByClip(clipID string) (int64, error)
@@ -56,6 +62,15 @@ func (r *clipNoteRepository) CountByClip(clipID string) (int64, error) {
 // the clip_note id. Order flips to ASC when only sinceID is supplied,
 // matching paginationOrder (upstream QueryService.makePaginationQuery parity).
 func (r *clipNoteRepository) ListByClip(clipID string, untilID, sinceID string, limit int) ([]*model.ClipNote, error) {
+	return r.listByClip(clipID, "", false, untilID, sinceID, limit)
+}
+
+// ListByClipVisible is ListByClip with the visibility push-down enabled.
+func (r *clipNoteRepository) ListByClipVisible(clipID, viewerID, untilID, sinceID string, limit int) ([]*model.ClipNote, error) {
+	return r.listByClip(clipID, viewerID, true, untilID, sinceID, limit)
+}
+
+func (r *clipNoteRepository) listByClip(clipID, viewerID string, filterVisibility bool, untilID, sinceID string, limit int) ([]*model.ClipNote, error) {
 	if limit <= 0 {
 		limit = 30
 	}
@@ -63,6 +78,21 @@ func (r *clipNoteRepository) ListByClip(clipID string, untilID, sinceID string, 
 		limit = 100
 	}
 	q := r.db.Where("\"clipId\" = ?", clipID)
+	if filterVisibility {
+		// clip_note は author 混在のため、note を相関 EXISTS で join して
+		// visibility を LIMIT 前に絞る。条件は core/note.CanSeeNote と一致。
+		if viewerID == "" {
+			q = q.Where(`EXISTS (SELECT 1 FROM "note" v WHERE v."id" = "clip_note"."noteId" AND v."visibility" IN ('public','home'))`)
+		} else {
+			q = q.Where(
+				`EXISTS (SELECT 1 FROM "note" v WHERE v."id" = "clip_note"."noteId" AND (`+
+					`v."visibility" IN ('public','home') `+
+					`OR v."userId" = ? `+
+					`OR (v."visibility" = 'followers' AND v."userId" IN (SELECT f."followeeId" FROM "following" f WHERE f."followerId" = ?)) `+
+					`OR (v."visibility" = 'specified' AND ? = ANY(v."visibleUserIds"))))`,
+				viewerID, viewerID, viewerID)
+		}
+	}
 	if untilID != "" {
 		q = q.Where("id < ?", untilID)
 	}

--- a/internal/repository/clip_note_test.go
+++ b/internal/repository/clip_note_test.go
@@ -127,13 +127,12 @@ func TestClipNoteRepository_ListByClipVisible(t *testing.T) {
 		{ID: "n_cnv_fol", UserID: author.ID, Visibility: model.NoteVisibilityFollowers, Reactions: datatypes.JSON([]byte("{}"))},
 		{ID: "n_cnv_spec", UserID: author.ID, Visibility: model.NoteVisibilitySpecified, VisibleUserIDs: pq.StringArray{allowed.ID}, Reactions: datatypes.JSON([]byte("{}"))},
 	}
-	for i, n := range notes {
+	for _, n := range notes {
 		require.NoError(t, noteRepo.Create(n))
 		defer cleanupNote(t, n.ID)
 		cn := &model.ClipNote{ID: "cnv_" + n.ID, ClipID: c.ID, NoteID: n.ID}
 		require.NoError(t, repo.Create(cn))
 		defer testDB.Exec(`DELETE FROM "clip_note" WHERE id = ?`, cn.ID)
-		_ = i
 	}
 
 	f := &model.Following{ID: "fl_cnv_1", FollowerID: follower.ID, FolloweeID: author.ID}

--- a/internal/repository/clip_note_test.go
+++ b/internal/repository/clip_note_test.go
@@ -2,8 +2,10 @@ package repository
 
 import (
 	"context"
+	"sort"
 	"testing"
 
+	"github.com/lib/pq"
 	"github.com/shiroha-a/mk/internal/model"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -95,6 +97,82 @@ func TestClipNoteRepository_ListByClip_LimitClampAndPagination(t *testing.T) {
 	rows, err = repo.ListByClip(c.ID, "", "cn_n_cn_2a", 10)
 	require.NoError(t, err)
 	assert.Len(t, rows, 2)
+}
+
+// TestClipNoteRepository_ListByClipVisible は clips/notes の visibility
+// push-down (#1418 review) を検証する。clip に public / followers / specified
+// の note を混在させ、viewer ごとに SQL 段階で見える clip_note が変わること、
+// および ListByClip (export 経路) は全件返す (= フィルタしない) ことを確認する。
+func TestClipNoteRepository_ListByClipVisible(t *testing.T) {
+	clipRepo := NewClipRepository(testDB)
+	repo := NewClipNoteRepository(testDB)
+	noteRepo := NewNoteRepository(testDB)
+	followingRepo := NewFollowingRepository(testDB)
+
+	mkUser := func(id, username string) *model.User {
+		u := insertTestUser(t, id, username)
+		t.Cleanup(func() { cleanupUser(t, u.ID) })
+		return u
+	}
+	author := mkUser("u_cnv_a", "cnvauthor")
+	follower := mkUser("u_cnv_f", "cnvfollower")
+	allowed := mkUser("u_cnv_al", "cnvallowed")
+
+	c := newTestClip("clp_cnv", author.ID, "vis")
+	require.NoError(t, clipRepo.Create(c))
+	defer cleanupClip(t, c.ID)
+
+	notes := []*model.Note{
+		{ID: "n_cnv_pub", UserID: author.ID, Visibility: model.NoteVisibilityPublic, Reactions: datatypes.JSON([]byte("{}"))},
+		{ID: "n_cnv_fol", UserID: author.ID, Visibility: model.NoteVisibilityFollowers, Reactions: datatypes.JSON([]byte("{}"))},
+		{ID: "n_cnv_spec", UserID: author.ID, Visibility: model.NoteVisibilitySpecified, VisibleUserIDs: pq.StringArray{allowed.ID}, Reactions: datatypes.JSON([]byte("{}"))},
+	}
+	for i, n := range notes {
+		require.NoError(t, noteRepo.Create(n))
+		defer cleanupNote(t, n.ID)
+		cn := &model.ClipNote{ID: "cnv_" + n.ID, ClipID: c.ID, NoteID: n.ID}
+		require.NoError(t, repo.Create(cn))
+		defer testDB.Exec(`DELETE FROM "clip_note" WHERE id = ?`, cn.ID)
+		_ = i
+	}
+
+	f := &model.Following{ID: "fl_cnv_1", FollowerID: follower.ID, FolloweeID: author.ID}
+	require.NoError(t, followingRepo.Create(f))
+	defer testDB.Exec(`DELETE FROM "following" WHERE id = ?`, f.ID)
+
+	noteIDsOf := func(rows []*model.ClipNote) []string {
+		out := make([]string, 0, len(rows))
+		for _, r := range rows {
+			out = append(out, r.NoteID)
+		}
+		sort.Strings(out)
+		return out
+	}
+
+	// ListByClip (export 経路) はフィルタせず全件返す。
+	rows, err := repo.ListByClip(c.ID, "", "", 50)
+	require.NoError(t, err)
+	assert.Equal(t, []string{"n_cnv_fol", "n_cnv_pub", "n_cnv_spec"}, noteIDsOf(rows))
+
+	// 匿名 viewer は public のみ。
+	rows, err = repo.ListByClipVisible(c.ID, "", "", "", 50)
+	require.NoError(t, err)
+	assert.Equal(t, []string{"n_cnv_pub"}, noteIDsOf(rows))
+
+	// follower は public + followers。
+	rows, err = repo.ListByClipVisible(c.ID, follower.ID, "", "", 50)
+	require.NoError(t, err)
+	assert.Equal(t, []string{"n_cnv_fol", "n_cnv_pub"}, noteIDsOf(rows))
+
+	// specified 対象 viewer は public + specified。
+	rows, err = repo.ListByClipVisible(c.ID, allowed.ID, "", "", 50)
+	require.NoError(t, err)
+	assert.Equal(t, []string{"n_cnv_pub", "n_cnv_spec"}, noteIDsOf(rows))
+
+	// author 本人は全 visibility を閲覧可。
+	rows, err = repo.ListByClipVisible(c.ID, author.ID, "", "", 50)
+	require.NoError(t, err)
+	assert.Equal(t, []string{"n_cnv_fol", "n_cnv_pub", "n_cnv_spec"}, noteIDsOf(rows))
 }
 
 func TestClipNoteRepository_ListByClip_QueryError(t *testing.T) {

--- a/internal/repository/note.go
+++ b/internal/repository/note.go
@@ -65,7 +65,12 @@ type NoteRepository interface {
 	//
 	// caller (handler) は JSON pointer field から bool 値を必ず upstream の
 	// デフォルトに合わせて詰めること (#1021)。
-	ListByUserIDFiltered(userID, untilID, sinceID string, limit int, withFiles, withReplies, withRenotes, withChannelNotes bool) ([]*model.Note, error)
+	//
+	// viewerID は visibility push-down のための閲覧者 ID。空文字は匿名
+	// (public/home のみ)。core/note.CanSeeNote と同じ可視性条件を LIMIT 前に
+	// SQL で絞ることで、post-fetch filter によるページ過少充填と followers
+	// 判定の N+1 を避ける (#1418 review)。
+	ListByUserIDFiltered(userID, viewerID, untilID, sinceID string, limit int, withFiles, withReplies, withRenotes, withChannelNotes bool) ([]*model.Note, error)
 	ListByChannelID(channelID string, untilID, sinceID string, limit int) ([]*model.Note, error)
 	FindManyByIDsWithUser(ids []string) ([]*model.Note, error)
 	ListRenotesOf(noteID string, untilID, sinceID string, limit int) ([]*model.Note, error)
@@ -272,9 +277,24 @@ func (r *noteRepository) ListByUserID(userID string, untilID, sinceID string, li
 // handler 側で必ず詰めること (例: handler は withReplies=true / withRenotes=true
 // / withChannelNotes=false で渡す)。filter struct ではなく bool 引数で受ける
 // のは testutil ↔ repository の import cycle を避けるため (#1021)。
-func (r *noteRepository) ListByUserIDFiltered(userID, untilID, sinceID string, limit int, withFiles, withReplies, withRenotes, withChannelNotes bool) ([]*model.Note, error) {
+func (r *noteRepository) ListByUserIDFiltered(userID, viewerID, untilID, sinceID string, limit int, withFiles, withReplies, withRenotes, withChannelNotes bool) ([]*model.Note, error) {
 	var notes []*model.Note
 	q := preloadNoteRelations(r.db).Where(`"userId" = ?`, userID)
+	// upstream の generateVisibilityQuery 相当を LIMIT 前に push down する。
+	// post-fetch filter だと viewer が見られない note を除外した分 1 ページが
+	// limit 未満になりページネーションが途切れる + followers 判定が note ごとの
+	// N+1 になるため、LIMIT 前に SQL で絞る。条件は core/note.CanSeeNote と
+	// 一致させる (note_reaction.ListByUserID と同じ可視性定義)。
+	if viewerID == "" {
+		q = q.Where(`"visibility" IN ('public','home')`)
+	} else {
+		q = q.Where(
+			`("visibility" IN ('public','home') `+
+				`OR "userId" = ? `+
+				`OR ("visibility" = 'followers' AND "userId" IN (SELECT f."followeeId" FROM "following" f WHERE f."followerId" = ?)) `+
+				`OR ("visibility" = 'specified' AND ? = ANY("visibleUserIds")))`,
+			viewerID, viewerID, viewerID)
+	}
 	if untilID != "" {
 		q = q.Where("id < ?", untilID)
 	}

--- a/internal/repository/note_test.go
+++ b/internal/repository/note_test.go
@@ -2,6 +2,7 @@ package repository
 
 import (
 	"context"
+	"sort"
 	"strings"
 	"testing"
 	"time"
@@ -470,15 +471,82 @@ func TestNoteRepository_ListByUserIDFiltered(t *testing.T) {
 
 	// withFiles=false の defaults (= withReplies=true / withRenotes=true /
 	// withChannelNotes=false)。channel=false の filter は本ケースで影響なし。
-	out, err := repo.ListByUserIDFiltered(user.ID, "", "", 10, false, true, true, false)
+	out, err := repo.ListByUserIDFiltered(user.ID, "", "", "", 10, false, true, true, false)
 	require.NoError(t, err)
 	assert.Len(t, out, 2)
 
 	// withFiles=true で file 添付のみ
-	out, err = repo.ListByUserIDFiltered(user.ID, "", "", 10, true, true, true, false)
+	out, err = repo.ListByUserIDFiltered(user.ID, "", "", "", 10, true, true, true, false)
 	require.NoError(t, err)
 	require.Len(t, out, 1)
 	assert.Equal(t, "n_lf_file", out[0].ID)
+}
+
+// TestNoteRepository_ListByUserIDFiltered_VisibilityPushDown は users/notes の
+// visibility push-down (#1418 review) を検証する。author が public / followers /
+// specified の 3 note を持ち、viewer ごとに SQL 段階で見える note が変わること
+// を確認する (LIMIT 前に絞られるためページネーションが途切れない)。
+func TestNoteRepository_ListByUserIDFiltered_VisibilityPushDown(t *testing.T) {
+	repo := NewNoteRepository(testDB)
+	followingRepo := NewFollowingRepository(testDB)
+
+	mkUser := func(id, username string) *model.User {
+		u := insertTestUser(t, id, username)
+		t.Cleanup(func() { cleanupUser(t, u.ID) })
+		return u
+	}
+	author := mkUser("u_lfv_a", "lfvauthor")
+	follower := mkUser("u_lfv_f", "lfvfollower")
+	allowed := mkUser("u_lfv_al", "lfvallowed")
+	stranger := mkUser("u_lfv_s", "lfvstranger")
+
+	notes := []*model.Note{
+		{ID: "n_lfv_pub", UserID: author.ID, Visibility: model.NoteVisibilityPublic, Reactions: datatypes.JSON([]byte("{}")), FileIDs: pq.StringArray{}},
+		{ID: "n_lfv_fol", UserID: author.ID, Visibility: model.NoteVisibilityFollowers, Reactions: datatypes.JSON([]byte("{}")), FileIDs: pq.StringArray{}},
+		{ID: "n_lfv_spec", UserID: author.ID, Visibility: model.NoteVisibilitySpecified, VisibleUserIDs: pq.StringArray{allowed.ID}, Reactions: datatypes.JSON([]byte("{}")), FileIDs: pq.StringArray{}},
+	}
+	for _, n := range notes {
+		require.NoError(t, repo.Create(n))
+		defer cleanupNote(t, n.ID)
+	}
+
+	f := &model.Following{ID: "fl_lfv_1", FollowerID: follower.ID, FolloweeID: author.ID}
+	require.NoError(t, followingRepo.Create(f))
+	defer testDB.Exec(`DELETE FROM "following" WHERE id = ?`, f.ID)
+
+	idsOf := func(rows []*model.Note) []string {
+		out := make([]string, 0, len(rows))
+		for _, n := range rows {
+			out = append(out, n.ID)
+		}
+		sort.Strings(out)
+		return out
+	}
+
+	// 匿名 viewer は public のみ。
+	out, err := repo.ListByUserIDFiltered(author.ID, "", "", "", 50, false, true, true, false)
+	require.NoError(t, err)
+	assert.Equal(t, []string{"n_lfv_pub"}, idsOf(out))
+
+	// stranger (follow なし / specified 対象外) も public のみ。
+	out, err = repo.ListByUserIDFiltered(author.ID, stranger.ID, "", "", 50, false, true, true, false)
+	require.NoError(t, err)
+	assert.Equal(t, []string{"n_lfv_pub"}, idsOf(out))
+
+	// follower は public + followers。
+	out, err = repo.ListByUserIDFiltered(author.ID, follower.ID, "", "", 50, false, true, true, false)
+	require.NoError(t, err)
+	assert.Equal(t, []string{"n_lfv_fol", "n_lfv_pub"}, idsOf(out))
+
+	// specified の visibleUserIds に含まれる viewer は public + specified。
+	out, err = repo.ListByUserIDFiltered(author.ID, allowed.ID, "", "", 50, false, true, true, false)
+	require.NoError(t, err)
+	assert.Equal(t, []string{"n_lfv_pub", "n_lfv_spec"}, idsOf(out))
+
+	// author 本人は全 visibility を閲覧可。
+	out, err = repo.ListByUserIDFiltered(author.ID, author.ID, "", "", 50, false, true, true, false)
+	require.NoError(t, err)
+	assert.Equal(t, []string{"n_lfv_fol", "n_lfv_pub", "n_lfv_spec"}, idsOf(out))
 }
 
 func TestNoteRepository_ListByUserIDFiltered_QueryError(t *testing.T) {
@@ -486,7 +554,7 @@ func TestNoteRepository_ListByUserIDFiltered_QueryError(t *testing.T) {
 	cancel()
 	db := testDB.WithContext(ctx)
 	repo := NewNoteRepository(db)
-	_, err := repo.ListByUserIDFiltered("a", "", "", 10, true, true, true, false)
+	_, err := repo.ListByUserIDFiltered("a", "", "", "", 10, true, true, true, false)
 	assert.Error(t, err)
 }
 

--- a/internal/server/router.go
+++ b/internal/server/router.go
@@ -1682,6 +1682,7 @@ func (s *Server) setupRoutes() {
 	clipsHandler.SetReactionReader(reactionCountWriter)
 	clipsHandler.SetNoteFieldResolver(noteFieldResolver)
 	clipsHandler.SetUserRepo(userRepo)
+	clipsHandler.SetFollowingRepo(followingRepo)
 	api.POST("/clips/create", clipsHandler.Create, middleware.RequireAuth())
 	api.POST("/clips/show", clipsHandler.Show)
 	api.POST("/clips/update", clipsHandler.Update, middleware.RequireAuth())

--- a/internal/server/router.go
+++ b/internal/server/router.go
@@ -1636,7 +1636,6 @@ func (s *Server) setupRoutes() {
 	clipsHandler.SetReactionReader(reactionCountWriter)
 	clipsHandler.SetNoteFieldResolver(noteFieldResolver)
 	clipsHandler.SetUserRepo(userRepo)
-	clipsHandler.SetFollowingRepo(followingRepo)
 	api.POST("/clips/create", clipsHandler.Create, middleware.RequireAuth())
 	api.POST("/clips/show", clipsHandler.Show)
 	api.POST("/clips/update", clipsHandler.Update, middleware.RequireAuth())

--- a/internal/testutil/mock_repository.go
+++ b/internal/testutil/mock_repository.go
@@ -739,6 +739,12 @@ func applyProfileFields(p *model.UserProfile, fields map[string]any) {
 type MockNoteRepository struct {
 	Notes          map[string]*model.Note
 	ReactionCounts map[string]map[string]int // noteID -> reaction -> count
+	// Following は ListByUserIDFiltered の visibility push-down (followers note
+	// の follow 判定) に使う followerID -> followeeIDs map。未設定なら follow
+	// なし扱い (= 非 follower viewer)。testutil は core/note を import すると
+	// repository 内部テストとの循環になるため CanSeeNote は使わず inline で
+	// 可視性を再現する (条件は CanSeeNote / real repo SQL と一致させる)。
+	Following map[string][]string
 }
 
 func NewMockNoteRepository() *MockNoteRepository {
@@ -1003,9 +1009,13 @@ func (m *MockNoteRepository) ListByUserID(userID string, untilID, sinceID string
 // 詰めて listFiltered に委譲する (#1021)。bool 4 引数は repository interface
 // の signature に整合 (= struct を介さない理由は testutil ↔ repository の
 // import cycle 回避)。
-func (m *MockNoteRepository) ListByUserIDFiltered(userID, untilID, sinceID string, limit int, withFiles, withReplies, withRenotes, withChannelNotes bool) ([]*model.Note, error) {
+func (m *MockNoteRepository) ListByUserIDFiltered(userID, viewerID, untilID, sinceID string, limit int, withFiles, withReplies, withRenotes, withChannelNotes bool) ([]*model.Note, error) {
 	return m.listFiltered(func(n *model.Note) bool {
 		if n.UserID != userID {
+			return false
+		}
+		// visibility push-down を real repo SQL と揃えて inline 再現する。
+		if !m.canViewerSeeNote(viewerID, n) {
 			return false
 		}
 		if withFiles && len(n.FileIDs) == 0 {
@@ -1029,6 +1039,41 @@ func (m *MockNoteRepository) ListByUserIDFiltered(userID, untilID, sinceID strin
 		}
 		return true
 	}, untilID, sinceID, limit), nil
+}
+
+// canViewerSeeNote replicates the real repo's visibility push-down inline.
+// 条件は core/note.CanSeeNote / real repo の SQL と一致させる (public/home は
+// 全員、followers は author 本人または follow 済み、specified は author 本人
+// または visibleUserIds に含まれる)。
+func (m *MockNoteRepository) canViewerSeeNote(viewerID string, n *model.Note) bool {
+	switch n.Visibility {
+	case model.NoteVisibilityPublic, model.NoteVisibilityHome:
+		return true
+	}
+	if viewerID == "" {
+		return false
+	}
+	// author 本人は followers/specified を問わず閲覧可。
+	if viewerID == n.UserID {
+		return true
+	}
+	switch n.Visibility {
+	case model.NoteVisibilityFollowers:
+		for _, followee := range m.Following[viewerID] {
+			if followee == n.UserID {
+				return true
+			}
+		}
+		return false
+	case model.NoteVisibilitySpecified:
+		for _, id := range n.VisibleUserIDs {
+			if id == viewerID {
+				return true
+			}
+		}
+		return false
+	}
+	return false
 }
 
 func (m *MockNoteRepository) FindManyByIDsWithUser(ids []string) ([]*model.Note, error) {

--- a/internal/testutil/mock_repository.go
+++ b/internal/testutil/mock_repository.go
@@ -1041,39 +1041,10 @@ func (m *MockNoteRepository) ListByUserIDFiltered(userID, viewerID, untilID, sin
 	}, untilID, sinceID, limit), nil
 }
 
-// canViewerSeeNote replicates the real repo's visibility push-down inline.
-// 条件は core/note.CanSeeNote / real repo の SQL と一致させる (public/home は
-// 全員、followers は author 本人または follow 済み、specified は author 本人
-// または visibleUserIds に含まれる)。
+// canViewerSeeNote replicates the real repo's visibility push-down inline via
+// the shared noteVisibleToViewer helper.
 func (m *MockNoteRepository) canViewerSeeNote(viewerID string, n *model.Note) bool {
-	switch n.Visibility {
-	case model.NoteVisibilityPublic, model.NoteVisibilityHome:
-		return true
-	}
-	if viewerID == "" {
-		return false
-	}
-	// author 本人は followers/specified を問わず閲覧可。
-	if viewerID == n.UserID {
-		return true
-	}
-	switch n.Visibility {
-	case model.NoteVisibilityFollowers:
-		for _, followee := range m.Following[viewerID] {
-			if followee == n.UserID {
-				return true
-			}
-		}
-		return false
-	case model.NoteVisibilitySpecified:
-		for _, id := range n.VisibleUserIDs {
-			if id == viewerID {
-				return true
-			}
-		}
-		return false
-	}
-	return false
+	return noteVisibleToViewer(viewerID, n, m.Following)
 }
 
 func (m *MockNoteRepository) FindManyByIDsWithUser(ids []string) ([]*model.Note, error) {
@@ -1462,6 +1433,14 @@ func (m *MockNoteReactionRepository) ListByUserID(userID, viewerID, untilID, sin
 // が note 行を要求して false になるのと揃えて除外する (production は FK + Preload
 // で note が必ず存在するためこの分岐は起きない。test は note を必ず seed する)。
 func (m *MockNoteReactionRepository) canViewerSeeNote(viewerID string, n *model.Note) bool {
+	return noteVisibleToViewer(viewerID, n, m.Following)
+}
+
+// noteVisibleToViewer replicates core/note.CanSeeNote / the real repo の
+// visibility SQL を inline で再現する共通ヘルパー。testutil は core/note を
+// import すると repository 内部テストとの循環になるためロジックを複製する
+// (条件は CanSeeNote と一致させる)。following は followerID -> followeeIDs。
+func noteVisibleToViewer(viewerID string, n *model.Note, following map[string][]string) bool {
 	if n == nil {
 		return false
 	}
@@ -1478,7 +1457,7 @@ func (m *MockNoteReactionRepository) canViewerSeeNote(viewerID string, n *model.
 	}
 	switch n.Visibility {
 	case model.NoteVisibilityFollowers:
-		for _, followee := range m.Following[viewerID] {
+		for _, followee := range following[viewerID] {
 			if followee == n.UserID {
 				return true
 			}
@@ -3020,6 +2999,11 @@ func applyClipFields(c *model.Clip, fields map[string]any) {
 // MockClipNoteRepository is a test double for repository.ClipNoteRepository.
 type MockClipNoteRepository struct {
 	Entries map[string]*model.ClipNote
+	// Notes / Following は ListByClipVisible の visibility push-down 再現に
+	// 使う。Notes は noteID -> note (visibility 判定用)、Following は
+	// followerID -> followeeIDs。未設定なら note 不在扱い (= 非可視)。
+	Notes     map[string]*model.Note
+	Following map[string][]string
 }
 
 // NewMockClipNoteRepository creates an empty MockClipNoteRepository.
@@ -3057,9 +3041,22 @@ func (m *MockClipNoteRepository) CountByClip(clipID string) (int64, error) {
 }
 
 func (m *MockClipNoteRepository) ListByClip(clipID string, untilID, sinceID string, limit int) ([]*model.ClipNote, error) {
+	return m.listByClip(clipID, "", false, untilID, sinceID, limit)
+}
+
+// ListByClipVisible mirrors the real repo's visibility push-down: clip entries
+// whose note the viewer cannot see are dropped before the limit slice.
+func (m *MockClipNoteRepository) ListByClipVisible(clipID, viewerID, untilID, sinceID string, limit int) ([]*model.ClipNote, error) {
+	return m.listByClip(clipID, viewerID, true, untilID, sinceID, limit)
+}
+
+func (m *MockClipNoteRepository) listByClip(clipID, viewerID string, filterVisibility bool, untilID, sinceID string, limit int) ([]*model.ClipNote, error) {
 	var rows []*model.ClipNote
 	for _, cn := range m.Entries {
 		if cn.ClipID != clipID {
+			continue
+		}
+		if filterVisibility && !noteVisibleToViewer(viewerID, m.Notes[cn.NoteID], m.Following) {
 			continue
 		}
 		if untilID != "" && cn.ID >= untilID {


### PR DESCRIPTION
## Summary

`users/notes` ・ `users/featured-notes` ・ `users/show#pinnedNotes` ・ `clips/notes` の 4 経路で `core/note.CanSeeNote` 相当の visibility filter を補強します。詳細は別途リポジトリ主宛に共有済みの内部レポートを参照してください。

## 変更点

- `internal/api/users/handler.go` / `handler_extra.go`
  - `filterVisible(viewer, notes)` ヘルパーを追加し、`Notes` / `FeaturedNotes` / `fillPinned` (= `users/show` の pinnedNotes 埋め込み) の pack 直前で呼び出し。
- `internal/api/clips/handler.go`
  - `followingRepo` フィールドと `SetFollowingRepo` を追加し、handler 内で同等の `filterVisible` を `Notes` 経路に挿入。
- `internal/server/router.go`
  - clips handler に `SetFollowingRepo(followingRepo)` を配線。

`core/note.CanSeeNote` 自体には変更なし。すでに wire 済みの `followingRepo` を passthrough して利用します。`followingRepo` 未配線時は CanSeeNote が fail-closed (= 投稿者本人以外には followers/specified visibility を見せない) に倒れます。

## テスト

新規 4 ケース:

- `internal/api/users/handler_test.go`
  - `TestNotes_AnonymousExcludesNonPublicVisibility` — anonymous viewer は public のみ
  - `TestNotes_FollowerSeesFollowersVisibility` — follower viewer は followers を見える
- `internal/api/users/handler_extra_test.go`
  - `TestFeaturedNotes_AnonymousExcludesNonPublicVisibility`
- `internal/api/clips/handler_test.go`
  - `TestNotes_AnonymousExcludesNonPublicVisibilityInPublicClip`

```
go test ./internal/api/users/ ./internal/api/clips/ ./internal/api/notes/
ok  	internal/api/users
ok  	internal/api/clips
ok  	internal/api/notes
```

`make fmt && make lint` clean。