### PR TITLE
fix(userlists): push/pull/delete に owner 検証を追加

### DIFF
--- a/internal/api/userlists/handler.go
+++ b/internal/api/userlists/handler.go
@@ -210,15 +210,16 @@ func (h *Handler) Pull(c echo.Context) error {
 	if err := c.Bind(&req); err != nil || req.ListID == "" || req.UserID == "" {
 		return c.JSON(http.StatusBadRequest, apierr.Error("INVALID_PARAM", "listId and userId are required.", "3d81ceae-475f-4600-b2a8-2bc116157532"))
 	}
-	// 所有者以外は存在ごと隠す。Show と同 UUID を返して、「存在しない」と
-	// 「他人」の判別ができないようにする (probing 耐性)。
+	// 所有者以外は存在ごと隠す。upstream Misskey TS users/lists/pull と同 UUID
+	// (= update-membership と共有)。これにより「未存在」と「他人」を error UUID
+	// で識別できないようにする副次効果も得られる。
 	list, err := h.repo.FindByID(req.ListID)
 	if err != nil {
-		return c.JSON(http.StatusNotFound, apierr.Error("NO_SUCH_LIST", "No such list.", "7bc05c21-1d7a-41ae-88f1-66820f4dc686"))
+		return c.JSON(http.StatusNotFound, apierr.Error("NO_SUCH_LIST", "No such list.", "7f44670e-ab16-43b8-b4c1-ccd2ee89cc02"))
 	}
 	viewer := middleware.GetUser(c)
 	if viewer == nil || list.UserID != viewer.ID {
-		return c.JSON(http.StatusNotFound, apierr.Error("NO_SUCH_LIST", "No such list.", "7bc05c21-1d7a-41ae-88f1-66820f4dc686"))
+		return c.JSON(http.StatusNotFound, apierr.Error("NO_SUCH_LIST", "No such list.", "7f44670e-ab16-43b8-b4c1-ccd2ee89cc02"))
 	}
 	if err := h.repo.RemoveMember(req.ListID, req.UserID); err != nil {
 		return c.JSON(http.StatusInternalServerError, apierr.Error("INTERNAL_ERROR", "Internal error.", "5d37dbcb-891e-41ca-a3d6-e690c97775ac"))
@@ -235,14 +236,15 @@ func (h *Handler) Delete(c echo.Context) error {
 		return c.JSON(http.StatusBadRequest, apierr.Error("INVALID_PARAM", "listId is required.", "3d81ceae-475f-4600-b2a8-2bc116157532"))
 	}
 	// 所有者以外は存在ごと隠す。これが無いと任意の認証ユーザーが他人の list
-	// を delete できる (data loss、ulid のため復元不能)。
+	// を delete できる (data loss、ulid のため復元不能)。UUID は upstream
+	// Misskey TS users/lists/delete と一致させる。
 	list, err := h.repo.FindByID(req.ListID)
 	if err != nil {
-		return c.JSON(http.StatusNotFound, apierr.Error("NO_SUCH_LIST", "No such list.", "7bc05c21-1d7a-41ae-88f1-66820f4dc686"))
+		return c.JSON(http.StatusNotFound, apierr.Error("NO_SUCH_LIST", "No such list.", "78436795-db79-42f5-b1e2-55ea2cf19166"))
 	}
 	viewer := middleware.GetUser(c)
 	if viewer == nil || list.UserID != viewer.ID {
-		return c.JSON(http.StatusNotFound, apierr.Error("NO_SUCH_LIST", "No such list.", "7bc05c21-1d7a-41ae-88f1-66820f4dc686"))
+		return c.JSON(http.StatusNotFound, apierr.Error("NO_SUCH_LIST", "No such list.", "78436795-db79-42f5-b1e2-55ea2cf19166"))
 	}
 	if err := h.repo.Delete(req.ListID); err != nil {
 		return c.JSON(http.StatusInternalServerError, apierr.Error("INTERNAL_ERROR", "Internal error.", "5d37dbcb-891e-41ca-a3d6-e690c97775ac"))

--- a/internal/api/userlists/handler.go
+++ b/internal/api/userlists/handler.go
@@ -166,9 +166,14 @@ func (h *Handler) Push(c echo.Context) error {
 	if err != nil {
 		return c.JSON(http.StatusNotFound, apierr.Error("NO_SUCH_LIST", "No such list.", "2214501d-ac96-4049-b717-91e42272a711"))
 	}
+	// 認証ユーザーが list 所有者でない場合は存在ごと隠す (NO_SUCH_LIST)。これが
+	// 無いと任意の認証ユーザーが他人の list に勝手に member を push できる。
+	viewer := middleware.GetUser(c)
+	if viewer == nil || list.UserID != viewer.ID {
+		return c.JSON(http.StatusNotFound, apierr.Error("NO_SUCH_LIST", "No such list.", "2214501d-ac96-4049-b717-91e42272a711"))
+	}
 	// userEachUserListsLimit role policy gate (#1029)。list owner の policy
-	// で評価する (upstream は owner = me 経路、mk-go も owner.UserID と me 一致
-	// を確認する access gate は別途必要だが本 PR scope 外、limit 単独で gate)。
+	// で評価する (= owner == viewer は直上で確定済)。
 	if h.rolePolicyProvider != nil {
 		if limit, ok := h.rolePolicyProvider.GetUserPolicies(list.UserID)["userEachUserListsLimit"].(int); ok && limit >= 0 {
 			count, err := h.repo.CountMembers(list.ID)
@@ -205,6 +210,16 @@ func (h *Handler) Pull(c echo.Context) error {
 	if err := c.Bind(&req); err != nil || req.ListID == "" || req.UserID == "" {
 		return c.JSON(http.StatusBadRequest, apierr.Error("INVALID_PARAM", "listId and userId are required.", "3d81ceae-475f-4600-b2a8-2bc116157532"))
 	}
+	// 所有者以外は存在ごと隠す。Show と同 UUID を返して、「存在しない」と
+	// 「他人」の判別ができないようにする (probing 耐性)。
+	list, err := h.repo.FindByID(req.ListID)
+	if err != nil {
+		return c.JSON(http.StatusNotFound, apierr.Error("NO_SUCH_LIST", "No such list.", "7bc05c21-1d7a-41ae-88f1-66820f4dc686"))
+	}
+	viewer := middleware.GetUser(c)
+	if viewer == nil || list.UserID != viewer.ID {
+		return c.JSON(http.StatusNotFound, apierr.Error("NO_SUCH_LIST", "No such list.", "7bc05c21-1d7a-41ae-88f1-66820f4dc686"))
+	}
 	if err := h.repo.RemoveMember(req.ListID, req.UserID); err != nil {
 		return c.JSON(http.StatusInternalServerError, apierr.Error("INTERNAL_ERROR", "Internal error.", "5d37dbcb-891e-41ca-a3d6-e690c97775ac"))
 	}
@@ -218,6 +233,16 @@ func (h *Handler) Delete(c echo.Context) error {
 	}
 	if err := c.Bind(&req); err != nil || req.ListID == "" {
 		return c.JSON(http.StatusBadRequest, apierr.Error("INVALID_PARAM", "listId is required.", "3d81ceae-475f-4600-b2a8-2bc116157532"))
+	}
+	// 所有者以外は存在ごと隠す。これが無いと任意の認証ユーザーが他人の list
+	// を delete できる (data loss、ulid のため復元不能)。
+	list, err := h.repo.FindByID(req.ListID)
+	if err != nil {
+		return c.JSON(http.StatusNotFound, apierr.Error("NO_SUCH_LIST", "No such list.", "7bc05c21-1d7a-41ae-88f1-66820f4dc686"))
+	}
+	viewer := middleware.GetUser(c)
+	if viewer == nil || list.UserID != viewer.ID {
+		return c.JSON(http.StatusNotFound, apierr.Error("NO_SUCH_LIST", "No such list.", "7bc05c21-1d7a-41ae-88f1-66820f4dc686"))
 	}
 	if err := h.repo.Delete(req.ListID); err != nil {
 		return c.JSON(http.StatusInternalServerError, apierr.Error("INTERNAL_ERROR", "Internal error.", "5d37dbcb-891e-41ca-a3d6-e690c97775ac"))

--- a/internal/api/userlists/handler_test.go
+++ b/internal/api/userlists/handler_test.go
@@ -107,7 +107,8 @@ func TestPush_InvalidParam(t *testing.T) {
 }
 
 func TestPull_Success(t *testing.T) {
-	h, _ := newTestHandler(t)
+	h, repo := newTestHandler(t)
+	repo.Lists["l1"] = &model.UserList{ID: "l1", UserID: "u1"}
 	rec := doPost(h.Pull, `{"listId":"l1","userId":"u2"}`, &model.User{ID: "u1"})
 	assert.Equal(t, http.StatusNoContent, rec.Code)
 }
@@ -120,7 +121,7 @@ func TestPull_InvalidParam(t *testing.T) {
 
 func TestDelete_Success(t *testing.T) {
 	h, repo := newTestHandler(t)
-	repo.Lists["l1"] = &model.UserList{ID: "l1"}
+	repo.Lists["l1"] = &model.UserList{ID: "l1", UserID: "u1"}
 	rec := doPost(h.Delete, `{"listId":"l1"}`, &model.User{ID: "u1"})
 	assert.Equal(t, http.StatusNoContent, rec.Code)
 }
@@ -235,7 +236,7 @@ func (f *failingAddMemberRepo) AddMember(_ *model.UserListMembership) error { re
 
 func TestPush_Error(t *testing.T) {
 	repo := &failingAddMemberRepo{testutil.NewMockUserListRepository()}
-	repo.Lists["l1"] = &model.UserList{ID: "l1"}
+	repo.Lists["l1"] = &model.UserList{ID: "l1", UserID: "u1"}
 	idGen, _ := id.NewGenerator("aidx")
 	h := userlists.NewHandler(repo, idGen)
 	rec := doPost(h.Push, `{"listId":"l1","userId":"u2"}`, &model.User{ID: "u1"})
@@ -302,7 +303,7 @@ func TestPush_UserEachUserListsLimitExceeded(t *testing.T) {
 
 func TestPush_AlreadyAdded(t *testing.T) {
 	repo := &duplicateAddMemberRepo{testutil.NewMockUserListRepository()}
-	repo.Lists["l1"] = &model.UserList{ID: "l1"}
+	repo.Lists["l1"] = &model.UserList{ID: "l1", UserID: "u1"}
 	idGen, _ := id.NewGenerator("aidx")
 	h := userlists.NewHandler(repo, idGen)
 	rec := doPost(h.Push, `{"listId":"l1","userId":"u2"}`, &model.User{ID: "u1"})
@@ -320,8 +321,10 @@ type failingRemoveMemberRepo struct {
 func (f *failingRemoveMemberRepo) RemoveMember(_, _ string) error { return assert.AnError }
 
 func TestPull_Error(t *testing.T) {
+	repo := &failingRemoveMemberRepo{testutil.NewMockUserListRepository()}
+	repo.Lists["l1"] = &model.UserList{ID: "l1", UserID: "u1"}
 	idGen, _ := id.NewGenerator("aidx")
-	h := userlists.NewHandler(&failingRemoveMemberRepo{testutil.NewMockUserListRepository()}, idGen)
+	h := userlists.NewHandler(repo, idGen)
 	rec := doPost(h.Pull, `{"listId":"l1","userId":"u2"}`, &model.User{ID: "u1"})
 	assert.Equal(t, http.StatusInternalServerError, rec.Code)
 }
@@ -333,8 +336,10 @@ type failingDeleteRepo struct {
 func (f *failingDeleteRepo) Delete(_ string) error { return assert.AnError }
 
 func TestDelete_Error(t *testing.T) {
+	repo := &failingDeleteRepo{testutil.NewMockUserListRepository()}
+	repo.Lists["l1"] = &model.UserList{ID: "l1", UserID: "u1"}
 	idGen, _ := id.NewGenerator("aidx")
-	h := userlists.NewHandler(&failingDeleteRepo{testutil.NewMockUserListRepository()}, idGen)
+	h := userlists.NewHandler(repo, idGen)
 	rec := doPost(h.Delete, `{"listId":"l1"}`, &model.User{ID: "u1"})
 	assert.Equal(t, http.StatusInternalServerError, rec.Code)
 }
@@ -355,4 +360,56 @@ func TestShow_PublicListNonOwnerVisible(t *testing.T) {
 	repo.Lists["l1"] = &model.UserList{ID: "l1", UserID: "u1", Name: "Public", IsPublic: true}
 	rec := doPost(h.Show, `{"listId":"l1"}`, &model.User{ID: "u2"})
 	assert.Equal(t, http.StatusOK, rec.Code)
+}
+
+// 他人 list への push が「存在しない」扱いで弾かれること。viewer が list owner
+// 以外なら NO_SUCH_LIST を返し、AddMember が呼ばれてはならない (= owner gate
+// 抜けの IDOR 回帰防止)。
+func TestPush_NotOwner(t *testing.T) {
+	h, repo := newTestHandler(t)
+	repo.Lists["l1"] = &model.UserList{ID: "l1", UserID: "owner"}
+	rec := doPost(h.Push, `{"listId":"l1","userId":"u2"}`, &model.User{ID: "intruder"})
+	assert.Equal(t, http.StatusNotFound, rec.Code)
+	assert.Contains(t, rec.Body.String(), "NO_SUCH_LIST")
+	assert.Empty(t, repo.Members, "owner 以外の push は member を追加しないこと")
+}
+
+// 他人 list からの pull が「存在しない」扱いで弾かれること。
+func TestPull_NotOwner(t *testing.T) {
+	h, repo := newTestHandler(t)
+	repo.Lists["l1"] = &model.UserList{ID: "l1", UserID: "owner"}
+	repo.Members = []*model.UserListMembership{
+		{ID: "m1", UserListID: "l1", UserID: "u2"},
+	}
+	rec := doPost(h.Pull, `{"listId":"l1","userId":"u2"}`, &model.User{ID: "intruder"})
+	assert.Equal(t, http.StatusNotFound, rec.Code)
+	assert.Contains(t, rec.Body.String(), "NO_SUCH_LIST")
+	assert.Len(t, repo.Members, 1, "owner 以外の pull は member を削除しないこと")
+}
+
+// Pull が存在しない listId に対し 404 を返すこと (= 修正前は list を引かず
+// 204 を返していた箇所の挙動変更を test で固定)。
+func TestPull_ListNotFound(t *testing.T) {
+	h, _ := newTestHandler(t)
+	rec := doPost(h.Pull, `{"listId":"ghost","userId":"u2"}`, &model.User{ID: "u1"})
+	assert.Equal(t, http.StatusNotFound, rec.Code)
+	assert.Contains(t, rec.Body.String(), "NO_SUCH_LIST")
+}
+
+// 他人 list の delete が「存在しない」扱いで弾かれること。
+func TestDelete_NotOwner(t *testing.T) {
+	h, repo := newTestHandler(t)
+	repo.Lists["l1"] = &model.UserList{ID: "l1", UserID: "owner"}
+	rec := doPost(h.Delete, `{"listId":"l1"}`, &model.User{ID: "intruder"})
+	assert.Equal(t, http.StatusNotFound, rec.Code)
+	assert.Contains(t, rec.Body.String(), "NO_SUCH_LIST")
+	assert.Contains(t, repo.Lists, "l1", "owner 以外の delete は list を削除しないこと")
+}
+
+// Delete が存在しない listId に対し 404 を返すこと。
+func TestDelete_ListNotFound(t *testing.T) {
+	h, _ := newTestHandler(t)
+	rec := doPost(h.Delete, `{"listId":"ghost"}`, &model.User{ID: "u1"})
+	assert.Equal(t, http.StatusNotFound, rec.Code)
+	assert.Contains(t, rec.Body.String(), "NO_SUCH_LIST")
 }


### PR DESCRIPTION
## Summary

`users/lists/push`, `users/lists/pull`, `users/lists/delete` で操作対象 list
の所有者検証が抜けており、list 所有者以外からの member 操作・list 削除を
受け付けていた。隣接の `users/lists/update` / `update-membership` と同 pattern で
owner gate を入れる。

## 主な変更点

- `internal/api/userlists/handler.go`
  - `Push`: 既存の `FindByID` 直後に `list.UserID != viewer.ID` で `NO_SUCH_LIST`。
    残置されていた "本 PR scope 外" コメント (#1029) を削除。
  - `Pull`: `FindByID` + owner gate を追加 (現状 list 引きすらしていなかった)。
    error UUID は upstream Misskey TS `users/lists/pull` と同 `7f44670e-...`
    (`update-membership` と共有)。未存在と非所有者で同一 UUID を返すことで
    probing 耐性も得る。
  - `Delete`: 同上 (error UUID は upstream `users/lists/delete` の `78436795-...`)。

- `internal/api/userlists/handler_test.go`
  - 既存 `*_Success` / `*_Error` で `UserList.UserID` 未設定だった test を
    `UserID = "u1"` に揃えて正常系維持。
  - negative test 追加:
    - `TestPush_NotOwner` / `TestPull_NotOwner` / `TestDelete_NotOwner`
      → 他人 list の操作で 404、副作用 (member / list 行) が発生しないこと
    - `TestPull_ListNotFound` / `TestDelete_ListNotFound`
      → 修正後の挙動 (= list 引きで NotFound) を test で固定

## テスト

- `go test -race -count=1 ./internal/api/userlists/...` pass
- package coverage 95.9% (Pull / Delete 100%、Push 95.5% で middleware
  保険分岐のみ未到達)
- `make fmt && make lint` clean
- `go test -race -count=1 ./internal/api/users/... ./internal/server/...
   ./internal/repository/...` pass

## その他

隣接の `ListsUpdate` / `ListsUpdateMembership` (users/lists.go) は既に
owner gate + negative test 完備済のため変更不要。本 PR は `userlists/`
パッケージに閉じる。

🤖 Generated with [Claude Code](https://claude.com/claude-code)