### PR TITLE
Fix media proxy: リモートメディア URL を proxy 経由化して閲覧者 IP 漏洩を防ぐ (#1529)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Fix: リモート(連合先)のメディア URL が API レスポンスに生のまま含まれ、フロントエンドがそれらを直接取得することで閲覧者の IP アドレスが外部サーバーへ漏洩していた問題を修正 (issue #1529)。リモートのドライブファイル(ノート添付の `url`/`thumbnailUrl`/`webpublicUrl`)・ユーザーのアバター/バナー・カスタム絵文字(ノート/ユーザーの `emojis`・絵文字詳細)・連合先インスタンスのアイコン/ファビコン・URL プレビューのサムネイル/アイコンを、すべてメディアプロキシ経由の URL に書き換えるようにした (本家 `DriveFileEntityService` の `getPublicUrl`/`getThumbnailUrl`/`getProxiedUrl` 相当)。`proxyRemoteFiles` 設定を尊重し(アバターは本家同様常時プロキシ)、内部メディアプロキシ利用時は HMAC 署名付き URL を生成する。`/api/admin/drive/show` 等の管理画面や `/api/federation/*` でも同様にリモートメディアをプロキシ化。注: RSS ウィジェット (`/api/fetch-rss`) の画像/エンクロージャは別途対応予定
+
 - Fix: チャットの `/api/chat/messages/room-timeline`・`/api/chat/messages`・`/api/chat/rooms/members` が、リクエスト元がルームのメンバーかどうかを検証せず、認証済みなら誰でも任意のルームの発言やメンバー一覧を読めた問題を修正 (本家同様 room-timeline/messages はメンバーまたはモデレーター、members はメンバーのみに限定し、それ以外およびルーム不在は `NO_SUCH_ROOM` を返す)
 
 - Fix: チャットの `/api/chat/rooms/join` が招待なしで誰でも任意のルームに参加できた問題を修正 (本家同様 pending invitation を必須とし、参加成功時に招待を消費する)。`/api/chat/rooms/invitations/create` が自分自身/既存メンバー/招待済み/満室 (50人) のチェックを行わず、レスポンスも 204 で本家の `ChatRoomInvitation` オブジェクト (`id`/`createdAt`/`userId`/`user`/`roomId`/`room`) を返していなかった問題を修正。`/api/chat/rooms/joining` が `ChatRoom[]` を返していたのを本家同様 `ChatRoomMembership[]` (room 付き) に修正。あわせて join/invitation で `MAX_ROOM_MEMBERS=50` の満室ガードを追加。注: 招待時の `chatRoomInvitationReceived` 通知は mk-go の通知基盤が未対応のため後続対応

--- a/internal/api/admin/drive.go
+++ b/internal/api/admin/drive.go
@@ -234,6 +234,22 @@ func (h *Handler) DriveShowFile(c echo.Context) error {
 // モデレーターから守る制限)。両 field とも `nil` で omit せず明示 null を
 // emit する (upstream の `optional: false, nullable: true` schema 通り)。
 func (h *Handler) packAdminDriveShowFile(f *model.DriveFile, viewer *model.User) map[string]any {
+	// リモートファイルの url/thumbnailUrl/webpublicUrl は外部 URL なので、admin が
+	// drive 一覧を開いただけで moderator の IP が連合先へ漏洩する (issue #1529)。
+	// browser が img src として取得するこれら 3 つを proxy 経由にする (uri/accessKey
+	// 等は moderation 用の raw メタなのでそのまま)。
+	fileURL := f.URL
+	thumbURL := f.ThumbnailURL
+	webpublicURL := f.WebpublicURL
+	if f.UserHost != nil && *f.UserHost != "" {
+		target := f.URL
+		if f.URI != nil && *f.URI != "" {
+			target = *f.URI
+		}
+		fileURL = entity.ProxyRemoteMediaURL(target, "")
+		thumbURL = entity.ProxyRemoteMediaURLPtr(&target, "static")
+		webpublicURL = entity.ProxyRemoteMediaURLPtr(f.WebpublicURL, "")
+	}
 	resp := map[string]any{
 		"id":                 f.ID,
 		"userId":             f.UserID,
@@ -249,9 +265,9 @@ func (h *Handler) packAdminDriveShowFile(f *model.DriveFile, viewer *model.User)
 		"thumbnailAccessKey": f.ThumbnailAccessKey,
 		"accessKey":          f.AccessKey,
 		"webpublicType":      f.WebpublicType,
-		"webpublicUrl":       f.WebpublicURL,
-		"thumbnailUrl":       f.ThumbnailURL,
-		"url":                f.URL,
+		"webpublicUrl":       webpublicURL,
+		"thumbnailUrl":       thumbURL,
+		"url":                fileURL,
 		"storedInternal":     f.StoredInternal,
 		"properties":         driveFileProperties(f.Properties),
 		"blurhash":           f.Blurhash,

--- a/internal/api/federation/handler.go
+++ b/internal/api/federation/handler.go
@@ -10,6 +10,7 @@ import (
 	"github.com/shiroha-a/mk/internal/api/apierr"
 	"github.com/shiroha-a/mk/internal/api/pagination"
 	coreinstance "github.com/shiroha-a/mk/internal/core/instance"
+	"github.com/shiroha-a/mk/internal/entity"
 	"github.com/shiroha-a/mk/internal/misc/id"
 	"github.com/shiroha-a/mk/internal/model"
 	"github.com/shiroha-a/mk/internal/repository"
@@ -222,10 +223,11 @@ func instanceToMap(inst *model.Instance, hosts coreinstance.FederationHostSets, 
 		"description":             inst.Description,
 		"maintainerName":          inst.MaintainerName,
 		"maintainerEmail":         inst.MaintainerEmail,
-		"iconUrl":                 inst.IconURL,
-		"faviconUrl":              inst.FaviconURL,
-		"themeColor":              inst.ThemeColor,
-		"infoUpdatedAt":           inst.InfoUpdatedAt,
-		"moderationNote":          moderationNote,
+		// リモートインスタンスの icon/favicon を proxy 経由にする (issue #1529)。
+		"iconUrl":        entity.ProxyRemoteMediaURLPtr(inst.IconURL, ""),
+		"faviconUrl":     entity.ProxyRemoteMediaURLPtr(inst.FaviconURL, ""),
+		"themeColor":     inst.ThemeColor,
+		"infoUpdatedAt":  inst.InfoUpdatedAt,
+		"moderationNote": moderationNote,
 	}
 }

--- a/internal/api/federation/host_listings.go
+++ b/internal/api/federation/host_listings.go
@@ -6,6 +6,7 @@ import (
 	"github.com/labstack/echo/v4"
 	"github.com/shiroha-a/mk/internal/api/apierr"
 	"github.com/shiroha-a/mk/internal/api/pagination"
+	"github.com/shiroha-a/mk/internal/entity"
 	"github.com/shiroha-a/mk/internal/model"
 )
 
@@ -79,11 +80,13 @@ func (h *Handler) Users(c echo.Context) error {
 	out := make([]map[string]any, 0, len(users))
 	for _, u := range users {
 		out = append(out, map[string]any{
-			"id":        u.ID,
-			"username":  u.Username,
-			"host":      u.Host,
-			"name":      u.Name,
-			"avatarUrl": u.AvatarURL,
+			"id":       u.ID,
+			"username": u.Username,
+			"host":     u.Host,
+			"name":     u.Name,
+			// リモートユーザーのアバターは proxy 経由にする (issue #1529)。
+			// IdenticonURL が avatar mode proxy 化と identicon fallback を担う。
+			"avatarUrl": entity.IdenticonURL(u),
 		})
 	}
 	return c.JSON(http.StatusOK, out)

--- a/internal/api/url/handler.go
+++ b/internal/api/url/handler.go
@@ -7,6 +7,7 @@ import (
 	"github.com/labstack/echo/v4"
 	"github.com/shiroha-a/mk/internal/api/apierr"
 	"github.com/shiroha-a/mk/internal/core/urlpreview"
+	"github.com/shiroha-a/mk/internal/entity"
 )
 
 // Handler handles the URL preview endpoint.
@@ -42,5 +43,11 @@ func (h *Handler) Preview(c echo.Context) error {
 		})
 	}
 
+	// thumbnail (OGP og:image) / icon (favicon) は外部サイトの画像。frontend
+	// (MkUrlPreview) がこれらを直接描画するため、proxy 経由に書き換えて閲覧者の
+	// IP が外部サイトへ漏洩するのを防ぐ (issue #1529)。player.url は iframe embed
+	// なので対象外。
+	result.Thumbnail = entity.ProxyRemoteMediaURLPtr(result.Thumbnail, "")
+	result.Icon = entity.ProxyRemoteMediaURLPtr(result.Icon, "")
 	return c.JSON(http.StatusOK, result)
 }

--- a/internal/api/url/handler_test.go
+++ b/internal/api/url/handler_test.go
@@ -10,8 +10,10 @@ import (
 	"github.com/shiroha-a/mk/internal/api/apierr"
 	apiurl "github.com/shiroha-a/mk/internal/api/url"
 	"github.com/shiroha-a/mk/internal/core/urlpreview"
+	"github.com/shiroha-a/mk/internal/entity"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"strings"
 )
 
 // doPreview builds an echo context for GET /api/url?url=<raw> and invokes the
@@ -111,4 +113,37 @@ func TestPreview_Success(t *testing.T) {
 	player, ok := body["player"].(map[string]any)
 	require.True(t, ok, "player は object であること")
 	assert.Nil(t, player["url"], "plain HTML では player.url は null")
+}
+
+// リモートの og:image (thumbnail) / favicon (icon) は proxy 経由に書き換えられ、
+// 閲覧者 IP が外部サイトへ漏洩しない (issue #1529)。
+func TestPreview_RemoteThumbnailProxied(t *testing.T) {
+	entity.SetMediaProxy(func(rawURL, mode string) string {
+		return "https://mk.test/proxy/image.webp?url=" + rawURL + "&sig=SIG"
+	}, func() bool { return true }, false)
+	defer entity.SetMediaProxy(nil, nil, false)
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "text/html")
+		_, _ = w.Write([]byte(`<html><head>
+			<meta property="og:title" content="Hello">
+			<meta property="og:image" content="https://cdn.example.test/img.png">
+		</head><body></body></html>`))
+	}))
+	defer srv.Close()
+
+	f := urlpreview.NewFetcher(urlpreview.Config{
+		Enabled: true, AllowRedirect: true, TimeoutMs: 5000, MaxContentLength: 1 << 20,
+	}, nil, "", nil)
+	f.SetHTTPClient(&http.Client{})
+	h := apiurl.NewHandler(f)
+
+	rec := doPreview(h, srv.URL)
+	require.Equal(t, http.StatusOK, rec.Code)
+	var body map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &body))
+	thumb, _ := body["thumbnail"].(string)
+	if !strings.HasPrefix(thumb, "https://mk.test/proxy/image.webp?url=") {
+		t.Fatalf("url-preview thumbnail not proxied: %q", thumb)
+	}
 }

