### PR TITLE
fix(users): users/featured-notes を engagement ranking + visibility push-down に書き換え (#1487)

### DIFF
--- a/internal/api/notes/handler_test.go
+++ b/internal/api/notes/handler_test.go
@@ -860,6 +860,9 @@ func (f *failingNoteRepo) SearchByFilter(_ model.NoteSearchFilter) ([]*model.Not
 func (f *failingNoteRepo) ListFeatured(_, _ string, _, _ int) ([]*model.Note, error) {
 	return nil, nil
 }
+func (f *failingNoteRepo) ListFeaturedByUser(_, _, _ string, _ int) ([]*model.Note, error) {
+	return nil, nil
+}
 func (f *failingNoteRepo) FindRenoteByUser(_, _ string) (*model.Note, error) {
 	return nil, testutil.ErrNotFound
 }

--- a/internal/api/users/handler_extra.go
+++ b/internal/api/users/handler_extra.go
@@ -272,15 +272,17 @@ func (h *Handler) Reactions(c echo.Context) error {
 
 // FeaturedNotes handles POST /api/users/featured-notes.
 //
-// upstream は Redis sorted set (FeaturedService.getPerUserNotesRanking) を引いた
-// engagement ranking を返すが、mk-go は ListFeatured / channels timeline と同じ
-// SQL ranking + visibility push-down で揃える (#1487 Option B):
+// upstream featured-notes.ts は Redis sorted set (getPerUserNotesRanking) で
+// engagement 上位 50 を選抜したあと、Go 側で id DESC に並べ替えて untilId で
+// ページングする 2 段構成。mk-go は SQL ranking + visibility push-down に
+// 置き換えて同じ 2 段で揃える (#1487 Option B / #1491 review):
 //
-//   - ListByUserID → ListByUserIDFiltered 相当の後継 `ListFeaturedByUser` を使い、
-//     viewer 視点の visibility 句を LIMIT 前に push-down する (post-fetch
-//     FilterVisible のページ過少充填と followers 判定 N+1 を回避)。
-//   - 順序は `("renoteCount" + "repliesCount") DESC, id DESC` で人気順に。
-//   - channel 投稿は除外 (upstream featured-notes と一致)。
+//   - selection: `ListFeaturedByUser` が `("renoteCount" + "repliesCount") DESC,
+//     id DESC` + visibility push-down + channel 除外 + LIMIT 50 で SQL から
+//     プールを取る (post-fetch FilterVisible のページ過少充填と followers 判定
+//     N+1 を回避)。
+//   - display: 同 repo 内で id DESC sort → untilId filter → 先頭 limit 件。
+//     id cursor とソート順が一致するので untilId ページングで重複/欠落しない。
 //   - hard mute は packing 前に post-fetch で適用 (visibility と独立な viewer 個別
 //     filter なので SQL push-down 対象外)。
 func (h *Handler) FeaturedNotes(c echo.Context) error {

--- a/internal/api/users/handler_extra.go
+++ b/internal/api/users/handler_extra.go
@@ -271,21 +271,37 @@ func (h *Handler) Reactions(c echo.Context) error {
 }
 
 // FeaturedNotes handles POST /api/users/featured-notes.
+//
+// upstream は Redis sorted set (FeaturedService.getPerUserNotesRanking) を引いた
+// engagement ranking を返すが、mk-go は ListFeatured / channels timeline と同じ
+// SQL ranking + visibility push-down で揃える (#1487 Option B):
+//
+//   - ListByUserID → ListByUserIDFiltered 相当の後継 `ListFeaturedByUser` を使い、
+//     viewer 視点の visibility 句を LIMIT 前に push-down する (post-fetch
+//     FilterVisible のページ過少充填と followers 判定 N+1 を回避)。
+//   - 順序は `("renoteCount" + "repliesCount") DESC, id DESC` で人気順に。
+//   - channel 投稿は除外 (upstream featured-notes と一致)。
+//   - hard mute は packing 前に post-fetch で適用 (visibility と独立な viewer 個別
+//     filter なので SQL push-down 対象外)。
 func (h *Handler) FeaturedNotes(c echo.Context) error {
 	var req struct {
-		UserID string `json:"userId"`
-		Limit  int    `json:"limit"`
+		UserID  string `json:"userId"`
+		Limit   int    `json:"limit"`
+		UntilID string `json:"untilId"`
 	}
 	if err := c.Bind(&req); err != nil || req.UserID == "" {
 		return c.JSON(http.StatusBadRequest, apierr.Error("INVALID_PARAM", "userId is required.", "3d81ceae-475f-4600-b2a8-2bc116157532"))
 	}
 	req.Limit = pagination.ClampLimit(req.Limit, 10, 100)
-	notes, err := h.noteRepo.ListByUserID(req.UserID, "", "", req.Limit)
+	viewer := middleware.GetUser(c)
+	var viewerID string
+	if viewer != nil {
+		viewerID = viewer.ID
+	}
+	notes, err := h.noteRepo.ListFeaturedByUser(req.UserID, viewerID, req.UntilID, req.Limit)
 	if err != nil {
 		return c.JSON(http.StatusInternalServerError, apierr.Error("INTERNAL_ERROR", "Internal error.", "5d37dbcb-891e-41ca-a3d6-e690c97775ac"))
 	}
-	viewer := middleware.GetUser(c)
-	notes = notesfilter.FilterVisible(viewer, notes, h.followingRepo)
 	notes = notesfilter.ApplyHardMute(h.userRepo, viewer, notes)
 	result := entity.PackNotes(c.Request().Context(), notes, h.idGen, h.instanceLookup(), h.emojiLookup(), h.reactionReader())
 	h.fieldRes.Apply(result, viewer)

--- a/internal/api/users/handler_extra_test.go
+++ b/internal/api/users/handler_extra_test.go
@@ -413,24 +413,47 @@ func TestFeaturedNotes_AnonymousExcludesNonPublicVisibility(t *testing.T) {
 	assert.False(t, ids["fn_spec"], "specified は対象外 viewer に漏らさない")
 }
 
-// #1487 Option B: upstream は Redis sorted set engagement ranking。mk-go は
-// 同等の SQL ranking で揃え、`renoteCount + repliesCount` 降順 → id 降順で
-// 返ることを覆う。
-func TestFeaturedNotes_OrderedByEngagement(t *testing.T) {
+// #1487 Option B / #1491 review: upstream featured-notes.ts は engagement で
+// 上位を選抜したあと id DESC で表示する。mk-go も同じ 2 段で揃えるため、
+// engagement の高低と id の大小が一致しない fixture で表示順が id DESC に
+// なることを覆う (engagement DESC のままだと untilId cursor とソート順が
+// ずれてページングで重複/欠落するため逆の挙動を見せたい)。
+func TestFeaturedNotes_OrderedByIDDescAfterEngagementSelection(t *testing.T) {
 	h, _, noteRepo := newExtraHandler(t)
 	h.SetFollowingRepo(testutil.NewMockFollowingRepository())
-	noteRepo.Notes["fn_low"] = &model.Note{ID: "fn_low", UserID: "u1", Visibility: "public", RenoteCount: 1, RepliesCount: 0, User: &model.User{ID: "u1"}}
-	noteRepo.Notes["fn_mid"] = &model.Note{ID: "fn_mid", UserID: "u1", Visibility: "public", RenoteCount: 2, RepliesCount: 3, User: &model.User{ID: "u1"}}
-	noteRepo.Notes["fn_top"] = &model.Note{ID: "fn_top", UserID: "u1", Visibility: "public", RenoteCount: 10, RepliesCount: 0, User: &model.User{ID: "u1"}}
+	// engagement と id の並びが逆になる fixture:
+	//   id DESC:        fn_x3, fn_x2, fn_x1
+	//   engagement DESC: fn_x1 (10), fn_x2 (5), fn_x3 (1)
+	noteRepo.Notes["fn_x1"] = &model.Note{ID: "fn_x1", UserID: "u1", Visibility: "public", RenoteCount: 10, User: &model.User{ID: "u1"}}
+	noteRepo.Notes["fn_x2"] = &model.Note{ID: "fn_x2", UserID: "u1", Visibility: "public", RenoteCount: 5, User: &model.User{ID: "u1"}}
+	noteRepo.Notes["fn_x3"] = &model.Note{ID: "fn_x3", UserID: "u1", Visibility: "public", RenoteCount: 1, User: &model.User{ID: "u1"}}
 
 	rec := postExtra(h.FeaturedNotes, `{"userId":"u1","limit":10}`, nil)
 	require.Equal(t, http.StatusOK, rec.Code)
 	var out []map[string]any
 	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &out))
 	require.Len(t, out, 3)
-	assert.Equal(t, "fn_top", out[0]["id"])
-	assert.Equal(t, "fn_mid", out[1]["id"])
-	assert.Equal(t, "fn_low", out[2]["id"])
+	assert.Equal(t, "fn_x3", out[0]["id"], "display は id DESC")
+	assert.Equal(t, "fn_x2", out[1]["id"])
+	assert.Equal(t, "fn_x1", out[2]["id"])
+}
+
+// #1491 review: untilId は display 段 (id DESC + id < untilId) で適用され、
+// engagement DESC で発生する重複/欠落なしにページングできることを覆う。
+func TestFeaturedNotes_UntilIDPaginatesByIDDesc(t *testing.T) {
+	h, _, noteRepo := newExtraHandler(t)
+	h.SetFollowingRepo(testutil.NewMockFollowingRepository())
+	noteRepo.Notes["fn_x1"] = &model.Note{ID: "fn_x1", UserID: "u1", Visibility: "public", RenoteCount: 10, User: &model.User{ID: "u1"}}
+	noteRepo.Notes["fn_x2"] = &model.Note{ID: "fn_x2", UserID: "u1", Visibility: "public", RenoteCount: 5, User: &model.User{ID: "u1"}}
+	noteRepo.Notes["fn_x3"] = &model.Note{ID: "fn_x3", UserID: "u1", Visibility: "public", RenoteCount: 1, User: &model.User{ID: "u1"}}
+
+	// untilId="fn_x2" → id < fn_x2 = fn_x1 のみ。fn_x3 は除外され、fn_x2 自身も除外。
+	rec := postExtra(h.FeaturedNotes, `{"userId":"u1","limit":10,"untilId":"fn_x2"}`, nil)
+	require.Equal(t, http.StatusOK, rec.Code)
+	var out []map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &out))
+	require.Len(t, out, 1)
+	assert.Equal(t, "fn_x1", out[0]["id"])
 }
 
 // #1487: post-fetch FilterVisible → SQL push-down に変更されたことで、limit に

--- a/internal/api/users/handler_extra_test.go
+++ b/internal/api/users/handler_extra_test.go
@@ -413,6 +413,51 @@ func TestFeaturedNotes_AnonymousExcludesNonPublicVisibility(t *testing.T) {
 	assert.False(t, ids["fn_spec"], "specified は対象外 viewer に漏らさない")
 }
 
+// #1487 Option B: upstream は Redis sorted set engagement ranking。mk-go は
+// 同等の SQL ranking で揃え、`renoteCount + repliesCount` 降順 → id 降順で
+// 返ることを覆う。
+func TestFeaturedNotes_OrderedByEngagement(t *testing.T) {
+	h, _, noteRepo := newExtraHandler(t)
+	h.SetFollowingRepo(testutil.NewMockFollowingRepository())
+	noteRepo.Notes["fn_low"] = &model.Note{ID: "fn_low", UserID: "u1", Visibility: "public", RenoteCount: 1, RepliesCount: 0, User: &model.User{ID: "u1"}}
+	noteRepo.Notes["fn_mid"] = &model.Note{ID: "fn_mid", UserID: "u1", Visibility: "public", RenoteCount: 2, RepliesCount: 3, User: &model.User{ID: "u1"}}
+	noteRepo.Notes["fn_top"] = &model.Note{ID: "fn_top", UserID: "u1", Visibility: "public", RenoteCount: 10, RepliesCount: 0, User: &model.User{ID: "u1"}}
+
+	rec := postExtra(h.FeaturedNotes, `{"userId":"u1","limit":10}`, nil)
+	require.Equal(t, http.StatusOK, rec.Code)
+	var out []map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &out))
+	require.Len(t, out, 3)
+	assert.Equal(t, "fn_top", out[0]["id"])
+	assert.Equal(t, "fn_mid", out[1]["id"])
+	assert.Equal(t, "fn_low", out[2]["id"])
+}
+
+// #1487: post-fetch FilterVisible → SQL push-down に変更されたことで、limit に
+// 達するまでに非表示 note が間引かれないことを覆う (under-fill 回帰防止)。
+func TestFeaturedNotes_LimitNotUnderfilled(t *testing.T) {
+	h, _, noteRepo := newExtraHandler(t)
+	h.SetFollowingRepo(testutil.NewMockFollowingRepository())
+	// public 5 件 + non-visible (followers) 5 件、limit=5 で public のみ 5 件返る。
+	for i := 0; i < 5; i++ {
+		id := "fn_p" + string(rune('0'+i))
+		noteRepo.Notes[id] = &model.Note{ID: id, UserID: "u1", Visibility: "public", RenoteCount: int16(10 - i), User: &model.User{ID: "u1"}}
+	}
+	for i := 0; i < 5; i++ {
+		id := "fn_f" + string(rune('0'+i))
+		noteRepo.Notes[id] = &model.Note{ID: id, UserID: "u1", Visibility: "followers", RenoteCount: int16(100), User: &model.User{ID: "u1"}}
+	}
+	rec := postExtra(h.FeaturedNotes, `{"userId":"u1","limit":5}`, nil)
+	require.Equal(t, http.StatusOK, rec.Code)
+	var out []map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &out))
+	assert.Len(t, out, 5, "push-down で limit ぶん必ず埋まる")
+	for _, n := range out {
+		// followers は出ない。
+		assert.NotContains(t, n["id"].(string), "fn_f")
+	}
+}
+
 // --- SearchByUsernameAndHost ---
 
 func TestSearchByUsernameAndHost_Success(t *testing.T) {
@@ -524,9 +569,19 @@ func (f *failingListByUserRepo) ListByUserID(_ string, _, _ string, _ int) ([]*m
 	return nil, assert.AnError
 }
 
+// FeaturedNotes は #1487 で ListFeaturedByUser に切り替わったため、500 経路は
+// 当該メソッドが err を返す stub で覆う。
+type failingListFeaturedByUserRepo struct {
+	*testutil.MockNoteRepository
+}
+
+func (f *failingListFeaturedByUserRepo) ListFeaturedByUser(_, _, _ string, _ int) ([]*model.Note, error) {
+	return nil, assert.AnError
+}
+
 func TestFeaturedNotes_Error(t *testing.T) {
 	userRepo := testutil.NewMockUserRepository()
-	noteRepo := &failingListByUserRepo{testutil.NewMockNoteRepository()}
+	noteRepo := &failingListFeaturedByUserRepo{testutil.NewMockNoteRepository()}
 	piningRepo := testutil.NewMockUserNotePiningRepository()
 	idGen, _ := id.NewGenerator("aidx")
 	userSvc := coreuser.NewService(userRepo, noteRepo, piningRepo, idGen)

--- a/internal/repository/note.go
+++ b/internal/repository/note.go
@@ -1,6 +1,7 @@
 package repository
 
 import (
+	"sort"
 	"strconv"
 	"strings"
 	"time"
@@ -14,6 +15,12 @@ import (
 // misc/id パッケージに同値の非公開定数があるが、本ファイル内で時刻→ID 先頭
 // 変換に使うため独自に定義する。
 const aidxTime2000Ms int64 = 946684800000
+
+// featuredNotesPerUserPoolSize は users/featured-notes の selection 段で
+// engagement DESC top-N を SQL から取得する際の上限。upstream
+// FeaturedService.getPerUserNotesRanking の threshold (50) と揃える (#1487 / #1491)。
+// 選抜後は id DESC + untilID cursor + limit でページングする。
+const featuredNotesPerUserPoolSize = 50
 
 // aidxCutoffID は与えられた time に対応する最小のaidx ID文字列を返す。
 // aidxは「時刻base36(8) + nodeID(4) + counter(4)」の 16 文字で、先頭 8 文字が
@@ -91,16 +98,23 @@ type NoteRepository interface {
 	// pagination (id < untilID). offset is honoured only when no cursor
 	// is given.
 	ListFeatured(channelID, untilID string, limit, offset int) ([]*model.Note, error)
-	// ListFeaturedByUser returns userID's notes ranked by engagement
-	// ((renoteCount + repliesCount) DESC, id DESC) for users/featured-notes.
-	// upstream は Redis sorted set (FeaturedService.getPerUserNotesRanking) を
-	// 引いているが、mk-go は ListFeatured / channels timeline と同じく SQL ranking
-	// + visibility push-down で揃える (#1487 Option B)。
+	// ListFeaturedByUser returns userID's featured notes for users/featured-notes.
+	// upstream は Redis sorted set (FeaturedService.getPerUserNotesRanking) で
+	// engagement 上位を選抜してから id DESC で並べ替え untilID でページング
+	// する 2 段構成。mk-go も同じ 2 段で揃える (#1487 Option B):
+	//
+	//  1. selection: engagement = (renoteCount + repliesCount) DESC, id DESC で
+	//     featuredNotesPerUserPoolSize (=50, upstream 同値) 件を SQL push-down で
+	//     選抜。visibility 条件と channel 除外もここで同時に絞る (LIMIT 前)。
+	//     post-fetch FilterVisible だとページ過少充填 + followers 判定 N+1 を
+	//     起こすため (#1418 / #1440 と同 doctrine)。
+	//  2. display: 選抜結果を Go 側で id DESC に並べ替え、untilID < id でページング
+	//     してから先頭 limit 件を返す。これで「engagement で選抜・id で表示」が
+	//     upstream と一致し、id cursor とソート順がずれて発生する重複/欠落を
+	//     回避する (#1491 review)。
 	//
 	// viewerID は viewer 視点の visibility push-down 用。空文字は匿名
-	// (public/home のみ)。post-fetch FilterVisible だとページ過少充填 +
-	// followers 判定 N+1 を起こすため LIMIT 前に SQL で絞る (#1418 / #1440 と
-	// 同 doctrine)。channel 投稿は除外する (upstream featured-notes と一致)。
+	// (public/home のみ)。
 	ListFeaturedByUser(userID, viewerID, untilID string, limit int) ([]*model.Note, error)
 	FindRenoteByUser(userID, renoteID string) (*model.Note, error)
 	ListMentions(userID string, limit int, sinceID, untilID string) ([]*model.Note, error)
@@ -637,12 +651,16 @@ func (r *noteRepository) ListFeaturedByUser(userID, viewerID, untilID string, li
 	if limit <= 0 {
 		limit = 10
 	}
+	// === selection: engagement DESC top-N を SQL push-down で選抜 ===
+	// upstream FeaturedService.getPerUserNotesRanking が Redis sorted set
+	// 上位 50 件を引いてくる工程に相当。visibility 条件と channel 除外も
+	// LIMIT 前に同じ SQL で適用する (#1487 / #1491, ListByUserIDFiltered と
+	// 同 pattern)。post-fetch FilterVisible だと limit が削られページ過少充填、
+	// followers 判定が N+1。untilID はここでは適用しない (engagement プール
+	// を id DESC でページングする display 段で適用する)。
 	q := preloadNoteRelations(r.db).
 		Where(`"userId" = ?`, userID).
 		Where(`"channelId" IS NULL`)
-	// visibility push-down: core/note.CanSeeNote と同条件を LIMIT 前に絞る
-	// (#1487, ListByUserIDFiltered / ListByChannelID と同 pattern)。post-fetch
-	// FilterVisible だと limit が削られページ過少充填、followers 判定が N+1。
 	if viewerID == "" {
 		q = q.Where(`"visibility" IN ('public','home')`)
 	} else {
@@ -653,18 +671,31 @@ func (r *noteRepository) ListFeaturedByUser(userID, viewerID, untilID string, li
 				`OR ("visibility" = 'specified' AND ? = ANY("visibleUserIds")))`,
 			viewerID, viewerID, viewerID)
 	}
-	if untilID != "" {
-		q = q.Where(`id < ?`, untilID)
-	}
-	// upstream FeaturedService.getPerUserNotesRanking は Redis sorted set の
-	// score 降順だが、mk-go は engagement = renoteCount + repliesCount を
-	// SQL ranking で代替する (ListFeatured と一致)。tie-break は id DESC。
-	q = q.Order(`("renoteCount" + "repliesCount") DESC, id DESC`).Limit(limit)
-	var notes []*model.Note
-	if err := q.Find(&notes).Error; err != nil {
+	q = q.Order(`("renoteCount" + "repliesCount") DESC, id DESC`).Limit(featuredNotesPerUserPoolSize)
+	var pool []*model.Note
+	if err := q.Find(&pool).Error; err != nil {
 		return nil, err
 	}
-	return notes, nil
+	// === display: id DESC sort → untilID filter → 先頭 limit 件 ===
+	// upstream featured-notes.ts:100-104 と同じ手順。engagement プールを
+	// id DESC で見せると id cursor とソート順が一致してページングが整合的に
+	// なる (engagement DESC で表示すると untilId 進行時に重複/欠落するため)。
+	sort.Slice(pool, func(i, j int) bool {
+		return pool[i].ID > pool[j].ID
+	})
+	if untilID != "" {
+		filtered := pool[:0]
+		for _, n := range pool {
+			if n.ID < untilID {
+				filtered = append(filtered, n)
+			}
+		}
+		pool = filtered
+	}
+	if len(pool) > limit {
+		pool = pool[:limit]
+	}
+	return pool, nil
 }
 
 func (r *noteRepository) FindRenoteByUser(userID, renoteID string) (*model.Note, error) {

--- a/internal/repository/note.go
+++ b/internal/repository/note.go
@@ -91,6 +91,17 @@ type NoteRepository interface {
 	// pagination (id < untilID). offset is honoured only when no cursor
 	// is given.
 	ListFeatured(channelID, untilID string, limit, offset int) ([]*model.Note, error)
+	// ListFeaturedByUser returns userID's notes ranked by engagement
+	// ((renoteCount + repliesCount) DESC, id DESC) for users/featured-notes.
+	// upstream は Redis sorted set (FeaturedService.getPerUserNotesRanking) を
+	// 引いているが、mk-go は ListFeatured / channels timeline と同じく SQL ranking
+	// + visibility push-down で揃える (#1487 Option B)。
+	//
+	// viewerID は viewer 視点の visibility push-down 用。空文字は匿名
+	// (public/home のみ)。post-fetch FilterVisible だとページ過少充填 +
+	// followers 判定 N+1 を起こすため LIMIT 前に SQL で絞る (#1418 / #1440 と
+	// 同 doctrine)。channel 投稿は除外する (upstream featured-notes と一致)。
+	ListFeaturedByUser(userID, viewerID, untilID string, limit int) ([]*model.Note, error)
 	FindRenoteByUser(userID, renoteID string) (*model.Note, error)
 	ListMentions(userID string, limit int, sinceID, untilID string) ([]*model.Note, error)
 	// SearchByTag returns notes carrying tag that viewerID is allowed to see.
@@ -615,6 +626,40 @@ func (r *noteRepository) ListFeatured(channelID, untilID string, limit, offset i
 	if untilID == "" && offset > 0 {
 		q = q.Offset(offset)
 	}
+	var notes []*model.Note
+	if err := q.Find(&notes).Error; err != nil {
+		return nil, err
+	}
+	return notes, nil
+}
+
+func (r *noteRepository) ListFeaturedByUser(userID, viewerID, untilID string, limit int) ([]*model.Note, error) {
+	if limit <= 0 {
+		limit = 10
+	}
+	q := preloadNoteRelations(r.db).
+		Where(`"userId" = ?`, userID).
+		Where(`"channelId" IS NULL`)
+	// visibility push-down: core/note.CanSeeNote と同条件を LIMIT 前に絞る
+	// (#1487, ListByUserIDFiltered / ListByChannelID と同 pattern)。post-fetch
+	// FilterVisible だと limit が削られページ過少充填、followers 判定が N+1。
+	if viewerID == "" {
+		q = q.Where(`"visibility" IN ('public','home')`)
+	} else {
+		q = q.Where(
+			`("visibility" IN ('public','home') `+
+				`OR "userId" = ? `+
+				`OR ("visibility" = 'followers' AND "userId" IN (SELECT f."followeeId" FROM "following" f WHERE f."followerId" = ?)) `+
+				`OR ("visibility" = 'specified' AND ? = ANY("visibleUserIds")))`,
+			viewerID, viewerID, viewerID)
+	}
+	if untilID != "" {
+		q = q.Where(`id < ?`, untilID)
+	}
+	// upstream FeaturedService.getPerUserNotesRanking は Redis sorted set の
+	// score 降順だが、mk-go は engagement = renoteCount + repliesCount を
+	// SQL ranking で代替する (ListFeatured と一致)。tie-break は id DESC。
+	q = q.Order(`("renoteCount" + "repliesCount") DESC, id DESC`).Limit(limit)
 	var notes []*model.Note
 	if err := q.Find(&notes).Error; err != nil {
 		return nil, err

--- a/internal/repository/note_test.go
+++ b/internal/repository/note_test.go
@@ -1092,8 +1092,14 @@ func TestNoteRepository_ListFeatured_Error(t *testing.T) {
 	assert.Error(t, err)
 }
 
-// #1487 Option B: users/featured-notes 用の per-user engagement ranking +
-// visibility push-down を覆う。
+// #1487 Option B / #1491 review: users/featured-notes は selection 段で
+// engagement DESC + visibility push-down + channel 除外、display 段で id DESC +
+// untilID + limit という 2 段構成。selection は engagement 由来、display は
+// id DESC + id cursor で一致するように分離されていることを覆う。
+//
+// id と engagement の並びが意図的にずれた fixture (z>m>a の id に対し engagement
+// は a=10, m=5, z=1) を使い、display が id DESC で並ぶ (engagement DESC でない)
+// ことを断定する。
 func TestNoteRepository_ListFeaturedByUser(t *testing.T) {
 	repo := NewNoteRepository(testDB)
 	author := insertTestUser(t, "feat_by_u", "featbyu")
@@ -1117,39 +1123,43 @@ func TestNoteRepository_ListFeaturedByUser(t *testing.T) {
 	defer testDB.Exec(`DELETE FROM channel WHERE id = ?`, chID)
 
 	chPtr := chID
-	// 順序確認用の public 3 件と、可視性確認用の followers / specified、
-	// 除外確認用の channel note。
+	// engagement と id の並びが逆になる fixture。display 段が id DESC である
+	// ことを明示的に断定するため意図的にずらしている (= engagement DESC で
+	// 返してしまうとこのテストが落ちる)。
 	notes := []*model.Note{
-		{ID: "feat_by_top", UserID: author.ID, Visibility: "public", RenoteCount: 10},
-		{ID: "feat_by_mid", UserID: author.ID, Visibility: "public", RenoteCount: 3, RepliesCount: 2},
-		{ID: "feat_by_low", UserID: author.ID, Visibility: "public", RenoteCount: 1},
-		{ID: "feat_by_fol", UserID: author.ID, Visibility: "followers", RenoteCount: 100},
-		{ID: "feat_by_sp", UserID: author.ID, Visibility: "specified", VisibleUserIDs: pq.StringArray{specified.ID}, RenoteCount: 50},
-		{ID: "feat_by_ch", UserID: author.ID, Visibility: "public", RenoteCount: 999, ChannelID: &chPtr},
+		{ID: "feat_by_aaa", UserID: author.ID, Visibility: "public", RenoteCount: 10},                                                  // 最大 engagement / 最小 id
+		{ID: "feat_by_mmm", UserID: author.ID, Visibility: "public", RenoteCount: 3, RepliesCount: 2},                                  //
+		{ID: "feat_by_zzz", UserID: author.ID, Visibility: "public", RenoteCount: 1},                                                   // 最小 engagement / 最大 id
+		{ID: "feat_by_fol", UserID: author.ID, Visibility: "followers", RenoteCount: 100},                                              //
+		{ID: "feat_by_spc", UserID: author.ID, Visibility: "specified", VisibleUserIDs: pq.StringArray{specified.ID}, RenoteCount: 50}, //
+		{ID: "feat_by_chn", UserID: author.ID, Visibility: "public", RenoteCount: 999, ChannelID: &chPtr},                              //
 	}
 	for _, n := range notes {
 		require.NoError(t, testDB.Create(n).Error)
 		defer testDB.Exec(`DELETE FROM "note" WHERE id = ?`, n.ID)
 	}
 
-	// stranger は public 3 件、engagement DESC で top / mid / low の順。
+	// stranger: public 3 件、display は id DESC (zzz > mmm > aaa)。
 	got, err := repo.ListFeaturedByUser(author.ID, stranger.ID, "", 10)
 	require.NoError(t, err)
 	require.Len(t, got, 3)
-	assert.Equal(t, "feat_by_top", got[0].ID)
-	assert.Equal(t, "feat_by_mid", got[1].ID)
-	assert.Equal(t, "feat_by_low", got[2].ID)
+	assert.Equal(t, "feat_by_zzz", got[0].ID, "display は id DESC (engagement DESC ではない)")
+	assert.Equal(t, "feat_by_mmm", got[1].ID)
+	assert.Equal(t, "feat_by_aaa", got[2].ID)
 
 	// anonymous も同じ shape (channel 除外を含む)。
 	got, err = repo.ListFeaturedByUser(author.ID, "", "", 10)
 	require.NoError(t, err)
 	require.Len(t, got, 3)
 
-	// follower は public 3 + followers 1 = 4 件。followers が engagement top。
+	// follower は public 3 + followers 1 = 4 件。id DESC で zzz > mmm > fol > aaa。
 	got, err = repo.ListFeaturedByUser(author.ID, follower.ID, "", 10)
 	require.NoError(t, err)
 	require.Len(t, got, 4)
-	assert.Equal(t, "feat_by_fol", got[0].ID)
+	assert.Equal(t, "feat_by_zzz", got[0].ID)
+	assert.Equal(t, "feat_by_mmm", got[1].ID)
+	assert.Equal(t, "feat_by_fol", got[2].ID)
+	assert.Equal(t, "feat_by_aaa", got[3].ID)
 
 	// specified target は public 3 + specified 1 = 4 件。
 	got, err = repo.ListFeaturedByUser(author.ID, specified.ID, "", 10)
@@ -1159,7 +1169,7 @@ func TestNoteRepository_ListFeaturedByUser(t *testing.T) {
 	for _, n := range got {
 		ids[n.ID] = true
 	}
-	assert.True(t, ids["feat_by_sp"], "specified target に specified note が見える")
+	assert.True(t, ids["feat_by_spc"], "specified target に specified note が見える")
 	assert.False(t, ids["feat_by_fol"], "specified target は follower ではないので followers note は出ない")
 
 	// author 自身は channel 以外の全 visibility = 5 件。
@@ -1167,7 +1177,7 @@ func TestNoteRepository_ListFeaturedByUser(t *testing.T) {
 	require.NoError(t, err)
 	require.Len(t, got, 5)
 	for _, n := range got {
-		assert.NotEqual(t, "feat_by_ch", n.ID, "channel 投稿は除外")
+		assert.NotEqual(t, "feat_by_chn", n.ID, "channel 投稿は除外")
 	}
 
 	// limit <= 0 は 10 にデフォルト。
@@ -1175,13 +1185,13 @@ func TestNoteRepository_ListFeaturedByUser(t *testing.T) {
 	require.NoError(t, err)
 	assert.Len(t, got, 5)
 
-	// untilID cursor で id < untilID を返す。top は除外される (id 比較)。
-	got, err = repo.ListFeaturedByUser(author.ID, stranger.ID, "feat_by_top", 10)
+	// untilID="feat_by_mmm" → id DESC で id < mmm のもの (= feat_by_aaa) のみ
+	// 残る。display 段で適用するため id DESC と一致したページングになる
+	// (engagement DESC + id cursor の重複/欠落が起きない、#1491 review)。
+	got, err = repo.ListFeaturedByUser(author.ID, stranger.ID, "feat_by_mmm", 10)
 	require.NoError(t, err)
-	require.Len(t, got, 2)
-	for _, n := range got {
-		assert.Less(t, n.ID, "feat_by_top")
-	}
+	require.Len(t, got, 1)
+	assert.Equal(t, "feat_by_aaa", got[0].ID)
 }
 
 func TestNoteRepository_ListFeaturedByUser_Error(t *testing.T) {

--- a/internal/repository/note_test.go
+++ b/internal/repository/note_test.go
@@ -2,6 +2,7 @@ package repository
 
 import (
 	"context"
+	"fmt"
 	"sort"
 	"strings"
 	"testing"
@@ -1192,6 +1193,52 @@ func TestNoteRepository_ListFeaturedByUser(t *testing.T) {
 	require.NoError(t, err)
 	require.Len(t, got, 1)
 	assert.Equal(t, "feat_by_aaa", got[0].ID)
+}
+
+// #1491 re-review 指摘A: selection 段が「engagement DESC top-50 で絞る」核心
+// 挙動の回帰検出。fixture を 51 件にして pool cap を踏ませ、low engagement の
+// 1 件 (最大 id) が pool 外に出て display に現れないこと、選抜される 50 件が
+// engagement=10 の note (id prefix `feat_cap_pool_`) であることを断定する。
+//
+// 6 件以下の小規模 fixture では pool = 全件となり、選抜順序が engagement 順
+// でも id 順でも結果が変わらないため、`featuredNotesPerUserPoolSize` を 51 に
+// すれば落ちる test がここまで存在しなかった。本 test は cap を取り除くと
+// 必ず落ちる強い regression gate になる。
+func TestNoteRepository_ListFeaturedByUser_EngagementPoolCap(t *testing.T) {
+	repo := NewNoteRepository(testDB)
+	author := insertTestUser(t, "feat_cap_u", "featcapu")
+	defer cleanupUser(t, author.ID)
+	defer testDB.Exec(`DELETE FROM "note" WHERE id LIKE 'feat_cap_%'`)
+
+	// engagement=10 の note を 50 件 (id: feat_cap_pool_01 .. feat_cap_pool_50)。
+	// すべて pool に入る想定。
+	for i := 1; i <= 50; i++ {
+		id := fmt.Sprintf("feat_cap_pool_%02d", i)
+		require.NoError(t, testDB.Create(&model.Note{
+			ID: id, UserID: author.ID, Visibility: "public", RenoteCount: 10,
+		}).Error)
+	}
+	// engagement=0 の note を 1 件、最大 id (feat_cap_zzz_low) で。pool は
+	// engagement DESC top-50 で絞られるので、これは pool 外になる想定。
+	// id 順で並べたら一番上に来てしまうが、selection が engagement 順なので
+	// 出てこないことが重要。
+	const lowID = "feat_cap_zzz_low"
+	require.NoError(t, testDB.Create(&model.Note{
+		ID: lowID, UserID: author.ID, Visibility: "public", RenoteCount: 0,
+	}).Error)
+
+	got, err := repo.ListFeaturedByUser(author.ID, "", "", 100)
+	require.NoError(t, err)
+	// pool cap=50 で 50 件返る。limit=100 でも cap が優先。
+	require.Len(t, got, 50, "engagement pool cap=50 で 50 件に絞られる")
+	for _, n := range got {
+		assert.NotEqual(t, lowID, n.ID, "engagement 最下位の note は pool 外に落ちる")
+		assert.True(t, strings.HasPrefix(n.ID, "feat_cap_pool_"),
+			"engagement DESC 上位 50 件 (feat_cap_pool_*) のみが選抜される")
+	}
+	// display は id DESC: feat_cap_pool_50, _49, ..., _01。
+	assert.Equal(t, "feat_cap_pool_50", got[0].ID)
+	assert.Equal(t, "feat_cap_pool_01", got[49].ID)
 }
 
 func TestNoteRepository_ListFeaturedByUser_Error(t *testing.T) {

--- a/internal/repository/note_test.go
+++ b/internal/repository/note_test.go
@@ -1092,6 +1092,106 @@ func TestNoteRepository_ListFeatured_Error(t *testing.T) {
 	assert.Error(t, err)
 }
 
+// #1487 Option B: users/featured-notes 用の per-user engagement ranking +
+// visibility push-down を覆う。
+func TestNoteRepository_ListFeaturedByUser(t *testing.T) {
+	repo := NewNoteRepository(testDB)
+	author := insertTestUser(t, "feat_by_u", "featbyu")
+	defer cleanupUser(t, author.ID)
+	follower := insertTestUser(t, "feat_by_f", "featbyf")
+	defer cleanupUser(t, follower.ID)
+	stranger := insertTestUser(t, "feat_by_s", "featbys")
+	defer cleanupUser(t, stranger.ID)
+	specified := insertTestUser(t, "feat_by_sp", "featbysp")
+	defer cleanupUser(t, specified.ID)
+
+	// follower → author の follow を seed。
+	require.NoError(t, testDB.Create(&model.Following{
+		ID: "f_feat_by_1", FollowerID: follower.ID, FolloweeID: author.ID,
+	}).Error)
+	defer testDB.Exec(`DELETE FROM "following" WHERE id = ?`, "f_feat_by_1")
+
+	// channel 投稿はランキング対象外。
+	chID := "feat_by_ch"
+	require.NoError(t, testDB.Exec(`INSERT INTO channel (id, name, "userId") VALUES (?, ?, ?)`, chID, "feat-by-ch", author.ID).Error)
+	defer testDB.Exec(`DELETE FROM channel WHERE id = ?`, chID)
+
+	chPtr := chID
+	// 順序確認用の public 3 件と、可視性確認用の followers / specified、
+	// 除外確認用の channel note。
+	notes := []*model.Note{
+		{ID: "feat_by_top", UserID: author.ID, Visibility: "public", RenoteCount: 10},
+		{ID: "feat_by_mid", UserID: author.ID, Visibility: "public", RenoteCount: 3, RepliesCount: 2},
+		{ID: "feat_by_low", UserID: author.ID, Visibility: "public", RenoteCount: 1},
+		{ID: "feat_by_fol", UserID: author.ID, Visibility: "followers", RenoteCount: 100},
+		{ID: "feat_by_sp", UserID: author.ID, Visibility: "specified", VisibleUserIDs: pq.StringArray{specified.ID}, RenoteCount: 50},
+		{ID: "feat_by_ch", UserID: author.ID, Visibility: "public", RenoteCount: 999, ChannelID: &chPtr},
+	}
+	for _, n := range notes {
+		require.NoError(t, testDB.Create(n).Error)
+		defer testDB.Exec(`DELETE FROM "note" WHERE id = ?`, n.ID)
+	}
+
+	// stranger は public 3 件、engagement DESC で top / mid / low の順。
+	got, err := repo.ListFeaturedByUser(author.ID, stranger.ID, "", 10)
+	require.NoError(t, err)
+	require.Len(t, got, 3)
+	assert.Equal(t, "feat_by_top", got[0].ID)
+	assert.Equal(t, "feat_by_mid", got[1].ID)
+	assert.Equal(t, "feat_by_low", got[2].ID)
+
+	// anonymous も同じ shape (channel 除外を含む)。
+	got, err = repo.ListFeaturedByUser(author.ID, "", "", 10)
+	require.NoError(t, err)
+	require.Len(t, got, 3)
+
+	// follower は public 3 + followers 1 = 4 件。followers が engagement top。
+	got, err = repo.ListFeaturedByUser(author.ID, follower.ID, "", 10)
+	require.NoError(t, err)
+	require.Len(t, got, 4)
+	assert.Equal(t, "feat_by_fol", got[0].ID)
+
+	// specified target は public 3 + specified 1 = 4 件。
+	got, err = repo.ListFeaturedByUser(author.ID, specified.ID, "", 10)
+	require.NoError(t, err)
+	require.Len(t, got, 4)
+	ids := map[string]bool{}
+	for _, n := range got {
+		ids[n.ID] = true
+	}
+	assert.True(t, ids["feat_by_sp"], "specified target に specified note が見える")
+	assert.False(t, ids["feat_by_fol"], "specified target は follower ではないので followers note は出ない")
+
+	// author 自身は channel 以外の全 visibility = 5 件。
+	got, err = repo.ListFeaturedByUser(author.ID, author.ID, "", 10)
+	require.NoError(t, err)
+	require.Len(t, got, 5)
+	for _, n := range got {
+		assert.NotEqual(t, "feat_by_ch", n.ID, "channel 投稿は除外")
+	}
+
+	// limit <= 0 は 10 にデフォルト。
+	got, err = repo.ListFeaturedByUser(author.ID, author.ID, "", 0)
+	require.NoError(t, err)
+	assert.Len(t, got, 5)
+
+	// untilID cursor で id < untilID を返す。top は除外される (id 比較)。
+	got, err = repo.ListFeaturedByUser(author.ID, stranger.ID, "feat_by_top", 10)
+	require.NoError(t, err)
+	require.Len(t, got, 2)
+	for _, n := range got {
+		assert.Less(t, n.ID, "feat_by_top")
+	}
+}
+
+func TestNoteRepository_ListFeaturedByUser_Error(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	repo := NewNoteRepository(testDB.WithContext(ctx))
+	_, err := repo.ListFeaturedByUser("u", "", "", 10)
+	assert.Error(t, err)
+}
+
 func TestNoteRepository_FindRenoteByUser(t *testing.T) {
 	repo := NewNoteRepository(testDB)
 	user := insertTestUser(t, "unrn_u", "unrnuser")

--- a/internal/testutil/mock_repository.go
+++ b/internal/testutil/mock_repository.go
@@ -1093,14 +1093,22 @@ func (m *MockNoteRepository) ListFeatured(channelID, untilID string, limit, offs
 	return result[:limit], nil
 }
 
-// ListFeaturedByUser returns userID's notes ranked by engagement
-// (renoteCount + repliesCount DESC, id DESC) restricted to viewer's
-// visibility. channel 投稿は除外する。real repo の SQL push-down と一致 (#1487)。
+// mockFeaturedNotesPerUserPoolSize は repository.featuredNotesPerUserPoolSize
+// と揃える pool size (#1487 / #1491)。selection 段で engagement DESC top-N を
+// 取り、display 段で id DESC + untilID + limit を適用する 2 段構成を mock も
+// 同じ semantics で再現する。
+const mockFeaturedNotesPerUserPoolSize = 50
+
+// ListFeaturedByUser mirrors the real repository's 2-stage selection:
+// engagement DESC で top-50 を選抜したあと、id DESC でページングする。
+// channel 投稿は除外する。real repo の SQL push-down と一致 (#1487 / #1491)。
 func (m *MockNoteRepository) ListFeaturedByUser(userID, viewerID, untilID string, limit int) ([]*model.Note, error) {
 	if limit <= 0 {
 		limit = 10
 	}
-	var result []*model.Note
+	// === selection: viewer 視点で見える non-channel note を engagement DESC で
+	//     top-N 選抜 ===
+	var pool []*model.Note
 	for _, n := range m.Notes {
 		if n.UserID != userID {
 			continue
@@ -1108,27 +1116,39 @@ func (m *MockNoteRepository) ListFeaturedByUser(userID, viewerID, untilID string
 		if n.ChannelID != nil {
 			continue
 		}
-		if untilID != "" && n.ID >= untilID {
-			continue
-		}
 		if !noteVisibleToViewer(viewerID, n, m.Following) {
 			continue
 		}
-		result = append(result, n)
+		pool = append(pool, n)
 	}
-	// engagement DESC, id DESC.
-	sort.Slice(result, func(i, j int) bool {
-		ei := result[i].RenoteCount + result[i].RepliesCount
-		ej := result[j].RenoteCount + result[j].RepliesCount
+	sort.Slice(pool, func(i, j int) bool {
+		ei := pool[i].RenoteCount + pool[i].RepliesCount
+		ej := pool[j].RenoteCount + pool[j].RepliesCount
 		if ei != ej {
 			return ei > ej
 		}
-		return result[i].ID > result[j].ID
+		return pool[i].ID > pool[j].ID
 	})
-	if limit > len(result) {
-		limit = len(result)
+	if len(pool) > mockFeaturedNotesPerUserPoolSize {
+		pool = pool[:mockFeaturedNotesPerUserPoolSize]
 	}
-	return result[:limit], nil
+	// === display: id DESC sort → untilID filter → 先頭 limit 件 ===
+	sort.Slice(pool, func(i, j int) bool {
+		return pool[i].ID > pool[j].ID
+	})
+	if untilID != "" {
+		filtered := pool[:0]
+		for _, n := range pool {
+			if n.ID < untilID {
+				filtered = append(filtered, n)
+			}
+		}
+		pool = filtered
+	}
+	if len(pool) > limit {
+		pool = pool[:limit]
+	}
+	return pool, nil
 }
 
 func (m *MockNoteRepository) FindRenoteByUser(userID, renoteID string) (*model.Note, error) {

--- a/internal/testutil/mock_repository.go
+++ b/internal/testutil/mock_repository.go
@@ -1093,6 +1093,44 @@ func (m *MockNoteRepository) ListFeatured(channelID, untilID string, limit, offs
 	return result[:limit], nil
 }
 
+// ListFeaturedByUser returns userID's notes ranked by engagement
+// (renoteCount + repliesCount DESC, id DESC) restricted to viewer's
+// visibility. channel 投稿は除外する。real repo の SQL push-down と一致 (#1487)。
+func (m *MockNoteRepository) ListFeaturedByUser(userID, viewerID, untilID string, limit int) ([]*model.Note, error) {
+	if limit <= 0 {
+		limit = 10
+	}
+	var result []*model.Note
+	for _, n := range m.Notes {
+		if n.UserID != userID {
+			continue
+		}
+		if n.ChannelID != nil {
+			continue
+		}
+		if untilID != "" && n.ID >= untilID {
+			continue
+		}
+		if !noteVisibleToViewer(viewerID, n, m.Following) {
+			continue
+		}
+		result = append(result, n)
+	}
+	// engagement DESC, id DESC.
+	sort.Slice(result, func(i, j int) bool {
+		ei := result[i].RenoteCount + result[i].RepliesCount
+		ej := result[j].RenoteCount + result[j].RepliesCount
+		if ei != ej {
+			return ei > ej
+		}
+		return result[i].ID > result[j].ID
+	})
+	if limit > len(result) {
+		limit = len(result)
+	}
+	return result[:limit], nil
+}
+
 func (m *MockNoteRepository) FindRenoteByUser(userID, renoteID string) (*model.Note, error) {
 	for _, n := range m.Notes {
 		if n.UserID == userID && n.RenoteID != nil && *n.RenoteID == renoteID && n.Text == nil {


### PR DESCRIPTION
## Summary

`users/featured-notes` は upstream では Redis sorted set 由来の per-user engagement ranking (`FeaturedService.getPerUserNotesRanking`) を返すが、mk-go の現状実装は `ListByUserID` を呼ぶだけで、

- **仕様乖離**: 「人気のノート」タブが実際は「最新ノート (newest-first)」を返していた。
- **可視性 doctrine 違反**: visibility push-down 無しで取得して post-fetch `FilterVisible` していたため、limit に対するページ過少充填と followers 判定の N+1 を起こしていた。mk-go doctrine (#1418 / #1440 / #1441) と非対称。

issue 議論 (Option B = SQL ranking + push-down) に従い、Redis 経路を新設する代わりに既存の SQL ranking pattern で揃える。API response shape は upstream と同一。

## 主な変更点

- `internal/repository/note.go`
  - 新規 `ListFeaturedByUser(userID, viewerID, untilID, limit)` を追加。
  - `("renoteCount" + "repliesCount") DESC, id DESC` で engagement 順に並べ、channel 投稿は除外 (upstream featured-notes と一致)。
  - visibility 条件は LIMIT 前に push-down (`core/note.CanSeeNote` と一致、ListFeatured / ListByUserIDFiltered / ListByChannelID と同一 SQL)。
- `internal/api/users/handler_extra.go`
  - `ListByUserID` → `ListFeaturedByUser` に切替、`notesfilter.FilterVisible` を撤去。
  - cursor `untilId` を新 signature に通す。
  - hard mute は visibility と独立な viewer 個別 filter なので packing 前に残す。
- `internal/testutil/mock_repository.go`
  - `MockNoteRepository.ListFeaturedByUser` を追加 (engagement DESC + push-down)。
- `internal/api/users/handler_extra_test.go`
  - `failingListFeaturedByUserRepo` 追加で 500 経路を維持。
  - 新規 `TestFeaturedNotes_OrderedByEngagement` — engagement DESC 順の確認。
  - 新規 `TestFeaturedNotes_LimitNotUnderfilled` — push-down で limit 通り埋まる回帰防止。
- `internal/api/notes/handler_test.go`
  - `failingNoteRepo` に `ListFeaturedByUser` を追加 (interface 追従)。
- `internal/repository/note_test.go`
  - 新規 `TestNoteRepository_ListFeaturedByUser` — anonymous / stranger / follower / specified / author の per-viewer 絞り込み、engagement DESC 順、untilID cursor、channel 投稿除外を実 SQL に対して検証。
  - 新規 `TestNoteRepository_ListFeaturedByUser_Error` — エラー経路。

## テスト

- \`go build ./...\` ✅
- \`make fmt && make lint\` ✅
- \`go test ./internal/api/users/... ./internal/api/notes/... ./internal/testutil/...\` ✅
- \`go test ./internal/repository/...\` はローカル DB 未起動のため未実行 — CI で `TestNoteRepository_ListFeaturedByUser*` を実 PostgreSQL に対して検証する想定。

## upstream 互換性

- API response shape は upstream と一致 (note 配列、engagement 順序、視認可能 visibility のみ)。
- 実装上は Redis sorted set ではなく SQL ranking だが、mk-go では ListFeatured / channels timeline 等も同方針で揃えているので drop-in 互換は維持される。

## Closes

Closes #1487

## 関連

- #1418 (users/notes の visibility push-down)
- #1440 (channels/timeline の SQL push-down)
- #1441 (notes/mentions push-down)
- #1486 (users/get-frequently-replied-users の同 doctrine 適用 — 同 PR シリーズ)

🤖 Generated with [Claude Code](https://claude.com/claude-code)