### PR TITLE
Fix notes/drafts: NoteDraft full shape + create/update params + 所有/poll 検証

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Fix: 下書き (`/api/notes/drafts/*`) のレスポンスが `text`/`cw`/`visibility`/`localOnly`/`fileIds` しか持たず、本家 NoteDraft schema の `userId`/`reactionAcceptance`/`visibleUserIds`/`replyId`/`renoteId`/`channelId`/`hashtag`/`poll`/`scheduledAt`/`isActuallyScheduled`/`user`/`files` を欠いていた問題を修正 (一覧では全下書きの `files` を 1 クエリにまとめて N+1 を回避)。あわせて `/api/notes/drafts/create`・`/update` が `visibleUserIds`/`reactionAcceptance`/`replyId`/`renoteId`/`channelId`/`hashtag`/`poll` を受け付けず、レスポンスを本家同様の `{createdDraft}`/`{updatedDraft}` で包んでいなかった問題と、`fileIds` の所有検証 (`NO_SUCH_FILE`) と期限切れ poll の拒否 (`CANNOT_CREATE_ALREADY_EXPIRED_POLL`) が無かった問題も修正
 - Fix: ギャラリー投稿 (`/api/gallery/posts/*` と featured/popular/posts) のレスポンスで `files` が常に空配列で、閲覧者視点の `isLiked` も欠落していた問題を修正 (`fileIds` から DriveFile を解決。一覧では 1 クエリにまとめて N+1 を回避)。`/api/gallery/posts/create` が `fileIds` 必須・所有ファイル検証 (1-32 件 / 重複除去) を行わず、`/api/gallery/posts/update` が `fileIds`/`isSensitive` を無視して 204 を返していた問題も修正 (本家同様、所有ファイルのみ採用し更新後の GalleryPost を返す)
 
 - Fix: ユーザーの `onlineStatus` が常に `unknown` 固定だった問題を修正 (`lastActiveDate` と `hideOnlineStatus` から online/active/offline を算出。本家同様 10分=online / 3日=active のしきい値)。タイムライン・通知など全 UserLite 応答に反映される

--- a/internal/api/notes/handler_drafts.go
+++ b/internal/api/notes/handler_drafts.go
@@ -5,7 +5,9 @@ import (
 	"time"
 
 	"github.com/labstack/echo/v4"
+	"github.com/lib/pq"
 	"github.com/shiroha-a/mk/internal/api/apierr"
+	"github.com/shiroha-a/mk/internal/entity"
 	"github.com/shiroha-a/mk/internal/model"
 	"github.com/shiroha-a/mk/internal/queue"
 	"github.com/shiroha-a/mk/internal/queue/driver"
@@ -28,9 +30,17 @@ func (h *Handler) DraftsList(c echo.Context) error {
 	if err != nil {
 		return c.JSON(http.StatusOK, []any{})
 	}
+	// 全 draft の fileIds をまとめて 1 query で解決し N+1 を回避する。
+	allFileIDs := []string{}
+	for _, d := range drafts {
+		allFileIDs = append(allFileIDs, []string(d.FileIDs)...)
+	}
+	fileByID := h.resolveDraftFileMap(allFileIDs)
 	out := make([]map[string]any, len(drafts))
 	for i, d := range drafts {
-		out[i] = packDraft(d, h.idGen)
+		// drafts は viewer 自身のものなので user を埋める (repo は Preload しない)。
+		d.User = user
+		out[i] = h.packDraft(d, fileByID)
 	}
 	return c.JSON(http.StatusOK, out)
 }
@@ -45,12 +55,20 @@ func (h *Handler) DraftsCreate(c echo.Context) error {
 		return c.NoContent(http.StatusNoContent)
 	}
 	var req struct {
-		Text                *string  `json:"text"`
-		CW                  *string  `json:"cw"`
-		Visibility          string   `json:"visibility"`
-		FileIDs             []string `json:"fileIds"`
-		ScheduledAt         *int64   `json:"scheduledAt"`
-		IsActuallyScheduled bool     `json:"isActuallyScheduled"`
+		Text                *string    `json:"text"`
+		CW                  *string    `json:"cw"`
+		Visibility          string     `json:"visibility"`
+		VisibleUserIDs      []string   `json:"visibleUserIds"`
+		LocalOnly           bool       `json:"localOnly"`
+		ReactionAcceptance  *string    `json:"reactionAcceptance"`
+		FileIDs             []string   `json:"fileIds"`
+		ReplyID             *string    `json:"replyId"`
+		RenoteID            *string    `json:"renoteId"`
+		ChannelID           *string    `json:"channelId"`
+		Hashtag             *string    `json:"hashtag"`
+		Poll                *draftPoll `json:"poll"`
+		ScheduledAt         *int64     `json:"scheduledAt"`
+		IsActuallyScheduled bool       `json:"isActuallyScheduled"`
 	}
 	if err := c.Bind(&req); err != nil {
 		return c.JSON(http.StatusBadRequest, apierr.InvalidParam("Invalid parameters."))
@@ -111,16 +129,32 @@ func (h *Handler) DraftsCreate(c echo.Context) error {
 			}
 		}
 	}