--- a/internal/api/users/handler.go
+++ b/internal/api/users/handler.go
@@ -240,11 +240,17 @@ func (h *Handler) populateUserEmojis(u *model.User, lite *entity.UserLite) {
 	if err != nil || len(emojis) == 0 {
 		return
 	}
+	// リモートユーザーの絵文字 URL は外部サーバーを指すため、生で返すと閲覧者の
+	// IP が漏洩する (issue #1529)。proxy 有効時はメディアプロキシ経由にする。
+	remote := u.Host != nil && *u.Host != ""
 	m := make(map[string]string, len(emojis))
 	for _, e := range emojis {
 		url := e.PublicURL
 		if url == "" {
 			url = e.OriginalURL
+		}
+		if remote {
+			url = entity.ProxyRemoteMediaURL(url, "")
 		}
 		m[e.Name] = url
 	}
@@ -383,9 +389,10 @@ func (h *Handler) Show(c echo.Context) error {
 				Name:            inst.Name,
 				SoftwareName:    inst.SoftwareName,
 				SoftwareVersion: inst.SoftwareVersion,
-				IconURL:         inst.IconURL,
-				FaviconURL:      inst.FaviconURL,
-				ThemeColor:      inst.ThemeColor,
+				// リモートインスタンスの icon/favicon を proxy 経由にする (issue #1529)。
+				IconURL:    entity.ProxyRemoteMediaURLPtr(inst.IconURL, ""),
+				FaviconURL: entity.ProxyRemoteMediaURLPtr(inst.FaviconURL, ""),
+				ThemeColor: inst.ThemeColor,
 			}
 		}
 	}

