### PR TITLE
test(clips): show の未認証 viewer + private clip → 403 negative test を追加

### DIFF
--- a/internal/api/clips/handler_test.go
+++ b/internal/api/clips/handler_test.go
@@ -149,6 +149,18 @@ func TestShow_AnonymousOnPublic(t *testing.T) {
 	assert.Equal(t, http.StatusOK, rec.Code)
 }
 
+// IDOR audit follow-up (#1422): 通常 RequireAuth で弾かれるが、URL 設計次第で
+// middleware bypass や guest viewer 路を追加した時に regression するため、
+// 未認証 viewer (= viewer == nil) が private clip を叩いた時の 403 reject を
+// handler 層 negative test で固定する。
+func TestShow_AnonymousAccessDenied(t *testing.T) {
+	h, repo, _, _ := newHandler(t)
+	repo.Clips["c1"] = &model.Clip{ID: "c1", UserID: "alice", IsPublic: false}
+	c, rec := newReq(t, `{"clipId":"c1"}`)
+	require.NoError(t, h.Show(c))
+	assert.Equal(t, http.StatusForbidden, rec.Code)
+}
+
 // --- Update ----------------------------------------------------------------
 
 func TestUpdate_Success(t *testing.T) {


### PR DESCRIPTION
## Summary

IDOR audit follow-up (#1422)。`clips/show` は `TestShow_AccessDenied` で「異なる owner の viewer」による reject を cover していたが、「未認証 viewer (= `viewer == nil`) が private clip を叩いた時の 403」を明示する case が無かった。

通常 `RequireAuth` middleware が 401 で弾くが、URL 設計次第で middleware bypass や guest viewer 路を追加した時に regression する可能性があるため、handler 層 negative test で挙動を固定する。

## 主な変更点

- `internal/api/clips/handler_test.go` に `TestShow_AnonymousAccessDenied` を追加
  - `IsPublic: false` の clip に対して `setUser` を呼ばない (= `viewer == nil`) コンテキストで `clips/show` を叩き、`StatusForbidden` を assert
  - service 層では `!c.IsPublic && c.UserID != requesterID("")` → `ErrAccessDenied` → handler が `apierr.JSONAccessDenied` で 403 を返す経路
- production code 変更なし

## テスト

- `go test ./internal/api/clips/ -race -count=1 -timeout 2m` → PASS (1.121s)
- `make fmt` / `make lint` → diff なし

```
=== RUN   TestShow_AnonymousAccessDenied
--- PASS: TestShow_AnonymousAccessDenied (0.00s)
```

## Closes

Closes #1422

## 関連

- 認可コード: `internal/core/clip/clip_service.go:130-139`
- handler: `internal/api/clips/handler.go:121-140`
- audit context: IDOR audit follow-up