### PR TITLE
Fix: users/* parity の REAL 16 件をまとめて解消 (#1547)

### DIFF
--- a/internal/api/users/handler.go
+++ b/internal/api/users/handler.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"net/http"
+	"strings"
 	"sync"
 	"time"
 
@@ -282,8 +283,35 @@ type ShowRequest struct {
 	Host     *string  `json:"host"`
 }
 
+// isBlockedByTarget reports whether targetID has blocked the viewer (i.e. the
+// viewer is blocked BY the target). Used by users/notes・reactions・featured-notes
+// to early-return [] like upstream's userIdsWhoBlockingMe.has(ps.userId) (#1547)。
+// viewer==nil / repo 未配線なら false。
+func (h *Handler) isBlockedByTarget(viewer *model.User, targetID string) bool {
+	if viewer == nil || h.blockingRepo == nil {
+		return false
+	}
+	blocked, err := h.blockingRepo.Exists(targetID, viewer.ID)
+	return err == nil && blocked
+}
+
+// applyModerationNote sets UserDetailed.moderationNote when the viewer is a
+// moderator, mirroring upstream UserEntityService.ts:574
+// (iAmModerator ? profile.moderationNote ?? ” : undefined)。非 moderator には
+// 何もしない (= JSON で omit、#1547)。
+func (h *Handler) applyModerationNote(d *entity.UserDetailed, iAmModerator bool, profile *model.UserProfile) {
+	if !iAmModerator {
+		return
+	}
+	note := ""
+	if profile != nil && profile.ModerationNote != nil {
+		note = *profile.ModerationNote
+	}
+	d.ModerationNote = &note
+}
+
 // Show handles POST /api/users/show.
-// TS互換: userIds (配列) が渡された場合は UserLite の配列を返す。
+// TS互換: userIds (配列) が渡された場合は UserDetailed の配列を返す (#1547)。
 // userId / username が渡された場合は単体 UserDetailed を返す。
 func (h *Handler) Show(c echo.Context) error {
 	var req ShowRequest
@@ -310,22 +338,28 @@ func (h *Handler) Show(c echo.Context) error {
 		if err != nil {
 			return apierr.JSONInternalError(c)
 		}
+		// upstream show.ts:136-141 は非 moderator に isSuspended:false を強制して
+		// suspended user を除外する。moderator は素通し。
+		visible := make([]*user.UserWithProfile, 0, len(bundles))
 		users := make([]*model.User, 0, len(bundles))
 		for _, b := range bundles {
-			// upstream show.ts:136-141: 非 moderator には isSuspended:false を
-			// 強制し suspended user を結果から除外する。moderator は素通し。
 			if !iAmModerator && b.User.IsSuspended {
 				continue
 			}
+			visible = append(visible, b)
 			users = append(users, b.User)
 		}
 		resolver := entity.NewInstanceResolver(h.instanceLookup(), users...)
-		out := make([]entity.UserLite, 0, len(users))
-		for _, u := range users {
-			lite := entity.PackUserLite(u)
-			resolver.FillUserLite(&lite)
-			h.populateUserEmojis(u, &lite)
-			out = append(out, lite)
+		// upstream show.ts:151-153 は userIds バルクモードでも schema 'UserDetailed'
+		// で pack する。旧実装は UserLite を返していた (#1547)。move 解決と remote
+		// stats fetch は list path 同様 N+1 回避のため bulk では行わない。
+		out := make([]entity.UserDetailed, 0, len(visible))
+		for _, b := range visible {
+			detailed := entity.PackUserDetailed(b.User, b.Profile, h.idGen)
+			resolver.FillUserLite(&detailed.UserLite)
+			h.populateUserEmojis(b.User, &detailed.UserLite)
+			h.applyModerationNote(&detailed, iAmModerator, b.Profile)
+			out = append(out, detailed)
 		}
 		return c.JSON(http.StatusOK, out)
 	}
@@ -372,6 +406,7 @@ func (h *Handler) Show(c echo.Context) error {
 	}
 
 	detailed := entity.PackUserDetailed(bundle.User, bundle.Profile, h.idGen)
+	h.applyModerationNote(&detailed, iAmModerator, bundle.Profile)
 
 	// movedTo / alsoKnownAs を URI→ローカルID 解決して埋める (#1255)。単一
 	// ユーザー path なので FindByURI は数回で済む。list path (followers 等) は
@@ -510,6 +545,9 @@ type SearchRequest struct {
 	// "combined" (default)。空 / 不明値は "combined" 扱い (#763)。
 	Origin string `json:"origin"`
 	Offset int    `json:"offset"`
+	// Detail は upstream search.ts:38 と同じく default true。false のとき
+	// UserLite を返す (#1547)。
+	Detail *bool `json:"detail"`
 }
 
 // Search handles POST /api/users/search.
@@ -536,6 +574,20 @@ func (h *Handler) Search(c echo.Context) error {
 		return apierr.JSONInternalError(c)
 	}
 
+	resolver := entity.NewInstanceResolver(h.instanceLookup(), users...)
+
+	// detail は default true。false のとき UserLite を返す (upstream search.ts:56、#1547)。
+	if req.Detail != nil && !*req.Detail {
+		out := make([]entity.UserLite, 0, len(users))
+		for _, u := range users {
+			lite := entity.PackUserLite(u)
+			resolver.FillUserLite(&lite)
+			h.populateUserEmojis(u, &lite)
+			out = append(out, lite)
+		}
+		return c.JSON(http.StatusOK, out)
+	}
+
 	// users/search が検索結果 N 件ぶん per-row GetProfile を呼んでいた N+1 を
 	// 1 batch query に置換する (#517)。Profile が見つからない user は
 	// PackUserDetailed が nil profile を許容するのでそのまま渡る。
@@ -545,7 +597,6 @@ func (h *Handler) Search(c echo.Context) error {
 	}
 	profiles := h.userService.GetProfilesByUserIDs(ids)
 
-	resolver := entity.NewInstanceResolver(h.instanceLookup(), users...)
 	out := make([]entity.UserDetailed, 0, len(users))
 	for _, u := range users {
 		d := entity.PackUserDetailed(u, profiles[u.ID], h.idGen)
@@ -572,6 +623,10 @@ type NotesRequest struct {
 	WithReplies      *bool  `json:"withReplies"`
 	WithRenotes      *bool  `json:"withRenotes"`
 	WithChannelNotes *bool  `json:"withChannelNotes"`
+	// AllowPartial は upstream notes.ts:67 の fanout TL hint。mk-go は fanout TL
+	// を持たないため挙動には影響しないが、param を受理して 400 を出さないために
+	// 受ける (#1547)。
+	AllowPartial *bool `json:"allowPartial"`
 }
 
 // Notes handles POST /api/users/notes.
@@ -620,6 +675,11 @@ func (h *Handler) Notes(c echo.Context) error {
 	if viewer != nil {
 		viewerID = viewer.ID
 	}
+	// viewer が target にブロックされている場合は空配列を返す (upstream
+	// notes.ts:96-101 の userIdsWhoBlockingMe.has(ps.userId) 早期 return、#1547)。
+	if h.isBlockedByTarget(viewer, req.UserID) {
+		return c.JSON(http.StatusOK, []entity.NoteEntity{})
+	}
 	// visibility は repository 側で LIMIT 前に push down する (#1418 review)。
 	// post-fetch filter だとページ過少充填 + followers 判定の N+1 になるため。
 	notes, err := h.noteRepo.ListByUserIDFiltered(req.UserID, viewerID, untilID, sinceID, req.Limit, withFiles, withReplies, withRenotes, withChannelNotes)
@@ -635,14 +695,17 @@ func (h *Handler) Notes(c echo.Context) error {
 }
 
 // FollowersRequest is the request body for users/followers and users/following.
+// upstream paramDef anyOf で {userId} または {username, host} を受ける (#1547)。
 type FollowersRequest struct {
-	UserID    string `json:"userId"`
-	Limit     int    `json:"limit"`
-	Offset    int    `json:"offset"`
-	SinceID   string `json:"sinceId"`
-	UntilID   string `json:"untilId"`
-	SinceDate *int64 `json:"sinceDate"`
-	UntilDate *int64 `json:"untilDate"`
+	UserID    string  `json:"userId"`
+	Username  string  `json:"username"`
+	Host      *string `json:"host"`
+	Limit     int     `json:"limit"`
+	Offset    int     `json:"offset"`
+	SinceID   string  `json:"sinceId"`
+	UntilID   string  `json:"untilId"`
+	SinceDate *int64  `json:"sinceDate"`
+	UntilDate *int64  `json:"untilDate"`
 }
 
 // Followers handles POST /api/users/followers.
@@ -657,8 +720,24 @@ func (h *Handler) Following(c echo.Context) error {
 
 func (h *Handler) listRelations(c echo.Context, followers bool) error {
 	var req FollowersRequest
-	if err := c.Bind(&req); err != nil || req.UserID == "" {
+	if err := c.Bind(&req); err != nil {
 		return apierr.JSONInvalidParam(c)
+	}
+	// userId 指定が無ければ username(+host) から解決する (upstream followers.ts:60-71、
+	// #1547)。usernameLower + host で findOne。
+	if req.UserID == "" {
+		if req.Username == "" {
+			return apierr.JSONInvalidParam(c)
+		}
+		bundle, err := h.userService.ShowByUsername(strings.ToLower(req.Username), req.Host)
+		if err != nil || bundle == nil {
+			nsuID := "63e4aba4-4156-4e53-be25-c9559e42d71b" // users/following
+			if followers {
+				nsuID = "27fa5435-88ab-43de-9360-387de88727cd" // users/followers
+			}
+			return c.JSON(http.StatusNotFound, apierr.Error("NO_SUCH_USER", "No such user.", nsuID))
+		}
+		req.UserID = bundle.User.ID
 	}
 	if req.Limit <= 0 {
 		req.Limit = 10

--- a/internal/api/users/handler_extra.go
+++ b/internal/api/users/handler_extra.go
@@ -1,6 +1,7 @@
 package users
 
 import (
+	"encoding/json"
 	"errors"
 	"log/slog"
 	"net/http"
@@ -12,6 +13,7 @@ import (
 	"github.com/shiroha-a/mk/internal/api/notehide"
 	"github.com/shiroha-a/mk/internal/api/pagination"
 	"github.com/shiroha-a/mk/internal/core/notesfilter"
+	"github.com/shiroha-a/mk/internal/core/reaction"
 	"github.com/shiroha-a/mk/internal/entity"
 	"github.com/shiroha-a/mk/internal/misc/id"
 	"github.com/shiroha-a/mk/internal/model"
@@ -38,15 +40,40 @@ func (h *Handler) SetAbuseRepo(r repository.AbuseReportRepository) {
 // に保つので production runtime には影響しない (router で必ず wired される)。
 func (h *Handler) Relation(c echo.Context) error {
 	viewer := middleware.GetUser(c)
+	// upstream relation.ts:113-127 は userId を oneOf [string, array] で受け、
+	// 配列なら relation 配列を、単体なら relation オブジェクトを返す (#1547)。
 	var req struct {
-		UserID string `json:"userId"`
+		UserID json.RawMessage `json:"userId"`
 	}
-	if err := c.Bind(&req); err != nil || req.UserID == "" {
+	invalidParam := func() error {
 		return c.JSON(http.StatusBadRequest, apierr.Error("INVALID_PARAM", "userId is required.", "3d81ceae-475f-4600-b2a8-2bc116157532"))
 	}
+	if err := c.Bind(&req); err != nil || len(req.UserID) == 0 {
+		return invalidParam()
+	}
+	var single string
+	if err := json.Unmarshal(req.UserID, &single); err == nil {
+		if single == "" {
+			return invalidParam()
+		}
+		return c.JSON(http.StatusOK, h.computeRelation(viewer, single))
+	}
+	var arr []string
+	if err := json.Unmarshal(req.UserID, &arr); err == nil {
+		out := make([]map[string]any, 0, len(arr))
+		for _, id := range arr {
+			out = append(out, h.computeRelation(viewer, id))
+		}
+		return c.JSON(http.StatusOK, out)
+	}
+	return invalidParam()
+}
 
+// computeRelation builds the relation object for a single target user, matching
+// upstream getRelation (#1547)。viewer==nil なら全 false。
+func (h *Handler) computeRelation(viewer *model.User, targetID string) map[string]any {
 	out := map[string]any{
-		"id":                             req.UserID,
+		"id":                             targetID,
 		"isFollowing":                    false,
 		"isFollowed":                     false,
 		"hasPendingFollowRequestFromYou": false,
@@ -58,7 +85,7 @@ func (h *Handler) Relation(c echo.Context) error {
 	}
 
 	if viewer == nil {
-		return c.JSON(http.StatusOK, out)
+		return out
 	}
 
 	// FindByPair は (rec, err) で返す契約 (gorm.ErrRecordNotFound は relation
@@ -67,62 +94,62 @@ func (h *Handler) Relation(c echo.Context) error {
 	// (frontend には false で fallback、次の API call で正される程度の影響)。
 	warnRelErr := func(label string, err error) {
 		if err != nil && !errors.Is(err, gorm.ErrRecordNotFound) {
-			slog.Warn("users/relation lookup failed", "rel", label, "viewer", viewer.ID, "target", req.UserID, "err", err)
+			slog.Warn("users/relation lookup failed", "rel", label, "viewer", viewer.ID, "target", targetID, "err", err)
 		}
 	}
 
 	if h.followingRepo != nil {
-		if rec, err := h.followingRepo.FindByPair(viewer.ID, req.UserID); rec != nil {
+		if rec, err := h.followingRepo.FindByPair(viewer.ID, targetID); rec != nil {
 			out["isFollowing"] = true
 		} else {
 			warnRelErr("isFollowing", err)
 		}
-		if rec, err := h.followingRepo.FindByPair(req.UserID, viewer.ID); rec != nil {
+		if rec, err := h.followingRepo.FindByPair(targetID, viewer.ID); rec != nil {
 			out["isFollowed"] = true
 		} else {
 			warnRelErr("isFollowed", err)
 		}
 	}
 	if h.followRequestRepo != nil {
-		if rec, err := h.followRequestRepo.FindByPair(viewer.ID, req.UserID); rec != nil {
+		if rec, err := h.followRequestRepo.FindByPair(viewer.ID, targetID); rec != nil {
 			out["hasPendingFollowRequestFromYou"] = true
 		} else {
 			warnRelErr("hasPendingFollowRequestFromYou", err)
 		}
-		if rec, err := h.followRequestRepo.FindByPair(req.UserID, viewer.ID); rec != nil {
+		if rec, err := h.followRequestRepo.FindByPair(targetID, viewer.ID); rec != nil {
 			out["hasPendingFollowRequestToYou"] = true
 		} else {
 			warnRelErr("hasPendingFollowRequestToYou", err)
 		}
 	}
 	if h.blockingRepo != nil {
-		if rec, err := h.blockingRepo.FindByPair(viewer.ID, req.UserID); rec != nil {
+		if rec, err := h.blockingRepo.FindByPair(viewer.ID, targetID); rec != nil {
 			out["isBlocking"] = true
 		} else {
 			warnRelErr("isBlocking", err)
 		}
-		if rec, err := h.blockingRepo.FindByPair(req.UserID, viewer.ID); rec != nil {
+		if rec, err := h.blockingRepo.FindByPair(targetID, viewer.ID); rec != nil {
 			out["isBlocked"] = true
 		} else {
 			warnRelErr("isBlocked", err)
 		}
 	}
 	if h.mutingRepo != nil {
-		if rec, err := h.mutingRepo.FindByPair(viewer.ID, req.UserID); rec != nil {
+		if rec, err := h.mutingRepo.FindByPair(viewer.ID, targetID); rec != nil {
 			out["isMuted"] = true
 		} else {
 			warnRelErr("isMuted", err)
 		}
 	}
 	if h.renoteMutingRepo != nil {
-		if rec, err := h.renoteMutingRepo.FindByPair(viewer.ID, req.UserID); rec != nil {
+		if rec, err := h.renoteMutingRepo.FindByPair(viewer.ID, targetID); rec != nil {
 			out["isRenoteMuted"] = true
 		} else {
 			warnRelErr("isRenoteMuted", err)
 		}
 	}
 
-	return c.JSON(http.StatusOK, out)
+	return out
 }
 
 // ReportAbuse handles POST /api/users/report-abuse.
@@ -210,6 +237,12 @@ func (h *Handler) Reactions(c echo.Context) error {
 	// 丸ごと bypass して reaction list を返す。
 	iAmModerator := viewer != nil && h.moderatorChecker != nil && h.moderatorChecker.IsModerator(viewer.ID)
 
+	// viewer が target にブロックされていれば空配列 (upstream reactions.ts:91-94 の
+	// 非 moderator path 早期 return、#1547)。moderator は bypass。
+	if !iAmModerator && h.isBlockedByTarget(viewer, req.UserID) {
+		return c.JSON(http.StatusOK, []any{})
+	}
+
 	// target user lookup + remote / publicReactions check (non-moderator のみ)。
 	// production では userRepo が必ず wire されるが、既存の handler test
 	// (TestReactions_Success 等) は userRepo を wire しないので nil guard で
@@ -257,6 +290,36 @@ func (h *Handler) Reactions(c echo.Context) error {
 		return c.JSON(http.StatusInternalServerError, apierr.Error("INTERNAL_ERROR", "Internal error.", "5d37dbcb-891e-41ca-a3d6-e690c97775ac"))
 	}
 
+	// reaction 先 note の author/reply/renote author を viewer が mute / 自分を
+	// block している場合は除外する (upstream reactions.ts:115-121 の isUserRelated、
+	// #1547)。ApplyMuteBlockChannel で生き残った note id のみ残す。
+	sets, err := notesfilter.LoadMuteBlockSets(viewer, h.mutingRepo, h.blockingRepo, nil)
+	if err != nil {
+		return c.JSON(http.StatusInternalServerError, apierr.Error("INTERNAL_ERROR", "Internal error.", "5d37dbcb-891e-41ca-a3d6-e690c97775ac"))
+	}
+	if len(sets.MutedUserIDs) > 0 || len(sets.BlockerIDs) > 0 {
+		rowNotes := make([]*model.Note, 0, len(rows))
+		for _, r := range rows {
+			if r.Note != nil {
+				rowNotes = append(rowNotes, r.Note)
+			}
+		}
+		survived := make(map[string]struct{}, len(rowNotes))
+		for _, n := range notesfilter.ApplyMuteBlockChannel(rowNotes, sets) {
+			survived[n.ID] = struct{}{}
+		}
+		filtered := rows[:0]
+		for _, r := range rows {
+			if r.Note == nil {
+				continue
+			}
+			if _, ok := survived[r.Note.ID]; ok {
+				filtered = append(filtered, r)
+			}
+		}
+		rows = filtered
+	}
+
 	// note は upstream の packManyWithNote と同じく完全 shape で返す。最小 shape
 	// (id/userId/text) だと createdAt / visibility / user 等が欠落し、misskey_dart
 	// の Note.fromJson が非null フィールドの cast に失敗して落ちる (#1227)。
@@ -277,8 +340,11 @@ func (h *Handler) Reactions(c echo.Context) error {
 	out := make([]map[string]any, 0, len(rows))
 	for _, r := range rows {
 		entry := map[string]any{
-			"id":   r.ID,
-			"type": r.Reaction,
+			"id": r.ID,
+			// upstream NoteReactionEntityService は convertLegacyReaction を通す
+			// (legacy alias + 局所 custom emoji の @. 除去)。生 DB 文字列を
+			// leak しないよう read-time 変換する (#1547)。
+			"type": reaction.ConvertLegacy(r.Reaction),
 		}
 		if t, err := h.idGen.ParseTime(r.ID); err == nil {
 			entry["createdAt"] = t.UTC().Format("2006-01-02T15:04:05.000Z")
@@ -326,11 +392,22 @@ func (h *Handler) FeaturedNotes(c echo.Context) error {
 	if viewer != nil {
 		viewerID = viewer.ID
 	}
+	// viewer が target にブロックされていれば空配列 (upstream featured-notes.ts:58-61、#1547)。
+	if h.isBlockedByTarget(viewer, req.UserID) {
+		return c.JSON(http.StatusOK, []entity.NoteEntity{})
+	}
 	notes, err := h.noteRepo.ListFeaturedByUser(req.UserID, viewerID, req.UntilID, req.Limit)
 	if err != nil {
 		return c.JSON(http.StatusInternalServerError, apierr.Error("INTERNAL_ERROR", "Internal error.", "5d37dbcb-891e-41ca-a3d6-e690c97775ac"))
 	}
 	notes = notesfilter.ApplyHardMute(h.userRepo, viewer, notes)
+	// viewer が mute した user / viewer を block している user が note/reply/renote
+	// の author なら除外する (upstream featured-notes.ts:93-98 の isUserRelated、#1547)。
+	sets, err := notesfilter.LoadMuteBlockSets(viewer, h.mutingRepo, h.blockingRepo, nil)
+	if err != nil {
+		return c.JSON(http.StatusInternalServerError, apierr.Error("INTERNAL_ERROR", "Internal error.", "5d37dbcb-891e-41ca-a3d6-e690c97775ac"))
+	}
+	notes = notesfilter.ApplyMuteBlockChannel(notes, sets)
 	result := entity.PackNotes(c.Request().Context(), notes, h.idGen, h.instanceLookup(), h.emojiLookup(), h.reactionReader())
 	h.fieldRes.Apply(result, viewer)
 	notehide.HideEmbeds(viewer, result)
@@ -343,6 +420,9 @@ func (h *Handler) SearchByUsernameAndHost(c echo.Context) error {
 		Username string  `json:"username"`
 		Host     *string `json:"host"`
 		Limit    int     `json:"limit"`
+		// Detail は upstream search-by-username-and-host.ts:52 と同じく default
+		// true。false のとき UserLite を返す (#1547)。
+		Detail *bool `json:"detail"`
 	}
 	if err := c.Bind(&req); err != nil || req.Username == "" {
 		return c.JSON(http.StatusBadRequest, apierr.Error("INVALID_PARAM", "username is required.", "3d81ceae-475f-4600-b2a8-2bc116157532"))
@@ -355,12 +435,31 @@ func (h *Handler) SearchByUsernameAndHost(c echo.Context) error {
 		return c.JSON(http.StatusInternalServerError, apierr.Error("INTERNAL_ERROR", "Internal error.", "5d37dbcb-891e-41ca-a3d6-e690c97775ac"))
 	}
 	resolver := entity.NewInstanceResolver(h.instanceLookup(), users...)
-	result := make([]entity.UserLite, 0, len(users))
+
+	// detail=false → UserLite。default (true) は UserDetailed (upstream は
+	// detail default true で UserDetailed pack、#1547)。旧実装は常に UserLite。
+	if req.Detail != nil && !*req.Detail {
+		result := make([]entity.UserLite, 0, len(users))
+		for _, u := range users {
+			lite := entity.PackUserLite(u)
+			resolver.FillUserLite(&lite)
+			h.populateUserEmojis(u, &lite)
+			result = append(result, lite)
+		}
+		return c.JSON(http.StatusOK, result)
+	}
+
+	ids := make([]string, 0, len(users))
 	for _, u := range users {
-		lite := entity.PackUserLite(u)
-		resolver.FillUserLite(&lite)
-		h.populateUserEmojis(u, &lite)
-		result = append(result, lite)
+		ids = append(ids, u.ID)
+	}
+	profiles := h.userService.GetProfilesByUserIDs(ids)
+	result := make([]entity.UserDetailed, 0, len(users))
+	for _, u := range users {
+		d := entity.PackUserDetailed(u, profiles[u.ID], h.idGen)
+		resolver.FillUserLite(&d.UserLite)
+		h.populateUserEmojis(u, &d.UserLite)
+		result = append(result, d)
 	}
 	return c.JSON(http.StatusOK, result)
 }
@@ -375,6 +474,12 @@ func (h *Handler) UpdateMemo(c echo.Context) error {
 	}
 	if err := c.Bind(&req); err != nil || req.UserID == "" {
 		return c.JSON(http.StatusBadRequest, apierr.Error("INVALID_PARAM", "userId is required.", "3d81ceae-475f-4600-b2a8-2bc116157532"))
+	}
+
+	// upstream update-memo.ts:22-27 は getUser で target 存在を確認し、無ければ
+	// NO_SUCH_USER を返す (#1547)。旧実装は存在確認せず直接 upsert していた。
+	if _, err := h.userService.ShowByID(req.UserID); err != nil {
+		return c.JSON(http.StatusNotFound, apierr.Error("NO_SUCH_USER", "No such user.", "6fef56f3-e765-4957-88e5-c6f65329b8a5"))
 	}
 
 	if h.memoRepo == nil {

--- a/internal/api/users/handler_extra_test.go
+++ b/internal/api/users/handler_extra_test.go
@@ -596,9 +596,19 @@ func TestSearchByUsernameAndHost_FiltersByHost(t *testing.T) {
 // --- UpdateMemo ---
 
 func TestUpdateMemo_Success(t *testing.T) {
-	h, _, _ := newExtraHandler(t)
+	h, userRepo, _ := newExtraHandler(t)
+	userRepo.Users["u2"] = &model.User{ID: "u2"}
 	rec := postExtra(h.UpdateMemo, `{"userId":"u2"}`, &model.User{ID: "u1"})
 	assert.Equal(t, http.StatusNoContent, rec.Code)
+}
+
+// TestUpdateMemo_NoSuchUser: target が存在しなければ NO_SUCH_USER (#1547)。
+func TestUpdateMemo_NoSuchUser(t *testing.T) {
+	h, _, _ := newExtraHandler(t)
+	rec := postExtra(h.UpdateMemo, `{"userId":"ghost"}`, &model.User{ID: "u1"})
+	assert.Equal(t, http.StatusNotFound, rec.Code)
+	assert.Contains(t, rec.Body.String(), "NO_SUCH_USER")
+	assert.Contains(t, rec.Body.String(), "6fef56f3-e765-4957-88e5-c6f65329b8a5")
 }
 
 func TestUpdateMemo_InvalidParam(t *testing.T) {

--- a/internal/api/users/handler_parity1547_test.go
+++ b/internal/api/users/handler_parity1547_test.go
@@ -1,0 +1,157 @@
+package users
+
+import (
+	"encoding/json"
+	"net/http"
+	"testing"
+
+	"github.com/shiroha-a/mk/internal/model"
+	"github.com/shiroha-a/mk/internal/testutil"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gorm.io/datatypes"
+)
+
+// --- S1: users/show bulk が UserDetailed を返す ---
+
+func TestShow_BulkUserIDs_ReturnsUserDetailed(t *testing.T) {
+	h, repo := newTestHandler(t)
+	repo.Users["u1"] = &model.User{ID: "u1", Username: "alice", AvatarDecorations: datatypes.JSON([]byte("[]"))}
+	rec := post(h.Show, `{"userIds":["u1"]}`)
+	assert.Equal(t, http.StatusOK, rec.Code)
+	var out []map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &out))
+	require.Len(t, out, 1)
+	// UserDetailed 固有フィールド (UserLite には無い) が present であること (#1547)。
+	_, hasFollowers := out[0]["followersCount"]
+	_, hasCreatedAt := out[0]["createdAt"]
+	assert.True(t, hasFollowers, "bulk は UserDetailed なので followersCount を持つ")
+	assert.True(t, hasCreatedAt, "bulk は UserDetailed なので createdAt を持つ")
+}
+
+// --- R1: users/relation が userId 配列を受けて配列を返す ---
+
+func TestRelation_ArrayForm(t *testing.T) {
+	h, _ := newTestHandler(t)
+	rec := postStub(h.Relation, `{"userId":["u2","u3"]}`, &model.User{ID: "u1"})
+	assert.Equal(t, http.StatusOK, rec.Code)
+	var out []map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &out))
+	require.Len(t, out, 2, "配列入力には配列で応答する (#1547)")
+	assert.Equal(t, "u2", out[0]["id"])
+	assert.Equal(t, "u3", out[1]["id"])
+}
+
+func TestRelation_SingleFormStillObject(t *testing.T) {
+	h, _ := newTestHandler(t)
+	rec := postStub(h.Relation, `{"userId":"u2"}`, &model.User{ID: "u1"})
+	assert.Equal(t, http.StatusOK, rec.Code)
+	var out map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &out), "単体入力は従来どおりオブジェクト")
+	assert.Equal(t, "u2", out["id"])
+}
+
+// --- N3 / X1 / X4: viewer が target にブロックされている場合の早期 [] ---
+
+// blocked = target(req.UserID) が viewer を block している状態を作る。
+func wireBlock(h *Handler, blockerID, blockeeID string) *testutil.MockBlockingRepository {
+	br := testutil.NewMockBlockingRepository()
+	_ = br.Create(&model.Blocking{ID: "b1", BlockerID: blockerID, BlockeeID: blockeeID})
+	h.SetBlockingRepo(br)
+	return br
+}
+
+func TestNotes_BlockedByTargetReturnsEmpty(t *testing.T) {
+	h, repo := newTestHandler(t)
+	repo.Users["target"] = &model.User{ID: "target", Username: "t", AvatarDecorations: datatypes.JSON([]byte("[]"))}
+	wireBlock(h, "target", "viewer") // target blocks viewer
+	rec := postStub(h.Notes, `{"userId":"target"}`, &model.User{ID: "viewer"})
+	assert.Equal(t, http.StatusOK, rec.Code)
+	assert.Equal(t, "[]\n", rec.Body.String())
+}
+
+func TestReactions_BlockedByTargetReturnsEmpty(t *testing.T) {
+	h, _ := newTestHandler(t)
+	wireBlock(h, "target", "viewer")
+	rec := postStub(h.Reactions, `{"userId":"target"}`, &model.User{ID: "viewer"})
+	assert.Equal(t, http.StatusOK, rec.Code)
+	assert.Equal(t, "[]\n", rec.Body.String())
+}
+
+func TestFeaturedNotes_BlockedByTargetReturnsEmpty(t *testing.T) {
+	h, _ := newTestHandler(t)
+	wireBlock(h, "target", "viewer")
+	rec := postStub(h.FeaturedNotes, `{"userId":"target"}`, &model.User{ID: "viewer"})
+	assert.Equal(t, http.StatusOK, rec.Code)
+	assert.Equal(t, "[]\n", rec.Body.String())
+}
+
+// --- R3 / R2: search detail param ---
+
+func hasDetailedField(m map[string]any) bool {
+	_, ok := m["followersCount"]
+	return ok
+}
+
+func TestSearch_DetailFalseReturnsUserLite(t *testing.T) {
+	h, repo := newTestHandler(t)
+	addTestUser(repo)
+	rec := post(h.Search, `{"query":"test","detail":false}`)
+	assert.Equal(t, http.StatusOK, rec.Code)
+	var out []map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &out))
+	require.Len(t, out, 1)
+	assert.False(t, hasDetailedField(out[0]), "detail=false は UserLite (followersCount 無し、#1547)")
+}
+
+func TestSearchByUsernameAndHost_DefaultIsUserDetailed(t *testing.T) {
+	h, repo := newTestHandler(t)
+	addTestUser(repo)
+	rec := postStub(h.SearchByUsernameAndHost, `{"username":"testuser"}`, nil)
+	assert.Equal(t, http.StatusOK, rec.Code)
+	var out []map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &out))
+	require.Len(t, out, 1)
+	assert.True(t, hasDetailedField(out[0]), "default は UserDetailed (followersCount あり、#1547)")
+}
+
+func TestSearchByUsernameAndHost_DetailFalseUserLite(t *testing.T) {
+	h, repo := newTestHandler(t)
+	addTestUser(repo)
+	rec := postStub(h.SearchByUsernameAndHost, `{"username":"testuser","detail":false}`, nil)
+	assert.Equal(t, http.StatusOK, rec.Code)
+	var out []map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &out))
+	require.Len(t, out, 1)
+	assert.False(t, hasDetailedField(out[0]), "detail=false は UserLite (#1547)")
+}
+
+// --- S5: moderator viewer sees moderationNote ---
+
+type modStub struct{}
+
+func (modStub) IsModerator(string) bool     { return true }
+func (modStub) IsAdministrator(string) bool { return true }
+
+func TestShow_ModeratorSeesModerationNote(t *testing.T) {
+	h, repo := newTestHandler(t)
+	addTestUser(repo)
+	h.SetModeratorChecker(modStub{})
+	rec := postStub(h.Show, `{"userId":"user1"}`, &model.User{ID: "mod"})
+	assert.Equal(t, http.StatusOK, rec.Code)
+	var out map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &out))
+	_, ok := out["moderationNote"]
+	assert.True(t, ok, "moderator viewer には moderationNote が present (#1547)")
+}
+
+func TestShow_NonModeratorOmitsModerationNote(t *testing.T) {
+	h, repo := newTestHandler(t)
+	addTestUser(repo)
+	rec := postStub(h.Show, `{"userId":"user1"}`, &model.User{ID: "someone"})
+	assert.Equal(t, http.StatusOK, rec.Code)
+	var out map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &out))
+	_, ok := out["moderationNote"]
+	assert.False(t, ok, "非 moderator には moderationNote を omit (#1547)")
+}

--- a/internal/core/reaction/convert_legacy_test.go
+++ b/internal/core/reaction/convert_legacy_test.go
@@ -1,0 +1,30 @@
+package reaction_test
+
+import (
+	"testing"
+
+	"github.com/shiroha-a/mk/internal/core/reaction"
+	"github.com/stretchr/testify/assert"
+)
+
+// TestConvertLegacy covers the read-time reaction conversion used by
+// users/reactions (#1547): legacy aliases map to unicode and a local custom
+// emoji ":name@.:" is decoded back to ":name:". Remote custom emoji and plain
+// unicode pass through unchanged.
+func TestConvertLegacy(t *testing.T) {
+	cases := []struct {
+		in, want string
+	}{
+		{"like", "👍"},
+		{"love", "❤"},
+		{"star", "⭐"},
+		{":smile@.:", ":smile:"},             // 局所 custom emoji の @. を除去
+		{":smile:", ":smile:"},               // host 無しはそのまま
+		{":smile@ex.com:", ":smile@ex.com:"}, // remote はそのまま
+		{"👍", "👍"},                           // unicode はそのまま
+		{"unknown", "unknown"},               // 未知 legacy はそのまま
+	}
+	for _, tc := range cases {
+		assert.Equal(t, tc.want, reaction.ConvertLegacy(tc.in), "ConvertLegacy(%q)", tc.in)
+	}
+}

--- a/internal/core/reaction/reaction_service.go
+++ b/internal/core/reaction/reaction_service.go
@@ -68,6 +68,28 @@ var legacyMap = map[string]string{
 // ":smile@example.com:".
 var customEmojiPattern = regexp.MustCompile(`^:([\w+\-]+)(?:@([\w.\-]+))?:$`)
 
+// ConvertLegacy maps a stored reaction string to the read-time representation
+// upstream's ReactionService.convertLegacyReaction returns: legacy text aliases
+// ("like" → 👍) are mapped, and a local custom emoji ":name@.:" is decoded back
+// to ":name:" (the "@." local-host suffix is stripped). Remote custom emoji and
+// plain unicode pass through unchanged. Pure (no DB); used by read paths such as
+// users/reactions where the raw DB string must not leak (#1547)。
+func ConvertLegacy(raw string) string {
+	if v, ok := legacyMap[raw]; ok {
+		return v
+	}
+	if m := customEmojiPattern.FindStringSubmatch(raw); m != nil {
+		host := ""
+		if len(m) >= 3 {
+			host = m[2]
+		}
+		if host == "" || host == "." {
+			return ":" + m[1] + ":"
+		}
+	}
+	return raw
+}
+
 // NotificationHook is invoked after a reaction is created.
 type NotificationHook interface {
 	OnReactionCreated(notifieeID, notifierID, noteID, reaction string)

--- a/internal/entity/user.go
+++ b/internal/entity/user.go
@@ -150,6 +150,10 @@ type UserDetailed struct {
 	// #1228 の null-cast crash は非 null bool (`isFollowing as bool`) の話で、
 	// nullable string の memo には当てはまらない。
 	Memo *string `json:"memo"`
+	// ModerationNote は moderator viewer のみに見える profile.moderationNote
+	// (upstream UserEntityService.ts:574: iAmModerator ? note ?? '' : undefined)。
+	// 非 moderator には omit する (#1547)。handler 側で viewer の role を見て set。
+	ModerationNote *string `json:"moderationNote,omitempty"`
 }
 
 // MeDetailed extends UserDetailed with fields that upstream Misskey TS
@@ -506,6 +510,13 @@ func PackUserDetailed(u *model.User, profile *model.UserProfile, idGens ...id.Ge
 	if u.LastFetchedAt != nil {
 		s := u.LastFetchedAt.UTC().Format("2006-01-02T15:04:05.000Z")
 		d.LastFetchedAt = &s
+	}
+
+	// updatedAt は upstream UserEntityService.ts:536 と同じく user.updatedAt を
+	// ISO8601 で出す。未更新は null (#1547)。旧実装は常に null だった。
+	if u.UpdatedAt != nil {
+		s := u.UpdatedAt.UTC().Format("2006-01-02T15:04:05.000Z")
+		d.UpdatedAt = &s
 	}
 
 	if profile != nil {

--- a/internal/repository/user.go
+++ b/internal/repository/user.go
@@ -499,6 +499,11 @@ func (r *userRepository) ListUserRecommendations(viewerID string, activeSince ti
 	err := r.db.Model(&model.User{}).
 		Where(`"isLocked" = FALSE AND "isExplorable" = TRUE AND host IS NULL AND "updatedAt" >= ? AND id <> ?`, activeSince, viewerID).
 		Where(`id NOT IN (SELECT "followeeId" FROM "following" WHERE "followerId" = ?)`, viewerID).
+		// upstream recommendation.ts:64-67 と同じく viewer が mute / block している
+		// user、および viewer を block している user を除外する (#1547)。
+		Where(`id NOT IN (SELECT "muteeId" FROM "muting" WHERE "muterId" = ?)`, viewerID).
+		Where(`id NOT IN (SELECT "blockeeId" FROM "blocking" WHERE "blockerId" = ?)`, viewerID).
+		Where(`id NOT IN (SELECT "blockerId" FROM "blocking" WHERE "blockeeId" = ?)`, viewerID).
 		Order(`"followersCount" DESC`).
 		Limit(limit).
 		Offset(offset).


### PR DESCRIPTION
## Summary

#1547 (users/* parity) の **REAL 16 件** (HIGH 3 / MEDIUM 5 / LOW 8) を本家挙動に
合わせて解消する。全 27 項目を develop で再検証し、既に修正済みの 5 件と要判断の
6 件は除外した (詳細は #1547 のトリアージコメント)。`Closes` せず参照に留める。

## 主な変更点

**users/show** (`handler.go` / `entity/user.go`)
- userIds バルクモードを UserLite → **UserDetailed** に (upstream show.ts:151-153)
- `UserDetailed.updatedAt` を user.updatedAt から出力 (旧実装は常に null)
- moderator viewer に `moderationNote` を付与 (非 moderator には omit)

**users/relation** (`handler_extra.go`)
- `userId` の配列形式 (oneOf [string, array]) に対応し配列で応答 (relation 計算を
  `computeRelation` ヘルパーに抽出)

**users/search 系**
- search-by-username-and-host: `detail` (default true) で UserDetailed を返す
- search: `detail=false` で UserLite を返す

**blocked-by-target / mute filter** (`handler.go` / `handler_extra.go`)
- users/notes・reactions・featured-notes: viewer が target にブロックされている場合
  早期 `[]` を返す (`blockingRepo.Exists(target, viewer)`)
- users/reactions: reaction 先 note の author を mute/block している場合除外 +
  `type` を `reaction.ConvertLegacy` で変換 (legacy alias + 局所 emoji の @. 除去)
- users/featured-notes: viewer の mute/block による note 除外

**その他**
- users/recommendation: viewer が mute/block / viewer を block している user を除外
  (`ListUserRecommendations` の SQL に NOT IN subquery 追加)
- users/followers・following: `username`+`host` 形式に対応
- users/update-memo: target 存在確認を追加し無ければ `NO_SUCH_USER`
- users/notes: `allowPartial` param を受理 (mk-go は fanout TL 非対応で挙動不変)

## テスト

- bulk UserDetailed / relation 配列・単体 / search detail / blocked-by-target `[]` /
  update-memo NO_SUCH_USER / moderationNote present・omit / ConvertLegacy を追加
- `make fmt` / `go vet ./...` / `go build ./...` 通過
- 関連 package coverage: api/users 91.2% / entity 96.0% / core/reaction 93.8% /
  repository 90.5% (いずれも 90% gate クリア。repository は throwaway Postgres で実 DB 検証)

## スコープ外 (#1547 コメント参照)

- users/search・search-by-username-and-host の認証緩和 (mk-go は意図的に厳格)
- users/clips・pages の self-view (mk-go の方が寛容、所有者の private を隠さない)
- users/gallery files / users/clips clip-favorite (achievement / like 追跡 infra 依存)

## 関連

#1547 の REAL 16 件。既修正 5 件と要判断 6 件はトリアージコメントに整理。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
