### PR TITLE
perf(notes): mentions の visibility 振り分けを SQL push-down 化し under-fill を解消 (#1451)

### DIFF
--- a/internal/api/notes/handler_extra.go
+++ b/internal/api/notes/handler_extra.go
@@ -145,25 +145,16 @@ func (h *Handler) Mentions(c echo.Context) error {
 	req.Limit = pagination.ClampLimit(req.Limit, 10, 100)
 	// sinceDate / untilDate を aidx prefix に正規化 (#1166)。
 	sinceID, untilID := id.NormalizeCursor(req.SinceID, req.UntilID, req.SinceDate, req.UntilDate)
-	notes, err := h.noteRepo.ListMentions(user.ID, req.Limit, sinceID, untilID)
+	// visibility kind の絞り込みは ListMentions の SQL push-down に委譲する
+	// (#1451)。upstream TS notes/mentions と同じく、visibility 指定時のみ
+	// note.visibility = <値> で exact-match し、未指定は全種別を返す。旧実装は
+	// post-fetch で specified / 非specified に振り分けていたため、ページ内が片方の
+	// 種別で埋まると limit 未満になる under-fill が起きていた。
+	notes, err := h.noteRepo.ListMentions(user.ID, req.Visibility, req.Limit, sinceID, untilID)
 	if err != nil {
 		return c.JSON(http.StatusInternalServerError, apierr.Error("INTERNAL_ERROR", "Internal error.", "5d37dbcb-891e-41ca-a3d6-e690c97775ac"))
 	}
-	// visibilityフィルタ
-	// "specified" → DMのみ、未指定 → DM以外
-	var filtered []*model.Note
-	for _, n := range notes {
-		if req.Visibility == "specified" {
-			if n.Visibility == model.NoteVisibilitySpecified {
-				filtered = append(filtered, n)
-			}
-		} else {
-			if n.Visibility != model.NoteVisibilitySpecified {
-				filtered = append(filtered, n)
-			}
-		}
-	}
-	return c.JSON(http.StatusOK, h.packMany(c.Request().Context(), filtered, user))
+	return c.JSON(http.StatusOK, h.packMany(c.Request().Context(), notes, user))
 }
 
 // UserListTimeline handles POST /api/notes/user-list-timeline.

--- a/internal/api/notes/handler_extra_test.go
+++ b/internal/api/notes/handler_extra_test.go
@@ -311,6 +311,32 @@ func TestMentions_SpecifiedNonTargetExcluded(t *testing.T) {
 	assert.True(t, ids["m_spec"], "visibleUserIds 対象には specified mention が出る")
 }
 
+// #1451: 未指定 (default) は upstream TS と同じく全種別を返す。public mention に
+// 加えて specified(DM、me が visibleUserIds 対象) mention も含まれる (旧実装は
+// default で specified を除外していたが TS に揃えて含める)。
+func TestMentions_DefaultIncludesAllVisibilities(t *testing.T) {
+	h, noteRepo, _ := newExtraHandler(t)
+	noteRepo.Notes["m_pub"] = &model.Note{ID: "m_pub", UserID: "author", Mentions: []string{"me"}, Visibility: "public", User: &model.User{ID: "author"}}
+	noteRepo.Notes["m_dm"] = &model.Note{ID: "m_dm", UserID: "author", Mentions: []string{"me"}, Visibility: "specified", VisibleUserIDs: []string{"me"}, User: &model.User{ID: "author"}}
+
+	ids := mentionIDs(t, postExtra(h.Mentions, `{}`, &model.User{ID: "me"}))
+	assert.True(t, ids["m_pub"], "default は public mention を含む")
+	assert.True(t, ids["m_dm"], "default は specified(DM) mention も含む (TS 一致)")
+}
+
+// #1451: visibility 指定は exact-match。public 指定では public のみ返り、
+// specified は出ない (旧 binary split では非specified に specified 以外が全部
+// 入っていたが、TS の note.visibility = <値> に合わせる)。
+func TestMentions_VisibilityExactMatch(t *testing.T) {
+	h, noteRepo, _ := newExtraHandler(t)
+	noteRepo.Notes["m_pub"] = &model.Note{ID: "m_pub", UserID: "author", Mentions: []string{"me"}, Visibility: "public", User: &model.User{ID: "author"}}
+	noteRepo.Notes["m_dm"] = &model.Note{ID: "m_dm", UserID: "author", Mentions: []string{"me"}, Visibility: "specified", VisibleUserIDs: []string{"me"}, User: &model.User{ID: "author"}}
+
+	ids := mentionIDs(t, postExtra(h.Mentions, `{"visibility":"public"}`, &model.User{ID: "me"}))
+	assert.True(t, ids["m_pub"], "public 指定で public mention は出る")
+	assert.False(t, ids["m_dm"], "public 指定で specified は出ない (exact-match)")
+}
+
 // --- UserListTimeline ---
 
 func TestUserListTimeline_Success(t *testing.T) {
@@ -815,7 +841,7 @@ func TestUnrenote_DeleteError(t *testing.T) {
 
 type failingMentionsRepo struct{ *testutil.MockNoteRepository }
 
-func (f *failingMentionsRepo) ListMentions(_ string, _ int, _, _ string) ([]*model.Note, error) {
+func (f *failingMentionsRepo) ListMentions(_, _ string, _ int, _, _ string) ([]*model.Note, error) {
 	return nil, testutil.ErrNotFound
 }
 

--- a/internal/api/notes/handler_test.go
+++ b/internal/api/notes/handler_test.go
@@ -863,7 +863,7 @@ func (f *failingNoteRepo) ListFeatured(_, _ string, _, _ int) ([]*model.Note, er
 func (f *failingNoteRepo) FindRenoteByUser(_, _ string) (*model.Note, error) {
 	return nil, testutil.ErrNotFound
 }
-func (f *failingNoteRepo) ListMentions(_ string, _ int, _, _ string) ([]*model.Note, error) {
+func (f *failingNoteRepo) ListMentions(_, _ string, _ int, _, _ string) ([]*model.Note, error) {
 	return nil, nil
 }
 func (f *failingNoteRepo) SearchByTag(_, _ string, _ int, _, _ string) ([]*model.Note, error) {

--- a/internal/repository/note.go
+++ b/internal/repository/note.go
@@ -92,7 +92,12 @@ type NoteRepository interface {
 	// is given.
 	ListFeatured(channelID, untilID string, limit, offset int) ([]*model.Note, error)
 	FindRenoteByUser(userID, renoteID string) (*model.Note, error)
-	ListMentions(userID string, limit int, sinceID, untilID string) ([]*model.Note, error)
+	// ListMentions returns notes mentioning userID that userID can see.
+	// visibility が空でなければ note.visibility = visibility の exact-match で
+	// 絞る (upstream TS notes/mentions と同じ; 空は全種別)。振り分けを LIMIT 前に
+	// SQL で行うことで handler の post-fetch 振り分けによる under-fill を解消する
+	// (#1451)。
+	ListMentions(userID, visibility string, limit int, sinceID, untilID string) ([]*model.Note, error)
 	// SearchByTag returns notes carrying tag that viewerID is allowed to see.
 	// viewerID 空文字は匿名 (public/home のみ)。discovery 系の tag 検索は
 	// ID 既知公開 (notes/show) doctrine の対象外なので、core/note.CanSeeNote と
@@ -631,7 +636,7 @@ func (r *noteRepository) FindRenoteByUser(userID, renoteID string) (*model.Note,
 	return &note, nil
 }
 
-func (r *noteRepository) ListMentions(userID string, limit int, sinceID, untilID string) ([]*model.Note, error) {
+func (r *noteRepository) ListMentions(userID, visibility string, limit int, sinceID, untilID string) ([]*model.Note, error) {
 	if limit <= 0 {
 		limit = 10
 	}
@@ -648,6 +653,14 @@ func (r *noteRepository) ListMentions(userID string, limit int, sinceID, untilID
 			`OR ("visibility" = 'followers' AND "userId" IN (SELECT f."followeeId" FROM "following" f WHERE f."followerId" = ?)) `+
 			`OR ("visibility" = 'specified' AND ? = ANY("visibleUserIds")))`,
 		userID, userID, userID)
+	// visibility kind filter: upstream TS notes/mentions と同じく visibility 指定
+	// 時のみ note.visibility = <値> の exact-match で絞る (空は全種別)。これを
+	// LIMIT 前に SQL で行うことで、handler 側 post-fetch 振り分けで起きていた
+	// ページ under-fill を解消する (#1451)。値は parameterized で injection-safe、
+	// 未知の値は単に 0 件になる (TS と同じ挙動)。
+	if visibility != "" {
+		q = q.Where(`"visibility" = ?`, visibility)
+	}
 	q = q.Order(paginationOrder(sinceID, untilID, "id")).Limit(limit)
 	if sinceID != "" {
 		q = q.Where("id > ?", sinceID)

--- a/internal/repository/note_test.go
+++ b/internal/repository/note_test.go
@@ -1128,16 +1128,16 @@ func TestNoteRepository_ListMentions(t *testing.T) {
 	require.NoError(t, testDB.Create(n).Error)
 	defer testDB.Exec(`DELETE FROM "note" WHERE id = ?`, n.ID)
 
-	notes, err := repo.ListMentions(mentionee.ID, 10, "", "")
+	notes, err := repo.ListMentions(mentionee.ID, "", 10, "", "")
 	require.NoError(t, err)
 	assert.NotEmpty(t, notes)
 
 	// with cursors
-	notes, err = repo.ListMentions(mentionee.ID, 10, "", "zzz")
+	notes, err = repo.ListMentions(mentionee.ID, "", 10, "", "zzz")
 	require.NoError(t, err)
 	assert.NotEmpty(t, notes)
 
-	notes, err = repo.ListMentions(mentionee.ID, 10, "000", "")
+	notes, err = repo.ListMentions(mentionee.ID, "", 10, "000", "")
 	require.NoError(t, err)
 	assert.NotEmpty(t, notes)
 }
@@ -1179,7 +1179,7 @@ func TestNoteRepository_ListMentions_VisibilityPushDown(t *testing.T) {
 	}
 
 	// follow なし / visibleUserIds 非対象 -> public のみ (followers/specified は隠れる)。
-	out, err := repo.ListMentions(victim.ID, 50, "", "")
+	out, err := repo.ListMentions(victim.ID, "", 50, "", "")
 	require.NoError(t, err)
 	assert.Equal(t, []string{"n_lm_pub"}, idsOf(out))
 
@@ -1187,20 +1187,20 @@ func TestNoteRepository_ListMentions_VisibilityPushDown(t *testing.T) {
 	f := &model.Following{ID: "fl_lm_1", FollowerID: victim.ID, FolloweeID: author.ID}
 	require.NoError(t, followingRepo.Create(f))
 	defer testDB.Exec(`DELETE FROM "following" WHERE id = ?`, f.ID)
-	out, err = repo.ListMentions(victim.ID, 50, "", "")
+	out, err = repo.ListMentions(victim.ID, "", 50, "", "")
 	require.NoError(t, err)
 	assert.Equal(t, []string{"n_lm_fol", "n_lm_pub"}, idsOf(out))
 
 	// specified の visibleUserIds に victim を含めると specified も見える。
 	require.NoError(t, repo.UpdateFields("n_lm_spec", map[string]any{"visibleUserIds": pq.StringArray{victim.ID}}))
-	out, err = repo.ListMentions(victim.ID, 50, "", "")
+	out, err = repo.ListMentions(victim.ID, "", 50, "", "")
 	require.NoError(t, err)
 	assert.Equal(t, []string{"n_lm_fol", "n_lm_pub", "n_lm_spec"}, idsOf(out))
 }
 
 func TestNoteRepository_ListMentions_DefaultLimit(t *testing.T) {
 	repo := NewNoteRepository(testDB)
-	notes, err := repo.ListMentions("nobody", 0, "", "")
+	notes, err := repo.ListMentions("nobody", "", 0, "", "")
 	require.NoError(t, err)
 	assert.Empty(t, notes)
 }
@@ -1209,8 +1209,60 @@ func TestNoteRepository_ListMentions_Error(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel()
 	repo := NewNoteRepository(testDB.WithContext(ctx))
-	_, err := repo.ListMentions("x", 10, "", "")
+	_, err := repo.ListMentions("x", "", 10, "", "")
 	assert.Error(t, err)
+}
+
+// #1451: visibility 絞り込みを LIMIT 前に SQL push-down するので、別種別の mention
+// でページが埋まって under-fill することがない。未指定は upstream TS 同様に全種別を
+// 返す。
+func TestNoteRepository_ListMentions_VisibilityFilter(t *testing.T) {
+	repo := NewNoteRepository(testDB)
+	author := insertTestUser(t, "mvf_a", "mvfauthor")
+	me := insertTestUser(t, "mvf_m", "mvfme")
+	defer cleanupUser(t, author.ID)
+	defer cleanupUser(t, me.ID)
+
+	// public mention と specified(me を visibleUserIds に含む) mention を交互に
+	// 10 件作る。id 連番で混在させ、片種別だけ要求したときに別種別がページ枠を
+	// 食わないことを確認する。
+	ids := []string{"mvf_00", "mvf_01", "mvf_02", "mvf_03", "mvf_04", "mvf_05", "mvf_06", "mvf_07", "mvf_08", "mvf_09"}
+	for i, nid := range ids {
+		n := &model.Note{
+			ID: nid, UserID: author.ID,
+			Mentions:  pq.StringArray{me.ID},
+			Reactions: datatypes.JSON([]byte("{}")),
+		}
+		if i%2 == 0 {
+			n.Visibility = model.NoteVisibilityPublic
+		} else {
+			n.Visibility = model.NoteVisibilitySpecified
+			n.VisibleUserIDs = pq.StringArray{me.ID}
+		}
+		require.NoError(t, repo.Create(n))
+		defer cleanupNote(t, n.ID)
+	}
+
+	// public のみ limit=5 -> public が 5 件きっちり (specified がスロットを食わない)。
+	pub, err := repo.ListMentions(me.ID, "public", 5, "", "")
+	require.NoError(t, err)
+	require.Len(t, pub, 5, "public 指定で under-fill しない")
+	for _, n := range pub {
+		assert.Equal(t, model.NoteVisibilityPublic, n.Visibility)
+	}
+
+	// specified のみ limit=5 -> specified が 5 件。
+	spec, err := repo.ListMentions(me.ID, "specified", 5, "", "")
+	require.NoError(t, err)
+	require.Len(t, spec, 5, "specified 指定で under-fill しない")
+	for _, n := range spec {
+		assert.Equal(t, model.NoteVisibilitySpecified, n.Visibility)
+	}
+
+	// 未指定 (default) -> 全種別 (TS 一致): public + specified の両方が出る。
+	all, err := repo.ListMentions(me.ID, "", 100, "", "")
+	require.NoError(t, err)
+	assert.Len(t, all, 10, "default は全種別を返す")
 }
 
 func TestNoteRepository_SearchByTag(t *testing.T) {

--- a/internal/testutil/mock_repository.go
+++ b/internal/testutil/mock_repository.go
@@ -1102,13 +1102,19 @@ func (m *MockNoteRepository) FindRenoteByUser(userID, renoteID string) (*model.N
 	return nil, ErrNotFound
 }
 
-func (m *MockNoteRepository) ListMentions(userID string, limit int, sinceID, untilID string) ([]*model.Note, error) {
+func (m *MockNoteRepository) ListMentions(userID, visibility string, limit int, sinceID, untilID string) ([]*model.Note, error) {
 	if limit <= 0 {
 		limit = 10
 	}
 	return m.listFiltered(func(n *model.Note) bool {
 		// viewer (= mention 対象 = userID) が見られる note のみ (#1441)。
 		if !m.canViewerSeeNote(userID, n) {
+			return false
+		}
+		// visibility 指定時は exact-match で絞る (#1451)。listFiltered は
+		// filter -> sort -> limit 順なので、ここで弾けば SQL push-down 同様に
+		// LIMIT 前で絞られ under-fill しない。
+		if visibility != "" && string(n.Visibility) != visibility {
 			return false
 		}
 		for _, mention := range n.Mentions {


### PR DESCRIPTION
## Summary

#1447 (notes/mentions visibility push-down) のレビューで指摘された follow-up。
`internal/api/notes/handler_extra.go` の `Mentions` は `ListMentions` が全種別を
返した後に **post-fetch で specified / 非specified へ振り分け**ていたため、ページ内が
片方の種別で埋まると limit 未満になる **under-fill** が起きていた。#1418 の
`ListByUserIDFiltered` と同じく、振り分けを LIMIT 前の SQL に寄せて解消する。

## upstream TS との整合 (issue 前提の訂正)

実装にあたり upstream TS `notes/mentions.ts` を確認したところ、issue 本文の
「TS も同構造 (specified / 非specified の binary split)」という前提は**不正確**だった。
実際の TS は:

```ts
if (ps.visibility) {
  query.andWhere('note.visibility = :visibility', { visibility: ps.visibility });
}
```

= **visibility 指定時のみ `note.visibility = <値>` の exact-match、未指定は全種別**。

mk-go の現 binary split (`specified` → specified のみ / その他・未指定 → 非specified)
は、それ自体が TS から乖離していた。レビューで方針確認の上、**mk-go を TS の
exact-match semantics に揃える**。

## 主な変更点

- `internal/repository/note.go` `ListMentions`: `visibility` 引数を追加し、空でなければ
  `note.visibility = <値>` を #1441 可視性 push-down と同じく **LIMIT 前**に SQL で
  絞る (parameterized で injection-safe、未知の値は 0 件 = TS と同じ)。
- `internal/api/notes/handler_extra.go` `Mentions`: post-fetch 振り分けを撤去し
  `req.Visibility` を `ListMentions` にそのまま渡す。
- `internal/testutil/mock_repository.go`: mock も同 signature + exact-match。
  `listFiltered` の filter → sort → limit 順により SQL push-down と同じく under-fill
  しない。

### 挙動変更

- 旧実装は default (visibility 未指定) で specified(DM) mention を**除外**していたが、
  TS に揃えて default は**全種別 (DM 含む)** を返す。
- explicit visibility は exact-match (例: `public` 指定で public のみ。旧 binary split
  では非specified 全部が返っていた)。

## テスト

- `internal/repository/note_test.go` `TestNoteRepository_ListMentions_VisibilityFilter`:
  片種別 limit=5 で 5 件きっちり返る (**under-fill 解消**) + 未指定で全種別を返すことを
  実 DB で固定。
- `internal/api/notes/handler_extra_test.go`:
  `TestMentions_DefaultIncludesAllVisibilities` (default は DM 含む全種別) /
  `TestMentions_VisibilityExactMatch` (public 指定で specified は出ない) を追加。
- 既存 #1441 visibility push-down test (`TestMentions_FollowersNonFollowerExcluded` /
  `TestMentions_SpecifiedNonTargetExcluded` 等) は維持。

実行方法・結果:
- `make fmt && make lint` clean。
- `make test` 全体 green (130 packages ok / FAIL 0)。
- 両 `ListMentions` / `Mentions` は 100% 被覆、`internal/repository` 90.1% /
  `internal/api/notes` 92.7% (gate 通過)、`-race` green。

## その他 (スコープ外 / follow-up 候補)

TS の mention match 条件は `:meId <@ note.mentions OR :meId <@ note.visibleUserIds`
だが、mk-go の `ListMentions` は `mentions @> ARRAY[?]` のみで、**specified DM の本文
@mention 無し受信者を取りこぼす**別 gap が残る。本 issue (visibility kind の絞り込み)
のスコープ外のため本 PR では触れていない。必要なら別 issue で対応。

Closes #1451

🤖 Generated with [Claude Code](https://claude.com/claude-code)
