### PR TITLE
fix(users): users/get-frequently-replied-users に visibility push-down を追加 (#1486)

### DIFF
--- a/internal/api/notes/handler_test.go
+++ b/internal/api/notes/handler_test.go
@@ -884,7 +884,7 @@ func (f *failingNoteRepo) ListGlobalTimeline(_ int, _, _ string, _ model.Timelin
 }
 func (f *failingNoteRepo) DeleteExpiredRemoteNotes(_, _ int) (int64, error) { return 0, nil }
 func (f *failingNoteRepo) DeleteByUserBatch(_ string, _ int) (int64, error) { return 0, nil }
-func (f *failingNoteRepo) CountReplyTargets(_ string, _ int) ([]model.ReplyTargetCount, error) {
+func (f *failingNoteRepo) CountReplyTargets(_, _ string, _ int) ([]model.ReplyTargetCount, error) {
 	return nil, nil
 }
 func (f *failingNoteRepo) ListByUserList(_ string, _ int, _, _ string) ([]*model.Note, error) {

--- a/internal/api/users/handler_p189_test.go
+++ b/internal/api/users/handler_p189_test.go
@@ -77,6 +77,9 @@ func TestGetFrequentlyRepliedUsers_AggregatesAndWeights(t *testing.T) {
 			UserID:      "me",
 			ReplyID:     &ridDummy,
 			ReplyUserID: &uid,
+			// visibility push-down (#1486) によって viewer 不一致時は集計から
+			// 落ちるため、本テストは public reply での集計挙動を確認する。
+			Visibility: model.NoteVisibilityPublic,
 		}
 	}
 	rec := postP189(k.h.GetFrequentlyRepliedUsers, `{"userId":"me","limit":10}`, nil)
@@ -100,6 +103,57 @@ func TestGetFrequentlyRepliedUsers_UserNotFound(t *testing.T) {
 	k := newP189Kit(t)
 	rec := postP189(k.h.GetFrequentlyRepliedUsers, `{"userId":"ghost"}`, nil)
 	assert.Equal(t, http.StatusNotFound, rec.Code)
+}
+
+// 第三者 viewer に author の followers/specified reply 対人関係が leak しないこと
+// を確認する (#1486)。mock の noteVisibleToViewer が CanSeeNote と同じ条件で
+// 絞るため、anonymous は public のみ集計される。
+func TestGetFrequentlyRepliedUsers_VisibilityIDOR(t *testing.T) {
+	k := newP189Kit(t)
+	author := &model.User{ID: "auth", Username: "auth"}
+	target1 := &model.User{ID: "tg1", Username: "tg1"}
+	target2 := &model.User{ID: "tg2", Username: "tg2"}
+	stranger := &model.User{ID: "stg", Username: "stg"}
+	follower := &model.User{ID: "flw", Username: "flw"}
+	k.userRepo.Users[author.ID] = author
+	k.userRepo.Users[target1.ID] = target1
+	k.userRepo.Users[target2.ID] = target2
+	k.userRepo.Users[stranger.ID] = stranger
+	k.userRepo.Users[follower.ID] = follower
+	// follower → author (Mock の noteVisibleToViewer は followerID -> followeeIDs map を参照)
+	k.noteRepo.Following[follower.ID] = []string{author.ID}
+
+	replyDummy := "src"
+	tg1ID, tg2ID := target1.ID, target2.ID
+	// author → target1 (public + followers + specified target2)
+	k.noteRepo.Notes["np"] = &model.Note{ID: "np", UserID: author.ID, ReplyID: &replyDummy, ReplyUserID: &tg1ID, Visibility: model.NoteVisibilityPublic}
+	k.noteRepo.Notes["nf"] = &model.Note{ID: "nf", UserID: author.ID, ReplyID: &replyDummy, ReplyUserID: &tg1ID, Visibility: model.NoteVisibilityFollowers}
+	k.noteRepo.Notes["ns"] = &model.Note{ID: "ns", UserID: author.ID, ReplyID: &replyDummy, ReplyUserID: &tg2ID, Visibility: model.NoteVisibilitySpecified, VisibleUserIDs: []string{"some-other"}}
+
+	// stranger (匿名相当 = follower でも specified 対象でもない) は public のみ。
+	rec := postP189(k.h.GetFrequentlyRepliedUsers, `{"userId":"auth","limit":10}`, stranger)
+	require.Equal(t, http.StatusOK, rec.Code)
+	var out []map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &out))
+	require.Len(t, out, 1)
+	u := out[0]["user"].(map[string]any)
+	assert.Equal(t, target1.ID, u["id"])
+
+	// anonymous も同じ shape。
+	rec = postP189(k.h.GetFrequentlyRepliedUsers, `{"userId":"auth","limit":10}`, nil)
+	require.Equal(t, http.StatusOK, rec.Code)
+	out = out[:0]
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &out))
+	require.Len(t, out, 1)
+
+	// follower は public + followers で target1 が count=2、specified は対象外。
+	rec = postP189(k.h.GetFrequentlyRepliedUsers, `{"userId":"auth","limit":10}`, follower)
+	require.Equal(t, http.StatusOK, rec.Code)
+	out = out[:0]
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &out))
+	require.Len(t, out, 1)
+	u = out[0]["user"].(map[string]any)
+	assert.Equal(t, target1.ID, u["id"])
 }
 
 // --- GetFollowingUsersByBirthday ---