+	// fileIds は全て呼出ユーザー所有でなければ NO_SUCH_FILE (upstream NoteDraftService)。
+	if !h.allDraftFilesOwned(req.FileIDs, user.ID) {
+		return c.JSON(http.StatusBadRequest, apierr.Error("NO_SUCH_FILE", "Some files are not found.", "b6992544-63e7-67f0-fa7f-32444b1b5306"))
+	}
+	// 既に期限切れの poll は作成不可 (CANNOT_CREATE_ALREADY_EXPIRED_POLL)。
+	if pollAlreadyExpired(req.Poll, now) {
+		return c.JSON(http.StatusBadRequest, apierr.Error("CANNOT_CREATE_ALREADY_EXPIRED_POLL", "Cannot create an already expired poll.", "04da457d-b083-4055-9082-955525eda5a5"))
+	}
 	draft := &model.NoteDraft{
 		ID:                  h.idGen.Generate(now),
 		UserID:              user.ID,
 		Text:                req.Text,
 		CW:                  req.CW,
 		Visibility:          req.Visibility,
-		FileIDs:             req.FileIDs,
+		VisibleUserIDs:      pq.StringArray(req.VisibleUserIDs),
+		LocalOnly:           req.LocalOnly,
+		ReactionAcceptance:  req.ReactionAcceptance,
+		FileIDs:             pq.StringArray(req.FileIDs),
+		ReplyID:             req.ReplyID,
+		RenoteID:            req.RenoteID,
+		ChannelID:           req.ChannelID,
+		Hashtag:             req.Hashtag,
 		ScheduledAt:         scheduledAt,
 		IsActuallyScheduled: req.IsActuallyScheduled,
 	}
+	applyDraftPoll(draft, req.Poll)
 	if err := h.draftRepo.Create(draft); err != nil {
 		return c.JSON(http.StatusInternalServerError, apierr.InternalError())
 	}
@@ -137,7 +171,9 @@ func (h *Handler) DraftsCreate(c echo.Context) error {
 			return apierr.JSONInternalError(c)
 		}
 	}
-	return c.JSON(http.StatusOK, packDraft(draft, h.idGen))
+	draft.User = user
+	// upstream res は { createdDraft: NoteDraft } で包む。
+	return c.JSON(http.StatusOK, map[string]any{"createdDraft": h.packDraft(draft, nil)})
 }
 
 // DraftsUpdate handles POST /api/notes/drafts/update.
