### PR TITLE
fix(federation): resolver 経路に federation policy gate を追加

### DIFF
--- a/internal/core/federation/permanent_error.go
+++ b/internal/core/federation/permanent_error.go
@@ -28,6 +28,9 @@ import (
 //   - `corereaction.ErrNoteNotVisible` — note 解決後の visibility 違反。
 //     mk-go の policy 上 reaction を作れないので、activity 全体は ack
 //     して終わる方が筋。
+//   - `ErrHostNotAllowed` — federation policy (none / specified /
+//     blockedHosts) で許可されない host からの fetch / ingest。policy は
+//     retry では解消しないので ack して drop する (#1419 review)。
 //
 // transient と分類する (false 返す) error: 5xx / network error / timeout
 // 等、対側の一過性障害。retry サイクルに乗せる。`nil` も false を返す
@@ -48,6 +51,9 @@ func isPermanentSkipError(err error) bool {
 		return true
 	}
 	if errors.Is(err, corereaction.ErrNoteNotVisible) {
+		return true
+	}
+	if errors.Is(err, ErrHostNotAllowed) {
 		return true
 	}
 	return false

--- a/internal/core/federation/permanent_error_test.go
+++ b/internal/core/federation/permanent_error_test.go
@@ -32,6 +32,8 @@ func TestIsPermanentSkipError(t *testing.T) {
 		{"ErrInvalidNote wrapped", fmt.Errorf("ingest: %w", ErrInvalidNote), true},
 		{"ErrNoteNotVisible", corereaction.ErrNoteNotVisible, true},
 		{"ErrNoteNotVisible wrapped", fmt.Errorf("create: %w", corereaction.ErrNoteNotVisible), true},
+		{"ErrHostNotAllowed", ErrHostNotAllowed, true},
+		{"ErrHostNotAllowed wrapped", fmt.Errorf("resolve: %w", ErrHostNotAllowed), true},
 		{"status 404 wrapped", fmt.Errorf("fetch %s: %w", "url", &activitypub.StatusError{StatusCode: 404, Status: "404"}), true},
 		{"status 500 wrapped", fmt.Errorf("fetch: %w", &activitypub.StatusError{StatusCode: 500, Status: "500"}), false},
 		{"generic error", errors.New("dial failed"), false},

--- a/internal/core/federation/processor.go
+++ b/internal/core/federation/processor.go
@@ -787,6 +787,15 @@ func (p *Processor) handleAccept(act genericActivity) error {
 func (p *Processor) handleCreate(act genericActivity) error {
 	actor, err := p.resolver.ResolveActor(act.Actor)
 	if err != nil {
+		if errors.Is(err, ErrHostNotAllowed) {
+			// federation policy で許可されない host の actor からの Create は
+			// retry で解消しないため ack して drop する (#1419 review)。署名検証
+			// 経路では verifyPayload が先に弾くが、署名なし inbound 経路でも
+			// retry ループにならないようここでも吸収する。
+			slog.Info("federation: dropping Create from non-federated host actor",
+				"actor", act.Actor)
+			return nil
+		}
 		return err
 	}
 	// Note の `_misskey_talk` を覗き見て chat か通常 note かを分岐する。
@@ -820,6 +829,15 @@ func (p *Processor) handleCreate(act genericActivity) error {
 		// sentinel error の errors.Is で同等の non-retry 化を行う。
 		slog.Info("federation: dropping inbound note exceeding mentionLimit",
 			"actor", act.Actor, "limit", corenote.DefaultMentionLimit)
+		return nil
+	}
+	if errors.Is(err, ErrHostNotAllowed) {
+		// federation policy (none / specified / blockedHosts) で許可されない
+		// host の Create(Note) は retry で解消しないため ack して drop する
+		// (#1419 review)。handleAnnounce 等は isPermanentSkipError で吸収する
+		// が、handleCreate は他の error を retry に乗せる方針なので明示分岐。
+		slog.Info("federation: dropping inbound Create(Note) from non-federated host",
+			"actor", act.Actor)
 		return nil
 	}
 	if err != nil {

--- a/internal/core/federation/resolver.go
+++ b/internal/core/federation/resolver.go
@@ -73,6 +73,10 @@ var (
 	ErrInvalidActor = errors.New("invalid actor document")
 	// ErrInvalidNote is returned when a fetched Note cannot be parsed.
 	ErrInvalidNote = errors.New("invalid note document")
+	// ErrHostNotAllowed is returned when the resolver is asked to fetch /
+	// ingest content from a host that the local instance's federation policy
+	// (federation: none / specified, blockedHosts) does not allow.
+	ErrHostNotAllowed = errors.New("host not allowed by federation policy")
 )
 
 // DefaultActorTTL is the default duration after which a cached actor (and its
@@ -145,6 +149,12 @@ type Resolver struct {
 	// 未設定なら probe 自体をスキップする (安全側に倒す: SSRF リスクを
 	// 起こすくらいなら properties 空のまま運用)。
 	imageProbeClient *http.Client
+	// hostBlocker は federation 設定 (none / specified / blockedHosts) を
+	// 評価する gate。fetchActor / resolveNoteOnce / IngestNoteWithCreated
+	// の入口で URI の host / attributedTo の host を判定して、ホワイト
+	// リスト外 host からの取り込みを拒否する。未配線時は legacy 挙動
+	// (全 host 許可) にフォールバック。
+	hostBlocker HostBlockChecker
 
 	// resolveActorGroup / resolveNoteGroup は同一 URI への並行 ResolveActor /
 	// ResolveNote 呼び出しを 1 度の DB lookup + HTTP fetch に collapse する
@@ -267,6 +277,36 @@ func (r *Resolver) SetImageProbeClient(client *http.Client) {
 // は無視される (旧挙動)。
 func (r *Resolver) SetDriveFileRepo(repo repository.DriveFileRepository) {
 	r.driveFileRepo = repo
+}
+
+// SetHostBlockChecker attaches a federation-policy checker used to reject
+// new fetches / ingests from hosts that the running instance does not
+// federate with (federation: none / specified、blockedHosts)。未配線時は
+// gate が無効化されて legacy 挙動 (全 host 許可) に倒れる。
+func (r *Resolver) SetHostBlockChecker(c HostBlockChecker) {
+	r.hostBlocker = c
+}
+
+// hostAllowed reports whether the resolver may talk to / persist content
+// authored on host. host == "" (= local) は常に true。未配線時も true。
+func (r *Resolver) hostAllowed(host string) bool {
+	if r.hostBlocker == nil || host == "" {
+		return true
+	}
+	if r.hostBlocker.IsBlocked(host) {
+		return false
+	}
+	return r.hostBlocker.IsAllowed(host)
+}
+
+// hostAllowedForURI parses uri and applies hostAllowed. URI 解析不可は別
+// 経路で reject される前提で許容 (= true) する。
+func (r *Resolver) hostAllowedForURI(uri string) bool {
+	host, err := hostFromURI(uri)
+	if err != nil {
+		return true
+	}
+	return r.hostAllowed(host)
 }
 
 // PublicKeyForActor returns the cached public key PEM for an actor ID.
@@ -634,6 +674,13 @@ func (r *Resolver) refreshActor(existing *model.User, uri string) {
 // document whose `type` is not in activitypub.ValidActorTypes — this guards
 // against a non-Actor object (e.g. a Note) being interpreted as a Person.
 func (r *Resolver) fetchActor(uri string) (*activitypub.Person, error) {
+	// federation policy gate: ホワイトリスト連合 (federation: specified) や
+	// blockedHosts 設定下では、対象 URI の host が許可されていなければ HTTP
+	// fetch 自体を抑止する。refreshActor / refreshPublicKey / resolveActorOnce
+	// すべてここを経由するため、actor 側はこの 1 箇所で塞げる。
+	if !r.hostAllowedForURI(uri) {
+		return nil, ErrHostNotAllowed
+	}
 	body, err := r.fetcher.FetchObject(uri)
 	if err != nil {
 		return nil, err
@@ -813,6 +860,13 @@ func (r *Resolver) resolveNoteOnce(uri string) (*model.Note, error) {
 	if existing, err := r.noteRepo.FindByURI(uri); err == nil {
 		return existing, nil
 	}
+	// federation policy gate: ホワイトリスト外 / blocked な host の note は
+	// HTTP fetch も DB 永続化もしない。Announce 経由で第三者 host の note を
+	// 渡されるケースを塞ぐ (handleAnnounce → ResolveNote)。既存行 (上の
+	// FindByURI hit) は素通しで legacy 互換。
+	if !r.hostAllowedForURI(uri) {
+		return nil, ErrHostNotAllowed
+	}
 	body, err := r.fetcher.FetchObject(uri)
 	if err != nil {
 		return nil, err
@@ -861,6 +915,13 @@ func (r *Resolver) IngestNoteWithCreated(body []byte) (*model.Note, bool, error)
 	}
 	if existing, err := r.noteRepo.FindByURI(apNote.ID); err == nil {
 		return existing, false, nil
+	}
+	// federation policy gate: 直接 handleCreate から受け取った body や、
+	// 中継経由で attributedTo が allowlist 外の host を指している payload を
+	// DB 永続化させない。既存 row hit (上の FindByURI) は素通しで legacy
+	// 互換を維持する。
+	if !r.hostAllowedForURI(apNote.AttributedTo) {
+		return nil, false, ErrHostNotAllowed
 	}
 	actor, err := r.ResolveActor(apNote.AttributedTo)
 	if err != nil {

--- a/internal/core/federation/resolver_allowlist_test.go
+++ b/internal/core/federation/resolver_allowlist_test.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/shiroha-a/mk/internal/activitypub"
 	"github.com/shiroha-a/mk/internal/core/federation"
+	corefollowing "github.com/shiroha-a/mk/internal/core/following"
 	"github.com/shiroha-a/mk/internal/misc/id"
 	"github.com/shiroha-a/mk/internal/model"
 	"github.com/shiroha-a/mk/internal/testutil"
@@ -128,4 +129,25 @@ func TestIngestNote_DedupHitPassesEvenIfHostBlocked(t *testing.T) {
 	require.NotNil(t, got)
 	assert.Equal(t, "existing", got.ID)
 	assert.False(t, created)
+}
+
+// 非連合 host からの Create(Note) を inbox processor が受けたとき、gate の
+// ErrHostNotAllowed は permanent skip として ack され (Process は nil を返す)、
+// queue retry に乗らないこと。actor / note いずれも DB に作られないことも確認。
+func TestProcessCreate_NonFederatedHostIsDroppedNotRetried(t *testing.T) {
+	repo := testutil.NewMockUserRepository()
+	noteRepo := testutil.NewMockNoteRepository()
+	followingRepo := testutil.NewMockFollowingRepository()
+	urls := activitypub.NewURLBuilder("https://example.com")
+	idGen, _ := id.NewGenerator("aidx")
+	resolver := federation.NewResolver(repo, noteRepo, urls, &stubFetcher{body: []byte(sampleActor)}, idGen)
+	resolver.SetHostBlockChecker(&stubHostBlocker{disallowed: map[string]bool{"remote.example": true}})
+	followingSvc := corefollowing.NewService(repo, followingRepo, testutil.NewMockFollowRequestRepository(), idGen)
+	p := federation.NewProcessor(resolver, followingSvc, nil, nil, repo, noteRepo)
+
+	body := []byte(`{"type":"Create","actor":"https://remote.example/users/alice","object":` + sampleRemoteNote + `}`)
+	// permanent skip = ack。err を返すと queue が無駄に retry してしまう。
+	require.NoError(t, p.Process(body))
+	assert.Empty(t, noteRepo.Notes, "非連合 host の note は永続化しない")
+	assert.Empty(t, repo.Users, "非連合 host の actor も作らない")
 }

--- a/internal/core/federation/resolver_allowlist_test.go
+++ b/internal/core/federation/resolver_allowlist_test.go
@@ -151,3 +151,24 @@ func TestProcessCreate_NonFederatedHostIsDroppedNotRetried(t *testing.T) {
 	assert.Empty(t, noteRepo.Notes, "非連合 host の note は永続化しない")
 	assert.Empty(t, repo.Users, "非連合 host の actor も作らない")
 }
+
+// 送信者 (act.Actor) の host は許可されているが、note の attributedTo が
+// 非連合 host を指すケース (中継経由)。handleCreate 冒頭の actor 解決は通過し、
+// IngestNoteWithCreated 段の gate で ErrHostNotAllowed → ack される (= ingest
+// 段の drop 分岐を踏む)。note は永続化されないこと。
+func TestProcessCreate_AllowedSenderNonFederatedAttributedToIsDropped(t *testing.T) {
+	repo := testutil.NewMockUserRepository()
+	noteRepo := testutil.NewMockNoteRepository()
+	followingRepo := testutil.NewMockFollowingRepository()
+	urls := activitypub.NewURLBuilder("https://example.com")
+	idGen, _ := id.NewGenerator("aidx")
+	resolver := federation.NewResolver(repo, noteRepo, urls, &stubFetcher{body: []byte(sampleActor)}, idGen)
+	// note の attributedTo (remote.example) のみ非連合。送信者 host は許可。
+	resolver.SetHostBlockChecker(&stubHostBlocker{disallowed: map[string]bool{"remote.example": true}})
+	followingSvc := corefollowing.NewService(repo, followingRepo, testutil.NewMockFollowRequestRepository(), idGen)
+	p := federation.NewProcessor(resolver, followingSvc, nil, nil, repo, noteRepo)
+
+	body := []byte(`{"type":"Create","actor":"https://relay.allowed/users/relay","object":` + sampleRemoteNote + `}`)
+	require.NoError(t, p.Process(body))
+	assert.Empty(t, noteRepo.Notes, "非連合 host (attributedTo) の note は永続化しない")
+}

--- a/internal/core/federation/resolver_allowlist_test.go
+++ b/internal/core/federation/resolver_allowlist_test.go
@@ -1,0 +1,131 @@
+package federation_test
+
+import (
+	"testing"
+
+	"github.com/shiroha-a/mk/internal/activitypub"
+	"github.com/shiroha-a/mk/internal/core/federation"
+	"github.com/shiroha-a/mk/internal/misc/id"
+	"github.com/shiroha-a/mk/internal/model"
+	"github.com/shiroha-a/mk/internal/testutil"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// stubHostBlocker implements federation.HostBlockChecker.
+//
+//	IsAllowed(host) → !disallowed[host]
+//	IsBlocked(host) → blocked[host]
+//
+// 「ホワイトリスト連合 (federation: specified) で host が allowlist 外」の
+// シナリオは disallowed に詰めて再現する。
+type stubHostBlocker struct {
+	blocked    map[string]bool
+	disallowed map[string]bool
+}
+
+func (s *stubHostBlocker) IsBlocked(host string) bool { return s.blocked[host] }
+func (s *stubHostBlocker) IsAllowed(host string) bool { return !s.disallowed[host] }
+
+func newGatedResolver(t *testing.T, body string, blocker federation.HostBlockChecker) (*federation.Resolver, *testutil.MockUserRepository, *testutil.MockNoteRepository) {
+	t.Helper()
+	repo := testutil.NewMockUserRepository()
+	noteRepo := testutil.NewMockNoteRepository()
+	urls := activitypub.NewURLBuilder("https://example.com")
+	idGen, _ := id.NewGenerator("aidx")
+	r := federation.NewResolver(repo, noteRepo, urls, &stubFetcher{body: []byte(body)}, idGen)
+	if blocker != nil {
+		r.SetHostBlockChecker(blocker)
+	}
+	return r, repo, noteRepo
+}
+
+// federation: specified モードで allowlist 外の host から actor を resolve しよう
+// とすると ErrHostNotAllowed を返し、HTTP fetch も DB write も走らないこと。
+func TestResolveActor_HostNotAllowedRejectsFetch(t *testing.T) {
+	blocker := &stubHostBlocker{disallowed: map[string]bool{"remote.example": true}}
+	r, repo, _ := newGatedResolver(t, sampleActor, blocker)
+
+	_, err := r.ResolveActor("https://remote.example/users/alice")
+	require.ErrorIs(t, err, federation.ErrHostNotAllowed)
+	assert.Empty(t, repo.Users, "blocked host の actor は DB に作らない")
+}
+
+// blockedHosts に登録された host も ErrHostNotAllowed (allowlist 範囲外と
+// 同じ扱い) になること。
+func TestResolveActor_BlockedHostRejectsFetch(t *testing.T) {
+	blocker := &stubHostBlocker{blocked: map[string]bool{"bad.example": true}}
+	r, _, _ := newGatedResolver(t, sampleActor, blocker)
+
+	_, err := r.ResolveActor("https://bad.example/users/alice")
+	require.ErrorIs(t, err, federation.ErrHostNotAllowed)
+}
+
+// allowlist 内 host は従来どおり通過すること (legacy compat)。
+func TestResolveActor_AllowedHostFetchesNormally(t *testing.T) {
+	blocker := &stubHostBlocker{}
+	r, repo, _ := newGatedResolver(t, sampleActor, blocker)
+
+	user, err := r.ResolveActor("https://remote.example/users/alice")
+	require.NoError(t, err)
+	assert.Equal(t, "alice", user.Username)
+	assert.Len(t, repo.Users, 1)
+}
+
+// hostBlocker 未配線の resolver は legacy 挙動 (= 全 host 許可) で動くこと。
+func TestResolveActor_HostBlockerUnwiredAllowsAll(t *testing.T) {
+	r, _ := newResolver(t, sampleActor, nil)
+	_, err := r.ResolveActor("https://remote.example/users/alice")
+	require.NoError(t, err)
+}
+
+// ResolveNote が allowlist 外 host の URI で fetch 起こさず ErrHostNotAllowed
+// を返すこと。Announce 経由 (handleAnnounce → ResolveNote) で第三者 host の
+// note を取り込む leak を guard する。
+func TestResolveNote_HostNotAllowedRejectsFetch(t *testing.T) {
+	blocker := &stubHostBlocker{disallowed: map[string]bool{"random.example": true}}
+	r, _, _ := newGatedResolver(t, sampleRemoteNote, blocker)
+
+	_, err := r.ResolveNote("https://random.example/notes/x")
+	require.ErrorIs(t, err, federation.ErrHostNotAllowed)
+}
+
+// allowlist 外でも DB に既存 row があれば素通しすること (legacy data 互換)。
+// gate を入れた後に既存 remote データの read が壊れないことの保証。
+func TestResolveNote_ExistingRowPassesEvenIfHostBlocked(t *testing.T) {
+	blocker := &stubHostBlocker{disallowed: map[string]bool{"random.example": true}}
+	r, _, noteRepo := newGatedResolver(t, "", blocker)
+	uri := "https://random.example/notes/cached"
+	noteRepo.Notes["cached"] = &model.Note{ID: "cached", URI: &uri}
+
+	got, err := r.ResolveNote(uri)
+	require.NoError(t, err)
+	assert.Equal(t, "cached", got.ID)
+}
+
+// IngestNoteWithCreated は body 内 attributedTo の host を判定して、
+// allowlist 外 host の Create activity を直接受け取った場合に DB に
+// 永続化させないこと (handleCreate → IngestNote 経路)。
+func TestIngestNote_HostNotAllowedByAttributedTo(t *testing.T) {
+	blocker := &stubHostBlocker{disallowed: map[string]bool{"remote.example": true}}
+	r, _, noteRepo := newGatedResolver(t, sampleActor, blocker)
+
+	_, _, err := r.IngestNoteWithCreated([]byte(sampleRemoteNote))
+	require.ErrorIs(t, err, federation.ErrHostNotAllowed)
+	assert.Empty(t, noteRepo.Notes, "blocked host の note は DB に作らない")
+}
+
+// IngestNote も既存行 dedup の経路 (= attributedTo に対する gate より前で
+// FindByURI hit) では素通しすること。
+func TestIngestNote_DedupHitPassesEvenIfHostBlocked(t *testing.T) {
+	blocker := &stubHostBlocker{disallowed: map[string]bool{"remote.example": true}}
+	r, _, noteRepo := newGatedResolver(t, sampleActor, blocker)
+	uri := "https://remote.example/notes/n1"
+	noteRepo.Notes["existing"] = &model.Note{ID: "existing", URI: &uri}
+
+	got, created, err := r.IngestNoteWithCreated([]byte(sampleRemoteNote))
+	require.NoError(t, err)
+	require.NotNil(t, got)
+	assert.Equal(t, "existing", got.ID)
+	assert.False(t, created)
+}

--- a/internal/server/router.go
+++ b/internal/server/router.go
@@ -527,6 +527,10 @@ func (s *Server) setupRoutes() {
 	// Instance management (Phase 3 Step H)
 	instanceService := coreinstance.NewService(instanceRepo, metaRepo, idGen)
 	federationResolver.SetInstanceTracker(instanceService)
+	// ホワイトリスト連合 (federation: specified) / blockedHosts に対する gate を
+	// resolver の入口 (fetchActor / resolveNoteOnce / IngestNoteWithCreated) に
+	// 適用する。deliver_service / inboxProcessor と同じ instanceService を共有。
+	federationResolver.SetHostBlockChecker(instanceService)
 	// 新規 instance row 発見時に nodeinfo を取得して metadata を更新する。
 	// admin/federation/refresh-remote-instance-metadata でも同じ fetcher を
 	// 再利用して on-demand で再取得する (#351 フォロー)。


### PR DESCRIPTION
## Summary

`internal/core/federation/resolver.go` の actor / note fetch / ingest 入口に federation policy gate (`federation: none / specified` + `blockedHosts`) を追加します。詳細は別途リポジトリ主宛に共有予定の内部レポートを参照してください。

## 変更点

- `internal/core/federation/resolver.go`
  - `HostBlockChecker` (deliver_service.go で既出の interface) を `Resolver` に inject する `SetHostBlockChecker` を追加。
  - `ErrHostNotAllowed` を新設。`fetchActor` / `resolveNoteOnce` (HTTP fetch 直前) / `IngestNoteWithCreated` (attributedTo) に gate を挿入。
  - 既存 DB row hit (FindByURI で見つかるケース) は gate を通過させて legacy data の read を壊さない。
  - hostBlocker 未配線時は legacy 挙動 (全 host 許可) に fallback。
- `internal/server/router.go`
  - `federationResolver.SetHostBlockChecker(instanceService)` を配線。deliver_service / inbox processor と同じ `instanceService` を共有。

## テスト

新規 `internal/core/federation/resolver_allowlist_test.go` に 8 ケース:

- `TestResolveActor_HostNotAllowedRejectsFetch` / `TestResolveActor_BlockedHostRejectsFetch` — allowlist 外 / blocked host で `ErrHostNotAllowed`
- `TestResolveActor_AllowedHostFetchesNormally` — allowlist 内は素通し
- `TestResolveActor_HostBlockerUnwiredAllowsAll` — 未配線 legacy 互換
- `TestResolveNote_HostNotAllowedRejectsFetch` — Announce 経路の note ingest gate
- `TestResolveNote_ExistingRowPassesEvenIfHostBlocked` — 既存 row 互換
- `TestIngestNote_HostNotAllowedByAttributedTo` — handleCreate 経由の body ingest gate
- `TestIngestNote_DedupHitPassesEvenIfHostBlocked` — dedup hit 互換

```
go test ./internal/core/federation/ ./internal/queue/processors/ ./internal/api/inbox/
ok  	internal/core/federation
ok  	internal/queue/processors
ok  	internal/api/inbox
```

`make fmt && make lint` clean。