### PR TITLE
refactor(repository): 可視性 push-down WHERE 句を共通 helper に集約 (#1454)

### DIFF
--- a/internal/repository/clip_note.go
+++ b/internal/repository/clip_note.go
@@ -80,18 +80,8 @@ func (r *clipNoteRepository) listByClip(clipID, viewerID string, filterVisibilit
 	q := r.db.Where("\"clipId\" = ?", clipID)
 	if filterVisibility {
 		// clip_note は author 混在のため、note を相関 EXISTS で join して
-		// visibility を LIMIT 前に絞る。条件は core/note.CanSeeNote と一致。
-		if viewerID == "" {
-			q = q.Where(`EXISTS (SELECT 1 FROM "note" v WHERE v."id" = "clip_note"."noteId" AND v."visibility" IN ('public','home'))`)
-		} else {
-			q = q.Where(
-				`EXISTS (SELECT 1 FROM "note" v WHERE v."id" = "clip_note"."noteId" AND (`+
-					`v."visibility" IN ('public','home') `+
-					`OR v."userId" = ? `+
-					`OR (v."visibility" = 'followers' AND v."userId" IN (SELECT f."followeeId" FROM "following" f WHERE f."followerId" = ?)) `+
-					`OR (v."visibility" = 'specified' AND ? = ANY(v."visibleUserIds"))))`,
-				viewerID, viewerID, viewerID)
-		}
+		// visibility を LIMIT 前に絞る。条件は core/note.CanSeeNote と一致 (#1454)。
+		q = applyViewerVisibilityExists(q, `"clip_note"."noteId"`, viewerID)
 	}
 	if untilID != "" {
 		q = q.Where("id < ?", untilID)

--- a/internal/repository/note.go
+++ b/internal/repository/note.go
@@ -347,16 +347,7 @@ func (r *noteRepository) ListByUserIDFiltered(userID, viewerID, untilID, sinceID
 	// limit 未満になりページネーションが途切れる + followers 判定が note ごとの
 	// N+1 になるため、LIMIT 前に SQL で絞る。条件は core/note.CanSeeNote と
 	// 一致させる (note_reaction.ListByUserID と同じ可視性定義)。
-	if viewerID == "" {
-		q = q.Where(`"visibility" IN ('public','home')`)
-	} else {
-		q = q.Where(
-			`("visibility" IN ('public','home') `+
-				`OR "userId" = ? `+
-				`OR ("visibility" = 'followers' AND "userId" IN (SELECT f."followeeId" FROM "following" f WHERE f."followerId" = ?)) `+
-				`OR ("visibility" = 'specified' AND ? = ANY("visibleUserIds")))`,
-			viewerID, viewerID, viewerID)
-	}
+	q = applyViewerVisibility(q, viewerID)
 	if untilID != "" {
 		q = q.Where("id < ?", untilID)
 	}
@@ -396,16 +387,7 @@ func (r *noteRepository) ListByChannelID(channelID, viewerID, untilID, sinceID s
 	// core/note.CanSeeNote と同じ可視性条件を LIMIT 前に SQL で絞る。
 	// post-fetch filter だとページが過少充填されるのと followers 判定が
 	// note ごとの N+1 になるため LIMIT 前に push down する (#1440)。
-	if viewerID == "" {
-		q = q.Where(`"visibility" IN ('public','home')`)
-	} else {
-		q = q.Where(
-			`("visibility" IN ('public','home') `+
-				`OR "userId" = ? `+
-				`OR ("visibility" = 'followers' AND "userId" IN (SELECT f."followeeId" FROM "following" f WHERE f."followerId" = ?)) `+
-				`OR ("visibility" = 'specified' AND ? = ANY("visibleUserIds")))`,
-			viewerID, viewerID, viewerID)
-	}
+	q = applyViewerVisibility(q, viewerID)
 	if untilID != "" {
 		q = q.Where("id < ?", untilID)
 	}
@@ -686,16 +668,7 @@ func (r *noteRepository) ListFeaturedByUser(userID, viewerID, untilID string, li
 	q := preloadNoteRelations(r.db).
 		Where(`"userId" = ?`, userID).
 		Where(`"channelId" IS NULL`)
-	if viewerID == "" {
-		q = q.Where(`"visibility" IN ('public','home')`)
-	} else {
-		q = q.Where(
-			`("visibility" IN ('public','home') `+
-				`OR "userId" = ? `+
-				`OR ("visibility" = 'followers' AND "userId" IN (SELECT f."followeeId" FROM "following" f WHERE f."followerId" = ?)) `+
-				`OR ("visibility" = 'specified' AND ? = ANY("visibleUserIds")))`,
-			viewerID, viewerID, viewerID)
-	}
+	q = applyViewerVisibility(q, viewerID)
 	q = q.Order(`("renoteCount" + "repliesCount") DESC, id DESC`).Limit(featuredNotesPerUserPoolSize)
 	var pool []*model.Note
 	if err := q.Find(&pool).Error; err != nil {
@@ -743,12 +716,9 @@ func (r *noteRepository) ListMentions(userID, visibility string, limit int, sinc
 	// の visibleUserIds とは独立なので、これが無いと followers/specified note を
 	// mention されただけの非対象 viewer が本文と author を取得できてしまう (#1441)。
 	// viewer は notes/mentions の認証ユーザー = userID 固定。
-	q = q.Where(
-		`("visibility" IN ('public','home') `+
-			`OR "userId" = ? `+
-			`OR ("visibility" = 'followers' AND "userId" IN (SELECT f."followeeId" FROM "following" f WHERE f."followerId" = ?)) `+
-			`OR ("visibility" = 'specified' AND ? = ANY("visibleUserIds")))`,
-		userID, userID, userID)
+	// notes/mentions は RequireAuth 配下で userID 非空のため、helper の認証分岐
+	// (= 4 分岐 CanSeeNote) がそのまま適用される。
+	q = applyViewerVisibility(q, userID)
 	// visibility kind filter: upstream TS notes/mentions と同じく visibility 指定
 	// 時のみ note.visibility = <値> の exact-match で絞る (空は全種別)。これを
 	// LIMIT 前に SQL で行うことで、handler 側 post-fetch 振り分けで起きていた
@@ -779,16 +749,7 @@ func (r *noteRepository) SearchByTag(tag, viewerID string, limit int, sinceID, u
 		Where("tags @> ARRAY[?]::varchar[]", tag)
 	// visibility push-down: core/note.CanSeeNote と同じ条件を LIMIT 前に絞る。
 	// ListByUserIDFiltered / clip の ListByClipVisible と同じ可視性定義 (#1439)。
-	if viewerID == "" {
-		q = q.Where(`"visibility" IN ('public','home')`)
-	} else {
-		q = q.Where(
-			`("visibility" IN ('public','home') `+
-				`OR "userId" = ? `+
-				`OR ("visibility" = 'followers' AND "userId" IN (SELECT f."followeeId" FROM "following" f WHERE f."followerId" = ?)) `+
-				`OR ("visibility" = 'specified' AND ? = ANY("visibleUserIds")))`,
-			viewerID, viewerID, viewerID)
-	}
+	q = applyViewerVisibility(q, viewerID)
 	q = q.Order(paginationOrder(sinceID, untilID, "id")).Limit(limit)
 	if sinceID != "" {
 		q = q.Where("id > ?", sinceID)
@@ -1103,16 +1064,7 @@ func (r *noteRepository) CountReplyTargets(userID, viewerID string, limit int) (
 	// 見られるものだけを残す。これが無いと第三者 viewer が author の
 	// followers/specified reply の対人関係を集計値経由で観測できる (#1486)。
 	// 条件は ListByUserIDFiltered / ListMentions / SearchByTag と同一。
-	if viewerID == "" {
-		q = q.Where(`"visibility" IN ('public','home')`)
-	} else {
-		q = q.Where(
-			`("visibility" IN ('public','home') `+
-				`OR "userId" = ? `+
-				`OR ("visibility" = 'followers' AND "userId" IN (SELECT f."followeeId" FROM "following" f WHERE f."followerId" = ?)) `+
-				`OR ("visibility" = 'specified' AND ? = ANY("visibleUserIds")))`,
-			viewerID, viewerID, viewerID)
-	}
+	q = applyViewerVisibility(q, viewerID)
 	err := q.Group(`"replyUserId"`).
 		Order(`count DESC`).
 		Limit(limit).

--- a/internal/repository/note_reaction.go
+++ b/internal/repository/note_reaction.go
@@ -116,17 +116,8 @@ func (r *noteReactionRepository) ListByUserID(userID, viewerID, untilID, sinceID
 	// 絞る。条件は core/note.CanSeeNote と一致させる (= timeline の FilterVisible
 	// と同じ可視性定義。upstream の mentions / replyUserId は CanSeeNote 側に
 	// 無いので合わせて含めない)。
-	if viewerID == "" {
-		// 匿名は public / home のみ。
-		q = q.Where(`EXISTS (SELECT 1 FROM "note" v WHERE v."id" = "note_reaction"."noteId" AND v."visibility" IN ('public','home'))`)
-	} else {
-		q = q.Where(`EXISTS (SELECT 1 FROM "note" v WHERE v."id" = "note_reaction"."noteId" AND (`+
-			`v."visibility" IN ('public','home') `+
-			`OR v."userId" = ? `+
-			`OR (v."visibility" = 'followers' AND v."userId" IN (SELECT f."followeeId" FROM "following" f WHERE f."followerId" = ?)) `+
-			`OR (v."visibility" = 'specified' AND ? = ANY(v."visibleUserIds"))))`,
-			viewerID, viewerID, viewerID)
-	}
+	// 条件は core/note.CanSeeNote と一致 (#1454 で共通 helper に集約)。
+	q = applyViewerVisibilityExists(q, `"note_reaction"."noteId"`, viewerID)
 	if untilID != "" {
 		q = q.Where("id < ?", untilID)
 	}

--- a/internal/repository/visibility.go
+++ b/internal/repository/visibility.go
@@ -1,0 +1,48 @@
+package repository
+
+import "gorm.io/gorm"
+
+// applyViewerVisibility appends the core/note.CanSeeNote-equivalent visibility
+// predicate to a query over the note table (unqualified columns). Empty
+// viewerID means an anonymous viewer, which can only see public/home notes.
+//
+// visibility IDOR push-down (#1418 / #1439 / #1441 / #1486 / #1487 等) で各
+// repository メソッドにコピペされていた同一述語を 1 箇所に集約する (#1454)。
+// instance-block / muted-user 等の条件を将来足すときも、ここ 1 箇所を直せば
+// 全 push-down 経路に反映されるので drift (条件の食い違い) を防げる。
+//
+// 注意: list timeline 系 (ListByUserList) は DM 非表示のため specified を含めない
+// 別述語を使う。本 helper は specified を含む完全な CanSeeNote 版なので、そちらに
+// は使わない。
+func applyViewerVisibility(q *gorm.DB, viewerID string) *gorm.DB {
+	if viewerID == "" {
+		return q.Where(`"visibility" IN ('public','home')`)
+	}
+	return q.Where(
+		`("visibility" IN ('public','home') `+
+			`OR "userId" = ? `+
+			`OR ("visibility" = 'followers' AND "userId" IN (SELECT f."followeeId" FROM "following" f WHERE f."followerId" = ?)) `+
+			`OR ("visibility" = 'specified' AND ? = ANY("visibleUserIds")))`,
+		viewerID, viewerID, viewerID)
+}
+
+// applyViewerVisibilityExists is the correlated-EXISTS variant of
+// applyViewerVisibility for tables that list rows referencing notes of mixed
+// authors (clip_note / note_reaction). It filters by a CanSeeNote-equivalent
+// predicate against the note table aliased `v`, joined on noteIDColumn (e.g.
+// `"clip_note"."noteId"`). Empty viewerID = anonymous (public/home only).
+//
+// noteIDColumn は内部の固定識別子のみを渡すこと (呼び出し側のリテラル)。ユーザー
+// 入力を渡さない前提なので文字列連結は injection-safe。viewerID は bind param。
+func applyViewerVisibilityExists(q *gorm.DB, noteIDColumn, viewerID string) *gorm.DB {
+	if viewerID == "" {
+		return q.Where(`EXISTS (SELECT 1 FROM "note" v WHERE v."id" = ` + noteIDColumn + ` AND v."visibility" IN ('public','home'))`)
+	}
+	return q.Where(
+		`EXISTS (SELECT 1 FROM "note" v WHERE v."id" = `+noteIDColumn+` AND (`+
+			`v."visibility" IN ('public','home') `+
+			`OR v."userId" = ? `+
+			`OR (v."visibility" = 'followers' AND v."userId" IN (SELECT f."followeeId" FROM "following" f WHERE f."followerId" = ?)) `+
+			`OR (v."visibility" = 'specified' AND ? = ANY(v."visibleUserIds"))))`,
+		viewerID, viewerID, viewerID)
+}


### PR DESCRIPTION
## Summary

visibility IDOR push-down batch (#1418 / #1439 / #1440 / #1441 / #1486 / #1487) で各 repository メソッドにコピペされていた `core/note.CanSeeNote` 相当の WHERE 述語を共通 helper に集約する。今後 instance-block / muted-user 等の条件を足すときに複数箇所同時編集 (drift) になる罠を防ぐ。**挙動は完全に不変** (pure refactor)。

## 主な変更点

- 新規 `internal/repository/visibility.go`:
  - `applyViewerVisibility(q, viewerID)` — note table 直接版 (4 分岐完全形 = public/home | author | followers+follow | specified+ANY visibleUserIds)。
  - `applyViewerVisibilityExists(q, noteIDColumn, viewerID)` — clip_note / note_reaction のように author 混在テーブルが note を相関 EXISTS で join する版 (`v.` alias)。`noteIDColumn` は内部固定リテラルのみ (injection-safe)、viewerID は bind param。
  - 匿名 (`viewerID == ""`) は public/home に縮退。
- `internal/repository/note.go` 6 箇所を `applyViewerVisibility` に置換:
  - `ListByUserIDFiltered` (#1418) / `SearchByTag` (#1439) / `ListMentions` (#1441) / `ListByChannelID` (#1440) / `ListFeaturedByUser` (#1487) / `CountReplyTargets` (#1486)。
  - `ListMentions` は RequireAuth 配下で `userID` 非空のため helper の認証分岐で等価。
- `internal/repository/clip_note.go` / `note_reaction.go` の EXISTS 版を `applyViewerVisibilityExists` に置換。

## 対象外 (意図的)

- `ListByUserList` (#1452 user-list-timeline) は DM 非表示のため **specified を含めない** timeline 型述語で、上記 4 分岐完全形とは別物。helper には含めず、その旨を helper の doc コメントに明記した (将来「なぜここだけ別述語か」で迷わないように)。

## テスト

`#1454` 完了条件「挙動不変・既存テスト全 pass」に従い新規テストは追加せず、既存テストで回帰を担保:

- `make fmt && make lint && go build ./...`
- `go test ./internal/repository/...` (実 PostgreSQL) — **coverage 90.4%** (閾値 90% 超)、両 helper **100% カバー** (全 8 呼び出し経路が anonymous / authed 両分岐を既存統合テストで exercise)。
- `go test ./internal/api/clips/... ./internal/api/notes/... ./internal/api/users/...` — 全 pass。

## Closes

Closes #1454

（重複していた #1494 は本 issue を canonical として既にクローズ済み。）

## 関連

- #1446 (本 issue の発生元レビュー)
- #1418 / #1439 / #1440 / #1441 / #1486 / #1487 (visibility push-down batch)
- #1452 (ListByUserList — specified 非表示の timeline 型で対象外)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
