### PR TITLE
Fix admin/captcha parity: current nested shape・save generic params+検証+error codes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Fix: `/api/admin/captcha/current` のレスポンスが flat な `{provider, siteKey}` で、本家の `{provider, hcaptcha:{...}, mcaptcha:{...}, recaptcha:{...}, turnstile:{...}}` という provider 別 nested 構造を欠いていた問題を修正 (フロントエンドが `res.hcaptcha.siteKey` 等を読めず undefined になっていた)。`/api/admin/captcha/save` が本家の generic パラメータ (`provider`/`captchaResult`/`sitekey`/`secret`/`instanceUrl`) を受け取らず保存値が DB に書かれていなかった問題、mCaptcha/testCaptcha provider 非対応、`captchaResult` の検証ステップと各エラーコード (`INVALID_PROVIDER`/`INVALID_PARAMETERS`/`VERIFICATION_FAILED` 等) の欠落も修正 (本家同様 captchaResult を検証し pass 時のみ設定を保存)。あわせて mCaptcha インスタンスの非200応答が `VERIFICATION_FAILED` になっていた問題を `REQUEST_FAILED` に修正 (本家 verifyMcaptcha と一致)
+
 - Fix: `/api/admin/abuse-user-reports` の `reporter`/`targetUser`/`assignee` が生のユーザーモデルで返り、`usernameLower` 等の内部フィールドが漏れ UserDetailedNotMe 固有フィールドを欠いていた問題を修正 (本家同様 UserDetailed で pack、`assignee` は未割当でも `null` でキー常在)。あわせて `targetUserHost`/`reporterHost` の余剰フィールド露出も除去
 - Fix: `/api/admin/update-abuse-user-report` が `moderationNote` を無視し代わりに `resolved=true` を立てていた問題 (resolve-abuse-user-report との取り違え) を修正 (本家同様 `moderationNote` のみ更新し、変化時に `updateAbuseReportNote` を記録)。`/api/admin/resolve-abuse-user-report` が `assigneeId` を記録していなかった問題も修正
 - Fix: `/api/admin/forward-abuse-user-report` がローカル対象 (targetUserHost が null) や既に転送済みの通報をガードせず転送扱いにしていた問題と、存在しない通報で 404 `NO_SUCH_ABUSE_REPORT` を返していなかった問題を修正。あわせて abuse-report 系エンドポイントのエラーコードを本家の `NO_SUCH_ABUSE_REPORT` (エンドポイント別 UUID) に統一

--- a/internal/api/admin/captcha.go
+++ b/internal/api/admin/captcha.go
@@ -1,91 +1,214 @@
 package admin
 
 import (
+	"errors"
 	"net/http"
 
 	"github.com/labstack/echo/v4"
 	"github.com/shiroha-a/mk/internal/api/apierr"
+	"github.com/shiroha-a/mk/internal/core/captcha"
+	"github.com/shiroha-a/mk/internal/model"
 )
+
+// supportedCaptchaProviders mirrors upstream CaptchaService.supportedCaptchaProviders.
+var supportedCaptchaProviders = map[string]struct{}{
+	"none": {}, "hcaptcha": {}, "mcaptcha": {}, "recaptcha": {}, "turnstile": {}, "testcaptcha": {},
+}
 
 // CaptchaCurrent handles POST /api/admin/captcha/current.
 //
