### PR TITLE
fix(stream): notification stream の Pack に notifiee visibility gate を追加 (#1471)

### DIFF
--- a/internal/core/notification/notification_service.go
+++ b/internal/core/notification/notification_service.go
@@ -122,8 +122,13 @@ type MainStreamPublisher interface {
 // (map with userId / user / note / reaction / etc.). Injected as an
 // interface so core/notification stays independent of entity / repository
 // layers. 実装は internal/stream で提供される。
+//
+// notifieeID は packed body を受け取る viewer の ID (= 通知を受け取る
+// ローカルユーザー)。実装側で note embed の visibility check (#1471) に
+// 使う: followers / specified note は notifiee が CanSeeNote を満たさない
+// ときに note field を落として本文 leak を防ぐ。
 type Packer interface {
-	Pack(n *Notification) any
+	Pack(notifieeID string, n *Notification) any
 }
 
 // unreadPublishDelay は Notification 永続化から `unreadNotification` を main
@@ -247,9 +252,12 @@ func (s *Service) Create(ctx context.Context, in CreateInput) (*Notification, er
 	}
 	// Packer配線済みなら user/note を fetch する Pack() は1回だけ実行し、
 	// publisher / main の両方で packed body を共有する(Devin #314 #1)。
+	// notifieeID を渡して Pack 側で note embed の visibility check (#1471)
+	// を効かせる; followers / specified note を非閲覧 notifiee の stream に
+	// 流さない (REST i/notifications #1444 と対称な doctrine)。
 	var packed any = n
 	if s.packer != nil {
-		packed = s.packer.Pack(n)
+		packed = s.packer.Pack(in.NotifieeID, n)
 	}
 	if s.publisher != nil {
 		// Publisher が packed bodyを受け取れる場合は渡して double-pack

--- a/internal/core/notification/notification_service_test.go
+++ b/internal/core/notification/notification_service_test.go
@@ -227,12 +227,14 @@ func TestService_Create_PublishesUnreadNotification(t *testing.T) {
 
 // stubPacker returns a predefined map as the packed form.
 type stubPacker struct {
-	calls int
-	out   map[string]any
+	calls          int
+	lastNotifieeID string
+	out            map[string]any
 }
 
-func (s *stubPacker) Pack(_ *Notification) any {
+func (s *stubPacker) Pack(notifieeID string, _ *Notification) any {
 	s.calls++
+	s.lastNotifieeID = notifieeID
 	return s.out
 }
 
@@ -248,6 +250,11 @@ func TestService_Create_UsesPackerForUnreadNotification(t *testing.T) {
 	})
 	require.NoError(t, err)
 	assert.Equal(t, 1, packer.calls)
+	// #1471: Service.Create は Pack に notifieeID を渡すことで Packer 側で
+	// note embed の visibility gate を効かせる契約。stub に届く notifieeID
+	// を確認しておくと、将来 Pack signature を変えたときに silent failure
+	// (= visibility check の入力がずれて leak) を起こさない。
+	assert.Equal(t, "alice", packer.lastNotifieeID)
 	require.Len(t, pub.calls, 1)
 	// body はpackerの出力 map に置き換わる (TS互換shape)
 	body, ok := pub.calls[0].body.(map[string]any)

--- a/internal/server/router.go
+++ b/internal/server/router.go
@@ -1744,6 +1744,10 @@ func (s *Server) setupRoutes() {
 	notificationPublisher.SetRepos(userRepo, noteRepo, idGen)
 	notificationPublisher.SetInstanceLookup(instanceRepo)
 	notificationPublisher.SetEmojiLookup(emojiRepo)
+	// followingRepo: Pack 内 noteVisibleToNotifiee の followers visibility
+	// gate (#1471) に必要。未配線時は CanSeeNote semantics に合わせて
+	// followers note を本人以外に embed しない (= fail-closed)。
+	notificationPublisher.SetFollowingChecker(followingRepo)
 	drivePublisher := stream.NewDrivePublisher(streamPubSub)
 	reversiPublisher := stream.NewReversiGamePublisher(streamPubSub)
 	mainStreamPublisher := stream.NewMainStreamPublisher(streamPubSub)

--- a/internal/stream/note_publisher.go
+++ b/internal/stream/note_publisher.go
@@ -158,6 +158,14 @@ type NotificationNoteRepo interface {
 	FindByIDWithRelations(id string) (*model.Note, error)
 }
 
+// NotificationFollowingChecker abstracts the FollowingRepository.Exists call
+// needed by Pack's visibility gate (#1471). Narrow interface so we don't pull
+// the whole repository package into the stream layer (mirrors the
+// NotificationUserRepo / NotificationNoteRepo pattern).
+type NotificationFollowingChecker interface {
+	Exists(followerID, followeeID string) (bool, error)
+}
+
 // NotificationPublisher serializes a notification.Notification and publishes
 // it to the per-user `notifications:<id>` topic. Implements
 // core/notification.StreamingPublisher. When userRepo / noteRepo are set
@@ -167,6 +175,7 @@ type NotificationPublisher struct {
 	pub            PubSubPublisher
 	userRepo       NotificationUserRepo
 	noteRepo       NotificationNoteRepo
+	followingRepo  NotificationFollowingChecker
 	idGen          id.Generator
 	instanceLookup entity.InstanceLookup
 	emojiLookup    entity.EmojiLookup
@@ -199,10 +208,27 @@ func (p *NotificationPublisher) SetEmojiLookup(lookup entity.EmojiLookup) {
 	p.emojiLookup = lookup
 }
 
+// SetFollowingChecker attaches the follow relation checker used by Pack to
+// gate note embeds against notifiee visibility (#1471). When unset, Pack
+// falls back to a fail-closed branch for `followers` visibility (= note
+// embed is dropped for non-author notifiees), mirroring core/note.CanSeeNote
+// の `followingChecker == nil` semantics。
+func (p *NotificationPublisher) SetFollowingChecker(c NotificationFollowingChecker) {
+	p.followingRepo = c
+}
+
 // Pack implements core/notification.Packer. Returns the packed map shape
 // when repos are wired, otherwise the raw Notification so callers can
 // fall back to prior behaviour.
-func (p *NotificationPublisher) Pack(n *corenotification.Notification) any {
+//
+// notifieeID は packed body を受け取る viewer。followers / specified
+// visibility の note は notifiee が CanSeeNote 相当の判定を満たさない
+// 場合 note field を nil にして本文 leak を防ぐ (#1471 IDOR fix)。
+// REST `i/notifications` の #1444 fix と対称: notification 行自体は残す
+// が note detail を落とすことで非可視 viewer に「通知は来た / 本文は隠す」
+// shape を実現する。notifieeID が空 (= Pack の呼び出し元が context を
+// 渡し損ねた) ときも fail-closed で followers / specified note を落とす。
+func (p *NotificationPublisher) Pack(notifieeID string, n *corenotification.Notification) any {
 	if n == nil {
 		return nil
 	}
@@ -218,10 +244,61 @@ func (p *NotificationPublisher) Pack(n *corenotification.Notification) any {
 	var note *model.Note
 	if n.NoteID != "" && p.noteRepo != nil {
 		if n2, err := p.noteRepo.FindByIDWithRelations(n.NoteID); err == nil {
-			note = n2
+			// visibility gate (#1471): note embed を pack に通す前に
+			// notifiee が見られるかを判定。core/note.CanSeeNote と同じ
+			// 条件を、stream → repository への直接依存を避けるため inline
+			// で再現する (NotificationUserRepo / NotificationNoteRepo と
+			// 同じ design pattern)。
+			if noteVisibleToNotifiee(notifieeID, n2, p.followingRepo) {
+				note = n2
+			}
 		}
 	}
 	return entity.PackNotification(n, user, note, p.idGen, p.instanceLookup, p.emojiLookup)
+}
+
+// noteVisibleToNotifiee mirrors core/note.CanSeeNote: returns true when
+// notifieeID is allowed to see n per its visibility level. Inlined here so
+// the stream package does not need to import core/note + repository (matches
+// the narrow-interface pattern used by NotificationUserRepo). 条件は
+// CanSeeNote と一致させること。
+func noteVisibleToNotifiee(notifieeID string, n *model.Note, follow NotificationFollowingChecker) bool {
+	if n == nil {
+		return false
+	}
+	switch n.Visibility {
+	case model.NoteVisibilityPublic, model.NoteVisibilityHome:
+		return true
+	case model.NoteVisibilityFollowers:
+		if notifieeID == "" {
+			return false
+		}
+		if notifieeID == n.UserID {
+			return true
+		}
+		if follow == nil {
+			return false
+		}
+		ok, err := follow.Exists(notifieeID, n.UserID)
+		if err != nil {
+			return false
+		}
+		return ok
+	case model.NoteVisibilitySpecified:
+		if notifieeID == "" {
+			return false
+		}
+		if notifieeID == n.UserID {
+			return true
+		}
+		for _, id := range n.VisibleUserIDs {
+			if id == notifieeID {
+				return true
+			}
+		}
+		return false
+	}
+	return false
 }
 
 // PublishNotification serializes the notification and publishes to
@@ -232,7 +309,7 @@ func (p *NotificationPublisher) PublishNotification(notifieeID string, n *coreno
 	if p.pub == nil || notifieeID == "" || n == nil {
 		return
 	}
-	p.publishPacked(notifieeID, p.Pack(n))
+	p.publishPacked(notifieeID, p.Pack(notifieeID, n))
 }
 
 // PublishPackedNotification publishes an already-packed body to

--- a/internal/stream/note_publisher_test.go
+++ b/internal/stream/note_publisher_test.go
@@ -311,9 +311,11 @@ func TestNotificationPublisher_WithRepos_PacksUserAndNote(t *testing.T) {
 	pub := &stubPublisher{}
 	np := NewNotificationPublisher(pub)
 	idGen, _ := id.NewGenerator("aidx")
+	// #1471: visibility gate が入ったので test data も visibility を明示。
+	// public は誰でも見られるので note embed が残ることを確認する path。
 	np.SetRepos(
 		&stubNotifUserRepo{user: &model.User{ID: "u2", Username: "bob"}},
-		&stubNotifNoteRepo{note: &model.Note{ID: "note1", UserID: "u2"}},
+		&stubNotifNoteRepo{note: &model.Note{ID: "note1", UserID: "u2", Visibility: model.NoteVisibilityPublic}},
 		idGen,
 	)
 	n := &corenotification.Notification{
@@ -338,14 +340,14 @@ func TestNotificationPublisher_WithRepos_PacksUserAndNote(t *testing.T) {
 
 func TestNotificationPublisher_Pack_NilNotification(t *testing.T) {
 	np := NewNotificationPublisher(nil)
-	assert.Nil(t, np.Pack(nil))
+	assert.Nil(t, np.Pack("alice", nil))
 }
 
 func TestNotificationPublisher_Pack_WithoutRepos_ReturnsRawNotification(t *testing.T) {
 	np := NewNotificationPublisher(nil)
 	n := &corenotification.Notification{ID: "x"}
 	// SetReposを呼ばなければ raw *Notificationがそのまま返る。
-	assert.Equal(t, n, np.Pack(n))
+	assert.Equal(t, n, np.Pack("alice", n))
 }
 
 func TestNotificationPublisher_Pack_WithRepos_ReturnsPackedMap(t *testing.T) {
@@ -361,7 +363,7 @@ func TestNotificationPublisher_Pack_WithRepos_ReturnsPackedMap(t *testing.T) {
 		Type:       corenotification.TypeFollow,
 		NotifierID: "u_b",
 	}
-	out := np.Pack(n)
+	out := np.Pack("alice", n)
 	body, ok := out.(map[string]any)
 	require.True(t, ok)
 	assert.Equal(t, "u_b", body["userId"])
@@ -369,6 +371,204 @@ func TestNotificationPublisher_Pack_WithRepos_ReturnsPackedMap(t *testing.T) {
 	_, hasNote := body["note"]
 	assert.False(t, hasNote)
 }
+
+// stubNotifFollowingChecker は CanSeeNote の followers branch を test 用に
+// stub する。`followers` map に (follower, followee) を入れておくと
+// Exists が true を返す。
+type stubNotifFollowingChecker struct {
+	followers map[string]map[string]bool
+}
+
+func (s *stubNotifFollowingChecker) Exists(followerID, followeeID string) (bool, error) {
+	if s == nil || s.followers == nil {
+		return false, nil
+	}
+	return s.followers[followerID][followeeID], nil
+}
+
+// #1471 IDOR fix: followers visibility note への mention/reply 通知が
+// non-follower notifiee の stream に流れた際、note embed を nil 化して
+// 本文を漏らさないこと。
+func TestNotificationPublisher_Pack_FollowersNote_NonFollowerNotifiee_DropsNote(t *testing.T) {
+	np := NewNotificationPublisher(nil)
+	idGen, _ := id.NewGenerator("aidx")
+	np.SetRepos(
+		&stubNotifUserRepo{user: &model.User{ID: "bob"}},
+		&stubNotifNoteRepo{note: &model.Note{
+			ID:         "note1",
+			UserID:     "bob",
+			Visibility: model.NoteVisibilityFollowers,
+			Text:       strPtr("secret followers content"),
+		}},
+		idGen,
+	)
+	np.SetFollowingChecker(&stubNotifFollowingChecker{followers: map[string]map[string]bool{
+		// alice は bob を follow していない
+	}})
+	n := &corenotification.Notification{
+		ID:         "x",
+		Type:       corenotification.TypeMention,
+		NotifierID: "bob",
+		NoteID:     "note1",
+	}
+	out := np.Pack("alice", n)
+	body, ok := out.(map[string]any)
+	require.True(t, ok)
+	// notifierID は残る (= 通知行は出す) が note は落とす
+	assert.Equal(t, "bob", body["userId"])
+	assert.Nil(t, body["note"], "non-follower notifiee には followers note の embed を返さない")
+}
+
+// follower 関係がある notifiee には従来通り note を embed する (regress
+// guard: visibility gate が overshoot して全 follower まで落としていないか)。
+func TestNotificationPublisher_Pack_FollowersNote_FollowerNotifiee_KeepsNote(t *testing.T) {
+	np := NewNotificationPublisher(nil)
+	idGen, _ := id.NewGenerator("aidx")
+	np.SetRepos(
+		&stubNotifUserRepo{user: &model.User{ID: "bob"}},
+		&stubNotifNoteRepo{note: &model.Note{
+			ID:         "note1",
+			UserID:     "bob",
+			Visibility: model.NoteVisibilityFollowers,
+		}},
+		idGen,
+	)
+	np.SetFollowingChecker(&stubNotifFollowingChecker{followers: map[string]map[string]bool{
+		"alice": {"bob": true}, // alice → bob follow
+	}})
+	n := &corenotification.Notification{
+		ID:         "x",
+		Type:       corenotification.TypeReply,
+		NotifierID: "bob",
+		NoteID:     "note1",
+	}
+	out := np.Pack("alice", n)
+	body, ok := out.(map[string]any)
+	require.True(t, ok)
+	assert.NotNil(t, body["note"])
+}
+
+// specified note は visibleUserIDs に含まれない notifiee には note を
+// 落とす (mention 経路で visibleUserIDs 外の user に通知が走る ill-formed
+// state での leak 防止)。
+func TestNotificationPublisher_Pack_SpecifiedNote_NonRecipient_DropsNote(t *testing.T) {
+	np := NewNotificationPublisher(nil)
+	idGen, _ := id.NewGenerator("aidx")
+	np.SetRepos(
+		&stubNotifUserRepo{user: &model.User{ID: "bob"}},
+		&stubNotifNoteRepo{note: &model.Note{
+			ID:             "note1",
+			UserID:         "bob",
+			Visibility:     model.NoteVisibilitySpecified,
+			VisibleUserIDs: []string{"charlie"}, // alice は含まれない
+		}},
+		idGen,
+	)
+	n := &corenotification.Notification{
+		ID:         "x",
+		Type:       corenotification.TypeMention,
+		NotifierID: "bob",
+		NoteID:     "note1",
+	}
+	out := np.Pack("alice", n)
+	body, ok := out.(map[string]any)
+	require.True(t, ok)
+	assert.Nil(t, body["note"], "visibleUserIDs 外の notifiee には specified note embed を返さない")
+}
+
+// specified note でも author 本人 / visibleUserIDs 内の notifiee には
+// 従来通り note を embed する。
+func TestNotificationPublisher_Pack_SpecifiedNote_Recipient_KeepsNote(t *testing.T) {
+	np := NewNotificationPublisher(nil)
+	idGen, _ := id.NewGenerator("aidx")
+	np.SetRepos(
+		&stubNotifUserRepo{user: &model.User{ID: "bob"}},
+		&stubNotifNoteRepo{note: &model.Note{
+			ID:             "note1",
+			UserID:         "bob",
+			Visibility:     model.NoteVisibilitySpecified,
+			VisibleUserIDs: []string{"alice"},
+		}},
+		idGen,
+	)
+	n := &corenotification.Notification{
+		ID:         "x",
+		Type:       corenotification.TypeMention,
+		NotifierID: "bob",
+		NoteID:     "note1",
+	}
+	out := np.Pack("alice", n)
+	body, ok := out.(map[string]any)
+	require.True(t, ok)
+	assert.NotNil(t, body["note"])
+}
+
+// followingRepo 未配線時は CanSeeNote の semantics (followers branch で
+// 本人外不可) に倣って fail-closed。production の router は必ず
+// SetFollowingChecker するが、test の partial setup で followers note の
+// embed が抜けないことを固定する。
+func TestNotificationPublisher_Pack_FollowersNote_NilFollowingChecker_DropsForNonAuthor(t *testing.T) {
+	np := NewNotificationPublisher(nil)
+	idGen, _ := id.NewGenerator("aidx")
+	np.SetRepos(
+		&stubNotifUserRepo{user: &model.User{ID: "bob"}},
+		&stubNotifNoteRepo{note: &model.Note{
+			ID:         "note1",
+			UserID:     "bob",
+			Visibility: model.NoteVisibilityFollowers,
+		}},
+		idGen,
+	)
+	// SetFollowingChecker は呼ばない
+	n := &corenotification.Notification{
+		ID:         "x",
+		Type:       corenotification.TypeReply,
+		NotifierID: "bob",
+		NoteID:     "note1",
+	}
+	out := np.Pack("alice", n)
+	body, _ := out.(map[string]any)
+	require.NotNil(t, body)
+	assert.Nil(t, body["note"], "followingRepo 未配線時は followers note を非著者に embed しない")
+}
+
+// PublishNotification は内部で Pack(notifieeID, n) を呼んでいるので、
+// followers note への non-follower mention で stream payload にも note が
+// 漏れないことを end-to-end で固定。
+func TestNotificationPublisher_PublishNotification_GatesNoteByVisibility(t *testing.T) {
+	pub := &stubPublisher{}
+	np := NewNotificationPublisher(pub)
+	idGen, _ := id.NewGenerator("aidx")
+	np.SetRepos(
+		&stubNotifUserRepo{user: &model.User{ID: "bob"}},
+		&stubNotifNoteRepo{note: &model.Note{
+			ID:         "note1",
+			UserID:     "bob",
+			Visibility: model.NoteVisibilityFollowers,
+			Text:       strPtr("secret"),
+		}},
+		idGen,
+	)
+	np.SetFollowingChecker(&stubNotifFollowingChecker{})
+	n := &corenotification.Notification{
+		ID:         "x",
+		Type:       corenotification.TypeMention,
+		NotifierID: "bob",
+		NoteID:     "note1",
+	}
+	np.PublishNotification("alice", n)
+	require.Len(t, pub.payloads, 1)
+	raw, ok := pub.payloads[0].(json.RawMessage)
+	require.True(t, ok)
+	var body map[string]any
+	require.NoError(t, json.Unmarshal(raw, &body))
+	assert.Nil(t, body["note"], "stream payload にも本文を流さない")
+	// 本文 string が JSON 内に出現しないこと (defensive: 別 field 経由の
+	// leak も塞ぐ)。
+	assert.NotContains(t, string(raw), "secret")
+}
+
+func strPtr(s string) *string { return &s }
 
 func TestNotificationPublisher_NilPubIsNoOp(t *testing.T) {
 	np := NewNotificationPublisher(nil)


### PR DESCRIPTION
## Summary

- `Packer` interface に `notifieeID` 引数を追加し、`NotificationPublisher.Pack` で `core/note.CanSeeNote` と同条件の visibility 判定を inline。
- followers / specified visibility note は notifiee が viewer 資格を満たさない場合 note field を `nil` にして PackNotification に渡す (notification 行は残す、note detail だけ落とす)。
- `NotificationFollowingChecker` narrow interface + `SetFollowingChecker` で `followingRepo` を配線。router.go で wire。未配線時は CanSeeNote semantics に倣って fail-closed。

## 主な変更点

- `internal/core/notification/notification_service.go`: `Packer.Pack` signature 変更 + call site 更新。
- `internal/stream/note_publisher.go`: `NotificationPublisher` に `followingRepo` field と `noteVisibleToNotifiee` helper 追加。Pack 内で visibility gate。`NotificationFollowingChecker` interface を追加 (stream → repository 直接依存を避ける既存 pattern 踏襲)。
- `internal/server/router.go`: `notificationPublisher.SetFollowingChecker(followingRepo)` を 1 行追加。
- `internal/core/notification/notification_service_test.go`: `stubPacker.Pack` を新 signature 対応 + `lastNotifieeID` field で contract assert。
- `internal/stream/note_publisher_test.go`: 5 件 negative + 1 件 end-to-end visibility test を追加 (詳細は test plan)。

## テスト

- `make fmt && go vet ./...` 差分無し / 失敗無し。
- `go test ./internal/stream/... -cover` → **90.4%** (gate 90% 維持)。
- `go test ./internal/core/notification/... -cover` → **91.6%** (gate 90% 維持)。
- `go build ./...` clean。

## Test plan

- [x] `TestNotificationPublisher_Pack_FollowersNote_NonFollowerNotifiee_DropsNote` (followers leak の core scenario)
- [x] `TestNotificationPublisher_Pack_FollowersNote_FollowerNotifiee_KeepsNote` (regress: follower には embed が残る)
- [x] `TestNotificationPublisher_Pack_SpecifiedNote_NonRecipient_DropsNote` (specified の visibleUserIDs 外 mention)
- [x] `TestNotificationPublisher_Pack_SpecifiedNote_Recipient_KeepsNote` (regress: visibleUserIDs 内には残る)
- [x] `TestNotificationPublisher_Pack_FollowersNote_NilFollowingChecker_DropsForNonAuthor` (followingRepo 未配線時 fail-closed)
- [x] `TestNotificationPublisher_PublishNotification_GatesNoteByVisibility` (end-to-end: stream payload の JSON 内に "secret" 本文が出現しないことまで assert)
- [x] `TestService_Create_UsesPackerForUnreadNotification` に notifieeID が Packer に渡る契約も assert。

Closes #1471

🤖 Generated with [Claude Code](https://claude.com/claude-code)