### PR TITLE
fix(antennas): matchNote と Notes handler に visibility check を追加

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Fix: アンテナが他ユーザーのフォロワー限定 / specified ノートを公開範囲チェックを経ずに pickup し、`/api/antennas/notes` と WebSocket `antenna` チャネルの両方からそれらが取得できる問題を修正 (アンテナ作成だけで `src=all` / `src=users` 経由のキーワード検索で非公開投稿が漏れていた)
 - Fix: `useObjectStorage = true` のインスタンスで、`storedInternal = true` なドライブファイルへの `/files/:accessKey` アクセスが常に 404 になる問題を修正 (Misskey TS からの S3 移行前に保存されたローカルファイルが、移行後もアクセス可能に)
 - Fix: Misskey TS から mk-go に移行した直後、既に期限切れだったアンケートに対してアンケート終了 (pollEnded) 通知が一斉発火する問題を修正 (移行時 backfill migration を追加)
 - Fix: 配送先が一時的にダウンしている場合に、deliver/inbox ジョブが設定省略時にリトライされない問題を修正 (既定の試行回数を Misskey 本家と同じ deliver=12 / inbox=8 に。従来の no-retry 挙動が必要な場合は `deliverJobMaxAttempts` / `inboxJobMaxAttempts` に 1 を指定)

