### PR TITLE
Fix admin/server-info parity: machine string化・os/node/psql/redis/net 追加・公開版 shape 限定

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Fix: `/api/admin/server-info` の `machine` がオブジェクト (`{name}`) で本家の文字列 (ホスト名) と型が異なり、`os`/`node`/`psql`/`redis`/`net.interface` が欠落していた問題を修正 (本家同様 machine は文字列、`os`(プラットフォーム)/`node`(ランタイム版)/`psql`(PostgreSQL版)/`redis`(Redis版)/`net.interface` を返す)。あわせて本家には無い `enableServerMachineStats` ゲートを admin から外し常に実値を返すように。公開 `/api/server-info` は本家同様 `machine`/`cpu`/`mem`/`fs` のみに限定し、`os`/`node`/`net.interface` 等が未認証クライアントに露出していた問題 (機械統計有効時) を修正
+
 - Fix: `/api/admin/captcha/current` のレスポンスが flat な `{provider, siteKey}` で、本家の `{provider, hcaptcha:{...}, mcaptcha:{...}, recaptcha:{...}, turnstile:{...}}` という provider 別 nested 構造を欠いていた問題を修正 (フロントエンドが `res.hcaptcha.siteKey` 等を読めず undefined になっていた)。`/api/admin/captcha/save` が本家の generic パラメータ (`provider`/`captchaResult`/`sitekey`/`secret`/`instanceUrl`) を受け取らず保存値が DB に書かれていなかった問題、mCaptcha/testCaptcha provider 非対応、`captchaResult` の検証ステップと各エラーコード (`INVALID_PROVIDER`/`INVALID_PARAMETERS`/`VERIFICATION_FAILED` 等) の欠落も修正 (本家同様 captchaResult を検証し pass 時のみ設定を保存)。あわせて mCaptcha インスタンスの非200応答が `VERIFICATION_FAILED` になっていた問題を `REQUEST_FAILED` に修正 (本家 verifyMcaptcha と一致)
 
 - Fix: `/api/admin/abuse-user-reports` の `reporter`/`targetUser`/`assignee` が生のユーザーモデルで返り、`usernameLower` 等の内部フィールドが漏れ UserDetailedNotMe 固有フィールドを欠いていた問題を修正 (本家同様 UserDetailed で pack、`assignee` は未割当でも `null` でキー常在)。あわせて `targetUserHost`/`reporterHost` の余剰フィールド露出も除去

