### PR TITLE
fix(admin): admin/promo/create で非public note の promote を 403 で reject

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Fix: 管理画面のプロモーション登録 (`/api/admin/promo/create`) で、公開範囲が public 以外のノート (フォロワー限定 / ホーム / specified) も登録できていた問題を修正 (将来 promo 表示エンドポイントが実装された際に非公開ノートが全閲覧者に漏れる潜在的問題を作成段階で防止)
 - Fix: `useObjectStorage = true` のインスタンスで、`storedInternal = true` なドライブファイルへの `/files/:accessKey` アクセスが常に 404 になる問題を修正 (Misskey TS からの S3 移行前に保存されたローカルファイルが、移行後もアクセス可能に)
 - Fix: Misskey TS から mk-go に移行した直後、既に期限切れだったアンケートに対してアンケート終了 (pollEnded) 通知が一斉発火する問題を修正 (移行時 backfill migration を追加)
 - Fix: 配送先が一時的にダウンしている場合に、deliver/inbox ジョブが設定省略時にリトライされない問題を修正 (既定の試行回数を Misskey 本家と同じ deliver=12 / inbox=8 に。従来の no-retry 挙動が必要な場合は `deliverJobMaxAttempts` / `inboxJobMaxAttempts` に 1 を指定)

--- a/internal/api/admin/ad_invite_promo_test.go
+++ b/internal/api/admin/ad_invite_promo_test.go
@@ -483,6 +483,25 @@ func TestPromoCreate_NonPublicNoteRejected(t *testing.T) {
 	}
 }
 
