### PR TITLE
fix(stream): WebSocket subNote に visibility check を追加 (#1460)

### DIFF
--- a/internal/server/router.go
+++ b/internal/server/router.go
@@ -1723,6 +1723,12 @@ func (s *Server) setupRoutes() {
 	// 失敗 / anonymous は nil 返却で degrade — channel は 3 escape hatch のみで
 	// 動く (= 旧来の "全 reply drop" よりは upstream 互換に近い)。
 	streamManager.SetFollowingSnapshotLookup(&followingSnapshotAdapter{repo: followingRepo})
+	// subNote visibility gate (#1460 IDOR fix): handleSubNote が任意の noteID
+	// で noteStream を subscribe させると、followers / specified note の
+	// reacted / unreacted / pollVoted / deleted event が非対象 viewer に
+	// 漏れる (HTTP 側 #1444 i/notifications IDOR の WS 版)。noteQueryService
+	// の RequireVisible が NoteVisibilityChecker interface を自動 satisfy する。
+	streamManager.SetNoteVisibilityChecker(noteQueryService)
 	// hardMutedWords 変更時に reload event を受け取って該当 connection の
 	// rules を refresh する subscriber を起動 (#791)。i/update 側 publisher
 	// と同じ topic 名を共有 (= stream.WordMuteReloadTopic)。

--- a/internal/stream/dispatcher.go
+++ b/internal/stream/dispatcher.go
@@ -4,6 +4,8 @@ import (
 	"encoding/json"
 	"log/slog"
 	"sync"
+
+	"github.com/shiroha-a/mk/internal/model"
 )
 
 // PubSubBus is the minimal pubsub interface that Dispatcher needs. core/event.
@@ -28,6 +30,20 @@ type NotificationReader interface {
 	ReadAll(userID string) error
 }
 
+// NoteVisibilityChecker gates subNote subscriptions by checking whether the
+// connection's viewer is allowed to see the target note (#1460 IDOR fix)。
+// 旧実装は noteID を持っていれば誰でも noteStream:<noteID> を subscribe
+// でき、followers / specified note の reacted / unreacted / pollVoted /
+// deleted event が漏れていた (i/notifications の #1444 IDOR の WS 版)。
+//
+// *core/note.QueryService が既存 RequireVisible(viewer, noteID) method で
+// 本 interface を自動 satisfy する (戻り値の (*model.Note, error) と
+// ErrNoteNotFound セマンティクスは存在隠蔽用)。dispatcher は note 本体は
+// 使わず err 有無だけで gate するので、interface に追加メソッドは不要。
+type NoteVisibilityChecker interface {
+	RequireVisible(viewer *model.User, noteID string) (*model.Note, error)
+}
+
 // Dispatcher is the per-Connection state holding registered channels and the
 // reverse map "topic → channel id" used to route inbound pubsub events.
 //
@@ -45,9 +61,10 @@ type Dispatcher struct {
 	topics   map[string]map[string]bool // topic → set of channel ids
 
 	// subNote の refcount 管理 (noteID → count)
-	noteSubMu   sync.Mutex
-	noteSubs    map[string]int
-	notifReader NotificationReader
+	noteSubMu      sync.Mutex
+	noteSubs       map[string]int
+	notifReader    NotificationReader
+	noteVisibility NoteVisibilityChecker
 }
 
 // NewDispatcher constructs a Dispatcher for the given connection. registry /
@@ -66,6 +83,15 @@ func NewDispatcher(conn *Connection, registry *Registry, bus PubSubBus) *Dispatc
 // SetNotificationReader wires a NotificationReader for readNotification.
 func (d *Dispatcher) SetNotificationReader(nr NotificationReader) {
 	d.notifReader = nr
+}
+
+// SetNoteVisibilityChecker wires a NoteVisibilityChecker so handleSubNote
+// can refuse subscribing to non-visible notes (#1460 IDOR fix)。未配線時
+// は fail-closed で全 subNote が subscribe しない (= production の
+// router.go は必ず wire する、test の partial setup を漏れに繋げない、
+// notifications #1444 と同 doctrine)。
+func (d *Dispatcher) SetNoteVisibilityChecker(c NoteVisibilityChecker) {
+	d.noteVisibility = c
 }
 
 // HandleClientMessage parses a Misskey-style envelope and forwards it to the
@@ -441,6 +467,25 @@ func (d *Dispatcher) handleSubNote(body json.RawMessage) {
 		ID string `json:"id"`
 	}
 	if err := json.Unmarshal(body, &req); err != nil || req.ID == "" {
+		return
+	}
+	// Visibility gate (#1460 IDOR fix): 任意の noteID で subscribe させると
+	// followers / specified note の reacted / unreacted / pollVoted / deleted
+	// event を非対象 viewer に漏らす。HTTP 側 #1444 と同じ shape で、
+	// RequireVisible が ErrNoteNotFound (= 不存在 / 非可視を hide) を返したら
+	// subscribe を silently skip する。refcount inc の前で gate するので、
+	// 拒否されたあとに unsubNote で state を leak する経路も発生しない。
+	// 匿名 conn (User()==nil) は CanSeeNote の nil-viewer 判定で followers /
+	// specified が自動的に弾かれる。checker 未配線時は fail-closed (= 同じく
+	// silently skip)。
+	if d.noteVisibility == nil {
+		return
+	}
+	var viewer *model.User
+	if d.conn != nil {
+		viewer = d.conn.User()
+	}
+	if _, err := d.noteVisibility.RequireVisible(viewer, req.ID); err != nil {
 		return
 	}
 	topic := "noteStream:" + req.ID

--- a/internal/stream/dispatcher_test.go
+++ b/internal/stream/dispatcher_test.go
@@ -2,6 +2,7 @@ package stream
 
 import (
 	"encoding/json"
+	"errors"
 	"sync"
 	"testing"
 	"time"
@@ -735,6 +736,32 @@ func (s *stubNotifReader) ReadAll(userID string) error {
 	return nil
 }
 
+// stubNoteVisibility implements NoteVisibilityChecker for subNote tests
+// (#1460)。allowed[noteID] = true なら visible、defaultAllow=true なら
+// allowed 未登録 noteID も visible 扱い (permissive)。lastViewer / calls
+// で checker が dispatch から正しい引数で呼ばれたか sanity check できる。
+type stubNoteVisibility struct {
+	allowed      map[string]bool
+	defaultAllow bool
+	lastViewer   *model.User
+	calls        int
+}
+
+func (s *stubNoteVisibility) RequireVisible(viewer *model.User, noteID string) (*model.Note, error) {
+	s.lastViewer = viewer
+	s.calls++
+	if v, ok := s.allowed[noteID]; ok {
+		if v {
+			return &model.Note{ID: noteID}, nil
+		}
+		return nil, errors.New("not visible")
+	}
+	if s.defaultAllow {
+		return &model.Note{ID: noteID}, nil
+	}
+	return nil, errors.New("not visible")
+}
+
 func TestDispatcher_ReadNotification(t *testing.T) {
 	conn := NewConnection("test", &model.User{ID: "alice"}, newFakeConn())
 	bus := newStubBus()
@@ -758,6 +785,10 @@ func TestDispatcher_SubNote_UnsubNote(t *testing.T) {
 	conn := NewConnection("test", &model.User{ID: "alice"}, newFakeConn())
 	bus := newStubBus()
 	d := NewDispatcher(conn, nil, bus)
+	// #1460: subNote は noteVisibility 必須 (未配線時は fail-closed で
+	// subscribe しない)。本 test の主旨は refcount semantics なので permissive
+	// stub を wire して旧挙動を維持する。
+	d.SetNoteVisibilityChecker(&stubNoteVisibility{defaultAllow: true})
 
 	// subscribe
 	d.HandleClientMessage("s", json.RawMessage(`{"id":"n1"}`))
@@ -790,6 +821,10 @@ func TestDispatcher_SubNote_UnsubNote(t *testing.T) {
 func TestDispatcher_SubNote_InvalidBody(t *testing.T) {
 	conn := NewConnection("test", &model.User{ID: "alice"}, newFakeConn())
 	d := NewDispatcher(conn, nil, newStubBus())
+	// #1460: 空 body は parse 直後に return するので visibility check 自体
+	// 到達しないが、interface gate 配線後でも panic しないことを確認するため
+	// permissive stub を wire しておく。
+	d.SetNoteVisibilityChecker(&stubNoteVisibility{defaultAllow: true})
 	// empty body → no panic
 	d.HandleClientMessage("s", json.RawMessage(`{}`))
 	d.HandleClientMessage("un", json.RawMessage(`{}`))
@@ -819,6 +854,8 @@ func TestDispatcher_ForwardNoteEvent_TSEnvelope(t *testing.T) {
 			defer conn.Close()
 			bus := newStubBus()
 			d := NewDispatcher(conn, nil, bus)
+			// #1460: subNote の visibility gate を permissive stub で素通り。
+			d.SetNoteVisibilityChecker(&stubNoteVisibility{defaultAllow: true})
 			d.HandleClientMessage("s", json.RawMessage(`{"id":"n1"}`))
 
 			bus.deliver("noteStream:n1", []byte(tc.inner))
@@ -855,6 +892,8 @@ func TestDispatcher_ForwardNoteEvent_InvalidPayload(t *testing.T) {
 	defer conn.Close()
 	bus := newStubBus()
 	d := NewDispatcher(conn, nil, bus)
+	// #1460: subNote の visibility gate を permissive stub で素通り。
+	d.SetNoteVisibilityChecker(&stubNoteVisibility{defaultAllow: true})
 	d.HandleClientMessage("s", json.RawMessage(`{"id":"n1"}`))
 
 	// invalid JSON / 空 type のどちらも Send しない (早期 return)。
@@ -867,6 +906,149 @@ func TestDispatcher_ForwardNoteEvent_InvalidPayload(t *testing.T) {
 	n := len(fc.writes)
 	fc.mu.Unlock()
 	assert.Zero(t, n)
+}
+
+// --- #1460 subNote visibility gate tests ---
+
+// TestDispatcher_SubNote_HiddenNote_NoSubscribe は非可視 note への subNote
+// を checker が拒否した場合、bus.Subscribe / refcount どちらにも痕跡が
+// 残らないことを確認する。refcount 加算前で gate しないと、後から
+// unsubNote で d.noteSubs map state を leak する経路が残るため。
+func TestDispatcher_SubNote_HiddenNote_NoSubscribe(t *testing.T) {
+	conn := NewConnection("test", &model.User{ID: "alice"}, newFakeConn())
+	bus := newStubBus()
+	d := NewDispatcher(conn, nil, bus)
+	stub := &stubNoteVisibility{allowed: map[string]bool{"n1": false}}
+	d.SetNoteVisibilityChecker(stub)
+
+	d.HandleClientMessage("s", json.RawMessage(`{"id":"n1"}`))
+
+	// checker が呼ばれ、viewer が conn.User() で渡っている。
+	assert.Equal(t, 1, stub.calls)
+	require.NotNil(t, stub.lastViewer)
+	assert.Equal(t, "alice", stub.lastViewer.ID)
+
+	bus.mu.Lock()
+	_, subbed := bus.subs["noteStream:n1"]
+	subbedSlice := append([]string(nil), bus.subscribed...)
+	bus.mu.Unlock()
+	assert.False(t, subbed, "should not subscribe to hidden note")
+	assert.NotContains(t, subbedSlice, "noteStream:n1")
+
+	// refcount も加算されていない。後続の unsubNote が noise として
+	// d.noteSubs map state を leak しないため必須。
+	d.noteSubMu.Lock()
+	cnt := d.noteSubs["n1"]
+	d.noteSubMu.Unlock()
+	assert.Equal(t, 0, cnt)
+}
+
+// TestDispatcher_SubNote_HiddenNote_NoEventForwarded は subNote 拒否後に
+// note の publisher が event を流しても、subscribe 自体が存在しないため
+// client 側 write が 1 件も発生しないことを end-to-end で確認する
+// (issue #1460 完了条件の「event を受け取らない」を担保)。
+func TestDispatcher_SubNote_HiddenNote_NoEventForwarded(t *testing.T) {
+	fc := newFakeConn()
+	conn := NewConnection("test", &model.User{ID: "alice"}, fc)
+	go conn.Start()
+	defer conn.Close()
+	bus := newStubBus()
+	d := NewDispatcher(conn, nil, bus)
+	d.SetNoteVisibilityChecker(&stubNoteVisibility{allowed: map[string]bool{"n1": false}})
+
+	d.HandleClientMessage("s", json.RawMessage(`{"id":"n1"}`))
+	// publisher が event を流しても deliver 先 handler が登録されていない
+	// ので no-op になる。
+	bus.deliver("noteStream:n1", []byte(`{"type":"reacted","body":{"reaction":":smile:","userId":"u1"}}`))
+
+	time.Sleep(50 * time.Millisecond)
+	fc.mu.Lock()
+	n := len(fc.writes)
+	fc.mu.Unlock()
+	assert.Zero(t, n, "no event should reach client for denied subscribe")
+}
+
+// TestDispatcher_SubNote_PublicNote_Subscribes は permissive checker (=
+// public/home/visible note) の場合、既存の subscribe + event forward が
+// regress していないことを確認する。
+func TestDispatcher_SubNote_PublicNote_Subscribes(t *testing.T) {
+	conn := NewConnection("test", &model.User{ID: "alice"}, newFakeConn())
+	bus := newStubBus()
+	d := NewDispatcher(conn, nil, bus)
+	d.SetNoteVisibilityChecker(&stubNoteVisibility{defaultAllow: true})
+
+	d.HandleClientMessage("s", json.RawMessage(`{"id":"n1"}`))
+
+	bus.mu.Lock()
+	_, subbed := bus.subs["noteStream:n1"]
+	bus.mu.Unlock()
+	assert.True(t, subbed)
+	d.noteSubMu.Lock()
+	cnt := d.noteSubs["n1"]
+	d.noteSubMu.Unlock()
+	assert.Equal(t, 1, cnt)
+}
+
+// TestDispatcher_SubNote_Author_Subscribes は author 自身が自分の
+// followers note を sub する経路。stubNoteVisibility は viewer.ID を見て
+// allow するわけではなく allowed[noteID] map を見るので、本 test では
+// 「allow されている noteID なら viewer が誰であっても通る」ことを確認する
+// (実本番では QueryService.RequireVisible が CanSeeNote 経由で viewer.ID
+// == note.UserID を見て author を素通しする)。
+func TestDispatcher_SubNote_Author_Subscribes(t *testing.T) {
+	conn := NewConnection("test", &model.User{ID: "alice"}, newFakeConn())
+	bus := newStubBus()
+	d := NewDispatcher(conn, nil, bus)
+	stub := &stubNoteVisibility{allowed: map[string]bool{"my-note": true}}
+	d.SetNoteVisibilityChecker(stub)
+
+	d.HandleClientMessage("s", json.RawMessage(`{"id":"my-note"}`))
+
+	require.NotNil(t, stub.lastViewer)
+	assert.Equal(t, "alice", stub.lastViewer.ID)
+	bus.mu.Lock()
+	_, subbed := bus.subs["noteStream:my-note"]
+	bus.mu.Unlock()
+	assert.True(t, subbed)
+}
+
+// TestDispatcher_SubNote_Anonymous_HiddenNote_NoSubscribe は匿名 conn
+// (User()==nil) からの非可視 sub が、checker に nil viewer を渡した上で
+// 拒否されることを確認する。CanSeeNote は nil viewer + followers/specified
+// を必ず false にするので、本経路は production でも自動的に塞がる。
+func TestDispatcher_SubNote_Anonymous_HiddenNote_NoSubscribe(t *testing.T) {
+	conn := NewConnection("test", nil, newFakeConn())
+	bus := newStubBus()
+	d := NewDispatcher(conn, nil, bus)
+	stub := &stubNoteVisibility{allowed: map[string]bool{"n1": false}}
+	d.SetNoteVisibilityChecker(stub)
+
+	d.HandleClientMessage("s", json.RawMessage(`{"id":"n1"}`))
+
+	assert.Equal(t, 1, stub.calls)
+	assert.Nil(t, stub.lastViewer, "anonymous viewer should be passed as nil to checker")
+	bus.mu.Lock()
+	_, subbed := bus.subs["noteStream:n1"]
+	bus.mu.Unlock()
+	assert.False(t, subbed)
+}
+
+// TestDispatcher_SubNote_QueryServiceNil_FailClosed は checker が wire
+// されていないとき (production wiring drift / test の partial setup)
+// subscribe を一切させない fail-closed 挙動を確認する。notifications
+// #1444 と同 doctrine。
+func TestDispatcher_SubNote_QueryServiceNil_FailClosed(t *testing.T) {
+	conn := NewConnection("test", &model.User{ID: "alice"}, newFakeConn())
+	bus := newStubBus()
+	d := NewDispatcher(conn, nil, bus)
+	// 意図的に SetNoteVisibilityChecker を呼ばない。
+
+	d.HandleClientMessage("s", json.RawMessage(`{"id":"n1"}`))
+
+	bus.mu.Lock()
+	_, subbed := bus.subs["noteStream:n1"]
+	bus.mu.Unlock()
+	assert.False(t, subbed, "fail-closed: no checker should block all subscribes")
 }
 
 func countOccurrences(slice []string, target string) int {

--- a/internal/stream/manager.go
+++ b/internal/stream/manager.go
@@ -40,6 +40,7 @@ type Manager struct {
 	notifReader     NotificationReader
 	hardMute        HardMuteRulesLookup
 	followingLookup FollowingSnapshotLookup
+	noteVisibility  NoteVisibilityChecker
 }
 
 // NewManager constructs a Manager with no live connections. registry / bus が
@@ -74,6 +75,14 @@ func (m *Manager) SetFollowingSnapshotLookup(l FollowingSnapshotLookup) {
 	m.followingLookup = l
 }
 
+// SetNoteVisibilityChecker wires a NoteVisibilityChecker so per-connection
+// Dispatcher can refuse subNote subscriptions to non-visible notes
+// (#1460 IDOR fix)。未配線時は fail-closed で全 subNote が subscribe しない
+// (= production の router.go は必ず wire する、notifications #1444 と同 doctrine)。
+func (m *Manager) SetNoteVisibilityChecker(c NoteVisibilityChecker) {
+	m.noteVisibility = c
+}
+
 // Accept implements api/streaming.ConnectionAcceptor. *websocket.Conn から
 // Connection を組み立て、Dispatcher 経由で channel framework に橋渡しする。
 func (m *Manager) Accept(ws *websocket.Conn, user *model.User) {
@@ -93,6 +102,9 @@ func (m *Manager) Accept(ws *websocket.Conn, user *model.User) {
 	dispatcher := NewDispatcher(c, m.registry, m.bus)
 	if m.notifReader != nil {
 		dispatcher.SetNotificationReader(m.notifReader)
+	}
+	if m.noteVisibility != nil {
+		dispatcher.SetNoteVisibilityChecker(m.noteVisibility)
 	}
 	c.SetMessageHandler(dispatcher.HandleClientMessage)
 	c.SetCloseHandler(func() {


### PR DESCRIPTION
## Summary

- `internal/stream/dispatcher.go:handleSubNote` が任意 `noteID` で `noteStream:<id>` topic を素通しで subscribe させていたため、followers / specified visibility note の `reacted` / `unreacted` / `pollVoted` / `deleted` event を非対象 viewer に realtime で leak していた (HTTP 側 #1444 i/notifications IDOR の WS 版)。匿名 conn (`User()==nil`) からも subscribe 可で、anonymous でも engagement metadata を観測できていた。
- stream-local interface `NoteVisibilityChecker` を新設、refcount inc の前に `RequireVisible` で gate し、非可視は silently skip するよう変更。
- `*core/note.QueryService` が既存 `RequireVisible(viewer, noteID)` で本 interface を自動 satisfy するため adapter 不要、router.go で `noteQueryService` をそのまま渡す。

## 主な変更点

| File | 変更 |
|---|---|
| `internal/stream/dispatcher.go` | `NoteVisibilityChecker` interface + Dispatcher field + `SetNoteVisibilityChecker` + `handleSubNote` の visibility gate |
| `internal/stream/manager.go` | Manager field + setter + `Accept` での Dispatcher propagation (`SetNotificationReader` と同形) |
| `internal/server/router.go` | `streamManager.SetNoteVisibilityChecker(noteQueryService)` を `SetFollowingSnapshotLookup` の直後に追加 |
| `internal/stream/dispatcher_test.go` | `stubNoteVisibility` 追加、既存 subNote / forwardNoteEvent test 4 件に permissive stub wire、新規 6 test 追加 |

### 設計の補足

- Dispatcher の既存依存 (`NotificationReader` / `HardMuteRulesLookup` / `FollowingSnapshotLookup`) はすべて stream-local interface なので本 fix もそれに合わせる (notifications #1444 が concrete `*corenote.QueryService` field を持つ pattern とは別)。
- Fail-closed: checker 未配線時は subscribe を丸ごと skip する。notifications #1444 と同 doctrine。production の router.go では必ず wire する前提で、test の partial setup を漏れに繋げない。
- 匿名 conn は `CanSeeNote` の nil-viewer 判定で followers / specified が自動的に弾かれるため、handler 側に追加の nil-special case は不要。
- refcount inc **より前**に gate するので、拒否されたあとに `unsubNote` で `d.noteSubs` の state が leak する経路も発生しない。

## テスト

### 新規 (`internal/stream/dispatcher_test.go`)

- `TestDispatcher_SubNote_HiddenNote_NoSubscribe` — 非可視 → `bus.subs` / `d.noteSubs` どちらにも痕跡なし
- `TestDispatcher_SubNote_HiddenNote_NoEventForwarded` — 拒否後の `bus.deliver` で client write が 0 件 (issue 完了条件「event を受け取らない」を end-to-end で担保)
- `TestDispatcher_SubNote_PublicNote_Subscribes` — permissive で旧 flow が regress していない
- `TestDispatcher_SubNote_Author_Subscribes` — allow されている noteID は viewer が通る
- `TestDispatcher_SubNote_Anonymous_HiddenNote_NoSubscribe` — `User()==nil` で checker に `nil viewer` が渡る + 拒否
- `TestDispatcher_SubNote_QueryServiceNil_FailClosed` — checker 未配線 → subscribe しない

### 既存

- `TestDispatcher_SubNote_UnsubNote` / `TestDispatcher_SubNote_InvalidBody` / `TestDispatcher_ForwardNoteEvent_TSEnvelope` / `TestDispatcher_ForwardNoteEvent_InvalidPayload` に permissive stub を wire (refcount / forward 経路の挙動を変えない最小改変)。

### 実行結果

```
$ make fmt && make lint                                 # clean
$ go test ./internal/stream/... -run SubNote -v         # 8/8 PASS (新6+既存2)
$ go test ./internal/stream/...                         # PASS
$ go test ./internal/server/...                         # PASS
$ go test ./internal/api/notifications/...              # PASS (note.QueryService 利用 package の regression check)
$ go build ./...                                        # clean
```

ローカル環境では `test/e2e` / `test/e2e_federation` / `internal/repository` (testcontainer / PG bind / no route to host) と `internal/safehttp` (IPv6 SSRF test の env 依存) が落ちますが、いずれも `git stash` で revert しても同じ failure を確認済みで、`upstream/develop` に既に存在する pre-existing 環境依存 failure です。CI (GitHub Actions) では PASS する想定。

## その他

- visibility 変更レース (sub 時点 public → 後で followers に絞った場合) は subscription を tear down しない。HTTP `notes/show` #799 ID-known doctrine + #1444 の post-fact 通知 scrub をしない方針と整合させたため、本 fix の範囲外。
- `sr` opcode (`subNote` + `readNotification`) で subscribe 拒否でも `readNotification` 半分は走る。notification 既読化は viewer 自身に対する独立 authorization なので意図的に許可。
- 同 noteID への duplicate sub で毎回 `RequireVisible` を呼ぶ (per-call 1 DB query)。実用上問題ない頻度なので allow-cache は scope 外。

Closes #1460

関連: #1418 (visibility-filter-followups batch) / #1443 / #1444 / #1445 / #1456 (HTTP 側 IDOR fixes) / #799 (notes/show ID-known doctrine — 本 fix には適用不可な点)