### PR TITLE
feat(notes): user-list-timeline に renote/withFiles クエリパラメータを実装 (#1498)

### DIFF
--- a/internal/api/notes/handler_extra.go
+++ b/internal/api/notes/handler_extra.go
@@ -161,12 +161,17 @@ func (h *Handler) Mentions(c echo.Context) error {
 func (h *Handler) UserListTimeline(c echo.Context) error {
 	me := middleware.GetUser(c)
 	var req struct {
-		ListID    string `json:"listId"`
-		Limit     int    `json:"limit"`
-		SinceID   string `json:"sinceId"`
-		UntilID   string `json:"untilId"`
-		SinceDate *int64 `json:"sinceDate"`
-		UntilDate *int64 `json:"untilDate"`
+		ListID                string `json:"listId"`
+		Limit                 int    `json:"limit"`
+		SinceID               string `json:"sinceId"`
+		UntilID               string `json:"untilId"`
+		SinceDate             *int64 `json:"sinceDate"`
+		UntilDate             *int64 `json:"untilDate"`
+		WithFiles             bool   `json:"withFiles"`
+		WithRenotes           *bool  `json:"withRenotes"`
+		IncludeMyRenotes      *bool  `json:"includeMyRenotes"`
+		IncludeRenotedMyNotes *bool  `json:"includeRenotedMyNotes"`
+		IncludeLocalRenotes   *bool  `json:"includeLocalRenotes"`
 	}
 	if err := c.Bind(&req); err != nil || req.ListID == "" {
 		return c.JSON(http.StatusBadRequest, apierr.Error("INVALID_PARAM", "listId is required.", "3d81ceae-475f-4600-b2a8-2bc116157532"))
@@ -191,7 +196,19 @@ func (h *Handler) UserListTimeline(c echo.Context) error {
 	// followers 判定 N+1 を解消した。viewer の見える note だけが返るため handler
 	// 側の post-fetch FilterVisible / fail-closed ガードは不要。
 	// RequireAuth() 配下なので me は非nil (所有権チェックでも me.ID を直接参照)。
-	notes, err := h.noteRepo.ListByUserList(req.ListID, me.ID, req.Limit, sinceID, untilID)
+	//
+	// renote/file 系 param は他 timeline と同じ filter で SQL push-down する
+	// (#1498)。WithReplies は per-member (membership.withReplies, #1496) で別途
+	// 処理されるため filter には積まない。
+	filter := model.TimelineDBFilter{
+		ViewerID:              me.ID,
+		WithFiles:             req.WithFiles,
+		WithRenotes:           req.WithRenotes,
+		IncludeMyRenotes:      req.IncludeMyRenotes,
+		IncludeRenotedMyNotes: req.IncludeRenotedMyNotes,
+		IncludeLocalRenotes:   req.IncludeLocalRenotes,
+	}
+	notes, err := h.noteRepo.ListByUserList(req.ListID, req.Limit, sinceID, untilID, filter)
 	if err != nil {
 		return c.JSON(http.StatusInternalServerError, apierr.Error("INTERNAL_ERROR", "Internal error.", "5d37dbcb-891e-41ca-a3d6-e690c97775ac"))
 	}

--- a/internal/api/notes/handler_extra_test.go
+++ b/internal/api/notes/handler_extra_test.go
@@ -386,27 +386,28 @@ func TestUserListTimeline_InvalidParam(t *testing.T) {
 }
 
 // userListNotesRepo は ListByUserList で固定の note を返しつつ、handler から
-// 渡された listID / viewerID を記録する fake。#1452 で可視性が repo の SQL
+// 渡された listID / filter を記録する fake。#1452 で可視性が repo の SQL
 // push-down に移ったため、handler は repo の返り値をそのまま返す。可視性絞り
 // 込み自体の検証は repository.TestNoteRepository_ListByUserList_VisibilityPushdown
 // で実 SQL に対して行う。
 type userListNotesRepo struct {
 	*testutil.MockNoteRepository
-	rows        []*model.Note
-	gotListID   string
-	gotViewerID string
+	rows      []*model.Note
+	gotListID string
+	gotFilter model.TimelineDBFilter
 }
 
-func (r *userListNotesRepo) ListByUserList(listID, viewerID string, _ int, _, _ string) ([]*model.Note, error) {
+func (r *userListNotesRepo) ListByUserList(listID string, _ int, _, _ string, filter model.TimelineDBFilter) ([]*model.Note, error) {
 	r.gotListID = listID
-	r.gotViewerID = viewerID
+	r.gotFilter = filter
 	return r.rows, nil
 }
 
-// #1452: handler は viewer (= me.ID) を viewerID として repo に渡し、可視性絞り
-// 込みは ListByUserList の SQL push-down に委ねる。post-fetch FilterVisible は
-// 撤去済みなので、handler は repo の返り値をそのまま pack する。
-func TestUserListTimeline_PassesViewerIDToRepo(t *testing.T) {
+// #1452 / #1498: handler は viewer (= me.ID) と renote/file 系 param を
+// TimelineDBFilter に詰めて repo に渡し、可視性 / renote 絞り込みは repo の SQL
+// push-down に委ねる。post-fetch FilterVisible は撤去済みなので handler は repo の
+// 返り値をそのまま pack する。
+func TestUserListTimeline_PassesFilterToRepo(t *testing.T) {
 	pub := &model.Note{ID: "ul_pub", UserID: "B", Visibility: "public", User: &model.User{ID: "B"}}
 	noteRepo := &userListNotesRepo{MockNoteRepository: testutil.NewMockNoteRepository(), rows: []*model.Note{pub}}
 	fRepo := testutil.NewMockFollowingRepository()
@@ -418,13 +419,16 @@ func TestUserListTimeline_PassesViewerIDToRepo(t *testing.T) {
 	h := NewHandler(noteRepo, corenote.NewCreateService(noteRepo, pollRepo, idGen, nil), corenote.NewDeleteService(noteRepo), querySvc, nil, nil, nil, nil, idGen)
 	h.SetUserListRepo(listRepo)
 
-	rec := postExtra(h.UserListTimeline, `{"listId":"l1"}`, &model.User{ID: "A"})
+	rec := postExtra(h.UserListTimeline, `{"listId":"l1","withRenotes":false,"withFiles":true}`, &model.User{ID: "A"})
 	require.Equal(t, http.StatusOK, rec.Code)
 	var out []map[string]any
 	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &out))
-	// viewer (me.ID) と listId が repo に渡ることを確認 (可視性 push-down の入力)。
+	// viewer (me.ID) / listId / renote・file 系 param が filter 経由で repo に渡る。
 	assert.Equal(t, "l1", noteRepo.gotListID, "listId が repo に渡る")
-	assert.Equal(t, "A", noteRepo.gotViewerID, "viewer (me.ID) が viewerID として repo に渡る")
+	assert.Equal(t, "A", noteRepo.gotFilter.ViewerID, "viewer (me.ID) が filter.ViewerID として渡る")
+	require.NotNil(t, noteRepo.gotFilter.WithRenotes)
+	assert.False(t, *noteRepo.gotFilter.WithRenotes, "withRenotes=false が filter に渡る")
+	assert.True(t, noteRepo.gotFilter.WithFiles, "withFiles=true が filter に渡る")
 	// post-fetch filter は無いので repo の返り値がそのまま返る。
 	require.Len(t, out, 1)
 	assert.Equal(t, "ul_pub", out[0]["id"])
@@ -439,7 +443,7 @@ func TestUserListTimeline_WithoutUserListRepo(t *testing.T) {
 
 type failingListByUserListRepo struct{ *testutil.MockNoteRepository }
 
-func (f *failingListByUserListRepo) ListByUserList(_, _ string, _ int, _, _ string) ([]*model.Note, error) {
+func (f *failingListByUserListRepo) ListByUserList(_ string, _ int, _, _ string, _ model.TimelineDBFilter) ([]*model.Note, error) {
 	return nil, testutil.ErrNotFound
 }
 

--- a/internal/api/notes/handler_test.go
+++ b/internal/api/notes/handler_test.go
@@ -890,7 +890,7 @@ func (f *failingNoteRepo) DeleteByUserBatch(_ string, _ int) (int64, error) { re
 func (f *failingNoteRepo) CountReplyTargets(_, _ string, _ int) ([]model.ReplyTargetCount, error) {
 	return nil, nil
 }
-func (f *failingNoteRepo) ListByUserList(_, _ string, _ int, _, _ string) ([]*model.Note, error) {
+func (f *failingNoteRepo) ListByUserList(_ string, _ int, _, _ string, _ model.TimelineDBFilter) ([]*model.Note, error) {
 	return nil, nil
 }
 func (f *failingNoteRepo) CountLocalNotes() (int64, error)    { return 0, nil }

--- a/internal/repository/note.go
+++ b/internal/repository/note.go
@@ -151,8 +151,8 @@ type NoteRepository interface {
 	// with keyset pagination via paginationOrder (DESC by default; ASC when
 	// only sinceID is supplied). Channel notes are excluded.
 	//
-	// viewerID は viewer 視点の visibility push-down 用。followers は viewer が
-	// author 本人か follow 済みのときだけ、specified は list timeline では除外
+	// filter.ViewerID は viewer 視点の visibility push-down 用。followers は viewer
+	// が author 本人か follow 済みのときだけ、specified は list timeline では除外
 	// (DM 非表示 / upstream 準拠)。空文字は匿名 (public/home のみ)。これを LIMIT
 	// 前に SQL で絞ることで、handler post-fetch FilterVisible のページ過少充填と
 	// followers 判定 N+1 を解消する (#1452, #1418 / #1486 と同 doctrine)。
@@ -160,7 +160,12 @@ type NoteRepository interface {
 	// 返信は user_list_membership.withReplies を尊重して出し分ける (#1496, upstream
 	// と一致): 返信でない / 自己への返信 / viewer 宛ての返信 / メンバーが
 	// withReplies=ON のときだけ含め、第三者宛ての返信は既定で除外する。
-	ListByUserList(listID, viewerID string, limit int, sinceID, untilID string) ([]*model.Note, error)
+	//
+	// filter の withRenotes / includeMyRenotes / includeRenotedMyNotes /
+	// includeLocalRenotes / withFiles は applyTimelineFilter で他 timeline と同じ
+	// SQL を適用する (#1498, upstream getFromDb と一致)。muting / WithReplies は
+	// user-list-timeline では使わない (返信は上記 per-member 経路、muting は対象外)。
+	ListByUserList(listID string, limit int, sinceID, untilID string, filter model.TimelineDBFilter) ([]*model.Note, error)
 	// CountReplyTargets returns the users that userID most frequently replies
 	// to, ordered by reply count descending. Used by
 	// users/get-frequently-replied-users.
@@ -849,7 +854,9 @@ func applyTimelineFilter(q *gorm.DB, f model.TimelineDBFilter) *gorm.DB {
 		q = q.Where(`("replyId" IS NULL OR "replyUserId" = "note"."userId")`)
 	}
 	if f.IncludeMyRenotes != nil && !*f.IncludeMyRenotes && f.ViewerID != "" {
-		q = q.Where(`NOT ("renoteId" IS NOT NULL AND text IS NULL AND "fileIds" = '{}' AND "userId" = ?)`, f.ViewerID)
+		// "userId" は JOIN を持つ呼び出し元 (ListByUserList の user_list_membership)
+		// で membership.userId と衝突するため "note". で修飾する (#1498)。
+		q = q.Where(`NOT ("renoteId" IS NOT NULL AND text IS NULL AND "fileIds" = '{}' AND "note"."userId" = ?)`, f.ViewerID)
 	}
 	if f.IncludeRenotedMyNotes != nil && !*f.IncludeRenotedMyNotes && f.ViewerID != "" {
 		q = q.Where(`NOT ("renoteId" IS NOT NULL AND text IS NULL AND "fileIds" = '{}' AND "renoteUserId" = ?)`, f.ViewerID)
@@ -894,7 +901,8 @@ func applyTimelineFilter(q *gorm.DB, f model.TimelineDBFilter) *gorm.DB {
 			f.ViewerID, f.ViewerID,
 		)
 	} else if len(f.MutedUserIDs) > 0 {
-		q = q.Where(`"userId" NOT IN ? AND ("renoteUserId" IS NULL OR "renoteUserId" NOT IN ?)`, f.MutedUserIDs, f.MutedUserIDs)
+		// "userId" は JOIN 併用時の曖昧性回避のため "note". で修飾 (#1498)。
+		q = q.Where(`"note"."userId" NOT IN ? AND ("renoteUserId" IS NULL OR "renoteUserId" NOT IN ?)`, f.MutedUserIDs, f.MutedUserIDs)
 	}
 	// renote-mute filter (#903): 投稿者が renote-muted で **かつ** pure
 	// renote の note のみ除外する。投稿者の plain note / quote renote は
@@ -1023,10 +1031,13 @@ func (r *noteRepository) DeleteByUserBatch(userID string, batchSize int) (int64,
 // ListByUserList returns notes authored by members of the given user list
 // with keyset pagination via paginationOrder. user_list_membership テーブルと
 // INNER JOIN してメンバーのノートだけを返す。channel ノートは除外する (TS互換)。
-func (r *noteRepository) ListByUserList(listID, viewerID string, limit int, sinceID, untilID string) ([]*model.Note, error) {
+func (r *noteRepository) ListByUserList(listID string, limit int, sinceID, untilID string, filter model.TimelineDBFilter) ([]*model.Note, error) {
 	if limit <= 0 {
 		limit = 10
 	}
+	// #1452 (visibility) / #1496 (reply) push-down は viewer ID を使う。旧 viewerID
+	// 引数を filter.ViewerID に畳み込んだ (#1498)。
+	viewerID := filter.ViewerID
 	q := preloadNoteRelations(r.db).
 		Joins(`INNER JOIN "user_list_membership" m ON m."userId" = "note"."userId" AND m."userListId" = ?`, listID).
 		Where(`"note"."channelId" IS NULL`)
@@ -1066,6 +1077,12 @@ func (r *noteRepository) ListByUserList(listID, viewerID string, limit int, sinc
 	if untilID != "" {
 		q = q.Where(`"note"."id" < ?`, untilID)
 	}
+	// withRenotes / includeMyRenotes / includeRenotedMyNotes / includeLocalRenotes
+	// / withFiles を他 timeline と同じ SQL で適用する (#1498, upstream getFromDb と
+	// 一致)。WithReplies は上の per-member 経路 (#1496) で処理済みなので filter には
+	// 積まない (nil = applyTimelineFilter は skip)。muting は user-list-timeline では
+	// 対象外なので filter に積まない。
+	q = applyTimelineFilter(q, filter)
 	var notes []*model.Note
 	if err := q.Order(paginationOrder(sinceID, untilID, `"note"."id"`)).Limit(limit).Find(&notes).Error; err != nil {
 		return nil, err

--- a/internal/repository/note_test.go
+++ b/internal/repository/note_test.go
@@ -1468,15 +1468,18 @@ func TestNoteRepository_ListByUserList_RenoteFilters(t *testing.T) {
 	defer testDB.Exec(`DELETE FROM "note" WHERE id = ?`, target)
 
 	emptyFiles := pq.StringArray{}
-	// plain (通常投稿), pure renote (member), quote renote (member, text あり),
-	// file 付き plain, viewer の pure renote。
+	remoteHost := "remote.example"
+	// plain (通常投稿), pure renote (member, ローカル), quote renote (member, text
+	// あり), file 付き plain, viewer の pure renote, remote pure renote
+	// (renoteUserHost あり)。ulr_pure は renoteUserHost NULL = ローカル renote。
 	plain := &model.Note{ID: "ulr_plain", UserID: member.ID, Visibility: "public", FileIDs: emptyFiles}
 	pureRenote := &model.Note{ID: "ulr_pure", UserID: member.ID, Visibility: "public", RenoteID: &target, RenoteUserID: &member.ID, FileIDs: emptyFiles}
 	quoteText := "quote"
 	quoteRenote := &model.Note{ID: "ulr_quote", UserID: member.ID, Visibility: "public", RenoteID: &target, RenoteUserID: &member.ID, Text: &quoteText, FileIDs: emptyFiles}
 	withFile := &model.Note{ID: "ulr_file", UserID: member.ID, Visibility: "public", FileIDs: pq.StringArray{"f1"}}
 	myPureRenote := &model.Note{ID: "ulr_my_pure", UserID: viewer.ID, Visibility: "public", RenoteID: &target, RenoteUserID: &member.ID, FileIDs: emptyFiles}
-	for _, n := range []*model.Note{plain, pureRenote, quoteRenote, withFile, myPureRenote} {
+	remotePureRenote := &model.Note{ID: "ulr_remote", UserID: member.ID, Visibility: "public", RenoteID: &target, RenoteUserID: &member.ID, RenoteUserHost: &remoteHost, FileIDs: emptyFiles}
+	for _, n := range []*model.Note{plain, pureRenote, quoteRenote, withFile, myPureRenote, remotePureRenote} {
 		require.NoError(t, testDB.Create(n).Error)
 		defer testDB.Exec(`DELETE FROM "note" WHERE id = ?`, n.ID)
 	}
@@ -1524,6 +1527,13 @@ func TestNoteRepository_ListByUserList_RenoteFilters(t *testing.T) {
 	ids = collect(model.TimelineDBFilter{IncludeRenotedMyNotes: no()})
 	assert.False(t, ids["ulr_renote_mine"], "自分の note の pure renote は除外")
 	assert.True(t, ids["ulr_pure"], "他人の note の pure renote は残る")
+
+	// includeLocalRenotes=false: renoteUserHost NULL (ローカル) の pure renote を
+	// 除外し、remote (renoteUserHost あり) の pure renote は残す。
+	ids = collect(model.TimelineDBFilter{IncludeLocalRenotes: no()})
+	assert.False(t, ids["ulr_pure"], "ローカル投稿の pure renote は除外")
+	assert.True(t, ids["ulr_remote"], "remote 投稿の pure renote は残る")
+	assert.True(t, ids["ulr_quote"], "quote renote は残る")
 
 	// withFiles=true: ファイル付き note のみ。
 	ids = collect(model.TimelineDBFilter{WithFiles: true})

--- a/internal/repository/note_test.go
+++ b/internal/repository/note_test.go
@@ -1294,7 +1294,7 @@ func TestNoteRepository_ListByUserList_VisibilityPushdown(t *testing.T) {
 	}
 
 	collect := func(viewerID string) map[string]bool {
-		got, err := repo.ListByUserList(listID, viewerID, 50, "", "")
+		got, err := repo.ListByUserList(listID, 50, "", "", model.TimelineDBFilter{ViewerID: viewerID})
 		require.NoError(t, err)
 		ids := map[string]bool{}
 		for _, n := range got {
@@ -1327,14 +1327,14 @@ func TestNoteRepository_ListByUserList_VisibilityPushdown(t *testing.T) {
 	assert.False(t, ids["ult_n_f_self_fol"], "匿名は誰の followers も不可")
 
 	// 並び順は id DESC (no cursor)。
-	got, err := repo.ListByUserList(listID, viewer.ID, 50, "", "")
+	got, err := repo.ListByUserList(listID, 50, "", "", model.TimelineDBFilter{ViewerID: viewer.ID})
 	require.NoError(t, err)
 	for i := 1; i < len(got); i++ {
 		assert.Greater(t, got[i-1].ID, got[i].ID, "id DESC order")
 	}
 
 	// untilID cursor: id < untilID のみ返る。
-	got, err = repo.ListByUserList(listID, viewer.ID, 50, "", "ult_n_c_fol")
+	got, err = repo.ListByUserList(listID, 50, "", "ult_n_c_fol", model.TimelineDBFilter{ViewerID: viewer.ID})
 	require.NoError(t, err)
 	for _, n := range got {
 		assert.Less(t, n.ID, "ult_n_c_fol", "untilID 未満のみ")
@@ -1369,7 +1369,7 @@ func TestNoteRepository_ListByUserList_NoUnderfill(t *testing.T) {
 
 	// limit=5: push-down で public のみが対象 → 5 件埋まる。followers が混ざって
 	// 後段 filter で削られ under-fill する旧挙動の回帰防止。
-	got, err := repo.ListByUserList(listID, viewer.ID, 5, "", "")
+	got, err := repo.ListByUserList(listID, 5, "", "", model.TimelineDBFilter{ViewerID: viewer.ID})
 	require.NoError(t, err)
 	require.Len(t, got, 5, "push-down で limit ぶん public で埋まる")
 	for _, n := range got {
@@ -1381,7 +1381,7 @@ func TestNoteRepository_ListByUserList_Error(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel()
 	repo := NewNoteRepository(testDB.WithContext(ctx))
-	_, err := repo.ListByUserList("l", "v", 10, "", "")
+	_, err := repo.ListByUserList("l", 10, "", "", model.TimelineDBFilter{ViewerID: "v"})
 	assert.Error(t, err)
 }
 
@@ -1429,7 +1429,7 @@ func TestNoteRepository_ListByUserList_WithReplies(t *testing.T) {
 		defer testDB.Exec(`DELETE FROM "note" WHERE id = ?`, n.ID)
 	}
 
-	got, err := repo.ListByUserList(listID, viewer.ID, 50, "", "")
+	got, err := repo.ListByUserList(listID, 50, "", "", model.TimelineDBFilter{ViewerID: viewer.ID})
 	require.NoError(t, err)
 	ids := map[string]bool{}
 	for _, n := range got {
@@ -1440,6 +1440,96 @@ func TestNoteRepository_ListByUserList_WithReplies(t *testing.T) {
 	assert.True(t, ids["ulw_n_toviewer"], "viewer 宛ての返信は出る")
 	assert.False(t, ids["ulw_n_tothird"], "withReplies=false メンバーの第三者宛て返信は出ない")
 	assert.True(t, ids["ulw_n2_tothird"], "withReplies=true メンバーの第三者宛て返信は出る")
+}
+
+// #1498: TimelineDBFilter 経由の renote/file 系 param (withRenotes /
+// includeMyRenotes / includeRenotedMyNotes / includeLocalRenotes / withFiles) が
+// applyTimelineFilter で適用されることを実 SQL で覆う。pure renote と quote renote
+// (text あり) を区別し、quote は常に残ることも確認する。
+func TestNoteRepository_ListByUserList_RenoteFilters(t *testing.T) {
+	repo := NewNoteRepository(testDB)
+	viewer := insertTestUser(t, "ulr_v", "ulrV") // list owner かつ member
+	defer cleanupUser(t, viewer.ID)
+	member := insertTestUser(t, "ulr_m", "ulrM")
+	defer cleanupUser(t, member.ID)
+
+	listID := "ulr_list"
+	require.NoError(t, testDB.Create(&model.UserList{ID: listID, UserID: viewer.ID, Name: "l"}).Error)
+	defer testDB.Exec(`DELETE FROM "user_list" WHERE id = ?`, listID)
+	for i, mem := range []string{viewer.ID, member.ID} {
+		mid := fmt.Sprintf("ulr_mem_%d", i)
+		require.NoError(t, testDB.Create(&model.UserListMembership{ID: mid, UserListID: listID, UserID: mem}).Error)
+		defer testDB.Exec(`DELETE FROM "user_list_membership" WHERE id = ?`, mid)
+	}
+
+	// renote 先 note (FK 充足用)。
+	target := "ulr_target"
+	require.NoError(t, testDB.Create(&model.Note{ID: target, UserID: member.ID, Visibility: "public"}).Error)
+	defer testDB.Exec(`DELETE FROM "note" WHERE id = ?`, target)
+
+	emptyFiles := pq.StringArray{}
+	// plain (通常投稿), pure renote (member), quote renote (member, text あり),
+	// file 付き plain, viewer の pure renote。
+	plain := &model.Note{ID: "ulr_plain", UserID: member.ID, Visibility: "public", FileIDs: emptyFiles}
+	pureRenote := &model.Note{ID: "ulr_pure", UserID: member.ID, Visibility: "public", RenoteID: &target, RenoteUserID: &member.ID, FileIDs: emptyFiles}
+	quoteText := "quote"
+	quoteRenote := &model.Note{ID: "ulr_quote", UserID: member.ID, Visibility: "public", RenoteID: &target, RenoteUserID: &member.ID, Text: &quoteText, FileIDs: emptyFiles}
+	withFile := &model.Note{ID: "ulr_file", UserID: member.ID, Visibility: "public", FileIDs: pq.StringArray{"f1"}}
+	myPureRenote := &model.Note{ID: "ulr_my_pure", UserID: viewer.ID, Visibility: "public", RenoteID: &target, RenoteUserID: &member.ID, FileIDs: emptyFiles}
+	for _, n := range []*model.Note{plain, pureRenote, quoteRenote, withFile, myPureRenote} {
+		require.NoError(t, testDB.Create(n).Error)
+		defer testDB.Exec(`DELETE FROM "note" WHERE id = ?`, n.ID)
+	}
+
+	collect := func(f model.TimelineDBFilter) map[string]bool {
+		f.ViewerID = viewer.ID
+		got, err := repo.ListByUserList(listID, 50, "", "", f)
+		require.NoError(t, err)
+		ids := map[string]bool{}
+		for _, n := range got {
+			ids[n.ID] = true
+		}
+		return ids
+	}
+
+	no := func() *bool { b := false; return &b }
+
+	// 既定 (filter 空, renote 系 nil = true) は全件 (target は member 投稿だが
+	// renote 先として list member なので出る点に注意 → target も含む)。
+	ids := collect(model.TimelineDBFilter{})
+	assert.True(t, ids["ulr_plain"] && ids["ulr_pure"] && ids["ulr_quote"] && ids["ulr_file"] && ids["ulr_my_pure"], "既定は renote も全部出る")
+
+	// withRenotes=false: pure renote を除外、quote renote は残す。
+	ids = collect(model.TimelineDBFilter{WithRenotes: no()})
+	assert.False(t, ids["ulr_pure"], "withRenotes=false で pure renote は除外")
+	assert.False(t, ids["ulr_my_pure"], "withRenotes=false で他の pure renote も除外")
+	assert.True(t, ids["ulr_quote"], "quote renote (text あり) は残る")
+	assert.True(t, ids["ulr_plain"], "通常投稿は残る")
+
+	// includeMyRenotes=false: viewer 自身の pure renote のみ除外。member の pure
+	// renote は残る。
+	ids = collect(model.TimelineDBFilter{IncludeMyRenotes: no()})
+	assert.False(t, ids["ulr_my_pure"], "自分の pure renote は除外")
+	assert.True(t, ids["ulr_pure"], "他人の pure renote は残る")
+
+	// includeRenotedMyNotes=false: 自分の note を renote した pure renote を除外。
+	// fixture では renote 先 target は member 投稿なので除外されない (= 全 renote
+	// 残る)。viewer 自身の note を renote した fixture を別途用意する。
+	myTarget := "ulr_mytarget"
+	require.NoError(t, testDB.Create(&model.Note{ID: myTarget, UserID: viewer.ID, Visibility: "public", FileIDs: emptyFiles}).Error)
+	defer testDB.Exec(`DELETE FROM "note" WHERE id = ?`, myTarget)
+	renoteOfMine := &model.Note{ID: "ulr_renote_mine", UserID: member.ID, Visibility: "public", RenoteID: &myTarget, RenoteUserID: &viewer.ID, FileIDs: emptyFiles}
+	require.NoError(t, testDB.Create(renoteOfMine).Error)
+	defer testDB.Exec(`DELETE FROM "note" WHERE id = ?`, renoteOfMine.ID)
+	ids = collect(model.TimelineDBFilter{IncludeRenotedMyNotes: no()})
+	assert.False(t, ids["ulr_renote_mine"], "自分の note の pure renote は除外")
+	assert.True(t, ids["ulr_pure"], "他人の note の pure renote は残る")
+
+	// withFiles=true: ファイル付き note のみ。
+	ids = collect(model.TimelineDBFilter{WithFiles: true})
+	assert.True(t, ids["ulr_file"], "ファイル付きは残る")
+	assert.False(t, ids["ulr_plain"], "ファイル無しは除外")
+	assert.False(t, ids["ulr_pure"], "ファイル無し renote も除外")
 }
 
 func TestNoteRepository_FindRenoteByUser(t *testing.T) {

--- a/internal/testutil/mock_repository.go
+++ b/internal/testutil/mock_repository.go
@@ -1250,7 +1250,7 @@ func (m *MockNoteRepository) DeleteByUserBatch(userID string, batchSize int) (in
 	return n, nil
 }
 
-func (m *MockNoteRepository) ListByUserList(_, _ string, _ int, _, _ string) ([]*model.Note, error) {
+func (m *MockNoteRepository) ListByUserList(_ string, _ int, _, _ string, _ model.TimelineDBFilter) ([]*model.Note, error) {
 	return nil, nil
 }
 


### PR DESCRIPTION
## Summary

`notes/user-list-timeline` に upstream `getFromDb` の renote/file 系クエリパラメータ (`withRenotes` / `includeMyRenotes` / `includeRenotedMyNotes` / `includeLocalRenotes` / `withFiles`) を実装する。これまで handler が param を受けず `ListByUserList` も renote/file 絞り込みを持たなかったため、クライアントがこれらのフラグを送っても**黙って無視**されていた (既定値では upstream 互換、明示フラグ時のみの乖離)。

#1496 (withReplies) のスコープ外として切り出した follow-up。

## 主な変更点

既存の `model.TimelineDBFilter` + `applyTimelineFilter` (home/hybrid/global TL で使用済み) を**再利用**する。新規 renote 判定ロジックは追加しない。

- `internal/repository/note.go`
  - `ListByUserList` の signature を `(listID, viewerID string, limit, sinceID, untilID)` → `(listID string, limit int, sinceID, untilID string, filter model.TimelineDBFilter)` に変更。旧 `viewerID` 引数を `filter.ViewerID` に畳み込み、#1452 visibility / #1496 reply push-down はそのまま `filter.ViewerID` を参照する。
  - LIMIT 前に `applyTimelineFilter(q, filter)` を適用。`WithReplies` は per-member (`membership.withReplies`, #1496) で処理済みなので filter に積まない。muting は user-list-timeline では対象外 (scope 外)。
  - `applyTimelineFilter` の `includeMyRenotes` / `MutedUserIDs` 分岐の無修飾 `"userId"` を `"note"."userId"` に修飾。JOIN を持つ `ListByUserList` で `user_list_membership.userId` と衝突するため (単一テーブルの既存呼び出しは意味不変)。
- `internal/api/notes/handler_extra.go`: req struct に 5 param を追加し `TimelineDBFilter` を構築して渡す。
- `internal/testutil/mock_repository.go` + fake 3 種: signature 追従。
- `internal/api/notes/handler_extra_test.go`: `TestUserListTimeline_PassesViewerIDToRepo` を `PassesFilterToRepo` に拡張 (viewerID + renote/file param が filter 経由で repo に渡ることを検証)。
- `internal/repository/note_test.go`: 統合テスト `TestNoteRepository_ListByUserList_RenoteFilters` 新設。既存 ListByUserList repo test 6 呼び出しを新 signature に更新。

## テスト

- `make fmt && make lint && go build ./...`
- `go test ./internal/repository/...` — testcontainers の実 PostgreSQL に対して green。
  - 新規 `TestNoteRepository_ListByUserList_RenoteFilters`: 既定全表示 / `withRenotes=false` (pure renote 除外・quote renote 残存) / `includeMyRenotes=false` / `includeRenotedMyNotes=false` / `withFiles=true` を実 SQL で検証。
  - 既存 `_VisibilityPushdown` / `_NoUnderfill` / `_WithReplies` / `_Error` は新 signature で回帰なし。
  - **shared `applyTimelineFilter` の他呼び出し元** (home/hybrid/global timeline test) も `"userId"` 修飾後に回帰なしを確認。
- `go test ./internal/api/notes/...` (coverage 92.6%) / `./internal/testutil/...`。

## 互換性 / スコープ

- upstream `getFromDb` の renote/file 意味論と一致 (pure renote = `renoteId` あり + text/files/poll なし、を出し分け。quote renote は常に残す)。API response shape 不変。
- `allowPartial` / fanout (Redis) timeline は別軸 (mk-go は DB 経路のみ)、muting は scope 外で本 PR では扱わない。

## Closes

Closes #1498

## 関連

- #1496 (withReplies — 本 PR の発生元)
- #1452 (visibility push-down — viewerID 配線元)
- home/hybrid/global timeline (`applyTimelineFilter` 共有元)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
