### PR TITLE
fix(notes): search-by-tag に visibility push-down を追加 (IDOR)

### DIFF
--- a/internal/api/notes/handler_extra.go
+++ b/internal/api/notes/handler_extra.go
@@ -219,12 +219,20 @@ func (h *Handler) SearchByTag(c echo.Context) error {
 	req.Limit = pagination.ClampLimit(req.Limit, 10, 100)
 	// sinceDate / untilDate を aidx prefix に正規化 (#1166)。
 	sinceID, untilID := id.NormalizeCursor(req.SinceID, req.UntilID, req.SinceDate, req.UntilDate)
-	// tagsカラムにtagを含むノートを検索
-	notes, err := h.noteRepo.SearchByTag(req.Tag, req.Limit, sinceID, untilID)
+	// tagsカラムにtagを含むノートを検索。visibility は repository 側で
+	// push-down する (#1439)。discovery 系の tag 検索は notes/show の
+	// 「ID 既知公開」doctrine 対象外なので、匿名/非follower には followers/
+	// specified note を返さない。
+	viewer := middleware.GetUser(c)
+	viewerID := ""
+	if viewer != nil {
+		viewerID = viewer.ID
+	}
+	notes, err := h.noteRepo.SearchByTag(req.Tag, viewerID, req.Limit, sinceID, untilID)
 	if err != nil {
 		return c.JSON(http.StatusOK, []entity.NoteEntity{})
 	}
-	return c.JSON(http.StatusOK, h.packMany(c.Request().Context(), notes, middleware.GetUser(c)))
+	return c.JSON(http.StatusOK, h.packMany(c.Request().Context(), notes, viewer))
 }
 
 // Clips handles POST /api/notes/clips.

