### PR TITLE
perf(federation): inbound verify ごとの公開鍵 x509 再パースをキャッシュ (#1426)

### DIFF
--- a/internal/activitypub/public_key_cache.go
+++ b/internal/activitypub/public_key_cache.go
@@ -1,0 +1,101 @@
+package activitypub
+
+import (
+	"crypto"
+	"crypto/sha256"
+	"encoding/hex"
+	"net/http"
+
+	lru "github.com/hashicorp/golang-lru/v2"
+)
+
+// DefaultPublicKeyCacheSize bounds the parsed-public-key LRU used by the
+// inbound HTTP Signature verify path. 受信側 actor key は実質「自分が交流
+// している remote actor 数」に比例し、relay 経由でも数千 order なので 4096 で
+// 大半の instance の working set を賄える。超過分は LRU が evict する。
+const DefaultPublicKeyCacheSize = 4096
+
+// parsedPublicKey bundles a decoded public key with its discriminated type so
+// the verify path can dispatch RSA / Ed25519 without re-parsing.
+type parsedPublicKey struct {
+	pub crypto.PublicKey
+	kt  KeyType
+}
+
+// PublicKeyCache memoizes the PEM -> parsed-key (pub, KeyType) decode so the
+// inbound HTTP Signature verify hot path skips pem.Decode +
+// x509.ParsePKIXPublicKey on every activity (#1426). It is the inbound
+// analogue of DeliverProcessor.signingKey on the outbound side (#1425).
+//
+// cache key は (keyId, PEM) の sha256 hex。PEM が変わる (= 鍵 rotation) と cache
+// key も変わるため stale な鍵を返さない。これにより resolver が常に「永続層の
+// 最新 PEM」を返す既存セマンティクス (Resolver.PublicKeyForKeyID の doc) を壊さ
+// ずに、同一 PEM に対する x509 パースだけを 1 回に集約できる。
+//
+// 並行安全: lru.Cache は内部 mutex を持つため複数 inbox worker から同時に呼んで
+// よい。parse seam (parse field) はテストでパース回数を観測するためのもので、
+// 本番では ParsePublicKey 固定。
+type PublicKeyCache struct {
+	lru *lru.Cache[string, parsedPublicKey]
+	// parse はパースの seam。本番は ParsePublicKey、テストではパース回数を数える
+	// closure を差し込む。NewPublicKeyCache が ParsePublicKey で初期化する。
+	parse func(pemStr string) (crypto.PublicKey, KeyType, error)
+}
+
+// NewPublicKeyCache constructs a PublicKeyCache with the given LRU size.
+// size <= 0 は DefaultPublicKeyCacheSize に丸める。lru.New は size>0 で error を
+// 返さない実装だが、防御的に握って lru==nil (= 都度パース) にフォールバックする。
+func NewPublicKeyCache(size int) *PublicKeyCache {
+	if size <= 0 {
+		size = DefaultPublicKeyCacheSize
+	}
+	c := &PublicKeyCache{parse: ParsePublicKey}
+	if l, err := lru.New[string, parsedPublicKey](size); err == nil {
+		c.lru = l
+	}
+	return c
+}
+
+// publicKeyCacheKey folds (keyID, PEM) into a sha256 hex string. map key を
+// ~1.5KB の PEM から 64B に縮め、PEM 本体が key 経由でログ等に漏れるリスクも
+// 下げる (deliver.go と同じ方式)。null-byte separator で keyID/PEM 境界の曖昧
+// さを避ける。
+func publicKeyCacheKey(keyID, pemStr string) string {
+	sum := sha256.Sum256([]byte(keyID + "\x00" + pemStr))
+	return hex.EncodeToString(sum[:])
+}
+
+// parsedKey returns the parsed (pub, kt) for (keyID, pem), memoizing the x509
+// parse. nil receiver / lru 未設定 (= New 失敗の防御経路) では都度パースに
+// フォールバックする。パース失敗はキャッシュしない (次回再試行できる)。
+func (c *PublicKeyCache) parsedKey(keyID, pemStr string) (crypto.PublicKey, KeyType, error) {
+	if c == nil {
+		return ParsePublicKey(pemStr)
+	}
+	if c.lru == nil {
+		return c.parse(pemStr)
+	}
+	ck := publicKeyCacheKey(keyID, pemStr)
+	if v, ok := c.lru.Get(ck); ok {
+		return v.pub, v.kt, nil
+	}
+	pub, kt, err := c.parse(pemStr)
+	if err != nil {
+		return nil, 0, err
+	}
+	c.lru.Add(ck, parsedPublicKey{pub: pub, kt: kt})
+	return pub, kt, nil
+}
+
+// VerifyRequestCached verifies req's HTTP Signature using a memoized parse of
+// (keyID, pem). 挙動は activitypub.VerifyRequest と等価だが、(keyId, PEM) 単位で
+// x509 パースを 1 回に集約する inbound hot path 用 drop-in (#1426)。pem は呼び
+// 出し側 (resolver) が返す「永続層の最新値」前提で、stale PEM は cache key 不一致
+// で自動的に再パースされる。
+func (c *PublicKeyCache) VerifyRequestCached(req *http.Request, keyID, pemStr string) error {
+	pub, kt, err := c.parsedKey(keyID, pemStr)
+	if err != nil {
+		return err
+	}
+	return VerifyRequestWithKey(req, pub, kt)
+}

--- a/internal/activitypub/public_key_cache.go
+++ b/internal/activitypub/public_key_cache.go
@@ -96,14 +96,22 @@ func (c *PublicKeyCache) parsedKey(keyID, pemStr string) (crypto.PublicKey, KeyT
 }
 
 // VerifyRequestCached verifies req's HTTP Signature using a memoized parse of
-// (keyID, pem). 挙動は activitypub.VerifyRequest と等価だが、(keyId, PEM) 単位で
+// (keyID, pem). 挙動は activitypub.VerifyRequest と等価で、(keyId, PEM) 単位で
 // x509 パースを 1 回に集約する inbound hot path 用 drop-in (#1426)。pem は呼び
 // 出し側 (resolver) が返す「永続層の最新値」前提で、stale PEM は cache key 不一致
 // で自動的に再パースされる。
+//
+// VerifyRequest と同じく signature header parse + algorithm guard を公開鍵パース
+// (ここでは cache 参照) より前に行うため、未対応 algorithm のリクエストでは鍵を
+// パース / cache 参照せず短絡し、エラー優先順位も一致する (#1426 review)。
 func (c *PublicKeyCache) VerifyRequestCached(req *http.Request, keyID, pemStr string) error {
+	parsed, err := parseSignatureForVerify(req)
+	if err != nil {
+		return err
+	}
 	pub, kt, err := c.parsedKey(keyID, pemStr)
 	if err != nil {
 		return err
 	}
-	return VerifyRequestWithKey(req, pub, kt)
+	return verifyParsed(req, parsed, pub, kt)
 }

--- a/internal/activitypub/public_key_cache.go
+++ b/internal/activitypub/public_key_cache.go
@@ -72,14 +72,22 @@ func (c *PublicKeyCache) parsedKey(keyID, pemStr string) (crypto.PublicKey, KeyT
 	if c == nil {
 		return ParsePublicKey(pemStr)
 	}
+	// parse seam が未設定 (= NewPublicKeyCache を経由せずゼロ値の PublicKeyCache を
+	// 直接生成した場合) でも panic させず ParsePublicKey にフォールバックする。
+	// PublicKeyCache は exported 型なので、他パッケージが `&PublicKeyCache{}` を
+	// 作って呼ぶ誤用に備える (本番経路は必ず NewPublicKeyCache で parse 配線済み)。
+	parse := c.parse
+	if parse == nil {
+		parse = ParsePublicKey
+	}
 	if c.lru == nil {
-		return c.parse(pemStr)
+		return parse(pemStr)
 	}
 	ck := publicKeyCacheKey(keyID, pemStr)
 	if v, ok := c.lru.Get(ck); ok {
 		return v.pub, v.kt, nil
 	}
-	pub, kt, err := c.parse(pemStr)
+	pub, kt, err := parse(pemStr)
 	if err != nil {
 		return nil, 0, err
 	}

--- a/internal/activitypub/public_key_cache_test.go
+++ b/internal/activitypub/public_key_cache_test.go
@@ -175,6 +175,22 @@ func TestPublicKeyCache_VerifyRequestCached_Success(t *testing.T) {
 	assert.Equal(t, 1, parses, "VerifyRequestCached must reuse the memoized key")
 }
 
+func TestPublicKeyCache_VerifyRequestCached_AlgCheckedBeforeParse(t *testing.T) {
+	// 未対応 algorithm のリクエストは公開鍵をパース / cache 参照する前に弾く
+	// (= VerifyRequest と同じエラー優先順位)。bad PEM を渡しても "unsupported
+	// algorithm" が返り、parse seam は一度も呼ばれない。
+	req, _ := http.NewRequest(http.MethodGet, "https://x.example/", nil)
+	req.Header.Set("Signature", `keyId="x",algorithm="hmac-sha256",signature="y"`)
+	c := NewPublicKeyCache(8)
+	var parses int
+	c.parse = countingParse(&parses)
+
+	err := c.VerifyRequestCached(req, "x", "not a pem")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "unsupported")
+	assert.Equal(t, 0, parses, "unsupported algorithm must short-circuit before parsing the key")
+}
+
 func TestPublicKeyCache_VerifyRequestCached_ParseError(t *testing.T) {
 	key, _ := newTestKey(t)
 	req, _ := http.NewRequest(http.MethodGet, "https://remote.example/users/bob", nil)

--- a/internal/activitypub/public_key_cache_test.go
+++ b/internal/activitypub/public_key_cache_test.go
@@ -1,0 +1,188 @@
+package activitypub
+
+import (
+	"bytes"
+	"crypto"
+	"errors"
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// countingParse wraps ParsePublicKey and records how many times the cache had
+// to actually decode a PEM. メモ化が効いていれば同一 (keyId, PEM) では 1 回しか
+// 増えない。
+func countingParse(n *int) func(string) (crypto.PublicKey, KeyType, error) {
+	return func(pemStr string) (crypto.PublicKey, KeyType, error) {
+		*n++
+		return ParsePublicKey(pemStr)
+	}
+}
+
+func TestNewPublicKeyCache_Defaults(t *testing.T) {
+	// size<=0 は default に丸めつつ lru / parse seam が配線される。
+	for _, size := range []int{0, -5} {
+		c := NewPublicKeyCache(size)
+		require.NotNil(t, c)
+		require.NotNil(t, c.lru, "size=%d should still allocate the LRU", size)
+		require.NotNil(t, c.parse, "parse seam defaults to ParsePublicKey")
+	}
+	c := NewPublicKeyCache(8)
+	require.NotNil(t, c.lru)
+}
+
+func TestPublicKeyCache_MemoizesRSAParse(t *testing.T) {
+	_, pub := newTestKey(t)
+	c := NewPublicKeyCache(8)
+	var parses int
+	c.parse = countingParse(&parses)
+
+	p1, kt1, err := c.parsedKey("kid", pub)
+	require.NoError(t, err)
+	assert.Equal(t, KeyTypeRSA, kt1)
+
+	p2, _, err := c.parsedKey("kid", pub)
+	require.NoError(t, err)
+
+	// 同一 (keyId, PEM) は 1 回だけパースされ、同じ *rsa.PublicKey ポインタが返る。
+	assert.Equal(t, 1, parses, "same (keyId, PEM) must parse exactly once")
+	assert.Same(t, p1, p2, "cache hit must return the identical parsed key")
+}
+
+func TestPublicKeyCache_ReparsesOnRotation(t *testing.T) {
+	_, pub := newTestKey(t)
+	c := NewPublicKeyCache(8)
+	var parses int
+	c.parse = countingParse(&parses)
+
+	p1, _, err := c.parsedKey("kid", pub)
+	require.NoError(t, err)
+
+	// 同じ keyId でも PEM が変われば (= 鍵 rotation) cache key が変わり再パース。
+	_, rotated, err := GenerateRSAKeypair()
+	require.NoError(t, err)
+	p2, _, err := c.parsedKey("kid", rotated)
+	require.NoError(t, err)
+
+	assert.Equal(t, 2, parses, "rotated PEM under same keyId must re-parse")
+	assert.NotSame(t, p1, p2, "rotation must not return the stale parsed key")
+}
+
+func TestPublicKeyCache_MemoizesEd25519Parse(t *testing.T) {
+	_, pub := newTestEd25519Key(t)
+	c := NewPublicKeyCache(8)
+	var parses int
+	c.parse = countingParse(&parses)
+
+	_, kt1, err := c.parsedKey("ed-kid", pub)
+	require.NoError(t, err)
+	assert.Equal(t, KeyTypeEd25519, kt1)
+
+	_, _, err = c.parsedKey("ed-kid", pub)
+	require.NoError(t, err)
+	// ed25519.PublicKey は slice なので pointer 比較はできない。parse 回数で
+	// メモ化を確認する。
+	assert.Equal(t, 1, parses)
+}
+
+func TestPublicKeyCache_DistinctKeyIDsParseSeparately(t *testing.T) {
+	_, pub := newTestKey(t)
+	c := NewPublicKeyCache(8)
+	var parses int
+	c.parse = countingParse(&parses)
+
+	_, _, err := c.parsedKey("kid-a", pub)
+	require.NoError(t, err)
+	// 同じ PEM でも keyId が異なれば別 entry (cache key は keyId+PEM の sha256)。
+	_, _, err = c.parsedKey("kid-b", pub)
+	require.NoError(t, err)
+	assert.Equal(t, 2, parses)
+}
+
+func TestPublicKeyCache_ParseErrorNotCached(t *testing.T) {
+	c := NewPublicKeyCache(8)
+	var parses int
+	c.parse = func(string) (crypto.PublicKey, KeyType, error) {
+		parses++
+		return nil, 0, errors.New("boom")
+	}
+	_, _, err := c.parsedKey("kid", "bad pem")
+	require.Error(t, err)
+	// 失敗はキャッシュされず、次回は再試行される。
+	_, _, err = c.parsedKey("kid", "bad pem")
+	require.Error(t, err)
+	assert.Equal(t, 2, parses, "parse errors must not be memoized")
+}
+
+func TestPublicKeyCache_NilReceiverFallsBackToParse(t *testing.T) {
+	_, pub := newTestKey(t)
+	var c *PublicKeyCache
+	// nil receiver でも都度パースで動く (防御経路)。
+	_, kt, err := c.parsedKey("kid", pub)
+	require.NoError(t, err)
+	assert.Equal(t, KeyTypeRSA, kt)
+
+	_, _, err = c.parsedKey("kid", "not pem")
+	assert.Error(t, err)
+}
+
+func TestPublicKeyCache_NilLRUFallsBackToParse(t *testing.T) {
+	_, pub := newTestKey(t)
+	c := NewPublicKeyCache(8)
+	c.lru = nil // lru.New 失敗を模した防御経路
+	var parses int
+	c.parse = countingParse(&parses)
+
+	_, _, err := c.parsedKey("kid", pub)
+	require.NoError(t, err)
+	_, _, err = c.parsedKey("kid", pub)
+	require.NoError(t, err)
+	// lru が無いので memoize されず毎回パースされるが、エラーにはならない。
+	assert.Equal(t, 2, parses)
+}
+
+func TestPublicKeyCache_VerifyRequestCached_Success(t *testing.T) {
+	key, pub := newTestKey(t)
+	body := []byte(`{"type":"Create"}`)
+	req, err := http.NewRequest(http.MethodPost, "https://remote.example/inbox", bytes.NewReader(body))
+	require.NoError(t, err)
+	require.NoError(t, SignRequest(req, key, SHA256Digest(body), []string{"(request-target)", "date", "host", "digest"}))
+	req.Header.Set("Host", "remote.example")
+
+	c := NewPublicKeyCache(8)
+	var parses int
+	c.parse = countingParse(&parses)
+
+	require.NoError(t, c.VerifyRequestCached(req, key.KeyID, pub))
+	// 2 回目の verify (同一 keyId/PEM) でも x509 パースは増えない。
+	require.NoError(t, c.VerifyRequestCached(req, key.KeyID, pub))
+	assert.Equal(t, 1, parses, "VerifyRequestCached must reuse the memoized key")
+}
+
+func TestPublicKeyCache_VerifyRequestCached_ParseError(t *testing.T) {
+	key, _ := newTestKey(t)
+	req, _ := http.NewRequest(http.MethodGet, "https://remote.example/users/bob", nil)
+	require.NoError(t, SignRequest(req, key, "", []string{"(request-target)", "date", "host"}))
+	req.Header.Set("Host", "remote.example")
+
+	c := NewPublicKeyCache(8)
+	// PEM が壊れていれば parse error がそのまま返る。
+	err := c.VerifyRequestCached(req, key.KeyID, "not a pem")
+	assert.Error(t, err)
+}
+
+func TestPublicKeyCache_VerifyRequestCached_VerifyFails(t *testing.T) {
+	key, _ := newTestKey(t)
+	// 署名鍵とは別の鍵で verify すると失敗する。
+	_, otherPub, err := GenerateRSAKeypair()
+	require.NoError(t, err)
+	req, _ := http.NewRequest(http.MethodGet, "https://remote.example/users/bob", nil)
+	require.NoError(t, SignRequest(req, key, "", []string{"(request-target)", "date", "host"}))
+	req.Header.Set("Host", "remote.example")
+
+	c := NewPublicKeyCache(8)
+	err = c.VerifyRequestCached(req, key.KeyID, otherPub)
+	assert.Error(t, err)
+}

--- a/internal/activitypub/public_key_cache_test.go
+++ b/internal/activitypub/public_key_cache_test.go
@@ -143,6 +143,20 @@ func TestPublicKeyCache_NilLRUFallsBackToParse(t *testing.T) {
 	assert.Equal(t, 2, parses)
 }
 
+func TestPublicKeyCache_ZeroValueDoesNotPanic(t *testing.T) {
+	_, pub := newTestKey(t)
+	// NewPublicKeyCache を経由しないゼロ値 (lru / parse とも nil) でも panic せず
+	// 都度パースで動く (exported 型の誤用に対する防御)。
+	c := &PublicKeyCache{}
+	got, kt, err := c.parsedKey("kid", pub)
+	require.NoError(t, err)
+	require.NotNil(t, got)
+	assert.Equal(t, KeyTypeRSA, kt)
+
+	_, _, err = c.parsedKey("kid", "not pem")
+	assert.Error(t, err)
+}
+
 func TestPublicKeyCache_VerifyRequestCached_Success(t *testing.T) {
 	key, pub := newTestKey(t)
 	body := []byte(`{"type":"Create"}`)

--- a/internal/activitypub/signature.go
+++ b/internal/activitypub/signature.go
@@ -201,18 +201,44 @@ func ParseSignatureHeader(header string) (*ParsedSignature, error) {
 // supplied PEM public key. RSA / Ed25519 public keys are both supported,
 // dispatched on the parsed Signature `algorithm` parameter and the public
 // key type.
+//
+// 公開鍵 PEM を毎回パースする経路。inbound hot path で同一鍵を繰り返し検証する
+// 場合は PublicKeyCache.VerifyRequestCached で x509 パースをメモ化すること
+// (#1426)。
 func VerifyRequest(req *http.Request, publicKeyPEM string) error {
 	parsed, err := ParseSignatureHeader(req.Header.Get("Signature"))
 	if err != nil {
 		return err
 	}
 	// 早期にalgorithm名を弾く (公開鍵PEMパースより前に判定したい)。
+	// VerifyRequestWithKey も同じ guard を持つが、ここで先に弾くことで未対応
+	// algorithm のリクエストに対し無駄な x509 パースを走らせない (空 PEM で
+	// algorithm error を期待する既存テスト互換も維持)。
 	if !isKnownAlgorithm(parsed.Algorithm) {
 		return fmt.Errorf("unsupported algorithm %q", parsed.Algorithm)
 	}
 	pub, kt, err := ParsePublicKey(publicKeyPEM)
 	if err != nil {
 		return err
+	}
+	return VerifyRequestWithKey(req, pub, kt)
+}
+
+// VerifyRequestWithKey verifies an incoming HTTP request signature against an
+// already-parsed public key. This is the parse-free core of VerifyRequest: the
+// inbound hot path (#1426) supplies a memoized (pub, kt) so the per-request
+// pem.Decode + x509.ParsePKIXPublicKey cost is paid once per (keyId, PEM)
+// instead of on every verify.
+//
+// pub / kt は ParsePublicKey 由来であること (RSA は *rsa.PublicKey、Ed25519 は
+// ed25519.PublicKey)。algorithm と鍵種別の不一致は verifyAlgorithm が拒否する。
+func VerifyRequestWithKey(req *http.Request, pub crypto.PublicKey, kt KeyType) error {
+	parsed, err := ParseSignatureHeader(req.Header.Get("Signature"))
+	if err != nil {
+		return err
+	}
+	if !isKnownAlgorithm(parsed.Algorithm) {
+		return fmt.Errorf("unsupported algorithm %q", parsed.Algorithm)
 	}
 	signingString, err := buildSigningString(req, parsed.Headers)
 	if err != nil {

--- a/internal/activitypub/signature.go
+++ b/internal/activitypub/signature.go
@@ -206,26 +206,22 @@ func ParseSignatureHeader(header string) (*ParsedSignature, error) {
 // 場合は PublicKeyCache.VerifyRequestCached で x509 パースをメモ化すること
 // (#1426)。
 func VerifyRequest(req *http.Request, publicKeyPEM string) error {
-	parsed, err := ParseSignatureHeader(req.Header.Get("Signature"))
+	// signature header の parse と algorithm guard は PEM パースより前に行う。
+	// 未対応 algorithm のリクエストに無駄な x509 パースを走らせず、空 PEM でも
+	// algorithm error を返す既存挙動を維持する。
+	parsed, err := parseSignatureForVerify(req)
 	if err != nil {
 		return err
-	}
-	// 早期にalgorithm名を弾く (公開鍵PEMパースより前に判定したい)。
-	// VerifyRequestWithKey も同じ guard を持つが、ここで先に弾くことで未対応
-	// algorithm のリクエストに対し無駄な x509 パースを走らせない (空 PEM で
-	// algorithm error を期待する既存テスト互換も維持)。
-	if !isKnownAlgorithm(parsed.Algorithm) {
-		return fmt.Errorf("unsupported algorithm %q", parsed.Algorithm)
 	}
 	pub, kt, err := ParsePublicKey(publicKeyPEM)
 	if err != nil {
 		return err
 	}
-	return VerifyRequestWithKey(req, pub, kt)
+	return verifyParsed(req, parsed, pub, kt)
 }
 
 // VerifyRequestWithKey verifies an incoming HTTP request signature against an
-// already-parsed public key. This is the parse-free core of VerifyRequest: the
+// already-parsed public key. This is the parse-free entry of VerifyRequest: the
 // inbound hot path (#1426) supplies a memoized (pub, kt) so the per-request
 // pem.Decode + x509.ParsePKIXPublicKey cost is paid once per (keyId, PEM)
 // instead of on every verify.
@@ -233,13 +229,33 @@ func VerifyRequest(req *http.Request, publicKeyPEM string) error {
 // pub / kt は ParsePublicKey 由来であること (RSA は *rsa.PublicKey、Ed25519 は
 // ed25519.PublicKey)。algorithm と鍵種別の不一致は verifyAlgorithm が拒否する。
 func VerifyRequestWithKey(req *http.Request, pub crypto.PublicKey, kt KeyType) error {
-	parsed, err := ParseSignatureHeader(req.Header.Get("Signature"))
+	parsed, err := parseSignatureForVerify(req)
 	if err != nil {
 		return err
 	}
-	if !isKnownAlgorithm(parsed.Algorithm) {
-		return fmt.Errorf("unsupported algorithm %q", parsed.Algorithm)
+	return verifyParsed(req, parsed, pub, kt)
+}
+
+// parseSignatureForVerify parses the Signature header and rejects unsupported
+// algorithm names. これを verify 経路 (VerifyRequest / VerifyRequestWithKey /
+// PublicKeyCache.VerifyRequestCached) で共有することで、header parse を 1 経路
+// につき 1 回に統一し、algorithm guard を必ず公開鍵パースより前に効かせる
+// (= 3 経路でエラー優先順位を揃える、#1426 review)。
+func parseSignatureForVerify(req *http.Request) (*ParsedSignature, error) {
+	parsed, err := ParseSignatureHeader(req.Header.Get("Signature"))
+	if err != nil {
+		return nil, err
 	}
+	if !isKnownAlgorithm(parsed.Algorithm) {
+		return nil, fmt.Errorf("unsupported algorithm %q", parsed.Algorithm)
+	}
+	return parsed, nil
+}
+
+// verifyParsed is the shared verification core invoked once the signature
+// header is parsed and the public key is available. signing string の再構築 →
+// 署名 base64 decode → 鍵種別ごとの verify → Digest フォーマットチェックを行う。
+func verifyParsed(req *http.Request, parsed *ParsedSignature, pub crypto.PublicKey, kt KeyType) error {
 	signingString, err := buildSigningString(req, parsed.Headers)
 	if err != nil {
 		return err

--- a/internal/activitypub/signature_test.go
+++ b/internal/activitypub/signature_test.go
@@ -450,3 +450,73 @@ func TestVerifyRequest_FromHTTPServer(t *testing.T) {
 	defer resp.Body.Close()
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
 }
+
+// --- VerifyRequestWithKey (#1426): the parse-free core used by PublicKeyCache ---
+
+func TestVerifyRequestWithKey_RSASuccess(t *testing.T) {
+	key, pubPEM := newTestKey(t)
+	body := []byte(`{"type":"Create"}`)
+	req, _ := http.NewRequest(http.MethodPost, "https://remote.example/inbox", bytes.NewReader(body))
+	require.NoError(t, SignRequest(req, key, SHA256Digest(body), []string{"(request-target)", "date", "host", "digest"}))
+	req.Header.Set("Host", "remote.example")
+
+	pub, kt, err := ParsePublicKey(pubPEM)
+	require.NoError(t, err)
+	require.NoError(t, VerifyRequestWithKey(req, pub, kt))
+}
+
+func TestVerifyRequestWithKey_Ed25519Success(t *testing.T) {
+	key, pubPEM := newTestEd25519Key(t)
+	req, _ := http.NewRequest(http.MethodGet, "https://remote.example/users/bob", nil)
+	require.NoError(t, SignRequest(req, key, "", []string{"(request-target)", "date", "host"}))
+	req.Header.Set("Host", "remote.example")
+
+	pub, kt, err := ParsePublicKey(pubPEM)
+	require.NoError(t, err)
+	require.NoError(t, VerifyRequestWithKey(req, pub, kt))
+}
+
+func TestVerifyRequestWithKey_BadSignatureHeader(t *testing.T) {
+	_, pubPEM := newTestKey(t)
+	pub, kt, err := ParsePublicKey(pubPEM)
+	require.NoError(t, err)
+	req, _ := http.NewRequest(http.MethodGet, "https://x.example/", nil)
+	// Signature ヘッダ無し -> ParseSignatureHeader で弾かれる。
+	assert.Error(t, VerifyRequestWithKey(req, pub, kt))
+}
+
+func TestVerifyRequestWithKey_UnsupportedAlgorithm(t *testing.T) {
+	_, pubPEM := newTestKey(t)
+	pub, kt, err := ParsePublicKey(pubPEM)
+	require.NoError(t, err)
+	req, _ := http.NewRequest(http.MethodGet, "https://x.example/", nil)
+	req.Header.Set("Signature", `keyId="x",algorithm="hmac-sha256",signature="y"`)
+	err = VerifyRequestWithKey(req, pub, kt)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "unsupported")
+}
+
+func TestVerifyRequestWithKey_KeyTypeMismatch(t *testing.T) {
+	// RSA 鍵に対し algorithm=ed25519 -> verifyAlgorithm が拒否する。
+	_, pubPEM := newTestKey(t)
+	pub, kt, err := ParsePublicKey(pubPEM)
+	require.NoError(t, err)
+	req, _ := http.NewRequest(http.MethodGet, "https://remote.example/", nil)
+	req.Header.Set("Date", "Mon, 01 Jan 2024 00:00:00 GMT")
+	dummySig := base64.StdEncoding.EncodeToString(make([]byte, 64))
+	req.Header.Set("Signature", `keyId="x",algorithm="ed25519",headers="date",signature="`+dummySig+`"`)
+	err = VerifyRequestWithKey(req, pub, kt)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "Ed25519")
+}
+
+func TestVerifyRequestWithKey_BadSignatureBase64(t *testing.T) {
+	key, pubPEM := newTestKey(t)
+	pub, kt, err := ParsePublicKey(pubPEM)
+	require.NoError(t, err)
+	req, _ := http.NewRequest(http.MethodGet, "https://x.example/users/bob", nil)
+	require.NoError(t, SignRequest(req, key, "", []string{"(request-target)", "date", "host"}))
+	req.Header.Set("Host", "x.example")
+	req.Header.Set("Signature", `keyId="x",algorithm="rsa-sha256",headers="(request-target) date host",signature="!!notbase64!!"`)
+	assert.Error(t, VerifyRequestWithKey(req, pub, kt))
+}

--- a/internal/api/inbox/handler.go
+++ b/internal/api/inbox/handler.go
@@ -59,11 +59,15 @@ type Handler struct {
 	instanceTracker InstanceTracker
 	chartHook       ChartHook
 	enqueuer        InboxEnqueuer
+	// keyCache は同期 fallback 経路 (SetEnqueuer 未配線時) の HTTP Signature
+	// verify で公開鍵パースをメモ化する (#1426)。worker 側 InboxProcessor と
+	// 同じ最適化を、enqueue せず inline verify する構成にも適用する。
+	keyCache *activitypub.PublicKeyCache
 }
 
 // NewHandler constructs a Handler.
 func NewHandler(resolver *federation.Resolver, processor *federation.Processor) *Handler {
-	return &Handler{resolver: resolver, processor: processor}
+	return &Handler{resolver: resolver, processor: processor, keyCache: activitypub.NewPublicKeyCache(0)}
 }
 
 // SetEnqueuer wires the queue.Enqueuer used to dispatch verified activities
@@ -227,7 +231,9 @@ func (h *Handler) verifySignature(req *http.Request) (*model.User, error) {
 	if err != nil {
 		return nil, err
 	}
-	if err := activitypub.VerifyRequest(req, pem); err != nil {
+	// keyCache 経由で verify し、同一 (keyId, PEM) の x509 パースをメモ化する
+	// (#1426)。挙動は VerifyRequest と等価。
+	if err := h.keyCache.VerifyRequestCached(req, parsed.KeyID, pem); err != nil {
 		return nil, err
 	}
 	return actor, nil

--- a/internal/queue/processors/inbox.go
+++ b/internal/queue/processors/inbox.go
@@ -87,13 +87,18 @@ type InboxProcessor struct {
 	hostBlocker     HostBlockChecker
 	instanceTracker InstanceTracker
 	chartHook       InboxChartHook
+	// keyCache は受信 HTTP Signature verify の公開鍵パースをメモ化する (#1426)。
+	// InboxProcessor は worker 間共有の単一インスタンス (router.go:616) なので、
+	// 同一 remote actor からの連続 activity で x509 パースを 1 回に集約できる
+	// (#1436 の DeliverProcessor.keyCache と対になる inbound 側最適化)。
+	keyCache *activitypub.PublicKeyCache
 }
 
 // NewInboxProcessor constructs an InboxProcessor wrapping the supplied
 // federation.Processor. Set* メソッドで verify / block / track / chart の
 // 各 dep を別途配線する。未配線の dep は no-op として扱われる。
 func NewInboxProcessor(p FederationProcessor) *InboxProcessor {
-	return &InboxProcessor{processor: p}
+	return &InboxProcessor{processor: p, keyCache: activitypub.NewPublicKeyCache(0)}
 }
 
 // SetLDSignatureVerifier wires an optional LD-Signature verifier that runs
@@ -223,7 +228,9 @@ func (p *InboxProcessor) verifyPayload(payload queue.InboxPayload) (*model.User,
 	if err != nil {
 		return nil, err
 	}
-	if err := activitypub.VerifyRequest(req, pem); err != nil {
+	// keyCache 経由で verify することで、同一 (keyId, PEM) の x509 パースを
+	// worker 横断で 1 回に集約する (#1426)。挙動は VerifyRequest と等価。
+	if err := p.keyCache.VerifyRequestCached(req, parsed.KeyID, pem); err != nil {
 		return nil, err
 	}
 	return actor, nil


### PR DESCRIPTION
## Summary

inbox worker は受信 activity 1 件ごとに `activitypub.VerifyRequest` →
`ParsePublicKey` で公開鍵を `pem.Decode` + `x509.ParsePKIXPublicKey` し直して
いた。in-memory cache (`resolver.publicKeyEntry`) は PEM 文字列しか保持して
おらず、パース済み `crypto.PublicKey` を持たないため、高 inbound rps の relay /
大規模連合で worker CPU を浪費していた。#1425 (deliver 秘密鍵メモ化、#1436) の
対になる inbound 側改善。

verify 境界に `(keyId, PEM)` をキーにしたパース済み鍵キャッシュを置き、同一
PEM に対する x509 パースを 1 回に集約する。

## 設計判断 (issue 原案からの逸脱)

issue 原案は `publicKeyEntry` にパース済み `crypto.PublicKey` を保持する方針
だったが、inbox verify が呼ぶ `PublicKeyForKeyID` の **Ed25519/Multikey 分岐は
in-memory cache を意図的に通さず** `publickeyExtraRepo.FindByKeyID` で DB から
直接 PEM を返す (resolver doc: "永続層の最新値で verify する")。このため原案
では Ed25519 経路をメモ化できず、本番では `publickeyExtraRepo` 配線済みで RSA
cache hit 時も毎回 x509 パースが走る。

そこで **verify 境界のパース済み鍵キャッシュ** に変更した:

- RSA / Ed25519 両経路を均一にカバー。
- 鍵 rotation は PEM が変われば cache key も変わり自動的に再パース → stale 鍵を
  返さず、resolver の「常に最新 PEM で verify」セマンティクスを破壊しない。
- `resolver.go` は非変更。マージ済みの対 PR #1436 (DeliverProcessor.keyCache) と
  対称な processor-level pattern。

(設計判断の詳細は issue #1426 の方針確認を参照)

## 主な変更点

- `internal/activitypub/public_key_cache.go` (new): `PublicKeyCache`
  (`lru.Cache` + parse seam)。cache key = `sha256(keyId + "\x00" + PEM)` hex
  (deliver.go と同方式で PEM 本体を key に晒さない)。`VerifyRequestCached` を提供。
- `internal/activitypub/signature.go`: `VerifyRequestWithKey(req, pub, kt)` を
  切り出し、`VerifyRequest` はそれに委譲する薄い wrapper に。alg-known guard を
  x509 パースより前に維持し既存テスト互換。
- `internal/queue/processors/inbox.go`: `InboxProcessor` に `keyCache` を配線
  (worker hot path)。
- `internal/api/inbox/handler.go`: 同期 fallback handler (SetEnqueuer 未配線時)
  にも同型 cache を配線し、全 inbound HTTP-sig verify 経路を網羅。

## テスト

- `internal/activitypub/public_key_cache_test.go` (new):
  - 同一 `(keyId, PEM)` で x509 パースが 1 回 (counter) + 同一ポインタ
    (`assert.Same`)。
  - PEM rotation (同 keyId・別 PEM) で再パース (counter==2) + `assert.NotSame`。
  - Ed25519 経路、distinct keyId は別 entry、parse error 非キャッシュ。
  - nil receiver / lru-nil fallback、`VerifyRequestCached` 成功 / parse error /
    verify fail。
- `internal/activitypub/signature_test.go`: `VerifyRequestWithKey` 直接テスト
  6 件 (RSA/Ed25519 成功、header 不正、unsupported algorithm、key-type 不一致、
  bad base64)。
- 既存 inbox / api/inbox の verify テストは挙動等価で green。

実行方法・結果:
- `make fmt && make lint` clean。
- `make test` 全体 green (130 packages ok / FAIL 0)。
- 変更 3 パッケージ `-race` green。新規関数 4 つ + `VerifyRequestWithKey` は
  100% 被覆。package coverage: activitypub 90.7% / queue/processors 90.8% /
  api/inbox 98.5% (各 90% gate 通過)。

## その他

- 効果測定は隔離 bench stack で別途実施 (本番 UDS では行わない)。
- スコープ外: LD-Signature (RsaSignature2017) verify の鍵パース、`api/ap` の直接
  PEM パース (別 issue 候補)。

Closes #1426

🤖 Generated with [Claude Code](https://claude.com/claude-code)
