### PR TITLE
fix(stream): userList fanout/channel に followers visibility gate を追加

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Fix: ユーザーリストのタイムライン (`/api/notes/user-list-timeline` の REST 経路は #1442 で修正済) について、WebSocket `userList` チャネルと fanout 配信が他ユーザーのフォロワー限定ノートをリスト所有者のフォロー関係に関係なくプッシュしていた問題を修正 (任意のユーザーをリストに追加しただけで、フォローしていない相手のフォロワー限定ノートをリアルタイムに受信できていた)
 - Fix: `useObjectStorage = true` のインスタンスで、`storedInternal = true` なドライブファイルへの `/files/:accessKey` アクセスが常に 404 になる問題を修正 (Misskey TS からの S3 移行前に保存されたローカルファイルが、移行後もアクセス可能に)
 - Fix: Misskey TS から mk-go に移行した直後、既に期限切れだったアンケートに対してアンケート終了 (pollEnded) 通知が一斉発火する問題を修正 (移行時 backfill migration を追加)
 - Fix: 配送先が一時的にダウンしている場合に、deliver/inbox ジョブが設定省略時にリトライされない問題を修正 (既定の試行回数を Misskey 本家と同じ deliver=12 / inbox=8 に。従来の no-retry 挙動が必要な場合は `deliverJobMaxAttempts` / `inboxJobMaxAttempts` に 1 を指定)

--- a/internal/core/antenna/antenna_service_test.go
+++ b/internal/core/antenna/antenna_service_test.go
@@ -903,7 +903,7 @@ func (r *failingUserListRepo) ListMembersByListIDs(_ []string) (map[string][]str
 }
 func (r *failingUserListRepo) UpdateList(_ string, _ map[string]any) error { return nil }
 func (r *failingUserListRepo) UpdateMembership(_, _ string, _ bool) error  { return nil }
-func (r *failingUserListRepo) ListIDsByMember(_ string) ([]string, error) { return nil, nil }
+func (r *failingUserListRepo) ListIDsByMember(_ string) ([]string, error)  { return nil, nil }
 func (r *failingUserListRepo) ListIDsAndOwnersByMember(_ string) (map[string]string, error) {
 	return nil, nil
 }

--- a/internal/core/antenna/antenna_service_test.go
+++ b/internal/core/antenna/antenna_service_test.go
@@ -903,7 +903,10 @@ func (r *failingUserListRepo) ListMembersByListIDs(_ []string) (map[string][]str
 }
 func (r *failingUserListRepo) UpdateList(_ string, _ map[string]any) error { return nil }
 func (r *failingUserListRepo) UpdateMembership(_, _ string, _ bool) error  { return nil }
-func (r *failingUserListRepo) ListIDsByMember(_ string) ([]string, error)  { return nil, nil }
+func (r *failingUserListRepo) ListIDsByMember(_ string) ([]string, error) { return nil, nil }
+func (r *failingUserListRepo) ListIDsAndOwnersByMember(_ string) (map[string]string, error) {
+	return nil, nil
+}
 func (r *failingUserListRepo) ListsContainingMember(_, _ string) ([]*model.UserList, error) {
 	return nil, nil
 }

--- a/internal/core/timeline/fanout_hook.go
+++ b/internal/core/timeline/fanout_hook.go
@@ -362,15 +362,49 @@ func (h *FanoutHook) fanoutToUserLists(ctx context.Context, n *model.Note, autho
 		}
 		return
 	}
