### PR TITLE
Fix parity (HIGH/channels): bannerId/pinnedNoteIds/search type/isMuting を本家整合

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Fix: `/api/channels/create`・`/update` が `bannerId` を無視し、`/update` が `pinnedNoteIds` を反映できなかった問題を修正 (bannerId は所有権検証付き、`""` で banner 解除)。`/api/channels/search` が `type` (`nameAndDescription` 既定 / `nameOnly`) を無視して description を検索対象にしていなかった問題と、archived チャンネルを検索結果から除外していなかった問題も修正。チャンネルの packed レスポンス (show / search / featured / owned 等) に閲覧者視点の `isMuting` が欠落していた問題を修正
+
 - Fix: `/api/admin/roles/create`・`/show`・`/list` と公開 `/api/roles/list`・`/show` の Role レスポンスが raw な内部モデルで `usersCount`・`createdAt`・`target`・`condFormula`・`policies`(デフォルト値マージ)・`preserveAssignmentOnMoveAccount` を欠いていた問題を修正 (Misskey 本家 RoleEntityService.pack 相当の共通 packer に統一)。公開 `/api/roles/list` の `isExplorable` フィルタ欠落も合わせて修正 (本家同様 isPublic かつ isExplorable のみ列挙)
 
 - Fix: `/api/admin/emoji/add` が `category`/`aliases`/`license`/`isSensitive`/`localOnly`/`roleIdsThatCanBeUsedThisEmojiAsReaction` パラメータを無視し、さらに raw な内部モデルを返して `url` 欠落 + `originalUrl`/`publicUrl`/`uri`/`type` 等の内部フィールドが漏れていた問題を修正 (Misskey 本家同様に全パラメータを永続化し EmojiDetailed を返す)。あわせて重複名 (DUPLICATE_NAME) / emoji 名パターン (`^[a-zA-Z0-9_]+$`) の検証を追加し、`fileId` 経路では本家 `FILE_TYPE_IMAGE` 許可リストで MIME を検証 (XSS 対策で `image/svg+xml` は除外) して `originalUrl`/`publicUrl`/`type` を webpublic variant 優先で永続化する。なお legacy な `url` 直接指定経路では MIME 検証は行わない (管理者専用)

--- a/internal/api/channels/handler.go
+++ b/internal/api/channels/handler.go
@@ -145,6 +145,7 @@ type CreateRequest struct {
 	Description *string `json:"description"`
 	Color       string  `json:"color"`
 	IsSensitive bool    `json:"isSensitive"`
+	BannerID    *string `json:"bannerId"`
 }
 
 // Create handles POST /api/channels/create.