-// Returns which captcha provider (if any) is currently enabled and its public
-// site key so the admin UI can render the correct configuration form.
+// Returns the currently enabled provider plus every provider's site/secret keys
+// in the nested shape upstream `CaptchaService.get` produces (current.ts res).
+// 旧実装は flat な {provider, siteKey} のみで、frontend が res.hcaptcha.siteKey
+// 等を読むと undefined になっていた。
 func (h *Handler) CaptchaCurrent(c echo.Context) error {
 	if h.metaRepo == nil {
-		return c.JSON(http.StatusOK, map[string]any{"provider": nil})
+		// frontend は res.hcaptcha.siteKey 等を無条件に参照するので、未配線でも
+		// full nested shape (値は nil) を返して shape を崩さない。
+		return c.JSON(http.StatusOK, captchaCurrentShape("none", &model.Meta{}))
 	}
 	meta, err := h.metaRepo.Fetch()
 	if err != nil {
 		return c.JSON(http.StatusInternalServerError, apierr.InternalError())
 	}
-	var provider any
-	var siteKey *string
+	provider := "none"
 	switch {
 	case meta.EnableHcaptcha:
 		provider = "hcaptcha"
-		siteKey = meta.HcaptchaSiteKey
+	case meta.EnableMcaptcha:
+		provider = "mcaptcha"
 	case meta.EnableRecaptcha:
 		provider = "recaptcha"
-		siteKey = meta.RecaptchaSiteKey
 	case meta.EnableTurnstile:
 		provider = "turnstile"
-		siteKey = meta.TurnstileSiteKey
+	case meta.EnableTestcaptcha:
+		provider = "testcaptcha"
 	}
-	return c.JSON(http.StatusOK, map[string]any{
+	return c.JSON(http.StatusOK, captchaCurrentShape(provider, meta))
+}
+
+// captchaCurrentShape builds the nested captcha/current response (upstream
+// CaptchaService.get). nil *string fields serialize to JSON null (nullable:true).
+func captchaCurrentShape(provider string, meta *model.Meta) map[string]any {
+	return map[string]any{
 		"provider": provider,
-		"siteKey":  siteKey,
-	})
+		"hcaptcha": map[string]any{
+			"siteKey":   meta.HcaptchaSiteKey,
+			"secretKey": meta.HcaptchaSecretKey,
+		},
+		"mcaptcha": map[string]any{
+			"siteKey":     meta.McaptchaSiteKey,
+			"secretKey":   meta.McaptchaSecretKey,
+			"instanceUrl": meta.McaptchaInstanceURL,
+		},
+		"recaptcha": map[string]any{
+			"siteKey":   meta.RecaptchaSiteKey,
+			"secretKey": meta.RecaptchaSecretKey,
+		},
+		"turnstile": map[string]any{
+			"siteKey":   meta.TurnstileSiteKey,
+			"secretKey": meta.TurnstileSecretKey,
+		},
+	}
 }
 
 // CaptchaSave handles POST /api/admin/captcha/save.