--- a/internal/api/users/recommendation.go
+++ b/internal/api/users/recommendation.go
@@ -14,6 +14,9 @@ import (
 //
 // 指定 userId が最近返信している相手上位 limit 件を weight = count / peak
 // (最大件数で正規化) 付きで返す。Misskey 本家と同じレスポンス shape。
+//
+// reply 集計は visibility push-down で viewer が CanSeeNote で見られる reply
+// のみに絞る (#1486)。匿名 viewer は public/home のみ集計する。
 func (h *Handler) GetFrequentlyRepliedUsers(c echo.Context) error {
 	var req struct {
 		UserID string `json:"userId"`
@@ -26,7 +29,11 @@ func (h *Handler) GetFrequentlyRepliedUsers(c echo.Context) error {
 	if _, err := h.userService.ShowByID(req.UserID); err != nil {
 		return c.JSON(http.StatusNotFound, apierr.Error("NO_SUCH_USER", "No such user.", "e6965129-7b2a-40a4-bae2-cd84cd434822"))
 	}
-	rows, err := h.noteRepo.CountReplyTargets(req.UserID, req.Limit)
+	var viewerID string
+	if viewer := middleware.GetUser(c); viewer != nil {
+		viewerID = viewer.ID
+	}
+	rows, err := h.noteRepo.CountReplyTargets(req.UserID, viewerID, req.Limit)
 	if err != nil {
 		return apierr.JSONInternalError(c)
 	}

--- a/internal/repository/note.go
+++ b/internal/repository/note.go
@@ -124,7 +124,12 @@ type NoteRepository interface {
 	// CountReplyTargets returns the users that userID most frequently replies
 	// to, ordered by reply count descending. Used by
 	// users/get-frequently-replied-users.
-	CountReplyTargets(userID string, limit int) ([]model.ReplyTargetCount, error)
+	//
+	// viewerID は viewer 視点での visibility push-down に使う。userID の reply note
+	// のうち viewer が core/note.CanSeeNote で見られるものだけを集計する。空文字は
+	// 匿名 (public/home のみ)。これが無いと userID の followers/specified reply の
+	// 対人関係が第三者に leak する (#1486)。
+	CountReplyTargets(userID, viewerID string, limit int) ([]model.ReplyTargetCount, error)
 	// CountLocalNotes returns the number of notes authored by local users
 	// (userHost IS NULL). nodeinfo `usage.localPosts` 相当 (#403)。
 	CountLocalNotes() (int64, error)
@@ -940,16 +945,30 @@ func (r *noteRepository) ListByUserList(listID string, limit int, sinceID, until
 	return notes, nil
 }
 
-func (r *noteRepository) CountReplyTargets(userID string, limit int) ([]model.ReplyTargetCount, error) {
+func (r *noteRepository) CountReplyTargets(userID, viewerID string, limit int) ([]model.ReplyTargetCount, error) {
 	if limit <= 0 {
 		limit = 10
 	}
 	var rows []model.ReplyTargetCount
 	// replyUserIdがNULLのもの (通常起こり得ないが防御)と自己返信は集計から除外する。
-	err := r.db.Model(&model.Note{}).
+	q := r.db.Model(&model.Note{}).
 		Select(`"replyUserId", COUNT(*) AS count`).
-		Where(`"userId" = ? AND "replyId" IS NOT NULL AND "replyUserId" IS NOT NULL AND "replyUserId" <> ?`, userID, userID).
-		Group(`"replyUserId"`).
+		Where(`"userId" = ? AND "replyId" IS NOT NULL AND "replyUserId" IS NOT NULL AND "replyUserId" <> ?`, userID, userID)
+	// visibility push-down: 集計対象 reply note のうち viewer が CanSeeNote で
+	// 見られるものだけを残す。これが無いと第三者 viewer が author の
+	// followers/specified reply の対人関係を集計値経由で観測できる (#1486)。
+	// 条件は ListByUserIDFiltered / ListMentions / SearchByTag と同一。
+	if viewerID == "" {
+		q = q.Where(`"visibility" IN ('public','home')`)
+	} else {
+		q = q.Where(
+			`("visibility" IN ('public','home') `+
+				`OR "userId" = ? `+
+				`OR ("visibility" = 'followers' AND "userId" IN (SELECT f."followeeId" FROM "following" f WHERE f."followerId" = ?)) `+
+				`OR ("visibility" = 'specified' AND ? = ANY("visibleUserIds")))`,
+			viewerID, viewerID, viewerID)
+	}
+	err := q.Group(`"replyUserId"`).
 		Order(`count DESC`).
 		Limit(limit).
 		Scan(&rows).Error

--- a/internal/repository/note_test.go
+++ b/internal/repository/note_test.go
@@ -1724,7 +1724,8 @@ func TestNoteRepository_CountReplyTargets(t *testing.T) {
 		defer testDB.Exec(`DELETE FROM "note" WHERE id = ?`, n.ID)
 	}
 
-	rows, err := repo.CountReplyTargets(author.ID, 10)
+	// viewer == author 自身は全 visibility 見える (= 既存挙動)
+	rows, err := repo.CountReplyTargets(author.ID, author.ID, 10)
 	require.NoError(t, err)
 	require.Len(t, rows, 2)
 	assert.Equal(t, t1.ID, rows[0].UserID)
@@ -1733,16 +1734,94 @@ func TestNoteRepository_CountReplyTargets(t *testing.T) {
 	assert.EqualValues(t, 1, rows[1].Count)
 
 	// limit <= 0 は 10 にデフォルト。
-	rows2, err := repo.CountReplyTargets(author.ID, 0)
+	rows2, err := repo.CountReplyTargets(author.ID, author.ID, 0)
 	require.NoError(t, err)
 	assert.Len(t, rows2, 2)
+}
+
+func TestNoteRepository_CountReplyTargets_VisibilityPushdown(t *testing.T) {
+	repo := NewNoteRepository(testDB)
+	author := insertTestUser(t, "u_crt_vp_a", "crtVpA")
+	defer cleanupUser(t, author.ID)
+	t1 := insertTestUser(t, "u_crt_vp_t1", "crtVpT1")
+	defer cleanupUser(t, t1.ID)
+	t2 := insertTestUser(t, "u_crt_vp_t2", "crtVpT2")
+	defer cleanupUser(t, t2.ID)
+	stranger := insertTestUser(t, "u_crt_vp_s", "crtVpS")
+	defer cleanupUser(t, stranger.ID)
+	follower := insertTestUser(t, "u_crt_vp_f", "crtVpF")
+	defer cleanupUser(t, follower.ID)
+	specified := insertTestUser(t, "u_crt_vp_sp", "crtVpSp")
+	defer cleanupUser(t, specified.ID)
+
+	// follower → author の follow を seed。
+	require.NoError(t, testDB.Create(&model.Following{
+		ID:           "f_crt_vp_1",
+		FollowerID:   follower.ID,
+		FolloweeID:   author.ID,
+		FollowerHost: nil,
+		FolloweeHost: nil,
+	}).Error)
+	defer testDB.Exec(`DELETE FROM "following" WHERE id = ?`, "f_crt_vp_1")
+
+	replyID := "n_crt_vp_src"
+	require.NoError(t, testDB.Create(&model.Note{ID: replyID, UserID: t1.ID, Visibility: model.NoteVisibilityPublic}).Error)
+	defer testDB.Exec(`DELETE FROM "note" WHERE id = ?`, replyID)
+
+	// author → t1: public 1 件, followers 1 件
+	// author → t2: specified (visibleUserIds=[specified]) 1 件
+	pubNote := &model.Note{ID: "n_crt_vp_pub", UserID: author.ID, ReplyID: &replyID, ReplyUserID: &t1.ID, Visibility: model.NoteVisibilityPublic}
+	folNote := &model.Note{ID: "n_crt_vp_fol", UserID: author.ID, ReplyID: &replyID, ReplyUserID: &t1.ID, Visibility: model.NoteVisibilityFollowers}
+	spNote := &model.Note{ID: "n_crt_vp_sp", UserID: author.ID, ReplyID: &replyID, ReplyUserID: &t2.ID, Visibility: model.NoteVisibilitySpecified, VisibleUserIDs: pq.StringArray{specified.ID}}
+	for _, n := range []*model.Note{pubNote, folNote, spNote} {
+		require.NoError(t, testDB.Create(n).Error)
+		defer testDB.Exec(`DELETE FROM "note" WHERE id = ?`, n.ID)
+	}
+
+	// stranger (非フォロワー、非 specified) は public のみ集計。t1=1, t2 は出ない。
+	rows, err := repo.CountReplyTargets(author.ID, stranger.ID, 10)
+	require.NoError(t, err)
+	require.Len(t, rows, 1)
+	assert.Equal(t, t1.ID, rows[0].UserID)
+	assert.EqualValues(t, 1, rows[0].Count)
+
+	// anonymous (viewerID="") も同じく public のみ。
+	rows, err = repo.CountReplyTargets(author.ID, "", 10)
+	require.NoError(t, err)
+	require.Len(t, rows, 1)
+	assert.Equal(t, t1.ID, rows[0].UserID)
+	assert.EqualValues(t, 1, rows[0].Count)
+
+	// follower は public + followers が見える。t1=2, t2 は specified 対象外で出ない。
+	rows, err = repo.CountReplyTargets(author.ID, follower.ID, 10)
+	require.NoError(t, err)
+	require.Len(t, rows, 1)
+	assert.Equal(t, t1.ID, rows[0].UserID)
+	assert.EqualValues(t, 2, rows[0].Count)
+
+	// specified は visibleUserIds 経由で t2 への specified 1 件が見える + public 1 件。
+	rows, err = repo.CountReplyTargets(author.ID, specified.ID, 10)
+	require.NoError(t, err)
+	require.Len(t, rows, 2)
+	// 順序は count DESC で同数なら不定 (どちらも 1 件)
+	gotIDs := map[string]int64{}
+	for _, r := range rows {
+		gotIDs[r.UserID] = r.Count
+	}
+	assert.Equal(t, int64(1), gotIDs[t1.ID])
+	assert.Equal(t, int64(1), gotIDs[t2.ID])
+
+	// author 自身は全 visibility 集計可能。
+	rows, err = repo.CountReplyTargets(author.ID, author.ID, 10)
+	require.NoError(t, err)
+	require.Len(t, rows, 2)
 }
 
 func TestNoteRepository_CountReplyTargets_Error(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel()
 	repo := NewNoteRepository(testDB.WithContext(ctx))
-	_, err := repo.CountReplyTargets("me", 10)
+	_, err := repo.CountReplyTargets("me", "", 10)
 	assert.Error(t, err)
 }
 

--- a/internal/testutil/mock_repository.go
+++ b/internal/testutil/mock_repository.go
@@ -1190,7 +1190,7 @@ func (m *MockNoteRepository) ListByUserList(_ string, _ int, _, _ string) ([]*mo
 	return nil, nil
 }
 
-func (m *MockNoteRepository) CountReplyTargets(userID string, limit int) ([]model.ReplyTargetCount, error) {
+func (m *MockNoteRepository) CountReplyTargets(userID, viewerID string, limit int) ([]model.ReplyTargetCount, error) {
 	if limit <= 0 {
 		limit = 10
 	}
@@ -1200,6 +1200,10 @@ func (m *MockNoteRepository) CountReplyTargets(userID string, limit int) ([]mode
 			continue
 		}
 		if *n.ReplyUserID == userID {
+			continue
+		}
+		// visibility push-down: viewer が見られない note は集計しない (#1486)。
+		if !noteVisibleToViewer(viewerID, n, m.Following) {
 			continue
 		}
 		counts[*n.ReplyUserID]++


### PR DESCRIPTION
## Summary

`users/get-frequently-replied-users` の `CountReplyTargets` に visibility 句が無く、第三者 viewer が author の followers/specified reply の対人関係を集計値経由で観測できていた IDOR を修正する。

### 漏洩シナリオ (現状)

1. A が B に `followers` / `specified` visibility で頻繁に reply (A の private な対人関係)。
2. 第三者 C (A の非 follower) が `POST /api/users/get-frequently-replied-users { userId: <A> }` を叩く。
3. レスポンスに B が count weight 付きで top reply target として返る。
4. A → B の interaction の存在が exposed される。

### 修正方針

`ListByUserIDFiltered` / `ListMentions` / `SearchByTag` (#1418 / #1441 / #1439) と同一 pattern の SQL push-down。`CountReplyTargets` の signature に `viewerID` を追加し、`Group BY` の前に visibility EXISTS 等価条件 (= `core/note.CanSeeNote` と一致) を適用する。匿名 viewer は public/home のみ集計に縮退する。

## 主な変更点

- `internal/repository/note.go`
  - `CountReplyTargets(userID, viewerID, limit)` に signature 変更。
  - visibility push-down (public/home | author 自身 | followers + EXISTS subquery | specified + ANY visibleUserIds) を SQL に追加。
- `internal/api/users/recommendation.go`
  - handler で `middleware.GetUser(c)` から viewer ID を取得して新 signature に渡す。
- `internal/testutil/mock_repository.go`
  - `MockNoteRepository.CountReplyTargets` も同 signature に揃え、`noteVisibleToViewer` で post-filter (= 既存の他メソッドと同じ doctrine)。
- `internal/api/notes/handler_test.go`
  - `failingNoteRepo.CountReplyTargets` の signature 追従。
- `internal/api/users/handler_p189_test.go`
  - 既存集計テストの note に `Visibility=Public` を明示 (push-down 適用後の前提)。
  - 新規 `TestGetFrequentlyRepliedUsers_VisibilityIDOR` — stranger / anonymous / follower それぞれの集計結果が意図通り絞り込まれることを確認。
- `internal/repository/note_test.go`
  - 既存 `TestNoteRepository_CountReplyTargets` を author 視点に書き換え (push-down 適用後も同等の集計が返ることを確認)。
  - 新規 `TestNoteRepository_CountReplyTargets_VisibilityPushdown` — 実 SQL に対する viewer 視点別 (anonymous / stranger / follower / specified / author) の集計絞り込みを検証。

## テスト

- `go build ./...` ✅
- `make fmt && make lint` ✅
- `go test ./internal/api/users/... ./internal/api/notes/... ./internal/testutil/...` ✅
- `go test ./internal/repository/...` はローカル DB 未起動のため未実行 — CI (test-shards) で `TestNoteRepository_CountReplyTargets*` を実 PostgreSQL に対して検証する想定。

## Closes

Closes #1486

## 関連

- #1441 (notes/mentions push-down — 同 pattern の直接参考)
- #1418 / #1439 (ListByUserIDFiltered / SearchByTag の visibility push-down 確立)
- #1471 (notification stream Pack の visibility gate — 同種の secondary path IDOR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)