### PR TITLE
Fix chat room membership parity: join 招待必須・invitations/create checks+shape・joining membership shape

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Fix: チャットの `/api/chat/rooms/join` が招待なしで誰でも任意のルームに参加できた問題を修正 (本家同様 pending invitation を必須とし、参加成功時に招待を消費する)。`/api/chat/rooms/invitations/create` が自分自身/既存メンバー/招待済み/満室 (50人) のチェックを行わず、レスポンスも 204 で本家の `ChatRoomInvitation` オブジェクト (`id`/`createdAt`/`userId`/`user`/`roomId`/`room`) を返していなかった問題を修正。`/api/chat/rooms/joining` が `ChatRoom[]` を返していたのを本家同様 `ChatRoomMembership[]` (room 付き) に修正。あわせて join/invitation で `MAX_ROOM_MEMBERS=50` の満室ガードを追加。注: 招待時の `chatRoomInvitationReceived` 通知は mk-go の通知基盤が未対応のため後続対応
+
 - Fix: `/api/admin/relays/add` が inbox URL のプロトコルを検証せず、`http://` や非 URL でもそのまま relay 行を作成しようとしていた問題を修正 (本家同様 https 以外 / parse 失敗を `INVALID_URL` で弾く)。あわせて `/api/admin/federation/update-instance`・`/api/admin/federation/refresh-remote-instance-metadata` が指定ホストの instance 行が存在しない場合に無言で 204 を返していた問題を修正 (本家同様 instance not found を 500 で伝播)。両エンドポイントで lookup 前にホストを toPuny 正規化 (punycode + 小文字化) するようにし、大文字混じり / IDN ホストでも instance を引けるように (本家 `utilityService.toPuny` 相当)。注: 取り込み側 (ActivityPub actor 解決) のホスト正規化は別スコープのため、生 Unicode で保存された IDN ホストとの整合は今後の課題
 
 - Fix: `/api/admin/drive/clean-remote-files` の削除対象条件が逆 (`isLink=true` のリンク専用プロキシを消し、本来消すべき `isLink=false` のキャッシュ実体を残していた) で、かつオブジェクトストレージの物理ファイルを消していなかった問題を修正 (本家同様 `userHost IS NOT NULL AND isLink=false` を対象に、access/thumbnail/webpublic オブジェクトを削除してから DB 行を削除)。`/api/admin/delete-all-files-of-a-user` も DB 行のみ削除で物理ファイルが orphan 化していた問題を修正 (storage バックエンド配線時はオブジェクトも削除)

--- a/internal/api/chat/handler.go
+++ b/internal/api/chat/handler.go
@@ -31,7 +31,15 @@ type Handler struct {
 	// 時は当該 endpoint が空配列を返す。
 	fileRepo         repository.DriveFileRepository
 	moderatorChecker ModeratorChecker
+	// userRepo は invitations/create のレスポンス (ChatRoomInvitation.user =
+	// UserLite) で invitee user を解決するために使う (#... H-PR9a)。未配線時は
+	// user field を省略する。
+	userRepo repository.UserRepository
 }
+
+// maxRoomMembers mirrors upstream ChatService.MAX_ROOM_MEMBERS。join /
+// invitations/create で room の membership 数がこの上限に達したら拒否する。
+const maxRoomMembers = 50
 
 // ModeratorChecker reports whether a user has moderator privileges. Implemented
 // by core/role.Service. Used to widen attached-chat-messages from owner-only to
