### PR TITLE
Fix GA measurement id leak: meta cache の cross-process invalidation (issue #1533)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Fix: Google Analytics の Measurement ID を管理画面で空にしても、別プロセス経由のページ表示で GA タグ (`stats.g.doubleclick.net/collect`) が読み込まれ続けることがあった問題を修正 (issue #1533)。`CachedMetaRepository` は meta 行を TTL 付き in-memory cache し、`admin/update-meta` 時に**自プロセスの cache しか invalidate しなかった**ため、複数プロセス構成では update を処理していないプロセスが TTL 切れまで古い meta を返し続けていた。特に frontend の SSR boot meta (`<script id="misskey_meta">`) には常に新しい `data-generated-at` が付くため、古い `googleAnalyticsMeasurementId` 入りの SSR meta が client の localStorage cache を上書きし、`initAnalytics` が削除済みの GA を読み込んでいた。本家 Misskey の `MetaService` の `metaUpdated` internal event 同様、`Update` 成功時に Redis pubsub (`meta:reload`) で全プロセスへ reload を broadcast し、受信側が local cache を即座に捨てるようにした (hardMutedWords reload #791 と同じ仕組み)。broadcast は best-effort で、publish 失敗は admin update を失敗させない
+
 - Fix: 連合 note 取り込みの dedup race で同一リモート note が重複保存され、引用元の `renoteCount` が二重増分されうる問題を修正 (#1527 follow-up)。本家同様 `note.uri` に部分 UNIQUE index (`uri IS NOT NULL`) を追加 (migration 000056 で既存重複行を最小 id を残して除去 → 000057 で最大テーブル方針に従い `CREATE UNIQUE INDEX CONCURRENTLY`) し、`IngestNote` の `Create` が UNIQUE 制約違反になった場合は既存行を引いて dedup hit 扱い (created=false) にして重複 INSERT と hook / `renoteCount` の二重発火を防ぐ。
 
 - Fix: 連合先からの引用ノート (quote renote) の引用元がノートカードに表示されず本文のみになっていた問題を修正 (issue #1527)。inbound の ActivityPub Note 取り込み (`IngestNote`) が `_misskey_quote` / `quoteUrl` を読まず `renoteId` を立てていなかったため、リモートの引用が「引用元なし」で保存されていた。本家 `ApNoteService` 同様に両 URI を順に解決して引用元 note を紐付け (local / 取り込み済みは fetch 無し、未知は fetch、quote サイクルは in-flight guard で遮断)、引用元の `renoteCount` も本家 `NoteCreateService` 準拠で increment する (自己引用・bot は除外)。

--- a/internal/repository/meta_cached.go
+++ b/internal/repository/meta_cached.go
@@ -1,11 +1,35 @@
 package repository
 
 import (
+	"context"
+	"log/slog"
 	"sync"
 	"time"
 
 	"github.com/shiroha-a/mk/internal/model"
 )
+
+// MetaReloadTopic is the Redis pubsub topic on which meta cache invalidation
+// is broadcast across processes (#1533). It mirrors the upstream Misskey
+// MetaService "metaUpdated" internal event: when admin/update-meta changes the
+// singleton meta row in one process, every other process must drop its local
+// cache so it stops serving stale values (e.g. the SSR boot meta's
+// googleAnalyticsMeasurementId). Without this, a non-updating process keeps the
+// old meta for up to the cache TTL and clients keep loading the removed GA tag.
+const MetaReloadTopic = "meta:reload"
+
+// MetaReloadPayload is the JSON wire format for MetaReloadTopic. The body
+// carries no data today (the signal alone triggers a local invalidate); the
+// struct exists so future reload variants can extend it without a wire break.
+type MetaReloadPayload struct{}
+
+// MetaReloadPublisher broadcasts meta cache invalidation to other processes.
+// core/event.PubSubService satisfies this structurally, so the repository layer
+// does not import the pubsub package directly (dependency inversion keeps the
+// repository -> core import direction from being reversed).
+type MetaReloadPublisher interface {
+	Publish(ctx context.Context, channel string, payload any) error
+}
 
 // CachedMetaRepository wraps a MetaRepository with a time-based in-memory
 // cache. The meta table is a singleton row that rarely changes (admin-only
@@ -18,6 +42,17 @@ type CachedMetaRepository struct {
 	mu  sync.RWMutex
 	val *model.Meta
 	at  time.Time
+
+	// publisher broadcasts MetaReloadTopic on Update so sibling processes drop
+	// their cache (#1533). nil = single-process / no broadcast (Update still
+	// invalidates the local cache).
+	publisher MetaReloadPublisher
+}
+
+// SetReloadPublisher wires the cross-process invalidation broadcaster. It is
+// called once at startup (server router) after the pubsub service exists.
+func (c *CachedMetaRepository) SetReloadPublisher(p MetaReloadPublisher) {
+	c.publisher = p
 }
 
 // NewCachedMetaRepository creates a cached wrapper with a 5-minute TTL.
@@ -57,25 +92,41 @@ func (c *CachedMetaRepository) Fetch() (*model.Meta, error) {
 	return m, nil
 }
 
-// Update delegates to the inner repository and invalidates the cache.
+// Update delegates to the inner repository and invalidates the cache. On
+// success it also broadcasts MetaReloadTopic so other processes invalidate
+// their caches (#1533). The broadcast is best-effort: a publish failure must
+// not fail the admin update (the local cache is already correct), so the error
+// is only logged.
 func (c *CachedMetaRepository) Update(fields map[string]any) error {
 	err := c.inner.Update(fields)
-	if err == nil {
-		c.invalidate()
+	if err != nil {
+		return err
 	}
-	return err
+	c.Invalidate()
+	if c.publisher != nil {
+		if perr := c.publisher.Publish(context.Background(), MetaReloadTopic, MetaReloadPayload{}); perr != nil {
+			slog.Warn("meta: reload broadcast failed", "err", perr)
+		}
+	}
+	return nil
 }
 
 // EnsureInitial delegates to the inner repository and invalidates the cache.
+// It does not broadcast: this runs at startup to seed the singleton row, and
+// every process performs it independently, so there is no stale cache to bust
+// elsewhere.
 func (c *CachedMetaRepository) EnsureInitial(id string) error {
 	err := c.inner.EnsureInitial(id)
 	if err == nil {
-		c.invalidate()
+		c.Invalidate()
 	}
 	return err
 }
 
-func (c *CachedMetaRepository) invalidate() {
+// Invalidate drops the cached meta so the next Fetch reloads from the inner
+// repository. It is exported so the cross-process reload subscriber can call it
+// when a MetaReloadTopic message arrives from another process.
+func (c *CachedMetaRepository) Invalidate() {
 	c.mu.Lock()
 	c.val = nil
 	c.mu.Unlock()

--- a/internal/repository/meta_cached_test.go
+++ b/internal/repository/meta_cached_test.go
@@ -1,6 +1,7 @@
 package repository_test
 
 import (
+	"context"
 	"errors"
 	"sync"
 	"sync/atomic"
@@ -12,6 +13,27 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+// recordingPublisher captures MetaReloadTopic broadcasts for assertions and can
+// be configured to fail to verify best-effort publish handling.
+type recordingPublisher struct {
+	mu       sync.Mutex
+	channels []string
+	err      error
+}
+
+func (p *recordingPublisher) Publish(_ context.Context, channel string, _ any) error {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	p.channels = append(p.channels, channel)
+	return p.err
+}
+
+func (p *recordingPublisher) recorded() []string {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	return append([]string(nil), p.channels...)
+}
 
 // countingMetaRepo counts calls to each method for cache verification.
 type countingMetaRepo struct {
@@ -157,6 +179,67 @@ func TestCachedMetaRepository_ConcurrentFetch(t *testing.T) {
 
 	// ダブルチェックロックにより1〜数回のFetchで済む
 	assert.LessOrEqual(t, inner.fetchCount.Load(), int32(3))
+}
+
+// #1533: Update は他プロセスの cache を捨てさせるため MetaReloadTopic を
+// broadcast する。
+func TestCachedMetaRepository_UpdateBroadcastsReload(t *testing.T) {
+	inner := &countingMetaRepo{meta: &model.Meta{ID: "m1"}}
+	cached := repository.NewCachedMetaRepositoryWithTTL(inner, 1*time.Minute)
+	pub := &recordingPublisher{}
+	cached.SetReloadPublisher(pub)
+
+	require.NoError(t, cached.Update(map[string]any{"name": "new"}))
+
+	assert.Equal(t, []string{repository.MetaReloadTopic}, pub.recorded())
+}
+
+// #1533: publish 失敗は admin update を失敗させず、local cache invalidate も
+// そのまま行われる (best-effort broadcast)。
+func TestCachedMetaRepository_UpdatePublishErrorIsNonFatal(t *testing.T) {
+	inner := &countingMetaRepo{meta: &model.Meta{ID: "m1"}}
+	cached := repository.NewCachedMetaRepositoryWithTTL(inner, 1*time.Minute)
+	cached.SetReloadPublisher(&recordingPublisher{err: errors.New("redis down")})
+
+	_, err := cached.Fetch()
+	require.NoError(t, err)
+	require.Equal(t, int32(1), inner.fetchCount.Load())
+
+	require.NoError(t, cached.Update(map[string]any{"name": "new"}))
+
+	// publish が失敗しても cache は invalidate され、次の Fetch は再取得する。
+	_, err = cached.Fetch()
+	require.NoError(t, err)
+	assert.Equal(t, int32(2), inner.fetchCount.Load())
+}
+
+// #1533: EnsureInitial は startup seed なので broadcast しない。
+func TestCachedMetaRepository_EnsureInitialDoesNotBroadcast(t *testing.T) {
+	inner := &countingMetaRepo{meta: &model.Meta{ID: "m1"}}
+	cached := repository.NewCachedMetaRepositoryWithTTL(inner, 1*time.Minute)
+	pub := &recordingPublisher{}
+	cached.SetReloadPublisher(pub)
+
+	require.NoError(t, cached.EnsureInitial("m1"))
+
+	assert.Empty(t, pub.recorded())
+}
+
+// #1533: cross-process subscriber が呼ぶ Invalidate() は次の Fetch を強制再取得
+// させる。
+func TestCachedMetaRepository_InvalidateBustsCache(t *testing.T) {
+	inner := &countingMetaRepo{meta: &model.Meta{ID: "m1"}}
+	cached := repository.NewCachedMetaRepositoryWithTTL(inner, 1*time.Minute)
+
+	_, err := cached.Fetch()
+	require.NoError(t, err)
+	require.Equal(t, int32(1), inner.fetchCount.Load())
+
+	cached.Invalidate()
+
+	_, err = cached.Fetch()
+	require.NoError(t, err)
+	assert.Equal(t, int32(2), inner.fetchCount.Load())
 }
 
 // #739: NewCachedMetaRepository (default 5-min TTL constructor) を coverage 化。

--- a/internal/server/router.go
+++ b/internal/server/router.go
@@ -1708,6 +1708,26 @@ func (s *Server) setupRoutes() {
 	streamPubSub := event.NewPubSubService(s.redis.Pubsub, "stream:")
 	streamBus := stream.NewEventPubSubBus(streamPubSub)
 
+	// meta cache の cross-process invalidation (#1533)。admin/update-meta は
+	// 1 プロセスの in-memory cache しか invalidate しないため、他プロセスは TTL
+	// 切れまで stale meta を返し続ける。特に frontend SSR boot meta
+	// (<script id="misskey_meta">) の googleAnalyticsMeasurementId が残ると、
+	// 管理画面で空にしても別プロセス経由のページ表示で GA タグが読み込まれ続ける。
+	// wordmute reload (#791) と同じく Redis pubsub で全プロセスへ reload を
+	// broadcast し、受信側は local cache を即座に捨てる (upstream MetaService の
+	// metaUpdated internal event 相当)。
+	if cmr, ok := metaRepo.(*repository.CachedMetaRepository); ok {
+		cmr.SetReloadPublisher(streamPubSub)
+		streamPubSub.Subscribe(context.Background(), repository.MetaReloadTopic, func([]byte) {
+			cmr.Invalidate()
+		})
+		// graceful shutdown 時に subscription goroutine と Redis 接続を解放する
+		// (serverStats/queueStats publisher や wordmute reload と同じ運用)。
+		s.registerShutdownHook(func(_ context.Context) {
+			_ = streamPubSub.Unsubscribe(repository.MetaReloadTopic)
+		})
+	}
+
 	// pollVoted / reacted / unreacted / deleted を noteStream:<id> に publish
 	// する共通 publisher。subNote / sn メッセージで購読しているクライアントへ
 	// リアクション・削除イベントが流れる (#690 / #700)。pollService /


### PR DESCRIPTION
## Summary

管理画面で Google Analytics の Measurement ID を空にしても、ページ表示時に GA タグ (`stats.g.doubleclick.net/collect`) が読み込まれ続けることがある問題 (issue #1533) を修正する。

## 根本原因

フロントエンドの GA 読み込み判定 (`analytics.ts`: `if (!instance.googleAnalyticsMeasurementId) return;`) は正しく、空なら読み込まない。問題はバックエンドが配る meta が古いままになる点にある。

- `CachedMetaRepository` (`internal/repository/meta_cached.go`) は singleton な meta 行を TTL 5分の in-memory cache で保持し、`admin/update-meta` の `Update()` 時に**自プロセスの cache しか invalidate しない**。
- mk-go は複数プロセス構成を前提とする (nginx 背後、`hardMutedWords` の #791 でも同じ理由で Redis pubsub reload を実装済み)。update を処理していないプロセスは TTL 切れまで古い meta を返し続ける。
- frontend の SSR boot meta (`<script id="misskey_meta" data-generated-at="...">`、`frontend.go`) には**常に現在時刻**の `data-generated-at` が付く。`instance.ts` は `providedAt > cachedAt` なら SSR meta を採用し localStorage cache を上書きするため、古い `googleAnalyticsMeasurementId` 入りの SSR meta を配るプロセスに当たると、削除済みの GA が `initAnalytics` で読み込まれてしまう。

本家 Misskey は `MetaService` が Redis の `metaUpdated` internal event を全プロセスで subscribe し、update 時に publish して cache を同期することでこれを防いでいる。mk-go には meta 用の同等機構が無かった。

## 主な変更点

- `internal/repository/meta_cached.go`
  - `MetaReloadTopic` (`meta:reload`) / `MetaReloadPayload` / `MetaReloadPublisher` interface を追加。`PubSubService` が構造的に満たすため repository → core の逆依存は発生しない (interface は repository 側に定義)。
  - `Update()` 成功時に local invalidate に加えて `MetaReloadTopic` を broadcast。broadcast は **best-effort** で、publish 失敗は admin update を失敗させず log のみ。
  - `invalidate()` を `Invalidate()` として export (cross-process subscriber が呼ぶ)。
  - `EnsureInitial` は startup seed なので broadcast しない (各プロセスが独立に実行するため stale cache が他に無い)。
- `internal/server/router.go`
  - `streamPubSub` 生成後に `metaRepo` (= `*CachedMetaRepository`) へ `SetReloadPublisher(streamPubSub)` を配線し、`Subscribe(meta:reload)` で受信時に `Invalidate()` を呼ぶ。
  - graceful shutdown 時に `Unsubscribe` で subscription goroutine / Redis 接続を解放する shutdown hook を登録 (serverStats/queueStats publisher・wordmute reload と同じ運用)。

## テスト

- `internal/repository/meta_cached_test.go` に追加:
  - `Update` が `MetaReloadTopic` を broadcast すること
  - publish 失敗時も `Update` は成功し local cache は invalidate されること (best-effort)
  - `EnsureInitial` は broadcast しないこと
  - export した `Invalidate()` が cache を bust すること
- 実行: `go test ./internal/repository/ -run CachedMeta -count=1` → pass
- `make fmt` / `go vet ./...` / `go build ./...` / 全 test バイナリの compile → pass
- 多エージェントの敵対的レビュー (correctness / concurrency / layering-parity / test-coverage の4観点) を実施し、確定した指摘 (shutdown hook 欠落) を本 PR で修正済み。

## 補足

- `router.go` は `internal/server` (wire 層、CI カバレッジ 0% 例外) のため、実挙動は e2e/drop-in で検証する設計に従う。
- 単一プロセス構成では従来どおり `Update()` の local invalidate だけで完結し、本変更は no-op 相当 (broadcast の自己受信による double-invalidate は冪等で無害)。

Closes #1533

🤖 Generated with [Claude Code](https://claude.com/claude-code)