### PR TITLE
perf(db): note.mentions / note.fileIds に GIN インデックスを追加 (#1427)

### DIFF
--- a/internal/repository/note_test.go
+++ b/internal/repository/note_test.go
@@ -1810,6 +1810,45 @@ func TestNoteRepository_ListByFileID_Cursor(t *testing.T) {
 	assert.Equal(t, "n_lbfi_d", rows[1].ID)
 }
 
+// TestNoteRepository_MentionsFileIdsGINIndexes verifies that the #1427 GIN
+// indexes (migration 000054 / 000055) are created and actually usable for the
+// array-containment (@>) queries behind ListMentions / ListByFileID. これらが
+// 落ちると seq scan に戻り、note テーブル肥大に比例して静かに性能退行するため
+// regression guard として固定する。
+func TestNoteRepository_MentionsFileIdsGINIndexes(t *testing.T) {
+	// 1. index が存在し GIN 型であること (CONCURRENTLY migration が適用された
+	//    ことの確認も兼ねる)。
+	for _, idx := range []string{"IDX_note_mentions", "IDX_note_fileIds"} {
+		var indexdef string
+		err := testDB.Raw(
+			`SELECT indexdef FROM pg_indexes WHERE tablename = 'note' AND indexname = ?`, idx,
+		).Scan(&indexdef).Error
+		require.NoError(t, err)
+		require.NotEmpty(t, indexdef, "GIN index %s must exist (migration applied)", idx)
+		assert.Contains(t, indexdef, "USING gin", "%s must be a GIN index", idx)
+	}
+
+	// 2. planner が @> containment に GIN index を選べること。小さな test
+	//    テーブルでは planner が seq scan を選ぶため、同一接続上で
+	//    enable_seqscan=off を効かせて index 経路を強制し、plan に index 名が
+	//    現れることを確認する (index が無ければ強制しても seq scan のまま)。
+	//    SET LOCAL は transaction スコープなので Begin/Rollback で閉じる。
+	checkPlanUsesIndex := func(query, arg, indexName string) {
+		tx := testDB.Begin()
+		defer tx.Rollback()
+		require.NoError(t, tx.Exec(`SET LOCAL enable_seqscan = off`).Error)
+		var lines []string
+		require.NoError(t, tx.Raw(`EXPLAIN `+query, arg).Scan(&lines).Error)
+		plan := strings.Join(lines, "\n")
+		assert.Contains(t, plan, indexName,
+			"@> query should use %s under enable_seqscan=off; plan was:\n%s", indexName, plan)
+	}
+	checkPlanUsesIndex(
+		`SELECT * FROM "note" WHERE "mentions" @> ARRAY[?]::varchar[]`, "u1", "IDX_note_mentions")
+	checkPlanUsesIndex(
+		`SELECT * FROM "note" WHERE "fileIds" @> ARRAY[?]::varchar[]`, "f1", "IDX_note_fileIds")
+}
+
 func TestNoteRepository_IncrementUserNotesCount(t *testing.T) {
 	repo := NewNoteRepository(testDB)
 	user := insertTestUser(t, "u_n_inc_2", "incuser2")

--- a/migration/000054_note_mentions_gin_index.down.sql
+++ b/migration/000054_note_mentions_gin_index.down.sql
@@ -1,0 +1,3 @@
+-- CONCURRENTLY で作った index は CONCURRENTLY で drop して write block を避ける
+-- (DROP INDEX CONCURRENTLY も transaction 外・単一文でのみ実行可能)。
+DROP INDEX CONCURRENTLY IF EXISTS "IDX_note_mentions";

--- a/migration/000054_note_mentions_gin_index.up.sql
+++ b/migration/000054_note_mentions_gin_index.up.sql
@@ -1,0 +1,13 @@
+-- #1427 (perf audit finding 4): notes/mentions (ListMentions, note.go:610) は
+-- note.mentions に対する array containment ("mentions" @> ARRAY[?]::varchar[])
+-- で検索するが、note.tags (IDX_note_tags, 000043) と違い GIN index が無く note
+-- 全行 seq scan になっていた。テーブル肥大に比例して線形悪化するため GIN index
+-- を追加して index scan 化する。
+--
+-- note は最大テーブルなので CONCURRENTLY で書き込みを block せずに構築する
+-- (000045 の "次回 large table への index 追加では CONCURRENTLY を採用する"
+-- 方針に準拠)。golang-migrate v4 の postgres driver は migration を transaction
+-- 外で ExecContext するため CONCURRENTLY を直接書ける。CONCURRENTLY は単一文で
+-- しか実行できない (複数文だと postgres の暗黙 transaction で失敗する) ため、
+-- mentions / fileIds をそれぞれ別 migration (000054 / 000055) に分割している。
+CREATE INDEX CONCURRENTLY IF NOT EXISTS "IDX_note_mentions" ON "note" USING gin ("mentions");

--- a/migration/000054_note_mentions_gin_index.up.sql
+++ b/migration/000054_note_mentions_gin_index.up.sql
@@ -10,4 +10,14 @@
 -- 外で ExecContext するため CONCURRENTLY を直接書ける。CONCURRENTLY は単一文で
 -- しか実行できない (複数文だと postgres の暗黙 transaction で失敗する) ため、
 -- mentions / fileIds をそれぞれ別 migration (000054 / 000055) に分割している。
+--
+-- 失敗時の回復: CONCURRENTLY build が途中で失敗 (kill / deadlock / server 側
+-- statement_timeout 等) すると INVALID な index が残り、再実行時の
+-- IF NOT EXISTS は名前一致で skip するため恒久的に再構築されない。さらに
+-- golang-migrate は当該 version を dirty のまま残す。回復は以下:
+--   1. 無効 index を特定して DROP:
+--      SELECT i.relname FROM pg_index x JOIN pg_class i ON i.oid = x.indexrelid
+--        WHERE i.relname = 'IDX_note_mentions' AND NOT x.indisvalid;
+--      DROP INDEX CONCURRENTLY IF EXISTS "IDX_note_mentions";
+--   2. migrate の dirty を解除 (migrate force <直前 version>) してから再適用。
 CREATE INDEX CONCURRENTLY IF NOT EXISTS "IDX_note_mentions" ON "note" USING gin ("mentions");

--- a/migration/000054_note_mentions_gin_index.up.sql
+++ b/migration/000054_note_mentions_gin_index.up.sql
@@ -19,5 +19,10 @@
 --      SELECT i.relname FROM pg_index x JOIN pg_class i ON i.oid = x.indexrelid
 --        WHERE i.relname = 'IDX_note_mentions' AND NOT x.indisvalid;
 --      DROP INDEX CONCURRENTLY IF EXISTS "IDX_note_mentions";
---   2. migrate の dirty を解除 (migrate force <直前 version>) してから再適用。
+--   2. golang-migrate の dirty フラグを解除する。本 repo の cmd/migrate は
+--      -direction up/down のみで force を持たないため、schema_migrations
+--      (単一行) を直前に成功した version へ直接戻す:
+--        UPDATE "schema_migrations" SET version = <直前 version>, dirty = false;
+--      その後 make migrate-up で再適用される (standalone golang-migrate CLI が
+--      あれば migrate force <直前 version> でも可)。
 CREATE INDEX CONCURRENTLY IF NOT EXISTS "IDX_note_mentions" ON "note" USING gin ("mentions");

--- a/migration/000055_note_fileids_gin_index.down.sql
+++ b/migration/000055_note_fileids_gin_index.down.sql
@@ -1,0 +1,3 @@
+-- CONCURRENTLY で作った index は CONCURRENTLY で drop して write block を避ける
+-- (DROP INDEX CONCURRENTLY も transaction 外・単一文でのみ実行可能)。
+DROP INDEX CONCURRENTLY IF EXISTS "IDX_note_fileIds";

--- a/migration/000055_note_fileids_gin_index.up.sql
+++ b/migration/000055_note_fileids_gin_index.up.sql
@@ -1,0 +1,8 @@
+-- #1427 (perf audit finding 4): drive/files/attached-notes (ListByFileID,
+-- note.go:652) は note.fileIds に対する array containment
+-- ("fileIds" @> ARRAY[?]::varchar[]) で検索するが GIN index が無く note 全行
+-- seq scan になっていた。index scan 化する。
+--
+-- CONCURRENTLY 採用理由・別 migration 分割の経緯は 000054 と同じ (#1427)。
+-- note は最大テーブルのため書き込みを block しない CONCURRENTLY で構築する。
+CREATE INDEX CONCURRENTLY IF NOT EXISTS "IDX_note_fileIds" ON "note" USING gin ("fileIds");

--- a/migration/000055_note_fileids_gin_index.up.sql
+++ b/migration/000055_note_fileids_gin_index.up.sql
@@ -3,6 +3,8 @@
 -- ("fileIds" @> ARRAY[?]::varchar[]) で検索するが GIN index が無く note 全行
 -- seq scan になっていた。index scan 化する。
 --
--- CONCURRENTLY 採用理由・別 migration 分割の経緯は 000054 と同じ (#1427)。
+-- CONCURRENTLY 採用理由・別 migration 分割の経緯、および失敗時の回復手順
+-- (INVALID index の DROP + migrate dirty 解除) は 000054 と同じ (#1427)。
+-- 対象 index 名はこちらは "IDX_note_fileIds"。
 -- note は最大テーブルのため書き込みを block しない CONCURRENTLY で構築する。
 CREATE INDEX CONCURRENTLY IF NOT EXISTS "IDX_note_fileIds" ON "note" USING gin ("fileIds");


### PR DESCRIPTION
## Summary

note.tags は GIN index 化済み (`migration/000043`) だが、同じ `varchar(32)[]` の
`note.mentions` / `note.fileIds` には array containment (`@>`) 用 index が無く、
以下が note 全行 seq scan になっていた (perf audit finding 4):

- `ListMentions` (`internal/repository/note.go:610`) — `/api/notes/mentions`(通知系で高頻度)
- `ListByFileID` (`internal/repository/note.go:652`) — `/api/drive/files/attached-notes`

テーブル肥大に比例して線形悪化するため、`note.tags` の `IDX_note_tags` と同方針で
GIN index を追加して index scan 化する。

## 設計判断 (CONCURRENTLY / 2 ファイル分割)

issue 本文は「000043 と同型 (通常の `CREATE INDEX`)」だったが、`note` は最大
テーブルで、通常の `CREATE INDEX` は build 中 `note` への書き込みを block する
(ACCESS EXCLUSIVE 相当)。プロジェクト自身が `000045` のコメントで
**「次回 large table への index 追加では CONCURRENTLY を採用する」** と明文化して
いるため、それに準拠して `CREATE INDEX CONCURRENTLY` で構築する。

- golang-migrate v4 の postgres driver は migration を transaction 外で
  `ExecContext` するため `CONCURRENTLY` を直接書ける (`000045` / #754 で確認済み)。
- `CONCURRENTLY` は単一文でのみ実行可 (複数文は postgres の暗黙 transaction で
  失敗) のため、mentions / fileIds をそれぞれ別 migration に分割している。

(方式は issue #1427 上でユーザー確認済み)

## 主な変更点

- `migration/000054_note_mentions_gin_index.{up,down}.sql`:
  `IDX_note_mentions` を `note.mentions` に GIN で作成 / 削除 (CONCURRENTLY)。
- `migration/000055_note_fileids_gin_index.{up,down}.sql`:
  `IDX_note_fileIds` を `note.fileIds` に GIN で作成 / 削除 (CONCURRENTLY)。
- `internal/repository/note_test.go`: `TestNoteRepository_MentionsFileIdsGINIndexes`
  を追加。

## テスト

- `TestNoteRepository_MentionsFileIdsGINIndexes`:
  - `pg_indexes` で両 index の存在 + GIN 型 (`USING gin`) を確認
    (= CONCURRENTLY migration が test DB に適用されたことの検証も兼ねる)。
  - `enable_seqscan = off` を効かせた transaction 内で `EXPLAIN` を取り、
    `@>` containment クエリが当該 GIN index を選ぶこと (seq scan -> index scan)
    を固定する。小さな test テーブルでも planner 依存にならず決定的。
- 既存の `ListMentions` / `ListByFileID` テストも green。

実行方法・結果:
- `make fmt && make lint` clean。
- `make test` 全体 green (130 packages ok / FAIL 0)、`internal/repository` 90.1%
  (gate 通過)。

## その他

- 本番反映 (`make migrate-up`) は CONCURRENTLY なので write block は無いが、
  大規模 `note` では build に時間がかかる (2 パススキャン)。適用タイミングは
  運用判断。
- finding 5 (channelId / replyId / renoteId の index) は別 issue 想定でスコープ外。

Closes #1427

🤖 Generated with [Claude Code](https://claude.com/claude-code)