@@ -157,12 +158,25 @@ func (h *Handler) Create(c echo.Context) error {
 	if err := c.Bind(&req); err != nil || req.Name == "" {
 		return apierr.JSONInvalidParam(c)
 	}
+	// bannerId="" は「banner 無し」に正規化する (TS は misskey:id format で空文字を
+	// 400 にするため空文字が DB に入ることはない。mk-go では空文字 column を作らない)。
+	if req.BannerID != nil && *req.BannerID == "" {
+		req.BannerID = nil
+	}
+	// bannerId 指定時は呼出ユーザー所有の drive file であることを検証する
+	// (upstream channels/create: findOneBy({id, userId: me.id}) → NO_SUCH_FILE)。
+	if req.BannerID != nil {
+		if !h.bannerOwnedBy(*req.BannerID, user.ID) {
+			return c.JSON(http.StatusBadRequest, apierr.Error("NO_SUCH_FILE", "No such file.", "cd1e9f3e-5a12-4ab4-96f6-5d0a2cc32050"))
+		}
+	}
 	ch, err := h.svc.Create(corechannel.CreateInput{
 		OwnerID:     user.ID,
 		Name:        req.Name,
 		Description: req.Description,
 		Color:       req.Color,
 		IsSensitive: req.IsSensitive,
+		BannerID:    req.BannerID,
 	})
 	if err != nil {
 		return apierr.JSONInternalError(c)
@@ -193,12 +207,14 @@ func (h *Handler) Show(c echo.Context) error {
 
 // UpdateRequest is the request body for channels/update.
 type UpdateRequest struct {
-	ChannelID   string  `json:"channelId"`
-	Name        *string `json:"name"`
-	Description *string `json:"description"`
-	Color       *string `json:"color"`
-	IsArchived  *bool   `json:"isArchived"`
-	IsSensitive *bool   `json:"isSensitive"`
+	ChannelID     string    `json:"channelId"`
+	Name          *string   `json:"name"`
+	Description   *string   `json:"description"`
+	Color         *string   `json:"color"`
+	IsArchived    *bool     `json:"isArchived"`
+	IsSensitive   *bool     `json:"isSensitive"`
+	BannerID      *string   `json:"bannerId"`
+	PinnedNoteIDs *[]string `json:"pinnedNoteIds"`
 }
 
 // Update handles POST /api/channels/update.
@@ -209,14 +225,23 @@ func (h *Handler) Update(c echo.Context) error {
 		return apierr.JSONInvalidParam(c)
 	}
 	in := corechannel.UpdateInput{
-		Name:        req.Name,
-		Color:       req.Color,
-		IsArchived:  req.IsArchived,
-		IsSensitive: req.IsSensitive,
+		Name:          req.Name,
+		Color:         req.Color,
+		IsArchived:    req.IsArchived,
+		IsSensitive:   req.IsSensitive,
+		BannerID:      req.BannerID,
+		PinnedNoteIDs: req.PinnedNoteIDs,
 	}
 	if req.Description != nil {
 		desc := req.Description
 		in.Description = &desc
+	}
+	// bannerId 設定時 (空文字 = 解除は検証不要) は所有権を検証する
+	// (upstream channels/update: bannerId != null → findOneBy({id, userId}) → NO_SUCH_FILE)。
+	if req.BannerID != nil && *req.BannerID != "" {
+		if !h.bannerOwnedBy(*req.BannerID, user.ID) {
+			return c.JSON(http.StatusBadRequest, apierr.Error("NO_SUCH_FILE", "No such file.", "e86c14a4-0da2-4032-8df3-e737a04c7f3b"))
+		}
 	}
 	ch, err := h.svc.Update(user.ID, req.ChannelID, in)
 	if err != nil {
@@ -342,6 +367,7 @@ func (h *Handler) Featured(c echo.Context) error {
 // SearchRequest carries the query string for channels/search.
 type SearchRequest struct {
 	Query     string `json:"query"`
+	Type      string `json:"type"`
 	Limit     int    `json:"limit"`
 	Offset    int    `json:"offset"`
 	SinceID   string `json:"sinceId"`
@@ -356,14 +382,34 @@ func (h *Handler) Search(c echo.Context) error {
 	if err := c.Bind(&req); err != nil {
 		return apierr.JSONInvalidParam(c)
 	}
+	// type は enum ['nameAndDescription','nameOnly'] (空は default)。upstream は
+	// enum 外を 400 で弾くので silent fallback せず合わせる。
+	if req.Type != "" && req.Type != "nameAndDescription" && req.Type != "nameOnly" {
+		return apierr.JSONInvalidParam(c)
+	}
 	// sinceDate / untilDate を aidx prefix に正規化 (#1166)。
 	sinceID, untilID := id.NormalizeCursor(req.SinceID, req.UntilID, req.SinceDate, req.UntilDate)
 	req.Limit = pagination.ClampLimit(req.Limit, 5, 100)
-	rows, err := h.svc.Search(req.Query, sinceID, untilID, req.Limit, req.Offset)
+	rows, err := h.svc.Search(req.Query, req.Type, sinceID, untilID, req.Limit, req.Offset)
 	if err != nil {
 		return apierr.JSONInternalError(c)
 	}
 	return c.JSON(http.StatusOK, h.channelsToList(rows, middleware.GetUser(c)))
+}
+
+// bannerOwnedBy reports whether bannerID resolves to a drive file owned by
+// userID. Used to validate channels/create・update の bannerId
+// (upstream は findOneBy({id, userId: me.id}) で所有を確認する)。bannerResolver
+// 未配線時は検証不能なので true を返さず false (fail-closed) にする。
+func (h *Handler) bannerOwnedBy(bannerID, userID string) bool {
+	if h.bannerResolver == nil {
+		return false
+	}
+	f, err := h.bannerResolver.FindByID(bannerID)
+	if err != nil || f == nil || f.UserID == nil || *f.UserID != userID {
+		return false
+	}
+	return true
 }
 
 // TimelineRequest is the request body for channels/timeline.
@@ -532,6 +578,12 @@ func (h *Handler) channelToMapForViewer(ch *model.Channel, viewer *model.User) m
 			out["isFavorited"] = ok
 		}
 	}
+	// upstream Channel schema は viewer 視点の isMuting を含む。
+	if h.mutingRepo != nil {
+		if ok, err := h.mutingRepo.Exists(viewer.ID, ch.ID); err == nil {
+			out["isMuting"] = ok
+		}
+	}
 	return out
 }
 
@@ -541,7 +593,7 @@ func (h *Handler) channelToMapForViewer(ch *model.Channel, viewer *model.User) m
 func (h *Handler) channelsToList(rows []*model.Channel, viewer *model.User) []map[string]any {
 	out := make([]map[string]any, 0, len(rows))
 	banners := h.resolveBannerURLs(rows)
-	if viewer == nil || (h.followingRepo == nil && h.favoriteRepo == nil) {
+	if viewer == nil || (h.followingRepo == nil && h.favoriteRepo == nil && h.mutingRepo == nil) {
 		for _, ch := range rows {
 			out = append(out, h.channelToMap(ch, banners[ch.ID]))
 		}
@@ -558,6 +610,18 @@ func (h *Handler) channelsToList(rows []*model.Channel, viewer *model.User) []ma
 	if h.favoriteRepo != nil {
 		favorited, _ = h.favoriteRepo.ExistsMany(viewer.ID, ids)
 	}
+	// isMuting も list pack に乗せる (単一 show だけでなく search/featured/owned/
+	// favorites でも upstream Channel schema の isMuting が出る)。muting repo に
+	// ExistsMany が無いため ListByUser で viewer の muted set を一括取得する。
+	var mutedSet map[string]bool
+	if h.mutingRepo != nil {
+		if mutings, err := h.mutingRepo.ListByUser(viewer.ID); err == nil {
+			mutedSet = make(map[string]bool, len(mutings))
+			for _, m := range mutings {
+				mutedSet[m.ChannelID] = true
+			}
+		}
+	}
 	for _, ch := range rows {
 		m := h.channelToMap(ch, banners[ch.ID])
 		if followed != nil {
@@ -565,6 +629,9 @@ func (h *Handler) channelsToList(rows []*model.Channel, viewer *model.User) []ma
 		}
 		if favorited != nil {
 			m["isFavorited"] = favorited[ch.ID]
+		}
+		if mutedSet != nil {
+			m["isMuting"] = mutedSet[ch.ID]
 		}
 		out = append(out, m)
 	}

--- a/internal/api/channels/handler_test.go
+++ b/internal/api/channels/handler_test.go
@@ -71,6 +71,41 @@ func TestCreate_BadJSON(t *testing.T) {
 	assert.Equal(t, http.StatusBadRequest, rec.Code)
 }
 
+func TestCreate_BannerIDPersisted(t *testing.T) {
+	h, repo, _, _ := newHandler(t)
+	dr := testutil.NewMockDriveFileRepository()
+	owner := "alice"
+	require.NoError(t, dr.Create(&model.DriveFile{ID: "b1", UserID: &owner, Type: "image/png", URL: "https://x/b.png"}))
+	h.SetDriveFileRepo(dr)
+
+	c, rec := newReq(t, `{"name":"ch","color":"#abcdef","bannerId":"b1"}`)
+	setUser(c, "alice")
+	require.NoError(t, h.Create(c))
+	require.Equal(t, http.StatusOK, rec.Code)
+	// 永続化された channel に bannerId が入る。
+	var found *model.Channel
+	for _, ch := range repo.Channels {
+		found = ch
+	}
+	require.NotNil(t, found)
+	require.NotNil(t, found.BannerID)
+	assert.Equal(t, "b1", *found.BannerID)
+}
+
+func TestCreate_ForeignBannerRejected(t *testing.T) {
+	h, _, _, _ := newHandler(t)
+	dr := testutil.NewMockDriveFileRepository()
+	other := "bob"
+	require.NoError(t, dr.Create(&model.DriveFile{ID: "b1", UserID: &other, Type: "image/png", URL: "https://x/b.png"}))
+	h.SetDriveFileRepo(dr)
+
+	c, rec := newReq(t, `{"name":"ch","color":"#abcdef","bannerId":"b1"}`)
+	setUser(c, "alice")
+	require.NoError(t, h.Create(c))
+	assert.Equal(t, http.StatusBadRequest, rec.Code)
+	assert.Contains(t, rec.Body.String(), "NO_SUCH_FILE")
+}
+
 func TestCreate_NameRequired(t *testing.T) {
 	h, _, _, _ := newHandler(t)
 	c, rec := newReq(t, `{}`)
@@ -446,6 +481,169 @@ func TestSearch_BadJSON(t *testing.T) {
 	c, rec := newReq(t, `{not`)
 	require.NoError(t, h.Search(c))
 	assert.Equal(t, http.StatusBadRequest, rec.Code)
+}
+
+// type 省略時 (= nameAndDescription) は description 一致でもヒットする。
+func TestSearch_DefaultMatchesDescription(t *testing.T) {
+	h, repo, _, _ := newHandler(t)
+	desc := "a channel about gophers"
+	repo.Channels["c1"] = &model.Channel{ID: "c1", Name: "alpha", Description: &desc}
+	c, rec := newReq(t, `{"query":"gophers"}`)
+	require.NoError(t, h.Search(c))
+	require.Equal(t, http.StatusOK, rec.Code)
+	assert.Contains(t, rec.Body.String(), "alpha", "description 一致で hit")
+}
+
+// type=nameOnly は description 一致を除外する。
+func TestSearch_NameOnlyExcludesDescription(t *testing.T) {
+	h, repo, _, _ := newHandler(t)
+	desc := "a channel about gophers"
+	repo.Channels["c1"] = &model.Channel{ID: "c1", Name: "alpha", Description: &desc}
+	c, rec := newReq(t, `{"query":"gophers","type":"nameOnly"}`)
+	require.NoError(t, h.Search(c))
+	require.Equal(t, http.StatusOK, rec.Code)
+	assert.NotContains(t, rec.Body.String(), "alpha", "nameOnly は description を見ない")
+}
+
+// enum 外の type は 400 (upstream は ajv enum validation で弾く)。
+func TestSearch_InvalidTypeRejected(t *testing.T) {
+	h, _, _, _ := newHandler(t)
+	c, rec := newReq(t, `{"query":"x","type":"bogus"}`)
+	require.NoError(t, h.Search(c))
+	assert.Equal(t, http.StatusBadRequest, rec.Code)
+}
+
+// search は archived channel を除外する (upstream は常に isArchived=FALSE)。
+func TestSearch_ExcludesArchived(t *testing.T) {
+	h, repo, _, _ := newHandler(t)
+	repo.Channels["c1"] = &model.Channel{ID: "c1", Name: "alpha-live"}
+	repo.Channels["c2"] = &model.Channel{ID: "c2", Name: "alpha-archived", IsArchived: true}
+	c, rec := newReq(t, `{"query":"alpha"}`)
+	require.NoError(t, h.Search(c))
+	require.Equal(t, http.StatusOK, rec.Code)
+	assert.Contains(t, rec.Body.String(), "alpha-live")
+	assert.NotContains(t, rec.Body.String(), "alpha-archived")
+}
+
+// isMuting は list 経路 (search/featured/owned) にも乗る。
+func TestSearch_ListIncludesIsMuting(t *testing.T) {
+	h, repo, _, _ := newHandler(t)
+	repo.Channels["c1"] = &model.Channel{ID: "c1", Name: "muted-ch"}
+	muting := testutil.NewMockChannelMutingRepository()
+	require.NoError(t, muting.Create(&model.ChannelMuting{ID: "m1", UserID: "alice", ChannelID: "c1"}))
+	h.SetMutingRepo(muting)
+
+	c, rec := newReq(t, `{"query":"muted"}`)
+	setUser(c, "alice")
+	require.NoError(t, h.Search(c))
+	require.Equal(t, http.StatusOK, rec.Code)
+	var resp []map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+	require.Len(t, resp, 1)
+	assert.Equal(t, true, resp[0]["isMuting"])
+}
+
+// 解除: bannerId:"" で既存 banner が null 化される。
+func TestUpdate_BannerClear(t *testing.T) {
+	h, repo, _, _ := newHandler(t)
+	owner := "alice"
+	existing := "b0"
+	repo.Channels["c1"] = &model.Channel{ID: "c1", Name: "ch", UserID: &owner, BannerID: &existing}
+	c, rec := newReq(t, `{"channelId":"c1","bannerId":""}`)
+	setUser(c, "alice")
+	require.NoError(t, h.Update(c))
+	require.Equal(t, http.StatusOK, rec.Code)
+	assert.Nil(t, repo.Channels["c1"].BannerID, `bannerId:"" は banner を解除する`)
+}
+
+// Update で他人所有 banner は NO_SUCH_FILE (update 固有 error id)。
+func TestUpdate_ForeignBannerRejected(t *testing.T) {
+	h, repo, _, _ := newHandler(t)
+	owner := "alice"
+	repo.Channels["c1"] = &model.Channel{ID: "c1", Name: "ch", UserID: &owner}
+	dr := testutil.NewMockDriveFileRepository()
+	other := "bob"
+	require.NoError(t, dr.Create(&model.DriveFile{ID: "b1", UserID: &other, Type: "image/png", URL: "https://x/b.png"}))
+	h.SetDriveFileRepo(dr)
+	c, rec := newReq(t, `{"channelId":"c1","bannerId":"b1"}`)
+	setUser(c, "alice")
+	require.NoError(t, h.Update(c))
+	assert.Equal(t, http.StatusBadRequest, rec.Code)
+	assert.Contains(t, rec.Body.String(), "e86c14a4-0da2-4032-8df3-e737a04c7f3b")
+}
+
+// bannerResolver 未配線 + bannerId 指定は fail-closed (NO_SUCH_FILE)。
+func TestCreate_BannerNoResolverFailsClosed(t *testing.T) {
+	h, _, _, _ := newHandler(t) // SetDriveFileRepo を呼ばない
+	c, rec := newReq(t, `{"name":"ch","color":"#abcdef","bannerId":"b1"}`)
+	setUser(c, "alice")
+	require.NoError(t, h.Create(c))
+	assert.Equal(t, http.StatusBadRequest, rec.Code)
+	assert.Contains(t, rec.Body.String(), "NO_SUCH_FILE")
+}
+
+// pinnedNoteIds:[] は空配列として永続化 (nil でない)。
+func TestUpdate_PinnedNotesEmpty(t *testing.T) {
+	h, repo, _, _ := newHandler(t)
+	owner := "alice"
+	repo.Channels["c1"] = &model.Channel{ID: "c1", Name: "ch", UserID: &owner, PinnedNoteIDs: []string{"n1"}}
+	c, rec := newReq(t, `{"channelId":"c1","pinnedNoteIds":[]}`)
+	setUser(c, "alice")
+	require.NoError(t, h.Update(c))
+	require.Equal(t, http.StatusOK, rec.Code)
+	got := repo.Channels["c1"]
+	assert.NotNil(t, got.PinnedNoteIDs, "[] は nil でなく空配列")
+	assert.Len(t, []string(got.PinnedNoteIDs), 0)
+}
+
+// isMuting=false ケース (muting 配線済だが対象を mute していない)。
+func TestShow_IsMutingFalse(t *testing.T) {
+	h, repo, _, _ := newHandler(t)
+	repo.Channels["c1"] = &model.Channel{ID: "c1", Name: "ch"}
+	h.SetMutingRepo(testutil.NewMockChannelMutingRepository())
+	c, rec := newReq(t, `{"channelId":"c1"}`)
+	setUser(c, "alice")
+	require.NoError(t, h.Show(c))
+	require.Equal(t, http.StatusOK, rec.Code)
+	var resp map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+	assert.Equal(t, false, resp["isMuting"])
+}
+
+// channels/update が bannerId / pinnedNoteIds を反映する。
+func TestUpdate_BannerAndPinnedNotes(t *testing.T) {
+	h, repo, _, _ := newHandler(t)
+	owner := "alice"
+	repo.Channels["c1"] = &model.Channel{ID: "c1", Name: "ch", UserID: &owner}
+	dr := testutil.NewMockDriveFileRepository()
+	require.NoError(t, dr.Create(&model.DriveFile{ID: "b1", UserID: &owner, Type: "image/png", URL: "https://x/b.png"}))
+	h.SetDriveFileRepo(dr)
+
+	c, rec := newReq(t, `{"channelId":"c1","bannerId":"b1","pinnedNoteIds":["n1","n2"]}`)
+	setUser(c, "alice")
+	require.NoError(t, h.Update(c))
+	require.Equal(t, http.StatusOK, rec.Code)
+	got := repo.Channels["c1"]
+	require.NotNil(t, got.BannerID)
+	assert.Equal(t, "b1", *got.BannerID)
+	assert.Equal(t, []string{"n1", "n2"}, []string(got.PinnedNoteIDs))
+}
+
+// viewer 視点の isMuting が pack に含まれる。
+func TestShow_IncludesIsMuting(t *testing.T) {
+	h, repo, _, _ := newHandler(t)
+	repo.Channels["c1"] = &model.Channel{ID: "c1", Name: "ch"}
+	muting := testutil.NewMockChannelMutingRepository()
+	require.NoError(t, muting.Create(&model.ChannelMuting{ID: "m1", UserID: "alice", ChannelID: "c1"}))
+	h.SetMutingRepo(muting)
+
+	c, rec := newReq(t, `{"channelId":"c1"}`)
+	setUser(c, "alice")
+	require.NoError(t, h.Show(c))
+	require.Equal(t, http.StatusOK, rec.Code)
+	var resp map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+	assert.Equal(t, true, resp["isMuting"])
 }
 
 func TestSearch_RepoError(t *testing.T) {

--- a/internal/core/channel/channel_service.go
+++ b/internal/core/channel/channel_service.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"time"
 
+	"github.com/lib/pq"
 	"github.com/shiroha-a/mk/internal/misc/id"
 	"github.com/shiroha-a/mk/internal/model"
 	"github.com/shiroha-a/mk/internal/repository"
@@ -74,6 +75,7 @@ type CreateInput struct {
 	Description *string
 	Color       string
 	IsSensitive bool
+	BannerID    *string
 }
 
 // Create persists a new channel and returns it. Color が空文字なら Misskey
@@ -98,6 +100,7 @@ func (s *Service) Create(in CreateInput) (*model.Channel, error) {
 		Color:                 color,
 		UserID:                &owner,
 		IsSensitive:           in.IsSensitive,
+		BannerID:              in.BannerID,
 		AllowRenoteToExternal: true,
 	}
 	if err := s.repo.Create(c); err != nil {
@@ -122,6 +125,10 @@ type UpdateInput struct {
 	Color       *string
 	IsArchived  *bool
 	IsSensitive *bool
+	// BannerID: nil = 変更なし、非 nil で "" = banner 解除(null)、値 = 設定。
+	BannerID *string
+	// PinnedNoteIDs: nil = 変更なし、非 nil = その配列で置換。
+	PinnedNoteIDs *[]string
 }
 
 // Update applies the non-nil fields to a channel owned by ownerID.
@@ -151,6 +158,23 @@ func (s *Service) Update(ownerID, channelID string, in UpdateInput) (*model.Chan
 	}
 	if in.IsSensitive != nil {
 		fields["isSensitive"] = *in.IsSensitive
+	}
+	if in.BannerID != nil {
+		// "" は banner 解除 (null)、それ以外は設定。なお upstream の TS
+		// update.ts は bannerId:null を送っても解除しない (banner は外せない既知
+		// 制約) ので、"" 解除は mk-go 独自の利便機能。stock frontend は解除時
+		// bannerId:null を送るが、Go の *string は null/absent を区別できず
+		// 「変更なし」に落ちるため、この "" 解除分岐は API 直叩き専用。
+		if *in.BannerID == "" {
+			fields["bannerId"] = nil
+		} else {
+			fields["bannerId"] = *in.BannerID
+		}
+	}
+	if in.PinnedNoteIDs != nil {
+		// pq.StringArray でラップしないと空 slice が NULL 化して NOT NULL 制約
+		// 違反になる (aliases #729 と同型)。
+		fields["pinnedNoteIds"] = pq.StringArray(*in.PinnedNoteIDs)
 	}
 	if err := s.repo.UpdateFields(channelID, fields); err != nil {
 		return nil, err
@@ -255,13 +279,19 @@ func (s *Service) ListFeatured(sinceID, untilID string, limit, offset int) ([]*m
 }
 
 // Search returns channels whose name matches the query.
-func (s *Service) Search(query, sinceID, untilID string, limit, offset int) ([]*model.Channel, error) {
+// Search finds channels by name (and description when searchType is
+// "nameAndDescription", the upstream default). "nameOnly" matches name only.
+func (s *Service) Search(query, searchType, sinceID, untilID string, limit, offset int) ([]*model.Channel, error) {
+	// upstream channels/search は常に isArchived=FALSE を AND する。
+	notArchived := false
 	return s.repo.List(model.ChannelListFilter{
-		Query:   query,
-		Limit:   limit,
-		Offset:  offset,
-		SinceID: sinceID,
-		UntilID: untilID,
+		Query:             query,
+		SearchDescription: searchType != "nameOnly",
+		IsArchived:        &notArchived,
+		Limit:             limit,
+		Offset:            offset,
+		SinceID:           sinceID,
+		UntilID:           untilID,
 	})
 }
 

--- a/internal/core/channel/channel_service_test.go
+++ b/internal/core/channel/channel_service_test.go
@@ -350,7 +350,7 @@ func TestSearch(t *testing.T) {
 	svc, repo, _, _ := newSvc(t)
 	repo.Channels["c1"] = &model.Channel{ID: "c1", Name: "alpha"}
 	repo.Channels["c2"] = &model.Channel{ID: "c2", Name: "beta"}
-	rows, err := svc.Search("alp", "", "", 10, 0)
+	rows, err := svc.Search("alp", "nameAndDescription", "", "", 10, 0)
 	require.NoError(t, err)
 	assert.Len(t, rows, 1)
 }

--- a/internal/model/channel.go
+++ b/internal/model/channel.go
@@ -39,12 +39,15 @@ func (ChannelFollowing) TableName() string { return "channel_following" }
 // 0 値は無効化を意味する (フィルタしない)。Repository と service の双方から
 // 参照されるため model パッケージに置く (循環依存の回避)。
 type ChannelListFilter struct {
-	OwnerID    string // 所有者で絞る
-	Query      string // name 部分一致
-	IsArchived *bool  // archived 状態で絞る
-	SortBy     string // "+lastNotedAt" / "-lastNotedAt" / "+name" / "-notesCount" 等
-	Limit      int
-	Offset     int
+	OwnerID string // 所有者で絞る
+	Query   string // name (SearchDescription 時は description も) 部分一致
+	// SearchDescription: true で Query を name OR description にマッチさせる
+	// (upstream channels/search type=nameAndDescription, 既定)。false は name のみ。
+	SearchDescription bool
+	IsArchived        *bool  // archived 状態で絞る
+	SortBy            string // "+lastNotedAt" / "-lastNotedAt" / "+name" / "-notesCount" 等
+	Limit             int
+	Offset            int
 	// Cursor pagination (frontend Paginator). 指定時は SortBy を id 順に
 	// 上書きして cursor 一貫性を保つ。Offset は無視する。
 	SinceID string

--- a/internal/repository/channel.go
+++ b/internal/repository/channel.go
@@ -73,7 +73,13 @@ func (r *channelRepository) List(filter model.ChannelListFilter) ([]*model.Chann
 		q = q.Where("\"userId\" = ?", filter.OwnerID)
 	}
 	if filter.Query != "" {
-		q = q.Where("name ILIKE ?", "%"+filter.Query+"%")
+		like := "%" + filter.Query + "%"
+		if filter.SearchDescription {
+			// upstream type=nameAndDescription: name OR description。
+			q = q.Where("name ILIKE ? OR description ILIKE ?", like, like)
+		} else {
+			q = q.Where("name ILIKE ?", like)
+		}
 	}
 	if filter.IsArchived != nil {
 		q = q.Where("\"isArchived\" = ?", *filter.IsArchived)

--- a/internal/repository/channel_test.go
+++ b/internal/repository/channel_test.go
@@ -49,6 +49,38 @@ func TestChannelRepository_FindByID_NotFound(t *testing.T) {
 	assert.Error(t, err)
 }
 
+// SearchDescription=true は name OR description にマッチ、false は name のみ。
+func TestChannelRepository_List_SearchDescription(t *testing.T) {
+	repo := NewChannelRepository(testDB)
+	user := insertTestUser(t, "u_chr_sd", "channelusersd")
+	defer cleanupUser(t, user.ID)
+	uid := user.ID
+
+	desc := "about gophers and go"
+	c := newTestChannel("ch_sd_1", "sd-plainname", &uid)
+	c.Description = &desc
+	require.NoError(t, repo.Create(c))
+	defer cleanupChannel(t, c.ID)
+
+	// nameAndDescription (SearchDescription=true): description 一致で hit。
+	rows, err := repo.List(model.ChannelListFilter{Query: "gophers", SearchDescription: true})
+	require.NoError(t, err)
+	found := false
+	for _, r := range rows {
+		if r.ID == "ch_sd_1" {
+			found = true
+		}
+	}
+	assert.True(t, found, "SearchDescription=true は description 一致を返す")
+
+	// nameOnly (SearchDescription=false): description 一致は除外。
+	rows, err = repo.List(model.ChannelListFilter{Query: "gophers", SearchDescription: false})
+	require.NoError(t, err)
+	for _, r := range rows {
+		assert.NotEqual(t, "ch_sd_1", r.ID, "nameOnly は description を見ない")
+	}
+}
+
 func TestChannelRepository_UpdateFields(t *testing.T) {
 	repo := NewChannelRepository(testDB)
 	user := insertTestUser(t, "u_chr_2", "channeluser2")

--- a/internal/testutil/mock_repository.go
+++ b/internal/testutil/mock_repository.go
@@ -4184,8 +4184,15 @@ func (m *MockChannelRepository) List(filter model.ChannelListFilter) ([]*model.C
 				continue
 			}
 		}
-		if filter.Query != "" && !strings.Contains(c.Name, filter.Query) {
-			continue
+		if filter.Query != "" {
+			match := strings.Contains(c.Name, filter.Query)
+			// SearchDescription 時は description も対象 (production の ILIKE と整合)。
+			if !match && filter.SearchDescription && c.Description != nil {
+				match = strings.Contains(*c.Description, filter.Query)
+			}
+			if !match {
+				continue
+			}
 		}
 		if filter.IsArchived != nil && c.IsArchived != *filter.IsArchived {
 			continue
@@ -4239,6 +4246,22 @@ func applyChannelFields(c *model.Channel, fields map[string]any) {
 		case "lastNotedAt":
 			if t, ok := v.(*time.Time); ok {
 				c.LastNotedAt = t
+			}
+		case "bannerId":
+			switch s := v.(type) {
+			case string:
+				c.BannerID = &s
+			case *string:
+				c.BannerID = s
+			case nil:
+				c.BannerID = nil
+			}
+		case "pinnedNoteIds":
+			switch arr := v.(type) {
+			case pq.StringArray:
+				c.PinnedNoteIDs = arr
+			case []string:
+				c.PinnedNoteIDs = arr
 			}
 		}
 	}


### PR DESCRIPTION
## Summary

互換性監査 **HIGH を重要度順に消化するバッチ第3弾 (channels)**。チャンネルのパラメータ取りこぼし・検索仕様差・閲覧者状態欠落を本家整合させる。実装後に多エージェント敵対的レビューを実施し、確定指摘も同 PR で対応済み。

## 主な変更点

- **channels/create・update**: `bannerId` を受け取り永続化。所有権を検証 (呼出ユーザー所有の drive file でなければ `NO_SUCH_FILE`、create=`cd1e9f3e…` / update=`e86c14a4…`)。`""` で banner 解除。
- **channels/update**: `pinnedNoteIds` を反映 (`pq.StringArray` で空配列も保持)。
- **channels/search**: `type` (`nameAndDescription` 既定 / `nameOnly`) を受け、既定では description も検索対象に。archived チャンネルを除外 (upstream は常に `isArchived=FALSE`)。enum 外の `type` は 400。
- **Channel packed レスポンス**: 閲覧者視点の `isMuting` を追加 (単一 `show` + list 経路 `search`/`featured`/`owned` 両方)。

## レビュー対応 (確定 14 / HIGH 0 / 残り Medige は再検証で Low)
- `isMuting` を list packer (`channelsToList`) にも反映 (単一行だけだった非対称を解消)。
- `create` の `bannerId=""` を nil 正規化 (空文字カラムを作らない / TS は `misskey:id` format で 400)。
- `search` の `type` enum validation + `isArchived=FALSE` フィルタ。
- banner 解除 `""` sentinel が TS の挙動 (null では解除されない) と非対称な点をコメントで明示。
- テスト追加: list `isMuting` / invalid type 400 / archived 除外 / banner clear / update foreign banner `NO_SUCH_FILE` / nil resolver fail-closed / `pinnedNoteIds[]` / `isMuting=false` / repo の `SearchDescription`。

## テスト
- `make fmt` / `go vet ./...` クリーン。`internal/api/channels` 93.0% / `internal/core/channel` 95.0% / `internal/repository` 90.5%。

## その他 (本 PR scope 外 / 別途対応)
- `channels/mute/create` の `expiresAt`: `channel_muting` テーブルに `expiresAt` カラムが無く **DB migration が必要**なため別 PR。
- `channels/show` の `pinnedNotes` (detail): pinned note の取得・pack 配線が必要なため別 PR。

🤖 Generated with [Claude Code](https://claude.com/claude-code)