### PR TITLE
Fix chat read-access parity: room-timeline/messages/members に member 権限ガード + NO_SUCH_ROOM

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Fix: チャットの `/api/chat/messages/room-timeline`・`/api/chat/messages`・`/api/chat/rooms/members` が、リクエスト元がルームのメンバーかどうかを検証せず、認証済みなら誰でも任意のルームの発言やメンバー一覧を読めた問題を修正 (本家同様 room-timeline/messages はメンバーまたはモデレーター、members はメンバーのみに限定し、それ以外およびルーム不在は `NO_SUCH_ROOM` を返す)
+
 - Fix: チャットの `/api/chat/rooms/join` が招待なしで誰でも任意のルームに参加できた問題を修正 (本家同様 pending invitation を必須とし、参加成功時に招待を消費する)。`/api/chat/rooms/invitations/create` が自分自身/既存メンバー/招待済み/満室 (50人) のチェックを行わず、レスポンスも 204 で本家の `ChatRoomInvitation` オブジェクト (`id`/`createdAt`/`userId`/`user`/`roomId`/`room`) を返していなかった問題を修正。`/api/chat/rooms/joining` が `ChatRoom[]` を返していたのを本家同様 `ChatRoomMembership[]` (room 付き) に修正。あわせて join/invitation で `MAX_ROOM_MEMBERS=50` の満室ガードを追加。注: 招待時の `chatRoomInvitationReceived` 通知は mk-go の通知基盤が未対応のため後続対応
 
 - Fix: `/api/admin/relays/add` が inbox URL のプロトコルを検証せず、`http://` や非 URL でもそのまま relay 行を作成しようとしていた問題を修正 (本家同様 https 以外 / parse 失敗を `INVALID_URL` で弾く)。あわせて `/api/admin/federation/update-instance`・`/api/admin/federation/refresh-remote-instance-metadata` が指定ホストの instance 行が存在しない場合に無言で 204 を返していた問題を修正 (本家同様 instance not found を 500 で伝播)。両エンドポイントで lookup 前にホストを toPuny 正規化 (punycode + 小文字化) するようにし、大文字混じり / IDN ホストでも instance を引けるように (本家 `utilityService.toPuny` 相当)。注: 取り込み側 (ActivityPub actor 解決) のホスト正規化は別スコープのため、生 Unicode で保存された IDN ホストとの整合は今後の課題

--- a/internal/api/chat/handler.go
+++ b/internal/api/chat/handler.go
@@ -262,6 +262,21 @@ func (h *Handler) packInvitationDetailed(inv *model.ChatRoomInvitation, meID str
 	return result
 }
 
+// isRoomMember reports whether userID is the owner of, or a member of, the room
+// (upstream ChatService.isRoomMember: room.ownerId===userId || membership exists)。
+func (h *Handler) isRoomMember(room *model.ChatRoom, userID string) bool {
+	if room.OwnerID == userID {
+		return true
+	}
+	_, err := h.repo.FindMembership(userID, room.ID)
+	return err == nil
+}
+
+// isModerator reports whether userID has moderator privileges (nil-safe).
+func (h *Handler) isModerator(userID string) bool {
+	return h.moderatorChecker != nil && h.moderatorChecker.IsModerator(userID)
+}
+
 // packMembershipDetailed builds the upstream ChatRoomMembership response shape
 // {id, createdAt, userId, roomId, room(ChatRoom)} used by rooms/joining
 // (upstream ChatEntityService.packRoomMembership with populateRoom:true,
