### PR TITLE
fix(notes): notes/translate に visibility check を追加 (IDOR + DeepL コスト)

### DIFF
--- a/internal/api/notes/handler_extra.go
+++ b/internal/api/notes/handler_extra.go
@@ -273,6 +273,17 @@ func (h *Handler) Translate(c echo.Context) error {
 		return c.JSON(http.StatusNotFound, apierr.Error("NO_SUCH_NOTE", "No such note.", "bea9b03f-36e0-49c5-a4db-627a029f8971"))
 	}
 
+	// 旧実装は存在確認のみで visibility check が無く、note ID 既知の viewer が
+	// followers / specified note を翻訳 = 本文の content leak + DeepL quota 消費
+	// ができた (#1445)。upstream TS `notes/translate` は非可視 note を専用の
+	// CANNOT_TRANSLATE_INVISIBLE_NOTE で弾く (NO_SUCH_NOTE で隠さない) ため
+	// それに合わせる。queryService 未配線時は fail-closed で同エラー。
+	// この gate は translator.Translate より前なので DeepL を消費しない。
+	viewer := middleware.GetUser(c)
+	if h.queryService == nil || !h.queryService.CanSee(viewer, n) {
+		return c.JSON(http.StatusBadRequest, apierr.Error("CANNOT_TRANSLATE_INVISIBLE_NOTE", "Cannot translate invisible note.", "ea29f2ca-c368-43b3-aaf1-5ac3e74bbe5d"))
+	}
+
 	if n.Text == nil || *n.Text == "" {
 		return c.JSON(http.StatusBadRequest, apierr.Error("CANNOT_TRANSLATE", "Nothing to translate.", "bef6e895-c05f-4572-96ab-58f5ae1e2e28"))
 	}

--- a/internal/api/notes/handler_extra_test.go
+++ b/internal/api/notes/handler_extra_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/labstack/echo/v4"
 	corenote "github.com/shiroha-a/mk/internal/core/note"
+	"github.com/shiroha-a/mk/internal/core/translate"
 	"github.com/shiroha-a/mk/internal/misc/id"
 	"github.com/shiroha-a/mk/internal/model"
 	"github.com/shiroha-a/mk/internal/server/middleware"
