### PR TITLE
Fix federation quote renote: inbound _misskey_quote/quoteUrl を解決して引用元を表示 (#1527)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Fix: 連合先からの引用ノート (quote renote) の引用元がノートカードに表示されず本文のみになっていた問題を修正 (issue #1527)。inbound の ActivityPub Note 取り込み (`IngestNote`) が `_misskey_quote` / `quoteUrl` を読まず `renoteId` を立てていなかったため、リモートの引用が「引用元なし」で保存されていた。本家 `ApNoteService` 同様に両 URI を順に解決して引用元 note を紐付け (local / 取り込み済みは fetch 無し、未知は fetch、quote サイクルは in-flight guard で遮断)、引用元の `renoteCount` も本家 `NoteCreateService` 準拠で increment する (自己引用・bot は除外)。
+
 - Fix: リモート(連合先)のメディア URL が API レスポンスに生のまま含まれ、フロントエンドがそれらを直接 `<img src>` で取得することで閲覧者の IP アドレスが外部サーバーへ漏洩していた問題を修正 (issue #1529)。pack 時に remote origin を判定して media proxy 経由 URL へ書き換える server 側書き換え層 (`entity.MediaURLContext`) を追加し、本家 `DriveFileEntityService` の `getPublicUrl`/`getThumbnailUrl` 相当を server 側で行う。対象はフロントエンドが verbatim 描画する surface: ドライブファイル(ノート添付の `url`/`thumbnailUrl`/`webpublicUrl`)・ユーザーのアバター/バナー・チャンネルバナー・ロールの `iconUrl`・アナウンスの `imageUrl`・URL プレビューのサムネイル/アイコン・`/api/federation/users` のアバター・`/api/admin/drive/show` (モデレーターの IP 保護)。`url` フィールドは image MIME に限定して書き換え (proxy の passThrough が非 browsersafe MIME を拒否するため、PDF/zip 等のダウンロードを壊さない)、サムネイルは static mode。`proxyRemoteFiles` 設定を尊重し(アバターは本家同様常時プロキシ)、内部メディアプロキシ利用時は HMAC 署名付き URL を生成 (`mediaproxy.SignURL` と byte 一致を parity test で担保)。なおカスタム絵文字と連合先インスタンスのアイコン/ファビコンは、本家フロント (`MkCustomEmoji`/`MkInstanceTicker`) が `meta.mediaProxy` で client 側プロキシ済のため、二重プロキシと本家 API shape からの乖離を避けて raw のまま返す。注: RSS ウィジェット (`/api/fetch-rss`) の画像/エンクロージャは別途対応予定
 
 - Fix: チャットの `/api/chat/messages/room-timeline`・`/api/chat/messages`・`/api/chat/rooms/members` が、リクエスト元がルームのメンバーかどうかを検証せず、認証済みなら誰でも任意のルームの発言やメンバー一覧を読めた問題を修正 (本家同様 room-timeline/messages はメンバーまたはモデレーター、members はメンバーのみに限定し、それ以外およびルーム不在は `NO_SUCH_ROOM` を返す)

--- a/internal/core/federation/resolver.go
+++ b/internal/core/federation/resolver.go
@@ -162,6 +162,10 @@ type Resolver struct {
 	// が連続して届く現実的なケースで thundering herd を抑える。
 	resolveActorGroup singleflight.Group
 	resolveNoteGroup  singleflight.Group
+	// ingesting tracks note URIs currently being ingested (key: AP id) so quote
+	// resolution can break cycles (A が B を quote し B が A を quote する等)。
+	// quote target が in-flight なら fetch を skip する (#1527)。
+	ingesting sync.Map
 }
 
 // NewResolver constructs a Resolver.
@@ -874,6 +878,61 @@ func (r *Resolver) resolveNoteOnce(uri string) (*model.Note, error) {
 	return r.IngestNote(body)
 }
 
+// resolveQuoteTarget resolves the quote target of an inbound note from its
+// `_misskey_quote` / `quoteUrl` URIs (misskeyQuote takes precedence, matching
+// upstream ApNoteService `note._misskey_quote ?? note.quoteUrl`). Returns nil
+// when no quote URI is present or the target cannot be resolved (best-effort:
+// an unresolvable quote degrades to a plain note rather than failing ingest).
+//
+// 既知 note (local ID / 取り込み済み URI) を fetch 無しで優先的に引く。未知 URI は
+// ResolveNote で fetch するが、その URI が現在 ingest 中 (quote cycle) の場合は
+// fetch を skip して無限再帰を防ぐ (#1527)。
+func (r *Resolver) resolveQuoteTarget(misskeyQuote, quoteURL string) *model.Note {
+	if r.noteRepo == nil {
+		return nil
+	}
+	// upstream ApNoteService は `[_misskey_quote, quoteUrl]` を順に解決し、最初に
+	// 成功した note を採用する (`.at(0)`)。通常は両者同値だが、片方しか解決できない
+	// ケースで取りこぼさないよう順に試す。
+	if n := r.resolveQuoteURI(misskeyQuote); n != nil {
+		return n
+	}
+	if quoteURL != misskeyQuote {
+		if n := r.resolveQuoteURI(quoteURL); n != nil {
+			return n
+		}
+	}
+	return nil
+}
+
+// resolveQuoteURI resolves a single quote URI to a local note row. 既知 note
+// (local ID / 取り込み済み URI) は fetch 無しで引き、未知 URI は cycle でなければ
+// ResolveNote で fetch する。空 URI / 解決不能は nil。
+func (r *Resolver) resolveQuoteURI(uri string) *model.Note {
+	if uri == "" {
+		return nil
+	}
+	// 1. ローカル note URI なら ID 抽出して DB から (fetch 不要)。
+	if id := r.extractLocalNoteID(uri); id != "" {
+		if n, err := r.noteRepo.FindByID(id); err == nil {
+			return n
+		}
+		return nil
+	}
+	// 2. 取り込み済みのリモート note なら DB から (fetch 不要)。
+	if n, err := r.noteRepo.FindByURI(uri); err == nil {
+		return n
+	}
+	// 3. 未知 URI: cycle でなければ fetch して取り込む (本家同様)。
+	if _, inflight := r.ingesting.Load(uri); inflight {
+		return nil
+	}
+	if n, err := r.ResolveNote(uri); err == nil {
+		return n
+	}
+	return nil
+}
+
 // IngestNote parses an ActivityStreams Note JSON and persists it as a local
 // row authored by the (resolved) attributedTo actor. 既に同じ URI の note を
 // 取り込み済みなら既存レコードを返す。
@@ -916,6 +975,11 @@ func (r *Resolver) IngestNoteWithCreated(body []byte) (*model.Note, bool, error)
 	if existing, err := r.noteRepo.FindByURI(apNote.ID); err == nil {
 		return existing, false, nil
 	}
+	// quote cycle 遮断用に、この note URI を ingest 中として mark する (#1527)。
+	// quote 解決が fetch するネストした ingest から、この URI への再 fetch を
+	// 検出できる。
+	r.ingesting.Store(apNote.ID, struct{}{})
+	defer r.ingesting.Delete(apNote.ID)
 	// federation policy gate: 直接 handleCreate から受け取った body や、
 	// 中継経由で attributedTo が allowlist 外の host を指している payload を
 	// DB 永続化させない。既存 row hit (上の FindByURI) は素通しで legacy
@@ -981,6 +1045,16 @@ func (r *Resolver) IngestNoteWithCreated(body []byte) (*model.Note, bool, error)
 			note.ReplyUserID = &replyTarget.UserID
 			note.ReplyUserHost = replyTarget.UserHost
 		}
+	}
+	// 引用 renote: upstream ApNoteService と同じく `_misskey_quote` / `quoteUrl` が
+	// 指す note を解決して renoteId に紐付ける (#1527)。これが無いと remote quote が
+	// 「本文だけ」で引用元が表示されない。解決失敗は best-effort で quote 無し扱い。
+	// renoteCount の増分は Create 後 (下方) に本家準拠で行う。
+	quoted := r.resolveQuoteTarget(apNote.MisskeyQuote, apNote.QuoteURL)
+	if quoted != nil && quoted.ID != note.ID {
+		note.RenoteID = &quoted.ID
+		note.RenoteUserID = &quoted.UserID
+		note.RenoteUserHost = quoted.UserHost
 	}
 	// AP vote 判定: reply target が poll を持ち apNote.Name (choice 名) が
 	// 入っていれば「投票」として処理し、note は作らずに早期 return する
