### PR TITLE
Fix security: Misskey互換性監査で確定したセキュリティ系差分を一括修正

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@
 - Fix: Misskey TS から mk-go に移行した直後、既に期限切れだったアンケートに対してアンケート終了 (pollEnded) 通知が一斉発火する問題を修正 (移行時 backfill migration を追加)
 - Fix: 配送先が一時的にダウンしている場合に、deliver/inbox ジョブが設定省略時にリトライされない問題を修正 (既定の試行回数を Misskey 本家と同じ deliver=12 / inbox=8 に。従来の no-retry 挙動が必要な場合は `deliverJobMaxAttempts` / `inboxJobMaxAttempts` に 1 を指定)
 - Fix: `/api/i/notifications` の通知 payload に埋め込まれるノート本体が公開範囲チェックを経ずに返り、フォロワー限定ノートがリプライ通知などを介して非フォロワーに漏れる問題を修正
+- Fix: `/api/drive/files/move-bulk` が呼び出しユーザーの所有権を検証せず、任意の `fileIds` を指定することで他人のドライブファイルをフォルダ移動できた問題 (IDOR) を修正 (更新を `userId` で絞り込み、宛先フォルダの所有権も検証)
+- Fix: ActivityPub inbox で HTTP 署名者と activity の `actor` の一致を検証しておらず、有効な鍵で署名しつつ body の `actor` に他人を詐称した活動 (Delete / Create 等) を受理してしまう問題 (なりすまし) を修正 (署名者と actor が一致しない場合は、LD-Signature が actor を認証している転送活動のみ許可し、それ以外は破棄)
+- Fix: `/api/chat/messages/create-to-user` で受信者が送信者をブロックしていても DM が届く問題を修正 (`YOU_HAVE_BEEN_BLOCKED` で拒否)
+- Fix: 公開エンドポイントである `/api/federation/instances`・`/api/federation/show-instance`・`/api/federation/stats` がモデレーター専用フィールド `moderationNote` を誰にでも返していた問題を修正 (モデレーターに対してのみ実値を返し、それ以外は null)
+- Fix: `/api/flash/featured`・`/api/flash/search` が公開範囲フィルタを欠き、非公開 (visibility != public) の Play が含まれていた問題を修正 (公開 Play のみを対象に。featured は likedCount > 0 条件も付与)
+- Fix: `/api/admin/suspend-user` がモデレーター / 管理者 / root アカウントを凍結できてしまう問題を修正 (本家同様に拒否)。あわせて `/api/admin/delete-account`・`/api/admin/accounts/delete` で root アカウントの削除を防止
 
 ## 0.9.2
 