--- a/internal/api/notes/handler_extra.go
+++ b/internal/api/notes/handler_extra.go
@@ -232,9 +232,10 @@ func (h *Handler) SearchByTag(c echo.Context) error {
 	notes, err := h.noteRepo.SearchByTag(req.Tag, viewerID, req.Limit, sinceID, untilID)
 	if err != nil {
 		// tag 検索失敗は従来どおり空配列で返す (TS 互換) が、visibility
-		// push-down 追加で SQL エラーも黙殺されうるため debug 用に 1 行残す
-		// (#1439 review)。
-		slog.Warn("notes/search-by-tag: SearchByTag failed", "tag", req.Tag, "err", err)
+		// push-down 追加で SQL エラーも黙殺されうるため診断用に 1 行残す。
+		// ユーザー挙動 (200 + 空配列) は不変で operator-actionable でもないため
+		// Warn ではなく Debug に留める (#1446 review)。
+		slog.Debug("notes/search-by-tag: SearchByTag failed", "tag", req.Tag, "err", err)
 		return c.JSON(http.StatusOK, []entity.NoteEntity{})
 	}
 	return c.JSON(http.StatusOK, h.packMany(c.Request().Context(), notes, viewer))

--- a/internal/api/notes/handler_extra.go
+++ b/internal/api/notes/handler_extra.go
@@ -1,6 +1,7 @@
 package notes
 
 import (
+	"log/slog"
 	"net/http"
 	"time"
 
@@ -230,6 +231,10 @@ func (h *Handler) SearchByTag(c echo.Context) error {
 	}
 	notes, err := h.noteRepo.SearchByTag(req.Tag, viewerID, req.Limit, sinceID, untilID)
 	if err != nil {
+		// tag 検索失敗は従来どおり空配列で返す (TS 互換) が、visibility
+		// push-down 追加で SQL エラーも黙殺されうるため debug 用に 1 行残す
+		// (#1439 review)。
+		slog.Warn("notes/search-by-tag: SearchByTag failed", "tag", req.Tag, "err", err)
 		return c.JSON(http.StatusOK, []entity.NoteEntity{})
 	}
 	return c.JSON(http.StatusOK, h.packMany(c.Request().Context(), notes, viewer))

--- a/internal/api/notes/handler_extra_test.go
+++ b/internal/api/notes/handler_extra_test.go
@@ -274,9 +274,72 @@ func TestSearchByTag_QueryArrayEmpty(t *testing.T) {
 	assert.Equal(t, http.StatusBadRequest, postExtra(h.SearchByTag, `{"query":[[]]}`, nil).Code)
 }
 
+// search-by-tag の visibility push-down (#1439)。discovery 系なので匿名/非
+// follower には followers / specified note を返さず、author 本人 / follower /
+// visibleUserIds 対象には返すことを固定する。
+func seedSearchVisibilityNotes(noteRepo *testutil.MockNoteRepository) {
+	noteRepo.Notes["t_pub"] = &model.Note{ID: "t_pub", UserID: "author", Tags: []string{"tag"}, Visibility: "public", User: &model.User{ID: "author"}}
+	noteRepo.Notes["t_fol"] = &model.Note{ID: "t_fol", UserID: "author", Tags: []string{"tag"}, Visibility: "followers", User: &model.User{ID: "author"}}
+	noteRepo.Notes["t_spec"] = &model.Note{ID: "t_spec", UserID: "author", Tags: []string{"tag"}, Visibility: "specified", VisibleUserIDs: []string{"allowed"}, User: &model.User{ID: "author"}}
+}
+
+func searchTagIDs(t *testing.T, rec *httptest.ResponseRecorder) map[string]bool {
+	t.Helper()
+	require.Equal(t, http.StatusOK, rec.Code)
+	var out []map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &out))
+	ids := map[string]bool{}
+	for _, n := range out {
+		ids[n["id"].(string)] = true
+	}
+	return ids
+}
+
+func TestSearchByTag_AnonymousExcludesNonPublic(t *testing.T) {
+	h, noteRepo, _ := newExtraHandler(t)
+	seedSearchVisibilityNotes(noteRepo)
+	ids := searchTagIDs(t, postExtra(h.SearchByTag, `{"tag":"tag"}`, nil))
+	assert.True(t, ids["t_pub"], "public は匿名に見える")
+	assert.False(t, ids["t_fol"], "followers は匿名に漏らさない")
+	assert.False(t, ids["t_spec"], "specified は対象外に漏らさない")
+}
+
+func TestSearchByTag_NonFollowerExcludesFollowers(t *testing.T) {
+	h, noteRepo, _ := newExtraHandler(t)
+	seedSearchVisibilityNotes(noteRepo)
+	// stranger は follow なし / specified 対象外 -> public のみ。
+	ids := searchTagIDs(t, postExtra(h.SearchByTag, `{"tag":"tag"}`, &model.User{ID: "stranger"}))
+	assert.True(t, ids["t_pub"])
+	assert.False(t, ids["t_fol"])
+	assert.False(t, ids["t_spec"])
+}
+
+func TestSearchByTag_FollowerSeesFollowers(t *testing.T) {
+	h, noteRepo, _ := newExtraHandler(t)
+	seedSearchVisibilityNotes(noteRepo)
+	noteRepo.Following = map[string][]string{"follower": {"author"}}
+	ids := searchTagIDs(t, postExtra(h.SearchByTag, `{"tag":"tag"}`, &model.User{ID: "follower"}))
+	assert.True(t, ids["t_pub"])
+	assert.True(t, ids["t_fol"], "follower は followers note を見られる")
+	assert.False(t, ids["t_spec"])
+}
+
+func TestSearchByTag_SpecifiedTargetAndAuthorSee(t *testing.T) {
+	h, noteRepo, _ := newExtraHandler(t)
+	seedSearchVisibilityNotes(noteRepo)
+	// visibleUserIds 対象は public + specified。
+	allowedIDs := searchTagIDs(t, postExtra(h.SearchByTag, `{"tag":"tag"}`, &model.User{ID: "allowed"}))
+	assert.True(t, allowedIDs["t_pub"])
+	assert.True(t, allowedIDs["t_spec"], "visibleUserIds 対象は specified を見られる")
+	assert.False(t, allowedIDs["t_fol"])
+	// author 本人は全 visibility を見られる。
+	authorIDs := searchTagIDs(t, postExtra(h.SearchByTag, `{"tag":"tag"}`, &model.User{ID: "author"}))
+	assert.True(t, authorIDs["t_pub"] && authorIDs["t_fol"] && authorIDs["t_spec"], "author 本人は全て見られる")
+}
+
 type failingSearchByTagRepo struct{ *testutil.MockNoteRepository }
 
