### PR TITLE
fix(drive): drive/files/attached-notes に viewer 所有 file gate を追加 (#1470)

### DIFF
--- a/internal/api/drive/handler.go
+++ b/internal/api/drive/handler.go
@@ -691,7 +691,20 @@ func (h *Handler) FilesCheckExistence(c echo.Context) error {
 // くる。upstream Misskey TS と同じく cursor で keyset pagination する。
 // 過去はページング非対応で同じ note を返し続ける無限スクロール bug が
 // 出ていた (#488)。
+//
+// 旧実装は fileId を viewer 所有か検証せず直に `noteRepo.ListByFileID` を
+// 叩いていたため、認証 viewer が他人 owner の fileID を投げて当該 file を
+// attach した followers / specified note を本文ごと列挙できる IDOR が
+// 成立していた (#1470)。upstream TS と同じく viewer 所有 file のみ許可し、
+// 不存在 / owner mismatch / system file (userId IS NULL) はいずれも
+// NO_SUCH_FILE で隠蔽する。`fileRepo` 未配線も同じく fail-closed。
+//
+// owner check 通過後の note は upstream `notes/create` の `checkFileIDs`
+// が「file は author 所有」を強制するため必然的に viewer 自身の note で
+// あり、CanSeeNote は本人 short-circuit で常に true (= 追加の
+// FilterVisible が無くても leak しない)。
 func (h *Handler) FilesAttachedNotes(c echo.Context) error {
+	viewer := middleware.GetUser(c)
 	var req struct {
 		FileID    string `json:"fileId"`
 		Limit     int    `json:"limit"`
@@ -702,6 +715,17 @@ func (h *Handler) FilesAttachedNotes(c echo.Context) error {
 	}
 	if err := c.Bind(&req); err != nil || req.FileID == "" {
 		return apierr.JSONInvalidParam(c)
+	}
+	// upstream Misskey TS の attached-notes.ts と同じ semantics: viewer 所有
+	// file のみ許可 (#1470 IDOR fix)。upstream 専用 UUID
+	// `c118ece3-2e4b-4296-99d1-51756e32d232` を使い、汎用 NoSuchFile
+	// (UUIDNoSuchFile) と区別する。
+	if h.fileRepo == nil {
+		return c.JSON(http.StatusBadRequest, apierr.Error("NO_SUCH_FILE", "No such file.", "c118ece3-2e4b-4296-99d1-51756e32d232"))
+	}
+	f, err := h.fileRepo.FindByID(req.FileID)
+	if err != nil || f.UserID == nil || *f.UserID != viewer.ID {
+		return c.JSON(http.StatusBadRequest, apierr.Error("NO_SUCH_FILE", "No such file.", "c118ece3-2e4b-4296-99d1-51756e32d232"))
 	}
 	// fileIds配列にfileIDを含むノートを検索 (PostgreSQL配列演算子)
 	if h.noteRepo == nil {
@@ -714,7 +738,6 @@ func (h *Handler) FilesAttachedNotes(c echo.Context) error {
 	if err != nil {
 		return c.JSON(http.StatusOK, []any{})
 	}
-	viewer := middleware.GetUser(c)
 	notes = notesfilter.ApplyHardMute(h.userRepo, viewer, notes)
 	out := entity.PackNotes(c.Request().Context(), notes, h.idGen, h.instanceLookup(), h.emojiLookup(), h.reactionReader())
 	h.fieldRes.Apply(out, viewer)

--- a/internal/api/drive/handler_test.go
+++ b/internal/api/drive/handler_test.go
@@ -893,7 +893,9 @@ func TestFilesCheckExistence_NilRepo(t *testing.T) {
 }
 
 func TestFilesAttachedNotes_Success(t *testing.T) {
-	h, _, _ := newHandlerWithRepos(t)
+	h, fileRepo, _ := newHandlerWithRepos(t)
+	uid := "u1"
+	fileRepo.Files["f1"] = &model.DriveFile{ID: "f1", UserID: &uid}
 	c, rec := newJSONReq(t, `{"fileId":"f1"}`)
 	setUser(c, "u1")
 	require.NoError(t, h.FilesAttachedNotes(c))
@@ -908,12 +910,67 @@ func TestFilesAttachedNotes_InvalidParam(t *testing.T) {
 	assert.Equal(t, http.StatusBadRequest, rec.Code)
 }
 
+// fileRepo 未配線時は fail-closed (= NO_SUCH_FILE 400)。旧実装は ListByFileID
+// を直に叩いて 200 を返していたが、IDOR (#1470) 防止のため file ownership 検証
+// 経路を必ず通すこと自体を要求に格上げした。
 func TestFilesAttachedNotes_NilRepo(t *testing.T) {
 	h, _, _ := newHandler(t)
 	c, rec := newJSONReq(t, `{"fileId":"f1"}`)
 	setUser(c, "u1")
 	require.NoError(t, h.FilesAttachedNotes(c))
-	assert.Equal(t, http.StatusOK, rec.Code)
+	assert.Equal(t, http.StatusBadRequest, rec.Code)
+	assert.Contains(t, rec.Body.String(), "NO_SUCH_FILE")
+	// upstream Misskey TS attached-notes.ts と同じ UUID。汎用 NoSuchFile
+	// (UUIDNoSuchFile) と区別するために値比較しておく。
+	assert.Contains(t, rec.Body.String(), "c118ece3-2e4b-4296-99d1-51756e32d232")
+}
+
+// 他人 owner の fileID を投げると NO_SUCH_FILE で隠蔽する (#1470)。旧実装は
+// file ownership 検証なしに ListByFileID を叩いていたため、認証 viewer が
+// 他人 owner の fileID を投げて該当 file を attach した followers / specified
+// note の本文を列挙できる IDOR が成立していた。
+func TestFilesAttachedNotes_OtherOwnerDenied(t *testing.T) {
+	h, fileRepo, _ := newHandlerWithRepos(t)
+	other := "u2"
+	fileRepo.Files["f-other"] = &model.DriveFile{ID: "f-other", UserID: &other}
+	c, rec := newJSONReq(t, `{"fileId":"f-other"}`)
+	setUser(c, "u1")
+	require.NoError(t, h.FilesAttachedNotes(c))
+	assert.Equal(t, http.StatusBadRequest, rec.Code)
+	assert.Contains(t, rec.Body.String(), "NO_SUCH_FILE")
+	// upstream Misskey TS attached-notes.ts と同じ UUID。汎用 NoSuchFile
+	// (UUIDNoSuchFile) と区別するために値比較しておく。
+	assert.Contains(t, rec.Body.String(), "c118ece3-2e4b-4296-99d1-51756e32d232")
+}
+
+// system file (userId IS NULL — emoji copy / import zip 用、#670) も viewer の
+// 所有では無いので NO_SUCH_FILE。owner check に NULL handling を残さないと
+// `*f.UserID` で nil pointer panic を起こすので noregress test も兼ねる。
+func TestFilesAttachedNotes_SystemFileDenied(t *testing.T) {
+	h, fileRepo, _ := newHandlerWithRepos(t)
+	fileRepo.Files["f-sys"] = &model.DriveFile{ID: "f-sys", UserID: nil}
+	c, rec := newJSONReq(t, `{"fileId":"f-sys"}`)
+	setUser(c, "u1")
+	require.NoError(t, h.FilesAttachedNotes(c))
+	assert.Equal(t, http.StatusBadRequest, rec.Code)
+	assert.Contains(t, rec.Body.String(), "NO_SUCH_FILE")
+	// upstream Misskey TS attached-notes.ts と同じ UUID。汎用 NoSuchFile
+	// (UUIDNoSuchFile) と区別するために値比較しておく。
+	assert.Contains(t, rec.Body.String(), "c118ece3-2e4b-4296-99d1-51756e32d232")
+}
+
+// 不存在 fileID も NO_SUCH_FILE で同じ shape に集約 (file 存在判定 oracle を
+// 塞ぐ; 他人 owner 判定との timing oracle にもならないように同経路に揃える)。
+func TestFilesAttachedNotes_NotFound(t *testing.T) {
+	h, _, _ := newHandlerWithRepos(t)
+	c, rec := newJSONReq(t, `{"fileId":"nonexistent"}`)
+	setUser(c, "u1")
+	require.NoError(t, h.FilesAttachedNotes(c))
+	assert.Equal(t, http.StatusBadRequest, rec.Code)
+	assert.Contains(t, rec.Body.String(), "NO_SUCH_FILE")
+	// upstream Misskey TS attached-notes.ts と同じ UUID。汎用 NoSuchFile
+	// (UUIDNoSuchFile) と区別するために値比較しておく。
+	assert.Contains(t, rec.Body.String(), "c118ece3-2e4b-4296-99d1-51756e32d232")
 }
 
 // frontend Paginator から渡される sinceId / untilId / limit が
@@ -939,6 +996,11 @@ func TestFilesAttachedNotes_ForwardsCursorParams(t *testing.T) {
 	h, fileRepo, folderRepo := newHandler(t)
 	spy := &spyNoteRepo{MockNoteRepository: testutil.NewMockNoteRepository()}
 	h.SetRepos(fileRepo, folderRepo, spy)
+	// #1470 IDOR fix: handler が ListByFileID を呼ぶ前に viewer 所有 file の
+	// 存在を要求するようになったので、cursor forward test も該当 file を
+	// 用意してから経路を通す。
+	uid := "u1"
+	fileRepo.Files["f1"] = &model.DriveFile{ID: "f1", UserID: &uid}
 
 	c, rec := newJSONReq(t, `{"fileId":"f1","untilId":"u_xxx","limit":7}`)
 	setUser(c, "u1")


### PR DESCRIPTION
## Summary

- `POST /api/drive/files/attached-notes` の handler 冒頭に `fileRepo.FindByID(fileID)` + `f.UserID == viewer.ID` の owner check を追加。
- 不存在 / 他人 owner / system file (userId IS NULL) / `fileRepo` 未配線はすべて upstream 専用 UUID `c118ece3-2e4b-4296-99d1-51756e32d232` 付きの `NO_SUCH_FILE` (400) に集約。
- handler_test に他人 owner / system file / 不存在 / nil fileRepo の 4 negative test を追加し、cursor forward test も該当 file 準備込みに更新。

## 主な変更点

- `internal/api/drive/handler.go`: `FilesAttachedNotes` 冒頭で `fileRepo` 経由の所有 lookup を必須化。godoc に上流互換と本修正の意図を明記。
- `internal/api/drive/handler_test.go`: 4 negative test + 既存 Success / NilRepo / ForwardsCursorParams を新 contract に合わせて更新。
- 設計判断: `notes/create` の `checkFileIDs` で「note.fileIds は必ず author 所有」が強制されるため、owner check 通過後の note は CanSeeNote の本人 short-circuit で常に true。よって追加の `FilterVisible` は不要 (= followingRepo の wiring を増やさない)。godoc にも理由を記載。

## テスト

- `make fmt && go vet ./internal/api/drive/...` 差分無し / 失敗無し。
- `go test ./internal/api/drive/... -count=1 -cover` → coverage **90.6%** (gate 90% を維持)、追加 4 test 含めて全 pass。

## Test plan

- [x] `TestFilesAttachedNotes_OtherOwnerDenied` で他人 owner 拒否を固定
- [x] `TestFilesAttachedNotes_SystemFileDenied` で `userId IS NULL` 拒否 + nil pointer 回避
- [x] `TestFilesAttachedNotes_NotFound` で不存在 fileID を同経路に集約 (oracle 塞ぎ)
- [x] `TestFilesAttachedNotes_NilRepo` で `fileRepo` 未配線時 fail-closed
- [x] 既存 Success / ForwardsCursorParams を新 contract に追従

Closes #1470

🤖 Generated with [Claude Code](https://claude.com/claude-code)