### PR TITLE
fix(notes): notes/mentions の match を mentions OR visibleUserIds に拡張 (#1484)

### DIFF
--- a/internal/api/notes/handler_extra_test.go
+++ b/internal/api/notes/handler_extra_test.go
@@ -337,6 +337,22 @@ func TestMentions_VisibilityExactMatch(t *testing.T) {
 	assert.False(t, ids["m_dm"], "public 指定で specified は出ない (exact-match)")
 }
 
+// #1484: 本文 @mention の無い specified DM (viewer ∈ visibleUserIds のみ) も
+// Direct タブ (visibility=specified) に出る。UI で宛先を選んだだけの DM を
+// 受信者が取りこぼさないことを固定する。
+func TestMentions_SpecifiedVisibleUserIDsOnly(t *testing.T) {
+	h, noteRepo, _ := newExtraHandler(t)
+	// mentions は空、visibleUserIds にだけ recipient を含む specified DM。
+	noteRepo.Notes["m_dm_vu"] = &model.Note{ID: "m_dm_vu", UserID: "author", Visibility: "specified", VisibleUserIDs: []string{"recipient"}, User: &model.User{ID: "author"}}
+
+	ids := mentionIDs(t, postExtra(h.Mentions, `{"visibility":"specified"}`, &model.User{ID: "recipient"}))
+	assert.True(t, ids["m_dm_vu"], "本文 @mention の無い specified DM も visibleUserIds 経由で Direct タブに出る")
+
+	// 宛先でない viewer には出ない (#1441 gate との整合)。
+	ids = mentionIDs(t, postExtra(h.Mentions, `{"visibility":"specified"}`, &model.User{ID: "stranger"}))
+	assert.False(t, ids["m_dm_vu"], "宛先でない viewer には specified DM が出ない")
+}
+
 // --- UserListTimeline ---
 
 func TestUserListTimeline_Success(t *testing.T) {

--- a/internal/repository/note.go
+++ b/internal/repository/note.go
@@ -715,8 +715,14 @@ func (r *noteRepository) ListMentions(userID, visibility string, limit int, sinc
 	// visibleUserIds にしか入らないため (= 宛先指定だけの DM)、mentions 単独 match
 	// だと受信者の notes/mentions / Direct タブで取りこぼす (#1484)。OR は単一 note
 	// 行の boolean なので重複行は出ない。
+	//
+	// 両枝とも containment 演算子 `@>` で書く: `scalar = ANY(array)` は GIN を使えず、
+	// `array @> ARRAY[scalar]` だけが GIN index 対象になる。viewer は単一要素なので
+	// 論理的に等価で、将来 visibleUserIds に GIN index を足せば mentions 枝
+	// (IDX_note_mentions, #1427) と揃って planner が BitmapOr で両枝 index 利用できる
+	// (#1484 review)。
 	q := preloadNoteRelations(r.db).
-		Where(`(mentions @> ARRAY[?]::varchar[] OR ? = ANY("visibleUserIds"))`, userID, userID)
+		Where(`(mentions @> ARRAY[?]::varchar[] OR "visibleUserIds" @> ARRAY[?]::varchar[])`, userID, userID)
 	// visibility push-down: mention 対象 (= viewer = userID) が CanSeeNote で
 	// 見られる note のみ返す。mentions 配列は本文の @user パース結果で specified
 	// の visibleUserIds とは独立なので、これが無いと followers/specified note を

--- a/internal/repository/note.go
+++ b/internal/repository/note.go
@@ -709,8 +709,14 @@ func (r *noteRepository) ListMentions(userID, visibility string, limit int, sinc
 	if limit <= 0 {
 		limit = 10
 	}
+	// match 条件: TS notes/mentions と同じく mentions または visibleUserIds の
+	// どちらかに viewer が含まれれば対象とする (TS: `:meId <@ note.mentions OR
+	// :meId <@ note.visibleUserIds`)。本文に @mention の無い specified DM は
+	// visibleUserIds にしか入らないため (= 宛先指定だけの DM)、mentions 単独 match
+	// だと受信者の notes/mentions / Direct タブで取りこぼす (#1484)。OR は単一 note
+	// 行の boolean なので重複行は出ない。
 	q := preloadNoteRelations(r.db).
-		Where("mentions @> ARRAY[?]::varchar[]", userID)
+		Where(`(mentions @> ARRAY[?]::varchar[] OR ? = ANY("visibleUserIds"))`, userID, userID)
 	// visibility push-down: mention 対象 (= viewer = userID) が CanSeeNote で
 	// 見られる note のみ返す。mentions 配列は本文の @user パース結果で specified
 	// の visibleUserIds とは独立なので、これが無いと followers/specified note を

--- a/internal/repository/note_test.go
+++ b/internal/repository/note_test.go
@@ -1715,6 +1715,64 @@ func TestNoteRepository_ListMentions_VisibilityFilter(t *testing.T) {
 	assert.Len(t, all, 10, "default は全種別を返す")
 }
 
+// TestNoteRepository_ListMentions_VisibleUserIDsOnly は #1484 を検証する。
+// 本文 @mention の無い specified DM (viewer ∈ visibleUserIds のみ) が
+// notes/mentions に出ること、mentions と visibleUserIds の両方に入っても重複行が
+// 出ないこと、宛先でも mention 対象でもない viewer には依然出ないこと (#1441 gate
+// 整合) を固定する。
+func TestNoteRepository_ListMentions_VisibleUserIDsOnly(t *testing.T) {
+	repo := NewNoteRepository(testDB)
+
+	mkUser := func(id, username string) *model.User {
+		u := insertTestUser(t, id, username)
+		t.Cleanup(func() { cleanupUser(t, u.ID) })
+		return u
+	}
+	author := mkUser("u_vu_a", "vuauthor")
+	recipient := mkUser("u_vu_r", "vurecipient")
+	stranger := mkUser("u_vu_s", "vustranger")
+
+	notes := []*model.Note{
+		// 本文 @mention 無し / visibleUserIds に recipient のみ (= 宛先指定だけの DM)。
+		{ID: "n_vu_dm", UserID: author.ID, Visibility: model.NoteVisibilitySpecified, VisibleUserIDs: pq.StringArray{recipient.ID}, Reactions: datatypes.JSON([]byte("{}"))},
+		// mentions と visibleUserIds の両方に recipient (重複行が出ないことの確認用)。
+		{ID: "n_vu_both", UserID: author.ID, Visibility: model.NoteVisibilitySpecified, Mentions: pq.StringArray{recipient.ID}, VisibleUserIDs: pq.StringArray{recipient.ID}, Reactions: datatypes.JSON([]byte("{}"))},
+	}
+	for _, n := range notes {
+		require.NoError(t, repo.Create(n))
+		defer cleanupNote(t, n.ID)
+	}
+
+	countOf := func(rows []*model.Note, id string) int {
+		c := 0
+		for _, n := range rows {
+			if n.ID == id {
+				c++
+			}
+		}
+		return c
+	}
+
+	// recipient (default = 全種別): visibleUserIds 由来 / mentions+visibleUserIds
+	// 両方とも 1 行ずつ。OR は単一行 boolean なので重複しない。
+	out, err := repo.ListMentions(recipient.ID, "", 50, "", "")
+	require.NoError(t, err)
+	assert.Equal(t, 1, countOf(out, "n_vu_dm"), "@mention の無い specified DM が visibleUserIds 経由で出る")
+	assert.Equal(t, 1, countOf(out, "n_vu_both"), "mentions と visibleUserIds 両方に入っても重複行は出ない")
+
+	// recipient (Direct タブ = visibility=specified): 同じく両方出る。
+	out, err = repo.ListMentions(recipient.ID, "specified", 50, "", "")
+	require.NoError(t, err)
+	assert.Equal(t, 1, countOf(out, "n_vu_dm"), "Direct タブでも visibleUserIds-only DM が出る")
+	assert.Equal(t, 1, countOf(out, "n_vu_both"))
+
+	// stranger: 宛先でも mention 対象でもないので何も出ない (#1441 gate 整合)。
+	out, err = repo.ListMentions(stranger.ID, "", 50, "", "")
+	require.NoError(t, err)
+	assert.Equal(t, 0, countOf(out, "n_vu_dm"))
+	assert.Equal(t, 0, countOf(out, "n_vu_both"))
+}
+
 func TestNoteRepository_SearchByTag(t *testing.T) {
 	repo := NewNoteRepository(testDB)
 	user := insertTestUser(t, "tag_u", "taguser")

--- a/internal/testutil/mock_repository.go
+++ b/internal/testutil/mock_repository.go
@@ -1175,8 +1175,16 @@ func (m *MockNoteRepository) ListMentions(userID, visibility string, limit int, 
 		if visibility != "" && string(n.Visibility) != visibility {
 			return false
 		}
+		// TS notes/mentions parity: mentions または visibleUserIds の
+		// どちらかに viewer が含まれれば対象 (#1484)。本文 @mention の無い
+		// specified DM も visibleUserIds 経由で拾う。
 		for _, mention := range n.Mentions {
 			if mention == userID {
+				return true
+			}
+		}
+		for _, vu := range n.VisibleUserIDs {
+			if vu == userID {
 				return true
 			}
 		}


### PR DESCRIPTION
## Summary

`notes/mentions` が **本文に @mention の無い specified DM** を取りこぼす parity gap を修正する (#1484)。

upstream Misskey TS `notes/mentions.ts` は match 条件を

```ts
qb.where(':meIdAsList <@ note.mentions')
  .orWhere(':meIdAsList <@ note.visibleUserIds');
```

= `mentions` または `visibleUserIds` のどちらかに viewer が含まれれば対象、としている。一方 mk-go の `ListMentions` は `mentions @> ARRAY[viewer]` の単独 match だった。

specified note では `mentions` (本文 / tag 由来) と `visibleUserIds` (宛先指定) が乖離しうるため、UI で宛先を選んだだけで本文に @mention の無い DM は `visibleUserIds` にしか入らず、受信者の `notes/mentions` / Direct タブ (`visibility=specified`) に出てこなかった。drop-in 互換のズレに加え、受信者が DM を見落とす実害がある (#1451 / PR #1483 のレビュー中に発見)。

## 主な変更点

- `internal/repository/note.go` `ListMentions`: match 条件を
  `(mentions @> ARRAY[?]::varchar[] OR ? = ANY("visibleUserIds"))` に拡張。
  - 直後の `applyViewerVisibility(q, userID)` (#1441 / #1454) による visibility push-down gate は**不変のまま AND** される。visibleUserIds 由来で拾った specified note も `visibility = 'specified' AND viewer = ANY(visibleUserIds)` を満たす viewer (= 宛先本人) のみ通過するため、新たな leak は無い。
  - OR は単一 note 行の boolean なので重複行は出ない。
  - #1451 の visibility kind filter (`visibility != "" → "visibility" = ?`) とも直交し、Direct タブ / default いずれでも正しく動く。
- `internal/testutil/mock_repository.go` `ListMentions`: mock の match も `mentions OR visibleUserIds` に揃える (`canViewerSeeNote` gate は不変)。

## テスト

- `repository.TestNoteRepository_ListMentions_VisibleUserIDsOnly` (DB 統合):
  - visibleUserIds-only の specified DM が default / `visibility=specified` 双方で出る
  - mentions と visibleUserIds の両方に入っても重複行が出ない (count == 1)
  - 宛先でも mention 対象でもない viewer には出ない (#1441 gate 整合)
- `api/notes.TestMentions_SpecifiedVisibleUserIDsOnly` (handler): Direct タブで visibleUserIds-only DM が出る / 非宛先には出ない
- 既存の `TestNoteRepository_ListMentions_VisibilityPushDown` (#1441) / `_VisibilityFilter` (#1451) は不変で pass = 回帰なし
- ローカル: `make fmt` / `make lint` / `go build ./...` clean。`internal/repository` + `internal/api/notes` を実 PostgreSQL に対して pass。

Closes #1484