-func (f *failingSearchByTagRepo) SearchByTag(_ string, _ int, _, _ string) ([]*model.Note, error) {
+func (f *failingSearchByTagRepo) SearchByTag(_, _ string, _ int, _, _ string) ([]*model.Note, error) {
 	return nil, testutil.ErrNotFound
 }
 

--- a/internal/api/notes/handler_test.go
+++ b/internal/api/notes/handler_test.go
@@ -866,7 +866,7 @@ func (f *failingNoteRepo) FindRenoteByUser(_, _ string) (*model.Note, error) {
 func (f *failingNoteRepo) ListMentions(_ string, _ int, _, _ string) ([]*model.Note, error) {
 	return nil, nil
 }
-func (f *failingNoteRepo) SearchByTag(_ string, _ int, _, _ string) ([]*model.Note, error) {
+func (f *failingNoteRepo) SearchByTag(_, _ string, _ int, _, _ string) ([]*model.Note, error) {
 	return nil, nil
 }
 func (f *failingNoteRepo) ListByFileID(_, _, _ string, _ int) ([]*model.Note, error) {

--- a/internal/repository/note.go
+++ b/internal/repository/note.go
@@ -85,7 +85,11 @@ type NoteRepository interface {
 	ListFeatured(channelID, untilID string, limit, offset int) ([]*model.Note, error)
 	FindRenoteByUser(userID, renoteID string) (*model.Note, error)
 	ListMentions(userID string, limit int, sinceID, untilID string) ([]*model.Note, error)
-	SearchByTag(tag string, limit int, sinceID, untilID string) ([]*model.Note, error)
+	// SearchByTag returns notes carrying tag that viewerID is allowed to see.
+	// viewerID 空文字は匿名 (public/home のみ)。discovery 系の tag 検索は
+	// ID 既知公開 (notes/show) doctrine の対象外なので、core/note.CanSeeNote と
+	// 同じ可視性条件を LIMIT 前に SQL で絞る (#1439)。
+	SearchByTag(tag, viewerID string, limit int, sinceID, untilID string) ([]*model.Note, error)
 	// ListByFileID returns notes whose fileIds array contains fileID, with
 	// cursor (sinceID/untilID) pagination matching upstream Misskey's
 	// makePaginationQuery. limit <= 0 defaults to 10.
@@ -622,13 +626,25 @@ func (r *noteRepository) ListMentions(userID string, limit int, sinceID, untilID
 	return notes, nil
 }
 
-func (r *noteRepository) SearchByTag(tag string, limit int, sinceID, untilID string) ([]*model.Note, error) {
+func (r *noteRepository) SearchByTag(tag, viewerID string, limit int, sinceID, untilID string) ([]*model.Note, error) {
 	if limit <= 0 {
 		limit = 10
 	}
 	q := preloadNoteRelations(r.db).
-		Where("tags @> ARRAY[?]::varchar[]", tag).
-		Order(paginationOrder(sinceID, untilID, "id")).Limit(limit)
+		Where("tags @> ARRAY[?]::varchar[]", tag)
+	// visibility push-down: core/note.CanSeeNote と同じ条件を LIMIT 前に絞る。
+	// ListByUserIDFiltered / clip の ListByClipVisible と同じ可視性定義 (#1439)。
+	if viewerID == "" {
+		q = q.Where(`"visibility" IN ('public','home')`)
+	} else {
+		q = q.Where(
+			`("visibility" IN ('public','home') `+
+				`OR "userId" = ? `+
+				`OR ("visibility" = 'followers' AND "userId" IN (SELECT f."followeeId" FROM "following" f WHERE f."followerId" = ?)) `+
+				`OR ("visibility" = 'specified' AND ? = ANY("visibleUserIds")))`,
+			viewerID, viewerID, viewerID)
+	}
+	q = q.Order(paginationOrder(sinceID, untilID, "id")).Limit(limit)
 	if sinceID != "" {
 		q = q.Where("id > ?", sinceID)
 	}

--- a/internal/repository/note_test.go
+++ b/internal/repository/note_test.go
@@ -1086,21 +1086,21 @@ func TestNoteRepository_SearchByTag(t *testing.T) {
 	require.NoError(t, testDB.Create(n).Error)
 	defer testDB.Exec(`DELETE FROM "note" WHERE id = ?`, n.ID)
 
-	notes, err := repo.SearchByTag("golang", 10, "", "")
+	notes, err := repo.SearchByTag("golang", "", 10, "", "")
 	require.NoError(t, err)
 	assert.NotEmpty(t, notes)
 
-	notes, err = repo.SearchByTag("nonexistent", 10, "", "")
+	notes, err = repo.SearchByTag("nonexistent", "", 10, "", "")
 	require.NoError(t, err)
 	assert.Empty(t, notes)
 
 	// default limit
-	notes, err = repo.SearchByTag("golang", 0, "", "")
+	notes, err = repo.SearchByTag("golang", "", 0, "", "")
 	require.NoError(t, err)
 	assert.NotEmpty(t, notes)
 
 	// with cursors
-	notes, err = repo.SearchByTag("golang", 10, "000", "zzz")
+	notes, err = repo.SearchByTag("golang", "", 10, "000", "zzz")
 	require.NoError(t, err)
 	assert.NotEmpty(t, notes)
 }
@@ -1109,8 +1109,73 @@ func TestNoteRepository_SearchByTag_Error(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel()
 	repo := NewNoteRepository(testDB.WithContext(ctx))
-	_, err := repo.SearchByTag("x", 10, "", "")
+	_, err := repo.SearchByTag("x", "", 10, "", "")
 	assert.Error(t, err)
+}
+
+// TestNoteRepository_SearchByTag_VisibilityPushDown は #1439 の visibility
+// push-down を検証する。同一 tag に public / followers / specified を付け、
+// viewer ごとに SQL 段で見える note が変わることを確認する。
+func TestNoteRepository_SearchByTag_VisibilityPushDown(t *testing.T) {
+	repo := NewNoteRepository(testDB)
+	followingRepo := NewFollowingRepository(testDB)
+
+	mkUser := func(id, username string) *model.User {
+		u := insertTestUser(t, id, username)
+		t.Cleanup(func() { cleanupUser(t, u.ID) })
+		return u
+	}
+	author := mkUser("u_sbt_a", "sbtauthor")
+	follower := mkUser("u_sbt_f", "sbtfollower")
+	allowed := mkUser("u_sbt_al", "sbtallowed")
+	stranger := mkUser("u_sbt_s", "sbtstranger")
+
+	notes := []*model.Note{
+		{ID: "n_sbt_pub", UserID: author.ID, Visibility: model.NoteVisibilityPublic, Tags: pq.StringArray{"sbttag"}, Reactions: datatypes.JSON([]byte("{}"))},
+		{ID: "n_sbt_fol", UserID: author.ID, Visibility: model.NoteVisibilityFollowers, Tags: pq.StringArray{"sbttag"}, Reactions: datatypes.JSON([]byte("{}"))},
+		{ID: "n_sbt_spec", UserID: author.ID, Visibility: model.NoteVisibilitySpecified, VisibleUserIDs: pq.StringArray{allowed.ID}, Tags: pq.StringArray{"sbttag"}, Reactions: datatypes.JSON([]byte("{}"))},
+	}
+	for _, n := range notes {
+		require.NoError(t, repo.Create(n))
+		defer cleanupNote(t, n.ID)
+	}
+
+	f := &model.Following{ID: "fl_sbt_1", FollowerID: follower.ID, FolloweeID: author.ID}
+	require.NoError(t, followingRepo.Create(f))
+	defer testDB.Exec(`DELETE FROM "following" WHERE id = ?`, f.ID)
+
+	idsOf := func(rows []*model.Note) []string {
+		out := make([]string, 0, len(rows))
+		for _, n := range rows {
+			out = append(out, n.ID)
+		}
+		sort.Strings(out)
+		return out
+	}
+
+	// 匿名 / stranger は public のみ。
+	out, err := repo.SearchByTag("sbttag", "", 50, "", "")
+	require.NoError(t, err)
+	assert.Equal(t, []string{"n_sbt_pub"}, idsOf(out))
+
+	out, err = repo.SearchByTag("sbttag", stranger.ID, 50, "", "")
+	require.NoError(t, err)
+	assert.Equal(t, []string{"n_sbt_pub"}, idsOf(out))
+
+	// follower は public + followers。
+	out, err = repo.SearchByTag("sbttag", follower.ID, 50, "", "")
+	require.NoError(t, err)
+	assert.Equal(t, []string{"n_sbt_fol", "n_sbt_pub"}, idsOf(out))
+
+	// visibleUserIds 対象は public + specified。
+	out, err = repo.SearchByTag("sbttag", allowed.ID, 50, "", "")
+	require.NoError(t, err)
+	assert.Equal(t, []string{"n_sbt_pub", "n_sbt_spec"}, idsOf(out))
+
+	// author 本人は全 visibility。
+	out, err = repo.SearchByTag("sbttag", author.ID, 50, "", "")
+	require.NoError(t, err)
+	assert.Equal(t, []string{"n_sbt_fol", "n_sbt_pub", "n_sbt_spec"}, idsOf(out))
 }
 
 // TestNoteRepository_DeleteByUserBatch verifies that one call deletes up to
@@ -1706,14 +1771,14 @@ func TestNoteRepository_SinceIDFlipsOrderASC(t *testing.T) {
 	}
 
 	// sinceID単独指定: ASC順 (古い→新しい)。asc_n_a より大なので b, c が返る想定。
-	notes, err := repo.SearchByTag("ascflip", 10, "asc_n_a", "")
+	notes, err := repo.SearchByTag("ascflip", "", 10, "asc_n_a", "")
 	require.NoError(t, err)
 	require.Len(t, notes, 2)
 	assert.Equal(t, "asc_n_b", notes[0].ID)
 	assert.Equal(t, "asc_n_c", notes[1].ID)
 
 	// untilID単独指定: DESC順 (既存挙動)。asc_n_c より小なので b, a が返る。
-	notes, err = repo.SearchByTag("ascflip", 10, "", "asc_n_c")
+	notes, err = repo.SearchByTag("ascflip", "", 10, "", "asc_n_c")
 	require.NoError(t, err)
 	require.Len(t, notes, 2)
 	assert.Equal(t, "asc_n_b", notes[0].ID)

--- a/internal/testutil/mock_repository.go
+++ b/internal/testutil/mock_repository.go
@@ -1112,11 +1112,14 @@ func (m *MockNoteRepository) ListMentions(userID string, limit int, sinceID, unt
 	}, untilID, sinceID, limit), nil
 }
 
-func (m *MockNoteRepository) SearchByTag(tag string, limit int, sinceID, untilID string) ([]*model.Note, error) {
+func (m *MockNoteRepository) SearchByTag(tag, viewerID string, limit int, sinceID, untilID string) ([]*model.Note, error) {
 	if limit <= 0 {
 		limit = 10
 	}
 	return m.listFiltered(func(n *model.Note) bool {
+		if !m.canViewerSeeNote(viewerID, n) {
+			return false
+		}
 		for _, t := range n.Tags {
 			if t == tag {
 				return true


### PR DESCRIPTION
## Summary

`notes/search-by-tag` は `SearchByTag` が tag 条件のみで visibility を見ず、`packMany` も `FilterVisible` しないため、**匿名ユーザーが followers / specified visibility note の本文と author を tag 検索で取得できる** IDOR があった。discovery 系の tag 検索は notes/show の「ID 既知公開」doctrine の対象外。

`users/notes` (#1418 `ListByUserIDFiltered`) / `clips/notes` (#1418 `ListByClipVisible`) と同じ SQL push-down で塞ぐ (issue #1439 の option A)。

## 主な変更点

- `internal/repository/note.go`
  - `SearchByTag` に `viewerID` を追加し、`core/note.CanSeeNote` と同じ可視性条件 (public/home / 本人 / followers の follow EXISTS / specified の visibleUserIds) を LIMIT 前に push-down。
  - 本番呼び出しは handler 1 箇所のみで非フィルタ用途が無いため、別メソッドではなく既存 signature に `viewerID` を足す方針 (`ListByUserIDFiltered` と同方針。`ListByClipVisible` を別メソッドにしたのは export という第2 caller があったため)。
- `internal/api/notes/handler_extra.go`: `SearchByTag` で viewer を解決し `viewerID` を渡す。
- `internal/testutil/mock_repository.go`: mock の `SearchByTag` に visibility filter (`noteVisibleToViewer`、#1418 で共通化したヘルパー) を適用。
- テスト追加:
  - `handler_extra_test.go`: 匿名/非follower/specified対象外は followers・specified を除外、author/follower/visibleUserIds 対象は閲覧可。
  - `note_test.go`: real-DB の visibility push-down テスト (匿名/stranger/follower/specified対象/本人の5観点)。
  - 既存 `SearchByTag` テスト・fake の signature を更新。

## テスト

- `go test ./internal/api/notes/ ./internal/repository/` pass
- coverage: notes 91.5% / repository 90.0% (閾値クリア)
- `make fmt && make lint` clean

## Closes

Closes #1439