### PR TITLE
fix(pages): pages/like の非public・非所有者アクセスも 404 で隠す

### DIFF
--- a/internal/api/pages/handler.go
+++ b/internal/api/pages/handler.go
@@ -380,10 +380,14 @@ func (h *Handler) Like(c echo.Context) error {
 	}
 	if err := h.svc.Like(user.ID, req.PageID); err != nil {
 		switch {
-		case errors.Is(err, corepage.ErrPageNotFound):
+		// upstream TS pages/like は accessDenied を宣言しておらず可視性ゲート
+		// 自体を持たない (noSuchPage / yourPage / alreadyLiked のみ)。mk-go は
+		// Page.visibility (drop-in #367) を持つため core service にゲートを残す
+		// が、ErrAccessDenied は show (#1434) と同じく 404 NO_SUCH_PAGE で隠して
+		// private page の存在を 403 で露呈しないようにする (#1435)。
+		case errors.Is(err, corepage.ErrPageNotFound),
+			errors.Is(err, corepage.ErrAccessDenied):
 			return c.JSON(http.StatusNotFound, apierr.Error("NO_SUCH_PAGE", "No such page.", "cc98a8a2-0dc3-4123-b198-62c71df18ed3"))
-		case errors.Is(err, corepage.ErrAccessDenied):
-			return apierr.JSONAccessDenied(c)
 		case errors.Is(err, corepage.ErrAlreadyLiked):
 			return c.JSON(http.StatusBadRequest, apierr.Error("ALREADY_LIKED", "You already liked that page.", "d4c1edbe-7da2-4eae-8714-1acfd2d63941"))
 		}

--- a/internal/api/pages/handler_test.go
+++ b/internal/api/pages/handler_test.go
@@ -255,6 +255,21 @@ func TestShow_AccessDenied_ByUsername(t *testing.T) {
 	assert.Contains(t, rec.Body.String(), "NO_SUCH_PAGE")
 }
 
+// guest (未認証) viewer が非 public page を引いた場合も 404 NO_SUCH_PAGE で
+// 存在隠蔽されること (#1435)。handler は user==nil 時に requesterID="" を
+// service へ渡すので、authenticated non-owner と同じ ErrAccessDenied 経路に
+// 落ち、404 化フォールスルーで存在を隠す。guest probe は最も悪用されやすい
+// 経路なので明示的に固定する。
+func TestShow_AccessDenied_Guest(t *testing.T) {
+	h, repo, _ := newHandler(t)
+	repo.Pages["p1"] = &model.Page{ID: "p1", UserID: "owner", Visibility: model.PageVisibilityFollowers}
+	c, rec := newReq(t, `{"pageId":"p1"}`)
+	// setUser is intentionally NOT called — middleware.GetUser returns nil.
+	require.NoError(t, h.Show(c))
+	assert.Equal(t, http.StatusNotFound, rec.Code)
+	assert.Contains(t, rec.Body.String(), "NO_SUCH_PAGE")
+}
+
 // --- Update ----------------------------------------------------------------
 
 func TestUpdate_Success(t *testing.T) {
@@ -551,13 +566,22 @@ func TestLike_NotFound(t *testing.T) {
 	assert.Equal(t, http.StatusNotFound, rec.Code)
 }
 
+// 非 public page を非所有者が like しようとすると、存在ごと隠して 404
+// NO_SUCH_PAGE を返すこと (#1435)。upstream TS pages/like は accessDenied を
+// 宣言しておらず、mk-go の可視性ゲート (drop-in 都合で残置) も外部からは
+// noSuchPage に集約して 403 で存在露呈しない。
 func TestLike_AccessDenied(t *testing.T) {
 	h, repo, _ := newHandler(t)
 	repo.Pages["p1"] = &model.Page{ID: "p1", UserID: "alice", Visibility: model.PageVisibilityFollowers}
 	c, rec := newReq(t, `{"pageId":"p1"}`)
 	setUser(c, "bob")
 	require.NoError(t, h.Like(c))
-	assert.Equal(t, http.StatusForbidden, rec.Code)
+	assert.Equal(t, http.StatusNotFound, rec.Code)
+	var resp map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+	errObj := resp["error"].(map[string]any)
+	assert.Equal(t, "NO_SUCH_PAGE", errObj["code"])
+	assert.Equal(t, "cc98a8a2-0dc3-4123-b198-62c71df18ed3", errObj["id"])
 }
 
 func TestLike_AlreadyLiked(t *testing.T) {


### PR DESCRIPTION
## Summary

#1434 (pages/show の存在隠蔽 404 化) の follow-up。同じ parity sweep として `pages/like` も 403 ACCESS_DENIED → 404 NO_SUCH_PAGE に倒し、private page の存在露呈を防ぐ。

合わせて pages/show の guest viewer (= 未認証) 経路で 404 に倒れることを test で固定する (#1434 で見落としていた)。

## 論点

### 1. pages/like の error mapping

`third_party/misskey/packages/backend/src/server/api/endpoints/pages/like.ts` を確認したところ、TS は `accessDenied` を宣言しておらず可視性ゲート自体を持たない (`noSuchPage` / `yourPage` / `alreadyLiked` のみ)。mk-go は `Page.visibility` (drop-in #367) を持つため `core/page.Service.Like` のゲートは必要(削除しない)だが、外部に対しては show と同じ存在隠蔽パターンで 404 NO_SUCH_PAGE に集約する。

```ts
// third_party/misskey/.../pages/like.ts L22-40
errors: {
  noSuchPage: { code: 'NO_SUCH_PAGE', id: 'cc98a8a2-...' },
  yourPage: { code: 'YOUR_PAGE', id: '28800466-...' },
  alreadyLiked: { code: 'ALREADY_LIKED', id: 'd4c1edbe-...' },
},
```

UUID `cc98a8a2-0dc3-4123-b198-62c71df18ed3` は mk-go の Like で既に NO_SUCH_PAGE として使用されており、TS とも一致しているのでそのまま fallthrough する。

### 2. pages/show guest viewer test

handler は `user == nil` 時に `requesterID = ""` を service へ渡すので、authenticated non-owner と同じ `ErrAccessDenied` 経路に落ち、#1434 の修正で 404 化フォールスルーが効く。実害は無いが test 未カバーだったので明示的に regression を防ぐ。

## 主な変更点

- `internal/api/pages/handler.go`
  - `Like` の err 分岐から `ErrAccessDenied -> JSONAccessDenied (403)` を撤去し、`ErrPageNotFound` と同じ 404 NO_SUCH_PAGE 経路にフォールスルー。TS が gate を持たない事実を踏まえた hide 化を背景としてコメントで記録。
- `internal/api/pages/handler_test.go`
  - `TestLike_AccessDenied` を 404 + `NO_SUCH_PAGE` (UUID `cc98a8a2-...`) を検証する内容に更新。
  - `TestShow_AccessDenied_Guest` を新規追加。`setUser` を呼ばない guest 経路で非 public page が 404 NO_SUCH_PAGE で隠れることを assert。

`yourPage` (TS 28800466-...) parity は本 PR の scope 外 (#1435 が指摘していた論点ではない)。別途 follow-up が必要なら issue を立てる方針。

## テスト

- `go test ./internal/api/pages/ ./internal/core/page/` pass
- pages パッケージ coverage 97.5% (90%+ 維持)
- `make fmt && make lint` clean
- ローカル `make test` のうち pages/core/page は green。gallery / hashtags / repository / safehttp / e2e_federation は CI services (PostgreSQL / Redis / IPv6 listener) 依存で local では env 起因 fail、本変更とは無関係。

## Closes

Closes #1435