### PR TITLE
Fix admin/queue parity: stats shape・jobId param・clear state・metrics.meta・jobs search

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Fix: `/api/admin/queue/stats` のレスポンスが `{deliver, inbox}` の2キーのみで本家の `db`/`objectStorage` キーを欠き、各値も `completed`/`failed` を含んでいなかった問題を修正 (本家同様 4キー + QueueCount `{waiting,active,completed,failed,delayed}`)。`/api/admin/queue/{remove-job,retry-job,show-job,show-job-logs}` が本家の `jobId` パラメータを受け付けず `id` しか読まなかった問題 (`jobId` を優先、`id` も後方互換) と、`/api/admin/queue/clear` が `state` パラメータを無視して常に pending のみ削除していた問題 (本家同様 state 別に削除、`*` で全 state) も修正。あわせて `queues`/`queue-stats` の `metrics.completed`/`failed` に必須の `meta` オブジェクトが欠けていた問題と、`/api/admin/queue/jobs` の `search` パラメータが無視されていた問題 (本家同様 JSON 表現への全 term マッチで最大100件) を修正
+
 - Fix: `/api/admin/server-info` の `machine` がオブジェクト (`{name}`) で本家の文字列 (ホスト名) と型が異なり、`os`/`node`/`psql`/`redis`/`net.interface` が欠落していた問題を修正 (本家同様 machine は文字列、`os`(プラットフォーム)/`node`(ランタイム版)/`psql`(PostgreSQL版)/`redis`(Redis版)/`net.interface` を返す)。あわせて本家には無い `enableServerMachineStats` ゲートを admin から外し常に実値を返すように。公開 `/api/server-info` は本家同様 `machine`/`cpu`/`mem`/`fs` のみに限定し、`os`/`node`/`net.interface` 等が未認証クライアントに露出していた問題 (機械統計有効時) を修正
 
 - Fix: `/api/admin/captcha/current` のレスポンスが flat な `{provider, siteKey}` で、本家の `{provider, hcaptcha:{...}, mcaptcha:{...}, recaptcha:{...}, turnstile:{...}}` という provider 別 nested 構造を欠いていた問題を修正 (フロントエンドが `res.hcaptcha.siteKey` 等を読めず undefined になっていた)。`/api/admin/captcha/save` が本家の generic パラメータ (`provider`/`captchaResult`/`sitekey`/`secret`/`instanceUrl`) を受け取らず保存値が DB に書かれていなかった問題、mCaptcha/testCaptcha provider 非対応、`captchaResult` の検証ステップと各エラーコード (`INVALID_PROVIDER`/`INVALID_PARAMETERS`/`VERIFICATION_FAILED` 等) の欠落も修正 (本家同様 captchaResult を検証し pass 時のみ設定を保存)。あわせて mCaptcha インスタンスの非200応答が `VERIFICATION_FAILED` になっていた問題を `REQUEST_FAILED` に修正 (本家 verifyMcaptcha と一致)

--- a/internal/api/admin/queue.go
+++ b/internal/api/admin/queue.go
@@ -29,8 +29,63 @@ func (h *Handler) QueueClear(c echo.Context) error {
 	if h.queueInspector == nil {
 		return c.NoContent(http.StatusNoContent)
 	}
-	_, _ = h.queueInspector.DeleteAllPendingTasks(req.Queue)
+	h.clearQueueState(req.Queue, req.State)
 	return c.NoContent(http.StatusNoContent)
+}
+
+// clearQueueState removes jobs of the given Bull state from queue, mirroring
+// upstream queue.clean(0,0,state). state '*' clears all clearable states.
+// mkq には state 単位の bulk-delete API が無いため、pending は DrainPending、
+// それ以外は state 別の list → DeleteTask で消す (best-effort)。
+//
+// 注意点 (mkq 制約 / upstream との差): (1) "wait" は DrainPending を呼ぶが mkq の
+// DrainPending は wait に加え paused / prioritized バケットも drain する。mk-go は
+// queue を pause せず deliver/inbox で per-job priority も使わないため両バケットは
+// 実運用で常に空であり observable な差は無い。(2) active / paused / prioritized を
+// 単独 state で指定した場合は対応する bulk-clear 経路が無いため no-op。(3) cron
+// (repeat) 由来の delayed job は RemoveJob が拒否するため clear('delayed') で消えない。
+// (4) clearable job が約 100k を超える queue では 1 リクエストで消し切らない (再実行で継続)。
+func (h *Handler) clearQueueState(queue, state string) {
+	// deleteAll はリストが空になるまで先頭ページを引いて消す。削除で件数が
+	// 減るため page=1 を繰り返す。delete が 1 件も進まなければ無限ループを
+	// 避けて打ち切る。上限 1000 反復 (= 約 100k tasks) の安全弁付き。
+	deleteAll := func(lister func(string, int, int) ([]*QueueTaskSummary, error)) {
+		for i := 0; i < 1000; i++ {
+			rows, err := lister(queue, 1, 100)
+			if err != nil || len(rows) == 0 {
+				return
+			}
+			progressed := false
+			for _, t := range rows {
+				if h.queueInspector.DeleteTask(queue, t.ID) == nil {
+					progressed = true
+				}
+			}
+			if !progressed {
+				return
+			}
+		}
+	}
+	switch state {
+	case "*":
+		_, _ = h.queueInspector.DeleteAllPendingTasks(queue)
+		deleteAll(h.queueInspector.ListScheduledTasks)
+		deleteAll(h.queueInspector.ListRetryTasks)
+		deleteAll(h.queueInspector.ListFailedTasks)
+		deleteAll(h.queueInspector.ListCompletedTasks)
+	case "wait", "waiting", "pending":
+		_, _ = h.queueInspector.DeleteAllPendingTasks(queue)
+	case "delayed":
+		deleteAll(h.queueInspector.ListScheduledTasks)
+		deleteAll(h.queueInspector.ListRetryTasks)
+	case "failed":
+		deleteAll(h.queueInspector.ListFailedTasks)
+	case "completed":
+		deleteAll(h.queueInspector.ListCompletedTasks)
+	default:
+		// active / paused / prioritized は単独 state での bulk-clear 経路が
+		// 無いため no-op (paused/prioritized は wait 経由の DrainPending で消える)。
+	}
 }
 
 // QueueDeliverDelayed handles POST /api/admin/queue/deliver-delayed.
