### PR TITLE
Fix parity (HIGH/user-packer): onlineStatus と isSilenced を活動状態/role policy から算出

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+- Fix: ユーザーの `onlineStatus` が常に `unknown` 固定だった問題を修正 (`lastActiveDate` と `hideOnlineStatus` から online/active/offline を算出。本家同様 10分=online / 3日=active のしきい値)。タイムライン・通知など全 UserLite 応答に反映される
+- Fix: `isSilenced` (サイレンス状態) が `/api/i` 以外のユーザー応答 (users/show・admin/show-user 等) で常に `false` 固定だった問題を修正 (role policy の `canPublicNote` を否定する role を持つかで算出。本家 UserEntityService 互換)
+
 - Fix: `/api/channels/create`・`/update` が `bannerId` を無視し、`/update` が `pinnedNoteIds` を反映できなかった問題を修正 (bannerId は所有権検証付き、`""` で banner 解除)。`/api/channels/search` が `type` (`nameAndDescription` 既定 / `nameOnly`) を無視して description を検索対象にしていなかった問題と、archived チャンネルを検索結果から除外していなかった問題も修正。チャンネルの packed レスポンス (show / search / featured / owned 等) に閲覧者視点の `isMuting` が欠落していた問題を修正
 
 - Fix: `/api/admin/roles/create`・`/show`・`/list` と公開 `/api/roles/list`・`/show` の Role レスポンスが raw な内部モデルで `usersCount`・`createdAt`・`target`・`condFormula`・`policies`(デフォルト値マージ)・`preserveAssignmentOnMoveAccount` を欠いていた問題を修正 (Misskey 本家 RoleEntityService.pack 相当の共通 packer に統一)。公開 `/api/roles/list` の `isExplorable` フィルタ欠落も合わせて修正 (本家同様 isPublic かつ isExplorable のみ列挙)

