### PR TITLE
fix(channels): channels/timeline の followers/specified note を非閲覧者に隠す (#1440)

### DIFF
--- a/internal/api/channels/handler.go
+++ b/internal/api/channels/handler.go
@@ -391,14 +391,21 @@ func (h *Handler) Timeline(c echo.Context) error {
 	}
 	// sinceDate / untilDate を aidx prefix に正規化 (#1166)。
 	sinceID, untilID := id.NormalizeCursor(req.SinceID, req.UntilID, req.SinceDate, req.UntilDate)
-	notes, err := h.svc.Timeline(req.ChannelID, untilID, sinceID, limit)
+	viewer := middleware.GetUser(c)
+	viewerID := ""
+	if viewer != nil {
+		viewerID = viewer.ID
+	}
+	// public channel に投稿された followers / specified note を非フォロワーに
+	// 返さないよう、visibility filter は service / repo 層で LIMIT 前に SQL
+	// push-down する (#1440)。
+	notes, err := h.svc.Timeline(req.ChannelID, viewerID, untilID, sinceID, limit)
 	if err != nil {
 		if errors.Is(err, corechannel.ErrChannelNotFound) {
 			return c.JSON(http.StatusNotFound, apierr.Error("NO_SUCH_CHANNEL", "No such channel.", "4d0eeeba-a02c-4c3c-9966-ef60d38d2e7f"))
 		}
 		return apierr.JSONInternalError(c)
 	}
-	viewer := middleware.GetUser(c)
 	notes = notesfilter.ApplyHardMute(h.userRepo, viewer, notes)
 	entities := entity.PackNotes(c.Request().Context(), notes, h.idGen, h.instanceLookup(), h.emojiLookup(), h.reactionReader())
 	h.fieldRes.Apply(entities, viewer)

--- a/internal/api/channels/handler_test.go
+++ b/internal/api/channels/handler_test.go
@@ -493,13 +493,63 @@ func TestTimeline_LimitClamping(t *testing.T) {
 	assert.Equal(t, http.StatusOK, rec.Code)
 }
 
-// failingNoteRepo: ListByChannelID returns an error so Timeline hits the
-// internal-error branch.
+// TestTimeline_HidesNonPublicFromOutsiders は public channel に投稿された
+// followers / specified note が非フォロワー / non-target viewer / 匿名に
+// 露出しないことを handler 層で固定する (#1440 IDOR)。
+func TestTimeline_HidesNonPublicFromOutsiders(t *testing.T) {
+	h, repo, _, noteRepo := newHandler(t)
+	repo.Channels["c1"] = &model.Channel{ID: "c1"}
+	cid := "c1"
+	noteRepo.Notes["n_pub"] = &model.Note{
+		ID: "n_pub", ChannelID: &cid, UserID: "author", Visibility: model.NoteVisibilityPublic,
+	}
+	noteRepo.Notes["n_fol"] = &model.Note{
+		ID: "n_fol", ChannelID: &cid, UserID: "author", Visibility: model.NoteVisibilityFollowers,
+	}
+	noteRepo.Notes["n_spec"] = &model.Note{
+		ID: "n_spec", ChannelID: &cid, UserID: "author",
+		Visibility:     model.NoteVisibilitySpecified,
+		VisibleUserIDs: []string{"allowed"},
+	}
+	noteRepo.Following["follower"] = []string{"author"}
+
+	cases := []struct {
+		name    string
+		viewer  string // 空文字 = 匿名
+		visible map[string]bool
+	}{
+		{"anonymous", "", map[string]bool{"n_pub": true}},
+		{"non-follower", "stranger", map[string]bool{"n_pub": true}},
+		{"non-target specified viewer", "stranger", map[string]bool{"n_pub": true}},
+		{"follower", "follower", map[string]bool{"n_pub": true, "n_fol": true}},
+		{"specified target", "allowed", map[string]bool{"n_pub": true, "n_spec": true}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			c, rec := newReq(t, `{"channelId":"c1","limit":50}`)
+			if tc.viewer != "" {
+				setUser(c, tc.viewer)
+			}
+			require.NoError(t, h.Timeline(c))
+			require.Equal(t, http.StatusOK, rec.Code)
+			var rows []map[string]any
+			require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &rows))
+			got := make(map[string]bool, len(rows))
+			for _, r := range rows {
+				got[r["id"].(string)] = true
+			}
+			assert.Equal(t, tc.visible, got)
+		})
+	}
+}
+
+// failingNoteRepo: ListByChannelIDVisible returns an error so Timeline hits the
+// internal-error branch (#1440 で service が ListByChannelIDVisible に切替)。
 type failingChannelNoteRepo struct {
 	*testutil.MockNoteRepository
 }
 
