### PR TITLE
fix(pages): pages/show は非public・非所有者アクセスを 404 で隠す

### DIFF
--- a/internal/api/pages/handler.go
+++ b/internal/api/pages/handler.go
@@ -158,9 +158,10 @@ func (h *Handler) Show(c echo.Context) error {
 		return apierr.JSONInvalidParam(c)
 	}
 	if err != nil {
-		if errors.Is(err, corepage.ErrAccessDenied) {
-			return apierr.JSONAccessDenied(c)
-		}
+		// 非 public page を非許可 viewer が引いた場合 (ErrAccessDenied) も存在ごと
+		// 隠して NO_SUCH_PAGE (404) を返す。upstream TS pages/show は可視性ゲートを
+		// 持たず noSuchPage のみ返すため shape が一致し、private page の存在を 403 で
+		// 露呈しない (#1432)。update/delete は TS に accessDenied があるため 403 のまま。
 		return c.JSON(http.StatusNotFound, apierr.Error("NO_SUCH_PAGE", "No such page.", "222120c0-3ead-4528-811b-b96f233388d7"))
 	}
 	// owner / isLiked を attach (#1134)。owner lookup miss は frontend page.vue

--- a/internal/api/pages/handler.go
+++ b/internal/api/pages/handler.go
@@ -233,6 +233,8 @@ func (h *Handler) Update(c echo.Context) error {
 		switch {
 		case errors.Is(err, corepage.ErrPageNotFound):
 			return c.JSON(http.StatusNotFound, apierr.Error("NO_SUCH_PAGE", "No such page.", "21149b9e-3616-4778-9592-c4ce89f5a864"))
+		// upstream TS pages/update は accessDenied (UUID 3c15cd52) を持つため、
+		// show (存在隠蔽 404) とは異なり 403 を維持する (#1432)。
 		case errors.Is(err, corepage.ErrAccessDenied):
 			return c.JSON(http.StatusForbidden, apierr.Error("ACCESS_DENIED", "Access denied.", "3c15cd52-3b4b-4274-967d-6456fc4f792b"))
 		case errors.Is(err, corepage.ErrPageNameRequired),
@@ -262,6 +264,8 @@ func (h *Handler) Delete(c echo.Context) error {
 		switch {
 		case errors.Is(err, corepage.ErrPageNotFound):
 			return c.JSON(http.StatusNotFound, apierr.Error("NO_SUCH_PAGE", "No such page.", "eb0c6e1d-d519-4764-9486-52a7e1c6392a"))
+		// upstream TS pages/delete は accessDenied (UUID 8b741b3e) を持つため、
+		// show (存在隠蔽 404) とは異なり 403 を維持する (#1432)。
 		case errors.Is(err, corepage.ErrAccessDenied):
 			return c.JSON(http.StatusForbidden, apierr.Error("ACCESS_DENIED", "Access denied.", "8b741b3e-2c22-44b3-a15f-29949aa1601e"))
 		}

--- a/internal/api/pages/handler_test.go
+++ b/internal/api/pages/handler_test.go
@@ -229,6 +229,32 @@ func TestShow_AccessDenied(t *testing.T) {
 	assert.Equal(t, "NO_SUCH_PAGE", errObj["code"])
 }
 
+// 存在隠蔽は経路非依存であることを固定する (#1432 review)。{userId, name} 経路
+// (ShowByName) でも非public・非所有者には 404 NO_SUCH_PAGE を返す。
+func TestShow_AccessDenied_ByName(t *testing.T) {
+	h, repo, _ := newHandler(t)
+	repo.Pages["p1"] = &model.Page{ID: "p1", UserID: "owner", Name: "alpha", Visibility: model.PageVisibilityFollowers}
+	c, rec := newReq(t, `{"userId":"owner","name":"alpha"}`)
+	setUser(c, "alice")
+	require.NoError(t, h.Show(c))
+	assert.Equal(t, http.StatusNotFound, rec.Code)
+	assert.Contains(t, rec.Body.String(), "NO_SUCH_PAGE")
+}
+
+// {username, name} 経路 (#955) でも非public・非所有者には 404 NO_SUCH_PAGE。
+func TestShow_AccessDenied_ByUsername(t *testing.T) {
+	h, repo, _ := newHandler(t)
+	repo.Pages["p1"] = &model.Page{ID: "p1", UserID: "alice", Name: "alpha", Visibility: model.PageVisibilityFollowers}
+	h.SetUserSource(&stubUserSource{
+		byUsernameBundle: &coreuser.UserWithProfile{User: &model.User{ID: "alice", Username: "alice"}},
+	})
+	c, rec := newReq(t, `{"username":"alice","name":"alpha"}`)
+	setUser(c, "bob")
+	require.NoError(t, h.Show(c))
+	assert.Equal(t, http.StatusNotFound, rec.Code)
+	assert.Contains(t, rec.Body.String(), "NO_SUCH_PAGE")
+}
+
 // --- Update ----------------------------------------------------------------
 
 func TestUpdate_Success(t *testing.T) {

--- a/internal/api/pages/handler_test.go
+++ b/internal/api/pages/handler_test.go
@@ -213,13 +213,20 @@ func TestShow_NotFound(t *testing.T) {
 	assert.Equal(t, http.StatusNotFound, rec.Code)
 }
 
+// 非 public page を非所有者が show すると、存在ごと隠して 404 NO_SUCH_PAGE を
+// 返すこと (#1432)。upstream TS pages/show は可視性ゲートを持たず noSuchPage
+// のみ返すため shape が一致し、private page の存在を 403 で露呈しない。
 func TestShow_AccessDenied(t *testing.T) {
 	h, repo, _ := newHandler(t)
 	repo.Pages["p1"] = &model.Page{ID: "p1", UserID: "owner", Visibility: model.PageVisibilityFollowers}
 	c, rec := newReq(t, `{"pageId":"p1"}`)
 	setUser(c, "alice")
 	require.NoError(t, h.Show(c))
-	assert.Equal(t, http.StatusForbidden, rec.Code)
+	assert.Equal(t, http.StatusNotFound, rec.Code)
+	var resp map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+	errObj := resp["error"].(map[string]any)
+	assert.Equal(t, "NO_SUCH_PAGE", errObj["code"])
 }
 
 // --- Update ----------------------------------------------------------------


### PR DESCRIPTION
## Summary

`pages/show` で非 public page を非許可 viewer が引いた際、`ErrAccessDenied` -> 403 ACCESS_DENIED を返しており、private page の**存在を露呈**していた。upstream Misskey TS の `pages/show` は可視性ゲートを持たず `noSuchPage` (404) のみ返す。これに合わせ、show では存在ごと隠す 404 NO_SUCH_PAGE に倒す。

mk-go は `page_visibility_enum` (public/followers/specified) を持つため可視性ゲート自体は必要(削除しない)。論点は 403(露呈)か 404(隠蔽)かのみで、TS shape 一致 + 存在隠蔽の観点から後者を選択。`users/lists` / `notes` の存在隠蔽パターンとも一貫。

## 主な変更点

- `internal/api/pages/handler.go`
  - `Show` の err 分岐から `ErrAccessDenied -> JSONAccessDenied (403)` を撤去し、`NO_SUCH_PAGE` (404) にフォールスルー。
  - `update` / `delete` は TS に `accessDenied` (UUID `3c15cd52` / `8b741b3e`) があるため **403 のまま変更なし**。
- `internal/api/pages/handler_test.go`
  - `TestShow_AccessDenied` を 404 + `NO_SUCH_PAGE` を検証する内容に更新。

## 背景

#1420 (pages owner-mismatch test) の調査中に発見した parity gap を #1432 として切り出したもの。TS vanilla の Page には `visibility` カラムが無く show にゲートが無い一方、mk-go は drop-in 対象 (#367) の enum に合わせて visibility を持つため、show のゲートは必要だが error 挙動だけ TS shape (noSuchPage 404) に揃える。

## テスト

- `go test ./internal/api/pages/ ./internal/core/page/` pass
- pages パッケージ coverage 97.5% (90%+ 維持)
- `make fmt && make lint` clean

## Closes

Closes #1432