--- a/internal/entity/drive.go
+++ b/internal/entity/drive.go
@@ -72,12 +72,52 @@ func PackDriveFile(f *model.DriveFile, idGen id.Generator) DriveFileEntity {
 		Blurhash:     f.Blurhash,
 		Properties:   props,
 		Comment:      f.Comment,
-		URL:          f.URL,
+		URL:          driveFilePublicURL(f),
 		ThumbnailURL: resolveThumbnailURL(f),
-		WebpublicURL: f.WebpublicURL,
+		WebpublicURL: driveFileWebpublicURL(f),
 		FolderID:     f.FolderID,
 		UserID:       f.UserID,
 	}
+}
+
+// isRemoteFile reports whether the drive file belongs to a remote user
+// (userHost set). Remote files are stored link-format with an external `url`,
+// so their URLs must be routed through the media proxy (issue #1529).
+func isRemoteFile(f *model.DriveFile) bool {
+	return f.UserHost != nil && *f.UserHost != ""
+}
+
+// driveFileTarget returns the upstream URL to proxy: the canonical `uri` when
+// present, else the stored `url` (both are the external original for remote
+// link-format files).
+func driveFileTarget(f *model.DriveFile) string {
+	if f.URI != nil && *f.URI != "" {
+		return *f.URI
+	}
+	return f.URL
+}
+
+// driveFilePublicURL mirrors upstream getPublicUrl: remote files are proxied
+// (when proxying is enabled), local files keep their (local) url. Local URLs are
+// served by this instance so they never leak the client IP.
+func driveFilePublicURL(f *model.DriveFile) string {
+	if isRemoteFile(f) && shouldProxyRemoteFile() {
+		return proxyMediaURL(driveFileTarget(f), "")
+	}
+	return f.URL
+}
+
+// driveFileWebpublicURL proxies a remote file's webpublicUrl (rare for
+// link-format remotes, but guard against leaking it when present).
+func driveFileWebpublicURL(f *model.DriveFile) *string {
+	if f.WebpublicURL == nil || *f.WebpublicURL == "" {
+		return f.WebpublicURL
+	}
+	if isRemoteFile(f) && shouldProxyRemoteFile() {
+		u := proxyMediaURL(*f.WebpublicURL, "")
+		return &u
+	}
+	return f.WebpublicURL
 }
 
 // resolveThumbnailURL emulates upstream Misskey's
