### PR TITLE
fix(notifications): i/notifications の note embed に visibility check を追加 (#1444)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Fix: `useObjectStorage = true` のインスタンスで、`storedInternal = true` なドライブファイルへの `/files/:accessKey` アクセスが常に 404 になる問題を修正 (Misskey TS からの S3 移行前に保存されたローカルファイルが、移行後もアクセス可能に)
 - Fix: Misskey TS から mk-go に移行した直後、既に期限切れだったアンケートに対してアンケート終了 (pollEnded) 通知が一斉発火する問題を修正 (移行時 backfill migration を追加)
 - Fix: 配送先が一時的にダウンしている場合に、deliver/inbox ジョブが設定省略時にリトライされない問題を修正 (既定の試行回数を Misskey 本家と同じ deliver=12 / inbox=8 に。従来の no-retry 挙動が必要な場合は `deliverJobMaxAttempts` / `inboxJobMaxAttempts` に 1 を指定)
+- Fix: `/api/i/notifications` の通知 payload に埋め込まれるノート本体が公開範囲チェックを経ずに返り、フォロワー限定ノートがリプライ通知などを介して非フォロワーに漏れる問題を修正
 
 ## 0.9.2
 

--- a/internal/api/notifications/handler.go
+++ b/internal/api/notifications/handler.go
@@ -8,6 +8,7 @@ import (
 	"github.com/labstack/echo/v4"
 	"github.com/shiroha-a/mk/internal/api/apierr"
 	"github.com/shiroha-a/mk/internal/api/pagination"
+	corenote "github.com/shiroha-a/mk/internal/core/note"
 	"github.com/shiroha-a/mk/internal/core/notification"
 	"github.com/shiroha-a/mk/internal/entity"
 	"github.com/shiroha-a/mk/internal/misc/id"
@@ -22,6 +23,7 @@ type Handler struct {
 	idGen         id.Generator
 	userRepo      repository.UserRepository
 	noteRepo      repository.NoteRepository
+	queryService  *corenote.QueryService
 	followReqRepo repository.FollowRequestRepository
 	instanceRepo  repository.InstanceRepository
 	emojiRepo     repository.EmojiRepository
@@ -67,6 +69,15 @@ func (h *Handler) emojiLookup() entity.EmojiLookup {
 		return nil
 	}
 	return h.emojiRepo
+}
+
+// SetQueryService attaches a note QueryService used to gate embedded notes by
+// viewer visibility. #1444 で「i/notifications の note embed が CanSeeNote
+// check 無しで followers / specified note を漏らす」IDOR を塞ぐ。未配線の
+// 場合は fail-closed として note embed 自体を丸ごと skip する (production の
+// router.go は必ず wire する)。
+func (h *Handler) SetQueryService(qs *corenote.QueryService) {
+	h.queryService = qs
 }
 
 // SetFollowRequestRepo attaches a FollowRequestRepository. 受信済み
@@ -182,14 +193,24 @@ func (h *Handler) Show(c echo.Context) error {
 			}
 		}
 	}
+	// noteByID 構築には CanSeeNote ゲートを挟む。followers / specified note は
+	// 通知 recipient が author の follower でない / visibleUserIds に含まれない
+	// 場合に embed を nil 化する。これが無いと B の followers note への reply
+	// 通知経由で「A が B を follow していなくても」B の full note + author が
+	// 漏れる (#1444 IDOR)。通知行自体は残し、note field だけ落とすことで本家
+	// NotificationEntityService と同じ shape (noteId は残るが detail は無い) を
+	// 維持する。queryService 未配線時は fail-closed で note embed を完全 skip
+	// する (= production router は必ず wire、test の partial setup を漏れに
+	// 繋げない)。
 	noteByID := make(map[string]*model.Note, len(noteIDSet))
