### PR TITLE
Docs: CLAUDE.md に issue/PR 日本語記述厳守 + CHANGELOG リリース時一括記述ルールを追記

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -277,6 +277,9 @@ Misskeyは用途別に複数のRedis接続を持つ（`default`, `pubsub`, `jobQ
 
 複数人での開発を前提とし、タスク管理はGitHub Issues、実装の取り込みはPull Requestで行う。
 
+- **Issue・PRのタイトルおよび本文は日本語で記述することを厳守する**。コード識別子・エラーコード・ファイルパス・コマンド等の技術用語は原文のまま残してよいが、説明文・見出し・箇条書きの地の文は日本語で書く（英語の本文・見出しを混在させない）。
+- **プロジェクトの`CHANGELOG.md`はリリース時にまとめて記述する**。個別のPR・fixごとに`## Unreleased`へ追記せず、リリースのタイミングで該当期間の変更を一括で記載する。
+
 ### Issue駆動ワークフロー
 
 すべての作業は**対応するissueを先に作成**してから着手する。
@@ -468,6 +471,7 @@ Issueの作成・操作には`gh`コマンドを使う（`gh issue create`, `gh 
 (Section 1-10 の policy / Makefile target / CI 閾値 / CI workflow 等) を変更した
 タイミングのみ記録する。
 
+- **2026-06-09**: Section 7 (Git Workflow) に 2 つのルールを追記。(1)「Issue・PR のタイトル・本文は日本語記述を厳守する」(技術用語は原文のまま残してよいが、説明文・見出し・箇条書きの地の文に英語を混在させない)。(2)「`CHANGELOG.md` はリリース時にまとめて記述する」(個別 PR・fix ごとに `## Unreleased` へ追記せず、リリースのタイミングで一括記載する)。
 - **2026-05-16**: `Makefile` に `make dropin-fedibird-test` を追加 (#1086)。Section 3 (Development Commands) の Drop-in 系コマンド一覧に Fedibird-like mock との Ed25519 e2e を載せる。
 - **2026-05-07**: Playwright nightly CI workflow を Section 8 に追記 (#816)。`.github/workflows/playwright.yml` で Phase 1 spec を毎日 17:00 UTC に develop で実行する、matrix `backend = [mk-go, ts]` 並列、`fail-fast: false`、PR required check には含めない方針を明文化。
 - **2026-04-28**: `internal/server`のCIカバレッジ閾値を0%例外に追加 (#462)。`avatar.go`/`avatar_test.go`の追加で同パッケージ初の`_test.go`が入り、`router.go`(2000行超のwire層)込みのpackage全体カバレッジが2.5%で計測されてCIが落ちたため。`testutil`/`e2e`と同じく実挙動はe2e/drop-in testで検証する設計に揃える。個別handlerファイルは`_test.go`単体で90%相当をカバーする運用は維持。


### PR DESCRIPTION
## 概要

`CLAUDE.md` の Section 7 (Git Workflow) に 2 つの運用ルールを追記する。ドキュメントのみの変更。

## 主な変更点

- **Issue・PRの日本語記述厳守**: タイトル・本文は日本語で記述する。コード識別子・エラーコード・ファイルパス・コマンド等の技術用語は原文のまま残してよいが、説明文・見出し・箇条書きの地の文に英語を混在させない。
- **CHANGELOGはリリース時に一括記述**: `CHANGELOG.md` は個別のPR・fixごとに`## Unreleased`へ追記せず、リリースのタイミングで該当期間の変更をまとめて記載する。
- 末尾の**更新記録**に本変更 (2026-06-09) を追記。

## テスト

ドキュメントのみの変更のためコード影響なし。CI (build / test / lint) が通ることを確認する。

## その他

本ルールに従い、本PRでは`CHANGELOG.md`へのエントリ追記は行わない。