--- a/internal/api/antennas/handler.go
+++ b/internal/api/antennas/handler.go
@@ -306,8 +306,10 @@ func (h *Handler) Notes(c echo.Context) error {
 	// visibility filter (defense-in-depth, #1464): push 段 (core/antenna
 	// matchNote) で followers/specified note は antenna owner 視点で gate されて
 	// いるが、過去に stream に滞留した entry や設定ミスに対するフォールバック
-	// として handler でも 1 段 filter する (`channels/timeline` / `user-list-timeline`
-	// と同じパターン)。queryService 未配線時は filter skip (旧挙動)。
+	// として handler でも 1 段 filter する (`notes/user-list-timeline`
+	// (`internal/api/notes/handler_extra.go:UserListTimeline`) と同じパターン。
+	// なお `channels/timeline` は service/repo 層で SQL push-down する別パターン
+	// で filter している (#1440))。queryService 未配線時は filter skip (旧挙動)。
 	if h.queryService != nil {
 		notes = h.queryService.FilterVisible(user, notes)
 	}

--- a/internal/api/antennas/handler.go
+++ b/internal/api/antennas/handler.go
@@ -10,6 +10,7 @@ import (
 	"github.com/shiroha-a/mk/internal/api/apierr"
 	"github.com/shiroha-a/mk/internal/api/pagination"
 	coreantenna "github.com/shiroha-a/mk/internal/core/antenna"
+	corenote "github.com/shiroha-a/mk/internal/core/note"
 	"github.com/shiroha-a/mk/internal/core/notesfilter"
 	"github.com/shiroha-a/mk/internal/entity"
 	"github.com/shiroha-a/mk/internal/misc/id"
@@ -30,12 +31,25 @@ type Handler struct {
 	// userRepo は antennas/notes の hardMutedWords filter (#787) のために
 	// viewer profile を引く。未配線時は filter skip。
 	userRepo repository.UserRepository
+	// queryService は antennas/notes の visibility filter (#1464) で
+	// FilterVisible を呼ぶための note.QueryService。本来 push 段
+	// (core/antenna matchNote) で visibility gate しているが、過去に stream へ
+	// 滞留した entry や設定ミスに対する defense-in-depth として handler でも
+	// 1 段 filter する。未配線時は filter skip (旧挙動)。
+	queryService *corenote.QueryService
 }
 
 // SetUserRepo wires a UserRepository so antennas/notes filters out notes that
 // match the viewer's hardMutedWords (#787).
 func (h *Handler) SetUserRepo(r repository.UserRepository) {
 	h.userRepo = r
+}
+
+// SetQueryService wires a note.QueryService used by Notes as defense-in-depth
+// for visibility filtering (#1464). 通常 push 段 (matchNote) で gate されるが、
+// stream に残留した entry を捌くために handler 側でも 1 段 filter する。
+func (h *Handler) SetQueryService(qs *corenote.QueryService) {
+	h.queryService = qs
 }
 
 // SetNoteFieldResolver attaches the shared resolver that fills Files /
@@ -288,6 +302,14 @@ func (h *Handler) Notes(c echo.Context) error {
 	notes, err := h.noteRepo.FindManyByIDsWithUser(ids)
 	if err != nil {
 		return apierr.JSONInternalError(c)
+	}
+	// visibility filter (defense-in-depth, #1464): push 段 (core/antenna
+	// matchNote) で followers/specified note は antenna owner 視点で gate されて
+	// いるが、過去に stream に滞留した entry や設定ミスに対するフォールバック
+	// として handler でも 1 段 filter する (`channels/timeline` / `user-list-timeline`
+	// と同じパターン)。queryService 未配線時は filter skip (旧挙動)。
+	if h.queryService != nil {
+		notes = h.queryService.FilterVisible(user, notes)
 	}
 	notes = notesfilter.ApplyHardMute(h.userRepo, user, notes)
 	entities := entity.PackNotes(c.Request().Context(), notes, h.idGen, h.instanceLookup(), h.emojiLookup(), h.reactionReader())

--- a/internal/api/antennas/handler.go
+++ b/internal/api/antennas/handler.go
@@ -289,7 +289,16 @@ func (h *Handler) Notes(c echo.Context) error {
 	// sinceDate / untilDate を aidx prefix に正規化 (#1166)。
 	sinceID, untilID := id.NormalizeCursor(req.SinceID, req.UntilID, req.SinceDate, req.UntilDate)
 	req.Limit = pagination.ClampLimit(req.Limit, 10, 100)
-	ids, err := h.svc.Notes(c.Request().Context(), user.ID, req.AntennaID, req.Limit, sinceID, untilID)
+	// over-fetch: stream に滞留した followers/specified entry や hardMute hit が
+	// handler 側 filter で削られると、返却件数が req.Limit を下回り得る。安全側に
+	// limit の 2 倍 (上限 MaxNotesPerAntenna) で stream から拾い、filter 後に
+	// req.Limit へトリミングする (#1467 review)。FE は最後の note id を untilId
+	// に渡してくるため、トリミングしてもページング境界は保たれる。
+	overFetch := req.Limit * 2
+	if overFetch > coreantenna.MaxNotesPerAntenna {
+		overFetch = coreantenna.MaxNotesPerAntenna
+	}
+	ids, err := h.svc.Notes(c.Request().Context(), user.ID, req.AntennaID, overFetch, sinceID, untilID)
 	if err != nil {
 		switch {
 		case errors.Is(err, coreantenna.ErrAntennaNotFound):
@@ -314,6 +323,11 @@ func (h *Handler) Notes(c echo.Context) error {
 		notes = h.queryService.FilterVisible(user, notes)
 	}
 	notes = notesfilter.ApplyHardMute(h.userRepo, user, notes)
+	// over-fetch 分を要求 limit に揃える。FindManyByIDsWithUser が ids の順序を
+	// 保つので newest-first の先頭 req.Limit 件を返せばよい (#1467 review)。
+	if len(notes) > req.Limit {
+		notes = notes[:req.Limit]
+	}
 	entities := entity.PackNotes(c.Request().Context(), notes, h.idGen, h.instanceLookup(), h.emojiLookup(), h.reactionReader())
 	h.fieldRes.Apply(entities, user)
 	out := make([]any, 0, len(entities))

--- a/internal/api/antennas/handler_test.go
+++ b/internal/api/antennas/handler_test.go
@@ -503,6 +503,97 @@ func TestNotes_FollowersNote_FilteredByQueryService(t *testing.T) {
 		"defense-in-depth filter should drop a residual followers note from a non-follower")
 }
 
+// #1467 review: stream の最新側に大量の followers/specified residual entry が
+// 残っていても、handler が over-fetch して filter 後に req.Limit 件を返せること
+// を assert する (ページ欠け対策)。
+//
+// 仕込み: stream に 15 件 push。最新 5 件は alice にとって不可視な followers note、
+// 続く 10 件は public note。req.Limit (デフォルト 10) で叩くと、over-fetch せず
+// に fetch 10 すると最新 5 件が filter で落ちて 5 件しか返らないが、over-fetch
+// (limit*2=20) なら 15 件全部拾って followers 5 件を落として残り 10 件を返せる。
+func TestNotes_OverFetchTrim_PreservesLimitAfterFilterVisible(t *testing.T) {
+	h, repo, noteRepo := newHandler(t)
+	repo.Antennas["a-trim"] = &model.Antenna{ID: "a-trim", UserID: "alice"}
+
+	// alice は author を follow していない (= followers note は不可視)
+	followingRepo := testutil.NewMockFollowingRepository()
+	h.SetQueryService(corenote.NewQueryService(noteRepo, followingRepo))
+
+	ctx := context.Background()
+	// 古い側: public note 10 件 (ms = 100..109)
+	publicIDs := make([]string, 10)
+	for i := 0; i < 10; i++ {
+		nid := fmt.Sprintf("n-pub-%02d", i)
+		publicIDs[i] = nid
+		noteRepo.Notes[nid] = &model.Note{
+			ID: nid, UserID: "author", Visibility: model.NoteVisibilityPublic,
+		}
+		require.NoError(t, testRedis.Client.XAdd(ctx, &redis.XAddArgs{
+			Stream: "antennaTimeline:a-trim",
+			ID:     fmt.Sprintf("%d-0", 100+i),
+			Values: map[string]any{"noteId": nid},
+		}).Err())
+	}
+	// 新しい側: followers note 5 件 (ms = 200..204) — filter で全て落ちる
+	for i := 0; i < 5; i++ {
+		nid := fmt.Sprintf("n-fol-%02d", i)
+		noteRepo.Notes[nid] = &model.Note{
+			ID: nid, UserID: "author", Visibility: model.NoteVisibilityFollowers,
+		}
+		require.NoError(t, testRedis.Client.XAdd(ctx, &redis.XAddArgs{
+			Stream: "antennaTimeline:a-trim",
+			ID:     fmt.Sprintf("%d-0", 200+i),
+			Values: map[string]any{"noteId": nid},
+		}).Err())
+	}
+
+	c, rec := newReq(t, `{"antennaId":"a-trim","limit":10}`)
+	setUser(c, "alice")
+	require.NoError(t, h.Notes(c))
+	assert.Equal(t, http.StatusOK, rec.Code)
+
+	var resp []map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+	// over-fetch trim 後、newest-first で public 10 件が返るはず。
+	assert.Len(t, resp, 10, "handler should return req.Limit notes by over-fetching past the residual followers entries")
+	// followers note は 1 件も含まれない (defense-in-depth filter)
+	body := rec.Body.String()
+	for i := 0; i < 5; i++ {
+		assert.NotContains(t, body, fmt.Sprintf("n-fol-%02d", i),
+			"residual followers note should be filtered out")
+	}
+}
+
+// #1467 review: queryService 未配線時は filter skip = 旧挙動互換 で req.Limit を
+// そのまま渡す (over-fetch しても trim 後の件数は req.Limit に揃う)。
+func TestNotes_OverFetchTrim_QueryServiceUnwired_DefaultLimit(t *testing.T) {
+	h, repo, noteRepo := newHandler(t)
+	repo.Antennas["a-default"] = &model.Antenna{ID: "a-default", UserID: "alice"}
+
+	ctx := context.Background()
+	// 30 件 push して default limit (10) で叩く → trim 後 10 件
+	for i := 0; i < 30; i++ {
+		nid := fmt.Sprintf("n-%02d", i)
+		noteRepo.Notes[nid] = &model.Note{
+			ID: nid, UserID: "alice", Visibility: model.NoteVisibilityPublic,
+		}
+		require.NoError(t, testRedis.Client.XAdd(ctx, &redis.XAddArgs{
+			Stream: "antennaTimeline:a-default",
+			ID:     fmt.Sprintf("%d-0", 100+i),
+			Values: map[string]any{"noteId": nid},
+		}).Err())
+	}
+
+	c, rec := newReq(t, `{"antennaId":"a-default"}`)
+	setUser(c, "alice")
+	require.NoError(t, h.Notes(c))
+	assert.Equal(t, http.StatusOK, rec.Code)
+
+	var resp []map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+	assert.Len(t, resp, 10, "over-fetch should trim back to default limit (10) when no filter drops apply")
+}
+
 // #1464: queryService 配線時、follow 関係があれば followers note は引き続き
 // 表示される (gate が過剰に絞っていないことの guard)。
 func TestNotes_FollowersNote_VisibleToFollower(t *testing.T) {

--- a/internal/api/antennas/handler_test.go
+++ b/internal/api/antennas/handler_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/labstack/echo/v4"
 	"github.com/redis/go-redis/v9"
 	coreantenna "github.com/shiroha-a/mk/internal/core/antenna"
+	corenote "github.com/shiroha-a/mk/internal/core/note"
 	"github.com/shiroha-a/mk/internal/entitycompat/shapetest"
 	"github.com/shiroha-a/mk/internal/misc/id"
 	"github.com/shiroha-a/mk/internal/model"
@@ -471,4 +472,61 @@ func TestNotes_NoteRepoError(t *testing.T) {
 	setUser(c, "alice")
 	require.NoError(t, h.Notes(c))
 	assert.Equal(t, http.StatusInternalServerError, rec.Code)
+}
+
+// #1464: queryService 配線時、stream に残留した followers note は handler の
+// FilterVisible で落ちる (defense-in-depth)。push 段で gate 済の前提だが、
+// 過去 entry 用フォールバックが動くことを confirm する。
+func TestNotes_FollowersNote_FilteredByQueryService(t *testing.T) {
+	h, repo, noteRepo := newHandler(t)
+	repo.Antennas["a-vis"] = &model.Antenna{ID: "a-vis", UserID: "alice"}
+
+	// followingRepo は空 = alice は author を follow していない。
+	followingRepo := testutil.NewMockFollowingRepository()
+	h.SetQueryService(corenote.NewQueryService(noteRepo, followingRepo))
+
+	// stream には残留した「alice にとって不可視な followers note」が積まれている。
+	noteRepo.Notes["n-leak"] = &model.Note{
+		ID: "n-leak", UserID: "author", Visibility: model.NoteVisibilityFollowers,
+	}
+	require.NoError(t, testRedis.Client.XAdd(context.Background(), &redis.XAddArgs{
+		Stream: "antennaTimeline:a-vis",
+		ID:     "1-0",
+		Values: map[string]any{"noteId": "n-leak"},
+	}).Err())
+
+	c, rec := newReq(t, `{"antennaId":"a-vis"}`)
+	setUser(c, "alice")
+	require.NoError(t, h.Notes(c))
+	assert.Equal(t, http.StatusOK, rec.Code)
+	assert.NotContains(t, rec.Body.String(), "n-leak",
+		"defense-in-depth filter should drop a residual followers note from a non-follower")
+}
+
+// #1464: queryService 配線時、follow 関係があれば followers note は引き続き
+// 表示される (gate が過剰に絞っていないことの guard)。
+func TestNotes_FollowersNote_VisibleToFollower(t *testing.T) {
+	h, repo, noteRepo := newHandler(t)
+	repo.Antennas["a-ok"] = &model.Antenna{ID: "a-ok", UserID: "alice"}
+
+	followingRepo := testutil.NewMockFollowingRepository()
+	require.NoError(t, followingRepo.Create(&model.Following{
+		ID: "f1", FollowerID: "alice", FolloweeID: "author",
+	}))
+	h.SetQueryService(corenote.NewQueryService(noteRepo, followingRepo))
+
+	noteRepo.Notes["n-ok"] = &model.Note{
+		ID: "n-ok", UserID: "author", Visibility: model.NoteVisibilityFollowers,
+	}
+	require.NoError(t, testRedis.Client.XAdd(context.Background(), &redis.XAddArgs{
+		Stream: "antennaTimeline:a-ok",
+		ID:     "1-0",
+		Values: map[string]any{"noteId": "n-ok"},
+	}).Err())
+
+	c, rec := newReq(t, `{"antennaId":"a-ok"}`)
+	setUser(c, "alice")
+	require.NoError(t, h.Notes(c))
+	assert.Equal(t, http.StatusOK, rec.Code)
+	assert.Contains(t, rec.Body.String(), "n-ok")
 }

--- a/internal/core/antenna/antenna_service.go
+++ b/internal/core/antenna/antenna_service.go
@@ -431,6 +431,11 @@ func (s *Service) matchNote(a *model.Antenna, n *model.Note, author *model.User)
 	if !corenote.CanSeeNote(owner, n, s.followingRepo) {
 		return false
 	}
+	// followers visibility かつ owner != author で CanSeeNote を通った場合、
+	// 内部で `followingRepo.Exists(owner.ID, author.ID) == true` が確定している。
+	// `home` source は同じ pair の follow を再 query するため、ヒントとして
+	// matchSource に渡し重複呼び出しを避ける (#1467 review nit)。
+	ownerFollowsAuthor := n.Visibility == model.NoteVisibilityFollowers && a.UserID != author.ID
 	if a.LocalOnly && author.Host != nil && *author.Host != "" {
 		return false
 	}
@@ -443,7 +448,7 @@ func (s *Service) matchNote(a *model.Antenna, n *model.Note, author *model.User)
 	if !a.WithReplies && n.ReplyID != nil {
 		return false
 	}
-	if !s.matchSource(a, author) {
+	if !s.matchSource(a, author, ownerFollowsAuthor) {
 		return false
 	}
 	text := noteText(n)
@@ -466,13 +471,20 @@ func (s *Service) matchNote(a *model.Antenna, n *model.Note, author *model.User)
 //
 // followingRepo / userListRepo が未注入のときは対応ソースを match 不成立
 // とみなす (all へのフォールバックではなく、設定ミスが検出しやすい側)。
-func (s *Service) matchSource(a *model.Antenna, author *model.User) bool {
+//
+// ownerFollowsAuthor は matchNote 内 visibility gate (CanSeeNote) で既に
+// `Exists(owner, author) == true` が確定している場合 true。`home` source の
+// 重複 Exists 呼び出しをスキップするヒント (#1467 review nit)。
+func (s *Service) matchSource(a *model.Antenna, author *model.User, ownerFollowsAuthor bool) bool {
 	switch a.Src {
 	case model.AntennaSourceUsers:
 		return slices.Contains(a.Users, author.Username)
 	case model.AntennaSourceUsersBlacklist:
 		return !slices.Contains(a.Users, author.Username)
 	case model.AntennaSourceHome:
+		if ownerFollowsAuthor {
+			return true
+		}
 		if s.followingRepo == nil {
 			return false
 		}

--- a/internal/core/antenna/antenna_service.go
+++ b/internal/core/antenna/antenna_service.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/lib/pq"
 	"github.com/redis/go-redis/v9"
+	corenote "github.com/shiroha-a/mk/internal/core/note"
 	"github.com/shiroha-a/mk/internal/misc/id"
 	"github.com/shiroha-a/mk/internal/model"
 	"github.com/shiroha-a/mk/internal/repository"
@@ -407,14 +408,29 @@ func (s *Service) pushNote(ctx context.Context, antennaID, noteID string, now ti
 
 // matchNote evaluates whether the note satisfies the antenna's filter set.
 // 評価順 (短絡):
-//  1. localOnly でリモート著者なら false
-//  2. excludeBots で bot 著者なら false
-//  3. withFile が真でファイル添付がなければ false
-//  4. withReplies が偽で reply なら false
-//  5. source 別に user フィルタを適用
-//  6. keywords (DNF) のいずれかにマッチしなければ false
-//  7. excludeKeywords (DNF) のいずれかにマッチすれば false
+//  1. visibility が antenna owner から見える (= CanSeeNote 相当) かを check
+//  2. localOnly でリモート著者なら false
+//  3. excludeBots で bot 著者なら false
+//  4. withFile が真でファイル添付がなければ false
+//  5. withReplies が偽で reply なら false
+//  6. source 別に user フィルタを適用
+//  7. keywords (DNF) のいずれかにマッチしなければ false
+//  8. excludeKeywords (DNF) のいずれかにマッチすれば false
+//
+// 旧実装は visibility を一切見ずに matched 判定で antenna stream へ push して
+// いたため、`src=all` / `src=users` 等の broad source antenna が「antenna owner が
+// follow していない author の followers / specified note」を pickup して
+// content leak する IDOR があった (#1464)。CanSeeNote 相当を push 段で
+// 1 回 gate することで REST `antennas/notes` と WS `antenna` channel の両方で
+// 漏洩を断つ。
 func (s *Service) matchNote(a *model.Antenna, n *model.Note, author *model.User) bool {
+	// visibility gate: antenna owner を viewer とみなして CanSeeNote 判定する。
+	// followingRepo 未配線時は CanSeeNote の semantics 通り `followers` を
+	// 投稿者本人以外には見せない fail-closed (= matchSource `home` と同じ方針)。
+	owner := &model.User{ID: a.UserID}
+	if !corenote.CanSeeNote(owner, n, s.followingRepo) {
+		return false
+	}
 	if a.LocalOnly && author.Host != nil && *author.Host != "" {
 		return false
 	}

--- a/internal/core/antenna/antenna_service_test.go
+++ b/internal/core/antenna/antenna_service_test.go
@@ -1073,3 +1073,62 @@ func TestOnNoteCreated_PublicNote_PushedRegardlessOfFollow(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, []string{"n-public"}, rows)
 }
+
+// countingFollowingRepo は Exists の呼び出し回数を記録する MockFollowingRepository
+// の薄い wrap。#1467 review nit (home source の Exists 二重呼び出し回避) の回帰テスト
+// 専用。Following struct を直接操作するため map にも直接 push する。
+type countingFollowingRepo struct {
+	*testutil.MockFollowingRepository
+	existsCalls int
+}
+
+func newCountingFollowingRepo() *countingFollowingRepo {
+	return &countingFollowingRepo{MockFollowingRepository: testutil.NewMockFollowingRepository()}
+}
+
+func (c *countingFollowingRepo) Exists(followerID, followeeID string) (bool, error) {
+	c.existsCalls++
+	return c.MockFollowingRepository.Exists(followerID, followeeID)
+}
+
+// #1467 review nit: home source antenna が followers visibility note を pickup する
+// ケースで、CanSeeNote 内 (`Exists(owner, author)`) と matchSource 内
+// (`Exists(a.UserID, author.ID)`) の同一 pair に対する Exists を 1 回に畳めている
+// ことを assert する。
+func TestMatchNote_HomeSource_FollowersNote_NoDuplicateExists(t *testing.T) {
+	svc, _ := newSvc(t)
+	counting := newCountingFollowingRepo()
+	// owner → author を follow
+	require.NoError(t, counting.Create(&model.Following{ID: "f1", FollowerID: "owner", FolloweeID: "author"}))
+	svc.SetFollowingRepo(counting)
+	a, err := svc.Create(CreateInput{OwnerID: "owner", Name: "home-followers", Src: model.AntennaSourceHome})
+	require.NoError(t, err)
+
+	text := "hi"
+	n := &model.Note{ID: "n1", UserID: "author", Text: &text, Visibility: model.NoteVisibilityFollowers}
+	author := &model.User{ID: "author", Username: "author"}
+
+	require.True(t, svc.matchNote(a, n, author))
+	assert.Equal(t, 1, counting.existsCalls,
+		"Exists should be called exactly once for home source + followers visibility (no duplicate after #1467 review)")
+}
+
+// home source + public note では visibility gate (CanSeeNote) が Exists を呼ばないため、
+// matchSource 側の Exists が 1 回だけ走る。NoDuplicateExists test の対照 (公開範囲が
+// followers でないと最適化の前提も失われていないことを示す)。
+func TestMatchNote_HomeSource_PublicNote_SingleExists(t *testing.T) {
+	svc, _ := newSvc(t)
+	counting := newCountingFollowingRepo()
+	require.NoError(t, counting.Create(&model.Following{ID: "f1", FollowerID: "owner", FolloweeID: "author"}))
+	svc.SetFollowingRepo(counting)
+	a, err := svc.Create(CreateInput{OwnerID: "owner", Name: "home-public", Src: model.AntennaSourceHome})
+	require.NoError(t, err)
+
+	text := "hi"
+	n := &model.Note{ID: "n1", UserID: "author", Text: &text, Visibility: model.NoteVisibilityPublic}
+	author := &model.User{ID: "author", Username: "author"}
+
+	require.True(t, svc.matchNote(a, n, author))
+	assert.Equal(t, 1, counting.existsCalls,
+		"public visibility skips CanSeeNote Exists; matchSource home performs the single call")
+}

--- a/internal/core/antenna/antenna_service_test.go
+++ b/internal/core/antenna/antenna_service_test.go
@@ -455,14 +455,14 @@ func TestOnNoteCreated_SelfAuthoredSkipsUnread(t *testing.T) {
 func TestOnNoteCreated_NilArgsAreNoOp(t *testing.T) {
 	svc, _ := newSvc(t)
 	svc.OnNoteCreated(nil, &model.User{})
-	svc.OnNoteCreated(&model.Note{}, nil)
+	svc.OnNoteCreated(&model.Note{Visibility: model.NoteVisibilityPublic}, nil)
 }
 
 func TestOnNoteCreated_RepoErrorIsNoOp(t *testing.T) {
 	repo := testutil.NewMockAntennaRepository()
 	svc := NewService(&listFailRepo{repo}, testutil.NewMockUserRepository(), testRedis.Client, idGen)
 	text := "hi"
-	svc.OnNoteCreated(&model.Note{ID: "n1", Text: &text}, &model.User{ID: "u1"})
+	svc.OnNoteCreated(&model.Note{ID: "n1", Text: &text, Visibility: model.NoteVisibilityPublic}, &model.User{ID: "u1"})
 }
 
 // listFailRepo causes ListAllActive to fail.
@@ -480,7 +480,7 @@ func TestOnNoteCreated_NoMatchSkipped(t *testing.T) {
 
 	text := "hello world"
 	svc.OnNoteCreated(
-		&model.Note{ID: "n1", Text: &text},
+		&model.Note{ID: "n1", Text: &text, Visibility: model.NoteVisibilityPublic},
 		&model.User{ID: "author", Username: "alice"},
 	)
 
@@ -497,7 +497,7 @@ func TestMatchNote_LocalOnlyRejectsRemote(t *testing.T) {
 		a.LocalOnly = true
 	})
 	host := "remote.example"
-	require.False(t, svc.matchNote(repo.Antennas["a1"], &model.Note{}, &model.User{Host: &host}))
+	require.False(t, svc.matchNote(repo.Antennas["a1"], &model.Note{Visibility: model.NoteVisibilityPublic}, &model.User{Host: &host}))
 }
 
 func TestMatchNote_ExcludeBotsRejectsBot(t *testing.T) {
@@ -505,7 +505,7 @@ func TestMatchNote_ExcludeBotsRejectsBot(t *testing.T) {
 	repo.Antennas["a1"] = makeAntenna(t, "a1", "u1", nil, func(a *model.Antenna) {
 		a.ExcludeBots = true
 	})
-	require.False(t, svc.matchNote(repo.Antennas["a1"], &model.Note{}, &model.User{IsBot: true}))
+	require.False(t, svc.matchNote(repo.Antennas["a1"], &model.Note{Visibility: model.NoteVisibilityPublic}, &model.User{IsBot: true}))
 }
 
 func TestMatchNote_WithFileRequiresAttachment(t *testing.T) {
@@ -513,15 +513,15 @@ func TestMatchNote_WithFileRequiresAttachment(t *testing.T) {
 	repo.Antennas["a1"] = makeAntenna(t, "a1", "u1", nil, func(a *model.Antenna) {
 		a.WithFile = true
 	})
-	require.False(t, svc.matchNote(repo.Antennas["a1"], &model.Note{}, &model.User{}))
-	require.True(t, svc.matchNote(repo.Antennas["a1"], &model.Note{FileIDs: []string{"f1"}}, &model.User{}))
+	require.False(t, svc.matchNote(repo.Antennas["a1"], &model.Note{Visibility: model.NoteVisibilityPublic}, &model.User{}))
+	require.True(t, svc.matchNote(repo.Antennas["a1"], &model.Note{FileIDs: []string{"f1"}, Visibility: model.NoteVisibilityPublic}, &model.User{}))
 }
 
 func TestMatchNote_WithRepliesFalseRejectsReplies(t *testing.T) {
 	svc, repo := newSvc(t)
 	repo.Antennas["a1"] = makeAntenna(t, "a1", "u1", nil)
 	parent := "p1"
-	require.False(t, svc.matchNote(repo.Antennas["a1"], &model.Note{ReplyID: &parent}, &model.User{}))
+	require.False(t, svc.matchNote(repo.Antennas["a1"], &model.Note{ReplyID: &parent, Visibility: model.NoteVisibilityPublic}, &model.User{}))
 }
 
 func TestMatchNote_WithRepliesTrueAllowsReplies(t *testing.T) {
@@ -530,7 +530,7 @@ func TestMatchNote_WithRepliesTrueAllowsReplies(t *testing.T) {
 		a.WithReplies = true
 	})
 	parent := "p1"
-	require.True(t, svc.matchNote(repo.Antennas["a1"], &model.Note{ReplyID: &parent}, &model.User{}))
+	require.True(t, svc.matchNote(repo.Antennas["a1"], &model.Note{ReplyID: &parent, Visibility: model.NoteVisibilityPublic}, &model.User{}))
 }
 
 func TestMatchNote_UsersSourceWhitelist(t *testing.T) {
@@ -539,8 +539,8 @@ func TestMatchNote_UsersSourceWhitelist(t *testing.T) {
 		a.Src = model.AntennaSourceUsers
 		a.Users = []string{"alice"}
 	})
-	require.True(t, svc.matchNote(repo.Antennas["a1"], &model.Note{}, &model.User{Username: "alice"}))
-	require.False(t, svc.matchNote(repo.Antennas["a1"], &model.Note{}, &model.User{Username: "bob"}))
+	require.True(t, svc.matchNote(repo.Antennas["a1"], &model.Note{Visibility: model.NoteVisibilityPublic}, &model.User{Username: "alice"}))
+	require.False(t, svc.matchNote(repo.Antennas["a1"], &model.Note{Visibility: model.NoteVisibilityPublic}, &model.User{Username: "bob"}))
 }
 
 func TestMatchNote_UsersBlacklist(t *testing.T) {
@@ -549,8 +549,8 @@ func TestMatchNote_UsersBlacklist(t *testing.T) {
 		a.Src = model.AntennaSourceUsersBlacklist
 		a.Users = []string{"alice"}
 	})
-	require.False(t, svc.matchNote(repo.Antennas["a1"], &model.Note{}, &model.User{Username: "alice"}))
-	require.True(t, svc.matchNote(repo.Antennas["a1"], &model.Note{}, &model.User{Username: "bob"}))
+	require.False(t, svc.matchNote(repo.Antennas["a1"], &model.Note{Visibility: model.NoteVisibilityPublic}, &model.User{Username: "alice"}))
+	require.True(t, svc.matchNote(repo.Antennas["a1"], &model.Note{Visibility: model.NoteVisibilityPublic}, &model.User{Username: "bob"}))
 }
 
 func TestMatchNote_KeywordsCaseSensitiveMiss(t *testing.T) {
@@ -559,7 +559,7 @@ func TestMatchNote_KeywordsCaseSensitiveMiss(t *testing.T) {
 		a.CaseSensitive = true
 	})
 	text := "this is misskey"
-	require.False(t, svc.matchNote(repo.Antennas["a1"], &model.Note{Text: &text}, &model.User{}))
+	require.False(t, svc.matchNote(repo.Antennas["a1"], &model.Note{Text: &text, Visibility: model.NoteVisibilityPublic}, &model.User{}))
 }
 
 func TestMatchNote_KeywordsCaseSensitiveHit(t *testing.T) {
@@ -568,7 +568,7 @@ func TestMatchNote_KeywordsCaseSensitiveHit(t *testing.T) {
 		a.CaseSensitive = true
 	})
 	text := "this is Misskey"
-	require.True(t, svc.matchNote(repo.Antennas["a1"], &model.Note{Text: &text}, &model.User{}))
+	require.True(t, svc.matchNote(repo.Antennas["a1"], &model.Note{Text: &text, Visibility: model.NoteVisibilityPublic}, &model.User{}))
 }
 
 func TestMatchNote_KeywordsAndOr(t *testing.T) {
@@ -578,9 +578,9 @@ func TestMatchNote_KeywordsAndOr(t *testing.T) {
 	hit1 := "foo bar"
 	hit2 := "baz only"
 	miss := "foo only"
-	require.True(t, svc.matchNote(repo.Antennas["a1"], &model.Note{Text: &hit1}, &model.User{}))
-	require.True(t, svc.matchNote(repo.Antennas["a1"], &model.Note{Text: &hit2}, &model.User{}))
-	require.False(t, svc.matchNote(repo.Antennas["a1"], &model.Note{Text: &miss}, &model.User{}))
+	require.True(t, svc.matchNote(repo.Antennas["a1"], &model.Note{Text: &hit1, Visibility: model.NoteVisibilityPublic}, &model.User{}))
+	require.True(t, svc.matchNote(repo.Antennas["a1"], &model.Note{Text: &hit2, Visibility: model.NoteVisibilityPublic}, &model.User{}))
+	require.False(t, svc.matchNote(repo.Antennas["a1"], &model.Note{Text: &miss, Visibility: model.NoteVisibilityPublic}, &model.User{}))
 }
 
 func TestMatchNote_ExcludeKeywords(t *testing.T) {
@@ -591,8 +591,8 @@ func TestMatchNote_ExcludeKeywords(t *testing.T) {
 	})
 	dirty := "this is spam"
 	clean := "this is fine"
-	require.False(t, svc.matchNote(repo.Antennas["a1"], &model.Note{Text: &dirty}, &model.User{}))
-	require.True(t, svc.matchNote(repo.Antennas["a1"], &model.Note{Text: &clean}, &model.User{}))
+	require.False(t, svc.matchNote(repo.Antennas["a1"], &model.Note{Text: &dirty, Visibility: model.NoteVisibilityPublic}, &model.User{}))
+	require.True(t, svc.matchNote(repo.Antennas["a1"], &model.Note{Text: &clean, Visibility: model.NoteVisibilityPublic}, &model.User{}))
 }
 
 func TestMatchNote_BadKeywordsJSONTreatedAsEmpty(t *testing.T) {
@@ -602,7 +602,7 @@ func TestMatchNote_BadKeywordsJSONTreatedAsEmpty(t *testing.T) {
 	})
 	// 不正 JSON は emptyMatches=true として扱うので keyword フィルタは pass
 	// (matchKeywords が true を返す)
-	require.True(t, svc.matchNote(repo.Antennas["a1"], &model.Note{}, &model.User{}))
+	require.True(t, svc.matchNote(repo.Antennas["a1"], &model.Note{Visibility: model.NoteVisibilityPublic}, &model.User{}))
 }
 
 func TestMatchNote_NilKeywordsTreatedAsEmpty(t *testing.T) {
@@ -610,7 +610,7 @@ func TestMatchNote_NilKeywordsTreatedAsEmpty(t *testing.T) {
 	repo.Antennas["a1"] = makeAntenna(t, "a1", "u1", nil, func(a *model.Antenna) {
 		a.Keywords = nil // empty raw → emptyMatches=true
 	})
-	require.True(t, svc.matchNote(repo.Antennas["a1"], &model.Note{}, &model.User{}))
+	require.True(t, svc.matchNote(repo.Antennas["a1"], &model.Note{Visibility: model.NoteVisibilityPublic}, &model.User{}))
 }
 
 func TestMatchNote_EmptyInnerGroupSkipped(t *testing.T) {
@@ -621,15 +621,15 @@ func TestMatchNote_EmptyInnerGroupSkipped(t *testing.T) {
 		a.Keywords = datatypes.JSON([]byte(`[[],["foo"]]`))
 	})
 	miss := "no match here"
-	require.False(t, svc.matchNote(repo.Antennas["a1"], &model.Note{Text: &miss}, &model.User{}))
+	require.False(t, svc.matchNote(repo.Antennas["a1"], &model.Note{Text: &miss, Visibility: model.NoteVisibilityPublic}, &model.User{}))
 	hit := "foo here"
-	require.True(t, svc.matchNote(repo.Antennas["a1"], &model.Note{Text: &hit}, &model.User{}))
+	require.True(t, svc.matchNote(repo.Antennas["a1"], &model.Note{Text: &hit, Visibility: model.NoteVisibilityPublic}, &model.User{}))
 }
 
 func TestNoteText_CWAndText(t *testing.T) {
 	cw := "warning"
 	text := "body"
-	n := &model.Note{CW: &cw, Text: &text}
+	n := &model.Note{CW: &cw, Text: &text, Visibility: model.NoteVisibilityPublic}
 	got := noteText(n)
 	assert.Contains(t, got, "warning")
 	assert.Contains(t, got, "body")
@@ -668,7 +668,7 @@ func TestMatchNote_HomeSource_Follows(t *testing.T) {
 	a, err := svc.Create(CreateInput{OwnerID: "u1", Name: "homeA", Src: model.AntennaSourceHome})
 	require.NoError(t, err)
 	text := "hi"
-	n := &model.Note{ID: "n1", UserID: "alice", Text: &text}
+	n := &model.Note{ID: "n1", UserID: "alice", Text: &text, Visibility: model.NoteVisibilityPublic}
 	assert.True(t, svc.matchNote(a, n, &model.User{ID: "alice", Username: "alice"}))
 }
 
@@ -678,7 +678,7 @@ func TestMatchNote_HomeSource_NotFollowing(t *testing.T) {
 	a, err := svc.Create(CreateInput{OwnerID: "u1", Name: "homeB", Src: model.AntennaSourceHome})
 	require.NoError(t, err)
 	text := "hi"
-	n := &model.Note{ID: "n1", UserID: "bob", Text: &text}
+	n := &model.Note{ID: "n1", UserID: "bob", Text: &text, Visibility: model.NoteVisibilityPublic}
 	assert.False(t, svc.matchNote(a, n, &model.User{ID: "bob", Username: "bob"}))
 }
 
@@ -688,7 +688,7 @@ func TestMatchNote_HomeSource_NilRepoMisses(t *testing.T) {
 	a, err := svc.Create(CreateInput{OwnerID: "u1", Name: "homeC", Src: model.AntennaSourceHome})
 	require.NoError(t, err)
 	text := "hi"
-	n := &model.Note{ID: "n1", UserID: "alice", Text: &text}
+	n := &model.Note{ID: "n1", UserID: "alice", Text: &text, Visibility: model.NoteVisibilityPublic}
 	assert.False(t, svc.matchNote(a, n, &model.User{ID: "alice", Username: "alice"}))
 }
 
@@ -703,7 +703,7 @@ func TestMatchNote_ListSource_MemberMatches(t *testing.T) {
 	a, err := svc.Create(CreateInput{OwnerID: "u1", Name: "listA", Src: model.AntennaSourceList, UserListID: &listID})
 	require.NoError(t, err)
 	text := "hi"
-	n := &model.Note{ID: "n1", UserID: "alice", Text: &text}
+	n := &model.Note{ID: "n1", UserID: "alice", Text: &text, Visibility: model.NoteVisibilityPublic}
 	assert.True(t, svc.matchNote(a, n, &model.User{ID: "alice", Username: "alice"}))
 }
 
@@ -716,7 +716,7 @@ func TestMatchNote_ListSource_NonMember(t *testing.T) {
 	a, err := svc.Create(CreateInput{OwnerID: "u1", Name: "listB", Src: model.AntennaSourceList, UserListID: &listID})
 	require.NoError(t, err)
 	text := "hi"
-	n := &model.Note{ID: "n1", UserID: "bob", Text: &text}
+	n := &model.Note{ID: "n1", UserID: "bob", Text: &text, Visibility: model.NoteVisibilityPublic}
 	assert.False(t, svc.matchNote(a, n, &model.User{ID: "bob", Username: "bob"}))
 }
 
@@ -754,22 +754,22 @@ func TestOnNoteCreated_ListSource_OnlyMemberNotesAppear(t *testing.T) {
 
 	// リストメンバー alice のノート → アンテナに届くはず
 	text1 := "hello from alice"
-	n1 := &model.Note{ID: "n1", UserID: "alice", Text: &text1}
+	n1 := &model.Note{ID: "n1", UserID: "alice", Text: &text1, Visibility: model.NoteVisibilityPublic}
 	svc.OnNoteCreated(n1, &model.User{ID: "alice", Username: "alice"})
 
 	// 非メンバー bob のノート → アンテナに届かないはず
 	text2 := "hello from bob"
-	n2 := &model.Note{ID: "n2", UserID: "bob", Text: &text2}
+	n2 := &model.Note{ID: "n2", UserID: "bob", Text: &text2, Visibility: model.NoteVisibilityPublic}
 	svc.OnNoteCreated(n2, &model.User{ID: "bob", Username: "bob"})
 
 	// リストメンバー carol のノート → アンテナに届くはず
 	text3 := "hello from carol"
-	n3 := &model.Note{ID: "n3", UserID: "carol", Text: &text3}
+	n3 := &model.Note{ID: "n3", UserID: "carol", Text: &text3, Visibility: model.NoteVisibilityPublic}
 	svc.OnNoteCreated(n3, &model.User{ID: "carol", Username: "carol"})
 
 	// 非メンバー dave のノート → アンテナに届かないはず
 	text4 := "hello from dave"
-	n4 := &model.Note{ID: "n4", UserID: "dave", Text: &text4}
+	n4 := &model.Note{ID: "n4", UserID: "dave", Text: &text4, Visibility: model.NoteVisibilityPublic}
 	svc.OnNoteCreated(n4, &model.User{ID: "dave", Username: "dave"})
 
 	rows, err := svc.Notes(context.Background(), "owner", "ant1", 100, "", "")
@@ -803,21 +803,21 @@ func TestOnNoteCreated_ListSource_WithKeywords(t *testing.T) {
 	// alice のノートでキーワードマッチ → 届く
 	text1 := "I love golang"
 	svc.OnNoteCreated(
-		&model.Note{ID: "n1", UserID: "alice", Text: &text1},
+		&model.Note{ID: "n1", UserID: "alice", Text: &text1, Visibility: model.NoteVisibilityPublic},
 		&model.User{ID: "alice", Username: "alice"},
 	)
 
 	// alice のノートでキーワード不一致 → 届かない
 	text2 := "I love python"
 	svc.OnNoteCreated(
-		&model.Note{ID: "n2", UserID: "alice", Text: &text2},
+		&model.Note{ID: "n2", UserID: "alice", Text: &text2, Visibility: model.NoteVisibilityPublic},
 		&model.User{ID: "alice", Username: "alice"},
 	)
 
 	// 非メンバー bob のノートでキーワードマッチ → 届かない (リスト外)
 	text3 := "I love golang too"
 	svc.OnNoteCreated(
-		&model.Note{ID: "n3", UserID: "bob", Text: &text3},
+		&model.Note{ID: "n3", UserID: "bob", Text: &text3, Visibility: model.NoteVisibilityPublic},
 		&model.User{ID: "bob", Username: "bob"},
 	)
 
@@ -836,7 +836,7 @@ func TestMatchNote_ListSource_NilRepoMisses(t *testing.T) {
 	a, err := svc.Create(CreateInput{OwnerID: "u1", Name: "noRepo", Src: model.AntennaSourceList, UserListID: &listID})
 	require.NoError(t, err)
 	text := "hi"
-	assert.False(t, svc.matchNote(a, &model.Note{Text: &text}, &model.User{ID: "alice", Username: "alice"}))
+	assert.False(t, svc.matchNote(a, &model.Note{Text: &text, Visibility: model.NoteVisibilityPublic}, &model.User{ID: "alice", Username: "alice"}))
 }
 
 // UserListID が nil のとき list ソースは不一致になる。
@@ -850,7 +850,7 @@ func TestMatchNote_ListSource_NilUserListID(t *testing.T) {
 	})
 	repo.Antennas["ant-nil"] = a
 	text := "hi"
-	assert.False(t, svc.matchNote(a, &model.Note{Text: &text}, &model.User{ID: "alice", Username: "alice"}))
+	assert.False(t, svc.matchNote(a, &model.Note{Text: &text, Visibility: model.NoteVisibilityPublic}, &model.User{ID: "alice", Username: "alice"}))
 }
 
 // UserListID が空文字列のとき list ソースは不一致になる。
@@ -865,7 +865,7 @@ func TestMatchNote_ListSource_EmptyUserListID(t *testing.T) {
 	})
 	repo.Antennas["ant-empty"] = a
 	text := "hi"
-	assert.False(t, svc.matchNote(a, &model.Note{Text: &text}, &model.User{ID: "alice", Username: "alice"}))
+	assert.False(t, svc.matchNote(a, &model.Note{Text: &text, Visibility: model.NoteVisibilityPublic}, &model.User{ID: "alice", Username: "alice"}))
 }
 
 // ListMembers がエラーを返す場合 list ソースは不一致になる。
@@ -879,7 +879,7 @@ func TestMatchNote_ListSource_ListMembersError(t *testing.T) {
 	})
 	repo.Antennas["ant-err"] = a
 	text := "hi"
-	assert.False(t, svc.matchNote(a, &model.Note{Text: &text}, &model.User{ID: "alice", Username: "alice"}))
+	assert.False(t, svc.matchNote(a, &model.Note{Text: &text, Visibility: model.NoteVisibilityPublic}, &model.User{ID: "alice", Username: "alice"}))
 }
 
 // failingUserListRepo causes ListMembers and FindByID to fail.
@@ -931,15 +931,145 @@ func TestOnNoteCreated_ListSource_MemberRemoved(t *testing.T) {
 
 	text := "post after removal"
 	svc.OnNoteCreated(
-		&model.Note{ID: "n-alice", UserID: "alice", Text: &text},
+		&model.Note{ID: "n-alice", UserID: "alice", Text: &text, Visibility: model.NoteVisibilityPublic},
 		&model.User{ID: "alice", Username: "alice"},
 	)
 	svc.OnNoteCreated(
-		&model.Note{ID: "n-bob", UserID: "bob", Text: &text},
+		&model.Note{ID: "n-bob", UserID: "bob", Text: &text, Visibility: model.NoteVisibilityPublic},
 		&model.User{ID: "bob", Username: "bob"},
 	)
 
 	rows, err := svc.Notes(context.Background(), "owner", "ant-rm", 100, "", "")
 	require.NoError(t, err)
 	assert.Equal(t, []string{"n-alice"}, rows)
+}
+
+// --- Visibility gate (#1464) ----------------------------------------------
+//
+// matchNote が note visibility に対して CanSeeNote 相当のチェックを行うことを
+// 保証する。`src=all` / `src=users` のような broad source antenna が
+// followers / specified note を pickup してしまう IDOR (#1464) の regression
+// gate。
+
+// followers note: antenna owner が follow していなければ matchNote が false。
+func TestMatchNote_FollowersVisibility_NonFollowerOwnerRejected(t *testing.T) {
+	svc, repo := newSvc(t)
+	// followingRepo を空 (= owner は author を follow していない) で配線
+	svc.SetFollowingRepo(testutil.NewMockFollowingRepository())
+	repo.Antennas["a1"] = makeAntenna(t, "a1", "owner", [][]string{{"hi"}})
+
+	text := "hi"
+	n := &model.Note{ID: "n1", UserID: "author", Text: &text, Visibility: model.NoteVisibilityFollowers}
+	author := &model.User{ID: "author", Username: "alice"}
+
+	require.False(t, svc.matchNote(repo.Antennas["a1"], n, author))
+}
+
+// followers note: antenna owner が follower なら matchNote が true。
+func TestMatchNote_FollowersVisibility_FollowerOwnerAccepted(t *testing.T) {
+	svc, repo := newSvc(t)
+	follows := testutil.NewMockFollowingRepository()
+	// owner → author を follow
+	require.NoError(t, follows.Create(&model.Following{ID: "f1", FollowerID: "owner", FolloweeID: "author"}))
+	svc.SetFollowingRepo(follows)
+	repo.Antennas["a1"] = makeAntenna(t, "a1", "owner", [][]string{{"hi"}})
+
+	text := "hi"
+	n := &model.Note{ID: "n1", UserID: "author", Text: &text, Visibility: model.NoteVisibilityFollowers}
+	author := &model.User{ID: "author", Username: "alice"}
+
+	require.True(t, svc.matchNote(repo.Antennas["a1"], n, author))
+}
+
+// followers note: antenna owner == author なら follow チェック無しで通る。
+func TestMatchNote_FollowersVisibility_SelfAuthored(t *testing.T) {
+	svc, repo := newSvc(t)
+	// followingRepo は無くて良い (本人 short-circuit)
+	repo.Antennas["a1"] = makeAntenna(t, "a1", "author", [][]string{{"hi"}})
+
+	text := "hi"
+	n := &model.Note{ID: "n1", UserID: "author", Text: &text, Visibility: model.NoteVisibilityFollowers}
+	author := &model.User{ID: "author", Username: "alice"}
+
+	require.True(t, svc.matchNote(repo.Antennas["a1"], n, author))
+}
+
+// specified note: antenna owner が visibleUserIds に含まれていなければ false。
+func TestMatchNote_SpecifiedVisibility_NonRecipientRejected(t *testing.T) {
+	svc, repo := newSvc(t)
+	repo.Antennas["a1"] = makeAntenna(t, "a1", "owner", [][]string{{"hi"}})
+
+	text := "hi"
+	n := &model.Note{
+		ID: "n1", UserID: "author", Text: &text,
+		Visibility:     model.NoteVisibilitySpecified,
+		VisibleUserIDs: []string{"someoneElse"},
+	}
+	author := &model.User{ID: "author", Username: "alice"}
+
+	require.False(t, svc.matchNote(repo.Antennas["a1"], n, author))
+}
+
+// specified note: antenna owner が visibleUserIds に含まれていれば true。
+func TestMatchNote_SpecifiedVisibility_RecipientAccepted(t *testing.T) {
+	svc, repo := newSvc(t)
+	repo.Antennas["a1"] = makeAntenna(t, "a1", "owner", [][]string{{"hi"}})
+
+	text := "hi"
+	n := &model.Note{
+		ID: "n1", UserID: "author", Text: &text,
+		Visibility:     model.NoteVisibilitySpecified,
+		VisibleUserIDs: []string{"owner"},
+	}
+	author := &model.User{ID: "author", Username: "alice"}
+
+	require.True(t, svc.matchNote(repo.Antennas["a1"], n, author))
+}
+
+// followingRepo 未配線 + followers note → CanSeeNote の fail-closed semantics
+// で本人以外は reject される (= IDOR fail-closed)。
+func TestMatchNote_FollowersVisibility_NilFollowingRepoFailClosed(t *testing.T) {
+	svc, repo := newSvc(t)
+	// followingRepo を意図的に注入しない (本番でも `home` source 設定ミス検出時と同じ挙動)
+	repo.Antennas["a1"] = makeAntenna(t, "a1", "owner", [][]string{{"hi"}})
+
+	text := "hi"
+	n := &model.Note{ID: "n1", UserID: "author", Text: &text, Visibility: model.NoteVisibilityFollowers}
+	author := &model.User{ID: "author", Username: "alice"}
+
+	require.False(t, svc.matchNote(repo.Antennas["a1"], n, author))
+}
+
+// OnNoteCreated 経由でも push されないことを確認 (REST/WS 両 surface への gate)。
+func TestOnNoteCreated_FollowersNote_NotPushedToNonFollowerAntenna(t *testing.T) {
+	svc, repo := newSvc(t)
+	svc.SetFollowingRepo(testutil.NewMockFollowingRepository()) // 空 → owner は author を follow していない
+	repo.Antennas["a1"] = makeAntenna(t, "a1", "owner", [][]string{{"hi"}})
+
+	text := "hi there"
+	svc.OnNoteCreated(
+		&model.Note{ID: "n-followers", UserID: "author", Text: &text, Visibility: model.NoteVisibilityFollowers},
+		&model.User{ID: "author", Username: "alice"},
+	)
+
+	rows, err := svc.Notes(context.Background(), "owner", "a1", 10, "", "")
+	require.NoError(t, err)
+	assert.Empty(t, rows, "non-follower antenna owner should not receive followers note")
+}
+
+// public note は visibility gate を素通りすることを confirm (regression guard)。
+func TestOnNoteCreated_PublicNote_PushedRegardlessOfFollow(t *testing.T) {
+	svc, repo := newSvc(t)
+	svc.SetFollowingRepo(testutil.NewMockFollowingRepository()) // 空でも public は通る
+	repo.Antennas["a1"] = makeAntenna(t, "a1", "owner", [][]string{{"hi"}})
+
+	text := "hi there"
+	svc.OnNoteCreated(
+		&model.Note{ID: "n-public", UserID: "author", Text: &text, Visibility: model.NoteVisibilityPublic},
+		&model.User{ID: "author", Username: "alice"},
+	)
+
+	rows, err := svc.Notes(context.Background(), "owner", "a1", 10, "", "")
+	require.NoError(t, err)
+	assert.Equal(t, []string{"n-public"}, rows)
 }

--- a/internal/core/antenna/note_hook_test.go
+++ b/internal/core/antenna/note_hook_test.go
@@ -17,7 +17,7 @@ func TestNoteCreateHook_OnNoteCreatedForwards(t *testing.T) {
 	hook := NewNoteCreateHook(svc)
 	text := "hi there"
 	hook.OnNoteCreated(
-		&model.Note{ID: "n1", UserID: "u2", Text: &text},
+		&model.Note{ID: "n1", UserID: "u2", Text: &text, Visibility: model.NoteVisibilityPublic},
 		&model.User{ID: "u2", Username: "alice"},
 	)
 

--- a/internal/server/router.go
+++ b/internal/server/router.go
@@ -1626,6 +1626,7 @@ func (s *Server) setupRoutes() {
 	antennasHandler.SetReactionReader(reactionCountWriter)
 	antennasHandler.SetNoteFieldResolver(noteFieldResolver)
 	antennasHandler.SetUserRepo(userRepo)
+	antennasHandler.SetQueryService(noteQueryService) // #1464: Notes の visibility filter (defense-in-depth)
 	api.POST("/antennas/create", antennasHandler.Create, middleware.RequireAuth())
 	api.POST("/antennas/show", antennasHandler.Show, middleware.RequireAuth())
 	api.POST("/antennas/update", antennasHandler.Update, middleware.RequireAuth())


### PR DESCRIPTION
## Summary

- antenna service の matchNote が note の visibility を一切 check せず matched 判定で `antennaTimeline:<antennaID>` Redis stream へ push していた IDOR (#1464) を修正。
- `src=all` / `src=users` 等の broad source antenna で他ユーザーの followers / specified visibility note が REST `/api/antennas/notes` と WebSocket `antenna` channel の両方からフル shape で取得できる状態だったのを、push 段で `CanSeeNote` 相当の gate を 1 段かけて塞ぐ。
- 加えて `antennas/notes` handler 側に `queryService.FilterVisible` を defense-in-depth として挿し、stream に滞留した過去 entry / 設定ミスへのフォールバックを設けた (`channels/timeline` / `user-list-timeline` と同じパターン)。

## 主な変更点

- `internal/core/antenna/antenna_service.go`
  - `matchNote` の先頭で `core/note.CanSeeNote(owner, n, followingRepo)` 相当の gate を追加。followers は owner == author or follower のみ、specified は visibleUserIds に含まれるか author のみ通す。public / home はそのまま通る。followingRepo 未配線時は CanSeeNote semantics 通り fail-closed。
- `internal/api/antennas/handler.go`
  - `SetQueryService` を追加し、`Notes` 内で `noteRepo.FindManyByIDsWithUser` 直後に `queryService.FilterVisible(user, notes)` を 1 段挟む defense-in-depth filter。queryService 未配線時は filter skip (旧挙動互換)。
- `internal/server/router.go`
  - antennasHandler に `noteQueryService` を wire。
- `internal/core/antenna/antenna_service_test.go` / `note_hook_test.go`
  - 既存 `&model.Note{...}` 構造体に Visibility=public を追加 (visibility gate 導入後の既存テスト互換)。
  - matchNote の visibility gate を public / home / followers (follower / non-follower / self / nil-repo fail-closed) / specified (recipient / non-recipient) で網羅する 8 件の新規ケース。
  - OnNoteCreated 経路で followers note が非フォロー antenna owner に push されないこと、public note は引き続き push されることを assert。
- `internal/api/antennas/handler_test.go`
  - handler 側 (queryService 配線時) で stream 残留 followers note が非フォロー viewer 向けに FilterVisible で落ちること + follower には引き続き表示されること。
- `CHANGELOG.md`
  - Unreleased セクションにエントリを追記。

## テスト

- `go test ./internal/api/antennas/... ./internal/core/antenna/... ./internal/core/note/... ./internal/stream/... ./internal/core/timeline/... ./internal/server/...` — green
- 新規追加した 10 ケース (`TestMatchNote_FollowersVisibility_*` / `TestMatchNote_SpecifiedVisibility_*` / `TestOnNoteCreated_FollowersNote_NotPushedToNonFollowerAntenna` / `TestOnNoteCreated_PublicNote_PushedRegardlessOfFollow` / `TestNotes_FollowersNote_FilteredByQueryService` / `TestNotes_FollowersNote_VisibleToFollower`) がすべて pass。
- `make fmt && make lint` — green。

## Closes

Closes #1464

## その他

- `audit-note-idor-2026-06-02.md` の HIGH-1 + HIGH-2 (同根の REST + WS 両 surface) を 1 PR で対応。
- 残りの監査項目: #1465 (WS userList visibility, HIGH-3) / #1466 (admin/promo/create, MEDIUM-1) は後続 PR で対応。

🤖 Generated with [Claude Code](https://claude.com/claude-code)