### PR TITLE
test(notes): drafts/update に他人 draftID 404 negative test を追加

### DIFF
--- a/internal/api/notes/handler_drafts_test.go
+++ b/internal/api/notes/handler_drafts_test.go
@@ -240,6 +240,26 @@ func TestDraftsUpdate_InvalidParam(t *testing.T) {
 	assert.Equal(t, http.StatusBadRequest, rec.Code)
 }
 
+// #1421: 他人 draftID を投げると NO_SUCH_NOTE_DRAFT 404 で reject される
+// (IDOR regression guard)。現行 handler は repo.FindByIDAndUser に owner filter
+// を SQL push-down しているので構造的に他人 draft を書き換えられないが、
+// refactor で FindByID に入れ替わると owner check が抜ける。その回帰を
+// handler 層 negative test で固定する。
+func TestDraftsUpdate_OtherUserDraft(t *testing.T) {
+	h, repo := newDraftHandlerWithRepo()
+	text := "owner-only"
+	repo.drafts["d1"] = &model.NoteDraft{ID: "d1", UserID: "u1", Text: &text, Visibility: "public"}
+	rec := postDraft(h.DraftsUpdate, `{"draftId":"d1","text":"pwned"}`, &model.User{ID: "u2"})
+	assert.Equal(t, http.StatusNotFound, rec.Code)
+	var resp map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+	errObj := resp["error"].(map[string]any)
+	assert.Equal(t, "NO_SUCH_NOTE_DRAFT", errObj["code"])
+	assert.Equal(t, apierr.UUIDNoSuchNoteDraft, errObj["id"])
+	// 他人 draft の text は変更されない
+	assert.Equal(t, "owner-only", *repo.drafts["d1"].Text)
+}
+
 // --- DraftsDelete ---
 
 func TestDraftsDelete_NilRepo(t *testing.T) {


### PR DESCRIPTION
## Summary

- IDOR audit follow-up。`notes/drafts/update` は `repo.FindByIDAndUser(draftID, user.ID)` で SQL 段 owner filter が乗っており、構造的に他人 draft の更新を防いでいる
- ただし「他人 draftID を投げたら 404 になる」negative test が無いため、handler refactor で `FindByID` に入れ替わった際の regression を test で捕まえられない
- handler 層 negative test で防御を固定する

## 主な変更点

- `internal/api/notes/handler_drafts_test.go`
  - `TestDraftsUpdate_OtherUserDraft` を追加
    - `u1` 所有の draft `d1` を作成 → `u2` で `notes/drafts/update` を投げる
    - `404 / NO_SUCH_NOTE_DRAFT / apierr.UUIDNoSuchNoteDraft` を assert
    - 念のため他人 draft の text が改竄されていないことも assert
- production code は変更なし

## テスト

- `go test ./internal/api/notes/ -run TestDraftsUpdate -v` で `TestDraftsUpdate_OtherUserDraft` が新規 pass
- パッケージ全体 (`go test ./internal/api/notes/...`) も pass
- `make fmt && make lint` pass

## Closes

Closes #1421