### PR TITLE
fix(clips): clips/add-note に visibility check を追加 (#1456)

### DIFF
--- a/internal/api/clips/handler.go
+++ b/internal/api/clips/handler.go
@@ -9,6 +9,7 @@ import (
 	"github.com/shiroha-a/mk/internal/api/apierr"
 	"github.com/shiroha-a/mk/internal/api/pagination"
 	coreclip "github.com/shiroha-a/mk/internal/core/clip"
+	corenote "github.com/shiroha-a/mk/internal/core/note"
 	"github.com/shiroha-a/mk/internal/core/notesfilter"
 	"github.com/shiroha-a/mk/internal/entity"
 	"github.com/shiroha-a/mk/internal/misc/id"
@@ -29,6 +30,11 @@ type Handler struct {
 	// userRepo は clips/notes 経由で他人の clip を閲覧する際の hardMutedWords
 	// filter (#787) のために viewer profile を引く。未配線時は filter skip。
 	userRepo repository.UserRepository
+	// queryService は clips/add-note の visibility gate (#1456) で
+	// RequireVisible を呼ぶための note.QueryService。未配線時は fail-closed
+	// で 404 NO_SUCH_NOTE を返し、visibility 未検証の note を絶対に clip に
+	// 永続化しない (#1455 favorites/create と同形)。
+	queryService *corenote.QueryService
 }
 
 // SetUserRepo wires a UserRepository so clips/notes filters out notes that
@@ -77,6 +83,14 @@ func (h *Handler) emojiLookup() entity.EmojiLookup {
 		return nil
 	}
 	return h.emojiRepo
+}
+
+// SetQueryService wires a note.QueryService used by AddNote to enforce
+// note visibility (#1456). When unwired, AddNote fails closed with 404
+// NO_SUCH_NOTE so that a clip never ends up referencing a note whose
+// visibility the viewer is not entitled to.
+func (h *Handler) SetQueryService(qs *corenote.QueryService) {
+	h.queryService = qs
 }
 
 // NewHandler creates a new clips Handler.
@@ -247,6 +261,17 @@ func (h *Handler) AddNote(c echo.Context) error {
 	var req AddNoteRequest
 	if err := c.Bind(&req); err != nil || req.ClipID == "" || req.NoteID == "" {
 		return apierr.JSONInvalidParam(c)
+	}
+	// Visibility gate (#1456): clip は read 側 #1418 で push-down 済みでも、
+	// 非可視 note を追加できる/不可で 204 vs 404 が分岐すると存在 enumeration
+	// が成立する (favorite-class IDOR の弱変種)。RequireVisible で存在不可と
+	// 同じ NO_SUCH_NOTE 404 に集約して oracle を塞ぐ。queryService 未配線時は
+	// fail-closed で同じ 404 を返し、unchecked note を絶対に永続化しない。
+	if h.queryService == nil {
+		return c.JSON(http.StatusNotFound, apierr.Error("NO_SUCH_NOTE", "No such note.", "fc8c0b49-c7a3-4664-a0a6-b418d386bb8b"))
+	}
+	if _, err := h.queryService.RequireVisible(user, req.NoteID); err != nil {
+		return c.JSON(http.StatusNotFound, apierr.Error("NO_SUCH_NOTE", "No such note.", "fc8c0b49-c7a3-4664-a0a6-b418d386bb8b"))
 	}
 	if err := h.svc.AddNote(user.ID, req.ClipID, req.NoteID); err != nil {
 		switch {

--- a/internal/api/clips/handler_test.go
+++ b/internal/api/clips/handler_test.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/labstack/echo/v4"
 	coreclip "github.com/shiroha-a/mk/internal/core/clip"
+	corenote "github.com/shiroha-a/mk/internal/core/note"
 	"github.com/shiroha-a/mk/internal/entitycompat/shapetest"
 	"github.com/shiroha-a/mk/internal/misc/id"
 	"github.com/shiroha-a/mk/internal/model"
@@ -27,12 +28,30 @@ func newHandler(t *testing.T) (
 	*testutil.MockNoteRepository,
 ) {
 	t.Helper()
+	h, repo, noteRepo, notes, _ := newHandlerWithFollowing(t)
+	return h, repo, noteRepo, notes
+}
+
+// newHandlerWithFollowing は followers/specified visibility テスト用に
+// MockFollowingRepository も返す helper。followers note を seed して
+// follow 関係を Followings に登録できる (#1456 AddNote visibility テスト)。
+func newHandlerWithFollowing(t *testing.T) (
+	*Handler,
+	*testutil.MockClipRepository,
+	*testutil.MockClipNoteRepository,
+	*testutil.MockNoteRepository,
+	*testutil.MockFollowingRepository,
+) {
+	t.Helper()
 	repo := testutil.NewMockClipRepository()
 	noteRepo := testutil.NewMockClipNoteRepository()
 	notes := testutil.NewMockNoteRepository()
+	followingRepo := testutil.NewMockFollowingRepository()
 	idGen, _ := id.NewGenerator("aidx")
 	svc := coreclip.NewService(repo, noteRepo, notes, idGen)
-	return NewHandler(svc, idGen), repo, noteRepo, notes
+	h := NewHandler(svc, idGen)
+	h.SetQueryService(corenote.NewQueryService(notes, followingRepo))
+	return h, repo, noteRepo, notes, followingRepo
 }
 
 func newReq(t *testing.T, body string) (echo.Context, *httptest.ResponseRecorder) {
@@ -372,7 +391,7 @@ func TestList_RepoError(t *testing.T) {
 func TestAddNote_Success(t *testing.T) {
 	h, repo, _, notes := newHandler(t)
 	repo.Clips["c1"] = &model.Clip{ID: "c1", UserID: "alice"}
-	notes.Notes["n1"] = &model.Note{ID: "n1"}
+	notes.Notes["n1"] = &model.Note{ID: "n1", Visibility: model.NoteVisibilityPublic}
 	c, rec := newReq(t, `{"clipId":"c1","noteId":"n1"}`)
 	setUser(c, "alice")
 	require.NoError(t, h.AddNote(c))
@@ -388,16 +407,23 @@ func TestAddNote_BadJSON(t *testing.T) {
 }
 
 func TestAddNote_ClipNotFound(t *testing.T) {
-	h, _, _, _ := newHandler(t)
+	h, _, _, notes := newHandler(t)
+	// visibility gate (#1456) を通過させた上で、後続の clip 検索で
+	// NO_SUCH_CLIP に到達することを担保する seed。
+	notes.Notes["n1"] = &model.Note{ID: "n1", Visibility: model.NoteVisibilityPublic}
 	c, rec := newReq(t, `{"clipId":"missing","noteId":"n1"}`)
 	setUser(c, "alice")
 	require.NoError(t, h.AddNote(c))
 	assert.Equal(t, http.StatusNotFound, rec.Code)
+	assert.Contains(t, rec.Body.String(), "NO_SUCH_CLIP")
 }
 
 func TestAddNote_AccessDenied(t *testing.T) {
-	h, repo, _, _ := newHandler(t)
+	h, repo, _, notes := newHandler(t)
 	repo.Clips["c1"] = &model.Clip{ID: "c1", UserID: "owner"}
+	// visibility gate (#1456) を通過させた上で、owner 不一致で ACCESS_DENIED
+	// に到達することを担保する seed。
+	notes.Notes["n1"] = &model.Note{ID: "n1", Visibility: model.NoteVisibilityPublic}
 	c, rec := newReq(t, `{"clipId":"c1","noteId":"n1"}`)
 	setUser(c, "alice")
 	require.NoError(t, h.AddNote(c))
@@ -411,12 +437,13 @@ func TestAddNote_NoteNotFound(t *testing.T) {
 	setUser(c, "alice")
 	require.NoError(t, h.AddNote(c))
 	assert.Equal(t, http.StatusNotFound, rec.Code)
+	assert.Contains(t, rec.Body.String(), "NO_SUCH_NOTE")
 }
 
 func TestAddNote_AlreadyClipped(t *testing.T) {
 	h, repo, _, notes := newHandler(t)
 	repo.Clips["c1"] = &model.Clip{ID: "c1", UserID: "alice"}
-	notes.Notes["n1"] = &model.Note{ID: "n1"}
+	notes.Notes["n1"] = &model.Note{ID: "n1", Visibility: model.NoteVisibilityPublic}
 	c, rec := newReq(t, `{"clipId":"c1","noteId":"n1"}`)
 	setUser(c, "alice")
 	require.NoError(t, h.AddNote(c))
@@ -438,15 +465,119 @@ func TestAddNote_RepoError(t *testing.T) {
 	repo := testutil.NewMockClipRepository()
 	repo.Clips["c1"] = &model.Clip{ID: "c1", UserID: "alice"}
 	notes := testutil.NewMockNoteRepository()
-	notes.Notes["n1"] = &model.Note{ID: "n1"}
+	notes.Notes["n1"] = &model.Note{ID: "n1", Visibility: model.NoteVisibilityPublic}
 	noteRepo := &failingClipNoteCreateRepo{MockClipNoteRepository: testutil.NewMockClipNoteRepository()}
 	idGen, _ := id.NewGenerator("aidx")
 	svc := coreclip.NewService(repo, noteRepo, notes, idGen)
 	h := NewHandler(svc, idGen)
+	// AddNote の visibility gate (#1456) を通過させるため queryService を wire。
+	h.SetQueryService(corenote.NewQueryService(notes, nil))
 	c, rec := newReq(t, `{"clipId":"c1","noteId":"n1"}`)
 	setUser(c, "alice")
 	require.NoError(t, h.AddNote(c))
 	assert.Equal(t, http.StatusInternalServerError, rec.Code)
+}
+
+// --- AddNote visibility gate (#1456) --------------------------------------
+
+// 非フォロワーが followers visibility note を clip に追加しようとしても
+// 不存在 note と同じ NO_SUCH_NOTE 404 で隠蔽され、永続化されないこと。
+// content leak 自体は #1418 (ListByClipVisible) で塞がれているが、
+// 204 vs 404 の差で存在 enumeration が成立する favorite-class IDOR の
+// 弱変種を、可視性チェックで存在 oracle ごと潰す。
+func TestAddNote_FollowersNote_NonFollower_Hidden(t *testing.T) {
+	h, repo, clipNoteRepo, notes, _ := newHandlerWithFollowing(t)
+	repo.Clips["c1"] = &model.Clip{ID: "c1", UserID: "alice"}
+	notes.Notes["n1"] = &model.Note{ID: "n1", UserID: "author", Visibility: model.NoteVisibilityFollowers}
+	c, rec := newReq(t, `{"clipId":"c1","noteId":"n1"}`)
+	setUser(c, "alice")
+	require.NoError(t, h.AddNote(c))
+	assert.Equal(t, http.StatusNotFound, rec.Code)
+	assert.Contains(t, rec.Body.String(), "NO_SUCH_NOTE")
+	assert.Empty(t, clipNoteRepo.Entries, "visibility 違反 note は永続化されない")
+}
+
+// フォロワーは followers visibility note を自分の clip に追加できる。
+func TestAddNote_FollowersNote_Follower_OK(t *testing.T) {
+	h, repo, clipNoteRepo, notes, followingRepo := newHandlerWithFollowing(t)
+	repo.Clips["c1"] = &model.Clip{ID: "c1", UserID: "alice"}
+	notes.Notes["n1"] = &model.Note{ID: "n1", UserID: "author", Visibility: model.NoteVisibilityFollowers}
+	followingRepo.Followings["f1"] = &model.Following{ID: "f1", FollowerID: "alice", FolloweeID: "author"}
+	c, rec := newReq(t, `{"clipId":"c1","noteId":"n1"}`)
+	setUser(c, "alice")
+	require.NoError(t, h.AddNote(c))
+	assert.Equal(t, http.StatusNoContent, rec.Code)
+	assert.Len(t, clipNoteRepo.Entries, 1)
+}
+
+// 自分の followers visibility note は自分の clip に追加できる
+// (author は visibility に関わらず自分の note を見られる)。
+func TestAddNote_FollowersNote_Author_OK(t *testing.T) {
+	h, repo, clipNoteRepo, notes, _ := newHandlerWithFollowing(t)
+	repo.Clips["c1"] = &model.Clip{ID: "c1", UserID: "alice"}
+	notes.Notes["n1"] = &model.Note{ID: "n1", UserID: "alice", Visibility: model.NoteVisibilityFollowers}
+	c, rec := newReq(t, `{"clipId":"c1","noteId":"n1"}`)
+	setUser(c, "alice")
+	require.NoError(t, h.AddNote(c))
+	assert.Equal(t, http.StatusNoContent, rec.Code)
+	assert.Len(t, clipNoteRepo.Entries, 1)
+}
+
+// specified visibility で VisibleUserIDs に入っていない viewer は
+// 不存在と同じ 404 で隠蔽され、永続化されない。
+func TestAddNote_SpecifiedNote_NotInList_Hidden(t *testing.T) {
+	h, repo, clipNoteRepo, notes, _ := newHandlerWithFollowing(t)
+	repo.Clips["c1"] = &model.Clip{ID: "c1", UserID: "alice"}
+	notes.Notes["n1"] = &model.Note{
+		ID:             "n1",
+		UserID:         "author",
+		Visibility:     model.NoteVisibilitySpecified,
+		VisibleUserIDs: []string{"other"},
+	}
+	c, rec := newReq(t, `{"clipId":"c1","noteId":"n1"}`)
+	setUser(c, "alice")
+	require.NoError(t, h.AddNote(c))
+	assert.Equal(t, http.StatusNotFound, rec.Code)
+	assert.Contains(t, rec.Body.String(), "NO_SUCH_NOTE")
+	assert.Empty(t, clipNoteRepo.Entries)
+}
+
+// specified visibility で VisibleUserIDs に入っている viewer は追加可。
+func TestAddNote_SpecifiedNote_InList_OK(t *testing.T) {
+	h, repo, clipNoteRepo, notes, _ := newHandlerWithFollowing(t)
+	repo.Clips["c1"] = &model.Clip{ID: "c1", UserID: "alice"}
+	notes.Notes["n1"] = &model.Note{
+		ID:             "n1",
+		UserID:         "author",
+		Visibility:     model.NoteVisibilitySpecified,
+		VisibleUserIDs: []string{"alice"},
+	}
+	c, rec := newReq(t, `{"clipId":"c1","noteId":"n1"}`)
+	setUser(c, "alice")
+	require.NoError(t, h.AddNote(c))
+	assert.Equal(t, http.StatusNoContent, rec.Code)
+	assert.Len(t, clipNoteRepo.Entries, 1)
+}
+
+// queryService が未配線の Handler は fail-closed で 404 NO_SUCH_NOTE を
+// 返し、unchecked note を絶対に永続化しない (router 配線漏れ等の
+// 設定ミスでも visibility filter を bypass させない安全弁)。
+func TestAddNote_NoQueryServiceRejects(t *testing.T) {
+	repo := testutil.NewMockClipRepository()
+	repo.Clips["c1"] = &model.Clip{ID: "c1", UserID: "alice"}
+	clipNoteRepo := testutil.NewMockClipNoteRepository()
+	notes := testutil.NewMockNoteRepository()
+	notes.Notes["n1"] = &model.Note{ID: "n1", Visibility: model.NoteVisibilityPublic}
+	idGen, _ := id.NewGenerator("aidx")
+	svc := coreclip.NewService(repo, clipNoteRepo, notes, idGen)
+	h := NewHandler(svc, idGen) // SetQueryService を意図的に呼ばない
+	c, rec := newReq(t, `{"clipId":"c1","noteId":"n1"}`)
+	setUser(c, "alice")
+	require.NoError(t, h.AddNote(c))
+	assert.Equal(t, http.StatusNotFound, rec.Code)
+	assert.Contains(t, rec.Body.String(), "NO_SUCH_NOTE")
+	assert.Empty(t, clipNoteRepo.Entries,
+		"queryService 未配線時に visibility 未検証 note を永続化してはならない")
 }
 
 // --- RemoveNote ------------------------------------------------------------
@@ -454,7 +585,7 @@ func TestAddNote_RepoError(t *testing.T) {
 func TestRemoveNote_Success(t *testing.T) {
 	h, repo, _, notes := newHandler(t)
 	repo.Clips["c1"] = &model.Clip{ID: "c1", UserID: "alice"}
-	notes.Notes["n1"] = &model.Note{ID: "n1"}
+	notes.Notes["n1"] = &model.Note{ID: "n1", Visibility: model.NoteVisibilityPublic}
 	c, rec := newReq(t, `{"clipId":"c1","noteId":"n1"}`)
 	setUser(c, "alice")
 	require.NoError(t, h.AddNote(c))

--- a/internal/core/note/note_query_service.go
+++ b/internal/core/note/note_query_service.go
@@ -66,6 +66,17 @@ func (s *QueryService) ShowForAPI(noteID string) (*model.Note, error) {
 	return n, nil
 }
 
+// RequireVisible は viewer から見て対象 note が可視であることを要求する
+// 公開 wrapper。非存在・非可視のいずれも ErrNoteNotFound に集約して返す
+// ことで「note が存在するが見えない」と「note 自体が無い」を区別させない
+// (= 存在 enumeration 防止)。clips/add-note (#1456) や favorites/create
+// (#1443) 等、ID 既知の viewer が note を別 channel (clip / favorite) に
+// 永続化する mutation 経路で、author が visibility を絞った後も content
+// が漏れ続ける/存在が漏れる security risk を防ぐためのチェック。
+func (s *QueryService) RequireVisible(viewer *model.User, noteID string) (*model.Note, error) {
+	return s.requireVisible(viewer, noteID)
+}
+
 // requireVisible は visibility check 用の軽量ロード。返り値の note は
 // 呼び出し元で pack せず捨てるか top-level フィールドだけを参照する想定 (#425)。
 // Show は handler に返す note を full preload するため別経路。

--- a/internal/server/router.go
+++ b/internal/server/router.go
@@ -1682,6 +1682,7 @@ func (s *Server) setupRoutes() {
 	clipsHandler.SetReactionReader(reactionCountWriter)
 	clipsHandler.SetNoteFieldResolver(noteFieldResolver)
 	clipsHandler.SetUserRepo(userRepo)
+	clipsHandler.SetQueryService(noteQueryService) // #1456: AddNote の visibility gate
 	api.POST("/clips/create", clipsHandler.Create, middleware.RequireAuth())
 	api.POST("/clips/show", clipsHandler.Show)
 	api.POST("/clips/update", clipsHandler.Update, middleware.RequireAuth())


### PR DESCRIPTION
## Summary

`clips/add-note` に visibility check を追加し、非可視 note の存在
enumeration (favorite-class IDOR の弱変種) を塞ぐ。先行 fix #1455
(`notes/favorites/create`) と同形に **handler 層** で
`note.QueryService.RequireVisible` を呼ぶ。

### 問題

`internal/core/clip/clip_service.go` `Service.AddNote` は note 存在を
`s.notes.FindByID` で確認するだけで、`CanSeeNote` を経由しない。Handler
側も owner gate のみ。結果として:

- 非可視 note でも clip に追加できる (HTTP 204)
- 不存在 note は 404 `NO_SUCH_NOTE` (`fc8c0b49-...`)
- この差分で **任意 note ID について private note の存在 enumeration**
  が成立する。content leak 自体は #1418 (`ListByClipVisible` の read-side
  visibility push-down) で塞がれているため影響は弱いが、存在 oracle は
  依然漏れる。

### 修正

1. `note.QueryService` に public `RequireVisible(viewer, noteID)` wrapper
   を export。private `requireVisible` のみだったため package 外から
   visibility check を単発で呼べなかった (#1443/#1455 が未マージで wrapper
   が無いため、本 PR で先行追加)。
2. `internal/api/clips/handler.go` に `queryService` field と
   `SetQueryService` setter を追加。`AddNote` の Bind 検証直後・
   `svc.AddNote` 呼び出し前に `RequireVisible` を呼び、非可視/不存在を
   同じ 404 `NO_SUCH_NOTE` に集約する。
3. `internal/server/router.go` で `clipsHandler.SetQueryService(noteQueryService)`
   を配線。
4. `queryService` 未配線時は fail-closed で 404 `NO_SUCH_NOTE` を返し、
   unchecked note を絶対に永続化しない (router 配線漏れの安全弁)。

core 層の `clip_service.go` は触らず、既存 `s.notes.FindByID` も belt-
and-suspenders として残す (非 HTTP 経路 / 既存 service テスト無傷化)。

## 主な変更点

- `internal/api/clips/handler.go` — `queryService` field + `SetQueryService`
  setter + `AddNote` 冒頭の visibility gate
- `internal/server/router.go` — `clipsHandler.SetQueryService(noteQueryService)`
  1 行追加
- `internal/core/note/note_query_service.go` — public `RequireVisible`
  wrapper を export (private `requireVisible` への薄い委譲)
- `internal/api/clips/handler_test.go` — `newHandler` を `newHandlerWithFollowing`
  経由に組み替えて全 helper で `SetQueryService` を wire。既存 AddNote 系
  seed に `Visibility: model.NoteVisibilityPublic` を付与し、6 件の新規テスト
  (followers/specified の hidden/OK + fail-closed) を追加

## テスト

新規テスト (`internal/api/clips/handler_test.go`):

- `TestAddNote_FollowersNote_NonFollower_Hidden` — followers note を non-
  follower が追加しようとすると 404 `NO_SUCH_NOTE` で隠蔽 + 永続化なし
- `TestAddNote_FollowersNote_Follower_OK` — follower は追加可 (204)
- `TestAddNote_FollowersNote_Author_OK` — author は visibility 関係なく
  自分の note を自分の clip に追加可
- `TestAddNote_SpecifiedNote_NotInList_Hidden` — `VisibleUserIDs` に
  入っていない viewer は 404 で隠蔽
- `TestAddNote_SpecifiedNote_InList_OK` — `VisibleUserIDs` に入っていれば
  追加可
- `TestAddNote_NoQueryServiceRejects` — `SetQueryService` 未呼び出しで
  fail-closed 404 + 永続化なし

### 実行

```
go test ./internal/api/clips/... -run TestAddNote -v       # 13/13 pass
go test ./internal/api/clips/... ./internal/core/clip/... \
        ./internal/core/note/... ./internal/api/notes/... \
        ./internal/server/... -v                            # all pass
make fmt && make lint                                       # clean
```

`make test` 全体は CI 必要な PostgreSQL / Redis / IPv6 依存テストが
ローカルで落ちるが、stock develop でも同様に再現するため本 PR の
変更とは無関係。

## Closes

Closes #1456

## 関連

- #1455 / #1443 (favorites/create — 同 class、本 fix の precedent)
- #1418 (clips/notes 読み側 push-down)
- #1428 (userlists IDOR) / #1444 (notifications note embed visibility)