### PR TITLE
perf(federation): deliver job の秘密鍵 PEM 再パースをメモ化

### DIFF
--- a/internal/queue/processors/deliver.go
+++ b/internal/queue/processors/deliver.go
@@ -26,6 +26,13 @@ import (
 // ユーザー数なので 1024 で大半の instance を賄える。超過分は LRU が evict する。
 const deliverKeyCacheSize = 1024
 
+// signingKey の cache key 先頭に付ける鍵種別の判別子。RSA / Ed25519 の entry を
+// 区別する。将来 P-256 等を増やす際の typo 耐性のため定数化 (#1425 review)。
+const (
+	keyKindRSA     = "rsa"
+	keyKindEd25519 = "ed"
+)
+
 // HTTPSigner abstracts the signed POST capability of activitypub.Client so
 // that DeliverProcessor can be unit-tested without an actual HTTP client.
 type HTTPSigner interface {
@@ -358,7 +365,7 @@ func (p *DeliverProcessor) Handle(_ context.Context, t driver.Task) error {
 // 場合は driver.SkipRetry で投函を中止。
 func (p *DeliverProcessor) sendOnce(payload queue.DeliverPayload, useEd25519 bool) (*http.Response, error) {
 	if useEd25519 {
-		key, err := p.signingKey("ed", payload.Ed25519KeyID, payload.Ed25519PrivPEM, activitypub.NewEd25519PrivateKey)
+		key, err := p.signingKey(keyKindEd25519, payload.Ed25519KeyID, payload.Ed25519PrivPEM, activitypub.NewEd25519PrivateKey)
 		if err == nil {
 			resp, perr := p.signer.PostSigned(payload.Inbox, payload.Body, key)
 			if perr != nil {
@@ -372,7 +379,7 @@ func (p *DeliverProcessor) sendOnce(payload queue.DeliverPayload, useEd25519 boo
 			"inbox", payload.Inbox, "err", err)
 		// fallthrough: RSA で sign
 	}
-	key, err := p.signingKey("rsa", payload.KeyID, payload.KeyPEM, activitypub.NewPrivateKey)
+	key, err := p.signingKey(keyKindRSA, payload.KeyID, payload.KeyPEM, activitypub.NewPrivateKey)
 	if err != nil {
 		return nil, fmt.Errorf("parse private key: %w: %w", err, driver.SkipRetry)
 	}

--- a/internal/queue/processors/deliver.go
+++ b/internal/queue/processors/deliver.go
@@ -5,6 +5,8 @@ package processors
 
 import (
 	"context"
+	"crypto/sha256"
+	"encoding/hex"
 	"errors"
 	"fmt"
 	"io"
@@ -13,11 +15,16 @@ import (
 	"net/url"
 	"time"
 
+	lru "github.com/hashicorp/golang-lru/v2"
 	"github.com/redis/go-redis/v9"
 	"github.com/shiroha-a/mk/internal/activitypub"
 	"github.com/shiroha-a/mk/internal/queue"
 	"github.com/shiroha-a/mk/internal/queue/driver"
 )
+
+// deliverKeyCacheSize bounds the parsed-signing-key LRU. 署名者は実質ローカル
+// ユーザー数なので 1024 で大半の instance を賄える。超過分は LRU が evict する。
+const deliverKeyCacheSize = 1024
 
 // HTTPSigner abstracts the signed POST capability of activitypub.Client so
 // that DeliverProcessor can be unit-tested without an actual HTTP client.
@@ -67,11 +74,43 @@ type DeliverProcessor struct {
 	// 未配線時は capability gate なしの楽観動作 (= payload に Ed25519 鍵が
 	// あれば必ず Ed25519 sign を試す) になるが、production では必須。
 	redis *redis.Client
+	// keyCache は (kind, keyID, PEM) -> パース済み *PrivateKey の LRU。
+	// ap:deliver は inbox ごとに 1 job なので、同一署名者へ fan-out する際に
+	// 毎 job で PEM->x509 を再パースしていた。worker 間共有の単一 processor
+	// にここを持たせて job 横断でメモ化する (#1425)。nil の場合は都度パース。
+	keyCache *lru.Cache[string, *activitypub.PrivateKey]
 }
 
 // NewDeliverProcessor constructs a DeliverProcessor.
 func NewDeliverProcessor(signer HTTPSigner) *DeliverProcessor {
-	return &DeliverProcessor{signer: signer}
+	p := &DeliverProcessor{signer: signer}
+	// lru.New は size>0 で error を返さない実装だが、防御的に握って nil
+	// fallback (= 都度パース) に倒す。
+	if c, err := lru.New[string, *activitypub.PrivateKey](deliverKeyCacheSize); err == nil {
+		p.keyCache = c
+	}
+	return p
+}
+
+// signingKey returns a parsed PrivateKey for (keyID, pem), memoizing the parse
+// across deliver jobs. kind は "rsa" / "ed" で、RSA と Ed25519 の cache entry を
+// 区別する。PEM が変わる (= 鍵 rotation) と cache key も変わるため stale な鍵を
+// 返さない。keyCache 未配線時は parse をそのまま呼ぶ。
+func (p *DeliverProcessor) signingKey(kind, keyID, pem string, parse func(string, string) (*activitypub.PrivateKey, error)) (*activitypub.PrivateKey, error) {
+	if p.keyCache == nil {
+		return parse(keyID, pem)
+	}
+	sum := sha256.Sum256([]byte(keyID + "\x00" + pem))
+	ck := kind + "\x00" + hex.EncodeToString(sum[:])
+	if k, ok := p.keyCache.Get(ck); ok {
+		return k, nil
+	}
+	k, err := parse(keyID, pem)
+	if err != nil {
+		return nil, err
+	}
+	p.keyCache.Add(ck, k)
+	return k, nil
 }
 
 // SetRedis attaches a Redis client used to persist per-host Ed25519 degrade
@@ -319,7 +358,7 @@ func (p *DeliverProcessor) Handle(_ context.Context, t driver.Task) error {
 // 場合は driver.SkipRetry で投函を中止。
 func (p *DeliverProcessor) sendOnce(payload queue.DeliverPayload, useEd25519 bool) (*http.Response, error) {
 	if useEd25519 {
-		key, err := activitypub.NewEd25519PrivateKey(payload.Ed25519KeyID, payload.Ed25519PrivPEM)
+		key, err := p.signingKey("ed", payload.Ed25519KeyID, payload.Ed25519PrivPEM, activitypub.NewEd25519PrivateKey)
 		if err == nil {
 			resp, perr := p.signer.PostSigned(payload.Inbox, payload.Body, key)
 			if perr != nil {
@@ -333,7 +372,7 @@ func (p *DeliverProcessor) sendOnce(payload queue.DeliverPayload, useEd25519 boo
 			"inbox", payload.Inbox, "err", err)
 		// fallthrough: RSA で sign
 	}
-	key, err := activitypub.NewPrivateKey(payload.KeyID, payload.KeyPEM)
+	key, err := p.signingKey("rsa", payload.KeyID, payload.KeyPEM, activitypub.NewPrivateKey)
 	if err != nil {
 		return nil, fmt.Errorf("parse private key: %w: %w", err, driver.SkipRetry)
 	}

--- a/internal/queue/processors/deliver.go
+++ b/internal/queue/processors/deliver.go
@@ -103,6 +103,11 @@ func NewDeliverProcessor(signer HTTPSigner) *DeliverProcessor {
 // across deliver jobs. kind は "rsa" / "ed" で、RSA と Ed25519 の cache entry を
 // 区別する。PEM が変わる (= 鍵 rotation) と cache key も変わるため stale な鍵を
 // 返さない。keyCache 未配線時は parse をそのまま呼ぶ。
+//
+// cache key は PEM 本体ではなく sha256(keyID+PEM) の hex を使う。map key を
+// ~1.5KB から 64B 程度に縮めて memory footprint を抑え、cache key 経由で PEM
+// 本体がログ等に混入するリスクも下げる。null-byte separator で keyID/PEM 境界
+// の曖昧さを避ける。
 func (p *DeliverProcessor) signingKey(kind, keyID, pem string, parse func(string, string) (*activitypub.PrivateKey, error)) (*activitypub.PrivateKey, error) {
 	if p.keyCache == nil {
 		return parse(keyID, pem)

--- a/internal/queue/processors/deliver_test.go
+++ b/internal/queue/processors/deliver_test.go
@@ -484,3 +484,50 @@ func TestDeliverProcessor_ChartHook_UnparseableInbox(t *testing.T) {
 	require.Len(t, hook.delivered, 1)
 	assert.Equal(t, "", hook.delivered[0].host)
 }
+
+// keyCapturingSigner records the *PrivateKey passed to each PostSigned so a
+// test can assert pointer identity (= parsed-key cache hit).
+type keyCapturingSigner struct {
+	resp *http.Response
+	keys []*activitypub.PrivateKey
+}
+
+func (s *keyCapturingSigner) PostSigned(_ string, _ []byte, key *activitypub.PrivateKey) (*http.Response, error) {
+	s.keys = append(s.keys, key)
+	return s.resp, nil
+}
+
+// #1425: 同一署名者へ fan-out する deliver job は、PEM のパース結果が job 横断で
+// メモ化され同じ *PrivateKey を再利用すること。PEM が変われば (鍵 rotation 相当)
+// 別 entry で再パースされること。
+func TestDeliverProcessor_RSAKeyCacheReuse(t *testing.T) {
+	signer := &keyCapturingSigner{resp: okResponse(http.StatusOK)}
+	p := processors.NewDeliverProcessor(signer)
+
+	payload := makePayload(t) // KeyID + KeyPEM 固定
+	require.NoError(t, p.Handle(context.Background(), makeTask(t, payload)))
+	require.NoError(t, p.Handle(context.Background(), makeTask(t, payload)))
+	require.Len(t, signer.keys, 2)
+	assert.Same(t, signer.keys[0], signer.keys[1], "同一 PEM は cache hit で同じ *PrivateKey を再利用する")
+
+	// 同じ KeyID でも PEM が変われば (= rotation) 別 entry で再パースし、別 instance。
+	rotated := makePayload(t) // generateTestKey は毎回新規 RSA 鍵
+	require.NoError(t, p.Handle(context.Background(), makeTask(t, rotated)))
+	require.Len(t, signer.keys, 3)
+	assert.NotSame(t, signer.keys[1], signer.keys[2], "別 PEM は別 entry でパースし直す")
+}
+
+// Ed25519 経路も同様に parsed-key がメモ化されること (#1425)。
+func TestDeliverProcessor_Ed25519KeyCacheReuse(t *testing.T) {
+	signer := &keyCapturingSigner{resp: okResponse(http.StatusOK)}
+	p := processors.NewDeliverProcessor(signer)
+
+	payload := makePayload(t)
+	payload.Ed25519KeyID = "https://example.com/users/u1#ed25519-key"
+	payload.Ed25519PrivPEM = generateTestEd25519Key(t)
+
+	require.NoError(t, p.Handle(context.Background(), makeTask(t, payload)))
+	require.NoError(t, p.Handle(context.Background(), makeTask(t, payload)))
+	require.Len(t, signer.keys, 2)
+	assert.Same(t, signer.keys[0], signer.keys[1], "同一 Ed25519 PEM は cache hit で再利用する")
+}


### PR DESCRIPTION
## Summary

`ap:deliver` は recipient inbox ごとに 1 job で、各 job の `sendOnce` が `activitypub.NewPrivateKey` / `NewEd25519PrivateKey` で PEM->x509 を毎回パースしていた。フォロワー N 件への fan-out 配信では同一署名者の鍵を N 回パースし直す(RSA は PEM/ASN.1 decode + big.Int 初期化のコストがかかる。なお `Precompute()` は呼んでいないため CRT precompute 自体は発生しない)。worker 間共有の単一 `DeliverProcessor` に parsed-key LRU を持たせ、job 横断でメモ化する。

パフォーマンス監査 finding 1 (HIGH) の対応。

## 主な変更点

- `internal/queue/processors/deliver.go`
  - `DeliverProcessor` に `keyCache *lru.Cache[string, *activitypub.PrivateKey]`(`hashicorp/golang-lru/v2`、既存依存・thread-safe)を追加。`NewDeliverProcessor` で生成(`lru.New` 失敗時は nil fallback)。
  - `signingKey(kind, keyID, pem, parse)` を新設し、`sendOnce` の RSA / Ed25519 パースをこれ経由に置換。
  - cache key = `kind("rsa"/"ed") + sha256(keyID + PEM)`。**PEM が変われば(鍵 rotation)別 entry**になり stale を返さない (rotation-safe)。サイズ 1024、超過分は LRU evict。
- `internal/queue/processors/deliver_test.go`
  - `keyCapturingSigner` を追加し、`PostSigned` が受け取る `*PrivateKey` のポインタ同一性で cache hit を観測。
  - `TestDeliverProcessor_RSAKeyCacheReuse`(同一 PEM→再利用 / 別 PEM→再パース)、`_Ed25519KeyCacheReuse` を追加。

## 挙動・互換性

- 署名結果は不変(同じ鍵を返すだけ)。機能挙動の変更なし。
- 鍵 rotation 時は PEM が変わるため cache key も変わり、新しい鍵で署名される。
- 効果測定は隔離 bench stack で実施想定(本番 UDS では行わない)。

## テスト

- `go test ./internal/queue/processors/` pass、coverage 90.8%(閾値超)
- `make fmt && make lint` clean
- develop 取り込み済み

## Closes

Closes #1425