### PR TITLE
Fix: 不正JSON bodyを本家Fastifyのbody parse error envelopeで返す (#1609)

### DIFF
--- a/internal/server/middleware/auth.go
+++ b/internal/server/middleware/auth.go
@@ -396,12 +396,15 @@ func extractToken(c echo.Context) string {
 	if req.Body != nil && req.ContentLength != 0 {
 		body, err := io.ReadAll(req.Body)
 		if err == nil && len(body) > 0 {
-			// ボディをリセット
+			// ボディをリセット (下流のJSONBodyParse/c.Bindには原文を渡す)
 			req.Body = io.NopCloser(bytes.NewReader(body))
 			var parsed struct {
 				I string `json:"i"`
 			}
-			if json.Unmarshal(body, &parsed) == nil && parsed.I != "" {
+			// 本家 (secure-json-parse) はUTF-8 BOMを除去してからparseする
+			// ため、BOM付きbodyのtoken抽出もここで除去して揃える (#1609)。
+			// encoding/json はBOMを受理しないので除去しないと匿名扱いになる。
+			if json.Unmarshal(bytes.TrimPrefix(body, utf8BOM), &parsed) == nil && parsed.I != "" {
 				return parsed.I
 			}
 		}

--- a/internal/server/middleware/auth_test.go
+++ b/internal/server/middleware/auth_test.go
@@ -501,6 +501,36 @@ func TestAuthenticate_JSONBodyToken(t *testing.T) {
 	assert.NoError(t, err)
 }
 
+// TestAuthenticate_JSONBodyToken_BOMPrefix は UTF-8 BOM 付き JSON body の
+// token 抽出を確認する (#1609)。本家は secure-json-parse が BOM を除去して
+// から body.i を読むため認証が成功する。encoding/json は BOM を受理しない
+// ので、除去せず Unmarshal すると匿名扱いに落ちて本家とずれる。
+func TestAuthenticate_JSONBodyToken_BOMPrefix(t *testing.T) {
+	userRepo := testutil.NewMockUserRepository()
+	tokenRepo := testutil.NewMockAccessTokenRepository()
+	user := &model.User{ID: "user5", Username: "bomuser"}
+	nativeToken := "bomtoken12345678"
+	userRepo.Tokens[nativeToken] = user
+
+	auth := NewAuthMiddleware(userRepo, tokenRepo)
+
+	e := echo.New()
+	body := "\xEF\xBB\xBF" + `{"i":"` + nativeToken + `"}`
+	req := httptest.NewRequest(http.MethodPost, "/api/i", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+
+	handler := auth.Authenticate()(func(c echo.Context) error {
+		u := GetUser(c)
+		assert.NotNil(t, u, "BOM-prefixed body token must authenticate")
+		assert.Equal(t, "user5", u.ID)
+		return c.String(http.StatusOK, "ok")
+	})
+
+	require.NoError(t, handler(c))
+}
+
 func TestAuthenticate_JSONBodyToken_EmptyI(t *testing.T) {
 	userRepo := testutil.NewMockUserRepository()
 	tokenRepo := testutil.NewMockAccessTokenRepository()

--- a/internal/server/middleware/jsonbody.go
+++ b/internal/server/middleware/jsonbody.go
@@ -1,0 +1,177 @@
+package middleware
+
+import (
+	"bytes"
+	"encoding/json"
+	"io"
+	"mime"
+	"net/http"
+	"regexp"
+	"strings"
+
+	"github.com/labstack/echo/v4"
+)
+
+// fastifyError is the error envelope Fastify's default error handler
+// serializes for content-type-parser failures. Upstream Misskey leaves the
+// /api scope on the default JSON parser and default error handler, so a
+// malformed JSON body is answered with this shape instead of the Misskey
+// API error envelope. Field order matches Fastify's generated serializer
+// (statusCode, code, error, message).
+type fastifyError struct {
+	StatusCode int    `json:"statusCode"`
+	Code       string `json:"code"`
+	Error      string `json:"error"`
+	Message    string `json:"message"`
+}
+
+// Fastify 5 の FST_ERR_CTP_* 定義 (lib/errors.js) と同文。
+var (
+	errEmptyJSONBody = fastifyError{
+		StatusCode: http.StatusBadRequest,
+		Code:       "FST_ERR_CTP_EMPTY_JSON_BODY",
+		Error:      "Bad Request",
+		Message:    "Body cannot be empty when content-type is set to 'application/json'",
+	}
+	errInvalidJSONBody = fastifyError{
+		StatusCode: http.StatusBadRequest,
+		Code:       "FST_ERR_CTP_INVALID_JSON_BODY",
+		Error:      "Bad Request",
+		Message:    "Body is not valid JSON but content-type is set to 'application/json'",
+	}
+)
+
+// secure-json-parse の fast-path 正規表現の移植。raw body に怪しい
+// パターンが無ければ構造walkを省略できる (大半のリクエストは1回の
+// 正規表現スキャンだけで通過する)。エスケープされた unicode 形式
+// (_ 等) もオリジナルと同様に検出する。
+var (
+	suspectProtoRx       = regexp.MustCompile(`"(?:_|\\u005[Ff])(?:_|\\u005[Ff])(?:p|\\u0070)(?:r|\\u0072)(?:o|\\u006[Ff])(?:t|\\u0074)(?:o|\\u006[Ff])(?:_|\\u005[Ff])(?:_|\\u005[Ff])"\s*:`)
+	suspectConstructorRx = regexp.MustCompile(`"(?:c|\\u0063)(?:o|\\u006[Ff])(?:n|\\u006[Ee])(?:s|\\u0073)(?:t|\\u0074)(?:r|\\u0072)(?:u|\\u0075)(?:c|\\u0063)(?:t|\\u0074)(?:o|\\u006[Ff])(?:r|\\u0072)"\s*:`)
+)
+
+// utf8BOM is the UTF-8 byte order mark Fastify's JSON parser strips before
+// JSON.parse (secure-json-parse normalizes charCode 0xFEFF at index 0).
+var utf8BOM = []byte{0xEF, 0xBB, 0xBF}
+
+// JSONBodyParse mirrors Fastify's application/json content-type parser for
+// the /api scope. Upstream parses the body during the request lifecycle
+// before the endpoint handler (and before rate limiting / authentication,
+// which Misskey performs inside the handler), so a malformed or empty JSON
+// body short-circuits with a Fastify error envelope regardless of endpoint,
+// auth state or rate limit budget. Registering this middleware first on the
+// /api group reproduces that ordering (#1609).
+//
+// Requests whose content type is not application/json (multipart uploads,
+// no content type at all) pass through untouched, as do GET/HEAD requests:
+// Fastify never parses bodies for those methods. After this middleware,
+// c.Bind can no longer fail on malformed JSON for application/json POSTs;
+// remaining Bind failures are type mismatches, which handlers keep
+// answering with the Misskey INVALID_PARAM envelope (= upstream's schema
+// validation error), preserving the distinction between the two layers.
+func JSONBodyParse() echo.MiddlewareFunc {
+	return func(next echo.HandlerFunc) echo.HandlerFunc {
+		return func(c echo.Context) error {
+			req := c.Request()
+			// FastifyはGET/HEAD/TRACEのbodyを一切パースしない (bodyless
+			// method 扱い)。content-typeがJSONでもそのまま素通しする。
+			if req.Method == http.MethodGet || req.Method == http.MethodHead || req.Method == http.MethodTrace {
+				return next(c)
+			}
+			if !isJSONContentType(req.Header.Get(echo.HeaderContentType)) {
+				return next(c)
+			}
+
+			body, err := io.ReadAll(req.Body)
+			if err != nil {
+				return c.JSON(http.StatusBadRequest, errInvalidJSONBody)
+			}
+			if len(body) == 0 {
+				return c.JSON(http.StatusBadRequest, errEmptyJSONBody)
+			}
+			// secure-json-parse は先頭の U+FEFF (UTF-8 BOM) を除去してから
+			// JSON.parse するため、BOM付き有効JSONは受理される。Goの
+			// encoding/json はBOMを受け付けないので、ここで剥がしたbodyを
+			// 下流の c.Bind にも渡す。
+			body = bytes.TrimPrefix(body, utf8BOM)
+			if !json.Valid(body) || isPoisonedJSON(body) {
+				return c.JSON(http.StatusBadRequest, errInvalidJSONBody)
+			}
+
+			req.Body = io.NopCloser(bytes.NewReader(body))
+			return next(c)
+		}
+	}
+}
+
+// isPoisonedJSON reports whether the (already syntactically valid) JSON
+// body would be rejected by secure-json-parse with the Fastify defaults
+// onProtoPoisoning='error' / onConstructorPoisoning='error': any object
+// holding an own "__proto__" key, or a "constructor" key whose value is an
+// object with an own "prototype" key.
+func isPoisonedJSON(body []byte) bool {
+	// fast path: raw text に怪しいキーが見えなければ走査しない
+	if !suspectProtoRx.Match(body) && !suspectConstructorRx.Match(body) {
+		return false
+	}
+	// UseNumberで数値をjson.Numberのまま保持する。float64変換だと 1e999 の
+	// ような範囲外数値がDecodeエラーになり、JSON.parse (Infinity扱いで成功)
+	// との差で poisoned 誤判定するため。
+	dec := json.NewDecoder(bytes.NewReader(body))
+	dec.UseNumber()
+	var v any
+	if err := dec.Decode(&v); err != nil {
+		return true
+	}
+	return hasPoisonedKey(v)
+}
+
+// isJSONContentType reports whether Fastify's content-type parser would
+// route the request to the application/json parser. Fastify only validates
+// the type/subtype token (lib/content-type.js) and tolerates malformed
+// parameter lists, while Go's mime.ParseMediaType rejects them — e.g. a
+// bare "charset" without value or duplicate parameters. On parse error we
+// therefore fall back to comparing the raw essence before the first ';'.
+func isJSONContentType(ct string) bool {
+	essence, _, err := mime.ParseMediaType(ct)
+	if err == nil {
+		return essence == echo.MIMEApplicationJSON
+	}
+	// パラメータ構文が壊れていてもfastifyはessenceでparserを選ぶため、
+	// ';' 手前を自前で取り出して判定する (mime: duplicate parameter name
+	// 等ではessenceすら返らない)。
+	if i := strings.IndexByte(ct, ';'); i >= 0 {
+		ct = ct[:i]
+	}
+	return strings.ToLower(strings.TrimSpace(ct)) == echo.MIMEApplicationJSON
+}
+
+// hasPoisonedKey walks the decoded JSON tree the same way secure-json-parse's
+// filter() does, descending into both objects and arrays.
+func hasPoisonedKey(v any) bool {
+	switch x := v.(type) {
+	case map[string]any:
+		if _, ok := x["__proto__"]; ok {
+			return true
+		}
+		if cv, ok := x["constructor"]; ok {
+			if cm, ok := cv.(map[string]any); ok {
+				if _, ok := cm["prototype"]; ok {
+					return true
+				}
+			}
+		}
+		for _, vv := range x {
+			if hasPoisonedKey(vv) {
+				return true
+			}
+		}
+	case []any:
+		for _, vv := range x {
+			if hasPoisonedKey(vv) {
+				return true
+			}
+		}
+	}
+	return false
+}

--- a/internal/server/middleware/jsonbody_test.go
+++ b/internal/server/middleware/jsonbody_test.go
@@ -1,0 +1,246 @@
+package middleware
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/labstack/echo/v4"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// doJSONBody runs one request through JSONBodyParse with a handler that
+// binds {"value": string} and echoes it back, mimicking how API handlers
+// answer Bind failures with the Misskey INVALID_PARAM envelope.
+func doJSONBody(t *testing.T, method, contentType, body string) (*httptest.ResponseRecorder, *bool) {
+	t.Helper()
+	e := echo.New()
+	handlerRan := false
+	h := func(c echo.Context) error {
+		handlerRan = true
+		var req struct {
+			Value string `json:"value"`
+		}
+		if err := c.Bind(&req); err != nil {
+			return c.JSON(http.StatusBadRequest, map[string]any{
+				"error": map[string]any{
+					"message": "Invalid param.",
+					"code":    "INVALID_PARAM",
+					"id":      "3d81ceae-475f-4600-b2a8-2bc116157532",
+				},
+			})
+		}
+		return c.JSON(http.StatusOK, map[string]any{"value": req.Value})
+	}
+	req := httptest.NewRequest(method, "/api/test", strings.NewReader(body))
+	if contentType != "" {
+		req.Header.Set(echo.HeaderContentType, contentType)
+	}
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+	err := JSONBodyParse()(h)(c)
+	require.NoError(t, err)
+	return rec, &handlerRan
+}
+
+const (
+	invalidEnvelope = `{"statusCode":400,"code":"FST_ERR_CTP_INVALID_JSON_BODY","error":"Bad Request","message":"Body is not valid JSON but content-type is set to 'application/json'"}`
+	emptyEnvelope   = `{"statusCode":400,"code":"FST_ERR_CTP_EMPTY_JSON_BODY","error":"Bad Request","message":"Body cannot be empty when content-type is set to 'application/json'"}`
+)
+
+func TestJSONBodyParse_MalformedJSONReturnsFastifyEnvelope(t *testing.T) {
+	rec, ran := doJSONBody(t, http.MethodPost, echo.MIMEApplicationJSON, "{not json")
+	assert.Equal(t, http.StatusBadRequest, rec.Code)
+	assert.JSONEq(t, invalidEnvelope, rec.Body.String())
+	assert.False(t, *ran, "handler must not run on parse error")
+}
+
+func TestJSONBodyParse_EmptyBodyReturnsEmptyJSONEnvelope(t *testing.T) {
+	rec, ran := doJSONBody(t, http.MethodPost, echo.MIMEApplicationJSON, "")
+	assert.Equal(t, http.StatusBadRequest, rec.Code)
+	assert.JSONEq(t, emptyEnvelope, rec.Body.String())
+	assert.False(t, *ran)
+}
+
+func TestJSONBodyParse_ValidJSONPassesThroughToBind(t *testing.T) {
+	rec, ran := doJSONBody(t, http.MethodPost, echo.MIMEApplicationJSON, `{"value":"hello"}`)
+	assert.Equal(t, http.StatusOK, rec.Code)
+	assert.True(t, *ran)
+	// middleware が body を復元して下流の c.Bind が読めること
+	assert.JSONEq(t, `{"value":"hello"}`, rec.Body.String())
+}
+
+// TestJSONBodyParse_TypeMismatchStaysInvalidParam は #1609 の区別要件:
+// 構文的に正しいJSONの型ミスマッチは middleware を通過し、handler 側の
+// INVALID_PARAM (= 本家の schema validation エラー) で返ることを固定する。
+func TestJSONBodyParse_TypeMismatchStaysInvalidParam(t *testing.T) {
+	rec, ran := doJSONBody(t, http.MethodPost, echo.MIMEApplicationJSON, `{"value":123}`)
+	assert.Equal(t, http.StatusBadRequest, rec.Code)
+	assert.True(t, *ran, "type mismatch must reach the handler")
+	assert.Contains(t, rec.Body.String(), "INVALID_PARAM")
+	assert.NotContains(t, rec.Body.String(), "FST_ERR")
+}
+
+func TestJSONBodyParse_CharsetParameterIsStillJSON(t *testing.T) {
+	rec, ran := doJSONBody(t, http.MethodPost, "application/json; charset=utf-8", "{broken")
+	assert.Equal(t, http.StatusBadRequest, rec.Code)
+	assert.JSONEq(t, invalidEnvelope, rec.Body.String())
+	assert.False(t, *ran)
+}
+
+func TestJSONBodyParse_NonJSONContentTypePassesThrough(t *testing.T) {
+	for _, ct := range []string{"text/plain", "multipart/form-data; boundary=x", "application/x-www-form-urlencoded"} {
+		rec, ran := doJSONBody(t, http.MethodPost, ct, "{definitely not json")
+		// Fastifyの対象外content-typeはJSON parserを通らない。handler 側の
+		// 既存挙動 (echo Bind の可否) はこの middleware の関心外。
+		assert.True(t, *ran, "content-type %s must pass through", ct)
+		assert.NotContains(t, rec.Body.String(), "FST_ERR", "content-type %s", ct)
+	}
+}
+
+func TestJSONBodyParse_NoContentTypePassesThrough(t *testing.T) {
+	_, ran := doJSONBody(t, http.MethodPost, "", "{garbage")
+	assert.True(t, *ran)
+}
+
+func TestJSONBodyParse_BodylessMethodsSkipBodyParsing(t *testing.T) {
+	// FastifyのbodylessセットはGET/HEAD/TRACE (fastify.js bodylessMethods)
+	for _, m := range []string{http.MethodGet, http.MethodHead, http.MethodTrace} {
+		_, ran := doJSONBody(t, m, echo.MIMEApplicationJSON, "{garbage")
+		assert.True(t, *ran, "method %s must skip body parsing", m)
+	}
+}
+
+// TestJSONBodyParse_MalformedContentTypeParams は Fastify が content-type の
+// パラメータ構文不正を無視して essence で JSON parser を選ぶ挙動の互換性を
+// 固定する。Go の mime.ParseMediaType はこれらをエラーにするため、essence
+// 自前抽出の fallback が無いと素通しして本家とずれる (#1609 レビュー指摘)。
+func TestJSONBodyParse_MalformedContentTypeParams(t *testing.T) {
+	jsonCTs := []string{
+		"application/json; charset",          // 値なしパラメータ
+		"application/json; foo=bar; foo=baz", // 重複パラメータ
+		`application/json; charset="utf-8`,   // 未終端 quote
+		"application/json; =nokey",           // キー無し
+	}
+	for _, ct := range jsonCTs {
+		rec, ran := doJSONBody(t, http.MethodPost, ct, "{broken")
+		assert.Equal(t, http.StatusBadRequest, rec.Code, "content-type %q", ct)
+		assert.JSONEq(t, invalidEnvelope, rec.Body.String(), "content-type %q", ct)
+		assert.False(t, *ran, "content-type %q", ct)
+	}
+	// type/subtype 自体が壊れている場合は fastify でも JSON parser に
+	// 到達しない (415系) ので素通し (mk-go 既存挙動) を維持する。
+	_, ran := doJSONBody(t, http.MethodPost, "application / json", "{broken")
+	assert.True(t, *ran, "broken type/subtype must pass through")
+}
+
+// TestJSONBodyParse_BOMStrippedAndBindable は secure-json-parse の BOM 除去
+// 互換: UTF-8 BOM 付き有効JSONを受理し、下流の c.Bind にはBOM抜きの body
+// が渡ることを確認する (Goの encoding/json はBOMを受理しないため必須)。
+func TestJSONBodyParse_BOMStrippedAndBindable(t *testing.T) {
+	rec, ran := doJSONBody(t, http.MethodPost, echo.MIMEApplicationJSON, "\xEF\xBB\xBF{\"value\":\"bom\"}")
+	assert.Equal(t, http.StatusOK, rec.Code)
+	assert.True(t, *ran)
+	assert.JSONEq(t, `{"value":"bom"}`, rec.Body.String())
+}
+
+func TestJSONBodyParse_ScalarJSONIsValid(t *testing.T) {
+	// JSON.parse は scalar も受理する。middleware は通過させ、Bind の失敗は
+	// handler 側 INVALID_PARAM に委ねる。
+	rec, ran := doJSONBody(t, http.MethodPost, echo.MIMEApplicationJSON, `123`)
+	assert.True(t, *ran)
+	assert.Contains(t, rec.Body.String(), "INVALID_PARAM")
+}
+
+func TestJSONBodyParse_ProtoPoisoningRejected(t *testing.T) {
+	cases := []struct {
+		name string
+		body string
+		want bool // true = rejected with invalid envelope
+	}{
+		{name: "top-level __proto__ key", body: `{"__proto__":{"x":1}}`, want: true},
+		{name: "nested __proto__ key", body: `{"a":{"__proto__":1}}`, want: true},
+		{name: "__proto__ inside array element", body: `{"a":[{"__proto__":1}]}`, want: true},
+		// JSON escape 形式のキーも decode 後に "__proto__" になるため reject
+		// される (本家 suspectProtoRx も _ 形式を検出する)
+		{name: "escaped unicode proto key", body: `{"\u005f\u005fproto\u005f\u005f":1}`, want: true},
+		{name: "__proto__ as string value is fine", body: `{"a":"__proto__"}`, want: false},
+		{name: "constructor with prototype", body: `{"constructor":{"prototype":{}}}`, want: true},
+		{name: "nested constructor with prototype", body: `{"a":{"constructor":{"prototype":1}}}`, want: true},
+		{name: "constructor with scalar value is fine", body: `{"constructor":"x"}`, want: false},
+		{name: "constructor object without prototype is fine", body: `{"constructor":{"x":1}}`, want: false},
+		// float64 範囲外の数値は JSON.parse では Infinity として成功する。
+		// UseNumber decode で誤って poisoned 扱いしないこと
+		{name: "constructor with out-of-range number is fine", body: `{"constructor":1e999}`, want: false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			rec, ran := doJSONBody(t, http.MethodPost, echo.MIMEApplicationJSON, tc.body)
+			if tc.want {
+				assert.Equal(t, http.StatusBadRequest, rec.Code)
+				assert.JSONEq(t, invalidEnvelope, rec.Body.String())
+				assert.False(t, *ran)
+			} else {
+				assert.True(t, *ran, "body %s must pass", tc.body)
+				assert.NotContains(t, rec.Body.String(), "FST_ERR")
+			}
+		})
+	}
+}
+
+func TestJSONBodyParse_EnvelopeFieldOrderMatchesFastify(t *testing.T) {
+	// Fastifyの生成serializerは statusCode, code, error, message の順で
+	// 出力する。drop-in 比較で見やすいよう同順を維持する (JSONとしては
+	// 順序非依存だが、念のため raw 文字列でも固定する)。
+	rec, _ := doJSONBody(t, http.MethodPost, echo.MIMEApplicationJSON, "{broken")
+	raw := strings.TrimSpace(rec.Body.String())
+	assert.Equal(t, invalidEnvelope, raw)
+}
+
+func TestHasPoisonedKey_NonObjectValues(t *testing.T) {
+	assert.False(t, hasPoisonedKey("string"))
+	assert.False(t, hasPoisonedKey(123.0))
+	assert.False(t, hasPoisonedKey(nil))
+	assert.False(t, hasPoisonedKey([]any{"a", 1.0}))
+	assert.True(t, hasPoisonedKey([]any{map[string]any{"__proto__": 1.0}}))
+}
+
+// errReader simulates a request body whose read fails mid-stream.
+type errReader struct{}
+
+func (errReader) Read([]byte) (int, error) { return 0, assert.AnError }
+
+func TestJSONBodyParse_BodyReadErrorReturnsInvalidEnvelope(t *testing.T) {
+	e := echo.New()
+	req := httptest.NewRequest(http.MethodPost, "/api/test", errReader{})
+	req.Header.Set(echo.HeaderContentType, echo.MIMEApplicationJSON)
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+	handlerRan := false
+	err := JSONBodyParse()(func(echo.Context) error {
+		handlerRan = true
+		return nil
+	})(c)
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusBadRequest, rec.Code)
+	assert.JSONEq(t, invalidEnvelope, rec.Body.String())
+	assert.False(t, handlerRan)
+}
+
+func TestIsPoisonedJSON_UnmarshalErrorIsPoisoned(t *testing.T) {
+	// json.Valid 通過後にしか呼ばれない前提だが、防御分岐として suspect
+	// パターンを含む不正JSONは poisoned 扱いにする
+	assert.True(t, isPoisonedJSON([]byte(`{"__proto__":`)))
+}
+
+func TestIsPoisonedJSON_FastPathSkipsWalk(t *testing.T) {
+	// 怪しいパターンを含まない body は正規表現スキャンのみで通過する
+	assert.False(t, isPoisonedJSON([]byte(`{"text":"hello world"}`)))
+	// 文字列値中の escaped-quote 形式は正規表現にもマッチしない (JSの
+	// suspectProtoRx と同じ挙動)
+	assert.False(t, isPoisonedJSON([]byte(`{"text":"say \"__proto__\": hi"}`)))
+	// 正規表現にはマッチするが walk で安全と判定されるケース
+	assert.False(t, isPoisonedJSON([]byte(`{"constructor":"x"}`)))
+}

--- a/internal/server/require_scope_wiring_test.go
+++ b/internal/server/require_scope_wiring_test.go
@@ -125,6 +125,8 @@ func TestRequireScopeWiring(t *testing.T) {
 		// router.go と同様 auth.Authenticate() をグローバル前段に置く。
 		e.Use(auth.Authenticate())
 		api := e.Group("/api")
+		// router.go と同様 JSONBodyParse を api group の先頭に置く (#1609)。
+		api.Use(middleware.JSONBodyParse())
 		for _, tc := range cases {
 			// /api prefix を group が付けるので relative path で登録。
 			api.POST(tc.path[len("/api"):], func(c echo.Context) error {

--- a/internal/server/router.go
+++ b/internal/server/router.go
@@ -854,6 +854,12 @@ func (s *Server) setupRoutes() {
 
 	api := s.echo.Group("/api")
 
+	// Fastify互換のJSON body事前パース (#1609)。本家はbody parseが
+	// endpoint handler (rate limit / 認証を含む) より先に走るため、
+	// rate limiterより前に登録して malformed JSON を FST_ERR_CTP_* envelope
+	// で先に弾く。
+	api.Use(middleware.JSONBodyParse())
+
 	// Rate limiter: Redisバックエンドのsliding window、Misskey TS互換。
 	// auth.Authenticate()がグローバルミドルウェアとして先に実行されるため、
 	// GetUser(c)で認証済みユーザーを取得できる。


### PR DESCRIPTION
## Summary

#1565 (PR #1587) のfollow-up。mk-goは`c.Bind`失敗 (malformed JSON body等) を`INVALID_PARAM` (400) で返していたが、本家FastifyはbodyパースエラーをFastify標準の`FST_ERR_CTP_*` envelopeで返す。全`c.Bind`使用endpointに横断する差分を、handler変更ゼロの集約middlewareで解消する。

本家側の確認結果 (Fastify 5.8.5、`/api` scopeはデフォルトJSONパーサ+デフォルトエラーハンドラ、Misskey側のカスタムなし):

- malformed JSON → 400 `{"statusCode":400,"code":"FST_ERR_CTP_INVALID_JSON_BODY","error":"Bad Request","message":"Body is not valid JSON but content-type is set to 'application/json'"}`
- 空body+JSON content-type → 400 `FST_ERR_CTP_EMPTY_JSON_BODY` envelope
- secure-json-parseの`__proto__`/`constructor.prototype` poisoningも同じ400 invalid envelope (デフォルト`onProtoPoisoning='error'`)
- UTF-8 BOMは除去して受理、GET/HEAD/TRACEはbodyパースなし、parse errorはhandler実行前 (=rate limit・認証より先)

## 主な変更点

- `internal/server/middleware/jsonbody.go` (新規) — Fastifyの`application/json` content-type parserを移植したmiddleware
  - envelope文言・フィールド順 (statusCode/code/error/message) は本家`lib/errors.js`/生成serializerと逐語一致
  - poisoning検出のfast-path正規表現 (`suspectProtoRx`/`suspectConstructorRx`) はsecure-json-parseと1文字単位で同一。walkは`UseNumber`デコードで`1e999`等の範囲外数値の誤判定を回避
  - content-type判定はFastify同様essenceベース。`mime.ParseMediaType`がエラーにする構文不正パラメータ (値なし`charset`・重複パラメータ・未終端quote等) も`;`手前のessence自前抽出でJSONパーサに到達させる
  - BOM除去後のbodyを下流`c.Bind`へ復元 (Goの`encoding/json`はBOM非対応のため必須)
- `internal/server/router.go` — `/api` groupの先頭 (rate limiterより前) に登録。本家のlifecycle順 (body parse→handler内のrate limit/認証) を再現し、parse errorがrate limit budgetを消費しない点も一致
- `internal/server/middleware/auth.go` — body token (`i`) 抽出時のBOM除去を追加。本家はsecure-json-parseがBOM除去後に`body.i`を読むため、除去しないとBOM付きbodyが匿名扱いに落ちて本家とずれる
- `internal/server/require_scope_wiring_test.go` — router.goとのmiddleware構成mirrorを維持するため`JSONBodyParse`を追加

`INVALID_PARAM`との区別 (issue完了条件): 構文的に正しいJSONの型ミスマッチはmiddlewareを通過しhandler側の`INVALID_PARAM` (=本家のschema validationエラー) で返る。handler側の変更は不要。

## テスト

- `make fmt` / `make lint` / フルテストスイート (`go test ./...`) パス
- middleware unit test 22ケース追加: envelope完全一致 (フィールド順含む)・空body・型ミスマッチ区別・charset付き/構文不正content-type・bodylessメソッド (GET/HEAD/TRACE) スキップ・BOM除去+Bind可・proto/constructor poisoning 10パターン・防御分岐
- auth側: BOM付きbody tokenの認証成功テスト追加
- `internal/server/middleware`パッケージカバレッジ96.2% (CI gate 90%超)、jsonbody.go全関数100%
- 検証: 実Fastify 5.8.5へのraw HTTP probeとmk-go実機probeの突き合わせで、envelope byte一致・空body全パス (CL:0/CLなし/chunked空)・BOM・poisoning・404ルート・CORS preflight非干渉・raw body読み取りhandler (/inbox・WebAuthn) 非干渉を確認。既存テスト・クライアント (misskey_dart含む、最小bodyは常に`{}`) への回帰なし

## Closes

Closes #1609

## その他

- 影響範囲: `/api`配下の非GET/HEAD/TRACEリクエストでcontent-type essenceが`application/json`のもののみ。multipart (drive upload)・content-typeなし・`/streaming`・AP `/inbox`は非干渉
- 挙動変更: 空body+JSON content-typeのPOSTは従来200になり得たが400 `FST_ERR_CTP_EMPTY_JSON_BODY`になる。本家TSも同条件で400を返すためdrop-in parityとして正しい (本家で動くクライアントは影響なし)
- 既知の残差 (スコープ外、follow-up候補): bodyLimit 1MiB相当 (本家413 `FST_ERR_CTP_BODY_TOO_LARGE`) の不在、content-typeなし+bodyあり等の415系envelope

🤖 Generated with [Claude Code](https://claude.com/claude-code)