### PR TITLE
perf(notes): notes/renotes・replies・children の visibility を SQL push-down 化 (#1500)

### DIFF
--- a/internal/api/notes/handler_query_test.go
+++ b/internal/api/notes/handler_query_test.go
@@ -323,13 +323,13 @@ type failingQueryRepo struct {
 	*testutil.MockNoteRepository
 }
 
-func (f *failingQueryRepo) ListRenotesOf(_, _, _ string, _ int) ([]*model.Note, error) {
+func (f *failingQueryRepo) ListRenotesOf(_, _, _, _ string, _ int) ([]*model.Note, error) {
 	return nil, testutil.ErrNotFound
 }
-func (f *failingQueryRepo) ListRepliesOf(_, _, _ string, _ int) ([]*model.Note, error) {
+func (f *failingQueryRepo) ListRepliesOf(_, _, _, _ string, _ int) ([]*model.Note, error) {
 	return nil, testutil.ErrNotFound
 }
-func (f *failingQueryRepo) ListChildrenOf(_, _, _ string, _ int) ([]*model.Note, error) {
+func (f *failingQueryRepo) ListChildrenOf(_, _, _, _ string, _ int) ([]*model.Note, error) {
 	return nil, testutil.ErrNotFound
 }
 func (f *failingQueryRepo) SearchByFilter(_ model.NoteSearchFilter) ([]*model.Note, error) {

--- a/internal/api/notes/handler_test.go
+++ b/internal/api/notes/handler_test.go
@@ -845,13 +845,13 @@ func (f *failingNoteRepo) ListByChannelID(_, _, _, _ string, _ int) ([]*model.No
 func (f *failingNoteRepo) FindManyByIDsWithUser(_ []string) ([]*model.Note, error) {
 	return nil, nil
 }
-func (f *failingNoteRepo) ListRenotesOf(_ string, _, _ string, _ int) ([]*model.Note, error) {
+func (f *failingNoteRepo) ListRenotesOf(_, _, _, _ string, _ int) ([]*model.Note, error) {
 	return nil, nil
 }
-func (f *failingNoteRepo) ListRepliesOf(_ string, _, _ string, _ int) ([]*model.Note, error) {
+func (f *failingNoteRepo) ListRepliesOf(_, _, _, _ string, _ int) ([]*model.Note, error) {
 	return nil, nil
 }
-func (f *failingNoteRepo) ListChildrenOf(_ string, _, _ string, _ int) ([]*model.Note, error) {
+func (f *failingNoteRepo) ListChildrenOf(_, _, _, _ string, _ int) ([]*model.Note, error) {
 	return nil, nil
 }
 func (f *failingNoteRepo) SearchByFilter(_ model.NoteSearchFilter) ([]*model.Note, error) {

--- a/internal/core/federation/processor.go
+++ b/internal/core/federation/processor.go
@@ -701,7 +701,10 @@ func (p *Processor) handleUndoAnnounce(act genericActivity, inner genericActivit
 	}
 	// announcer が pure renote を 1 件でも持っていれば削除する。複数あった場合
 	// は最新の 1 件のみで十分 (本家 misskey の挙動と同じ)。
-	renotes, err := p.noteRepo.ListRenotesOf(target.ID, "", "", 50)
+	// viewerID には announcer.ID を渡す: push-down 後 (#1500) も self-branch で
+	// announcer 自身の renote は visibility を問わず全件見えるため、下の
+	// `n.UserID != announcer.ID` で残す対象行は従来どおり取得できる。
+	renotes, err := p.noteRepo.ListRenotesOf(target.ID, announcer.ID, "", "", 50)
 	if err != nil {
 		return err
 	}

--- a/internal/core/federation/processor_step_f_test.go
+++ b/internal/core/federation/processor_step_f_test.go
@@ -1292,7 +1292,7 @@ type listRenotesFailRepo struct {
 	*testutil.MockNoteRepository
 }
 
-func (r *listRenotesFailRepo) ListRenotesOf(_, _, _ string, _ int) ([]*model.Note, error) {
+func (r *listRenotesFailRepo) ListRenotesOf(_, _, _, _ string, _ int) ([]*model.Note, error) {
 	return nil, errors.New("list failed")
 }
 

--- a/internal/core/note/note_query_service.go
+++ b/internal/core/note/note_query_service.go
@@ -110,11 +110,10 @@ func (s *QueryService) ListRenotes(viewer *model.User, noteID, untilID, sinceID 
 	if _, err := s.requireVisible(viewer, noteID); err != nil {
 		return nil, err
 	}
-	rows, err := s.noteRepo.ListRenotesOf(noteID, untilID, sinceID, limit)
-	if err != nil {
-		return nil, err
-	}
-	return s.filterVisible(viewer, rows), nil
+	// visibility は repository が LIMIT 前に SQL push-down する (#1500)。post-fetch
+	// filterVisible だとページ過少充填 + followers 判定 N+1 になるため撤去。親 note の
+	// requireVisible ゲートは維持。viewer==nil は匿名 (public/home のみ)。
+	return s.noteRepo.ListRenotesOf(noteID, viewerIDOf(viewer), untilID, sinceID, limit)
 }
 
 // ListReplies returns replies to the given noteID after filtering for visibility.
@@ -122,11 +121,8 @@ func (s *QueryService) ListReplies(viewer *model.User, noteID, untilID, sinceID 
 	if _, err := s.requireVisible(viewer, noteID); err != nil {
 		return nil, err
 	}
-	rows, err := s.noteRepo.ListRepliesOf(noteID, untilID, sinceID, limit)
-	if err != nil {
-		return nil, err
-	}
-	return s.filterVisible(viewer, rows), nil
+	// visibility は repository が LIMIT 前に SQL push-down する (#1500)。
+	return s.noteRepo.ListRepliesOf(noteID, viewerIDOf(viewer), untilID, sinceID, limit)
 }
 
 // ListChildren returns notes that reply to or quote the given noteID.
@@ -134,11 +130,8 @@ func (s *QueryService) ListChildren(viewer *model.User, noteID, untilID, sinceID
 	if _, err := s.requireVisible(viewer, noteID); err != nil {
 		return nil, err
 	}
-	rows, err := s.noteRepo.ListChildrenOf(noteID, untilID, sinceID, limit)
-	if err != nil {
-		return nil, err
-	}
-	return s.filterVisible(viewer, rows), nil
+	// visibility は repository が LIMIT 前に SQL push-down する (#1500)。
+	return s.noteRepo.ListChildrenOf(noteID, viewerIDOf(viewer), untilID, sinceID, limit)
 }
 
 // Conversation walks up the reply chain from the given noteID and returns
@@ -225,6 +218,16 @@ type NoteState struct {
 // handlers that perform bulk lookups outside of QueryService (e.g. BulkShow).
 func (s *QueryService) FilterVisible(viewer *model.User, rows []*model.Note) []*model.Note {
 	return s.filterVisible(viewer, rows)
+}
+
+// viewerIDOf returns the viewer's ID, or "" for an anonymous (nil) viewer.
+// repository の visibility push-down (applyViewerVisibility) は viewerID="" を
+// 匿名 (public/home のみ) として扱う (#1500)。
+func viewerIDOf(viewer *model.User) string {
+	if viewer == nil {
+		return ""
+	}
+	return viewer.ID
 }
 
 // filterVisible drops notes the viewer cannot see.

--- a/internal/core/note/note_query_service_test.go
+++ b/internal/core/note/note_query_service_test.go
@@ -149,6 +149,31 @@ func TestQueryService_ListChildren_ParentMissing(t *testing.T) {
 	require.ErrorIs(t, err, note.ErrNoteNotFound)
 }
 
+// #1500: visibility は repository の SQL push-down に委譲される。QueryService は
+// viewer の ID を repo に正しく渡すだけ (post-fetch filterVisible は撤去)。
+// public parent への followers reply は、author を follow していない viewer には
+// 返らず、follow すると返ることで viewerID 伝播 + push-down の委譲を固定する。
+func TestQueryService_ListReplies_VisibilityDelegatedToRepo(t *testing.T) {
+	svc, noteRepo, _ := newQueryService(t)
+	noteRepo.Notes["parent"] = &model.Note{ID: "parent", UserID: "a", Visibility: model.NoteVisibilityPublic}
+	parentID := "parent"
+	noteRepo.Notes["pub"] = &model.Note{ID: "pub", UserID: "a", Visibility: model.NoteVisibilityPublic, ReplyID: &parentID}
+	noteRepo.Notes["fol"] = &model.Note{ID: "fol", UserID: "a", Visibility: model.NoteVisibilityFollowers, ReplyID: &parentID}
+
+	viewer := &model.User{ID: "v"}
+	// 非フォロワー: followers reply は見えない (push-down が効いている)。
+	out, err := svc.ListReplies(viewer, "parent", "", "", 10)
+	require.NoError(t, err)
+	require.Len(t, out, 1)
+	assert.Equal(t, "pub", out[0].ID)
+
+	// follow すると followers reply も返る。
+	noteRepo.Following = map[string][]string{"v": {"a"}}
+	out, err = svc.ListReplies(viewer, "parent", "", "", 10)
+	require.NoError(t, err)
+	assert.Len(t, out, 2)
+}
+
 func TestQueryService_Conversation_Empty(t *testing.T) {
 	svc, noteRepo, _ := newQueryService(t)
 	noteRepo.Notes["root"] = &model.Note{ID: "root", UserID: "a", Visibility: model.NoteVisibilityPublic}
@@ -267,25 +292,25 @@ type failingRepoForList struct {
 	mode string
 }
 
-func (f *failingRepoForList) ListRenotesOf(_, _, _ string, _ int) ([]*model.Note, error) {
+func (f *failingRepoForList) ListRenotesOf(_, _, _, _ string, _ int) ([]*model.Note, error) {
 	if f.mode == "renotes" {
 		return nil, errors.New("boom")
 	}
-	return f.MockNoteRepository.ListRenotesOf("", "", "", 0)
+	return f.MockNoteRepository.ListRenotesOf("", "", "", "", 0)
 }
 
-func (f *failingRepoForList) ListRepliesOf(_, _, _ string, _ int) ([]*model.Note, error) {
+func (f *failingRepoForList) ListRepliesOf(_, _, _, _ string, _ int) ([]*model.Note, error) {
 	if f.mode == "replies" {
 		return nil, errors.New("boom")
 	}
-	return f.MockNoteRepository.ListRepliesOf("", "", "", 0)
+	return f.MockNoteRepository.ListRepliesOf("", "", "", "", 0)
 }
 
-func (f *failingRepoForList) ListChildrenOf(_, _, _ string, _ int) ([]*model.Note, error) {
+func (f *failingRepoForList) ListChildrenOf(_, _, _, _ string, _ int) ([]*model.Note, error) {
 	if f.mode == "children" {
 		return nil, errors.New("boom")
 	}
-	return f.MockNoteRepository.ListChildrenOf("", "", "", 0)
+	return f.MockNoteRepository.ListChildrenOf("", "", "", "", 0)
 }
 
 func TestQueryService_ListRenotes_RepoError(t *testing.T) {

--- a/internal/repository/note.go
+++ b/internal/repository/note.go
@@ -451,9 +451,10 @@ func (r *noteRepository) ListRepliesOf(noteID, viewerID, untilID, sinceID string
 // notes/childrenでスレッドツリーの直下を取得するために使用する。
 func (r *noteRepository) ListChildrenOf(noteID, viewerID, untilID, sinceID string, limit int) ([]*model.Note, error) {
 	var notes []*model.Note
-	// base 条件の OR は明示的に括弧で囲む。visibility 述語が後続の AND で結合される
-	// とき、括弧が無いと `replyId=? OR (renoteId=? AND visibility...)` と解釈されて
-	// reply 側が visibility 無視で漏れるため (#1500)。
+	// base 条件の OR は明示的に括弧で囲む。GORM は複数 Where の生 OR 文字列を暗黙に
+	// グルーピングするが、その挙動に依存せず「後続 AND の visibility 述語が
+	// replyId/renoteId の OR 全体に係る」意図を明示するための defensive clarity
+	// (#1500)。実際のリーク防止は ListChildrenOf_VisibilityPushDown の回帰テストで担保。
 	q := preloadNoteRelations(r.db).
 		Where("(\"replyId\" = ? OR \"renoteId\" = ?)", noteID, noteID)
 	// visibility push-down (#1500): viewer が見られる child のみ LIMIT 前に絞る。

--- a/internal/repository/note.go
+++ b/internal/repository/note.go
@@ -88,9 +88,15 @@ type NoteRepository interface {
 	// 取り込む形に統合した (#1439 / #1441 と同じパターン)。
 	ListByChannelID(channelID, viewerID, untilID, sinceID string, limit int) ([]*model.Note, error)
 	FindManyByIDsWithUser(ids []string) ([]*model.Note, error)
-	ListRenotesOf(noteID string, untilID, sinceID string, limit int) ([]*model.Note, error)
-	ListRepliesOf(noteID string, untilID, sinceID string, limit int) ([]*model.Note, error)
-	ListChildrenOf(noteID string, untilID, sinceID string, limit int) ([]*model.Note, error)
+	// ListRenotesOf / ListRepliesOf / ListChildrenOf は viewerID 視点の可視性を
+	// LIMIT 前に SQL push-down する (#1500)。viewerID="" は匿名 (public/home のみ)。
+	// 条件は core/note.CanSeeNote 完全版 (specified 込み): スレッドの reply/renote は
+	// viewer が visibleUserIds 対象なら specified note も見えるため、timeline 系の
+	// specified 除外版を流用しないこと。post-fetch filter だとページ過少充填 +
+	// followers 判定 N+1 になるため (#1418 / #1452 と同 doctrine)。
+	ListRenotesOf(noteID, viewerID, untilID, sinceID string, limit int) ([]*model.Note, error)
+	ListRepliesOf(noteID, viewerID, untilID, sinceID string, limit int) ([]*model.Note, error)
+	ListChildrenOf(noteID, viewerID, untilID, sinceID string, limit int) ([]*model.Note, error)
 	SearchByFilter(filter model.NoteSearchFilter) ([]*model.Note, error)
 	// ListFeatured returns ranked public notes (renote+reply count). When
 	// channelID is non-empty restricts to that channel, mirroring upstream
@@ -405,9 +411,11 @@ func (r *noteRepository) ListByChannelID(channelID, viewerID, untilID, sinceID s
 
 // ListRenotesOf returns notes whose renoteId equals noteID.
 // テキストやファイルを伴わない pure renote だけでなく quote renote も含む。
-func (r *noteRepository) ListRenotesOf(noteID string, untilID, sinceID string, limit int) ([]*model.Note, error) {
+func (r *noteRepository) ListRenotesOf(noteID, viewerID, untilID, sinceID string, limit int) ([]*model.Note, error) {
 	var notes []*model.Note
 	q := preloadNoteRelations(r.db).Where("\"renoteId\" = ?", noteID)
+	// visibility push-down (#1500): viewer が見られる renote のみ LIMIT 前に絞る。
+	q = applyViewerVisibility(q, viewerID)
 	if untilID != "" {
 		q = q.Where("id < ?", untilID)
 	}
@@ -422,9 +430,11 @@ func (r *noteRepository) ListRenotesOf(noteID string, untilID, sinceID string, l
 
 // ListRepliesOf returns notes whose replyId equals noteID.
 // すべてのユーザーからの返信を返す(ミュート判定はServiceで行う)。
-func (r *noteRepository) ListRepliesOf(noteID string, untilID, sinceID string, limit int) ([]*model.Note, error) {
+func (r *noteRepository) ListRepliesOf(noteID, viewerID, untilID, sinceID string, limit int) ([]*model.Note, error) {
 	var notes []*model.Note
 	q := preloadNoteRelations(r.db).Where("\"replyId\" = ?", noteID)
+	// visibility push-down (#1500): viewer が見られる reply のみ LIMIT 前に絞る。
+	q = applyViewerVisibility(q, viewerID)
 	if untilID != "" {
 		q = q.Where("id < ?", untilID)
 	}
@@ -439,10 +449,15 @@ func (r *noteRepository) ListRepliesOf(noteID string, untilID, sinceID string, l
 
 // ListChildrenOf returns notes that are either replies or quote-renotes of the given noteID.
 // notes/childrenでスレッドツリーの直下を取得するために使用する。
-func (r *noteRepository) ListChildrenOf(noteID string, untilID, sinceID string, limit int) ([]*model.Note, error) {
+func (r *noteRepository) ListChildrenOf(noteID, viewerID, untilID, sinceID string, limit int) ([]*model.Note, error) {
 	var notes []*model.Note
+	// base 条件の OR は明示的に括弧で囲む。visibility 述語が後続の AND で結合される
+	// とき、括弧が無いと `replyId=? OR (renoteId=? AND visibility...)` と解釈されて
+	// reply 側が visibility 無視で漏れるため (#1500)。
 	q := preloadNoteRelations(r.db).
-		Where("\"replyId\" = ? OR \"renoteId\" = ?", noteID, noteID)
+		Where("(\"replyId\" = ? OR \"renoteId\" = ?)", noteID, noteID)
+	// visibility push-down (#1500): viewer が見られる child のみ LIMIT 前に絞る。
+	q = applyViewerVisibility(q, viewerID)
 	if untilID != "" {
 		q = q.Where("id < ?", untilID)
 	}

--- a/internal/repository/note_test.go
+++ b/internal/repository/note_test.go
@@ -753,13 +753,13 @@ func TestNoteRepository_QueryErrors(t *testing.T) {
 	_, err = repo.FindManyByIDsWithUser([]string{"a"})
 	assert.Error(t, err)
 
-	_, err = repo.ListRenotesOf("a", "", "", 10)
+	_, err = repo.ListRenotesOf("a", "", "", "", 10)
 	assert.Error(t, err)
 
-	_, err = repo.ListRepliesOf("a", "", "", 10)
+	_, err = repo.ListRepliesOf("a", "", "", "", 10)
 	assert.Error(t, err)
 
-	_, err = repo.ListChildrenOf("a", "", "", 10)
+	_, err = repo.ListChildrenOf("a", "", "", "", 10)
 	assert.Error(t, err)
 
 	_, err = repo.SearchByFilter(model.NoteSearchFilter{Query: "a", Limit: 10})
@@ -849,16 +849,16 @@ func TestNoteRepository_ListRenotesOf(t *testing.T) {
 		defer cleanupNote(t, id)
 	}
 
-	out, err := repo.ListRenotesOf(parent.ID, "", "", 10)
+	out, err := repo.ListRenotesOf(parent.ID, "", "", "", 10)
 	require.NoError(t, err)
 	assert.Len(t, out, 3)
 	assert.Equal(t, "n_lr_r3", out[0].ID)
 
-	out, err = repo.ListRenotesOf(parent.ID, "n_lr_r3", "", 10)
+	out, err = repo.ListRenotesOf(parent.ID, "", "n_lr_r3", "", 10)
 	require.NoError(t, err)
 	assert.Len(t, out, 2)
 
-	out, err = repo.ListRenotesOf(parent.ID, "", "n_lr_r1", 10)
+	out, err = repo.ListRenotesOf(parent.ID, "", "", "n_lr_r1", 10)
 	require.NoError(t, err)
 	assert.Len(t, out, 2)
 }
@@ -886,15 +886,15 @@ func TestNoteRepository_ListRepliesOf(t *testing.T) {
 		defer cleanupNote(t, id)
 	}
 
-	out, err := repo.ListRepliesOf(parent.ID, "", "", 10)
+	out, err := repo.ListRepliesOf(parent.ID, "", "", "", 10)
 	require.NoError(t, err)
 	assert.Len(t, out, 2)
 
-	out, err = repo.ListRepliesOf(parent.ID, "n_lp_r2", "", 10)
+	out, err = repo.ListRepliesOf(parent.ID, "", "n_lp_r2", "", 10)
 	require.NoError(t, err)
 	assert.Len(t, out, 1)
 
-	out, err = repo.ListRepliesOf(parent.ID, "", "n_lp_r1", 10)
+	out, err = repo.ListRepliesOf(parent.ID, "", "", "n_lp_r1", 10)
 	require.NoError(t, err)
 	assert.Len(t, out, 1)
 }
@@ -929,19 +929,201 @@ func TestNoteRepository_ListChildrenOf(t *testing.T) {
 	require.NoError(t, repo.Create(quote))
 	defer cleanupNote(t, quote.ID)
 
-	out, err := repo.ListChildrenOf(parent.ID, "", "", 10)
+	out, err := repo.ListChildrenOf(parent.ID, "", "", "", 10)
 	require.NoError(t, err)
 	assert.Len(t, out, 2)
 
-	out, err = repo.ListChildrenOf(parent.ID, "n_lc_c2", "", 10)
+	out, err = repo.ListChildrenOf(parent.ID, "", "n_lc_c2", "", 10)
 	require.NoError(t, err)
 	assert.Len(t, out, 1)
 	assert.Equal(t, "n_lc_c1", out[0].ID)
 
-	out, err = repo.ListChildrenOf(parent.ID, "", "n_lc_c1", 10)
+	out, err = repo.ListChildrenOf(parent.ID, "", "", "n_lc_c1", 10)
 	require.NoError(t, err)
 	assert.Len(t, out, 1)
 	assert.Equal(t, "n_lc_c2", out[0].ID)
+}
+
+// --- #1500 visibility push-down (renotes / replies / children) ---
+//
+// スレッド系 3 メソッドが viewer の可視性を LIMIT 前に SQL push-down し、
+// (1) anonymous / 非フォロワー / フォロワー / specified-target / author で正しく
+// 絞り込むこと、(2) 非表示 note が LIMIT 枠を食わず under-fill しないこと、
+// (3) specified note が宛先 viewer には見えること (timeline 型の specified 除外を
+// 流用していないこと) を実 SQL で固定する。
+
+// threadVizFixture は author A による mixed-visibility の子 note 群と、
+// follower F / 非フォロワー viewer V を用意するヘルパ。childKind は "reply" /
+// "renote" を選び、ListRepliesOf / ListRenotesOf に流用する。
+func threadVizFixture(t *testing.T, repo NoteRepository, prefix, childKind string) (author, follower, viewer *model.User, parentID string, ids map[string]string) {
+	t.Helper()
+	followingRepo := NewFollowingRepository(testDB)
+	mkUser := func(suffix, username string) *model.User {
+		u := insertTestUser(t, prefix+"_"+suffix, username)
+		t.Cleanup(func() { cleanupUser(t, u.ID) })
+		return u
+	}
+	author = mkUser("a", prefix+"author")
+	follower = mkUser("f", prefix+"follower")
+	viewer = mkUser("v", prefix+"viewer")
+
+	f := &model.Following{ID: prefix + "_fl", FollowerID: follower.ID, FolloweeID: author.ID}
+	require.NoError(t, followingRepo.Create(f))
+	t.Cleanup(func() { testDB.Exec(`DELETE FROM "following" WHERE id = ?`, f.ID) })
+
+	parent := &model.Note{ID: prefix + "_parent", UserID: author.ID, Visibility: model.NoteVisibilityPublic, Reactions: datatypes.JSON([]byte("{}"))}
+	require.NoError(t, repo.Create(parent))
+	t.Cleanup(func() { cleanupNote(t, parent.ID) })
+	parentID = parent.ID
+
+	// ID は昇順 (1..5) で、非表示になりがちな specified/followers を「新しい側」に
+	// 寄せることで、旧 fetch-then-filter 実装なら limit 枠を食って under-fill した
+	// ケースを再現する。
+	ids = map[string]string{
+		"pub":    prefix + "_c1_pub",
+		"home":   prefix + "_c2_home",
+		"fol":    prefix + "_c3_fol",
+		"spec_v": prefix + "_c4_specv",
+		"spec_x": prefix + "_c5_specx",
+	}
+	mk := func(id string, vis model.NoteVisibility, visible []string) {
+		n := &model.Note{ID: id, UserID: author.ID, Visibility: vis, Reactions: datatypes.JSON([]byte("{}"))}
+		if len(visible) > 0 {
+			n.VisibleUserIDs = pq.StringArray(visible)
+		}
+		switch childKind {
+		case "renote":
+			n.RenoteID = &parentID
+			// quote 扱いにして pure renote 除外ロジックと干渉しないよう text を持たせる
+			txt := "q"
+			n.Text = &txt
+		default:
+			n.ReplyID = &parentID
+		}
+		require.NoError(t, repo.Create(n))
+		t.Cleanup(func() { cleanupNote(t, id) })
+	}
+	mk(ids["pub"], model.NoteVisibilityPublic, nil)
+	mk(ids["home"], model.NoteVisibilityHome, nil)
+	mk(ids["fol"], model.NoteVisibilityFollowers, nil)
+	mk(ids["spec_v"], model.NoteVisibilitySpecified, []string{viewer.ID})
+	mk(ids["spec_x"], model.NoteVisibilitySpecified, []string{"someone-else"})
+	return author, follower, viewer, parentID, ids
+}
+
+func idSet(rows []*model.Note) map[string]bool {
+	out := map[string]bool{}
+	for _, n := range rows {
+		out[n.ID] = true
+	}
+	return out
+}
+
+func TestNoteRepository_ListRepliesOf_VisibilityPushDown(t *testing.T) {
+	repo := NewNoteRepository(testDB)
+	author, follower, viewer, parentID, ids := threadVizFixture(t, repo, "rvp", "reply")
+
+	// anonymous: public/home のみ。
+	got, err := repo.ListRepliesOf(parentID, "", "", "", 10)
+	require.NoError(t, err)
+	assert.Equal(t, map[string]bool{ids["pub"]: true, ids["home"]: true}, idSet(got))
+
+	// 非フォロワー viewer: public/home + 自分が宛先の specified。followers は見えない。
+	got, err = repo.ListRepliesOf(parentID, viewer.ID, "", "", 10)
+	require.NoError(t, err)
+	assert.Equal(t, map[string]bool{ids["pub"]: true, ids["home"]: true, ids["spec_v"]: true}, idSet(got))
+
+	// follower: public/home + followers。宛先でない specified は見えない。
+	got, err = repo.ListRepliesOf(parentID, follower.ID, "", "", 10)
+	require.NoError(t, err)
+	assert.Equal(t, map[string]bool{ids["pub"]: true, ids["home"]: true, ids["fol"]: true}, idSet(got))
+
+	// author: 自分の note は全 visibility 見える。
+	got, err = repo.ListRepliesOf(parentID, author.ID, "", "", 10)
+	require.NoError(t, err)
+	assert.Len(t, got, 5)
+
+	// under-fill しない: 非表示 (fol/spec_v/spec_x) が新しい側に 3 件あるが、
+	// anonymous で limit=2 を要求すると visible 2 件 (pub/home) がきっちり返る。
+	// 旧 fetch-then-filter なら新しい 2 行 (spec_x/spec_v) を取って filter で 0 件に
+	// なっていた。
+	got, err = repo.ListRepliesOf(parentID, "", "", "", 2)
+	require.NoError(t, err)
+	assert.Equal(t, map[string]bool{ids["pub"]: true, ids["home"]: true}, idSet(got))
+}
+
+func TestNoteRepository_ListRenotesOf_VisibilityPushDown(t *testing.T) {
+	repo := NewNoteRepository(testDB)
+	author, follower, viewer, parentID, ids := threadVizFixture(t, repo, "rnvp", "renote")
+
+	got, err := repo.ListRenotesOf(parentID, "", "", "", 10)
+	require.NoError(t, err)
+	assert.Equal(t, map[string]bool{ids["pub"]: true, ids["home"]: true}, idSet(got))
+
+	got, err = repo.ListRenotesOf(parentID, viewer.ID, "", "", 10)
+	require.NoError(t, err)
+	assert.Equal(t, map[string]bool{ids["pub"]: true, ids["home"]: true, ids["spec_v"]: true}, idSet(got))
+
+	got, err = repo.ListRenotesOf(parentID, follower.ID, "", "", 10)
+	require.NoError(t, err)
+	assert.Equal(t, map[string]bool{ids["pub"]: true, ids["home"]: true, ids["fol"]: true}, idSet(got))
+
+	got, err = repo.ListRenotesOf(parentID, author.ID, "", "", 10)
+	require.NoError(t, err)
+	assert.Len(t, got, 5)
+}
+
+func TestNoteRepository_ListChildrenOf_VisibilityPushDown(t *testing.T) {
+	repo := NewNoteRepository(testDB)
+	followingRepo := NewFollowingRepository(testDB)
+	mkUser := func(id, username string) *model.User {
+		u := insertTestUser(t, id, username)
+		t.Cleanup(func() { cleanupUser(t, u.ID) })
+		return u
+	}
+	author := mkUser("cvp_a", "cvpauthor")
+	viewer := mkUser("cvp_v", "cvpviewer")
+	follower := mkUser("cvp_f", "cvpfollower")
+	f := &model.Following{ID: "cvp_fl", FollowerID: follower.ID, FolloweeID: author.ID}
+	require.NoError(t, followingRepo.Create(f))
+	t.Cleanup(func() { testDB.Exec(`DELETE FROM "following" WHERE id = ?`, f.ID) })
+
+	parent := &model.Note{ID: "cvp_parent", UserID: author.ID, Visibility: model.NoteVisibilityPublic, Reactions: datatypes.JSON([]byte("{}"))}
+	require.NoError(t, repo.Create(parent))
+	t.Cleanup(func() { cleanupNote(t, parent.ID) })
+	pid := parent.ID
+
+	// children = reply + quote-renote の混在。followers を「reply 側」に置くことで、
+	// もし base の OR が括弧で囲われず `replyId=? OR (renoteId=? AND visibility)` と
+	// 解釈されていたら followers reply が漏れる。そのリーク回帰を固定する。
+	txt := "q"
+	rows := []*model.Note{
+		{ID: "cvp_c1_pubreply", UserID: author.ID, Visibility: model.NoteVisibilityPublic, ReplyID: &pid, Reactions: datatypes.JSON([]byte("{}"))},
+		{ID: "cvp_c2_folreply", UserID: author.ID, Visibility: model.NoteVisibilityFollowers, ReplyID: &pid, Reactions: datatypes.JSON([]byte("{}"))},
+		{ID: "cvp_c3_pubquote", UserID: author.ID, Visibility: model.NoteVisibilityPublic, RenoteID: &pid, Text: &txt, Reactions: datatypes.JSON([]byte("{}"))},
+		{ID: "cvp_c4_folquote", UserID: author.ID, Visibility: model.NoteVisibilityFollowers, RenoteID: &pid, Text: &txt, Reactions: datatypes.JSON([]byte("{}"))},
+	}
+	for _, n := range rows {
+		require.NoError(t, repo.Create(n))
+		id := n.ID
+		t.Cleanup(func() { cleanupNote(t, id) })
+	}
+
+	// 非フォロワー viewer: followers の reply / quote は両方とも見えない (= 括弧で
+	// OR 全体に visibility が AND されている証拠)。public の reply / quote のみ。
+	got, err := repo.ListChildrenOf(pid, viewer.ID, "", "", 10)
+	require.NoError(t, err)
+	assert.Equal(t, map[string]bool{"cvp_c1_pubreply": true, "cvp_c3_pubquote": true}, idSet(got))
+
+	// follower: followers の reply / quote も見える。
+	got, err = repo.ListChildrenOf(pid, follower.ID, "", "", 10)
+	require.NoError(t, err)
+	assert.Len(t, got, 4)
+
+	// anonymous: public のみ。
+	got, err = repo.ListChildrenOf(pid, "", "", "", 10)
+	require.NoError(t, err)
+	assert.Equal(t, map[string]bool{"cvp_c1_pubreply": true, "cvp_c3_pubquote": true}, idSet(got))
 }
 
 func TestNoteRepository_SearchByFilter(t *testing.T) {

--- a/internal/testutil/mock_repository.go
+++ b/internal/testutil/mock_repository.go
@@ -884,22 +884,32 @@ func (m *MockNoteRepository) IncrementReaction(noteID, reaction string, delta in
 }
 
 // ListRenotesOf returns notes whose renoteId equals noteID.
-func (m *MockNoteRepository) ListRenotesOf(noteID string, untilID, sinceID string, limit int) ([]*model.Note, error) {
+func (m *MockNoteRepository) ListRenotesOf(noteID, viewerID, untilID, sinceID string, limit int) ([]*model.Note, error) {
 	return m.listFiltered(func(n *model.Note) bool {
+		// viewer 視点の可視性を LIMIT 前に絞る (#1500、real repo の SQL push-down 相当)。
+		if !m.canViewerSeeNote(viewerID, n) {
+			return false
+		}
 		return n.RenoteID != nil && *n.RenoteID == noteID
 	}, untilID, sinceID, limit), nil
 }
 
 // ListRepliesOf returns notes whose replyId equals noteID.
-func (m *MockNoteRepository) ListRepliesOf(noteID string, untilID, sinceID string, limit int) ([]*model.Note, error) {
+func (m *MockNoteRepository) ListRepliesOf(noteID, viewerID, untilID, sinceID string, limit int) ([]*model.Note, error) {
 	return m.listFiltered(func(n *model.Note) bool {
+		if !m.canViewerSeeNote(viewerID, n) {
+			return false
+		}
 		return n.ReplyID != nil && *n.ReplyID == noteID
 	}, untilID, sinceID, limit), nil
 }
 
 // ListChildrenOf returns notes that reply to or quote the given noteID.
-func (m *MockNoteRepository) ListChildrenOf(noteID string, untilID, sinceID string, limit int) ([]*model.Note, error) {
+func (m *MockNoteRepository) ListChildrenOf(noteID, viewerID, untilID, sinceID string, limit int) ([]*model.Note, error) {
 	return m.listFiltered(func(n *model.Note) bool {
+		if !m.canViewerSeeNote(viewerID, n) {
+			return false
+		}
 		if n.ReplyID != nil && *n.ReplyID == noteID {
 			return true
 		}


### PR DESCRIPTION
## Summary

スレッド系 3 endpoint (`notes/renotes` / `notes/replies` / `notes/children`) の可視性フィルタを post-fetch から SQL push-down に移し、ページ過少充填 (under-fill) と followers 判定 N+1 を解消する (#1500、#1453 audit の follow-up)。leak は #1453 で「無し」と確認済みで、本 PR は perf / UX 改善。

これまで 3 メソッドは「親 `requireVisible` → `limit` 件 fetch → post-fetch `filterVisible`」で、(1) 非表示分だけ 1 ページが `limit` 未満になり frontend が「もう無い」と誤判定、(2) followers 判定が note ごとの `followingRepo.Exists` で N+1 だった。

## 主な変更点

- `repository.ListRenotesOf` / `ListRepliesOf` / `ListChildrenOf` に `viewerID` を追加し、共通 helper `applyViewerVisibility` (#1454) で **CanSeeNote 完全版 (specified 込み)** を LIMIT 前に push-down。
  - スレッドの reply/renote は viewer が `visibleUserIds` 対象なら specified note も見えるため、timeline 系の specified 除外版は流用しない。`viewerID=""` は匿名 (public/home のみ)。
  - `ListChildrenOf` の base 条件 `(replyId = ? OR renoteId = ?)` を**明示的に括弧で囲む**。括弧が無いと visibility の AND が renote 側だけに係り reply が漏れる。
- `QueryService.ListRenotes` / `ListReplies` / `ListChildren` の post-fetch `filterVisible` を撤去し `viewerIDOf(viewer)` を渡す。親 note の `requireVisible` ゲートは維持。`filterVisible` / `FilterVisible` 自体は BulkShow 等が使うため残す。
- federation `handleUndoAnnounce` は `announcer.ID` を `viewerID` に渡す: self-branch で announcer 自身の renote は visibility を問わず全件見えるため、`n.UserID == announcer.ID` で残す対象行は従来どおり取得でき挙動不変。
- mock / fake の signature 追従。

`applyViewerVisibility` は除去した `CanSeeNote`/`filterVisible` と branch 単位で意味的に等価 (public/home→全員、followers→author+follower、specified→author+visibleUserIds、anonymous→public/home のみ) なので、結果集合は under-fill 修正を除いて不変。

## テスト

- `repository` 統合テスト (`TestNoteRepository_List{Replies,Renotes,Children}Of_VisibilityPushDown`): anonymous / 非フォロワー / フォロワー / specified-target / author の絞り込みを実 SQL で固定。
  - **under-fill 回帰**: 非表示 note を新しい側に寄せ、`limit=2` の anonymous で visible 2 件がきっちり返る (旧 fetch-then-filter なら 0 件) ことを固定。
  - **OR 括弧リーク回帰**: `ListChildrenOf` で followers reply が非フォロワーに漏れないことを固定。
- `core/note` の delegation テスト (`TestQueryService_ListReplies_VisibilityDelegatedToRepo`): viewerID 伝播 + push-down 委譲を固定。
- ローカル: `make fmt` / `make lint` / `go build ./...` clean。`internal/repository` (実 PostgreSQL) / `internal/core/note` / `internal/core/federation` / `internal/api/notes` 全て pass。

## スコープ外

- `notes/conversation` は祖先チェーンを `CanSeeNote` で walk する別形 (limit-then-filter ではない) なので本 issue では扱わない。

Closes #1500