### PR TITLE
Fix admin federation/relays parity: relays/add INVALID_URL + instance-not-found 500 + toPuny host 正規化

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Fix: `/api/admin/relays/add` が inbox URL のプロトコルを検証せず、`http://` や非 URL でもそのまま relay 行を作成しようとしていた問題を修正 (本家同様 https 以外 / parse 失敗を `INVALID_URL` で弾く)。あわせて `/api/admin/federation/update-instance`・`/api/admin/federation/refresh-remote-instance-metadata` が指定ホストの instance 行が存在しない場合に無言で 204 を返していた問題を修正 (本家同様 instance not found を 500 で伝播)。両エンドポイントで lookup 前にホストを toPuny 正規化 (punycode + 小文字化) するようにし、大文字混じり / IDN ホストでも instance を引けるように (本家 `utilityService.toPuny` 相当)。注: 取り込み側 (ActivityPub actor 解決) のホスト正規化は別スコープのため、生 Unicode で保存された IDN ホストとの整合は今後の課題
+
 - Fix: `/api/admin/drive/clean-remote-files` の削除対象条件が逆 (`isLink=true` のリンク専用プロキシを消し、本来消すべき `isLink=false` のキャッシュ実体を残していた) で、かつオブジェクトストレージの物理ファイルを消していなかった問題を修正 (本家同様 `userHost IS NOT NULL AND isLink=false` を対象に、access/thumbnail/webpublic オブジェクトを削除してから DB 行を削除)。`/api/admin/delete-all-files-of-a-user` も DB 行のみ削除で物理ファイルが orphan 化していた問題を修正 (storage バックエンド配線時はオブジェクトも削除)
 
 - Fix: `/api/admin/queue/stats` のレスポンスが `{deliver, inbox}` の2キーのみで本家の `db`/`objectStorage` キーを欠き、各値も `completed`/`failed` を含んでいなかった問題を修正 (本家同様 4キー + QueueCount `{waiting,active,completed,failed,delayed}`)。`/api/admin/queue/{remove-job,retry-job,show-job,show-job-logs}` が本家の `jobId` パラメータを受け付けず `id` しか読まなかった問題 (`jobId` を優先、`id` も後方互換) と、`/api/admin/queue/clear` が `state` パラメータを無視して常に pending のみ削除していた問題 (本家同様 state 別に削除、`*` で全 state) も修正。あわせて `queues`/`queue-stats` の `metrics.completed`/`failed` に必須の `meta` オブジェクトが欠けていた問題と、`/api/admin/queue/jobs` の `search` パラメータが無視されていた問題 (本家同様 JSON 表現への全 term マッチで最大100件) を修正

--- a/internal/api/admin/federation_admin.go
+++ b/internal/api/admin/federation_admin.go
@@ -3,13 +3,34 @@ package admin
 import (
 	"log/slog"
 	"net/http"
+	"strings"
 
 	"github.com/labstack/echo/v4"
+	"golang.org/x/net/idna"
+
 	"github.com/shiroha-a/mk/internal/api/apierr"
 	"github.com/shiroha-a/mk/internal/core/moderationlog"
 	"github.com/shiroha-a/mk/internal/model"
 	"github.com/shiroha-a/mk/internal/queue"
 )
+
+// toPunyHost normalizes a host the same way upstream UtilityService.toPuny does
+// (domainToASCII(host.toLowerCase()), node:url / UTS#46)。Go では idna.ToASCII の
+// default (非 transitional) profile がこれに最も近い。idna.ToASCII が失敗する不正
+// host は小文字化のみで返し、後段の FindByHost に「見つからない」と判定させる。
+//
+// 注意: mk-go の取り込み側 (resolver.hostFromURI / RegisterFromHost) は host を
+// 生のまま保存し punycode 正規化していない。canonical な AP actor URI は authority
+// を punycode 小文字で持つため大半のリモート instance は本 lookup と一致するが、
+// 生 Unicode の IDN host で保存された行は形式が食い違い得る。保存側の正規化統一は
+// 別スコープ (federation 層) の課題として残す。
+func toPunyHost(host string) string {
+	lower := strings.ToLower(host)
+	if ascii, err := idna.ToASCII(lower); err == nil {
+		return ascii
+	}
+	return lower
+}
 
 // FederationDeleteAllFiles handles POST /api/admin/federation/delete-all-files.
 //
@@ -46,10 +67,20 @@ func (h *Handler) FederationRefreshRemoteInstanceMetadata(c echo.Context) error 
 	if h.instanceMetadataFetcher == nil || req.Host == "" {
 		return c.NoContent(http.StatusNoContent)
 	}