@@ -490,6 +491,104 @@ func TestTranslate_InvalidParam(t *testing.T) {
 	h, _, _ := newExtraHandler(t)
 	rec := postExtra(h.Translate, `{}`, nil)
 	assert.Equal(t, http.StatusBadRequest, rec.Code)
+}
+
+// newTranslateHandler は translator (non-nil dummy DeepL) + queryService +
+// followingRepo を wire した handler。dummy DeepL の Translate は呼ばれた
+// 場合のみ network に出るので、visibility gate が translator.Translate より
+// 前で弾くこと (= DeepL quota を消費しないこと) を、ネットワークなしの
+// テストで検証できる (#1445)。
+func newTranslateHandler(t *testing.T) (*Handler, *testutil.MockNoteRepository, *testutil.MockFollowingRepository) {
+	t.Helper()
+	noteRepo := testutil.NewMockNoteRepository()
+	followingRepo := testutil.NewMockFollowingRepository()
+	idGen, _ := id.NewGenerator("aidx")
+	querySvc := corenote.NewQueryService(noteRepo, followingRepo)
+	h := NewHandler(noteRepo, nil, nil, querySvc, nil, nil, nil, nil, idGen)
+	h.SetTranslator(translate.NewDeepL("dummy", false, nil))
+	return h, noteRepo, followingRepo
+}
+
+func translateBody(t *testing.T, rec *httptest.ResponseRecorder) (string, string) {
+	t.Helper()
+	var resp map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+	errObj, _ := resp["error"].(map[string]any)
+	code, _ := errObj["code"].(string)
+	idStr, _ := errObj["id"].(string)
+	return code, idStr
+}
+
+// followers note を非 follower / 匿名 viewer が翻訳しようとすると、本文が
+// あっても translator に渡さず 400 CANNOT_TRANSLATE_INVISIBLE_NOTE で弾く。
+func TestTranslate_FollowersNote_NonFollower_Invisible(t *testing.T) {
+	secret := "secret body"
+	for _, viewer := range []*model.User{nil, {ID: "u2"}} {
+		h, noteRepo, _ := newTranslateHandler(t)
+		noteRepo.Notes["n1"] = &model.Note{ID: "n1", UserID: "u1", Visibility: model.NoteVisibilityFollowers, Text: &secret}
+		rec := postExtra(h.Translate, `{"noteId":"n1","targetLang":"en"}`, viewer)
+		assert.Equal(t, http.StatusBadRequest, rec.Code)
+		code, idStr := translateBody(t, rec)
+		assert.Equal(t, "CANNOT_TRANSLATE_INVISIBLE_NOTE", code)
+		assert.Equal(t, "ea29f2ca-c368-43b3-aaf1-5ac3e74bbe5d", idStr)
+	}
+}
+
+// specified note を visibleUserIds 外の viewer が翻訳しようとすると 400 で弾く。
+func TestTranslate_SpecifiedNote_NotInList_Invisible(t *testing.T) {
+	secret := "secret body"
+	h, noteRepo, _ := newTranslateHandler(t)
+	noteRepo.Notes["n1"] = &model.Note{ID: "n1", UserID: "u1", Visibility: model.NoteVisibilitySpecified, VisibleUserIDs: []string{"u3"}, Text: &secret}
+	rec := postExtra(h.Translate, `{"noteId":"n1","targetLang":"en"}`, &model.User{ID: "u2"})
+	assert.Equal(t, http.StatusBadRequest, rec.Code)
+	code, _ := translateBody(t, rec)
+	assert.Equal(t, "CANNOT_TRANSLATE_INVISIBLE_NOTE", code)
+}
+
+// follower / visibleUserIds 対象 / author は visibility gate を通過する。
+// Text を空にして text-empty 経路 (CANNOT_TRANSLATE) で止め、DeepL を呼ばずに
+// 「gate を通った」ことを検証する (invisible エラーでないことを確認)。
+func TestTranslate_VisibleViewers_PassVisibilityGate(t *testing.T) {
+	empty := ""
+	cases := []struct {
+		name   string
+		note   *model.Note
+		viewer *model.User
+		follow bool
+	}{
+		{"follower", &model.Note{ID: "n1", UserID: "u1", Visibility: model.NoteVisibilityFollowers, Text: &empty}, &model.User{ID: "u2"}, true},
+		{"author", &model.Note{ID: "n1", UserID: "u1", Visibility: model.NoteVisibilityFollowers, Text: &empty}, &model.User{ID: "u1"}, false},
+		{"specified target", &model.Note{ID: "n1", UserID: "u1", Visibility: model.NoteVisibilitySpecified, VisibleUserIDs: []string{"u2"}, Text: &empty}, &model.User{ID: "u2"}, false},
+		{"public anonymous", &model.Note{ID: "n1", UserID: "u1", Visibility: model.NoteVisibilityPublic, Text: &empty}, nil, false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			h, noteRepo, fRepo := newTranslateHandler(t)
+			noteRepo.Notes["n1"] = tc.note
+			if tc.follow {
+				fRepo.Followings["f1"] = &model.Following{ID: "f1", FollowerID: tc.viewer.ID, FolloweeID: "u1"}
+			}
+			rec := postExtra(h.Translate, `{"noteId":"n1","targetLang":"en"}`, tc.viewer)
+			assert.Equal(t, http.StatusBadRequest, rec.Code)
+			code, _ := translateBody(t, rec)
+			assert.Equal(t, "CANNOT_TRANSLATE", code, "visibility gate を通過し text-empty 経路に到達する")
+		})
+	}
+}
+
+// queryService 未配線時は visibility を確認できないため fail-closed で
+// CANNOT_TRANSLATE_INVISIBLE_NOTE を返す (public note でも translate しない)。
+func TestTranslate_NoQueryServiceRejects(t *testing.T) {
+	noteRepo := testutil.NewMockNoteRepository()
+	secret := "secret body"
+	noteRepo.Notes["n1"] = &model.Note{ID: "n1", UserID: "u1", Visibility: model.NoteVisibilityPublic, Text: &secret}
+	idGen, _ := id.NewGenerator("aidx")
+	h := NewHandler(noteRepo, nil, nil, nil, nil, nil, nil, nil, idGen) // queryService=nil
+	h.SetTranslator(translate.NewDeepL("dummy", false, nil))
+	rec := postExtra(h.Translate, `{"noteId":"n1","targetLang":"en"}`, &model.User{ID: "u1"})
+	assert.Equal(t, http.StatusBadRequest, rec.Code)
+	code, _ := translateBody(t, rec)
+	assert.Equal(t, "CANNOT_TRANSLATE_INVISIBLE_NOTE", code)
 }
 
 // --- ShowPartialBulk ---