+//
+// upstream paramDef は generic な {provider(required), captchaResult, sitekey,
+// secret, instanceUrl}。選択 provider の captchaResult を検証し、pass した場合
+// のみ per-provider の sitekey/secret/instanceUrl を保存する (CaptchaService.save)。
+// 旧実装は per-provider key (hcaptchaSiteKey 等) を期待しており frontend の保存
+// 値が DB に書かれず、captchaResult の検証も無かった。
 func (h *Handler) CaptchaSave(c echo.Context) error {
 	var req struct {
-		Provider    string  `json:"provider"`
-		HcaptchaSK  *string `json:"hcaptchaSiteKey"`
-		HcaptchaSS  *string `json:"hcaptchaSecretKey"`
-		RecaptchaSK *string `json:"recaptchaSiteKey"`
-		RecaptchaSS *string `json:"recaptchaSecretKey"`
-		TurnstileSK *string `json:"turnstileSiteKey"`
-		TurnstileSS *string `json:"turnstileSecretKey"`
+		Provider      string  `json:"provider"`
+		CaptchaResult *string `json:"captchaResult"`
+		Sitekey       *string `json:"sitekey"`
+		Secret        *string `json:"secret"`
+		InstanceURL   *string `json:"instanceUrl"`
 	}
 	if err := c.Bind(&req); err != nil {
 		return c.JSON(http.StatusBadRequest, apierr.InvalidParam("Invalid parameters."))
 	}
-	// provider が空 or "none" の場合は captcha 無効化として扱う。
-	switch req.Provider {
-	case "", "none", "hcaptcha", "recaptcha", "turnstile":
-	default:
-		return c.JSON(http.StatusBadRequest, apierr.InvalidParam("Unknown captcha provider."))
+	if _, ok := supportedCaptchaProviders[req.Provider]; !ok {
+		return c.JSON(http.StatusBadRequest, apierr.Error("INVALID_PROVIDER", "Invalid provider.", "14bf7ae1-80cc-4363-acb2-4fd61d086af0"))
 	}
+
+	secret := strDeref(req.Secret)
+	sitekey := strDeref(req.Sitekey)
+	instanceURL := strDeref(req.InstanceURL)
+	captchaResult := strDeref(req.CaptchaResult)
+
+	// provider 別の必須 param 検証 + captchaResult 検証 (upstream CaptchaService.save)。
+	needsVerify := false
+	switch req.Provider {
+	case "none":
+		// 無効化。検証不要。
+	case "mcaptcha":
+		if secret == "" || sitekey == "" || instanceURL == "" || captchaResult == "" {
+			return invalidCaptchaParams(c)
+		}
+		needsVerify = true
+	case "testcaptcha":
+		if captchaResult == "" {
+			return invalidCaptchaParams(c)
+		}
+		needsVerify = true
+	default: // hcaptcha / recaptcha / turnstile
+		if secret == "" || captchaResult == "" {
+			return invalidCaptchaParams(c)
+		}
+		needsVerify = true
+	}
+	if needsVerify {
+		v := h.buildCaptchaVerifier(req.Provider, secret, sitekey, instanceURL)
+		if v == nil {
+			return c.JSON(http.StatusInternalServerError, apierr.Error("UNKNOWN", "unknown", "f868d509-e257-42a9-99c1-42614b031a97"))
+		}
+		if err := v.Verify(c.Request().Context(), captchaResult); err != nil {
+			return mapCaptchaError(c, err)
+		}
+	}
+
 	if h.metaRepo == nil {
 		return c.NoContent(http.StatusNoContent)
 	}
+	// enable flag は全 provider 分を上書きし、選択 provider のみ true にする。
+	// per-provider の key は param が送られた (非 nil) ときだけ更新する
+	// (upstream updateMeta の updateIfNotUndefined)。
 	fields := map[string]any{
-		"enableHcaptcha":  req.Provider == "hcaptcha",
-		"enableRecaptcha": req.Provider == "recaptcha",
-		"enableTurnstile": req.Provider == "turnstile",
+		"enableHcaptcha":    req.Provider == "hcaptcha",
+		"enableMcaptcha":    req.Provider == "mcaptcha",
+		"enableRecaptcha":   req.Provider == "recaptcha",
+		"enableTurnstile":   req.Provider == "turnstile",
+		"enableTestcaptcha": req.Provider == "testcaptcha",
 	}
-	if req.HcaptchaSK != nil {
-		fields["hcaptchaSiteKey"] = *req.HcaptchaSK
-	}
-	if req.HcaptchaSS != nil {
-		fields["hcaptchaSecretKey"] = *req.HcaptchaSS
-	}
-	if req.RecaptchaSK != nil {
-		fields["recaptchaSiteKey"] = *req.RecaptchaSK
-	}
-	if req.RecaptchaSS != nil {
-		fields["recaptchaSecretKey"] = *req.RecaptchaSS
-	}
-	if req.TurnstileSK != nil {
-		fields["turnstileSiteKey"] = *req.TurnstileSK
-	}
-	if req.TurnstileSS != nil {
-		fields["turnstileSecretKey"] = *req.TurnstileSS
+	switch req.Provider {
+	case "hcaptcha":
+		setIfProvided(fields, "hcaptchaSiteKey", req.Sitekey)
+		setIfProvided(fields, "hcaptchaSecretKey", req.Secret)
+	case "mcaptcha":
+		// DB 列名は mcaptchaSitekey (lower k)。
+		setIfProvided(fields, "mcaptchaSitekey", req.Sitekey)
+		setIfProvided(fields, "mcaptchaSecretKey", req.Secret)
+		setIfProvided(fields, "mcaptchaInstanceUrl", req.InstanceURL)
+	case "recaptcha":
+		setIfProvided(fields, "recaptchaSiteKey", req.Sitekey)
+		setIfProvided(fields, "recaptchaSecretKey", req.Secret)
+	case "turnstile":
+		setIfProvided(fields, "turnstileSiteKey", req.Sitekey)
+		setIfProvided(fields, "turnstileSecretKey", req.Secret)
 	}
 	if err := h.metaRepo.Update(fields); err != nil {
 		return c.JSON(http.StatusInternalServerError, apierr.InternalError())
 	}
 	return c.NoContent(http.StatusNoContent)
+}
+
+// mapCaptchaError writes the upstream save.ts error response for a captcha
+// verification error (sentinel errors from internal/core/captcha).
+func mapCaptchaError(c echo.Context, err error) error {
+	switch {
+	case errors.Is(err, captcha.ErrNoResponse):
+		return c.JSON(http.StatusBadRequest, apierr.Error("NO_RESPONSE_PROVIDED", "No response provided.", "40acbba8-0937-41fb-bb3f-474514d40afe"))
+	case errors.Is(err, captcha.ErrRequestFailed):
+		return c.JSON(http.StatusInternalServerError, apierr.Error("REQUEST_FAILED", "Request failed.", "0f4fe2f1-2c15-4d6e-b714-efbfcde231cd"))
+	case errors.Is(err, captcha.ErrVerificationFail):
+		return c.JSON(http.StatusBadRequest, apierr.Error("VERIFICATION_FAILED", "Verification failed.", "c41c067f-24f3-4150-84b2-b5a3ae8c2214"))
+	default:
+		return c.JSON(http.StatusInternalServerError, apierr.Error("UNKNOWN", "unknown", "f868d509-e257-42a9-99c1-42614b031a97"))
+	}
+}
+
+// buildCaptchaVerifier returns the verifier for provider, using the injected
+// factory when set (tests) or the real provider constructors otherwise.
+func (h *Handler) buildCaptchaVerifier(provider, secret, sitekey, instanceURL string) captcha.Verifier {
+	if h.captchaVerifierFactory != nil {
+		return h.captchaVerifierFactory(provider, secret, sitekey, instanceURL)
+	}
+	switch provider {
+	case "hcaptcha":
+		return captcha.NewHcaptcha(secret)
+	case "recaptcha":
+		return captcha.NewRecaptcha(secret)
+	case "turnstile":
+		return captcha.NewTurnstile(secret)
+	case "mcaptcha":
+		return captcha.NewMcaptcha(instanceURL, sitekey, secret)
+	case "testcaptcha":
+		return captcha.NewTestcaptcha()
+	}
+	return nil
+}
+
+func invalidCaptchaParams(c echo.Context) error {
+	return c.JSON(http.StatusBadRequest, apierr.Error("INVALID_PARAMETERS", "Invalid parameters.", "26654194-410e-44e2-b42e-460ff6f92476"))
+}
+
+// setIfProvided sets fields[col] to the dereferenced value only when the param
+// pointer is non-nil (mirrors upstream updateIfNotUndefined).
+func setIfProvided(fields map[string]any, col string, p *string) {
+	if p != nil {
+		fields[col] = *p
+	}
 }

--- a/internal/api/admin/captcha_test.go
+++ b/internal/api/admin/captcha_test.go
@@ -1,13 +1,21 @@
 package admin_test
 
 import (
+	"context"
 	"encoding/json"
 	"net/http"
 	"testing"
 
+	"github.com/shiroha-a/mk/internal/core/captcha"
+	"github.com/shiroha-a/mk/internal/model"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+// stubCaptchaVerifier returns a fixed error from Verify (nil = pass).
+type stubCaptchaVerifier struct{ err error }
+
+func (s stubCaptchaVerifier) Verify(context.Context, string) error { return s.err }
 
 // --- thin smoke tests ---
 
@@ -16,46 +24,210 @@ func TestCaptchaCurrent(t *testing.T) {
 	assert.Equal(t, http.StatusOK, doPost(h.CaptchaCurrent, `{}`, adminUser).Code)
 }
 
-func TestCaptchaSave(t *testing.T) {
-	h, _, _, _ := newTestHandler(t)
-	assert.Equal(t, http.StatusNoContent, doPost(h.CaptchaSave, `{}`, adminUser).Code)
+// provider=none で captcha 無効化 (検証不要) → 204。
+func TestCaptchaSave_None(t *testing.T) {
+	h, _, metaRepo, _ := newTestHandler(t)
+	metaRepo.Meta.EnableHcaptcha = true
+	rec := doPost(h.CaptchaSave, `{"provider":"none"}`, adminUser)
+	assert.Equal(t, http.StatusNoContent, rec.Code)
+	assert.False(t, metaRepo.Meta.EnableHcaptcha, "none で全 provider が無効化される")
 }
 
-// --- detailed tests (旧 queue_stats_test.go から #578 で移動 / #583 半分回収) ---
+// --- captcha/current nested shape ---
 
 func TestCaptchaCurrent_WithHcaptchaEnabled(t *testing.T) {
 	h, _, metaRepo, _ := newTestHandler(t)
 	siteKey := "sk-hcap"
+	secret := "ss-hcap"
 	metaRepo.Meta.EnableHcaptcha = true
 	metaRepo.Meta.HcaptchaSiteKey = &siteKey
+	metaRepo.Meta.HcaptchaSecretKey = &secret
 	rec := doPost(h.CaptchaCurrent, `{}`, adminUser)
-	assert.Equal(t, http.StatusOK, rec.Code)
+	require.Equal(t, http.StatusOK, rec.Code)
 	var got map[string]any
 	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &got))
 	assert.Equal(t, "hcaptcha", got["provider"])
-	assert.Equal(t, "sk-hcap", got["siteKey"])
+	// nested provider object shape (upstream current.ts res)。
+	hcap := got["hcaptcha"].(map[string]any)
+	assert.Equal(t, "sk-hcap", hcap["siteKey"])
+	assert.Equal(t, "ss-hcap", hcap["secretKey"])
+	// 全 provider object が key として存在する。
+	for _, p := range []string{"hcaptcha", "mcaptcha", "recaptcha", "turnstile"} {
+		_, ok := got[p].(map[string]any)
+		assert.True(t, ok, p+" object が存在する")
+	}
+	// mcaptcha は instanceUrl も持つ。
+	mcap := got["mcaptcha"].(map[string]any)
+	_, hasInstance := mcap["instanceUrl"]
+	assert.True(t, hasInstance)
 }
 
 func TestCaptchaCurrent_NoneEnabled(t *testing.T) {
 	h, _, _, _ := newTestHandler(t)
 	rec := doPost(h.CaptchaCurrent, `{}`, adminUser)
-	assert.Equal(t, http.StatusOK, rec.Code)
+	require.Equal(t, http.StatusOK, rec.Code)
 	var got map[string]any
 	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &got))
-	assert.Nil(t, got["provider"])
+	assert.Equal(t, "none", got["provider"], "無効時は provider='none'")
 }
 