@@ -236,6 +291,13 @@ func (h *Handler) QueueJobs(c echo.Context) error {
 		req.Page = 1
 	}
 	states := parseStateField(req.State)
+	terms := searchTerms(req.Search)
+	if len(terms) > 0 {
+		// upstream queueGetJobs の search 経路は paramDef に limit/page を持たず、
+		// 1000 件取得→filter→最大 100 件返す。専用ページング経路に委譲する。
+		return c.JSON(http.StatusOK, h.searchQueueJobs(req.Queue, states, terms))
+	}
+
 	seen := make(map[string]struct{}, req.Limit)
 	out := make([]map[string]any, 0, req.Limit)
 outer:
@@ -258,6 +320,67 @@ outer:
 		}
 	}
 	return c.JSON(http.StatusOK, out)
+}
+
+// searchQueueJobs reproduces upstream queueGetJobs の search 経路。各 state を
+// 100 件 (driver の page size 上限) ずつ最大 searchMaxPages ページ取得して候補
+// プールを ~1000 件まで広げ、JSON 表現に全 term を含む job だけを最大
+// searchReturnLimit (=100) 件返す。driver の pageSize>100 clamp を跨ぐため
+// 単一呼び出しでなくページングで候補を集める。
+func (h *Handler) searchQueueJobs(queue string, states, terms []string) []map[string]any {
+	const searchReturnLimit = 100 // upstream RETURN_LIMIT
+	const searchPageSize = 100    // driver の page size 上限
+	const searchMaxPages = 10     // upstream getJobs(0, 1000) 相当の候補プール
+	seen := make(map[string]struct{}, searchReturnLimit)
+	out := make([]map[string]any, 0, searchReturnLimit)
+	for _, state := range states {
+		for page := 1; page <= searchMaxPages; page++ {
+			rows, err := h.listTasksForState(queue, state, page, searchPageSize)
+			if err != nil || len(rows) == 0 {
+				break
+			}
+			for _, t := range rows {
+				if len(out) >= searchReturnLimit {
+					return out
+				}
+				if _, dup := seen[t.ID]; dup {
+					continue
+				}
+				packed := packTaskSummary(t)
+				if !jobMatchesSearch(packed, terms) {
+					continue
+				}
+				seen[t.ID] = struct{}{}
+				out = append(out, packed)
+			}
+			if len(rows) < searchPageSize {
+				break
+			}
+		}
+	}
+	return out
+}
+
+// searchTerms lowercases and splits a search query into whitespace-separated
+// terms (upstream splits on space and requires every term to match).
+func searchTerms(search string) []string {
+	return strings.Fields(strings.ToLower(search))
+}
+
+// jobMatchesSearch reports whether the packed job's JSON representation contains
+// every search term (upstream matches against JSON.stringify(job).toLowerCase()).
+func jobMatchesSearch(packed map[string]any, terms []string) bool {
+	b, err := json.Marshal(packed)
+	if err != nil {
+		return false
+	}
+	hay := strings.ToLower(string(b))
+	for _, t := range terms {
+		if !strings.Contains(hay, t) {
+			return false
+		}
+	}
+	return true
 }
 
 // parseStateField normalizes the `state` request field which can be a single
@@ -381,14 +504,28 @@ func shapeQueueForFrontend(info *QueueInfoResult, completed, failed *QueueMetric
 			"completed": info.Completed,
 			"failed":    info.Failed,
 		},