--- a/internal/core/note/note_query_service.go
+++ b/internal/core/note/note_query_service.go
@@ -80,6 +80,16 @@ func (s *QueryService) requireVisible(viewer *model.User, noteID string) (*model
 	return n, nil
 }
 
+// CanSee reports whether viewer may see the already-loaded note n, using the
+// service's followingRepo for follower checks. requireVisible が「不存在も
+// 非閲覧も ErrNoteNotFound に集約して存在隠蔽する」のに対し、caller が
+// 「存在は確認済みで可視性だけ別エラーにしたい」場合に使う。例: notes/translate
+// は upstream TS に合わせ、非可視を NO_SUCH_NOTE ではなく専用の
+// CANNOT_TRANSLATE_INVISIBLE_NOTE で返す (#1445)。
+func (s *QueryService) CanSee(viewer *model.User, n *model.Note) bool {
+	return CanSeeNote(viewer, n, s.followingRepo)
+}
+
 // ListRenotes returns the renotes of the given noteID after filtering for visibility.
 // 元のノートが閲覧できない場合はErrNoteNotFoundを返す。
 func (s *QueryService) ListRenotes(viewer *model.User, noteID, untilID, sinceID string, limit int) ([]*model.Note, error) {


### PR DESCRIPTION
## Summary

`notes/translate` が note の存在確認のみで `CanSeeNote` を欠いており、note ID 既知の viewer が followers / specified visibility note を翻訳 = 本文の content leak、かつ非閲覧者 (`RequireAuth` + `CanUseTranslator` policy は通過済み) が他人の private note を対象に DeepL を叩ける quota / 課金消費の問題があった (#1445)。

## upstream TS 準拠

`packages/backend/src/server/api/endpoints/notes/translate.ts` を確認したところ、TS は:
- note not found → `NO_SUCH_NOTE` (`bea9b03f`)
- `isVisibleForMe` false → 専用の **`CANNOT_TRANSLATE_INVISIBLE_NOTE`** (`ea29f2ca`, 400)

と区別し、**存在隠蔽はしない**。issue の「NO_SUCH_NOTE / ACCESS_DENIED」案ではなく、API 互換上はこの専用エラーに合わせる。順序も TS (getNote → visibility → text) に揃える。

## 主な変更点

- `internal/core/note/note_query_service.go`: `QueryService.CanSee(viewer, note) bool` を追加。`requireVisible` が「不存在も非閲覧も `ErrNoteNotFound` に集約」するのに対し、「存在は確認済みで可視性だけ別エラーにしたい」caller 用 (translate のように非可視を専用エラーで返す経路)。
- `internal/api/notes/handler_extra.go` (`Translate`): `FindByID` 直後・`translator.Translate` より前に visibility gate を挿入。非可視 → `CANNOT_TRANSLATE_INVISIBLE_NOTE` (400, `ea29f2ca`)。`queryService == nil` は fail-closed で同エラー。gate が translate より前なので **DeepL quota を消費しない**。
- `internal/api/notes/handler_extra_test.go`: negative (followers の非follower/匿名、specified の非対象) + positive (follower/author/visibleUserIds対象/public は gate 通過 → text-empty 経路で DeepL を呼ばず確認) + queryService nil fail-closed。

## テスト

- `go test ./internal/api/notes/ ./internal/core/note/` pass
- coverage: notes 92.7% / core/note 94.1% (gate pass)
- `make fmt && make lint` clean

## 備考

`CanSee` は #1455 (favorites/create) の `RequireVisible` とは別メソッド (translate は存在隠蔽せず専用エラーを返す必要があるため、集約版は使えない)。両者は additive で競合しない。

## Closes

Closes #1445