-func TestCaptchaSave_AppliesFlags(t *testing.T) {
+// --- captcha/save ---
+
+// 検証 pass 時に enable flag と generic sitekey/secret が永続化される。
+func TestCaptchaSave_VerifiesAndPersists(t *testing.T) {
 	h, _, metaRepo, _ := newTestHandler(t)
+	h.SetCaptchaVerifierFactory(func(string, string, string, string) captcha.Verifier {
+		return stubCaptchaVerifier{err: nil}
+	})
 	rec := doPost(h.CaptchaSave,
-		`{"provider":"turnstile","turnstileSiteKey":"sk","turnstileSecretKey":"ss"}`, adminUser)
-	assert.Equal(t, http.StatusNoContent, rec.Code)
+		`{"provider":"turnstile","sitekey":"sk","secret":"ss","captchaResult":"tok"}`, adminUser)
+	require.Equal(t, http.StatusNoContent, rec.Code)
 	assert.True(t, metaRepo.Meta.EnableTurnstile)
 	assert.False(t, metaRepo.Meta.EnableHcaptcha)
+	require.NotNil(t, metaRepo.Meta.TurnstileSiteKey)
+	assert.Equal(t, "sk", *metaRepo.Meta.TurnstileSiteKey)
+	require.NotNil(t, metaRepo.Meta.TurnstileSecretKey)
+	assert.Equal(t, "ss", *metaRepo.Meta.TurnstileSecretKey)
 }
 
