### PR TITLE
fix(users): users/followers, users/following に visibility check を追加 (#1461)

### DIFF
--- a/internal/api/users/handler.go
+++ b/internal/api/users/handler.go
@@ -654,6 +654,17 @@ func (h *Handler) listRelations(c echo.Context, followers bool) error {
 	req.SinceID, req.UntilID = id.NormalizeCursor(req.SinceID, req.UntilID, req.SinceDate, req.UntilDate)
 
 	viewer := middleware.GetUser(c)
+
+	// followersVisibility / followingVisibility gate (#1461)。upstream
+	// `users/followers.ts` / `users/following.ts` と同等に、target profile の
+	// 設定で viewer を gate する。moderator は users/reactions 側と同じく
+	// bypass 経路に乗せる (upstream: `!await roleService.isModerator(me)`)。
+	// profile 行が無い (= 古いデータ / remote 未同期) 場合は upstream の
+	// default 値 'public' を採用して素通りさせる。
+	if denied, err := h.gateRelationVisibility(c, req.UserID, viewer, followers); denied {
+		return err
+	}
+
 	var (
 		rows []relationItem
 		err  error
@@ -668,6 +679,63 @@ func (h *Handler) listRelations(c echo.Context, followers bool) error {
 	}
 
 	return c.JSON(http.StatusOK, rows)
+}
+
+// gateRelationVisibility enforces the target user's followersVisibility /
+// followingVisibility setting on users/followers and users/following (#1461).
+// Returns (denied=true, response error) when the viewer must be blocked, or
+// (denied=false, nil) when the request should proceed. followers=true gates
+// the "followers" list (uses FollowersVisibility), followers=false gates the
+// "following" list (uses FollowingVisibility).
+func (h *Handler) gateRelationVisibility(c echo.Context, targetID string, viewer *model.User, followers bool) (bool, error) {
+	// upstream forbidden error UUID は endpoint ごとに別 (drop-in 互換維持)。
+	forbiddenID := "f6cdb0df-c19f-ec5c-7dbb-0ba84a1f92ba" // users/following
+	if followers {
+		forbiddenID = "3c6a84db-d619-26af-ca14-06232a21df8a" // users/followers
+	}
+	deny := func() (bool, error) {
+		return true, c.JSON(http.StatusForbidden, apierr.Error("FORBIDDEN", "Forbidden.", forbiddenID))
+	}
+
+	vis := model.FollowingVisibilityPublic
+	if profile := h.userService.GetProfile(targetID); profile != nil {
+		if followers {
+			vis = profile.FollowersVisibility
+		} else {
+			vis = profile.FollowingVisibility
+		}
+		if vis == "" {
+			vis = model.FollowingVisibilityPublic
+		}
+	}
+	if vis == model.FollowingVisibilityPublic {
+		return false, nil
+	}
+
+	// self / moderator は常に bypass。upstream の
+	// `me.id === user.id` / `roleService.isModerator(me)` 経路に対応。
+	isSelf := viewer != nil && viewer.ID == targetID
+	isMod := viewer != nil && h.moderatorChecker != nil && h.moderatorChecker.IsModerator(viewer.ID)
+	if isSelf || isMod {
+		return false, nil
+	}
+
+	switch vis {
+	case model.FollowingVisibilityPrivate:
+		return deny()
+	case model.FollowingVisibilityFollowers:
+		if viewer == nil || h.followingRepo == nil {
+			return deny()
+		}
+		ok, err := h.followingRepo.Exists(viewer.ID, targetID)
+		if err != nil {
+			return true, apierr.JSONInternalError(c)
+		}
+		if !ok {
+			return deny()
+		}
+	}
+	return false, nil
 }
 
 // relationItem represents a single entry in followers/following lists.

--- a/internal/api/users/handler_test.go
+++ b/internal/api/users/handler_test.go
@@ -1381,13 +1381,15 @@ func TestFollowers_BatchFetchesUsers(t *testing.T) {
 	require.Len(t, resp, 5)
 
 	// listRelations の冒頭で ShowByID(req.UserID) を呼んで target 存在確認
-	// するため、FindByID と FindProfileByUserID が 1 回ずつ走るのは
-	// 想定どおり。重要なのは follower 5 件の解決で per-row 経路に落ちて
+	// するため、FindByID が 1 回走る。FindProfileByUserID は (1) target 存在
+	// 確認 + (2) #1461 の followersVisibility / followingVisibility gate で
+	// 2 回走るが、いずれも target single 行の O(1) lookup なので follower
+	// 件数とは独立。重要なのは follower 5 件の解決で per-row 経路に落ちて
 	// いないこと = listRelations の N+1 が解消されていること。
 	assert.Equal(t, 1, repo.findByIDCalls,
 		"only target existence check should call FindByID; per-row must use batch")
-	assert.Equal(t, 1, repo.findProfileByUserIDCalls,
-		"only target existence check should call FindProfileByUserID; per-row must use batch")
+	assert.Equal(t, 2, repo.findProfileByUserIDCalls,
+		"target existence check + visibility gate (#1461) should call FindProfileByUserID twice; per-row must use batch")
 	assert.Equal(t, 1, repo.findManyByIDsCalls,
 		"FindManyByIDs should be called exactly once per request for the 5 followers")
 	assert.Equal(t, 5, repo.findManyByIDsCallSize,
@@ -1439,6 +1441,207 @@ func TestFollowing_InvalidParam(t *testing.T) {
 	h, _ := newTestHandler(t)
 	rec := post(h.Following, `{}`)
 	assert.Equal(t, http.StatusBadRequest, rec.Code)
+}
+
+// --- followersVisibility / followingVisibility gate (#1461) ---
+//
+// upstream Misskey TS の users/followers.ts (line 115-135) /
+// users/following.ts (line 123-143) と挙動を揃え、profile の
+// followersVisibility / followingVisibility 設定で viewer を gate する。
+// public はそのまま 200、private は self 以外を 403、followers は viewer
+// が target を follow しているときだけ通す。moderator は bypass。
+// drop-in 互換のため 403 body の error.id は endpoint 別 UUID を assert する。
+
+const (
+	uuidUsersFollowersForbidden = "3c6a84db-d619-26af-ca14-06232a21df8a"
+	uuidUsersFollowingForbidden = "f6cdb0df-c19f-ec5c-7dbb-0ba84a1f92ba"
+)
+
+// visibilityModStub は #1461 visibility gate test 用の ModeratorChecker 実装。
+// handler_extra_test.go の stubModeratorChecker と同等 (あちらは users_test
+// package のため白箱 test 側からは参照できないので、内側 package 用に別途
+// 定義する)。
+type visibilityModStub struct{ modID string }
+
+func (s visibilityModStub) IsModerator(userID string) bool { return userID == s.modID }
+
+// setupRelationVisibilityFixture wires target user (user1) with the given
+// followers/following visibility and adds a stand-in follower (alice) so the
+// follower-list returns a non-empty payload when the gate is open.
+func setupRelationVisibilityFixture(t *testing.T, followersVis, followingVis model.FollowingVisibility) (*Handler, *testutil.MockUserRepository) {
+	t.Helper()
+	h, repo := newTestHandler(t)
+	addTestUser(repo) // user1 = target
+	repo.Profiles["user1"] = &model.UserProfile{
+		UserID:              "user1",
+		FollowersVisibility: followersVis,
+		FollowingVisibility: followingVis,
+	}
+	repo.Users["alice"] = &model.User{
+		ID: "alice", Username: "alice", UsernameLower: "alice",
+		AvatarDecorations: datatypes.JSON([]byte("[]")),
+	}
+	_, err := h.followingService.Follow("alice", "user1", corefollowing.FollowOptions{})
+	require.NoError(t, err)
+	// followee 方向もそろえて users/following でも非空 payload になるようにする
+	repo.Users["carol"] = &model.User{
+		ID: "carol", Username: "carol", UsernameLower: "carol",
+		AvatarDecorations: datatypes.JSON([]byte("[]")),
+	}
+	_, err = h.followingService.Follow("user1", "carol", corefollowing.FollowOptions{})
+	require.NoError(t, err)
+	return h, repo
+}
+
+func assertForbiddenWithUUID(t *testing.T, rec *httptest.ResponseRecorder, wantUUID string) {
+	t.Helper()
+	require.Equal(t, http.StatusForbidden, rec.Code)
+	var body map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &body))
+	errObj, ok := body["error"].(map[string]any)
+	require.True(t, ok, "error field must be a map")
+	assert.Equal(t, "FORBIDDEN", errObj["code"])
+	assert.Equal(t, wantUUID, errObj["id"])
+}
+
+// public は anonymous viewer でも従来どおり 200 を返す (regression guard)。
+func TestFollowers_VisibilityPublic_Anonymous(t *testing.T) {
+	h, _ := setupRelationVisibilityFixture(t,
+		model.FollowingVisibilityPublic, model.FollowingVisibilityPublic)
+	rec := post(h.Followers, `{"userId":"user1"}`)
+	assert.Equal(t, http.StatusOK, rec.Code)
+}
+
+func TestFollowing_VisibilityPublic_Anonymous(t *testing.T) {
+	h, _ := setupRelationVisibilityFixture(t,
+		model.FollowingVisibilityPublic, model.FollowingVisibilityPublic)
+	rec := post(h.Following, `{"userId":"user1"}`)
+	assert.Equal(t, http.StatusOK, rec.Code)
+}
+
+// private は self だけ通す。他 viewer / anonymous は 403。
+func TestFollowers_VisibilityPrivate_Self(t *testing.T) {
+	h, repo := setupRelationVisibilityFixture(t,
+		model.FollowingVisibilityPrivate, model.FollowingVisibilityPublic)
+	rec := postStub(h.Followers, `{"userId":"user1"}`, repo.Users["user1"])
+	assert.Equal(t, http.StatusOK, rec.Code)
+}
+
+func TestFollowers_VisibilityPrivate_OtherViewer_Forbidden(t *testing.T) {
+	h, _ := setupRelationVisibilityFixture(t,
+		model.FollowingVisibilityPrivate, model.FollowingVisibilityPublic)
+	rec := postStub(h.Followers, `{"userId":"user1"}`, &model.User{ID: "bob"})
+	assertForbiddenWithUUID(t, rec, uuidUsersFollowersForbidden)
+}
+
+func TestFollowers_VisibilityPrivate_Anonymous_Forbidden(t *testing.T) {
+	h, _ := setupRelationVisibilityFixture(t,
+		model.FollowingVisibilityPrivate, model.FollowingVisibilityPublic)
+	rec := post(h.Followers, `{"userId":"user1"}`)
+	assertForbiddenWithUUID(t, rec, uuidUsersFollowersForbidden)
+}
+
+func TestFollowing_VisibilityPrivate_Self(t *testing.T) {
+	h, repo := setupRelationVisibilityFixture(t,
+		model.FollowingVisibilityPublic, model.FollowingVisibilityPrivate)
+	rec := postStub(h.Following, `{"userId":"user1"}`, repo.Users["user1"])
+	assert.Equal(t, http.StatusOK, rec.Code)
+}
+
+func TestFollowing_VisibilityPrivate_OtherViewer_Forbidden(t *testing.T) {
+	h, _ := setupRelationVisibilityFixture(t,
+		model.FollowingVisibilityPublic, model.FollowingVisibilityPrivate)
+	rec := postStub(h.Following, `{"userId":"user1"}`, &model.User{ID: "bob"})
+	assertForbiddenWithUUID(t, rec, uuidUsersFollowingForbidden)
+}
+
+func TestFollowing_VisibilityPrivate_Anonymous_Forbidden(t *testing.T) {
+	h, _ := setupRelationVisibilityFixture(t,
+		model.FollowingVisibilityPublic, model.FollowingVisibilityPrivate)
+	rec := post(h.Following, `{"userId":"user1"}`)
+	assertForbiddenWithUUID(t, rec, uuidUsersFollowingForbidden)
+}
+
+// followers は follower viewer / self だけ通し、それ以外 (非 follower /
+// anonymous) は 403。
+func TestFollowers_VisibilityFollowers_FollowerViewer(t *testing.T) {
+	h, repo := setupRelationVisibilityFixture(t,
+		model.FollowingVisibilityFollowers, model.FollowingVisibilityPublic)
+	// bob が target (user1) を follow している → 通る。
+	repo.Users["bob"] = &model.User{
+		ID: "bob", Username: "bob", UsernameLower: "bob",
+		AvatarDecorations: datatypes.JSON([]byte("[]")),
+	}
+	_, err := h.followingService.Follow("bob", "user1", corefollowing.FollowOptions{})
+	require.NoError(t, err)
+	rec := postStub(h.Followers, `{"userId":"user1"}`, repo.Users["bob"])
+	assert.Equal(t, http.StatusOK, rec.Code)
+}
+
+func TestFollowers_VisibilityFollowers_NonFollower_Forbidden(t *testing.T) {
+	h, _ := setupRelationVisibilityFixture(t,
+		model.FollowingVisibilityFollowers, model.FollowingVisibilityPublic)
+	rec := postStub(h.Followers, `{"userId":"user1"}`, &model.User{ID: "bob"})
+	assertForbiddenWithUUID(t, rec, uuidUsersFollowersForbidden)
+}
+
+func TestFollowers_VisibilityFollowers_Anonymous_Forbidden(t *testing.T) {
+	h, _ := setupRelationVisibilityFixture(t,
+		model.FollowingVisibilityFollowers, model.FollowingVisibilityPublic)
+	rec := post(h.Followers, `{"userId":"user1"}`)
+	assertForbiddenWithUUID(t, rec, uuidUsersFollowersForbidden)
+}
+
+func TestFollowers_VisibilityFollowers_Self(t *testing.T) {
+	h, repo := setupRelationVisibilityFixture(t,
+		model.FollowingVisibilityFollowers, model.FollowingVisibilityPublic)
+	rec := postStub(h.Followers, `{"userId":"user1"}`, repo.Users["user1"])
+	assert.Equal(t, http.StatusOK, rec.Code)
+}
+
+func TestFollowing_VisibilityFollowers_FollowerViewer(t *testing.T) {
+	h, repo := setupRelationVisibilityFixture(t,
+		model.FollowingVisibilityPublic, model.FollowingVisibilityFollowers)
+	repo.Users["bob"] = &model.User{
+		ID: "bob", Username: "bob", UsernameLower: "bob",
+		AvatarDecorations: datatypes.JSON([]byte("[]")),
+	}
+	_, err := h.followingService.Follow("bob", "user1", corefollowing.FollowOptions{})
+	require.NoError(t, err)
+	rec := postStub(h.Following, `{"userId":"user1"}`, repo.Users["bob"])
+	assert.Equal(t, http.StatusOK, rec.Code)
+}
+
+func TestFollowing_VisibilityFollowers_NonFollower_Forbidden(t *testing.T) {
+	h, _ := setupRelationVisibilityFixture(t,
+		model.FollowingVisibilityPublic, model.FollowingVisibilityFollowers)
+	rec := postStub(h.Following, `{"userId":"user1"}`, &model.User{ID: "bob"})
+	assertForbiddenWithUUID(t, rec, uuidUsersFollowingForbidden)
+}
+
+func TestFollowing_VisibilityFollowers_Anonymous_Forbidden(t *testing.T) {
+	h, _ := setupRelationVisibilityFixture(t,
+		model.FollowingVisibilityPublic, model.FollowingVisibilityFollowers)
+	rec := post(h.Following, `{"userId":"user1"}`)
+	assertForbiddenWithUUID(t, rec, uuidUsersFollowingForbidden)
+}
+
+// moderator は private/followers のいずれも bypass する (upstream
+// roleService.isModerator(me) 経路)。
+func TestFollowers_VisibilityPrivate_ModeratorBypass(t *testing.T) {
+	h, _ := setupRelationVisibilityFixture(t,
+		model.FollowingVisibilityPrivate, model.FollowingVisibilityPublic)
+	h.SetModeratorChecker(visibilityModStub{modID: "u_mod"})
+	rec := postStub(h.Followers, `{"userId":"user1"}`, &model.User{ID: "u_mod"})
+	assert.Equal(t, http.StatusOK, rec.Code)
+}
+
+func TestFollowing_VisibilityPrivate_ModeratorBypass(t *testing.T) {
+	h, _ := setupRelationVisibilityFixture(t,
+		model.FollowingVisibilityPublic, model.FollowingVisibilityPrivate)
+	h.SetModeratorChecker(visibilityModStub{modID: "u_mod"})
+	rec := postStub(h.Following, `{"userId":"user1"}`, &model.User{ID: "u_mod"})
+	assert.Equal(t, http.StatusOK, rec.Code)
 }
 
 func TestShow_BulkUserIDs(t *testing.T) {


### PR DESCRIPTION
## Summary

`users/followers` / `users/following` で target の `followersVisibility` /
`followingVisibility` 設定を見ずに follower / followee list を返していた
privacy IDOR を修正する。`private` / `followers` 設定のアカウントの社会関係を
任意の閲覧者が enumerate できる upstream Misskey TS との乖離・drop-in 互換
違反を解消。

upstream `users/followers.ts:115-135` / `users/following.ts:123-143` と
同等の gate に揃え、403 の error shape (status / code / UUID) も
endpoint 別 UUID で一致させる。

## 主な変更点

### `internal/api/users/handler.go`

- `listRelations` 冒頭の `ShowByID` チェック直後・`collectFollowers` /
  `collectFollowing` 呼び出し前に `gateRelationVisibility` を挿入
- 新規 helper `gateRelationVisibility(c, targetID, viewer, followers)`:
  - target profile を `h.userService.GetProfile(targetID)` で取得
    (profile 行が無い remote 等は upstream 同様 default `public` 扱い)
  - `followers=true` なら `FollowersVisibility`、`false` なら
    `FollowingVisibility` を見る
  - `public` は素通り
  - self (viewer.ID == target) と moderator (既存 `moderatorChecker.IsModerator`
    経由、`users/reactions` と同じ bypass 経路) は常に通す
  - `private` は self/moderator 以外を 403
  - `followers` は viewer が target を follow しているか
    `h.followingRepo.Exists(viewerID, targetID)` で問い合わせ、follower
    でない / anonymous は 403
- 403 body: `code=FORBIDDEN` + endpoint 別 UUID
  (`3c6a84db-…` for followers / `f6cdb0df-…` for following)

### `internal/api/users/handler_test.go`

新規 visibility gate test を 17 件追加 (followers / following 対称):

- `public` + anonymous → 200 (regression guard)
- `private` + self → 200
- `private` + 他 viewer → 403 + 期待 UUID
- `private` + anonymous → 403
- `followers` + follower viewer → 200
- `followers` + 非 follower viewer → 403
- `followers` + anonymous → 403
- `followers` + self → 200
- moderator bypass: `private` + moderator viewer → 200

`assertForbiddenWithUUID` で 403 body の `error.id` まで検証
(drop-in regression 防止)。

`TestFollowers_BatchFetchesUsers` の `findProfileByUserIDCalls` 期待値を
1→2 に更新。visibility gate が target 単行を追加で 1 回 lookup するため
だが、follower 件数 N とは独立なので per-row N+1 でないという test 本来
の意図 (= `findManyByIDsCalls=1` / `findProfilesByUserIDs=1`) は維持。

## テスト

- `go test ./internal/api/users/... -run 'TestFollowers_Visibility|TestFollowing_Visibility' -v` → 17/17 PASS
- `go test ./internal/api/users/` → green、coverage 92.9% (>= 90% threshold)
- `gateRelationVisibility` 単体 coverage 92.9% (uncovered は profile vis 空文字列の
  defensive guard と `followingRepo.Exists` の DB error path のみ、mock に
  error 注入機構が無いため見送り)
- `make lint` (= `go vet ./...`) green
- `gofmt -s -d` diff なし
- `make test` の他 package 失敗 5 件 (gallery / hashtags / repository /
  safehttp / e2e_federation) は develop の clean tree でも同じく failing
  な pre-existing で本 PR 無関係

## Closes

Closes #1461

## その他

- moderator bypass は upstream の `roleService.isModerator(me)` 経路に
  揃えるため含めた (issue 完了条件には明記されていなかったが drop-in 互換
  優先方針で plan 時に確認済)。
- `internal/api/apierr/errors.go` に専用 helper / const を追加するか
  迷ったが、既存の NO_SUCH_USER UUID 振り分けと同じく `listRelations`
  ローカルで followers フラグから UUID 選択するスタイルに揃えた。

🤖 Generated with [Claude Code](https://claude.com/claude-code)