### PR TITLE
fix(stream): publishNoteMainEvents の reply/renote/mention に CanSeeNote gate を追加 (#1472)

### DIFF
--- a/internal/core/note/note_create_service.go
+++ b/internal/core/note/note_create_service.go
@@ -717,19 +717,39 @@ func (s *CreateService) Create(in CreateInput) (*model.Note, error) {
 // the relevant local users' main channels. TS本家と同じくdedupはせず、
 // 同一userに対して複数イベント(例: 相手へのリプライかつメンション)が
 // 並列で届きうる(frontendはイベント種別ごとに意味付けるため)。
+//
+// 旧実装は target が note を見られるか検証せずに `entity.PackNote` の full
+// payload (Text / CW / Files / Renote / Reply embed) を main stream に流して
+// いた (#1472)。followers visibility note を非フォロワー reply/renote/mention
+// target に届けたり、specified visibility note を visibleUserIDs 外の
+// mentioned user に届けて本文が漏れる IDOR が成立していた。各 publish の前に
+// CanSeeNote 同等の判定で gate する: REST `i/notifications` (#1444) / stream
+// `notifications:` (#1471) と doctrine を揃える。
 func (s *CreateService) publishNoteMainEvents(note *model.Note, author *model.User, replyTarget, renoteTarget *model.Note) {
 	if s.mainStreamPublisher == nil {
 		return
 	}
 	packed := entity.PackNote(note, s.idGen)
 	// reply: reply先がlocal (UserHost == nil) かつ自分自身へのリプライで
-	// ない場合にemit。
+	// ない場合にemit。visibility gate (#1472): reply target が note を見ら
+	// れないとき (= 非 follower や visibleUserIds 外) は本文 leak になるので
+	// publish skip。CanSeeNote は viewer.ID == note.UserID で短絡するため
+	// 著者自身への self-reply は元から exclude されている `UserID != author.ID`
+	// と重ねて防御。
 	if replyTarget != nil && replyTarget.UserHost == nil && replyTarget.UserID != author.ID {
-		s.mainStreamPublisher.PublishMainEvent(replyTarget.UserID, "reply", packed)
+		viewer := &model.User{ID: replyTarget.UserID}
+		if CanSeeNote(viewer, note, s.followingRepo) {
+			s.mainStreamPublisher.PublishMainEvent(replyTarget.UserID, "reply", packed)
+		}
 	}
-	// renote: 同上 (TS: caller ≠ target author条件あり)。
+	// renote: 同上 (TS: caller ≠ target author条件あり)。visibility gate も
+	// reply と同じ理由で必要。renote target が non-follower の場合、quote
+	// renote (= Text/CW 持ち) は本文ごと leak する。
 	if renoteTarget != nil && renoteTarget.UserHost == nil && renoteTarget.UserID != author.ID {
-		s.mainStreamPublisher.PublishMainEvent(renoteTarget.UserID, "renote", packed)
+		viewer := &model.User{ID: renoteTarget.UserID}
+		if CanSeeNote(viewer, note, s.followingRepo) {
+			s.mainStreamPublisher.PublishMainEvent(renoteTarget.UserID, "renote", packed)
+		}
 	}
 	// mention: note.Mentionsは(userRepo設定時)user ID配列なので、
 	// 各userをfetchしてlocalかつauthor自身でなければemitする。
@@ -747,6 +767,14 @@ func (s *CreateService) publishNoteMainEvents(note *model.Note, author *model.Us
 		}
 		if u.Host != nil {
 			continue // remote user — AP配送(別レイヤ)が担当
+		}
+		// visibility gate (#1472): specified visibility 経路では note.Mentions
+		// と note.VisibleUserIDs が乖離しうる (本文に @x が含まれるが visible
+		// 指定は別) ため、CanSeeNote の slices.Contains で visibleUserIDs 外の
+		// mention target を弾く。followers visibility 経路でも non-follower
+		// mention をここで止める。
+		if !CanSeeNote(u, note, s.followingRepo) {
+			continue
 		}
 		s.mainStreamPublisher.PublishMainEvent(uid, "mention", packed)
 	}

--- a/internal/core/note/note_create_service_test.go
+++ b/internal/core/note/note_create_service_test.go
@@ -58,6 +58,19 @@ func newCreateService(t *testing.T) (*note.CreateService, *testutil.MockNoteRepo
 	return svc, noteRepo, pollRepo
 }
 
+// newCreateServiceWithFollowing wires a MockFollowingRepository so tests can
+// exercise the followers-visibility main-stream gate (#1472). Returns the
+// service plus both repos so tests can plant rows directly.
+func newCreateServiceWithFollowing(t *testing.T) (*note.CreateService, *testutil.MockNoteRepository, *testutil.MockFollowingRepository) {
+	t.Helper()
+	noteRepo := testutil.NewMockNoteRepository()
+	pollRepo := testutil.NewMockPollRepository()
+	followingRepo := testutil.NewMockFollowingRepository()
+	idGen, _ := id.NewGenerator("aidx")
+	svc := note.NewCreateService(noteRepo, pollRepo, idGen, followingRepo)
+	return svc, noteRepo, followingRepo
+}
+
 func TestCreateService_Success(t *testing.T) {
 	svc, noteRepo, _ := newCreateService(t)
 
@@ -1591,6 +1604,171 @@ func TestCreateService_NoMainStreamPublisher_NoEmit(t *testing.T) {
 		User: &model.User{ID: "alice"}, Text: &text, ReplyID: &replyID,
 	})
 	require.NoError(t, err)
+}
+
+// --- #1472 visibility gate (publishNoteMainEvents) ---
+
+// followers visibility note を non-follower reply target に publish しない
+// (本文 / CW / Files が main stream で leak するのを塞ぐ)。
+func TestCreateService_SkipsReplyMainEvent_FollowersToNonFollower(t *testing.T) {
+	svc, noteRepo, _ := newCreateServiceWithFollowing(t)
+	pub := &stubMainStreamPublisher{}
+	svc.SetMainStreamPublisher(pub)
+	// reply target bob は alice (author) を follow していない
+	noteRepo.Notes["r1"] = &model.Note{
+		ID: "r1", UserID: "bob", Visibility: model.NoteVisibilityPublic,
+	}
+	replyID := "r1"
+	text := "secret followers reply"
+	_, err := svc.Create(note.CreateInput{
+		User:       &model.User{ID: "alice"},
+		Text:       &text,
+		ReplyID:    &replyID,
+		Visibility: model.NoteVisibilityFollowers,
+	})
+	require.NoError(t, err)
+	assert.Empty(t, pub.userIDsOf("reply"), "non-follower reply target には followers note の main event を流さない")
+}
+
+// follower 関係がある reply target には従来通り publish する (regress
+// guard: visibility gate が overshoot して legitimate notification を抑え
+// ていないか)。
+func TestCreateService_PublishesReplyMainEvent_FollowersToFollower(t *testing.T) {
+	svc, noteRepo, followingRepo := newCreateServiceWithFollowing(t)
+	pub := &stubMainStreamPublisher{}
+	svc.SetMainStreamPublisher(pub)
+	noteRepo.Notes["r1"] = &model.Note{
+		ID: "r1", UserID: "bob", Visibility: model.NoteVisibilityPublic,
+	}
+	// bob → alice の follow を planting (= bob は alice を follow している)
+	followingRepo.Followings["f1"] = &model.Following{
+		ID: "f1", FollowerID: "bob", FolloweeID: "alice",
+	}
+	replyID := "r1"
+	text := "hi follower"
+	_, err := svc.Create(note.CreateInput{
+		User:       &model.User{ID: "alice"},
+		Text:       &text,
+		ReplyID:    &replyID,
+		Visibility: model.NoteVisibilityFollowers,
+	})
+	require.NoError(t, err)
+	assert.Equal(t, []string{"bob"}, pub.userIDsOf("reply"))
+}
+
+// specified visibility note を visibleUserIDs 外の reply target に publish
+// しない (DM 用 visibility 経路で reply target が ill-formed に含まれて
+// しまった場合の defense-in-depth)。
+func TestCreateService_SkipsReplyMainEvent_SpecifiedExcludesNonRecipient(t *testing.T) {
+	svc, noteRepo, _ := newCreateServiceWithFollowing(t)
+	pub := &stubMainStreamPublisher{}
+	svc.SetMainStreamPublisher(pub)
+	noteRepo.Notes["r1"] = &model.Note{
+		ID: "r1", UserID: "bob", Visibility: model.NoteVisibilityPublic,
+	}
+	replyID := "r1"
+	text := "specified secret"
+	_, err := svc.Create(note.CreateInput{
+		User:           &model.User{ID: "alice"},
+		Text:           &text,
+		ReplyID:        &replyID,
+		Visibility:     model.NoteVisibilitySpecified,
+		VisibleUserIDs: []string{"charlie"}, // bob は含まれない
+	})
+	require.NoError(t, err)
+	assert.Empty(t, pub.userIDsOf("reply"))
+}
+
+// specified visibility で reply target が visibleUserIDs に含まれていれば
+// publish する。slices.Contains 経路の regress guard。
+func TestCreateService_PublishesReplyMainEvent_SpecifiedIncludesRecipient(t *testing.T) {
+	svc, noteRepo, _ := newCreateServiceWithFollowing(t)
+	pub := &stubMainStreamPublisher{}
+	svc.SetMainStreamPublisher(pub)
+	noteRepo.Notes["r1"] = &model.Note{
+		ID: "r1", UserID: "bob", Visibility: model.NoteVisibilityPublic,
+	}
+	replyID := "r1"
+	text := "dm"
+	_, err := svc.Create(note.CreateInput{
+		User:           &model.User{ID: "alice"},
+		Text:           &text,
+		ReplyID:        &replyID,
+		Visibility:     model.NoteVisibilitySpecified,
+		VisibleUserIDs: []string{"bob"},
+	})
+	require.NoError(t, err)
+	assert.Equal(t, []string{"bob"}, pub.userIDsOf("reply"))
+}
+
+// mention: followers note を non-follower mentioned user に publish しない。
+// #1472 でいちばん見落としていた経路 — `notifyVisibleToTarget` は notification
+// 経路で gate するが main stream は独立 publish なので、ここで止めないと
+// 本文 / CW が realtime に漏れる。
+func TestCreateService_SkipsMentionMainEvent_FollowersToNonFollower(t *testing.T) {
+	svc, _, _ := newCreateServiceWithFollowing(t)
+	userRepo := testutil.NewMockUserRepository()
+	userRepo.Users["uA"] = &model.User{ID: "uA", Username: "alice", UsernameLower: "alice"}
+	svc.SetUserRepo(userRepo)
+	pub := &stubMainStreamPublisher{}
+	svc.SetMainStreamPublisher(pub)
+
+	// followingRepo は空 = uA は author を follow していない
+	text := "secret @alice"
+	_, err := svc.Create(note.CreateInput{
+		User:       &model.User{ID: "author1"},
+		Text:       &text,
+		Visibility: model.NoteVisibilityFollowers,
+	})
+	require.NoError(t, err)
+	assert.Empty(t, pub.userIDsOf("mention"), "non-follower mention に followers note の main event を流さない")
+}
+
+// specified visibility で mentioned user が visibleUserIDs に含まれない場合
+// (mention 経路で resolve された user が visible 指定外) も skip する。
+// upstream #17363 / mk-go #1444 の specified note 通知ルールを main event 側
+// にも適用する。
+func TestCreateService_SkipsMentionMainEvent_SpecifiedExcludesNonRecipient(t *testing.T) {
+	svc, _, _ := newCreateServiceWithFollowing(t)
+	userRepo := testutil.NewMockUserRepository()
+	userRepo.Users["uA"] = &model.User{ID: "uA", Username: "alice", UsernameLower: "alice"}
+	userRepo.Users["uC"] = &model.User{ID: "uC", Username: "charlie", UsernameLower: "charlie"}
+	svc.SetUserRepo(userRepo)
+	pub := &stubMainStreamPublisher{}
+	svc.SetMainStreamPublisher(pub)
+
+	text := "specified @alice @charlie"
+	_, err := svc.Create(note.CreateInput{
+		User:           &model.User{ID: "author1"},
+		Text:           &text,
+		Visibility:     model.NoteVisibilitySpecified,
+		VisibleUserIDs: []string{"uA"}, // charlie は含まれない
+	})
+	require.NoError(t, err)
+	// alice (uA) のみ通知、charlie (uC) は visibleUserIds 外なので skip
+	assert.Equal(t, []string{"uA"}, pub.userIDsOf("mention"))
+}
+
+// renote target の visibility gate: quote renote (= Text / CW を伴う) を
+// followers 設定で投げて renote target が non-follower の場合、本文ごと
+// main stream で leak するのを塞ぐ。
+func TestCreateService_SkipsRenoteMainEvent_FollowersToNonFollower(t *testing.T) {
+	svc, noteRepo, _ := newCreateServiceWithFollowing(t)
+	pub := &stubMainStreamPublisher{}
+	svc.SetMainStreamPublisher(pub)
+	noteRepo.Notes["r1"] = &model.Note{
+		ID: "r1", UserID: "bob", Visibility: model.NoteVisibilityPublic,
+	}
+	renoteID := "r1"
+	text := "quote secret"
+	_, err := svc.Create(note.CreateInput{
+		User:       &model.User{ID: "alice"},
+		Text:       &text,
+		RenoteID:   &renoteID,
+		Visibility: model.NoteVisibilityFollowers,
+	})
+	require.NoError(t, err)
+	assert.Empty(t, pub.userIDsOf("renote"))
 }
 
 func TestSafeGo_RecoversPanic(t *testing.T) {


### PR DESCRIPTION
## Summary

- `publishNoteMainEvents` (note_create_service.go) の reply / renote / mention 3 publish のそれぞれの直前に `corenote.CanSeeNote(viewer, note, s.followingRepo)` の visibility gate を追加。
- followers visibility: 非フォロワーの reply / renote / mention target にもれていた本文 / CW / Files の main stream payload を塞ぐ。
- specified visibility: `note.Mentions` の for-loop で visibleUserIDs 外の mentioned user にも publish していたのを `slices.Contains` 経由で正しく絞る。
- REST `i/notifications` (#1444) / stream `notifications:<userID>` (#1471) と同じ doctrine: 通知行は残すが note detail を非可視 viewer に流さない。

## 主な変更点

- `internal/core/note/note_create_service.go`: `publishNoteMainEvents` の reply / renote / mention 経路に CanSeeNote gate を追加。同 package なので `CanSeeNote` を直接呼び出し可能 (新 import 不要)。godoc に IDOR 経路と修正意図、followers/specified それぞれで helper が何を弾くかを記載。
- `internal/core/note/note_create_service_test.go`: `newCreateServiceWithFollowing` helper を追加し、followers/specified 双方の正常系・異常系をカバーする 7 件の test を追加。

## テスト

- `make fmt && go vet ./...` 差分無し / 失敗無し。
- `go test ./internal/core/note/... -count=1 -cover` → coverage **94.4%** (gate 90% を維持)。
- 既存の `Publishes*` / `Skips*` 6 test も pass。
- `go build ./...` clean。

## Test plan

- [x] `TestCreateService_SkipsReplyMainEvent_FollowersToNonFollower` (followers leak の core scenario)
- [x] `TestCreateService_PublishesReplyMainEvent_FollowersToFollower` (regress: follower には残す)
- [x] `TestCreateService_SkipsReplyMainEvent_SpecifiedExcludesNonRecipient` (specified の visibleUserIDs 外 reply target)
- [x] `TestCreateService_PublishesReplyMainEvent_SpecifiedIncludesRecipient` (regress: visibleUserIDs 内には残す)
- [x] `TestCreateService_SkipsMentionMainEvent_FollowersToNonFollower` (mention 経路の core: notify ≠ main の独立 publish path)
- [x] `TestCreateService_SkipsMentionMainEvent_SpecifiedExcludesNonRecipient` (mention 経路の specified gate)
- [x] `TestCreateService_SkipsRenoteMainEvent_FollowersToNonFollower` (quote renote の本文 leak)

Closes #1472

🤖 Generated with [Claude Code](https://claude.com/claude-code)