--- a/internal/api/admin/server_stats.go
+++ b/internal/api/admin/server_stats.go
@@ -1,6 +1,7 @@
 package admin
 
 import (
+	"context"
 	"net/http"
 
 	"github.com/labstack/echo/v4"
@@ -98,10 +99,40 @@ func (h *Handler) GetUserIPs(c echo.Context) error {
 }
 
 // ServerInfo handles POST /api/admin/server-info.
-// meta.enableServerMachineStats が false ならゼロ値を返す。
+//
+// upstream admin/server-info.ts は enableServerMachineStats gate を持たず、
+// moderator には常に live な machine 情報を返す (gate は公開 server-info.ts 側
+// のみ)。psql / redis のバージョンは system info に含まれないため DB / Redis
+// から best-effort で埋める (upstream は SHOW server_version / redis INFO を引く)。
 func (h *Handler) ServerInfo(c echo.Context) error {
-	if m, err := h.metaRepo.Fetch(); err == nil && m.EnableServerMachineStats {
-		return c.JSON(http.StatusOK, serverstats.Collect())
+	stats := serverstats.Collect()
+	stats.Psql = h.postgresVersion()
+	stats.Redis = h.redisVersion(c.Request().Context())
+	return c.JSON(http.StatusOK, stats)
+}
+
+// postgresVersion returns the PostgreSQL `server_version` string, or "" when the
+// DB is unwired or the query fails (best-effort, upstream `SHOW server_version`).
+func (h *Handler) postgresVersion() string {
+	if h.adminDB == nil {
+		return ""
 	}
-	return c.JSON(http.StatusOK, serverstats.Empty())
+	var version string
+	if err := h.adminDB.Raw("SHOW server_version").Scan(&version).Error; err != nil {
+		return ""
+	}
+	return version
+}
+
+// redisVersion returns the Redis `redis_version` from INFO, or "" when the Redis
+// info provider is unwired or the call fails (best-effort).
+func (h *Handler) redisVersion(ctx context.Context) string {
+	if h.queueRedis == nil {
+		return ""
+	}
+	raw, err := h.queueRedis.QueueRedisInfo(ctx)
+	if err != nil {
+		return ""
+	}
+	return parseRedisInfo(raw)["redis_version"]
 }

--- a/internal/api/admin/server_stats_test.go
+++ b/internal/api/admin/server_stats_test.go
@@ -1,11 +1,14 @@
 package admin_test
 
 import (
+	"context"
+	"encoding/json"
 	"net/http"
 	"testing"
 
 	"github.com/shiroha-a/mk/internal/model"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 type stubIPRepo struct{}
@@ -41,10 +44,92 @@ func TestGetUserIPs_Success(t *testing.T) {
 	assert.Equal(t, http.StatusOK, rec.Code)
 }
 
-func TestServerInfo_Disabled(t *testing.T) {
-	h, _, _, _ := newTestHandler(t)
+// admin/server-info は upstream 同様 enableServerMachineStats gate を持たず、
+// 常に live な full shape を返す (機械統計が無効でも moderator には実値)。
+func TestServerInfo_NoGateAlwaysLive(t *testing.T) {
+	h, _, metaRepo, _ := newTestHandler(t)
+	metaRepo.Meta.EnableServerMachineStats = false // gate が効かないことを確認
 	rec := doPost(h.ServerInfo, `{}`, adminUser)
-	assert.Equal(t, http.StatusOK, rec.Code)
-	// enableServerMachineStats = false (デフォルト) なので Empty() が返る
-	assert.Contains(t, rec.Body.String(), `"name":"?"`)
+	require.Equal(t, http.StatusOK, rec.Code)
+	var got map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &got))
+	// machine は実値 (string, "?" でない)。
+	machine, ok := got["machine"].(string)
+	require.True(t, ok)
+	assert.NotEmpty(t, machine)
+	assert.NotEqual(t, "?", machine)
+	// 全 admin field が present。
+	for _, k := range []string{"machine", "os", "node", "psql", "redis", "cpu", "mem", "fs", "net"} {
+		_, ok := got[k]
+		assert.True(t, ok, k+" は present")
+	}
+}
+
+// enableServerMachineStats = true で本家 server-info shape を返す。
+// machine は string、os/node が埋まり、psql/redis は DB/Redis 未配線で空文字。
+func TestServerInfo_EnabledShape(t *testing.T) {
+	h, _, metaRepo, _ := newTestHandler(t)
+	metaRepo.Meta.EnableServerMachineStats = true
+	rec := doPost(h.ServerInfo, `{}`, adminUser)
+	require.Equal(t, http.StatusOK, rec.Code)
+	var got map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &got))
+	// machine は string (型不一致 regression guard)。
+	machine, ok := got["machine"].(string)
+	require.True(t, ok, "machine must be a string, got %T", got["machine"])
+	assert.NotEmpty(t, machine)
+	assert.NotEmpty(t, got["os"])
+	assert.NotEmpty(t, got["node"])
+	// psql / redis は adminDB / queueRedis 未配線なので空文字 (string 型を維持)。
+	assert.Equal(t, "", got["psql"])
+	assert.Equal(t, "", got["redis"])
+	cpu := got["cpu"].(map[string]any)
+	assert.Greater(t, cpu["cores"].(float64), float64(0))
+	net := got["net"].(map[string]any)
+	_, hasIface := net["interface"]
+	assert.True(t, hasIface)
+}
+
+// adminDB 配線時は SHOW server_version から psql を埋める (実 PG が必要)。
+func TestServerInfo_PostgresVersionFromDB(t *testing.T) {
+	if integrationDB == nil {
+		t.Skip("integrationDB unavailable (set TEST_DB_HOST or run with Docker daemon for testcontainer)")
+	}
+	h, _, _, _ := newTestHandler(t)
+	h.SetAdminDB(integrationDB)
+	rec := doPost(h.ServerInfo, `{}`, adminUser)
+	require.Equal(t, http.StatusOK, rec.Code)
+	var got map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &got))
+	psql, _ := got["psql"].(string)
+	assert.NotEmpty(t, psql, "adminDB 配線時は SHOW server_version で psql が埋まる")
+}
+
+// queueRedis 配線時は redis INFO から redis_version を埋める。
+func TestServerInfo_RedisVersionFromInfo(t *testing.T) {
+	h, _, _, _ := newTestHandler(t)
+	h.SetQueueRedis(stubQueueRedisInfo{raw: "# Server\r\nredis_version:7.2.4\r\n"})
+	rec := doPost(h.ServerInfo, `{}`, adminUser)
+	require.Equal(t, http.StatusOK, rec.Code)
+	var got map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &got))
+	assert.Equal(t, "7.2.4", got["redis"])
+}
+
+// erroringQueueRedis は QueueRedisInfo が常にエラーを返す stub。
+type erroringQueueRedis struct{}
+
+func (erroringQueueRedis) QueueRedisInfo(context.Context) (string, error) {
+	return "", assertError{}
+}
+
+// redis INFO 取得失敗時は redis を空文字に fallback する (best-effort)。
+func TestServerInfo_RedisVersionError(t *testing.T) {
+	h, _, _, _ := newTestHandler(t)
+	h.SetQueueRedis(erroringQueueRedis{})
+	rec := doPost(h.ServerInfo, `{}`, adminUser)
+	require.Equal(t, http.StatusOK, rec.Code)
+	var got map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &got))
+	assert.Equal(t, "", got["redis"])
 }

