### PR TITLE
Fix parity (HIGH/gallery): files 解決・isLiked・create/update の fileIds 検証

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Fix: ギャラリー投稿 (`/api/gallery/posts/*` と featured/popular/posts) のレスポンスで `files` が常に空配列で、閲覧者視点の `isLiked` も欠落していた問題を修正 (`fileIds` から DriveFile を解決。一覧では 1 クエリにまとめて N+1 を回避)。`/api/gallery/posts/create` が `fileIds` 必須・所有ファイル検証 (1-32 件 / 重複除去) を行わず、`/api/gallery/posts/update` が `fileIds`/`isSensitive` を無視して 204 を返していた問題も修正 (本家同様、所有ファイルのみ採用し更新後の GalleryPost を返す)
+
 - Fix: ユーザーの `onlineStatus` が常に `unknown` 固定だった問題を修正 (`lastActiveDate` と `hideOnlineStatus` から online/active/offline を算出。本家同様 10分=online / 3日=active のしきい値)。タイムライン・通知など全 UserLite 応答に反映される
 - Fix: `isSilenced` (サイレンス状態) が `/api/i` 以外のユーザー応答 (users/show・admin/show-user 等) で常に `false` 固定だった問題を修正 (role policy の `canPublicNote` を否定する role を持つかで算出。本家 UserEntityService 互換)
 