@@ -771,6 +786,16 @@ func (h *Handler) Messages(c echo.Context) error {
 	}
 	var msgs []*model.ChatMessage
 	if req.RoomID != "" {
+		// room 発言の閲覧は room-timeline と同じ permission gate を適用する
+		// (member OR moderator)。これが無いと room-timeline を塞いでも本経路から
+		// 任意 room の発言を読めてしまう。
+		room, err := h.repo.FindRoomByID(req.RoomID)
+		if err != nil {
+			return c.JSON(http.StatusNotFound, apierr.Error("NO_SUCH_ROOM", "No such room.", "c4d9f88c-9270-4632-b032-6ed8cee36f7f"))
+		}
+		if !h.isRoomMember(room, user.ID) && !h.isModerator(user.ID) {
+			return c.JSON(http.StatusNotFound, apierr.Error("NO_SUCH_ROOM", "No such room.", "c4d9f88c-9270-4632-b032-6ed8cee36f7f"))
+		}
 		msgs, _ = h.repo.ListMessagesByRoom(req.RoomID, req.Limit)
 	} else if req.UserID != "" {
 		msgs, _ = h.repo.ListMessagesByUser(user.ID, req.UserID, req.Limit)
@@ -1086,6 +1111,16 @@ func (h *Handler) RoomTimeline(c echo.Context) error {
 	if req.Limit > 100 {
 		req.Limit = 100
 	}
+	// upstream room-timeline.ts: room 不在 / 閲覧権限なし (member でも moderator でも
+	// ない) は NO_SUCH_ROOM。これが無いと任意の認証ユーザーが任意 room の発言を
+	// 読めてしまう (security)。owner は isRoomMember で member 扱い。
+	room, err := h.repo.FindRoomByID(req.RoomID)
+	if err != nil {
+		return c.JSON(http.StatusNotFound, apierr.Error("NO_SUCH_ROOM", "No such room.", "c4d9f88c-9270-4632-b032-6ed8cee36f7f"))
+	}
+	if !h.isRoomMember(room, user.ID) && !h.isModerator(user.ID) {
+		return c.JSON(http.StatusNotFound, apierr.Error("NO_SUCH_ROOM", "No such room.", "c4d9f88c-9270-4632-b032-6ed8cee36f7f"))
+	}
 	msgs, err := h.repo.ListMessagesByRoom(req.RoomID, req.Limit)
 	if err != nil {
 		return apierr.JSONInternalError(c)
@@ -1233,12 +1268,23 @@ func (h *Handler) RoomsJoining(c echo.Context) error {
 
 // RoomsMembers handles POST /api/chat/rooms/members.
 func (h *Handler) RoomsMembers(c echo.Context) error {
+	user := middleware.GetUser(c)
 	var req struct {
 		RoomID string `json:"roomId"`
 		Limit  int    `json:"limit"`
 	}
 	if err := c.Bind(&req); err != nil || req.RoomID == "" {
 		return apierr.JSONInvalidParam(c)
+	}
+	// upstream members.ts: room 不在 / 非 member は NO_SUCH_ROOM (member-only、
+	// room-timeline と違い moderator は許可しない)。member でない第三者に member
+	// 一覧を晒さない。
+	room, err := h.repo.FindRoomByID(req.RoomID)
+	if err != nil {
+		return c.JSON(http.StatusNotFound, apierr.Error("NO_SUCH_ROOM", "No such room.", "7b9fe84c-eafc-4d21-bf89-485458ed2c18"))
+	}
+	if !h.isRoomMember(room, user.ID) {
+		return c.JSON(http.StatusNotFound, apierr.Error("NO_SUCH_ROOM", "No such room.", "7b9fe84c-eafc-4d21-bf89-485458ed2c18"))
 	}
 	members, err := h.repo.ListMembersByRoom(req.RoomID)
 	if err != nil {

--- a/internal/api/chat/handler_test.go
+++ b/internal/api/chat/handler_test.go
@@ -57,6 +57,18 @@ func post(handler func(echo.Context) error, body string, user *model.User) *http
 var u1 = &model.User{ID: "u1", Username: "alice"}
 var u2 = &model.User{ID: "u2", Username: "bob"}
 
+// assertErrorCode unmarshals an error response and asserts the Misskey error
+// code + id (body shape is {"error": {code, id, message}}).
+func assertErrorCode(t *testing.T, rec *httptest.ResponseRecorder, code, id string) {
+	t.Helper()
+	var resp map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+	errObj, ok := resp["error"].(map[string]any)
+	require.True(t, ok, "response must have error object")
+	assert.Equal(t, code, errObj["code"])
+	assert.Equal(t, id, errObj["id"])
+}
+
 // --- Rooms ---
 
 func TestRoomsCreate_Success(t *testing.T) {
@@ -371,11 +383,29 @@ func TestMessages_WithData(t *testing.T) {
 	base := testutil.NewMockChatRepository()
 	idGen, _ := id.NewGenerator("aidx")
 	h := NewHandler(&mockMsgRepo{base}, idGen)
+	// room 発言の閲覧には member であることが必要 (u1 を owner にする)。
+	base.Rooms["r1"] = &model.ChatRoom{ID: "r1", OwnerID: u1.ID}
 	rec := post(h.Messages, `{"roomId":"r1"}`, u1)
 	assert.Equal(t, http.StatusOK, rec.Code)
 	var resp []any
 	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
 	assert.Len(t, resp, 1)
+}
+
+// /chat/messages の room 経路も room-timeline と同じ permission gate を持つ
+// (非 member は NO_SUCH_ROOM、room-timeline を塞いでも本経路から漏れない)。
+func TestMessages_RoomPermission(t *testing.T) {
+	h, repo := newTestHandler()
+	// 存在しない room → NO_SUCH_ROOM。
+	rec := post(h.Messages, `{"roomId":"r1"}`, u1)
+	require.Equal(t, http.StatusNotFound, rec.Code)
+	assertErrorCode(t, rec, "NO_SUCH_ROOM", "c4d9f88c-9270-4632-b032-6ed8cee36f7f")
+	// 非 member → NO_SUCH_ROOM。
+	repo.Rooms["r1"] = &model.ChatRoom{ID: "r1", OwnerID: u2.ID}
+	assert.Equal(t, http.StatusNotFound, post(h.Messages, `{"roomId":"r1"}`, u1).Code)
+	// member なら閲覧可。
+	require.NoError(t, repo.CreateMembership(&model.ChatRoomMembership{ID: "m1", UserID: u1.ID, RoomID: "r1"}))
+	assert.Equal(t, http.StatusOK, post(h.Messages, `{"roomId":"r1"}`, u1).Code)
 }
 
 func TestMessagesSearch_WithData(t *testing.T) {
@@ -461,7 +491,8 @@ func TestMessagesRead_InvalidParam(t *testing.T) {
 }
 
 func TestMessages_List(t *testing.T) {
-	h, _ := newTestHandler()
+	h, repo := newTestHandler()
+	repo.Rooms["r1"] = &model.ChatRoom{ID: "r1", OwnerID: u1.ID}
 	rec := post(h.Messages, `{"roomId":"r1"}`, u1)
 	assert.Equal(t, http.StatusOK, rec.Code)
 }
@@ -852,6 +883,8 @@ func TestRoomTimeline_MarksReadOnOpen(t *testing.T) {
 	spy := &readMarkSpyRepo{MockChatRepository: testutil.NewMockChatRepository()}
 	idGen, _ := id.NewGenerator("aidx")
 	h := NewHandler(spy, idGen)
+	// u1 を owner にして閲覧権限を満たす。
+	spy.Rooms["r_x"] = &model.ChatRoom{ID: "r_x", OwnerID: u1.ID}
 	rec := post(h.RoomTimeline, `{"roomId":"r_x"}`, u1)
 	assert.Equal(t, http.StatusOK, rec.Code)
 	assert.Equal(t, "u1", spy.markInRoomCalled.reader)
@@ -870,6 +903,7 @@ func TestTimeline_BestEffortReadMark(t *testing.T) {
 	r := &readMarkErrRepo{MockChatRepository: testutil.NewMockChatRepository()}
 	idGen, _ := id.NewGenerator("aidx")
 	h := NewHandler(r, idGen)
+	r.Rooms["r1"] = &model.ChatRoom{ID: "r1", OwnerID: u1.ID}
 	assert.Equal(t, http.StatusOK, post(h.UserTimeline, `{"userId":"u2"}`, u1).Code)
 	assert.Equal(t, http.StatusOK, post(h.RoomTimeline, `{"roomId":"r1"}`, u1).Code)
 }
@@ -931,12 +965,32 @@ func TestUserTimeline(t *testing.T) {
 }
 
 func TestRoomTimeline(t *testing.T) {
-	h, _ := newTestHandler()
+	h, repo := newTestHandler()
 	assert.Equal(t, http.StatusBadRequest, post(h.RoomTimeline, `{}`, u1).Code)
+	// 存在しない room は NO_SUCH_ROOM (endpoint 固有 id)。
+	rec0 := post(h.RoomTimeline, `{"roomId":"r1"}`, u1)
+	require.Equal(t, http.StatusNotFound, rec0.Code)
+	assertErrorCode(t, rec0, "NO_SUCH_ROOM", "c4d9f88c-9270-4632-b032-6ed8cee36f7f")
+	repo.Rooms["r1"] = &model.ChatRoom{ID: "r1", OwnerID: u2.ID}
+	// member でも moderator でもない第三者は NO_SUCH_ROOM。
+	rec1 := post(h.RoomTimeline, `{"roomId":"r1"}`, u1)
+	require.Equal(t, http.StatusNotFound, rec1.Code)
+	assertErrorCode(t, rec1, "NO_SUCH_ROOM", "c4d9f88c-9270-4632-b032-6ed8cee36f7f")
+	// member なら閲覧可。
+	require.NoError(t, repo.CreateMembership(&model.ChatRoomMembership{ID: "m1", UserID: u1.ID, RoomID: "r1"}))
 	rec := post(h.RoomTimeline, `{"roomId":"r1"}`, u1)
 	assert.Equal(t, http.StatusOK, rec.Code)
 	rec2 := post(h.RoomTimeline, `{"roomId":"r1","limit":5}`, u1)
 	assert.Equal(t, http.StatusOK, rec2.Code)
+}
+
+// room-timeline は moderator にも閲覧を許可する (member でなくても)。
+func TestRoomTimeline_ModeratorAllowed(t *testing.T) {
+	h, repo := newTestHandler()
+	h.SetModeratorChecker(fakeModeratorChecker{mods: map[string]bool{u1.ID: true}})
+	repo.Rooms["r1"] = &model.ChatRoom{ID: "r1", OwnerID: u2.ID}
+	rec := post(h.RoomTimeline, `{"roomId":"r1"}`, u1)
+	assert.Equal(t, http.StatusOK, rec.Code)
 }
 
 func TestReadAll(t *testing.T) {
@@ -1121,8 +1175,26 @@ func TestRoomsJoining_RepoError(t *testing.T) {
 }
 
 func TestRoomsMembers(t *testing.T) {
-	h, _ := newTestHandler()
+	h, repo := newTestHandler()
 	assert.Equal(t, http.StatusBadRequest, post(h.RoomsMembers, `{}`, u1).Code)
+	// 存在しない room は NO_SUCH_ROOM (endpoint 固有 id)。
+	rec0 := post(h.RoomsMembers, `{"roomId":"r1"}`, u1)
+	require.Equal(t, http.StatusNotFound, rec0.Code)
+	assertErrorCode(t, rec0, "NO_SUCH_ROOM", "7b9fe84c-eafc-4d21-bf89-485458ed2c18")
+	repo.Rooms["r1"] = &model.ChatRoom{ID: "r1", OwnerID: u2.ID}
+	// 非 member は NO_SUCH_ROOM (members は moderator も許可しない)。
+	h.SetModeratorChecker(fakeModeratorChecker{mods: map[string]bool{u1.ID: true}})
+	assert.Equal(t, http.StatusNotFound, post(h.RoomsMembers, `{"roomId":"r1"}`, u1).Code)
+	// member なら閲覧可。
+	require.NoError(t, repo.CreateMembership(&model.ChatRoomMembership{ID: "m1", UserID: u1.ID, RoomID: "r1"}))
+	rec := post(h.RoomsMembers, `{"roomId":"r1"}`, u1)
+	assert.Equal(t, http.StatusOK, rec.Code)
+}
+
+// owner は member 扱いで自室の member 一覧を閲覧できる (isRoomMember の owner 分岐)。
+func TestRoomsMembers_OwnerAllowed(t *testing.T) {
+	h, repo := newTestHandler()
+	repo.Rooms["r1"] = &model.ChatRoom{ID: "r1", OwnerID: u1.ID}
 	rec := post(h.RoomsMembers, `{"roomId":"r1"}`, u1)
 	assert.Equal(t, http.StatusOK, rec.Code)
 }


### PR DESCRIPTION
## Summary

Misskey TS ↔ mk-go の互換性監査 (chat バッチ H-PR9b: read-access permission)。mk-go の chat は Misskey core + CherryPick federation 拡張の合成。本 PR は chat の **read アクセス権限 gap** を本家 `endpoints/chat/*` と突合して塞ぐ (federation 拡張は不変)。

## 主な変更点

- **`messages/room-timeline` の権限ガード (HIGH security)**: 従来は認証済みなら誰でも任意ルームの発言を読めた。本家 `room-timeline.ts` + `hasPermissionToViewRoomTimeline` 同様、ルーム不在 / メンバーでもモデレーターでもない場合は `NO_SUCH_ROOM` (id `c4d9f88c-...`)。
- **`/chat/messages` (room 経路) の権限ガード (HIGH security)**: room-timeline と同一の gate を適用。**レビューで発見**: room-timeline だけ塞いでも、同じ `ListMessagesByRoom` を呼ぶ `/chat/messages` の room 経路が無防備で任意ルームの発言を読めたため、同時に修正。
- **`rooms/members` の権限ガード (MEDIUM)**: ルーム不在 / 非メンバーは `NO_SUCH_ROOM` (id `7b9fe84c-...`)。members は member-only でモデレーターは許可しない (本家 `members.ts` と一致、room-timeline との非対称は意図通り)。
- **helper**: `isRoomMember` (owner || membership) / `isModerator` (nil-safe) を追加。owner は member 扱い。

### defer (review findings / 別スコープ)

- `rooms/members` の response shape (本家 `ChatRoomMembership` の `createdAt` 欠落 / `isMuted` 余剰): permission-only の本 finding 対象外、別 follow-up。
- `NO_SUCH_*` の HTTP status (mk-go は 404、本家は kind=client で 400): mk-go 全体の既存規約のため codebase-wide sweep で別途 (body の code/id は本家一致)。
- `FindRoomByID` の DB error と not-found の混同: 既存の chat handler 共通パターン。
- `react` 検証は **H-PR9c**、message-create 検証は **H-PR9d** に分割。

## テスト

- `room-timeline`/`messages`/`members` の not-found・非メンバー (code/id assert)・メンバー OK・owner OK・moderator (room-timeline のみ) OK・members で moderator 拒否 を追加/更新。既存 spy テストにルーム seed を追加。
- `go vet ./...` clean / `gofmt -s` 差分なし / `go build ./...` OK / `internal/api/chat` coverage 92.8% (gate 90%)。

## レビュー

実装後に多エージェント敵対的レビュー (room-timeline / members / helpers+security / tests の4観点 → 各 verify) を実施。確定13件 (high 1 / medium 1 / low 11)。**HIGH = `/chat/messages` の同一 read gap** を本 PR 内で修正、**MEDIUM = 権限テストが code/id を未検証** を assert 追加で対応。残りの low (404 vs 400・shape・DB-err 混同・helper 重複) は pre-existing 規約 / 別スコープとして整理。

🤖 Generated with [Claude Code](https://claude.com/claude-code)