-	// fetch 失敗はユーザーへ明示的にエラー返す必要はない (frontendは成功前提
-	// でUI更新するだけ)。ログに残してリトライ可能な状態にしておく。
-	if err := h.instanceMetadataFetcher.Fetch(req.Host); err != nil {
-		slog.Warn("federation refresh metadata failed", "host", req.Host, "err", err)
+	host := toPunyHost(req.Host)
+	// upstream は findOneBy({host: toPuny(host)}) == null で
+	// `throw new Error('instance not found')` (= 500 INTERNAL_ERROR) する。
+	// instanceRepo 配線時は事前に存在確認し、未登録 host へのエラーを伝播する。
+	if h.instanceRepo != nil {
+		if _, err := h.instanceRepo.FindByHost(host); err != nil {
+			return apierr.JSONInternalError(c)
+		}
+	}
+	// fetch 失敗はユーザーへ明示的にエラー返す必要はない (upstream も
+	// fetchInstanceMetadata を await せず fire-and-forget する)。ログに残して
+	// リトライ可能な状態にしておく。
+	if err := h.instanceMetadataFetcher.Fetch(host); err != nil {
+		slog.Warn("federation refresh metadata failed", "host", host, "err", err)
 	}
 	return c.NoContent(http.StatusNoContent)
 }