@@ -1072,6 +1146,13 @@ func (r *Resolver) IngestNoteWithCreated(body []byte) (*model.Note, bool, error)
 	// 含むようになる。失敗はベストエフォートで無視。
 	if note.ReplyID != nil {
 		_ = r.noteRepo.IncrementCount(*note.ReplyID, "repliesCount", 1)
+	}
+	// 引用 renote は本家 NoteCreateService と同様、対象 note の renoteCount を増分する
+	// (line 786: `data.renote && data.renote.userId !== user.id && !user.isBot`)。
+	// 自分の note の自己引用と bot 投稿は除外する (#1527)。pure renote (Announce) は
+	// handleAnnounce 側で別途 increment 済み。
+	if note.RenoteID != nil && quoted != nil && quoted.UserID != actor.ID && !actor.IsBot {
+		_ = r.noteRepo.IncrementCount(*note.RenoteID, "renoteCount", 1)
 	}
 	// Question (投票) の処理: oneOf/anyOf から Poll レコードを作成
 	if r.pollRepo != nil && note.HasPoll {

--- a/internal/core/federation/resolver.go
+++ b/internal/core/federation/resolver.go
@@ -1046,16 +1046,6 @@ func (r *Resolver) IngestNoteWithCreated(body []byte) (*model.Note, bool, error)
 			note.ReplyUserHost = replyTarget.UserHost
 		}
 	}
