### PR TITLE
Phase: Migrate local drive files to object storage (#1476)

### DIFF
--- a/.config/default.yml.example
+++ b/.config/default.yml.example
@@ -366,6 +366,7 @@ proxyBypassHosts:
 #  deleteLocal: false
 #  localPath: ./drive-files
 #  concurrency: 2
+#  scanBatchSize: 100
 
 #   ┌──────────────────────────────────┐
 #───┘ Test / debug (mk-go specific) └───────────────────────────

--- a/.config/default.yml.example
+++ b/.config/default.yml.example
@@ -354,6 +354,19 @@ proxyBypassHosts:
 #    enableQueryParamLogging: false
 #    disableQueryTruncation: false
 
+#   ┌─────────────────────────────────────┐
+#───┘ Local drive → object storage migration └──────────────────
+
+# mk-go specific (#1476). Migrates files under ./drive-files that are still
+# storedInternal=true into the S3 backend configured in the meta table.
+# Requires meta.useObjectStorage=true and a valid bucket before startup.
+#
+#driveLocalToObjectStorage:
+#  enabled: false
+#  deleteLocal: false
+#  localPath: ./drive-files
+#  concurrency: 2
+
 #   ┌──────────────────────────────────┐
 #───┘ Test / debug (mk-go specific) └───────────────────────────
 

--- a/.config/docker.yml.example
+++ b/.config/docker.yml.example
@@ -217,6 +217,17 @@ proxyBypassHosts:
 #    enableQueryParamLogging: false
 #    disableQueryTruncation: false
 
+#   ┌─────────────────────────────────────┐
+#───┘ Local drive → object storage migration └──────────────────
+
+# mk-go specific (#1476). See default.yml.example for field descriptions.
+#
+#driveLocalToObjectStorage:
+#  enabled: false
+#  deleteLocal: false
+#  localPath: ./drive-files
+#  concurrency: 2
+
 # Expose the Prometheus /metrics endpoint with job-queue metrics.
 # Unauthenticated; restrict access via nginx / LB ACL if exposed outside
 # the cluster. See docs/design/auto-scale-job-workers.md §6.1.

--- a/.config/docker.yml.example
+++ b/.config/docker.yml.example
@@ -227,6 +227,7 @@ proxyBypassHosts:
 #  deleteLocal: false
 #  localPath: ./drive-files
 #  concurrency: 2
+#  scanBatchSize: 100
 
 # Expose the Prometheus /metrics endpoint with job-queue metrics.
 # Unauthenticated; restrict access via nginx / LB ACL if exposed outside

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,1 @@
+CLAUDE.md

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Change: `useObjectStorage=true` かつ `storedInternal=false` の `GET /files/:accessKey` は公開 URL（S3 / CDN）へ 302 リダイレクトする。ローカル→S3 移行ジョブ（`driveLocalToObjectStorage`）の有無に関わらず、object storage 運用インスタンス全体に適用される。same-origin プロキシで付与していた `Cache-Control: no-transform` はリダイレクト先に引き継がれない（#730 / #1476）
+- Fix: ローカルドライブ→S3 移行のフォールバック存在確認で `S3Storage.Get` のレスポンスボディを破棄していた問題を修正。`HeadObject` ベースの `Exists` に切り替え（#1476）
 - Fix: 管理画面のプロモーション登録 (`/api/admin/promo/create`) で、公開範囲が public 以外のノート (フォロワー限定 / ホーム / specified) も登録できていた問題を修正 (将来 promo 表示エンドポイントが実装された際に非公開ノートが全閲覧者に漏れる潜在的問題を作成段階で防止)
 - Fix: ユーザーリストのタイムライン (`/api/notes/user-list-timeline` の REST 経路は #1442 で修正済) について、WebSocket `userList` チャネルと fanout 配信が他ユーザーのフォロワー限定ノートをリスト所有者のフォロー関係に関係なくプッシュしていた問題を修正 (任意のユーザーをリストに追加しただけで、フォローしていない相手のフォロワー限定ノートをリアルタイムに受信できていた)
 - Fix: アンテナが他ユーザーのフォロワー限定 / specified ノートを公開範囲チェックを経ずに pickup し、`/api/antennas/notes` と WebSocket `antenna` チャネルの両方からそれらが取得できる問題を修正 (アンテナ作成だけで `src=all` / `src=users` 経由のキーワード検索で非公開投稿が漏れていた)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+- Fix: `storedInternal=false` かつ URL が same-origin `/files/` のままの行で `/files/:accessKey` が自己参照 302 ループに陥る問題を修正。リダイレクトせず storage から配信する（#1476）
+- Fix: ローカル→S3 移行の起動時 enqueue / Redis lock チェック失敗でサーバー全体が起動不能になる問題を修正。エラーはログのみ（#1476）
+- Fix: `driveLocalToObjectStorage.localPath` の `os.Stat` で存在以外のエラー（権限拒否等）を無視していた問題を修正（#1476）
 - Change: `useObjectStorage=true` かつ `storedInternal=false` の `GET /files/:accessKey` は公開 URL（S3 / CDN）へ 302 リダイレクトする。ローカル→S3 移行ジョブ（`driveLocalToObjectStorage`）の有無に関わらず、object storage 運用インスタンス全体に適用される。same-origin プロキシで付与していた `Cache-Control: no-transform` はリダイレクト先に引き継がれない（#730 / #1476）
 - Fix: ローカルドライブ→S3 移行のフォールバック存在確認で `S3Storage.Get` のレスポンスボディを破棄していた問題を修正。`HeadObject` ベースの `Exists` に切り替え（#1476）
 - Fix: 管理画面のプロモーション登録 (`/api/admin/promo/create`) で、公開範囲が public 以外のノート (フォロワー限定 / ホーム / specified) も登録できていた問題を修正 (将来 promo 表示エンドポイントが実装された際に非公開ノートが全閲覧者に漏れる潜在的問題を作成段階で防止)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,11 @@
 
 ### Upgrade notes (object storage / #1476)
 
-`meta.useObjectStorage=true` のインスタンスは、**`driveLocalToObjectStorage` を有効にしていなくても**、`storedInternal=false` の `GET /files/:accessKey` が公開 URL（S3 / CDN）へ **302** になります（従来は mk-go が same-origin でプロキシ配信し `Cache-Control: no-transform` を付与）。
+> **リリース時**: この小節を GitHub Release 本文にそのままコピーし、object storage 運用インスタンスの運用者へ周知すること。
+
+`meta.useObjectStorage=true` のインスタンスは、**`driveLocalToObjectStorage.enabled` の有無に関わらず**（ローカル→S3 移行ジョブを有効にしていない既存 S3 運用も含む）、`storedInternal=false` の `GET /files/:accessKey` が公開 URL（S3 / CDN）へ **302** になります（従来は mk-go が same-origin でプロキシ配信し `Cache-Control: no-transform` を付与）。Misskey TS 互換の意図的な配信経路変更です。
+
+**same-origin でプロキシが継続する条件**: `drive_file.url`（および該当する thumb/webpublic URL）がまだ `https://<instance>/files/...` のとき、または `objectStorage.baseUrl` を同一オリジンに向けた proxy 運用のときは 302 せず mk-go が `storage.Get` で配信します（`URLUsesDrivePrefix`）。
 
 - **確認**: アップグレード前後で代表ファイルに `curl -I https://<instance>/files/<accessKey>` を実行し、`Location` が想定 CDN か確認する
 - **CDN (#730)**: `no-transform` はリダイレクト先に引き継がれない。Cloudflare Polish 等を使う場合は S3 / CloudFront / CDN 側で同等ヘッダを設定する

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 ## Unreleased
 
+### Upgrade notes (object storage / #1476)
+
+`meta.useObjectStorage=true` のインスタンスは、**`driveLocalToObjectStorage` を有効にしていなくても**、`storedInternal=false` の `GET /files/:accessKey` が公開 URL（S3 / CDN）へ **302** になります（従来は mk-go が same-origin でプロキシ配信し `Cache-Control: no-transform` を付与）。
+
+- **確認**: アップグレード前後で代表ファイルに `curl -I https://<instance>/files/<accessKey>` を実行し、`Location` が想定 CDN か確認する
+- **CDN (#730)**: `no-transform` はリダイレクト先に引き継がれない。Cloudflare Polish 等を使う場合は S3 / CloudFront / CDN 側で同等ヘッダを設定する
+- **CORS / クライアント**: 同一オリジン `/files/` URL を前提とした埋め込みは、リダイレクト先ドメインの CORS に依存する
+- **private bucket**: pre-signed URL 前提の非公開バケット運用は想定外（公開 URL / CloudFront 前提）
+- **例外 (same-origin)**: DB の URL がまだインスタンス same-origin `/files/` の行は 302 せず storage から配信（移行途中・ハーフ適用対策）。`objectStorage.baseUrl` を同一オリジンに向けた proxy 運用もこの経路で従来どおりプロキシされる
+
 - Fix: `storedInternal=false` かつ URL が same-origin `/files/` のままの行で `/files/:accessKey` が自己参照 302 ループに陥る問題を修正。リダイレクトせず storage から配信する（#1476）
 - Fix: ローカル→S3 移行の起動時 enqueue / Redis lock チェック失敗でサーバー全体が起動不能になる問題を修正。エラーはログのみ（#1476）
 - Fix: `driveLocalToObjectStorage.localPath` の `os.Stat` で存在以外のエラー（権限拒否等）を無視していた問題を修正（#1476）

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -145,7 +145,7 @@ mk-go 固有。`meta` テーブルで object storage を有効化したあと、
 5. `enabled: false` に戻して再起動する（完了後の誤再実行防止）
 6. 任意: ローカルディレクトリをバックアップして削除する
 
-移行後の `GET /files/:accessKey` は、DB 上 `storedInternal=false` の行について公開 URL へ **302 リダイレクト** する。リクエストキーに応じて `drive_file.url` / `thumbnailUrl` / `webpublicUrl` を出し分ける。
+object storage 利用時（`meta.useObjectStorage=true`）の `GET /files/:accessKey` は、DB 上 `storedInternal=false` の行について公開 URL へ **302 リダイレクト** する（`driveLocalToObjectStorage` の有無に関わらず、S3 へ直接アップロードしたファイルも含む）。リクエストキーに応じて `drive_file.url` / `thumbnailUrl` / `webpublicUrl` を出し分ける。drop-in 互換・CORS・同一オリジン URL を前提としたクライアントは、リダイレクト先ドメインへの影響を確認すること。
 
 **配信と CDN (#730)**: 302 化により same-origin プロキシで付与していた `Cache-Control: no-transform` はリダイレクト先へ引き継がれない。Cloudflare Polish 等による再エンコードを避けるには、S3 / CloudFront / CDN 側で同等のヘッダを設定すること。private bucket + pre-signed URL 運用は想定外（公開 URL / CloudFront 前提）。
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -118,7 +118,33 @@ cp .config/docker.yml.example .config/docker.yml
 
 ### メディア
 
-ローカルストレージ (S3未設定時) のファイル保存先は`./drive-files`固定。Docker環境ではコンテナ内の`/app/drive-files`にボリュームマウントが必要。
+ローカルストレージ (S3未設定時) のファイル保存先はデフォルトで `./drive-files`。`driveLocalToObjectStorage.localPath` で上書き可能。Docker環境ではコンテナ内の `/app/drive-files` にボリュームマウントが必要。
+
+#### ローカルドライブ → オブジェクトストレージ移行 (`driveLocalToObjectStorage`, #1476)
+
+mk-go 固有。`meta` テーブルで object storage を有効化したあと、まだ `storedInternal=true` のローカル実体を S3 に移すバックグラウンドジョブを起動する。
+
+| キー | 型 | デフォルト | 説明 |
+|---|---|---|---|
+| `driveLocalToObjectStorage.enabled` | bool | `false` | `true` で起動時に `objectStorage` キューへ scan ジョブを 1 件投入 |
+| `driveLocalToObjectStorage.deleteLocal` | bool | `false` | 移行成功後にローカル blob を削除 |
+| `driveLocalToObjectStorage.localPath` | string | `./drive-files` | 移行元ディレクトリ |
+| `driveLocalToObjectStorage.concurrency` | int | `2` | `objectStorage` キューの worker 数 (`mkq` / `asynq` 両方) |
+
+環境変数: `MK_DRIVE_LOCAL_TO_OBJECT_STORAGE_ENABLED`, `MK_DRIVE_LOCAL_TO_OBJECT_STORAGE_DELETE_LOCAL`, `MK_DRIVE_LOCAL_TO_OBJECT_STORAGE_LOCAL_PATH`, `MK_DRIVE_LOCAL_TO_OBJECT_STORAGE_CONCURRENCY`
+
+**前提**: `meta.useObjectStorage=true` かつ `meta.objectStorageBucket` が設定済み。満たさない状態で `enabled: true` にすると **起動失敗** する。
+
+**運用手順**:
+
+1. 管理画面または API で object storage を有効化し、接続を確認する
+2. `.config/default.yml` に `driveLocalToObjectStorage.enabled: true` を設定する
+3. プロセスを再起動する（起動ログに `scan job enqueued` / `pendingFiles` が出る）
+4. 既存 `admin/queue/*` API または DB で `storedInternal` 残件が 0 になることを確認する
+5. `enabled: false` に戻して再起動する（完了後の誤再実行防止）
+6. 任意: ローカルディレクトリをバックアップして削除する
+
+移行後の `GET /files/:accessKey` は、DB 上 `storedInternal=false` の行について公開 URL (`drive_file.url` 等) へ **302 リダイレクト** する。
 
 | キー | 型 | デフォルト | 説明 |
 |---|---|---|---|

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -128,12 +128,13 @@ mk-go 固有。`meta` テーブルで object storage を有効化したあと、
 |---|---|---|---|
 | `driveLocalToObjectStorage.enabled` | bool | `false` | `true` で起動時に `objectStorage` キューへ scan ジョブを 1 件投入 |
 | `driveLocalToObjectStorage.deleteLocal` | bool | `false` | 移行成功後にローカル blob を削除 |
-| `driveLocalToObjectStorage.localPath` | string | `./drive-files` | 移行元ディレクトリ |
-| `driveLocalToObjectStorage.concurrency` | int | `2` | `objectStorage` キューの worker 数 (`mkq` / `asynq` 両方) |
+| `driveLocalToObjectStorage.localPath` | string | `./drive-files` | 移行元ディレクトリ（`enabled: true` 時は起動時に絶対パスへ解決。存在しない場合は警告のみ） |
+| `driveLocalToObjectStorage.concurrency` | int | `2` | `objectStorage` キューの worker 数（**プロセス再起動後**に反映、`mkq` / `asynq` 両方） |
+| `driveLocalToObjectStorage.scanBatchSize` | int | `100` | 1 回の `migrateScan` が enqueue する `migrateFile` 件数。残件がある場合は次バッチ用 scan を連鎖投入 |
 
-環境変数: `MK_DRIVE_LOCAL_TO_OBJECT_STORAGE_ENABLED`, `MK_DRIVE_LOCAL_TO_OBJECT_STORAGE_DELETE_LOCAL`, `MK_DRIVE_LOCAL_TO_OBJECT_STORAGE_LOCAL_PATH`, `MK_DRIVE_LOCAL_TO_OBJECT_STORAGE_CONCURRENCY`
+環境変数: `MK_DRIVE_LOCAL_TO_OBJECT_STORAGE_ENABLED`, `MK_DRIVE_LOCAL_TO_OBJECT_STORAGE_DELETE_LOCAL`, `MK_DRIVE_LOCAL_TO_OBJECT_STORAGE_LOCAL_PATH`, `MK_DRIVE_LOCAL_TO_OBJECT_STORAGE_CONCURRENCY`, `MK_DRIVE_LOCAL_TO_OBJECT_STORAGE_SCAN_BATCH_SIZE`
 
-**前提**: `meta.useObjectStorage=true` かつ `meta.objectStorageBucket` が設定済み。満たさない状態で `enabled: true` にすると **起動失敗** する。
+**前提**: `meta.useObjectStorage=true` かつ `meta.objectStorageBucket` が設定済み。満たさない状態で `enabled: true` にしても **サーバーは起動する** が、移行ジョブは投入されない（起動ログに警告）。
 
 **運用手順**:
 
@@ -144,7 +145,11 @@ mk-go 固有。`meta` テーブルで object storage を有効化したあと、
 5. `enabled: false` に戻して再起動する（完了後の誤再実行防止）
 6. 任意: ローカルディレクトリをバックアップして削除する
 
-移行後の `GET /files/:accessKey` は、DB 上 `storedInternal=false` の行について公開 URL (`drive_file.url` 等) へ **302 リダイレクト** する。
+移行後の `GET /files/:accessKey` は、DB 上 `storedInternal=false` の行について公開 URL へ **302 リダイレクト** する。リクエストキーに応じて `drive_file.url` / `thumbnailUrl` / `webpublicUrl` を出し分ける。
+
+**配信と CDN (#730)**: 302 化により same-origin プロキシで付与していた `Cache-Control: no-transform` はリダイレクト先へ引き継がれない。Cloudflare Polish 等による再エンコードを避けるには、S3 / CloudFront / CDN 側で同等のヘッダを設定すること。private bucket + pre-signed URL 運用は想定外（公開 URL / CloudFront 前提）。
+
+**scan ジョブ**: `migrateScan` は `scanBatchSize` 件ずつ `migrateFile` を enqueue し、残件があれば `untilId` 付きで次の scan を連鎖する。Redis ロックで並行 scan を抑止する。
 
 | キー | 型 | デフォルト | 説明 |
 |---|---|---|---|

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -145,11 +145,25 @@ mk-go 固有。`meta` テーブルで object storage を有効化したあと、
 5. `enabled: false` に戻して再起動する（完了後の誤再実行防止）
 6. 任意: ローカルディレクトリをバックアップして削除する
 
-object storage 利用時（`meta.useObjectStorage=true`）の `GET /files/:accessKey` は、DB 上 `storedInternal=false` の行について公開 URL へ **302 リダイレクト** する（`driveLocalToObjectStorage` の有無に関わらず、S3 へ直接アップロードしたファイルも含む）。リクエストキーに応じて `drive_file.url` / `thumbnailUrl` / `webpublicUrl` を出し分ける。drop-in 互換・CORS・同一オリジン URL を前提としたクライアントは、リダイレクト先ドメインへの影響を確認すること。
+**scan ジョブ**: `migrateScan` は `scanBatchSize` 件ずつ `migrateFile` を enqueue し、残件があれば `untilId` 付きで次の scan を連鎖する。Redis ロックは **1 バッチの `HandleScan` 実行中のみ** 保持され、バッチ完了時に解放される（バッチ間や `migrateFile` 処理中の再起動では別 scan チェーンが走りうる。`migrateFile` は冪等のため実害は重複ジョブ程度）。`ListStoredInternalIDs` は専用インデックスなしの seq scan になりうるため、巨大 `drive_file` では初回 scan に時間がかかることがある。
 
-**配信と CDN (#730)**: 302 化により same-origin プロキシで付与していた `Cache-Control: no-transform` はリダイレクト先へ引き継がれない。Cloudflare Polish 等による再エンコードを避けるには、S3 / CloudFront / CDN 側で同等のヘッダを設定すること。private bucket + pre-signed URL 運用は想定外（公開 URL / CloudFront 前提）。
+#### object storage 利用時の `/files/:accessKey` 配信 (#1476)
 
-**scan ジョブ**: `migrateScan` は `scanBatchSize` 件ずつ `migrateFile` を enqueue し、残件があれば `untilId` 付きで次の scan を連鎖する。Redis ロックで並行 scan を抑止する。
+`meta.useObjectStorage=true` のインスタンス向け。**移行ジョブ (`driveLocalToObjectStorage`) の有無に関わらず**、DB 上 `storedInternal=false` の行は公開 URL（S3 / CDN）へ **302 リダイレクト** する（S3 へ直接アップロードしたファイルも含む）。リクエストキーに応じて `drive_file.url` / `thumbnailUrl` / `webpublicUrl` を出し分ける。
+
+| 項目 | 内容 |
+|---|---|
+| 影響範囲 | `useObjectStorage=true` の全インスタンス（移行 YAML を有効にしていない既存 S3 運用も含む） |
+| 従来挙動 | mk-go が primary (S3) から same-origin プロキシ配信し `Cache-Control: no-transform` を付与 |
+| 本番挙動 | 公開 URL へ 302（`no-transform` はリダイレクト先に引き継がれない） |
+| same-origin 例外 | DB の URL がまだインスタンス same-origin `/files/` の行は 302 せず storage から配信。`objectStorage.baseUrl` を同一オリジンに向けた proxy 運用も継続可能 |
+
+**アップグレード前チェックリスト**:
+
+1. 代表ファイルで `curl -I https://<instance>/files/<accessKey>` を実行し、`Location` が想定 CDN か確認する
+2. drop-in 互換・CORS・同一オリジン `/files/` URL 前提のクライアントは、リダイレクト先ドメインへの影響を確認する
+3. Cloudflare Polish 等を使う場合は S3 / CloudFront / CDN 側で `Cache-Control: no-transform` 等を設定する（#730）
+4. private bucket + pre-signed URL 運用は想定外（公開 URL / CloudFront 前提）
 
 | キー | 型 | デフォルト | 説明 |
 |---|---|---|---|

--- a/internal/api/admin/emoji_image_fetcher_test.go
+++ b/internal/api/admin/emoji_image_fetcher_test.go
@@ -52,6 +52,8 @@ func (r *recordingStorage) Delete(accessKey string) error {
 	return nil
 }
 
+func (r *recordingStorage) StoredInternal() bool { return true }
+
 // We need a drive.Storage interface; use a minimal embedding fake. Build a
 // real drive.Service with mock repositories so Upload exercises the full
 // path including row creation.

--- a/internal/api/proxy/handler_test.go
+++ b/internal/api/proxy/handler_test.go
@@ -37,6 +37,7 @@ type mockStorage struct {
 
 func (m *mockStorage) Put(_ string, _ io.Reader) (string, error) { return "", nil }
 func (m *mockStorage) Delete(_ string) error                     { return nil }
+func (m *mockStorage) StoredInternal() bool                      { return true }
 func (m *mockStorage) Get(key string) (io.ReadCloser, error) {
 	data, ok := m.files[key]
 	if !ok {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -280,6 +280,51 @@ type Source struct {
 	// distribution rather than pointing at the source repository URL. Exposed
 	// via /api/meta.providesTarball.
 	PublishTarballInsteadOfProvideRepositoryUrl bool `mapstructure:"publishTarballInsteadOfProvideRepositoryUrl"`
+
+	// DriveLocalToObjectStorage controls background migration of legacy
+	// locally stored drive files into object storage (#1476).
+	DriveLocalToObjectStorage *DriveLocalToObjectStorageOptions `mapstructure:"driveLocalToObjectStorage"`
+}
+
+// DriveLocalToObjectStorageOptions is the YAML shape for local→S3 migration.
+type DriveLocalToObjectStorageOptions struct {
+	Enabled     bool   `mapstructure:"enabled"`
+	DeleteLocal bool   `mapstructure:"deleteLocal"`
+	LocalPath   string `mapstructure:"localPath"`
+	Concurrency int    `mapstructure:"concurrency"`
+}
+
+// DriveLocalToObjectStorageConfig is the resolved migration settings.
+type DriveLocalToObjectStorageConfig struct {
+	Enabled     bool
+	DeleteLocal bool
+	LocalPath   string
+	Concurrency int
+}
+
+const (
+	defaultDriveMigrationLocalPath   = "./drive-files"
+	defaultDriveMigrationConcurrency = 2
+)
+
+// ResolveDriveLocalToObjectStorage normalises YAML/env into runtime defaults.
+func ResolveDriveLocalToObjectStorage(src *DriveLocalToObjectStorageOptions) DriveLocalToObjectStorageConfig {
+	cfg := DriveLocalToObjectStorageConfig{
+		LocalPath:   defaultDriveMigrationLocalPath,
+		Concurrency: defaultDriveMigrationConcurrency,
+	}
+	if src == nil {
+		return cfg
+	}
+	cfg.Enabled = src.Enabled
+	cfg.DeleteLocal = src.DeleteLocal
+	if p := strings.TrimSpace(src.LocalPath); p != "" {
+		cfg.LocalPath = p
+	}
+	if src.Concurrency > 0 {
+		cfg.Concurrency = src.Concurrency
+	}
+	return cfg
 }
 
 // Config represents the resolved application configuration.
@@ -403,6 +448,10 @@ type Config struct {
 	// PublishTarballInsteadOfProvideRepositoryUrl is exposed to clients via
 	// /api/meta.providesTarball. See the Source struct for details.
 	PublishTarballInsteadOfProvideRepositoryUrl bool
+
+	// DriveLocalToObjectStorage is the resolved local→object-storage migration
+	// settings (#1476).
+	DriveLocalToObjectStorage DriveLocalToObjectStorageConfig
 }
 
 const defaultMaxFileSize int64 = 262144000
@@ -479,6 +528,10 @@ func bindEnvKeys(v *viper.Viper) {
 		"minWorkers",
 		"maxWorkersGlobal",
 		"autoScaleCooldownSeconds",
+		"driveLocalToObjectStorage.enabled",
+		"driveLocalToObjectStorage.deleteLocal",
+		"driveLocalToObjectStorage.localPath",
+		"driveLocalToObjectStorage.concurrency",
 	}
 	for _, k := range keys {
 		_ = v.BindEnv(k)
@@ -634,6 +687,15 @@ func resolve(src *Source) (*Config, error) {
 		SentryForFrontend: src.SentryForFrontend,
 
 		PublishTarballInsteadOfProvideRepositoryUrl: src.PublishTarballInsteadOfProvideRepositoryUrl,
+
+		DriveLocalToObjectStorage: ResolveDriveLocalToObjectStorage(src.DriveLocalToObjectStorage),
+	}
+
+	if cfg.DriveLocalToObjectStorage.Enabled {
+		slog.Info("config: driveLocalToObjectStorage migration is enabled; storedInternal files will be migrated on startup",
+			"localPath", cfg.DriveLocalToObjectStorage.LocalPath,
+			"deleteLocal", cfg.DriveLocalToObjectStorage.DeleteLocal,
+			"concurrency", cfg.DriveLocalToObjectStorage.Concurrency)
 	}
 
 	if cfg.TestMode {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -6,6 +6,8 @@ import (
 	"log/slog"
 	"net"
 	"net/url"
+	"os"
+	"path/filepath"
 	"strings"
 	"time"
 
@@ -288,30 +290,34 @@ type Source struct {
 
 // DriveLocalToObjectStorageOptions is the YAML shape for local→S3 migration.
 type DriveLocalToObjectStorageOptions struct {
-	Enabled     bool   `mapstructure:"enabled"`
-	DeleteLocal bool   `mapstructure:"deleteLocal"`
-	LocalPath   string `mapstructure:"localPath"`
-	Concurrency int    `mapstructure:"concurrency"`
+	Enabled       bool   `mapstructure:"enabled"`
+	DeleteLocal   bool   `mapstructure:"deleteLocal"`
+	LocalPath     string `mapstructure:"localPath"`
+	Concurrency   int    `mapstructure:"concurrency"`
+	ScanBatchSize int    `mapstructure:"scanBatchSize"`
 }
 
 // DriveLocalToObjectStorageConfig is the resolved migration settings.
 type DriveLocalToObjectStorageConfig struct {
-	Enabled     bool
-	DeleteLocal bool
-	LocalPath   string
-	Concurrency int
+	Enabled       bool
+	DeleteLocal   bool
+	LocalPath     string
+	Concurrency   int
+	ScanBatchSize int
 }
 
 const (
-	defaultDriveMigrationLocalPath   = "./drive-files"
-	defaultDriveMigrationConcurrency = 2
+	defaultDriveMigrationLocalPath     = "./drive-files"
+	defaultDriveMigrationConcurrency   = 2
+	defaultDriveMigrationScanBatchSize = 100
 )
 
 // ResolveDriveLocalToObjectStorage normalises YAML/env into runtime defaults.
 func ResolveDriveLocalToObjectStorage(src *DriveLocalToObjectStorageOptions) DriveLocalToObjectStorageConfig {
 	cfg := DriveLocalToObjectStorageConfig{
-		LocalPath:   defaultDriveMigrationLocalPath,
-		Concurrency: defaultDriveMigrationConcurrency,
+		LocalPath:     defaultDriveMigrationLocalPath,
+		Concurrency:   defaultDriveMigrationConcurrency,
+		ScanBatchSize: defaultDriveMigrationScanBatchSize,
 	}
 	if src == nil {
 		return cfg
@@ -324,7 +330,27 @@ func ResolveDriveLocalToObjectStorage(src *DriveLocalToObjectStorageOptions) Dri
 	if src.Concurrency > 0 {
 		cfg.Concurrency = src.Concurrency
 	}
+	if src.ScanBatchSize > 0 {
+		cfg.ScanBatchSize = src.ScanBatchSize
+	}
 	return cfg
+}
+
+// normalizeDriveLocalMigrationPath resolves localPath to an absolute path when migration is enabled.
+func normalizeDriveLocalMigrationPath(cfg *DriveLocalToObjectStorageConfig) error {
+	if cfg == nil || !cfg.Enabled {
+		return nil
+	}
+	abs, err := filepath.Abs(cfg.LocalPath)
+	if err != nil {
+		return fmt.Errorf("driveLocalToObjectStorage.localPath: %w", err)
+	}
+	cfg.LocalPath = abs
+	if _, err := os.Stat(abs); os.IsNotExist(err) {
+		slog.Warn("driveLocalToObjectStorage.localPath does not exist; migration will skip missing blobs",
+			"path", abs)
+	}
+	return nil
 }
 
 // Config represents the resolved application configuration.
@@ -532,6 +558,7 @@ func bindEnvKeys(v *viper.Viper) {
 		"driveLocalToObjectStorage.deleteLocal",
 		"driveLocalToObjectStorage.localPath",
 		"driveLocalToObjectStorage.concurrency",
+		"driveLocalToObjectStorage.scanBatchSize",
 	}
 	for _, k := range keys {
 		_ = v.BindEnv(k)
@@ -691,11 +718,16 @@ func resolve(src *Source) (*Config, error) {
 		DriveLocalToObjectStorage: ResolveDriveLocalToObjectStorage(src.DriveLocalToObjectStorage),
 	}
 
+	if err := normalizeDriveLocalMigrationPath(&cfg.DriveLocalToObjectStorage); err != nil {
+		return nil, err
+	}
+
 	if cfg.DriveLocalToObjectStorage.Enabled {
 		slog.Info("config: driveLocalToObjectStorage migration is enabled; storedInternal files will be migrated on startup",
 			"localPath", cfg.DriveLocalToObjectStorage.LocalPath,
 			"deleteLocal", cfg.DriveLocalToObjectStorage.DeleteLocal,
-			"concurrency", cfg.DriveLocalToObjectStorage.Concurrency)
+			"concurrency", cfg.DriveLocalToObjectStorage.Concurrency,
+			"scanBatchSize", cfg.DriveLocalToObjectStorage.ScanBatchSize)
 	}
 
 	if cfg.TestMode {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -346,9 +346,13 @@ func normalizeDriveLocalMigrationPath(cfg *DriveLocalToObjectStorageConfig) erro
 		return fmt.Errorf("driveLocalToObjectStorage.localPath: %w", err)
 	}
 	cfg.LocalPath = abs
-	if _, err := os.Stat(abs); os.IsNotExist(err) {
-		slog.Warn("driveLocalToObjectStorage.localPath does not exist; migration will skip missing blobs",
-			"path", abs)
+	if _, err := os.Stat(abs); err != nil {
+		if os.IsNotExist(err) {
+			slog.Warn("driveLocalToObjectStorage.localPath does not exist; migration will skip missing blobs",
+				"path", abs)
+			return nil
+		}
+		return fmt.Errorf("driveLocalToObjectStorage.localPath: cannot stat %s: %w", abs, err)
 	}
 	return nil
 }

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -91,6 +91,7 @@ func TestLoad_Defaults(t *testing.T) {
 }
 
 func TestLoad_DriveLocalToObjectStorage(t *testing.T) {
+	t.Parallel()
 	yaml := testYAML + `
 driveLocalToObjectStorage:
   enabled: true
@@ -110,6 +111,7 @@ driveLocalToObjectStorage:
 }
 
 func TestResolveDriveLocalToObjectStorage_Nil(t *testing.T) {
+	t.Parallel()
 	cfg := ResolveDriveLocalToObjectStorage(nil)
 	assert.False(t, cfg.Enabled)
 	assert.Equal(t, "./drive-files", cfg.LocalPath)
@@ -118,6 +120,7 @@ func TestResolveDriveLocalToObjectStorage_Nil(t *testing.T) {
 }
 
 func TestNormalizeDriveLocalMigrationPath_AbsWhenEnabled(t *testing.T) {
+	t.Parallel()
 	dir := t.TempDir()
 	cfg := DriveLocalToObjectStorageConfig{
 		Enabled:   true,
@@ -128,6 +131,7 @@ func TestNormalizeDriveLocalMigrationPath_AbsWhenEnabled(t *testing.T) {
 }
 
 func TestNormalizeDriveLocalMigrationPath_NotExistWarns(t *testing.T) {
+	t.Parallel()
 	cfg := DriveLocalToObjectStorageConfig{
 		Enabled:   true,
 		LocalPath: filepath.Join(t.TempDir(), "missing-subdir"),
@@ -136,6 +140,7 @@ func TestNormalizeDriveLocalMigrationPath_NotExistWarns(t *testing.T) {
 }
 
 func TestNormalizeDriveLocalMigrationPath_StatError(t *testing.T) {
+	t.Parallel()
 	if os.Getuid() == 0 {
 		t.Skip("root may stat chmod 000 directories")
 	}

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -87,6 +87,7 @@ func TestLoad_Defaults(t *testing.T) {
 	assert.False(t, cfg.DriveLocalToObjectStorage.Enabled)
 	assert.Equal(t, "./drive-files", cfg.DriveLocalToObjectStorage.LocalPath)
 	assert.Equal(t, 2, cfg.DriveLocalToObjectStorage.Concurrency)
+	assert.Equal(t, 100, cfg.DriveLocalToObjectStorage.ScanBatchSize)
 }
 
 func TestLoad_DriveLocalToObjectStorage(t *testing.T) {
@@ -96,6 +97,7 @@ driveLocalToObjectStorage:
   deleteLocal: true
   localPath: /data/drive
   concurrency: 4
+  scanBatchSize: 50
 `
 	path := writeTestConfig(t, yaml)
 	cfg, err := Load(path)
@@ -104,6 +106,7 @@ driveLocalToObjectStorage:
 	assert.True(t, cfg.DriveLocalToObjectStorage.DeleteLocal)
 	assert.Equal(t, "/data/drive", cfg.DriveLocalToObjectStorage.LocalPath)
 	assert.Equal(t, 4, cfg.DriveLocalToObjectStorage.Concurrency)
+	assert.Equal(t, 50, cfg.DriveLocalToObjectStorage.ScanBatchSize)
 }
 
 func TestResolveDriveLocalToObjectStorage_Nil(t *testing.T) {
@@ -111,6 +114,17 @@ func TestResolveDriveLocalToObjectStorage_Nil(t *testing.T) {
 	assert.False(t, cfg.Enabled)
 	assert.Equal(t, "./drive-files", cfg.LocalPath)
 	assert.Equal(t, 2, cfg.Concurrency)
+	assert.Equal(t, 100, cfg.ScanBatchSize)
+}
+
+func TestNormalizeDriveLocalMigrationPath_AbsWhenEnabled(t *testing.T) {
+	dir := t.TempDir()
+	cfg := DriveLocalToObjectStorageConfig{
+		Enabled:   true,
+		LocalPath: dir,
+	}
+	require.NoError(t, normalizeDriveLocalMigrationPath(&cfg))
+	assert.True(t, filepath.IsAbs(cfg.LocalPath))
 }
 
 func TestLoad_DisableEndpointRateLimitsTrue(t *testing.T) {

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -84,6 +84,33 @@ func TestLoad_Defaults(t *testing.T) {
 	assert.Equal(t, int64(262144000), cfg.MaxFileSize)
 	assert.Equal(t, 1000, cfg.PerChannelMaxNoteCacheCount)
 	assert.Equal(t, 500, cfg.PerUserNotificationsMaxCount)
+	assert.False(t, cfg.DriveLocalToObjectStorage.Enabled)
+	assert.Equal(t, "./drive-files", cfg.DriveLocalToObjectStorage.LocalPath)
+	assert.Equal(t, 2, cfg.DriveLocalToObjectStorage.Concurrency)
+}
+
+func TestLoad_DriveLocalToObjectStorage(t *testing.T) {
+	yaml := testYAML + `
+driveLocalToObjectStorage:
+  enabled: true
+  deleteLocal: true
+  localPath: /data/drive
+  concurrency: 4
+`
+	path := writeTestConfig(t, yaml)
+	cfg, err := Load(path)
+	require.NoError(t, err)
+	assert.True(t, cfg.DriveLocalToObjectStorage.Enabled)
+	assert.True(t, cfg.DriveLocalToObjectStorage.DeleteLocal)
+	assert.Equal(t, "/data/drive", cfg.DriveLocalToObjectStorage.LocalPath)
+	assert.Equal(t, 4, cfg.DriveLocalToObjectStorage.Concurrency)
+}
+
+func TestResolveDriveLocalToObjectStorage_Nil(t *testing.T) {
+	cfg := ResolveDriveLocalToObjectStorage(nil)
+	assert.False(t, cfg.Enabled)
+	assert.Equal(t, "./drive-files", cfg.LocalPath)
+	assert.Equal(t, 2, cfg.Concurrency)
 }
 
 func TestLoad_DisableEndpointRateLimitsTrue(t *testing.T) {

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -127,6 +127,32 @@ func TestNormalizeDriveLocalMigrationPath_AbsWhenEnabled(t *testing.T) {
 	assert.True(t, filepath.IsAbs(cfg.LocalPath))
 }
 
+func TestNormalizeDriveLocalMigrationPath_NotExistWarns(t *testing.T) {
+	cfg := DriveLocalToObjectStorageConfig{
+		Enabled:   true,
+		LocalPath: filepath.Join(t.TempDir(), "missing-subdir"),
+	}
+	require.NoError(t, normalizeDriveLocalMigrationPath(&cfg))
+}
+
+func TestNormalizeDriveLocalMigrationPath_StatError(t *testing.T) {
+	if os.Getuid() == 0 {
+		t.Skip("root may stat chmod 000 directories")
+	}
+	dir := t.TempDir()
+	locked := filepath.Join(dir, "locked")
+	require.NoError(t, os.Mkdir(locked, 0o000))
+	t.Cleanup(func() { _ = os.Chmod(locked, 0o700) })
+	if _, probeErr := os.Stat(locked); probeErr == nil {
+		t.Skip("owner can stat mode 000 directories on this platform")
+	}
+
+	cfg := DriveLocalToObjectStorageConfig{Enabled: true, LocalPath: locked}
+	err := normalizeDriveLocalMigrationPath(&cfg)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "cannot stat")
+}
+
 func TestLoad_DisableEndpointRateLimitsTrue(t *testing.T) {
 	// disableEndpointRateLimits=true は bench / test 用の opt-in 設定。
 	// production 同梱 example には載せず、env / 個別 yml で明示指定する想定。

--- a/internal/core/drive/drive_service.go
+++ b/internal/core/drive/drive_service.go
@@ -103,6 +103,7 @@ type Service struct {
 	fileRepo            repository.DriveFileRepository
 	folderRepo          repository.DriveFolderRepository
 	storage             Storage
+	legacyLocalStorage  Storage // optional ./drive-files for dual-delete after S3 migration (#1476)
 	idGen               id.Generator
 	publisher           StreamingPublisher
 	mainStreamPublisher MainStreamPublisher
@@ -121,6 +122,10 @@ type Service struct {
 // inspect any file (matching upstream Misskey's drive/files/show behaviour).
 // Nil keeps the existing owner-only check.
 func (s *Service) SetRoleChecker(rc RoleChecker) { s.roleChecker = rc }
+
+// SetLegacyLocalStorage keeps the local FS backend for deleting blobs left
+// after migrating rows to object storage (#1476).
+func (s *Service) SetLegacyLocalStorage(st Storage) { s.legacyLocalStorage = st }
 
 // SetSensitiveDetection attaches the sensitive media detector and config.
 func (s *Service) SetSensitiveDetection(detector SensitiveDetector, cfg SensitiveConfig) {
@@ -342,6 +347,11 @@ func (s *Service) Upload(ctx context.Context, in UploadInput) (*model.DriveFile,
 		userIDPtr = &uid
 		userHostPtr = in.User.Host
 	}
+	storedInternal := true
+	if _, ok := s.storage.(*S3Storage); ok {
+		// S3 保存時は TS 互換で storedInternal=false（実体は object storage のみ）
+		storedInternal = false
+	}
 	f := &model.DriveFile{
 		ID:                 fileID,
 		UserID:             userIDPtr,
@@ -353,7 +363,7 @@ func (s *Service) Upload(ctx context.Context, in UploadInput) (*model.DriveFile,
 		Comment:            in.Comment,
 		Blurhash:           blurhash,
 		Properties:         properties,
-		StoredInternal:     true,
+		StoredInternal:     storedInternal,
 		URL:                url,
 		ThumbnailURL:       thumbnailURL,
 		WebpublicURL:       webpublicURL,
@@ -622,6 +632,21 @@ func (s *Service) Update(user *model.User, id string, in UpdateInput) (*model.Dr
 	return updated, nil
 }
 
+func (s *Service) deleteLegacyLocalKeys(f *model.DriveFile) {
+	if s.legacyLocalStorage == nil {
+		return
+	}
+	if f.AccessKey != nil {
+		_ = s.legacyLocalStorage.Delete(*f.AccessKey)
+	}
+	if f.ThumbnailAccessKey != nil {
+		_ = s.legacyLocalStorage.Delete(*f.ThumbnailAccessKey)
+	}
+	if f.WebpublicAccessKey != nil {
+		_ = s.legacyLocalStorage.Delete(*f.WebpublicAccessKey)
+	}
+}
+
 // Delete removes a file from storage and the database.
 // Owner-only: moderator が他ユーザーの file を削除できないよう
 // findOwnedFile() を使う (#499)。
@@ -642,6 +667,7 @@ func (s *Service) Delete(user *model.User, id string) error {
 	if f.WebpublicAccessKey != nil {
 		_ = s.storage.Delete(*f.WebpublicAccessKey)
 	}
+	s.deleteLegacyLocalKeys(f)
 	if err := s.fileRepo.Delete(f); err != nil {
 		return err
 	}

--- a/internal/core/drive/drive_service.go
+++ b/internal/core/drive/drive_service.go
@@ -347,11 +347,7 @@ func (s *Service) Upload(ctx context.Context, in UploadInput) (*model.DriveFile,
 		userIDPtr = &uid
 		userHostPtr = in.User.Host
 	}
-	storedInternal := true
-	if _, ok := s.storage.(*S3Storage); ok {
-		// S3 保存時は TS 互換で storedInternal=false（実体は object storage のみ）
-		storedInternal = false
-	}
+	storedInternal := s.storage.StoredInternal()
 	f := &model.DriveFile{
 		ID:                 fileID,
 		UserID:             userIDPtr,

--- a/internal/core/drive/migrator.go
+++ b/internal/core/drive/migrator.go
@@ -65,7 +65,7 @@ func (m *Migrator) MigrateFile(ctx context.Context, fileID string) error {
 		return nil
 	}
 	if !f.StoredInternal {
-		if !urlUsesDrivePrefix(f.URL, m.driveURL) {
+		if !URLUsesDrivePrefix(f.URL, m.driveURL) {
 			return m.repairDenormalizedCascade(ctx, f, fileID)
 		}
 		// storedInternal=false だが URL がまだ same-origin /files/ の行は再移行する。
@@ -113,7 +113,7 @@ func (m *Migrator) repairDenormalizedCascade(ctx context.Context, f *model.Drive
 		return nil
 	}
 	newURL := f.URL
-	if newURL == "" || urlUsesDrivePrefix(newURL, m.driveURL) {
+	if newURL == "" || URLUsesDrivePrefix(newURL, m.driveURL) {
 		return nil
 	}
 	oldURL := fileURLForAccessKey(m.driveURL, *f.AccessKey)
@@ -121,7 +121,7 @@ func (m *Migrator) repairDenormalizedCascade(ctx context.Context, f *model.Drive
 	var oldThumbURL, newThumbURL *string
 	if f.ThumbnailAccessKey != nil && f.ThumbnailURL != nil {
 		ot := fileURLForAccessKey(m.driveURL, *f.ThumbnailAccessKey)
-		if urlUsesDrivePrefix(*f.ThumbnailURL, m.driveURL) {
+		if URLUsesDrivePrefix(*f.ThumbnailURL, m.driveURL) {
 			ot = *f.ThumbnailURL
 		}
 		oldThumbURL = &ot
@@ -132,7 +132,7 @@ func (m *Migrator) repairDenormalizedCascade(ctx context.Context, f *model.Drive
 	var oldWebpublicURL, newWebpublicURL *string
 	if f.WebpublicAccessKey != nil && f.WebpublicURL != nil {
 		ow := fileURLForAccessKey(m.driveURL, *f.WebpublicAccessKey)
-		if urlUsesDrivePrefix(*f.WebpublicURL, m.driveURL) {
+		if URLUsesDrivePrefix(*f.WebpublicURL, m.driveURL) {
 			ow = *f.WebpublicURL
 		}
 		oldWebpublicURL = &ow
@@ -190,7 +190,8 @@ func migrationMetaReady(meta *model.Meta) bool {
 	return true
 }
 
-func urlUsesDrivePrefix(u, driveURL string) bool {
+// URLUsesDrivePrefix reports whether u is under the instance same-origin /files/ base.
+func URLUsesDrivePrefix(u, driveURL string) bool {
 	if u == "" || driveURL == "" {
 		return false
 	}
@@ -243,6 +244,11 @@ func cascadeDenormalizedURLs(
 	oldThumbURL, newThumbURL *string,
 	oldWebpublicURL, newWebpublicURL *string,
 ) error {
+	if oldURL == newURL &&
+		(oldThumbURL == nil || newThumbURL == nil || *oldThumbURL == *newThumbURL) &&
+		(oldWebpublicURL == nil || newWebpublicURL == nil || *oldWebpublicURL == *newWebpublicURL) {
+		return nil
+	}
 	if err := tx.Model(&model.User{}).Where(`"avatarId" = ?`, fileID).Update("avatarUrl", newURL).Error; err != nil {
 		return err
 	}

--- a/internal/core/drive/migrator.go
+++ b/internal/core/drive/migrator.go
@@ -14,6 +14,9 @@ import (
 // ErrMigrationNotConfigured is returned when object storage is not enabled in meta.
 var ErrMigrationNotConfigured = errors.New("object storage is not configured in meta")
 
+// storageFromMeta is the factory used by MigrateFile; tests may replace it to inject S3Storage.
+var storageFromMeta = NewStorageFromMeta
+
 // Migrator moves locally stored drive files into object storage (#1476).
 type Migrator struct {
 	metaRepo repository.MetaRepository
@@ -62,7 +65,7 @@ func (m *Migrator) MigrateFile(ctx context.Context, fileID string) error {
 	}
 
 	local := NewLocalStorage(m.cfg.LocalPath, m.driveURL)
-	remote := NewStorageFromMeta(meta, m.cfg.LocalPath, m.driveURL)
+	remote := storageFromMeta(meta, m.cfg.LocalPath, m.driveURL)
 	s3, ok := remote.(*S3Storage)
 	if !ok {
 		return ErrMigrationNotConfigured

--- a/internal/core/drive/migrator.go
+++ b/internal/core/drive/migrator.go
@@ -1,0 +1,200 @@
+package drive
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/shiroha-a/mk/internal/config"
+	"github.com/shiroha-a/mk/internal/model"
+	"github.com/shiroha-a/mk/internal/repository"
+	"gorm.io/gorm"
+)
+
+// ErrMigrationNotConfigured is returned when object storage is not enabled in meta.
+var ErrMigrationNotConfigured = errors.New("object storage is not configured in meta")
+
+// Migrator moves locally stored drive files into object storage (#1476).
+type Migrator struct {
+	metaRepo repository.MetaRepository
+	fileRepo repository.DriveFileRepository
+	db       *gorm.DB
+	cfg      config.DriveLocalToObjectStorageConfig
+	driveURL string
+}
+
+// NewMigrator constructs a Migrator.
+func NewMigrator(
+	metaRepo repository.MetaRepository,
+	fileRepo repository.DriveFileRepository,
+	db *gorm.DB,
+	cfg config.DriveLocalToObjectStorageConfig,
+	driveURL string,
+) *Migrator {
+	return &Migrator{
+		metaRepo: metaRepo,
+		fileRepo: fileRepo,
+		db:       db,
+		cfg:      cfg,
+		driveURL: driveURL,
+	}
+}
+
+// MigrateFile copies one drive_file row from local disk to S3 and updates DB URLs.
+func (m *Migrator) MigrateFile(ctx context.Context, fileID string) error {
+	if ctx.Err() != nil {
+		return ctx.Err()
+	}
+	meta, err := m.metaRepo.Fetch()
+	if err != nil {
+		return fmt.Errorf("fetch meta: %w", err)
+	}
+	if !migrationMetaReady(meta) {
+		return ErrMigrationNotConfigured
+	}
+
+	f, err := m.fileRepo.FindByID(fileID)
+	if err != nil {
+		return err
+	}
+	if !f.StoredInternal || f.IsLink {
+		return nil
+	}
+
+	local := NewLocalStorage(m.cfg.LocalPath, m.driveURL)
+	remote := NewStorageFromMeta(meta, m.cfg.LocalPath, m.driveURL)
+	s3, ok := remote.(*S3Storage)
+	if !ok {
+		return ErrMigrationNotConfigured
+	}
+
+	oldURL := f.URL
+	oldThumbURL := f.ThumbnailURL
+	oldWebpublicURL := f.WebpublicURL
+
+	newURL, err := m.migrateObject(local, s3, f.AccessKey)
+	if err != nil {
+		return fmt.Errorf("migrate primary %s: %w", fileID, err)
+	}
+
+	var newThumbURL, newWebpublicURL *string
+	if f.ThumbnailAccessKey != nil {
+		u, err := m.migrateObject(local, s3, f.ThumbnailAccessKey)
+		if err != nil {
+			return fmt.Errorf("migrate thumbnail %s: %w", fileID, err)
+		}
+		newThumbURL = &u
+	}
+	if f.WebpublicAccessKey != nil {
+		u, err := m.migrateObject(local, s3, f.WebpublicAccessKey)
+		if err != nil {
+			return fmt.Errorf("migrate webpublic %s: %w", fileID, err)
+		}
+		newWebpublicURL = &u
+	}
+
+	fields := map[string]any{
+		"url":            newURL,
+		"storedInternal": false,
+	}
+	if newThumbURL != nil {
+		fields["thumbnailUrl"] = *newThumbURL
+	}
+	if newWebpublicURL != nil {
+		fields["webpublicUrl"] = *newWebpublicURL
+	}
+
+	if err := m.db.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
+		if err := tx.Model(&model.DriveFile{}).Where("id = ?", fileID).Updates(fields).Error; err != nil {
+			return err
+		}
+		return cascadeDenormalizedURLs(tx, fileID, oldURL, newURL, oldThumbURL, newThumbURL, oldWebpublicURL, newWebpublicURL)
+	}); err != nil {
+		return err
+	}
+
+	if m.cfg.DeleteLocal {
+		m.deleteLocalKeys(local, f)
+	}
+	return nil
+}
+
+func migrationMetaReady(meta *model.Meta) bool {
+	if meta == nil || !meta.UseObjectStorage {
+		return false
+	}
+	if meta.ObjectStorageBucket == nil || *meta.ObjectStorageBucket == "" {
+		return false
+	}
+	return true
+}
+
+func (m *Migrator) migrateObject(local Storage, s3 *S3Storage, accessKey *string) (string, error) {
+	if accessKey == nil || *accessKey == "" {
+		return "", fmt.Errorf("empty access key")
+	}
+	key := *accessKey
+	body, err := local.Get(key)
+	if err != nil {
+		if errors.Is(err, ErrObjectNotFound) {
+			if _, headErr := s3.Get(key); headErr == nil {
+				return s3.publicURL(key), nil
+			}
+			return "", fmt.Errorf("local object missing for key %s: %w", key, err)
+		}
+		return "", err
+	}
+	defer body.Close()
+	return s3.Put(key, body)
+}
+
+func (m *Migrator) deleteLocalKeys(local Storage, f *model.DriveFile) {
+	if f.AccessKey != nil {
+		_ = local.Delete(*f.AccessKey)
+	}
+	if f.ThumbnailAccessKey != nil {
+		_ = local.Delete(*f.ThumbnailAccessKey)
+	}
+	if f.WebpublicAccessKey != nil {
+		_ = local.Delete(*f.WebpublicAccessKey)
+	}
+}
+
+func cascadeDenormalizedURLs(
+	tx *gorm.DB,
+	fileID, oldURL, newURL string,
+	oldThumbURL, newThumbURL *string,
+	oldWebpublicURL, newWebpublicURL *string,
+) error {
+	if err := tx.Model(&model.User{}).Where(`"avatarId" = ?`, fileID).Update("avatarUrl", newURL).Error; err != nil {
+		return err
+	}
+	if err := tx.Model(&model.User{}).Where(`"bannerId" = ?`, fileID).Update("bannerUrl", newURL).Error; err != nil {
+		return err
+	}
+	if oldURL != "" {
+		if err := tx.Model(&model.Emoji{}).Where(`"originalUrl" = ?`, oldURL).Update("originalUrl", newURL).Error; err != nil {
+			return err
+		}
+		if err := tx.Model(&model.Emoji{}).Where(`"publicUrl" = ?`, oldURL).Update("publicUrl", newURL).Error; err != nil {
+			return err
+		}
+	}
+	if oldThumbURL != nil && newThumbURL != nil && *oldThumbURL != "" {
+		if err := tx.Model(&model.Emoji{}).Where(`"originalUrl" = ?`, *oldThumbURL).Update("originalUrl", *newThumbURL).Error; err != nil {
+			return err
+		}
+		if err := tx.Model(&model.Emoji{}).Where(`"publicUrl" = ?`, *oldThumbURL).Update("publicUrl", *newThumbURL).Error; err != nil {
+			return err
+		}
+	}
+	if oldWebpublicURL != nil && newWebpublicURL != nil && *oldWebpublicURL != "" {
+		if err := tx.Model(&model.Emoji{}).Where(`"originalUrl" = ?`, *oldWebpublicURL).Update("originalUrl", *newWebpublicURL).Error; err != nil {
+			return err
+		}
+		if err := tx.Model(&model.Emoji{}).Where(`"publicUrl" = ?`, *oldWebpublicURL).Update("publicUrl", *newWebpublicURL).Error; err != nil {
+			return err
+		}
+	}
+	return nil
+}

--- a/internal/core/drive/migrator.go
+++ b/internal/core/drive/migrator.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"strings"
 
 	"github.com/shiroha-a/mk/internal/config"
 	"github.com/shiroha-a/mk/internal/model"
@@ -60,8 +61,14 @@ func (m *Migrator) MigrateFile(ctx context.Context, fileID string) error {
 	if err != nil {
 		return err
 	}
-	if !f.StoredInternal || f.IsLink {
+	if f.IsLink {
 		return nil
+	}
+	if !f.StoredInternal {
+		if !urlUsesDrivePrefix(f.URL, m.driveURL) {
+			return m.repairDenormalizedCascade(ctx, f, fileID)
+		}
+		// storedInternal=false だが URL がまだ same-origin /files/ の行は再移行する。
 	}
 
 	local := NewLocalStorage(m.cfg.LocalPath, m.driveURL)
@@ -96,6 +103,57 @@ func (m *Migrator) MigrateFile(ctx context.Context, fileID string) error {
 		newWebpublicURL = &u
 	}
 
+	return m.persistMigration(ctx, fileID, f, local, oldURL, newURL, oldThumbURL, newThumbURL, oldWebpublicURL, newWebpublicURL)
+}
+
+// repairDenormalizedCascade re-runs user/emoji URL updates when drive_file already
+// points at object storage but denormalized columns were not updated (#1476).
+func (m *Migrator) repairDenormalizedCascade(ctx context.Context, f *model.DriveFile, fileID string) error {
+	if m.db == nil || f.AccessKey == nil {
+		return nil
+	}
+	newURL := f.URL
+	if newURL == "" || urlUsesDrivePrefix(newURL, m.driveURL) {
+		return nil
+	}
+	oldURL := fileURLForAccessKey(m.driveURL, *f.AccessKey)
+
+	var oldThumbURL, newThumbURL *string
+	if f.ThumbnailAccessKey != nil && f.ThumbnailURL != nil {
+		ot := fileURLForAccessKey(m.driveURL, *f.ThumbnailAccessKey)
+		if urlUsesDrivePrefix(*f.ThumbnailURL, m.driveURL) {
+			ot = *f.ThumbnailURL
+		}
+		oldThumbURL = &ot
+		nt := *f.ThumbnailURL
+		newThumbURL = &nt
+	}
+
+	var oldWebpublicURL, newWebpublicURL *string
+	if f.WebpublicAccessKey != nil && f.WebpublicURL != nil {
+		ow := fileURLForAccessKey(m.driveURL, *f.WebpublicAccessKey)
+		if urlUsesDrivePrefix(*f.WebpublicURL, m.driveURL) {
+			ow = *f.WebpublicURL
+		}
+		oldWebpublicURL = &ow
+		nw := *f.WebpublicURL
+		newWebpublicURL = &nw
+	}
+
+	return m.db.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
+		return cascadeDenormalizedURLs(tx, fileID, oldURL, newURL, oldThumbURL, newThumbURL, oldWebpublicURL, newWebpublicURL)
+	})
+}
+
+func (m *Migrator) persistMigration(
+	ctx context.Context,
+	fileID string,
+	f *model.DriveFile,
+	local Storage,
+	oldURL, newURL string,
+	oldThumbURL, newThumbURL *string,
+	oldWebpublicURL, newWebpublicURL *string,
+) error {
 	fields := map[string]any{
 		"url":            newURL,
 		"storedInternal": false,
@@ -130,6 +188,18 @@ func migrationMetaReady(meta *model.Meta) bool {
 		return false
 	}
 	return true
+}
+
+func urlUsesDrivePrefix(u, driveURL string) bool {
+	if u == "" || driveURL == "" {
+		return false
+	}
+	base := strings.TrimRight(driveURL, "/")
+	return strings.HasPrefix(u, base+"/") || u == base
+}
+
+func fileURLForAccessKey(driveURL, accessKey string) string {
+	return strings.TrimRight(driveURL, "/") + "/" + accessKey
 }
 
 func (m *Migrator) migrateObject(local Storage, s3 *S3Storage, accessKey *string) (string, error) {

--- a/internal/core/drive/migrator.go
+++ b/internal/core/drive/migrator.go
@@ -210,7 +210,11 @@ func (m *Migrator) migrateObject(local Storage, s3 *S3Storage, accessKey *string
 	body, err := local.Get(key)
 	if err != nil {
 		if errors.Is(err, ErrObjectNotFound) {
-			if _, headErr := s3.Get(key); headErr == nil {
+			exists, existsErr := s3.Exists(key)
+			if existsErr != nil {
+				return "", existsErr
+			}
+			if exists {
 				return s3.publicURL(key), nil
 			}
 			return "", fmt.Errorf("local object missing for key %s: %w", key, err)

--- a/internal/core/drive/migrator_test.go
+++ b/internal/core/drive/migrator_test.go
@@ -85,6 +85,56 @@ func TestMigrator_DeleteLocalKeys(t *testing.T) {
 	assert.True(t, os.IsNotExist(err))
 }
 
+func TestURLUsesDrivePrefix(t *testing.T) {
+	base := "https://example.com/files"
+	assert.True(t, urlUsesDrivePrefix("https://example.com/files/abc", base))
+	assert.False(t, urlUsesDrivePrefix("https://cdn.example.com/abc", base))
+}
+
+func TestMigrator_RepairDenormalizedCascade(t *testing.T) {
+	db := openMigratorTestDB(t)
+
+	fileID := "frepair1"
+	key := "repairkey"
+	oldURL := "https://example.com/files/" + key
+	newURL := "https://cdn.example.com/files/" + key
+	f := &model.DriveFile{
+		ID:             fileID,
+		StoredInternal: false,
+		AccessKey:      &key,
+		URL:            newURL,
+		Properties:     datatypes.JSON([]byte("{}")),
+		RequestHeaders: datatypes.JSON([]byte("{}")),
+	}
+	require.NoError(t, db.Create(f).Error)
+	t.Cleanup(func() { db.Exec(`DELETE FROM "drive_file" WHERE id = ?`, fileID) })
+
+	user := &model.User{
+		ID:                "urepair1",
+		Username:          "repair1",
+		UsernameLower:     "repair1",
+		AvatarID:          &fileID,
+		AvatarURL:         &oldURL,
+		AvatarDecorations: datatypes.JSON([]byte("[]")),
+	}
+	require.NoError(t, db.Create(user).Error)
+	t.Cleanup(func() { db.Exec(`DELETE FROM "user" WHERE id = ?`, user.ID) })
+
+	bucket := "b"
+	metaRepo := testutil.NewMockMetaRepository()
+	metaRepo.Meta = &model.Meta{UseObjectStorage: true, ObjectStorageBucket: &bucket}
+	fileRepo := testutil.NewMockDriveFileRepository()
+	fileRepo.Files[fileID] = f
+
+	m := NewMigrator(metaRepo, fileRepo, db, config.DriveLocalToObjectStorageConfig{}, "https://example.com/files")
+	require.NoError(t, m.MigrateFile(context.Background(), fileID))
+
+	var got model.User
+	require.NoError(t, db.First(&got, "id = ?", user.ID).Error)
+	require.NotNil(t, got.AvatarURL)
+	assert.Equal(t, newURL, *got.AvatarURL)
+}
+
 func TestMigrator_MigrateFile_SkipsNonInternal(t *testing.T) {
 	bucket := "b"
 	metaRepo := testutil.NewMockMetaRepository()

--- a/internal/core/drive/migrator_test.go
+++ b/internal/core/drive/migrator_test.go
@@ -1,0 +1,268 @@
+package drive
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"io"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/shiroha-a/mk/internal/config"
+	"github.com/shiroha-a/mk/internal/model"
+	"github.com/shiroha-a/mk/internal/testutil"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gorm.io/datatypes"
+	"gorm.io/gorm"
+)
+
+func TestMigrationMetaReady(t *testing.T) {
+	bucket := "b"
+	assert.False(t, migrationMetaReady(nil))
+	assert.False(t, migrationMetaReady(&model.Meta{UseObjectStorage: false}))
+	assert.False(t, migrationMetaReady(&model.Meta{UseObjectStorage: true}))
+	assert.True(t, migrationMetaReady(&model.Meta{
+		UseObjectStorage:    true,
+		ObjectStorageBucket: &bucket,
+	}))
+}
+
+func TestMigrator_MigrateObject_FromLocal(t *testing.T) {
+	dir := t.TempDir()
+	key := "abc123"
+	require.NoError(t, os.WriteFile(filepath.Join(dir, key), []byte("hello"), 0o644))
+
+	mock := &mockS3API{}
+	s3 := NewS3Storage(S3StorageConfig{
+		Client:  mock,
+		Bucket:  "bucket",
+		Prefix:  "files",
+		BaseURL: "https://cdn.example.com",
+	})
+	local := NewLocalStorage(dir, "https://example.com/files")
+
+	m := &Migrator{}
+	url, err := m.migrateObject(local, s3, &key)
+	require.NoError(t, err)
+	assert.Equal(t, "https://cdn.example.com/files/abc123", url)
+	require.NotNil(t, mock.putInput)
+}
+
+func TestMigrator_MigrateObject_FallbackWhenLocalMissing(t *testing.T) {
+	dir := t.TempDir()
+	key := "only-s3"
+	mock := &mockS3API{getBody: io.NopCloser(bytes.NewReader([]byte("x")))}
+	s3 := NewS3Storage(S3StorageConfig{
+		Client:  mock,
+		Bucket:  "bucket",
+		BaseURL: "https://cdn.example.com",
+	})
+	local := NewLocalStorage(dir, "https://example.com/files")
+
+	m := &Migrator{}
+	url, err := m.migrateObject(local, s3, &key)
+	require.NoError(t, err)
+	assert.Equal(t, "https://cdn.example.com/only-s3", url)
+}
+
+func TestMigrator_MigrateObject_EmptyKey(t *testing.T) {
+	m := &Migrator{}
+	_, err := m.migrateObject(NewLocalStorage(t.TempDir(), ""), &S3Storage{}, nil)
+	require.Error(t, err)
+}
+
+func TestMigrator_DeleteLocalKeys(t *testing.T) {
+	dir := t.TempDir()
+	key := "k1"
+	require.NoError(t, os.WriteFile(filepath.Join(dir, key), []byte("x"), 0o644))
+	local := NewLocalStorage(dir, "")
+	m := &Migrator{}
+	f := &model.DriveFile{AccessKey: &key}
+	m.deleteLocalKeys(local, f)
+	_, err := os.Stat(filepath.Join(dir, key))
+	assert.True(t, os.IsNotExist(err))
+}
+
+func TestMigrator_MigrateFile_SkipsNonInternal(t *testing.T) {
+	bucket := "b"
+	metaRepo := testutil.NewMockMetaRepository()
+	metaRepo.Meta = &model.Meta{UseObjectStorage: true, ObjectStorageBucket: &bucket}
+	fileRepo := testutil.NewMockDriveFileRepository()
+	fileRepo.Files["f1"] = &model.DriveFile{ID: "f1", StoredInternal: false, IsLink: false}
+	m := NewMigrator(metaRepo, fileRepo, nil, config.DriveLocalToObjectStorageConfig{}, "https://example.com/files")
+	require.NoError(t, m.MigrateFile(context.Background(), "f1"))
+}
+
+func TestMigrator_MigrateFile_NotConfigured(t *testing.T) {
+	metaRepo := testutil.NewMockMetaRepository()
+	metaRepo.Meta = &model.Meta{UseObjectStorage: false}
+	fileRepo := testutil.NewMockDriveFileRepository()
+	key := "k"
+	fileRepo.Files["f1"] = &model.DriveFile{ID: "f1", StoredInternal: true, AccessKey: &key}
+	m := NewMigrator(metaRepo, fileRepo, nil, config.DriveLocalToObjectStorageConfig{}, "https://example.com/files")
+	err := m.MigrateFile(context.Background(), "f1")
+	require.ErrorIs(t, err, ErrMigrationNotConfigured)
+}
+
+func TestMigrator_MigrateFile_ContextCanceled(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	m := NewMigrator(testutil.NewMockMetaRepository(), testutil.NewMockDriveFileRepository(), nil, config.DriveLocalToObjectStorageConfig{}, "")
+	err := m.MigrateFile(ctx, "f1")
+	require.ErrorIs(t, err, context.Canceled)
+}
+
+func TestMigrator_MigrateFile_SkipsLink(t *testing.T) {
+	bucket := "b"
+	metaRepo := testutil.NewMockMetaRepository()
+	metaRepo.Meta = &model.Meta{UseObjectStorage: true, ObjectStorageBucket: &bucket}
+	fileRepo := testutil.NewMockDriveFileRepository()
+	key := "k"
+	fileRepo.Files["f1"] = &model.DriveFile{ID: "f1", StoredInternal: true, IsLink: true, AccessKey: &key}
+	m := NewMigrator(metaRepo, fileRepo, nil, config.DriveLocalToObjectStorageConfig{}, "https://example.com/files")
+	require.NoError(t, m.MigrateFile(context.Background(), "f1"))
+}
+
+func TestMigrator_MigrateObject_LocalMissingNoS3(t *testing.T) {
+	key := "missing"
+	local := NewLocalStorage(t.TempDir(), "https://example.com/files")
+	s3 := NewS3Storage(S3StorageConfig{Client: &mockS3API{getErr: errors.New("not found")}, Bucket: "b", BaseURL: "https://cdn.example.com"})
+	m := &Migrator{}
+	_, err := m.migrateObject(local, s3, &key)
+	require.Error(t, err)
+}
+
+func TestMigrator_DeleteLocalKeys_AllVariants(t *testing.T) {
+	dir := t.TempDir()
+	keys := []string{"p", "t", "w"}
+	for _, k := range keys {
+		require.NoError(t, os.WriteFile(filepath.Join(dir, k), []byte("x"), 0o644))
+	}
+	local := NewLocalStorage(dir, "")
+	m := &Migrator{}
+	f := &model.DriveFile{
+		AccessKey:          &keys[0],
+		ThumbnailAccessKey: &keys[1],
+		WebpublicAccessKey: &keys[2],
+	}
+	m.deleteLocalKeys(local, f)
+	for _, k := range keys {
+		_, err := os.Stat(filepath.Join(dir, k))
+		assert.True(t, os.IsNotExist(err))
+	}
+}
+
+func TestMigrator_MigrateFile_HappyPath(t *testing.T) {
+	db := openMigratorTestDB(t)
+
+	dir := t.TempDir()
+	key := "migkey"
+	require.NoError(t, os.WriteFile(filepath.Join(dir, key), []byte("payload"), 0o644))
+
+	bucket := "bucket"
+	baseURL := "https://cdn.example.com"
+	meta := &model.Meta{UseObjectStorage: true, ObjectStorageBucket: &bucket, ObjectStorageBaseURL: &baseURL}
+	metaRepo := testutil.NewMockMetaRepository()
+	metaRepo.Meta = meta
+
+	oldURL := "https://example.com/files/" + key
+	f := &model.DriveFile{
+		ID:             "fmig_happy",
+		StoredInternal: true,
+		AccessKey:      &key,
+		URL:            oldURL,
+		Properties:     datatypes.JSON([]byte("{}")),
+		RequestHeaders: datatypes.JSON([]byte("{}")),
+	}
+	require.NoError(t, db.Create(f).Error)
+	t.Cleanup(func() { db.Exec(`DELETE FROM "drive_file" WHERE id = ?`, f.ID) })
+
+	fileRepo := testutil.NewMockDriveFileRepository()
+	fileRepo.Files[f.ID] = f
+
+	mock := &mockS3API{}
+	restore := setStorageFromMetaForTest(func(_ *model.Meta, localDir, _ string) Storage {
+		return NewS3Storage(S3StorageConfig{
+			Client:  mock,
+			Bucket:  bucket,
+			Prefix:  "files",
+			BaseURL: baseURL,
+		})
+	})
+	t.Cleanup(restore)
+
+	m := NewMigrator(metaRepo, fileRepo, db, config.DriveLocalToObjectStorageConfig{
+		LocalPath:   dir,
+		DeleteLocal: true,
+	}, "https://example.com/files")
+	require.NoError(t, m.MigrateFile(context.Background(), f.ID))
+
+	var got model.DriveFile
+	require.NoError(t, db.First(&got, "id = ?", f.ID).Error)
+	assert.False(t, got.StoredInternal)
+	assert.Equal(t, "https://cdn.example.com/files/migkey", got.URL)
+	_, err := os.Stat(filepath.Join(dir, key))
+	assert.True(t, os.IsNotExist(err))
+}
+
+func TestCascadeDenormalizedURLs(t *testing.T) {
+	db := openMigratorTestDB(t)
+
+	fileID := "fcascade1"
+	oldURL := "https://example.com/files/cascade1"
+	newURL := "https://cdn.example.com/files/cascade1"
+	oldThumb := "https://example.com/files/cascade1-thumb"
+	newThumb := "https://cdn.example.com/files/cascade1-thumb"
+
+	user := &model.User{
+		ID:                "ucascade1",
+		Username:          "cascade1",
+		UsernameLower:     "cascade1",
+		AvatarID:          &fileID,
+		AvatarURL:         &oldURL,
+		AvatarDecorations: datatypes.JSON([]byte("[]")),
+	}
+	require.NoError(t, db.Create(user).Error)
+	t.Cleanup(func() { db.Exec(`DELETE FROM "user" WHERE id = ?`, user.ID) })
+
+	emoji := &model.Emoji{
+		ID:          "ecascade1",
+		Name:        "cascade_emoji",
+		OriginalURL: oldURL,
+		PublicURL:   oldURL,
+	}
+	require.NoError(t, db.Create(emoji).Error)
+	t.Cleanup(func() { db.Exec(`DELETE FROM "emoji" WHERE id = ?`, emoji.ID) })
+
+	require.NoError(t, db.Transaction(func(tx *gorm.DB) error {
+		return cascadeDenormalizedURLs(tx, fileID, oldURL, newURL, &oldThumb, &newThumb, nil, nil)
+	}))
+
+	var gotUser model.User
+	require.NoError(t, db.First(&gotUser, "id = ?", user.ID).Error)
+	require.NotNil(t, gotUser.AvatarURL)
+	assert.Equal(t, newURL, *gotUser.AvatarURL)
+
+	var gotEmoji model.Emoji
+	require.NoError(t, db.First(&gotEmoji, "id = ?", emoji.ID).Error)
+	assert.Equal(t, newURL, gotEmoji.OriginalURL)
+	assert.Equal(t, newURL, gotEmoji.PublicURL)
+}
+
+func openMigratorTestDB(t *testing.T) *gorm.DB {
+	t.Helper()
+	db, err := testutil.OpenTestDB()
+	if err != nil {
+		t.Skipf("postgres not available: %v", err)
+	}
+	testutil.ApplyMigrations(db)
+	return db
+}
+
+func setStorageFromMetaForTest(fn func(*model.Meta, string, string) Storage) func() {
+	prev := storageFromMeta
+	storageFromMeta = fn
+	return func() { storageFromMeta = prev }
+}

--- a/internal/core/drive/migrator_test.go
+++ b/internal/core/drive/migrator_test.go
@@ -17,6 +17,7 @@ import (
 )
 
 func TestMigrationMetaReady(t *testing.T) {
+	t.Parallel()
 	bucket := "b"
 	assert.False(t, migrationMetaReady(nil))
 	assert.False(t, migrationMetaReady(&model.Meta{UseObjectStorage: false}))
@@ -28,6 +29,7 @@ func TestMigrationMetaReady(t *testing.T) {
 }
 
 func TestMigrator_MigrateObject_FromLocal(t *testing.T) {
+	t.Parallel()
 	dir := t.TempDir()
 	key := "abc123"
 	require.NoError(t, os.WriteFile(filepath.Join(dir, key), []byte("hello"), 0o644))
@@ -49,6 +51,7 @@ func TestMigrator_MigrateObject_FromLocal(t *testing.T) {
 }
 
 func TestMigrator_MigrateObject_FallbackWhenLocalMissing(t *testing.T) {
+	t.Parallel()
 	dir := t.TempDir()
 	key := "only-s3"
 	mock := &mockS3API{}
@@ -68,6 +71,7 @@ func TestMigrator_MigrateObject_FallbackWhenLocalMissing(t *testing.T) {
 }
 
 func TestMigrator_MigrateObject_FallbackUsesHeadNotGet(t *testing.T) {
+	t.Parallel()
 	key := "s3-only"
 	mock := &mockS3API{}
 	s3 := NewS3Storage(S3StorageConfig{
@@ -85,12 +89,14 @@ func TestMigrator_MigrateObject_FallbackUsesHeadNotGet(t *testing.T) {
 }
 
 func TestMigrator_MigrateObject_EmptyKey(t *testing.T) {
+	t.Parallel()
 	m := &Migrator{}
 	_, err := m.migrateObject(NewLocalStorage(t.TempDir(), ""), &S3Storage{}, nil)
 	require.Error(t, err)
 }
 
 func TestMigrator_DeleteLocalKeys(t *testing.T) {
+	t.Parallel()
 	dir := t.TempDir()
 	key := "k1"
 	require.NoError(t, os.WriteFile(filepath.Join(dir, key), []byte("x"), 0o644))
@@ -103,12 +109,14 @@ func TestMigrator_DeleteLocalKeys(t *testing.T) {
 }
 
 func TestURLUsesDrivePrefix(t *testing.T) {
+	t.Parallel()
 	base := "https://example.com/files"
 	assert.True(t, URLUsesDrivePrefix("https://example.com/files/abc", base))
 	assert.False(t, URLUsesDrivePrefix("https://cdn.example.com/abc", base))
 }
 
 func TestMigrator_RepairDenormalizedCascade(t *testing.T) {
+	t.Parallel()
 	db := openMigratorTestDB(t)
 
 	fileID := "frepair1"
@@ -153,6 +161,7 @@ func TestMigrator_RepairDenormalizedCascade(t *testing.T) {
 }
 
 func TestMigrator_MigrateFile_SkipsNonInternal(t *testing.T) {
+	t.Parallel()
 	bucket := "b"
 	metaRepo := testutil.NewMockMetaRepository()
 	metaRepo.Meta = &model.Meta{UseObjectStorage: true, ObjectStorageBucket: &bucket}
@@ -163,6 +172,7 @@ func TestMigrator_MigrateFile_SkipsNonInternal(t *testing.T) {
 }
 
 func TestMigrator_MigrateFile_NotConfigured(t *testing.T) {
+	t.Parallel()
 	metaRepo := testutil.NewMockMetaRepository()
 	metaRepo.Meta = &model.Meta{UseObjectStorage: false}
 	fileRepo := testutil.NewMockDriveFileRepository()
@@ -174,6 +184,7 @@ func TestMigrator_MigrateFile_NotConfigured(t *testing.T) {
 }
 
 func TestMigrator_MigrateFile_ContextCanceled(t *testing.T) {
+	t.Parallel()
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel()
 	m := NewMigrator(testutil.NewMockMetaRepository(), testutil.NewMockDriveFileRepository(), nil, config.DriveLocalToObjectStorageConfig{}, "")
@@ -182,6 +193,7 @@ func TestMigrator_MigrateFile_ContextCanceled(t *testing.T) {
 }
 
 func TestMigrator_MigrateFile_SkipsLink(t *testing.T) {
+	t.Parallel()
 	bucket := "b"
 	metaRepo := testutil.NewMockMetaRepository()
 	metaRepo.Meta = &model.Meta{UseObjectStorage: true, ObjectStorageBucket: &bucket}
@@ -193,6 +205,7 @@ func TestMigrator_MigrateFile_SkipsLink(t *testing.T) {
 }
 
 func TestMigrator_MigrateObject_LocalMissingNoS3(t *testing.T) {
+	t.Parallel()
 	key := "missing"
 	local := NewLocalStorage(t.TempDir(), "https://example.com/files")
 	s3 := NewS3Storage(S3StorageConfig{
@@ -206,6 +219,7 @@ func TestMigrator_MigrateObject_LocalMissingNoS3(t *testing.T) {
 }
 
 func TestMigrator_DeleteLocalKeys_AllVariants(t *testing.T) {
+	t.Parallel()
 	dir := t.TempDir()
 	keys := []string{"p", "t", "w"}
 	for _, k := range keys {
@@ -225,6 +239,7 @@ func TestMigrator_DeleteLocalKeys_AllVariants(t *testing.T) {
 	}
 }
 
+// storageFromMeta を差し替えるため t.Parallel() 非対応
 func TestMigrator_MigrateFile_HappyPath(t *testing.T) {
 	db := openMigratorTestDB(t)
 
@@ -278,6 +293,7 @@ func TestMigrator_MigrateFile_HappyPath(t *testing.T) {
 	assert.True(t, os.IsNotExist(err))
 }
 
+// storageFromMeta を差し替えるため t.Parallel() 非対応
 func TestMigrator_MigrateFile_HappyPath_DeleteLocalFalse(t *testing.T) {
 	db := openMigratorTestDB(t)
 
@@ -328,6 +344,7 @@ func TestMigrator_MigrateFile_HappyPath_DeleteLocalFalse(t *testing.T) {
 }
 
 func TestCascadeDenormalizedURLs(t *testing.T) {
+	t.Parallel()
 	db := openMigratorTestDB(t)
 
 	fileID := "fcascade1"

--- a/internal/core/drive/migrator_test.go
+++ b/internal/core/drive/migrator_test.go
@@ -216,6 +216,20 @@ func TestCascadeDenormalizedURLs(t *testing.T) {
 	oldThumb := "https://example.com/files/cascade1-thumb"
 	newThumb := "https://cdn.example.com/files/cascade1-thumb"
 
+	avatarFile := &model.DriveFile{
+		ID:             fileID,
+		MD5:            "cascade_md5",
+		Name:           "cascade.bin",
+		Type:           "application/octet-stream",
+		Size:           1,
+		StoredInternal: true,
+		URL:            oldURL,
+		Properties:     datatypes.JSON([]byte("{}")),
+		RequestHeaders: datatypes.JSON([]byte("{}")),
+	}
+	require.NoError(t, db.Create(avatarFile).Error)
+	t.Cleanup(func() { db.Exec(`DELETE FROM "drive_file" WHERE id = ?`, fileID) })
+
 	user := &model.User{
 		ID:                "ucascade1",
 		Username:          "cascade1",

--- a/internal/core/drive/migrator_test.go
+++ b/internal/core/drive/migrator_test.go
@@ -104,8 +104,8 @@ func TestMigrator_DeleteLocalKeys(t *testing.T) {
 
 func TestURLUsesDrivePrefix(t *testing.T) {
 	base := "https://example.com/files"
-	assert.True(t, urlUsesDrivePrefix("https://example.com/files/abc", base))
-	assert.False(t, urlUsesDrivePrefix("https://cdn.example.com/abc", base))
+	assert.True(t, URLUsesDrivePrefix("https://example.com/files/abc", base))
+	assert.False(t, URLUsesDrivePrefix("https://cdn.example.com/abc", base))
 }
 
 func TestMigrator_RepairDenormalizedCascade(t *testing.T) {
@@ -276,6 +276,55 @@ func TestMigrator_MigrateFile_HappyPath(t *testing.T) {
 	assert.Equal(t, "https://cdn.example.com/files/migkey", got.URL)
 	_, err := os.Stat(filepath.Join(dir, key))
 	assert.True(t, os.IsNotExist(err))
+}
+
+func TestMigrator_MigrateFile_HappyPath_DeleteLocalFalse(t *testing.T) {
+	db := openMigratorTestDB(t)
+
+	dir := t.TempDir()
+	key := "migkey_keep"
+	require.NoError(t, os.WriteFile(filepath.Join(dir, key), []byte("payload"), 0o644))
+
+	bucket := "bucket"
+	baseURL := "https://cdn.example.com"
+	meta := &model.Meta{UseObjectStorage: true, ObjectStorageBucket: &bucket, ObjectStorageBaseURL: &baseURL}
+	metaRepo := testutil.NewMockMetaRepository()
+	metaRepo.Meta = meta
+
+	oldURL := "https://example.com/files/" + key
+	f := &model.DriveFile{
+		ID:             "fmig_keep",
+		StoredInternal: true,
+		AccessKey:      &key,
+		URL:            oldURL,
+		Properties:     datatypes.JSON([]byte("{}")),
+		RequestHeaders: datatypes.JSON([]byte("{}")),
+	}
+	require.NoError(t, db.Create(f).Error)
+	t.Cleanup(func() { db.Exec(`DELETE FROM "drive_file" WHERE id = ?`, f.ID) })
+
+	fileRepo := testutil.NewMockDriveFileRepository()
+	fileRepo.Files[f.ID] = f
+
+	mock := &mockS3API{}
+	restore := setStorageFromMetaForTest(func(_ *model.Meta, localDir, _ string) Storage {
+		return NewS3Storage(S3StorageConfig{
+			Client:  mock,
+			Bucket:  bucket,
+			Prefix:  "files",
+			BaseURL: baseURL,
+		})
+	})
+	t.Cleanup(restore)
+
+	m := NewMigrator(metaRepo, fileRepo, db, config.DriveLocalToObjectStorageConfig{
+		LocalPath:   dir,
+		DeleteLocal: false,
+	}, "https://example.com/files")
+	require.NoError(t, m.MigrateFile(context.Background(), f.ID))
+
+	_, err := os.Stat(filepath.Join(dir, key))
+	require.NoError(t, err, "local blob should remain when DeleteLocal is false")
 }
 
 func TestCascadeDenormalizedURLs(t *testing.T) {

--- a/internal/core/drive/migrator_test.go
+++ b/internal/core/drive/migrator_test.go
@@ -1,14 +1,12 @@
 package drive
 
 import (
-	"bytes"
 	"context"
-	"errors"
-	"io"
 	"os"
 	"path/filepath"
 	"testing"
 
+	smithy "github.com/aws/smithy-go"
 	"github.com/shiroha-a/mk/internal/config"
 	"github.com/shiroha-a/mk/internal/model"
 	"github.com/shiroha-a/mk/internal/testutil"
@@ -53,7 +51,7 @@ func TestMigrator_MigrateObject_FromLocal(t *testing.T) {
 func TestMigrator_MigrateObject_FallbackWhenLocalMissing(t *testing.T) {
 	dir := t.TempDir()
 	key := "only-s3"
-	mock := &mockS3API{getBody: io.NopCloser(bytes.NewReader([]byte("x")))}
+	mock := &mockS3API{}
 	s3 := NewS3Storage(S3StorageConfig{
 		Client:  mock,
 		Bucket:  "bucket",
@@ -65,6 +63,25 @@ func TestMigrator_MigrateObject_FallbackWhenLocalMissing(t *testing.T) {
 	url, err := m.migrateObject(local, s3, &key)
 	require.NoError(t, err)
 	assert.Equal(t, "https://cdn.example.com/only-s3", url)
+	assert.True(t, mock.headCalled)
+	assert.False(t, mock.getCalled)
+}
+
+func TestMigrator_MigrateObject_FallbackUsesHeadNotGet(t *testing.T) {
+	key := "s3-only"
+	mock := &mockS3API{}
+	s3 := NewS3Storage(S3StorageConfig{
+		Client:  mock,
+		Bucket:  "bucket",
+		BaseURL: "https://cdn.example.com",
+	})
+	local := NewLocalStorage(t.TempDir(), "https://example.com/files")
+
+	m := &Migrator{}
+	_, err := m.migrateObject(local, s3, &key)
+	require.NoError(t, err)
+	assert.True(t, mock.headCalled, "fallback must use HeadObject, not GetObject")
+	assert.False(t, mock.getCalled)
 }
 
 func TestMigrator_MigrateObject_EmptyKey(t *testing.T) {
@@ -178,7 +195,11 @@ func TestMigrator_MigrateFile_SkipsLink(t *testing.T) {
 func TestMigrator_MigrateObject_LocalMissingNoS3(t *testing.T) {
 	key := "missing"
 	local := NewLocalStorage(t.TempDir(), "https://example.com/files")
-	s3 := NewS3Storage(S3StorageConfig{Client: &mockS3API{getErr: errors.New("not found")}, Bucket: "b", BaseURL: "https://cdn.example.com"})
+	s3 := NewS3Storage(S3StorageConfig{
+		Client:  &mockS3API{headErr: &smithy.GenericAPIError{Code: "NoSuchKey", Message: "not found"}},
+		Bucket:  "b",
+		BaseURL: "https://cdn.example.com",
+	})
 	m := &Migrator{}
 	_, err := m.migrateObject(local, s3, &key)
 	require.Error(t, err)

--- a/internal/core/drive/s3_storage.go
+++ b/internal/core/drive/s3_storage.go
@@ -163,6 +163,9 @@ func (s *S3Storage) Get(accessKey string) (io.ReadCloser, error) {
 	return output.Body, nil
 }
 
+// StoredInternal implements Storage.
+func (s *S3Storage) StoredInternal() bool { return false }
+
 // Delete removes an object from S3. Missing objects are silently ignored.
 func (s *S3Storage) Delete(accessKey string) error {
 	key := s.objectKey(accessKey)

--- a/internal/core/drive/s3_storage.go
+++ b/internal/core/drive/s3_storage.go
@@ -3,6 +3,7 @@ package drive
 import (
 	"bytes"
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -11,6 +12,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/s3"
 	"github.com/aws/aws-sdk-go-v2/service/s3/types"
+	smithy "github.com/aws/smithy-go"
 )
 
 // S3API abstracts the subset of S3 client operations used by S3Storage.
@@ -18,6 +20,7 @@ import (
 type S3API interface {
 	PutObject(ctx context.Context, input *s3.PutObjectInput, opts ...func(*s3.Options)) (*s3.PutObjectOutput, error)
 	GetObject(ctx context.Context, input *s3.GetObjectInput, opts ...func(*s3.Options)) (*s3.GetObjectOutput, error)
+	HeadObject(ctx context.Context, input *s3.HeadObjectInput, opts ...func(*s3.Options)) (*s3.HeadObjectOutput, error)
 	DeleteObject(ctx context.Context, input *s3.DeleteObjectInput, opts ...func(*s3.Options)) (*s3.DeleteObjectOutput, error)
 }
 
@@ -118,6 +121,33 @@ func (s *S3Storage) Put(accessKey string, body io.Reader) (string, error) {
 		return "", fmt.Errorf("s3 put %s: %w", key, err)
 	}
 	return s.publicURL(accessKey), nil
+}
+
+// Exists reports whether an object is present in the bucket without downloading it.
+func (s *S3Storage) Exists(accessKey string) (bool, error) {
+	key := s.objectKey(accessKey)
+	_, err := s.client.HeadObject(context.Background(), &s3.HeadObjectInput{
+		Bucket: aws.String(s.bucket),
+		Key:    aws.String(key),
+	})
+	if err == nil {
+		return true, nil
+	}
+	if isS3ObjectMissing(err) {
+		return false, nil
+	}
+	return false, fmt.Errorf("s3 head %s: %w", key, err)
+}
+
+func isS3ObjectMissing(err error) bool {
+	var apiErr smithy.APIError
+	if errors.As(err, &apiErr) {
+		switch apiErr.ErrorCode() {
+		case "NotFound", "NoSuchKey":
+			return true
+		}
+	}
+	return false
 }
 
 // Get retrieves an object from S3 and returns an io.ReadCloser.

--- a/internal/core/drive/s3_storage_test.go
+++ b/internal/core/drive/s3_storage_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/aws/aws-sdk-go-v2/service/s3"
 	"github.com/aws/aws-sdk-go-v2/service/s3/types"
+	smithy "github.com/aws/smithy-go"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -18,11 +19,14 @@ import (
 // ---------------------------------------------------------------------------
 
 type mockS3API struct {
-	putInput  *s3.PutObjectInput
-	putErr    error
-	getBody   io.ReadCloser
-	getErr    error
-	deleteErr error
+	putInput   *s3.PutObjectInput
+	putErr     error
+	getBody    io.ReadCloser
+	getErr     error
+	headErr    error
+	deleteErr  error
+	getCalled  bool
+	headCalled bool
 }
 
 func (m *mockS3API) PutObject(_ context.Context, input *s3.PutObjectInput, _ ...func(*s3.Options)) (*s3.PutObjectOutput, error) {
@@ -31,10 +35,19 @@ func (m *mockS3API) PutObject(_ context.Context, input *s3.PutObjectInput, _ ...
 }
 
 func (m *mockS3API) GetObject(_ context.Context, _ *s3.GetObjectInput, _ ...func(*s3.Options)) (*s3.GetObjectOutput, error) {
+	m.getCalled = true
 	if m.getErr != nil {
 		return nil, m.getErr
 	}
 	return &s3.GetObjectOutput{Body: m.getBody}, nil
+}
+
+func (m *mockS3API) HeadObject(_ context.Context, _ *s3.HeadObjectInput, _ ...func(*s3.Options)) (*s3.HeadObjectOutput, error) {
+	m.headCalled = true
+	if m.headErr != nil {
+		return nil, m.headErr
+	}
+	return &s3.HeadObjectOutput{}, nil
 }
 
 func (m *mockS3API) DeleteObject(_ context.Context, _ *s3.DeleteObjectInput, _ ...func(*s3.Options)) (*s3.DeleteObjectOutput, error) {
@@ -158,6 +171,46 @@ func TestS3Storage_Get_NotFound(t *testing.T) {
 
 	_, err := st.Get("missing")
 	assert.ErrorIs(t, err, ErrObjectNotFound)
+}
+
+func TestS3Storage_Exists_HappyPath(t *testing.T) {
+	mock := &mockS3API{}
+	st := NewS3Storage(S3StorageConfig{
+		Client: mock,
+		Bucket: "bucket",
+		Prefix: "files/",
+	})
+
+	ok, err := st.Exists("key1")
+	require.NoError(t, err)
+	assert.True(t, ok)
+	assert.True(t, mock.headCalled)
+	assert.False(t, mock.getCalled)
+}
+
+func TestS3Storage_Exists_NotFound(t *testing.T) {
+	mock := &mockS3API{headErr: &smithy.GenericAPIError{Code: "NoSuchKey", Message: "not found"}}
+	st := NewS3Storage(S3StorageConfig{
+		Client: mock,
+		Bucket: "bucket",
+	})
+
+	ok, err := st.Exists("missing")
+	require.NoError(t, err)
+	assert.False(t, ok)
+}
+
+func TestS3Storage_Exists_APIError(t *testing.T) {
+	mock := &mockS3API{headErr: errors.New("access denied")}
+	st := NewS3Storage(S3StorageConfig{
+		Client: mock,
+		Bucket: "bucket",
+	})
+
+	ok, err := st.Exists("key1")
+	assert.Error(t, err)
+	assert.False(t, ok)
+	assert.Contains(t, err.Error(), "s3 head")
 }
 
 func TestS3Storage_Delete_HappyPath(t *testing.T) {

--- a/internal/core/drive/s3_storage_test.go
+++ b/internal/core/drive/s3_storage_test.go
@@ -174,6 +174,7 @@ func TestS3Storage_Get_NotFound(t *testing.T) {
 }
 
 func TestS3Storage_Exists_HappyPath(t *testing.T) {
+	t.Parallel()
 	mock := &mockS3API{}
 	st := NewS3Storage(S3StorageConfig{
 		Client: mock,
@@ -189,6 +190,7 @@ func TestS3Storage_Exists_HappyPath(t *testing.T) {
 }
 
 func TestS3Storage_Exists_NotFound(t *testing.T) {
+	t.Parallel()
 	mock := &mockS3API{headErr: &smithy.GenericAPIError{Code: "NoSuchKey", Message: "not found"}}
 	st := NewS3Storage(S3StorageConfig{
 		Client: mock,
@@ -201,6 +203,7 @@ func TestS3Storage_Exists_NotFound(t *testing.T) {
 }
 
 func TestS3Storage_Exists_APIError(t *testing.T) {
+	t.Parallel()
 	mock := &mockS3API{headErr: errors.New("access denied")}
 	st := NewS3Storage(S3StorageConfig{
 		Client: mock,

--- a/internal/core/drive/storage.go
+++ b/internal/core/drive/storage.go
@@ -21,6 +21,8 @@ type Storage interface {
 	Get(accessKey string) (io.ReadCloser, error)
 	// Delete removes an object. Missing objects do not produce an error.
 	Delete(accessKey string) error
+	// StoredInternal reports whether file bytes live on the instance (local FS).
+	StoredInternal() bool
 }
 
 // LocalStorage stores objects on the local filesystem.
@@ -67,6 +69,9 @@ func (s *LocalStorage) Get(accessKey string) (io.ReadCloser, error) {
 	}
 	return f, nil
 }
+
+// StoredInternal implements Storage.
+func (s *LocalStorage) StoredInternal() bool { return true }
 
 // Delete removes the object from disk. Missing files are ignored.
 func (s *LocalStorage) Delete(accessKey string) error {

--- a/internal/core/mediaproxy/local_thumbnail_test.go
+++ b/internal/core/mediaproxy/local_thumbnail_test.go
@@ -210,3 +210,4 @@ func (s *stubDriveStorage) Get(key string) (io.ReadCloser, error) {
 // Put / Delete satisfy coredrive.Storage; not exercised here.
 func (s *stubDriveStorage) Put(_ string, _ io.Reader) (string, error) { return "", nil }
 func (s *stubDriveStorage) Delete(_ string) error                     { return nil }
+func (s *stubDriveStorage) StoredInternal() bool                      { return true }

--- a/internal/core/mediaproxy/service_test.go
+++ b/internal/core/mediaproxy/service_test.go
@@ -33,6 +33,7 @@ type mockStorage struct {
 
 func (m *mockStorage) Put(_ string, _ io.Reader) (string, error) { return "", nil }
 func (m *mockStorage) Delete(_ string) error                     { return nil }
+func (m *mockStorage) StoredInternal() bool                      { return true }
 func (m *mockStorage) Get(key string) (io.ReadCloser, error) {
 	data, ok := m.files[key]
 	if !ok {

--- a/internal/core/transfer/drive_reader_test.go
+++ b/internal/core/transfer/drive_reader_test.go
@@ -32,6 +32,7 @@ func (f *fakeStorage) Get(accessKey string) (io.ReadCloser, error) {
 	return io.NopCloser(strings.NewReader(string(b))), nil
 }
 func (f *fakeStorage) Delete(_ string) error { return nil }
+func (f *fakeStorage) StoredInternal() bool  { return true }
 
 // fakeDriveFileRepo is a minimal stub sufficient for the reader test.
 // Only FindByID is exercised. Other methods return nil errors to satisfy the

--- a/internal/core/transfer/drive_reader_test.go
+++ b/internal/core/transfer/drive_reader_test.go
@@ -102,7 +102,6 @@ func (f *fakeDriveFileRepo) FindByAccessKey(_ string) (*model.DriveFile, error) 
 func (f *fakeDriveFileRepo) FindByAnyAccessKey(_ string) (*model.DriveFile, error) {
 	return nil, errors.New("not implemented")
 }
-func (f *fakeDriveFileRepo) CountStoredInternal() (int64, error) { return 0, nil }
 func (f *fakeDriveFileRepo) ListStoredInternalIDs(_ string, _ int) ([]string, error) {
 	return nil, nil
 }

--- a/internal/core/transfer/drive_reader_test.go
+++ b/internal/core/transfer/drive_reader_test.go
@@ -101,6 +101,10 @@ func (f *fakeDriveFileRepo) FindByAccessKey(_ string) (*model.DriveFile, error) 
 func (f *fakeDriveFileRepo) FindByAnyAccessKey(_ string) (*model.DriveFile, error) {
 	return nil, errors.New("not implemented")
 }
+func (f *fakeDriveFileRepo) CountStoredInternal() (int64, error) { return 0, nil }
+func (f *fakeDriveFileRepo) ListStoredInternalIDs(_ string, _ int) ([]string, error) {
+	return nil, nil
+}
 
 // Ensure fakeDriveFileRepo implements the real repository interface so the
 // reader accepts it.

--- a/internal/queue/driver/asynqdriver/server.go
+++ b/internal/queue/driver/asynqdriver/server.go
@@ -48,12 +48,13 @@ func NewServer(redisOpt asynq.RedisClientOpt, cfg ServerConfig) *Server {
 		// 新しい queue を増やすときはここと queue.QueueName 等の
 		// 定数追加を同時に行う。
 		queues = map[string]int{
-			"deliver":     1,
-			"inbox":       1,
-			"push":        1,
-			"export":      1,
-			"webhook":     1,
-			"maintenance": 1,
+			"deliver":       1,
+			"inbox":         1,
+			"push":          1,
+			"export":        1,
+			"webhook":       1,
+			"maintenance":   1,
+			"objectStorage": 1,
 		}
 	}
 	inner := asynq.NewServer(redisOpt, asynq.Config{

--- a/internal/queue/driver/mkqdriver/driver.go
+++ b/internal/queue/driver/mkqdriver/driver.go
@@ -25,6 +25,7 @@ var QueueNames = []string{
 	"export",
 	"webhook",
 	"maintenance",
+	"objectStorage",
 }
 
 // Config is the per-driver configuration the constructor consumes.
@@ -215,12 +216,13 @@ func (d *Driver) Client() driver.Client {
 // workerPoolSize() で自動的にこの合計 + poolHeadroom に合わせる。operator は
 // <queue>JobConcurrency でいつでも上書きできる (pool も追従する)。
 var defaultQueueConcurrency = map[string]int{
-	"inbox":       16, // = Misskey inboxJobConcurrency ?? 16
-	"deliver":     16, // upstream は 128 だが Go の per-worker 効率を踏まえ抑制
-	"webhook":     4,
-	"push":        4,
-	"export":      2,
-	"maintenance": 2,
+	"inbox":         16, // = Misskey inboxJobConcurrency ?? 16
+	"deliver":       16, // upstream は 128 だが Go の per-worker 効率を踏まえ抑制
+	"webhook":       4,
+	"push":          4,
+	"export":        2,
+	"maintenance":   2,
+	"objectStorage": 2, // local→S3 migration (#1476)
 }
 
 // unknownQueueConcurrency is applied to any queue absent from

--- a/internal/queue/processors/object_storage_migrate.go
+++ b/internal/queue/processors/object_storage_migrate.go
@@ -15,45 +15,56 @@ import (
 	"github.com/shiroha-a/mk/internal/repository"
 )
 
-const (
-	objectStorageScanLockKey   = "mk:drive:objectStorage:migrateScan:lock"
-	objectStorageScanLockTTL   = 6 * time.Hour
-	objectStorageScanBatchSize = 500
-)
+// ObjectStorageScanLockKey prevents concurrent migrateScan workers (#1476).
+const ObjectStorageScanLockKey = "mk:drive:objectStorage:migrateScan:lock"
+
+// ObjectStorageScanLockTTL bounds how long a crashed scan worker blocks rescheduling.
+const ObjectStorageScanLockTTL = 6 * time.Hour
 
 // ObjectStorageMigrateProcessor handles local→S3 drive migration tasks (#1476).
 type ObjectStorageMigrateProcessor struct {
-	migrator    *coredrive.Migrator
-	fileRepo    repository.DriveFileRepository
-	enqueueFile func(fileID string) error
-	redis       redis.UniversalClient
+	migrator      *coredrive.Migrator
+	fileRepo      repository.DriveFileRepository
+	enqueueFile   func(fileID string) error
+	enqueueScan   func(untilID string) error
+	scanBatchSize int
+	redis         redis.UniversalClient
 }
 
 // ObjectStorageMigrateProcessorConfig wires dependencies for the processor.
 type ObjectStorageMigrateProcessorConfig struct {
-	Migrator    *coredrive.Migrator
-	FileRepo    repository.DriveFileRepository
-	EnqueueFile func(fileID string) error
-	Redis       redis.UniversalClient
+	Migrator      *coredrive.Migrator
+	FileRepo      repository.DriveFileRepository
+	EnqueueFile   func(fileID string) error
+	EnqueueScan   func(untilID string) error
+	ScanBatchSize int
+	Redis         redis.UniversalClient
 }
 
 // NewObjectStorageMigrateProcessor constructs the processor.
 func NewObjectStorageMigrateProcessor(cfg ObjectStorageMigrateProcessorConfig) *ObjectStorageMigrateProcessor {
+	batch := cfg.ScanBatchSize
+	if batch <= 0 {
+		batch = 100
+	}
 	return &ObjectStorageMigrateProcessor{
-		migrator:    cfg.Migrator,
-		fileRepo:    cfg.FileRepo,
-		enqueueFile: cfg.EnqueueFile,
-		redis:       cfg.Redis,
+		migrator:      cfg.Migrator,
+		fileRepo:      cfg.FileRepo,
+		enqueueFile:   cfg.EnqueueFile,
+		enqueueScan:   cfg.EnqueueScan,
+		scanBatchSize: batch,
+		redis:         cfg.Redis,
 	}
 }
 
-// HandleScan fans out migrateFile jobs for storedInternal rows.
-func (p *ObjectStorageMigrateProcessor) HandleScan(ctx context.Context) error {
+// HandleScan enqueues migrateFile jobs for one batch of storedInternal rows and
+// chains another scan task when more rows remain (#1476).
+func (p *ObjectStorageMigrateProcessor) HandleScan(ctx context.Context, untilID string) error {
 	if p.fileRepo == nil || p.enqueueFile == nil {
 		return fmt.Errorf("object storage migrate scan not configured: %w", driver.SkipRetry)
 	}
 	if p.redis != nil {
-		ok, err := p.redis.SetNX(ctx, objectStorageScanLockKey, "1", objectStorageScanLockTTL).Result()
+		ok, err := p.redis.SetNX(ctx, ObjectStorageScanLockKey, "1", ObjectStorageScanLockTTL).Result()
 		if err != nil {
 			return err
 		}
@@ -61,32 +72,45 @@ func (p *ObjectStorageMigrateProcessor) HandleScan(ctx context.Context) error {
 			slog.Info("object storage migrate scan skipped: lock held")
 			return nil
 		}
-		defer func() { _ = p.redis.Del(context.Background(), objectStorageScanLockKey).Err() }()
 	}
 
-	var untilID string
-	for {
-		if ctx.Err() != nil {
-			return ctx.Err()
-		}
-		ids, err := p.fileRepo.ListStoredInternalIDs(untilID, objectStorageScanBatchSize)
-		if err != nil {
-			return err
-		}
-		if len(ids) == 0 {
-			break
-		}
-		for _, id := range ids {
-			if err := p.enqueueFile(id); err != nil {
-				return err
-			}
-		}
-		untilID = ids[len(ids)-1]
-		if len(ids) < objectStorageScanBatchSize {
-			break
+	releaseLock := func() {
+		if p.redis != nil {
+			_ = p.redis.Del(context.Background(), ObjectStorageScanLockKey).Err()
 		}
 	}
-	slog.Info("object storage migrate scan completed", "lastUntilId", untilID)
+
+	ids, err := p.fileRepo.ListStoredInternalIDs(untilID, p.scanBatchSize)
+	if err != nil {
+		releaseLock()
+		return err
+	}
+	for _, id := range ids {
+		if ctx.Err() != nil {
+			releaseLock()
+			return ctx.Err()
+		}
+		if err := p.enqueueFile(id); err != nil {
+			releaseLock()
+			return err
+		}
+	}
+
+	hasMore := len(ids) >= p.scanBatchSize
+	releaseLock()
+
+	if hasMore {
+		if p.enqueueScan == nil {
+			return fmt.Errorf("object storage migrate scan chain not configured: %w", driver.SkipRetry)
+		}
+		nextUntil := ids[len(ids)-1]
+		if err := p.enqueueScan(nextUntil); err != nil {
+			return err
+		}
+		slog.Info("object storage migrate scan chained next batch", "batchSize", len(ids), "nextUntilId", nextUntil)
+		return nil
+	}
+	slog.Info("object storage migrate scan completed", "lastBatch", len(ids))
 	return nil
 }
 
@@ -111,7 +135,11 @@ func (p *ObjectStorageMigrateProcessor) HandleFile(ctx context.Context, fileID s
 func (p *ObjectStorageMigrateProcessor) Handle(ctx context.Context, t driver.Task) error {
 	switch t.Type() {
 	case queue.TaskTypeObjectStorageMigrateScan:
-		return p.HandleScan(ctx)
+		scanPayload, err := queue.DecodeObjectStorageMigrateScanPayload(t.Payload())
+		if err != nil {
+			return fmt.Errorf("decode migrate scan payload: %w: %w", err, driver.SkipRetry)
+		}
+		return p.HandleScan(ctx, scanPayload.UntilID)
 	case queue.TaskTypeObjectStorageMigrateFile:
 		payload, err := queue.DecodeObjectStorageMigrateFilePayload(t.Payload())
 		if err != nil {

--- a/internal/queue/processors/object_storage_migrate.go
+++ b/internal/queue/processors/object_storage_migrate.go
@@ -16,6 +16,8 @@ import (
 )
 
 // ObjectStorageScanLockKey prevents concurrent migrateScan workers (#1476).
+// The lock is held only for the duration of one HandleScan batch (released via defer Del);
+// a restart between batches may start a second scan chain (harmless duplicate enqueue).
 const ObjectStorageScanLockKey = "mk:drive:objectStorage:migrateScan:lock"
 
 // ObjectStorageScanLockTTL bounds how long a crashed scan worker blocks rescheduling.

--- a/internal/queue/processors/object_storage_migrate.go
+++ b/internal/queue/processors/object_storage_migrate.go
@@ -1,0 +1,124 @@
+package processors
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log/slog"
+	"time"
+
+	"github.com/redis/go-redis/v9"
+
+	coredrive "github.com/shiroha-a/mk/internal/core/drive"
+	"github.com/shiroha-a/mk/internal/queue"
+	"github.com/shiroha-a/mk/internal/queue/driver"
+	"github.com/shiroha-a/mk/internal/repository"
+)
+
+const (
+	objectStorageScanLockKey   = "mk:drive:objectStorage:migrateScan:lock"
+	objectStorageScanLockTTL   = 6 * time.Hour
+	objectStorageScanBatchSize = 500
+)
+
+// ObjectStorageMigrateProcessor handles local→S3 drive migration tasks (#1476).
+type ObjectStorageMigrateProcessor struct {
+	migrator    *coredrive.Migrator
+	fileRepo    repository.DriveFileRepository
+	enqueueFile func(fileID string) error
+	redis       redis.UniversalClient
+}
+
+// ObjectStorageMigrateProcessorConfig wires dependencies for the processor.
+type ObjectStorageMigrateProcessorConfig struct {
+	Migrator    *coredrive.Migrator
+	FileRepo    repository.DriveFileRepository
+	EnqueueFile func(fileID string) error
+	Redis       redis.UniversalClient
+}
+
+// NewObjectStorageMigrateProcessor constructs the processor.
+func NewObjectStorageMigrateProcessor(cfg ObjectStorageMigrateProcessorConfig) *ObjectStorageMigrateProcessor {
+	return &ObjectStorageMigrateProcessor{
+		migrator:    cfg.Migrator,
+		fileRepo:    cfg.FileRepo,
+		enqueueFile: cfg.EnqueueFile,
+		redis:       cfg.Redis,
+	}
+}
+
+// HandleScan fans out migrateFile jobs for storedInternal rows.
+func (p *ObjectStorageMigrateProcessor) HandleScan(ctx context.Context) error {
+	if p.fileRepo == nil || p.enqueueFile == nil {
+		return fmt.Errorf("object storage migrate scan not configured: %w", driver.SkipRetry)
+	}
+	if p.redis != nil {
+		ok, err := p.redis.SetNX(ctx, objectStorageScanLockKey, "1", objectStorageScanLockTTL).Result()
+		if err != nil {
+			return err
+		}
+		if !ok {
+			slog.Info("object storage migrate scan skipped: lock held")
+			return nil
+		}
+		defer func() { _ = p.redis.Del(context.Background(), objectStorageScanLockKey).Err() }()
+	}
+
+	var untilID string
+	for {
+		if ctx.Err() != nil {
+			return ctx.Err()
+		}
+		ids, err := p.fileRepo.ListStoredInternalIDs(untilID, objectStorageScanBatchSize)
+		if err != nil {
+			return err
+		}
+		if len(ids) == 0 {
+			break
+		}
+		for _, id := range ids {
+			if err := p.enqueueFile(id); err != nil {
+				return err
+			}
+		}
+		untilID = ids[len(ids)-1]
+		if len(ids) < objectStorageScanBatchSize {
+			break
+		}
+	}
+	slog.Info("object storage migrate scan completed", "lastUntilId", untilID)
+	return nil
+}
+
+// HandleFile migrates one drive_file row.
+func (p *ObjectStorageMigrateProcessor) HandleFile(ctx context.Context, fileID string) error {
+	if p.migrator == nil {
+		return fmt.Errorf("object storage migrator not configured: %w", driver.SkipRetry)
+	}
+	if fileID == "" {
+		return fmt.Errorf("missing fileId: %w", driver.SkipRetry)
+	}
+	if err := p.migrator.MigrateFile(ctx, fileID); err != nil {
+		if errors.Is(err, coredrive.ErrMigrationNotConfigured) {
+			return fmt.Errorf("%w: %w", err, driver.SkipRetry)
+		}
+		return err
+	}
+	return nil
+}
+
+// Handle dispatches objectStorage migration tasks by type.
+func (p *ObjectStorageMigrateProcessor) Handle(ctx context.Context, t driver.Task) error {
+	switch t.Type() {
+	case queue.TaskTypeObjectStorageMigrateScan:
+		return p.HandleScan(ctx)
+	case queue.TaskTypeObjectStorageMigrateFile:
+		payload, err := queue.DecodeObjectStorageMigrateFilePayload(t.Payload())
+		if err != nil {
+			return fmt.Errorf("decode migrate file payload: %w: %w", err, driver.SkipRetry)
+		}
+		return p.HandleFile(ctx, payload.FileID)
+	default:
+		return fmt.Errorf("unknown task type %q: %w", t.Type(), driver.SkipRetry)
+	}
+}

--- a/internal/queue/processors/object_storage_migrate.go
+++ b/internal/queue/processors/object_storage_migrate.go
@@ -72,32 +72,25 @@ func (p *ObjectStorageMigrateProcessor) HandleScan(ctx context.Context, untilID 
 			slog.Info("object storage migrate scan skipped: lock held")
 			return nil
 		}
-	}
-
-	releaseLock := func() {
-		if p.redis != nil {
+		defer func() {
 			_ = p.redis.Del(context.Background(), ObjectStorageScanLockKey).Err()
-		}
+		}()
 	}
 
 	ids, err := p.fileRepo.ListStoredInternalIDs(untilID, p.scanBatchSize)
 	if err != nil {
-		releaseLock()
 		return err
 	}
 	for _, id := range ids {
 		if ctx.Err() != nil {
-			releaseLock()
 			return ctx.Err()
 		}
 		if err := p.enqueueFile(id); err != nil {
-			releaseLock()
 			return err
 		}
 	}
 
 	hasMore := len(ids) >= p.scanBatchSize
-	releaseLock()
 
 	if hasMore {
 		if p.enqueueScan == nil {

--- a/internal/queue/processors/object_storage_migrate_test.go
+++ b/internal/queue/processors/object_storage_migrate_test.go
@@ -20,6 +20,7 @@ import (
 )
 
 func TestObjectStorageMigrateProcessor_HandleFile_NotConfigured(t *testing.T) {
+	t.Parallel()
 	p := processors.NewObjectStorageMigrateProcessor(processors.ObjectStorageMigrateProcessorConfig{})
 	task := queue.NewObjectStorageMigrateFileTask(queue.ObjectStorageMigrateFilePayload{FileID: "f1"})
 	err := p.Handle(context.Background(), task)
@@ -28,6 +29,7 @@ func TestObjectStorageMigrateProcessor_HandleFile_NotConfigured(t *testing.T) {
 }
 
 func TestObjectStorageMigrateProcessor_HandleFile_MissingID(t *testing.T) {
+	t.Parallel()
 	p := processors.NewObjectStorageMigrateProcessor(processors.ObjectStorageMigrateProcessorConfig{
 		Migrator: coredrive.NewMigrator(nil, nil, nil, config.DriveLocalToObjectStorageConfig{}, "https://example.com/files"),
 	})
@@ -38,6 +40,7 @@ func TestObjectStorageMigrateProcessor_HandleFile_MissingID(t *testing.T) {
 }
 
 func TestObjectStorageMigrateProcessor_HandleScan_Enqueues(t *testing.T) {
+	t.Parallel()
 	key := "abc"
 	repo := testutil.NewMockDriveFileRepository()
 	repo.Files["a"] = &model.DriveFile{
@@ -61,6 +64,7 @@ func TestObjectStorageMigrateProcessor_HandleScan_Enqueues(t *testing.T) {
 }
 
 func TestObjectStorageMigrateProcessor_HandleFile_MigrationNotConfigured(t *testing.T) {
+	t.Parallel()
 	meta := testutil.NewMockMetaRepository()
 	meta.Meta = &model.Meta{UseObjectStorage: false}
 	fileRepo := testutil.NewMockDriveFileRepository()
@@ -82,6 +86,7 @@ func TestObjectStorageMigrateProcessor_HandleFile_MigrationNotConfigured(t *test
 }
 
 func TestObjectStorageMigrateProcessor_HandleScan_NotConfigured(t *testing.T) {
+	t.Parallel()
 	p := processors.NewObjectStorageMigrateProcessor(processors.ObjectStorageMigrateProcessorConfig{})
 	err := p.Handle(context.Background(), queue.NewObjectStorageMigrateScanTask(queue.ObjectStorageMigrateScanPayload{}))
 	require.Error(t, err)
@@ -89,6 +94,7 @@ func TestObjectStorageMigrateProcessor_HandleScan_NotConfigured(t *testing.T) {
 }
 
 func TestObjectStorageMigrateProcessor_Handle_UnknownType(t *testing.T) {
+	t.Parallel()
 	p := processors.NewObjectStorageMigrateProcessor(processors.ObjectStorageMigrateProcessorConfig{})
 	err := p.Handle(context.Background(), driver.RawTask{TypeName: "objectStorage:unknown", Body: []byte("{}")})
 	require.Error(t, err)
@@ -96,6 +102,7 @@ func TestObjectStorageMigrateProcessor_Handle_UnknownType(t *testing.T) {
 }
 
 func TestObjectStorageMigrateProcessor_HandleFile_BadPayload(t *testing.T) {
+	t.Parallel()
 	p := processors.NewObjectStorageMigrateProcessor(processors.ObjectStorageMigrateProcessorConfig{
 		Migrator: coredrive.NewMigrator(nil, nil, nil, config.DriveLocalToObjectStorageConfig{}, "https://example.com/files"),
 	})
@@ -105,6 +112,7 @@ func TestObjectStorageMigrateProcessor_HandleFile_BadPayload(t *testing.T) {
 }
 
 func TestObjectStorageMigrateProcessor_HandleScan_LockHeld(t *testing.T) {
+	t.Parallel()
 	mr, rdb := newMiniredisClient(t)
 	require.NoError(t, mr.Set(processors.ObjectStorageScanLockKey, "1"))
 
@@ -121,6 +129,7 @@ func TestObjectStorageMigrateProcessor_HandleScan_LockHeld(t *testing.T) {
 }
 
 func TestObjectStorageMigrateProcessor_HandleScan_EmptyRepo(t *testing.T) {
+	t.Parallel()
 	p := processors.NewObjectStorageMigrateProcessor(processors.ObjectStorageMigrateProcessorConfig{
 		FileRepo: testutil.NewMockDriveFileRepository(),
 		EnqueueFile: func(string) error {
@@ -132,6 +141,7 @@ func TestObjectStorageMigrateProcessor_HandleScan_EmptyRepo(t *testing.T) {
 }
 
 func TestObjectStorageMigrateProcessor_HandleScan_ListError(t *testing.T) {
+	t.Parallel()
 	repo := &listErrDriveRepo{
 		MockDriveFileRepository: testutil.NewMockDriveFileRepository(),
 		listErr:                 errors.New("list failed"),
@@ -145,6 +155,7 @@ func TestObjectStorageMigrateProcessor_HandleScan_ListError(t *testing.T) {
 }
 
 func TestObjectStorageMigrateProcessor_HandleScan_EnqueueError(t *testing.T) {
+	t.Parallel()
 	key := "k"
 	repo := testutil.NewMockDriveFileRepository()
 	repo.Files["a"] = &model.DriveFile{
@@ -162,6 +173,7 @@ func TestObjectStorageMigrateProcessor_HandleScan_EnqueueError(t *testing.T) {
 }
 
 func TestObjectStorageMigrateProcessor_HandleScan_ContextCanceled(t *testing.T) {
+	t.Parallel()
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel()
 	key := "k"
@@ -181,6 +193,7 @@ func TestObjectStorageMigrateProcessor_HandleScan_ContextCanceled(t *testing.T) 
 }
 
 func TestObjectStorageMigrateProcessor_HandleScan_MultiPage(t *testing.T) {
+	t.Parallel()
 	repo := testutil.NewMockDriveFileRepository()
 	for i := 1; i <= 501; i++ {
 		id := fmt.Sprintf("f%03d", i)
@@ -208,6 +221,7 @@ func TestObjectStorageMigrateProcessor_HandleScan_MultiPage(t *testing.T) {
 }
 
 func TestObjectStorageMigrateProcessor_HandleScan_ChainsNextBatch(t *testing.T) {
+	t.Parallel()
 	repo := testutil.NewMockDriveFileRepository()
 	for i := 0; i < 3; i++ {
 		id := fmt.Sprintf("f%d", i)
@@ -243,6 +257,7 @@ func TestObjectStorageMigrateProcessor_HandleScan_ChainsNextBatch(t *testing.T) 
 }
 
 func TestObjectStorageMigrateProcessor_HandleFile_Success(t *testing.T) {
+	t.Parallel()
 	bucket := "b"
 	meta := testutil.NewMockMetaRepository()
 	meta.Meta = &model.Meta{UseObjectStorage: true, ObjectStorageBucket: &bucket}
@@ -255,6 +270,7 @@ func TestObjectStorageMigrateProcessor_HandleFile_Success(t *testing.T) {
 }
 
 func TestObjectStorageMigrateProcessor_HandleScan_WithRedisLock(t *testing.T) {
+	t.Parallel()
 	_, rdb := newMiniredisClient(t)
 
 	key := "k"

--- a/internal/queue/processors/object_storage_migrate_test.go
+++ b/internal/queue/processors/object_storage_migrate_test.go
@@ -5,6 +5,8 @@ import (
 	"errors"
 	"testing"
 
+	"github.com/alicebob/miniredis/v2"
+	goredis "github.com/redis/go-redis/v9"
 	"github.com/shiroha-a/mk/internal/config"
 	coredrive "github.com/shiroha-a/mk/internal/core/drive"
 	"github.com/shiroha-a/mk/internal/model"
@@ -76,4 +78,78 @@ func TestObjectStorageMigrateProcessor_HandleFile_MigrationNotConfigured(t *test
 	require.Error(t, err)
 	require.ErrorIs(t, err, driver.SkipRetry)
 	require.True(t, errors.Is(err, coredrive.ErrMigrationNotConfigured))
+}
+
+func TestObjectStorageMigrateProcessor_HandleScan_NotConfigured(t *testing.T) {
+	p := processors.NewObjectStorageMigrateProcessor(processors.ObjectStorageMigrateProcessorConfig{})
+	err := p.Handle(context.Background(), queue.NewObjectStorageMigrateScanTask())
+	require.Error(t, err)
+	require.ErrorIs(t, err, driver.SkipRetry)
+}
+
+func TestObjectStorageMigrateProcessor_Handle_UnknownType(t *testing.T) {
+	p := processors.NewObjectStorageMigrateProcessor(processors.ObjectStorageMigrateProcessorConfig{})
+	err := p.Handle(context.Background(), driver.RawTask{TypeName: "objectStorage:unknown", Body: []byte("{}")})
+	require.Error(t, err)
+	require.ErrorIs(t, err, driver.SkipRetry)
+}
+
+func TestObjectStorageMigrateProcessor_HandleFile_BadPayload(t *testing.T) {
+	p := processors.NewObjectStorageMigrateProcessor(processors.ObjectStorageMigrateProcessorConfig{
+		Migrator: coredrive.NewMigrator(nil, nil, nil, config.DriveLocalToObjectStorageConfig{}, "https://example.com/files"),
+	})
+	err := p.Handle(context.Background(), driver.RawTask{TypeName: queue.TaskTypeObjectStorageMigrateFile, Body: []byte("not-json")})
+	require.Error(t, err)
+	require.ErrorIs(t, err, driver.SkipRetry)
+}
+
+func TestObjectStorageMigrateProcessor_HandleScan_LockHeld(t *testing.T) {
+	mr, rdb := newMiniredisClient(t)
+	require.NoError(t, mr.Set("mk:drive:objectStorage:migrateScan:lock", "1"))
+
+	repo := testutil.NewMockDriveFileRepository()
+	p := processors.NewObjectStorageMigrateProcessor(processors.ObjectStorageMigrateProcessorConfig{
+		FileRepo: repo,
+		EnqueueFile: func(string) error {
+			t.Fatal("enqueue should not run when lock held")
+			return nil
+		},
+		Redis: rdb,
+	})
+	require.NoError(t, p.Handle(context.Background(), queue.NewObjectStorageMigrateScanTask()))
+}
+
+func TestObjectStorageMigrateProcessor_HandleScan_WithRedisLock(t *testing.T) {
+	_, rdb := newMiniredisClient(t)
+
+	key := "k"
+	repo := testutil.NewMockDriveFileRepository()
+	repo.Files["a"] = &model.DriveFile{
+		ID:             "a",
+		StoredInternal: true,
+		URL:            "https://example.com/files/k",
+		AccessKey:      &key,
+		Properties:     datatypes.JSON([]byte("{}")),
+	}
+	var enqueued []string
+	p := processors.NewObjectStorageMigrateProcessor(processors.ObjectStorageMigrateProcessorConfig{
+		FileRepo: repo,
+		EnqueueFile: func(fileID string) error {
+			enqueued = append(enqueued, fileID)
+			return nil
+		},
+		Redis: rdb,
+	})
+	require.NoError(t, p.Handle(context.Background(), queue.NewObjectStorageMigrateScanTask()))
+	require.Contains(t, enqueued, "a")
+}
+
+func newMiniredisClient(t *testing.T) (*miniredis.Miniredis, goredis.UniversalClient) {
+	t.Helper()
+	mr, err := miniredis.Run()
+	require.NoError(t, err)
+	t.Cleanup(mr.Close)
+	rdb := goredis.NewClient(&goredis.Options{Addr: mr.Addr()})
+	t.Cleanup(func() { _ = rdb.Close() })
+	return mr, rdb
 }

--- a/internal/queue/processors/object_storage_migrate_test.go
+++ b/internal/queue/processors/object_storage_migrate_test.go
@@ -3,6 +3,7 @@ package processors_test
 import (
 	"context"
 	"errors"
+	"fmt"
 	"testing"
 
 	"github.com/alicebob/miniredis/v2"
@@ -119,6 +120,95 @@ func TestObjectStorageMigrateProcessor_HandleScan_LockHeld(t *testing.T) {
 	require.NoError(t, p.Handle(context.Background(), queue.NewObjectStorageMigrateScanTask()))
 }
 
+func TestObjectStorageMigrateProcessor_HandleScan_EmptyRepo(t *testing.T) {
+	p := processors.NewObjectStorageMigrateProcessor(processors.ObjectStorageMigrateProcessorConfig{
+		FileRepo: testutil.NewMockDriveFileRepository(),
+		EnqueueFile: func(string) error {
+			t.Fatal("enqueue should not run for empty repo")
+			return nil
+		},
+	})
+	require.NoError(t, p.Handle(context.Background(), queue.NewObjectStorageMigrateScanTask()))
+}
+
+func TestObjectStorageMigrateProcessor_HandleScan_ListError(t *testing.T) {
+	repo := &listErrDriveRepo{
+		MockDriveFileRepository: testutil.NewMockDriveFileRepository(),
+		listErr:                 errors.New("list failed"),
+	}
+	p := processors.NewObjectStorageMigrateProcessor(processors.ObjectStorageMigrateProcessorConfig{
+		FileRepo:    repo,
+		EnqueueFile: func(string) error { return nil },
+	})
+	err := p.Handle(context.Background(), queue.NewObjectStorageMigrateScanTask())
+	require.ErrorContains(t, err, "list failed")
+}
+
+func TestObjectStorageMigrateProcessor_HandleScan_EnqueueError(t *testing.T) {
+	key := "k"
+	repo := testutil.NewMockDriveFileRepository()
+	repo.Files["a"] = &model.DriveFile{
+		ID:             "a",
+		StoredInternal: true,
+		AccessKey:      &key,
+		Properties:     datatypes.JSON([]byte("{}")),
+	}
+	p := processors.NewObjectStorageMigrateProcessor(processors.ObjectStorageMigrateProcessorConfig{
+		FileRepo: repo,
+		EnqueueFile: func(string) error { return errors.New("enqueue failed") },
+	})
+	err := p.Handle(context.Background(), queue.NewObjectStorageMigrateScanTask())
+	require.ErrorContains(t, err, "enqueue failed")
+}
+
+func TestObjectStorageMigrateProcessor_HandleScan_ContextCanceled(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	p := processors.NewObjectStorageMigrateProcessor(processors.ObjectStorageMigrateProcessorConfig{
+		FileRepo:    testutil.NewMockDriveFileRepository(),
+		EnqueueFile: func(string) error { return nil },
+	})
+	err := p.Handle(ctx, queue.NewObjectStorageMigrateScanTask())
+	require.ErrorIs(t, err, context.Canceled)
+}
+
+func TestObjectStorageMigrateProcessor_HandleScan_MultiPage(t *testing.T) {
+	repo := testutil.NewMockDriveFileRepository()
+	for i := 1; i <= 501; i++ {
+		id := fmt.Sprintf("f%03d", i)
+		key := "k" + id
+		repo.Files[id] = &model.DriveFile{
+			ID:             id,
+			StoredInternal: true,
+			URL:            "https://example.com/files/" + key,
+			AccessKey:      &key,
+			Properties:     datatypes.JSON([]byte("{}")),
+		}
+	}
+	var enqueued int
+	p := processors.NewObjectStorageMigrateProcessor(processors.ObjectStorageMigrateProcessorConfig{
+		FileRepo: repo,
+		EnqueueFile: func(string) error {
+			enqueued++
+			return nil
+		},
+	})
+	require.NoError(t, p.Handle(context.Background(), queue.NewObjectStorageMigrateScanTask()))
+	require.Equal(t, 501, enqueued)
+}
+
+func TestObjectStorageMigrateProcessor_HandleFile_Success(t *testing.T) {
+	bucket := "b"
+	meta := testutil.NewMockMetaRepository()
+	meta.Meta = &model.Meta{UseObjectStorage: true, ObjectStorageBucket: &bucket}
+	fileRepo := testutil.NewMockDriveFileRepository()
+	fileRepo.Files["f1"] = &model.DriveFile{ID: "f1", StoredInternal: false}
+	m := coredrive.NewMigrator(meta, fileRepo, nil, config.DriveLocalToObjectStorageConfig{}, "https://example.com/files")
+	p := processors.NewObjectStorageMigrateProcessor(processors.ObjectStorageMigrateProcessorConfig{Migrator: m})
+	task := queue.NewObjectStorageMigrateFileTask(queue.ObjectStorageMigrateFilePayload{FileID: "f1"})
+	require.NoError(t, p.Handle(context.Background(), task))
+}
+
 func TestObjectStorageMigrateProcessor_HandleScan_WithRedisLock(t *testing.T) {
 	_, rdb := newMiniredisClient(t)
 
@@ -142,6 +232,15 @@ func TestObjectStorageMigrateProcessor_HandleScan_WithRedisLock(t *testing.T) {
 	})
 	require.NoError(t, p.Handle(context.Background(), queue.NewObjectStorageMigrateScanTask()))
 	require.Contains(t, enqueued, "a")
+}
+
+type listErrDriveRepo struct {
+	*testutil.MockDriveFileRepository
+	listErr error
+}
+
+func (r *listErrDriveRepo) ListStoredInternalIDs(string, int) ([]string, error) {
+	return nil, r.listErr
 }
 
 func newMiniredisClient(t *testing.T) (*miniredis.Miniredis, goredis.UniversalClient) {

--- a/internal/queue/processors/object_storage_migrate_test.go
+++ b/internal/queue/processors/object_storage_migrate_test.go
@@ -1,0 +1,79 @@
+package processors_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/shiroha-a/mk/internal/config"
+	coredrive "github.com/shiroha-a/mk/internal/core/drive"
+	"github.com/shiroha-a/mk/internal/model"
+	"github.com/shiroha-a/mk/internal/queue"
+	"github.com/shiroha-a/mk/internal/queue/driver"
+	"github.com/shiroha-a/mk/internal/queue/processors"
+	"github.com/shiroha-a/mk/internal/testutil"
+	"github.com/stretchr/testify/require"
+	"gorm.io/datatypes"
+)
+
+func TestObjectStorageMigrateProcessor_HandleFile_NotConfigured(t *testing.T) {
+	p := processors.NewObjectStorageMigrateProcessor(processors.ObjectStorageMigrateProcessorConfig{})
+	task := queue.NewObjectStorageMigrateFileTask(queue.ObjectStorageMigrateFilePayload{FileID: "f1"})
+	err := p.Handle(context.Background(), task)
+	require.Error(t, err)
+	require.ErrorIs(t, err, driver.SkipRetry)
+}
+
+func TestObjectStorageMigrateProcessor_HandleFile_MissingID(t *testing.T) {
+	p := processors.NewObjectStorageMigrateProcessor(processors.ObjectStorageMigrateProcessorConfig{
+		Migrator: coredrive.NewMigrator(nil, nil, nil, config.DriveLocalToObjectStorageConfig{}, "https://example.com/files"),
+	})
+	task := queue.NewObjectStorageMigrateFileTask(queue.ObjectStorageMigrateFilePayload{})
+	err := p.Handle(context.Background(), task)
+	require.Error(t, err)
+	require.ErrorIs(t, err, driver.SkipRetry)
+}
+
+func TestObjectStorageMigrateProcessor_HandleScan_Enqueues(t *testing.T) {
+	key := "abc"
+	repo := testutil.NewMockDriveFileRepository()
+	repo.Files["a"] = &model.DriveFile{
+		ID:             "a",
+		StoredInternal: true,
+		URL:            "https://example.com/files/" + key,
+		AccessKey:      &key,
+		Properties:     datatypes.JSON([]byte("{}")),
+	}
+	var enqueued []string
+	p := processors.NewObjectStorageMigrateProcessor(processors.ObjectStorageMigrateProcessorConfig{
+		FileRepo: repo,
+		EnqueueFile: func(fileID string) error {
+			enqueued = append(enqueued, fileID)
+			return nil
+		},
+	})
+	err := p.Handle(context.Background(), queue.NewObjectStorageMigrateScanTask())
+	require.NoError(t, err)
+	require.Contains(t, enqueued, "a")
+}
+
+func TestObjectStorageMigrateProcessor_HandleFile_MigrationNotConfigured(t *testing.T) {
+	meta := testutil.NewMockMetaRepository()
+	meta.Meta = &model.Meta{UseObjectStorage: false}
+	fileRepo := testutil.NewMockDriveFileRepository()
+	key := "k"
+	fileRepo.Files["f1"] = &model.DriveFile{
+		ID:             "f1",
+		StoredInternal: true,
+		URL:            "https://example.com/files/k",
+		AccessKey:      &key,
+		Properties:     datatypes.JSON([]byte("{}")),
+	}
+	m := coredrive.NewMigrator(meta, fileRepo, nil, config.DriveLocalToObjectStorageConfig{}, "https://example.com/files")
+	p := processors.NewObjectStorageMigrateProcessor(processors.ObjectStorageMigrateProcessorConfig{Migrator: m})
+	task := queue.NewObjectStorageMigrateFileTask(queue.ObjectStorageMigrateFilePayload{FileID: "f1"})
+	err := p.Handle(context.Background(), task)
+	require.Error(t, err)
+	require.ErrorIs(t, err, driver.SkipRetry)
+	require.True(t, errors.Is(err, coredrive.ErrMigrationNotConfigured))
+}

--- a/internal/queue/processors/object_storage_migrate_test.go
+++ b/internal/queue/processors/object_storage_migrate_test.go
@@ -55,7 +55,7 @@ func TestObjectStorageMigrateProcessor_HandleScan_Enqueues(t *testing.T) {
 			return nil
 		},
 	})
-	err := p.Handle(context.Background(), queue.NewObjectStorageMigrateScanTask())
+	err := p.Handle(context.Background(), queue.NewObjectStorageMigrateScanTask(queue.ObjectStorageMigrateScanPayload{}))
 	require.NoError(t, err)
 	require.Contains(t, enqueued, "a")
 }
@@ -83,7 +83,7 @@ func TestObjectStorageMigrateProcessor_HandleFile_MigrationNotConfigured(t *test
 
 func TestObjectStorageMigrateProcessor_HandleScan_NotConfigured(t *testing.T) {
 	p := processors.NewObjectStorageMigrateProcessor(processors.ObjectStorageMigrateProcessorConfig{})
-	err := p.Handle(context.Background(), queue.NewObjectStorageMigrateScanTask())
+	err := p.Handle(context.Background(), queue.NewObjectStorageMigrateScanTask(queue.ObjectStorageMigrateScanPayload{}))
 	require.Error(t, err)
 	require.ErrorIs(t, err, driver.SkipRetry)
 }
@@ -106,7 +106,7 @@ func TestObjectStorageMigrateProcessor_HandleFile_BadPayload(t *testing.T) {
 
 func TestObjectStorageMigrateProcessor_HandleScan_LockHeld(t *testing.T) {
 	mr, rdb := newMiniredisClient(t)
-	require.NoError(t, mr.Set("mk:drive:objectStorage:migrateScan:lock", "1"))
+	require.NoError(t, mr.Set(processors.ObjectStorageScanLockKey, "1"))
 
 	repo := testutil.NewMockDriveFileRepository()
 	p := processors.NewObjectStorageMigrateProcessor(processors.ObjectStorageMigrateProcessorConfig{
@@ -117,7 +117,7 @@ func TestObjectStorageMigrateProcessor_HandleScan_LockHeld(t *testing.T) {
 		},
 		Redis: rdb,
 	})
-	require.NoError(t, p.Handle(context.Background(), queue.NewObjectStorageMigrateScanTask()))
+	require.NoError(t, p.Handle(context.Background(), queue.NewObjectStorageMigrateScanTask(queue.ObjectStorageMigrateScanPayload{})))
 }
 
 func TestObjectStorageMigrateProcessor_HandleScan_EmptyRepo(t *testing.T) {
@@ -128,7 +128,7 @@ func TestObjectStorageMigrateProcessor_HandleScan_EmptyRepo(t *testing.T) {
 			return nil
 		},
 	})
-	require.NoError(t, p.Handle(context.Background(), queue.NewObjectStorageMigrateScanTask()))
+	require.NoError(t, p.Handle(context.Background(), queue.NewObjectStorageMigrateScanTask(queue.ObjectStorageMigrateScanPayload{})))
 }
 
 func TestObjectStorageMigrateProcessor_HandleScan_ListError(t *testing.T) {
@@ -140,7 +140,7 @@ func TestObjectStorageMigrateProcessor_HandleScan_ListError(t *testing.T) {
 		FileRepo:    repo,
 		EnqueueFile: func(string) error { return nil },
 	})
-	err := p.Handle(context.Background(), queue.NewObjectStorageMigrateScanTask())
+	err := p.Handle(context.Background(), queue.NewObjectStorageMigrateScanTask(queue.ObjectStorageMigrateScanPayload{}))
 	require.ErrorContains(t, err, "list failed")
 }
 
@@ -154,21 +154,29 @@ func TestObjectStorageMigrateProcessor_HandleScan_EnqueueError(t *testing.T) {
 		Properties:     datatypes.JSON([]byte("{}")),
 	}
 	p := processors.NewObjectStorageMigrateProcessor(processors.ObjectStorageMigrateProcessorConfig{
-		FileRepo: repo,
+		FileRepo:    repo,
 		EnqueueFile: func(string) error { return errors.New("enqueue failed") },
 	})
-	err := p.Handle(context.Background(), queue.NewObjectStorageMigrateScanTask())
+	err := p.Handle(context.Background(), queue.NewObjectStorageMigrateScanTask(queue.ObjectStorageMigrateScanPayload{}))
 	require.ErrorContains(t, err, "enqueue failed")
 }
 
 func TestObjectStorageMigrateProcessor_HandleScan_ContextCanceled(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel()
+	key := "k"
+	repo := testutil.NewMockDriveFileRepository()
+	repo.Files["a"] = &model.DriveFile{
+		ID:             "a",
+		StoredInternal: true,
+		AccessKey:      &key,
+		Properties:     datatypes.JSON([]byte("{}")),
+	}
 	p := processors.NewObjectStorageMigrateProcessor(processors.ObjectStorageMigrateProcessorConfig{
-		FileRepo:    testutil.NewMockDriveFileRepository(),
+		FileRepo:    repo,
 		EnqueueFile: func(string) error { return nil },
 	})
-	err := p.Handle(ctx, queue.NewObjectStorageMigrateScanTask())
+	err := p.Handle(ctx, queue.NewObjectStorageMigrateScanTask(queue.ObjectStorageMigrateScanPayload{}))
 	require.ErrorIs(t, err, context.Canceled)
 }
 
@@ -187,14 +195,51 @@ func TestObjectStorageMigrateProcessor_HandleScan_MultiPage(t *testing.T) {
 	}
 	var enqueued int
 	p := processors.NewObjectStorageMigrateProcessor(processors.ObjectStorageMigrateProcessorConfig{
-		FileRepo: repo,
+		FileRepo:      repo,
+		ScanBatchSize: 600,
 		EnqueueFile: func(string) error {
 			enqueued++
 			return nil
 		},
+		EnqueueScan: func(string) error { return nil },
 	})
-	require.NoError(t, p.Handle(context.Background(), queue.NewObjectStorageMigrateScanTask()))
+	require.NoError(t, p.Handle(context.Background(), queue.NewObjectStorageMigrateScanTask(queue.ObjectStorageMigrateScanPayload{})))
 	require.Equal(t, 501, enqueued)
+}
+
+func TestObjectStorageMigrateProcessor_HandleScan_ChainsNextBatch(t *testing.T) {
+	repo := testutil.NewMockDriveFileRepository()
+	for i := 0; i < 3; i++ {
+		id := fmt.Sprintf("f%d", i)
+		key := fmt.Sprintf("k%d", i)
+		repo.Files[id] = &model.DriveFile{
+			ID:             id,
+			StoredInternal: true,
+			URL:            "https://example.com/files/" + key,
+			AccessKey:      &key,
+			Properties:     datatypes.JSON([]byte("{}")),
+		}
+	}
+	var enqueuedFiles []string
+	var scanJobs int
+	var chainedUntil string
+	p := processors.NewObjectStorageMigrateProcessor(processors.ObjectStorageMigrateProcessorConfig{
+		FileRepo:      repo,
+		ScanBatchSize: 2,
+		EnqueueFile: func(fileID string) error {
+			enqueuedFiles = append(enqueuedFiles, fileID)
+			return nil
+		},
+		EnqueueScan: func(untilID string) error {
+			scanJobs++
+			chainedUntil = untilID
+			return nil
+		},
+	})
+	require.NoError(t, p.Handle(context.Background(), queue.NewObjectStorageMigrateScanTask(queue.ObjectStorageMigrateScanPayload{})))
+	require.Len(t, enqueuedFiles, 2)
+	require.Equal(t, 1, scanJobs)
+	require.Equal(t, "f1", chainedUntil)
 }
 
 func TestObjectStorageMigrateProcessor_HandleFile_Success(t *testing.T) {
@@ -230,7 +275,7 @@ func TestObjectStorageMigrateProcessor_HandleScan_WithRedisLock(t *testing.T) {
 		},
 		Redis: rdb,
 	})
-	require.NoError(t, p.Handle(context.Background(), queue.NewObjectStorageMigrateScanTask()))
+	require.NoError(t, p.Handle(context.Background(), queue.NewObjectStorageMigrateScanTask(queue.ObjectStorageMigrateScanPayload{})))
 	require.Contains(t, enqueued, "a")
 }
 

--- a/internal/queue/queue.go
+++ b/internal/queue/queue.go
@@ -49,8 +49,10 @@ const WebhookQueueName = "webhook"
 // drop-in compat.
 const InboxQueueName = "inbox"
 
-// ObjectStorageQueueName migrates locally stored drive files to S3 (#1476).
-// Name matches Misskey TS BullMQ queue for drop-in admin job-queue tabs.
+// ObjectStorageQueueName holds local→S3 drive migration tasks (#1476).
+// The queue name matches Misskey TS BullMQ "objectStorage" for drop-in
+// admin job-queue tab compat; upstream TS uses this queue for file deletion
+// and remote cleanup, while mk-go reuses the name for migration work.
 const ObjectStorageQueueName = "objectStorage"
 
 // Enqueuer abstracts task enqueueing for callers (DeliverService,
@@ -456,17 +458,26 @@ func (c *Client) EnqueueObjectStorageMigrateScan() error {
 // EnqueueObjectStorageMigrateScanFrom continues a chained scan from untilID.
 func (c *Client) EnqueueObjectStorageMigrateScanFrom(untilID string) error {
 	body := mustMarshal(ObjectStorageMigrateScanPayload{UntilID: untilID})
-	base := []driver.EnqueueOption{driver.WithQueue(ObjectStorageQueueName)}
-	base = append(base, c.retentionOpts(ObjectStorageQueueName)...)
-	return c.inner.Enqueue(context.Background(), TaskTypeObjectStorageMigrateScan, body, base...)
+	return c.enqueueObjectStorage(context.Background(), TaskTypeObjectStorageMigrateScan, body)
 }
 
 // EnqueueObjectStorageMigrateFile enqueues migration for one drive_file row.
 func (c *Client) EnqueueObjectStorageMigrateFile(fileID string) error {
 	body := mustMarshal(ObjectStorageMigrateFilePayload{FileID: fileID})
+	return c.enqueueObjectStorage(context.Background(), TaskTypeObjectStorageMigrateFile, body)
+}
+
+// enqueueObjectStorage applies objectStorage queue Policy (MaxAttempts,
+// backoff, retention) like EnqueueInbox (#1476 review: mkq default was no retry).
+func (c *Client) enqueueObjectStorage(ctx context.Context, taskType string, body []byte) error {
+	p := c.policyFor(ObjectStorageQueueName)
 	base := []driver.EnqueueOption{driver.WithQueue(ObjectStorageQueueName)}
-	base = append(base, c.retentionOpts(ObjectStorageQueueName)...)
-	return c.inner.Enqueue(context.Background(), TaskTypeObjectStorageMigrateFile, body, base...)
+	if p.MaxAttempts > 0 {
+		base = append(base, driver.WithMaxRetry(p.MaxAttempts-1))
+	}
+	base = append(base, backoffOptFromPolicy(p))
+	base = append(base, retentionOptsFromPolicy(p)...)
+	return c.inner.Enqueue(ctx, taskType, body, base...)
 }
 
 // Close releases the underlying client connection.

--- a/internal/queue/queue.go
+++ b/internal/queue/queue.go
@@ -49,6 +49,10 @@ const WebhookQueueName = "webhook"
 // drop-in compat.
 const InboxQueueName = "inbox"
 
+// ObjectStorageQueueName migrates locally stored drive files to S3 (#1476).
+// Name matches Misskey TS BullMQ queue for drop-in admin job-queue tabs.
+const ObjectStorageQueueName = "objectStorage"
+
 // Enqueuer abstracts task enqueueing for callers (DeliverService,
 // admin handlers, etc.). The interface is driver-neutral so callers
 // can be unit-tested with mocks.
@@ -441,6 +445,22 @@ func (c *Client) EnqueueUnfollow(payload UnfollowPayload) error {
 	}
 	base = append(base, c.retentionOpts(QueueName)...)
 	return c.inner.Enqueue(context.Background(), TaskTypeUnfollow, body, base...)
+}
+
+// EnqueueObjectStorageMigrateScan starts a coordinator that fans out
+// per-file migration jobs (#1476).
+func (c *Client) EnqueueObjectStorageMigrateScan() error {
+	base := []driver.EnqueueOption{driver.WithQueue(ObjectStorageQueueName)}
+	base = append(base, c.retentionOpts(ObjectStorageQueueName)...)
+	return c.inner.Enqueue(context.Background(), TaskTypeObjectStorageMigrateScan, []byte("{}"), base...)
+}
+
+// EnqueueObjectStorageMigrateFile enqueues migration for one drive_file row.
+func (c *Client) EnqueueObjectStorageMigrateFile(fileID string) error {
+	body := mustMarshal(ObjectStorageMigrateFilePayload{FileID: fileID})
+	base := []driver.EnqueueOption{driver.WithQueue(ObjectStorageQueueName)}
+	base = append(base, c.retentionOpts(ObjectStorageQueueName)...)
+	return c.inner.Enqueue(context.Background(), TaskTypeObjectStorageMigrateFile, body, base...)
 }
 
 // Close releases the underlying client connection.

--- a/internal/queue/queue.go
+++ b/internal/queue/queue.go
@@ -450,9 +450,15 @@ func (c *Client) EnqueueUnfollow(payload UnfollowPayload) error {
 // EnqueueObjectStorageMigrateScan starts a coordinator that fans out
 // per-file migration jobs (#1476).
 func (c *Client) EnqueueObjectStorageMigrateScan() error {
+	return c.EnqueueObjectStorageMigrateScanFrom("")
+}
+
+// EnqueueObjectStorageMigrateScanFrom continues a chained scan from untilID.
+func (c *Client) EnqueueObjectStorageMigrateScanFrom(untilID string) error {
+	body := mustMarshal(ObjectStorageMigrateScanPayload{UntilID: untilID})
 	base := []driver.EnqueueOption{driver.WithQueue(ObjectStorageQueueName)}
 	base = append(base, c.retentionOpts(ObjectStorageQueueName)...)
-	return c.inner.Enqueue(context.Background(), TaskTypeObjectStorageMigrateScan, []byte("{}"), base...)
+	return c.inner.Enqueue(context.Background(), TaskTypeObjectStorageMigrateScan, body, base...)
 }
 
 // EnqueueObjectStorageMigrateFile enqueues migration for one drive_file row.

--- a/internal/queue/queue_test.go
+++ b/internal/queue/queue_test.go
@@ -643,6 +643,7 @@ func TestDecodeWebPushPayload_Invalid(t *testing.T) {
 }
 
 func TestNewObjectStorageMigrateScanTask_RoundTrip(t *testing.T) {
+	t.Parallel()
 	payload := queue.ObjectStorageMigrateScanPayload{UntilID: "f100"}
 	task := queue.NewObjectStorageMigrateScanTask(payload)
 	assert.Equal(t, queue.TaskTypeObjectStorageMigrateScan, task.Type())
@@ -653,11 +654,13 @@ func TestNewObjectStorageMigrateScanTask_RoundTrip(t *testing.T) {
 }
 
 func TestDecodeObjectStorageMigrateScanPayload_Invalid(t *testing.T) {
+	t.Parallel()
 	_, err := queue.DecodeObjectStorageMigrateScanPayload([]byte(`{bad`))
 	assert.Error(t, err)
 }
 
 func TestNewObjectStorageMigrateFileTask_RoundTrip(t *testing.T) {
+	t.Parallel()
 	payload := queue.ObjectStorageMigrateFilePayload{FileID: "f1"}
 	task := queue.NewObjectStorageMigrateFileTask(payload)
 	assert.Equal(t, queue.TaskTypeObjectStorageMigrateFile, task.Type())
@@ -668,6 +671,7 @@ func TestNewObjectStorageMigrateFileTask_RoundTrip(t *testing.T) {
 }
 
 func TestDecodeObjectStorageMigrateFilePayload_Invalid(t *testing.T) {
+	t.Parallel()
 	_, err := queue.DecodeObjectStorageMigrateFilePayload([]byte(`{bad`))
 	assert.Error(t, err)
 }

--- a/internal/queue/queue_test.go
+++ b/internal/queue/queue_test.go
@@ -676,6 +676,30 @@ func TestDecodeObjectStorageMigrateFilePayload_Invalid(t *testing.T) {
 	assert.Error(t, err)
 }
 
+func TestClient_EnqueueObjectStorageMigrate_PolicyMaxAttemptsApplied(t *testing.T) {
+	testutil.SkipIfNoDocker(t)
+	flushTestRedis(t)
+
+	c := queue.NewClient(newDriver())
+	defer func() { _ = c.Close() }()
+	c.SetPolicy(queue.ObjectStorageQueueName, queue.Policy{MaxAttempts: 5})
+
+	require.NoError(t, c.EnqueueObjectStorageMigrateFile("f1"))
+	require.NoError(t, c.EnqueueObjectStorageMigrateScanFrom("f200"))
+
+	insp := asynq.NewInspector(redisOpt())
+	defer func() { _ = insp.Close() }()
+
+	tasks, err := insp.ListPendingTasks(queue.ObjectStorageQueueName)
+	require.NoError(t, err)
+	require.Len(t, tasks, 2)
+	for _, task := range tasks {
+		info, err := insp.GetTaskInfo(queue.ObjectStorageQueueName, task.ID)
+		require.NoError(t, err)
+		assert.Equal(t, 4, info.MaxRetry, "MaxAttempts=5 (BullMQ-style total) → asynq MaxRetry=4")
+	}
+}
+
 func TestClient_EnqueueObjectStorageMigrate(t *testing.T) {
 	testutil.SkipIfNoDocker(t)
 	flushTestRedis(t)

--- a/internal/queue/queue_test.go
+++ b/internal/queue/queue_test.go
@@ -642,6 +642,62 @@ func TestDecodeWebPushPayload_Invalid(t *testing.T) {
 	assert.Error(t, err)
 }
 
+func TestNewObjectStorageMigrateScanTask_RoundTrip(t *testing.T) {
+	payload := queue.ObjectStorageMigrateScanPayload{UntilID: "f100"}
+	task := queue.NewObjectStorageMigrateScanTask(payload)
+	assert.Equal(t, queue.TaskTypeObjectStorageMigrateScan, task.Type())
+
+	decoded, err := queue.DecodeObjectStorageMigrateScanPayload(task.Payload())
+	require.NoError(t, err)
+	assert.Equal(t, payload, decoded)
+}
+
+func TestDecodeObjectStorageMigrateScanPayload_Invalid(t *testing.T) {
+	_, err := queue.DecodeObjectStorageMigrateScanPayload([]byte(`{bad`))
+	assert.Error(t, err)
+}
+
+func TestNewObjectStorageMigrateFileTask_RoundTrip(t *testing.T) {
+	payload := queue.ObjectStorageMigrateFilePayload{FileID: "f1"}
+	task := queue.NewObjectStorageMigrateFileTask(payload)
+	assert.Equal(t, queue.TaskTypeObjectStorageMigrateFile, task.Type())
+
+	decoded, err := queue.DecodeObjectStorageMigrateFilePayload(task.Payload())
+	require.NoError(t, err)
+	assert.Equal(t, payload, decoded)
+}
+
+func TestDecodeObjectStorageMigrateFilePayload_Invalid(t *testing.T) {
+	_, err := queue.DecodeObjectStorageMigrateFilePayload([]byte(`{bad`))
+	assert.Error(t, err)
+}
+
+func TestClient_EnqueueObjectStorageMigrate(t *testing.T) {
+	testutil.SkipIfNoDocker(t)
+	flushTestRedis(t)
+
+	c := queue.NewClient(newDriver())
+	defer func() { _ = c.Close() }()
+
+	require.NoError(t, c.EnqueueObjectStorageMigrateScan())
+	require.NoError(t, c.EnqueueObjectStorageMigrateScanFrom("f200"))
+	require.NoError(t, c.EnqueueObjectStorageMigrateFile("f1"))
+
+	insp := asynq.NewInspector(redisOpt())
+	defer func() { _ = insp.Close() }()
+
+	tasks, err := insp.ListPendingTasks(queue.ObjectStorageQueueName)
+	require.NoError(t, err)
+	require.Len(t, tasks, 3)
+
+	types := make([]string, len(tasks))
+	for i, task := range tasks {
+		types[i] = task.Type
+	}
+	assert.Contains(t, types, queue.TaskTypeObjectStorageMigrateScan)
+	assert.Contains(t, types, queue.TaskTypeObjectStorageMigrateFile)
+}
+
 func TestClient_EnqueueWebPush(t *testing.T) {
 	testutil.SkipIfNoDocker(t)
 	flushTestRedis(t)

--- a/internal/queue/tasks.go
+++ b/internal/queue/tasks.go
@@ -362,8 +362,10 @@ const TaskTypeObjectStorageMigrateScan = "objectStorage:migrateScan"
 // TaskTypeObjectStorageMigrateFile migrates a single drive_file row to S3.
 const TaskTypeObjectStorageMigrateFile = "objectStorage:migrateFile"
 
-// ObjectStorageMigrateScanPayload is an empty scan coordinator payload.
-type ObjectStorageMigrateScanPayload struct{}
+// ObjectStorageMigrateScanPayload carries pagination for chained scan jobs.
+type ObjectStorageMigrateScanPayload struct {
+	UntilID string `json:"untilId,omitempty"`
+}
 
 // ObjectStorageMigrateFilePayload identifies one drive_file to migrate.
 type ObjectStorageMigrateFilePayload struct {
@@ -371,8 +373,18 @@ type ObjectStorageMigrateFilePayload struct {
 }
 
 // NewObjectStorageMigrateScanTask builds a scan task.
-func NewObjectStorageMigrateScanTask() driver.Task {
-	return driver.RawTask{TypeName: TaskTypeObjectStorageMigrateScan, Body: []byte("{}")}
+func NewObjectStorageMigrateScanTask(payload ObjectStorageMigrateScanPayload) driver.Task {
+	body, _ := json.Marshal(payload)
+	return driver.RawTask{TypeName: TaskTypeObjectStorageMigrateScan, Body: body}
+}
+
+// DecodeObjectStorageMigrateScanPayload extracts a scan coordinator payload.
+func DecodeObjectStorageMigrateScanPayload(body []byte) (ObjectStorageMigrateScanPayload, error) {
+	var p ObjectStorageMigrateScanPayload
+	if err := json.Unmarshal(body, &p); err != nil {
+		return ObjectStorageMigrateScanPayload{}, err
+	}
+	return p, nil
 }
 
 // NewObjectStorageMigrateFileTask builds a per-file migration task.

--- a/internal/queue/tasks.go
+++ b/internal/queue/tasks.go
@@ -354,3 +354,38 @@ func DecodePostScheduledNotePayload(body []byte) (PostScheduledNotePayload, erro
 	}
 	return p, nil
 }
+
+// TaskTypeObjectStorageMigrateScan enqueues per-file migration jobs for all
+// storedInternal=true rows (#1476).
+const TaskTypeObjectStorageMigrateScan = "objectStorage:migrateScan"
+
+// TaskTypeObjectStorageMigrateFile migrates a single drive_file row to S3.
+const TaskTypeObjectStorageMigrateFile = "objectStorage:migrateFile"
+
+// ObjectStorageMigrateScanPayload is an empty scan coordinator payload.
+type ObjectStorageMigrateScanPayload struct{}
+
+// ObjectStorageMigrateFilePayload identifies one drive_file to migrate.
+type ObjectStorageMigrateFilePayload struct {
+	FileID string `json:"fileId"`
+}
+
+// NewObjectStorageMigrateScanTask builds a scan task.
+func NewObjectStorageMigrateScanTask() driver.Task {
+	return driver.RawTask{TypeName: TaskTypeObjectStorageMigrateScan, Body: []byte("{}")}
+}
+
+// NewObjectStorageMigrateFileTask builds a per-file migration task.
+func NewObjectStorageMigrateFileTask(payload ObjectStorageMigrateFilePayload) driver.Task {
+	body, _ := json.Marshal(payload)
+	return driver.RawTask{TypeName: TaskTypeObjectStorageMigrateFile, Body: body}
+}
+
+// DecodeObjectStorageMigrateFilePayload extracts a file migration payload.
+func DecodeObjectStorageMigrateFilePayload(body []byte) (ObjectStorageMigrateFilePayload, error) {
+	var p ObjectStorageMigrateFilePayload
+	if err := json.Unmarshal(body, &p); err != nil {
+		return ObjectStorageMigrateFilePayload{}, err
+	}
+	return p, nil
+}

--- a/internal/repository/drive_file.go
+++ b/internal/repository/drive_file.go
@@ -55,6 +55,12 @@ type DriveFileRepository interface {
 	// remote instance host. Returns affected count. Used by
 	// admin/federation/delete-all-files (#587)。
 	DeleteByHost(host string) (int64, error)
+	// ListStoredInternalIDs returns IDs of locally stored files pending
+	// migration to object storage (#1476). untilID is an exclusive upper
+	// bound on id when non-empty (cursor pagination).
+	ListStoredInternalIDs(untilID string, limit int) ([]string, error)
+	// CountStoredInternal returns rows with storedInternal=true and isLink=false.
+	CountStoredInternal() (int64, error)
 }
 
 type driveFileRepository struct {
@@ -347,4 +353,31 @@ func (r *driveFileRepository) DeleteByHost(host string) (int64, error) {
 	// ローカル user (userHost IS NULL) は誤って巻き込まないよう明示一致のみ。
 	tx := r.db.Where(`"userHost" = ?`, host).Delete(&model.DriveFile{})
 	return tx.RowsAffected, tx.Error
+}
+
+func (r *driveFileRepository) storedInternalQuery() *gorm.DB {
+	return r.db.Model(&model.DriveFile{}).Where(`"storedInternal" = true AND "isLink" = false`)
+}
+
+func (r *driveFileRepository) CountStoredInternal() (int64, error) {
+	var n int64
+	if err := r.storedInternalQuery().Count(&n).Error; err != nil {
+		return 0, err
+	}
+	return n, nil
+}
+
+func (r *driveFileRepository) ListStoredInternalIDs(untilID string, limit int) ([]string, error) {
+	if limit <= 0 {
+		limit = 500
+	}
+	q := r.storedInternalQuery().Select("id")
+	if untilID != "" {
+		q = q.Where("id < ?", untilID)
+	}
+	var ids []string
+	if err := q.Order("id DESC").Limit(limit).Pluck("id", &ids).Error; err != nil {
+		return nil, err
+	}
+	return ids, nil
 }

--- a/internal/repository/drive_file.go
+++ b/internal/repository/drive_file.go
@@ -58,9 +58,9 @@ type DriveFileRepository interface {
 	// ListStoredInternalIDs returns IDs of locally stored files pending
 	// migration to object storage (#1476). untilID is an exclusive upper
 	// bound on id when non-empty (cursor pagination).
+	// No dedicated index exists for storedInternal+isLink+ORDER BY id DESC;
+	// expect sequential scans on very large drive_file tables during one-off scans.
 	ListStoredInternalIDs(untilID string, limit int) ([]string, error)
-	// CountStoredInternal returns rows with storedInternal=true and isLink=false.
-	CountStoredInternal() (int64, error)
 }
 
 type driveFileRepository struct {
@@ -357,14 +357,6 @@ func (r *driveFileRepository) DeleteByHost(host string) (int64, error) {
 
 func (r *driveFileRepository) storedInternalQuery() *gorm.DB {
 	return r.db.Model(&model.DriveFile{}).Where(`"storedInternal" = true AND "isLink" = false`)
-}
-
-func (r *driveFileRepository) CountStoredInternal() (int64, error) {
-	var n int64
-	if err := r.storedInternalQuery().Count(&n).Error; err != nil {
-		return 0, err
-	}
-	return n, nil
 }
 
 func (r *driveFileRepository) ListStoredInternalIDs(untilID string, limit int) ([]string, error) {

--- a/internal/repository/drive_file_test.go
+++ b/internal/repository/drive_file_test.go
@@ -551,4 +551,39 @@ func TestDriveFileRepository_DeleteByUser(t *testing.T) {
 	assert.Error(t, err)
 }
 
+func TestDriveFileRepository_StoredInternalMigrationQueries(t *testing.T) {
+	repo := NewDriveFileRepository(testDB)
+	user := insertTestUser(t, "u_df_mig", "dfmig")
+	defer cleanupUser(t, user.ID)
+
+	local := newTestDriveFile("f_mig_local", user.ID, "mig1", nil)
+	local.StoredInternal = true
+	require.NoError(t, repo.Create(local))
+	defer cleanupDriveFile(t, local.ID)
+
+	migrated := newTestDriveFile("f_mig_done", user.ID, "mig2", nil)
+	migrated.StoredInternal = false
+	require.NoError(t, repo.Create(migrated))
+	defer cleanupDriveFile(t, migrated.ID)
+
+	link := newTestDriveFile("f_mig_link", user.ID, "mig3", nil)
+	link.StoredInternal = false
+	link.IsLink = true
+	require.NoError(t, repo.Create(link))
+	defer cleanupDriveFile(t, link.ID)
+
+	n, err := repo.CountStoredInternal()
+	require.NoError(t, err)
+	assert.Equal(t, int64(1), n)
+
+	ids, err := repo.ListStoredInternalIDs("", 10)
+	require.NoError(t, err)
+	require.Len(t, ids, 1)
+	assert.Equal(t, "f_mig_local", ids[0])
+
+	ids, err = repo.ListStoredInternalIDs("f_mig_local", 10)
+	require.NoError(t, err)
+	assert.Empty(t, ids)
+}
+
 var _ = context.Background // import guard

--- a/internal/repository/drive_file_test.go
+++ b/internal/repository/drive_file_test.go
@@ -572,10 +572,6 @@ func TestDriveFileRepository_StoredInternalMigrationQueries(t *testing.T) {
 	require.NoError(t, repo.Create(link))
 	defer cleanupDriveFile(t, link.ID)
 
-	n, err := repo.CountStoredInternal()
-	require.NoError(t, err)
-	assert.Equal(t, int64(1), n)
-
 	ids, err := repo.ListStoredInternalIDs("", 10)
 	require.NoError(t, err)
 	require.Len(t, ids, 1)

--- a/internal/server/drive_migration.go
+++ b/internal/server/drive_migration.go
@@ -1,0 +1,50 @@
+package server
+
+import (
+	"fmt"
+	"log/slog"
+
+	"github.com/shiroha-a/mk/internal/config"
+	"github.com/shiroha-a/mk/internal/model"
+	"github.com/shiroha-a/mk/internal/repository"
+)
+
+// validateDriveLocalMigration checks meta when YAML migration is enabled.
+func validateDriveLocalMigration(cfg *config.Config, meta *model.Meta) error {
+	if !cfg.DriveLocalToObjectStorage.Enabled {
+		return nil
+	}
+	if meta == nil || !meta.UseObjectStorage {
+		return fmt.Errorf("driveLocalToObjectStorage.enabled requires meta.useObjectStorage=true")
+	}
+	if meta.ObjectStorageBucket == nil || *meta.ObjectStorageBucket == "" {
+		return fmt.Errorf("driveLocalToObjectStorage.enabled requires meta.objectStorageBucket")
+	}
+	return nil
+}
+
+// maybeEnqueueDriveLocalMigration starts the scan job when configured.
+func (s *Server) maybeEnqueueDriveLocalMigration(
+	fileRepo repository.DriveFileRepository,
+) error {
+	cfg := s.config.DriveLocalToObjectStorage
+	if !cfg.Enabled {
+		return nil
+	}
+	if fileRepo == nil || s.queueClient == nil {
+		return fmt.Errorf("drive migration: file repository or queue client not configured")
+	}
+	n, err := fileRepo.CountStoredInternal()
+	if err != nil {
+		return fmt.Errorf("drive migration: count storedInternal: %w", err)
+	}
+	if n == 0 {
+		slog.Info("drive local→object storage migration: no pending files")
+		return nil
+	}
+	if err := s.queueClient.EnqueueObjectStorageMigrateScan(); err != nil {
+		return fmt.Errorf("drive migration: enqueue scan: %w", err)
+	}
+	slog.Info("drive local→object storage migration: scan job enqueued", "pendingFiles", n)
+	return nil
+}

--- a/internal/server/drive_migration.go
+++ b/internal/server/drive_migration.go
@@ -1,34 +1,40 @@
 package server
 
 import (
+	"context"
 	"fmt"
 	"log/slog"
 
 	"github.com/shiroha-a/mk/internal/config"
 	"github.com/shiroha-a/mk/internal/model"
+	"github.com/shiroha-a/mk/internal/queue/processors"
 	"github.com/shiroha-a/mk/internal/repository"
 )
 
-// validateDriveLocalMigration checks meta when YAML migration is enabled.
-func validateDriveLocalMigration(cfg *config.Config, meta *model.Meta) error {
-	if !cfg.DriveLocalToObjectStorage.Enabled {
-		return nil
+// driveLocalMigrationReady reports whether background migration may run.
+// When YAML enables migration but meta is not configured for S3, logs a warning
+// and returns false so the server still starts (#1476 review).
+func driveLocalMigrationReady(cfg *config.Config, meta *model.Meta) bool {
+	if cfg == nil || !cfg.DriveLocalToObjectStorage.Enabled {
+		return false
 	}
 	if meta == nil || !meta.UseObjectStorage {
-		return fmt.Errorf("driveLocalToObjectStorage.enabled requires meta.useObjectStorage=true")
+		slog.Warn("driveLocalToObjectStorage.enabled is set but meta.useObjectStorage is false; migration jobs will not run")
+		return false
 	}
 	if meta.ObjectStorageBucket == nil || *meta.ObjectStorageBucket == "" {
-		return fmt.Errorf("driveLocalToObjectStorage.enabled requires meta.objectStorageBucket")
+		slog.Warn("driveLocalToObjectStorage.enabled is set but meta.objectStorageBucket is empty; migration jobs will not run")
+		return false
 	}
-	return nil
+	return true
 }
 
 // maybeEnqueueDriveLocalMigration starts the scan job when configured.
 func (s *Server) maybeEnqueueDriveLocalMigration(
 	fileRepo repository.DriveFileRepository,
+	meta *model.Meta,
 ) error {
-	cfg := s.config.DriveLocalToObjectStorage
-	if !cfg.Enabled {
+	if !driveLocalMigrationReady(s.config, meta) {
 		return nil
 	}
 	if fileRepo == nil || s.queueClient == nil {
@@ -41,6 +47,17 @@ func (s *Server) maybeEnqueueDriveLocalMigration(
 	if n == 0 {
 		slog.Info("drive local→object storage migration: no pending files")
 		return nil
+	}
+	if s.redis != nil && s.redis.JobQueue != nil {
+		ctx := context.Background()
+		held, err := s.redis.JobQueue.Exists(ctx, processors.ObjectStorageScanLockKey).Result()
+		if err != nil {
+			return fmt.Errorf("drive migration: scan lock check: %w", err)
+		}
+		if held > 0 {
+			slog.Info("drive local→object storage migration: scan already scheduled or running")
+			return nil
+		}
 	}
 	if err := s.queueClient.EnqueueObjectStorageMigrateScan(); err != nil {
 		return fmt.Errorf("drive migration: enqueue scan: %w", err)

--- a/internal/server/drive_migration.go
+++ b/internal/server/drive_migration.go
@@ -44,7 +44,9 @@ func (s *Server) maybeEnqueueDriveLocalMigration(
 		ctx := context.Background()
 		held, err := s.redis.JobQueue.Exists(ctx, processors.ObjectStorageScanLockKey).Result()
 		if err != nil {
-			return fmt.Errorf("drive migration: scan lock check: %w", err)
+			slog.Error("drive migration: scan lock check failed; server will start without enqueueing migration",
+				"error", err)
+			return nil
 		}
 		if held > 0 {
 			slog.Info("drive local→object storage migration: scan already scheduled or running")
@@ -52,7 +54,9 @@ func (s *Server) maybeEnqueueDriveLocalMigration(
 		}
 	}
 	if err := s.queueClient.EnqueueObjectStorageMigrateScan(); err != nil {
-		return fmt.Errorf("drive migration: enqueue scan: %w", err)
+		slog.Error("drive migration: enqueue scan failed; server will start without migration job",
+			"error", err)
+		return nil
 	}
 	slog.Info("drive local→object storage migration: scan job enqueued")
 	return nil

--- a/internal/server/drive_migration.go
+++ b/internal/server/drive_migration.go
@@ -40,14 +40,6 @@ func (s *Server) maybeEnqueueDriveLocalMigration(
 	if fileRepo == nil || s.queueClient == nil {
 		return fmt.Errorf("drive migration: file repository or queue client not configured")
 	}
-	n, err := fileRepo.CountStoredInternal()
-	if err != nil {
-		return fmt.Errorf("drive migration: count storedInternal: %w", err)
-	}
-	if n == 0 {
-		slog.Info("drive local→object storage migration: no pending files")
-		return nil
-	}
 	if s.redis != nil && s.redis.JobQueue != nil {
 		ctx := context.Background()
 		held, err := s.redis.JobQueue.Exists(ctx, processors.ObjectStorageScanLockKey).Result()
@@ -62,6 +54,6 @@ func (s *Server) maybeEnqueueDriveLocalMigration(
 	if err := s.queueClient.EnqueueObjectStorageMigrateScan(); err != nil {
 		return fmt.Errorf("drive migration: enqueue scan: %w", err)
 	}
-	slog.Info("drive local→object storage migration: scan job enqueued", "pendingFiles", n)
+	slog.Info("drive local→object storage migration: scan job enqueued")
 	return nil
 }

--- a/internal/server/drive_migration_test.go
+++ b/internal/server/drive_migration_test.go
@@ -1,0 +1,45 @@
+package server
+
+import (
+	"testing"
+
+	"github.com/shiroha-a/mk/internal/config"
+	"github.com/shiroha-a/mk/internal/model"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestValidateDriveLocalMigration_Disabled(t *testing.T) {
+	cfg := &config.Config{}
+	require.NoError(t, validateDriveLocalMigration(cfg, nil))
+}
+
+func TestValidateDriveLocalMigration_RequiresMeta(t *testing.T) {
+	cfg := &config.Config{
+		DriveLocalToObjectStorage: config.DriveLocalToObjectStorageConfig{Enabled: true},
+	}
+	err := validateDriveLocalMigration(cfg, &model.Meta{UseObjectStorage: false})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "useObjectStorage")
+}
+
+func TestValidateDriveLocalMigration_RequiresBucket(t *testing.T) {
+	cfg := &config.Config{
+		DriveLocalToObjectStorage: config.DriveLocalToObjectStorageConfig{Enabled: true},
+	}
+	err := validateDriveLocalMigration(cfg, &model.Meta{UseObjectStorage: true})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "objectStorageBucket")
+}
+
+func TestValidateDriveLocalMigration_OK(t *testing.T) {
+	bucket := "my-bucket"
+	cfg := &config.Config{
+		DriveLocalToObjectStorage: config.DriveLocalToObjectStorageConfig{Enabled: true},
+	}
+	meta := &model.Meta{
+		UseObjectStorage:    true,
+		ObjectStorageBucket: &bucket,
+	}
+	require.NoError(t, validateDriveLocalMigration(cfg, meta))
+}

--- a/internal/server/drive_migration_test.go
+++ b/internal/server/drive_migration_test.go
@@ -1,11 +1,14 @@
 package server
 
 import (
+	"context"
+	"errors"
 	"testing"
 
 	"github.com/shiroha-a/mk/internal/config"
 	"github.com/shiroha-a/mk/internal/model"
 	"github.com/shiroha-a/mk/internal/queue"
+	"github.com/shiroha-a/mk/internal/queue/driver"
 	"github.com/shiroha-a/mk/internal/testutil"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -73,4 +76,30 @@ func TestMaybeEnqueueDriveLocalMigration_SkipsCountStoredInternal(t *testing.T) 
 	require.NoError(t, srv.maybeEnqueueDriveLocalMigration(spy, meta))
 	assert.False(t, spy.countCalled, "startup must not run COUNT on drive_file")
 	assert.Equal(t, queue.TaskTypeObjectStorageMigrateScan, rec.lastTaskType)
+}
+
+type failingEnqueueClient struct {
+	err error
+}
+
+func (f *failingEnqueueClient) Enqueue(context.Context, string, []byte, ...driver.EnqueueOption) error {
+	return f.err
+}
+func (f *failingEnqueueClient) Close() error { return nil }
+
+func TestMaybeEnqueueDriveLocalMigration_EnqueueFailureDoesNotBlockStartup(t *testing.T) {
+	bucket := "my-bucket"
+	srv := &Server{
+		config: &config.Config{
+			DriveLocalToObjectStorage: config.DriveLocalToObjectStorageConfig{Enabled: true},
+		},
+		queueClient: queue.NewClient(&stubDriver{client: &failingEnqueueClient{err: errors.New("redis unavailable")}}),
+	}
+	defer func() { _ = srv.queueClient.Close() }()
+
+	meta := &model.Meta{
+		UseObjectStorage:    true,
+		ObjectStorageBucket: &bucket,
+	}
+	require.NoError(t, srv.maybeEnqueueDriveLocalMigration(testutil.NewMockDriveFileRepository(), meta))
 }

--- a/internal/server/drive_migration_test.go
+++ b/internal/server/drive_migration_test.go
@@ -5,8 +5,22 @@ import (
 
 	"github.com/shiroha-a/mk/internal/config"
 	"github.com/shiroha-a/mk/internal/model"
+	"github.com/shiroha-a/mk/internal/queue"
+	"github.com/shiroha-a/mk/internal/testutil"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
+
+// countSpyFileRepo records whether CountStoredInternal was invoked.
+type countSpyFileRepo struct {
+	*testutil.MockDriveFileRepository
+	countCalled bool
+}
+
+func (s *countSpyFileRepo) CountStoredInternal() (int64, error) {
+	s.countCalled = true
+	return s.MockDriveFileRepository.CountStoredInternal()
+}
 
 func TestDriveLocalMigrationReady_Disabled(t *testing.T) {
 	cfg := &config.Config{}
@@ -37,4 +51,26 @@ func TestDriveLocalMigrationReady_OK(t *testing.T) {
 		ObjectStorageBucket: &bucket,
 	}
 	assert.True(t, driveLocalMigrationReady(cfg, meta))
+}
+
+func TestMaybeEnqueueDriveLocalMigration_SkipsCountStoredInternal(t *testing.T) {
+	bucket := "my-bucket"
+	rec := &recordingDriverClient{}
+	srv := &Server{
+		config: &config.Config{
+			DriveLocalToObjectStorage: config.DriveLocalToObjectStorageConfig{Enabled: true},
+		},
+		queueClient: queue.NewClient(&stubDriver{client: rec}),
+	}
+	defer func() { _ = srv.queueClient.Close() }()
+
+	spy := &countSpyFileRepo{MockDriveFileRepository: testutil.NewMockDriveFileRepository()}
+	meta := &model.Meta{
+		UseObjectStorage:    true,
+		ObjectStorageBucket: &bucket,
+	}
+
+	require.NoError(t, srv.maybeEnqueueDriveLocalMigration(spy, meta))
+	assert.False(t, spy.countCalled, "startup must not run COUNT on drive_file")
+	assert.Equal(t, queue.TaskTypeObjectStorageMigrateScan, rec.lastTaskType)
 }

--- a/internal/server/drive_migration_test.go
+++ b/internal/server/drive_migration_test.go
@@ -6,33 +6,28 @@ import (
 	"github.com/shiroha-a/mk/internal/config"
 	"github.com/shiroha-a/mk/internal/model"
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 )
 
-func TestValidateDriveLocalMigration_Disabled(t *testing.T) {
+func TestDriveLocalMigrationReady_Disabled(t *testing.T) {
 	cfg := &config.Config{}
-	require.NoError(t, validateDriveLocalMigration(cfg, nil))
+	assert.False(t, driveLocalMigrationReady(cfg, nil))
 }
 
-func TestValidateDriveLocalMigration_RequiresMeta(t *testing.T) {
+func TestDriveLocalMigrationReady_RequiresMeta(t *testing.T) {
 	cfg := &config.Config{
 		DriveLocalToObjectStorage: config.DriveLocalToObjectStorageConfig{Enabled: true},
 	}
-	err := validateDriveLocalMigration(cfg, &model.Meta{UseObjectStorage: false})
-	require.Error(t, err)
-	assert.Contains(t, err.Error(), "useObjectStorage")
+	assert.False(t, driveLocalMigrationReady(cfg, &model.Meta{UseObjectStorage: false}))
 }
 
-func TestValidateDriveLocalMigration_RequiresBucket(t *testing.T) {
+func TestDriveLocalMigrationReady_RequiresBucket(t *testing.T) {
 	cfg := &config.Config{
 		DriveLocalToObjectStorage: config.DriveLocalToObjectStorageConfig{Enabled: true},
 	}
-	err := validateDriveLocalMigration(cfg, &model.Meta{UseObjectStorage: true})
-	require.Error(t, err)
-	assert.Contains(t, err.Error(), "objectStorageBucket")
+	assert.False(t, driveLocalMigrationReady(cfg, &model.Meta{UseObjectStorage: true}))
 }
 
-func TestValidateDriveLocalMigration_OK(t *testing.T) {
+func TestDriveLocalMigrationReady_OK(t *testing.T) {
 	bucket := "my-bucket"
 	cfg := &config.Config{
 		DriveLocalToObjectStorage: config.DriveLocalToObjectStorageConfig{Enabled: true},
@@ -41,5 +36,5 @@ func TestValidateDriveLocalMigration_OK(t *testing.T) {
 		UseObjectStorage:    true,
 		ObjectStorageBucket: &bucket,
 	}
-	require.NoError(t, validateDriveLocalMigration(cfg, meta))
+	assert.True(t, driveLocalMigrationReady(cfg, meta))
 }

--- a/internal/server/drive_migration_test.go
+++ b/internal/server/drive_migration_test.go
@@ -14,23 +14,14 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// countSpyFileRepo records whether CountStoredInternal was invoked.
-type countSpyFileRepo struct {
-	*testutil.MockDriveFileRepository
-	countCalled bool
-}
-
-func (s *countSpyFileRepo) CountStoredInternal() (int64, error) {
-	s.countCalled = true
-	return s.MockDriveFileRepository.CountStoredInternal()
-}
-
 func TestDriveLocalMigrationReady_Disabled(t *testing.T) {
+	t.Parallel()
 	cfg := &config.Config{}
 	assert.False(t, driveLocalMigrationReady(cfg, nil))
 }
 
 func TestDriveLocalMigrationReady_RequiresMeta(t *testing.T) {
+	t.Parallel()
 	cfg := &config.Config{
 		DriveLocalToObjectStorage: config.DriveLocalToObjectStorageConfig{Enabled: true},
 	}
@@ -38,6 +29,7 @@ func TestDriveLocalMigrationReady_RequiresMeta(t *testing.T) {
 }
 
 func TestDriveLocalMigrationReady_RequiresBucket(t *testing.T) {
+	t.Parallel()
 	cfg := &config.Config{
 		DriveLocalToObjectStorage: config.DriveLocalToObjectStorageConfig{Enabled: true},
 	}
@@ -45,6 +37,7 @@ func TestDriveLocalMigrationReady_RequiresBucket(t *testing.T) {
 }
 
 func TestDriveLocalMigrationReady_OK(t *testing.T) {
+	t.Parallel()
 	bucket := "my-bucket"
 	cfg := &config.Config{
 		DriveLocalToObjectStorage: config.DriveLocalToObjectStorageConfig{Enabled: true},
@@ -56,7 +49,8 @@ func TestDriveLocalMigrationReady_OK(t *testing.T) {
 	assert.True(t, driveLocalMigrationReady(cfg, meta))
 }
 
-func TestMaybeEnqueueDriveLocalMigration_SkipsCountStoredInternal(t *testing.T) {
+func TestMaybeEnqueueDriveLocalMigration_EnqueuesScan(t *testing.T) {
+	t.Parallel()
 	bucket := "my-bucket"
 	rec := &recordingDriverClient{}
 	srv := &Server{
@@ -67,14 +61,12 @@ func TestMaybeEnqueueDriveLocalMigration_SkipsCountStoredInternal(t *testing.T) 
 	}
 	defer func() { _ = srv.queueClient.Close() }()
 
-	spy := &countSpyFileRepo{MockDriveFileRepository: testutil.NewMockDriveFileRepository()}
 	meta := &model.Meta{
 		UseObjectStorage:    true,
 		ObjectStorageBucket: &bucket,
 	}
 
-	require.NoError(t, srv.maybeEnqueueDriveLocalMigration(spy, meta))
-	assert.False(t, spy.countCalled, "startup must not run COUNT on drive_file")
+	require.NoError(t, srv.maybeEnqueueDriveLocalMigration(testutil.NewMockDriveFileRepository(), meta))
 	assert.Equal(t, queue.TaskTypeObjectStorageMigrateScan, rec.lastTaskType)
 }
 
@@ -88,6 +80,7 @@ func (f *failingEnqueueClient) Enqueue(context.Context, string, []byte, ...drive
 func (f *failingEnqueueClient) Close() error { return nil }
 
 func TestMaybeEnqueueDriveLocalMigration_EnqueueFailureDoesNotBlockStartup(t *testing.T) {
+	t.Parallel()
 	bucket := "my-bucket"
 	srv := &Server{
 		config: &config.Config{

--- a/internal/server/files.go
+++ b/internal/server/files.go
@@ -4,7 +4,9 @@ import (
 	"bytes"
 	"io"
 	"net/http"
+	"net/url"
 	"os"
+	"strings"
 	"time"
 
 	"github.com/labstack/echo/v4"
@@ -46,8 +48,12 @@ func filesHandler(lookup filesDriveLookup, primary, local coredrive.Storage) ech
 		key := c.Param("accessKey")
 		storage := primary
 		if lookup != nil && local != nil {
-			if f, err := lookup.FindByAnyAccessKey(key); err == nil && f.StoredInternal {
-				storage = local
+			if f, err := lookup.FindByAnyAccessKey(key); err == nil {
+				if f.StoredInternal {
+					storage = local
+				} else if target := redirectURLForAccessKey(f, key); target != "" {
+					return c.Redirect(http.StatusFound, target)
+				}
 			}
 		}
 		body, err := storage.Get(key)
@@ -96,4 +102,28 @@ func filesHandler(lookup filesDriveLookup, primary, local coredrive.Storage) ech
 		http.ServeContent(c.Response(), c.Request(), key, modtime, seeker)
 		return nil
 	}
+}
+
+// redirectURLForAccessKey returns the public CDN/S3 URL for a migrated file row.
+func redirectURLForAccessKey(f *model.DriveFile, accessKey string) string {
+	if f == nil {
+		return ""
+	}
+	var u string
+	if f.AccessKey != nil && *f.AccessKey == accessKey {
+		u = f.URL
+	} else if f.ThumbnailAccessKey != nil && *f.ThumbnailAccessKey == accessKey && f.ThumbnailURL != nil {
+		u = *f.ThumbnailURL
+	} else if f.WebpublicAccessKey != nil && *f.WebpublicAccessKey == accessKey && f.WebpublicURL != nil {
+		u = *f.WebpublicURL
+	} else {
+		return ""
+	}
+	if !strings.HasPrefix(u, "http://") && !strings.HasPrefix(u, "https://") {
+		return ""
+	}
+	if _, err := url.Parse(u); err != nil {
+		return ""
+	}
+	return u
 }

--- a/internal/server/files.go
+++ b/internal/server/files.go
@@ -43,7 +43,7 @@ type filesDriveLookup interface {
 // 倒していたが、Cloudflare Tunnel 経由のデプロイで bigger-than-buffer
 // (33KB 程度) なファイルが truncate される問題があった (#730)。明示
 // Content-Length + Cache-Control: no-transform でこれを回避する。
-func filesHandler(lookup filesDriveLookup, primary, local coredrive.Storage) echo.HandlerFunc {
+func filesHandler(lookup filesDriveLookup, primary, local coredrive.Storage, driveURL string) echo.HandlerFunc {
 	return func(c echo.Context) error {
 		key := c.Param("accessKey")
 		storage := primary
@@ -51,7 +51,7 @@ func filesHandler(lookup filesDriveLookup, primary, local coredrive.Storage) ech
 			if f, err := lookup.FindByAnyAccessKey(key); err == nil {
 				if f.StoredInternal {
 					storage = local
-				} else if target := redirectURLForAccessKey(f, key); target != "" {
+				} else if target := redirectURLForAccessKey(f, key, driveURL); target != "" {
 					return c.Redirect(http.StatusFound, target)
 				}
 			}
@@ -105,7 +105,8 @@ func filesHandler(lookup filesDriveLookup, primary, local coredrive.Storage) ech
 }
 
 // redirectURLForAccessKey returns the public CDN/S3 URL for a migrated file row.
-func redirectURLForAccessKey(f *model.DriveFile, accessKey string) string {
+// Same-origin /files/ URLs are not redirected (avoids 302 loops during migration).
+func redirectURLForAccessKey(f *model.DriveFile, accessKey, driveURL string) string {
 	if f == nil {
 		return ""
 	}
@@ -123,6 +124,9 @@ func redirectURLForAccessKey(f *model.DriveFile, accessKey string) string {
 		return ""
 	}
 	if _, err := url.Parse(u); err != nil {
+		return ""
+	}
+	if coredrive.URLUsesDrivePrefix(u, driveURL) {
 		return ""
 	}
 	return u

--- a/internal/server/files_test.go
+++ b/internal/server/files_test.go
@@ -18,6 +18,8 @@ import (
 	"github.com/shiroha-a/mk/internal/model"
 )
 
+const testDriveURL = "https://example.com/files"
+
 // stubFilesLookup is a minimal stand-in for filesDriveLookup. We hand-roll
 // the stub rather than reuse testutil.MockDriveFileRepository so the test
 // stays focused on the handler's storage-switching contract.
@@ -53,7 +55,8 @@ func (m *memStorage) Get(key string) (io.ReadCloser, error) {
 	}
 	return io.NopCloser(strings.NewReader(body)), nil
 }
-func (m *memStorage) Delete(string) error { return nil }
+func (m *memStorage) Delete(string) error  { return nil }
+func (m *memStorage) StoredInternal() bool { return false }
 
 func newFilesTestContext(t *testing.T, key string) (echo.Context, *httptest.ResponseRecorder) {
 	t.Helper()
@@ -82,7 +85,7 @@ func TestFilesHandler_StoredInternalServesFromLocal(t *testing.T) {
 	local := &memStorage{byKey: map[string]string{key: "local-body"}}
 
 	c, rec := newFilesTestContext(t, key)
-	h := filesHandler(lookup, primary, local)
+	h := filesHandler(lookup, primary, local, testDriveURL)
 	require.NoError(t, h(c))
 
 	assert.Equal(t, http.StatusOK, rec.Code)
@@ -107,7 +110,7 @@ func TestFilesHandler_ThumbnailKeyRedirectsToThumbnailURL(t *testing.T) {
 		},
 	}
 	c, rec := newFilesTestContext(t, thumbKey)
-	h := filesHandler(lookup, &memStorage{}, &memStorage{})
+	h := filesHandler(lookup, &memStorage{}, &memStorage{}, testDriveURL)
 	require.NoError(t, h(c))
 	assert.Equal(t, http.StatusFound, rec.Code)
 	assert.Equal(t, thumbURL, rec.Header().Get("Location"))
@@ -130,7 +133,7 @@ func TestFilesHandler_WebpublicKeyRedirectsToWebpublicURL(t *testing.T) {
 		},
 	}
 	c, rec := newFilesTestContext(t, webKey)
-	h := filesHandler(lookup, &memStorage{}, &memStorage{})
+	h := filesHandler(lookup, &memStorage{}, &memStorage{}, testDriveURL)
 	require.NoError(t, h(c))
 	assert.Equal(t, http.StatusFound, rec.Code)
 	assert.Equal(t, webURL, rec.Header().Get("Location"))
@@ -148,11 +151,52 @@ func TestFilesHandler_MigratedRowRedirectsToPublicURL(t *testing.T) {
 	local := &memStorage{byKey: map[string]string{}}
 
 	c, rec := newFilesTestContext(t, key)
-	h := filesHandler(lookup, primary, local)
+	h := filesHandler(lookup, primary, local, testDriveURL)
 	require.NoError(t, h(c))
 
 	assert.Equal(t, http.StatusFound, rec.Code)
 	assert.Equal(t, cdnURL, rec.Header().Get("Location"))
+}
+
+func TestRedirectURLForAccessKey_SameOriginReturnsEmpty(t *testing.T) {
+	key := "loop-key"
+	sameOrigin := testDriveURL + "/" + key
+	f := &model.DriveFile{
+		ID:        "f1",
+		URL:       sameOrigin,
+		AccessKey: &key,
+	}
+	assert.Empty(t, redirectURLForAccessKey(f, key, testDriveURL))
+}
+
+func TestRedirectURLForAccessKey_NoMatch(t *testing.T) {
+	key := "unknown-key"
+	other := "other-key"
+	f := &model.DriveFile{
+		ID:        "f1",
+		AccessKey: &other,
+		URL:       "https://cdn.example.com/files/other-key",
+	}
+	assert.Empty(t, redirectURLForAccessKey(f, key, testDriveURL))
+}
+
+func TestFilesHandler_SameOriginURLFallsBackToPrimary(t *testing.T) {
+	key := "loop-key"
+	sameOrigin := testDriveURL + "/" + key
+	lookup := &stubFilesLookup{
+		byKey: map[string]*model.DriveFile{
+			key: {ID: "f1", StoredInternal: false, URL: sameOrigin, AccessKey: &key},
+		},
+	}
+	primary := &memStorage{byKey: map[string]string{key: "primary-body"}}
+	local := &memStorage{byKey: map[string]string{key: "local-body"}}
+
+	c, rec := newFilesTestContext(t, key)
+	h := filesHandler(lookup, primary, local, testDriveURL)
+	require.NoError(t, h(c))
+
+	assert.Equal(t, http.StatusOK, rec.Code)
+	assert.Equal(t, "primary-body", rec.Body.String())
 }
 
 // DB に行がなければ primary に倒す (旧挙動互換)。
@@ -163,7 +207,7 @@ func TestFilesHandler_LookupMissFallsBackToPrimary(t *testing.T) {
 	local := &memStorage{byKey: map[string]string{key: "should-not-be-used"}}
 
 	c, rec := newFilesTestContext(t, key)
-	h := filesHandler(lookup, primary, local)
+	h := filesHandler(lookup, primary, local, testDriveURL)
 	require.NoError(t, h(c))
 
 	assert.Equal(t, http.StatusOK, rec.Code)
@@ -178,7 +222,7 @@ func TestFilesHandler_NilLookupUsesPrimary(t *testing.T) {
 	local := &memStorage{byKey: map[string]string{key: "l"}}
 
 	c, rec := newFilesTestContext(t, key)
-	h := filesHandler(nil, primary, local)
+	h := filesHandler(nil, primary, local, testDriveURL)
 	require.NoError(t, h(c))
 
 	assert.Equal(t, "p", rec.Body.String())
@@ -192,7 +236,7 @@ func TestFilesHandler_PrimaryMissReturns404(t *testing.T) {
 	local := &memStorage{byKey: map[string]string{}}
 
 	c, rec := newFilesTestContext(t, key)
-	h := filesHandler(lookup, primary, local)
+	h := filesHandler(lookup, primary, local, testDriveURL)
 	require.NoError(t, h(c))
 
 	assert.Equal(t, http.StatusNotFound, rec.Code)
@@ -212,7 +256,8 @@ func (s *fileStorage) Get(key string) (io.ReadCloser, error) {
 	}
 	return f, nil
 }
-func (s *fileStorage) Delete(string) error { return nil }
+func (s *fileStorage) Delete(string) error  { return nil }
+func (s *fileStorage) StoredInternal() bool { return true }
 
 // LocalStorage 互換経路 (*os.File を返す storage) で Stat() からの
 // modtime 取得と Last-Modified 出力経路まで踏む。
@@ -228,7 +273,7 @@ func TestFilesHandler_OsFileSeekablePath(t *testing.T) {
 	local := &fileStorage{root: dir}
 
 	c, rec := newFilesTestContext(t, key)
-	h := filesHandler(lookup, primary, local)
+	h := filesHandler(lookup, primary, local, testDriveURL)
 	require.NoError(t, h(c))
 
 	assert.Equal(t, http.StatusOK, rec.Code)
@@ -245,7 +290,7 @@ func TestFilesHandler_SetsDetectedContentType(t *testing.T) {
 	pngHeader := "\x89PNG\r\n\x1a\n"
 	primary := &memStorage{byKey: map[string]string{key: pngHeader + "..."}}
 	c, rec := newFilesTestContext(t, key)
-	h := filesHandler(nil, primary, nil)
+	h := filesHandler(nil, primary, nil, testDriveURL)
 	require.NoError(t, h(c))
 
 	assert.Equal(t, http.StatusOK, rec.Code)

--- a/internal/server/files_test.go
+++ b/internal/server/files_test.go
@@ -90,6 +90,52 @@ func TestFilesHandler_StoredInternalServesFromLocal(t *testing.T) {
 	assert.Equal(t, "max-age=31536000, immutable, no-transform", rec.Header().Get("Cache-Control"))
 }
 
+func TestFilesHandler_ThumbnailKeyRedirectsToThumbnailURL(t *testing.T) {
+	thumbKey := "thumb-key"
+	primaryKey := "primary-key"
+	thumbURL := "https://cdn.example.com/files/thumb-key"
+	lookup := &stubFilesLookup{
+		byKey: map[string]*model.DriveFile{
+			thumbKey: {
+				ID:                 "f-thumb",
+				StoredInternal:     false,
+				URL:                "https://cdn.example.com/files/primary-key",
+				AccessKey:          &primaryKey,
+				ThumbnailAccessKey: &thumbKey,
+				ThumbnailURL:       &thumbURL,
+			},
+		},
+	}
+	c, rec := newFilesTestContext(t, thumbKey)
+	h := filesHandler(lookup, &memStorage{}, &memStorage{})
+	require.NoError(t, h(c))
+	assert.Equal(t, http.StatusFound, rec.Code)
+	assert.Equal(t, thumbURL, rec.Header().Get("Location"))
+}
+
+func TestFilesHandler_WebpublicKeyRedirectsToWebpublicURL(t *testing.T) {
+	webKey := "web-key"
+	primaryKey := "primary-key"
+	webURL := "https://cdn.example.com/files/web-key"
+	lookup := &stubFilesLookup{
+		byKey: map[string]*model.DriveFile{
+			webKey: {
+				ID:                 "f-web",
+				StoredInternal:     false,
+				URL:                "https://cdn.example.com/files/primary-key",
+				AccessKey:          &primaryKey,
+				WebpublicAccessKey: &webKey,
+				WebpublicURL:       &webURL,
+			},
+		},
+	}
+	c, rec := newFilesTestContext(t, webKey)
+	h := filesHandler(lookup, &memStorage{}, &memStorage{})
+	require.NoError(t, h(c))
+	assert.Equal(t, http.StatusFound, rec.Code)
+	assert.Equal(t, webURL, rec.Header().Get("Location"))
+}
+
 func TestFilesHandler_MigratedRowRedirectsToPublicURL(t *testing.T) {
 	key := "s3-key"
 	cdnURL := "https://cdn.example.com/files/s3-key"

--- a/internal/server/files_test.go
+++ b/internal/server/files_test.go
@@ -90,11 +90,12 @@ func TestFilesHandler_StoredInternalServesFromLocal(t *testing.T) {
 	assert.Equal(t, "max-age=31536000, immutable, no-transform", rec.Header().Get("Cache-Control"))
 }
 
-func TestFilesHandler_NonInternalServesFromPrimary(t *testing.T) {
+func TestFilesHandler_MigratedRowRedirectsToPublicURL(t *testing.T) {
 	key := "s3-key"
+	cdnURL := "https://cdn.example.com/files/s3-key"
 	lookup := &stubFilesLookup{
 		byKey: map[string]*model.DriveFile{
-			key: {ID: "f2", StoredInternal: false},
+			key: {ID: "f2", StoredInternal: false, URL: cdnURL, AccessKey: &key},
 		},
 	}
 	primary := &memStorage{byKey: map[string]string{key: "s3-body"}}
@@ -104,8 +105,8 @@ func TestFilesHandler_NonInternalServesFromPrimary(t *testing.T) {
 	h := filesHandler(lookup, primary, local)
 	require.NoError(t, h(c))
 
-	assert.Equal(t, http.StatusOK, rec.Code)
-	assert.Equal(t, "s3-body", rec.Body.String())
+	assert.Equal(t, http.StatusFound, rec.Code)
+	assert.Equal(t, cdnURL, rec.Header().Get("Location"))
 }
 
 // DB に行がなければ primary に倒す (旧挙動互換)。

--- a/internal/server/queue_factory.go
+++ b/internal/server/queue_factory.go
@@ -111,6 +111,11 @@ func perQueueRatesFromConfig(cfg *config.Config) map[string]int {
 const (
 	defaultDeliverJobMaxAttempts = 12
 	defaultInboxJobMaxAttempts   = 8
+	// defaultObjectStorageMigrateMaxAttempts is the total tries for local→S3
+	// migrate jobs when no YAML override exists (#1476 review). Smaller than
+	// deliver/inbox; transient S3/network errors should retry without waiting
+	// for a full re-scan on restart.
+	defaultObjectStorageMigrateMaxAttempts = 5
 )
 
 // defaultKeepFailed bounds the failed bucket retention applied to inbox /
@@ -157,6 +162,8 @@ func applyClientPolicies(c *queue.Client, cfg *config.Config) {
 	c.SetPolicy(queue.ExportQueueName, defaultPolicy())
 	c.SetPolicy(queue.PushQueueName, defaultPolicy())
 	c.SetPolicy(queue.WebhookQueueName, defaultPolicy())
+	c.SetPolicy(queue.ObjectStorageQueueName,
+		buildPolicy(nil, defaultObjectStorageMigrateMaxAttempts, nil, nil))
 }
 
 // defaultPolicy returns the queue.Policy applied when no operator config

--- a/internal/server/queue_factory.go
+++ b/internal/server/queue_factory.go
@@ -72,6 +72,9 @@ func perQueueConcurrencyFromConfig(cfg *config.Config) map[string]int {
 	if cfg.InboxJobConcurrency != nil && *cfg.InboxJobConcurrency > 0 {
 		out["inbox"] = *cfg.InboxJobConcurrency
 	}
+	if cfg.DriveLocalToObjectStorage.Concurrency > 0 {
+		out[queue.ObjectStorageQueueName] = cfg.DriveLocalToObjectStorage.Concurrency
+	}
 	if len(out) == 0 {
 		return nil
 	}

--- a/internal/server/queue_factory_test.go
+++ b/internal/server/queue_factory_test.go
@@ -223,6 +223,18 @@ func TestApplyClientPolicies_DeliverInboxDefaultAttempts(t *testing.T) {
 	assert.Equal(t, defaultInboxJobMaxAttempts-1, rec.lastOpts.MaxRetry)
 }
 
+func TestApplyClientPolicies_ObjectStorageDefaultAttempts(t *testing.T) {
+	rec := &recordingDriverClient{}
+	c := queue.NewClient(&stubDriver{client: rec})
+	defer func() { _ = c.Close() }()
+
+	applyClientPolicies(c, &config.Config{})
+
+	require.NoError(t, c.EnqueueObjectStorageMigrateFile("f1"))
+	assert.True(t, rec.lastOpts.MaxRetrySet, "objectStorage migrate default attempts must propagate")
+	assert.Equal(t, defaultObjectStorageMigrateMaxAttempts-1, rec.lastOpts.MaxRetry)
+}
+
 // TestApplyClientPolicies_OperatorAttemptsOptOut: operator が
 // deliverJobMaxAttempts=0 を明示すると opt-out (リトライ無し) として尊重され、
 // WithMaxRetry が付かない (= mkq attempts=0)。KeepFailed/KeepCompleted と同じ

--- a/internal/server/router.go
+++ b/internal/server/router.go
@@ -2,6 +2,7 @@ package server
 
 import (
 	"context"
+	"fmt"
 	"net/http"
 	"net/http/pprof"
 	urlpkg "net/url"
@@ -12,6 +13,7 @@ import (
 	"time"
 
 	"github.com/labstack/echo/v4"
+	"github.com/redis/go-redis/v9"
 	"github.com/shiroha-a/mk/internal/activitypub"
 	apiadmin "github.com/shiroha-a/mk/internal/api/admin"
 	apiannouncements "github.com/shiroha-a/mk/internal/api/announcements"
@@ -116,7 +118,7 @@ import (
 	"log/slog"
 )
 
-func (s *Server) setupRoutes() {
+func (s *Server) setupRoutes() error {
 	idGen, err := id.NewGenerator(s.config.ID)
 	if err != nil {
 		idGen, _ = id.NewGenerator("aidx")
@@ -362,14 +364,25 @@ func (s *Server) setupRoutes() {
 	// localDriveStorage は driveStorage が S3 に切り替わっても、
 	// storedInternal=true な drive_file を `/files/:accessKey` で提供する
 	// fallback として常に保持する (#1414)。
-	localDriveStorage := coredrive.NewLocalStorage("./drive-files", s.config.DriveURL)
+	localPath := s.config.DriveLocalToObjectStorage.LocalPath
+	localDriveStorage := coredrive.NewLocalStorage(localPath, s.config.DriveURL)
+	serverMeta, serverMetaErr := metaRepo.Fetch()
+	if s.config.DriveLocalToObjectStorage.Enabled {
+		if serverMetaErr != nil {
+			return fmt.Errorf("drive migration: fetch meta: %w", serverMetaErr)
+		}
+		if err := validateDriveLocalMigration(s.config, serverMeta); err != nil {
+			return err
+		}
+	}
 	var driveStorage coredrive.Storage
-	if serverMeta, err := metaRepo.Fetch(); err == nil {
-		driveStorage = coredrive.NewStorageFromMeta(serverMeta, "./drive-files", s.config.DriveURL)
+	if serverMetaErr == nil {
+		driveStorage = coredrive.NewStorageFromMeta(serverMeta, localPath, s.config.DriveURL)
 	} else {
 		driveStorage = localDriveStorage
 	}
 	driveService := coredrive.NewService(driveFileRepo, driveFolderRepo, driveStorage, idGen)
+	driveService.SetLegacyLocalStorage(localDriveStorage)
 	// drive/files/show は moderator なら他人 / リモートユーザー所有の file
 	// も返せるようにする (upstream Misskey の roleService.isModerator 経路
 	// と一致)。リモート添付メディアの詳細閲覧に必要。
@@ -459,6 +472,20 @@ func (s *Server) setupRoutes() {
 	})
 	emojiImportProcessor := processors.NewImportCustomEmojisProcessor(emojiImporter)
 	s.queueServer.Handle(queue.TaskTypeImportCustomEmojis, emojiImportProcessor.Handle)
+
+	driveMigrator := coredrive.NewMigrator(metaRepo, driveFileRepo, s.db, s.config.DriveLocalToObjectStorage, s.config.DriveURL)
+	var migrateRedis redis.UniversalClient
+	if s.redis != nil {
+		migrateRedis = s.redis.JobQueue
+	}
+	osMigrateProcessor := processors.NewObjectStorageMigrateProcessor(processors.ObjectStorageMigrateProcessorConfig{
+		Migrator:    driveMigrator,
+		FileRepo:    driveFileRepo,
+		EnqueueFile: s.queueClient.EnqueueObjectStorageMigrateFile,
+		Redis:       migrateRedis,
+	})
+	s.queueServer.Handle(queue.TaskTypeObjectStorageMigrateScan, osMigrateProcessor.Handle)
+	s.queueServer.Handle(queue.TaskTypeObjectStorageMigrateFile, osMigrateProcessor.Handle)
 
 	// Search (Phase 4.6)
 	// 設定に従って provider を選択する。Meilisearch が設定されていれば
@@ -2529,6 +2556,11 @@ func (s *Server) setupRoutes() {
 
 	// Frontend HTML shell — SPA catchall (最後に登録)
 	s.echo.GET("/*", frontend)
+
+	if err := s.maybeEnqueueDriveLocalMigration(driveFileRepo); err != nil {
+		return err
+	}
+	return nil
 }
 
 // notifReaderAdapter bridges stream.NotificationReader to

--- a/internal/server/router.go
+++ b/internal/server/router.go
@@ -2,7 +2,6 @@ package server
 
 import (
 	"context"
-	"fmt"
 	"net/http"
 	"net/http/pprof"
 	urlpkg "net/url"
@@ -367,13 +366,8 @@ func (s *Server) setupRoutes() error {
 	localPath := s.config.DriveLocalToObjectStorage.LocalPath
 	localDriveStorage := coredrive.NewLocalStorage(localPath, s.config.DriveURL)
 	serverMeta, serverMetaErr := metaRepo.Fetch()
-	if s.config.DriveLocalToObjectStorage.Enabled {
-		if serverMetaErr != nil {
-			return fmt.Errorf("drive migration: fetch meta: %w", serverMetaErr)
-		}
-		if err := validateDriveLocalMigration(s.config, serverMeta); err != nil {
-			return err
-		}
+	if s.config.DriveLocalToObjectStorage.Enabled && serverMetaErr != nil {
+		slog.Warn("driveLocalToObjectStorage.enabled but meta could not be loaded; migration jobs will not run", "error", serverMetaErr)
 	}
 	var driveStorage coredrive.Storage
 	if serverMetaErr == nil {
@@ -479,10 +473,12 @@ func (s *Server) setupRoutes() error {
 		migrateRedis = s.redis.JobQueue
 	}
 	osMigrateProcessor := processors.NewObjectStorageMigrateProcessor(processors.ObjectStorageMigrateProcessorConfig{
-		Migrator:    driveMigrator,
-		FileRepo:    driveFileRepo,
-		EnqueueFile: s.queueClient.EnqueueObjectStorageMigrateFile,
-		Redis:       migrateRedis,
+		Migrator:      driveMigrator,
+		FileRepo:      driveFileRepo,
+		EnqueueFile:   s.queueClient.EnqueueObjectStorageMigrateFile,
+		EnqueueScan:   s.queueClient.EnqueueObjectStorageMigrateScanFrom,
+		ScanBatchSize: s.config.DriveLocalToObjectStorage.ScanBatchSize,
+		Redis:         migrateRedis,
 	})
 	s.queueServer.Handle(queue.TaskTypeObjectStorageMigrateScan, osMigrateProcessor.Handle)
 	s.queueServer.Handle(queue.TaskTypeObjectStorageMigrateFile, osMigrateProcessor.Handle)
@@ -2561,7 +2557,7 @@ func (s *Server) setupRoutes() error {
 	// Frontend HTML shell — SPA catchall (最後に登録)
 	s.echo.GET("/*", frontend)
 
-	if err := s.maybeEnqueueDriveLocalMigration(driveFileRepo); err != nil {
+	if err := s.maybeEnqueueDriveLocalMigration(driveFileRepo, serverMeta); err != nil {
 		return err
 	}
 	return nil

--- a/internal/server/router.go
+++ b/internal/server/router.go
@@ -1535,7 +1535,7 @@ func (s *Server) setupRoutes() error {
 	if _, isLocal := driveStorage.(*coredrive.LocalStorage); !isLocal {
 		filesLookup = driveFileRepo
 	}
-	s.echo.GET("/files/:accessKey", filesHandler(filesLookup, driveStorage, localDriveStorage))
+	s.echo.GET("/files/:accessKey", filesHandler(filesLookup, driveStorage, localDriveStorage, s.config.DriveURL))
 
 	// Media proxy endpoint
 	proxyAllowlist := coremediaproxy.NewDBAllowlistChecker(s.db)

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -239,7 +239,9 @@ func New(cfg *config.Config, db *gorm.DB, redis *cache.RedisClients) (*Server, e
 		queueMetrics:   newQueueMetrics(queueDriver),
 	}
 
-	s.setupRoutes()
+	if err := s.setupRoutes(); err != nil {
+		return nil, fmt.Errorf("server: setup routes: %w", err)
+	}
 
 	return s, nil
 }

--- a/internal/testutil/mock_drive.go
+++ b/internal/testutil/mock_drive.go
@@ -1,6 +1,7 @@
 package testutil
 
 import (
+	"sort"
 	"strings"
 
 	"github.com/shiroha-a/mk/internal/model"
@@ -515,13 +516,7 @@ func (m *MockDriveFileRepository) ListStoredInternalIDs(untilID string, limit in
 		ids = append(ids, id)
 	}
 	// desc order by id (aidx sorts lexicographically as time order)
-	for i := 0; i < len(ids); i++ {
-		for j := i + 1; j < len(ids); j++ {
-			if ids[j] > ids[i] {
-				ids[i], ids[j] = ids[j], ids[i]
-			}
-		}
-	}
+	sort.Sort(sort.Reverse(sort.StringSlice(ids)))
 	if len(ids) > limit {
 		ids = ids[:limit]
 	}

--- a/internal/testutil/mock_drive.go
+++ b/internal/testutil/mock_drive.go
@@ -489,3 +489,41 @@ func (m *MockDriveFileRepository) DeleteByHost(host string) (int64, error) {
 	}
 	return n, nil
 }
+
+func (m *MockDriveFileRepository) CountStoredInternal() (int64, error) {
+	var n int64
+	for _, f := range m.Files {
+		if f.StoredInternal && !f.IsLink {
+			n++
+		}
+	}
+	return n, nil
+}
+
+func (m *MockDriveFileRepository) ListStoredInternalIDs(untilID string, limit int) ([]string, error) {
+	if limit <= 0 {
+		limit = 500
+	}
+	var ids []string
+	for id, f := range m.Files {
+		if !f.StoredInternal || f.IsLink {
+			continue
+		}
+		if untilID != "" && id >= untilID {
+			continue
+		}
+		ids = append(ids, id)
+	}
+	// desc order by id (aidx sorts lexicographically as time order)
+	for i := 0; i < len(ids); i++ {
+		for j := i + 1; j < len(ids); j++ {
+			if ids[j] > ids[i] {
+				ids[i], ids[j] = ids[j], ids[i]
+			}
+		}
+	}
+	if len(ids) > limit {
+		ids = ids[:limit]
+	}
+	return ids, nil
+}

--- a/internal/testutil/mock_drive.go
+++ b/internal/testutil/mock_drive.go
@@ -491,16 +491,6 @@ func (m *MockDriveFileRepository) DeleteByHost(host string) (int64, error) {
 	return n, nil
 }
 
-func (m *MockDriveFileRepository) CountStoredInternal() (int64, error) {
-	var n int64
-	for _, f := range m.Files {
-		if f.StoredInternal && !f.IsLink {
-			n++
-		}
-	}
-	return n, nil
-}
-
 func (m *MockDriveFileRepository) ListStoredInternalIDs(untilID string, limit int) ([]string, error) {
 	if limit <= 0 {
 		limit = 500


### PR DESCRIPTION
## Summary

- Add `driveLocalToObjectStorage` YAML/env settings to opt in local `./drive-files` → S3 migration on server boot (#1476).
- Run migration via `objectStorage` queue (`migrateScan` / `migrateFile`); update `drive_file` URLs, cascade `user`/`emoji` denormalized URLs, optional local blob deletion.
- Redirect migrated `GET /files/:accessKey` to public CDN/S3 URLs (302); set `storedInternal=false` for new S3 uploads; dual-delete legacy local blobs on file delete.
- **Important:** The 302 redirect behavior applies to **all** `useObjectStorage=true` instances when `storedInternal=false`, not only during `driveLocalToObjectStorage` migration. Same-origin `/files/` URLs in DB still proxy via storage (no redirect loop). See `docs/configuration.md`, CHANGELOG Unreleased **Upgrade notes**, and review thread.

### Upgrade / operations (object storage instances)

Before upgrading production instances with `useObjectStorage=true`:

1. `curl -I https://<instance>/files/<accessKey>` on representative files and confirm `Location` points at the expected CDN.
2. Plan for loss of same-origin `Cache-Control: no-transform` on proxied delivery (#730); set equivalent headers on S3 / CloudFront / CDN if using Polish or similar.
3. Validate CORS and clients that assumed same-origin `/files/` URLs.

### Other notes

- `AGENTS.md` → `CLAUDE.md` symlink is included intentionally for non-Claude agents; unrelated to #1476 but kept in this PR by author choice.

## 主な変更点

| Area | Change |
|------|--------|
| Config | `driveLocalToObjectStorage.{enabled,deleteLocal,localPath,concurrency}` + `MK_DRIVE_*` env keys |
| Core | `internal/core/drive/migrator.go` |
| Queue | `objectStorage` queue on asynq/mkq; processors in `object_storage_migrate.go` |
| Server | Startup validation + scan enqueue; enqueue/Redis errors log-only (startup continues) |
| Files | 302 redirect when `storedInternal=false` and row found in DB; same-origin `/files/` URLs fall back to storage (no redirect loop) |

## テスト

- `go test ./internal/config/... ./internal/core/drive/... ./internal/server/... ./internal/queue/... ./internal/queue/processors/...`

## 運用

1. Enable object storage in DB `meta` (existing admin flow).
2. Set `driveLocalToObjectStorage.enabled: true` in `.config/default.yml` and restart.
3. Monitor via logs / existing `admin/queue/*` APIs; set `enabled: false` after completion.

## Closes

Closes #1476