+// #1469 review (指摘 2): promoNoteRepo は配線済み + noteFinder 未配線の状態で
+// visibility check ができないまま promote が通る fail-open を塞ぐ。production の
+// router.go では SetPromoNoteRepo の直後に SetNoteFinder が必ず呼ばれるため
+// 経路に達しないが、設定ミス検出 + 兄弟 PR (#1467/#1468/#1460) の fail-closed
+// doctrine と揃えるため明示 gate する。
+func TestPromoCreate_NoteFinderUnwired_FailClosed(t *testing.T) {
+	h, _, _, _ := newTestHandler(t)
+	promo := &stubPromoRepo{}
+	h.SetPromoNoteRepo(promo)
+	// SetNoteFinder は故意に呼ばない
+
+	expires := time.Now().Add(24 * time.Hour).UnixMilli()
+	body := fmt.Sprintf(`{"noteId":"n1","expiresAt":%d}`, expires)
+	rec := doPost(h.PromoCreate, body, adminUser)
+	assert.Equal(t, http.StatusInternalServerError, rec.Code,
+		"missing noteFinder must fail-closed instead of bypassing visibility check")
+	assert.Nil(t, promo.created, "promo row must not be persisted when visibility cannot be verified")
+}
+
 func TestPromoCreate_MissingNoteID(t *testing.T) {
 	h, _, _, _ := newTestHandler(t)
 	h.SetPromoNoteRepo(&stubPromoRepo{})

--- a/internal/api/admin/ad_invite_promo_test.go
+++ b/internal/api/admin/ad_invite_promo_test.go
@@ -437,7 +437,7 @@ func TestPromoCreate_Success(t *testing.T) {
 	h, _, _, _ := newTestHandler(t)
 	promo := &stubPromoRepo{}
 	h.SetPromoNoteRepo(promo)
-	note := &model.Note{ID: "n1", UserID: "authorU"}
+	note := &model.Note{ID: "n1", UserID: "authorU", Visibility: model.NoteVisibilityPublic}
 	h.SetNoteFinder(&stubNoteFinder{note: note})
 
 	expires := time.Now().Add(24 * time.Hour).UnixMilli()
@@ -447,6 +447,40 @@ func TestPromoCreate_Success(t *testing.T) {
 	require.NotNil(t, promo.created)
 	assert.Equal(t, "n1", promo.created.NoteID)
 	assert.Equal(t, "authorU", promo.created.UserID)
+}
+
+// #1466: followers / home / specified visibility note の promote 試行は
+// ACCESS_DENIED (403) で reject される。promo 表示 endpoint が実装された時に
+// 非 public note の本文が viewer に漏れる latent IDOR を create 段で塞ぐ。
+func TestPromoCreate_NonPublicNoteRejected(t *testing.T) {
+	cases := []struct {
+		name string
+		vis  model.NoteVisibility
+	}{
+		{"followers", model.NoteVisibilityFollowers},
+		{"home", model.NoteVisibilityHome},
+		{"specified", model.NoteVisibilitySpecified},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			h, _, _, _ := newTestHandler(t)
+			promo := &stubPromoRepo{}
+			h.SetPromoNoteRepo(promo)
+			h.SetNoteFinder(&stubNoteFinder{note: &model.Note{ID: "n1", UserID: "authorU", Visibility: tc.vis}})
+
+			expires := time.Now().Add(24 * time.Hour).UnixMilli()
+			body := fmt.Sprintf(`{"noteId":"n1","expiresAt":%d}`, expires)
+			rec := doPost(h.PromoCreate, body, adminUser)
+			assert.Equal(t, http.StatusForbidden, rec.Code, "non-public note must be rejected with 403")
+			assert.Nil(t, promo.created, "promo row must not be persisted for non-public note")
+
+			var respBody map[string]any
+			require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &respBody))
+			errField, ok := respBody["error"].(map[string]any)
+			require.True(t, ok)
+			assert.Equal(t, "ACCESS_DENIED", errField["code"])
+		})
+	}
 }
 
 func TestPromoCreate_MissingNoteID(t *testing.T) {
@@ -468,7 +502,7 @@ func TestPromoCreate_NoSuchNote(t *testing.T) {
 func TestPromoCreate_AlreadyPromoted(t *testing.T) {
 	h, _, _, _ := newTestHandler(t)
 	h.SetPromoNoteRepo(&stubPromoRepo{exists: true})
-	h.SetNoteFinder(&stubNoteFinder{note: &model.Note{ID: "n1", UserID: "u"}})
+	h.SetNoteFinder(&stubNoteFinder{note: &model.Note{ID: "n1", UserID: "u", Visibility: model.NoteVisibilityPublic}})
 	rec := doPost(h.PromoCreate, `{"noteId":"n1","expiresAt":1}`, adminUser)
 	assert.Equal(t, http.StatusBadRequest, rec.Code)
 	var body map[string]any

--- a/internal/api/admin/promo.go
+++ b/internal/api/admin/promo.go
@@ -30,6 +30,14 @@ func (h *Handler) PromoCreate(c echo.Context) error {
 		if err != nil {
 			return c.JSON(http.StatusBadRequest, apierr.Error("NO_SUCH_NOTE", "No such note.", "ee449fbe-af2a-453b-9cae-cf2fe7c895fc"))
 		}
+		// 公開範囲が public 以外の note は promote できない (#1466)。
+		// upstream Misskey TS `admin/promo/create.ts` は `note.visibility !==
+		// 'public'` で ACCESS_DENIED を返す。followers / specified / home note を
+		// promote すると、将来 promo 表示 endpoint 実装時に全 viewer に本文が
+		// 漏れる latent IDOR になるため create 段で reject する。
+		if note.Visibility != model.NoteVisibilityPublic {
+			return apierr.JSONAccessDenied(c)
+		}
 		targetUserID = note.UserID
 	}
 

--- a/internal/api/admin/promo.go
+++ b/internal/api/admin/promo.go
@@ -7,7 +7,6 @@ import (
 	"github.com/labstack/echo/v4"
 	"github.com/shiroha-a/mk/internal/api/apierr"
 	"github.com/shiroha-a/mk/internal/model"
-	"github.com/shiroha-a/mk/internal/server/middleware"
 )
 
 // PromoCreate handles POST /api/admin/promo/create.
@@ -23,23 +22,33 @@ func (h *Handler) PromoCreate(c echo.Context) error {
 		return c.JSON(http.StatusBadRequest, apierr.Error("INVALID_PARAM", "noteId is required.", "3d81ceae-475f-4600-b2a8-2bc116157532"))
 	}
 
-	// 対象 note の存在確認 → 既に promote 済みでないか確認
-	var targetUserID string
-	if h.noteFinder != nil {
-		note, err := h.noteFinder.FindByID(req.NoteID)
-		if err != nil {
-			return c.JSON(http.StatusBadRequest, apierr.Error("NO_SUCH_NOTE", "No such note.", "ee449fbe-af2a-453b-9cae-cf2fe7c895fc"))
-		}
-		// 公開範囲が public 以外の note は promote できない (#1466)。
-		// upstream Misskey TS `admin/promo/create.ts` は `note.visibility !==
-		// 'public'` で ACCESS_DENIED を返す。followers / specified / home note を
-		// promote すると、将来 promo 表示 endpoint 実装時に全 viewer に本文が
-		// 漏れる latent IDOR になるため create 段で reject する。
-		if note.Visibility != model.NoteVisibilityPublic {
-			return apierr.JSONAccessDenied(c)
-		}
-		targetUserID = note.UserID
+	// noteFinder 未配線時は visibility 検証ができないため fail-closed で
+	// promote を断る (#1466 / #1469 review)。production の router.go では
+	// SetPromoNoteRepo の直後に SetNoteFinder が必ず呼ばれるため経路には
+	// 到達しないが、設定ミス時に visibility check を黙って bypass しないよう
+	// 兄弟 PR (#1467/#1468/#1460) と doctrine を揃える。
+	if h.noteFinder == nil {
+		return c.JSON(http.StatusInternalServerError, apierr.InternalError())
 	}
+	// 対象 note の存在確認 → 公開範囲確認 → 既に promote 済みでないか確認
+	note, err := h.noteFinder.FindByID(req.NoteID)
+	if err != nil {
+		return c.JSON(http.StatusBadRequest, apierr.Error("NO_SUCH_NOTE", "No such note.", "ee449fbe-af2a-453b-9cae-cf2fe7c895fc"))
+	}
+	// 公開範囲が public 以外の note は promote できない (#1466)。upstream
+	// Misskey TS の `admin/promo/create.ts` (pinned 2026.5.4) には visibility
+	// check 自体が存在しないため、本実装は mk-go 独自の forward defense
+	// (= 意図的な divergence) として加える。実害観点では upstream / mk-go
+	// どちらも promo を表示する endpoint が未実装で latent な穴に留まるが、
+	// 表示実装が将来入った瞬間に followers / specified / home note の本文が
+	// 全 viewer に漏れる IDOR となるため create 段で先回りで reject する。
+	// home は LTL/GTL に出ないため厳密な非公開ではないが、promo は全 viewer
+	// 露出なので public のみ許可で揃える (upstream に明示根拠は無いが、
+	// 漏洩面を最小化する保守側に倒す)。
+	if note.Visibility != model.NoteVisibilityPublic {
+		return apierr.JSONAccessDenied(c)
+	}
+	targetUserID := note.UserID
 
 	exists, err := h.promoNoteRepo.Exists(req.NoteID)
 	if err != nil {
@@ -47,13 +56,6 @@ func (h *Handler) PromoCreate(c echo.Context) error {
 	}
 	if exists {
 		return c.JSON(http.StatusBadRequest, apierr.Error("ALREADY_PROMOTED", "The note has already promoted.", "ae427aa2-7a41-484f-a18c-2c1104051604"))
-	}
-
-	// note 情報が取れなかった場合は呼び出し admin を userId として記録 (最低限の整合)
-	if targetUserID == "" {
-		if u := middleware.GetUser(c); u != nil {
-			targetUserID = u.ID
-		}
 	}
 
 	promo := &model.PromoNote{


### PR DESCRIPTION
## Summary

- `admin/promo/create` が note の visibility を見ず、followers / specified / home visibility note も `promo_note` 行を作れた問題 (#1466) を修正。
- mk-go には現時点で promo 表示エンドポイントが未実装なので実害ゼロだが、表示実装と同時に「admin が誤って非 public note を promote → 全 viewer に本文露出」となる latent IDOR になる。
- **本実装の性質**: pinned `third_party/misskey` (2026.5.4) の `admin/promo/create.ts` には visibility check も `ACCESS_DENIED` エラー定義も存在しない (errors は `noSuchNote` / `alreadyPromoted` のみ)。upstream 側の promo 表示 endpoint も同様に未実装。よって本修正は **upstream 互換の追従ではなく、mk-go 独自の forward defense (= 意図的 divergence)** として加える。「将来の表示実装入りで漏れる latent IDOR を create 段で先回りで塞ぐ」位置づけ。

## 主な変更点

- `internal/api/admin/promo.go`
  - `PromoCreate` で `noteFinder.FindByID` 直後に `note.Visibility != model.NoteVisibilityPublic` なら `apierr.JSONAccessDenied(c)` (403 `ACCESS_DENIED`) で返す。`ALREADY_PROMOTED` 判定よりも前に置くことで `ALREADY_PROMOTED` を oracle に他人の promote 状態を引き出す経路も塞ぐ (admin only 経路なので脅威モデルは弱いが、順序設計として正しい)。
  - **(#1469 review 指摘 2 対応)** `noteFinder == nil` 時を fail-closed 化 (500 `INTERNAL_ERROR`)。production の router.go では `SetPromoNoteRepo` の直後に `SetNoteFinder` が必ず呼ばれるため経路には到達しないが、設定ミス時に visibility check を黙って bypass しないよう兄弟 PR (#1467 antenna / #1468 fanout / #1460 subNote) の fail-closed doctrine と揃える。
  - 上記対応に伴い `targetUserID == ""` フォールバック (admin user ID を userId に詰めるコード) は死コード化したので削除。`internal/server/middleware` import も不要化。
  - **(#1469 review 指摘 1 対応)** コメントから「upstream Misskey TS は visibility != public で ACCESS_DENIED を返す」記述を削除し、「pinned 2026.5.4 には未実装、本実装は forward defense として独自に追加」と明示。home visibility も reject する根拠 (promo は全 viewer 露出なので public のみ許可) も追記。
- `internal/api/admin/ad_invite_promo_test.go`
  - `TestPromoCreate_NonPublicNoteRejected` (followers / home / specified の sub-test) で 403 `ACCESS_DENIED` + `promo_note` 行が永続化されないことを assert。
  - **(#1469 review 指摘 2 対応で追加)** `TestPromoCreate_NoteFinderUnwired_FailClosed`: promoNoteRepo 配線済み + noteFinder 未配線で 500 `INTERNAL_ERROR` が返り `promo_note` 行が永続化されない fail-closed 挙動を assert。
  - 既存 `TestPromoCreate_Success` / `TestPromoCreate_AlreadyPromoted` の fixture note に `Visibility: NoteVisibilityPublic` を補完 (visibility gate 導入後の既存テスト互換)。
- `CHANGELOG.md` Unreleased セクションに追記。

## テスト

- `go test ./internal/api/admin/... -run TestPromo` — 全 9 ケース green
  - `TestPromoCreate_Success`
  - `TestPromoCreate_NonPublicNoteRejected/{followers,home,specified}` (新規)
  - `TestPromoCreate_NoteFinderUnwired_FailClosed` (新規 / review 対応)
  - `TestPromoCreate_MissingNoteID`
  - `TestPromoCreate_NoSuchNote`
  - `TestPromoCreate_AlreadyPromoted`
  - `TestPromoCreate` (nil-repo smoke)
- `make fmt && make lint` — green。
- `go test ./internal/api/admin/...` — green (admin package 全体、coverage 87.9%、CI 閾値 80% 以上)。

## Closes

Closes #1466

## その他

- `audit-note-idor-2026-06-02.md` の MEDIUM-1 (= latent IDOR、admin only) を対応。
- 同 audit batch (HIGH-1+2 / HIGH-3 / MEDIUM-1) の最後の 1 件。先行 PR は #1467 (antenna IDOR) / #1468 (WS userList visibility)。
- **本 PR は upstream Misskey TS (2026.5.4) には存在しない security hardening を独自に加えるため、API 互換性最優先方針との関係では意図的 divergence の合意を取った上でマージ予定。promo 機能が upstream / mk-go の双方で表示 endpoint 未実装な vestigial 状態なので、admin client 視点での挙動差は実質的に観測されない。**

🤖 Generated with [Claude Code](https://claude.com/claude-code)