@@ -45,6 +53,10 @@ func (h *Handler) SetDriveFileRepo(r repository.DriveFileRepository) { h.fileRep
 
 // SetModeratorChecker wires a moderator checker for attached-chat-messages.
 func (h *Handler) SetModeratorChecker(m ModeratorChecker) { h.moderatorChecker = m }
+
+// SetUserRepo wires the user repository for resolving invitee UserLite in the
+// invitations/create response.
+func (h *Handler) SetUserRepo(r repository.UserRepository) { h.userRepo = r }
 
 // NewHandler creates a new chat handler.
 func NewHandler(repo repository.ChatRepository, idGen id.Generator) *Handler {
@@ -224,6 +236,48 @@ func (h *Handler) packRoomDetailed(r *model.ChatRoom, meID string) map[string]an
 	}
 	result["isMuted"] = isMuted
 	result["invitationExists"] = invitationExists
+	return result
+}
+
+// packInvitationDetailed builds the upstream ChatRoomInvitation response shape
+// {id, createdAt, userId, user(UserLite), roomId, room(ChatRoom)} used by
+// invitations/create (upstream ChatEntityService.packRoomInvitation)。
+// inv.User / inv.Room が eager load 済みならそれを pack する (caller が事前に
+// 解決して詰める)。meID は room pack の viewer (= inviter)。
+func (h *Handler) packInvitationDetailed(inv *model.ChatRoomInvitation, meID string) map[string]any {
+	result := map[string]any{
+		"id": inv.ID, "userId": inv.UserID, "roomId": inv.RoomID,
+	}
+	if h.idGen != nil {
+		if t, err := h.idGen.ParseTime(inv.ID); err == nil {
+			result["createdAt"] = t.UTC().Format("2006-01-02T15:04:05.000Z")
+		}
+	}
+	if inv.User != nil {
+		result["user"] = packUser(inv.User)
+	}
+	if inv.Room != nil {
+		result["room"] = h.packRoomDetailed(inv.Room, meID)
+	}
+	return result
+}
+
+// packMembershipDetailed builds the upstream ChatRoomMembership response shape
+// {id, createdAt, userId, roomId, room(ChatRoom)} used by rooms/joining
+// (upstream ChatEntityService.packRoomMembership with populateRoom:true,
+// populateUser:false)。m.Room が eager load 済みなら room を pack する。
+func (h *Handler) packMembershipDetailed(m *model.ChatRoomMembership, meID string) map[string]any {
+	result := map[string]any{
+		"id": m.ID, "userId": m.UserID, "roomId": m.RoomID,
+	}
+	if h.idGen != nil {
+		if t, err := h.idGen.ParseTime(m.ID); err == nil {
+			result["createdAt"] = t.UTC().Format("2006-01-02T15:04:05.000Z")
+		}
+	}
+	if m.Room != nil {
+		result["room"] = h.packRoomDetailed(m.Room, meID)
+	}
 	return result
 }
 
@@ -796,23 +850,66 @@ func (h *Handler) InvitationsCreate(c echo.Context) error {
 	}
 	// owner だけが招待を作成・連合できる。これが無いと任意の認証ユーザーが
 	// owner の鍵で署名された Invite を remote へなりすまし送信できてしまう
-	// (#1201 review)。room owner 以外は NO_SUCH_ROOM で弾く (RoomsUpdate と同方針)。
+	// (#1201 review)。upstream create.ts は findMyRoomById==null で先に noSuchRoom
+	// (404) を投げるため、yourself より前に owner-check を行う (error 種別を揃える)。
 	room, err := h.repo.FindRoomByID(req.RoomID)
 	if err != nil || room.OwnerID != user.ID {
-		return c.JSON(http.StatusNotFound, apierr.Error("NO_SUCH_ROOM", "No such room.", "6ab4d7df-5043-57b9-bd5d-ff9908288473"))
+		return c.JSON(http.StatusNotFound, apierr.Error("NO_SUCH_ROOM", "No such room.", "916f9507-49ba-4e90-b57f-1fd4deaa47a5"))
+	}
+	// upstream createRoomInvitation は room 確認後に各 soft-reject を plain Error
+	// (= generic 500) で投げる: yourself / already-member / already-invited /
+	// room-full。owner が inviter のため invitee==owner のケースは yourself に
+	// 収束する (upstream isRoomMember(ownerId===inviteeId) 相当は到達不能)。
+	if user.ID == req.UserID {
+		return apierr.JSONInternalError(c) // 'yourself'
+	}
+	if _, err := h.repo.FindMembership(req.UserID, req.RoomID); err == nil {
+		return apierr.JSONInternalError(c) // 'already member'
+	}
+	if _, err := h.repo.FindInvitation(req.UserID, req.RoomID); err == nil {
+		return apierr.JSONInternalError(c) // 'already invited'
+	}
+	// room-full 判定。count 取得失敗は fail-closed で 500 にする (upstream countBy
+	// 失敗は request を abort する)。owner は membership 行を持たないため count は
+	// 非 owner member 数 = TS countBy({roomId}) と一致 (上限 owner + 50)。
+	members, err := h.repo.ListMembersByRoom(req.RoomID)
+	if err != nil {
+		return apierr.JSONInternalError(c)
+	}
+	if len(members) >= maxRoomMembers {
+		return apierr.JSONInternalError(c) // 'room is full'
+	}
+	// upstream packRoomInvitation は invitee を必須 UserLite として pack し、解決
+	// 失敗時は throw (= 500)。invitee を永続化前に解決し、存在しない user への
+	// invitation 行を作らない。userRepo 未配線 (test / early boot) は degraded path
+	// として user field 省略で続行する (production は router で配線済み)。
+	var inviteeUser *model.User
+	if h.userRepo != nil {
+		u, uerr := h.userRepo.FindByID(req.UserID)
+		if uerr != nil {
+			return apierr.JSONInternalError(c)
+		}
+		inviteeUser = u
 	}
 	inv := &model.ChatRoomInvitation{
 		ID: h.idGen.Generate(time.Now()), UserID: req.UserID, RoomID: req.RoomID,
 	}
 	if err := h.repo.CreateInvitation(inv); err != nil {
-		return c.JSON(http.StatusInternalServerError, apierr.Error("INTERNAL_ERROR", "Internal error.", "5d37dbcb-891e-41ca-a3d6-e690c97775ac"))
+		return apierr.JSONInternalError(c)
 	}
