### PR TITLE
Fix parity (HIGH/roles): Role レスポンスを本家 RoleEntityService.pack 相当に整合

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Fix: `/api/admin/roles/create`・`/show`・`/list` と公開 `/api/roles/list`・`/show` の Role レスポンスが raw な内部モデルで `usersCount`・`createdAt`・`target`・`condFormula`・`policies`(デフォルト値マージ)・`preserveAssignmentOnMoveAccount` を欠いていた問題を修正 (Misskey 本家 RoleEntityService.pack 相当の共通 packer に統一)。公開 `/api/roles/list` の `isExplorable` フィルタ欠落も合わせて修正 (本家同様 isPublic かつ isExplorable のみ列挙)
+
 - Fix: `/api/admin/emoji/add` が `category`/`aliases`/`license`/`isSensitive`/`localOnly`/`roleIdsThatCanBeUsedThisEmojiAsReaction` パラメータを無視し、さらに raw な内部モデルを返して `url` 欠落 + `originalUrl`/`publicUrl`/`uri`/`type` 等の内部フィールドが漏れていた問題を修正 (Misskey 本家同様に全パラメータを永続化し EmojiDetailed を返す)。あわせて重複名 (DUPLICATE_NAME) / emoji 名パターン (`^[a-zA-Z0-9_]+$`) の検証を追加し、`fileId` 経路では本家 `FILE_TYPE_IMAGE` 許可リストで MIME を検証 (XSS 対策で `image/svg+xml` は除外) して `originalUrl`/`publicUrl`/`type` を webpublic variant 優先で永続化する。なお legacy な `url` 直接指定経路では MIME 検証は行わない (管理者専用)
 - Fix: `/api/admin/emoji/update` が `fileId` による画像差し替え (webpublic variant 優先 + MIME 許可リスト検証) と `roleIdsThatCanBeUsedThisEmojiAsReaction` の更新を受け付けていなかった問題を修正 (リネーム時の SAME_NAME_EMOJI_EXISTS チェックも追加)
 - Fix: `/api/emoji` (EmojiDetailed) のレスポンスに `license` と `roleIdsThatCanBeUsedThisEmojiAsReaction` が欠落し、`url` が `publicUrl` 固定で `originalUrl` フォールバックが無かった問題を修正

--- a/internal/api/admin/handler.go
+++ b/internal/api/admin/handler.go
@@ -1434,7 +1434,15 @@ func (h *Handler) RolesCreate(c echo.Context) error {
 		"roleId": r.ID,
 		"role":   r,
 	})
-	return c.JSON(http.StatusOK, r)
+	return c.JSON(http.StatusOK, h.packRole(r))
+}
+
+// packRole renders a role in the upstream-compatible shape (usersCount /
+// createdAt / default-filled policies 等)。raw model.Role を返すとこれらが欠落
+// する。usersCount は active assignment 数 (per-role count、role は少数なので
+// N+1 でも許容、upstream pack も per-role count する)。
+func (h *Handler) packRole(r *model.Role) map[string]any {
+	return entity.PackRole(r, h.roleService.CountAssignedUsers(r.ID), h.idGen, role.DefaultPolicies())
 }
 
 // RolesShow handles POST /api/admin/roles/show.
@@ -1449,7 +1457,7 @@ func (h *Handler) RolesShow(c echo.Context) error {
 	if err != nil {
 		return c.JSON(http.StatusNotFound, apierr.Error("NO_SUCH_ROLE", "No such role.", "07dc7d34-c0d8-49b7-96c6-db3ce64ee0b3"))
 	}
-	return c.JSON(http.StatusOK, r)
+	return c.JSON(http.StatusOK, h.packRole(r))
 }
 
 // RolesList handles POST /api/admin/roles/list.
@@ -1458,7 +1466,11 @@ func (h *Handler) RolesList(c echo.Context) error {
 	if err != nil {
 		return c.JSON(http.StatusInternalServerError, apierr.Error("INTERNAL_ERROR", "Internal error.", "5d37dbcb-891e-41ca-a3d6-e690c97775ac"))
 	}
-	return c.JSON(http.StatusOK, roles)
+	out := make([]map[string]any, 0, len(roles))
+	for _, r := range roles {
+		out = append(out, h.packRole(r))
+	}
+	return c.JSON(http.StatusOK, out)
 }
 
 // RolesUpdate handles POST /api/admin/roles/update.