--- a/internal/api/admin/accounts.go
+++ b/internal/api/admin/accounts.go
@@ -18,6 +18,10 @@ func (h *Handler) AccountsDelete(c echo.Context) error {
 	if err := c.Bind(&req); err != nil || req.UserID == "" {
 		return c.NoContent(http.StatusNoContent)
 	}
+	// root アカウントの削除は壊滅的なので防御的に拒否する (誤操作 / 権限昇格)。
+	if h.isRootUser(req.UserID) {
+		return c.JSON(http.StatusForbidden, apierr.Error("ACCESS_DENIED", "Cannot delete the root account.", "1fb7cb09-d46a-4fff-b8df-057708cce513"))
+	}
 	if err := h.userRepo.UpdateUser(req.UserID, map[string]any{"isSuspended": true, "isDeleted": true}); err == nil {
 		// 論理削除直後の auth bypass 防止 (#965)。target の全 token cache
 		// entry を即時 invalidate して 30s stale window を消す。DB 更新が
@@ -64,6 +68,10 @@ func (h *Handler) DeleteAccount(c echo.Context) error {
 	if err := c.Bind(&req); err != nil || req.UserID == "" {
 		return c.NoContent(http.StatusNoContent)
 	}
+	// root アカウントの削除は壊滅的なので防御的に拒否する (誤操作 / 権限昇格)。
+	if h.isRootUser(req.UserID) {
+		return c.JSON(http.StatusForbidden, apierr.Error("ACCESS_DENIED", "Cannot delete the root account.", "1fb7cb09-d46a-4fff-b8df-057708cce513"))
+	}
 	if err := h.userRepo.UpdateUser(req.UserID, map[string]any{"isSuspended": true, "isDeleted": true}); err == nil {
 		// AccountsDelete と同じ。target の全 token cache entry を即時
 		// invalidate (#965)。
@@ -72,6 +80,20 @@ func (h *Handler) DeleteAccount(c echo.Context) error {
 	}
 	h.scheduleAccountCascade(req.UserID)
 	return c.NoContent(http.StatusNoContent)
+}
+
+// isRootUser reports whether the given user ID is the instance root account.
+// Used to guard destructive admin actions (delete-account) against removing
+// the root account. Returns false when the user cannot be resolved.
+func (h *Handler) isRootUser(userID string) bool {
+	if h.userRepo == nil || userID == "" {
+		return false
+	}
+	u, err := h.userRepo.FindByID(userID)
+	if err != nil || u == nil {
+		return false
+	}
+	return u.IsRoot
 }
 
 // scheduleAccountCascade queues the background cascade deletion. Errors

--- a/internal/api/admin/accounts.go
+++ b/internal/api/admin/accounts.go
@@ -3,6 +3,7 @@ package admin
 import (
 	"log/slog"
 	"net/http"
+	"strings"
 
 	"github.com/labstack/echo/v4"
 	"github.com/shiroha-a/mk/internal/api/apierr"
@@ -18,9 +19,9 @@ func (h *Handler) AccountsDelete(c echo.Context) error {
 	if err := c.Bind(&req); err != nil || req.UserID == "" {
 		return c.NoContent(http.StatusNoContent)
 	}
-	// root アカウントの削除は壊滅的なので防御的に拒否する (誤操作 / 権限昇格)。
-	if h.isRootUser(req.UserID) {
-		return c.JSON(http.StatusForbidden, apierr.Error("ACCESS_DENIED", "Cannot delete the root account.", "1fb7cb09-d46a-4fff-b8df-057708cce513"))
+	// root / system アカウントの削除は連合を壊すため拒否する (#parity review F1)。
+	if h.isProtectedAccount(req.UserID) {
+		return c.JSON(http.StatusForbidden, apierr.Error("ACCESS_DENIED", "Cannot delete a root or system account.", "1fb7cb09-d46a-4fff-b8df-057708cce513"))
 	}
 	if err := h.userRepo.UpdateUser(req.UserID, map[string]any{"isSuspended": true, "isDeleted": true}); err == nil {
 		// 論理削除直後の auth bypass 防止 (#965)。target の全 token cache
@@ -68,9 +69,9 @@ func (h *Handler) DeleteAccount(c echo.Context) error {
 	if err := c.Bind(&req); err != nil || req.UserID == "" {
 		return c.NoContent(http.StatusNoContent)
 	}
-	// root アカウントの削除は壊滅的なので防御的に拒否する (誤操作 / 権限昇格)。
-	if h.isRootUser(req.UserID) {
-		return c.JSON(http.StatusForbidden, apierr.Error("ACCESS_DENIED", "Cannot delete the root account.", "1fb7cb09-d46a-4fff-b8df-057708cce513"))
+	// root / system アカウントの削除は連合を壊すため拒否する (#parity review F1)。
+	if h.isProtectedAccount(req.UserID) {
+		return c.JSON(http.StatusForbidden, apierr.Error("ACCESS_DENIED", "Cannot delete a root or system account.", "1fb7cb09-d46a-4fff-b8df-057708cce513"))
 	}
 	if err := h.userRepo.UpdateUser(req.UserID, map[string]any{"isSuspended": true, "isDeleted": true}); err == nil {
 		// AccountsDelete と同じ。target の全 token cache entry を即時
@@ -82,18 +83,35 @@ func (h *Handler) DeleteAccount(c echo.Context) error {
 	return c.NoContent(http.StatusNoContent)
 }
 
-// isRootUser reports whether the given user ID is the instance root account.
-// Used to guard destructive admin actions (delete-account) against removing
-// the root account. Returns false when the user cannot be resolved.
-func (h *Handler) isRootUser(userID string) bool {
+// isProtectedAccount reports whether the given user ID is an account that must
+// never be deleted: the instance root account or a local system account
+// (instance.actor / relay.actor / proxy.actor 等)。upstream DeleteAccountService
+// の `meta.rootUserId === user.id` (root) と `user.host === null &&
+// username.includes('.')` (system account) ガードに対応する (#parity review F1)。
+// Returns false when the user cannot be resolved.
+func (h *Handler) isProtectedAccount(userID string) bool {
 	if h.userRepo == nil || userID == "" {
 		return false
+	}
+	// root user id は meta が権威ソース (role service の isRootUser と揃える)。
+	if h.metaRepo != nil {
+		if meta, err := h.metaRepo.Fetch(); err == nil && meta != nil && meta.RootUserID != nil && *meta.RootUserID == userID {
+			return true
+		}
 	}
 	u, err := h.userRepo.FindByID(userID)
 	if err != nil || u == nil {
 		return false
 	}
-	return u.IsRoot
+	if u.IsRoot {
+		return true
+	}
+	// ローカル system account: host=null かつ username に '.' を含む
+	// (systemaccount は `<kind>.actor` 形式で作られる)。
+	if u.Host == nil && strings.Contains(u.Username, ".") {
+		return true
+	}
+	return false
 }
 
 // scheduleAccountCascade queues the background cascade deletion. Errors

--- a/internal/api/admin/accounts_test.go
+++ b/internal/api/admin/accounts_test.go
@@ -120,6 +120,26 @@ func TestAccountsDelete_EnqueueFailureIsLogged(t *testing.T) {
 		doPost(h.AccountsDelete, `{"userId":"u1"}`, adminUser).Code)
 }
 
+// root アカウントは削除できない (誤操作 / 権限昇格対策)。
+func TestAccountsDelete_RejectsRoot(t *testing.T) {
+	h, userRepo, _, _ := newTestHandler(t)
+	userRepo.Users["root"] = &model.User{ID: "root", IsRoot: true}
+	stub := &stubDeleteAccountEnqueuer{}
+	h.SetDeleteAccountEnqueuer(stub)
+	rec := doPost(h.AccountsDelete, `{"userId":"root"}`, adminUser)
+	assert.Equal(t, http.StatusForbidden, rec.Code)
+	assert.Equal(t, 0, stub.called, "root deletion must not enqueue cascade")
+	assert.False(t, userRepo.Users["root"].IsDeleted)
+}
+
+func TestDeleteAccount_RejectsRoot(t *testing.T) {
+	h, userRepo, _, _ := newTestHandler(t)
+	userRepo.Users["root"] = &model.User{ID: "root", IsRoot: true}
+	rec := doPost(h.DeleteAccount, `{"userId":"root"}`, adminUser)
+	assert.Equal(t, http.StatusForbidden, rec.Code)
+	assert.False(t, userRepo.Users["root"].IsDeleted)
+}
+
 // #965: 論理削除直後の auth bypass 防止のため、AccountsDelete / DeleteAccount
 // 成功時に target user の全 token cache を即時 invalidate することを担保。
 func TestAccountsDelete_InvalidatesTargetTokenCache(t *testing.T) {

--- a/internal/api/admin/accounts_test.go
+++ b/internal/api/admin/accounts_test.go
@@ -140,6 +140,31 @@ func TestDeleteAccount_RejectsRoot(t *testing.T) {
 	assert.False(t, userRepo.Users["root"].IsDeleted)
 }
 
+// ローカル system account (host=nil, username に '.' を含む, IsRoot=false) も
+// 削除拒否される (upstream の system-account ガード相当)。
+func TestAccountsDelete_RejectsSystemAccount(t *testing.T) {
+	h, userRepo, _, _ := newTestHandler(t)
+	userRepo.Users["sys"] = &model.User{ID: "sys", Username: "relay.actor", Host: nil, IsRoot: false}
+	stub := &stubDeleteAccountEnqueuer{}
+	h.SetDeleteAccountEnqueuer(stub)
+	rec := doPost(h.AccountsDelete, `{"userId":"sys"}`, adminUser)
+	assert.Equal(t, http.StatusForbidden, rec.Code)
+	assert.Equal(t, 0, stub.called, "system account deletion must not enqueue cascade")
+	assert.False(t, userRepo.Users["sys"].IsDeleted)
+}
+
+// root user id が meta.rootUserId で示されるケース (IsRoot 列が無い drop-in) も
+// 削除拒否される。
+func TestDeleteAccount_RejectsMetaRootUser(t *testing.T) {
+	h, userRepo, metaRepo, _ := newTestHandler(t)
+	rootID := "metaRoot"
+	metaRepo.Meta = &model.Meta{ID: "x", RootUserID: &rootID}
+	userRepo.Users["metaRoot"] = &model.User{ID: "metaRoot", Username: "alice", IsRoot: false}
+	rec := doPost(h.DeleteAccount, `{"userId":"metaRoot"}`, adminUser)
+	assert.Equal(t, http.StatusForbidden, rec.Code)
+	assert.False(t, userRepo.Users["metaRoot"].IsDeleted)
+}
+
 // #965: 論理削除直後の auth bypass 防止のため、AccountsDelete / DeleteAccount
 // 成功時に target user の全 token cache を即時 invalidate することを担保。
 func TestAccountsDelete_InvalidatesTargetTokenCache(t *testing.T) {

--- a/internal/api/admin/handler.go
+++ b/internal/api/admin/handler.go
@@ -885,6 +885,12 @@ func (h *Handler) SuspendUser(c echo.Context) error {
 		return c.JSON(http.StatusNotFound, apierr.Error("NO_SUCH_USER", "No such user.", "2b730f78-1179-461b-88ad-d24c9af1a5ce"))
 	}
 
+	// upstream suspend-user.ts: モデレーター/管理者 (root を含む) アカウントは
+	// 凍結できない。moderator が他の moderator/admin を凍結する権限昇格を防ぐ。
+	if user.IsRoot || (h.roleService != nil && h.roleService.IsModerator(user.ID)) {
+		return c.JSON(http.StatusForbidden, apierr.Error("ACCESS_DENIED", "Cannot suspend a moderator account.", "1fb7cb09-d46a-4fff-b8df-057708cce513"))
+	}
+
 	if err := h.userRepo.UpdateUser(req.UserID, map[string]any{"isSuspended": true}); err != nil {
 		return c.JSON(http.StatusInternalServerError, apierr.Error("INTERNAL_ERROR", "Internal error.", "5d37dbcb-891e-41ca-a3d6-e690c97775ac"))
 	}

--- a/internal/api/admin/handler_test.go
+++ b/internal/api/admin/handler_test.go
@@ -470,6 +470,19 @@ func TestSuspendUser_RejectsRoot(t *testing.T) {
 	assert.False(t, userRepo.Users["root"].IsSuspended)
 }
 
+// IsAdministrator role (IsModerator=false / IsAdministrator=true) を持つ対象も
+// 凍結できない (IsModerator が admin role を含むため)。
+func TestSuspendUser_RejectsAdministrator(t *testing.T) {
+	h, userRepo, _, roleRepo, assignRepo := newTestHandlerWithAssign(t)
+	userRepo.Users["adm1"] = &model.User{ID: "adm1", Username: "adm"}
+	roleRepo.Roles["admrole"] = &model.Role{ID: "admrole", Name: "Admin", IsAdministrator: true}
+	assignRepo.Assignments["adm1:admrole"] = &model.RoleAssignment{ID: "a1", UserID: "adm1", RoleID: "admrole"}
+
+	rec := doPost(h.SuspendUser, `{"userId":"adm1"}`, nil)
+	assert.Equal(t, http.StatusForbidden, rec.Code)
+	assert.False(t, userRepo.Users["adm1"].IsSuspended, "administrator must not be suspended")
+}
+
 func TestUnsuspendUser_Success(t *testing.T) {
 	h, userRepo, _, _ := newTestHandler(t)
 	userRepo.Users["u1"] = &model.User{ID: "u1", IsSuspended: true}

--- a/internal/api/admin/handler_test.go
+++ b/internal/api/admin/handler_test.go
@@ -448,6 +448,28 @@ func TestSuspendUser_InvalidParam(t *testing.T) {
 	assert.Equal(t, http.StatusBadRequest, rec.Code)
 }
 
+// upstream suspend-user.ts: モデレーター role を持つ対象は凍結できない。
+func TestSuspendUser_RejectsModerator(t *testing.T) {
+	h, userRepo, _, roleRepo, assignRepo := newTestHandlerWithAssign(t)
+	userRepo.Users["mod1"] = &model.User{ID: "mod1", Username: "mod"}
+	roleRepo.Roles["modrole"] = &model.Role{ID: "modrole", Name: "Mod", IsModerator: true}
+	assignRepo.Assignments["mod1:modrole"] = &model.RoleAssignment{ID: "a1", UserID: "mod1", RoleID: "modrole"}
+
+	rec := doPost(h.SuspendUser, `{"userId":"mod1"}`, nil)
+	assert.Equal(t, http.StatusForbidden, rec.Code)
+	assert.False(t, userRepo.Users["mod1"].IsSuspended, "moderator must not be suspended")
+}
+
+// root アカウントは凍結できない。
+func TestSuspendUser_RejectsRoot(t *testing.T) {
+	h, userRepo, _, _ := newTestHandler(t)
+	userRepo.Users["root"] = &model.User{ID: "root", IsRoot: true}
+
+	rec := doPost(h.SuspendUser, `{"userId":"root"}`, nil)
+	assert.Equal(t, http.StatusForbidden, rec.Code)
+	assert.False(t, userRepo.Users["root"].IsSuspended)
+}
+
 func TestUnsuspendUser_Success(t *testing.T) {
 	h, userRepo, _, _ := newTestHandler(t)
 	userRepo.Users["u1"] = &model.User{ID: "u1", IsSuspended: true}

--- a/internal/api/chat/handler.go
+++ b/internal/api/chat/handler.go
@@ -67,6 +67,9 @@ func (h *Handler) mapChatErr(c echo.Context, err error) error {
 		return c.JSON(http.StatusForbidden, apierr.Error("ACCESS_DENIED", "Access denied.", "1fb7cb09-d46a-4fff-b8df-057708cce513"))
 	case errors.Is(err, corechat.ErrInvalidTarget):
 		return c.JSON(http.StatusBadRequest, apierr.Error("INVALID_PARAM", "toUserId or toRoomId is required.", "ed1d7571-a3ac-4370-899c-0dbe5e230cc8"))
+	case errors.Is(err, corechat.ErrChatBlocked):
+		// recipient が sender を block している (upstream YOU_HAVE_BEEN_BLOCKED)。
+		return c.JSON(http.StatusForbidden, apierr.Error("YOU_HAVE_BEEN_BLOCKED", "You cannot send a message because you have been blocked by this user.", "c15a5199-7422-4968-941a-2a462c478f7d"))
 	case errors.Is(err, corechat.ErrChatScopeViolation):
 		// CherryPick の `recipient is cannot chat (...)` 相当 (#692)。
 		// upstream は ApiError を持たず単なる Error を投げるので mk-go 固有

--- a/internal/api/chat/handler_test.go
+++ b/internal/api/chat/handler_test.go
@@ -812,6 +812,28 @@ func TestMessagesCreateToUser(t *testing.T) {
 	assert.Equal(t, http.StatusOK, rec.Code)
 }
 
+// recipient が sender を block している場合は YOU_HAVE_BEEN_BLOCKED (403)。
+func TestMessagesCreateToUser_Blocked(t *testing.T) {
+	repo := testutil.NewMockChatRepository()
+	idGen, _ := id.NewGenerator("aidx")
+	h := NewHandler(repo, idGen)
+	svc := corechat.NewService(repo, idGen)
+	blocks := testutil.NewMockBlockingRepository()
+	// blocker=u2 (recipient), blockee=u1 (sender)。
+	require.NoError(t, blocks.Create(&model.Blocking{ID: "b1", BlockerID: "u2", BlockeeID: "u1"}))
+	svc.SetBlockingRepo(blocks)
+	h.SetService(svc)
+
+	rec := post(h.MessagesCreateToUser, `{"text":"hi","toUserId":"u2"}`, u1)
+	assert.Equal(t, http.StatusForbidden, rec.Code)
+
+	var resp map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+	errObj, _ := resp["error"].(map[string]any)
+	require.NotNil(t, errObj)
+	assert.Equal(t, "YOU_HAVE_BEEN_BLOCKED", errObj["code"])
+}
+
 func TestMessagesCreateToRoom(t *testing.T) {
 	h, repo := newTestHandler()
 	repo.Rooms["r1"] = &model.ChatRoom{ID: "r1", OwnerID: u1.ID}

--- a/internal/api/drive/handler.go
+++ b/internal/api/drive/handler.go
@@ -791,6 +791,7 @@ func (h *Handler) FilesUploadFromURL(c echo.Context) error {
 
 // FilesMoveBulk handles POST /api/drive/files/move-bulk.
 func (h *Handler) FilesMoveBulk(c echo.Context) error {
+	user := middleware.GetUser(c)
 	var req struct {
 		FileIDs  []string `json:"fileIds"`
 		FolderID *string  `json:"folderId"`
@@ -798,8 +799,17 @@ func (h *Handler) FilesMoveBulk(c echo.Context) error {
 	if err := c.Bind(&req); err != nil || len(req.FileIDs) == 0 {
 		return apierr.JSONInvalidParam(c)
 	}
+	// 宛先 folder が指定されている場合は呼出ユーザー所有であることを検証する
+	// (他人の folder へ移動できる経路を塞ぐ)。root (folderId=null) は検証不要。
+	if req.FolderID != nil && *req.FolderID != "" && h.folderRepo != nil {
+		folder, err := h.folderRepo.FindByID(*req.FolderID)
+		if err != nil || folder.UserID == nil || *folder.UserID != user.ID {
+			return c.JSON(http.StatusNotFound, apierr.Error("NO_SUCH_FOLDER", "No such folder.", "d77545ec-1283-4b73-bbe1-e90e1da6a4e7"))
+		}
+	}
 	if h.fileRepo != nil {
-		_ = h.fileRepo.UpdateBulkFolder(req.FileIDs, req.FolderID)
+		// userId scope で IDOR を防ぐ (他人の DriveFile は移動されない)。
+		_ = h.fileRepo.UpdateBulkFolder(user.ID, req.FileIDs, req.FolderID)
 	}
 	return c.NoContent(http.StatusNoContent)
 }

--- a/internal/api/drive/handler.go
+++ b/internal/api/drive/handler.go
@@ -799,9 +799,18 @@ func (h *Handler) FilesMoveBulk(c echo.Context) error {
 	if err := c.Bind(&req); err != nil || len(req.FileIDs) == 0 {
 		return apierr.JSONInvalidParam(c)
 	}
+	// 空文字 folderId は root(null) と同義に正規化する (upstream の
+	// `folderId ?? null` 相当、#parity review DRV-2)。
+	if req.FolderID != nil && *req.FolderID == "" {
+		req.FolderID = nil
+	}
 	// 宛先 folder が指定されている場合は呼出ユーザー所有であることを検証する
 	// (他人の folder へ移動できる経路を塞ぐ)。root (folderId=null) は検証不要。
-	if req.FolderID != nil && *req.FolderID != "" && h.folderRepo != nil {
+	// folderRepo 未配線時は検証不能なので fail-closed で弾く (#parity review DRV-1)。
+	if req.FolderID != nil {
+		if h.folderRepo == nil {
+			return c.JSON(http.StatusNotFound, apierr.Error("NO_SUCH_FOLDER", "No such folder.", "d77545ec-1283-4b73-bbe1-e90e1da6a4e7"))
+		}
 		folder, err := h.folderRepo.FindByID(*req.FolderID)
 		if err != nil || folder.UserID == nil || *folder.UserID != user.ID {
 			return c.JSON(http.StatusNotFound, apierr.Error("NO_SUCH_FOLDER", "No such folder.", "d77545ec-1283-4b73-bbe1-e90e1da6a4e7"))

--- a/internal/api/drive/handler_test.go
+++ b/internal/api/drive/handler_test.go
@@ -1021,11 +1021,37 @@ func TestFilesUploadFromURL(t *testing.T) {
 }
 
 func TestFilesMoveBulk_Success(t *testing.T) {
-	h, _, _ := newHandlerWithRepos(t)
+	h, fileRepo, _ := newHandlerWithRepos(t)
 	c, rec := newJSONReq(t, `{"fileIds":["f1","f2"]}`)
 	setUser(c, "u1")
 	require.NoError(t, h.FilesMoveBulk(c))
 	assert.Equal(t, http.StatusNoContent, rec.Code)
+	// IDOR guard: handler は必ず呼出ユーザーの ID を repo に渡す。
+	assert.Equal(t, "u1", fileRepo.BulkFolderUserID)
+	assert.Equal(t, []string{"f1", "f2"}, fileRepo.BulkFolderFileIDs)
+}
+
+func TestFilesMoveBulk_RejectsForeignFolder(t *testing.T) {
+	h, fileRepo, folderRepo := newHandlerWithRepos(t)
+	owner := "someoneElse"
+	folderRepo.Folders["folderX"] = &model.DriveFolder{ID: "folderX", UserID: &owner}
+	c, rec := newJSONReq(t, `{"fileIds":["f1"],"folderId":"folderX"}`)
+	setUser(c, "u1")
+	require.NoError(t, h.FilesMoveBulk(c))
+	// 他人所有の宛先 folder は NO_SUCH_FOLDER で拒否し、移動は実行しない。
+	assert.Equal(t, http.StatusNotFound, rec.Code)
+	assert.Empty(t, fileRepo.BulkFolderUserID, "must not move files into a foreign folder")
+}
+
+func TestFilesMoveBulk_AcceptsOwnFolder(t *testing.T) {
+	h, fileRepo, folderRepo := newHandlerWithRepos(t)
+	owner := "u1"
+	folderRepo.Folders["folderOwn"] = &model.DriveFolder{ID: "folderOwn", UserID: &owner}
+	c, rec := newJSONReq(t, `{"fileIds":["f1"],"folderId":"folderOwn"}`)
+	setUser(c, "u1")
+	require.NoError(t, h.FilesMoveBulk(c))
+	assert.Equal(t, http.StatusNoContent, rec.Code)
+	assert.Equal(t, "u1", fileRepo.BulkFolderUserID)
 }
 
 func TestFilesMoveBulk_InvalidParam(t *testing.T) {

--- a/internal/api/drive/handler_test.go
+++ b/internal/api/drive/handler_test.go
@@ -1054,6 +1054,25 @@ func TestFilesMoveBulk_AcceptsOwnFolder(t *testing.T) {
 	assert.Equal(t, "u1", fileRepo.BulkFolderUserID)
 }
 
+func TestFilesMoveBulk_NonexistentFolder(t *testing.T) {
+	h, fileRepo, _ := newHandlerWithRepos(t)
+	c, rec := newJSONReq(t, `{"fileIds":["f1"],"folderId":"ghost"}`)
+	setUser(c, "u1")
+	require.NoError(t, h.FilesMoveBulk(c))
+	assert.Equal(t, http.StatusNotFound, rec.Code)
+	assert.Empty(t, fileRepo.BulkFolderUserID, "must not move into a nonexistent folder")
+}
+
+// folderId 未指定 (root への移動) は folder 検証をスキップして移動する。
+func TestFilesMoveBulk_RootMoveSkipsFolderCheck(t *testing.T) {
+	h, fileRepo, _ := newHandlerWithRepos(t)
+	c, rec := newJSONReq(t, `{"fileIds":["f1"]}`)
+	setUser(c, "u1")
+	require.NoError(t, h.FilesMoveBulk(c))
+	assert.Equal(t, http.StatusNoContent, rec.Code)
+	assert.Equal(t, "u1", fileRepo.BulkFolderUserID)
+}
+
 func TestFilesMoveBulk_InvalidParam(t *testing.T) {
 	h, _, _ := newHandlerWithRepos(t)
 	c, rec := newJSONReq(t, `{}`)

--- a/internal/api/federation/handler.go
+++ b/internal/api/federation/handler.go
@@ -13,6 +13,7 @@ import (
 	"github.com/shiroha-a/mk/internal/misc/id"
 	"github.com/shiroha-a/mk/internal/model"
 	"github.com/shiroha-a/mk/internal/repository"
+	"github.com/shiroha-a/mk/internal/server/middleware"
 )
 
 // ActorResolver is the narrow subset of core/federation.Resolver that
@@ -22,12 +23,21 @@ type ActorResolver interface {
 	ForceResolveActor(uri string) (*model.User, error)
 }
 
+// ModeratorChecker reports whether a user has moderator privileges. Used to
+// gate moderator-only fields (moderationNote) on the otherwise-public
+// federation/instances and federation/show-instance responses. nil disables
+// the gate (moderationNote is never exposed).
+type ModeratorChecker interface {
+	IsModerator(userID string) bool
+}
+
 // Handler handles federation-related API endpoints.
 type Handler struct {
 	svc           *coreinstance.Service
 	followingRepo repository.FollowingRepository
 	userRepo      repository.UserRepository
 	resolver      ActorResolver
+	moderator     ModeratorChecker
 }
 
 // NewHandler creates a new federation Handler.
@@ -48,6 +58,26 @@ func (h *Handler) SetUserRepo(r repository.UserRepository) {
 // SetResolver attaches an ActorResolver for update-remote-user.
 func (h *Handler) SetResolver(r ActorResolver) {
 	h.resolver = r
+}
+
+// SetModeratorChecker attaches a ModeratorChecker so moderationNote is only
+// surfaced to moderators on the public instance-listing endpoints.
+func (h *Handler) SetModeratorChecker(m ModeratorChecker) {
+	h.moderator = m
+}
+
+// requesterIsModerator reports whether the (optionally authenticated) caller
+// is a moderator. The global Authenticate middleware populates the user when a
+// valid token is presented; unauthenticated callers return false.
+func (h *Handler) requesterIsModerator(c echo.Context) bool {
+	if h.moderator == nil {
+		return false
+	}
+	user := middleware.GetUser(c)
+	if user == nil {
+		return false
+	}
+	return h.moderator.IsModerator(user.ID)
 }
 
 // InstancesRequest is the request body for federation/instances.
@@ -108,9 +138,10 @@ func (h *Handler) Instances(c echo.Context) error {
 	if err != nil {
 		return apierr.JSONInternalError(c)
 	}
+	showModNote := h.requesterIsModerator(c)
 	out := make([]map[string]any, 0, len(rows))
 	for _, inst := range rows {
-		out = append(out, instanceToMap(inst, hosts))
+		out = append(out, instanceToMap(inst, hosts, showModNote))
 	}
 	return c.JSON(http.StatusOK, out)
 }
@@ -143,7 +174,7 @@ func (h *Handler) ShowInstance(c echo.Context) error {
 		slog.Error("federation/show-instance: FederationHostLists failed", "host", req.Host, "err", err)
 		return apierr.JSONInternalError(c)
 	}
-	return c.JSON(http.StatusOK, instanceToMap(inst, hosts))
+	return c.JSON(http.StatusOK, instanceToMap(inst, hosts, h.requesterIsModerator(c)))
 }
 
 // instanceToMap shapes an Instance row into the JSON response object expected
@@ -157,7 +188,14 @@ func (h *Handler) ShowInstance(c echo.Context) error {
 // meta.blockedHosts / silencedHosts / mediaSilencedHosts との suffix-match で
 // 判定する (本家 InstanceEntityService と同じ)。突合対象の host 一覧は呼び出し
 // 元が meta から 1 度だけ取得して渡す。
-func instanceToMap(inst *model.Instance, hosts coreinstance.FederationHostSets) map[string]any {
+func instanceToMap(inst *model.Instance, hosts coreinstance.FederationHostSets, showModerationNote bool) map[string]any {
+	// moderationNote はモデレーター専用フィールド。公開エンドポイントなので
+	// 非モデレーターには null を返す (upstream InstanceEntityService の
+	// `moderationNote: iAmModerator ? note : null` 互換)。
+	var moderationNote any
+	if showModerationNote {
+		moderationNote = inst.ModerationNote
+	}
 	return map[string]any{
 		"id":                      inst.ID,
 		"firstRetrievedAt":        inst.FirstRetrievedAt,
@@ -188,6 +226,6 @@ func instanceToMap(inst *model.Instance, hosts coreinstance.FederationHostSets) 
 		"faviconUrl":              inst.FaviconURL,
 		"themeColor":              inst.ThemeColor,
 		"infoUpdatedAt":           inst.InfoUpdatedAt,
-		"moderationNote":          inst.ModerationNote,
+		"moderationNote":          moderationNote,
 	}
 }

--- a/internal/api/federation/handler_test.go
+++ b/internal/api/federation/handler_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/shiroha-a/mk/internal/entitycompat/shapetest"
 	"github.com/shiroha-a/mk/internal/misc/id"
 	"github.com/shiroha-a/mk/internal/model"
+	"github.com/shiroha-a/mk/internal/server/middleware"
 	"github.com/shiroha-a/mk/internal/testutil"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -81,6 +82,57 @@ func TestInstances_Empty(t *testing.T) {
 	c, rec := newReq(t, `{}`)
 	require.NoError(t, h.Instances(c))
 	assert.Equal(t, http.StatusOK, rec.Code)
+}
+
+// fakeModerator implements ModeratorChecker for the moderationNote gate tests.
+type fakeModerator struct{ ids map[string]bool }
+
+func (f fakeModerator) IsModerator(userID string) bool { return f.ids[userID] }
+
+// moderationNote は公開エンドポイントなので未認証 (non-moderator) には null。
+func TestShowInstance_ModerationNoteHiddenFromPublic(t *testing.T) {
+	h, repo := newHandler(t)
+	inst := seedInstance(t, repo, "alpha.example")
+	inst.ModerationNote = "secret moderator memo"
+
+	c, rec := newReq(t, `{"host":"alpha.example"}`)
+	require.NoError(t, h.ShowInstance(c))
+	assert.Equal(t, http.StatusOK, rec.Code)
+
+	var resp map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+	assert.Nil(t, resp["moderationNote"], "moderationNote must be null for non-moderator")
+	assert.NotContains(t, rec.Body.String(), "secret moderator memo")
+}
+
+// moderator として認証されていれば moderationNote の実値が返る。
+func TestShowInstance_ModerationNoteVisibleToModerator(t *testing.T) {
+	h, repo := newHandler(t)
+	h.SetModeratorChecker(fakeModerator{ids: map[string]bool{"mod1": true}})
+	inst := seedInstance(t, repo, "alpha.example")
+	inst.ModerationNote = "secret moderator memo"
+
+	c, rec := newReq(t, `{"host":"alpha.example"}`)
+	c.Set(string(middleware.UserContextKey), &model.User{ID: "mod1"})
+	require.NoError(t, h.ShowInstance(c))
+	assert.Equal(t, http.StatusOK, rec.Code)
+
+	var resp map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+	assert.Equal(t, "secret moderator memo", resp["moderationNote"])
+}
+
+// 認証済みでも moderator でなければ moderationNote は隠す。
+func TestInstances_ModerationNoteHiddenFromNonModerator(t *testing.T) {
+	h, repo := newHandler(t)
+	h.SetModeratorChecker(fakeModerator{ids: map[string]bool{"mod1": true}})
+	inst := seedInstance(t, repo, "alpha.example")
+	inst.ModerationNote = "secret memo"
+
+	c, rec := newReq(t, `{"host":"alpha"}`)
+	c.Set(string(middleware.UserContextKey), &model.User{ID: "regular"})
+	require.NoError(t, h.Instances(c))
+	assert.NotContains(t, rec.Body.String(), "secret memo")
 }
 
 func TestInstances_Filtered(t *testing.T) {

--- a/internal/api/federation/handler_test.go
+++ b/internal/api/federation/handler_test.go
@@ -135,6 +135,36 @@ func TestInstances_ModerationNoteHiddenFromNonModerator(t *testing.T) {
 	assert.NotContains(t, rec.Body.String(), "secret memo")
 }
 
+// Instances (複数行) でも moderator には moderationNote が実値で返る。
+func TestInstances_ModerationNoteVisibleToModerator(t *testing.T) {
+	h, repo := newHandler(t)
+	h.SetModeratorChecker(fakeModerator{ids: map[string]bool{"mod1": true}})
+	inst := seedInstance(t, repo, "alpha.example")
+	inst.ModerationNote = "visible memo"
+
+	c, rec := newReq(t, `{"host":"alpha"}`)
+	c.Set(string(middleware.UserContextKey), &model.User{ID: "mod1"})
+	require.NoError(t, h.Instances(c))
+	var resp []map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+	require.NotEmpty(t, resp)
+	assert.Equal(t, "visible memo", resp[0]["moderationNote"])
+}
+
+// SetModeratorChecker 未配線 (moderator==nil) なら認証済みでも fail-closed で hidden。
+func TestShowInstance_ModerationNoteHiddenWhenCheckerUnwired(t *testing.T) {
+	h, repo := newHandler(t) // SetModeratorChecker を呼ばない
+	inst := seedInstance(t, repo, "alpha.example")
+	inst.ModerationNote = "secret memo"
+
+	c, rec := newReq(t, `{"host":"alpha.example"}`)
+	c.Set(string(middleware.UserContextKey), &model.User{ID: "whoever"})
+	require.NoError(t, h.ShowInstance(c))
+	var resp map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+	assert.Nil(t, resp["moderationNote"])
+}
+
 func TestInstances_Filtered(t *testing.T) {
 	h, repo := newHandler(t)
 	seedInstance(t, repo, "alpha.example")

--- a/internal/api/federation/stats.go
+++ b/internal/api/federation/stats.go
@@ -56,6 +56,9 @@ func (h *Handler) Stats(c echo.Context) error {
 	}
 
 	// federation/stats は公開エンドポイントなので moderationNote は出さない。
+	// upstream は me を packMany に渡し moderator には見せるが、frontend の stats
+	// consumer は host/count しか使わないため、mk-go は安全側に倒して常に隠す
+	// (緩い→厳しい方向の意図的な divergence、#parity review F1-fed)。
 	topSubFollowers := 0
 	topSub := make([]map[string]any, 0, len(subs))
 	for _, inst := range subs {

--- a/internal/api/federation/stats.go
+++ b/internal/api/federation/stats.go
@@ -55,17 +55,18 @@ func (h *Handler) Stats(c echo.Context) error {
 		return apierr.JSONInternalError(c)
 	}
 
+	// federation/stats は公開エンドポイントなので moderationNote は出さない。
 	topSubFollowers := 0
 	topSub := make([]map[string]any, 0, len(subs))
 	for _, inst := range subs {
 		topSubFollowers += inst.FollowersCount
-		topSub = append(topSub, instanceToMap(inst, hosts))
+		topSub = append(topSub, instanceToMap(inst, hosts, false))
 	}
 	topPubFollowing := 0
 	topPub := make([]map[string]any, 0, len(pubs))
 	for _, inst := range pubs {
 		topPubFollowing += inst.FollowingCount
-		topPub = append(topPub, instanceToMap(inst, hosts))
+		topPub = append(topPub, instanceToMap(inst, hosts, false))
 	}
 
 	return c.JSON(http.StatusOK, map[string]any{

--- a/internal/api/inbox/handler.go
+++ b/internal/api/inbox/handler.go
@@ -181,7 +181,12 @@ func (h *Handler) Inbox(c echo.Context) error {
 	}
 
 	// Legacy synchronous fallback (enqueuer 未配線時)。テストや旧来配線を
-	// 維持するために残してある。
+	// 維持するために残してある。production では router.go が必ず SetEnqueuer を
+	// 呼ぶため到達しない。なお本経路は worker 側 InboxProcessor が持つ
+	// actor-authorization gate (署名者 != activity.actor のなりすまし検出,
+	// #parity review AUTH-1/AUTH-4) を通らない。production が async 一択である
+	// 前提のため許容しているが、将来この fallback を残すなら同 gate の適用
+	// (または fallback 自体の撤去) が必要。
 	actor, err := h.verifySignature(c.Request())
 	if err != nil {
 		slog.Warn("inbox signature verification failed", "err", err)

--- a/internal/core/chat/service.go
+++ b/internal/core/chat/service.go
@@ -41,6 +41,10 @@ var (
 	// collides with an unrelated local room, so the inbound activity can never
 	// be applied. Callers should not retry.
 	ErrRoomOwnerMismatch = errors.New("chat room federation: room owner mismatch")
+	// ErrChatBlocked is returned by CreateMessageToUser when the recipient has
+	// blocked the sender. Mirrors upstream ChatService's 'blocked' error
+	// (YOU_HAVE_BEEN_BLOCKED).
+	ErrChatBlocked = errors.New("you have been blocked by the recipient")
 )
 
 // StreamingPublisher is the Redis pub/sub dispatch interface the service uses
@@ -96,6 +100,10 @@ type Service struct {
 	// moderatorChecker: chat/rooms/show 等の権限 gate で「moderator は閲覧可」
 	// を判定するために使う (upstream 2026.5.4 互換)。nil 安全。
 	moderatorChecker ModeratorChecker
+	// blockingRepo: 1-on-1 DM 送信時に recipient が sender を block して
+	// いないか判定する (upstream ChatService の YOU_HAVE_BEEN_BLOCKED gate)。
+	// nil なら block check は skip。
+	blockingRepo repository.BlockingRepository
 }
 
 // NewService constructs a chat Service.
@@ -131,6 +139,12 @@ func (s *Service) SetAPDelivery(userRepo repository.UserRepository, renderer *ac
 // nil なら moderator bypass は無効化 (= owner / member / 招待のみ true)。
 func (s *Service) SetModeratorChecker(m ModeratorChecker) {
 	s.moderatorChecker = m
+}
+
+// SetBlockingRepo wires a BlockingRepository so CreateMessageToUser can reject
+// DMs to a recipient who has blocked the sender. nil disables the block check.
+func (s *Service) SetBlockingRepo(r repository.BlockingRepository) {
+	s.blockingRepo = r
 }
 
 // HasPermissionToViewRoomInfo は room のメタ情報を閲覧できる権限を持つか判定する
@@ -269,6 +283,14 @@ func (s *Service) CreateMessageToUser(ctx context.Context, fromUserID, toUserID,
 					return nil, err
 				}
 			}
+		}
+	}
+	// recipient が sender を block している場合は DM を拒否する (upstream
+	// ChatService.createMessageToUser の checkBlocked(toUser, fromUser) 相当)。
+	if s.blockingRepo != nil {
+		blocked, err := s.blockingRepo.Exists(toUserID, fromUserID)
+		if err == nil && blocked {
+			return nil, ErrChatBlocked
 		}
 	}
 	msg := &model.ChatMessage{

--- a/internal/core/chat/service.go
+++ b/internal/core/chat/service.go
@@ -287,9 +287,13 @@ func (s *Service) CreateMessageToUser(ctx context.Context, fromUserID, toUserID,
 	}
 	// recipient が sender を block している場合は DM を拒否する (upstream
 	// ChatService.createMessageToUser の checkBlocked(toUser, fromUser) 相当)。
+	// DB error は fail-closed で扱う (canChat の granular check と同方針)。
 	if s.blockingRepo != nil {
 		blocked, err := s.blockingRepo.Exists(toUserID, fromUserID)
-		if err == nil && blocked {
+		if err != nil {
+			return nil, fmt.Errorf("chat block check: %w", err)
+		}
+		if blocked {
 			return nil, ErrChatBlocked
 		}
 	}
@@ -565,6 +569,18 @@ func (s *Service) CreateMessageViaAP(ctx context.Context, uri string, fromUser *
 			if err := s.canChat(fromUser, recipient); err != nil {
 				return nil, err
 			}
+		}
+	}
+	// inbound (連合) DM でも、recipient が sender を block していれば拒否する。
+	// CreateMessageToUser と同じ checkBlocked(toUser, fromUser) gate を AP 経路
+	// にも適用する (#parity review chat-block-1)。
+	if s.blockingRepo != nil {
+		blocked, err := s.blockingRepo.Exists(toUserID, fromUser.ID)
+		if err != nil {
+			return nil, fmt.Errorf("chat block check: %w", err)
+		}
+		if blocked {
+			return nil, ErrChatBlocked
 		}
 	}
 	msg := &model.ChatMessage{

--- a/internal/core/chat/service_test.go
+++ b/internal/core/chat/service_test.go
@@ -152,6 +152,33 @@ func TestCreateMessageToUser_NotBlockedPasses(t *testing.T) {
 	require.NoError(t, err)
 }
 
+// block check の DB error は fail-closed (送信せず error を返す)。
+func TestCreateMessageToUser_BlockCheckFailClosed(t *testing.T) {
+	svc, _, pub := newSvc(t)
+	blocks := testutil.NewMockBlockingRepository()
+	blocks.ExistsErr = errors.New("db down")
+	svc.SetBlockingRepo(blocks)
+
+	_, err := svc.CreateMessageToUser(context.Background(), "alice", "bob", "hi", "")
+	require.Error(t, err)
+	assert.Empty(t, pub.userCalls, "fail-closed: message must not be sent on block-check error")
+}
+
+// 連合 inbound DM (CreateMessageViaAP) でも recipient が sender を block して
+// いれば拒否される (#parity review chat-block-1)。
+func TestCreateMessageViaAP_BlockedByRecipient(t *testing.T) {
+	svc, _, pub := newSvc(t)
+	blocks := testutil.NewMockBlockingRepository()
+	// blocker=bob (local recipient), blockee=alice (remote sender)。
+	require.NoError(t, blocks.Create(&model.Blocking{ID: "b1", BlockerID: "bob", BlockeeID: "alice"}))
+	svc.SetBlockingRepo(blocks)
+
+	remoteSender := &model.User{ID: "alice"}
+	_, err := svc.CreateMessageViaAP(context.Background(), "https://remote/notes/1", remoteSender, "bob", "hi")
+	assert.ErrorIs(t, err, corechat.ErrChatBlocked)
+	assert.Empty(t, pub.userCalls, "blocked inbound DM must not be persisted/published")
+}
+
 // --- CreateMessageToRoom ---
 
 func seedRoom(t *testing.T, repo *testutil.MockChatRepository, id string, owner string, members ...string) {
@@ -173,6 +200,21 @@ func TestCreateMessageToRoom_Success(t *testing.T) {
 	require.Len(t, pub.roomCalls, 1)
 	assert.Equal(t, "r1", pub.roomCalls[0].roomID)
 	assert.Equal(t, corechat.EventMessage, pub.roomCalls[0].eventType)
+}
+
+// block は 1-on-1 DM のみに効き、room メッセージには影響しない (upstream の
+// createMessageToRoom も checkBlocked を呼ばない、#parity review chat-block-3)。
+func TestCreateMessageToRoom_BlockDoesNotAffectRoom(t *testing.T) {
+	svc, repo, _ := newSvc(t)
+	seedRoom(t, repo, "r1", "alice", "bob")
+	blocks := testutil.NewMockBlockingRepository()
+	// alice と bob が相互 block していても room メッセージは通る。
+	require.NoError(t, blocks.Create(&model.Blocking{ID: "b1", BlockerID: "alice", BlockeeID: "bob"}))
+	require.NoError(t, blocks.Create(&model.Blocking{ID: "b2", BlockerID: "bob", BlockeeID: "alice"}))
+	svc.SetBlockingRepo(blocks)
+
+	_, err := svc.CreateMessageToRoom(context.Background(), "bob", "r1", "hi room", "")
+	require.NoError(t, err, "room message must not be blocked by 1-on-1 block")
 }
 
 func TestCreateMessageToRoom_OwnerIsImplicitMember(t *testing.T) {

--- a/internal/core/chat/service_test.go
+++ b/internal/core/chat/service_test.go
@@ -127,6 +127,31 @@ func TestCreateMessageToUser_RepoError(t *testing.T) {
 	assert.Empty(t, pub.userCalls)
 }
 
+// recipient (bob) が sender (alice) を block していると DM は ErrChatBlocked。
+func TestCreateMessageToUser_BlockedByRecipient(t *testing.T) {
+	svc, _, pub := newSvc(t)
+	blocks := testutil.NewMockBlockingRepository()
+	// blocker=bob, blockee=alice。
+	require.NoError(t, blocks.Create(&model.Blocking{ID: "b1", BlockerID: "bob", BlockeeID: "alice"}))
+	svc.SetBlockingRepo(blocks)
+
+	_, err := svc.CreateMessageToUser(context.Background(), "alice", "bob", "hi", "")
+	assert.ErrorIs(t, err, corechat.ErrChatBlocked)
+	assert.Empty(t, pub.userCalls, "blocked DM must not be persisted/published")
+}
+
+// block 関係が無ければ通常どおり送信できる (block check は逆方向を見ない)。
+func TestCreateMessageToUser_NotBlockedPasses(t *testing.T) {
+	svc, _, _ := newSvc(t)
+	blocks := testutil.NewMockBlockingRepository()
+	// alice が bob を block していても、bob→alice は送れる(逆方向 block は無関係)。
+	require.NoError(t, blocks.Create(&model.Blocking{ID: "b1", BlockerID: "alice", BlockeeID: "bob"}))
+	svc.SetBlockingRepo(blocks)
+
+	_, err := svc.CreateMessageToUser(context.Background(), "alice", "bob", "hi", "")
+	require.NoError(t, err)
+}
+
 // --- CreateMessageToRoom ---
 
 func seedRoom(t *testing.T, repo *testutil.MockChatRepository, id string, owner string, members ...string) {

--- a/internal/core/federation/extract_actor_test.go
+++ b/internal/core/federation/extract_actor_test.go
@@ -1,0 +1,33 @@
+package federation_test
+
+import (
+	"testing"
+
+	corefed "github.com/shiroha-a/mk/internal/core/federation"
+	"github.com/stretchr/testify/assert"
+)
+
+// ExtractActorIRI must derive the SAME actor that Process dispatches on, after
+// applying the singleton-array unwrap + JSON-LD normalization. This is what
+// makes the InboxProcessor actor-authorization gate robust against
+// as:actor / {"@id":...} / array-wrapped spoof shapes (#parity review AUTH-1).
+func TestExtractActorIRI(t *testing.T) {
+	const victim = "https://victim.example/users/alice"
+	cases := []struct {
+		name string
+		body string
+		want string
+	}{
+		{"plain string", `{"type":"Delete","actor":"` + victim + `"}`, victim},
+		{"@id object", `{"type":"Delete","actor":{"@id":"` + victim + `"}}`, victim},
+		{"as:actor prefix", `{"type":"Delete","as:actor":"` + victim + `"}`, victim},
+		{"singleton array", `[{"type":"Delete","actor":"` + victim + `"}]`, victim},
+		{"missing actor", `{"type":"Delete"}`, ""},
+		{"invalid json", `{not json`, ""},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, corefed.ExtractActorIRI([]byte(tc.body)))
+		})
+	}
+}

--- a/internal/core/federation/ld_signature_verifier.go
+++ b/internal/core/federation/ld_signature_verifier.go
@@ -47,24 +47,39 @@ func NewLDSignatureVerifier(pubkeyRepo repository.UserPublickeyRepository) *LDSi
 //   - RsaSignature2017 verify fails (signature mismatch / key mismatch /
 //     unsupported algorithm)
 func (v *LDSignatureVerifier) VerifyIfPresent(rawBody []byte) error {
+	_, _, err := v.VerifyAndCreator(rawBody)
+	return err
+}
+
+// VerifyAndCreator behaves like VerifyIfPresent but additionally reports
+// whether the activity carried an LD-Signature (`present`) and, on success,
+// the verified `signature.creator` key URI. Callers use the creator to
+// confirm the LD-Signature actually authenticates the activity's `actor`
+// (forwarded-activity authentication, upstream
+// `authUser.user.uri !== getApId(activity.actor)` gate).
+//
+//   - no `signature` field        -> ("", false, nil)
+//   - signature present + verify  -> (creator, true, nil)
+//   - signature present + invalid -> ("", true, err)
+func (v *LDSignatureVerifier) VerifyAndCreator(rawBody []byte) (string, bool, error) {
 	if v == nil || v.pubkeyRepo == nil {
-		return nil
+		return "", false, nil
 	}
 	var act map[string]any
 	if err := json.Unmarshal(rawBody, &act); err != nil {
-		return fmt.Errorf("ld-sig: body unmarshal: %w", err)
+		return "", false, fmt.Errorf("ld-sig: body unmarshal: %w", err)
 	}
 	sigRaw, hasSig := act["signature"]
 	if !hasSig || sigRaw == nil {
-		return nil
+		return "", false, nil
 	}
 	sig, ok := sigRaw.(map[string]any)
 	if !ok {
-		return errors.New("ld-sig: signature field is not an object")
+		return "", true, errors.New("ld-sig: signature field is not an object")
 	}
 	creator, _ := sig["creator"].(string)
 	if creator == "" {
-		return errors.New("ld-sig: signature.creator missing")
+		return "", true, errors.New("ld-sig: signature.creator missing")
 	}
 	// per-verify fresh processor (upstream JsonLd class instance と等価)。
 	// cache cap / freeze は新規 instance ごとに reset される。
@@ -89,12 +104,15 @@ func (v *LDSignatureVerifier) VerifyIfPresent(rawBody []byte) error {
 	// `proc.Compact(act, ...)` を挟んでから check するフローに変更する。
 	proc := ld.NewProcessor()
 	if err := proc.CheckForForbiddenDirectives(act); err != nil {
-		return err
+		return "", true, err
 	}
 	proc.Freeze()
 	pubkey, err := v.pubkeyRepo.FindByKeyID(creator)
 	if err != nil {
-		return fmt.Errorf("ld-sig: public key not found for keyId=%s: %w", creator, err)
+		return "", true, fmt.Errorf("ld-sig: public key not found for keyId=%s: %w", creator, err)
 	}
-	return proc.VerifyRsaSignature2017(act, pubkey.KeyPEM)
+	if err := proc.VerifyRsaSignature2017(act, pubkey.KeyPEM); err != nil {
+		return "", true, err
+	}
+	return creator, true, nil
 }

--- a/internal/core/federation/ld_signature_verifier_test.go
+++ b/internal/core/federation/ld_signature_verifier_test.go
@@ -66,6 +66,19 @@ func TestLDSignatureVerifier_MissingCreator_Rejected(t *testing.T) {
 	assert.Contains(t, err.Error(), "creator missing")
 }
 
+// signature field がオブジェクトでない (例: 文字列) 場合は reject。present=true
+// を報告しつつ error を返す (VerifyAndCreator 経路)。
+func TestLDSignatureVerifier_SignatureNotObject_Rejected(t *testing.T) {
+	repo := testutil.NewMockUserPublickeyRepository()
+	v := corefederation.NewLDSignatureVerifier(repo)
+
+	creator, present, err := v.VerifyAndCreator([]byte(`{"type":"Note","signature":"not-an-object"}`))
+	require.Error(t, err)
+	assert.True(t, present, "signature field exists, so present must be true")
+	assert.Empty(t, creator)
+	assert.Contains(t, err.Error(), "not an object")
+}
+
 func TestLDSignatureVerifier_UnknownCreator_Rejected(t *testing.T) {
 	repo := testutil.NewMockUserPublickeyRepository()
 	v := corefederation.NewLDSignatureVerifier(repo)

--- a/internal/core/federation/processor.go
+++ b/internal/core/federation/processor.go
@@ -394,6 +394,31 @@ func (p *Processor) Process(body []byte) error {
 	return ErrUnsupportedActivity
 }
 
+// ExtractActorIRI returns the authoritative actor IRI of an inbound activity,
+// applying the SAME singleton-array unwrap + JSON-LD normalization that Process
+// performs before dispatch. The InboxProcessor's actor-authorization gate must
+// use this (not a raw-body parse) so that the actor it authorizes is exactly
+// the actor Process will act on. Otherwise `as:actor`, `actor:{"@id":...}` or a
+// singleton-array-wrapped activity would let an attacker present an empty/benign
+// actor to the gate while Process resolves the real (spoofed) actor.
+//
+// Returns "" when no actor can be derived (Process will then reject the body).
+func ExtractActorIRI(body []byte) string {
+	if unwrapped, ok := tryUnwrapSingletonArray(body); ok {
+		body = unwrapped
+	}
+	normalized, err := activitypub.Normalize(body)
+	if err != nil {
+		return ""
+	}
+	var act genericActivity
+	if err := json.Unmarshal(normalized, &act); err != nil {
+		return ""
+	}
+	act.normalizeActor(normalized)
+	return act.Actor
+}
+
 // SetBlockingService wires the blocking service for Block/Undo Block activities.
 func (p *Processor) SetBlockingService(svc *coreblocking.Service) {
 	p.blockingService = svc

--- a/internal/core/transfer/drive_reader_test.go
+++ b/internal/core/transfer/drive_reader_test.go
@@ -76,11 +76,11 @@ func (f *fakeDriveFileRepo) ListByUser(_ string, _ *string, _, _ string, _ int) 
 func (f *fakeDriveFileRepo) FindByName(_, _ string, _ *string) ([]*model.DriveFile, error) {
 	return nil, nil
 }
-func (f *fakeDriveFileRepo) ExistsByMD5(_, _ string) (bool, error)                { return false, nil }
-func (f *fakeDriveFileRepo) CountByFolder(_ string) (int, error)                  { return 0, nil }
-func (f *fakeDriveFileRepo) ListByFileIDs(_ []string) ([]*model.DriveFile, error) { return nil, nil }
-func (f *fakeDriveFileRepo) UsageByUser(_ string) (int64, error)                  { return 0, nil }
-func (f *fakeDriveFileRepo) UpdateBulkFolder(_ []string, _ *string) error         { return nil }
+func (f *fakeDriveFileRepo) ExistsByMD5(_, _ string) (bool, error)                  { return false, nil }
+func (f *fakeDriveFileRepo) CountByFolder(_ string) (int, error)                    { return 0, nil }
+func (f *fakeDriveFileRepo) ListByFileIDs(_ []string) ([]*model.DriveFile, error)   { return nil, nil }
+func (f *fakeDriveFileRepo) UsageByUser(_ string) (int64, error)                    { return 0, nil }
+func (f *fakeDriveFileRepo) UpdateBulkFolder(_ string, _ []string, _ *string) error { return nil }
 func (f *fakeDriveFileRepo) ListForAdmin(_, _, _, _, _, _ string, _ int) ([]*model.DriveFile, error) {
 	return nil, nil
 }

--- a/internal/queue/processors/inbox.go
+++ b/internal/queue/processors/inbox.go
@@ -3,6 +3,7 @@ package processors
 import (
 	"bytes"
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"log/slog"
@@ -78,6 +79,11 @@ type InboxChartHook interface {
 // 実装は core/federation.LDSignatureVerifier。
 type LDSignatureVerifier interface {
 	VerifyIfPresent(rawBody []byte) error
+	// VerifyAndCreator additionally reports whether the activity carried an
+	// LD-Signature and, on success, the verified signature.creator key URI.
+	// Used to authenticate forwarded activities whose HTTP signer differs
+	// from the activity actor.
+	VerifyAndCreator(rawBody []byte) (creator string, present bool, err error)
 }
 
 type InboxProcessor struct {
@@ -170,27 +176,31 @@ func (p *InboxProcessor) Handle(_ context.Context, t driver.Task) error {
 			// よって upstream の追加 case 分岐は mk-go では不要 (= triage #1003 close)。
 			return nil
 		}
+		// HTTP 署名者 (actor) が activity body の actor と一致することを保証する
+		// (actor spoofing 対策)。一致しない場合は転送活動とみなし LD-Signature が
+		// body actor を認証している場合のみ許可する。LD-Signature の hardening
+		// (forbidden directive 等) も本 gate に集約する。
+		if err := p.authorizeActor(payload.Body, actor); err != nil {
+			slog.Warn("inbox: actor authorization failed, dropping activity",
+				"host", payload.Host, "err", err)
+			return nil
+		}
 		if actor != nil && actor.Host != nil {
 			host = *actor.Host
 		}
 		p.touchInstance(actor)
 		p.commitChart(actor)
-	}
-	_ = host // reserved for future per-host stats; currently unused
-
-	// LD-Signature verify (#1164 Phase D)。HTTP Signature 検証通過後の追加
-	// gate で、activity body に signature field があれば RsaSignature2017 +
-	// 2026.5.4 hardening を実行する。fail なら activity を drop (= queue ack
-	// するが Process は呼ばない、upstream UnrecoverableError 互換挙動)。
-	// signature 無し / verifier 未配線では skip (= HTTP Signature のみ
-	// で従来通り処理)。
-	if p.ldVerifier != nil {
+	} else if p.ldVerifier != nil {
+		// legacy / direct-enqueue 経路 (Headers 無し = HTTP 署名者を特定できない)。
+		// 署名者照合はできないが、body に LD-Signature があれば従来どおり検証して
+		// hardening を効かせる (#1164 Phase D)。fail なら drop。
 		if err := p.ldVerifier.VerifyIfPresent(payload.Body); err != nil {
 			slog.Warn("inbox: LD-Signature verification failed, dropping activity",
 				"host", payload.Host, "err", err)
 			return nil
 		}
 	}
+	_ = host // reserved for future per-host stats; currently unused
 
 	if err := p.processor.Process(payload.Body); err != nil {
 		if errors.Is(err, federation.ErrUnsupportedActivity) {
@@ -234,6 +244,88 @@ func (p *InboxProcessor) verifyPayload(payload queue.InboxPayload) (*model.User,
 		return nil, err
 	}
 	return actor, nil
+}
+
+// authorizeActor enforces that the HTTP-signature signer is authorized to
+// post the given activity, mirroring upstream InboxProcessorService's
+// `authUser.user.uri !== getApId(activity.actor)` gate.
+//
+//   - signer URI == activity.actor  -> accept (the common case). LD-Signature,
+//     if present, is still verified for hardening (forbidden directives etc.).
+//   - signer URI != activity.actor  -> the activity was forwarded (e.g.
+//     Mastodon-style relay). Accept ONLY when a valid LD-Signature
+//     authenticates the activity actor: the LD-Signature must be present, must
+//     verify, and its creator key must belong to a user whose URI equals
+//     activity.actor. Otherwise drop (return error) to block actor spoofing.
+func (p *InboxProcessor) authorizeActor(body []byte, signer *model.User) error {
+	bodyActor := extractActorIRI(body)
+	if bodyActor == "" {
+		// actor 欠落は Process 側 ("activity missing actor") が弾く。ここでは
+		// 判定不能なので素通しし、なりすまし対象が無い状態にする。
+		return nil
+	}
+	signerURI := ""
+	if signer != nil && signer.URI != nil {
+		signerURI = *signer.URI
+	}
+
+	if signerURI != "" && signerURI == bodyActor {
+		// 署名者 == actor。LD-Signature があれば hardening のため検証する。
+		if p.ldVerifier != nil {
+			return p.ldVerifier.VerifyIfPresent(body)
+		}
+		return nil
+	}
+
+	// 署名者 != actor: 転送活動の可能性。LD-Signature による actor 認証が必須。
+	if p.ldVerifier == nil {
+		return fmt.Errorf("actor mismatch and no LD verifier: signer=%q actor=%q", signerURI, bodyActor)
+	}
+	creator, present, err := p.ldVerifier.VerifyAndCreator(body)
+	if err != nil {
+		return fmt.Errorf("ld-signature verify failed: %w", err)
+	}
+	if !present {
+		return fmt.Errorf("actor mismatch and no LD-signature: signer=%q actor=%q", signerURI, bodyActor)
+	}
+	// LD-Signature の creator (鍵) の owner URI が activity.actor と一致するか
+	// 確認する。一致しなければ「自分の鍵で署名したが他人を actor に詐称」した
+	// 活動なので drop する。
+	ldUser, err := p.verifier.ResolveActor(activitypub.ResolveKeyURL(creator))
+	if err != nil {
+		return fmt.Errorf("resolve ld-signature creator %q: %w", creator, err)
+	}
+	ldURI := ""
+	if ldUser != nil && ldUser.URI != nil {
+		ldURI = *ldUser.URI
+	}
+	if ldURI == "" || ldURI != bodyActor {
+		return fmt.Errorf("ld-signature signer %q != activity.actor %q", ldURI, bodyActor)
+	}
+	return nil
+}
+
+// extractActorIRI reads the `actor` IRI from an activity body. The actor may
+// be a bare string IRI or an embedded object carrying an `id` (upstream
+// Misskey #17340), so both shapes are handled.
+func extractActorIRI(body []byte) string {
+	var probe struct {
+		Actor json.RawMessage `json:"actor"`
+	}
+	if err := json.Unmarshal(body, &probe); err != nil || len(probe.Actor) == 0 {
+		return ""
+	}
+	var s string
+	if err := json.Unmarshal(probe.Actor, &s); err == nil {
+		return s
+	}
+	var obj struct {
+		ID string `json:"id"`
+	}
+	if err := json.Unmarshal(probe.Actor, &obj); err == nil {
+		return obj.ID
+	}
+	return ""
 }
 
 // buildSignedRequest reconstructs an *http.Request that activitypub.

--- a/internal/queue/processors/inbox.go
+++ b/internal/queue/processors/inbox.go
@@ -258,7 +258,11 @@ func (p *InboxProcessor) verifyPayload(payload queue.InboxPayload) (*model.User,
 //     verify, and its creator key must belong to a user whose URI equals
 //     activity.actor. Otherwise drop (return error) to block actor spoofing.
 func (p *InboxProcessor) authorizeActor(body []byte, signer *model.User) error {
-	bodyActor := extractActorIRI(body)
+	// gate は Process と同じ unwrap+Normalize を経た actor を見る必要がある。
+	// raw body を直接 parse すると `as:actor` / `{"@id":...}` / 配列 wrap で
+	// gate を空 actor にすり抜けさせ、Process だけが本当の actor で動く
+	// なりすまし経路が残る (#parity review AUTH-1)。
+	bodyActor := federation.ExtractActorIRI(body)
 	if bodyActor == "" {
 		// actor 欠落は Process 側 ("activity missing actor") が弾く。ここでは
 		// 判定不能なので素通しし、なりすまし対象が無い状態にする。
@@ -281,20 +285,28 @@ func (p *InboxProcessor) authorizeActor(body []byte, signer *model.User) error {
 	if p.ldVerifier == nil {
 		return fmt.Errorf("actor mismatch and no LD verifier: signer=%q actor=%q", signerURI, bodyActor)
 	}
-	creator, present, err := p.ldVerifier.VerifyAndCreator(body)
-	if err != nil {
-		return fmt.Errorf("ld-signature verify failed: %w", err)
+	// LD-Signature の creator (鍵 URI) を body から読む。
+	creatorKeyID := extractLDCreator(body)
+	if creatorKeyID == "" {
+		return fmt.Errorf("actor mismatch and no LD-signature: signer=%q actor=%q", signerURI, bodyActor)
 	}
-	if !present {
+	// 検証より先に creator actor を解決して鍵を取得/永続化する。VerifyAndCreator
+	// は FindByKeyID の純粋 DB read で、先に解決しておかないと未知 origin actor
+	// からの最初の転送活動が常に drop される (#parity review AUTH-2、upstream
+	// getAuthUserFromKeyId は未知 actor を fetch する挙動と整合)。
+	ldUser, err := p.verifier.ResolveActor(activitypub.ResolveKeyURL(creatorKeyID))
+	if err != nil {
+		return fmt.Errorf("resolve ld-signature creator %q: %w", creatorKeyID, err)
+	}
+	// 鍵が DB に載った状態で LD-Signature 本体を検証する。
+	if _, present, err := p.ldVerifier.VerifyAndCreator(body); err != nil {
+		return fmt.Errorf("ld-signature verify failed: %w", err)
+	} else if !present {
 		return fmt.Errorf("actor mismatch and no LD-signature: signer=%q actor=%q", signerURI, bodyActor)
 	}
 	// LD-Signature の creator (鍵) の owner URI が activity.actor と一致するか
 	// 確認する。一致しなければ「自分の鍵で署名したが他人を actor に詐称」した
 	// 活動なので drop する。
-	ldUser, err := p.verifier.ResolveActor(activitypub.ResolveKeyURL(creator))
-	if err != nil {
-		return fmt.Errorf("resolve ld-signature creator %q: %w", creator, err)
-	}
 	ldURI := ""
 	if ldUser != nil && ldUser.URI != nil {
 		ldURI = *ldUser.URI
@@ -305,27 +317,18 @@ func (p *InboxProcessor) authorizeActor(body []byte, signer *model.User) error {
 	return nil
 }
 
-// extractActorIRI reads the `actor` IRI from an activity body. The actor may
-// be a bare string IRI or an embedded object carrying an `id` (upstream
-// Misskey #17340), so both shapes are handled.
-func extractActorIRI(body []byte) string {
+// extractLDCreator reads `signature.creator` (the LD-Signature key URI) from a
+// raw activity body. Returns "" when there is no LD-Signature or no creator.
+func extractLDCreator(body []byte) string {
 	var probe struct {
-		Actor json.RawMessage `json:"actor"`
+		Signature struct {
+			Creator string `json:"creator"`
+		} `json:"signature"`
 	}
-	if err := json.Unmarshal(body, &probe); err != nil || len(probe.Actor) == 0 {
+	if err := json.Unmarshal(body, &probe); err != nil {
 		return ""
 	}
-	var s string
-	if err := json.Unmarshal(probe.Actor, &s); err == nil {
-		return s
-	}
-	var obj struct {
-		ID string `json:"id"`
-	}
-	if err := json.Unmarshal(probe.Actor, &obj); err == nil {
-		return obj.ID
-	}
-	return ""
+	return probe.Signature.Creator
 }
 
 // buildSignedRequest reconstructs an *http.Request that activitypub.

--- a/internal/queue/processors/inbox_test.go
+++ b/internal/queue/processors/inbox_test.go
@@ -176,8 +176,9 @@ func TestInboxProcessor_VerifiesSignatureAndCommitsHooks(t *testing.T) {
 	require.NoError(t, err)
 
 	host := "remote.example"
+	aliceURI := "https://remote.example/users/alice"
 	verifier := &stubVerifier{
-		actor:  &model.User{ID: "alice", Host: &host},
+		actor:  &model.User{ID: "alice", Host: &host, URI: &aliceURI},
 		pubKey: pub,
 	}
 	tracker := &stubInstanceTracker{}
@@ -384,11 +385,225 @@ func TestInboxProcessor_LegacyPayloadSkipsVerify(t *testing.T) {
 type stubLDVerifier struct {
 	err       error
 	callCount int
+	// VerifyAndCreator outcome (forwarded-activity path).
+	creator      string
+	present      bool
+	creatorCount int
 }
 
 func (s *stubLDVerifier) VerifyIfPresent(_ []byte) error {
 	s.callCount++
 	return s.err
+}
+
+func (s *stubLDVerifier) VerifyAndCreator(_ []byte) (string, bool, error) {
+	s.creatorCount++
+	return s.creator, s.present, s.err
+}
+
+// multiActorVerifier resolves different actors keyed by the (fragment-less)
+// actor URI passed to ResolveActor, so actor-authorization tests can model a
+// signer and an LD-Signature creator that map to distinct users.
+type multiActorVerifier struct {
+	pubKey string
+	byURI  map[string]*model.User
+}
+
+func (m *multiActorVerifier) ResolveActor(actorURI string) (*model.User, error) {
+	if u, ok := m.byURI[actorURI]; ok {
+		return u, nil
+	}
+	return nil, errors.New("not found")
+}
+
+func (m *multiActorVerifier) PublicKeyForActor(_ string) (string, error) {
+	return m.pubKey, nil
+}
+
+func (m *multiActorVerifier) PublicKeyForKeyID(_, _ string) (string, error) {
+	return m.pubKey, nil
+}
+
+func uptr(s string) *string { return &s }
+
+// 署名者 (HTTP signature) と activity body の actor が異なり、LD-Signature も
+// 無い場合は actor spoofing として drop される。
+func TestInboxProcessor_ActorSpoofDropped(t *testing.T) {
+	priv, pub, err := activitypub.GenerateRSAKeypair()
+	require.NoError(t, err)
+	// 署名者 = evil/bob だが body actor は victim/alice を詐称する。
+	key, err := activitypub.NewPrivateKey("https://evil.example/users/bob#main-key", priv)
+	require.NoError(t, err)
+
+	bobHost := "evil.example"
+	verifier := &multiActorVerifier{
+		pubKey: pub,
+		byURI: map[string]*model.User{
+			"https://evil.example/users/bob": {ID: "bob", Host: &bobHost, URI: uptr("https://evil.example/users/bob")},
+		},
+	}
+	stub := &stubFedProcessor{}
+	p := processors.NewInboxProcessor(stub)
+	p.SetSignatureVerifier(verifier)
+	p.SetLDSignatureVerifier(&stubLDVerifier{present: false})
+
+	body := []byte(`{"type":"Delete","actor":"https://victim.example/users/alice","object":"https://victim.example/notes/1"}`)
+	payload := signedInboxPayload(t, key, body)
+	require.NoError(t, p.Handle(context.Background(), driver.RawTask{
+		TypeName: queue.TaskTypeInbox,
+		Body:     mustEncode(t, payload),
+	}))
+	assert.Empty(t, stub.calls, "spoofed actor (signer != actor, no LD-sig) must be dropped")
+}
+
+// 署名者 != actor でも、LD-Signature が body actor を正しく認証していれば
+// 転送活動として受理する (Mastodon-style forwarding)。
+func TestInboxProcessor_ForwardedWithValidLDSig(t *testing.T) {
+	priv, pub, err := activitypub.GenerateRSAKeypair()
+	require.NoError(t, err)
+	// 署名者 = relay。
+	key, err := activitypub.NewPrivateKey("https://relay.example/actor#main-key", priv)
+	require.NoError(t, err)
+
+	relayHost := "relay.example"
+	originHost := "origin.example"
+	verifier := &multiActorVerifier{
+		pubKey: pub,
+		byURI: map[string]*model.User{
+			"https://relay.example/actor":        {ID: "relay", Host: &relayHost, URI: uptr("https://relay.example/actor")},
+			"https://origin.example/users/alice": {ID: "alice", Host: &originHost, URI: uptr("https://origin.example/users/alice")},
+		},
+	}
+	stub := &stubFedProcessor{}
+	p := processors.NewInboxProcessor(stub)
+	p.SetSignatureVerifier(verifier)
+	// LD-Signature が origin/alice の鍵で署名済 (creator が alice を指す)。
+	p.SetLDSignatureVerifier(&stubLDVerifier{present: true, creator: "https://origin.example/users/alice#main-key"})
+
+	body := []byte(`{"type":"Create","actor":"https://origin.example/users/alice","signature":{"type":"RsaSignature2017"}}`)
+	payload := signedInboxPayload(t, key, body)
+	require.NoError(t, p.Handle(context.Background(), driver.RawTask{
+		TypeName: queue.TaskTypeInbox,
+		Body:     mustEncode(t, payload),
+	}))
+	require.Len(t, stub.calls, 1, "forwarded activity authenticated by LD-Signature must be processed")
+}
+
+// activity.actor が embedded object ({"id": ...}) 形式でも署名者 URI と
+// 照合できる (upstream #17340 互換)。
+func TestInboxProcessor_ActorObjectFormMatches(t *testing.T) {
+	priv, pub, err := activitypub.GenerateRSAKeypair()
+	require.NoError(t, err)
+	key, err := activitypub.NewPrivateKey("https://remote.example/users/alice#main-key", priv)
+	require.NoError(t, err)
+
+	host := "remote.example"
+	verifier := &multiActorVerifier{
+		pubKey: pub,
+		byURI: map[string]*model.User{
+			"https://remote.example/users/alice": {ID: "alice", Host: &host, URI: uptr("https://remote.example/users/alice")},
+		},
+	}
+	stub := &stubFedProcessor{}
+	p := processors.NewInboxProcessor(stub)
+	p.SetSignatureVerifier(verifier)
+
+	body := []byte(`{"type":"Follow","actor":{"id":"https://remote.example/users/alice","type":"Person"}}`)
+	payload := signedInboxPayload(t, key, body)
+	require.NoError(t, p.Handle(context.Background(), driver.RawTask{
+		TypeName: queue.TaskTypeInbox,
+		Body:     mustEncode(t, payload),
+	}))
+	require.Len(t, stub.calls, 1, "object-form actor matching the signer must be processed")
+}
+
+// 署名者 != actor かつ LD verifier 未配線なら drop。
+func TestInboxProcessor_ActorMismatchNoLDVerifierDropped(t *testing.T) {
+	priv, pub, err := activitypub.GenerateRSAKeypair()
+	require.NoError(t, err)
+	key, err := activitypub.NewPrivateKey("https://evil.example/users/bob#main-key", priv)
+	require.NoError(t, err)
+
+	bobHost := "evil.example"
+	verifier := &multiActorVerifier{
+		pubKey: pub,
+		byURI: map[string]*model.User{
+			"https://evil.example/users/bob": {ID: "bob", Host: &bobHost, URI: uptr("https://evil.example/users/bob")},
+		},
+	}
+	stub := &stubFedProcessor{}
+	p := processors.NewInboxProcessor(stub)
+	p.SetSignatureVerifier(verifier) // ldVerifier は配線しない
+
+	body := []byte(`{"type":"Delete","actor":"https://victim.example/users/alice"}`)
+	payload := signedInboxPayload(t, key, body)
+	require.NoError(t, p.Handle(context.Background(), driver.RawTask{
+		TypeName: queue.TaskTypeInbox,
+		Body:     mustEncode(t, payload),
+	}))
+	assert.Empty(t, stub.calls, "mismatch with no LD verifier must be dropped")
+}
+
+// 署名者 != actor、LD-Signature は present だが creator を resolve できない
+// 場合は drop。
+func TestInboxProcessor_ForwardedLDCreatorUnresolvableDropped(t *testing.T) {
+	priv, pub, err := activitypub.GenerateRSAKeypair()
+	require.NoError(t, err)
+	key, err := activitypub.NewPrivateKey("https://relay.example/actor#main-key", priv)
+	require.NoError(t, err)
+
+	relayHost := "relay.example"
+	verifier := &multiActorVerifier{
+		pubKey: pub,
+		byURI: map[string]*model.User{
+			"https://relay.example/actor": {ID: "relay", Host: &relayHost, URI: uptr("https://relay.example/actor")},
+			// LD creator (unknown.example) は byURI に無い → ResolveActor が error。
+		},
+	}
+	stub := &stubFedProcessor{}
+	p := processors.NewInboxProcessor(stub)
+	p.SetSignatureVerifier(verifier)
+	p.SetLDSignatureVerifier(&stubLDVerifier{present: true, creator: "https://unknown.example/users/x#main-key"})
+
+	body := []byte(`{"type":"Create","actor":"https://origin.example/users/alice","signature":{"type":"RsaSignature2017"}}`)
+	payload := signedInboxPayload(t, key, body)
+	require.NoError(t, p.Handle(context.Background(), driver.RawTask{
+		TypeName: queue.TaskTypeInbox,
+		Body:     mustEncode(t, payload),
+	}))
+	assert.Empty(t, stub.calls, "unresolvable LD creator must be dropped")
+}
+
+// 署名者 != actor で LD-Signature はあるが、その creator が body actor とは
+// 別人を指す場合は drop する (自分の鍵で署名して他人を詐称する攻撃)。
+func TestInboxProcessor_ForwardedLDSigWrongActorDropped(t *testing.T) {
+	priv, pub, err := activitypub.GenerateRSAKeypair()
+	require.NoError(t, err)
+	key, err := activitypub.NewPrivateKey("https://relay.example/actor#main-key", priv)
+	require.NoError(t, err)
+
+	relayHost := "relay.example"
+	evilHost := "evil.example"
+	verifier := &multiActorVerifier{
+		pubKey: pub,
+		byURI: map[string]*model.User{
+			"https://relay.example/actor":    {ID: "relay", Host: &relayHost, URI: uptr("https://relay.example/actor")},
+			"https://evil.example/users/mal": {ID: "mal", Host: &evilHost, URI: uptr("https://evil.example/users/mal")},
+		},
+	}
+	stub := &stubFedProcessor{}
+	p := processors.NewInboxProcessor(stub)
+	p.SetSignatureVerifier(verifier)
+	// LD creator = mal だが body actor は alice を詐称。
+	p.SetLDSignatureVerifier(&stubLDVerifier{present: true, creator: "https://evil.example/users/mal#main-key"})
+
+	body := []byte(`{"type":"Create","actor":"https://origin.example/users/alice","signature":{"type":"RsaSignature2017"}}`)
+	payload := signedInboxPayload(t, key, body)
+	require.NoError(t, p.Handle(context.Background(), driver.RawTask{
+		TypeName: queue.TaskTypeInbox,
+		Body:     mustEncode(t, payload),
+	}))
+	assert.Empty(t, stub.calls, "LD-Signature creator != activity.actor must be dropped")
 }
 
 // SetLDSignatureVerifier 未配線 (= ldVerifier nil) なら gate は skip され

--- a/internal/queue/processors/inbox_test.go
+++ b/internal/queue/processors/inbox_test.go
@@ -480,7 +480,7 @@ func TestInboxProcessor_ForwardedWithValidLDSig(t *testing.T) {
 	// LD-Signature が origin/alice の鍵で署名済 (creator が alice を指す)。
 	p.SetLDSignatureVerifier(&stubLDVerifier{present: true, creator: "https://origin.example/users/alice#main-key"})
 
-	body := []byte(`{"type":"Create","actor":"https://origin.example/users/alice","signature":{"type":"RsaSignature2017"}}`)
+	body := []byte(`{"type":"Create","actor":"https://origin.example/users/alice","signature":{"type":"RsaSignature2017","creator":"https://origin.example/users/alice#main-key"}}`)
 	payload := signedInboxPayload(t, key, body)
 	require.NoError(t, p.Handle(context.Background(), driver.RawTask{
 		TypeName: queue.TaskTypeInbox,
@@ -563,9 +563,9 @@ func TestInboxProcessor_ForwardedLDCreatorUnresolvableDropped(t *testing.T) {
 	stub := &stubFedProcessor{}
 	p := processors.NewInboxProcessor(stub)
 	p.SetSignatureVerifier(verifier)
-	p.SetLDSignatureVerifier(&stubLDVerifier{present: true, creator: "https://unknown.example/users/x#main-key"})
+	p.SetLDSignatureVerifier(&stubLDVerifier{present: true})
 
-	body := []byte(`{"type":"Create","actor":"https://origin.example/users/alice","signature":{"type":"RsaSignature2017"}}`)
+	body := []byte(`{"type":"Create","actor":"https://origin.example/users/alice","signature":{"type":"RsaSignature2017","creator":"https://unknown.example/users/x#main-key"}}`)
 	payload := signedInboxPayload(t, key, body)
 	require.NoError(t, p.Handle(context.Background(), driver.RawTask{
 		TypeName: queue.TaskTypeInbox,
@@ -595,15 +595,59 @@ func TestInboxProcessor_ForwardedLDSigWrongActorDropped(t *testing.T) {
 	p := processors.NewInboxProcessor(stub)
 	p.SetSignatureVerifier(verifier)
 	// LD creator = mal だが body actor は alice を詐称。
-	p.SetLDSignatureVerifier(&stubLDVerifier{present: true, creator: "https://evil.example/users/mal#main-key"})
+	p.SetLDSignatureVerifier(&stubLDVerifier{present: true})
 
-	body := []byte(`{"type":"Create","actor":"https://origin.example/users/alice","signature":{"type":"RsaSignature2017"}}`)
+	body := []byte(`{"type":"Create","actor":"https://origin.example/users/alice","signature":{"type":"RsaSignature2017","creator":"https://evil.example/users/mal#main-key"}}`)
 	payload := signedInboxPayload(t, key, body)
 	require.NoError(t, p.Handle(context.Background(), driver.RawTask{
 		TypeName: queue.TaskTypeInbox,
 		Body:     mustEncode(t, payload),
 	}))
 	assert.Empty(t, stub.calls, "LD-Signature creator != activity.actor must be dropped")
+}
+
+// AUTH-1 regression guard: gate は Process と同じ正規化 (unwrap + JSON-LD
+// Normalize) を経た actor で判定するため、`as:actor` / `actor:{"@id":...}` /
+// singleton-array wrap のいずれの形状でも署名者と異なる actor を詐称した
+// 活動は drop される (raw body を直 parse していた頃はこれらで gate を
+// すり抜けられた)。
+func TestInboxProcessor_SpoofShapesDropped(t *testing.T) {
+	bobHost := "evil.example"
+	newP := func(t *testing.T) (*processors.InboxProcessor, *stubFedProcessor, *activitypub.PrivateKey) {
+		t.Helper()
+		priv, pub, err := activitypub.GenerateRSAKeypair()
+		require.NoError(t, err)
+		key, err := activitypub.NewPrivateKey("https://evil.example/users/bob#main-key", priv)
+		require.NoError(t, err)
+		verifier := &multiActorVerifier{
+			pubKey: pub,
+			byURI: map[string]*model.User{
+				"https://evil.example/users/bob": {ID: "bob", Host: &bobHost, URI: uptr("https://evil.example/users/bob")},
+			},
+		}
+		stub := &stubFedProcessor{}
+		p := processors.NewInboxProcessor(stub)
+		p.SetSignatureVerifier(verifier)
+		p.SetLDSignatureVerifier(&stubLDVerifier{present: false})
+		return p, stub, key
+	}
+
+	cases := map[string]string{
+		"as:actor prefix": `{"type":"Delete","as:actor":"https://victim.example/users/alice","object":"https://victim.example/notes/1"}`,
+		"@id object form": `{"type":"Delete","actor":{"@id":"https://victim.example/users/alice"},"object":"https://victim.example/notes/1"}`,
+		"singleton array": `[{"type":"Delete","actor":"https://victim.example/users/alice","object":"https://victim.example/notes/1"}]`,
+	}
+	for name, body := range cases {
+		t.Run(name, func(t *testing.T) {
+			p, stub, key := newP(t)
+			payload := signedInboxPayload(t, key, []byte(body))
+			require.NoError(t, p.Handle(context.Background(), driver.RawTask{
+				TypeName: queue.TaskTypeInbox,
+				Body:     mustEncode(t, payload),
+			}))
+			assert.Empty(t, stub.calls, "spoofed actor via %s must be dropped", name)
+		})
+	}
 }
 
 // SetLDSignatureVerifier 未配線 (= ldVerifier nil) なら gate は skip され

--- a/internal/repository/drive_file.go
+++ b/internal/repository/drive_file.go
@@ -42,7 +42,11 @@ type DriveFileRepository interface {
 	ExistsByMD5(userID, md5 string) (bool, error)
 	ListByFileIDs(fileIDs []string) ([]*model.DriveFile, error)
 	UsageByUser(userID string) (int64, error)
-	UpdateBulkFolder(fileIDs []string, folderID *string) error
+	// UpdateBulkFolder moves the given files into folderID, scoped to the
+	// owning user. The userID predicate prevents a caller from moving drive
+	// files they do not own (IDOR): upstream drive/files/move-bulk only ever
+	// touches the caller's own rows.
+	UpdateBulkFolder(userID string, fileIDs []string, folderID *string) error
 	// DeleteOrphans removes rows whose userId is NULL. Returns affected count.
 	DeleteOrphans() (int64, error)
 	// DeleteRemoteCache removes remote cache rows (isLink=true with host set).
@@ -234,8 +238,12 @@ func (r *driveFileRepository) UsageByUser(userID string) (int64, error) {
 	return total, nil
 }
 
-func (r *driveFileRepository) UpdateBulkFolder(fileIDs []string, folderID *string) error {
-	return r.db.Model(&model.DriveFile{}).Where("id IN ?", fileIDs).Update("folderId", folderID).Error
+func (r *driveFileRepository) UpdateBulkFolder(userID string, fileIDs []string, folderID *string) error {
+	// userId で絞ることで他人の DriveFile を移動できる IDOR を防ぐ (#parity)。
+	return r.db.Model(&model.DriveFile{}).
+		Where("id IN ?", fileIDs).
+		Where(`"userId" = ?`, userID).
+		Update("folderId", folderID).Error
 }
 
 func (r *driveFileRepository) ListForAdmin(userID, origin, host, fileType, untilID, sinceID string, limit int) ([]*model.DriveFile, error) {

--- a/internal/repository/drive_file_test.go
+++ b/internal/repository/drive_file_test.go
@@ -523,12 +523,21 @@ func TestDriveFileRepository_UpdateBulkFolder(t *testing.T) {
 	})
 
 	target := "df_bulk_folder"
-	require.NoError(t, repo.UpdateBulkFolder([]string{f.ID}, &target))
+	require.NoError(t, repo.UpdateBulkFolder("df_bulk_u1", []string{f.ID}, &target))
 
 	got, err := repo.FindByID(f.ID)
 	require.NoError(t, err)
 	require.NotNil(t, got.FolderID)
 	assert.Equal(t, "df_bulk_folder", *got.FolderID)
+
+	// IDOR guard: 別ユーザーIDで同じ fileId を移動しても、所有者が違うため
+	// 行は更新されない (folderId が維持される)。
+	other := "df_bulk_other_folder"
+	require.NoError(t, repo.UpdateBulkFolder("someone_else", []string{f.ID}, &other))
+	got, err = repo.FindByID(f.ID)
+	require.NoError(t, err)
+	require.NotNil(t, got.FolderID)
+	assert.Equal(t, "df_bulk_folder", *got.FolderID, "other user must not move the file (IDOR)")
 }
 
 func TestDriveFileRepository_DeleteByUser(t *testing.T) {

--- a/internal/repository/flash.go
+++ b/internal/repository/flash.go
@@ -122,6 +122,9 @@ func (r *flashRepository) ListFeatured(sinceID, untilID string, limit, offset in
 		limit = 100
 	}
 	q := r.db.Session(&gorm.Session{})
+	// upstream FlashService.featured: 公開かつ likedCount>0 のみ。非公開 flash
+	// が featured に漏れるのを防ぐ。
+	q = q.Where("visibility = ?", "public").Where(`"likedCount" > 0`)
 	if sinceID != "" {
 		q = q.Where("id > ?", sinceID)
 	}
@@ -154,6 +157,8 @@ func (r *flashRepository) Search(query, sinceID, untilID string, limit, offset i
 		limit = 100
 	}
 	q := r.db.Where("title ILIKE ? OR summary ILIKE ?", "%"+query+"%", "%"+query+"%")
+	// upstream FlashService.search: 公開 flash のみを検索対象にする。
+	q = q.Where("visibility = ?", "public")
 	if sinceID != "" {
 		q = q.Where("id > ?", sinceID)
 	}

--- a/internal/repository/flash_test.go
+++ b/internal/repository/flash_test.go
@@ -177,6 +177,15 @@ func TestFlashRepository_ListFeatured(t *testing.T) {
 	}
 	flashes[0].LikedCount = 5
 	flashes[1].LikedCount = 10
+	// likedCount=0 は featured 対象外。
+	zeroLiked := newTestFlash("fl_ft_zero", user.ID, "ftzero")
+	zeroLiked.LikedCount = 0
+	flashes = append(flashes, zeroLiked)
+	// 非公開 flash は likedCount>0 でも featured から除外される。
+	private := newTestFlash("fl_ft_priv", user.ID, "ftpriv")
+	private.LikedCount = 99
+	private.Visibility = "private"
+	flashes = append(flashes, private)
 	for _, f := range flashes {
 		require.NoError(t, repo.Create(f))
 		defer cleanupFlash(t, f.ID)
@@ -189,7 +198,7 @@ func TestFlashRepository_ListFeatured(t *testing.T) {
 			found = append(found, f)
 		}
 	}
-	require.Len(t, found, 2)
+	require.Len(t, found, 2, "likedCount=0 と非公開 flash は除外される")
 	assert.Equal(t, "fl_ft_2", found[0].ID)
 	assert.Equal(t, "fl_ft_1", found[1].ID)
 }
@@ -226,6 +235,11 @@ func TestFlashRepository_Search(t *testing.T) {
 		require.NoError(t, repo.Create(f))
 		defer cleanupFlash(t, f.ID)
 	}
+	// 非公開 flash は title が一致しても検索結果に出ない。
+	priv := newTestFlash("fl_sr_priv", user.ID, "delta calc secret")
+	priv.Visibility = "private"
+	require.NoError(t, repo.Create(priv))
+	defer cleanupFlash(t, priv.ID)
 
 	rows, err := repo.Search("calc", "", "", 10, 0)
 	require.NoError(t, err)
@@ -235,7 +249,10 @@ func TestFlashRepository_Search(t *testing.T) {
 			found = append(found, f)
 		}
 	}
-	assert.Len(t, found, 2)
+	assert.Len(t, found, 2, "非公開 flash は検索対象外")
+	for _, f := range found {
+		assert.NotEqual(t, "fl_sr_priv", f.ID)
+	}
 }
 
 func TestFlashRepository_Search_LimitClamp(t *testing.T) {

--- a/internal/repository/flash_test.go
+++ b/internal/repository/flash_test.go
@@ -203,6 +203,29 @@ func TestFlashRepository_ListFeatured(t *testing.T) {
 	assert.Equal(t, "fl_ft_1", found[1].ID)
 }
 
+// cursor (untilID) モードでも visibility / likedCount フィルタが効くこと。
+func TestFlashRepository_ListFeatured_CursorExcludesPrivate(t *testing.T) {
+	repo := NewFlashRepository(testDB)
+	user := insertTestUser(t, "u_fla_cur", "flashusercur")
+	defer cleanupUser(t, user.ID)
+
+	pub := newTestFlash("fl_cur_pub", user.ID, "pub")
+	pub.LikedCount = 3
+	priv := newTestFlash("fl_cur_priv", user.ID, "priv")
+	priv.LikedCount = 99
+	priv.Visibility = "private"
+	for _, f := range []*model.Flash{pub, priv} {
+		require.NoError(t, repo.Create(f))
+		defer cleanupFlash(t, f.ID)
+	}
+	// untilID をテスト対象 ID より大きい値にして両方を candidate に含める。
+	rows, err := repo.ListFeatured("", "fl_cur_zzzz", 10, 0)
+	require.NoError(t, err)
+	for _, f := range rows {
+		assert.NotEqual(t, "fl_cur_priv", f.ID, "cursor モードでも非公開は除外される")
+	}
+}
+
 func TestFlashRepository_ListFeatured_LimitClamp(t *testing.T) {
 	repo := NewFlashRepository(testDB)
 	_, err := repo.ListFeatured("", "", 9999, 0)

--- a/internal/server/router.go
+++ b/internal/server/router.go
@@ -1582,6 +1582,8 @@ func (s *Server) setupRoutes() {
 	federationHandler.SetFollowingRepo(followingRepo)
 	federationHandler.SetUserRepo(userRepo)
 	federationHandler.SetResolver(federationResolver)
+	// moderationNote は公開エンドポイントで moderator にのみ返す (情報漏洩対策)。
+	federationHandler.SetModeratorChecker(roleService)
 	api.POST("/federation/instances", federationHandler.Instances)
 	api.GET("/federation/instances", federationHandler.Instances)
 	api.POST("/federation/show-instance", federationHandler.ShowInstance)
@@ -1811,6 +1813,9 @@ func (s *Server) setupRoutes() {
 	// chat/rooms/show の権限 gate で moderator bypass を効かせる
 	// (upstream 2026.5.4 hasPermissionToViewRoomInfo 互換、#1164 Phase C)。
 	chatService.SetModeratorChecker(roleService)
+	// 1-on-1 DM で recipient が sender を block している場合に弾く
+	// (upstream YOU_HAVE_BEEN_BLOCKED 互換)。
+	chatService.SetBlockingRepo(blockingRepo)
 	streamRegistry.Register("chatRoom", channels.NewChatRoomFactory(chatService).New)
 	streamRegistry.Register("chatUser", channels.NewChatUserFactory(chatService).New)
 	// Phase 9.7: federation processor / reversi handler に reversi 依存を注入。

--- a/internal/testutil/mock_block_mute.go
+++ b/internal/testutil/mock_block_mute.go
@@ -9,6 +9,8 @@ import (
 // MockBlockingRepository is a test double for repository.BlockingRepository.
 type MockBlockingRepository struct {
 	Blockings map[string]*model.Blocking // keyed by ID
+	// ExistsErr, when set, is returned by Exists to exercise fail-closed paths.
+	ExistsErr error
 }
 
 func NewMockBlockingRepository() *MockBlockingRepository {
@@ -35,6 +37,9 @@ func (m *MockBlockingRepository) FindByPair(blockerID, blockeeID string) (*model
 }
 
 func (m *MockBlockingRepository) Exists(blockerID, blockeeID string) (bool, error) {
+	if m.ExistsErr != nil {
+		return false, m.ExistsErr
+	}
 	_, err := m.FindByPair(blockerID, blockeeID)
 	return err == nil, nil
 }

--- a/internal/testutil/mock_drive.go
+++ b/internal/testutil/mock_drive.go
@@ -15,6 +15,11 @@ type MockDriveFileRepository struct {
 	// で判定する経路を test 用に模倣する (#722)。空なら guard 無効 (= 旧来の
 	// userId NULL 全削除) で既存テスト互換。
 	EmojiReferencedURLs map[string]bool
+
+	// BulkFolderUserID / BulkFolderFileIDs record the last UpdateBulkFolder
+	// call so handler tests can assert the owning user is scoped (IDOR guard).
+	BulkFolderUserID  string
+	BulkFolderFileIDs []string
 }
 
 func NewMockDriveFileRepository() *MockDriveFileRepository {
@@ -145,7 +150,9 @@ func (m *MockDriveFileRepository) UsageByUser(userID string) (int64, error) {
 	return total, nil
 }
 
-func (m *MockDriveFileRepository) UpdateBulkFolder(_ []string, _ *string) error {
+func (m *MockDriveFileRepository) UpdateBulkFolder(userID string, fileIDs []string, _ *string) error {
+	m.BulkFolderUserID = userID
+	m.BulkFolderFileIDs = fileIDs
 	return nil
 }
 


### PR DESCRIPTION
## Summary

Misskey TS (2026.5.4) ↔ mk-go の API/連合互換性監査で確定した、**mk-go が upstream より緩く実害(IDOR / なりすまし / 情報漏洩)のあるセキュリティ差分**を一括修正する。実装後に多エージェント敵対的レビューを行い、検出された修正漏れ・回避経路(自分の AP 修正自体のバイパスを含む)も同ブランチで対応済み。

エンドポイント表面は監査時点で TS 正規 434 本すべて登録済み(route 欠落 0)。本 PR は内部実装の差分のうちセキュリティに関わるものに限定する。

## 主な変更点

### セキュリティ修正 (commit 1)
- **drive/files/move-bulk (IDOR)**: `UpdateBulkFolder` を `userId` で絞り込み、他人の DriveFile を移動できる経路を遮断。宛先 folder の所有権も検証。
- **ActivityPub inbox (actor なりすまし)**: HTTP 署名者と activity の `actor` の一致を検証。不一致時は LD-Signature が actor を認証している転送活動のみ許可し、それ以外は破棄。
- **chat/messages/create-to-user**: 受信者が送信者をブロックしていれば `YOU_HAVE_BEEN_BLOCKED` で拒否。
- **federation/instances・show-instance・stats**: モデレーター専用フィールド `moderationNote` をモデレーターにのみ返す(公開エンドポイントでの漏洩を修正)。
- **flash/featured・search**: `visibility = 'public'` フィルタで非公開 Play の漏洩を修正(featured は `likedCount > 0` も)。
- **admin/suspend-user**: モデレーター/管理者/root を凍結不可に。**delete-account/accounts-delete**: root の削除を防止。

### レビュー指摘の対応 (commit 2)
- **AUTH-1 (HIGH, 自身の AP 修正のバイパス)**: gate が正規化前の raw body を見ていたため `as:actor` / `actor:{"@id":...}` / singleton-array wrap で空 actor を見せてすり抜け可能だった。`federation.ExtractActorIRI` を新設し、gate も Process と同一の unwrap+Normalize を経た actor で判定。
- **F1 (HIGH)**: delete 系のガードを `isProtectedAccount` に拡張し、root に加え `meta.rootUserId` とローカル system account (`host==null && username に '.' を含む` instance.actor/relay.actor 等) の削除も拒否。
- **AUTH-2 (MEDIUM)**: 転送活動の LD 検証前に creator actor を解決して鍵を fetch/永続化し、未知 origin からの初回転送が必ず落ちる回帰を解消。
- **chat-block-1/2 (MEDIUM)**: AP inbound DM (`CreateMessageViaAP`) にもブロック gate を適用し、ブロックチェックを fail-closed 化。
- **LOW**: drive move-bulk の空 folderId 正規化 + folderRepo 未配線時 fail-closed、legacy 同期 inbox fallback の gate 非適用を明記(本番は async 一択で到達不能)、stats の安全側 divergence を明記。

### 据え置き(理由明記)
- app アクセストークンの scope(kind) 検証: 全 434 endpoint への権限メタデータ付与を要する大規模機能。最も機微な endpoint は既に `RequireSecure`(native token 限定)で保護済みのため別 PR。
- suspend/delete の AP Delete 配信等の連合副作用、notes/delete のモデレーター削除(mk-go が upstream より厳しい安全方向): セキュリティ穴ではなく機能差分のため別途。

## テスト
- 各修正に敵対的ケース + 正常系の unit test を追加(なりすまし drop / spoof 形状 (as:actor・@id・配列) / 転送許可 / IDOR / ブロック (REST + AP inbound) / fail-closed / 漏洩除外 / 各ガード拒否 / system account 削除拒否 等)。
- 実行: `make fmt && make lint && make test`。`go test ./...` 全緑(exit 0)。
- 影響パッケージのカバレッジは CI 閾値以上(`internal/api/inbox` 98.5% / `internal/api/federation` 93.2% / `internal/core/chat` 91.1% / `internal/queue/processors` 90.8% / `internal/repository` 90.5% / `internal/api/drive` 90.3% / `internal/core/federation` 90.1% / `internal/api/admin` 87.9%(閾値80%))。

## その他
- 互換性監査(Misskey TS ↔ mk-go)で確定した High 差分のうちセキュリティ系のサブセットを対象とする。残りの機能差分(レスポンス形状・param 欠落・stub・stream/queue/notification 等)は別途 issue/PR で追跡予定。
- 対応する issue は未作成。必要であれば本 PR を起点に tracking issue を作成する。

🤖 Generated with [Claude Code](https://claude.com/claude-code)