+		// metrics は upstream packedQueueMetricsSchema 互換: {meta, data, count}。
+		// meta は required object {count, prevTS, prevCount}。mk-go は前回 sample の
+		// prevTS/prevCount を保持しないため 0 埋め (data 末尾が現在値)。
 		"metrics": map[string]any{
-			"completed": map[string]any{"data": completedData, "count": completedCount},
-			"failed":    map[string]any{"data": failedData, "count": failedCount},
+			"completed": queueMetricObject(completedData, completedCount),
+			"failed":    queueMetricObject(failedData, failedCount),
 		},
 		// db は job-queue Redis の INFO 由来 (memory / clients / uptime 等)。
 		// caller が queueDBStats() で一度引いて全 queue に渡す (INFO は接続単位
 		// で全 queue 同値)。provider 未配線時は defaultQueueDB() の 0 埋め。
 		"db": db,
+	}
+}
+
+// queueMetricObject builds the upstream QueueMetrics shape ({meta, data, count}).
+// meta.count mirrors the headline count; prevTS / prevCount are 0 because mkq
+// does not retain the previous sample window.
+func queueMetricObject(data []int64, count int64) map[string]any {
+	return map[string]any{
+		"meta":  map[string]any{"count": count, "prevTS": 0, "prevCount": 0},
+		"data":  data,
+		"count": count,
 	}
 }
 