--- a/internal/api/gallery/handler.go
+++ b/internal/api/gallery/handler.go
@@ -5,6 +5,7 @@ import (
 	"time"
 
 	"github.com/labstack/echo/v4"
+	"github.com/lib/pq"
 	"github.com/shiroha-a/mk/internal/api/apierr"
 	"github.com/shiroha-a/mk/internal/api/pagination"
 	"github.com/shiroha-a/mk/internal/entity"
@@ -31,7 +32,7 @@ func (h *Handler) Featured(c echo.Context) error {
 	if err := h.db.Preload("User").Order("\"likedCount\" DESC").Limit(10).Find(&posts).Error; err != nil {
 		return c.JSON(http.StatusInternalServerError, apierr.Error("INTERNAL_ERROR", "Internal error.", "5d37dbcb-891e-41ca-a3d6-e690c97775ac"))
 	}
-	return c.JSON(http.StatusOK, h.packMany(posts))
+	return c.JSON(http.StatusOK, h.packMany(posts, middleware.GetUser(c)))
 }
 
 // Popular handles POST /api/gallery/popular.
@@ -78,7 +79,7 @@ func (h *Handler) Posts(c echo.Context) error {
 	if err := q.Find(&posts).Error; err != nil {
 		return c.JSON(http.StatusInternalServerError, apierr.Error("INTERNAL_ERROR", "Internal error.", "5d37dbcb-891e-41ca-a3d6-e690c97775ac"))
 	}
-	return c.JSON(http.StatusOK, h.packMany(posts))
+	return c.JSON(http.StatusOK, h.packMany(posts, middleware.GetUser(c)))
 }
 
 // PostsCreate handles POST /api/gallery/posts/create.
@@ -93,8 +94,17 @@ func (h *Handler) PostsCreate(c echo.Context) error {
 	if err := c.Bind(&req); err != nil || req.Title == "" {
 		return c.JSON(http.StatusBadRequest, apierr.Error("INVALID_PARAM", "title is required.", "3d81ceae-475f-4600-b2a8-2bc116157532"))
 	}
-	if req.FileIDs == nil {
-		req.FileIDs = []string{}
+	// upstream paramDef: fileIds required, minItems:1。所有する drive file のみ
+	// を残し、1 件も残らなければ reject (upstream は filter→0 で throw)。
+	if len(req.FileIDs) == 0 || len(req.FileIDs) > galleryMaxFiles {
+		return c.JSON(http.StatusBadRequest, apierr.Error("INVALID_PARAM", "fileIds must contain 1-32 items.", "3d81ceae-475f-4600-b2a8-2bc116157532"))
+	}
+	owned, err := h.ownedFileIDs(req.FileIDs, user.ID)
+	if err != nil {
+		return c.JSON(http.StatusInternalServerError, apierr.Error("INTERNAL_ERROR", "Internal error.", "5d37dbcb-891e-41ca-a3d6-e690c97775ac"))
+	}
+	if len(owned) == 0 {
+		return c.JSON(http.StatusBadRequest, apierr.Error("INVALID_PARAM", "No valid files.", "3d81ceae-475f-4600-b2a8-2bc116157532"))
 	}
 	now := time.Now()
 	post := &model.GalleryPost{
@@ -103,7 +113,7 @@ func (h *Handler) PostsCreate(c echo.Context) error {
 		Title:       req.Title,
 		Description: req.Description,
 		UserID:      user.ID,
-		FileIDs:     req.FileIDs,
+		FileIDs:     pq.StringArray(owned),
 		IsSensitive: req.IsSensitive,
 		Tags:        []string{},
 	}
@@ -111,7 +121,37 @@ func (h *Handler) PostsCreate(c echo.Context) error {
 		return c.JSON(http.StatusInternalServerError, apierr.Error("INTERNAL_ERROR", "Internal error.", "5d37dbcb-891e-41ca-a3d6-e690c97775ac"))
 	}
 	post.User = user
-	return c.JSON(http.StatusOK, h.packOne(post))
+	return c.JSON(http.StatusOK, h.packOne(post, user))
+}
+
+// galleryMaxFiles mirrors upstream paramDef fileIds.maxItems.
+const galleryMaxFiles = 32
+
+// ownedFileIDs returns the subset of fileIDs that belong to userID, preserving
+// input order and deduplicating (upstream fileIds.uniqueItems). A DB error is
+// propagated (not swallowed) so the handler returns 500 rather than masking it
+// as a "no valid files" 400.
+func (h *Handler) ownedFileIDs(fileIDs []string, userID string) ([]string, error) {
+	if len(fileIDs) == 0 {
+		return nil, nil
+	}
+	var rows []*model.DriveFile
+	if err := h.db.Select("id").Where("id IN ? AND \"userId\" = ?", fileIDs, userID).Find(&rows).Error; err != nil {
+		return nil, err
+	}
+	ownedSet := make(map[string]bool, len(rows))
+	for _, f := range rows {
+		ownedSet[f.ID] = true
+	}
+	seen := make(map[string]bool, len(fileIDs))
+	out := make([]string, 0, len(fileIDs))
+	for _, fid := range fileIDs {
+		if ownedSet[fid] && !seen[fid] {
+			seen[fid] = true
+			out = append(out, fid)
+		}
+	}
+	return out, nil
 }
 
 // PostsShow handles POST /api/gallery/posts/show.
@@ -126,7 +166,7 @@ func (h *Handler) PostsShow(c echo.Context) error {
 	if err := h.db.Preload("User").Where("id = ?", req.PostID).First(&post).Error; err != nil {
 		return c.JSON(http.StatusNotFound, apierr.Error("NO_SUCH_POST", "No such post.", "1137bf14-c5b0-4604-85bb-5b5371b1cd45"))
 	}
-	return c.JSON(http.StatusOK, h.packOne(&post))
+	return c.JSON(http.StatusOK, h.packOne(&post, middleware.GetUser(c)))
 }
 
 // PostsDelete handles POST /api/gallery/posts/delete.
@@ -149,25 +189,54 @@ func (h *Handler) PostsDelete(c echo.Context) error {
 func (h *Handler) PostsUpdate(c echo.Context) error {
 	user := middleware.GetUser(c)
 	var req struct {
-		PostID      string  `json:"postId"`
-		Title       *string `json:"title"`
-		Description *string `json:"description"`
+		PostID      string    `json:"postId"`
+		Title       *string   `json:"title"`
+		Description *string   `json:"description"`
+		FileIDs     *[]string `json:"fileIds"`
+		// upstream paramDef は isSensitive: default false。省略時も false で
+		// 上書きされる (TypeORM は undefined だけ skip)。bool で受け常に書く。
+		IsSensitive bool `json:"isSensitive"`
 	}
 	if err := c.Bind(&req); err != nil || req.PostID == "" {
 		return c.JSON(http.StatusBadRequest, apierr.Error("INVALID_PARAM", "postId is required.", "3d81ceae-475f-4600-b2a8-2bc116157532"))
 	}
-	fields := map[string]any{}
+	// title は minLength:1 (空文字は 400)。
+	if req.Title != nil && *req.Title == "" {
+		return c.JSON(http.StatusBadRequest, apierr.Error("INVALID_PARAM", "title must not be empty.", "3d81ceae-475f-4600-b2a8-2bc116157532"))
+	}
+	// upstream は updatedAt と isSensitive(default false) を必ず更新する。fields が
+	// 空にならないので RowsAffected==0 (= 行不在) を NO_SUCH_POST 判定に使える。
+	fields := map[string]any{"updatedAt": time.Now(), "isSensitive": req.IsSensitive}
 	if req.Title != nil {
 		fields["title"] = *req.Title
 	}
 	if req.Description != nil {
 		fields["description"] = *req.Description
 	}
+	if req.FileIDs != nil {
+		if len(*req.FileIDs) == 0 || len(*req.FileIDs) > galleryMaxFiles {
+			return c.JSON(http.StatusBadRequest, apierr.Error("INVALID_PARAM", "fileIds must contain 1-32 items.", "3d81ceae-475f-4600-b2a8-2bc116157532"))
+		}
+		// fileIds 指定時は所有 file のみに絞り、1 件も無ければ reject。
+		owned, err := h.ownedFileIDs(*req.FileIDs, user.ID)
+		if err != nil {
+			return c.JSON(http.StatusInternalServerError, apierr.Error("INTERNAL_ERROR", "Internal error.", "5d37dbcb-891e-41ca-a3d6-e690c97775ac"))
+		}
+		if len(owned) == 0 {
+			return c.JSON(http.StatusBadRequest, apierr.Error("INVALID_PARAM", "No valid files.", "3d81ceae-475f-4600-b2a8-2bc116157532"))
+		}
+		fields["fileIds"] = pq.StringArray(owned)
+	}
 	result := h.db.Model(&model.GalleryPost{}).Where("id = ? AND \"userId\" = ?", req.PostID, user.ID).Updates(fields)
 	if result.RowsAffected == 0 {
 		return c.JSON(http.StatusNotFound, apierr.Error("NO_SUCH_POST", "No such post.", "1137bf14-c27b-46e0-86d3-0cbbf8b0aca5"))
 	}
-	return c.NoContent(http.StatusNoContent)
+	// upstream は更新後の GalleryPost を返す (204 ではない)。
+	var post model.GalleryPost
+	if err := h.db.Preload("User").Where("id = ?", req.PostID).First(&post).Error; err != nil {
+		return c.JSON(http.StatusNotFound, apierr.Error("NO_SUCH_POST", "No such post.", "1137bf14-c27b-46e0-86d3-0cbbf8b0aca5"))
+	}
+	return c.JSON(http.StatusOK, h.packOne(&post, user))
 }
 
 // PostsLike handles POST /api/gallery/posts/like.
@@ -205,34 +274,139 @@ func (h *Handler) PostsUnlike(c echo.Context) error {
 	return c.NoContent(http.StatusNoContent)
 }
 
-func (h *Handler) packMany(posts []*model.GalleryPost) []map[string]any {
+// resolveFiles fetches the DriveFiles for fileIDs and packs them in the same
+// order as fileIDs (upstream GalleryPost.files is the resolved DriveFile[]).
+// Missing files are skipped. Returns a non-nil slice so JSON is [] not null.
+func (h *Handler) resolveFiles(fileIDs []string) []entity.DriveFileEntity {
+	out := make([]entity.DriveFileEntity, 0, len(fileIDs))
+	if len(fileIDs) == 0 {
+		return out
+	}
+	var rows []*model.DriveFile
+	if err := h.db.Where("id IN ?", fileIDs).Find(&rows).Error; err != nil {
+		return out
+	}
+	byID := make(map[string]*model.DriveFile, len(rows))
+	for _, f := range rows {
+		byID[f.ID] = f
+	}
+	for _, fid := range fileIDs {
+		if f := byID[fid]; f != nil {
+			out = append(out, entity.PackDriveFile(f, h.idGen))
+		}
+	}
+	return out
+}
+
+// likedPostIDs returns the set of postIDs (from the given list) that viewerID
+// has liked, in one query. Empty when viewer is nil.
+func (h *Handler) likedPostIDs(viewerID string, postIDs []string) map[string]bool {
+	set := map[string]bool{}
+	if viewerID == "" || len(postIDs) == 0 {
+		return set
+	}
+	var liked []string
+	h.db.Model(&model.GalleryLike{}).
+		Where("\"userId\" = ? AND \"postId\" IN ?", viewerID, postIDs).
+		Pluck("\"postId\"", &liked)
+	for _, id := range liked {
+		set[id] = true
+	}
+	return set
+}
+
+func (h *Handler) packMany(posts []*model.GalleryPost, viewer *model.User) []map[string]any {
+	// batch file resolution (N+1 回避): 全 post の fileIds をまとめて 1 query。
+	idSet := map[string]struct{}{}
+	postIDs := make([]string, 0, len(posts))
+	for _, p := range posts {
+		postIDs = append(postIDs, p.ID)
+		for _, fid := range p.FileIDs {
+			idSet[fid] = struct{}{}
+		}
+	}
+	allFileIDs := make([]string, 0, len(idSet))
+	for fid := range idSet {
+		allFileIDs = append(allFileIDs, fid)
+	}
+	fileByID := map[string]entity.DriveFileEntity{}
+	if len(allFileIDs) > 0 {
+		var rows []*model.DriveFile
+		if err := h.db.Where("id IN ?", allFileIDs).Find(&rows).Error; err == nil {
+			for _, f := range rows {
+				fileByID[f.ID] = entity.PackDriveFile(f, h.idGen)
+			}
+		}
+	}
+	var likedSet map[string]bool
+	if viewer != nil {
+		likedSet = h.likedPostIDs(viewer.ID, postIDs)
+	}
+
 	result := make([]map[string]any, 0, len(posts))
 	for _, p := range posts {
-		result = append(result, h.packOne(p))
+		files := make([]entity.DriveFileEntity, 0, len(p.FileIDs))
+		for _, fid := range p.FileIDs {
+			if f, ok := fileByID[fid]; ok {
+				files = append(files, f)
+			}
+		}
+		var isLiked *bool
+		if viewer != nil {
+			v := likedSet[p.ID]
+			isLiked = &v
+		}
+		result = append(result, h.buildPostMap(p, files, isLiked))
 	}
 	return result
 }
 
-func (h *Handler) packOne(p *model.GalleryPost) map[string]any {
+// packOne packs a single post, resolving its files + the viewer's like state.
+// viewer may be nil (isLiked is then omitted, matching upstream optional field).
+func (h *Handler) packOne(p *model.GalleryPost, viewer *model.User) map[string]any {
+	files := h.resolveFiles(p.FileIDs)
+	var isLiked *bool
+	if viewer != nil {
+		liked := h.likedPostIDs(viewer.ID, []string{p.ID})
+		v := liked[p.ID]
+		isLiked = &v
+	}
+	return h.buildPostMap(p, files, isLiked)
+}
+
+// buildPostMap assembles the GalleryPost response shape from precomputed files
+// and isLiked. isLiked nil omits the field (upstream `isLiked` is optional).
+func (h *Handler) buildPostMap(p *model.GalleryPost, files []entity.DriveFileEntity, isLiked *bool) map[string]any {
 	createdAt := ""
 	if t, err := h.idGen.ParseTime(p.ID); err == nil {
 		createdAt = t.UTC().Format("2006-01-02T15:04:05.000Z")
 	}
+	fileIDs := []string(p.FileIDs)
+	if fileIDs == nil {
+		fileIDs = []string{}
+	}
+	tags := []string(p.Tags)
+	if tags == nil {
+		tags = []string{}
+	}
 	resp := map[string]any{
 		"id":          p.ID,
 		"createdAt":   createdAt,
-		"updatedAt":   p.UpdatedAt,
+		"updatedAt":   p.UpdatedAt.UTC().Format("2006-01-02T15:04:05.000Z"),
 		"title":       p.Title,
 		"description": p.Description,
 		"userId":      p.UserID,
-		"fileIds":     p.FileIDs,
-		"files":       []any{},
+		"fileIds":     fileIDs,
+		"files":       files,
 		"isSensitive": p.IsSensitive,
 		"likedCount":  p.LikedCount,
-		"tags":        p.Tags,
+		"tags":        tags,
 	}
 	if p.User != nil {
 		resp["user"] = entity.PackUserLite(p.User)
+	}
+	if isLiked != nil {
+		resp["isLiked"] = *isLiked
 	}
 	return resp
 }

--- a/internal/api/gallery/handler_test.go
+++ b/internal/api/gallery/handler_test.go
@@ -44,6 +44,16 @@ func brokenHandler() *gallery.Handler {
 func cleanup() {
 	testDB.Exec(`DELETE FROM "gallery_like"`)
 	testDB.Exec(`DELETE FROM "gallery_post"`)
+	testDB.Exec(`DELETE FROM "drive_file" WHERE id LIKE 'galf_%'`)
+}
+
+// seedDriveFile inserts a minimal drive file owned by ownerID for gallery tests.
+func seedDriveFile(id, ownerID string) {
+	uid := ownerID
+	testDB.Create(&model.DriveFile{
+		ID: id, UserID: &uid, MD5: "x", Name: id + ".png", Type: "image/png",
+		Size: 1, StoredInternal: true, URL: "https://example/" + id + ".png",
+	})
 }
 
 func doPost(h func(echo.Context) error, body string, user *model.User) *httptest.ResponseRecorder {
@@ -85,6 +95,95 @@ func TestPosts_Success(t *testing.T) {
 	assert.Equal(t, http.StatusOK, doPost(newHandler().Posts, `{}`, nil).Code)
 }
 
+// list (Posts) が複数 post の files を batch 解決し (順序保持)、各 post の
+// isLiked を viewer ごとに正しく埋める (liked=true / not-liked=false)。
+func TestPosts_BatchFilesAndPerPostIsLiked(t *testing.T) {
+	cleanup()
+	defer cleanup()
+	seedDriveFile("galf_a1", "gal_u1")
+	seedDriveFile("galf_a2", "gal_u1")
+	seedDriveFile("galf_b1", "gal_u1")
+	// postA: files [a1,a2]、liked。postB: [b1]、not-liked。
+	testDB.Create(&model.GalleryPost{ID: "gp_a", UpdatedAt: time.Now(), Title: "A", UserID: "gal_u1", FileIDs: []string{"galf_a1", "galf_a2"}, Tags: []string{}})
+	testDB.Create(&model.GalleryPost{ID: "gp_b", UpdatedAt: time.Now(), Title: "B", UserID: "gal_u1", FileIDs: []string{"galf_b1"}, Tags: []string{}})
+	testDB.Create(&model.GalleryLike{ID: "gl_a", UserID: "gal_u1", PostID: "gp_a"})
+
+	rec := doPost(newHandler().Posts, `{}`, &model.User{ID: "gal_u1"})
+	require.Equal(t, http.StatusOK, rec.Code)
+	var resp []map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+	byID := map[string]map[string]any{}
+	for _, p := range resp {
+		byID[p["id"].(string)] = p
+	}
+	a, b := byID["gp_a"], byID["gp_b"]
+	require.NotNil(t, a)
+	require.NotNil(t, b)
+	// 各 post は自分の files のみを fileIds 順で持つ。
+	assert.Equal(t, []any{"galf_a1", "galf_a2"}, a["fileIds"])
+	assert.Len(t, a["files"].([]any), 2)
+	assert.Len(t, b["files"].([]any), 1)
+	// isLiked は post ごとに正しい (A=true, B=false)。
+	assert.Equal(t, true, a["isLiked"])
+	assert.Equal(t, false, b["isLiked"])
+}
+
+func TestPostsUpdate_DBError(t *testing.T) {
+	assert.Equal(t, http.StatusInternalServerError,
+		doPost(brokenHandler().PostsUpdate, `{"postId":"x","fileIds":["galf_x"]}`, &model.User{ID: "gal_u1"}).Code)
+}
+
+// update で isSensitive 省略時は false で上書きされる (TS default:false)。
+func TestPostsUpdate_IsSensitiveResetOnOmit(t *testing.T) {
+	cleanup()
+	defer cleanup()
+	testDB.Create(&model.GalleryPost{ID: "gp_ir", UpdatedAt: time.Now(), Title: "Old", UserID: "gal_u1", FileIDs: []string{}, Tags: []string{}, IsSensitive: true})
+	rec := doPost(newHandler().PostsUpdate, `{"postId":"gp_ir","title":"New"}`, &model.User{ID: "gal_u1"})
+	require.Equal(t, http.StatusOK, rec.Code)
+	var resp map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+	assert.Equal(t, false, resp["isSensitive"], "isSensitive 省略時は false で上書き (TS default)")
+}
+
+// create: title 空文字 / fileIds 重複 dedup / maxItems 超過。
+func TestPostsCreate_TitleEmptyAndDedup(t *testing.T) {
+	cleanup()
+	defer cleanup()
+	seedDriveFile("galf_d1", "gal_u1")
+	// title 空は 400 (update 側 minLength)。create は title=="" を既存どおり弾く。
+	assert.Equal(t, http.StatusBadRequest, doPost(newHandler().PostsCreate, `{"title":"","fileIds":["galf_d1"]}`, &model.User{ID: "gal_u1"}).Code)
+	// 重複 fileId は dedup されて 1 件で保存される。
+	rec := doPost(newHandler().PostsCreate, `{"title":"Dup","fileIds":["galf_d1","galf_d1"]}`, &model.User{ID: "gal_u1"})
+	require.Equal(t, http.StatusOK, rec.Code)
+	var resp map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+	assert.Equal(t, []any{"galf_d1"}, resp["fileIds"], "重複は dedup")
+}
+
+// create: fileIds が 32 を超えると 400 (maxItems)。
+func TestPostsCreate_TooManyFiles(t *testing.T) {
+	ids := make([]string, 33)
+	for i := range ids {
+		ids[i] = `"f` + string(rune('a'+i%26)) + string(rune('0'+i/26)) + `"`
+	}
+	body := `{"title":"x","fileIds":[` + strings.Join(ids, ",") + `]}`
+	assert.Equal(t, http.StatusBadRequest, doPost(newHandler().PostsCreate, body, &model.User{ID: "gal_u1"}).Code)
+}
+
+// 混在 (owned + foreign) は owned のみを入力順で残す。
+func TestPostsCreate_MixedOwnedForeignOrder(t *testing.T) {
+	cleanup()
+	defer cleanup()
+	seedDriveFile("galf_m1", "gal_u1")
+	seedDriveFile("galf_m2", "gal_u1")
+	seedDriveFile("galf_mforeign", "someone_else")
+	rec := doPost(newHandler().PostsCreate, `{"title":"Mix","fileIds":["galf_m2","galf_mforeign","galf_m1"]}`, &model.User{ID: "gal_u1"})
+	require.Equal(t, http.StatusOK, rec.Code)
+	var resp map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+	assert.Equal(t, []any{"galf_m2", "galf_m1"}, resp["fileIds"], "owned のみ入力順で残す")
+}
+
 func TestPosts_WithOffset(t *testing.T) {
 	assert.Equal(t, http.StatusOK, doPost(newHandler().Posts, `{"limit":5,"offset":1}`, nil).Code)
 }
@@ -105,14 +204,36 @@ func TestPosts_DBError(t *testing.T) {
 
 func TestPostsCreate_Success(t *testing.T) {
 	cleanup()
+	defer cleanup()
+	seedDriveFile("galf_c1", "gal_u1")
 	user := &model.User{ID: "gal_u1", Username: "galuser"}
-	rec := doPost(newHandler().PostsCreate, `{"title":"My Art"}`, user)
+	rec := doPost(newHandler().PostsCreate, `{"title":"My Art","fileIds":["galf_c1"]}`, user)
 	assert.Equal(t, http.StatusOK, rec.Code)
 	var resp map[string]any
 	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
 	assert.Equal(t, "My Art", resp["title"])
+	// files が DriveFile に解決される (空配列でない)。
+	files, ok := resp["files"].([]any)
+	require.True(t, ok)
+	assert.Len(t, files, 1)
+	// 作成者視点なので isLiked=false が出る。
+	assert.Equal(t, false, resp["isLiked"])
 	shapetest.Assert(t, "GalleryPost", resp) // L3 (#1270)
+}
+
+// fileIds 必須: 省略時は 400。
+func TestPostsCreate_FileIdsRequired(t *testing.T) {
+	assert.Equal(t, http.StatusBadRequest,
+		doPost(newHandler().PostsCreate, `{"title":"x"}`, &model.User{ID: "gal_u1"}).Code)
+}
+
+// 他人所有の fileId のみだと有効ファイル 0 で 400。
+func TestPostsCreate_ForeignFilesRejected(t *testing.T) {
 	cleanup()
+	defer cleanup()
+	seedDriveFile("galf_other", "someone_else")
+	rec := doPost(newHandler().PostsCreate, `{"title":"x","fileIds":["galf_other"]}`, &model.User{ID: "gal_u1"})
+	assert.Equal(t, http.StatusBadRequest, rec.Code)
 }
 
 func TestPostsCreate_InvalidParam(t *testing.T) {
@@ -120,7 +241,8 @@ func TestPostsCreate_InvalidParam(t *testing.T) {
 }
 
 func TestPostsCreate_DBError(t *testing.T) {
-	assert.Equal(t, http.StatusInternalServerError, doPost(brokenHandler().PostsCreate, `{"title":"x"}`, &model.User{ID: "u1"}).Code)
+	// fileIds 検証 (ownedFileIDs) が壊れた DB で error → 500。
+	assert.Equal(t, http.StatusInternalServerError, doPost(brokenHandler().PostsCreate, `{"title":"x","fileIds":["galf_x"]}`, &model.User{ID: "u1"}).Code)
 }
 
 // --- Show ---
@@ -134,6 +256,32 @@ func TestPostsShow_Found(t *testing.T) {
 	var resp map[string]any
 	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
 	shapetest.Assert(t, "GalleryPost", resp) // L3 (#1320)
+}
+
+// viewer が like 済みなら show の isLiked=true。未認証 viewer では isLiked 省略。
+func TestPostsShow_IsLikedAndFiles(t *testing.T) {
+	cleanup()
+	defer cleanup()
+	seedDriveFile("galf_s2", "gal_u1")
+	testDB.Create(&model.GalleryPost{ID: "gp_s2", UpdatedAt: time.Now(), Title: "S", UserID: "gal_u1", FileIDs: []string{"galf_s2"}, Tags: []string{}})
+	testDB.Create(&model.GalleryLike{ID: "gl_s2", UserID: "gal_u1", PostID: "gp_s2"})
+
+	// 認証 viewer (like 済み): isLiked=true、files 解決。
+	rec := doPost(newHandler().PostsShow, `{"postId":"gp_s2"}`, &model.User{ID: "gal_u1"})
+	require.Equal(t, http.StatusOK, rec.Code)
+	var resp map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+	assert.Equal(t, true, resp["isLiked"])
+	files, _ := resp["files"].([]any)
+	assert.Len(t, files, 1)
+
+	// 未認証 viewer: isLiked は省略される (upstream optional)。
+	rec = doPost(newHandler().PostsShow, `{"postId":"gp_s2"}`, nil)
+	require.Equal(t, http.StatusOK, rec.Code)
+	var anon map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &anon))
+	_, has := anon["isLiked"]
+	assert.False(t, has, "未認証では isLiked を出さない")
 }
 
 func TestPostsShow_NotFound(t *testing.T) {
@@ -166,14 +314,45 @@ func TestPostsUpdate_Success(t *testing.T) {
 	cleanup()
 	testDB.Create(&model.GalleryPost{ID: "gp_u1", UpdatedAt: time.Now(), Title: "Old", UserID: "gal_u1", FileIDs: []string{}, Tags: []string{}})
 	defer cleanup()
-	assert.Equal(t, http.StatusNoContent, doPost(newHandler().PostsUpdate, `{"postId":"gp_u1","title":"New"}`, &model.User{ID: "gal_u1"}).Code)
+	// upstream は更新後の GalleryPost を返す (204 ではない)。
+	rec := doPost(newHandler().PostsUpdate, `{"postId":"gp_u1","title":"New"}`, &model.User{ID: "gal_u1"})
+	require.Equal(t, http.StatusOK, rec.Code)
+	var resp map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+	assert.Equal(t, "New", resp["title"])
 }
 
 func TestPostsUpdate_WithDescription(t *testing.T) {
 	cleanup()
 	testDB.Create(&model.GalleryPost{ID: "gp_ud1", UpdatedAt: time.Now(), Title: "Old", UserID: "gal_u1", FileIDs: []string{}, Tags: []string{}})
 	defer cleanup()
-	assert.Equal(t, http.StatusNoContent, doPost(newHandler().PostsUpdate, `{"postId":"gp_ud1","title":"New","description":"desc"}`, &model.User{ID: "gal_u1"}).Code)
+	assert.Equal(t, http.StatusOK, doPost(newHandler().PostsUpdate, `{"postId":"gp_ud1","title":"New","description":"desc"}`, &model.User{ID: "gal_u1"}).Code)
+}
+
+// update で他人所有 fileId のみ指定すると有効ファイル 0 で 400 (更新されない)。
+func TestPostsUpdate_ForeignFilesRejected(t *testing.T) {
+	cleanup()
+	defer cleanup()
+	seedDriveFile("galf_foreign", "someone_else")
+	testDB.Create(&model.GalleryPost{ID: "gp_uf", UpdatedAt: time.Now(), Title: "Old", UserID: "gal_u1", FileIDs: []string{}, Tags: []string{}})
+	rec := doPost(newHandler().PostsUpdate, `{"postId":"gp_uf","fileIds":["galf_foreign"]}`, &model.User{ID: "gal_u1"})
+	assert.Equal(t, http.StatusBadRequest, rec.Code)
+}
+
+// update が fileIds / isSensitive を反映し、files を解決して返す。
+func TestPostsUpdate_FileIdsAndSensitive(t *testing.T) {
+	cleanup()
+	defer cleanup()
+	seedDriveFile("galf_u2a", "gal_u1")
+	testDB.Create(&model.GalleryPost{ID: "gp_u2", UpdatedAt: time.Now(), Title: "Old", UserID: "gal_u1", FileIDs: []string{}, Tags: []string{}})
+	rec := doPost(newHandler().PostsUpdate, `{"postId":"gp_u2","fileIds":["galf_u2a"],"isSensitive":true}`, &model.User{ID: "gal_u1"})
+	require.Equal(t, http.StatusOK, rec.Code)
+	var resp map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+	assert.Equal(t, true, resp["isSensitive"])
+	assert.Equal(t, []any{"galf_u2a"}, resp["fileIds"])
+	files, _ := resp["files"].([]any)
+	assert.Len(t, files, 1)
 }
 
 func TestPostsUpdate_NotFound(t *testing.T) {


### PR DESCRIPTION
## Summary

互換性監査 **HIGH を重要度順に消化するバッチ第5弾 (gallery)**。ギャラリー投稿のレスポンスで `files` が常に空・`isLiked` 欠落、create/update のパラメータ取りこぼしを本家整合させる。実装後に多エージェント敵対的レビューを実施し確定指摘も対応済み。

## 主な変更点

- **files 解決 / isLiked**: `packOne`/`packMany` が `fileIds` から DriveFile を解決 (一覧は全 post を **1 クエリで batch 解決し N+1 回避**)。閲覧者視点の `isLiked` を付与 (未認証時は省略 = upstream optional)。
- **PostsCreate**: `fileIds` 必須 (1-32 件 / `uniqueItems` 重複除去 / 所有ファイルのみ採用、0 件→400)、更新後 GalleryPost を返却。
- **PostsUpdate**: `fileIds` (所有 filter) / `isSensitive` を反映、`updatedAt` 常時更新、204 でなく更新後 GalleryPost を返却。`ownedFileIDs` は DB error を伝播 (500)。

## レビュー対応 (確定 25 / HIGH は test-gap / Medium 4 / Low 20)
- `updatedAt` を `createdAt` と同じ ms ISO 形式に統一 (raw `time.Time` のナノ秒乖離を解消)。
- update の `isSensitive` を `default false` で常時上書き (TS paramDef 互換)。
- `fileIds` の `uniqueItems`(dedup) / `maxItems`(32) / `title` minLength を検証。
- テスト追加: 複数 post の batch files + per-post `isLiked`(true/false) / update DB error / `isSensitive` reset / dedup / maxItems / mixed owned-foreign の順序保持 / show の `isLiked`(me 限定)・anon 省略。

## 意図的 divergence (mk-go の方が安全、コメント済)
- 存在しない / 他人所有の post への update は mk-go が **404** を返す (TS は 500 / 他人の post を 200 で返す挙動)。

## テスト
- `make fmt` / `go vet ./...` クリーン。`internal/api/gallery` 93.7%。

## その他 (本 PR scope 外 / 別バッチ)
- `i/gallery/*`・`users/gallery/*` の packer (まだ files 未解決 / isLiked なし)。
- `tags` 空時の omit (現状 `[]`、frontend は `?? []` で無害)。

🤖 Generated with [Claude Code](https://claude.com/claude-code)