@@ -182,13 +213,17 @@ func (h *Handler) FederationUpdateInstance(c echo.Context) error {
 	if err := c.Bind(&req); err != nil || req.Host == "" {
 		return c.NoContent(http.StatusNoContent)
 	}
+	// upstream は lookup 前に toPuny(host) で punycode / 小文字化する。IDN / 大文字
+	// host でも instance を引けるよう正規化してから FindByHost / UpdateFields に渡す。
+	host := toPunyHost(req.Host)
 	// before snapshot for moderation log diff (`isSuspended` の変化判定 +
-	// `moderationNote` の before/after)。lookup 失敗は instance 不在として
-	// no-op で 204 を返す (元の挙動は単純 Updates 1 回だけだったので失敗時
-	// silent と一貫)。
-	beforePtr, err := h.instanceRepo.FindByHost(req.Host)
+	// `moderationNote` の before/after)。
+	beforePtr, err := h.instanceRepo.FindByHost(host)
 	if err != nil {
-		return c.NoContent(http.StatusNoContent)
+		// upstream は instance==null で `throw new Error('instance not found')`
+		// (= 500 INTERNAL_ERROR) する。旧実装は silent 204 だったが本家に合わせて
+		// エラーを伝播する。
+		return apierr.JSONInternalError(c)
 	}
 	// 値コピーで snapshot を凍結する: UpdateFields の実装によっては同じ struct
 	// を mutate することがあり (例: in-memory mock)、後段の moderation log diff
@@ -200,15 +235,15 @@ func (h *Handler) FederationUpdateInstance(c echo.Context) error {
 	// 時は deep copy への昇格を検討。
 	before := *beforePtr
 	if updates := req.updates(); len(updates) > 0 {
-		if err := h.instanceRepo.UpdateFields(req.Host, updates); err != nil {
+		if err := h.instanceRepo.UpdateFields(host, updates); err != nil {
 			// silently 握り潰すと #724 のように DB 列ミスマッチで NO-OP に
 			// なって moderation log だけ書き込まれる症状が再発する。warn
 			// で残すことで運用者が気付ける。
-			slog.Warn("admin: instance UpdateFields failed", "host", req.Host, "err", err)
+			slog.Warn("admin: instance UpdateFields failed", "host", host, "err", err)
 		} else if req.IsSuspended != nil {
 			// suspensionState を更新したら deliver hot path の suspend 判定
 			// cache を即時失効し、TTL を待たず配送可否へ反映する (#1407 review)。
-			h.invalidateInstanceSuspendCache(req.Host)
+			h.invalidateInstanceSuspendCache(host)
 		}
 	}
 	// suspend / unsuspend と moderationNote 変更で個別 log を出す。

--- a/internal/api/admin/federation_admin_test.go
+++ b/internal/api/admin/federation_admin_test.go
@@ -88,6 +88,31 @@ func TestFederationRefreshRemoteInstanceMetadata_FetchError_Still204(t *testing.
 	assert.Equal(t, []string{"remote.example"}, fetcher.calls)
 }
 
+// instanceRepo 配線時、未登録 host への refresh は upstream 同様 500 で、
+// fetcher は叩かれない (instance not found)。
+func TestFederationRefreshRemoteInstanceMetadata_HostNotFound(t *testing.T) {
+	h, _, _, _ := newTestHandler(t)
+	fetcher := &stubInstanceMetadataFetcher{}
+	h.SetInstanceMetadataFetcher(fetcher)
+	h.SetInstanceRepo(testutil.NewMockInstanceRepository())
+	rec := doPost(h.FederationRefreshRemoteInstanceMetadata, `{"host":"ghost.example"}`, adminUser)
+	assert.Equal(t, http.StatusInternalServerError, rec.Code)
+	assert.Empty(t, fetcher.calls, "未登録 host では fetcher を叩かない")
+}
+
+// instance 存在時は toPuny 正規化した host で fetcher を叩き 204。
+func TestFederationRefreshRemoteInstanceMetadata_TopunyExists(t *testing.T) {
+	h, _, _, _ := newTestHandler(t)
+	fetcher := &stubInstanceMetadataFetcher{}
+	h.SetInstanceMetadataFetcher(fetcher)
+	instRepo := testutil.NewMockInstanceRepository()
+	require.NoError(t, instRepo.Create(&model.Instance{ID: "i1", Host: "remote.example"}))
+	h.SetInstanceRepo(instRepo)
+	rec := doPost(h.FederationRefreshRemoteInstanceMetadata, `{"host":"Remote.EXAMPLE"}`, adminUser)
+	assert.Equal(t, http.StatusNoContent, rec.Code)
+	assert.Equal(t, []string{"remote.example"}, fetcher.calls, "正規化 host で fetcher を叩く")
+}
+
 func TestFederationRemoveAllFollowing(t *testing.T) {
 	h, _, _, _ := newTestHandler(t)
 	assert.Equal(t, http.StatusNoContent, doPost(h.FederationRemoveAllFollowing, `{}`, adminUser).Code)
@@ -193,12 +218,60 @@ func TestFederationUpdateInstance_NoOpWithoutInstanceRepo(t *testing.T) {
 	assertNoLogWritten(t, repo)
 }
 
-// #676: instance 行が存在しない host への update は no-op (FindByHost が err)。
+// instance 行が存在しない host への update は upstream 同様 500 (instance not found)。
+// 旧実装は silent 204 だったが本家 (throw new Error('instance not found')) に揃える。
 func TestFederationUpdateInstance_HostNotFound(t *testing.T) {
 	h, repo := setupFederationUpdateInstance(t, nil)
 	rec := doPost(h.FederationUpdateInstance, `{"host":"ghost.example","isSuspended":true}`, adminUser)
-	assert.Equal(t, http.StatusNoContent, rec.Code)
+	assert.Equal(t, http.StatusInternalServerError, rec.Code)
 	assertNoLogWritten(t, repo)
+}
+
+// 大文字混じり host でも toPuny (ToLower) 正規化して instance を引ける。
+func TestFederationUpdateInstance_TopunyHostLookup(t *testing.T) {
+	h, repo := setupFederationUpdateInstance(t, &model.Instance{
+		ID:              "inst-puny",
+		Host:            "remote.example",
+		SuspensionState: model.SuspensionStateNone,
+	})
+	rec := doPost(h.FederationUpdateInstance, `{"host":"Remote.EXAMPLE","isSuspended":true}`, adminUser)
+	require.Equal(t, http.StatusNoContent, rec.Code)
+	// lookup が成功して suspend log が 1 件出ることで正規化を確認する。
+	require.Eventually(t, func() bool { return len(repo.Snapshot()) == 1 }, 500*time.Millisecond, 5*time.Millisecond)
+}
+
+// 実 IDN: instance は punycode 小文字 (canonical AP authority / TS drop-in 形式) で
+// 保存され、admin が Unicode IDN 形式で送っても toPuny で punycode 化して引ける。
+// あわせて UpdateFields が正規化 host で効くこと (suspensionState 遷移) を確認する。
+func TestFederationUpdateInstance_IDNHostLookup(t *testing.T) {
+	h, _, _, _ := newTestHandler(t)
+	instRepo := testutil.NewMockInstanceRepository()
+	require.NoError(t, instRepo.Create(&model.Instance{
+		ID: "inst-idn", Host: "xn--caf-dma.example", SuspensionState: model.SuspensionStateNone,
+	}))
+	h.SetInstanceRepo(instRepo)
+	modlog := attachModLog(t, h)
+
+	rec := doPost(h.FederationUpdateInstance, `{"host":"Café.example","isSuspended":true}`, adminUser)
+	require.Equal(t, http.StatusNoContent, rec.Code)
+	// idna.ToASCII が実変換して punycode row を引き、UpdateFields も正規化 host で効く (T5)。
+	require.NotNil(t, instRepo.Instances["xn--caf-dma.example"])
+	assert.Equal(t, model.SuspensionStateManuallySuspended, instRepo.Instances["xn--caf-dma.example"].SuspensionState)
+	require.Eventually(t, func() bool { return len(modlog.Snapshot()) == 1 }, 500*time.Millisecond, 5*time.Millisecond)
+}
+
+// 実 IDN の refresh: punycode 保存 instance を Unicode IDN 入力で引き、fetcher が
+// punycode host で叩かれる。
+func TestFederationRefreshRemoteInstanceMetadata_IDNHostLookup(t *testing.T) {
+	h, _, _, _ := newTestHandler(t)
+	fetcher := &stubInstanceMetadataFetcher{}
+	h.SetInstanceMetadataFetcher(fetcher)
+	instRepo := testutil.NewMockInstanceRepository()
+	require.NoError(t, instRepo.Create(&model.Instance{ID: "i-idn", Host: "xn--caf-dma.example"}))
+	h.SetInstanceRepo(instRepo)
+	rec := doPost(h.FederationRefreshRemoteInstanceMetadata, `{"host":"Café.example"}`, adminUser)
+	assert.Equal(t, http.StatusNoContent, rec.Code)
+	assert.Equal(t, []string{"xn--caf-dma.example"}, fetcher.calls, "fetcher は punycode 化 host で叩かれる")
 }
 
 // #676: isSuspended=true への遷移で suspendRemoteInstance 1 件だけ書く。

--- a/internal/api/admin/relays.go
+++ b/internal/api/admin/relays.go
@@ -2,6 +2,7 @@ package admin
 
 import (
 	"net/http"
+	"net/url"
 	"time"
 
 	"github.com/labstack/echo/v4"
@@ -18,8 +19,12 @@ func (h *Handler) RelaysAdd(c echo.Context) error {
 		Inbox string `json:"inbox"`
 	}
 	_ = c.Bind(&req)
-	if req.Inbox == "" {
-		return c.NoContent(http.StatusNoContent)
+	// upstream add.ts は `new URL(inbox).protocol !== 'https:'` または URL parse
+	// 失敗で INVALID_URL を投げる。https 以外 (http:// / 非 URL / 空) を relay 行
+	// 作成前に弾く。Go の url.Parse は相対 URL でも err にならないので、scheme と
+	// host の存在も明示的に検証する。
+	if u, err := url.Parse(req.Inbox); err != nil || u.Scheme != "https" || u.Host == "" {
+		return c.JSON(http.StatusBadRequest, apierr.Error("INVALID_URL", "Invalid URL", "fb8c92d3-d4e5-44e7-b3d4-800d5cef8b2c"))
 	}
 	if h.relayService != nil {
 		rel, err := h.relayService.Add(c.Request().Context(), req.Inbox)

--- a/internal/api/admin/relays_test.go
+++ b/internal/api/admin/relays_test.go
@@ -36,9 +36,16 @@ func (f *fakeRelaySvc) List(_ context.Context) ([]*model.Relay, error) {
 	return f.retList, f.err
 }
 
-func TestRelaysAdd(t *testing.T) {
+func TestRelaysAdd_InvalidUrl(t *testing.T) {
 	h, _, _, _ := newTestHandler(t)
-	assert.Equal(t, http.StatusNoContent, doPost(h.RelaysAdd, `{}`, adminUser).Code)
+	// upstream add.ts は inbox 未指定 / 空 / https 以外 / 非 URL を INVALID_URL で弾く。
+	assert.Equal(t, http.StatusBadRequest, doPost(h.RelaysAdd, `{}`, adminUser).Code)
+	assert.Equal(t, http.StatusBadRequest, doPost(h.RelaysAdd, `{"inbox":""}`, adminUser).Code)
+	assert.Equal(t, http.StatusBadRequest, doPost(h.RelaysAdd, `{"inbox":"http://r.example/inbox"}`, adminUser).Code)
+	rec := doPost(h.RelaysAdd, `{"inbox":"notaurl"}`, adminUser)
+	assert.Equal(t, http.StatusBadRequest, rec.Code)
+	assert.Contains(t, rec.Body.String(), "INVALID_URL")
+	assert.Contains(t, rec.Body.String(), "fb8c92d3-d4e5-44e7-b3d4-800d5cef8b2c")
 }
 
 func TestRelaysAdd_WithService(t *testing.T) {


### PR DESCRIPTION
## Summary

Misskey TS ↔ mk-go の互換性監査 (admin federation/relays バッチ, H-PR8h)。`/api/admin/relays/add` と `/api/admin/federation/{update-instance,refresh-remote-instance-metadata}` を本家と突合し、URL 検証欠落・instance 不在時のエラー非伝播・host 正規化欠落を修正する。

## 主な変更点

- **`relays/add` の INVALID_URL 検証** (`relays.go`): inbox を `url.Parse` し `scheme != "https"` / host 空 / parse 失敗を `INVALID_URL` (code `INVALID_URL`, id `fb8c92d3-d4e5-44e7-b3d4-800d5cef8b2c`, 400) で reject。本家 `add.ts` の `new URL(inbox).protocol !== 'https:'` 相当。従来の空 inbox→204 special case は撤去 (本家は空でも INVALID_URL を投げる)。
- **`federation/update-instance`・`refresh` の instance-not-found 500** (`federation_admin.go`): 指定 host の instance 行が存在しない場合に無言 204 を返していたのを 500 INTERNAL_ERROR に変更。本家 `throw new Error('instance not found')` (generic → 500) 相当。moderation log を書かず early return する点は維持。
- **toPuny host 正規化**: 両エンドポイントで lookup 前に `toPunyHost` (`idna.ToASCII(strings.ToLower(host))`) でホストを punycode + 小文字化。本家 `utilityService.toPuny` (= `domainToASCII(host.toLowerCase())`) 相当で、大文字混じり / IDN ホストでも instance を引ける。`update-instance` では `UpdateFields` / suspend cache 失効も正規化 host を使用。

### defer (review findings)

- **取り込み側の host 正規化統一** (TP1): mk-go は `resolver.hostFromURI` / `RegisterFromHost` がホストを生のまま保存し punycode 正規化していない。canonical な AP actor URI は authority を punycode 小文字で持つため大半のリモート instance は本 lookup と一致するが、生 Unicode の IDN host で保存された行は形式が食い違い得る。保存側の正規化は federation 層の別スコープとして残す (`toPunyHost` の doc コメントに明記)。
- **RelaysAdd adminDB fallback test** (T1/R3): 本番では relayService が常に配線され到達しない fallback 経路。real-DB infra が必要なため accept。
- 低優先 parity nit: omit 時の INVALID_PARAM vs INVALID_URL 区別 (R1)、WHATWG URL の degenerate 入力差 (R2)、INTERNAL_ERROR の message 文言 (F2、project-wide 既存) は accept。

## テスト

- `relays_test.go`: `TestRelaysAdd_InvalidUrl` (空/`http://`/非 URL → 400 + code/id assert) を追加 (旧 `TestRelaysAdd` の `{}`→204 を置換)。
- `federation_admin_test.go`: `TestFederationUpdateInstance_HostNotFound` を 500 に更新、`_TopunyHostLookup` (大文字 ASCII)、`_IDNHostLookup` (punycode 保存 instance を Unicode IDN 入力で lookup + `suspensionState` 遷移で UpdateFields 正規化 host 伝播を確認)、`FederationRefreshRemoteInstanceMetadata_HostNotFound` / `_TopunyExists` / `_IDNHostLookup` を追加。
- `go test ./internal/api/admin/...`: 追加分含め green (ローカルの `TestFederationUpdateInstance_Integration*` 2件は stale local DB の unique 制約由来で本変更と無関係、CI は fresh DB で green)。
- `go vet ./...` clean / `gofmt -s` 差分なし / `go build ./...` OK / `go.mod` 変更なし (`golang.org/x/net/idna` は既存依存)。
- `internal/api/admin` パッケージ coverage 89.4% (gate 80%)。

## レビュー

実装後に多エージェント敵対的レビュー (relays INVALID_URL / federation not-found 500 / toPuny normalization / tests の4観点 → 各 verify) を実施。確定16件 (high 0 / medium 5 / low 11)。修正可能な doc 誤り・IDN 実変換のテスト網羅 (F4/T2/TP3) と propagation assert (T5) を反映、storage 正規化 (TP1) と adminDB fallback test (T1) を別スコープ/accept として整理。

🤖 Generated with [Claude Code](https://claude.com/claude-code)