+// mcaptcha は sitekey/secret/instanceUrl を generic param から保存する。
+func TestCaptchaSave_Mcaptcha(t *testing.T) {
+	h, _, metaRepo, _ := newTestHandler(t)
+	h.SetCaptchaVerifierFactory(func(string, string, string, string) captcha.Verifier {
+		return stubCaptchaVerifier{err: nil}
+	})
+	rec := doPost(h.CaptchaSave,
+		`{"provider":"mcaptcha","sitekey":"mk","secret":"ms","instanceUrl":"https://mcap.example","captchaResult":"tok"}`, adminUser)
+	require.Equal(t, http.StatusNoContent, rec.Code)
+	assert.True(t, metaRepo.Meta.EnableMcaptcha)
+	require.NotNil(t, metaRepo.Meta.McaptchaSiteKey)
+	assert.Equal(t, "mk", *metaRepo.Meta.McaptchaSiteKey)
+	require.NotNil(t, metaRepo.Meta.McaptchaInstanceURL)
+	assert.Equal(t, "https://mcap.example", *metaRepo.Meta.McaptchaInstanceURL)
+}
+
+// 検証失敗時は VERIFICATION_FAILED を返し、設定を永続化しない。
+func TestCaptchaSave_VerificationFailed(t *testing.T) {
+	h, _, metaRepo, _ := newTestHandler(t)
+	h.SetCaptchaVerifierFactory(func(string, string, string, string) captcha.Verifier {
+		return stubCaptchaVerifier{err: captcha.ErrVerificationFail}
+	})
+	rec := doPost(h.CaptchaSave,
+		`{"provider":"hcaptcha","sitekey":"sk","secret":"ss","captchaResult":"bad"}`, adminUser)
+	assert.Equal(t, http.StatusBadRequest, rec.Code)
+	assert.Contains(t, rec.Body.String(), "VERIFICATION_FAILED")
+	assert.False(t, metaRepo.Meta.EnableHcaptcha, "検証失敗時は永続化しない")
+}
+
+// 必須 param 欠落は INVALID_PARAMETERS。
+func TestCaptchaSave_MissingParams(t *testing.T) {
+	h, _, _, _ := newTestHandler(t)
+	rec := doPost(h.CaptchaSave, `{"provider":"hcaptcha"}`, adminUser)
+	assert.Equal(t, http.StatusBadRequest, rec.Code)
+	assert.Contains(t, rec.Body.String(), "INVALID_PARAMETERS")
+}
+
+// 未知 provider は INVALID_PROVIDER。
 func TestCaptchaSave_UnknownProvider(t *testing.T) {
 	h, _, _, _ := newTestHandler(t)
 	rec := doPost(h.CaptchaSave, `{"provider":"garbage"}`, adminUser)
 	assert.Equal(t, http.StatusBadRequest, rec.Code)
+	assert.Contains(t, rec.Body.String(), "INVALID_PROVIDER")
+}
+
+// provider 未指定 (enum 外) も INVALID_PROVIDER。
+func TestCaptchaSave_MissingProvider(t *testing.T) {
+	h, _, _, _ := newTestHandler(t)
+	rec := doPost(h.CaptchaSave, `{}`, adminUser)
+	assert.Equal(t, http.StatusBadRequest, rec.Code)
+	assert.Contains(t, rec.Body.String(), "INVALID_PROVIDER")
+}
+
+// testcaptcha は captchaResult のみ必須 (secret/sitekey 不要) で、検証 pass 時に
+// enableTestcaptcha=true を保存する。
+func TestCaptchaSave_Testcaptcha(t *testing.T) {
+	h, _, metaRepo, _ := newTestHandler(t)
+	h.SetCaptchaVerifierFactory(func(string, string, string, string) captcha.Verifier {
+		return stubCaptchaVerifier{err: nil}
+	})
+	rec := doPost(h.CaptchaSave, `{"provider":"testcaptcha","captchaResult":"tok"}`, adminUser)
+	require.Equal(t, http.StatusNoContent, rec.Code)
+	assert.True(t, metaRepo.Meta.EnableTestcaptcha)
+	assert.False(t, metaRepo.Meta.EnableHcaptcha)
+}
+
+// mcaptcha は instanceUrl 等が欠けると INVALID_PARAMETERS。
+func TestCaptchaSave_McaptchaMissingInstanceURL(t *testing.T) {
+	h, _, _, _ := newTestHandler(t)
+	rec := doPost(h.CaptchaSave,
+		`{"provider":"mcaptcha","sitekey":"mk","secret":"ms","captchaResult":"tok"}`, adminUser)
+	assert.Equal(t, http.StatusBadRequest, rec.Code)
+	assert.Contains(t, rec.Body.String(), "INVALID_PARAMETERS")
+}
+
+// 検証エラーの sentinel は upstream save.ts の error code にマップされる。
+func TestCaptchaSave_ErrorCodeMapping(t *testing.T) {
+	cases := []struct {
+		name     string
+		err      error
+		wantCode int
+		wantBody string
+	}{
+		{"requestFailed", captcha.ErrRequestFailed, http.StatusInternalServerError, "REQUEST_FAILED"},
+		{"noResponse", captcha.ErrNoResponse, http.StatusBadRequest, "NO_RESPONSE_PROVIDED"},
+		{"unknown", assertError{}, http.StatusInternalServerError, "UNKNOWN"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			h, _, metaRepo, _ := newTestHandler(t)
+			h.SetCaptchaVerifierFactory(func(string, string, string, string) captcha.Verifier {
+				return stubCaptchaVerifier{err: tc.err}
+			})
+			rec := doPost(h.CaptchaSave,
+				`{"provider":"hcaptcha","sitekey":"sk","secret":"ss","captchaResult":"tok"}`, adminUser)
+			assert.Equal(t, tc.wantCode, rec.Code)
+			assert.Contains(t, rec.Body.String(), tc.wantBody)
+			assert.False(t, metaRepo.Meta.EnableHcaptcha, "検証エラー時は永続化しない")
+		})
+	}
+}
+
+// factory が nil verifier を返す misconfiguration では UNKNOWN を返す。
+func TestCaptchaSave_NilVerifier(t *testing.T) {
+	h, _, _, _ := newTestHandler(t)
+	h.SetCaptchaVerifierFactory(func(string, string, string, string) captcha.Verifier {
+		return nil
+	})
+	rec := doPost(h.CaptchaSave,
+		`{"provider":"hcaptcha","sitekey":"sk","secret":"ss","captchaResult":"tok"}`, adminUser)
+	assert.Equal(t, http.StatusInternalServerError, rec.Code)
+	assert.Contains(t, rec.Body.String(), "UNKNOWN")
+}
+
+// CaptchaCurrent の provider 判定が各 enable flag に対応する (upstream get の順序)。
+func TestCaptchaCurrent_ProviderDetection(t *testing.T) {
+	cases := []struct {
+		field func(m *model.Meta)
+		want  string
+	}{
+		{func(m *model.Meta) { m.EnableMcaptcha = true }, "mcaptcha"},
+		{func(m *model.Meta) { m.EnableRecaptcha = true }, "recaptcha"},
+		{func(m *model.Meta) { m.EnableTurnstile = true }, "turnstile"},
+		{func(m *model.Meta) { m.EnableTestcaptcha = true }, "testcaptcha"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.want, func(t *testing.T) {
+			h, _, metaRepo, _ := newTestHandler(t)
+			tc.field(metaRepo.Meta)
+			rec := doPost(h.CaptchaCurrent, `{}`, adminUser)
+			require.Equal(t, http.StatusOK, rec.Code)
+			var got map[string]any
+			require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &got))
+			assert.Equal(t, tc.want, got["provider"])
+			// nil *string field は JSON null として直列化される。
+			mcap := got["mcaptcha"].(map[string]any)
+			_, hasSecret := mcap["secretKey"]
+			assert.True(t, hasSecret)
+		})
+	}
 }