--- a/internal/core/serverstats/stats.go
+++ b/internal/core/serverstats/stats.go
@@ -1,24 +1,28 @@
-// Package serverstats provides server machine statistics (CPU, memory, disk)
-// for the /api/admin/server-info endpoint.
+// Package serverstats provides server machine statistics (CPU, memory, disk,
+// OS, network) for the /api/admin/server-info endpoint.
 package serverstats
 
 import (
+	"net"
 	"os"
 	"runtime"
 	"syscall"
 )
 
-// Stats holds server machine information matching Misskey's server-info response.
+// Stats holds server machine information matching Misskey's server-info response
+// (server-info.ts res). machine/os/node/psql/redis are strings; cpu/mem/fs/net
+// are nested objects. psql/redis are filled by the handler (they need DB / Redis
+// access) and left empty by Collect.
 type Stats struct {
-	Machine MachineInfo `json:"machine"`
-	CPU     CPUInfo     `json:"cpu"`
-	Mem     MemInfo     `json:"mem"`
-	FS      FSInfo      `json:"fs"`
-}
-
-// MachineInfo holds the hostname.
-type MachineInfo struct {
-	Name string `json:"name"`
+	Machine string  `json:"machine"`
+	OS      string  `json:"os"`
+	Node    string  `json:"node"`
+	Psql    string  `json:"psql"`
+	Redis   string  `json:"redis"`
+	CPU     CPUInfo `json:"cpu"`
+	Mem     MemInfo `json:"mem"`
+	FS      FSInfo  `json:"fs"`
+	Net     NetInfo `json:"net"`
 }
 
 // CPUInfo holds CPU model and core count.
@@ -38,7 +42,13 @@ type FSInfo struct {
 	Used  uint64 `json:"used"`
 }
 
-// Collect gathers current server statistics.
+// NetInfo holds the default network interface name (upstream net.interface).
+type NetInfo struct {
+	Interface string `json:"interface"`
+}
+
+// Collect gathers current server statistics (system info only). Psql/Redis are
+// left empty for the handler to populate from the DB / Redis connection.
 func Collect() Stats {
 	hostname, _ := os.Hostname()
 
@@ -49,26 +59,75 @@ func Collect() Stats {
 		fs.Used = (stat.Blocks - stat.Bfree) * uint64(stat.Bsize)
 	}
 
-	var mem runtime.MemStats
-	runtime.ReadMemStats(&mem)
-
 	return Stats{
-		Machine: MachineInfo{Name: hostname},
+		Machine: hostname,
+		// upstream は os.platform() (linux/darwin/...) と process.version。
+		// Go 移植では runtime.GOOS / runtime.Version() が同等の情報。
+		OS:   runtime.GOOS,
+		Node: runtime.Version(),
 		CPU: CPUInfo{
 			Model: cpuModel(),
 			Cores: runtime.NumCPU(),
 		},
 		Mem: MemInfo{Total: totalMemory()},
 		FS:  fs,
+		Net: NetInfo{Interface: defaultInterface()},
 	}
 }
 