+	// upstream は chatRoomInvitationReceived 通知も作成するが、mk-go の通知基盤
+	// (notification type + entity packer + handler 配線) が未対応のため本 PR では
+	// 未実装。通知対応は H-PR9 follow-up で別途扱う。
+	//
 	// invitee が remote user なら Invite activity を配送する (CherryPick group
 	// chat federation, #1201)。local invitee なら service 側で no-op。
 	if h.svc != nil {
 		h.svc.FederateInvitation(req.RoomID, req.UserID)
 	}
-	return c.NoContent(http.StatusNoContent)
+	// upstream res は packed ChatRoomInvitation を返す (旧 mk-go は 204)。
+	inv.Room = room
+	inv.User = inviteeUser
+	return c.JSON(http.StatusOK, h.packInvitationDetailed(inv, user.ID))
 }
 
 // InvitationsDelete handles POST /api/chat/rooms/invitations/delete.
@@ -1086,25 +1183,52 @@ func (h *Handler) RoomsJoin(c echo.Context) error {
 	if err := c.Bind(&req); err != nil || req.RoomID == "" {
 		return apierr.JSONInvalidParam(c)
 	}
-	if _, err := h.repo.FindRoomByID(req.RoomID); err != nil {
-		return c.JSON(http.StatusNotFound, apierr.Error("NO_SUCH_ROOM", "No such room.", "b3926861-29ef-4df6-98b5-a7c640ad2b5a"))
-	}
-	// UNIQUE制約違反を避けるため既存メンバーは冪等に204を返す
-	if _, err := h.repo.FindMembership(user.ID, req.RoomID); err == nil {
-		return c.NoContent(http.StatusNoContent)
-	}
-	mem := &model.ChatRoomMembership{
-		ID: h.idGen.Generate(time.Now()), UserID: user.ID, RoomID: req.RoomID,
-	}
-	if err := h.repo.CreateMembership(mem); err != nil {
+	// upstream joinToRoom は pending invitation を必須とする (findOneByOrFail)。
+	// これが無いと任意の認証ユーザーが任意の room に勝手に join できる (security)。
+	// invitation 不在は upstream の findOneByOrFail と同じく generic 500。
+	inv, err := h.repo.FindInvitation(user.ID, req.RoomID)
+	if err != nil {
 		return apierr.JSONInternalError(c)
 	}
+	// UNIQUE 制約違反を避けるため既存メンバーは冪等に扱う。新規 join 時のみ
+	// MAX_ROOM_MEMBERS=50 を超える room を拒否する (upstream 'room is full')。
+	if _, merr := h.repo.FindMembership(user.ID, req.RoomID); merr != nil {
+		// count 取得失敗は fail-closed で 500 (upstream countBy 失敗は abort)。
+		members, lerr := h.repo.ListMembersByRoom(req.RoomID)
+		if lerr != nil {
+			return apierr.JSONInternalError(c)
+		}
+		if len(members) >= maxRoomMembers {
+			return apierr.JSONInternalError(c)
+		}
+		mem := &model.ChatRoomMembership{
+			ID: h.idGen.Generate(time.Now()), UserID: user.ID, RoomID: req.RoomID,
+		}
+		if cerr := h.repo.CreateMembership(mem); cerr != nil {
+			return apierr.JSONInternalError(c)
+		}
+	}
+	// upstream は join 成功時に invitation を消費する。
+	_ = h.repo.DeleteInvitation(inv.ID)
 	return c.NoContent(http.StatusNoContent)
 }
 
-// RoomsJoining handles POST /api/chat/rooms/joining (TS-compatible alias for /joined).
+// RoomsJoining handles POST /api/chat/rooms/joining.
+//
+// upstream joining.ts は ChatRoomMembership[] (populateRoom:true,
+// populateUser:false) を返す。旧 mk-go は RoomsJoined (= ChatRoom[]) の alias
+// だったが、shape が異なるため membership を返すよう独立実装する。
 func (h *Handler) RoomsJoining(c echo.Context) error {
-	return h.RoomsJoined(c)
+	user := middleware.GetUser(c)
+	rows, err := h.repo.ListMembershipsByUser(user.ID)
+	if err != nil {
+		return apierr.JSONInternalError(c)
+	}
+	out := make([]map[string]any, 0, len(rows))
+	for _, m := range rows {
+		out = append(out, h.packMembershipDetailed(m, user.ID))
+	}
+	return c.JSON(http.StatusOK, out)
 }
 
 // RoomsMembers handles POST /api/chat/rooms/members.

--- a/internal/api/chat/handler_test.go
+++ b/internal/api/chat/handler_test.go
@@ -623,9 +623,89 @@ func TestReactionsDelete(t *testing.T) {
 
 func TestInvitationsCreate_Success(t *testing.T) {
 	h, repo := newTestHandler()
-	require.NoError(t, repo.CreateRoom(&model.ChatRoom{ID: "r1", Name: "General", OwnerID: u1.ID}))
+	userRepo := testutil.NewMockUserRepository()
+	userRepo.Users["u2"] = u2
+	h.SetUserRepo(userRepo)
+	// owner を populate して nested room.owner (required UserLite) も検証する。
+	require.NoError(t, repo.CreateRoom(&model.ChatRoom{ID: "r1", Name: "General", OwnerID: u1.ID, Owner: u1}))
 	rec := post(h.InvitationsCreate, `{"roomId":"r1","userId":"u2"}`, u1)
-	assert.Equal(t, http.StatusNoContent, rec.Code)
+	require.Equal(t, http.StatusOK, rec.Code)
+	// upstream res は packed ChatRoomInvitation {id, createdAt, userId, user, roomId, room}。
+	var resp map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+	assert.NotEmpty(t, resp["id"])
+	assert.NotEmpty(t, resp["createdAt"])
+	assert.Equal(t, "u2", resp["userId"])
+	assert.Equal(t, "r1", resp["roomId"])
+	user, ok := resp["user"].(map[string]any)
+	require.True(t, ok, "user (UserLite) must be resolved")
+	assert.Equal(t, "u2", user["id"])
+	room, ok := resp["room"].(map[string]any)
+	require.True(t, ok, "room (ChatRoom) must be present")
+	assert.Equal(t, "r1", room["id"])
+	owner, ok := room["owner"].(map[string]any)
+	require.True(t, ok, "room.owner (UserLite) must be present")
+	assert.Equal(t, "u1", owner["id"])
+	// invitation 行が永続化されている。
+	assert.Len(t, repo.Invitations, 1)
+}
+
+// userRepo 配線時に invitee user が存在しない (FindByID err) なら、upstream
+// packRoomInvitation の throw と同じく 500 を返し、invitation 行も作らない。
+func TestInvitationsCreate_InviteeNotFound(t *testing.T) {
+	h, repo := newTestHandler()
+	h.SetUserRepo(testutil.NewMockUserRepository()) // invitee 未登録
+	require.NoError(t, repo.CreateRoom(&model.ChatRoom{ID: "r1", OwnerID: u1.ID}))
+	rec := post(h.InvitationsCreate, `{"roomId":"r1","userId":"ghost"}`, u1)
+	assert.Equal(t, http.StatusInternalServerError, rec.Code)
+	assert.Empty(t, repo.Invitations, "解決不能な invitee には invitation 行を作らない")
+}
+
+// userRepo 未配線 (degraded path) では invitation を作成しつつ user field を省略する。
+func TestInvitationsCreate_NoUserRepoOmitsUser(t *testing.T) {
+	h, repo := newTestHandler() // SetUserRepo しない
+	require.NoError(t, repo.CreateRoom(&model.ChatRoom{ID: "r1", OwnerID: u1.ID}))
+	rec := post(h.InvitationsCreate, `{"roomId":"r1","userId":"u2"}`, u1)
+	require.Equal(t, http.StatusOK, rec.Code)
+	var resp map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+	_, hasUser := resp["user"]
+	assert.False(t, hasUser, "userRepo 未配線では user field を省略する")
+	assert.Len(t, repo.Invitations, 1)
+}
+
+// upstream: inviter==invitee は 'yourself' で拒否 (generic 500)。
+func TestInvitationsCreate_Yourself(t *testing.T) {
+	h, repo := newTestHandler()
+	require.NoError(t, repo.CreateRoom(&model.ChatRoom{ID: "r1", OwnerID: u1.ID}))
+	rec := post(h.InvitationsCreate, `{"roomId":"r1","userId":"u1"}`, u1)
+	assert.Equal(t, http.StatusInternalServerError, rec.Code)
+	assert.Empty(t, repo.Invitations)
+}
+
+// upstream: 既に member / 既に招待済みは拒否 (generic 500)。
+func TestInvitationsCreate_AlreadyMemberOrInvited(t *testing.T) {
+	h, repo := newTestHandler()
+	require.NoError(t, repo.CreateRoom(&model.ChatRoom{ID: "r1", OwnerID: u1.ID}))
+	// already member
+	require.NoError(t, repo.CreateMembership(&model.ChatRoomMembership{ID: "m1", UserID: "u2", RoomID: "r1"}))
+	assert.Equal(t, http.StatusInternalServerError, post(h.InvitationsCreate, `{"roomId":"r1","userId":"u2"}`, u1).Code)
+	// already invited
+	require.NoError(t, repo.CreateInvitation(&model.ChatRoomInvitation{ID: "i1", UserID: "u3", RoomID: "r1"}))
+	assert.Equal(t, http.StatusInternalServerError, post(h.InvitationsCreate, `{"roomId":"r1","userId":"u3"}`, u1).Code)
+}
+
+// upstream: membership 数が MAX_ROOM_MEMBERS(50) 以上なら 'room is full'。
+func TestInvitationsCreate_RoomFull(t *testing.T) {
+	h, repo := newTestHandler()
+	require.NoError(t, repo.CreateRoom(&model.ChatRoom{ID: "r1", OwnerID: u1.ID}))
+	for i := 0; i < maxRoomMembers; i++ {
+		uid := "filler" + string(rune('a'+i))
+		require.NoError(t, repo.CreateMembership(&model.ChatRoomMembership{ID: uid, UserID: uid, RoomID: "r1"}))
+	}
+	rec := post(h.InvitationsCreate, `{"roomId":"r1","userId":"u2"}`, u1)
+	assert.Equal(t, http.StatusInternalServerError, rec.Code)
+	assert.Empty(t, repo.Invitations)
 }
 
 func TestInvitationsCreate_InvalidParam(t *testing.T) {
@@ -949,17 +1029,95 @@ func TestInvitationsOutbox(t *testing.T) {
 
 func TestRoomsJoin(t *testing.T) {
 	h, repo := newTestHandler()
+	// invalid param
 	assert.Equal(t, http.StatusBadRequest, post(h.RoomsJoin, `{}`, u1).Code)
-	assert.Equal(t, http.StatusNotFound, post(h.RoomsJoin, `{"roomId":"ghost"}`, u1).Code)
+	// upstream: pending invitation が無いと join できない (generic 500)。
 	repo.Rooms["r1"] = &model.ChatRoom{ID: "r1", OwnerID: u2.ID}
+	assert.Equal(t, http.StatusInternalServerError, post(h.RoomsJoin, `{"roomId":"r1"}`, u1).Code)
+	assert.Empty(t, repo.Memberships, "invitation 無しでは membership を作らない")
+	// invitation があれば join 成功し、membership 作成 + invitation 消費。
+	require.NoError(t, repo.CreateInvitation(&model.ChatRoomInvitation{ID: "i1", UserID: u1.ID, RoomID: "r1"}))
 	rec := post(h.RoomsJoin, `{"roomId":"r1"}`, u1)
-	assert.Equal(t, http.StatusNoContent, rec.Code)
+	require.Equal(t, http.StatusNoContent, rec.Code)
+	_, mErr := repo.FindMembership(u1.ID, "r1")
+	assert.NoError(t, mErr, "membership が作成される")
+	assert.Empty(t, repo.Invitations, "join 成功で invitation は消費される")
 }
 
+// 既存 member が invitation 付きで再 join しても冪等に 204 (membership 重複なし)
+// + invitation 消費。room-full でも既存 member なら拒否しない (TS との意図的差異)。
+func TestRoomsJoin_Idempotent(t *testing.T) {
+	h, repo := newTestHandler()
+	repo.Rooms["r1"] = &model.ChatRoom{ID: "r1", OwnerID: u2.ID}
+	require.NoError(t, repo.CreateMembership(&model.ChatRoomMembership{ID: "m1", UserID: u1.ID, RoomID: "r1"}))
+	require.NoError(t, repo.CreateInvitation(&model.ChatRoomInvitation{ID: "i1", UserID: u1.ID, RoomID: "r1"}))
+	// 念のため room を満杯にしても既存 member は通る。
+	for i := 0; i < maxRoomMembers; i++ {
+		uid := "filler" + string(rune('a'+i))
+		require.NoError(t, repo.CreateMembership(&model.ChatRoomMembership{ID: uid, UserID: uid, RoomID: "r1"}))
+	}
+	rec := post(h.RoomsJoin, `{"roomId":"r1"}`, u1)
+	require.Equal(t, http.StatusNoContent, rec.Code)
+	mems, _ := repo.ListMembersByRoom("r1")
+	assert.Len(t, mems, maxRoomMembers+1, "membership は重複作成されない (既存 m1 + filler 50)")
+	assert.Empty(t, repo.Invitations, "再 join でも invitation は消費される")
+}
+
+// upstream: membership 数が MAX_ROOM_MEMBERS(50) 以上の room へは新規 join 不可。
+func TestRoomsJoin_RoomFull(t *testing.T) {
+	h, repo := newTestHandler()
+	repo.Rooms["r1"] = &model.ChatRoom{ID: "r1", OwnerID: u2.ID}
+	require.NoError(t, repo.CreateInvitation(&model.ChatRoomInvitation{ID: "i1", UserID: u1.ID, RoomID: "r1"}))
+	for i := 0; i < maxRoomMembers; i++ {
+		uid := "filler" + string(rune('a'+i))
+		require.NoError(t, repo.CreateMembership(&model.ChatRoomMembership{ID: uid, UserID: uid, RoomID: "r1"}))
+	}
+	rec := post(h.RoomsJoin, `{"roomId":"r1"}`, u1)
+	assert.Equal(t, http.StatusInternalServerError, rec.Code)
+	// room-full 失敗時は invitation を消費せず membership も作らない (再試行可能)。
+	assert.NotEmpty(t, repo.Invitations, "room-full では invitation を消費しない")
+	_, mErr := repo.FindMembership(u1.ID, "r1")
+	assert.Error(t, mErr, "room-full では membership を作らない")
+}
+
+// upstream joining.ts は ChatRoomMembership[] (room 付き, id 降順) を返す。
 func TestRoomsJoining(t *testing.T) {
-	h, _ := newTestHandler()
+	h, repo := newTestHandler()
+	idGen, _ := id.NewGenerator("aidx")
+	mid1 := idGen.Generate(time.Now())
+	mid2 := idGen.Generate(time.Now().Add(time.Second)) // newer
+	// owner を populate して nested room.owner (required UserLite) も検証する。
+	require.NoError(t, repo.CreateRoom(&model.ChatRoom{ID: "r1", Name: "General", OwnerID: u2.ID, Owner: u2}))
+	require.NoError(t, repo.CreateRoom(&model.ChatRoom{ID: "r2", Name: "Other", OwnerID: u2.ID, Owner: u2}))
+	require.NoError(t, repo.CreateMembership(&model.ChatRoomMembership{ID: mid1, UserID: u1.ID, RoomID: "r1"}))
+	require.NoError(t, repo.CreateMembership(&model.ChatRoomMembership{ID: mid2, UserID: u1.ID, RoomID: "r2"}))
 	rec := post(h.RoomsJoining, `{}`, u1)
-	assert.Equal(t, http.StatusOK, rec.Code)
+	require.Equal(t, http.StatusOK, rec.Code)
+	var rows []map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &rows))
+	require.Len(t, rows, 2)
+	// id 降順 (新しい mid2 が先頭)。
+	assert.Equal(t, mid2, rows[0]["id"])
+	assert.Equal(t, mid1, rows[1]["id"])
+	assert.Equal(t, u1.ID, rows[0]["userId"])
+	assert.NotEmpty(t, rows[0]["createdAt"])
+	room, ok := rows[0]["room"].(map[string]any)
+	require.True(t, ok, "membership は room (ChatRoom) を populate する")
+	assert.Equal(t, "r2", room["id"])
+	owner, ok := room["owner"].(map[string]any)
+	require.True(t, ok, "room.owner (UserLite) must be present")
+	assert.Equal(t, "u2", owner["id"])
+	// joining は populateUser:false なので user は含めない。
+	_, hasUser := rows[0]["user"]
+	assert.False(t, hasUser)
+}
+
+// repo error 時は 500 を返す。
+func TestRoomsJoining_RepoError(t *testing.T) {
+	h, repo := newTestHandler()
+	repo.ListMembershipsErr = errMock
+	rec := post(h.RoomsJoining, `{}`, u1)
+	assert.Equal(t, http.StatusInternalServerError, rec.Code)
 }
 
 func TestRoomsMembers(t *testing.T) {

--- a/internal/repository/chat.go
+++ b/internal/repository/chat.go
@@ -35,6 +35,7 @@ type ChatRepository interface {
 	UpdateMembership(m *model.ChatRoomMembership) error
 	DeleteMembership(userID, roomID string) error
 	ListMembersByRoom(roomID string) ([]*model.ChatRoomMembership, error)
+	ListMembershipsByUser(userID string) ([]*model.ChatRoomMembership, error)
 
 	// Invitation operations
 	CreateInvitation(inv *model.ChatRoomInvitation) error
@@ -246,6 +247,15 @@ func (r *chatRepository) ListMembersByRoom(roomID string) ([]*model.ChatRoomMemb
 		return nil, err
 	}
 	return members, nil
+}
+
+func (r *chatRepository) ListMembershipsByUser(userID string) ([]*model.ChatRoomMembership, error) {
+	var rows []*model.ChatRoomMembership
+	if err := r.db.Preload("Room").Preload("Room.Owner").Where(`"userId" = ?`, userID).
+		Order(`"id" DESC`).Find(&rows).Error; err != nil {
+		return nil, err
+	}
+	return rows, nil
 }
 
 func (r *chatRepository) CreateInvitation(inv *model.ChatRoomInvitation) error {

--- a/internal/repository/chat_test.go
+++ b/internal/repository/chat_test.go
@@ -169,6 +169,30 @@ func TestChatRepository_Membership(t *testing.T) {
 	require.NoError(t, err)
 	assert.Len(t, joined, 1)
 
+	// ListMembershipsByUser returns the membership rows with Room (+ Owner) populated.
+	memberships, err := repo.ListMembershipsByUser(user.ID)
+	require.NoError(t, err)
+	require.Len(t, memberships, 1)
+	assert.Equal(t, mem.ID, memberships[0].ID)
+	assert.Equal(t, room.ID, memberships[0].RoomID)
+	require.NotNil(t, memberships[0].Room, "Room must be eager-loaded")
+	assert.Equal(t, room.ID, memberships[0].Room.ID)
+	require.NotNil(t, memberships[0].Room.Owner, "Room.Owner must be eager-loaded (required UserLite)")
+	assert.Equal(t, user.ID, memberships[0].Room.Owner.ID)
+
+	// 2 件目を別 room に追加し、id 降順 (新しい順) で返ることを確認する。
+	room2 := &model.ChatRoom{ID: "cr_3b", Name: "Room2", OwnerID: user.ID}
+	require.NoError(t, repo.CreateRoom(room2))
+	defer testDB.Exec(`DELETE FROM "chat_room" WHERE id = ?`, room2.ID)
+	mem2 := &model.ChatRoomMembership{ID: "mem_2", UserID: user.ID, RoomID: room2.ID}
+	require.NoError(t, repo.CreateMembership(mem2))
+	defer testDB.Exec(`DELETE FROM "chat_room_membership" WHERE id = ?`, mem2.ID)
+	ordered, err := repo.ListMembershipsByUser(user.ID)
+	require.NoError(t, err)
+	require.Len(t, ordered, 2)
+	assert.Equal(t, "mem_2", ordered[0].ID, "id 降順で新しい membership が先頭")
+	assert.Equal(t, "mem_1", ordered[1].ID)
+
 	// DeleteMembership
 	require.NoError(t, repo.DeleteMembership(user.ID, room.ID))
 }

--- a/internal/server/router.go
+++ b/internal/server/router.go
@@ -2202,6 +2202,7 @@ func (s *Server) setupRoutes() {
 	// handler が処理する。file の owner-scope (moderator は任意 file 可) (#1218)。
 	chatHandler.SetDriveFileRepo(driveFileRepo)
 	chatHandler.SetModeratorChecker(roleService)
+	chatHandler.SetUserRepo(userRepo)
 	api.POST("/drive/files/attached-chat-messages", chatHandler.AttachedChatMessages, middleware.RequireAuth())
 	api.POST("/chat/rooms/create", chatHandler.RoomsCreate, middleware.RequireAuth())
 	api.POST("/chat/rooms/show", chatHandler.RoomsShow, middleware.RequireAuth())

--- a/internal/testutil/mock_chat.go
+++ b/internal/testutil/mock_chat.go
@@ -41,6 +41,8 @@ type MockChatRepository struct {
 	UpdateErr error
 	// DeleteErr forces DeleteMessage to return this error without removing.
 	DeleteErr error
+	// ListMembershipsErr forces ListMembershipsByUser to return this error.
+	ListMembershipsErr error
 }
 
 // NewMockChatRepository constructs an empty MockChatRepository ready for use.
@@ -251,6 +253,27 @@ func (m *MockChatRepository) ListMembersByRoom(roomID string) ([]*model.ChatRoom
 			out = append(out, mem)
 		}
 	}
+	return out, nil
+}
+
+func (m *MockChatRepository) ListMembershipsByUser(userID string) ([]*model.ChatRoomMembership, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if m.ListMembershipsErr != nil {
+		return nil, m.ListMembershipsErr
+	}
+	out := make([]*model.ChatRoomMembership, 0)
+	for _, mem := range m.Memberships {
+		if mem.UserID == userID {
+			cp := *mem
+			if r, ok := m.Rooms[mem.RoomID]; ok {
+				cp.Room = r
+			}
+			out = append(out, &cp)
+		}
+	}
+	// upstream getMyMemberships は membership id 降順で返す。
+	sort.Slice(out, func(i, j int) bool { return out[i].ID > out[j].ID })
 	return out, nil
 }
 


### PR DESCRIPTION
## Summary

Misskey TS ↔ mk-go の互換性監査 (chat バッチ H-PR9a)。mk-go の chat は Misskey core chat + CherryPick の federation 拡張 (federated group chat) の合成。本 PR は **core chat の parity gap** を本家 `ChatService` / `endpoints/chat/*` / `models/json-schema/chat-*.ts` と突合して修正し、CherryPick の federation 拡張 (`FederateInvitation` 等) は温存する。room membership の書き込みライフサイクル (join / invitations/create / joining) に絞った。

## 主な変更点

- **`rooms/join` の招待必須化 (HIGH security)**: 従来は認証ユーザーなら誰でも任意のルームに join できた。本家 `joinToRoom` 同様に pending invitation を必須とし (不在は generic 500)、join 成功時に invitation を消費する。新規 join 時のみ `MAX_ROOM_MEMBERS=50` の満室ガード (count 取得失敗は fail-closed で 500)。既存メンバーの再 join は冪等。
- **`rooms/invitations/create` の checks + shape (HIGH ×2)**: yourself / already-member / already-invited / room-full の各チェックを追加 (本家は plain Error = generic 500)。レスポンスを 204 から本家 `ChatRoomInvitation` object (`id`/`createdAt`/`userId`/`user`(UserLite)/`roomId`/`room`(ChatRoom)) に変更。invitee user は永続化前に解決し、解決不能なら 500 (本家 `packRoomInvitation` の throw 相当 + orphan invitation 行を作らない)。owner-check を yourself より前に置き、本家 (`findMyRoomById`→noSuchRoom が先行) と error 種別/順序を揃える。`FederateInvitation` は温存。
- **`rooms/joining` の shape (HIGH)**: `ChatRoom[]` の alias から独立し、本家 `joining.ts` 同様 `ChatRoomMembership[]` (`room` populate, `populateUser:false`, id 降順) を返す。
- **repository**: `ListMembershipsByUser(userID)` を追加 (`Room`/`Room.Owner` preload, id DESC)。

### defer (review findings / 別スコープ)

- `chatRoomInvitationReceived` 通知: mk-go の通知基盤 (notification type + entity packer + 配線) が未対応のため本 PR では未実装 (H-PR9 follow-up、ハンドラにコメント明記)。
- pagination (`limit`/`sinceId`/`untilId`): `joining`/`joined`/`owned` 横断で未対応の既存パターンのため defer。
- `messages/react` 検証・`room-timeline` 権限・message-create 検証は **H-PR9b** に分割。

## テスト

- `internal/api/chat/handler_test.go`: InvitationsCreate (Success+shape+room.owner / Yourself / AlreadyMemberOrInvited / RoomFull / InviteeNotFound→500 / NoUserRepoOmitsUser / Error), RoomsJoin (invitation 必須 + 消費 / Idempotent 再 join / RoomFull で invitation 非消費), RoomsJoining (membership shape + id 降順 + room.owner + RepoError) を追加/更新。
- `internal/repository/chat_test.go`: `ListMembershipsByUser` の Room.Owner preload + id 降順を実 DB で検証。
- `go vet ./...` clean / `gofmt -s` 差分なし / `go build ./...` OK。
- coverage: `internal/api/chat` 92.0% (gate 90%)、`internal/repository` 90.4% (gate 90%)。

## レビュー

実装後に多エージェント敵対的レビュー (join / invitations.create / joining / tests の4観点 → 各 verify) を実施。確定18件 (high 0 / medium 2 / low 16)。medium (invitee 解決失敗時の shape 違反、Room.Owner preload のテスト欠如) と low の cheap な parity/robustness/test-gap (fail-closed count、yourself/owner 順序、dead-branch 除去、各種テスト追加) を反映。pagination・通知・rate-limit 等の横断/別スコープ項目は defer として整理。

🤖 Generated with [Claude Code](https://claude.com/claude-code)