--- a/internal/api/admin/handler.go
+++ b/internal/api/admin/handler.go
@@ -17,6 +17,7 @@ import (
 	"github.com/shiroha-a/mk/internal/api/apierr"
 	"github.com/shiroha-a/mk/internal/api/pagination"
 	"github.com/shiroha-a/mk/internal/config"
+	"github.com/shiroha-a/mk/internal/core/captcha"
 	"github.com/shiroha-a/mk/internal/core/moderationlog"
 	"github.com/shiroha-a/mk/internal/core/role"
 	"github.com/shiroha-a/mk/internal/core/signup"
@@ -116,6 +117,10 @@ type Handler struct {
 	systemAccountFetcher    SystemAccountFetcher
 	followingRepo           repository.FollowingRepository
 	unfollowEnqueuer        UnfollowEnqueuer
+	// captchaVerifierFactory builds a one-off captcha.Verifier for
+	// admin/captcha/save verification. nil uses the real providers; tests
+	// inject a stub to avoid external HTTP calls.
+	captchaVerifierFactory CaptchaVerifierFactory
 	// instanceRepo は admin/federation/* の instance lookup / update を
 	// inject 可能にするための DI 口 (#676)。FederationUpdateInstance の
 	// log type 分岐をテストするため、`adminDB` 直叩きから repository 経由
@@ -326,6 +331,17 @@ func (h *Handler) SetRelayService(s RelayService) {
 // (pre-P4-5 behaviour).
 func (h *Handler) SetAbuseForwarder(f AbuseForwarder) {
 	h.abuseForwarder = f
+}
+
+// CaptchaVerifierFactory builds a captcha.Verifier for the given provider and
+// the request-supplied secret / sitekey / instanceUrl. Used by
+// admin/captcha/save to verify the captchaResult before persisting settings.
+type CaptchaVerifierFactory func(provider, secret, sitekey, instanceURL string) captcha.Verifier
+
+// SetCaptchaVerifierFactory overrides the captcha verifier construction used by
+// admin/captcha/save (tests inject a stub to avoid external HTTP).
+func (h *Handler) SetCaptchaVerifierFactory(f CaptchaVerifierFactory) {
+	h.captchaVerifierFactory = f
 }
 
 // SetDeleteAccountEnqueuer wires the enqueuer that schedules cascade

--- a/internal/core/captcha/captcha_test.go
+++ b/internal/core/captcha/captcha_test.go
@@ -110,7 +110,8 @@ func TestMcaptcha_ServerError(t *testing.T) {
 
 	v := captcha.NewMcaptchaWithClient(srv.URL, "site", "sec", srv.Client())
 	err := v.Verify(context.Background(), "token")
-	assert.ErrorIs(t, err, captcha.ErrVerificationFail)
+	// 非200は instance への到達失敗扱い (upstream verifyMcaptcha と同じ requestFailed)。
+	assert.ErrorIs(t, err, captcha.ErrRequestFailed)
 }
 
 // --- testcaptcha ---

--- a/internal/core/captcha/mcaptcha.go
+++ b/internal/core/captcha/mcaptcha.go
@@ -76,7 +76,9 @@ func (v *mcaptchaVerifier) Verify(ctx context.Context, token string) error {
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
-		return fmt.Errorf("%w: status %d", ErrVerificationFail, resp.StatusCode)
+		// upstream verifyMcaptcha は非200を requestFailed として扱う
+		// (verification の不成立ではなく instance への到達失敗扱い)。
+		return fmt.Errorf("%w: status %d", ErrRequestFailed, resp.StatusCode)
 	}
 
 	data, err := safehttp.ReadAllLimit(resp.Body, safehttp.DefaultThirdPartyAPILimit)

--- a/internal/testutil/mock_repository.go
+++ b/internal/testutil/mock_repository.go
@@ -2372,8 +2372,20 @@ func (m *MockMetaRepository) Update(fields map[string]any) error {
 			if s, ok := v.(string); ok {
 				m.Meta.UgcVisibilityForVisitor = s
 			}
+		case "enableMcaptcha":
+			if b, ok := v.(bool); ok {
+				m.Meta.EnableMcaptcha = b
+			}
+		case "enableTestcaptcha":
+			if b, ok := v.(bool); ok {
+				m.Meta.EnableTestcaptcha = b
+			}
 		case "mcaptchaSitekey":
 			setNullableStr(&m.Meta.McaptchaSiteKey, v)
+		case "mcaptchaSecretKey":
+			setNullableStr(&m.Meta.McaptchaSecretKey, v)
+		case "mcaptchaInstanceUrl":
+			setNullableStr(&m.Meta.McaptchaInstanceURL, v)
 		case "repositoryUrl":
 			setNullableStr(&m.Meta.RepositoryURL, v)
 		case "deeplAuthKey":


### PR DESCRIPTION
## Summary

互換性監査 (Misskey TS ↔ mk-go) の HIGH バッチ第8弾 (admin misc) の第3スライス (H-PR8c: captcha)。`/api/admin/captcha/current`・`/save` を本家 `CaptchaService` と揃える。

## 主な変更点

### `/api/admin/captcha/current`
- flat な `{provider, siteKey}` から本家 `CaptchaService.get` / current.ts res の **nested 構造** に変更:
  `{provider, hcaptcha:{siteKey,secretKey}, mcaptcha:{siteKey,secretKey,instanceUrl}, recaptcha:{...}, turnstile:{...}}`
- provider 判定順序 hcaptcha>mcaptcha>recaptcha>turnstile>testcaptcha>none。`provider` は文字列 (無効時 `"none"`)
- 従来はフロントエンドが `res.hcaptcha.siteKey` 等を読むと undefined になっていた

### `/api/admin/captcha/save`
- 本家の generic paramDef `{provider(required), captchaResult, sitekey, secret, instanceUrl}` を受け取り保存 (従来は per-provider key を期待しており保存値が DB に書かれていなかった)
- mCaptcha / testCaptcha provider に対応
- provider 検証 (`INVALID_PROVIDER`)、provider 別の必須パラメータ検証 (`INVALID_PARAMETERS`)、`captchaResult` を `internal/core/captcha` の verifier で検証し pass 時のみ設定を保存 (本家 `CaptchaService.save`)
- 検証エラーを `NO_RESPONSE_PROVIDED`/`REQUEST_FAILED`/`VERIFICATION_FAILED`/`UNKNOWN` (本家 save.ts の UUID/httpStatus) にマップ
- per-provider key は param が来たときだけ更新 (`updateIfNotUndefined` 相当)、enable flag は全消し+選択 provider のみ true
- verifier factory は `SetCaptchaVerifierFactory` でテスト注入可能 (本番は実 provider)

### `internal/core/captcha`
- mCaptcha インスタンスの非200応答を `VERIFICATION_FAILED` から `REQUEST_FAILED` に修正 (本家 `verifyMcaptcha` と一致、敵対的レビュー CAP-1)

## テスト
- `captcha_test.go`: current nested shape / provider 判定 (hcaptcha/mcaptcha/recaptcha/turnstile/none) / save (None/VerifiesAndPersists/Mcaptcha/Testcaptcha/VerificationFailed/error code mapping/MissingParams/McaptchaMissingInstanceURL/UnknownProvider/NilVerifier)
- `internal/core/captcha/captcha_test.go`: mcaptcha 非200 → REQUEST_FAILED
- `internal/testutil/mock_repository.go`: Meta.Update に enableMcaptcha/enableTestcaptcha/mcaptchaSecretKey/mcaptchaInstanceUrl
- 実行: `go test ./internal/api/admin/... ./internal/core/captcha/...` pass (captcha core 92.3% / admin 88.6%)、error-id drift gate pass、`gofmt -s`/`go vet` clean
- 注: `TestFederationUpdateInstance_Integration*` 2件はローカル共有テスト DB の残留行による既存失敗で本PR無関係

## 監査メモ
敵対的レビュー workflow (4観点 review→verify, 確定17件) を実施。HIGH 0。確定 Medium のうち実バグ (CAP-1: mcaptcha 非200 の error code) を修正、残りは test gap で本 PR にテスト追加。残る Low は意図的/防御的 divergence: provider 空/不明を `INVALID_PROVIDER` で返す (本家は AJV の `INVALID_PARAM` だが両者 400, 実クライアントは有効 provider のみ送出)、`setIfProvided` の explicit-null 非対応 (Go `*string` は null/absent 区別不可)、save の captcha 検証が SSRF-safe client でなく `http.DefaultClient` 経由 (admin 限定, mcaptcha の instanceUrl wiring は follow-up)。

## 残り (H-PR8 後続スライス)
notification-recipient packer / server-info / queue / drive clean-remote-files を別 PR で対応予定。

🤖 Generated with [Claude Code](https://claude.com/claude-code)