--- a/internal/api/admin/handler.go
+++ b/internal/api/admin/handler.go
@@ -785,6 +785,10 @@ func (h *Handler) packAdminUser(u *model.User, profile *model.UserProfile) map[s
 	if h.roleService != nil {
 		resp["isAdmin"] = h.roleService.IsAdministrator(u.ID)
 		resp["isModerator"] = h.roleService.IsModerator(u.ID)
+		// isSilenced は role policy 由来 (canPublicNote を否定する role を持つか)。
+		// upstream admin/show-user も roleService から算出する。map literal の
+		// false 固定をここで上書きする。
+		resp["isSilenced"] = h.roleService.IsSilenced(u.ID)
 		// roles: GetUserRoles は assigned + expired 除外済 list を返す
 		// (= 即時 active な role の minimal shape)。err 時は frontend が
 		// `user.roles.map(...)` で例外を吐かないよう空配列に fallback し

--- a/internal/api/admin/handler_test.go
+++ b/internal/api/admin/handler_test.go
@@ -21,6 +21,7 @@ import (
 	"github.com/shiroha-a/mk/internal/testutil"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"gorm.io/datatypes"
 )
 
 func newTestHandler(t *testing.T) (*apiadmin.Handler, *testutil.MockUserRepository, *testutil.MockMetaRepository, *testutil.MockRoleRepository) {
@@ -310,6 +311,26 @@ func TestShowUser_WithRoleAssigns(t *testing.T) {
 	assert.Equal(t, "r1", entry["roleId"])
 	assert.NotNil(t, entry["createdAt"])
 	assert.NotNil(t, entry["expiresAt"])
+}
+
+// admin/show-user は role policy 由来の isSilenced を返す (canPublicNote を
+// 否定する role を持つ user は true)。旧実装は false 固定だった。
+func TestShowUser_IsSilencedFromRolePolicy(t *testing.T) {
+	h, userRepo, _, roleRepo, assignRepo := newTestHandlerWithAssign(t)
+	uid := "silenced1"
+	userRepo.Users[uid] = &model.User{ID: uid, Username: "muted", AvatarDecorations: []byte("[]")}
+	userRepo.Profiles[uid] = &model.UserProfile{
+		UserID: uid, MutedWords: []byte("[]"), HardMutedWords: []byte("[]"), MutedInstances: []byte("[]"),
+	}
+	// canPublicNote=false の role を割り当てる → isSilenced=true。
+	roleRepo.Roles["silrole"] = &model.Role{ID: "silrole", Name: "Silenced", Policies: datatypes.JSON([]byte(`{"canPublicNote":{"useDefault":false,"priority":1,"value":false}}`))}
+	assignRepo.Assignments[uid+":silrole"] = &model.RoleAssignment{ID: "as1", UserID: uid, RoleID: "silrole"}
+
+	rec := doPost(h.ShowUser, `{"userId":"`+uid+`"}`, nil)
+	require.Equal(t, http.StatusOK, rec.Code)
+	var resp map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+	assert.Equal(t, true, resp["isSilenced"])
 }
 
 func TestShowUser_NotFound(t *testing.T) {

--- a/internal/api/i/handler.go
+++ b/internal/api/i/handler.go
@@ -649,7 +649,10 @@ func (h *Handler) Me(c echo.Context) error {
 	// (optional・null 不可、moderator が他者を見るとき専用) なので self-view
 	// (/api/i) では出さない。旧実装は `resp["moderationNote"]=nil` で null を出し
 	// golden 非互換だった (#1270 L3 で検出)。
-	// isSilenced は role policy 由来で /api/i 固有 (MeDetailed には無い)。
+	// isSilenced は role policy 由来 (MeDetailed/UserDetailedNotMe 共通 field)。
+	// PackUserDetailed も entity.SetSilencedLookup 経由で同値を埋めるが、/api/i は
+	// handler 層の roleProvider を権威ソースとして明示的に上書きする (両者とも
+	// 同一 roleService なので値は一致)。
 	resp["isSilenced"] = h.isSilenced(u.ID)
 
 	// Private fields from profile (MeDetailed scope 外)

--- a/internal/entity/silenced.go
+++ b/internal/entity/silenced.go
@@ -1,0 +1,43 @@
+package entity
+
+import "sync"
+
+// SilencedLookup resolves a user's `isSilenced` state from role policies.
+// Mirrors upstream UserEntityService.pack which sets
+// `isSilenced: !(await roleService.getUserPolicies(user.id)).canPublicNote`.
+//
+// Implemented structurally by role.Service.IsSilenced(userID) bool, so the
+// router can wire it directly without an adapter (keeps layering: entity never
+// imports core/role).
+type SilencedLookup interface {
+	IsSilenced(userID string) bool
+}
+
+// silencedLookup is process-wide so PackUserDetailed can resolve isSilenced
+// without changing its signature (called from many sites). Router wires this
+// once at startup via SetSilencedLookup. nil leaves isSilenced=false, which
+// keeps tests that don't wire it green (matches the previous hardcoded value).
+var (
+	silencedLookupMu sync.RWMutex
+	silencedLookup   SilencedLookup
+)
+
+// SetSilencedLookup wires the role-policy lookup used by PackUserDetailed to
+// derive isSilenced. Pass nil to clear (used in tests).
+func SetSilencedLookup(l SilencedLookup) {
+	silencedLookupMu.Lock()
+	silencedLookup = l
+	silencedLookupMu.Unlock()
+}
+
+// resolveSilenced returns isSilenced for userID via the registered lookup,
+// falling back to false when the lookup is unwired.
+func resolveSilenced(userID string) bool {
+	silencedLookupMu.RLock()
+	l := silencedLookup
+	silencedLookupMu.RUnlock()
+	if l == nil {
+		return false
+	}
+	return l.IsSilenced(userID)
+}

--- a/internal/entity/user.go
+++ b/internal/entity/user.go
@@ -3,11 +3,36 @@ package entity
 import (
 	"encoding/json"
 	"strings"
+	"time"
 
 	"github.com/shiroha-a/mk/internal/misc/id"
 	"github.com/shiroha-a/mk/internal/model"
 	"gorm.io/datatypes"
 )
+
+// upstream const.ts: USER_ONLINE_THRESHOLD=10min, USER_ACTIVE_THRESHOLD=3days。
+const (
+	userOnlineThreshold = 10 * time.Minute
+	userActiveThreshold = 3 * 24 * time.Hour
+)
+
+// computeOnlineStatus mirrors upstream UserEntityService.getOnlineStatus:
+// hideOnlineStatus or no lastActiveDate → "unknown"; otherwise online/active/
+// offline by elapsed time since lastActiveDate.
+func computeOnlineStatus(u *model.User) string {
+	if u.HideOnlineStatus || u.LastActiveDate == nil {
+		return "unknown"
+	}
+	elapsed := time.Since(*u.LastActiveDate)
+	switch {
+	case elapsed < userOnlineThreshold:
+		return "online"
+	case elapsed < userActiveThreshold:
+		return "active"
+	default:
+		return "offline"
+	}
+}
 
 // UserLite is the minimal user representation returned by most API endpoints.
 // Phase 7-5a (#247) added requireSigninToViewContents, makeNotes*Before and
@@ -413,7 +438,7 @@ func PackUserLite(u *model.User) UserLite {
 		IsBot:             u.IsBot,
 		IsCat:             u.IsCat,
 		Emojis:            make(map[string]string),
-		OnlineStatus:      "unknown",
+		OnlineStatus:      computeOnlineStatus(u),
 		BadgeRoles:        packBadgeRoles(u),
 		// upstream `chatAvailability === 'available'` 互換 (#988)。
 		// 旧実装は `u.ChatScope != "none"` で user 自身の受信設定を返して
@@ -457,6 +482,9 @@ func PackUserDetailed(u *model.User, profile *model.UserProfile, idGens ...id.Ge
 		PinnedNoteIDs:       []string{},
 		PinnedNotes:         []any{},
 		Roles:               packPublicRoles(u),
+		// isSilenced は role policy 由来 (canPublicNote を否定する role を持つか)。
+		// router で wire される lookup から解決する。unwired なら false。
+		IsSilenced: resolveSilenced(u.ID),
 		// DBデフォルト値 (user_profileのpublicReactions DEFAULT true)
 		PublicReactions: true,
 	}

--- a/internal/entity/user_test.go
+++ b/internal/entity/user_test.go
@@ -12,6 +12,55 @@ import (
 	"gorm.io/datatypes"
 )
 
+func TestComputeOnlineStatus(t *testing.T) {
+	now := time.Now()
+	mk := func(hide bool, last *time.Time) *model.User {
+		return &model.User{ID: "u", HideOnlineStatus: hide, LastActiveDate: last}
+	}
+	online := now.Add(-1 * time.Minute)
+	active := now.Add(-1 * time.Hour)
+	offline := now.Add(-10 * 24 * time.Hour)
+
+	assert.Equal(t, "unknown", computeOnlineStatus(mk(false, nil)), "lastActiveDate nil → unknown")
+	assert.Equal(t, "unknown", computeOnlineStatus(mk(true, &online)), "hideOnlineStatus → unknown")
+	assert.Equal(t, "online", computeOnlineStatus(mk(false, &online)))
+	assert.Equal(t, "active", computeOnlineStatus(mk(false, &active)))
+	assert.Equal(t, "offline", computeOnlineStatus(mk(false, &offline)))
+
+	// 境界: threshold 直前/直後 (< が online、>= が次段階)。
+	justOnline := now.Add(-userOnlineThreshold + time.Second)
+	justActive := now.Add(-userOnlineThreshold - time.Second)
+	justOffline := now.Add(-userActiveThreshold - time.Second)
+	assert.Equal(t, "online", computeOnlineStatus(mk(false, &justOnline)))
+	assert.Equal(t, "active", computeOnlineStatus(mk(false, &justActive)))
+	assert.Equal(t, "offline", computeOnlineStatus(mk(false, &justOffline)))
+
+	// PackUserLite が computeOnlineStatus を使う。
+	lite := PackUserLite(mk(false, &online))
+	assert.Equal(t, "online", lite.OnlineStatus)
+	// HideOnlineStatus は packer 経由でも尊重される。
+	assert.Equal(t, "unknown", PackUserLite(mk(true, &online)).OnlineStatus)
+}
+
+func TestPackUserDetailed_IsSilenced(t *testing.T) {
+	t.Cleanup(func() { SetSilencedLookup(nil) })
+	u := &model.User{ID: "silenced-user"}
+
+	// lookup 未配線なら false。
+	SetSilencedLookup(nil)
+	assert.False(t, PackUserDetailed(u, nil).IsSilenced)
+
+	// lookup が true を返せば反映される。
+	SetSilencedLookup(stubSilenced{ids: map[string]bool{"silenced-user": true}})
+	assert.True(t, PackUserDetailed(u, nil).IsSilenced)
+	// 別ユーザーは false。
+	assert.False(t, PackUserDetailed(&model.User{ID: "other"}, nil).IsSilenced)
+}
+
+type stubSilenced struct{ ids map[string]bool }
+
+func (s stubSilenced) IsSilenced(userID string) bool { return s.ids[userID] }
+
 func TestPackUserLite(t *testing.T) {
 	name := "Test User"
 	avatarURL := "https://example.com/avatar.png"

--- a/internal/server/router.go
+++ b/internal/server/router.go
@@ -1339,6 +1339,12 @@ func (s *Server) setupRoutes() {
 	// に表示されなかった。roleService.GetUserRoles も in-memory cache 経由
 	// (#761) で hot path コスト無し。
 	entity.SetUserRolesLookup(corerole.NewUserRolesLookup(roleService))
+	// PackUserDetailed の isSilenced を role policy 由来に揃える (旧実装は
+	// /api/i 以外で常に false 固定だった)。roleService.IsSilenced が
+	// entity.SilencedLookup を構造的に満たすので直接 wire する。GetUserRoles は
+	// in-memory cache (#761) だが IsSilenced 内の policy merge 自体は per-call
+	// なので、UserDetailed pack は単一 user の detail 取得が主用途であり許容範囲。
+	entity.SetSilencedLookup(roleService)
 	iHandler.SetNoteFieldResolver(noteFieldResolver)
 	// announcementRepoは後続で構築されるため SetupAdditional() 相当の順序依存があるが、
 	// 現状 announcementRepo := ... の行がここより後にあるため下で wire する。


### PR DESCRIPTION
## Summary

互換性監査 **HIGH を重要度順に消化するバッチ第4弾 (core User packer)**。`UserLite`/`UserDetailed` のコア packer が `onlineStatus` を常に `unknown`、`isSilenced` を常に `false` 固定で返していた問題を本家整合させる。**タイムライン・通知・users/show・admin 等、全ユーザー応答 (100+ 箇所) に効く高レバレッジ修正**。実装後に多エージェント敵対的レビューを実施し確定指摘も対応済み。

## 主な変更点

- **onlineStatus** (`entity/user.go`): `"unknown"` 固定 → `computeOnlineStatus`。`hideOnlineStatus` or `lastActiveDate==nil` → `unknown`、それ以外は経過時間で `online` (<10min) / `active` (<3days) / `offline` (本家 `getOnlineStatus` + `USER_ONLINE_THRESHOLD`/`USER_ACTIVE_THRESHOLD` 互換)。
- **isSilenced** (`entity/silenced.go` 新規 + `PackUserDetailed`): `false` 固定 → process-wide `SilencedLookup` (既存 `CanChatLookup` パターン踏襲)。`roleService.IsSilenced` (= role policy の `canPublicNote` 否定) を router で wire。
- **admin/show-user** (`packAdminUser`): `isSilenced: false` 固定を `roleService.IsSilenced` 由来に修正 (entity packer との整合、moderation view の実バグ)。

## レビュー対応 (確定 13 / HIGH 0 / Medium 1)
- `packAdminUser` の `isSilenced` 固定を修正 (SIL-2, 実 moderation バグ)。
- `/api/i` の `isSilenced` override コメントを実態 (MeDetailed も isSilenced を含む) に修正、router/silenced のコスト記述を是正。
- テスト追加: `onlineStatus` の各しきい値境界 + `HideOnlineStatus` packer 経由 / `isSilenced` の wired・unwired・別ユーザー / admin/show-user の role policy 由来 `isSilenced`。

## テスト
- `make fmt` / `go vet ./...` クリーン。`internal/entity` 95.9%。全 consumer (timeline/notification/notes/entitycompat shapetest 等) 緑。
- テスト用途では `lastActiveDate` 未設定→`unknown`、lookup 未配線→`false` で既存挙動を保ち、**本番でのみ新挙動が有効**。

## その他 (本 PR scope 外 / 別バッチ)
- handler 単位の pack-level 修正: users/show (userIds bulk → UserDetailed)、users/search-by-username-and-host (detail)、pinned-users (UserDetailed)、ap/show、auth/session/userkey、federation/users、bubble-game/ranking。
- `core/reversi` の `onlineStatus` ハードコード。
- (既知) `admin` の `TestFederationUpdateInstance_Integration*` はローカル test DB の既存残骸由来で本変更と無関係、CI は fresh DB で緑。

🤖 Generated with [Claude Code](https://claude.com/claude-code)