### PR TITLE
Fix admin drive cleanup parity: clean-remote-files の isLink 条件 + object storage 物理削除

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Fix: `/api/admin/drive/clean-remote-files` の削除対象条件が逆 (`isLink=true` のリンク専用プロキシを消し、本来消すべき `isLink=false` のキャッシュ実体を残していた) で、かつオブジェクトストレージの物理ファイルを消していなかった問題を修正 (本家同様 `userHost IS NOT NULL AND isLink=false` を対象に、access/thumbnail/webpublic オブジェクトを削除してから DB 行を削除)。`/api/admin/delete-all-files-of-a-user` も DB 行のみ削除で物理ファイルが orphan 化していた問題を修正 (storage バックエンド配線時はオブジェクトも削除)
+
 - Fix: `/api/admin/queue/stats` のレスポンスが `{deliver, inbox}` の2キーのみで本家の `db`/`objectStorage` キーを欠き、各値も `completed`/`failed` を含んでいなかった問題を修正 (本家同様 4キー + QueueCount `{waiting,active,completed,failed,delayed}`)。`/api/admin/queue/{remove-job,retry-job,show-job,show-job-logs}` が本家の `jobId` パラメータを受け付けず `id` しか読まなかった問題 (`jobId` を優先、`id` も後方互換) と、`/api/admin/queue/clear` が `state` パラメータを無視して常に pending のみ削除していた問題 (本家同様 state 別に削除、`*` で全 state) も修正。あわせて `queues`/`queue-stats` の `metrics.completed`/`failed` に必須の `meta` オブジェクトが欠けていた問題と、`/api/admin/queue/jobs` の `search` パラメータが無視されていた問題 (本家同様 JSON 表現への全 term マッチで最大100件) を修正
 
 - Fix: `/api/admin/server-info` の `machine` がオブジェクト (`{name}`) で本家の文字列 (ホスト名) と型が異なり、`os`/`node`/`psql`/`redis`/`net.interface` が欠落していた問題を修正 (本家同様 machine は文字列、`os`(プラットフォーム)/`node`(ランタイム版)/`psql`(PostgreSQL版)/`redis`(Redis版)/`net.interface` を返す)。あわせて本家には無い `enableServerMachineStats` ゲートを admin から外し常に実値を返すように。公開 `/api/server-info` は本家同様 `machine`/`cpu`/`mem`/`fs` のみに限定し、`os`/`node`/`net.interface` 等が未認証クライアントに露出していた問題 (機械統計有効時) を修正