-// Empty returns zeroed stats (used when enableServerMachineStats is false).
-func Empty() Stats {
-	return Stats{
-		Machine: MachineInfo{Name: "?"},
+// PublicStats is the reduced shape returned by the unauthenticated public
+// /api/server-info endpoint (upstream server-info.ts res): machine/cpu/mem/fs
+// only. os/node/psql/redis/net are admin-only and must NOT leak to anonymous
+// callers.
+type PublicStats struct {
+	Machine string  `json:"machine"`
+	CPU     CPUInfo `json:"cpu"`
+	Mem     MemInfo `json:"mem"`
+	FS      FSInfo  `json:"fs"`
+}
+
+// CollectPublic gathers the public-endpoint subset (machine/cpu/mem/fs).
+func CollectPublic() PublicStats {
+	s := Collect()
+	return PublicStats{Machine: s.Machine, CPU: s.CPU, Mem: s.Mem, FS: s.FS}
+}
+
+// EmptyPublic returns the public placeholder shape used when
+// enableServerMachineStats is false (upstream server-info.ts disabled branch).
+func EmptyPublic() PublicStats {
+	return PublicStats{
+		Machine: "?",
 		CPU:     CPUInfo{Model: "?", Cores: 0},
 		Mem:     MemInfo{Total: 0},
 		FS:      FSInfo{Total: 0, Used: 0},
 	}
+}
+
+// defaultInterface returns the name of the first non-loopback, up interface with
+// a unicast address — approximating upstream `networkInterfaceDefault()`. Empty
+// when none is found.
+func defaultInterface() string {
+	ifaces, err := net.Interfaces()
+	if err != nil {
+		return ""
+	}
+	return pickDefaultInterface(ifaces, func(i net.Interface) ([]net.Addr, error) { return i.Addrs() })
+}
+
+// pickDefaultInterface holds the filtering logic of defaultInterface in a pure,
+// testable form: it skips down / loopback / address-less interfaces and returns
+// the first remaining interface's name. addrsOf resolves an interface's
+// addresses (injected so tests can drive each branch).
+func pickDefaultInterface(ifaces []net.Interface, addrsOf func(net.Interface) ([]net.Addr, error)) string {
+	for _, ifi := range ifaces {
+		if ifi.Flags&net.FlagUp == 0 || ifi.Flags&net.FlagLoopback != 0 {
+			continue
+		}
+		addrs, err := addrsOf(ifi)
+		if err != nil || len(addrs) == 0 {
+			continue
+		}
+		return ifi.Name
+	}
+	return ""
 }

--- a/internal/core/serverstats/stats_test.go
+++ b/internal/core/serverstats/stats_test.go
@@ -1,6 +1,9 @@
 package serverstats
 
 import (
+	"encoding/json"
+	"net"
+	"sort"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -8,10 +11,13 @@ import (
 
 func TestCollect(t *testing.T) {
 	s := Collect()
-	assert.NotEmpty(t, s.Machine.Name)
+	assert.NotEmpty(t, s.Machine)
 	assert.Greater(t, s.CPU.Cores, 0)
 	assert.Greater(t, s.Mem.Total, uint64(0))
 	assert.Greater(t, s.FS.Total, uint64(0))
+	// os / node は system info から常に埋まる (machine string 型)。
+	assert.NotEmpty(t, s.OS)
+	assert.NotEmpty(t, s.Node)
 }
 
 func TestCpuModel(t *testing.T) {
@@ -29,10 +35,62 @@ func TestCollect_CPUModelNotEmpty(t *testing.T) {
 	assert.NotEqual(t, "?", s.CPU.Model, "CPU model should be resolved on Linux")
 }
 
-func TestEmpty(t *testing.T) {
-	s := Empty()
-	assert.Equal(t, "?", s.Machine.Name)
+// CollectPublic / EmptyPublic は machine/cpu/mem/fs のみ (公開エンドポイント)。
+// os/node/psql/redis/net が漏れないことを JSON key で固定する (SI-1 regression guard)。
+func TestPublicStatsShape(t *testing.T) {
+	for _, ps := range []PublicStats{CollectPublic(), EmptyPublic()} {
+		b, err := json.Marshal(ps)
+		assert.NoError(t, err)
+		var got map[string]any
+		assert.NoError(t, json.Unmarshal(b, &got))
+		keys := make([]string, 0, len(got))
+		for k := range got {
+			keys = append(keys, k)
+		}
+		sort.Strings(keys)
+		assert.Equal(t, []string{"cpu", "fs", "machine", "mem"}, keys, "公開 shape は 4 field のみ")
+	}
+}
+
+func TestEmptyPublic(t *testing.T) {
+	s := EmptyPublic()
+	assert.Equal(t, "?", s.Machine)
 	assert.Equal(t, "?", s.CPU.Model)
 	assert.Equal(t, 0, s.CPU.Cores)
 	assert.Equal(t, uint64(0), s.Mem.Total)
+	assert.Equal(t, uint64(0), s.FS.Total)
+}
+
+func TestCollectPublic(t *testing.T) {
+	s := CollectPublic()
+	assert.NotEmpty(t, s.Machine)
+	assert.Greater(t, s.CPU.Cores, 0)
+}
+
+func TestPickDefaultInterface(t *testing.T) {
+	loopback := net.Interface{Name: "lo", Flags: net.FlagUp | net.FlagLoopback}
+	down := net.Interface{Name: "eth-down", Flags: 0}
+	noAddr := net.Interface{Name: "eth-noaddr", Flags: net.FlagUp}
+	addrErr := net.Interface{Name: "eth-err", Flags: net.FlagUp}
+	good := net.Interface{Name: "eth0", Flags: net.FlagUp}
+
+	addrsOf := func(i net.Interface) ([]net.Addr, error) {
+		switch i.Name {
+		case "eth-noaddr":
+			return nil, nil
+		case "eth-err":
+			return nil, assert.AnError
+		case "eth0":
+			return []net.Addr{&net.IPNet{IP: net.IPv4(10, 0, 0, 2)}}, nil
+		}
+		return nil, nil
+	}
+
+	// loopback/down/no-addr/addr-err は飛ばし、最初の有効 interface を返す。
+	got := pickDefaultInterface([]net.Interface{loopback, down, noAddr, addrErr, good}, addrsOf)
+	assert.Equal(t, "eth0", got)
+
+	// 有効な interface が無ければ空文字。
+	none := pickDefaultInterface([]net.Interface{loopback, down}, addrsOf)
+	assert.Equal(t, "", none)
 }

--- a/internal/server/router.go
+++ b/internal/server/router.go
@@ -2258,10 +2258,12 @@ func (s *Server) setupRoutes() {
 	// frontend の server-metric widget は `misskeyApiGet` で GET 呼び出し、
 	// それ以外の MkVisitorDashboard 等は POST で呼ぶため両メソッドを登録。
 	serverInfoHandler := func(c echo.Context) error {
+		// 公開エンドポイントは machine/cpu/mem/fs のみを返す (upstream public
+		// server-info.ts)。os/node/psql/redis/net は admin 専用で未認証には出さない。
 		if m, err := metaRepo.Fetch(); err == nil && m.EnableServerMachineStats {
-			return c.JSON(http.StatusOK, serverstats.Collect())
+			return c.JSON(http.StatusOK, serverstats.CollectPublic())
 		}
-		return c.JSON(http.StatusOK, serverstats.Empty())
+		return c.JSON(http.StatusOK, serverstats.EmptyPublic())
 	}
 	api.POST("/server-info", serverInfoHandler)
 	api.GET("/server-info", serverInfoHandler)

--- a/tests/playwright/specs/admin/server_meta.spec.ts
+++ b/tests/playwright/specs/admin/server_meta.spec.ts
@@ -38,11 +38,16 @@ test.describe('admin server / meta read shape', () => {
     const resp = await callApi(request, 'admin/server-info', { i: root.token });
     expect(resp.status()).toBe(200);
     const body = (await resp.json()) as Record<string, unknown>;
-    // meta は public /api/server-info と同 shape (= machine / cpu / mem / fs)
+    // admin/server-info は public /api/server-info の machine/cpu/mem/fs に加え
+    // os/node/psql/redis/net を返す (公開版は machine/cpu/mem/fs のみ)。
     expect(body.machine).toBeDefined();
     expect(body.cpu).toBeDefined();
     expect(body.mem).toBeDefined();
     expect(body.fs).toBeDefined();
+    // admin 専用の拡張 field。
+    expect(body.os).toBeDefined();
+    expect(body.node).toBeDefined();
+    expect(body.net).toBeDefined();
   });
 
   test('admin/emoji/list-remote returns array shape', async ({ request }) => {


### PR DESCRIPTION
## Summary

互換性監査 (Misskey TS ↔ mk-go) の HIGH バッチ第8弾 (admin misc) の第4スライス (H-PR8d: server-info)。`/api/admin/server-info` を本家 `server-info.ts` と揃える。

## 主な変更点

### `serverstats.Stats` (shape)
- `machine` をオブジェクト `{name}` から **文字列** (ホスト名) に変更 (本家の型と一致)
- `os` (`runtime.GOOS`) / `node` (`runtime.Version()`) / `psql` / `redis` / `net.interface` を追加
- `Collect()` が system info (machine/os/node/cpu/mem/fs/net) を埋め、psql/redis はハンドラが補完

### `/api/admin/server-info`
- 本家には無い `enableServerMachineStats` ゲートを admin から除去し、moderator には常に live な full shape を返す (本家 admin/server-info.ts はゲート無し)
- `psql` は `SHOW server_version`、`redis` は INFO の `redis_version` から best-effort で埋める (DB/Redis 未配線時は空文字)

### 公開 `/api/server-info` (敵対的レビュー SI-1, HIGH 回帰の修正)
- `Collect()` を共有していたため、shape 拡張で `os`/`node`/`net.interface` が **未認証クライアントに露出**する回帰を導入してしまっていた
- 本家 public `server-info.ts` 同様 `PublicStats` (`machine`/`cpu`/`mem`/`fs` のみ) に限定。`enableServerMachineStats` ゲートは公開版のみ維持 (本家一致)。psql/redis は元々埋めていないため version leak は無し

### その他
- `defaultInterface` を `pickDefaultInterface` (pure) に抽出してテスト容易化

## テスト
- `internal/core/serverstats/stats_test.go`: Collect/EmptyPublic/CollectPublic/**公開 shape regression guard (4 field のみ)**/pickDefaultInterface 全分岐
- `internal/api/admin/server_stats_test.go`: admin no-gate always-live / EnabledShape (machine string 型 guard) / psql wired (integrationDB, PG 必須) / redis wired+error fallback
- `tests/playwright/specs/admin/server_meta.spec.ts`: admin が os/node/net を返すことを assert (コメント更新)
- 実行: `go test ./internal/core/serverstats/... ./internal/api/admin/...` pass (serverstats 94.1% / admin 88.7%)、`gofmt -s`/`go vet` clean
- 注: `TestFederationUpdateInstance_Integration*` 2件はローカル共有テスト DB の残留行による既存失敗で本PR無関係

## 監査メモ
敵対的レビュー workflow (4観点 review→verify, 確定20件) を実施。確定 HIGH 1件 (SI-1: 公開エンドポイントの shape leak — 本 PR の `Collect()` 拡張で導入した回帰) を `PublicStats` 分離で修正。Medium (SI-2: admin の非本家ゲート除去 / psql wired test gap) も修正。残る Low は意図的 divergence: `node` は Go ランタイム版 (本家は Node 版)、`redis` は jobQueue Redis 由来 (本家は default Redis、通常同一サーバ)。

## 残り (H-PR8 後続スライス)
queue stats/clear/jobId / drive clean-remote-files / notification-recipient を別 PR で対応予定。

🤖 Generated with [Claude Code](https://claude.com/claude-code)