### PR TITLE
Fix: checkModeratorsActivity の招待制 announcement に realtime stream event を発行 (#1606)

### DIFF
--- a/internal/core/announcement/creator.go
+++ b/internal/core/announcement/creator.go
@@ -1,0 +1,60 @@
+// Package announcement provides a thin creation service that persists an
+// announcement and emits the realtime `announcementCreated` main-stream
+// event, mirroring upstream AnnouncementService.create (#1606).
+//
+// Repository の Create を直接呼ぶ経路 (例: #1563 の moderator-activity check)
+// は stream event が出ず、対象 user が realtime に announcement へ気付けない。
+// 永続化と event 発行を常に対で行いたい caller はこの Creator を使う。
+// announcements handler (AdminCreate) は modlog 等が絡む既存経路のため
+// 本パッケージへは未統合 (同 shape の publish を handler 内で行っている)。
+package announcement
+
+import (
+	"github.com/shiroha-a/mk/internal/entity"
+	"github.com/shiroha-a/mk/internal/misc/id"
+	"github.com/shiroha-a/mk/internal/model"
+)
+
+// Repo is the persistence dependency (repository.AnnouncementRepository).
+type Repo interface {
+	Create(a *model.Announcement) error
+}
+
+// MainStreamPublisher emits events to a user's `main` WebSocket channel
+// (internal/stream). Accepted as an interface to avoid a hard dependency on
+// internal/stream (循環依存回避、api/announcements の同名 interface と同型)。
+type MainStreamPublisher interface {
+	PublishMainEvent(userID, eventType string, body any)
+}
+
+// Creator persists announcements and publishes the `announcementCreated`
+// event for per-user announcements, like upstream AnnouncementService.create.
+type Creator struct {
+	repo      Repo
+	idGen     id.Generator
+	publisher MainStreamPublisher
+}
+
+// NewCreator constructs a Creator. publisher may be nil to disable the
+// stream emit (graceful for tests / partial wiring).
+func NewCreator(repo Repo, idGen id.Generator, publisher MainStreamPublisher) *Creator {
+	return &Creator{repo: repo, idGen: idGen, publisher: publisher}
+}
+
+// Create persists the announcement and, for a per-user announcement
+// (UserID != nil), publishes `announcementCreated` to the target user's main
+// channel with the upstream event body shape ({"announcement": packed}).
+//
+// global announcement (UserID == nil) は本家では broadcast stream へ
+// publish されるが、mk-go は broadcast インフラ未実装のため skip する
+// (api/announcements AdminCreate と同じ判断)。
+func (c *Creator) Create(a *model.Announcement) error {
+	if err := c.repo.Create(a); err != nil {
+		return err
+	}
+	if c.publisher != nil && a.UserID != nil {
+		body := map[string]any{"announcement": entity.PackAnnouncement(a, c.idGen, false)}
+		c.publisher.PublishMainEvent(*a.UserID, "announcementCreated", body)
+	}
+	return nil
+}

--- a/internal/core/announcement/creator_test.go
+++ b/internal/core/announcement/creator_test.go
@@ -1,0 +1,115 @@
+package announcement
+
+import (
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/shiroha-a/mk/internal/misc/id"
+	"github.com/shiroha-a/mk/internal/model"
+)
+
+type fakeRepo struct {
+	created []*model.Announcement
+	err     error
+}
+
+func (f *fakeRepo) Create(a *model.Announcement) error {
+	if f.err != nil {
+		return f.err
+	}
+	f.created = append(f.created, a)
+	return nil
+}
+
+type mainEvent struct {
+	userID    string
+	eventType string
+	body      any
+}
+
+type fakePublisher struct{ events []mainEvent }
+
+func (f *fakePublisher) PublishMainEvent(userID, eventType string, body any) {
+	f.events = append(f.events, mainEvent{userID, eventType, body})
+}
+
+func ptr[T any](v T) *T { return &v }
+
+func newAnnouncement(t *testing.T, userID *string) (*model.Announcement, id.Generator) {
+	t.Helper()
+	idGen, err := id.NewGenerator("aidx")
+	require.NoError(t, err)
+	return &model.Announcement{
+		ID:                     idGen.Generate(time.Date(2026, 6, 1, 12, 0, 0, 0, time.UTC)),
+		Title:                  "Change to Invitation-Only",
+		Text:                   "body",
+		Icon:                   "info",
+		Display:                "normal",
+		IsActive:               true,
+		ForExistingUsers:       true,
+		NeedConfirmationToRead: true,
+		UserID:                 userID,
+	}, idGen
+}
+
+func TestCreate_PerUserPublishesAnnouncementCreated(t *testing.T) {
+	a, idGen := newAnnouncement(t, ptr("mod1"))
+	repo := &fakeRepo{}
+	pub := &fakePublisher{}
+	c := NewCreator(repo, idGen, pub)
+
+	require.NoError(t, c.Create(a))
+	require.Len(t, repo.created, 1)
+	require.Len(t, pub.events, 1)
+	ev := pub.events[0]
+	assert.Equal(t, "mod1", ev.userID)
+	assert.Equal(t, "announcementCreated", ev.eventType)
+	// upstream AnnouncementService.create の event body shape
+	// ({"announcement": packed}) と一致させる。
+	body, ok := ev.body.(map[string]any)
+	require.True(t, ok)
+	packed, ok := body["announcement"].(map[string]any)
+	require.True(t, ok)
+	assert.Equal(t, a.ID, packed["id"])
+	assert.Equal(t, "Change to Invitation-Only", packed["title"])
+	assert.Equal(t, true, packed["forYou"])
+	assert.Equal(t, false, packed["isRead"])
+	assert.Equal(t, "2026-06-01T12:00:00.000Z", packed["createdAt"])
+}
+
+func TestCreate_GlobalAnnouncementDoesNotPublish(t *testing.T) {
+	// global (UserID nil) は本家では broadcast stream 経路。mk-go は
+	// broadcast 未実装のため main-stream へは何も出さない。
+	a, idGen := newAnnouncement(t, nil)
+	repo := &fakeRepo{}
+	pub := &fakePublisher{}
+	c := NewCreator(repo, idGen, pub)
+
+	require.NoError(t, c.Create(a))
+	assert.Len(t, repo.created, 1)
+	assert.Empty(t, pub.events)
+}
+
+func TestCreate_NilPublisherStillPersists(t *testing.T) {
+	a, idGen := newAnnouncement(t, ptr("mod1"))
+	repo := &fakeRepo{}
+	c := NewCreator(repo, idGen, nil)
+
+	require.NoError(t, c.Create(a))
+	assert.Len(t, repo.created, 1)
+}
+
+func TestCreate_RepoErrorPropagatesWithoutPublish(t *testing.T) {
+	a, idGen := newAnnouncement(t, ptr("mod1"))
+	repo := &fakeRepo{err: errors.New("db down")}
+	pub := &fakePublisher{}
+	c := NewCreator(repo, idGen, pub)
+
+	err := c.Create(a)
+	assert.Error(t, err)
+	assert.Empty(t, pub.events, "永続化に失敗した announcement の event は出さない")
+}

--- a/internal/core/moderatoractivity/service.go
+++ b/internal/core/moderatoractivity/service.go
@@ -39,7 +39,10 @@ type (
 	ProfileLookup interface {
 		FindProfilesByUserIDs(userIDs []string) ([]*model.UserProfile, error)
 	}
-	// AnnouncementCreator persists an announcement (repository.AnnouncementRepository).
+	// AnnouncementCreator persists an announcement. Wired to
+	// core/announcement.Creator, which also publishes the realtime
+	// `announcementCreated` main-stream event for per-user announcements
+	// (#1606、本家 AnnouncementService.create 相当)。
 	AnnouncementCreator interface {
 		Create(a *model.Announcement) error
 	}

--- a/internal/core/moderatoractivity/service_stream_test.go
+++ b/internal/core/moderatoractivity/service_stream_test.go
@@ -1,0 +1,56 @@
+package moderatoractivity
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	coreannouncement "github.com/shiroha-a/mk/internal/core/announcement"
+	"github.com/shiroha-a/mk/internal/model"
+)
+
+type capturedMainEvent struct {
+	userID    string
+	eventType string
+}
+
+type fakeMainPublisher struct{ events []capturedMainEvent }
+
+func (f *fakeMainPublisher) PublishMainEvent(userID, eventType string, _ any) {
+	f.events = append(f.events, capturedMainEvent{userID, eventType})
+}
+
+// TestCheck_AllInactive_PublishesAnnouncementCreatedPerModerator wires the
+// real core/announcement.Creator (the router.go wiring of #1606) and verifies
+// the invitation-only switch emits one `announcementCreated` main-stream
+// event per moderator, mirroring upstream AnnouncementService.create.
+func TestCheck_AllInactive_PublishesAnnouncementCreatedPerModerator(t *testing.T) {
+	now := time.Date(2026, 1, 30, 12, 0, 0, 0, time.UTC)
+	old := now.Add(-10 * 24 * time.Hour)
+	meta := &fakeMeta{meta: &model.Meta{DisableRegistration: false}}
+	mods := &fakeModerators{users: []*model.User{
+		userWithActive("a", &old),
+		userWithActive("b", &old),
+	}}
+
+	repo := &fakeAnnounce{}
+	pub := &fakeMainPublisher{}
+	// idGen=nil でも Creator は publish する (packed createdAt が空になるだけ)。
+	creator := coreannouncement.NewCreator(repo, nil, pub)
+	s := NewService(mods, meta, &fakeProfiles{}, creator, &fakeWebhook{}, &fakeIDGen{}, nil)
+	s.now = func() time.Time { return now }
+
+	require.NoError(t, s.Check())
+	require.Len(t, repo.created, 2, "moderator ごとに announcement を永続化する")
+	require.Len(t, pub.events, 2, "moderator ごとに announcementCreated を publish する")
+	got := map[string]string{}
+	for _, ev := range pub.events {
+		got[ev.userID] = ev.eventType
+	}
+	assert.Equal(t, map[string]string{
+		"a": "announcementCreated",
+		"b": "announcementCreated",
+	}, got)
+}

--- a/internal/server/router.go
+++ b/internal/server/router.go
@@ -61,6 +61,7 @@ import (
 	apiwebhooks "github.com/shiroha-a/mk/internal/api/webhooks"
 	"github.com/shiroha-a/mk/internal/api/wellknown"
 	coreabuse "github.com/shiroha-a/mk/internal/core/abuse"
+	coreannouncement "github.com/shiroha-a/mk/internal/core/announcement"
 	coreantenna "github.com/shiroha-a/mk/internal/core/antenna"
 	"github.com/shiroha-a/mk/internal/core/avatardecoration"
 	coreblocking "github.com/shiroha-a/mk/internal/core/blocking"
@@ -1993,12 +1994,14 @@ func (s *Server) setupRoutes() {
 	// Moderator-activity check (#1563): scheduler の cron (30 * * * *) が enqueue
 	// する。全 moderator が 7 日非アクティブだと登録を招待制へ自動切替し、残 2 日で
 	// 6h ごとに警告メール / announcement / SystemWebhook を送る。announcementRepo /
-	// webhookService がここで揃うため本箇所で配線する。
+	// webhookService がここで揃うため本箇所で配線する。announcement は repo 直接
+	// ではなく create + announcementCreated publish を対で行う Creator 経由
+	// (#1606、本家 AnnouncementService.create 相当)。
 	modActivitySvc := coremoderatoractivity.NewService(
 		roleService,
 		metaRepo,
 		userRepo,
-		announcementRepo,
+		coreannouncement.NewCreator(announcementRepo, idGen, mainStreamPublisher),
 		webhookService,
 		idGen,
 		miscsmtp.SubjectBodySenderFromMeta(metaRepo, s.config.ProxySmtp),


### PR DESCRIPTION
## Summary

#1563 (PR #1602) の `notifyChangeToInvitationOnly` は moderator 宛 announcement を `AnnouncementRepository.Create` 直接で作成しており、本家 `AnnouncementService.create` が per-user announcement で publish する main-stream の `announcementCreated` イベントを出していなかった。そのため対象 moderator は realtime に気付けず次回 fetch 時に表示されていた (#1602 敵対的レビュー [LOW] の follow-up)。

## 主な変更点

### `internal/core/announcement` (新規パッケージ)

- 「永続化 + `announcementCreated` publish」を対で行う薄い `Creator` を新設。
- 本家 `AnnouncementService.create` と同じく、per-user announcement (`UserID != nil`) のとき対象 user の main チャンネルへ `{"announcement": <packed>}` (= `entity.PackAnnouncement`、`/api/admin/announcements/create` handler の emit と同 shape) を publish する。
- global announcement (UserID nil) は本家では broadcast stream 経路だが、mk-go は broadcast インフラ未実装のため skip (announcements handler `AdminCreate` と同じ判断)。publisher nil でも graceful に動作 (永続化のみ)。
- 永続化に失敗した announcement の event は出さない (repo error を伝播)。

### 配線 (`internal/server/router.go`)

- `moderatoractivity.NewService` への `AnnouncementCreator` 注入を `announcementRepo` 直接から `coreannouncement.NewCreator(announcementRepo, idGen, mainStreamPublisher)` に差し替え。moderatoractivity の service 本体ロジックは不変 (interface doc のみ更新)。
- announcements handler (`AdminCreate`) は modlog 等が絡む既存経路のため本パッケージへは未統合 (同 shape の publish を handler 内で実施済、1 issue = 1 PR の方針で scope 外)。

## テスト

- `internal/core/announcement`: per-user publish (event body shape の upstream 一致、createdAt 含む) / global skip / publisher nil / repo error 伝播の 4 ケース。**カバレッジ 100%**。
- `internal/core/moderatoractivity`: 実 `Creator` を配線した統合テスト `TestCheck_AllInactive_PublishesAnnouncementCreatedPerModerator` を追加し、招待制切替時に moderator ごとの `announcementCreated` が publish されることを検証。カバレッジ 95.4%。
- `make fmt` / `make lint` / 全パッケージテスト pass (`test/e2e_federation` の reversi e2e のみ並列実行時に flake、単独実行で pass。本変更と無関係な既知パターン)。
- 実行方法: `go test ./internal/core/announcement/ ./internal/core/moderatoractivity/`

## Closes

Closes #1606

## その他

- global announcement の broadcast stream (`publishBroadcastStream`) は別インフラのため引き続き未実装 (既存の handler 側 skip と同じ扱い)。

🤖 Generated with [Claude Code](https://claude.com/claude-code)