### PR TITLE
docs(i): i/favorites のスタレ visibility 設計判断を upstream-aligned (現状維持) として明文化 (#1488)

### DIFF
--- a/internal/api/i/handler_extra.go
+++ b/internal/api/i/handler_extra.go
@@ -127,6 +127,23 @@ func (h *Handler) DeleteAccount(c echo.Context) error {
 // CherryPick / Misskey 本家互換で sinceId / untilId による keyset pagination
 // を受け付ける (#424)。フロントの無限スクロールは untilId を毎ページ送って
 // くるので、cursor 無視だと同一ページが永久ループする。
+//
+// 設計メモ — visibility re-check しない理由 (#1488):
+//
+//   - favorite は viewer の意図的なローカル「ブックマーク」相当の保存行為。
+//     viewer は favorite 作成時点で当該 note に対して RequireVisible を通過済み
+//     (= note ID と本文を既に知っている状態。#1443)。
+//   - ID-known doctrine: viewer の persisted bookmark 行を later に author が
+//     visibility 縮小したからといって viewer のローカル UX を破壊するのは違和感
+//     がある (upstream Misskey TS も同じ shape で content を返す)。
+//   - スタレ favorite の content は viewer 自身しか取得できないため mass leak で
+//     はなく、ID-known な notes/show ShowForAPI doctrine と同じ境界線。
+//   - drop-in 互換 (CLAUDE.md Section 6) を維持するために upstream と shape を
+//     揃える。doctrine 側に倒す案 (Option B) は #1488 で議論されたが
+//     Option A (現状維持 = upstream-aligned) を採用 (wontfix)。
+//
+// 関連: #1443 (notes/favorites/create で create 段の visibility gate)、
+// memory: project_visibility_idor_sweep の「ShowForAPI doctrine 例外」リスト。
 func (h *Handler) Favorites(c echo.Context) error {
 	u := middleware.GetUser(c)
 	var req struct {


### PR DESCRIPTION
## Summary

#1488 で議論された「viewer が favorite した時点では visible だった note を、author が後から visibility 縮小した場合に i/favorites の list 段で content が漏れ続ける」挙動について、**Option A (現状維持 = upstream-aligned)** を採用する設計判断を `i/favorites` handler 本体に明記する。

### 判断の理由

- favorite は viewer 自身のローカル「ブックマーク」相当の意図的な保存行為。`notes/favorites/create` (#1443) の create 段で `RequireVisible` を通過済みなので、viewer は ID と本文を必ず一度は知った状態の note を保存している。
- ID-known doctrine (`notes/show` ShowForAPI 経路) と同じ境界線。スタレ content は viewer 自身しか取得できないため mass leak ではない。
- upstream Misskey TS も同 shape。drop-in 互換 (CLAUDE.md Section 6) を維持。

### Option B (= list 段で `FilterVisible` 適用) を採らない理由

- favorite UX (= ローカルブックマーク) を viewer 視点で破壊する。
- upstream 非互換になり、frontend infinite scroll 表示が壊れる可能性。
- スタレ favorite は viewer 自身しか観測できない非対称 leak ではないので、doctrine 違反のコスト < UX/互換コスト。

## 主な変更点

- `internal/api/i/handler_extra.go`
  - `Favorites` handler の GoDoc に「visibility re-check しない理由」設計メモを追加。`notes/favorites/create` (#1443) 側の create-time gate との対称性 / ID-known doctrine 境界線 / upstream drop-in 互換を残す方針を明文化。

(memory `project_visibility_idor_sweep` の例外リストにも同方針を追記している — リポジトリ外ファイルなので PR には含まれない。)

## テスト

- 動作変更なし (コメント追加のみ)
- \`go build ./...\` ✅
- \`make fmt && make lint\` ✅

## Closes

Closes #1488 (wontfix)

## 関連

- #1443 (notes/favorites/create の visibility gate — create 段で固める方針の確立)
- #1444 (notifications で note embed を nil 化 — Option B 側の参考実装)
- #1456 (clips/add-note — clip は list 段でも push-down 適用、favorite との非対称性)

🤖 Generated with [Claude Code](https://claude.com/claude-code)