### PR TITLE
Fix: notes/* core parity の MEDIUM 差分をまとめて解消 (#1538)

### DIFF
--- a/internal/api/notes/handler.go
+++ b/internal/api/notes/handler.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"net/http"
+	"strings"
 	"time"
 
 	"github.com/labstack/echo/v4"
@@ -263,17 +264,23 @@ func NewHandler(
 
 // CreateRequest is the request body for notes/create.
 type CreateRequest struct {
-	Visibility         string       `json:"visibility"`
-	VisibleUserIDs     []string     `json:"visibleUserIds"`
-	CW                 *string      `json:"cw"`
-	Text               *string      `json:"text"`
-	LocalOnly          bool         `json:"localOnly"`
-	ReactionAcceptance *string      `json:"reactionAcceptance"`
-	FileIDs            []string     `json:"fileIds"`
-	ReplyID            *string      `json:"replyId"`
-	RenoteID           *string      `json:"renoteId"`
-	ChannelID          *string      `json:"channelId"`
-	Poll               *PollRequest `json:"poll"`
+	Visibility         string   `json:"visibility"`
+	VisibleUserIDs     []string `json:"visibleUserIds"`
+	CW                 *string  `json:"cw"`
+	Text               *string  `json:"text"`
+	LocalOnly          bool     `json:"localOnly"`
+	ReactionAcceptance *string  `json:"reactionAcceptance"`
+	FileIDs            []string `json:"fileIds"`
+	// MediaIDs は fileIds の別名 (upstream は fileIds ?? mediaIds、#1538)。
+	MediaIDs  []string     `json:"mediaIds"`
+	ReplyID   *string      `json:"replyId"`
+	RenoteID  *string      `json:"renoteId"`
+	ChannelID *string      `json:"channelId"`
+	Poll      *PollRequest `json:"poll"`
+	// noExtract* は mention/hashtag/emoji の自動抽出を抑止する (#1538)。
+	NoExtractMentions bool `json:"noExtractMentions"`
+	NoExtractHashtags bool `json:"noExtractHashtags"`
+	NoExtractEmojis   bool `json:"noExtractEmojis"`
 }
 
 // PollRequest is the poll part of a create note request.
@@ -293,6 +300,18 @@ func (h *Handler) Create(c echo.Context) error {
 		return apierr.JSONInvalidParam(c)
 	}
 
+	// fileIds ?? mediaIds (upstream alias、#1538)。fileIds が空のときのみ
+	// mediaIds をフォールバックで使う。
+	fileIDs := req.FileIDs
+	if len(fileIDs) == 0 && len(req.MediaIDs) > 0 {
+		fileIDs = req.MediaIDs
+	}
+
+	// 入力検証 (upstream notes/create.ts paramDef、#1538)。違反は 400 INVALID_PARAM。
+	if err := validateCreateInput(&req, fileIDs); err != nil {
+		return c.JSON(http.StatusBadRequest, apierr.Error("INVALID_PARAM", err.Error(), apierr.UUIDInvalidParam))
+	}
+
 	in := note.CreateInput{
 		User:               user,
 		Text:               req.Text,
@@ -301,10 +320,13 @@ func (h *Handler) Create(c echo.Context) error {
 		VisibleUserIDs:     req.VisibleUserIDs,
 		LocalOnly:          req.LocalOnly,
 		ReactionAcceptance: req.ReactionAcceptance,
-		FileIDs:            req.FileIDs,
+		FileIDs:            fileIDs,
 		ReplyID:            req.ReplyID,
 		RenoteID:           req.RenoteID,
 		ChannelID:          req.ChannelID,
+		NoExtractMentions:  req.NoExtractMentions,
+		NoExtractHashtags:  req.NoExtractHashtags,
+		NoExtractEmojis:    req.NoExtractEmojis,
 	}
 
 	if req.Poll != nil {
@@ -372,6 +394,47 @@ func (h *Handler) Create(c echo.Context) error {
 	})
 }
 
+// maxNoteTextLength mirrors upstream MAX_NOTE_TEXT_LENGTH (const.ts、#1538)。
+const maxNoteTextLength = 3000
+
+// validateCreateInput enforces the upstream notes/create.ts paramDef limits
+// (text/cw length, poll choices, fileIds count) and the text-only [^\s]+ rule.
+// fileIDs is the effective attachment list after the fileIds/mediaIds merge.
+// Returns a non-nil error (its message becomes the INVALID_PARAM body) on the
+// first violation, matching upstream's 400 rejection (#1538)。
+func validateCreateInput(req *CreateRequest, fileIDs []string) error {
+	if req.Text != nil && len([]rune(*req.Text)) > maxNoteTextLength {
+		return errors.New("text is too long")
+	}
+	if req.CW != nil {
+		if n := len([]rune(*req.CW)); n < 1 || n > 100 {
+			return errors.New("cw must be between 1 and 100 characters")
+		}
+	}
+	if len(fileIDs) > 16 {
+		return errors.New("too many files (max 16)")
+	}
+	if req.Poll != nil {
+		if n := len(req.Poll.Choices); n < 2 || n > 10 {
+			return errors.New("poll must have between 2 and 10 choices")
+		}
+		for _, ch := range req.Poll.Choices {
+			if n := len([]rune(ch)); n < 1 || n > 50 {
+				return errors.New("each poll choice must be between 1 and 50 characters")
+			}
+		}
+	}
+	// text のみで成立する note (renote/file/poll 無し) は空白だけの text を弾く
+	// (upstream の pattern '[^\\s]+')。text=nil の content-less は service 側の
+	// ErrNoteContentRequired に委ねる。
+	if req.RenoteID == nil && len(fileIDs) == 0 && req.Poll == nil && req.Text != nil {
+		if strings.TrimSpace(*req.Text) == "" {
+			return errors.New("text must contain at least one non-whitespace character")
+		}
+	}
+	return nil
+}
+
 // ShowRequest is the request body for notes/show.
 type ShowRequest struct {
 	NoteID string `json:"noteId"`
@@ -388,6 +451,20 @@ func (h *Handler) Show(c echo.Context) error {
 	n, err := h.lookupForShow(req.NoteID)
 	if err != nil {
 		return apierr.JSONNoSuchNote(c)
+	}
+
+	// 未ログイン閲覧の制限 (upstream notes/show.ts:69-79, #1538)。
+	//   1. 著者が requireSigninToViewContents=true → CONTENT_RESTRICTED_BY_USER
+	//   2. server の ugcVisibilityForVisitor='none' → CONTENT_RESTRICTED_BY_SERVER
+	//   3. 'local' かつ remote note → CONTENT_RESTRICTED_BY_SERVER
+	// ログイン済み viewer には一切適用しない。
+	if viewer == nil {
+		if n.User != nil && n.User.RequireSigninToViewContents {
+			return c.JSON(http.StatusForbidden, apierr.Error("CONTENT_RESTRICTED_BY_USER", "This content is not available because the author requires sign-in to view it.", "fbcc002d-37d9-4944-a6b0-d9e29f2d33ab"))
+		}
+		if h.ugcVisibility == "none" || (h.ugcVisibility == "local" && n.UserHost != nil) {
+			return c.JSON(http.StatusForbidden, apierr.Error("CONTENT_RESTRICTED_BY_SERVER", "This content is not available for visitors on this server.", "145f88d2-b03d-4087-8143-a78928883c4b"))
+		}
 	}
 
 	packed := entity.PackNoteWithInstance(c.Request().Context(), n, h.idGen, h.instanceLookup(), h.emojiLookup(), h.reactionReader())

--- a/internal/api/notes/handler_drafts.go
+++ b/internal/api/notes/handler_drafts.go
@@ -27,7 +27,18 @@ func (h *Handler) DraftsList(c echo.Context) error {
 	if h.draftRepo == nil {
 		return c.JSON(http.StatusOK, []any{})
 	}
-	drafts, err := h.draftRepo.ListByUser(user.ID, 20)
+	// upstream drafts/list.ts は limit(default30/max100) + sinceId/untilId +
+	// scheduled(boolean) を受ける (#1538)。sinceDate/untilDate は mk-go の
+	// id-based keyset 方針 (NoteDraft に createdAt 列が無い) のため非対応。
+	var req struct {
+		Limit     int    `json:"limit"`
+		SinceID   string `json:"sinceId"`
+		UntilID   string `json:"untilId"`
+		Scheduled *bool  `json:"scheduled"`
+	}
+	_ = c.Bind(&req)
+	limit := pagination.ClampLimit(req.Limit, 30, 100)
+	drafts, err := h.draftRepo.ListByUser(user.ID, req.SinceID, req.UntilID, req.Scheduled, limit)
 	if err != nil {
 		return c.JSON(http.StatusOK, []any{})
 	}
@@ -402,11 +413,13 @@ func (h *Handler) DraftsDelete(c echo.Context) error {
 // DraftsCount handles POST /api/notes/drafts/count.
 func (h *Handler) DraftsCount(c echo.Context) error {
 	user := middleware.GetUser(c)
+	// upstream drafts/count.ts は res type:'number' で裸の数値を返す。旧実装は
+	// {"count": N} オブジェクトを返していた (#1538)。
 	if h.draftRepo == nil {
-		return c.JSON(http.StatusOK, map[string]any{"count": 0})
+		return c.JSON(http.StatusOK, 0)
 	}
 	count, _ := h.draftRepo.CountByUser(user.ID)
-	return c.JSON(http.StatusOK, map[string]any{"count": count})
+	return c.JSON(http.StatusOK, count)
 }
 
 // SetThreadMutingRepo wires the NoteThreadMutingRepository used by the

--- a/internal/api/notes/handler_drafts_test.go
+++ b/internal/api/notes/handler_drafts_test.go
@@ -68,12 +68,25 @@ func (m *mockDraftRepo) FindByIDAndUser(id, userID string) (*model.NoteDraft, er
 	}
 	return nil, errDraftMock
 }
-func (m *mockDraftRepo) ListByUser(userID string, _ int) ([]*model.NoteDraft, error) {
+func (m *mockDraftRepo) ListByUser(userID, sinceID, untilID string, scheduled *bool, limit int) ([]*model.NoteDraft, error) {
 	var result []*model.NoteDraft
 	for _, d := range m.drafts {
-		if d.UserID == userID {
-			result = append(result, d)
+		if d.UserID != userID {
+			continue
 		}
+		if sinceID != "" && d.ID <= sinceID {
+			continue
+		}
+		if untilID != "" && d.ID >= untilID {
+			continue
+		}
+		if scheduled != nil && d.IsActuallyScheduled != *scheduled {
+			continue
+		}
+		result = append(result, d)
+	}
+	if limit > 0 && len(result) > limit {
+		result = result[:limit]
 	}
 	return result, nil
 }
@@ -506,7 +519,8 @@ func TestDraftsCount_NilRepo(t *testing.T) {
 	h := newDraftHandler()
 	rec := postDraft(h.DraftsCount, `{}`, &model.User{ID: "u1"})
 	assert.Equal(t, http.StatusOK, rec.Code)
-	assert.Contains(t, rec.Body.String(), `"count":0`)
+	// upstream drafts/count は res type:'number' で裸の数値 (#1538)。
+	assert.JSONEq(t, `0`, rec.Body.String())
 }
 
 func TestDraftsCount_WithData(t *testing.T) {
@@ -514,7 +528,7 @@ func TestDraftsCount_WithData(t *testing.T) {
 	repo.drafts["d1"] = &model.NoteDraft{ID: "d1", UserID: "u1"}
 	rec := postDraft(h.DraftsCount, `{}`, &model.User{ID: "u1"})
 	assert.Equal(t, http.StatusOK, rec.Code)
-	assert.Contains(t, rec.Body.String(), `"count":1`)
+	assert.JSONEq(t, `1`, rec.Body.String())
 }
 
 // --- ThreadMuting ---

--- a/internal/api/notes/handler_extra.go
+++ b/internal/api/notes/handler_extra.go
@@ -75,6 +75,17 @@ func (h *Handler) FavoritesDelete(c echo.Context) error {
 	if h.favoriteRepo == nil {
 		return c.JSON(http.StatusInternalServerError, apierr.Error("INTERNAL_ERROR", "Internal error.", "5d37dbcb-891e-41ca-a3d6-e690c97775ac"))
 	}
+	// upstream favorites/delete.ts は getNote で存在確認 (無ければ NO_SUCH_NOTE)
+	// → favorite 行が無ければ NOT_FAVORITED を返す (#1538)。旧実装は Delete を
+	// 直接呼び未 favorite でも 204 を返していた。delete は自分の favorite 行のみ
+	// 操作するので visibility gate は不要 (可視性を絞られた後でも un-favorite
+	// できるべき)、存在確認のみ行う。
+	if _, err := h.noteRepo.FindByID(req.NoteID); err != nil {
+		return c.JSON(http.StatusNotFound, apierr.Error("NO_SUCH_NOTE", "No such note.", "80848a2c-398f-4343-baa9-df1d57696c56"))
+	}
+	if exists, _ := h.favoriteRepo.Exists(user.ID, req.NoteID); !exists {
+		return c.JSON(http.StatusBadRequest, apierr.Error("NOT_FAVORITED", "You have not favorited that note.", "b625fc69-635e-45e9-86f4-dbefbef35af5"))
+	}
 	if err := h.favoriteRepo.Delete(user.ID, req.NoteID); err != nil {
 		return c.JSON(http.StatusInternalServerError, apierr.Error("INTERNAL_ERROR", "Internal error.", "5d37dbcb-891e-41ca-a3d6-e690c97775ac"))
 	}

--- a/internal/api/notes/handler_extra_test.go
+++ b/internal/api/notes/handler_extra_test.go
@@ -175,11 +175,33 @@ func TestFavoritesCreate_SpecifiedNote_InList_OK(t *testing.T) {
 }
 
 func TestFavoritesDelete_Success(t *testing.T) {
-	h, _, favRepo := newExtraHandler(t)
+	h, noteRepo, favRepo := newExtraHandler(t)
+	noteRepo.Notes["n1"] = &model.Note{ID: "n1", UserID: "u1", Visibility: model.NoteVisibilityPublic}
 	favRepo.Favorites["u1:n1"] = &model.NoteFavorite{UserID: "u1", NoteID: "n1"}
 	rec := postExtra(h.FavoritesDelete, `{"noteId":"n1"}`, &model.User{ID: "u1"})
 	assert.Equal(t, http.StatusNoContent, rec.Code)
 	assert.Empty(t, favRepo.Favorites)
+}
+
+// TestFavoritesDelete_NoSuchNote: note が存在しなければ NO_SUCH_NOTE (#1538)。
+func TestFavoritesDelete_NoSuchNote(t *testing.T) {
+	h, _, favRepo := newExtraHandler(t)
+	favRepo.Favorites["u1:n1"] = &model.NoteFavorite{UserID: "u1", NoteID: "n1"}
+	rec := postExtra(h.FavoritesDelete, `{"noteId":"n1"}`, &model.User{ID: "u1"})
+	assert.Equal(t, http.StatusNotFound, rec.Code)
+	assert.Contains(t, rec.Body.String(), "NO_SUCH_NOTE")
+	assert.Contains(t, rec.Body.String(), "80848a2c-398f-4343-baa9-df1d57696c56")
+}
+
+// TestFavoritesDelete_NotFavorited: note は在るが favorite 行が無ければ
+// NOT_FAVORITED (旧実装は未 favorite でも 204、#1538)。
+func TestFavoritesDelete_NotFavorited(t *testing.T) {
+	h, noteRepo, _ := newExtraHandler(t)
+	noteRepo.Notes["n1"] = &model.Note{ID: "n1", UserID: "u1", Visibility: model.NoteVisibilityPublic}
+	rec := postExtra(h.FavoritesDelete, `{"noteId":"n1"}`, &model.User{ID: "u1"})
+	assert.Equal(t, http.StatusBadRequest, rec.Code)
+	assert.Contains(t, rec.Body.String(), "NOT_FAVORITED")
+	assert.Contains(t, rec.Body.String(), "b625fc69-635e-45e9-86f4-dbefbef35af5")
 }
 
 func TestFavoritesDelete_InvalidParam(t *testing.T) {
@@ -866,8 +888,13 @@ func (f *failingFavDeleteRepo) Delete(_, _ string) error { return testutil.ErrNo
 
 func TestFavoritesDelete_Error(t *testing.T) {
 	idGen, _ := id.NewGenerator("aidx")
-	h := NewHandler(testutil.NewMockNoteRepository(), nil, nil, nil, nil, nil, nil, nil, idGen)
-	h.SetFavoriteRepo(&failingFavDeleteRepo{testutil.NewMockNoteFavoriteRepository()})
+	noteRepo := testutil.NewMockNoteRepository()
+	noteRepo.Notes["n1"] = &model.Note{ID: "n1", UserID: "u1", Visibility: model.NoteVisibilityPublic}
+	h := NewHandler(noteRepo, nil, nil, nil, nil, nil, nil, nil, idGen)
+	// note 存在 + favorite 存在の状態で Delete だけ失敗させ、500 経路を踏ませる。
+	failing := &failingFavDeleteRepo{testutil.NewMockNoteFavoriteRepository()}
+	failing.Favorites["u1:n1"] = &model.NoteFavorite{UserID: "u1", NoteID: "n1"}
+	h.SetFavoriteRepo(failing)
 	rec := postExtra(h.FavoritesDelete, `{"noteId":"n1"}`, &model.User{ID: "u1"})
 	assert.Equal(t, http.StatusInternalServerError, rec.Code)
 }

--- a/internal/api/notes/handler_parity1538_test.go
+++ b/internal/api/notes/handler_parity1538_test.go
@@ -1,0 +1,132 @@
+package notes
+
+import (
+	"net/http"
+	"strings"
+	"testing"
+
+	corenote "github.com/shiroha-a/mk/internal/core/note"
+	corepoll "github.com/shiroha-a/mk/internal/core/poll"
+	"github.com/shiroha-a/mk/internal/misc/id"
+	"github.com/shiroha-a/mk/internal/model"
+	"github.com/shiroha-a/mk/internal/testutil"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// blockStub satisfies both reaction.BlockingChecker and poll.BlockingChecker
+// (同一シグネチャ IsBlocked(blocker, blockee))。#1538 の vote/reaction blocking
+// 経路テスト用。
+type blockStub struct{ blocked bool }
+
+func (b blockStub) IsBlocked(_, _ string) (bool, error) { return b.blocked, nil }
+
+func strPtr(s string) *string { return &s }
+
+// --- C3/C4: notes/create 入力検証 (validateCreateInput) ---
+
+func TestValidateCreateInput(t *testing.T) {
+	tests := []struct {
+		name    string
+		req     *CreateRequest
+		fileIDs []string
+		wantErr bool
+	}{
+		{"valid text", &CreateRequest{Text: strPtr("hello")}, nil, false},
+		{"text at max", &CreateRequest{Text: strPtr(strings.Repeat("あ", 3000))}, nil, false},
+		{"text over max", &CreateRequest{Text: strPtr(strings.Repeat("あ", 3001))}, nil, true},
+		{"cw empty", &CreateRequest{Text: strPtr("x"), CW: strPtr("")}, nil, true},
+		{"cw over 100", &CreateRequest{Text: strPtr("x"), CW: strPtr(strings.Repeat("c", 101))}, nil, true},
+		{"cw valid", &CreateRequest{Text: strPtr("x"), CW: strPtr("spoiler")}, nil, false},
+		{"too many files", &CreateRequest{}, make([]string, 17), true},
+		{"16 files ok", &CreateRequest{}, make([]string, 16), false},
+		{"poll too few choices", &CreateRequest{Text: strPtr("x"), Poll: &PollRequest{Choices: []string{"a"}}}, nil, true},
+		{"poll too many choices", &CreateRequest{Text: strPtr("x"), Poll: &PollRequest{Choices: make([]string, 11)}}, nil, true},
+		{"poll empty choice", &CreateRequest{Text: strPtr("x"), Poll: &PollRequest{Choices: []string{"a", ""}}}, nil, true},
+		{"poll choice over 50", &CreateRequest{Text: strPtr("x"), Poll: &PollRequest{Choices: []string{"a", strings.Repeat("b", 51)}}}, nil, true},
+		{"poll valid", &CreateRequest{Text: strPtr("x"), Poll: &PollRequest{Choices: []string{"a", "b"}}}, nil, false},
+		{"whitespace-only text-only", &CreateRequest{Text: strPtr("   \n\t")}, nil, true},
+		{"whitespace text with file ok", &CreateRequest{Text: strPtr("   ")}, []string{"f1"}, false},
+		{"whitespace text with renote ok", &CreateRequest{Text: strPtr("   "), RenoteID: strPtr("r1")}, nil, false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := validateCreateInput(tt.req, tt.fileIDs)
+			if tt.wantErr {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}
+
+// A3 (reactions blocked code/id) と D3 (polls NO_POLL code/id) は既存の
+// TestReactionsCreate_Blocked / TestPollsVote_NoPoll を強化して検証している。
+
+// --- D4: polls/vote blocking ---
+
+func TestPollsVote_Blocked(t *testing.T) {
+	noteRepo := testutil.NewMockNoteRepository()
+	pollRepo := testutil.NewMockPollRepository()
+	voteRepo := testutil.NewMockPollVoteRepository()
+	idGen, _ := id.NewGenerator("aidx")
+	querySvc := corenote.NewQueryService(noteRepo, nil)
+	pollSvc := corepoll.NewService(noteRepo, pollRepo, voteRepo, nil, idGen)
+	pollSvc.SetBlockingChecker(blockStub{blocked: true})
+	h := NewHandler(noteRepo, nil, nil, querySvc, nil, nil, pollSvc, nil, idGen)
+	seedPollNote(noteRepo, pollRepo, model.NoteVisibilityPublic, nil)
+
+	c, rec := newJSONRequest(t, "/api/notes/polls/vote", `{"noteId":"n1","choice":1}`)
+	setAuthUser(c, &model.User{ID: "viewer"})
+	require.NoError(t, h.PollsVote(c))
+	assert.Equal(t, http.StatusForbidden, rec.Code)
+	assert.Contains(t, rec.Body.String(), "YOU_HAVE_BEEN_BLOCKED")
+	assert.Contains(t, rec.Body.String(), "85a5377e-b1e9-4617-b0b9-5bea73331e49")
+}
+
+// --- D2: notes/show anonymous content restrictions ---
+
+func newShowHandler(t *testing.T) (*Handler, *testutil.MockNoteRepository) {
+	t.Helper()
+	noteRepo := testutil.NewMockNoteRepository()
+	idGen, _ := id.NewGenerator("aidx")
+	querySvc := corenote.NewQueryService(noteRepo, nil)
+	h := NewHandler(noteRepo, nil, nil, querySvc, nil, nil, nil, nil, idGen)
+	return h, noteRepo
+}
+
+func TestShow_RequireSigninAnonymous(t *testing.T) {
+	h, noteRepo := newShowHandler(t)
+	seedReactionNote(noteRepo, "n1", "public")
+	noteRepo.Notes["n1"].User.RequireSigninToViewContents = true
+	c, rec := newJSONRequest(t, "/api/notes/show", `{"noteId":"n1"}`)
+	// anonymous (no setAuthUser)
+	require.NoError(t, h.Show(c))
+	assert.Equal(t, http.StatusForbidden, rec.Code)
+	assert.Contains(t, rec.Body.String(), "CONTENT_RESTRICTED_BY_USER")
+	assert.Contains(t, rec.Body.String(), "fbcc002d-37d9-4944-a6b0-d9e29f2d33ab")
+}
+
+func TestShow_UgcVisibilityNoneAnonymous(t *testing.T) {
+	h, noteRepo := newShowHandler(t)
+	h.SetUGCVisibility("none")
+	seedReactionNote(noteRepo, "n1", "public")
+	c, rec := newJSONRequest(t, "/api/notes/show", `{"noteId":"n1"}`)
+	require.NoError(t, h.Show(c))
+	assert.Equal(t, http.StatusForbidden, rec.Code)
+	assert.Contains(t, rec.Body.String(), "CONTENT_RESTRICTED_BY_SERVER")
+	assert.Contains(t, rec.Body.String(), "145f88d2-b03d-4087-8143-a78928883c4b")
+}
+
+func TestShow_AuthedBypassesRestrictions(t *testing.T) {
+	h, noteRepo := newShowHandler(t)
+	h.SetUGCVisibility("none")
+	seedReactionNote(noteRepo, "n1", "public")
+	noteRepo.Notes["n1"].User.RequireSigninToViewContents = true
+	c, rec := newJSONRequest(t, "/api/notes/show", `{"noteId":"n1"}`)
+	setAuthUser(c, &model.User{ID: "viewer"})
+	require.NoError(t, h.Show(c))
+	// ログイン済みなら制限は一切適用されず note 本体が返る。
+	assert.Equal(t, http.StatusOK, rec.Code)
+}

--- a/internal/api/notes/polls_handler.go
+++ b/internal/api/notes/polls_handler.go
@@ -26,10 +26,16 @@ func (h *Handler) PollsVote(c echo.Context) error {
 
 	if err := h.pollService.Vote(user, req.NoteID, *req.Choice); err != nil {
 		switch {
-		case errors.Is(err, poll.ErrNoteNotFound), errors.Is(err, poll.ErrNoPoll):
+		case errors.Is(err, poll.ErrNoteNotFound):
 			return c.JSON(http.StatusNotFound, apierr.Error("NO_SUCH_NOTE", "No such note.", "ecafbd2e-c283-4d6d-aecb-1a0a33b75396"))
+		case errors.Is(err, poll.ErrNoPoll):
+			// upstream vote.ts は poll を持たない note への投票に対し NO_SUCH_NOTE
+			// でなく専用の NO_POLL を返す (#1538)。
+			return c.JSON(http.StatusNotFound, apierr.Error("NO_POLL", "The note has no poll.", "5f979967-52d9-4314-a911-1c673727f92f"))
 		case errors.Is(err, poll.ErrNoteNotVisible):
 			return c.JSON(http.StatusForbidden, apierr.Error("ACCESS_DENIED", "You can not see this note.", "fe8d7103-0ea8-4ec3-814d-f8b401dc69e9"))
+		case errors.Is(err, poll.ErrYouHaveBeenBlocked):
+			return c.JSON(http.StatusForbidden, apierr.Error("YOU_HAVE_BEEN_BLOCKED", "You cannot vote this note because you have been blocked by this user.", "85a5377e-b1e9-4617-b0b9-5bea73331e49"))
 		case errors.Is(err, poll.ErrInvalidChoice):
 			return c.JSON(http.StatusBadRequest, apierr.Error("INVALID_CHOICE", "Invalid choice.", "e0cc9a04-f2e8-41e4-a5f1-4127293260cc"))
 		case errors.Is(err, poll.ErrPollExpired):

--- a/internal/api/notes/polls_handler_test.go
+++ b/internal/api/notes/polls_handler_test.go
@@ -127,6 +127,9 @@ func TestPollsVote_NoPoll(t *testing.T) {
 	setAuthUser(c, &model.User{ID: "viewer"})
 	require.NoError(t, h.PollsVote(c))
 	assert.Equal(t, http.StatusNotFound, rec.Code)
+	// upstream vote.ts は poll を持たない note に専用の NO_POLL を返す (#1538)。
+	assert.Contains(t, rec.Body.String(), "NO_POLL")
+	assert.Contains(t, rec.Body.String(), "5f979967-52d9-4314-a911-1c673727f92f")
 }
 
 // failingVoteRepo causes Create to fail.

--- a/internal/api/notes/reactions_handler.go
+++ b/internal/api/notes/reactions_handler.go
@@ -41,7 +41,11 @@ func (h *Handler) ReactionsCreate(c echo.Context) error {
 		case errors.Is(err, reaction.ErrCannotReactToPureRenote):
 			return c.JSON(http.StatusBadRequest, apierr.Error("CANNOT_REACT_TO_RENOTE", "You can not react to a pure Renote.", "eaccdc08-ddef-43fe-908f-d108faad57f5"))
 		case errors.Is(err, reaction.ErrBlocked):
-			return c.JSON(http.StatusForbidden, apierr.Error("BLOCKED", "You are blocked by that user.", "e70412a4-7197-4726-8e74-f3e0deb92aa7"))
+			// upstream notes/reactions/create.ts は ReactionService の内部 id
+			// (e70412a4…) を catch し、endpoint error youHaveBeenBlocked
+			// (code=YOU_HAVE_BEEN_BLOCKED, id=20ef5475…) に変換して返す。旧実装は
+			// 内部 id と独自 code=BLOCKED をそのまま leak していた (#1538)。
+			return c.JSON(http.StatusForbidden, apierr.Error("YOU_HAVE_BEEN_BLOCKED", "You cannot react this note because you have been blocked by this user.", "20ef5475-9f38-4e4c-bd33-de6d979498ec"))
 		}
 		return apierr.JSONInternalError(c)
 	}

--- a/internal/api/notes/reactions_handler_test.go
+++ b/internal/api/notes/reactions_handler_test.go
@@ -130,6 +130,11 @@ func TestReactionsCreate_Blocked(t *testing.T) {
 	setAuthUser(c, &model.User{ID: "viewer"})
 	require.NoError(t, h.ReactionsCreate(c))
 	assert.Equal(t, http.StatusForbidden, rec.Code)
+	// upstream create.ts は endpoint error youHaveBeenBlocked に変換する。
+	// 旧実装は内部 id (e70412a4) と code=BLOCKED を leak していた (#1538)。
+	assert.Contains(t, rec.Body.String(), "YOU_HAVE_BEEN_BLOCKED")
+	assert.Contains(t, rec.Body.String(), "20ef5475-9f38-4e4c-bd33-de6d979498ec")
+	assert.NotContains(t, rec.Body.String(), `"BLOCKED"`)
 }
 
 func TestReactionsCreate_PureRenote(t *testing.T) {

--- a/internal/core/note/note_create_service.go
+++ b/internal/core/note/note_create_service.go
@@ -75,6 +75,12 @@ type CreateInput struct {
 	RenoteID           *string
 	ChannelID          *string
 	Poll               *PollInput
+	// NoExtract* suppress automatic mention/hashtag/emoji extraction from text.
+	// upstream notes/create.ts は apMentions/apHashtags/apEmojis に [] を渡して
+	// 抽出を抑止する (= 主に AP inbox / bridge 経由の二重抽出防止、#1538)。
+	NoExtractMentions bool
+	NoExtractHashtags bool
+	NoExtractEmojis   bool
 }
 
 // PollInput represents the poll part of a create note input.
@@ -504,14 +510,17 @@ func (s *CreateService) Create(in CreateInput) (*model.Note, error) {
 	// hashtag 抽出: text/cw から #tag を拾い note.tags 列に格納する。
 	// hashtags/trend の動的集計や hashtag 検索が機能するためには
 	// note.tags が常に正しく埋められている必要がある (#655)。
-	var hashtagParts []string
-	if in.Text != nil {
-		hashtagParts = append(hashtagParts, *in.Text)
+	var tags []string
+	if !in.NoExtractHashtags {
+		var hashtagParts []string
+		if in.Text != nil {
+			hashtagParts = append(hashtagParts, *in.Text)
+		}
+		if in.CW != nil {
+			hashtagParts = append(hashtagParts, *in.CW)
+		}
+		tags = hashtag.Extract(hashtagParts...)
 	}
-	if in.CW != nil {
-		hashtagParts = append(hashtagParts, *in.CW)
-	}
-	tags := hashtag.Extract(hashtagParts...)
 
 	note := &model.Note{
 		ID:                 noteID,
@@ -549,7 +558,7 @@ func (s *CreateService) Create(in CreateInput) (*model.Note, error) {
 	// host 列の等価比較で lookup する。未知のユーザーは単にスキップする
 	// (remote webfinger 解決は pre-lookup されている前提)。
 	// userRepo が未設定のときは後方互換のため username 文字列をそのまま格納する。
-	if in.Text != nil {
+	if in.Text != nil && !in.NoExtractMentions {
 		if s.userRepo != nil {
 			mentions := ExtractMentionStructs(*in.Text)
 			if len(mentions) > 0 {
@@ -600,7 +609,7 @@ func (s *CreateService) Create(in CreateInput) (*model.Note, error) {
 	// (#629)。連合配信時に renderer.addEmojiTags が note.Emojis を walk して
 	// AP Note.tag に Emoji エントリを足すので、ここで埋めないと連合先で
 	// custom emoji が画像化されず文字列のまま表示される。
-	{
+	if !in.NoExtractEmojis {
 		var text, cw string
 		if in.Text != nil {
 			text = *in.Text

--- a/internal/core/note/note_create_service_test.go
+++ b/internal/core/note/note_create_service_test.go
@@ -93,6 +93,32 @@ func TestCreateService_Success(t *testing.T) {
 	assert.Len(t, noteRepo.Notes, 1)
 }
 
+// TestCreateService_NoExtract verifies the noExtract* flags suppress mention /
+// hashtag / emoji extraction (#1538). Without them the same text would populate
+// Tags / Mentions / Emojis.
+func TestCreateService_NoExtract(t *testing.T) {
+	svc, _, _ := newCreateService(t)
+	user := &model.User{ID: "user1", Username: "alice"}
+	text := "hello #tag @bob :smile:"
+
+	withExtract, err := svc.Create(note.CreateInput{User: user, Text: &text, Visibility: model.NoteVisibilityPublic})
+	require.NoError(t, err)
+	assert.NotEmpty(t, withExtract.Tags, "デフォルトでは hashtag を抽出する")
+
+	created, err := svc.Create(note.CreateInput{
+		User:              user,
+		Text:              &text,
+		Visibility:        model.NoteVisibilityPublic,
+		NoExtractMentions: true,
+		NoExtractHashtags: true,
+		NoExtractEmojis:   true,
+	})
+	require.NoError(t, err)
+	assert.Empty(t, created.Tags, "noExtractHashtags で hashtag 抽出を抑止")
+	assert.Empty(t, created.Mentions, "noExtractMentions で mention 抽出を抑止")
+	assert.Empty(t, created.Emojis, "noExtractEmojis で emoji 抽出を抑止")
+}
+
 func TestCreateService_DefaultVisibility(t *testing.T) {
 	svc, _, _ := newCreateService(t)
 

--- a/internal/core/poll/poll_service.go
+++ b/internal/core/poll/poll_service.go
@@ -25,7 +25,16 @@ var (
 	ErrPollExpired = errors.New("poll has expired")
 	// ErrAlreadyVoted is returned when the user has already voted.
 	ErrAlreadyVoted = errors.New("already voted")
+	// ErrYouHaveBeenBlocked is returned when the note author has blocked the
+	// voter, mirroring upstream notes/polls/vote.ts youHaveBeenBlocked.
+	ErrYouHaveBeenBlocked = errors.New("blocked by note author")
 )
+
+// BlockingChecker reports whether one user has blocked another. 循環依存を避ける
+// ため interface で受け取る (実装は core/blocking)。reaction.Service と同じ契約。
+type BlockingChecker interface {
+	IsBlocked(blockerID, blockeeID string) (bool, error)
+}
 
 // NotificationHook is invoked after a vote is recorded so the notification
 // subsystem can deliver a "pollVote" notification to the note author.
@@ -63,6 +72,7 @@ type Service struct {
 	notificationHook NotificationHook
 	eventPub         NoteEventPublisher
 	federationHook   FederationDeliveryHook
+	blockingChecker  BlockingChecker
 	nowFn            func() time.Time
 }
 
@@ -97,6 +107,13 @@ func (s *Service) SetEventPublisher(p NoteEventPublisher) {
 	s.eventPub = p
 }
 
+// SetBlockingChecker attaches a BlockingChecker used by Vote to reject votes
+// from users the note author has blocked (upstream youHaveBeenBlocked)。nil
+// 配線時は block 判定を skip (local-only テスト環境向け)。
+func (s *Service) SetBlockingChecker(c BlockingChecker) {
+	s.blockingChecker = c
+}
+
 // SetFederationHook attaches a FederationDeliveryHook used after a vote is
 // recorded on a remote poll, so the choice is propagated to the remote
 // author's inbox via AP. nil 配線時は配信 skip — local-only deployments
@@ -120,6 +137,17 @@ func (s *Service) Vote(user *model.User, noteID string, choice int) error {
 	}
 	if !target.HasPoll {
 		return ErrNoPoll
+	}
+
+	// 投票者が note 著者にブロックされている場合は弾く。upstream vote.ts は
+	// hasPoll guard の直後・poll lookup の前に checkBlocked(note.userId, me.id)
+	// を行う (#1538)。自分の poll への投票は対象外。
+	if s.blockingChecker != nil && target.UserID != user.ID {
+		if blocked, err := s.blockingChecker.IsBlocked(target.UserID, user.ID); err != nil {
+			return err
+		} else if blocked {
+			return ErrYouHaveBeenBlocked
+		}
 	}
 
 	p, err := s.pollRepo.FindByNoteID(target.ID)

--- a/internal/core/poll/poll_service_test.go
+++ b/internal/core/poll/poll_service_test.go
@@ -79,6 +79,48 @@ func TestVote_PollNotFoundForNote(t *testing.T) {
 	require.ErrorIs(t, err, poll.ErrNoPoll)
 }
 
+// stubBlockingChecker is a configurable BlockingChecker for the vote-blocking
+// path (#1538). blocked/err はそのまま IsBlocked から返す。
+type stubBlockingChecker struct {
+	blocked bool
+	err     error
+}
+
+func (s stubBlockingChecker) IsBlocked(_, _ string) (bool, error) { return s.blocked, s.err }
+
+func TestVote_BlockedByAuthor(t *testing.T) {
+	svc, noteRepo, pollRepo, _ := newSvc(t)
+	seedPollNote(noteRepo, pollRepo, "n1", "author", false, nil)
+	svc.SetBlockingChecker(stubBlockingChecker{blocked: true})
+	err := svc.Vote(&model.User{ID: "viewer"}, "n1", 0)
+	require.ErrorIs(t, err, poll.ErrYouHaveBeenBlocked)
+}
+
+func TestVote_NotBlockedProceeds(t *testing.T) {
+	svc, noteRepo, pollRepo, _ := newSvc(t)
+	seedPollNote(noteRepo, pollRepo, "n1", "author", false, nil)
+	svc.SetBlockingChecker(stubBlockingChecker{blocked: false})
+	err := svc.Vote(&model.User{ID: "viewer"}, "n1", 0)
+	require.NoError(t, err, "ブロックされていなければ通常通り投票できる")
+}
+
+func TestVote_BlockingCheckerError(t *testing.T) {
+	svc, noteRepo, pollRepo, _ := newSvc(t)
+	seedPollNote(noteRepo, pollRepo, "n1", "author", false, nil)
+	svc.SetBlockingChecker(stubBlockingChecker{err: stubError})
+	err := svc.Vote(&model.User{ID: "viewer"}, "n1", 0)
+	require.ErrorIs(t, err, stubError)
+}
+
+func TestVote_SelfVoteSkipsBlockCheck(t *testing.T) {
+	svc, noteRepo, pollRepo, _ := newSvc(t)
+	seedPollNote(noteRepo, pollRepo, "n1", "author", false, nil)
+	// blocked=true でも自分の poll への投票は block 判定を skip する。
+	svc.SetBlockingChecker(stubBlockingChecker{blocked: true})
+	err := svc.Vote(&model.User{ID: "author"}, "n1", 0)
+	require.NoError(t, err)
+}
+
 func TestVote_InvalidChoice(t *testing.T) {
 	svc, noteRepo, pollRepo, _ := newSvc(t)
 	seedPollNote(noteRepo, pollRepo, "n1", "author", false, nil)

--- a/internal/repository/coverage_complete_test.go
+++ b/internal/repository/coverage_complete_test.go
@@ -278,7 +278,7 @@ func TestErrorPaths_CancelledContext(t *testing.T) {
 	assert.Error(t, err)
 	_, err = nr.DeleteByUserBatch("x", 10)
 	assert.Error(t, err)
-	_, err = NewNoteDraftRepository(db).ListByUser("x", 10)
+	_, err = NewNoteDraftRepository(db).ListByUser("x", "", "", nil, 10)
 	assert.Error(t, err)
 	_, err = NewNoteDraftRepository(db).CountByUser("x")
 	assert.Error(t, err)

--- a/internal/repository/note_draft.go
+++ b/internal/repository/note_draft.go
@@ -13,7 +13,13 @@ type NoteDraftRepository interface {
 	// Used by internal worker paths (= scheduled note processor) that act on
 	// behalf of the draft owner stored in the row (#1040)。
 	FindByID(id string) (*model.NoteDraft, error)
-	ListByUser(userID string, limit int) ([]*model.NoteDraft, error)
+	// ListByUser lists a user's drafts newest-first with keyset pagination.
+	// sinceID/untilID page on the draft id (aidx, time-ordered) mirroring
+	// upstream makePaginationQuery; scheduled, when non-nil, filters on
+	// isActuallyScheduled. mk-go は他 repo と同様 id-based keyset のみで、
+	// upstream の sinceDate/untilDate (NoteDraft に createdAt 列が無い) は
+	// 非対応 (#1538)。
+	ListByUser(userID, sinceID, untilID string, scheduled *bool, limit int) ([]*model.NoteDraft, error)
 	Update(draft *model.NoteDraft) error
 	// Delete returns the number of rows affected so callers can detect
 	// "no such draft" without a separate FindByIDAndUser pre-check (single
@@ -47,12 +53,24 @@ func (r *noteDraftRepository) FindByIDAndUser(id, userID string) (*model.NoteDra
 	return &d, nil
 }
 
-func (r *noteDraftRepository) ListByUser(userID string, limit int) ([]*model.NoteDraft, error) {
+func (r *noteDraftRepository) ListByUser(userID, sinceID, untilID string, scheduled *bool, limit int) ([]*model.NoteDraft, error) {
 	if limit <= 0 {
-		limit = 20
+		limit = 30
+	}
+	q := r.db.Where(`"userId" = ?`, userID)
+	// id は note_draft.id (aidx) で keyset pagination する。note_favorite と
+	// 同じ向き: untilId は < cursor (DESC で次ページ)、sinceId は > cursor。
+	if untilID != "" {
+		q = q.Where(`"id" < ?`, untilID)
+	}
+	if sinceID != "" {
+		q = q.Where(`"id" > ?`, sinceID)
+	}
+	if scheduled != nil {
+		q = q.Where(`"isActuallyScheduled" = ?`, *scheduled)
 	}
 	var drafts []*model.NoteDraft
-	if err := r.db.Where(`"userId" = ?`, userID).Order(`"id" DESC`).Limit(limit).Find(&drafts).Error; err != nil {
+	if err := q.Order(`"id" DESC`).Limit(limit).Find(&drafts).Error; err != nil {
 		return nil, err
 	}
 	return drafts, nil

--- a/internal/repository/note_draft_test.go
+++ b/internal/repository/note_draft_test.go
@@ -41,7 +41,7 @@ func TestNoteDraftRepository_Full(t *testing.T) {
 	assert.Error(t, err)
 
 	// ListByUser
-	list, err := repo.ListByUser(user.ID, 10)
+	list, err := repo.ListByUser(user.ID, "", "", nil, 10)
 	require.NoError(t, err)
 	assert.Len(t, list, 1)
 
@@ -51,9 +51,31 @@ func TestNoteDraftRepository_Full(t *testing.T) {
 	assert.Equal(t, int64(0), scheduled)
 
 	// ListByUser - default limit
-	list2, err := repo.ListByUser(user.ID, 0)
+	list2, err := repo.ListByUser(user.ID, "", "", nil, 0)
 	require.NoError(t, err)
 	assert.Len(t, list2, 1)
+
+	// ListByUser pagination + scheduled filter (#1538). draft.ID は aidx で
+	// keyset pagination する。untilId=自身の id 未満 → 該当 0、scheduled=true
+	// フィルタ → 通常 draft (isActuallyScheduled=false) は除外。
+	only := list[0]
+	emptyByUntil, err := repo.ListByUser(user.ID, "", only.ID, nil, 10)
+	require.NoError(t, err)
+	assert.Empty(t, emptyByUntil, "untilId=自身の id では < cursor に該当無し")
+
+	emptyBySince, err := repo.ListByUser(user.ID, only.ID, "", nil, 10)
+	require.NoError(t, err)
+	assert.Empty(t, emptyBySince, "sinceId=自身の id では > cursor に該当無し")
+
+	wantScheduled := true
+	noScheduled, err := repo.ListByUser(user.ID, "", "", &wantScheduled, 10)
+	require.NoError(t, err)
+	assert.Empty(t, noScheduled, "scheduled=true フィルタで通常 draft は除外")
+
+	wantNotScheduled := false
+	stillThere, err := repo.ListByUser(user.ID, "", "", &wantNotScheduled, 10)
+	require.NoError(t, err)
+	assert.Len(t, stillThere, 1, "scheduled=false フィルタは通常 draft を含む")
 
 	// Update
 	newText := "updated text"

--- a/internal/server/router.go
+++ b/internal/server/router.go
@@ -353,6 +353,8 @@ func (s *Server) setupRoutes() {
 	// Polls
 	pollService := corepoll.NewService(noteRepo, pollRepo, pollVoteRepo, followingRepo, idGen)
 	pollService.SetNotificationHook(notificationHook)
+	// note 著者にブロックされた user の投票を弾く (upstream youHaveBeenBlocked、#1538)。
+	pollService.SetBlockingChecker(blockingService)
 	// poll federation hook は deliverService が下で生成されるので、
 	// `pollService.SetFederationHook(...)` の呼び出しは deliverService 構築後
 	// (router.go:493 以降) に行う。下方の wire-up コメント参照。


### PR DESCRIPTION
## Summary

#1538 (notes/* core parity) の **MEDIUM 10 件 + LOW 1 件** を本家挙動に合わせて
解消する。HIGH 6 件は既に別 PR で実装済み (再検証で確認: moderator delete /
reactionAcceptance / show-partial-bulk shape / polls recommendation / thread-muting /
drafts fields)。本 PR では `Closes` せず、残件の状況は #1538 のコメントに整理する。

## 主な変更点

**notes/create** (`handler.go` / `note_create_service.go`)
- `mediaIds` を `fileIds` の別名として受理 (upstream `fileIds ?? mediaIds`)
- `noExtractMentions` / `noExtractHashtags` / `noExtractEmojis` で mention/hashtag/
  emoji の自動抽出を抑止
- 入力長検証 (text<=3000, cw 1-100, poll choices 2-10・item<=50, fileIds<=16) を
  追加し違反は 400 INVALID_PARAM
- renote/file/poll の無いテキストのみ投稿で空白のみの text を弾く

**notes/show** (`handler.go`)
- 未ログイン閲覧時: 著者 `requireSigninToViewContents` → `CONTENT_RESTRICTED_BY_USER`、
  server `ugcVisibilityForVisitor='none'` または `'local'`+remote note →
  `CONTENT_RESTRICTED_BY_SERVER`

**notes/reactions/create** (`reactions_handler.go`)
- ブロック時の code/id を `BLOCKED` / `e70412a4…` (ReactionService 内部 id の leak)
  から本家 endpoint 値 `YOU_HAVE_BEEN_BLOCKED` / `20ef5475…` に修正

**notes/polls/vote** (`polls_handler.go` / `poll_service.go` / `router.go`)
- poll を持たない note に専用 `NO_POLL` (`5f979967…`) を返す (旧 `NO_SUCH_NOTE`)
- 投票時にブロック判定を追加し `YOU_HAVE_BEEN_BLOCKED` (`85a5377e…`) を返す
  (poll Service に `BlockingChecker` を setter 注入、reaction Service と同パターン)

**notes/favorites/delete** (`handler_extra.go`)
- note 存在確認 (`NO_SUCH_NOTE` `80848a2c…`) + 未 favorite 判定 (`NOT_FAVORITED`
  `b625fc69…`) を追加 (旧実装は未 favorite でも 204)

**notes/drafts** (`handler_drafts.go` / `note_draft.go`)
- `drafts/count` を `{count:N}` から bare number に (upstream res type:'number')
- `drafts/list` に `limit`/`sinceId`/`untilId`/`scheduled` の param + keyset
  pagination を追加 (`sinceDate`/`untilDate` は NoteDraft に createdAt 列が無く、
  mk-go 共通の id-based keyset 方針のため非対応)

## テスト

- `validateCreateInput` table test / show 制限 (CONTENT_RESTRICTED_BY_*) /
  polls NO_POLL・vote blocking / favorites NO_SUCH_NOTE・NOT_FAVORITED /
  noExtract 抑止 / draft pagination・scheduled filter を追加
- `make fmt` / `go vet ./...` / `go build ./...` 通過
- 関連 package coverage: api/notes 91.8% / core/poll 92.1% / core/note 93.8% /
  repository 90.5% (いずれも 90% gate クリア)

## スコープ外 (#1538 コメント参照)

- `drafts/create` の `TOO_MANY_NOTE_DRAFTS` code: mk-go 独自で意図的 (UUID は一致)
- reactions の不可視ノート `ACCESS_DENIED`: 本家は 500 に落ちるため mk-go の方が親切
- `favorites/create` の `myNoteFavorited1` achievement: server-side achievement
  infra 未整備のため別途
- Note res の `deletedAt` / `reactionAndUserPairCache`: optional フィールド

## 関連

#1538 の MEDIUM tier。HIGH は実装済み、残 LOW は上記の通り。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