-	if h.noteRepo != nil && len(noteIDSet) > 0 {
+	if h.noteRepo != nil && h.queryService != nil && len(noteIDSet) > 0 {
 		ids := make([]string, 0, len(noteIDSet))
 		for id := range noteIDSet {
 			ids = append(ids, id)
 		}
 		if notes, err := h.noteRepo.FindManyByIDsWithUser(ids); err == nil {
-			for _, nn := range notes {
+			visible := h.queryService.FilterVisible(user, notes)
+			for _, nn := range visible {
 				noteByID[nn.ID] = nn
 			}
 		}

--- a/internal/api/notifications/handler_test.go
+++ b/internal/api/notifications/handler_test.go
@@ -16,6 +16,7 @@ import (
 
 	"github.com/labstack/echo/v4"
 	"github.com/redis/go-redis/v9"
+	corenote "github.com/shiroha-a/mk/internal/core/note"
 	"github.com/shiroha-a/mk/internal/core/notification"
 	"github.com/shiroha-a/mk/internal/entitycompat/shapetest"
 	"github.com/shiroha-a/mk/internal/misc/id"
@@ -424,6 +425,7 @@ func TestShow_WithUserAndNoteResolution(t *testing.T) {
 	userRepo.Users["bob"] = &model.User{ID: "bob", Username: "bobuser"}
 	noteRepo.Notes["n1"] = &model.Note{ID: "n1", UserID: "bob", Visibility: "public", User: &model.User{ID: "bob", Username: "bobuser"}}
 	h.SetRepos(userRepo, noteRepo)
+	h.SetQueryService(corenote.NewQueryService(noteRepo, testutil.NewMockFollowingRepository()))
 
 	ctx := context.Background()
 	_, err := svc.Create(ctx, notification.CreateInput{
@@ -600,6 +602,7 @@ func TestShow_BatchFetchesNotifierAndNote(t *testing.T) {
 			User: &model.User{ID: uid, Username: uid}}
 	}
 	h.SetRepos(userRepo, noteRepo)
+	h.SetQueryService(corenote.NewQueryService(noteRepo, testutil.NewMockFollowingRepository()))
 
 	ctx := context.Background()
 	for i := 0; i < 5; i++ {
@@ -638,4 +641,151 @@ func TestShow_BatchFetchesNotifierAndNote(t *testing.T) {
 		assert.NotNilf(t, item["user"], "item[%d].user must be present", i)
 		assert.NotNilf(t, item["note"], "item[%d].note must be present", i)
 	}
+}
+
+// #1444 IDOR: B が followers note で A に reply した時、A (= B を follow して
+// いない recipient) の通知一覧で note embed が CanSeeNote で gate され、
+// 通知行は残るが `note` field が落ちることを確認する (本家
+// NotificationEntityService と同じ shape)。`noteId` は echo されるので
+// frontend が note id だけ拾って後段 API で 404 を貰うことは可能だが、
+// 全文 / author / visibleUserIds などの leak は止まる。
+func TestShow_FollowersReply_NonFollower_NoteHidden(t *testing.T) {
+	h, svc := newTestHandler(t)
+	userRepo := testutil.NewMockUserRepository()
+	noteRepo := testutil.NewMockNoteRepository()
+	followingRepo := testutil.NewMockFollowingRepository()
+	userRepo.Users["bob"] = &model.User{ID: "bob", Username: "bobuser"}
+	noteRepo.Notes["n1"] = &model.Note{
+		ID: "n1", UserID: "bob", Visibility: model.NoteVisibilityFollowers,
+		User: &model.User{ID: "bob", Username: "bobuser"},
+	}
+	// alice → bob の follow 関係は設定しない (= 非フォロワー視点)
+	h.SetRepos(userRepo, noteRepo)
+	h.SetQueryService(corenote.NewQueryService(noteRepo, followingRepo))
+
+	ctx := context.Background()
+	_, err := svc.Create(ctx, notification.CreateInput{
+		NotifieeID: "alice", NotifierID: "bob", Type: notification.TypeReply, NoteID: "n1",
+	})
+	require.NoError(t, err)
+
+	c, rec := newJSONRequest(t, "/api/i/notifications", `{}`)
+	setAuth(c, &model.User{ID: "alice"})
+	require.NoError(t, h.Show(c))
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	var resp []map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+	require.Len(t, resp, 1, "通知行自体は残ること (= IDOR 修正で通知を消すのではなく embed のみ落とす)")
+	assert.Equal(t, "reply", resp[0]["type"])
+	assert.Equal(t, "n1", resp[0]["noteId"], "noteId は echo される (本家 shape 互換)")
+	_, hasNote := resp[0]["note"]
+	assert.False(t, hasNote, "followers note の full body が非フォロワーに漏れないこと (#1444)")
+}
+
+// 上記の positive counterpart: A が B を follow していれば followers reply
+// 通知でも note が full で取れる (= 正当 viewer は regression しない)。
+func TestShow_FollowersReply_Follower_NoteVisible(t *testing.T) {
+	h, svc := newTestHandler(t)
+	userRepo := testutil.NewMockUserRepository()
+	noteRepo := testutil.NewMockNoteRepository()
+	followingRepo := testutil.NewMockFollowingRepository()
+	userRepo.Users["bob"] = &model.User{ID: "bob", Username: "bobuser"}
+	noteRepo.Notes["n1"] = &model.Note{
+		ID: "n1", UserID: "bob", Visibility: model.NoteVisibilityFollowers,
+		User: &model.User{ID: "bob", Username: "bobuser"},
+	}
+	// alice → bob の follow 関係を張る (CanSeeNote の followers branch が
+	// followingRepo.Exists(alice, bob) で true を返す状況)。
+	followingRepo.Followings["alice-bob"] = &model.Following{
+		ID: "alice-bob", FollowerID: "alice", FolloweeID: "bob",
+	}
+	h.SetRepos(userRepo, noteRepo)
+	h.SetQueryService(corenote.NewQueryService(noteRepo, followingRepo))
+
+	ctx := context.Background()
+	_, err := svc.Create(ctx, notification.CreateInput{
+		NotifieeID: "alice", NotifierID: "bob", Type: notification.TypeReply, NoteID: "n1",
+	})
+	require.NoError(t, err)
+
+	c, rec := newJSONRequest(t, "/api/i/notifications", `{}`)
+	setAuth(c, &model.User{ID: "alice"})
+	require.NoError(t, h.Show(c))
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	var resp []map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+	require.Len(t, resp, 1)
+	assert.Equal(t, "reply", resp[0]["type"])
+	assert.NotNil(t, resp[0]["note"], "follower 視点では followers note が full で見えること")
+}
+
+// regression guard: 自分の note への reaction 通知では引き続き note が full で
+// 取れる (= viewer = author の typical case が #1444 修正で壊れていないこと)。
+func TestShow_OwnNoteReaction_NoteVisible(t *testing.T) {
+	h, svc := newTestHandler(t)
+	userRepo := testutil.NewMockUserRepository()
+	noteRepo := testutil.NewMockNoteRepository()
+	userRepo.Users["bob"] = &model.User{ID: "bob", Username: "bobuser"}
+	// alice 自身の followers note。reaction は bob から来る。
+	noteRepo.Notes["n1"] = &model.Note{
+		ID: "n1", UserID: "alice", Visibility: model.NoteVisibilityFollowers,
+		User: &model.User{ID: "alice", Username: "alice"},
+	}
+	h.SetRepos(userRepo, noteRepo)
+	h.SetQueryService(corenote.NewQueryService(noteRepo, testutil.NewMockFollowingRepository()))
+
+	ctx := context.Background()
+	_, err := svc.Create(ctx, notification.CreateInput{
+		NotifieeID: "alice", NotifierID: "bob", Type: notification.TypeReaction,
+		NoteID: "n1", Reaction: "👍",
+	})
+	require.NoError(t, err)
+
+	c, rec := newJSONRequest(t, "/api/i/notifications", `{}`)
+	setAuth(c, &model.User{ID: "alice"})
+	require.NoError(t, h.Show(c))
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	var resp []map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+	require.Len(t, resp, 1)
+	assert.Equal(t, "reaction", resp[0]["type"])
+	assert.NotNil(t, resp[0]["note"], "viewer = author の reaction 通知では note が full で取れること")
+}
+
+// fail-closed: queryService 未配線 + noteRepo 配線という partial setup でも
+// note embed が漏れないこと。production の router.go では必ず queryService が
+// wire されるが、テスト / future refactor で wire 漏れが起きても #1444 IDOR
+// が再発しない安全網。
+func TestShow_QueryServiceNil_NoteEmbedDropped(t *testing.T) {
+	h, svc := newTestHandler(t)
+	userRepo := testutil.NewMockUserRepository()
+	noteRepo := testutil.NewMockNoteRepository()
+	userRepo.Users["bob"] = &model.User{ID: "bob", Username: "bobuser"}
+	noteRepo.Notes["n1"] = &model.Note{
+		ID: "n1", UserID: "bob", Visibility: model.NoteVisibilityPublic,
+		User: &model.User{ID: "bob", Username: "bobuser"},
+	}
+	h.SetRepos(userRepo, noteRepo)
+	// あえて SetQueryService を呼ばない。
+
+	ctx := context.Background()
+	_, err := svc.Create(ctx, notification.CreateInput{
+		NotifieeID: "alice", NotifierID: "bob", Type: notification.TypeMention, NoteID: "n1",
+	})
+	require.NoError(t, err)
+
+	c, rec := newJSONRequest(t, "/api/i/notifications", `{}`)
+	setAuth(c, &model.User{ID: "alice"})
+	require.NoError(t, h.Show(c))
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	var resp []map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+	require.Len(t, resp, 1)
+	_, hasNote := resp[0]["note"]
+	assert.False(t, hasNote, "queryService 未配線時は fail-closed で note embed を skip すること")
+	assert.Equal(t, "n1", resp[0]["noteId"], "noteId 自体は echo される")
 }

--- a/internal/server/router.go
+++ b/internal/server/router.go
@@ -1385,6 +1385,7 @@ func (s *Server) setupRoutes() {
 	// Notifications endpoints
 	notificationsHandler := notifications.NewHandler(notificationService, idGen)
 	notificationsHandler.SetRepos(userRepo, noteRepo)
+	notificationsHandler.SetQueryService(noteQueryService)
 	notificationsHandler.SetFollowRequestRepo(followRequestRepo)
 	notificationsHandler.SetInstanceRepo(instanceRepo)
 	notificationsHandler.SetEmojiRepo(emojiRepo)


### PR DESCRIPTION
## Summary

`/api/i/notifications` で notification payload に embed する note を bulk fetch する経路に `CanSeeNote` 検査が無く、followers visibility note を非フォロワー recipient に漏らす IDOR を修正する。

例: B (followers visibility 利用者) が recipient A の note に reply / quote した場合、A が B を follow していなくても reply / quote 通知の `note` field 経由で B の full note + author + visibleUserIds が leak していた。

#1006 で row レベルの notification visibility filter (= 不可視 note を含む通知行を破棄) は入っているが、**embed される note 本体のチェックは別経路** として残っていた。upstream Misskey TS の `NotificationEntityService` は `noteEntityService.pack(noteId, { id: meId }, { detail: true })` 経由で note packer 側 visibility に委ねる設計だが、mk-go は packer が pre-filtered 前提なので handler 側で filter する必要があった。#1443 と同じ `corenote.QueryService.FilterVisible` pattern を踏襲する。

## 修正方針

- `Handler` に `*corenote.QueryService` を inject する setter を追加し、`Show` の note bulk fetch 直後に `FilterVisible(viewer, notes)` を挟む。
- 見えない note は `noteByID` に登録しないため、後段の `noteByID[n.NoteID]` lookup が `nil` を返り `entity.PackNotifications` の nil-safe path で `note` field のみ落ちる (= 通知行 / `noteId` echo は残るので本家 `NotificationEntityService` と同じ shape)。
- `queryService` 未配線時は **note embed を完全 skip** する fail-closed (= production の `router.go` は必ず wire するが、partial setup での再発を防ぐ)。

## 主な変更点

### production

- `internal/api/notifications/handler.go`: `queryService *corenote.QueryService` field + `SetQueryService` setter を追加。`Show` の note bulk fetch 直後に `FilterVisible` を挟み、`queryService` 未配線時は fail-closed で `noteByID` を空のまま。
- `internal/server/router.go`: 既存 `noteQueryService` (L219 で構築済み) を `notificationsHandler.SetQueryService` で wire。
- `CHANGELOG.md`: Unreleased セクションに修正項目を追記。

### test

- `internal/api/notifications/handler_test.go`:
  - 既存 `TestShow_WithUserAndNoteResolution` / `TestShow_BatchFetchesNotifierAndNote` を `corenote.NewQueryService` 配線形に更新 (queryService 未配線で `Note: nil` になる挙動の意図しない regression を避けるため)。
  - negative test を新規 4 件追加:
    - `TestShow_FollowersReply_NonFollower_NoteHidden` — IDOR の直接 repro (followers note の reply 通知、非フォロワー視点で `note` field が落ちる + `noteId` は残る + 通知行は残る)
    - `TestShow_FollowersReply_Follower_NoteVisible` — 正当 viewer (follow 済み) の non-regression
    - `TestShow_OwnNoteReaction_NoteVisible` — viewer = author の typical case が壊れていないこと
    - `TestShow_QueryServiceNil_NoteEmbedDropped` — fail-closed (queryService 未配線で note embed が drop)

## テスト

- `make fmt && make lint` clean
- `go test ./internal/api/notifications/...` pass (新規 4 test 含む)
- coverage `internal/api/notifications` **93.8%** (90% 閾値クリア)
- `go test ./internal/server/...` pass (wiring 変更)

フルテスト走行で本変更に起因する failure なし (= `safehttp` IPv6 SSRF / `repository` SASL / `e2e_federation` second-DB / `core/timeline` の port collision は develop の HEAD でも同じ failure を `git stash` で確認済み、本 PR 対象外で CI service container 経路なら通る)。

## Closes

Closes #1444

## 関連

- #1006 / #947 sub-8 / upstream #17335 — Notification 行レベルの visibility filter (今回 fix は embed 側)
- #1443 — notes/favorites/create visibility check (同じ `RequireVisible` / `FilterVisible` pattern)
- #1418 / #1439 〜 #1442 — 同 batch IDOR fixes

🤖 Generated with [Claude Code](https://claude.com/claude-code)