### PR TITLE
test(visibility): mock parity + handler-layer regression + safehttp env-skip (#1504)

### DIFF
--- a/internal/api/notes/handler_extra_test.go
+++ b/internal/api/notes/handler_extra_test.go
@@ -201,9 +201,12 @@ func TestFeatured_Success(t *testing.T) {
 	noteRepo.Notes["n1"] = &model.Note{ID: "n1", UserID: "u1", Visibility: "public", User: &model.User{ID: "u1"}}
 	rec := postExtra(h.Featured, `{}`, nil)
 	assert.Equal(t, http.StatusOK, rec.Code)
-	var resp []any
+	var resp []map[string]any
 	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
-	assert.NotEmpty(t, resp)
+	// #1491 audit 指摘 6: NotEmpty だけだと body が `null` / 空配列 / shape
+	// 違いの fail-open regression を取り逃す。seeded id がそのまま返ることを fix。
+	require.Len(t, resp, 1)
+	assert.Equal(t, "n1", resp[0]["id"])
 }
 
 func TestFeatured_InvalidJSON(t *testing.T) {
@@ -256,9 +259,16 @@ func TestUnrenote_InvalidParam(t *testing.T) {
 
 func TestMentions_Success(t *testing.T) {
 	h, noteRepo, _ := newExtraHandler(t)
-	noteRepo.Notes["n1"] = &model.Note{ID: "n1", UserID: "u2", Mentions: []string{"u1"}, User: &model.User{ID: "u2"}}
+	noteRepo.Notes["n1"] = &model.Note{ID: "n1", UserID: "u2", Visibility: "public", Mentions: []string{"u1"}, User: &model.User{ID: "u2"}}
 	rec := postExtra(h.Mentions, `{}`, &model.User{ID: "u1"})
-	assert.Equal(t, http.StatusOK, rec.Code)
+	require.Equal(t, http.StatusOK, rec.Code)
+	// #1491 audit 指摘 6: 旧 test は status のみで body 未検証。seeded id が
+	// 返ることを fix し、push-down 経路 (#1441 / #1484) の under-fill / 空 body
+	// regression を取れるようにする。
+	var resp []map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+	require.Len(t, resp, 1)
+	assert.Equal(t, "n1", resp[0]["id"])
 }
 
 func TestMentions_InvalidJSON(t *testing.T) {
@@ -360,12 +370,21 @@ func TestUserListTimeline_Success(t *testing.T) {
 	listRepo := testutil.NewMockUserListRepository()
 	listRepo.Lists["l1"] = &model.UserList{ID: "l1", UserID: "u1", Name: "my list"}
 	h.SetUserListRepo(listRepo)
-	// リストメンバーのノートを用意
+	// リストメンバーのノートを用意 + mock ListByUserList の membership map を seed
+	// (#1491 audit 指摘 1 で mock parity を持たせたので、membership 経由で
+	// filter される。これが無いと mock は空を返し、本 test の body assert が
+	// 落ちる)。
 	noteRepo.Notes["n1"] = &model.Note{ID: "n1", UserID: "member1", Visibility: "public", User: &model.User{ID: "member1"}}
+	noteRepo.UserListMembers["l1"] = []*model.UserListMembership{{UserListID: "l1", UserID: "member1"}}
+
 	rec := postExtra(h.UserListTimeline, `{"listId":"l1"}`, &model.User{ID: "u1"})
-	assert.Equal(t, http.StatusOK, rec.Code)
-	var resp []any
+	require.Equal(t, http.StatusOK, rec.Code)
+	// #1491 audit 指摘 6: body shape / id を明示 fix。push-down で空 / 別 id を
+	// 返すような regression を取り漏らさないようにする。
+	var resp []map[string]any
 	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+	require.Len(t, resp, 1)
+	assert.Equal(t, "n1", resp[0]["id"])
 }
 
 func TestUserListTimeline_NotOwner(t *testing.T) {
@@ -435,7 +454,10 @@ func TestUserListTimeline_PassesFilterToRepo(t *testing.T) {
 	h := NewHandler(noteRepo, corenote.NewCreateService(noteRepo, pollRepo, idGen, nil), corenote.NewDeleteService(noteRepo), querySvc, nil, nil, nil, nil, idGen)
 	h.SetUserListRepo(listRepo)
 
-	rec := postExtra(h.UserListTimeline, `{"listId":"l1","withRenotes":false,"withFiles":true}`, &model.User{ID: "A"})
+	rec := postExtra(h.UserListTimeline,
+		`{"listId":"l1","withRenotes":false,"withFiles":true,`+
+			`"includeMyRenotes":false,"includeRenotedMyNotes":false,"includeLocalRenotes":false}`,
+		&model.User{ID: "A"})
 	require.Equal(t, http.StatusOK, rec.Code)
 	var out []map[string]any
 	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &out))
@@ -445,6 +467,16 @@ func TestUserListTimeline_PassesFilterToRepo(t *testing.T) {
 	require.NotNil(t, noteRepo.gotFilter.WithRenotes)
 	assert.False(t, *noteRepo.gotFilter.WithRenotes, "withRenotes=false が filter に渡る")
 	assert.True(t, noteRepo.gotFilter.WithFiles, "withFiles=true が filter に渡る")
+	// #1504 audit follow-up: Include*Renotes も applyTimelineFilter 経路で
+	// 効くため、handler が forward しているかを fix。1 つでも落ちると
+	// user-list-timeline で pure-renote 関連の filter が silently 効かなく
+	// なる回帰になる。
+	require.NotNil(t, noteRepo.gotFilter.IncludeMyRenotes)
+	assert.False(t, *noteRepo.gotFilter.IncludeMyRenotes, "includeMyRenotes=false が filter に渡る")
+	require.NotNil(t, noteRepo.gotFilter.IncludeRenotedMyNotes)
+	assert.False(t, *noteRepo.gotFilter.IncludeRenotedMyNotes, "includeRenotedMyNotes=false が filter に渡る")
+	require.NotNil(t, noteRepo.gotFilter.IncludeLocalRenotes)
+	assert.False(t, *noteRepo.gotFilter.IncludeLocalRenotes, "includeLocalRenotes=false が filter に渡る")
 	// post-fetch filter は無いので repo の返り値がそのまま返る。
 	require.Len(t, out, 1)
 	assert.Equal(t, "ul_pub", out[0]["id"])
@@ -476,7 +508,12 @@ func TestSearchByTag_Success(t *testing.T) {
 	h, noteRepo, _ := newExtraHandler(t)
 	noteRepo.Notes["n1"] = &model.Note{ID: "n1", UserID: "u1", Tags: []string{"golang"}, Visibility: "public", User: &model.User{ID: "u1"}}
 	rec := postExtra(h.SearchByTag, `{"tag":"golang"}`, nil)
-	assert.Equal(t, http.StatusOK, rec.Code)
+	require.Equal(t, http.StatusOK, rec.Code)
+	// #1491 audit 指摘 6: status 200 だけでは body=null / 別 id を取り損ねる。
+	var resp []map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+	require.Len(t, resp, 1)
+	assert.Equal(t, "n1", resp[0]["id"])
 }
 
 func TestSearchByTag_InvalidParam(t *testing.T) {
@@ -490,7 +527,14 @@ func TestSearchByTag_QueryArray(t *testing.T) {
 	noteRepo.Notes["n1"] = &model.Note{ID: "n1", UserID: "u1", Tags: []string{"go"}, Visibility: "public", User: &model.User{ID: "u1"}}
 	// query の最初の要素がタグとして使われる
 	rec := postExtra(h.SearchByTag, `{"query":[["go","rust"],["web"]]}`, nil)
-	assert.Equal(t, http.StatusOK, rec.Code)
+	require.Equal(t, http.StatusOK, rec.Code)
+	// #1491 audit 指摘 6: query 配列 parse の正しさを id 識別で fix。
+	// 旧 test は status のみ確認していて、tag が "rust"/"web" 等にズレても通って
+	// しまっていた。
+	var resp []map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+	require.Len(t, resp, 1)
+	assert.Equal(t, "n1", resp[0]["id"])
 }
 
 func TestSearchByTag_QueryArrayEmpty(t *testing.T) {

--- a/internal/api/notes/handler_query_test.go
+++ b/internal/api/notes/handler_query_test.go
@@ -151,6 +151,158 @@ func TestChildren_LimitClamping(t *testing.T) {
 	assert.Equal(t, http.StatusOK, rec.Code)
 }
 
+// #1500 audit follow-up: notes/renotes・replies・children の visibility は repo
+// (mock) の push-down delegation に委ねており、handler 自体は viewerID を渡す
+// だけ。followers child が「非フォロワーには見えず、follower には見える」ことを
+// handler 経由で fix することで、handler が viewerIDOf(viewer) を落とした
+// 場合に検出できる (#1491 audit 指摘 4)。
+//
+// ヘルパー: followers visibility の child note を seed (User も付ける)。
+func seedFollowersChild(repo *testutil.MockNoteRepository, id, parentID string, isReply bool) *model.Note {
+	pid := parentID
+	n := &model.Note{
+		ID:         id,
+		UserID:     "fol_author",
+		Visibility: model.NoteVisibilityFollowers,
+		Reactions:  datatypes.JSON([]byte("{}")),
+	}
+	if isReply {
+		n.ReplyID = &pid
+	} else {
+		n.RenoteID = &pid
+	}
+	n.User = &model.User{
+		ID:                "fol_author",
+		Username:          "folauthor",
+		AvatarDecorations: datatypes.JSON([]byte("[]")),
+	}
+	repo.Notes[id] = n
+	return n
+}
+
+func TestRenotes_FollowersChildHiddenFromNonFollower(t *testing.T) {
+	h, repo := newQueryHandler(t)
+	seedPublicNote(repo, "parent")
+	pub := seedPublicNote(repo, "pub_r")
+	pid := "parent"
+	pub.RenoteID = &pid
+	seedFollowersChild(repo, "fol_r", "parent", false)
+
+	// 非フォロワー viewer は public renote のみ。
+	c, rec := newJSONRequest(t, "/api/notes/renotes", `{"noteId":"parent"}`)
+	setAuthUser(c, &model.User{ID: "viewer"})
+	require.NoError(t, h.Renotes(c))
+	require.Equal(t, http.StatusOK, rec.Code)
+	var resp []map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+	require.Len(t, resp, 1)
+	assert.Equal(t, "pub_r", resp[0]["id"], "非フォロワーには followers renote が見えない")
+}
+
+func TestRenotes_FollowersChildVisibleToFollower(t *testing.T) {
+	h, repo := newQueryHandler(t)
+	seedPublicNote(repo, "parent")
+	pub := seedPublicNote(repo, "pub_r")
+	pid := "parent"
+	pub.RenoteID = &pid
+	seedFollowersChild(repo, "fol_r", "parent", false)
+	repo.Following = map[string][]string{"viewer": {"fol_author"}}
+
+	c, rec := newJSONRequest(t, "/api/notes/renotes", `{"noteId":"parent"}`)
+	setAuthUser(c, &model.User{ID: "viewer"})
+	require.NoError(t, h.Renotes(c))
+	require.Equal(t, http.StatusOK, rec.Code)
+	var resp []map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+	assert.Len(t, resp, 2, "follow すると followers renote も見える")
+}
+
+func TestReplies_FollowersChildHiddenFromAnonymous(t *testing.T) {
+	h, repo := newQueryHandler(t)
+	seedPublicNote(repo, "p")
+	pub := seedPublicNote(repo, "pub_re")
+	pid := "p"
+	pub.ReplyID = &pid
+	seedFollowersChild(repo, "fol_re", "p", true)
+
+	// auth user 未 set = anonymous → handler は viewerID=""
+	c, rec := newJSONRequest(t, "/api/notes/replies", `{"noteId":"p"}`)
+	require.NoError(t, h.Replies(c))
+	require.Equal(t, http.StatusOK, rec.Code)
+	var resp []map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+	require.Len(t, resp, 1)
+	assert.Equal(t, "pub_re", resp[0]["id"], "anonymous には followers reply が見えない")
+}
+
+func TestReplies_FollowersChildVisibleToFollower(t *testing.T) {
+	h, repo := newQueryHandler(t)
+	seedPublicNote(repo, "p")
+	pub := seedPublicNote(repo, "pub_re")
+	pid := "p"
+	pub.ReplyID = &pid
+	seedFollowersChild(repo, "fol_re", "p", true)
+	repo.Following = map[string][]string{"viewer": {"fol_author"}}
+
+	c, rec := newJSONRequest(t, "/api/notes/replies", `{"noteId":"p"}`)
+	setAuthUser(c, &model.User{ID: "viewer"})
+	require.NoError(t, h.Replies(c))
+	require.Equal(t, http.StatusOK, rec.Code)
+	var resp []map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+	assert.Len(t, resp, 2)
+}
+
+func TestChildren_FollowersChildHiddenFromNonFollower(t *testing.T) {
+	h, repo := newQueryHandler(t)
+	seedPublicNote(repo, "p")
+	// 1 件は public reply、1 件は public quote renote、1 件は followers reply、1 件は followers quote renote。
+	pub_re := seedPublicNote(repo, "pub_re")
+	pid := "p"
+	pub_re.ReplyID = &pid
+	pub_q := seedPublicNote(repo, "pub_q")
+	pub_q.RenoteID = &pid
+	seedFollowersChild(repo, "fol_re", "p", true)
+	seedFollowersChild(repo, "fol_q", "p", false)
+
+	c, rec := newJSONRequest(t, "/api/notes/children", `{"noteId":"p","limit":50}`)
+	setAuthUser(c, &model.User{ID: "viewer"})
+	require.NoError(t, h.Children(c))
+	require.Equal(t, http.StatusOK, rec.Code)
+	var resp []map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+	require.Len(t, resp, 2, "非フォロワーは public 2 件のみ")
+	idsSet := map[string]bool{}
+	for _, r := range resp {
+		idsSet[r["id"].(string)] = true
+	}
+	assert.True(t, idsSet["pub_re"])
+	assert.True(t, idsSet["pub_q"])
+	assert.False(t, idsSet["fol_re"], "followers reply は非フォロワーに漏れない")
+	assert.False(t, idsSet["fol_q"], "followers quote renote も非フォロワーに漏れない")
+}
+
+func TestChildren_FollowersChildVisibleToFollower(t *testing.T) {
+	h, repo := newQueryHandler(t)
+	seedPublicNote(repo, "p")
+	pub_re := seedPublicNote(repo, "pub_re")
+	pid := "p"
+	pub_re.ReplyID = &pid
+	pub_q := seedPublicNote(repo, "pub_q")
+	pub_q.RenoteID = &pid
+	seedFollowersChild(repo, "fol_re", "p", true)
+	seedFollowersChild(repo, "fol_q", "p", false)
+	repo.Following = map[string][]string{"viewer": {"fol_author"}}
+
+	c, rec := newJSONRequest(t, "/api/notes/children", `{"noteId":"p","limit":50}`)
+	setAuthUser(c, &model.User{ID: "viewer"})
+	require.NoError(t, h.Children(c))
+	require.Equal(t, http.StatusOK, rec.Code)
+	var resp []map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+	assert.Len(t, resp, 4, "follow すると followers reply + followers quote renote も見える")
+}
+
 func TestSearch_OK(t *testing.T) {
 	h, repo := newQueryHandler(t)
 	hello := "Hello world"

--- a/internal/api/users/handler_extra_test.go
+++ b/internal/api/users/handler_extra_test.go
@@ -3,6 +3,7 @@ package users_test
 import (
 	"encoding/json"
 	"errors"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -454,6 +455,45 @@ func TestFeaturedNotes_UntilIDPaginatesByIDDesc(t *testing.T) {
 	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &out))
 	require.Len(t, out, 1)
 	assert.Equal(t, "fn_x1", out[0]["id"])
+}
+
+// #1491 audit 指摘: TestFeaturedNotes_* は 3-10 件の fixture しか使っておらず、
+// mock 側の pool cap (mockFeaturedNotesPerUserPoolSize=50) を踏まない。51 件
+// fixture で「engagement=0 最大id の note は pool 外に落ちて display に現れず、
+// engagement=10 の 50 件のみ id DESC で返る」ことを mock 経由でも fix する。
+// repo 側の TestNoteRepository_ListFeaturedByUser_EngagementPoolCap の handler
+// レイヤー版で、mock の pool cap が silently 別値になった瞬間に落ちる。
+func TestFeaturedNotes_EngagementPoolCap_DropsLowEngagementBelow50(t *testing.T) {
+	h, _, noteRepo := newExtraHandler(t)
+	h.SetFollowingRepo(testutil.NewMockFollowingRepository())
+
+	// engagement=10 を 50 件 (id: fn_cap_pool_01 .. fn_cap_pool_50)。
+	for i := 1; i <= 50; i++ {
+		id := fmt.Sprintf("fn_cap_pool_%02d", i)
+		noteRepo.Notes[id] = &model.Note{
+			ID: id, UserID: "u1", Visibility: "public", RenoteCount: 10, User: &model.User{ID: "u1"},
+		}
+	}
+	// engagement=0 + 最大 id (lex order で全 pool note より後ろ)。
+	const lowID = "fn_cap_zzz_low"
+	noteRepo.Notes[lowID] = &model.Note{
+		ID: lowID, UserID: "u1", Visibility: "public", RenoteCount: 0, User: &model.User{ID: "u1"},
+	}
+
+	rec := postExtra(h.FeaturedNotes, `{"userId":"u1","limit":100}`, nil)
+	require.Equal(t, http.StatusOK, rec.Code)
+	var out []map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &out))
+	require.Len(t, out, 50, "mock pool cap=50 が踏まれて 50 件に絞られる")
+	for _, n := range out {
+		gotID := n["id"].(string)
+		assert.NotEqual(t, lowID, gotID, "engagement 最下位 (=0) は pool 外に落ちる")
+		assert.True(t, strings.HasPrefix(gotID, "fn_cap_pool_"),
+			"engagement DESC 上位 50 件 (fn_cap_pool_*) のみが選抜される")
+	}
+	// display は id DESC: fn_cap_pool_50 が先頭、fn_cap_pool_01 が末尾。
+	assert.Equal(t, "fn_cap_pool_50", out[0]["id"])
+	assert.Equal(t, "fn_cap_pool_01", out[49]["id"])
 }
 
 // #1487: post-fetch FilterVisible → SQL push-down に変更されたことで、limit に

--- a/internal/core/note/note_query_service_test.go
+++ b/internal/core/note/note_query_service_test.go
@@ -174,6 +174,55 @@ func TestQueryService_ListReplies_VisibilityDelegatedToRepo(t *testing.T) {
 	assert.Len(t, out, 2)
 }
 
+// #1500 audit follow-up: ListRenotes も同じ doctrine (push-down delegation +
+// viewerID 伝播) なので symmetric な regression test を置く (#1491 audit 指摘 3)。
+//
+// 注意: 本 test が直接捕捉できるのは「QueryService が viewerID を repo に
+// 渡し忘れて空文字で叩いた」regression のみ。「post-fetch FilterVisible が
+// 復活した」regression は、mock がすでに同じ条件で pre-filter している関係上
+// 同じ結果セットになって検出できない (#1504 adversarial review 指摘)。
+// それでも viewerID 伝播の固定として意味があるので残す。
+func TestQueryService_ListRenotes_VisibilityDelegatedToRepo(t *testing.T) {
+	svc, noteRepo, _ := newQueryService(t)
+	noteRepo.Notes["parent"] = &model.Note{ID: "parent", UserID: "a", Visibility: model.NoteVisibilityPublic}
+	parentID := "parent"
+	noteRepo.Notes["pub"] = &model.Note{ID: "pub", UserID: "a", Visibility: model.NoteVisibilityPublic, RenoteID: &parentID}
+	noteRepo.Notes["fol"] = &model.Note{ID: "fol", UserID: "a", Visibility: model.NoteVisibilityFollowers, RenoteID: &parentID}
+
+	viewer := &model.User{ID: "v"}
+	out, err := svc.ListRenotes(viewer, "parent", "", "", 10)
+	require.NoError(t, err)
+	require.Len(t, out, 1)
+	assert.Equal(t, "pub", out[0].ID, "非フォロワーには followers renote が見えない (push-down 委譲)")
+
+	noteRepo.Following = map[string][]string{"v": {"a"}}
+	out, err = svc.ListRenotes(viewer, "parent", "", "", 10)
+	require.NoError(t, err)
+	assert.Len(t, out, 2, "follow すると followers renote も返る (viewerID 伝播)")
+}
+
+// ListChildren も同じ doctrine。children は reply + quote renote の合算なので
+// followers reply / followers renote 両方の visibility delegation を覆う。
+func TestQueryService_ListChildren_VisibilityDelegatedToRepo(t *testing.T) {
+	svc, noteRepo, _ := newQueryService(t)
+	noteRepo.Notes["parent"] = &model.Note{ID: "parent", UserID: "a", Visibility: model.NoteVisibilityPublic}
+	parentID := "parent"
+	noteRepo.Notes["pub_reply"] = &model.Note{ID: "pub_reply", UserID: "a", Visibility: model.NoteVisibilityPublic, ReplyID: &parentID}
+	noteRepo.Notes["fol_reply"] = &model.Note{ID: "fol_reply", UserID: "a", Visibility: model.NoteVisibilityFollowers, ReplyID: &parentID}
+	noteRepo.Notes["fol_quote"] = &model.Note{ID: "fol_quote", UserID: "a", Visibility: model.NoteVisibilityFollowers, RenoteID: &parentID}
+
+	viewer := &model.User{ID: "v"}
+	out, err := svc.ListChildren(viewer, "parent", "", "", 10)
+	require.NoError(t, err)
+	require.Len(t, out, 1, "非フォロワーには followers reply/quote が見えない")
+	assert.Equal(t, "pub_reply", out[0].ID)
+
+	noteRepo.Following = map[string][]string{"v": {"a"}}
+	out, err = svc.ListChildren(viewer, "parent", "", "", 10)
+	require.NoError(t, err)
+	assert.Len(t, out, 3, "follow すると followers reply + followers quote も返る")
+}
+
 func TestQueryService_Conversation_Empty(t *testing.T) {
 	svc, noteRepo, _ := newQueryService(t)
 	noteRepo.Notes["root"] = &model.Note{ID: "root", UserID: "a", Visibility: model.NoteVisibilityPublic}

--- a/internal/repository/note.go
+++ b/internal/repository/note.go
@@ -16,11 +16,15 @@ import (
 // 変換に使うため独自に定義する。
 const aidxTime2000Ms int64 = 946684800000
 
-// featuredNotesPerUserPoolSize は users/featured-notes の selection 段で
+// FeaturedNotesPerUserPoolSize は users/featured-notes の selection 段で
 // engagement DESC top-N を SQL から取得する際の上限。upstream
 // FeaturedService.getPerUserNotesRanking の threshold (50) と揃える (#1487 / #1491)。
 // 選抜後は id DESC + untilID cursor + limit でページングする。
-const featuredNotesPerUserPoolSize = 50
+//
+// テスト用 mock (internal/testutil/mock_repository.go の ListFeaturedByUser) も
+// この定数を直接参照することで mock と real repo の pool cap が drift しない
+// ことを保証する (#1491 review B 指摘の二重定義解消)。
+const FeaturedNotesPerUserPoolSize = 50
 
 // aidxCutoffID は与えられた time に対応する最小のaidx ID文字列を返す。
 // aidxは「時刻base36(8) + nodeID(4) + counter(4)」の 16 文字で、先頭 8 文字が
@@ -110,7 +114,7 @@ type NoteRepository interface {
 	// する 2 段構成。mk-go も同じ 2 段で揃える (#1487 Option B):
 	//
 	//  1. selection: engagement = (renoteCount + repliesCount) DESC, id DESC で
-	//     featuredNotesPerUserPoolSize (=50, upstream 同値) 件を SQL push-down で
+	//     FeaturedNotesPerUserPoolSize (=50, upstream 同値) 件を SQL push-down で
 	//     選抜。visibility 条件と channel 除外もここで同時に絞る (LIMIT 前)。
 	//     post-fetch FilterVisible だとページ過少充填 + followers 判定 N+1 を
 	//     起こすため (#1418 / #1440 と同 doctrine)。
@@ -685,7 +689,7 @@ func (r *noteRepository) ListFeaturedByUser(userID, viewerID, untilID string, li
 		Where(`"userId" = ?`, userID).
 		Where(`"channelId" IS NULL`)
 	q = applyViewerVisibility(q, viewerID)
-	q = q.Order(`("renoteCount" + "repliesCount") DESC, id DESC`).Limit(featuredNotesPerUserPoolSize)
+	q = q.Order(`("renoteCount" + "repliesCount") DESC, id DESC`).Limit(FeaturedNotesPerUserPoolSize)
 	var pool []*model.Note
 	if err := q.Find(&pool).Error; err != nil {
 		return nil, err

--- a/internal/repository/note_test.go
+++ b/internal/repository/note_test.go
@@ -1383,7 +1383,7 @@ func TestNoteRepository_ListFeaturedByUser(t *testing.T) {
 // engagement=10 の note (id prefix `feat_cap_pool_`) であることを断定する。
 //
 // 6 件以下の小規模 fixture では pool = 全件となり、選抜順序が engagement 順
-// でも id 順でも結果が変わらないため、`featuredNotesPerUserPoolSize` を 51 に
+// でも id 順でも結果が変わらないため、`FeaturedNotesPerUserPoolSize` を 51 に
 // すれば落ちる test がここまで存在しなかった。本 test は cap を取り除くと
 // 必ず落ちる強い regression gate になる。
 func TestNoteRepository_ListFeaturedByUser_EngagementPoolCap(t *testing.T) {

--- a/internal/safehttp/ssrf_test.go
+++ b/internal/safehttp/ssrf_test.go
@@ -344,6 +344,20 @@ func TestNewSSRFSafeTransport_AddressFamilyIPv6FiltersOutIPv4(t *testing.T) {
 }
 
 func TestNewSSRFSafeTransport_IPv6ProxyDefaultPort(t *testing.T) {
+	// #486 regression は「`http://[::1]` (= port 80 default) を proxy URL に
+	// 指定したとき SSRF guard が `[[::1]]:80` と二重 bracket せず正しく
+	// `[::1]:80` で比較できる」ことを「dial が SSRF block 以外のエラーで
+	// 失敗する」観測経由で覆う。原作者コメント (fef6210e) のとおり「dial 自体は
+	// ループバック上の閉じた port なので connection refused 系のエラーになる」
+	// 前提に依存しているため、開発機で [::]:80 に nginx 等が listen していると
+	// dial が成功して err=nil になり require.Error が trip する。
+	// CI runner は port 80 に何も listen していないので無条件に通る。
+	// 開発機向けの fail-safe として probe を入れ、listener 検出時は skip する。
+	if conn, perr := net.DialTimeout("tcp6", "[::1]:80", 200*time.Millisecond); perr == nil {
+		_ = conn.Close()
+		t.Skip("something is listening on [::1]:80 (e.g. local nginx); cannot observe #486 regression via dial-fail branch")
+	}
+
 	tr := NewSSRFSafeTransport(nil, WithProxy("http://[::1]", nil))
 	require.NotNil(t, tr)
 	require.NotNil(t, tr.Proxy)

--- a/internal/stream/channels/new_channels_test.go
+++ b/internal/stream/channels/new_channels_test.go
@@ -265,6 +265,33 @@ func TestUserList_BrokenPayload_Dropped(t *testing.T) {
 	assert.Empty(t, ctx.sentType)
 }
 
+// #1491 audit 指摘 5: userListVisibilityShouldEmit は visibility == "followers"
+// 以外の payload を素通りする (user_list.go:112)。コメントには「specified は
+// fanout (shouldFanoutToFollowers) で除外されるからここに来ない」と書いてある
+// が、その assumption は untested。fanout 側の refactor がうっかり specified
+// payload を user_list stream へ送り始めた瞬間に WS gate も passthrough して
+// しまうので、その日の defense-in-depth がどう動くかを test で確定させておく。
+//
+// 現実装は specified payload を非宛先 viewer にも emit する (passthrough)。
+// この test が落ちる条件 = ゲートが visibility 別 path を追加して specified を
+// 個別に判定するようになったとき、そのときは併せて fanout 側のテスト
+// (TestFanoutHook_FanoutToUserLists_SpecifiedVisibilitySkipped) を見直すべき。
+func TestUserList_SpecifiedVisibility_AssumesFanoutSkips(t *testing.T) {
+	ctx := newCtx(&model.User{ID: "alice"})
+	ch := NewUserList(ctx)
+	ch.Init(json.RawMessage(`{"listId":"l1"}`))
+
+	// alice 宛ではない specified payload。fanout 側で normally この shape は
+	// user_list stream に流れない (= shouldFanoutToFollowers で specified が
+	// 除外される) が、もし流れた場合 WS gate は passthrough する現状動作。
+	ch.OnRedisEvent([]byte(`{"id":"n1","userId":"author","visibility":"specified","visibleUserIds":["other"]}`))
+	require.Len(t, ctx.sentType, 1,
+		"現状の userListVisibilityShouldEmit は specified payload を passthrough する "+
+			"(fanout 側 shouldFanoutToFollowers が specified を弾く前提)。fanout の "+
+			"assumption が崩れた瞬間に WS leak になるので、本 test を grep して "+
+			"両層をセットで見直すこと。")
+}
+
 // --- RoleTimeline ---
 
 func TestRoleTimeline_Lifecycle(t *testing.T) {

--- a/internal/testutil/featured_pool_size_test.go
+++ b/internal/testutil/featured_pool_size_test.go
@@ -1,0 +1,29 @@
+package testutil
+
+import (
+	"testing"
+
+	"github.com/shiroha-a/mk/internal/repository"
+)
+
+// TestFeaturedPoolSizeMatchesRepo は #1491 review B 指摘の drift 検出。
+// mockFeaturedNotesPerUserPoolSize と repository.FeaturedNotesPerUserPoolSize
+// は users/featured-notes の selection 段 pool cap として同値でなければ
+// ならない。production code から repository を import すると repository の
+// test build を介して import cycle になるため (mock_chat_test.go と同じ
+// pattern)、_test.go で runtime に等価性を確認する。
+//
+// 一方を変更してもう一方を見落とした PR がここで落ちる。CI が走る
+// internal/testutil パッケージのテストとして実行されるので、CI で必ず検出。
+func TestFeaturedPoolSizeMatchesRepo(t *testing.T) {
+	if mockFeaturedNotesPerUserPoolSize != repository.FeaturedNotesPerUserPoolSize {
+		t.Fatalf(
+			"pool size drift: mockFeaturedNotesPerUserPoolSize=%d != repository.FeaturedNotesPerUserPoolSize=%d. "+
+				"両者は users/featured-notes の selection 段 pool cap として同値でなければならない。"+
+				"一方だけ変更すると handler 層の TestFeaturedNotes_* が mock 経由で pass する一方、"+
+				"実 SQL の挙動と乖離する (#1491 review)。",
+			mockFeaturedNotesPerUserPoolSize,
+			repository.FeaturedNotesPerUserPoolSize,
+		)
+	}
+}

--- a/internal/testutil/mock_list_by_user_list_test.go
+++ b/internal/testutil/mock_list_by_user_list_test.go
@@ -1,0 +1,344 @@
+package testutil
+
+import (
+	"testing"
+
+	"github.com/shiroha-a/mk/internal/model"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// helper: 文字列ポインタ
+func sp(v string) *string { return &v }
+
+// helper: bool ポインタ (TimelineDBFilter.WithRenotes に渡す)
+func bp(v bool) *bool { return &v }
+
+// helper: list 化された ID 集合を返す
+func ids(notes []*model.Note) []string {
+	out := make([]string, 0, len(notes))
+	for _, n := range notes {
+		out = append(out, n.ID)
+	}
+	return out
+}
+
+// MockNoteRepository.ListByUserList が real repo の SQL push-down と同
+// semantics を持つことを確認する parity test (#1491 audit 指摘 1)。
+// 旧 stub は (nil, nil) を返すだけで、real SQL の挙動 (#1452 visibility /
+// #1496 withReplies / #1498 withRenotes / WithFiles) を全く模擬していなかった。
+
+func TestMockListByUserList_NonMemberDropped(t *testing.T) {
+	m := NewMockNoteRepository()
+	m.UserListMembers["l1"] = []*model.UserListMembership{
+		{UserListID: "l1", UserID: "alice"},
+	}
+	m.Notes["n_alice"] = &model.Note{ID: "n_alice", UserID: "alice", Visibility: model.NoteVisibilityPublic}
+	m.Notes["n_bob"] = &model.Note{ID: "n_bob", UserID: "bob", Visibility: model.NoteVisibilityPublic}
+
+	got, err := m.ListByUserList("l1", 10, "", "", model.TimelineDBFilter{ViewerID: "viewer"})
+	require.NoError(t, err)
+	assert.Equal(t, []string{"n_alice"}, ids(got))
+}
+
+func TestMockListByUserList_ChannelExcluded(t *testing.T) {
+	m := NewMockNoteRepository()
+	m.UserListMembers["l1"] = []*model.UserListMembership{{UserListID: "l1", UserID: "alice"}}
+	m.Notes["n_pub"] = &model.Note{ID: "n_pub", UserID: "alice", Visibility: model.NoteVisibilityPublic}
+	m.Notes["n_ch"] = &model.Note{ID: "n_ch", UserID: "alice", Visibility: model.NoteVisibilityPublic, ChannelID: sp("c1")}
+
+	got, err := m.ListByUserList("l1", 10, "", "", model.TimelineDBFilter{ViewerID: "viewer"})
+	require.NoError(t, err)
+	assert.Equal(t, []string{"n_pub"}, ids(got))
+}
+
+func TestMockListByUserList_FollowersVisibility_NonFollowerDropped(t *testing.T) {
+	m := NewMockNoteRepository()
+	m.UserListMembers["l1"] = []*model.UserListMembership{{UserListID: "l1", UserID: "alice"}}
+	// viewer は alice を follow していない (Following 未 seed)。
+	m.Notes["n_fol"] = &model.Note{ID: "n_fol", UserID: "alice", Visibility: model.NoteVisibilityFollowers}
+
+	got, err := m.ListByUserList("l1", 10, "", "", model.TimelineDBFilter{ViewerID: "viewer"})
+	require.NoError(t, err)
+	assert.Empty(t, ids(got))
+}
+
+func TestMockListByUserList_FollowersVisibility_FollowerSees(t *testing.T) {
+	m := NewMockNoteRepository()
+	m.UserListMembers["l1"] = []*model.UserListMembership{{UserListID: "l1", UserID: "alice"}}
+	m.Following["viewer"] = []string{"alice"}
+	m.Notes["n_fol"] = &model.Note{ID: "n_fol", UserID: "alice", Visibility: model.NoteVisibilityFollowers}
+
+	got, err := m.ListByUserList("l1", 10, "", "", model.TimelineDBFilter{ViewerID: "viewer"})
+	require.NoError(t, err)
+	assert.Equal(t, []string{"n_fol"}, ids(got))
+}
+
+func TestMockListByUserList_FollowersVisibility_SelfAuthor(t *testing.T) {
+	m := NewMockNoteRepository()
+	m.UserListMembers["l1"] = []*model.UserListMembership{{UserListID: "l1", UserID: "alice"}}
+	// viewer = author = alice。Following 無くても本人は閲覧可。
+	m.Notes["n_fol"] = &model.Note{ID: "n_fol", UserID: "alice", Visibility: model.NoteVisibilityFollowers}
+
+	got, err := m.ListByUserList("l1", 10, "", "", model.TimelineDBFilter{ViewerID: "alice"})
+	require.NoError(t, err)
+	assert.Equal(t, []string{"n_fol"}, ids(got))
+}
+
+func TestMockListByUserList_FollowersVisibility_AnonymousDropped(t *testing.T) {
+	m := NewMockNoteRepository()
+	m.UserListMembers["l1"] = []*model.UserListMembership{{UserListID: "l1", UserID: "alice"}}
+	m.Notes["n_fol"] = &model.Note{ID: "n_fol", UserID: "alice", Visibility: model.NoteVisibilityFollowers}
+
+	got, err := m.ListByUserList("l1", 10, "", "", model.TimelineDBFilter{ViewerID: ""})
+	require.NoError(t, err)
+	assert.Empty(t, ids(got))
+}
+
+func TestMockListByUserList_SpecifiedExcluded(t *testing.T) {
+	m := NewMockNoteRepository()
+	m.UserListMembers["l1"] = []*model.UserListMembership{{UserListID: "l1", UserID: "alice"}}
+	// viewer は宛先本人。それでも list timeline は specified (DM) を出さない。
+	m.Notes["n_dm"] = &model.Note{
+		ID: "n_dm", UserID: "alice",
+		Visibility:     model.NoteVisibilitySpecified,
+		VisibleUserIDs: []string{"viewer"},
+	}
+
+	got, err := m.ListByUserList("l1", 10, "", "", model.TimelineDBFilter{ViewerID: "viewer"})
+	require.NoError(t, err)
+	assert.Empty(t, ids(got))
+}
+
+func TestMockListByUserList_Reply_WithRepliesFalse_OnlySelfThreadVisible(t *testing.T) {
+	m := NewMockNoteRepository()
+	// alice は WithReplies=false で list に居る。
+	m.UserListMembers["l1"] = []*model.UserListMembership{
+		{UserListID: "l1", UserID: "alice", WithReplies: false},
+	}
+	m.Notes["n_top"] = &model.Note{ID: "n_top", UserID: "alice", Visibility: model.NoteVisibilityPublic}
+	// alice の self-thread reply は通る。
+	m.Notes["n_self"] = &model.Note{
+		ID: "n_self", UserID: "alice", Visibility: model.NoteVisibilityPublic,
+		ReplyID: sp("n_top"), ReplyUserID: sp("alice"),
+	}
+	// alice → bob (= 第三者) reply は WithReplies=false なので drop。
+	m.Notes["n_other"] = &model.Note{
+		ID: "n_other", UserID: "alice", Visibility: model.NoteVisibilityPublic,
+		ReplyID: sp("n_someone"), ReplyUserID: sp("bob"),
+	}
+
+	got, err := m.ListByUserList("l1", 10, "", "", model.TimelineDBFilter{ViewerID: "viewer"})
+	require.NoError(t, err)
+	gotIDs := ids(got)
+	assert.Contains(t, gotIDs, "n_top")
+	assert.Contains(t, gotIDs, "n_self", "self-thread reply は WithReplies=false でも残る")
+	assert.NotContains(t, gotIDs, "n_other", "第三者宛 reply は WithReplies=false で drop")
+}
+
+func TestMockListByUserList_Reply_ViewerTargetedSurvives(t *testing.T) {
+	m := NewMockNoteRepository()
+	m.UserListMembers["l1"] = []*model.UserListMembership{
+		{UserListID: "l1", UserID: "alice", WithReplies: false},
+	}
+	// alice → viewer reply は viewer 宛なので WithReplies=false でも通る。
+	m.Notes["n_to_me"] = &model.Note{
+		ID: "n_to_me", UserID: "alice", Visibility: model.NoteVisibilityPublic,
+		ReplyID: sp("p"), ReplyUserID: sp("viewer"),
+	}
+
+	got, err := m.ListByUserList("l1", 10, "", "", model.TimelineDBFilter{ViewerID: "viewer"})
+	require.NoError(t, err)
+	assert.Equal(t, []string{"n_to_me"}, ids(got))
+}
+
+func TestMockListByUserList_Reply_WithRepliesTrue_ThirdPartyVisible(t *testing.T) {
+	m := NewMockNoteRepository()
+	m.UserListMembers["l1"] = []*model.UserListMembership{
+		{UserListID: "l1", UserID: "alice", WithReplies: true},
+	}
+	m.Notes["n_3p"] = &model.Note{
+		ID: "n_3p", UserID: "alice", Visibility: model.NoteVisibilityPublic,
+		ReplyID: sp("p"), ReplyUserID: sp("bob"),
+	}
+
+	got, err := m.ListByUserList("l1", 10, "", "", model.TimelineDBFilter{ViewerID: "viewer"})
+	require.NoError(t, err)
+	assert.Equal(t, []string{"n_3p"}, ids(got))
+}
+
+func TestMockListByUserList_WithFilesRequiresAttachment(t *testing.T) {
+	m := NewMockNoteRepository()
+	m.UserListMembers["l1"] = []*model.UserListMembership{{UserListID: "l1", UserID: "alice"}}
+	m.Notes["n_text"] = &model.Note{ID: "n_text", UserID: "alice", Visibility: model.NoteVisibilityPublic}
+	m.Notes["n_file"] = &model.Note{ID: "n_file", UserID: "alice", Visibility: model.NoteVisibilityPublic, FileIDs: []string{"f1"}}
+
+	got, err := m.ListByUserList("l1", 10, "", "", model.TimelineDBFilter{ViewerID: "viewer", WithFiles: true})
+	require.NoError(t, err)
+	assert.Equal(t, []string{"n_file"}, ids(got))
+}
+
+func TestMockListByUserList_WithRenotesFalseExcludesPureRenote(t *testing.T) {
+	m := NewMockNoteRepository()
+	m.UserListMembers["l1"] = []*model.UserListMembership{{UserListID: "l1", UserID: "alice"}}
+	text := "quote text"
+	// pure renote (text=nil, files=空): 除外。
+	m.Notes["n_pure"] = &model.Note{
+		ID: "n_pure", UserID: "alice", Visibility: model.NoteVisibilityPublic,
+		RenoteID: sp("orig1"),
+	}
+	// quote renote (text あり): 通る。
+	m.Notes["n_quote"] = &model.Note{
+		ID: "n_quote", UserID: "alice", Visibility: model.NoteVisibilityPublic,
+		RenoteID: sp("orig2"), Text: &text,
+	}
+	// plain note: 通る。
+	m.Notes["n_plain"] = &model.Note{ID: "n_plain", UserID: "alice", Visibility: model.NoteVisibilityPublic}
+
+	got, err := m.ListByUserList("l1", 10, "", "", model.TimelineDBFilter{
+		ViewerID:    "viewer",
+		WithRenotes: bp(false),
+	})
+	require.NoError(t, err)
+	gotIDs := ids(got)
+	assert.NotContains(t, gotIDs, "n_pure", "pure renote は WithRenotes=false で除外")
+	assert.Contains(t, gotIDs, "n_quote", "quote renote は WithRenotes=false でも残る")
+	assert.Contains(t, gotIDs, "n_plain")
+}
+
+func TestMockListByUserList_PaginationUntilID(t *testing.T) {
+	m := NewMockNoteRepository()
+	m.UserListMembers["l1"] = []*model.UserListMembership{{UserListID: "l1", UserID: "alice"}}
+	for _, id := range []string{"n1", "n2", "n3"} {
+		m.Notes[id] = &model.Note{ID: id, UserID: "alice", Visibility: model.NoteVisibilityPublic}
+	}
+
+	got, err := m.ListByUserList("l1", 10, "", "n3", model.TimelineDBFilter{ViewerID: "viewer"})
+	require.NoError(t, err)
+	assert.Equal(t, []string{"n2", "n1"}, ids(got), "untilID=n3 で id DESC")
+}
+
+func TestMockListByUserList_PaginationSinceID(t *testing.T) {
+	m := NewMockNoteRepository()
+	m.UserListMembers["l1"] = []*model.UserListMembership{{UserListID: "l1", UserID: "alice"}}
+	for _, id := range []string{"n1", "n2", "n3"} {
+		m.Notes[id] = &model.Note{ID: id, UserID: "alice", Visibility: model.NoteVisibilityPublic}
+	}
+
+	got, err := m.ListByUserList("l1", 10, "n1", "", model.TimelineDBFilter{ViewerID: "viewer"})
+	require.NoError(t, err)
+	assert.Equal(t, []string{"n2", "n3"}, ids(got), "sinceID=n1 で id ASC")
+}
+
+func TestMockListByUserList_LimitDefault(t *testing.T) {
+	m := NewMockNoteRepository()
+	m.UserListMembers["l1"] = []*model.UserListMembership{{UserListID: "l1", UserID: "alice"}}
+	for i := 0; i < 15; i++ {
+		id := "n" + string(rune('a'+i))
+		m.Notes[id] = &model.Note{ID: id, UserID: "alice", Visibility: model.NoteVisibilityPublic}
+	}
+
+	got, err := m.ListByUserList("l1", 0, "", "", model.TimelineDBFilter{ViewerID: "viewer"})
+	require.NoError(t, err)
+	assert.Len(t, got, 10, "limit<=0 のデフォルトは 10")
+}
+
+func TestMockListByUserList_EmptyList(t *testing.T) {
+	m := NewMockNoteRepository()
+	m.Notes["n1"] = &model.Note{ID: "n1", UserID: "alice", Visibility: model.NoteVisibilityPublic}
+	// UserListMembers["l1"] 未設定。
+
+	got, err := m.ListByUserList("l1", 10, "", "", model.TimelineDBFilter{ViewerID: "viewer"})
+	require.NoError(t, err)
+	assert.Empty(t, got)
+}
+
+// #1491 review high 指摘: real repo の applyTimelineFilter は
+// IncludeMyRenotes / IncludeRenotedMyNotes / IncludeLocalRenotes を適用するが、
+// mock 側の旧実装は WithFiles + WithRenotes のみで Include* 系を読まなかった。
+// 以下 3 件で各 flag の pure-renote 分岐除外を fix する。これが無いと、handler
+// が Include* を停止しても mock 経由のテストでは検出できない (= 旧 (nil, nil)
+// stub と同じ silent regression を再導入してしまう)。
+
+func TestMockListByUserList_IncludeMyRenotesFalse_DropsViewerOwnPureRenote(t *testing.T) {
+	m := NewMockNoteRepository()
+	m.UserListMembers["l1"] = []*model.UserListMembership{
+		{UserListID: "l1", UserID: "viewer"},
+		{UserListID: "l1", UserID: "other"},
+	}
+	// viewer の pure renote: 除外される。
+	m.Notes["n_mine"] = &model.Note{
+		ID: "n_mine", UserID: "viewer", Visibility: model.NoteVisibilityPublic,
+		RenoteID: sp("orig1"),
+	}
+	// 他人の pure renote: 残る。
+	m.Notes["n_other"] = &model.Note{
+		ID: "n_other", UserID: "other", Visibility: model.NoteVisibilityPublic,
+		RenoteID: sp("orig2"),
+	}
+	// viewer の plain note: 残る (pure renote ではない)。
+	m.Notes["n_mine_plain"] = &model.Note{ID: "n_mine_plain", UserID: "viewer", Visibility: model.NoteVisibilityPublic}
+
+	got, err := m.ListByUserList("l1", 10, "", "", model.TimelineDBFilter{
+		ViewerID:         "viewer",
+		IncludeMyRenotes: bp(false),
+	})
+	require.NoError(t, err)
+	gotIDs := ids(got)
+	assert.NotContains(t, gotIDs, "n_mine", "IncludeMyRenotes=false で viewer 自身の pure renote が除外")
+	assert.Contains(t, gotIDs, "n_other")
+	assert.Contains(t, gotIDs, "n_mine_plain")
+}
+
+func TestMockListByUserList_IncludeRenotedMyNotesFalse_DropsRenoteOfViewer(t *testing.T) {
+	m := NewMockNoteRepository()
+	m.UserListMembers["l1"] = []*model.UserListMembership{
+		{UserListID: "l1", UserID: "other"},
+	}
+	// other が viewer の note を pure renote: 除外される。
+	m.Notes["n_renote_me"] = &model.Note{
+		ID: "n_renote_me", UserID: "other", Visibility: model.NoteVisibilityPublic,
+		RenoteID: sp("orig1"), RenoteUserID: sp("viewer"),
+	}
+	// other が誰か他人の note を pure renote: 残る。
+	m.Notes["n_renote_3p"] = &model.Note{
+		ID: "n_renote_3p", UserID: "other", Visibility: model.NoteVisibilityPublic,
+		RenoteID: sp("orig2"), RenoteUserID: sp("bob"),
+	}
+
+	got, err := m.ListByUserList("l1", 10, "", "", model.TimelineDBFilter{
+		ViewerID:              "viewer",
+		IncludeRenotedMyNotes: bp(false),
+	})
+	require.NoError(t, err)
+	gotIDs := ids(got)
+	assert.NotContains(t, gotIDs, "n_renote_me", "IncludeRenotedMyNotes=false で viewer の note の renote が除外")
+	assert.Contains(t, gotIDs, "n_renote_3p")
+}
+
+func TestMockListByUserList_IncludeLocalRenotesFalse_DropsLocalUserRenote(t *testing.T) {
+	m := NewMockNoteRepository()
+	m.UserListMembers["l1"] = []*model.UserListMembership{
+		{UserListID: "l1", UserID: "other"},
+	}
+	host := "remote.example"
+	// local user (RenoteUserHost=nil) の note を pure renote: 除外される。
+	m.Notes["n_local"] = &model.Note{
+		ID: "n_local", UserID: "other", Visibility: model.NoteVisibilityPublic,
+		RenoteID: sp("orig1"), RenoteUserID: sp("local"), RenoteUserHost: nil,
+	}
+	// remote user の note を pure renote: 残る。
+	m.Notes["n_remote"] = &model.Note{
+		ID: "n_remote", UserID: "other", Visibility: model.NoteVisibilityPublic,
+		RenoteID: sp("orig2"), RenoteUserID: sp("remote"), RenoteUserHost: &host,
+	}
+
+	got, err := m.ListByUserList("l1", 10, "", "", model.TimelineDBFilter{
+		ViewerID:            "viewer",
+		IncludeLocalRenotes: bp(false),
+	})
+	require.NoError(t, err)
+	gotIDs := ids(got)
+	assert.NotContains(t, gotIDs, "n_local", "IncludeLocalRenotes=false で local user の pure renote が除外")
+	assert.Contains(t, gotIDs, "n_remote")
+}

--- a/internal/testutil/mock_repository.go
+++ b/internal/testutil/mock_repository.go
@@ -745,13 +745,19 @@ type MockNoteRepository struct {
 	// repository 内部テストとの循環になるため CanSeeNote は使わず inline で
 	// 可視性を再現する (条件は CanSeeNote / real repo SQL と一致させる)。
 	Following map[string][]string
+	// UserListMembers は ListByUserList の member-filter + reply gate (#1495 /
+	// #1496) を mock 側で再現するための listID -> memberships。テストは
+	// noteRepo.UserListMembers[listID] = []*model.UserListMembership{...} の
+	// shape で直接 seed する。空 / nil の listID は member 不在として空結果。
+	UserListMembers map[string][]*model.UserListMembership
 }
 
 func NewMockNoteRepository() *MockNoteRepository {
 	return &MockNoteRepository{
-		Notes:          make(map[string]*model.Note),
-		ReactionCounts: make(map[string]map[string]int),
-		Following:      make(map[string][]string),
+		Notes:           make(map[string]*model.Note),
+		ReactionCounts:  make(map[string]map[string]int),
+		Following:       make(map[string][]string),
+		UserListMembers: make(map[string][]*model.UserListMembership),
 	}
 }
 
@@ -1103,10 +1109,17 @@ func (m *MockNoteRepository) ListFeatured(channelID, untilID string, limit, offs
 	return result[:limit], nil
 }
 
-// mockFeaturedNotesPerUserPoolSize は repository.featuredNotesPerUserPoolSize
+// mockFeaturedNotesPerUserPoolSize は repository.FeaturedNotesPerUserPoolSize
 // と揃える pool size (#1487 / #1491)。selection 段で engagement DESC top-N を
 // 取り、display 段で id DESC + untilID + limit を適用する 2 段構成を mock も
 // 同じ semantics で再現する。
+//
+// production code ファイルから repository を import すると repository の test
+// build 経由で import cycle になる (mock_chat_test.go のコメント参照)。よって
+// 定数は二重定義のままにし、testutil パッケージの _test.go で repository から
+// import した本物と一致しているかを runtime check する
+// (featured_pool_size_test.go の TestFeaturedPoolSizeMatchesRepo)。
+// drift があれば testutil パッケージ自身のテストが落ちて即座に検出される。
 const mockFeaturedNotesPerUserPoolSize = 50
 
 // ListFeaturedByUser mirrors the real repository's 2-stage selection:
@@ -1268,8 +1281,148 @@ func (m *MockNoteRepository) DeleteByUserBatch(userID string, batchSize int) (in
 	return n, nil
 }
 
-func (m *MockNoteRepository) ListByUserList(_ string, _ int, _, _ string, _ model.TimelineDBFilter) ([]*model.Note, error) {
-	return nil, nil
+// ListByUserList mirrors the real repository's SQL push-down for user-list
+// timeline (#1452 visibility / #1496 withReplies / #1498 renote / WithFiles).
+// Caller seeds UserListMembers[listID] = []*model.UserListMembership{...}.
+//
+// 旧 stub は (nil, nil) を返していて real SQL との parity drift があり、
+// handler-layer 以外で visibility / withReplies / withRenotes / withFiles の
+// regression を mock 経由で検出できなかった (#1491 audit 指摘 1)。本実装で
+// real repo と同 semantics を再現する。
+//
+// 適用順:
+//  1. listID member でない author の note は除外
+//  2. channel note は除外
+//  3. visibility push-down: public/home は常時、followers は author 本人か
+//     viewer が follow 済みのときのみ、specified は list timeline に出さない
+//     (DM 非表示, ListByUserList の real SQL も同じ)
+//  4. reply gate (#1496): replyId IS NULL || replyUserId==note.userId
+//     (self-thread) || replyUserId==viewerID || membership.WithReplies
+//  5. sinceID / untilID cursor
+//  6. WithFiles (= ファイル添付必須) / WithRenotes nil=true (false なら pure
+//     renote 除外) / IncludeMyRenotes・IncludeRenotedMyNotes・IncludeLocalRenotes
+//     (いずれも nil=true、false で対応する pure renote 分岐を除外) を
+//     applyTimelineFilter と同じ条件で適用
+//  7. paginationOrder: sinceID only → ASC, otherwise DESC
+//
+// 未実装 (= parity 対象外): MutedChannelIDs / muting subquery (UseMutingSubquery /
+// MutedUserIDs)。user-list-timeline では real repo もこれらを積まない方針
+// なので mock も省略する。これらを使う test は専用 fake (userListNotesRepo 系)
+// で受けること。
+func (m *MockNoteRepository) ListByUserList(listID string, limit int, sinceID, untilID string, filter model.TimelineDBFilter) ([]*model.Note, error) {
+	if limit <= 0 {
+		limit = 10
+	}
+	members := m.UserListMembers[listID]
+	if len(members) == 0 {
+		return nil, nil
+	}
+	memberOf := make(map[string]*model.UserListMembership, len(members))
+	for _, mem := range members {
+		memberOf[mem.UserID] = mem
+	}
+	viewerID := filter.ViewerID
+	withRenotes := true
+	if filter.WithRenotes != nil {
+		withRenotes = *filter.WithRenotes
+	}
+	var result []*model.Note
+	for _, n := range m.Notes {
+		mem, ok := memberOf[n.UserID]
+		if !ok {
+			continue
+		}
+		if n.ChannelID != nil {
+			continue
+		}
+		// visibility: list timeline は specified を出さない (real SQL も同じ)。
+		switch n.Visibility {
+		case model.NoteVisibilityPublic, model.NoteVisibilityHome:
+			// always visible
+		case model.NoteVisibilityFollowers:
+			if viewerID == "" {
+				continue
+			}
+			if viewerID != n.UserID {
+				followed := false
+				for _, fid := range m.Following[viewerID] {
+					if fid == n.UserID {
+						followed = true
+						break
+					}
+				}
+				if !followed {
+					continue
+				}
+			}
+		default:
+			// specified / その他 (= 未知) は drop。
+			continue
+		}
+		// reply gate (#1496)
+		if n.ReplyID != nil {
+			allowed := false
+			if n.ReplyUserID != nil {
+				if *n.ReplyUserID == n.UserID {
+					allowed = true
+				} else if viewerID != "" && *n.ReplyUserID == viewerID {
+					allowed = true
+				}
+			}
+			if !allowed && mem.WithReplies {
+				allowed = true
+			}
+			if !allowed {
+				continue
+			}
+		}
+		if sinceID != "" && n.ID <= sinceID {
+			continue
+		}
+		if untilID != "" && n.ID >= untilID {
+			continue
+		}
+		if filter.WithFiles && len(n.FileIDs) == 0 {
+			continue
+		}
+		// pure renote 判定: applyTimelineFilter と同じく
+		// `RenoteID != nil && Text == nil && len(FileIDs) == 0` で一致させる
+		// (real SQL: renoteId IS NOT NULL AND text IS NULL AND fileIds = '{}')。
+		isPureRenote := n.RenoteID != nil && n.Text == nil && len(n.FileIDs) == 0
+		if !withRenotes && isPureRenote {
+			// pure renote (= boost) excluded; quote renote (text or files あり) は通る。
+			continue
+		}
+		// IncludeMyRenotes nil=true。false かつ pure renote かつ author == viewer
+		// (= 自分の renote) を除外 (real SQL: note.userId = viewerID, #1498)。
+		if filter.IncludeMyRenotes != nil && !*filter.IncludeMyRenotes && viewerID != "" &&
+			isPureRenote && n.UserID == viewerID {
+			continue
+		}
+		// IncludeRenotedMyNotes nil=true。false かつ pure renote かつ
+		// renoteUserId == viewer (= 自分の note が renote された) を除外。
+		if filter.IncludeRenotedMyNotes != nil && !*filter.IncludeRenotedMyNotes && viewerID != "" &&
+			isPureRenote && n.RenoteUserID != nil && *n.RenoteUserID == viewerID {
+			continue
+		}
+		// IncludeLocalRenotes nil=true。false かつ pure renote かつ
+		// renoteUserHost == nil (= local user の renote) を除外。
+		if filter.IncludeLocalRenotes != nil && !*filter.IncludeLocalRenotes &&
+			isPureRenote && n.RenoteUserHost == nil {
+			continue
+		}
+		result = append(result, n)
+	}
+	sort.Slice(result, func(i, j int) bool {
+		if sinceID != "" && untilID == "" {
+			return result[i].ID < result[j].ID
+		}
+		return result[i].ID > result[j].ID
+	})
+	if len(result) > limit {
+		result = result[:limit]
+	}
+	return result, nil
 }
 
 func (m *MockNoteRepository) CountReplyTargets(userID, viewerID string, limit int) ([]model.ReplyTargetCount, error) {


### PR DESCRIPTION
## Summary

#1467 / #1491 / #1500 系の visibility / IDOR push-down シリーズに対する事後 audit (multi-agent diagnosis) で見つかった test 品質ギャップを 1 PR でまとめて塞ぐ。production code は untouched (定数 1 つの export 化のみ)。

## 主な変更点

### Core (mock parity / drift detection / env-only skip)

- **`internal/testutil/mock_repository.go`**: `MockNoteRepository.ListByUserList` を `(nil, nil)` stub から real SQL semantics に揃えた full impl に書き換え。
  - membership + channel 除外 + visibility (public/home/followers, specified DROP) + reply gate (#1496 `user_list_membership.withReplies`) + sinceID/untilID + WithFiles + WithRenotes + `Include{My,Renoted,Local}Renotes` を `applyTimelineFilter` と同条件で反映。
  - 未実装の `MutedChannelIDs` / muting subquery (`UseMutingSubquery` / `MutedUserIDs`) は docstring に明記して fake repo (`userListNotesRepo` 系) に escalate する方針。
  - 新 field `UserListMembers map[string][]*model.UserListMembership` を導入し、テストは `noteRepo.UserListMembers[listID]` で seed する。
- **`internal/testutil/mock_list_by_user_list_test.go` (新規)**: 17 件の mock-parity test。visibility / channel exclusion / reply gate / cursor / WithFiles / WithRenotes / `IncludeMyRenotes` / `IncludeRenotedMyNotes` / `IncludeLocalRenotes` を網羅。
- **`internal/repository/note.go`**: `featuredNotesPerUserPoolSize` → `FeaturedNotesPerUserPoolSize` に rename (exported 化)。両者の drift 検知のため **`internal/testutil/featured_pool_size_test.go` (新規)** を追加。production code が repository を import すると cycle になる (`mock_chat_test.go` の既存 pattern) ため、`_test.go` に drift detector を置く形で二重定義の安全性を確保。
- **`internal/safehttp/ssrf_test.go`**: `TestNewSSRFSafeTransport_IPv6ProxyDefaultPort` に env-only probe + `t.Skip` を追加。開発機で `[::]:80` に nginx 等が listen していると dial 成功で落ちる現象を回避 (#486 regression intent は CI で引き続き fix される)。

### Visibility hardening

- **`internal/core/note/note_query_service_test.go`**: `TestQueryService_ListRenotes_VisibilityDelegatedToRepo` / `_ListChildren_VisibilityDelegatedToRepo` を追加 (既存 `ListReplies` と対称)。viewerID 伝播を固定。
  - 注: mock pre-filter のため post-fetch FilterVisible 復活の検出はできない旨を docstring に明記。
- **`internal/api/notes/handler_query_test.go`**: Renotes / Replies / Children の followers regression を 6 件追加 (anonymous / 非フォロワー / フォロワー)。followers child の隠蔽 + 解禁を handler 経由で fix。
- **`internal/stream/channels/new_channels_test.go`**: `TestUserList_SpecifiedVisibility_AssumesFanoutSkips` を追加。`userListVisibilityShouldEmit` が specified payload を passthrough する現状動作を test で lock-in。fanout 側 (`shouldFanoutToFollowers`) の assumption が崩れた瞬間に検出するための trigger。
- **`internal/api/users/handler_extra_test.go`**: `TestFeaturedNotes_EngagementPoolCap_DropsLowEngagementBelow50` を追加。51 件 fixture で mock cap=50 を fix。
- **`internal/api/notes/handler_extra_test.go`**:
  - 弱い Success assertions (`TestFeatured_Success` / `TestMentions_Success` / `TestUserListTimeline_Success` / `TestSearchByTag_Success` / `TestSearchByTag_QueryArray`) を body decode + id assert に強化。
  - `TestUserListTimeline_PassesFilterToRepo` に `Include{My,Renoted,Local}Renotes` の forward assertion を追加 (handler→filter の伝播 fix)。

## テスト

- `go build ./...` ✅
- `make fmt && make lint` ✅
- `go test -race -count=1 ./internal/testutil/... ./internal/core/note/... ./internal/api/notes/... ./internal/api/users/... ./internal/stream/... ./internal/safehttp/...` ✅
- `go test -race -count=1 ./internal/repository/...` (throwaway PG) ✅
- 新規 / 強化 test 計 30 件、すべて pass。

## adversarial review (commit 前)

3 並列 reviewer (mock semantics / test quality / drift consistency) で multi-agent review を実施。aggregate verdict = **fix-and-ship**。
- High 1 件 (`Include*Renotes` parity gap) + Medium 2 件 (`Include*` propagation 未 assert / delegation test の overclaim コメント) を本 commit で対応済み。
- 残り Low 12 件はコメント polish や任意フォローアップで defer (CHANGELOG 非対象を含む)。

## Closes

Closes #1504

## 関連

- #1467 / #1468 / #1469 / #1473 / #1474 / #1475 / #1490 / #1491 / #1495 / #1500 / #1502 / #1503

🤖 Generated with [Claude Code](https://claude.com/claude-code)