@@ -150,13 +186,21 @@ func (h *Handler) DraftsUpdate(c echo.Context) error {
 		return c.NoContent(http.StatusNoContent)
 	}
 	var req struct {
-		DraftID             string   `json:"draftId"`
-		Text                *string  `json:"text"`
-		CW                  *string  `json:"cw"`
-		Visibility          string   `json:"visibility"`
-		FileIDs             []string `json:"fileIds"`
-		ScheduledAt         *int64   `json:"scheduledAt"`
-		IsActuallyScheduled *bool    `json:"isActuallyScheduled"`
+		DraftID             string     `json:"draftId"`
+		Text                *string    `json:"text"`
+		CW                  *string    `json:"cw"`
+		Visibility          string     `json:"visibility"`
+		VisibleUserIDs      *[]string  `json:"visibleUserIds"`
+		LocalOnly           *bool      `json:"localOnly"`
+		ReactionAcceptance  *string    `json:"reactionAcceptance"`
+		FileIDs             []string   `json:"fileIds"`
+		ReplyID             *string    `json:"replyId"`
+		RenoteID            *string    `json:"renoteId"`
+		ChannelID           *string    `json:"channelId"`
+		Hashtag             *string    `json:"hashtag"`
+		Poll                *draftPoll `json:"poll"`
+		ScheduledAt         *int64     `json:"scheduledAt"`
+		IsActuallyScheduled *bool      `json:"isActuallyScheduled"`
 	}
 	if err := c.Bind(&req); err != nil || req.DraftID == "" {
 		return c.JSON(http.StatusBadRequest, apierr.InvalidParam("draftId is required."))
@@ -174,14 +218,45 @@ func (h *Handler) DraftsUpdate(c echo.Context) error {
 	if req.Visibility != "" {
 		draft.Visibility = req.Visibility
 	}
+	if req.VisibleUserIDs != nil {
+		draft.VisibleUserIDs = pq.StringArray(*req.VisibleUserIDs)
+	}
+	if req.LocalOnly != nil {
+		draft.LocalOnly = *req.LocalOnly
+	}
+	if req.ReactionAcceptance != nil {
+		draft.ReactionAcceptance = req.ReactionAcceptance
+	}
 	if req.FileIDs != nil {
-		draft.FileIDs = req.FileIDs
+		// fileIds 指定時は全て所有 file でなければ NO_SUCH_FILE。
+		if !h.allDraftFilesOwned(req.FileIDs, user.ID) {
+			return c.JSON(http.StatusBadRequest, apierr.Error("NO_SUCH_FILE", "Some files are not found.", "b6992544-63e7-67f0-fa7f-32444b1b5306"))
+		}
+		draft.FileIDs = pq.StringArray(req.FileIDs)
+	}
+	if req.ReplyID != nil {
+		draft.ReplyID = req.ReplyID
+	}
+	if req.RenoteID != nil {
+		draft.RenoteID = req.RenoteID
+	}
+	if req.ChannelID != nil {
+		draft.ChannelID = req.ChannelID
+	}
+	if req.Hashtag != nil {
+		draft.Hashtag = req.Hashtag
 	}
 	// scheduled 関連 field の変更検出 (#1045 Phase 2-C)。リクエストに
 	// scheduledAt / isActuallyScheduled が含まれている場合のみ削除 + 再
 	// enqueue する。それ以外は既存 draft 状態を維持。
 	scheduleChanged := false
 	now := time.Now()
+	if req.Poll != nil {
+		if pollAlreadyExpired(req.Poll, now) {
+			return c.JSON(http.StatusBadRequest, apierr.Error("CANNOT_CREATE_ALREADY_EXPIRED_POLL", "Cannot create an already expired poll.", "04da457d-b083-4055-9082-955525eda5a5"))
+		}
+		applyDraftPoll(draft, req.Poll)
+	}
 	if req.ScheduledAt != nil {
 		t := time.UnixMilli(*req.ScheduledAt)
 		draft.ScheduledAt = &t
@@ -222,7 +297,70 @@ func (h *Handler) DraftsUpdate(c echo.Context) error {
 			}
 		}
 	}
-	return c.JSON(http.StatusOK, packDraft(draft, h.idGen))
+	draft.User = user
+	// upstream res は { updatedDraft: NoteDraft } で包む。
+	return c.JSON(http.StatusOK, map[string]any{"updatedDraft": h.packDraft(draft, nil)})
+}
+
+// draftPoll mirrors the upstream notes/drafts poll param object.
+type draftPoll struct {
+	Choices      []string `json:"choices"`
+	Multiple     bool     `json:"multiple"`
+	ExpiresAt    *int64   `json:"expiresAt"`
+	ExpiredAfter *int64   `json:"expiredAfter"`
+}
+
+// allDraftFilesOwned reports whether every fileID exists and is owned by
+// userID (upstream NoteDraftService requires files.length === fileIds.length).
+// Unwired driveFileRepo (tests) skips the check.
+func (h *Handler) allDraftFilesOwned(fileIDs []string, userID string) bool {
+	if len(fileIDs) == 0 || h.driveFileRepo == nil {
+		return true
+	}
+	rows, err := h.driveFileRepo.FindByIDs(fileIDs)
+	if err != nil {
+		return false
+	}
+	owned := make(map[string]bool, len(rows))
+	for _, f := range rows {
+		if f.UserID != nil && *f.UserID == userID {
+			owned[f.ID] = true
+		}
+	}
+	for _, fid := range fileIDs {
+		if !owned[fid] {
+			return false
+		}
+	}
+	return true
+}
+
+// pollAlreadyExpired reports whether the poll's expiresAt is in the past.
+func pollAlreadyExpired(p *draftPoll, now time.Time) bool {
+	return p != nil && p.ExpiresAt != nil && time.UnixMilli(*p.ExpiresAt).Before(now)
+}
+
+// applyDraftPoll writes poll fields into the draft. nil clears the poll
+// (hasPoll=false); non-nil sets hasPoll=true + the choices/multiple/expiry.
+func applyDraftPoll(d *model.NoteDraft, p *draftPoll) {
+	if p == nil {
+		d.HasPoll = false
+		d.PollChoices = pq.StringArray{}
+		d.PollMultiple = false
+		d.PollExpiresAt = nil
+		d.PollExpiredAfter = nil
+		return
+	}
+	d.HasPoll = true
+	d.PollChoices = pq.StringArray(p.Choices)
+	d.PollMultiple = p.Multiple
+	d.PollExpiredAfter = p.ExpiredAfter
+	if p.ExpiresAt != nil {
+		t := time.UnixMilli(*p.ExpiresAt)
+		d.PollExpiresAt = &t
+	} else {
+		d.PollExpiresAt = nil
+	}
 }
 
 // DraftsDelete handles POST /api/notes/drafts/delete.
