### PR TITLE
fix(notes): user-list-timeline で user_list_membership.withReplies を尊重した返信フィルタを実装 (#1496)

### DIFF
--- a/internal/repository/note.go
+++ b/internal/repository/note.go
@@ -1051,6 +1051,9 @@ func (r *noteRepository) ListByUserList(listID, viewerID string, limit int, sinc
 	// 返信 / viewer 宛ての返信 / メンバーが withReplies=ON のときだけ返信を含め、
 	// それ以外 (第三者宛ての返信) は既定で除外する。withReplies 列は JOIN した
 	// membership 由来なので m. で参照する。
+	// upstream は各 OR 分岐に `replyId IS NOT NULL AND` ガードを付けるが、非返信は
+	// 先頭の `replyId IS NULL` 分岐が必ず拾うため、後続分岐のガードは冗長で省ける
+	// (replyId NOT NULL の reply にのみ replyUserId / withReplies 条件が効く)。
 	q = q.Where(
 		`("note"."replyId" IS NULL `+
 			`OR "note"."replyUserId" = "note"."userId" `+

--- a/internal/repository/note.go
+++ b/internal/repository/note.go
@@ -156,6 +156,10 @@ type NoteRepository interface {
 	// (DM 非表示 / upstream 準拠)。空文字は匿名 (public/home のみ)。これを LIMIT
 	// 前に SQL で絞ることで、handler post-fetch FilterVisible のページ過少充填と
 	// followers 判定 N+1 を解消する (#1452, #1418 / #1486 と同 doctrine)。
+	//
+	// 返信は user_list_membership.withReplies を尊重して出し分ける (#1496, upstream
+	// と一致): 返信でない / 自己への返信 / viewer 宛ての返信 / メンバーが
+	// withReplies=ON のときだけ含め、第三者宛ての返信は既定で除外する。
 	ListByUserList(listID, viewerID string, limit int, sinceID, untilID string) ([]*model.Note, error)
 	// CountReplyTargets returns the users that userID most frequently replies
 	// to, ordered by reply count descending. Used by
@@ -1042,6 +1046,17 @@ func (r *noteRepository) ListByUserList(listID, viewerID string, limit int, sinc
 				`OR "note"."userId" IN (SELECT f."followeeId" FROM "following" f WHERE f."followerId" = ?))))`,
 			viewerID, viewerID)
 	}
+	// reply 内包: user_list_membership.withReplies を尊重して返信を出し分ける
+	// (#1496, upstream user-list-timeline getFromDb と一致)。返信でない / 自己への
+	// 返信 / viewer 宛ての返信 / メンバーが withReplies=ON のときだけ返信を含め、
+	// それ以外 (第三者宛ての返信) は既定で除外する。withReplies 列は JOIN した
+	// membership 由来なので m. で参照する。
+	q = q.Where(
+		`("note"."replyId" IS NULL `+
+			`OR "note"."replyUserId" = "note"."userId" `+
+			`OR "note"."replyUserId" = ? `+
+			`OR m."withReplies" = true)`,
+		viewerID)
 	if sinceID != "" {
 		q = q.Where(`"note"."id" > ?`, sinceID)
 	}

--- a/internal/repository/note_test.go
+++ b/internal/repository/note_test.go
@@ -1385,6 +1385,63 @@ func TestNoteRepository_ListByUserList_Error(t *testing.T) {
 	assert.Error(t, err)
 }
 
+// #1496: user_list_membership.withReplies を尊重した返信フィルタを実 SQL で覆う。
+// 返信でない / 自己への返信 / viewer 宛ての返信は常に出る。第三者宛ての返信は
+// メンバーが withReplies=ON のときだけ出る (upstream user-list-timeline getFromDb
+// と一致)。可視性条件と切り分けるため全 note を public にしている。
+func TestNoteRepository_ListByUserList_WithReplies(t *testing.T) {
+	repo := NewNoteRepository(testDB)
+	viewer := insertTestUser(t, "ulw_v", "ulwV")
+	defer cleanupUser(t, viewer.ID)
+	m := insertTestUser(t, "ulw_m", "ulwM") // withReplies=false
+	defer cleanupUser(t, m.ID)
+	m2 := insertTestUser(t, "ulw_m2", "ulwM2") // withReplies=true
+	defer cleanupUser(t, m2.ID)
+	third := insertTestUser(t, "ulw_x", "ulwX") // 第三者 (reply 先、list 非メンバー)
+	defer cleanupUser(t, third.ID)
+
+	listID := "ulw_list"
+	require.NoError(t, testDB.Create(&model.UserList{ID: listID, UserID: viewer.ID, Name: "l"}).Error)
+	defer testDB.Exec(`DELETE FROM "user_list" WHERE id = ?`, listID)
+	require.NoError(t, testDB.Create(&model.UserListMembership{ID: "ulw_mem_m", UserListID: listID, UserID: m.ID, WithReplies: false}).Error)
+	defer testDB.Exec(`DELETE FROM "user_list_membership" WHERE id = ?`, "ulw_mem_m")
+	require.NoError(t, testDB.Create(&model.UserListMembership{ID: "ulw_mem_m2", UserListID: listID, UserID: m2.ID, WithReplies: true}).Error)
+	defer testDB.Exec(`DELETE FROM "user_list_membership" WHERE id = ?`, "ulw_mem_m2")
+
+	// reply 先の source note (FK 充足用、list 非メンバー third 投稿なので結果には出ない)。
+	srcID := "ulw_src"
+	require.NoError(t, testDB.Create(&model.Note{ID: srcID, UserID: third.ID, Visibility: "public"}).Error)
+	defer testDB.Exec(`DELETE FROM "note" WHERE id = ?`, srcID)
+
+	mkReply := func(id, author, replyUser string) *model.Note {
+		ruid := replyUser
+		return &model.Note{ID: id, UserID: author, Visibility: "public", ReplyID: &srcID, ReplyUserID: &ruid}
+	}
+	notes := []*model.Note{
+		{ID: "ulw_n_plain", UserID: m.ID, Visibility: "public"}, // 返信でない
+		mkReply("ulw_n_self", m.ID, m.ID),                       // 自己への返信
+		mkReply("ulw_n_toviewer", m.ID, viewer.ID),              // viewer 宛て返信
+		mkReply("ulw_n_tothird", m.ID, third.ID),                // 第三者宛て (withReplies=false)
+		mkReply("ulw_n2_tothird", m2.ID, third.ID),              // 第三者宛て (withReplies=true)
+	}
+	for _, n := range notes {
+		require.NoError(t, testDB.Create(n).Error)
+		defer testDB.Exec(`DELETE FROM "note" WHERE id = ?`, n.ID)
+	}
+
+	got, err := repo.ListByUserList(listID, viewer.ID, 50, "", "")
+	require.NoError(t, err)
+	ids := map[string]bool{}
+	for _, n := range got {
+		ids[n.ID] = true
+	}
+	assert.True(t, ids["ulw_n_plain"], "返信でない note は出る")
+	assert.True(t, ids["ulw_n_self"], "自己への返信は出る")
+	assert.True(t, ids["ulw_n_toviewer"], "viewer 宛ての返信は出る")
+	assert.False(t, ids["ulw_n_tothird"], "withReplies=false メンバーの第三者宛て返信は出ない")
+	assert.True(t, ids["ulw_n2_tothird"], "withReplies=true メンバーの第三者宛て返信は出る")
+}
+
 func TestNoteRepository_FindRenoteByUser(t *testing.T) {
 	repo := NewNoteRepository(testDB)
 	user := insertTestUser(t, "unrn_u", "unrnuser")


### PR DESCRIPTION
## Summary

`notes/user-list-timeline` の `ListByUserList` が **返信を一切フィルタせず**、リストメンバーの第三者宛て返信まで無条件に TL へ出していた upstream 乖離を是正する。`user_list_membership.withReplies` は永続化・更新可能 (`UpdateMembership`) なのに timeline クエリで参照されていなかった。

#1452 (visibility push-down) の follow-up。viewerID は #1452 で配線済みのものをそのまま使う。

## 主な変更点

- `internal/repository/note.go`
  - `ListByUserList` に upstream `user-list-timeline` の `getFromDb` と同じ返信内包条件を追加:

    ```sql
    ("note"."replyId" IS NULL                  -- 返信でない
     OR "note"."replyUserId" = "note"."userId" -- 自己への返信
     OR "note"."replyUserId" = ?               -- viewer 宛ての返信
     OR m."withReplies" = true)                -- メンバーが withReplies=ON
    ```

    第三者宛ての返信はメンバーが `withReplies=true` を選んだ場合のみ表示し、既定 (`false`) では除外する。`m."withReplies"` は JOIN 済み membership 由来。列は #1452 同様 `"note".` で修飾。
  - interface GoDoc に返信出し分けの仕様を追記。
- handler / mock / signature は**無変更**(#1452 で viewerID 配線済みのため repo 層の WHERE 追加のみで完結)。

## テスト

- `make fmt && make lint && go build ./...`
- `go test ./internal/repository/...` — testcontainers の実 PostgreSQL に対して green。
  - 新規 `TestNoteRepository_ListByUserList_WithReplies`: 返信でない / 自己への返信 / viewer 宛ての返信は表示、第三者宛て返信は `withReplies=false` メンバーで非表示・`withReplies=true` メンバーで表示、を実 SQL で固定。
  - 既存 `_VisibilityPushdown` / `_NoUnderfill`(返信なし note)は回帰なし。
- `go test ./internal/api/notes/...`(handler 無変更、coverage 92.6%)。

## 互換性

upstream `getFromDb` と返信内包の意味論が一致。可視性 push-down (#1452) と直交する変更で、API response shape は不変。

## スコープ外 (別途)

upstream `getFromDb` の `withRenotes` / `includeMyRenotes` / `withFiles` / muted channel renote 除外等は `UserListTimeline` handler が param 自体を受けておらず、本 PR は **withReplies (返信フィルタ) に限定**(issue #1496 のスコープどおり)。

## Closes

Closes #1496

## 関連

- #1452 (visibility push-down — viewerID 配線元)
- #1448 (user-list-timeline の visibility filter 追加)
- `ListByUserIDFiltered` (users/notes の withReplies 出し分け参考実装)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