-func (r *failingChannelNoteRepo) ListByChannelID(_ string, _, _ string, _ int) ([]*model.Note, error) {
+func (r *failingChannelNoteRepo) ListByChannelIDVisible(_, _, _, _ string, _ int) ([]*model.Note, error) {
 	return nil, errors.New("boom")
 }
 

--- a/internal/api/channels/handler_test.go
+++ b/internal/api/channels/handler_test.go
@@ -543,13 +543,13 @@ func TestTimeline_HidesNonPublicFromOutsiders(t *testing.T) {
 	}
 }
 
-// failingNoteRepo: ListByChannelIDVisible returns an error so Timeline hits the
-// internal-error branch (#1440 で service が ListByChannelIDVisible に切替)。
+// failingChannelNoteRepo: ListByChannelID returns an error so Timeline hits the
+// internal-error branch (#1440 で service が visibility push-down 版に切替)。
 type failingChannelNoteRepo struct {
 	*testutil.MockNoteRepository
 }
 
-func (r *failingChannelNoteRepo) ListByChannelIDVisible(_, _, _, _ string, _ int) ([]*model.Note, error) {
+func (r *failingChannelNoteRepo) ListByChannelID(_, _, _, _ string, _ int) ([]*model.Note, error) {
 	return nil, errors.New("boom")
 }
 

--- a/internal/api/notes/handler_test.go
+++ b/internal/api/notes/handler_test.go
@@ -842,6 +842,9 @@ func (f *failingNoteRepo) ListByUserIDFiltered(_, _, _, _ string, _ int, _, _, _
 func (f *failingNoteRepo) ListByChannelID(_ string, _, _ string, _ int) ([]*model.Note, error) {
 	return nil, nil
 }
+func (f *failingNoteRepo) ListByChannelIDVisible(_, _, _, _ string, _ int) ([]*model.Note, error) {
+	return nil, nil
+}
 func (f *failingNoteRepo) FindManyByIDsWithUser(_ []string) ([]*model.Note, error) {
 	return nil, nil
 }

--- a/internal/api/notes/handler_test.go
+++ b/internal/api/notes/handler_test.go
@@ -839,10 +839,7 @@ func (f *failingNoteRepo) ListByUserID(_ string, _, _ string, _ int) ([]*model.N
 func (f *failingNoteRepo) ListByUserIDFiltered(_, _, _, _ string, _ int, _, _, _, _ bool) ([]*model.Note, error) {
 	return nil, nil
 }
-func (f *failingNoteRepo) ListByChannelID(_ string, _, _ string, _ int) ([]*model.Note, error) {
-	return nil, nil
-}
-func (f *failingNoteRepo) ListByChannelIDVisible(_, _, _, _ string, _ int) ([]*model.Note, error) {
+func (f *failingNoteRepo) ListByChannelID(_, _, _, _ string, _ int) ([]*model.Note, error) {
 	return nil, nil
 }
 func (f *failingNoteRepo) FindManyByIDsWithUser(_ []string) ([]*model.Note, error) {

--- a/internal/core/channel/channel_service.go
+++ b/internal/core/channel/channel_service.go
@@ -265,12 +265,15 @@ func (s *Service) Search(query, sinceID, untilID string, limit, offset int) ([]*
 	})
 }
 
-// Timeline returns notes posted to the channel, newest first.
-func (s *Service) Timeline(channelID, untilID, sinceID string, limit int) ([]*model.Note, error) {
+// Timeline returns notes posted to the channel, newest first. viewerID は
+// 閲覧者 ID (匿名は空文字)。public channel は誰でも見られるが、そこに投稿
+// された followers / specified note は viewer に応じて SQL で除外しないと
+// 非フォロワーへ流出する (#1440)。
+func (s *Service) Timeline(channelID, viewerID, untilID, sinceID string, limit int) ([]*model.Note, error) {
 	if _, err := s.repo.FindByID(channelID); err != nil {
 		return nil, ErrChannelNotFound
 	}
-	return s.noteRepo.ListByChannelID(channelID, untilID, sinceID, limit)
+	return s.noteRepo.ListByChannelIDVisible(channelID, viewerID, untilID, sinceID, limit)
 }
 
 // OnNotePosted updates lastNotedAt / notesCount and, when unreadRepo is

--- a/internal/core/channel/channel_service.go
+++ b/internal/core/channel/channel_service.go
@@ -273,7 +273,7 @@ func (s *Service) Timeline(channelID, viewerID, untilID, sinceID string, limit i
 	if _, err := s.repo.FindByID(channelID); err != nil {
 		return nil, ErrChannelNotFound
 	}
-	return s.noteRepo.ListByChannelIDVisible(channelID, viewerID, untilID, sinceID, limit)
+	return s.noteRepo.ListByChannelID(channelID, viewerID, untilID, sinceID, limit)
 }
 
 // OnNotePosted updates lastNotedAt / notesCount and, when unreadRepo is

--- a/internal/core/channel/channel_service_test.go
+++ b/internal/core/channel/channel_service_test.go
@@ -361,16 +361,68 @@ func TestTimeline_HappyPath(t *testing.T) {
 	svc, repo, _, noteRepo := newSvc(t)
 	repo.Channels["c1"] = &model.Channel{ID: "c1"}
 	cid := "c1"
-	noteRepo.Notes["n1"] = &model.Note{ID: "n1", ChannelID: &cid}
-	rows, err := svc.Timeline("c1", "", "", 10)
+	noteRepo.Notes["n1"] = &model.Note{ID: "n1", ChannelID: &cid, Visibility: model.NoteVisibilityPublic}
+	rows, err := svc.Timeline("c1", "", "", "", 10)
 	require.NoError(t, err)
 	assert.Len(t, rows, 1)
 }
 
 func TestTimeline_ChannelNotFound(t *testing.T) {
 	svc, _, _, _ := newSvc(t)
-	_, err := svc.Timeline("missing", "", "", 10)
+	_, err := svc.Timeline("missing", "", "", "", 10)
 	assert.ErrorIs(t, err, channel.ErrChannelNotFound)
+}
+
+// TestTimeline_VisibilityFilter は public channel に投稿された followers /
+// specified note が viewer 単位で適切に除外されることを固定する (#1440)。
+// 匿名 / 非フォロワー / specified 対象外の各 viewer ごとに、見えるはずの
+// note しか返ってこないことを確認する。
+func TestTimeline_VisibilityFilter(t *testing.T) {
+	svc, repo, _, noteRepo := newSvc(t)
+	repo.Channels["c1"] = &model.Channel{ID: "c1"}
+	cid := "c1"
+	author := "author"
+	follower := "follower"
+	allowed := "allowed"
+	stranger := "stranger"
+	// author を follow しているのは follower のみ。Mock の Following は
+	// followerID -> []followeeIDs (testutil/mock_repository.go の
+	// noteVisibleToViewer 経路で使われる)。
+	noteRepo.Following[follower] = []string{author}
+	noteRepo.Notes["n_pub"] = &model.Note{
+		ID: "n_pub", ChannelID: &cid, UserID: author, Visibility: model.NoteVisibilityPublic,
+	}
+	noteRepo.Notes["n_fol"] = &model.Note{
+		ID: "n_fol", ChannelID: &cid, UserID: author, Visibility: model.NoteVisibilityFollowers,
+	}
+	noteRepo.Notes["n_spec"] = &model.Note{
+		ID: "n_spec", ChannelID: &cid, UserID: author,
+		Visibility:     model.NoteVisibilitySpecified,
+		VisibleUserIDs: []string{allowed},
+	}
+
+	cases := []struct {
+		name    string
+		viewer  string
+		visible []string
+	}{
+		{"anonymous", "", []string{"n_pub"}},
+		{"stranger", stranger, []string{"n_pub"}},
+		{"follower", follower, []string{"n_pub", "n_fol"}},
+		{"specified target", allowed, []string{"n_pub", "n_spec"}},
+		{"author", author, []string{"n_pub", "n_fol", "n_spec"}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			rows, err := svc.Timeline("c1", tc.viewer, "", "", 50)
+			require.NoError(t, err)
+			got := make([]string, 0, len(rows))
+			for _, n := range rows {
+				got = append(got, n.ID)
+			}
+			assert.ElementsMatch(t, tc.visible, got)
+		})
+	}
 }
 
 // --- OnNotePosted ----------------------------------------------------------

--- a/internal/repository/note.go
+++ b/internal/repository/note.go
@@ -72,6 +72,13 @@ type NoteRepository interface {
 	// 判定の N+1 を避ける (#1418 review)。
 	ListByUserIDFiltered(userID, viewerID, untilID, sinceID string, limit int, withFiles, withReplies, withRenotes, withChannelNotes bool) ([]*model.Note, error)
 	ListByChannelID(channelID string, untilID, sinceID string, limit int) ([]*model.Note, error)
+	// ListByChannelIDVisible は ListByChannelID に visibility push-down を加えた版。
+	// channels/timeline は public channel 自体が誰でも閲覧可能だが、そこに投稿
+	// された note 個々の visibility (followers / specified) は viewer 単位で
+	// 絞らないと非フォロワーに followers note が流出する (IDOR, #1440)。
+	// viewerID 空文字は匿名 (public/home のみ)。条件は core/note.CanSeeNote と
+	// 一致 (clip_note.ListByClipVisible と同じ式)。
+	ListByChannelIDVisible(channelID, viewerID, untilID, sinceID string, limit int) ([]*model.Note, error)
 	FindManyByIDsWithUser(ids []string) ([]*model.Note, error)
 	ListRenotesOf(noteID string, untilID, sinceID string, limit int) ([]*model.Note, error)
 	ListRepliesOf(noteID string, untilID, sinceID string, limit int) ([]*model.Note, error)
@@ -325,8 +332,32 @@ func (r *noteRepository) ListByUserIDFiltered(userID, viewerID, untilID, sinceID
 
 // ListByChannelID returns notes posted to the channel.
 func (r *noteRepository) ListByChannelID(channelID string, untilID, sinceID string, limit int) ([]*model.Note, error) {
+	return r.listByChannelID(channelID, "", false, untilID, sinceID, limit)
+}
+
+// ListByChannelIDVisible is ListByChannelID with the visibility push-down enabled.
+func (r *noteRepository) ListByChannelIDVisible(channelID, viewerID, untilID, sinceID string, limit int) ([]*model.Note, error) {
+	return r.listByChannelID(channelID, viewerID, true, untilID, sinceID, limit)
+}
+
+func (r *noteRepository) listByChannelID(channelID, viewerID string, filterVisibility bool, untilID, sinceID string, limit int) ([]*model.Note, error) {
 	var notes []*model.Note
 	q := preloadNoteRelations(r.db).Where("\"channelId\" = ?", channelID)
+	if filterVisibility {
+		// core/note.CanSeeNote と同じ可視性条件を LIMIT 前に SQL で絞る。
+		// post-fetch filter だとページが過少充填されるのと followers 判定が
+		// note ごとの N+1 になるため LIMIT 前に push down する (#1440)。
+		if viewerID == "" {
+			q = q.Where(`"visibility" IN ('public','home')`)
+		} else {
+			q = q.Where(
+				`("visibility" IN ('public','home') `+
+					`OR "userId" = ? `+
+					`OR ("visibility" = 'followers' AND "userId" IN (SELECT f."followeeId" FROM "following" f WHERE f."followerId" = ?)) `+
+					`OR ("visibility" = 'specified' AND ? = ANY("visibleUserIds")))`,
+				viewerID, viewerID, viewerID)
+		}
+	}
 	if untilID != "" {
 		q = q.Where("id < ?", untilID)
 	}

--- a/internal/repository/note.go
+++ b/internal/repository/note.go
@@ -71,14 +71,15 @@ type NoteRepository interface {
 	// SQL で絞ることで、post-fetch filter によるページ過少充填と followers
 	// 判定の N+1 を避ける (#1418 review)。
 	ListByUserIDFiltered(userID, viewerID, untilID, sinceID string, limit int, withFiles, withReplies, withRenotes, withChannelNotes bool) ([]*model.Note, error)
-	ListByChannelID(channelID string, untilID, sinceID string, limit int) ([]*model.Note, error)
-	// ListByChannelIDVisible は ListByChannelID に visibility push-down を加えた版。
+	// ListByChannelID は channel の note を viewer の可視性で絞って返す。
 	// channels/timeline は public channel 自体が誰でも閲覧可能だが、そこに投稿
 	// された note 個々の visibility (followers / specified) は viewer 単位で
 	// 絞らないと非フォロワーに followers note が流出する (IDOR, #1440)。
 	// viewerID 空文字は匿名 (public/home のみ)。条件は core/note.CanSeeNote と
-	// 一致 (clip_note.ListByClipVisible と同じ式)。
-	ListByChannelIDVisible(channelID, viewerID, untilID, sinceID string, limit int) ([]*model.Note, error)
+	// 一致 (clip_note.ListByClipVisible と同じ式)。#1449 review で
+	// ListByChannelIDVisible を別メソッドに切り出さず本 signature に viewerID を
+	// 取り込む形に統合した (#1439 / #1441 と同じパターン)。
+	ListByChannelID(channelID, viewerID, untilID, sinceID string, limit int) ([]*model.Note, error)
 	FindManyByIDsWithUser(ids []string) ([]*model.Note, error)
 	ListRenotesOf(noteID string, untilID, sinceID string, limit int) ([]*model.Note, error)
 	ListRepliesOf(noteID string, untilID, sinceID string, limit int) ([]*model.Note, error)
@@ -330,33 +331,26 @@ func (r *noteRepository) ListByUserIDFiltered(userID, viewerID, untilID, sinceID
 	return notes, nil
 }
 
-// ListByChannelID returns notes posted to the channel.
-func (r *noteRepository) ListByChannelID(channelID string, untilID, sinceID string, limit int) ([]*model.Note, error) {
-	return r.listByChannelID(channelID, "", false, untilID, sinceID, limit)
-}
-
-// ListByChannelIDVisible is ListByChannelID with the visibility push-down enabled.
-func (r *noteRepository) ListByChannelIDVisible(channelID, viewerID, untilID, sinceID string, limit int) ([]*model.Note, error) {
-	return r.listByChannelID(channelID, viewerID, true, untilID, sinceID, limit)
-}
-
-func (r *noteRepository) listByChannelID(channelID, viewerID string, filterVisibility bool, untilID, sinceID string, limit int) ([]*model.Note, error) {
+// ListByChannelID returns notes posted to the channel that viewerID can see.
+// viewerID="" means anonymous (public/home only). Visibility conditions are
+// pushed down before LIMIT to mirror core/note.CanSeeNote and avoid the
+// underfilled-page / N+1 follower-check problems of post-fetch filtering
+// (#1440).
+func (r *noteRepository) ListByChannelID(channelID, viewerID, untilID, sinceID string, limit int) ([]*model.Note, error) {
 	var notes []*model.Note
 	q := preloadNoteRelations(r.db).Where("\"channelId\" = ?", channelID)
-	if filterVisibility {
-		// core/note.CanSeeNote と同じ可視性条件を LIMIT 前に SQL で絞る。
-		// post-fetch filter だとページが過少充填されるのと followers 判定が
-		// note ごとの N+1 になるため LIMIT 前に push down する (#1440)。
-		if viewerID == "" {
-			q = q.Where(`"visibility" IN ('public','home')`)
-		} else {
-			q = q.Where(
-				`("visibility" IN ('public','home') `+
-					`OR "userId" = ? `+
-					`OR ("visibility" = 'followers' AND "userId" IN (SELECT f."followeeId" FROM "following" f WHERE f."followerId" = ?)) `+
-					`OR ("visibility" = 'specified' AND ? = ANY("visibleUserIds")))`,
-				viewerID, viewerID, viewerID)
-		}
+	// core/note.CanSeeNote と同じ可視性条件を LIMIT 前に SQL で絞る。
+	// post-fetch filter だとページが過少充填されるのと followers 判定が
+	// note ごとの N+1 になるため LIMIT 前に push down する (#1440)。
+	if viewerID == "" {
+		q = q.Where(`"visibility" IN ('public','home')`)
+	} else {
+		q = q.Where(
+			`("visibility" IN ('public','home') `+
+				`OR "userId" = ? `+
+				`OR ("visibility" = 'followers' AND "userId" IN (SELECT f."followeeId" FROM "following" f WHERE f."followerId" = ?)) `+
+				`OR ("visibility" = 'specified' AND ? = ANY("visibleUserIds")))`,
+			viewerID, viewerID, viewerID)
 	}
 	if untilID != "" {
 		q = q.Where("id < ?", untilID)

--- a/internal/repository/note_test.go
+++ b/internal/repository/note_test.go
@@ -340,6 +340,85 @@ func TestNoteRepository_ListByChannelID(t *testing.T) {
 	assert.Len(t, rows, 3)
 }
 
+// TestNoteRepository_ListByChannelIDVisible は channels/timeline の visibility
+// push-down (#1440 IDOR) を SQL 段階で検証する。public channel に
+// followers / specified visibility の note を混在させ、viewer ごとに見える
+// note が変わること、および ListByChannelID (filter なし) は全件返すことを
+// 確認する。
+func TestNoteRepository_ListByChannelIDVisible(t *testing.T) {
+	repo := NewNoteRepository(testDB)
+	chRepo := NewChannelRepository(testDB)
+	followingRepo := NewFollowingRepository(testDB)
+
+	mkUser := func(id, username string) *model.User {
+		u := insertTestUser(t, id, username)
+		t.Cleanup(func() { cleanupUser(t, u.ID) })
+		return u
+	}
+	author := mkUser("u_cv_a", "cvauthor")
+	follower := mkUser("u_cv_f", "cvfollower")
+	allowed := mkUser("u_cv_al", "cvallowed")
+
+	uid := author.ID
+	ch := newTestChannel("ch_cv_1", "channel-vis", &uid)
+	require.NoError(t, chRepo.Create(ch))
+	defer cleanupChannel(t, ch.ID)
+
+	cid := ch.ID
+	notes := []*model.Note{
+		{ID: "n_cv_pub", UserID: author.ID, ChannelID: &cid, Visibility: model.NoteVisibilityPublic, Reactions: datatypes.JSON([]byte("{}"))},
+		{ID: "n_cv_fol", UserID: author.ID, ChannelID: &cid, Visibility: model.NoteVisibilityFollowers, Reactions: datatypes.JSON([]byte("{}"))},
+		{ID: "n_cv_spec", UserID: author.ID, ChannelID: &cid, Visibility: model.NoteVisibilitySpecified, VisibleUserIDs: pq.StringArray{allowed.ID}, Reactions: datatypes.JSON([]byte("{}"))},
+	}
+	for _, n := range notes {
+		require.NoError(t, repo.Create(n))
+		defer cleanupNote(t, n.ID)
+	}
+
+	f := &model.Following{ID: "fl_cv_1", FollowerID: follower.ID, FolloweeID: author.ID}
+	require.NoError(t, followingRepo.Create(f))
+	defer testDB.Exec(`DELETE FROM "following" WHERE id = ?`, f.ID)
+
+	idsOf := func(rows []*model.Note) []string {
+		out := make([]string, 0, len(rows))
+		for _, r := range rows {
+			out = append(out, r.ID)
+		}
+		sort.Strings(out)
+		return out
+	}
+
+	// ListByChannelID (filter なし) は全件返す。
+	rows, err := repo.ListByChannelID(ch.ID, "", "", 50)
+	require.NoError(t, err)
+	assert.Equal(t, []string{"n_cv_fol", "n_cv_pub", "n_cv_spec"}, idsOf(rows))
+
+	// 匿名 viewer: public のみ。followers / specified が漏れない (#1440)。
+	rows, err = repo.ListByChannelIDVisible(ch.ID, "", "", "", 50)
+	require.NoError(t, err)
+	assert.Equal(t, []string{"n_cv_pub"}, idsOf(rows))
+
+	// 非 follower viewer に followers note は見えない。
+	rows, err = repo.ListByChannelIDVisible(ch.ID, "u_cv_stranger", "", "", 50)
+	require.NoError(t, err)
+	assert.Equal(t, []string{"n_cv_pub"}, idsOf(rows))
+
+	// follower viewer は public + followers。
+	rows, err = repo.ListByChannelIDVisible(ch.ID, follower.ID, "", "", 50)
+	require.NoError(t, err)
+	assert.Equal(t, []string{"n_cv_fol", "n_cv_pub"}, idsOf(rows))
+
+	// specified 対象 viewer は public + specified。
+	rows, err = repo.ListByChannelIDVisible(ch.ID, allowed.ID, "", "", 50)
+	require.NoError(t, err)
+	assert.Equal(t, []string{"n_cv_pub", "n_cv_spec"}, idsOf(rows))
+
+	// author 本人は全 visibility を閲覧可。
+	rows, err = repo.ListByChannelIDVisible(ch.ID, author.ID, "", "", 50)
+	require.NoError(t, err)
+	assert.Equal(t, []string{"n_cv_fol", "n_cv_pub", "n_cv_spec"}, idsOf(rows))
+}
+
 func TestNoteRepository_FindByURI(t *testing.T) {
 	repo := NewNoteRepository(testDB)
 	user := insertTestUser(t, "u_nuri_1", "noteuser_uri")
@@ -667,6 +746,12 @@ func TestNoteRepository_QueryErrors(t *testing.T) {
 	assert.Error(t, err)
 
 	_, err = repo.ListByChannelID("a", "", "", 10)
+	assert.Error(t, err)
+
+	_, err = repo.ListByChannelIDVisible("a", "", "", "", 10)
+	assert.Error(t, err)
+
+	_, err = repo.ListByChannelIDVisible("a", "viewer", "", "", 10)
 	assert.Error(t, err)
 
 	_, err = repo.FindManyByIDsWithUser([]string{"a"})

--- a/internal/repository/note_test.go
+++ b/internal/repository/note_test.go
@@ -323,29 +323,30 @@ func TestNoteRepository_ListByChannelID(t *testing.T) {
 		defer cleanupNote(t, note.ID)
 	}
 
-	rows, err := repo.ListByChannelID(ch.ID, "", "", 10)
+	// すべて public note なので匿名 viewer (viewerID="") でも全件見える。
+	// visibility push-down (#1440 / #1449) の matrix は別 test で確認する。
+	rows, err := repo.ListByChannelID(ch.ID, "", "", "", 10)
 	require.NoError(t, err)
 	assert.Len(t, rows, 3)
 
-	rows, err = repo.ListByChannelID(ch.ID, "n_lc_3", "", 10)
+	rows, err = repo.ListByChannelID(ch.ID, "", "n_lc_3", "", 10)
 	require.NoError(t, err)
 	assert.Len(t, rows, 2)
 
-	rows, err = repo.ListByChannelID(ch.ID, "", "n_lc_1", 10)
+	rows, err = repo.ListByChannelID(ch.ID, "", "", "n_lc_1", 10)
 	require.NoError(t, err)
 	assert.Len(t, rows, 2)
 
-	rows, err = repo.ListByChannelID(ch.ID, "", "", 0) // 0 → default 30
+	rows, err = repo.ListByChannelID(ch.ID, "", "", "", 0) // 0 → default 30
 	require.NoError(t, err)
 	assert.Len(t, rows, 3)
 }
 
-// TestNoteRepository_ListByChannelIDVisible は channels/timeline の visibility
+// TestNoteRepository_ListByChannelID_Visibility は channels/timeline の visibility
 // push-down (#1440 IDOR) を SQL 段階で検証する。public channel に
 // followers / specified visibility の note を混在させ、viewer ごとに見える
-// note が変わること、および ListByChannelID (filter なし) は全件返すことを
-// 確認する。
-func TestNoteRepository_ListByChannelIDVisible(t *testing.T) {
+// note が変わることを matrix で確認する (#1449 review で signature 統合)。
+func TestNoteRepository_ListByChannelID_Visibility(t *testing.T) {
 	repo := NewNoteRepository(testDB)
 	chRepo := NewChannelRepository(testDB)
 	followingRepo := NewFollowingRepository(testDB)
@@ -388,33 +389,28 @@ func TestNoteRepository_ListByChannelIDVisible(t *testing.T) {
 		return out
 	}
 
-	// ListByChannelID (filter なし) は全件返す。
-	rows, err := repo.ListByChannelID(ch.ID, "", "", 50)
-	require.NoError(t, err)
-	assert.Equal(t, []string{"n_cv_fol", "n_cv_pub", "n_cv_spec"}, idsOf(rows))
-
 	// 匿名 viewer: public のみ。followers / specified が漏れない (#1440)。
-	rows, err = repo.ListByChannelIDVisible(ch.ID, "", "", "", 50)
+	rows, err := repo.ListByChannelID(ch.ID, "", "", "", 50)
 	require.NoError(t, err)
 	assert.Equal(t, []string{"n_cv_pub"}, idsOf(rows))
 
 	// 非 follower viewer に followers note は見えない。
-	rows, err = repo.ListByChannelIDVisible(ch.ID, "u_cv_stranger", "", "", 50)
+	rows, err = repo.ListByChannelID(ch.ID, "u_cv_stranger", "", "", 50)
 	require.NoError(t, err)
 	assert.Equal(t, []string{"n_cv_pub"}, idsOf(rows))
 
 	// follower viewer は public + followers。
-	rows, err = repo.ListByChannelIDVisible(ch.ID, follower.ID, "", "", 50)
+	rows, err = repo.ListByChannelID(ch.ID, follower.ID, "", "", 50)
 	require.NoError(t, err)
 	assert.Equal(t, []string{"n_cv_fol", "n_cv_pub"}, idsOf(rows))
 
 	// specified 対象 viewer は public + specified。
-	rows, err = repo.ListByChannelIDVisible(ch.ID, allowed.ID, "", "", 50)
+	rows, err = repo.ListByChannelID(ch.ID, allowed.ID, "", "", 50)
 	require.NoError(t, err)
 	assert.Equal(t, []string{"n_cv_pub", "n_cv_spec"}, idsOf(rows))
 
 	// author 本人は全 visibility を閲覧可。
-	rows, err = repo.ListByChannelIDVisible(ch.ID, author.ID, "", "", 50)
+	rows, err = repo.ListByChannelID(ch.ID, author.ID, "", "", 50)
 	require.NoError(t, err)
 	assert.Equal(t, []string{"n_cv_fol", "n_cv_pub", "n_cv_spec"}, idsOf(rows))
 }
@@ -745,13 +741,12 @@ func TestNoteRepository_QueryErrors(t *testing.T) {
 	_, err := repo.ListByUserID("a", "", "", 10)
 	assert.Error(t, err)
 
-	_, err = repo.ListByChannelID("a", "", "", 10)
+	// 匿名 viewer (public/home only) と認証 viewer (full visibility 句) の
+	// 双方で DB error が propagate することを確認 (#1449)。
+	_, err = repo.ListByChannelID("a", "", "", "", 10)
 	assert.Error(t, err)
 
-	_, err = repo.ListByChannelIDVisible("a", "", "", "", 10)
-	assert.Error(t, err)
-
-	_, err = repo.ListByChannelIDVisible("a", "viewer", "", "", 10)
+	_, err = repo.ListByChannelID("a", "viewer", "", "", 10)
 	assert.Error(t, err)
 
 	_, err = repo.FindManyByIDsWithUser([]string{"a"})

--- a/internal/testutil/mock_repository.go
+++ b/internal/testutil/mock_repository.go
@@ -751,6 +751,7 @@ func NewMockNoteRepository() *MockNoteRepository {
 	return &MockNoteRepository{
 		Notes:          make(map[string]*model.Note),
 		ReactionCounts: make(map[string]map[string]int),
+		Following:      make(map[string][]string),
 	}
 }
 
@@ -993,6 +994,17 @@ func (m *MockNoteRepository) listFiltered(filter func(*model.Note) bool, untilID
 func (m *MockNoteRepository) ListByChannelID(channelID string, untilID, sinceID string, limit int) ([]*model.Note, error) {
 	return m.listFiltered(func(n *model.Note) bool {
 		return n.ChannelID != nil && *n.ChannelID == channelID
+	}, untilID, sinceID, limit), nil
+}
+
+// ListByChannelIDVisible mirrors the real repo's visibility push-down for
+// channels/timeline (#1440).
+func (m *MockNoteRepository) ListByChannelIDVisible(channelID, viewerID, untilID, sinceID string, limit int) ([]*model.Note, error) {
+	return m.listFiltered(func(n *model.Note) bool {
+		if n.ChannelID == nil || *n.ChannelID != channelID {
+			return false
+		}
+		return m.canViewerSeeNote(viewerID, n)
 	}, untilID, sinceID, limit), nil
 }
 

--- a/internal/testutil/mock_repository.go
+++ b/internal/testutil/mock_repository.go
@@ -989,17 +989,9 @@ func (m *MockNoteRepository) listFiltered(filter func(*model.Note) bool, untilID
 	return out
 }
 
-// ListByChannelID returns notes posted to the given channel using the
-// shared listFiltered helper (paginationOrder: ASC when sinceID-only, DESC otherwise).
-func (m *MockNoteRepository) ListByChannelID(channelID string, untilID, sinceID string, limit int) ([]*model.Note, error) {
-	return m.listFiltered(func(n *model.Note) bool {
-		return n.ChannelID != nil && *n.ChannelID == channelID
-	}, untilID, sinceID, limit), nil
-}
-
-// ListByChannelIDVisible mirrors the real repo's visibility push-down for
-// channels/timeline (#1440).
-func (m *MockNoteRepository) ListByChannelIDVisible(channelID, viewerID, untilID, sinceID string, limit int) ([]*model.Note, error) {
+// ListByChannelID mirrors the real repo's visibility push-down for
+// channels/timeline (#1440). viewerID="" は匿名 (public/home のみ)。
+func (m *MockNoteRepository) ListByChannelID(channelID, viewerID, untilID, sinceID string, limit int) ([]*model.Note, error) {
 	return m.listFiltered(func(n *model.Note) bool {
 		if n.ChannelID == nil || *n.ChannelID != channelID {
 			return false


### PR DESCRIPTION
## Summary

`channels/timeline` が public channel に投稿された followers / specified visibility の note を viewer の関係性に関係なく全閲覧者に返してしまう IDOR を修正する。

`#1418` (clips/notes) と同じ SQL push-down 方式で、`core/note.CanSeeNote` 相当の可視性条件を LIMIT 前に絞り込む。

## 主な変更点

### production

- `internal/repository/note.go`: `ListByChannelIDVisible(channelID, viewerID, untilID, sinceID, limit)` を新設。`clip_note.ListByClipVisible` (#1418) と揃えた visibility 条件 (public/home / author 本人 / followers + following EXISTS / specified + ANY visibleUserIds) を `listByChannelID` 内に統合 (filter on/off の bool で `ListByChannelID` と共有)。
- `internal/core/channel/channel_service.go`: `Service.Timeline` の signature に `viewerID` を追加し、新 repo メソッドを呼ぶように切替。
- `internal/api/channels/handler.go`: `Handler.Timeline` で `middleware.GetUser(c)` から `viewerID` を抽出して service に流す (匿名は空文字)。

### test

- `internal/repository/note_test.go`: `TestNoteRepository_ListByChannelIDVisible` を追加。匿名 / 非 follower / follower / specified target / author の各 viewer で見えるべき note のみが返ることを SQL 段で固定。`ListByChannelID` (filter なし) は全件返すことも併せて確認。`TestNoteRepository_QueryErrors` にも error path を追加。
- `internal/core/channel/channel_service_test.go`: `TestTimeline_VisibilityFilter` で同じ viewer matrix を service 層でも固定。既存 `TestTimeline_HappyPath` / `TestTimeline_ChannelNotFound` も新 signature に追従。
- `internal/api/channels/handler_test.go`: `TestTimeline_HidesNonPublicFromOutsiders` を追加。`failingChannelNoteRepo` の error injection も `ListByChannelIDVisible` に切替。
- `internal/testutil/mock_repository.go`: `MockNoteRepository.ListByChannelIDVisible` を `noteVisibleToViewer` ヘルパー経由で実装。`Following` map の lazy nil を避けるため `NewMockNoteRepository` で初期化。
- `internal/api/notes/handler_test.go`: 既存 `failingNoteRepo` stub にも `ListByChannelIDVisible` を追加 (interface 充足のため)。

## テスト

- `make fmt && make lint` clean
- `TEST_DB_PORT=5433 go test -race -count=1 -timeout 5m ./internal/api/channels/... ./internal/core/channel/... ./internal/repository/...` green
  - `internal/api/channels`: 92.7%
  - `internal/core/channel`: 98.2%
  - `internal/repository`: 90.0% (新 `ListByChannelIDVisible` / `listByChannelID` は 100%)
- フルテスト走行で本変更に起因する failure なし (= 既存の `safehttp` IPv6 SSRF / `e2e_federation` second-DB は develop の HEAD でも同じ failure を確認済み、本 PR 対象外)。

### 手元での再現可能性

\`\`\`bash
TEST_DB_PORT=5433 go test -race -count=1 -timeout 5m \\
  -run \"ListByChannelID\" ./internal/repository/
TEST_DB_PORT=5433 go test -race -count=1 -timeout 5m \\
  ./internal/api/channels/... ./internal/core/channel/...
\`\`\`

## Closes

Closes #1440

## 関連

- #1418 (clips/notes / users/notes visibility push-down — 同じ SQL 形)
- #1439 (search-by-tag, 同 batch)
- #1006 (Note 通知 visibility filter)

🤖 Generated with [Claude Code](https://claude.com/claude-code)