@@ -297,20 +435,114 @@ func (h *Handler) PollsRecommendation(c echo.Context) error {
 	return c.JSON(http.StatusOK, []any{})
 }
 
-func packDraft(d *model.NoteDraft, idGen interface {
-	ParseTime(string) (time.Time, error)
-}) map[string]any {
-	result := map[string]any{
-		"id":         d.ID,
-		"userId":     d.UserID,
-		"text":       d.Text,
-		"cw":         d.CW,
-		"visibility": d.Visibility,
-		"localOnly":  d.LocalOnly,
-		"fileIds":    d.FileIDs,
+// packDraft renders a NoteDraft into the upstream-compatible shape. 旧実装は
+// text/cw/visibility/localOnly/fileIds しか出さず、reactionAcceptance /
+// visibleUserIds / replyId / renoteId / channelId / hashtag / poll /
+// scheduledAt / isActuallyScheduled / user / files を欠いていた。
+//
+// reply / renote / channel の解決済みオブジェクトは現状 null で返す (ID は
+// 出すので frontend は再取得可能)。files は driveFileRepo から解決する。
+// packDraft packs a draft. fileByID, when non-nil, is a pre-resolved DriveFile
+// map (List uses it to batch all drafts' files in one query, avoiding N+1).
+// When nil, files are resolved per-draft (single create/update/show path).
+func (h *Handler) packDraft(d *model.NoteDraft, fileByID map[string]entity.DriveFileEntity) map[string]any {
+	const tsFmt = "2006-01-02T15:04:05.000Z"
+	visibleUserIDs := []string(d.VisibleUserIDs)
+	if visibleUserIDs == nil {
+		visibleUserIDs = []string{}
 	}
-	if t, err := idGen.ParseTime(d.ID); err == nil {
-		result["createdAt"] = t.UTC().Format("2006-01-02T15:04:05.000Z")
+	fileIDs := []string(d.FileIDs)
+	if fileIDs == nil {
+		fileIDs = []string{}
+	}
+	result := map[string]any{
+		"id":                  d.ID,
+		"userId":              d.UserID,
+		"text":                d.Text,
+		"cw":                  d.CW,
+		"visibility":          d.Visibility,
+		"localOnly":           d.LocalOnly,
+		"reactionAcceptance":  d.ReactionAcceptance,
+		"visibleUserIds":      visibleUserIDs,
+		"fileIds":             fileIDs,
+		"replyId":             d.ReplyID,
+		"renoteId":            d.RenoteID,
+		"channelId":           d.ChannelID,
+		"hashtag":             d.Hashtag,
+		"isActuallyScheduled": d.IsActuallyScheduled,
+		// 解決済みオブジェクトは未対応 (ID は上で返す)。
+		"reply":   nil,
+		"renote":  nil,
+		"channel": nil,
+		"files":   h.draftFiles(fileIDs, fileByID),
+	}
+	if t, err := h.idGen.ParseTime(d.ID); err == nil {
+		result["createdAt"] = t.UTC().Format(tsFmt)
+	}
+	// upstream schema: scheduledAt は number (ms epoch)。createdAt は ISO 文字列
+	// だが scheduledAt は getTime() なので number で返す。
+	if d.ScheduledAt != nil {
+		result["scheduledAt"] = d.ScheduledAt.UnixMilli()
+	} else {
+		result["scheduledAt"] = nil
+	}
+	// poll: hasPoll のときだけ object、それ以外は null (upstream schema)。
+	if d.HasPoll {
+		choices := []string(d.PollChoices)
+		if choices == nil {
+			choices = []string{}
+		}
+		poll := map[string]any{
+			"choices":      choices,
+			"multiple":     d.PollMultiple,
+			"expiredAfter": d.PollExpiredAfter,
+		}
+		if d.PollExpiresAt != nil {
+			poll["expiresAt"] = d.PollExpiresAt.UTC().Format(tsFmt)
+		} else {
+			poll["expiresAt"] = nil
+		}
+		result["poll"] = poll
+	} else {
+		result["poll"] = nil
+	}
+	if d.User != nil {
+		result["user"] = entity.PackUserLite(d.User)
 	}
 	return result
+}
+
+// draftFiles resolves a draft's fileIds to packed DriveFiles in order. When
+// fileByID is provided (List batch path) it is used directly; otherwise a
+// per-draft FindByIDs query runs. Returns a non-nil slice ([] when empty).
+func (h *Handler) draftFiles(fileIDs []string, fileByID map[string]entity.DriveFileEntity) []entity.DriveFileEntity {
+	out := make([]entity.DriveFileEntity, 0, len(fileIDs))
+	if len(fileIDs) == 0 {
+		return out
+	}
+	if fileByID == nil {
+		fileByID = h.resolveDraftFileMap(fileIDs)
+	}
+	for _, fid := range fileIDs {
+		if f, ok := fileByID[fid]; ok {
+			out = append(out, f)
+		}
+	}
+	return out
+}
+
+// resolveDraftFileMap fetches+packs DriveFiles for the given ids into a map.
+func (h *Handler) resolveDraftFileMap(fileIDs []string) map[string]entity.DriveFileEntity {
+	m := map[string]entity.DriveFileEntity{}
+	if len(fileIDs) == 0 || h.driveFileRepo == nil {
+		return m
+	}
+	rows, err := h.driveFileRepo.FindByIDs(fileIDs)
+	if err != nil {
+		return m
+	}
+	for _, f := range rows {
+		m[f.ID] = entity.PackDriveFile(f, h.idGen)
+	}
+	return m
 }

--- a/internal/api/notes/handler_drafts_test.go
+++ b/internal/api/notes/handler_drafts_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/shiroha-a/mk/internal/misc/id"
 	"github.com/shiroha-a/mk/internal/model"
 	"github.com/shiroha-a/mk/internal/server/middleware"
+	"github.com/shiroha-a/mk/internal/testutil"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -161,6 +162,56 @@ func TestDraftsCreate_DefaultVisibility(t *testing.T) {
 	assert.Equal(t, http.StatusOK, rec.Code)
 }
 
+// create が replyId/renoteId/channelId/visibleUserIds/reactionAcceptance/
+// localOnly/hashtag/poll を永続化し、{createdDraft} で full shape を返す。
+func TestDraftsCreate_PersistsAllFieldsAndWraps(t *testing.T) {
+	h, repo := newDraftHandlerWithRepo()
+	body := `{"text":"t","visibility":"specified","visibleUserIds":["v1"],"localOnly":true,` +
+		`"reactionAcceptance":"likeOnly","replyId":"r1","renoteId":"rn1","channelId":"ch1",` +
+		`"hashtag":"tag","poll":{"choices":["a","b"],"multiple":true,"expiredAfter":3600000}}`
+	rec := postDraft(h.DraftsCreate, body, &model.User{ID: "u1"})
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	// 永続化検証。
+	require.Len(t, repo.drafts, 1)
+	var d *model.NoteDraft
+	for _, v := range repo.drafts {
+		d = v
+	}
+	require.NotNil(t, d.ReplyID)
+	assert.Equal(t, "r1", *d.ReplyID)
+	require.NotNil(t, d.RenoteID)
+	assert.Equal(t, "rn1", *d.RenoteID)
+	require.NotNil(t, d.ChannelID)
+	assert.Equal(t, "ch1", *d.ChannelID)
+	assert.Equal(t, []string{"v1"}, []string(d.VisibleUserIDs))
+	assert.True(t, d.LocalOnly)
+	require.NotNil(t, d.ReactionAcceptance)
+	assert.Equal(t, "likeOnly", *d.ReactionAcceptance)
+	require.NotNil(t, d.Hashtag)
+	assert.Equal(t, "tag", *d.Hashtag)
+	assert.True(t, d.HasPoll)
+	assert.Equal(t, []string{"a", "b"}, []string(d.PollChoices))
+	assert.True(t, d.PollMultiple)
+
+	// レスポンスは {createdDraft: NoteDraft} で full shape。
+	var resp map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+	cd, ok := resp["createdDraft"].(map[string]any)
+	require.True(t, ok, "createdDraft で包む")
+	assert.Equal(t, "r1", cd["replyId"])
+	assert.Equal(t, "ch1", cd["channelId"])
+	assert.Equal(t, []any{"v1"}, cd["visibleUserIds"])
+	assert.Equal(t, "likeOnly", cd["reactionAcceptance"])
+	poll, ok := cd["poll"].(map[string]any)
+	require.True(t, ok, "poll object が出る")
+	assert.Equal(t, []any{"a", "b"}, poll["choices"])
+	assert.Equal(t, true, poll["multiple"])
+	// user (UserLite) が埋まる。
+	_, hasUser := cd["user"]
+	assert.True(t, hasUser)
+}
+
 func TestDraftsCreate_InvalidJSON(t *testing.T) {
 	h, _ := newDraftHandlerWithRepo()
 	rec := postDraft(h.DraftsCreate, `invalid`, &model.User{ID: "u1"})
@@ -219,6 +270,157 @@ func TestDraftsUpdate_Success(t *testing.T) {
 	rec := postDraft(h.DraftsUpdate, `{"draftId":"d1","text":"new","visibility":"home"}`, &model.User{ID: "u1"})
 	assert.Equal(t, http.StatusOK, rec.Code)
 	assert.Equal(t, "new", *repo.drafts["d1"].Text)
+}
+
+// update が新 param を反映し {updatedDraft} で包んで返す。
+func TestDraftsUpdate_PersistsParamsAndWraps(t *testing.T) {
+	h, repo := newDraftHandlerWithRepo()
+	text := "old"
+	repo.drafts["d1"] = &model.NoteDraft{ID: "d1", UserID: "u1", Text: &text, Visibility: "public"}
+	body := `{"draftId":"d1","visibleUserIds":["v2"],"reactionAcceptance":"likeOnly","replyId":"rp","poll":{"choices":["x"],"multiple":false}}`
+	rec := postDraft(h.DraftsUpdate, body, &model.User{ID: "u1"})
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	d := repo.drafts["d1"]
+	assert.Equal(t, []string{"v2"}, []string(d.VisibleUserIDs))
+	require.NotNil(t, d.ReplyID)
+	assert.Equal(t, "rp", *d.ReplyID)
+	assert.True(t, d.HasPoll)
+
+	var resp map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+	ud, ok := resp["updatedDraft"].(map[string]any)
+	require.True(t, ok, "updatedDraft で包む")
+	assert.Equal(t, "rp", ud["replyId"])
+	assert.Equal(t, []any{"v2"}, ud["visibleUserIds"])
+}
+
+// seedDraftFile registers a drive file owned by ownerID in the mock repo.
+func seedDraftFile(repo *testutil.MockDriveFileRepository, fid, ownerID string) {
+	uid := ownerID
+	repo.Files[fid] = &model.DriveFile{ID: fid, UserID: &uid, Name: fid + ".png", Type: "image/png"}
+}
+
+// scheduledAt はレスポンス上 number (ms epoch) でなければならない (ISO 文字列で
+// 返すと misskey-js の Date 変換が壊れる)。F1 回帰固定。
+func TestDraftsCreate_ScheduledAtIsNumber(t *testing.T) {
+	h, _ := newDraftHandlerWithRepo()
+	enq := &scheduledEnqueueStub{}
+	h.SetScheduledNoteEnqueuer(enq)
+	at := futureMs(time.Hour)
+	body := fmt.Sprintf(`{"text":"hi","scheduledAt":%d,"isActuallyScheduled":true}`, at)
+	rec := postDraft(h.DraftsCreate, body, &model.User{ID: "u1"})
+	require.Equal(t, http.StatusOK, rec.Code)
+	var resp map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+	cd := resp["createdDraft"].(map[string]any)
+	// JSON number は encoding/json で float64 に decode される。
+	v, ok := cd["scheduledAt"].(float64)
+	require.True(t, ok, "scheduledAt は number で返る")
+	assert.Equal(t, at, int64(v))
+}
+
+// poll.expiresAt が過去の場合は create を CANNOT_CREATE_ALREADY_EXPIRED_POLL で
+// 弾く (upstream NoteDraftService と同 validation)。F4。
+func TestDraftsCreate_ExpiredPollRejected(t *testing.T) {
+	h, repo := newDraftHandlerWithRepo()
+	past := time.Now().Add(-time.Hour).UnixMilli()
+	body := fmt.Sprintf(`{"text":"t","poll":{"choices":["a","b"],"expiresAt":%d}}`, past)
+	rec := postDraft(h.DraftsCreate, body, &model.User{ID: "u1"})
+	assert.Equal(t, http.StatusBadRequest, rec.Code)
+	assert.Contains(t, rec.Body.String(), "CANNOT_CREATE_ALREADY_EXPIRED_POLL")
+	assert.Contains(t, rec.Body.String(), "04da457d-b083-4055-9082-955525eda5a5")
+	assert.Empty(t, repo.drafts, "期限切れ poll では永続化しない")
+}
+
+// update でも過去 expiresAt の poll は弾く。F4。
+func TestDraftsUpdate_ExpiredPollRejected(t *testing.T) {
+	h, repo := newDraftHandlerWithRepo()
+	repo.drafts["d1"] = &model.NoteDraft{ID: "d1", UserID: "u1", Visibility: "public"}
+	past := time.Now().Add(-time.Hour).UnixMilli()
+	body := fmt.Sprintf(`{"draftId":"d1","poll":{"choices":["a"],"expiresAt":%d}}`, past)
+	rec := postDraft(h.DraftsUpdate, body, &model.User{ID: "u1"})
+	assert.Equal(t, http.StatusBadRequest, rec.Code)
+	assert.Contains(t, rec.Body.String(), "CANNOT_CREATE_ALREADY_EXPIRED_POLL")
+	assert.False(t, repo.drafts["d1"].HasPoll, "期限切れ poll は適用しない")
+}
+
+// 所有していない fileId を含む create は NO_SUCH_FILE で弾く。F5。
+func TestDraftsCreate_UnownedFileRejected(t *testing.T) {
+	h, repo := newDraftHandlerWithRepo()
+	fileRepo := testutil.NewMockDriveFileRepository()
+	seedDraftFile(fileRepo, "f1", "u1")
+	h.SetDriveFileRepo(fileRepo)
+	// f2 は存在しない (= 所有検証で落ちる)。
+	rec := postDraft(h.DraftsCreate, `{"text":"t","fileIds":["f1","f2"]}`, &model.User{ID: "u1"})
+	assert.Equal(t, http.StatusBadRequest, rec.Code)
+	assert.Contains(t, rec.Body.String(), "NO_SUCH_FILE")
+	assert.Contains(t, rec.Body.String(), "b6992544-63e7-67f0-fa7f-32444b1b5306")
+	assert.Empty(t, repo.drafts)
+}
+
+// 他人所有の fileId も NO_SUCH_FILE。F5 (所有権)。
+func TestDraftsCreate_OtherUserFileRejected(t *testing.T) {
+	h, _ := newDraftHandlerWithRepo()
+	fileRepo := testutil.NewMockDriveFileRepository()
+	seedDraftFile(fileRepo, "f1", "someone-else")
+	h.SetDriveFileRepo(fileRepo)
+	rec := postDraft(h.DraftsCreate, `{"text":"t","fileIds":["f1"]}`, &model.User{ID: "u1"})
+	assert.Equal(t, http.StatusBadRequest, rec.Code)
+	assert.Contains(t, rec.Body.String(), "NO_SUCH_FILE")
+}
+
+// update で所有していない fileId を渡すと NO_SUCH_FILE。F5。
+func TestDraftsUpdate_UnownedFileRejected(t *testing.T) {
+	h, repo := newDraftHandlerWithRepo()
+	repo.drafts["d1"] = &model.NoteDraft{ID: "d1", UserID: "u1", Visibility: "public"}
+	fileRepo := testutil.NewMockDriveFileRepository()
+	h.SetDriveFileRepo(fileRepo)
+	rec := postDraft(h.DraftsUpdate, `{"draftId":"d1","fileIds":["ghost"]}`, &model.User{ID: "u1"})
+	assert.Equal(t, http.StatusBadRequest, rec.Code)
+	assert.Contains(t, rec.Body.String(), "NO_SUCH_FILE")
+}
+
+// 所有 file は packDraft で fileIds の順序どおり files に解決される
+// (resolveDraftFileMap が map でも順序は fileIds に従う)。
+func TestDraftsCreate_OwnedFilesResolvedInOrder(t *testing.T) {
+	h, _ := newDraftHandlerWithRepo()
+	fileRepo := testutil.NewMockDriveFileRepository()
+	seedDraftFile(fileRepo, "f1", "u1")
+	seedDraftFile(fileRepo, "f2", "u1")
+	h.SetDriveFileRepo(fileRepo)
+	// fileIds を逆順 [f2,f1] で渡し、その順で files が並ぶことを確認。
+	rec := postDraft(h.DraftsCreate, `{"text":"t","fileIds":["f2","f1"]}`, &model.User{ID: "u1"})
+	require.Equal(t, http.StatusOK, rec.Code)
+	var resp map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+	cd := resp["createdDraft"].(map[string]any)
+	files := cd["files"].([]any)
+	require.Len(t, files, 2)
+	assert.Equal(t, "f2", files[0].(map[string]any)["id"])
+	assert.Equal(t, "f1", files[1].(map[string]any)["id"])
+	assert.Equal(t, []any{"f2", "f1"}, cd["fileIds"])
+}
+
+// 省略した field は update で維持される (partial update)。
+func TestDraftsUpdate_PartialUpdateMaintained(t *testing.T) {
+	h, repo := newDraftHandlerWithRepo()
+	oldText := "old"
+	cw := "warn"
+	repo.drafts["d1"] = &model.NoteDraft{
+		ID: "d1", UserID: "u1", Text: &oldText, CW: &cw, Visibility: "home",
+		LocalOnly: true, VisibleUserIDs: []string{"v1"},
+	}
+	// text だけ更新。他 field は維持される。
+	rec := postDraft(h.DraftsUpdate, `{"draftId":"d1","text":"new"}`, &model.User{ID: "u1"})
+	require.Equal(t, http.StatusOK, rec.Code)
+	d := repo.drafts["d1"]
+	assert.Equal(t, "new", *d.Text)
+	require.NotNil(t, d.CW)
+	assert.Equal(t, "warn", *d.CW, "cw は維持")
+	assert.Equal(t, "home", d.Visibility, "visibility は維持")
+	assert.True(t, d.LocalOnly, "localOnly は維持")
+	assert.Equal(t, []string{"v1"}, []string(d.VisibleUserIDs), "visibleUserIds は維持")
 }
 
 func TestDraftsUpdate_NotFound(t *testing.T) {


### PR DESCRIPTION
## Summary

互換性監査 (Misskey TS ↔ mk-go) の HIGH バッチ。下書き (`/api/notes/drafts/*`) のレスポンス形と create/update のパラメータ取り扱いが本家と大きく乖離していた問題をまとめて修正する。

## 主な変更点

### packDraft を本家 NoteDraft schema の full shape に
旧実装は `text`/`cw`/`visibility`/`localOnly`/`fileIds` しか出しておらず、以下を欠いていた:
- `userId` / `reactionAcceptance` / `visibleUserIds` / `replyId` / `renoteId` / `channelId` / `hashtag`
- `poll` (hasPoll 時 object、それ以外 null)
- `scheduledAt` (ms epoch の **number**)、`isActuallyScheduled`
- `user` (UserLite)、`files` (DriveFile 解決)
- `reply` / `renote` / `channel` は ID は出すが解決済みオブジェクトは null (本家 schema も nullable)

一覧 (`drafts/list`) では全下書きの `files` を **1 クエリにまとめて解決** し N+1 を回避。

### create / update のパラメータ + レスポンス wrap
- `drafts/create`・`drafts/update` が `visibleUserIds` / `reactionAcceptance` / `replyId` / `renoteId` / `channelId` / `hashtag` / `poll` を受け付けるように。
- レスポンスを本家同様 `{createdDraft: NoteDraft}` / `{updatedDraft: NoteDraft}` で包む。
- update は partial 更新 (省略 field は維持)。

### 検証の追加 (本家 `NoteDraftService` 互換)
- `fileIds` は全て呼出ユーザー所有でなければ `NO_SUCH_FILE` (`b6992544-63e7-67f0-fa7f-32444b1b5306`)。
- 期限切れ poll (`poll.expiresAt < now`) は `CANNOT_CREATE_ALREADY_EXPIRED_POLL` (`04da457d-b083-4055-9082-955525eda5a5`)。

なお `reply` / `renote` / `channel` の **存在検証** は本 PR のスコープ外 (別途対応)。

## テスト
- `internal/api/notes/handler_drafts_test.go` に以下を追加:
  - `TestDraftsCreate_PersistsAllFieldsAndWraps` / `TestDraftsUpdate_PersistsParamsAndWraps`
  - `TestDraftsCreate_ScheduledAtIsNumber` (scheduledAt が number で返る回帰固定)
  - `TestDraftsCreate_ExpiredPollRejected` / `TestDraftsUpdate_ExpiredPollRejected`
  - `TestDraftsCreate_UnownedFileRejected` / `TestDraftsCreate_OtherUserFileRejected` / `TestDraftsUpdate_UnownedFileRejected`
  - `TestDraftsCreate_OwnedFilesResolvedInOrder` (fileIds 順で files 解決)
  - `TestDraftsUpdate_PartialUpdateMaintained`
- 実行: `go test ./internal/api/notes/...` (pass、package coverage 92.3% で 90% ゲート維持)
- `gofmt -s` / `go vet ./internal/api/notes/...` clean

## 監査メモ
本バッチは敵対的レビュー workflow を実施し、確定指摘 (scheduledAt の型・所有検証・期限切れ poll・N+1) を本 PR で修正済み。

🤖 Generated with [Claude Code](https://claude.com/claude-code)