--- a/internal/api/admin/handler_test.go
+++ b/internal/api/admin/handler_test.go
@@ -1074,6 +1074,27 @@ func TestRolesShow_Success(t *testing.T) {
 	assert.Equal(t, http.StatusOK, rec.Code)
 }
 
+// admin の Role response に usersCount / createdAt / policies(default-fill) /
+// target / preserveAssignmentOnMoveAccount が含まれること (旧実装は raw model で
+// 欠落していた)。
+func TestRolesShow_IncludesPackedFields(t *testing.T) {
+	h, _, _, roleRepo, assignRepo := newTestHandlerWithAssign(t)
+	roleRepo.Roles["r1"] = &model.Role{ID: "r1", Name: "Test", Target: model.RoleTargetManual}
+	require.NoError(t, assignRepo.Create(&model.RoleAssignment{ID: "a1", UserID: "u1", RoleID: "r1"}))
+
+	rec := doPost(h.RolesShow, `{"roleId":"r1"}`, nil)
+	require.Equal(t, http.StatusOK, rec.Code)
+	var resp map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+	assert.Equal(t, float64(1), resp["usersCount"])
+	assert.Contains(t, resp, "createdAt")
+	assert.Contains(t, resp, "preserveAssignmentOnMoveAccount")
+	assert.Equal(t, "manual", resp["target"])
+	policies, ok := resp["policies"].(map[string]any)
+	require.True(t, ok)
+	assert.NotEmpty(t, policies, "policies は default-fill されて非空")
+}
+
 func TestRolesShow_NotFound(t *testing.T) {
 	h, _, _, _ := newTestHandler(t)
 	rec := doPost(h.RolesShow, `{"roleId":"ghost"}`, nil)

--- a/internal/api/roles/handler.go
+++ b/internal/api/roles/handler.go
@@ -99,7 +99,8 @@ func (h *Handler) List(c echo.Context) error {
 	}
 	var result []any
 	for _, r := range roles {
-		if r.IsPublic {
+		// upstream roles/list は isPublic AND isExplorable の 2 条件で絞る。
+		if r.IsPublic && r.IsExplorable {
 			result = append(result, h.packRole(r))
 		}
 	}
@@ -195,33 +196,11 @@ func (h *Handler) Notes(c echo.Context) error {
 // usersCount (非null num) を含めないと misskey_dart の RolesListResponse.fromJson
 // が cast で落ちる (#1249)。usersCount は mk-go が role member 数を集計していない
 // ため 0 固定 (best-effort、非crashing)。
+// packRole renders a public role in the upstream-compatible shape. upstream の
+// roles/show・list は admin と同じ RoleEntityService.pack を使うため共通 packer
+// (entity.PackRole) に統一する。旧実装は target / condFormula / policies /
+// preserveAssignmentOnMoveAccount を欠き usersCount を 0 固定していた。
+// usersCount は active assignment 数 (role は少数なので per-role count)。
 func (h *Handler) packRole(r *model.Role) map[string]any {
-	const tsFormat = "2006-01-02T15:04:05.000Z"
-	// createdAt は role ID (aidx) から復元する。misskey_dart は createdAt を
-	// DateTimeConverter で parse するため、空文字だと FormatException で落ちる。
-	// ID が aidx でない等で ParseTime に失敗した場合は updatedAt (非null) へ
-	// フォールバックし、常に有効な日付文字列を返す (#1249)。
-	createdAt := r.UpdatedAt.UTC().Format(tsFormat)
-	if h.idGen != nil {
-		if t, err := h.idGen.ParseTime(r.ID); err == nil {
-			createdAt = t.UTC().Format(tsFormat)
-		}
-	}
-	return map[string]any{
-		"id":                        r.ID,
-		"createdAt":                 createdAt,
-		"updatedAt":                 r.UpdatedAt.UTC().Format(tsFormat),
-		"name":                      r.Name,
-		"color":                     r.Color,
-		"iconUrl":                   r.IconURL,
-		"description":               r.Description,
-		"isModerator":               r.IsModerator,
-		"isAdministrator":           r.IsAdministrator,
-		"isPublic":                  r.IsPublic,
-		"isExplorable":              r.IsExplorable,
-		"asBadge":                   r.AsBadge,
-		"canEditMembersByModerator": r.CanEditMembersByModerator,
-		"displayOrder":              r.DisplayOrder,
-		"usersCount":                0,
-	}
+	return entity.PackRole(r, h.roleService.CountAssignedUsers(r.ID), h.idGen, role.DefaultPolicies())
 }

--- a/internal/api/roles/handler_test.go
+++ b/internal/api/roles/handler_test.go
@@ -61,13 +61,15 @@ func doPost(h func(echo.Context) error, body string) *httptest.ResponseRecorder 
 
 func TestList_PublicOnly(t *testing.T) {
 	h, roleRepo := newTestHandler(t)
-	roleRepo.Roles["r1"] = &model.Role{ID: "r1", Name: "Public", IsPublic: true}
+	// upstream は isPublic AND isExplorable。public+explorable のみ list に出る。
+	roleRepo.Roles["r1"] = &model.Role{ID: "r1", Name: "Public", IsPublic: true, IsExplorable: true}
 	roleRepo.Roles["r2"] = &model.Role{ID: "r2", Name: "Private", IsPublic: false}
+	roleRepo.Roles["r3"] = &model.Role{ID: "r3", Name: "PublicNonExplorable", IsPublic: true, IsExplorable: false}
 	rec := doPost(h.List, `{}`)
 	assert.Equal(t, http.StatusOK, rec.Code)
 	var resp []any
 	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
-	assert.Len(t, resp, 1)
+	assert.Len(t, resp, 1, "isPublic かつ isExplorable のみ (r1)")
 }
 
 func TestList_Empty(t *testing.T) {
@@ -84,7 +86,7 @@ func TestList_FullShape(t *testing.T) {
 	idGen, _ := id.NewGenerator("aidx")
 	roleID := idGen.Generate(time.Now())
 	roleRepo.Roles[roleID] = &model.Role{
-		ID: roleID, Name: "Public", IsPublic: true,
+		ID: roleID, Name: "Public", IsPublic: true, IsExplorable: true,
 		UpdatedAt:                 time.Date(2026, 5, 1, 0, 0, 0, 0, time.UTC),
 		CanEditMembersByModerator: true,
 	}
@@ -110,13 +112,45 @@ func TestShow_Success(t *testing.T) {
 	assert.Equal(t, http.StatusOK, rec.Code)
 }
 
+// 公開 role の pack に target / condFormula / policies(default-fill) /
+// preserveAssignmentOnMoveAccount / 実 usersCount が含まれること (旧実装は
+// これらを欠き usersCount=0 固定だった)。
+func TestShow_IncludesPoliciesTargetAndUsersCount(t *testing.T) {
+	roleRepo := testutil.NewMockRoleRepository()
+	assignRepo := testutil.NewMockRoleAssignmentRepository(roleRepo)
+	metaRepo := testutil.NewMockMetaRepository()
+	metaRepo.Meta = &model.Meta{ID: "x"}
+	idGen, _ := id.NewGenerator("aidx")
+	svc := corerole.NewService(roleRepo, assignRepo, metaRepo, idGen)
+	h := roles.NewHandler(svc, idGen)
+
+	roleRepo.Roles["r1"] = &model.Role{ID: "r1", Name: "Pub", IsPublic: true, Target: model.RoleTargetManual}
+	require.NoError(t, assignRepo.Create(&model.RoleAssignment{ID: "a1", UserID: "u1", RoleID: "r1"}))
+	require.NoError(t, assignRepo.Create(&model.RoleAssignment{ID: "a2", UserID: "u2", RoleID: "r1"}))
+
+	rec := doPost(h.Show, `{"roleId":"r1"}`)
+	require.Equal(t, http.StatusOK, rec.Code)
+	var resp map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+	assert.Equal(t, float64(2), resp["usersCount"], "usersCount は active assignment 数")
+	assert.Equal(t, "manual", resp["target"])
+	assert.Contains(t, resp, "condFormula")
+	assert.Contains(t, resp, "preserveAssignmentOnMoveAccount")
+	policies, ok := resp["policies"].(map[string]any)
+	require.True(t, ok, "policies が含まれること")
+	// default-fill された任意の policy key が {useDefault:true,...} 形式。
+	if cp, ok := policies["canPublicNote"].(map[string]any); ok {
+		assert.Equal(t, true, cp["useDefault"])
+	}
+}
+
 // #1249: role ID が aidx でなく ParseTime が失敗しても createdAt は空文字に
 // ならず updatedAt にフォールバックすること (misskey_dart の DateTimeConverter
 // は空文字を FormatException にするため)。
 func TestList_CreatedAtFallsBackToUpdatedAt(t *testing.T) {
 	h, roleRepo := newTestHandler(t)
 	roleRepo.Roles["non-aidx-id"] = &model.Role{
-		ID: "non-aidx-id", Name: "Seeded", IsPublic: true,
+		ID: "non-aidx-id", Name: "Seeded", IsPublic: true, IsExplorable: true,
 		UpdatedAt: time.Date(2026, 5, 1, 0, 0, 0, 0, time.UTC),
 	}
 	rec := doPost(h.List, `{}`)

--- a/internal/core/role/role_service.go
+++ b/internal/core/role/role_service.go
@@ -968,6 +968,21 @@ func (s *Service) ListByRole(roleID, untilID, sinceID string, limit int) ([]*mod
 	return s.assignmentRepo.ListByRole(roleID, untilID, sinceID, limit)
 }
 
+// CountAssignedUsers returns the number of users currently assigned to a role
+// (non-expired assignments). Used by the Role packer's usersCount field. On
+// repository error it returns 0 so packing never fails the whole response.
+func (s *Service) CountAssignedUsers(roleID string) int {
+	n, err := s.assignmentRepo.CountActiveByRole(roleID)
+	if err != nil {
+		// fail-soft: pack 全体を失敗させない (upstream は 500 だが mk-go は
+		// best-effort で 0 を返す)。ただし silent に 0 を返すと corrupt/transient
+		// DB error が usersCount:0 として隠れるため warn で観測可能にする。
+		slog.Warn("role: CountActiveByRole failed; usersCount falls back to 0", "roleId", roleID, "err", err)
+		return 0
+	}
+	return n
+}
+
 // UpdateFields updates the named columns of an existing role and
 // returns the role state after the update for audit logging. Returns
 // ErrRoleNotFound if the role does not exist before the update.

--- a/internal/core/role/role_service_test.go
+++ b/internal/core/role/role_service_test.go
@@ -776,6 +776,29 @@ func (f *failingAssignRepo) Exists(_ string, _ string) (bool, error) {
 	return false, assert.AnError
 }
 
+func (f *failingAssignRepo) CountActiveByRole(_ string) (int, error) {
+	return 0, assert.AnError
+}
+
+// CountAssignedUsers は active assignment 数を返す。
+func TestCountAssignedUsers_Counts(t *testing.T) {
+	svc, roleRepo, assignRepo, _ := newTestService(t)
+	roleRepo.Roles["r1"] = &model.Role{ID: "r1", Name: "R"}
+	assignRepo.Assignments["u1:r1"] = &model.RoleAssignment{ID: "a1", UserID: "u1", RoleID: "r1"}
+	assignRepo.Assignments["u2:r1"] = &model.RoleAssignment{ID: "a2", UserID: "u2", RoleID: "r1"}
+	assert.Equal(t, 2, svc.CountAssignedUsers("r1"))
+}
+
+// repo error 時は fail-open で 0 を返す (pack 全体を失敗させない)。
+func TestCountAssignedUsers_FailOpen(t *testing.T) {
+	roleRepo := testutil.NewMockRoleRepository()
+	assignRepo := &failingAssignRepo{testutil.NewMockRoleAssignmentRepository(roleRepo)}
+	metaRepo := testutil.NewMockMetaRepository()
+	idGen, _ := id.NewGenerator("aidx")
+	svc := role.NewService(roleRepo, assignRepo, metaRepo, idGen)
+	assert.Equal(t, 0, svc.CountAssignedUsers("r1"))
+}
+
 type failingRoleRepo struct {
 	*testutil.MockRoleRepository
 }

--- a/internal/entity/role.go
+++ b/internal/entity/role.go
@@ -1,0 +1,80 @@
+package entity
+
+import (
+	"encoding/json"
+
+	"github.com/shiroha-a/mk/internal/misc/id"
+	"github.com/shiroha-a/mk/internal/model"
+)
+
+// roleTSTimeFormat is Misskey's ISO timestamp format (ms precision, Z).
+const roleTSTimeFormat = "2006-01-02T15:04:05.000Z"
+
+// PackRole builds the upstream-compatible Role response shape (mirrors
+// RoleEntityService.pack). Both admin (/api/admin/roles/*) and public
+// (/api/roles/*) endpoints return this shape in Misskey.
+//
+// usersCount is the number of non-expired assignments (caller resolves it via
+// RoleAssignmentRepository.CountActiveByRole). defaultPolicies is the instance
+// DEFAULT_POLICIES map (key -> default value); each policy key absent from the
+// role's own overrides is filled with {useDefault:true, priority:0, value}.
+// idGen derives createdAt from the role ID (aidx); on failure it falls back to
+// updatedAt so the timestamp is always a valid ISO string.
+func PackRole(r *model.Role, usersCount int, idGen id.Generator, defaultPolicies map[string]any) map[string]any {
+	createdAt := r.UpdatedAt.UTC().Format(roleTSTimeFormat)
+	if idGen != nil {
+		if t, err := idGen.ParseTime(r.ID); err == nil {
+			createdAt = t.UTC().Format(roleTSTimeFormat)
+		}
+	}
+
+	// policies: role の override に default-fill を被せる (upstream pack と同じ)。
+	policies := map[string]any{}
+	if len(r.Policies) > 0 {
+		_ = json.Unmarshal(r.Policies, &policies)
+	}
+	for k, v := range defaultPolicies {
+		if cur, ok := policies[k]; !ok || cur == nil {
+			policies[k] = map[string]any{
+				"useDefault": true,
+				"priority":   0,
+				"value":      v,
+			}
+		}
+	}
+
+	// condFormula は jsonb を object として返す (空/不正/非object なら {})。
+	// upstream packedRoleSchema は condFormula を object 必須としているため、
+	// 配列やスカラーが入っていても object 契約を守る。
+	condFormula := map[string]any{}
+	if len(r.CondFormula) > 0 {
+		var parsed any
+		if json.Unmarshal(r.CondFormula, &parsed) == nil {
+			if m, ok := parsed.(map[string]any); ok {
+				condFormula = m
+			}
+		}
+	}
+
+	return map[string]any{
+		"id":                              r.ID,
+		"createdAt":                       createdAt,
+		"updatedAt":                       r.UpdatedAt.UTC().Format(roleTSTimeFormat),
+		"name":                            r.Name,
+		"description":                     r.Description,
+		"color":                           r.Color,
+		"iconUrl":                         r.IconURL,
+		"target":                          r.Target,
+		"condFormula":                     condFormula,
+		"isPublic":                        r.IsPublic,
+		"isAdministrator":                 r.IsAdministrator,
+		"isModerator":                     r.IsModerator,
+		"isExplorable":                    r.IsExplorable,
+		"asBadge":                         r.AsBadge,
+		"preserveAssignmentOnMoveAccount": r.PreserveAssignmentOnMoveAccount,
+		"canEditMembersByModerator":       r.CanEditMembersByModerator,
+		"displayOrder":                    r.DisplayOrder,
+		"policies":                        policies,
+		"usersCount":                      usersCount,
+	}
+}

--- a/internal/entity/role_test.go
+++ b/internal/entity/role_test.go
@@ -1,0 +1,136 @@
+package entity_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/shiroha-a/mk/internal/entity"
+	"github.com/shiroha-a/mk/internal/misc/id"
+	"github.com/shiroha-a/mk/internal/model"
+	"gorm.io/datatypes"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestPackRole(t *testing.T) {
+	idGen, err := id.NewGenerator("aidx")
+	require.NoError(t, err)
+	roleID := idGen.Generate(time.Date(2026, 6, 1, 0, 0, 0, 0, time.UTC))
+
+	color := "#fff"
+	r := &model.Role{
+		ID:                              roleID,
+		Name:                            "Trusted",
+		Description:                     "trusted users",
+		Color:                           &color,
+		Target:                          model.RoleTargetManual,
+		CondFormula:                     datatypes.JSON([]byte(`{"type":"isLocal"}`)),
+		IsPublic:                        true,
+		IsExplorable:                    true,
+		PreserveAssignmentOnMoveAccount: true,
+		CanEditMembersByModerator:       true,
+		DisplayOrder:                    3,
+		// role 固有 override: canSearchNotes のみ value=true で上書き。
+		Policies: datatypes.JSON([]byte(`{"canSearchNotes":{"useDefault":false,"priority":1,"value":true}}`)),
+	}
+	defaultPolicies := map[string]any{
+		"canSearchNotes": false,
+		"canPublicNote":  true,
+		"mentionLimit":   20,
+	}
+
+	out := entity.PackRole(r, 7, idGen, defaultPolicies)
+
+	assert.Equal(t, roleID, out["id"])
+	assert.Equal(t, 7, out["usersCount"])
+	assert.Equal(t, "Trusted", out["name"])
+	assert.Equal(t, model.RoleTargetManual, out["target"])
+	assert.Equal(t, true, out["preserveAssignmentOnMoveAccount"])
+	assert.Equal(t, true, out["canEditMembersByModerator"])
+	// createdAt は aidx 由来の ISO 文字列。
+	createdAt, _ := out["createdAt"].(string)
+	assert.Regexp(t, `^\d{4}-\d{2}-\d{2}T.*Z$`, createdAt)
+	// condFormula は object として返る。
+	cf, ok := out["condFormula"].(map[string]any)
+	require.True(t, ok)
+	assert.Equal(t, "isLocal", cf["type"])
+
+	// policies: override は維持、未設定 key は default-fill。
+	policies, ok := out["policies"].(map[string]any)
+	require.True(t, ok)
+	// 上書き済み canSearchNotes はそのまま (useDefault:false)。
+	override, ok := policies["canSearchNotes"].(map[string]any)
+	require.True(t, ok)
+	assert.Equal(t, false, override["useDefault"])
+	assert.Equal(t, true, override["value"])
+	// 未設定 canPublicNote / mentionLimit は default-fill (useDefault:true)。
+	filled, ok := policies["canPublicNote"].(map[string]any)
+	require.True(t, ok)
+	assert.Equal(t, true, filled["useDefault"])
+	assert.Equal(t, 0, filled["priority"])
+	assert.Equal(t, true, filled["value"])
+	ment, ok := policies["mentionLimit"].(map[string]any)
+	require.True(t, ok)
+	assert.Equal(t, 20, ment["value"])
+}
+
+// explicit null override: policies に明示的 null が入っている key も
+// (upstream `policies[k] == null` と同じく) default-fill 対象になる。
+func TestPackRole_ExplicitNullOverrideDefaultFilled(t *testing.T) {
+	r := &model.Role{
+		ID:        "r",
+		UpdatedAt: time.Date(2026, 6, 1, 0, 0, 0, 0, time.UTC),
+		Policies:  datatypes.JSON([]byte(`{"canPublicNote":null}`)),
+	}
+	out := entity.PackRole(r, 0, nil, map[string]any{"canPublicNote": true})
+	policies := out["policies"].(map[string]any)
+	filled, ok := policies["canPublicNote"].(map[string]any)
+	require.True(t, ok, "explicit null は default-fill される")
+	assert.Equal(t, true, filled["useDefault"])
+	assert.Equal(t, true, filled["value"])
+}
+
+// malformed jsonb は fail-soft: panic せず全 default-fill / condFormula は {}。
+func TestPackRole_MalformedJSONFailsSoft(t *testing.T) {
+	r := &model.Role{
+		ID:          "r",
+		UpdatedAt:   time.Date(2026, 6, 1, 0, 0, 0, 0, time.UTC),
+		Policies:    datatypes.JSON([]byte(`{bad`)),
+		CondFormula: datatypes.JSON([]byte(`{bad`)),
+	}
+	out := entity.PackRole(r, 0, nil, map[string]any{"canPublicNote": true})
+	policies := out["policies"].(map[string]any)
+	filled, ok := policies["canPublicNote"].(map[string]any)
+	require.True(t, ok)
+	assert.Equal(t, true, filled["useDefault"])
+	cf, ok := out["condFormula"].(map[string]any)
+	require.True(t, ok)
+	assert.Empty(t, cf)
+}
+
+// 非 object な condFormula (配列/スカラー) は object 契約のため {} に正規化。
+func TestPackRole_CondFormulaNonObjectNormalized(t *testing.T) {
+	for _, raw := range []string{`[1,2,3]`, `42`, `"x"`} {
+		r := &model.Role{ID: "r", UpdatedAt: time.Date(2026, 6, 1, 0, 0, 0, 0, time.UTC), CondFormula: datatypes.JSON([]byte(raw))}
+		out := entity.PackRole(r, 0, nil, map[string]any{})
+		cf, ok := out["condFormula"].(map[string]any)
+		require.True(t, ok, "condFormula=%s は object に正規化される", raw)
+		assert.Empty(t, cf)
+	}
+}
+
+// createdAt fallback: idGen 無し / 非 aidx ID は updatedAt にフォールバック。
+func TestPackRole_CreatedAtFallback(t *testing.T) {
+	r := &model.Role{ID: "not-aidx", Name: "x", UpdatedAt: time.Date(2026, 6, 1, 12, 0, 0, 0, time.UTC)}
+	out := entity.PackRole(r, 0, nil, map[string]any{})
+	createdAt, _ := out["createdAt"].(string)
+	assert.Regexp(t, `^\d{4}-\d{2}-\d{2}T.*Z$`, createdAt)
+	// policies は空 default でも map (nil でない)。
+	_, ok := out["policies"].(map[string]any)
+	assert.True(t, ok)
+	// condFormula は空 jsonb のとき {}。
+	cf, ok := out["condFormula"].(map[string]any)
+	require.True(t, ok)
+	assert.Empty(t, cf)
+}

--- a/internal/repository/role.go
+++ b/internal/repository/role.go
@@ -60,6 +60,9 @@ type RoleAssignmentRepository interface {
 	ListByUser(userID string) ([]*model.RoleAssignment, error)
 	ListByRole(roleID string, untilID, sinceID string, limit int) ([]*model.RoleAssignment, error)
 	Exists(userID, roleID string) (bool, error)
+	// CountActiveByRole returns the number of non-expired assignments for a
+	// role (expiresAt IS NULL OR > now). Used for the Role packer's usersCount.
+	CountActiveByRole(roleID string) (int, error)
 }
 
 type roleAssignmentRepository struct {
@@ -115,6 +118,15 @@ func (r *roleAssignmentRepository) ListByRole(roleID string, untilID, sinceID st
 		return nil, err
 	}
 	return assignments, nil
+}
+
+func (r *roleAssignmentRepository) CountActiveByRole(roleID string) (int, error) {
+	var count int64
+	now := time.Now()
+	err := r.db.Model(&model.RoleAssignment{}).
+		Where("\"roleId\" = ? AND (\"expiresAt\" IS NULL OR \"expiresAt\" > ?)", roleID, now).
+		Count(&count).Error
+	return int(count), err
 }
 
 func (r *roleAssignmentRepository) Exists(userID, roleID string) (bool, error) {

--- a/internal/repository/role_test.go
+++ b/internal/repository/role_test.go
@@ -176,6 +176,49 @@ func TestRoleAssignmentRepository_ListByRole_WithPagination(t *testing.T) {
 	assert.Equal(t, "pag_a2", result[0].ID)
 }
 
+func TestRoleAssignmentRepository_CountActiveByRole(t *testing.T) {
+	roleRepo := NewRoleRepository(testDB)
+	assignRepo := NewRoleAssignmentRepository(testDB)
+
+	now := time.Now()
+	role := &model.Role{
+		ID: "role_cnt_test", UpdatedAt: now, LastUsedAt: now, Name: "Cnt",
+		Target: model.RoleTargetManual, Policies: datatypes.JSON([]byte("{}")),
+		CondFormula: datatypes.JSON([]byte("{}")),
+	}
+	require.NoError(t, roleRepo.Create(role))
+	defer cleanupRole(t, role.ID)
+
+	createTestUser(t, "cnt_u1")
+	createTestUser(t, "cnt_u2")
+	createTestUser(t, "cnt_u3")
+	future := now.Add(time.Hour)
+	past := now.Add(-time.Hour)
+	require.NoError(t, assignRepo.Create(&model.RoleAssignment{ID: "cnt_a1", UserID: "cnt_u1", RoleID: role.ID}))
+	require.NoError(t, assignRepo.Create(&model.RoleAssignment{ID: "cnt_a2", UserID: "cnt_u2", RoleID: role.ID, ExpiresAt: &future}))
+	// 期限切れは active count に含めない。
+	require.NoError(t, assignRepo.Create(&model.RoleAssignment{ID: "cnt_a3", UserID: "cnt_u3", RoleID: role.ID, ExpiresAt: &past}))
+
+	// 別 role の assignment は count に混ざらない (cross-role isolation)。
+	otherRole := &model.Role{
+		ID: "role_cnt_other", UpdatedAt: now, LastUsedAt: now, Name: "Other",
+		Target: model.RoleTargetManual, Policies: datatypes.JSON([]byte("{}")),
+		CondFormula: datatypes.JSON([]byte("{}")),
+	}
+	require.NoError(t, roleRepo.Create(otherRole))
+	defer cleanupRole(t, otherRole.ID)
+	createTestUser(t, "cnt_u4")
+	require.NoError(t, assignRepo.Create(&model.RoleAssignment{ID: "cnt_a4", UserID: "cnt_u4", RoleID: otherRole.ID}))
+
+	n, err := assignRepo.CountActiveByRole(role.ID)
+	require.NoError(t, err)
+	assert.Equal(t, 2, n, "active (nil + future) のみ数え、expired と別 role は除外")
+
+	n, err = assignRepo.CountActiveByRole(otherRole.ID)
+	require.NoError(t, err)
+	assert.Equal(t, 1, n)
+}
+
 func TestRoleAssignmentRepository_ListByRole_Error(t *testing.T) {
 	db := cancelledDB(t)
 	repo := NewRoleAssignmentRepository(db)

--- a/internal/testutil/mock_repository.go
+++ b/internal/testutil/mock_repository.go
@@ -5968,6 +5968,23 @@ func (m *MockRoleAssignmentRepository) Exists(userID, roleID string) (bool, erro
 	return true, nil
 }
 
+func (m *MockRoleAssignmentRepository) CountActiveByRole(roleID string) (int, error) {
+	now := time.Now()
+	count := 0
+	for _, a := range m.Assignments {
+		if a.RoleID != roleID {
+			continue
+		}
+		// production SQL は `expiresAt IS NULL OR expiresAt > now` (厳密 >) なので
+		// expiresAt <= now (== now 含む) は非 active。!After(now) で境界を揃える。
+		if a.ExpiresAt != nil && !a.ExpiresAt.After(now) {
+			continue
+		}
+		count++
+	}
+	return count, nil
+}
+
 // MockUserPendingRepository is a test double for repository.UserPendingRepository.
 type MockUserPendingRepository struct {
 	Rows map[string]*model.UserPending // keyed by ID


### PR DESCRIPTION
## Summary

互換性監査 **HIGH を重要度順に消化するバッチの第2弾 (roles)**。Role エンティティのレスポンス形状が raw な内部モデルで、本家 `RoleEntityService.pack` が返す `usersCount` / `createdAt` / `target` / `condFormula` / `policies`(デフォルト値マージ) / `preserveAssignmentOnMoveAccount` を欠いていた問題を、admin / 公開の両系で整合させる。実装後に多エージェント敵対的レビューを実施し、確定指摘も同 PR で対応済み。

## 主な変更点

- **新規 `entity.PackRole`**: upstream `RoleEntityService.pack` 相当の共通 packer。`policies` は role の override に DEFAULT_POLICIES を `{useDefault:true, priority:0, value}` 形でデフォルト fill。`createdAt` は aidx ID 由来 (失敗時 `updatedAt` fallback)、`condFormula` は object 正規化、`usersCount` は active assignment 数。
- **admin/roles** `create`・`show`・`list` が packed Role を返す (`update` は upstream 同様 res 無しの 204 で据え置き)。
- **公開 roles** `list`・`show` を共通 `entity.PackRole` に統一 (旧 packRole は target/condFormula/policies/preserveAssignment を欠き usersCount=0 固定)。`list` の `isExplorable` フィルタ欠落も修正 (本家は isPublic AND isExplorable)。
- **repo** `RoleAssignmentRepository.CountActiveByRole` (expiresAt IS NULL OR > now) + **service** `Service.CountAssignedUsers`。
- testutil mock に `CountActiveByRole`。

## レビュー対応 (確定 15 件 / HIGH 0 / Medium 1 / Low 14)
- PackRole の非 object な `condFormula` を `{}` に正規化 (object 契約維持)。
- mock `CountActiveByRole` の境界を production の strict `>` に揃える (`!After(now)`)。
- `CountAssignedUsers` の fail-open に `slog.Warn` を追加 (DB error の観測性)。
- テスト追加: explicit-null override の default-fill / malformed jsonb fail-soft / 非 object condFormula / `CountAssignedUsers` happy+fail-open / repo の cross-role isolation。
- 据え置き (別途明記): 公開 `roles/users` の完全実装 (UserDetailed packing + isPublic/isExplorable gate) と admin `roles/list` の order (lastUsedAt DESC) は本 PR scope 外。

## テスト
- `make fmt` / `go vet ./...` クリーン。`internal/entity` 95.8% / `internal/api/roles` 98.5% / `internal/core/role` 95.4% / `internal/repository` 90.5%。
- 注: `internal/api/admin` の `TestFederationUpdateInstance_Integration*` 2 件はローカル test DB (`misskey_test`) に過去の中断実行が残した `int_admin` 行と衝突して落ちるが、**本変更と無関係** (clean develop でも再現) で **CI は毎回 fresh DB のため緑**。該当テストの分離脆弱性は別途修正候補。

## その他
- 互換性監査 HIGH の roles レスポンス形状クラスタ。以降 channels / user packer / gallery / drafts / meta / chat / notes / stream / federation ... を重要度順の別 PR で順次対応予定。各 PR は実装→敵対的レビュー→修正をワンセットで実施。

🤖 Generated with [Claude Code](https://claude.com/claude-code)