### PR TITLE
fix(notes): mentions に visibility push-down を追加 (IDOR)

### DIFF
--- a/internal/api/notes/handler_extra_test.go
+++ b/internal/api/notes/handler_extra_test.go
@@ -176,6 +176,50 @@ func TestMentions_InvalidJSON(t *testing.T) {
 	assert.Equal(t, http.StatusBadRequest, rec.Code)
 }
 
+func mentionIDs(t *testing.T, rec *httptest.ResponseRecorder) map[string]bool {
+	t.Helper()
+	require.Equal(t, http.StatusOK, rec.Code)
+	var out []map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &out))
+	ids := map[string]bool{}
+	for _, n := range out {
+		ids[n["id"].(string)] = true
+	}
+	return ids
+}
+
+// #1441 攻撃 a: 非 follower を mention した followers note は、mention された
+// だけの非 follower viewer には返らない。follower になれば返る。
+func TestMentions_FollowersNonFollowerExcluded(t *testing.T) {
+	h, noteRepo, _ := newExtraHandler(t)
+	noteRepo.Notes["m_fol"] = &model.Note{ID: "m_fol", UserID: "author", Mentions: []string{"victim"}, Visibility: "followers", User: &model.User{ID: "author"}}
+
+	// victim は author を follow していない -> followers note は出ない。
+	ids := mentionIDs(t, postExtra(h.Mentions, `{}`, &model.User{ID: "victim"}))
+	assert.False(t, ids["m_fol"], "非 follower を mention した followers note は漏らさない")
+
+	// follower になれば出る。
+	noteRepo.Following = map[string][]string{"victim": {"author"}}
+	ids = mentionIDs(t, postExtra(h.Mentions, `{}`, &model.User{ID: "victim"}))
+	assert.True(t, ids["m_fol"], "follower には mention された followers note が出る")
+}
+
+// #1441 攻撃 b: visibleUserIds に含まれない viewer を mention した specified
+// note は、その viewer には返らない。visibleUserIds 対象なら返る。
+func TestMentions_SpecifiedNonTargetExcluded(t *testing.T) {
+	h, noteRepo, _ := newExtraHandler(t)
+	// mentions に victim を含むが visibleUserIds は other のみ。
+	noteRepo.Notes["m_spec"] = &model.Note{ID: "m_spec", UserID: "author", Mentions: []string{"victim"}, Visibility: "specified", VisibleUserIDs: []string{"other"}, User: &model.User{ID: "author"}}
+
+	ids := mentionIDs(t, postExtra(h.Mentions, `{"visibility":"specified"}`, &model.User{ID: "victim"}))
+	assert.False(t, ids["m_spec"], "visibleUserIds 非対象を mention した specified note は漏らさない")
+
+	// victim が visibleUserIds 対象なら出る。
+	noteRepo.Notes["m_spec"].VisibleUserIDs = []string{"victim"}
+	ids = mentionIDs(t, postExtra(h.Mentions, `{"visibility":"specified"}`, &model.User{ID: "victim"}))
+	assert.True(t, ids["m_spec"], "visibleUserIds 対象には specified mention が出る")
+}
+
 // --- UserListTimeline ---
 
 func TestUserListTimeline_Success(t *testing.T) {

--- a/internal/repository/note.go
+++ b/internal/repository/note.go
@@ -607,8 +607,19 @@ func (r *noteRepository) ListMentions(userID string, limit int, sinceID, untilID
 		limit = 10
 	}
 	q := preloadNoteRelations(r.db).
-		Where("mentions @> ARRAY[?]::varchar[]", userID).
-		Order(paginationOrder(sinceID, untilID, "id")).Limit(limit)
+		Where("mentions @> ARRAY[?]::varchar[]", userID)
+	// visibility push-down: mention 対象 (= viewer = userID) が CanSeeNote で
+	// 見られる note のみ返す。mentions 配列は本文の @user パース結果で specified
+	// の visibleUserIds とは独立なので、これが無いと followers/specified note を
+	// mention されただけの非対象 viewer が本文と author を取得できてしまう (#1441)。
+	// viewer は notes/mentions の認証ユーザー = userID 固定。
+	q = q.Where(
+		`("visibility" IN ('public','home') `+
+			`OR "userId" = ? `+
+			`OR ("visibility" = 'followers' AND "userId" IN (SELECT f."followeeId" FROM "following" f WHERE f."followerId" = ?)) `+
+			`OR ("visibility" = 'specified' AND ? = ANY("visibleUserIds")))`,
+		userID, userID, userID)
+	q = q.Order(paginationOrder(sinceID, untilID, "id")).Limit(limit)
 	if sinceID != "" {
 		q = q.Where("id > ?", sinceID)
 	}

--- a/internal/repository/note_test.go
+++ b/internal/repository/note_test.go
@@ -1062,6 +1062,62 @@ func TestNoteRepository_ListMentions(t *testing.T) {
 	assert.NotEmpty(t, notes)
 }
 
+// TestNoteRepository_ListMentions_VisibilityPushDown は #1441 を検証する。
+// mention 対象 (= viewer) が CanSeeNote で見られない followers / specified note を
+// mention されただけでは取得できないこと、follow / visibleUserIds 対象なら
+// 取得できることを確認する。
+func TestNoteRepository_ListMentions_VisibilityPushDown(t *testing.T) {
+	repo := NewNoteRepository(testDB)
+	followingRepo := NewFollowingRepository(testDB)
+
+	mkUser := func(id, username string) *model.User {
+		u := insertTestUser(t, id, username)
+		t.Cleanup(func() { cleanupUser(t, u.ID) })
+		return u
+	}
+	author := mkUser("u_lm_a", "lmauthor")
+	victim := mkUser("u_lm_v", "lmvictim")
+
+	notes := []*model.Note{
+		{ID: "n_lm_pub", UserID: author.ID, Visibility: model.NoteVisibilityPublic, Mentions: pq.StringArray{victim.ID}, Reactions: datatypes.JSON([]byte("{}"))},
+		{ID: "n_lm_fol", UserID: author.ID, Visibility: model.NoteVisibilityFollowers, Mentions: pq.StringArray{victim.ID}, Reactions: datatypes.JSON([]byte("{}"))},
+		// specified だが visibleUserIds に victim を含まない (mentions のみ)。
+		{ID: "n_lm_spec", UserID: author.ID, Visibility: model.NoteVisibilitySpecified, VisibleUserIDs: pq.StringArray{"someone-else"}, Mentions: pq.StringArray{victim.ID}, Reactions: datatypes.JSON([]byte("{}"))},
+	}
+	for _, n := range notes {
+		require.NoError(t, repo.Create(n))
+		defer cleanupNote(t, n.ID)
+	}
+
+	idsOf := func(rows []*model.Note) []string {
+		out := make([]string, 0, len(rows))
+		for _, n := range rows {
+			out = append(out, n.ID)
+		}
+		sort.Strings(out)
+		return out
+	}
+
+	// follow なし / visibleUserIds 非対象 -> public のみ (followers/specified は隠れる)。
+	out, err := repo.ListMentions(victim.ID, 50, "", "")
+	require.NoError(t, err)
+	assert.Equal(t, []string{"n_lm_pub"}, idsOf(out))
+
+	// victim が author を follow すると followers note も見える。
+	f := &model.Following{ID: "fl_lm_1", FollowerID: victim.ID, FolloweeID: author.ID}
+	require.NoError(t, followingRepo.Create(f))
+	defer testDB.Exec(`DELETE FROM "following" WHERE id = ?`, f.ID)
+	out, err = repo.ListMentions(victim.ID, 50, "", "")
+	require.NoError(t, err)
+	assert.Equal(t, []string{"n_lm_fol", "n_lm_pub"}, idsOf(out))
+
+	// specified の visibleUserIds に victim を含めると specified も見える。
+	require.NoError(t, repo.UpdateFields("n_lm_spec", map[string]any{"visibleUserIds": pq.StringArray{victim.ID}}))
+	out, err = repo.ListMentions(victim.ID, 50, "", "")
+	require.NoError(t, err)
+	assert.Equal(t, []string{"n_lm_fol", "n_lm_pub", "n_lm_spec"}, idsOf(out))
+}
+
 func TestNoteRepository_ListMentions_DefaultLimit(t *testing.T) {
 	repo := NewNoteRepository(testDB)
 	notes, err := repo.ListMentions("nobody", 0, "", "")

--- a/internal/testutil/mock_repository.go
+++ b/internal/testutil/mock_repository.go
@@ -1103,6 +1103,10 @@ func (m *MockNoteRepository) ListMentions(userID string, limit int, sinceID, unt
 		limit = 10
 	}
 	return m.listFiltered(func(n *model.Note) bool {
+		// viewer (= mention 対象 = userID) が見られる note のみ (#1441)。
+		if !m.canViewerSeeNote(userID, n) {
+			return false
+		}
 		for _, mention := range n.Mentions {
 			if mention == userID {
 				return true


### PR DESCRIPTION
## Summary

`notes/mentions` は `ListMentions` が `mentions @> ARRAY[?]` のみで visibility を見ず、handler の filter も specified/non-specified の振り分けだけで `CanSeeNote` を経ない (`packMany` も hardMute のみ)。`mentions` 配列は本文の `@user` パース結果で specified の `visibleUserIds` とは独立なため、2 系統の leak があった:

- **攻撃 a (followers)**: 任意ユーザーが followers visibility note の本文で `@victim` するだけで、victim が author の follower でなくても note の本文と author を取得できる。
- **攻撃 b (specified)**: specified note の `mentions` に victim を含むが `visibleUserIds` に含めないケースで、specified の本来対象でない victim が note を取得できる。

`users/notes` / `clips/notes` (#1418) / `search-by-tag` (#1439) と同じ SQL push-down で塞ぐ (issue #1441 の方針)。

## 主な変更点

- `internal/repository/note.go`
  - `ListMentions` に `core/note.CanSeeNote` と同じ可視性条件 (public/home / 本人 / followers の follow EXISTS / specified の visibleUserIds) を LIMIT 前に push-down。
  - mention 対象 (= viewer) は notes/mentions の認証ユーザー = `userID` 固定なので **signature 変更は不要** (既存 `userID` を viewer として可視性条件に使う)。handler の specified/non-specified 振り分けはそのまま機能として残す。
- `internal/testutil/mock_repository.go`: mock の `ListMentions` に visibility filter (`noteVisibleToViewer`、#1418 で共通化) を適用。
- テスト追加:
  - `handler_extra_test.go`: 攻撃 a / b それぞれの除外 + follower / visibleUserIds 対象は閲覧可。
  - `note_test.go`: real-DB の visibility push-down テスト (follow なし→public のみ、follow 後→followers も、visibleUserIds 追加後→specified も)。

## テスト

- `go test ./internal/api/notes/ ./internal/repository/` pass
- coverage: notes 91.8% / repository 90.0% (閾値クリア)
- `make fmt && make lint` clean

## Closes

Closes #1441