### PR TITLE
Fix: reversi/* + bubble-game/* parity の REAL 差分 7 件をまとめて解消 (#1553)

### DIFF
--- a/internal/api/bubblegame/handler.go
+++ b/internal/api/bubblegame/handler.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/labstack/echo/v4"
 	"github.com/shiroha-a/mk/internal/api/apierr"
+	"github.com/shiroha-a/mk/internal/entity"
 	"github.com/shiroha-a/mk/internal/misc/id"
 	"github.com/shiroha-a/mk/internal/model"
 	"github.com/shiroha-a/mk/internal/repository"
@@ -94,11 +95,11 @@ func (h *Handler) Ranking(c echo.Context) error {
 			"id":    r.ID,
 			"score": r.Score,
 		}
+		// upstream ranking.ts は user を ref:'UserLite' で返す。ad-hoc な
+		// 4 フィールドマップだと avatarUrl 等の必須フィールドが欠けて
+		// frontend のランキング表示が壊れるため packer を経由する (#1553)。
 		if r.User != nil {
-			entry["user"] = map[string]any{
-				"id": r.User.ID, "username": r.User.Username,
-				"name": r.User.Name, "host": r.User.Host,
-			}
+			entry["user"] = entity.PackUserLite(r.User)
 		}
 		result[i] = entry
 	}

--- a/internal/api/bubblegame/handler_test.go
+++ b/internal/api/bubblegame/handler_test.go
@@ -123,6 +123,30 @@ func TestRanking_Success(t *testing.T) {
 	assert.Len(t, resp, 2)
 }
 
+// TestRanking_UserIsUserLite guards that ranking items embed a full UserLite
+// (#1553). Upstream ranking.ts declares user as ref:'UserLite', so ad-hoc
+// 4-field maps break clients that expect avatarUrl / onlineStatus etc.
+func TestRanking_UserIsUserLite(t *testing.T) {
+	h, repo := newTestHandler()
+	repo.records = []*model.BubbleGameRecord{
+		{ID: "r1", Score: 200, User: &model.User{ID: "u1", Username: "alice"}},
+	}
+	rec := post(h.Ranking, `{"gameMode":"normal"}`, nil)
+	assert.Equal(t, http.StatusOK, rec.Code)
+
+	var resp []map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+	require.Len(t, resp, 1)
+	user, ok := resp[0]["user"].(map[string]any)
+	require.True(t, ok, "user must be an object")
+	// UserLite 必須フィールドが揃っていること (ad-hoc map では欠けていた組)。
+	for _, key := range []string{"id", "username", "name", "host", "avatarUrl", "isBot", "isCat", "emojis", "onlineStatus", "badgeRoles"} {
+		_, has := user[key]
+		assert.True(t, has, "UserLite field %q must be present", key)
+	}
+	assert.Equal(t, "u1", user["id"])
+}
+
 func TestRanking_Empty(t *testing.T) {
 	h, _ := newTestHandler()
 	rec := post(h.Ranking, `{"gameMode":"normal"}`, nil)

--- a/internal/api/reversi/handler.go
+++ b/internal/api/reversi/handler.go
@@ -6,7 +6,6 @@ import (
 	"errors"
 	"log/slog"
 	"net/http"
-	"strconv"
 	"strings"
 	"time"
 
@@ -152,7 +151,9 @@ func packGame(g *model.ReversiGame, idGen id.Generator) map[string]any {
 	// winner は upstream Misskey TS の ReversiGameEntityService.packDetail と
 	// 同じく winnerId から UserLite を派生させる (#649)。frontend は
 	// `v-if="game.winner"` で勝敗表示を切り替えるため、winnerId だけでは
-	// draw に倒れる。
+	// draw に倒れる。json-schema は optional:false, nullable:true なので
+	// winnerId が無い (対局中 / draw) ときもキー自体は null で常に出す (#1553)。
+	result["winner"] = nil
 	if g.WinnerID != nil {
 		if g.User1 != nil && g.User1.ID == *g.WinnerID {
 			result["winner"] = entity.PackUserLite(g.User1)
@@ -339,24 +340,40 @@ func (h *Handler) Match(c echo.Context) error {
 		req.UserID = resolved
 	}
 
+	// 自分自身を相手指定したら upstream match.ts:57 と同じ TARGET_IS_YOURSELF。
+	// acct (`@自分`) が self に解決されるケースも弾くため resolve の後で判定する。
+	if req.UserID != "" && req.UserID == user.ID {
+		return c.JSON(http.StatusBadRequest, apierr.Error("TARGET_IS_YOURSELF", "Target user is yourself.", "96fd7bd6-d2bc-426c-a865-d055dcd2828e"))
+	}
+
+	// ランダムマッチ (userId 無し) は相手が確定するまで成立しない。upstream は
+	// meta.res が optional:true で、matchAnyUser がマッチ未成立時に null を返す
+	// と endpoint も空ボディ (204) になる (match.ts:33-37,68)。従来の
+	// 「user1=user2 の仮置き game 行を作って 200 で返す」実装は frontend を
+	// 即ゲーム画面 (自分 vs 自分) に遷移させてしまう上、仮置き行が invitations
+	// に自分自身として出るため、行を作らず本家と同じ空レスポンスを返す (#1553)。
+	// any-match の実ペアリング (本家は Redis queue) は未実装で、frontend の
+	// matchHeatbeat が定期的に再呼び出しする前提。
+	if req.UserID == "" {
+		return c.NoContent(http.StatusNoContent)
+	}
+
 	// 既に相手から招待を受けている pending game があれば、それを accept 扱いで
 	// 再利用する (#417 P1)。CherryPick 本家の matchSpecificUser と同じ動作:
 	// inbound Invite 経由で作成された reversi_game 行 (User1=相手, User2=自分)
 	// を流用し、相手に Join を返すだけにする。これをやらないと /match が毎回
 	// 新しいゲーム + 新しい session_id を作って二重招待になり、state 伝播が
 	// 噛み合わなくなる。
-	if req.UserID != "" {
-		if existing := h.findPendingInvitationFrom(user.ID, req.UserID); existing != nil {
-			h.sendJoinForAcceptedInvite(c, user, existing)
-			return c.JSON(http.StatusOK, packGame(existing, h.idGen))
-		}
+	if existing := h.findPendingInvitationFrom(user.ID, req.UserID); existing != nil {
+		h.sendJoinForAcceptedInvite(c, user, existing)
+		return c.JSON(http.StatusOK, packGame(existing, h.idGen))
 	}
 
 	// target user を一度だけ引いて pre-check と deliver 両方で使い回す
 	// (#417 P3 Devin review: 元実装では pre-check と delivery で 2 回
 	// FindByID していた)。
 	var targetUser *model.User
-	if req.UserID != "" && h.userRepo != nil {
+	if h.userRepo != nil {
 		if u, err := h.userRepo.FindByID(req.UserID); err == nil {
 			targetUser = u
 		}
@@ -383,10 +400,6 @@ func (h *Handler) Match(c echo.Context) error {
 		BW:                   "random",
 		TimeLimitForEachTurn: 90,
 		Logs:                 datatypes.JSON("[]"),
-	}
-	if req.UserID == "" {
-		// ランダムマッチ — user2IDを空にしてマッチ待ち
-		game.User2ID = user.ID // 自分vs自分 (仮置き、実際はマッチング待ち)
 	}
 
 	if err := h.repo.Create(game); err != nil {
@@ -473,10 +486,21 @@ func (h *Handler) sendJoinForAcceptedInvite(c echo.Context, accepter *model.User
 // 片付く。svc 未配線な旧テスト互換のため repo.Delete フォールバックも残す。
 func (h *Handler) CancelMatch(c echo.Context) error {
 	user := middleware.GetUser(c)
+	var req struct {
+		UserID string `json:"userId"`
+	}
+	_ = c.Bind(&req)
 	ctx := c.Request().Context()
 	games, _ := h.repo.ListByUser(user.ID, 10)
 	for _, g := range games {
 		if g.IsStarted || g.IsEnded {
+			continue
+		}
+		// userId 指定時は upstream matchSpecificUserCancel 互換 (cancel-match.ts:
+		// 33-38): 自分がその相手に送った招待 (User1=自分, User2=相手) だけを
+		// 取り消す。未指定時は従来通り自分の pending を全部片付ける (mk-go は
+		// any-match queue を持たないため、これが matchAnyUserCancel の近似)。
+		if req.UserID != "" && (g.User1ID != user.ID || g.User2ID != req.UserID) {
 			continue
 		}
 		if h.svc != nil {
@@ -574,16 +598,18 @@ func surrenderErrorResponse(c echo.Context, err error) error {
 }
 
 // Verify handles POST /api/reversi/verify — verify game integrity.
-// CherryPick 互換: クライアントが送ってくる `crc32` をサーバ側で再計算した
-// ものと比較し、不一致なら `{desynced: true, game}` を返してフロント側で
-// restoreGame を走らせる。一致なら `{desynced: false}` のみ。
+// クライアントが送ってくる `crc32` を保存済みの game.crc32 と比較し、
+// 不一致なら `{desynced: true, game}` を返してフロント側で restoreGame を
+// 走らせる。一致なら `{desynced: false}` のみ。
 func (h *Handler) Verify(c echo.Context) error {
 	var req struct {
 		GameID string `json:"gameId"`
 		CRC32  string `json:"crc32"`
 	}
-	if err := c.Bind(&req); err != nil || req.GameID == "" {
-		return c.JSON(http.StatusBadRequest, apierr.Error("INVALID_PARAM", "gameId is required.", "ed1d7571-a3ac-4370-899c-0dbe5e230cc8"))
+	// crc32 は upstream verify.ts:38-41 で required (gameId と同列)。欠落を
+	// 黙って desynced=false にすると client 側の desync が一生検出されない。
+	if err := c.Bind(&req); err != nil || req.GameID == "" || req.CRC32 == "" {
+		return c.JSON(http.StatusBadRequest, apierr.Error("INVALID_PARAM", "gameId and crc32 are required.", "ed1d7571-a3ac-4370-899c-0dbe5e230cc8"))
 	}
 	game, err := h.repo.FindByID(req.GameID)
 	if err != nil {
@@ -591,17 +617,12 @@ func (h *Handler) Verify(c echo.Context) error {
 		return c.JSON(http.StatusNotFound, apierr.Error("NO_SUCH_GAME", "No such game.", "8fb05624-b525-43dd-90f7-511852bdfeee"))
 	}
 
-	// ログを再生して engine CRC を算出し、client が送ってきた crc32 と
-	// 比較する。CRC が合わなければ desync 判定。client が crc32 を送って
-	// こないケースは比較不可なので常に desynced=false。ログ parse は
-	// EngineFromGame を再利用して二重実装を避ける (#417 Devin review)。
-	g, err := corereversi.EngineFromGame(game)
-	if err != nil {
-		return c.JSON(http.StatusInternalServerError, apierr.Error("INTERNAL_ERROR", "Internal error.", "5d37dbcb-891e-41ca-a3d6-e690c97775ac"))
-	}
-
-	serverCRC := strconv.FormatUint(uint64(g.CalcCRC32()), 10)
-	desynced := req.CRC32 != "" && req.CRC32 != serverCRC
+	// upstream checkCrc は DB 保存済みの game.crc32 と直接比較する
+	// (ReversiService.ts:618)。ログ再生で都度再計算すると保存値と別ソースに
+	// なり desync 判定が本家と乖離するため、StartGame / PutStone が更新する
+	// 保存値をそのまま使う (#1553)。保存値が無い (開始前) 場合は本家同様
+	// 不一致 = desynced 扱いになり、client は game から状態を復元する。
+	desynced := game.CRC32 == nil || *game.CRC32 != req.CRC32
 	resp := map[string]any{"desynced": desynced}
 	if desynced {
 		resp["game"] = packGame(game, h.idGen)

--- a/internal/api/reversi/handler_test.go
+++ b/internal/api/reversi/handler_test.go
@@ -5,7 +5,6 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
-	"strconv"
 	"strings"
 	"testing"
 	"time"
@@ -290,10 +289,34 @@ func TestMatch_Success(t *testing.T) {
 	assert.Len(t, repo.games, 1)
 }
 
+// userId 無し (ランダムマッチ) は相手未確定なので upstream 同様 204 空ボディ。
+// 旧実装は user1=user2 の仮置き game 行を作って 200 を返していた (#1553)。
 func TestMatch_NoTarget(t *testing.T) {
-	h, _ := newTestHandler()
+	h, repo := newTestHandler()
 	rec := post(h.Match, `{}`, u1)
-	assert.Equal(t, http.StatusOK, rec.Code)
+	assert.Equal(t, http.StatusNoContent, rec.Code)
+	assert.Empty(t, rec.Body.String(), "マッチ未成立時は空ボディ")
+	assert.Empty(t, repo.games, "仮置き game 行を作らない")
+}
+
+// 自分自身を相手指定したら upstream match.ts と同じ TARGET_IS_YOURSELF (#1553)。
+func TestMatch_SelfTarget(t *testing.T) {
+	h, repo := newTestHandler()
+	rec := post(h.Match, `{"userId":"u1"}`, u1)
+	assert.Equal(t, http.StatusBadRequest, rec.Code)
+	assert.Empty(t, repo.games)
+}
+
+// acct (`@自分`) が self に解決されるケースも TARGET_IS_YOURSELF で弾く。
+func TestMatch_AcctSelfTarget(t *testing.T) {
+	h, repo := newTestHandler()
+	userRepo := testutil.NewMockUserRepository()
+	userRepo.Users["u1"] = &model.User{ID: "u1", Username: "alice", UsernameLower: "alice"}
+	h.SetFederation("https://example.com", nil, nil, userRepo)
+
+	rec := post(h.Match, `{"userId":"@alice"}`, u1)
+	assert.Equal(t, http.StatusBadRequest, rec.Code)
+	assert.Empty(t, repo.games)
 }
 
 func TestMatch_CreateError(t *testing.T) {
@@ -366,6 +389,40 @@ func TestCancelMatch_Success(t *testing.T) {
 	assert.Empty(t, repo.games)
 }
 
+// userId 指定時は upstream matchSpecificUserCancel 互換で、その相手に送った
+// 招待だけを取り消す。他の相手への pending 招待は残す (#1553)。
+func TestCancelMatch_SpecificUserOnly(t *testing.T) {
+	h, repo := newTestHandler()
+	toU2 := sampleGame() // User1=u1, User2=u2
+	repo.games["g1"] = toU2
+	toU3 := sampleGame()
+	toU3.ID = "g2"
+	toU3.User2ID = "u3"
+	repo.games["g2"] = toU3
+
+	rec := post(h.CancelMatch, `{"userId":"u2"}`, u1)
+	assert.Equal(t, http.StatusNoContent, rec.Code)
+	_, g1Left := repo.games["g1"]
+	assert.False(t, g1Left, "u2 への招待は取り消される")
+	_, g2Left := repo.games["g2"]
+	assert.True(t, g2Left, "u3 への招待は残る")
+}
+
+// userId 指定時、相手から受けている招待 (User1=相手, User2=自分) は取り消さ
+// ない。upstream matchSpecificUserCancel も自分が送った招待のみ削除する。
+func TestCancelMatch_SpecificUserKeepsInbound(t *testing.T) {
+	h, repo := newTestHandler()
+	inbound := sampleGame()
+	inbound.User1ID = "u2"
+	inbound.User2ID = "u1"
+	repo.games["g1"] = inbound
+
+	rec := post(h.CancelMatch, `{"userId":"u2"}`, u1)
+	assert.Equal(t, http.StatusNoContent, rec.Code)
+	_, left := repo.games["g1"]
+	assert.True(t, left, "受信側の招待は cancel-match では消えない")
+}
+
 // --- Surrender ---
 
 func TestSurrender_Success(t *testing.T) {
@@ -400,19 +457,9 @@ func TestSurrender_InvalidParam(t *testing.T) {
 
 // --- Verify ---
 
-func TestVerify_Success(t *testing.T) {
-	h, repo := newTestHandler()
-	repo.games["g1"] = sampleGame()
-	rec := post(h.Verify, `{"gameId":"g1"}`, nil)
-	assert.Equal(t, http.StatusOK, rec.Code)
-	var resp map[string]any
-	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
-	assert.Equal(t, false, resp["desynced"])
-}
-
 func TestVerify_NotFound(t *testing.T) {
 	h, _ := newTestHandler()
-	rec := post(h.Verify, `{"gameId":"ghost"}`, nil)
+	rec := post(h.Verify, `{"gameId":"ghost","crc32":"1"}`, nil)
 	assert.Equal(t, http.StatusNotFound, rec.Code)
 }
 
@@ -422,26 +469,24 @@ func TestVerify_InvalidParam(t *testing.T) {
 	assert.Equal(t, http.StatusBadRequest, rec.Code)
 }
 
-func TestVerify_WithLogs(t *testing.T) {
-	h, repo := newTestHandler()
-	g := sampleGame()
-	g.Logs = datatypes.JSON(`[[26,1]]`) // pos=26 (2,3 on 8x8 board)
-	repo.games["g1"] = g
-	rec := post(h.Verify, `{"gameId":"g1"}`, nil)
-	assert.Equal(t, http.StatusOK, rec.Code)
-}
-
-// crc32 を送ってサーバ側計算値と比較: 一致で desynced=false
-// (#417 Devin review: Verify が従来 dead code だった)。
-func TestVerify_MatchingCRC(t *testing.T) {
+// crc32 は upstream verify.ts:38-41 で required (#1553)。欠落は 400。
+func TestVerify_MissingCRC32(t *testing.T) {
 	h, repo := newTestHandler()
 	repo.games["g1"] = sampleGame()
-	// 空ログの初期状態 CRC を求めるため一度 empty payload で叩いて期待値を
-	// 得てから、その値を client crc32 として返し desynced=false を期待する。
-	g := corereversi.NewGame(sampleGame().Map, corereversi.Options{})
-	expectedCRC := strconv.FormatUint(uint64(g.CalcCRC32()), 10)
+	rec := post(h.Verify, `{"gameId":"g1"}`, nil)
+	assert.Equal(t, http.StatusBadRequest, rec.Code)
+}
 
-	rec := post(h.Verify, `{"gameId":"g1","crc32":"`+expectedCRC+`"}`, nil)
+// 保存済み game.crc32 と一致で desynced=false (#1553)。upstream checkCrc は
+// ログ再生での再計算ではなく DB 保存値と比較する (ReversiService.ts:618)。
+func TestVerify_MatchingCRC(t *testing.T) {
+	h, repo := newTestHandler()
+	g := sampleGame()
+	stored := "123456789"
+	g.CRC32 = &stored
+	repo.games["g1"] = g
+
+	rec := post(h.Verify, `{"gameId":"g1","crc32":"123456789"}`, nil)
 	assert.Equal(t, http.StatusOK, rec.Code)
 	var resp map[string]any
 	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
@@ -450,10 +495,13 @@ func TestVerify_MatchingCRC(t *testing.T) {
 	assert.False(t, hasGame, "同期時は game は返さない")
 }
 
-// crc32 が不一致で desynced=true + game が返る。
+// crc32 が保存値と不一致で desynced=true + game が返る。
 func TestVerify_DivergingCRC(t *testing.T) {
 	h, repo := newTestHandler()
-	repo.games["g1"] = sampleGame()
+	g := sampleGame()
+	stored := "123456789"
+	g.CRC32 = &stored
+	repo.games["g1"] = g
 
 	rec := post(h.Verify, `{"gameId":"g1","crc32":"999999"}`, nil)
 	assert.Equal(t, http.StatusOK, rec.Code)
@@ -462,6 +510,18 @@ func TestVerify_DivergingCRC(t *testing.T) {
 	assert.Equal(t, true, resp["desynced"])
 	_, hasGame := resp["game"]
 	assert.True(t, hasGame, "desync 時は game を返して restoreGame させる")
+}
+
+// 保存値が無い (開始前等) 場合は upstream 同様に不一致 = desynced 扱い。
+func TestVerify_NoStoredCRC(t *testing.T) {
+	h, repo := newTestHandler()
+	repo.games["g1"] = sampleGame() // CRC32 nil
+
+	rec := post(h.Verify, `{"gameId":"g1","crc32":"1"}`, nil)
+	assert.Equal(t, http.StatusOK, rec.Code)
+	var resp map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+	assert.Equal(t, true, resp["desynced"])
 }
 
 // --- Federation ---
@@ -719,6 +779,8 @@ func TestMatch_CreateErrorWithRemote(t *testing.T) {
 	assert.Equal(t, 0, d.calls) // Create失敗時はInvite送らない
 }
 
+// userId 無しのランダムマッチは federation 配線済みでも 204 空ボディで、
+// 仮置き game 行も Invite 配信も発生しない (#1553)。
 func TestMatch_EmptyUserIDIsRandomMatch(t *testing.T) {
 	h, repo := newTestHandler()
 	d := &mockDeliverer{}
@@ -727,8 +789,8 @@ func TestMatch_EmptyUserIDIsRandomMatch(t *testing.T) {
 	h.SetFederation("https://example.com", d, fedCache, userRepo)
 
 	rec := post(h.Match, `{}`, u1)
-	assert.Equal(t, http.StatusOK, rec.Code)
-	assert.Len(t, repo.games, 1)
+	assert.Equal(t, http.StatusNoContent, rec.Code)
+	assert.Empty(t, repo.games)
 	assert.Equal(t, 0, d.calls)
 }
 
@@ -773,8 +835,11 @@ func TestPackGame_WinnerField(t *testing.T) {
 			User1: user1, User2: user2,
 		}
 		out := packGame(g, idGen)
-		_, has := out["winner"]
-		assert.False(t, has, "winner must be omitted when WinnerID is nil")
+		// upstream json-schema は winner を optional:false, nullable:true で
+		// 宣言するためキー欠落ではなく null を出す (#1553)。
+		w, has := out["winner"]
+		require.True(t, has, "winner key must always be present")
+		assert.Nil(t, w, "winner must be null when WinnerID is nil")
 	})
 }
 
@@ -867,7 +932,7 @@ func TestReversiErrorIDsMatchUpstream(t *testing.T) {
 
 	t.Run("verify NO_SUCH_GAME", func(t *testing.T) {
 		h, _ := newTestHandler()
-		rec := post(h.Verify, `{"gameId":"ghost"}`, nil)
+		rec := post(h.Verify, `{"gameId":"ghost","crc32":"1"}`, nil)
 		assert.Equal(t, http.StatusNotFound, rec.Code)
 		assert.Equal(t, "8fb05624-b525-43dd-90f7-511852bdfeee", errorID(t, rec))
 	})
@@ -912,6 +977,13 @@ func TestReversiErrorIDsMatchUpstream(t *testing.T) {
 		rec := post(h.Match, `{"userId":"@ghost"}`, u1)
 		assert.Equal(t, http.StatusNotFound, rec.Code)
 		assert.Equal(t, "0b4f0559-b484-4e31-9581-3f73cee89b28", errorID(t, rec))
+	})
+
+	t.Run("match TARGET_IS_YOURSELF", func(t *testing.T) {
+		h, _ := newTestHandler()
+		rec := post(h.Match, `{"userId":"u1"}`, u1)
+		assert.Equal(t, http.StatusBadRequest, rec.Code)
+		assert.Equal(t, "96fd7bd6-d2bc-426c-a865-d055dcd2828e", errorID(t, rec))
 	})
 }
 

--- a/internal/core/reversi/service.go
+++ b/internal/core/reversi/service.go
@@ -483,6 +483,15 @@ func (s *Service) StartGame(ctx context.Context, game *model.ReversiGame) error 
 	now := time.Now()
 	game.StartedAt = &now
 
+	// 開始時点の盤面 CRC32 を保存する (#1553)。upstream startGame は fresh
+	// engine の calcCrc32 を crc32 カラムに書き、以降 /reversi/verify は
+	// この保存値とクライアント申告値を比較する (ReversiService.ts:321,618)。
+	// 開始時は logs が空なので EngineFromGame は初期盤面の engine を返す。
+	if engine, err := EngineFromGame(game); err == nil {
+		crc := strconv.FormatUint(uint64(engine.CalcCRC32()), 10)
+		game.CRC32 = &crc
+	}
+
 	if err := s.repo.Update(game); err != nil {
 		return err
 	}
@@ -561,6 +570,14 @@ func (s *Service) PutStone(ctx context.Context, gameID, userID string, pos int) 
 	logs = append(logs, []int{int(timeDelta), playerInt, 0, pos})
 	raw, _ := json.Marshal(logs)
 	game.Logs = raw
+
+	// 一手ごとに盤面 CRC32 を保存する (#1553)。upstream putStoneToGame が
+	// engine.calcCrc32() を都度 game.crc32 に書くのと同じ
+	// (ReversiService.ts:489-493)。/reversi/verify の desync 判定はこの
+	// 保存値に対して行われるため、更新を怠ると対局中の verify が常に
+	// desynced になる。
+	crc := strconv.FormatUint(uint64(engine.CalcCRC32()), 10)
+	game.CRC32 = &crc
 
 	if engine.Turn == nil {
 		// ゲーム終了

--- a/internal/core/reversi/service_wire_test.go
+++ b/internal/core/reversi/service_wire_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"strconv"
 	"sync"
 	"testing"
 	"time"
@@ -367,6 +368,29 @@ func TestService_PutStone_Valid(t *testing.T) {
 	// log event published
 	types := pub.types()
 	assert.Contains(t, types, "log")
+}
+
+// TestService_CRC32MaintainedAcrossMoves guards that StartGame stores the
+// initial board crc32 and PutStone refreshes it on every move (#1553).
+// /reversi/verify は保存済み crc32 と比較する (upstream checkCrc 互換) ため、
+// ここの更新が無いと対局中の verify が常に desynced になる。
+func TestService_CRC32MaintainedAcrossMoves(t *testing.T) {
+	game, repo, _, svc := startedGame(t)
+
+	started, _ := repo.FindByID(game.ID)
+	require.NotNil(t, started.CRC32, "開始時に初期盤面の crc32 を保存する")
+	engine, err := EngineFromGame(started)
+	require.NoError(t, err)
+	assert.Equal(t, strconv.FormatUint(uint64(engine.CalcCRC32()), 10), *started.CRC32)
+
+	require.NoError(t, svc.PutStone(context.Background(), game.ID, "alice", 19))
+
+	moved, _ := repo.FindByID(game.ID)
+	require.NotNil(t, moved.CRC32)
+	assert.NotEqual(t, *started.CRC32, *moved.CRC32, "一手ごとに crc32 を更新する")
+	engine2, err := EngineFromGame(moved)
+	require.NoError(t, err)
+	assert.Equal(t, strconv.FormatUint(uint64(engine2.CalcCRC32()), 10), *moved.CRC32)
 }
 
 func TestService_PutStone_NotYourTurn(t *testing.T) {


### PR DESCRIPTION
## Summary

parity 監査 issue #1553 (reversi/* + bubble-game/*) の未対応 REAL 差分 7 件をまとめて解消する。着手前に全項目を develop HEAD の現コードで再検証し、7 件すべてが実差分として現存することを確認済み。

## 主な変更点

### [HIGH] bubble-game/ranking — user を UserLite に (`internal/api/bubblegame/handler.go`)

ranking の `user` が `{id, username, name, host}` の ad-hoc マップだったのを `entity.PackUserLite` 経由に変更。upstream ranking.ts は `ref:'UserLite'` で返すため、avatarUrl / onlineStatus / badgeRoles 等の必須フィールドが欠落していた。PackUserLite は remote avatar の proxy 書き換え (#1529) も内蔵している。

### [MEDIUM] packGame — winner キーを常に出力 (`internal/api/reversi/handler.go`)

upstream json-schema は winner を `optional:false, nullable:true` で宣言し、packDetail/packLite は winnerId 無しでも常に `winner: null` を出す。mk-go は `if g.WinnerID != nil` ブロック内でしか設定せずキー自体が欠落していたため、`result["winner"] = nil` をデフォルトとして常に出力するように変更。

### [MEDIUM] reversi/match — TARGET_IS_YOURSELF (`internal/api/reversi/handler.go`)

自分自身を相手指定した場合に upstream match.ts と同じ `TARGET_IS_YOURSELF` (id `96fd7bd6-d2bc-426c-a865-d055dcd2828e`) を返す。CherryPick 拡張の acct 形式 (`@自分`) が self に解決されるケースも弾くため、acct 解決の後に判定する。

### [LOW] reversi/match — マッチ未成立時は 204 空ボディ (`internal/api/reversi/handler.go`)

upstream は `meta.res` が `optional:true` で、matchAnyUser がマッチ未成立時に null を返すと endpoint も空ボディになる。mk-go はランダムマッチ (userId 無し) で user1=user2 の仮置き game 行を作って必ず 200 + game を返しており、frontend が即「自分 vs 自分」のゲーム画面に遷移してしまう上、仮置き行が invitations に自分自身として混入する副作用もあった。行を作らず 204 を返すように変更 (any-match の実ペアリングは本家 Redis queue 相当が未実装のままで、frontend の matchHeatbeat による再呼び出し前提)。

### [MEDIUM] reversi/cancel-match — userId param 対応 (`internal/api/reversi/handler.go`)

従来は req を Bind せず viewer の pending game を無差別に全削除していた。upstream cancel-match.ts の `matchSpecificUserCancel` 互換として、`userId` 指定時は自分がその相手に送った招待 (User1=自分, User2=相手) のみ取り消すように変更。未指定時は従来通り全 pending を片付ける (mk-go は any-match queue を持たないため matchAnyUserCancel の近似)。受信側の招待 (User1=相手) は対象外。

### [MEDIUM+LOW] reversi/verify — 保存済み crc32 比較 + required 化 (`internal/api/reversi/handler.go`, `internal/core/reversi/service.go`)

- upstream checkCrc は DB 保存済みの `game.crc32` とクライアント申告値を直接比較する (ReversiService.ts:618)。mk-go はログ再生で都度再計算しており、保存値と別ソースのため desync 判定が本家と乖離しうる。保存値との直接比較に変更。
- その前提として `StartGame` (初期盤面) / `PutStone` (一手ごと) が `crc32` カラムを更新するように core service を修正 (upstream startGame / putStoneToGame 互換)。
- `crc32` を required param 化 (upstream verify.ts:38-41)。従来は欠落時に黙って desynced=false を返し、client 側の desync が検出不能だった。
- 保存値が無い (開始前等) 場合は本家同様に不一致 = desynced 扱い。

## テスト

- 新規テスト 8 件: TARGET_IS_YOURSELF (直接 + acct self) / cancel-match specific (取消対象の絞り込み + 受信招待の保護) / verify (required 化・保存値一致・保存値なし) / CRC32 が StartGame→PutStone で維持されること / ranking が UserLite shape であること
- 旧挙動前提の既存テスト 6 件を更新 (random match 200→204、winner キー省略→null 等)
- `make fmt` / `make lint` 通過
- カバレッジ: `internal/api/reversi` 93.5% / `internal/api/bubblegame` 100% / `internal/core/reversi` 92.2% (いずれも閾値 90% クリア)
- DB 依存パッケージ (gallery / hashtags / repository) も throwaway Postgres + TEST_DB_* で緑を確認。`test/e2e_federation` のみローカル Docker ネットワーク起因で実行不可 (本変更とは無関係)
- nightly Playwright spec (reversi / bubble_game) は match のステータスを `[200, 204]` 両対応で検証しており互換

## Closes

Closes #1553

## その他

- reversi の any-match 実ペアリング (本家 ReversiService の Redis queue 相当) は本 PR の範囲外。レスポンス shape のみ本家互換にした。必要なら別 issue で扱う。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
