### PR TITLE
fix(notes): user-list-timeline に visibility filter を追加 (IDOR)

### DIFF
--- a/internal/api/notes/handler_extra.go
+++ b/internal/api/notes/handler_extra.go
@@ -185,6 +185,14 @@ func (h *Handler) UserListTimeline(c echo.Context) error {
 	if err != nil {
 		return c.JSON(http.StatusInternalServerError, apierr.Error("INTERNAL_ERROR", "Internal error.", "5d37dbcb-891e-41ca-a3d6-e690c97775ac"))
 	}
+	// list owner gate だけでは note の visibility を守れない。list メンバーは
+	// 自由に編集できるため、未フォローのアカウントを list に詰めれば followers
+	// visibility note を読めてしまう。BulkShow / ShowPartialBulk と同じく
+	// queryService 未配線なら fail-closed、配線済みなら CanSeeNote で絞る (#1442)。
+	if h.queryService == nil {
+		return c.JSON(http.StatusOK, []entity.NoteEntity{})
+	}
+	notes = h.queryService.FilterVisible(me, notes)
 	return c.JSON(http.StatusOK, h.packMany(c.Request().Context(), notes, me))
 }
 

--- a/internal/api/notes/handler_extra_test.go
+++ b/internal/api/notes/handler_extra_test.go
@@ -224,6 +224,82 @@ func TestUserListTimeline_InvalidParam(t *testing.T) {
 	assert.Equal(t, http.StatusBadRequest, rec.Code)
 }
 