-	// 引用 renote: upstream ApNoteService と同じく `_misskey_quote` / `quoteUrl` が
-	// 指す note を解決して renoteId に紐付ける (#1527)。これが無いと remote quote が
-	// 「本文だけ」で引用元が表示されない。解決失敗は best-effort で quote 無し扱い。
-	// renoteCount の増分は Create 後 (下方) に本家準拠で行う。
-	quoted := r.resolveQuoteTarget(apNote.MisskeyQuote, apNote.QuoteURL)
-	if quoted != nil && quoted.ID != note.ID {
-		note.RenoteID = &quoted.ID
-		note.RenoteUserID = &quoted.UserID
-		note.RenoteUserHost = quoted.UserHost
-	}
 	// AP vote 判定: reply target が poll を持ち apNote.Name (choice 名) が
 	// 入っていれば「投票」として処理し、note は作らずに早期 return する
 	// (#690)。Misskey TS の ApNoteService.create と同等の wire format。
@@ -1137,6 +1127,17 @@ func (r *Resolver) IngestNoteWithCreated(body []byte) (*model.Note, bool, error)
 	// Question（投票）の場合はhasPollフラグをCreate前に設定
 	if len(apNote.OneOf) > 0 || len(apNote.AnyOf) > 0 {
 		note.HasPoll = true
+	}
+	// 引用 renote: upstream ApNoteService と同じく `_misskey_quote` / `quoteUrl` が
+	// 指す note を解決して renoteId に紐付ける (#1527)。これが無いと remote quote が
+	// 「本文だけ」で引用元が表示されない。解決失敗は best-effort で quote 無し扱い。
+	// AP vote の早期 return より後 (= 実際に note を作る経路) で解決し、vote object に
+	// quote field が乗っていても無駄な fetch をしない。renoteCount の増分は Create 後。
+	quoted := r.resolveQuoteTarget(apNote.MisskeyQuote, apNote.QuoteURL)
+	if quoted != nil && quoted.ID != note.ID {
+		note.RenoteID = &quoted.ID
+		note.RenoteUserID = &quoted.UserID
+		note.RenoteUserHost = quoted.UserHost
 	}
 	if err := r.noteRepo.Create(note); err != nil {
 		return nil, false, err

--- a/internal/core/federation/resolver_test.go
+++ b/internal/core/federation/resolver_test.go
@@ -4356,3 +4356,327 @@ func TestResolveActor_NewUserIngestsHashtags(t *testing.T) {
 	// Hashtag のみ正規化して取り込む (Emoji は除外)。
 	assert.ElementsMatch(t, []string{"golang", "activitypub"}, []string(user.Tags))
 }
+
+// --- #1527: inbound quote (引用) renote resolution ---
+
+// _misskey_quote が既存 note を指す inbound note は、その note を renote として
+// 紐付ける (fetch 不要 = DB hit)。
+func TestIngestNote_QuoteMisskeyQuote(t *testing.T) {
+	repo := testutil.NewMockUserRepository()
+	noteRepo := testutil.NewMockNoteRepository()
+	quotedURI := "https://remote.example/notes/quoted"
+	noteRepo.Notes["quoted1"] = &model.Note{ID: "quoted1", URI: &quotedURI, UserID: "qu", UserHost: strPtr("remote.example")}
+	urls := activitypub.NewURLBuilder("https://example.com")
+	idGen, _ := id.NewGenerator("aidx")
+	// attributedTo の actor 解決のみ fetch (quote は DB hit)。
+	r := federation.NewResolver(repo, noteRepo, urls, &stubFetcher{body: []byte(sampleActor)}, idGen)
+
+	body := `{
+		"id": "https://remote.example/notes/q1",
+		"type": "Note",
+		"attributedTo": "https://remote.example/users/alice",
+		"content": "見て",
+		"_misskey_quote": "https://remote.example/notes/quoted",
+		"to": ["https://www.w3.org/ns/activitystreams#Public"]
+	}`
+	got, err := r.IngestNote([]byte(body))
+	require.NoError(t, err)
+	require.NotNil(t, got.RenoteID)
+	assert.Equal(t, "quoted1", *got.RenoteID)
+	require.NotNil(t, got.RenoteUserID)
+	assert.Equal(t, "qu", *got.RenoteUserID)
+	require.NotNil(t, got.Text)
+	assert.Equal(t, "見て", *got.Text)
+}
+
+// quoteUrl は _misskey_quote が無いときの fallback。
+func TestIngestNote_QuoteUrlFallback(t *testing.T) {
+	repo := testutil.NewMockUserRepository()
+	noteRepo := testutil.NewMockNoteRepository()
+	quotedURI := "https://remote.example/notes/quoted"
+	noteRepo.Notes["quoted1"] = &model.Note{ID: "quoted1", URI: &quotedURI, UserID: "qu"}
+	urls := activitypub.NewURLBuilder("https://example.com")
+	idGen, _ := id.NewGenerator("aidx")
+	r := federation.NewResolver(repo, noteRepo, urls, &stubFetcher{body: []byte(sampleActor)}, idGen)
+
+	body := `{
+		"id": "https://remote.example/notes/q1",
+		"type": "Note",
+		"attributedTo": "https://remote.example/users/alice",
+		"content": "quote via quoteUrl",
+		"quoteUrl": "https://remote.example/notes/quoted",
+		"to": ["https://www.w3.org/ns/activitystreams#Public"]
+	}`
+	got, err := r.IngestNote([]byte(body))
+	require.NoError(t, err)
+	require.NotNil(t, got.RenoteID)
+	assert.Equal(t, "quoted1", *got.RenoteID)
+}
+
+// quote URI が未知 (DB 未取り込み) なら fetch して取り込み、renote 紐付けする。
+func TestIngestNote_QuoteFetchesUnknownTarget(t *testing.T) {
+	repo := testutil.NewMockUserRepository()
+	noteRepo := testutil.NewMockNoteRepository()
+	urls := activitypub.NewURLBuilder("https://example.com")
+	idGen, _ := id.NewGenerator("aidx")
+	// 1: outer note の actor 解決 / 2: quote 先 note / 3: quote 先 note の actor 解決。
+	quotedNote := `{
+		"id": "https://remote.example/notes/quoted",
+		"type": "Note",
+		"attributedTo": "https://remote.example/users/alice",
+		"content": "original",
+		"to": ["https://www.w3.org/ns/activitystreams#Public"]
+	}`
+	fetcher := &scriptedFetcher{bodies: [][]byte{[]byte(sampleActor), []byte(quotedNote), []byte(sampleActor)}}
+	r := federation.NewResolver(repo, noteRepo, urls, fetcher, idGen)
+
+	body := `{
+		"id": "https://remote.example/notes/q1",
+		"type": "Note",
+		"attributedTo": "https://remote.example/users/alice",
+		"content": "quote of unknown",
+		"_misskey_quote": "https://remote.example/notes/quoted",
+		"to": ["https://www.w3.org/ns/activitystreams#Public"]
+	}`
+	got, err := r.IngestNote([]byte(body))
+	require.NoError(t, err)
+	require.NotNil(t, got.RenoteID, "unknown quote target should be fetched and linked")
+}
+
+// quote field が無いノートは RenoteID nil (通常の投稿)。
+func TestIngestNote_NoQuote(t *testing.T) {
+	repo := testutil.NewMockUserRepository()
+	noteRepo := testutil.NewMockNoteRepository()
+	urls := activitypub.NewURLBuilder("https://example.com")
+	idGen, _ := id.NewGenerator("aidx")
+	r := federation.NewResolver(repo, noteRepo, urls, &stubFetcher{body: []byte(sampleActor)}, idGen)
+	got, err := r.IngestNote([]byte(sampleRemoteNote))
+	require.NoError(t, err)
+	assert.Nil(t, got.RenoteID)
+}
+
+// 解決不能な quote (fetch 失敗) は best-effort で quote 無し扱い (ingest は成功)。
+func TestIngestNote_QuoteUnresolvableDegrades(t *testing.T) {
+	repo := testutil.NewMockUserRepository()
+	noteRepo := testutil.NewMockNoteRepository()
+	urls := activitypub.NewURLBuilder("https://example.com")
+	idGen, _ := id.NewGenerator("aidx")
+	// actor は解決できるが quote fetch は失敗する。
+	fetcher := &scriptedFetcher{bodies: [][]byte{[]byte(sampleActor)}}
+	r := federation.NewResolver(repo, noteRepo, urls, fetcher, idGen)
+	body := `{
+		"id": "https://remote.example/notes/q1",
+		"type": "Note",
+		"attributedTo": "https://remote.example/users/alice",
+		"content": "quote of gone",
+		"_misskey_quote": "https://remote.example/notes/gone",
+		"to": ["https://www.w3.org/ns/activitystreams#Public"]
+	}`
+	got, err := r.IngestNote([]byte(body))
+	require.NoError(t, err)
+	assert.Nil(t, got.RenoteID, "unresolvable quote degrades to plain note")
+	require.NotNil(t, got.Text)
+}
+
+// quote cycle (A が B を quote し B が A を quote) でも無限再帰せず両者を ingest する。
+// 後から辿る側 (cycle 検出) は quote 未解決で degrade する (#1527 在庫 guard)。
+func TestIngestNote_QuoteCycleNoInfiniteRecursion(t *testing.T) {
+	repo := testutil.NewMockUserRepository()
+	noteRepo := testutil.NewMockNoteRepository()
+	urls := activitypub.NewURLBuilder("https://example.com")
+	idGen, _ := id.NewGenerator("aidx")
+	// A.ingest: actor(alice) fetch → quote B fetch → B.ingest: actor は DB hit、
+	// quote A は in-flight で skip。よって body は [actor, B-note] で足りる。
+	bNote := `{
+		"id": "https://remote.example/notes/B",
+		"type": "Note",
+		"attributedTo": "https://remote.example/users/alice",
+		"content": "B quotes A",
+		"_misskey_quote": "https://remote.example/notes/A",
+		"to": ["https://www.w3.org/ns/activitystreams#Public"]
+	}`
+	fetcher := &scriptedFetcher{bodies: [][]byte{[]byte(sampleActor), []byte(bNote)}}
+	r := federation.NewResolver(repo, noteRepo, urls, fetcher, idGen)
+	aBody := `{
+		"id": "https://remote.example/notes/A",
+		"type": "Note",
+		"attributedTo": "https://remote.example/users/alice",
+		"content": "A quotes B",
+		"_misskey_quote": "https://remote.example/notes/B",
+		"to": ["https://www.w3.org/ns/activitystreams#Public"]
+	}`
+	done := make(chan struct{})
+	var got *model.Note
+	var err error
+	go func() {
+		got, err = r.IngestNote([]byte(aBody))
+		close(done)
+	}()
+	select {
+	case <-done:
+	case <-time.After(5 * time.Second):
+		t.Fatal("IngestNote did not terminate (quote cycle caused infinite recursion)")
+	}
+	require.NoError(t, err)
+	require.NotNil(t, got.RenoteID, "A should link its quote B")
+	// 両 note が永続化されている。
+	assert.GreaterOrEqual(t, len(noteRepo.Notes), 2)
+	// cycle を辿った側 (B) は quote 未解決で degrade している (in-flight guard が
+	// A への再 fetch を遮断したため)。
+	var bNoteRow *model.Note
+	for _, n := range noteRepo.Notes {
+		if n.URI != nil && *n.URI == "https://remote.example/notes/B" {
+			bNoteRow = n
+		}
+	}
+	require.NotNil(t, bNoteRow, "B should be persisted")
+	assert.Nil(t, bNoteRow.RenoteID, "B's quote (back to A) is broken by the cycle guard")
+}
+
+// remote note が LOCAL note を quote する場合、URI から local ID を抽出して
+// fetch 無しで紐付ける (resolveQuoteTarget の extractLocalNoteID 経路)。
+func TestIngestNote_QuoteLocalNote(t *testing.T) {
+	repo := testutil.NewMockUserRepository()
+	noteRepo := testutil.NewMockNoteRepository()
+	noteRepo.Notes["localq1"] = &model.Note{ID: "localq1", UserID: "localuser"}
+	urls := activitypub.NewURLBuilder("https://example.com")
+	idGen, _ := id.NewGenerator("aidx")
+	r := federation.NewResolver(repo, noteRepo, urls, &stubFetcher{body: []byte(sampleActor)}, idGen)
+	body := `{
+		"id": "https://remote.example/notes/q1",
+		"type": "Note",
+		"attributedTo": "https://remote.example/users/alice",
+		"content": "quoting a local note",
+		"_misskey_quote": "https://example.com/notes/localq1",
+		"to": ["https://www.w3.org/ns/activitystreams#Public"]
+	}`
+	got, err := r.IngestNote([]byte(body))
+	require.NoError(t, err)
+	require.NotNil(t, got.RenoteID)
+	assert.Equal(t, "localq1", *got.RenoteID)
+}
+
+// local quote URI だが DB に存在しないなら quote 無し扱い (fetch しない)。
+func TestIngestNote_QuoteLocalNoteMissing(t *testing.T) {
+	repo := testutil.NewMockUserRepository()
+	noteRepo := testutil.NewMockNoteRepository()
+	urls := activitypub.NewURLBuilder("https://example.com")
+	idGen, _ := id.NewGenerator("aidx")
+	r := federation.NewResolver(repo, noteRepo, urls, &stubFetcher{body: []byte(sampleActor)}, idGen)
+	body := `{
+		"id": "https://remote.example/notes/q1",
+		"type": "Note",
+		"attributedTo": "https://remote.example/users/alice",
+		"content": "quoting a missing local note",
+		"_misskey_quote": "https://example.com/notes/ghost",
+		"to": ["https://www.w3.org/ns/activitystreams#Public"]
+	}`
+	got, err := r.IngestNote([]byte(body))
+	require.NoError(t, err)
+	assert.Nil(t, got.RenoteID)
+}
+
+// 引用は対象 note の renoteCount を increment する (本家 NoteCreateService:786 準拠)。
+// あわせて RenoteUserHost が denormalize される。
+func TestIngestNote_QuoteIncrementsRenoteCountAndSetsHost(t *testing.T) {
+	repo := testutil.NewMockUserRepository()
+	noteRepo := testutil.NewMockNoteRepository()
+	quotedURI := "https://remote.example/notes/quoted"
+	noteRepo.Notes["quoted1"] = &model.Note{ID: "quoted1", URI: &quotedURI, UserID: "qu", UserHost: strPtr("other.example")}
+	urls := activitypub.NewURLBuilder("https://example.com")
+	idGen, _ := id.NewGenerator("aidx")
+	r := federation.NewResolver(repo, noteRepo, urls, &stubFetcher{body: []byte(sampleActor)}, idGen)
+	body := `{
+		"id": "https://remote.example/notes/q1",
+		"type": "Note",
+		"attributedTo": "https://remote.example/users/alice",
+		"content": "quote",
+		"_misskey_quote": "https://remote.example/notes/quoted",
+		"to": ["https://www.w3.org/ns/activitystreams#Public"]
+	}`
+	got, err := r.IngestNote([]byte(body))
+	require.NoError(t, err)
+	require.NotNil(t, got.RenoteUserHost)
+	assert.Equal(t, "other.example", *got.RenoteUserHost)
+	assert.Equal(t, int16(1), noteRepo.Notes["quoted1"].RenoteCount, "quote は対象の renoteCount を増分する")
+}
+
+// 自分の note を自己引用した場合は renoteCount を増やさない (本家 userId !== user.id)。
+func TestIngestNote_SelfQuoteNoIncrement(t *testing.T) {
+	repo := testutil.NewMockUserRepository()
+	noteRepo := testutil.NewMockNoteRepository()
+	quotedURI := "https://remote.example/notes/quoted"
+	// quote 先の作者 = 引用する actor (alice) と同一。
+	noteRepo.Notes["quoted1"] = &model.Note{ID: "quoted1", URI: &quotedURI, UserID: "ualice", UserHost: strPtr("remote.example")}
+	repo.Users["ualice"] = &model.User{ID: "ualice", Username: "alice", Host: strPtr("remote.example"), URI: strPtr("https://remote.example/users/alice")}
+	urls := activitypub.NewURLBuilder("https://example.com")
+	idGen, _ := id.NewGenerator("aidx")
+	r := federation.NewResolver(repo, noteRepo, urls, &stubFetcher{body: []byte(sampleActor)}, idGen)
+	body := `{
+		"id": "https://remote.example/notes/q1",
+		"type": "Note",
+		"attributedTo": "https://remote.example/users/alice",
+		"content": "self quote",
+		"_misskey_quote": "https://remote.example/notes/quoted",
+		"to": ["https://www.w3.org/ns/activitystreams#Public"]
+	}`
+	got, err := r.IngestNote([]byte(body))
+	require.NoError(t, err)
+	require.NotNil(t, got.RenoteID, "自己引用でも quote 紐付け自体はする")
+	assert.Equal(t, int16(0), noteRepo.Notes["quoted1"].RenoteCount, "自己引用は renoteCount を増やさない")
+}
+
+// reply と quote を併せ持つ note は ReplyID / RenoteID の両方が立つ。
+func TestIngestNote_ReplyAndQuote(t *testing.T) {
+	repo := testutil.NewMockUserRepository()
+	noteRepo := testutil.NewMockNoteRepository()
+	replyURI := "https://remote.example/notes/reply-target"
+	quotedURI := "https://remote.example/notes/quoted"
+	noteRepo.Notes["rt"] = &model.Note{ID: "rt", URI: &replyURI, UserID: "ru"}
+	noteRepo.Notes["quoted1"] = &model.Note{ID: "quoted1", URI: &quotedURI, UserID: "qu"}
+	urls := activitypub.NewURLBuilder("https://example.com")
+	idGen, _ := id.NewGenerator("aidx")
+	r := federation.NewResolver(repo, noteRepo, urls, &stubFetcher{body: []byte(sampleActor)}, idGen)
+	body := `{
+		"id": "https://remote.example/notes/q1",
+		"type": "Note",
+		"attributedTo": "https://remote.example/users/alice",
+		"content": "reply + quote",
+		"inReplyTo": "https://remote.example/notes/reply-target",
+		"_misskey_quote": "https://remote.example/notes/quoted",
+		"to": ["https://www.w3.org/ns/activitystreams#Public"]
+	}`
+	got, err := r.IngestNote([]byte(body))
+	require.NoError(t, err)
+	require.NotNil(t, got.ReplyID)
+	assert.Equal(t, "rt", *got.ReplyID)
+	require.NotNil(t, got.RenoteID)
+	assert.Equal(t, "quoted1", *got.RenoteID)
+}
+
+// _misskey_quote が解決できなくても quoteUrl で解決できれば quote を採用する
+// (本家は両 URI を試して最初に成功したものを使う)。
+func TestIngestNote_QuotePrefersResolvableUrl(t *testing.T) {
+	repo := testutil.NewMockUserRepository()
+	noteRepo := testutil.NewMockNoteRepository()
+	quotedURI := "https://example.com/notes/localq" // quoteUrl 側 (local, 解決可)
+	_ = quotedURI
+	noteRepo.Notes["localq"] = &model.Note{ID: "localq", UserID: "lu"}
+	urls := activitypub.NewURLBuilder("https://example.com")
+	idGen, _ := id.NewGenerator("aidx")
+	// _misskey_quote は未知 remote (fetch 失敗); quoteUrl は local 解決可。
+	r := federation.NewResolver(repo, noteRepo, urls, &stubFetcher{body: []byte(sampleActor)}, idGen)
+	body := `{
+		"id": "https://remote.example/notes/q1",
+		"type": "Note",
+		"attributedTo": "https://remote.example/users/alice",
+		"content": "two quote uris",
+		"_misskey_quote": "https://remote.example/notes/gone",
+		"quoteUrl": "https://example.com/notes/localq",
+		"to": ["https://www.w3.org/ns/activitystreams#Public"]
+	}`
+	got, err := r.IngestNote([]byte(body))
+	require.NoError(t, err)
+	require.NotNil(t, got.RenoteID, "_misskey_quote 失敗時は quoteUrl にフォールバックする")
+	assert.Equal(t, "localq", *got.RenoteID)
+}


### PR DESCRIPTION
## Summary

連合先からの引用ノート (quote renote) の引用元がノートカードに表示されず、本文のみになっていた問題を修正する (issue #1527)。

### 原因

inbound の ActivityPub Note 取り込み (`resolver.IngestNoteWithCreated`) が `_misskey_quote` / `quoteUrl` を**一切読まず** `renoteId` を立てていなかった。reply (`inReplyTo`) は処理していたが quote の紐付けが無く、リモートの引用ノートは `renoteId = nil` で保存され、embed renote が解決されず「本文だけ」になっていた。outbound renderer は `_misskey_quote`/`quoteUrl` を出している (renderer.go:396) ので、mk-go 同士でも受信側が取りこぼしていた。なおローカル quote は `preloadNoteRelations` + packer で正常に表示される (= 連合受信側だけの不具合)。

## 主な変更点 (`internal/core/federation/resolver.go`)

- **quote 解決を追加**: 本家 `ApNoteService` 同様 `_misskey_quote` → `quoteUrl` の順に解決し、最初に解決できた note を `renoteId` / `renoteUserId` / `renoteUserHost` に紐付ける (self-quote は無視)。
- **解決経路**: local note URI は ID 抽出 → `FindByID`、取り込み済みリモートは `FindByURI` (いずれも fetch 無し)。未知 URI は `ResolveNote` で fetch して取り込む (本家同様)。
- **サイクル安全性**: `Resolver` に in-flight set (`sync.Map`) を追加し、`IngestNoteWithCreated` 冒頭で note URI を mark / defer unmark。quote fetch 前に対象 URI が in-flight なら fetch を skip して A↔B quote サイクルの無限再帰・fetch storm を防ぐ。
- **renoteCount**: 本家 `NoteCreateService.ts:786` (`data.renote && renote.userId !== user.id && !user.isBot` で無条件 increment) 準拠で、Create 後に引用元の `renoteCount` を increment (自己引用・bot は除外)。

## レビュー (重要な是正)

実装後に多エージェント敵対的レビュー (parity / recursion / regression / tests) を実施。初版に対し **2 件の HIGH parity バグ**を検出し本 PR 内で是正:
1. **renoteCount**: 初版は「quote では increment しない」としていたが、本家は line 786 で**無条件 increment** (line 519 の `isRenote && !isQuote` は blocking check であって count ではない) と判明 → increment するよう修正。
2. **quote URI 優先順位**: 初版は `_misskey_quote` が空のときだけ `quoteUrl` を見ていたが、本家は両方を解決して最初に成功した方を採用 → `_misskey_quote` 解決失敗時に `quoteUrl` へフォールバックするよう修正。

### defer (pre-existing / 別スコープ)

`note.uri` の UNIQUE 制約欠如 + `FindByURI`→`Create` の dedup race (連合全般の既存課題)、quote notification の type (`quote` vs `renote`、processor 側)、local create の `isPureRenote` が `ReplyID` を見ない点 (ローカル投稿経路) は本 PR の表示修正スコープ外として残置。

## テスト

`resolver_test.go` に追加: `_misskey_quote` / `quoteUrl` fallback / 未知 URI fetch / quote 無し / 解決不能 degrade / **A↔B サイクル (無限再帰せず B は degrade)** / local note quote / local missing / **renoteCount increment** / **self-quote は非 increment** / **reply+quote 併存** / **`_misskey_quote` 失敗→`quoteUrl` フォールバック** / RenoteUserHost。

`go vet ./...` clean / `gofmt -s` 差分なし / `go build ./...` OK / `internal/core/federation` coverage 90.1% (gate 90%、`resolveQuoteURI` 100%)。

Closes #1527

🤖 Generated with [Claude Code](https://claude.com/claude-code)