--- a/internal/api/admin/drive.go
+++ b/internal/api/admin/drive.go
@@ -2,6 +2,7 @@ package admin
 
 import (
 	"encoding/json"
+	"log/slog"
 	"net/http"
 
 	"github.com/labstack/echo/v4"
@@ -14,14 +15,89 @@ import (
 	"gorm.io/datatypes"
 )
 
+// driveCleanupBatchSize はバルク削除の 1 バッチ件数。upstream の cursor 巡回
+// (8 件) より大きめにして round-trip を減らす。
+const driveCleanupBatchSize = 100
+
+// driveCleanupMaxBatches は無限ループ防止の安全弁 (= 約 100 万件)。
+const driveCleanupMaxBatches = 10000
+
 // DriveCleanRemoteFiles handles POST /api/admin/drive/clean-remote-files.
+//
+// upstream CleanRemoteFilesProcessorService はキャッシュ済みリモートファイル
+// (userHost IS NOT NULL AND isLink=false) を物理オブジェクトごと削除する。
+// storage backend が配線されていれば list→object storage 削除→DB 行削除を
+// バッチで回す。未配線時は DB 行のみ削除 (条件は修正済 = isLink=false)。
 func (h *Handler) DriveCleanRemoteFiles(c echo.Context) error {
-	// 単一 DELETE 文なので同期実行で十分。将来バッチ化が必要ならここを
-	// queue ジョブに差し替える。
-	if h.driveFileRepo != nil {
+	if h.driveFileRepo == nil {
+		return c.NoContent(http.StatusNoContent)
+	}
+	if h.storageDeleter == nil {
+		// storage 未配線: DB 行のみ削除 (condition は isLink=false に修正済)。
 		_, _ = h.driveFileRepo.DeleteRemoteCache()
+		return c.NoContent(http.StatusNoContent)
+	}
+	if err := h.deleteFilesBatched(c, h.driveFileRepo.ListRemoteCache); err != nil {
+		return c.JSON(http.StatusInternalServerError, apierr.InternalError())
 	}
 	return c.NoContent(http.StatusNoContent)
+}
+
+// deleteFilesBatched lists files via list() in batches, deletes each file's
+// object-storage objects, then deletes the DB rows, until none remain. Because
+// the rows are deleted each round, list() naturally returns the next batch
+// (driveCleanupMaxBatches caps the loop against a non-shrinking repo).
+//
+// storage object 削除は best-effort (失敗しても DB 行は消す)。同期ループで
+// upstream のような job 再試行ができないため、storage 失敗で DB 削除を止めると
+// 同じ行を re-list し続けてしまう。失敗は slog で観測可能にし orphan を検知できる
+// ようにする。list / DeleteByIDs (= DB) の失敗は hard error として返し、handler が
+// 500 を返す (DB-only 経路の 500 と整合)。
+func (h *Handler) deleteFilesBatched(c echo.Context, list func(limit int) ([]*model.DriveFile, error)) error {
+	for i := 0; i < driveCleanupMaxBatches; i++ {
+		files, err := list(driveCleanupBatchSize)
+		if err != nil {
+			slog.ErrorContext(c.Request().Context(), "drive cleanup: list failed", "err", err)
+			return err
+		}
+		if len(files) == 0 {
+			return nil
+		}
+		ids := make([]string, 0, len(files))
+		for _, f := range files {
+			h.deleteFileStorageObjects(c, f)
+			ids = append(ids, f.ID)
+		}
+		if _, err := h.driveFileRepo.DeleteByIDs(ids); err != nil {
+			slog.ErrorContext(c.Request().Context(), "drive cleanup: DeleteByIDs failed", "err", err)
+			return err
+		}
+		if len(files) < driveCleanupBatchSize {
+			return nil
+		}
+	}
+	return nil
+}
+
+// deleteFileStorageObjects removes a file's primary / thumbnail / webpublic
+// objects from object storage. best-effort: 欠損 object はエラーにならない
+// (Storage.Delete の契約) が、それ以外の失敗は slog.Warn で残す (DB 行は消すので
+// orphan を後追いできるように)。upstream は thumbnailUrl/webpublicUrl の有無で
+// gate するが、mk-go は access key の有無で判定する (best-effort なので余分な key
+// への Delete は no-op)。storedInternal=true でローカル disk にある object を S3
+// backend で消そうとするケース (#1414 の二系統 storage) は本経路では消えない。
+func (h *Handler) deleteFileStorageObjects(c echo.Context, f *model.DriveFile) {
+	if h.storageDeleter == nil || f == nil {
+		return
+	}
+	for _, key := range []*string{f.AccessKey, f.ThumbnailAccessKey, f.WebpublicAccessKey} {
+		if key != nil && *key != "" {
+			if err := h.storageDeleter.Delete(*key); err != nil {
+				slog.WarnContext(c.Request().Context(), "drive cleanup: storage delete failed (object may be orphaned)",
+					"fileId", f.ID, "err", err)
+			}
+		}
+	}
 }
 
 // DriveCleanup handles POST /api/admin/drive/cleanup.

--- a/internal/api/admin/drive_emoji_test.go
+++ b/internal/api/admin/drive_emoji_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"strconv"
 	"testing"
 	"time"
 
@@ -295,15 +296,19 @@ func TestDriveCleanup_PreservesEmojiReferencedSystemFiles(t *testing.T) {
 func TestDriveCleanRemoteFiles_InvokesDeleteRemoteCache(t *testing.T) {
 	host := "remote.example"
 	u := "u1"
+	// 削除対象は「キャッシュ済みリモートファイル」= isLink=false かつ host あり。
+	// isLink=true (link-only proxy) とローカルファイルは保持する (条件修正の回帰 guard)。
 	h, repo := setupDriveFileHandler(t,
-		&model.DriveFile{ID: "remote1", IsLink: true, UserHost: &host},
+		&model.DriveFile{ID: "cached_remote", IsLink: false, UserHost: &host},
+		&model.DriveFile{ID: "link_only", IsLink: true, UserHost: &host},
 		&model.DriveFile{ID: "local1", UserID: &u},
 	)
 
 	rec := doPost(h.DriveCleanRemoteFiles, `{}`, adminUser)
 	assert.Equal(t, http.StatusNoContent, rec.Code)
-	assert.NotContains(t, repo.Files, "remote1")
-	assert.Contains(t, repo.Files, "local1")
+	assert.NotContains(t, repo.Files, "cached_remote", "キャッシュ実体は削除される")
+	assert.Contains(t, repo.Files, "link_only", "link-only proxy は保持される")
+	assert.Contains(t, repo.Files, "local1", "ローカルファイルは保持される")
 }
 
 // --- Emoji ------------------------------------------------------------------
@@ -1350,4 +1355,153 @@ func TestEmojiDeleteBulk_BatchedSingleInsert(t *testing.T) {
 	create, createMany := repo.CallCounts()
 	assert.Equal(t, 0, create, "Create must not be called per-item (would defeat #671 batching)")
 	assert.Equal(t, 1, createMany, "CreateMany must be called exactly once for the whole batch")
+}
+
+// stubStorageDeleter records the access keys passed to Delete. failKeys 内の
+// key には error を返す (best-effort 続行の検証用)。
+type stubStorageDeleter struct {
+	deleted  []string
+	failKeys map[string]bool
+}
+
+func (s *stubStorageDeleter) Delete(key string) error {
+	s.deleted = append(s.deleted, key)
+	if s.failKeys[key] {
+		return assertError{}
+	}
+	return nil
+}
+
+// clean-remote-files: storage backend 配線時は cached remote file の
+// access/thumbnail/webpublic object を削除してから DB 行を消す。
+func TestDriveCleanRemoteFiles_DeletesStorageObjects(t *testing.T) {
+	host := "remote.example"
+	ak1, tk1, ak2, akl := "ak1", "tk1", "ak2", "akl"
+	h, repo := setupDriveFileHandler(t,
+		&model.DriveFile{ID: "c1", IsLink: false, UserHost: &host, AccessKey: &ak1, ThumbnailAccessKey: &tk1},
+		&model.DriveFile{ID: "c2", IsLink: false, UserHost: &host, AccessKey: &ak2},
+		&model.DriveFile{ID: "link", IsLink: true, UserHost: &host, AccessKey: &akl},
+	)
+	sd := &stubStorageDeleter{}
+	h.SetStorageDeleter(sd)
+
+	rec := doPost(h.DriveCleanRemoteFiles, `{}`, adminUser)
+	require.Equal(t, http.StatusNoContent, rec.Code)
+	assert.NotContains(t, repo.Files, "c1")
+	assert.NotContains(t, repo.Files, "c2")
+	assert.Contains(t, repo.Files, "link", "link-only proxy は削除しない")
+	// cached file の object key のみ削除 (link-only の akl は対象外)。
+	assert.ElementsMatch(t, []string{"ak1", "tk1", "ak2"}, sd.deleted)
+}
+
+// delete-all-files-of-a-user: storage 配線時は対象ユーザーの file object も削除。
+func TestDeleteAllFilesOfUser_DeletesStorageObjects(t *testing.T) {
+	u, other := "u1", "u2"
+	ak := "aku1"
+	h, repo := setupDriveFileHandler(t,
+		&model.DriveFile{ID: "f1", UserID: &u, AccessKey: &ak},
+		&model.DriveFile{ID: "f2", UserID: &other},
+	)
+	sd := &stubStorageDeleter{}
+	h.SetStorageDeleter(sd)
+
+	rec := doPost(h.DeleteAllFilesOfUser, `{"userId":"u1"}`, adminUser)
+	require.Equal(t, http.StatusNoContent, rec.Code)
+	assert.NotContains(t, repo.Files, "f1")
+	assert.Contains(t, repo.Files, "f2", "他ユーザーの file は残す")
+	assert.Contains(t, sd.deleted, "aku1")
+}
+
+// clean-remote-files が driveCleanupBatchSize(100) を超える件数を複数バッチで
+// 全削除する (batching の終了性 + 継続)。
+func TestDriveCleanRemoteFiles_MultiBatch(t *testing.T) {
+	host := "remote.example"
+	h, repo := setupDriveFileHandler(t)
+	for i := 0; i < 150; i++ {
+		ak := "ak" + strconv.Itoa(i)
+		require.NoError(t, repo.Create(&model.DriveFile{
+			ID: "c" + strconv.Itoa(i), IsLink: false, UserHost: &host, AccessKey: &ak,
+		}))
+	}
+	sd := &stubStorageDeleter{}
+	h.SetStorageDeleter(sd)
+
+	rec := doPost(h.DriveCleanRemoteFiles, `{}`, adminUser)
+	require.Equal(t, http.StatusNoContent, rec.Code)
+	assert.Empty(t, repo.Files, "150 件すべて削除される (複数バッチ)")
+	assert.Len(t, sd.deleted, 150, "全 access key が storage 削除される")
+}
+
+// storage Delete が失敗しても他 key の削除を続行し DB 行は消す (best-effort)。
+func TestDriveCleanRemoteFiles_StorageDeleteFailureBestEffort(t *testing.T) {
+	host := "remote.example"
+	ak1, tk1, ak2 := "ak1", "tk1", "ak2"
+	h, repo := setupDriveFileHandler(t,
+		&model.DriveFile{ID: "c1", IsLink: false, UserHost: &host, AccessKey: &ak1, ThumbnailAccessKey: &tk1},
+		&model.DriveFile{ID: "c2", IsLink: false, UserHost: &host, AccessKey: &ak2},
+	)
+	sd := &stubStorageDeleter{failKeys: map[string]bool{"ak1": true}}
+	h.SetStorageDeleter(sd)
+
+	rec := doPost(h.DriveCleanRemoteFiles, `{}`, adminUser)
+	require.Equal(t, http.StatusNoContent, rec.Code)
+	// ak1 が失敗しても tk1 / ak2 の削除は続行され、DB 行は全て消える。
+	assert.ElementsMatch(t, []string{"ak1", "tk1", "ak2"}, sd.deleted)
+	assert.Empty(t, repo.Files)
+}
+
+// list (DB) 失敗は 500 (DB-only 経路の 500 と整合)。
+func TestDriveCleanRemoteFiles_ListErrorReturns500(t *testing.T) {
+	h, repo := setupDriveFileHandler(t)
+	repo.ListRemoteCacheErr = assertError{}
+	h.SetStorageDeleter(&stubStorageDeleter{})
+	rec := doPost(h.DriveCleanRemoteFiles, `{}`, adminUser)
+	assert.Equal(t, http.StatusInternalServerError, rec.Code)
+}
+
+// DeleteByIDs (DB) 失敗も 500。
+func TestDeleteAllFilesOfUser_DeleteErrorReturns500(t *testing.T) {
+	u := "u1"
+	ak := "aku"
+	h, repo := setupDriveFileHandler(t, &model.DriveFile{ID: "f1", UserID: &u, AccessKey: &ak})
+	repo.DeleteByIDsErr = assertError{}
+	h.SetStorageDeleter(&stubStorageDeleter{})
+	rec := doPost(h.DeleteAllFilesOfUser, `{"userId":"u1"}`, adminUser)
+	assert.Equal(t, http.StatusInternalServerError, rec.Code)
+}
+
+// DeleteByIDs が行を消さない degenerate ケースでも maxBatches 安全弁で有限終了する。
+func TestDriveCleanRemoteFiles_TerminatesWhenNoProgress(t *testing.T) {
+	host := "remote.example"
+	ak := "ak1"
+	h, repo := setupDriveFileHandler(t,
+		&model.DriveFile{ID: "c1", IsLink: false, UserHost: &host, AccessKey: &ak},
+	)
+	repo.DeleteByIDsNoOp = true // 行が縮小しない
+	h.SetStorageDeleter(&stubStorageDeleter{})
+	done := make(chan struct{})
+	go func() {
+		doPost(h.DriveCleanRemoteFiles, `{}`, adminUser)
+		close(done)
+	}()
+	select {
+	case <-done:
+	case <-time.After(5 * time.Second):
+		t.Fatal("deleteFilesBatched did not terminate (safety valve failed)")
+	}
+}
+
+// webpublic access key も storage 削除対象に含まれ、空文字 key は skip される。
+func TestDriveCleanRemoteFiles_WebpublicKeyAndEmptySkip(t *testing.T) {
+	host := "remote.example"
+	ak, wk, empty := "ak1", "wk1", ""
+	h, _ := setupDriveFileHandler(t,
+		&model.DriveFile{ID: "c1", IsLink: false, UserHost: &host, AccessKey: &ak, WebpublicAccessKey: &wk, ThumbnailAccessKey: &empty},
+	)
+	sd := &stubStorageDeleter{}
+	h.SetStorageDeleter(sd)
+	rec := doPost(h.DriveCleanRemoteFiles, `{}`, adminUser)
+	require.Equal(t, http.StatusNoContent, rec.Code)
+	// access + webpublic は削除、空文字 thumbnail key は skip。
+	assert.ElementsMatch(t, []string{"ak1", "wk1"}, sd.deleted)
 }

--- a/internal/api/admin/handler.go
+++ b/internal/api/admin/handler.go
@@ -117,6 +117,9 @@ type Handler struct {
 	systemAccountFetcher    SystemAccountFetcher
 	followingRepo           repository.FollowingRepository
 	unfollowEnqueuer        UnfollowEnqueuer
+	// storageDeleter は admin の bulk drive cleanup で物理オブジェクトを消す
+	// object storage backend (nil なら DB 行のみ削除)。
+	storageDeleter StorageDeleter
 	// captchaVerifierFactory builds a one-off captcha.Verifier for
 	// admin/captcha/save verification. nil uses the real providers; tests
 	// inject a stub to avoid external HTTP calls.
@@ -441,6 +444,19 @@ type QueueTaskSummary struct {
 // SetDriveFileRepo attaches a DriveFileRepository for admin drive operations.
 func (h *Handler) SetDriveFileRepo(r repository.DriveFileRepository) {
 	h.driveFileRepo = r
+}
+
+// StorageDeleter removes a stored object by its access key (drive.Storage の
+// Delete に対応)。admin/drive/clean-remote-files と delete-all-files-of-a-user で
+// DB 行削除前に object storage の物理オブジェクトを消すために使う。
+type StorageDeleter interface {
+	Delete(accessKey string) error
+}
+
+// SetStorageDeleter wires the object-storage backend so bulk drive cleanups can
+// remove physical objects (not just DB rows). nil keeps the DB-only behaviour.
+func (h *Handler) SetStorageDeleter(s StorageDeleter) {
+	h.storageDeleter = s
 }
 
 // SetAdminDB attaches a DB connection for ad/invite/relay operations.

--- a/internal/api/admin/moderation.go
+++ b/internal/api/admin/moderation.go
@@ -7,6 +7,7 @@ import (
 	"github.com/labstack/echo/v4"
 	"github.com/shiroha-a/mk/internal/api/apierr"
 	"github.com/shiroha-a/mk/internal/core/moderationlog"
+	"github.com/shiroha-a/mk/internal/model"
 )
 
 // UnsetUserAvatar handles POST /api/admin/unset-user-avatar.
@@ -119,8 +120,12 @@ func (h *Handler) UpdateAbuseUserReport(c echo.Context) error {
 }
 
 // DeleteAllFilesOfUser handles POST /api/admin/delete-all-files-of-a-user.
-// driveFile レコードを user 単位で一括 DELETE する。S3 等 object storage の
-// 物理 file 削除は drive_file の deletion hook (別経路) で扱う想定。
+//
+// upstream delete-all-files-of-a-user.ts は対象ユーザーの全 drive file を
+// findBy({userId}) で回し driveService.deleteFile で物理ストレージごと削除する
+// (dbQueue 'deleteDriveFiles' processor は upstream でも未使用の vestigial)。
+// storage backend が配線されていれば list→object storage 削除→DB 行削除を
+// バッチで回し orphan を残さない。未配線時は DB 行のみ一括削除。
 func (h *Handler) DeleteAllFilesOfUser(c echo.Context) error {
 	var req struct {
 		UserID string `json:"userId"`
@@ -131,9 +136,16 @@ func (h *Handler) DeleteAllFilesOfUser(c echo.Context) error {
 	if h.driveFileRepo == nil {
 		return c.NoContent(http.StatusNoContent)
 	}
-	// 単一の DELETE 文で完結するため同期実行。大量ファイル (数万) の場合も
-	// PostgreSQL で 1 秒未満に収まる想定。将来バッチが必要なら queue へ。
-	if _, err := h.driveFileRepo.DeleteByUser(req.UserID); err != nil {
+	if h.storageDeleter == nil {
+		// storage 未配線: DB 行のみ一括削除。
+		if _, err := h.driveFileRepo.DeleteByUser(req.UserID); err != nil {
+			return c.JSON(http.StatusInternalServerError, apierr.InternalError())
+		}
+		return c.NoContent(http.StatusNoContent)
+	}
+	if err := h.deleteFilesBatched(c, func(limit int) ([]*model.DriveFile, error) {
+		return h.driveFileRepo.ListByUserAll(req.UserID, limit)
+	}); err != nil {
 		return c.JSON(http.StatusInternalServerError, apierr.InternalError())
 	}
 	return c.NoContent(http.StatusNoContent)

--- a/internal/core/transfer/drive_reader_test.go
+++ b/internal/core/transfer/drive_reader_test.go
@@ -89,6 +89,13 @@ func (f *fakeDriveFileRepo) ListSystemFiles(_, _, _ string, _ int) ([]*model.Dri
 }
 func (f *fakeDriveFileRepo) DeleteOrphans() (int64, error)     { return 0, nil }
 func (f *fakeDriveFileRepo) DeleteRemoteCache() (int64, error) { return 0, nil }
+func (f *fakeDriveFileRepo) ListRemoteCache(_ int) ([]*model.DriveFile, error) {
+	return nil, nil
+}
+func (f *fakeDriveFileRepo) ListByUserAll(_ string, _ int) ([]*model.DriveFile, error) {
+	return nil, nil
+}
+func (f *fakeDriveFileRepo) DeleteByIDs(_ []string) (int64, error) { return 0, nil }
 func (f *fakeDriveFileRepo) DeleteByUser(_ string) (int64, error) {
 	return 0, nil
 }

--- a/internal/repository/drive_file.go
+++ b/internal/repository/drive_file.go
@@ -49,9 +49,20 @@ type DriveFileRepository interface {
 	UpdateBulkFolder(userID string, fileIDs []string, folderID *string) error
 	// DeleteOrphans removes rows whose userId is NULL. Returns affected count.
 	DeleteOrphans() (int64, error)
-	// DeleteRemoteCache removes remote cache rows (isLink=true with host set).
-	// Returns affected count.
+	// DeleteRemoteCache removes cached remote files (isLink=false with host set)
+	// — the rows whose actual bytes are cached locally / in object storage.
+	// Returns affected count. Used as the DB-only fallback for
+	// admin/drive/clean-remote-files when no storage backend is wired.
 	DeleteRemoteCache() (int64, error)
+	// ListRemoteCache returns up to limit cached remote files (isLink=false with
+	// host set) so the caller can delete their object-storage objects before the
+	// DB rows. Order is unspecified.
+	ListRemoteCache(limit int) ([]*model.DriveFile, error)
+	// ListByUserAll returns up to limit files owned by userID across all folders
+	// (admin/delete-all-files-of-a-user storage cleanup).
+	ListByUserAll(userID string, limit int) ([]*model.DriveFile, error)
+	// DeleteByIDs removes the given rows in one statement. Returns affected count.
+	DeleteByIDs(ids []string) (int64, error)
 	// DeleteByUser removes every drive_file owned by userID. Returns affected
 	// count. Used by admin/delete-all-files-of-a-user.
 	DeleteByUser(userID string) (int64, error)
@@ -335,7 +346,41 @@ func (r *driveFileRepository) DeleteOrphans() (int64, error) {
 }
 
 func (r *driveFileRepository) DeleteRemoteCache() (int64, error) {
-	tx := r.db.Where(`"isLink" = true AND "userHost" IS NOT NULL`).Delete(&model.DriveFile{})
+	// upstream CleanRemoteFilesProcessorService は userHost IS NOT NULL AND
+	// isLink=false (= 実体をキャッシュしているリモートファイル) を消す。旧実装は
+	// isLink=true (= 実体を持たない link-only proxy) を消しており条件が逆だった。
+	tx := r.db.Where(`"isLink" = false AND "userHost" IS NOT NULL`).Delete(&model.DriveFile{})
+	return tx.RowsAffected, tx.Error
+}
+
+func (r *driveFileRepository) ListRemoteCache(limit int) ([]*model.DriveFile, error) {
+	if limit <= 0 {
+		limit = 100
+	}
+	var files []*model.DriveFile
+	err := r.db.Where(`"isLink" = false AND "userHost" IS NOT NULL`).
+		Order("id DESC").Limit(limit).Find(&files).Error
+	return files, err
+}
+
+func (r *driveFileRepository) ListByUserAll(userID string, limit int) ([]*model.DriveFile, error) {
+	if userID == "" {
+		return nil, nil
+	}
+	if limit <= 0 {
+		limit = 100
+	}
+	var files []*model.DriveFile
+	err := r.db.Where(`"userId" = ?`, userID).
+		Order("id DESC").Limit(limit).Find(&files).Error
+	return files, err
+}
+
+func (r *driveFileRepository) DeleteByIDs(ids []string) (int64, error) {
+	if len(ids) == 0 {
+		return 0, nil
+	}
+	tx := r.db.Where("id IN ?", ids).Delete(&model.DriveFile{})
 	return tx.RowsAffected, tx.Error
 }
 

--- a/internal/repository/drive_file_test.go
+++ b/internal/repository/drive_file_test.go
@@ -324,18 +324,24 @@ func TestDriveFileRepository_DeleteOrphansAndRemoteCache(t *testing.T) {
 	orphan.UserID = nil
 	kept := newTestDriveFile("kept1", user.ID, "md5k", nil)
 
-	// remote cache (isLink=true, userHost set) と local link
+	// cached remote file (isLink=false, userHost set) は DeleteRemoteCache の
+	// 対象。link-only proxy (isLink=true) は対象外で保持される (upstream 互換)。
 	host := "cache.example"
 	remoteCache := newTestDriveFile("rc1", user.ID, "md5rc", nil)
-	remoteCache.IsLink = true
+	remoteCache.IsLink = false
 	remoteCache.UserHost = &host
+	linkOnly := newTestDriveFile("lo1", user.ID, "md5lo", nil)
+	linkOnly.IsLink = true
+	linkOnly.UserHost = &host
 
 	require.NoError(t, repo.Create(orphan))
 	require.NoError(t, repo.Create(kept))
 	require.NoError(t, repo.Create(remoteCache))
+	require.NoError(t, repo.Create(linkOnly))
 	defer cleanupDriveFile(t, orphan.ID)
 	defer cleanupDriveFile(t, kept.ID)
 	defer cleanupDriveFile(t, remoteCache.ID)
+	defer cleanupDriveFile(t, linkOnly.ID)
 
 	n, err := repo.DeleteOrphans()
 	require.NoError(t, err)
@@ -349,7 +355,9 @@ func TestDriveFileRepository_DeleteOrphansAndRemoteCache(t *testing.T) {
 	require.NoError(t, err)
 	assert.GreaterOrEqual(t, n, int64(1))
 	_, err = repo.FindByID(remoteCache.ID)
-	assert.Error(t, err)
+	assert.Error(t, err, "isLink=false のキャッシュ実体は削除される")
+	_, err = repo.FindByID(linkOnly.ID)
+	assert.NoError(t, err, "isLink=true の link-only は保持される")
 }
 
 // TestDriveFileRepository_DeleteOrphans_PreservesEmojiReferenced は #722
@@ -561,3 +569,54 @@ func TestDriveFileRepository_DeleteByUser(t *testing.T) {
 }
 
 var _ = context.Background // import guard
+
+// ListRemoteCache / ListByUserAll / DeleteByIDs の動作 (#H-PR8f)。
+func TestDriveFileRepository_CleanupHelpers(t *testing.T) {
+	repo := NewDriveFileRepository(testDB)
+	user := insertTestUser(t, "u_clh", "clh")
+	defer cleanupUser(t, user.ID)
+	host := "clh.example"
+
+	cached := newTestDriveFile("clh_c", user.ID, "md5c", nil)
+	cached.IsLink = false
+	cached.UserHost = &host
+	link := newTestDriveFile("clh_l", user.ID, "md5l", nil)
+	link.IsLink = true
+	link.UserHost = &host
+	local := newTestDriveFile("clh_loc", user.ID, "md5loc", nil)
+	for _, f := range []*model.DriveFile{cached, link, local} {
+		require.NoError(t, repo.Create(f))
+		defer cleanupDriveFile(t, f.ID)
+	}
+
+	idset := func(fs []*model.DriveFile) map[string]bool {
+		m := map[string]bool{}
+		for _, f := range fs {
+			m[f.ID] = true
+		}
+		return m
+	}
+
+	// ListRemoteCache は isLink=false かつ host あり (= キャッシュ実体) のみ。
+	rc, err := repo.ListRemoteCache(100)
+	require.NoError(t, err)
+	rcIDs := idset(rc)
+	assert.True(t, rcIDs[cached.ID], "cached を含む")
+	assert.False(t, rcIDs[link.ID], "link-only は含まない")
+	assert.False(t, rcIDs[local.ID], "local は含まない")
+
+	// ListByUserAll は user 所有の全 file (folder 問わず)。
+	ua, err := repo.ListByUserAll(user.ID, 100)
+	require.NoError(t, err)
+	uaIDs := idset(ua)
+	assert.True(t, uaIDs[cached.ID] && uaIDs[link.ID] && uaIDs[local.ID])
+
+	// DeleteByIDs は指定 ID のみ削除。
+	n, err := repo.DeleteByIDs([]string{cached.ID, link.ID})
+	require.NoError(t, err)
+	assert.Equal(t, int64(2), n)
+	_, err = repo.FindByID(cached.ID)
+	assert.Error(t, err)
+	_, err = repo.FindByID(local.ID)
+	assert.NoError(t, err, "指定外の local は残る")
+}

--- a/internal/server/router.go
+++ b/internal/server/router.go
@@ -1968,6 +1968,9 @@ func (s *Server) setupRoutes() {
 	announcementHandler.SetUserRepo(userRepo)
 	adminHandler.SetEmojiRepo(emojiRepo)
 	adminHandler.SetDriveFileRepo(driveFileRepo)
+	// bulk drive cleanup (clean-remote-files / delete-all-files-of-a-user) で
+	// object storage の物理オブジェクトも消すため storage backend を渡す。
+	adminHandler.SetStorageDeleter(driveStorage)
 	adminHandler.SetAdminDB(s.db)
 	adminHandler.SetUserIPRepo(userIPRepo)
 	adminHandler.SetEmojiImportEnqueuer(s.queueClient)

--- a/internal/testutil/mock_drive.go
+++ b/internal/testutil/mock_drive.go
@@ -20,6 +20,15 @@ type MockDriveFileRepository struct {
 	// call so handler tests can assert the owning user is scoped (IDOR guard).
 	BulkFolderUserID  string
 	BulkFolderFileIDs []string
+
+	// 以下は bulk cleanup (clean-remote-files / delete-all-files) のエラー経路を
+	// テストするための注入フィールド。nil なら通常動作。
+	ListRemoteCacheErr error
+	ListByUserAllErr   error
+	DeleteByIDsErr     error
+	// DeleteByIDsNoOp を true にすると DeleteByIDs が err=nil で 0 件削除する
+	// (= 行が縮小しない degenerate ケース。maxBatches 安全弁の終了性検証用)。
+	DeleteByIDsNoOp bool
 }
 
 func NewMockDriveFileRepository() *MockDriveFileRepository {
@@ -461,7 +470,67 @@ func (m *MockDriveFileRepository) DeleteOrphans() (int64, error) {
 func (m *MockDriveFileRepository) DeleteRemoteCache() (int64, error) {
 	n := int64(0)
 	for id, f := range m.Files {
-		if f.IsLink && f.UserHost != nil {
+		// upstream は isLink=false (キャッシュ実体) を消す。
+		if !f.IsLink && f.UserHost != nil {
+			delete(m.Files, id)
+			n++
+		}
+	}
+	return n, nil
+}
+
+func (m *MockDriveFileRepository) ListRemoteCache(limit int) ([]*model.DriveFile, error) {
+	if m.ListRemoteCacheErr != nil {
+		return nil, m.ListRemoteCacheErr
+	}
+	if limit <= 0 {
+		limit = 100
+	}
+	out := make([]*model.DriveFile, 0, limit)
+	for _, f := range m.Files {
+		if !f.IsLink && f.UserHost != nil {
+			out = append(out, f)
+			if len(out) >= limit {
+				break
+			}
+		}
+	}
+	return out, nil
+}
+
+func (m *MockDriveFileRepository) ListByUserAll(userID string, limit int) ([]*model.DriveFile, error) {
+	if m.ListByUserAllErr != nil {
+		return nil, m.ListByUserAllErr
+	}
+	if userID == "" {
+		return nil, nil
+	}
+	if limit <= 0 {
+		limit = 100
+	}
+	out := make([]*model.DriveFile, 0, limit)
+	for _, f := range m.Files {
+		if f.UserID != nil && *f.UserID == userID {
+			out = append(out, f)
+			if len(out) >= limit {
+				break
+			}
+		}
+	}
+	return out, nil
+}
+
+func (m *MockDriveFileRepository) DeleteByIDs(ids []string) (int64, error) {
+	if m.DeleteByIDsErr != nil {
+		return 0, m.DeleteByIDsErr
+	}
+	if m.DeleteByIDsNoOp {
+		// 行を消さず成功扱い (= list が縮小しない degenerate ケース)。
+		return 0, nil
+	}
+	n := int64(0)
+	for _, id := range ids {
+		if _, ok := m.Files[id]; ok {
 			delete(m.Files, id)
 			n++
 		}


### PR DESCRIPTION
## Summary

互換性監査 (Misskey TS ↔ mk-go) の HIGH バッチ第8弾 (admin misc) の第6スライス (H-PR8f: drive cleanup)。`/api/admin/drive/clean-remote-files` と `/api/admin/delete-all-files-of-a-user` を本家と揃える。

## 主な変更点

### `/api/admin/drive/clean-remote-files` (HIGH)
- **削除対象条件が逆だったのを修正**: 旧実装は `isLink=true` (実体を持たない link-only proxy) を消し、本来消すべき `isLink=false` (キャッシュ実体) を残していた。本家 `CleanRemoteFilesProcessorService` 同様 `userHost IS NOT NULL AND isLink=false` を対象に
- **object storage の物理オブジェクトを削除**: access/thumbnail/webpublic オブジェクトを削除してから DB 行を削除 (旧実装は DB 行のみ削除で物理ファイルが orphan 化)

### `/api/admin/delete-all-files-of-a-user` (MEDIUM)
- DB 行のみ削除で物理ファイルが orphan 化していた問題を修正 (storage 配線時はオブジェクトも削除)

### 実装
- `StorageDeleter` interface (`Delete(accessKey) error`) を admin handler に追加し、router で `driveStorage` を配線
- repo に `ListRemoteCache` / `ListByUserAll` / `DeleteByIDs` を追加、`DeleteRemoteCache` の条件を `isLink=false` に修正
- バッチ削除 (100件/バッチ, 最大10000反復の安全弁)。storage 未配線時は DB 行のみ削除 (条件は修正済)

## テスト
- admin: condition flip 回帰 guard (cached削除/link-only保持)、storage path (access/thumbnail/webpublic 削除)、**multi-batch (150件) 終了**、**storage Delete 失敗の best-effort 続行**、list/DeleteByIDs エラー→500、**maxBatches 安全弁での有限終了**、webpublic key + 空文字 skip
- repo: `ListRemoteCache`/`ListByUserAll`/`DeleteByIDs`、`DeleteOrphansAndRemoteCache` の isLink flip
- mock: エラー注入フィールド (`ListRemoteCacheErr`/`DeleteByIDsErr`/`DeleteByIDsNoOp`) + failable storage stub を追加
- 実行: `go test ./internal/api/admin/... ./internal/repository/...` pass (repository 90.4% / admin 89.0%)、`gofmt -s`/`go vet` clean
- 注: `TestFederationUpdateInstance_Integration*` 2件はローカル共有テスト DB の残留行による既存失敗で本PR無関係

## 監査メモ
敵対的レビュー workflow (4観点 review→verify, 確定18件) を実施。HIGH 0。確定 Medium (storage Delete 失敗の握り潰し + 常に204 で DB-only 経路の500と非整合 / multi-batch・error・best-effort の test gap) を修正: storage 削除失敗を slog 化し DB 失敗時は500を返すよう統一、テストを追加。Low の意図的 divergence (thumbnail/webpublic を URL でなく key 有無で削除=best-effort、storedInternal のローカル実体は S3 backend では消えない #1414 由来) はコメント明記。dead な dbQueue processor を指していたコメントも訂正。

## 残り (H-PR8 後続スライス / 本バッチ defer)
- defer: `delete_account` processor の storage orphan (account 削除経路、別 finding)、cron `clean` processor (userIp prune 等、別 missing-processor finding)
- 別スライス: notification-recipient / relays-add INVALID_URL / federation update-instance

🤖 Generated with [Claude Code](https://claude.com/claude-code)