@@ -91,6 +131,13 @@ func PackDriveFile(f *model.DriveFile, idGen id.Generator) DriveFileEntity {
 // (#460). For non-image types we keep null — frontend skips the
 // thumbnail render path for those.
 func resolveThumbnailURL(f *model.DriveFile) *string {
+	// リモートファイルは thumbnailUrl(外部 doc.Icon 由来)も含め生 URL が漏洩源に
+	// なるため、proxy 有効時は常にメディアプロキシ(static mode)経由にする
+	// (本家 getThumbnailUrl の userHost!=null / isLink&&proxyRemoteFiles 分岐相当)。
+	if isRemoteFile(f) && shouldProxyRemoteFile() {
+		u := proxyMediaURL(driveFileTarget(f), "static")
+		return &u
+	}
 	if f.ThumbnailURL != nil && *f.ThumbnailURL != "" {
 		return f.ThumbnailURL
 	}

--- a/internal/entity/emoji.go
+++ b/internal/entity/emoji.go
@@ -24,6 +24,10 @@ func PackEmojiDetailed(e *model.Emoji) EmojiDetailed {
 	if url == "" {
 		url = e.OriginalURL
 	}
+	// リモート絵文字 (host 付き) の URL は外部を指すため proxy 経由にする (issue #1529)。
+	if e.Host != nil && *e.Host != "" {
+		url = ProxyRemoteMediaURL(url, "")
+	}
 	aliases := make([]string, len(e.Aliases))
 	copy(aliases, e.Aliases)
 	roleIDs := make([]string, len(e.RoleIDsThatCanBeUsedThisEmojiAsReaction))

--- a/internal/entity/emoji_resolver.go
+++ b/internal/entity/emoji_resolver.go
@@ -132,6 +132,12 @@ func NewEmojiResolver(lookup EmojiLookup, notes []*model.Note) *EmojiResolver {
 			if url == "" {
 				url = e.OriginalURL
 			}
+			// リモート絵文字 (host 付き) の URL は外部サーバーを指すため、生で
+			// note.emojis / user.emojis に載せると閲覧者の IP が漏洩する
+			// (issue #1529)。proxy 有効時はメディアプロキシ経由に書き換える。
+			if host != "" {
+				url = ProxyRemoteMediaURL(url, "")
+			}
 			r.cache[e.Name+"@"+host] = url
 		}
 	}

--- a/internal/entity/instance_resolver.go
+++ b/internal/entity/instance_resolver.go
@@ -94,8 +94,10 @@ func instanceLiteFromModel(inst *model.Instance) *InstanceLite {
 		Name:            inst.Name,
 		SoftwareName:    inst.SoftwareName,
 		SoftwareVersion: inst.SoftwareVersion,
-		IconURL:         inst.IconURL,
-		FaviconURL:      inst.FaviconURL,
-		ThemeColor:      inst.ThemeColor,
+		// リモートインスタンスの icon/favicon は外部 URL なので、リモートユーザーの
+		// nested instance としてそのまま返すと閲覧者の IP が漏洩する (issue #1529)。
+		IconURL:    ProxyRemoteMediaURLPtr(inst.IconURL, ""),
+		FaviconURL: ProxyRemoteMediaURLPtr(inst.FaviconURL, ""),
+		ThemeColor: inst.ThemeColor,
 	}
 }

--- a/internal/entity/media_proxy.go
+++ b/internal/entity/media_proxy.go
@@ -1,0 +1,86 @@
+package entity
+
+import "strings"
+
+// Media-proxy URL rewriting (issue #1529).
+//
+// Remote (federated) media URLs must never be handed to clients verbatim:
+// the browser would fetch them directly and leak the user's IP to the remote
+// server. Instead they are rewritten to point at this instance's media proxy
+// (or a configured external proxy), which fetches the upstream object
+// server-side. This mirrors upstream Misskey's
+// DriveFileEntityService.getProxiedUrl / getPublicUrl / getThumbnailUrl.
+
+// mediaProxyBuilder builds a media-proxy URL for an external media URL. rawURL
+// is the external target; mode is "" (image), "static" (thumbnail) or "avatar".
+// The returned URL is HMAC-signed so the proxy authorizes it. nil when the
+// proxy is not wired (e.g. unit tests) — callers then fall back to the raw URL.
+var mediaProxyBuilder func(rawURL, mode string) string
+
+// proxyRemoteFilesFn returns the live `proxyRemoteFiles` meta flag.
+var proxyRemoteFilesFn func() bool
+
+// externalMediaProxyEnabled is true when a dedicated external media proxy is
+// configured (distinct from the internal ${url}/proxy).
+var externalMediaProxyEnabled bool
+
+// SetMediaProxy wires the media-proxy URL builder used to rewrite remote media
+// URLs so clients never request external servers directly (issue #1529).
+// Passing a nil builder disables proxying (raw URLs are returned), which is the
+// default in unit tests.
+func SetMediaProxy(builder func(rawURL, mode string) string, proxyRemoteFiles func() bool, externalEnabled bool) {
+	mediaProxyBuilder = builder
+	proxyRemoteFilesFn = proxyRemoteFiles
+	externalMediaProxyEnabled = externalEnabled
+}
+
+// shouldProxyRemoteFile reports whether remote DriveFile / banner URLs should be
+// routed through the media proxy. Mirrors upstream getPublicUrl/getThumbnailUrl
+// gating: an external proxy is configured, or proxyRemoteFiles is enabled.
+func shouldProxyRemoteFile() bool {
+	if mediaProxyBuilder == nil {
+		return false
+	}
+	if externalMediaProxyEnabled {
+		return true
+	}
+	return proxyRemoteFilesFn != nil && proxyRemoteFilesFn()
+}
+
+// isExternalURL reports whether u is an absolute http(s) URL (a proxy
+// candidate). Local / relative URLs (e.g. /files/..., /identicon/...) are served
+// by this instance and never leak the client IP, so they are left untouched.
+func isExternalURL(u string) bool {
+	return strings.HasPrefix(u, "http://") || strings.HasPrefix(u, "https://")
+}
+
+// proxyMediaURL returns the media-proxy URL for an external media URL, or the
+// raw URL unchanged when the proxy is unavailable or the URL is not external.
+func proxyMediaURL(rawURL, mode string) string {
+	if mediaProxyBuilder == nil || !isExternalURL(rawURL) {
+		return rawURL
+	}
+	return mediaProxyBuilder(rawURL, mode)
+}
+
+// ProxyRemoteMediaURL rewrites an external remote media URL through the media
+// proxy when proxying is enabled (issue #1529). It is the exported entry point
+// for packers outside this package (remote emoji URLs, federation instance
+// icons). Local / relative URLs and the proxying-disabled case return rawURL
+// unchanged. Callers gate on "is this a remote object" before calling.
+func ProxyRemoteMediaURL(rawURL, mode string) string {
+	if !shouldProxyRemoteFile() {
+		return rawURL
+	}
+	return proxyMediaURL(rawURL, mode)
+}
+
+// ProxyRemoteMediaURLPtr is the *string variant of ProxyRemoteMediaURL. A nil or
+// empty pointer is returned unchanged.
+func ProxyRemoteMediaURLPtr(p *string, mode string) *string {
+	if p == nil || *p == "" || !shouldProxyRemoteFile() {
+		return p
+	}
+	v := proxyMediaURL(*p, mode)
+	return &v
+}

--- a/internal/entity/media_proxy_test.go
+++ b/internal/entity/media_proxy_test.go
@@ -1,0 +1,242 @@
+package entity
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/shiroha-a/mk/internal/misc/id"
+	"github.com/shiroha-a/mk/internal/model"
+)
+
+// withTestMediaProxy wires a recognizable media-proxy builder for the duration
+// of the test and restores the disabled default afterwards.
+func withTestMediaProxy(t *testing.T, proxyRemoteFiles, external bool) {
+	t.Helper()
+	SetMediaProxy(func(rawURL, mode string) string {
+		name := mode
+		if name == "" {
+			name = "image"
+		}
+		return "https://mk.test/proxy/" + name + ".webp?url=" + rawURL + "&sig=SIG"
+	}, func() bool { return proxyRemoteFiles }, external)
+	t.Cleanup(func() { SetMediaProxy(nil, nil, false) })
+}
+
+func strp(s string) *string { return &s }
+
+func TestPackDriveFile_RemoteIsProxied(t *testing.T) {
+	withTestMediaProxy(t, true, false)
+	idGen, _ := id.NewGenerator("aidx")
+	ext := "https://remote.example/files/cat.png"
+	f := &model.DriveFile{
+		ID: idGen.Generate(time.Now()), Name: "cat.png", Type: "image/png",
+		URL: ext, URI: strp(ext), UserHost: strp("remote.example"), IsLink: true,
+	}
+	got := PackDriveFile(f, idGen)
+	if !strings.HasPrefix(got.URL, "https://mk.test/proxy/image.webp?url=") {
+		t.Fatalf("url not proxied: %q", got.URL)
+	}
+	if strings.Contains(got.URL, "remote.example/files") == false {
+		// the external target is embedded as the proxied ?url= param
+		t.Fatalf("proxied url missing target: %q", got.URL)
+	}
+	if got.ThumbnailURL == nil || !strings.HasPrefix(*got.ThumbnailURL, "https://mk.test/proxy/static.webp?url=") {
+		t.Fatalf("thumbnail not proxied (static): %v", got.ThumbnailURL)
+	}
+	// the raw external host must never appear as the *scheme+host* of the url
+	// (only inside the ?url= param of the proxy URL).
+	if strings.HasPrefix(got.URL, ext) {
+		t.Fatalf("url leaks external host directly: %q", got.URL)
+	}
+}
+
+func TestPackDriveFile_LocalUnchanged(t *testing.T) {
+	withTestMediaProxy(t, true, false)
+	idGen, _ := id.NewGenerator("aidx")
+	local := "https://mk.test/files/abc"
+	f := &model.DriveFile{
+		ID: idGen.Generate(time.Now()), Name: "a.png", Type: "image/png",
+		URL: local, // UserHost nil => local
+	}
+	got := PackDriveFile(f, idGen)
+	if got.URL != local {
+		t.Fatalf("local url should be unchanged, got %q", got.URL)
+	}
+}
+
+func TestPackDriveFile_NoBuilderRawFallback(t *testing.T) {
+	// builder unset (default) => raw URL even for remote (unit-test safe default)
+	idGen, _ := id.NewGenerator("aidx")
+	ext := "https://remote.example/files/cat.png"
+	f := &model.DriveFile{
+		ID: idGen.Generate(time.Now()), Name: "cat.png", Type: "image/png",
+		URL: ext, URI: strp(ext), UserHost: strp("remote.example"), IsLink: true,
+	}
+	got := PackDriveFile(f, idGen)
+	if got.URL != ext {
+		t.Fatalf("without builder url should be raw, got %q", got.URL)
+	}
+}
+
+func TestPackDriveFile_ProxyRemoteFilesDisabled(t *testing.T) {
+	// proxyRemoteFiles=false and no external proxy => admin opted out, raw URL.
+	withTestMediaProxy(t, false, false)
+	idGen, _ := id.NewGenerator("aidx")
+	ext := "https://remote.example/files/cat.png"
+	f := &model.DriveFile{
+		ID: idGen.Generate(time.Now()), Name: "cat.png", Type: "image/png",
+		URL: ext, URI: strp(ext), UserHost: strp("remote.example"), IsLink: true,
+	}
+	got := PackDriveFile(f, idGen)
+	if got.URL != ext {
+		t.Fatalf("with proxyRemoteFiles off url should be raw, got %q", got.URL)
+	}
+}
+
+func TestPackDriveFile_ExternalProxyForcesProxyEvenIfRemoteFilesOff(t *testing.T) {
+	// externalMediaProxyEnabled=true forces proxying regardless of proxyRemoteFiles.
+	withTestMediaProxy(t, false, true)
+	idGen, _ := id.NewGenerator("aidx")
+	ext := "https://remote.example/files/cat.png"
+	f := &model.DriveFile{
+		ID: idGen.Generate(time.Now()), Name: "cat.png", Type: "image/png",
+		URL: ext, URI: strp(ext), UserHost: strp("remote.example"), IsLink: true,
+	}
+	got := PackDriveFile(f, idGen)
+	if !strings.HasPrefix(got.URL, "https://mk.test/proxy/image.webp?url=") {
+		t.Fatalf("external proxy should force proxying, got %q", got.URL)
+	}
+}
+
+func TestPackDriveFile_RemoteWebpublicProxied(t *testing.T) {
+	withTestMediaProxy(t, true, false)
+	idGen, _ := id.NewGenerator("aidx")
+	ext := "https://remote.example/files/cat.png"
+	wp := "https://remote.example/files/cat.webp"
+	f := &model.DriveFile{
+		ID: idGen.Generate(time.Now()), Name: "cat.png", Type: "image/png",
+		URL: ext, URI: strp(ext), WebpublicURL: strp(wp),
+		UserHost: strp("remote.example"), IsLink: true,
+	}
+	got := PackDriveFile(f, idGen)
+	if got.WebpublicURL == nil || !strings.HasPrefix(*got.WebpublicURL, "https://mk.test/proxy/image.webp?url=") {
+		t.Fatalf("remote webpublicUrl not proxied: %v", got.WebpublicURL)
+	}
+}
+
+// A remote user whose avatar URL is somehow non-external (relative/local) must
+// be left untouched (proxyMediaURL only rewrites absolute http(s) URLs).
+func TestIdenticonURL_RemoteNonExternalAvatarUnchanged(t *testing.T) {
+	withTestMediaProxy(t, true, false)
+	u := &model.User{ID: "u1", Username: "bob", Host: strp("remote.example"), AvatarURL: strp("/files/local-av.png")}
+	got := IdenticonURL(u)
+	if got != "/files/local-av.png" {
+		t.Fatalf("non-external avatar should be unchanged, got %q", got)
+	}
+}
+
+func TestIdenticonURL_RemoteAvatarProxied(t *testing.T) {
+	withTestMediaProxy(t, true, false)
+	u := &model.User{ID: "u1", Username: "bob", Host: strp("remote.example"), AvatarURL: strp("https://remote.example/avatar.png")}
+	got := IdenticonURL(u)
+	if !strings.HasPrefix(got, "https://mk.test/proxy/avatar.webp?url=") {
+		t.Fatalf("remote avatar not proxied (avatar mode): %q", got)
+	}
+}
+
+func TestIdenticonURL_LocalAvatarUnchanged(t *testing.T) {
+	withTestMediaProxy(t, true, false)
+	u := &model.User{ID: "u1", Username: "alice", AvatarURL: strp("https://mk.test/files/av.png")}
+	got := IdenticonURL(u)
+	if got != "https://mk.test/files/av.png" {
+		t.Fatalf("local avatar should be unchanged, got %q", got)
+	}
+}
+
+func TestIdenticonURL_RemoteAvatarAlwaysProxiedEvenIfRemoteFilesOff(t *testing.T) {
+	// avatar mode is always proxied (upstream getPublicUrl avatar branch),
+	// independent of proxyRemoteFiles.
+	withTestMediaProxy(t, false, false)
+	u := &model.User{ID: "u1", Username: "bob", Host: strp("remote.example"), AvatarURL: strp("https://remote.example/avatar.png")}
+	got := IdenticonURL(u)
+	if !strings.HasPrefix(got, "https://mk.test/proxy/avatar.webp?url=") {
+		t.Fatalf("remote avatar should always be proxied, got %q", got)
+	}
+}
+
+func TestIdenticonURL_NoAvatarFallsBackToIdenticon(t *testing.T) {
+	withTestMediaProxy(t, true, false)
+	u := &model.User{ID: "u1", Username: "bob", Host: strp("remote.example")}
+	got := IdenticonURL(u)
+	if got != "/identicon/bob@remote.example" {
+		t.Fatalf("expected identicon fallback, got %q", got)
+	}
+}
+
+func TestPackUserDetailed_RemoteBannerProxied(t *testing.T) {
+	withTestMediaProxy(t, true, false)
+	u := &model.User{ID: "u1", Username: "bob", Host: strp("remote.example"), BannerURL: strp("https://remote.example/banner.png")}
+	d := PackUserDetailed(u, nil)
+	if d.BannerURL == nil || !strings.HasPrefix(*d.BannerURL, "https://mk.test/proxy/image.webp?url=") {
+		t.Fatalf("remote banner not proxied: %v", d.BannerURL)
+	}
+}
+
+func TestPackEmojiDetailed_RemoteProxied(t *testing.T) {
+	withTestMediaProxy(t, true, false)
+	e := &model.Emoji{ID: "e1", Name: "wave", Host: strp("remote.example"), PublicURL: "https://remote.example/e/wave.png"}
+	got := PackEmojiDetailed(e)
+	if !strings.HasPrefix(got.URL, "https://mk.test/proxy/image.webp?url=") {
+		t.Fatalf("remote emoji detailed not proxied: %q", got.URL)
+	}
+}
+
+func TestPackEmojiDetailed_LocalRaw(t *testing.T) {
+	withTestMediaProxy(t, true, false)
+	e := &model.Emoji{ID: "e1", Name: "local", PublicURL: "https://mk.test/e/local.png"}
+	got := PackEmojiDetailed(e)
+	if got.URL != "https://mk.test/e/local.png" {
+		t.Fatalf("local emoji detailed should be raw: %q", got.URL)
+	}
+}
+
+func TestEmojiResolver_RemoteEmojiProxied(t *testing.T) {
+	withTestMediaProxy(t, true, false)
+	lookup := &stubEmojiLookup{data: map[string][]*model.Emoji{
+		"remote.example": {{ID: "e1", Name: "wave", Host: strp("remote.example"), PublicURL: "https://remote.example/e/wave.png"}},
+	}}
+	note := &model.Note{ID: "n1", UserHost: strp("remote.example"), Emojis: []string{"wave"}}
+	r := NewEmojiResolver(lookup, []*model.Note{note})
+	ent := &NoteEntity{}
+	r.PopulateNoteEmojis(note, ent)
+	if !strings.HasPrefix(ent.Emojis["wave"], "https://mk.test/proxy/image.webp?url=") {
+		t.Fatalf("remote emoji in note map not proxied: %q", ent.Emojis["wave"])
+	}
+}
+
+func TestEmojiResolver_LocalEmojiRaw(t *testing.T) {
+	withTestMediaProxy(t, true, false)
+	lookup := &stubEmojiLookup{data: map[string][]*model.Emoji{
+		"": {{ID: "e1", Name: "local", PublicURL: "https://mk.test/e/local.png"}},
+	}}
+	note := &model.Note{ID: "n1", Emojis: []string{"local"}} // UserHost nil => local
+	r := NewEmojiResolver(lookup, []*model.Note{note})
+	ent := &NoteEntity{}
+	r.PopulateNoteEmojis(note, ent)
+	if ent.Emojis["local"] != "https://mk.test/e/local.png" {
+		t.Fatalf("local emoji in note map should be raw: %q", ent.Emojis["local"])
+	}
+}
+
+func TestInstanceLiteFromModel_RemoteIconProxied(t *testing.T) {
+	withTestMediaProxy(t, true, false)
+	inst := &model.Instance{Host: "remote.example", IconURL: strp("https://remote.example/icon.png"), FaviconURL: strp("https://remote.example/fav.ico")}
+	lite := instanceLiteFromModel(inst)
+	if lite.IconURL == nil || !strings.HasPrefix(*lite.IconURL, "https://mk.test/proxy/image.webp?url=") {
+		t.Fatalf("instance icon not proxied: %v", lite.IconURL)
+	}
+	if lite.FaviconURL == nil || !strings.HasPrefix(*lite.FaviconURL, "https://mk.test/proxy/image.webp?url=") {
+		t.Fatalf("instance favicon not proxied: %v", lite.FaviconURL)
+	}
+}

