### PR TITLE
fix(pages): pages/like に YOUR_PAGE (自分の page は like 不可) を実装 (#1438)

### DIFF
--- a/internal/api/pages/handler.go
+++ b/internal/api/pages/handler.go
@@ -388,6 +388,9 @@ func (h *Handler) Like(c echo.Context) error {
 		case errors.Is(err, corepage.ErrPageNotFound),
 			errors.Is(err, corepage.ErrAccessDenied):
 			return c.JSON(http.StatusNotFound, apierr.Error("NO_SUCH_PAGE", "No such page.", "cc98a8a2-0dc3-4123-b198-62c71df18ed3"))
+		case errors.Is(err, corepage.ErrYourPage):
+			// 自分の page への like は upstream TS と同じく YOUR_PAGE で弾く (#1438)。
+			return c.JSON(http.StatusBadRequest, apierr.Error("YOUR_PAGE", "You cannot like your own page.", "28800466-e6db-40f2-8fae-bf9e82aa92b8"))
 		case errors.Is(err, corepage.ErrAlreadyLiked):
 			return c.JSON(http.StatusBadRequest, apierr.Error("ALREADY_LIKED", "You already liked that page.", "d4c1edbe-7da2-4eae-8714-1acfd2d63941"))
 		}

--- a/internal/api/pages/handler_test.go
+++ b/internal/api/pages/handler_test.go
@@ -598,6 +598,22 @@ func TestLike_AlreadyLiked(t *testing.T) {
 	_ = rec
 }
 
+// #1438: owner が自分の page を like しようとすると 400 YOUR_PAGE
+// (28800466-...) を返す (upstream TS pages/like 準拠)。
+func TestLike_YourPage(t *testing.T) {
+	h, repo, _ := newHandler(t)
+	repo.Pages["p1"] = &model.Page{ID: "p1", UserID: "alice", Visibility: model.PageVisibilityPublic}
+	c, rec := newReq(t, `{"pageId":"p1"}`)
+	setUser(c, "alice")
+	require.NoError(t, h.Like(c))
+	assert.Equal(t, http.StatusBadRequest, rec.Code)
+	var resp map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+	errObj := resp["error"].(map[string]any)
+	assert.Equal(t, "YOUR_PAGE", errObj["code"])
+	assert.Equal(t, "28800466-e6db-40f2-8fae-bf9e82aa92b8", errObj["id"])
+}
+
 // failingCreateLikeRepo causes Create to fail.
 type failingCreateLikeRepo struct {
 	*testutil.MockPageLikeRepository

--- a/internal/core/page/page_service.go
+++ b/internal/core/page/page_service.go
@@ -27,6 +27,10 @@ var (
 	// ErrAlreadyLiked is returned when a user attempts to Like a page they
 	// have already liked.
 	ErrAlreadyLiked = errors.New("page is already liked")
+	// ErrYourPage is returned when a user attempts to Like their own page.
+	// upstream Misskey TS pages/like の yourPage (28800466-...) に対応する
+	// (#1438)。自分の page への like を禁止する。
+	ErrYourPage = errors.New("cannot like your own page")
 	// ErrNotLiked is returned when a user attempts to Unlike a page they
 	// have not liked.
 	ErrNotLiked = errors.New("page is not liked")
@@ -283,6 +287,13 @@ func (s *Service) Like(userID, pageID string) error {
 	}
 	if p.Visibility != model.PageVisibilityPublic && p.UserID != userID {
 		return ErrAccessDenied
+	}
+	// 自分の page は like できない (upstream TS pages/like の yourPage, #1438)。
+	// TS の順序 (noSuchPage -> 可視性 -> yourPage -> alreadyLiked) に合わせて
+	// 可視性ゲートの後・already-liked チェックの前に置く。owner は可視性ゲートを
+	// 常に素通りするため、ここでの判定が owner への唯一の gate になる。
+	if p.UserID == userID {
+		return ErrYourPage
 	}
 	if exists, err := s.likeRepo.Exists(userID, pageID); err != nil {
 		return err

--- a/internal/core/page/page_service_test.go
+++ b/internal/core/page/page_service_test.go
@@ -360,10 +360,25 @@ func TestLike_PrivateAccessDenied(t *testing.T) {
 	assert.ErrorIs(t, err, page.ErrAccessDenied)
 }
 
-func TestLike_OwnPrivateOK(t *testing.T) {
+// #1438: owner は自分の page を like できない (upstream TS の yourPage)。可視性に
+// 依らず YOUR_PAGE で弾く。owner は可視性ゲートを素通りするため、private page でも
+// ErrYourPage が返る (ErrAccessDenied ではない)。
+func TestLike_OwnPrivate_YourPage(t *testing.T) {
 	svc, repo, _ := newSvc(t)
 	repo.Pages["p1"] = &model.Page{ID: "p1", UserID: "u1", Visibility: model.PageVisibilityFollowers}
-	require.NoError(t, svc.Like("u1", "p1"))
+	err := svc.Like("u1", "p1")
+	assert.ErrorIs(t, err, page.ErrYourPage)
+}
+
+// #1438: public page でも owner 自身の like は YOUR_PAGE で弾き、like 行も
+// likedCount も増やさない。
+func TestLike_OwnPublic_YourPage(t *testing.T) {
+	svc, repo, likeRepo := newSvc(t)
+	repo.Pages["p1"] = &model.Page{ID: "p1", UserID: "u1", Visibility: model.PageVisibilityPublic}
+	err := svc.Like("u1", "p1")
+	assert.ErrorIs(t, err, page.ErrYourPage)
+	assert.Empty(t, likeRepo.Likes)
+	assert.Equal(t, 0, repo.Pages["p1"].LikedCount)
 }
 
 func TestLike_AlreadyLiked(t *testing.T) {


### PR DESCRIPTION
## Summary

#1437 (pages/like の存在隠蔽 404 化) のレビュー中に発見した parity gap。upstream
Misskey TS の `pages/like` は `page.userId === me.id` の場合 **`YOUR_PAGE`**
(`28800466-e6db-40f2-8fae-bf9e82aa92b8`) を返し自分の page を like できないように
しているが、mk-go の `core/page.Service.Like` には yourPage チェックが無く、**owner が
自分の page を like できてしまっていた** (divergence)。`golden_error_ids.json` は
`pages/like.YOUR_PAGE` の id を既に mapping 済みなのに handler が emit していない
shape / error-id drift でもあった。

## 主な変更点

- `internal/core/page/page_service.go`: `ErrYourPage` sentinel を追加し、`Like` で
  `p.UserID == userID` のとき返す。TS の順序 (noSuchPage -> 可視性 -> yourPage ->
  alreadyLiked) に合わせ、可視性ゲートの後・already-liked チェックの前に置く。
- `internal/api/pages/handler.go`: `ErrYourPage` -> 400 `YOUR_PAGE`
  (`28800466-e6db-40f2-8fae-bf9e82aa92b8`) を追加。
- `internal/core/page/page_service_test.go`: 旧 `TestLike_OwnPrivateOK` は owner が
  自分の private page を like できる**旧挙動**を encode していたため、`ErrYourPage`
  を期待する形に更新 (+ public page 版を追加)。
- `internal/api/pages/handler_test.go`: owner -> 400 `YOUR_PAGE` + id を検証。

### 順序についての補足

upstream TS の `pages/like` は可視性ゲート自体を持たず (noSuchPage / yourPage /
alreadyLiked のみ)。mk-go は `Page.visibility` (drop-in #367) を持つため可視性ゲートを
残しているが、owner はそのゲートを常に素通りする (`p.Visibility != Public && p.UserID
!= userID` の後半が owner では false)。よって yourPage を可視性ゲートの後に置いても
owner には必ず効き、TS と**観測等価**になる。

## テスト

- service: owner の private / public page like がともに `ErrYourPage` (like 行 /
  likedCount が増えないことも検証)。
- handler: owner -> 400 `YOUR_PAGE` + `28800466-...`。
- `TestErrorIDDrift` (error-id gate): `pages/like.YOUR_PAGE` の id 整合 (drift なし)
  を確認。

実行方法・結果:
- `make fmt && make lint` clean。
- `make test` 全体 green (130 packages ok / FAIL 0)。
- 両 `Like` 関数は 100% 被覆、`internal/core/page` 99.2% / `internal/api/pages`
  97.5% (gate 通過)。

## その他

- **挙動変更**: 従来 owner は自分の page を like できたが、本変更で不可 (`YOUR_PAGE`)
  になる (TS 準拠、本 issue の目的どおり)。

Closes #1438

🤖 Generated with [Claude Code](https://claude.com/claude-code)