+// userListNotesRepo は ListByUserList で固定の note を返す fake。mock の
+// ListByUserList は nil を返すため、FilterVisible の効果検証用に差し替える。
+type userListNotesRepo struct {
+	*testutil.MockNoteRepository
+	rows []*model.Note
+}
+
+func (r *userListNotesRepo) ListByUserList(_ string, _ int, _, _ string) ([]*model.Note, error) {
+	return r.rows, nil
+}
+
+// #1442: list owner gate だけでは note の visibility を守れない。list owner A が
+// 未フォローの B を list に詰めても、B の followers / specified note は A に返らない。
+// A が B の follower なら followers note は返る。
+func TestUserListTimeline_FiltersNonVisible(t *testing.T) {
+	pub := &model.Note{ID: "ul_pub", UserID: "B", Visibility: "public", User: &model.User{ID: "B"}}
+	fol := &model.Note{ID: "ul_fol", UserID: "B", Visibility: "followers", User: &model.User{ID: "B"}}
+	spec := &model.Note{ID: "ul_spec", UserID: "B", Visibility: "specified", VisibleUserIDs: []string{"other"}, User: &model.User{ID: "B"}}
+	noteRepo := &userListNotesRepo{MockNoteRepository: testutil.NewMockNoteRepository(), rows: []*model.Note{pub, fol, spec}}
+	fRepo := testutil.NewMockFollowingRepository()
+	listRepo := testutil.NewMockUserListRepository()
+	listRepo.Lists["l1"] = &model.UserList{ID: "l1", UserID: "A"}
+	pollRepo := testutil.NewMockPollRepository()
+	idGen, _ := id.NewGenerator("aidx")
+	querySvc := corenote.NewQueryService(noteRepo, fRepo)
+	h := NewHandler(noteRepo, corenote.NewCreateService(noteRepo, pollRepo, idGen, nil), corenote.NewDeleteService(noteRepo), querySvc, nil, nil, nil, nil, idGen)
+	h.SetUserListRepo(listRepo)
+
+	listTimelineIDs := func() map[string]bool {
+		rec := postExtra(h.UserListTimeline, `{"listId":"l1"}`, &model.User{ID: "A"})
+		require.Equal(t, http.StatusOK, rec.Code)
+		var out []map[string]any
+		require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &out))
+		ids := map[string]bool{}
+		for _, n := range out {
+			ids[n["id"].(string)] = true
+		}
+		return ids
+	}
+
+	// A は B を follow していない / specified 対象外 -> public のみ。
+	ids := listTimelineIDs()
+	assert.True(t, ids["ul_pub"], "public は list 経由で見える")
+	assert.False(t, ids["ul_fol"], "未フォローの followers note は list 経由でも漏らさない")
+	assert.False(t, ids["ul_spec"], "specified 対象外は list 経由でも漏らさない")
+
+	// A が B を follow すると followers note は見える (specified は依然対象外)。
+	fRepo.Followings["f1"] = &model.Following{ID: "f1", FollowerID: "A", FolloweeID: "B"}
+	ids = listTimelineIDs()
+	assert.True(t, ids["ul_pub"] && ids["ul_fol"], "follower には followers note が出る")
+	assert.False(t, ids["ul_spec"], "specified は follow しても visibleUserIds 対象外なら出ない")
+
+	// visibleUserIds に A を含めると specified も見える。
+	spec.VisibleUserIDs = []string{"A"}
+	ids = listTimelineIDs()
+	assert.True(t, ids["ul_spec"], "visibleUserIds 対象には specified が出る")
+}
+
+// queryService 未配線時は fail-closed で空配列 (visibility filter を経ずに
+// 全 note を返さない)。
+func TestUserListTimeline_NilQueryServiceFailsClosed(t *testing.T) {
+	noteRepo := &userListNotesRepo{MockNoteRepository: testutil.NewMockNoteRepository(), rows: []*model.Note{
+		{ID: "ul_fol", UserID: "B", Visibility: "followers", User: &model.User{ID: "B"}},
+	}}
+	listRepo := testutil.NewMockUserListRepository()
+	listRepo.Lists["l1"] = &model.UserList{ID: "l1", UserID: "A"}
+	idGen, _ := id.NewGenerator("aidx")
+	h := NewHandler(noteRepo, nil, nil, nil, nil, nil, nil, nil, idGen) // queryService=nil
+	h.SetUserListRepo(listRepo)
+	rec := postExtra(h.UserListTimeline, `{"listId":"l1"}`, &model.User{ID: "A"})
+	require.Equal(t, http.StatusOK, rec.Code)
+	var out []map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &out))
+	assert.Empty(t, out, "queryService 未配線なら fail-closed で空")
+}
+
 func TestUserListTimeline_WithoutUserListRepo(t *testing.T) {
 	// userListRepoがnilの場合は所有権チェックをスキップしてDBクエリに進む
 	h, _, _ := newExtraHandler(t)


### PR DESCRIPTION
## Summary

`notes/user-list-timeline` は list owner gate (自分の list のみ閲覧可) はあるが、note の visibility filter が無く `packMany` も hardMute のみ。list メンバーは自由に編集できるため、**未フォローのアカウントを list に詰めれば B の followers visibility note を読めてしまう** IDOR があった (specified も visibleUserIds 非対象で漏洩)。

## 修正方針 (option A)

issue #1442 の推奨どおり、`ListByUserList` の SQL push-down (user_list と following の 2 段 EXISTS) は複雑なため、handler 側で `queryService.FilterVisible` を挟む最小修正で塞ぐ。`BulkShow` / `ShowPartialBulk` (#509) と同じ規約・idiom:

- list owner gate の直後、`packMany` の前に `FilterVisible(me, notes)`。
- `queryService` 未配線なら fail-closed で空配列 (visibility を経ずに全 note を返さない)。

## 主な変更点

- `internal/api/notes/handler_extra.go` `UserListTimeline`: `FilterVisible` + nil-guard を追加。
- `internal/api/notes/handler_extra_test.go`:
  - `TestUserListTimeline_FiltersNonVisible`: 未フォローの followers/specified は除外、follow 後は followers が出る、visibleUserIds 対象は specified が出る。
  - `TestUserListTimeline_NilQueryServiceFailsClosed`: 未配線時 fail-closed。
  - `userListNotesRepo` fake で `ListByUserList` が固定 note を返すようにして FilterVisible の効果を検証。

## テスト

- `go test ./internal/api/notes/` pass、coverage 91.5%
- `make fmt && make lint` clean

## Closes

Closes #1442