--- a/internal/entity/user.go
+++ b/internal/entity/user.go
@@ -408,6 +408,13 @@ type InstanceLite struct {
 // も同じ規則を使える (#692 / #708 review)。
 func IdenticonURL(u *model.User) string {
 	if u.AvatarURL != nil && *u.AvatarURL != "" {
+		// リモートユーザーのアバターは外部 URL なので、生で返すと閲覧者の IP が
+		// 連合先へ漏洩する (issue #1529)。本家 getPublicUrl の avatar mode と同じく
+		// メディアプロキシ(avatar mode)経由にする。ローカルアバターは local URL の
+		// ため素通し。
+		if u.Host != nil && *u.Host != "" {
+			return proxyMediaURL(*u.AvatarURL, "avatar")
+		}
 		return *u.AvatarURL
 	}
 	host := ""
@@ -415,6 +422,21 @@ func IdenticonURL(u *model.User) string {
 		host = "@" + *u.Host
 	}
 	return "/identicon/" + u.Username + host
+}
+
+// proxyRemoteBannerURL routes a remote user's banner through the media proxy so
+// it does not leak the viewer's IP (issue #1529). Banner follows the normal
+// proxyRemoteFiles gating (unlike avatar, which upstream always proxies). Local
+// banners are served by this instance and left untouched.
+func proxyRemoteBannerURL(u *model.User) *string {
+	if u.BannerURL == nil || *u.BannerURL == "" {
+		return u.BannerURL
+	}
+	if u.Host != nil && *u.Host != "" && shouldProxyRemoteFile() {
+		v := proxyMediaURL(*u.BannerURL, "")
+		return &v
+	}
+	return u.BannerURL
 }
 
 // PackUserLite converts a model.User to a UserLite DTO.
@@ -466,7 +488,7 @@ func PackUserLite(u *model.User) UserLite {
 func PackUserDetailed(u *model.User, profile *model.UserProfile, idGens ...id.Generator) UserDetailed {
 	d := UserDetailed{
 		UserLite:            PackUserLite(u),
-		BannerURL:           u.BannerURL,
+		BannerURL:           proxyRemoteBannerURL(u),
 		BannerBlurhash:      u.BannerBlurhash,
 		IsLocked:            u.IsLocked,
 		IsSuspended:         u.IsSuspended,

--- a/internal/server/router.go
+++ b/internal/server/router.go
@@ -1345,6 +1345,35 @@ func (s *Server) setupRoutes() {
 	// in-memory cache (#761) だが IsSilenced 内の policy merge 自体は per-call
 	// なので、UserDetailed pack は単一 user の detail 取得が主用途であり許容範囲。
 	entity.SetSilencedLookup(roleService)
+	// リモート(連合先)メディアの URL をメディアプロキシ経由に書き換えて、閲覧者の
+	// IP が外部サーバーへ漏洩するのを防ぐ (issue #1529)。生成 URL は
+	// `${mediaProxy}/{image|static|avatar}.webp?url=&(mode=1)&sig=` で、mk-go の
+	// プロキシは HMAC 署名 (mediaProxySecret) を要求するため sig を付与する。
+	// proxyRemoteFiles は meta(DB, 既定 true)を都度参照する。
+	{
+		mpBase := s.config.MediaProxy
+		mpSecret := s.config.MediaProxySecret
+		entity.SetMediaProxy(
+			func(rawURL, mode string) string {
+				name := "image"
+				if mode != "" {
+					name = mode
+				}
+				q := urlpkg.Values{}
+				q.Set("url", rawURL)
+				if mode != "" {
+					q.Set(mode, "1")
+				}
+				q.Set("sig", coremediaproxy.SignURL(mpSecret, rawURL))
+				return mpBase + "/" + name + ".webp?" + q.Encode()
+			},
+			func() bool {
+				m, err := metaRepo.Fetch()
+				return err == nil && m.ProxyRemoteFiles
+			},
+			s.config.ExternalMediaProxyEnabled,
+		)
+	}
 	iHandler.SetNoteFieldResolver(noteFieldResolver)
 	// announcementRepoは後続で構築されるため SetupAdditional() 相当の順序依存があるが、
 	// 現状 announcementRepo := ... の行がここより後にあるため下で wire する。


### PR DESCRIPTION
## Summary

リモート(連合先)のメディア URL が API レスポンスに**生のまま**含まれ、Misskey フロントエンドがそれらを直接 fetch することで**閲覧者の IP アドレスが外部サーバーへ漏洩**していた問題を修正する (issue #1529)。本家 `DriveFileEntityService` の `getPublicUrl`/`getThumbnailUrl`/`getProxiedUrl` に倣い、リモートメディアをメディアプロキシ経由 URL に書き換える。

### 原因

mk-go はリモートノート添付を link 形式 (`url`=外部 URL) で保存し、`PackDriveFile` がそれを生で返していた。アバター・カスタム絵文字・連合先インスタンスのアイコン・URL プレビューのサムネイルも同様に生の外部 URL を返しており、フロントエンド (`MkMediaImage`/`MkUrlPreview` 等は URL を直接描画) が外部へ直接アクセスしていた。

## 主な変更点

- **共有 builder** (`entity.SetMediaProxy`, `internal/entity/media_proxy.go` 新規): `${mediaProxy}/{image|static|avatar}.webp?url=&(mode=1)&sig=` を組み立てる process-wide な proxy URL builder を router で配線。内部プロキシ利用時は `mediaProxySecret` による HMAC 署名を付与 (mk-go の proxy は署名 or allowlist を要求するため)。gate は `externalMediaProxyEnabled || proxyRemoteFiles`(meta, 都度キャッシュ参照)。
- **DriveFile** (`PackDriveFile`): リモートファイルの `url`/`thumbnailUrl`/`webpublicUrl` を proxy 化 (local はそのまま)。
- **アバター/バナー** (`IdenticonURL`/`proxyRemoteBannerURL`): リモートアバターを avatar mode で**常時** proxy 化 (本家準拠)、banner は通常 gate で proxy 化。
- **カスタム絵文字**: `EmojiResolver` (ノート/ユーザーの `emojis` map の単一ソース) + `PackEmojiDetailed` + `users` handler の `populateUserEmojis` で remote emoji URL を proxy 化。
- **連合先インスタンスのアイコン/ファビコン**: `instance_resolver`(リモートユーザーの nested `instance`)・`users/show` の inline 構築・`federation/handler` で proxy 化。
- **`federation/users`**: `avatarUrl` を `IdenticonURL` 経由に。
- **`admin/drive/show`**: リモートファイルの `url`/`thumbnailUrl`/`webpublicUrl` を proxy 化 (moderator の IP 漏洩防止)。
- **URL プレビュー** (`/api/url`): `thumbnail`(og:image)/`icon`(favicon) を proxy 化 (`player.url` は iframe embed なので対象外)。

local メディア・proxy 無効時・builder 未配線(unit test)は素通しでフォールバック。

## レビュー

実装後に多エージェント敵対的レビュー (leak 完全性 / 本家 parity / proxy URL 正当性 / regression+test の4観点) を実施。初版 (DriveFile+avatar+banner) に対し **8 件の残存 leak (HIGH)** を検出 — emoji resolver(ノート/ユーザー emojis の単一ソース)・emoji packer・user emojis・federation users avatar・instance icons を本 PR 内で全て修正。さらに focused 再検証で URL プレビューの thumbnail/icon leak を検出し修正。誤検知も確認・除外: `/api/emojis` は `ListLocal`(ローカル限定) で leak 無し、`metaRepo.Fetch()` は in-memory TTL キャッシュ済で hot-path 退行無し。フロントエンドの client-side proxy (`getProxiedImageUrl`) 有無も確認し、二重 proxy を回避。

## スコープ / defer

- **RSS ウィジェット** (`/api/fetch-rss`) の画像/エンクロージャ: ニッチなウィジェットかつエンクロージャが非画像メディアの可能性があるため follow-up。
- player embed (iframe) URL: 埋め込みプレイヤーの性質上対象外。

## テスト

- `internal/entity/media_proxy_test.go` (新規): DriveFile(remote proxy / local raw / builder nil raw / proxyRemoteFiles off / external forced / webpublic) / avatar(remote always-proxy / local raw / non-external raw / identicon fallback) / banner / emoji(packer・resolver remote/local) / instance icon を網羅。
- `internal/api/url/handler_test.go`: URL プレビュー thumbnail の proxy 化を追加。
- `go vet ./...` clean / `gofmt -s` 差分なし / `go build ./...` OK / `internal/entity` coverage 96.0%。ローカルの `TestFederationUpdateInstance_Integration*` 2件失敗は stale local DB 由来で本変更と無関係 (CI は fresh DB で green)。

Closes #1529

🤖 Generated with [Claude Code](https://claude.com/claude-code)