### PR TITLE
fix(testutil): MockNoteRepository.ListByUserList で muting subquery 系 filter を panic-on-use 化 (#1506)

### DIFF
--- a/internal/testutil/mock_list_by_user_list_test.go
+++ b/internal/testutil/mock_list_by_user_list_test.go
@@ -342,3 +342,54 @@ func TestMockListByUserList_IncludeLocalRenotesFalse_DropsLocalUserRenote(t *tes
 	assert.NotContains(t, gotIDs, "n_local", "IncludeLocalRenotes=false で local user の pure renote が除外")
 	assert.Contains(t, gotIDs, "n_remote")
 }
+
+// #1506: muting subquery 系 filter は mock 未実装。docstring の案内だけだと
+// silent regression を招くため、これら 3 fields のいずれかが set されたら panic
+// で loud-fail させる。下記 3 件で各 entry point の panic 経路を担保する。
+// member seeding は最低限 (panic は filter check で前段に出るので member 構成
+// は実質関係しないが、real path に近い形で 1 件だけ seed しておく)。
+
+func TestMockListByUserList_PanicsOnUseMutingSubquery(t *testing.T) {
+	m := NewMockNoteRepository()
+	m.UserListMembers["l1"] = []*model.UserListMembership{{UserListID: "l1", UserID: "alice"}}
+	m.Notes["n1"] = &model.Note{ID: "n1", UserID: "alice", Visibility: model.NoteVisibilityPublic}
+
+	require.PanicsWithValue(t,
+		"testutil.MockNoteRepository.ListByUserList: muting subquery filter "+
+			"(UseMutingSubquery / MutedUserIDs / MutedChannelIDs) is not implemented in this mock. "+
+			"Escalate to a dedicated fake such as userListNotesRepo in internal/api/notes/handler_extra_test.go, "+
+			"or exercise the real SQL push-down in internal/repository/note.go applyTimelineFilter via a DB-backed test (#1506).",
+		func() {
+			_, _ = m.ListByUserList("l1", 10, "", "", model.TimelineDBFilter{
+				ViewerID:          "viewer",
+				UseMutingSubquery: true,
+			})
+		},
+	)
+}
+
+func TestMockListByUserList_PanicsOnMutedUserIDs(t *testing.T) {
+	m := NewMockNoteRepository()
+	m.UserListMembers["l1"] = []*model.UserListMembership{{UserListID: "l1", UserID: "alice"}}
+	m.Notes["n1"] = &model.Note{ID: "n1", UserID: "alice", Visibility: model.NoteVisibilityPublic}
+
+	require.Panics(t, func() {
+		_, _ = m.ListByUserList("l1", 10, "", "", model.TimelineDBFilter{
+			ViewerID:     "viewer",
+			MutedUserIDs: []string{"muted-author"},
+		})
+	})
+}
+
+func TestMockListByUserList_PanicsOnMutedChannelIDs(t *testing.T) {
+	m := NewMockNoteRepository()
+	m.UserListMembers["l1"] = []*model.UserListMembership{{UserListID: "l1", UserID: "alice"}}
+	m.Notes["n1"] = &model.Note{ID: "n1", UserID: "alice", Visibility: model.NoteVisibilityPublic}
+
+	require.Panics(t, func() {
+		_, _ = m.ListByUserList("l1", 10, "", "", model.TimelineDBFilter{
+			ViewerID:        "viewer",
+			MutedChannelIDs: []string{"ch-muted"},
+		})
+	})
+}

--- a/internal/testutil/mock_repository.go
+++ b/internal/testutil/mock_repository.go
@@ -1309,7 +1309,19 @@ func (m *MockNoteRepository) DeleteByUserBatch(userID string, batchSize int) (in
 // MutedUserIDs)。user-list-timeline では real repo もこれらを積まない方針
 // なので mock も省略する。これらを使う test は専用 fake (userListNotesRepo 系)
 // で受けること。
+//
+// muting subquery 系 filter が渡された場合は panic で loud-fail させる (#1506)。
+// docstring の案内だけでは将来の test 著者が読まずに mock 経由で書く可能性が
+// あり、その場合 real SQL では mute されるはずの note が mock で素通りする
+// silent regression を引き起こす。stacktrace から専用 fake への escalation を
+// 即座に促すために panic を選択している。
 func (m *MockNoteRepository) ListByUserList(listID string, limit int, sinceID, untilID string, filter model.TimelineDBFilter) ([]*model.Note, error) {
+	if filter.UseMutingSubquery || len(filter.MutedUserIDs) > 0 || len(filter.MutedChannelIDs) > 0 {
+		panic("testutil.MockNoteRepository.ListByUserList: muting subquery filter " +
+			"(UseMutingSubquery / MutedUserIDs / MutedChannelIDs) is not implemented in this mock. " +
+			"Escalate to a dedicated fake such as userListNotesRepo in internal/api/notes/handler_extra_test.go, " +
+			"or exercise the real SQL push-down in internal/repository/note.go applyTimelineFilter via a DB-backed test (#1506).")
+	}
 	if limit <= 0 {
 		limit = 10
 	}


### PR DESCRIPTION
## Summary

#1505 で MockNoteRepository.ListByUserList を real SQL semantics 相当に書き換えた後も、muting subquery 系 filter (UseMutingSubquery / MutedUserIDs / MutedChannelIDs) は mock 未実装として残されていた。docstring 案内のみだと将来の test 著者が読まずに mock 経由でテストを書くリスクがあり (real SQL では mute されるはずの note が mock で素通りする silent regression)、#1505 の audit follow-up として本 PR で塞ぐ。

## 主な変更点

- `internal/testutil/mock_repository.go`: `MockNoteRepository.ListByUserList` の冒頭に muting subquery 系 3 fields の panic guard を追加。panic message には次を含める:
  - mock 未実装である旨
  - `userListNotesRepo` 系 fake (`internal/api/notes/handler_extra_test.go`) への escalation pointer
  - real repo (`internal/repository/note.go` の `applyTimelineFilter`) への pointer
  - 案件番号 (#1506)
- `internal/testutil/mock_list_by_user_list_test.go`: panic 経路の test を 3 件追加。
  - `TestMockListByUserList_PanicsOnUseMutingSubquery` は `require.PanicsWithValue` で panic message を完全一致 verify (message contract を runtime に固定)
  - `MutedUserIDs` / `MutedChannelIDs` 経路は `require.Panics` で発生のみ確認 (panic 文字列は 1 つの literal を共有しているため contract 検査は 1 件で代表)

## 影響範囲

- production の `UserListTimeline` handler は muting 3 fields を一切 set しないため、誤爆リスクはゼロ。
- 既存 test に対して `grep -rn 'UseMutingSubquery\|MutedUserIDs\|MutedChannelIDs' internal/` で確認した結果、`MockNoteRepository.ListByUserList` を muting flag 付きで直接叩く test は 0 件 (該当 fields の set 箇所は production handler 配線と `internal/core/timeline` / `internal/api/notes/timeline_handler.go` の unit test のみ)。
- ListLocal / ListSocial 等への横展開は本 issue scope 外 (issue 本文で別 issue に明記)。

## テスト

- [x] `go test -race -count=1 ./internal/testutil/...` → PASS
- [x] `go test -race -count=1 ./internal/api/notes/...` → PASS (regression なし)
- [x] `go test -race -count=1 ./internal/core/timeline/...` → PASS (regression なし)
- [x] `gofmt -s -d .` / `go vet ./...` → clean

## Closes

Closes #1506

## 関連

- #1505 (本 follow-up の起点 / #1504 audit)

🤖 Generated with [Claude Code](https://claude.com/claude-code)