@@ -486,12 +623,9 @@ func (h *Handler) QueueQueues(c echo.Context) error {
 
 // QueueRemoveJob handles POST /api/admin/queue/remove-job.
 func (h *Handler) QueueRemoveJob(c echo.Context) error {
-	var req struct {
-		Queue string `json:"queue"`
-		ID    string `json:"id"`
-	}
-	if err := c.Bind(&req); err != nil || req.Queue == "" || req.ID == "" {
-		return c.JSON(http.StatusBadRequest, apierr.InvalidParam("queue and id are required."))
+	queue, id, ok := bindQueueJobReq(c)
+	if !ok {
+		return c.JSON(http.StatusBadRequest, apierr.InvalidParam("queue and jobId are required."))
 	}
 	if h.queueInspector == nil {
 		return c.NoContent(http.StatusNoContent)
@@ -499,33 +633,53 @@ func (h *Handler) QueueRemoveJob(c echo.Context) error {
 	// asynq DeleteTask は不明 task id でも nil error を返す (= idempotent)
 	// が、upstream Misskey TS は 4xx を返す。drop-in 互換のため事前に
 	// GetTaskInfo で存在確認して、無ければ 404 を返す (#929)。
-	if _, err := h.queueInspector.GetTaskInfo(req.Queue, req.ID); err != nil {
+	if _, err := h.queueInspector.GetTaskInfo(queue, id); err != nil {
 		return c.JSON(http.StatusNotFound, apierr.NotFound())
 	}
-	if err := h.queueInspector.DeleteTask(req.Queue, req.ID); err != nil {
+	if err := h.queueInspector.DeleteTask(queue, id); err != nil {
 		return c.JSON(http.StatusNotFound, apierr.NotFound())
 	}
 	return c.NoContent(http.StatusNoContent)
 }
 
-// QueueRetryJob handles POST /api/admin/queue/retry-job.
-func (h *Handler) QueueRetryJob(c echo.Context) error {
+// bindQueueJobReq binds the shared {queue, jobId} param of remove-job /
+// retry-job / show-job / show-job-logs. upstream の required は (queue, jobId)。
+// 旧 mk-go の `id` キーも後方互換で受ける (jobId 優先)。queue と job id が
+// 揃わなければ ok=false。
+func bindQueueJobReq(c echo.Context) (queue, id string, ok bool) {
 	var req struct {
 		Queue string `json:"queue"`
+		JobID string `json:"jobId"`
 		ID    string `json:"id"`
 	}
-	if err := c.Bind(&req); err != nil || req.Queue == "" || req.ID == "" {
-		return c.JSON(http.StatusBadRequest, apierr.InvalidParam("queue and id are required."))
+	if err := c.Bind(&req); err != nil {
+		return "", "", false
+	}
+	id = req.JobID
+	if id == "" {
+		id = req.ID
+	}
+	if req.Queue == "" || id == "" {
+		return "", "", false
+	}
+	return req.Queue, id, true
+}
+
+// QueueRetryJob handles POST /api/admin/queue/retry-job.
+func (h *Handler) QueueRetryJob(c echo.Context) error {
+	queue, id, ok := bindQueueJobReq(c)
+	if !ok {
+		return c.JSON(http.StatusBadRequest, apierr.InvalidParam("queue and jobId are required."))
 	}
 	if h.queueInspector == nil {
 		return c.NoContent(http.StatusNoContent)
 	}
 	// asynq RunTask も不明 id で nil を返す idempotent 挙動。drop-in 互換の
 	// ため事前に GetTaskInfo で存在確認 (#929)。
-	if _, err := h.queueInspector.GetTaskInfo(req.Queue, req.ID); err != nil {
+	if _, err := h.queueInspector.GetTaskInfo(queue, id); err != nil {
 		return c.JSON(http.StatusNotFound, apierr.NotFound())
 	}
-	if err := h.queueInspector.RunTask(req.Queue, req.ID); err != nil {
+	if err := h.queueInspector.RunTask(queue, id); err != nil {
 		return c.JSON(http.StatusNotFound, apierr.NotFound())
 	}
 	return c.NoContent(http.StatusNoContent)
@@ -533,17 +687,14 @@ func (h *Handler) QueueRetryJob(c echo.Context) error {
 
 // QueueShowJob handles POST /api/admin/queue/show-job.
 func (h *Handler) QueueShowJob(c echo.Context) error {
-	var req struct {
-		Queue string `json:"queue"`
-		ID    string `json:"id"`
-	}
-	if err := c.Bind(&req); err != nil || req.Queue == "" || req.ID == "" {
-		return c.JSON(http.StatusBadRequest, apierr.InvalidParam("queue and id are required."))
+	queue, id, ok := bindQueueJobReq(c)
+	if !ok {
+		return c.JSON(http.StatusBadRequest, apierr.InvalidParam("queue and jobId are required."))
 	}
 	if h.queueInspector == nil {
 		return c.JSON(http.StatusNotFound, apierr.NotFound())
 	}
-	t, err := h.queueInspector.GetTaskInfo(req.Queue, req.ID)
+	t, err := h.queueInspector.GetTaskInfo(queue, id)
 	if err != nil {
 		return c.JSON(http.StatusNotFound, apierr.NotFound())
 	}
@@ -551,9 +702,15 @@ func (h *Handler) QueueShowJob(c echo.Context) error {
 }
 
 // QueueShowJobLogs handles POST /api/admin/queue/show-job-logs.
-// asynq does not persist per-task log output. Returns an empty array to keep
-// the admin UI usable without extra infra.
-func (h *Handler) QueueShowJobLogs(c echo.Context) error { return c.JSON(http.StatusOK, []any{}) }
+// mkq / asynq does not persist per-task log output, so this always returns an
+// empty array (upstream returns queue.getJobLogs(jobId).logs). queue + jobId
+// は upstream 同様 required として検証する。
+func (h *Handler) QueueShowJobLogs(c echo.Context) error {
+	if _, _, ok := bindQueueJobReq(c); !ok {
+		return c.JSON(http.StatusBadRequest, apierr.InvalidParam("queue and jobId are required."))
+	}
+	return c.JSON(http.StatusOK, []any{})
+}
 
 // packTaskSummary normalizes a QueueTaskSummary into the Misskey Bull-shaped
 // JSON expected by admin/job-queue.vue and job-queue.job.vue. frontend は
@@ -670,25 +827,37 @@ func rawJSONOrString(payload []byte) any {
 }
 
 // QueueStats handles POST /api/admin/queue/stats.
+//
+// upstream res は {deliver, inbox, db, objectStorage} の 4 キーで、各値は
+// QueueCount = {waiting, active, completed, failed, delayed} (全 required)。
+// mk-go は db / objectStorage を独立 queue として運用しないため、その 2 つは
+// ゼロ埋め QueueCount を返して shape parity を満たす。deliver / inbox は実値。
 func (h *Handler) QueueStats(c echo.Context) error {
-	if h.queueInspector == nil {
-		return c.JSON(http.StatusOK, map[string]any{
-			"deliver": map[string]any{"activeSince": nil, "active": 0, "waiting": 0, "delayed": 0},
-			"inbox":   map[string]any{"activeSince": nil, "active": 0, "waiting": 0, "delayed": 0},
-		})
+	zero := func() map[string]any {
+		return map[string]any{"waiting": 0, "active": 0, "completed": 0, "failed": 0, "delayed": 0}
 	}
-	result := map[string]any{}
+	result := map[string]any{
+		"deliver":       zero(),
+		"inbox":         zero(),
+		"db":            zero(),
+		"objectStorage": zero(),
+	}
+	if h.queueInspector == nil {
+		return c.JSON(http.StatusOK, result)
+	}
 	for _, qname := range []string{"deliver", "inbox"} {
 		info, err := h.queueInspector.GetQueueInfo(qname)
 		if err != nil {
-			result[qname] = map[string]any{"activeSince": nil, "active": 0, "waiting": 0, "delayed": 0}
 			continue
 		}
 		result[qname] = map[string]any{
-			// Bull の delayed は asynq の Scheduled (未来実行予定) と
-			// Retry (失敗後再試行待ち) の両方を含む。stream/queue_stats_publisher.go
-			// の WebSocket publisher と semantics を揃える (#654)。
-			"activeSince": nil, "active": info.Active, "waiting": info.Pending, "delayed": info.Scheduled + info.Retry,
+			"waiting":   info.Pending,
+			"active":    info.Active,
+			"completed": info.Completed,
+			"failed":    info.Failed,
+			// Bull の delayed は asynq の Scheduled (未来実行予定) と Retry
+			// (失敗後再試行待ち) の両方を含む (#654)。
+			"delayed": info.Scheduled + info.Retry,
 		}
 	}
 	return c.JSON(http.StatusOK, result)

--- a/internal/api/admin/queue_test.go
+++ b/internal/api/admin/queue_test.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"errors"
 	"net/http"
+	"strconv"
 	"testing"
 	"time"
 
@@ -84,12 +85,35 @@ func (s *stubQueueInspector) GetQueueInfo(q string) (*apiadmin.QueueInfoResult, 
 	}
 	return nil, errors.New("not found")
 }
-func (s *stubQueueInspector) DeleteTask(_, id string) error {
+func (s *stubQueueInspector) DeleteTask(q, id string) error {
 	if s.deleteErr != nil {
 		return s.deleteErr
 	}
 	s.deleted = append(s.deleted, id)
+	// 実 inspector 同様、削除した task を各 state list から除く (clearQueueState
+	// の list→delete ループが list の縮小で終了することを担保する)。
+	for _, m := range []map[string][]*apiadmin.QueueTaskSummary{
+		s.pending, s.active, s.scheduled, s.retry, s.completed, s.failed,
+	} {
+		removeStubTask(m, q, id)
+	}
+	delete(s.task, id)
 	return nil
+}
+
+// removeStubTask drops the task with id from m[q] (test helper).
+func removeStubTask(m map[string][]*apiadmin.QueueTaskSummary, q, id string) {
+	if m == nil {
+		return
+	}
+	rows := m[q]
+	out := rows[:0:0]
+	for _, t := range rows {
+		if t.ID != id {
+			out = append(out, t)
+		}
+	}
+	m[q] = out
 }
 func (s *stubQueueInspector) DeleteAllPendingTasks(q string) (int, error) {
 	s.deleteAllHits = append(s.deleteAllHits, q)
@@ -678,7 +702,12 @@ func TestQueueShowJob(t *testing.T) {
 
 func TestQueueShowJobLogs(t *testing.T) {
 	h, _, _, _ := newTestHandler(t)
-	assert.Equal(t, http.StatusOK, doPost(h.QueueShowJobLogs, `{}`, adminUser).Code)
+	// queue/jobId 欠落は 400 (upstream required)。
+	assert.Equal(t, http.StatusBadRequest, doPost(h.QueueShowJobLogs, `{}`, adminUser).Code)
+	// 正規 bind では常に空配列を返す (mkq は per-task ログ非保持)。
+	rec := doPost(h.QueueShowJobLogs, `{"queue":"deliver","jobId":"x"}`, adminUser)
+	assert.Equal(t, http.StatusOK, rec.Code)
+	assert.Equal(t, "[]\n", rec.Body.String())
 }
 
 func TestQueueStatsAdmin(t *testing.T) {
@@ -812,4 +841,238 @@ func TestQueueJobs_TimestampsFromJobState(t *testing.T) {
 	require.Len(t, got3, 1)
 	assert.EqualValues(t, processed.UnixMilli(), got3[0]["processedOn"])
 	assert.EqualValues(t, finished.UnixMilli(), got3[0]["finishedOn"])
+}
+
+// --- #H-PR8e: queue parity additions ---
+
+// remove/retry/show-job は upstream の jobId キーを受け付ける (旧 id も互換)。
+func TestQueueJobHandlers_AcceptJobId(t *testing.T) {
+	mkHandler := func() (*apiadmin.Handler, *stubQueueInspector) {
+		h, _, _, _ := newTestHandler(t)
+		insp := &stubQueueInspector{task: map[string]*apiadmin.QueueTaskSummary{
+			"j1": {ID: "j1", Queue: "deliver", Type: "x"},
+		}}
+		h.SetQueueInspector(insp)
+		return h, insp
+	}
+
+	h, insp := mkHandler()
+	rec := doPost(h.QueueRemoveJob, `{"queue":"deliver","jobId":"j1"}`, adminUser)
+	assert.Equal(t, http.StatusNoContent, rec.Code)
+	assert.Contains(t, insp.deleted, "j1")
+
+	h, insp = mkHandler()
+	rec = doPost(h.QueueRetryJob, `{"queue":"deliver","jobId":"j1"}`, adminUser)
+	assert.Equal(t, http.StatusNoContent, rec.Code)
+	assert.Contains(t, insp.runCalls, "j1")
+
+	h, _ = mkHandler()
+	rec = doPost(h.QueueShowJob, `{"queue":"deliver","jobId":"j1"}`, adminUser)
+	assert.Equal(t, http.StatusOK, rec.Code)
+
+	// jobId 欠落 (queue だけ) は 400。
+	h, _ = mkHandler()
+	assert.Equal(t, http.StatusBadRequest, doPost(h.QueueRemoveJob, `{"queue":"deliver"}`, adminUser).Code)
+}
+
+// queue/stats は deliver/inbox/db/objectStorage の 4 キーで、各値が
+// waiting/active/completed/failed/delayed を持つ (upstream QueueCount)。
+func TestQueueStats_FullShape(t *testing.T) {
+	h, _, _, _ := newTestHandler(t)
+	insp := &stubQueueInspector{info: map[string]*apiadmin.QueueInfoResult{
+		"deliver": {Queue: "deliver", Active: 1, Pending: 2, Completed: 3, Failed: 4, Scheduled: 5, Retry: 6},
+		"inbox":   {Queue: "inbox", Active: 7, Pending: 8, Completed: 9, Failed: 10, Scheduled: 1, Retry: 1},
+	}}
+	h.SetQueueInspector(insp)
+	rec := doPost(h.QueueStats, `{}`, adminUser)
+	require.Equal(t, http.StatusOK, rec.Code)
+	var got map[string]map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &got))
+	for _, k := range []string{"deliver", "inbox", "db", "objectStorage"} {
+		require.Contains(t, got, k)
+		for _, f := range []string{"waiting", "active", "completed", "failed", "delayed"} {
+			_, ok := got[k][f]
+			assert.True(t, ok, k+"."+f+" present")
+		}
+	}
+	assert.Equal(t, float64(3), got["deliver"]["completed"])
+	assert.Equal(t, float64(4), got["deliver"]["failed"])
+	assert.Equal(t, float64(11), got["deliver"]["delayed"]) // scheduled(5)+retry(6)
+	// db/objectStorage はゼロ埋め。
+	assert.Equal(t, float64(0), got["db"]["completed"])
+}
+
+// queue/clear は state を尊重する。failed 指定は pending を drain せず failed
+// task を DeleteTask で消す。
+func TestQueueClear_ByFailedState(t *testing.T) {
+	h, _, _, _ := newTestHandler(t)
+	insp := &stubQueueInspector{failed: map[string][]*apiadmin.QueueTaskSummary{
+		"deliver": {{ID: "f1"}, {ID: "f2"}},
+	}}
+	h.SetQueueInspector(insp)
+	rec := doPost(h.QueueClear, `{"queue":"deliver","state":"failed"}`, adminUser)
+	require.Equal(t, http.StatusNoContent, rec.Code)
+	assert.ElementsMatch(t, []string{"f1", "f2"}, insp.deleted)
+	assert.Empty(t, insp.deleteAllHits, "failed 指定では pending を drain しない")
+}
+
+// state='*' は pending drain + 各 state を消す。
+func TestQueueClear_AllStates(t *testing.T) {
+	h, _, _, _ := newTestHandler(t)
+	insp := &stubQueueInspector{
+		failed:    map[string][]*apiadmin.QueueTaskSummary{"deliver": {{ID: "f1"}}},
+		completed: map[string][]*apiadmin.QueueTaskSummary{"deliver": {{ID: "c1"}}},
+		scheduled: map[string][]*apiadmin.QueueTaskSummary{"deliver": {{ID: "s1"}}},
+	}
+	h.SetQueueInspector(insp)
+	rec := doPost(h.QueueClear, `{"queue":"deliver","state":"*"}`, adminUser)
+	require.Equal(t, http.StatusNoContent, rec.Code)
+	assert.Equal(t, []string{"deliver"}, insp.deleteAllHits)
+	assert.ElementsMatch(t, []string{"f1", "c1", "s1"}, insp.deleted)
+}
+
+// queue-stats の metrics.completed/failed は meta オブジェクトを持つ。
+func TestQueueQueueStats_MetricsHaveMeta(t *testing.T) {
+	h, _, _, _ := newTestHandler(t)
+	insp := &stubQueueInspector{info: map[string]*apiadmin.QueueInfoResult{
+		"deliver": {Queue: "deliver", Completed: 5, Failed: 2},
+	}}
+	h.SetQueueInspector(insp)
+	rec := doPost(h.QueueQueueStats, `{"queue":"deliver"}`, adminUser)
+	require.Equal(t, http.StatusOK, rec.Code)
+	var got map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &got))
+	metrics := got["metrics"].(map[string]any)
+	completed := metrics["completed"].(map[string]any)
+	meta, ok := completed["meta"].(map[string]any)
+	require.True(t, ok, "metrics.completed.meta が存在する")
+	for _, f := range []string{"count", "prevTS", "prevCount"} {
+		_, ok := meta[f]
+		assert.True(t, ok, "meta."+f)
+	}
+}
+
+// queue/jobs は search で job を絞り込む (JSON 表現に全 term を含むもの)。
+func TestQueueJobs_SearchFilter(t *testing.T) {
+	h, _, _, _ := newTestHandler(t)
+	insp := &stubQueueInspector{pending: map[string][]*apiadmin.QueueTaskSummary{
+		"deliver": {
+			{ID: "p1", Queue: "deliver", Type: "deliverNote", Payload: []byte(`{"host":"alpha.example"}`)},
+			{ID: "p2", Queue: "deliver", Type: "deliverNote", Payload: []byte(`{"host":"beta.example"}`)},
+		},
+	}}
+	h.SetQueueInspector(insp)
+	rec := doPost(h.QueueJobs, `{"queue":"deliver","state":"wait","search":"alpha"}`, adminUser)
+	require.Equal(t, http.StatusOK, rec.Code)
+	var rows []map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &rows))
+	require.Len(t, rows, 1)
+	assert.Equal(t, "p1", rows[0]["id"])
+}
+
+// jobId と id を両方送ると jobId が優先される (後方互換の優先順位)。
+func TestQueueRemoveJob_JobIdWinsOverId(t *testing.T) {
+	h, _, _, _ := newTestHandler(t)
+	insp := &stubQueueInspector{task: map[string]*apiadmin.QueueTaskSummary{
+		"j1": {ID: "j1", Queue: "deliver"},
+	}}
+	h.SetQueueInspector(insp)
+	rec := doPost(h.QueueRemoveJob, `{"queue":"deliver","jobId":"j1","id":"OTHER"}`, adminUser)
+	require.Equal(t, http.StatusNoContent, rec.Code)
+	assert.Contains(t, insp.deleted, "j1")
+	assert.NotContains(t, insp.deleted, "OTHER")
+}
+
+// clear state=delayed は scheduled + retry の両方を消す。
+func TestQueueClear_ByDelayedState(t *testing.T) {
+	h, _, _, _ := newTestHandler(t)
+	insp := &stubQueueInspector{
+		scheduled: map[string][]*apiadmin.QueueTaskSummary{"deliver": {{ID: "s1"}}},
+		retry:     map[string][]*apiadmin.QueueTaskSummary{"deliver": {{ID: "r1"}}},
+	}
+	h.SetQueueInspector(insp)
+	rec := doPost(h.QueueClear, `{"queue":"deliver","state":"delayed"}`, adminUser)
+	require.Equal(t, http.StatusNoContent, rec.Code)
+	assert.ElementsMatch(t, []string{"s1", "r1"}, insp.deleted)
+	assert.Empty(t, insp.deleteAllHits)
+}
+
+// clear state=active 等は no-op (pending drain も DeleteTask もしない)。
+func TestQueueClear_NoOpStates(t *testing.T) {
+	h, _, _, _ := newTestHandler(t)
+	insp := &stubQueueInspector{
+		failed: map[string][]*apiadmin.QueueTaskSummary{"deliver": {{ID: "f1"}}},
+	}
+	h.SetQueueInspector(insp)
+	rec := doPost(h.QueueClear, `{"queue":"deliver","state":"active"}`, adminUser)
+	require.Equal(t, http.StatusNoContent, rec.Code)
+	assert.Empty(t, insp.deleted, "active は何も消さない")
+	assert.Empty(t, insp.deleteAllHits)
+}
+
+// clearQueueState の deleteAll は DeleteTask が失敗 (list 縮小しない) しても
+// progressed=false で 1 反復で抜け、無限ループしない。
+func TestQueueClear_StopsWhenDeleteFails(t *testing.T) {
+	h, _, _, _ := newTestHandler(t)
+	insp := &stubQueueInspector{
+		failed:    map[string][]*apiadmin.QueueTaskSummary{"deliver": {{ID: "f1"}}},
+		deleteErr: errors.New("locked"),
+	}
+	h.SetQueueInspector(insp)
+	done := make(chan struct{})
+	go func() {
+		doPost(h.QueueClear, `{"queue":"deliver","state":"failed"}`, adminUser)
+		close(done)
+	}()
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("clearQueueState did not terminate (infinite loop)")
+	}
+}
+
+// search は複数 term の AND マッチで、どれも含まない job は落とす。
+func TestQueueJobs_SearchMultiTermAndZeroMatch(t *testing.T) {
+	h, _, _, _ := newTestHandler(t)
+	insp := &stubQueueInspector{pending: map[string][]*apiadmin.QueueTaskSummary{
+		"deliver": {
+			{ID: "p1", Queue: "deliver", Type: "x", Payload: []byte(`{"host":"alpha.example","kind":"urgent"}`)},
+			{ID: "p2", Queue: "deliver", Type: "x", Payload: []byte(`{"host":"alpha.example","kind":"calm"}`)},
+		},
+	}}
+	h.SetQueueInspector(insp)
+
+	// "alpha urgent" は両 term を含む p1 のみ (p2 は urgent を含まない)。
+	rec := doPost(h.QueueJobs, `{"queue":"deliver","state":"wait","search":"alpha urgent"}`, adminUser)
+	require.Equal(t, http.StatusOK, rec.Code)
+	var rows []map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &rows))
+	require.Len(t, rows, 1)
+	assert.Equal(t, "p1", rows[0]["id"])
+
+	// マッチ無しは空配列。
+	rec = doPost(h.QueueJobs, `{"queue":"deliver","state":"wait","search":"zzznomatch"}`, adminUser)
+	require.Equal(t, http.StatusOK, rec.Code)
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &rows))
+	assert.Empty(t, rows)
+}
+
+// search は最大 100 件返す (upstream RETURN_LIMIT、非 search の既定 limit 30 で
+// 頭打ちにならない)。
+func TestQueueJobs_SearchReturnsUpTo100(t *testing.T) {
+	h, _, _, _ := newTestHandler(t)
+	tasks := make([]*apiadmin.QueueTaskSummary, 0, 150)
+	for i := 0; i < 150; i++ {
+		tasks = append(tasks, &apiadmin.QueueTaskSummary{
+			ID: "p" + strconv.Itoa(i), Queue: "deliver", Type: "deliverNote",
+			Payload: []byte(`{"host":"match.example"}`),
+		})
+	}
+	insp := &stubQueueInspector{pending: map[string][]*apiadmin.QueueTaskSummary{"deliver": tasks}}
+	h.SetQueueInspector(insp)
+	rec := doPost(h.QueueJobs, `{"queue":"deliver","state":"wait","search":"match"}`, adminUser)
+	require.Equal(t, http.StatusOK, rec.Code)
+	var rows []map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &rows))
+	assert.Len(t, rows, 100, "search は最大 100 件 (RETURN_LIMIT)")
 }


### PR DESCRIPTION
## Summary

互換性監査 (Misskey TS ↔ mk-go) の HIGH バッチ第8弾 (admin misc) の第5スライス (H-PR8e: queue)。`/api/admin/queue/*` を本家と揃える。

## 主な変更点

### `/api/admin/queue/stats` (HIGH)
- `{deliver, inbox}` の2キーから本家の `{deliver, inbox, db, objectStorage}` 4キーに。各値を `QueueCount {waiting, active, completed, failed, delayed}` に揃える (旧は `completed`/`failed` 欠落)。`db`/`objectStorage` は mk-go が独立 queue として運用しないためゼロ埋め

### `/api/admin/queue/{remove-job,retry-job,show-job,show-job-logs}` (HIGH)
- 本家の `jobId` パラメータを受理 (旧 `id` も後方互換、`jobId` 優先)。`show-job-logs` は `queue`+`jobId` 必須化 (mkq は per-task ログ非保持のため中身は `[]` 維持)

### `/api/admin/queue/clear` (HIGH)
- `state` を無視して常に pending のみ削除していたのを state 別削除に修正 (`*`/`wait`/`delayed`/`failed`/`completed`)。pending は `DrainPending`、他は state 別 list→`DeleteTask` ループ (list 縮小で終了 + 1000 反復安全弁)

### `queues`/`queue-stats` + `jobs` (MEDIUM)
- `metrics.completed`/`failed` に必須の `meta {count, prevTS, prevCount}` を追加 (mkq は前 sample 非保持のため prevTS/prevCount=0)
- `/api/admin/queue/jobs` の `search` を実装: 候補をページングで最大 ~1000 件集め、各 job の JSON 表現に全 term (空白区切り) を含むものを最大 100 件 (本家 RETURN_LIMIT) 返す

## テスト
- `queue_test.go`: jobId 受理 + jobId/id 優先順位、stats 4キー full shape、clear by failed/delayed/completed/`*`/no-op(active)/delete失敗時のループ終了、metrics.meta、search (単一/複数term AND/zero-match/最大100件)
- stub の `DeleteTask` を実 inspector 同様「list から削除」する挙動に拡張 (clear ループの終了性を担保)
- 実行: `go test ./internal/api/admin/...` pass (admin 89.0%)、error-id drift gate pass、`gofmt -s`/`go vet` clean
- 注: `TestFederationUpdateInstance_Integration*` 2件はローカル共有テスト DB の残留行による既存失敗で本PR無関係

## 監査メモ
敵対的レビュー workflow (4観点 review→verify, 確定19件) を実施。HIGH 0。確定 Medium (search の候補プールが driver の pageSize clamp で 30 に丸められていた問題、出力が 30 で頭打ちだった問題) をページング + RETURN_LIMIT=100 で修正。clear のコメント誤記 (paused/prioritized は mkq に実在) も訂正し、mkq 制約 (wait clear が paused/prioritized も drain・cron delayed は消せない・~100k 上限) をコメント明記。

## 残り (H-PR8 後続スライス + 本バッチ defer)
- defer (architectural/inherent): `queues`/`queue-stats` の `QUEUE_TYPES` enum 不一致 (system/db/objectStorage 等 8 queue が返らない)、`show-job-logs` の実ログ (mkq 非保持)、`QueueJob.processedBy` (optional, mkq に worker-id 概念無し)
- 別スライス: drive clean-remote-files / notification-recipient / relays-add INVALID_URL / federation update-instance

🤖 Generated with [Claude Code](https://claude.com/claude-code)