+	// distinct な non-self owner を 1 query で「author を follow しているか」
+	// 判定する (#1144 batch method の前例に揃える)。owner ごとに `Exists` を
+	// ループすると、author が多数の異なる owner 所有 list の member の場合に
+	// N+1 になり、同一 owner が複数 list を持つ場合は重複呼び出しになる
+	// (#1468 review)。
+	distinctOwners := make(map[string]struct{}, len(owners))
+	for _, ownerID := range owners {
+		if ownerID == author.ID {
+			continue
+		}
+		distinctOwners[ownerID] = struct{}{}
+	}
+	followingOwners := make(map[string]struct{}, len(distinctOwners))
+	if len(distinctOwners) > 0 {
+		candidates := make([]string, 0, len(distinctOwners))
+		for ownerID := range distinctOwners {
+			candidates = append(candidates, ownerID)
+		}
+		// rows where followerID IN owners AND followeeID = author → returns the
+		// subset of owners that follow author. err 時は fail-closed: 本人 list
+		// 以外は push しない (= 旧 per-owner Exists 失敗時より厳しめだが、
+		// "誰が author を follow しているか" 全く分からない状況で部分 push する
+		// より安全寄り)。
+		filtered, ferr := h.followingRepo.FilterFollowingsToAnchor(author.ID, candidates)
+		if ferr != nil {
+			slog.Warn("fanoutToUserLists: batch follow check failed",
+				"err", ferr, "author", author.ID, "owners", len(candidates))
+			for listID, ownerID := range owners {
+				if ownerID != author.ID {
+					continue
+				}
+				h.pushWithLimit(ctx, UserListTimelineName(listID), n.ID, listCap)
+				h.publishNote("userListTimeline:"+listID, n, author)
+			}
+			return
+		}
+		for _, ownerID := range filtered {
+			followingOwners[ownerID] = struct{}{}
+		}
+	}
 	for listID, ownerID := range owners {
 		if ownerID != author.ID {
-			follows, err := h.followingRepo.Exists(ownerID, author.ID)
-			if err != nil {
-				slog.Warn("fanoutToUserLists: follow check failed",
-					"err", err, "owner", ownerID, "author", author.ID)
-				continue
-			}
-			if !follows {
+			if _, ok := followingOwners[ownerID]; !ok {
 				continue
 			}
 		}

--- a/internal/core/timeline/fanout_hook.go
+++ b/internal/core/timeline/fanout_hook.go
@@ -46,8 +46,13 @@ type StreamingPublisher interface {
 // UserListMemberLookup abstracts the query "which user lists contain this
 // user?" for user list timeline fanout. 循環依存を避けるため interface で
 // 受け取る (実装は repository.UserListRepository)。
+//
+// ListIDsAndOwnersByMember は followers visibility note の per-list owner
+// follow gate (#1465) で使う。owner ごとに author を follow しているかを
+// 確認するため list owner 情報が必要なので、専用の 1-query lookup を分けている。
 type UserListMemberLookup interface {
 	ListIDsByMember(userID string) ([]string, error)
+	ListIDsAndOwnersByMember(memberID string) (map[string]string, error)
 }
 
 // FanoutHook implements note.TimelineFanoutHook by pushing newly-created notes
@@ -307,13 +312,68 @@ func (h *FanoutHook) fanoutToFollowersAndStream(ctx context.Context, authorID st
 }
 
 // fanoutToUserLists pushes the note to all user lists that contain the author.
+//
+// followers visibility note の場合は per-list owner が author を follow している
+// 場合のみ push する (#1465)。user-list は owner が任意のユーザーを member に
+// 追加できる (フォロー関係不要) ので、何も gate しないと「list owner が author
+// を follow していない」状態でも followers note を REST `notes/user-list-timeline`
+// (#1442 で REST 側は SQL/handler で塞いだ) と WS `userList` channel の両方から
+// 取得できてしまう。REST handler の visibility filter は post-fetch で済むが、
+// WS channel は pubsub 受信時点でフィルタを持たないため push 段で gate しないと
+// realtime に漏れる。本人 (`ownerID == author.ID`) は CanSeeNote の short-circuit
+// と同じく無条件 pass。public / home は従来どおり全 list に push する。
 func (h *FanoutHook) fanoutToUserLists(ctx context.Context, n *model.Note, author *model.User, listCap int) {
-	listIDs, err := h.userListRepo.ListIDsByMember(author.ID)
-	if err != nil {
-		slog.Warn("fanoutToUserLists: list lookup failed", "err", err, "author", author.ID)
+	// followers 以外 (public / home) は per-list owner の follow check 不要なので
+	// 旧経路 (ListIDsByMember + 全 list へ push) のままで済ます。これにより
+	// 通常 note の hot path に lookup を増やさない。
+	if n.Visibility != model.NoteVisibilityFollowers {
+		listIDs, err := h.userListRepo.ListIDsByMember(author.ID)
+		if err != nil {
+			slog.Warn("fanoutToUserLists: list lookup failed", "err", err, "author", author.ID)
+			return
+		}
+		for _, listID := range listIDs {
+			h.pushWithLimit(ctx, UserListTimelineName(listID), n.ID, listCap)
+			h.publishNote("userListTimeline:"+listID, n, author)
+		}
 		return
 	}
-	for _, listID := range listIDs {
+
+	// followers visibility: list owner ごとに author を follow しているかを check。
+	// 自分自身 (owner == author) も pass する (CanSeeNote と同じ短絡)。
+	owners, err := h.userListRepo.ListIDsAndOwnersByMember(author.ID)
+	if err != nil {
+		slog.Warn("fanoutToUserLists: list+owner lookup failed", "err", err, "author", author.ID)
+		return
+	}
+	if len(owners) == 0 {
+		return
+	}
+	// followingRepo 未配線時は fail-closed に倒す (= followers visibility note は
+	// 本人 list へのみ push し、他 owner の list には push しない)。
+	// CanSeeNote の semantics と一致させる。
+	if h.followingRepo == nil {
+		for listID, ownerID := range owners {
+			if ownerID != author.ID {
+				continue
+			}
+			h.pushWithLimit(ctx, UserListTimelineName(listID), n.ID, listCap)
+			h.publishNote("userListTimeline:"+listID, n, author)
+		}
+		return
+	}
+	for listID, ownerID := range owners {
+		if ownerID != author.ID {
+			follows, err := h.followingRepo.Exists(ownerID, author.ID)
+			if err != nil {
+				slog.Warn("fanoutToUserLists: follow check failed",
+					"err", err, "owner", ownerID, "author", author.ID)
+				continue
+			}
+			if !follows {
+				continue
+			}
+		}
 		h.pushWithLimit(ctx, UserListTimelineName(listID), n.ID, listCap)
 		h.publishNote("userListTimeline:"+listID, n, author)
 	}

--- a/internal/core/timeline/fanout_hook_test.go
+++ b/internal/core/timeline/fanout_hook_test.go
@@ -598,9 +598,17 @@ func TestFanoutHook_StreamingFanoutAcrossPages(t *testing.T) {
 // calls. 旧実装は Redis push と streaming publish で同じ followers ページネ
 // ーションを 2 回繰り返していた。マージ後は 1 ページにつき 1 call で済む
 // ことを担保する (#300 2-4)。
+//
+// #1468 review の N+1 解消で `Exists` から `FilterFollowingsToAnchor` へ
+// 切り替えた regression gate にも使う。`existsCalls` / `filterToAnchorCalls` /
+// `lastCandidates` を見て「Exists は呼ばれない」「batch query は 1 回・
+// candidates は distinct owner」を assert する。
 type countingFollowingRepo struct {
 	*testutil.MockFollowingRepository
-	listFollowersCalls atomic.Int64
+	listFollowersCalls  atomic.Int64
+	existsCalls         int
+	filterToAnchorCalls int
+	lastCandidates      []string
 }
 
 func (c *countingFollowingRepo) ListFollowers(userID string, limit, offset int) ([]*model.Following, error) {
@@ -608,9 +616,33 @@ func (c *countingFollowingRepo) ListFollowers(userID string, limit, offset int) 
 	return c.MockFollowingRepository.ListFollowers(userID, limit, offset)
 }
 
+func (c *countingFollowingRepo) Exists(followerID, followeeID string) (bool, error) {
+	c.existsCalls++
+	return c.MockFollowingRepository.Exists(followerID, followeeID)
+}
+
+func (c *countingFollowingRepo) FilterFollowingsToAnchor(anchorID string, candidateIDs []string) ([]string, error) {
+	c.filterToAnchorCalls++
+	c.lastCandidates = append([]string(nil), candidateIDs...)
+	return c.MockFollowingRepository.FilterFollowingsToAnchor(anchorID, candidateIDs)
+}
+
 // インターフェース実装は完全に MockFollowingRepository に委譲するための
 // コンパイル時アサート。
 var _ repository.FollowingRepository = (*countingFollowingRepo)(nil)
+
+// failingFilterFollowingRepo wraps MockFollowingRepository so
+// FilterFollowingsToAnchor always errors. Used to assert the fail-closed branch
+// of fanoutToUserLists when batch follow check is unavailable (#1468 review).
+type failingFilterFollowingRepo struct {
+	*testutil.MockFollowingRepository
+}
+
+func (f *failingFilterFollowingRepo) FilterFollowingsToAnchor(_ string, _ []string) ([]string, error) {
+	return nil, assertError{}
+}
+
+var _ repository.FollowingRepository = (*failingFilterFollowingRepo)(nil)
 
 func TestFanoutHook_FollowersFanoutSinglePassListsFollowersOnce(t *testing.T) {
 	testRedis.FlushAll(context.Background())
@@ -928,6 +960,104 @@ func TestFanoutHook_FanoutToUserLists_PublicNote_NoFollowCheck(t *testing.T) {
 	out, err := fanout.Get(ctx, UserListTimelineName("list1"), "", "", 10)
 	require.NoError(t, err)
 	assert.Equal(t, []string{noteID}, out)
+}
+
+// #1468 review: distinct owner 集合に対する FilterFollowingsToAnchor 1 query で
+// 「author を follow している owner」を判定し、per-owner Exists の N+1 を消す。
+// 5 list / 4 distinct owner (うち 1 名重複所有) のシナリオで、batch query は
+// 1 回・候補は distinct owner 数 (3 名、本人除く) だけ渡る・本人 list は
+// 無条件 push される、を assert する。
+func TestFanoutHook_FanoutToUserLists_FollowersVisibility_BatchFollowCheck_SingleCall(t *testing.T) {
+	h, fanout, _ := newTestHook(t)
+	ctx := context.Background()
+
+	// list1 / list2 -> alice (follower / 同一 owner で 2 list)
+	// list3 -> bob (follower)
+	// list4 -> carol (non-follower)
+	// list5 -> author (本人)
+	lookup := &stubUserListLookup{
+		memberToLists: map[string][]string{"author": {"list1", "list2", "list3", "list4", "list5"}},
+		listOwners: map[string]string{
+			"list1": "alice", "list2": "alice",
+			"list3": "bob",
+			"list4": "carol",
+			"list5": "author",
+		},
+	}
+	h.SetUserListRepo(lookup)
+
+	counting := &countingFollowingRepo{
+		MockFollowingRepository: testutil.NewMockFollowingRepository(),
+	}
+	require.NoError(t, counting.Create(&model.Following{ID: "f1", FollowerID: "alice", FolloweeID: "author"}))
+	require.NoError(t, counting.Create(&model.Following{ID: "f2", FollowerID: "bob", FolloweeID: "author"}))
+	h.followingRepo = counting
+
+	noteID := idGen.Generate(time.Now())
+	h.OnNoteCreated(
+		&model.Note{ID: noteID, UserID: "author", Visibility: model.NoteVisibilityFollowers},
+		&model.User{ID: "author"},
+	)
+
+	// follower 所有 list + 本人 list には push、non-follower には push されない
+	for _, listID := range []string{"list1", "list2", "list3", "list5"} {
+		out, err := fanout.Get(ctx, UserListTimelineName(listID), "", "", 10)
+		require.NoError(t, err)
+		assert.Equal(t, []string{noteID}, out, "%s should receive followers note", listID)
+	}
+	out, err := fanout.Get(ctx, UserListTimelineName("list4"), "", "", 10)
+	require.NoError(t, err)
+	assert.Empty(t, out, "list4 (non-follower carol) should NOT receive followers note")
+
+	// N+1 解消の核心: batch query は 1 回・per-owner Exists は呼ばれない
+	assert.Equal(t, 1, counting.filterToAnchorCalls,
+		"FilterFollowingsToAnchor should be called exactly once for the whole fanout")
+	assert.Equal(t, 0, counting.existsCalls,
+		"Exists should not be called after #1468 review N+1 fix")
+	// distinct owner 数 (本人除外) が候補に渡っていることを assert
+	require.Len(t, counting.lastCandidates, 3)
+	assert.ElementsMatch(t, []string{"alice", "bob", "carol"}, counting.lastCandidates,
+		"candidates should be the distinct non-self owners")
+}
+
+// #1468 review: FilterFollowingsToAnchor がエラーを返した時は本人 list 以外を
+// push しない fail-closed 挙動。旧実装は per-owner Exists エラーをスキップして
+// 他 owner を続行していたが、batch query では「誰が follow しているか分からない」
+// 状況なので全体を保守的に閉じる。
+func TestFanoutHook_FanoutToUserLists_FollowersVisibility_BatchFollowCheck_Error_FailClosed(t *testing.T) {
+	h, fanout, _ := newTestHook(t)
+	ctx := context.Background()
+
+	lookup := &stubUserListLookup{
+		memberToLists: map[string][]string{"author": {"list1", "self-list"}},
+		listOwners: map[string]string{
+			"list1":     "alice", // 本来 follow しているが query が落ちる経路
+			"self-list": "author",
+		},
+	}
+	h.SetUserListRepo(lookup)
+
+	failing := &failingFilterFollowingRepo{
+		MockFollowingRepository: testutil.NewMockFollowingRepository(),
+	}
+	// alice は author を follow しているが、 batch query 自体が boom する
+	require.NoError(t, failing.Create(&model.Following{ID: "f1", FollowerID: "alice", FolloweeID: "author"}))
+	h.followingRepo = failing
+
+	noteID := idGen.Generate(time.Now())
+	h.OnNoteCreated(
+		&model.Note{ID: noteID, UserID: "author", Visibility: model.NoteVisibilityFollowers},
+		&model.User{ID: "author"},
+	)
+
+	// 本人 list には push される
+	out, err := fanout.Get(ctx, UserListTimelineName("self-list"), "", "", 10)
+	require.NoError(t, err)
+	assert.Equal(t, []string{noteID}, out)
+	// 他 owner の list は fail-closed で push されない
+	out, err = fanout.Get(ctx, UserListTimelineName("list1"), "", "", 10)
+	require.NoError(t, err)
+	assert.Empty(t, out, "non-self list must not receive note when batch follow check errors out")
 }
 
 // followers visibility 経路の lookup error はベストエフォートで握り潰す。

--- a/internal/core/timeline/fanout_hook_test.go
+++ b/internal/core/timeline/fanout_hook_test.go
@@ -693,10 +693,33 @@ func TestFanoutHook_StreamingPublisherNilFollowingRepo(t *testing.T) {
 type stubUserListLookup struct {
 	// memberToLists maps userID -> list IDs containing that user.
 	memberToLists map[string][]string
+	// listOwners maps listID -> ownerID. ListIDsAndOwnersByMember (#1465) で
+	// followers visibility note の per-list owner follow gate を再現する。
+	// 旧テストで未設定なら listID 自身を owner として扱う (= public note 経路の
+	// 既存挙動を保つ defensive fallback)。
+	listOwners map[string]string
 }
 
 func (s *stubUserListLookup) ListIDsByMember(userID string) ([]string, error) {
 	return s.memberToLists[userID], nil
+}
+
+// ListIDsAndOwnersByMember returns {listID: ownerID} for lists containing memberID.
+// listOwners が nil の test では listID 自身を owner として返す
+// (= follow gate に到達しない public note path の既存挙動を破壊しない)。
+func (s *stubUserListLookup) ListIDsAndOwnersByMember(memberID string) (map[string]string, error) {
+	out := make(map[string]string)
+	for _, listID := range s.memberToLists[memberID] {
+		if s.listOwners != nil {
+			if owner, ok := s.listOwners[listID]; ok {
+				out[listID] = owner
+				continue
+			}
+		}
+		// fallback: listID 自体を owner 扱い (test compat)
+		out[listID] = listID
+	}
+	return out, nil
 }
 
 func TestFanoutHook_FanoutToUserLists(t *testing.T) {
@@ -778,6 +801,10 @@ func (f *failingUserListLookup) ListIDsByMember(_ string) ([]string, error) {
 	return nil, assertError{}
 }
 
+func (f *failingUserListLookup) ListIDsAndOwnersByMember(_ string) (map[string]string, error) {
+	return nil, assertError{}
+}
+
 func TestFanoutHook_FanoutToUserLists_LookupError(t *testing.T) {
 	h, fanout, _ := newTestHook(t)
 	ctx := context.Background()
@@ -787,6 +814,132 @@ func TestFanoutHook_FanoutToUserLists_LookupError(t *testing.T) {
 	noteID := idGen.Generate(time.Now())
 	n := &model.Note{ID: noteID, UserID: "author", Visibility: model.NoteVisibilityPublic}
 	// エラーがあっても上位に伝搬しない（ログ出力のみ）
+	h.OnNoteCreated(n, &model.User{ID: "author"})
+
+	out, err := fanout.Get(ctx, UserListTimelineName("list1"), "", "", 10)
+	require.NoError(t, err)
+	assert.Empty(t, out)
+}
+
+// --- followers visibility user list fanout gate (#1465) ----------------------
+
+// followers visibility note: list owner が author を follow していない場合、
+// その list には push されない。
+func TestFanoutHook_FanoutToUserLists_FollowersVisibility_NonFollowerOwnerDropped(t *testing.T) {
+	h, fanout, following := newTestHook(t)
+	ctx := context.Background()
+
+	// list1 は owner=alice、list2 は owner=bob。author は両 list の member。
+	lookup := &stubUserListLookup{
+		memberToLists: map[string][]string{"author": {"list1", "list2"}},
+		listOwners:    map[string]string{"list1": "alice", "list2": "bob"},
+	}
+	h.SetUserListRepo(lookup)
+	// alice だけが author を follow。bob は follow していない。
+	following.Followings["f1"] = &model.Following{ID: "f1", FollowerID: "alice", FolloweeID: "author"}
+
+	noteID := idGen.Generate(time.Now())
+	n := &model.Note{ID: noteID, UserID: "author", Visibility: model.NoteVisibilityFollowers}
+	h.OnNoteCreated(n, &model.User{ID: "author"})
+
+	// alice の list は push される
+	out, err := fanout.Get(ctx, UserListTimelineName("list1"), "", "", 10)
+	require.NoError(t, err)
+	assert.Equal(t, []string{noteID}, out, "list1 (owned by follower alice) should receive followers note")
+
+	// bob の list は push されない
+	out, err = fanout.Get(ctx, UserListTimelineName("list2"), "", "", 10)
+	require.NoError(t, err)
+	assert.Empty(t, out, "list2 (owned by non-follower bob) should NOT receive followers note")
+}
+
+// followers visibility note: owner == author の list には follow check 無しで
+// push される (本人 short-circuit)。
+func TestFanoutHook_FanoutToUserLists_FollowersVisibility_SelfOwnedList(t *testing.T) {
+	h, fanout, following := newTestHook(t)
+	ctx := context.Background()
+
+	// author 自身が owner の self-list。following は空 (= author は誰も follow していない)。
+	lookup := &stubUserListLookup{
+		memberToLists: map[string][]string{"author": {"self-list"}},
+		listOwners:    map[string]string{"self-list": "author"},
+	}
+	h.SetUserListRepo(lookup)
+	_ = following // 未使用だが setup の対称性のため取得
+
+	noteID := idGen.Generate(time.Now())
+	n := &model.Note{ID: noteID, UserID: "author", Visibility: model.NoteVisibilityFollowers}
+	h.OnNoteCreated(n, &model.User{ID: "author"})
+
+	out, err := fanout.Get(ctx, UserListTimelineName("self-list"), "", "", 10)
+	require.NoError(t, err)
+	assert.Equal(t, []string{noteID}, out, "self-owned list should always receive own followers note")
+}
+
+// followers visibility note + followingRepo 未配線 → fail-closed (= 他 owner の
+// list へは push しない)。NewFanoutHook の constructor が必ず followingRepo を
+// 受け取るので production では起きない経路だが、safety net として確認する。
+func TestFanoutHook_FanoutToUserLists_FollowersVisibility_NilFollowingRepoFailClosed(t *testing.T) {
+	h, fanout, _ := newTestHook(t)
+	ctx := context.Background()
+
+	// followingRepo を解除 (production では起きない nil state)。
+	h.followingRepo = nil
+
+	lookup := &stubUserListLookup{
+		memberToLists: map[string][]string{"author": {"list1", "self-list"}},
+		listOwners:    map[string]string{"list1": "alice", "self-list": "author"},
+	}
+	h.SetUserListRepo(lookup)
+
+	noteID := idGen.Generate(time.Now())
+	n := &model.Note{ID: noteID, UserID: "author", Visibility: model.NoteVisibilityFollowers}
+	h.OnNoteCreated(n, &model.User{ID: "author"})
+
+	// 本人 list には push される
+	out, err := fanout.Get(ctx, UserListTimelineName("self-list"), "", "", 10)
+	require.NoError(t, err)
+	assert.Equal(t, []string{noteID}, out)
+
+	// 他 owner の list には push されない (fail-closed)
+	out, err = fanout.Get(ctx, UserListTimelineName("list1"), "", "", 10)
+	require.NoError(t, err)
+	assert.Empty(t, out)
+}
+
+// public/home visibility note は per-list owner follow check を経ずに全 list
+// に push される (旧経路 hot path の regression guard)。
+func TestFanoutHook_FanoutToUserLists_PublicNote_NoFollowCheck(t *testing.T) {
+	h, fanout, _ := newTestHook(t)
+	ctx := context.Background()
+
+	// list1 は owner=alice (author を follow していない)。にもかかわらず public
+	// note は push される。
+	lookup := &stubUserListLookup{
+		memberToLists: map[string][]string{"author": {"list1"}},
+		listOwners:    map[string]string{"list1": "alice"},
+	}
+	h.SetUserListRepo(lookup)
+
+	noteID := idGen.Generate(time.Now())
+	n := &model.Note{ID: noteID, UserID: "author", Visibility: model.NoteVisibilityPublic}
+	h.OnNoteCreated(n, &model.User{ID: "author"})
+
+	out, err := fanout.Get(ctx, UserListTimelineName("list1"), "", "", 10)
+	require.NoError(t, err)
+	assert.Equal(t, []string{noteID}, out)
+}
+
+// followers visibility 経路の lookup error はベストエフォートで握り潰す。
+func TestFanoutHook_FanoutToUserLists_FollowersVisibility_LookupError(t *testing.T) {
+	h, fanout, _ := newTestHook(t)
+	ctx := context.Background()
+
+	h.SetUserListRepo(&failingUserListLookup{})
+
+	noteID := idGen.Generate(time.Now())
+	n := &model.Note{ID: noteID, UserID: "author", Visibility: model.NoteVisibilityFollowers}
+	// エラーが上位に伝搬しないこと
 	h.OnNoteCreated(n, &model.User{ID: "author"})
 
 	out, err := fanout.Get(ctx, UserListTimelineName("list1"), "", "", 10)

--- a/internal/repository/user_list.go
+++ b/internal/repository/user_list.go
@@ -39,6 +39,11 @@ type UserListRepository interface {
 	// ListIDsByMember returns all list IDs that contain userID as a member.
 	// Used by timeline fanout to push notes to user list timelines.
 	ListIDsByMember(userID string) ([]string, error)
+	// ListIDsAndOwnersByMember returns a map of listID → ownerID for lists that
+	// contain memberID. fanoutToUserLists が followers visibility note を per-list
+	// owner の follow 関係で gate するために使う (#1465)。1 query で join
+	// する。空 map の場合 memberID はどの list にも属していない。
+	ListIDsAndOwnersByMember(memberID string) (map[string]string, error)
 }
 
 type userListRepository struct {
@@ -147,6 +152,30 @@ func (r *userListRepository) ListIDsByMember(userID string) ([]string, error) {
 		return nil, err
 	}
 	return ids, nil
+}
+
+// ListIDsAndOwnersByMember returns {listID: ownerID} for every list that
+// contains memberID. fanoutToUserLists が followers visibility note の per-list
+// owner follow gate を 1 query で済ませるために導入 (#1465)。
+func (r *userListRepository) ListIDsAndOwnersByMember(memberID string) (map[string]string, error) {
+	out := make(map[string]string)
+	type row struct {
+		UserListID string `gorm:"column:userListId"`
+		UserID     string `gorm:"column:userId"`
+	}
+	var rows []row
+	err := r.db.Table(`"user_list_membership"`).
+		Select(`"user_list_membership"."userListId" AS "userListId", "user_list"."userId" AS "userId"`).
+		Joins(`JOIN "user_list" ON "user_list"."id" = "user_list_membership"."userListId"`).
+		Where(`"user_list_membership"."userId" = ?`, memberID).
+		Find(&rows).Error
+	if err != nil {
+		return nil, err
+	}
+	for _, r := range rows {
+		out[r.UserListID] = r.UserID
+	}
+	return out, nil
 }
 
 // ListMembersByListIDs returns userIDs grouped by listID in a single SELECT.

--- a/internal/repository/user_list_test.go
+++ b/internal/repository/user_list_test.go
@@ -167,3 +167,68 @@ func TestUserListRepository_AddMember_Duplicate(t *testing.T) {
 	assert.True(t, errors.Is(err, ErrUserListDuplicateMember),
 		"既 member の AddMember は ErrUserListDuplicateMember を返すこと, got: %v", err)
 }
+
+// ListIDsAndOwnersByMember は fanoutToUserLists が followers visibility note
+// の per-list owner follow gate を 1 query で済ませるために導入 (#1465)。
+// 同じ member が複数 owner の list に属するケース、member の居ない list が
+// 出てこないケース、空 result のケースを check する。
+func TestUserListRepository_ListIDsAndOwnersByMember(t *testing.T) {
+	repo := NewUserListRepository(testDB)
+	createTestUser(t, "ul_lo_o1")
+	createTestUser(t, "ul_lo_o2")
+	createTestUser(t, "ul_lo_m1")
+	createTestUser(t, "ul_lo_m2")
+
+	// member 不在 → 空 map
+	out, err := repo.ListIDsAndOwnersByMember("nonexistent")
+	require.NoError(t, err)
+	assert.Empty(t, out)
+
+	// o1 が list A1 (m1, m2) と list A2 (m1) を所有、o2 が list B1 (m1) を所有
+	listA1 := &model.UserList{ID: "ul_lo_a1", UserID: "ul_lo_o1", Name: "A1"}
+	require.NoError(t, repo.Create(listA1))
+	defer cleanupUserList(t, listA1.ID)
+	listA2 := &model.UserList{ID: "ul_lo_a2", UserID: "ul_lo_o1", Name: "A2"}
+	require.NoError(t, repo.Create(listA2))
+	defer cleanupUserList(t, listA2.ID)
+	listB1 := &model.UserList{ID: "ul_lo_b1", UserID: "ul_lo_o2", Name: "B1"}
+	require.NoError(t, repo.Create(listB1))
+	defer cleanupUserList(t, listB1.ID)
+	// m1 が含まれない list (regression guard: 含まれない list は出てこない)
+	listC := &model.UserList{ID: "ul_lo_c", UserID: "ul_lo_o2", Name: "C"}
+	require.NoError(t, repo.Create(listC))
+	defer cleanupUserList(t, listC.ID)
+
+	require.NoError(t, repo.AddMember(&model.UserListMembership{ID: "ulm_lo_1", UserListID: listA1.ID, UserID: "ul_lo_m1"}))
+	require.NoError(t, repo.AddMember(&model.UserListMembership{ID: "ulm_lo_2", UserListID: listA1.ID, UserID: "ul_lo_m2"}))
+	require.NoError(t, repo.AddMember(&model.UserListMembership{ID: "ulm_lo_3", UserListID: listA2.ID, UserID: "ul_lo_m1"}))
+	require.NoError(t, repo.AddMember(&model.UserListMembership{ID: "ulm_lo_4", UserListID: listB1.ID, UserID: "ul_lo_m1"}))
+	// listC は member 無し
+
+	// m1 視点: A1 (o1) + A2 (o1) + B1 (o2) の 3 件、C は出ない
+	out, err = repo.ListIDsAndOwnersByMember("ul_lo_m1")
+	require.NoError(t, err)
+	require.Len(t, out, 3)
+	assert.Equal(t, "ul_lo_o1", out[listA1.ID])
+	assert.Equal(t, "ul_lo_o1", out[listA2.ID])
+	assert.Equal(t, "ul_lo_o2", out[listB1.ID])
+	_, hasC := out[listC.ID]
+	assert.False(t, hasC, "member が居ない list は map に含まれない")
+
+	// m2 視点: A1 のみ
+	out, err = repo.ListIDsAndOwnersByMember("ul_lo_m2")
+	require.NoError(t, err)
+	require.Len(t, out, 1)
+	assert.Equal(t, "ul_lo_o1", out[listA1.ID])
+}
+
+// 不正な query (= 壊れた DB session) で error が返ることを confirm。
+// MustOpenTestDB で取った session を意図的に close して reuse する形で
+// session 失敗を再現する。
+func TestUserListRepository_ListIDsAndOwnersByMember_Error(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel() // ctx を canceled state にして session 経由の query を fail させる
+	repo := NewUserListRepository(testDB.WithContext(ctx))
+	_, err := repo.ListIDsAndOwnersByMember("anyone")
+	assert.Error(t, err)
+}

--- a/internal/stream/channels/new_channels_test.go
+++ b/internal/stream/channels/new_channels_test.go
@@ -179,6 +179,92 @@ func TestUserList_WithRepliesFalse_ReplyPassthrough(t *testing.T) {
 	assert.Equal(t, "note", ctx.sentType[0])
 }
 
+// #1465: followers visibility note は viewer が author を follow している
+// 場合のみ emit される (defense-in-depth)。fanout 段で list owner の follow
+// を check してから push する設計だが、stream 残留 entry に対するフォール
+// バックとして channel 側でも 1 段 gate する。
+func TestUserList_FollowersVisibility_NonFollowerDropped(t *testing.T) {
+	ctx := newCtx(&model.User{ID: "alice"})
+	ctx.followingSnap = map[string]bool{} // alice は author を follow していない
+	ch := NewUserList(ctx)
+	ch.Init(json.RawMessage(`{"listId":"l1"}`))
+
+	ch.OnRedisEvent([]byte(`{"id":"n1","userId":"author","visibility":"followers"}`))
+	assert.Empty(t, ctx.sentType, "non-follower viewer must not receive followers note")
+}
+
+func TestUserList_FollowersVisibility_FollowerAccepted(t *testing.T) {
+	ctx := newCtx(&model.User{ID: "alice"})
+	ctx.followingSnap = map[string]bool{"author": false} // value (withReplies) は関係ない
+	ch := NewUserList(ctx)
+	ch.Init(json.RawMessage(`{"listId":"l1"}`))
+
+	ch.OnRedisEvent([]byte(`{"id":"n1","userId":"author","visibility":"followers"}`))
+	require.Len(t, ctx.sentType, 1)
+	assert.Equal(t, "note", ctx.sentType[0])
+}
+
+func TestUserList_FollowersVisibility_SelfAuthored(t *testing.T) {
+	ctx := newCtx(&model.User{ID: "alice"})
+	// snap は nil でも本人 short-circuit で通る
+	ch := NewUserList(ctx)
+	ch.Init(json.RawMessage(`{"listId":"l1"}`))
+
+	ch.OnRedisEvent([]byte(`{"id":"n1","userId":"alice","visibility":"followers"}`))
+	require.Len(t, ctx.sentType, 1)
+}
+
+func TestUserList_FollowersVisibility_NilSnapshotFailClosed(t *testing.T) {
+	ctx := newCtx(&model.User{ID: "alice"})
+	// followingSnap=nil (= snapshot lookup 未配線 / 取得失敗) で他人の followers
+	// note は drop される。本人は別 case (上) で通すことを確認済。
+	ch := NewUserList(ctx)
+	ch.Init(json.RawMessage(`{"listId":"l1"}`))
+
+	ch.OnRedisEvent([]byte(`{"id":"n1","userId":"author","visibility":"followers"}`))
+	assert.Empty(t, ctx.sentType, "nil snapshot must fail-closed for followers note from non-self author")
+}
+
+func TestUserList_PublicVisibility_NoFollowCheck(t *testing.T) {
+	ctx := newCtx(&model.User{ID: "alice"})
+	// public は snap 無くても、follow 関係に関係なく通る
+	ch := NewUserList(ctx)
+	ch.Init(json.RawMessage(`{"listId":"l1"}`))
+
+	ch.OnRedisEvent([]byte(`{"id":"n1","userId":"author","visibility":"public"}`))
+	require.Len(t, ctx.sentType, 1)
+}
+
+func TestUserList_HomeVisibility_NoFollowCheck(t *testing.T) {
+	ctx := newCtx(&model.User{ID: "alice"})
+	ch := NewUserList(ctx)
+	ch.Init(json.RawMessage(`{"listId":"l1"}`))
+
+	ch.OnRedisEvent([]byte(`{"id":"n1","userId":"author","visibility":"home"}`))
+	require.Len(t, ctx.sentType, 1)
+}
+
+// visibility 欠如 payload は parse 自体は通るが visibility != "followers" の
+// branch で素通りする (regression guard / 後方互換)。
+func TestUserList_NoVisibilityField_Passthrough(t *testing.T) {
+	ctx := newCtx(&model.User{ID: "alice"})
+	ch := NewUserList(ctx)
+	ch.Init(json.RawMessage(`{"listId":"l1"}`))
+
+	ch.OnRedisEvent([]byte(`{"id":"n1"}`))
+	require.Len(t, ctx.sentType, 1)
+}
+
+// 不正 payload はパース失敗で conservative drop される (IDOR fail-closed)。
+func TestUserList_BrokenPayload_Dropped(t *testing.T) {
+	ctx := newCtx(&model.User{ID: "alice"})
+	ch := NewUserList(ctx)
+	ch.Init(json.RawMessage(`{"listId":"l1"}`))
+
+	ch.OnRedisEvent([]byte(`{not json`))
+	assert.Empty(t, ctx.sentType)
+}
+
 // --- RoleTimeline ---
 
 func TestRoleTimeline_Lifecycle(t *testing.T) {

--- a/internal/stream/channels/user_list.go
+++ b/internal/stream/channels/user_list.go
@@ -59,7 +59,20 @@ func (c *UserListChannel) Init(params json.RawMessage) error {
 }
 
 func (c *UserListChannel) OnRedisEvent(payload []byte) {
-	if !c.filter.shouldEmit(payload, c.ctx.HardMuteRules(), viewerIDFromCtx(c.ctx)) {
+	viewerID := viewerIDFromCtx(c.ctx)
+	if !c.filter.shouldEmit(payload, c.ctx.HardMuteRules(), viewerID) {
+		return
+	}
+	// followers visibility note の defense-in-depth filter (#1465)。fanout 段
+	// で list owner の follow 関係を check してから push する設計だが、過去に
+	// stream へ滞留した entry や fanout の設定ミスに対して WS 側でも 1 段
+	// gate する。本人 (`viewerID == note.userId`) は CanSeeNote の semantics
+	// と同じく無条件 pass、それ以外は FollowingSnapshot で `note.userId` を
+	// follow しているか確認する。snapshot が nil (= anonymous は Init で
+	// 弾く設計なので来ない / lookup 未配線) の場合は fail-closed で drop する。
+	// public / home / specified は fanout 段で適切に gate 済 (specified は
+	// shouldFanoutToFollowers が除外) のためここでは何もしない。
+	if !userListVisibilityShouldEmit(payload, viewerID, c.ctx.FollowingSnapshot()) {
 		return
 	}
 	_ = c.ctx.Send("note", json.RawMessage(payload))
@@ -71,4 +84,43 @@ func (c *UserListChannel) Dispose() {
 	if c.topic != "" {
 		c.ctx.Unsubscribe(c.topic)
 	}
+}
+
+// userListVisibilityPayload は userList channel の visibility gate が
+// 参照する最小 fields。`visibility` と `userId` (author) があれば判定できる。
+type userListVisibilityPayload struct {
+	UserID     string `json:"userId"`
+	Visibility string `json:"visibility"`
+}
+
+// userListVisibilityShouldEmit returns false when a `followers` visibility note
+// is being delivered to a viewer who does not follow the author (and is not the
+// author themselves). For `public` / `home` / `specified` payloads it returns
+// true unconditionally — fanout already filters those (specified is excluded by
+// shouldFanoutToFollowers, public / home reach every list member by design).
+//
+// Defensive behaviour:
+//   - payload parse 失敗 → conservative に drop (= 既存 reply gate と逆の方針
+//     だが、visibility 不明 note は IDOR fail-closed が安全)。
+//   - snapshot=nil + viewer ≠ author → drop (anonymous は Init で弾くが、
+//     followingSnapshot lookup が未配線 / 取得失敗で nil 返却の場合に備える)。
+func userListVisibilityShouldEmit(payload []byte, viewerID string, snap map[string]bool) bool {
+	var note userListVisibilityPayload
+	if err := json.Unmarshal(payload, &note); err != nil {
+		return false
+	}
+	if note.Visibility != "followers" {
+		return true
+	}
+	if viewerID == "" {
+		return false
+	}
+	if note.UserID == viewerID {
+		return true
+	}
+	if snap == nil {
+		return false
+	}
+	_, follows := snap[note.UserID]
+	return follows
 }

--- a/internal/testutil/mock_repository.go
+++ b/internal/testutil/mock_repository.go
@@ -4910,6 +4910,20 @@ func (m *MockUserListRepository) ListIDsByMember(userID string) ([]string, error
 	return ids, nil
 }
 
+// ListIDsAndOwnersByMember returns {listID: ownerID} for lists containing memberID.
+func (m *MockUserListRepository) ListIDsAndOwnersByMember(memberID string) (map[string]string, error) {
+	out := make(map[string]string)
+	for _, mem := range m.Members {
+		if mem.UserID != memberID {
+			continue
+		}
+		if list, ok := m.Lists[mem.UserListID]; ok {
+			out[mem.UserListID] = list.UserID
+		}
+	}
+	return out, nil
+}
+
 func (m *MockUserListRepository) ListsContainingMember(ownerID, memberUserID string) ([]*model.UserList, error) {
 	listIDs := make(map[string]struct{})
 	for _, mem := range m.Members {


### PR DESCRIPTION
## Summary

- REST `notes/user-list-timeline` は #1442 で SQL push-down + handler の `FilterVisible` で塞いだが、**WebSocket `userList` channel と fanout 段** (`fanoutToUserLists`) が同じ semantics を追従できておらず、follower でない list owner の WS 接続に follower-only ノートがリアルタイム配信されていた IDOR (#1465) を修正。
- fanout 段で followers visibility note の per-list owner follow check を 1 段かけ、WS channel 側にも defense-in-depth で同等の gate を入れる (WS hot path に DB 問い合わせを足さない `FollowingSnapshot` ベースの in-memory 判定で、`replyShouldEmit` と同じ snapshot 方式)。

## 主な変更点

- `internal/core/timeline/fanout_hook.go`
  - `fanoutToUserLists` を 2 経路に分岐:
    - public / home → 旧経路 (`ListIDsByMember` + 全 list へ push)。hot path にオーバーヘッドなし。
    - followers → 新 lookup `ListIDsAndOwnersByMember` で `{listID: ownerID}` を 1 query で取得し、`FilterFollowingsToAnchor(author.ID, distinctOwners)` で「author を follow している owner 集合」を 1 query 取って、その owner の list だけに push。本人 (owner == author) は無条件 pass。**(#1144 batch method を活用して per-owner Exists の N+1 を消す。#1468 review 対応で 2026-06-02 に Exists ループから差し替え)**
  - `followingRepo` 未配線時 / batch query エラー時は fail-closed (= followers note は本人 list のみに push)。
  - `specified` は `shouldFanoutToFollowers` で既に除外済みなので追加処理不要。
- `internal/stream/channels/user_list.go`
  - `OnRedisEvent` に visibility gate を追加 (`userListVisibilityShouldEmit`)。payload から `userId` / `visibility` を抽出し、followers visibility は viewer の `FollowingSnapshot` で author follow を確認、本人は短絡 pass。public / home / specified / 欠如は素通り、不正 payload は conservative drop。
- `internal/repository/user_list.go`
  - `UserListRepository.ListIDsAndOwnersByMember(memberID) (map[string]string, error)` を追加 (1-query JOIN)。
- `internal/core/timeline/fanout_hook.go`
  - `UserListMemberLookup` interface に `ListIDsAndOwnersByMember` を追加。test stub (`stubUserListLookup` / `failingUserListLookup`) も更新。
- `internal/testutil/mock_repository.go`
  - `MockUserListRepository.ListIDsAndOwnersByMember` を実装。
- `internal/core/antenna/antenna_service_test.go`
  - 既存 `failingUserListRepo` に新 method の no-op 実装を追加 (interface satisfaction)。
- `CHANGELOG.md` Unreleased セクションに追記。

## テスト

新規ケース:

- fanout (`internal/core/timeline/fanout_hook_test.go`)
  - `FollowersVisibility_NonFollowerOwnerDropped`: 非フォロー owner の list には push されない
  - `FollowersVisibility_SelfOwnedList`: 本人 owned list は short-circuit で push される
  - `FollowersVisibility_NilFollowingRepoFailClosed`: followingRepo 解除時は fail-closed (本人 list のみ)
  - `PublicNote_NoFollowCheck`: public note は follow check を skip して全 list に push される (regression guard)
  - `FollowersVisibility_LookupError`: lookup error は best-effort no-op
  - **(2026-06-02 #1468 review 対応で追加)** `FollowersVisibility_BatchFollowCheck_SingleCall`: 5 list / 4 distinct owner で `FilterFollowingsToAnchor` が 1 回、`Exists` が 0 回、candidates が distinct owner であることを assert
  - **(2026-06-02 #1468 review 対応で追加)** `FollowersVisibility_BatchFollowCheck_Error_FailClosed`: batch query エラー時に本人 list のみ push される fail-closed 挙動
- WS channel (`internal/stream/channels/new_channels_test.go`)
  - `FollowersVisibility_NonFollowerDropped` / `FollowerAccepted` / `SelfAuthored` / `NilSnapshotFailClosed`
  - `PublicVisibility_NoFollowCheck` / `HomeVisibility_NoFollowCheck` / `NoVisibilityField_Passthrough` / `BrokenPayload_Dropped`

- `go test ./internal/api/antennas/... ./internal/core/antenna/... ./internal/core/timeline/... ./internal/stream/... ./internal/server/... ./internal/testutil/...` — green
- `make fmt && make lint` — green

## Closes

Closes #1465

## その他

- `audit-note-idor-2026-06-02.md` の HIGH-3 (= WS userList + fanout の非対称穴) を 1 PR で対応。
- 同 audit batch の残: #1466 (admin/promo/create, MEDIUM-1) は後続 PR で対応。
- 関連: #1442 (REST 側), #1460 (WS subNote — checker 方式で DB 問い合わせ。本 PR の snapshot 方式とは別アプローチ), #1464 (antenna IDOR)。

🤖 Generated with [Claude Code](https://claude.com/claude-code)